### PR TITLE
Bugfix: Replication::m_selected_link_list was not cleared

### DIFF
--- a/src/tightdb/replication.cpp
+++ b/src/tightdb/replication.cpp
@@ -21,7 +21,10 @@ const size_t init_subtab_path_buf_size = 2*init_subtab_path_buf_levels - 1;
 } // anonymous namespace
 
 
-Replication::Replication(): m_selected_table(0), m_selected_spec(0)
+Replication::Replication():
+    m_selected_table(0),
+    m_selected_spec(0),
+    m_selected_link_list(0)
 {
     m_subtab_path_buf.set_size(init_subtab_path_buf_size); // Throws
 }

--- a/src/tightdb/replication.hpp
+++ b/src/tightdb/replication.hpp
@@ -521,6 +521,7 @@ inline void Replication::begin_write_transact(SharedGroup& sg)
     do_begin_write_transact(sg);
     m_selected_table = 0;
     m_selected_spec  = 0;
+    m_selected_link_list  = 0;
 }
 
 inline Replication::version_type


### PR DESCRIPTION
This bug was capable of corrupting memory due to the "dangling" pointer.

It is likely that this bug could also manifest itself through the Cocoa binding. Here are the steps that I would expect would reveal it:
1. On the main thread, establish a situation where a particular link list accessor is **kept alive**. From the point of view of the binding, this probably means that some RLMArray needs to be kept alive.
2. On a background thread, acquire access to the same link list (RLMArray), **and make sure it is kept alive**.
3. On the background thread, modify the link list (RLMArray).
4. On the main thread, advance/refresh the ongoing read transaction.
5. On the background thread, modify the link list (RLMArray) again (second time).
6. On the main thread, advance/refresh the ongoing read transaction again (second time).
7. On the main thread, check that the last modification is visible.
8. On the main thread, call Group::Verify().

This should give a failure in both 7 and 8.

See also https://github.com/Tightdb/tightdb/blob/f1d3610b8cfdcf78f822b18e08d5e5365be2b461/test/test_lang_bind_helper.cpp#L6074.

@alazier @finnschiermer @astigsen @tgoyne 
