### PR TITLE
Removed trailing whitespace

### DIFF
--- a/doc/development/finn.txt
+++ b/doc/development/finn.txt
@@ -23,9 +23,9 @@ m_child -----------           m_child ---------          m_child = ----------   
 The population of m_children happens through a gather_children() method call from init().
 
 All these m_children vectors could maybe be gathered into a single vector stored somewhere else. However, note that sub node chains of ORNodes would need their own. So a single global is not enough. More analyzing is needed.
-														 
+														
 Idea
-********************************************************************************************************												 
+********************************************************************************************************												
 The methods of QueryState (which consumes matches) are templated by Action (find, findall, count, etc):
 
     template<Action action, bool pattern>
@@ -41,17 +41,17 @@ Also, many methods of Node classes are templated. It *could* be a simplification
 This would be a bit more complex task than QueryState. So begin with QueryState.	
 
 Idea
-********************************************************************************************************												 
+********************************************************************************************************												
 query_expression: Sqrt operator in query_expression.hpp
 
 
 Idea
-********************************************************************************************************												 
+********************************************************************************************************												
 query_engine: Optimize cost() method and/or m_dD and m_dT constants for the different node classes. Do not trust that any existing values or formulas are near optimal at all, because I have only done very little measurements, and
 mostly just guessing.
 
 
 Idea
-********************************************************************************************************												 
+********************************************************************************************************												
 query_engine: Implement NOT node
 

--- a/release_notes.md
+++ b/release_notes.md
@@ -19,7 +19,7 @@
 
 ### Internals:
 
-* Disabled unittest Shared_RobustAgainstDeathDuringWrite on Linux, as 
+* Disabled unittest Shared_RobustAgainstDeathDuringWrite on Linux, as
   it could run forever.
 
 ----------------------------------------------
@@ -70,7 +70,7 @@ versions [0.97.0].**
 
 * Language bindings can now test if a TableView depends on a deleted LinkList
   (detached LinkView) using `bool TableViewBase::depends_deleted_linklist()`.
-  See https://github.com/realm/realm-core/issues/1509 and also 
+  See https://github.com/realm/realm-core/issues/1509 and also
   TEST(Query_ReferDeletedLinkView) in test_query.cpp for details.
 * `LangBindHelper::advance_read()` and friends no longer take a history
   argument. Access to the history is now gained automatically via
@@ -233,8 +233,8 @@ versions [0.97.0].**
 
 * Any attempt to execute a query that depends on a LinkList that has been
   deleted from its table will now throw `DeletedLinkView` instead of
-  segfaulting. No other changes has been made; you must still verify 
-  LinkViewRef::is_attached() before calling any methods on a LinkViewRef, as 
+  segfaulting. No other changes has been made; you must still verify
+  LinkViewRef::is_attached() before calling any methods on a LinkViewRef, as
   usual.
 
 ### Enhancements:
@@ -369,7 +369,7 @@ versions [0.97.0].**
 
 ### Bugfixes:
 
-* Fixed bug where Query::average() would include the number of nulls in the 
+* Fixed bug where Query::average() would include the number of nulls in the
   result.
 * Presumably fixed a race between commit and opening the database.
 

--- a/src/realm/array.hpp
+++ b/src/realm/array.hpp
@@ -667,9 +667,9 @@ public:
     /// destroy_deep() for every contained 'ref' element.
     static void destroy_deep(MemRef, Allocator&) noexcept;
 
