### PR TITLE
New logging features in unit test framework, and option to abort on failure

### DIFF
--- a/README.md
+++ b/README.md
@@ -255,6 +255,16 @@ These are the available variables:
    file. For details, see `realm::test_util::unit_test::create_xml_reporter()`
    in `test/util/unit_test.hpp`.
 
+ - Set `UNITTEST_LOG_TO_FILES` to a non-empty value to redirect log messages
+   (including progress messages) to log files. One log file will be created per
+   test thread (`UNITTEST_THREADS`). The files will be named
+   `test_logs_%1/thread_%2_.log` where `%1` is a timestamp and `%2` is the test
+   thread number.
+
+ - Set `UNITTEST_ABORT_ON_FAILURE` to a non-empty value to termination of the
+   testing process as soon as a check fails or an unexpected exception is thrown
+   in a test.
+
 Memory debugging:
 
 Realm currently allows for uninitialized data to be written to a database

--- a/release_notes.md
+++ b/release_notes.md
@@ -23,6 +23,10 @@
   it could run forever.
 * Fixed a few compiler warnings
 * Disabled unittest Shared_WaitForChange again, as it can still run forever
+* New features in the unit test framework: Ability to log to a file (one for
+  each test thread) (`UNITTEST_LOG_TO_FILES`), and an option to abort on first
+  failed check (`UNITTEST_ABORT_ON_FAILURE`). Additionally, logging
+  (`util::Logger`) is now directly available to each unit test.
 
 ----------------------------------------------
 

--- a/src/realm/util/logger.hpp
+++ b/src/realm/util/logger.hpp
@@ -20,13 +20,16 @@
 #ifndef REALM_UTIL_LOGGER_HPP
 #define REALM_UTIL_LOGGER_HPP
 
+#include <utility>
 #include <string>
+#include <locale>
 #include <sstream>
 #include <iostream>
 
 #include <realm/util/features.h>
 #include <realm/util/tuple.hpp>
 #include <realm/util/thread.hpp>
+#include <realm/util/file.hpp>
 
 namespace realm {
 namespace util {
@@ -38,111 +41,208 @@ namespace util {
 ///    logger.log("Listening for peers on %1:%2", listen_address, listen_port);
 class Logger {
 public:
-    template<class... Params>
-    void log(const char* message, Params... params)
-    {
-        State state(message);
-        log_impl(state, params...);
-    }
+    template<class... Params> void log(const char* message, Params...);
 
-    virtual ~Logger() {}
+    Logger() noexcept;
+    virtual ~Logger() noexcept;
 
 protected:
-    virtual void do_log(const std::string& message)
-    {
-        std::cerr << message << '\n' << std::flush;
-    }
+    static void do_log(Logger&, std::string message);
 
-    static void do_log(Logger* logger, const std::string& message)
-    {
-        logger->do_log(message);
-    }
+    virtual void do_log(std::string message) = 0;
 
 private:
-    struct State {
-        std::string m_message;
-        std::string m_search;
-        int m_param_num = 1;
-        std::ostringstream m_formatter;
-        State(const char* s):
-            m_message(s),
-            m_search(m_message)
-        {
-        }
-    };
+    struct State;
+    template<class> struct Subst;
 
-    template<class T>
-    struct Subst {
-        void operator()(const T& param, State* state)
-        {
-            state->m_formatter << "%" << state->m_param_num;
-            std::string key = state->m_formatter.str();
-            state->m_formatter.str(std::string());
-            std::string::size_type j = state->m_search.find(key);
-            if (j != std::string::npos) {
-                state->m_formatter << param;
-                std::string str = state->m_formatter.str();
-                state->m_formatter.str(std::string());
-                state->m_message.replace(j, key.size(), str);
-                state->m_search.replace(j, key.size(), std::string(str.size(), '\0'));
-            }
-            ++state->m_param_num;
-        }
-    };
-
-    void log_impl(State& state)
-    {
-        do_log(state.m_message);
-    }
-
-    template<class Param, class... Params>
-    void log_impl(State& state, const Param& param, Params... params)
-    {
-        Subst<Param>()(param, &state);
-        log_impl(state, params...);
-    }
+    void log_impl(State&);
+    template<class Param, class... Params> void log_impl(State&, const Param&, Params...);
 };
 
 
 
-/// this makes all the log() methods are thread-safe.
-class ThreadSafeLogger: public Logger {
+class StderrLogger: public Logger {
+protected:
+    void do_log(std::string) override;
+};
+
+
+
+class StreamLogger: public Logger {
 public:
-    ThreadSafeLogger(Logger& base_logger):
-        m_base_logger(&base_logger)
-    {
-    }
+    explicit StreamLogger(std::ostream&) noexcept;
 
 protected:
-    Logger* const m_base_logger;
-    Mutex m_mutex;
+    void do_log(std::string) override;
 
-    void do_log(const std::string& msg) override
-    {
-        LockGuard l(m_mutex);
-        Logger::do_log(m_base_logger, msg);
-    }
+private:
+    std::ostream& m_out;
+};
+
+
+
+class FileLogger: public StreamLogger {
+public:
+    explicit FileLogger(std::string path);
+    explicit FileLogger(util::File);
+
+private:
+    util::File m_file;
+    util::File::Streambuf m_streambuf;
+    std::ostream m_out;
+};
+
+
+
+/// This makes Logger::log() thread-safe.
+class ThreadSafeLogger: public Logger {
+public:
+    explicit ThreadSafeLogger(Logger& base_logger);
+
+protected:
+    void do_log(std::string) override;
+
+private:
+    Logger& m_base_logger;
+    Mutex m_mutex;
 };
 
 
 
 class PrefixLogger: public Logger {
 public:
-    PrefixLogger(std::string prefix, Logger& base_logger):
-        m_prefix(prefix), m_base_logger(&base_logger)
-    {
-    }
+    PrefixLogger(std::string prefix, Logger& base_logger);
 
 protected:
-    const std::string m_prefix;
-    Logger* const m_base_logger;
+    void do_log(std::string) override;
 
-    void do_log(const std::string& msg) override
+private:
+    const std::string m_prefix;
+    Logger& m_base_logger;
+};
+
+
+
+
+// Implementation
+
+struct Logger::State {
+    std::string m_message;
+    std::string m_search;
+    int m_param_num = 1;
+    std::ostringstream m_formatter;
+    State(const char* s):
+        m_message(s),
+        m_search(m_message)
     {
-        Logger::do_log(m_base_logger, m_prefix + msg);
+        m_formatter.imbue(std::locale::classic());
     }
 };
 
+template<class T> struct Logger::Subst {
+    void operator()(const T& param, State* state)
+    {
+        state->m_formatter << "%" << state->m_param_num;
+        std::string key = state->m_formatter.str();
+        state->m_formatter.str(std::string());
+        std::string::size_type j = state->m_search.find(key);
+        if (j != std::string::npos) {
+            state->m_formatter << param;
+            std::string str = state->m_formatter.str();
+            state->m_formatter.str(std::string());
+            state->m_message.replace(j, key.size(), str);
+            state->m_search.replace(j, key.size(), std::string(str.size(), '\0'));
+        }
+        ++state->m_param_num;
+    }
+};
+
+inline Logger::Logger() noexcept
+{
+}
+
+inline Logger::~Logger() noexcept
+{
+}
+
+template<class... Params>
+inline void Logger::log(const char* message, Params... params)
+{
+    State state(message);
+    log_impl(state, params...);
+}
+
+inline void Logger::do_log(Logger& logger, std::string message)
+{
+    logger.do_log(std::move(message));
+}
+
+inline void Logger::log_impl(State& state)
+{
+    do_log(std::move(state.m_message));
+}
+
+template<class Param, class... Params>
+inline void Logger::log_impl(State& state, const Param& param, Params... params)
+{
+    Subst<Param>()(param, &state);
+    log_impl(state, params...);
+}
+
+inline void StderrLogger::do_log(std::string message)
+{
+    std::cerr << message << '\n'; // Throws
+    std::cerr.flush(); // Throws
+}
+
+inline StreamLogger::StreamLogger(std::ostream& out) noexcept:
+    m_out(out)
+{
+}
+
+inline void StreamLogger::do_log(std::string message)
+{
+    m_out << message << '\n'; // Throws
+    m_out.flush(); // Throws
+}
+
+inline FileLogger::FileLogger(std::string path):
+    StreamLogger(m_out),
+    m_file(path, util::File::mode_Write), // Throws
+    m_streambuf(&m_file), // Throws
+    m_out(&m_streambuf) // Throws
+{
+}
+
+inline FileLogger::FileLogger(util::File file):
+    StreamLogger(m_out),
+    m_file(std::move(file)),
+    m_streambuf(&m_file), // Throws
+    m_out(&m_streambuf) // Throws
+{
+}
+
+inline ThreadSafeLogger::ThreadSafeLogger(Logger& base_logger):
+    m_base_logger(base_logger)
+{
+}
+
+inline void ThreadSafeLogger::do_log(std::string message)
+{
+    LockGuard l(m_mutex);
+    Logger::do_log(m_base_logger, message); // Throws
+}
+
+inline PrefixLogger::PrefixLogger(std::string prefix, Logger& base_logger):
+    m_prefix(std::move(prefix)), // Throws
+    m_base_logger(base_logger)
+{
+}
+
+inline void PrefixLogger::do_log(std::string message)
+{
+    Logger::do_log(m_base_logger, m_prefix + message); // Throws
+}
 
 } // namespace util
 } // namespace realm

--- a/test/experiments/testcase.cpp
+++ b/test/experiments/testcase.cpp
@@ -23,9 +23,6 @@
 
 #include "../test.hpp"
 #include "../util/demangle.hpp"
-#include "../util/random.hpp"
-#include "../util/thread_wrapper.hpp"
-#include "../util/random.hpp"
 
 using namespace realm;
 using namespace realm::util;

--- a/test/experiments/upper_lower_bound.cpp
+++ b/test/experiments/upper_lower_bound.cpp
@@ -13,8 +13,6 @@
 #include <realm/array_binary.hpp>
 #include <realm/array_string_long.hpp>
 
-#include "../util/thread_wrapper.hpp"
-
 #include "../util/timer.hpp"
 #include "unit_test.hpp"
 

--- a/test/test.hpp
+++ b/test/test.hpp
@@ -2,6 +2,7 @@
 #define REALM_TEST_HPP
 
 #include "util/random.hpp"
+#include "util/thread_wrapper.hpp"
 #include "util/unit_test.hpp"
 #include "util/test_types.hpp"
 #include "util/test_path.hpp"

--- a/test/test_all.hpp
+++ b/test/test_all.hpp
@@ -1,6 +1,8 @@
 #ifndef REALM_TEST_TEST_ALL_HPP
 #define REALM_TEST_TEST_ALL_HPP
 
-int test_all(int argc, char* argv[]);
+#include <realm/util/logger.hpp>
+
+int test_all(int argc, char* argv[], realm::util::Logger* = nullptr);
 
 #endif // REALM_TEST_TEST_ALL_HPP

--- a/test/test_file.cpp
+++ b/test/test_file.cpp
@@ -373,4 +373,18 @@ TEST(File_Exists)
                    File::Exists, e.get_path() == std::string(path));
 }
 
