### PR TITLE
"Optional" type

### DIFF
--- a/test/test_optional.cpp
+++ b/test/test_optional.cpp
@@ -83,9 +83,9 @@ TEST(Optional_References)
 {
     int n = 0;
     Optional<int&> x { n };
-    fmap(x, [&](int& y) {
-        y = 123;
-    });
+    if (x) {
+        x.value() = 123;
+    }
     CHECK(x);
     CHECK_EQUAL(x.value(), 123);
     x = realm::none;
@@ -167,67 +167,13 @@ TEST(Optional_ReferenceBinding)
     ttt2 = iref;
 }
 
-TEST(Optional_VoidIsEquivalentToBool)
-{
-    auto a = some<void>();
-    CHECK_EQUAL(sizeof(a), sizeof(bool));
-    CHECK(a);
-    Optional<void> b = none;
-    CHECK_EQUAL(sizeof(b), sizeof(bool));
-    CHECK(!b);
-}
-
-TEST(Optional_fmap)
-{
-    Optional<int> a { 123 };
-    bool a_called = false;
-    auto ar = fmap(a, [&](int) {
-        a_called = true;
-    });
-    CHECK(a_called);
-    CHECK(ar);
-
-    Optional<int> b { 123 };
-    auto bs = fmap(b, [](int foo) {
-        std::stringstream ss;
-        ss << foo;
-        return ss.str();
-    });
-    CHECK(bs);
-    CHECK_EQUAL(*bs, "123");
-
-    Optional<int> c;
-    Optional<int> cx = fmap(c, [](int) { return 0; });
-    CHECK(!cx);
-}
-
-TEST(Optional_StreamingMap)
-{
-    Optional<int> a { 123 };
-
-    auto result = a
-        >> [](int b) { return b + 200; }
-        >> [](int c) {
-            std::ostringstream os;
-            os << c;
-            return os.str();
-        };
-    CHECK(result);
-    CHECK_EQUAL(result.value(), "323");
-
-    Optional<int> b { 500 };
-    Optional<int> result2 = b
-        >> [](int x) { return x > 300 ? some<int>(x + 300) : none; };
-    CHECK(result2);
-}
-
-TEST(Optional_Chaining)
-{
-    struct Foo {
-        int bar() { return 123; }
-    };
-    Optional<Foo> foo { Foo{} };
-    auto r = foo >> std::mem_fn(&Foo::bar);
-    CHECK(r);
-    CHECK_EQUAL(r.value(), 123);
-}
+// Disabled for compliance with std::optional
+// TEST(Optional_VoidIsEquivalentToBool)
+// {
+//     auto a = some<void>();
+//     CHECK_EQUAL(sizeof(a), sizeof(bool));
+//     CHECK(a);
+//     Optional<void> b = none;
+//     CHECK_EQUAL(sizeof(b), sizeof(bool));
+//     CHECK(!b);
+// }


### PR DESCRIPTION
Basically I was awake way too early, so I whipped up this little implementation of an `Optional` type that I've been propagandizing about for a while now. This is more an initiative for a discussion about the programming technique as well as the direction we want to go in terms of coding style, than it is a concrete request for a change (there is nothing right now that depends on this).
# What is it?

For `Optional<T>`, it is a `T` and a `bool` indicating whether the `T` is there. The representation attempts to be efficient by representing the bool as a single byte at the end of the storage area for better alignment.

This implementation follows a strict subset of the proposed [`std::optional`](http://en.cppreference.com/w/cpp/experimental/optional), which itself is a strict subset of `boost::optional` (except for type names).

The idea is to express the same thing that you would express with a nullable pointer, while limiting the risk of undefined behaviour by making it difficult to trigger the equivalent of dereferencing a null pointer. In addition, it achieves by-value semantics, as the `Optional<T>` owns the storage for `T`. It can also be used as an alternative to "magic" values that represent "nothingness" (consider for instance returning an empty `Optional<size_t>` instead of `size_t(-1)` to represent "not found").
# How is it used?

Pretty much how you'd expect.

``` c++
Optional<int> maybe_a_number { 123 };
if (maybe_a_number) {
    std::cout << *maybe_a_number << '\n';
    maybe_a_number = realm::none;
}
maybe_a_number.value() = 0; // throws, because we just set it to none.
```

`Optional<T>` supports move semantics if `T` supports move semantics.

You can also use `Optional` with reference types, in which case it becomes a simple (non-owning) pointer behind the scenes. This is useful because it's a way to enforce NULL checks through the type system (i.e., `Optional<T&>` is different from `T*` in that the former requires a NULL check to be dereferenced, while the latter just causes a segfault).
# fmap

In addition to the (unsafe) API demonstrated above, I've provided a simple `fmap` function that makes it impossible to create bugs (!) by collapsing the check and the dereference operation.

``` c++
Optional<int> maybe_a_number { 123 };
util::fmap(maybe_a_number, [](int number) {
    std::cout << number << '\n';
});
```

The idea is that you give it a lambda (or other function object) which takes the inner type `T` as an argument, but only gets called if the value is actually there.

The return type of `fmap` is `Optional<return type of the passed-in lambda>`, so you can chain things like this:

``` c++
Optional<int> maybe_a_number { 123 };
Optional<std::string> b = fmap(maybe_a_number, [](int n) {
    std::stringstream ss;
    ss << n;
    return ss.str();
});
```

You can also return an `Optional` from the lambda itself, in which case it will be collapsed — i.e. if the lambda returns `Optional<R>`, the return type of `fmap` does not become `Optional<Optional<R>>`, but just `Optional<R>` (also known as "monadic join").

There is a bit of syntactic sugar in the form of `operator>>(Optional<T>, F)`, which simply calls `fmap`, but makes it possible to structure code in a way that reflects control flow in a more readable way (and with a syntax that looks like the equivalent operation in Haskell, also known as "monadic bind"):

``` c++
Optional<int> a { 123 };
Optional<std::string> b = a >> [](int n) {
    std::stringstream ss;
    ss << n;
    return ss.str();
};
```

This is especially useful when chaining strings of options. For instance, calling a method on a member of something that may not exist can be expressed as:

``` c++
struct Foo {
    Bar bar();
};

Optional<Foo> maybe_foo = ...;
maybe_foo >> std::mem_fn(&Foo::bar) >> std::mem_fn(&Bar::something);
```

This should be read as: "If `maybe_foo` has a value, call `bar()` on it, and then call `something()` on the return value of that". If `Foo::bar()` returned an `Optional<Bar>` instead of `Bar`, this code would still work unchanged.
# Optional<void>

… is the same as a `bool` in this implementation. This is mainly convenient when you use lots of `fmap`s, but also kind of fun to think about. :-)

It means you can pass in a lambda to `fmap` that returns `void`, and the return value will be an `Optional<void>` that indicates whether or not the lambda was run.
