### PR TITLE
Remove two no-op implementations from Replication interface

### DIFF
--- a/src/realm/history.cpp
+++ b/src/realm/history.cpp
@@ -27,6 +27,16 @@ public:
         _impl::InRealmHistory::initialize(sgf::get_group(sg)); // Throws
     }
 
+    void initiate_session(version_type) override
+    {
+        // No-op
+    }
+
+    void terminate_session() noexcept override
+    {
+        // No-op
+    }
+
     version_type prepare_changeset(const char* data, size_t size,
                                    version_type orig_version) override
     {

--- a/src/realm/replication.hpp
+++ b/src/realm/replication.hpp
@@ -79,7 +79,7 @@ public:
     /// subsequent commits on the Realm file failed.
     ///
     /// The default implementation does nothing.
-    virtual void initiate_session(version_type version);
+    virtual void initiate_session(version_type version) = 0;
 
     /// Called by the associated SharedGroup object when a session is
     /// terminated. See initiate_session() for the definition of a
@@ -87,7 +87,7 @@ public:
     /// last SharedGroup object within the session.
     ///
     /// The default implementation does nothing.
-    virtual void terminate_session() noexcept;
+    virtual void terminate_session() noexcept = 0;
 
 
     //@{
@@ -454,16 +454,6 @@ private:
 inline Replication::Replication():
     _impl::TransactLogConvenientEncoder(static_cast<_impl::TransactLogStream&>(*this))
 {
-}
-
-inline void Replication::initiate_session(version_type)
-{
-    // No-op by default
-}
-
-inline void Replication::terminate_session() noexcept
-{
-    // No-op by default
 }
 
 inline void Replication::initiate_transact(version_type current_version, bool history_updated)

--- a/test/test_lang_bind_helper.cpp
+++ b/test/test_lang_bind_helper.cpp
@@ -139,6 +139,16 @@ public:
     {
     }
 
+    void initiate_session(version_type) override
+    {
+        // No-op
+    }
+
+    void terminate_session() noexcept override
+    {
+        // No-op
+    }
+
     version_type prepare_changeset(const char* data, size_t size,
                                    version_type orig_version) override
     {

--- a/test/test_replication.cpp
+++ b/test/test_replication.cpp
@@ -63,6 +63,16 @@ public:
         m_changesets.clear();
     }
 
+    void initiate_session(version_type) override
+    {
+        // No-op
+    }
+
+    void terminate_session() noexcept override
+    {
+        // No-op
+    }
+
     HistoryType get_history_type() const noexcept override
     {
         return hist_None;


### PR DESCRIPTION
... for consistency.

@simonask 
