### PR TITLE
Allow specification of MAX_BPNODE_SIZE during configuration

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -378,6 +378,15 @@ case "$MODE" in
             tightdb_version="$(printf "%s\n" "$value" | sed 's/^v//')" || exit 1
         fi
 
+        max_bpnode_size=1000
+        max_bpnode_size_debug=1000
+        if [ "$TIGHTDB_MAX_BPNODE_SIZE" ]; then
+            max_bpnode_size="$TIGHTDB_MAX_BPNODE_SIZE"
+        fi
+        if [ "$TIGHTDB_MAX_BPNODE_SIZE_DEBUG" ]; then
+            max_bpnode_size_debug="$TIGHTDB_MAX_BPNODE_SIZE_DEBUG"
+        fi
+
         enable_replication="no"
         if [ "$TIGHTDB_ENABLE_REPLICATION" ]; then
             enable_replication="yes"
@@ -457,6 +466,8 @@ INSTALL_INCLUDEDIR    = $install_includedir
 INSTALL_BINDIR        = $install_bindir
 INSTALL_LIBDIR        = $install_libdir
 INSTALL_LIBEXECDIR    = $install_libexecdir
+MAX_BPNODE_SIZE       = $max_bpnode_size
+MAX_BPNODE_SIZE_DEBUG = $max_bpnode_size_debug
 ENABLE_REPLICATION    = $enable_replication
 ENABLE_ALLOC_SET_ZERO = $enable_alloc_set_zero
 XCODE_HOME            = $xcode_home

--- a/release_notes.md
+++ b/release_notes.md
@@ -16,7 +16,8 @@
 
 ### Internals:
 
-* Lorem ipsum.
+* `TIGHTDB_MAX_LIST_SIZE` was renamed to `TIGHTDB_MAX_BPNODE_SIZE`. `BPNODE`
+  stands for "B+-tree node".
 
 ----------------------------------------------
 

--- a/src/tightdb/array.cpp
+++ b/src/tightdb/array.cpp
@@ -102,7 +102,7 @@
 //   `N_t` is the total number of elements in the subtree
 //         (`total_elems_in_subtree`).
 //
-// `N_c` must always be a power of `TIGHTDB_MAX_LIST_SIZE`.
+// `N_c` must always be a power of `TIGHTDB_MAX_BPNODE_SIZE`.
 //
 // It is expected that `N_t` will be removed in a future version of
 // the file format. This will make it much more efficient to append
