### PR TITLE
Fixed bug that prevented updates of TableViews that had been moved.

### DIFF
--- a/src/tightdb/table_view.hpp
+++ b/src/tightdb/table_view.hpp
@@ -604,6 +604,12 @@ inline void TableViewBase::move_assign(TableViewBase* tv) TIGHTDB_NOEXCEPT
     m_query.move_assign(tv->m_query);
 #ifdef TIGHTDB_ENABLE_REPLICATION
     m_last_seen_version = tv->m_last_seen_version;
+    m_auto_sort = tv->m_auto_sort;
+    m_start = tv->m_start;
+    m_end = tv->m_end;
+    m_limit = tv->m_limit;
+    m_ascending = tv->m_ascending;
+    m_sort_index = tv->m_sort_index;
 #endif
 }
 

--- a/test/test_table_view.cpp
+++ b/test/test_table_view.cpp
@@ -429,6 +429,31 @@ TEST(TableView_Follows_Changes)
     CHECK_EQUAL(1, v.get_int(0,0));
 }
 
+TEST(TableView_SyncAfterCopy) {
+    Table table;
+    table.add_column(type_Int, "first");
+    table.add_empty_row();
+    table.set_int(0,0,1);
+
+    // do initial query
+    Query q = table.where().equal(0,1);
+    TableView v = q.find_all();
+    CHECK_EQUAL(1, v.size());
+    CHECK_EQUAL(1, v.get_int(0,0));
+
+    // move the tableview
+    TableView v2 = v;
+    CHECK_EQUAL(1, v2.size());
+
+    // make a change
+    size_t ndx2 = table.add_empty_row();
+    table.set_int(0, ndx2, 1);
+
+    // verify that the copied view sees the change
+    v2.sync_if_needed();
+    CHECK_EQUAL(2, v2.size());
+}
+
 TEST(TableView_FindAll)
 {
     TestTableInt table;


### PR DESCRIPTION
This is just a minor bug fix, but there is a similar fix in the cocoa binding that depends on it.

@kspangsege @finnschiermer @rrrlasse @bmunkholm 
