### PR TITLE
Fixing replication bug (subspec index vs column index) and some cleanup

### DIFF
--- a/src/tightdb/descriptor.hpp
+++ b/src/tightdb/descriptor.hpp
@@ -361,6 +361,10 @@ private:
     friend class util::bind_ptr<Descriptor>;
     friend class util::bind_ptr<const Descriptor>;
     friend class Table;
+
+#ifdef TIGHTDB_ENABLE_REPLICATION
+    friend class Replication;
+#endif
 };
 
 

--- a/src/tightdb/group.cpp
+++ b/src/tightdb/group.cpp
@@ -11,7 +11,9 @@
 #include <tightdb/utilities.hpp>
 #include <tightdb/group_writer.hpp>
 #include <tightdb/group.hpp>
-#include <pthread.h>
+#ifdef TIGHTDB_ENABLE_REPLICATION
+#  include <tightdb/replication.hpp>
+#endif
 
 using namespace std;
 using namespace tightdb;

--- a/src/tightdb/group.hpp
+++ b/src/tightdb/group.hpp
@@ -216,12 +216,13 @@ public:
     /// Get the table with the specified name (or at the specified
     /// idnex) from this group.
     ///
-    /// The non-const versions of this function will create a table
-    /// with the specified name if one does not already exist. The
-    /// const versions will not.
+    /// The non-const versions of this function, that take a name as
+    /// argument, will create a table with the specified name if one
+    /// does not already exist. The other versions will not.
     ///
     /// It is an error to call one of the const-qualified versions for
-    /// a table that does not already exist. Doing so will result in
+    /// a table that does not already exist. The same is true for the
+    /// versions taking and index as argument. Doing so will result in
     /// undefined behavior.
     ///
     /// The non-template versions will return dynamically typed table
@@ -232,16 +233,17 @@ public:
     /// table whose dynamic type does not match the specified static
     /// type. Doing so will result in undefined behavior.
     ///
-    /// New tables created by the non-const non-template version will
-    /// have no columns initially. New tables created by the non-const
-    /// template version will have a dynamic type (set of columns)
-    /// that matches the specifed static type.
+    /// New tables created by non-template versions will have no
+    /// columns initially. New tables created by template versions
+    /// will have a dynamic type (set of columns) that matches the
+    /// specifed static type.
     ///
     /// \tparam T An instance of the BasicTable<> class template.
+    TableRef      get_table(std::size_t table_ndx);
+    ConstTableRef get_table(std::size_t table_ndx) const;
     TableRef      get_table(StringData name);
     TableRef      get_table(StringData name, bool& was_created);
     ConstTableRef get_table(StringData name) const;
-    ConstTableRef get_table(std::size_t table_ndx) const;
     template<class T> typename T::Ref      get_table(StringData name);
     template<class T> typename T::ConstRef get_table(StringData name) const;
     //@}
@@ -566,6 +568,16 @@ template<class T> inline const T* Group::get_table_ptr(StringData name) const
     return static_cast<const T*>(table);
 }
 
