### PR TITLE
Removing Query::tableview

### DIFF
--- a/release_notes.md
+++ b/release_notes.md
@@ -6,7 +6,8 @@
 
 ### API breaking changes:
 
-* Lorem ipsum.
+* `Query::tableview()` removed as it might lead to wrong results
+  e.g., when sorting a sorted tableview.
 
 ### Enhancements:
 

--- a/src/tightdb/query.cpp
+++ b/src/tightdb/query.cpp
@@ -145,14 +145,6 @@ Query& Query::expression(Expression* compare, bool auto_delete)
     return *this;
 }
 
-// Makes query search only in rows contained in tv
-Query& Query::tableview(TableView& tv)
-{
-    ParentNode* const p = new ListviewNode(tv);
-    UpdatePointers(p, &p->m_child);
-    return *this;
-}
-
 // Binary
 Query& Query::equal(size_t column_ndx, BinaryData b)
 {

--- a/src/tightdb/query.hpp
+++ b/src/tightdb/query.hpp
@@ -69,9 +69,6 @@ public:
     Query& expression(Expression* compare, bool auto_delete = false);
     Expression* get_expression();
 
-    // Conditions: Query only rows contained in tv
-    Query& tableview(TableView& tv); // throws
-
     // Find links that point to a specific target row 
 
     // Find links that point to a specific target row 

--- a/src/tightdb/table_basic.hpp
+++ b/src/tightdb/table_basic.hpp
@@ -346,12 +346,6 @@ public:
     Query(const Query& q): Spec::template ColNames<QueryCol, Query*>(this), m_impl(q.m_impl) {}
     ~Query() TIGHTDB_NOEXCEPT {}
 
-    Query& tableview(const typename BasicTable<Spec>::View& v)
-    {
-        m_impl.tableview(const_cast<TableView&>(*v.get_impl()));
-        return *this;
-    }
-
     Query& group() { m_impl.group(); return *this; }
 
     Query& end_group() { m_impl.end_group(); return *this; }


### PR DESCRIPTION
Using the `Query::tableview` method will in certain situations give the wrong result e.g., when sorting a sorted table view.  By removing the method, we encourage the usage of `Table::where(TableView)` instead.

@kspangsege @rrrlasse @finnschiermer 
