### PR TITLE
Allow setting the durability level for SharedGroups with replication

### DIFF
--- a/release_notes.md
+++ b/release_notes.md
@@ -11,7 +11,8 @@
 
 ### Enhancements:
 
-* Lorem ipsum.
+* Make the durability level settable in the `SharedGroup` constructor and
+  `open()` overloads taking a `Replication`.
 
 -----------
 

--- a/src/tightdb/group_shared.cpp
+++ b/src/tightdb/group_shared.cpp
@@ -756,12 +756,11 @@ void SharedGroup::open(const string& path, bool no_create_file,
 
 #ifdef TIGHTDB_ENABLE_REPLICATION
 
-void SharedGroup::open(Replication& repl)
+void SharedGroup::open(Replication& repl, DurabilityLevel dlevel)
 {
     TIGHTDB_ASSERT(!is_attached());
     string file = repl.get_database_path();
     bool no_create   = false;
-    DurabilityLevel dlevel = durability_Full;
     open(file, no_create, dlevel); // Throws
     typedef _impl::GroupFriend gf;
     gf::set_replication(m_group, &repl);

--- a/src/tightdb/group_shared.hpp
+++ b/src/tightdb/group_shared.hpp
@@ -175,12 +175,13 @@ public:
 
     /// Equivalent to calling open(Replication&) on a
     /// default constructed instance.
-    explicit SharedGroup(Replication&);
+    explicit SharedGroup(Replication& repl,
+                         DurabilityLevel dlevel = durability_Full);
 
     /// Open this group in replication mode. The specified Replication
     /// instance must remain in exixtence for as long as the
     /// SharedGroup.
-    void open(Replication&);
+    void open(Replication&, DurabilityLevel dlevel = durability_Full);
 
     friend class Replication;
 
@@ -558,11 +559,11 @@ inline bool SharedGroup::is_attached() const TIGHTDB_NOEXCEPT
 }
 
 #ifdef TIGHTDB_ENABLE_REPLICATION
-inline SharedGroup::SharedGroup(Replication& repl):
+inline SharedGroup::SharedGroup(Replication& repl, DurabilityLevel dlevel):
     m_group(Group::shared_tag()),
     m_transactions_are_pinned(false)
 {
-    open(repl);
+    open(repl, dlevel);
 }
 #endif
 


### PR DESCRIPTION
Needed for the in-memory realms in the obj-c binding to actually be useful, as currently they can't be shared between threads.
