### PR TITLE
added 'nonconcurrent' to tests relying on timing

### DIFF
--- a/src/realm/util/interprocess_mutex.hpp
+++ b/src/realm/util/interprocess_mutex.hpp
@@ -22,11 +22,9 @@
 #define REALM_UTIL_INTERPROCESS_MUTEX
 
 // Enable this only on platforms where it might be needed
-//#if REALM_PLATFORM_APPLE || REALM_ANDROID
-// FIXME: Just testing if unittest suite will run with emulation
-// on all platforms..
+#if REALM_PLATFORM_APPLE || REALM_PLATFORM_ANDROID
 #define REALM_ROBUST_MUTEX_EMULATION
-//#endif
+#endif
 
 #include <realm/util/features.h>
 #include <realm/util/thread.hpp>


### PR DESCRIPTION
Some of the unittests are timing dependent. This may cause them to fail or hang spuriously in high load situations. This PR classifies them as non-concurrent tests, to limit the load while they're run.