+inline TableRef Group::get_table(std::size_t table_ndx)
+{
+    return get_table_by_ndx(table_ndx)->get_table_ref();
+}
+
+inline ConstTableRef Group::get_table(std::size_t table_ndx) const
+{
+    return get_table_by_ndx(table_ndx)->get_table_ref();
+}
+
 inline TableRef Group::get_table(StringData name)
 {
     return get_table_ptr(name)->get_table_ref();
@@ -581,11 +593,6 @@ inline ConstTableRef Group::get_table(StringData name) const
 {
     TIGHTDB_ASSERT(has_table(name));
     return get_table_ptr(name)->get_table_ref();
-}
-
-inline ConstTableRef Group::get_table(std::size_t table_ndx) const
-{
-    return get_table_by_ndx(table_ndx)->get_table_ref();
 }
 
 template<class T> inline typename T::Ref Group::get_table(StringData name)

--- a/src/tightdb/replication.cpp
+++ b/src/tightdb/replication.cpp
@@ -51,7 +51,8 @@ void Replication::select_table(const Table* table)
     size_t* end;
     for (;;) {
         begin = m_subtab_path_buf.data();
-        end = table->record_subtable_path(begin, begin+m_subtab_path_buf.size());
+        end   = begin + m_subtab_path_buf.size();
+        end = _impl::TableFriend::record_subtable_path(*table, begin, end);
         if (end)
             break;
         size_t new_size = m_subtab_path_buf.size();
@@ -67,7 +68,7 @@ void Replication::select_table(const Table* table)
     const size_t level = (end - begin) / 2;
     buf = encode_int(buf, level);
     for (;;) {
-        for (int i=0; i<max_elems_per_chunk; ++i) {
+        for (int i = 0; i < max_elems_per_chunk; ++i) {
             buf = encode_int(buf, *--end);
             if (begin == end)
                 goto good;
@@ -83,16 +84,16 @@ good:
 }
 
 
-void Replication::select_spec(const Table* table, const Spec* spec)
+void Replication::select_desc(const Descriptor& desc)
 {
-    TIGHTDB_ASSERT(!table->has_shared_type());
-    check_table(table);
+    check_table(&*desc.m_root_table);
     size_t* begin;
     size_t* end;
     for (;;) {
         begin = m_subtab_path_buf.data();
-        end = table->record_subspec_path(*spec, begin, begin+m_subtab_path_buf.size());
-        if (end)
+        end   = begin + m_subtab_path_buf.size();
+        begin = desc.record_subdesc_path(begin, end);
+        if (begin)
             break;
         size_t new_size = m_subtab_path_buf.size();
         if (int_multiply_with_overflow_detect(new_size, 2))
@@ -100,17 +101,17 @@ void Replication::select_spec(const Table* table, const Spec* spec)
         m_subtab_path_buf.set_size(new_size); // Throws
     }
     char* buf;
-    const int max_elems_per_chunk = 8; // FIXME: Use smaller number when compiling in debug mode
+    int max_elems_per_chunk = 8; // FIXME: Use smaller number when compiling in debug mode
     transact_log_reserve(&buf, 1 + (1+max_elems_per_chunk)*max_enc_bytes_per_int); // Throws
     *buf++ = 'S';
-    const size_t level = end - begin;
+    size_t level = end - begin;
     buf = encode_int(buf, level);
     if (begin == end)
         goto good;
     for (;;) {
-        for (int i=0; i<max_elems_per_chunk; ++i) {
-            buf = encode_int(buf, *--end);
-            if (begin == end)
+        for (int i = 0; i < max_elems_per_chunk; ++i) {
+            buf = encode_int(buf, *begin);
+            if (++begin == end)
                 goto good;
         }
         transact_log_advance(buf);
@@ -119,7 +120,7 @@ void Replication::select_spec(const Table* table, const Spec* spec)
 
 good:
     transact_log_advance(buf);
-    m_selected_spec = spec;
+    m_selected_spec = desc.m_spec;
 }
 
 
@@ -190,12 +191,14 @@ private:
         switch (type) {
             case type_Int:
             case type_Bool:
-            case type_DateTime:
+            case type_Float:
+            case type_Double:
             case type_String:
             case type_Binary:
+            case type_DateTime:
             case type_Table:
-            case type_Mixed: return true;
-            default:         break;
+            case type_Mixed:
+                return true;
         }
         return false;
     }
@@ -374,26 +377,6 @@ void Replication::TransactLogApplier::set_or_insert(size_t column_ndx, size_t nd
             }
             return;
         }
-        case type_DateTime: {
-            time_t value = read_int<time_t>(); // Throws
-#ifdef TIGHTDB_DEBUG
-            if (m_log) {
-                if (insert) {
-                    *m_log << "table->insert_datetime("<<column_ndx<<", "<<ndx<<", "<<value<<")\n";
-                }
-                else {
-                    *m_log << "table->set_datetime("<<column_ndx<<", "<<ndx<<", "<<value<<")\n";
-                }
-            }
-#endif
-            if (insert) {
-                m_table->insert_datetime(column_ndx, ndx, value); // FIXME: Memory allocation failure!!!
-            }
-            else {
-                m_table->set_datetime(column_ndx, ndx, value); // FIXME: Memory allocation failure!!!
-            }
-            return;
-        }
         case type_String: {
             read_string(m_string_buffer); // Throws
             StringData value(m_string_buffer.data(), m_string_buffer.size());
@@ -436,6 +419,26 @@ void Replication::TransactLogApplier::set_or_insert(size_t column_ndx, size_t nd
             }
             return;
         }
+        case type_DateTime: {
+            time_t value = read_int<time_t>(); // Throws
+#ifdef TIGHTDB_DEBUG
+            if (m_log) {
+                if (insert) {
+                    *m_log << "table->insert_datetime("<<column_ndx<<", "<<ndx<<", "<<value<<")\n";
+                }
+                else {
+                    *m_log << "table->set_datetime("<<column_ndx<<", "<<ndx<<", "<<value<<")\n";
+                }
+            }
+#endif
+            if (insert) {
+                m_table->insert_datetime(column_ndx, ndx, value); // FIXME: Memory allocation failure!!!
+            }
+            else {
+                m_table->set_datetime(column_ndx, ndx, value); // FIXME: Memory allocation failure!!!
+            }
+            return;
+        }
         case type_Table: {
 #ifdef TIGHTDB_DEBUG
             if (m_log) {
@@ -456,131 +459,73 @@ void Replication::TransactLogApplier::set_or_insert(size_t column_ndx, size_t nd
             return;
         }
         case type_Mixed: {
-            int type = read_int<int>(); // Throws
+            DataType type = DataType(read_int<int>()); // Throws
+            Mixed mixed;
             switch (type) {
                 case type_Int: {
                     int64_t value = read_int<int64_t>(); // Throws
-#ifdef TIGHTDB_DEBUG
-                    if (m_log) {
-                        if (insert) {
-                            *m_log << "table->insert_mixed("<<column_ndx<<", "<<ndx<<", "<<value<<")\n";
-                        }
-                        else {
-                            *m_log << "table->set_mixed("<<column_ndx<<", "<<ndx<<", "<<value<<")\n";
-                        }
-                    }
-#endif
-                    if (insert) {
-                        m_table->insert_mixed(column_ndx, ndx, value); // FIXME: Memory allocation failure!!!
-                    }
-                    else {
-                        m_table->set_mixed(column_ndx, ndx, value); // FIXME: Memory allocation failure!!!
-                    }
-                    return;
+                    mixed = value;
+                    goto mixed;
                 }
                 case type_Bool: {
                     bool value = read_int<bool>(); // Throws
-#ifdef TIGHTDB_DEBUG
-                    if (m_log) {
-                        if (insert) {
-                            *m_log << "table->insert_mixed("<<column_ndx<<", "<<ndx<<", "<<value<<")\n";
-                        }
-                        else {
-                            *m_log << "table->set_mixed("<<column_ndx<<", "<<ndx<<", "<<value<<")\n";
-                        }
-                    }
-#endif
-                    if (insert) {
-                        m_table->insert_mixed(column_ndx, ndx, value); // FIXME: Memory allocation failure!!!
-                    }
-                    else {
-                        m_table->set_mixed(column_ndx, ndx, value); // FIXME: Memory allocation failure!!!
-                    }
-                    return;
+                    mixed = value;
+                    goto mixed;
+                }
+                case type_Float: {
+                    float value = read_float(); // Throws
+                    mixed = value;
+                    goto mixed;
+                }
+                case type_Double: {
+                    double value = read_double(); // Throws
+                    mixed = value;
+                    goto mixed;
                 }
                 case type_DateTime: {
                     time_t value = read_int<time_t>(); // Throws
-#ifdef TIGHTDB_DEBUG
-                    if (m_log) {
-                        if (insert) {
-                            *m_log << "table->insert_mixed("<<column_ndx<<", "<<ndx<<", DateTime("<<value<<"))\n";
-                        }
-                        else {
-                            *m_log << "table->set_mixed("<<column_ndx<<", "<<ndx<<", DateTime("<<value<<"))\n";
-                        }
-                    }
-#endif
-                    if (insert) {
-                        m_table->insert_mixed(column_ndx, ndx, DateTime(value)); // FIXME: Memory allocation failure!!!
-                    }
-                    else {
-                        m_table->set_mixed(column_ndx, ndx, DateTime(value)); // FIXME: Memory allocation failure!!!
-                    }
-                    return;
+                    mixed = DateTime(value);
+                    goto mixed;
                 }
                 case type_String: {
                     read_string(m_string_buffer); // Throws
                     StringData value(m_string_buffer.data(), m_string_buffer.size());
-#ifdef TIGHTDB_DEBUG
-                    if (m_log) {
-                        if (insert) {
-                            *m_log << "table->insert_mixed("<<column_ndx<<", "<<ndx<<", \""<<value<<"\")\n";
-                        }
-                        else {
-                            *m_log << "table->set_mixed("<<column_ndx<<", "<<ndx<<", \""<<value<<"\")\n";
-                        }
-                    }
-#endif
-                    if (insert) {
-                        m_table->insert_mixed(column_ndx, ndx, value); // FIXME: Memory allocation failure!!!
-                    }
-                    else {
-                        m_table->set_mixed(column_ndx, ndx, value); // FIXME: Memory allocation failure!!!
-                    }
-                    return;
+                    mixed = value;
+                    goto mixed;
                 }
                 case type_Binary: {
                     read_string(m_string_buffer); // Throws
                     BinaryData value(m_string_buffer.data(), m_string_buffer.size());
-#ifdef TIGHTDB_DEBUG
-                    if (m_log) {
-                        if (insert) {
-                            *m_log << "table->insert_mixed("<<column_ndx<<", "<<ndx<<", BinaryData(...))\n";
-                        }
-                        else {
-                            *m_log << "table->set_mixed("<<column_ndx<<", "<<ndx<<", BinaryData(...))\n";
-                        }
-                    }
-#endif
-                    if (insert) {
-                        m_table->insert_mixed(column_ndx, ndx, value); // FIXME: Memory allocation failure!!!
-                    }
-                    else {
-                        m_table->set_mixed(column_ndx, ndx, value); // FIXME: Memory allocation failure!!!
-                    }
-                    return;
+                    mixed = value;
+                    goto mixed;
                 }
                 case type_Table: {
-#ifdef TIGHTDB_DEBUG
-                    if (m_log) {
-                        if (insert) {
-                            *m_log << "table->insert_mixed("<<column_ndx<<", "<<ndx<<", Mixed::subtable_tag())\n";
-                        }
-                        else {
-                            *m_log << "table->set_mixed("<<column_ndx<<", "<<ndx<<", Mixed::subtable_tag())\n";
-                        }
-                    }
-#endif
-                    if (insert) {
-                        m_table->insert_mixed(column_ndx, ndx, Mixed::subtable_tag()); // FIXME: Memory allocation failure!!!
-                    }
-                    else {
-                        m_table->set_mixed(column_ndx, ndx, Mixed::subtable_tag()); // FIXME: Memory allocation failure!!!
-                    }
-                    return;
+                    mixed = Mixed::subtable_tag();
+                    goto mixed;
                 }
+                case type_Mixed:
+                    break;
             }
             break;
+
+          mixed:
+#ifdef TIGHTDB_DEBUG
+            if (m_log) {
+                if (insert) {
+                    *m_log << "table->insert_mixed("<<column_ndx<<", "<<ndx<<", \""<<mixed<<"\")\n";
+                }
+                else {
+                    *m_log << "table->set_mixed("<<column_ndx<<", "<<ndx<<", \""<<mixed<<"\")\n";
+                }
+            }
+#endif
+            if (insert) {
+                m_table->insert_mixed(column_ndx, ndx, mixed); // FIXME: Memory allocation failure!!!
+            }
+            else {
+                m_table->set_mixed(column_ndx, ndx, mixed); // FIXME: Memory allocation failure!!!
+            }
+            return;
         }
     }
     throw BadTransactLog();
@@ -687,11 +632,11 @@ void Replication::TransactLogApplier::apply()
                     goto bad_transact_log;
 #ifdef TIGHTDB_DEBUG
                 if (m_log)
-                    *m_log << "table = group->get_table_by_ndx("<<ndx<<")\n";
+                    *m_log << "table = group->get_table("<<ndx<<")\n";
 #endif
-                m_table = m_group.get_table_by_ndx(ndx)->get_table_ref();
+                m_table = m_group.get_table(ndx);
                 desc.reset();
-                for (int i=0; i<levels; ++i) {
+                for (int i = 0; i < levels; ++i) {
                     size_t column_ndx = read_int<size_t>(); // Throws
                     ndx = read_int<size_t>(); // Throws
                     if (column_ndx >= m_table->get_column_count())
@@ -805,15 +750,15 @@ void Replication::TransactLogApplier::apply()
 #endif
                 desc = m_table->get_descriptor();
                 int levels = read_int<int>(); // Throws
-                for (int i=0; i<levels; ++i) {
-                    size_t subdesc_ndx = read_int<size_t>(); // Throws
-                    if (subdesc_ndx >= _impl::TableFriend::get_num_subdescs(*desc))
+                for (int i = 0; i < levels; ++i) {
+                    size_t column_ndx = read_int<size_t>(); // Throws
+                    if (column_ndx >= desc->get_column_count())
                         goto bad_transact_log;
 #ifdef TIGHTDB_DEBUG
                     if (m_log)
-                        *m_log << "desc = desc->get_subdescriptor("<<subdesc_ndx<<")\n";
+                        *m_log << "desc = desc->get_subdescriptor("<<column_ndx<<")\n";
 #endif
-                    desc = desc->get_subdescriptor(subdesc_ndx);
+                    desc = desc->get_subdescriptor(column_ndx);
                 }
                 break;
             }
@@ -887,11 +832,12 @@ public:
 
 } // anonymous namespace
 
-void TrivialReplication::apply_transact_log(const char* data, size_t size, SharedGroup& target)
+void TrivialReplication::apply_transact_log(const char* data, size_t size, SharedGroup& target,
+                                            ostream* log)
 {
     InputStreamImpl in(data, size);
     WriteTransaction wt(target); // Throws
-    Replication::apply_transact_log(in, wt.get_group()); // Throws
+    Replication::apply_transact_log(in, wt.get_group(), log); // Throws
     wt.commit(); // Throws
 }
 

--- a/src/tightdb/spec.hpp
+++ b/src/tightdb/spec.hpp
@@ -75,7 +75,6 @@ public:
 
     std::size_t get_subspec_ndx(std::size_t column_ndx) const TIGHTDB_NOEXCEPT;
     ref_type get_subspec_ref(std::size_t subspec_ndx) const TIGHTDB_NOEXCEPT;
-    std::size_t get_num_subspecs() const TIGHTDB_NOEXCEPT;
     SubspecRef get_subspec_by_ndx(std::size_t subspec_ndx) TIGHTDB_NOEXCEPT;
     ConstSubspecRef get_subspec_by_ndx(std::size_t subspec_ndx) const TIGHTDB_NOEXCEPT;
 
@@ -148,10 +147,6 @@ private:
 
     void get_column_info(std::size_t column_ndx, ColumnInfo&) const TIGHTDB_NOEXCEPT;
 
-    // Precondition: 1 <= end - begin
-    std::size_t* record_subspec_path(const Array& root_subspecs, std::size_t* begin,
-                                     std::size_t* end) const TIGHTDB_NOEXCEPT;
-
     // Returns false if the spec has no columns, otherwise it returns
     // true and sets `type` to the type of the first column.
     static bool get_first_column_type_from_ref(ref_type, Allocator&,
@@ -218,12 +213,6 @@ inline ref_type Spec::get_subspec_ref(std::size_t subspec_ndx) const TIGHTDB_NOE
     // by number of sub-table columns
     return m_subspecs.get_as_ref(subspec_ndx);
 }
-
-inline std::size_t Spec::get_num_subspecs() const TIGHTDB_NOEXCEPT
-{
-    return m_subspecs.is_attached() ? m_subspecs.size() : 0;
-}
-
 
 inline Spec::Spec(SubspecRef r) TIGHTDB_NOEXCEPT:
     m_top(r.m_parent->get_alloc()), m_spec(r.m_parent->get_alloc()),

--- a/src/tightdb/table.cpp
+++ b/src/tightdb/table.cpp
@@ -20,6 +20,9 @@
 #include <tightdb/column_mixed.hpp>
 #include <tightdb/index_string.hpp>
 #include <tightdb/group.hpp>
+#ifdef TIGHTDB_ENABLE_REPLICATION
+#  include <tightdb/replication.hpp>
+#endif
 
 using namespace std;
 using namespace tightdb;
@@ -65,6 +68,7 @@ size_t Table::add_column(DataType type, StringData name, DescriptorRef* subdesc)
     return get_column_count() - 1;
 }
 
+
 void Table::insert_column(size_t column_ndx, DataType type, StringData name,
                           DescriptorRef* subdesc)
 {
@@ -72,11 +76,13 @@ void Table::insert_column(size_t column_ndx, DataType type, StringData name,
     get_descriptor()->insert_column(column_ndx, type, name, subdesc); // Throws
 }
 
+
 void Table::remove_column(size_t column_ndx)
 {
     TIGHTDB_ASSERT(!has_shared_type());
     get_descriptor()->remove_column(column_ndx); // Throws
 }
+
 
 void Table::rename_column(size_t column_ndx, StringData name)
 {
@@ -112,20 +118,24 @@ DescriptorRef Table::get_descriptor()
     return move(desc);
 }
 
+
 ConstDescriptorRef Table::get_descriptor() const
 {
     return const_cast<Table*>(this)->get_descriptor(); // Throws
 }
+
 
 DescriptorRef Table::get_subdescriptor(size_t column_ndx)
 {
     return get_descriptor()->get_subdescriptor(column_ndx); // Throws
 }
 
+
 ConstDescriptorRef Table::get_subdescriptor(size_t column_ndx) const
 {
     return get_descriptor()->get_subdescriptor(column_ndx); // Throws
 }
+
 
 DescriptorRef Table::get_subdescriptor(const path_vec& path)
 {
@@ -137,10 +147,12 @@ DescriptorRef Table::get_subdescriptor(const path_vec& path)
     return desc;
 }
 
+
 ConstDescriptorRef Table::get_subdescriptor(const path_vec& path) const
 {
     return const_cast<Table*>(this)->get_subdescriptor(path); // Throws
 }
+
 
 size_t Table::add_subcolumn(const path_vec& path, DataType type, StringData name)
 {
@@ -150,16 +162,19 @@ size_t Table::add_subcolumn(const path_vec& path, DataType type, StringData name
     return column_ndx;
 }
 
+
 void Table::insert_subcolumn(const path_vec& path, size_t column_ndx,
                              DataType type, StringData name)
 {
     get_subdescriptor(path)->insert_column(column_ndx, type, name); // Throws
 }
 
+
 void Table::remove_subcolumn(const path_vec& path, size_t column_ndx)
 {
     get_subdescriptor(path)->remove_column(column_ndx); // Throws
 }
+
 
 void Table::rename_subcolumn(const path_vec& path, size_t column_ndx, StringData name)
 {
@@ -186,6 +201,7 @@ void Table::init_from_ref(ref_type top_ref, ArrayParent* parent, size_t ndx_in_p
 
     cache_columns(); // Also initializes m_size
 }
+
 
 void Table::init_from_ref(ConstSubspecRef shared_spec, ref_type columns_ref,
                           ArrayParent* parent, size_t ndx_in_parent)
@@ -221,6 +237,7 @@ private:
     const DataType m_type;
 };
 
+
 struct Table::RemoveSubtableColumns: Table::SubtableUpdater {
     RemoveSubtableColumns(size_t i):
         m_column_ndx(i)
@@ -236,6 +253,7 @@ private:
     const size_t m_column_ndx;
 };
 
+
 void Table::do_insert_column(const Descriptor& desc, size_t column_ndx,
                              DataType type, StringData name)
 {
@@ -243,7 +261,7 @@ void Table::do_insert_column(const Descriptor& desc, size_t column_ndx,
 
     Table& root_table = *desc.m_root_table;
     TIGHTDB_ASSERT(!root_table.has_shared_type());
-    TIGHTDB_ASSERT(column_ndx <= desc.m_spec->get_column_count());
+    TIGHTDB_ASSERT(column_ndx <= desc.get_column_count());
 
     root_table.detach_subtable_accessors();
 
@@ -259,9 +277,11 @@ void Table::do_insert_column(const Descriptor& desc, size_t column_ndx,
     }
 
 #ifdef TIGHTDB_ENABLE_REPLICATION
-    root_table.transact_log().insert_column(*desc.m_spec, column_ndx, type, name); // Throws
+    if (Replication* repl = root_table.get_repl())
+        repl->insert_column(desc, column_ndx, type, name); // Throws
 #endif
 }
+
 
 void Table::do_remove_column(const Descriptor& desc, size_t column_ndx)
 {
@@ -269,7 +289,7 @@ void Table::do_remove_column(const Descriptor& desc, size_t column_ndx)
 
     Table& root_table = *desc.m_root_table;
     TIGHTDB_ASSERT(!root_table.has_shared_type());
-    TIGHTDB_ASSERT(column_ndx < desc.m_spec->get_column_count());
+    TIGHTDB_ASSERT(column_ndx < desc.get_column_count());
 
     root_table.detach_subtable_accessors();
 
@@ -285,9 +305,11 @@ void Table::do_remove_column(const Descriptor& desc, size_t column_ndx)
     }
 
 #ifdef TIGHTDB_ENABLE_REPLICATION
-    root_table.transact_log().remove_column(*desc.m_spec, column_ndx); // Throws
+    if (Replication* repl = root_table.get_repl())
+        repl->remove_column(desc, column_ndx); // Throws
 #endif
 }
+
 
 void Table::do_rename_column(const Descriptor& desc, size_t column_ndx, StringData name)
 {
@@ -295,19 +317,15 @@ void Table::do_rename_column(const Descriptor& desc, size_t column_ndx, StringDa
 
     Table& root_table = *desc.m_root_table;
     TIGHTDB_ASSERT(!root_table.has_shared_type());
-    TIGHTDB_ASSERT(column_ndx < desc.m_spec->get_column_count());
+    TIGHTDB_ASSERT(column_ndx < desc.get_column_count());
 
     root_table.detach_subtable_accessors();
     desc.m_spec->rename_column(column_ndx, name); // Throws
 
 #ifdef TIGHTDB_ENABLE_REPLICATION
-    root_table.transact_log().rename_column(*desc.m_spec, column_ndx, name); // Throws
+    if (Replication* repl = root_table.get_repl())
+        repl->rename_column(desc, column_ndx, name); // Throws
 #endif
-}
-
-size_t Table::get_num_subdescs(const Descriptor& desc) TIGHTDB_NOEXCEPT
-{
-    return desc.m_spec->get_num_subspecs();
 }
 
 
@@ -462,6 +480,7 @@ void Table::update_subtables(const Descriptor& desc, SubtableUpdater& updater)
     }
 }
 
+
 void Table::update_subtables(const size_t* path_begin, const size_t* path_end,
                              SubtableUpdater& updater)
 {
@@ -591,7 +610,8 @@ void Table::create_columns()
 void Table::detach() TIGHTDB_NOEXCEPT
 {
 #ifdef TIGHTDB_ENABLE_REPLICATION
-    transact_log().on_table_destroyed();
+    if (Replication* repl = get_repl())
+        repl->on_table_destroyed(this);
     m_spec.m_top.detach();
 #endif
 
@@ -606,8 +626,9 @@ void Table::detach() TIGHTDB_NOEXCEPT
     detach_subtable_accessors();
 
     destroy_column_accessors();
-    detach_views_except(NULL);
+    detach_views_except(0);
 }
+
 
 // Note about exception safety:
 // This function must be called with a view that is either 0, OR
@@ -631,13 +652,14 @@ void Table::detach_views_except(const TableViewBase* view) TIGHTDB_NOEXCEPT
     }
 }
 
+
 void Table::detach_subtable_accessors() TIGHTDB_NOEXCEPT
 {
     if (is_empty())
         return;
 
     size_t n = m_cols.size();
-    for (size_t i=0; i<n; ++i) {
+    for (size_t i = 0; i < n; ++i) {
         ColumnBase* c = reinterpret_cast<ColumnBase*>(uintptr_t(m_cols.get(i)));
         c->detach_subtable_accessors();
     }
@@ -661,6 +683,7 @@ void Table::instantiate_before_change()
     if (!m_columns.is_attached())
         create_columns();
 }
+
 
 void Table::cache_columns()
 {
@@ -805,7 +828,8 @@ Table::~Table() TIGHTDB_NOEXCEPT
     }
 
 #ifdef TIGHTDB_ENABLE_REPLICATION
-    transact_log().on_table_destroyed();
+    if (Replication* repl = get_repl())
+        repl->on_table_destroyed(this);
     m_spec.m_top.detach();
 #endif
 
@@ -852,12 +876,14 @@ Table::~Table() TIGHTDB_NOEXCEPT
     m_top.destroy_deep();
 }
 
+
 bool Table::has_index(size_t column_ndx) const TIGHTDB_NOEXCEPT
 {
     TIGHTDB_ASSERT(column_ndx < get_column_count());
     const ColumnBase& col = get_column_base(column_ndx);
     return col.has_index();
 }
+
 
 void Table::set_index(size_t column_ndx, bool update_spec)
 {
@@ -903,7 +929,8 @@ void Table::set_index(size_t column_ndx, bool update_spec)
         m_spec.set_column_attr(column_ndx, col_attr_Indexed);
 
 #ifdef TIGHTDB_ENABLE_REPLICATION
-    transact_log().add_index_to_column(column_ndx); // Throws
+    if (Replication* repl = get_repl())
+        repl->add_index_to_column(this, column_ndx); // Throws
 #endif
 }
 
@@ -916,6 +943,7 @@ ColumnBase& Table::get_column_base(size_t ndx)
     TIGHTDB_ASSERT(m_cols.size() == get_column_count());
     return *reinterpret_cast<ColumnBase*>(m_cols.get(ndx));
 }
+
 
 const ColumnBase& Table::get_column_base(size_t ndx) const TIGHTDB_NOEXCEPT
 {
@@ -1169,7 +1197,8 @@ size_t Table::add_empty_row(size_t num_rows)
     m_size += num_rows;
 
 #ifdef TIGHTDB_ENABLE_REPLICATION
-    transact_log().insert_empty_rows(new_ndx, 1); // Throws
+    if (Replication* repl = get_repl())
+        repl->insert_empty_rows(this, new_ndx, 1); // Throws
 #endif
 
     return new_ndx;
@@ -1190,7 +1219,8 @@ void Table::insert_empty_row(size_t ndx, size_t num_rows)
     m_size += num_rows;
 
 #ifdef TIGHTDB_ENABLE_REPLICATION
-    transact_log().insert_empty_rows(ndx, num_rows); // Throws
+    if (Replication* repl = get_repl())
+        repl->insert_empty_rows(this, ndx, num_rows); // Throws
 #endif
 }
 
@@ -1205,7 +1235,8 @@ void Table::clear()
     m_size = 0;
 
 #ifdef TIGHTDB_ENABLE_REPLICATION
-    transact_log().clear_table(); // Throws
+    if (Replication* repl = get_repl())
+        repl->clear_table(this); // Throws
 #endif
 }
 
@@ -1222,7 +1253,8 @@ void Table::do_remove(size_t ndx)
     --m_size;
 
 #ifdef TIGHTDB_ENABLE_REPLICATION
-    transact_log().remove_row(ndx); // Throws
+    if (Replication* repl = get_repl())
+        repl->remove_row(this, ndx); // Throws
 #endif
 }
 
@@ -1239,7 +1271,9 @@ void Table::move_last_over(size_t ndx)
     --m_size;
 
 #ifdef TIGHTDB_ENABLE_REPLICATION
-    //TODO: transact_log().move_last_over(ndx); // Throws
+    // FIXME: Implement this
+//    if (Replication* repl = get_repl())
+//        repl->move_last_over(this, ndx); // Throws
 #endif
 }
 
@@ -1255,7 +1289,8 @@ void Table::insert_subtable(size_t col_ndx, size_t row_ndx, const Table* table)
 
     // FIXME: Replication is not yet able to handle copying insertion of non-empty tables.
 #ifdef TIGHTDB_ENABLE_REPLICATION
-    transact_log().insert_value(col_ndx, row_ndx, Replication::subtable_tag()); // Throws
+    if (Replication* repl = get_repl())
+        repl->insert_value(this, col_ndx, row_ndx, Replication::subtable_tag()); // Throws
 #endif
 }
 
