### PR TITLE
Revert "Updated compiler flags for iOS for compatiblity with changes com...

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -516,7 +516,7 @@ EOF
             platform="$(printf "%s\n" "$x" | cut -d: -f1)" || exit 1
             sdk="$(printf "%s\n" "$x" | cut -d: -f2)" || exit 1
             archs="$(printf "%s\n" "$x" | cut -d: -f3 | sed 's/,/ /g')" || exit 1
-            cflags_arch="-mios-version-min=5.0"
+            cflags_arch=""
             for y in $archs; do
                 word_list_append "cflags_arch" "-arch $y" || exit 1
             done


### PR DESCRIPTION
...ing"

@pauldardeau @kspangsege 

This reverts commit 1db7feb9a493e943b4bb30eefebb7627a5545d52.

The reason is that an application that should be compatible with something
earlier than iOS7, will not include a 64 bit slice[1].

So we have actually not been compiling for arm64, even though it looked in a
lot of ways as though we did. I might be wrong, but my arm64 app is much more
happy to link now :)

[1] http://prod.lists.apple.com/archives/xcode-users/2013/Oct/msg00091.html
