### PR TITLE
disabled test which use fork() on android

### DIFF
--- a/test/test_lang_bind_helper.cpp
+++ b/test/test_lang_bind_helper.cpp
@@ -6580,6 +6580,9 @@ TEST(LangBindHelper_SyncCannotBeChanged_2)
 #ifndef TIGHTDB_ENABLE_ENCRYPTION
 // Interprocess communication does not work with encryption enabled
 
+#if !defined(TIGHTDB_ANDROID) && !defined(TIGHTDB_IOS)
+// fork should not be used on android or ios.
+
 TEST(LangBindHelper_ImplicitTransactions_InterProcess)
 {
     const int write_process_count = 7;
@@ -6663,6 +6666,7 @@ TEST(LangBindHelper_ImplicitTransactions_InterProcess)
     }
 
 }
+#endif
 #endif
 #endif
 

--- a/test/test_shared.cpp
+++ b/test/test_shared.cpp
@@ -163,7 +163,7 @@ void killer(TestResults& test_results, int pid, string path, int id)
 
 } // anonymous namespace
 
-#if !defined(__APPLE__) && !defined(_WIN32)&& !defined TIGHTDB_ENABLE_ENCRYPTION
+#if !defined(__APPLE__) && !defined(_WIN32)&& !defined TIGHTDB_ENABLE_ENCRYPTION && !defined(TIGHTDB_ANDROID)
 
 TEST(Shared_PipelinedWritesWithKills)
 {
@@ -1162,6 +1162,8 @@ TEST(Shared_WriterThreads)
 
 
 #if defined TEST_ROBUSTNESS && defined ENABLE_ROBUST_AGAINST_DEATH_DURING_WRITE && !defined TIGHTDB_ENABLE_ENCRYPTION
+#if !defined TIGHTDB_ANDROID && !defined TIGHTDB_IOS
+
 // Not supported on Windows in particular? Keywords: winbug
 TEST(Shared_RobustAgainstDeathDuringWrite)
 {
@@ -1227,6 +1229,7 @@ TEST(Shared_RobustAgainstDeathDuringWrite)
     }
 }
 
+#endif // not ios or android
 #endif // defined TEST_ROBUSTNESS && defined ENABLE_ROBUST_AGAINST_DEATH_DURING_WRITE && !defined TIGHTDB_ENABLE_ENCRYPTION
 
 


### PR DESCRIPTION
This PR disables unittests using the fork() system call when running on android. This should allow us to start running the unittests on android again.
