### PR TITLE
Fix assertion failure in TableViewBase::is_row_attached()

### DIFF
--- a/release_notes.md
+++ b/release_notes.md
@@ -33,6 +33,8 @@
   encryption.
 * Query expression comparisons now give correct results when comparing a linked
   column with a column in the base table.
+* Fixed assertion failure when TableViewBase::is_row_attached() would return
+  false in a debug build.
 
 ### API breaking changes:
 

--- a/src/realm/table_view.hpp
+++ b/src/realm/table_view.hpp
@@ -699,7 +699,7 @@ inline bool TableViewBase::is_attached() const noexcept
 
 inline bool TableViewBase::is_row_attached(std::size_t row_ndx) const noexcept
 {
-    return get_source_ndx(row_ndx) != detached_ref;
+    return size_t(m_row_indexes.get(row_ndx)) != detached_ref;
 }
 
 inline std::size_t TableViewBase::size() const noexcept


### PR DESCRIPTION
In debug builds to_size_t(-1) doesn't work, so is_row_attached() would only work when it returned true.

@finnschiermer 
