### PR TITLE
Fix incorrect semantics when comparing a LinkList column with a Row using a query expression

### DIFF
--- a/src/realm/query_expression.hpp
+++ b/src/realm/query_expression.hpp
@@ -2019,17 +2019,22 @@ Query compare(const Subexpr2<Link>& left, const ConstRow& row)
         LinkMap link_map = column->link_map();
         REALM_ASSERT(link_map.target_table() == row.get_table() || !row.is_attached());
 #ifdef REALM_OLDQUERY_FALLBACK
-        if (link_map.m_link_columns.size() == 1 &&
-            (link_map.m_link_types[0] == col_type_Link || link_map.m_link_types[0] == col_type_LinkList)) {
-            const Table* t = column->get_base_table();
-            Query query(*t);
+        if (link_map.m_link_columns.size() == 1) {
+            // We can fall back to Query::links_to for != and == operations on links, but only
+            // for == on link lists. This is because negating query.links_to(…) is equivalent to
+            // to "ALL linklist != row" rather than the "ANY linklist != row" semantics we're after.
+            if (link_map.m_link_types[0] == col_type_Link ||
+                (link_map.m_link_types[0] == col_type_LinkList && std::is_same<Operator, Equal>::value)) {
+                const Table* t = column->get_base_table();
+                Query query(*t);
 
-            if (std::is_same<Operator, NotEqual>::value) {
-                // Negate the following `links_to`.
-                query.Not();
+                if (std::is_same<Operator, NotEqual>::value) {
+                    // Negate the following `links_to`.
+                    query.Not();
+                }
+                query.links_to(link_map.m_link_column_indexes[0], row);
+                return query;
             }
-            query.links_to(link_map.m_link_column_indexes[0], row);
-            return query;
         }
 #endif
     }

--- a/test/test_link_query_view.cpp
+++ b/test/test_link_query_view.cpp
@@ -652,13 +652,13 @@ TEST(LinkList_QueryFindLinkTarget)
     CHECK_TABLE_VIEW(tv, {});
 
     tv = (table1->column<LinkList>(col_link3) != table2->get(2)).find_all();
-    CHECK_TABLE_VIEW(tv, {0, 2});
+    CHECK_TABLE_VIEW(tv, {0, 1});
 
     tv = (table1->column<LinkList>(col_link3) != table2->get(1)).find_all();
-    CHECK_TABLE_VIEW(tv, {2});
+    CHECK_TABLE_VIEW(tv, {0, 1});
 
     tv = (table1->column<LinkList>(col_link3) != table2->get(3)).find_all();
-    CHECK_TABLE_VIEW(tv, {0, 1, 2});
+    CHECK_TABLE_VIEW(tv, {0, 1});
 }
 
 


### PR DESCRIPTION
The old query fallback path that attempts to take advantage of `Query::links_to`'s performance was being selected in cases where it has different semantics than we need. In particular, the sequence of `Query::Not` / `Query::links_to` on a link list column only matches rows where none of the links is equal to the row we're looking for. Comparisons against values from link lists are expected to match if any of the values fulfills the criteria.

This was noticed due to "failing" tests when run with `REALM_OLDQUERY_FALLBACK` disabled. The failing results were in fact the correct results, with the test having the wrong expectations.

/cc @rrrlasse
