### PR TITLE
Improved and cleaned up SharedGroup::ringbuf_expand()

### DIFF
--- a/src/tightdb/group_shared.cpp
+++ b/src/tightdb/group_shared.cpp
@@ -612,7 +612,7 @@ void SharedGroup::ringbuf_expand()
     // than the size of the containing linear buffer.
     //
     // FIXME: It is no good that we convert back and forth between
-    // uint32_t and size_t, because that defetas the purpose of this
+    // uint32_t and size_t, because that defeats the purpose of this
     // check.
     if (old_buffer_size > (numeric_limits<size_t>::max() -
                            base_file_size) / (2 * sizeof (ReadCount)))


### PR DESCRIPTION
It had two problems: It was hard to read, and it had unused code.

\cc @astigsen
