### PR TITLE
Fix asan errors when running tests with encryption enabled

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -1011,6 +1011,7 @@ EOF
         check_mode="$(printf "%s\n" "$MODE" | sed 's/asan/check/')" || exit 1
         auto_configure || exit 1
         touch "$CONFIG_MK" || exit 1 # Force complete rebuild
+        export ASAN_OPTIONS="detect_odr_violation=2"
         export REALM_HAVE_CONFIG="1"
         error=""
         if ! UNITTEST_THREADS="1" UNITTEST_PROGRESS="1" $MAKE EXTRA_CFLAGS="-fsanitize=address" EXTRA_LDFLAGS="-fsanitize=address" "$check_mode"; then

--- a/test/crypt_key.hpp
+++ b/test/crypt_key.hpp
@@ -27,7 +27,7 @@ namespace {
 
 const char* crypt_key(bool always=false)
 {
-    static const char key[] = "12345678901234567890123456789011234567890123456789012345678901";
+    static const char key[] = "1234567890123456789012345678901123456789012345678901234567890123";
     if (always) {
 #ifdef REALM_ENABLE_ENCRYPTION
         return key;

--- a/test/test_encrypted_file_mapping.cpp
+++ b/test/test_encrypted_file_mapping.cpp
@@ -42,11 +42,15 @@
 
 using namespace realm::util;
 
+namespace {
+const uint8_t test_key[] = "1234567890123456789012345678901123456789012345678901234567890123";
+}
+
 TEST(EncryptedFile_CryptorBasic)
 {
     TEST_PATH(path);
 
-    AESCryptor cryptor((const uint8_t *)"12345678901234567890123456789012");
+    AESCryptor cryptor(test_key);
     cryptor.set_file_size(16);
     const char data[4096] = "test data";
     char buffer[4096];
@@ -61,7 +65,7 @@ TEST(EncryptedFile_CryptorBasic)
 TEST(EncryptedFile_CryptorRepeatedWrites)
 {
     TEST_PATH(path);
-    AESCryptor cryptor((const uint8_t *)"12345678901234567890123456789012");
+    AESCryptor cryptor(test_key);
     cryptor.set_file_size(16);
 
     const char data[4096] = "test data";
@@ -90,12 +94,12 @@ TEST(EncryptedFile_SeparateCryptors)
 
     int fd = open(path.c_str(), O_CREAT|O_RDWR, S_IRUSR|S_IWUSR|S_IRGRP|S_IROTH);
     {
-        AESCryptor cryptor((const uint8_t *)"12345678901234567890123456789012");
+        AESCryptor cryptor(test_key);
         cryptor.set_file_size(16);
         cryptor.write(fd, 0, data, sizeof(data));
     }
     {
-        AESCryptor cryptor((const uint8_t *)"12345678901234567890123456789012");
+        AESCryptor cryptor(test_key);
         cryptor.set_file_size(16);
         cryptor.read(fd, 0, buffer, sizeof(buffer));
     }
@@ -112,7 +116,7 @@ TEST(EncryptedFile_InterruptedWrite)
 
     int fd = open(path.c_str(), O_CREAT|O_RDWR, S_IRUSR|S_IWUSR|S_IRGRP|S_IROTH);
     {
-        AESCryptor cryptor((const uint8_t *)"12345678901234567890123456789012");
+        AESCryptor cryptor(test_key);
         cryptor.set_file_size(16);
         cryptor.write(fd, 0, data, sizeof(data));
     }
@@ -125,7 +129,7 @@ TEST(EncryptedFile_InterruptedWrite)
     pwrite(fd, buffer, 64, 0);
 
     {
-        AESCryptor cryptor((const uint8_t *)"12345678901234567890123456789012");
+        AESCryptor cryptor(test_key);
         cryptor.set_file_size(16);
         cryptor.read(fd, 0, buffer, sizeof(buffer));
         CHECK(memcmp(buffer, data, strlen(data)) == 0);
@@ -142,7 +146,7 @@ TEST(EncryptedFile_LargePages)
     for (size_t i = 0; i < sizeof(data); ++i)
         data[i] = static_cast<char>(i);
 
-    AESCryptor cryptor((const uint8_t *)"12345678901234567890123456789012");
+    AESCryptor cryptor(test_key);
     cryptor.set_file_size(sizeof(data));
     char buffer[sizeof(data)];
 


### PR DESCRIPTION
The keys used in some tests were too short (63 bytes in one place, 32 bytes in another), but everything worked by coincidence due to the string literals used being in the middle of the data section.
