### PR TITLE
Assert that the LinkView passed to table->where(lvr) is for the correct table

### DIFF
--- a/src/realm/query.cpp
+++ b/src/realm/query.cpp
@@ -29,6 +29,7 @@ Query::Query(const Table& table, const LinkViewRef& lv):
     m_source_link_view(lv), m_source_table_view(nullptr), m_owns_source_table_view(false)
 {
     REALM_ASSERT_DEBUG(m_view == nullptr || m_view->cookie == m_view->cookie_expected);
+    REALM_ASSERT_DEBUG(&lv->get_target_table() == m_table);
     create();
 }
 


### PR DESCRIPTION
Passing in a different table gives nonsensical results and/or crashes. Mostly crashes.
