### PR TITLE
Bug fixes in POSIX networking API

### DIFF
--- a/release_notes.md
+++ b/release_notes.md
@@ -2,6 +2,10 @@
 
 ### Bugfixes:
 
+* Bug fix: Misbehavior of empty asynchronous write in POSIX networking API.
+* Bug fix: Access dangling pointer while handling canceled asynchronous accept
+  in POSIX networking API.
+
 ### API breaking changes:
 
 * Lorem ipsum.
@@ -27,6 +31,7 @@
   each test thread) (`UNITTEST_LOG_TO_FILES`), and an option to abort on first
   failed check (`UNITTEST_ABORT_ON_FAILURE`). Additionally, logging
   (`util::Logger`) is now directly available to each unit test.
+* New unit tests: `Network_CancelEmptyWrite`, `Network_ThrowFromHandlers`.
 
 ----------------------------------------------
 

--- a/test/test_util_network.cpp
+++ b/test/test_util_network.cpp
@@ -428,20 +428,9 @@ TEST(Network_CancelEmptyRead)
     // cancelable
 
     network::io_service service;
-    network::acceptor acceptor(service);
-    acceptor.open(network::protocol::ip_v4());
-    acceptor.listen();
-    network::socket socket_1(service);
-    bool was_accepted = false;
-    auto accept_handler = [&](std::error_code ec) {
-        if (!ec)
-            was_accepted = true;
-    };
-    acceptor.async_accept(socket_1, accept_handler);
-    network::socket socket_2(service);
-    socket_2.connect(acceptor.local_endpoint());
-    service.run();
-    CHECK(was_accepted);
+    network::socket socket_1(service), socket_2(service);
+    connect_sockets(socket_1, socket_2);
+    network::buffered_input_stream stream(socket_2);
     const size_t size = 1;
     char data[size] = { 'a' };
     bool write_was_canceled = false;
@@ -450,14 +439,44 @@ TEST(Network_CancelEmptyRead)
             write_was_canceled = true;
     };
     socket_2.async_write(data, size, write_handler);
-    network::buffered_input_stream input(socket_2);
     char buffer[size];
     bool read_was_canceled = false;
     auto read_handler = [&](std::error_code ec, size_t) {
         if (ec == error::operation_aborted)
             read_was_canceled = true;
     };
-    input.async_read(buffer, 0, read_handler);
+    stream.async_read(buffer, 0, read_handler);
+    socket_2.close();
+    service.run();
+    CHECK(read_was_canceled);
+    CHECK(write_was_canceled);
+}
+
+
+TEST(Network_CancelEmptyWrite)
+{
+    // Make sure that an immediately completable write operation is still
+    // cancelable
+
+    network::io_service service;
+    network::socket socket_1(service), socket_2(service);
+    connect_sockets(socket_1, socket_2);
+    network::buffered_input_stream stream(socket_2);
+    const size_t size = 1;
+    char buffer[size];
+    bool read_was_canceled = false;
+    auto read_handler = [&](std::error_code ec, size_t) {
+        if (ec == error::operation_aborted)
+            read_was_canceled = true;
+    };
+    stream.async_read(buffer, 1, read_handler);
+    char data[size] = { 'a' };
+    bool write_was_canceled = false;
+    auto write_handler = [&](std::error_code ec, size_t) {
+        if (ec == error::operation_aborted)
+            write_was_canceled = true;
+    };
+    socket_2.async_write(data, 0, write_handler);
     socket_2.close();
     service.run();
     CHECK(read_was_canceled);
@@ -669,6 +688,68 @@ TEST(Network_DeadlineTimer_Special)
     service.run();
 }
 */
+
+
+TEST(Network_ThrowFromHandlers)
+{
+    // Check that exceptions can propagate correctly out from any type of
+    // completion handler
+    network::io_service service;
+    struct TestException1 {};
+    service.post([] { throw TestException1(); });
+    CHECK_THROW(service.run(), TestException1);
+
+    {
+        network::acceptor acceptor(service);
+        network::endpoint ep = bind_acceptor(acceptor);
+        acceptor.listen();
+        network::socket socket_1(service);
+        struct TestException2 {};
+        acceptor.async_accept(socket_1, [](std::error_code) { throw TestException2(); });
+        network::socket socket_2(service);
+        socket_2.async_connect(ep, [](std::error_code) {});
+        CHECK_THROW(service.run(), TestException2);
+    }
+    {
+        network::acceptor acceptor(service);
+        network::endpoint ep = bind_acceptor(acceptor);
+        acceptor.listen();
+        network::socket socket_1(service);
+        acceptor.async_accept(socket_1, [](std::error_code) {});
+        network::socket socket_2(service);
+        struct TestException3 {};
+        socket_2.async_connect(ep, [](std::error_code) { throw TestException3(); });
+        CHECK_THROW(service.run(), TestException3);
+    }
+    {
+        network::socket socket_1(service), socket_2(service);
+        connect_sockets(socket_1, socket_2);
+        network::buffered_input_stream stream(socket_1);
+        char ch_1;
+        struct TestException4 {};
+        stream.async_read(&ch_1, 1, [](std::error_code, size_t) { throw TestException4(); });
+        char ch_2 = 0;
+        socket_2.async_write(&ch_2, 1, [](std::error_code, size_t) {});
+        CHECK_THROW(service.run(), TestException4);
+    }
+    {
+        network::socket socket_1(service), socket_2(service);
+        connect_sockets(socket_1, socket_2);
+        network::buffered_input_stream stream(socket_1);
+        char ch_1;
+        stream.async_read(&ch_1, 1, [](std::error_code, size_t) {});
+        char ch_2 = 0;
+        struct TestException5 {};
+        socket_2.async_write(&ch_2, 1, [](std::error_code, size_t) { throw TestException5(); });
+        CHECK_THROW(service.run(), TestException5);
+    }
+    {
+        network::deadline_timer timer(service);
+        struct TestException6 {};
+        timer.async_wait(std::chrono::seconds(0), [](std::error_code) { throw TestException6(); });
+        CHECK_THROW(service.run(), TestException6);
+    }
+}
 
 
 TEST(Network_HandlerDealloc)


### PR DESCRIPTION
- Bug fix: Misbehavior of empty asynchronous write in POSIX networking API.
  - Bug fix: Access dangling pointer while handling canceled asynchronous accept in POSIX networking API.
  - New unit tests: `Network_CancelEmptyWrite`, `Network_ThrowFromHandlers`.

@simonask
