### PR TITLE
Restore the SharedGroup to a consistent state if the transact log observer throws

### DIFF
--- a/release_notes.md
+++ b/release_notes.md
@@ -8,6 +8,8 @@
 * Fewer things are copied in TableView's move constructor.
 * Prevent spurious blocking in networking subsystem (put sockets in nonblocking
   mode even when used with poll/select).
+* Fixed the shared group being left in an inconsistent state if the transaction
+  log observer threw an exception.
 
 ### API breaking changes:
 

--- a/src/realm/group_shared.hpp
+++ b/src/realm/group_shared.hpp
@@ -902,11 +902,20 @@ inline void SharedGroup::advance_read(History& history, O* observer, VersionID v
     const BinaryData* changesets_end = changesets_begin + num_changesets;
 
     if (observer) {
-        _impl::TransactLogParser parser;
-        _impl::MultiLogNoCopyInputStream in(changesets_begin, changesets_end);
-        parser.parse(in, *observer); // Throws
-        observer->parse_complete(); // Throws
+        try {
+            _impl::TransactLogParser parser;
+            _impl::MultiLogNoCopyInputStream in(changesets_begin, changesets_end);
+            parser.parse(in, *observer); // Throws
+            observer->parse_complete(); // Throws
+        }
+        catch (...) {
+            release_readlock(m_readlock);
+            m_readlock = old_readlock;
+            rlug.release();
+            throw;
+        }
     }
+
     _impl::MultiLogNoCopyInputStream in(changesets_begin, changesets_end);
     using gf = _impl::GroupFriend;
     gf::advance_transact(m_group, m_readlock.m_top_ref, m_readlock.m_file_size, in); // Throws


### PR DESCRIPTION
The SharedGroup was left holding the readlock for the new version while the Group was still pointing at the (no longer locked) old version.
