### PR TITLE
fixed missing initialization in replication parsing

### DIFF
--- a/src/tightdb/replication.hpp
+++ b/src/tightdb/replication.hpp
@@ -1224,6 +1224,7 @@ inline void Replication::on_link_list_destroyed(const LinkView& list) TIGHTDB_NO
 inline Replication::TransactLogParser::TransactLogParser(Replication::InputStream& transact_log):
     m_input(transact_log)
 {
+    m_input_begin = m_input_end = 0;
 }
 
 


### PR DESCRIPTION
Exposed if the very first commit is an empty commit.
