### PR TITLE
Async Commits

### DIFF
--- a/src/tightdb/group_shared.hpp
+++ b/src/tightdb/group_shared.hpp
@@ -35,7 +35,8 @@ class SharedGroup {
 public:
     enum DurabilityLevel {
         durability_Full,
-        durability_MemOnly
+        durability_MemOnly,
+        durability_Async
     };
 
     /// Equivalent to calling open(const std::string&, bool,
@@ -84,7 +85,7 @@ public:
     /// thrown. Note that InvalidDatabase is among these derived
     /// exception types.
     void open(const std::string& file, bool no_create = false,
-              DurabilityLevel dlevel=durability_Full);
+              DurabilityLevel dlevel=durability_Full, bool is_backend=false);
 
 #ifdef TIGHTDB_ENABLE_REPLICATION
 
@@ -188,6 +189,8 @@ private:
     // Must be called only by someone that has a lock on the write
     // mutex.
     void low_level_commit(std::size_t new_version);
+
+    void do_async_commits();
 
     friend class ReadTransaction;
     friend class WriteTransaction;

--- a/src/tightdb/group_writer.hpp
+++ b/src/tightdb/group_writer.hpp
@@ -47,9 +47,9 @@ public:
     void ZeroFreeSpace();
 #endif
 
-private:
     void DoCommit(uint64_t topPos);
 
+private:
     std::size_t get_free_space(size_t len);
     std::size_t reserve_free_space(size_t len, size_t start=0);
     void        add_free_space(size_t pos, size_t len, size_t version=0);


### PR DESCRIPTION
This is the initial implementation of async commits. It is still very rough, so it is being put up  so that we can discuss the approach.

The core idea is all processes that open the db, can commit, but only to memory. Then we start a separate process that keeps a read lock to ensure that no data that has not been committed to disk get overwritten. It then watches for changes to the in-memory mapping, and syncs them to disk as they come up (so we get continuous writing to disk).

During the commit it holds a second read lock on the version it is committing, and when done it can use this to replace the old lock as this no longer has to be protected. So in this way we can leapfrog ahead, always ensuring that no corruption can happen to the on-disk representation.

The main point of contention is how we start the backend async_commit process. Right now I have implemented it as a straight fork from the process that first opens the db, but that has the following potential problems:
1. Process name: The backend process will have the same name as the parent, which could confuse users when they look for it with ps (or Activity Monitor on mac).
2. It pulls in a lot of state from the parent process, could potentially give problems at shutdown?

The alternative could be to exec a separate executable as the backend. That would fix the two above problems, but might introduce its own problems (primarily how to ensure that you can always find it in a multiuser environment).
