### PR TITLE
Update TableViews when applying instr_ClearTable

### DIFF
--- a/release_notes.md
+++ b/release_notes.md
@@ -4,6 +4,7 @@
 
 * When inserting a new non-nullable Binary column to a table that had
   *existing* rows, then the automatically added values would become null
+* Fixed updating TableViews when applying a transaction log with a table clear.
 * Fewer things are copied in TableView's move constructor.
 
 ### API breaking changes:

--- a/src/realm/table.cpp
+++ b/src/realm/table.cpp
@@ -5061,6 +5061,11 @@ void Table::adj_acc_clear_root_table() noexcept
         if (ColumnBase* col = m_cols[i])
             col->adj_acc_clear_root_table();
     }
+
+    // Adjust rows in tableviews after removal of all rows
+    for (auto& view : m_views) {
+        view->adj_row_acc_clear();
+    }
 }
 
 

--- a/src/realm/table_view.cpp
+++ b/src/realm/table_view.cpp
@@ -536,6 +536,14 @@ void TableViewBase::adj_row_acc_move_over(size_t from_row_ndx, size_t to_row_ndx
 }
 
 
+void TableViewBase::adj_row_acc_clear() noexcept
+{
+    m_num_detached_refs = m_row_indexes.size();
+    for (size_t i = 0, size = m_row_indexes.size(); i < size; ++i)
+        m_row_indexes.set(i, -1);
+}
+
+
 void TableView::remove(size_t row_ndx, RemoveMode underlying_mode)
 {
     check_cookie();

--- a/src/realm/table_view.hpp
+++ b/src/realm/table_view.hpp
@@ -410,6 +410,7 @@ private:
     void adj_row_acc_insert_rows(size_t row_ndx, size_t num_rows) noexcept;
     void adj_row_acc_erase_row(size_t row_ndx) noexcept;
     void adj_row_acc_move_over(size_t from_row_ndx, size_t to_row_ndx) noexcept;
+    void adj_row_acc_clear() noexcept;
 
     template<typename Tab>
     friend class BasicTableView;


### PR DESCRIPTION
The `CHECK(!tv.is_row_attached(0));` check in the newly added test fails without this.