@@ -1271,7 +1306,8 @@ void Table::set_subtable(size_t col_ndx, size_t row_ndx, const Table* table)
 
     // FIXME: Replication is not yet able to handle copying insertion of non-empty tables.
 #ifdef TIGHTDB_ENABLE_REPLICATION
-    transact_log().set_value(col_ndx, row_ndx, Replication::subtable_tag()); // Throws
+    if (Replication* repl = get_repl())
+        repl->set_value(this, col_ndx, row_ndx, Replication::subtable_tag()); // Throws
 #endif
 }
 
@@ -1287,7 +1323,8 @@ void Table::insert_mixed_subtable(size_t col_ndx, size_t row_ndx, const Table* t
 
     // FIXME: Replication is not yet able to handle copuing insertion of non-empty tables.
 #ifdef TIGHTDB_ENABLE_REPLICATION
-    transact_log().insert_value(col_ndx, row_ndx, Replication::subtable_tag()); // Throws
+    if (Replication* repl = get_repl())
+        repl->insert_value(this, col_ndx, row_ndx, Replication::subtable_tag()); // Throws
 #endif
 }
 
@@ -1303,7 +1340,8 @@ void Table::set_mixed_subtable(size_t col_ndx, size_t row_ndx, const Table* t)
 
     // FIXME: Replication is not yet able to handle copying assignment of non-empty tables.
 #ifdef TIGHTDB_ENABLE_REPLICATION
