### PR TITLE
Eliminate Table::get_index_in_parent() [BREAKS PUBLIC API]

### DIFF
--- a/release_notes.md
+++ b/release_notes.md
@@ -6,7 +6,9 @@
 
 ### API breaking changes:
 
-* Lorem ipsum.
+* `Table::get_parent_row_index()` and `Table::get_index_in_group()` together
+  replace `Table::get_index_in_parent()`. This was done to avoid a confusing mix
+  of distinct concepts.
 
 ### Enhancements:
 
@@ -34,7 +36,9 @@
 
 ### Enhancements:
 
-* Lets you search for null-links, such as `table2->column<Link>(col_link2).is_null().find()`. Works for `Link` and `LinkedList`.
+* Lets you search for null-links, such as
+  `table2->column<Link>(col_link2).is_null().find()`. Works for `Link` and
+  `LinkedList`.
 
 -----------
 

--- a/src/tightdb/column_backlink.cpp
+++ b/src/tightdb/column_backlink.cpp
@@ -296,7 +296,7 @@ void ColumnBackLink::Verify(const Table& table, size_t col_ndx) const
     TIGHTDB_ASSERT(&m_origin_column->get_backlink_column() == this);
 
     // Check that m_origin_table is the table specified by the spec
-    size_t origin_table_ndx = m_origin_table->get_index_in_parent();
+    size_t origin_table_ndx = m_origin_table->get_index_in_group();
     typedef _impl::TableFriend tf;
     const Spec& spec = tf::get_spec(table);
     TIGHTDB_ASSERT(origin_table_ndx == spec.get_opposite_link_table_ndx(col_ndx));

--- a/src/tightdb/column_link_base.cpp
+++ b/src/tightdb/column_link_base.cpp
@@ -17,7 +17,7 @@ void ColumnLinkBase::Verify(const Table& table, size_t col_ndx) const
     TIGHTDB_ASSERT(&m_backlink_column->get_origin_column() == this);
 
     // Check that m_target_table is the table specified by the spec
-    size_t target_table_ndx = m_target_table->get_index_in_parent();
+    size_t target_table_ndx = m_target_table->get_index_in_group();
     typedef _impl::TableFriend tf;
     const Spec& spec = tf::get_spec(table);
     TIGHTDB_ASSERT(target_table_ndx == spec.get_opposite_link_table_ndx(col_ndx));
@@ -25,7 +25,7 @@ void ColumnLinkBase::Verify(const Table& table, size_t col_ndx) const
     // Check that m_backlink_column is the column specified by the target table spec
     const Spec& target_spec = tf::get_spec(*m_target_table);
     size_t backlink_col_ndx =
-        target_spec.find_backlink_column(table.get_index_in_parent(), col_ndx);
+        target_spec.find_backlink_column(table.get_index_in_group(), col_ndx);
     TIGHTDB_ASSERT(m_backlink_column == &tf::get_column(*m_target_table, backlink_col_ndx));
 }
 

--- a/src/tightdb/column_mixed.cpp
+++ b/src/tightdb/column_mixed.cpp
@@ -402,7 +402,7 @@ void ColumnMixed::Verify(const Table& table, size_t col_ndx) const
         if (v == 0 || v & 0x1)
             continue;
         ConstTableRef subtable = m_data->get_subtable_ptr(i)->get_table_ref();
-        TIGHTDB_ASSERT(subtable->get_index_in_parent() == i);
+        TIGHTDB_ASSERT(subtable->get_parent_row_index() == i);
         subtable->Verify();
     }
 }

--- a/src/tightdb/column_table.cpp
+++ b/src/tightdb/column_table.cpp
@@ -403,7 +403,7 @@ void ColumnTable::Verify(const Table& table, size_t col_ndx) const
         // want to skip null refs here.
         ConstTableRef subtable = get_subtable_ptr(i)->get_table_ref();
         TIGHTDB_ASSERT(tf::get_spec(*subtable).get_ndx_in_parent() == subspec_ndx);
