### PR TITLE
Add SharedGroup::get_transact_stage()

### DIFF
--- a/release_notes.md
+++ b/release_notes.md
@@ -10,7 +10,7 @@
 
 ### Enhancements:
 
-* Lorem ipsum.
+* Add SharedGroup::get_transact_stage().
 
 -----------
 

--- a/src/realm/group_shared.hpp
+++ b/src/realm/group_shared.hpp
@@ -374,6 +374,14 @@ public:
 
     //@}
 
+    enum TransactStage {
+        transact_Ready,
+        transact_Reading,
+        transact_Writing
+    };
+
+    /// Get the current transaction type
+    TransactStage get_transact_stage() const noexcept;
 
     /// Get a version id which may be used to request a different SharedGroup
     /// to start transaction at a specific version.
@@ -524,11 +532,6 @@ private:
     std::string m_lockfile_path;
     std::string m_db_path;
     const char* m_key;
-    enum TransactStage {
-        transact_Ready,
-        transact_Reading,
-        transact_Writing
-    };
     TransactStage m_transact_stage;
     util::Mutex m_handover_lock;
 #ifndef _WIN32
@@ -799,6 +802,11 @@ inline void SharedGroup::open(Replication& repl, DurabilityLevel durability,
 inline bool SharedGroup::is_attached() const noexcept
 {
     return m_file_map.is_attached();
+}
+
+inline SharedGroup::TransactStage SharedGroup::get_transact_stage() const noexcept
+{
+    return m_transact_stage;
 }
 
 class SharedGroup::ReadLockUnlockGuard {


### PR DESCRIPTION
Having the transaction state be private makes sense with scoped transactions, but keeping track of it separately for continuous transactions is the source of some nontrivial complexity (primarily with ensuring that it's kept in sync when exceptions are thrown) and has had some bugs (https://github.com/realm/realm-cocoa/pull/3202, https://github.com/realm/realm-core/issues/1457). Being able to use the SharedGroup's transaction state directly would eliminate an entire category of bugs where the wrapper's state and the SharedGroup's state do not match.
