### PR TITLE
Fix a crash when calling get_sorted_view() on an empty LinkList

### DIFF
--- a/release_notes.md
+++ b/release_notes.md
@@ -2,7 +2,7 @@
 
 ### Bugfixes:
 
-* Lorem ipsum.
+* Fixed a crash when calling get_sorted_view() on an empty LinkList.
 
 ### API breaking changes:
 

--- a/src/tightdb/link_view.cpp
+++ b/src/tightdb/link_view.cpp
@@ -272,9 +272,11 @@ TableView LinkView::get_sorted_view(vector<size_t> column_indexes, vector<bool> 
     v.m_last_seen_version = m_origin_table->m_version;
     // sets m_linkview_source to indicate that this TableView was generated from a LinkView
     v.m_linkview_source = ConstLinkViewRef(this);
-    for (size_t t = 0; t < m_row_indexes.size(); t++) // todo, simpler way?
-        v.m_row_indexes.add(get(t).get_index());
-    v.sort(column_indexes, ascending);
+    if (m_row_indexes.is_attached()) {
+        for (size_t t = 0; t < m_row_indexes.size(); t++) // todo, simpler way?
+            v.m_row_indexes.add(get(t).get_index());
+        v.sort(column_indexes, ascending);
+    }
     return v;
 }
 

--- a/test/test_link_query_view.cpp
+++ b/test/test_link_query_view.cpp
@@ -1007,6 +1007,21 @@ TEST(LinkList_SortLinkView)
 }
 
 
+TEST(Link_EmptySortedView)
+{
+    Group group;
+    TableRef source = group.add_table("source");
+    TableRef destination = group.add_table("destination");
+
+    source->add_column_link(type_LinkList, "link", *destination);
+    source->add_empty_row();
+    LinkViewRef lvr = source->get_linklist(0, 0);
+
+    CHECK_EQUAL(lvr->size(), 0);
+    CHECK_EQUAL(lvr->get_sorted_view(0).size(), 0);
+}
+
+
 TEST(Link_FindNullLink)
 {
     size_t match;


### PR DESCRIPTION
Reported at https://github.com/realm/realm-cocoa/issues/1255
