### PR TITLE
lr_removebug: Unit tests that exposes crash at remove with LinkList colu...

### DIFF
--- a/test/test_links.cpp
+++ b/test/test_links.cpp
@@ -850,6 +850,23 @@ TEST(Links_ClearLinkListWithTwoLevelBptree)
     group.Verify();
 }
 
+// Exposes new crash bug at remove, which seems analog to the two tests above
+ONLY(LinkList_RemoveCrash)
+{
+    Group group;
+
+    TableRef table1 = group.add_table("table1");
+    TableRef table2 = group.add_table("table2");
+
+    table1->add_column(type_Int, "col1");
+
+    table1->add_empty_row();
+    table1->add_empty_row();
+
+    size_t col_link2 = table2->add_column_link(type_LinkList, "linklist", *table1);
+
+    table1->remove(0);
+}
 
 TEST(Links_FormerMemLeakCase)
 {
@@ -922,5 +939,6 @@ TEST(Links_RandomizedOperations)
         }
     }
 }
+
 
 #endif // TEST_LINKS


### PR DESCRIPTION
...mn present. Crashes with following settings:

TightDB version: 0.82.2
  with Debug Enabled
  with Replication Enabled

TIGHTDB_MAX_BPNODE_SIZE = 1000

sizeof (size_t) \* 8 = 32

Compiler supported SSE (auto detect):       No
This CPU supports SSE (auto detect):        None
Compiler supported AVX (auto detect):       No
This CPU supports AVX (AVX1) (auto detect): No

d:\lr_removebug\src\tightdb\column_backlink.cpp:230: Assertion failed: is_last
