### PR TITLE
Handle both nullable and non-nullable DateTime columns.

### DIFF
--- a/src/realm/column_mixed.cpp
+++ b/src/realm/column_mixed.cpp
@@ -53,7 +53,7 @@ void MixedColumn::create(Allocator& alloc, ref_type ref, Table* table, size_t co
     // TimestampColumn is only there if needed
     if (top->size() >= 4) {
         ref_type timestamp_ref = top->get_as_ref(3);
-        m_timestamp.reset(new TimestampColumn(alloc, timestamp_ref)); // Throws
+        m_timestamp.reset(new TimestampColumn(alloc, timestamp_ref, false)); // Throws
         m_timestamp->set_parent(&*top, 3);
     }
 
@@ -86,8 +86,8 @@ void MixedColumn::ensure_timestamp_column()
     if (m_timestamp)
         return;
 
-    ref_type ref = TimestampColumn::create(m_array->get_alloc()); // Throws
-    m_timestamp.reset(new TimestampColumn(m_array->get_alloc(), ref)); // Throws
+    ref_type ref = TimestampColumn::create(m_array->get_alloc(), 0, false); // Throws
+    m_timestamp.reset(new TimestampColumn(m_array->get_alloc(), ref, false)); // Throws
     REALM_ASSERT_3(m_array->size(), ==, 3);
     m_array->add(ref); // Throws
     m_timestamp->set_parent(m_array.get(), 3);
@@ -298,6 +298,7 @@ void MixedColumn::set_binary(size_t ndx, BinaryData value)
 void MixedColumn::set_timestamp(size_t ndx, Timestamp value)
 {
     REALM_ASSERT_3(ndx, <, m_types->size());
+    REALM_ASSERT(!value.is_null());
     ensure_timestamp_column();
 
     MixedColType type = MixedColType(m_types->get(ndx));

--- a/src/realm/column_mixed_tpl.hpp
+++ b/src/realm/column_mixed_tpl.hpp
@@ -343,6 +343,7 @@ inline void MixedColumn::insert_datetime(size_t ndx, DateTime value)
 
 inline void MixedColumn::insert_timestamp(size_t ndx, Timestamp value)
 {
+    REALM_ASSERT(!value.is_null());
     ensure_timestamp_column();
     size_t data_ndx = m_timestamp->size();
     m_timestamp->add(value); // Throws

--- a/src/realm/column_timestamp.hpp
+++ b/src/realm/column_timestamp.hpp
@@ -62,10 +62,10 @@ inline std::basic_ostream<C, T>& operator<<(std::basic_ostream<C, T>& out, const
 // column type
 class TimestampColumn : public ColumnBaseSimple, public ColumnTemplate<Timestamp> {
 public:
-    TimestampColumn(Allocator& alloc, ref_type ref);
+    TimestampColumn(Allocator& alloc, ref_type ref, bool nullable);
     ~TimestampColumn() noexcept override;
 
-    static ref_type create(Allocator& alloc, size_t size = 0);
+    static ref_type create(Allocator& alloc, size_t size, bool nullable);
 
     /// Get the number of entries in this column. This operation is relatively
     /// slow.
@@ -117,17 +117,24 @@ public:
     size_t count(Timestamp) const;
 
     void erase(size_t ndx, bool is_last) {
-        m_seconds.erase(ndx, is_last);
+        if (m_nullable)
+            m_nullable_seconds.erase(ndx, is_last);
+        else
+            m_nonnullable_seconds.erase(ndx, is_last);
         m_nanoseconds.erase(ndx, is_last);
     }
 
     typedef Timestamp value_type;
 
 private:
-    BpTree<util::Optional<int64_t>> m_seconds;
+    BpTree<int64_t> m_nonnullable_seconds;
+    BpTree<util::Optional<int64_t>> m_nullable_seconds;
     BpTree<int64_t> m_nanoseconds;
+    bool m_nullable;
 
     std::unique_ptr<StringIndex> m_search_index;
+
+    template<class BT> class CreateHandler;
 };
 
 } // namespace realm

--- a/src/realm/table.cpp
+++ b/src/realm/table.cpp
@@ -1446,7 +1446,7 @@ ColumnBase* Table::create_column_accessor(ColumnType col_type, size_t col_ndx, s
             break;
         case col_type_Timestamp:
             // Origin table will be set by group after entire table has been created
-            col = new TimestampColumn(alloc, ref); // Throws
+            col = new TimestampColumn(alloc, ref, nullable); // Throws
             break;
         case col_type_Reserved4:
             // These have no function yet and are therefore unexpected.
@@ -2013,7 +2013,7 @@ ref_type Table::create_column(ColumnType col_type, size_t size, bool nullable, A
                 return IntegerColumn::create(alloc, Array::type_Normal, size); // Throws
             }
         case col_type_Timestamp:
-            return TimestampColumn::create(alloc, size); // Throws
+            return TimestampColumn::create(alloc, size, nullable); // Throws
         case col_type_Float:
             return FloatColumn::create(alloc, Array::type_Normal, size); // Throws
         case col_type_Double:

--- a/test/test_column_mixed.cpp
+++ b/test/test_column_mixed.cpp
@@ -224,7 +224,7 @@ TEST(MixedColumn_Timestamp)
     ref_type ref = MixedColumn::create(Allocator::get_default());
     MixedColumn c(Allocator::get_default(), ref, 0, 0);
 
-    c.insert_timestamp(0, Timestamp(null()));
+    c.insert_timestamp(0, Timestamp(0, 0));
     c.insert_timestamp(1, Timestamp(100, 200));
     c.insert_timestamp(2, Timestamp(0, 0)); // Should *not* equal null
     c.insert_timestamp(3, Timestamp(-1000, 0));
@@ -388,10 +388,8 @@ TEST(MixedColumn_Mixed)
     c.set_subtable(5, 0);
     c.set_float(6, 1.124f);
     c.set_double(7, 1234.124);
-    c.set_timestamp(8, Timestamp());
     CHECK_EQUAL(9, c.size());
 
-    CHECK_EQUAL(type_Timestamp, c.get_type(8));
     CHECK_EQUAL(type_Double, c.get_type(7));
     CHECK_EQUAL(type_Float,  c.get_type(6));
     CHECK_EQUAL(type_Table,  c.get_type(5));

--- a/test/test_column_timestamp.cpp
+++ b/test/test_column_timestamp.cpp
@@ -39,13 +39,14 @@ using namespace realm;
 // check-testcase` (or one of its friends) from the command line.
 
 
-TEST(TimestampColumn_Basic)
+TEST_TYPES(DateTimeColumn_Basic, std::true_type, std::false_type)
 {
-    ref_type ref = TimestampColumn::create(Allocator::get_default());
-    TimestampColumn c(Allocator::get_default(), ref);
+    const bool nullable = TEST_TYPE::value;
+    ref_type ref = TimestampColumn::create(Allocator::get_default(), 0, nullable);
+    TimestampColumn c(Allocator::get_default(), ref, nullable);
     c.add(Timestamp(123,123));
     Timestamp ts = c.get(0);
-    CHECK(ts == Timestamp(123, 123));
+    CHECK_EQUAL(ts, Timestamp(123, 123));
 }
 
 TEST(TimestampColumn_Basic_Nulls)
@@ -77,10 +78,11 @@ TEST(TimestampColumn_Relocate)
     }
 }
 
-TEST(TimestampColumn_Compare)
+TEST_TYPES(TimestampColumn_Compare, std::true_type, std::false_type)
 {
-    ref_type ref = TimestampColumn::create(Allocator::get_default());
-    TimestampColumn c(Allocator::get_default(), ref);
+    const bool nullable = TEST_TYPE::value;
+    ref_type ref = TimestampColumn::create(Allocator::get_default(), 0, nullable);
+    TimestampColumn c(Allocator::get_default(), ref, nullable);
 
     for (unsigned int i = 0; i < 10000; i++) {
         c.add(Timestamp(i, i));
@@ -89,16 +91,17 @@ TEST(TimestampColumn_Compare)
     CHECK(c.compare(c));
 
     {
-        ref_type ref = TimestampColumn::create(Allocator::get_default());
-        TimestampColumn c2(Allocator::get_default(), ref);
+        ref_type ref = TimestampColumn::create(Allocator::get_default(), 0, nullable);
+        TimestampColumn c2(Allocator::get_default(), ref, nullable);
         CHECK_NOT(c.compare(c2));
     }
 }
 
-TEST(TimestampColumn_Index)
+TEST_TYPES(TimestampColumn_Index, std::true_type, std::false_type)
 {
-    ref_type ref = TimestampColumn::create(Allocator::get_default());
-    TimestampColumn c(Allocator::get_default(), ref);
+    const bool nullable = TEST_TYPE::value;
+    ref_type ref = TimestampColumn::create(Allocator::get_default(), 0, nullable);
+    TimestampColumn c(Allocator::get_default(), ref, nullable);
     StringIndex* index = c.create_search_index();
     CHECK(index);
 
@@ -114,18 +117,20 @@ TEST(TimestampColumn_Index)
     c.destroy();
 }
 
-TEST(TimestampColumn_Is_Nullable)
+TEST_TYPES(TimestampColumn_Is_Nullable, std::true_type, std::false_type)
 {
-    ref_type ref = TimestampColumn::create(Allocator::get_default());
-    TimestampColumn c(Allocator::get_default(), ref);
-    CHECK(c.is_nullable());
+    const bool nullable = TEST_TYPE::value;
+    ref_type ref = TimestampColumn::create(Allocator::get_default(), 0, nullable);
+    TimestampColumn c(Allocator::get_default(), ref, nullable);
+    CHECK_EQUAL(c.is_nullable(), nullable);
     c.destroy();
 }
 
 TEST(TimestampColumn_Set_Null_With_Index)
 {
-    ref_type ref = TimestampColumn::create(Allocator::get_default());
-    TimestampColumn c(Allocator::get_default(), ref);
+    const bool nullable = true;
+    ref_type ref = TimestampColumn::create(Allocator::get_default(), 0, nullable);
+    TimestampColumn c(Allocator::get_default(), ref, nullable);
     c.add(Timestamp{1, 1});
     CHECK(!c.is_null(0));
 
@@ -139,17 +144,18 @@ TEST(TimestampColumn_Set_Null_With_Index)
     c.destroy();
 }
 
-TEST(TimestampColumn_Insert_Rows_With_Index)
+TEST_TYPES(TimestampColumn_Insert_Rows_With_Index, std::true_type, std::false_type)
 {
-    ref_type ref = TimestampColumn::create(Allocator::get_default());
-    TimestampColumn c(Allocator::get_default(), ref);
+    const bool nullable = TEST_TYPE::value;
+    ref_type ref = TimestampColumn::create(Allocator::get_default(), 0, nullable);
+    TimestampColumn c(Allocator::get_default(), ref, nullable);
 
     StringIndex* index = c.create_search_index();
     CHECK(index);
 
-    c.insert_rows(0, 1, 0, true);
+    c.insert_rows(0, 1, 0, nullable);
     c.set(0, Timestamp{1, 1});
-    c.insert_rows(1, 1, 1, true);
+    c.insert_rows(1, 1, 1, nullable);
 
     c.destroy_search_index();
     c.destroy();
@@ -157,8 +163,9 @@ TEST(TimestampColumn_Insert_Rows_With_Index)
 
 TEST(TimestampColumn_Move_Last_Over)
 {
-    ref_type ref = TimestampColumn::create(Allocator::get_default());
-    TimestampColumn c(Allocator::get_default(), ref);
+    const bool nullable = true;
+    ref_type ref = TimestampColumn::create(Allocator::get_default(), 0, nullable);
+    TimestampColumn c(Allocator::get_default(), ref, nullable);
     StringIndex* index = c.create_search_index();
     CHECK(index);
 
@@ -173,10 +180,11 @@ TEST(TimestampColumn_Move_Last_Over)
     c.destroy();
 }
 
-TEST(TimestampColumn_Clear)
+TEST_TYPES(TimestampColumn_Clear, std::true_type, std::false_type)
 {
-    ref_type ref = TimestampColumn::create(Allocator::get_default());
-    TimestampColumn c(Allocator::get_default(), ref);
+    const bool nullable = TEST_TYPE::value;
+    ref_type ref = TimestampColumn::create(Allocator::get_default(), 0, nullable);
+    TimestampColumn c(Allocator::get_default(), ref, nullable);
     StringIndex* index = c.create_search_index();
     CHECK(index);
 
@@ -192,10 +200,11 @@ TEST(TimestampColumn_Clear)
     c.destroy();
 }
 
-TEST(TimestampColumn_SwapRows)
+TEST_TYPES(TimestampColumn_SwapRows, std::true_type, std::false_type)
 {
-    ref_type ref = TimestampColumn::create(Allocator::get_default());
-    TimestampColumn c(Allocator::get_default(), ref);
+    const bool nullable = TEST_TYPE::value;
+    ref_type ref = TimestampColumn::create(Allocator::get_default(), 0, nullable);
+    TimestampColumn c(Allocator::get_default(), ref, nullable);
     StringIndex* index = c.create_search_index();
     CHECK(index);
 


### PR DESCRIPTION
This does the following:
- Remove the abillity of NewDates in MixedColumn to be NULL.
- Attach different "seconds" accessor depending on whether or not the datetime column should be nullable.