+
+TEST(File_Move)
+{
+    TEST_PATH(path);
+    File file_1(path, File::mode_Write);
+    CHECK(file_1.is_attached());
+    File file_2(std::move(file_1));
+    CHECK_NOT(file_1.is_attached());
+    CHECK(file_2.is_attached());
+    file_1 = std::move(file_2);
+    CHECK(file_1.is_attached());
+    CHECK_NOT(file_2.is_attached());
+}
+
 #endif // TEST_FILE

--- a/test/test_file_locks.cpp
+++ b/test/test_file_locks.cpp
@@ -11,7 +11,6 @@
 #include <realm/util/features.h>
 
 #include "test.hpp"
-#include "util/thread_wrapper.hpp"
 
 using namespace realm::util;
 using namespace realm::test_util;

--- a/test/test_replication.cpp
+++ b/test/test_replication.cpp
@@ -2,10 +2,10 @@
 #ifdef TEST_REPLICATION
 
 #include <algorithm>
+#include <memory>
 
 #include <realm.hpp>
 #include <realm/util/features.h>
-#include <memory>
 #include <realm/util/file.hpp>
 #include <realm/replication.hpp>
 
@@ -189,10 +189,10 @@ TEST(Replication_General)
         wt.commit();
     }
 
-    std::unique_ptr<util::Logger> replay_logger;
-//    replay_logger.reset(new util::Logger);
+    util::Logger* replay_logger = nullptr;
+//    replay_logger = &test_context.thread_context.logger;
     SharedGroup sg_2(path_2);
-    repl.replay_transacts(sg_2, replay_logger.get());
+    repl.replay_transacts(sg_2, replay_logger);
 
     {
         ReadTransaction rt_1(sg_1);
@@ -253,8 +253,8 @@ TEST(Replication_Links)
     SHARED_GROUP_TEST_PATH(path_1);
     SHARED_GROUP_TEST_PATH(path_2);
 
-    std::unique_ptr<util::Logger> replay_logger;
-//    replay_logger.reset(new util::Logger);
+    util::Logger* replay_logger = nullptr;
+//    replay_logger = &test_context.thread_context.logger;
 
     MyTrivialReplication repl(path_1);
     SharedGroup sg_1(repl);
@@ -273,7 +273,7 @@ TEST(Replication_Links)
         target_2->add_empty_row(2);
         wt.commit();
     }
