### PR TITLE
Sync the data in SharedGroup::compact

### DIFF
--- a/release_notes.md
+++ b/release_notes.md
@@ -17,6 +17,8 @@
   point to a removed row. It did however issue those instructions after the
   clear instruction, which is incorrect, as the links do not exist after the
   clear operation. Was fixed.
+* `SharedGroup::compact()` does a sync before renaming to avoid corrupted db
+  file after compacting.
 
 ### API breaking changes:
 

--- a/src/realm/group.cpp
+++ b/src/realm/group.cpp
@@ -627,12 +627,18 @@ void Group::write(const std::string& path, const char* encryption_key, uint_fast
     File file;
     int flags = 0;
     file.open(path, File::access_ReadWrite, File::create_Must, flags);
+    write(file, encryption_key, version_number);
+}
+
+void Group::write(File& file, const char* encryption_key, uint_fast64_t version_number) const
+{
+    REALM_ASSERT(file.get_size() == 0);
+
     file.set_encryption_key(encryption_key);
     File::Streambuf streambuf(&file);
     std::ostream out(&streambuf);
     write(out, encryption_key != 0, version_number);
 }
-
 
 BinaryData Group::write_to_mem() const
 {

--- a/src/realm/group.hpp
+++ b/src/realm/group.hpp
@@ -655,6 +655,8 @@ private:
 
     void write(const std::string& file, const char* encryption_key,
                uint_fast64_t version_number) const;
+    void write(util::File& file, const char* encryption_key,
+               uint_fast64_t version_number) const;
     void write(std::ostream&, bool pad, uint_fast64_t version_numer) const;
 
     Replication* get_replication() const noexcept;

--- a/src/realm/group_shared.cpp
+++ b/src/realm/group_shared.cpp
@@ -35,6 +35,7 @@
 #include <realm/link_view.hpp>
 #include <realm/replication.hpp>
 #include <realm/impl/simulated_failure.hpp>
+#include <realm/disable_sync_to_disk.hpp>
 
 #ifndef _WIN32
 #  include <sys/wait.h>
@@ -921,7 +922,13 @@ bool SharedGroup::compact()
 
     // Compact by writing a new file holding only live data, then renaming the new file
     // so it becomes the database file, replacing the old one in the process.
-    m_group.write(tmp_path, m_key, info->latest_version_number);
+    File file;
+    file.open(tmp_path, File::access_ReadWrite, File::create_Must, 0);
+    m_group.write(file, m_key, info->latest_version_number);
+    // Data needs to be flushed to the disk before renaming.
+    bool disable_sync = get_disable_sync_to_disk();
+    if (!disable_sync)
+        file.sync(); // Throws
     rename(tmp_path.c_str(), m_db_path.c_str());
     {
         SharedInfo* r_info = m_reader_map.get_addr();


### PR DESCRIPTION
Close #1485
There is a chance that the process gets killed while compacting which
will lead to a corrupted db if the data is not flushed and renaming
happens in the SharedGroup::compact().
