### PR TITLE
Disabled unit test Thread_CondvarNotifyWakeup

### DIFF
--- a/test/test_thread.cpp
+++ b/test/test_thread.cpp
@@ -548,6 +548,8 @@ void wakeup_signaller(int* signal_state, InterprocessMutex* mutex, InterprocessC
     cv->notify_all();
 }
 
+/* FIXME: Disabled because of sporadic failures on Android, which makes CI results non-deterministic
+
 void waiter_with_count(bowl_of_stones_semaphore* feedback, int* wait_counter, 
                        InterprocessMutex* mutex, InterprocessCondVar* cv)
 {
@@ -558,6 +560,8 @@ void waiter_with_count(bowl_of_stones_semaphore* feedback, int* wait_counter,
     -- *wait_counter;
     feedback->add_stone();
 }
+
+*/
 
 void waiter(InterprocessMutex* mutex, InterprocessCondVar* cv)
 {
@@ -686,6 +690,8 @@ TEST(Thread_CondvarNotifyAllWakeup)
 }
 
 
+/* FIXME: Disabled because of sporadic failures on Android, which makes CI results non-deterministic
+
 // test that notify will wake up only a single thread, even if there
 // are many waiters:
 TEST(Thread_CondvarNotifyWakeup)
@@ -720,6 +726,7 @@ TEST(Thread_CondvarNotifyWakeup)
     changed.release_shared_part();
     mutex.release_shared_part();
 }
+*/
 
 #endif // _WIN32
 


### PR DESCRIPTION
because of sporadic failures on Android, which makes CI results non-deterministic

@finnschiermer @teotwaki 
