### PR TITLE
Callback after write transaction, assume callback does not throw.

### DIFF
--- a/src/realm/group_shared.cpp
+++ b/src/realm/group_shared.cpp
@@ -1454,16 +1454,10 @@ void SharedGroup::upgrade_file_format(bool allow_file_format_upgrade,
             // Note: The file format version stored in the Realm file will be
             // updated to the new file format version as part of the following
             // commit operation. This happens in GroupWriter::commit().
-            if (m_upgrade_callback) {
-                try {
-                    m_upgrade_callback(current_file_format_version_2, target_file_format_version); // Throws
-                }
-                catch(...) {
-                    rollback();
-                    throw;
-                }
-            }
             commit(); // Throws
+            if (m_upgrade_callback) {
+                m_upgrade_callback(current_file_format_version_2, target_file_format_version); // Should not throw
+            }
         }
         else {
             // If somebody else has already performed the upgrade, we still need

--- a/src/realm/group_shared.hpp
+++ b/src/realm/group_shared.hpp
@@ -141,9 +141,9 @@ public:
     };
 
     /// \brief Same as calling the corresponding version of open() on a instance
-    /// constructed in the unattached state. Exception safety note: if the
-    /// `upgrade_callback` throws, then the file will be closed properly and the
-    /// upgrade will be aborted.
+    /// constructed in the unattached state. Exception safety note: the
+    /// `upgrade_callback` should not throw, but if it does, the upgraded Realm
+    /// will be closed properly.
     explicit SharedGroup(const std::string& file, bool no_create = false,
                          DurabilityLevel durability = durability_Full,
                          const char* encryption_key = nullptr,
@@ -151,9 +151,9 @@ public:
                          std::function<void(int,int)> upgrade_callback = std::function<void(int,int)>());
 
     /// \brief Same as calling the corresponding version of open() on a instance
-    /// constructed in the unattached state. Exception safety note: if the
-    /// `upgrade_callback` throws, then the file will be closed properly and
-    /// the upgrade will be aborted.
+    /// constructed in the unattached state. Exception safety note: the
+    /// `upgrade_callback` should not throw, but if it does, the upgraded Realm
+    /// will be closed properly.
     explicit SharedGroup(Replication& repl,
                          DurabilityLevel durability = durability_Full,
                          const char* encryption_key = nullptr,

--- a/test/test_upgrade_database.cpp
+++ b/test/test_upgrade_database.cpp
@@ -883,7 +883,7 @@ TEST(Upgrade_DatabaseWithCallbackWithException)
         new_version = to;
     };
 
-    // Callback that throws should revert the upgrade
+    // Callback should be called here, upgrade should succeed and throw
     upgrade_callback = exception_callback;
     bool exception_thrown = false;
     try {
@@ -898,9 +898,8 @@ TEST(Upgrade_DatabaseWithCallbackWithException)
         exception_thrown = true;
     }
     CHECK(exception_thrown);
-    CHECK(!did_upgrade);
 
-    // Callback should be triggered here because the file still needs to be upgraded
+    // Callback should not be triggered here because the file has already been upgraded
     upgrade_callback = successful_callback;
     SharedGroup sg2(temp_copy,
                    no_create,
@@ -908,18 +907,6 @@ TEST(Upgrade_DatabaseWithCallbackWithException)
                    encryption_key,
                    allow_file_format_upgrade,
                    upgrade_callback);
-    CHECK(did_upgrade);
-    CHECK_EQUAL(old_version, 3);
-    CHECK(new_version >= 5);
-
-    // Callback should not be triggered here because the file is already upgraded
-    did_upgrade = false;
-    SharedGroup sg3(temp_copy,
-                    no_create,
-                    durability,
-                    encryption_key,
-                    allow_file_format_upgrade,
-                    upgrade_callback);
     CHECK(!did_upgrade);
 }
 


### PR DESCRIPTION
These changes address concerns about the upgrade callback throwing.
The callback is now triggered only after the write transaction for upgrading the file has succeeded. The assumption is that the callback does not throw. If the callback does throw, the realm will be closed properly but only after the upgrade has succeeded. This means that the upgrade callback will not be triggered on the next open of the Realm if it throws the first time. If there is a problem in the code of the callback, the owner of the callback should keep track of this and address it later.

This is related to #1773

@simonask @bdash @alazier
