### PR TITLE
Fix unbounded growth of the write log when committing from a single SharedGroup

### DIFF
--- a/release_notes.md
+++ b/release_notes.md
@@ -2,7 +2,8 @@
 
 ### Bugfixes:
 
-* Lorem ipsum.
+* Fixed unbounded growth of the write log when a single SharedGroup is used for
+  repeated writes.
 
 ### API breaking changes:
 

--- a/src/tightdb/group_shared.cpp
+++ b/src/tightdb/group_shared.cpp
@@ -967,8 +967,10 @@ void SharedGroup::advance_read(TransactLogRegistry& log_registry)
     grab_latest_readlock(m_readlock, same_as_before); // Throws
     release_readlock(old_readlock);
 
-    if (same_as_before)
+    if (same_as_before) {
+        log_registry.release_commit_entries(m_readlock.m_version);
         return;
+    }
 
     // If the new top-ref is zero, then the previous top-ref must have
     // been zero too, and we are still seing an empty TightDB file


### PR DESCRIPTION
Entries in the write log were only ever released when advance_read actually changed the version, but when every write is made from a single SharedGroup, that group's version is always the latest. As a result, the WriteLogRegistry did not get notified that the writing SG did not need the old entries until that SG is destructed.

Fix this by telling the TransactLogRegistry to release older entries in advance_read even if the version didn't change. It'd be nicer to call release_commit_entries in commit_and_continue_as_read, but that function currently doesn't have access to the TransactLogRegistry.

@finnschiermer 
