### PR TITLE
Fix opening encrypted files with footers which will be resized on open

### DIFF
--- a/release_notes.md
+++ b/release_notes.md
@@ -2,7 +2,9 @@
 
 ### Bugfixes:
 
-* Lorem ipsum.
+* Fixed error when opening encrypted streaming-form files which would be
+  resized on open due to the size not aligning with a chunked mapping section
+  boundary.
 
 ### API breaking changes:
 

--- a/src/realm/alloc_slab.cpp
+++ b/src/realm/alloc_slab.cpp
@@ -564,7 +564,7 @@ ref_type SlabAlloc::attach_file(const std::string& path, Config& cfg)
         File::Map<char> map(m_file, File::access_ReadOnly, size); // Throws
         // we'll read header and (potentially) footer
         realm::util::encryption_read_barrier(map, 0, sizeof(Header));
-        realm::util::encryption_read_barrier(map, size - sizeof(Header), sizeof(Header));
+        realm::util::encryption_read_barrier(map, initial_size_of_file - sizeof(Header), sizeof(Header));
 
         if (!cfg.skip_validate) {
             // Verify the data structures

--- a/test/test_lang_bind_helper.cpp
+++ b/test/test_lang_bind_helper.cpp
@@ -10334,6 +10334,45 @@ TEST(LangBindHelper_Compact)
     }
 }
 
+TEST(LangBindHelper_CompactLargeEncryptedFile)
+{
+    SHARED_GROUP_TEST_PATH(path);
+
+    // We need to ensure that the size of the compacted file does not line up
+    // with the chunked-memory-mapping section boundaries, so that the file is
+    // resized on open. This targets the gap between 32 and 36 pages by writing
+    // 32 pages of data and assuming that the file overhead will be greater than
+    // zero bytes and less than four pages.
+    std::vector<char> data(realm::util::page_size());
+    const size_t N = 32;
+
+    {
+        std::unique_ptr<ClientHistory> hist(make_client_history(path, crypt_key(true)));
+        SharedGroup sg(*hist, SharedGroup::durability_Full, crypt_key(true));
+        WriteTransaction wt(sg);
+        TableRef table = wt.get_or_add_table("test");
+        table->add_column(type_String, "string");
+        for (size_t i = 0; i < N; ++i) {
+            table->add_empty_row();
+            table->set_string(0, i, StringData(data.data(), data.size()));
+        }
+        wt.commit();
+
+        CHECK_EQUAL(true, sg.compact());
+
+        sg.close();
+    }
+
+    {
+        std::unique_ptr<ClientHistory> hist(make_client_history(path, crypt_key(true)));
+        SharedGroup sg(*hist, SharedGroup::durability_Full, crypt_key(true));
+        ReadTransaction r(sg);
+        ConstTableRef table = r.get_table("test");
+        CHECK_EQUAL(N, table->size());
+        sg.close();
+    }
+}
+
 TEST(LangBindHelper_TableViewAggregateAfterAdvanceRead)
 {
     SHARED_GROUP_TEST_PATH(path);


### PR DESCRIPTION
The encryption write barrier needs to use the initial size to locate the footer, not the post-resize size.

@finnschiermer 
