### PR TITLE
4K size array on stack is not a good practice

### DIFF
--- a/release_notes.md
+++ b/release_notes.md
@@ -7,6 +7,8 @@
 * `Spec` and thereby `Descriptor` and `Table` equality has been fixed. Now
   handles attributes (nullability etc), sub tables, optimized string columns
   and target link types correctly.
+* A stackoverflow issue in encrypted_file_mapping. Allocing 4k bytes on the
+  stack would cause some random crashes on small stack size configurations.
 
 ### API breaking changes:
 

--- a/src/realm/util/encrypted_file_mapping.hpp
+++ b/src/realm/util/encrypted_file_mapping.hpp
@@ -99,6 +99,7 @@ private:
 
     uint8_t m_hmacKey[32];
     std::vector<iv_table> m_iv_buffer;
+    std::unique_ptr<char[]> m_rw_buffer;
 
     void calc_hmac(const void* src, size_t len, uint8_t* dst, const uint8_t* key) const;
     bool check_hmac(const void *data, size_t len, const uint8_t *hmac) const;


### PR DESCRIPTION
It might cause lots of random crashes.

This caused crash with encryption on my genymotion. Probably the root cause of other crashes on low mem device.
