### PR TITLE
Add missing bump_version in table::set_null

### DIFF
--- a/release_notes.md
+++ b/release_notes.md
@@ -6,6 +6,7 @@
   transaction rollback in certain cases, backlink columns were removed from
   internal (not the end) indices and the roll back should put them back there.
   This could cause a crash on rollback and was reported in ticket #1502.
+* Bumps table version when `Table::set_null()` called.
 
 ### API breaking changes:
 

--- a/src/realm/table.cpp
+++ b/src/realm/table.cpp
@@ -3192,6 +3192,8 @@ void Table::set_null(size_t col_ndx, size_t row_ndx)
     if (!is_nullable(col_ndx)) {
         throw LogicError{LogicError::column_not_nullable};
     }
+
+    bump_version();
     ColumnBase& col = get_column_base(col_ndx);
     col.set_null(row_ndx);
 

--- a/test/test_table.cpp
+++ b/test/test_table.cpp
@@ -6591,4 +6591,49 @@ TEST(Table_DetachedAccessor)
     CHECK_LOGIC_ERROR(table->set_link(3, 0, 0), LogicError::detached_accessor);
 }
 
+TEST(Table_getVersionCounterAfterRowAccessor) {
+    Table t;
+    size_t col_bool   = t.add_column(type_Bool,     "bool",   true);
+    size_t col_int    = t.add_column(type_Int,      "int",    true);
+    size_t col_string = t.add_column(type_String,   "string", true);
+    size_t col_float  = t.add_column(type_Float,    "float",  true);
+    size_t col_double = t.add_column(type_Double,   "double", true);
+    size_t col_date   = t.add_column(type_DateTime, "date",   true);
+    size_t col_binary = t.add_column(type_Binary,   "binary", true);
+
+    t.add_empty_row(1);
+
+    int_fast64_t ver = t.get_version_counter();
+    int_fast64_t newVer;
+
+#define _CHECK_VER_BUMP() \
+    newVer = t.get_version_counter();\
+    CHECK_EQUAL(ver + 1, newVer); \
+    ver = newVer;
+
+    t.set_bool(col_bool, 0, true);
+    _CHECK_VER_BUMP();
+
+    t.set_int(col_int, 0, 42);
+    _CHECK_VER_BUMP();
+
+    t.set_string(col_string, 0, "foo");
+    _CHECK_VER_BUMP();
+
+    t.set_float(col_float, 0, 0.42);
+    _CHECK_VER_BUMP();
+
+    t.set_double(col_double, 0, 0.42);
+    _CHECK_VER_BUMP();
+
+    t.set_datetime(col_date, 0, 1234);
+    _CHECK_VER_BUMP();
+
+    t.set_binary(col_binary, 0, BinaryData("binary", 7));
+    _CHECK_VER_BUMP();
+
+    t.set_null(0, 0);
+    _CHECK_VER_BUMP();
+}
+
 #endif // TEST_TABLE


### PR DESCRIPTION
Found by java issue:
https://github.com/realm/realm-java/issues/2366
