### PR TITLE
Fixed erroneous whitespace changes around templates

### DIFF
--- a/src/realm/table_accessors.hpp
+++ b/src/realm/table_accessors.hpp
@@ -78,8 +78,7 @@ struct SpecBase {
     ///     typedef TypeAppend<void, int>::type Columns1;
     ///     typedef TypeAppend<Columns1, bool>::type Columns;
     ///
-    ///     template<template<int>
-    ///     class Col, class Init>
+    ///     template<template<int> class Col, class Init>
     ///     struct ColNames {
     ///       typename Col<0>::type foo;
     ///       typename Col<1>::type bar;
@@ -93,8 +92,8 @@ struct SpecBase {
     /// particular column index. You may specify the column names in
     /// any order. Multiple names may refer to the same column, and
     /// you do not have to specify a name for every column.
-    template<template<int>
-    class Col, class Init> struct ColNames {
+    template<template<int> class Col, class Init>
+    struct ColNames {
         ColNames(Init) noexcept {}
     };
 

--- a/src/realm/util/file_mapper.cpp
+++ b/src/realm/util/file_mapper.cpp
@@ -194,8 +194,7 @@ void copy_state(const RaiseRequest<CodeType>&, const RaiseStateIdentityRequest<N
     // RaiseRequest does not have state
 }
 
-template<template<typename>
-class ForwardType, typename ForwardCodeType>
+template<template<typename> class ForwardType, typename ForwardCodeType>
 void copy_state(ForwardType<ForwardCodeType>& forward,
                 const RaiseStateIdentityRequest<NativeCodeType>& request,
                 typename ForwardType<ForwardCodeType>::has_state = 0)
@@ -225,8 +224,7 @@ void copy_thread(const RaiseStateRequest<CodeType>&, const RaiseStateIdentityReq
     // RaiseStateRequest does not have a thread
 }
 
-template<template<typename>
-class ForwardType, typename ForwardCodeType>
+template<template<typename> class ForwardType, typename ForwardCodeType>
 void copy_thread(ForwardType<ForwardCodeType>& forward,
                 const RaiseStateIdentityRequest<NativeCodeType>& request,
                 typename ForwardType<ForwardCodeType>::has_thread = 0)
@@ -236,8 +234,7 @@ void copy_thread(ForwardType<ForwardCodeType>& forward,
     forward.thread.task = request.thread.task;
 }
 
-template<template<typename>
-class ForwardType, typename ForwardCodeType>
+template<template<typename> class ForwardType, typename ForwardCodeType>
 void convert_and_forward_message(const RaiseStateIdentityRequest<NativeCodeType>& request, MachExceptionMessageID msg)
 {
     ForwardType<ForwardCodeType> forward;

--- a/src/realm/util/tuple.hpp
+++ b/src/realm/util/tuple.hpp
@@ -37,8 +37,7 @@ struct Tuple {
     Tuple(const head_type& h, const tail_type& t): m_head(h), m_tail(t) {}
 };
 template<>
-struct Tuple<void>
-{};
+struct Tuple<void> {};
 
 
 template<class H, class T>
@@ -84,16 +83,14 @@ tuple(const A& a, const B& b, const C& c, const D& d, const E& e)
 }
 
 template<class A, class B, class C, class D, class E, class F>
-inline
-Tuple<TypeCons<A, TypeCons<B, TypeCons<C, TypeCons<D, TypeCons<E, TypeCons<F, void>>>>>>>
+inline Tuple<TypeCons<A, TypeCons<B, TypeCons<C, TypeCons<D, TypeCons<E, TypeCons<F, void>>>>>>>
 tuple(const A& a, const B& b, const C& c, const D& d, const E& e, const F& f)
 {
     return cons(a, tuple(b,c,d,e,f));
 }
 
 template<class A, class B, class C, class D, class E, class F, class G>
-inline
-Tuple<TypeCons<A, TypeCons<B, TypeCons<C, TypeCons<D, TypeCons<E, TypeCons<F, TypeCons<G, void>>>>>>>>
+inline Tuple<TypeCons<A, TypeCons<B, TypeCons<C, TypeCons<D, TypeCons<E, TypeCons<F, TypeCons<G, void>>>>>>>>
 tuple(const A& a, const B& b, const C& c, const D& d, const E& e, const F& f, const G& g)
 {
     return cons(a, tuple(b,c,d,e,f,g));
@@ -155,26 +152,22 @@ inline typename TypeAt<L,i>::type at(const Tuple<L>& tuple)
     return _impl::TupleAt<L,i>::exec(tuple);
 }
 
-template<template<class T>
-class Op, class L>
+template<template<class T> class Op, class L>
 inline void for_each(const Tuple<L>& tuple)
 {
     Op<typename L::head>()(tuple.head);
     for_each<Op>(tuple.m_tail);
 }
-template<template<class T>
-class Op>
+template<template<class T> class Op>
 inline void for_each(const Tuple<void>&) {}
 
-template<template<class T>
-class Op, class L, class A>
+template<template<class T> class Op, class L, class A>
 inline void for_each(const Tuple<L>& tuple, const A& a)
 {
     Op<typename L::head>()(tuple.m_head, a);
     for_each<Op>(tuple.m_tail, a);
 }
-template<template<class T>
-class Op, class A>
+template<template<class T> class Op, class A>
 inline void for_each(const Tuple<void>&, const A&) {}
 
 template<class Ch, class Tr, class L>

--- a/src/realm/util/type_list.hpp
+++ b/src/realm/util/type_list.hpp
@@ -104,8 +104,8 @@ struct TypeCount<void>
 ///
 /// \tparam Pred Must be such that `Pred<T>::value` is true if, and
 /// only if the predicate is satisfied for `T`.
-template<class List, template<class>
-class Pred> struct FindType {
+template<class List, template<class> class Pred>
+struct FindType {
 private:
     typedef typename List::head                                type_1;
     typedef typename FindType<typename List::tail, Pred>::type type_2;
@@ -113,8 +113,8 @@ public:
     typedef typename std::conditional<Pred<type_1>::value, type_1, type_2>::type type;
 };
 /// Base case for empty type list.
-template<template<class>
-class Pred> struct FindType<void, Pred> {
+template<template<class> class Pred>
+struct FindType<void, Pred> {
     typedef void type;
 };
 
@@ -123,8 +123,8 @@ class Pred> struct FindType<void, Pred> {
 ///
 /// \tparam List The list of types, constructed using TypeCons<>. Note
 /// that 'void' is interpreted as a zero-length list.
-template<class List, template<class T, int i>
-class Op, int i=0> struct ForEachType {
+template<class List, template<class T, int i> class Op, int i=0>
+struct ForEachType {
     /// Execute the `Op<T,i>::exec()` for each type `T` at index `i`
     /// in `List`.
     static void exec()
@@ -177,8 +177,8 @@ class Op, int i> struct ForEachType<void, Op, i> {
 ///
 /// \tparam List The list of types, constructed using TypeCons<>. Note
 /// that 'void' is interpreted as a zero-length list.
-template<class List, template<class T, int i>
-class Pred, int i=0> struct HasType {
+template<class List, template<class T, int i> class Pred, int i=0>
+struct HasType {
     /// Execute the `Op<T,i>::exec()` for each type `T` at index `i`
     /// in `List`.
     static bool exec()
@@ -212,8 +212,8 @@ class Pred, int i=0> struct HasType {
     }
 };
 /// Base case for empty type list.
-template<template<class T, int i>
-class Pred, int i> struct HasType<void, Pred, i> {
+template<template<class T, int i> class Pred, int i>
+struct HasType<void, Pred, i> {
     static bool exec() { return false; }
     template<class A>
     static bool exec(const A&) { return false; }


### PR DESCRIPTION
These erroneous formatting errors were introduced previously by my quick-and-dirty regular expressions. Should be trivial to review, though.
