### PR TITLE
ask for repro steps in termination log

### DIFF
--- a/src/realm/util/terminate.cpp
+++ b/src/realm/util/terminate.cpp
@@ -107,7 +107,7 @@ REALM_NORETURN void terminate_internal(std::stringstream& ss) noexcept
     free(strs);
 #endif
 
-    ss << "IMPORTANT: if you see this error, please send this log to help@realm.io.";
+    ss << "IMPORTANT: if you see this error, please send this log and reproduction steps to help@realm.io.";
 #ifdef REALM_DEBUG
     std::cerr << ss.rdbuf() << '\n';
 #endif


### PR DESCRIPTION
it's quite common for users to think that a stack trace is all we need to make progress on an issue, so we constantly get emails to help@realm.io with nothing but a stack trace, no further information. I'm hoping this encourages them to provide more information.
