### PR TITLE
Allow bindings to install a termination notification handler

### DIFF
--- a/src/realm/util/terminate.cpp
+++ b/src/realm/util/terminate.cpp
@@ -49,7 +49,8 @@ void please_report_this_error_to_help_at_realm_dot_io() {
 namespace {
 
 #if REALM_PLATFORM_APPLE
-void nslog(const char *message) {
+void nslog(const char *message) noexcept
+{
     CFStringRef str = CFStringCreateWithCStringNoCopy(kCFAllocatorDefault, message, kCFStringEncodingUTF8, kCFAllocatorNull);
     CFShow(str);
 
@@ -63,20 +64,20 @@ void nslog(const char *message) {
     CFRelease(str);
 }
 
-static realm::util::TerminationNotificationCallback termination_notification_callback = nslog;
+void(*termination_notification_callback)(const char*) noexcept = nslog;
 
 #elif REALM_PLATFORM_ANDROID
 
-void android_log(const char* message)
+void android_log(const char* message) noexcept
 {
     __android_log_print(ANDROID_LOG_ERROR, "REALM", message);
 }
 
-static realm::util::TerminationNotificationCallback termination_notification_callback = android_log;
+void(*termination_notification_callback)(const char*) noexcept = android_log;
 
 #else
 
-static realm::util::TerminationNotificationCallback termination_notification_callback = nullptr;
+void(*termination_notification_callback)(const char*) noexcept = nullptr;
 
 #endif
 
@@ -85,7 +86,7 @@ static realm::util::TerminationNotificationCallback termination_notification_cal
 namespace realm {
 namespace util {
 
-void set_termination_notification_callback(TerminationNotificationCallback callback)
+void set_termination_notification_callback(void(*callback)(const char* ) noexcept) noexcept
 {
     termination_notification_callback = callback;
 }

--- a/src/realm/util/terminate.hpp
+++ b/src/realm/util/terminate.hpp
@@ -32,9 +32,17 @@
 namespace realm {
 namespace util {
 
-using TerminationNotificationCallback = void(*)(const char* message);
-
-void set_termination_notification_callback(TerminationNotificationCallback);
+/// Install a custom termination notification callback. This will only be called as a result of
+/// Realm crashing internally, i.e. a failed assertion or an otherwise irrecoverable error
+/// condition. The termination notification callback is supplied with a zero-terminated string
+/// containing information relevant for debugging the issue leading to the crash.
+///
+/// The termination notification callback is shared by all threads, which is another way of saying
+/// that it must be reentrant, in case multiple threads crash simultaneously.
+///
+/// Furthermore, the provided callback must be `noexcept`, indicating that if an exception
+/// is thrown in the callback, the process is terminated with a call to `std::terminate`.
+void set_termination_notification_callback(void(*callback)(const char* message) noexcept) noexcept;
 
 REALM_NORETURN void terminate_internal(std::stringstream&) noexcept;
 


### PR DESCRIPTION
Fixes #1320

It is intended that bindings will call logging functions that forward the message string to a crash handler, such as Crashlytics with `CLS_LOG` or similar.

Potentially, depending on the installed crash handler for the app, the bindings may also choose to upload extra information that will help debugging crashes (such as the realm file itself if it's small enough, or extra logging about what the user might have been doing prior to the crash).

@kspangsege @rrrlasse @mrackwitz 