-    repl.replay_transacts(sg_2, replay_logger.get());
+    repl.replay_transacts(sg_2, replay_logger);
     {
         ReadTransaction rt(sg_2);
         check(test_context, sg_1, rt);
@@ -288,7 +288,7 @@ TEST(Replication_Links)
         origin_2->add_empty_row(2);
         wt.commit();
     }
-    repl.replay_transacts(sg_2, replay_logger.get());
+    repl.replay_transacts(sg_2, replay_logger);
     // O_1: LL_1->T_1
     // O_2: F_1
     {
@@ -305,7 +305,7 @@ TEST(Replication_Links)
         origin_2->set_link(0, 0, 1); // O_2_L_2[0] -> T_1[1]
         wt.commit();
     }
-    repl.replay_transacts(sg_2, replay_logger.get());
+    repl.replay_transacts(sg_2, replay_logger);
     // O_1: F_2   LL_1->T_1
     // O_2: L_2->T_1   F_1
     {
@@ -325,7 +325,7 @@ TEST(Replication_Links)
         origin_2->get_linklist(2, 1)->add(1); // O_2_LL_3[1] -> T_2[1]
         wt.commit();
     }
-    repl.replay_transacts(sg_2, replay_logger.get());
+    repl.replay_transacts(sg_2, replay_logger);
     // O_1: L_3->T_1   F_2   LL_1->T_1
     // O_2: L_2->T_1   F_1   LL_3->T_2
     {
@@ -343,7 +343,7 @@ TEST(Replication_Links)
         origin_2->set_link(3, 1, 0); // O_2_L_4[1] -> T_2[0]
         wt.commit();
     }
-    repl.replay_transacts(sg_2, replay_logger.get());
+    repl.replay_transacts(sg_2, replay_logger);
     // O_1: L_3->T_1   F_2   L_4->T_2   LL_1->T_1
     // O_2: L_2->T_1   F_1   LL_3->T_2   L_4->T_2
     {
@@ -360,7 +360,7 @@ TEST(Replication_Links)
         origin_2->insert_column(3, type_Int, "o_2_f_5");
         wt.commit();
     }
-    repl.replay_transacts(sg_2, replay_logger.get());
+    repl.replay_transacts(sg_2, replay_logger);
     // O_1: L_3->T_1   F_2   L_4->T_2   F_5   LL_1->T_1
     // O_2: L_2->T_1   F_1   LL_3->T_2   F_5   L_4->T_2
     {
@@ -377,7 +377,7 @@ TEST(Replication_Links)
         origin_1->get_linklist(4, 1)->add(0); // O_1_LL_1[1] -> T_1[0]
         wt.commit();
     }
-    repl.replay_transacts(sg_2, replay_logger.get());
+    repl.replay_transacts(sg_2, replay_logger);
     // O_1_L_3    O_1_L_4    O_1_LL_1               O_2_L_2    O_2_LL_3               O_2_L_4
     // ----------------------------------------------------------------------------------------
     // null       T_2[0]     []                     T_1[1]     [ T_2[1] ]             T_2[1]
@@ -456,7 +456,7 @@ TEST(Replication_Links)
         origin_1_w->set_int(1, 2, 13);
         wt.commit();
     }
-    repl.replay_transacts(sg_2, replay_logger.get());
+    repl.replay_transacts(sg_2, replay_logger);
     // O_1_L_3    O_1_L_4    O_1_LL_1               O_2_L_2    O_2_LL_3               O_2_L_4
     // ----------------------------------------------------------------------------------------
     // null       T_2[0]     []                     T_1[1]     [ T_2[1] ]             T_2[1]
@@ -513,7 +513,7 @@ TEST(Replication_Links)
         target_1_w->set_int(0, 2, 17);
         wt.commit();
     }
-    repl.replay_transacts(sg_2, replay_logger.get());
+    repl.replay_transacts(sg_2, replay_logger);
     // O_1_L_3    O_1_L_4    O_1_LL_1               O_2_L_2    O_2_LL_3               O_2_L_4
     // ----------------------------------------------------------------------------------------
     // null       T_2[0]     []                     T_1[1]     [ T_2[1] ]             T_2[1]
@@ -577,7 +577,7 @@ TEST(Replication_Links)
         origin_2_w->set_link(4, 2, 0);  // O_2_L_4[2] -> T_2[0]
         wt.commit();
     }
-    repl.replay_transacts(sg_2, replay_logger.get());
+    repl.replay_transacts(sg_2, replay_logger);
     // O_1_L_3    O_1_L_4    O_1_LL_1               O_2_L_2    O_2_LL_3               O_2_L_4
     // ----------------------------------------------------------------------------------------
     // null       T_2[0]     []                     T_1[1]     [ T_2[1] ]             T_2[1]
@@ -644,7 +644,7 @@ TEST(Replication_Links)
         // Adds    O_1_L_3[2] -> T_1[1]  and  O_2_L_4[2] -> T_2[1]
         wt.commit();
     }
-    repl.replay_transacts(sg_2, replay_logger.get());
+    repl.replay_transacts(sg_2, replay_logger);
     // O_1_L_3    O_1_L_4    O_1_LL_1               O_2_L_2    O_2_LL_3               O_2_L_4
     // ----------------------------------------------------------------------------------------
     // null       T_2[0]     []                     T_1[1]     [ T_2[1] ]             T_2[1]
@@ -709,7 +709,7 @@ TEST(Replication_Links)
         link_list_2_2_w->add(0); // O_2_LL_3[2] -> T_2[0]
         wt.commit();
     }
-    repl.replay_transacts(sg_2, replay_logger.get());
+    repl.replay_transacts(sg_2, replay_logger);
     // O_1_L_3    O_1_L_4    O_1_LL_1               O_2_L_2    O_2_LL_3               O_2_L_4
     // ----------------------------------------------------------------------------------------
     // null       T_2[0]     []                     T_1[1]     [ T_2[1] ]             T_2[1]
@@ -783,7 +783,7 @@ TEST(Replication_Links)
         link_list_2_2_w->add(1);    // Add     O_2_LL_3[2] -> T_2[1]
         wt.commit();
     }
-    repl.replay_transacts(sg_2, replay_logger.get());
+    repl.replay_transacts(sg_2, replay_logger);
     // O_1_L_3    O_1_L_4    O_1_LL_1               O_2_L_2    O_2_LL_3               O_2_L_4
     // ----------------------------------------------------------------------------------------
     // null       T_2[0]     []                     T_1[1]     [ T_2[1] ]             T_2[1]
