### PR TITLE
Fix -Wmisleading-indentation warnings

### DIFF
--- a/src/realm/array.cpp
+++ b/src/realm/array.cpp
@@ -835,8 +835,7 @@ size_t Array::find_gte(const int64_t target, size_t start, Array const* indirect
     if (high > m_size)
         high = m_size;
 
-   // if (start > 0)
-        start--;
+    start--;
 
     //start og high
 

--- a/src/realm/util/encrypted_file_mapping.hpp
+++ b/src/realm/util/encrypted_file_mapping.hpp
@@ -113,7 +113,7 @@ inline void EncryptedFileMapping::read_barrier(const void* addr, size_t size,
     if (!m_up_to_date_pages[first_idx]) {
         if (!lock.holds_lock())
             lock.lock();
-            refresh_page(first_idx);
+        refresh_page(first_idx);
     }
 
     if (header_to_size) {


### PR DESCRIPTION
This is a new on-by-default warning in gcc 6. There's also a bunch of -Wterminate warnings from throwing out of noexcept functions, but those are less obvious how to fix.
