### PR TITLE
Fix address sanitizer failure

### DIFF
--- a/src/tightdb/query.cpp
+++ b/src/tightdb/query.cpp
@@ -75,6 +75,8 @@ Query::Query(const Query& copy, const TCopyExpressionTag&)
 
 Query& Query::operator = (const Query& source)
 {
+    TIGHTDB_ASSERT(source.do_delete);
+
     if (this != &source) {
         // free destination object
         delete_nodes();

--- a/test/test_query.cpp
+++ b/test/test_query.cpp
@@ -5424,6 +5424,7 @@ TEST(Query_TableViewMoveAssignLeak2)
 
     Query q3;
 
+    q2 = t.column().ints <= t.column().doubles;
     q3 = q2;
 
     q3.find();


### PR DESCRIPTION
Copying from a Query after moving from it is not valid.
