### PR TITLE
Disable unit test LangBindHelper_ImplicitTransactions_InterProcess

### DIFF
--- a/test/test_lang_bind_helper.cpp
+++ b/test/test_lang_bind_helper.cpp
@@ -6564,7 +6564,7 @@ TEST(LangBindHelper_SyncCannotBeChanged_2)
         bool did_throw = false;
         try {
             SharedGroup sg(*repl);
-        } 
+        }
         catch (std::runtime_error& e)
         {
             std::string error_report = e.what();
@@ -6580,6 +6580,12 @@ TEST(LangBindHelper_SyncCannotBeChanged_2)
 
 #if !defined(REALM_ANDROID) && !defined(REALM_IOS)
 // fork should not be used on android or ios.
+
+/*
+
+This unit test has been disabled as it occasionally gets itself into a hang
+(which has plauged the testing process for a long time). It is unknown to me
+(Kristian) whether this is due to a bug in Core or a bug in this test.
 
 TEST(LangBindHelper_ImplicitTransactions_InterProcess)
 {
@@ -6664,6 +6670,9 @@ TEST(LangBindHelper_ImplicitTransactions_InterProcess)
     }
 
 }
+
+*/
+
 #endif
 #endif
 #endif


### PR DESCRIPTION
@finnschiermer @emanuelez 
