### PR TITLE
Avoid `-D_POSIX_THREAD_PROCESS_SHARED` when building for Android

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -585,7 +585,7 @@ EOF
             fi
             export CXX="$(cd "$temp_dir/bin" && echo $android_prefix-linux-*-gcc)"
             export AR="$(cd "$temp_dir/bin" && echo $android_prefix-linux-*-ar)"
-            extra_cflags="-DANDROID -D_POSIX_THREAD_PROCESS_SHARED -fPIC -DPIC -Os"
+            extra_cflags="-DANDROID -fPIC -DPIC -Os"
             if [ "$target" = "arm" ]; then
                 extra_cflags="$extra_cflags -mthumb"
             elif [ "$target" = "arm-v7a" ]; then

--- a/src/tightdb/util/thread.cpp
+++ b/src/tightdb/util/thread.cpp
@@ -8,25 +8,28 @@
 #  include <unistd.h>
 #endif
 
-// Unfortunately Older Ubuntu releases such as 10.04 reports
-// support for robust mutexes by setting _POSIX_THREADS = 200809L and
+// "Process shared mutexes" are not officially supported on Android,
+// but they appear to work anyway.
+#if _POSIX_THREAD_PROCESS_SHARED > 0 || defined ANDROID
+#  define TIGHTDB_HAVE_PTHREAD_PROCESS_SHARED
+#endif
+
+// Unfortunately Older Ubuntu releases such as 10.04 reports support
+// for robust mutexes by setting _POSIX_THREADS = 200809L and
 // _POSIX_THREAD_PROCESS_SHARED = 200809L even though they do not
 // provide pthread_mutex_consistent(). See also
 // http://www.gnu.org/software/gnulib/manual/gnulib.html#pthread_005fmutex_005fconsistent.
-// Support was added to glibc 2.12, so we disable for earlier versions of glibs
-
-#ifdef _POSIX_THREAD_PROCESS_SHARED
-#  if _POSIX_THREAD_PROCESS_SHARED != -1 // can apparently also be -1
-#    define TIGHTDB_HAVE_PTHREAD_PROCESS_SHARED
-#    if !defined _WIN32 // robust not supported by our windows pthreads port
-#      if _POSIX_THREADS >= 200809L
-#        ifdef __GNU_LIBRARY__
-#          if (__GLIBC__ >= 2)  && (__GLIBC_MINOR__ >= 12)
-#            define TIGHTDB_HAVE_ROBUST_PTHREAD_MUTEX
-#          endif
-#        else
+// Support was added to glibc 2.12, so we disable for earlier versions
+// of glibs
+#ifdef TIGHTDB_HAVE_PTHREAD_PROCESS_SHARED
+#  if !defined _WIN32 // 'robust' not supported by our windows pthreads port
+#    if _POSIX_THREADS >= 200809L
+#      ifdef __GNU_LIBRARY__
+#        if __GLIBC__ >= 2  && __GLIBC_MINOR__ >= 12
 #          define TIGHTDB_HAVE_ROBUST_PTHREAD_MUTEX
 #        endif
+#      else
+#        define TIGHTDB_HAVE_ROBUST_PTHREAD_MUTEX
 #      endif
 #    endif
 #  endif


### PR DESCRIPTION
Avoid the need to specify `-D_POSIX_THREAD_PROCESS_SHARED` when building for Android.

@emanuelez @finnschiermer 
