### PR TITLE
Build the ios simulator versions with -fembed-bitcode-marker

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -733,6 +733,7 @@ EOF
                 word_list_append "cflags_arch" "-fembed-bitcode" || exit 1
             else
                 word_list_append "cflags_arch" "-mios-simulator-version-min=7.0" || exit 1
+                word_list_append "cflags_arch" "-fembed-bitcode-marker" || exit 1
             fi
             sdk_root="$xcode_home/Platforms/$platform.platform/Developer/SDKs/$sdk"
             $MAKE -C "src/realm" "librealm-$platform.a" "librealm-$platform-dbg.a" BASE_DENOM="$platform" CFLAGS_ARCH="$cflags_arch -isysroot '$sdk_root'" || exit 1

--- a/release_notes.md
+++ b/release_notes.md
@@ -10,6 +10,8 @@
   incorrectly attributed the failure to `pthread_mutex_lock()`.
 * The error handling for several File functions incorrectly attributed the
   failure to `open()`.
+* Added the bitcode marker to ios simulator builds so that bitcode for device
+  builds can actually be used.
 
 ### API breaking changes:
 


### PR DESCRIPTION
It appears that all slices of a fat library must be built with either bitcode or the bitcode marker for it to be used from any of them.

Without this `otool -l librealm-ios.a | grep bitcode` matches nothing; with it there are a whole bunch of matches.
