### PR TITLE
Fix a few error messages

### DIFF
--- a/release_notes.md
+++ b/release_notes.md
@@ -8,6 +8,8 @@
   crash (if assert was disabled).
 * The error handling for `pthread_cond_wait()/pthread_cond_timedwait()`
   incorrectly attributed the failure to `pthread_mutex_lock()`.
+* The error handling for several File functions incorrectly attributed the
+  failure to `open()`.
 
 ### API breaking changes:
 

--- a/src/realm/util/file.cpp
+++ b/src/realm/util/file.cpp
@@ -87,7 +87,7 @@ void make_dir(const std::string& path)
         return;
 #endif
     int err = errno; // Eliminate any risk of clobbering
-    std::string msg = get_errno_msg("open() failed: ", err);
+    std::string msg = get_errno_msg("make_dir() failed: ", err);
     switch (err) {
         case EACCES:
         case EROFS:
@@ -116,7 +116,7 @@ void remove_dir(const std::string& path)
         return;
 #endif
     int err = errno; // Eliminate any risk of clobbering
-    std::string msg = get_errno_msg("open() failed: ", err);
+    std::string msg = get_errno_msg("remove_dir() failed: ", err);
     switch (err) {
         case EACCES:
         case EROFS:
@@ -885,7 +885,7 @@ void File::remove(const std::string& path)
     if (try_remove(path))
         return;
     int err = ENOENT;
-    std::string msg = get_errno_msg("open() failed: ", err);
+    std::string msg = get_errno_msg("remove() failed: ", err);
     throw NotFound(msg, path);
 }
 


### PR DESCRIPTION
Several functions in File threw errors incorrectly claiming that open() was the thing that failed.
