### PR TITLE
Set MaxOpenFiles to maximum allowed by system

### DIFF
--- a/build/vs2013/TightDB.vcxproj
+++ b/build/vs2013/TightDB.vcxproj
@@ -1044,6 +1044,7 @@
       <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Static library, release|Win32'">true</ExcludedFromBuild>
     </ClCompile>
     <ClCompile Include="..\..\test\util\random.cpp" />
+    <ClCompile Include="..\..\test\util\resource_limits.cpp" />
     <ClCompile Include="..\..\test\util\test_only.cpp" />
     <ClCompile Include="..\..\test\util\test_path.cpp" />
     <ClCompile Include="..\..\test\util\timer.cpp" />

--- a/build/vs2013/TightDB.vcxproj.filters
+++ b/build/vs2013/TightDB.vcxproj.filters
@@ -231,6 +231,9 @@
     <ClCompile Include="..\..\test\util\random.cpp">
       <Filter>test\util</Filter>
     </ClCompile>
+    <ClCompile Include="..\..\test\util\resource_limits.cpp">
+      <Filter>test\util</Filter>
+    </ClCompile>
     <ClCompile Include="..\..\test\test_all.cpp">
       <Filter>test</Filter>
     </ClCompile>

--- a/test/util/Makefile
+++ b/test/util/Makefile
@@ -2,7 +2,7 @@ check_LIBRARIES = test-util.a
 
 test_util_a_SOURCES = demangle.cpp mem.cpp timer.cpp random.cpp benchmark_results.cpp \
 wildcard.cpp unit_test.cpp test_path.cpp test_only.cpp misc.cpp verified_integer.cpp \
-verified_string.cpp
+verified_string.cpp resource_limits.cpp
 
 test_util_a_LIBS = ../../src/tightdb/libtightdb.a
 

--- a/test/util/resource_limits.cpp
+++ b/test/util/resource_limits.cpp
@@ -1,0 +1,120 @@
+#include <stdexcept>
+
+#include <tightdb/util/assert.hpp>
+
+#include "resource_limits.hpp"
+
+#ifndef _WIN32
+#  define TIGHTDB_HAVE_POSIX_RLIMIT 1
+#endif
+
+#if TIGHTDB_HAVE_POSIX_RLIMIT
+#  include <sys/resource.h>
+#endif
+
+using namespace std;
+using namespace tightdb;
+using namespace tightdb::test_util;
+
+#if TIGHTDB_HAVE_POSIX_RLIMIT
+
+namespace {
+
+long get_rlimit(Resource resource, bool hard)
+{
+    int resource_2 = -1;
+    switch (resource) {
+        case resource_NumOpenFiles:
+            resource_2 = RLIMIT_NOFILE;
+            break;
+    }
+    TIGHTDB_ASSERT(resource_2 != -1);
+    rlimit rlimit;
+    int status = getrlimit(resource_2, &rlimit);
+    if (status < 0)
+        throw runtime_error("getrlimit() failed");
+    rlim_t value = hard ? rlimit.rlim_max : rlimit.rlim_cur;
+    return value == RLIM_INFINITY ? -1 : long(value);
+}
+
+void set_rlimit(Resource resource, long value, bool hard)
+{
+    int resource_2 = -1;
+    switch (resource) {
+        case resource_NumOpenFiles:
+            resource_2 = RLIMIT_NOFILE;
+            break;
+    }
+    TIGHTDB_ASSERT(resource_2 != -1);
+    rlimit rlimit;
+    int status = getrlimit(resource_2, &rlimit);
+    if (status < 0)
+        throw runtime_error("getrlimit() failed");
+    rlim_t value_2 = value < 0 ? RLIM_INFINITY : rlim_t(value);
+    (hard ? rlimit.rlim_max : rlimit.rlim_cur) = value_2;
+    status = setrlimit(resource_2, &rlimit);
+    if (status < 0)
+        throw runtime_error("setrlimit() failed");
+}
+
+} // anonymous namespace
+
+#endif // TIGHTDB_HAVE_POSIX_RLIMIT
+
+
+namespace tightdb {
+namespace test_util {
+
+#if TIGHTDB_HAVE_POSIX_RLIMIT
+
+bool system_has_rlimit(Resource) TIGHTDB_NOEXCEPT
+{
+    return true;
+}
+
+long get_hard_rlimit(Resource resource)
+{
+    bool hard = true;
+    return get_rlimit(resource, hard);
+}
+
+long get_soft_rlimit(Resource resource)
+{
+    bool hard = false;
+    return get_rlimit(resource, hard);
+}
+
+void set_soft_rlimit(Resource resource, long value)
+{
+    bool hard = false;
+    set_rlimit(resource, value, hard);
+}
+
+#else // ! TIGHTDB_HAVE_POSIX_RLIMIT
+
+bool system_has_rlimit(Resource) TIGHTDB_NOEXCEPT
+{
+    return false;
+}
+
+long get_hard_rlimit(Resource)
+{
+    throw runtime_error("Not supported");
+}
+
+long get_soft_rlimit(Resource)
+{
+    throw runtime_error("Not supported");
+}
+
+void set_soft_rlimit(Resource, long)
+{
+    throw runtime_error("Not supported");
+}
+
+#endif // ! TIGHTDB_HAVE_POSIX_RLIMIT
+
+
+} // namespace test_util
+} // namespace tightdb
+