@@ -857,7 +857,7 @@ TEST(Replication_Links)
         link_list_2_2_w->move(0,1); // [ 0, 1 ] -> [ 1, 0 ]
         wt.commit();
     }
-    repl.replay_transacts(sg_2, replay_logger.get());
+    repl.replay_transacts(sg_2, replay_logger);
     // O_1_L_3    O_1_L_4    O_1_LL_1               O_2_L_2    O_2_LL_3               O_2_L_4
     // ----------------------------------------------------------------------------------------
     // null       T_2[0]     []                     T_1[1]     [ T_2[1] ]             T_2[1]
@@ -926,7 +926,7 @@ TEST(Replication_Links)
         link_list_2_2_w->swap(0,1); // [ 1, 0 ] -> [ 0, 1 ]
         wt.commit();
     }
-    repl.replay_transacts(sg_2, replay_logger.get());
+    repl.replay_transacts(sg_2, replay_logger);
     // O_1_L_3    O_1_L_4    O_1_LL_1               O_2_L_2    O_2_LL_3               O_2_L_4
     // ----------------------------------------------------------------------------------------
     // null       T_2[0]     []                     T_1[1]     [ T_2[1] ]             T_2[1]
@@ -995,7 +995,7 @@ TEST(Replication_Links)
         link_list_2_2_w->swap(1,1); // [ 0, 1 ] -> [ 0, 1 ]
         wt.commit();
     }
-    repl.replay_transacts(sg_2, replay_logger.get());
+    repl.replay_transacts(sg_2, replay_logger);
     // O_1_L_3    O_1_L_4    O_1_LL_1               O_2_L_2    O_2_LL_3               O_2_L_4
     // ----------------------------------------------------------------------------------------
     // null       T_2[0]     []                     T_1[1]     [ T_2[1] ]             T_2[1]
@@ -1083,7 +1083,7 @@ TEST(Replication_Links)
         // Adds     O_1_L_3[0]  -> T_1[1]
         wt.commit();
     }
-    repl.replay_transacts(sg_2, replay_logger.get());
+    repl.replay_transacts(sg_2, replay_logger);
     // O_1_L_3    O_1_L_4    O_1_LL_1               O_2_L_2    O_2_LL_3               O_2_L_4
     // ----------------------------------------------------------------------------------------
     // T_1[1]     null       []                     T_1[1]     [ T_2[1] ]             T_2[1]
@@ -1150,7 +1150,7 @@ TEST(Replication_Links)
         // Adds     O_1_L_4[2]  -> T_2[0]  and  O_2_LL_3[0] -> T_2[0]  and  O_2_L_4[0] -> T_2[0]
         wt.commit();
     }
-    repl.replay_transacts(sg_2, replay_logger.get());
+    repl.replay_transacts(sg_2, replay_logger);
     // O_1_L_3    O_1_L_4    O_1_LL_1               O_2_L_2    O_2_LL_3               O_2_L_4
     // ----------------------------------------------------------------------------------------
     // T_1[1]     null       []                     null       [ T_2[0], T_2[1] ]     T_2[0]
@@ -1217,7 +1217,7 @@ TEST(Replication_Links)
         // Adds     O_1_L_4[1]  -> T_2[0]
         wt.commit();
     }
-    repl.replay_transacts(sg_2, replay_logger.get());
+    repl.replay_transacts(sg_2, replay_logger);
     // O_1_L_3    O_1_L_4    O_1_LL_1               O_2_L_2    O_2_LL_3               O_2_L_4
     // ----------------------------------------------------------------------------------------
     // T_1[1]     null       []
@@ -1276,7 +1276,7 @@ TEST(Replication_Links)
         origin_2_w->set_link(4,2,0);           // O_2_L_4[2]  -> T_2[0]
         wt.commit();
     }
-    repl.replay_transacts(sg_2, replay_logger.get());
+    repl.replay_transacts(sg_2, replay_logger);
     // O_1_L_3    O_1_L_4    O_1_LL_1               O_2_L_2    O_2_LL_3               O_2_L_4
     // ----------------------------------------------------------------------------------------
     // T_1[1]     null       []                     T_1[0]     [ T_2[1] ]             T_2[1]
@@ -1345,7 +1345,7 @@ TEST(Replication_Links)
         origin_1_w->get_linklist(4,2)->add(1); // O_1_LL_1[2] -> T_1[1]
         wt.commit();
     }
-    repl.replay_transacts(sg_2, replay_logger.get());
+    repl.replay_transacts(sg_2, replay_logger);
     // O_1_L_3    O_1_L_4    O_1_LL_1               O_2_L_2    O_2_LL_3               O_2_L_4
     // ----------------------------------------------------------------------------------------
     // T_1[1]     T_2[1]     []                     T_1[0]     [ T_2[1] ]             T_2[1]
@@ -1431,7 +1431,7 @@ TEST(Replication_Links)
         // Adds     O_1_LL_1[1] -> T_1[2]  and  O_2_LL_3[2] -> T_2[2]  and  O_2_L_4[0] -> T_2[2]
         wt.commit();
     }
-    repl.replay_transacts(sg_2, replay_logger.get());
+    repl.replay_transacts(sg_2, replay_logger);
     // O_1_L_3    O_1_L_4    O_1_LL_1               O_2_L_2    O_2_LL_3               O_2_L_4
     // ----------------------------------------------------------------------------------------
     // T_1[1]     T_2[1]     []                     T_1[0]     [ T_2[1] ]             T_2[2]
@@ -1514,7 +1514,7 @@ TEST(Replication_Links)
         //          O_2_L_2[0] -> T_1[0]  and  O_2_LL_3[2] -> T_2[2]  and  O_2_L_4[0] -> T_2[2]
         wt.commit();
     }
-    repl.replay_transacts(sg_2, replay_logger.get());
+    repl.replay_transacts(sg_2, replay_logger);
     // O_1_L_3    O_1_L_4    O_1_LL_1               O_2_L_2    O_2_LL_3               O_2_L_4
     // ----------------------------------------------------------------------------------------
     // T_1[1]     T_2[1]     []                     null       [ T_2[1] ]             null
@@ -1611,7 +1611,7 @@ TEST(Replication_Links)
         //          O_2_LL_3[2] -> T_2[0]
         wt.commit();
     }
-    repl.replay_transacts(sg_2, replay_logger.get());
+    repl.replay_transacts(sg_2, replay_logger);
     // O_1_L_3    O_1_L_4    O_1_LL_1               O_2_L_2    O_2_LL_3               O_2_L_4
     // ----------------------------------------------------------------------------------------
     // T_1[1]     T_2[0]     []                     T_1[2]     [ T_2[0] ]             null
