### PR TITLE
Added code to extend list of active readers when ringbuffer is full.

### DIFF
--- a/src/tightdb/group_shared.cpp
+++ b/src/tightdb/group_shared.cpp
@@ -246,7 +246,7 @@ SharedGroup::~SharedGroup()
     remove(m_file_path.c_str());
 }
 
-bool SharedGroup::has_changed() const
+bool SharedGroup::has_changed() const TIGHTDB_NOEXCEPT
 {
     // Have we changed since last transaction?
     // Visibility of changes can be delayed when using has_changed() because m_info->current_version is tested
@@ -255,7 +255,7 @@ bool SharedGroup::has_changed() const
     // system bus and make cache controllers invalidate caches of reader). Some excotic architectures may need
     // explicit synchronization which isn't implemented yet.
     TIGHTDB_SYNC_IF_NO_CACHE_COHERENCE
-    SharedInfo* const info = m_file_map.get_addr();
+    const SharedInfo* const info = m_file_map.get_addr();
     const bool is_changed = (m_version != info->current_version);
     return is_changed;
 }

--- a/src/tightdb/group_shared.hpp
+++ b/src/tightdb/group_shared.hpp
@@ -109,7 +109,7 @@ public:
     bool is_attached() const TIGHTDB_NOEXCEPT;
 
     // Has db been modified since last transaction?
-    bool has_changed() const;
+    bool has_changed() const TIGHTDB_NOEXCEPT;
 
     // Read transactions
     const Group& begin_read();


### PR DESCRIPTION
Note that the original code failed silently as it would would never correctly report the ringbuf as full.

@kspangsege @rrrlasse @bmunkholm 
