### PR TITLE
Unit test that catches leak in strings

### DIFF
--- a/test/main.cpp
+++ b/test/main.cpp
@@ -12,7 +12,7 @@
 #include "util/timer.hpp"
 
 
-//#define USE_VLD
+#define USE_VLD
 #if defined(_MSC_VER) && defined(_DEBUG) && defined(USE_VLD)
     #include "C:\\Program Files (x86)\\Visual Leak Detector\\include\\vld.h"
 #endif

--- a/test/test_array_blob.cpp
+++ b/test/test_array_blob.cpp
@@ -6,6 +6,7 @@
 #include <UnitTest++.h>
 
 #include <tightdb/array_blob.hpp>
+#include <tightdb/column_string.hpp>
 
 using namespace std;
 using namespace tightdb;
@@ -77,6 +78,15 @@ TEST(ArrayBlob)
 
     // Cleanup
     blob.destroy();
+}
+
+TEST(AdaptiveStringLeak)
+{
+    AdaptiveStringColumn asc;
+    for(size_t t = 0; t < 2 * TIGHTDB_MAX_LIST_SIZE; t++)
+        asc.insert(0, std::string(100, 'a'));  // use constant larger than 'medium_string_max_size'
+
+    asc.destroy();
 }
 
 #endif // TEST_ARRAY_BLOB


### PR DESCRIPTION
Added unit test below which leaks. Alexander, can you look at it?

TEST(AdaptiveStringLeak)
{
AdaptiveStringColumn asc;
for(size_t t = 0; t < 2 \* TIGHTDB_MAX_LIST_SIZE; t++)
asc.insert(0, std::string(100, 'a')); // use constant larger than 'medium_string_max_size'
asc.destroy();
}

@astigsen @kspangsege @bmunkholm 
