### PR TITLE
Ensure that the constexpr parts of Optional compile when used in constant expressions

### DIFF
--- a/src/realm/util/optional.hpp
+++ b/src/realm/util/optional.hpp
@@ -46,6 +46,8 @@ struct BadOptionalAccess : std::logic_error {
     explicit BadOptionalAccess(const char* what_arg) : std::logic_error(what_arg) {}
 };
 
+} // namespace util
+
 namespace _impl {
 
 template <class T, bool=std::is_trivially_destructible<T>::value> struct OptionalStorage;
@@ -69,7 +71,9 @@ template <class T> inline REALM_CONSTEXPR T&& constexpr_forward(typename std::re
     return static_cast<T&&>(t);
 }
 
-}
+} // namespace _impl
+
+namespace util {
 
 // Note: Should conform with the future std::optional.
 template <class T>
@@ -502,6 +506,8 @@ auto operator>>(Optional<T> lhs, F&& rhs) -> decltype(fmap(lhs, std::forward<F>(
     return fmap(lhs, std::forward<F>(rhs));
 }
 
+} // namespace util
+
 namespace _impl {
 
 struct Empty {};
@@ -545,8 +551,6 @@ struct OptionalStorage<T, false> {
 };
 
 } // namespace _impl
-
-} // namespace util
 
 using util::none;
 

--- a/src/realm/util/safe_int_ops.hpp
+++ b/src/realm/util/safe_int_ops.hpp
@@ -471,54 +471,54 @@ namespace util {
 
 template<class T> inline bool is_negative(T value) REALM_NOEXCEPT
 {
-    return realm::_impl::IsNegative<T, std::numeric_limits<T>::is_signed>::test(value);
+    return _impl::IsNegative<T, std::numeric_limits<T>::is_signed>::test(value);
 }
 
 template<class To, class From> inline To cast_to_unsigned(From value) REALM_NOEXCEPT
 {
-    return realm::_impl::CastToUnsigned<To>::cast(value);
+    return _impl::CastToUnsigned<To>::cast(value);
 }
 
 template<class A, class B> inline bool int_equal_to(A a, B b) REALM_NOEXCEPT
 {
-    return realm::_impl::SafeIntBinops<A,B>::equal(a,b);
+    return _impl::SafeIntBinops<A,B>::equal(a,b);
 }
 
 template<class A, class B> inline bool int_not_equal_to(A a, B b) REALM_NOEXCEPT
 {
-    return !realm::_impl::SafeIntBinops<A,B>::equal(a,b);
+    return !_impl::SafeIntBinops<A,B>::equal(a,b);
 }
 
 template<class A, class B> inline bool int_less_than(A a, B b) REALM_NOEXCEPT
 {
-    return realm::_impl::SafeIntBinops<A,B>::less(a,b);
+    return _impl::SafeIntBinops<A,B>::less(a,b);
 }
 
 template<class A, class B> inline bool int_less_than_or_equal(A a, B b) REALM_NOEXCEPT
 {
-    return !realm::_impl::SafeIntBinops<B,A>::less(b,a); // Not greater than
+    return !_impl::SafeIntBinops<B,A>::less(b,a); // Not greater than
 }
 
 template<class A, class B> inline bool int_greater_than(A a, B b) REALM_NOEXCEPT
 {
-    return realm::_impl::SafeIntBinops<B,A>::less(b,a);
+    return _impl::SafeIntBinops<B,A>::less(b,a);
 }
 
 template<class A, class B> inline bool int_greater_than_or_equal(A a, B b) REALM_NOEXCEPT
 {
-    return !::realm::_impl::SafeIntBinops<A,B>::less(a,b); // Not less than
+    return !_impl::SafeIntBinops<A,B>::less(a,b); // Not less than
 }
 
 template<class L, class R>
 inline bool int_add_with_overflow_detect(L& lval, R rval) REALM_NOEXCEPT
 {
-    return ::realm::_impl::SafeIntBinops<L,R>::add(lval, rval);
+    return _impl::SafeIntBinops<L,R>::add(lval, rval);
 }
 
 template<class L, class R>
 inline bool int_subtract_with_overflow_detect(L& lval, R rval) REALM_NOEXCEPT
 {
-    return ::realm::_impl::SafeIntBinops<L,R>::sub(lval, rval);
+    return _impl::SafeIntBinops<L,R>::sub(lval, rval);
 }
 
 template<class L, class R>


### PR DESCRIPTION
In order to be used in constant expressions, `Optional<T>` must be a literal type. One constraint on such types is that they are trivially destructible (i.e., their destructor must do nothing). `Optional<T>` can satisfy this constraint when `T` is itself trivially destructible. To accomplish this, we split `Optional`s storage into a separate `OptionalStorage` type that is specialized based on whether `T` is trivially destructible. In the trivially-destructible case, the default destructor is used. In the non-trivially-destructible case, the value's destructor is explicitly called when the value is engaged.

A second constraint on literal types is that their `constexpr` constructors must initialize all data members. To achieve this without needing to initialize the storage used by `T` when constructing a disengaged `Optional`, we store `T` in an anonymous union along with an empty type. The empty type is initialized when constructing a disengaged `OptionalStorage`, with the `T` member being initialized in other cases. An extra advantage that this technique provides is that the compiler will track which member of a union in a literal type is active, and will provide a diagnostic if the program attempts to access any other member. The end result is that a diagnostic will be generated if a user attempts to dereference a disengaged `constexpr Optional<T>`.

/cc @simonask 

I'm not sure that this matters for use within our codebase, but I think we should either make `constexpr` things work, or not bother with marking things as `constexpr`.
