### PR TITLE
Signed-right-shift bugs and warnings in 32 bit mode

### DIFF
--- a/src/tightdb/alloc_slab.cpp
+++ b/src/tightdb/alloc_slab.cpp
@@ -370,11 +370,11 @@ void SlabAlloc::FreeAll(size_t filesize)
     const size_t count = m_slabs.size();
     for (size_t i = 0; i < count; ++i) {
         const Slabs::Cursor c = m_slabs[i];
-        const size_t size = c.offset - ref;
+        const size_t size = to_size_t(c.offset - ref);
 
         m_freeSpace.add(ref, size);
 
-        ref = c.offset;
+        ref = to_size_t(c.offset);
     }
 
     // If the file size have changed, we need to remap the readonly buffer
@@ -408,7 +408,7 @@ bool SlabAlloc::ReMap(size_t filesize)
     for (size_t i = 0; i < count; ++i) {
         FreeSpace::Cursor c = m_freeSpace[i];
         c.ref = new_offset;
-        new_offset += c.size;
+        new_offset = to_size_t(new_offset + c.size);
 
         m_slabs[i].offset = new_offset;
     }

--- a/src/tightdb/array.cpp
+++ b/src/tightdb/array.cpp
@@ -15,6 +15,7 @@
 #include <tightdb/column.hpp>
 #include <tightdb/query_conditions.hpp>
 #include <tightdb/column_string.hpp>
+#include <tightdb/utilities.hpp>
 
 using namespace std;
 
@@ -147,7 +148,7 @@ static size_t BitWidth(int64_t v)
 {
     // FIXME: Assuming there is a 64-bit CPU reverse bitscan instruction and it is fast, then this function could be implemented simply as (v<2 ? v : 2<<rev_bitscan(rev_bitscan(v))).
 
-    if ((v >> 4) == 0) {
+    if ((uint64_t(v) >> 4) == 0) {
         static const int8_t bits[] = {0, 1, 2, 2, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4};
         return bits[(int8_t)v];
     }
@@ -156,7 +157,7 @@ static size_t BitWidth(int64_t v)
     if (v < 0) v = ~v;
 
     // Then check if bits 15-31 used (32b), 7-31 used (16b), else (8b)
-    return v >> 31 ? 64 : v >> 15 ? 32 : v >> 7 ? 16 : 8;
+    return uint64_t(v) >> 31 ? 64 : uint64_t(v) >> 15 ? 32 : uint64_t(v) >> 7 ? 16 : 8;
 }
 
 // Allocates space for 'count' items being between min and min in size, both inclusive. Crashes! Why? Todo/fixme
@@ -215,10 +216,10 @@ void Array::Clear()
     // Make sure we don't have any dangling references
     if (m_hasRefs) {
         for (size_t i = 0; i < size(); ++i) {
-            const size_t ref = GetAsRef(i);
-            if (ref == 0 || ref & 0x1) continue; // zero-refs and refs that are not 64-aligned do not point to sub-trees
+            const int64_t v = Get(i);
+            if (v == 0 || v & 0x1) continue; // zero-refs and refs that are not 64-aligned do not point to sub-trees
 
-            Array sub(ref, this, i, m_alloc);
+            Array sub(to_ref(v), this, i, m_alloc);
             sub.Destroy();
         }
     }
@@ -604,7 +605,7 @@ size_t Array::FirstSetBit64(int64_t v) const
     return __builtin_clzll(v);
 #else
     unsigned int v0 = (unsigned int)v;
-    unsigned int v1 = (unsigned int)(v >> 32);
+    unsigned int v1 = (unsigned int)(uint64_t(v) >> 32);
     size_t r;
 
     if (v0 != 0)
@@ -1739,7 +1740,7 @@ void Array::ToDot(std::ostream& out, const char* title) const
         if (m_hasRefs) {
             // zero-refs and refs that are not 64-aligned do not point to sub-trees
             if (v == 0) out << "<TD>none";
-            else if (v & 0x1) out << "<TD BGCOLOR=\"grey90\">" << (v >> 1);
+            else if (v & 0x1) out << "<TD BGCOLOR=\"grey90\">" << (uint64_t(v) >> 1);
             else out << "<TD PORT=\"" << i << "\">";
         }
         else out << "<TD>" << v;
@@ -1900,7 +1901,6 @@ inline size_t upper_bound(const char* header, int64_t value) TIGHTDB_NOEXCEPT
     return i;
 }
 
-
 // Find the child that contains the specified local tree index.
 // Returns (child_ndx, local_tree_offset) where 'local_tree_offset' is
 // the local tree index offset of the located child.
