### PR TITLE
Fix a bug in TableView handover

### DIFF
--- a/src/realm/table_view.cpp
+++ b/src/realm/table_view.cpp
@@ -36,10 +36,13 @@ TableViewBase::TableViewBase(TableViewBase& src, HandoverPatch& patch,
       m_linked_table(TableRef()),
       m_linked_column(src.m_linked_column),
       m_linked_row(src.m_linked_row),
-      m_linkview_source(LinkViewRef()),
-      m_query(src.m_query, patch.query_patch, mode)
+      m_linkview_source(LinkViewRef())
 {
     patch.was_in_sync = src.is_in_sync();
+    // m_query must be exported after patch.was_in_sync is updated
+    // as exporting m_query will bring src out of sync.
+    m_query = Query(src.m_query, patch.query_patch, mode);
+
     Table::generate_patch(src.m_table, patch.m_table);
     Table::generate_patch(src.m_linked_table, patch.linked_table);
     patch.linked_column = src.m_linked_column;


### PR DESCRIPTION
Handing over an in-sync `TableView` based on a `Query` that is restricted to a `TableView` should result in a `TableView` that is also in-sync.

The order of operations performed within `TableViewBase`'s handover constructor was resulting in the source `TableView` falling out of sync before it could be queried to populate the `was_in_sync` flag of the handover patch. This happened due to `is_in_sync()` depending on the source `TableView` being intact, while the `Query` handover constructor had handed over any restricting `TableView` and invalidated it in the process.

We fix this by populating the `was_in_sync` flag before handing over the `Query`.

/cc @finnschiermer 

This is needed for Cocoa's backlinks feature (realm/realm-cocoa#3419).
