### PR TITLE
Fix timestamp set, update index first.

### DIFF
--- a/src/realm/column_timestamp.cpp
+++ b/src/realm/column_timestamp.cpp
@@ -345,12 +345,13 @@ void TimestampColumn::set(size_t row_ndx, const Timestamp& ts)
     bool is_null = ts.is_null();
     util::Optional<int64_t> seconds = is_null ? util::none : util::make_optional(ts.m_seconds);
     int32_t nanoseconds = is_null ? 0 : ts.m_nanoseconds;
-    m_seconds->set(row_ndx, seconds);
-    m_nanoseconds->set(row_ndx, nanoseconds);
 
     if (has_search_index()) {
         m_search_index->set(row_ndx, ts);
     }
+
+    m_seconds->set(row_ndx, seconds);
+    m_nanoseconds->set(row_ndx, nanoseconds);
 }
 
 bool TimestampColumn::compare(const TimestampColumn& c) const noexcept

--- a/test/test_column_timestamp.cpp
+++ b/test/test_column_timestamp.cpp
@@ -234,4 +234,20 @@ TEST(TimestampColumn_DeleteWithIndex)
 
 }
 
+TEST(TimestampColumn_DeleteAfterSetWithIndex)
+{
+    ref_type ref = TimestampColumn::create(Allocator::get_default());
+    TimestampColumn c(Allocator::get_default(), ref);
+    StringIndex* index = c.create_search_index();
+    CHECK(index);
+
+    c.add(Timestamp{1, 1});
+    c.set(0,Timestamp{2, 2});
+    c.erase_rows(0, 1, 1, false);
+    CHECK_EQUAL(c.size(), 0);
+
+    c.destroy_search_index();
+    c.destroy();
+}
+
 #endif // TEST_COLUMN_TIMESTAMP


### PR DESCRIPTION
Fix timestamp set, update index first. StringIndex::set checks if the new value is different than the previous one.
Added a test for this case.

@danielpovlsen @rrrlasse WDYT?
