### PR TITLE
Optimise for size

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -577,7 +577,7 @@ EOF
             fi
             export CXX="$(cd "$temp_dir/bin" && echo $android_prefix-linux-*-gcc)"
             export AR="$(cd "$temp_dir/bin" && echo $android_prefix-linux-*-ar)"
-            extra_cflags="-DANDROID -D_POSIX_THREAD_PROCESS_SHARED -fPIC -DPIC"
+            extra_cflags="-DANDROID -D_POSIX_THREAD_PROCESS_SHARED -fPIC -DPIC -Os"
             if [ "$target" = "arm" ]; then
                 extra_cflags="$extra_cflags -mthumb"
             elif [ "$target" = "arm-v7a" ]; then


### PR DESCRIPTION
The difference is remarcable
# Results with -O3

Core:
7.7M libtightdb-android-arm-v7a.a
7.8M libtightdb-android-arm.a
8.0M libtightdb-android-mips.a
6.3M libtightdb-android-x86.a

JNI:
3.0M armeabi-v7a/libtightdb-jni.so
3.2M armeabi/libtightdb-jni.so
5.3M mips/libtightdb-jni.so
3.6M x86/libtightdb-jni.so
# Results with -Os

Core:
2.5M libtightdb-android-arm-v7a.a
2.5M libtightdb-android-arm.a
3.0M libtightdb-android-mips.a
2.6M libtightdb-android-x86.a

JNI:
1.2M armeabi-v7a/libtightdb-jni.so
1.3M armeabi/libtightdb-jni.so
2.1M mips/libtightdb-jni.so
1.8M x86/libtightdb-jni.so
