### PR TITLE
REALM_ASSERT should be enough to consider a variable "used"

### DIFF
--- a/src/realm/util/assert.hpp
+++ b/src/realm/util/assert.hpp
@@ -34,7 +34,7 @@
 #if REALM_ASSERTIONS_ENABLED
 #  define REALM_ASSERT(condition) REALM_ASSERT_RELEASE(condition)
 #else
-#  define REALM_ASSERT(condition) static_cast<void>(0)
+#  define REALM_ASSERT(condition) static_cast<void>(condition)
 #endif
 
 #ifdef REALM_DEBUG
@@ -78,8 +78,8 @@
                                __FILE__, __LINE__, left1, right1, left2, right2, left3, right3))
 #else
 #  define REALM_ASSERT_EX(...) static_cast<void>(0)
-#  define REALM_ASSERT_3(left, condition, right) static_cast<void>(0)
-#  define REALM_ASSERT_7(left1, condition1, right1, logical, left2, condition2, right2) static_cast<void>(0)
+#  define REALM_ASSERT_3(left, condition, right) static_cast<void>(left); static_cast<void>(right)
+#  define REALM_ASSERT_7(left1, condition1, right1, logical, left2, condition2, right2) static_cast<void>(left1); static_cast<void>(right1); static_cast<void>(left2); static_cast<void>(right2)
 #  define REALM_ASSERT_11(left1, condition1, right1, logical1, left2, condition2, right2, logical3, left3, condition3, right3) static_cast<void>(0)
 #endif
 


### PR DESCRIPTION
This means that `REALM_ASSERT(cond)` will not cause warnings about unused variables in release mode, when `cond` is not used outside of the assert.

`REALM_ASSERT_DEBUG` retains the old behavior, because debug asserts may rely on function definitions that only exist in debug mode.

This should also fix the problems addressed by #1294 

@danielpovlsen @kspangsege @rrrlasse 
