### PR TITLE
Fix core headers to be clean when building for 32-bit with -Wshorten-64-to-32

### DIFF
--- a/src/realm/impl/input_stream.hpp
+++ b/src/realm/impl/input_stream.hpp
@@ -215,10 +215,10 @@ inline size_t ChangesetInputStream::next_block(const char*& begin, const char*& 
         if (REALM_UNLIKELY(m_changesets_begin == m_changesets_end)) {
             if (m_begin_version == m_end_version)
                 return 0; // End of input
-            uint_fast64_t n = sizeof m_changesets / sizeof m_changesets[0];
-            uint_fast64_t avail = m_end_version - m_begin_version;
+            size_t n = sizeof m_changesets / sizeof m_changesets[0];
+            version_type avail = m_end_version - m_begin_version;
             if (n > avail)
-                n = avail;
+                n = size_t(avail);
             version_type end_version = m_begin_version + n;
             m_history.get_changesets(m_begin_version, end_version, m_changesets);
             m_begin_version = end_version;


### PR DESCRIPTION
The Makefile doesn't enable this warning, but it is enabled by default for the targets CocoaPods uses to build pods, so when Realm Cocoa is built by CocoaPods users they see this warning.
#1411 tracks enabling -Wshorten-64-to-32 in core builds which would help to catch these issues earlier.

/cc @kspangsege 
