### PR TITLE
Changed the upgrade tests to use the SHARED_GROUP_TEST_PATH macro to get...

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,8 +1,6 @@
 *.ncb
 *.suo
 *.swp
-*.realm.tmp
-*.realm.tmp.lock
 *~
 cscope.*
 tags

--- a/test/test_upgrade_database.cpp
+++ b/test/test_upgrade_database.cpp
@@ -52,6 +52,8 @@ using namespace realm::util;
 
 TEST(Upgrade_Database_2_3)
 {
+    const string path = test_util::get_test_path_prefix() + "test_upgrade_database_" + std::to_string(REALM_MAX_BPNODE_SIZE) + "_1.realm";
+
     // Test upgrading the database file format from version 2 to 3. When you open a version 2 file using SharedGroup
     // it gets converted automatically by Group::upgrade_file_format(). Files cannot be read or written (you cannot
     // even read using Get()) without upgrading the database first.
@@ -63,18 +65,17 @@ TEST(Upgrade_Database_2_3)
     // and this unit test will not upgrade the file. The REALM_NULL_STRINGS flag was introduced to be able to merge
     // null branch into master but without activating version 3 yet.
 #if 1
+    SHARED_GROUP_TEST_PATH(temp_copy);
 
 #if 0 // Not possible to upgrade from Group (needs write access to file)
     // Automatic upgrade from Group
     {
         // Make a copy of the version 2 database so that we keep the original file intact and unmodified
-        string path = test_util::get_test_path_prefix() + "test_upgrade_database_" + std::to_string(REALM_MAX_BPNODE_SIZE) + "_1.realm";
-
-        CHECK(File::copy(path, path + ".tmp"));
+        CHECK(File::copy(path, temp_copy);
 
         // Open copy. Group constructor will upgrade automatically if needed, also even though user requested ReadOnly. Todo,
         // discuss if this is OK.
-        Group g(path + ".tmp", 0, Group::mode_ReadOnly);
+        Group g(temp_copy, 0, Group::mode_ReadOnly);
         
         TableRef t = g.get_table("table");
 
@@ -111,11 +112,9 @@ TEST(Upgrade_Database_2_3)
     // Automatic upgrade from SharedGroup
     {
         // Make a copy of the version 2 database so that we keep the original file intact and unmodified
-        string path = test_util::get_test_path_prefix() + "test_upgrade_database_" + std::to_string(REALM_MAX_BPNODE_SIZE) + "_1.realm";
+        CHECK(File::copy(path, temp_copy));
 
-        CHECK(File::copy(path, path + ".tmp"));
-
-        SharedGroup sg(path + ".tmp");
+        SharedGroup sg(temp_copy);
         ReadTransaction rt(sg);
         ConstTableRef t = rt.get_table("table");
 
@@ -138,10 +137,7 @@ TEST(Upgrade_Database_2_3)
 
     // Now see if we can open the upgraded file and also commit to it
     {
-        // Make a copy of the version 2 database so that we keep the original file intact and unmodified
-        string path = test_util::get_test_path_prefix() + "test_upgrade_database_" + std::to_string(REALM_MAX_BPNODE_SIZE) + "_1.realm";
-
-        SharedGroup sg(path + ".tmp");
+        SharedGroup sg(temp_copy);
         WriteTransaction rt(sg);
         TableRef t = rt.get_table("table");
 
@@ -167,11 +163,9 @@ TEST(Upgrade_Database_2_3)
     // Begin from scratch; see if we can upgrade file and then use a write transaction
     {
         // Make a copy of the version 2 database so that we keep the original file intact and unmodified
-        string path = test_util::get_test_path_prefix() + "test_upgrade_database_" + std::to_string(REALM_MAX_BPNODE_SIZE) + "_1.realm";
+        CHECK(File::copy(path, temp_copy));
 
-        CHECK(File::copy(path, path + ".tmp"));
-
-        SharedGroup sg(path + ".tmp");
+        SharedGroup sg(temp_copy);
         WriteTransaction rt(sg);
         TableRef t = rt.get_table("table");
 
@@ -217,7 +211,6 @@ TEST(Upgrade_Database_2_3)
     // For creating a version 2 database; use in OLD (0.84) core
     char leafsize[20];
     sprintf(leafsize, "%d", REALM_MAX_BPNODE_SIZE);
-    string path = test_util::get_test_path_prefix() + "test_upgrade_database_" + leafsize + "_1.realm";
     File::try_remove(path);
 
     Group g;
@@ -246,12 +239,14 @@ TEST(Upgrade_Database_2_Backwards_Compatible)
 {
     // Copy/paste the bottommost commented-away unit test into test_group.cpp of Realm Core 0.84 or older to create a
     // version 2 database file. Then copy it into the /test directory of this current Realm core.
+    const string path = test_util::get_test_path_prefix() + "test_upgrade_database_" + std::to_string(REALM_MAX_BPNODE_SIZE) + "_2.realm";
 
 #if 1
     // Make a copy of the database so that we keep the original file intact and unmodified
-    string path = test_util::get_test_path_prefix() + "test_upgrade_database_" + std::to_string(REALM_MAX_BPNODE_SIZE) + "_2.realm";
-    CHECK(File::copy(path, path + ".tmp"));
-    SharedGroup g(path + ".tmp", 0);
+    SHARED_GROUP_TEST_PATH(temp_copy);
+
+    CHECK(File::copy(path, temp_copy));
+    SharedGroup g(temp_copy, 0);
 
     // First table is non-indexed for all columns, second is indexed for all columns
     for (size_t tbl = 0; tbl < 2; tbl++) {
@@ -333,7 +328,6 @@ TEST(Upgrade_Database_2_Backwards_Compatible)
     }
 #else
     // Create database file (run this from old core)
-    string path = test_util::get_test_path_prefix() + "test_upgrade_database_" + std::to_string(REALM_MAX_BPNODE_SIZE) + "_2.realm";
     File::try_remove(path);
 
     Group g;
@@ -388,12 +382,15 @@ TEST(Upgrade_Database_2_Backwards_Compatible_WriteTransaction)
 {
     // Copy/paste the bottommost commented-away unit test into test_group.cpp of Realm Core 0.84 or older to create a
     // version 2 database file. Then copy it into the /test directory of this current Realm core.
+    const string path = test_util::get_test_path_prefix() + "test_upgrade_database_" + std::to_string(REALM_MAX_BPNODE_SIZE) + "_2.realm";
 
 #if 1
     // Make a copy of the database so that we keep the original file intact and unmodified
-    string path = test_util::get_test_path_prefix() + "test_upgrade_database_" + std::to_string(REALM_MAX_BPNODE_SIZE) + "_2.realm";
-    CHECK(File::copy(path, path + ".tmp"));
-    SharedGroup g(path + ".tmp", 0);
+
+    SHARED_GROUP_TEST_PATH(temp_copy);
+
+    CHECK(File::copy(path, temp_copy));
+    SharedGroup g(temp_copy, 0);
 
     // First table is non-indexed for all columns, second is indexed for all columns
     for (size_t tbl = 0; tbl < 2; tbl++) {
@@ -473,7 +470,6 @@ TEST(Upgrade_Database_2_Backwards_Compatible_WriteTransaction)
     }
 #else
     // Create database file (run this from old core)
-    string path = test_util::get_test_path_prefix() + "test_upgrade_database_" + std::to_string(REALM_MAX_BPNODE_SIZE) + "_2.realm";
     File::try_remove(path);
 
     Group g;


### PR DESCRIPTION
... temporary realm file paths. Fixes #784 that was caused by multiple, concurrently running tests using the same path for temporary realm files. SHARED_GROUP_TEST_PATH temp files are automatically cleaned up, so .gitignore does not need the previous change.

@rrrlasse @simonask 
