### PR TITLE
handle signals in relation to waitpid

### DIFF
--- a/src/tightdb/group_shared.cpp
+++ b/src/tightdb/group_shared.cpp
@@ -161,10 +161,10 @@ void spawn_daemon(const string& file)
         
         // use childs exit code to catch and report any errors:
         int status;
-	int pid_changed;
-	do {
-	    pid_changed = waitpid(pid, &status, 0);
-	} while (pid_changed == -1 && errno == EINTR);
+        int pid_changed;
+        do {
+            pid_changed = waitpid(pid, &status, 0);
+        } while (pid_changed == -1 && errno == EINTR);
         if (pid_changed != pid)
             throw runtime_error("failed to wait for daemon start");
         if (!WIFEXITED(status))


### PR DESCRIPTION
Handle the situation where a waitpid call is interrupted by a signal.
(this always happens when run from inside xcode, but it must be handled on all systems)
