### PR TITLE
Added methods to delete target rows through LinkView.

### DIFF
--- a/release_notes.md
+++ b/release_notes.md
@@ -33,6 +33,7 @@ C++ (core)
 * Support for row accessors.
 * Table, row, and descriptor accessors are now generally retained and properly adjusted when the parent table is modified.
 * Added methods to find rows by target in TableView and LinkView.
+* Added methods `LinkView::remove_target_row()` and `LinkView::remove_all_target_rows()`.
 
 
 -----------

--- a/src/tightdb/link_view.cpp
+++ b/src/tightdb/link_view.cpp
@@ -152,7 +152,9 @@ void LinkView::clear()
 #endif
 }
 
-void LinkView::delete_target_row(std::size_t link_ndx) {
+
+void LinkView::remove_target_row(std::size_t link_ndx)
+{
     TIGHTDB_ASSERT(is_attached());
     TIGHTDB_ASSERT(m_target_row_indexes.is_attached() && link_ndx < m_target_row_indexes.size());
 
@@ -164,7 +166,9 @@ void LinkView::delete_target_row(std::size_t link_ndx) {
     target_table.move_last_over(target_row_ndx);
 }
 
-void LinkView::delete_all() {
+
+void LinkView::remove_all_target_rows()
+{
     TIGHTDB_ASSERT(is_attached());
 
     Table& target_table = get_target_table();
@@ -181,6 +185,7 @@ void LinkView::delete_all() {
         target_table.move_last_over(target_row_ndx);
     }
 }
+
 
 void LinkView::do_nullify_link(std::size_t old_target_row_ndx)
 {

--- a/src/tightdb/link_view.hpp
+++ b/src/tightdb/link_view.hpp
@@ -60,9 +60,15 @@ public:
     void remove(std::size_t link_ndx);
     void clear();
 
-    /// Remove from linkview and delete in target table
-    void delete_target_row(std::size_t link_ndx);
-    void delete_all();
+    /// Remove the target row of the specified link from the target table. This
+    /// also removes the specified link from this link list, and any other link
+    /// pointing to that row. This is merely a shorthand for
+    /// `get_target_table.move_last_over(get(link_ndx))`.
+    void remove_target_row(std::size_t link_ndx);
+
+    /// Remove all target rows pointed to by links in this link list, and clear
+    /// this link list.
+    void remove_all_target_rows();
 
     /// Search this list for a link to the specified target table row (specified
     /// by its index in the target table). If found, the index of the link to

--- a/test/test_links.cpp
+++ b/test/test_links.cpp
@@ -712,7 +712,7 @@ TEST(Links_Transactions)
     }
 }
 
-TEST(Links_DeleteTargetRows)
+TEST(Links_RemoveTargetRows)
 {
     Group group;
 
@@ -732,15 +732,15 @@ TEST(Links_DeleteTargetRows)
     links->add(0);
 
     // delete target rows through the links one at a time
-    links->delete_target_row(0);
+    links->remove_target_row(0);
     CHECK_EQUAL(2, target->size());
     CHECK_EQUAL(2, links->size());
 
-    links->delete_target_row(1);
+    links->remove_target_row(1);
     CHECK_EQUAL(1, target->size());
     CHECK_EQUAL(1, links->size());
 
-    links->delete_target_row(0);
+    links->remove_target_row(0);
     CHECK_EQUAL(0, target->size());
     CHECK_EQUAL(0, links->size());
 
@@ -752,8 +752,8 @@ TEST(Links_DeleteTargetRows)
     links->add(1);
     links->add(0);
 
-    // delete all targets through the links
-    links->delete_all();
+    // Remove all targets through the links
+    links->remove_all_target_rows();
     CHECK(target->is_empty());
     CHECK(links->is_empty());
 }


### PR DESCRIPTION
This is quite error prone to do from the bindings, so it should really be core methods.

@kspangsege @rrrlasse @bmunkholm 
