### PR TITLE
further API improvement (of wait_for_change)

### DIFF
--- a/src/tightdb/group_shared.cpp
+++ b/src/tightdb/group_shared.cpp
@@ -808,6 +808,9 @@ void SharedGroup::open(const string& path, bool no_create_file,
             // Initially there is a single version in the file
             info->number_of_versions = 1;
 
+            // Initially wait_for_change is enabled
+            m_wait_for_change_enabled = true;
+
             // Keep the mappings and file open:
             fug_2.release(); // Do not unmap
             fug_1.release(); // Do not unmap
@@ -959,8 +962,7 @@ bool SharedGroup::wait_for_change()
 {
     SharedInfo* info = m_file_map.get_addr();
     RobustLockGuard lock(info->controlmutex, recover_from_dead_write_transact);
-    m_waiting_for_change = true;
-    while (m_readlock.m_version == info->latest_version_number && m_waiting_for_change) {
+    while (m_readlock.m_version == info->latest_version_number && m_wait_for_change_enabled) {
         info->new_commit_available.wait(info->controlmutex,
                                         &recover_from_dead_write_transact,
                                         0);
@@ -973,9 +975,18 @@ void SharedGroup::wait_for_change_release()
 {
     SharedInfo* info = m_file_map.get_addr();
     RobustLockGuard lock(info->controlmutex, recover_from_dead_write_transact);
-    m_waiting_for_change = false;
+    m_wait_for_change_enabled = false;
     info->new_commit_available.notify_all();
 }
+
+
+void SharedGroup::enable_wait_for_change()
+{
+    SharedInfo* info = m_file_map.get_addr();
+    RobustLockGuard lock(info->controlmutex, recover_from_dead_write_transact);
+    m_wait_for_change_enabled = true;
+}
+
 
 void SharedGroup::do_async_commits()
 {

--- a/src/tightdb/group_shared.hpp
+++ b/src/tightdb/group_shared.hpp
@@ -240,13 +240,17 @@ public:
     bool has_changed();
 
     /// The calling thread goes to sleep until the database is changed, or
-    /// until wait_for_change_release() is called. Return true if the database
-    /// has changed, false if it might have. At most one thread may wait in 
-    /// wait_for_change() on any single SharedGroup.
+    /// until wait_for_change_release() is called. After a call to wait_for_change_release()
+    /// further calls to wait_for_change() will return immediately. To restore
+    /// the ability to wait for a change, a call to enable_wait_for_change()
+    /// is required. Return true if the database has changed, false if it might have. 
     bool wait_for_change();
 
     /// release any thread waiting in wait_for_change() on *this* SharedGroup.
     void wait_for_change_release();
+
+    /// re-enable waiting for change
+    void enable_wait_for_change();
 
     // Transactions:
 
@@ -347,7 +351,7 @@ private:
     util::File m_file;
     util::File::Map<SharedInfo> m_file_map; // Never remapped
     util::File::Map<SharedInfo> m_reader_map;
-    bool m_waiting_for_change;
+    bool m_wait_for_change_enabled;
     std::string m_lockfile_path;
     std::string m_db_path;
     const char* m_key;


### PR DESCRIPTION
This ia continuation of PR #592, with an API that should be safer to use, as the previous one could easily be used in a way that would constitute a race condition.
