### PR TITLE
Add support for querying over backlinks

### DIFF
--- a/src/realm/query_expression.hpp
+++ b/src/realm/query_expression.hpp
@@ -1401,21 +1401,30 @@ public:
         m_base_table = table;
         m_link_columns.clear();
         m_link_types.clear();
+        m_only_unary_links = true;
 
         for (size_t link_column_index : m_link_column_indexes) {
             // Link column can be either LinkList or single Link
             ColumnType type = table->get_real_column_type(link_column_index);
+            REALM_ASSERT(Table::is_link_type(type) || type == col_type_BackLink);
+            m_link_types.push_back(type);
+
             if (type == col_type_LinkList) {
                 const LinkListColumn& cll = table->get_column_link_list(link_column_index);
                 m_link_columns.push_back(&cll);
-                m_link_types.push_back(realm::type_LinkList);
+                m_only_unary_links = false;
                 table = &cll.get_target_table();
             }
-            else {
+            else if (type == col_type_Link) {
                 const LinkColumn& cl = table->get_column_link(link_column_index);
                 m_link_columns.push_back(&cl);
-                m_link_types.push_back(realm::type_Link);
                 table = &cl.get_target_table();
+            }
+            else if (type == col_type_BackLink) {
+                const BacklinkColumn& bl = table->get_column_backlink(link_column_index);
+                m_link_columns.push_back(&bl);
+                m_only_unary_links = false;
+                table = &bl.get_origin_table();
             }
         }
 
@@ -1443,7 +1452,7 @@ public:
 
     bool only_unary_links() const
     {
-        return std::find(m_link_types.begin(), m_link_types.end(), type_LinkList) == m_link_types.end();
+        return m_only_unary_links;
     }
 
     const Table* base_table() const
@@ -1456,13 +1465,14 @@ public:
         return m_target_table;
     }
 
-    std::vector<const LinkColumnBase*> m_link_columns;
+    std::vector<const ColumnBase*> m_link_columns;
 
 private:
     void map_links(size_t column, size_t row, LinkMapFunction& lm)
     {
         bool last = (column + 1 == m_link_columns.size());
-        if (m_link_types[column] == type_Link) {
+        ColumnType type = m_link_types[column];
+        if (type == col_type_Link) {
             const LinkColumn& cl = *static_cast<const LinkColumn*>(m_link_columns[column]);
             size_t r = to_size_t(cl.get(row));
             if (r == 0)
@@ -1476,7 +1486,7 @@ private:
             else
                 map_links(column + 1, r, lm);
         }
-        else {
+        else if (type == col_type_LinkList) {
             const LinkListColumn& cll = *static_cast<const LinkListColumn*>(m_link_columns[column]);
             ConstLinkViewRef lvr = cll.get(row);
             for (size_t t = 0; t < lvr->size(); t++) {
@@ -1490,6 +1500,19 @@ private:
                     map_links(column + 1, r, lm);
             }
         }
+        else if (type == col_type_BackLink) {
+            const BacklinkColumn& bl = *static_cast<const BacklinkColumn*>(m_link_columns[column]);
+            size_t count = bl.get_backlink_count(row);
+            for (size_t i = 0; i < count; ++i) {
+                size_t r = bl.get_backlink(row, i);
+                if (last) {
+                    bool continue2 = lm.consume(r);
+                    if (!continue2)
+                        return;
+                } else
+                    map_links(column + 1, r, lm);
+            }
+        }
     }
 
 
@@ -1500,9 +1523,10 @@ private:
     }
 
     std::vector<size_t> m_link_column_indexes;
-    std::vector<realm::DataType> m_link_types;
+    std::vector<ColumnType> m_link_types;
     const Table* m_base_table = nullptr;
     const Table* m_target_table = nullptr;
+    bool m_only_unary_links = true;
 };
 
 template<class T, class S, class I>
@@ -1818,7 +1842,7 @@ private:
 template<typename T>
 class SubColumns;
 
