### PR TITLE
Fix the build with Visual Studio 2015

### DIFF
--- a/src/realm/util/optional.hpp
+++ b/src/realm/util/optional.hpp
@@ -37,8 +37,10 @@ template <class T, class... Args> Optional<T> some(Args&&...);
 template <class T> struct Some;
 
 // Note: Should conform with the future std::nullopt_t and std::in_place_t.
-static constexpr struct None { constexpr explicit None(int) {} } none { 0 };
-static constexpr struct InPlace { constexpr InPlace() {} } in_place;
+struct None { constexpr explicit None(int) {} };
+static constexpr None none { 0 };
+struct InPlace { constexpr InPlace() {} };
+static constexpr InPlace in_place;
 
 // Note: Should conform with the future std::bad_optional_access.
 struct BadOptionalAccess : std::logic_error {
@@ -146,6 +148,8 @@ private:
 // };
 
 /// An Optional<T&> is a non-owning nullable pointer that throws on dereference.
+// FIXME: Visual Studio 2015's constexpr support isn't sufficient to allow Optional<T&> to compile
+// in constexpr contexts.
 template <class T>
 class Optional<T&> {
 public:
@@ -510,14 +514,12 @@ auto operator>>(Optional<T> lhs, F&& rhs) -> decltype(fmap(lhs, std::forward<F>(
 
 namespace _impl {
 
-struct Empty {};
-
 // T is trivially destructible.
 template <class T>
 struct OptionalStorage<T, true> {
     union {
         T m_value;
-        Empty m_null_state;
+        char m_null_state;
     };
     bool m_engaged = false;
 
@@ -533,7 +535,7 @@ template <class T>
 struct OptionalStorage<T, false> {
     union {
         T m_value;
-        Empty m_null_state;
+        char m_null_state;
     };
     bool m_engaged = false;
 

--- a/test/test_optional.cpp
+++ b/test/test_optional.cpp
@@ -195,6 +195,8 @@ TEST(Optional_ConstExpr) {
     CHECK_EQUAL(1234, g);
 }
 
+// FIXME: Visual Studio 2015's constexpr support isn't sufficient to allow Optional<T&> to compile.
+#ifndef _WIN32
 TEST(Optional_ReferenceConstExpr) {
     // Should compile:
     constexpr Optional<const int&> a;
@@ -208,6 +210,7 @@ TEST(Optional_ReferenceConstExpr) {
     constexpr bool f { Optional<const int&>{ none } };
     CHECK_EQUAL(false, f);
 }
+#endif
 
 // Disabled for compliance with std::optional
 // TEST(Optional_VoidIsEquivalentToBool)


### PR DESCRIPTION
Visual Studio 2015's support for `constexpr` is less complete than recent
versions of GCC and Clang. The following changes are necessary in order to
make optional.hpp compile:
1. Definition of `none` and `in_place` need to be split from the
   declarations of their respective classes to suppress an error about them
   not being constant.
2. The tests for `constexpr Optional<T&>` are disabled on Windows due to Visual
   Studio believing that many `constexpr` member functions access
   non-constant data.
3. `Empty` is replaced with `char` in `OptionalStorage` as Visual Studio
   complains about one member of the union being uninitialized when that
   member is an empty type.

/cc @simonask @rrrlasse 
