### PR TITLE
Lr/handoverdetachedlinkview

### DIFF
--- a/src/realm/link_view.cpp
+++ b/src/realm/link_view.cpp
@@ -29,7 +29,7 @@ using namespace realm;
 
 void LinkView::generate_patch(const ConstLinkViewRef& ref, std::unique_ptr<HandoverPatch>& patch)
 {
-    if (bool(ref)) {
+    if (bool(ref) && ref->is_attached()) {
         patch.reset(new HandoverPatch);
         Table::generate_patch(ref->m_origin_table, patch->m_table);
         patch->m_col_num = ref->m_origin_column.m_column_ndx;

--- a/test/test_lang_bind_helper.cpp
+++ b/test/test_lang_bind_helper.cpp
@@ -9744,7 +9744,7 @@ TEST(LangBindHelper_HandoverDependentViews)
 }
 
 
-ONLY(LangBindHelper_HandoverTableViewWithLinkView)
+TEST(LangBindHelper_HandoverTableViewWithLinkView)
 {
     // First iteration hands-over a normal valid attached LinkView. Second
     // iteration hands-over a detached LinkView.
@@ -9824,9 +9824,15 @@ ONLY(LangBindHelper_HandoverTableViewWithLinkView)
             std::unique_ptr<TableView> tv(sg.import_from_handover(move(handover))); // <-- import tv
 
             CHECK(tv->is_in_sync());
-            CHECK_EQUAL(2, tv->size());
-            CHECK_EQUAL(0, tv->get_source_ndx(0));
-            CHECK_EQUAL(2, tv->get_source_ndx(1));
+            if (detached == 1) {
+                CHECK_EQUAL(0, tv->size());
+            }
+            else {
+                CHECK_EQUAL(2, tv->size());
+                CHECK_EQUAL(0, tv->get_source_ndx(0));
+                CHECK_EQUAL(2, tv->get_source_ndx(1));
+            }
+
         }
     }
 }


### PR DESCRIPTION
Fixes handover of Query that depends on detached LinkView (see https://github.com/realm/realm-core/pull/1459#issuecomment-175661782 )
