### PR TITLE
Removing dead-code from test-* subdirs

### DIFF
--- a/test/test-realm/test-realm.cpp
+++ b/test/test-realm/test-realm.cpp
@@ -10,16 +10,6 @@ using namespace realm;
 
 namespace {
 
-// Get and Set are too fast (50ms/M) for normal 64-bit rand*rand*rand*rand*rand (5-10ms/M)
-uint64_t rand2()
-{
-    static int64_t seed = 2862933555777941757ULL;
-    static int64_t seed2 = 0;
-    seed = (2862933555777941757ULL * seed + 3037000493ULL);
-    seed2++;
-    return seed * seed2 + seed2;
-}
-
 REALM_TABLE_1(IntegerTable,
                 first, Int)
 

--- a/test/test-stl/test-stl.cpp
+++ b/test/test-stl/test-stl.cpp
@@ -61,19 +61,6 @@ private:
     const Days m_target;
 };
 
-// Get and Set are too fast (50ms/M) for normal 64-bit rand*rand*rand*rand*rand (5-10ms/M)
-uint64_t rand2()
-{
-    return (uint64_t)rand() * (uint64_t)rand() * (uint64_t)rand() * (uint64_t)rand() * (uint64_t)rand();
-
-
-    static int64_t seed = 2862933555777941757ULL;
-    static int64_t seed2 = 0;
-    seed = (2862933555777941757ULL * seed + 3037000493ULL);
-    seed2++;
-    return seed * seed2 + seed2;
-}
-
 } // anonymous namespace
 
 


### PR DESCRIPTION
This looks dead to me.. and non-working due to an old, bad merge.

Not sure if this is still the way we remove dead code like this.

@rrrlasse @kspangsege 
