### PR TITLE
Prevent "unused" warnings from symbols that are only used in assertions

### DIFF
--- a/src/realm/alloc_slab.cpp
+++ b/src/realm/alloc_slab.cpp
@@ -815,7 +815,9 @@ void SlabAlloc::reset_free_space_tracking()
         chunk.ref = slab.ref_end;
     }
 
+#ifdef REALM_DEBUG
     REALM_ASSERT_DEBUG(is_all_free());
+#endif
 
     m_free_space_state = free_space_Clean;
 }

--- a/src/realm/array.cpp
+++ b/src/realm/array.cpp
@@ -856,7 +856,9 @@ size_t Array::find_gte(const int64_t target, size_t start, Array const* indirect
 
 exit:
 
+#if REALM_DEBUG
     REALM_ASSERT_DEBUG(ref == ret);
+#endif
 
     return ret;
 }

--- a/src/realm/array_basic_tpl.hpp
+++ b/src/realm/array_basic_tpl.hpp
@@ -69,8 +69,6 @@ inline MemRef BasicArray<T>::create_array(Array::Type type, bool context_flag, s
 {
     REALM_ASSERT(type == Array::type_Normal);
     REALM_ASSERT(!context_flag);
-    static_cast<void>(type);
-    static_cast<void>(context_flag);
     MemRef mem = create_array(size, alloc);
     if (size) {
         BasicArray<T> tmp(alloc);
@@ -88,8 +86,6 @@ inline void BasicArray<T>::create(Array::Type type, bool context_flag)
 {
     REALM_ASSERT(type == Array::type_Normal);
     REALM_ASSERT(!context_flag);
-    static_cast<void>(type);
-    static_cast<void>(context_flag);
     size_t size = 0;
     MemRef mem = create_array(size, get_alloc()); // Throws
     init_from_mem(mem);

--- a/src/realm/column.hpp
+++ b/src/realm/column.hpp
@@ -1264,7 +1264,6 @@ template<class T> struct NullOrDefaultValue<T, typename std::enable_if<!Implicit
     static T null_or_default_value(bool is_null)
     {
         REALM_ASSERT(!is_null);
-        static_cast<void>(is_null);
         return T{};
     }
 };

--- a/src/realm/column_binary.hpp
+++ b/src/realm/column_binary.hpp
@@ -306,7 +306,6 @@ inline void BinaryColumn::insert_rows(size_t row_ndx, size_t num_rows_to_insert,
     REALM_ASSERT_DEBUG(prior_num_rows == size());
     REALM_ASSERT(row_ndx <= prior_num_rows);
     REALM_ASSERT(!insert_nulls || m_nullable);
-    static_cast<void>(insert_nulls);
 
     size_t row_ndx_2 = (row_ndx == prior_num_rows ? realm::npos : row_ndx);
     BinaryData value = m_nullable ? BinaryData() : BinaryData("", 0);

--- a/src/realm/column_link.cpp
+++ b/src/realm/column_link.cpp
@@ -54,7 +54,6 @@ void LinkColumn::insert_rows(size_t row_ndx, size_t num_rows_to_insert, size_t p
     REALM_ASSERT_DEBUG(prior_num_rows == size());
     REALM_ASSERT(row_ndx <= prior_num_rows);
     REALM_ASSERT(insert_nulls);
-    static_cast<void>(insert_nulls);
 
     // Update backlinks to the moved origin rows
     size_t num_rows_moved = prior_num_rows - row_ndx;

--- a/src/realm/column_mixed_tpl.hpp
+++ b/src/realm/column_mixed_tpl.hpp
@@ -414,7 +414,6 @@ inline void MixedColumn::insert_rows(size_t row_ndx, size_t num_rows_to_insert,
     REALM_ASSERT_DEBUG(prior_num_rows == size());
     REALM_ASSERT(row_ndx <= prior_num_rows);
     REALM_ASSERT(!insert_nulls);
-    static_cast<void>(insert_nulls);
 
     size_t row_ndx_2 = (row_ndx == prior_num_rows ? realm::npos : row_ndx);
 

--- a/src/realm/column_string.hpp
+++ b/src/realm/column_string.hpp
@@ -349,7 +349,6 @@ inline void StringColumn::insert_rows(size_t row_ndx, size_t num_rows_to_insert,
     REALM_ASSERT_DEBUG(prior_num_rows == size());
     REALM_ASSERT(row_ndx <= prior_num_rows);
     REALM_ASSERT(!insert_nulls || m_nullable);
-    static_cast<void>(insert_nulls);
 
     StringData value = m_nullable ? realm::null() : StringData("");
     bool is_append = (row_ndx == prior_num_rows);

--- a/src/realm/column_string_enum.hpp
+++ b/src/realm/column_string_enum.hpp
@@ -240,7 +240,6 @@ inline void StringEnumColumn::insert_rows(size_t row_ndx, size_t num_rows_to_ins
     REALM_ASSERT_DEBUG(prior_num_rows == size());
     REALM_ASSERT(row_ndx <= prior_num_rows);
     REALM_ASSERT(!insert_nulls || m_nullable);
-    static_cast<void>(insert_nulls);
 
     StringData value = m_nullable ? realm::null() : StringData("");
     bool is_append = (row_ndx == prior_num_rows);

--- a/src/realm/column_table.hpp
+++ b/src/realm/column_table.hpp
@@ -250,7 +250,6 @@ inline void SubtableColumnBase::insert_rows(size_t row_ndx, size_t num_rows_to_i
     REALM_ASSERT_DEBUG(prior_num_rows == size());
     REALM_ASSERT(row_ndx <= prior_num_rows);
     REALM_ASSERT(!insert_nulls);
-    static_cast<void>(insert_nulls);
 
     size_t row_ndx_2 = (row_ndx == prior_num_rows ? realm::npos : row_ndx);
     int_fast64_t value = 0;

--- a/src/realm/group.cpp
+++ b/src/realm/group.cpp
@@ -1155,7 +1155,6 @@ public:
     {
         REALM_ASSERT_3(table_ndx, <=, num_tables);
         REALM_ASSERT(m_group.m_table_accessors.empty() || m_group.m_table_accessors.size() == num_tables);
-        static_cast<void>(num_tables);
 
         if (!m_group.m_table_accessors.empty()) {
             m_group.m_table_accessors.insert(m_group.m_table_accessors.begin() + table_ndx, nullptr);
@@ -1177,7 +1176,6 @@ public:
     {
         REALM_ASSERT_3(table_ndx, <, num_tables);
         REALM_ASSERT(m_group.m_table_accessors.empty() || m_group.m_table_accessors.size() == num_tables);
-        static_cast<void>(num_tables);
 
         if (!m_group.m_table_accessors.empty()) {
             // Link target tables do not need to be considered here, since all

--- a/src/realm/query.cpp
+++ b/src/realm/query.cpp
@@ -19,7 +19,9 @@ Query::Query() : m_view(nullptr), m_source_table_view(nullptr), m_owns_source_ta
 Query::Query(Table& table, TableViewBase* tv)
     : m_table(table.get_table_ref()), m_view(tv), m_source_table_view(tv), m_owns_source_table_view(false)
 {
+#ifdef REALM_DEBUG
     REALM_ASSERT_DEBUG(m_view == nullptr || m_view->cookie == m_view->cookie_expected);
+#endif
     create();
 }
 
@@ -28,7 +30,9 @@ Query::Query(const Table& table, const LinkViewRef& lv):
     m_view(lv.get()),
     m_source_link_view(lv), m_source_table_view(nullptr), m_owns_source_table_view(false)
 {
+#ifdef REALM_DEBUG
     REALM_ASSERT_DEBUG(m_view == nullptr || m_view->cookie == m_view->cookie_expected);
+#endif
     REALM_ASSERT_DEBUG(&lv->get_target_table() == m_table);
     create();
 }
@@ -36,7 +40,9 @@ Query::Query(const Table& table, const LinkViewRef& lv):
 Query::Query(const Table& table, TableViewBase* tv)
     : m_table((const_cast<Table&>(table)).get_table_ref()), m_view(tv), m_source_table_view(tv), m_owns_source_table_view(false)
 {
+#ifdef REALM_DEBUG
     REALM_ASSERT_DEBUG(m_view == nullptr ||m_view->cookie == m_view->cookie_expected);
+#endif
     create();
 }
 
@@ -45,7 +51,9 @@ Query::Query(const Table& table, std::unique_ptr<TableViewBase> tv)
 {
     tv.release();
 
+#ifdef REALM_DEBUG
     REALM_ASSERT_DEBUG(m_view == nullptr ||m_view->cookie == m_view->cookie_expected);
+#endif
     create();
 }
 
@@ -689,7 +697,9 @@ Query& Query::not_equal(size_t column_ndx, StringData value, bool case_sensitive
 size_t Query::peek_tableview(size_t tv_index) const
 {
     REALM_ASSERT(m_view);
+#ifdef REALM_DEBUG
     REALM_ASSERT_DEBUG(m_view->cookie == m_view->cookie_expected);
+#endif
     REALM_ASSERT_3(tv_index, <, m_view->size());
 
     // Cannot use to_size_t() because the get() may return -1

--- a/src/realm/table.cpp
+++ b/src/realm/table.cpp
@@ -1884,8 +1884,6 @@ void Table::validate_column_type(const ColumnBase& column, ColumnType col_type, 
         REALM_ASSERT_3(col_type, ==, real_col_type);
     }
     static_cast<void>(column);
-    static_cast<void>(ndx);
-    static_cast<void>(real_col_type);
 }
 
 

--- a/src/realm/util/assert.hpp
+++ b/src/realm/util/assert.hpp
@@ -34,13 +34,13 @@
 #if REALM_ASSERTIONS_ENABLED
 #  define REALM_ASSERT(condition) REALM_ASSERT_RELEASE(condition)
 #else
-#  define REALM_ASSERT(condition) static_cast<void>(0)
+#  define REALM_ASSERT(condition) static_cast<void>(sizeof bool(condition))
 #endif
 
 #ifdef REALM_DEBUG
 #  define REALM_ASSERT_DEBUG(condition) REALM_ASSERT_RELEASE(condition)
 #else
-#  define REALM_ASSERT_DEBUG(condition) static_cast<void>(0)
+#  define REALM_ASSERT_DEBUG(condition) static_cast<void>(sizeof bool(condition))
 #endif
 
 #define REALM_STRINGIFY(X) #X
@@ -53,34 +53,45 @@
 #ifdef REALM_DEBUG
 #  define REALM_ASSERT_DEBUG_EX REALM_ASSERT_RELEASE_EX
 #else
-#  define REALM_ASSERT_DEBUG_EX(...) static_cast<void>(0)
+#  define REALM_ASSERT_DEBUG_EX(condition, ...) static_cast<void>(sizeof bool(condition))
 #endif
 
-// Becase the assert is used in noexcept methods, it's a bad idea to allocate buffer space for the message
-// so therefore we must pass it to terminate which will 'cerr' it for us without needing any buffer
+// Becase the assert is used in noexcept methods, it's a bad idea to allocate
+// buffer space for the message so therefore we must pass it to terminate which
+// will 'cerr' it for us without needing any buffer
 #if REALM_ENABLE_ASSERTIONS || defined(REALM_DEBUG)
 
 #  define REALM_ASSERT_EX REALM_ASSERT_RELEASE_EX
 
-#  define REALM_ASSERT_3(left, condition, right) \
-    (((left) condition (right)) ? static_cast<void>(0) :                \
-        realm::util::terminate("Assertion failed: " #left " " #condition " " #right, \
-                               __FILE__, __LINE__, left, right))
+#  define REALM_ASSERT_3(left, cmp, right) \
+    (((left) cmp (right)) ? static_cast<void>(0) : \
+     realm::util::terminate("Assertion failed: " \
+                            "" #left " " #cmp " " #right, \
+                            __FILE__, __LINE__, left, right))
 
-#  define REALM_ASSERT_7(left1, condition1, right1, logical, left2, condition2, right2) \
-    ((((left1) condition1 (right1)) logical ((left2) condition2 (right2))) ? static_cast<void>(0) : \
-        realm::util::terminate("Assertion failed: " #left1 " " #condition1 " " #right1 " " #logical " " #left2 " " #condition2 " " #right2, \
-                               __FILE__, __LINE__, left1, right1, left2, right2))
+#  define REALM_ASSERT_7(left1, cmp1, right1, logical, left2, cmp2, right2) \
+    ((((left1) cmp1 (right1)) logical ((left2) cmp2 (right2))) ? static_cast<void>(0) : \
+     realm::util::terminate("Assertion failed: " \
+                            "" #left1 " " #cmp1 " " #right1 " " #logical " " \
+                            "" #left2 " " #cmp2 " " #right2, \
+                            __FILE__, __LINE__, left1, right1, left2, right2))
 
-#  define REALM_ASSERT_11(left1, condition1, right1, logical1, left2, condition2, right2, logical2, left3, condition3, right3) \
-    ((((left1) condition1 (right1)) logical1 ((left2) condition2 (right2)) logical2 ((left3) condition3 (right3))) ? static_cast<void>(0) : \
-        realm::util::terminate("Assertion failed: " #left1 " " #condition1 " " #right1 " " #logical1 " " #left2 " " #condition2 " " #right2 " " #logical2 " " #left3 " " #condition3 " " #right3, \
-                               __FILE__, __LINE__, left1, right1, left2, right2, left3, right3))
+#  define REALM_ASSERT_11(left1, cmp1, right1, logical1, left2, cmp2, right2, logical2, left3, cmp3, right3) \
+    ((((left1) cmp1 (right1)) logical1 ((left2) cmp2 (right2)) logical2 ((left3) cmp3 (right3))) ? static_cast<void>(0) : \
+     realm::util::terminate("Assertion failed: " \
+                            "" #left1 " " #cmp1 " " #right1 " " #logical1 " " \
+                            "" #left2 " " #cmp2 " " #right2 " " #logical2 " " \
+                            "" #left3 " " #cmp3 " " #right3, \
+                            __FILE__, __LINE__, left1, right1, left2, right2, left3, right3))
 #else
-#  define REALM_ASSERT_EX(...) static_cast<void>(0)
-#  define REALM_ASSERT_3(left, condition, right) static_cast<void>(0)
-#  define REALM_ASSERT_7(left1, condition1, right1, logical, left2, condition2, right2) static_cast<void>(0)
-#  define REALM_ASSERT_11(left1, condition1, right1, logical1, left2, condition2, right2, logical3, left3, condition3, right3) static_cast<void>(0)
+#  define REALM_ASSERT_EX(condition, ...) \
+    static_cast<void>(sizeof bool(condition))
+#  define REALM_ASSERT_3(left, cmp, right) \
+    static_cast<void>(sizeof bool((left) cmp (right)))
+#  define REALM_ASSERT_7(left1, cmp1, right1, logical, left2, cmp2, right2) \
+    static_cast<void>(sizeof bool(((left1) cmp1 (right1)) logical ((left2) cmp2 (right2))))
+#  define REALM_ASSERT_11(left1, cmp1, right1, logical1, left2, cmp2, right2, logical2, left3, cmp3, right3) \
+    static_cast<void>(sizeof bool(((left1) cmp1 (right1)) logical1 ((left2) cmp2 (right2)) logical2 ((left3) cmp3 (right3))))
 #endif
 
 #define REALM_UNREACHABLE() \

--- a/src/realm/util/encrypted_file_mapping.cpp
+++ b/src/realm/util/encrypted_file_mapping.cpp
@@ -114,7 +114,6 @@ void check_write(int fd, off_t pos, const void *data, size_t len)
 {
     ssize_t ret = pwrite(fd, data, len, pos);
     REALM_ASSERT(ret >= 0 && static_cast<size_t>(ret) == len);
-    static_cast<void>(ret);
 }
 
 size_t check_read(int fd, off_t pos, void *dst, size_t len)
@@ -284,8 +283,6 @@ void AESCryptor::crypt(EncryptionMode mode, off_t pos, char* dst,
     CCCryptorStatus err = CCCryptorUpdate(cryptor, src, block_size, dst, block_size, &bytesEncrypted);
     REALM_ASSERT(err == kCCSuccess);
     REALM_ASSERT(bytesEncrypted == block_size);
-    static_cast<void>(bytesEncrypted);
-    static_cast<void>(err);
 #else
     AES_cbc_encrypt(reinterpret_cast<const uint8_t*>(src), reinterpret_cast<uint8_t*>(dst),
                     block_size, mode == mode_Encrypt ? &m_ectx : &m_dctx, iv, mode);

--- a/src/realm/util/file_mapper.cpp
+++ b/src/realm/util/file_mapper.cpp
@@ -256,7 +256,6 @@ void* mmap(int fd, size_t size, File::AccessMode access, size_t offset, const ch
     else
 #else
     REALM_ASSERT(!encryption_key);
-    static_cast<void>(encryption_key);
 #endif
     {
         int prot = PROT_READ;

--- a/src/realm/util/network.cpp
+++ b/src/realm/util/network.cpp
@@ -883,7 +883,6 @@ void socket_base::do_close() noexcept
     // POSIX, but we shall assume it anyway). `EBADF`, however, would indicate
     // an implementation bug, so we don't want to ignore that.
     REALM_ASSERT(ret != -1 || errno != EBADF);
-    static_cast<void>(ret);
     m_sock_fd = -1;
 }
 

--- a/src/realm/util/thread.cpp
+++ b/src/realm/util/thread.cpp
@@ -130,7 +130,6 @@ void Mutex::init_as_process_shared(bool robust_if_available)
     r = pthread_mutex_init(&m_impl, &attr);
     int r2 = pthread_mutexattr_destroy(&attr);
     REALM_ASSERT(r2 == 0);
-    static_cast<void>(r2);
     if (REALM_UNLIKELY(r != 0))
         init_failed(r);
 #else // !REALM_HAVE_PTHREAD_PROCESS_SHARED
@@ -217,7 +216,6 @@ bool RobustMutex::is_valid() noexcept
     if (r == 0) {
         r = pthread_mutex_unlock(&m_impl);
         REALM_ASSERT(r == 0);
-        static_cast<void>(r);
         return true;
     }
     return r != EINVAL;
@@ -229,7 +227,6 @@ void RobustMutex::mark_as_consistent() noexcept
 #ifdef REALM_HAVE_ROBUST_PTHREAD_MUTEX
     int r = pthread_mutex_consistent(&m_impl);
     REALM_ASSERT(r == 0);
-    static_cast<void>(r);
 #endif
 }
 
@@ -247,7 +244,6 @@ CondVar::CondVar(process_shared_tag)
     r = pthread_cond_init(&m_impl, &attr);
     int r2 = pthread_condattr_destroy(&attr);
     REALM_ASSERT(r2 == 0);
-    static_cast<void>(r2);
     if (REALM_UNLIKELY(r != 0))
         init_failed(r);
 #else // !REALM_HAVE_PTHREAD_PROCESS_SHARED

--- a/src/realm/util/thread.hpp
+++ b/src/realm/util/thread.hpp
@@ -402,7 +402,6 @@ inline void Mutex::unlock() noexcept
 {
     int r = pthread_mutex_unlock(&m_impl);
     REALM_ASSERT(r == 0);
-    static_cast<void>(r);
 }
 
 
@@ -574,14 +573,12 @@ inline void CondVar::notify() noexcept
 {
     int r = pthread_cond_signal(&m_impl);
     REALM_ASSERT(r == 0);
-    static_cast<void>(r);
 }
 
 inline void CondVar::notify_all() noexcept
 {
     int r = pthread_cond_broadcast(&m_impl);
     REALM_ASSERT(r == 0);
-    static_cast<void>(r);
 }
 
 


### PR DESCRIPTION
I.e.,

```
REALM_ASSERT(foo);
```

now counts as a use of `foo`, even in release mode, so the annoying `static_cast<void>(foo)` is no longer needed in cases where `foo` is only used in an assertion.

@simonask @danielpovlsen
