### PR TITLE
Enable very, very strict warnings (on Clang)

### DIFF
--- a/src/project.mk
+++ b/src/project.mk
@@ -12,6 +12,12 @@ ifneq ($(REALM_ENABLE_FAT_BINARIES),)
   endif
 endif
 
+ifeq ($(COMPILER_IS),clang)
+	CFLAGS_ARCH += -Weverything -Wno-c++98-compat -Wno-c++98-compat-pedantic -Wno-undef \
+				   -Wno-exit-time-destructors -Wno-global-constructors -Wno-padded \
+				   -Wno-sign-conversion
+endif
+
 ifeq ($(OS),Darwin)
   CFLAGS_ARCH += -mmacosx-version-min=10.8 -stdlib=libc++ -Wno-nested-anon-types
   VALGRIND_FLAGS += --dsymutil=yes --suppressions=$(GENERIC_MK_DIR)/../test/corefoundation-yosemite.suppress


### PR DESCRIPTION
Please discuss. :-)

I have added the `-Weverything` flag when building with Clang, which makes the compiler very stern. I have selectively disabled a couple of warnings that we legitimately do not want to care about.

**Motivation:** We are shipping header files to app developers (in Cocoa), even if they aren't open source, and app developers should ideally be free to enable much stricter warnings than what's included by `-Wall`.

The question is whether we can live with this.

Disabled warnings:
- `-Wno-undef`: Undefined macros evaluate to 0. I would actually prefer to enable this, but there are many places where we use `_MSC_VER` to detect MSVC.
- `-Wno-c++98-compat` and `-Wno-c++98-compat-pedantic`: Even in C++11 mode, `-Weverything` warns about incompatibility with C++98.
- `-Wno-global-constructors` and `-Wno-exit-time-destructors`: Globals requiring construction/destruction. I would actually prefer to enable these, but it seems unrealistic at this point.
- `-Wno-padded`: Clang with `-Weverything` warns every time padding is inserted in the middle of a struct. I don't see a way to enable this.
- `-Wno-sign-conversion`: We tolerate conversion from signed to unsigned, which is allowed by the standard.

Interesting things uncovered by other enabled warnings:
- `-Wdocumentation`: Clang warns if the Doxygen comments are out of date (i.e. if they mention a `\param` that is not present in the parameter list, or similar).
- `-Wweak-vtables`: Clang warns when a struct has no out-of-line virtual method definitions, which means its vtable will be emitted in every translation unit. We wonder whether this has caused some of the issues we have seen with cross-binary `dynamic_cast`.
- A lot of "shorten-64-to-32" warnings when building in 32-bit mode.
- Probably more, but there are so many. :-)

@rrrlasse @kspangsege @danielpovlsen @finnschiermer @teotwaki @bdash @tgoyne 
