### PR TITLE
Limit maximum system load during building

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -220,7 +220,7 @@ if ! printf "%s\n" "$MODE" | grep -q '^\(src-\|bin-\)\?dist'; then
         fi
     fi
     if [ "$NUM_PROCESSORS" ]; then
-        word_list_prepend MAKEFLAGS "-j$NUM_PROCESSORS" || exit 1
+        word_list_prepend MAKEFLAGS "-j$NUM_PROCESSORS -l$NUM_PROCESSORS" || exit 1
         export MAKEFLAGS
 
         if ! [ "$UNITTEST_THREADS" ]; then


### PR DESCRIPTION
For @emanuelez and @kspangsege:

This (minuscule) change allows make to auto-balance the system load. We're using the same value as the `-j` option. What this change means:

> While the system load is inferior to the number of cores/hyperthreads, maximise parallel builds. As soon as the limit is hit, reduce the number of parallel builds until the system recovers.

This is to limit the impact of the 4 jobs getting kicked off on FastLinux. It's a quad-core (2 HTs per core), so when the 4 jobs kick off, it's actually `make -j32` getting called, which pretty much kills the machine. This change equates to having a hard limit on -j8, regardless of the number of concurrent jobs being executed.

Impact: Builds should be faster.
