### PR TITLE
Replicating how the Java binding opens a Realm file

### DIFF
--- a/test/test_lang_bind_helper.cpp
+++ b/test/test_lang_bind_helper.cpp
@@ -8909,4 +8909,22 @@ TEST(LangBindHelper_ImplicitTransaction)
     CHECK_EQUAL(N, group.size());
 }
 
+TEST(LangBindHelper_ImplicitTransaction_Reduced)
+{
+    SHARED_GROUP_TEST_PATH(path);
+    size_t N = 28;
+
+    std::unique_ptr<ClientHistory> hist_w(make_client_history(path, crypt_key(true)));
+    SharedGroup sg_w(*hist_w, SharedGroup::durability_Full, crypt_key(true));
+    WriteTransaction w{sg_w};
+    for (size_t i = 0; i < N; ++i) {
+        std::string s = "Hello" + std::to_string(i);
+        w.add_table(s);
+    }
+    w.commit();
+
+    ReadTransaction r{sg_w};
+    CHECK_EQUAL(N, r.get_group().size());
+}
+
 #endif


### PR DESCRIPTION
When the Java binding opens a Realm, it will populate it with the data model by translating classes to tables. In this unit test, I have pulled together how it works.

If encryption is enabled (`REALM_ENABLE_ENCRYPTION`) and used (the `true` parameter in `crypt_key()`), then a crash will happen if `N >= 28`.
