### PR TITLE
throwing LockFileButNoData

### DIFF
--- a/src/tightdb/group_shared.cpp
+++ b/src/tightdb/group_shared.cpp
@@ -424,7 +424,12 @@ void SharedGroup::open(const string& path, bool no_create_file,
             bool read_only = false;
             bool no_create = true;
             bool skip_validate = true; // To avoid race conditions
-            alloc.attach_file(path, is_shared, read_only, no_create, skip_validate); // Throws
+            try {
+                alloc.attach_file(path, is_shared, read_only, no_create, skip_validate); // Throws
+            } 
+            catch (File::NotFound) {
+                throw LockFileButNoData(path);
+            }
 
         }
 

--- a/src/tightdb/group_shared.hpp
+++ b/src/tightdb/group_shared.hpp
@@ -162,6 +162,15 @@ public:
         PresumablyStaleLockFile(const std::string& msg): std::runtime_error(msg) {}
     };
 
+    // If the database file is deleted while there are open shared groups,
+    // subsequent attempts to open shared groups will try to join an already
+    // active sharing scheme, but fail due to the missing database file.
+    // This causes the following exception to be thrown from Open or the constructor.
+    class LockFileButNoData : public std::runtime_error {
+    public:
+        LockFileButNoData(const std::string& msg) : std::runtime_error(msg) {}
+    };
+
 private:
     struct SharedInfo;
 


### PR DESCRIPTION
Detects and throws an exception in the case where a shared group attempts to join an active sharing scheme (lock file present, other shared groups present) but the database file is missing.
