### PR TITLE
Fix failures in LangBindHelper_AdvanceReadTransact_TransactLog on Windows

### DIFF
--- a/test/util/test_path.cpp
+++ b/test/util/test_path.cpp
@@ -23,10 +23,25 @@ void keep_test_files()
     keep_files = true;
 }
 
+#ifdef _WIN32
+std::string sanitize_for_file_name(std::string str)
+{
+    static const std::string invalid("<>:\"|?*\\/");
+    std::transform(str.begin(), str.end(), str.begin(), [](char c) {
+        if (invalid.find(c) != std::string::npos)
+            return '-';
+        return c;
+    });
+    return str;
+}
+#else
+std::string sanitize_for_file_name(const std::string& str) { return str; }
+#endif
+
 std::string get_test_path(const TestDetails& test_details, const std::string& suffix)
 {
     std::string path = path_prefix;
-    path += test_details.test_name;
+    path += sanitize_for_file_name(test_details.test_name);
     path += suffix;
     return path;
 }


### PR DESCRIPTION
The test fails when attempting to remove the Realm file as the name contains characters that cannot exist in file names on Windows, namely < and >. Fix this by replacing the invalid characters with dashes.
