### PR TITLE
Prevent spurious blocking in networking subsystem

### DIFF
--- a/release_notes.md
+++ b/release_notes.md
@@ -6,6 +6,8 @@
   *existing* rows, then the automatically added values would become null
 * Fixed updating TableViews when applying a transaction log with a table clear.
 * Fewer things are copied in TableView's move constructor.
+* Prevent spurious blocking in networking subsystem (put sockets in nonblocking
+  mode even when used with poll/select).
 
 ### API breaking changes:
 

--- a/src/realm/util/network.cpp
+++ b/src/realm/util/network.cpp
@@ -21,6 +21,7 @@ using namespace realm::util::network;
 
 namespace {
 
+// `ec` untouched on success
 std::error_code set_nonblocking(int fd, bool enable, std::error_code& ec) noexcept
 {
     int flags = ::fcntl(fd, F_GETFL, 0);
@@ -36,8 +37,7 @@ std::error_code set_nonblocking(int fd, bool enable, std::error_code& ec) noexce
         ec = make_basic_system_error_code(errno);
         return ec;
     }
-    ec = std::error_code(); // Success
-    return ec;
+    return std::error_code(); // Success
 }
 
 void set_nonblocking(int fd, bool enable)
@@ -338,12 +338,12 @@ public:
             case io_op_Read:
                 REALM_ASSERT(!oper_slot.read_oper);
                 pollfd_slot.events |= POLLRDNORM;
-                oper_slot.read_oper = move(op);
+                oper_slot.read_oper = std::move(op);
                 goto finish;
             case io_op_Write:
                 REALM_ASSERT(!oper_slot.write_oper);
                 pollfd_slot.events |= POLLWRNORM;
-                oper_slot.write_oper = move(op);
+                oper_slot.write_oper = std::move(op);
                 goto finish;
         }
         REALM_ASSERT(false);
@@ -376,14 +376,14 @@ public:
 
     void add_completed_oper(std::unique_ptr<async_oper> op) noexcept
     {
-        m_completed_operations.push_back(move(op));
+        m_completed_operations.push_back(std::move(op));
     }
 
     void add_post_oper(std::unique_ptr<async_oper> op) noexcept
     {
         {
             LockGuard l(m_mutex);
-            m_post_operations.push_back(move(op));
+            m_post_operations.push_back(std::move(op));
         }
         wake_up_poll_thread();
     }
@@ -400,11 +400,11 @@ public:
         io_oper_slot& oper_slot = m_io_operations[fd];
         REALM_ASSERT(oper_slot.read_oper || oper_slot.write_oper);
         if (oper_slot.read_oper) {
-            m_completed_operations.push_back(move(oper_slot.read_oper));
+            m_completed_operations.push_back(std::move(oper_slot.read_oper));
             --m_num_active_io_operations;
         }
         if (oper_slot.write_oper) {
-            m_completed_operations.push_back(move(oper_slot.write_oper));
+            m_completed_operations.push_back(std::move(oper_slot.write_oper));
             --m_num_active_io_operations;
         }
     }
@@ -569,7 +569,7 @@ private:
                     pollfd_slot.events &= ~POLLRDNORM;
                     if (pollfd_slot.events == 0)
                         pollfd_slot.fd = -1;
-                    m_completed_operations.push_back(move(oper_slot.read_oper));
+                    m_completed_operations.push_back(std::move(oper_slot.read_oper));
                     --m_num_active_io_operations;
                 }
             }
@@ -581,7 +581,7 @@ private:
                     pollfd_slot.events &= ~POLLWRNORM;
                     if (pollfd_slot.events == 0)
                         pollfd_slot.fd = -1;
-                    m_completed_operations.push_back(move(oper_slot.write_oper));
+                    m_completed_operations.push_back(std::move(oper_slot.write_oper));
                     --m_num_active_io_operations;
                 }
             }
@@ -650,22 +650,22 @@ void io_service::reset() noexcept
 
 void io_service::add_io_oper(int fd, std::unique_ptr<async_oper> op, io_op type)
 {
-    m_impl->add_io_oper(fd, move(op), type); // Throws
+    m_impl->add_io_oper(fd, std::move(op), type); // Throws
 }
 
 void io_service::add_wait_oper(std::unique_ptr<wait_oper_base> op)
 {
-    m_impl->add_wait_oper(move(op)); // Throws
+    m_impl->add_wait_oper(std::move(op)); // Throws
 }
 
 void io_service::add_completed_oper(std::unique_ptr<async_oper> op) noexcept
 {
-    m_impl->add_completed_oper(move(op));
+    m_impl->add_completed_oper(std::move(op));
 }
 
 void io_service::add_post_oper(std::unique_ptr<async_oper> op) noexcept
 {
-    m_impl->add_post_oper(move(op));
+    m_impl->add_post_oper(std::move(op));
 }
 
 
