### PR TITLE
Refresh indexes on int columns on advance/rollback

### DIFF
--- a/release_notes.md
+++ b/release_notes.md
@@ -1,3 +1,12 @@
+# 0.89.5 Release notes
+
+### Bugfixes:
+
+* Fixed errors when a changes to a table with an indexed int column are rolled
+  back or advanced over.
+
+----------------------------------------------
+
 # 0.89.4 Release notes
 
 ### Enhancements:
@@ -6,6 +15,7 @@
   safely from any thread.
 * Improved performance of Query::find_all() with assertions enabled.
 
+----------------------------------------------
 
 # 0.89.3 Release notes
 

--- a/src/realm/column.cpp
+++ b/src/realm/column.cpp
@@ -1104,7 +1104,7 @@ ref_type Column::write(size_t slice_offset, size_t slice_size,
 }
 
 
-void Column::refresh_accessor_tree(size_t, const Spec&)
+void Column::refresh_accessor_tree(size_t new_col_ndx, const Spec& spec)
 {
     // With this type of column (Column), `m_array` is always an instance of
     // Array. This is true because all leafs are instances of Array, and when
@@ -1112,6 +1112,12 @@ void Column::refresh_accessor_tree(size_t, const Spec&)
     // is cached. This means that we never have to change the type of the cached
     // root array.
     m_array->init_from_parent();
+
+    if (m_search_index) {
+        size_t ndx_in_parent = m_array->get_ndx_in_parent();
+        m_search_index->get_root_array()->set_ndx_in_parent(ndx_in_parent + 1);
+        m_search_index->refresh_accessor_tree(new_col_ndx, spec);
+    }
 }
 
 

--- a/test/test_lang_bind_helper.cpp
+++ b/test/test_lang_bind_helper.cpp
@@ -5895,6 +5895,43 @@ TEST(LangBindHelper_AdvanceReadTransact_RemoveTableMovesTableWithLinksOver)
 }
 
 
+TEST(LangBindHelper_AdvanceReadTransact_IntIndex)
+{
+    SHARED_GROUP_TEST_PATH(path);
+
+    std::unique_ptr<Replication> repl(makeWriteLogCollector(path, false, crypt_key()));
+    SharedGroup sg(*repl, SharedGroup::durability_Full, crypt_key());
+    Group& g = const_cast<Group&>(sg.begin_read());
+
+    LangBindHelper::promote_to_write(sg);
+
+    TableRef target = g.add_table("target");
+    target->add_column(type_Int, "pk");
+    target->add_search_index(0);
+
+    target->add_empty_row(REALM_MAX_BPNODE_SIZE+1);
+
+    LangBindHelper::commit_and_continue_as_read(sg);
+
+    // open a second copy that'll be advanced over the write
+    std::unique_ptr<Replication> repl_r(makeWriteLogCollector(path, false, crypt_key()));
+    SharedGroup sg_r(*repl_r, SharedGroup::durability_Full, crypt_key());
+    Group& g_r = const_cast<Group&>(sg_r.begin_read());
+    TableRef t_r = g_r.get_table("target");
+
+    LangBindHelper::promote_to_write(sg);
+    // Ensure that the index has a different bptree layout so that failing to
+    // refresh it will do bad things
+    for (int i = 0; i < REALM_MAX_BPNODE_SIZE + 1; ++i)
+        target->set_int(0, i, i);
+    LangBindHelper::commit_and_continue_as_read(sg);
+
+    LangBindHelper::promote_to_write(sg_r);
+    // Crashes if index has an invalid parent ref
+    t_r->clear();
+}
+
+
 TEST(LangBindHelper_ImplicitTransactions)
 {
     SHARED_GROUP_TEST_PATH(path);
@@ -6297,6 +6334,35 @@ TEST(LangBindHelper_RollbackAndContinueAsRead_MoveLastOverSubtables)
     }
 }
 
+TEST(LangBindHelper_RollbackAndContinueAsRead_IntIndex)
+{
+    SHARED_GROUP_TEST_PATH(path);
+    std::unique_ptr<Replication> repl(makeWriteLogCollector(path, false, crypt_key()));
+    SharedGroup sg(*repl, SharedGroup::durability_Full, crypt_key());
+    Group& g = const_cast<Group&>(sg.begin_read());
+
+    LangBindHelper::promote_to_write(sg);
+
+    TableRef target = g.add_table("target");
+    target->add_column(type_Int, "pk");
+    target->add_search_index(0);
+
+    target->add_empty_row(REALM_MAX_BPNODE_SIZE+1);
+
+    LangBindHelper::commit_and_continue_as_read(sg);
+    LangBindHelper::promote_to_write(sg);
+
+    // Ensure that the index has a different bptree layout so that failing to
+    // refresh it will do bad things
+    for (int i = 0; i < REALM_MAX_BPNODE_SIZE + 1; ++i)
+        target->set_int(0, i, i);
+
+    LangBindHelper::rollback_and_continue_as_read(sg);
+    LangBindHelper::promote_to_write(sg);
+
+    // Crashes if index has an invalid parent ref
+    target->clear();
+}
 
 TEST(LangBindHelper_ImplicitTransactions_OverSharedGroupDestruction)
 {


### PR DESCRIPTION
Backport of #851 to stable since it turns out that users are hitting it. Fixes #853.

@finnschiermer We could use a release of stable after this is merged.
