### PR TITLE
Add exception.hpp for necessary declaration

### DIFF
--- a/src/realm/Makefile
+++ b/src/realm/Makefile
@@ -2,6 +2,7 @@ nobase_subinclude_HEADERS = \
 util/features.h \
 util/meta.hpp \
 util/assert.hpp \
+util/encryption_not_supported_exception.hpp \
 util/terminate.hpp \
 util/type_list.hpp \
 util/tuple.hpp \

--- a/src/realm/util/encrypted_file_mapping.hpp
+++ b/src/realm/util/encrypted_file_mapping.hpp
@@ -165,10 +165,6 @@ struct DecryptionFailed: util::File::AccessError {
     DecryptionFailed(): util::File::AccessError("Decryption failed", std::string()) {}
 };
 
-struct EncryptionNotSupportedOnThisDevice: std::runtime_error {
-    EncryptionNotSupportedOnThisDevice(): std::runtime_error("Encryption is not supported on this device") { }
-};
-
 }
 }
 

--- a/src/realm/util/encryption_not_supported_exception.hpp
+++ b/src/realm/util/encryption_not_supported_exception.hpp
@@ -1,0 +1,36 @@
+/*************************************************************************
+ *
+ * REALM CONFIDENTIAL
+ * __________________
+ *
+ *  [2011] - [2015] Realm Inc
+ *  All Rights Reserved.
+ *
+ * NOTICE:  All information contained herein is, and remains
+ * the property of Realm Incorporated and its suppliers,
+ * if any.  The intellectual and technical concepts contained
+ * herein are proprietary to Realm Incorporated
+ * and its suppliers and may be covered by U.S. and Foreign Patents,
+ * patents in process, and are protected by trade secret or copyright law.
+ * Dissemination of this information or reproduction of this material
+ * is strictly forbidden unless prior written permission is obtained
+ * from Realm Incorporated.
+ *
+ **************************************************************************/
+
+#ifndef REALM_UTIL_ENCRYPTION_NOT_SUPPORTED_EXCEPTION_HPP
+#define REALM_UTIL_ENCRYPTION_NOT_SUPPORTED_EXCEPTION_HPP
+
+#include <stdexcept>
+
+namespace realm {
+namespace util {
+
+struct EncryptionNotSupportedOnThisDevice: std::runtime_error {
+    EncryptionNotSupportedOnThisDevice(): std::runtime_error("Encryption is not supported on this device") { }
+};
+
+}
+}
+
+#endif //REALM_UTIL_ENCRYPTION_NOT_SUPPORTED_EXCEPTION_HPP

--- a/src/realm/util/file_mapper.cpp
+++ b/src/realm/util/file_mapper.cpp
@@ -39,6 +39,7 @@
 #include <atomic>
 
 #include <realm/util/errno.hpp>
+#include <realm/util/encryption_not_supported_exception.hpp>
 #include <realm/util/shared_ptr.hpp>
 #include <realm/util/terminate.hpp>
 #include <realm/util/thread.hpp>


### PR DESCRIPTION
EncryptionNotSupportedOnThisDevice is needed for Android JNI compiling.
