### PR TITLE
Timestamp accessor safety

### DIFF
--- a/src/realm/timestamp.hpp
+++ b/src/realm/timestamp.hpp
@@ -37,11 +37,13 @@ struct Timestamp {
 
     int64_t get_seconds() const noexcept
     {
+        REALM_ASSERT(!m_is_null);
         return m_seconds;
     }
 
     uint32_t get_nanoseconds() const noexcept
     {
+        REALM_ASSERT(!m_is_null);
         return m_nanoseconds;
     }
 


### PR DESCRIPTION
Removed unnecessary, unused setters.

Added asserts on getters on null-values.

@rrrlasse @simonask @teotwaki 

Connects to #1476 