@@ -806,14 +806,14 @@ endpoint socket_base::local_endpoint(std::error_code& ec) const
 }
 
 
-void socket_base::do_open(const protocol& prot, std::error_code& ec)
+std::error_code socket_base::open(const protocol& prot, std::error_code& ec)
 {
     if (REALM_UNLIKELY(is_open()))
         throw std::runtime_error("Socket is already open");
     int sock_fd = ::socket(prot.m_family, prot.m_socktype, prot.m_protocol);
     if (REALM_UNLIKELY(sock_fd == -1)) {
         ec = make_basic_system_error_code(errno);
-        return;
+        return ec;
     }
 
 #if REALM_PLATFORM_APPLE
@@ -823,14 +823,17 @@ void socket_base::do_open(const protocol& prot, std::error_code& ec)
         if (REALM_UNLIKELY(ret == -1)) {
             ec = make_basic_system_error_code(errno);
             ::close(sock_fd);
-            return;
+            return ec;
         }
     }
 #endif
 
     m_protocol = prot;
     m_sock_fd = sock_fd;
+    // Sockets are in blocking mode by default
+    m_in_blocking_mode = true;
     ec = std::error_code(); // Success
+    return ec;
 }
 
 
@@ -893,37 +896,31 @@ void socket_base::map_option(opt_enum opt, int& level, int& option_name) const
 }
 
 
