### PR TITLE
Bugfix: When inserting a new Binary column in a table where `table.si…

### DIFF
--- a/src/realm/array_binary.cpp
+++ b/src/realm/array_binary.cpp
@@ -172,7 +172,7 @@ ref_type ArrayBinary::bptree_leaf_insert(size_t ndx, BinaryData value, bool add_
 }
 
 
-MemRef ArrayBinary::create_array(size_t size, Allocator& alloc)
+MemRef ArrayBinary::create_array(size_t size, Allocator& alloc, bool nullable)
 {
     Array top(alloc);
     _impl::DeepArrayDestroyGuard dg(&top);
@@ -202,7 +202,7 @@ MemRef ArrayBinary::create_array(size_t size, Allocator& alloc)
         // must thus check if this array exists before trying to access it. If it doesn't, it must be interpreted as if its 
         // column isn't nullable.
         bool context_flag = false;
-        int64_t value = 1; // all entries are null by default
+        int64_t value = nullable ? 1 : 0;
         MemRef mem = ArrayInteger::create_array(type_Normal, context_flag, size, value, alloc); // Throws
         dg_2.reset(mem.m_ref);
         int64_t v = from_ref(mem.m_ref);

--- a/src/realm/array_binary.hpp
+++ b/src/realm/array_binary.hpp
@@ -105,7 +105,7 @@ public:
     /// Construct a binary array of the specified size and return just
     /// the reference to the underlying memory. All elements will be
     /// initialized to zero size blobs.
-    static MemRef create_array(size_t size, Allocator&);
+    static MemRef create_array(size_t size, Allocator&, bool nullable);
 
     /// Construct a copy of the specified slice of this binary array
     /// using the specified target allocator.
@@ -140,7 +140,7 @@ inline ArrayBinary::ArrayBinary(Allocator& alloc) noexcept:
 inline void ArrayBinary::create()
 {
     size_t size = 0;
-    MemRef mem = create_array(size, get_alloc()); // Throws
+    MemRef mem = create_array(size, get_alloc(), false); // Throws
     init_from_mem(mem);
 }
 

--- a/src/realm/column_binary.cpp
+++ b/src/realm/column_binary.cpp
@@ -383,19 +383,21 @@ bool BinaryColumn::upgrade_root_leaf(size_t value_size)
 
 class BinaryColumn::CreateHandler: public ColumnBase::CreateHandler {
 public:
-    CreateHandler(Allocator& alloc): m_alloc(alloc) {}
+    CreateHandler(Allocator& alloc, bool nullable): m_alloc(alloc), m_nullable(nullable) {}
+
     ref_type create_leaf(size_t size) override
     {
-        MemRef mem = ArrayBinary::create_array(size, m_alloc); // Throws
+        MemRef mem = ArrayBinary::create_array(size, m_alloc, m_nullable); // Throws
         return mem.m_ref;
     }
 private:
     Allocator& m_alloc;
+    bool m_nullable;
 };
 
-ref_type BinaryColumn::create(Allocator& alloc, size_t size)
+ref_type BinaryColumn::create(Allocator& alloc, size_t size, bool nullable)
 {
-    CreateHandler handler(alloc);
+    CreateHandler handler(alloc, nullable);
     return ColumnBase::create(alloc, size, handler);
 }
 

--- a/src/realm/column_binary.hpp
+++ b/src/realm/column_binary.hpp
@@ -65,7 +65,7 @@ public:
     /// Compare two binary columns for equality.
     bool compare_binary(const BinaryColumn&) const;
 
-    static ref_type create(Allocator&, size_t size = 0);
+    static ref_type create(Allocator&, size_t size = 0, bool nullable = false);
 
     static size_t get_size_from_ref(ref_type root_ref, Allocator&) noexcept;
 

--- a/src/realm/table.cpp
+++ b/src/realm/table.cpp
@@ -761,6 +761,7 @@ void Table::do_insert_root_column(size_t ndx, ColumnType type, StringData name, 
 
     Spec::ColumnInfo info = m_spec.get_column_info(ndx);
     size_t ndx_in_parent = info.m_column_ref_ndx;
+
     ref_type col_ref = create_column(type, m_size, nullable, m_columns.get_alloc()); // Throws
     m_columns.insert(ndx_in_parent, col_ref); // Throws
 }
@@ -1846,7 +1847,7 @@ ref_type Table::create_column(ColumnType col_type, size_t size, bool nullable, A
         case col_type_String:
             return StringColumn::create(alloc, size); // Throws
         case col_type_Binary:
-            return BinaryColumn::create(alloc, size); // Throws
+            return BinaryColumn::create(alloc, size, nullable); // Throws
         case col_type_Table:
             return SubtableColumn::create(alloc, size); // Throws
         case col_type_Mixed:

--- a/test/test_column_binary.cpp
+++ b/test/test_column_binary.cpp
@@ -353,4 +353,6 @@ TEST(ColumnBinary_Nulls)
     c.destroy();
 }
 
+
+
 #endif // TEST_COLUMN_BINARY

--- a/test/test_table.cpp
+++ b/test/test_table.cpp
@@ -6306,6 +6306,26 @@ TEST(Table_AllocatorCapacityBug)
     }
 }
 
+TEST(ColumnBinary_InitOfEmptyColumn2)
+{
+    Table t;
+    t.add_column(type_Int, "works");
+    t.add_empty_row();
+    t.add_empty_row();
+    t.add_empty_row();
+    t.add_empty_row();
+    t.add_empty_row();
+    t.add_empty_row();
+    t.add_empty_row();
+    t.add_column(type_Binary, "doesn't work");
+    t.add_column(type_String, "doesn't work");
+    CHECK_NOT_EQUAL(BinaryData(), t.get_binary(1, 0));
+    CHECK_NOT_EQUAL(StringData(), t.get_string(2, 0));
+    CHECK(!t.is_null(1, 0));
+    CHECK(!t.is_null(2, 0));
 
+
+
+}
 
 #endif // TEST_TABLE


### PR DESCRIPTION
…ze() > 0`, then the automatically inserted values would default to null even if the column was marked non-nullable.
