### PR TITLE
TIGHTDB_UNREACHABLE macro

### DIFF
--- a/src/tightdb/util/assert.hpp
+++ b/src/tightdb/util/assert.hpp
@@ -46,6 +46,10 @@
     tightdb::util::terminate(TIGHTDB_VER_CHUNK " Assertion failed: " #condition, __FILE__, __LINE__))
 
 
+#define TIGHTDB_UNREACHABLE() \
+    tightdb::util::terminate(TIGHTDB_VER_CHUNK " Unreachable code", __FILE__, __LINE__)
+
+
 #ifdef TIGHTDB_HAVE_CXX11_STATIC_ASSERT
 #  define TIGHTDB_STATIC_ASSERT(condition, message) static_assert(condition, message)
 #else

--- a/src/tightdb/util/features.h
+++ b/src/tightdb/util/features.h
@@ -252,12 +252,6 @@
     #define TIGHTDB_NOINLINE
 #endif
 
-#if defined(__GNUC__) || defined(__INTEL_COMPILER)
-    #define TIGHTDB_UNREACHABLE() __builtin_unreachable()
-#else
-    #define TIGHTDB_UNREACHABLE() do { abort(); } while(0)
-#endif
-
 
 #if defined ANDROID
 #  define TIGHTDB_ANDROID 1


### PR DESCRIPTION
Using `__builtin_unreachable()` where available, otherwise `abort()`.
