### PR TITLE
Use an intrusive list for tracking table row accessors

### DIFF
--- a/src/tightdb/row.hpp
+++ b/src/tightdb/row.hpp
@@ -199,11 +199,12 @@ protected:
     void reattach(Table*, std::size_t row_ndx);
     void impl_detach() TIGHTDB_NOEXCEPT;
 
+private:
+    RowBase* m_prev; // Null if first, undefined if detached.
+    RowBase* m_next; // Null if last, undefined if detached.
+
     // Table needs to be able to modify m_table and m_row_ndx.
     friend class Table;
-private:
-    RowBase* m_prev; // Undefined if detached.
-    RowBase* m_next; // Undefined if detached.
 };
 
 

--- a/src/tightdb/table.hpp
+++ b/src/tightdb/table.hpp
@@ -739,7 +739,8 @@ private:
     typedef std::vector<const TableViewBase*> views;
     mutable views m_views;
 
-    mutable RowBase *m_row_accessors;
+    // Points to first bound row accessor, or is null if there are none.
+    mutable RowBase* m_row_accessors;
 
     // Used for queries: Items are added with link() method during buildup of query
     mutable std::vector<size_t> m_link_chain;
@@ -1307,7 +1308,7 @@ inline Table::Table(Allocator& alloc):
 {
     m_ref_count = 1; // Explicitely managed lifetime
     m_descriptor = 0;
-    m_row_accessors = null_ptr;
+    m_row_accessors = 0;
 
     ref_type ref = create_empty_table(alloc); // Throws
     Parent* parent = 0;
@@ -1322,7 +1323,7 @@ inline Table::Table(const Table& t, Allocator& alloc):
 {
     m_ref_count = 1; // Explicitely managed lifetime
     m_descriptor = 0;
-    m_row_accessors = null_ptr;
+    m_row_accessors = 0;
 
     ref_type ref = t.clone(alloc); // Throws
     Parent* parent = 0;
@@ -1337,7 +1338,7 @@ inline Table::Table(ref_count_tag, Allocator& alloc):
 {
     m_ref_count = 0; // Lifetime managed by reference counting
     m_descriptor = 0;
-    m_row_accessors = null_ptr;
+    m_row_accessors = 0;
 }
 
 inline TableRef Table::create(Allocator& alloc)


### PR DESCRIPTION
Makes destroying row accessors O(1) rather than O(N), as in some situations the vector search utterly dominated all other work done.

Performance impact from this on [these benchmarks](https://github.com/realm/realm-cocoa/blob/tg-perf-tests/Realm/Tests/PerformanceTests.m) on my iPhone 4S (average of ten runs):

| Test | Old | New |
| --- | --- | --- |
| testArrayValidation | 0.008 | 0.009 |
| testCountWhere | 0.010 | 0.010 |
| testDeleteAll | 0.118 | 0.123 |
| testEnumerateAndAccessAll | 5.184 | 0.299 |
| testEnumerateAndAccessArrayProperty | 5.123 | 0.390 |
| testEnumerateAndAccessQuery | 2.477 | 0.106 |
| testEnumerateAndMutateAutoreleasePool | 21.764 | 0.321 |
| testEnumerateAndMutate | 22.042 | 0.275 |
| testInsertMultipleAutoreleasePool | 0.565 | 0.547 |
| testInsertMultipleLiteralAutoreleasePool | 0.686 | 0.677 |
| testInsertMultipleLiteral | 2.470 | 0.668 |
| testInsertMultiple | 0.553 | 0.535 |
