### PR TITLE
Fixed source code flaw

### DIFF
--- a/src/realm/array_basic_tpl.hpp
+++ b/src/realm/array_basic_tpl.hpp
@@ -76,6 +76,7 @@ inline MemRef BasicArray<T>::create_array(Array::Type type, bool context_flag, s
         for (size_t i = 0; i < size; ++i) {
             tmp.set(i, value);
         }
+        return tmp.get_mem();
     }
     return mem;
 }


### PR DESCRIPTION
Fixed source code "flaw" where we return an old reference to an array after we have called ::set() on it which could have relocated it.

The bug is never hit in practise because BasicArray<T> is only instantiated for floats/doubles that do not bit expand. However, it's still a risky pattern if we should one day make BasicArray support other types or copy/paste some of its code and reuse it.
