### PR TITLE
Fixed new crashes in Query if it depended on deleted LinkList

### DIFF
--- a/release_notes.md
+++ b/release_notes.md
@@ -2,7 +2,8 @@
 
 ### Bugfixes:
 
-* Lorem ipsum.
+* Fixed crash in Query::count(), Query::find() and other Query methods, if it 
+  depended on a deleted LinkList. Will now throw DeletedLinkView instead
 
 ### API breaking changes:
 

--- a/src/realm/link_view.hpp
+++ b/src/realm/link_view.hpp
@@ -48,7 +48,7 @@ public:
 
     // Size info
     bool is_empty() const noexcept;
-    size_t size() const noexcept;
+    size_t size() const;
 
     bool operator==(const LinkView&) const noexcept;
     bool operator!=(const LinkView&) const noexcept;
@@ -210,9 +210,12 @@ inline bool LinkView::is_empty() const noexcept
     return m_row_indexes.is_empty();
 }
 
-inline size_t LinkView::size() const noexcept
+inline size_t LinkView::size() const
 {
-    REALM_ASSERT(is_attached());
+    // FIXME: This throw only exists in order to make Query throw if it depends on a deleted LinkList. The size()
+    // method happens to be the first method executed in various places.
+    if(!is_attached())
+        throw(DeletedLinkView());
 
     if (!m_row_indexes.is_attached())
         return 0;


### PR DESCRIPTION
See issue https://github.com/realm/realm-core/issues/1451
