### PR TITLE
Add some missing `override`s

### DIFF
--- a/src/realm/column.hpp
+++ b/src/realm/column.hpp
@@ -427,7 +427,7 @@ public:
     void move_assign(TColumn<T, Nullable>&);
     bool IsIntColumn() const REALM_NOEXCEPT override;
 
-    std::size_t size() const REALM_NOEXCEPT;
+    std::size_t size() const REALM_NOEXCEPT override;
     bool is_empty() const REALM_NOEXCEPT { return size() == 0; }
 
     /// Provides access to the leaf that contains the element at the

--- a/src/realm/column_basic.hpp
+++ b/src/realm/column_basic.hpp
@@ -108,7 +108,7 @@ public:
     void refresh_accessor_tree(std::size_t, const Spec&) override;
 
 #ifdef REALM_DEBUG
-    void Verify() const;
+    void Verify() const override;
     void to_dot(std::ostream&, StringData title) const override;
     void do_dump_node_structure(std::ostream&, int) const override;
 #endif

--- a/src/realm/column_mixed.hpp
+++ b/src/realm/column_mixed.hpp
@@ -73,7 +73,7 @@ public:
     double get_double(std::size_t ndx) const REALM_NOEXCEPT;
     StringData get_string(std::size_t ndx) const REALM_NOEXCEPT;
     BinaryData get_binary(std::size_t ndx) const REALM_NOEXCEPT;
-    StringData get_index_data(std::size_t ndx, char* buffer) const REALM_NOEXCEPT;
+    StringData get_index_data(std::size_t ndx, char* buffer) const REALM_NOEXCEPT override;
 
     /// The returned array ref is zero if the specified row does not
     /// contain a subtable.

--- a/src/realm/commit_log.cpp
+++ b/src/realm/commit_log.cpp
@@ -87,12 +87,12 @@ public:
     void stop_logging() override;
     void reset_log_management(version_type last_version) override;
     virtual void set_last_version_seen_locally(version_type last_seen_version_number)
-        REALM_NOEXCEPT;
-    virtual void set_last_version_synced(version_type last_seen_version_number) REALM_NOEXCEPT;
+        REALM_NOEXCEPT override;
+    virtual void set_last_version_synced(version_type last_seen_version_number) REALM_NOEXCEPT override;
     virtual version_type get_last_version_synced(version_type* newest_version_number)
-        REALM_NOEXCEPT;
+        REALM_NOEXCEPT override;
     virtual void get_commit_entries(version_type from_version, version_type to_version,
-                                    BinaryData* logs_buffer) REALM_NOEXCEPT;
+                                    BinaryData* logs_buffer) REALM_NOEXCEPT override;
 
 protected:
     // file and memory mappings are always multiples of this size


### PR DESCRIPTION
Clang now has a warning for overriding virtual methods without marking them as `override`.
