### PR TITLE
View size fixup

### DIFF
--- a/doc/ref_cpp/data/dyn_view_ref.yaml
+++ b/doc/ref_cpp/data/dyn_view_ref.yaml
@@ -48,8 +48,8 @@ CATEGORIES :
   METHODS:
   - g_dyn_view_size:
       NAME     : size
-      SUMMARY  : *g_dyn_table_size_summary
-      DESCR    : *g_dyn_table_size_descr
+      SUMMARY  : *g_typed_view_size_summary
+      DESCR    : *g_typed_view_size_descr
       CONST    : True
       RETURN:
         TYPES  : size_t

--- a/doc/ref_cpp/data/typed_view_ref.yaml
+++ b/doc/ref_cpp/data/typed_view_ref.yaml
@@ -40,8 +40,10 @@ CATEGORIES :
   METHODS:
   - g_typed_view_size:
       NAME     : size
-      SUMMARY  : *g_typed_table_size_summary
-      DESCR    : *g_typed_table_size_descr
+      SUMMARY  : &g_typed_view_size_summary
+                 Number of rows.
+      DESCR    : &g_typed_view_size_descr
+                 This method returns the number of rows in the table view.
       CONST    : True
       RETURN:
         TYPES  : size_t


### PR DESCRIPTION
The original version would write "size of table", not "size of table view".

This does not break the documentation of any of the other language bindings (except if they don't import typed_view_ref before importing dyn_view_ref).

@bmunkholm @kneth 
