### PR TITLE
Have `TableView` and `Query` expose whether their rows are guaranteed to be in table order

### DIFF
--- a/release_notes.md
+++ b/release_notes.md
@@ -12,7 +12,7 @@
 
 ### Enhancements:
 
-* Lorem ipsum.
+* TableView can now report whether its rows are guaranteed to be in table order.
 
 -----------
 

--- a/src/realm/query.hpp
+++ b/src/realm/query.hpp
@@ -275,6 +275,9 @@ public:
 
     TableRef& get_table() {return m_table;}
 
+    // True if matching rows are guaranteed to be returned in table order.
+    bool produces_results_in_table_order() const { return !m_view; }
+
     std::string validate();
 
 protected:

--- a/src/realm/table.cpp
+++ b/src/realm/table.cpp
@@ -4076,7 +4076,7 @@ void Table::aggregate(size_t group_by_column, size_t aggr_column, AggrType op, T
 
 TableView Table::get_range_view(size_t begin, size_t end)
 {
-    REALM_ASSERT(!m_columns.is_attached() || end < size());
+    REALM_ASSERT(!m_columns.is_attached() || end <= size());
 
     TableView ctv(*this);
     if (m_columns.is_attached()) {

--- a/src/realm/table_view.cpp
+++ b/src/realm/table_view.cpp
@@ -809,3 +809,26 @@ void TableViewBase::do_sync()
 
     m_last_seen_version = outside_version();
 }
+
+bool TableViewBase::is_in_table_order() const
+{
+    if (!m_table) {
+        return false;
+    }
+    else if (m_linkview_source) {
+        return false;
+    }
+    else if (m_table && m_linked_table) {
+        return false;
+    }
+    else if (!m_query.m_table) {
+        // TableView originated from Table::find_all().
+        return !m_sorting_predicate;
+    }
+    else if (m_query.produces_results_in_table_order()) {
+        return !m_sorting_predicate;
+    }
+    else {
+        return false;
+    }
+}

--- a/src/realm/table_view.hpp
+++ b/src/realm/table_view.hpp
@@ -320,8 +320,11 @@ public:
     void distinct(size_t column);
     void distinct(std::vector<size_t> columns);
 
-    // Actual sorting facility is provided by the base class:
-    using RowIndexes::sort;
+    // Returns whether the rows are guaranteed to be in table order.
+    // This is true only of unsorted TableViews created from either:
+    // - Table::find_all()
+    // - Query::find_all() when the query is not restricted to a view.
+    bool is_in_table_order() const;
 
     virtual ~TableViewBase() noexcept;
 
@@ -336,6 +339,10 @@ protected:
     uint64_t outside_version() const;
 
     void do_sync();
+
+    // Actual sorting facility is provided by the base class:
+    using RowIndexes::sort;
+
     // Null if, and only if, the view is detached.
     mutable TableRef m_table;
 

--- a/src/realm/views.hpp
+++ b/src/realm/views.hpp
@@ -98,6 +98,8 @@ public:
             }
         }
 
+        explicit operator bool() const { return !m_column_indexes.empty(); }
+
         std::vector<size_t> m_column_indexes;
         std::vector<bool> m_ascending;
         std::vector<const ColumnTemplateBase*> m_columns;

--- a/test/test_table_view.cpp
+++ b/test/test_table_view.cpp
@@ -1870,4 +1870,60 @@ TEST(TableView_Distinct)
     CHECK(tv.get_string(0, 5).is_null());
 }
 
+TEST(TableView_IsInTableOrder)
+{
+    Group g;
+
+    TableRef source = g.add_table("source");
+    TableRef target = g.add_table("target");
+
+    size_t col_link = source->add_column_link(type_LinkList, "link", *target);
+    size_t col_name = source->add_column(type_String, "name");
+    size_t col_id = target->add_column(type_Int, "id");
+    target->add_search_index(col_id);
+
+    source->add_empty_row();
+    target->add_empty_row();
+
+    // Detached views are in table order.
+    TableView tv;
+    CHECK_EQUAL(false, tv.is_in_table_order());
+
+    // Queries not restricted by views are in table order.
+    tv = target->where().find_all();
+    CHECK_EQUAL(true, tv.is_in_table_order());
+
+    // Views that have a distinct filter remain in table order.
+    tv.distinct(col_id);
+    CHECK_EQUAL(true, tv.is_in_table_order());
+
+    // Views that are sorted are not guaranteed to be in table order.
+    tv.sort(col_id, true);
+    CHECK_EQUAL(false, tv.is_in_table_order());
+
+    // Queries restricted by views are not guaranteed to be in table order.
+    TableView restricting_view = target->where().equal(col_id, 0).find_all();
+    tv = target->where(&restricting_view).find_all();
+    CHECK_EQUAL(false, tv.is_in_table_order());
+
+    // Backlinks are not guaranteed to be in table order.
+    tv = target->get_backlink_view(0, source.get(), col_link);
+    CHECK_EQUAL(false, tv.is_in_table_order());
+
+    // Views derived from a LinkView are not guaranteed to be in table order.
+    LinkViewRef ll = source->get_linklist(col_link, 0);
+    tv = ll->get_sorted_view(col_name);
+    CHECK_EQUAL(false, tv.is_in_table_order());
+
+    // Views based directly on a table are in table order.
+    tv = target->get_range_view(0, 1);
+    CHECK_EQUAL(true, tv.is_in_table_order());
+    tv = target->get_distinct_view(col_id);
+    CHECK_EQUAL(true, tv.is_in_table_order());
+
+    // … unless sorted.
+    tv = target->get_sorted_view(col_id);
+    CHECK_EQUAL(false, tv.is_in_table_order());
+}
+
 #endif // TEST_TABLE_VIEW


### PR DESCRIPTION
The change calculation logic in Cocoa's fine-grained notifications has an optimization for rows guaranteed to be in table order, but knowing when this optimization can be activated requires tracking the source of each `TableView`. This is unnecessary given that a `TableView` itself already knows its source and therefore knows whether its rows are guaranteed to be in table order.

/cc @rrrlasse 

Required for realm/realm-cocoa#3419 as it allows backlinks to work with Cocoa's recently-added fine-grained notifications feature.
