### PR TITLE
Adding LangBindHelper::get_version_of_latest_snapshot()

### DIFF
--- a/src/realm/group_shared.hpp
+++ b/src/realm/group_shared.hpp
@@ -1130,6 +1130,11 @@ public:
         return sg.get_file_format_version();
     }
 
+    static SharedGroup::version_type get_version_of_latest_snapshot(SharedGroup& sg)
+    {
+        return sg.get_version_of_latest_snapshot();
+    }
+
     static SharedGroup::version_type get_version_of_bound_snapshot(const SharedGroup& sg) noexcept
     {
         return sg.get_version_of_bound_snapshot();

--- a/src/realm/lang_bind_helper.hpp
+++ b/src/realm/lang_bind_helper.hpp
@@ -195,6 +195,8 @@ public:
     ///
     /// </pre>
     static const char* get_data_type_name(DataType) noexcept;
+
+    static SharedGroup::version_type get_version_of_latest_snapshot(SharedGroup&);
 };
 
 
@@ -384,6 +386,12 @@ inline void LangBindHelper::rollback_and_continue_as_read(SharedGroup& sg, O&& o
 {
     using sgf = _impl::SharedGroupFriend;
     sgf::rollback_and_continue_as_read(sg, &observer); // Throws
+}
+
+inline SharedGroup::version_type LangBindHelper::get_version_of_latest_snapshot(SharedGroup& sg)
+{
+    using sgf = _impl::SharedGroupFriend;
+    return sgf::get_version_of_latest_snapshot(sg); // Throws
 }
 
 } // namespace realm


### PR DESCRIPTION
Needed for the integration of the C++ sync client in the Cocoa binding.

@simonask 