@@ -1909,7 +1909,7 @@ find_child_offset(const char* header, size_t local_ndx) TIGHTDB_NOEXCEPT
 {
     size_t child_ndx = upper_bound<width>(header, local_ndx);
     size_t local_tree_offset = child_ndx == 0 ? 0 :
-        get_direct<width>(tightdb::Array::get_data_from_header(header), child_ndx-1);
+        tightdb::to_ref(get_direct<width>(tightdb::Array::get_data_from_header(header), child_ndx-1));
     return make_pair(child_ndx, local_tree_offset);
 }
 
@@ -2255,10 +2255,10 @@ top:
                 // might be so many matches that it has branched into a column
                 size_t row_ref;
                 if (!sub_isnode)
-                    row_ref = get_direct(sub_data, sub_width, 0);
+                    row_ref = to_size_t(get_direct(sub_data, sub_width, 0));
                 else {
                     const Array sub(ref, NULL, 0, m_alloc);
-                    row_ref = sub.column_get(0);
+                    row_ref = to_size_t(sub.column_get(0));
                 }
 
                 // If the last byte in the stored key is zero, we know that we have
@@ -2359,7 +2359,7 @@ top:
                 if (!sub_isnode) {
                     const size_t sub_width = get_width_from_header(sub_header);
                     const char* sub_data = get_data_from_header(sub_header);
-                    const size_t first_row_ref = get_direct(sub_data, sub_width, 0);
+                    const size_t first_row_ref = to_size_t(get_direct(sub_data, sub_width, 0));
 
                     // If the last byte in the stored key is not zero, we have
                     // not yet compared against the entire (target) string
@@ -2373,13 +2373,13 @@ top:
                     const size_t sub_len  = get_len_from_header(sub_header);
 
                     for (size_t i = 0; i < sub_len; ++i) {
-                        const size_t row_ref = get_direct(sub_data, sub_width, i);
+                        const size_t row_ref = to_size_t(get_direct(sub_data, sub_width, i));
                         result.add(row_ref);
                     }
                 }
                 else {
                     const Column sub(ref, NULL, 0, m_alloc);
-                    const size_t first_row_ref = sub.Get(0);
+                    const size_t first_row_ref = to_size_t(sub.Get(0));
 
                     // If the last byte in the stored key is not zero, we have
                     // not yet compared against the entire (target) string
@@ -2393,7 +2393,7 @@ top:
                     const size_t sub_len  = sub.Size();
 
                     for (size_t i = 0; i < sub_len; ++i) {
-                        const size_t row_ref = sub.Get(i);
+                        const size_t row_ref = to_size_t(sub.Get(i));
                         result.add(row_ref);
                     }
                 }
@@ -2491,7 +2491,7 @@ top:
 
                     const char* sub_data = get_data_from_header(sub_header);
                     const size_t sub_width  = get_width_from_header(sub_header);
-                    row_ref = get_direct(sub_data, sub_width, 0);
+                    row_ref = to_size_t(get_direct(sub_data, sub_width, 0));
                 }
                 else {
                     const Column sub(ref, NULL, 0, m_alloc);
@@ -2501,7 +2501,7 @@ top:
                     // compared against the entire (target) string
                     if (!(stored_key << 24)) return sub_count;
 
-                    row_ref = sub.Get(0);
+                    row_ref = to_size_t(sub.Get(0));
                 }
 
                 const char* const str = (*get_func)(column, row_ref);

--- a/src/tightdb/column.cpp
+++ b/src/tightdb/column.cpp
@@ -251,7 +251,7 @@ size_t ColumnBase::get_size_from_ref(size_t ref, Allocator& alloc) TIGHTDB_NOEXC
     Array a(ref, 0, 0, alloc);
     if (!a.IsNode())
         return a.size();
-    Array offsets(a.Get(0), 0, 0, alloc);
+    Array offsets(a.GetAsRef(0), 0, 0, alloc);
     return offsets.is_empty() ? 0 : size_t(offsets.back());
 }
 

--- a/src/tightdb/column_mixed.cpp
+++ b/src/tightdb/column_mixed.cpp
@@ -315,8 +315,8 @@ void ColumnMixed::Verify() const
     // Verify each sub-table
     const size_t count = Size();
     for (size_t i = 0; i < count; ++i) {
-        const size_t tref = m_refs->GetAsRef(i);
-        if (tref == 0 || tref & 0x1) continue;
+        const int64_t v = m_refs->Get(i);
+        if (v == 0 || v & 0x1) continue;
         ConstTableRef subtable = m_refs->get_subtable(i);
         subtable->Verify();
     }

--- a/src/tightdb/group_shared.cpp
+++ b/src/tightdb/group_shared.cpp
@@ -277,9 +277,9 @@ const Group& SharedGroup::begin_read()
         }
 
         // Get the current top ref
