### PR TITLE
Fixed leak (still reachable) in test path subsystem (and simplification)

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -661,7 +661,10 @@ EOF
 
     "check"|"memcheck"|"check-"*|"memcheck-"*)
         auto_configure || exit 1
+        export TIGHTDB_HAVE_CONFIG="1"
         $MAKE "$MODE" || exit 1
+        echo "Test passed"
+        exit 0
         ;;
 
     "show-install")

--- a/test/android/jni/main.cpp
+++ b/test/android/jni/main.cpp
@@ -48,9 +48,8 @@ void android_main(struct android_app* state)
     AAssetDir_close(assetDir);
     LOGI("Copying of asset files completed");
 
-    tightdb::test_util::PlatformConfig* platform_config = tightdb::test_util::PlatformConfig::Instance();
-    platform_config->set_path(inDataPath + "/");
-    platform_config->set_resource_path(inDataPath + "/");
+    tightdb::test_util::set_test_path_prefix(inDataPath + "/");
+    tightdb::test_util::set_test_resource_path(inDataPath + "/");
 
     LOGI("Starting unit tests...");
 

--- a/test/test_table.cpp
+++ b/test/test_table.cpp
@@ -854,8 +854,7 @@ TEST(Table_ToString)
     stringstream ss;
     table.to_string(ss);
     const string result = ss.str();
-    PlatformConfig* platform_config = PlatformConfig::Instance();
-    string file_name = platform_config->get_resource_path();
+    string file_name = get_test_resource_path();
 #if _MSC_VER
     file_name += "expect_string-win.txt";
 #else
@@ -890,8 +889,7 @@ TEST(Table_JsonAllData)
     stringstream ss;
     table.to_json(ss);
     const string json = ss.str();
-    PlatformConfig* platform_config = PlatformConfig::Instance();
-    string file_name = platform_config->get_resource_path();
+    string file_name = get_test_resource_path();
 #if _MSC_VER
     file_name += "expect_json-win.json";
 #else

--- a/test/util/test_path.cpp
+++ b/test/util/test_path.cpp
@@ -10,6 +10,9 @@ namespace {
 
 bool keep_files = false;
 
+string path_prefix;
+string resource_path;
+
 } // anonymous namespace
 
 namespace tightdb {
@@ -21,46 +24,30 @@ void keep_test_files()
     keep_files = true;
 }
 
-
 string get_test_path(const TestDetails& test_details, const char* suffix)
 {
-    string path = "";
-    PlatformConfig* platform_config = PlatformConfig::Instance();
-    path += platform_config->get_path();
+    string path = path_prefix;
     path += test_details.test_name;
     path += suffix;
     return path;
 }
 
-PlatformConfig* PlatformConfig::instance = NULL;
-
-PlatformConfig* PlatformConfig::Instance() {
-    if (!instance) {
-        instance = new PlatformConfig();
-        instance->set_path("");
-        instance->set_resource_path("");
-    }
-
-    return instance;
+void set_test_path_prefix(const string& prefix)
+{
+    path_prefix = prefix;
 }
 
-std::string PlatformConfig::get_path() {
-    return test_path;
+string get_test_resource_path()
+{
+    return resource_path;
 }
 
-void PlatformConfig::set_path(std::string path) {
-    test_path = path;
+void set_test_resource_path(const string& path)
+{
+    resource_path = path;
 }
 
-std::string PlatformConfig::get_resource_path() {
-    return test_resource_path;
-}
-
-void PlatformConfig::set_resource_path(std::string path) {
-    test_resource_path = path;
-}
-
-TestPathGuard::TestPathGuard(const std::string& path):
+TestPathGuard::TestPathGuard(const string& path):
     m_path(path)
 {
     File::try_remove(m_path);
@@ -79,7 +66,7 @@ TestPathGuard::~TestPathGuard() TIGHTDB_NOEXCEPT
 }
 
 
-SharedGroupTestPathGuard::SharedGroupTestPathGuard(const std::string& path):
+SharedGroupTestPathGuard::SharedGroupTestPathGuard(const string& path):
     TestPathGuard(path)
 {
     File::try_remove(m_path+".lock");

--- a/test/util/test_path.hpp
+++ b/test/util/test_path.hpp
@@ -45,23 +45,16 @@ namespace test_util {
 /// before any TestPathGuard object is created.
 void keep_test_files();
 
+/// By default, test files are placed in the current working
+/// directory. Use this function to set a path prefix. The specified
+/// prefix must contain a final `/`.
+void set_test_path_prefix(const std::string&);
+
 std::string get_test_path(const unit_test::TestDetails&, const char* suffix);
 
-class PlatformConfig {
-public:
-    static PlatformConfig* Instance();
-    std::string get_path();
-    void set_path(std::string);
-    std::string get_resource_path();
-    void set_resource_path(std::string);
-private:
-    PlatformConfig(){};
-    PlatformConfig(PlatformConfig const&){}; // Private copy constructor
-    PlatformConfig& operator=(PlatformConfig const&); // Private assignment operator
-    static PlatformConfig* instance;
-    std::string test_path;
-    std::string test_resource_path;
-};
+std::string get_test_resource_path();
+void set_test_resource_path(const std::string&);
+
 
 /// Constructor and destructor removes file if it exists.
 class TestPathGuard {


### PR DESCRIPTION
Emanuele, I fixed a leak in your PlatformConfig stuff, and while I was at it, I simplified it a great deal. It was hugely over-engineered :-).

```
==32089== 16 bytes in 1 blocks are still reachable in loss record 1 of 1
==32089==    at 0x4C2A879: operator new(unsigned long) (in /usr/lib/valgrind/vgpreload_memcheck-amd64-linux.so)
==32089==    by 0x676230: tightdb::test_util::PlatformConfig::Instance() (test_path.cpp:39)
==32089==    by 0x676159: tightdb::test_util::get_test_path(tightdb::test_util::unit_test::TestDetails const&, char const*) (test_path.cpp:28)
==32089==    by 0x5C9418: Tightdb_UnitTest__Shared_Initial::test_run() (test_shared.cpp:131)
==32089==    by 0x66D416: tightdb::test_util::unit_test::TestList::ExecContext::run() (unit_test.cpp:313)
==32089==    by 0x66DA62: tightdb::test_util::unit_test::TestList::run(tightdb::test_util::unit_test::Reporter*, tightdb::test_util::unit_test::Filter*, int, bool) (unit_test.cpp:362)
==32089==    by 0x430F0B: (anonymous namespace)::run_tests() (test_all.cpp:312)
==32089==    by 0x431201: test_all(int, char**) (test_all.cpp:333)
==32089==    by 0x66C07F: main (main.cpp:5)
```

@emanuelez @rrrlasse 
