### PR TITLE
File_SetEncryptionKey fails

### DIFF
--- a/test/test_file.cpp
+++ b/test/test_file.cpp
@@ -249,7 +249,6 @@ TEST(File_SetEncryptionKey)
 #if REALM_ENABLE_ENCRYPTION
     f.set_encryption_key(key); // should not throw
 #else
-    // FIXME: https://ci.realm.io/job/core_android/784/testReport/(root)/DefaultSuite/File_SetEncryptionKey/
     CHECK_THROW(f.set_encryption_key(key), std::runtime_error);
 #endif
 }


### PR DESCRIPTION
It _looks_ like different compilation units _may_ have different values (if set at all) for `REALM_ENABLE_ENCRYPTION`.

https://ci.realm.io/job/core_android/784/testReport/(root)/DefaultSuite/File_SetEncryptionKey/
