### PR TITLE
Eliminate type_BackLink as member of public enum DataType

### DIFF
--- a/src/tightdb/column_mixed.cpp
+++ b/src/tightdb/column_mixed.cpp
@@ -286,7 +286,6 @@ bool ColumnMixed::compare_mixed(const ColumnMixed& c) const
             case type_Mixed:
             case type_Link:
             case type_LinkList:
-            case type_BackLink:
                 TIGHTDB_ASSERT(false);
                 break;
         }

--- a/src/tightdb/data_type.hpp
+++ b/src/tightdb/data_type.hpp
@@ -37,8 +37,7 @@ enum DataType {
     type_Table      =  5,
     type_Mixed      =  6,
     type_Link       = 12,
-    type_LinkList   = 13,
-    type_BackLink   = 14
+    type_LinkList   = 13
 };
 
 

--- a/src/tightdb/descriptor.cpp
+++ b/src/tightdb/descriptor.cpp
@@ -34,7 +34,7 @@ DescriptorRef Descriptor::get_subdescriptor(size_t column_ndx)
 size_t Descriptor::get_num_unique_values(size_t column_ndx) const
 {
     TIGHTDB_ASSERT(is_attached());
-    ColumnType col_type = m_spec->get_real_column_type(column_ndx);
+    ColumnType col_type = m_spec->get_column_type(column_ndx);
     if (col_type != col_type_StringEnum)
         return 0;
     ref_type ref = m_spec->get_enumkeys_ref(column_ndx);

--- a/src/tightdb/descriptor.hpp
+++ b/src/tightdb/descriptor.hpp
@@ -410,7 +410,7 @@ inline StringData Descriptor::get_column_name(std::size_t ndx) const TIGHTDB_NOE
 inline DataType Descriptor::get_column_type(std::size_t ndx) const TIGHTDB_NOEXCEPT
 {
     TIGHTDB_ASSERT(is_attached());
-    return m_spec->get_column_type(ndx);
+    return m_spec->get_public_column_type(ndx);
 }
 
 inline std::size_t Descriptor::get_column_index(StringData name) const TIGHTDB_NOEXCEPT
@@ -421,7 +421,7 @@ inline std::size_t Descriptor::get_column_index(StringData name) const TIGHTDB_N
 
 inline std::size_t Descriptor::add_column(DataType type, StringData name, DescriptorRef* subdesc)
 {
-    std::size_t column_ndx = (type == type_BackLink) ? m_spec->get_column_count() : m_spec->get_public_column_count();
+    std::size_t column_ndx = m_spec->get_public_column_count();
     insert_column(column_ndx, type, name, subdesc); // Throws
     return column_ndx;
 }

--- a/src/tightdb/lang_bind_helper.cpp
+++ b/src/tightdb/lang_bind_helper.cpp
@@ -30,7 +30,6 @@ const char* LangBindHelper::get_data_type_name(DataType type) TIGHTDB_NOEXCEPT
         case type_Mixed:    return "mixed";
         case type_Link:     return "link";
         case type_LinkList: return "linklist";
-        case type_BackLink: return "backlink";
     }
     TIGHTDB_ASSERT(false);
     return "int";

--- a/src/tightdb/mixed.hpp
+++ b/src/tightdb/mixed.hpp
@@ -380,7 +380,6 @@ inline std::basic_ostream<Ch, Tr>& operator<<(std::basic_ostream<Ch, Tr>& out, c
         case type_Mixed:
         case type_Link:
         case type_LinkList:
-        case type_BackLink:
             TIGHTDB_ASSERT(false);
     }
     out << ")";

--- a/src/tightdb/replication.cpp
+++ b/src/tightdb/replication.cpp
@@ -668,8 +668,6 @@ private:
                 return "Link";
             case type_LinkList:
                 return "LinkList";
-            case type_BackLink:
-                return "BackLink";
         }
         TIGHTDB_ASSERT(false);
         return 0;

