### PR TITLE
[DOC] get_column_name index out of range: behaviour undefined

### DIFF
--- a/doc/ref_cpp/data/dyn_table_ref.yaml
+++ b/doc/ref_cpp/data/dyn_table_ref.yaml
@@ -321,8 +321,10 @@ CATEGORIES :
 
       RETURN:
         TYPES  : StringData
-        DESCR  : &g_dyn_table_get_column_name_return_descr
-                 The column name. An empty string if index is out of range.
+        DESCR  :
+        - TEXT : &g_dyn_table_get_column_name_return_descr
+                 The column name.
+        - TEXT : The behaviour is undefined if the index is out of range.
       EXAMPLES:
       - CODE   : ex_cpp_dyn_table_get_column_name
         DESCR  :


### PR DESCRIPTION
A simpler solution that doesn't break other bindings.

@bmunkholm @kspangsege 
