### PR TITLE
Clarify why Group::TransactAdvancer::insert_link() works

### DIFF
--- a/src/tightdb/group.cpp
+++ b/src/tightdb/group.cpp
@@ -937,6 +937,9 @@ public:
 
     bool insert_link(size_t col_ndx, size_t row_ndx, size_t) TIGHTDB_NOEXCEPT
     {
+        // The marking dirty of the target table is handled by
+        // insert_empty_rows() regardless of whether the link column is the
+        // first column or not.
         if (col_ndx == 0)
             insert_empty_rows(row_ndx, 1);
        return true;
@@ -1020,7 +1023,7 @@ public:
         // link-target table when there is no accessor for the origin
         // table. Fortunately, due to the fact that back-link column accessors
         // refer to the origin table accessor (and vice versa), it follows that
-        // the link-target table accessor exists if, and only if then origin
+        // the link-target table accessor exists if, and only if the origin
         // table accessor exists.
         //
         // get_link_target_table_accessor() will return null if the

--- a/src/tightdb/group_shared.hpp
+++ b/src/tightdb/group_shared.hpp
@@ -345,7 +345,7 @@ private:
     // End the current write transaction and transition atomically into
     // a read transaction, WITHOUT synchronizing to external changes
     // to data. All accessors are retained and continue to reflect the
-    // state at commit. 
+    // state at commit.
     void commit_and_continue_as_read();
 #endif
     friend class ReadTransaction;


### PR DESCRIPTION
Finn, it turned out that I was wrong. Nothing was missing in the implementation of `Group::TransactAdvancer::insert_link()`. I added a test, and a comment that tries to explain why it works.

This should make you happy, because it means that there is symmetry between the insert instructions after all.

@finnschiermer 
