### PR TITLE
Fix adding empty rows to table with search index

### DIFF
--- a/src/realm/column_timestamp.cpp
+++ b/src/realm/column_timestamp.cpp
@@ -100,20 +100,16 @@ void TimestampColumn::set_null(size_t row_ndx)
 void TimestampColumn::insert_rows(size_t row_ndx, size_t num_rows_to_insert, size_t /*prior_num_rows*/,
     bool nullable)
 {
-    size_t old_size = this->size();
-    if (row_ndx == old_size)
-        row_ndx = npos;
+    bool is_append = row_ndx == size();
+    size_t row_ndx_or_npos = is_append ? realm::npos : row_ndx;
 
     if (nullable)
-        m_seconds.insert(row_ndx, null{}, num_rows_to_insert);
+        m_seconds.insert(row_ndx_or_npos, null{}, num_rows_to_insert);
     else
-        m_seconds.insert(row_ndx, 0, num_rows_to_insert);
-    m_nanoseconds.insert(row_ndx, 0, num_rows_to_insert);
+        m_seconds.insert(row_ndx_or_npos, 0, num_rows_to_insert);
+    m_nanoseconds.insert(row_ndx_or_npos, 0, num_rows_to_insert);
 
     if (has_search_index()) {
-        bool is_append = row_ndx == npos || row_ndx == old_size;
-        if (is_append)
-            row_ndx = old_size;
         if (nullable) {
             m_search_index->insert(row_ndx, null{}, num_rows_to_insert, is_append);
         }

--- a/test/test_group.cpp
+++ b/test/test_group.cpp
@@ -2523,14 +2523,15 @@ TEST(Group_ToDot)
 #endif // REALM_TO_DOT
 #endif // REALM_DEBUG
 
-TEST(Group_TimestampAddAIndexAndThenInsertEmptyRows)
+TEST_TYPES(Group_TimestampAddAIndexAndThenInsertEmptyRows, std::true_type, std::false_type)
 {
+    constexpr bool nullable = TEST_TYPE::value;
     Group g;
-    g.add_table("");
-    g.get_table(0)->clear();
-    g.get_table(0)->insert_column(0, type_Timestamp, "",true);
-    { TableRef t = g.get_table(0); t->add_search_index(0); }
-    g.get_table(0)->add_empty_row(5);
+    TableRef table = g.add_table("");
+    table->insert_column(0, type_Timestamp, "", nullable);
+    table->add_search_index(0);
+    table->add_empty_row(5);
+    CHECK_EQUAL(table->size(), 5);
 }
 
 #endif // TEST_GROUP


### PR DESCRIPTION
Adding empty rows to a table would crash when you had already a search index.
Bug was found using the fuzz tester.

That is because the new size was used when as row_ndx when inserting into the index.

@danielpovlsen @rrrlasse Please review and let me know if I should change/ improve anything.
Thank you
