### PR TITLE
Enable encryption feature in tvOS

### DIFF
--- a/src/realm/util/features.h
+++ b/src/realm/util/features.h
@@ -176,9 +176,6 @@
 #  if TARGET_OS_TV
 /* Device (Apple TV) or simulator. */
 #    define REALM_TVOS 1
-/* The necessary signal handling / mach exception APIs are all unavailable */
-#    undef  REALM_ENABLE_ENCRYPTION
-#    define REALM_ENABLE_ENCRYPTION 0
 #  endif
 #else
 #  define REALM_PLATFORM_APPLE 0


### PR DESCRIPTION
Switch away from Mach exceptions allow encrypted Realms to work on tvOS
I've confirmed all unit tests are passed on devices.

cc/ @bdash @jpsim @finnschiermer @beeender 
