### PR TITLE
[trivial] Add link testcase

### DIFF
--- a/test/test_links.cpp
+++ b/test/test_links.cpp
@@ -599,7 +599,7 @@ TEST(Links_LinkList_AccessorUpdates)
     CHECK_EQUAL(false, links2again->is_attached());
 }
 
-TEST(Link_Circular_Accessors)
+TEST(Links_CircularAccessors)
 {
     SHARED_GROUP_TEST_PATH(path);
     SharedGroup sg(path);


### PR DESCRIPTION
Testcase demonstrating that there is no problem in getting table accessors correct when loading tables
which refer to each other in a cycle.
