### PR TITLE
Adding Group::remove_table() and Group::rename_table() to public API

### DIFF
--- a/release_notes.md
+++ b/release_notes.md
@@ -29,6 +29,7 @@
 * `Group::find_table()` added as a way of mapping a table name to the index of
   table in the group.
 * `Group::add_table()` and `Group::get_or_add_table()` were added.
+* `Group::remove_table()` and `Group::rename_table()` were added.
 * `WriteTransaction::add_table()` and `WriteTransaction::get_or_add_table()`
   ware added.
 
@@ -45,11 +46,14 @@
 ### API breaking changes:
 
 * `Table::get_parent_row_index()` and `Table::get_index_in_group()` together
-  replace `Table::get_index_in_parent()`. This was done to avoid a confusing mix of distinct concepts.
+  replace `Table::get_index_in_parent()`. This was done to avoid a confusing mix
+  of distinct concepts.
 
 ### Enhancements:
 
-* It's now possible to sort a LinkRef according to a column in the target table. Also lets you build a TableView with the sorted result instead. The new methods on LinkViewRef are `sort()` and `get_sorted_view()`
+* It's now possible to sort a LinkRef according to a column in the target
+  table. Also lets you build a TableView with the sorted result instead. The new
+  methods on LinkViewRef are `sort()` and `get_sorted_view()`
 
 ----------------------------------------------
 

--- a/src/tightdb/column.hpp
+++ b/src/tightdb/column.hpp
@@ -155,8 +155,14 @@ public:
                                               std::size_t last_row_ndx) TIGHTDB_NOEXCEPT;
     virtual void adj_acc_clear_root_table() TIGHTDB_NOEXCEPT;
 
-    virtual void recursive_mark() TIGHTDB_NOEXCEPT;
-    virtual void mark_link_target_table() TIGHTDB_NOEXCEPT;
+    enum {
+        mark_Recursive   = 0x01,
+        mark_LinkTargets = 0x02,
+        mark_LinkOrigins = 0x04
+    };
+
+    virtual void mark(int type) TIGHTDB_NOEXCEPT;
+
     virtual void bump_link_origin_table_version() TIGHTDB_NOEXCEPT;
 
     /// Refresh the dirty part of the accessor subtree rooted at this column
@@ -466,12 +472,7 @@ inline void ColumnBase::adj_acc_clear_root_table() TIGHTDB_NOEXCEPT
     // Noop
 }
 
-inline void ColumnBase::recursive_mark() TIGHTDB_NOEXCEPT
-{
-    // Noop
-}
-
-inline void ColumnBase::mark_link_target_table() TIGHTDB_NOEXCEPT
+inline void ColumnBase::mark(int) TIGHTDB_NOEXCEPT
 {
     // Noop
 }

--- a/src/tightdb/column_backlink.hpp
+++ b/src/tightdb/column_backlink.hpp
@@ -67,6 +67,8 @@ public:
     void adj_accessors_move_last_over(std::size_t, std::size_t) TIGHTDB_NOEXCEPT TIGHTDB_OVERRIDE;
     void adj_acc_clear_root_table() TIGHTDB_NOEXCEPT TIGHTDB_OVERRIDE;
 
+    void mark(int) TIGHTDB_NOEXCEPT TIGHTDB_OVERRIDE;
+
     void bump_link_origin_table_version() TIGHTDB_NOEXCEPT TIGHTDB_OVERRIDE;
 
 #ifdef TIGHTDB_DEBUG
@@ -174,11 +176,21 @@ inline void ColumnBackLink::adj_acc_clear_root_table() TIGHTDB_NOEXCEPT
     tf::mark(*m_origin_table);
 }
 
+inline void ColumnBackLink::mark(int type) TIGHTDB_NOEXCEPT
+{
+    if (type & mark_LinkOrigins) {
+        typedef _impl::TableFriend tf;
+        tf::mark(*m_origin_table);
+    }
+}
+
 inline void ColumnBackLink::bump_link_origin_table_version() TIGHTDB_NOEXCEPT
 {
     typedef _impl::TableFriend tf;
-    if (m_origin_table)
-        tf::bump_version(*m_origin_table);
+    if (m_origin_table) {
+        bool bump_global = false;
+        tf::bump_version(*m_origin_table, bump_global);
+    }
 }
 
 #ifdef TIGHTDB_DEBUG

--- a/src/tightdb/column_linkbase.hpp
+++ b/src/tightdb/column_linkbase.hpp
@@ -45,7 +45,7 @@ public:
     void adj_accessors_move_last_over(std::size_t, std::size_t) TIGHTDB_NOEXCEPT TIGHTDB_OVERRIDE;
     void adj_acc_clear_root_table() TIGHTDB_NOEXCEPT TIGHTDB_OVERRIDE;
 
