### PR TITLE
Fix a crash when handing over a detached Row

### DIFF
--- a/release_notes.md
+++ b/release_notes.md
@@ -5,6 +5,7 @@
 * Bug fix: Misbehavior of empty asynchronous write in POSIX networking API.
 * Bug fix: Access dangling pointer while handling canceled asynchronous accept
   in POSIX networking API.
+* Handing over a detached row accessor no longer crashes.
 
 ### API breaking changes:
 

--- a/src/realm/row.cpp
+++ b/src/realm/row.cpp
@@ -70,7 +70,8 @@ void RowBase::generate_patch(const RowBase& source, HandoverPatch& patch)
 void RowBase::apply_patch(HandoverPatch& patch, Group& group)
 {
     m_table = Table::create_from_and_consume_patch(patch.m_table, group);
-    m_table->register_row_accessor(this);
+    if (m_table)
+        m_table->register_row_accessor(this);
     m_row_ndx = patch.row_ndx;
 }
 

--- a/test/test_lang_bind_helper.cpp
+++ b/test/test_lang_bind_helper.cpp
@@ -10473,6 +10473,7 @@ TEST(LangBindHelper_HandoverQueryLinksTo)
     std::unique_ptr<SharedGroup::Handover<Query>> handoverQueryNot;
     std::unique_ptr<SharedGroup::Handover<Query>> handoverQueryAndAndOr;
     std::unique_ptr<SharedGroup::Handover<Query>> handoverQueryWithExpression;
+    std::unique_ptr<SharedGroup::Handover<Query>> handoverQueryLinksToDetached;
 
     {
         LangBindHelper::promote_to_write(sg_w);
@@ -10483,15 +10484,19 @@ TEST(LangBindHelper_HandoverQueryLinksTo)
         size_t col_link = source->add_column_link(type_Link, "link", *target);
         size_t col_name = target->add_column(type_String, "name");
 
-        target->add_empty_row(3);
+        target->add_empty_row(4);
         target->set_string(col_name, 0, "A");
         target->set_string(col_name, 1, "B");
         target->set_string(col_name, 2, "C");
+        target->set_string(col_name, 3, "D");
 
         source->add_empty_row(3);
         source->set_link(col_link, 0, 0);
         source->set_link(col_link, 1, 1);
         source->set_link(col_link, 2, 2);
+
+        Row detached_row = target->get(3);
+        target->move_last_over(3);
 
         LangBindHelper::commit_and_continue_as_read(sg_w);
 
@@ -10512,6 +10517,9 @@ TEST(LangBindHelper_HandoverQueryLinksTo)
 
         Query queryWithExpression = source->column<LinkList>(col_link).is_not_null() && query;
         handoverQueryWithExpression = sg_w.export_for_handover(queryWithExpression, ConstSourcePayload::Copy);
+
+        Query queryLinksToDetached = source->where().links_to(col_link, detached_row);
+        handoverQueryLinksToDetached = sg_w.export_for_handover(queryLinksToDetached, ConstSourcePayload::Copy);
     }
 
     SharedGroup::VersionID vid =  sg_w.get_version_of_current_transaction(); // vid == 2
@@ -10524,6 +10532,7 @@ TEST(LangBindHelper_HandoverQueryLinksTo)
         std::unique_ptr<Query> queryNot(sg.import_from_handover(move(handoverQueryNot)));
         std::unique_ptr<Query> queryAndAndOr(sg.import_from_handover(move(handoverQueryAndAndOr)));
         std::unique_ptr<Query> queryWithExpression(sg.import_from_handover(move(handoverQueryWithExpression)));
+        std::unique_ptr<Query> queryLinksToDetached(sg.import_from_handover(move(handoverQueryLinksToDetached)));
 
         CHECK_EQUAL(1, query->count());
         CHECK_EQUAL(2, queryOr->count());
@@ -10531,6 +10540,7 @@ TEST(LangBindHelper_HandoverQueryLinksTo)
         CHECK_EQUAL(1, queryNot->count());
         CHECK_EQUAL(1, queryAndAndOr->count());
         CHECK_EQUAL(1, queryWithExpression->count());
+        CHECK_EQUAL(0, queryLinksToDetached->count());
 
 
         // Remove the linked-to row.
@@ -10550,6 +10560,7 @@ TEST(LangBindHelper_HandoverQueryLinksTo)
         CHECK_EQUAL(1, queryNot->count());
         CHECK_EQUAL(1, queryAndAndOr->count());
         CHECK_EQUAL(1, queryWithExpression->count());
+        CHECK_EQUAL(0, queryLinksToDetached->count());
     }
 }
 


### PR DESCRIPTION
`RowBase::apply_patch` was assuming that `m_table` was non-null after handing over the `Table`. This is only the case for an attached row accessor.

Reported in realm/realm-cocoa#3372.
