### PR TITLE
Don't build i386 for OS X

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -345,7 +345,7 @@ find_apple_sdks()
             elif [ "$x" = "appletvos" ]; then
                 archs="arm64"
             elif [ "$x" = "macosx" ]; then
-                archs="i386,x86_64"
+                archs="x86_64"
             else
                 continue
             fi


### PR DESCRIPTION
We don't support it in the Cocoa binding (it uses an older version of the obj-c runtime that doesn't support most of the features added in the last decade or so), so building it is just a waste of time.