-    transact_log().set_value(col_ndx, row_ndx, Replication::subtable_tag()); // Throws
+    if (Replication* repl = get_repl())
+        repl->set_value(this, col_ndx, row_ndx, Replication::subtable_tag()); // Throws
 #endif
 }
 
@@ -1373,7 +1411,8 @@ void Table::clear_subtable(size_t col_idx, size_t row_idx)
         subtables.set(row_idx, 0);
 
 #ifdef TIGHTDB_ENABLE_REPLICATION
-        transact_log().set_value(col_idx, row_idx, Replication::subtable_tag()); // Throws
+        if (Replication* repl = get_repl())
+            repl->set_value(this, col_idx, row_idx, Replication::subtable_tag()); // Throws
 #endif
     }
     else if (type == col_type_Mixed) {
@@ -1381,7 +1420,8 @@ void Table::clear_subtable(size_t col_idx, size_t row_idx)
         subtables.set_subtable(row_idx, 0);
 
 #ifdef TIGHTDB_ENABLE_REPLICATION
-        transact_log().set_value(col_idx, row_idx, Mixed(Mixed::subtable_tag())); // Throws
+        if (Replication* repl = get_repl())
+            repl->set_value(this, col_idx, row_idx, Mixed(Mixed::subtable_tag())); // Throws
 #endif
     }
     else {
@@ -1431,7 +1471,8 @@ void Table::set_int(size_t column_ndx, size_t ndx, int64_t value)
     column.set(ndx, value);
 
 #ifdef TIGHTDB_ENABLE_REPLICATION
-    transact_log().set_value(column_ndx, ndx, value); // Throws
+    if (Replication* repl = get_repl())
+        repl->set_value(this, column_ndx, ndx, value); // Throws
 #endif
 }
 
