### PR TITLE
Log the correct value for is_move_last_over in Table::batch_erase_rows()

### DIFF
--- a/release_notes.md
+++ b/release_notes.md
@@ -2,7 +2,7 @@
 
 ### Bugfixes:
 
-* Lorem ipsum.
+* Fixed Row accessor updating after an unordered TableView::clear().
 
 ### API breaking changes:
 

--- a/src/realm/table.cpp
+++ b/src/realm/table.cpp
@@ -2126,7 +2126,6 @@ void Table::batch_erase_rows(const IntegerColumn& row_indexes, bool is_move_last
             if (repl) {
                 size_t num_rows_to_erase = 1;
                 size_t prior_num_rows = m_size;
-                bool is_move_last_over = false;
                 repl->erase_rows(this, row_ndx, num_rows_to_erase, prior_num_rows,
                                  is_move_last_over); // Throws
             }


### PR DESCRIPTION
It was always logging clear() as ordered removals, resulting in the accessors on other threads being updated incorrectly.
