### PR TITLE
Don't build fat binaries on OSX by default.

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -300,7 +300,7 @@ build_apple()
         cp "src/realm/librealm-$tag-dbg.a" "$temp_dir/platforms/$tag/librealm-dbg.a" || exit 1
     done
     all_caps_name=$(echo "$os_name" | tr "[:upper:]" "[:lower:]")
-    REALM_ENABLE_FAT_BINARIES="1" $MAKE -C "src/realm" "realm-config-$os_name" "realm-config-$os_name-dbg" BASE_DENOM="$os_name" CFLAGS_ARCH="-fembed-bitcode -DREALM_CONFIG_$all_caps_name" AR="libtool" ARFLAGS="-o" || exit 1
+    $MAKE -C "src/realm" "realm-config-$os_name" "realm-config-$os_name-dbg" BASE_DENOM="$os_name" CFLAGS_ARCH="-fembed-bitcode -DREALM_CONFIG_$all_caps_name" AR="libtool" ARFLAGS="-o" || exit 1
     mkdir -p "$dir" || exit 1
     echo "Creating '$dir/librealm-$os_name$platform_suffix.a'"
     libtool "$temp_dir/platforms"/*/"librealm.a"     -static -o "$dir/librealm-$os_name$platform_suffix.a"     || exit 1
@@ -683,7 +683,7 @@ EOF
     "build")
         auto_configure || exit 1
         export REALM_HAVE_CONFIG="1"
-        REALM_ENABLE_FAT_BINARIES="1" $MAKE || exit 1
+        $MAKE || exit 1
         echo "Done building"
         exit 0
         ;;
@@ -695,7 +695,7 @@ EOF
         # are such that <src/realm/util/config.h> is not recreated
         # automatically by src/realm/Makfile. Using --always-make is
         # a work-around.
-        REALM_ENABLE_FAT_BINARIES="1" $MAKE --always-make -C "src/realm" "realm-config" "realm-config-dbg" || exit 1
+        $MAKE --always-make -C "src/realm" "realm-config" "realm-config-dbg" || exit 1
         echo "Done building config programs"
         exit 0
         ;;

--- a/src/project.mk
+++ b/src/project.mk
@@ -3,15 +3,6 @@ ENABLE_INSTALL_STATIC_LIBS = 1
 ENABLE_INSTALL_DEBUG_LIBS  = 1
 ENABLE_INSTALL_DEBUG_PROGS = 1
 
-# Construct fat binaries on Darwin when using Clang
-ifneq ($(REALM_ENABLE_FAT_BINARIES),)
-  ifeq ($(OS),Darwin)
-    ifeq ($(COMPILER_IS),clang)
-      CFLAGS_ARCH += -arch i386 -arch x86_64
-    endif
-  endif
-endif
-
 ifeq ($(OS),Darwin)
   CFLAGS_ARCH += -mmacosx-version-min=10.8 -stdlib=libc++ -Wno-nested-anon-types
   VALGRIND_FLAGS += --dsymutil=yes --suppressions=$(GENERIC_MK_DIR)/../test/corefoundation-yosemite.suppress


### PR DESCRIPTION
See https://github.com/realm/realm-sync/pull/214.

While the same change is not required on the core-side, there is not much use of it for the same reasons as are explained in the sync-side PR. So for consistency, I'm removing the feature here too.

@teotwaki 