-    Allocator& get_alloc() const noexcept 
-    { 
-        return m_alloc;     
+    Allocator& get_alloc() const noexcept
+    {
+        return m_alloc;
     }
 
     // Serialization
@@ -2642,7 +2642,7 @@ bool Array::find_optimized(int64_t value, size_t start, size_t end, size_t basei
         // Huge speed optimizations are possible here! This is a very simple generic method.
         for (; start2 < end; start2++) {
             int64_t v = get<bitwidth>(start2 + 1);
-            if (c(v, value, v == get(0), find_null)) {                
+            if (c(v, value, v == get(0), find_null)) {
                 util::Optional<int64_t> v2(v == get(0) ? util::none : util::make_optional(v));
                 if (!find_action<action, Callback>(start2 + baseindex, v2, state, callback))
                     return false; // tell caller to stop aggregating/search

--- a/src/realm/array_binary.cpp
+++ b/src/realm/array_binary.cpp
@@ -110,7 +110,7 @@ BinaryData ArrayBinary::get(const char* header, size_t ndx, Allocator& alloc) no
     // See comment in legacy_array_type() and also in array_binary.hpp.
     size_t siz = Array::get_size_from_header(header);
     REALM_ASSERT_7(siz, ==, 2, ||, siz, ==, 3);
-    
+
     if (siz == 3) {
         std::pair<int64_t, int64_t> p = get_two(header, 1);
         const char* nulls_header = alloc.translate(to_ref(p.second));
@@ -119,9 +119,9 @@ BinaryData ArrayBinary::get(const char* header, size_t ndx, Allocator& alloc) no
         REALM_ASSERT_3(n == 1, ||, n == 0);
         bool null = (n != 0);
         if (null)
-            return BinaryData(0, 0);        
+            return BinaryData(0, 0);
     }
-    
+
     std::pair<int64_t, int64_t> p = get_two(header, 0);
     const char* offsets_header = alloc.translate(to_ref(p.first));
     const char* blob_header = alloc.translate(to_ref(p.second));
@@ -200,7 +200,7 @@ MemRef ArrayBinary::create_array(size_t size, Allocator& alloc, BinaryData value
     {
         // Always create a m_nulls array, regardless if its column is marked as nullable or not. NOTE: This is new
         // - existing binary arrays from earier versions of core will not have this third array. All methods on ArrayBinary
-        // must thus check if this array exists before trying to access it. If it doesn't, it must be interpreted as if its 
+        // must thus check if this array exists before trying to access it. If it doesn't, it must be interpreted as if its
         // column isn't nullable.
         bool context_flag = false;
         int64_t value = values.is_null() ? 1 : 0;

--- a/src/realm/commit_log.cpp
+++ b/src/realm/commit_log.cpp
@@ -238,7 +238,7 @@ protected:
     //
     //     [ preamble->begin_newest_commit_range .. preamble->end_commit_range [
     void get_maps_in_order(const CommitLogPreamble* preamble,
-                           const util::File::Map<CommitLogHeader>*& first, 
+                           const util::File::Map<CommitLogHeader>*& first,
                            const util::File::Map<CommitLogHeader>*& second) const;
 
     // Ensure the file is open so that it can be resized or mapped

--- a/src/realm/datetime.hpp
+++ b/src/realm/datetime.hpp
@@ -69,7 +69,7 @@ public:
     template<class Ch, class Tr>
     friend std::basic_ostream<Ch, Tr>& operator<<(std::basic_ostream<Ch, Tr>& out, const DateTime&);
 
-    // This is used by query_expression.hpp to generalize its templates and simplify the code *alot*; it is needed 
+    // This is used by query_expression.hpp to generalize its templates and simplify the code *alot*; it is needed
     // because DateTime is internally stored in an int64_t column.
     operator int_fast64_t() noexcept;
 

--- a/src/realm/header.txt
+++ b/src/realm/header.txt
@@ -1,11 +1,11 @@
 /*************************************************************************
- * 
+ *
  * REALM CONFIDENTIAL
  * __________________
- * 
+ *
  *  [2011] - [2015] Realm Inc
  *  All Rights Reserved.
- * 
+ *
  * NOTICE:  All information contained herein is, and remains
  * the property of Realm Incorporated and its suppliers,
  * if any.  The intellectual and technical concepts contained

--- a/src/realm/index_string.cpp
+++ b/src/realm/index_string.cpp
@@ -661,8 +661,8 @@ void StringIndex::do_update_ref(StringData value, size_t row_ndx, size_t new_row
                 REALM_ASSERT(old_pos != not_found);
                 REALM_ASSERT(size_t(sub.get(new_pos)) != new_row_ndx);
 
-                // The payload-value exists in multiple rows, and these rows indexes are stored in an IntegerColumn. 
-                // They must be in increasing order, so we cannot just use "set()". We must delete the old row index 
+                // The payload-value exists in multiple rows, and these rows indexes are stored in an IntegerColumn.
+                // They must be in increasing order, so we cannot just use "set()". We must delete the old row index
                 // and insert the new at the correct position computed above.
                 if (new_pos < old_pos) {
                     sub.insert_without_updating_index(new_pos, new_row_ndx, 1);

--- a/src/realm/index_string.hpp
+++ b/src/realm/index_string.hpp
@@ -29,8 +29,8 @@
 #include <realm/column_fwd.hpp>
 
  /*
-The StringIndex class is used for both type_String and all integral types, such as type_Bool, type_DateTime and 
-type_Int. When used for integral types, the 64-bit integer is simply casted to a string of 8 bytes through a 
+The StringIndex class is used for both type_String and all integral types, such as type_Bool, type_DateTime and
+type_Int. When used for integral types, the 64-bit integer is simply casted to a string of 8 bytes through a
 pretty simple "wrapper layer" in all public methods.
 
 The StringIndex data structure is like an "inversed" B+ tree where the leafs contain row indexes and the non-leafs
@@ -39,7 +39,7 @@ contain 4-byte chunks of payload. Imagine a table with following strings:
         hello, kitty, kitten, foobar, kitty, foobar
 
 The topmost level of the index tree contains prefixes of the payload strings of length <= 4. The next level contains
-prefixes of the remaining parts of the strings. Unnecessary levels of the tree are optimized away; the prefix "foob" 
+prefixes of the remaining parts of the strings. Unnecessary levels of the tree are optimized away; the prefix "foob"
 is shared only by rows that are identical ("foobar"), so "ar" is not needed to be stored in the tree.
 
         hell   kitt      foob
@@ -51,11 +51,11 @@ is shared only by rows that are identical ("foobar"), so "ar" is not needed to b
 Each non-leafs consists of two integer arrays of the same length, one containing payload and the other containing
 references to the sublevel nodes.
 
-The leafs can be either a single value or a Column. If the reference in its parent node has its least significant 
-bit set, then the remaining upper bits specify the row index at which the string is stored. If the bit is clear, 
+The leafs can be either a single value or a Column. If the reference in its parent node has its least significant
+bit set, then the remaining upper bits specify the row index at which the string is stored. If the bit is clear,
 it must be interpreted as a reference to a Column that stores the row indexes at which the string is stored.
 
-If a Column is used, then all row indexes are guaranteed to be sorted increasingly, which means you an search in it 
+If a Column is used, then all row indexes are guaranteed to be sorted increasingly, which means you an search in it
 using our binary search functions such as upper_bound() and lower_bound().
 */
 

--- a/src/realm/query_conditions.hpp
+++ b/src/realm/query_conditions.hpp
@@ -85,14 +85,14 @@ struct EndsWith : public HackClass {
 struct Equal {
     static const int avx = 0x00; // _CMP_EQ_OQ
 //    bool operator()(const bool v1, const bool v2, bool v1null = false, bool v2null = false) const { return v1 == v2; }
-    bool operator()(StringData v1, const char*, const char*, StringData v2, bool = false, bool = false) const 
-    { 
-        return v1 == v2; 
+    bool operator()(StringData v1, const char*, const char*, StringData v2, bool = false, bool = false) const
+    {
+        return v1 == v2;
     }
     bool operator()(BinaryData v1, BinaryData v2, bool = false, bool = false) const { return v1 == v2; }
 
     template<class T>
-    bool operator()(const T& v1, const T& v2, bool v1null = false, bool v2null = false) const 
+    bool operator()(const T& v1, const T& v2, bool v1null = false, bool v2null = false) const
     {
         return (v1null && v2null) || (!v1null && !v2null && v1 == v2);
     }
@@ -107,17 +107,17 @@ struct NotEqual {
    // bool operator()(BinaryData v1, BinaryData v2, bool = false, bool = false) const { return v1 != v2; }
 
     template<class T>
-    bool operator()(const T& v1, const T& v2, bool v1null = false, bool v2null = false) const 
-    { 
-        if (!v1null && !v2null) 
-            return v1 != v2; 
+    bool operator()(const T& v1, const T& v2, bool v1null = false, bool v2null = false) const
+    {
+        if (!v1null && !v2null)
+            return v1 != v2;
 
         if (v1null && v2null)
             return false;
 
         return true;
     }
-    
+
     static const int condition = cond_NotEqual;
     bool can_match(int64_t v, int64_t lbound, int64_t ubound) { return !(v == 0 && ubound == 0 && lbound == 0); }
     bool will_match(int64_t v, int64_t lbound, int64_t ubound) { return (v > ubound || v < lbound); }
@@ -263,7 +263,7 @@ struct NotEqualIns : public HackClass {
             return true;
 
         if (v1.size() != v2.size())
-            return true;        
+            return true;
         std::string v1_upper = case_map(v1, true, IgnoreErrors);
         std::string v1_lower = case_map(v1, false, IgnoreErrors);
         return !equal_case_fold(v2, v1_upper.c_str(), v1_lower.c_str());
@@ -280,7 +280,7 @@ struct NotEqualIns : public HackClass {
 struct Greater {
     static const int avx = 0x1E;  // _CMP_GT_OQ
     template<class T>
-    bool operator()(const T& v1, const T& v2, bool v1null = false, bool v2null = false) const 
+    bool operator()(const T& v1, const T& v2, bool v1null = false, bool v2null = false) const
     {
         if (v1null || v2null)
             return false;
@@ -323,7 +323,7 @@ struct Less {
         if (v1null || v2null)
             return false;
 
-        return v1 < v2; 
+        return v1 < v2;
     }
     template<class A, class B, class C, class D>
     bool operator()(A, B, C, D) const { REALM_ASSERT(false); return false; }
@@ -361,7 +361,7 @@ struct GreaterEqual : public HackClass {
 };
 
 
-// CompareLess is a temporary hack to have a generalized way to compare any realm types. Todo, enable correct < 
+// CompareLess is a temporary hack to have a generalized way to compare any realm types. Todo, enable correct <
 // operator of StringData (currently gives circular header dependency with utf8.hpp)
 template<class T>
 struct CompareLess

--- a/src/realm/query_engine.cpp
+++ b/src/realm/query_engine.cpp
@@ -47,7 +47,7 @@ void ParentNode::aggregate_local_prepare(Action TAction, DataType col_id, bool n
     }
     else if (TAction == act_Count) {
         // For count(), the column below is a dummy and the caller sets it to nullptr. Hence, no data is being read
-        // from any column upon each query match (just matchcount++ is performed), and we pass nullable = false simply 
+        // from any column upon each query match (just matchcount++ is performed), and we pass nullable = false simply
         // by convention. FIXME: Clean up all this.
         if (nullable)
             REALM_ASSERT(false);
@@ -65,7 +65,7 @@ void ParentNode::aggregate_local_prepare(Action TAction, DataType col_id, bool n
     }
     else if (TAction == act_Sum && col_id == type_Double) {
         m_column_action_specializer = &ThisType::column_action_specialization<act_Sum, DoubleColumn>;
-    }    
+    }
     else if (TAction == act_Max && col_id == type_Int) {
         if (nullable)
             m_column_action_specializer = &ThisType::column_action_specialization<act_Max, IntNullColumn>;
@@ -92,7 +92,7 @@ void ParentNode::aggregate_local_prepare(Action TAction, DataType col_id, bool n
     }
     else if (TAction == act_FindAll) {
         // For find_all(), the column below is a dummy and the caller sets it to nullptr. Hence, no data is being read
-        // from any column upon each query match (just a TableView.add(size_t index) is performed), and we pass 
+        // from any column upon each query match (just a TableView.add(size_t index) is performed), and we pass
         // nullable = false simply by convention. FIXME: Clean up all this.
         if (nullable)
             REALM_ASSERT(false);

--- a/src/realm/query_expression.hpp
+++ b/src/realm/query_expression.hpp
@@ -300,8 +300,8 @@ public:
     // When the user constructs a query, it always "belongs" to one single base/parent table (regardless of
     // any links or not and regardless of any queries assembled with || or &&). When you do a Query::find(),
     // then Query::m_table is set to this table, and set_base_table() is called on all Columns and LinkMaps in
-    // the query expression tree so that they can set/update their internals as required. 
-    // 
+    // the query expression tree so that they can set/update their internals as required.
+    //
     // During thread-handover of a Query, set_base_table() is also called to make objects point at the new table
     // instead of the old one from the old thread.
     virtual void set_base_table(const Table*) {}

--- a/src/realm/table_view.cpp
+++ b/src/realm/table_view.cpp
@@ -640,7 +640,7 @@ void TableViewBase::distinct(size_t column)
     distinct(std::vector<size_t> { column });
 }
 
-/// Remove rows that are duplicated with respect to the column set passed as argument. 
+/// Remove rows that are duplicated with respect to the column set passed as argument.
 /// Will keep original sorting order so that you can both have a distinct and sorted view.
 void TableViewBase::distinct(std::vector<size_t> columns)
 {
@@ -664,7 +664,7 @@ void TableViewBase::distinct(std::vector<size_t> columns)
     Sorter s(columns, ascending);
     sort(s);
 
-    // Step 3: Create column accessors for all columns in the column set. 
+    // Step 3: Create column accessors for all columns in the column set.
     std::vector<const ColumnTemplateBase*> m_columns;
     std::vector<const StringEnumColumn*> m_columns_enum;
     m_columns.resize(columns.size());
@@ -672,8 +672,8 @@ void TableViewBase::distinct(std::vector<size_t> columns)
 
     for (size_t i = 0; i < columns.size(); i++) {
         const ColumnBase& cb = m_table->get_column_base(m_distinct_columns[i]);
-        // FIXME: If we decide to keep StringEnumColumn (see Table::optimize()), then below conditional type casting 
-        // should be removed in favor for a more elegant/generalized solution, because this casting pattern is used 
+        // FIXME: If we decide to keep StringEnumColumn (see Table::optimize()), then below conditional type casting
+        // should be removed in favor for a more elegant/generalized solution, because this casting pattern is used
         // in a couple of other places in Core too.
         const ColumnTemplateBase* ctb = dynamic_cast<const ColumnTemplateBase*>(&cb);
         REALM_ASSERT(ctb);

--- a/src/realm/table_view.hpp
+++ b/src/realm/table_view.hpp
@@ -181,7 +181,7 @@ public:
 
     // Tells if the table that this TableView points at still exists or has been deleted.
     bool is_attached() const noexcept;
-    
+
     bool is_row_attached(size_t row_ndx) const noexcept;
     size_t size() const noexcept;
     size_t num_attached_rows() const noexcept;
@@ -295,7 +295,7 @@ public:
     // before any of the other access-methods whenever the view may have become
     // outdated.
     //
-    // This method will throw a DeletedLinkView exception if the TableView 
+    // This method will throw a DeletedLinkView exception if the TableView
     // depends on a LinkList that was deleted from its table.
     uint_fast64_t sync_if_needed() const;
 
@@ -311,7 +311,7 @@ public:
     // Sort m_row_indexes according to multiple columns
     void sort(std::vector<size_t> columns, std::vector<bool> ascending);
 
-    // Remove rows that are duplicated with respect to the column set passed as argument. 
+    // Remove rows that are duplicated with respect to the column set passed as argument.
     // distinct() will preserve the original order of the row pointers, also if the order is a result of sort()
     // If two rows are indentical (for the given set of distinct-columns), then the last row is removed.
     // You can call sync_if_needed() to update the distinct view, just like you can for a sorted view.

--- a/src/realm/unicode.cpp
+++ b/src/realm/unicode.cpp
@@ -49,7 +49,7 @@ namespace {
 // Converts unicodes 0...0x6ff (up to Arabic) to their respective lower case characters using a popular UnicodeData.txt
 // file (http://www.opensource.apple.com/source/Heimdal/Heimdal-247.9/lib/wind/UnicodeData.txt) that contains case
 // conversion information. The conversion does not take your current locale in count; it can be slightly wrong in some
-// countries! If the input is already lower case, or outside range 0...0x6ff, then input value is returned untouched. 
+// countries! If the input is already lower case, or outside range 0...0x6ff, then input value is returned untouched.
 uint32_t to_lower(uint32_t character)
 {
     static const int16_t lowers[] = {
@@ -143,7 +143,7 @@ namespace realm {
             while (begin + i != end) {
                 if ((static_cast<int>(std::char_traits<char>::to_int_type(begin[i])) & (0x80 + 0x40)) != 0x80)
                     break;
-                if (begin[i] != begin2[i]) 
+                if (begin[i] != begin2[i])
                     return false;
                 ++i;
             }
@@ -188,8 +188,8 @@ namespace realm {
             , 268, 293, 535, 367, 366, 172, 171, 180, 179, 411, 410, 176, 175, 178, 177, 253, 252, 255, 254, 318, 317, 320, 319, 417, 416, 419, 418, 450, 449, 452, 451, 520, 519, 522, 521, 464, 463, 483, 482, 261, 260, 289, 288, 377, 227, 427, 426, 567, 566, 155, 154, 249, 248, 409, 408, 413, 412, 392, 391, 407, 406, 547, 546, 358, 381, 485, 326, 219, 437, 168, 203, 202, 351, 484, 465, 568, 591, 590, 184, 510, 529, 251, 250, 331, 330, 436, 435, 448, 447, 551, 550 };
 
         if (string_compare_method == STRING_COMPARE_CORE) {
-            // Core-only method. Compares in us_EN locale (sorting may be slightly inaccurate in some countries). Will 
-            // return arbitrary return value for invalid utf8 (silent error treatment). If one or both strings have 
+            // Core-only method. Compares in us_EN locale (sorting may be slightly inaccurate in some countries). Will
+            // return arbitrary return value for invalid utf8 (silent error treatment). If one or both strings have
             // unicodes beyond 'Latin Extended 2' (0...591), then the strings are compared by unicode value.
             uint32_t char1;
             uint32_t char2;
@@ -426,7 +426,7 @@ namespace realm {
     {
         for (size_t i = 0; i != haystack.size(); ++i) {
             char c = haystack[i];
-            if (needle_lower[i] != c && needle_upper[i] != c) 
+            if (needle_lower[i] != c && needle_upper[i] != c)
                 return false;
         }
 
@@ -435,7 +435,7 @@ namespace realm {
         const char* i = begin;
         while (i != end) {
             if (!equal_sequence(i, end, needle_lower + (i - begin)) &&
-                !equal_sequence(i, end, needle_upper + (i - begin))) 
+                !equal_sequence(i, end, needle_upper + (i - begin)))
                 return false;
         }
         return true;

--- a/src/realm/util/encrypted_file_mapping.cpp
+++ b/src/realm/util/encrypted_file_mapping.cpp
@@ -319,7 +319,7 @@ void AESCryptor::calc_hmac(const void* src, size_t len, uint8_t* dst, const uint
 #endif
 }
 
-EncryptedFileMapping::EncryptedFileMapping(SharedFileInfo& file, size_t file_offset, void* addr, size_t size, 
+EncryptedFileMapping::EncryptedFileMapping(SharedFileInfo& file, size_t file_offset, void* addr, size_t size,
                                            File::AccessMode access)
 : m_file(file)
 , m_page_shift(log2(realm::util::page_size()))

--- a/src/realm/util/encrypted_file_mapping.hpp
+++ b/src/realm/util/encrypted_file_mapping.hpp
@@ -40,7 +40,7 @@ class EncryptedFileMapping;
 class EncryptedFileMapping {
 public:
     // Adds the newly-created object to file.mappings iff it's successfully constructed
-    EncryptedFileMapping(SharedFileInfo& file, size_t file_offset, 
+    EncryptedFileMapping(SharedFileInfo& file, size_t file_offset,
                          void* addr, size_t size, File::AccessMode access);
     ~EncryptedFileMapping();
 
@@ -53,7 +53,7 @@ public:
 
     // Make sure that memory in the specified range is synchronized with any
     // changes made globally visible through call to write_barrier
-    void read_barrier(const void* addr, size_t size, 
+    void read_barrier(const void* addr, size_t size,
                       UniqueLock& lock,
                       Header_to_size header_to_size);
 
@@ -102,7 +102,7 @@ private:
 
 
 
-inline void EncryptedFileMapping::read_barrier(const void* addr, size_t size, 
+inline void EncryptedFileMapping::read_barrier(const void* addr, size_t size,
                                                UniqueLock& lock,
                                                Header_to_size header_to_size)
 {

--- a/src/realm/util/file.hpp
+++ b/src/realm/util/file.hpp
@@ -346,7 +346,7 @@ public:
                 int map_flags = 0, size_t file_offset = 0) const;
 
 #if REALM_ENABLE_ENCRYPTION
-    void* map(AccessMode, size_t size, EncryptedFileMapping*& mapping, 
+    void* map(AccessMode, size_t size, EncryptedFileMapping*& mapping,
               int map_flags = 0, size_t offset = 0) const;
 #endif
     /// Unmap the specified address range which must have been

--- a/src/realm/util/file_mapper.cpp
+++ b/src/realm/util/file_mapper.cpp
@@ -326,7 +326,7 @@ void* mremap(int fd, size_t file_offset, void* old_addr, size_t old_size,
             return new_addr;
         int err = errno; // Eliminate any risk of clobbering
         // Do not throw here if mremap is declared as "not supported" by the
-        // platform Eg. When compiling with GNU libc on OSX, iOS. 
+        // platform Eg. When compiling with GNU libc on OSX, iOS.
         // In this case fall through to no-mremap case below.
         if (err != ENOTSUP && err != ENOSYS) {
             if (is_mmap_memory_error(err)) {

--- a/src/realm/util/file_mapper.hpp
+++ b/src/realm/util/file_mapper.hpp
@@ -44,16 +44,16 @@ class EncryptedFileMapping;
 
 // This variant allows the caller to obtain direct access to the encrypted file mapping
 // for optimization purposes.
-void *mmap(int fd, size_t size, File::AccessMode access, size_t offset, const char *encryption_key, 
+void *mmap(int fd, size_t size, File::AccessMode access, size_t offset, const char *encryption_key,
            EncryptedFileMapping*& mapping);
 
-void do_encryption_read_barrier(const void* addr, size_t size, 
+void do_encryption_read_barrier(const void* addr, size_t size,
                                 HeaderToSize header_to_size,
                                 EncryptedFileMapping* mapping);
 
 void do_encryption_write_barrier(const void* addr, size_t size, EncryptedFileMapping* mapping);
 
-void inline encryption_read_barrier(const void* addr, size_t size, 
+void inline encryption_read_barrier(const void* addr, size_t size,
                                     EncryptedFileMapping* mapping,
                                     HeaderToSize header_to_size = nullptr)
 {
@@ -70,7 +70,7 @@ void inline encryption_write_barrier(const void* addr, size_t size, EncryptedFil
 
 extern util::Mutex mapping_mutex;
 
-inline void do_encryption_read_barrier(const void* addr, size_t size, 
+inline void do_encryption_read_barrier(const void* addr, size_t size,
                                        HeaderToSize header_to_size,
                                        EncryptedFileMapping* mapping)
 {
@@ -78,7 +78,7 @@ inline void do_encryption_read_barrier(const void* addr, size_t size,
     mapping->read_barrier(addr, size, lock, header_to_size);
 }
 
-inline void do_encryption_write_barrier(const void* addr, size_t size, 
+inline void do_encryption_write_barrier(const void* addr, size_t size,
                                         EncryptedFileMapping* mapping)
 {
     LockGuard lock(mapping_mutex);
@@ -88,9 +88,9 @@ inline void do_encryption_write_barrier(const void* addr, size_t size,
 
 
 #else
-void inline encryption_read_barrier(const void*, size_t, 
+void inline encryption_read_barrier(const void*, size_t,
                                     EncryptedFileMapping*,
-                                    HeaderToSize header_to_size = nullptr) 
+                                    HeaderToSize header_to_size = nullptr)
 {
     static_cast<void>(header_to_size);
 }

--- a/src/realm/util/interprocess_condvar.cpp
+++ b/src/realm/util/interprocess_condvar.cpp
@@ -84,7 +84,7 @@ InterprocessCondVar::~InterprocessCondVar() noexcept
 
 
 
-void InterprocessCondVar::set_shared_part(SharedPart& shared_part, std::string base_path, 
+void InterprocessCondVar::set_shared_part(SharedPart& shared_part, std::string base_path,
                                           std::string condvar_name)
 {
     close();

--- a/src/realm/util/interprocess_mutex.hpp
+++ b/src/realm/util/interprocess_mutex.hpp
@@ -76,8 +76,8 @@ public:
     /// Attempt to check if the mutex is valid (only relevant if not emulating)
     bool is_valid() noexcept;
 
-    static bool is_robust_on_this_platform() 
-    { 
+    static bool is_robust_on_this_platform()
+    {
 #ifdef REALM_ROBUST_MUTEX_EMULATION
         return true;  // we're faking it!
 #else

--- a/src/realm/utilities.cpp
+++ b/src/realm/utilities.cpp
@@ -275,13 +275,13 @@ int fast_popcount64(int64_t x)
 }
 
 // A fast, thread safe, mediocre-quality random number generator named Xorshift
-uint64_t fastrand(uint64_t max, bool is_seed) 
+uint64_t fastrand(uint64_t max, bool is_seed)
 {
     // All the atomics (except the add) may be eliminated completely by the compiler on x64
     static std::atomic<uint64_t> state(is_seed ? max : 1);
-    
+
     // Thread safe increment to prevent two threads from producing the same value if called at the exact same time
-    state.fetch_add(1, std::memory_order_release); 
+    state.fetch_add(1, std::memory_order_release);
     uint64_t x = state.load(std::memory_order_acquire);
     // The result of this arithmetic may be overwritten by another thread, but that's fine in a rand generator
     x ^= x >> 12; // a

--- a/src/realm/utilities.hpp
+++ b/src/realm/utilities.hpp
@@ -202,8 +202,8 @@ struct is_any<T, T, Ts...> : std::true_type { };
 
 template<typename T, typename U, typename... Ts>
 struct is_any<T, U, Ts...> : is_any<T, Ts...> { };
-    
-    
+
+
 // Use safe_equal() instead of std::equal() when comparing sequences which can have a 0 elements.
 template<class InputIterator1, class InputIterator2>
 bool safe_equal(InputIterator1 first1, InputIterator1 last1, InputIterator2 first2)

--- a/test/benchmark-common-tasks-ios/ViewController.h
+++ b/test/benchmark-common-tasks-ios/ViewController.h
@@ -1,11 +1,11 @@
 /*************************************************************************
- * 
+ *
  * REALM CONFIDENTIAL
  * __________________
- * 
+ *
  *  [2011] - [2015] Realm Inc
  *  All Rights Reserved.
- * 
+ *
  * NOTICE:  All information contained herein is, and remains
  * the property of Realm Incorporated and its suppliers,
  * if any.  The intellectual and technical concepts contained

--- a/test/benchmark-common-tasks-ios/ViewController.mm
+++ b/test/benchmark-common-tasks-ios/ViewController.mm
@@ -12,7 +12,7 @@ extern "C" int benchmark_common_tasks_main();
 
 - (void)viewDidLoad {
     [super viewDidLoad];
-    
+
     std::string tmp_dir{[NSTemporaryDirectory() UTF8String]};
     realm::test_util::set_test_path_prefix(tmp_dir);
 
@@ -22,7 +22,7 @@ extern "C" int benchmark_common_tasks_main();
     [[NSProcessInfo processInfo] performActivityWithOptions:NSActivityLatencyCritical reason:@"benchmark-common-tasks" usingBlock:^{
         benchmark_common_tasks_main();
     }];
-    
+
     exit(0);
 }
 

--- a/test/benchmark-common-tasks/main.cpp
+++ b/test/benchmark-common-tasks/main.cpp
@@ -509,7 +509,7 @@ int benchmark_common_tasks_main()
 {
     std::string results_file_stem = test_util::get_test_path_prefix() + "results";
     BenchmarkResults results(40, results_file_stem.c_str());
-    
+
     run_benchmark<BenchmarkUnorderedTableViewClear>(results);
     run_benchmark<BenchmarkEmptyCommit>(results);
     run_benchmark<AddTable>(results);

--- a/test/benchmark-transaction/run-benchmarks.sh
+++ b/test/benchmark-transaction/run-benchmarks.sh
@@ -19,7 +19,7 @@ function bench {
     echo "# Duration: ${duration}" >> $out
     echo "# Readers Writers TPS(Reader) TPS(Writer) TPS(total)" >> $out
     for i in $(seq 0 $Nmax)
-    do 
+    do
         for j in $(seq 0 $Nmax)
         do
             echo -n "$j $i " >> $out

--- a/test/experiments/innotest.cpp
+++ b/test/experiments/innotest.cpp
@@ -35,25 +35,25 @@ int main(int argc, char* argv [])
         SharedGroup db("parallel_benchmark.realm", true, SharedGroup::durability_Async);
 
         for (size_t round = 0; round < 20; ++round) {
-    
+
             for (size_t i = 0; i < 1000000; ++i) {
                 if (reads_per_write != 0 && (i % reads_per_write) == 0)
                 {
                     WriteTransaction trx(db);
-                    
+
                     TableRef t = trx.get_table("test");
-                    
+
                     size_t ndx = rand() % 1000000;
-                    
+
                     int v = t->get_int(0, ndx);
                     t->set_int(0, ndx, v + 1);
                     trx.commit();
                 }
                 else {
                     ReadTransaction trx(db);
-                    
+
                     ConstTableRef t = trx.get_table("test");
-                    
+
                     size_t ndx = rand() % 1000000;
                     volatile int v;
                     v = t->get_int(0, ndx);
@@ -70,6 +70,6 @@ int main(int argc, char* argv [])
         wait(&status); // wait for child to complete
         spawns--;
     }
-    
+
     return 0;
 }

--- a/test/experiments/innotest.py
+++ b/test/experiments/innotest.py
@@ -13,7 +13,7 @@ print "Filling db"
 with db.write() as group:
     table = group.create_table("test", ["key",   "int",
                                         "value", "string"])
-    
+
     for i in range(1000000):
         table += [i, str(i)]
 

--- a/test/fuzz_group.cpp
+++ b/test/fuzz_group.cpp
@@ -343,7 +343,7 @@ void parse_and_apply_instructions(std::string& in, Group& g, util::Optional<std:
                         }
                     }
                 }
-            }               
+            }
             else if (instr == REMOVE_ROW && g.size() > 0) {
                 size_t table_ndx = get_next(s) % g.size();
                 TableRef t = g.get_table(table_ndx);

--- a/test/ios/template/App/AppDelegate.mm
+++ b/test/ios/template/App/AppDelegate.mm
@@ -23,7 +23,7 @@ using namespace realm::test_util;
     // Override point for customization after application launch.
     self.window.backgroundColor = [UIColor whiteColor];
     [self.window makeKeyAndVisible];
-    
+
     // Set the path prefix.
     string path_prefix = [NSTemporaryDirectory() UTF8String];
     set_test_path_prefix(path_prefix);
@@ -34,7 +34,7 @@ using namespace realm::test_util;
 
     // Run the tests.
     test_all(0, NULL);
-    
+
     // Report to stdout.
     std::cout << "====================" << std::endl;
     std::ifstream if_xml(path_prefix + "unit-test-report.xml", std::ios_base::binary);
@@ -54,7 +54,7 @@ using namespace realm::test_util;
 
 - (void)applicationDidEnterBackground:(UIApplication *)application
 {
-    // Use this method to release shared resources, save user data, invalidate timers, and store enough application state information to restore your application to its current state in case it is terminated later. 
+    // Use this method to release shared resources, save user data, invalidate timers, and store enough application state information to restore your application to its current state in case it is terminated later.
     // If your application supports background execution, this method is called instead of applicationWillTerminate: when the user quits.
 }
 

--- a/test/test_array_string.cpp
+++ b/test/test_array_string.cpp
@@ -518,7 +518,7 @@ TEST(ArrayString_Null)
 
         a.add("foo");
         a.add("");
-        a.add(realm::null()); 
+        a.add(realm::null());
 
         CHECK_EQUAL(a.is_null(0), false);
         CHECK_EQUAL(a.is_null(1), false);
@@ -540,7 +540,7 @@ TEST(ArrayString_Null)
         ArrayString a(Allocator::get_default(), true);
         a.create();
 
-        a.add(realm::null());  
+        a.add(realm::null());
         a.add("");
         a.add("foo");
 
@@ -550,9 +550,9 @@ TEST(ArrayString_Null)
         CHECK(a.get(2) == "foo");
 
         // Test insert
-        a.insert(0, realm::null()); 
-        a.insert(2, realm::null()); 
-        a.insert(4, realm::null()); 
+        a.insert(0, realm::null());
+        a.insert(2, realm::null());
+        a.insert(4, realm::null());
 
         CHECK_EQUAL(a.is_null(0), true);
         CHECK_EQUAL(a.is_null(1), true);
@@ -653,7 +653,7 @@ TEST(ArrayString_Null)
         }
         a.destroy();
     }
-   
+
 }
 
 
@@ -686,7 +686,7 @@ TEST(ArrayString_Null2)
         // Keeps width = 0
         a.add("");
 
-        // Now add an "a" which will relocate the array and initialize the trailing width-byte of the empty string 
+        // Now add an "a" which will relocate the array and initialize the trailing width-byte of the empty string
         // (see array_string.hpp header) to the same value as m_width (which is 2). For a nullable column, that would
         // indicate that a[0] == null. But we're not nullable, so the following get(0) should not return null.
         a.add("a");
@@ -694,7 +694,7 @@ TEST(ArrayString_Null2)
         StringData sd = a.get(0);
         CHECK(!sd.is_null());
         CHECK_EQUAL(a.find_first(""), 0);
-        
+
         a.destroy();
         b.destroy();
     }

--- a/test/test_array_string_long.cpp
+++ b/test/test_array_string_long.cpp
@@ -49,7 +49,7 @@ struct nullable {
 struct non_nullable {
     static constexpr bool value = false;
 };
-    
+
 } // anonymous namespace
 
 
@@ -280,7 +280,7 @@ TEST(ArrayStringLong_Null)
 
         a.add("foo");
         a.add("");
-        a.add(realm::null()); 
+        a.add(realm::null());
 
         CHECK_EQUAL(a.is_null(0), false);
         CHECK_EQUAL(a.is_null(1), false);
@@ -302,7 +302,7 @@ TEST(ArrayStringLong_Null)
         ArrayStringLong a(Allocator::get_default(), true);
         a.create();
 
-        a.add(realm::null());  
+        a.add(realm::null());
         a.add("");
         a.add("foo");
 
@@ -312,9 +312,9 @@ TEST(ArrayStringLong_Null)
         CHECK(a.get(2) == "foo");
 
         // Test insert
-        a.insert(0, realm::null()); 
-        a.insert(2, realm::null()); 
-        a.insert(4, realm::null()); 
+        a.insert(0, realm::null());
+        a.insert(2, realm::null());
+        a.insert(4, realm::null());
 
         CHECK_EQUAL(a.is_null(0), true);
         CHECK_EQUAL(a.is_null(1), true);

--- a/test/test_group.cpp
+++ b/test/test_group.cpp
@@ -2365,7 +2365,7 @@ TEST(Group_Fuzzy)
 
         for (size_t counter = 0; counter < iterations; counter++)
         {
-            // You can use your own seed if you have observed a crashing unit test that 
+            // You can use your own seed if you have observed a crashing unit test that
             // printed out some specific seed (the "Unit test random seed:" part that appears).
             //fastrand(534653645, true);
             fastrand(unit_test_random_seed + counter, true);

--- a/test/test_index_string.cpp
+++ b/test/test_index_string.cpp
@@ -1031,8 +1031,8 @@ TEST(StringIndex_Zero_Crash2)
                 table.add_search_index(0);
             }
             else if (action > 48 && table.size() < 10) {
-                // Generate string with equal probability of being empty, null, short, medium and long, and with 
-                // their contents having equal proability of being either random or a duplicate of a previous 
+                // Generate string with equal probability of being empty, null, short, medium and long, and with
+                // their contents having equal proability of being either random or a duplicate of a previous
                 // string. When it's random, each char must have equal probability of being 0 or non-0e
                 char buf[] = "This string is around 90 bytes long, which falls in the long-string type of Realm strings";
                 char* buf1 = static_cast<char*>(malloc(sizeof(buf)));
@@ -1062,7 +1062,7 @@ TEST(StringIndex_Zero_Crash2)
                         else
                             buf2[t] = static_cast<char>(random.draw_int<int>());  // random byte
                     }
-                    // no generated string can equal "null" (our vector magic value for null) because 
+                    // no generated string can equal "null" (our vector magic value for null) because
                     // len == 4 is not possible
                     sd = StringData(buf2, len);
                 }
@@ -1115,7 +1115,7 @@ TEST(StringIndex_Integer_Increasing)
     for (size_t row = 0; row < rows; row++) {
         int64_t v = table.get_int(0, row);
         size_t c = table.count_int(0, v);
-        
+
         size_t start = std::lower_bound(reference.begin(), reference.end(), v) - reference.begin();
         size_t ref_count = 0;
         for (size_t t = start; t < reference.size(); t++) {

--- a/test/test_link_query_view.cpp
+++ b/test/test_link_query_view.cpp
@@ -126,7 +126,7 @@ TEST(LinkList_MissingDeepCopy)
     table2->set_link(col_link2, 0, 1);
     table2->set_link(col_link2, 1, 2);
 
-    char* c = new char[10000000]; 
+    char* c = new char[10000000];
     c[10000000 - 1] = '!';
     Query q = table2->link(col_link2).column<String>(1) == StringData(&c[10000000 - 1], 1);
 
@@ -1322,15 +1322,15 @@ TEST(LinkList_QueryOnLinkList)
 
     // Should of course work even if nothing has changed
     tv.sync_if_needed();
-  
+
     // Modify the LinkList and see if sync_if_needed takes it in count
     lvr->remove(2); // bumps version of table2 and only table2
     tv.sync_if_needed();
-    
+
     CHECK_EQUAL(1, tv.size()); // fail
     CHECK_EQUAL(0, tv.get_source_ndx(0));
-    
-    // Now test if changes in linked-to table bumps the version of the linked-from table and that 
+
+    // Now test if changes in linked-to table bumps the version of the linked-from table and that
     // the query of 'tv' is re-run
     table1->set_int(0, 2, 50); // exclude row 2 from tv because of the '> 100' condition in Query
     tv.sync_if_needed();
@@ -1400,7 +1400,7 @@ TEST(LinkList_QueryLinkNull)
     // +-+--------+------+------+--------+------+
     // | | string | link | int  | double | date |
     // +-+--------+------+------+--------+------+
-    // |0| Fish   |    0 |   1  |   1.0  |  1   | 
+    // |0| Fish   |    0 |   1  |   1.0  |  1   |
     // |1| null   | null | null |  null  | null |
     // |2| Horse  |    1 |   2  |   2.0  |  2   |
     // +-+--------+------+------+--------+------+
@@ -1569,10 +1569,10 @@ TEST(LinkList_QueryDateTime)
     table1->add_column_link(type_LinkList, "link", *table2);
 
     table2->add_column(type_DateTime, "date");
-    
+
     table2->add_empty_row();
     table2->set_datetime(0, 0, DateTime(1));
-    
+
     table1->add_empty_row();
     LinkViewRef lvr = table1->get_linklist(0, 0);
     lvr->add(0);

--- a/test/test_query.cpp
+++ b/test/test_query.cpp
@@ -490,9 +490,9 @@ TEST(Query_NextGenSyntax)
 /*
 This tests the new string conditions now available for the expression syntax.
 
-Null behaviour (+ means concatenation): 
+Null behaviour (+ means concatenation):
 
-If A + B == B, then A is a prefix of B, and B is a suffix of A. This is valid for any A and B, including null and 
+If A + B == B, then A is a prefix of B, and B is a suffix of A. This is valid for any A and B, including null and
 empty strings. Some examples:
 
 1)    "" both begins with null and ends with null and contains null.
@@ -5791,7 +5791,7 @@ TEST(Query_DeepCopyLeak1)
 
 TEST(Query_DeepCopyTest)
 {
-    // If Query::first vector was relocated because of push_back, then Query would crash, because referenced 
+    // If Query::first vector was relocated because of push_back, then Query would crash, because referenced
     // pointers were pointing into it.
     Table table;
     table.add_column(type_Int, "first");
@@ -5916,8 +5916,8 @@ TEST(Query_Nulls_Fuzzy)
                 unsigned char action = static_cast<unsigned char>(random.draw_int_max<unsigned int>(100));
 
                 if (action > 48 && table.size() < 10) {
-                    // Generate string with equal probability of being empty, null, short, medium and long, and with 
-                    // their contents having equal proability of being either random or a duplicate of a previous 
+                    // Generate string with equal probability of being empty, null, short, medium and long, and with
+                    // their contents having equal proability of being either random or a duplicate of a previous
                     // string. When it's random, each char must have equal probability of being 0 or non-0
                     char buf[] = "This string is around 90 bytes long, which falls in the long-string type of Realm strings";
                     char* buf1 = static_cast<char*>(malloc(sizeof(buf)));
@@ -5957,7 +5957,7 @@ TEST(Query_Nulls_Fuzzy)
                                 else
                                     buf2[t] = static_cast<char>(fastrand(255));  // random byte
                             }
-                            // no generated string can equal "null" (our vector magic value for null) because 
+                            // no generated string can equal "null" (our vector magic value for null) because
                             // len == 4 is not possible
                             sd = StringData(buf2, len);
                             st = std::string(buf2, len);
@@ -6005,7 +6005,7 @@ TEST(Query_BinaryNull)
     table.set_binary(0, 0, BinaryData());
     table.set_binary(0, 1, BinaryData("", 0)); // NOTE: Specify size = 0, else size turns into 1!
     table.set_binary(0, 2, BinaryData("foo"));
-    
+
     TableView t;
 
     // Next gen syntax
@@ -6479,7 +6479,7 @@ TEST(Query_NullShowcase)
     int64_t i;
     double d;
     DateTime dt;
-    tv = table->where().find_all();    
+    tv = table->where().find_all();
 
     // Integer column
     i = tv.maximum_int(0);
@@ -6536,19 +6536,19 @@ TEST(Query_NullShowcase)
 
     table->set_float(1, 0, std::numeric_limits<float>::signaling_NaN());
     table->set_float(1, 1, std::numeric_limits<float>::quiet_NaN());
-    
-    // Realm may return a signalling/quiet NaN that is different from the signalling/quiet NaN you stored 
-    // (the IEEE standard defines a sequence of bits in the NaN that can have custom contents). Realm does 
+
+    // Realm may return a signalling/quiet NaN that is different from the signalling/quiet NaN you stored
+    // (the IEEE standard defines a sequence of bits in the NaN that can have custom contents). Realm does
     // not preserve these bits.
     CHECK(std::isnan(table->get_float(1, 0)));
     CHECK(std::isnan(table->get_float(1, 1)));
 
- 
+
     // FIXME: std::numeric_limits<float>::signaling_NaN() seems broken in VS2015 in that it returns a non-
-    // signaling NaN. A bug report has been filed to Microsoft. Update: It turns out that on 32-bit Intel 
-    // Architecture (at least on my Core i7 in 32 bit code), if you push a float-NaN (fld instruction) that 
+    // signaling NaN. A bug report has been filed to Microsoft. Update: It turns out that on 32-bit Intel
+    // Architecture (at least on my Core i7 in 32 bit code), if you push a float-NaN (fld instruction) that
     // has bit 22 clear (indicates it's signaling), and pop it back (fst instruction), the FPU will toggle
-    // that bit into being set. All this needs further investigation, so a P2 has been created. Note that 
+    // that bit into being set. All this needs further investigation, so a P2 has been created. Note that
     // IEEE just began specifying signaling vs. non-signaling NaNs in 2008. Also note that all this seems
     // to work fine on ARM in both 32 and 64 bit mode.
 
@@ -6957,7 +6957,7 @@ TEST(Query_Null_BetweenMinMax_Nullable)
     CHECK_EQUAL(count, 1);
     count = 123;
     CHECK_EQUAL(tv.average_double(3, &count), 10.);
-    CHECK_EQUAL(count, 1); 
+    CHECK_EQUAL(count, 1);
 }
 
 
@@ -7964,7 +7964,7 @@ TEST(Query_FuzzyFind)
         const size_t rows = 18;
         for (size_t i = 0; i < rows; ++i) {
             table->add_empty_row();
-            
+
             // Produce numbers -3 ... 17. Just to test edge cases around 4-bit values also
             int64_t t = (fastrand() % 21) - 3;
             table->set_int(col, i, t);
@@ -8087,7 +8087,7 @@ TEST(Query_MaximumSumAverage)
         table1->add_column(type_Int, "int2", /* nullable */ n);
         table1->add_column(type_Double, "d", /* nullable */ n);
 
-        // Create three identical columns with values: For the nullable case: 
+        // Create three identical columns with values: For the nullable case:
         //      3, 4, null
         // For non-nullable iteration:
         //      3, 4
@@ -8401,7 +8401,7 @@ TEST(Query_ReferDeletedLinkView)
     LinkViewRef links = table->get_linklist(0, 0);
     Query q = table->where(links);
     TableView tv = q.find_all();
-    
+
     // TableView that depends on LinkView soon to be deleted
     TableView tv_sorted = links->get_sorted_view(1);
 
@@ -8436,7 +8436,7 @@ TEST(Query_ReferDeletedLinkView)
 
     CHECK(!links->is_attached());
     tv.sync_if_needed();
-    
+
     // PLEASE NOTE that 'tv' will still return true in this case! Even though it indirectly depends on
     // the LinkView through multiple levels!
     CHECK(tv.is_attached());

--- a/test/test_string_data.cpp
+++ b/test/test_string_data.cpp
@@ -240,7 +240,7 @@ TEST(StringData_LexicographicCompare)
 TEST(StringData_Substrings)
 {
     // Reasoning behind behaviour is that if you append strings A + B then B is a suffix of a, and hence A
-    // "ends with" B, and B "begins with" A. This is true even though appending a null or empty string keeps the 
+    // "ends with" B, and B "begins with" A. This is true even though appending a null or empty string keeps the
     // original unchanged
 
     StringData empty("");

--- a/test/test_table_view.cpp
+++ b/test/test_table_view.cpp
@@ -1783,7 +1783,7 @@ TEST(TableView_Distinct)
     // Now test sync_if_needed()
     tv = t.where().find_all();
     // "", null, "", null, "foo", "foo", "bar"
-    
+
     tv.sort(0, false);
     // "foo", "foo", "bar", "", "", null, null
 

--- a/test/test_thread.cpp
+++ b/test/test_thread.cpp
@@ -153,7 +153,7 @@ struct Robust {
 
 class QueueMonitor {
 public:
-    QueueMonitor(): m_closed(false) 
+    QueueMonitor(): m_closed(false)
     {
     }
 

--- a/test/test_utf8.cpp
+++ b/test/test_utf8.cpp
@@ -192,7 +192,7 @@ NONCONCURRENT_TEST(UTF8_Compare_Core_utf8_invalid)
     // Test that invalid utf8 won't make decisions on data beyond Realm payload. Do that by placing an utf8 header that
     // indicate 5 octets will follow, and put spurious1 and spurious2 after them to see if Realm will access these too
     // and make sorting decisions on them. Todo: This does not guarantee that spurious data access does not happen;
-    // todo: make unit test that attempts to trigger segfault near a page limit instead. 
+    // todo: make unit test that attempts to trigger segfault near a page limit instead.
     char invalid1[] = "\xfc";
     char spurious1[] = "aaaaaaaaaaaaaaaa";
     char invalid2[] = "\xfc";

--- a/test/unit-tests-ios/ViewController.h
+++ b/test/unit-tests-ios/ViewController.h
@@ -1,11 +1,11 @@
 /*************************************************************************
- * 
+ *
  * REALM CONFIDENTIAL
  * __________________
- * 
+ *
  *  [2011] - [2015] Realm Inc
  *  All Rights Reserved.
- * 
+ *
  * NOTICE:  All information contained herein is, and remains
  * the property of Realm Incorporated and its suppliers,
  * if any.  The intellectual and technical concepts contained

--- a/windows/Builder_Readme.txt
+++ b/windows/Builder_Readme.txt
@@ -18,7 +18,7 @@ consisting of LIB files, and header files.
 
 You will need both Visual Studio 2010 and Visual Studio 2012 to build the release.
 
-Warning : Following the instructions below, vs2012 will have changed the project files. 
+Warning : Following the instructions below, vs2012 will have changed the project files.
 Do not check these changed files back into github as VS2010 cannot read them correctly.
 
 If You have access to many cores, or two computers you can do vs2010 on one computer in one repository
@@ -26,7 +26,7 @@ If You have access to many cores, or two computers you can do vs2010 on one comp
 
 1. open Realm.sln in VS2010
 
-2. select Build->Batch Build. Unmark *all* , mark the 4 called 
+2. select Build->Batch Build. Unmark *all* , mark the 4 called
 project:  configuration: Platform
 Realm   Debug      Win32
 Realm   Debug      x64
@@ -40,7 +40,7 @@ click clean
 
 5. Look through Output, look for warnings.
 
-6. For each warning, click on it to view the source. The source should have a note about the specific warning, 
+6. For each warning, click on it to view the source. The source should have a note about the specific warning,
 otherwise a c++ developer will have to evaluate the warning and fix the problem or write a note
 
 7. Assuming all warnigs are noted in the source, and all 8 projects build, continue..
@@ -68,17 +68,17 @@ Select Release in Solution Configurations drop down
 Select x64 in solution platform drops down
 Click the green run arrow. after a while,
 top5 timings will be shown. No unit tests should be listed as failed.
-Press ENTER. 
+Press ENTER.
 
 11.
 Select Release in Solution Configurations drop down
 Select win32 in solution platform drops down
 Click the green run arrow. after a while,
 top5 timings will be shown. No unit tests should be listed as failed.
-Press ENTER. 
+Press ENTER.
 
 
-12. select Build->Batch Build. Unmark *all* , mark the 4 called 
+12. select Build->Batch Build. Unmark *all* , mark the 4 called
 project:  configuration: Platform
 Realm   Static library, debug    Win32
 Realm   Static library, debug    x64
@@ -92,7 +92,7 @@ click clean
 
 15. Look through Output, look for warnings.
 
-16. For each warning, click on it to view the source. The source should have a note about the specific warning, 
+16. For each warning, click on it to view the source. The source should have a note about the specific warning,
 otherwise a c++ developer will have to evaluate the warning and fix the problem or write a note
 6. Assuming all warnigs are noted in the source, and all 8 projects build, continue..
 
@@ -105,7 +105,7 @@ otherwise a c++ developer will have to evaluate the warning and fix the problem 
 20. in the windows folder, double click on winrelease2010.cmd
 
 
-***Visual studio 2012 build 
+***Visual studio 2012 build
 
 21. Open Realm.sln with visual studio 2012 . right click "Solution 'Realm' (8 projects) in Solution Explorer
 
@@ -115,7 +115,7 @@ otherwise a c++ developer will have to evaluate the warning and fix the problem 
 
 24. wait while VS2012 updates the projects.
 
-25. select Build->Batch Build. Unmark *all* , mark the 4 called 
+25. select Build->Batch Build. Unmark *all* , mark the 4 called
 project:  configuration: Platform
 Realm   Debug      Win32
 Realm   Debug      x64
@@ -129,7 +129,7 @@ click clean
 
 28. Look through Output, look for warnings.
 
-29. For each warning, click on it to view the source. The source should have a note about the specific warning, 
+29. For each warning, click on it to view the source. The source should have a note about the specific warning,
 otherwise a c++ developer will have to evaluate the warning and fix the problem or write a note
 
 30. Assuming all warnigs are noted in the source, and all 8 projects build, continue..
@@ -157,17 +157,17 @@ Select Release in Solution Configurations drop down
 Select x64 in solution platform drops down
 Click the green run arrow. after a while,
 top5 timings will be shown. No unit tests should be listed as failed.
-Press ENTER. 
+Press ENTER.
 
 34.
 Select Release in Solution Configurations drop down
 Select win32 in solution platform drops down
 Click the green run arrow. after a while,
 top5 timings will be shown. No unit tests should be listed as failed.
-Press ENTER. 
+Press ENTER.
 
 
-35. select Build->Batch Build. Unmark *all* , mark the 4 called 
+35. select Build->Batch Build. Unmark *all* , mark the 4 called
 project:  configuration: Platform
 Realm   Static library, debug    Win32
 Realm   Static library, debug    x64
@@ -181,7 +181,7 @@ click clean
 
 38. Look through Output, look for warnings.
 
-39. For each warning, click on it to view the source. The source should have a note about the specific warning, 
+39. For each warning, click on it to view the source. The source should have a note about the specific warning,
 otherwise a c++ developer will have to evaluate the warning and fix the problem or write a note
 
 40. Assuming all warnigs are noted in the source, and all 8 projects build, continue..
@@ -199,10 +199,10 @@ otherwise a c++ developer will have to evaluate the warning and fix the problem 
 
 The release files can now be found in the directories Windows\release\vs2010 and Windows\release\vs2012
 the VS20NN directories contains two sub directories:
-files\ 
-release\  
+files\
+release\
 
 files\
- is an unpacked version, 
+ is an unpacked version,
 release\
 contains a timestamped zip file with the same files as are found in the files\ directory

--- a/windows/Release_Readme.txt
+++ b/windows/Release_Readme.txt
@@ -1,21 +1,21 @@
 This is a binary relase of the Realm Engine, for Microsoft Visual Studio.
 
-to use realm in Visual Studio C++ solutions, You will have to reference the LIB 
+to use realm in Visual Studio C++ solutions, You will have to reference the LIB
 and header files enclosed in this archive.
-Furthermore any compiler settings that change ABI layout, must match those used 
+Furthermore any compiler settings that change ABI layout, must match those used
 to build Realm core.
 
-In the examples directory you will find an empty C++ solution with a console project 
+In the examples directory you will find an empty C++ solution with a console project
 that uses realm. You can use that solution as a starting point,
 or adapt Your own project settings, using the example project settings as a guide.
 
 It is critically important that You reference debug libraries in debug builds, and
 release binaries in release builds, and that the 64/32 bitness matches up correctly.
 
-Please note that the free visual studio c++ express 2010 does not support 
-64 bit builds, and that the example solution includes 64 bit support. 
+Please note that the free visual studio c++ express 2010 does not support
+64 bit builds, and that the example solution includes 64 bit support.
 You will not be able to get the sample solution to work using the free visual studio
-express c++ 2010 You will need the commercial Visual studio professional 2010 or 
+express c++ 2010 You will need the commercial Visual studio professional 2010 or
 the free visual studio 2012 express.
 
 (Please also note that the example solution has not yet been created, so it is not

--- a/windows/winrelease.cmd
+++ b/windows/winrelease.cmd
@@ -4,8 +4,8 @@ echo Realm core c++ binding Windows Release.
 Echo beta 0.11
 echo ----------------------------------------------------------
 echo This cmd file will collect the result of a visual studio
-echo Version %1 build of Realm and create a release archive 
-echo with all the files that should be distributed 
+echo Version %1 build of Realm and create a release archive
+echo with all the files that should be distributed
 echo to c++ binding users.
 echo The release will be located in Windows\Release\vs%1
 echo ----------------------------------------------------------
@@ -59,7 +59,7 @@ cd %location%release\vs%vsversion%\files
 echo %location%7z.exe a -tzip -r %location%release\vs%vsversion%\release\%releasefilename% *.*
 %location%7z.exe a -tzip -r %releasefilename% *.*
 :revision history
-:0.01 
+:0.01
 :First version. still needs to set up date time and developer environment variables correctly
 :Only support for vs2012
 :still need to be able to call the compiler to get things built


### PR DESCRIPTION
Quick and dirty reg. ex. search + replace. Reason for this cleanup: I got conflicts (on whitespace changes), when trying to integrate latest `master` into `newdate`.

@teotwaki
