### PR TITLE
Set the last seen version correctly for TableViews created from queries on LinkViews

### DIFF
--- a/release_notes.md
+++ b/release_notes.md
@@ -2,7 +2,9 @@
 
 ### Bugfixes:
 
-* Lorem ipsum.
+* Fixed incorrect initialization of TableViews from queries on LinkViews
+  resulting in `TableView::is_in_sync()` being incorrect until the first time
+  it is brought back into sync.
 
 ### API breaking changes:
 

--- a/src/realm/table_view.cpp
+++ b/src/realm/table_view.cpp
@@ -98,10 +98,6 @@ void TableViewBase::apply_patch(Handover_patch& patch, Group& group)
 {
     TableRef tr = group.get_table(patch.table_num);
     m_table = tr;
-    if (patch.was_in_sync)
-        m_last_seen_version = tr->m_version;
-    else
-        m_last_seen_version = -1;
     tr->register_view(this);
     m_query.apply_patch(patch.query_patch, group);
     m_linkview_source = LinkView::create_from_and_consume_patch(patch.linkview_patch, group);
@@ -112,6 +108,11 @@ void TableViewBase::apply_patch(Handover_patch& patch, Group& group)
         m_linked_column = patch.linked_column;
         m_linked_row = patch.linked_row;
     }
+
+    if (patch.was_in_sync)
+        m_last_seen_version = outside_version();
+    else
+        m_last_seen_version = -1;
 }
 
 // Searching

--- a/src/realm/table_view.hpp
+++ b/src/realm/table_view.hpp
@@ -332,10 +332,8 @@ protected:
     // If this TableView was created from a LinkView, then this reference points to it. Otherwise it's 0
     mutable ConstLinkViewRef m_linkview_source;
 
-    mutable uint_fast64_t m_last_seen_version;
-
     // m_distinct_column_source != npos if this view was created from distinct values in a column of m_table.
-    size_t m_distinct_column_source;
+    size_t m_distinct_column_source = npos;
 
     // If m_distinct_columns.size() > 0, it means that this TableView has had called TableView::distinct() and
     // must only contain unique rows with respect to that column set of the parent table
@@ -353,6 +351,8 @@ protected:
     size_t m_start;
     size_t m_end;
     size_t m_limit;
+
+    mutable uint_fast64_t m_last_seen_version = 0;
 
     size_t m_num_detached_refs = 0;
     /// Construct null view (no memory allocated).
@@ -760,10 +760,7 @@ inline size_t TableViewBase::find_by_source_ndx(size_t source_ndx) const noexcep
 }
 
 inline TableViewBase::TableViewBase():