@@ -1705,7 +1705,7 @@ TEST(Replication_Links)
         //          O_2_L_2[0]  -> T_1[1]
         wt.commit();
     }
-    repl.replay_transacts(sg_2, replay_logger.get());
+    repl.replay_transacts(sg_2, replay_logger);
     // O_1_L_3    O_1_L_4    O_1_LL_1               O_2_L_2    O_2_LL_3               O_2_L_4
     // ----------------------------------------------------------------------------------------
     // null       null       []                     T_1[1]     []                     null
@@ -1792,7 +1792,7 @@ TEST(Replication_Links)
         origin_2_w->set_link(4,1,1);           // O_2_L_4[1]  -> T_2[1]
         wt.commit();
     }
-    repl.replay_transacts(sg_2, replay_logger.get());
+    repl.replay_transacts(sg_2, replay_logger);
     // O_1_L_3    O_1_L_4    O_1_LL_1               O_2_L_2    O_2_LL_3               O_2_L_4
     // ----------------------------------------------------------------------------------------
     // null       T_2[1]     []                     null       [ T_2[1], T_2[1] ]     T_2[0]
@@ -1883,7 +1883,7 @@ TEST(Replication_Links)
         origin_2_w->set_link(0,2,1); // O_2_L_2[2] -> T_1[1]
         wt.commit();
     }
-    repl.replay_transacts(sg_2, replay_logger.get());
+    repl.replay_transacts(sg_2, replay_logger);
     // O_1_L_3    O_1_L_4    O_1_LL_1               O_2_L_2    O_2_LL_3               O_2_L_4
     // ----------------------------------------------------------------------------------------
     // T_1[1]     T_2[1]     [ T_1[1], T_1[0] ]     T_1[0]     [ T_2[1], T_2[1] ]     T_2[0]
@@ -1976,7 +1976,7 @@ TEST(Replication_Links)
         origin_2_w->clear();
         wt.commit();
     }
-    repl.replay_transacts(sg_2, replay_logger.get());
+    repl.replay_transacts(sg_2, replay_logger);
     // O_1_L_3    O_1_L_4    O_1_LL_1               O_2_L_2    O_2_LL_3               O_2_L_4
     // ----------------------------------------------------------------------------------------
     // T_1[1]     T_2[1]     [ T_1[1], T_1[0] ]
@@ -2042,7 +2042,7 @@ TEST(Replication_Links)
         origin_2_w->set_link(4,1,1);
         wt.commit();
     }
-    repl.replay_transacts(sg_2, replay_logger.get());
+    repl.replay_transacts(sg_2, replay_logger);
     // O_1_L_3    O_1_L_4    O_1_LL_1               O_2_L_2    O_2_LL_3               O_2_L_4
     // ----------------------------------------------------------------------------------------
     // T_1[1]     T_2[1]     [ T_1[1], T_1[0] ]     T_1[0]     [ T_2[1], T_2[1] ]     T_2[0]
@@ -2121,7 +2121,7 @@ TEST(Replication_Links)
         target_2_w->clear();
         wt.commit();
     }
-    repl.replay_transacts(sg_2, replay_logger.get());
+    repl.replay_transacts(sg_2, replay_logger);
     // O_1_L_3    O_1_L_4    O_1_LL_1               O_2_L_2    O_2_LL_3               O_2_L_4
     // ----------------------------------------------------------------------------------------
     // T_1[1]     null       [ T_1[1], T_1[0] ]     T_1[0]     []                     null
@@ -2197,7 +2197,7 @@ TEST(Replication_Links)
         origin_2_w->set_link(4,1,1);
         wt.commit();
     }
-    repl.replay_transacts(sg_2, replay_logger.get());
+    repl.replay_transacts(sg_2, replay_logger);
     // O_1_L_3    O_1_L_4    O_1_LL_1               O_2_L_2    O_2_LL_3               O_2_L_4
     // ----------------------------------------------------------------------------------------
     // T_1[1]     T_2[1]     [ T_1[1], T_1[0] ]     T_1[0]     [ T_2[1], T_2[1] ]     T_2[0]
@@ -2300,7 +2300,7 @@ TEST(Replication_Links)
         origin_2_w->insert_column(6, type_String, "foo_3");
         wt.commit();
     }
-    repl.replay_transacts(sg_2, replay_logger.get());
+    repl.replay_transacts(sg_2, replay_logger);
     {
         ReadTransaction rt(sg_2);
         check(test_context, sg_1, rt);
@@ -2389,7 +2389,7 @@ TEST(Replication_Links)
         origin_2_w->remove_column(0);
         wt.commit();
     }
-    repl.replay_transacts(sg_2, replay_logger.get());
+    repl.replay_transacts(sg_2, replay_logger);
     {
         ReadTransaction rt(sg_2);
         check(test_context, sg_1, rt);
@@ -2477,7 +2477,7 @@ TEST(Replication_Links)
         origin_2_w->remove_column(5);
         wt.commit();
     }
-    repl.replay_transacts(sg_2, replay_logger.get());
+    repl.replay_transacts(sg_2, replay_logger);
     {
         ReadTransaction rt(sg_2);
         check(test_context, sg_1, rt);
@@ -2569,7 +2569,7 @@ TEST(Replication_Links)
         origin_2_w->set_link(0,1,0);
         wt.commit();
     }
-    repl.replay_transacts(sg_2, replay_logger.get());
+    repl.replay_transacts(sg_2, replay_logger);
     {
         ReadTransaction rt(sg_2);
         check(test_context, sg_1, rt);
@@ -2689,7 +2689,7 @@ TEST(Replication_Links)
         origin_2_w->get_linklist(5,2)->add(0);
         wt.commit();
     }
-    repl.replay_transacts(sg_2, replay_logger.get());
+    repl.replay_transacts(sg_2, replay_logger);
     {
         ReadTransaction rt(sg_2);
         check(test_context, sg_1, rt);
@@ -2813,7 +2813,7 @@ TEST(Replication_Links)
         origin_2_w->remove_column(5);
         wt.commit();
     }
-    repl.replay_transacts(sg_2, replay_logger.get());
+    repl.replay_transacts(sg_2, replay_logger);
     {
         ReadTransaction rt(sg_2);
         check(test_context, sg_1, rt);
@@ -2901,7 +2901,7 @@ TEST(Replication_Links)
         target_2_w->insert_column_link(1, type_Link, "t_4", *target_1_w);
         wt.commit();
     }
-    repl.replay_transacts(sg_2, replay_logger.get());
+    repl.replay_transacts(sg_2, replay_logger);
     {
         ReadTransaction rt(sg_2);
         check(test_context, sg_1, rt);
@@ -2945,7 +2945,7 @@ TEST(Replication_Links)
         target_2_w->remove_column(0);
         wt.commit();
     }