@@ -2076,7 +2076,7 @@ ref_type Array::insert_bptree_child(Array& offsets, size_t orig_child_ndx,
     size_t insert_ndx = orig_child_ref_ndx + 1;
 
     TIGHTDB_ASSERT(insert_ndx <= size() - 1);
-    if (TIGHTDB_LIKELY(size() < 1 + TIGHTDB_MAX_LIST_SIZE + 1)) {
+    if (TIGHTDB_LIKELY(size() < 1 + TIGHTDB_MAX_BPNODE_SIZE + 1)) {
         // Case 1/2: This parent has space for the new child, so it
         // does not have to be split.
         insert(insert_ndx, new_sibling_ref); // Throws
@@ -2121,8 +2121,8 @@ ref_type Array::insert_bptree_child(Array& offsets, size_t orig_child_ndx,
         new_sibling.add(v); // Throws
     }
     size_t new_split_offset, new_split_size;
-    if (insert_ndx - 1 >= TIGHTDB_MAX_LIST_SIZE) {
-        TIGHTDB_ASSERT(insert_ndx - 1 == TIGHTDB_MAX_LIST_SIZE);
+    if (insert_ndx - 1 >= TIGHTDB_MAX_BPNODE_SIZE) {
+        TIGHTDB_ASSERT(insert_ndx - 1 == TIGHTDB_MAX_BPNODE_SIZE);
         // Case 1/2: The split child was the last child of the parent
         // to be split. In this case the parent may or may not be on
         // the compact form.
@@ -2176,10 +2176,10 @@ ref_type Array::insert_bptree_child(Array& offsets, size_t orig_child_ndx,
 ref_type Array::bptree_leaf_insert(size_t ndx, int64_t value, TreeInsertBase& state)
 {
     size_t leaf_size = size();
-    TIGHTDB_ASSERT(leaf_size <= TIGHTDB_MAX_LIST_SIZE);
+    TIGHTDB_ASSERT(leaf_size <= TIGHTDB_MAX_BPNODE_SIZE);
     if (leaf_size < ndx)
         ndx = leaf_size;
-    if (TIGHTDB_LIKELY(leaf_size < TIGHTDB_MAX_LIST_SIZE)) {
+    if (TIGHTDB_LIKELY(leaf_size < TIGHTDB_MAX_BPNODE_SIZE)) {
         insert(ndx, value); // Throws
         return 0; // Leaf was not split
     }

--- a/src/tightdb/array.hpp
+++ b/src/tightdb/array.hpp
@@ -2177,7 +2177,7 @@ ref_type Array::bptree_insert(std::size_t elem_ndx, TreeInsert<TreeTraits>& stat
     char* child_header = static_cast<char*>(m_alloc.translate(child_ref));
     bool child_is_leaf = !get_is_inner_bptree_node_from_header(child_header);
     if (child_is_leaf) {
-        TIGHTDB_ASSERT(elem_ndx_in_child <= TIGHTDB_MAX_LIST_SIZE);
+        TIGHTDB_ASSERT(elem_ndx_in_child <= TIGHTDB_MAX_BPNODE_SIZE);
         new_sibling_ref =
             TreeTraits::leaf_insert(MemRef(child_header, child_ref), childs_parent,
                                     child_ref_ndx, m_alloc, elem_ndx_in_child, state); // Throws

--- a/src/tightdb/array_basic_tpl.hpp
+++ b/src/tightdb/array_basic_tpl.hpp
@@ -322,10 +322,10 @@ template<class T>
 ref_type BasicArray<T>::bptree_leaf_insert(size_t ndx, T value, TreeInsertBase& state)
 {
     size_t leaf_size = size();
-    TIGHTDB_ASSERT(leaf_size <= TIGHTDB_MAX_LIST_SIZE);
+    TIGHTDB_ASSERT(leaf_size <= TIGHTDB_MAX_BPNODE_SIZE);
     if (leaf_size < ndx)
         ndx = leaf_size;
-    if (TIGHTDB_LIKELY(leaf_size < TIGHTDB_MAX_LIST_SIZE)) {
+    if (TIGHTDB_LIKELY(leaf_size < TIGHTDB_MAX_BPNODE_SIZE)) {
         insert(ndx, value);
         return 0; // Leaf was not split
     }

--- a/src/tightdb/array_binary.cpp
+++ b/src/tightdb/array_binary.cpp
@@ -98,10 +98,10 @@ ref_type ArrayBinary::bptree_leaf_insert(size_t ndx, BinaryData value, bool add_
                                          TreeInsertBase& state)
 {
     size_t leaf_size = size();
-    TIGHTDB_ASSERT(leaf_size <= TIGHTDB_MAX_LIST_SIZE);
+    TIGHTDB_ASSERT(leaf_size <= TIGHTDB_MAX_BPNODE_SIZE);
     if (leaf_size < ndx)
         ndx = leaf_size;
-    if (TIGHTDB_LIKELY(leaf_size < TIGHTDB_MAX_LIST_SIZE)) {
+    if (TIGHTDB_LIKELY(leaf_size < TIGHTDB_MAX_BPNODE_SIZE)) {
         insert(ndx, value, add_zero_term); // Throws
         return 0; // Leaf was not split
     }

--- a/src/tightdb/array_blobs_big.cpp
+++ b/src/tightdb/array_blobs_big.cpp
@@ -112,10 +112,10 @@ ref_type ArrayBigBlobs::bptree_leaf_insert(size_t ndx, BinaryData value, bool ad
                                            TreeInsertBase& state)
 {
     size_t leaf_size = size();
-    TIGHTDB_ASSERT(leaf_size <= TIGHTDB_MAX_LIST_SIZE);
+    TIGHTDB_ASSERT(leaf_size <= TIGHTDB_MAX_BPNODE_SIZE);
     if (leaf_size < ndx)
         ndx = leaf_size;
-    if (TIGHTDB_LIKELY(leaf_size < TIGHTDB_MAX_LIST_SIZE)) {
+    if (TIGHTDB_LIKELY(leaf_size < TIGHTDB_MAX_BPNODE_SIZE)) {
         insert(ndx, value, add_zero_term);
         return 0; // Leaf was not split
     }

--- a/src/tightdb/array_string.cpp
+++ b/src/tightdb/array_string.cpp
@@ -336,9 +336,9 @@ bool ArrayString::compare_string(const ArrayString& c) const TIGHTDB_NOEXCEPT
 ref_type ArrayString::bptree_leaf_insert(size_t ndx, StringData value, TreeInsertBase& state)
 {
     size_t leaf_size = size();
-    TIGHTDB_ASSERT(leaf_size <= TIGHTDB_MAX_LIST_SIZE);
+    TIGHTDB_ASSERT(leaf_size <= TIGHTDB_MAX_BPNODE_SIZE);
     if (leaf_size < ndx) ndx = leaf_size;
-    if (TIGHTDB_LIKELY(leaf_size < TIGHTDB_MAX_LIST_SIZE)) {
+    if (TIGHTDB_LIKELY(leaf_size < TIGHTDB_MAX_BPNODE_SIZE)) {
         insert(ndx, value); // Throws
         return 0; // Leaf was not split
     }

--- a/src/tightdb/array_string_long.cpp
+++ b/src/tightdb/array_string_long.cpp
@@ -150,10 +150,10 @@ StringData ArrayStringLong::get(const char* header, size_t ndx, Allocator& alloc
 ref_type ArrayStringLong::bptree_leaf_insert(size_t ndx, StringData value, TreeInsertBase& state)
 {
     size_t leaf_size = size();
-    TIGHTDB_ASSERT(leaf_size <= TIGHTDB_MAX_LIST_SIZE);
+    TIGHTDB_ASSERT(leaf_size <= TIGHTDB_MAX_BPNODE_SIZE);
     if (leaf_size < ndx)
         ndx = leaf_size;
-    if (TIGHTDB_LIKELY(leaf_size < TIGHTDB_MAX_LIST_SIZE)) {
+    if (TIGHTDB_LIKELY(leaf_size < TIGHTDB_MAX_BPNODE_SIZE)) {
         insert(ndx, value); // Throws
         return 0; // Leaf was not split
     }

--- a/src/tightdb/column_basic_tpl.hpp
+++ b/src/tightdb/column_basic_tpl.hpp
@@ -539,7 +539,7 @@ template<class T> void BasicColumn<T>::do_insert(std::size_t row_ndx, T value, s
     for (std::size_t i = 0; i != num_rows; ++i) {
         std::size_t row_ndx_2 = row_ndx == tightdb::npos ? tightdb::npos : row_ndx + i;
         if (root_is_leaf()) {
-            TIGHTDB_ASSERT(row_ndx_2 == tightdb::npos || row_ndx_2 < TIGHTDB_MAX_LIST_SIZE);
+            TIGHTDB_ASSERT(row_ndx_2 == tightdb::npos || row_ndx_2 < TIGHTDB_MAX_BPNODE_SIZE);
             BasicArray<T>* leaf = static_cast<BasicArray<T>*>(m_array);
             new_sibling_ref = leaf->bptree_leaf_insert(row_ndx_2, value, state);
         }

--- a/src/tightdb/column_binary.cpp
+++ b/src/tightdb/column_binary.cpp
@@ -305,7 +305,7 @@ void ColumnBinary::do_insert(size_t row_ndx, BinaryData value, bool add_zero_ter
     for (size_t i = 0; i != num_rows; ++i) {
         size_t row_ndx_2 = row_ndx == tightdb::npos ? tightdb::npos : row_ndx + i;
         if (root_is_leaf()) {
-            TIGHTDB_ASSERT(row_ndx_2 == tightdb::npos || row_ndx_2 < TIGHTDB_MAX_LIST_SIZE);
+            TIGHTDB_ASSERT(row_ndx_2 == tightdb::npos || row_ndx_2 < TIGHTDB_MAX_BPNODE_SIZE);
             bool is_big = upgrade_root_leaf(value.size()); // Throws
             if (!is_big) {
                 // Small blobs root leaf

--- a/src/tightdb/column_string.cpp
+++ b/src/tightdb/column_string.cpp
@@ -949,7 +949,7 @@ void AdaptiveStringColumn::bptree_insert(size_t row_ndx, StringData value, size_
     for (size_t i = 0; i != num_rows; ++i) {
         size_t row_ndx_2 = row_ndx == tightdb::npos ? tightdb::npos : row_ndx + i;
         if (root_is_leaf()) {
-            TIGHTDB_ASSERT(row_ndx_2 == tightdb::npos || row_ndx_2 < TIGHTDB_MAX_LIST_SIZE);
+            TIGHTDB_ASSERT(row_ndx_2 == tightdb::npos || row_ndx_2 < TIGHTDB_MAX_BPNODE_SIZE);
             LeafType leaf_type = upgrade_root_leaf(value.size()); // Throws
             switch (leaf_type) {
                 case leaf_type_Small: {

--- a/src/tightdb/config_tool.cpp
+++ b/src/tightdb/config_tool.cpp
@@ -54,15 +54,7 @@ void emit_flags()
     if (emit_cflags) {
 #ifdef TIGHTDB_HAVE_CONFIG
         emit_flags("-DTIGHTDB_HAVE_CONFIG");
-#else
-#  ifdef TIGHTDB_ENABLE_REPLICATION
-        emit_flags("-DTIGHTDB_ENABLE_REPLICATION");
-#  endif
 #endif
-
-        if (TIGHTDB_MAX_LIST_SIZE != TIGHTDB_DEFAULT_MAX_LIST_SIZE)
-            emit_flags("-DTIGHTDB_MAX_LIST_SIZE=" TO_STR(TIGHTDB_MAX_LIST_SIZE));
-
 #ifdef TIGHTDB_DEBUG
         emit_flags("-DTIGHTDB_DEBUG");
 #endif

--- a/src/tightdb/index_string.cpp
+++ b/src/tightdb/index_string.cpp
@@ -182,7 +182,7 @@ StringIndex::NodeChange StringIndex::DoInsert(size_t row_ndx, key_type key, size
         }
 
         // If there is room, just update node directly
-        if (offsets.size() < TIGHTDB_MAX_LIST_SIZE) {
+        if (offsets.size() < TIGHTDB_MAX_BPNODE_SIZE) {
             if (nc.type == NodeChange::split) {
                 NodeInsertSplit(node_ndx, nc.ref2);
             }
@@ -210,7 +210,7 @@ StringIndex::NodeChange StringIndex::DoInsert(size_t row_ndx, key_type key, size
         switch (node_ndx) {
             case 0:             // insert before
                 return NodeChange(NodeChange::insert_before, new_node.get_ref());
-            case TIGHTDB_MAX_LIST_SIZE: // insert after
+            case TIGHTDB_MAX_BPNODE_SIZE: // insert after
                 if (nc.type == NodeChange::split)
                     return NodeChange(NodeChange::split, get_ref(), new_node.get_ref());
                 return NodeChange(NodeChange::insert_after, new_node.get_ref());
@@ -233,7 +233,7 @@ StringIndex::NodeChange StringIndex::DoInsert(size_t row_ndx, key_type key, size
         TIGHTDB_ASSERT(m_array->size() == old_offsets.size()+1);
 
         size_t count = old_offsets.size();
-        bool noextend = count >= TIGHTDB_MAX_LIST_SIZE;
+        bool noextend = count >= TIGHTDB_MAX_BPNODE_SIZE;
 
         // See if we can fit entry into current leaf
         // Works if there is room or it can join existing entries
@@ -287,7 +287,7 @@ void StringIndex::NodeInsertSplit(size_t ndx, size_t new_ref)
 
     TIGHTDB_ASSERT(m_array->size() == offsets.size()+1);
     TIGHTDB_ASSERT(ndx < offsets.size());
-    TIGHTDB_ASSERT(offsets.size() < TIGHTDB_MAX_LIST_SIZE);
+    TIGHTDB_ASSERT(offsets.size() < TIGHTDB_MAX_BPNODE_SIZE);
 
     // Get sublists
     size_t refs_ndx = ndx+1; // first entry in refs points to offsets
@@ -316,7 +316,7 @@ void StringIndex::NodeInsert(size_t ndx, size_t ref)
     TIGHTDB_ASSERT(m_array->size() == offsets.size()+1);
 
     TIGHTDB_ASSERT(ndx <= offsets.size());
-    TIGHTDB_ASSERT(offsets.size() < TIGHTDB_MAX_LIST_SIZE);
+    TIGHTDB_ASSERT(offsets.size() < TIGHTDB_MAX_BPNODE_SIZE);
 
     StringIndex col(ref, 0, 0, m_target_column, m_get_func, alloc);
     key_type last_key = col.GetLastKey();
@@ -700,7 +700,7 @@ void StringIndex::NodeAddKey(ref_type ref)
     Array offsets(alloc);
     get_child(*m_array, 0, offsets);
     TIGHTDB_ASSERT(m_array->size() == offsets.size()+1);
-    TIGHTDB_ASSERT(offsets.size() < TIGHTDB_MAX_LIST_SIZE+1);
+    TIGHTDB_ASSERT(offsets.size() < TIGHTDB_MAX_BPNODE_SIZE+1);
 
     Array new_top(alloc), new_offsets(alloc);
     new_top.init_from_ref(ref);

--- a/src/tightdb/query_engine.hpp
+++ b/src/tightdb/query_engine.hpp
@@ -865,7 +865,7 @@ public:
                 m_condition_column->GetBlock(s, m_array, m_leaf_start);
                 m_leaf_end = m_leaf_start + m_array.size();
                 size_t w = m_array.get_width();
-                m_dT = (w == 0 ? 1.0 / TIGHTDB_MAX_LIST_SIZE : w / float(bitwidth_time_unit));
+                m_dT = (w == 0 ? 1.0 / TIGHTDB_MAX_BPNODE_SIZE : w / float(bitwidth_time_unit));
             }
 
             size_t end2;

--- a/src/tightdb/util/config.sh
+++ b/src/tightdb/util/config.sh
@@ -31,20 +31,6 @@ cstring_escape()
 tightdb_version="$(get_config_param "TIGHTDB_VERSION")" || exit 1
 tigthdb_version_escaped="$(cstring_escape "$tightdb_version")" || exit 1
 
-enable_replication="$(get_config_param "ENABLE_REPLICATION")" || exit 1
-if [ "$enable_replication" = "yes" ]; then
-    enable_replication="1"
-else
-    enable_replication="0"
-fi
-
-enable_alloc_set_zero="$(get_config_param "ENABLE_ALLOC_SET_ZERO")" || exit 1
-if [ "$enable_alloc_set_zero" = "yes" ]; then
-    enable_alloc_set_zero="1"
-else
-    enable_alloc_set_zero="0"
-fi
-
 install_prefix="$(get_config_param "INSTALL_PREFIX")" || exit 1
 install_prefix_escaped="$(cstring_escape "$install_prefix")" || exit 1
 
@@ -63,6 +49,23 @@ install_libdir_escaped="$(cstring_escape "$install_libdir")" || exit 1
 install_libexecdir="$(get_config_param "INSTALL_LIBEXECDIR")" || exit 1
 install_libexecdir_escaped="$(cstring_escape "$install_libexecdir")" || exit 1
 
+max_bpnode_size="$(get_config_param "MAX_BPNODE_SIZE")" || exit 1
+max_bpnode_size_debug="$(get_config_param "MAX_BPNODE_SIZE_DEBUG")" || exit 1
+
+enable_replication="$(get_config_param "ENABLE_REPLICATION")" || exit 1
+if [ "$enable_replication" = "yes" ]; then
+    enable_replication="1"
+else
+    enable_replication="0"
+fi
+
+enable_alloc_set_zero="$(get_config_param "ENABLE_ALLOC_SET_ZERO")" || exit 1
+if [ "$enable_alloc_set_zero" = "yes" ]; then
+    enable_alloc_set_zero="1"
+else
+    enable_alloc_set_zero="0"
+fi
+
 cat >"$target" <<EOF
 /*************************************************************************
  *
@@ -74,6 +77,19 @@ cat >"$target" <<EOF
 
 #define TIGHTDB_VERSION "$tigthdb_version_escaped"
 
+#define TIGHTDB_INSTALL_PREFIX      "$install_prefix_escaped"
+#define TIGHTDB_INSTALL_EXEC_PREFIX "$install_exec_prefix_escaped"
+#define TIGHTDB_INSTALL_INCLUDEDIR  "$install_includedir_escaped"
+#define TIGHTDB_INSTALL_BINDIR      "$install_bindir_escaped"
+#define TIGHTDB_INSTALL_LIBDIR      "$install_libdir_escaped"
+#define TIGHTDB_INSTALL_LIBEXECDIR  "$install_libexecdir_escaped"
+
+#ifdef TIGHTDB_DEBUG
+#  define TIGHTDB_MAX_BPNODE_SIZE $max_bpnode_size_debug
+#else
+#  define TIGHTDB_MAX_BPNODE_SIZE $max_bpnode_size
+#endif
+
 #if $enable_replication
 #  define TIGHTDB_ENABLE_REPLICATION 1
 #endif
@@ -81,11 +97,4 @@ cat >"$target" <<EOF
 #if $enable_alloc_set_zero
 #  define TIGHTDB_ENABLE_ALLOC_SET_ZERO 1
 #endif
-
-#define TIGHTDB_INSTALL_PREFIX      "$install_prefix_escaped"
-#define TIGHTDB_INSTALL_EXEC_PREFIX "$install_exec_prefix_escaped"
-#define TIGHTDB_INSTALL_INCLUDEDIR  "$install_includedir_escaped"
-#define TIGHTDB_INSTALL_BINDIR      "$install_bindir_escaped"
-#define TIGHTDB_INSTALL_LIBDIR      "$install_libdir_escaped"
-#define TIGHTDB_INSTALL_LIBEXECDIR  "$install_libexecdir_escaped"
 EOF

--- a/src/tightdb/util/features.h
+++ b/src/tightdb/util/features.h
@@ -37,20 +37,13 @@
 
 
 
-/* This one is needed to allow tightdb-config to know whether a
- * nondefault value is in effect. */
-#ifdef TIGHTDB_DEBUG
-#  define TIGHTDB_DEFAULT_MAX_LIST_SIZE 4
-#else
-#  define TIGHTDB_DEFAULT_MAX_LIST_SIZE 1000
+/* The maximum number of elements in a B+-tree node. Applies to inner nodes and
+ * to leaves. The minimum allowable value is 2.
+ */
+#ifndef TIGHTDB_MAX_BPNODE_SIZE
+#  define TIGHTDB_MAX_BPNODE_SIZE 1000
 #endif
 
-/* The maximum number of elements in a B+-tree node. You may override
- * this on the compiler command line. The minimum allowable value is
- * 2. */
-#ifndef TIGHTDB_MAX_LIST_SIZE
-#  define TIGHTDB_MAX_LIST_SIZE TIGHTDB_DEFAULT_MAX_LIST_SIZE
-#endif
 
 
 #if __cplusplus >= 201103 || __GXX_EXPERIMENTAL_CXX0X__ || _MSC_VER >= 1700

--- a/test/large_tests/test_column_large.cpp
+++ b/test/large_tests/test_column_large.cpp
@@ -50,7 +50,7 @@ using namespace tightdb::test_util;
 
 
 // These tests take ~5 min in release mode with
-// TIGHTDB_MAX_LIST_SIZE=1000
+// TIGHTDB_MAX_BPNODE_SIZE=1000
 
 
 TEST_IF(ColumnLarge_Less, TEST_DURATION >= 2)

--- a/test/large_tests/test_strings.cpp
+++ b/test/large_tests/test_strings.cpp
@@ -45,7 +45,7 @@ namespace {
 
 string randstring(Random& random)
 {
-    // If there are in the order of TIGHTDB_MAX_LIST_SIZE different strings, then we'll get a good
+    // If there are in the order of TIGHTDB_MAX_BPNODE_SIZE different strings, then we'll get a good
     // distribution btw. arrays with no matches and arrays with multiple matches, when
     // testing Find/FindAll
     int64_t t = random.draw_int_mod(100) * 100;

--- a/test/test_all.cpp
+++ b/test/test_all.cpp
@@ -163,7 +163,7 @@ void display_build_config()
         "  with Debug "<<with_debug<<"\n"
         "  with Replication "<<with_replication<<"\n"
         "\n"
-        "TIGHTDB_MAX_LIST_SIZE = "<<TIGHTDB_MAX_LIST_SIZE<<"\n"
+        "TIGHTDB_MAX_BPNODE_SIZE = "<<TIGHTDB_MAX_BPNODE_SIZE<<"\n"
         "\n"
         // Be aware that ps3/xbox have sizeof (void*) = 4 && sizeof (size_t) == 8
         // We decide to print size_t here

--- a/test/test_array.cpp
+++ b/test/test_array.cpp
@@ -492,7 +492,7 @@ TEST(Array_AddNeg1_1)
 TEST(Array_UpperLowerBound)
 {
     // Tests Array::upper_bound() and Array::lower_bound()
-    // This test is independent of TIGHTDB_MAX_LIST_SIZE
+    // This test is independent of TIGHTDB_MAX_BPNODE_SIZE
     Array a(Allocator::get_default());
     a.create(Array::type_Normal);
     vector<int> v;

--- a/test/test_array_blob.cpp
+++ b/test/test_array_blob.cpp
@@ -119,7 +119,7 @@ TEST(ArrayBlob_AdaptiveStringLeak)
 {
     ref_type col_ref = AdaptiveStringColumn::create(Allocator::get_default());
     AdaptiveStringColumn col(Allocator::get_default(), col_ref);
-    for (size_t i = 0; i != 2 * TIGHTDB_MAX_LIST_SIZE; ++i)
+    for (size_t i = 0; i != 2 * TIGHTDB_MAX_BPNODE_SIZE; ++i)
         col.insert(0, string(100, 'a'));  // use constant larger than 'medium_string_max_size'
 
     col.destroy();

--- a/test/test_column.cpp
+++ b/test/test_column.cpp
@@ -439,21 +439,21 @@ TEST(Column_FindLeafs)
 
     // Create values that span multible leaves
     // we use 5 to ensure that we get two levels
-    // when testing with TIGHTDB_MAX_LIST_SIZE=4
-    for (size_t i = 0; i < TIGHTDB_MAX_LIST_SIZE*5; ++i)
+    // when testing with TIGHTDB_MAX_BPNODE_SIZE=4
+    for (size_t i = 0; i < TIGHTDB_MAX_BPNODE_SIZE*5; ++i)
         a.add(0);
 
     // Set sentinel values at before and after each break
     a.set(0, 1);
-    a.set(TIGHTDB_MAX_LIST_SIZE-1, 2);
-    a.set(TIGHTDB_MAX_LIST_SIZE, 3);
-    a.set(TIGHTDB_MAX_LIST_SIZE*2-1, 4);
-    a.set(TIGHTDB_MAX_LIST_SIZE*2, 5);
-    a.set(TIGHTDB_MAX_LIST_SIZE*3-1, 6);
-    a.set(TIGHTDB_MAX_LIST_SIZE*3, 7);
-    a.set(TIGHTDB_MAX_LIST_SIZE*4-1, 8);
-    a.set(TIGHTDB_MAX_LIST_SIZE*4, 9);
-    a.set(TIGHTDB_MAX_LIST_SIZE*5-1, 10);
+    a.set(TIGHTDB_MAX_BPNODE_SIZE-1, 2);
+    a.set(TIGHTDB_MAX_BPNODE_SIZE, 3);
+    a.set(TIGHTDB_MAX_BPNODE_SIZE*2-1, 4);
+    a.set(TIGHTDB_MAX_BPNODE_SIZE*2, 5);
+    a.set(TIGHTDB_MAX_BPNODE_SIZE*3-1, 6);
+    a.set(TIGHTDB_MAX_BPNODE_SIZE*3, 7);
+    a.set(TIGHTDB_MAX_BPNODE_SIZE*4-1, 8);
+    a.set(TIGHTDB_MAX_BPNODE_SIZE*4, 9);
+    a.set(TIGHTDB_MAX_BPNODE_SIZE*5-1, 10);
 
     size_t res1 = a.find_first(1);
     size_t res2 = a.find_first(2);
@@ -467,15 +467,15 @@ TEST(Column_FindLeafs)
     size_t res10 = a.find_first(10);
 
     CHECK_EQUAL(0, res1);
-    CHECK_EQUAL(TIGHTDB_MAX_LIST_SIZE-1, res2);
-    CHECK_EQUAL(TIGHTDB_MAX_LIST_SIZE, res3);
-    CHECK_EQUAL(TIGHTDB_MAX_LIST_SIZE*2-1, res4);
-    CHECK_EQUAL(TIGHTDB_MAX_LIST_SIZE*2, res5);
-    CHECK_EQUAL(TIGHTDB_MAX_LIST_SIZE*3-1, res6);
-    CHECK_EQUAL(TIGHTDB_MAX_LIST_SIZE*3, res7);
-    CHECK_EQUAL(TIGHTDB_MAX_LIST_SIZE*4-1, res8);
-    CHECK_EQUAL(TIGHTDB_MAX_LIST_SIZE*4, res9);
-    CHECK_EQUAL(TIGHTDB_MAX_LIST_SIZE*5-1, res10);
+    CHECK_EQUAL(TIGHTDB_MAX_BPNODE_SIZE-1, res2);
+    CHECK_EQUAL(TIGHTDB_MAX_BPNODE_SIZE, res3);
+    CHECK_EQUAL(TIGHTDB_MAX_BPNODE_SIZE*2-1, res4);
+    CHECK_EQUAL(TIGHTDB_MAX_BPNODE_SIZE*2, res5);
+    CHECK_EQUAL(TIGHTDB_MAX_BPNODE_SIZE*3-1, res6);
+    CHECK_EQUAL(TIGHTDB_MAX_BPNODE_SIZE*3, res7);
+    CHECK_EQUAL(TIGHTDB_MAX_BPNODE_SIZE*4-1, res8);
+    CHECK_EQUAL(TIGHTDB_MAX_BPNODE_SIZE*4, res9);
+    CHECK_EQUAL(TIGHTDB_MAX_BPNODE_SIZE*5-1, res10);
 
     a.destroy();
 }
@@ -770,12 +770,12 @@ TEST(Column_Sort2)
     Column c;
 
     Random random(random_int<unsigned long>()); // Seed from slow global generator
-    for (size_t t = 0; t < 9*TIGHTDB_MAX_LIST_SIZE; t++)
+    for (size_t t = 0; t < 9*TIGHTDB_MAX_BPNODE_SIZE; t++)
         c.add(random.draw_int(-100, 199));
 
     c.sort();
 
-    for (size_t t = 1; t < 9*TIGHTDB_MAX_LIST_SIZE; t++)
+    for (size_t t = 1; t < 9*TIGHTDB_MAX_BPNODE_SIZE; t++)
         CHECK(c.get(t) >= c.get(t - 1));
 
     c.destroy();

--- a/test/test_column_string.cpp
+++ b/test/test_column_string.cpp
@@ -722,7 +722,7 @@ TEST(ColumnString_FindAllRangesLong)
     ref_type col_ref = Column::create(Allocator::get_default());
     Column c(Allocator::get_default(), col_ref);
 
-    // 17 elements, to test node splits with TIGHTDB_MAX_LIST_SIZE = 3 or other small number
+    // 17 elements, to test node splits with TIGHTDB_MAX_BPNODE_SIZE = 3 or other small number
     asc.add("HEJSA"); // 0
     asc.add("70 chars  70 chars  70 chars  70 chars  70 chars  70 chars  70 chars  ");
     asc.add("HEJSA");
@@ -779,7 +779,7 @@ TEST(ColumnString_FindAllRanges)
     ref_type col_ref = Column::create(Allocator::get_default());
     Column c(Allocator::get_default(), col_ref);
 
-    // 17 elements, to test node splits with TIGHTDB_MAX_LIST_SIZE = 3 or other small number
+    // 17 elements, to test node splits with TIGHTDB_MAX_BPNODE_SIZE = 3 or other small number
     asc.add("HEJSA"); // 0
     asc.add("1");
     asc.add("HEJSA");
@@ -832,7 +832,7 @@ TEST(ColumnString_Count)
     ref_type asc_ref = AdaptiveStringColumn::create(Allocator::get_default());
     AdaptiveStringColumn asc(Allocator::get_default(), asc_ref);
 
-    // 17 elements, to test node splits with TIGHTDB_MAX_LIST_SIZE = 3 or other small number
+    // 17 elements, to test node splits with TIGHTDB_MAX_BPNODE_SIZE = 3 or other small number
     asc.add("HEJSA"); // 0
     asc.add("1");
     asc.add("HEJSA");
@@ -875,7 +875,7 @@ TEST(ColumnString_Index)
     ref_type asc_ref = AdaptiveStringColumn::create(Allocator::get_default());
     AdaptiveStringColumn asc(Allocator::get_default(), asc_ref);
 
-    // 17 elements, to test node splits with TIGHTDB_MAX_LIST_SIZE = 3 or other small number
+    // 17 elements, to test node splits with TIGHTDB_MAX_BPNODE_SIZE = 3 or other small number
     asc.add("HEJSA"); // 0
     asc.add("1");
     asc.add("HEJSA");

--- a/test/test_lang_bind_helper.cpp
+++ b/test/test_lang_bind_helper.cpp
@@ -413,7 +413,7 @@ TEST(LangBindHelper_AdvanceReadTransact_ColumnRootTypeChange)
     CHECK_EQUAL(type_Table, other->get_column_type(2));
     CHECK_EQUAL(1, other->size());
 
-    size_t leaf_x4    = 4 * TIGHTDB_MAX_LIST_SIZE;
+    size_t leaf_x4    = 4 * TIGHTDB_MAX_BPNODE_SIZE;
     size_t leaf_x4p16 = leaf_x4 + 16;
 
     // Change root type in various string columns (including mixed)

--- a/test/test_links.cpp
+++ b/test/test_links.cpp
@@ -827,7 +827,7 @@ TEST(Links_ClearColumnWithTwoLevelBptree)
     target->add_empty_row();
 
     origin->add_column_link(type_LinkList, "", *target);
-    origin->add_empty_row(TIGHTDB_MAX_LIST_SIZE+1);
+    origin->add_empty_row(TIGHTDB_MAX_BPNODE_SIZE+1);
     origin->clear();
     origin->add_empty_row();
     origin->get_linklist(0,0)->add(0);
@@ -844,7 +844,7 @@ TEST(Links_ClearLinkListWithTwoLevelBptree)
     origin->add_column_link(type_LinkList, "", *target);
     origin->add_empty_row();
     LinkViewRef link_list = origin->get_linklist(0,0);
-    for (size_t i = 0; i < TIGHTDB_MAX_LIST_SIZE+1; ++i)
+    for (size_t i = 0; i < TIGHTDB_MAX_BPNODE_SIZE+1; ++i)
         link_list->add(0);
     link_list->clear();
     group.Verify();

--- a/test/test_query.cpp
+++ b/test/test_query.cpp
@@ -169,7 +169,7 @@ TEST(Query_Count)
 {
     // Intended to test QueryState::match<pattern = true>(); which is only triggered if:
     // * Table size is large enough to have SSE-aligned or bithack-aligned rows (this requires
-    //   TIGHTDB_MAX_LIST_SIZE > [some large number]!)
+    //   TIGHTDB_MAX_BPNODE_SIZE > [some large number]!)
     // * You're doing a 'count' which is currently the only operation that uses 'pattern', and
     // * There exists exactly 1 condition (if there is 0 conditions, it will fallback to column::count
     //   and if there exists > 1 conditions, 'pattern' is currently not supported - but could easily be
@@ -181,7 +181,7 @@ TEST(Query_Count)
         table.add_column(type_Int, "i");
 
         size_t count = 0;
-        size_t rows = random.draw_int_mod(5 * TIGHTDB_MAX_LIST_SIZE); // to cross some leaf boundaries
+        size_t rows = random.draw_int_mod(5 * TIGHTDB_MAX_BPNODE_SIZE); // to cross some leaf boundaries
 
         for (size_t i = 0; i < rows; ++i) {
             table.add_empty_row();
@@ -492,7 +492,7 @@ TEST(Query_NextGenSyntaxMonkey0)
     Random random(random_int<unsigned long>()); // Seed from slow global generator
     for (int iter = 1; iter < 100 + TEST_DURATION * 10000; iter++)
     {
-        const size_t rows = 1 + random.draw_int_mod(2 * TIGHTDB_MAX_LIST_SIZE);
+        const size_t rows = 1 + random.draw_int_mod(2 * TIGHTDB_MAX_BPNODE_SIZE);
         Table table;
 
         // Two different row types prevents fallback to query_engine (good because we want to test query_expression)
@@ -549,7 +549,7 @@ TEST(Query_NextGenSyntaxMonkey)
     for (int iter = 1; iter < 20 * (TEST_DURATION * TEST_DURATION * TEST_DURATION + 1); iter++) {
         // Keep at least '* 20' else some tests will give 0 matches and bad coverage
         const size_t rows =
-            1 + random.draw_int_mod<size_t>(TIGHTDB_MAX_LIST_SIZE * 20 *
+            1 + random.draw_int_mod<size_t>(TIGHTDB_MAX_BPNODE_SIZE * 20 *
             (TEST_DURATION * TEST_DURATION * TEST_DURATION + 1));
         Table table;
         table.add_column(type_Int, "first");
@@ -884,7 +884,7 @@ TEST(Query_MergeQueriesMonkey)
 {
     Random random(random_int<unsigned long>()); // Seed from slow global generator
     for (int iter = 0; iter < 5; iter++) {
-        const size_t rows = TIGHTDB_MAX_LIST_SIZE * 4;
+        const size_t rows = TIGHTDB_MAX_BPNODE_SIZE * 4;
         Table table;
         table.add_column(type_Int, "first");
         table.add_column(type_Int, "second");
@@ -1062,7 +1062,7 @@ TEST(Query_MergeQueriesMonkeyOverloads)
 {
     Random random(random_int<unsigned long>()); // Seed from slow global generator
     for (int iter = 0; iter < 5; iter++) {
-        const size_t rows = TIGHTDB_MAX_LIST_SIZE * 4;
+        const size_t rows = TIGHTDB_MAX_BPNODE_SIZE * 4;
         Table table;
         table.add_column(type_Int, "first");
         table.add_column(type_Int, "second");
@@ -1602,7 +1602,7 @@ TEST(Query_StrIndexCrash)
 
         size_t eights = 0;
 
-        for (int i = 0; i < TIGHTDB_MAX_LIST_SIZE * 2; ++i) {
+        for (int i = 0; i < TIGHTDB_MAX_BPNODE_SIZE * 2; ++i) {
             int v = random.draw_int_mod(10);
             if (v == 8) {
                 eights++;
@@ -1653,7 +1653,7 @@ TEST(Query_TwoColsEqualVaryWidthAndValues)
     table.add_column(type_Double, "sixth");
 
 #ifdef TIGHTDB_DEBUG
-    for (int i = 0; i < TIGHTDB_MAX_LIST_SIZE * 5; i++) {
+    for (int i = 0; i < TIGHTDB_MAX_BPNODE_SIZE * 5; i++) {
 #else
     for (int i = 0; i < 50000; i++) {
 #endif
@@ -2051,12 +2051,12 @@ TEST(Query_OnTableView)
         OneIntTable oti;
         size_t cnt1 = 0;
         size_t cnt0 = 0;
-        size_t limit = random.draw_int_max(TIGHTDB_MAX_LIST_SIZE * 10);
+        size_t limit = random.draw_int_max(TIGHTDB_MAX_BPNODE_SIZE * 10);
 
-        size_t lbound = random.draw_int_mod(TIGHTDB_MAX_LIST_SIZE * 10);
-        size_t ubound = lbound + random.draw_int_mod(TIGHTDB_MAX_LIST_SIZE * 10 - lbound);
+        size_t lbound = random.draw_int_mod(TIGHTDB_MAX_BPNODE_SIZE * 10);
+        size_t ubound = lbound + random.draw_int_mod(TIGHTDB_MAX_BPNODE_SIZE * 10 - lbound);
 
-        for (size_t i = 0; i < TIGHTDB_MAX_LIST_SIZE * 10; i++) {
+        for (size_t i = 0; i < TIGHTDB_MAX_BPNODE_SIZE * 10; i++) {
             int v = random.draw_int_mod(3);
 
             if (v == 1 && i >= lbound && i < ubound && cnt0 < limit)
@@ -2090,12 +2090,12 @@ TEST(Query_OnTableView_where)
         OneIntTable oti;
         size_t cnt1 = 0;
         size_t cnt0 = 0;
-        size_t limit = random.draw_int_max(TIGHTDB_MAX_LIST_SIZE * 10);
+        size_t limit = random.draw_int_max(TIGHTDB_MAX_BPNODE_SIZE * 10);
 
-        size_t lbound = random.draw_int_mod(TIGHTDB_MAX_LIST_SIZE * 10);
-        size_t ubound = lbound + random.draw_int_mod(TIGHTDB_MAX_LIST_SIZE * 10 - lbound);
+        size_t lbound = random.draw_int_mod(TIGHTDB_MAX_BPNODE_SIZE * 10);
+        size_t ubound = lbound + random.draw_int_mod(TIGHTDB_MAX_BPNODE_SIZE * 10 - lbound);
 
-        for (size_t i = 0; i < TIGHTDB_MAX_LIST_SIZE * 10; i++) {
+        for (size_t i = 0; i < TIGHTDB_MAX_BPNODE_SIZE * 10; i++) {
             int v = random.draw_int_mod(3);
 
             if (v == 1 && i >= lbound && i < ubound && cnt0 < limit)
@@ -2142,13 +2142,13 @@ TEST(Query_StrIndex3)
 #endif
             // 1/500 match probability because we want possibility for a 1000 sized leaf to contain 0 matches (important
             // edge case)
-            int f1 = random.draw_int_mod(TIGHTDB_MAX_LIST_SIZE) / 2 + 1;
-            int f2 = random.draw_int_mod(TIGHTDB_MAX_LIST_SIZE) / 2 + 1;
+            int f1 = random.draw_int_mod(TIGHTDB_MAX_BPNODE_SIZE) / 2 + 1;
+            int f2 = random.draw_int_mod(TIGHTDB_MAX_BPNODE_SIZE) / 2 + 1;
             bool longstrings = random.chance(1, 5);
 
             // 2200 entries with that probability to fill out two concecutive 1000 sized leaves with above probability,
             // plus a remainder (edge case)
-            for (int j = 0; j < TIGHTDB_MAX_LIST_SIZE * 2 + TIGHTDB_MAX_LIST_SIZE / 5; j++) {
+            for (int j = 0; j < TIGHTDB_MAX_BPNODE_SIZE * 2 + TIGHTDB_MAX_BPNODE_SIZE / 5; j++) {
                 if (random.chance(1, f1)) {
                     if (random.chance(1, f2)) {
                         ttt.add(0, longstrings ? "AAAAAAAAAAAAAAAAAAAAAAAA" : "AA");
@@ -2261,7 +2261,7 @@ TEST(Query_StrEnum)
     for (int i = 0; i < 100; ++i) {
         ttt.clear();
         aa = 0;
-        for (size_t t = 0; t < TIGHTDB_MAX_LIST_SIZE * 2; ++t) {
+        for (size_t t = 0; t < TIGHTDB_MAX_BPNODE_SIZE * 2; ++t) {
             if (random.chance(1, 3)) {
                 ttt.add(1, "AA");
                 ++aa;
@@ -3679,7 +3679,7 @@ TEST(Query_Sort_And_Requery_Untyped_Monkey2)
         table.add_column(type_Int, "second1");
 
         // Add random data to table
-        for (size_t t = 0; t < 3 * TIGHTDB_MAX_LIST_SIZE; t++) {
+        for (size_t t = 0; t < 3 * TIGHTDB_MAX_BPNODE_SIZE; t++) {
             table.add_empty_row();
             int64_t val1 = rand() % 5;
             table.set_int(0, t, val1);
@@ -4002,7 +4002,7 @@ TEST(Query_FindNextBackwards)
     TupleTableType ttt;
 
     // Create multiple leaves
-    for (size_t i = 0; i < TIGHTDB_MAX_LIST_SIZE * 4; i++) {
+    for (size_t i = 0; i < TIGHTDB_MAX_BPNODE_SIZE * 4; i++) {
         ttt.add(6, "X");
         ttt.add(7, "X");
     }
@@ -4011,8 +4011,8 @@ TEST(Query_FindNextBackwards)
 
     // Check if leaf caching works correctly in the case you go backwards. 'res' result is not so important
     // in this test; this test tests if we assert errorneously. Next test (TestQueryFindRandom) is more exhaustive
-    size_t res = q.find(TIGHTDB_MAX_LIST_SIZE * 2);
-    CHECK_EQUAL(TIGHTDB_MAX_LIST_SIZE * 2, res);
+    size_t res = q.find(TIGHTDB_MAX_BPNODE_SIZE * 2);
+    CHECK_EQUAL(TIGHTDB_MAX_BPNODE_SIZE * 2, res);
     res = q.find(0);
     CHECK_EQUAL(0, res);
 }
@@ -4025,14 +4025,14 @@ TEST(Query_FindRandom)
     Random random(random_int<unsigned long>()); // Seed from slow global generator
 
     TupleTableType ttt;
-    int64_t search = TIGHTDB_MAX_LIST_SIZE / 2;
-    size_t rows = TIGHTDB_MAX_LIST_SIZE * 20;
+    int64_t search = TIGHTDB_MAX_BPNODE_SIZE / 2;
+    size_t rows = TIGHTDB_MAX_BPNODE_SIZE * 20;
 
     // Create multiple leaves
     for (size_t i = 0; i < rows; i++) {
         // This value distribution makes us sometimes cross a leaf boundary, and sometimes not, with both having
         // a fair probability of happening
-        ttt.add(random.draw_int_mod(TIGHTDB_MAX_LIST_SIZE), "X");
+        ttt.add(random.draw_int_mod(TIGHTDB_MAX_BPNODE_SIZE), "X");
     }
 
     TupleTableType::Query q = ttt.where().first.equal(search);
@@ -5051,7 +5051,7 @@ TEST(Query_Avg2)
 TEST(Query_OfByOne)
 {
     TupleTableType t;
-    for (size_t i = 0; i < TIGHTDB_MAX_LIST_SIZE * 2; ++i) {
+    for (size_t i = 0; i < TIGHTDB_MAX_BPNODE_SIZE * 2; ++i) {
         t.add(1, "a");
     }
 
@@ -5062,19 +5062,19 @@ TEST(Query_OfByOne)
     t[0].first = 1; // reset
 
     // Before split
-    t[TIGHTDB_MAX_LIST_SIZE - 1].first = 0;
+    t[TIGHTDB_MAX_BPNODE_SIZE - 1].first = 0;
     res = t.where().first.equal(0).find();
-    CHECK_EQUAL(TIGHTDB_MAX_LIST_SIZE - 1, res);
-    t[TIGHTDB_MAX_LIST_SIZE - 1].first = 1; // reset
+    CHECK_EQUAL(TIGHTDB_MAX_BPNODE_SIZE - 1, res);
+    t[TIGHTDB_MAX_BPNODE_SIZE - 1].first = 1; // reset
 
     // After split
-    t[TIGHTDB_MAX_LIST_SIZE].first = 0;
+    t[TIGHTDB_MAX_BPNODE_SIZE].first = 0;
     res = t.where().first.equal(0).find();
-    CHECK_EQUAL(TIGHTDB_MAX_LIST_SIZE, res);
-    t[TIGHTDB_MAX_LIST_SIZE].first = 1; // reset
+    CHECK_EQUAL(TIGHTDB_MAX_BPNODE_SIZE, res);
+    t[TIGHTDB_MAX_BPNODE_SIZE].first = 1; // reset
 
     // Before end
-    const size_t last_pos = (TIGHTDB_MAX_LIST_SIZE * 2) - 1;
+    const size_t last_pos = (TIGHTDB_MAX_BPNODE_SIZE * 2) - 1;
     t[last_pos].first = 0;
     res = t.where().first.equal(0).find();
     CHECK_EQUAL(last_pos, res);

--- a/test/test_shared.cpp
+++ b/test/test_shared.cpp
@@ -885,7 +885,7 @@ TEST(Shared_WritesSpecialOrder)
     SHARED_GROUP_TEST_PATH(path);
     SharedGroup sg(path);
 
-    const int num_rows = 5; // FIXME: Should be strictly greater than TIGHTDB_MAX_LIST_SIZE, but that takes a loooooong time!
+    const int num_rows = 5; // FIXME: Should be strictly greater than TIGHTDB_MAX_BPNODE_SIZE, but that takes a loooooong time!
     const int num_reps = 25;
 
     {
@@ -1386,9 +1386,9 @@ TEST_IF(Shared_StringIndexBug1, TEST_DURATION >= 3)
         TableRef table = group.add_table("users");
         table->add_column(type_String, "username");
         table->set_index(0);
-        for (int i = 0; i < TIGHTDB_MAX_LIST_SIZE + 1; ++i)
+        for (int i = 0; i < TIGHTDB_MAX_BPNODE_SIZE + 1; ++i)
             table->add_empty_row();
-        for (int i = 0; i < TIGHTDB_MAX_LIST_SIZE + 1; ++i)
+        for (int i = 0; i < TIGHTDB_MAX_BPNODE_SIZE + 1; ++i)
             table->remove(0);
         db.commit();
     }
@@ -2340,7 +2340,7 @@ TEST(Shared_ArrayEraseBug)
 {
     // This test only makes sense when we can insert a number of rows
     // equal to the square of the maximum B+-tree node size.
-    size_t max_node_size = TIGHTDB_MAX_LIST_SIZE;
+    size_t max_node_size = TIGHTDB_MAX_BPNODE_SIZE;
     size_t max_node_size_squared = max_node_size;
     if (int_multiply_with_overflow_detect(max_node_size_squared, max_node_size))
         return;

--- a/test/test_table.cpp
+++ b/test/test_table.cpp
@@ -2823,7 +2823,7 @@ TIGHTDB_TABLE_3(TableAgg,
 } // anonymous namespace
 
 #if TEST_DURATION > 0
-#define TBL_SIZE TIGHTDB_MAX_LIST_SIZE*10
+#define TBL_SIZE TIGHTDB_MAX_BPNODE_SIZE*10
 #else
 #define TBL_SIZE 10
 #endif
@@ -5284,7 +5284,7 @@ TEST(Table_AddColumnWithThreeLevelBptree)
 {
     Table table;
     table.add_column(type_Int, "");
-    table.add_empty_row(TIGHTDB_MAX_LIST_SIZE*TIGHTDB_MAX_LIST_SIZE+1);
+    table.add_empty_row(TIGHTDB_MAX_BPNODE_SIZE*TIGHTDB_MAX_BPNODE_SIZE+1);
     table.add_column(type_Int, "");
     table.Verify();
 }
@@ -5294,7 +5294,7 @@ TEST(Table_ClearWithTwoLevelBptree)
 {
     Table table;
     table.add_column(type_Mixed, "");
-    table.add_empty_row(TIGHTDB_MAX_LIST_SIZE+1);
+    table.add_empty_row(TIGHTDB_MAX_BPNODE_SIZE+1);
     table.clear();
     table.Verify();
 }

--- a/test/test_transactions_lasse.cpp
+++ b/test/test_transactions_lasse.cpp
@@ -279,7 +279,7 @@ private:
 const int ITER3 =     20;
 const int WRITERS3 =   4;
 const int READERS3 =   4;
-const size_t ROWS3 = 1*1000*1000 + 1000; // + 1000 to add extra depth level if TIGHTDB_MAX_LIST_SIZE = 1000
+const size_t ROWS3 = 1*1000*1000 + 1000; // + 1000 to add extra depth level if TIGHTDB_MAX_BPNODE_SIZE = 1000
 volatile bool terminate3 = false;
 
 void write_thread3(string path)


### PR DESCRIPTION
Macro `TIGHTDB_MAX_LIST_SIZE` was renamed to `TIGHTDB_MAX_PBNODE_SIZE`, where `BPNODE` stands for _B+-tree node_.

Macro `TIGHTDB_MAX_BPNODE_SIZE` now defaults to 1000 in both _release_ and _debug_ mode.

One can now specify a custom value for `TIGHTDB_MAX_BPNODE_SIZE` in debug mode during configuration  as follows:

```
TIGHTDB_MAX_BPNODE_SIZE_DEBUG=4 sh build.sh config
```

This was done as an emergency fix, and it is by no means a good solution. It is bad because it will reintroduce confusion about the value of TIGHTDB_MAX_BPNODE_SIZE in debug mode, something that has caused a lot of wasted effort earlier.

@bmunkholm @astigsen @finnschiermer @rrrlasse 
