### PR TITLE
Subtable queries can be validated

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -11,6 +11,9 @@ Format:
 . Any other notes ....                   (internal changes)
 
 
+2014-01-23 (Kenneth Geisshirt)
+! Fixed bug: Subtable queries is validated by Query::validate(). An invalid subtable query can lead to a segfault.
+
 2014-01-07 (Kenneth Geisshirt)
 + Table::range() added. The method returns a set of rows as a TableView.
 

--- a/src/tightdb/query.cpp
+++ b/src/tightdb/query.cpp
@@ -538,7 +538,7 @@ R Query::aggregate(R (ColType::*aggregateMethod)(size_t start, size_t end, size_
     **************************************************************************************************************/
 
     void Query::aggregate_internal(Action TAction, DataType TSourceColumn,
-                                   ParentNode* pn, QueryStateBase* st, 
+                                   ParentNode* pn, QueryStateBase* st,
                                    size_t start, size_t end, SequentialGetterBase* source_column) const
     {
         if (end == not_found)
@@ -675,7 +675,7 @@ Query& Query::group()
 Query& Query::end_group()
 {
     if (first.size() < 2) {
-        error_code = "Unbalanced blockBegin/blockEnd";
+        error_code = "Unbalanced group";
         return *this;
     }
 
@@ -718,6 +718,11 @@ void Query::subtable(size_t column)
 
 void Query::end_subtable()
 {
+    if (subtables.size() == 0) {
+        error_code = "Unbalanced subtable";
+        return;
+    }
+
     end_group();
 
     if (update[update.size()-1] != 0)
@@ -1075,4 +1080,3 @@ Query Query::operator&&(Query q)
 
     return q2;
 }
-

--- a/src/tightdb/query_engine.hpp
+++ b/src/tightdb/query_engine.hpp
@@ -356,7 +356,7 @@ public:
     {
         if (TAction == act_ReturnFirst)
             m_column_action_specializer = & ThisType::column_action_specialization<act_ReturnFirst, int64_t>;
-        
+
         else if (TAction == act_Count)
             m_column_action_specializer = & ThisType::column_action_specialization<act_Count, int64_t>;
 
@@ -398,12 +398,12 @@ public:
     {
         // Sum of float column must accumulate in double
         typedef typename ColumnTypeTraitsSum<TSourceColumn, TAction>::sum_type TResult;
-        TIGHTDB_STATIC_ASSERT( !(TAction == act_Sum && (util::SameType<TSourceColumn, float>::value && 
+        TIGHTDB_STATIC_ASSERT( !(TAction == act_Sum && (util::SameType<TSourceColumn, float>::value &&
                                                         !util::SameType<TResult, double>::value)), "");
-        
+
         // TResult: type of query result
         // TSourceColumn: type of aggregate source
-        TSourceColumn av = (TSourceColumn)0; 
+        TSourceColumn av = (TSourceColumn)0;
         // uses_val test becuase compiler cannot see that Column::Get has no side effect and result is discarded
         if (static_cast<QueryState<TResult>*>(st)->template uses_val<TAction>() && source_column != null_ptr) {
             TIGHTDB_ASSERT(dynamic_cast<SequentialGetter<TSourceColumn>*>(source_column) != null_ptr);
@@ -568,6 +568,16 @@ public:
             m_child2->init(table);
     }
 
+    std::string validate()
+    {
+        if (error_code != "")
+            return error_code;
+        if (m_child == 0)
+            return "Unbalanced subtable/end_subtable block";
+        else
+            return m_child->validate();
+    }
+
     size_t find_first_local(size_t start, size_t end) TIGHTDB_OVERRIDE
     {
         TIGHTDB_ASSERT(m_table);
@@ -632,7 +642,7 @@ public:
         return b;
     }
 
-    IntegerNodeBase() :  m_array(Array::no_prealloc_tag()) 
+    IntegerNodeBase() :  m_array(Array::no_prealloc_tag())
     {
         m_child = 0;
         m_conds = 0;
@@ -748,9 +758,9 @@ public:
         m_state = st;
 
         // If there are no other nodes than us (m_conds == 1) AND the column used for our condition is
-        // the same as the column used for the aggregate action, then the entire query can run within scope of that 
+        // the same as the column used for the aggregate action, then the entire query can run within scope of that
         // column only, with no references to other columns:
-        bool fastmode = (m_conds == 1 && 
+        bool fastmode = (m_conds == 1 &&
                          (source_column == null_ptr ||
                           (!m_fastmode_disabled
                            && static_cast<SequentialGetter<int64_t>*>(source_column)->m_column == m_condition_column)));

--- a/test/test_query.cpp
+++ b/test/test_query.cpp
@@ -484,7 +484,7 @@ TEST(NextGenSyntaxMonkey)
     for(int iter = 1; iter < 20 * (TEST_DURATION * TEST_DURATION * TEST_DURATION + 1); iter++)
     {
         // Keep at least '* 20' else some tests will give 0 matches and bad coverage
-        const size_t rows = 1 + ((size_t)rand() * (size_t)rand()) 
+        const size_t rows = 1 + ((size_t)rand() * (size_t)rand())
             % (TIGHTDB_MAX_LIST_SIZE * 20 * (TEST_DURATION * TEST_DURATION * TEST_DURATION + 1));
         Table table;
         table.add_column(type_Int, "first");
@@ -3847,6 +3847,85 @@ TEST(TestQuerySyntaxCheck)
     CHECK(s != "");
 #endif
 */
+}
+
+TEST(TestQuerySubtableSyntaxCheck)
+{
+    Group group;
+    TableRef table = group.get_table("test");
+    string s;
+
+    // Create specification with sub-table
+    table->add_column(type_Int,    "first");
+    table->add_column(type_String, "second");
+    table->add_column(type_Table,  "third");
+    table->add_subcolumn(tuple(2), type_Int,    "sub_first");
+    table->add_subcolumn(tuple(2), type_String, "sub_second");
+
+    // Main table
+    table->insert_int(0, 0, 111);
+    table->insert_string(1, 0, "this");
+    table->insert_subtable(2, 0);
+    table->insert_done();
+
+    table->insert_int(0, 1, 222);
+    table->insert_string(1, 1, "is");
+    table->insert_subtable(2, 1);
+    table->insert_done();
+
+    table->insert_int(0, 2, 333);
+    table->insert_string(1, 2, "a test");
+    table->insert_subtable(2, 2);
+    table->insert_done();
+
+    table->insert_int(0, 3, 444);
+    table->insert_string(1, 3, "of queries");
+    table->insert_subtable(2, 3);
+    table->insert_done();
+
+
+    // Sub tables
+    TableRef subtable = table->get_subtable(2, 0);
+    subtable->insert_int(0, 0, 11);
+    subtable->insert_string(1, 0, "a");
+    subtable->insert_done();
+
+    subtable = table->get_subtable(2, 1);
+    subtable->insert_int(0, 0, 22);
+    subtable->insert_string(1, 0, "b");
+    subtable->insert_done();
+    subtable->insert_int(0, 1, 33);
+    subtable->insert_string(1, 1, "c");
+    subtable->insert_done();
+
+    subtable = table->get_subtable(2, 2);
+    subtable->insert_int(0, 0, 44);
+    subtable->insert_string(1, 0, "d");
+    subtable->insert_done();
+
+    subtable = table->get_subtable(2, 3);
+    subtable->insert_int(0, 0, 55);
+    subtable->insert_string(1, 0, "e");
+    subtable->insert_done();
+
+    Query q1 = table->where();
+    q1.subtable(2);
+    q1.greater(0, 50);
+    s = q1.validate();
+    CHECK(s != "");
+
+    Query q2 = table->where();
+    q2.subtable(2);
+    q2.greater(0, 50);
+    q2.end_subtable();
+    s = q2.validate();
+    CHECK(s == "");
+
+    Query q3 = table->where();
+    q3.greater(0, 50);
+    q3.end_subtable();
+    s = q3.validate();
+    CHECK(s != "");
 }
 
 TEST(TestTV)


### PR DESCRIPTION
`Query::validate()` is used for validating a query before calling an aggregate function or a search function. An invalid subtable query can lead to a segfault.

@finnschiermer @kspangsege