--- a/src/tightdb/replication.hpp
+++ b/src/tightdb/replication.hpp
@@ -730,7 +730,6 @@ inline void Replication::mixed_cmd(Instruction instr, std::size_t col_ndx,
             break;
         case type_Link:
         case type_LinkList:
-        case type_BackLink:
             // FIXME: Need to handle new link types here
             TIGHTDB_ASSERT(false);
             break;
@@ -1414,7 +1413,6 @@ inline void Replication::TransactLogParser::read_mixed(Mixed* mixed)
             break;
         case type_Link:
         case type_LinkList:
-        case type_BackLink:
             // FIXME: Need to handle new link types here
             TIGHTDB_ASSERT(false);
             break;

--- a/src/tightdb/spec.hpp
+++ b/src/tightdb/spec.hpp
@@ -39,7 +39,7 @@ public:
 
     Allocator& get_alloc() const TIGHTDB_NOEXCEPT;
 
-    void insert_column(std::size_t column_ndx, DataType type, StringData name,
+    void insert_column(std::size_t column_ndx, ColumnType type, StringData name,
                        ColumnAttr attr = col_attr_None);
     void rename_column(std::size_t column_ndx, StringData new_name);
 
@@ -64,8 +64,8 @@ public:
     // Column info
     std::size_t get_column_count() const TIGHTDB_NOEXCEPT;
     std::size_t get_public_column_count() const TIGHTDB_NOEXCEPT;
-    DataType get_column_type(std::size_t column_ndx) const TIGHTDB_NOEXCEPT;
-    ColumnType get_real_column_type(std::size_t column_ndx) const TIGHTDB_NOEXCEPT;
+    DataType get_public_column_type(std::size_t column_ndx) const TIGHTDB_NOEXCEPT;
+    ColumnType get_column_type(std::size_t column_ndx) const TIGHTDB_NOEXCEPT;
     StringData get_column_name(std::size_t column_ndx) const TIGHTDB_NOEXCEPT;
 
     /// Returns std::size_t(-1) if the specified column is not found.
@@ -273,7 +273,7 @@ inline Spec::Spec(Allocator& alloc, MemRef mem, ArrayParent* parent,
 inline SubspecRef Spec::get_subtable_spec(std::size_t column_ndx) TIGHTDB_NOEXCEPT
 {
     TIGHTDB_ASSERT(column_ndx < get_column_count());
-    TIGHTDB_ASSERT(get_column_type(column_ndx) == type_Table);
+    TIGHTDB_ASSERT(get_column_type(column_ndx) == col_type_Table);
     std::size_t subspec_ndx = get_subspec_ndx(column_ndx);
     return SubspecRef(&m_subspecs, subspec_ndx);
 }
@@ -281,7 +281,7 @@ inline SubspecRef Spec::get_subtable_spec(std::size_t column_ndx) TIGHTDB_NOEXCE
 inline ConstSubspecRef Spec::get_subtable_spec(std::size_t column_ndx) const TIGHTDB_NOEXCEPT
 {
     TIGHTDB_ASSERT(column_ndx < get_column_count());
-    TIGHTDB_ASSERT(get_column_type(column_ndx) == type_Table);
+    TIGHTDB_ASSERT(get_column_type(column_ndx) == col_type_Table);
     std::size_t subspec_ndx = get_subspec_ndx(column_ndx);
     return ConstSubspecRef(&m_subspecs, subspec_ndx);
 }
@@ -354,7 +354,7 @@ inline std::size_t Spec::get_public_column_count() const TIGHTDB_NOEXCEPT
     return m_names.size();
 }
 
-inline ColumnType Spec::get_real_column_type(std::size_t ndx) const TIGHTDB_NOEXCEPT
+inline ColumnType Spec::get_column_type(std::size_t ndx) const TIGHTDB_NOEXCEPT
 {
     TIGHTDB_ASSERT(ndx < get_column_count());
     return ColumnType(m_spec.get(ndx));

--- a/src/tightdb/table.cpp
+++ b/src/tightdb/table.cpp
@@ -258,13 +258,14 @@ void Table::create_backlinks_column(size_t source_table_ndx, size_t source_table
     TIGHTDB_ASSERT(get_parent_group());
 
     DescriptorRef desc = get_descriptor();
-    size_t column_ndx = desc->add_column(type_BackLink, ""); // Throws
-    m_spec.set_link_target_table(column_ndx, source_table_ndx);
-    m_spec.set_backlink_source_column(column_ndx, source_table_column_ndx);
+    size_t col_ndx = m_spec.get_column_count();
+    insert_root_column(col_ndx, col_type_BackLink, ""); // Throws
+    m_spec.set_link_target_table(col_ndx, source_table_ndx);
+    m_spec.set_backlink_source_column(col_ndx, source_table_column_ndx);
 
     // Column needs source table to create accessors
     Table* source_table = get_parent_group()->get_table_by_ndx(source_table_ndx);
-    ColumnBackLink& column = get_column<ColumnBackLink, col_type_BackLink>(column_ndx);
+    ColumnBackLink& column = get_column<ColumnBackLink, col_type_BackLink>(col_ndx);
     column.set_source_table(source_table->get_table_ref());
 
     DataType col_type = source_table->get_column_type(source_table_column_ndx);
@@ -321,7 +322,7 @@ void Table::initialize_link_targets()
     size_t current_table_ndx = get_index_in_parent();
 
     for (size_t i = 0; i < column_count; ++i) {
-        ColumnType column_type = spec->get_real_column_type(i);
+        ColumnType column_type = spec->get_column_type(i);
 
         if (column_type == col_type_Link || column_type == col_type_LinkList) {
             // Get the target table from group
@@ -512,7 +513,7 @@ struct Table::InsertSubtableColumns: SubtableUpdater {
     {
         size_t subtable_size = subtables.get_subtable_size(row_ndx);
         Allocator& alloc = subcolumns.get_alloc();
-        ref_type column_ref = create_column(m_type, subtable_size, alloc); // Throws
+        ref_type column_ref = create_column(ColumnType(m_type), subtable_size, alloc); // Throws
         _impl::DeepArrayRefDestroyGuard dg(column_ref, alloc);
         subcolumns.insert(m_column_ndx, column_ref); // Throws
         dg.release();
@@ -562,11 +563,11 @@ void Table::do_insert_column(Descriptor& desc, size_t column_ndx,
     TIGHTDB_ASSERT(column_ndx <= df::get_internal_column_count(desc));
 
     if (desc.is_root()) {
-        root_table.insert_root_column(column_ndx, type, name); // Throws
+        root_table.insert_root_column(column_ndx, ColumnType(type), name); // Throws
     }
     else {
         Spec* spec = df::get_spec(desc);
-        spec->insert_column(column_ndx, type, name); // Throws
+        spec->insert_column(column_ndx, ColumnType(type), name); // Throws
         if (!root_table.is_empty()) {
             InsertSubtableColumns updater(column_ndx, type);
             update_subtables(desc, &updater); // Throws
@@ -636,104 +637,28 @@ void Table::do_rename_column(Descriptor& desc, size_t column_ndx, StringData nam
 }
 
 
-void Table::insert_root_column(size_t column_ndx, DataType type, StringData name)
+void Table::insert_root_column(size_t col_ndx, ColumnType col_type, StringData name)
 {
+    TIGHTDB_ASSERT(col_type != col_type_BackLink || col_ndx == m_columns.size());
+
     m_search_index = 0;
 
     // Add the column to the spec
-    m_spec.insert_column(column_ndx, type, name); // Throws
+    m_spec.insert_column(col_ndx, col_type, name); // Throws
 
     Spec::ColumnInfo info;
-    m_spec.get_column_info(column_ndx, info);
-
-    Allocator& alloc = m_columns.get_alloc();
-    ref_type ref = 0;
-    Array* parent = &m_columns;
+    m_spec.get_column_info(col_ndx, info);
     size_t ndx_in_parent = info.m_column_ref_ndx;
-    UniquePtr<ColumnBase> new_col;
 
-    try {
-        switch (type) {
-            case type_Int:
-            case type_Bool:
-            case type_DateTime: {
-                int_fast64_t value = 0;
-                ref = Column::create(Array::type_Normal, size(), value, alloc); // Throws
-                new_col.reset(new Column(ref, parent, ndx_in_parent, alloc)); // Throws
-                goto add;
-            }
-            case type_Link: {
-                ref = ColumnLink::create(size(), alloc); // Throws
-                new_col.reset(new ColumnLink(ref, parent, ndx_in_parent, alloc)); // Throws
-                goto add;
-            }
-            case type_LinkList: {
-                ref = ColumnLinkList::create(size(), alloc); // Throws
-                new_col.reset(new ColumnLinkList(ref, parent, ndx_in_parent, alloc)); // Throws
-                goto add;
-            }
-            case type_BackLink: {
-                TIGHTDB_ASSERT(column_ndx == m_columns.size());
-
-                ref = ColumnBackLink::create(size(), alloc); // Throws
-                new_col.reset(new ColumnBackLink(ref, parent, ndx_in_parent, alloc)); // Throws
-                goto add;
-            }
-            case type_Float:
-                ref = ColumnFloat::create(size(), alloc); // Throws
-                new_col.reset(new ColumnFloat(ref, parent, ndx_in_parent, alloc)); // Throws
-                goto add;
-            case type_Double:
-                ref = ColumnDouble::create(size(), alloc); // Throws
-                new_col.reset(new ColumnDouble(ref, parent, ndx_in_parent, alloc)); // Throws
-                goto add;
-            case type_String:
-                ref = AdaptiveStringColumn::create(size(), alloc); // Throws
-                new_col.reset(new AdaptiveStringColumn(ref, parent, ndx_in_parent,
-                                                       alloc)); // Throws
-                goto add;
-            case type_Binary:
-                ref = ColumnBinary::create(size(), alloc); // Throws
-                new_col.reset(new ColumnBinary(ref, parent, ndx_in_parent, alloc)); // Throws
-                goto add;
-            case type_Table: {
-                ref = ColumnTable::create(size(), alloc); // Throws
-                new_col.reset(new ColumnTable(alloc, this, column_ndx, parent, ndx_in_parent,
-                                              ref)); // Throws
-                goto add;
-            }
-            case type_Mixed:
-                ref = ColumnMixed::create(size(), alloc); // Throws
-                new_col.reset(new ColumnMixed(alloc, this, column_ndx, parent, ndx_in_parent,
-                                              ref)); // Throws
-                goto add;
-        }
-        TIGHTDB_ASSERT(false);
-
-      add:
-        m_columns.insert(ndx_in_parent, new_col->get_ref()); // Throws
-        try {
-            // FIXME: intptr_t is not guaranteed to exists, even in
-            // C++11. Solve this by changing the type of
-            // `Table::m_cols` to `std::vector<ColumnBase*>`. Also
-            // change its name to `Table::m_column_accessors`.
-            m_cols.insert(column_ndx, intptr_t(new_col.get())); // Throws
-            new_col.release();
-        }
-        catch (...) {
-            m_columns.erase(ndx_in_parent); // Guaranteed to not throw
-            throw;
-        }
-    }
-    catch (...) {
-        if (ref != 0)
-            Array::destroy_deep(ref, alloc);
-        throw;
-    }
+    ref_type ref = create_column(col_type, m_size, m_columns.get_alloc()); // Throws
+    m_columns.insert(ndx_in_parent, ref); // Throws
+    UniquePtr<ColumnBase> col(create_column_accessor(col_type, col_ndx, ndx_in_parent)); // Throws
+    m_cols.insert(col_ndx, intptr_t(col.get())); // Throws
+    col.release();
 
     // Update cached column indexes for subsequent column accessors
     int ndx_in_parent_diff = 1;
-    adjust_column_index(column_ndx+1, ndx_in_parent_diff);
+    adjust_column_index(col_ndx+1, ndx_in_parent_diff);
 }
 
 
@@ -963,7 +888,7 @@ void Table::create_columns()
     // Add the newly defined columns
     size_t n = m_spec.get_column_count();
     for (size_t i=0; i<n; ++i) {
-        ColumnType type = m_spec.get_real_column_type(i);
+        ColumnType type = m_spec.get_column_type(i);
         ColumnAttr attr = m_spec.get_column_attr(i);
         size_t ref_pos =  m_columns.size();
         ColumnBase* new_col = 0;
@@ -1171,13 +1096,13 @@ ColumnBase* Table::create_column_accessor(ColumnType col_type, size_t col_ndx, s
             return new ColumnTable(alloc, this, col_ndx, &m_columns, ndx_in_parent, ref); // Throws
         case col_type_Mixed:
             return new ColumnMixed(alloc, this, col_ndx, &m_columns, ndx_in_parent, ref); // Throws
-        case type_Link:
+        case col_type_Link:
             // Target table will be set by group after entire table has been created
             return new ColumnLink(ref, &m_columns, ndx_in_parent, alloc); // Throws
-        case type_LinkList:
+        case col_type_LinkList:
             // Target table will be set by group after entire table has been created
             return new ColumnLinkList(ref, &m_columns, ndx_in_parent, alloc); // Throws
-        case type_BackLink:
+        case col_type_BackLink:
             // Source table will be set by group after entire table has been created
             return new ColumnBackLink(ref, &m_columns, ndx_in_parent, alloc); // Throws
         case col_type_Reserved1:
@@ -1197,7 +1122,7 @@ void Table::create_column_accessors()
     size_t ndx_in_parent = 0;
     size_t num_cols = m_spec.get_column_count();
     for (size_t col_ndx = 0; col_ndx < num_cols; ++col_ndx) {
-        ColumnType col_type = m_spec.get_real_column_type(col_ndx);
+        ColumnType col_type = m_spec.get_column_type(col_ndx);
         ColumnBase* col = create_column_accessor(col_type, col_ndx, ndx_in_parent); // Throws
         // FIXME: Memory leak if the following addition statement fails. This
         // problem disappears as soon as m_cols is changed to be of std::vector
@@ -1438,8 +1363,8 @@ const ColumnBase& Table::get_column_base(size_t ndx) const TIGHTDB_NOEXCEPT
 ColumnLinkBase& Table::get_column_linkbase(size_t ndx)
 {
     TIGHTDB_ASSERT(ndx < m_spec.get_column_count());
-    TIGHTDB_ASSERT(m_spec.get_column_type(ndx) == type_Link ||
-                   m_spec.get_column_type(ndx) == type_LinkList);
+    TIGHTDB_ASSERT(m_spec.get_column_type(ndx) == col_type_Link ||
+                   m_spec.get_column_type(ndx) == col_type_LinkList);
     instantiate_before_change();
     TIGHTDB_ASSERT(m_cols.size() == m_spec.get_column_count());
 
@@ -1449,13 +1374,13 @@ ColumnLinkBase& Table::get_column_linkbase(size_t ndx)
 }
 
 
-void Table::validate_column_type(const ColumnBase& column, ColumnType coltype, size_t ndx) const
+void Table::validate_column_type(const ColumnBase& column, ColumnType col_type, size_t ndx) const
 {
-    if (coltype == col_type_Int || coltype == col_type_DateTime || coltype == col_type_Bool) {
+    if (col_type == col_type_Int || col_type == col_type_DateTime || col_type == col_type_Bool) {
         TIGHTDB_ASSERT(column.IsIntColumn());
     }
     else {
-        TIGHTDB_ASSERT(coltype == get_real_column_type(ndx));
+        TIGHTDB_ASSERT(col_type == get_real_column_type(ndx));
     }
     static_cast<void>(column);
     static_cast<void>(ndx);
@@ -1504,36 +1429,38 @@ ref_type Table::create_empty_table(Allocator& alloc)
 }
 
 
-ref_type Table::create_column(DataType column_type, size_t size, Allocator& alloc)
+ref_type Table::create_column(ColumnType col_type, size_t size, Allocator& alloc)
 {
-    switch (column_type) {
-        case type_Int:
-        case type_Bool:
-        case type_DateTime: {
+    switch (col_type) {
+        case col_type_Int:
+        case col_type_Bool:
+        case col_type_DateTime: {
             int_fast64_t value = 0;
             return Column::create(Array::type_Normal, size, value, alloc); // Throws
         }
-        case type_Link:
-            return ColumnLink::create(size, alloc); // Throws
-        case type_LinkList:
-            return ColumnLinkList::create(size, alloc); // Throws
-        case type_Float:
+        case col_type_Float:
             return ColumnFloat::create(size, alloc); // Throws
-        case type_Double:
+        case col_type_Double:
             return ColumnDouble::create(size, alloc); // Throws
-        case type_String:
+        case col_type_String:
             return AdaptiveStringColumn::create(size, alloc); // Throws
-        case type_Binary:
+        case col_type_Binary:
             return ColumnBinary::create(size, alloc); // Throws
-        case type_Table:
+        case col_type_Table:
             return ColumnTable::create(size, alloc); // Throws
-        case type_Mixed:
+        case col_type_Mixed:
             return ColumnMixed::create(size, alloc); // Throws
-        case type_BackLink:
-            TIGHTDB_ASSERT(false);
-            return 0;
+        case col_type_Link:
+            return ColumnLink::create(size, alloc); // Throws
+        case col_type_LinkList:
+            return ColumnLinkList::create(size, alloc); // Throws
+        case col_type_BackLink:
+            return ColumnBackLink::create(size, alloc); // Throws
+        case col_type_StringEnum:
+        case col_type_Reserved1:
+        case col_type_Reserved4:
+            break;
     }
-
     TIGHTDB_ASSERT(false);
     return 0;
 }
@@ -2285,7 +2212,6 @@ Mixed Table::get_mixed(size_t column_ndx, size_t ndx) const TIGHTDB_NOEXCEPT
         case type_Mixed:
         case type_Link:
         case type_LinkList:
-        case type_BackLink:
             break;
     }
     TIGHTDB_ASSERT(false);
@@ -2337,7 +2263,6 @@ void Table::set_mixed(size_t column_ndx, size_t ndx, Mixed value)
         case type_Mixed:
         case type_Link:
         case type_LinkList:
-        case type_BackLink:
             TIGHTDB_ASSERT(false);
             break;
     }
@@ -2384,7 +2309,6 @@ void Table::insert_mixed(size_t column_ndx, size_t ndx, Mixed value)
         case type_Mixed:
         case type_Link:
         case type_LinkList:
-        case type_BackLink:
             TIGHTDB_ASSERT(false);
             break;
     }
@@ -3589,7 +3513,7 @@ void Table::adjust_column_index(size_t column_ndx_begin, int ndx_in_parent_diff)
 
         // If we modified before link columns, we have to update their
         // backlinks to point to their new position
-        ColumnType type = m_spec.get_real_column_type(col_ndx);
+        ColumnType type = m_spec.get_column_type(col_ndx);
         if (type == col_type_Link || type == col_type_LinkList) {
             size_t table_ndx = get_index_in_parent();
             ColumnLinkBase* col = static_cast<ColumnLinkBase*>(column);
@@ -3749,7 +3673,6 @@ void Table::to_json_row(size_t row_ndx, ostream& out) const
                         case type_Mixed:
                         case type_Link:
                         case type_LinkList:
-                        case type_BackLink:
                             TIGHTDB_ASSERT(false);
                             break;
                     }
@@ -3764,8 +3687,6 @@ void Table::to_json_row(size_t row_ndx, ostream& out) const
                 // TODO: print entire list of linked row
                 //out << "\"Link to: " << get_int(i, row_ndx) << "\"";
                 break;
-            case type_BackLink:
-                TIGHTDB_ASSERT(false);
         }
     }
     out << "}";
@@ -3919,7 +3840,6 @@ void Table::to_string_header(ostream& out, vector<size_t>& widths) const
                         case type_Mixed:
                         case type_Link:
                         case type_LinkList:
-                        case type_BackLink:
                             TIGHTDB_ASSERT(false);
                             break;
                     }
@@ -3929,8 +3849,6 @@ void Table::to_string_header(ostream& out, vector<size_t>& widths) const
             case type_LinkList:
                 width = 5;
                 break;
-            case type_BackLink:
-                TIGHTDB_ASSERT(false);
         }
         // Set width to max of column name and the longest value
         size_t name_len = name.size();
@@ -4044,7 +3962,6 @@ void Table::to_string_row(size_t row_ndx, ostream& out, const vector<size_t>& wi
                         case type_Mixed:
                         case type_Link:
                         case type_LinkList:
-                        case type_BackLink:
                             TIGHTDB_ASSERT(false);
                             break;
                     }
@@ -4058,8 +3975,6 @@ void Table::to_string_row(size_t row_ndx, ostream& out, const vector<size_t>& wi
             case type_LinkList:
                 // TODO: print number of links in list
                 break;
-            case type_BackLink:
-                TIGHTDB_ASSERT(false);
         }
     }
     out << "\n";
@@ -4446,7 +4361,7 @@ void Table::refresh_accessor_tree(size_t ndx_in_parent)
         // then we need to replace the accessor with an instance of
         // ColumnStringEnum.
         if (col && col->is_string_col()) {
-            ColumnType col_type = m_spec.get_real_column_type(col_ndx);
+            ColumnType col_type = m_spec.get_column_type(col_ndx);
             if (col_type == col_type_StringEnum) {
                 delete col;
                 col = 0;
@@ -4463,7 +4378,7 @@ void Table::refresh_accessor_tree(size_t ndx_in_parent)
             col->refresh_accessor_tree(col_ndx, m_spec); // Throws
         }
         else {
-            ColumnType col_type = m_spec.get_real_column_type(col_ndx);
+            ColumnType col_type = m_spec.get_column_type(col_ndx);
             col = create_column_accessor(col_type, col_ndx, col_ndx_in_parent); // Throws
             // FIXME: Memory leak if the following assignment statement
             // fails. This problem disappears as soon as m_cols is changed to be

--- a/src/tightdb/table.hpp
+++ b/src/tightdb/table.hpp
@@ -798,7 +798,7 @@ private:
     struct InsertSubtableColumns;
     struct RemoveSubtableColumns;
 
-    void insert_root_column(std::size_t column_ndx, DataType type, StringData name);
+    void insert_root_column(std::size_t column_ndx, ColumnType, StringData name);
     void remove_root_column(std::size_t column_ndx);
 
     struct SubtableUpdater {
@@ -933,7 +933,7 @@ private:
     /// Create a column of the specified type, fill it with the
     /// specified number of default values, and return just the
     /// reference to the underlying memory.
-    static ref_type create_column(DataType column_type, size_t num_default_values, Allocator&);
+    static ref_type create_column(ColumnType column_type, size_t num_default_values, Allocator&);
 
     /// Construct a copy of the columns array of this table using the
     /// specified allocator and return just the ref to that array.
@@ -1137,13 +1137,13 @@ inline std::size_t Table::get_column_index(StringData name) const TIGHTDB_NOEXCE
 inline ColumnType Table::get_real_column_type(std::size_t ndx) const TIGHTDB_NOEXCEPT
 {
     TIGHTDB_ASSERT(ndx < m_spec.get_column_count());
-    return m_spec.get_real_column_type(ndx);
+    return m_spec.get_column_type(ndx);
 }
 
 inline DataType Table::get_column_type(std::size_t ndx) const TIGHTDB_NOEXCEPT
 {
     TIGHTDB_ASSERT(ndx < m_spec.get_column_count());
-    return m_spec.get_column_type(ndx);
+    return m_spec.get_public_column_type(ndx);
 }
 
 template <class C, ColumnType coltype>

--- a/src/tightdb/table_basic.hpp
+++ b/src/tightdb/table_basic.hpp
@@ -480,7 +480,7 @@ template<class Subtab, int col_idx> struct AddCol<SpecBase::Subtable<Subtab>, co
 template<class Type, int col_idx> struct CmpColType {
     static bool exec(const Spec* spec, const StringData* col_names)
     {
-        return GetColumnTypeId<Type>::id != spec->get_column_type(col_idx) ||
+        return GetColumnTypeId<Type>::id != spec->get_public_column_type(col_idx) ||
             col_names[col_idx] != spec->get_column_name(col_idx);
     }
 };
@@ -489,7 +489,7 @@ template<class Type, int col_idx> struct CmpColType {
 template<class Subtab, int col_idx> struct CmpColType<SpecBase::Subtable<Subtab>, col_idx> {
     static bool exec(const Spec* spec, const StringData* col_names)
     {
-        if (spec->get_column_type(col_idx) != type_Table ||
+        if (spec->get_column_type(col_idx) != col_type_Table ||
             col_names[col_idx] != spec->get_column_name(col_idx)) return true;
         const Spec subspec = const_cast<Spec*>(spec)->get_subtable_spec(col_idx);
         return !Subtab::matches_dynamic_spec(&subspec);

--- a/test/test_table.cpp
+++ b/test/test_table.cpp
@@ -3149,14 +3149,12 @@ void compare_table_with_slice(TestResults& test_results, const Table& table,
                             case type_Mixed:
                             case type_Link:
                             case type_LinkList:
-                            case type_BackLink:
                                 TIGHTDB_ASSERT(false);
                         }
                     }
                 }
                 break;
             case type_LinkList:
-            case type_BackLink:
                 break;
         }
     }


### PR DESCRIPTION
This is a cleanup PR. Most importantly, it eliminates `type_BackLink` as a member of the public `enum` `DataType`. These are mere preparations for another upcoming PR that deals with some of the missing link related stuff.

@astigsen @finnschiermer @rrrlasse 
