### PR TITLE
Adding a target for creating OS X framework

### DIFF
--- a/README.md
+++ b/README.md
@@ -274,7 +274,8 @@ nonempty value during configuration as in the following example:
 Packaging for OS X
 -------------------
 
-You can create a framework for Mac OS X. The framework is useful when
+You can create a framework for Mac OS X after you have built the
+core library (the `build` target). The framework is useful when
 creating OS X application. The command is:
 
     sh build.sh build-osx-framework
@@ -283,7 +284,8 @@ creating OS X application. The command is:
 Packaging for iOS
 -----------------
 
-You can create a framework for iOS. The framework is useful when
+You can create a framework for iOS after you have built the core
+library for iOS (the `build-iphone` target=. The framework is useful when
 creating apps for iPhone and iPad. The command is:
 
     sh build.sh build-ios-framework

--- a/build.sh
+++ b/build.sh
@@ -616,7 +616,7 @@ EOF
         BASENAME="RealmCore"
         FRAMEWORK="$BASENAME.framework"
         rm -rf "$FRAMEWORK" || exit 1
-        rm -f realm-osx-*.zip || exit 1
+        rm -f realm-core-ios-*.zip || exit 1
 
         mkdir -p "$FRAMEWORK/Headers" || exit 1
         if [ ! -f "$IPHONE_DIR/libtightdb-ios.a" ]; then
@@ -629,8 +629,8 @@ EOF
         find "$FRAMEWORK/Headers" -iregex "^.*\.[ch]\(pp\)\{0,1\}$" \
             -exec sed -i '' -e "s/<tightdb\(.*\)>/<$BASENAME\/tightdb\1>/g" {} \; || exit 1
  
-        zip -r -q realm-ios-$realm_version.zip $FRAMEWORK || exit 1
-        echo "Core framework for iOS can be found under $FRAMEWORK and realm-ios-$realm_version.zip."
+        zip -r -q realm-core-ios-$realm_version.zip $FRAMEWORK || exit 1
+        echo "Core framework for iOS can be found under $FRAMEWORK and realm-core-ios-$realm_version.zip."
         exit 0
         ;;
 
@@ -644,7 +644,7 @@ EOF
         BASENAME="RealmCore"
         FRAMEWORK="$BASENAME.framework"
         rm -rf "$FRAMEWORK" || exit 1
-        rm -f realm-osx-*.zip || exit 1
+        rm -f realm-core-osx-*.zip || exit 1
 
         mkdir -p "$FRAMEWORK/Headers/tightdb" || exit 1
         if [ ! -f "src/tightdb/libtightdb.a" ]; then
@@ -662,8 +662,8 @@ EOF
         find "$FRAMEWORK/Headers" -iregex "^.*\.[ch]\(pp\)\{0,1\}$" \
             -exec sed -i '' -e "s/<tightdb\(.*\)>/<$BASENAME\/tightdb\1>/g" {} \; || exit 1
 
-        zip -r -q realm-osx-$realm_version.zip $FRAMEWORK || exit 1
-        echo "Core framework for OS X can be found under $FRAMEWORK and realm-osx-$realm_version.zip."
+        zip -r -q realm-core-osx-$realm_version.zip $FRAMEWORK || exit 1
+        echo "Core framework for OS X can be found under $FRAMEWORK and realm-core-osx-$realm_version.zip."
         exit 0
         ;;
 


### PR DESCRIPTION
A target in `build.sh` for creating OS X framework. Moreover, zip file including version number will be generated.

See https://app.asana.com/0/1442494018425/12279924650171

@emanuelez 
