### PR TITLE
Replace method pointers in Array with vtable-like struct

### DIFF
--- a/src/realm/array.hpp
+++ b/src/realm/array.hpp
@@ -847,10 +847,6 @@ public:
     /// array is used.
     std::size_t get_width() const REALM_NOEXCEPT { return m_width; }
 
-    // FIXME: Should not be mutable
-    // FIXME: Should not be public
-    mutable char* m_data; // Points to first byte after header
-
     static char* get_data_from_header(char*) REALM_NOEXCEPT;
     static char* get_header_from_data(char*) REALM_NOEXCEPT;
     static const char* get_data_from_header(const char*) REALM_NOEXCEPT;
@@ -990,27 +986,12 @@ protected:
     void copy_on_write();
 
 private:
-    std::size_t m_ref;
 
     template<size_t w> int64_t sum(size_t start, size_t end) const;
     template<bool max, std::size_t w> bool minmax(int64_t& result, std::size_t start,
                                                   std::size_t end, std::size_t* return_ndx) const;
-protected:
-    std::size_t m_size;     // Number of elements currently stored.
-    std::size_t m_capacity; // Number of elements that fit inside the allocated memory.
-// FIXME: m_width Should be an 'int'
-    std::size_t m_width;    // Size of an element (meaning depend on type of array).
-    bool m_is_inner_bptree_node; // This array is an inner node of B+-tree.
-    bool m_has_refs;        // Elements whose first bit is zero are refs to subarrays.
-    bool m_context_flag;    // Meaning depends on context.
-
-private:
-    ArrayParent* m_parent;
-    std::size_t m_ndx_in_parent; // Ignored if m_parent is null.
 
 protected:
-    Allocator& m_alloc;
-
     /// The total size in bytes (including the header) of a new empty
     /// array. Must be a multiple of 8 (i.e., 64-bit aligned).
     static const std::size_t initial_capacity = 128;
@@ -1060,12 +1041,7 @@ protected:
     };
     template <size_t w> struct VTableForWidth;
 
-private:
-    const VTable* m_vtable;
-
 protected:
-    int64_t m_lbound;       // min number that can be stored with current m_width
-    int64_t m_ubound;       // max number that can be stored with current m_width
 
     /// Takes a 64-bit value and returns the minimum number of bits needed
     /// to fit the value. For alignment this is rounded up to nearest
@@ -1075,6 +1051,33 @@ protected:
 #ifdef REALM_DEBUG
     void report_memory_usage_2(MemUsageHandler&) const;
 #endif
+
+private:
+    Getter m_getter = nullptr; // cached to avoid indirection
+    const VTable* m_vtable = nullptr;
+
+public:
+    // FIXME: Should not be mutable
+    // FIXME: Should not be public
+    mutable char* m_data = nullptr; // Points to first byte after header
+
+protected:
+    int64_t m_lbound;       // min number that can be stored with current m_width
+    int64_t m_ubound;       // max number that can be stored with current m_width
+
+    std::size_t m_size = 0;     // Number of elements currently stored.
+    std::size_t m_capacity = 0; // Number of elements that fit inside the allocated memory.
+
+    Allocator& m_alloc;
+private:
+    std::size_t m_ref;
+    ArrayParent* m_parent = nullptr;
+    std::size_t m_ndx_in_parent = 0; // Ignored if m_parent is null.
+protected:
+    unsigned char m_width = 0;  // Size of an element (meaning depend on type of array).
+    bool m_is_inner_bptree_node; // This array is an inner node of B+-tree.
+    bool m_has_refs;        // Elements whose first bit is zero are refs to subarrays.
+    bool m_context_flag;    // Meaning depends on context.
 
     friend class SlabAlloc;
     friend class GroupWriter;
@@ -1305,9 +1308,6 @@ public:
 
 
 inline Array::Array(Allocator& alloc) REALM_NOEXCEPT:
-    m_data(0),
-    m_parent(0),
-    m_ndx_in_parent(0),
     m_alloc(alloc)
 {
 }
@@ -1366,7 +1366,7 @@ inline int64_t Array::get(std::size_t ndx) const REALM_NOEXCEPT
 {
     REALM_ASSERT_DEBUG(is_attached());
     REALM_ASSERT_DEBUG(ndx < m_size);
-    return (this->*(m_vtable->getter))(ndx);
+    return (this->*m_getter)(ndx);
 
 // Two ideas that are not efficient but may be worth looking into again:
 /*


### PR DESCRIPTION
We've talked about this change many times, and I was bored, so I decided to see what it would take. It turned out to be much easier than expected. :)

This reduces `sizeof(Array)` from 256 to 104 on x86-64, and should improve cache locality significantly.

@kspangsege @astigsen @rrrlasse 
