### PR TITLE
Build both bitcode and no-bitcode versions for iOS

### DIFF
--- a/release_notes.md
+++ b/release_notes.md
@@ -12,6 +12,8 @@
   failure to `open()`.
 * Added the bitcode marker to iOS Simulator builds so that bitcode for device
   builds can actually be used.
+* Build with bitcode both enabled and disabled for iOS for compatibility with
+  Xcode 6.
 
 ### API breaking changes:
 


### PR DESCRIPTION
Turns out that Xcode 6 barfs on files built with -fembed-bitcode-marker, so we need two versions.
