### PR TITLE
Fix duplicated results when querying on link columns at rows 1000+

### DIFF
--- a/release_notes.md
+++ b/release_notes.md
@@ -2,7 +2,7 @@
 
 ### Bugfixes:
 
-* Lorem ipsum.
+* Fixed duplicated results when querying on a link column with matches at row 1000+.
 
 ### API breaking changes:
 

--- a/src/tightdb/query_engine.hpp
+++ b/src/tightdb/query_engine.hpp
@@ -1772,7 +1772,7 @@ public:
         if (type == type_Link) {
             ColumnLinkBase& clb = const_cast<Table*>(m_table)->get_column_link_base(m_origin_column);
             ColumnLink& cl = static_cast<ColumnLink&>(clb);
-            ret = cl.find_first(m_target_row + 1, start); // ColumnLink stores link to row N as the integer N + 1
+            ret = cl.find_first(m_target_row + 1, start, end); // ColumnLink stores link to row N as the integer N + 1
         }
         else if (type == type_LinkList) {
             ColumnLinkBase& clb = const_cast<Table*>(m_table)->get_column_link_base(m_origin_column);

--- a/test/test_link_query_view.cpp
+++ b/test/test_link_query_view.cpp
@@ -1204,6 +1204,23 @@ TEST(LinkList_FindNotNullLink)
     CHECK_EQUAL(6, q1.find_all().size());
 }
 
+TEST(Link_FirstResultPastRow1000)
+{
+    Group g;
+
+    TableRef data_table = g.add_table("data_table");
+    TableRef link_table = g.add_table("link_table");
+    link_table->add_column_link(type_Link, "link", *data_table);
+
+    data_table->add_empty_row();
+    link_table->add_empty_row(1001);
+
+    link_table->set_link(0, 1000, 0);
+
+    TableView tv = link_table->where().links_to(0, 0).find_all();
+    CHECK_EQUAL(1, tv.size());
+}
+
 
 // Tests queries on a LinkList
 TEST(LinkList_QueryOnLinkList)


### PR DESCRIPTION
All matching rows were appearing in the resulting TableView ceil((row_ndx + 1) / 1000) times due to searching 1000 row blocks and  `end` not being passed along at one point. All other column types appear to be correct.

@rrrlasse 
