### PR TITLE
Update OpenSSL to 1.0.1s

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -216,7 +216,7 @@ download_openssl()
     fi
 
     echo 'Downloading OpenSSL...'
-    openssl_ver='1.0.1p'
+    openssl_ver='1.0.1s'
     curl -L -s "http://www.openssl.org/source/openssl-${openssl_ver}.tar.gz" -o openssl.tar.gz || return 1
     tar -xzf openssl.tar.gz || return 1
     mv openssl-$openssl_ver openssl || return 1
@@ -848,12 +848,12 @@ EOF
                              no-rc2 no-rc4 no-rc5 no-md2 no-md4 no-ripemd \
                              no-mdc2 no-rsa no-dsa no-dh no-ec no-ecdsa no-ecdh \
                              no-sock no-ssl2 no-ssl3 no-err no-krb5 no-engine \
-                             no-srtp no-speed -DOPENSSL_NO_SHA512 \
+                             no-srtp no-speed no-hmac no-rand  -DOPENSSL_NO_SHA512 \
                              -DOPENSSL_NO_SHA0 -w -fPIC || exit 1
                     $MAKE clean
                 ) || exit 1
 
-                PATH="$path" CC="$cc" CFLAGS="$cflags_arch" $MAKE -C "openssl" build_crypto|| exit 1
+                PATH="$path" CC="$cc" CFLAGS="$cflags_arch" PERL="perl" $MAKE -C "openssl/crypto" ../libcrypto.a || exit 1
                 cp "openssl/libcrypto.a" "$ANDROID_DIR/$libcrypto_name" || exit 1
             fi
 

--- a/release_notes.md
+++ b/release_notes.md
@@ -43,6 +43,7 @@
   (`util::Logger`) is now directly available to each unit test.
 * New unit tests: `Network_CancelEmptyWrite`, `Network_ThrowFromHandlers`.
 * New failure simulation features: Ability to prime for random triggering.
+* Upgraded OpenSSL to 1.0.1s (Android).
 
 ----------------------------------------------
 


### PR DESCRIPTION
Now with the required changes to actually build. Disabling components via `Configure` officially requires running `make depend` afterwards, but `makedepend` doesn't actually work on my machine, so I instead shifted the `make` command to be more specific about what exactly to build.
