### PR TITLE
lr_tableviewsort: Fixes user bug where he sorted an already-sorted view ...

### DIFF
--- a/src/tightdb/query.cpp
+++ b/src/tightdb/query.cpp
@@ -122,14 +122,6 @@ Query& Query::expression(Expression* compare, bool auto_delete)
     return *this;
 }
 
-// Makes query search only in rows contained in tv
-Query& Query::tableview(const TableView& tv)
-{
-    ParentNode* const p = new ListviewNode(tv);
-    UpdatePointers(p, &p->m_child);
-    return *this;
-}
-
 // Binary
 Query& Query::equal(size_t column_ndx, BinaryData b)
 {

--- a/src/tightdb/query.hpp
+++ b/src/tightdb/query.hpp
@@ -65,9 +65,6 @@ public:
     Query& expression(Expression* compare, bool auto_delete = false);
     Expression* get_expression();
 
-    // Conditions: Query only rows contained in tv
-    Query& tableview(const TableView& tv); // throws
-
     // Find links that point to a specific target row 
     Query& links_to(size_t column_ndx, size_t target_row);
 

--- a/src/tightdb/table.hpp
+++ b/src/tightdb/table.hpp
@@ -567,8 +567,7 @@ public:
 
     // Queries
     // Using where(tv) is the new method to perform queries on TableView. The 'tv' can have any order; it does not
-    // need to be sorted, and, resulting view retains its order. Using where.tableview(tv) is deprecated and needs 
-    // 'tv' to be sorted.
+    // need to be sorted, and, resulting view retains its order.
     Query where(TableViewBase* tv = null_ptr) { return Query(*this, tv); }
 
     // FIXME: We need a ConstQuery class or runtime check against modifications in read transaction.

--- a/src/tightdb/table_basic.hpp
+++ b/src/tightdb/table_basic.hpp
@@ -347,12 +347,6 @@ public:
     Query(const Query& q): Spec::template ColNames<QueryCol, Query*>(this), m_impl(q.m_impl) {}
     ~Query() TIGHTDB_NOEXCEPT {}
 
-    Query& tableview(const typename BasicTable<Spec>::View& v)
-    {
-        m_impl.tableview(*v.get_impl());
-        return *this;
-    }
-
     Query& group() { m_impl.group(); return *this; }
 
     Query& end_group() { m_impl.end_group(); return *this; }

--- a/test/test_query.cpp
+++ b/test/test_query.cpp
@@ -2041,45 +2041,6 @@ TEST(Query_Huge)
     }
 }
 
-TEST(Query_OnTableView)
-{
-    Random random;
-
-    // Mostly intended to test the Array::FindGTE method
-    for (int iter = 0; iter < 100 * (1 + TEST_DURATION * TEST_DURATION * TEST_DURATION * TEST_DURATION * TEST_DURATION); iter++) {
-        random.seed(164);
-        OneIntTable oti;
-        size_t cnt1 = 0;
-        size_t cnt0 = 0;
-        size_t limit = random.draw_int_max(TIGHTDB_MAX_BPNODE_SIZE * 10);
-
-        size_t lbound = random.draw_int_mod(TIGHTDB_MAX_BPNODE_SIZE * 10);
-        size_t ubound = lbound + random.draw_int_mod(TIGHTDB_MAX_BPNODE_SIZE * 10 - lbound);
-
-        for (size_t i = 0; i < TIGHTDB_MAX_BPNODE_SIZE * 10; i++) {
-            int v = random.draw_int_mod(3);
-
-            if (v == 1 && i >= lbound && i < ubound && cnt0 < limit)
-                cnt1++;
-
-            if (v != 0 && i >= lbound && i < ubound)
-                cnt0++;
-
-            oti.add(v);
-        }
-
-        OneIntTable::View v = oti.where().first.not_equal(0).find_all(lbound, ubound, limit);
-        size_t cnt2 = oti.where().tableview(v).first.equal(1).count();
-
-        if (cnt1 != cnt2)
-            cerr << iter << " ";
-
-        CHECK_EQUAL(cnt1, cnt2);
-
-
-    }
-
-}
 
 TEST(Query_OnTableView_where)
 {
@@ -4779,24 +4740,6 @@ TEST(Query_SubtableSyntaxCheck)
     CHECK(s != "");
 }
 
-TEST(Query_TestTV)
-{
-    TupleTableType t;
-    t.add(1, "a");
-    t.add(2, "a");
-    t.add(3, "c");
-
-    TupleTableType::View v = t.where().first.greater(1).find_all();
-
-    TupleTableType::Query q1 = t.where().tableview(v);
-    CHECK_EQUAL(2, q1.count());
-
-    TupleTableType::Query q3 = t.where().tableview(v).second.equal("a");
-    CHECK_EQUAL(1, q3.count());
-
-    TupleTableType::Query q4 = t.where().tableview(v).first.between(3, 6);
-    CHECK_EQUAL(1, q4.count());
-}
 
 TEST(Query_TestTV_where)
 {

--- a/test/test_table.cpp
+++ b/test/test_table.cpp
@@ -1038,41 +1038,6 @@ TEST(Table_SortedInt)
 #endif
 }
 
-TEST(Table_SortedQuery)
-{
-    TestTable table;
-
-    table.add(0, 10, true, Wed); // 0: 4
-    table.add(0, 20, false, Wed); // 1: 7
-    table.add(0,  0, false, Wed); // 2: 0
-    table.add(0, 40, false, Wed); // 3: 8
-    table.add(0, 15, false, Wed); // 4: 6
-    table.add(0, 11, true, Wed); // 5: 5
-    table.add(0,  6, true, Wed); // 6: 3
-    table.add(0,  4, true, Wed); // 7: 2
-    table.add(0, 99, true, Wed); // 8: 9
-    table.add(0,  2, true, Wed); // 9: 1
-
-    // Count booleans
-    size_t count_original = table.where().third.equal(false).count();
-    CHECK_EQUAL(4, count_original);
-
-    // Get a view containing the complete table
-    TestTable::View v = table.column().first.find_all(0);
-    CHECK_EQUAL(table.size(), v.size());
-
-    // Count booleans
-    size_t count_view = table.where().tableview(v).third.equal(false).count();
-    CHECK_EQUAL(4, count_view);
-
-    TestTable::View v_sorted = table.column().second.get_sorted_view();
-    CHECK_EQUAL(table.size(), v_sorted.size());
-
-#ifdef TIGHTDB_DEBUG
-    table.Verify();
-#endif
-}
-
 
 TEST(Table_Sorted_Query_where)
 {


### PR DESCRIPTION
...and got smaller item count in resulting view (items were removed).

Fix was to remove deprecated Query::tableview() method because it only worked for unsorted views, and replace it by where(&tv) in the language binding
