### PR TITLE
Drop -Os when building for Android

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -572,9 +572,8 @@ EOF
             # `bash` and must therefore be executed by `bash`.
             make_toolchain="$android_ndk_home/build/tools/make-standalone-toolchain.sh"
             bash "$make_toolchain" --platform="android-$platform" --install-dir="$temp_dir" --arch="$target" || exit 1
-            if [ "$target" = "arm" ]; then
-                android_prefix="arm"
-            elif [ "$target" = "arm-v7a" ]; then
+            android_prefix="$target"
+            if [ "$target" = "arm-v7a" ]; then
                 android_prefix="arm"
             elif [ "$target" = "mips" ]; then
                 android_prefix="mipsel"
@@ -583,7 +582,7 @@ EOF
             fi
             path="$temp_dir/bin:$PATH"
             cc="$(cd "$temp_dir/bin" && echo $android_prefix-linux-*-gcc)" || exit 1
-            extra_cflags="-DANDROID -fPIC -DPIC -Os"
+            extra_cflags="-DANDROID -fPIC -DPIC"
             if [ "$target" = "arm" ]; then
                 extra_cflags="$extra_cflags -mthumb"
             elif [ "$target" = "arm-v7a" ]; then


### PR DESCRIPTION
After all, `-Os` does not significantly reduce the size of the libraries over `-O3` (on ARM it is worse). Given that, `-O3` is preferable since it is default for `generic.mk` and should be expected to produce faster code.
## -Os:

```
-rw-r--r-- 1 kristian kristian 2670210 Mar 17 20:12 libtightdb-android-arm.a
-rw-r--r-- 1 kristian kristian 2646714 Mar 17 20:12 libtightdb-android-arm-v7a.a
-rw-r--r-- 1 kristian kristian 3098336 Mar 17 20:12 libtightdb-android-mips.a
-rw-r--r-- 1 kristian kristian 2735804 Mar 17 20:13 libtightdb-android-x86.a
```
## -O3:

```
-rw-r--r-- 1 kristian kristian 2564432 Mar 17 20:14 libtightdb-android-arm.a
-rw-r--r-- 1 kristian kristian 2506176 Mar 17 20:14 libtightdb-android-arm-v7a.a
-rw-r--r-- 1 kristian kristian 3167716 Mar 17 20:14 libtightdb-android-mips.a
-rw-r--r-- 1 kristian kristian 2897414 Mar 17 20:15 libtightdb-android-x86.a
```

@emanuelez 
