### PR TITLE
Reduced VS2015 warnings from ~1000 to ~450

### DIFF
--- a/src/realm/array.cpp
+++ b/src/realm/array.cpp
@@ -728,7 +728,7 @@ std::size_t Array::find_gte(const int64_t target, std::size_t start, Array const
     size_t idx;
 
     for (idx = start; idx < m_size; ++idx) {
-        if (get(indirection ? indirection->get(idx) : idx) >= target) {
+        if (get(indirection ? to_size_t(indirection->get(idx)) : idx) >= target) {
             ref = idx;
             break;
         }

--- a/src/realm/array_binary.cpp
+++ b/src/realm/array_binary.cpp
@@ -40,7 +40,7 @@ void ArrayBinary::add(BinaryData value, bool add_zero_term)
         ++stored_size;
     size_t offset = stored_size;
     if (!m_offsets.is_empty())
-        offset += m_offsets.back();//fixme:32bit:src\realm\array_binary.cpp(61): warning C4244: '+=' : conversion from 'int64_t' to 'size_t', possible loss of data
+        offset += to_size_t(m_offsets.back());
     m_offsets.add(offset);
 
     if (!legacy_array_type())

--- a/src/realm/array_integer.hpp
+++ b/src/realm/array_integer.hpp
@@ -642,7 +642,9 @@ bool ArrayIntNull::find(int64_t value, std::size_t start, std::size_t end, std::
 template<class cond, Action action, class Callback>
 bool ArrayIntNull::find(null, std::size_t start, std::size_t end, std::size_t baseindex, QueryState<int64_t>* state, Callback callback) const
 {
-    return find<cond, action>(null{}, start, end, baseindex, state, std::forward<Callback>(callback));
+    return Array::find<cond, action>(0 /*ignored*/, start, end, baseindex, state, std::forward<Callback>(callback), 
+                                     true /*treat as nullable array*/,
+                                     true /*search for null, ignore value argument*/);
 }
 
 
@@ -672,7 +674,7 @@ template<class cond> std::size_t ArrayIntNull::find_first(null, std::size_t star
                                        true /*treat as nullable array*/,
                                        true /*search for null, ignore value argument*/);
     if (state.m_match_count > 0)
-        return state.m_state;
+        return to_size_t(state.m_state);
     else
         return not_found;
 }
@@ -685,7 +687,7 @@ template<class cond> std::size_t ArrayIntNull::find_first(int64_t value, std::si
                                        true /*treat as nullable array*/,
                                        false /*search parameter given in 'value' argument*/);
     if (state.m_match_count > 0)
-        return state.m_state;
+        return to_size_t(state.m_state);
     else
         return not_found;
 }

--- a/src/realm/column.hpp
+++ b/src/realm/column.hpp
@@ -736,7 +736,7 @@ std::size_t Column<T, N>::count(T target) const
     if (has_search_index()) {
         return m_search_index->count(target);
     }
-    return aggregate<T, T, act_Count, Equal>(*this, target, 0, size(), npos, nullptr);
+    return to_size_t(aggregate<T, T, act_Count, Equal>(*this, target, 0, size(), npos, nullptr));
 }
 
 template <class T, bool N>
@@ -755,7 +755,7 @@ double Column<T, N>::average(std::size_t start, std::size_t end, std::size_t lim
         end = size();
 
     auto s = sum(start, end, limit);
-    size_t cnt = aggregate<T, int64_t, act_Count, NotNull>(*this, 0, start, end, limit, nullptr);
+    size_t cnt = to_size_t(aggregate<T, int64_t, act_Count, NotNull>(*this, 0, start, end, limit, nullptr));
     if (return_ndx)
         *return_ndx = cnt;
     double avg = double(s) / (cnt == 0 ? 1 : cnt);

--- a/src/realm/column_backlink.cpp
+++ b/src/realm/column_backlink.cpp
@@ -196,7 +196,7 @@ std::size_t BacklinkColumn::for_each_link(std::size_t row_ndx, bool do_destroy, 
                 backlink_list.destroy();
         }
     }
-    return value;
+    return to_size_t(value);
 }
 
 

