### PR TITLE
Turn on compiler warnings for using undefined macros

### DIFF
--- a/realm.xcodeproj/project.pbxproj
+++ b/realm.xcodeproj/project.pbxproj
@@ -2733,6 +2733,7 @@
 				OTHER_CFLAGS = (
 					"$(inherited)",
 					"-fno-elide-constructors",
+					"-Wundef",
 				);
 				SDKROOT = macosx;
 				WATCHOS_DEPLOYMENT_TARGET = 2.0;
@@ -2775,6 +2776,10 @@
 				IPHONEOS_DEPLOYMENT_TARGET = 7.0;
 				MACOSX_DEPLOYMENT_TARGET = 10.9;
 				ONLY_ACTIVE_ARCH = YES;
+				OTHER_CFLAGS = (
+					"$(inherited)",
+					"-Wundef",
+				);
 				SDKROOT = macosx;
 				WATCHOS_DEPLOYMENT_TARGET = 2.0;
 			};

--- a/src/project.mk
+++ b/src/project.mk
@@ -10,7 +10,7 @@ endif
 
 CFLAGS_DEBUG += -fno-elide-constructors
 CFLAGS_PTHREADS += -pthread
-CFLAGS_GENERAL += -Wextra -pedantic
+CFLAGS_GENERAL += -Wextra -pedantic -Wundef
 CFLAGS_CXX = -std=c++14
 
 # Avoid a warning from Clang when linking on OS X. By default,

