### PR TITLE
Removed column methods is_int_column() and is_string_col()

### DIFF
--- a/src/realm/column.hpp
+++ b/src/realm/column.hpp
@@ -132,11 +132,6 @@ public:
     /// should ignore this argument.
     virtual void clear(std::size_t num_rows, bool broken_reciprocal_backlinks) = 0;
 
-    virtual bool is_int_column() const REALM_NOEXCEPT { return false; }
-
-    // Returns true if, and only if this column is an StringColumn.
-    virtual bool is_string_col() const REALM_NOEXCEPT;
-
     virtual void destroy() REALM_NOEXCEPT = 0;
     void move_assign(ColumnBase& col) REALM_NOEXCEPT;
 
@@ -412,7 +407,6 @@ public:
     MemRef clone_deep(Allocator&) const override;
 
     void move_assign(Column<T, Nullable>&);
-    bool is_int_column() const REALM_NOEXCEPT override;
 
     std::size_t size() const REALM_NOEXCEPT override;
     bool is_empty() const REALM_NOEXCEPT { return size() == 0; }
@@ -577,11 +571,6 @@ private:
 
 
 // Implementation:
-
-inline bool ColumnBase::is_string_col() const REALM_NOEXCEPT
-{
-    return false;
-}
 
 inline bool ColumnBase::has_search_index() const REALM_NOEXCEPT
 {
@@ -969,12 +958,6 @@ void Column<T,N>::move_assign(Column<T,N>& col)
 {
     ColumnBaseWithIndex::move_assign(col);
     m_tree = std::move(col.m_tree);
-}
-
-template <class T, bool N>
-bool Column<T,N>::is_int_column() const REALM_NOEXCEPT
-{
-    return std::is_integral<T>::value;
 }
 
 template <class T, bool N>

--- a/src/realm/column_string.hpp
+++ b/src/realm/column_string.hpp
@@ -131,8 +131,6 @@ public:
     ref_type write(std::size_t, std::size_t, std::size_t,
                    _impl::OutputStream&) const override;
 
-    bool is_string_col() const REALM_NOEXCEPT override;
-
     void insert_rows(size_t, size_t, size_t) override;
     void erase_rows(size_t, size_t, size_t, bool) override;
     void move_last_row_over(size_t, size_t, bool) override;
@@ -337,11 +335,6 @@ inline std::size_t StringColumn::get_size_from_ref(ref_type root_ref,
         return ArrayBigBlobs::get_size_from_header(root_header);
     }
     return Array::get_bptree_size_from_header(root_header);
-}
-
-inline bool StringColumn::is_string_col() const REALM_NOEXCEPT
-{
-    return true;
 }
 
 // Implementing pure virtual method of ColumnBase.

--- a/src/realm/table.cpp
+++ b/src/realm/table.cpp
@@ -4855,7 +4855,7 @@ void Table::refresh_column_accessors(size_t col_ndx_begin)
         // If the current column accessor is StringColumn, but the underlying
         // column has been upgraded to an enumerated strings column, then we
         // need to replace the accessor with an instance of StringEnumColumn.
-        if (col && col->is_string_col()) {
+        if (dynamic_cast<StringColumn*>(col) != nullptr) {
             ColumnType col_type = m_spec.get_column_type(col_ndx);
             if (col_type == col_type_StringEnum) {
                 delete col;


### PR DESCRIPTION
NOTE: This changes a virtual method call in `Table::refresh_column_accessors` to be a `dynamic_cast`. This is inherently safer, but can also potentially perform worse. There are already tons of virtual method calls in that function, so I worked on the assumption that it wasn't highly performance sensitive.

@rrrlasse @kspangsege 