-    RowIndexes(IntegerColumn::unattached_root_tag(), Allocator::get_default()), // Throws
-    m_last_seen_version(0),
-    m_distinct_column_source(npos),
-    m_auto_sort(false)
+    RowIndexes(IntegerColumn::unattached_root_tag(), Allocator::get_default()) // Throws
 {
     ref_type ref = IntegerColumn::create(m_row_indexes.get_alloc()); // Throws
     m_row_indexes.get_root_array()->init_from_ref(ref);
@@ -772,10 +769,8 @@ inline TableViewBase::TableViewBase():
 inline TableViewBase::TableViewBase(Table* parent):
     RowIndexes(IntegerColumn::unattached_root_tag(), Allocator::get_default()),
     m_table(parent->get_table_ref()), // Throws
-    m_last_seen_version(m_table ? m_table->m_version : 0),
-    m_distinct_column_source(npos),
-    m_auto_sort(false)
-    {
+    m_last_seen_version(m_table ? m_table->m_version : 0)
+{
     // FIXME: This code is unreasonably complicated because it uses `IntegerColumn` as
     // a free-standing container, and beause `IntegerColumn` does not conform to the
     // RAII idiom (nor should it).
@@ -789,13 +784,11 @@ inline TableViewBase::TableViewBase(Table* parent):
 inline TableViewBase::TableViewBase(Table* parent, Query& query, size_t start, size_t end, size_t limit):
     RowIndexes(IntegerColumn::unattached_root_tag(), Allocator::get_default()), // Throws
     m_table(parent->get_table_ref()),
-    m_last_seen_version(m_table ? m_table->m_version : 0),
-    m_distinct_column_source(npos),
-    m_auto_sort(false),
     m_query(query),
     m_start(start),
     m_end(end),
-    m_limit(limit)
+    m_limit(limit),
+    m_last_seen_version(outside_version())
 {
     // FIXME: This code is unreasonably complicated because it uses `IntegerColumn` as
     // a free-standing container, and beause `IntegerColumn` does not conform to the
@@ -813,9 +806,7 @@ inline TableViewBase::TableViewBase(Table *parent, Table *linked_table, size_t c
     m_linked_table(linked_table->get_table_ref()), // Throws
     m_linked_column(column),
     m_linked_row(row_ndx),
-    m_last_seen_version(m_table ? m_table->m_version : 0),
-    m_distinct_column_source(npos),
-    m_auto_sort(false)
+    m_last_seen_version(m_table ? m_table->m_version : 0)
 {
     // FIXME: This code is unreasonably complicated because it uses `IntegerColumn` as
     // a free-standing container, and beause `IntegerColumn` does not conform to the
@@ -834,7 +825,6 @@ inline TableViewBase::TableViewBase(const TableViewBase& tv):
     m_linked_column(tv.m_linked_column),
     m_linked_row(tv.m_linked_row),
     m_linkview_source(tv.m_linkview_source),
-    m_last_seen_version(tv.m_last_seen_version),
     m_distinct_column_source(tv.m_distinct_column_source),
     m_distinct_columns(std::move(tv.m_distinct_columns)),
     m_sorting_predicate(std::move(tv.m_sorting_predicate)),
@@ -843,6 +833,7 @@ inline TableViewBase::TableViewBase(const TableViewBase& tv):
     m_start(tv.m_start),
     m_end(tv.m_end),
     m_limit(tv.m_limit),
+    m_last_seen_version(tv.m_last_seen_version),
     m_num_detached_refs(tv.m_num_detached_refs)
     {
     // FIXME: This code is unreasonably complicated because it uses `IntegerColumn` as
@@ -864,9 +855,6 @@ inline TableViewBase::TableViewBase(TableViewBase&& tv) noexcept:
     m_linked_column(tv.m_linked_column),
     m_linked_row(tv.m_linked_row),
     m_linkview_source(std::move(tv.m_linkview_source)),
-    // if we are created from a table view which is outdated, take care to use the outdated
-    // version number so that we can later trigger a sync if needed.
-    m_last_seen_version(tv.m_last_seen_version),
     m_distinct_column_source(tv.m_distinct_column_source),
     m_distinct_columns(std::move(tv.m_distinct_columns)),
     m_sorting_predicate(std::move(tv.m_sorting_predicate)),
@@ -875,6 +863,9 @@ inline TableViewBase::TableViewBase(TableViewBase&& tv) noexcept:
     m_start(tv.m_start),
     m_end(tv.m_end),
     m_limit(tv.m_limit),
+    // if we are created from a table view which is outdated, take care to use the outdated
+    // version number so that we can later trigger a sync if needed.
+    m_last_seen_version(tv.m_last_seen_version),
     m_num_detached_refs(tv.m_num_detached_refs)
 {
     if (m_table)

--- a/test/test_lang_bind_helper.cpp
+++ b/test/test_lang_bind_helper.cpp
@@ -9513,6 +9513,7 @@ TEST(LangBindHelper_HandoverTableViewWithLinkView)
 
         // tv.m_table == table1
         tv = q.find_all(); // tv = { 0, 2 }
+        CHECK(tv.is_in_sync());
 
         // TableView tv2 = lvr->get_sorted_view(0);
         LangBindHelper::commit_and_continue_as_read(sg_w);
@@ -9524,6 +9525,7 @@ TEST(LangBindHelper_HandoverTableViewWithLinkView)
         sg_w.close();
         std::unique_ptr<TableView> tv( sg.import_from_handover(move(handover)) ); // <-- import tv
 
+        CHECK(tv->is_in_sync());
         CHECK_EQUAL(2, tv->size());
         CHECK_EQUAL(0, tv->get_source_ndx(0));
         CHECK_EQUAL(2, tv->get_source_ndx(1));


### PR DESCRIPTION
The initial last seen version was always being set to the target's version, while is_in_sync() uses the origin table's version. This normally just resulted in the query being rerun when it didn't need to be, but could theoretically result in it not being rerun when needed given sufficiently bad luck.
