### PR TITLE
Attempt at workaround for clang 3.0 3.1 bug

### DIFF
--- a/src/tightdb/table_ref.hpp
+++ b/src/tightdb/table_ref.hpp
@@ -115,7 +115,14 @@ public:
 #ifdef TIGHTDB_HAVE_CXX11_EXPLICIT_CONV_OPERATORS
     using bind_ptr<T>::operator bool;
 #else
+#  ifdef __clang__
+    // Clang 3.0 and 3.1 has a bug that causes it to effectively
+    // ignore the 'using' declaration.
+    typedef typename bind_ptr<T>::unspecified_bool_type unspecified_bool_type;
+    operator unspecified_bool_type() const TIGHTDB_NOEXCEPT { return bind_ptr<T>::operator unspecified_bool_type(); }
+#  else
     using bind_ptr<T>::operator typename bind_ptr<T>::unspecified_bool_type;
+#  endif
 #endif
 
     void reset() TIGHTDB_NOEXCEPT { bind_ptr<T>::reset(); }


### PR DESCRIPTION
Alexander, could you try this?

Finn, could you also try this on the office Mac?

As far as I understand, the office Mac with its Clang 3.1 suffered from the same problem as Alexanders Clang 3.0.

Note that I did this blind-folded as I have no access to Clang 3.0 or 3.1. I have checked it in Clang 3.2, but Clang 3.2 did not have the problem in the first place.

@astigsen @finnschiermer 
