### PR TITLE
Misunderstood test fixtures removed

### DIFF
--- a/test/test_array.cpp
+++ b/test/test_array.cpp
@@ -52,7 +52,9 @@ void has_zero_byte(int64_t value, size_t reps)
 
 } // anonymous namespace
 
-TEST(UPPERLOWERBOUND)
+
+// Oops, see Array_LowerUpperBound
+TEST(Array_UpperLowerBound)
 {
     // Tests Array::upper_bound() and Array::lower_bound()
     // This test is independent of TIGHTDB_MAX_LIST_SIZE
@@ -640,7 +642,7 @@ TEST(Array_Sort)
  */
 
 
-TEST(findallint0)
+TEST(Array_FindAllInt0)
 {
     Array a;
     Array r;
@@ -668,7 +670,7 @@ TEST(findallint0)
     r.destroy();
 }
 
-TEST(findallint1)
+TEST(Array_FindAllInt1)
 {
     Array a;
     Array r;
@@ -699,7 +701,7 @@ TEST(findallint1)
     r.destroy();
 }
 
-TEST(findallint2)
+TEST(Array_FindAllInt2)
 {
     Array a;
     Array r;
@@ -730,7 +732,7 @@ TEST(findallint2)
     r.destroy();
 }
 
-TEST(findallint3)
+TEST(Array_FindAllInt3)
 {
     Array a;
     Array r;
@@ -761,7 +763,7 @@ TEST(findallint3)
     r.destroy();
 }
 
-TEST(findallint4)
+TEST(Array_FindAllInt4)
 {
     Array a;
     Array r;
@@ -793,7 +795,7 @@ TEST(findallint4)
     r.destroy();
 }
 
-TEST(findallint5)
+TEST(Array_FindAllInt5)
 {
     Array a;
     Array r;
@@ -825,7 +827,7 @@ TEST(findallint5)
     r.destroy();
 }
 
-TEST(findallint6)
+TEST(Array_FindAllInt6)
 {
     Array a;
     Array r;
@@ -857,7 +859,7 @@ TEST(findallint6)
     r.destroy();
 }
 
-TEST(findallint7)
+TEST(Array_FindAllInt7)
 {
     Array a;
     Array r;
@@ -890,7 +892,7 @@ TEST(findallint7)
 }
 
 // Tests the case where a value does *not* exist in one entire 64-bit chunk (triggers the 'if (has_zero_byte()) break;' condition)
-TEST(FindHasZeroByte)
+TEST(Array_FindHasZeroByte)
 {
     // we want at least 1 entire 64-bit chunk-test, and we also want a remainder-test, so we chose n to be a prime > 64
     size_t n = 73;
@@ -904,7 +906,7 @@ TEST(FindHasZeroByte)
 }
 
 // New find test for SSE search, to trigger partial finds (see FindSSE()) before and after the aligned data area
-TEST(FindSSE)
+TEST(Array_FindSSE)
 {
     Array a;
     for (uint64_t i = 0; i < 100; i++) {
@@ -922,7 +924,7 @@ TEST(FindSSE)
 }
 
 
-TEST(Sum0)
+TEST(Array_Sum0)
 {
     Array a;
     for (int i = 0; i < 64 + 7; i++) {
@@ -932,7 +934,7 @@ TEST(Sum0)
     a.destroy();
 }
 
-TEST(Sum1)
+TEST(Array_Sum1)
 {
     int64_t s1 = 0;
     Array a;
@@ -952,7 +954,7 @@ TEST(Sum1)
     a.destroy();
 }
 
-TEST(Sum2)
+TEST(Array_Sum2)
 {
     int64_t s1 = 0;
     Array a;
@@ -973,7 +975,7 @@ TEST(Sum2)
 }
 
 
-TEST(Sum4)
+TEST(Array_Sum4)
 {
     int64_t s1 = 0;
     Array a;
@@ -993,7 +995,7 @@ TEST(Sum4)
     a.destroy();
 }
 
-TEST(Sum16)
+TEST(Array_Sum16)
 {
     int64_t s1 = 0;
     Array a;
@@ -1013,7 +1015,7 @@ TEST(Sum16)
     a.destroy();
 }
 
-TEST(Greater)
+TEST(Array_Greater)
 {
     Array a;
 
@@ -1138,7 +1140,7 @@ TEST(Greater)
 
 
 
-TEST(Less)
+TEST(Array_Less)
 {
     Array a;
 
@@ -1258,7 +1260,7 @@ TEST(Less)
 }
 
 
-TEST(NotEqual1)
+TEST(Array_NotEqual1)
 {
     Array a;
 
@@ -1272,7 +1274,7 @@ TEST(NotEqual1)
     a.destroy();
 }
 
-TEST(NotEqual)
+TEST(Array_NotEqual)
 {
     Array a;
 
@@ -1393,7 +1395,7 @@ TEST(NotEqual)
 
 
 
-TEST(ArraySort)
+TEST(Array_Sort1)
 {
     // negative values
     Array a;
@@ -1412,7 +1414,7 @@ TEST(ArraySort)
 }
 
 
-TEST(ArraySort2)
+TEST(Array_Sort2)
 {
     // 64 bit values
     Array a;
@@ -1430,7 +1432,7 @@ TEST(ArraySort2)
     a.destroy();
 }
 
-TEST(ArraySort3)
+TEST(Array_Sort3)
 {
     // many values
     Array a;
@@ -1449,7 +1451,7 @@ TEST(ArraySort3)
 }
 
 
-TEST(ArraySort4)
+TEST(Array_Sort4)
 {
     // same values
     Array a;
@@ -1467,7 +1469,7 @@ TEST(ArraySort4)
     a.destroy();
 }
 
-TEST(ArrayCopy)
+TEST(Array_Copy)
 {
     Array a;
     a.add(0);
@@ -1516,7 +1518,7 @@ TEST(ArrayCopy)
     d.destroy_deep();
 }
 
-TEST(ArrayCount)
+TEST(Array_Count)
 {
     Array a;
 

--- a/test/test_array_binary.cpp
+++ b/test/test_array_binary.cpp
@@ -9,14 +9,21 @@ using namespace tightdb;
 // Note: You can now temporarely declare unit tests with the ONLY(TestName) macro instead of TEST(TestName). This
 // will disable all unit tests except these. Remember to undo your temporary changes before committing.
 
+namespace {
+
 struct db_setup_binary {
     static ArrayBinary c;
 };
 
 ArrayBinary db_setup_binary::c;
 
-TEST_FIXTURE(db_setup_binary, ArrayBinaryMultiEmpty)
+} // anonnymous namespace
+
+
+TEST(ArrayBinary_MultiEmpty)
 {
+    ArrayBinary& c = db_setup_binary::c;
+
     c.add(BinaryData("", 0));
     c.add(BinaryData("", 0));
     c.add(BinaryData("", 0));
@@ -34,8 +41,10 @@ TEST_FIXTURE(db_setup_binary, ArrayBinaryMultiEmpty)
     CHECK_EQUAL(0, c.get(5).size());
 }
 
-TEST_FIXTURE(db_setup_binary, ArrayBinarySet)
+TEST(ArrayBinary_Set)
 {
+    ArrayBinary& c = db_setup_binary::c;
+
     c.set(0, BinaryData("hey", 4));
 
     CHECK_EQUAL(6, c.size());
@@ -49,8 +58,10 @@ TEST_FIXTURE(db_setup_binary, ArrayBinarySet)
     CHECK_EQUAL(0, c.get(5).size());
 }
 
-TEST_FIXTURE(db_setup_binary, ArrayBinaryAdd)
+TEST(ArrayBinary_Add)
 {
+    ArrayBinary& c = db_setup_binary::c;
+
     c.clear();
     CHECK_EQUAL(0, c.size());
 
@@ -67,8 +78,10 @@ TEST_FIXTURE(db_setup_binary, ArrayBinaryAdd)
     CHECK_EQUAL(2, c.size());
 }
 
-TEST_FIXTURE(db_setup_binary, ArrayBinarySet2)
+TEST(ArrayBinary_Set2)
 {
+    ArrayBinary& c = db_setup_binary::c;
+
     // {shrink, grow} x {first, middle, last, single}
     c.clear();
 
@@ -122,8 +135,9 @@ TEST_FIXTURE(db_setup_binary, ArrayBinarySet2)
     CHECK_EQUAL(3, c.size());
 }
 
-TEST_FIXTURE(db_setup_binary, ArrayBinaryInsert)
+TEST(ArrayBinary_Insert)
 {
+    ArrayBinary& c = db_setup_binary::c;
     c.clear();
 
     c.insert(0, BinaryData("abc", 4)); // single
@@ -157,8 +171,9 @@ TEST_FIXTURE(db_setup_binary, ArrayBinaryInsert)
     CHECK_EQUAL(5, c.size());
 }
 
-TEST_FIXTURE(db_setup_binary, ArrayBinaryErase)
+TEST(ArrayBinary_Erase)
 {
+    ArrayBinary& c = db_setup_binary::c;
     c.clear();
 
     c.add(BinaryData("a", 2));
@@ -194,8 +209,10 @@ TEST_FIXTURE(db_setup_binary, ArrayBinaryErase)
     CHECK(c.is_empty());
 }
 
-TEST_FIXTURE(db_setup_binary, ArrayBinary_Destroy)
+TEST(ArrayBinary_Destroy)
 {
+    ArrayBinary& c = db_setup_binary::c;
+
     // clean up (ALWAYS PUT THIS LAST)
     c.destroy();
 }

--- a/test/test_array_blobs_big.cpp
+++ b/test/test_array_blobs_big.cpp
@@ -6,19 +6,29 @@ using namespace tightdb;
 // Note: You can now temporarely declare unit tests with the ONLY(TestName) macro instead of TEST(TestName). This
 // will disable all unit tests except these. Remember to undo your temporary changes before committing.
 
+
+namespace {
+
 struct db_setup_big_blobs {
     static ArrayBigBlobs c;
 };
 
 ArrayBigBlobs db_setup_big_blobs::c;
 
-TEST_FIXTURE(db_setup_big_blobs, ArrayBigBlobsIsEmpty)
+} // anonymous namespace
+
+
+TEST(ArrayBigBlobs_IsEmpty)
 {
+    ArrayBigBlobs& c = db_setup_big_blobs::c;
+
     CHECK_EQUAL(true, c.is_empty());
 }
 
-TEST_FIXTURE(db_setup_big_blobs, ArrayBigBlobsMultiEmpty)
+TEST(ArrayBigBlobs_MultiEmpty)
 {
+    ArrayBigBlobs& c = db_setup_big_blobs::c;
+
     c.add(BinaryData("", 0));
     c.add(BinaryData("", 0));
     c.add(BinaryData("", 0));
@@ -36,8 +46,10 @@ TEST_FIXTURE(db_setup_big_blobs, ArrayBigBlobsMultiEmpty)
     CHECK_EQUAL(0, c.get(5).size());
 }
 
-TEST_FIXTURE(db_setup_big_blobs, ArrayBigBlobsSet)
+TEST(ArrayBigBlobs_Set)
 {
+    ArrayBigBlobs& c = db_setup_big_blobs::c;
+
     c.set(0, BinaryData("hey", 4));
 
     CHECK_EQUAL(6, c.size());
@@ -51,9 +63,11 @@ TEST_FIXTURE(db_setup_big_blobs, ArrayBigBlobsSet)
     CHECK_EQUAL(0, c.get(5).size());
 }
 
-TEST_FIXTURE(db_setup_big_blobs, ArrayBigBlobsAdd)
+TEST(ArrayBigBlobs_Add)
 {
+    ArrayBigBlobs& c = db_setup_big_blobs::c;
     c.clear();
+
     CHECK_EQUAL(0, c.size());
 
     c.add(BinaryData("abc", 4));
@@ -69,8 +83,10 @@ TEST_FIXTURE(db_setup_big_blobs, ArrayBigBlobsAdd)
     CHECK_EQUAL(2, c.size());
 }
 
-TEST_FIXTURE(db_setup_big_blobs, ArrayBigBlobsSet2)
+TEST(ArrayBigBlobs_Set2)
 {
+    ArrayBigBlobs& c = db_setup_big_blobs::c;
+
     // {shrink, grow} x {first, middle, last, single}
     c.clear();
 
@@ -124,8 +140,9 @@ TEST_FIXTURE(db_setup_big_blobs, ArrayBigBlobsSet2)
     CHECK_EQUAL(3, c.size());
 }
 
-TEST_FIXTURE(db_setup_big_blobs, ArrayBigBlobsInsert)
+TEST(ArrayBigBlobs_Insert)
 {
+    ArrayBigBlobs& c = db_setup_big_blobs::c;
     c.clear();
 
     c.insert(0, BinaryData("abc", 4)); // single
@@ -159,8 +176,9 @@ TEST_FIXTURE(db_setup_big_blobs, ArrayBigBlobsInsert)
     CHECK_EQUAL(5, c.size());
 }
 
-TEST_FIXTURE(db_setup_big_blobs, ArrayBigBlobsErase)
+TEST(ArrayBigBlobs_Erase)
 {
+    ArrayBigBlobs& c = db_setup_big_blobs::c;
     c.clear();
 
     c.add(BinaryData("a", 2));
@@ -196,8 +214,9 @@ TEST_FIXTURE(db_setup_big_blobs, ArrayBigBlobsErase)
     CHECK(c.is_empty());
 }
 
-TEST_FIXTURE(db_setup_big_blobs, ArrayBigBlobsCount)
+TEST(ArrayBigBlobs_Count)
 {
+    ArrayBigBlobs& c = db_setup_big_blobs::c;
     c.clear();
 
     // first, middle and end
@@ -215,8 +234,10 @@ TEST_FIXTURE(db_setup_big_blobs, ArrayBigBlobsCount)
     CHECK_EQUAL(3, count2);
 }
 
-TEST_FIXTURE(db_setup_big_blobs, ArrayBigBlobsFind)
+TEST(ArrayBigBlobs_Find)
 {
+    ArrayBigBlobs& c = db_setup_big_blobs::c;
+
     const size_t res = c.find_first(BinaryData("baz", 4));
     CHECK_EQUAL(3, res);
 
@@ -235,8 +256,10 @@ TEST_FIXTURE(db_setup_big_blobs, ArrayBigBlobsFind)
     results.destroy();
 }
 
-TEST_FIXTURE(db_setup_big_blobs, ArrayBigBlobs_Destroy)
+TEST(ArrayBigBlobs_Destroy)
 {
+    ArrayBigBlobs& c = db_setup_big_blobs::c;
+
     // clean up (ALWAYS PUT THIS LAST)
     c.destroy();
 }

--- a/test/test_array_string.cpp
+++ b/test/test_array_string.cpp
@@ -10,14 +10,22 @@ using namespace tightdb;
 // Note: You can now temporarely declare unit tests with the ONLY(TestName) macro instead of TEST(TestName). This
 // will disable all unit tests except these. Remember to undo your temporary changes before committing.
 
+
+namespace {
+
 struct db_setup_string {
     static ArrayString c;
 };
 
 ArrayString db_setup_string::c;
 
-TEST_FIXTURE(db_setup_string, ArrayStringMultiEmpty)
+} // anonnymous namespace
+
+
+TEST(ArrayString_MultiEmpty)
 {
+    ArrayString& c = db_setup_string::c;
+
     c.add("");
     c.add("");
     c.add("");
@@ -34,8 +42,10 @@ TEST_FIXTURE(db_setup_string, ArrayStringMultiEmpty)
     CHECK_EQUAL("", c.get(5));
 }
 
-TEST_FIXTURE(db_setup_string, ArrayStringSetEmpty1)
+TEST(ArrayString_SetEmpty1)
 {
+    ArrayString& c = db_setup_string::c;
+
     c.set(0, "");
 
     CHECK_EQUAL(6, c.size());
@@ -47,13 +57,16 @@ TEST_FIXTURE(db_setup_string, ArrayStringSetEmpty1)
     CHECK_EQUAL("", c.get(5));
 }
 
-TEST_FIXTURE(db_setup_string, ArrayStringErase0)
+TEST(ArrayString_Erase0)
 {
+    ArrayString& c = db_setup_string::c;
     c.erase(5);
 }
 
-TEST_FIXTURE(db_setup_string, ArrayStringInsert0)
+TEST(ArrayString_Insert0)
 {
+    ArrayString& c = db_setup_string::c;
+
     // Intention: Insert a non-empty string into an array that is not
     // empty but contains only empty strings (and only ever have
     // contained empty strings). The insertion is not at the end of
@@ -61,8 +74,10 @@ TEST_FIXTURE(db_setup_string, ArrayStringInsert0)
     c.insert(0, "x");
 }
 
-TEST_FIXTURE(db_setup_string, ArrayStringSetEmpty2)
+TEST(ArrayString_SetEmpty2)
 {
+    ArrayString& c = db_setup_string::c;
+
     c.set(0, "");
     c.set(5, "");
 
@@ -75,9 +90,11 @@ TEST_FIXTURE(db_setup_string, ArrayStringSetEmpty2)
     CHECK_EQUAL("", c.get(5));
 }
 
-TEST_FIXTURE(db_setup_string, ArrayStringClear)
+TEST(ArrayString_Clear)
 {
+    ArrayString& c = db_setup_string::c;
     c.clear();
+
     c.add("");
     c.add("");
     c.add("");
@@ -94,8 +111,10 @@ TEST_FIXTURE(db_setup_string, ArrayStringClear)
     CHECK_EQUAL("", c.get(5));
 }
 
-TEST_FIXTURE(db_setup_string, ArrayStringFind1)
+TEST(ArrayString_Find1)
 {
+    ArrayString& c = db_setup_string::c;
+
     CHECK_EQUAL(6, c.size());
     CHECK_EQUAL("", c.get(0));
     // Intention: Search for strings in an array that is not empty but
@@ -107,8 +126,10 @@ TEST_FIXTURE(db_setup_string, ArrayStringFind1)
     CHECK_EQUAL(size_t(-1), c.find_first("", 6));
 }
 
-TEST_FIXTURE(db_setup_string, ArrayStringSetExpand4)
+TEST(ArrayString_SetExpand4)
 {
+    ArrayString& c = db_setup_string::c;
+
     c.set(0, "hey");
 
     CHECK_EQUAL(6, c.size());
@@ -120,15 +141,19 @@ TEST_FIXTURE(db_setup_string, ArrayStringSetExpand4)
     CHECK_EQUAL("", c.get(5));
 }
 
-TEST_FIXTURE(db_setup_string, ArrayStringFind2)
+TEST(ArrayString_Find2)
 {
+    ArrayString& c = db_setup_string::c;
+
     // Intention: Search for non-empty string P that is not in then
     // array, but the array does contain a string where P is a prefix.
     CHECK_EQUAL(size_t(-1), c.find_first("he"));
 }
 
-TEST_FIXTURE(db_setup_string, ArrayStringSetExpand8)
+TEST(ArrayString_SetExpand8)
 {
+    ArrayString& c = db_setup_string::c;
+
     c.set(1, "test");
 
     CHECK_EQUAL(6, c.size());
@@ -140,24 +165,30 @@ TEST_FIXTURE(db_setup_string, ArrayStringSetExpand8)
     CHECK_EQUAL("", c.get(5));
 }
 
-TEST_FIXTURE(db_setup_string, ArrayArrayStringAdd0)
+TEST(ArrayArrayString_Add0)
 {
+    ArrayString& c = db_setup_string::c;
     c.clear();
+
     c.add();
     CHECK_EQUAL("", c.get(0));
     CHECK_EQUAL(1, c.size());
 }
 
-TEST_FIXTURE(db_setup_string, ArrayStringAdd1)
+TEST(ArrayString_Add1)
 {
+    ArrayString& c = db_setup_string::c;
+
     c.add("a");
     CHECK_EQUAL("",  c.get(0));
     CHECK_EQUAL("a", c.get(1));
     CHECK_EQUAL(2, c.size());
 }
 
-TEST_FIXTURE(db_setup_string, ArrayStringAdd2)
+TEST(ArrayString_Add2)
 {
+    ArrayString& c = db_setup_string::c;
+
     c.add("bb");
     CHECK_EQUAL("",   c.get(0));
     CHECK_EQUAL("a",  c.get(1));
@@ -165,8 +196,10 @@ TEST_FIXTURE(db_setup_string, ArrayStringAdd2)
     CHECK_EQUAL(3, c.size());
 }
 
-TEST_FIXTURE(db_setup_string, ArrayStringAdd3)
+TEST(ArrayString_Add3)
 {
+    ArrayString& c = db_setup_string::c;
+
     c.add("ccc");
     CHECK_EQUAL("",    c.get(0));
     CHECK_EQUAL("a",   c.get(1));
@@ -175,8 +208,10 @@ TEST_FIXTURE(db_setup_string, ArrayStringAdd3)
     CHECK_EQUAL(4, c.size());
 }
 
-TEST_FIXTURE(db_setup_string, ArrayStringAdd4)
+TEST(ArrayString_Add4)
 {
+    ArrayString& c = db_setup_string::c;
+
     c.add("dddd");
     CHECK_EQUAL("",     c.get(0));
     CHECK_EQUAL("a",    c.get(1));
@@ -186,8 +221,10 @@ TEST_FIXTURE(db_setup_string, ArrayStringAdd4)
     CHECK_EQUAL(5, c.size());
 }
 
-TEST_FIXTURE(db_setup_string, ArrayStringAdd8)
+TEST(ArrayString_Add8)
 {
+    ArrayString& c = db_setup_string::c;
+
     c.add("eeeeeeee");
     CHECK_EQUAL("",     c.get(0));
     CHECK_EQUAL("a",    c.get(1));
@@ -198,8 +235,10 @@ TEST_FIXTURE(db_setup_string, ArrayStringAdd8)
     CHECK_EQUAL(6, c.size());
 }
 
-TEST_FIXTURE(db_setup_string, ArrayStringAdd16)
+TEST(ArrayString_Add16)
 {
+    ArrayString& c = db_setup_string::c;
+
     c.add("ffffffffffffffff");
     CHECK_EQUAL("",     c.get(0));
     CHECK_EQUAL("a",    c.get(1));
@@ -211,8 +250,10 @@ TEST_FIXTURE(db_setup_string, ArrayStringAdd16)
     CHECK_EQUAL(7, c.size());
 }
 
-TEST_FIXTURE(db_setup_string, ArrayStringAdd32)
+TEST(ArrayString_Add32)
 {
+    ArrayString& c = db_setup_string::c;
+
     c.add("gggggggggggggggggggggggggggggggg");
 
     CHECK_EQUAL("",     c.get(0));
@@ -226,8 +267,10 @@ TEST_FIXTURE(db_setup_string, ArrayStringAdd32)
     CHECK_EQUAL(8, c.size());
 }
 
-TEST_FIXTURE(db_setup_string, ArrayStringSet1)
+TEST(ArrayString_Set1)
 {
+    ArrayString& c = db_setup_string::c;
+
     c.set(0, "ccc");
     c.set(1, "bb");
     c.set(2, "a");
@@ -244,8 +287,10 @@ TEST_FIXTURE(db_setup_string, ArrayStringSet1)
     CHECK_EQUAL(8, c.size());
 }
 
-TEST_FIXTURE(db_setup_string, ArrayStringInsert1)
+TEST(ArrayString_Insert1)
 {
+    ArrayString& c = db_setup_string::c;
+
     // Insert in middle
     c.insert(4, "xx");
 
@@ -261,8 +306,10 @@ TEST_FIXTURE(db_setup_string, ArrayStringInsert1)
     CHECK_EQUAL(9, c.size());
 }
 
-TEST_FIXTURE(db_setup_string, ArrayStringErase1)
+TEST(ArrayString_Erase1)
 {
+    ArrayString& c = db_setup_string::c;
+
     // Erase from end
     c.erase(8);
 
@@ -277,8 +324,10 @@ TEST_FIXTURE(db_setup_string, ArrayStringErase1)
     CHECK_EQUAL(8, c.size());
 }
 
-TEST_FIXTURE(db_setup_string, ArrayStringErase2)
+TEST(ArrayString_Erase2)
 {
+    ArrayString& c = db_setup_string::c;
+
     // Erase from top
     c.erase(0);
 
@@ -292,8 +341,10 @@ TEST_FIXTURE(db_setup_string, ArrayStringErase2)
     CHECK_EQUAL(7, c.size());
 }
 
-TEST_FIXTURE(db_setup_string, ArrayStringErase3)
+TEST(ArrayString_Erase3)
 {
+    ArrayString& c = db_setup_string::c;
+
     // Erase from middle
     c.erase(3);
 
@@ -306,8 +357,10 @@ TEST_FIXTURE(db_setup_string, ArrayStringErase3)
     CHECK_EQUAL(6, c.size());
 }
 
-TEST_FIXTURE(db_setup_string, ArrayStringEraseAll)
+TEST(ArrayString_EraseAll)
 {
+    ArrayString& c = db_setup_string::c;
+
     // Erase all items one at a time
     c.erase(0);
     c.erase(0);
@@ -320,8 +373,10 @@ TEST_FIXTURE(db_setup_string, ArrayStringEraseAll)
     CHECK_EQUAL(0, c.size());
 }
 
-TEST_FIXTURE(db_setup_string, ArrayStringInsert2)
+TEST(ArrayString_Insert2)
 {
+    ArrayString& c = db_setup_string::c;
+
     // Create new list
     c.clear();
     c.add("a");
@@ -340,8 +395,10 @@ TEST_FIXTURE(db_setup_string, ArrayStringInsert2)
     CHECK_EQUAL(5, c.size());
 }
 
-TEST_FIXTURE(db_setup_string, ArrayStringInsert3)
+TEST(ArrayString_Insert3)
 {
+    ArrayString& c = db_setup_string::c;
+
     // Insert in middle with expansion
     c.insert(3, "xxxxxxxxxx");
 
@@ -354,8 +411,10 @@ TEST_FIXTURE(db_setup_string, ArrayStringInsert3)
     CHECK_EQUAL(6, c.size());
 }
 
-TEST_FIXTURE(db_setup_string, ArrayStringFind3)
+TEST(ArrayString_Find3)
 {
+    ArrayString& c = db_setup_string::c;
+
     // Create new list
     c.clear();
     c.add("a");
@@ -369,8 +428,10 @@ TEST_FIXTURE(db_setup_string, ArrayStringFind3)
     CHECK_EQUAL(3, r);
 }
 
-TEST_FIXTURE(db_setup_string, ArrayStringFind4)
+TEST(ArrayString_Find4)
 {
+    ArrayString& c = db_setup_string::c;
+
     // Expand to 8 bytes width
     c.add("eeeeee");
 
@@ -380,8 +441,10 @@ TEST_FIXTURE(db_setup_string, ArrayStringFind4)
     CHECK_EQUAL(4, r);
 }
 
-TEST_FIXTURE(db_setup_string, ArrayStringFind5)
+TEST(ArrayString_Find5)
 {
+    ArrayString& c = db_setup_string::c;
+
     // Expand to 16 bytes width
     c.add("ffffffffffff");
 
@@ -391,8 +454,10 @@ TEST_FIXTURE(db_setup_string, ArrayStringFind5)
     CHECK_EQUAL(5, r);
 }
 
-TEST_FIXTURE(db_setup_string, ArrayStringFind6)
+TEST(ArrayString_Find6)
 {
+    ArrayString& c = db_setup_string::c;
+
     // Expand to 32 bytes width
     c.add("gggggggggggggggggggggggg");
 
@@ -402,8 +467,10 @@ TEST_FIXTURE(db_setup_string, ArrayStringFind6)
     CHECK_EQUAL(6, r);
 }
 
-TEST_FIXTURE(db_setup_string, ArrayStringFind7)
+TEST(ArrayString_Find7)
 {
+    ArrayString& c = db_setup_string::c;
+
     // Expand to 64 bytes width
     c.add("hhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhh");
 
@@ -413,9 +480,11 @@ TEST_FIXTURE(db_setup_string, ArrayStringFind7)
     CHECK_EQUAL(7, r);
 }
 
-TEST_FIXTURE(db_setup_string, ArrayStringFindAll)
+TEST(ArrayString_FindAll)
 {
+    ArrayString& c = db_setup_string::c;
     c.clear();
+
     Array col;
 
     // first, middle and end
@@ -435,8 +504,9 @@ TEST_FIXTURE(db_setup_string, ArrayStringFindAll)
     col.destroy();
 }
 
-TEST_FIXTURE(db_setup_string, ArrayStringCount)
+TEST(ArrayString_Count)
 {
+    ArrayString& c = db_setup_string::c;
     c.clear();
 
     // first, middle and end
@@ -450,8 +520,9 @@ TEST_FIXTURE(db_setup_string, ArrayStringCount)
     CHECK_EQUAL(3, count);
 }
 
-TEST_FIXTURE(db_setup_string, ArrayStringWithZeroBytes)
+TEST(ArrayString_WithZeroBytes)
 {
+    ArrayString& c = db_setup_string::c;
     c.clear();
 
     const char buf_1[] = { 'a', 0, 'b', 0, 'c' };
@@ -471,13 +542,15 @@ TEST_FIXTURE(db_setup_string, ArrayStringWithZeroBytes)
     CHECK_EQUAL(StringData(buf_3, sizeof buf_3), c.get(2));
 }
 
-TEST_FIXTURE(db_setup_string, ArrayStringDestroy)
+TEST(ArrayString_Destroy)
 {
+    ArrayString& c = db_setup_string::c;
+
     // clean up (ALWAYS PUT THIS LAST)
     c.destroy();
 }
 
-TEST(ArrayStringCompare)
+TEST(ArrayString_Compare)
 {
     ArrayString a, b;
 

--- a/test/test_array_string_long.cpp
+++ b/test/test_array_string_long.cpp
@@ -9,14 +9,22 @@ using namespace tightdb;
 // Note: You can now temporarely declare unit tests with the ONLY(TestName) macro instead of TEST(TestName). This
 // will disable all unit tests except these. Remember to undo your temporary changes before committing.
 
+
+namespace {
+
 struct db_setup_string_long {
     static ArrayStringLong c;
 };
 
 ArrayStringLong db_setup_string_long::c;
 
-TEST_FIXTURE(db_setup_string_long, ArrayStringLongMultiEmpty)
+} // anonymous namespace
+
+
+TEST(ArrayStringLong_MultiEmpty)
 {
+    ArrayStringLong& c = db_setup_string_long::c;
+
     c.add("");
     c.add("");
     c.add("");
@@ -33,8 +41,10 @@ TEST_FIXTURE(db_setup_string_long, ArrayStringLongMultiEmpty)
     CHECK_EQUAL("", c.get(5));
 }
 
-TEST_FIXTURE(db_setup_string_long, ArrayStringLongSet)
+TEST(ArrayStringLong_Set)
 {
+    ArrayStringLong& c = db_setup_string_long::c;
+
     c.set(0, "hey");
 
     CHECK_EQUAL(6, c.size());
@@ -46,9 +56,11 @@ TEST_FIXTURE(db_setup_string_long, ArrayStringLongSet)
     CHECK_EQUAL("", c.get(5));
 }
 
-TEST_FIXTURE(db_setup_string_long, ArrayStringLongAdd)
+TEST(ArrayStringLong_Add)
 {
+    ArrayStringLong& c = db_setup_string_long::c;
     c.clear();
+
     CHECK_EQUAL(0, c.size());
 
     c.add("abc");
@@ -61,8 +73,10 @@ TEST_FIXTURE(db_setup_string_long, ArrayStringLongAdd)
     CHECK_EQUAL(2, c.size());
 }
 
-TEST_FIXTURE(db_setup_string_long, ArrayStringLongSet2)
+TEST(ArrayStringLong_Set2)
 {
+    ArrayStringLong& c = db_setup_string_long::c;
+
     // {shrink, grow} x {first, middle, last, single}
     c.clear();
 
@@ -117,8 +131,9 @@ TEST_FIXTURE(db_setup_string_long, ArrayStringLongSet2)
 }
 
 
-TEST_FIXTURE(db_setup_string_long, ArrayStringLongInsert)
+TEST(ArrayStringLong_Insert)
 {
+    ArrayStringLong& c = db_setup_string_long::c;
     c.clear();
 
     c.insert(0, "abc"); // single
@@ -152,8 +167,9 @@ TEST_FIXTURE(db_setup_string_long, ArrayStringLongInsert)
     CHECK_EQUAL(5, c.size());
 }
 
-TEST_FIXTURE(db_setup_string_long, ArrayStringLongDelete)
+TEST(ArrayStringLong_Delete)
 {
+    ArrayStringLong& c = db_setup_string_long::c;
     c.clear();
 
     c.add("a");
@@ -189,8 +205,9 @@ TEST_FIXTURE(db_setup_string_long, ArrayStringLongDelete)
     CHECK(c.is_empty());
 }
 
-TEST_FIXTURE(db_setup_string_long, ArrayStringLongFind)
+TEST(ArrayStringLong_Find)
 {
+    ArrayStringLong& c = db_setup_string_long::c;
     c.clear();
 
     c.add("a");
@@ -209,8 +226,9 @@ TEST_FIXTURE(db_setup_string_long, ArrayStringLongFind)
     CHECK_EQUAL(3, res3);
 }
 
-TEST_FIXTURE(db_setup_string_long, ArrayStringLongCount)
+TEST(ArrayStringLong_Count)
 {
+    ArrayStringLong& c = db_setup_string_long::c;
     c.clear();
 
     // first, middle and end
@@ -225,8 +243,10 @@ TEST_FIXTURE(db_setup_string_long, ArrayStringLongCount)
 }
 
 
-TEST_FIXTURE(db_setup_string_long, ArrayStringLong_Destroy)
+TEST(ArrayStringLong_Destroy)
 {
+    ArrayStringLong& c = db_setup_string_long::c;
+
     // clean up (ALWAYS PUT THIS LAST)
     c.destroy();
 }

--- a/test/test_column.cpp
+++ b/test/test_column.cpp
@@ -12,38 +12,46 @@ using namespace tightdb;
 // Note: You can now temporarely declare unit tests with the ONLY(TestName) macro instead of TEST(TestName). This
 // will disable all unit tests except these. Remember to undo your temporary changes before committing.
 
+
+namespace {
+
 struct db_setup {
     static Column c;
 };
 
-// Pre-declare local functions
-
 Column db_setup::c;
 
-TEST_FIXTURE(db_setup, Column_IsEmpty)
+} // anonymous namespace
+
+
+TEST(Column_IsEmpty)
 {
+    Column& c = db_setup::c;
     CHECK_EQUAL(0U, c.size());
     CHECK(c.is_empty());
 }
 
-TEST_FIXTURE(db_setup, Column_Add0)
+TEST(Column_Add0)
 {
+    Column& c = db_setup::c;
     c.add(0);
     CHECK_EQUAL(0, c.get(0));
     CHECK_EQUAL(1U, c.size());
     CHECK(!c.is_empty());
 }
 
-TEST_FIXTURE(db_setup, Column_Add1)
+TEST(Column_Add1)
 {
+    Column& c = db_setup::c;
     c.add(1);
     CHECK_EQUAL(0, c.get(0));
     CHECK_EQUAL(1, c.get(1));
     CHECK_EQUAL(2U, c.size());
 }
 
-TEST_FIXTURE(db_setup, Column_Add2)
+TEST(Column_Add2)
 {
+    Column& c = db_setup::c;
     c.add(2);
     CHECK_EQUAL(0, c.get(0));
     CHECK_EQUAL(1, c.get(1));
@@ -51,8 +59,9 @@ TEST_FIXTURE(db_setup, Column_Add2)
     CHECK_EQUAL(3U, c.size());
 }
 
-TEST_FIXTURE(db_setup, Column_Add3)
+TEST(Column_Add3)
 {
+    Column& c = db_setup::c;
     c.add(3);
     CHECK_EQUAL(0, c.get(0));
     CHECK_EQUAL(1, c.get(1));
@@ -61,8 +70,9 @@ TEST_FIXTURE(db_setup, Column_Add3)
     CHECK_EQUAL(4U, c.size());
 }
 
-TEST_FIXTURE(db_setup, Column_Add4)
+TEST(Column_Add4)
 {
+    Column& c = db_setup::c;
     c.add(4);
     CHECK_EQUAL(0, c.get(0));
     CHECK_EQUAL(1, c.get(1));
@@ -72,8 +82,9 @@ TEST_FIXTURE(db_setup, Column_Add4)
     CHECK_EQUAL(5U, c.size());
 }
 
-TEST_FIXTURE(db_setup, Column_Add5)
+TEST(Column_Add5)
 {
+    Column& c = db_setup::c;
     c.add(16);
     CHECK_EQUAL(0,  c.get(0));
     CHECK_EQUAL(1,  c.get(1));
@@ -84,8 +95,9 @@ TEST_FIXTURE(db_setup, Column_Add5)
     CHECK_EQUAL(6U, c.size());
 }
 
-TEST_FIXTURE(db_setup, Column_Add6)
+TEST(Column_Add6)
 {
+    Column& c = db_setup::c;
     c.add(256);
     CHECK_EQUAL(0,   c.get(0));
     CHECK_EQUAL(1,   c.get(1));
@@ -97,8 +109,9 @@ TEST_FIXTURE(db_setup, Column_Add6)
     CHECK_EQUAL(7U, c.size());
 }
 
-TEST_FIXTURE(db_setup, Column_Add7)
+TEST(Column_Add7)
 {
+    Column& c = db_setup::c;
     c.add(65536);
     CHECK_EQUAL(0,     c.get(0));
     CHECK_EQUAL(1,     c.get(1));
@@ -111,8 +124,9 @@ TEST_FIXTURE(db_setup, Column_Add7)
     CHECK_EQUAL(8U, c.size());
 }
 
-TEST_FIXTURE(db_setup, Column_Add8)
+TEST(Column_Add8)
 {
+    Column& c = db_setup::c;
     c.add(4294967296LL);
     CHECK_EQUAL(0,            c.get(0));
     CHECK_EQUAL(1,            c.get(1));
@@ -126,17 +140,21 @@ TEST_FIXTURE(db_setup, Column_Add8)
     CHECK_EQUAL(9U, c.size());
 }
 
-TEST_FIXTURE(db_setup, Column_AddNeg1)
+TEST(Column_AddNeg1)
 {
+    Column& c = db_setup::c;
     c.clear();
+
     c.add(-1);
 
     CHECK_EQUAL(1U, c.size());
     CHECK_EQUAL(-1, c.get(0));
 }
 
-TEST_FIXTURE(db_setup, Column_AddNeg2)
+TEST(Column_AddNeg2)
 {
+    Column& c = db_setup::c;
+
     c.add(-256);
 
     CHECK_EQUAL(2U, c.size());
@@ -144,8 +162,10 @@ TEST_FIXTURE(db_setup, Column_AddNeg2)
     CHECK_EQUAL(-256, c.get(1));
 }
 
-TEST_FIXTURE(db_setup, Column_AddNeg3)
+TEST(Column_AddNeg3)
 {
+    Column& c = db_setup::c;
+
     c.add(-65536);
 
     CHECK_EQUAL(3U, c.size());
@@ -154,8 +174,10 @@ TEST_FIXTURE(db_setup, Column_AddNeg3)
     CHECK_EQUAL(-65536, c.get(2));
 }
 
-TEST_FIXTURE(db_setup, Column_AddNeg4)
+TEST(Column_AddNeg4)
 {
+    Column& c = db_setup::c;
+
     c.add(-4294967296LL);
 
     CHECK_EQUAL(4U, c.size());
@@ -165,8 +187,10 @@ TEST_FIXTURE(db_setup, Column_AddNeg4)
     CHECK_EQUAL(-4294967296LL, c.get(3));
 }
 
-TEST_FIXTURE(db_setup, Column_Set)
+TEST(Column_Set)
 {
+    Column& c = db_setup::c;
+
     c.set(0, 3);
     c.set(1, 2);
     c.set(2, 1);
@@ -179,8 +203,10 @@ TEST_FIXTURE(db_setup, Column_Set)
     CHECK_EQUAL(0, c.get(3));
 }
 
-TEST_FIXTURE(db_setup, Column_Insert1)
+TEST(Column_Insert1)
 {
+    Column& c = db_setup::c;
+
     // Set up some initial values
     c.clear();
     c.add(0);
@@ -199,8 +225,10 @@ TEST_FIXTURE(db_setup, Column_Insert1)
     CHECK_EQUAL(3,  c.get(4));
 }
 
-TEST_FIXTURE(db_setup, Column_Insert2)
+TEST(Column_Insert2)
 {
+    Column& c = db_setup::c;
+
     // Insert at top
     c.insert(0, 256);
 
@@ -213,8 +241,10 @@ TEST_FIXTURE(db_setup, Column_Insert2)
     CHECK_EQUAL(3,   c.get(5));
 }
 
-TEST_FIXTURE(db_setup, Column_Insert3)
+TEST(Column_Insert3)
 {
+    Column& c = db_setup::c;
+
     // Insert at bottom
     c.insert(6, 65536);
 
@@ -229,8 +259,10 @@ TEST_FIXTURE(db_setup, Column_Insert3)
 }
 
 /*
-TEST_FIXTURE(db_setup, Column_Index1)
+TEST(Column_Index1)
 {
+    Column& c = db_setup::c;
+
     // Create index
     Column index;
     c.BuildIndex(index);
@@ -247,8 +279,10 @@ TEST_FIXTURE(db_setup, Column_Index1)
 }
 */
 
-TEST_FIXTURE(db_setup, Column_Delete1)
+TEST(Column_Delete1)
 {
+    Column& c = db_setup::c;
+
     // Delete from middle
     c.erase(3, 3 == c.size()-1);
 
@@ -261,8 +295,10 @@ TEST_FIXTURE(db_setup, Column_Delete1)
     CHECK_EQUAL(65536, c.get(5));
 }
 
-TEST_FIXTURE(db_setup, Column_Delete2)
+TEST(Column_Delete2)
 {
+    Column& c = db_setup::c;
+
     // Delete from top
     c.erase(0, 0 == c.size()-1);
 
@@ -274,8 +310,10 @@ TEST_FIXTURE(db_setup, Column_Delete2)
     CHECK_EQUAL(65536, c.get(4));
 }
 
-TEST_FIXTURE(db_setup, Column_Delete3)
+TEST(Column_Delete3)
 {
+    Column& c = db_setup::c;
+
     // Delete from bottom
     c.erase(4, 4 == c.size()-1);
 
@@ -286,8 +324,10 @@ TEST_FIXTURE(db_setup, Column_Delete3)
     CHECK_EQUAL(3, c.get(3));
 }
 
-TEST_FIXTURE(db_setup, Column_DeleteAll)
+TEST(Column_DeleteAll)
 {
+    Column& c = db_setup::c;
+
     // Delete all items one at a time
     c.erase(0, 0 == c.size()-1);
     c.erase(0, 0 == c.size()-1);
@@ -299,16 +339,20 @@ TEST_FIXTURE(db_setup, Column_DeleteAll)
 }
 
 
-TEST_FIXTURE(db_setup, Column_Find1)
+TEST(Column_Find1)
 {
+    Column& c = db_setup::c;
+
     // Look for a non-existing value
     size_t res = c.find_first(10);
 
     CHECK_EQUAL(-1, res);
 }
 
-TEST_FIXTURE(db_setup, Column_Find2)
+TEST(Column_Find2)
 {
+    Column& c = db_setup::c;
+
     // zero-bit width
     c.clear();
     c.add(0);
@@ -318,8 +362,10 @@ TEST_FIXTURE(db_setup, Column_Find2)
     CHECK_EQUAL(0, res);
 }
 
-TEST_FIXTURE(db_setup, Column_Find3)
+TEST(Column_Find3)
 {
+    Column& c = db_setup::c;
+
     // expand to 1-bit width
     c.add(1);
 
@@ -327,8 +373,10 @@ TEST_FIXTURE(db_setup, Column_Find3)
     CHECK_EQUAL(2, res);
 }
 
-TEST_FIXTURE(db_setup, Column_Find4)
+TEST(Column_Find4)
 {
+    Column& c = db_setup::c;
+
     // expand to 2-bit width
     c.add(2);
 
@@ -336,8 +384,10 @@ TEST_FIXTURE(db_setup, Column_Find4)
     CHECK_EQUAL(3, res);
 }
 
-TEST_FIXTURE(db_setup, Column_Find5)
+TEST(Column_Find5)
 {
+    Column& c = db_setup::c;
+
     // expand to 4-bit width
     c.add(4);
 
@@ -345,8 +395,10 @@ TEST_FIXTURE(db_setup, Column_Find5)
     CHECK_EQUAL(4, res);
 }
 
-TEST_FIXTURE(db_setup, Column_Find6)
+TEST(Column_Find6)
 {
+    Column& c = db_setup::c;
+
     // expand to 8-bit width
     c.add(16);
 
@@ -359,8 +411,10 @@ TEST_FIXTURE(db_setup, Column_Find6)
     CHECK_EQUAL(7, res);
 }
 
-TEST_FIXTURE(db_setup, Column_Find7)
+TEST(Column_Find7)
 {
+    Column& c = db_setup::c;
+
     // expand to 16-bit width
     c.add(256);
 
@@ -368,8 +422,10 @@ TEST_FIXTURE(db_setup, Column_Find7)
     CHECK_EQUAL(8, res);
 }
 
-TEST_FIXTURE(db_setup, Column_Find8)
+TEST(Column_Find8)
 {
+    Column& c = db_setup::c;
+
     // expand to 32-bit width
     c.add(65536);
 
@@ -377,8 +433,10 @@ TEST_FIXTURE(db_setup, Column_Find8)
     CHECK_EQUAL(9, res);
 }
 
-TEST_FIXTURE(db_setup, Column_Find9)
+TEST(Column_Find9)
 {
+    Column& c = db_setup::c;
+
     // expand to 64-bit width
     c.add(4294967296LL);
 
@@ -386,7 +444,7 @@ TEST_FIXTURE(db_setup, Column_Find9)
     CHECK_EQUAL(10, res);
 }
 
-TEST_FIXTURE(db_setup, Column_FindLeafs)
+TEST(Column_FindLeafs)
 {
     Column a;
 
@@ -435,8 +493,9 @@ TEST_FIXTURE(db_setup, Column_FindLeafs)
 
 /* Partial find is not fully implemented yet
 #define PARTIAL_COUNT 100
-TEST_FIXTURE(db_setup, Column_PartialFind1)
+TEST(Column_PartialFind1)
 {
+    Column& c = db_setup::c;
     c.clear();
 
     for (size_t i = 0; i < PARTIAL_COUNT; ++i)
@@ -448,15 +507,19 @@ TEST_FIXTURE(db_setup, Column_PartialFind1)
 }
 */
 
-TEST_FIXTURE(db_setup, Column_HeaderParse)
+TEST(Column_HeaderParse)
 {
+    Column& c = db_setup::c;
+
     Column column(c.get_ref(), 0, 0);
     bool is_equal = c.compare_int(column);
     CHECK(is_equal);
 }
 
-TEST_FIXTURE(db_setup, Column_Destroy)
+TEST(Column_Destroy)
 {
+    Column& c = db_setup::c;
+
     // clean up (ALWAYS PUT THIS LAST)
     c.destroy();
 }
@@ -499,7 +562,7 @@ TEST(Column_Sort)
  *
  */
 
-TEST(Column_FindAll_IntMin)
+TEST(Column_FindAllIntMin)
 {
     Column c;
     Array r;
@@ -526,7 +589,7 @@ TEST(Column_FindAll_IntMin)
     r.destroy();
 }
 
-TEST(Column_FindAll_IntMax)
+TEST(Column_FindAllIntMax)
 {
     Column c;
     Array r;
@@ -612,7 +675,7 @@ TEST(Column_Average)
     c.destroy();
 }
 
-TEST(Column_Sum_Average)
+TEST(Column_SumAverage)
 {
     Column c;
     int64_t sum = 0;
@@ -752,7 +815,7 @@ TEST(Column_Sort2)
 
 #if TEST_DURATION > 0
 
-TEST(Column_prepend_many)
+TEST(Column_PrependMany)
 {
     // Test against a "Assertion failed: start < m_len, file src\Array.cpp, line 276" bug
     Column a;

--- a/test/test_column_binary.cpp
+++ b/test/test_column_binary.cpp
@@ -11,14 +11,22 @@ using namespace tightdb;
 // Note: You can now temporarely declare unit tests with the ONLY(TestName) macro instead of TEST(TestName). This
 // will disable all unit tests except these. Remember to undo your temporary changes before committing.
 
+
+namespace {
+
 struct db_setup_column_binary {
     static ColumnBinary c;
 };
 
 ColumnBinary db_setup_column_binary::c;
 
-TEST_FIXTURE(db_setup_column_binary, ColumnBinaryMultiEmpty)
+} // anonymous namespace
+
+
+TEST(ColumnBinary_MultiEmpty)
 {
+    ColumnBinary& c = db_setup_column_binary::c;
+
     c.add(BinaryData("", 0));
     c.add(BinaryData("", 0));
     c.add(BinaryData("", 0));
@@ -36,8 +44,10 @@ TEST_FIXTURE(db_setup_column_binary, ColumnBinaryMultiEmpty)
     CHECK_EQUAL(0, c.get(5).size());
 }
 
-TEST_FIXTURE(db_setup_column_binary, ColumnBinarySet)
+TEST(ColumnBinary_Set)
 {
+    ColumnBinary& c = db_setup_column_binary::c;
+
     c.set(0, BinaryData("hey", 4));
 
     CHECK_EQUAL(6, c.size());
@@ -51,9 +61,11 @@ TEST_FIXTURE(db_setup_column_binary, ColumnBinarySet)
     CHECK_EQUAL(0, c.get(5).size());
 }
 
-TEST_FIXTURE(db_setup_column_binary, ColumnBinaryAdd)
+TEST(ColumnBinary_Add)
 {
+    ColumnBinary& c = db_setup_column_binary::c;
     c.clear();
+
     CHECK_EQUAL(0, c.size());
 
     c.add(BinaryData("abc", 4));
@@ -69,8 +81,10 @@ TEST_FIXTURE(db_setup_column_binary, ColumnBinaryAdd)
     CHECK_EQUAL(2, c.size());
 }
 
-TEST_FIXTURE(db_setup_column_binary, ColumnBinarySet2)
+TEST(ColumnBinary_Set2)
 {
+    ColumnBinary& c = db_setup_column_binary::c;
+
     // {shrink, grow} x {first, middle, last, single}
     c.clear();
 
@@ -124,8 +138,9 @@ TEST_FIXTURE(db_setup_column_binary, ColumnBinarySet2)
     CHECK_EQUAL(3, c.size());
 }
 
-TEST_FIXTURE(db_setup_column_binary, ColumnBinaryInsert)
+TEST(ColumnBinary_Insert)
 {
+    ColumnBinary& c = db_setup_column_binary::c;
     c.clear();
 
     c.insert(0, BinaryData("abc", 4)); // single
@@ -168,8 +183,9 @@ TEST_FIXTURE(db_setup_column_binary, ColumnBinaryInsert)
     CHECK_EQUAL(6, c.size());
 }
 
-TEST_FIXTURE(db_setup_column_binary, ColumnBinaryDelete)
+TEST(ColumnBinary_Delete)
 {
+    ColumnBinary& c = db_setup_column_binary::c;
     c.clear();
 
     c.add(BinaryData("a", 2));
@@ -205,8 +221,9 @@ TEST_FIXTURE(db_setup_column_binary, ColumnBinaryDelete)
     CHECK(c.is_empty());
 }
 
-TEST_FIXTURE(db_setup_column_binary, ColumnBinaryBig)
+TEST(ColumnBinary_Big)
 {
+    ColumnBinary& c = db_setup_column_binary::c;
     c.clear();
 
     c.add(BinaryData("70 chars  70 chars  70 chars  70 chars  70 chars  70 chars  70 chars  ", 71));
@@ -251,8 +268,10 @@ TEST_FIXTURE(db_setup_column_binary, ColumnBinaryBig)
     }
 }
 
-TEST_FIXTURE(db_setup_column_binary, ColumnBinary_Destroy)
+TEST(ColumnBinary_Destroy)
 {
+    ColumnBinary& c = db_setup_column_binary::c;
+
     // clean up (ALWAYS PUT THIS LAST)
     c.destroy();
 }

--- a/test/test_column_string.cpp
+++ b/test/test_column_string.cpp
@@ -8,17 +8,25 @@
 
 using namespace tightdb;
 
+// Note: You can now temporarely declare unit tests with the ONLY(TestName) macro instead of TEST(TestName). This
+// will disable all unit tests except these. Remember to undo your temporary changes before committing.
+
+
+namespace {
+
 struct db_setup_column_string {
     static AdaptiveStringColumn c;
 };
 
 AdaptiveStringColumn db_setup_column_string::c;
 
-// Note: You can now temporarely declare unit tests with the ONLY(TestName) macro instead of TEST(TestName). This
-// will disable all unit tests except these. Remember to undo your temporary changes before committing.
+} // anonymous namespace
 
-TEST_FIXTURE(db_setup_column_string, ColumnStringMultiEmpty)
+
+TEST(ColumnString_MultiEmpty)
 {
+    AdaptiveStringColumn& c = db_setup_column_string::c;
+
     c.add("");
     c.add("");
     c.add("");
@@ -36,8 +44,10 @@ TEST_FIXTURE(db_setup_column_string, ColumnStringMultiEmpty)
 }
 
 
-TEST_FIXTURE(db_setup_column_string, ColumnStringSetExpand4)
+TEST(ColumnString_SetExpand4)
 {
+    AdaptiveStringColumn& c = db_setup_column_string::c;
+
     c.set(0, "hey");
 
     CHECK_EQUAL(6, c.size());
@@ -49,8 +59,10 @@ TEST_FIXTURE(db_setup_column_string, ColumnStringSetExpand4)
     CHECK_EQUAL("", c.get(5));
 }
 
-TEST_FIXTURE(db_setup_column_string, ColumnStringSetExpand8)
+TEST(ColumnString_SetExpand8)
 {
+    AdaptiveStringColumn& c = db_setup_column_string::c;
+
     c.set(1, "test");
 
     CHECK_EQUAL(6, c.size());
@@ -62,24 +74,27 @@ TEST_FIXTURE(db_setup_column_string, ColumnStringSetExpand8)
     CHECK_EQUAL("", c.get(5));
 }
 
-TEST_FIXTURE(db_setup_column_string, ColumnStringAdd0)
+TEST(ColumnString_Add0)
 {
+    AdaptiveStringColumn& c = db_setup_column_string::c;
     c.clear();
     c.add();
     CHECK_EQUAL("", c.get(0));
     CHECK_EQUAL(1, c.size());
 }
 
-TEST_FIXTURE(db_setup_column_string, ColumnStringAdd1)
+TEST(ColumnString_Add1)
 {
+    AdaptiveStringColumn& c = db_setup_column_string::c;
     c.add("a");
     CHECK_EQUAL("",  c.get(0));
     CHECK_EQUAL("a", c.get(1));
     CHECK_EQUAL(2, c.size());
 }
 
-TEST_FIXTURE(db_setup_column_string, ColumnStringAdd2)
+TEST(ColumnString_Add2)
 {
+    AdaptiveStringColumn& c = db_setup_column_string::c;
     c.add("bb");
     CHECK_EQUAL("",   c.get(0));
     CHECK_EQUAL("a",  c.get(1));
@@ -87,8 +102,9 @@ TEST_FIXTURE(db_setup_column_string, ColumnStringAdd2)
     CHECK_EQUAL(3, c.size());
 }
 
-TEST_FIXTURE(db_setup_column_string, ColumnStringAdd3)
+TEST(ColumnString_Add3)
 {
+    AdaptiveStringColumn& c = db_setup_column_string::c;
     c.add("ccc");
     CHECK_EQUAL("",    c.get(0));
     CHECK_EQUAL("a",   c.get(1));
@@ -97,8 +113,9 @@ TEST_FIXTURE(db_setup_column_string, ColumnStringAdd3)
     CHECK_EQUAL(4, c.size());
 }
 
-TEST_FIXTURE(db_setup_column_string, ColumnStringAdd4)
+TEST(ColumnString_Add4)
 {
+    AdaptiveStringColumn& c = db_setup_column_string::c;
     c.add("dddd");
     CHECK_EQUAL("",     c.get(0));
     CHECK_EQUAL("a",    c.get(1));
@@ -108,8 +125,9 @@ TEST_FIXTURE(db_setup_column_string, ColumnStringAdd4)
     CHECK_EQUAL(5, c.size());
 }
 
-TEST_FIXTURE(db_setup_column_string, ColumnStringAdd8)
+TEST(ColumnString_Add8)
 {
+    AdaptiveStringColumn& c = db_setup_column_string::c;
     c.add("eeeeeeee");
     CHECK_EQUAL("",     c.get(0));
     CHECK_EQUAL("a",    c.get(1));
@@ -120,8 +138,9 @@ TEST_FIXTURE(db_setup_column_string, ColumnStringAdd8)
     CHECK_EQUAL(6, c.size());
 }
 
-TEST_FIXTURE(db_setup_column_string, ColumnStringAdd16)
+TEST(ColumnString_Add16)
 {
+    AdaptiveStringColumn& c = db_setup_column_string::c;
     c.add("ffffffffffffffff");
     CHECK_EQUAL("",     c.get(0));
     CHECK_EQUAL("a",    c.get(1));
@@ -133,8 +152,10 @@ TEST_FIXTURE(db_setup_column_string, ColumnStringAdd16)
     CHECK_EQUAL(7, c.size());
 }
 
-TEST_FIXTURE(db_setup_column_string, ColumnStringAdd32)
+TEST(ColumnString_Add32)
 {
+    AdaptiveStringColumn& c = db_setup_column_string::c;
+
     c.add("gggggggggggggggggggggggggggggggg");
 
     CHECK_EQUAL("",     c.get(0));
@@ -148,8 +169,10 @@ TEST_FIXTURE(db_setup_column_string, ColumnStringAdd32)
     CHECK_EQUAL(8, c.size());
 }
 
-TEST_FIXTURE(db_setup_column_string, ColumnStringAdd64)
+TEST(ColumnString_Add64)
 {
+    AdaptiveStringColumn& c = db_setup_column_string::c;
+
     // Add a string longer than 64 bytes to trigger long strings
     c.add("xxxxxxxx xxxxxxxx xxxxxxxx xxxxxxxx xxxxxxxx xxxxxxxx xxxxxxxx xxxxxxxx");
 
@@ -166,8 +189,10 @@ TEST_FIXTURE(db_setup_column_string, ColumnStringAdd64)
 }
 
 
-TEST_FIXTURE(db_setup_column_string, ColumnStringSet1)
+TEST(ColumnString_Set1)
 {
+    AdaptiveStringColumn& c = db_setup_column_string::c;
+
     c.set(0, "ccc");
     c.set(1, "bb");
     c.set(2, "a");
@@ -186,8 +211,10 @@ TEST_FIXTURE(db_setup_column_string, ColumnStringSet1)
     CHECK_EQUAL("xxxxxxxx xxxxxxxx xxxxxxxx xxxxxxxx xxxxxxxx xxxxxxxx xxxxxxxx xxxxxxxx", c.get(8));
 }
 
-TEST_FIXTURE(db_setup_column_string, ColumnStringInsert1)
+TEST(ColumnString_Insert1)
 {
+    AdaptiveStringColumn& c = db_setup_column_string::c;
+
     // Insert in middle
     c.insert(4, "xx");
 
@@ -205,8 +232,10 @@ TEST_FIXTURE(db_setup_column_string, ColumnStringInsert1)
     CHECK_EQUAL("xxxxxxxx xxxxxxxx xxxxxxxx xxxxxxxx xxxxxxxx xxxxxxxx xxxxxxxx xxxxxxxx", c.get(9));
 }
 
-TEST_FIXTURE(db_setup_column_string, ColumnStringDelete1)
+TEST(ColumnString_Delete1)
 {
+    AdaptiveStringColumn& c = db_setup_column_string::c;
+
     // Delete from end
     c.erase(9, 9 == c.size()-1);
 
@@ -223,8 +252,10 @@ TEST_FIXTURE(db_setup_column_string, ColumnStringDelete1)
     CHECK_EQUAL("gggggggggggggggggggggggggggggggg", c.get(8));
 }
 
-TEST_FIXTURE(db_setup_column_string, ColumnStringDelete2)
+TEST(ColumnString_Delete2)
 {
+    AdaptiveStringColumn& c = db_setup_column_string::c;
+
     // Delete from top
     c.erase(0, 0 == c.size()-1);
 
@@ -240,8 +271,10 @@ TEST_FIXTURE(db_setup_column_string, ColumnStringDelete2)
     CHECK_EQUAL("gggggggggggggggggggggggggggggggg", c.get(7));
 }
 
-TEST_FIXTURE(db_setup_column_string, ColumnStringDelete3)
+TEST(ColumnString_Delete3)
 {
+    AdaptiveStringColumn& c = db_setup_column_string::c;
+
     // Delete from middle
     c.erase(3, 3 == c.size()-1);
 
@@ -256,8 +289,10 @@ TEST_FIXTURE(db_setup_column_string, ColumnStringDelete3)
     CHECK_EQUAL("gggggggggggggggggggggggggggggggg", c.get(6));
 }
 
-TEST_FIXTURE(db_setup_column_string, ColumnStringDeleteAll)
+TEST(ColumnString_DeleteAll)
 {
+    AdaptiveStringColumn& c = db_setup_column_string::c;
+
     // Delete all items one at a time
     c.erase(0, 0 == c.size()-1);
     CHECK_EQUAL(6, c.size());
@@ -277,8 +312,10 @@ TEST_FIXTURE(db_setup_column_string, ColumnStringDeleteAll)
     CHECK(c.is_empty());
 }
 
-TEST_FIXTURE(db_setup_column_string, ColumnStringInsert2)
+TEST(ColumnString_Insert2)
 {
+    AdaptiveStringColumn& c = db_setup_column_string::c;
+
     // Create new list
     c.clear();
     c.add("a");
@@ -297,8 +334,10 @@ TEST_FIXTURE(db_setup_column_string, ColumnStringInsert2)
     CHECK_EQUAL(5, c.size());
 }
 
-TEST_FIXTURE(db_setup_column_string, ColumnStringInsert3)
+TEST(ColumnString_Insert3)
 {
+    AdaptiveStringColumn& c = db_setup_column_string::c;
+
     // Insert in middle with expansion
     c.insert(3, "xxxxxxxxxx");
 
@@ -311,7 +350,7 @@ TEST_FIXTURE(db_setup_column_string, ColumnStringInsert3)
     CHECK_EQUAL(6, c.size());
 }
 
-TEST(ColumnStringFind1)
+TEST(ColumnString_Find1)
 {
     AdaptiveStringColumn c;
 
@@ -334,7 +373,7 @@ TEST(ColumnStringFind1)
     c.destroy();
 }
 
-TEST(ColumnStringFind2)
+TEST(ColumnString_Find2)
 {
     AdaptiveStringColumn c;
 
@@ -363,7 +402,7 @@ TEST(ColumnStringFind2)
     c.destroy();
 }
 
-TEST(ColumnStringAutoEnumerate)
+TEST(ColumnString_AutoEnumerate)
 {
     AdaptiveStringColumn c;
 
@@ -407,7 +446,7 @@ TEST(ColumnStringAutoEnumerate)
 
 #if !defined DISABLE_INDEX
 
-TEST(ColumnStringAutoEnumerateIndex)
+TEST(ColumnString_AutoEnumerateIndex)
 {
     AdaptiveStringColumn c;
 
@@ -489,7 +528,7 @@ TEST(ColumnStringAutoEnumerateIndex)
     results.destroy();
 }
 
-TEST(ColumnStringAutoEnumerateIndexReuse)
+TEST(ColumnString_AutoEnumerateIndexReuse)
 {
     AdaptiveStringColumn c;
 
@@ -535,9 +574,11 @@ TEST(ColumnStringAutoEnumerateIndexReuse)
 
 
 // Test "Replace string array with long string array" when doing it through LeafSet()
-TEST_FIXTURE(db_setup_column_string, ArrayStringSetLeafToLong)
+TEST(ColumnString_SetLeafToLong)
 {
+    AdaptiveStringColumn& c = db_setup_column_string::c;
     c.clear();
+
     Column col;
 
     c.add("foobar");
@@ -556,9 +597,11 @@ TEST_FIXTURE(db_setup_column_string, ArrayStringSetLeafToLong)
 }
 
 // Test "Replace string array with long string array" when doing it through LeafSet()
-TEST_FIXTURE(db_setup_column_string, ArrayStringSetLeafToBig)
+TEST(ColumnString_SetLeafToBig)
 {
+    AdaptiveStringColumn& c = db_setup_column_string::c;
     c.clear();
+
     Column col;
 
     c.add("foobar");
@@ -577,9 +620,11 @@ TEST_FIXTURE(db_setup_column_string, ArrayStringSetLeafToBig)
 }
 
 // Test against a bug where FindWithLen() would fail finding ajacent hits
-TEST_FIXTURE(db_setup_column_string, ArrayStringLongFindAjacent)
+TEST(ColumnString_FindAjacentLong)
 {
+    AdaptiveStringColumn& c = db_setup_column_string::c;
     c.clear();
+
     Array col;
 
     c.add("40 chars  40 chars  40 chars  40 chars  ");
@@ -595,9 +640,11 @@ TEST_FIXTURE(db_setup_column_string, ArrayStringLongFindAjacent)
     col.destroy();
 }
 
-TEST_FIXTURE(db_setup_column_string, ArrayStringBigFindAjacent)
+TEST(ColumnString_FindAjacentBig)
 {
+    AdaptiveStringColumn& c = db_setup_column_string::c;
     c.clear();
+
     Array col;
 
     c.add("70 chars  70 chars  70 chars  70 chars  70 chars  70 chars  70 chars  ");
@@ -613,7 +660,7 @@ TEST_FIXTURE(db_setup_column_string, ArrayStringBigFindAjacent)
     col.destroy();
 }
 
-TEST(AdaptiveStringColumnFindAllExpand)
+TEST(ColumnString_FindAllExpand)
 {
     AdaptiveStringColumn asc;
     Array c;
@@ -657,7 +704,7 @@ TEST(AdaptiveStringColumnFindAllExpand)
 }
 
 // FindAll using ranges, when expanded ArrayStringLong
-TEST(AdaptiveStringColumnFindAllRangesLong)
+TEST(ColumnString_FindAllRangesLong)
 {
     AdaptiveStringColumn asc;
     Array c;
@@ -711,7 +758,7 @@ TEST(AdaptiveStringColumnFindAllRangesLong)
 }
 
 // FindAll using ranges, when not expanded (using ArrayString)
-TEST(AdaptiveStringColumnFindAllRanges)
+TEST(ColumnString_FindAllRanges)
 {
     AdaptiveStringColumn asc;
     Array c;
@@ -764,7 +811,7 @@ TEST(AdaptiveStringColumnFindAllRanges)
     c.destroy();
 }
 
-TEST(AdaptiveStringColumnCount)
+TEST(ColumnString_Count)
 {
     AdaptiveStringColumn asc;
 
@@ -809,7 +856,7 @@ TEST(AdaptiveStringColumnCount)
 
 #if !defined DISABLE_INDEX
 
-TEST(AdaptiveStringColumnIndex)
+TEST(ColumnString_Index)
 {
     AdaptiveStringColumn asc;
 
@@ -910,8 +957,10 @@ TEST(AdaptiveStringColumnIndex)
 #endif // !defined DISABLE_INDEX
 
 
-TEST_FIXTURE(db_setup_column_string, ColumnString_Destroy)
+TEST(ColumnString_Destroy)
 {
+    AdaptiveStringColumn& c = db_setup_column_string::c;
+
     // clean up (ALWAYS PUT THIS LAST)
     c.destroy();
 }


### PR DESCRIPTION
The `TEST_FIXTURE` macro of UnitTest++ was in widespread use in our test suite, however, its use was everywhere based on a misunderstanding of the concept of test fixtures.

According to UnitTest++, a "test fixture" is a class that is independently and individually instantiated for each test declared with with `TEST_FIXTURE`.

From the way it was used in our test suite, it was clear that the desire was to keep a state from one test to the next. Since UnitTest++ offers no support for chained tests, the actual state-keeping was done manually anyway, and therefore, the use of `TEST_FIXTURE` was completely futile, and highly misleading for the reader.

Further more, since it is so easy in C++ to create a setup/teardown senario (RAII), there is no real need for test fixtures in C++ test frameworks.

@emanuelez @astigsen 
