### PR TITLE
Doc query actions fixups

### DIFF
--- a/doc/ref_cpp/data/dyn_query_ref.yaml
+++ b/doc/ref_cpp/data/dyn_query_ref.yaml
@@ -684,12 +684,12 @@ CATEGORIES :
       NAMES    : [average_int, average_float, average_double]
       SUMMARY  : &g_dyn_query_average_summary
                  Calculates the average.
-      DESCR    : &g_dyn_query_average_descr
+      DESCR    :
+      - TEXT   : &g_dyn_query_average_descr
                  |
                  The method calculates the average of a specific column.
-
-                 Note: <code>average()</code> uses <code>sum()</code> which can overflow depending on the values stored. Nothing will indicate this.
-                 Note: Averaging many floats or doubles can accumulate representation imprecisions.
+      - TEXT   : *g_dyn_table_average_descr_notes
+      - TEXT   : *g_dyn_table_average_descr_double
       CONST    : true
       SIGNATURE: |
                  double average_int(size_t column_ndx, size_t* resultcount=NULL, size_t start=0, size_t end = size_t(-1), size_t limit=size_t(-1)) const;

--- a/doc/ref_cpp/data/dyn_table_ref.yaml
+++ b/doc/ref_cpp/data/dyn_table_ref.yaml
@@ -1185,8 +1185,18 @@ CATEGORIES :
       NAMES    : [average_int, average_float, average_double]
       SUMMARY  : &g_dyn_table_average_summary
                  Calculate the average value.
-      DESCR    : &g_dyn_table_average_descr
+      DESCR    :
+      - TEXT   : &g_dyn_table_average_descr
                  This method calculates the average value in the specified column.
+      - TEXT   : &g_dyn_table_average_descr_notes
+                 |
+                 Note: The method performs a summation, which can overflow depending on the values stored. Nothing will indicate this.
+                 Note: Averaging many floats or doubles can accumulate representation imprecisions.
+      - TEXT   : &g_dyn_table_average_descr_double
+                 >
+                 As the sum of many <code>int64_t</code> or <code>float</code>
+                 values can be greater than the average value of the type, a <code>double</code>
+                 is returned.
       CONST    : True
       SIGNATURE: |
                  double  average_int(size_t column_ndx) const;

--- a/doc/ref_cpp/data/dyn_view_ref.yaml
+++ b/doc/ref_cpp/data/dyn_view_ref.yaml
@@ -507,10 +507,8 @@ CATEGORIES :
       DESCR    :
       - TEXT   : &g_dyn_view_average_descr
                  Calculates the average of a column.
-      - TEXT   : >
-                 As the sum of many <code>int64_t</code> or <code>float</code>
-                 values can be greater than the average value of the type, a <code>double</code>
-                 is returned.
+      - TEXT   : *g_dyn_table_average_descr_notes
+      - TEXT   : *g_dyn_table_average_descr_double
       CONST    : True
       SIGNATURE: |
                  double  average_int(size_t column_ndx) const;


### PR DESCRIPTION
Adds the notes on the possibility of overflow and imprecision of sum to other instances of sum and average. The reason that I don't just let all methods use the table description text with notes is that for e.g. Query, the description text (aside from the notes) should probably be different.

@bmunkholm @kneth 
