### PR TITLE
Use int64_t to represent DateTime

### DIFF
--- a/src/realm/column_mixed_tpl.hpp
+++ b/src/realm/column_mixed_tpl.hpp
@@ -137,7 +137,7 @@ inline DateTime ColumnMixed::get_datetime(std::size_t ndx) const REALM_NOEXCEPT
 {
     REALM_ASSERT_3(m_types->get(ndx), ==, mixcol_Date);
 
-    return DateTime(std::time_t(get_value(ndx)));
+    return DateTime(get_value(ndx));
 }
 
 inline float ColumnMixed::get_float(std::size_t ndx) const REALM_NOEXCEPT

--- a/src/realm/datetime.hpp
+++ b/src/realm/datetime.hpp
@@ -32,10 +32,10 @@ public:
 
     /// Construct from the number of seconds since Jan 1 00:00:00 UTC
     /// 1970.
-    DateTime(std::time_t d) REALM_NOEXCEPT : m_time(d) {}
+    DateTime(int_fast64_t d) REALM_NOEXCEPT : m_time(d) {}
 
     /// Return the time as seconds since Jan 1 00:00:00 UTC 1970.
-    std::time_t get_datetime() const REALM_NOEXCEPT { return m_time; }
+    int_fast64_t get_datetime() const REALM_NOEXCEPT { return m_time; }
 
     friend bool operator==(const DateTime&, const DateTime&) REALM_NOEXCEPT;
     friend bool operator!=(const DateTime&, const DateTime&) REALM_NOEXCEPT;
@@ -71,11 +71,11 @@ public:
 private:
     // This is used by query_expression.hpp to generalize its templates and simplify the code *alot*; it is needed 
     // because DateTime is internally stored in an int64_t column.
-    operator time_t() REALM_NOEXCEPT;
+    operator int_fast64_t() REALM_NOEXCEPT;
 
 
 private:
-    std::time_t m_time; // Seconds since Jan 1 00:00:00 UTC 1970.
+    int_fast64_t m_time; // Seconds since Jan 1 00:00:00 UTC 1970.
     static std::time_t assemble(int year, int month, int day, int hours, int minutes, int seconds);
     template <typename T> friend class Value;
 };
@@ -113,7 +113,7 @@ inline bool operator>=(const DateTime& a, const DateTime& b) REALM_NOEXCEPT
     return a.m_time >= b.m_time;
 }
 
-inline DateTime::operator time_t() REALM_NOEXCEPT
+inline DateTime::operator int_fast64_t() REALM_NOEXCEPT
 {
     return m_time;
 }

--- a/src/realm/impl/transact_log.hpp
+++ b/src/realm/impl/transact_log.hpp
@@ -1554,7 +1554,7 @@ void TransactLogParser::parse_one(InstructionHandler& handler)
         case instr_SetDateTime: {
             std::size_t col_ndx = read_int<std::size_t>(); // Throws
             std::size_t row_ndx = read_int<std::size_t>(); // Throws
-            std::time_t value = read_int<std::time_t>(); // Throws
+            int_fast64_t value = read_int<int_fast64_t>(); // Throws
             if (!handler.set_date_time(col_ndx, row_ndx, value)) // Throws
                 parser_error();
             return;
@@ -1651,7 +1651,7 @@ void TransactLogParser::parse_one(InstructionHandler& handler)
             std::size_t col_ndx = read_int<std::size_t>(); // Throws
             std::size_t row_ndx = read_int<std::size_t>(); // Throws
             std::size_t tbl_sz = read_int<std::size_t>(); // Throws
-            std::time_t value = read_int<std::time_t>(); // Throws
+            int_fast64_t value = read_int<int_fast64_t>(); // Throws
             if (!handler.insert_date_time(col_ndx, row_ndx, tbl_sz, value)) // Throws
                 parser_error();
             return;
@@ -2052,7 +2052,7 @@ inline void TransactLogParser::read_mixed(Mixed* mixed)
             return;
         }
         case type_DateTime: {
-            std::time_t value = read_int<std::time_t>(); // Throws
+            int_fast64_t value = read_int<int_fast64_t>(); // Throws
             mixed->set_datetime(value);
             return;
         }

--- a/src/realm/mixed.hpp
+++ b/src/realm/mixed.hpp
@@ -151,7 +151,7 @@ private:
         float        m_float;
         double       m_double;
         const char*  m_data;
-        std::time_t  m_date;
+        int_fast64_t m_date;
     };
     std::size_t m_size = 0;
 };

--- a/src/realm/table.cpp
+++ b/src/realm/table.cpp
@@ -2505,11 +2505,11 @@ DateTime Table::get_datetime(size_t col_ndx, size_t ndx) const REALM_NOEXCEPT
 
     if (is_nullable(col_ndx)) {
         const ColumnIntNull& column = get_column_int_null(col_ndx);
-        return time_t(column.get(ndx));
+        return column.get(ndx);
     }
     else {
         const Column& column = get_column(col_ndx);
-        return time_t(column.get(ndx));
+        return column.get(ndx);
     }
 }
 