-    repl.replay_transacts(sg_2, replay_logger.get());
+    repl.replay_transacts(sg_2, replay_logger);
     {
         ReadTransaction rt(sg_2);
         check(test_context, sg_1, rt);
@@ -2989,7 +2989,7 @@ TEST(Replication_Links)
         target_1_w->remove_column(0);
         wt.commit();
     }
-    repl.replay_transacts(sg_2, replay_logger.get());
+    repl.replay_transacts(sg_2, replay_logger);
     {
         ReadTransaction rt(sg_2);
         check(test_context, sg_1, rt);
@@ -3056,8 +3056,8 @@ TEST(Replication_CascadeRemove_ColumnLink)
     SHARED_GROUP_TEST_PATH(path_1);
     SHARED_GROUP_TEST_PATH(path_2);
 
-    std::unique_ptr<util::Logger> replay_logger;
-//    replay_logger.reset(new util::Logger);
+    util::Logger* replay_logger = nullptr;
+//    replay_logger = &test_context.thread_context.logger;
 
     SharedGroup sg(path_1);
     MyTrivialReplication repl(path_2);
@@ -3105,7 +3105,7 @@ TEST(Replication_CascadeRemove_ColumnLink)
 
         // Apply the changes to sg via replication
         sg.end_read();
-        repl.replay_transacts(sg, replay_logger.get());
+        repl.replay_transacts(sg, replay_logger);
         const Group& group = sg.begin_read();
         group.verify();
 
@@ -3161,8 +3161,8 @@ TEST(LangBindHelper_AdvanceReadTransact_CascadeRemove_ColumnLinkList)
     SHARED_GROUP_TEST_PATH(path_1);
     SHARED_GROUP_TEST_PATH(path_2);
 
-    std::unique_ptr<util::Logger> replay_logger;
-//    replay_logger.reset(new util::Logger);
+    util::Logger* replay_logger = nullptr;
+//    replay_logger = &test_context.thread_context.logger;
 
     SharedGroup sg(path_1);
     MyTrivialReplication repl(path_2);
@@ -3211,7 +3211,7 @@ TEST(LangBindHelper_AdvanceReadTransact_CascadeRemove_ColumnLinkList)
 
         // Apply the changes to sg via replication
         sg.end_read();
-        repl.replay_transacts(sg, replay_logger.get());
+        repl.replay_transacts(sg, replay_logger);
         const Group& group = sg.begin_read();
         group.verify();
 
@@ -3274,8 +3274,8 @@ TEST(Replication_NullStrings)
     SHARED_GROUP_TEST_PATH(path_1);
     SHARED_GROUP_TEST_PATH(path_2);
 
-    std::unique_ptr<util::Logger> replay_logger;
-//    replay_logger.reset(new util::Logger);
+    util::Logger* replay_logger = nullptr;
+//    replay_logger = &test_context.thread_context.logger;
 
     MyTrivialReplication repl(path_1);
     SharedGroup sg_1(repl);
@@ -3304,7 +3304,7 @@ TEST(Replication_NullStrings)
 
         wt.commit();
     }
-    repl.replay_transacts(sg_2, replay_logger.get());
+    repl.replay_transacts(sg_2, replay_logger);
     {
         ReadTransaction rt(sg_2);
         ConstTableRef table2 = rt.get_table("table");
@@ -3324,8 +3324,8 @@ TEST(Replication_NullInteger)
     SHARED_GROUP_TEST_PATH(path_1);
     SHARED_GROUP_TEST_PATH(path_2);
 
-    std::unique_ptr<util::Logger> replay_logger;
-//    replay_logger.reset(new util::Logger);
+    util::Logger* replay_logger = nullptr;
+//    replay_logger = &test_context.thread_context.logger;
 
     MyTrivialReplication repl(path_1);
     SharedGroup sg_1(repl);
@@ -3346,7 +3346,7 @@ TEST(Replication_NullInteger)
 
         wt.commit();
     }
-    repl.replay_transacts(sg_2, replay_logger.get());
+    repl.replay_transacts(sg_2, replay_logger);
     {
         ReadTransaction rt(sg_2);
         ConstTableRef table2 = rt.get_table("table");
@@ -3363,7 +3363,8 @@ TEST(Replication_SetUnique)
     SHARED_GROUP_TEST_PATH(path_1);
     SHARED_GROUP_TEST_PATH(path_2);
 
-    std::unique_ptr<util::Logger> replay_logger;
+    util::Logger* replay_logger = nullptr;
+//    replay_logger = &test_context.thread_context.logger;
 
     MyTrivialReplication repl(path_1);
     SharedGroup sg_1(repl);
@@ -3387,7 +3388,7 @@ TEST(Replication_SetUnique)
         table1->set_string_unique(3, 0, "Hello, World!");
         wt.commit();
     }
