### PR TITLE
protect against database corruption following crash in the critical p…

### DIFF
--- a/src/realm/group_shared.cpp
+++ b/src/realm/group_shared.cpp
@@ -436,6 +436,10 @@ struct alignas(8) SharedGroup::SharedInfo {
     /// writer crashes during this phase, there is no safe way of continuing
     /// with further write transactions. When beginning a write transaction, 
     /// this must be checked and an exception thrown if set.
+    /// FIXME: This is a temporary approach until we get the commitlog data
+    /// moved into the realm file. After that it should be feasible to either
+    /// handle the error condition properly or preclude it by using a non-robust
+    /// mutex for the remaining and much smaller critical section.
     uint8_t commit_in_critical_phase : 1; // Offset 3
 
     /// The target Realm file format version for the current session. This


### PR DESCRIPTION
The introduction of use of robust mutexes unfortunately opens for a situation where a crash in the midst of a commit may allow a subsequent commit to leave the database in an inconsistent state, if said commit also crashes. To prevent this and protect the integrity of the database (at all costs), this PR will cause begin_write to throw an exception if the situation can arise. This will ultimately kill all session participants as soon as they try to commit anything. When a new session is initiated, the problem will be fixed by the mechanisms already in place in SharedGroup::open().

This is not intended to be a long lasting solution.
