### PR TITLE
Changes in Group::OpenMode

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -13,6 +13,16 @@ Format:
 ==================
 
 
+2013-06-25 (Kristian Spangsege)
+. The default group open mode has been changed from Group::mode_Normal
+  (read/write) to Group::mode_ReadOnly. This makes it possible to open
+  a read-only file without specifying a special open mode. Also, since
+  changed groups are generally written to new files, there is rarely a
+  need for the group to be opened in read/write mode.
+. Group::mode_Normal has been renamed to Group::mode_ReadWrite since it is no longer a normal mode.
+. Group::mode_NoCreate has been renamed to Group::mode_ReadWriteNoCreate for clarity.
+
+
 2013-06-05 (Kristian Spangsege)
 . Group::write(path) now throws File::Exists if 'path' already exists in the file system.
 

--- a/doc/ref_cpp/data/group_ref.yaml
+++ b/doc/ref_cpp/data/group_ref.yaml
@@ -54,7 +54,7 @@ CATEGORIES:
                  Creates a table group.
       SIGNATURE: |
                  Group();
-                 Group(const std::string& file, OpenMode mode = mode_Normal);
+                 Group(const std::string& file, OpenMode mode = mode_ReadOnly);
                  Group(BinaryData buffer, bool take_ownership = true);
                  Group(unattached_tag) noexcept;
       PARAMS:
@@ -65,9 +65,9 @@ CATEGORIES:
       - NAME   : mode
         TYPES  : Group::OpenMode
         DESCR  : |
-                 Group::mode_Normal:   Open in read/write mode, create the file if it does not already exist.
-                 Group::mode_ReadOnly: Open in read-only mode, fail if the file does not already exist.
-                 Group::mode_NoCreate: Open in read/write mode, fail if the file does not already exist.
+                 Group::mode_ReadOnly:          Open in read-only mode. Fail if the file does not already exist.
+                 Group::mode_ReadWrite:         Open in read/write mode. Create the file if it does not already exist.
+                 Group::mode_ReadWriteNoCreate: Open in read/write mode. Fail if the file does not already exist.
       - NAME   : buffer
         TYPES  : BinaryData
         DESCR  : &g_group_constructor_memory_parm3_descr
@@ -324,7 +324,7 @@ CATEGORIES:
       EXAMPLES:
       - DESCR  :
         CODE   : ex_cpp_group_tostring
-        
+
   - g_group_open_file:
   - g_group_open_memory:
       NAMES    : [open, open]
@@ -333,28 +333,67 @@ CATEGORIES:
                  Attach this Group instance to a file or an externally
                  supplied memory buffer.
 
-                 If the specified file exists in the file system, it
-                 must contain a valid TightDB database. If the file
-                 does not exist, it will be created (unless
-                 mode_NoCreate is specified). While a group
-                 constructed this way, can be used to access and
-                 manipulate a TightDB database, it is generally better
-                 to use a SharedGroup instance along with proper
-                 transactions.
+                 By default, the specified file is opened in read-only
+                 mode (mode_ReadOnly). This allows opening a file even
+                 when the caller lacks permission to write to that
+                 file. The opened group may still be modified freely,
+                 but the changes cannot be written back to the same
+                 file using the commit() function. An attempt to do
+                 that, will cause an exception to be thrown. When
+                 opening in read-only mode, it is an error if the
+                 specified file does not already exist in the file
+                 system.
 
-                 Changes made to the database via a Group instance are
-                 not automatically committed to the specified
-                 file. You may, however, at any time, call write() to
-                 write the entire database to a new file. After
-                 writing the new file, the Group will continue to be
-                 associated with the file that was specified in the
-                 call to open().
+                 Alternatively, the file can be opened in read/write
+                 mode (mode_ReadWrite). This allows use of the
+                 commit() function, but, of course, it also requires
+                 that the caller has permission to write to the
+                 specified file. When opening in read-write mode, an
+                 attempt to create the specified file will be made, if
+                 it does not already exist in the file system.
+
+                 In any case, if the file already exists, it must
+                 contain a valid TightDB database. In many cases
+                 invalidity will be detected and cause the
+                 InvalidDatabase exception to be thrown, but you
+                 should not rely on it.
+
+                 Note that changes made to the database via a Group
+                 instance are not automatically committed to the
+                 specified file. You may, however, at any time,
+                 explicitly commit your changes by calling the
+                 commit() method, provided that the specified
+                 open-mode is not mode_ReadOnly. Alternatively, you
+                 may call write() to write the entire database to a
+                 new file. Writing the database to a new file does not
+                 end, or in any other way change the association
+                 between the Group instance and the file that was
+                 specified in the call to open().
 
                  A file that is passed to Group::open(), may not be