-        TIGHTDB_ASSERT(subtable->get_index_in_parent() == i);
+        TIGHTDB_ASSERT(subtable->get_parent_row_index() == i);
         subtable->Verify();
     }
 }

--- a/src/tightdb/group.cpp
+++ b/src/tightdb/group.cpp
@@ -1362,7 +1362,7 @@ void Group::Verify() const
         size_t n = m_tables.size();
         for (size_t i = 0; i != n; ++i) {
             const Table* table = get_table_by_ndx(i);
-            TIGHTDB_ASSERT(table->get_index_in_parent() == i);
+            TIGHTDB_ASSERT(table->get_index_in_group() == i);
             table->Verify();
         }
     }

--- a/src/tightdb/link_view.hpp
+++ b/src/tightdb/link_view.hpp
@@ -204,7 +204,7 @@ inline bool LinkView::operator==(const LinkView& link_list) const TIGHTDB_NOEXCE
 {
     Table& target_table_1 = m_origin_column.get_target_table();
     Table& target_table_2 = link_list.m_origin_column.get_target_table();
-    if (target_table_1.get_index_in_parent() != target_table_2.get_index_in_parent())
+    if (target_table_1.get_index_in_group() != target_table_2.get_index_in_group())
         return false;
     if (!m_target_row_indexes.is_attached() || m_target_row_indexes.is_empty()) {
         return !link_list.m_target_row_indexes.is_attached() ||

--- a/src/tightdb/replication.hpp
+++ b/src/tightdb/replication.hpp
@@ -807,7 +807,7 @@ inline void Replication::insert_column(const Descriptor& desc, std::size_t col_n
     simple_cmd(instr_InsertColumn, util::tuple(col_ndx, int(type), name.size())); // Throws
     transact_log_append(name.data(), name.size()); // Throws
     if (link_target_table) {
-        std::size_t target_table_ndx = link_target_table->get_index_in_parent();
+        std::size_t target_table_ndx = link_target_table->get_index_in_group();
         append_num(target_table_ndx); // Throws
     }
 }
@@ -828,9 +828,9 @@ inline void Replication::erase_column(const Descriptor& desc, std::size_t col_nd
     const Table& origin_table = df::get_root_table(desc);
     TIGHTDB_ASSERT(origin_table.is_group_level());
     const Table& target_table = *tf::get_link_target_table_accessor(origin_table, col_ndx);
-    std::size_t target_table_ndx = target_table.get_index_in_parent();
+    std::size_t target_table_ndx = target_table.get_index_in_group();
     const Spec& target_spec = tf::get_spec(target_table);
-    std::size_t origin_table_ndx = origin_table.get_index_in_parent();
+    std::size_t origin_table_ndx = origin_table.get_index_in_group();
     std::size_t backlink_col_ndx = target_spec.find_backlink_column(origin_table_ndx, col_ndx);
     simple_cmd(instr_EraseLinkColumn, util::tuple(col_ndx, target_table_ndx,
                                                   backlink_col_ndx)); // Throws

--- a/src/tightdb/table.hpp
+++ b/src/tightdb/table.hpp
@@ -62,25 +62,22 @@ class Replication;
 
 
 /// The Table class is non-polymorphic, that is, it has no virtual
-/// functions. This is important because it ensures that there is no
-/// run-time distinction between a Table instance and an instance of
-/// any variation of BasicTable<T>, and this, in turn, makes it valid
-/// to cast a pointer from Table to BasicTable<T> even when the
-/// instance is constructed as a Table. Of course, this also assumes
-/// that BasicTable<> is non-polymorphic, has no destructor, and adds
-/// no extra data members.
+/// functions. This is important because it ensures that there is no run-time
+/// distinction between a Table instance and an instance of any variation of
+/// BasicTable<T>, and this, in turn, makes it valid to cast a pointer from
+/// Table to BasicTable<T> even when the instance is constructed as a Table. Of
+/// course, this also assumes that BasicTable<> is non-polymorphic, has no
+/// destructor, and adds no extra data members.
 ///
-/// FIXME: Table assignment (from any group to any group) could be made
-/// aliasing safe as follows: Start by cloning source table into
-/// target allocator. On success, assign, and then deallocate any
-/// previous structure at the target.
+/// FIXME: Table assignment (from any group to any group) could be made aliasing
+/// safe as follows: Start by cloning source table into target allocator. On
+/// success, assign, and then deallocate any previous structure at the target.
 ///
-/// FIXME: It might be desirable to have a 'table move' feature
-/// between two places inside the same group (say from a subtable or a
-/// mixed column to group level). This could be done in a very
-/// efficient manner.
+/// FIXME: It might be desirable to have a 'table move' feature between two
+/// places inside the same group (say from a subtable or a mixed column to group
+/// level). This could be done in a very efficient manner.
 ///
-/// FIXME: When compiling in debug mode, all public table methods
+/// FIXME: When compiling in debug mode, all public non-static table functions
 /// should TIGHTDB_ASSERT(is_attached()).
 class Table {
 public:
@@ -121,10 +118,10 @@ public:
     /// A table accessor may get detached from the underlying row for various
     /// reasons (see below). When it does, it no longer refers to anything, and
     /// can no longer be used, except for calling is_attached(). The
-    /// consequences of calling other methods on a detached table accessor are
-    /// undefined. Table accessors obtained by calling functions in the TightDB
-    /// API are always in the 'attached' state immediately upon return from
-    /// those functions.
+    /// consequences of calling other non-static functions on a detached table
+    /// accessor are unspecified. Table accessors obtained by calling functions in
+    /// the TightDB API are always in the 'attached' state immediately upon
+    /// return from those functions.
     ///
     /// A table accessor of a free-standing table never becomes detached (except
     /// during its eventual destruction). A group-level table accessor becomes
@@ -156,10 +153,10 @@ public:
     StringData get_name() const TIGHTDB_NOEXCEPT;
 
     //@{
-    /// Conventience methods for inspecting the dynamic table type.
+    /// Conventience functions for inspecting the dynamic table type.
     ///
-    /// These methods behave as if they were called on the descriptor
-    /// returned by get_descriptor().
+    /// These functions behave as if they were called on the descriptor returned
+    /// by get_descriptor().
     std::size_t get_column_count() const TIGHTDB_NOEXCEPT;
     DataType    get_column_type(std::size_t column_ndx) const TIGHTDB_NOEXCEPT;
     StringData  get_column_name(std::size_t column_ndx) const TIGHTDB_NOEXCEPT;
@@ -167,31 +164,28 @@ public:
     //@}
 
     //@{
-    /// Convenience methods for manipulating the dynamic table type.
+    /// Convenience functions for manipulating the dynamic table type.
     ///
-    /// These function must be called only for tables with independent
-    /// dynamic type. A table has independent dynamic type if the
-    /// function has_shared_type() returns false. A table that is a
-    /// direct member of a group has independent dynamic type. So does
-    /// a free-standing table, and a subtable in a column of type
-    /// 'mixed'. All other tables have shared dynamic type. The
-    /// consequences of calling any of these functions for a table
-    /// with shared dynamic type are undefined.
+    /// These function must be called only for tables with independent dynamic
+    /// type. A table has independent dynamic type if the function
+    /// has_shared_type() returns false. A table that is a direct member of a
+    /// group has independent dynamic type. So does a free-standing table, and a
+    /// subtable in a column of type 'mixed'. All other tables have shared
+    /// dynamic type. The consequences of calling any of these functions for a
+    /// table with shared dynamic type are undefined.
     ///
-    /// Apart from that, these methods behave as if they were called on the
+    /// Apart from that, these functions behave as if they were called on the
     /// descriptor returned by get_descriptor(). Note especially that the
     /// `_link` suffixed functions must be used when inserting link-type
     /// columns.
     ///
-    /// If you need to change the shared dynamic type of the subtables
-    /// in a subtable column, consider using the API offered by the
-    /// Descriptor class.
+    /// If you need to change the shared dynamic type of the subtables in a
+    /// subtable column, consider using the API offered by the Descriptor class.
     ///
-    /// \param subdesc If a non-null pointer is passed, and the
-    /// specified type is `type_Table`, then this function
-    /// automatically reteives the descriptor associated with the new
-    /// subtable column, and stores a reference to its accessor in
-    /// `*subdesc`.
+    /// \param subdesc If a non-null pointer is passed, and the specified type
+    /// is `type_Table`, then this function automatically reteives the
+    /// descriptor associated with the new subtable column, and stores a
+    /// reference to its accessor in `*subdesc`.
     ///
     /// \return The value returned by add_column() and add_column_link(), is the
     /// index of the added column.
@@ -224,13 +218,12 @@ public:
     //@{
     /// Get the dynamic type descriptor for this table.
     ///
-    /// Every table has an associated descriptor that specifies its
-    /// dynamic type. For simple tables, that is, tables without
-    /// subtable columns, the dynamic type can be inspected and
-    /// modified directly using methods such as get_column_count() and
-    /// add_column(). For more complex tables, the type is best
-    /// managed through the associated descriptor object which is
-    /// returned by this method.
+    /// Every table has an associated descriptor that specifies its dynamic
+    /// type. For simple tables, that is, tables without subtable columns, the
+    /// dynamic type can be inspected and modified directly using member
+    /// functions such as get_column_count() and add_column(). For more complex
+    /// tables, the type is best managed through the associated descriptor
+    /// object which is returned by this function.
     ///
     /// \sa has_shared_type()
     DescriptorRef get_descriptor();
@@ -241,9 +234,8 @@ public:
     /// Get the dynamic type descriptor for the column with the
     /// specified index. That column must have type 'table'.
     ///
-    /// This is merely a shorthand for calling
-    /// `get_subdescriptor(column_ndx)` on the descriptor
-    /// returned by `get_descriptor()`.
+    /// This is merely a shorthand for calling `get_subdescriptor(column_ndx)`
+    /// on the descriptor returned by `get_descriptor()`.
     DescriptorRef get_subdescriptor(std::size_t column_ndx);
     ConstDescriptorRef get_subdescriptor(std::size_t column_ndx) const;
     //@}
@@ -252,21 +244,20 @@ public:
     /// Get access to an arbitrarily nested dynamic type descriptor.
     ///
     /// The returned descriptor is the one you would get by calling
-    /// Descriptor::get_subdescriptor() once for each entry in the
-    /// specified path, starting with the descriptor returned by
-    /// get_descriptor(). The path is allowed to be empty.
+    /// Descriptor::get_subdescriptor() once for each entry in the specified
+    /// path, starting with the descriptor returned by get_descriptor(). The
+    /// path is allowed to be empty.
     typedef std::vector<std::size_t> path_vec;
     DescriptorRef get_subdescriptor(const path_vec& path);
     ConstDescriptorRef get_subdescriptor(const path_vec& path) const;
     //@}
 
     //@{
-    /// Convenience methods for manipulating nested table types.
+    /// Convenience functions for manipulating nested table types.
     ///
-    /// These functions behave as if they were called on the
-    /// descriptor returned by `get_subdescriptor(path)`. These
-    /// function must be called only on tables with independent
-    /// dynamic type.
+    /// These functions behave as if they were called on the descriptor returned
+    /// by `get_subdescriptor(path)`. These function must be called only on
+    /// tables with independent dynamic type.
     ///
     /// \return The value returned by add_subcolumn(), is the index of
     /// the added column within the descriptor referenced by the
@@ -294,7 +285,7 @@ public:
     /// such subtables, this function returns true. See
     /// Descriptor::is_root() for more on this.
     ///
-    /// Please note that Table methods that modify the dynamic type
+    /// Please note that Table functions that modify the dynamic type
     /// directly, such as add_column(), are only allowed to be used on
     /// tables with non-shared type. If you need to modify a shared
     /// type, you will have to do that through the descriptor returned
@@ -435,12 +426,10 @@ public:
     /// parent table, and the subtable either resides in a column of type
     /// `table` or of type `mixed` in that parent. In that case
     /// get_parent_table() returns a reference to the accessor associated with
-    /// the parent, and get_index_in_parent() returns the index of the row in
-    /// which the subtable resides. Otherwise, if this table is a group-level
-    /// table, get_parent_table() returns null and get_index_in_parent() returns
-    /// the index of this table within the group. Otherwise this table is a
-    /// free-standing table, get_parent_table() returns null, and
-    /// get_index_in_parent() returns tightdb::npos.
+    /// the parent, and get_parent_row_index() returns the index of the row in
+    /// which the subtable resides. In all other cases (free-standing and
+    /// group-level tables), get_parent_table() returns null and
+    /// get_parent_row_index() returns tightdb::npos.
     ///
     /// If this accessor is attached to a subtable, and \a column_ndx_out is
     /// specified, then `*column_ndx_out` is set to the index of the column of
@@ -449,12 +438,16 @@ public:
     /// value upon return.
     TableRef get_parent_table(std::size_t* column_ndx_out = 0) TIGHTDB_NOEXCEPT;
     ConstTableRef get_parent_table(std::size_t* column_ndx_out = 0) const TIGHTDB_NOEXCEPT;
-    std::size_t get_index_in_parent() const TIGHTDB_NOEXCEPT;
+    std::size_t get_parent_row_index() const TIGHTDB_NOEXCEPT;
     //@}
 
     /// Only group-level unordered tables can be used as origins or targets for
     /// links.
     bool is_group_level() const TIGHTDB_NOEXCEPT;
+
+    /// If this table is a group-level table, then this function returns the
+    /// index of this table within the group. Otherwise it returns tightdb::npos.
+    std::size_t get_index_in_group() const TIGHTDB_NOEXCEPT;
 
     // Aggregate functions
     std::size_t count_int(std::size_t column_ndx, int64_t value) const;

--- a/test/test_table.cpp
+++ b/test/test_table.cpp
@@ -3240,7 +3240,8 @@ TEST(Table_Parent)
 {
     TableRef table = Table::create();
     CHECK_EQUAL(TableRef(), table->get_parent_table());
-    CHECK_EQUAL(tightdb::npos, table->get_index_in_parent());
+    CHECK_EQUAL(tightdb::npos, table->get_parent_row_index()); // Not a subtable
+    CHECK_EQUAL(tightdb::npos, table->get_index_in_group()); // Not a group-level table
 
     DescriptorRef subdesc;
     table->add_column(type_Table, "", &subdesc);
@@ -3256,22 +3257,22 @@ TEST(Table_Parent)
     subtab = table->get_subtable(0,0);
     CHECK_EQUAL(table, subtab->get_parent_table(&column_ndx));
     CHECK_EQUAL(0, column_ndx);
-    CHECK_EQUAL(0, subtab->get_index_in_parent());
+    CHECK_EQUAL(0, subtab->get_parent_row_index());
 
     subtab = table->get_subtable(0,1);
     CHECK_EQUAL(table, subtab->get_parent_table(&column_ndx));
     CHECK_EQUAL(0, column_ndx);
-    CHECK_EQUAL(1, subtab->get_index_in_parent());
+    CHECK_EQUAL(1, subtab->get_parent_row_index());
 
     subtab = table->get_subtable(1,0);
     CHECK_EQUAL(table, subtab->get_parent_table(&column_ndx));
     CHECK_EQUAL(1, column_ndx);
-    CHECK_EQUAL(0, subtab->get_index_in_parent());
+    CHECK_EQUAL(0, subtab->get_parent_row_index());
 
     subtab = table->get_subtable(1,1);
     CHECK_EQUAL(table, subtab->get_parent_table(&column_ndx));
     CHECK_EQUAL(1, column_ndx);
-    CHECK_EQUAL(1, subtab->get_index_in_parent());
+    CHECK_EQUAL(1, subtab->get_parent_row_index());
 
     // Check that column indexes are properly adjusted after new
     // column is insert.
@@ -3280,22 +3281,22 @@ TEST(Table_Parent)
     subtab = table->get_subtable(1,0);
     CHECK_EQUAL(table, subtab->get_parent_table(&column_ndx));
     CHECK_EQUAL(1, column_ndx);
-    CHECK_EQUAL(0, subtab->get_index_in_parent());
+    CHECK_EQUAL(0, subtab->get_parent_row_index());
 
     subtab = table->get_subtable(1,1);
     CHECK_EQUAL(table, subtab->get_parent_table(&column_ndx));
     CHECK_EQUAL(1, column_ndx);
-    CHECK_EQUAL(1, subtab->get_index_in_parent());
+    CHECK_EQUAL(1, subtab->get_parent_row_index());
 
     subtab = table->get_subtable(2,0);
     CHECK_EQUAL(table, subtab->get_parent_table(&column_ndx));
     CHECK_EQUAL(2, column_ndx);
-    CHECK_EQUAL(0, subtab->get_index_in_parent());
+    CHECK_EQUAL(0, subtab->get_parent_row_index());
 
     subtab = table->get_subtable(2,1);
     CHECK_EQUAL(table, subtab->get_parent_table(&column_ndx));
     CHECK_EQUAL(2, column_ndx);
-    CHECK_EQUAL(1, subtab->get_index_in_parent());
+    CHECK_EQUAL(1, subtab->get_parent_row_index());
 
     // Check that column indexes are properly adjusted after inserted
     // column is removed.
@@ -3304,22 +3305,22 @@ TEST(Table_Parent)
     subtab = table->get_subtable(0,0);
     CHECK_EQUAL(table, subtab->get_parent_table(&column_ndx));
     CHECK_EQUAL(0, column_ndx);
-    CHECK_EQUAL(0, subtab->get_index_in_parent());
+    CHECK_EQUAL(0, subtab->get_parent_row_index());
 
     subtab = table->get_subtable(0,1);
     CHECK_EQUAL(table, subtab->get_parent_table(&column_ndx));
     CHECK_EQUAL(0, column_ndx);
-    CHECK_EQUAL(1, subtab->get_index_in_parent());
+    CHECK_EQUAL(1, subtab->get_parent_row_index());
 
     subtab = table->get_subtable(1,0);
     CHECK_EQUAL(table, subtab->get_parent_table(&column_ndx));
     CHECK_EQUAL(1, column_ndx);
-    CHECK_EQUAL(0, subtab->get_index_in_parent());
+    CHECK_EQUAL(0, subtab->get_parent_row_index());
 
     subtab = table->get_subtable(1,1);
     CHECK_EQUAL(table, subtab->get_parent_table(&column_ndx));
     CHECK_EQUAL(1, column_ndx);
-    CHECK_EQUAL(1, subtab->get_index_in_parent());
+    CHECK_EQUAL(1, subtab->get_parent_row_index());
 }
 
 


### PR DESCRIPTION
This PR removes function `Table::get_index_in_parent()` from our public API and replaces it with two new functions, `Table::get_parent_row_index()` and `Table::get_index_in_group()`. This was done to avoid a confusing mix of distinct concepts.

This PR is also a preparation for a later PR that will add support for removal of group-level tables.

@astigsen @finnschiermer @rrrlasse 
