### PR TITLE
updated windows cmd file that copies windows release files to a release ...

### DIFF
--- a/winrelease.cmd
+++ b/winrelease.cmd
@@ -1,37 +1,38 @@
 @echo off
 echo Tightdb core c++ binding Windows Release.
-Echo alpha 0.02
+Echo beta 0.1
 echo ----------------------------------------------------------
-Echo Currently this cmd file will create a release version of
-echo the already built source in the directory where the cmd
-echo file resides. The release version will be placed in 
-echo (git checkout directory)\release\VS2012\files
-echo the directory is created if it does not exist.
-echo prior contents of VS2012 will be deleted, except zip files.
-echo the contents of the directory will be the library files 
-echo from lib, as well as header files from src and 
-echo subdirectories.
-echo in other words, release\VS2012 will contain 
-echo the static .lib files version of the current c++ binding
-echo only usable with the exact same compiler version that 
-echo compiled the static lib files, and only with the exact 
-echo same settings.
-echo
-echo after the files have been assembled, they are compressed 
-echo with 7zip to create an archive redistributable called 
-echo core_vs2012_yyyy_mm_dd_hh_mm_computername.zip
-echo the zip will be placed in
-echo (git checkout directory)\release\vs2012\release
-echo only the release directory is needed by c++ binding 
+echo In general, relase.cmd will create release directories
+echo with release versions of the already built solution in the
+echo same directory as where the solution file is.
+echo The release version will be placed in a directory called
+echo release, in two sub directories files\ and release\
+echo files\ will be an uncompressed release of all needed files
+echo laid out in a logical way, and release\ will contain
+echo a zipped version of the files\directory - named according
+echo to the time the winrelease.cmd file was run
+echo the zipfile will also contain the username from the
+echo computer that generated the zipfile
+echo only the release\files directory is needed by c++ binding 
 echo developers (on windows, using VS2012 c++)
+echo the zip file in release\vs2012\release can be shipped to
+echo c++ binding users and coders of bindings to other languages
+echo on the windows platform.
 echo ----------------------------------------------------------
-echo parametres (%0)
+echo parameters (%0)
 echo where this file is located (%~dp0)
 set location=%~dp0
-set date=xdatex
-set time=xtimex
-set developer=xdeveloperx
+set reldate=%date:~6,4%-%date:~3,2%-%date:~0,2%
+set reltime=%time::=%
+set reltime=%reltime: =%
+set reltime=%reltime:,=%
+set reldeveloper=%USERNAME: =%
+set reldeveloper=%reldeveloper:,=%
 echo this batchfile is located at %location%
+echo -
+echo - release date will be set to %reldate%
+echo - release time will be set to %reltime%
+echo - release user will be set to %reldeveloper%
 echo -
 echo Press Any key to proceed, or close the window to abort
 pause
@@ -58,7 +59,11 @@ copy %location%lib\*.lib %location%\release\vs2012\files
 xcopy %location%src\*.h* %location%\release\vs2012\files\src /S /y
 :archive the files directory and put it in the release directory
 echo creating release archive
-cd %location%release\vs2012\files%location%7z.exe a -tzip -r %location%\release\vs2012\release\tightdb_cpp_VS2012_%xdatex%_%xtimex%_%xdeveloperx% *.*
+set releasefilename=%location%\release\vs2012\release\tightdb_cpp_VS2012_%reldate%_%reltime%_%reldeveloper%
+echo release file name set to %releasefilename%
+cd %location%release\vs2012\files
+echo %location%7z.exe a -tzip -r %location%release\vs2012\release\%releasefilename% *.*
+%location%7z.exe a -tzip -r %releasefilename% *.*
 :revision history
 :0.01 
 :First version. still needs to set up date time and developer environment variables correctly
@@ -68,3 +73,7 @@ cd %location%release\vs2012\files%location%7z.exe a -tzip -r %location%\release\
 :0.02 7zip now called so that it makes a .zip file instead of a 7z file
 :0.02 file renamed to winrelease.bat from build.bat
 :0.03 file renamed to winrelease.cmd from winrelease.bat
+:0.04 Added time and date and username to the filename
+:0.05 changed comments, reoved debug pause commands
+echo Finished!
+pause


### PR DESCRIPTION
...archive.

(work in progress but this one actually works - it is the one I use to get me files to be used by my VS2012 c++ DLL). Would like to have it in the release branch as it is part of the procedure to create a directory with VS2012 lib and header files to be used to create the c++ DLL part of a C# release.