--- a/src/realm/array.cpp
+++ b/src/realm/array.cpp
@@ -790,7 +790,7 @@ size_t Array::find_gte(const int64_t target, size_t start, Array const* indirect
 {
     REALM_ASSERT(start < (indirection ? indirection->size() : size()));
 
-#if REALM_DEBUG
+#ifdef REALM_DEBUG
     // Reference implementation to illustrate and test behaviour
     size_t ref = 0;
     size_t idx;

--- a/src/realm/importer.cpp
+++ b/src/realm/importer.cpp
@@ -100,7 +100,7 @@ void print_row(Table& table, size_t r)
         if(table.get_column_type(c) == type_Int)
             sprintf(buf, "%lld", static_cast<long long>(table.get_int(c, r)));
         if(table.get_column_type(c) == type_String) {
-#if _MSC_VER
+#if defined(_MSC_VER) && _MSC_VER
             _snprintf(buf, sizeof(buf), "%s", table.get_string(c, r).data());
 #else
             snprintf(buf, sizeof(buf), "%s", table.get_string(c, r).data());

--- a/src/realm/query_engine.hpp
+++ b/src/realm/query_engine.hpp
@@ -115,7 +115,7 @@ AggregateState      State of the aggregate - contains a state variable that stor
 #include <iostream>
 #include <map>
 
-#if _MSC_FULL_VER >= 160040219
+#if defined(_MSC_FULL_VER) && _MSC_FULL_VER >= 160040219
 #  include <immintrin.h>
 #endif
 

--- a/src/realm/unicode.cpp
+++ b/src/realm/unicode.cpp
@@ -95,7 +95,7 @@ namespace realm {
     bool set_string_compare_method(string_compare_method_t method, StringCompareCallback callback)
     {
         if (method == STRING_COMPARE_CPP11) {
-#if !defined(REALM_ANDROID)
+#if !REALM_ANDROID
             std::string l = std::locale("").name();
             // We cannot use C locale because it puts 'Z' before 'a'
             if (l == "C")

--- a/src/realm/util/assert.hpp
+++ b/src/realm/util/assert.hpp
@@ -25,6 +25,8 @@
 
 #if REALM_ENABLE_ASSERTIONS || defined(REALM_DEBUG)
 #  define REALM_ASSERTIONS_ENABLED 1
+#else
+#  define REALM_ASSERTIONS_ENABLED 0
 #endif
 
 #define REALM_ASSERT_RELEASE(condition) \

--- a/src/realm/util/features.h
+++ b/src/realm/util/features.h
@@ -114,13 +114,13 @@
 #endif
 
 /* Compiler is MSVC (Microsoft Visual C++) */
-#if _MSC_VER >= 1600
+#if defined(_MSC_VER) && _MSC_VER >= 1600
 #  define REALM_HAVE_AT_LEAST_MSVC_10_2010 1
 #endif
-#if _MSC_VER >= 1700
+#if defined(_MSC_VER) && _MSC_VER >= 1700
 #  define REALM_HAVE_AT_LEAST_MSVC_11_2012 1
 #endif
-#if _MSC_VER >= 1800
+#if defined(_MSC_VER) && _MSC_VER >= 1800
 #  define REALM_HAVE_AT_LEAST_MSVC_12_2013 1
 #endif
 
@@ -130,7 +130,7 @@
 #  define REALM_NORETURN [[noreturn]]
 #elif __GNUC__
 #  define REALM_NORETURN __attribute__((noreturn))
-#elif _MSC_VER
+#elif defined(_MSC_VER)
 #  define REALM_NORETURN __declspec(noreturn)
 #else
 #  define REALM_NORETURN
@@ -183,6 +183,8 @@
 
 #if defined __ANDROID__
 #  define REALM_ANDROID 1
+#else
+#  define REALM_ANDROID 0
 #endif
 
 // Some documentation of the defines provided by Apple:
@@ -194,6 +196,8 @@
 #  if TARGET_OS_IPHONE == 1
 /* Device (iPhone or iPad) or simulator. */
 #    define REALM_IOS 1
+#  else
+#    define REALM_IOS 0
 #  endif
 #  if TARGET_OS_WATCH == 1
 /* Device (Apple Watch) or simulator. */
@@ -201,13 +205,20 @@
 /* The necessary signal handling / mach exception APIs are all unavailable */
 #    undef  REALM_ENABLE_ENCRYPTION
 #    define REALM_ENABLE_ENCRYPTION 0
+#  else
+#    define REALM_WATCHOS 0
 #  endif
 #  if TARGET_OS_TV
 /* Device (Apple TV) or simulator. */
 #    define REALM_TVOS 1
+#  else
+#    define REALM_TVOS 0
 #  endif
 #else
 #  define REALM_PLATFORM_APPLE 0
+#  define REALM_IOS 0
+#  define REALM_WATCHOS 0
+#  define REALM_TVOS 0
 #endif
 
 

--- a/src/realm/util/file.cpp
+++ b/src/realm/util/file.cpp
@@ -534,7 +534,7 @@ void File::prealloc(SizeType offset, size_t size)
 {
     REALM_ASSERT_RELEASE(is_attached());
 
-#if _POSIX_C_SOURCE >= 200112L // POSIX.1-2001 version
+#if defined(_POSIX_C_SOURCE) && _POSIX_C_SOURCE >= 200112L // POSIX.1-2001 version
 
     prealloc_if_supported(offset, size);
 
@@ -553,7 +553,7 @@ void File::prealloc_if_supported(SizeType offset, size_t size)
 {
     REALM_ASSERT_RELEASE(is_attached());
 
-#if _POSIX_C_SOURCE >= 200112L // POSIX.1-2001 version
+#if defined(_POSIX_C_SOURCE) && _POSIX_C_SOURCE >= 200112L // POSIX.1-2001 version
 
     REALM_ASSERT_RELEASE(is_prealloc_supported());
 
@@ -591,7 +591,7 @@ void File::prealloc_if_supported(SizeType offset, size_t size)
 
 bool File::is_prealloc_supported()
 {
-#if _POSIX_C_SOURCE >= 200112L // POSIX.1-2001 version
+#if defined(_POSIX_C_SOURCE) && _POSIX_C_SOURCE >= 200112L // POSIX.1-2001 version
     return true;
 #else
     return false;

--- a/src/realm/util/file_mapper.cpp
+++ b/src/realm/util/file_mapper.cpp
@@ -54,7 +54,7 @@
 #   include <mach/exc.h>
 #endif
 
-#ifdef REALM_ANDROID
+#if REALM_ANDROID
 #include <linux/unistd.h>
 #include <sys/syscall.h>
 #endif

--- a/src/realm/util/interprocess_condvar.cpp
+++ b/src/realm/util/interprocess_condvar.cpp
@@ -93,7 +93,7 @@ void InterprocessCondVar::set_shared_part(SharedPart& shared_part, std::string b
     static_cast<void>(base_path);
     static_cast<void>(condvar_name);
 #ifdef REALM_CONDVAR_EMULATION
-#if !TARGET_OS_TV
+#if !REALM_TVOS
     m_resource_path = base_path + "." + condvar_name + ".cv";
 
     // Create and open the named pipe
@@ -130,7 +130,7 @@ void InterprocessCondVar::set_shared_part(SharedPart& shared_part, std::string b
         throw std::system_error(errno, std::system_category());
     }
 
-#else // !TARGET_OS_TV
+#else // !REALM_TVOS
 
     // tvOS does not support named pipes, so use an anonymous pipe instead
     int notification_pipe[2];
@@ -142,7 +142,7 @@ void InterprocessCondVar::set_shared_part(SharedPart& shared_part, std::string b
     m_fd_read = notification_pipe[0];
     m_fd_write = notification_pipe[1];
 
-#endif // TARGET_OS_TV
+#endif // REALM_TVOS
 
     // Make writing to the pipe return -1 when the pipe's buffer is full
     // rather than blocking until there's space available

--- a/src/realm/util/thread.cpp
+++ b/src/realm/util/thread.cpp
@@ -28,7 +28,7 @@
 
 // "Process shared mutexes" are not officially supported on Android,
 // but they appear to work anyway.
-#if _POSIX_THREAD_PROCESS_SHARED > 0 || REALM_ANDROID
+#if (defined(_POSIX_THREAD_PROCESS_SHARED) && _POSIX_THREAD_PROCESS_SHARED > 0) || REALM_ANDROID
 #  define REALM_HAVE_PTHREAD_PROCESS_SHARED
 #endif
 

--- a/src/realm/utilities.cpp
+++ b/src/realm/utilities.cpp
@@ -18,7 +18,7 @@
 namespace {
 
 #ifdef REALM_COMPILER_SSE
-#  if !defined __clang__ && ((_MSC_FULL_VER >= 160040219) || defined __GNUC__)
+#  if !defined __clang__ && ((defined(_MSC_FULL_VER) && _MSC_FULL_VER >= 160040219) || defined __GNUC__)
 #    if defined REALM_COMPILER_AVX && defined __GNUC__
 #      define _XCR_XFEATURE_ENABLED_MASK 0
 
@@ -82,7 +82,7 @@ void cpuid_init()
     bool avxSupported = false;
 
 // seems like in jenkins builds, __GNUC__ is defined for clang?! todo fixme
-#  if !defined __clang__ && ((_MSC_FULL_VER >= 160040219) || defined __GNUC__)
+#  if !defined __clang__ && ((defined(_MSC_FULL_VER) && _MSC_FULL_VER >= 160040219) || defined __GNUC__)
     bool osUsesXSAVE_XRSTORE = cret & (1 << 27) || false;
     bool cpuAVXSuport = cret & (1 << 28) || false;
 

--- a/src/realm/utilities.hpp
+++ b/src/realm/utilities.hpp
@@ -49,7 +49,7 @@
 #  define REALM_ARCH_ARM
 #endif
 
-#if defined _LP64 || defined __LP64__ || defined __64BIT__ || _ADDR64 || defined _WIN64 || defined __arch64__ || __WORDSIZE == 64 || (defined __sparc && defined __sparcv9) || defined __x86_64 || defined __amd64 || defined __x86_64__ || defined _M_X64 || defined _M_IA64 || defined __ia64 || defined __IA64__
+#if defined _LP64 || defined __LP64__ || defined __64BIT__ || defined _ADDR64 || defined _WIN64 || defined __arch64__ || (defined(__WORDSIZE) && __WORDSIZE == 64) || (defined __sparc && defined __sparcv9) || defined __x86_64 || defined __amd64 || defined __x86_64__ || defined _M_X64 || defined _M_IA64 || defined __ia64 || defined __IA64__
 #  define REALM_PTR_64
 #endif
 

--- a/test/benchmark-common-tasks/main.cpp
+++ b/test/benchmark-common-tasks/main.cpp
@@ -539,7 +539,7 @@ TEST(benchmark_common_tasks_main)
 #undef BENCH
 }
 
-#if !defined(REALM_IOS)
+#if !REALM_IOS
 int main(int, const char**)
 {
     bool success;

--- a/test/test_lang_bind_helper.cpp
+++ b/test/test_lang_bind_helper.cpp
@@ -8943,7 +8943,7 @@ TEST(LangBindHelper_ImplicitTransactions_MultipleTrackers)
 #if !REALM_ENABLE_ENCRYPTION
 // Interprocess communication does not work with encryption enabled
 
-#if !defined(REALM_ANDROID) && !defined(REALM_IOS)
+#if !REALM_ANDROID && !REALM_IOS
 // fork should not be used on android or ios.
 
 /*
@@ -9038,7 +9038,7 @@ TEST(LangBindHelper_ImplicitTransactions_InterProcess)
 
 */
 
-#endif // !defined(REALM_ANDROID) && !defined(REALM_IOS)
+#endif // !REALM_ANDROID && !REALM_IOS
 #endif // not REALM_ENABLE_ENCRYPTION
 #endif // not defined _WIN32
 

--- a/test/test_shared.cpp
+++ b/test/test_shared.cpp
@@ -176,7 +176,7 @@ void killer(TestContext& test_context, int pid, std::string path, int id)
 
 } // anonymous namespace
 
-#if !defined(_WIN32)&& !REALM_ENABLE_ENCRYPTION && !defined(REALM_ANDROID)
+#if !defined(_WIN32)&& !REALM_ENABLE_ENCRYPTION && !REALM_ANDROID
 
 TEST_IF(Shared_PipelinedWritesWithKills, false)
 {


### PR DESCRIPTION
I carefully tried to change as little as possible to build without warnings with `-Wundef` enabled. `REALM_ANDROID`, `REALM_IOS`, `REALM_WATCHOS`, `REALM_TVOS`, `REALM_ASSERTIONS_ENABLED` will now always be defined to either `0` or `1` and checks should always use `#if`, not `#ifdef` or similar.

Partially fixes #1833. We should consider changing all macros to be defined to either `0` or `1`.

@teotwaki @simonask @kspangsege 

Not yet tested on Windows / Visual Studio. Unsure if there is a warning that matches `-Wundef`. @rrrlasse 
