### PR TITLE
New default constructor added to BasicRowExpr<>

### DIFF
--- a/release_notes.md
+++ b/release_notes.md
@@ -10,7 +10,8 @@
 
 ### Enhancements:
 
-* Lorem ipsum.
+* New default constructor added to `BasicRowExpr<>`. A default constructed
+  instance is in the detached state.
 
 -----------
 

--- a/src/realm/row.hpp
+++ b/src/realm/row.hpp
@@ -182,6 +182,8 @@ template<class T>
 class BasicRowExpr:
         public RowFuncs<T, BasicRowExpr<T>> {
 public:
+    BasicRowExpr() noexcept;
+
     template<class U>
     BasicRowExpr(const BasicRowExpr<U>&) noexcept;
 
@@ -647,6 +649,13 @@ inline size_t RowFuncs<T,R>::row_ndx() const noexcept
     return static_cast<const R*>(this)->impl_get_row_ndx();
 }
 
+
+template<class T>
+inline BasicRowExpr<T>::BasicRowExpr() noexcept:
+    m_table(0),
+    m_row_ndx(0)
+{
+}
 
 template<class T>
 template<class U>

--- a/test/test_table.cpp
+++ b/test/test_table.cpp
@@ -5287,6 +5287,14 @@ TEST(Table_RowAccessorDetach)
 }
 
 
+TEST(Table_RowAccessor_DetachedRowExpr)
+{
+    // Check that it is possible to create a detached RowExpr from scratch.
+    BasicRowExpr<Table> row;
+    CHECK_NOT(row.is_attached());
+}
+
+
 TEST(Table_RowAccessorCopyAndAssign)
 {
     Table table;


### PR DESCRIPTION
New default constructor added to `BasicRowExpr<>`. A default constructed instance begins its life in the detached state.

@alazier 
