### PR TITLE
Remove incorrect TIGHTDB_OVERRIDE

### DIFF
--- a/src/tightdb/group.cpp
+++ b/src/tightdb/group.cpp
@@ -882,7 +882,7 @@ public:
     {
     }
 
-    size_t read(char* buffer, size_t size) TIGHTDB_OVERRIDE
+    size_t read(char* buffer, size_t size)
     {
         if (m_logs_begin == m_logs_end)
             return 0;


### PR DESCRIPTION
MultiLogInputStream::read doesn't actually override anything.