-// This is for LinkList too because we have 'typedef List LinkList'
+// This is for LinkList and BackLink too since they're declared as typedefs of Link.
 template <> class Columns<Link> : public Subexpr2<Link>
 {
 public:

--- a/src/realm/table.cpp
+++ b/src/realm/table.cpp
@@ -3744,7 +3744,7 @@ const Table* Table::get_link_chain_target(const std::vector<size_t>& link_chain)
 {
     const Table* table = this;
     for (size_t t = 0; t < link_chain.size(); t++) {
-        // Link column can be either LinkList or single Link
+        // Link column can be a single Link, LinkList, or BackLink.
         ColumnType type = table->get_real_column_type(link_chain[t]);
         if (type == col_type_LinkList) {
             const LinkListColumn& cll = table->get_column_link_list(link_chain[t]);
@@ -3753,6 +3753,10 @@ const Table* Table::get_link_chain_target(const std::vector<size_t>& link_chain)
         else if (type == col_type_Link) {
             const LinkColumn& cl = table->get_column_link(link_chain[t]);
             table = &cl.get_target_table();
+        }
+        else if (type == col_type_BackLink) {
+            const BacklinkColumn& bl = table->get_column_backlink(link_chain[t]);
+            table = &bl.get_origin_table();
         }
         else {
             // Only last column in link chain is allowed to be non-link

--- a/test/test_link_query_view.cpp
+++ b/test/test_link_query_view.cpp
@@ -8,6 +8,7 @@
 
 #include <realm/table_macros.hpp>
 #include <realm/link_view.hpp> // lasse todo remove
+#include <realm/util/to_string.hpp>
 #include <realm.hpp>
 
 #include "util/misc.hpp"
@@ -1581,4 +1582,217 @@ TEST(LinkList_QueryDateTime)
 
     CHECK_EQUAL(1, tv.size());
 }
+
+// void CHECK_TABLE_VIEW(const TableView&, std::initializer_list<size_t>);
+#define CHECK_TABLE_VIEW(_tv, ...) \
+    do { \
+        TableView tv(_tv); \
+        std::vector<size_t> expected __VA_ARGS__; \
+        CHECK_EQUAL(tv.size(), expected.size()); \
+        if (tv.size() == expected.size()) { \
+            for (size_t i = 0; i < expected.size(); ++i) { \
+                test_context.check_equal(tv.get_source_ndx(i), expected[i], __FILE__, __LINE__, \
+                                         ("tv.get_source_ndx(" + util::to_string(i) + ")").c_str(), \
+                                         ("expected[" + util::to_string(i) + "]").c_str()); \
+            } \
+        } \
+    } while (false)
+
+// Test queries involving the backlinks of a link column.
+TEST(BackLink_Query_Link)
+{
+    Group group;
+
+    TableRef source = group.add_table("source");
+    TableRef target = group.add_table("target");
+
+    size_t col_id = target->add_column(type_Int, "id");
+
+    target->add_empty_row(4);
+    target->set_int(col_id, 0, 0);
+    target->set_int(col_id, 1, 1);
+    target->set_int(col_id, 2, 2);
+    target->set_int(col_id, 3, 3);
+
+    size_t col_link = source->add_column_link(type_Link, "link", *target);
+    size_t col_int = source->add_column(type_Int, "int");
+    size_t col_double = source->add_column(type_Double, "double");
+    size_t col_string = source->add_column(type_String, "string");
+
+    auto add_row = [&](util::Optional<size_t> link_target, int64_t i, double d, const char* string) {
+        size_t row = source->add_empty_row();
+        if (link_target)
+            source->set_link(col_link, row, *link_target);
+        source->set_int(col_int, row, i);
+        source->set_double(col_double, row, d);
+        source->set_string(col_string, row, string);
+    };
+
+    add_row(util::none, 10, 10.0, "first");
+    add_row(1, 20, 20.0, "second");
+    add_row(2, 30, 30.0, "third");
+    add_row(3, 40, 40.0, "fourth");
+    add_row(3, 50, 50.0, "fifth");
+
+    Query q1 = target->backlink(*source, col_link).column<Int>(col_int) > 25;
+    CHECK_TABLE_VIEW(q1.find_all(), {2, 3});
+
+    Query q2 = target->backlink(*source, col_link).column<Double>(col_double) < 25.0;
+    CHECK_TABLE_VIEW(q2.find_all(), {1});
+
+    Query q3 = target->backlink(*source, col_link).column<StringData>(col_string).begins_with("f");
+    CHECK_TABLE_VIEW(q3.find_all(), {3});
+
+    Query q4 = target->column<BackLink>(*source, col_link).is_null();
+    CHECK_TABLE_VIEW(q4.find_all(), {0});
+
+    Query q5 = target->column<BackLink>(*source, col_link).count() == 0;
+    CHECK_TABLE_VIEW(q5.find_all(), {0});
+
+    Query q6 = target->column<BackLink>(*source, col_link).column<Int>(col_int).average() > 42.5;
+    CHECK_TABLE_VIEW(q6.find_all(), {3});
+
+    Query q7 = target->column<BackLink>(*source, col_link).column<Double>(col_double).min() < 30.0;
+    CHECK_TABLE_VIEW(q7.find_all(), {1});
+
+    Query q8 = target->column<BackLink>(*source, col_link).column<Int>(col_int).sum() == 0;
+    CHECK_TABLE_VIEW(q8.find_all(), {0});
+
+    Query q9 = target->column<BackLink>(*source, col_link).column<Int>(col_int).average() == null();
+    CHECK_TABLE_VIEW(q9.find_all(), {0});
+}
+
+// Test queries involving the backlinks of a link list column.
+TEST(BackLink_Query_LinkList)
+{
+    Group group;
+
+    TableRef source = group.add_table("source");
+    TableRef target = group.add_table("target");
+
+    size_t col_id = target->add_column(type_Int, "id");
+
+    target->add_empty_row(5);
+    target->set_int(col_id, 0, 0);
+    target->set_int(col_id, 1, 1);
+    target->set_int(col_id, 2, 2);
+    target->set_int(col_id, 3, 3);
+    target->set_int(col_id, 4, 4);
+
+    size_t col_linklist = source->add_column_link(type_LinkList, "linklist", *target);
+    size_t col_int = source->add_column(type_Int, "int");
+    size_t col_double = source->add_column(type_Double, "double");
+    size_t col_string = source->add_column(type_String, "string");
+
+    auto add_row = [&](std::vector<size_t> link_targets, int64_t i, double d, const char* string) {
+        size_t row = source->add_empty_row();
+        auto link_view = source->get_linklist(col_linklist, row);
+        for (auto link_target: link_targets)
+            link_view->add(link_target);
+        source->set_int(col_int, row, i);
+        source->set_double(col_double, row, d);
+        source->set_string(col_string, row, string);
+    };
+
+    add_row({}, 10, 10.0, "first");
+    add_row({1, 1}, 20, 20.0, "second");
+    add_row({0, 1}, 30, 30.0, "third");
+    add_row({2, 3}, 40, 40.0, "fourth");
+    add_row({3}, 50, 50.0, "fifth");
+
+    Query q1 = target->backlink(*source, col_linklist).column<Int>(col_int) > 25;
+    CHECK_TABLE_VIEW(q1.find_all(), {0, 1, 2, 3});
+
+    Query q2 = target->backlink(*source, col_linklist).column<Double>(col_double) < 25.0;
+    CHECK_TABLE_VIEW(q2.find_all(), {1});
+
+    Query q3 = target->backlink(*source, col_linklist).column<StringData>(col_string).begins_with("f");
+    CHECK_TABLE_VIEW(q3.find_all(), {2, 3});
+
+    Query q4 = target->column<BackLink>(*source, col_linklist).is_null();
+    CHECK_TABLE_VIEW(q4.find_all(), {4});
+
+    Query q5 = target->column<BackLink>(*source, col_linklist).count() == 0;
+    CHECK_TABLE_VIEW(q5.find_all(), {4});
+
+    Query q6 = target->column<BackLink>(*source, col_linklist).column<Int>(col_int).average() > 42.5;
+    CHECK_TABLE_VIEW(q6.find_all(), {3});
+
+    Query q7 = target->column<BackLink>(*source, col_linklist).column<Double>(col_double).min() < 30.0;
+    CHECK_TABLE_VIEW(q7.find_all(), {1});
+
+    Query q8 = target->column<BackLink>(*source, col_linklist).column<Int>(col_int).sum() == 0;
+    CHECK_TABLE_VIEW(q8.find_all(), {4});
+
+    Query q9 = target->column<BackLink>(*source, col_linklist).column<Int>(col_int).average() == null();
+    CHECK_TABLE_VIEW(q9.find_all(), {4});
+
+    Query q10 = target->column<BackLink>(*source, col_linklist).column<Double>(col_double).sum() == 70;
+    CHECK_TABLE_VIEW(q10.find_all(), {1});
+
+    Query q11 = target->column<BackLink>(*source, col_linklist, source->column<Double>(col_double) == 20.0).count() == 2;
+    CHECK_TABLE_VIEW(q11.find_all(), {1});
+}
+
+// Test queries involving multiple levels of links and backlinks.
+TEST(BackLink_Query_MultipleLevels)
+{
+    Group group;
+
+    TableRef people = group.add_table("people");
+
+    size_t col_name = people->add_column(type_String, "name");
+    size_t col_age = people->add_column(type_Int, "age");
+    size_t col_children = people->add_column_link(type_LinkList, "children", *people);
+
+    auto add_person = [&](std::string name, int age, std::vector<size_t> children) {
+        size_t row = people->add_empty_row();
+        auto children_link_view = people->get_linklist(col_children, row);
+        for (auto child: children)
+            children_link_view->add(child);
+        people->set_string(col_name, row, name);
+        people->set_int(col_age, row, age);
+        return row;
+    };
+
+    auto hannah   = add_person("Hannah", 0, {});
+    auto elijah   = add_person("Elijah", 3, {});
+
+    auto mark     = add_person("Mark",  30, {hannah});
+    auto jason    = add_person("Jason", 31, {elijah});
+
+    auto diane    = add_person("Diane", 29, {hannah});
+    auto carol    = add_person("Carol", 32, {});
+
+    auto don      = add_person("Don",   64, {diane, carol});
+    auto diane_sr = add_person("Diane", 60, {diane, carol});
+
+    add_person("Michael",  57, {jason, mark});
+    add_person("Raewynne", 56, {jason, mark});
+
+    // People that have a parent with a name that starts with 'M'.
+    Query q1 = people->backlink(*people, col_children).column<String>(col_name).begins_with("M");
+    CHECK_TABLE_VIEW(q1.find_all(), {hannah, mark, jason});
+
+    // People that have a grandparent with a name that starts with 'M'.
+    Query q2 = people->backlink(*people, col_children).backlink(*people, col_children).column<String>(col_name).begins_with("M");
+    CHECK_TABLE_VIEW(q2.find_all(), {hannah, elijah});
+
+    // People that have children that have a parent named Diane.
+    Query q3 = people->link(col_children).backlink(*people, col_children).column<String>(col_name) == "Diane";
+    CHECK_TABLE_VIEW(q3.find_all(), {mark, diane, don, diane_sr});
+
+    // People that have children that have a grandparent named Don.
+    Query q4 = people->link(col_children).backlink(*people, col_children).backlink(*people, col_children).column<String>(col_name) == "Don";
+    CHECK_TABLE_VIEW(q4.find_all(), {mark, diane});
+
+    // People whose parents have an average age of < 60.
+    Query q5 = people->column<BackLink>(*people, col_children).column<Int>(col_age).average() < 60;
+    CHECK_TABLE_VIEW(q5.find_all(), {hannah, elijah, mark, jason});
+
+    // People that have at least one sibling.
+    Query q6 = people->column<BackLink>(*people, col_children, people->column<Link>(col_children).count() > 1).count() > 0;
+    CHECK_TABLE_VIEW(q6.find_all(), {mark, jason, diane, carol});
+}
+
 #endif


### PR DESCRIPTION
Overloads of `Table::column` are added that take a source table and column index to identify the backlink. `Table::backlink` is added as an analog to `Table::link`.

Fixes #776.

/cc @rrrlasse
