### PR TITLE
Throw with a more descriptive message when insufficient open() permissions

### DIFF
--- a/src/tightdb/util/file.cpp
+++ b/src/tightdb/util/file.cpp
@@ -288,6 +288,9 @@ void File::open_internal(const string& path, AccessMode a, CreateMode c, int fla
         case ENOTDIR:
         case ENXIO:
             throw AccessError(msg);
+        case EPERM:
+            msg = get_errno_msg("open() failed (insufficient permissions): ", err);
+            throw runtime_error(msg);
         default:
             throw runtime_error(msg);
     }


### PR DESCRIPTION
I hope my fix is correct. This PR aims to throw a clearer message when opening a readwrite realm file in a readonly path. Asana ticket: https://app.asana.com/0/861870036984/17678329857532

@tgoyne @kspangsege @finnschiermer is this right?
