### PR TITLE
Fix delete rows, first delete the index

### DIFF
--- a/src/realm/column_timestamp.cpp
+++ b/src/realm/column_timestamp.cpp
@@ -148,12 +148,12 @@ void TimestampColumn::erase_rows(size_t row_ndx, size_t num_rows_to_erase, size_
 {
     bool is_last = (row_ndx + num_rows_to_erase) == size();
     for (size_t i = 0; i < num_rows_to_erase; ++i) {
-        m_seconds->erase(row_ndx + num_rows_to_erase - i - 1, is_last);
-        m_nanoseconds->erase(row_ndx + num_rows_to_erase - i - 1, is_last);
-        
         if (has_search_index()) {
             m_search_index->erase<StringData>(row_ndx + num_rows_to_erase - i - 1, is_last);
         }
+
+        m_seconds->erase(row_ndx + num_rows_to_erase - i - 1, is_last);
+        m_nanoseconds->erase(row_ndx + num_rows_to_erase - i - 1, is_last);
     }
 }
 

--- a/test/test_column_timestamp.cpp
+++ b/test/test_column_timestamp.cpp
@@ -217,4 +217,21 @@ TEST(TimestampColumn_SwapRows)
 
 }
 
+TEST(TimestampColumn_DeleteWithIndex)
+{
+    ref_type ref = TimestampColumn::create(Allocator::get_default());
+    TimestampColumn c(Allocator::get_default(), ref);
+    StringIndex* index = c.create_search_index();
+    CHECK(index);
+
+
+    c.add(Timestamp{2, 2});
+    c.erase_rows(0, 1, 1, false);
+    CHECK_EQUAL(c.size(), 0);
+
+    c.destroy_search_index();
+    c.destroy();
+
+}
+
 #endif // TEST_COLUMN_TIMESTAMP


### PR DESCRIPTION
Fix delete_rows by deleting the index first, because the index deletion accesses the value.
Also added a unit test for this case.

@rrrlasse @danielpovlsen What do you think?
