### PR TITLE
Unit test to check for heap leak in ColumnMixed::write

### DIFF
--- a/test/test_column_mixed.cpp
+++ b/test/test_column_mixed.cpp
@@ -404,4 +404,24 @@ TEST(ColumnMixed_SubtableSize)
 }
 
 
+TEST(ColumnMixed_WriteLeak)
+{
+    class NullBuffer : public std::streambuf { public: int overflow(int c) { return c; } };
+
+    NullBuffer null_buffer;
+    std::ostream null_stream(&null_buffer);
+    _impl::OutputStream out(null_stream);
+
+    ref_type ref = ColumnMixed::create(Allocator::get_default());
+    ColumnMixed c(Allocator::get_default(), ref, 0, 0);
+
+    c.insert_subtable(0, 0);
+    c.insert_subtable(1, 0);
+
+    c.write(0, 2, 2, out);
+
+    c.destroy();
+}
+
+
 #endif // TEST_COLUMN_MIXED


### PR DESCRIPTION
Connected to #932

This is a unit test to help in the diagnostics of #932. After checking with @kspangsege, it doesn't appear that there was any leak after all.

The original code in `ColumnMixed::write` tried to call `dg.release`, but that happened in a piece of unreachable code due to an early `return`. The call to `dg.release` was definitely wrong, as it would have created the leak, but luckily the early `return` prevented the leak.
