### PR TITLE
group operator== checks table names.

### DIFF
--- a/src/realm/group.cpp
+++ b/src/realm/group.cpp
@@ -983,6 +983,11 @@ bool Group::operator==(const Group& g) const
     if (n != g.size())
         return false;
     for (size_t i = 0; i < n; ++i) {
+        const StringData& table_name_1 = get_table_name(i); // Throws
+        const StringData& table_name_2 = g.get_table_name(i); // Throws
+        if (table_name_1 != table_name_2)
+            return false;
+
         ConstTableRef table_1 = get_table(i); // Throws
         ConstTableRef table_2 = g.get_table(i); // Throws
         if (*table_1 != *table_2)

--- a/src/realm/group.hpp
+++ b/src/realm/group.hpp
@@ -524,6 +524,7 @@ public:
     /// only if, they contain the same tables in the same order, that
     /// is, for each table T at index I in one of the groups, there is
     /// a table at index I in the other group that is equal to T.
+    /// Tables are equal if they have the same content and the same table name.
     bool operator==(const Group&) const;
 
     /// Compare two groups for inequality. See operator==().

--- a/test/test_group.cpp
+++ b/test/test_group.cpp
@@ -924,7 +924,7 @@ void setup_table(TestTableGroup::Ref t)
 
 TEST(Group_Equal)
 {
-    Group g1, g2;
+    Group g1, g2, g3;
     CHECK(g1 == g2);
     TestTableGroup::Ref t1 = g1.add_table<TestTableGroup>("TABLE1");
     CHECK_NOT(g1 == g2);
@@ -934,6 +934,9 @@ TEST(Group_Equal)
     CHECK(g1 == g2);
     t2->add("hey", 2, false, Thu);
     CHECK(g1 != g2);
+    TestTableGroup::Ref t3 = g3.add_table<TestTableGroup>("TABLE3");
+    setup_table(t3);
+    CHECK(g1 != g3);
 }
 
 


### PR DESCRIPTION
Currently "group operator==" checks that the content of the tables are equal
but not the table names.

Work done:
group operator== has been changed to check for table names.
Unit tests to detect the issue and verify the solution.
