### PR TITLE
Handle both nullable and non-nullable DateTime columns

### DIFF
--- a/src/realm/column_mixed.cpp
+++ b/src/realm/column_mixed.cpp
@@ -53,7 +53,7 @@ void MixedColumn::create(Allocator& alloc, ref_type ref, Table* table, size_t co
     // TimestampColumn is only there if needed
     if (top->size() >= 4) {
         ref_type timestamp_ref = top->get_as_ref(3);
-        m_timestamp.reset(new TimestampColumn(alloc, timestamp_ref)); // Throws
+        m_timestamp.reset(new TimestampColumn(alloc, timestamp_ref, false)); // Throws
         m_timestamp->set_parent(&*top, 3);
     }
 
@@ -87,7 +87,7 @@ void MixedColumn::ensure_timestamp_column()
         return;
 
     ref_type ref = TimestampColumn::create(m_array->get_alloc()); // Throws
-    m_timestamp.reset(new TimestampColumn(m_array->get_alloc(), ref)); // Throws
+    m_timestamp.reset(new TimestampColumn(m_array->get_alloc(), ref, false)); // Throws
     REALM_ASSERT_3(m_array->size(), ==, 3);
     m_array->add(ref); // Throws
     m_timestamp->set_parent(m_array.get(), 3);
@@ -298,6 +298,7 @@ void MixedColumn::set_binary(size_t ndx, BinaryData value)
 void MixedColumn::set_timestamp(size_t ndx, Timestamp value)
 {
     REALM_ASSERT_3(ndx, <, m_types->size());
+    REALM_ASSERT(!value.is_null());
     ensure_timestamp_column();
 
     MixedColType type = MixedColType(m_types->get(ndx));

--- a/src/realm/column_mixed_tpl.hpp
+++ b/src/realm/column_mixed_tpl.hpp
@@ -343,6 +343,7 @@ inline void MixedColumn::insert_datetime(size_t ndx, DateTime value)
 
 inline void MixedColumn::insert_timestamp(size_t ndx, Timestamp value)
 {
+    REALM_ASSERT(!value.is_null());
     ensure_timestamp_column();
     size_t data_ndx = m_timestamp->size();
     m_timestamp->add(value); // Throws

--- a/src/realm/column_timestamp.cpp
+++ b/src/realm/column_timestamp.cpp
@@ -24,7 +24,8 @@
 namespace realm {
 
 
-TimestampColumn::TimestampColumn(Allocator& alloc, ref_type ref)
+TimestampColumn::TimestampColumn(Allocator& alloc, ref_type ref, bool nullable):
+    m_nullable(nullable)
 {
     char* header = alloc.translate(ref);
     MemRef mem(header, ref);
@@ -36,10 +37,15 @@ TimestampColumn::TimestampColumn(Allocator& alloc, ref_type ref)
     ref_type seconds = m_array->get_as_ref(0);
     ref_type nano = m_array->get_as_ref(1);
 
-    m_seconds.init_from_ref(alloc, seconds);
+    if (m_nullable) {
+        m_nullable_seconds.init_from_ref(alloc, seconds);
+        m_nullable_seconds.set_parent(root, 0);
+    }
+    else {
+        m_nonnullable_seconds.init_from_ref(alloc, seconds);
+        m_nonnullable_seconds.set_parent(root, 0);
+    }
     m_nanoseconds.init_from_ref(alloc, nano);
-
-    m_seconds.set_parent(root, 0);
     m_nanoseconds.set_parent(root, 1);
 }
 
@@ -50,16 +56,42 @@ TimestampColumn::~TimestampColumn() noexcept
 }
 
 
-ref_type TimestampColumn::create(Allocator& alloc, size_t size)
+template<class BT> class TimestampColumn::CreateHandler: public ColumnBase::CreateHandler {
+public:
+    CreateHandler(typename BT::value_type value, Allocator& alloc):
+        m_value(value), m_alloc(alloc) {}
+
+    ref_type create_leaf(size_t size) override
+    {
+        MemRef mem = BT::create_leaf(Array::type_Normal, size, m_value, m_alloc); // Throws
+        return mem.m_ref;
+    }
+private:
+    const typename BT::value_type m_value;
+    Allocator& m_alloc;
+};
+
+ref_type TimestampColumn::create(Allocator& alloc, size_t size, bool nullable)
 {
     Array top(alloc);
     top.create(Array::type_HasRefs, false /* context_flag */, 2);
 
-    MemRef seconds = BpTree<util::Optional<int64_t>>::create_leaf(Array::type_Normal, size, null{}, alloc);
-    MemRef nano = BpTree<int64_t>::create_leaf(Array::type_Normal, size, 0, alloc);
+    ref_type seconds;
 
-    top.set_as_ref(0, seconds.m_ref);
-    top.set_as_ref(1, nano.m_ref);
+    if (nullable) {
+        CreateHandler<BpTree<util::Optional<int64_t>>> create_handler{null{}, alloc};
+        seconds = ColumnBase::create(alloc, size, create_handler);
+    }
+    else {
+        CreateHandler<BpTree<int64_t>> create_handler{0, alloc};
+        seconds = ColumnBase::create(alloc, size, create_handler);
+    }
+
+    CreateHandler<BpTree<int64_t>> nano_create_handler{0, alloc};
+    ref_type nano = ColumnBase::create(alloc, size, nano_create_handler);
+
+    top.set_as_ref(0, seconds);
+    top.set_as_ref(1, nano);
 
     ref_type top_ref = top.get_ref();
     return top_ref;
@@ -71,27 +103,32 @@ ref_type TimestampColumn::create(Allocator& alloc, size_t size)
 size_t TimestampColumn::size() const noexcept
 {
     // FIXME: Consider debug asserts on the columns having the same size
-    return m_seconds.size();
+    if (m_nullable)
+        return m_nullable_seconds.size();
+    return m_nonnullable_seconds.size();
 }
 
 /// Whether or not this column is nullable.
 bool TimestampColumn::is_nullable() const noexcept
 {
-    return true;
+    return m_nullable;
 }
 
 /// Whether or not the value at \a row_ndx is NULL. If the column is not
 /// nullable, always returns false.
 bool TimestampColumn::is_null(size_t row_ndx) const noexcept
 {
-    return m_seconds.is_null(row_ndx);
+    if (!m_nullable)
+        return false;
+    return m_nullable_seconds.is_null(row_ndx);
 }
 
 /// Sets the value at \a row_ndx to be NULL.
 /// \throw LogicError Thrown if this column is not nullable.
 void TimestampColumn::set_null(size_t row_ndx)
 {
-    m_seconds.set_null(row_ndx);
+    REALM_ASSERT(m_nullable);
+    m_nullable_seconds.set_null(row_ndx);
     if (has_search_index()) {
         m_search_index->set(row_ndx, null{});
     }
@@ -104,9 +141,9 @@ void TimestampColumn::insert_rows(size_t row_ndx, size_t num_rows_to_insert, siz
     if (row_ndx == size())
         row_ndx = npos;
     if (nullable)
-        m_seconds.insert(row_ndx, null{}, num_rows_to_insert);
+        m_nullable_seconds.insert(row_ndx, null{}, num_rows_to_insert);
     else
-        m_seconds.insert(row_ndx, 0, num_rows_to_insert);
+        m_nonnullable_seconds.insert(row_ndx, 0, num_rows_to_insert);
     m_nanoseconds.insert(row_ndx, 0, num_rows_to_insert);
 
     if (has_search_index()) {
@@ -129,11 +166,15 @@ void TimestampColumn::erase_rows(size_t row_ndx, size_t num_rows_to_erase, size_
     static_cast<void>(broken_reciprocal_backlinks);
     bool is_last = (row_ndx + num_rows_to_erase) == size();
     for (size_t i = 0; i < num_rows_to_erase; ++i) {
-        m_seconds.erase(row_ndx + num_rows_to_erase - i - 1, is_last);
-        m_nanoseconds.erase(row_ndx + num_rows_to_erase - i - 1, is_last);
+        size_t ndx = row_ndx + num_rows_to_erase - i - 1;
+        if (m_nullable)
+            m_nullable_seconds.erase(ndx, is_last);
+        else
+            m_nonnullable_seconds.erase(ndx, is_last);
+        m_nanoseconds.erase(ndx, is_last);
         
         if (has_search_index()) {
-            m_search_index->erase<StringData>(row_ndx + num_rows_to_erase - i - 1, is_last);
+            m_search_index->erase<StringData>(ndx, is_last);
         }
     }
 }
@@ -157,15 +198,21 @@ void TimestampColumn::move_last_row_over(size_t row_ndx, size_t prior_num_rows,
         }
     }
 
-    m_seconds.move_last_over(row_ndx, prior_num_rows);
+    if (m_nullable)
+        m_nullable_seconds.move_last_over(row_ndx, prior_num_rows);
+    else
+        m_nonnullable_seconds.move_last_over(row_ndx, prior_num_rows);
     m_nanoseconds.move_last_over(row_ndx, prior_num_rows);
 }
 
 void TimestampColumn::clear(size_t num_rows, bool broken_reciprocal_backlinks)
 {
-    REALM_ASSERT_EX(num_rows == m_seconds.size(), num_rows, m_seconds.size());
+    REALM_ASSERT_EX(num_rows == size(), num_rows, size());
     static_cast<void>(broken_reciprocal_backlinks);
-    m_seconds.clear();
+    if (m_nullable)
+        m_nullable_seconds.clear();
+    else
+        m_nonnullable_seconds.clear();
     m_nanoseconds.clear();
     if (has_search_index()) {
         m_search_index->clear();
@@ -186,9 +233,15 @@ void TimestampColumn::swap_rows(size_t row_ndx_1, size_t row_ndx_2)
         m_search_index->insert(row_ndx_2, value_1, 1, row_ndx_2_is_last);
     }
 
-    auto tmp1 = m_seconds.get(row_ndx_1);
-    m_seconds.set(row_ndx_1, m_seconds.get(row_ndx_2));
-    m_seconds.set(row_ndx_2, tmp1);
+    auto tmp1 = get(row_ndx_1).m_seconds;
+    if (m_nullable) {
+        m_nullable_seconds.set(row_ndx_1, m_nullable_seconds.get(row_ndx_2));
+        m_nullable_seconds.set(row_ndx_2, tmp1);
+    }
+    else {
+        m_nonnullable_seconds.set(row_ndx_1, m_nonnullable_seconds.get(row_ndx_2));
+        m_nonnullable_seconds.set(row_ndx_2, tmp1);
+    }
     auto tmp2 = m_nanoseconds.get(row_ndx_1);
     m_nanoseconds.set(row_ndx_1, m_nanoseconds.get(row_ndx_2));
     m_nanoseconds.set(row_ndx_2, tmp2);
@@ -196,7 +249,10 @@ void TimestampColumn::swap_rows(size_t row_ndx_1, size_t row_ndx_2)
 
 void TimestampColumn::destroy() noexcept
 {
-    m_seconds.destroy();
+    if (m_nullable)
+        m_nullable_seconds.destroy();
+    else
+        m_nonnullable_seconds.destroy();
     m_nanoseconds.destroy();
     if (m_array)
         m_array->destroy();
@@ -307,10 +363,15 @@ void TimestampColumn::leaf_to_dot(MemRef, ArrayParent*, size_t /*ndx_in_parent*/
 
 void TimestampColumn::add(const Timestamp& ts)
 {
-    bool is_null = ts.is_null();
-    util::Optional<int64_t> seconds = is_null ? util::none : util::make_optional(ts.m_seconds);
-    int32_t nanoseconds = is_null ? 0 : ts.m_nanoseconds;
-    m_seconds.insert(npos, seconds);
+    uint32_t nanoseconds = ts.is_null() ? 0 : ts.m_nanoseconds;
+    if (m_nullable) {
+        util::Optional<int64_t> seconds = ts.is_null() ? util::none : util::some<int64_t>(ts.m_seconds);
+        m_nullable_seconds.insert(npos, seconds);
+    }
+    else {
+        REALM_ASSERT(!ts.is_null());
+        m_nonnullable_seconds.insert(npos, ts.m_seconds);
+    }
     m_nanoseconds.insert(npos, nanoseconds);
 
     if (has_search_index()) {
@@ -321,8 +382,19 @@ void TimestampColumn::add(const Timestamp& ts)
 
 Timestamp TimestampColumn::get(size_t row_ndx) const noexcept
 {
-    util::Optional<int64_t> seconds = m_seconds.get(row_ndx);
-    return seconds ? Timestamp(*seconds, int32_t(m_nanoseconds.get(row_ndx))) : Timestamp(null());
+    int64_t seconds;
+    if (m_nullable) {
+        util::Optional<int64_t> maybe_seconds = m_nullable_seconds.get(row_ndx);
+        if (maybe_seconds)
+            seconds = *maybe_seconds;
+        else
+            return null{};
+    }
+    else {
+        seconds = m_nonnullable_seconds.get(row_ndx);
+    }
+    uint32_t ns = static_cast<uint32_t>(m_nanoseconds.get(row_ndx));
+    return Timestamp{seconds, ns};
 }
 
 void TimestampColumn::set(size_t row_ndx, const Timestamp& ts)
@@ -330,7 +402,13 @@ void TimestampColumn::set(size_t row_ndx, const Timestamp& ts)
     bool is_null = ts.is_null();
     util::Optional<int64_t> seconds = is_null ? util::none : util::make_optional(ts.m_seconds);
     int32_t nanoseconds = is_null ? 0 : ts.m_nanoseconds;
-    m_seconds.set(row_ndx, seconds);
+    if (m_nullable) {
+        m_nullable_seconds.set(row_ndx, seconds);
+    }
+    else {
+        REALM_ASSERT(!is_null);
+        m_nonnullable_seconds.set(row_ndx, *seconds);
+    }
     m_nanoseconds.set(row_ndx, nanoseconds);
 
     if (has_search_index()) {

--- a/src/realm/column_timestamp.hpp
+++ b/src/realm/column_timestamp.hpp
@@ -62,10 +62,10 @@ inline std::basic_ostream<C, T>& operator<<(std::basic_ostream<C, T>& out, const
 // column type
 class TimestampColumn : public ColumnBaseSimple, public ColumnTemplate<Timestamp> {
 public:
-    TimestampColumn(Allocator& alloc, ref_type ref);
+    TimestampColumn(Allocator& alloc, ref_type ref, bool nullable);
     ~TimestampColumn() noexcept override;
 
-    static ref_type create(Allocator& alloc, size_t size = 0);
+    static ref_type create(Allocator& alloc, size_t size = 0, bool nullable = false);
 
     /// Get the number of entries in this column. This operation is relatively
     /// slow.
@@ -117,17 +117,24 @@ public:
     size_t count(Timestamp) const;
 
     void erase(size_t ndx, bool is_last) {
-        m_seconds.erase(ndx, is_last);
+        if (m_nullable)
+            m_nullable_seconds.erase(ndx, is_last);
+        else
+            m_nonnullable_seconds.erase(ndx, is_last);
         m_nanoseconds.erase(ndx, is_last);
     }
 
     typedef Timestamp value_type;
 
 private:
-    BpTree<util::Optional<int64_t>> m_seconds;
+    BpTree<int64_t> m_nonnullable_seconds;
+    BpTree<util::Optional<int64_t>> m_nullable_seconds;
     BpTree<int64_t> m_nanoseconds;
+    bool m_nullable;
 
     std::unique_ptr<StringIndex> m_search_index;
+
+    template<class BT> class CreateHandler;
 };
 
 } // namespace realm

--- a/src/realm/table.cpp
+++ b/src/realm/table.cpp
@@ -1446,7 +1446,7 @@ ColumnBase* Table::create_column_accessor(ColumnType col_type, size_t col_ndx, s
             break;
         case col_type_Timestamp:
             // Origin table will be set by group after entire table has been created
-            col = new TimestampColumn(alloc, ref); // Throws
+            col = new TimestampColumn(alloc, ref, nullable); // Throws
             break;
         case col_type_Reserved4:
             // These have no function yet and are therefore unexpected.

--- a/test/test_column_mixed.cpp
+++ b/test/test_column_mixed.cpp
@@ -224,7 +224,7 @@ TEST(MixedColumn_Timestamp)
     ref_type ref = MixedColumn::create(Allocator::get_default());
     MixedColumn c(Allocator::get_default(), ref, 0, 0);
 
-    c.insert_timestamp(0, Timestamp(null()));
+    c.insert_timestamp(0, Timestamp(0, 0));
     c.insert_timestamp(1, Timestamp(100, 200));
     c.insert_timestamp(2, Timestamp(0, 0)); // Should *not* equal null
     c.insert_timestamp(3, Timestamp(-1000, 0));
@@ -388,10 +388,8 @@ TEST(MixedColumn_Mixed)
     c.set_subtable(5, 0);
     c.set_float(6, 1.124f);
     c.set_double(7, 1234.124);
-    c.set_timestamp(8, Timestamp());
     CHECK_EQUAL(9, c.size());
 
-    CHECK_EQUAL(type_Timestamp, c.get_type(8));
     CHECK_EQUAL(type_Double, c.get_type(7));
     CHECK_EQUAL(type_Float,  c.get_type(6));
     CHECK_EQUAL(type_Table,  c.get_type(5));

--- a/test/test_column_timestamp.cpp
+++ b/test/test_column_timestamp.cpp
@@ -39,13 +39,14 @@ using namespace realm;
 // check-testcase` (or one of its friends) from the command line.
 
 
-TEST(TimestampColumn_Basic)
+TEST_TYPES(DateTimeColumn_Basic, std::true_type, std::false_type)
 {
-    ref_type ref = TimestampColumn::create(Allocator::get_default());
-    TimestampColumn c(Allocator::get_default(), ref);
+    bool nullable = TEST_TYPE::value;
+    ref_type ref = TimestampColumn::create(Allocator::get_default(), 0, nullable);
+    TimestampColumn c(Allocator::get_default(), ref, nullable);
     c.add(Timestamp(123,123));
     Timestamp ts = c.get(0);
-    CHECK(ts == Timestamp(123, 123));
+    CHECK_EQUAL(ts, Timestamp(123, 123));
 }
 
 TEST(TimestampColumn_Basic_Nulls)
@@ -77,10 +78,10 @@ TEST(TimestampColumn_Relocate)
     }
 }
 
-TEST(TimestampColumn_Compare)
+TEST_TYPES(TimestampColumn_Compare, std::true_type, std::false_type)
 {
-    ref_type ref = TimestampColumn::create(Allocator::get_default());
-    TimestampColumn c(Allocator::get_default(), ref);
+    ref_type ref = TimestampColumn::create(Allocator::get_default(), 0, TEST_TYPE::value);
+    TimestampColumn c(Allocator::get_default(), ref, TEST_TYPE::value);
 
     for (unsigned int i = 0; i < 10000; i++) {
         c.add(Timestamp(i, i));
@@ -89,16 +90,16 @@ TEST(TimestampColumn_Compare)
     CHECK(c.compare(c));
 
     {
-        ref_type ref = TimestampColumn::create(Allocator::get_default());
-        TimestampColumn c2(Allocator::get_default(), ref);
+        ref_type ref = TimestampColumn::create(Allocator::get_default(), 0, TEST_TYPE::value);
+        TimestampColumn c2(Allocator::get_default(), ref, TEST_TYPE::value);
         CHECK_NOT(c.compare(c2));
     }
 }
 
-TEST(TimestampColumn_Index)
+TEST_TYPES(TimestampColumn_Index, std::true_type, std::false_type)
 {
-    ref_type ref = TimestampColumn::create(Allocator::get_default());
-    TimestampColumn c(Allocator::get_default(), ref);
+    ref_type ref = TimestampColumn::create(Allocator::get_default(), 0, TEST_TYPE::value);
+    TimestampColumn c(Allocator::get_default(), ref, TEST_TYPE::value);
     StringIndex* index = c.create_search_index();
     CHECK(index);
 


### PR DESCRIPTION
This does the following:
- Remove the abillity of NewDates in MixedColumn to be NULL.
- Attach different "seconds" accessor depending on whether or not the datetime column should be nullable.

@danielpovlsen @rrrlasse
