### PR TITLE
Fixes for https://github.com/realm/realm-core/pull/1762

### DIFF
--- a/release_notes.md
+++ b/release_notes.md
@@ -18,7 +18,7 @@
 
 ### API breaking changes:
 
-* Classes inheriting from class Replication must now provide an implementation of close().
+* Lorem ipsum.
 
 ### Enhancements:
 

--- a/src/realm/commit_log.cpp
+++ b/src/realm/commit_log.cpp
@@ -97,7 +97,7 @@ public:
     void do_abort_transact() noexcept override;
     void do_interrupt() noexcept override {};
     void do_clear_interrupt() noexcept override {};
-    void close() noexcept override;
+    void commit_log_close() noexcept override;
     void transact_log_reserve(size_t size, char** new_begin, char** new_end) override;
     void transact_log_append(const char* data, size_t size, char** new_begin, char** new_end) override;
     HistoryType get_history_type() const noexcept override;
@@ -409,7 +409,7 @@ void WriteLogCollector::reset_header()
     m_lock.set_shared_part(m_header.get_addr()->shared_part_of_lock, std::move(header_file));
 }
 
-void WriteLogCollector::close() noexcept
+void WriteLogCollector::commit_log_close() noexcept
 {
     m_header.unmap();
     m_log_a.map.unmap();

--- a/src/realm/group_shared.cpp
+++ b/src/realm/group_shared.cpp
@@ -744,7 +744,7 @@ void SharedGroup::do_open(const std::string& path, bool no_create_file, Durabili
 
     Replication::HistoryType history_type = Replication::hist_None;
     if (Replication* repl = m_group.get_replication()) {
-        repl->close();
+        repl->commit_log_close();
         history_type = repl->get_history_type();
     }
 
@@ -1226,7 +1226,7 @@ void SharedGroup::close() noexcept
     m_group.detach();
     using gf = _impl::GroupFriend;
     if (Replication* repl = gf::get_replication(m_group))
-        repl->close();
+        repl->commit_log_close();
 
     m_transact_stage = transact_Ready;
     SharedInfo* info = m_file_map.get_addr();

--- a/src/realm/history.cpp
+++ b/src/realm/history.cpp
@@ -27,11 +27,6 @@ public:
         _impl::InRealmHistory::initialize(sgf::get_group(sg)); // Throws
     }
 
-    void close() noexcept override
-    {
-        // No-op
-    }
-
     void initiate_session(version_type) override
     {
         // No-op

--- a/src/realm/replication.hpp
+++ b/src/realm/replication.hpp
@@ -91,7 +91,13 @@ public:
 
     /// Called by the associated SharedGroup to close any open files
     /// or release similar system resources.
-    virtual void close() noexcept = 0;
+    ///
+    /// This is a special purpose function that solves a problem that is
+    /// specific to the implementation available through <commit_log.hpp>. At
+    /// least for now, it is not to be considered a genuine part of the
+    /// Replication interface. The default implementation does nothing and other
+    /// implementations should not override this function.
+    virtual void commit_log_close() noexcept {}
 
     //@{
 

--- a/test/test_lang_bind_helper.cpp
+++ b/test/test_lang_bind_helper.cpp
@@ -140,11 +140,6 @@ public:
     {
     }
 
-    void close() noexcept override
-    {
-        // No-op
-    }
-
     void initiate_session(version_type) override
     {
         // No-op

--- a/test/test_replication.cpp
+++ b/test/test_replication.cpp
@@ -63,11 +63,6 @@ public:
         m_changesets.clear();
     }
 
-    void close() noexcept override
-    {
-        // No-op
-    }
-
     void initiate_session(version_type) override
     {
         // No-op


### PR DESCRIPTION
The introduction of `Replication::close()` broke sync compilation.

Since I could not figure out what generic role it plays in the Replication API, I chose to more clearly mark is a relevant only to the commit logs implementation, and give it an empty default implementation so as to not disturb other implementations for which the method is likely to never be relevant.

It may be that `close()` can acquire a more generic role as part of the Replication API in the future, but in that case it would have to be worked out carefully, and explained well. In particular, it would need to be explained in appropriate abstract terms when `SharedGroup` calls it, such that each implementation can decide what to do (if anything) when it is called.

@finnschiermer @simonask 
