### PR TITLE
Speeds up unit test framework by a factor of >100 when the thread bug…

### DIFF
--- a/test/util/unit_test.cpp
+++ b/test/util/unit_test.cpp
@@ -244,7 +244,7 @@ class TestList::ExecContext {
 public:
     SharedContext* m_shared;
     Mutex m_mutex;
-	std::atomic<long long> m_num_checks;
+    std::atomic<long long> m_num_checks;
     long long m_num_failed_checks;
     long m_num_failed_tests;
     bool m_errors_seen;


### PR DESCRIPTION
… detection tool pthread_test.hpp is enabled (see beginning of thread.hpp). No measurable speedup when not enabled.
