### PR TITLE
Prelink static libraries

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -57,6 +57,8 @@ Static library*/
 /iphone-lib/include
 /iphone-lib/librealm-ios.a
 /iphone-lib/librealm-ios-dbg.a
+/iphone-lib/librealm-ios-prelink.a
+/iphone-lib/librealm-ios-dbg-prelink.a
 /iphone-lib/realm-config
 /iphone-lib/realm-config-dbg
 
@@ -64,6 +66,8 @@ Static library*/
 /watchos-lib/include
 /watchos-lib/librealm-watchos.a
 /watchos-lib/librealm-watchos-dbg.a
+/watchos-lib/librealm-watchos-prelink.a
+/watchos-lib/librealm-watchos-dbg-prelink.a
 /watchos-lib/realm-config
 /watchos-lib/realm-config-dbg
 

--- a/build.sh
+++ b/build.sh
@@ -690,8 +690,8 @@ EOF
         (
             cd src/realm
             export REALM_ENABLE_FAT_BINARIES="1"
-            REALM_ENABLE_FAT_BINARIES="1" $MAKE librealm.a EXTRA_CFLAGS="-fPIC -DPIC" || exit 1
-            REALM_ENABLE_FAT_BINARIES="1" $MAKE librealm-dbg.a EXTRA_CFLAGS="-fPIC -DPIC" || exit 1
+            REALM_ENABLE_FAT_BINARIES="1" $MAKE librealm-prelink.a EXTRA_CFLAGS="-fPIC -DPIC" || exit 1
+            REALM_ENABLE_FAT_BINARIES="1" $MAKE librealm-dbg-prelink.a EXTRA_CFLAGS="-fPIC -DPIC" || exit 1
         ) || exit 1
         exit 0
         ;;
@@ -724,10 +724,10 @@ EOF
                 word_list_append "cflags_arch" "-mios-simulator-version-min=7.0" || exit 1
             fi
             sdk_root="$xcode_home/Platforms/$platform.platform/Developer/SDKs/$sdk"
-            $MAKE -C "src/realm" "librealm-$platform.a" "librealm-$platform-dbg.a" BASE_DENOM="$platform" CFLAGS_ARCH="$cflags_arch -isysroot '$sdk_root'" || exit 1
+            $MAKE -C "src/realm" "librealm-$platform-prelink.a" "librealm-$platform-dbg-prelink.a" BASE_DENOM="$platform" CFLAGS_ARCH="$cflags_arch -isysroot '$sdk_root'" || exit 1
             mkdir "$temp_dir/platforms/$platform" || exit 1
-            cp "src/realm/librealm-$platform.a"     "$temp_dir/platforms/$platform/librealm.a"     || exit 1
-            cp "src/realm/librealm-$platform-dbg.a" "$temp_dir/platforms/$platform/librealm-dbg.a" || exit 1
+            cp "src/realm/librealm-$platform-prelink.a"     "$temp_dir/platforms/$platform/librealm.a"     || exit 1
+            cp "src/realm/librealm-$platform-dbg-prelink.a" "$temp_dir/platforms/$platform/librealm-dbg.a" || exit 1
         done
         REALM_ENABLE_FAT_BINARIES="1" $MAKE -C "src/realm" "realm-config-ios" "realm-config-ios-dbg" BASE_DENOM="ios" CFLAGS_ARCH="-fembed-bitcode -DREALM_CONFIG_IOS" AR="libtool" ARFLAGS="-o" || exit 1
         mkdir -p "$IPHONE_DIR" || exit 1
@@ -779,10 +779,10 @@ EOF
                 word_list_append "cflags_arch" "-mwatchos-simulator-version-min=2.0" || exit 1
             fi
             sdk_root="$xcode_home/Platforms/$platform.platform/Developer/SDKs/$sdk"
-            $MAKE -C "src/realm" "librealm-$platform.a" "librealm-$platform-dbg.a" BASE_DENOM="$platform" CFLAGS_ARCH="$cflags_arch -isysroot '$sdk_root'" || exit 1
+            $MAKE -C "src/realm" "librealm-$platform-prelink.a" "librealm-$platform-dbg-prelink.a" BASE_DENOM="$platform" CFLAGS_ARCH="$cflags_arch -isysroot '$sdk_root'" || exit 1
             mkdir "$temp_dir/platforms/$platform" || exit 1
