### PR TITLE
disabled unittest which can hang on Linux

### DIFF
--- a/release_notes.md
+++ b/release_notes.md
@@ -16,7 +16,8 @@
 
 ### Internals:
 
-* Lorem ipsum.
+* Disabled unittest Shared_RobustAgainstDeathDuringWrite on Linux, as 
+  it could run forever.
 
 ----------------------------------------------
 

--- a/test/test_shared.cpp
+++ b/test/test_shared.cpp
@@ -1335,9 +1335,12 @@ TEST(Shared_WriterThreads)
 }
 
 
-//#if defined TEST_ROBUSTNESS && defined ENABLE_ROBUST_AGAINST_DEATH_DURING_WRITE && !REALM_ENABLE_ENCRYPTION
 #if !REALM_ENABLE_ENCRYPTION &&  defined(ENABLE_ROBUST_AGAINST_DEATH_DURING_WRITE)
-//#if !defined REALM_ANDROID && !defined REALM_IOS
+// this unittest has issues that has not been fully understood, but could be
+// related to interaction between posix robust mutexes and the fork() system call.
+// it has so far only been seen failing on Linux, so we enable it on platforms where
+// the emulation is in use.
+#ifdef REALM_ROBUST_MUTEX_EMULATION
 
 // Not supported on Windows in particular? Keywords: winbug
 TEST(Shared_RobustAgainstDeathDuringWrite)
@@ -1404,6 +1407,7 @@ TEST(Shared_RobustAgainstDeathDuringWrite)
     }
 }
 
+#endif // emulation enabled
 #endif // encryption enabled
 
 // not ios or android


### PR DESCRIPTION
closes #1557 

note: this problem is not new and is not fully understood. 
The unittest was recently re-enabled after having been disabled for half a year. 

Apparently, the problem hasn't magically vanished. Since it's a problem we've
been able to live with before, since we believe it to be a problem with the testcase
rather than Core and since it is very time consuming to fully understand, we're
going to postpone full analysis till later. 

We merely disable the testcase for now.