--- a/test/util/resource_limits.hpp
+++ b/test/util/resource_limits.hpp
@@ -1,0 +1,47 @@
+/*************************************************************************
+ *
+ * TIGHTDB CONFIDENTIAL
+ * __________________
+ *
+ *  [2011] - [2012] TightDB Inc
+ *  All Rights Reserved.
+ *
+ * NOTICE:  All information contained herein is, and remains
+ * the property of TightDB Incorporated and its suppliers,
+ * if any.  The intellectual and technical concepts contained
+ * herein are proprietary to TightDB Incorporated
+ * and its suppliers and may be covered by U.S. and Foreign Patents,
+ * patents in process, and are protected by trade secret or copyright law.
+ * Dissemination of this information or reproduction of this material
+ * is strictly forbidden unless prior written permission is obtained
+ * from TightDB Incorporated.
+ *
+ **************************************************************************/
+#ifndef TIGHTDB_TEST_UTIL_RESOURCE_LIMITS_HPP
+#define TIGHTDB_TEST_UTIL_RESOURCE_LIMITS_HPP
+
+namespace tightdb {
+namespace test_util {
+
+
+enum Resource {
+    resource_NumOpenFiles
+};
+
+bool system_has_rlimit(Resource) TIGHTDB_NOEXCEPT;
+
+//@{
+
+/// Get or set resouce limits. A negative value means 'unlimited' both when
+/// getting and when setting.
+long get_hard_rlimit(Resource);
+long get_soft_rlimit(Resource);
+void set_soft_rlimit(Resource, long value);
+
+//@}
+
+
+} // namespace test_util
+} // namespace tightdb
+
+#endif // TIGHTDB_TEST_UTIL_RESOURCE_LIMITS_HPP

--- a/tightdb.xcodeproj/project.pbxproj
+++ b/tightdb.xcodeproj/project.pbxproj
@@ -189,6 +189,8 @@
 		522EA51B192C4D4B002AD3B6 /* unicode.hpp in Headers */ = {isa = PBXBuildFile; fileRef = 522EA51A192C4D4B002AD3B6 /* unicode.hpp */; };
 		523239F51800EF33006E9F13 /* test_binary_data.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 523239F41800EF33006E9F13 /* test_binary_data.cpp */; };
 		523239F81800EF33006E9F13 /* test_replication.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 523239F71800EF33006E9F13 /* test_replication.cpp */; };
+		5238B560193F503B003F1C38 /* resource_limits.hpp in Headers */ = {isa = PBXBuildFile; fileRef = 5238B55F193F503B003F1C38 /* resource_limits.hpp */; };
+		5238B562193F5051003F1C38 /* resource_limits.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 5238B561193F5051003F1C38 /* resource_limits.cpp */; };
 		523AC1A718EABFCC00049AEA /* random.hpp in Headers */ = {isa = PBXBuildFile; fileRef = 523AC1A618EABFCC00049AEA /* random.hpp */; };
 		523AC1AA18EABFE900049AEA /* random.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 523AC1A918EABFE900049AEA /* random.cpp */; };
 		524F3C9A18EA346A00DEE22A /* test_path.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 524F3C9918EA346A00DEE22A /* test_path.cpp */; };
@@ -476,6 +478,8 @@
 		522EA51A192C4D4B002AD3B6 /* unicode.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; name = unicode.hpp; path = tightdb/unicode.hpp; sourceTree = "<group>"; };
 		523239F41800EF33006E9F13 /* test_binary_data.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = test_binary_data.cpp; sourceTree = "<group>"; };
 		523239F71800EF33006E9F13 /* test_replication.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = test_replication.cpp; sourceTree = "<group>"; };
+		5238B55F193F503B003F1C38 /* resource_limits.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; path = resource_limits.hpp; sourceTree = "<group>"; };
+		5238B561193F5051003F1C38 /* resource_limits.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = resource_limits.cpp; sourceTree = "<group>"; };
 		523AC1A618EABFCC00049AEA /* random.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; path = random.hpp; sourceTree = "<group>"; };
 		523AC1A918EABFE900049AEA /* random.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = random.cpp; sourceTree = "<group>"; };
 		524F3C9918EA346A00DEE22A /* test_path.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = test_path.cpp; sourceTree = "<group>"; };
@@ -849,6 +853,8 @@
 				5219EB6718FB026100FF9232 /* verified_integer.cpp */,
 				5219EB6C18FB028300FF9232 /* verified_string.hpp */,
 				5219EB6B18FB028300FF9232 /* verified_string.cpp */,
+				5238B55F193F503B003F1C38 /* resource_limits.hpp */,
+				5238B561193F5051003F1C38 /* resource_limits.cpp */,
 				52D6E058175BDBDD00B423E5 /* Makefile */,
 			);
 			path = util;
@@ -1038,6 +1044,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				526F3EFF182464F1005217F1 /* misc.hpp in Headers */,
+				5238B560193F503B003F1C38 /* resource_limits.hpp in Headers */,
 				5219EB6E18FB028300FF9232 /* verified_string.hpp in Headers */,
 				526F3F0418246519005217F1 /* benchmark_results.hpp in Headers */,
 				526F3F081824652B005217F1 /* thread_wrapper.hpp in Headers */,
@@ -1348,6 +1355,7 @@
 				5219EB6D18FB028300FF9232 /* verified_string.cpp in Sources */,
 				52D6E06F175BDC5D00B423E5 /* mem.cpp in Sources */,
 				B159814A18CF560000E3C5DF /* demangle.cpp in Sources */,
+				5238B562193F5051003F1C38 /* resource_limits.cpp in Sources */,
 				526F3F0218246508005217F1 /* misc.cpp in Sources */,
 				526F3F0618246523005217F1 /* benchmark_results.cpp in Sources */,
 				B159627818DB14C4008B9421 /* wildcard.cpp in Sources */,


### PR DESCRIPTION
This is to avoid occasional failures during multi-threaded unit testing.

This may or may not wotk on iOS and Android. If it fails to build, or fails at run-time, I will disable it, but let's see.

@astigsen @emanuelez 