-            cp "src/realm/librealm-$platform.a"     "$temp_dir/platforms/$platform/librealm.a"     || exit 1
-            cp "src/realm/librealm-$platform-dbg.a" "$temp_dir/platforms/$platform/librealm-dbg.a" || exit 1
+            cp "src/realm/librealm-$platform-prelink.a"     "$temp_dir/platforms/$platform/librealm.a"     || exit 1
+            cp "src/realm/librealm-$platform-dbg-prelink.a" "$temp_dir/platforms/$platform/librealm-dbg.a" || exit 1
         done
         REALM_ENABLE_FAT_BINARIES="1" $MAKE -C "src/realm" "realm-config-watchos" "realm-config-watchos-dbg" BASE_DENOM="watchos" CFLAGS_ARCH="-fembed-bitcode -DREALM_CONFIG_WATCHOS" AR="libtool" ARFLAGS="-o" || exit 1
         mkdir -p "$WATCHOS_DIR" || exit 1
@@ -942,8 +942,8 @@ EOF
             cp "src/realm/librealm-$platform.a" "$tmpdir/$BASENAME" || exit 1
             cp "src/realm/librealm-$platform-dbg.a" "$tmpdir/$BASENAME" || exit 1
         done
-        cp src/realm/librealm.a "$tmpdir/$BASENAME" || exit 1
-        cp src/realm/librealm-dbg.a "$tmpdir/$BASENAME" || exit 1
+        cp src/realm/librealm-prelink.a "$tmpdir/$BASENAME/librealm.a" || exit 1
+        cp src/realm/librealm-dbg-prelink.a "$tmpdir/$BASENAME/librealm-dbg.a" || exit 1
         cp tools/LICENSE "$tmpdir/$BASENAME" || exit 1
         if ! [ "$REALM_DISABLE_MARKDOWN_CONVERT" ]; then
             command -v pandoc >/dev/null 2>&1 || { echo "Pandoc is required but it's not installed.  Aborting." >&2; exit 1; }

--- a/src/generic.mk
+++ b/src/generic.mk
@@ -1788,9 +1788,7 @@ $(foreach x,$(INST_PROGRAMS) $(DEV_PROGRAMS),$(call EVAL_PROG_RULES_1,$(x),INST)
 define STATIC_LIBRARY_RULE
 $(1): $(2) $(3)
 	$$(RM) $(1)
-	$(CXX) $(CFLAGS_PTHREADS) $(CFLAGS_ARCH) -Wl,-r -nostdlib $(2) -o $(1).o
-	$$(strip $$(AR) $$(ARFLAGS_GENERAL) $(1) $(1).o)
-	$$(RM) $(1).o
+	$$(strip $$(AR) $$(ARFLAGS_GENERAL) $(1) $(2))
 endef
 
 # ARGS: real_local_path, objects, finalized_expanded_librefs, extra_deps, link_cmd, ldflags, lib_version

--- a/src/realm/Makefile
+++ b/src/realm/Makefile
@@ -226,3 +226,15 @@ get-inst-programs:
 
 
 include ../generic.mk
+
+librealm$(BASE_DENOM_2)$(LIB_DENOM_OPTIM)-prelink.a: librealm$(SUFFIX_LIB_STATIC_OPTIM)
+	$(RM) $@
+	$(CXX) -Wl,-r -nostdlib $(CFLAGS_PTHREADS) $(CFLAGS_ARCH) $(CFLAGS_OPTIM) $(call GET_OBJECTS_FOR_TARGET,librealm.a,$(SUFFIX_OBJ_STATIC_OPTIM)) -o $@.o
+	$(strip $(AR) $(ARFLAGS_GENERAL) $@ $@.o)
+	$(RM) $@.o
+
+librealm$(BASE_DENOM_2)$(LIB_DENOM_DEBUG)-prelink.a: librealm$(SUFFIX_LIB_STATIC_DEBUG)
+	$(RM) $@
+	$(CXX) -Wl,-r -nostdlib $(CFLAGS_PTHREADS) $(CFLAGS_ARCH) $(CFLAGS_DEBUG) $(call GET_OBJECTS_FOR_TARGET,librealm.a,$(SUFFIX_OBJ_STATIC_DEBUG)) -o $@.o
+	$(strip $(AR) $(ARFLAGS_GENERAL) $@ $@.o)
+	$(RM) $@.o


### PR DESCRIPTION
This makes it so that all object files for static libraries are combined into a single object file which is then placed in the static library rather than the original files. This eliminates the duplicated definitions of templates/inline functions/weak vtables/etc. in each object file, dramatically reducing the size of the static libraries. AFAIK the only downsides are that it results in slightly less useful linker errors when consuming the static library (as the applicable object file will always be the combined one), and it makes it harder for the linker to drop unused things, which increases the final size of the Realm framework by ~1%.

The size differences from this:

| Library | master | prelink |
| --- | --- | --- |
| librealm-dbg.a | 90M | 16M |
| librealm-ios-dbg.a | 363M | 186M |
| librealm-ios.a | 37M | 30M |
| librealm-watchos-dbg.a | 129M | 61M |
| librealm-watchos.a | 13M | 11M |
| librealm.a | 8.1M | 5.3M |

@kspangsege 