@@ -1442,7 +1483,8 @@ void Table::add_int(size_t column_ndx, int64_t value)
     get_column(column_ndx).adjust(value);
 
 #ifdef TIGHTDB_ENABLE_REPLICATION
-    transact_log().add_int_to_column(column_ndx, value); // Throws
+    if (Replication* repl = get_repl())
+        repl->add_int_to_column(this, column_ndx, value); // Throws
 #endif
 }
 
@@ -1467,7 +1509,8 @@ void Table::set_bool(size_t column_ndx, size_t ndx, bool value)
     column.set(ndx, value ? 1 : 0);
 
 #ifdef TIGHTDB_ENABLE_REPLICATION
-    transact_log().set_value(column_ndx, ndx, int(value)); // Throws
+    if (Replication* repl = get_repl())
+        repl->set_value(this, column_ndx, ndx, int(value)); // Throws
 #endif
 }
 
@@ -1491,7 +1534,8 @@ void Table::set_datetime(size_t column_ndx, size_t ndx, DateTime value)
     column.set(ndx, int64_t(value.get_datetime()));
 
 #ifdef TIGHTDB_ENABLE_REPLICATION
-    transact_log().set_value(column_ndx, ndx, value.get_datetime()); // Throws
+    if (Replication* repl = get_repl())
+        repl->set_value(this, column_ndx, ndx, value.get_datetime()); // Throws
 #endif
 }
 
