### PR TITLE
Debian/Ubuntu to be included in src release

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -2047,12 +2047,7 @@ EOF
 /test
 /test-installed
 /doc
-/debian/changelog.in
-/debian/rules
-/debian/compat
-/debian/control
-/debian/copyright
-/examples/tutorial.cpp
+/debian
 EOF
         cat >"$TEMP_DIR/exclude" <<EOF
 .gitignore

--- a/debian/rules
+++ b/debian/rules
@@ -44,7 +44,6 @@ libtightdb-dev: build
 	dh_testroot -a
 	dh_installdocs -a
 	dh_installchangelogs -p$@ -a
-	dh_installexamples $$(pwd)/examples/tutorial.cpp
 	dh_strip -p$@ -a
 	dh_compress -p$@ -s
 	dh_fixperms -p$@ -a


### PR DESCRIPTION
Adding relevant files to dist-copy target in order to build debian/ubuntu packages from src release.

It seems that I forgot to create and checkout a branch for this. Please forgive me for my mistake.

@kspangsege @bmunkholm 
