### PR TITLE
Move expensive-to-copy things in TableView's move constructor

### DIFF
--- a/release_notes.md
+++ b/release_notes.md
@@ -4,6 +4,7 @@
 
 * When inserting a new non-nullable Binary column to a table that had 
   *existing* rows, then the automatically added values would become null
+* Fewer things are copied in TableView's move constructor.
 
 ### API breaking changes:
 

--- a/src/realm/table_view.hpp
+++ b/src/realm/table_view.hpp
@@ -837,14 +837,14 @@ inline TableViewBase::TableViewBase(TableViewBase&& tv) noexcept:
     m_linked_table(move(tv.m_linked_table)),
     m_linked_column(tv.m_linked_column),
     m_linked_row(tv.m_linked_row),
-    m_linkview_source(tv.m_linkview_source),
+    m_linkview_source(std::move(tv.m_linkview_source)),
     // if we are created from a table view which is outdated, take care to use the outdated
     // version number so that we can later trigger a sync if needed.
     m_last_seen_version(tv.m_last_seen_version),
     m_distinct_column_source(tv.m_distinct_column_source),
-    m_sorting_predicate(tv.m_sorting_predicate),
+    m_sorting_predicate(std::move(tv.m_sorting_predicate)),
     m_auto_sort(tv.m_auto_sort),
-    m_query(tv.m_query),
+    m_query(std::move(tv.m_query)),
     m_start(tv.m_start),
     m_end(tv.m_end),
     m_limit(tv.m_limit),
@@ -872,15 +872,15 @@ inline TableViewBase& TableViewBase::operator=(TableViewBase&& tv) noexcept
         m_table->move_registered_view(&tv, this);
 
     m_row_indexes.move_assign(tv.m_row_indexes);
-    m_query = tv.m_query;
+    m_query = std::move(tv.m_query);
     m_num_detached_refs = tv.m_num_detached_refs;
     m_last_seen_version = tv.m_last_seen_version;
     m_auto_sort = tv.m_auto_sort;
     m_start = tv.m_start;
     m_end = tv.m_end;
     m_limit = tv.m_limit;
-    m_linkview_source = tv.m_linkview_source;
-    m_sorting_predicate = tv.m_sorting_predicate;
+    m_linkview_source = std::move(tv.m_linkview_source);
+    m_sorting_predicate = std::move(tv.m_sorting_predicate);
 
     return *this;
 }


### PR DESCRIPTION
m_query was missed when Query's copy constructor was switched to actually copying, and m_sorting_predicate always should have been moved.
