### PR TITLE
Improve coverage of bptree.cpp

### DIFF
--- a/test/test_table.cpp
+++ b/test/test_table.cpp
@@ -3993,11 +3993,7 @@ TEST(Table_WriteSlice)
     // Run through a 3-D matrix of table sizes, slice offsets, and
     // slice sizes. Each test involves a table with columns of each
     // possible type.
-#ifdef REALM_DEBUG
-    int table_sizes[] = { 0, 1, 2, 3, 5, 9, 27, 81, 82, 135 };
-#else
     int table_sizes[] = { 0, 1, 2, 3, 5, 9, 27, 81, 82, 243, 729, 2187, 6561 };
-#endif
     int num_sizes = sizeof table_sizes / sizeof *table_sizes;
     for (int table_size_i = 0; table_size_i != num_sizes; ++table_size_i) {
         int table_size = table_sizes[table_size_i];


### PR DESCRIPTION
Turned out it was just a matter of removing an ifdef. :)

@kspangsege @rrrlasse 
