### PR TITLE
Probably race causes default header to not always be present in new files

### DIFF
--- a/src/tightdb/alloc_slab.cpp
+++ b/src/tightdb/alloc_slab.cpp
@@ -37,7 +37,8 @@ const char SlabAlloc::default_header[24] = {
     0,   0,   0,   0,   0,   0,   0,   0,
     0,   0,   0,   0,   0,   0,   0,   0,
     'T', '-', 'D', 'B',
-    current_file_format_version, 0, 0, 0
+    current_file_format_version,
+    current_file_format_version, 0, 0
 };
 
 void SlabAlloc::detach() TIGHTDB_NOEXCEPT


### PR DESCRIPTION
~~**NOT FIXED!**~~
**INVALID**

Exposed by

test_shared.cpp:194: Begin Shared1
test_shared.cpp:710: Begin Shared_WriterThreads

@finnschiermer 