+std::error_code socket_base::set_nonblocking_mode(bool enable, std::error_code& ec) noexcept
+{
+    return set_nonblocking(m_sock_fd, enable, ec);
+}
+
+
 std::error_code socket::connect(const endpoint& ep, std::error_code& ec)
 {
     REALM_ASSERT(!m_write_oper);
 
-    if (initiate_connect(ep, ec))
-        return ec; // Failure, or immediate completion
-
-    // Wait for file descriptor to become writable
-    {
-        using pollfd = struct pollfd;
-        pollfd slot = pollfd(); // Cleared slot
-        slot.fd = get_sock_fd();
-        slot.events = POLLWRNORM;
-        nfds_t nfds = 1;
-        int timeout = -1; // Wait indefinitely
-        for (;;) {
-            int ret = ::poll(&slot, nfds, timeout);
-            if (ret >= 0) {
-                REALM_ASSERT(ret == 1);
-                break;
-            }
-            if (REALM_UNLIKELY(errno != EINTR)) {
-                ec = make_basic_system_error_code(errno);
-                return ec;
-            }
-            // Retry on interruption by system signal
-        }
+    if (!is_open()) {
+        if (REALM_UNLIKELY(open(ep.protocol(), ec)))
+            return ec;
     }
 
-    if (finalize_connect(ec))
-        return ec; // Failure
+    if (REALM_UNLIKELY(ensure_blocking_mode(ec)))
+        return ec;
+
+    socklen_t addr_len = ep.m_protocol.is_ip_v4() ?
+        sizeof (endpoint::sockaddr_ip_v4_type) : sizeof (endpoint::sockaddr_ip_v6_type);
+    int ret = ::connect(get_sock_fd(), &ep.m_sockaddr_union.m_base, addr_len);
+    if (REALM_UNLIKELY(ret == -1)) {
+        ec = make_basic_system_error_code(errno);
+        return ec;
+    }
 
     ec = std::error_code(); // Success
     return ec;
@@ -933,10 +930,12 @@ std::error_code socket::connect(const endpoint& ep, std::error_code& ec)
 std::error_code socket::write(const char* data, size_t size, std::error_code& ec) noexcept
 {
     REALM_ASSERT(!m_write_oper);
+    if (ensure_blocking_mode(ec))
+        return ec;
     const char* begin = data;
     const char* end = data + size;
     while (begin != end) {
-        size_t n = write_some(begin, end-begin, ec);
+        size_t n = do_write_some(begin, end-begin, ec);
         if (REALM_UNLIKELY(ec))
             return ec;
         REALM_ASSERT(n > 0);
@@ -948,7 +947,7 @@ std::error_code socket::write(const char* data, size_t size, std::error_code& ec
 }
 
 
-size_t socket::read_some(char* buffer, size_t size, std::error_code& ec) noexcept
+size_t socket::do_read_some(char* buffer, size_t size, std::error_code& ec) noexcept
 {
     int flags = 0;
     for (;;) {
@@ -971,7 +970,7 @@ size_t socket::read_some(char* buffer, size_t size, std::error_code& ec) noexcep
 }
 
 
-size_t socket::write_some(const char* data, size_t size, std::error_code& ec) noexcept
+size_t socket::do_write_some(const char* data, size_t size, std::error_code& ec) noexcept
 {
     int flags = 0;
 #ifdef __linux__
@@ -993,24 +992,15 @@ size_t socket::write_some(const char* data, size_t size, std::error_code& ec) no
 }
 
 
-void socket::do_open(const protocol& prot, std::error_code& ec)
-{
-    socket_base::do_open(prot, ec); // Throws
-    if (ec)
-        return;
-    if (set_nonblocking(get_sock_fd(), true, ec)) {
-        do_close();
-        return;
-    }
-}
-
-
-bool socket::initiate_connect(const endpoint& ep, std::error_code& ec) noexcept
+bool socket::initiate_async_connect(const endpoint& ep, std::error_code& ec) noexcept
 {
     if (!is_open()) {
         if (REALM_UNLIKELY(open(ep.protocol(), ec)))
             return true; // Failure
     }
+
+    if (REALM_UNLIKELY(ensure_nonblocking_mode(ec)))
+        return true; // Failure
 
     // Initiate connect operation.
     socklen_t addr_len = ep.m_protocol.is_ip_v4() ?
@@ -1031,12 +1021,11 @@ bool socket::initiate_connect(const endpoint& ep, std::error_code& ec) noexcept
         return true; // Failure
     }
 
-    ec = std::error_code(); // Success
     return false; // Successful initiation, but no immediate completion.
 }
 
 
-std::error_code socket::finalize_connect(std::error_code& ec) noexcept
+std::error_code socket::finalize_async_connect(std::error_code& ec) noexcept
 {
     int connect_errno = 0;
     socklen_t connect_errno_size = sizeof connect_errno;
@@ -1050,13 +1039,7 @@ std::error_code socket::finalize_connect(std::error_code& ec) noexcept
         ec = make_basic_system_error_code(connect_errno);
         return ec; // connect failed
     }
-
-    // Disable nonblocking mode
-    if (REALM_UNLIKELY(set_nonblocking(get_sock_fd(), false, ec)))
-        return ec;
-
-    ec = std::error_code(); // Success
-    return ec;
+    return std::error_code(); // Success
 }
 
 
@@ -1111,6 +1094,7 @@ std::error_code acceptor::do_accept(socket& sock, endpoint* ep, std::error_code&
 #endif
 
     sock.m_sock_fd = sock_fd;
+    sock.m_in_blocking_mode = true;
     if (ep) {
         ep->m_protocol = m_protocol;
         ep->m_sockaddr_union = buffer.m_sockaddr_union;
@@ -1124,6 +1108,8 @@ size_t buffered_input_stream::do_read(char* buffer, size_t size, int delim,
                                       std::error_code& ec) noexcept
 {
     REALM_ASSERT(!m_socket.m_read_oper);
+    if (m_socket.ensure_blocking_mode(ec))
+        return 0;
     char* out_begin = buffer;
     char* out_end = buffer + size;
     for (;;) {
@@ -1147,7 +1133,7 @@ size_t buffered_input_stream::do_read(char* buffer, size_t size, int delim,
             *out_begin++ = *m_begin++; // Transfer delimiter
             break;
         }
-        size_t m = m_socket.read_some(m_buffer.get(), s_buffer_size, ec);
+        size_t m = m_socket.do_read_some(m_buffer.get(), s_buffer_size, ec);
         if (REALM_UNLIKELY(ec))
             return out_begin - buffer;
         REALM_ASSERT(m > 0);
@@ -1194,7 +1180,8 @@ void buffered_input_stream::read_oper_base::proceed() noexcept
     REALM_ASSERT(!m_error_code);
     REALM_ASSERT(m_stream.m_begin == m_stream.m_end);
     REALM_ASSERT(m_out_curr < m_out_end);
-    size_t n = m_stream.m_socket.read_some(m_stream.m_buffer.get(), s_buffer_size, m_error_code);
+    size_t n = m_stream.m_socket.do_read_some(m_stream.m_buffer.get(), s_buffer_size,
+                                              m_error_code);
     if (REALM_UNLIKELY(m_error_code)) {
         complete = true;
         return;


### PR DESCRIPTION
Prevent spurious blocking in networking subsystem by putting sockets into nonblocking mode even when used with poll/select.

The basic idea here is to switch the socket mode back and forth between blocking and nonblocking mode as necessary. The performance impact is insignificant as it is assumed that sockets will be use either predominantly in blocking mode, or predominantly in nonblocking mode. To efficiently know when to switch, `socket_base::m_in_blocking_mode` was added.

@teotwaki @simonask 
