### PR TITLE
Fixed slightly incorrect usage of open(). When the O_CREAT option is use...

### DIFF
--- a/test/test_encrypted_file_mapping.cpp
+++ b/test/test_encrypted_file_mapping.cpp
@@ -50,7 +50,7 @@ TEST(EncryptedFile_CryptorBasic)
     const char data[4096] = "test data";
     char buffer[4096];
 
-    int fd = open(path.c_str(), O_CREAT|O_RDWR);
+    int fd = open(path.c_str(), O_CREAT|O_RDWR, S_IRUSR|S_IWUSR|S_IRGRP|S_IROTH);
     cryptor.write(fd, 0, data, sizeof(data));
     cryptor.read(fd, 0, buffer, sizeof(buffer));
     CHECK(memcmp(buffer, data, strlen(data)) == 0);
@@ -65,7 +65,7 @@ TEST(EncryptedFile_CryptorRepeatedWrites)
 
     const char data[4096] = "test data";
     char raw_buffer_1[8192] = {0}, raw_buffer_2[9192] = {0};
-    int fd = open(path.c_str(), O_CREAT|O_RDWR);
+    int fd = open(path.c_str(), O_CREAT|O_RDWR, S_IRUSR|S_IWUSR|S_IRGRP|S_IROTH);
 
     cryptor.write(fd, 0, data, sizeof(data));
     lseek(fd, 0, SEEK_SET);
@@ -87,7 +87,7 @@ TEST(EncryptedFile_SeparateCryptors)
     const char data[4096] = "test data";
     char buffer[4096];
 
-    int fd = open(path.c_str(), O_CREAT|O_RDWR);
+    int fd = open(path.c_str(), O_CREAT|O_RDWR, S_IRUSR|S_IWUSR|S_IRGRP|S_IROTH);
     {
         AESCryptor cryptor((const uint8_t *)"12345678901234567890123456789012");
         cryptor.set_file_size(16);
@@ -109,7 +109,7 @@ TEST(EncryptedFile_InterruptedWrite)
 
     const char data[4096] = "test data";
 
-    int fd = open(path.c_str(), O_CREAT|O_RDWR);
+    int fd = open(path.c_str(), O_CREAT|O_RDWR, S_IRUSR|S_IWUSR|S_IRGRP|S_IROTH);
     {
         AESCryptor cryptor((const uint8_t *)"12345678901234567890123456789012");
         cryptor.set_file_size(16);


### PR DESCRIPTION
...d, the third parameter must be set. We set the file permissions to 644 (owner has read+write, group+others have only read).