--- a/src/realm/column_basic_tpl.hpp
+++ b/src/realm/column_basic_tpl.hpp
@@ -573,7 +573,7 @@ double BasicColumn<T>::average(std::size_t begin, std::size_t end, std::size_t l
         size = limit;
 
     auto s = sum(begin, end, limit, nullptr);
-    size_t cnt = aggregate<T, int64_t, act_Count, NotNull>(*this, 0, begin, end, limit, nullptr);
+    size_t cnt = to_size_t(aggregate<T, int64_t, act_Count, NotNull>(*this, 0, begin, end, limit, nullptr));
     if (return_ndx)
         *return_ndx = cnt;
     double avg = double(s) / (cnt == 0 ? 1 : cnt);

--- a/src/realm/query.cpp
+++ b/src/realm/query.cpp
@@ -752,7 +752,8 @@ size_t Query::peek_tableview(size_t tv_index) const
     REALM_ASSERT_DEBUG(m_view->cookie == m_view->cookie_expected);
     REALM_ASSERT_3(tv_index, <, m_view->size());
 
-    size_t tablerow = m_view->m_row_indexes.get(tv_index);
+    // Cannot use to_size_t() because the get() may return -1
+    size_t tablerow = static_cast<size_t>(m_view->m_row_indexes.get(tv_index));
 
     size_t r;
     if (first.size() > 0 && first[0])

--- a/src/realm/string_data.hpp
+++ b/src/realm/string_data.hpp
@@ -355,7 +355,8 @@ struct null {
     /// Returns the quiet NaNs that represent null for floats/doubles in Realm in stored payload.
     template <class T> static T get_null_float() {
         typename std::conditional<std::is_same<T, float>::value, uint32_t, uint64_t>::type i;
-        i = std::is_same<T, float>::value ? 0x7fc000aa : static_cast<decltype(i)>(0x7ff80000000000aa);
+        int64_t double_nan = 0x7ff80000000000aa;
+        i = std::is_same<T, float>::value ? 0x7fc000aa : static_cast<decltype(i)>(double_nan);
         T d = type_punning<T, decltype(i)>(i);
         REALM_ASSERT_DEBUG(isnan(static_cast<double>(d)));
         REALM_ASSERT_DEBUG(!is_signaling(d));

--- a/src/realm/table.cpp
+++ b/src/realm/table.cpp
@@ -2983,7 +2983,7 @@ double Table::minimum_double(size_t col_ndx, size_t* return_ndx) const
 DateTime Table::minimum_datetime(size_t col_ndx, size_t* return_ndx) const
 {
     if (!m_columns.is_attached())
-        return 0.;
+        return 0;
 
     if (is_nullable(col_ndx)) {
         const IntNullColumn& column = get_column<IntNullColumn, col_type_DateTime>(col_ndx);
@@ -3417,14 +3417,14 @@ size_t get_group_ndx_blocked(size_t i, AggrState& state, Table& result)
     // Since we know the exact number of distinct keys,
     // we can use that to avoid index lookups
     int64_t key = state.block->get(i - state.offset);
-    size_t ndx = state.keys[key];
+    size_t ndx = state.keys[to_size_t(key)];
 
     // Stored position is offset by one, so zero can indicate
     // that no entry have been added yet.
     if (ndx == 0) {
         ndx = result.add_empty_row();
         result.set_string(0, ndx, state.enums->get(i));
-        state.keys[key] = ndx+1;
+        state.keys[to_size_t(key)] = ndx+1;
         state.added_row = true;
     }
     else
@@ -3496,7 +3496,7 @@ void Table::aggregate(size_t group_by_column, size_t aggr_column, AggrType op, T
         switch (op) {
             case aggr_count:
                 for (size_t r = 0; r < count; ++r) {
-                    size_t i = viewrefs->get(r);
+                    size_t i = static_cast<size_t>(viewrefs->get(r));
                     size_t ndx = (*get_group_ndx_fnc)(i, state, result);
 
                     // Count
@@ -3505,7 +3505,7 @@ void Table::aggregate(size_t group_by_column, size_t aggr_column, AggrType op, T
                 break;
             case aggr_sum:
                 for (size_t r = 0; r < count; ++r) {
-                    size_t i = viewrefs->get(r);
+                    size_t i = static_cast<size_t>(viewrefs->get(r));
                     size_t ndx = (*get_group_ndx_fnc)(i, state, result);
 
                     // Sum
@@ -3520,7 +3520,7 @@ void Table::aggregate(size_t group_by_column, size_t aggr_column, AggrType op, T
                 IntegerColumn& cnt_column = result.get_column(2);
 
                 for (size_t r = 0; r < count; ++r) {
-                    size_t i = viewrefs->get(r);
+                    size_t i = static_cast<size_t>(viewrefs->get(r));
                     size_t ndx = (*get_group_ndx_fnc)(i, state, result);
 
                     // SUM
@@ -3549,7 +3549,7 @@ void Table::aggregate(size_t group_by_column, size_t aggr_column, AggrType op, T
             }
             case aggr_min:
                 for (size_t r = 0; r < count; ++r) {
-                    size_t i = viewrefs->get(r);
+                    size_t i = static_cast<size_t>(viewrefs->get(r));
 
                     size_t ndx = (*get_group_ndx_fnc)(i, state, result);
                     int64_t value = src_column.get(i);
@@ -3567,7 +3567,7 @@ void Table::aggregate(size_t group_by_column, size_t aggr_column, AggrType op, T
                 break;
             case aggr_max:
                 for (size_t r = 0; r < count; ++r) {
-                    size_t i = viewrefs->get(r);
+                    size_t i = static_cast<size_t>(static_cast<size_t>(viewrefs->get(r)));
 
                     size_t ndx = (*get_group_ndx_fnc)(i, state, result);
                     int64_t value = src_column.get(i);

--- a/src/realm/util/features.h
+++ b/src/realm/util/features.h
@@ -20,6 +20,9 @@
 #ifndef REALM_UTIL_FEATURES_H
 #define REALM_UTIL_FEATURES_H
 
+#ifdef _MSC_VER
+#pragma warning(disable:4800) // Visual Studio int->bool performance warnings
+#endif
 
 #ifdef REALM_HAVE_CONFIG
 #  include <realm/util/config.h>

--- a/src/realm/views.cpp
+++ b/src/realm/views.cpp
@@ -17,7 +17,7 @@ void RowIndexes::sort(Sorter& sorting_predicate)
     // (handling detached refs is not required in linkviews)
     size_t detached_ref_count = 0;
     for (size_t t = 0; t < sz; t++) {
-        size_t ndx = m_row_indexes.get(t);
+        size_t ndx = static_cast<size_t>(m_row_indexes.get(t));
         if (ndx != detached_ref) {
             v.push_back(ndx);
         }

--- a/test/large_tests/test_column_large.cpp
+++ b/test/large_tests/test_column_large.cpp
@@ -98,7 +98,7 @@ TEST_IF(ColumnLarge_Less, TEST_DURATION >= 3)
                         a.set(match, v[w] - 1);
                         state.init(act_ReturnFirst, &accu, size_t(-1));
                         a.find(cond_Less, act_ReturnFirst, v[w], from, to, 0, &state);
-                        size_t f = state.m_state;
+                        size_t f = to_size_t(state.m_state);
                         a.set(match, v[w]);
                         if (match >= from && match < to) {
                             CHECK(match == f);
@@ -113,7 +113,7 @@ TEST_IF(ColumnLarge_Less, TEST_DURATION >= 3)
                         a.set(match, v[w] + 1);
                         state.init(act_ReturnFirst, &accu, size_t(-1));
                         a.find(cond_Greater, act_ReturnFirst, v[w], from, to, 0, &state);
-                        size_t f = state.m_state;
+                        size_t f = to_size_t(state.m_state);
                         a.set(match, v[w]);
                         if (match >= from && match < to) {
                             CHECK(match == f);

--- a/test/large_tests/test_strings.cpp
+++ b/test/large_tests/test_strings.cpp
@@ -51,7 +51,7 @@ std::string randstring(Random& random)
     size_t len = random.draw_int_mod(10) * 100 + 1;
     std::string s;
     while (s.length() < len)
-        s += number_name(t);
+        s += number_name(static_cast<size_t>(t));
 
     s = s.substr(0, len);
     return s;

--- a/test/test_array_integer.cpp
+++ b/test/test_array_integer.cpp
@@ -362,8 +362,8 @@ TEST(ArrayIntNull_Find)
         a.find_all(&col, 0x44);
 
         CHECK_EQUAL(2, col.size());
-        CHECK_EQUAL(a[col.get(0)], 0x44);
-        CHECK_EQUAL(a[col.get(1)], 0x44);
+        CHECK_EQUAL(a[static_cast<size_t>(col.get(0))], 0x44);
+        CHECK_EQUAL(a[static_cast<size_t>(col.get(1))], 0x44);
 
         col.destroy();
 

--- a/test/test_query.cpp
+++ b/test/test_query.cpp
@@ -5926,7 +5926,7 @@ TEST(Query_Nulls_Fuzzy)
                     }
                     else {
                         // non-null string
-                        size_t len = fastrand(3);
+                        size_t len = static_cast<size_t>(fastrand(3));
                         if (len == 0)
                             len = 0;
                         else if (len == 1)
@@ -6162,11 +6162,11 @@ TEST(Query_64BitValues)
     const int64_t min = std::numeric_limits<int64_t>::min();
     const int64_t max = std::numeric_limits<int64_t>::max();
     table->add_empty_row(count);
-    for (int64_t i = 0; i < count; ++i) {
+    for (size_t i = 0; i < count; ++i) {
         table->set_int(0, i, start + i);
     }
 
-    for (int64_t i = 0; i < 5; i++) {
+    for (size_t i = 0; i < 5; i++) {
         // Insert values 5, 4, 3, 2, 1
         table->set_int(1, i, 5 - i);
     }

--- a/test/test_table_view.cpp
+++ b/test/test_table_view.cpp
@@ -314,8 +314,8 @@ TEST(TableView_Average)
     TestTableInt::View v = table.column().first.find_all(2);
     CHECK_EQUAL(5, v.size());
 
-    int64_t sum = v.column().first.average();
-    CHECK_EQUAL(2, sum);
+    double sum = v.column().first.average();
+    CHECK_APPROXIMATELY_EQUAL(2., sum, 0.00001);
 }
 
 TEST(TableView_SumNegative)


### PR DESCRIPTION
Still alot of warnings to go. @kspangsege some are in transact_log.\* and safe_int_ops.\* and it wasn't obvious to me if they were flawed or not. So I didn't fix them.
