### PR TITLE
disabled wait_for_change on apple

### DIFF
--- a/src/tightdb/group_shared.cpp
+++ b/src/tightdb/group_shared.cpp
@@ -967,6 +967,7 @@ bool SharedGroup::has_changed()
 }
 
 #ifndef _WIN32
+#ifndef __APPLE__
 bool SharedGroup::wait_for_change()
 {
     SharedInfo* info = m_file_map.get_addr();
@@ -993,7 +994,7 @@ void SharedGroup::enable_wait_for_change()
     RobustLockGuard lock(info->controlmutex, recover_from_dead_write_transact);
     m_wait_for_change_enabled = true;
 }
-
+#endif
 
 void SharedGroup::do_async_commits()
 {

--- a/src/tightdb/group_shared.hpp
+++ b/src/tightdb/group_shared.hpp
@@ -241,6 +241,7 @@ public:
     /// Has db been changed ?
     bool has_changed();
 
+#ifndef __APPLE__
     /// The calling thread goes to sleep until the database is changed, or
     /// until wait_for_change_release() is called. After a call to wait_for_change_release()
     /// further calls to wait_for_change() will return immediately. To restore
@@ -253,7 +254,7 @@ public:
 
     /// re-enable waiting for change
     void enable_wait_for_change();
-
+#endif
     // Transactions:
 
     struct VersionID {

--- a/test/test_shared.cpp
+++ b/test/test_shared.cpp
@@ -1990,7 +1990,7 @@ TEST_IF(Shared_AsyncMultiprocess, allow_async)
 
 #endif // !defined(_WIN32) && !defined(__APPLE__)
 
-#if !defined(_WIN32)
+#if !defined(_WIN32) && !defined(__APPLE__)
 
 namespace {
 
@@ -2113,7 +2113,8 @@ TEST(Shared_WaitForChange)
         threads[j].join();
 }
 
-#endif // endif not on windows
+#endif // endif not on windows (or apple)
+
 
 TEST(Shared_MultipleSharersOfStreamingFormat)
 {


### PR DESCRIPTION
since cocoa will implement interprocess in the binding and we know that cores
interprocess stuff does not work on apple, I'm disabling wait for change for apple.
