### PR TITLE
Rename applicationId of unit test.

### DIFF
--- a/test/android/AndroidManifest.xml
+++ b/test/android/AndroidManifest.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
-        package="io.realm.test"
+        package="io.realm.coretest"
         android:versionCode="1"
         android:versionName="1.0">
 

--- a/test/android/README.md
+++ b/test/android/README.md
@@ -72,13 +72,13 @@ Of course make sure the device is set to developer mode and connected.
 You can of course tap the app icon. Alternatively you can do it from the command line:
 
 ```
-$ adb shell am start -a android.intent.action.MAIN -n io.realm.test/android.app.NativeActivity
+$ adb shell am start -a android.intent.action.MAIN -n io.realm.coretest/android.app.NativeActivity
 ```
 
 It is possible to stop the app using the command:
 
 ```
-$ adb shell am force-stop io.realm.test
+$ adb shell am force-stop io.realm.coretest
 ```
 
 ## See the logs
@@ -92,5 +92,5 @@ $ adb logcat
 ## Retrieving the XML file containing the test results:
 
 ```
-$ adb pull /storage/sdcard0/Android/data/com.realm.test/files/unit-test-report.xml .
+$ adb pull /storage/sdcard0/Android/data/com.realm.coretest/files/unit-test-report.xml .
 ```

--- a/test/android/unittest.sh
+++ b/test/android/unittest.sh
@@ -1,14 +1,14 @@
 #!/bin/bash
 
 adb logcat -c
-adb shell am start -a android.intent.action.MAIN -n io.realm.test/android.app.NativeActivity
+adb shell am start -a android.intent.action.MAIN -n io.realm.coretest/android.app.NativeActivity
 while [ true ]; do
     sleep 10
     report=$(adb logcat -d | grep "The XML file" | cut -d/ -f3- | tr -d "\r")
     if [ "$report" != "" ]; then
 
         # adb pull <full-path-for-report-file>
-        adb shell am force-stop io.realm.test
+        adb shell am force-stop io.realm.coretest
         break
     fi
 done


### PR DESCRIPTION
Rename applicationId of unit test to `io.realm.coretest` to avoid conflict of Realm Java's test.

Realm Java's unit test sometime experiences `INSTALL_FAILED_VERSION_DOWNGRADE` error when installing test apk to the device.

The cause of that error is applicationIds of the core and java's unit test are the same and core's `versionCode` is greater than java's one.

Renaming the application id also requires updating CI configuration for unit test(https://ci.realm.io/view/All/job/core_android/configure).
I'll update that after merge of this PR.

Please review this @realm/core 
