### PR TITLE
Added public method to fix memory leakage in Obj-C group.

### DIFF
--- a/src/tightdb/group.hpp
+++ b/src/tightdb/group.hpp
@@ -234,6 +234,8 @@ public:
     ///
     /// \tparam T An instance of the BasicTable<> class template.
     TableRef      get_table(StringData name);
+    TableRef      get_table(StringData name, bool& was_created);
+
     ConstTableRef get_table(StringData name) const;
     template<class T> typename T::Ref      get_table(StringData name);
     template<class T> typename T::ConstRef get_table(StringData name) const;
@@ -549,6 +551,12 @@ template<class T> inline const T* Group::get_table_ptr(StringData name) const
 inline TableRef Group::get_table(StringData name)
 {
     return get_table_ptr(name)->get_table_ref();
+}
+
+inline TableRef Group::get_table(StringData name, bool& was_created)
+{
+    SpecSetter spec_setter = 0;
+    return get_table_ptr(name, spec_setter, was_created)->get_table_ref();
 }
 
 inline ConstTableRef Group::get_table(StringData name) const


### PR DESCRIPTION
Typed tables created in a group leaked due to a reference count error.
IMPORTANT: There is a matching update in the Obj-C source (group_objc.mm).

@kspangsege 
@bmunkholm 
