### PR TITLE
Fix queries over multiple levels of backlinks

### DIFF
--- a/release_notes.md
+++ b/release_notes.md
@@ -7,6 +7,8 @@
 * Fixed issue with Timestamps before the UNIX epoch not being read correctly in
   the `TransactLogParser`. Rollbacks and advances with such Timestamps would
   throw a `BadTransactLog` exception. (#1802)
+* Fix queries over multiple levels of backlinks to work when the tables involved have
+  their backlink columns at different indices.
 
 ### Breaking changes
 

--- a/src/realm/table.hpp
+++ b/src/realm/table.hpp
@@ -1734,7 +1734,8 @@ inline Columns<T> Table::column(const Table& origin, size_t origin_col_ndx)
     static_assert(std::is_same<T, BackLink>::value, "");
 
     size_t origin_table_ndx = origin.get_index_in_group();
-    size_t backlink_col_ndx = m_spec.find_backlink_column(origin_table_ndx, origin_col_ndx);
+    const Table& current_target_table = *get_link_chain_target(m_link_chain);
+    size_t backlink_col_ndx = current_target_table.m_spec.find_backlink_column(origin_table_ndx, origin_col_ndx);
 
     std::vector<size_t> link_chain = std::move(m_link_chain);
     m_link_chain.clear();
@@ -1767,7 +1768,8 @@ inline Table& Table::link(size_t link_column)
 inline Table& Table::backlink(const Table& origin, size_t origin_col_ndx)
 {
     size_t origin_table_ndx = origin.get_index_in_group();
-    size_t backlink_col_ndx = m_spec.find_backlink_column(origin_table_ndx, origin_col_ndx);
+    const Table& current_target_table = *get_link_chain_target(m_link_chain);
+    size_t backlink_col_ndx = current_target_table.m_spec.find_backlink_column(origin_table_ndx, origin_col_ndx);
     return link(backlink_col_ndx);
 }
 


### PR DESCRIPTION
Specifically, when the tables involved have their backlink columns at different indices.

The logic for finding the backlink columns was always using the query's root table to find the backlink column's index. That happened to work in some cases, but died with an assertion failure in others. We now use the current target of the link chain to find the index of the backlink column.

/cc @rrrlasse 

Reported in realm/realm-cocoa#3547.
