### PR TITLE
Greatly improve performance of Not()+Or()

### DIFF
--- a/release_notes.md
+++ b/release_notes.md
@@ -10,7 +10,8 @@
 
 ### Enhancements:
 
-* Lorem ipsum.
+* Speed up Or() groups within a Not() by about an order of magnitude, and
+  slightly speed up most other queries within a Not().
 
 -----------
 


### PR DESCRIPTION
Batch calls to NotNode's child node rather than checking each row individually, since many of the nodes are much more efficient when searching a range. Speeds up large Or() nodes inside a Not() by about an order of magnitude, slightly speeds up many other queries, and doesn't appear to significantly hurt any queries.

@rrrlasse