### PR TITLE
Fix TableView's move constructor declaration

### DIFF
--- a/src/realm/table_view.hpp
+++ b/src/realm/table_view.hpp
@@ -293,7 +293,7 @@ class TableView: public TableViewBase {
 public:
     TableView();
     TableView(const TableView&) = default;
-    TableView(TableView&) = default;
+    TableView(TableView&&) = default;
     ~TableView() REALM_NOEXCEPT;
     TableView& operator=(const TableView&) = default;
     TableView& operator=(TableView&&) = default;


### PR DESCRIPTION
Fixes compilation in VC++ and makes move-constructing a tableview actually work.
