### PR TITLE
benchmark

### DIFF
--- a/test/test_query.cpp
+++ b/test/test_query.cpp
@@ -8908,10 +8908,10 @@ ONLY(Query_TimestampBenchmark)
 
 
     timer.reset();
-    for (size_t u = 0; u < 100; u++)
+    for (size_t u = 0; u < 10000; u++)
         match = (table.column<Int>(2) == 0).find();
     CHECK(match == npos);
-    std::cerr << timer.get_elapsed_time() << "\n\n";
+    std::cerr << timer.get_elapsed_time() / 100 << "\n\n";
 
 
     timer.reset();
@@ -8929,10 +8929,10 @@ ONLY(Query_TimestampBenchmark)
 
 
     timer.reset();
-    for (size_t u = 0; u < 100; u++)
+    for (size_t u = 0; u < 10000; u++)
         match = (table.column<Int>(5) == 0).find();
     CHECK(match == npos);
-    std::cerr << timer.get_elapsed_time() << "\n";
+    std::cerr << timer.get_elapsed_time() / 100 << "\n";
 
 
 


### PR DESCRIPTION
@oleks (cc @kneth @bmunkholm )

I just made my own quick benchmark (testing Equal only) and I get different results:

Nullable:
0.562 - Timestamp
0.313 - DateTime
0.025 - Int

Non-nullable:
0.578 - Timestamp
0.188 - DateTime
0.00328 - Int

Your numbers show that TimeStamp is faster than DateTime while these show the opposite.

Anyway, just wanted to let you know.