@@ -1504,7 +1548,8 @@ void Table::insert_int(size_t column_ndx, size_t ndx, int64_t value)
     column.insert(ndx, value);
 
 #ifdef TIGHTDB_ENABLE_REPLICATION
-    transact_log().insert_value(column_ndx, ndx, value); // Throws
+    if (Replication* repl = get_repl())
+        repl->insert_value(this, column_ndx, ndx, value); // Throws
 #endif
 }
 
@@ -1527,7 +1572,8 @@ void Table::set_float(size_t column_ndx, size_t ndx, float value)
     column.set(ndx, value);
 
 #ifdef TIGHTDB_ENABLE_REPLICATION
-    transact_log().set_value(column_ndx, ndx, value); // Throws
+    if (Replication* repl = get_repl())
+        repl->set_value(this, column_ndx, ndx, value); // Throws
 #endif
 }
 
@@ -1540,7 +1586,8 @@ void Table::insert_float(size_t column_ndx, size_t ndx, float value)
     column.insert(ndx, value);
 
 #ifdef TIGHTDB_ENABLE_REPLICATION
-    transact_log().insert_value(column_ndx, ndx, value); // Throws
+    if (Replication* repl = get_repl())
+        repl->insert_value(this, column_ndx, ndx, value); // Throws
 #endif
 }
 