-    void mark_link_target_table() TIGHTDB_NOEXCEPT TIGHTDB_OVERRIDE;
+    void mark(int) TIGHTDB_NOEXCEPT TIGHTDB_OVERRIDE;
 
 #ifdef TIGHTDB_DEBUG
     void Verify(const Table&, std::size_t) const TIGHTDB_OVERRIDE;
@@ -131,10 +131,12 @@ inline void ColumnLinkBase::adj_acc_clear_root_table() TIGHTDB_NOEXCEPT
     tf::mark(*m_target_table);
 }
 
-inline void ColumnLinkBase::mark_link_target_table() TIGHTDB_NOEXCEPT
+inline void ColumnLinkBase::mark(int type) TIGHTDB_NOEXCEPT
 {
-    typedef _impl::TableFriend tf;
-    tf::mark(*m_target_table);
+    if (type & mark_LinkTargets) {
+        typedef _impl::TableFriend tf;
+        tf::mark(*m_target_table);
+    }
 }
 
 

--- a/src/tightdb/column_mixed.hpp
+++ b/src/tightdb/column_mixed.hpp
@@ -140,7 +140,7 @@ public:
     ref_type write(std::size_t, std::size_t, std::size_t,
                    _impl::OutputStream&) const TIGHTDB_OVERRIDE;
 
-    void recursive_mark() TIGHTDB_NOEXCEPT TIGHTDB_OVERRIDE;
+    void mark(int) TIGHTDB_NOEXCEPT TIGHTDB_OVERRIDE;
 
     void refresh_accessor_tree(std::size_t, const Spec&) TIGHTDB_OVERRIDE;
 

--- a/src/tightdb/column_mixed_tpl.hpp
+++ b/src/tightdb/column_mixed_tpl.hpp
@@ -393,9 +393,9 @@ inline void ColumnMixed::clear_value_and_discard_subtab_acc(std::size_t row_ndx,
         m_data->discard_subtable_accessor(row_ndx);
 }
 
-inline void ColumnMixed::recursive_mark() TIGHTDB_NOEXCEPT
+inline void ColumnMixed::mark(int type) TIGHTDB_NOEXCEPT
 {
-    m_data->recursive_mark();
+    m_data->mark(type);
 }
 
 inline void ColumnMixed::refresh_accessor_tree(std::size_t col_ndx, const Spec& spec)

--- a/src/tightdb/column_table.cpp
+++ b/src/tightdb/column_table.cpp
@@ -113,7 +113,7 @@ void ColumnSubtableParent::child_accessor_destroyed(Table* child) TIGHTDB_NOEXCE
 {
     // This function must assume no more than minimal consistency of the
     // accessor hierarchy. This means in particular that it cannot access the
-    // underlying node structure. See AccessorConcistncyLevels.
+    // underlying node structure. See AccessorConsistencyLevels.
 
     // Note that due to the possibility of a failure during child creation, it
     // is possible that the calling child is not in the map.
@@ -254,7 +254,8 @@ void ColumnSubtableParent::SubtableMap::refresh_accessor_tree(size_t spec_ndx_in
         tf::set_ndx_in_parent(*table, i->m_subtable_ndx);
         if (tf::is_marked(*table)) {
             tf::refresh_accessor_tree(*table);
-            tf::bump_version(*table);
+            bool bump_global = false;
+            tf::bump_version(*table, bump_global);
         }
     }
 }
@@ -335,7 +336,8 @@ void ColumnTable::set(size_t row_ndx, const Table* subtable)
         typedef _impl::TableFriend tf;
         tf::discard_child_accessors(*table_2);
         tf::refresh_accessor_tree(*table_2);
-        tf::bump_version(*table_2);
+        bool bump_global = false;
+        tf::bump_version(*table_2, bump_global);
     }
 }
 

--- a/src/tightdb/column_table.hpp
+++ b/src/tightdb/column_table.hpp
@@ -38,7 +38,7 @@ public:
     void move_last_over(std::size_t, std::size_t) TIGHTDB_OVERRIDE;
     void clear() TIGHTDB_OVERRIDE;
 
-    void recursive_mark() TIGHTDB_NOEXCEPT TIGHTDB_OVERRIDE;
+    void mark(int) TIGHTDB_NOEXCEPT TIGHTDB_OVERRIDE;
 
     void adj_accessors_insert_rows(std::size_t, std::size_t) TIGHTDB_NOEXCEPT TIGHTDB_OVERRIDE;
     void adj_accessors_erase_row(std::size_t) TIGHTDB_NOEXCEPT TIGHTDB_OVERRIDE;
@@ -277,9 +277,10 @@ inline void ColumnSubtableParent::move_last_over(std::size_t target_row_ndx,
         tf::unbind_ref(*m_table);
 }
 
