### PR TITLE
Remove C++03 move emulation from BasicTableRef and bind_ptr

### DIFF
--- a/src/realm/descriptor.cpp
+++ b/src/realm/descriptor.cpp
@@ -29,7 +29,7 @@ DescriptorRef Descriptor::get_subdescriptor(size_t column_ndx)
     }
 
   out:
-    return move(subdesc);
+    return subdesc;
 }
 
 

--- a/src/realm/table.cpp
+++ b/src/realm/table.cpp
@@ -416,7 +416,7 @@ DescriptorRef Table::get_descriptor()
     else {
         desc.reset(m_descriptor);
     }
-    return move(desc);
+    return desc;
 }
 
 

--- a/src/realm/table_basic.hpp
+++ b/src/realm/table_basic.hpp
@@ -693,7 +693,7 @@ inline typename BasicTable<Spec>::Ref BasicTable<Spec>::create(Allocator& alloc)
 {
     TableRef table = Table::create(alloc);
     set_dynamic_type(*table);
-    return unchecked_cast<BasicTable<Spec>>(move(table));
+    return unchecked_cast<BasicTable<Spec>>(std::move(table));
 }
 
 

--- a/src/realm/table_ref.hpp
+++ b/src/realm/table_ref.hpp
@@ -122,14 +122,6 @@ class BasicTable;
 /// \endcode
 ///
 ///
-/// This class provides a form of move semantics that is compatible
-/// with C++03. It is similar to, but not as powerful as what is
-/// provided natively by C++11. Instead of using `std::move()` (in
-/// C++11), one must use `move()` without qualification. This will
-/// call a special function that is a friend of this class. The
-/// effectiveness of this form of move semantics relies on 'return
-/// value optimization' being enabled in the compiler.
-///
 /// \sa Table
 /// \sa TableRef
 template<class T>
@@ -159,12 +151,6 @@ public:
     BasicTableRef& operator=(BasicTableRef&&) noexcept;
     template<class U>
     BasicTableRef& operator=(BasicTableRef<U>&&) noexcept;
-
-    // Replacement for std::move() in C++03
-    friend BasicTableRef move(BasicTableRef& r) noexcept
-    {
-        return BasicTableRef(&r, move_tag());
-    }
 
     //@{
     /// Comparison
@@ -259,10 +245,6 @@ private:
     friend class BasicTableRef;
 
     explicit BasicTableRef(T* t) noexcept: util::bind_ptr<T>(t) {}
-
-    typedef typename util::bind_ptr<T>::move_tag move_tag;
-    BasicTableRef(BasicTableRef* r, move_tag) noexcept:
-        util::bind_ptr<T>(r, move_tag()) {}
 
     typedef typename util::bind_ptr<T>::casting_move_tag casting_move_tag;
     template<class U>

--- a/src/realm/table_view.hpp
+++ b/src/realm/table_view.hpp
@@ -859,8 +859,8 @@ inline TableViewBase::TableViewBase(const TableViewBase& tv):
 
 inline TableViewBase::TableViewBase(TableViewBase&& tv) noexcept:
     RowIndexes(std::move(tv.m_row_indexes)),
-    m_table(move(tv.m_table)),
-    m_linked_table(move(tv.m_linked_table)),
+    m_table(std::move(tv.m_table)),
+    m_linked_table(std::move(tv.m_linked_table)),
     m_linked_column(tv.m_linked_column),
     m_linked_row(tv.m_linked_row),
     m_linkview_source(std::move(tv.m_linkview_source)),
@@ -894,7 +894,7 @@ inline TableViewBase& TableViewBase::operator=(TableViewBase&& tv) noexcept
 {
     if (m_table)
         m_table->unregister_view(this);
-    m_table = move(tv.m_table);
+    m_table = std::move(tv.m_table);
     if (m_table)
         m_table->move_registered_view(&tv, this);
 

--- a/src/realm/util/bind_ptr.hpp
+++ b/src/realm/util/bind_ptr.hpp
@@ -38,14 +38,6 @@ namespace util {
 /// object, but a common use is 'reference counting'. See RefCountBase
 /// for an example of that.
 ///
-/// This class provides a form of move semantics that is compatible
-/// with C++03. It is similar to, but not as powerful as what is
-/// provided natively by C++11. Instead of using `std::move()` (in
-/// C++11), one must use `move()` without qualification. This will
-/// call a special function that is a friend of this class. The
-/// effectiveness of this form of move semantics relies on 'return
-/// value optimization' being enabled in the compiler.
-///
 /// This smart pointer implementation assumes that the target object
 /// destructor never throws.
 template<class T>
@@ -76,9 +68,6 @@ public:
     bind_ptr& operator=(bind_ptr&& p) noexcept { bind_ptr(std::move(p)).swap(*this); return *this; }
     template<class U>
     bind_ptr& operator=(bind_ptr<U>&& p) noexcept { bind_ptr(std::move(p)).swap(*this); return *this; }
-
-    // Replacement for std::move() in C++11
-    friend bind_ptr move(bind_ptr& p) noexcept { return bind_ptr(&p, move_tag()); }
 
     //@{
     // Comparison
@@ -135,9 +124,6 @@ public:
     friend void swap(bind_ptr& a, bind_ptr& b) noexcept { a.swap(b); }
 
 protected:
-    struct move_tag {};
-    bind_ptr(bind_ptr* p, move_tag) noexcept: m_ptr(p->release()) {}
-
     struct casting_move_tag {};
     template<class U>
     bind_ptr(bind_ptr<U>* p, casting_move_tag) noexcept:


### PR DESCRIPTION
Now that we require C++11 we always have real move semantics.

Some confusion between when to use `move` vs `std::move` was mentioned in #1641. Eliminating `move` removes the potential for confusion.

/cc @rrrlasse @ironage @kspangsege
