### PR TITLE
Removed implicit conversion from int to realm::null

### DIFF
--- a/src/realm/null.hpp
+++ b/src/realm/null.hpp
@@ -57,7 +57,6 @@ The `S` bit is at position 22 (float) or 51 (double).
 */
 
 struct null {
-    null(int) {}
     null() {}
     operator int64_t() { throw(LogicError::type_mismatch); }
     template<class T>


### PR DESCRIPTION
as it too magic. E.g. `add_condition<Equal>(column_ndx, 42 /* == null{}*/);`.

Please review @rrrlasse @simonask

Fixes #1691
