### PR TITLE
[TestQuery] Add tests for querying nullable string columns across a link

### DIFF
--- a/test/test_query.cpp
+++ b/test/test_query.cpp
@@ -648,6 +648,64 @@ TEST(Query_NextGen_StringConditions)
 
     m = table2->column<String>(0).contains(realm::null(), false).count();
     CHECK_EQUAL(m, 3);
+
+    TableRef table3 = group.add_table(StringData("table3"));
+    table3->add_column_link(type_Link, "link1", *table2);
+
+    table3->add_empty_row();
+    table3->set_link(0, 0, 0);
+    table3->add_empty_row();
+    table3->set_link(0, 1, 1);
+    table3->add_empty_row();
+    table3->set_link(0, 2, 2);
+    table3->add_empty_row();
+    table3->set_link(0, 3, 3);
+
+    m = table3->link(0).column<String>(0).contains(StringData("")).count();
+    CHECK_EQUAL(m, 3);
+
+    m = table3->link(0).column<String>(0).begins_with(StringData("")).count();
+    CHECK_EQUAL(m, 3);
+
+    m = table3->link(0).column<String>(0).ends_with(StringData("")).count();
+    CHECK_EQUAL(m, 3);
+
+    m = table3->link(0).column<String>(0).equal(StringData("")).count();
+    CHECK_EQUAL(m, 0);
+
+    m = table3->link(0).column<String>(0).not_equal(StringData("")).count();
+    CHECK_EQUAL(m, 4);
+
+    m = table3->link(0).column<String>(0).equal(realm::null()).count();
+    CHECK_EQUAL(m, 1);
+
+    m = table3->link(0).column<String>(0).not_equal(realm::null()).count();
+    CHECK_EQUAL(m, 3);
+
+
+    m = table3->link(0).column<String>(0).contains(StringData(""), false).count();
+    CHECK_EQUAL(m, 3);
+
+    m = table3->link(0).column<String>(0).begins_with(StringData(""), false).count();
+    CHECK_EQUAL(m, 3);
+
+    m = table3->link(0).column<String>(0).ends_with(StringData(""), false).count();
+    CHECK_EQUAL(m, 3);
+
+    m = table3->link(0).column<String>(0).equal(StringData(""), false).count();
+    CHECK_EQUAL(m, 0);
+
+    m = table3->link(0).column<String>(0).not_equal(StringData(""), false).count();
+    CHECK_EQUAL(m, 4);
+
+    m = table3->link(0).column<String>(0).equal(realm::null(), false).count();
+    CHECK_EQUAL(m, 1);
+
+    m = table3->link(0).column<String>(0).not_equal(realm::null(), false).count();
+    CHECK_EQUAL(m, 3);
+
+    m = table3->link(0).column<String>(0).contains(realm::null(), false).count();
+    CHECK_EQUAL(m, 3);
 }
 
 


### PR DESCRIPTION
These tests expose a bug in querying with `equal` or `not_equal` against a string column across a link.

\c @rrrlasse 
