### PR TITLE
Disable file descriptor leak check on Apple platforms.

### DIFF
--- a/test/test_all.cpp
+++ b/test/test_all.cpp
@@ -140,7 +140,7 @@ long get_num_open_files()
             return num_open_files;
         }
     }
-#  endif
+#endif
     return -1;
 }
 


### PR DESCRIPTION
@danielpovlsen 
