### PR TITLE
Remove m_auto_delete from ExpressionNode.

### DIFF
--- a/src/realm/query.cpp
+++ b/src/realm/query.cpp
@@ -223,9 +223,9 @@ Expression* Query::get_expression() {
     return (static_cast<ExpressionNode*>(first[first.size()-1]))->m_compare;
 }
 */
-Query& Query::expression(Expression* compare, bool auto_delete)
+Query& Query::expression(Expression* compare)
 {
-    ParentNode* const p = new ExpressionNode(compare, auto_delete);
+    ParentNode* const p = new ExpressionNode(compare);
     UpdatePointers(p, &p->m_child);
     return *this;
 }

--- a/src/realm/query.hpp
+++ b/src/realm/query.hpp
@@ -69,7 +69,7 @@ public:
 
     Query& operator = (const Query& source);
 
-    Query& expression(Expression* compare, bool auto_delete = false);
+    Query& expression(Expression* compare);
     Expression* get_expression();
 
     // Find links that point to a specific target row 

--- a/src/realm/query_engine.hpp
+++ b/src/realm/query_engine.hpp
@@ -1742,9 +1742,8 @@ class ExpressionNode: public ParentNode {
 public:
     ~ExpressionNode() REALM_NOEXCEPT { }
 
-    ExpressionNode(Expression* compare, bool auto_delete)
+    ExpressionNode(Expression* compare)
     {
-        m_auto_delete = auto_delete;
         m_child = nullptr;
         m_compare = util::SharedPtr<Expression>(compare);
         m_dD = 10.0;
@@ -1776,7 +1775,6 @@ public:
         m_child = from.m_child;
     }
 
-    bool m_auto_delete;
     util::SharedPtr<Expression> m_compare;
 };
 

--- a/src/realm/query_expression.hpp
+++ b/src/realm/query_expression.hpp
@@ -1238,7 +1238,7 @@ class UnaryLinkCompare : public Expression
 public:
     UnaryLinkCompare(LinkMap lm) : m_link_map(lm)
     {
-        Query::expression(this, true);
+        Query::expression(this);
         Table* t = const_cast<Table*>(get_table());
         Query::m_table = t->get_table_ref();
     }
@@ -1564,7 +1564,7 @@ public:
             m_left(left), m_right(const_cast<TRight&>(right)), m_compare_string(compare_string)
     {
         m_auto_delete = auto_delete;
-        Query::expression(this, auto_delete);
+        Query::expression(this);
         Table* t = const_cast<Table*>(get_table()); // todo, const
 
         if (t)


### PR DESCRIPTION
It hasn't been used since ExpressionNode started sharing ownership of
its Expression in be6dff634ffaef97eb1d0e4547a73206333e0fc0.

/cc @rrrlasse 
