### PR TITLE
Add another operator= overload for BasicRow

### DIFF
--- a/src/tightdb/row.hpp
+++ b/src/tightdb/row.hpp
@@ -247,6 +247,7 @@ public:
     template<class U> BasicRow(const BasicRow<U>&) TIGHTDB_NOEXCEPT;
     template<class U> BasicRow& operator=(BasicRowExpr<U>) TIGHTDB_NOEXCEPT;
     template<class U> BasicRow& operator=(BasicRow<U>) TIGHTDB_NOEXCEPT;
+    BasicRow& operator=(const BasicRow<T>&) TIGHTDB_NOEXCEPT;
 
     ~BasicRow() TIGHTDB_NOEXCEPT;
 
@@ -589,6 +590,13 @@ inline BasicRow<T>& BasicRow<T>::operator=(BasicRow<U> row) TIGHTDB_NOEXCEPT
 {
     T* table = row.m_table.get(); // Check that pointer types are compatible
     reattach(const_cast<Table*>(table), row.m_row_ndx);
+    return *this;
+}
+
+template<class T>
+inline BasicRow<T>& BasicRow<T>::operator=(const BasicRow<T>& row) TIGHTDB_NOEXCEPT
+{
+    reattach(const_cast<Table*>(row.m_table.get()), row.m_row_ndx);
     return *this;
 }
 

--- a/test/test_table.cpp
+++ b/test/test_table.cpp
@@ -4732,20 +4732,29 @@ TEST(Table_RowAccessorAssignMultipleTables)
     Table tables[2];
     for (int i = 0; i < 2; ++i) {
         tables[i].add_column(type_Int, "");
-        tables[i].add_empty_row(2);
+        tables[i].add_empty_row(3);
         tables[i].set_int(0, 0, 750);
         tables[i].set_int(0, 1, 751);
+        tables[i].set_int(0, 2, 752);
     }
 
-    Row row_1 = tables[0][1];
-    Row row_2 = tables[1][1];
-    Row row_3 = tables[0][1];
-    row_1 = tables[1][1]; // Assign attached `Row` to a different table
+    Row row_1 = tables[0][2];
+    Row row_2 = tables[1][2];
+    Row row_3 = tables[0][2];
+    row_1 = tables[1][2]; // Assign attached `Row` to a different table via RowExpr
 
     // Veriy that the correct accessors are updated when removing from a table
     tables[0].remove(0);
-    CHECK_EQUAL(row_1.get_index(), 1);
-    CHECK_EQUAL(row_2.get_index(), 1);
+    CHECK_EQUAL(row_1.get_index(), 2);
+    CHECK_EQUAL(row_2.get_index(), 2);
+    CHECK_EQUAL(row_3.get_index(), 1);
+
+    row_1 = row_3; // Assign attached `Row` to a different table via Row
+
+    // Veriy that the correct accessors are updated when removing from a table
+    tables[0].remove(0);
+    CHECK_EQUAL(row_1.get_index(), 0);
+    CHECK_EQUAL(row_2.get_index(), 2);
     CHECK_EQUAL(row_3.get_index(), 0);
 }
 


### PR DESCRIPTION
When T == U, the compiler-generated default `operator=` is used rather than the `template<class U> BasicRow& operator=(BasicRow<U>)` overload, which means that assigning a Row to a ConstRow or vice-versa worked correctly, but assigning a Row to a Row did not.

None of the current tests actually verified that the user-supplied assignment operator was being used, so I expanded the Table_RowAccessorAssignMultipleTables test to also test assigning a Row to another Row (in addition to assigning a RowExpr to a Row).
