### PR TITLE
Added missing file mode flags to open() call with O_CREAT

### DIFF
--- a/test/test_encrypted_file_mapping.cpp
+++ b/test/test_encrypted_file_mapping.cpp
@@ -150,7 +150,7 @@ TEST(EncryptedFile_LargePages)
     cryptor.set_file_size(sizeof(data));
     char buffer[sizeof(data)];
 
-    int fd = open(path.c_str(), O_CREAT|O_RDWR);
+    int fd = open(path.c_str(), O_CREAT|O_RDWR, S_IRUSR|S_IWUSR|S_IRGRP|S_IROTH);
     cryptor.write(fd, 0, data, sizeof(data));
     cryptor.read(fd, 0, buffer, sizeof(buffer));
     CHECK(memcmp(buffer, data, sizeof(data)) == 0);


### PR DESCRIPTION
This seems to break the (compilation of) `EncryptedFile_LargePages` unit test on FastLinux.

@kspangsege @finnschiermer @simonask 