@@ -2522,11 +2522,11 @@ void Table::set_datetime(size_t col_ndx, size_t ndx, DateTime value)
 
     if (is_nullable(col_ndx)) {
         ColumnIntNull& column = get_column_int_null(col_ndx);
-        column.set(ndx, int64_t(value.get_datetime()));
+        column.set(ndx, value.get_datetime());
     }
     else {
         Column& column = get_column(col_ndx);
-        column.set(ndx, int64_t(value.get_datetime()));
+        column.set(ndx, value.get_datetime());
     }
 
 #ifdef REALM_ENABLE_REPLICATION

--- a/test/test_group.cpp
+++ b/test/test_group.cpp
@@ -1004,7 +1004,7 @@ TEST(Group_Serialize_All)
     CHECK_EQUAL(1, t->size());
     CHECK_EQUAL(12, t->get_int(0, 0));
     CHECK_EQUAL(true, t->get_bool(1, 0));
-    CHECK_EQUAL(time_t(12345), t->get_datetime(2, 0));
+    CHECK_EQUAL(12345, t->get_datetime(2, 0));
     CHECK_EQUAL("test", t->get_string(3, 0));
     CHECK_EQUAL(7, t->get_binary(4, 0).size());
     CHECK_EQUAL("binary", t->get_binary(4, 0).data());
@@ -1046,7 +1046,7 @@ TEST(Group_Persist)
     CHECK_EQUAL(1, table->size());
     CHECK_EQUAL(12, table->get_int(0, 0));
     CHECK_EQUAL(true, table->get_bool(1, 0));
-    CHECK_EQUAL(time_t(12345), table->get_datetime(2, 0));
+    CHECK_EQUAL(12345, table->get_datetime(2, 0));
     CHECK_EQUAL("test", table->get_string(3, 0));
     CHECK_EQUAL(7, table->get_binary(4, 0).size());
     CHECK_EQUAL("binary", table->get_binary(4, 0).data());
@@ -1067,7 +1067,7 @@ TEST(Group_Persist)
     CHECK_EQUAL(1, table->size());
     CHECK_EQUAL(12, table->get_int(0, 0));
     CHECK_EQUAL(true, table->get_bool(1, 0));
-    CHECK_EQUAL(time_t(12345), table->get_datetime(2, 0));
+    CHECK_EQUAL(12345, table->get_datetime(2, 0));
     CHECK_EQUAL("Changed!", table->get_string(3, 0));
     CHECK_EQUAL(7, table->get_binary(4, 0).size());
     CHECK_EQUAL("binary", table->get_binary(4, 0).data());

--- a/test/test_query.cpp
+++ b/test/test_query.cpp
@@ -5418,7 +5418,7 @@ TEST(Query_AllTypesDynamicallyTyped)
     const char bin[4] = { 0, 1, 2, 3 };
     BinaryData bin1(bin, sizeof bin / 2);
     BinaryData bin2(bin, sizeof bin);
-    time_t time_now = time(0);
+    int_fast64_t time_now = time(0);
     Mixed mix_int(int64_t(1));
     Mixed mix_subtab((Mixed::subtable_tag()));
 
@@ -5534,7 +5534,7 @@ TEST(Query_AllTypesStaticallyTyped)
     const char bin[4] = { 0, 1, 2, 3 };
     BinaryData bin1(bin, sizeof bin / 2);
     BinaryData bin2(bin, sizeof bin);
-    time_t time_now = time(0);
+    int_fast64_t time_now = time(0);
     TestQuerySub subtab;
     subtab.add(100);
     Mixed mix_int(int64_t(1));

--- a/test/test_table.cpp
+++ b/test/test_table.cpp
@@ -2774,7 +2774,7 @@ TEST(Table_Mixed2)
 
     CHECK_EQUAL(1,            table[0].first.get_int());
     CHECK_EQUAL(true,         table[1].first.get_bool());
-    CHECK_EQUAL(time_t(1234), table[2].first.get_datetime());
+    CHECK_EQUAL(1234,         table[2].first.get_datetime());
     CHECK_EQUAL("test",       table[3].first.get_string());
 }
 
