### PR TITLE
Add llvm-ar as an alternative archiver

### DIFF
--- a/src/generic.mk
+++ b/src/generic.mk
@@ -749,7 +749,7 @@ SHELL_ESCAPE = $(shell printf '%s\n' '$(call SHELL_ESCAPE_1,$(1))' | sed $(SHELL
 SHELL_ESCAPE_1 = $(subst $(APOSTROPHE),$(APOSTROPHE)\$(APOSTROPHE)$(APOSTROPHE),$(1))
 SHELL_ESCAPE_2 = 's/\([]$(TAB)$(SPACE)!"\#$$&'\''()*;<>?[\`{|}~]\)/\\\1/g'
 
-HAVE_CMD = $(shell which $(word 1,$(1)))
+HAVE_CMD = $(shell which $(word 1,$(1)) 2>/dev/null)
 
 # ARGS: command, prefix_to_class_map
 # Returns empty if identification fails


### PR DESCRIPTION
This PR allows for an alternative name of `clang-ar`, namely, `llvm-ar`, as seen on Fedora 22.

We might want to clean up this part: we're getting `which` failure messages a couple times when building the core, as well as during configuration steps and stuff. It adds a bit of unnecessary noise:

```
$ CXX=clang++ CC=clang sh build.sh check    
Using existing configuration in src/config.mk:
    REALM_VERSION         = 0.92.0-56-g9a16239
    INSTALL_PREFIX        = /usr/local
    INSTALL_EXEC_PREFIX   = /usr/local
    INSTALL_INCLUDEDIR    = /usr/local/include
    INSTALL_BINDIR        = /usr/local/bin
    INSTALL_LIBDIR        = /usr/local/lib64
    INSTALL_LIBEXECDIR    = /usr/local/libexec
    MAX_BPNODE_SIZE       = 4
    MAX_BPNODE_SIZE_DEBUG = 4
    ENABLE_ASSERTIONS     = yes
    ENABLE_ALLOC_SET_ZERO = yes
    ENABLE_ENCRYPTION     = no
    ENABLE_NULL_STRINGS   = yes
    XCODE_HOME            = none
    IPHONE_SDKS           = none
    IPHONE_SDKS_AVAIL     = no
    WATCHOS_SDKS          = none
    WATCHOS_SDKS_AVAIL    = no
    ANDROID_NDK_HOME      = none
which: no clang-ar in (/home/slau/bin:/usr/sbin:/sbin:/usr/local/bin:/usr/bin:/bin:/home/slau/.local/bin:/usr/local/games:/usr/games)
make[1]: Entering directory '/home/slau/src/realm/realm-core/src'
which: no clang-ar in (/home/slau/bin:/usr/sbin:/sbin:/usr/local/bin:/usr/bin:/bin:/home/slau/.local/bin:/usr/local/games:/usr/games)
make[2]: Entering directory '/home/slau/src/realm/realm-core/src/realm'
which: no clang-ar in (/home/slau/bin:/usr/sbin:/sbin:/usr/local/bin:/usr/bin:/bin:/home/slau/.local/bin:/usr/local/games:/usr/games)
clang++ -O3 -DNDEBUG -fPIC -DPIC -pthread -std=c++11 -I.. -Wall -Wextra -pedantic -Wunreachable-code -DREALM_HAVE_CONFIG -MMD -MP -c util/encrypted_file_mapping.cpp -o util/encrypted_file_mapping.pic.o
[...]
```

```
$ REALM_MAX_BPNODE_SIZE=4 REALM_MAX_BPNODE_SIZE_DEBUG=4 REALM_ENABLE_ALLOC_SET_ZERO=yes CXX=clang++ CC=clang sh build.sh config 
which: no clang-ar in (/home/slau/bin:/usr/sbin:/sbin:/usr/local/bin:/usr/bin:/bin:/home/slau/.local/bin:/usr/local/games:/usr/games)
which: no clang-ar in (/home/slau/bin:/usr/sbin:/sbin:/usr/local/bin:/usr/bin:/bin:/home/slau/.local/bin:/usr/local/games:/usr/games)
which: no clang-ar in (/home/slau/bin:/usr/sbin:/sbin:/usr/local/bin:/usr/bin:/bin:/home/slau/.local/bin:/usr/local/games:/usr/games)
which: no clang-ar in (/home/slau/bin:/usr/sbin:/sbin:/usr/local/bin:/usr/bin:/bin:/home/slau/.local/bin:/usr/local/games:/usr/games)
which: no clang-ar in (/home/slau/bin:/usr/sbin:/sbin:/usr/local/bin:/usr/bin:/bin:/home/slau/.local/bin:/usr/local/games:/usr/games)
New configuration in src/config.mk:
    REALM_VERSION         = 0.92.0-56-g9a16239
    INSTALL_PREFIX        = /usr/local
    INSTALL_EXEC_PREFIX   = /usr/local
    INSTALL_INCLUDEDIR    = /usr/local/include
    INSTALL_BINDIR        = /usr/local/bin
    INSTALL_LIBDIR        = /usr/local/lib64
    INSTALL_LIBEXECDIR    = /usr/local/libexec
    MAX_BPNODE_SIZE       = 4
    MAX_BPNODE_SIZE_DEBUG = 4
    ENABLE_ASSERTIONS     = yes
    ENABLE_ALLOC_SET_ZERO = yes
    ENABLE_ENCRYPTION     = no
    ENABLE_NULL_STRINGS   = yes
    XCODE_HOME            = none
    IPHONE_SDKS           = none
    IPHONE_SDKS_AVAIL     = no
    WATCHOS_SDKS          = none
    WATCHOS_SDKS_AVAIL    = no
    ANDROID_NDK_HOME      = none
Done configuring
```

PS: I realise having CXX/CC defined when calling `sh build.sh config` has no effect.

@kspangsege
