### PR TITLE
Small Android fix

### DIFF
--- a/src/tightdb/group_shared.cpp
+++ b/src/tightdb/group_shared.cpp
@@ -167,7 +167,11 @@ void spawn_daemon(const string& file)
 
         // if we continue here, exec has failed so return error
         // if exec succeeds, we don't come back here.
+#ifndef ANDROID        
         _Exit(1);
+#else
+        _exit(1);
+#endif
         // child process ends here
 
     }


### PR DESCRIPTION
The GNU libc provided by android does not support _Exit().
