### PR TITLE
Expose a method to bring a Query's restricting view into sync with its underlying data source

### DIFF
--- a/release_notes.md
+++ b/release_notes.md
@@ -27,6 +27,8 @@
 ### Enhancements:
 
 * TableView can now report whether its rows are guaranteed to be in table order. (Issue #1712)
+* `Query::sync_view_if_needed()` allows for bringing a query's restricting view into sync with
+  its underlying data source.
 
 -----------
 

--- a/src/realm/link_view.cpp
+++ b/src/realm/link_view.cpp
@@ -418,6 +418,14 @@ void LinkView::repl_unselect() noexcept
         repl->on_link_list_destroyed(*this);
 }
 
+uint_fast64_t LinkView::sync_if_needed() const
+{
+    if (m_origin_table)
+        return m_origin_table->m_version;
+
+    return std::numeric_limits<uint_fast64_t>::max();
+}
+
 
 #ifdef REALM_DEBUG
 

--- a/src/realm/link_view.hpp
+++ b/src/realm/link_view.hpp
@@ -49,7 +49,7 @@ public:
     bool is_empty() const noexcept;
 
     /// This method will return 0 if the LinkView is detached (no assert).
-    size_t size() const noexcept;
+    size_t size() const noexcept override;
 
     bool operator==(const LinkView&) const noexcept;
     bool operator!=(const LinkView&) const noexcept;
@@ -100,7 +100,7 @@ public:
     /// returned.
     size_t find(size_t target_row_ndx, size_t start=0) const noexcept;
 
-    const ColumnBase& get_column_base(size_t index) const; // FIXME: `ColumnBase` is not part of the public API, so this function must be made private.
+    const ColumnBase& get_column_base(size_t index) const override; // FIXME: `ColumnBase` is not part of the public API, so this function must be made private.
     const Table& get_origin_table() const noexcept;
     Table& get_origin_table() noexcept;
 
@@ -108,6 +108,10 @@ public:
 
     const Table& get_target_table() const noexcept;
     Table& get_target_table() noexcept;
+
+    // No-op because LinkViews are always kept in sync.
+    uint_fast64_t sync_if_needed() const override;
+    bool is_in_sync() const override { return true; }
 
 private:
     struct ctor_cookie {};

--- a/src/realm/query.cpp
+++ b/src/realm/query.cpp
@@ -1493,6 +1493,17 @@ Query Query::operator!()
     return q;
 }
 
+util::Optional<uint_fast64_t> Query::sync_view_if_needed() const
+{
+    if (m_view)
+        return m_view->sync_if_needed();
+
+    if (m_table)
+        return m_table->get_version_counter();
+
+    return util::none;
+}
+
 QueryGroup::QueryGroup(const QueryGroup& other) :
     m_root_node(other.m_root_node ? other.m_root_node->clone() : nullptr),
     m_pending_not(other.m_pending_not), m_subtable_column(other.m_subtable_column), m_state(other.m_state)

--- a/src/realm/query.hpp
+++ b/src/realm/query.hpp
@@ -278,6 +278,11 @@ public:
     // True if matching rows are guaranteed to be returned in table order.
     bool produces_results_in_table_order() const { return !m_view; }
 
+    // Calls sync_if_needed on the restricting view, if present.
+    // Returns the current version of the table(s) this query depends on,
+    // or util::none if the query is not associated with a table.
+    util::Optional<uint_fast64_t> sync_view_if_needed() const;
+
     std::string validate();
 
 protected:

--- a/src/realm/views.hpp
+++ b/src/realm/views.hpp
@@ -45,8 +45,8 @@ public:
 
     virtual size_t size() const = 0;
 
-    // These two methods are overridden by TableView. They are no-ops for LinkView because sync'ed automatically
-    virtual uint_fast64_t sync_if_needed() const { return 0; }
+    // These two methods are overridden by TableView and LinkView.
+    virtual uint_fast64_t sync_if_needed() const = 0;
     virtual bool is_in_sync() const { return true; }
 
     void check_cookie() const

