### PR TITLE
Fix bug in File::resize() on Windows

### DIFF
--- a/src/tightdb/util/file.hpp
+++ b/src/tightdb/util/file.hpp
@@ -237,6 +237,9 @@ public:
     /// offsets, as long as the cucrrent process is not forked.
     void seek(SizeType);
 
+    // Return file position (like ftell())
+    SizeType get_file_position();
+
     /// Flush in-kernel buffers to disk. This blocks the caller until
     /// the synchronization operation is complete.
     void sync();


### PR DESCRIPTION
Bug that made TEST(File_ReadWrite) fail on Windows
