### PR TITLE
Remove unnecessary fsync()s of commit log files

### DIFF
--- a/release_notes.md
+++ b/release_notes.md
@@ -10,7 +10,8 @@
 
 ### Enhancements
 
-* Lorem ipsum.
+* Improve performance of opening Realm files and making commits when using
+  external writelogs by eliminating some unneeded `fsync()`s.
 
 -----------
 

--- a/src/realm/commit_log.cpp
+++ b/src/realm/commit_log.cpp
@@ -390,9 +390,6 @@ void WriteLogCollector::reset_file(CommitLogMetadata& log)
     File::try_remove(log.name);
     log.file.open(log.name, File::mode_Write);
     log.file.resize(minimal_pages * page_size); // Throws
-    bool disable_sync = get_disable_sync_to_disk();
-    if (!disable_sync)
-        log.file.sync(); // Throws
     log.last_seen_mmap_counter = m_header.get_addr()->mmap_counter;
     log.map.map(log.file, File::access_ReadWrite, minimal_pages * page_size);
 }
@@ -404,9 +401,6 @@ void WriteLogCollector::reset_header()
 
     File header_file(m_header_name, File::mode_Write);
     header_file.resize(sizeof (CommitLogHeader)); // Throws
-    bool disable_sync = get_disable_sync_to_disk();
-    if (!disable_sync)
-        header_file.sync(); // Throws
     m_header.map(header_file, File::access_ReadWrite, sizeof (CommitLogHeader));
     m_lock.set_shared_part(m_header.get_addr()->shared_part_of_lock, std::move(header_file));
 }
@@ -456,9 +450,6 @@ void WriteLogCollector::cleanup_stale_versions(CommitLogPreamble* preamble)
             m_header.get_addr()->mmap_counter++;
             active_log->map.unmap();
             active_log->file.resize(size); // Throws
-            bool disable_sync = get_disable_sync_to_disk();
-            if (!disable_sync)
-                active_log->file.sync(); // Throws
         }
     }
 }
@@ -483,9 +474,6 @@ WriteLogCollector::internal_submit_log(HistoryEntry entry)
     if (size_needed > active_log->file.get_size()) {
         m_header.get_addr()->mmap_counter++;
         active_log->file.resize(size_needed); // Throws
-        bool disable_sync = get_disable_sync_to_disk();
-        if (!disable_sync)
-            active_log->file.sync(); // Throws
     }
 
     // create/update mapping so that we are sure it covers the file we are about
@@ -546,9 +534,6 @@ void WriteLogCollector::initiate_session(version_type version)
     // This protects us against deadlock when we restart after crash on a
     // platform without support for robust mutexes.
     new (& m_header.get_addr()->shared_part_of_lock) InterprocessMutex::SharedPart();
-    bool disable_sync = get_disable_sync_to_disk();
-    if (!disable_sync)
-        m_header.sync(); // Throws
 }
 
 


### PR DESCRIPTION
The writelogs do not need to survive power loss (or even ever actually hit disk at all), so there's no need to call `File::sync()` on them. These were incorrectly added by the combination of
0d2fd43a08734fecbaa2ceb30c7ecdd6a5bd3869 and 185de19a140c4c9cd2f6dcb46679e16db853df05: the first made all calls to `File::resize()` call `fsync()` even though only resizes of the Realm file itself need it, and the second fixed this by pulling the call to `fsync()` out of `resize()`, but did so even in places where the sync was not required.

There is a remaining call to `msync()` on the log files before flipping the active file bit in the header which has a much smaller impact on performance.

This cuts the time to open a SharedGroup on an iPad Air from 100ms to 30ms (and makes it not bound on disk write speed) and makes commits a bit faster (~10% for very small ones).

This should not go into 1.0; while it's a fix for a regression, it's a ~10 month old regression and one prompted by me trying to figure out what's going on with our performance tests and not due to a user report.

@finnschiermer
