### PR TITLE
Remove old unused code, preventing compile of fuzz_transact_log.cpp

### DIFF
--- a/test/fuzzy/fuzz_transact_log.cpp
+++ b/test/fuzzy/fuzz_transact_log.cpp
@@ -37,13 +37,6 @@ int main(int argc, const char* argv[])
     buffer.resize(1024);
     _impl::NoCopyInputStreamAdaptor in_aa{in_a, buffer.data(), buffer.size()};
 
-    test_util::unit_test::TestDetails test_details;
-    test_details.test_index = 0;
-    test_details.suite_name = "FuzzyTest";
-    test_details.test_name = "TransactLogApplier";
-    test_details.file_name = __FILE__;
-    test_details.line_number = __LINE__;
-
     Group group;
 
     try {


### PR DESCRIPTION
`TestDetails` has been updated recently to not use `test_index` but this change was not propagated to the fuzz test programs so there is a compile error. This code is not a unit test though and doesn't need an instance of test_details so I just removed it.
@danielpovlsen