-                 modified until after the Group object is
-                 destroyed. Behaviour is undefined if a file is
-                 modified while any Group object is associated with
-                 it.
+                 modified by a third party until after the Group
+                 object is destroyed. Behavior is undefined if a file
+                 is modified by a third party while any Group object
+                 is associated with it.
+
+                 Calling open() on a Group instance that is already in
+                 the attached state has undefined behavior.
+
+                 Accessing a TightDB database file through manual
+                 construction of a Group object does not offer any
+                 level of thread safety or transaction safety. When
+                 any of those kinds of safety are a concern, consider
+                 using a SharedGroup instead. When accessing a
+                 database file in read/write mode through a manually
+                 constructed Group object, it is entirely the
+                 responsibility of the application that the file is
+                 not accessed in any way by a third party during the
+                 life-time of that group object. It is, on the other
+                 hand, safe to concurrently access a database file by
+                 multiple manually created Group objects, as long as
+                 all of them are opened in read-only mode, and there
+                 is no other party that modifies the file
+                 concurrently.
 
 
                  Specifying a memory buffer is equivalent to
@@ -380,7 +419,7 @@ CATEGORIES:
       SUMMARY  : &g_group_open_summary
                  Attach to a file or a memory buffer.
       SIGNATURE: |
-                 void open(const std::string& file, OpenMode mode = mode_Normal);
+                 void open(const std::string& file, OpenMode mode = mode_ReadOnly);
                  void open(BinaryData buffer, bool take_ownership = true);
       PARAMS:
       - NAME   : file
@@ -390,7 +429,11 @@ CATEGORIES:
       - NAME   : mode
         TYPES  : Group::OpenMode
         DESCR  : &g_group_open_memory_parm2_descr
-                 See Group().
+                 Specifying a mode that is not mode_ReadOnly requires
+                 that the specified file can be opened in read/write
+                 mode. In general there is no reason to open a group
+                 in read/write mode unless you want to be able to call
+                 Group::commit().
       - NAME   : buffer
         TYPES  : BinaryData
         DESCR  : &g_group_open_memory_parm3_descr
@@ -408,7 +451,7 @@ CATEGORIES:
         CODE   : ex_cpp_group_open_file
       - DESCR  :
         CODE   : ex_cpp_group_open_memory
-        
+
   - g_group_is_attached:
       NAME     : is_attached
       SUMMARY  : &g_group_is_attached_summary

