### PR TITLE
Add missing copy constructor for StringNode<Equal>

### DIFF
--- a/release_notes.md
+++ b/release_notes.md
@@ -2,7 +2,8 @@
 
 ### Bugfixes:
 
-* Lorem ipsum.
+* Fixed a crash when copying a query checking for equality on an indexed string
+  column.
 
 ### API breaking changes:
 

--- a/src/tightdb/query_engine.hpp
+++ b/src/tightdb/query_engine.hpp
@@ -1464,6 +1464,13 @@ public:
         return new StringNode<Equal>(*this);
     }
 
+    StringNode(const StringNode& from) : StringNodeBase(from)
+    {
+        m_index_getter = 0;
+        m_index_matches = 0;
+        m_index_matches_destroy = false;
+    }
+
 private:
     inline BinaryData str_to_bin(const StringData& s) TIGHTDB_NOEXCEPT
     {

--- a/test/test_query.cpp
+++ b/test/test_query.cpp
@@ -5466,4 +5466,17 @@ TEST(Query_DeepCopyTest)
     q2.end_group();
 }
 
+TEST(Query_StringIndexCrash)
+{
+    // Test for a crash which occured when a query testing for equality on a
+    // string index was deep-copied after being run
+    Table table;
+    table.add_column(type_String, "s");
+    table.add_search_index(0);
+
+    Query q = table.where().equal(0, StringData(""));
+    q.count();
+    Query(q, Query::TCopyExpressionTag());
+}
+
 #endif // TEST_QUERY


### PR DESCRIPTION
Fixes a crash when copying a query checking for equality on an indexed string column caused by both queries trying to destruct the index matcher.

@rrrlasse 
