### PR TITLE
Fix and_query() on a deep-copied Query

### DIFF
--- a/src/tightdb/query.cpp
+++ b/src/tightdb/query.cpp
@@ -95,8 +95,12 @@ Query& Query::operator = (const Query& source)
         m_table = source.m_table;
         m_view = source.m_view;
 
-        for (size_t t = 0; t < update.size(); t++) {
-            update[t] = &first[0];
+        if (first[0]) {
+            ParentNode* node_to_update = first[0];
+            while (node_to_update->m_child) {
+                node_to_update = node_to_update->m_child;
+            }
+            update[0] = &node_to_update->m_child;
         }
     }
     return *this;

--- a/test/test_query.cpp
+++ b/test/test_query.cpp
@@ -5347,6 +5347,14 @@ TEST(Query_DeepCopy)
     q11.greater(2, 4.0);
     CHECK_EQUAL(3, q11.find());
     CHECK_EQUAL(0, q10.find());
+
+    // Test and_query() on a copy
+    Query q12 = t.column().ints > 2;
+    Query q13 = Query(q12, Query::TCopyExpressionTag());
+
+    q13.and_query(t.column().strings != "3");
+    CHECK_EQUAL(3, q13.find());
+    CHECK_EQUAL(2, q12.find());
 }
 
 TEST(Query_TableViewMoveAssign1)


### PR DESCRIPTION
Set `update` to the end of the expression chain in `operator=` rather than the beginning so that adding additional expressions doesn't overwrite all of the previous ones.

@rrrlasse 
