### PR TITLE
removed /usr/local/bin/tightdbd{-dbg} from list of installed programs in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,6 +102,8 @@ The following programs will be installed:
     /usr/local/bin/tightdb-import-dbg
     /usr/local/bin/tightdb-config
     /usr/local/bin/tightdb-config-dbg
+    /usr/local/libexec/tightdbd
+    /usr/local/libexec/tightdbd-dbg
 
 The `tightdb-import` tool lets you load files containing
 comma-separated values into TightDB. The next two are used


### PR DESCRIPTION
The README states that `tightdbd` and `tightdbd-dbg` are installed on, but that wasn't the case.

```
$ ls /usr/local/bin | grep tight
tightdb-config
tightdb-config-dbg
tightdb-import
tightdb-import-dbg
```

It could also be that the installation didn't work properly in my case, or that this daemon isn't installed on OS X. If so, disregard this PR.