@@ -3121,15 +3121,27 @@ REALM_TABLE_2(TableDateAndBinary,
 
 TEST(Table_DateAndBinary)
 {
-    TableDateAndBinary t;
+    {
+        TableDateAndBinary t;
 
-    const size_t size = 10;
-    char data[size];
-    for (size_t i=0; i<size; ++i) data[i] = (char)i;
-    t.add(8, BinaryData(data, size));
-    CHECK_EQUAL(t[0].date, 8);
-    CHECK_EQUAL(t[0].bin.size(), size);
-    CHECK(std::equal(t[0].bin.data(), t[0].bin.data()+size, data));
+        const size_t size = 10;
+        char data[size];
+        for (size_t i=0; i<size; ++i) data[i] = (char)i;
+        t.add(8, BinaryData(data, size));
+        CHECK_EQUAL(t[0].date, 8);
+        CHECK_EQUAL(t[0].bin.size(), size);
+        CHECK(std::equal(t[0].bin.data(), t[0].bin.data()+size, data));
+    }
+
+    // Test that 64-bit dates are preserved
+    {
+        TableDateAndBinary t;
+
+        int64_t date = std::numeric_limits<int64_t>::max() - 400;
+
+        t.add(date, BinaryData(""));
+        CHECK_EQUAL(t[0].date.get().get_datetime(), date);
+    }
 }
 
 // Test for a specific bug found: Calling clear on a group with a table with a subtable

--- a/test/test_transactions.cpp
+++ b/test/test_transactions.cpp
@@ -90,9 +90,9 @@ void round(TestResults& test_results, SharedGroup& db, int index)
         MyTable::Ref table = wt.get_or_add_table<MyTable>("my_table");
         if (table->is_empty()) {
             table->add();
-            table->add(0, false, moja, time_t(), "", EmptyNonNul, 0, Mixed(int64_t()));
+            table->add(0, false, moja, 0, "", EmptyNonNul, 0, Mixed(int64_t()));
             char binary_data[] = { 7, 6, 5, 7, 6, 5, 4, 3, 113 };
-            table->add(749321, true, kumi_na_tatu, time_t(99992), "click",
+            table->add(749321, true, kumi_na_tatu, 99992, "click",
                        BinaryData(binary_data), 0, Mixed("fido"));
         }
         wt.commit();
@@ -270,14 +270,14 @@ void round(TestResults& test_results, SharedGroup& db, int index)
         for (int i=0; i<n; ++i) {
             BinaryData bin("", 0);
             Mixed mix = int64_t(i);
-            subtable->add(0, false, moja,  time_t(), "alpha",   bin, 0, mix);
-            subtable->add(1, false, mbili, time_t(), "beta",    bin, 0, mix);
-            subtable->add(2, false, tatu,  time_t(), "gamma",   bin, 0, mix);
-            subtable->add(3, false, nne,   time_t(), "delta",   bin, 0, mix);
-            subtable->add(4, false, tano,  time_t(), "epsilon", bin, 0, mix);
-            subtable->add(5, false, sita,  time_t(), "zeta",    bin, 0, mix);
-            subtable->add(6, false, saba,  time_t(), "eta",     bin, 0, mix);
-            subtable->add(7, false, nane,  time_t(), "theta",   bin, 0, mix);
+            subtable->add(0, false, moja,  0, "alpha",   bin, 0, mix);
+            subtable->add(1, false, mbili, 0, "beta",    bin, 0, mix);
+            subtable->add(2, false, tatu,  0, "gamma",   bin, 0, mix);
+            subtable->add(3, false, nne,   0, "delta",   bin, 0, mix);
+            subtable->add(4, false, tano,  0, "epsilon", bin, 0, mix);
+            subtable->add(5, false, sita,  0, "zeta",    bin, 0, mix);
+            subtable->add(6, false, saba,  0, "eta",     bin, 0, mix);
+            subtable->add(7, false, nane,  0, "theta",   bin, 0, mix);
         }
         wt.commit();
     }
@@ -444,7 +444,7 @@ TEST(Transactions_General)
     CHECK_EQUAL(num_threads*num_rounds*4, table[0].alpha);
     CHECK_EQUAL(false,             table[0].beta);
     CHECK_EQUAL(moja,              table[0].gamma);
-    CHECK_EQUAL(time_t(0),         table[0].delta);
+    CHECK_EQUAL(0,                 table[0].delta);
     CHECK_EQUAL("",                table[0].epsilon);
     CHECK_EQUAL(3u,                table[0].eta->size());
     CHECK_EQUAL(0,                 table[0].theta);
@@ -452,7 +452,7 @@ TEST(Transactions_General)
     CHECK_EQUAL(749321,            table[1].alpha);
     CHECK_EQUAL(true,              table[1].beta);
     CHECK_EQUAL(kumi_na_tatu,      table[1].gamma);
-    CHECK_EQUAL(time_t(99992),     table[1].delta);
+    CHECK_EQUAL(99992,             table[1].delta);
     CHECK_EQUAL("click",           table[1].epsilon);
     CHECK_EQUAL(0u,                table[1].eta->size());
     CHECK_EQUAL(table1_theta_size, table[1].theta.get_subtable_size());


### PR DESCRIPTION
This allows for 64-bit precision on 32-bit platforms, where time_t is also 32-bit

This is needed to fix https://github.com/realm/realm-cocoa/issues/2152

\c @kspangsege @tgoyne 
