### PR TITLE
Adding `WriteTransaction::has_table()` and `WriteTransaction::rollback()` 

### DIFF
--- a/release_notes.md
+++ b/release_notes.md
@@ -10,7 +10,9 @@
 
 ### Enhancements:
 
-* Lorem ipsum.
+* `WriteTransaction::has_table()` and `WriteTransaction::rollback()` were
+  added. Previously, only implicit rollback was possible with
+  `WriteTransaction`.
 
 -----------
 

--- a/src/tightdb/group_shared.hpp
+++ b/src/tightdb/group_shared.hpp
@@ -508,6 +508,11 @@ public:
             m_shared_group->rollback();
     }
 
+    bool has_table(StringData name) const TIGHTDB_NOEXCEPT
+    {
+        return get_group().has_table(name);
+    }
+
     TableRef get_table(std::size_t table_ndx) const
     {
         return get_group().get_table(table_ndx); // Throws
@@ -554,6 +559,13 @@ public:
     {
         TIGHTDB_ASSERT(m_shared_group);
         m_shared_group->commit();
+        m_shared_group = 0;
+    }
+
+    void rollback() TIGHTDB_NOEXCEPT
+    {
+        TIGHTDB_ASSERT(m_shared_group);
+        m_shared_group->rollback();
         m_shared_group = 0;
     }
 

--- a/test/test_shared.cpp
+++ b/test/test_shared.cpp
@@ -2636,4 +2636,18 @@ TEST_IF(Shared_ArrayEraseBug, TEST_DURATION >= 1)
     }
 }
 
+
+TEST(Shared_ScopedRollback)
+{
+    SHARED_GROUP_TEST_PATH(path);
+    SharedGroup sg(path);
+    WriteTransaction wt(sg);
+    wt.add_table("foo");
+    wt.rollback();
+    // If wt.rollback() did nothing, then the next statement would cause a
+    // dead-lock. Know that this is part of the test.
+    WriteTransaction wt_2(sg);
+    CHECK_NOT(wt_2.has_table("foo"));
+}
+
 #endif // TEST_SHARED


### PR DESCRIPTION
Previously, only implicit rollback was possible with `WriteTransaction`.

@simonask 
