### PR TITLE
Fix the build with encryption disabled on Linux without OpenSSL headers on the system

### DIFF
--- a/src/realm/util/aes_cryptor.hpp
+++ b/src/realm/util/aes_cryptor.hpp
@@ -20,10 +20,11 @@
 
 #include <cstddef>
 #include <memory>
-#include <stdint.h>
 #include <realm/util/features.h>
-
+#include <stdint.h>
 #include <vector>
+
+#if REALM_ENABLE_ENCRYPTION
 
 #if REALM_PLATFORM_APPLE
 #  include <CommonCrypto/CommonCrypto.h>
@@ -91,3 +92,5 @@ struct SharedFileInfo {
 
 }
 }
+
+#endif // REALM_ENABLE_ENCRYPTION


### PR DESCRIPTION
The body of aes_cryptor.hpp was extracted from inside the `REALM_ENCRYPTION_ENABLED` #if in encrypted_file_mapping.hpp in ecbcc9d6, but ended up unguarded in the new file.