-inline void ColumnSubtableParent::recursive_mark() TIGHTDB_NOEXCEPT
+inline void ColumnSubtableParent::mark(int type) TIGHTDB_NOEXCEPT
 {
-    m_subtable_map.recursive_mark();
+    if (type & mark_Recursive)
+        m_subtable_map.recursive_mark();
 }
 
 inline void ColumnSubtableParent::refresh_accessor_tree(std::size_t col_ndx, const Spec& spec)
@@ -293,7 +294,7 @@ inline void ColumnSubtableParent::adj_accessors_insert_rows(std::size_t row_ndx,
 {
     // This function must assume no more than minimal consistency of the
     // accessor hierarchy. This means in particular that it cannot access the
-    // underlying node structure. See AccessorConcistncyLevels.
+    // underlying node structure. See AccessorConsistencyLevels.
 
     const bool fix_ndx_in_parent = false;
     m_subtable_map.adj_insert_rows<fix_ndx_in_parent>(row_ndx, num_rows);
@@ -303,7 +304,7 @@ inline void ColumnSubtableParent::adj_accessors_erase_row(std::size_t row_ndx) T
 {
     // This function must assume no more than minimal consistency of the
     // accessor hierarchy. This means in particular that it cannot access the
-    // underlying node structure. See AccessorConcistncyLevels.
+    // underlying node structure. See AccessorConsistencyLevels.
 
     const bool fix_ndx_in_parent = false;
     bool last_entry_removed = m_subtable_map.adj_erase_row<fix_ndx_in_parent>(row_ndx);
@@ -318,7 +319,7 @@ inline void ColumnSubtableParent::adj_accessors_move_last_over(std::size_t targe
 {
     // This function must assume no more than minimal consistency of the
     // accessor hierarchy. This means in particular that it cannot access the
-    // underlying node structure. See AccessorConcistncyLevels.
+    // underlying node structure. See AccessorConsistencyLevels.
 
     const bool fix_ndx_in_parent = false;
     bool last_entry_removed =
@@ -332,7 +333,7 @@ inline void ColumnSubtableParent::adj_acc_clear_root_table() TIGHTDB_NOEXCEPT
 {
     // This function must assume no more than minimal consistency of the
     // accessor hierarchy. This means in particular that it cannot access the
-    // underlying node structure. See AccessorConcistncyLevels.
+    // underlying node structure. See AccessorConsistencyLevels.
 
     Column::adj_acc_clear_root_table();
     discard_child_accessors();
@@ -343,7 +344,7 @@ inline Table* ColumnSubtableParent::get_subtable_accessor(std::size_t row_ndx) c
 {
     // This function must assume no more than minimal consistency of the
     // accessor hierarchy. This means in particular that it cannot access the
-    // underlying node structure. See AccessorConcistncyLevels.
+    // underlying node structure. See AccessorConsistencyLevels.
 
     Table* subtable = m_subtable_map.find(row_ndx);
     return subtable;
@@ -353,7 +354,7 @@ inline void ColumnSubtableParent::discard_subtable_accessor(std::size_t row_ndx)
 {
     // This function must assume no more than minimal consistency of the
     // accessor hierarchy. This means in particular that it cannot access the
-    // underlying node structure. See AccessorConcistncyLevels.
+    // underlying node structure. See AccessorConsistencyLevels.
 
     bool last_entry_removed = m_subtable_map.detach_and_remove(row_ndx);
     typedef _impl::TableFriend tf;
@@ -548,7 +549,7 @@ update_table_accessors(const std::size_t* col_path_begin, const std::size_t* col
 {
     // This function must assume no more than minimal consistency of the
     // accessor hierarchy. This means in particular that it cannot access the
-    // underlying node structure. See AccessorConcistncyLevels.
+    // underlying node structure. See AccessorConsistencyLevels.
 
     m_subtable_map.update_accessors(col_path_begin, col_path_end, updater); // Throws
 }

--- a/src/tightdb/exceptions.hpp
+++ b/src/tightdb/exceptions.hpp
@@ -43,7 +43,18 @@ class DescriptorMismatch: public std::exception {
 public:
     const char* what() const TIGHTDB_NOEXCEPT_OR_NOTHROW TIGHTDB_OVERRIDE
     {
-        return "The specified table name is already in use";
+        return "Incompatible dynamic table type";
+    }
+};
+
+
+/// Thrown by various functions to indicate that a specified table does not
+/// exist.
+class NoSuchTable: public std::exception {
+public:
+    const char* what() const TIGHTDB_NOEXCEPT_OR_NOTHROW TIGHTDB_OVERRIDE
+    {
+        return "No such table exists";
     }
 };
 
@@ -55,6 +66,17 @@ public:
     const char* what() const TIGHTDB_NOEXCEPT_OR_NOTHROW TIGHTDB_OVERRIDE
     {
         return "The specified table name is already in use";
+    }
+};
+
+
+// Thrown by functions that require a table to **not** be the target of link
+// columns, unless those link columns are part of the table itself.
+class CrossTableLinkTarget: public std::exception {
+public:
+    const char* what() const TIGHTDB_NOEXCEPT_OR_NOTHROW TIGHTDB_OVERRIDE
+    {
+        return "Table is target of cross-table link columns";
     }
 };
 

--- a/src/tightdb/group.cpp
+++ b/src/tightdb/group.cpp
@@ -1,6 +1,7 @@
 #include <cerrno>
 #include <new>
 #include <algorithm>
+#include <set>
 #include <iostream>
 #include <iomanip>
 #include <fstream>
@@ -9,6 +10,9 @@
 #include <tightdb/util/thread.hpp>
 #include <tightdb/impl/destroy_guard.hpp>
 #include <tightdb/utilities.hpp>
+#include <tightdb/exceptions.hpp>
+#include <tightdb/column_linkbase.hpp>
+#include <tightdb/column_backlink.hpp>
 #include <tightdb/group_writer.hpp>
 #include <tightdb/group.hpp>
 #ifdef TIGHTDB_ENABLE_REPLICATION
@@ -349,7 +353,7 @@ size_t Group::create_table(StringData name)
 
 #ifdef TIGHTDB_ENABLE_REPLICATION
     if (Replication* repl = m_alloc.get_replication())
-        repl->new_group_level_table(name); // Throws
+        repl->insert_group_level_table(ndx, ndx, name); // Throws
 #endif
 
     return ndx;
@@ -404,6 +408,135 @@ Table* Group::create_table_accessor(size_t table_ndx)
     tf::complete_accessor(*table); // Throws
     tf::unmark(*table);
     return table;
+}
+
+
+void Group::remove_table(StringData name)
+{
+    TIGHTDB_ASSERT(is_attached());
+    size_t table_ndx = m_table_names.find_first(name);
+    if (table_ndx == not_found)
+        throw NoSuchTable();
+    remove_table(table_ndx); // Throws
+}
+
+
+void Group::remove_table(size_t table_ndx)
+{
+    TIGHTDB_ASSERT(is_attached());
+    TableRef table = get_table(table_ndx);
+
+    // In principle we could remove a table even if it is the target of link
+    // columns of other tables, however, to do that, we would have to
+    // automatically remove the "offending" link columns from those other
+    // tables. Such a behaviour is deemed too obscure, and we shall therefore
+    // require that a removed table does not contain foreigh origin backlink
+    // columns.
+    typedef _impl::TableFriend tf;
+    if (tf::is_cross_table_link_target(*table))
+        throw CrossTableLinkTarget();
+
+    // There is no easy way for Group::TransactAdvancer to handle removal of
+    // tables that contain foreign target table link columns, because that
+    // involves removal of the corresponding backlink columns. For that reason,
+    // we start by removing all columns, and that will generate individual
+    // replication instructions for each column, with sufficient information for
+    // Group::TransactAdvancer to handle them.
+    size_t n = table->get_column_count();
+    for (size_t i = n; i > 0; --i)
+        table->remove_column(i-1);
+
+    ref_type ref = m_tables.get(table_ndx);
+
+    // If the specified table is not the last one, it will be removed by moving
+    // that last table to the index of the removed one. The movement of the last
+    // table requires link column adjustments.
+    size_t last_ndx = m_tables.size() - 1;
+    if (last_ndx != table_ndx) {
+        TableRef last_table = get_table(last_ndx);
+        const Spec& last_spec = tf::get_spec(*last_table);
+        size_t last_num_cols = last_spec.get_column_count();
+        set<Table*> opposite_tables;
+        for (size_t i = 0; i < last_num_cols; ++i) {
+            Table* opposite_table;
+            ColumnType type = last_spec.get_column_type(i);
+            if (tf::is_link_type(type)) {
+                ColumnBase& col = tf::get_column(*last_table, i);
+                TIGHTDB_ASSERT(dynamic_cast<ColumnLinkBase*>(&col));
+                ColumnLinkBase& link_col = static_cast<ColumnLinkBase&>(col);
+                opposite_table = &link_col.get_target_table();
+            }
+            else if (type == col_type_BackLink) {
+                ColumnBase& col = tf::get_column(*last_table, i);
+                TIGHTDB_ASSERT(dynamic_cast<ColumnBackLink*>(&col));
+                ColumnBackLink& backlink_col = static_cast<ColumnBackLink&>(col);
+                opposite_table = &backlink_col.get_origin_table();
+            }
+            else {
+                continue;
+            }
+            opposite_tables.insert(opposite_table); // Throws
+        }
+        typedef set<Table*>::const_iterator iter;
+        iter end = opposite_tables.end();
+        for (iter i = opposite_tables.begin(); i != end; ++i) {
+            Table* table_2 = *i;
+            Spec& spec_2 = tf::get_spec(*table_2);
+            size_t num_cols_2 = spec_2.get_column_count();
+            for (size_t col_ndx_2 = 0; col_ndx_2 < num_cols_2; ++col_ndx_2) {
+                ColumnType type_2 = spec_2.get_column_type(col_ndx_2);
+                if (type_2 == col_type_Link || type_2 == col_type_LinkList ||
+                    type_2 == col_type_BackLink) {
+                    size_t table_ndx_2 = spec_2.get_opposite_link_table_ndx(col_ndx_2);
+                    if (table_ndx_2 == last_ndx)
+                        spec_2.set_opposite_link_table_ndx(col_ndx_2, table_ndx); // Throws
+                }
+            }
+        }
+        m_tables.set(table_ndx, m_tables.get(last_ndx)); // Throws
+        m_table_names.set(table_ndx, m_table_names.get(last_ndx)); // Throws
+        tf::set_ndx_in_parent(*last_table, table_ndx);
+    }
+
+    m_tables.erase(last_ndx); // Throws
+    m_table_names.erase(last_ndx); // Throws
+
+    m_table_accessors[table_ndx] = m_table_accessors[last_ndx];
+    m_table_accessors.pop_back();
+    tf::detach(*table);
+    tf::unbind_ref(*table);
+
+    // Destroy underlying node structure
+    Array::destroy_deep(ref, m_alloc);
+
+#ifdef TIGHTDB_ENABLE_REPLICATION
+    if (Replication* repl = m_alloc.get_replication())
+        repl->erase_group_level_table(table_ndx, last_ndx+1); // Throws
+#endif
+}
+
+
+void Group::rename_table(StringData name, StringData new_name, bool require_unique_name)
+{
+    TIGHTDB_ASSERT(is_attached());
+    size_t table_ndx = m_table_names.find_first(name);
+    if (table_ndx == not_found)
+        throw NoSuchTable();
+    rename_table(table_ndx, new_name, require_unique_name); // Throws
+}
+
+
+void Group::rename_table(size_t table_ndx, StringData new_name, bool require_unique_name)
+{
+    TIGHTDB_ASSERT(is_attached());
+    TIGHTDB_ASSERT(m_tables.size() == m_table_names.size());
+    if (table_ndx >= m_tables.size())
+        throw InvalidArgument();
+    if (require_unique_name && has_table(new_name))
+        throw TableNameInUse();
+    m_table_names.set(table_ndx, new_name);
+    if (Replication* repl = m_alloc.get_replication())
+        repl->rename_group_level_table(table_ndx, new_name); // Throws
 }
 
 
@@ -849,7 +982,7 @@ private:
 
 
 // In general, this class cannot assume more than minimal accessor consistency
-// (See AccessorConcistncyLevels), it can however assume that replication
+// (See AccessorConsistencyLevels., it can however assume that replication
 // instruction arguments are meaningfull with respect to the current state of
 // the accessor hierarchy. For example, a column index argument of `i` is known
 // to refer to the `i`'th entry of Table::m_cols.
@@ -864,9 +997,52 @@ public:
     {
     }
 
-    bool new_group_level_table(StringData) TIGHTDB_NOEXCEPT
+    bool insert_group_level_table(size_t table_ndx, size_t num_tables, StringData) TIGHTDB_NOEXCEPT
     {
+        // For end-insertions, table_ndx will be equal to num_tables
+        TIGHTDB_ASSERT(table_ndx <= num_tables);
         m_group.m_table_accessors.push_back(0); // Throws
+        size_t last_ndx = num_tables;
+        m_group.m_table_accessors[last_ndx] = m_group.m_table_accessors[table_ndx];
+        m_group.m_table_accessors[table_ndx] = 0;
+        if (Table* moved_table = m_group.m_table_accessors[last_ndx]) {
+            typedef _impl::TableFriend tf;
+            tf::mark(*moved_table);
+            tf::mark_opposite_link_tables(*moved_table);
+        }
+        return true;
+    }
+
+    bool erase_group_level_table(size_t table_ndx, size_t num_tables) TIGHTDB_NOEXCEPT
+    {
+        TIGHTDB_ASSERT(table_ndx < num_tables);
+
+        // Link target tables do not need to be considered here, since all
+        // columns will already have been removed at this point.
+        if (Table* table = m_group.m_table_accessors[table_ndx]) {
+            typedef _impl::TableFriend tf;
+            tf::detach(*table);
+            tf::unbind_ref(*table);
+        }
+
+        size_t last_ndx = num_tables - 1;
+        if (table_ndx < last_ndx) {
+            if (Table* moved_table = m_group.m_table_accessors[last_ndx]) {
+                typedef _impl::TableFriend tf;
+                tf::mark(*moved_table);
+                tf::mark_opposite_link_tables(*moved_table);
+            }
+            m_group.m_table_accessors[table_ndx] = m_group.m_table_accessors[last_ndx];
+        }
+        m_group.m_table_accessors.pop_back();
+
+        return true;
+    }
+
+    bool rename_group_level_table(size_t, StringData) TIGHTDB_NOEXCEPT
+    {
+        // No-op since table names are properties of the group, and the group
+        // accessor is always refreshed
         return true;
     }
 
@@ -925,7 +1101,6 @@ public:
         typedef _impl::TableFriend tf;
         if (m_table)
             tf::adj_acc_clear_root_table(*m_table);
-        // tf::discard_child_accessors(*m_table);
         return true;
     }
 
@@ -1011,42 +1186,42 @@ public:
 
     bool row_insert_complete() TIGHTDB_NOEXCEPT
     {
-        return true; // Noop
+        return true; // No-op
     }
 
     bool set_int(size_t, size_t, int_fast64_t) TIGHTDB_NOEXCEPT
     {
-        return true; // Noop
+        return true; // No-op
     }
 
     bool set_bool(size_t, size_t, bool) TIGHTDB_NOEXCEPT
     {
-        return true; // Noop
+        return true; // No-op
     }
 
     bool set_float(size_t, size_t, float) TIGHTDB_NOEXCEPT
     {
-        return true; // Noop
+        return true; // No-op
     }
 
     bool set_double(size_t, size_t, double) TIGHTDB_NOEXCEPT
     {
-        return true; // Noop
+        return true; // No-op
     }
 
     bool set_string(size_t, size_t, StringData) TIGHTDB_NOEXCEPT
     {
-        return true; // Noop
+        return true; // No-op
     }
 
     bool set_binary(size_t, size_t, BinaryData) TIGHTDB_NOEXCEPT
     {
-        return true; // Noop
+        return true; // No-op
     }
 
     bool set_date_time(size_t, size_t, DateTime) TIGHTDB_NOEXCEPT
     {
-        return true; // Noop
+        return true; // No-op
     }
 
     bool set_table(size_t col_ndx, size_t row_ndx) TIGHTDB_NOEXCEPT
@@ -1097,12 +1272,12 @@ public:
 
     bool add_int_to_column(size_t, int_fast64_t) TIGHTDB_NOEXCEPT
     {
-        return true; // Noop
+        return true; // No-op
     }
 
     bool optimize_table() TIGHTDB_NOEXCEPT
     {
-        return true; // Noop
+        return true; // No-op
     }
 
     bool select_descriptor(int levels, const size_t* path)
@@ -1177,12 +1352,12 @@ public:
 
     bool rename_column(size_t, StringData) TIGHTDB_NOEXCEPT
     {
-        return true; // Noop
+        return true; // No-op
     }
 
     bool add_search_index(size_t) TIGHTDB_NOEXCEPT
     {
-        return true; // Noop
+        return true; // No-op
     }
 
     bool select_link_list(size_t col_ndx, size_t) TIGHTDB_NOEXCEPT
@@ -1193,32 +1368,32 @@ public:
             if (Table* target = tf::get_link_target_table_accessor(*m_table, col_ndx))
                 tf::mark(*target);
         }
-        return true; // Noop
+        return true; // No-op
     }
 
     bool link_list_set(size_t, size_t) TIGHTDB_NOEXCEPT
     {
-        return true; // Noop
+        return true; // No-op
     }
 
     bool link_list_insert(size_t, size_t) TIGHTDB_NOEXCEPT
     {
-        return true; // Noop
+        return true; // No-op
     }
 
     bool link_list_move(size_t, size_t) TIGHTDB_NOEXCEPT
     {
-        return true; // Noop
+        return true; // No-op
     }
 
     bool link_list_erase(size_t) TIGHTDB_NOEXCEPT
     {
-        return true; // Noop
+        return true; // No-op
     }
 
     bool link_list_clear() TIGHTDB_NOEXCEPT
     {
-        return true; // Noop
+        return true; // No-op
     }
 
 private:
@@ -1296,9 +1471,11 @@ void Group::advance_transact(ref_type new_top_ref, size_t new_file_size,
     for (size_t table_ndx = 0; table_ndx != num_tables; ++table_ndx) {
         if (Table* table = m_table_accessors[table_ndx]) {
             typedef _impl::TableFriend tf;
+            tf::set_ndx_in_parent(*table, table_ndx);
             if (tf::is_marked(*table)) {
                 tf::refresh_accessor_tree(*table); // Throws
-                tf::bump_version(*table);
+                bool bump_global = false;
+                tf::bump_version(*table, bump_global);
             }
         }
     }

--- a/src/tightdb/group_shared.hpp
+++ b/src/tightdb/group_shared.hpp
@@ -372,6 +372,11 @@ public:
         return get_group().has_table(name);
     }
 
+    ConstTableRef get_table(std::size_t table_ndx) const
+    {
+        return get_group().get_table(table_ndx); // Throws
+    }
+
     ConstTableRef get_table(StringData name) const
     {
         return get_group().get_table(name); // Throws
@@ -404,6 +409,11 @@ public:
     {
         if (m_shared_group)
             m_shared_group->rollback();
+    }
+
+    TableRef get_table(std::size_t table_ndx) const
+    {
+        return get_group().get_table(table_ndx); // Throws
     }
 
     TableRef get_table(StringData name) const

--- a/src/tightdb/link_view.cpp
+++ b/src/tightdb/link_view.cpp
@@ -34,7 +34,8 @@ void LinkView::insert(size_t link_ndx, size_t target_row_ndx)
     TIGHTDB_ASSERT(m_target_row_indexes.is_attached() || link_ndx == 0);
     TIGHTDB_ASSERT(!m_target_row_indexes.is_attached() || link_ndx <= m_target_row_indexes.size());
     TIGHTDB_ASSERT(target_row_ndx < m_origin_column.get_target_table().size());
-    m_origin_table->bump_version();
+    typedef _impl::TableFriend tf;
+    tf::bump_version(*m_origin_table);
 
     size_t row_ndx = get_origin_row_index();
 
@@ -61,7 +62,8 @@ void LinkView::set(size_t link_ndx, size_t target_row_ndx)
     TIGHTDB_ASSERT(is_attached());
     TIGHTDB_ASSERT(m_target_row_indexes.is_attached() && link_ndx < m_target_row_indexes.size());
     TIGHTDB_ASSERT(target_row_ndx < m_origin_column.get_target_table().size());
-    m_origin_table->bump_version();
+    typedef _impl::TableFriend tf;
+    tf::bump_version(*m_origin_table);
 
     // update backlinks
     size_t row_ndx = get_origin_row_index();
@@ -86,7 +88,8 @@ void LinkView::move(size_t old_link_ndx, size_t new_link_ndx)
 
     if (old_link_ndx == new_link_ndx)
         return;
-    m_origin_table->bump_version();
+    typedef _impl::TableFriend tf;
+    tf::bump_version(*m_origin_table);
 
     size_t link_ndx = (new_link_ndx <= old_link_ndx) ? new_link_ndx : new_link_ndx-1;
     size_t target_row_ndx = m_target_row_indexes.get(old_link_ndx);
@@ -105,7 +108,8 @@ void LinkView::remove(size_t link_ndx)
 {
     TIGHTDB_ASSERT(is_attached());
     TIGHTDB_ASSERT(m_target_row_indexes.is_attached() && link_ndx < m_target_row_indexes.size());
-    m_origin_table->bump_version();
+    typedef _impl::TableFriend tf;
+    tf::bump_version(*m_origin_table);
 
     // update backlinks
     size_t target_row_ndx = m_target_row_indexes.get(link_ndx);
@@ -134,7 +138,8 @@ void LinkView::clear()
     if (!m_target_row_indexes.is_attached())
         return;
 
-    m_origin_table->bump_version();
+    typedef _impl::TableFriend tf;
+    tf::bump_version(*m_origin_table);
 
     // Update backlinks
     size_t row_ndx = get_origin_row_index();

--- a/src/tightdb/replication.cpp
+++ b/src/tightdb/replication.cpp
@@ -665,19 +665,42 @@ public:
         return true;
     }
 
-    bool new_group_level_table(StringData name)
+    bool insert_group_level_table(size_t table_ndx, size_t num_tables, StringData name)
     {
-        if (TIGHTDB_LIKELY(!m_group.has_table(name))) {
+        if (TIGHTDB_UNLIKELY(table_ndx != num_tables))
+            return false;
+        if (TIGHTDB_UNLIKELY(num_tables != m_group.size()))
+            return false;
 #ifdef TIGHTDB_DEBUG
-            if (m_log)
-                *m_log << "group->add_table(\""<<name<<"\", false)\n";
+        if (m_log)
+            *m_log << "group->add_table(\""<<name<<"\", false)\n";
 #endif
-            typedef _impl::GroupFriend gf;
-            bool require_unique_name = false;
-            gf::add_table(m_group, name, require_unique_name); // Throws
-            return true;
-        }
-        return false;
+        typedef _impl::GroupFriend gf;
+        bool require_unique_name = false;
+        gf::add_table(m_group, name, require_unique_name); // Throws
+        return true;
+    }
+
+    bool erase_group_level_table(std::size_t table_ndx, size_t num_tables) TIGHTDB_NOEXCEPT
+    {
+        if (TIGHTDB_UNLIKELY(num_tables != m_group.size()))
+            return false;
+#ifdef TIGHTDB_DEBUG
+        if (m_log)
+            *m_log << "group->remove_table("<<table_ndx<<")\n";
+#endif
+        m_group.remove_table(table_ndx);
+        return true;
+    }
+
+    bool rename_group_level_table(std::size_t table_ndx, StringData new_name) TIGHTDB_NOEXCEPT
+    {
+#ifdef TIGHTDB_DEBUG
+        if (m_log)
+            *m_log << "group->rename_table("<<table_ndx<<", \""<<new_name<<"\")\n";
+#endif
+        m_group.rename_table(table_ndx, new_name);
+        return true;
     }
 
     bool optimize_table()

--- a/src/tightdb/table.hpp
+++ b/src/tightdb/table.hpp
@@ -441,7 +441,7 @@ public:
     std::size_t get_parent_row_index() const TIGHTDB_NOEXCEPT;
     //@}
 
-    /// Only group-level unordered tables can be used as origins or targets for
+    /// Only group-level unordered tables can be used as origins or targets of
     /// links.
     bool is_group_level() const TIGHTDB_NOEXCEPT;
 
@@ -751,6 +751,7 @@ private:
 
 #ifdef TIGHTDB_ENABLE_REPLICATION
     mutable uint_fast64_t m_version;
+#endif
 
     /// Update the version of this table and all tables which have links to it.
     /// This causes all views referring to those tables to go out of sync, so that
@@ -762,10 +763,7 @@ private:
     /// when a change is made to the table. When calling recursively (following links
     /// or going to the parent table), the parameter should be set to false to correctly
     /// prune traversal.
-    void bump_version(bool bump_global = true) const;
-#else
-    inline void bump_version(bool bump_global = true) const { static_cast<void>(bump_global); }
-#endif
+    void bump_version(bool bump_global = true) const TIGHTDB_NOEXCEPT;
 
     /// Disable copying assignment.
     ///
@@ -1024,6 +1022,7 @@ private:
     void unmark() TIGHTDB_NOEXCEPT;
     void recursive_mark() TIGHTDB_NOEXCEPT;
     void mark_link_target_tables(std::size_t col_ndx_begin) TIGHTDB_NOEXCEPT;
+    void mark_opposite_link_tables() TIGHTDB_NOEXCEPT;
 
 #ifdef TIGHTDB_ENABLE_REPLICATION
     Replication* get_repl() TIGHTDB_NOEXCEPT;
@@ -1068,6 +1067,8 @@ private:
 
     void refresh_column_accessors(std::size_t col_ndx_begin = 0);
 
+    bool is_cross_table_link_target() const TIGHTDB_NOEXCEPT;
+
 #ifdef TIGHTDB_DEBUG
     void to_dot_internal(std::ostream&) const;
 #endif
@@ -1079,7 +1080,6 @@ private:
     friend class LangBindHelper;
     friend class TableViewBase;
     friend class TableView;
-    friend class LinkView;
     template<class T> friend class Columns;
     friend class Columns<StringData>;
     friend class ParentNode;
@@ -1131,7 +1131,8 @@ protected:
 
 
 #ifdef TIGHTDB_ENABLE_REPLICATION
-inline void Table::bump_version(bool bump_global) const
+
+inline void Table::bump_version(bool bump_global) const TIGHTDB_NOEXCEPT
 {
     if (bump_global) {
         // This is only set on initial entry through an operation on the same
@@ -1156,7 +1157,15 @@ inline void Table::bump_version(bool bump_global) const
         }
     }
 }
-#endif
+
+#else // TIGHTDB_ENABLE_REPLICATION
+
+inline void Table::bump_version(bool) const TIGHTDB_NOEXCEPT
+{
+    // No-op when replication is disabled at compile time
+}
+
+#endif // TIGHTDB_ENABLE_REPLICATION
 
 inline void Table::remove_last()
 {
@@ -1838,6 +1847,11 @@ public:
         table.mark_link_target_tables(col_ndx_begin);
     }
 
+    static void mark_opposite_link_tables(Table& table) TIGHTDB_NOEXCEPT
+    {
+        table.mark_opposite_link_tables();
+    }
+
     static Descriptor* get_root_table_desc_accessor(Table& root_table) TIGHTDB_NOEXCEPT
     {
         return root_table.m_descriptor;
@@ -1871,12 +1885,14 @@ public:
         return Table::is_link_type(type);
     }
 
-    static inline void bump_version(Table& table)
+    static void bump_version(Table& table, bool bump_global = true) TIGHTDB_NOEXCEPT
     {
-        // calls going through tablefriend are always part of a recursion, so shouldn't
-        // bump the global counter
-        bool global_bump = false;
-        table.bump_version(global_bump);
+        table.bump_version(bump_global);
+    }
+
+    static bool is_cross_table_link_target(const Table& table)
+    {
+        return table.is_cross_table_link_target();
     }
 
 #ifdef TIGHTDB_ENABLE_REPLICATION


### PR DESCRIPTION
It is expected that these features will be useful in relation to automated migration in the Cocoa binding. Ari? Besides that, the ability to generate an `erase-group-level-table` instruction is needed by the rollback feature that Finn is working on.

@finnschiermer @alazier @astigsen 
