### PR TITLE
Eliminate unnecessary string copies when parsing the write log

### DIFF
--- a/release_notes.md
+++ b/release_notes.md
@@ -10,7 +10,7 @@
 
 ### Enhancements:
 
-* Lorem ipsum.
+* Improved performance of advance_read() over commits with string or binary data insertions.
 
 -----------
 


### PR DESCRIPTION
Use a StringData backed by the writelog buffer directly when possible. Makes `advance_read()` in the most extreme case (a commit consisting entirely of long string sets) about twice as fast.

@finnschiermer 
