### PR TITLE
Use get_uint/set_uint to get/set links

### DIFF
--- a/src/realm/column_link.hpp
+++ b/src/realm/column_link.hpp
@@ -172,12 +172,12 @@ inline void LinkColumn::do_swap_link(size_t row_ndx, size_t target_row_ndx_1,
     ++target_row_ndx_1;
     ++target_row_ndx_2;
 
-    size_t value = LinkColumnBase::get(row_ndx);
+    size_t value = LinkColumnBase::get_uint(row_ndx);
     if (value == target_row_ndx_1) {
-        LinkColumnBase::set(row_ndx, target_row_ndx_2);
+        LinkColumnBase::set_uint(row_ndx, target_row_ndx_2);
     }
     else if (value == target_row_ndx_2) {
-        LinkColumnBase::set(row_ndx, target_row_ndx_1);
+        LinkColumnBase::set_uint(row_ndx, target_row_ndx_1);
     }
 }
 


### PR DESCRIPTION
Note: These methods are technically deprecated.

Fixes #1391.

@danielpovlsen @kspangsege 
