### PR TITLE
Remove forgotten conflict marker

### DIFF
--- a/release_notes.md
+++ b/release_notes.md
@@ -1168,8 +1168,6 @@ Format:
 ! Fixed bug in Query with subtables. Whith empty subtables query returned incorrect results.
   In debug mode it could assert when querying a subtable with more columns than the base table.
 
->>>>>>> 1e936d3c43874f7e49231aa69c34bdbd67e5f0e9
-
 2014-01-23 (Kenneth Geisshirt)
 ! Fixed bug: Subtable queries is validated by Query::validate(). An invalid subtable query can lead to a segfault.
 


### PR DESCRIPTION
This PR removes a small conflict marker that was forgotten in release notes. I don't know if the conflict was properly resolved or not, but the other markers (opening and middle) have been removed previously.
