### PR TITLE
Update the file positions in File::read() and File::write() for encrypted files

### DIFF
--- a/release_notes.md
+++ b/release_notes.md
@@ -3,6 +3,7 @@
 ### Bugfixes:
 
 * Fixed out-of-bounds reads when using aggregate functions on sorted TableViews.
+* Fixed writing over 4KB of data to an encrypted file with Group::write().
 
 ### API breaking changes:
 

--- a/src/tightdb/util/file.cpp
+++ b/src/tightdb/util/file.cpp
@@ -354,6 +354,7 @@ error:
         off_t pos = lseek(m_fd, 0, SEEK_CUR);
         Map<char> map(*this, access_ReadOnly, static_cast<size_t>(pos + size));
         memcpy(data, map.get_addr() + pos, size);
+        lseek(m_fd, size, SEEK_CUR);
         return map.get_size() - pos;
     }
 
@@ -411,6 +412,7 @@ void File::write(const char* data, size_t size)
         off_t pos = lseek(m_fd, 0, SEEK_CUR);
         Map<char> map(*this, access_ReadWrite, static_cast<size_t>(pos + size));
         memcpy(map.get_addr() + pos, data, size);
+        lseek(m_fd, size, SEEK_CUR);
         return;
     }
 

--- a/test/test_file.cpp
+++ b/test/test_file.cpp
@@ -214,4 +214,21 @@ TEST(File_SetEncryptionKey)
 #endif
 }
 
+TEST(File_ReadWrite)
+{
+    TEST_PATH(path);
+    File f(path, File::mode_Write);
+    f.set_encryption_key(crypt_key(true));
+    f.resize(100);
+
+    for (char i = 0; i < 100; ++i)
+        f.write(&i, 1);
+    f.seek(0);
+    for (char i = 0; i < 100; ++i) {
+        char read;
+        f.read(&read, 1);
+        CHECK_EQUAL(i, read);
+    }
+}
+
 #endif // TEST_FILE


### PR DESCRIPTION
Makes writing multiple blocks of data actually work. With this change all of the unit tests now actually pass on an iPhone 6 with encryption enabled (I'd previously never managed to get the tests to run on device at all).

@rrrlasse 
