### PR TITLE
Fixed slow release of memory during Group destruction.

### DIFF
--- a/src/tightdb/group.cpp
+++ b/src/tightdb/group.cpp
@@ -317,8 +317,15 @@ Group::~Group() TIGHTDB_NOEXCEPT
 
     detach_table_accessors();
 
-    // Recursively deletes entire tree
+#ifdef TIGHTDB_DEBUG
+    // Recursively deletes entire tree. The destructor in
+    // the allocator will verify that all has been deleted.
     m_top.destroy();
+#else
+    // Just allow the allocator to release all mem in one chunk
+    // without having to traverse the entire tree first
+    m_alloc.detach();
+#endif
 }
 
 


### PR DESCRIPTION
During testing I noticed that it took a long time to destroy Group's. It turned out that it was because they traverse the entire tree and frees each array individually. That is nice for debug purposes (verifies that everything is removed correctly), but totally unnecessary in release mode where the allocator can just release its memory in one go.

@kspangsege @finnschiermer
