### PR TITLE
Updated string_index to use new btree structure

### DIFF
--- a/src/tightdb/array.cpp
+++ b/src/tightdb/array.cpp
@@ -2588,7 +2588,6 @@ top:
     for (;;) {
         // Get subnode table
         ref_type offsets_ref = to_ref(get_direct(data, width, 0));
-        ref_type refs_ref    = to_ref(get_direct(data, width, 1));
 
         // Find the position matching the key
         const char* offsets_header = m_alloc.translate(offsets_ref);
@@ -2601,10 +2600,8 @@ top:
             return not_found;
 
         // Get entry under key
-        const char* refs_header = m_alloc.translate(refs_ref);
-        const char* refs_data = get_data_from_header(refs_header);
-        size_t refs_width  = get_width_from_header(refs_header);
-        int64_t ref = get_direct(refs_data, refs_width, pos);
+        size_t pos_refs = pos + 1; // first entry in refs points to offsets
+        int64_t ref = get_direct(data, width, pos_refs);
 
         if (!is_leaf) {
             // Set vars for next iteration
@@ -2640,9 +2637,9 @@ top:
 
         // List of matching row indexes
         if (!sub_isindex) {
-            const char* sub_data = get_data_from_header(sub_header);
+            const char*  sub_data   = get_data_from_header(sub_header);
             const size_t sub_width  = get_width_from_header(sub_header);
-            const bool sub_isleaf = get_isleaf_from_header(sub_header);
+            const bool   sub_isleaf = get_isleaf_from_header(sub_header);
 
             // In most cases the row list will just be an array but
             // there might be so many matches that it has branched
@@ -2670,7 +2667,7 @@ top:
         }
 
         // Recurse into sub-index;
-        header  = m_alloc.translate(to_ref(ref)); // FIXME: This is wastefull since sub_header already contains this result
+        header  = sub_header;
         data    = get_data_from_header(header);
         width   = get_width_from_header(header);
         is_leaf = get_isleaf_from_header(header);
@@ -2702,7 +2699,6 @@ top:
     for (;;) {
         // Get subnode table
         ref_type offsets_ref = to_ref(get_direct(data, width, 0));
-        ref_type refs_ref    = to_ref(get_direct(data, width, 1));
 
         // Find the position matching the key
         const char* offsets_header = m_alloc.translate(offsets_ref);
@@ -2715,10 +2711,8 @@ top:
             return; // not_found
 
         // Get entry under key
-        const char* refs_header = m_alloc.translate(refs_ref);
-        const char* refs_data = get_data_from_header(refs_header);
-        size_t refs_width  = get_width_from_header(refs_header);
-        int64_t ref = get_direct(refs_data, refs_width, pos);
+        size_t pos_refs = pos + 1; // first entry in refs points to offsets
+        int64_t ref = get_direct(data, width, pos_refs);
 
         if (!is_leaf) {
             // Set vars for next iteration
@@ -2805,7 +2799,7 @@ top:
         }
 
         // Recurse into sub-index;
-        header  = m_alloc.translate(to_ref(ref)); // FIXME: This is wastefull since sub_header already contains this result
+        header  = sub_header;
         data    = get_data_from_header(header);
         width   = get_width_from_header(header);
         is_leaf = get_isleaf_from_header(header);
@@ -2837,7 +2831,6 @@ top:
     for (;;) {
         // Get subnode table
         ref_type offsets_ref = to_ref(get_direct(data, width, 0));
-        ref_type refs_ref    = to_ref(get_direct(data, width, 1));
 
         // Find the position matching the key
         const char* offsets_header = m_alloc.translate(offsets_ref);
@@ -2850,10 +2843,8 @@ top:
             return FindRes_not_found;
 
         // Get entry under key
-        const char* refs_header = m_alloc.translate(refs_ref);
-        const char* refs_data   = get_data_from_header(refs_header);
-        size_t refs_width  = get_width_from_header(refs_header);
-        int64_t ref = get_direct(refs_data, refs_width, pos);
+        size_t pos_refs = pos + 1; // first entry in refs points to offsets
+        int64_t ref = get_direct(data, width, pos_refs);
 
         if (!is_leaf) {
             // Set vars for next iteration
@@ -2929,7 +2920,7 @@ top:
         }
 
         // Recurse into sub-index;
-        header  = m_alloc.translate(to_ref(ref)); // FIXME: This is wastefull since sub_header already contains this result
+        header  = sub_header;
         data    = get_data_from_header(header);
         width   = get_width_from_header(header);
         is_leaf = get_isleaf_from_header(header);
@@ -2962,7 +2953,6 @@ top:
     for (;;) {
         // Get subnode table
         ref_type offsets_ref = to_ref(get_direct(data, width, 0));
-        ref_type refs_ref    = to_ref(get_direct(data, width, 1));
 
         // Find the position matching the key
         const char* offsets_header = m_alloc.translate(offsets_ref);
@@ -2975,10 +2965,8 @@ top:
             return 0;
 
         // Get entry under key
-        const char* refs_header = m_alloc.translate(refs_ref);
-        const char* refs_data = get_data_from_header(refs_header);
-        size_t refs_width  = get_width_from_header(refs_header);
-        int64_t ref = get_direct(refs_data, refs_width, pos);
+        size_t pos_refs = pos + 1; // first entry in refs points to offsets
+        int64_t ref = get_direct(data, width, pos_refs);
 
         if (!is_leaf) {
             // Set vars for next iteration
@@ -3054,7 +3042,7 @@ top:
         }
 
         // Recurse into sub-index;
-        header  = m_alloc.translate(to_ref(ref)); // FIXME: This is wastefull since sub_header already contains this result
+        header  = sub_header;
         data    = get_data_from_header(header);
         width   = get_width_from_header(header);
         is_leaf = get_isleaf_from_header(header);

--- a/src/tightdb/array.hpp
+++ b/src/tightdb/array.hpp
@@ -847,6 +847,7 @@ public:
         ~ToDotHandler() {}
     };
     void bptree_to_dot(std::ostream&, ToDotHandler&) const;
+    void to_dot_parent_edge(std::ostream&) const;
 #endif
 
 protected:
@@ -966,7 +967,6 @@ protected:
     void destroy_children() TIGHTDB_NOEXCEPT;
 
 #ifdef TIGHTDB_DEBUG
-    void to_dot_parent_edge(std::ostream&) const;
     std::pair<ref_type, std::size_t>
     get_to_dot_parent(std::size_t ndx_in_parent) const TIGHTDB_OVERRIDE;
 #endif
@@ -1954,7 +1954,7 @@ ref_type Array::bptree_insert(std::size_t elem_ndx, TreeInsert<TreeTraits>& stat
         elem_ndx_in_child = 0;
     }
     else {
-        // There is a choise to be made when the element is to be
+        // There is a choice to be made when the element is to be
         // inserted between two subtrees. It can either be appended to
         // the first subtree, or it can be prepended to the second
         // one. We currently always append to the first subtree. It is

--- a/src/tightdb/index_string.cpp
+++ b/src/tightdb/index_string.cpp
@@ -30,11 +30,8 @@ Array* StringIndex::create_node(Allocator& alloc, bool is_leaf)
     // Add subcolumns for leafs
     Array values(Array::type_Normal, 0, 0, alloc);
     values.ensure_minimum_width(0x7FFFFFFF); // This ensures 31 bits plus a sign bit
-    Array refs(Array::type_HasRefs, 0, 1, alloc);
-    top->add(values.get_ref());
-    top->add(refs.get_ref());
+    top->add(values.get_ref()); // first entry in refs points to offsets
     values.set_parent(top.get(), 0);
-    refs.set_parent(top.get(), 1);
 
     return top.release();
 }
@@ -85,15 +82,15 @@ void StringIndex::InsertRowList(size_t ref, size_t offset, StringData value)
 
     // Get subnode table
     Allocator& alloc = m_array->get_alloc();
-    Array values(alloc), refs(alloc);
+    Array values(alloc);
     get_child(*m_array, 0, values);
-    get_child(*m_array, 1, refs);
+    TIGHTDB_ASSERT(m_array->size() == values.size()+1);
 
     size_t ins_pos = values.lower_bound_int(key);
     if (ins_pos == values.size()) {
         // When key is outside current range, we can just add it
         values.add(key);
-        refs.add(ref);
+        m_array->add(ref);
         return;
     }
 
@@ -106,7 +103,7 @@ void StringIndex::InsertRowList(size_t ref, size_t offset, StringData value)
 
     // If key is not present we add it at the correct location
     values.insert(ins_pos, key);
-    refs.insert(ins_pos, ref);
+    m_array->insert(ins_pos+1, ref);
 }
 
 void StringIndex::TreeInsert(size_t row_ndx, key_type key, size_t offset, StringData value)
@@ -148,9 +145,9 @@ StringIndex::NodeChange StringIndex::DoInsert(size_t row_ndx, key_type key, size
     Allocator& alloc = m_array->get_alloc();
     if (!root_is_leaf()) {
         // Get subnode table
-        Array offsets(alloc), refs(alloc);
+        Array offsets(alloc);
         get_child(*m_array, 0, offsets);
-        get_child(*m_array, 1, refs);
+        TIGHTDB_ASSERT(m_array->size() == offsets.size()+1);
 
         // Find the subnode containing the item
         size_t node_ndx = offsets.lower_bound_int(key);
@@ -160,8 +157,9 @@ StringIndex::NodeChange StringIndex::DoInsert(size_t row_ndx, key_type key, size
         }
 
         // Get sublist
-        ref_type ref = refs.get_as_ref(node_ndx);
-        StringIndex target(ref, &refs, node_ndx, m_target_column, m_get_func, alloc);
+        size_t refs_ndx = node_ndx+1; // first entry in refs points to offsets
+        ref_type ref = m_array->get_as_ref(refs_ndx);
+        StringIndex target(ref, m_array, refs_ndx, m_target_column, m_get_func, alloc);
 
         // Insert item
         const NodeChange nc = target.DoInsert(row_ndx, key, offset, value);
@@ -172,7 +170,10 @@ StringIndex::NodeChange StringIndex::DoInsert(size_t row_ndx, key_type key, size
             return NodeChange::none; // no new nodes
         }
 
-        if (nc.type == NodeChange::insert_after) ++node_ndx;
+        if (nc.type == NodeChange::insert_after) {
+            ++node_ndx;
+            ++refs_ndx;
+        }
 
         // If there is room, just update node directly
         if (offsets.size() < TIGHTDB_MAX_LIST_SIZE) {
@@ -190,6 +191,7 @@ StringIndex::NodeChange StringIndex::DoInsert(size_t row_ndx, key_type key, size
 
             new_node.NodeAddKey(nc.ref2);
             ++node_ndx;
+            ++refs_ndx;
         }
         else {
             new_node.NodeAddKey(nc.ref1);
@@ -204,13 +206,13 @@ StringIndex::NodeChange StringIndex::DoInsert(size_t row_ndx, key_type key, size
                 else return NodeChange(NodeChange::insert_after, new_node.get_ref());
             default:            // split
                 // Move items after split to new node
-                size_t len = refs.size();
-                for (size_t i = node_ndx; i < len; ++i) {
-                    ref_type ref = refs.get_as_ref(i);
+                size_t len = m_array->size();
+                for (size_t i = refs_ndx; i < len; ++i) {
+                    ref_type ref = m_array->get_as_ref(i);
                     new_node.NodeAddKey(ref);
                 }
                 offsets.resize(node_ndx);
-                refs.resize(node_ndx);
+                m_array->resize(refs_ndx);
                 return NodeChange(NodeChange::split, get_ref(), new_node.get_ref());
         }
     }
@@ -218,6 +220,8 @@ StringIndex::NodeChange StringIndex::DoInsert(size_t row_ndx, key_type key, size
         // Is there room in the list?
         Array old_offsets(m_array->get_alloc());
         get_child(*m_array, 0, old_offsets);
+        TIGHTDB_ASSERT(m_array->size() == old_offsets.size()+1);
+
         size_t count = old_offsets.size();
         bool noextend = count >= TIGHTDB_MAX_LIST_SIZE;
 
@@ -244,22 +248,18 @@ StringIndex::NodeChange StringIndex::DoInsert(size_t row_ndx, key_type key, size
         }
 
         // split
-        Array old_refs(alloc);
         Array new_offsets(alloc);
-        Array new_refs(alloc);
-        get_child(*m_array, 1, old_refs);
         get_child(*new_list.m_array, 0, new_offsets);
-        get_child(*new_list.m_array, 1, new_refs);
         // Move items after split to new list
         for (size_t i = ndx; i < count; ++i) {
             int64_t v2 = old_offsets.get(i);
-            int64_t v3 = old_refs.get(i);
+            int64_t v3 = m_array->get(i+1);
 
             new_offsets.add(v2);
-            new_refs.add(v3);
+            new_list.m_array->add(v3);
         }
         old_offsets.resize(ndx);
-        old_refs.resize(ndx);
+        m_array->resize(ndx+1);
 
         return NodeChange(NodeChange::split, get_ref(), new_list.get_ref());
     }
@@ -274,16 +274,17 @@ void StringIndex::NodeInsertSplit(size_t ndx, size_t new_ref)
     TIGHTDB_ASSERT(new_ref);
 
     Allocator& alloc = m_array->get_alloc();
-    Array offsets(alloc), refs(alloc);
+    Array offsets(alloc);
     get_child(*m_array, 0, offsets);
-    get_child(*m_array, 1, refs);
 
+    TIGHTDB_ASSERT(m_array->size() == offsets.size()+1);
     TIGHTDB_ASSERT(ndx < offsets.size());
     TIGHTDB_ASSERT(offsets.size() < TIGHTDB_MAX_LIST_SIZE);
 
     // Get sublists
-    ref_type orig_ref = refs.get_as_ref(ndx);
-    StringIndex orig_col(orig_ref, &refs, ndx, m_target_column, m_get_func, alloc);
+    size_t refs_ndx = ndx+1; // first entry in refs points to offsets
+    ref_type orig_ref = m_array->get_as_ref(refs_ndx);
+    StringIndex orig_col(orig_ref, m_array, refs_ndx, m_target_column, m_get_func, alloc);
     StringIndex new_col(new_ref, 0, 0, m_target_column, m_get_func, alloc);
 
     // Update original key
@@ -293,7 +294,7 @@ void StringIndex::NodeInsertSplit(size_t ndx, size_t new_ref)
     // Insert new ref
     key_type new_key = new_col.GetLastKey();
     offsets.insert(ndx+1, new_key);
-    refs.insert(ndx+1, new_ref);
+    m_array->insert(ndx+2, new_ref);
 }
 
 void StringIndex::NodeInsert(size_t ndx, size_t ref)
@@ -302,9 +303,9 @@ void StringIndex::NodeInsert(size_t ndx, size_t ref)
     TIGHTDB_ASSERT(!root_is_leaf());
 
     Allocator& alloc = m_array->get_alloc();
-    Array offsets(alloc), refs(alloc);
+    Array offsets(alloc);
     get_child(*m_array, 0, offsets);
-    get_child(*m_array, 1, refs);
+    TIGHTDB_ASSERT(m_array->size() == offsets.size()+1);
 
     TIGHTDB_ASSERT(ndx <= offsets.size());
     TIGHTDB_ASSERT(offsets.size() < TIGHTDB_MAX_LIST_SIZE);
@@ -313,7 +314,7 @@ void StringIndex::NodeInsert(size_t ndx, size_t ref)
     key_type last_key = col.GetLastKey();
 
     offsets.insert(ndx, last_key);
-    refs.insert(ndx, ref);
+    m_array->insert(ndx+1, ref);
 }
 
 bool StringIndex::LeafInsert(size_t row_ndx, key_type key, size_t offset, StringData value, bool noextend)
@@ -322,18 +323,19 @@ bool StringIndex::LeafInsert(size_t row_ndx, key_type key, size_t offset, String
 
     // Get subnode table
     Allocator& alloc = m_array->get_alloc();
-    Array values(alloc), refs(alloc);
+    Array values(alloc);
     get_child(*m_array, 0, values);
-    get_child(*m_array, 1, refs);
+    TIGHTDB_ASSERT(m_array->size() == values.size()+1);
 
     size_t ins_pos = values.lower_bound_int(key);
+    size_t ins_pos_refs = ins_pos + 1; // first entry in refs points to offsets
     if (ins_pos == values.size()) {
         if (noextend) return false;
 
         // When key is outside current range, we can just add it
         values.add(key);
         int64_t shifted = int64_t((uint64_t(row_ndx) << 1) + 1); // shift to indicate literal
-        refs.add(shifted);
+        m_array->add(shifted);
         return true;
     }
 
@@ -345,11 +347,11 @@ bool StringIndex::LeafInsert(size_t row_ndx, key_type key, size_t offset, String
 
         values.insert(ins_pos, key);
         int64_t shifted = int64_t((uint64_t(row_ndx) << 1) + 1); // shift to indicate literal
-        refs.insert(ins_pos, shifted);
+        m_array->insert(ins_pos_refs, shifted);
         return true;
     }
 
-    int64_t ref = refs.get(ins_pos);
+    int64_t ref = m_array->get(ins_pos+1);
     size_t sub_offset = offset + 4;
 
     // Single match (lowest bit set indicates literal row_ndx)
@@ -361,14 +363,14 @@ bool StringIndex::LeafInsert(size_t row_ndx, key_type key, size_t offset, String
             Array row_list(Array::type_Normal, 0, 0, alloc);
             row_list.add(row_ndx < row_ndx2 ? row_ndx : row_ndx2);
             row_list.add(row_ndx < row_ndx2 ? row_ndx2 : row_ndx);
-            refs.set(ins_pos, row_list.get_ref());
+            m_array->set(ins_pos_refs, row_list.get_ref());
         }
         else {
             // convert to sub-index
             StringIndex sub_index(m_target_column, m_get_func, m_array->get_alloc());
             sub_index.InsertWithOffset(row_ndx2, sub_offset, v2);
             sub_index.InsertWithOffset(row_ndx, sub_offset, value);
-            refs.set(ins_pos, sub_index.get_ref());
+            m_array->set(ins_pos_refs, sub_index.get_ref());
         }
         return true;
     }
@@ -376,7 +378,7 @@ bool StringIndex::LeafInsert(size_t row_ndx, key_type key, size_t offset, String
     // If there alrady is a list of matches, we see if we fit there
     // or it has to be split into a sub-index
     if (!Array::is_index_node(to_ref(ref), alloc)) {
-        Column sub(to_ref(ref), &refs, ins_pos, alloc);
+        Column sub(to_ref(ref), m_array, ins_pos_refs, alloc);
 
         size_t r1 = size_t(sub.get(0));
         StringData v2 = get(r1);
@@ -399,13 +401,13 @@ bool StringIndex::LeafInsert(size_t row_ndx, key_type key, size_t offset, String
             StringIndex sub_index(m_target_column, m_get_func, m_array->get_alloc());
             sub_index.InsertRowList(sub.get_ref(), sub_offset, v2);
             sub_index.InsertWithOffset(row_ndx, sub_offset, value);
-            refs.set(ins_pos, sub_index.get_ref());
+            m_array->set(ins_pos_refs, sub_index.get_ref());
         }
         return true;
     }
 
     // sub-index
-    StringIndex sub_index(to_ref(ref), &refs, ins_pos, m_target_column, m_get_func, alloc);
+    StringIndex sub_index(to_ref(ref), m_array, ins_pos_refs, m_target_column, m_get_func, alloc);
     sub_index.InsertWithOffset(row_ndx, sub_offset, value);
 
     return true;
@@ -440,21 +442,19 @@ size_t StringIndex::count(StringData value) const
 void StringIndex::distinct(Array& result) const
 {
     Allocator& alloc = m_array->get_alloc();
-    Array refs(alloc);
-    get_child(*m_array, 1, refs);
-    const size_t count = refs.size();
+    const size_t count = m_array->size();
 
     // Get first matching row for every key
     if (!m_array->is_leaf()) {
-        for (size_t i = 0; i < count; ++i) {
-            size_t ref = refs.get_as_ref(i);
+        for (size_t i = 1; i < count; ++i) {
+            size_t ref = m_array->get_as_ref(i);
             const StringIndex ndx(ref, 0, 0, m_target_column, m_get_func, alloc);
             ndx.distinct(result);
         }
     }
     else {
-        for (size_t i = 0; i < count; ++i) {
-            int64_t ref = refs.get(i);
+        for (size_t i = 1; i < count; ++i) {
+            int64_t ref = m_array->get(i);
 
             // low bit set indicate literal ref (shifted)
             if (ref & 1) {
@@ -464,11 +464,11 @@ void StringIndex::distinct(Array& result) const
             else {
                 // A real ref either points to a list or a sub-index
                 if (Array::is_index_node(to_ref(ref), alloc)) {
-                    const StringIndex ndx(to_ref(ref), &refs, i, m_target_column, m_get_func, alloc);
+                    const StringIndex ndx(to_ref(ref), m_array, i, m_target_column, m_get_func, alloc);
                     ndx.distinct(result);
                 }
                 else {
-                    const Column sub(to_ref(ref), &refs, i, alloc);
+                    const Column sub(to_ref(ref), m_array, i, alloc);
                     const size_t r = to_size_t(sub.get(0)); // get first match
                     result.add(r);
                 }
@@ -482,38 +482,35 @@ void StringIndex::UpdateRefs(size_t pos, int diff)
     TIGHTDB_ASSERT(diff == 1 || diff == -1); // only used by insert and delete
 
     Allocator& alloc = m_array->get_alloc();
-    Array refs(alloc);
-    get_child(*m_array, 1, refs);
-    const size_t count = refs.size();
+    const size_t count = m_array->size();
 
     if (!m_array->is_leaf()) {
-        for (size_t i = 0; i < count; ++i) {
-            size_t ref = refs.get_as_ref(i);
-            StringIndex ndx(ref, &refs, i, m_target_column, m_get_func, alloc);
+        for (size_t i = 1; i < count; ++i) {
+            size_t ref = m_array->get_as_ref(i);
+            StringIndex ndx(ref, m_array, i, m_target_column, m_get_func, alloc);
             ndx.UpdateRefs(pos, diff);
         }
     }
     else {
-        for (size_t i = 0; i < count; ++i) {
-            int64_t ref = refs.get(i);
+        for (size_t i = 1; i < count; ++i) {
+            int64_t ref = m_array->get(i);
 
             // low bit set indicate literal ref (shifted)
             if (ref & 1) {
-                //const size_t r = (ref >> 1); Please NEVER right shift signed values - result varies btw Intel/AMD
                 size_t r = size_t(uint64_t(ref) >> 1);
                 if (r >= pos) {
                     size_t adjusted_ref = ((r + diff) << 1)+1;
-                    refs.set(i, adjusted_ref);
+                    m_array->set(i, adjusted_ref);
                 }
             }
             else {
                 // A real ref either points to a list or a sub-index
                 if (Array::is_index_node(to_ref(ref), alloc)) {
-                    StringIndex ndx(to_ref(ref), &refs, i, m_target_column, m_get_func, alloc);
+                    StringIndex ndx(to_ref(ref), m_array, i, m_target_column, m_get_func, alloc);
                     ndx.UpdateRefs(pos, diff);
                 }
                 else {
-                    Column sub(to_ref(ref), &refs, i, alloc);
+                    Column sub(to_ref(ref), m_array, i, alloc);
                     sub.adjust_ge(pos, diff);
                 }
             }
@@ -524,12 +521,16 @@ void StringIndex::UpdateRefs(size_t pos, int diff)
 void StringIndex::clear()
 {
     Array values(m_array->get_alloc());
-    Array refs(m_array->get_alloc());
     get_child(*m_array, 0, values);
-    get_child(*m_array, 1, refs);
+    TIGHTDB_ASSERT(m_array->size() == values.size()+1);
+
     values.clear();
-    refs.clear();
     values.ensure_minimum_width(0x7FFFFFFF); // This ensures 31 bits plus a sign bit
+
+    m_array->set(0, 1); // Don't delete values
+    m_array->clear();
+    m_array->add(values.get_ref());
+    m_array->set_type(Array::type_HasRefs);
 }
 
 void StringIndex::erase(size_t row_ndx, StringData value, bool is_last)
@@ -538,14 +539,12 @@ void StringIndex::erase(size_t row_ndx, StringData value, bool is_last)
 
     // Collapse top nodes with single item
     while (!root_is_leaf()) {
-        Array refs(m_array->get_alloc());
-        get_child(*m_array, 1, refs);
-        TIGHTDB_ASSERT(refs.size() != 0); // node cannot be empty
-        if (refs.size() > 1)
+        TIGHTDB_ASSERT(m_array->size() > 1); // node cannot be empty
+        if (m_array->size() > 2)
             break;
 
-        ref_type ref = refs.get_as_ref(0);
-        refs.erase(0); // avoid deleting subtree
+        ref_type ref = m_array->get_as_ref(1);
+        m_array->erase(1); // avoid deleting subtree
         m_array->destroy();
         m_array->init_from_ref(ref);
         m_array->update_parent();
@@ -559,25 +558,26 @@ void StringIndex::erase(size_t row_ndx, StringData value, bool is_last)
 void StringIndex::DoDelete(size_t row_ndx, StringData value, size_t offset)
 {
     Allocator& alloc = m_array->get_alloc();
-    Array values(alloc), refs(alloc);
+    Array values(alloc);
     get_child(*m_array, 0, values);
-    get_child(*m_array, 1, refs);
+    TIGHTDB_ASSERT(m_array->size() == values.size()+1);
 
     // Create 4 byte index key
     key_type key = create_key(value.substr(offset));
 
     const size_t pos = values.lower_bound_int(key);
+    const size_t pos_refs = pos + 1; // first entry in refs points to offsets
     TIGHTDB_ASSERT(pos != values.size());
 
     if (!m_array->is_leaf()) {
-        ref_type ref = refs.get_as_ref(pos);
-        StringIndex node(ref, &refs, pos, m_target_column, m_get_func, alloc);
+        ref_type ref = m_array->get_as_ref(pos_refs);
+        StringIndex node(ref, m_array, pos_refs, m_target_column, m_get_func, alloc);
         node.DoDelete(row_ndx, value, offset);
 
         // Update the ref
         if (node.is_empty()) {
             values.erase(pos);
-            refs.erase(pos);
+            m_array->erase(pos_refs);
             node.destroy();
         }
         else {
@@ -587,26 +587,26 @@ void StringIndex::DoDelete(size_t row_ndx, StringData value, size_t offset)
         }
     }
     else {
-        int64_t ref = refs.get(pos);
+        int64_t ref = m_array->get(pos_refs);
         if (ref & 1) {
             TIGHTDB_ASSERT((uint64_t(ref) >> 1) == uint64_t(row_ndx));
             values.erase(pos);
-            refs.erase(pos);
+            m_array->erase(pos_refs);
         }
         else {
             // A real ref either points to a list or a sub-index
             if (Array::is_index_node(to_ref(ref), alloc)) {
-                StringIndex subNdx(to_ref(ref), &refs, pos, m_target_column, m_get_func, alloc);
+                StringIndex subNdx(to_ref(ref), m_array, pos_refs, m_target_column, m_get_func, alloc);
                 subNdx.DoDelete(row_ndx, value, offset+4);
 
                 if (subNdx.is_empty()) {
                     values.erase(pos);
-                    refs.erase(pos);
+                    m_array->erase(pos_refs);
                     subNdx.destroy();
                 }
             }
             else {
-                Column sub(to_ref(ref), &refs, pos, alloc);
+                Column sub(to_ref(ref), m_array, pos_refs, alloc);
                 size_t r = sub.find_first(row_ndx);
                 TIGHTDB_ASSERT(r != not_found);
                 bool is_last = r == sub.size() - 1;
@@ -614,7 +614,7 @@ void StringIndex::DoDelete(size_t row_ndx, StringData value, size_t offset)
 
                 if (sub.size() == 0) {
                     values.erase(pos);
-                    refs.erase(pos);
+                    m_array->erase(pos_refs);
                     sub.destroy();
                 }
             }
@@ -630,36 +630,37 @@ void StringIndex::update_ref(StringData value, size_t old_row_ndx, size_t new_ro
 void StringIndex::do_update_ref(StringData value, size_t row_ndx, size_t new_row_ndx, size_t offset)
 {
     Allocator& alloc = m_array->get_alloc();
-    Array values(alloc), refs(alloc);
+    Array values(alloc);
     get_child(*m_array, 0, values);
-    get_child(*m_array, 1, refs);
+    TIGHTDB_ASSERT(m_array->size() == values.size()+1);
 
     // Create 4 byte index key
     key_type key = create_key(value.substr(offset));
 
     size_t pos = values.lower_bound_int(key);
+    size_t pos_refs = pos + 1; // first entry in refs points to offsets
     TIGHTDB_ASSERT(pos != values.size());
 
     if (!m_array->is_leaf()) {
-        ref_type ref = refs.get_as_ref(pos);
-        StringIndex node(ref, &refs, pos, m_target_column, m_get_func, alloc);
+        ref_type ref = m_array->get_as_ref(pos_refs);
+        StringIndex node(ref, m_array, pos_refs, m_target_column, m_get_func, alloc);
         node.do_update_ref(value, row_ndx, new_row_ndx, offset);
     }
     else {
-        int64_t ref = refs.get(pos);
+        int64_t ref = m_array->get(pos_refs);
         if (ref & 1) {
             TIGHTDB_ASSERT((uint64_t(ref) >> 1) == uint64_t(row_ndx));
             size_t shifted = (new_row_ndx << 1) + 1; // shift to indicate literal
-            refs.set(pos, shifted);
+            m_array->set(pos_refs, shifted);
         }
         else {
             // A real ref either points to a list or a sub-index
             if (Array::is_index_node(to_ref(ref), alloc)) {
-                StringIndex subNdx(to_ref(ref), &refs, pos, m_target_column, m_get_func, alloc);
+                StringIndex subNdx(to_ref(ref), m_array, pos_refs, m_target_column, m_get_func, alloc);
                 subNdx.do_update_ref(value, row_ndx, new_row_ndx, offset+4);
             }
             else {
-                Column sub(to_ref(ref), &refs, pos, alloc);
+                Column sub(to_ref(ref), m_array, pos_refs, alloc);
                 size_t r = sub.find_first(row_ndx);
                 TIGHTDB_ASSERT(r != not_found);
                 sub.set(r, new_row_ndx);
@@ -670,9 +671,7 @@ void StringIndex::do_update_ref(StringData value, size_t row_ndx, size_t new_row
 
 bool StringIndex::is_empty() const
 {
-    Array values(m_array->get_alloc());
-    get_child(*m_array, 0, values);
-    return values.is_empty();
+    return m_array->size() == 1; // first entry in refs points to offsets
 }
 
 
@@ -682,10 +681,10 @@ void StringIndex::NodeAddKey(ref_type ref)
     TIGHTDB_ASSERT(!root_is_leaf());
 
     Allocator& alloc = m_array->get_alloc();
-    Array offsets(alloc), refs(alloc);
+    Array offsets(alloc);
     get_child(*m_array, 0, offsets);
-    get_child(*m_array, 1, refs);
-    TIGHTDB_ASSERT(offsets.size() < TIGHTDB_MAX_LIST_SIZE);
+    TIGHTDB_ASSERT(m_array->size() == offsets.size()+1);
+    TIGHTDB_ASSERT(offsets.size() < TIGHTDB_MAX_LIST_SIZE+1);
 
     Array new_top(ref, 0, 0, m_array->get_alloc());
     Array new_offsets(new_top.get_as_ref(0), 0, 0, alloc);
@@ -693,7 +692,7 @@ void StringIndex::NodeAddKey(ref_type ref)
 
     int64_t key = new_offsets.back();
     offsets.add(key);
-    refs.add(ref);
+    m_array->add(ref);
 }
 
 
@@ -741,17 +740,18 @@ void StringIndex::to_dot_2(ostream& out, StringData title) const
     out << "}" << endl;
 }
 
-void StringIndex::array_to_dot(ostream& out, const Array& array) const
+void StringIndex::array_to_dot(ostream& out, const Array& array)
 {
-    if (!array.has_refs()) {
-        array.to_dot(out);
+    if (!array.is_index_node()) {
+        Column col(array.get_ref(), array.get_parent(), array.get_ndx_in_parent(), array.get_alloc());
+        col.to_dot(out, "ref_list");
         return;
     }
 
     Allocator& alloc = array.get_alloc();
-    Array offsets(alloc), refs(alloc);
+    Array offsets(alloc);
     get_child(const_cast<Array&>(array), 0, offsets);
-    get_child(const_cast<Array&>(array), 1, refs);
+    TIGHTDB_ASSERT(array.size() == offsets.size()+1);
     ref_type ref  = array.get_ref();
 
     if (array.is_leaf()) {
@@ -768,21 +768,19 @@ void StringIndex::array_to_dot(ostream& out, const Array& array) const
 
     out << "}" << endl;
 
-    refs.to_dot(out, "refs");
-
-    size_t count = refs.size();
-    for (size_t i = 0; i < count; ++i) {
-        int64_t v = refs.get(i);
+    size_t count = array.size();
+    for (size_t i = 1; i < count; ++i) {
+        int64_t v = array.get(i);
         if (v & 1)
             continue; // ignore literals
 
         Array r(alloc);
-        get_child(refs, i, r);
+        get_child(const_cast<Array&>(array), i, r);
         array_to_dot(out, r);
     }
 }
 
-void StringIndex::keys_to_dot(ostream& out, const Array& array, StringData title) const
+void StringIndex::keys_to_dot(ostream& out, const Array& array, StringData title)
 {
     ref_type ref = array.get_ref();
 
@@ -819,6 +817,8 @@ void StringIndex::keys_to_dot(ostream& out, const Array& array, StringData title
 
     out << "</TR></TABLE>>];" << endl;
     if (0 < title.size()) out << "}" << endl;
+
+    array.to_dot_parent_edge(out);
 
     out << endl;
 }

--- a/src/tightdb/index_string.hpp
+++ b/src/tightdb/index_string.hpp
@@ -104,8 +104,8 @@ private:
 
 #ifdef TIGHTDB_DEBUG
     void to_dot_2(std::ostream&, StringData title = StringData()) const;
-    void array_to_dot(std::ostream&, const Array&) const;
-    void keys_to_dot(std::ostream&, const Array&, StringData title = StringData()) const;
+    static void array_to_dot(std::ostream&, const Array&);
+    static void keys_to_dot(std::ostream&, const Array&, StringData title = StringData());
 #endif
 };
 

--- a/test/test_column_string.cpp
+++ b/test/test_column_string.cpp
@@ -829,8 +829,13 @@ TEST(AdaptiveStringColumnIndex)
     asc.add("15");
     asc.add("HEJSA"); // 16
 
-    asc.create_index();
+    const StringIndex& ndx = asc.create_index();
     CHECK(asc.has_index());
+#ifdef TIGHTDB_DEBUG
+    ndx.verify_entries(asc);
+#else
+    static_cast<void>(ndx);
+#endif
 
     const size_t count0 = asc.count("HEJ");
     const size_t count1 = asc.count("HEJSA");

--- a/test/test_index_string.cpp
+++ b/test/test_index_string.cpp
@@ -18,6 +18,20 @@ namespace {
 
 } // namespace
 
+TEST(StringIndex_IsEmpty)
+{
+    // Create a column with string values
+    AdaptiveStringColumn col;
+
+    // Create a new index on column
+    const StringIndex& ndx = col.create_index();
+
+    CHECK(ndx.is_empty());
+
+    // Clean up
+    col.destroy();
+}
+
 TEST(StringIndex_BuildIndex)
 {
     // Create a column with string values
@@ -152,6 +166,76 @@ TEST(StringIndex_Delete)
 #ifdef TIGHTDB_DEBUG
     CHECK(ndx.is_empty());
 #endif
+
+    // Clean up
+    col.destroy();
+}
+
+TEST(StringIndex_ClearEmpty)
+{
+    // Create a column with string values
+    AdaptiveStringColumn col;
+
+    // Create a new index on column
+    const StringIndex& ndx = col.create_index();
+
+    // Clear to remove all entries
+    col.clear();
+#ifdef TIGHTDB_DEBUG
+    CHECK(ndx.is_empty());
+#else
+    static_cast<void>(ndx);
+#endif
+
+    // Clean up
+    col.destroy();
+}
+
+TEST(StringIndex_Clear)
+{
+    // Create a column with string values
+    AdaptiveStringColumn col;
+    col.add(s1);
+    col.add(s2);
+    col.add(s3);
+    col.add(s4);
+    col.add(s1); // duplicate value
+    col.add(s5); // common prefix
+    col.add(s6); // common prefix
+
+    // Create a new index on column
+    const StringIndex& ndx = col.create_index();
+
+    // Clear to remove all entries
+    col.clear();
+#ifdef TIGHTDB_DEBUG
+    CHECK(ndx.is_empty());
+#else
+    static_cast<void>(ndx);
+#endif
+
+    // Re-insert values
+    col.add(s1);
+    col.add(s2);
+    col.add(s3);
+    col.add(s4);
+    col.add(s1); // duplicate value
+    col.add(s5); // common prefix
+    col.add(s6); // common prefix
+
+    const size_t r1 = ndx.find_first(s1);
+    const size_t r2 = ndx.find_first(s2);
+    const size_t r3 = ndx.find_first(s3);
+    const size_t r4 = ndx.find_first(s4);
+    const size_t r5 = ndx.find_first(s5);
+    const size_t r6 = ndx.find_first(s6);
+
+    CHECK_EQUAL(0, r1);
+    CHECK_EQUAL(1, r2);
+    CHECK_EQUAL(2, r3);
+    CHECK_EQUAL(3, r4);
+    CHECK_EQUAL(5, r5);
+    CHECK_EQUAL(6, r6);
 
     // Clean up
     col.destroy();
@@ -320,7 +404,6 @@ TEST(StringIndex_Distinct)
     col.destroy();
 }
 
-#if 0 // fixme
 TEST(StringIndex_FindAllNoCopy)
 {
     // Create a column with duplcate values
@@ -337,7 +420,7 @@ TEST(StringIndex_FindAllNoCopy)
     col.add(s4);
 
     // Create a new index on column
-    StringIndex& ndx = col.CreateIndex();
+    StringIndex& ndx = col.create_index();
 
     size_t ref = not_found;
     FindRes res1 = ndx.find_all("not there", ref);
@@ -350,15 +433,14 @@ TEST(StringIndex_FindAllNoCopy)
     FindRes res3 = ndx.find_all(s4, ref);
     CHECK_EQUAL(FindRes_column, res3);
     const Column results(ref);
-    CHECK_EQUAL(4, results.Size());
-    CHECK_EQUAL(6, results.Get(0));
-    CHECK_EQUAL(7, results.Get(1));
-    CHECK_EQUAL(8, results.Get(2));
-    CHECK_EQUAL(9, results.Get(3));
+    CHECK_EQUAL(4, results.size());
+    CHECK_EQUAL(6, results.get(0));
+    CHECK_EQUAL(7, results.get(1));
+    CHECK_EQUAL(8, results.get(2));
+    CHECK_EQUAL(9, results.get(3));
 
     // Clean up
     col.destroy();
 }
-#endif
 
 #endif // TEST_INDEX_STRING


### PR DESCRIPTION
The string index is now updated to use the new b-tree layout (just the part removing the need for a separate top-array in nodes).

These changes do not bring over the improved update mechanics (like the improved handling of node splits), so it will be a good idea to bring those over at a later time. But the actual structure is now correct, so the other optimizations can be added later without any format changes.

I have also fixed to_dot(), so that the index structure can be properly visualized.

@kspangsege 