@@ -1563,7 +1610,8 @@ void Table::set_double(size_t column_ndx, size_t ndx, double value)
     column.set(ndx, value);
 
 #ifdef TIGHTDB_ENABLE_REPLICATION
-    transact_log().set_value(column_ndx, ndx, value); // Throws
+    if (Replication* repl = get_repl())
+        repl->set_value(this, column_ndx, ndx, value); // Throws
 #endif
 }
 
@@ -1576,7 +1624,8 @@ void Table::insert_double(size_t column_ndx, size_t ndx, double value)
     column.insert(ndx, value);
 
 #ifdef TIGHTDB_ENABLE_REPLICATION
-    transact_log().insert_value(column_ndx, ndx, value); // Throws
+    if (Replication* repl = get_repl())
+        repl->insert_value(this, column_ndx, ndx, value); // Throws
 #endif
 }
 
@@ -1614,7 +1663,8 @@ void Table::set_string(size_t column_ndx, size_t ndx, StringData value)
     }
 
 #ifdef TIGHTDB_ENABLE_REPLICATION
-    transact_log().set_value(column_ndx, ndx, value); // Throws
+    if (Replication* repl = get_repl())
+        repl->set_value(this, column_ndx, ndx, value); // Throws
 #endif
 }
 
@@ -1635,7 +1685,8 @@ void Table::insert_string(size_t column_ndx, size_t ndx, StringData value)
     }
 
 #ifdef TIGHTDB_ENABLE_REPLICATION
