### PR TITLE
Don't have make limit the number of jobs based on load average on OS X

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -238,10 +238,11 @@ if ! printf "%s\n" "$MODE" | grep -q '^\(src-\|bin-\)\?dist'; then
     else
         if [ -r "/proc/cpuinfo" ]; then
             NUM_PROCESSORS="$(cat /proc/cpuinfo | grep -E 'processor[[:space:]]*:' | wc -l)" || exit 1
+            LIMIT_LOAD_AVERAGE=YES
         fi
     fi
     if [ "$NUM_PROCESSORS" ]; then
-        word_list_prepend MAKEFLAGS "-j$NUM_PROCESSORS -l$NUM_PROCESSORS" || exit 1
+        word_list_prepend MAKEFLAGS "-j$NUM_PROCESSORS ${LIMIT_LOAD_AVERAGE:+-l$MAX_LOAD_AVERAGE}" || exit 1
         export MAKEFLAGS
 
         if ! [ "$UNITTEST_THREADS" ]; then


### PR DESCRIPTION
This makes build-cocoa around 25% faster on my MacBook Pro, decreasing the time taken from ~23 minutes down to ~17 minutes.

The way that OS X computes load average is somewhat different than Linux. Building with a limit of only 4 jobs can easily send the load average up around 20. This results in substantially less parallelism than expected. Rather than trying to determine a reasonable load average for make to limit itself to on OS X, I've opted to just disable limiting based on load average.

/cc @kspangsege @teotwaki 
