### PR TITLE
Networking: Expose SO_LINGER option

### DIFF
--- a/src/realm/util/network.cpp
+++ b/src/realm/util/network.cpp
@@ -928,6 +928,16 @@ void socket_base::map_option(opt_enum opt, int& level, int& option_name) const
             level       = SOL_SOCKET;
             option_name = SO_REUSEADDR;
             return;
+        case opt_Linger:
+            level       = SOL_SOCKET;
+#if REALM_PLATFORM_APPLE
+            // By default, SO_LINGER on Darwin uses "ticks" instead of
+            // seconds for better accuracy, but we want to be cross-platform.
+            option_name = SO_LINGER_SEC;
+#else
+            option_name = SO_LINGER;
+#endif // REALM_PLATFORM_APPLE
+            return;
     }
     REALM_ASSERT(false);
 }

--- a/src/realm/util/network.hpp
+++ b/src/realm/util/network.hpp
@@ -411,13 +411,18 @@ public:
 
 private:
     enum opt_enum {
-        opt_ReuseAddr ///< `SOL_SOCKET`, `SO_REUSEADDR`
+        opt_ReuseAddr, ///< `SOL_SOCKET`, `SO_REUSEADDR`
+        opt_Linger,    ///< `SOL_SOCKET`, `SO_LINGER`
     };
 
     template<class, int, class> class option;
 
 public:
     typedef option<bool, opt_ReuseAddr, int> reuse_address;
+
+    // linger struct defined by POSIX sys/socket.h.
+    struct linger_opt;
+    typedef option<linger_opt, opt_Linger, struct linger> linger;
 
 private:
     int m_sock_fd;
@@ -463,6 +468,21 @@ private:
     void set(socket_base&, std::error_code&) const;
 
     friend class socket_base;
+};
+
+struct socket_base::linger_opt {
+    linger_opt(bool enabled, int timeout_seconds = 0)
+    {
+        m_linger.l_onoff = enabled ? 1 : 0;
+        m_linger.l_linger = timeout_seconds;
+    }
+
+    ::linger m_linger;
+
+    operator ::linger() const { return m_linger; }
+
+    bool enabled() const { return m_linger.l_onoff != 0; }
+    int  timeout() const { return m_linger.l_linger; }
 };
 
 


### PR DESCRIPTION
@kspangsege What do you think of this? It seems necessary to do this to avoid having the kernel discard data that has been written to the socket by the server process but not yet transmitted over the network. In theory, though, the impact of this should be minimal, because we're using nonblocking mode, but it's up to the kernel.

The background for introducing this change is to ensure that error messages are not partially discarded.