--- a/test/test_query.cpp
+++ b/test/test_query.cpp
@@ -8565,4 +8565,96 @@ TEST(Query_MoveDoesntDoubleDelete)
         q2 = std::move(q1);
     }
 }
+
+ONLY(Query_SyncViewIfNeeded)
+{
+    Group group;
+    TableRef source = group.add_table("source");
+    TableRef target = group.add_table("target");
+
+    size_t col_links = source->add_column_link(type_LinkList, "link", *target);
+    size_t col_id = target->add_column(type_Int, "id");
+
+    auto reset_table_contents = [&]{
+        source->clear();
+        target->clear();
+
+        for (size_t i = 0; i < 15; ++i) {
+            target->add_empty_row();
+            target->set_int(col_id, i, i);
+        }
+
+        source->add_empty_row();
+        LinkViewRef ll = source->get_linklist(col_links, 0);
+        for (size_t i = 6; i < 15; ++i) {
+            ll->add(i);
+        }
+    };
+
+    // Restricting TableView. Query::sync_view_if_needed() syncs the TableView if needed.
+    {
+        reset_table_contents();
+        TableView restricting_view = target->where().greater(col_id, 5).find_all();
+        Query q = target->where(&restricting_view).less(col_id, 10);
+
+        // Bring the view out of sync with the table.
+        target->set_int(col_id, 7, -7);
+        target->set_int(col_id, 8, -8);
+
+        // Verify that the query uses the view as-is.
+        CHECK_EQUAL(4, q.count());
+        CHECK_EQUAL(false, restricting_view.is_in_sync());
+
+        // And that syncing the query brings the view back into sync.
+        auto version = q.sync_view_if_needed();
+        CHECK_EQUAL(true, restricting_view.is_in_sync());
+        CHECK_EQUAL(2, q.count());
+        CHECK_EQUAL(version, target->get_version_counter());
+    }
+
+    // Restricting LinkView. Query::sync_view_if_needed() does nothing as LinkViews are always in sync.
+    {
+        reset_table_contents();
+        LinkViewRef restricting_view = source->get_linklist(col_links, 0);
+        Query q = target->where(restricting_view).less(col_id, 10);
+
+        // Modify the underlying table to remove rows from the LinkView.
+        target->move_last_over(7);
+        target->move_last_over(8);
+
+        // Verify that the view has remained in sync.
+        CHECK_EQUAL(true, restricting_view->is_in_sync());
+        CHECK_EQUAL(2, q.count());
+
+        // And that syncing the query does nothing.
+        auto version = q.sync_view_if_needed();
+        CHECK_EQUAL(true, restricting_view->is_in_sync());
+        CHECK_EQUAL(version, target->get_version_counter());
+        CHECK_EQUAL(2, q.count());
+    }
+
+    // No restricting view. Query::sync_view_if_needed() does nothing.
+    {
+        reset_table_contents();
+        Query q = target->where().greater(col_id, 5).less(col_id, 10);
+
+        target->set_int(col_id, 7, -7);
+        target->set_int(col_id, 8, -8);
+
+        CHECK_EQUAL(2, q.count());
+
+        auto version = q.sync_view_if_needed();
+        CHECK_EQUAL(version, target->get_version_counter());
+        CHECK_EQUAL(2, q.count());
+    }
+
+    // Query that is not associated with a Table. Query::sync_view_if_needed() does nothing.
+    {
+        reset_table_contents();
+        Query q;
+
+        auto version = q.sync_view_if_needed();
+        CHECK_EQUAL(bool(version), false);
+    }
+}
 #endif // TEST_QUERY


### PR DESCRIPTION
This is necessary for `Query` to provide up-to-date results (e.g., for `find_all` to always return a `TableView` that is in sync) when the caller is not aware which view the query is restricted to.

/cc @rrrlasse 

Required by realm/realm-cocoa#3419.