-    transact_log().insert_value(column_ndx, ndx, value); // Throws
+    if (Replication* repl = get_repl())
+        repl->insert_value(this, column_ndx, ndx, value); // Throws
 #endif
 }
 
@@ -1658,7 +1709,8 @@ void Table::set_binary(size_t column_ndx, size_t ndx, BinaryData value)
     column.set(ndx, value);
 
 #ifdef TIGHTDB_ENABLE_REPLICATION
-    transact_log().set_value(column_ndx, ndx, value); // Throws
+    if (Replication* repl = get_repl())
+        repl->set_value(this, column_ndx, ndx, value); // Throws
 #endif
 }
 
@@ -1671,7 +1723,8 @@ void Table::insert_binary(size_t column_ndx, size_t ndx, BinaryData value)
     column.insert(ndx, value);
 
 #ifdef TIGHTDB_ENABLE_REPLICATION
-    transact_log().insert_value(column_ndx, ndx, value); // Throws
+    if (Replication* repl = get_repl())
+        repl->insert_value(this, column_ndx, ndx, value); // Throws
 #endif
 }
 
@@ -1756,7 +1809,8 @@ void Table::set_mixed(size_t column_ndx, size_t ndx, Mixed value)
     }
 
 #ifdef TIGHTDB_ENABLE_REPLICATION
-    transact_log().set_value(column_ndx, ndx, value); // Throws
+    if (Replication* repl = get_repl())
+        repl->set_value(this, column_ndx, ndx, value); // Throws
 #endif
 }
 
@@ -1799,7 +1853,8 @@ void Table::insert_mixed(size_t column_ndx, size_t ndx, Mixed value)
     }
 
 #ifdef TIGHTDB_ENABLE_REPLICATION
-    transact_log().insert_value(column_ndx, ndx, value); // Throws
+    if (Replication* repl = get_repl())
+        repl->insert_value(this, column_ndx, ndx, value); // Throws
 #endif
 }
 
@@ -1809,7 +1864,8 @@ void Table::insert_done()
     ++m_size;
 
 #ifdef TIGHTDB_ENABLE_REPLICATION
-    transact_log().row_insert_complete(); // Throws
+    if (Replication* repl = get_repl())
+        repl->row_insert_complete(this); // Throws
 #endif
 }
 
@@ -2724,7 +2780,8 @@ void Table::optimize()
     }
 
 #ifdef TIGHTDB_ENABLE_REPLICATION
-    transact_log().optimize_table(); // Throws
+    if (Replication* repl = get_repl())
+        repl->optimize_table(this); // Throws
 #endif
 }
 


### PR DESCRIPTION
The problem was that a subdescriptor path recorded in the replication log was expressed in terms of subspec indexes (which are not equal to column indexes). The reapplication side, on the other hand, assumed it was expressed in terms of column indexes. This has been fixed so that the subdescriptor path is now expressed in terms of column indexes.

This prompted a number of cleanup tasks along the way.

Note that this work is part of the work on implicit transactions (which needs a proper replication log).

@finnschiermer @bmunkholm @astigsen 
