### PR TITLE
Breaking unit test with continuous transactions (and Timestamps)

### DIFF
--- a/test/test_shared.cpp
+++ b/test/test_shared.cpp
@@ -3011,5 +3011,27 @@ TEST(Shared_StaticFuzzTestRunSanityCheck)
     }
 }
 
+#include <realm/lang_bind_helper.hpp>
+#include <realm/commit_log.hpp>
+
+TEST_TYPES(SharedGroup_EmptyWrites, std::true_type, std::false_type)
+{
+    constexpr bool nullable = TEST_TYPE::value;
+    SHARED_GROUP_TEST_PATH(path);
+    std::unique_ptr<Replication> hist_w(make_client_history(path, nullptr));
+    SharedGroup sg_w(*hist_w, SharedGroup::durability_Full, nullptr);
+    Group& g = const_cast<Group&>(sg_w.begin_read());
+    LangBindHelper::promote_to_write(sg_w);
+
+    TableRef t = g.add_table("");
+    t->add_column(DataType(8), "", nullable);
+
+    for (int i = 0; i < 27; ++i) {
+        LangBindHelper::commit_and_continue_as_read(sg_w);
+        LangBindHelper::promote_to_write(sg_w);
+    }
+
+    t->insert_empty_row(0, 1);
+}
 
 #endif // TEST_SHARED


### PR DESCRIPTION
@radu-tutueanu found this bug with AFL and I reduced it a bit.

Could you take a look and confirm that what we are doing in this test should work?

Any deeper input is also welcome.

@finnschiermer @kspangsege @rrrlasse
