### PR TITLE
Extending Table::get_sorted_view() to support multi-column sorting.

### DIFF
--- a/release_notes.md
+++ b/release_notes.md
@@ -19,6 +19,7 @@
   Operators are provided so that VersionID's may be compared.
 * Creating distinct views on integer, datetime, bool and enum columns is now possible.
 * Add `Table::minimum_datetime()` and `Table::maximum_datetime()`.
+* Extending `Table::get_sorted_view()` to support multi-column sorting.
 
 -----------
 

--- a/src/tightdb/table.cpp
+++ b/src/tightdb/table.cpp
@@ -3308,6 +3308,18 @@ ConstTableView Table::get_sorted_view(size_t col_ndx, bool ascending) const
     return const_cast<Table*>(this)->get_sorted_view(col_ndx, ascending);
 }
 
+TableView Table::get_sorted_view(std::vector<size_t> col_ndx, std::vector<bool> ascending)
+{
+    TableView tv = where().find_all();
+    tv.sort(col_ndx, ascending);
+    return tv;
+}
+
+ConstTableView Table::get_sorted_view(std::vector<size_t> col_ndx, std::vector<bool> ascending) const
+{
+    return const_cast<Table*>(this)->get_sorted_view(col_ndx, ascending);
+}
+
 
 namespace {
 

--- a/src/tightdb/table.hpp
+++ b/src/tightdb/table.hpp
@@ -578,6 +578,9 @@ public:
     TableView      get_sorted_view(std::size_t column_ndx, bool ascending = true);
     ConstTableView get_sorted_view(std::size_t column_ndx, bool ascending = true) const;
 
+    TableView      get_sorted_view(std::vector<size_t> column_ndx, std::vector<bool> ascending);
+    ConstTableView get_sorted_view(std::vector<size_t> column_ndx, std::vector<bool> ascending) const;
+
     TableView      get_range_view(std::size_t begin, std::size_t end);
     ConstTableView get_range_view(std::size_t begin, std::size_t end) const;
 

--- a/test/test_table.cpp
+++ b/test/test_table.cpp
@@ -1147,6 +1147,64 @@ TEST(Table_Sorted_Query_where)
 #endif
 }
 
+TEST(Table_Multi_Sort)
+{
+    Table table;
+    table.add_column(type_Int, "first");
+    table.add_column(type_Int, "second");
+
+    table.add_empty_row(5);
+
+    // 1, 10
+    table.set_int(0, 0, 1);
+    table.set_int(1, 0, 10);
+
+    // 2, 10
+    table.set_int(0, 1, 2);
+    table.set_int(1, 1, 10);
+
+    // 0, 10
+    table.set_int(0, 2, 0);
+    table.set_int(1, 2, 10);
+
+    // 2, 14
+    table.set_int(0, 3, 2);
+    table.set_int(1, 3, 14);
+
+    // 1, 14
+    table.set_int(0, 4, 1);
+    table.set_int(1, 4, 14);
+
+    vector<size_t> col_ndx1;
+    col_ndx1.push_back(0);
+    col_ndx1.push_back(1);
+
+    vector<bool> asc;
+    asc.push_back(true);
+    asc.push_back(true);
+
+    // (0, 10); (1, 10); (1, 14); (2, 10); (2; 14)
+    TableView v_sorted1 = table.get_sorted_view(col_ndx1, asc);
+    CHECK_EQUAL(table.size(), v_sorted1.size());
+    CHECK_EQUAL(2, v_sorted1.get_source_ndx(0));
+    CHECK_EQUAL(0, v_sorted1.get_source_ndx(1));
+    CHECK_EQUAL(4, v_sorted1.get_source_ndx(2));
+    CHECK_EQUAL(1, v_sorted1.get_source_ndx(3));
+    CHECK_EQUAL(3, v_sorted1.get_source_ndx(4));
+
+    vector<size_t> col_ndx2;
+    col_ndx2.push_back(1);
+    col_ndx2.push_back(0);
+
+    // (0, 10); (1, 10); (2, 10); (1, 14); (2, 14)
+    TableView v_sorted2 = table.get_sorted_view(col_ndx2, asc);
+    CHECK_EQUAL(table.size(), v_sorted2.size());
+    CHECK_EQUAL(2, v_sorted2.get_source_ndx(0));
+    CHECK_EQUAL(0, v_sorted2.get_source_ndx(1));
+    CHECK_EQUAL(1, v_sorted2.get_source_ndx(2));
+    CHECK_EQUAL(4, v_sorted2.get_source_ndx(3));
+    CHECK_EQUAL(3, v_sorted2.get_source_ndx(4));
+}
 
 
 TEST(Table_IndexString)


### PR DESCRIPTION
I have extended `Table::get_sorted_view()` to support sorting on multiple columns so we get a consistent interface with `TableView::sort()`.

@rrrlasse @kspangsege @simonask 