-    repl.replay_transacts(sg_2, replay_logger.get());
+    repl.replay_transacts(sg_2, replay_logger);
     {
         ReadTransaction rt(sg_2);
         ConstTableRef table2 = rt.get_table("table");
@@ -3405,7 +3406,8 @@ TEST(Replication_RenameGroupLevelTable_MoveGroupLevelTable_RenameColumn_MoveColu
     SHARED_GROUP_TEST_PATH(path_1);
     SHARED_GROUP_TEST_PATH(path_2);
 
-    std::unique_ptr<util::Logger> replay_logger;
+    util::Logger* replay_logger = nullptr;
+//    replay_logger = &test_context.thread_context.logger;
 
     MyTrivialReplication repl(path_1);
     SharedGroup sg_1(repl);
@@ -3428,7 +3430,7 @@ TEST(Replication_RenameGroupLevelTable_MoveGroupLevelTable_RenameColumn_MoveColu
         wt.get_group().move_table(1, 0);
         wt.commit();
     }
-    repl.replay_transacts(sg_2, replay_logger.get());
+    repl.replay_transacts(sg_2, replay_logger);
     {
         ReadTransaction rt(sg_2);
         ConstTableRef foo = rt.get_table("foo");
@@ -3449,7 +3451,9 @@ TEST(Replication_ChangeLinkTargets)
     SHARED_GROUP_TEST_PATH(path_1);
     SHARED_GROUP_TEST_PATH(path_2);
 
-    std::unique_ptr<util::Logger> replay_logger;
+    util::Logger* replay_logger = nullptr;
+//    replay_logger = &test_context.thread_context.logger;
+
     MyTrivialReplication repl(path_1);
     SharedGroup sg_1(repl);
     SharedGroup sg_2(path_2);
@@ -3466,7 +3470,7 @@ TEST(Replication_ChangeLinkTargets)
         t0->change_link_targets(0, 1);
         wt.commit();
     }
-    repl.replay_transacts(sg_2, replay_logger.get());
+    repl.replay_transacts(sg_2, replay_logger);
     {
         ReadTransaction rt1(sg_1);
         ReadTransaction rt2(sg_2);
@@ -3487,7 +3491,8 @@ TEST(Replication_Substrings)
     SHARED_GROUP_TEST_PATH(path_1);
     SHARED_GROUP_TEST_PATH(path_2);
 
-    std::unique_ptr<util::Logger> replay_logger;
+    util::Logger* replay_logger = nullptr;
+//    replay_logger = &test_context.thread_context.logger;
 
     MyTrivialReplication repl(path_1);
     SharedGroup sg_1(repl);
@@ -3508,7 +3513,7 @@ TEST(Replication_Substrings)
         table->insert_substring(0, 0, 0, "Goodbye, Cruel");
         wt.commit();
     }
-    repl.replay_transacts(sg_2, replay_logger.get());
+    repl.replay_transacts(sg_2, replay_logger);
     {
         ReadTransaction rt(sg_2);
         auto table = rt.get_table("table");
@@ -3528,8 +3533,8 @@ TEST(Replication_MoveSelectedLinkView)
     SHARED_GROUP_TEST_PATH(path_1);
     SHARED_GROUP_TEST_PATH(path_2);
 
-    std::unique_ptr<util::Logger> replay_logger;
-//    replay_logger.reset(new util::Logger);
+    util::Logger* replay_logger = nullptr;
+//    replay_logger = &test_context.thread_context.logger;
 
     MyTrivialReplication repl(path_1);
     SharedGroup sg_1(repl);
@@ -3545,7 +3550,7 @@ TEST(Replication_MoveSelectedLinkView)
         target->add_empty_row(2);
         wt.commit();
     }
-    repl.replay_transacts(sg_2, replay_logger.get());
+    repl.replay_transacts(sg_2, replay_logger);
     {
         ReadTransaction rt(sg_2);
         rt.get_group().verify();
@@ -3560,7 +3565,7 @@ TEST(Replication_MoveSelectedLinkView)
         link_list->add(1); // Now modify it again
         wt.commit();
     }
-    repl.replay_transacts(sg_2, replay_logger.get());
+    repl.replay_transacts(sg_2, replay_logger);
     {
         ReadTransaction rt(sg_2);
         rt.get_group().verify();

--- a/test/test_self.cpp
+++ b/test/test_self.cpp
@@ -493,7 +493,7 @@ struct SummaryRecorder: Reporter {
         m_summary(summary)
     {
     }
-    void summary(const ExecContext&, const Summary& summary) override
+    void summary(const SharedContext&, const Summary& summary) override
     {
         m_summary = summary;
     }

--- a/test/test_shared.cpp
+++ b/test/test_shared.cpp
@@ -25,8 +25,6 @@
 #include <realm/util/thread.hpp>
 #include <realm/impl/simulated_failure.hpp>
 
-#include "util/thread_wrapper.hpp"
-
 #include "test.hpp"
 
 using namespace realm;

--- a/test/test_transactions.cpp
+++ b/test/test_transactions.cpp
@@ -12,8 +12,6 @@
 #include <realm/group_shared.hpp>
 #include <realm/table_macros.hpp>
 
-#include "util/thread_wrapper.hpp"
-
 #include "test.hpp"
 
 using namespace realm;

--- a/test/test_transactions_lasse.cpp
+++ b/test/test_transactions_lasse.cpp
@@ -18,8 +18,6 @@
 #include <realm/utilities.hpp>
 #include <realm/util/file.hpp>
 
-#include "util/thread_wrapper.hpp"
-
 #include "test.hpp"
 
 using namespace realm;

--- a/test/test_util_event_loop.cpp
+++ b/test/test_util_event_loop.cpp
@@ -1,5 +1,4 @@
 #include "test.hpp"
-#include "../test/util/thread_wrapper.hpp"
 
 #include <realm/util/memory_stream.hpp>
 #include <realm/util/event_loop.hpp>

--- a/test/test_util_logger.cpp
+++ b/test/test_util_logger.cpp
@@ -1,0 +1,190 @@
+#include <memory>
+#include <vector>
+#include <locale>
+
+#include <realm/util/logger.hpp>
+
+#include "test.hpp"
+
+using namespace realm;
+
+// Test independence and thread-safety
+// -----------------------------------
+//
+// All tests must be thread safe and independent of each other. This
+// is required because it allows for both shuffling of the execution
+// order and for parallelized testing.
+//
+// In particular, avoid using std::rand() since it is not guaranteed
+// to be thread safe. Instead use the API offered in
+// `test/util/random.hpp`.
+//
+// All files created in tests must use the TEST_PATH macro (or one of
+// its friends) to obtain a suitable file system path. See
+// `test/util/test_path.hpp`.
+//
+//
+// Debugging and the ONLY() macro
+// ------------------------------
+//
+// A simple way of disabling all tests except one called `Foo`, is to
+// replace TEST(Foo) with ONLY(Foo) and then recompile and rerun the
+// test suite. Note that you can also use filtering by setting the
+// environment varible `UNITTEST_FILTER`. See `README.md` for more on
+// this.
+//
+// Another way to debug a particular test, is to copy that test into
+// `experiments/testcase.cpp` and then run `sh build.sh
+// check-testcase` (or one of its friends) from the command line.
+
+namespace {
+
+TEST(Util_Logger_Stream)
+{
+    std::ostringstream out_1;
+    std::ostringstream out_2;
+    out_2.imbue(std::locale::classic());
+    {
+        util::StreamLogger logger(out_1);
+        for (int i = 0; i < 10; ++i) {
+            std::ostringstream formatter;
+            formatter << "Foo "<<i;
+            logger.log(formatter.str().c_str());
+            out_2 << "Foo "<<i<<"\n";
+        }
+    }
+    CHECK(out_1.str() == out_2.str());
+}
+
+
+TEST(Util_Logger_Formatting)
+{
+    std::ostringstream out_1;
+    std::ostringstream out_2;
+    out_2.imbue(std::locale::classic());
+    {
+        util::StreamLogger logger(out_1);
+        logger.log("Foo %1", 1);
+        out_2 << "Foo 1\n";
+        logger.log("Foo %1 bar %2", "x", 2);
+        out_2 << "Foo x bar 2\n";
+        logger.log("Foo %2 bar %1", 3, "y");
+        out_2 << "Foo y bar 3\n";
+        logger.log("%3 foo %1 bar %2", 4.1, 4, "z");
+        out_2 << "z foo 4.1 bar 4\n";
+        logger.log("Foo %1");
+        out_2 << "Foo %1\n";
+        logger.log("Foo %1 bar %2", "x");
+        out_2 << "Foo x bar %2\n";
+        logger.log("Foo %2 bar %1", "x");
+        out_2 << "Foo %2 bar x\n";
+    }
+    CHECK(out_1.str() == out_2.str());
+}
+
+
+TEST(Util_Logger_File_1)
+{
+    TEST_PATH(path);
+
+    std::ostringstream out;
+    out.imbue(std::locale::classic());
+    {
+        util::FileLogger logger(path);
+        for (int i = 0; i < 10; ++i) {
+            logger.log("Foo %1", i);
+            out << "Foo "<<i<<"\n";
+        }
+    }
+    std::string str = out.str();
+    size_t size = str.size();
+    std::unique_ptr<char[]> buffer(new char[size]);
+    util::File file(path);
+    if (CHECK_EQUAL(size, file.get_size())) {
+        file.read(buffer.get(), size);
+        CHECK(str == std::string(buffer.get(), size));
+    }
+}
+
+
+TEST(Util_Logger_File_2)
+{
+    TEST_PATH(path);
+
+    std::ostringstream out;
+    out.imbue(std::locale::classic());
+    {
+        util::FileLogger logger(util::File(path, util::File::mode_Write));
+        for (int i = 0; i < 10; ++i) {
+            logger.log("Foo %1", i);
+            out << "Foo "<<i<<"\n";
+        }
+    }
+    std::string str = out.str();
+    size_t size = str.size();
+    std::unique_ptr<char[]> buffer(new char[size]);
+    util::File file(path);
+    if (CHECK_EQUAL(size, file.get_size())) {
+        file.read(buffer.get(), size);
+        CHECK(str == std::string(buffer.get(), size));
+    }
+}
+
+
+TEST(Util_Logger_Prefix)
+{
+    std::ostringstream out_1;
+    std::ostringstream out_2;
+    {
+        util::StreamLogger base_logger(out_1);
+        util::PrefixLogger logger("Prefix: ", base_logger);
+        logger.log("Foo");
+        out_2 << "Prefix: Foo\n";
+        logger.log("Bar");
+        out_2 << "Prefix: Bar\n";
+    }
+    CHECK(out_1.str() == out_2.str());
+}
+
+
+TEST(Util_Logger_ThreadSafe)
+{
+    struct BaseLogger: public util::Logger {
+        std::vector<std::string> messages;
+        void do_log(std::string message) override
+        {
+            messages.push_back(std::move(message));
+        }
+    };
+    BaseLogger base_logger;
+    util::ThreadSafeLogger logger(base_logger);
+
+    const long num_iterations = 10000;
+    auto func = [&](int i) {
+        for (long j = 0; j < num_iterations; ++j)
+            logger.log("%1:%2", i, j);
+    };
+
+    const int num_threads = 8;
+    std::unique_ptr<test_util::ThreadWrapper[]> threads(new test_util::ThreadWrapper[num_threads]);
+    for (int i = 0; i < num_threads; ++i)
+        threads[i].start([&func, i] { func(i); });
+    for (int i = 0; i < num_threads; ++i)
+        CHECK_NOT(threads[i].join());
+
+    std::vector<std::string> messages_1(std::move(base_logger.messages)), messages_2;
+    for (int i = 0; i < num_threads; ++i) {
+        for (long j = 0; j < num_iterations; ++j) {
+            std::ostringstream out;
+            out.imbue(std::locale::classic());
+            out << i<<":"<<j;
+            messages_2.push_back(out.str());
+        }
+    }
+
+    std::sort(messages_1.begin(), messages_1.end());
+    std::sort(messages_2.begin(), messages_2.end());
+    CHECK(messages_1 == messages_2);
+}
+
+} // unnamed namespace

--- a/test/test_util_network.cpp
+++ b/test/test_util_network.cpp
@@ -10,7 +10,6 @@
 #include <realm/util/network.hpp>
 
 #include "test.hpp"
-#include "../test/util/thread_wrapper.hpp"
 
 using namespace realm::util;
 using namespace realm::test_util;

--- a/test/util/test_path.cpp
+++ b/test/util/test_path.cpp
@@ -44,7 +44,8 @@ std::string get_test_path(const TestContext& context, const std::string& suffix)
     int recurrence_index = context.recurrence_index;
     std::ostringstream out;
     out.imbue(std::locale::classic());
-    out << path_prefix << sanitize_for_file_name(test_name) << '.' << recurrence_index << suffix;
+    out << path_prefix << sanitize_for_file_name(test_name) << '.' << (recurrence_index+1) <<
+        suffix;
     return out.str();
 }
 

--- a/test/util/test_path.hpp
+++ b/test/util/test_path.hpp
@@ -69,7 +69,7 @@ std::string get_test_path(const unit_test::TestContext&, const std::string& suff
 void set_test_path_prefix(const std::string&);
 
 
-/// This function is thread-safe as long as tehre are no concurrent invocations
+/// This function is thread-safe as long as there are no concurrent invocations
 /// of set_test_resource_path().
 std::string get_test_resource_path();
 


### PR DESCRIPTION
New features in unit test framework (prompted by my search for the bug fixed in https://github.com/realm/realm-sync/pull/236):
1. Option for logging to files (one per test thread) (`UNITTEST_LOG_TO_FILES=1`).
2. Option for aborting of first check failure, or unexpected exception thrown in test (`UNITTEST_ABORT_ON_FAILURE=1`).
3. New logging features available in tests (`util::Logger`).

The advantage of logging to files, is that one can run with multiple test threads, and still not get mixed output from concurrently running tests.

The most important advantages of aborting of first check failure, is probably that it allows you to easily get a stacktrace in GDB at the point of failure. Another advantage is that it avoids the error messages to get burried when running with progress reporting, and a large number of tests (and/or repetitions).

Since `test_util::unit_test::TestBase` now inherits from `util::Logger`, one can now use the log methods offered by `util::Logger` directly from within the unit tests. This is advantageous compared to simply writing to `std::cerr`, since the logged messages will be qualified (prefixed) with thread information, or redirected to a log file (`UNITTEST_LOG_TO_FILES=1`).

Additionally, the thread-specific logger (prefixed with thread information, or redirected to log file) is available as `test_context.thread_context.logger`, which is relevant to tests that pass a logger or `test_context` to external helper functions. Likewise, `test_context.thread_context.shared_context.logger` is available, and refers to the logger shared by all threads. All these loggers are thread-safe and prevents garbling/mixing of concurrently written messages. See for example https://github.com/realm/realm-core/blob/ks/test-suite-log-to-file-per-thread/test/test_replication.cpp#L192.

@simonask @finnschiermer
