### PR TITLE
gcc 5.1 copy construction bug

### DIFF
--- a/test/test_optional.cpp
+++ b/test/test_optional.cpp
@@ -158,9 +158,9 @@ TEST(Optional_ReferenceBinding)
 {
     const int& iref = global_i;
     CHECK_EQUAL(&iref, &global_i);
-	// FIXME: The following line (assignment copy-constructor) fails on GCC 5.1.1 due to a regression in GCC:
-	// https://gcc.gnu.org/bugzilla/show_bug.cgi?id=66857
-	// Passing global_i as ctor argument fixes the issue.
+    // FIXME: The following line (assignment copy-constructor) fails on GCC 5.1.1 due to a regression in GCC:
+    // https://gcc.gnu.org/bugzilla/show_bug.cgi?id=66857
+    // Passing global_i as ctor argument fixes the issue.
     // TestingReferenceBinding ttt = global_i;
     TestingReferenceBinding ttt(global_i);
     ttt = global_i;


### PR DESCRIPTION
This PR fixes an issue with the new GCC 5.1.x compiler. With this compiler, the line

```
TestingReferenceBinding ttt = global_i;
```

Creates a temporary copy of `global_i`, which is what the `const int& ii` binds to, instead of binding directly to `global_i`. @rrrlasse and myself have found two workarounds:
- Use a non-const `global_i`;
- Call the constructor directly, without using the assignment huddle-jump.

Both of these work in all the tested compilers:
- gcc 5.1.1
- gcc 4.9.2
- clang 4.5.0.

As indicated in the comment, a bug [has been filed against](https://gcc.gnu.org/bugzilla/show_bug.cgi?id=66857) the GCC project to track this regression.
