### PR TITLE
Fix a use-after-free when adding columns

### DIFF
--- a/release_notes.md
+++ b/release_notes.md
@@ -2,7 +2,10 @@
 
 ### Bugfixes
 
-* Lorem ipsum.
+* Fix a use-after-free when using a column which was added to an existing table
+  with rows in the same transaction as it was added, which resulted in the
+  automatic migration from DateTime to Timestamp crashing with a stack overflow
+  in some circumstances.
 
 ### Breaking changes
 

--- a/src/realm/array_integer.cpp
+++ b/src/realm/array_integer.cpp
@@ -88,7 +88,7 @@ MemRef ArrayIntNull::create_array(Type type, bool context_flag, size_t size, val
         }
     }
     dg.release();
-    return r;
+    return arr.get_mem();
 }
 
 

--- a/test/test_column_timestamp.cpp
+++ b/test/test_column_timestamp.cpp
@@ -588,7 +588,9 @@ TEST(TimestampColumn_AddColumnAfterRows)
 
     Table t;
     t.add_column(type_Int, "1", non_nullable);
-    t.add_empty_row();
+    t.add_empty_row(REALM_MAX_BPNODE_SIZE * 2 + 1);
+    t.set_int(0, 0, 100);
+
     t.add_column(type_Timestamp, "2", non_nullable);
     t.add_column(type_Timestamp, "3", nullable);
     CHECK_EQUAL(t.get_timestamp(1, 0).get_seconds(), 0);


### PR DESCRIPTION
`arr.Array::set(0, null_value)` may reallocate `arr.m_data`, invalidating `r`, so the return value needs to be the updated `MemRef`.

The small modification to the unit test is enough to hit the problematic scenario, and while it usually ends up working by coincidence, ASan complains about it.

Fixes #1781. Fixes #1760.
