### PR TITLE
[TestQuery] Add a failing test for the null string containing the empty ...

### DIFF
--- a/test/test_query.cpp
+++ b/test/test_query.cpp
@@ -589,6 +589,12 @@ TEST(Query_NextGen_StringConditions)
 
     m = table2->column<String>(0).contains(StringData("")).count();
     CHECK_EQUAL(m, 3);
+
+    m = table2->column<String>(0).begins_with(StringData("")).count();
+    CHECK_EQUAL(m, 3);
+
+    m = table2->column<String>(0).ends_with(StringData("")).count();
+    CHECK_EQUAL(m, 3);
 }
 
 


### PR DESCRIPTION
...string

@rrrlasse this is a failing test for what I believe to be a bug querying nullable string columns. If I do a `contains` with the empty string, the query is also returning a row that has a `null` in that column.

Update: same bug also exists for `begins_with` and `ends_with`