--- a/src/tightdb/alloc_slab.cpp
+++ b/src/tightdb/alloc_slab.cpp
@@ -217,8 +217,8 @@ void SlabAlloc::attach_file(const string& path, bool is_shared, bool read_only, 
     TIGHTDB_ASSERT(!(is_shared && read_only));
     static_cast<void>(is_shared);
 
-    const File::AccessMode access = read_only ? File::access_ReadOnly : File::access_ReadWrite;
-    const File::CreateMode create = read_only || no_create ? File::create_Never : File::create_Auto;
+    File::AccessMode access = read_only ? File::access_ReadOnly : File::access_ReadWrite;
+    File::CreateMode create = read_only || no_create ? File::create_Never : File::create_Auto;
     m_file.open(path.c_str(), access, create, 0);
     File::CloseGuard fcg(m_file);
 

--- a/src/tightdb/alloc_slab.hpp
+++ b/src/tightdb/alloc_slab.hpp
@@ -57,9 +57,11 @@ public:
     /// allowed. When used by SharedGroup, concurrency is allowed, but
     /// read_only and no_create must both be false in this case.
     ///
-    /// \param is_shared Must be true iff we are called on behalf of SharedGroup.
+    /// \param is_shared Must be true if, and only if we are called on
+    /// behalf of SharedGroup.
     ///
-    /// \param read_only Open the file in read-only mode. This implies \a no_create.
+    /// \param read_only Open the file in read-only mode. This implies
+    /// \a no_create.
     ///
     /// \param no_create Fail if the file does not already exist.
     ///

--- a/src/tightdb/array.hpp
+++ b/src/tightdb/array.hpp
@@ -75,7 +75,7 @@ Searching: The main finding function is:
 
 namespace tightdb {
 
-enum Action {act_ReturnFirst, act_Sum, act_Max, act_Min, act_Count, act_FindAll, act_CallIdx, act_CallbackIdx, 
+enum Action {act_ReturnFirst, act_Sum, act_Max, act_Min, act_Count, act_FindAll, act_CallIdx, act_CallbackIdx,
              act_CallbackVal, act_CallbackNone, act_CallbackBoth};
 
 template<class T> inline T no0(T v) { return v == 0 ? 1 : v; }
@@ -343,35 +343,35 @@ public:
     bool Compare(const Array&) const;
 
     // Main finding function - used for find_first, find_all, sum, max, min, etc.
-    void find(int cond, Action action, int64_t value, size_t start, size_t end, size_t baseindex, 
+    void find(int cond, Action action, int64_t value, size_t start, size_t end, size_t baseindex,
               QueryState<int64_t>* state) const;
 
     template <class cond, Action action, size_t bitwidth, class Callback>
-    void find(int64_t value, size_t start, size_t end, size_t baseindex, QueryState<int64_t>* state, 
+    void find(int64_t value, size_t start, size_t end, size_t baseindex, QueryState<int64_t>* state,
               Callback callback) const;
 
     template <class cond, Action action, size_t bitwidth>
     void find(int64_t value, size_t start, size_t end, size_t baseindex, QueryState<int64_t>* state) const;
 
     template <class cond, Action action, class Callback>
-    void find(int64_t value, size_t start, size_t end, size_t baseindex, QueryState<int64_t>* state, 
+    void find(int64_t value, size_t start, size_t end, size_t baseindex, QueryState<int64_t>* state,
               Callback callback) const;
 
     // Optimized implementation for release mode
     template <class cond2, Action action, size_t bitwidth, class Callback>
-    void find_optimized(int64_t value, size_t start, size_t end, size_t baseindex, QueryState<int64_t>* state, 
+    void find_optimized(int64_t value, size_t start, size_t end, size_t baseindex, QueryState<int64_t>* state,
                         Callback callback) const;
 
     // Reference implementation of find() - verifies result from optimized version if debug mode
     template <class cond2, Action action, size_t bitwidth, class Callback>
-    int64_t find_reference(int64_t value, size_t start, size_t end, size_t baseindex, QueryState<int64_t>* state, 
+    int64_t find_reference(int64_t value, size_t start, size_t end, size_t baseindex, QueryState<int64_t>* state,
                            Callback callback) const;
 
     // Called for each search result
-    template <Action action, class Callback> 
+    template <Action action, class Callback>
     bool find_action(size_t index, int64_t value, QueryState<int64_t>* state, Callback callback) const;
 
-    template <Action action, class Callback> 
+    template <Action action, class Callback>
     bool find_action_pattern(size_t index, uint64_t pattern, QueryState<int64_t>* state, Callback callback) const;
 
     // Wrappers for backwards compatibility and for simple use without setting up state initialization etc
@@ -381,43 +381,43 @@ public:
 
     // Non-SSE find for the four functions Equal/NotEqual/Less/Greater
     template <class cond2, Action action, size_t bitwidth, class Callback>
-    bool Compare(int64_t value, size_t start, size_t end, size_t baseindex, QueryState<int64_t>* state, 
+    bool Compare(int64_t value, size_t start, size_t end, size_t baseindex, QueryState<int64_t>* state,
                  Callback callback) const;
 
     // Non-SSE find for Equal/NotEqual
     template <bool eq, Action action, size_t width, class Callback>
-    inline bool CompareEquality(int64_t value, size_t start, size_t end, size_t baseindex, 
+    inline bool CompareEquality(int64_t value, size_t start, size_t end, size_t baseindex,
                                 QueryState<int64_t>* state, Callback callback) const;
 
     // Non-SSE find for Less/Greater
     template <bool gt, Action action, size_t bitwidth, class Callback>
-    bool CompareRelation(int64_t value, size_t start, size_t end, size_t baseindex, QueryState<int64_t>* state, 
+    bool CompareRelation(int64_t value, size_t start, size_t end, size_t baseindex, QueryState<int64_t>* state,
                          Callback callback) const;
 
-    template <class cond, Action action, size_t foreign_width, class Callback, size_t width> 
-    bool CompareLeafs4(Array* foreign, size_t start, size_t end, size_t baseindex, QueryState<int64_t>* state, 
+    template <class cond, Action action, size_t foreign_width, class Callback, size_t width>
+    bool CompareLeafs4(Array* foreign, size_t start, size_t end, size_t baseindex, QueryState<int64_t>* state,
                        Callback callback) const;
 
-    template <class cond, Action action, class Callback, size_t bitwidth, size_t foreign_bitwidth> 
-    bool CompareLeafs(Array* foreign, size_t start, size_t end, size_t baseindex, QueryState<int64_t>* state, 
+    template <class cond, Action action, class Callback, size_t bitwidth, size_t foreign_bitwidth>
+    bool CompareLeafs(Array* foreign, size_t start, size_t end, size_t baseindex, QueryState<int64_t>* state,
                       Callback callback) const;
-    
+
     template <class cond, Action action, class Callback>
-    bool CompareLeafs(Array* foreign, size_t start, size_t end, size_t baseindex, QueryState<int64_t>* state, 
+    bool CompareLeafs(Array* foreign, size_t start, size_t end, size_t baseindex, QueryState<int64_t>* state,
                       Callback callback) const;
-   
+
     template <class cond, Action action, size_t width, class Callback>
-    bool CompareLeafs(Array* foreign, size_t start, size_t end, size_t baseindex, QueryState<int64_t>* state, 
+    bool CompareLeafs(Array* foreign, size_t start, size_t end, size_t baseindex, QueryState<int64_t>* state,
                       Callback callback) const;
 
     // SSE find for the four functions Equal/NotEqual/Less/Greater
 #ifdef TIGHTDB_COMPILER_SSE
     template <class cond2, Action action, size_t width, class Callback>
-    bool FindSSE(int64_t value, __m128i *data, size_t items, QueryState<int64_t>* state, size_t baseindex, 
+    bool FindSSE(int64_t value, __m128i *data, size_t items, QueryState<int64_t>* state, size_t baseindex,
                  Callback callback) const;
-    
-    template <class cond2, Action action, size_t width, class Callback> 
-    TIGHTDB_FORCEINLINE bool FindSSE_intern(__m128i* action_data, __m128i* data, size_t items, 
+
+    template <class cond2, Action action, size_t width, class Callback>
+    TIGHTDB_FORCEINLINE bool FindSSE_intern(__m128i* action_data, __m128i* data, size_t items,
                                             QueryState<int64_t>* state, size_t baseindex, Callback callback) const;
 
 #endif
@@ -433,7 +433,7 @@ public:
 
     // Find value greater/less in 64-bit chunk - only works for positive values
     template <bool gt, Action action, size_t width, class Callback>
-    bool FindGTLT_Fast(uint64_t chunk, uint64_t magic, QueryState<int64_t>* state, size_t baseindex, 
+    bool FindGTLT_Fast(uint64_t chunk, uint64_t magic, QueryState<int64_t>* state, size_t baseindex,
                        Callback callback) const;
 
     // Find value greater/less in 64-bit chunk - no constraints
@@ -833,9 +833,9 @@ inline Array Array::GetSubArray(std::size_t ndx) const TIGHTDB_NOEXCEPT
     const std::size_t ref = std::size_t(Get(ndx));
     TIGHTDB_ASSERT(ref);
 
-    // FIXME: Constness is not propagated to the sub-array. This constitutes a real problem, because modifying 
+    // FIXME: Constness is not propagated to the sub-array. This constitutes a real problem, because modifying
     // the returned array genrally causes the parent to be modified too.
-    return Array(ref, const_cast<Array*>(this), ndx, m_alloc); 
+    return Array(ref, const_cast<Array*>(this), ndx, m_alloc);
 }
 
 
@@ -1264,12 +1264,12 @@ computations for the given search criteria makes it feasible to construct such a
 // These wrapper functions only exist to enable a possibility to make the compiler see that 'value' and/or 'index' are unused, such that caller's
 // computation of these values will not be made. Only works if find_action() and find_action_pattern() rewritten as macros. Note: This problem has been fixed in
 // next upcoming array.hpp version
-template <Action action, class Callback> 
+template <Action action, class Callback>
 bool Array::find_action(size_t index, int64_t value, QueryState<int64_t>* state, Callback callback) const
 {
     return state->match<action, false, Callback>(index, 0, value, callback);
 }
-template <Action action, class Callback> 
+template <Action action, class Callback>
 bool Array::find_action_pattern(size_t index, uint64_t pattern, QueryState<int64_t>* state, Callback callback) const
 {
     return state->match<action, true, Callback>(index, pattern, 0, callback);
@@ -1385,27 +1385,27 @@ template <class cond2, Action action, size_t bitwidth, class Callback> void Arra
 
     // Test first few items with no initial time overhead
     if (start > 0) {
-        if (m_len > start && c(Get<bitwidth>(start), value) && start < end) { 
+        if (m_len > start && c(Get<bitwidth>(start), value) && start < end) {
             if (!find_action<action, Callback>(start + baseindex, Get<bitwidth>(start), state, callback)) return;
         }
 
         ++start;
 
-        if (m_len > start && c(Get<bitwidth>(start), value) && start < end) { 
+        if (m_len > start && c(Get<bitwidth>(start), value) && start < end) {
             if (!find_action<action, Callback>(start + baseindex, Get<bitwidth>(start), state, callback)) return;
-        } 
+        }
 
         ++start;
 
         if (m_len > start && c(Get<bitwidth>(start), value) && start < end) {
             if (!find_action<action, Callback>(start + baseindex, Get<bitwidth>(start), state, callback)) return;
-        } 
+        }
 
         ++start;
 
-        if (m_len > start && c(Get<bitwidth>(start), value) && start < end) { 
+        if (m_len > start && c(Get<bitwidth>(start), value) && start < end) {
             if (!find_action<action, Callback>(start + baseindex, Get<bitwidth>(start), state, callback)) return;
-        } 
+        }
 
         ++start;
     }
@@ -1526,14 +1526,14 @@ template <bool eq, size_t width>size_t Array::FindZero(uint64_t v) const
     size_t start = 0;
     uint64_t hasZeroByte;
     // Warning free way of computing (1ULL << width) - 1
-    uint64_t mask = (width == 64 ? ~0ULL : ((1ULL << (width == 64 ? 0 : width)) - 1ULL)); 
+    uint64_t mask = (width == 64 ? ~0ULL : ((1ULL << (width == 64 ? 0 : width)) - 1ULL));
 
     if (eq == (((v >> (width * start)) & mask) == 0)) {
         return 0;
     }
 
-    // Bisection optimization, speeds up small bitwidths with high match frequency. More partions than 2 do NOT pay 
-    // off because the work done by TestZero() is wasted for the cases where the value exists in first half, but 
+    // Bisection optimization, speeds up small bitwidths with high match frequency. More partions than 2 do NOT pay
+    // off because the work done by TestZero() is wasted for the cases where the value exists in first half, but
     // useful if it exists in last half. Sweet spot turns out to be the widths and partitions below.
     if (width <= 8) {
         hasZeroByte = TestZero<width>(v | 0xffffffff00000000ULL);
@@ -1562,7 +1562,7 @@ template <bool eq, size_t width>size_t Array::FindZero(uint64_t v) const
 
     while (eq == (((v >> (width * start)) & mask) != 0)) {
         // You must only call FindZero() if you are sure that at least 1 item matches
-        TIGHTDB_ASSERT(start <= 8 * sizeof(v)); 
+        TIGHTDB_ASSERT(start <= 8 * sizeof(v));
         start++;
     }
 
@@ -1822,24 +1822,24 @@ template <bool eq, Action action, size_t width, class Callback> inline bool Arra
         return true;
 }
 
-// There exists a couple of find() functions that take more or less template arguments. Always call the one that 
+// There exists a couple of find() functions that take more or less template arguments. Always call the one that
 // takes as most as possible to get best performance.
 
-template <class cond, Action action, size_t bitwidth> 
+template <class cond, Action action, size_t bitwidth>
 void Array::find(int64_t value, size_t start, size_t end, size_t baseindex, QueryState<int64_t>* state) const
 {
     find<cond, action, bitwidth>(value, start, end, baseindex, state, CallbackDummy());
 }
 
-template <class cond, Action action, class Callback> 
-void Array::find(int64_t value, size_t start, size_t end, size_t baseindex, QueryState<int64_t>* state, 
+template <class cond, Action action, class Callback>
+void Array::find(int64_t value, size_t start, size_t end, size_t baseindex, QueryState<int64_t>* state,
                  Callback callback) const
 {
     TIGHTDB_TEMPEX4(find, cond, action, m_width, Callback, (value, start, end, baseindex, state, callback));
 }
 
-template <class cond, Action action, size_t bitwidth, class Callback> 
-void Array::find(int64_t value, size_t start, size_t end, size_t baseindex, QueryState<int64_t>* state, 
+template <class cond, Action action, size_t bitwidth, class Callback>
+void Array::find(int64_t value, size_t start, size_t end, size_t baseindex, QueryState<int64_t>* state,
                  Callback callback) const
 {
 #ifdef TIGHTDB_DEBUG
@@ -1871,8 +1871,8 @@ void Array::find(int64_t value, size_t start, size_t end, size_t baseindex, Quer
 
 }
 
-template <class cond2, Action action, size_t bitwidth, class Callback> 
-int64_t Array::find_reference(int64_t value, size_t start, size_t end, size_t baseindex, QueryState<int64_t>* state, 
+template <class cond2, Action action, size_t bitwidth, class Callback>
+int64_t Array::find_reference(int64_t value, size_t start, size_t end, size_t baseindex, QueryState<int64_t>* state,
                               Callback callback) const
 {
     // Reference implementation of find_optimized for bug testing
@@ -1911,7 +1911,7 @@ int64_t Array::find_reference(int64_t value, size_t start, size_t end, size_t ba
 
 #ifdef TIGHTDB_COMPILER_SSE
 // 'items' is the number of 16-byte SSE chunks. Returns index of packed element relative to first integer of first chunk
-template <class cond2, Action action, size_t width, class Callback> 
+template <class cond2, Action action, size_t width, class Callback>
 bool Array::FindSSE(int64_t value, __m128i *data, size_t items, QueryState<int64_t>* state, size_t baseindex,
                     Callback callback) const
 {
@@ -1930,10 +1930,10 @@ bool Array::FindSSE(int64_t value, __m128i *data, size_t items, QueryState<int64
     return FindSSE_intern<cond2, action, width, Callback>(data, &search, items, state, baseindex, callback);
 }
 
-// Compares packed action_data with packed data (equal, less, etc) and performs aggregate action (max, min, sum, 
+// Compares packed action_data with packed data (equal, less, etc) and performs aggregate action (max, min, sum,
 // find_all, etc) on value inside action_data for first match, if any
-template <class cond2, Action action, size_t width, class Callback> 
-TIGHTDB_FORCEINLINE bool Array::FindSSE_intern(__m128i* action_data, __m128i* data, size_t items, 
+template <class cond2, Action action, size_t width, class Callback>
+TIGHTDB_FORCEINLINE bool Array::FindSSE_intern(__m128i* action_data, __m128i* data, size_t items,
                                                QueryState<int64_t>* state, size_t baseindex, Callback callback) const
 {
     cond2 c;
@@ -2031,7 +2031,7 @@ bool Array::CompareLeafs(Array* foreign, size_t start, size_t end, size_t basein
     }
 
     start++;
-    
+
     if (start + 3 < end) {
         v = Get(start);
         if (c(v, foreign->Get(start)))
@@ -2053,14 +2053,14 @@ bool Array::CompareLeafs(Array* foreign, size_t start, size_t end, size_t basein
     else if (start == end) {
         return true;
     }
- 
+
     bool r;
     TIGHTDB_TEMPEX4(r = CompareLeafs, cond, action, m_width, Callback, (foreign, start, end, baseindex, state, callback))
     return r;
 }
 
 
-template <class cond, Action action, size_t width, class Callback> bool Array::CompareLeafs(Array* foreign, size_t start, size_t end, size_t baseindex, QueryState<int64_t>* state, Callback callback) const 
+template <class cond, Action action, size_t width, class Callback> bool Array::CompareLeafs(Array* foreign, size_t start, size_t end, size_t baseindex, QueryState<int64_t>* state, Callback callback) const
 {
     size_t fw = foreign->m_width;
     bool r;
@@ -2069,12 +2069,12 @@ template <class cond, Action action, size_t width, class Callback> bool Array::C
 }
 
 
-template <class cond, Action action, size_t width, class Callback, size_t foreign_width> 
-bool Array::CompareLeafs4(Array* foreign, size_t start, size_t end, size_t baseindex, QueryState<int64_t>* state, 
+template <class cond, Action action, size_t width, class Callback, size_t foreign_width>
+bool Array::CompareLeafs4(Array* foreign, size_t start, size_t end, size_t baseindex, QueryState<int64_t>* state,
                           Callback callback) const
 {
     cond c;
-    char* foreign_m_data = foreign->m_data;     
+    char* foreign_m_data = foreign->m_data;
 
     if (width == 0 && foreign_width == 0) {
         if (c(0, 0)) {
@@ -2092,8 +2092,8 @@ bool Array::CompareLeafs4(Array* foreign, size_t start, size_t end, size_t basei
 
 #if defined(TIGHTDB_COMPILER_SSE)
     if (cpuid_sse<42>() && width == foreign_width && (width == 8 || width == 16 || width == 32)) {
-        // We can only use SSE if both bitwidths are equal and above 8 bits and all values are signed   
-        while (start < end && (((reinterpret_cast<size_t>(m_data) & 0xf) * 8 + start * width) % (128) != 0)) {            
+        // We can only use SSE if both bitwidths are equal and above 8 bits and all values are signed
+        while (start < end && (((reinterpret_cast<size_t>(m_data) & 0xf) * 8 + start * width) % (128) != 0)) {
             int64_t v = GetUniversal<width>(m_data, start);
             int64_t fv = GetUniversal<foreign_width>(foreign_m_data, start);
             if (c(v, fv)) {
@@ -2103,7 +2103,7 @@ bool Array::CompareLeafs4(Array* foreign, size_t start, size_t end, size_t basei
             start++;
         }
         if (start == end)
-            return true; 
+            return true;
 
 
         size_t sse_items = (end - start) * width / 128;
@@ -2112,7 +2112,7 @@ bool Array::CompareLeafs4(Array* foreign, size_t start, size_t end, size_t basei
         while (start < sse_end) {
             __m128i* a = reinterpret_cast<__m128i*>(m_data + start * width / 8);
             __m128i* b = reinterpret_cast<__m128i*>(foreign_m_data + start * width / 8);
-            
+
             bool continue_search = FindSSE_intern<cond, action, width, Callback>(a, b, 1, state, baseindex + start, callback);
 
             if (!continue_search)
@@ -2120,17 +2120,15 @@ bool Array::CompareLeafs4(Array* foreign, size_t start, size_t end, size_t basei
 
             start += 128 / no0(width);
         }
-        
-
     }
 #endif
-    
+
 
 #if 0 // this method turned out to be 33% slower than a naive loop. Find out why
 
     // index from which both arrays are 64-bit aligned
-    size_t a = round_up(start, 8*sizeof(int64_t) / (width < foreign_width ? width : foreign_width)); 
-    
+    size_t a = round_up(start, 8*sizeof(int64_t) / (width < foreign_width ? width : foreign_width));
+
     while (start < end && start < a) {
         int64_t v = GetUniversal<width>(m_data, start);
         int64_t fv = GetUniversal<foreign_width>(foreign_m_data, start);
@@ -2142,8 +2140,8 @@ bool Array::CompareLeafs4(Array* foreign, size_t start, size_t end, size_t basei
     }
 
     if (start >= end)
-        return r; 
-           
+        return r;
+
     uint64_t chunk;
     uint64_t fchunk;
 
@@ -2214,7 +2212,7 @@ bool Array::CompareLeafs4(Array* foreign, size_t start, size_t end, size_t basei
 
         start += 2;
     }
- */  
+ */
 
     while (start < end) {
         int64_t v = GetUniversal<width>(m_data, start);
@@ -2232,8 +2230,8 @@ bool Array::CompareLeafs4(Array* foreign, size_t start, size_t end, size_t basei
 }
 
 
-template <class cond2, Action action, size_t bitwidth, class Callback> 
-bool Array::Compare(int64_t value, size_t start, size_t end, size_t baseindex, QueryState<int64_t>* state, 
+template <class cond2, Action action, size_t bitwidth, class Callback>
+bool Array::Compare(int64_t value, size_t start, size_t end, size_t baseindex, QueryState<int64_t>* state,
                     Callback callback) const
 {
     cond2 c;
@@ -2254,8 +2252,8 @@ bool Array::Compare(int64_t value, size_t start, size_t end, size_t baseindex, Q
     return ret;
 }
 
-template <bool gt, Action action, size_t bitwidth, class Callback> 
-bool Array::CompareRelation(int64_t value, size_t start, size_t end, size_t baseindex, QueryState<int64_t>* state, 
+template <bool gt, Action action, size_t bitwidth, class Callback>
+bool Array::CompareRelation(int64_t value, size_t start, size_t end, size_t baseindex, QueryState<int64_t>* state,
                             Callback callback) const
 {
     TIGHTDB_ASSERT(start <= m_len && (end <= m_len || end == (size_t)-1) && start <= end);

--- a/src/tightdb/group.hpp
+++ b/src/tightdb/group.hpp
@@ -43,14 +43,20 @@ public:
     Group();
 
     enum OpenMode {
-        mode_Normal,   ///< Open in read/write mode, create the file if it does not already exist.
-        mode_ReadOnly, ///< Open in read-only mode, fail if the file does not already exist.
-        mode_NoCreate  ///< Open in read/write mode, fail if the file does not already exist.
+        /// Open in read-only mode. Fail if the file does not already
+        /// exist.
+        mode_ReadOnly,
+        /// Open in read/write mode. Create the file if it does not
+        /// already exist.
+        mode_ReadWrite,
+        /// Open in read/write mode. Fail if the file does not already
+        /// exist.
+        mode_ReadWriteNoCreate
     };
 
     /// Equivalent to calling open(const std::string&, OpenMode) on a
     /// default constructed instance.
-    explicit Group(const std::string& file, OpenMode = mode_Normal);
+    explicit Group(const std::string& file, OpenMode = mode_ReadOnly);
 
     /// Equivalent to calling open(BinaryData, bool) on a default
     /// constructed instance.
@@ -71,37 +77,72 @@ public:
 
     /// Attach this Group instance to the specified database file.
     ///
-    /// If the specified file exists in the file system, it must
-    /// contain a valid TightDB database. If the file does not exist,
-    /// it will be created (unless mode_NoCreate is specified). While
-    /// a group constructed this way, can be used to access and
-    /// manipulate a TightDB database, it is generally better to use a
-    /// SharedGroup instance along with proper transactions.
+    /// By default, the specified file is opened in read-only mode
+    /// (mode_ReadOnly). This allows opening a file even when the
+    /// caller lacks permission to write to that file. The opened
+    /// group may still be modified freely, but the changes cannot be
+    /// written back to the same file using the commit() function. An
+    /// attempt to do that, will cause an exception to be thrown. When
+    /// opening in read-only mode, it is an error if the specified
+    /// file does not already exist in the file system.
     ///
-    /// Changes made to the database via a Group instance are not
-    /// automatically committed to the specified file. You may,
-    /// however, at any time, explicitely commit your changes by
-    /// calling the commit() method. Alternatively you may call
-    /// write() to write the entire database to a new file. After
-    /// writing the new file, the Group will continue to be associated
-    /// with the file that was specified in the call to open().
+    /// Alternatively, the file can be opened in read/write mode
+    /// (mode_ReadWrite). This allows use of the commit() function,
+    /// but, of course, it also requires that the caller has
+    /// permission to write to the specified file. When opening in
+    /// read-write mode, an attempt to create the specified file will
+    /// be made, if it does not already exist in the file system.
     ///
-    /// A file that is passed to Group::open(), may not be modified
-    /// until after the Group object is destroyed. Behaviour is
-    /// undefined if a file is modified while any Group object is
-    /// associated with it.
+    /// In any case, if the file already exists, it must contain a
+    /// valid TightDB database. In many cases invalidity will be
+    /// detected and cause the InvalidDatabase exception to be thrown,
+    /// but you should not rely on it.
+    ///
+    /// Note that changes made to the database via a Group instance
+    /// are not automatically committed to the specified file. You
+    /// may, however, at any time, explicitly commit your changes by
+    /// calling the commit() method, provided that the specified
+    /// open-mode is not mode_ReadOnly. Alternatively, you may call
+    /// write() to write the entire database to a new file. Writing
+    /// the database to a new file does not end, or in any other way
+    /// change the association between the Group instance and the file
+    /// that was specified in the call to open().
+    ///
+    /// A file that is passed to Group::open(), may not be modified by
+    /// a third party until after the Group object is
+    /// destroyed. Behavior is undefined if a file is modified by a
+    /// third party while any Group object is associated with it.
     ///
     /// Calling open() on a Group instance that is already in the
     /// attached state has undefined behavior.
     ///
-    /// \param file Filesystem path to a TightDB database file.
+    /// Accessing a TightDB database file through manual construction
+    /// of a Group object does not offer any level of thread safety or
+    /// transaction safety. When any of those kinds of safety are a
+    /// concern, consider using a SharedGroup instead. When accessing
+    /// a database file in read/write mode through a manually
+    /// constructed Group object, it is entirely the responsibility of
+    /// the application that the file is not accessed in any way by a
+    /// third party during the life-time of that group object. It is,
+    /// on the other hand, safe to concurrently access a database file
+    /// by multiple manually created Group objects, as long as all of
+    /// them are opened in read-only mode, and there is no other party
+    /// that modifies the file concurrently.
+    ///
+    /// \param file File system path to a TightDB database file.
+    ///
+    /// \param mode Specifying a mode that is not mode_ReadOnly
+    /// requires that the specified file can be opened in read/write
+    /// mode. In general there is no reason to open a group in
+    /// read/write mode unless you want to be able to call
+    /// Group::commit().
     ///
     /// \throw File::AccessError If the file could not be opened. If
     /// the reason corresponds to one of the exception types that are
     /// derived from File::AccessError, the derived exception type is
     /// thrown. Note that InvalidDatabase is among these derived
     /// exception types.
-    void open(const std::string& file, OpenMode = mode_Normal);
+    void open(const std::string& file, OpenMode mode = mode_ReadOnly);
 
     /// Attach this Group instance to the specified memory buffer.
     ///
@@ -179,6 +220,13 @@ public:
     // calling write()? There is no documentation to be found anywhere
     // and it looks like it leaves the group in an invalid state. You
     // should probably not use it.
+    // FIXME: Must throw an exception if the group is opened in
+    // read-only mode. Currently this is impossible because the
+    // information is not stored anywhere. A flag probably needs to be
+    // added to SlabAlloc.
+    // FIXME: It needs to be determined whether or not this method can
+    // leave the Group instance in an invalid state. This issue
+    // strongly affects how high-level language bindings can use it.
     void commit();
 
     // Conversion
@@ -214,7 +262,7 @@ protected:
     void invalidate();
     bool in_initial_state() const;
     void init_shared();
-    size_t commit(size_t current_version, size_t readlock_version, bool doPersist);
+    size_t commit(size_t current_version, size_t readlock_version, bool persist);
     void rollback();
 
     SlabAlloc& get_allocator() {return m_alloc;}

--- a/src/tightdb/group_shared.cpp
+++ b/src/tightdb/group_shared.cpp
@@ -152,7 +152,7 @@ retry:
             // but we invalidate the internals right after to avoid conflicting
             // with old state when starting transactions
             const Group::OpenMode group_open_mode =
-                no_create_file ? Group::mode_NoCreate : Group::mode_Normal;
+                no_create_file ? Group::mode_ReadWriteNoCreate : Group::mode_ReadWrite;
             m_group.create_from_file(file, group_open_mode, true);
             m_group.invalidate();
 
@@ -199,7 +199,7 @@ retry:
                 throw runtime_error("Inconsistent durability level");
 
             // Setup the group, but leave it in invalid state
-            m_group.create_from_file(file, Group::mode_NoCreate, false);
+            m_group.create_from_file(file, Group::mode_ReadWriteNoCreate, false);
         }
 
         // We need to map the info file once more for the readers part

--- a/src/tightdb/group_writer.cpp
+++ b/src/tightdb/group_writer.cpp
@@ -21,7 +21,7 @@ void GroupWriter::SetVersions(size_t current, size_t readlock)
     m_readlock_version = readlock;
 }
 
-size_t GroupWriter::Commit()
+size_t GroupWriter::commit()
 {
     merge_free_space();
 

--- a/src/tightdb/group_writer.hpp
+++ b/src/tightdb/group_writer.hpp
@@ -37,7 +37,7 @@ public:
 
     void SetVersions(std::size_t current, std::size_t readlock);
 
-    std::size_t Commit();
+    std::size_t commit();
 
     size_t write(const char* p, std::size_t n);
     void WriteAt(std::size_t pos, const char* p, std::size_t n);

--- a/test/testgroup.cpp
+++ b/test/testgroup.cpp
@@ -397,7 +397,7 @@ TEST(Group_Persist)
     File::try_remove("testdb.tightdb");
 
     // Create new database
-    Group db("testdb.tightdb");
+    Group db("testdb.tightdb", Group::mode_ReadWrite);
 
     // Insert some data
     TableRef table = db.get_table("test");


### PR DESCRIPTION
- The default group open mode has been changed from Group::mode_Normal (read/write) to Group::mode_ReadOnly. This makes it possible to open a read-only file without specifying a special open mode. Also, since changed groups are generally written to new files, there is rarely a need for the group to be opened in read/write mode.
- Group::mode_Normal has been renamed to Group::mode_ReadWrite since it is no longer a normal mode.
- Group::mode_NoCreate has been renamed to Group::mode_ReadWriteNoCreate for clarity.

These changes are partially motivated by https://app.asana.com/0/864677753636/6157840487516.
