### PR TITLE
Fix aggregate functions on sorted TableViews

### DIFF
--- a/release_notes.md
+++ b/release_notes.md
@@ -2,7 +2,7 @@
 
 ### Bugfixes:
 
-* Lorem ipsum.
+* Fixed out-of-bounds reads when using aggregate functions on sorted TableViews.
 
 ### API breaking changes:
 

--- a/src/tightdb/table_view.cpp
+++ b/src/tightdb/table_view.cpp
@@ -115,7 +115,7 @@ R TableViewBase::aggregate(R(ColType::*aggregateMethod)(size_t, size_t, size_t, 
 
     for (size_t ss = 1; ss < m_row_indexes.size(); ++ss) {
         row_ndx = to_size_t(m_row_indexes.get(ss));
-        if (row_ndx >= leaf_end) {
+        if (row_ndx < leaf_start || row_ndx >= leaf_end) {
             column->GetBlock(row_ndx, arr, leaf_start);
             const size_t leaf_size = arr.size();
             leaf_end = leaf_start + leaf_size;

--- a/test/test_query.cpp
+++ b/test/test_query.cpp
@@ -5353,6 +5353,23 @@ TEST(Query_AllTypesDynamicallyTyped)
     CHECK_EQUAL(0.8, query.average_double(3));
 }
 
+TEST(Query_AggregateSortedView)
+{
+    Table table;
+    table.add_column(type_Double, "col");
+
+    const int count = TIGHTDB_MAX_BPNODE_SIZE * 2;
+    table.add_empty_row(count);
+    for (int i = 0; i < count; ++i)
+        table.set_double(0, i, i + 1); // no 0s to reduce chance of passing by coincidence
+
+    TableView tv = table.where().greater(0, 1.0).find_all();
+    tv.sort(0, false);
+
+    CHECK_EQUAL(2.0, tv.minimum_double(0));
+    CHECK_EQUAL(count, tv.maximum_double(0));
+    CHECK_APPROXIMATELY_EQUAL((count + 1) * count / 2, tv.sum_double(0), .1);
+}
 
 namespace {
     TIGHTDB_TABLE_1(TestQuerySub,


### PR DESCRIPTION
aggregate() assumed that row indexes were monotonically increasing, which is not always the case for sorted TableViews. Fixes https://github.com/realm/realm-cocoa/issues/1461.

@rrrlasse 
