### PR TITLE
Some improvements in NullableVector and Value

### DIFF
--- a/src/realm/query_expression.hpp
+++ b/src/realm/query_expression.hpp
@@ -636,9 +636,11 @@ template <class T, size_t prealloc = 8> struct NullableVector
 
     NullableVector& operator= (const NullableVector& other)
     {
-        init(other.m_size);
-        std::copy(other.m_first, other.m_first + other.m_size, m_first);
-        m_null = other.m_null;
+        if (this != &other) {
+            init(other.m_size);
+            std::copy(other.m_first, other.m_first + other.m_size, m_first);
+            m_null = other.m_null;
+        }
         return *this;
     }
 


### PR DESCRIPTION
This addresses a few things that I noticed while working in this code recently:
1. `NullableVector`'s copy constructor doesn't compile.
2. `NullableVector`'s copy assignment operator unnecessarily recomputes the null sentinel.
3. `Value::clone` doesn't preserve `from_link` and `m_value`.
4. `Value::export2` emits many warnings about implicit conversions when building.
5. `Value::export2` can avoid poking at `NullableVector`'s internals with small changes.

/cc @rrrlasse 
