### PR TITLE
Update outdated library name

### DIFF
--- a/test/util/Makefile
+++ b/test/util/Makefile
@@ -29,10 +29,8 @@ PROCPS_LDFLAGS := $(shell pkg-config libprocps --libs)
 test_util_a_CFLAGS  += $(PROCPS_CFLAGS)
 test_util_a_LDFLAGS += $(PROCPS_LDFLAGS)
 else
-test_util_a_LDFLAGS += -lproc
+test_util_a_LDFLAGS += -lprocps
 endif
-
-mem_o_CFLAGS = -DREALM_HAVE_LIBPROCPS
 
 endif
 

--- a/test/util/mem.cpp
+++ b/test/util/mem.cpp
@@ -5,8 +5,7 @@
 #  include <psapi.h>
 #elif defined __APPLE__
 #  include <mach/mach.h>
-#elif defined REALM_HAVE_LIBPROCPS
-// Requires libprocps (formerly known as libproc)
+#else
 #  include <proc/readproc.h>
 #endif
 
@@ -128,17 +127,13 @@ size_t get_mem_usage()
     // either, yet we will yse the resident size for now.
     return t_info.resident_size;
 
-#elif defined REALM_HAVE_LIBPROCPS
+#else
 
     struct proc_t usage;
     look_up_our_self(&usage);
     // The header file says 'vsize' is in number of pages, yet it
     // definitely appears to be in bytes.
     return usage.vsize;
-
-#else
-
-    throw std::runtime_error("Not supported");
 
 #endif
 }


### PR DESCRIPTION
The Makefile in `test/util` specified that if `pkg-config` couldn't give the name of the `procps` library, then we should attempt to link against `-lproc`. Regardless of the outcome, HAVE_LIBPROCPS was always defined.

This is problematic for two reasons:
- `libproc` has been renamed to `libprocps` on most platforms,
- In the event that `pkg-config` fails (or isn't installed), we force the use of `-lproc`, which happens to be wrong on most platforms,
- Regardless of whether `pkg-config` found `procps` or not, we declared `-DREALM_HAVE_PROCPS`.

@kspangsege @simonask
