### PR TITLE
only build iphone version with bitcode

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -730,12 +730,8 @@ EOF
         export os_name='ios'
         export sdks_config_key='IPHONE_SDKS'
         export dir="$IPHONE_DIR"
-        export platform_suffix='-bitcode'
+        export platform_suffix=''
         export enable_bitcode='yes'
-        build_apple
-
-        export platform_suffix='-no-bitcode'
-        export enable_bitcode='no'
         build_apple
         ;;
 


### PR DESCRIPTION
Now that cocoa is deprecating Xcode 6 support. /cc @tgoyne @bdash 
