### PR TITLE
Created Table::get<T>()

### DIFF
--- a/src/realm/table.cpp
+++ b/src/realm/table.cpp
@@ -2660,32 +2660,6 @@ template<> BinaryData Table::get(size_t col_ndx, size_t ndx) const noexcept
     return column.get(ndx);
 }
 
-
-int64_t Table::get_int(size_t col_ndx, size_t ndx) const noexcept
-{
-    return get<int64_t>(col_ndx, ndx);
-}
-
-
-void Table::set_int(size_t col_ndx, size_t ndx, int_fast64_t value)
-{
-    REALM_ASSERT_3(col_ndx, <, get_column_count());
-    REALM_ASSERT_3(ndx, <, m_size);
-    bump_version();
-
-    if (is_nullable(col_ndx)) {
-        auto& col = get_column_int_null(col_ndx);
-        col.set(ndx, value);
-    }
-    else {
-        auto& col = get_column(col_ndx);
-        col.set(ndx, value);
-    }
-
-    if (Replication* repl = get_repl())
-        repl->set_int(this, col_ndx, ndx, value); // Throws
-}
-
 } // namespace realm;
 
 template<class ColType, class T>
@@ -2734,6 +2708,10 @@ size_t Table::do_set_unique(ColType& col, size_t ndx, T&& value)
     return ndx;
 }
 
+int64_t Table::get_int(size_t col_ndx, size_t ndx) const noexcept
+{
+    return get<int64_t>(col_ndx, ndx);
+}
 
 void Table::set_int_unique(size_t col_ndx, size_t ndx, int_fast64_t value)
 {
@@ -2758,6 +2736,24 @@ void Table::set_int_unique(size_t col_ndx, size_t ndx, int_fast64_t value)
         repl->set_int_unique(this, col_ndx, ndx, value); // Throws
 }
 
+void Table::set_int(size_t col_ndx, size_t ndx, int_fast64_t value)
+{
+    REALM_ASSERT_3(col_ndx, <, get_column_count());
+    REALM_ASSERT_3(ndx, <, m_size);
+    bump_version();
+
+    if (is_nullable(col_ndx)) {
+        auto& col = get_column_int_null(col_ndx);
+        col.set(ndx, value);
+    }
+    else {
+        auto& col = get_column(col_ndx);
+        col.set(ndx, value);
+    }
+
+    if (Replication* repl = get_repl())
+        repl->set_int(this, col_ndx, ndx, value); // Throws
+}
 
 bool Table::get_bool(size_t col_ndx, size_t ndx) const noexcept
 {

--- a/src/realm/table.hpp
+++ b/src/realm/table.hpp
@@ -39,8 +39,6 @@
 #include <realm/query.hpp>
 #include <realm/column.hpp>
 
-#include <realm/column_binary.hpp>
-
 namespace realm {
 
 class TableView;


### PR DESCRIPTION
These templated getters are required in order to simply the Query system when adding the NewDate type.

I did not add templated set methods because I'm slightly unsure how to proceed; On one hand it adds code to table.hpp which is bad. We could sovle it by keeping the implementation inside the non-templared get_XXX in table.cpp file and make the templated methods be wrappers around these. I did the opposite though becuase it lets us get rid of the non-templated methods completely in the future...

Anyway, a small step towards generalization/code reuse.
