### PR TITLE
Lock the write log header file rather than creating a separate lockfile

### DIFF
--- a/src/realm/commit_log.cpp
+++ b/src/realm/commit_log.cpp
@@ -325,8 +325,8 @@ inline void WriteLogCollector::map_header_if_needed() const
     if (m_header.is_attached() == false) {
         File header_file(m_header_name, File::mode_Update);
         m_header.map(header_file, File::access_ReadWrite, sizeof (CommitLogHeader));
+        m_lock.set_shared_part(m_header.get_addr()->shared_part_of_lock, std::move(header_file));
     }
-    m_lock.set_shared_part(m_header.get_addr()->shared_part_of_lock, m_header_name, "0");
 }
 
 
@@ -405,7 +405,7 @@ void WriteLogCollector::reset_header()
     if (!disable_sync)
         header_file.sync(); // Throws
     m_header.map(header_file, File::access_ReadWrite, sizeof (CommitLogHeader));
-    m_lock.set_shared_part(m_header.get_addr()->shared_part_of_lock, m_header_name, "0");
+    m_lock.set_shared_part(m_header.get_addr()->shared_part_of_lock, std::move(header_file));
 }
 
 

--- a/src/realm/util/interprocess_mutex.hpp
+++ b/src/realm/util/interprocess_mutex.hpp
@@ -60,7 +60,8 @@ public:
     /// You need to bind the emulation to a SharedPart in shared/mmapped memory.
     /// The SharedPart is assumed to have been initialized (possibly by another process)
     /// elsewhere.
-    void set_shared_part(SharedPart& shared_part, std::string path, std::string mutex_name);
+    void set_shared_part(SharedPart& shared_part, const std::string& path, const std::string& mutex_name);
+    void set_shared_part(SharedPart& shared_part, File&& lock_file);
 
     /// Destroy shared object. Potentially release system resources. Caller must
     /// ensure that the shared_part is not in use at the point of call.
@@ -109,8 +110,8 @@ inline InterprocessMutex::~InterprocessMutex() noexcept
 }
 
 inline void InterprocessMutex::set_shared_part(SharedPart& shared_part,
-                                                 std::string path,
-                                                 std::string mutex_name)
+                                               const std::string& path,
+                                               const std::string& mutex_name)
 {
 #ifdef REALM_ROBUST_MUTEX_EMULATION
     static_cast<void>(shared_part);
@@ -124,14 +125,31 @@ inline void InterprocessMutex::set_shared_part(SharedPart& shared_part,
     m_shared_part = &shared_part;
     static_cast<void>(path);
     static_cast<void>(mutex_name);
+#endif
+}
 
+inline void InterprocessMutex::set_shared_part(SharedPart& shared_part,
+                                               File&& lock_file)
+{
+#ifdef REALM_ROBUST_MUTEX_EMULATION
+    static_cast<void>(shared_part);
+    if (m_file.is_attached()) {
+        m_file.close();
+    }
+    m_filename.clear();
+    std::lock_guard<Mutex> guard(m_local_mutex);
+    m_file = std::move(lock_file);
+#else
+    m_shared_part = &shared_part;
+    static_cast<void>(lock_file);
 #endif
 }
 
 inline void InterprocessMutex::release_shared_part()
 {
 #ifdef REALM_ROBUST_MUTEX_EMULATION
-    File::try_remove(m_filename);
+    if (!m_filename.empty())
+        File::try_remove(m_filename);
 #else
     m_shared_part = nullptr;
 #endif


### PR DESCRIPTION
Unlike with the main lockfile, nothing else is locking WriteLogCollector's header file, so we can use that as the file for the InterprocessMutex rather than creating a new one.

This fixes a performance regression introduced in #1446, which more than doubled the time required to commit small transactions due to all of the extra `open()` calls introduced. No release notes entry since #1446 has not yet been included in a release.

@finnschiermer