-        new_topref   = info->current_top;
-        new_filesize = info->filesize;
-        m_version    = info->current_version;
+        new_topref   = to_size_t(info->current_top);
+        new_filesize = to_size_t(info->filesize);
+        m_version    = to_size_t(info->current_version); // fixme, remember to remove to_size_t when m_version becomes 64 bit
 
         // Update reader list
         if (ringbuf_is_empty()) {
@@ -367,8 +367,8 @@ Group& SharedGroup::begin_write()
     pthread_mutex_lock(&info->writemutex);
 
     // Get the current top ref
-    const size_t new_topref   = info->current_top;
-    const size_t new_filesize = info->filesize;
+    const size_t new_topref   = to_size_t(info->current_top);
+    const size_t new_filesize = to_size_t(info->filesize);
 
     // Make sure the group is up-to-date
     // zero ref means that the file has just been created
@@ -686,7 +686,7 @@ void SharedGroup::zero_free_space()
     pthread_mutex_lock(&info->readmutex);
     {
         current_version = info->current_version + 1;
-        file_size = info->filesize;
+        file_size = to_size_t(info->filesize);
 
         if (ringbuf_is_empty())
             readlock_version = current_version;

--- a/src/tightdb/group_writer.cpp
+++ b/src/tightdb/group_writer.cpp
@@ -50,7 +50,7 @@ size_t GroupWriter::Commit()
 
     for (size_t i = 0; i < fcount; ++i) {
         SlabAlloc::FreeSpace::ConstCursor r = freeSpace[i];
-        add_free_space(r.ref, r.size, m_current_version);
+        add_free_space(to_size_t(r.ref), to_size_t(r.size), to_size_t(m_current_version));
     }
 
     // We now have a bit of an chicken-and-egg problem. We need to write our free
@@ -379,10 +379,10 @@ size_t GroupWriter::extend_free_space(size_t len)
 
     // See if we can merge in new space
     if (!fpositions.is_empty()) {
-        const size_t last_ndx = fpositions.size()-1;
-        const size_t last_len = flengths[last_ndx];
-        const size_t end  = fpositions[last_ndx] + last_len;
-        const size_t ver  = isShared ? fversions[last_ndx] : 0;
+        const size_t last_ndx = to_size_t(fpositions.size()-1);
+        const size_t last_len = to_size_t(flengths[last_ndx]);
+        const size_t end  = to_size_t(fpositions[last_ndx] + last_len);
+        const size_t ver  = to_size_t(isShared ? fversions[last_ndx] : 0);
         if (end == old_filesize && ver == 0) {
             flengths.Set(last_ndx, last_len + ext_len);
             return last_ndx;

--- a/src/tightdb/query_engine.hpp
+++ b/src/tightdb/query_engine.hpp
@@ -467,7 +467,7 @@ public:
 
         m_next = 0;
         if (m_size > 0)
-            m_max = m_arr.Get(m_size - 1);
+            m_max = m_arr.GetAsSizeT(m_size - 1);
         if (m_child) m_child->Init(table);
     }
 
@@ -478,7 +478,7 @@ public:
             return end;
 
         m_next = r;
-        return m_arr.Get(r);
+        return m_arr.GetAsSizeT(r);
     }
 
 protected:
@@ -1020,7 +1020,7 @@ public:
             if (m_condition_column->HasIndex()) {
                 size_t f = m_index.FindGTE(s, last_indexed);
                 if (f != not_found)
-                    s = m_index.Get(f);
+                    s = m_index.GetAsSizeT(f);
                 else
                     s = not_found;
                 last_indexed = f;

--- a/src/tightdb/utilities.hpp
+++ b/src/tightdb/utilities.hpp
@@ -135,9 +135,6 @@ inline std::size_t to_ref(int64_t v) TIGHTDB_NOEXCEPT
 #ifdef TIGHTDB_DEBUG
     uint64_t m = std::size_t(-1);
     TIGHTDB_ASSERT(uint64_t(v) <= m);
-    // FIXME: This misbehaves for negative v when size_t is 64-bits.
-    // FIXME: This misbehaves on architectures that do not use 2's complement represenation of negative numbers.
-    // FIXME: Should probably be TIGHTDB_ASSERT(0 <= v && uint64_t(v) <= numeric_limits<size_t>::max());
     // FIXME: Must also check that v is divisible by 8 (64-bit aligned).
 #endif
     return std::size_t(v);
@@ -149,8 +146,6 @@ inline std::size_t to_size_t(int64_t v) TIGHTDB_NOEXCEPT
 #ifdef TIGHTDB_DEBUG
     uint64_t m = std::size_t(-1);
     TIGHTDB_ASSERT(uint64_t(v) <= m);
-    // FIXME: This misbehaves for negative v when size_t is 64-bits.
-    // FIXME: This misbehaves on architectures that do not use 2's complement represenation of negative numbers.
     // FIXME: Should probably be TIGHTDB_ASSERT(0 <= v && uint64_t(v) <= numeric_limits<size_t>::max());
 #endif
     return std::size_t(v);


### PR DESCRIPTION
Fixed tons (50+) of warnings in 32 bit mode. Please use GetAsRef(), to_ref(), etc. where appropriate.
