### PR TITLE
Add support for automatic handling of release notes

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -890,6 +890,19 @@ EOF
         exit 0
         ;;
 
+    "release-notes-prerelease")
+        RELEASE_HEADER="# $(sh build.sh get-version) Release notes ($(date +%F))" || exit 1
+        sed -i.bak "1s/.*/$RELEASE_HEADER/" release_notes.md || exit 1
+        rm release_notes.md.bak
+        exit 0
+        ;;
+
+    "release-notes-postrelease")
+        cat doc/release_notes_template.md release_notes.md > release_notes.md.new || exit 1
+        mv release_notes.md.new release_notes.md || exit 1
+        exit 0
+        ;;
+
     "get-version")
         version_file="src/tightdb/version.hpp"
         tightdb_ver_major="$(grep ^"#define TIGHTDB_VER_MAJOR" $version_file | awk '{print $3}')" || exit 1

--- a/doc/release_notes_template.md
+++ b/doc/release_notes_template.md
@@ -1,0 +1,26 @@
+# NEXT RELEASE
+
+## C++ (core)
+
+The C++ API has been updated and your code will break!
+
+### Bugfixes:
+
+* None.
+
+### API breaking changes:
+
+* `???`
+
+### Enhancements:
+
+* `???`
+
+-----------
+
+### Internals:
+
+* `???`
+
+----------------------------------------------
+

--- a/release_notes.md
+++ b/release_notes.md
@@ -1,34 +1,4 @@
-Template
-=============================================================
-x.x.x Release notes (yyyy—MM-dd)
-================================
-
-C++ (core)
------------
-The C++ API has been updated and your code will break!
-
-### Bugfixes:
-
-* None.
-
-### API breaking changes:
-
-* `???`
-
-### Enhancements:
-
-* `???`
-
------------
-
-### Internals:
-
-* `???`
-
-----------------------------------------------
-
-x.x.x Release notes (yyyy—MM-dd)    <<<------------ PLEASE NOTE, THIS IS THE NEXT RELEASE!!!!!!
-================================
+# NEXT RELEASE
 
 C++ (core)
 -----------


### PR DESCRIPTION
Move the template in a separate file
Add targets to build.sh to manage pre and post release ops
