### PR TITLE
Fix string index corruption with move_last_over() and duplicate values

### DIFF
--- a/release_notes.md
+++ b/release_notes.md
@@ -8,6 +8,8 @@
   affect the data written to the compacted database, but later commits working on the outdated
   freelist might have. The fix forces proper (re)initialization of the free list.
 * Fixed incorrect results in querying on an indexed string column via a LinkView.
+* Fixed corruption of indexes when using move_last_over() on rows with
+  duplicated values for indexed properties.
 
 ### API breaking changes:
 

--- a/src/realm/index_string.cpp
+++ b/src/realm/index_string.cpp
@@ -662,9 +662,25 @@ void StringIndex::do_update_ref(StringData value, size_t row_ndx, size_t new_row
             else {
                 Column sub(alloc, to_ref(ref)); // Throws
                 sub.set_parent(array(), pos_refs);
-                size_t r = sub.find_first(row_ndx);
-                REALM_ASSERT(r != not_found);
-                sub.set(r, new_row_ndx);
+
+                size_t old_pos = sub.find_first(row_ndx);
+                size_t new_pos = sub.lower_bound_int(new_row_ndx);
+                REALM_ASSERT(old_pos != not_found);
+                REALM_ASSERT(size_t(sub.get(new_pos)) != new_row_ndx);
+
+                // shift each entry between the old and new position over one
+                if (new_pos < old_pos) {
+                    for (size_t i = old_pos; i > new_pos; --i)
+                        sub.set(i, sub.get(i - 1));
+                }
+                else if (new_pos > old_pos) {
+                    // we're removing the old entry from before the new entry,
+                    // so shift back one
+                    --new_pos;
+                    for (size_t i = old_pos; i < new_pos; ++i)
+                        sub.set(i, sub.get(i + 1));
+                }
+                sub.set(new_pos, new_row_ndx);
             }
         }
     }

--- a/test/test_index_string.cpp
+++ b/test/test_index_string.cpp
@@ -231,6 +231,76 @@ TEST(StringIndex_Delete)
     col.destroy();
 }
 
+TEST(StringIndex_MoveLastOver)
+{
+    ref_type ref = AdaptiveStringColumn::create(Allocator::get_default());
+    AdaptiveStringColumn col(Allocator::get_default(), ref);
+
+    col.add(s1);
+    col.add(s2);
+    col.add(s3);
+    col.add(s4);
+    col.add(s1); // duplicate value
+    col.add(s1); // duplicate value
+
+    col.create_search_index();
+
+    {
+        size_t index_ref;
+        FindRes fr = col.find_all_indexref(s1, index_ref);
+        CHECK_EQUAL(fr, FindRes_column);
+        if (fr != FindRes_column)
+            return;
+
+        Column matches(Column::unattached_root_tag(), col.get_alloc());
+        matches.get_root_array()->init_from_ref(index_ref);
+
+        CHECK_EQUAL(3, matches.size());
+        CHECK_EQUAL(0, matches.get(0));
+        CHECK_EQUAL(4, matches.get(1));
+        CHECK_EQUAL(5, matches.get(2));
+    }
+
+    // Remove a non-s1 row and change the order of the s1 rows
+    col.move_last_over(1);
+
+    {
+        size_t index_ref;
+        FindRes fr = col.find_all_indexref(s1, index_ref);
+        CHECK_EQUAL(fr, FindRes_column);
+        if (fr != FindRes_column)
+            return;
+
+        Column matches(Column::unattached_root_tag(), col.get_alloc());
+        matches.get_root_array()->init_from_ref(index_ref);
+
+        CHECK_EQUAL(3, matches.size());
+        CHECK_EQUAL(0, matches.get(0));
+        CHECK_EQUAL(1, matches.get(1));
+        CHECK_EQUAL(4, matches.get(2));
+    }
+
+    // Move a s1 row over a s1 row
+    col.move_last_over(1);
+
+    {
+        size_t index_ref;
+        FindRes fr = col.find_all_indexref(s1, index_ref);
+        CHECK_EQUAL(fr, FindRes_column);
+        if (fr != FindRes_column)
+            return;
+
+        Column matches(Column::unattached_root_tag(), col.get_alloc());
+        matches.get_root_array()->init_from_ref(index_ref);
+
+        CHECK_EQUAL(2, matches.size());
+        CHECK_EQUAL(0, matches.get(0));
+        CHECK_EQUAL(1, matches.get(1));
+    }
+
+    col.destroy();
+}
+
 TEST(StringIndex_ClearEmpty)
 {
     // Create a column with string values


### PR DESCRIPTION
Keep the list of rows for each value in the index in sorted order when rows are moved by move_last_over(), as the query code relies on that being the case.

@kspangsege @rrrlasse 
