### PR TITLE
Ensure LinkViews get refreshed after rolling back a table clear

### DIFF
--- a/release_notes.md
+++ b/release_notes.md
@@ -24,8 +24,9 @@
 
 ### Bugfixes:
 
-* Lorem ipsum.
-* 
+* Fixed LinkViews containing incorrect data after a write transaction
+  containing a table clear is rolled back.
+
 ### API breaking changes:
 
 * Lorem ipsum.

--- a/src/realm/group.cpp
+++ b/src/realm/group.cpp
@@ -1185,6 +1185,8 @@ public:
         typedef _impl::TableFriend tf;
         if (unordered) {
             if (m_table) {
+                if (num_rows == 0)
+                    tf::mark_opposite_link_tables(*m_table);
                 while (num_rows--) {
                     tf::adj_acc_move_over(*m_table, row_ndx + num_rows, last_row_ndx - num_rows);
                 }
@@ -1656,14 +1658,6 @@ void Group::advance_transact(ref_type new_top_ref, size_t new_file_size,
 class Group::TransactReverser  {
 public:
 
-    TransactReverser() :
-        m_encoder(m_buffer), current_instr_start(0),
-        m_pending_table_select(false), m_pending_descriptor_select(false)
-    {
-    }
-
-    // override only the instructions which need to be reversed. (NullHandler class provides
-    // default implementatins for the rest)
     bool select_table(std::size_t group_level_ndx, size_t levels, const size_t* path)
     {
         sync_table();
@@ -1852,7 +1846,9 @@ public:
 
     bool clear_table()
     {
-        return true; // No-op
+        m_encoder.insert_empty_rows(0, 0, 0, true);
+        append_instruction();
+        return true;
     }
 
     bool add_search_index(size_t)
@@ -1951,12 +1947,12 @@ public:
 
 private:
     _impl::TransactLogBufferStream m_buffer;
-    _impl::TransactLogEncoder m_encoder;
+    _impl::TransactLogEncoder m_encoder{m_buffer};
     struct Instr { size_t begin; size_t end; };
     std::vector<Instr> m_instructions;
-    size_t current_instr_start;
-    bool m_pending_table_select;
-    bool m_pending_descriptor_select;
+    size_t current_instr_start = 0;
+    bool m_pending_table_select = false;
+    bool m_pending_descriptor_select = false;
     Instr m_pending_ts_instr;
     Instr m_pending_ds_instr;
 


### PR DESCRIPTION
Reversing `table->clear()` isn't quite a no-op, since while it doesn't need to update any row accessors, it does need to mark any tables linking to the table which was cleared as dirty so that any active LinkViews get refreshed (without the change, the final `CHECK_EQUAL` in the added test fails). The fix is kinda ugly. I couldn't think of any particularly nice ways to do it, so I just went with the simple way.

@finnschiermer 
