### PR TITLE
Array::Size() renamed to Array::size()

### DIFF
--- a/src/tightdb/array.cpp
+++ b/src/tightdb/array.cpp
@@ -295,7 +295,7 @@ void Array::Clear()
 
     // Make sure we don't have any dangling references
     if (m_hasRefs) {
-        for (size_t i = 0; i < Size(); ++i) {
+        for (size_t i = 0; i < size(); ++i) {
             const size_t ref = GetAsRef(i);
             if (ref == 0 || ref & 0x1) continue; // zero-refs and refs that are not 64-aligned do not point to sub-trees
 
@@ -1606,7 +1606,7 @@ template <size_t w>void Array::ReferenceSort(Array& ref)
         }
 
         // Accumulate occurences
-        for (size_t t = 1; t < count.Size(); t++) {
+        for (size_t t = 1; t < count.size(); t++) {
             count.Set(t, count.Get(t) + count.Get(t - 1));
         }
 
@@ -1621,7 +1621,7 @@ template <size_t w>void Array::ReferenceSort(Array& ref)
         }
 
         // Copy result into ref
-        for (size_t t = 0; t < res.Size(); t++)
+        for (size_t t = 0; t < res.size(); t++)
             ref.Set(t, res.Get(t));
 
         res.Destroy();
@@ -1781,7 +1781,7 @@ template<size_t w> void Array::QuickSort(size_t lo, size_t hi)
 std::vector<int64_t> Array::ToVector(void) const
 {
     std::vector<int64_t> v;
-    const size_t count = Size();
+    const size_t count = size();
     for (size_t t = 0; t < count; ++t)
         v.push_back(Get(t));
     return v;
@@ -1789,9 +1789,9 @@ std::vector<int64_t> Array::ToVector(void) const
 
 bool Array::Compare(const Array& c) const
 {
-    if (c.Size() != Size()) return false;
+    if (c.size() != size()) return false;
 
-    for (size_t i = 0; i < Size(); ++i) {
+    for (size_t i = 0; i < size(); ++i) {
         if (Get(i) != c.Get(i)) return false;
     }
 
@@ -1803,8 +1803,8 @@ bool Array::Compare(const Array& c) const
 
 void Array::Print() const
 {
-    std::cout << std::hex << GetRef() << std::dec << ": (" << Size() << ") ";
-    for (size_t i = 0; i < Size(); ++i) {
+    std::cout << std::hex << GetRef() << std::dec << ": (" << size() << ") ";
+    for (size_t i = 0; i < size(); ++i) {
         if (i) std::cout << ", ";
         std::cout << Get(i);
     }

--- a/src/tightdb/array.hpp
+++ b/src/tightdb/array.hpp
@@ -248,7 +248,7 @@ public:
     bool IsValid() const TIGHTDB_NOEXCEPT {return m_data != NULL;}
     void Invalidate() const TIGHTDB_NOEXCEPT {m_data = NULL;}
 
-    virtual size_t Size() const TIGHTDB_NOEXCEPT {return m_len;}
+    virtual size_t size() const TIGHTDB_NOEXCEPT {return m_len;}
     bool is_empty() const TIGHTDB_NOEXCEPT {return m_len == 0;}
 
     void Insert(size_t ndx, int64_t value);
@@ -800,7 +800,7 @@ template<class S> size_t Array::Write(S& out, bool recurse, bool persist) const
             newRefs.SetIsIndexNode(true);
 
         // First write out all sub-arrays
-        const size_t count = Size();
+        const size_t count = size();
         for (size_t i = 0; i < count; ++i) {
             const size_t ref = GetAsRef(i);
             if (ref == 0 || ref & 0x1) {
@@ -1544,7 +1544,7 @@ template <class cond, Action action, size_t bitwidth, class Callback> void Array
     r_state.m_state = (int64_t)&r_arr;
 
     if (action == act_FindAll) {
-        for (size_t t = 0; t < akku->Size(); t++)
+        for (size_t t = 0; t < akku->size(); t++)
             r_arr.add(akku->Get(t));
     }
     else {
@@ -1572,8 +1572,8 @@ template <class cond2, Action action, size_t bitwidth, class Callback> int64_t A
     // Reference implementation of find_optimized for bug testing
     (void)callback;
 
-    if (end > Size())
-        end = Size();
+    if (end > size())
+        end = size();
 
     for (size_t t = start; t < end; t++) {
         int64_t v = Get(t);

--- a/src/tightdb/array_basic_tpl.hpp
+++ b/src/tightdb/array_basic_tpl.hpp
@@ -149,7 +149,7 @@ void BasicArray<T>::Delete(size_t ndx)
 template<typename T>
 bool BasicArray<T>::Compare(const BasicArray<T>& c) const
 {
-    for (size_t i = 0; i < Size(); ++i) {
+    for (size_t i = 0; i < size(); ++i) {
         if (Get(i) != c.Get(i))
             return false;
     }

--- a/src/tightdb/array_binary.cpp
+++ b/src/tightdb/array_binary.cpp
@@ -24,8 +24,8 @@ ArrayBinary::ArrayBinary(size_t ref, ArrayParent* parent, size_t pndx, Allocator
     m_blob(Array::GetAsRef(1), NULL, 0, alloc)
 {
     TIGHTDB_ASSERT(HasRefs() && !IsNode()); // HasRefs indicates that this is a long string
-    TIGHTDB_ASSERT(Array::Size() == 2);
-    TIGHTDB_ASSERT(m_blob.Size() ==(size_t)(m_offsets.is_empty() ? 0 : m_offsets.back()));
+    TIGHTDB_ASSERT(Array::size() == 2);
+    TIGHTDB_ASSERT(m_blob.size() ==(size_t)(m_offsets.is_empty() ? 0 : m_offsets.back()));
 
     m_offsets.SetParent(this, 0);
     m_blob.SetParent(this, 1);
@@ -39,14 +39,14 @@ bool ArrayBinary::is_empty() const TIGHTDB_NOEXCEPT
     return m_offsets.is_empty();
 }
 
-size_t ArrayBinary::Size() const TIGHTDB_NOEXCEPT
+size_t ArrayBinary::size() const TIGHTDB_NOEXCEPT
 {
-    return m_offsets.Size();
+    return m_offsets.size();
 }
 
 const char* ArrayBinary::Get(size_t ndx) const TIGHTDB_NOEXCEPT
 {
-    TIGHTDB_ASSERT(ndx < m_offsets.Size());
+    TIGHTDB_ASSERT(ndx < m_offsets.size());
 
     const size_t offset = ndx ? size_t(m_offsets.Get(ndx-1)) : 0;
     return m_blob.Get(offset);
@@ -54,7 +54,7 @@ const char* ArrayBinary::Get(size_t ndx) const TIGHTDB_NOEXCEPT
 
 size_t ArrayBinary::GetLen(size_t ndx) const TIGHTDB_NOEXCEPT
 {
-    TIGHTDB_ASSERT(ndx < m_offsets.Size());
+    TIGHTDB_ASSERT(ndx < m_offsets.size());
 
     const size_t start = ndx ? size_t(m_offsets.Get(ndx-1)) : 0;
     const size_t end = size_t(m_offsets.Get(ndx));
@@ -72,7 +72,7 @@ void ArrayBinary::add(const char* value, size_t len)
 
 void ArrayBinary::Set(size_t ndx, const char* value, size_t len)
 {
-    TIGHTDB_ASSERT(ndx < m_offsets.Size());
+    TIGHTDB_ASSERT(ndx < m_offsets.size());
     TIGHTDB_ASSERT(len == 0 || value);
 
     const size_t start = ndx ? (size_t)m_offsets.Get(ndx-1) : 0;
@@ -85,7 +85,7 @@ void ArrayBinary::Set(size_t ndx, const char* value, size_t len)
 
 void ArrayBinary::Insert(size_t ndx, const char* value, size_t len)
 {
-    TIGHTDB_ASSERT(ndx <= m_offsets.Size());
+    TIGHTDB_ASSERT(ndx <= m_offsets.size());
     TIGHTDB_ASSERT(len == 0 || value);
 
     const size_t pos = ndx ? (size_t)m_offsets.Get(ndx-1) : 0;
@@ -97,7 +97,7 @@ void ArrayBinary::Insert(size_t ndx, const char* value, size_t len)
 
 void ArrayBinary::Delete(size_t ndx)
 {
-    TIGHTDB_ASSERT(ndx < m_offsets.Size());
+    TIGHTDB_ASSERT(ndx < m_offsets.size());
 
     const size_t start = ndx ? (size_t)m_offsets.Get(ndx-1) : 0;
     const size_t end = (size_t)m_offsets.Get(ndx);
@@ -109,7 +109,7 @@ void ArrayBinary::Delete(size_t ndx)
 
 void ArrayBinary::Resize(size_t ndx)
 {
-    TIGHTDB_ASSERT(ndx < m_offsets.Size());
+    TIGHTDB_ASSERT(ndx < m_offsets.size());
 
     const size_t len = ndx ? (size_t)m_offsets.Get(ndx-1) : 0;
 

--- a/src/tightdb/array_binary.hpp
+++ b/src/tightdb/array_binary.hpp
@@ -34,7 +34,7 @@ public:
     //ArrayBinary(Allocator& alloc);
 
     bool is_empty() const TIGHTDB_NOEXCEPT;
-    size_t Size() const TIGHTDB_NOEXCEPT TIGHTDB_OVERRIDE;
+    size_t size() const TIGHTDB_NOEXCEPT TIGHTDB_OVERRIDE;
 
     const char* Get(size_t ndx) const TIGHTDB_NOEXCEPT;
     size_t GetLen(size_t ndx) const TIGHTDB_NOEXCEPT;

--- a/src/tightdb/array_blob.cpp
+++ b/src/tightdb/array_blob.cpp
@@ -66,7 +66,7 @@ void ArrayBlob::ToDot(std::ostream& out, const char* title) const
 
     // Values
     out << "<TD>";
-    out << Size() << " bytes"; //TODO: write content
+    out << size() << " bytes"; //TODO: write content
     out << "</TD>" << std::endl;
 
     out << "</TR></TABLE>>];" << std::endl;

--- a/src/tightdb/array_string.cpp
+++ b/src/tightdb/array_string.cpp
@@ -264,9 +264,9 @@ size_t ArrayString::FindWithLen(const char* value, size_t len, size_t start, siz
 
 bool ArrayString::Compare(const ArrayString& c) const
 {
-    if (c.Size() != Size()) return false;
+    if (c.size() != size()) return false;
 
-    for (size_t i = 0; i < Size(); ++i) {
+    for (size_t i = 0; i < size(); ++i) {
         if (strcmp(Get(i), c.Get(i)) != 0) return false;
     }
 

--- a/src/tightdb/array_string_long.cpp
+++ b/src/tightdb/array_string_long.cpp
@@ -24,8 +24,8 @@ ArrayStringLong::ArrayStringLong(size_t ref, ArrayParent* parent, size_t pndx, A
     m_blob(Array::GetAsRef(1), NULL, 0, alloc)
 {
     TIGHTDB_ASSERT(HasRefs() && !IsNode()); // HasRefs indicates that this is a long string
-    TIGHTDB_ASSERT(Array::Size() == 2);
-    TIGHTDB_ASSERT(m_blob.Size() == (m_offsets.is_empty() ? 0 : (size_t)m_offsets.back()));
+    TIGHTDB_ASSERT(Array::size() == 2);
+    TIGHTDB_ASSERT(m_blob.size() == (m_offsets.is_empty() ? 0 : (size_t)m_offsets.back()));
 
     m_offsets.SetParent(this, 0);
     m_blob.SetParent(this, 1);
@@ -36,7 +36,7 @@ ArrayStringLong::ArrayStringLong(size_t ref, ArrayParent* parent, size_t pndx, A
 
 const char* ArrayStringLong::Get(size_t ndx) const TIGHTDB_NOEXCEPT
 {
-    TIGHTDB_ASSERT(ndx < m_offsets.Size());
+    TIGHTDB_ASSERT(ndx < m_offsets.size());
 
     const size_t offset = ndx ? size_t(m_offsets.Get(ndx-1)) : 0;
     return m_blob.Get(offset);
@@ -63,7 +63,7 @@ void ArrayStringLong::Set(size_t ndx, const char* value)
 
 void ArrayStringLong::Set(size_t ndx, const char* value, size_t len)
 {
-    TIGHTDB_ASSERT(ndx < m_offsets.Size());
+    TIGHTDB_ASSERT(ndx < m_offsets.size());
     TIGHTDB_ASSERT(value);
 
     const size_t start = ndx ? (size_t)m_offsets.Get(ndx-1) : 0;
@@ -83,7 +83,7 @@ void ArrayStringLong::Insert(size_t ndx, const char* value)
 
 void ArrayStringLong::Insert(size_t ndx, const char* value, size_t len)
 {
-    TIGHTDB_ASSERT(ndx <= m_offsets.Size());
+    TIGHTDB_ASSERT(ndx <= m_offsets.size());
     TIGHTDB_ASSERT(value);
 
     const size_t pos = ndx ? (size_t)m_offsets.Get(ndx-1) : 0;
@@ -96,7 +96,7 @@ void ArrayStringLong::Insert(size_t ndx, const char* value, size_t len)
 
 void ArrayStringLong::Delete(size_t ndx)
 {
-    TIGHTDB_ASSERT(ndx < m_offsets.Size());
+    TIGHTDB_ASSERT(ndx < m_offsets.size());
 
     const size_t start = ndx ? (size_t)m_offsets.Get(ndx-1) : 0;
     const size_t end = (size_t)m_offsets.Get(ndx);
@@ -108,7 +108,7 @@ void ArrayStringLong::Delete(size_t ndx)
 
 void ArrayStringLong::Resize(size_t ndx)
 {
-    TIGHTDB_ASSERT(ndx < m_offsets.Size());
+    TIGHTDB_ASSERT(ndx < m_offsets.size());
 
     const size_t len = ndx ? (size_t)m_offsets.Get(ndx-1) : 0;
 
@@ -165,7 +165,7 @@ size_t ArrayStringLong::FindWithLen(const char* value, size_t len, size_t start,
     TIGHTDB_ASSERT(value);
 
     len += 1; // include trailing null byte
-    const size_t count = m_offsets.Size();
+    const size_t count = m_offsets.size();
     size_t offset = (start == 0 ? 0 : (size_t)m_offsets.Get(start - 1)); // todo, verify
     for (size_t i = start; i < count && i < end; ++i) {
         const size_t end = (size_t)m_offsets.Get(i);

--- a/src/tightdb/array_string_long.hpp
+++ b/src/tightdb/array_string_long.hpp
@@ -34,7 +34,7 @@ public:
     //ArrayStringLong(Allocator& alloc);
 
     bool is_empty() const TIGHTDB_NOEXCEPT;
-    size_t Size() const TIGHTDB_NOEXCEPT TIGHTDB_OVERRIDE;
+    size_t size() const TIGHTDB_NOEXCEPT TIGHTDB_OVERRIDE;
 
     const char* Get(size_t ndx) const TIGHTDB_NOEXCEPT;
     void add(const char* value);
@@ -73,9 +73,9 @@ inline bool ArrayStringLong::is_empty() const TIGHTDB_NOEXCEPT
     return m_offsets.is_empty();
 }
 
-inline std::size_t ArrayStringLong::Size() const TIGHTDB_NOEXCEPT
+inline std::size_t ArrayStringLong::size() const TIGHTDB_NOEXCEPT
 {
-    return m_offsets.Size();
+    return m_offsets.size();
 }
 
 } // namespace tightdb

--- a/src/tightdb/column.cpp
+++ b/src/tightdb/column.cpp
@@ -19,7 +19,7 @@ using namespace tightdb;
 Column GetColumnFromRef(Array &parent, size_t ndx)
 {
     TIGHTDB_ASSERT(parent.HasRefs());
-    TIGHTDB_ASSERT(ndx < parent.Size());
+    TIGHTDB_ASSERT(ndx < parent.size());
     return Column((size_t)parent.Get(ndx), &parent, ndx, parent.GetAllocator());
 }
 
@@ -52,8 +52,8 @@ void merge_core_references(Array* vals, Array* idx0, Array* idx1, Array* idxres)
     int64_t v0, v1;
     size_t i0, i1;
     size_t p0 = 0, p1 = 0;
-    size_t s0 = idx0->Size();
-    size_t s1 = idx1->Size();
+    size_t s0 = idx0->size();
+    size_t s1 = idx1->size();
 
     i0 = idx0->GetAsRef(p0++);
     i1 = idx1->GetAsRef(p1++);
@@ -92,7 +92,7 @@ void merge_core_references(Array* vals, Array* idx0, Array* idx1, Array* idxres)
         idxres->add(i1);
     }
 
-    TIGHTDB_ASSERT(idxres->Size() == idx0->Size() + idx1->Size());
+    TIGHTDB_ASSERT(idxres->size() == idx0->size() + idx1->size());
 }
 
 // Merge two sorted arrays into a single sorted array
@@ -102,8 +102,8 @@ void merge_core(const Array& a0, const Array& a1, Array& res)
 
     size_t p0 = 0;
     size_t p1 = 0;
-    const size_t s0 = a0.Size();
-    const size_t s1 = a1.Size();
+    const size_t s0 = a0.size();
+    const size_t s1 = a1.size();
 
     int64_t v0 = a0.Get(p0++);
     int64_t v1 = a1.Get(p1++);
@@ -137,7 +137,7 @@ void merge_core(const Array& a0, const Array& a1, Array& res)
         res.add(v1);
     }
 
-    TIGHTDB_ASSERT(res.Size() == a0.Size() + a1.Size());
+    TIGHTDB_ASSERT(res.size() == a0.size() + a1.size());
 }
 
 // Input:
@@ -146,7 +146,7 @@ void merge_core(const Array& a0, const Array& a1, Array& res)
 //     Merge-sorted array of all values
 Array* merge(const Array& arrayList)
 {
-    const size_t size = arrayList.Size();
+    const size_t size = arrayList.size();
 
     if (size == 1)
         return NULL; // already sorted
@@ -198,7 +198,7 @@ Array* merge(const Array& arrayList)
 // TODO: Set owner of created arrays and Destroy/delete them if created by merge_references()
 void merge_references(Array* valuelist, Array* indexlists, Array** indexresult)
 {
-    if (indexlists->Size() == 1) {
+    if (indexlists->size() == 1) {
 //      size_t ref = valuelist->Get(0);
         *indexresult = (Array *)indexlists->Get(0);
         return;
@@ -206,12 +206,12 @@ void merge_references(Array* valuelist, Array* indexlists, Array** indexresult)
 
     Array leftV, rightV;
     Array leftI, rightI;
-    size_t leftSize = indexlists->Size() / 2;
+    size_t leftSize = indexlists->size() / 2;
     for (size_t t = 0; t < leftSize; t++) {
         leftV.add(indexlists->Get(t));
         leftI.add(indexlists->Get(t));
     }
-    for (size_t t = leftSize; t < indexlists->Size(); t++) {
+    for (size_t t = leftSize; t < indexlists->size(); t++) {
         rightV.add(indexlists->Get(t));
         rightI.add(indexlists->Get(t));
     }
@@ -250,7 +250,7 @@ size_t ColumnBase::get_size_from_ref(size_t ref, Allocator& alloc) TIGHTDB_NOEXC
 {
     Array a(ref, 0, 0, alloc);
     if (!a.IsNode())
-        return a.Size();
+        return a.size();
     Array offsets(a.Get(0), 0, 0, alloc);
     return offsets.is_empty() ? 0 : size_t(offsets.back());
 }
@@ -338,7 +338,7 @@ bool Column::is_empty() const TIGHTDB_NOEXCEPT
 size_t Column::Size() const TIGHTDB_NOEXCEPT
 {
     if (!IsNode())
-        return m_array->Size();
+        return m_array->size();
     const Array offsets = NodeGetOffsets();
     return offsets.is_empty() ? 0 : size_t(offsets.back());
 }
@@ -468,7 +468,7 @@ void Column::sort(size_t start, size_t end)
 {
     Array arr;
     TreeVisitLeafs<Array, Column>(start, end, 0, callme_arrays, (void *)&arr);
-    for (size_t t = 0; t < arr.Size(); t++) {
+    for (size_t t = 0; t < arr.size(); t++) {
         const size_t ref = to_ref(arr.Get(t));
         Array a(ref);
         a.sort();
@@ -477,7 +477,7 @@ void Column::sort(size_t start, size_t end)
     Array* sorted = merge(arr);
     if (sorted) {
         // Todo, this is a bit slow. Add bulk insert or the like to Column
-        const size_t count = sorted->Size();
+        const size_t count = sorted->size();
         for (size_t t = 0; t < count; ++t) {
             Set(t, sorted->Get(t));
         }
@@ -500,16 +500,16 @@ void Column::ReferenceSort(size_t start, size_t end, Column& ref)
     TreeVisitLeafs<Array, Column>(start, end, 0, callme_arrays, (void *)&values);
 
     size_t offset = 0;
-    for (size_t t = 0; t < values.Size(); t++) {
+    for (size_t t = 0; t < values.size(); t++) {
         Array *i = new Array();
         size_t ref = values.GetAsRef(t);
         Array v(ref);
-        for (size_t j = 0; j < v.Size(); j++)
+        for (size_t j = 0; j < v.size(); j++)
             all_values.add(v.Get(j));
         v.ReferenceSort(*i);
-        for (size_t n = 0; n < v.Size(); n++)
+        for (size_t n = 0; n < v.size(); n++)
             i->Set(n, i->Get(n) + offset);
-        offset += v.Size();
+        offset += v.size();
         indexes.add((int64_t)i);
     }
 
@@ -517,7 +517,7 @@ void Column::ReferenceSort(size_t start, size_t end, Column& ref)
 
     merge_references(&all_values, &indexes, &ResI);
 
-    for (size_t t = 0; t < ResI->Size(); t++)
+    for (size_t t = 0; t < ResI->size(); t++)
         ref.add(ResI->Get(t));
 }
 
@@ -546,7 +546,7 @@ void ColumnBase::NodeUpdateOffsets(size_t ndx)
 
     Array offsets = NodeGetOffsets();
     Array refs = NodeGetRefs();
-    TIGHTDB_ASSERT(ndx < offsets.Size());
+    TIGHTDB_ASSERT(ndx < offsets.size());
 
     const int64_t newSize = GetRefSize((size_t)refs.Get(ndx));
     const int64_t oldSize = offsets.Get(ndx) - (ndx ? offsets.Get(ndx-1) : 0);
@@ -562,7 +562,7 @@ void ColumnBase::NodeAddKey(size_t ref)
 
     Array offsets = NodeGetOffsets();
     Array refs = NodeGetRefs();
-    TIGHTDB_ASSERT(offsets.Size() < TIGHTDB_MAX_LIST_SIZE);
+    TIGHTDB_ASSERT(offsets.size() < TIGHTDB_MAX_LIST_SIZE);
 
     const Array new_top(ref, NULL, 0,m_array->GetAllocator());
     const Array new_offsets(new_top.GetAsRef(0), NULL, 0,m_array->GetAllocator());
@@ -584,7 +584,7 @@ void Column::Delete(size_t ndx)
     // Flatten tree if possible
     while (IsNode()) {
         Array refs = NodeGetRefs();
-        if (refs.Size() != 1) break;
+        if (refs.size() != 1) break;
 
         const size_t ref = refs.GetAsRef(0);
         refs.Delete(0); // avoid destroying subtree
@@ -608,7 +608,7 @@ void Column::Increment64(int64_t value, size_t start, size_t end)
 
     //TODO: partial incr
     Array refs = NodeGetRefs();
-    const size_t count = refs.Size();
+    const size_t count = refs.size();
     for (size_t i = 0; i < count; ++i) {
         Column col = ::GetColumnFromRef(refs, i);
         col.Increment64(value);
@@ -620,7 +620,7 @@ void Column::IncrementIf(int64_t limit, int64_t value)
     if (!IsNode()) m_array->IncrementIf(limit, value);
     else {
         Array refs = NodeGetRefs();
-        const size_t count = refs.Size();
+        const size_t count = refs.size();
         for (size_t i = 0; i < count; ++i) {
             Column col = ::GetColumnFromRef(refs, i);
             col.IncrementIf(limit, value);
@@ -667,7 +667,7 @@ void Column::find_all_hamming(Array& result, uint64_t value, size_t maxdist, siz
         // Get subnode table
         const Array offsets = NodeGetOffsets();
         const Array refs = NodeGetRefs();
-        const size_t count = refs.Size();
+        const size_t count = refs.size();
 
         for (size_t i = 0; i < count; ++i) {
             const Column col((size_t)refs.Get(i));
@@ -785,10 +785,10 @@ void Column::Print() const
         const Array offsets = NodeGetOffsets();
         const Array refs = NodeGetRefs();
 
-        for (size_t i = 0; i < refs.Size(); ++i) {
+        for (size_t i = 0; i < refs.size(); ++i) {
             cout << " " << i << ": " << offsets.Get(i) << " " << hex << refs.Get(i) << dec <<"\n";
         }
-        for (size_t i = 0; i < refs.Size(); ++i) {
+        for (size_t i = 0; i < refs.size(); ++i) {
             const Column col((size_t)refs.Get(i));
             col.Print();
         }
@@ -801,7 +801,7 @@ void Column::Print() const
 void Column::Verify() const
 {
     if (IsNode()) {
-        TIGHTDB_ASSERT(m_array->Size() == 2);
+        TIGHTDB_ASSERT(m_array->size() == 2);
         //TIGHTDB_ASSERT(m_hasRefs);
 
         const Array offsets = NodeGetOffsets();
@@ -809,10 +809,10 @@ void Column::Verify() const
         offsets.Verify();
         refs.Verify();
         TIGHTDB_ASSERT(refs.HasRefs());
-        TIGHTDB_ASSERT(offsets.Size() == refs.Size());
+        TIGHTDB_ASSERT(offsets.size() == refs.size());
 
         size_t off = 0;
-        for (size_t i = 0; i < refs.Size(); ++i) {
+        for (size_t i = 0; i < refs.size(); ++i) {
             const size_t ref = size_t(refs.Get(i));
             TIGHTDB_ASSERT(ref);
 
@@ -860,7 +860,7 @@ void ColumnBase::ArrayToDot(std::ostream& out, const Array& array) const
 
         refs.ToDot(out, "refs");
 
-        const size_t count = refs.Size();
+        const size_t count = refs.size();
         for (size_t i = 0; i < count; ++i) {
             const Array r = refs.GetSubArray(i);
             ArrayToDot(out, r);

--- a/src/tightdb/column_basic_tpl.hpp
+++ b/src/tightdb/column_basic_tpl.hpp
@@ -109,7 +109,7 @@ size_t BasicColumn<T>::Size() const TIGHTDB_NOEXCEPT
         return size;
     }
     else {
-        return m_array->Size();
+        return m_array->size();
     }
 }
 
@@ -337,7 +337,7 @@ size_t BasicColumn<T>::count(T target) const
 
     if (m_array->IsNode()) {
         const Array refs = NodeGetRefs();
-        const size_t n = refs.Size();
+        const size_t n = refs.size();
 
         for (size_t i = 0; i < n; ++i) {
             const size_t ref = refs.GetAsRef(i);
@@ -362,7 +362,7 @@ T BasicColumn<T>::sum(size_t start, size_t end) const
 
     if (m_array->IsNode()) {
         const Array refs = NodeGetRefs();
-        const size_t n = refs.Size();
+        const size_t n = refs.size();
 
         for (size_t i = start; i < n; ++i) {
             const size_t ref = refs.GetAsRef(i);
@@ -399,7 +399,7 @@ T BasicColumn<T>::minimum(size_t start, size_t end) const
     T min_val = T(987.0);
     if (m_array->IsNode()) {
         const Array refs = NodeGetRefs();
-        const size_t n = refs.Size();
+        const size_t n = refs.size();
 
         for (size_t i = start; i < n; ++i) {
             const size_t ref = refs.GetAsRef(i);
@@ -428,7 +428,7 @@ T BasicColumn<T>::maximum(size_t start, size_t end) const
     T max_val = T(0.0);
     if (m_array->IsNode()) {
         const Array refs = NodeGetRefs();
-        const size_t n = refs.Size();
+        const size_t n = refs.size();
 
         for (size_t i = start; i < n; ++i) {
             const size_t ref = refs.GetAsRef(i);

--- a/src/tightdb/column_binary.cpp
+++ b/src/tightdb/column_binary.cpp
@@ -74,7 +74,7 @@ size_t ColumnBinary::Size() const  TIGHTDB_NOEXCEPT
         return size;
     }
     else {
-        return (static_cast<ArrayBinary*>(m_array))->Size();
+        return (static_cast<ArrayBinary*>(m_array))->size();
     }
 }
 

--- a/src/tightdb/column_mixed.cpp
+++ b/src/tightdb/column_mixed.cpp
@@ -51,7 +51,7 @@ void ColumnMixed::Create(Allocator& alloc, const Table* table, size_t column_ndx
                          ArrayParent* parent, size_t ndx_in_parent, size_t ref)
 {
     m_array = new Array(ref, parent, ndx_in_parent, alloc);
-    TIGHTDB_ASSERT(m_array->Size() == 2 || m_array->Size() == 3);
+    TIGHTDB_ASSERT(m_array->size() == 2 || m_array->size() == 3);
 
     const size_t types_ref = m_array->GetAsRef(0);
     const size_t refs_ref  = m_array->GetAsRef(1);
@@ -62,7 +62,7 @@ void ColumnMixed::Create(Allocator& alloc, const Table* table, size_t column_ndx
 
     // Binary column with values that does not fit in refs
     // is only there if needed
-    if (m_array->Size() == 3) {
+    if (m_array->size() == 3) {
         const size_t data_ref = m_array->GetAsRef(2);
         m_data = new ColumnBinary(data_ref, m_array, 2, alloc);
     }
@@ -73,7 +73,7 @@ void ColumnMixed::InitDataColumn()
     if (m_data)
         return;
 
-    TIGHTDB_ASSERT(m_array->Size() == 2);
+    TIGHTDB_ASSERT(m_array->size() == 2);
 
     // Create new data column for items that do not fit in refs
     m_data = new ColumnBinary(m_array->GetAllocator());
@@ -345,7 +345,7 @@ void ColumnMixed::ToDot(std::ostream& out, const char* title) const
     m_types->ToDot(out, "types");
     m_refs->ToDot(out, "refs");
 
-    if (m_array->Size() > 2) {
+    if (m_array->size() > 2) {
         m_data->ToDot(out, "data");
     }
 

--- a/src/tightdb/column_string.cpp
+++ b/src/tightdb/column_string.cpp
@@ -138,10 +138,10 @@ size_t AdaptiveStringColumn::Size() const TIGHTDB_NOEXCEPT
         return size;
     }
     else if (IsLongStrings()) {
-        return (static_cast<ArrayStringLong*>(m_array))->Size();
+        return (static_cast<ArrayStringLong*>(m_array))->size();
     }
     else {
-        return (static_cast<ArrayString*>(m_array))->Size();
+        return (static_cast<ArrayString*>(m_array))->size();
     }
 }
 
@@ -259,7 +259,7 @@ size_t AdaptiveStringColumn::count(const char* target) const
 
     if (m_array->IsNode()) {
         const Array refs = NodeGetRefs();
-        const size_t n = refs.Size();
+        const size_t n = refs.size();
 
         for (size_t i = 0; i < n; ++i) {
             const size_t ref = refs.GetAsRef(i);
@@ -327,7 +327,7 @@ void AdaptiveStringColumn::LeafSet(size_t ndx, const char* value)
 
     // Copy strings to new array
     ArrayString* const oldarray = (ArrayString*)m_array;
-    for (size_t i = 0; i < oldarray->Size(); ++i) {
+    for (size_t i = 0; i < oldarray->size(); ++i) {
         newarray->add(oldarray->Get(i));
     }
     newarray->Set(ndx, value, len);
@@ -364,7 +364,7 @@ void AdaptiveStringColumn::LeafInsert(size_t ndx, const char* value)
 
     // Copy strings to new array
     ArrayString* const oldarray = (ArrayString*)m_array;
-    const size_t n = oldarray->Size();
+    const size_t n = oldarray->size();
     for (size_t i=0; i<n; ++i) {
         newarray->add(oldarray->Get(i));
     }

--- a/src/tightdb/column_table.cpp
+++ b/src/tightdb/column_table.cpp
@@ -126,7 +126,7 @@ void ColumnTable::LeafToDot(std::ostream& out, const Array& array) const
 {
     array.ToDot(out);
 
-    const size_t count = array.Size();
+    const size_t count = array.size();
     for (size_t i = 0; i < count; ++i) {
         if (array.GetAsRef(i) == 0) continue;
         const ConstTableRef subtable = get_subtable(i, m_ref_specSet);

--- a/src/tightdb/column_table.hpp
+++ b/src/tightdb/column_table.hpp
@@ -294,7 +294,7 @@ inline void ColumnSubtableParent::SubtableMap::update_from_parents()
 {
     if (!m_indices.IsValid()) return;
 
-    const size_t count = m_wrappers.Size();
+    const size_t count = m_wrappers.size();
     for (size_t i = 0; i < count; ++i) {
         Table* const t = reinterpret_cast<Table*>(m_wrappers.Get(i));
         t->UpdateFromParent();
@@ -305,7 +305,7 @@ inline void ColumnSubtableParent::SubtableMap::invalidate_subtables()
 {
     if (!m_indices.IsValid()) return;
 
-    const size_t n = m_wrappers.Size();
+    const size_t n = m_wrappers.size();
     for (size_t i=0; i<n; ++i) {
         Table* const t = reinterpret_cast<Table*>(m_wrappers.Get(i));
         t->invalidate();

--- a/src/tightdb/column_tpl.hpp
+++ b/src/tightdb/column_tpl.hpp
@@ -176,7 +176,7 @@ template<typename T, class C> Column::NodeChange ColumnBase::DoInsert(size_t ndx
         size_t node_ndx = offsets.FindPos(ndx);
         if (node_ndx == (size_t)-1) {
             // node can never be empty, so try to fit in last item
-            node_ndx = offsets.Size()-1;
+            node_ndx = offsets.size()-1;
         }
 
         // Calc index in subnode
@@ -196,7 +196,7 @@ template<typename T, class C> Column::NodeChange ColumnBase::DoInsert(size_t ndx
         if (nc.type == NodeChange::insert_after) ++node_ndx;
 
         // If there is room, just update node directly
-        if (offsets.Size() < TIGHTDB_MAX_LIST_SIZE) {
+        if (offsets.size() < TIGHTDB_MAX_LIST_SIZE) {
             if (nc.type == NodeChange::split) NodeInsertSplit<C>(node_ndx, nc.ref2);
             else NodeInsert<C>(node_ndx, nc.ref1); // ::INSERT_BEFORE/AFTER
             return NodeChange::none;
@@ -224,7 +224,7 @@ template<typename T, class C> Column::NodeChange ColumnBase::DoInsert(size_t ndx
             else return NodeChange(NodeChange::insert_after, newNode.GetRef());
         default:            // split
             // Move items after split to new node
-            const size_t len = refs.Size();
+            const size_t len = refs.size();
             for (size_t i = node_ndx; i < len; ++i) {
                 const size_t ref = refs.GetAsRef(i);
                 newNode.NodeAdd<C>(ref);
@@ -273,8 +273,8 @@ template<class C> void ColumnBase::NodeInsertSplit(size_t ndx, size_t new_ref)
     Array offsets = NodeGetOffsets();
     Array refs = NodeGetRefs();
 
-    TIGHTDB_ASSERT(ndx < offsets.Size());
-    TIGHTDB_ASSERT(offsets.Size() < TIGHTDB_MAX_LIST_SIZE);
+    TIGHTDB_ASSERT(ndx < offsets.size());
+    TIGHTDB_ASSERT(offsets.size() < TIGHTDB_MAX_LIST_SIZE);
 
     // Get sublists
     const C orig_col = GetColumnFromRef<C>(refs, ndx);
@@ -299,7 +299,7 @@ template<class C> void ColumnBase::NodeInsertSplit(size_t ndx, size_t new_ref)
 #endif
 
     // Update following offsets
-    if (offsets.Size() > ndx+2)
+    if (offsets.size() > ndx+2)
         offsets.Increment(1, ndx+2);
 }
 
@@ -311,15 +311,15 @@ template<class C> void ColumnBase::NodeInsert(size_t ndx, size_t ref)
     Array offsets = NodeGetOffsets();
     Array refs = NodeGetRefs();
 
-    TIGHTDB_ASSERT(ndx <= offsets.Size());
-    TIGHTDB_ASSERT(offsets.Size() < TIGHTDB_MAX_LIST_SIZE);
+    TIGHTDB_ASSERT(ndx <= offsets.size());
+    TIGHTDB_ASSERT(offsets.size() < TIGHTDB_MAX_LIST_SIZE);
 
     const C col(ref, (Array*)NULL, 0, m_array->GetAllocator());
     const size_t refSize = col.Size();
     const int64_t newOffset = (ndx ? offsets.Get(ndx-1) : 0) + refSize;
 
     offsets.Insert(ndx, newOffset);
-    if (ndx+1 < offsets.Size()) {
+    if (ndx+1 < offsets.size()) {
         offsets.Increment(refSize, ndx+1);
     }
     refs.Insert(ndx, ref);
@@ -334,7 +334,7 @@ template<class C> void ColumnBase::NodeAdd(size_t ref)
     Array refs = NodeGetRefs();
     const C col(ref, (Array*)NULL, 0, m_array->GetAllocator());
 
-    TIGHTDB_ASSERT(offsets.Size() < TIGHTDB_MAX_LIST_SIZE);
+    TIGHTDB_ASSERT(offsets.size() < TIGHTDB_MAX_LIST_SIZE);
 
     const int64_t newOffset = (offsets.is_empty() ? 0 : offsets.back()) + col.Size();
     offsets.add(newOffset);
@@ -376,7 +376,7 @@ template<typename T, class C> void ColumnBase::TreeDelete(size_t ndx)
         }
         else {
             // Update lower offsets
-            if (node_ndx < offsets.Size()) offsets.Increment(-1, node_ndx);
+            if (node_ndx < offsets.size()) offsets.Increment(-1, node_ndx);
         }
     }
 }
@@ -397,7 +397,7 @@ size_t ColumnBase::TreeFind(T value, size_t start, size_t end) const
         // Get subnode table
         const Array offsets = NodeGetOffsets();
         const Array refs = NodeGetRefs();
-        const size_t count = refs.Size();
+        const size_t count = refs.size();
 
         if (start == 0 && end == size_t(-1)) {
             for (size_t i = 0; i < count; ++i) {
@@ -455,7 +455,7 @@ template<typename T, class C> void ColumnBase::TreeFindAll(Array &result, T valu
         // Get subnode table
         const Array offsets = NodeGetOffsets();
         const Array refs = NodeGetRefs();
-        const size_t count = refs.Size();
+        const size_t count = refs.size();
         size_t i = offsets.FindPos(start);
         size_t offset = i ? to_ref(offsets.Get(i-1)) : 0;
         size_t s = start - offset;
@@ -495,14 +495,14 @@ void ColumnBase::TreeVisitLeafs(size_t start, size_t end, size_t caller_offset,
 {
     if (!IsNode()) {
         if (end == size_t(-1))
-            end = m_array->Size();
-        if (m_array->Size() > 0)
+            end = m_array->size();
+        if (m_array->size() > 0)
             call(m_array, start, end, caller_offset, state);
     }
     else {
         const Array offsets = NodeGetOffsets();
         const Array refs = NodeGetRefs();
-        const size_t count = refs.Size();
+        const size_t count = refs.size();
         size_t i = offsets.FindPos(start);
         size_t offset = i ? to_ref(offsets.Get(i-1)) : 0;
         size_t s = start - offset;

--- a/src/tightdb/group.hpp
+++ b/src/tightdb/group.hpp
@@ -371,13 +371,13 @@ inline bool Group::in_initial_state() const
 inline std::size_t Group::get_table_count() const
 {
     if (!m_top.IsValid()) return 0;
-    return m_tableNames.Size();
+    return m_tableNames.size();
 }
 
 inline const char* Group::get_table_name(std::size_t table_ndx) const
 {
     TIGHTDB_ASSERT(m_top.IsValid());
-    TIGHTDB_ASSERT(table_ndx < m_tableNames.Size());
+    TIGHTDB_ASSERT(table_ndx < m_tableNames.size());
     return m_tableNames.Get(table_ndx);
 }
 
@@ -533,7 +533,7 @@ void Group::to_json(S& out) const
 
     out << "{";
 
-    for (size_t i = 0; i < m_tables.Size(); ++i) {
+    for (size_t i = 0; i < m_tables.size(); ++i) {
         const char* const name = m_tableNames.Get(i);
         const Table* const table = get_table_ptr(i);
 
@@ -549,7 +549,7 @@ void Group::to_json(S& out) const
 
 inline void Group::clear_cache()
 {
-    const size_t count = m_cachedtables.Size();
+    const size_t count = m_cachedtables.size();
     for (size_t i = 0; i < count; ++i) {
         if (Table* const t = reinterpret_cast<Table*>(m_cachedtables.Get(i))) {
             t->invalidate();

--- a/src/tightdb/group_writer.cpp
+++ b/src/tightdb/group_writer.cpp
@@ -30,8 +30,8 @@ size_t GroupWriter::Commit()
     Array& flengths     = m_group.m_freeLengths;
     Array& fversions    = m_group.m_freeVersions;
     const bool isShared = m_group.m_is_shared;
-    TIGHTDB_ASSERT(fpositions.Size() == flengths.Size());
-    TIGHTDB_ASSERT(!isShared || fversions.Size() == flengths.Size());
+    TIGHTDB_ASSERT(fpositions.size() == flengths.size());
+    TIGHTDB_ASSERT(!isShared || fversions.size() == flengths.size());
 
     // Ensure that the freelist arrays are are themselves added to
     // (the allocator) free list
@@ -60,7 +60,7 @@ size_t GroupWriter::Commit()
     // To make sure we have room for top and free list we calculate the absolute
     // largest size they can get:
     // (64bit width + one possible ekstra entry per alloc and header)
-    const size_t free_count = fpositions.Size() + 5;
+    const size_t free_count = fpositions.size() + 5;
     const size_t top_max_size = (5 + 1) * 8;
     const size_t flist_max_size = (free_count) * 8;
     const size_t total_reserve = top_max_size + (flist_max_size * (isShared ? 3 : 2));
@@ -87,7 +87,7 @@ size_t GroupWriter::Commit()
     top.Set(2, res_pos);
     top.Set(3, fl_pos);
     if (isShared) top.Set(4, fv_pos);
-    else if (top.Size() == 5) top.Delete(4); // versions
+    else if (top.size() == 5) top.Delete(4); // versions
 
     // Get final sizes
     const size_t top_size = top.GetByteSize(true);
@@ -184,7 +184,7 @@ void GroupWriter::merge_free_space()
     if (flengths.is_empty())
         return;
 
-    size_t count = flengths.Size()-1;
+    size_t count = flengths.size()-1;
     for (size_t i = 0; i < count; ++i) {
         const size_t i2 = i+1;
         const size_t pos1 = fpositions.GetAsSizeT(i);
@@ -249,7 +249,7 @@ size_t GroupWriter::reserve_free_space(size_t len, size_t start)
     const bool isShared = m_group.m_is_shared;
 
     // Do we have a free space we can reuse?
-    const size_t count = flengths.Size();
+    const size_t count = flengths.size();
     size_t ndx = not_found;
     for (size_t i = start; i < count; ++i) {
         const size_t free_len = flengths.GetAsSizeT(i);
@@ -297,7 +297,7 @@ size_t GroupWriter::get_free_space(size_t len)
     Array& fversions    = m_group.m_freeVersions;
     const bool isShared = m_group.m_is_shared;
 
-    const size_t count = flengths.Size();
+    const size_t count = flengths.size();
 
     // Since we do a 'first fit' search, the top pieces are likely
     // to get smaller and smaller. So if we are looking for a bigger piece
@@ -379,7 +379,7 @@ size_t GroupWriter::extend_free_space(size_t len)
 
     // See if we can merge in new space
     if (!fpositions.is_empty()) {
-        const size_t last_ndx = fpositions.Size()-1;
+        const size_t last_ndx = fpositions.size()-1;
         const size_t last_len = flengths[last_ndx];
         const size_t end  = fpositions[last_ndx] + last_len;
         const size_t ver  = isShared ? fversions[last_ndx] : 0;
@@ -394,7 +394,7 @@ size_t GroupWriter::extend_free_space(size_t len)
     flengths.add(ext_len);
     if (isShared) fversions.add(0); // new space is always free for writing
 
-    return fpositions.Size()-1;
+    return fpositions.size()-1;
 }
 
 
@@ -407,7 +407,7 @@ void GroupWriter::dump()
     Array& fversions    = m_group.m_freeVersions;
     const bool isShared = m_group.m_is_shared;
 
-    const size_t count = flengths.Size();
+    const size_t count = flengths.size();
     cout << "count: " << count << ", m_len = " << m_file_map.get_size() << ", version >= " << m_readlock_version << "\n";
     if (!isShared) {
         for (size_t i = 0; i < count; ++i) {

--- a/src/tightdb/index_string.cpp
+++ b/src/tightdb/index_string.cpp
@@ -174,7 +174,7 @@ Column::NodeChange StringIndex::DoInsert(size_t row_ndx, int32_t key, size_t off
         size_t node_ndx = offsets.FindPos2(key);
         if (node_ndx == (size_t)-1) {
             // node can never be empty, so try to fit in last item
-            node_ndx = offsets.Size()-1;
+            node_ndx = offsets.size()-1;
         }
 
         // Get sublist
@@ -193,7 +193,7 @@ Column::NodeChange StringIndex::DoInsert(size_t row_ndx, int32_t key, size_t off
         if (nc.type == NodeChange::insert_after) ++node_ndx;
 
         // If there is room, just update node directly
-        if (offsets.Size() < TIGHTDB_MAX_LIST_SIZE) {
+        if (offsets.size() < TIGHTDB_MAX_LIST_SIZE) {
             if (nc.type == NodeChange::split) NodeInsertSplit(node_ndx, nc.ref2);
             else NodeInsert(node_ndx, nc.ref1); // ::INSERT_BEFORE/AFTER
             return NodeChange::none;
@@ -220,7 +220,7 @@ Column::NodeChange StringIndex::DoInsert(size_t row_ndx, int32_t key, size_t off
                 else return NodeChange(NodeChange::insert_after, newNode.GetRef());
             default:            // split
                 // Move items after split to new node
-                const size_t len = refs.Size();
+                const size_t len = refs.size();
                 for (size_t i = node_ndx; i < len; ++i) {
                     const size_t ref = refs.GetAsRef(i);
                     newNode.NodeAddKey(ref);
@@ -233,7 +233,7 @@ Column::NodeChange StringIndex::DoInsert(size_t row_ndx, int32_t key, size_t off
     else {
         // Is there room in the list?
         Array old_offsets = m_array->GetSubArray(0);
-        const size_t count = old_offsets.Size();
+        const size_t count = old_offsets.size();
         const bool noextend = count >= TIGHTDB_MAX_LIST_SIZE;
 
         // See if we can fit entry into current leaf
@@ -286,8 +286,8 @@ void StringIndex::NodeInsertSplit(size_t ndx, size_t new_ref)
     Array offsets = NodeGetOffsets();
     Array refs = NodeGetRefs();
 
-    TIGHTDB_ASSERT(ndx < offsets.Size());
-    TIGHTDB_ASSERT(offsets.Size() < TIGHTDB_MAX_LIST_SIZE);
+    TIGHTDB_ASSERT(ndx < offsets.size());
+    TIGHTDB_ASSERT(offsets.size() < TIGHTDB_MAX_LIST_SIZE);
 
     // Get sublists
     const size_t orig_ref = refs.Get(ndx);
@@ -312,8 +312,8 @@ void StringIndex::NodeInsert(size_t ndx, size_t ref)
     Array offsets = NodeGetOffsets();
     Array refs = NodeGetRefs();
 
-    TIGHTDB_ASSERT(ndx <= offsets.Size());
-    TIGHTDB_ASSERT(offsets.Size() < TIGHTDB_MAX_LIST_SIZE);
+    TIGHTDB_ASSERT(ndx <= offsets.size());
+    TIGHTDB_ASSERT(offsets.size() < TIGHTDB_MAX_LIST_SIZE);
 
     const StringIndex col(ref, (Array*)NULL, 0, m_target_column, m_get_func, m_array->GetAllocator());
     const int64_t lastKey = col.GetLastKey();
@@ -438,7 +438,7 @@ size_t StringIndex::count(const char* value) const
 void StringIndex::distinct(Array& result) const
 {
     Array refs = m_array->GetSubArray(1);
-    const size_t count = refs.Size();
+    const size_t count = refs.size();
     Allocator& alloc = m_array->GetAllocator();
 
     // Get first matching row for every key
@@ -479,7 +479,7 @@ void StringIndex::UpdateRefs(size_t pos, int diff)
     TIGHTDB_ASSERT(diff == 1 || diff == -1); // only used by insert and delete
 
     Array refs = m_array->GetSubArray(1);
-    const size_t count = refs.Size();
+    const size_t count = refs.size();
     Allocator& alloc = m_array->GetAllocator();
 
     if (m_array->IsNode()) {
@@ -531,8 +531,8 @@ void StringIndex::Delete(size_t row_ndx, const char* value, bool isLast)
     // Collapse top nodes with single item
     while (IsNode()) {
         Array refs = m_array->GetSubArray(1);
-        TIGHTDB_ASSERT(refs.Size() != 0); // node cannot be empty
-        if (refs.Size() > 1) break;
+        TIGHTDB_ASSERT(refs.size() != 0); // node cannot be empty
+        if (refs.size() > 1) break;
 
         const size_t ref = (size_t)refs.Get(0);
         refs.Delete(0); // avoid deleting subtree
@@ -664,7 +664,7 @@ void StringIndex::ArrayToDot(std::ostream& out, const Array& array) const
 
         refs.ToDot(out, "refs");
 
-        const size_t count = refs.Size();
+        const size_t count = refs.size();
         for (size_t i = 0; i < count; ++i) {
             const size_t ref = refs.GetAsRef(i);
             if (ref & 1) continue; // ignore literals
@@ -699,7 +699,7 @@ void StringIndex::KeysToDot(std::ostream& out, const Array& array, const char* t
     out << "</FONT></TD>" << std::endl;
 
     // Values
-    const size_t count = array.Size();
+    const size_t count = array.size();
     for (size_t i = 0; i < count; ++i) {
         const int64_t v =  array.Get(i);
 

--- a/src/tightdb/query_engine.hpp
+++ b/src/tightdb/query_engine.hpp
@@ -198,7 +198,7 @@ public:
             // leave m_array untouched. Else call CreateFromHeader() on m_array (more time consuming) and return pointer to m_array.
             m_array_ptr = (ArrayType*) (((Column*)m_column)->GetBlock(index, m_array, m_leaf_start, true));
 //            m_array_ptr = m_column->GetBlock(index, m_array, m_leaf_start, true);
-            const size_t leaf_size = m_array_ptr->Size();
+            const size_t leaf_size = m_array_ptr->size();
             m_leaf_end = m_leaf_start + leaf_size;
             return true;
         }
@@ -455,13 +455,13 @@ protected:
 
 class ArrayNode: public ParentNode {
 public:
-    ArrayNode(const Array& arr) : m_arr(arr), m_max(0), m_next(0), m_size(arr.Size()) {m_child = 0; m_dT = 0.0;}
+    ArrayNode(const Array& arr) : m_arr(arr), m_max(0), m_next(0), m_size(arr.size()) {m_child = 0; m_dT = 0.0;}
 
     void Init(const Table& table)
     {
         m_table = &table;
 
-        m_dD =  m_table->size() / (m_arr.Size() + 1.0);
+        m_dD =  m_table->size() / (m_arr.size() + 1.0);
         m_probes = 0;
         m_matches = 0;
 
@@ -680,7 +680,7 @@ public:
             // Cache internal leafs
             if (s >= m_leaf_end) {
                 m_condition_column->GetBlock(s, m_array, m_leaf_start);
-                m_leaf_end = m_leaf_start + m_array.Size();
+                m_leaf_end = m_leaf_start + m_array.size();
                 size_t w = m_array.GetBitWidth();
                 m_dT = (w == 0 ? 1.0 / TIGHTDB_MAX_LIST_SIZE : w / float(bitwidth_time_unit));
             }
@@ -734,7 +734,7 @@ public:
             // Cache internal leafs
             if (start >= m_leaf_end) {
                 m_condition_column->GetBlock(start, m_array, m_leaf_start);
-                m_leaf_end = m_leaf_start + m_array.Size();
+                m_leaf_end = m_leaf_start + m_array.size();
             }
 
             // Do search directly on cached leaf array

--- a/src/tightdb/spec.cpp
+++ b/src/tightdb/spec.cpp
@@ -20,7 +20,7 @@ void Spec::init_from_ref(size_t ref, ArrayParent* parent, size_t ndx_in_parent)
 {
     m_specSet.UpdateRef(ref);
     m_specSet.SetParent(parent, ndx_in_parent);
-    TIGHTDB_ASSERT(m_specSet.Size() == 2 || m_specSet.Size() == 3);
+    TIGHTDB_ASSERT(m_specSet.size() == 2 || m_specSet.size() == 3);
 
     m_spec.UpdateRef(m_specSet.GetAsRef(0));
     m_spec.SetParent(&m_specSet, 0);
@@ -28,7 +28,7 @@ void Spec::init_from_ref(size_t ref, ArrayParent* parent, size_t ndx_in_parent)
     m_names.SetParent(&m_specSet, 1);
 
     // SubSpecs array is only there when there are subtables
-    if (m_specSet.Size() == 3) {
+    if (m_specSet.size() == 3) {
         m_subSpecs.UpdateRef(m_specSet.GetAsRef(2));
         m_subSpecs.SetParent(&m_specSet, 2);
     }
@@ -59,7 +59,7 @@ bool Spec::update_from_parent()
     if (m_specSet.UpdateFromParent()) {
         m_spec.UpdateFromParent();
         m_names.UpdateFromParent();
-        if (m_specSet.Size() == 3) {
+        if (m_specSet.size() == 3) {
             m_subSpecs.UpdateFromParent();
         }
         return true;
@@ -77,13 +77,13 @@ size_t Spec::add_column(DataType type, const char* name, ColumnType attr)
     // We can set column attribute on creation
     // TODO: add to replication log
     if (attr != col_attr_None) {
-        const size_t column_ndx = m_names.Size()-1;
+        const size_t column_ndx = m_names.size()-1;
         set_column_attr(column_ndx, attr);
     }
 
     if (type == type_Table) {
         // SubSpecs array is only there when there are subtables
-        if (m_specSet.Size() == 2) {
+        if (m_specSet.size() == 2) {
             m_subSpecs.SetType(coldef_HasRefs);
             //m_subSpecs.SetType((ColumnDef)4);
             //return;
@@ -110,7 +110,7 @@ size_t Spec::add_column(DataType type, const char* name, ColumnType attr)
     if (repl) repl->add_column(m_table, this, type, name); // Throws
 #endif
 
-    return (m_names.Size()-1); // column_ndx
+    return (m_names.size()-1); // column_ndx
 }
 
 size_t Spec::add_subcolumn(const vector<size_t>& column_path, DataType type, const char* name)
@@ -134,7 +134,7 @@ size_t Spec::do_add_subcolumn(const vector<size_t>& column_ids, size_t pos, Data
 
 Spec Spec::add_subtable_column(const char* name)
 {
-    const size_t column_ndx = m_names.Size();
+    const size_t column_ndx = m_names.size();
     add_column(type_Table, name);
 
     return get_subtable_spec(column_ndx);
@@ -142,7 +142,7 @@ Spec Spec::add_subtable_column(const char* name)
 
 void Spec::rename_column(size_t column_ndx, const char* newname)
 {
-    TIGHTDB_ASSERT(column_ndx < m_spec.Size());
+    TIGHTDB_ASSERT(column_ndx < m_spec.size());
 
     //TODO: Verify that new name is valid
 
@@ -168,7 +168,7 @@ void Spec::do_rename_column(const vector<size_t>& column_ids, size_t pos, const 
 
 void Spec::remove_column(size_t column_ndx)
 {
-    TIGHTDB_ASSERT(column_ndx < m_spec.Size());
+    TIGHTDB_ASSERT(column_ndx < m_spec.size());
 
     const size_t type_ndx = get_column_type_pos(column_ndx);
 
@@ -254,7 +254,7 @@ size_t Spec::get_subspec_ndx(size_t column_ndx) const
 
 size_t Spec::get_subspec_ref(std::size_t subspec_ndx) const
 {
-    TIGHTDB_ASSERT(subspec_ndx < m_subSpecs.Size());
+    TIGHTDB_ASSERT(subspec_ndx < m_subSpecs.size());
 
     // Note that this addresses subspecs directly, indexing
     // by number of sub-table columns
@@ -263,7 +263,7 @@ size_t Spec::get_subspec_ref(std::size_t subspec_ndx) const
 
 size_t Spec::get_type_attr_count() const
 {
-    return m_spec.Size();
+    return m_spec.size();
 }
 
 ColumnType Spec::get_type_attr(size_t ndx) const
@@ -273,7 +273,7 @@ ColumnType Spec::get_type_attr(size_t ndx) const
 
 size_t Spec::get_column_count() const TIGHTDB_NOEXCEPT
 {
-    return m_names.Size();
+    return m_names.size();
 }
 
 size_t Spec::get_column_type_pos(size_t column_ndx) const TIGHTDB_NOEXCEPT
@@ -326,7 +326,7 @@ void Spec::set_column_type(std::size_t column_ndx, ColumnType type)
 
     size_t type_ndx = 0;
     size_t column_count = 0;
-    const size_t count = m_spec.Size();
+    const size_t count = m_spec.size();
 
     for (;type_ndx < count; ++type_ndx) {
         const ColumnType t = ColumnType(m_spec.Get(type_ndx));
@@ -430,8 +430,8 @@ bool Spec::operator==(const Spec& spec) const
 void Spec::Verify() const
 {
     const size_t column_count = get_column_count();
-    TIGHTDB_ASSERT(column_count == m_names.Size());
-    TIGHTDB_ASSERT(column_count <= m_spec.Size());
+    TIGHTDB_ASSERT(column_count == m_names.size());
+    TIGHTDB_ASSERT(column_count <= m_spec.size());
 }
 
 void Spec::to_dot(std::ostream& out, const char*) const
@@ -447,7 +447,7 @@ void Spec::to_dot(std::ostream& out, const char*) const
     if (m_subSpecs.IsValid()) {
         m_subSpecs.ToDot(out, "subspecs");
 
-        const size_t count = m_subSpecs.Size();
+        const size_t count = m_subSpecs.size();
         Allocator& alloc = m_specSet.GetAllocator();
 
         // Write out subspecs

--- a/src/tightdb/spec.hpp
+++ b/src/tightdb/spec.hpp
@@ -107,7 +107,7 @@ private:
     size_t get_column_type_pos(size_t column_ndx) const TIGHTDB_NOEXCEPT;
     size_t get_subspec_ndx(size_t column_ndx) const;
     size_t get_subspec_ref(size_t subspec_ndx) const;
-    size_t get_num_subspecs() const { return m_subSpecs.IsValid() ? m_subSpecs.Size() : 0; }
+    size_t get_num_subspecs() const { return m_subSpecs.IsValid() ? m_subSpecs.size() : 0; }
     Spec get_subspec_by_ndx(size_t subspec_ndx);
 
     /// Construct an empty spec and return just the reference to the

--- a/src/tightdb/table.cpp
+++ b/src/tightdb/table.cpp
@@ -37,7 +37,7 @@ void Table::init_from_ref(size_t top_ref, ArrayParent* parent, size_t ndx_in_par
     // Load from allocated memory
     m_top.UpdateRef(top_ref);
     m_top.SetParent(parent, ndx_in_parent);
-    TIGHTDB_ASSERT(m_top.Size() == 2);
+    TIGHTDB_ASSERT(m_top.size() == 2);
 
     const size_t spec_ref    = m_top.GetAsRef(0);
     const size_t columns_ref = m_top.GetAsRef(1);
@@ -77,7 +77,7 @@ void Table::CreateColumns()
     // Add the newly defined columns
     for (size_t i=0; i<count; ++i) {
         const ColumnType type = m_spec_set.get_type_attr(i);
-        const size_t ref_pos =  m_columns.Size();
+        const size_t ref_pos =  m_columns.size();
         ColumnBase* new_col = 0;
 
         switch (type) {
@@ -125,7 +125,7 @@ void Table::CreateColumns()
             break;
         case type_Table:
             {
-                const size_t column_ndx = m_cols.Size();
+                const size_t column_ndx = m_cols.size();
                 const size_t subspec_ref = m_spec_set.get_subspec_ref(subtable_count);
                 ColumnTable* c = new ColumnTable(alloc, this, column_ndx, subspec_ref);
                 m_columns.add(c->GetRef());
@@ -136,7 +136,7 @@ void Table::CreateColumns()
             break;
         case type_Mixed:
             {
-                const size_t column_ndx = m_cols.Size();
+                const size_t column_ndx = m_cols.size();
                 ColumnMixed* c = new ColumnMixed(alloc, this, column_ndx);
                 m_columns.add(c->GetRef());
                 c->SetParent(&m_columns, ref_pos);
@@ -159,7 +159,7 @@ void Table::CreateColumns()
 
         // Atributes on columns may define that they come with an index
         if (attr != col_attr_None) {
-            const size_t column_ndx = m_cols.Size()-1;
+            const size_t column_ndx = m_cols.size()-1;
             set_index(column_ndx, false);
 
             attr = col_attr_None;
@@ -187,7 +187,7 @@ void Table::invalidate()
     m_columns.SetParent(0,0);
 
     // Invalidate all subtables
-    const size_t n = m_cols.Size();
+    const size_t n = m_cols.size();
     for (size_t i=0; i<n; ++i) {
         ColumnBase* const c = reinterpret_cast<ColumnBase*>(m_cols.Get(i));
         c->invalidate_subtables_virtual();
@@ -273,7 +273,7 @@ void Table::CacheColumns()
             break;
         case type_Table:
             {
-                const size_t column_ndx = m_cols.Size();
+                const size_t column_ndx = m_cols.size();
                 const size_t spec_ref = m_spec_set.get_subspec_ref(subtable_count);
                 ColumnTable* c = new ColumnTable(alloc, this, column_ndx, &m_columns, ndx_in_parent,
                                                  spec_ref, ref);
@@ -284,7 +284,7 @@ void Table::CacheColumns()
             break;
         case type_Mixed:
             {
-                const size_t column_ndx = m_cols.Size();
+                const size_t column_ndx = m_cols.size();
                 ColumnMixed* c =
                     new ColumnMixed(alloc, this, column_ndx, &m_columns, ndx_in_parent, ref);
                 colsize = c->Size();
@@ -333,7 +333,7 @@ void Table::ClearCachedColumns()
 {
     TIGHTDB_ASSERT(m_cols.IsValid());
 
-    const size_t count = m_cols.Size();
+    const size_t count = m_cols.size();
     for (size_t i = 0; i < count; ++i) {
         ColumnBase* const column = reinterpret_cast<ColumnBase*>(m_cols.Get(i));
         delete column;
@@ -484,7 +484,7 @@ size_t Table::add_column(DataType type, const char* name)
 size_t Table::do_add_column(DataType type)
 {
     const size_t count      = size();
-    const size_t column_ndx = m_cols.Size();
+    const size_t column_ndx = m_cols.size();
 
     ColumnBase* new_col = NULL;
     Allocator& alloc = m_columns.GetAllocator();
@@ -496,7 +496,7 @@ size_t Table::do_add_column(DataType type)
         {
             Column* c = new Column(coldef_Normal, alloc);
             m_columns.add(c->GetRef());
-            c->SetParent(&m_columns, m_columns.Size()-1);
+            c->SetParent(&m_columns, m_columns.size()-1);
             new_col = c;
             c->fill(count);
         }
@@ -505,7 +505,7 @@ size_t Table::do_add_column(DataType type)
         {
             ColumnFloat* c = new ColumnFloat(alloc);
             m_columns.add(c->GetRef());
-            c->SetParent(&m_columns, m_columns.Size()-1);
+            c->SetParent(&m_columns, m_columns.size()-1);
             new_col = c;
             c->fill(count);
         }
@@ -514,7 +514,7 @@ size_t Table::do_add_column(DataType type)
         {
             ColumnDouble* c = new ColumnDouble(alloc);
             m_columns.add(c->GetRef());
-            c->SetParent(&m_columns, m_columns.Size()-1);
+            c->SetParent(&m_columns, m_columns.size()-1);
             new_col = c;
             c->fill(count);
         }
@@ -523,7 +523,7 @@ size_t Table::do_add_column(DataType type)
         {
             AdaptiveStringColumn* c = new AdaptiveStringColumn(alloc);
             m_columns.add(c->GetRef());
-            c->SetParent(&m_columns, m_columns.Size()-1);
+            c->SetParent(&m_columns, m_columns.size()-1);
             new_col = c;
             c->fill(count);
         }
@@ -532,7 +532,7 @@ size_t Table::do_add_column(DataType type)
         {
             ColumnBinary* c = new ColumnBinary(alloc);
             m_columns.add(c->GetRef());
-            c->SetParent(&m_columns, m_columns.Size()-1);
+            c->SetParent(&m_columns, m_columns.size()-1);
             new_col = c;
             c->fill(count);
         }
@@ -542,7 +542,7 @@ size_t Table::do_add_column(DataType type)
         {
             ColumnTable* c = new ColumnTable(alloc, this, column_ndx, -1); // subspec ref will be filled in later
             m_columns.add(c->GetRef());
-            c->SetParent(&m_columns, m_columns.Size()-1);
+            c->SetParent(&m_columns, m_columns.size()-1);
             new_col = c;
             c->fill(count);
         }
@@ -552,7 +552,7 @@ size_t Table::do_add_column(DataType type)
         {
             ColumnMixed* c = new ColumnMixed(alloc, this, column_ndx);
             m_columns.add(c->GetRef());
-            c->SetParent(&m_columns, m_columns.Size()-1);
+            c->SetParent(&m_columns, m_columns.size()-1);
             new_col = c;
             c->fill(count);
         }
@@ -705,14 +705,14 @@ ColumnBase& Table::GetColumnBase(size_t ndx)
 {
     TIGHTDB_ASSERT(ndx < get_column_count());
     InstantiateBeforeChange();
-    TIGHTDB_ASSERT(m_cols.Size() == get_column_count());
+    TIGHTDB_ASSERT(m_cols.size() == get_column_count());
     return *reinterpret_cast<ColumnBase*>(m_cols.Get(ndx));
 }
 
 const ColumnBase& Table::GetColumnBase(size_t ndx) const TIGHTDB_NOEXCEPT
 {
     TIGHTDB_ASSERT(ndx < get_column_count());
-    TIGHTDB_ASSERT(m_cols.Size() == get_column_count());
+    TIGHTDB_ASSERT(m_cols.size() == get_column_count());
     return *reinterpret_cast<ColumnBase*>(m_cols.Get(ndx));
 }
 
@@ -1102,7 +1102,7 @@ void Table::insert_double(size_t column_ndx, size_t ndx, double value)
 
 const char* Table::get_string(size_t column_ndx, size_t ndx) const TIGHTDB_NOEXCEPT
 {
-    TIGHTDB_ASSERT(column_ndx < m_columns.Size());
+    TIGHTDB_ASSERT(column_ndx < m_columns.size());
     TIGHTDB_ASSERT(ndx < m_size);
 
     const ColumnType type = get_real_column_type(column_ndx);
@@ -1171,7 +1171,7 @@ void Table::insert_string(size_t column_ndx, size_t ndx, const char* value)
 
 BinaryData Table::get_binary(size_t column_ndx, size_t ndx) const
 {
-    TIGHTDB_ASSERT(column_ndx < m_columns.Size());
+    TIGHTDB_ASSERT(column_ndx < m_columns.size());
     TIGHTDB_ASSERT(ndx < m_size);
 
     const ColumnBinary& column = GetColumnBinary(column_ndx);
@@ -1207,7 +1207,7 @@ void Table::insert_binary(size_t column_ndx, size_t ndx, const char* data, size_
 
 Mixed Table::get_mixed(size_t column_ndx, size_t ndx) const
 {
-    TIGHTDB_ASSERT(column_ndx < m_columns.Size());
+    TIGHTDB_ASSERT(column_ndx < m_columns.size());
     TIGHTDB_ASSERT(ndx < m_size);
 
     const ColumnMixed& column = GetColumnMixed(column_ndx);
@@ -1239,7 +1239,7 @@ Mixed Table::get_mixed(size_t column_ndx, size_t ndx) const
 
 DataType Table::get_mixed_type(size_t column_ndx, size_t ndx) const TIGHTDB_NOEXCEPT
 {
-    TIGHTDB_ASSERT(column_ndx < m_columns.Size());
+    TIGHTDB_ASSERT(column_ndx < m_columns.size());
     TIGHTDB_ASSERT(ndx < m_size);
 
     const ColumnMixed& column = GetColumnMixed(column_ndx);
@@ -1527,7 +1527,7 @@ size_t Table::lookup(const char* value) const
 
 size_t Table::find_first_int(size_t column_ndx, int64_t value) const
 {
-    TIGHTDB_ASSERT(column_ndx < m_columns.Size());
+    TIGHTDB_ASSERT(column_ndx < m_columns.size());
     TIGHTDB_ASSERT(get_real_column_type(column_ndx) == col_type_Int);
     const Column& column = GetColumn(column_ndx);
 
@@ -1536,7 +1536,7 @@ size_t Table::find_first_int(size_t column_ndx, int64_t value) const
 
 size_t Table::find_first_bool(size_t column_ndx, bool value) const
 {
-    TIGHTDB_ASSERT(column_ndx < m_columns.Size());
+    TIGHTDB_ASSERT(column_ndx < m_columns.size());
     TIGHTDB_ASSERT(get_real_column_type(column_ndx) == col_type_Bool);
     const Column& column = GetColumn(column_ndx);
 
@@ -1545,7 +1545,7 @@ size_t Table::find_first_bool(size_t column_ndx, bool value) const
 
 size_t Table::find_first_date(size_t column_ndx, time_t value) const
 {
-    TIGHTDB_ASSERT(column_ndx < m_columns.Size());
+    TIGHTDB_ASSERT(column_ndx < m_columns.size());
     TIGHTDB_ASSERT(get_real_column_type(column_ndx) == col_type_Date);
     const Column& column = GetColumn(column_ndx);
 
@@ -1554,7 +1554,7 @@ size_t Table::find_first_date(size_t column_ndx, time_t value) const
 
 size_t Table::find_first_float(size_t column_ndx, float value) const
 {
-    TIGHTDB_ASSERT(column_ndx < m_columns.Size());
+    TIGHTDB_ASSERT(column_ndx < m_columns.size());
     TIGHTDB_ASSERT(get_real_column_type(column_ndx) == col_type_Float);
     const ColumnFloat& column = GetColumnFloat(column_ndx);
 
@@ -1563,7 +1563,7 @@ size_t Table::find_first_float(size_t column_ndx, float value) const
 
 size_t Table::find_first_double(size_t column_ndx, double value) const
 {
-    TIGHTDB_ASSERT(column_ndx < m_columns.Size());
+    TIGHTDB_ASSERT(column_ndx < m_columns.size());
     TIGHTDB_ASSERT(get_real_column_type(column_ndx) == col_type_Double);
     const ColumnDouble& column = GetColumnDouble(column_ndx);
 
@@ -1572,7 +1572,7 @@ size_t Table::find_first_double(size_t column_ndx, double value) const
 
 size_t Table::find_first_string(size_t column_ndx, const char* value) const
 {
-    TIGHTDB_ASSERT(column_ndx < m_columns.Size());
+    TIGHTDB_ASSERT(column_ndx < m_columns.size());
 
     const ColumnType type = get_real_column_type(column_ndx);
 
@@ -1603,7 +1603,7 @@ size_t Table::find_pos_int(size_t column_ndx, int64_t value) const TIGHTDB_NOEXC
 
 TableView Table::find_all_int(size_t column_ndx, int64_t value)
 {
-    TIGHTDB_ASSERT(column_ndx < m_columns.Size());
+    TIGHTDB_ASSERT(column_ndx < m_columns.size());
 
     const Column& column = GetColumn(column_ndx);
 
@@ -1614,7 +1614,7 @@ TableView Table::find_all_int(size_t column_ndx, int64_t value)
 
 ConstTableView Table::find_all_int(size_t column_ndx, int64_t value) const
 {
-    TIGHTDB_ASSERT(column_ndx < m_columns.Size());
+    TIGHTDB_ASSERT(column_ndx < m_columns.size());
 
     const Column& column = GetColumn(column_ndx);
 
@@ -1625,7 +1625,7 @@ ConstTableView Table::find_all_int(size_t column_ndx, int64_t value) const
 
 TableView Table::find_all_bool(size_t column_ndx, bool value)
 {
-    TIGHTDB_ASSERT(column_ndx < m_columns.Size());
+    TIGHTDB_ASSERT(column_ndx < m_columns.size());
 
     const Column& column = GetColumn(column_ndx);
 
@@ -1636,7 +1636,7 @@ TableView Table::find_all_bool(size_t column_ndx, bool value)
 
 ConstTableView Table::find_all_bool(size_t column_ndx, bool value) const
 {
-    TIGHTDB_ASSERT(column_ndx < m_columns.Size());
+    TIGHTDB_ASSERT(column_ndx < m_columns.size());
 
     const Column& column = GetColumn(column_ndx);
 
@@ -1648,7 +1648,7 @@ ConstTableView Table::find_all_bool(size_t column_ndx, bool value) const
 
 TableView Table::find_all_float(size_t column_ndx, float value)
 {
-    TIGHTDB_ASSERT(column_ndx < m_columns.Size());
+    TIGHTDB_ASSERT(column_ndx < m_columns.size());
 
     const ColumnFloat& column = GetColumnFloat(column_ndx);
 
@@ -1659,7 +1659,7 @@ TableView Table::find_all_float(size_t column_ndx, float value)
 
 ConstTableView Table::find_all_float(size_t column_ndx, float value) const
 {
-    TIGHTDB_ASSERT(column_ndx < m_columns.Size());
+    TIGHTDB_ASSERT(column_ndx < m_columns.size());
 
     const ColumnFloat& column = GetColumnFloat(column_ndx);
 
@@ -1670,7 +1670,7 @@ ConstTableView Table::find_all_float(size_t column_ndx, float value) const
 
 TableView Table::find_all_double(size_t column_ndx, double value)
 {
-    TIGHTDB_ASSERT(column_ndx < m_columns.Size());
+    TIGHTDB_ASSERT(column_ndx < m_columns.size());
 
     const ColumnDouble& column = GetColumnDouble(column_ndx);
 
@@ -1681,7 +1681,7 @@ TableView Table::find_all_double(size_t column_ndx, double value)
 
 ConstTableView Table::find_all_double(size_t column_ndx, double value) const
 {
-    TIGHTDB_ASSERT(column_ndx < m_columns.Size());
+    TIGHTDB_ASSERT(column_ndx < m_columns.size());
 
     const ColumnDouble& column = GetColumnDouble(column_ndx);
 
@@ -1692,7 +1692,7 @@ ConstTableView Table::find_all_double(size_t column_ndx, double value) const
 
 TableView Table::find_all_date(size_t column_ndx, time_t value)
 {
-    TIGHTDB_ASSERT(column_ndx < m_columns.Size());
+    TIGHTDB_ASSERT(column_ndx < m_columns.size());
 
     const Column& column = GetColumn(column_ndx);
 
@@ -1703,7 +1703,7 @@ TableView Table::find_all_date(size_t column_ndx, time_t value)
 
 ConstTableView Table::find_all_date(size_t column_ndx, time_t value) const
 {
-    TIGHTDB_ASSERT(column_ndx < m_columns.Size());
+    TIGHTDB_ASSERT(column_ndx < m_columns.size());
 
     const Column& column = GetColumn(column_ndx);
 
@@ -1714,7 +1714,7 @@ ConstTableView Table::find_all_date(size_t column_ndx, time_t value) const
 
 TableView Table::find_all_string(size_t column_ndx, const char *value)
 {
-    TIGHTDB_ASSERT(column_ndx < m_columns.Size());
+    TIGHTDB_ASSERT(column_ndx < m_columns.size());
 
     const ColumnType type = get_real_column_type(column_ndx);
 
@@ -1733,7 +1733,7 @@ TableView Table::find_all_string(size_t column_ndx, const char *value)
 
 ConstTableView Table::find_all_string(size_t column_ndx, const char *value) const
 {
-    TIGHTDB_ASSERT(column_ndx < m_columns.Size());
+    TIGHTDB_ASSERT(column_ndx < m_columns.size());
 
     const ColumnType type = get_real_column_type(column_ndx);
 
@@ -1771,7 +1771,7 @@ ConstTableView Table::find_all_binary(size_t column_ndx, const char* value, size
 
 TableView Table::find_all_hamming(size_t column_ndx, uint64_t value, size_t max)
 {
-    TIGHTDB_ASSERT(column_ndx < m_columns.Size());
+    TIGHTDB_ASSERT(column_ndx < m_columns.size());
 
     const Column& column = GetColumn(column_ndx);
 
@@ -1782,7 +1782,7 @@ TableView Table::find_all_hamming(size_t column_ndx, uint64_t value, size_t max)
 
 ConstTableView Table::find_all_hamming(size_t column_ndx, uint64_t value, size_t max) const
 {
-    TIGHTDB_ASSERT(column_ndx < m_columns.Size());
+    TIGHTDB_ASSERT(column_ndx < m_columns.size());
 
     const Column& column = GetColumn(column_ndx);
 
@@ -1794,7 +1794,7 @@ ConstTableView Table::find_all_hamming(size_t column_ndx, uint64_t value, size_t
 
 TableView Table::distinct(size_t column_ndx)
 {
-    TIGHTDB_ASSERT(column_ndx < m_columns.Size());
+    TIGHTDB_ASSERT(column_ndx < m_columns.size());
     TIGHTDB_ASSERT(has_index(column_ndx));
 
     TableView tv(*this);
@@ -1817,7 +1817,7 @@ TableView Table::distinct(size_t column_ndx)
 
 ConstTableView Table::distinct(size_t column_ndx) const
 {
-    TIGHTDB_ASSERT(column_ndx < m_columns.Size());
+    TIGHTDB_ASSERT(column_ndx < m_columns.size());
     TIGHTDB_ASSERT(has_index(column_ndx));
 
     ConstTableView tv(*this);
@@ -1840,7 +1840,7 @@ ConstTableView Table::distinct(size_t column_ndx) const
 
 TableView Table::get_sorted_view(size_t column_ndx, bool ascending)
 {
-    TIGHTDB_ASSERT(column_ndx < m_columns.Size());
+    TIGHTDB_ASSERT(column_ndx < m_columns.size());
 
     TableView tv(*this);
 
@@ -1859,7 +1859,7 @@ TableView Table::get_sorted_view(size_t column_ndx, bool ascending)
 
 ConstTableView Table::get_sorted_view(size_t column_ndx, bool ascending) const
 {
-    TIGHTDB_ASSERT(column_ndx < m_columns.Size());
+    TIGHTDB_ASSERT(column_ndx < m_columns.size());
 
     ConstTableView tv(*this);
 
@@ -1926,7 +1926,7 @@ void Table::optimize()
 
 void Table::UpdateColumnRefs(size_t column_ndx, int diff)
 {
-    for (size_t i = column_ndx; i < m_cols.Size(); ++i) {
+    for (size_t i = column_ndx; i < m_cols.size(); ++i) {
         ColumnBase* const column = reinterpret_cast<ColumnBase*>(m_cols.Get(i));
         column->UpdateParentNdx(diff);
     }
@@ -2411,7 +2411,7 @@ void Table::Verify() const
     m_columns.Verify();
     if (m_columns.IsValid()) {
         const size_t column_count = get_column_count();
-        TIGHTDB_ASSERT(column_count == m_cols.Size());
+        TIGHTDB_ASSERT(column_count == m_cols.size());
 
         for (size_t i = 0; i < column_count; ++i) {
             const ColumnType type = get_real_column_type(i);

--- a/src/tightdb/table_view.cpp
+++ b/src/tightdb/table_view.cpp
@@ -10,7 +10,7 @@ namespace tightdb {
 
 size_t TableViewBase::find_first_integer(size_t column_ndx, int64_t value) const
 {
-    for (size_t i = 0; i < m_refs.Size(); i++)
+    for (size_t i = 0; i < m_refs.size(); i++)
         if (get_int(column_ndx, i) == value)
             return i;
     return size_t(-1);
@@ -20,7 +20,7 @@ size_t TableViewBase::find_first_string(size_t column_ndx, const char* value) co
 {
     TIGHTDB_ASSERT_COLUMN_AND_TYPE(column_ndx, type_String);
 
-    for (size_t i = 0; i < m_refs.Size(); i++)
+    for (size_t i = 0; i < m_refs.size(); i++)
         if (strcmp(get_string(column_ndx, i), value) == 0)
             return i;
     return size_t(-1);
@@ -28,7 +28,7 @@ size_t TableViewBase::find_first_string(size_t column_ndx, const char* value) co
 
 size_t TableViewBase::find_first_float(size_t column_ndx, float value) const
 {
-    for (size_t i = 0; i < m_refs.Size(); i++)
+    for (size_t i = 0; i < m_refs.size(); i++)
         if (get_float(column_ndx, i) == value)
             return i;
     return size_t(-1);
@@ -36,7 +36,7 @@ size_t TableViewBase::find_first_float(size_t column_ndx, float value) const
 
 size_t TableViewBase::find_first_double(size_t column_ndx, double value) const
 {
-    for (size_t i = 0; i < m_refs.Size(); i++)
+    for (size_t i = 0; i < m_refs.size(); i++)
         if (get_double(column_ndx, i) == value)
             return i;
     return size_t(-1);
@@ -53,13 +53,13 @@ R TableViewBase::aggregate(R (ColType::*aggregateMethod)(size_t, size_t) const, 
     TIGHTDB_ASSERT(function == act_Sum || function == act_Max || function == act_Min);
     TIGHTDB_ASSERT(m_table);
     TIGHTDB_ASSERT(column_ndx < m_table->get_column_count());
-    if (m_refs.Size() == 0)
+    if (m_refs.size() == 0)
         return 0;
 
     typedef typename ColumnTypeTraits<T>::array_type ArrType;
     const ColType* column = (ColType*)&m_table->GetColumnBase(column_ndx);
 
-    if (m_refs.Size() == column->Size()) {
+    if (m_refs.size() == column->Size()) {
         // direct aggregate on the column
         return (column->*aggregateMethod)(0, size_t(-1));
     }
@@ -74,11 +74,11 @@ R TableViewBase::aggregate(R (ColType::*aggregateMethod)(size_t, size_t) const, 
 
     R res = static_cast<R>( column->template TreeGet<T,ColType>(m_refs.GetAsSizeT(0)) );
 
-    for (size_t ss = 1; ss < m_refs.Size(); ++ss) {
+    for (size_t ss = 1; ss < m_refs.size(); ++ss) {
         row_ndx = m_refs.GetAsSizeT(ss);
         if (row_ndx >= leaf_end) {
             ((Column*)column)->GetBlock(row_ndx, arr, leaf_start);
-            const size_t leaf_size = arr.Size();
+            const size_t leaf_size = arr.size();
             leaf_end = leaf_start + leaf_size;
         }
 
@@ -147,34 +147,34 @@ void TableViewBase::sort(size_t column, bool Ascending)
                    m_table->get_column_type(column) == type_Date ||
                    m_table->get_column_type(column) == type_Bool);
 
-    if (m_refs.Size() == 0)
+    if (m_refs.size() == 0)
         return;
 
     Array vals;
     Array ref;
     Array result;
 
-    //ref.Preset(0, m_refs.Size() - 1, m_refs.Size());
-    for (size_t t = 0; t < m_refs.Size(); t++)
+    //ref.Preset(0, m_refs.size() - 1, m_refs.size());
+    for (size_t t = 0; t < m_refs.size(); t++)
         ref.add(t);
 
     // Extract all values from the Column and put them in an Array because Array is much faster to operate on
     // with rand access (we have ~log(n) accesses to each element, so using 1 additional read to speed up the rest is faster)
     if (m_table->get_column_type(column) == type_Int) {
-        for (size_t t = 0; t < m_refs.Size(); t++) {
+        for (size_t t = 0; t < m_refs.size(); t++) {
             const int64_t v = m_table->get_int(column, size_t(m_refs.Get(t)));
             vals.add(v);
         }
     }
     else if (m_table->get_column_type(column) == type_Date) {
-        for (size_t t = 0; t < m_refs.Size(); t++) {
+        for (size_t t = 0; t < m_refs.size(); t++) {
             const size_t idx = size_t(m_refs.Get(t));
             const int64_t v = int64_t(m_table->get_date(column, idx));
             vals.add(v);
         }
     }
     else if (m_table->get_column_type(column) == type_Bool) {
-        for (size_t t = 0; t < m_refs.Size(); t++) {
+        for (size_t t = 0; t < m_refs.size(); t++) {
             const size_t idx = size_t(m_refs.Get(t));
             const int64_t v = int64_t(m_table->get_bool(column, idx));
             vals.add(v);
@@ -184,7 +184,7 @@ void TableViewBase::sort(size_t column, bool Ascending)
     vals.ReferenceSort(ref);
     vals.Destroy();
 
-    for (size_t t = 0; t < m_refs.Size(); t++) {
+    for (size_t t = 0; t < m_refs.size(); t++) {
         const size_t r  = (size_t)ref.Get(t);
         const size_t rr = (size_t)m_refs.Get(r);
         result.add(rr);
@@ -195,14 +195,14 @@ void TableViewBase::sort(size_t column, bool Ascending)
     // Copy result to m_refs (todo, there might be a shortcut)
     m_refs.Clear();
     if (Ascending) {
-        for (size_t t = 0; t < ref.Size(); t++) {
+        for (size_t t = 0; t < ref.size(); t++) {
             const size_t v = (size_t)result.Get(t);
             m_refs.add(v);
         }
     }
     else {
-        for (size_t t = 0; t < ref.Size(); t++) {
-            const size_t v = (size_t)result.Get(ref.Size() - t - 1);
+        for (size_t t = 0; t < ref.size(); t++) {
+            const size_t v = (size_t)result.Get(ref.size() - t - 1);
             m_refs.add(v);
         }
     }
@@ -251,7 +251,7 @@ void TableViewBase::to_string(std::ostream& out, size_t limit) const
 void TableView::remove(size_t ndx)
 {
     TIGHTDB_ASSERT(m_table);
-    TIGHTDB_ASSERT(ndx < m_refs.Size());
+    TIGHTDB_ASSERT(ndx < m_refs.size());
 
     // Delete row in source table
     const size_t real_ndx = size_t(m_refs.Get(ndx));
@@ -270,7 +270,7 @@ void TableView::clear()
 
     // Delete all referenced rows in source table
     // (in reverse order to avoid index drift)
-    const size_t count = m_refs.Size();
+    const size_t count = m_refs.size();
     for (size_t i = count; i; --i) {
         const size_t ndx = size_t(m_refs.Get(i-1));
         m_table->remove(ndx);

--- a/src/tightdb/table_view.hpp
+++ b/src/tightdb/table_view.hpp
@@ -37,7 +37,7 @@ using std::time_t;
 class TableViewBase {
 public:
     bool is_empty() const TIGHTDB_NOEXCEPT { return m_refs.is_empty(); }
-    size_t size() const TIGHTDB_NOEXCEPT { return m_refs.Size(); }
+    size_t size() const TIGHTDB_NOEXCEPT { return m_refs.size(); }
 
     // Column information
     size_t      get_column_count() const TIGHTDB_NOEXCEPT;
@@ -305,11 +305,11 @@ private:
 
 #define TIGHTDB_ASSERT_INDEX(column_ndx, row_ndx)                           \
     TIGHTDB_ASSERT_COLUMN(column_ndx)                                       \
-    TIGHTDB_ASSERT(row_ndx < m_refs.Size());
+    TIGHTDB_ASSERT(row_ndx < m_refs.size());
 
 #define TIGHTDB_ASSERT_INDEX_AND_TYPE(column_ndx, row_ndx, column_type)     \
     TIGHTDB_ASSERT_COLUMN_AND_TYPE(column_ndx, column_type)                 \
-    TIGHTDB_ASSERT(row_ndx < m_refs.Size());
+    TIGHTDB_ASSERT(row_ndx < m_refs.size());
 
 
 inline TableViewBase::TableViewBase(TableViewBase* tv):
@@ -468,7 +468,7 @@ template <class R, class V>
 R TableViewBase::find_all_integer(V* view, size_t column_ndx, int64_t value)
 {
     R tv(*view->m_table);
-    for (size_t i = 0; i < view->m_refs.Size(); i++)
+    for (size_t i = 0; i < view->m_refs.size(); i++)
         if (view->get_int(column_ndx, i) == value)
             tv.get_ref_column().add(i);
     return move(tv);
@@ -478,7 +478,7 @@ template <class R, class V>
 R TableViewBase::find_all_float(V* view, size_t column_ndx, float value)
 {
     R tv(*view->m_table);
-    for (size_t i = 0; i < view->m_refs.Size(); i++)
+    for (size_t i = 0; i < view->m_refs.size(); i++)
         if (view->get_float(column_ndx, i) == value)
             tv.get_ref_column().add(i);
     return move(tv);
@@ -488,7 +488,7 @@ template <class R, class V>
 R TableViewBase::find_all_double(V* view, size_t column_ndx, double value)
 {
     R tv(*view->m_table);
-    for (size_t i = 0; i < view->m_refs.Size(); i++)
+    for (size_t i = 0; i < view->m_refs.size(); i++)
         if (view->get_double(column_ndx, i) == value)
             tv.get_ref_column().add(i);
     return move(tv);
@@ -502,7 +502,7 @@ R TableViewBase::find_all_string(V* view, size_t column_ndx, const char* value)
     TIGHTDB_ASSERT(view->m_table->get_column_type(column_ndx) == type_String);
 
     R tv(*view->m_table);
-    for (size_t i = 0; i < view->m_refs.Size(); i++)
+    for (size_t i = 0; i < view->m_refs.size(); i++)
         if (strcmp(view->get_string(column_ndx, i), value) == 0)
             tv.get_ref_column().add(i);
     return move(tv);

--- a/test/TestQuery.cpp
+++ b/test/TestQuery.cpp
@@ -458,11 +458,11 @@ TEST(TestQueryFindAll_range_or_monkey2)
                 a.add(t);
             }
         }
-        size_t s1 = a.Size();
+        size_t s1 = a.size();
         size_t s2 = tv1.size();
 
         CHECK_EQUAL(s1, s2);
-        for (size_t t = 0; t < a.Size(); t++) {
+        for (size_t t = 0; t < a.size(); t++) {
             size_t i1 = a.GetAsSizeT(t);
             size_t i2 = tv1.get_source_ndx(t);
             CHECK_EQUAL(i1, i2);

--- a/test/large_tests/verified_integer.cpp
+++ b/test/large_tests/verified_integer.cpp
@@ -161,7 +161,7 @@ void VerifiedInteger::find_all(Array &c, int64_t value, size_t start, size_t end
     c.Clear();
 
     u.find_all(c, value);
-    if (c.Size() != result.size())
+    if (c.size() != result.size())
         TIGHTDB_ASSERT(false);
     for (size_t t = 0; t < result.size(); ++t) {
         if (result[t] != (size_t)c.Get(t))

--- a/test/large_tests/verified_string.cpp
+++ b/test/large_tests/verified_string.cpp
@@ -108,7 +108,7 @@ void VerifiedString::find_all(Array &c, const char *value, size_t start, size_t 
     c.Clear();
 
     u.find_all(c, value);
-    size_t cs = c.Size();
+    size_t cs = c.size();
     if (cs != result.size())
         TIGHTDB_ASSERT(false);
     for (size_t t = 0; t < result.size(); ++t) {

--- a/test/testarray.cpp
+++ b/test/testarray.cpp
@@ -33,11 +33,11 @@ void hasZeroByte(int64_t value, size_t reps)
     a.add(0);
 
     size_t t = a.find_first(0);
-    CHECK_EQUAL(a.Size() - 1, t);
+    CHECK_EQUAL(a.size() - 1, t);
 
     r.Clear();
     a.find_all(r, 0);
-    CHECK_EQUAL(int64_t(a.Size() - 1), r.Get(0));
+    CHECK_EQUAL(int64_t(a.size() - 1), r.Get(0));
 
     // Cleanup
     a.Destroy();
@@ -51,7 +51,7 @@ TEST_FIXTURE(db_setup_array, Array_Add0)
 {
     c.add(0);
     CHECK_EQUAL(c.Get(0), 0);
-    CHECK_EQUAL(c.Size(), (size_t)1);
+    CHECK_EQUAL(c.size(), (size_t)1);
     CHECK_EQUAL(0, c.GetBitWidth());
 }
 
@@ -60,7 +60,7 @@ TEST_FIXTURE(db_setup_array, Array_Add1)
     c.add(1);
     CHECK_EQUAL(c.Get(0), 0);
     CHECK_EQUAL(c.Get(1), 1);
-    CHECK_EQUAL(c.Size(), 2);
+    CHECK_EQUAL(c.size(), 2);
     CHECK_EQUAL(1, c.GetBitWidth());
 }
 
@@ -70,7 +70,7 @@ TEST_FIXTURE(db_setup_array, Array_Add2)
     CHECK_EQUAL(c.Get(0), 0);
     CHECK_EQUAL(c.Get(1), 1);
     CHECK_EQUAL(c.Get(2), 2);
-    CHECK_EQUAL(c.Size(), 3);
+    CHECK_EQUAL(c.size(), 3);
     CHECK_EQUAL(2, c.GetBitWidth());
 }
 
@@ -81,7 +81,7 @@ TEST_FIXTURE(db_setup_array, Array_Add3)
     CHECK_EQUAL(c.Get(1), 1);
     CHECK_EQUAL(c.Get(2), 2);
     CHECK_EQUAL(c.Get(3), 3);
-    CHECK_EQUAL(c.Size(), 4);
+    CHECK_EQUAL(c.size(), 4);
     CHECK_EQUAL(2, c.GetBitWidth());
 }
 
@@ -93,7 +93,7 @@ TEST_FIXTURE(db_setup_array, Array_Add4)
     CHECK_EQUAL(c.Get(2), 2);
     CHECK_EQUAL(c.Get(3), 3);
     CHECK_EQUAL(c.Get(4), 4);
-    CHECK_EQUAL(c.Size(), 5);
+    CHECK_EQUAL(c.size(), 5);
     CHECK_EQUAL(4, c.GetBitWidth());
 }
 
@@ -106,7 +106,7 @@ TEST_FIXTURE(db_setup_array, Array_Add5)
     CHECK_EQUAL(c.Get(3), 3);
     CHECK_EQUAL(c.Get(4), 4);
     CHECK_EQUAL(c.Get(5), 16);
-    CHECK_EQUAL(c.Size(), 6);
+    CHECK_EQUAL(c.size(), 6);
     CHECK_EQUAL(8, c.GetBitWidth());
 }
 
@@ -120,7 +120,7 @@ TEST_FIXTURE(db_setup_array, Array_Add6)
     CHECK_EQUAL(c.Get(4), 4);
     CHECK_EQUAL(c.Get(5), 16);
     CHECK_EQUAL(c.Get(6), 256);
-    CHECK_EQUAL(c.Size(), 7);
+    CHECK_EQUAL(c.size(), 7);
     CHECK_EQUAL(16, c.GetBitWidth());
 }
 
@@ -135,7 +135,7 @@ TEST_FIXTURE(db_setup_array, Array_Add7)
     CHECK_EQUAL(c.Get(5), 16);
     CHECK_EQUAL(c.Get(6), 256);
     CHECK_EQUAL(c.Get(7), 65536);
-    CHECK_EQUAL(c.Size(), 8);
+    CHECK_EQUAL(c.size(), 8);
     CHECK_EQUAL(32, c.GetBitWidth());
 }
 
@@ -151,7 +151,7 @@ TEST_FIXTURE(db_setup_array, Array_Add8)
     CHECK_EQUAL(c.Get(6), 256);
     CHECK_EQUAL(c.Get(7), 65536);
     CHECK_EQUAL(c.Get(8), 4294967296LL);
-    CHECK_EQUAL(c.Size(), 9);
+    CHECK_EQUAL(c.size(), 9);
     CHECK_EQUAL(64, c.GetBitWidth());
 }
 
@@ -160,7 +160,7 @@ TEST_FIXTURE(db_setup_array, Array_AddNeg1)
     c.Clear();
     c.add(-1);
 
-    CHECK_EQUAL(c.Size(), 1);
+    CHECK_EQUAL(c.size(), 1);
     CHECK_EQUAL(c.Get(0), -1);
     CHECK_EQUAL(8, c.GetBitWidth());
 }
@@ -174,7 +174,7 @@ TEST(Array_AddNeg1_1)
     c.add(3);
     c.add(-128);
 
-    CHECK_EQUAL(c.Size(), 4);
+    CHECK_EQUAL(c.size(), 4);
     CHECK_EQUAL(c.Get(0), 1);
     CHECK_EQUAL(c.Get(1), 2);
     CHECK_EQUAL(c.Get(2), 3);
@@ -189,7 +189,7 @@ TEST_FIXTURE(db_setup_array, Array_AddNeg2)
 {
     c.add(-256);
 
-    CHECK_EQUAL(c.Size(), 2);
+    CHECK_EQUAL(c.size(), 2);
     CHECK_EQUAL(c.Get(0), -1);
     CHECK_EQUAL(c.Get(1), -256);
     CHECK_EQUAL(16, c.GetBitWidth());
@@ -199,7 +199,7 @@ TEST_FIXTURE(db_setup_array, Array_AddNeg3)
 {
     c.add(-65536);
 
-    CHECK_EQUAL(c.Size(), 3);
+    CHECK_EQUAL(c.size(), 3);
     CHECK_EQUAL(c.Get(0), -1);
     CHECK_EQUAL(c.Get(1), -256);
     CHECK_EQUAL(c.Get(2), -65536);
@@ -210,7 +210,7 @@ TEST_FIXTURE(db_setup_array, Array_AddNeg4)
 {
     c.add(-4294967296LL);
 
-    CHECK_EQUAL(c.Size(), 4);
+    CHECK_EQUAL(c.size(), 4);
     CHECK_EQUAL(c.Get(0), -1);
     CHECK_EQUAL(c.Get(1), -256);
     CHECK_EQUAL(c.Get(2), -65536);
@@ -225,7 +225,7 @@ TEST_FIXTURE(db_setup_array, Array_Set)
     c.Set(2, 1);
     c.Set(3, 0);
 
-    CHECK_EQUAL(c.Size(), 4);
+    CHECK_EQUAL(c.size(), 4);
     CHECK_EQUAL(c.Get(0), 3);
     CHECK_EQUAL(c.Get(1), 2);
     CHECK_EQUAL(c.Get(2), 1);
@@ -244,7 +244,7 @@ TEST_FIXTURE(db_setup_array, Array_Insert1)
     // Insert in middle
     c.Insert(2, 16);
 
-    CHECK_EQUAL(c.Size(), 5);
+    CHECK_EQUAL(c.size(), 5);
     CHECK_EQUAL(c.Get(0), 0);
     CHECK_EQUAL(c.Get(1), 1);
     CHECK_EQUAL(c.Get(2), 16);
@@ -257,7 +257,7 @@ TEST_FIXTURE(db_setup_array, Array_Insert2)
     // Insert at top
     c.Insert(0, 256);
 
-    CHECK_EQUAL(c.Size(), 6);
+    CHECK_EQUAL(c.size(), 6);
     CHECK_EQUAL(c.Get(0), 256);
     CHECK_EQUAL(c.Get(1), 0);
     CHECK_EQUAL(c.Get(2), 1);
@@ -271,7 +271,7 @@ TEST_FIXTURE(db_setup_array, Array_Insert3)
     // Insert at bottom
     c.Insert(6, 65536);
 
-    CHECK_EQUAL(c.Size(), 7);
+    CHECK_EQUAL(c.size(), 7);
     CHECK_EQUAL(c.Get(0), 256);
     CHECK_EQUAL(c.Get(1), 0);
     CHECK_EQUAL(c.Get(2), 1);
@@ -305,7 +305,7 @@ TEST_FIXTURE(db_setup_array, Array_Delete1)
     // Delete from middle
     c.Delete(3);
 
-    CHECK_EQUAL(c.Size(), 6);
+    CHECK_EQUAL(c.size(), 6);
     CHECK_EQUAL(c.Get(0), 256);
     CHECK_EQUAL(c.Get(1), 0);
     CHECK_EQUAL(c.Get(2), 1);
@@ -319,7 +319,7 @@ TEST_FIXTURE(db_setup_array, Array_Delete2)
     // Delete from top
     c.Delete(0);
 
-    CHECK_EQUAL(c.Size(), 5);
+    CHECK_EQUAL(c.size(), 5);
     CHECK_EQUAL(c.Get(0), 0);
     CHECK_EQUAL(c.Get(1), 1);
     CHECK_EQUAL(c.Get(2), 2);
@@ -332,7 +332,7 @@ TEST_FIXTURE(db_setup_array, Array_Delete3)
     // Delete from bottom
     c.Delete(4);
 
-    CHECK_EQUAL(c.Size(), 4);
+    CHECK_EQUAL(c.size(), 4);
     CHECK_EQUAL(c.Get(0), 0);
     CHECK_EQUAL(c.Get(1), 1);
     CHECK_EQUAL(c.Get(2), 2);
@@ -348,7 +348,7 @@ TEST_FIXTURE(db_setup_array, Array_DeleteAll)
     c.Delete(0);
 
     CHECK(c.is_empty());
-    CHECK_EQUAL(0, c.Size());
+    CHECK_EQUAL(0, c.size());
 }
 
 TEST_FIXTURE(db_setup_array, Array_Find1)
@@ -510,11 +510,11 @@ TEST(findallint0)
     }
 
     a.find_all(r, value);
-    CHECK_EQUAL(vReps, r.Size());
+    CHECK_EQUAL(vReps, r.size());
 
     size_t i = 0;
     size_t j = 0;
-    while (i < a.Size()){
+    while (i < a.size()){
         if (a.Get(i) == value)
             CHECK_EQUAL(int64_t(i), r.Get(j++));
         i += 1;
@@ -541,11 +541,11 @@ TEST(findallint1)
     }
 
     a.find_all(r, value);
-    CHECK_EQUAL(vReps, r.Size());
+    CHECK_EQUAL(vReps, r.size());
 
     size_t i = 0;
     size_t j = 0;
-    while (i < a.Size()){
+    while (i < a.size()){
         if (a.Get(i) == value)
             CHECK_EQUAL(int64_t(i), r.Get(j++));
         i += 1;
@@ -572,11 +572,11 @@ TEST(findallint2)
     }
 
     a.find_all(r, value);
-    CHECK_EQUAL(vReps, r.Size());
+    CHECK_EQUAL(vReps, r.size());
 
     size_t i = 0;
     size_t j = 0;
-    while (i < a.Size()){
+    while (i < a.size()){
         if (a.Get(i) == value)
             CHECK_EQUAL(int64_t(i), r.Get(j++));
         i += 1;
@@ -603,11 +603,11 @@ TEST(findallint3)
     }
 
     a.find_all(r, value);
-    CHECK_EQUAL(vReps, r.Size());
+    CHECK_EQUAL(vReps, r.size());
 
     size_t i = 0;
     size_t j = 0;
-    while (i < a.Size()){
+    while (i < a.size()){
         if (a.Get(i) == value)
             CHECK_EQUAL(int64_t(i), r.Get(j++));
         i += 1;
@@ -635,11 +635,11 @@ TEST(findallint4)
     }
 
     a.find_all(r, value);
-    CHECK_EQUAL(vReps, r.Size());
+    CHECK_EQUAL(vReps, r.size());
 
     size_t i = 0;
     size_t j = 0;
-    while (i < a.Size()){
+    while (i < a.size()){
         if (a.Get(i) == value)
             CHECK_EQUAL(int64_t(i), r.Get(j++));
         i += 1;
@@ -667,11 +667,11 @@ TEST(findallint5)
     }
 
     a.find_all(r, value);
-    CHECK_EQUAL(vReps, r.Size());
+    CHECK_EQUAL(vReps, r.size());
 
     size_t i = 0;
     size_t j = 0;
-    while (i < a.Size()){
+    while (i < a.size()){
         if (a.Get(i) == value)
             CHECK_EQUAL(int64_t(i), r.Get(j++));
         i += 1;
@@ -699,11 +699,11 @@ TEST(findallint6)
     }
 
     a.find_all(r, value);
-    CHECK_EQUAL(vReps, r.Size());
+    CHECK_EQUAL(vReps, r.size());
 
     size_t i = 0;
     size_t j = 0;
-    while (i < a.Size()){
+    while (i < a.size()){
         if (a.Get(i) == value)
             CHECK_EQUAL(int64_t(i), r.Get(j++));
         i += 1;
@@ -731,11 +731,11 @@ TEST(findallint7)
     }
 
     a.find_all(r, value);
-    CHECK_EQUAL(vReps, r.Size());
+    CHECK_EQUAL(vReps, r.size());
 
     size_t i = 0;
     size_t j = 0;
-    while (i < a.Size()){
+    while (i < a.size()){
         if (a.Get(i) == value)
             CHECK_EQUAL(int64_t(i), r.Get(j++));
         i += 1;
@@ -785,7 +785,7 @@ TEST(Sum0)
     for (int i = 0; i < 64 + 7; i++) {
         a.add(0);
     }
-    CHECK_EQUAL(0, a.sum(0, a.Size()));
+    CHECK_EQUAL(0, a.sum(0, a.size()));
     a.Destroy();
 }
 
@@ -799,7 +799,7 @@ TEST(Sum1)
     s1 = 0;
     for (int i = 0; i < 256 + 7; i++)
         s1 += a.Get(i);
-    CHECK_EQUAL(s1, a.sum(0, a.Size()));
+    CHECK_EQUAL(s1, a.sum(0, a.size()));
 
     s1 = 0;
     for (int i = 3; i < 100; i++)
@@ -819,7 +819,7 @@ TEST(Sum2)
     s1 = 0;
     for (int i = 0; i < 256 + 7; i++)
         s1 += a.Get(i);
-    CHECK_EQUAL(s1, a.sum(0, a.Size()));
+    CHECK_EQUAL(s1, a.sum(0, a.size()));
 
     s1 = 0;
     for (int i = 3; i < 100; i++)
@@ -840,7 +840,7 @@ TEST(Sum4)
     s1 = 0;
     for (int i = 0; i < 256 + 7; i++)
         s1 += a.Get(i);
-    CHECK_EQUAL(s1, a.sum(0, a.Size()));
+    CHECK_EQUAL(s1, a.sum(0, a.size()));
 
     s1 = 0;
     for (int i = 3; i < 100; i++)
@@ -860,7 +860,7 @@ TEST(Sum16)
     s1 = 0;
     for (int i = 0; i < 256 + 7; i++)
         s1 += a.Get(i);
-    CHECK_EQUAL(s1, a.sum(0, a.Size()));
+    CHECK_EQUAL(s1, a.sum(0, a.size()));
 
     s1 = 0;
     for (int i = 3; i < 100; i++)
@@ -1258,11 +1258,11 @@ TEST(ArraySort)
     for (size_t t = 0; t < 400; t++)
         a.add(rand() % 300 - 100);
 
-    size_t orig_size = a.Size();
+    size_t orig_size = a.size();
     a.sort();
 
-    CHECK(a.Size() == orig_size);
-    for (size_t t = 1; t < a.Size(); t++)
+    CHECK(a.size() == orig_size);
+    for (size_t t = 1; t < a.size(); t++)
         CHECK(a.Get(t) >= a.Get(t - 1));
 
     a.Destroy();
@@ -1277,11 +1277,11 @@ TEST(ArraySort2)
     for (size_t t = 0; t < 400; t++)
         a.add((int64_t)rand() * (int64_t)rand() * (int64_t)rand() * (int64_t)rand() * (int64_t)rand() * (int64_t)rand() * (int64_t)rand() * (int64_t)rand());
 
-    size_t orig_size = a.Size();
+    size_t orig_size = a.size();
     a.sort();
 
-    CHECK(a.Size() == orig_size);
-    for (size_t t = 1; t < a.Size(); t++)
+    CHECK(a.size() == orig_size);
+    for (size_t t = 1; t < a.size(); t++)
         CHECK(a.Get(t) >= a.Get(t - 1));
 
     a.Destroy();
@@ -1295,11 +1295,11 @@ TEST(ArraySort3)
     for (size_t t = 0; t < 1000000ULL; t++)
         a.add(rand());
 
-    size_t orig_size = a.Size();
+    size_t orig_size = a.size();
     a.sort();
 
-    CHECK(a.Size() == orig_size);
-    for (size_t t = 1; t < a.Size(); t++)
+    CHECK(a.size() == orig_size);
+    for (size_t t = 1; t < a.size(); t++)
         CHECK(a.Get(t) >= a.Get(t - 1));
 
     a.Destroy();
@@ -1314,11 +1314,11 @@ TEST(ArraySort4)
     for (size_t t = 0; t < 1000; t++)
         a.add(0);
 
-    size_t orig_size = a.Size();
+    size_t orig_size = a.size();
     a.sort();
 
-    CHECK(a.Size() == orig_size);
-    for (size_t t = 1; t < a.Size(); t++)
+    CHECK(a.size() == orig_size);
+    for (size_t t = 1; t < a.size(); t++)
         CHECK(a.Get(t) == 0);
 
     a.Destroy();
@@ -1340,7 +1340,7 @@ TEST(ArrayCopy)
     b.Verify();
 #endif
 
-    CHECK_EQUAL(5, b.Size());
+    CHECK_EQUAL(5, b.size());
     CHECK_EQUAL(0, b.Get(0));
     CHECK_EQUAL(1, b.Get(1));
     CHECK_EQUAL(2, b.Get(2));
@@ -1359,10 +1359,10 @@ TEST(ArrayCopy)
 #endif
 
     CHECK(d.HasRefs());
-    CHECK_EQUAL(1, d.Size());
+    CHECK_EQUAL(1, d.size());
 
     const Array e = d.GetSubArray(0);
-    CHECK_EQUAL(5, e.Size());
+    CHECK_EQUAL(5, e.size());
     CHECK_EQUAL(0, e.Get(0));
     CHECK_EQUAL(1, e.Get(1));
     CHECK_EQUAL(2, e.Get(2));

--- a/test/testarrayblob.cpp
+++ b/test/testarrayblob.cpp
@@ -52,7 +52,7 @@ TEST(ArrayBlob)
 
     CHECK_EQUAL(t1, blob.Get(0));
     CHECK_EQUAL(t3, blob.Get(l1));
-    CHECK_EQUAL(l1 + l3, blob.Size());
+    CHECK_EQUAL(l1 + l3, blob.size());
 
     // Delete all
     blob.Delete(0, l1 + l3);

--- a/test/testarrayfloat.cpp
+++ b/test/testarrayfloat.cpp
@@ -40,7 +40,7 @@ void BasicArray_AddGet(T val[], size_t valLen)
     for (size_t i=0; i<valLen; ++i) {
         f.add(val[i]);
 
-        CHECK_EQUAL(i+1, f.Size());
+        CHECK_EQUAL(i+1, f.size());
 
         for (size_t j=0; j<i; ++j) {
             CHECK_EQUAL(val[j], f.Get(j));
@@ -48,7 +48,7 @@ void BasicArray_AddGet(T val[], size_t valLen)
     }
 
     f.Clear();
-    CHECK_EQUAL(0, f.Size());
+    CHECK_EQUAL(0, f.size());
 
     f.Destroy();    // cleanup
 }
@@ -65,7 +65,7 @@ void BasicArray_AddManyValues()
         f.add(T(i));
         T val = f.Get(i);
         CHECK_EQUAL(T(i), val);
-        CHECK_EQUAL(i+1, f.Size());
+        CHECK_EQUAL(i+1, f.size());
     }
     for (size_t i=0; i<repeats; ++i) {
         T val = f.Get(i);
@@ -73,7 +73,7 @@ void BasicArray_AddManyValues()
     }
 
     f.Clear();
-    CHECK_EQUAL(0, f.Size());
+    CHECK_EQUAL(0, f.size());
 
     f.Destroy();    // cleanup
 }
@@ -89,7 +89,7 @@ void BasicArray_Delete()
 
     // Delete first
     f.Delete(0);
-    CHECK_EQUAL(4, f.Size());
+    CHECK_EQUAL(4, f.size());
     CHECK_EQUAL(1, f.Get(0));
     CHECK_EQUAL(2, f.Get(1));
     CHECK_EQUAL(3, f.Get(2));
@@ -97,23 +97,23 @@ void BasicArray_Delete()
 
     // Delete last
     f.Delete(3);
-    CHECK_EQUAL(3, f.Size());
+    CHECK_EQUAL(3, f.size());
     CHECK_EQUAL(1, f.Get(0));
     CHECK_EQUAL(2, f.Get(1));
     CHECK_EQUAL(3, f.Get(2));
 
     // Delete middle
     f.Delete(1);
-    CHECK_EQUAL(2, f.Size());
+    CHECK_EQUAL(2, f.size());
     CHECK_EQUAL(1, f.Get(0));
     CHECK_EQUAL(3, f.Get(1));
 
     // Delete all
     f.Delete(0);
-    CHECK_EQUAL(1, f.Size());
+    CHECK_EQUAL(1, f.size());
     CHECK_EQUAL(3, f.Get(0));
     f.Delete(0);
-    CHECK_EQUAL(0, f.Size());
+    CHECK_EQUAL(0, f.size());
     CHECK(f.is_empty());
 
     f.Destroy();    // cleanup
@@ -126,10 +126,10 @@ template <class C, typename T>
 void BasicArray_Set(T val[], size_t valLen)
 {
     C f;
-    CHECK_EQUAL(0, f.Size());
+    CHECK_EQUAL(0, f.size());
     for (size_t i=0; i<valLen; ++i)
         f.add(val[i]);
-    CHECK_EQUAL(valLen, f.Size());
+    CHECK_EQUAL(valLen, f.size());
 
     f.Set(0, T(1.6));
     CHECK_EQUAL(T(1.6), f.Get(0));
@@ -139,7 +139,7 @@ void BasicArray_Set(T val[], size_t valLen)
     CHECK_EQUAL(val[1], f.Get(1));
     CHECK_EQUAL(val[2], f.Get(2));
     CHECK_EQUAL(val[4], f.Get(4));
-    CHECK_EQUAL(valLen, f.Size());
+    CHECK_EQUAL(valLen, f.size());
 
     f.Destroy();    // cleanup
 }
@@ -159,20 +159,20 @@ void BasicArray_Insert()
     // Insert in empty array
     f.Insert(0, v0);
     CHECK_EQUAL(v0, f.Get(0));
-    CHECK_EQUAL(1, f.Size());
+    CHECK_EQUAL(1, f.size());
 
     // Insert in top
     f.Insert(0, v1);
     CHECK_EQUAL(v1, f.Get(0));
     CHECK_EQUAL(v0, f.Get(1));
-    CHECK_EQUAL(2, f.Size());
+    CHECK_EQUAL(2, f.size());
 
     // Insert in middle
     f.Insert(1, v2);
     CHECK_EQUAL(v1, f.Get(0));
     CHECK_EQUAL(v2, f.Get(1));
     CHECK_EQUAL(v0, f.Get(2));
-    CHECK_EQUAL(3, f.Size());
+    CHECK_EQUAL(3, f.size());
 
     // Insert at buttom
     f.Insert(3, v3);
@@ -180,7 +180,7 @@ void BasicArray_Insert()
     CHECK_EQUAL(v2, f.Get(1));
     CHECK_EQUAL(v0, f.Get(2));
     CHECK_EQUAL(v3, f.Get(3));
-    CHECK_EQUAL(4, f.Size());
+    CHECK_EQUAL(4, f.size());
 
     f.Destroy();    // cleanup
 }
@@ -200,7 +200,7 @@ void BasicArray_Sum()
         f.add(values[i]);
         sum += values[i];
     }
-    CHECK_EQUAL(5, f.Size());
+    CHECK_EQUAL(5, f.size());
 
     // all
     CHECK_EQUAL(sum, f.sum());
@@ -230,7 +230,7 @@ void BasicArray_Minimum()
     for (size_t i=0; i<5; ++i) {
         f.add(values[i]);
     }
-    CHECK_EQUAL(5, f.Size());
+    CHECK_EQUAL(5, f.size());
 
     // middle match in all
     CHECK_EQUAL(true, f.minimum(res));
@@ -266,7 +266,7 @@ void BasicArray_Maximum()
     for (size_t i=0; i<5; ++i) {
         f.add(values[i]);
     }
-    CHECK_EQUAL(5, f.Size());
+    CHECK_EQUAL(5, f.size());
 
     // middle match in all
     CHECK_EQUAL(true, f.maximum(res));
@@ -323,13 +323,13 @@ void BasicArray_Find()
     // Find all
     Array resArr;
     f.find_all(resArr, T(1.1), 0);
-    CHECK_EQUAL(2, resArr.Size());
+    CHECK_EQUAL(2, resArr.size());
     CHECK_EQUAL(0, resArr.Get(0));
     CHECK_EQUAL(4, resArr.Get(1));
     // Find all, range limited -> no match
     resArr.Clear();
     f.find_all(resArr, T(1.1), 0, 1, 4);
-    CHECK_EQUAL(0, resArr.Size());
+    CHECK_EQUAL(0, resArr.size());
     resArr.Destroy();
 
     f.Destroy();    // cleanup

--- a/test/testarraystring.cpp
+++ b/test/testarraystring.cpp
@@ -18,7 +18,7 @@ TEST_FIXTURE(db_setup_string, ArrayStringMultiEmpty)
     c.add("");
     c.add("");
     c.add("");
-    CHECK_EQUAL(6, c.Size());
+    CHECK_EQUAL(6, c.size());
 
     CHECK_EQUAL("", c.Get(0));
     CHECK_EQUAL("", c.Get(1));
@@ -32,7 +32,7 @@ TEST_FIXTURE(db_setup_string, ArrayStringSetExpand4)
 {
     c.Set(0, "hey");
 
-    CHECK_EQUAL(6, c.Size());
+    CHECK_EQUAL(6, c.size());
     CHECK_EQUAL("hey", c.Get(0));
     CHECK_EQUAL("", c.Get(1));
     CHECK_EQUAL("", c.Get(2));
@@ -45,7 +45,7 @@ TEST_FIXTURE(db_setup_string, ArrayStringSetExpand8)
 {
     c.Set(1, "test");
 
-    CHECK_EQUAL(6, c.Size());
+    CHECK_EQUAL(6, c.size());
     CHECK_EQUAL("hey", c.Get(0));
     CHECK_EQUAL("test", c.Get(1));
     CHECK_EQUAL("", c.Get(2));
@@ -59,7 +59,7 @@ TEST_FIXTURE(db_setup_string, ArrayArrayStringAdd0)
     c.Clear();
     c.add();
     CHECK_EQUAL("", c.Get(0));
-    CHECK_EQUAL(1, c.Size());
+    CHECK_EQUAL(1, c.size());
 }
 
 TEST_FIXTURE(db_setup_string, ArrayStringAdd1)
@@ -67,7 +67,7 @@ TEST_FIXTURE(db_setup_string, ArrayStringAdd1)
     c.add("a");
     CHECK_EQUAL("",  c.Get(0));
     CHECK_EQUAL("a", c.Get(1));
-    CHECK_EQUAL(2, c.Size());
+    CHECK_EQUAL(2, c.size());
 }
 
 TEST_FIXTURE(db_setup_string, ArrayStringAdd2)
@@ -76,7 +76,7 @@ TEST_FIXTURE(db_setup_string, ArrayStringAdd2)
     CHECK_EQUAL("",   c.Get(0));
     CHECK_EQUAL("a",  c.Get(1));
     CHECK_EQUAL("bb", c.Get(2));
-    CHECK_EQUAL(3, c.Size());
+    CHECK_EQUAL(3, c.size());
 }
 
 TEST_FIXTURE(db_setup_string, ArrayStringAdd3)
@@ -86,7 +86,7 @@ TEST_FIXTURE(db_setup_string, ArrayStringAdd3)
     CHECK_EQUAL("a",   c.Get(1));
     CHECK_EQUAL("bb",  c.Get(2));
     CHECK_EQUAL("ccc", c.Get(3));
-    CHECK_EQUAL(4, c.Size());
+    CHECK_EQUAL(4, c.size());
 }
 
 TEST_FIXTURE(db_setup_string, ArrayStringAdd4)
@@ -97,7 +97,7 @@ TEST_FIXTURE(db_setup_string, ArrayStringAdd4)
     CHECK_EQUAL("bb",   c.Get(2));
     CHECK_EQUAL("ccc",  c.Get(3));
     CHECK_EQUAL("dddd", c.Get(4));
-    CHECK_EQUAL(5, c.Size());
+    CHECK_EQUAL(5, c.size());
 }
 
 TEST_FIXTURE(db_setup_string, ArrayStringAdd8)
@@ -109,7 +109,7 @@ TEST_FIXTURE(db_setup_string, ArrayStringAdd8)
     CHECK_EQUAL("ccc",  c.Get(3));
     CHECK_EQUAL("dddd", c.Get(4));
     CHECK_EQUAL("eeeeeeee", c.Get(5));
-    CHECK_EQUAL(6, c.Size());
+    CHECK_EQUAL(6, c.size());
 }
 
 TEST_FIXTURE(db_setup_string, ArrayStringAdd16)
@@ -122,7 +122,7 @@ TEST_FIXTURE(db_setup_string, ArrayStringAdd16)
     CHECK_EQUAL("dddd", c.Get(4));
     CHECK_EQUAL("eeeeeeee", c.Get(5));
     CHECK_EQUAL("ffffffffffffffff", c.Get(6));
-    CHECK_EQUAL(7, c.Size());
+    CHECK_EQUAL(7, c.size());
 }
 
 TEST_FIXTURE(db_setup_string, ArrayStringAdd32)
@@ -137,7 +137,7 @@ TEST_FIXTURE(db_setup_string, ArrayStringAdd32)
     CHECK_EQUAL("eeeeeeee", c.Get(5));
     CHECK_EQUAL("ffffffffffffffff", c.Get(6));
     CHECK_EQUAL("gggggggggggggggggggggggggggggggg", c.Get(7));
-    CHECK_EQUAL(8, c.Size());
+    CHECK_EQUAL(8, c.size());
 }
 
 TEST_FIXTURE(db_setup_string, ArrayStringSet1)
@@ -155,7 +155,7 @@ TEST_FIXTURE(db_setup_string, ArrayStringSet1)
     CHECK_EQUAL("eeeeeeee", c.Get(5));
     CHECK_EQUAL("ffffffffffffffff", c.Get(6));
     CHECK_EQUAL("gggggggggggggggggggggggggggggggg", c.Get(7));
-    CHECK_EQUAL(8, c.Size());
+    CHECK_EQUAL(8, c.size());
 }
 
 TEST_FIXTURE(db_setup_string, ArrayStringInsert1)
@@ -172,7 +172,7 @@ TEST_FIXTURE(db_setup_string, ArrayStringInsert1)
     CHECK_EQUAL("eeeeeeee", c.Get(6));
     CHECK_EQUAL("ffffffffffffffff", c.Get(7));
     CHECK_EQUAL("gggggggggggggggggggggggggggggggg", c.Get(8));
-    CHECK_EQUAL(9, c.Size());
+    CHECK_EQUAL(9, c.size());
 }
 
 TEST_FIXTURE(db_setup_string, ArrayStringDelete1)
@@ -188,7 +188,7 @@ TEST_FIXTURE(db_setup_string, ArrayStringDelete1)
     CHECK_EQUAL("dddd", c.Get(5));
     CHECK_EQUAL("eeeeeeee", c.Get(6));
     CHECK_EQUAL("ffffffffffffffff", c.Get(7));
-    CHECK_EQUAL(8, c.Size());
+    CHECK_EQUAL(8, c.size());
 }
 
 TEST_FIXTURE(db_setup_string, ArrayStringDelete2)
@@ -203,7 +203,7 @@ TEST_FIXTURE(db_setup_string, ArrayStringDelete2)
     CHECK_EQUAL("dddd", c.Get(4));
     CHECK_EQUAL("eeeeeeee", c.Get(5));
     CHECK_EQUAL("ffffffffffffffff", c.Get(6));
-    CHECK_EQUAL(7, c.Size());
+    CHECK_EQUAL(7, c.size());
 }
 
 TEST_FIXTURE(db_setup_string, ArrayStringDelete3)
@@ -217,7 +217,7 @@ TEST_FIXTURE(db_setup_string, ArrayStringDelete3)
     CHECK_EQUAL("dddd", c.Get(3));
     CHECK_EQUAL("eeeeeeee", c.Get(4));
     CHECK_EQUAL("ffffffffffffffff", c.Get(5));
-    CHECK_EQUAL(6, c.Size());
+    CHECK_EQUAL(6, c.size());
 }
 
 TEST_FIXTURE(db_setup_string, ArrayStringDeleteAll)
@@ -231,7 +231,7 @@ TEST_FIXTURE(db_setup_string, ArrayStringDeleteAll)
     c.Delete(0);
 
     CHECK(c.is_empty());
-    CHECK_EQUAL(0, c.Size());
+    CHECK_EQUAL(0, c.size());
 }
 
 TEST_FIXTURE(db_setup_string, ArrayStringInsert2)
@@ -251,7 +251,7 @@ TEST_FIXTURE(db_setup_string, ArrayStringInsert2)
     CHECK_EQUAL("b",     c.Get(2));
     CHECK_EQUAL("c",     c.Get(3));
     CHECK_EQUAL("d",     c.Get(4));
-    CHECK_EQUAL(5, c.Size());
+    CHECK_EQUAL(5, c.size());
 }
 
 TEST_FIXTURE(db_setup_string, ArrayStringInsert3)
@@ -265,7 +265,7 @@ TEST_FIXTURE(db_setup_string, ArrayStringInsert3)
     CHECK_EQUAL("xxxxxxxxxx", c.Get(3));
     CHECK_EQUAL("c",     c.Get(4));
     CHECK_EQUAL("d",     c.Get(5));
-    CHECK_EQUAL(6, c.Size());
+    CHECK_EQUAL(6, c.size());
 }
 
 TEST_FIXTURE(db_setup_string, ArrayStringFind1)
@@ -340,7 +340,7 @@ TEST_FIXTURE(db_setup_string, ArrayStringFindAll)
     c.add("foobar");
 
     c.find_all(col, "foobar");
-    CHECK_EQUAL(3, col.Size());
+    CHECK_EQUAL(3, col.size());
     CHECK_EQUAL(0, col.Get(0));
     CHECK_EQUAL(2, col.Get(1));
     CHECK_EQUAL(4, col.Get(2));

--- a/test/testarraystringlong.cpp
+++ b/test/testarraystringlong.cpp
@@ -17,7 +17,7 @@ TEST_FIXTURE(db_setup_string_long, ArrayStringLongMultiEmpty)
     c.add("");
     c.add("");
     c.add("");
-    CHECK_EQUAL(6, c.Size());
+    CHECK_EQUAL(6, c.size());
 
     CHECK_EQUAL("", c.Get(0));
     CHECK_EQUAL("", c.Get(1));
@@ -31,7 +31,7 @@ TEST_FIXTURE(db_setup_string_long, ArrayStringLongSet)
 {
     c.Set(0, "hey");
 
-    CHECK_EQUAL(6, c.Size());
+    CHECK_EQUAL(6, c.size());
     CHECK_EQUAL("hey", c.Get(0));
     CHECK_EQUAL("", c.Get(1));
     CHECK_EQUAL("", c.Get(2));
@@ -43,16 +43,16 @@ TEST_FIXTURE(db_setup_string_long, ArrayStringLongSet)
 TEST_FIXTURE(db_setup_string_long, ArrayStringLongAdd)
 {
     c.Clear();
-    CHECK_EQUAL(0, c.Size());
+    CHECK_EQUAL(0, c.size());
 
     c.add("abc");
     CHECK_EQUAL("abc", c.Get(0)); // single
-    CHECK_EQUAL(1, c.Size());
+    CHECK_EQUAL(1, c.size());
 
     c.add("defg"); //non-empty
     CHECK_EQUAL("abc", c.Get(0));
     CHECK_EQUAL("defg", c.Get(1));
-    CHECK_EQUAL(2, c.Size());
+    CHECK_EQUAL(2, c.size());
 }
 
 TEST_FIXTURE(db_setup_string_long, ArrayStringLongSet2)
@@ -63,51 +63,51 @@ TEST_FIXTURE(db_setup_string_long, ArrayStringLongSet2)
     c.add("abc");
     c.Set(0, "de"); // shrink single
     CHECK_EQUAL("de", c.Get(0));
-    CHECK_EQUAL(1, c.Size());
+    CHECK_EQUAL(1, c.size());
 
     c.Set(0, "abcd"); // grow single
     CHECK_EQUAL("abcd", c.Get(0));
-    CHECK_EQUAL(1, c.Size());
+    CHECK_EQUAL(1, c.size());
 
     c.add("efg");
     CHECK_EQUAL("abcd", c.Get(0));
     CHECK_EQUAL("efg", c.Get(1));
-    CHECK_EQUAL(2, c.Size());
+    CHECK_EQUAL(2, c.size());
 
     c.Set(1, "hi"); // shrink last
     CHECK_EQUAL("abcd", c.Get(0));
     CHECK_EQUAL("hi", c.Get(1));
-    CHECK_EQUAL(2, c.Size());
+    CHECK_EQUAL(2, c.size());
 
     c.Set(1, "jklmno"); // grow last
     CHECK_EQUAL("abcd", c.Get(0));
     CHECK_EQUAL("jklmno", c.Get(1));
-    CHECK_EQUAL(2, c.Size());
+    CHECK_EQUAL(2, c.size());
 
     c.add("pq");
     c.Set(1, "efghijkl"); // grow middle
     CHECK_EQUAL("abcd", c.Get(0));
     CHECK_EQUAL("efghijkl", c.Get(1));
     CHECK_EQUAL("pq", c.Get(2));
-    CHECK_EQUAL(3, c.Size());
+    CHECK_EQUAL(3, c.size());
 
     c.Set(1, "x"); // shrink middle
     CHECK_EQUAL("abcd", c.Get(0));
     CHECK_EQUAL("x", c.Get(1));
     CHECK_EQUAL("pq", c.Get(2));
-    CHECK_EQUAL(3, c.Size());
+    CHECK_EQUAL(3, c.size());
 
     c.Set(0, "qwertyuio"); // grow first
     CHECK_EQUAL("qwertyuio", c.Get(0));
     CHECK_EQUAL("x", c.Get(1));
     CHECK_EQUAL("pq", c.Get(2));
-    CHECK_EQUAL(3, c.Size());
+    CHECK_EQUAL(3, c.size());
 
     c.Set(0, "mno"); // shrink first
     CHECK_EQUAL("mno", c.Get(0));
     CHECK_EQUAL("x", c.Get(1));
     CHECK_EQUAL("pq", c.Get(2));
-    CHECK_EQUAL(3, c.Size());
+    CHECK_EQUAL(3, c.size());
 }
 
 
@@ -117,25 +117,25 @@ TEST_FIXTURE(db_setup_string_long, ArrayStringLongInsert)
 
     c.Insert(0, "abc"); // single
     CHECK_EQUAL(c.Get(0), "abc");
-    CHECK_EQUAL(1, c.Size());
+    CHECK_EQUAL(1, c.size());
 
     c.Insert(1, "d"); // end
     CHECK_EQUAL("abc", c.Get(0));
     CHECK_EQUAL("d", c.Get(1));
-    CHECK_EQUAL(2, c.Size());
+    CHECK_EQUAL(2, c.size());
 
     c.Insert(2, "ef"); // end
     CHECK_EQUAL("abc", c.Get(0));
     CHECK_EQUAL("d", c.Get(1));
     CHECK_EQUAL("ef", c.Get(2));
-    CHECK_EQUAL(3, c.Size());
+    CHECK_EQUAL(3, c.size());
 
     c.Insert(1, "ghij"); // middle
     CHECK_EQUAL("abc", c.Get(0));
     CHECK_EQUAL("ghij", c.Get(1));
     CHECK_EQUAL("d", c.Get(2));
     CHECK_EQUAL("ef", c.Get(3));
-    CHECK_EQUAL(4, c.Size());
+    CHECK_EQUAL(4, c.size());
 
     c.Insert(0, "klmno"); // first
     CHECK_EQUAL("klmno", c.Get(0));
@@ -143,7 +143,7 @@ TEST_FIXTURE(db_setup_string_long, ArrayStringLongInsert)
     CHECK_EQUAL("ghij", c.Get(2));
     CHECK_EQUAL("d", c.Get(3));
     CHECK_EQUAL("ef", c.Get(4));
-    CHECK_EQUAL(5, c.Size());
+    CHECK_EQUAL(5, c.size());
 }
 
 TEST_FIXTURE(db_setup_string_long, ArrayStringLongDelete)
@@ -161,25 +161,25 @@ TEST_FIXTURE(db_setup_string_long, ArrayStringLongDelete)
     CHECK_EQUAL("def", c.Get(1));
     CHECK_EQUAL("ghij", c.Get(2));
     CHECK_EQUAL("klmno", c.Get(3));
-    CHECK_EQUAL(4, c.Size());
+    CHECK_EQUAL(4, c.size());
 
     c.Delete(3); // last
     CHECK_EQUAL("bc", c.Get(0));
     CHECK_EQUAL("def", c.Get(1));
     CHECK_EQUAL("ghij", c.Get(2));
-    CHECK_EQUAL(3, c.Size());
+    CHECK_EQUAL(3, c.size());
 
     c.Delete(1); // middle
     CHECK_EQUAL("bc", c.Get(0));
     CHECK_EQUAL("ghij", c.Get(1));
-    CHECK_EQUAL(2, c.Size());
+    CHECK_EQUAL(2, c.size());
 
     c.Delete(0); // single
     CHECK_EQUAL("ghij", c.Get(0));
-    CHECK_EQUAL(1, c.Size());
+    CHECK_EQUAL(1, c.size());
 
     c.Delete(0); // all
-    CHECK_EQUAL(0, c.Size());
+    CHECK_EQUAL(0, c.size());
     CHECK(c.is_empty());
 }
 

--- a/test/testcolumn.cpp
+++ b/test/testcolumn.cpp
@@ -507,7 +507,7 @@ TEST(Column_FindAll_IntMin)
     }
 
     c.find_all(r, value);
-    CHECK_EQUAL(vReps, r.Size());
+    CHECK_EQUAL(vReps, r.size());
 
     size_t i = 0;
     size_t j = 0;
@@ -539,7 +539,7 @@ TEST(Column_FindAll_IntMax)
     }
 
     c.find_all(r, value);
-    CHECK_EQUAL(vReps, r.Size());
+    CHECK_EQUAL(vReps, r.size());
 
     size_t i = 0;
     size_t j = 0;
@@ -566,7 +566,7 @@ TEST(Column_FindHamming)
     Array res;
     col.find_all_hamming(res, 0x3333333333333332LL, 2);
 
-    CHECK_EQUAL(10, res.Size()); // Half should match
+    CHECK_EQUAL(10, res.size()); // Half should match
 
     // Clean up
     col.Destroy();

--- a/test/testcolumnstring.cpp
+++ b/test/testcolumnstring.cpp
@@ -435,7 +435,7 @@ TEST(ColumnStringAutoEnumerateIndex)
     CHECK_EQUAL(4, res2);
 
     e.find_all(results, "klmop");
-    CHECK_EQUAL(5, results.Size());
+    CHECK_EQUAL(5, results.size());
     CHECK_EQUAL(4, results.Get(0));
     CHECK_EQUAL(9, results.Get(1));
     CHECK_EQUAL(14, results.Get(2));
@@ -453,7 +453,7 @@ TEST(ColumnStringAutoEnumerateIndex)
 
     results.Clear();
     e.find_all(results, "newval");
-    CHECK_EQUAL(1, results.Size());
+    CHECK_EQUAL(1, results.size());
     CHECK_EQUAL(1, results.Get(0));
 
     // Insert a value
@@ -556,7 +556,7 @@ TEST_FIXTURE(db_setup_column_string, ArrayStringLongFindAjacent)
 
     c.find_all(col, "baz");
 
-    CHECK_EQUAL(2, col.Size());
+    CHECK_EQUAL(2, col.size());
 
     // Cleanup
     col.Destroy();
@@ -576,7 +576,7 @@ TEST(AdaptiveStringColumnFindAllExpand)
     asc.find_all(c, "HEJ");
 
     CHECK_EQUAL(5, asc.Size());
-    CHECK_EQUAL(3, c.Size());
+    CHECK_EQUAL(3, c.size());
     CHECK_EQUAL(0, c.Get(0));
     CHECK_EQUAL(2, c.Get(1));
     CHECK_EQUAL(4, c.Get(2));
@@ -593,7 +593,7 @@ TEST(AdaptiveStringColumnFindAllExpand)
     asc.find_all(c, "HEJ");
 
     CHECK_EQUAL(10, asc.Size());
-    CHECK_EQUAL(5, c.Size());
+    CHECK_EQUAL(5, c.size());
     CHECK_EQUAL(0, c.Get(0));
     CHECK_EQUAL(2, c.Get(1));
     CHECK_EQUAL(4, c.Get(2));
@@ -632,7 +632,7 @@ TEST(AdaptiveStringColumnFindAllRangesLong)
 
     c.Clear();
     asc.find_all(c, "HEJSA", 0, 17);
-    CHECK_EQUAL(9, c.Size());
+    CHECK_EQUAL(9, c.size());
     CHECK_EQUAL(0, c.Get(0));
     CHECK_EQUAL(2, c.Get(1));
     CHECK_EQUAL(4, c.Get(2));
@@ -645,7 +645,7 @@ TEST(AdaptiveStringColumnFindAllRangesLong)
 
     c.Clear();
     asc.find_all(c, "HEJSA", 1, 16);
-    CHECK_EQUAL(7, c.Size());
+    CHECK_EQUAL(7, c.size());
     CHECK_EQUAL(2, c.Get(0));
     CHECK_EQUAL(4, c.Get(1));
     CHECK_EQUAL(6, c.Get(2));
@@ -686,7 +686,7 @@ TEST(AdaptiveStringColumnFindAllRanges)
 
     c.Clear();
     asc.find_all(c, "HEJSA", 0, 17);
-    CHECK_EQUAL(9, c.Size());
+    CHECK_EQUAL(9, c.size());
     CHECK_EQUAL(0, c.Get(0));
     CHECK_EQUAL(2, c.Get(1));
     CHECK_EQUAL(4, c.Get(2));
@@ -699,7 +699,7 @@ TEST(AdaptiveStringColumnFindAllRanges)
 
     c.Clear();
     asc.find_all(c, "HEJSA", 1, 16);
-    CHECK_EQUAL(7, c.Size());
+    CHECK_EQUAL(7, c.size());
     CHECK_EQUAL(2, c.Get(0));
     CHECK_EQUAL(4, c.Get(1));
     CHECK_EQUAL(6, c.Get(2));

--- a/test/testearraybinary.cpp
+++ b/test/testearraybinary.cpp
@@ -18,7 +18,7 @@ TEST_FIXTURE(db_setup_binary, ArrayBinaryMultiEmpty)
     c.add(NULL, 0);
     c.add(NULL, 0);
 
-    CHECK_EQUAL(6, c.Size());
+    CHECK_EQUAL(6, c.size());
 
     CHECK_EQUAL(0, c.GetLen(0));
     CHECK_EQUAL(0, c.GetLen(1));
@@ -32,7 +32,7 @@ TEST_FIXTURE(db_setup_binary, ArrayBinarySet)
 {
     c.Set(0, "hey", 4);
 
-    CHECK_EQUAL(6, c.Size());
+    CHECK_EQUAL(6, c.size());
 
     CHECK_EQUAL("hey", c.Get(0));
     CHECK_EQUAL(4, c.GetLen(0));
@@ -46,19 +46,19 @@ TEST_FIXTURE(db_setup_binary, ArrayBinarySet)
 TEST_FIXTURE(db_setup_binary, ArrayBinaryAdd)
 {
     c.Clear();
-    CHECK_EQUAL(0, c.Size());
+    CHECK_EQUAL(0, c.size());
 
     c.add("abc", 4);
     CHECK_EQUAL("abc", c.Get(0)); // single
     CHECK_EQUAL(4, c.GetLen(0));
-    CHECK_EQUAL(1, c.Size());
+    CHECK_EQUAL(1, c.size());
 
     c.add("defg", 5); //non-empty
     CHECK_EQUAL("abc", c.Get(0));
     CHECK_EQUAL("defg", c.Get(1));
     CHECK_EQUAL(4, c.GetLen(0));
     CHECK_EQUAL(5, c.GetLen(1));
-    CHECK_EQUAL(2, c.Size());
+    CHECK_EQUAL(2, c.size());
 }
 
 TEST_FIXTURE(db_setup_binary, ArrayBinarySet2)
@@ -69,51 +69,51 @@ TEST_FIXTURE(db_setup_binary, ArrayBinarySet2)
     c.add("abc", 4);
     c.Set(0, "de", 3); // shrink single
     CHECK_EQUAL("de", c.Get(0));
-    CHECK_EQUAL(1, c.Size());
+    CHECK_EQUAL(1, c.size());
 
     c.Set(0, "abcd", 5); // grow single
     CHECK_EQUAL("abcd", c.Get(0));
-    CHECK_EQUAL(1, c.Size());
+    CHECK_EQUAL(1, c.size());
 
     c.add("efg", 4);
     CHECK_EQUAL("abcd", c.Get(0));
     CHECK_EQUAL("efg", c.Get(1));
-    CHECK_EQUAL(2, c.Size());
+    CHECK_EQUAL(2, c.size());
 
     c.Set(1, "hi", 3); // shrink last
     CHECK_EQUAL("abcd", c.Get(0));
     CHECK_EQUAL("hi", c.Get(1));
-    CHECK_EQUAL(2, c.Size());
+    CHECK_EQUAL(2, c.size());
 
     c.Set(1, "jklmno", 7); // grow last
     CHECK_EQUAL("abcd", c.Get(0));
     CHECK_EQUAL("jklmno", c.Get(1));
-    CHECK_EQUAL(2, c.Size());
+    CHECK_EQUAL(2, c.size());
 
     c.add("pq", 3);
     c.Set(1, "efghijkl", 9); // grow middle
     CHECK_EQUAL("abcd", c.Get(0));
     CHECK_EQUAL("efghijkl", c.Get(1));
     CHECK_EQUAL("pq", c.Get(2));
-    CHECK_EQUAL(3, c.Size());
+    CHECK_EQUAL(3, c.size());
 
     c.Set(1, "x", 2); // shrink middle
     CHECK_EQUAL("abcd", c.Get(0));
     CHECK_EQUAL("x", c.Get(1));
     CHECK_EQUAL("pq", c.Get(2));
-    CHECK_EQUAL(3, c.Size());
+    CHECK_EQUAL(3, c.size());
 
     c.Set(0, "qwertyuio", 10); // grow first
     CHECK_EQUAL("qwertyuio", c.Get(0));
     CHECK_EQUAL("x", c.Get(1));
     CHECK_EQUAL("pq", c.Get(2));
-    CHECK_EQUAL(3, c.Size());
+    CHECK_EQUAL(3, c.size());
 
     c.Set(0, "mno", 4); // shrink first
     CHECK_EQUAL("mno", c.Get(0));
     CHECK_EQUAL("x", c.Get(1));
     CHECK_EQUAL("pq", c.Get(2));
-    CHECK_EQUAL(3, c.Size());
+    CHECK_EQUAL(3, c.size());
 }
 
 TEST_FIXTURE(db_setup_binary, ArrayBinaryInsert)
@@ -122,25 +122,25 @@ TEST_FIXTURE(db_setup_binary, ArrayBinaryInsert)
 
     c.Insert(0, "abc", 4); // single
     CHECK_EQUAL("abc", c.Get(0));
-    CHECK_EQUAL(1, c.Size());
+    CHECK_EQUAL(1, c.size());
 
     c.Insert(1, "d", 2); // end
     CHECK_EQUAL("abc", c.Get(0));
     CHECK_EQUAL("d", c.Get(1));
-    CHECK_EQUAL(2, c.Size());
+    CHECK_EQUAL(2, c.size());
 
     c.Insert(2, "ef", 3); // end
     CHECK_EQUAL("abc", c.Get(0));
     CHECK_EQUAL("d", c.Get(1));
     CHECK_EQUAL("ef", c.Get(2));
-    CHECK_EQUAL(3, c.Size());
+    CHECK_EQUAL(3, c.size());
 
     c.Insert(1, "ghij", 5); // middle
     CHECK_EQUAL("abc", c.Get(0));
     CHECK_EQUAL("ghij", c.Get(1));
     CHECK_EQUAL("d", c.Get(2));
     CHECK_EQUAL("ef", c.Get(3));
-    CHECK_EQUAL(4, c.Size());
+    CHECK_EQUAL(4, c.size());
 
     c.Insert(0, "klmno", 6); // first
     CHECK_EQUAL("klmno", c.Get(0));
@@ -148,7 +148,7 @@ TEST_FIXTURE(db_setup_binary, ArrayBinaryInsert)
     CHECK_EQUAL("ghij", c.Get(2));
     CHECK_EQUAL("d", c.Get(3));
     CHECK_EQUAL("ef", c.Get(4));
-    CHECK_EQUAL(5, c.Size());
+    CHECK_EQUAL(5, c.size());
 }
 
 TEST_FIXTURE(db_setup_binary, ArrayBinaryDelete)
@@ -166,25 +166,25 @@ TEST_FIXTURE(db_setup_binary, ArrayBinaryDelete)
     CHECK_EQUAL("def", c.Get(1));
     CHECK_EQUAL("ghij", c.Get(2));
     CHECK_EQUAL("klmno", c.Get(3));
-    CHECK_EQUAL(4, c.Size());
+    CHECK_EQUAL(4, c.size());
 
     c.Delete(3); // last
     CHECK_EQUAL("bc", c.Get(0));
     CHECK_EQUAL("def", c.Get(1));
     CHECK_EQUAL("ghij", c.Get(2));
-    CHECK_EQUAL(3, c.Size());
+    CHECK_EQUAL(3, c.size());
 
     c.Delete(1); // middle
     CHECK_EQUAL("bc", c.Get(0));
     CHECK_EQUAL("ghij", c.Get(1));
-    CHECK_EQUAL(2, c.Size());
+    CHECK_EQUAL(2, c.size());
 
     c.Delete(0); // single
     CHECK_EQUAL("ghij", c.Get(0));
-    CHECK_EQUAL(1, c.Size());
+    CHECK_EQUAL(1, c.size());
 
     c.Delete(0); // all
-    CHECK_EQUAL(0, c.Size());
+    CHECK_EQUAL(0, c.size());
     CHECK(c.is_empty());
 }
 

--- a/test/testindexstring.cpp
+++ b/test/testindexstring.cpp
@@ -306,7 +306,7 @@ TEST(StringIndex_Distinct)
     Array result;
     ndx.distinct(result);
 
-    CHECK_EQUAL(4, result.Size());
+    CHECK_EQUAL(4, result.size());
     CHECK_EQUAL(1, result[0]); // s2 = Brian
     CHECK_EQUAL(0, result[1]); // s1 = John
     CHECK_EQUAL(3, result[2]); // s3 = Samantha


### PR DESCRIPTION
Small change, large impact.

I renamed Array::Size() to Array::size(). This pull request contains nothing else.

I took the opportunity to do it after I had to identify all calls to Array::Size() anyway.

/cc @astigsen @rrrlasse 
