### PR TITLE
Filenames each on their own line in src/tightdb/Makefile

### DIFF
--- a/src/tightdb/Makefile
+++ b/src/tightdb/Makefile
@@ -1,43 +1,158 @@
 REPLICATION_HPP = $(if $(TIGHTDB_ENABLE_REPLICATION),replication.hpp)
 REPLICATION_CPP = $(if $(TIGHTDB_ENABLE_REPLICATION),replication.cpp)
 
-nobase_subinclude_HEADERS = util/features.h util/meta.hpp util/assert.hpp util/terminate.hpp \
-util/type_list.hpp util/tuple.hpp util/type_traits.hpp util/bind.hpp util/safe_int_ops.hpp \
-util/unique_ptr.hpp util/bind_ptr.hpp util/buffer.hpp util/string_buffer.hpp util/shared_ptr.hpp \
-util/memory_stream.hpp util/logger.hpp util/thread.hpp util/file.hpp util/utf8.hpp exceptions.hpp \
-utilities.hpp alloc.hpp alloc_slab.hpp array.hpp array_string.hpp data_type.hpp column_type.hpp \
-column_fwd.hpp spec.hpp impl/destroy_guard.hpp impl/output_stream.hpp datetime.hpp string_data.hpp \
-binary_data.hpp mixed.hpp table.hpp table_ref.hpp table_basic_fwd.hpp table_accessors.hpp \
-table_basic.hpp table_view.hpp table_view_basic.hpp table_macros.hpp row.hpp descriptor_fwd.hpp \
-descriptor.hpp group.hpp group_shared.hpp $(REPLICATION_HPP) query.hpp query_conditions.hpp \
-lang_bind_helper.hpp tightdb_nmmintrin.h importer.hpp version.hpp unicode.hpp commit_log.hpp \
-link_view_fwd.hpp link_view.hpp views.hpp util/platform_specific_condvar.hpp
+nobase_subinclude_HEADERS = \
+	$(REPLICATION_HPP) \
+	alloc.hpp \
+	alloc_slab.hpp \
+	array.hpp \
+	array_string.hpp \
+	binary_data.hpp \
+	column_fwd.hpp \
+	column_type.hpp \
+	commit_log.hpp \
+	data_type.hpp \
+	datetime.hpp \
+	descriptor.hpp \
+	descriptor_fwd.hpp \
+	exceptions.hpp \
+	group.hpp \
+	group_shared.hpp \
+	impl/destroy_guard.hpp \
+	impl/output_stream.hpp \
+	importer.hpp \
+	lang_bind_helper.hpp \
+	link_view.hpp \
+	link_view_fwd.hpp \
+	mixed.hpp \
+	query.hpp \
+	query_conditions.hpp \
+	row.hpp \
+	spec.hpp \
+	string_data.hpp \
+	table.hpp \
+	table_accessors.hpp \
+	table_basic.hpp \
+	table_basic_fwd.hpp \
+	table_macros.hpp \
+	table_ref.hpp \
+	table_view.hpp \
+	table_view_basic.hpp \
+	tightdb_nmmintrin.h \
+	unicode.hpp \
+	util/assert.hpp \
+	util/bind.hpp \
+	util/bind_ptr.hpp \
+	util/buffer.hpp \
+	util/features.h \
+	util/file.hpp \
+	util/logger.hpp \
+	util/memory_stream.hpp \
+	util/meta.hpp \
+	util/platform_specific_condvar.hpp \
+	util/safe_int_ops.hpp \
+	util/shared_ptr.hpp \
+	util/string_buffer.hpp \
+	util/terminate.hpp \
+	util/thread.hpp \
+	util/tuple.hpp \
+	util/type_list.hpp \
+	util/type_traits.hpp \
+	util/unique_ptr.hpp \
+	util/utf8.hpp \
+	utilities.hpp \
+	version.hpp \
+	views.hpp \
+
 
 nobase_subinclude_HEADERS_EXTRA_UNINSTALL = *.h *.hpp util/*.h util/*.hpp impl/*.h impl/*.hpp
 
 # Temporary hack due to public dependency on query_engine.hpp in
 # Lasses new "query expressions" implementation. None of these should
 # really be installed.
-nobase_subinclude_HEADERS += array_basic.hpp array_basic_tpl.hpp array_binary.hpp array_blob.hpp \
-array_blobs_big.hpp array_string_long.hpp column.hpp column_tpl.hpp column_basic.hpp \
-column_basic_tpl.hpp column_binary.hpp column_string_enum.hpp column_string.hpp column_table.hpp \
-column_link.hpp column_linklist.hpp column_linkbase.hpp column_backlink.hpp column_mixed.hpp \
-column_mixed_tpl.hpp group_writer.hpp index_string.hpp query_engine.hpp query_expression.hpp
+nobase_subinclude_HEADERS += \
+	array_basic.hpp \
+	array_basic_tpl.hpp \
+	array_binary.hpp \
+	array_blob.hpp \
+	array_blobs_big.hpp \
+	array_string_long.hpp \
+	column.hpp \
+	column_backlink.hpp \
+	column_basic.hpp \
+	column_basic_tpl.hpp \
+	column_binary.hpp \
+	column_link.hpp \
+	column_linkbase.hpp \
+	column_linklist.hpp \
+	column_mixed.hpp \
+	column_mixed_tpl.hpp \
+	column_string.hpp \
+	column_string_enum.hpp \
+	column_table.hpp \
+	column_tpl.hpp \
+	group_writer.hpp \
+	index_string.hpp \
+	query_engine.hpp \
+	query_expression.hpp \
+
 
 lib_LIBRARIES    = libtightdb.a
 libexec_PROGRAMS = tightdbd
 bin_PROGRAMS     = tightdb-import
 DEV_PROGRAMS     = tightdb-config
 
-libtightdb_a_SOURCES = util/encrypted_file_mapping.cpp util/errno.cpp util/file.cpp \
-util/file_mapper.cpp util/memory_stream.cpp util/string_buffer.cpp util/terminate.cpp \
-util/thread.cpp $(REPLICATION_CPP) alloc.cpp alloc_slab.cpp array.cpp array_binary.cpp \
-array_blob.cpp array_blobs_big.cpp array_string.cpp array_string_long.cpp column.cpp \
-column_backlink.cpp column_binary.cpp column_link.cpp column_link_base.cpp column_linklist.cpp \
-column_mixed.cpp column_string.cpp column_string_enum.cpp column_table.cpp commit_log.cpp \
-descriptor.cpp exceptions.cpp group.cpp group_shared.cpp group_writer.cpp impl/output_stream.cpp \
-importer.cpp index_string.cpp lang_bind_helper.cpp link_view.cpp query.cpp query_engine.cpp row.cpp spec.cpp \
-table.cpp table_view.cpp unicode.cpp utilities.cpp version.cpp views.cpp util/platform_specific_condvar.cpp
+libtightdb_a_SOURCES = \
+	$(REPLICATION_CPP) \
+	alloc.cpp \
+	alloc_slab.cpp \
+	array.cpp \
+	array_binary.cpp \
+	array_blob.cpp \
+	array_blobs_big.cpp \
+	array_string.cpp \
+	array_string_long.cpp \
+	column.cpp \
+	column_backlink.cpp \
+	column_binary.cpp \
+	column_link.cpp \
+	column_link_base.cpp \
+	column_linklist.cpp \
+	column_mixed.cpp \
+	column_string.cpp \
+	column_string_enum.cpp \
+	column_table.cpp \
+	commit_log.cpp \
+	descriptor.cpp \
+	exceptions.cpp \
+	group.cpp \
+	group_shared.cpp \
+	group_writer.cpp \
+	impl/output_stream.cpp \
+	importer.cpp \
+	index_string.cpp \
+	lang_bind_helper.cpp \
+	link_view.cpp \
+	query.cpp \
+	query_engine.cpp \
+	row.cpp \
+	spec.cpp \
+	table.cpp \
+	table_view.cpp \
+	unicode.cpp \
+	util/encrypted_file_mapping.cpp \
+	util/errno.cpp \
+	util/file.cpp \
+	util/file_mapper.cpp \
+	util/memory_stream.cpp \
+	util/platform_specific_condvar.cpp \
+	util/string_buffer.cpp \
+	util/terminate.cpp \
+	util/thread.cpp \
+	utilities.cpp \
+	version.cpp \
+	views.cpp \
+
 
 # Format: CURRENT[:REVISION[:AGE]]
 #


### PR DESCRIPTION
Makefile-Ordnung muss sein!

Motivation: Making it humanly feasible to merge branches that each add files.

Bonus: Paths are sorted alphabetically.

Please review @kspangsege @rrrlasse @finnschiermer 
