### PR TITLE
removed destruction of mutexes

### DIFF
--- a/src/tightdb/group_shared.cpp
+++ b/src/tightdb/group_shared.cpp
@@ -418,7 +418,7 @@ SharedGroup::~SharedGroup() TIGHTDB_NOEXCEPT
         catch(...) { } // ignored on purpose
     }
 
-    info->~SharedInfo(); // Call destructor
+    // info->~SharedInfo(); // DO NOT Call destructor
     m_file.close();
     m_file_map.unmap();
     m_reader_map.unmap();
@@ -534,7 +534,7 @@ void SharedGroup::do_async_commits()
         if (shutdown) {
             // Being the backend process, we own the lock file, so we
             // have to clean up when we shut down.
-            info->~SharedInfo(); // Call destructor
+            // info->~SharedInfo(); // DO NOT Call destructor
             m_file_map.unmap();
 #ifdef TIGHTDB_ENABLE_LOGFILE
             cerr << "Removing coordination file" << endl;


### PR DESCRIPTION
This change prevents the following scenario:
a user crashes right after destroying the mutexes in sharedinfo.
unfortunately the changes are not propagated to the underlying .lock file.
This could leave an otherwise valid logfile pointing to the already destroyed mutexes.
A later use of groupshared may reuse the logfile, then once more destroy the mutexes.
