### PR TITLE
Avoid narrowing the return value of LinkColumnBase::get_uint

### DIFF
--- a/src/realm/column_link.hpp
+++ b/src/realm/column_link.hpp
@@ -172,7 +172,7 @@ inline void LinkColumn::do_swap_link(size_t row_ndx, size_t target_row_ndx_1,
     ++target_row_ndx_1;
     ++target_row_ndx_2;
 
-    size_t value = LinkColumnBase::get_uint(row_ndx);
+    uint64_t value = LinkColumnBase::get_uint(row_ndx);
     if (value == target_row_ndx_1) {
         LinkColumnBase::set_uint(row_ndx, target_row_ndx_2);
     }


### PR DESCRIPTION
This addresses a warning seen when building Realm for 32-bit iOS.

Fixes #1391.
