### PR TITLE
Avoid building CFRunLoop based implementation on Apple watchOS

### DIFF
--- a/src/realm/Makefile
+++ b/src/realm/Makefile
@@ -138,7 +138,7 @@ util/thread.cpp \
 util/network.cpp \
 util/event_loop.cpp \
 util/event_loop_posix.cpp \
-$(if $(call IS_EQUAL_TO,$(OS),Darwin),util/event_loop_apple_cf.cpp) \
+util/event_loop_apple_cf.cpp \
 util/uri.cpp \
 util/interprocess_condvar.cpp \
 alloc.cpp \

--- a/src/realm/util/event_loop.cpp
+++ b/src/realm/util/event_loop.cpp
@@ -1,60 +1,16 @@
 #include <realm/util/features.h>
 #include <realm/util/event_loop.hpp>
 
-
-#ifndef _WIN32
-#  define HAVE_POSIX_IMPLEMENTATION 1
-#endif
-
-/* The Apple Core Foundation based implementation is currently not working
- * correctly. When reenabling it, remember to also reenable it in
- * test_util_event_loop.cpp.
-
-#if REALM_PLATFORM_APPLE
-#  define HAVE_APPLE_CF_IMPLEMENTATION 1
-#endif
-
-*/
-
-
 using namespace realm;
 using namespace realm::util;
 
 namespace realm {
 namespace _impl {
 
-#if HAVE_POSIX_IMPLEMENTATION
-EventLoop::Implementation& get_posix_event_loop_impl();
-#endif
-
-#if HAVE_APPLE_CF_IMPLEMENTATION
-EventLoop::Implementation& get_apple_cf_event_loop_impl();
-#endif
+EventLoop::Implementation* get_posix_event_loop_impl();
+EventLoop::Implementation* get_apple_cf_event_loop_impl();
 
 } // namespace_impl
-
-
-namespace {
-
-EventLoop::Implementation* get_posix_impl()
-{
-#if HAVE_POSIX_IMPLEMENTATION
-    return &_impl::get_posix_event_loop_impl(); // Throws
-#else
-    return nullptr;
-#endif
-}
-
-EventLoop::Implementation* get_apple_cf_impl()
-{
-#if HAVE_APPLE_CF_IMPLEMENTATION
-    return &_impl::get_apple_cf_event_loop_impl(); // Throws
-#else
-    return nullptr;
-#endif
-}
-
-} // unnamed namespace
 
 
 namespace util {
@@ -63,12 +19,12 @@ EventLoop::Implementation& EventLoop::Implementation::get_default()
 {
     // On iOS, prefer Apple Core Foundation
 #if REALM_IOS
-    if (auto impl = get_apple_cf_impl()) // Throws
+    if (auto impl = _impl::get_apple_cf_event_loop_impl()) // Throws
         return *impl;
 #endif
 
     // Everywhere else, prefer POSIX
-    if (auto impl = get_posix_impl()) // Throws
+    if (auto impl = _impl::get_posix_event_loop_impl()) // Throws
         return *impl;
 
     auto all = get_all(); // Throws
@@ -92,9 +48,9 @@ EventLoop::Implementation& EventLoop::Implementation::get(const std::string& nam
 std::vector<EventLoop::Implementation*> EventLoop::Implementation::get_all()
 {
     std::vector<EventLoop::Implementation*> list;
-    if (auto impl = get_posix_impl()) // Throws
+    if (auto impl = _impl::get_posix_event_loop_impl()) // Throws
         list.push_back(impl); // Throws
-    if (auto impl = get_apple_cf_impl()) // Throws
+    if (auto impl = _impl::get_apple_cf_event_loop_impl()) // Throws
         list.push_back(impl); // Throws
     return list;
 }
@@ -102,7 +58,7 @@ std::vector<EventLoop::Implementation*> EventLoop::Implementation::get_all()
 
 EventLoop::Implementation& EventLoop::Implementation::get_posix()
 {
-    if (auto impl = get_posix_impl()) // Throws
+    if (auto impl = _impl::get_posix_event_loop_impl()) // Throws
         return *impl;
     throw NotAvailable();
 }
@@ -110,7 +66,7 @@ EventLoop::Implementation& EventLoop::Implementation::get_posix()
 
 EventLoop::Implementation& EventLoop::Implementation::get_apple_cf()
 {
-    if (auto impl = get_apple_cf_impl()) // Throws
+    if (auto impl = _impl::get_apple_cf_event_loop_impl()) // Throws
         return *impl;
     throw NotAvailable();
 }

--- a/src/realm/util/event_loop_apple_cf.cpp
+++ b/src/realm/util/event_loop_apple_cf.cpp
@@ -1,3 +1,19 @@
+#include <realm/util/features.h>
+#include <realm/util/event_loop.hpp>
+
+#if REALM_PLATFORM_APPLE && !REALM_WATCHOS
+// The Apple Core Foundation based implementation is currently not working
+// correctly. When reenabling it, remember to also reenable it in
+// test_util_event_loop.cpp.
+#  define HAVE_APPLE_CF_IMPLEMENTATION 0
+//#  define HAVE_APPLE_CF_IMPLEMENTATION 1
+#else
+#  define HAVE_APPLE_CF_IMPLEMENTATION 0
+#endif
+
+
+#if HAVE_APPLE_CF_IMPLEMENTATION
+
 #include <type_traits>
 #include <algorithm>
 #include <stdexcept>
@@ -12,7 +28,6 @@
 #include <realm/util/misc_errors.hpp>
 #include <realm/util/basic_system_errors.hpp>
 #include <realm/util/network.hpp>
-#include <realm/util/event_loop.hpp>
 
 // https://developer.apple.com/library/ios/documentation/NetworkingInternet/Conceptual/NetworkingTopics/Articles/UsingSocketsandSocketStreams.html#//apple_ref/doc/uid/CH73-SW4
 // https://developer.apple.com/library/mac/documentation/CoreFoundation/Conceptual/CFMemoryMgmt/CFMemoryMgmt.html
@@ -1425,13 +1440,19 @@ ImplementationImpl g_implementation;
 
 } // unnamed namespace
 
+#endif // HAVE_APPLE_CF_IMPLEMENTATION
+
 
 namespace realm {
 namespace _impl {
 
-EventLoop::Implementation& get_apple_cf_event_loop_impl()
+realm::util::EventLoop::Implementation* get_apple_cf_event_loop_impl()
 {
-    return g_implementation;
+#if HAVE_APPLE_CF_IMPLEMENTATION
+    return &g_implementation;
+#else
+    return nullptr;
+#endif
 }
 
 } // namespace _impl

--- a/src/realm/util/event_loop_posix.cpp
+++ b/src/realm/util/event_loop_posix.cpp
@@ -1,7 +1,18 @@
+#include <realm/util/features.h>
+#include <realm/util/event_loop.hpp>
+
+#ifndef _WIN32
+#  define HAVE_POSIX_IMPLEMENTATION 1
+#else
+#  define HAVE_POSIX_IMPLEMENTATION 0
+#endif
+
+
+#if HAVE_POSIX_IMPLEMENTATION
+
 #include <memory>
 
 #include <realm/util/network.hpp>
-#include <realm/util/event_loop.hpp>
 
 using namespace realm;
 using namespace realm::util;
@@ -245,13 +256,19 @@ ImplementationImpl g_implementation;
 
 } // unnamed namespace
 
+#endif // HAVE_POSIX_IMPLEMENTATION
+
 
 namespace realm {
 namespace _impl {
 
-EventLoop::Implementation& get_posix_event_loop_impl()
+realm::util::EventLoop::Implementation* get_posix_event_loop_impl()
 {
-    return g_implementation;
+#if HAVE_POSIX_IMPLEMENTATION
+    return &g_implementation;
+#else
+    return nullptr;
+#endif
 }
 
 } // namespace _impl

--- a/test/test_util_event_loop.cpp
+++ b/test/test_util_event_loop.cpp
@@ -31,7 +31,7 @@ template<> struct MakeEventLoop<AppleCoreFoundation> {
 };
 
 
-#if REALM_PLATFORM_APPLE
+#if REALM_PLATFORM_APPLE && !REALM_WATCHOS
 // Apple Core Foundation based implementation currently disabled because it is
 // broken.
 //#  define IMPLEMENTATIONS Posix, AppleCoreFoundation
@@ -205,7 +205,7 @@ void fill_kernel_write_buffer(Socket& socket, network::io_service& service)
     PingPongFixture ping_pong(service, event_loop);
     ping_pong.start();
     int num_successive_no_bytes_written = 0;
-    char data[40967];
+    char data[4096] = {};
     std::function<void()> initiate_write = [&] {
         auto handler = [&](std::error_code ec, size_t n) {
             if (ec && ec != error::operation_aborted)


### PR DESCRIPTION
and fix an uninitialized memory bug.

@danielpovlsen 
