### PR TITLE
Fix Optionals buggy copy and move assignment operators

### DIFF
--- a/src/realm/util/optional.hpp
+++ b/src/realm/util/optional.hpp
@@ -74,7 +74,7 @@ template <class T> inline constexpr T&& constexpr_forward(typename std::remove_r
 }
 
 template <class T, class U>
-class TypeIsAssignableToOptional {
+struct TypeIsAssignableToOptional {
     // Constraints from [optional.object.assign.18]
     static const bool value = (std::is_same<typename std::remove_reference<U>::type, T>::value
                                && std::is_constructible<T, U>::value

--- a/test/test_optional.cpp
+++ b/test/test_optional.cpp
@@ -62,6 +62,20 @@ TEST(Optional_CopyAssignment)
     CHECK(bool(b));
     CHECK_EQUAL(*a, "foo");
     CHECK_EQUAL(*b, "foo");
+
+    Optional<std::string> c { "foo" };
+    Optional<std::string> d { "bar" };
+    d = c;
+    CHECK(bool(c));
+    CHECK(bool(d));
+    CHECK_EQUAL(*c, "foo");
+    CHECK_EQUAL(*d, "foo");
+
+    Optional<std::string> e;
+    Optional<std::string> f { "foo" };
+    f = e;
+    CHECK(!bool(e));
+    CHECK(!bool(f));
 }
 
 TEST(Optional_MoveAssignment)
@@ -71,8 +85,32 @@ TEST(Optional_MoveAssignment)
     b = std::move(a);
     CHECK(bool(a));
     CHECK(bool(b));
-    CHECK_EQUAL(*a, "");
     CHECK_EQUAL(*b, "foo");
+
+    Optional<std::string> c { "foo" };
+    Optional<std::string> d { "bar" };
+    d = std::move(c);
+    CHECK(bool(c));
+    CHECK(bool(d));
+    CHECK_EQUAL(*d, "foo");
+
+    Optional<std::string> e;
+    Optional<std::string> f { "foo" };
+    f = std::move(e);
+    CHECK(!bool(e));
+    CHECK(!bool(f));
+}
+
+TEST(Optional_ValueAssignment)
+{
+    Optional<std::string> o;
+    o = std::string { "foo" };
+    CHECK(bool(o));
+    CHECK_EQUAL(*o, "foo");
+
+    o = std::string { "bar" };
+    CHECK(bool(o));
+    CHECK_EQUAL(*o, "bar");
 }
 
 struct SetBooleanOnDestroy {


### PR DESCRIPTION
Both assignment operators failed to set `m_engaged` when assigning an engaged optional to an unengaged optional. The lack of test coverage for these operators caused this issue to be missed.

Additionally, `Optional`s value assignment operator was insufficiently constrained resulting in compile errors when attempting to use the copy assignment operator due to ambiguity between the copy assignment and value assignment operators. To address this, the value assignment operator is now constrained to argument types as per [optional.object.assign.18](http://www.open-std.org/jtc1/sc22/wg21/docs/papers/2014/n3848.html#optional.object.assign.18).
