### PR TITLE
Squashed commit of the following:

### DIFF
--- a/src/realm/alloc.cpp
+++ b/src/realm/alloc.cpp
@@ -58,7 +58,7 @@ public:
 #if REALM_ENABLE_ALLOC_SET_ZERO
         std::fill(addr, addr+size, 0);
 #endif
-        return MemRef(addr, reinterpret_cast<size_t>(addr));
+        return MemRef(addr, reinterpret_cast<size_t>(addr), *this);
     }
 
     MemRef do_realloc(ref_type, const char* addr, size_t old_size,
@@ -74,7 +74,7 @@ public:
 #else
         static_cast<void>(old_size);
 #endif
-        return MemRef(new_addr, reinterpret_cast<size_t>(new_addr));
+        return MemRef(new_addr, reinterpret_cast<size_t>(new_addr), *this);
     }
 
     void do_free(ref_type, const char* addr) noexcept override
@@ -109,7 +109,7 @@ MemRef Allocator::do_realloc(ref_type ref, const char* addr, size_t old_size,
     MemRef new_mem = do_alloc(new_size); // Throws
 
     // Copy existing contents
-    char* new_addr = new_mem.m_addr;
+    char* new_addr = new_mem.get_addr();
     std::copy(addr, addr+old_size, new_addr);
 
     // Free old chunk

--- a/src/realm/alloc.hpp
+++ b/src/realm/alloc.hpp
@@ -41,13 +41,26 @@ ref_type to_ref(int_fast64_t) noexcept;
 
 class MemRef {
 public:
-    char* m_addr;
-    ref_type m_ref;
 
     MemRef() noexcept;
     ~MemRef() noexcept;
-    MemRef(char* addr, ref_type ref) noexcept;
+
+    MemRef(char* addr, ref_type ref, Allocator& alloc) noexcept;
     MemRef(ref_type ref, Allocator& alloc) noexcept;
+
+    char* get_addr();
+    ref_type get_ref();
+    void set_ref(ref_type ref);
+    void set_addr(char* addr);
+
+private:
+    char* m_addr;
+    ref_type m_ref;
+#ifdef REALM_MEMORY_DEBUG
+    // Allocator that created m_ref. Used to verify that the ref is valid whenever you call 
+    // get_ref()/get_addr and that it e.g. has not been free'ed
+    const Allocator* m_alloc = nullptr;
+#endif
 };
 
 
@@ -86,7 +99,7 @@ public:
     /// would conflict with a macro on the Windows platform.
     void free_(ref_type, const char* addr) noexcept;
 
-    /// Shorthand for free_(mem.m_ref, mem.m_addr).
+    /// Shorthand for free_(mem.get_ref(), mem.get_addr()).
     void free_(MemRef mem) noexcept;
 
     /// Calls do_translate().
@@ -295,18 +308,57 @@ inline MemRef::~MemRef() noexcept
 {
 }
 
-inline MemRef::MemRef(char* addr, ref_type ref) noexcept:
+inline MemRef::MemRef(char* addr, ref_type ref, Allocator& alloc) noexcept:
     m_addr(addr),
     m_ref(ref)
 {
+    static_cast<void>(alloc);
+#ifdef REALM_MEMORY_DEBUG
+    m_alloc = &alloc;
+#endif
 }
 
 inline MemRef::MemRef(ref_type ref, Allocator& alloc) noexcept:
     m_addr(alloc.translate(ref)),
     m_ref(ref)
 {
+    static_cast<void>(alloc);
+#ifdef REALM_MEMORY_DEBUG
+    m_alloc = &alloc;
+#endif
 }
 
+inline char* MemRef::get_addr()
+{
+#ifdef REALM_MEMORY_DEBUG
+    // Asserts if the ref has been freed
+    m_alloc->translate(m_ref);
+#endif
+    return m_addr;
+}
+
+inline ref_type MemRef::get_ref()
+{
+#ifdef REALM_MEMORY_DEBUG
+    // Asserts if the ref has been freed
+    m_alloc->translate(m_ref);
+#endif
+    return m_ref;
+}
+
+inline void MemRef::set_ref(ref_type ref)
+{
+#ifdef REALM_MEMORY_DEBUG
+    // Asserts if the ref has been freed
+    m_alloc->translate(ref);
+#endif
+    m_ref = ref;
+}
+
+inline void MemRef::set_addr(char* addr)
+{
+    m_addr = addr;
+}
 
 inline MemRef Allocator::alloc(size_t size)
 {
@@ -334,7 +386,7 @@ inline void Allocator::free_(ref_type ref, const char* addr) noexcept
 
 inline void Allocator::free_(MemRef mem) noexcept
 {
-    free_(mem.m_ref, mem.m_addr);
+    free_(mem.get_ref(), mem.get_addr());
 }
 
 inline char* Allocator::translate(ref_type ref) const noexcept

--- a/src/realm/alloc_slab.cpp
+++ b/src/realm/alloc_slab.cpp
@@ -218,6 +218,19 @@ MemRef SlabAlloc::do_alloc(size_t size)
         iter rend = m_free_space.rend();
         for (iter i = m_free_space.rbegin(); i != rend; ++i) {
             if (size <= i->size) {
+
+#ifdef REALM_MEMORY_DEBUG
+                // Pick a *random* match instead of just the first. This will increase the chance of catching
+                // use-after-free bugs in Core. It's chosen such that the mathematical average of all picked 
+                // positions is the middle of the list. 
+                iter j = i;
+                while (j != rend && (size > j->size || fastrand() % (m_free_space.size() / 2 + 1) != 0)) {
+                    j++;
+                }
+                if (j != rend)
+                    i = j;
+#endif
+
                 ref_type ref = i->ref;
                 size_t rest = i->size - size;
 
@@ -244,7 +257,7 @@ MemRef SlabAlloc::do_alloc(size_t size)
 #ifdef REALM_SLAB_ALLOC_DEBUG
                 malloc_debug_map[ref] = malloc(1);
 #endif
-                return MemRef(addr, ref);
+                return MemRef(addr, ref, *this);
             }
         }
     }
@@ -297,7 +310,7 @@ MemRef SlabAlloc::do_alloc(size_t size)
     malloc_debug_map[ref] = malloc(1);
 #endif
 
-    return MemRef(slab.addr, ref);
+    return MemRef(slab.addr, ref, *this);
 }
 
 
@@ -395,7 +408,7 @@ MemRef SlabAlloc::do_realloc(size_t ref, const char* addr, size_t old_size, size
     MemRef new_mem = do_alloc(new_size); // Throws
 
     // Copy existing segment
-    char* new_addr = new_mem.m_addr;
+    char* new_addr = new_mem.get_addr();
     std::copy(addr, addr+old_size, new_addr);
 
     // Add old segment to freelist
@@ -404,7 +417,7 @@ MemRef SlabAlloc::do_realloc(size_t ref, const char* addr, size_t old_size, size
 #ifdef REALM_DEBUG
     if (m_debug_out) {
         std::cerr << "Realloc orig_ref: " << ref << " old_size: " << old_size << " "
-            "new_ref: " << new_mem.m_ref << " new_size: " << new_size << "\n";
+            "new_ref: " << new_mem.get_ref() << " new_size: " << new_size << "\n";
     }
 #endif // REALM_DEBUG
 

--- a/src/realm/array.hpp
+++ b/src/realm/array.hpp
@@ -1222,6 +1222,13 @@ public:
     // FIXME: Should not be public
     char* m_data = nullptr; // Points to first byte after header
 
+#ifdef REALM_MEMORY_DEBUG
+    // If m_no_relocation is false, then copy_on_write() will always relocate this array, regardless if it's
+    // required or not. If it's true, then it will never relocate, which is currently only expeted inside 
+    // GroupWriter::write_group() due to a unique chicken/egg problem (see description there).l
+    bool m_no_relocation = false;
+#endif
+
 protected:
     int64_t m_lbound;       // min number that can be stored with current m_width
     int64_t m_ubound;       // max number that can be stored with current m_width
@@ -1234,6 +1241,7 @@ private:
     size_t m_ref;
     ArrayParent* m_parent = nullptr;
     size_t m_ndx_in_parent = 0; // Ignored if m_parent is null.
+
 protected:
     uint_least8_t m_width = 0;  // Size of an element (meaning depend on type of array).
     bool m_is_inner_bptree_node; // This array is an inner node of B+-tree.
@@ -1571,7 +1579,7 @@ inline void Array::init_from_ref(ref_type ref) noexcept
 {
     REALM_ASSERT_DEBUG(ref);
     char* header = m_alloc.translate(ref);
-    init_from_mem(MemRef(header, ref));
+    init_from_mem(MemRef(header, ref, m_alloc));
 }
 
 
@@ -1694,7 +1702,7 @@ inline ref_type Array::get_ref() const noexcept
 
 inline MemRef Array::get_mem() const noexcept
 {
-    return MemRef(get_header_from_data(m_data), m_ref);
+    return MemRef(get_header_from_data(m_data), m_ref, m_alloc);
 }
 
 inline void Array::destroy() noexcept
@@ -1803,7 +1811,7 @@ inline void Array::destroy_deep(ref_type ref, Allocator& alloc) noexcept
 
 inline void Array::destroy_deep(MemRef mem, Allocator& alloc) noexcept
 {
-    if (!get_hasrefs_from_header(mem.m_addr)) {
+    if (!get_hasrefs_from_header(mem.get_addr())) {
         alloc.free_(mem);
         return;
     }
@@ -2140,7 +2148,7 @@ inline void Array::init_header(char* header, bool is_inner_bptree_node, bool has
 inline MemRef Array::clone_deep(Allocator& target_alloc) const
 {
     char* header = get_header_from_data(m_data);
-    return clone(MemRef(header, m_ref), m_alloc, target_alloc); // Throws
+    return clone(MemRef(header, m_ref, m_alloc), m_alloc, target_alloc); // Throws
 }
 
 inline void Array::move_assign(Array& a) noexcept
@@ -2325,12 +2333,12 @@ ref_type Array::bptree_append(TreeInsert<TreeTraits>& state)
     if (child_is_leaf) {
         size_t elem_ndx_in_child = npos; // Append
         new_sibling_ref =
-            TreeTraits::leaf_insert(MemRef(child_header, child_ref), childs_parent,
+            TreeTraits::leaf_insert(MemRef(child_header, child_ref, m_alloc), childs_parent,
                                     child_ref_ndx, m_alloc, elem_ndx_in_child, state); // Throws
     }
     else {
         Array child(m_alloc);
-        child.init_from_mem(MemRef(child_header, child_ref));
+        child.init_from_mem(MemRef(child_header, child_ref, m_alloc));
         child.set_parent(&childs_parent, child_ref_ndx);
         new_sibling_ref = child.bptree_append(state); // Throws
     }
@@ -2391,12 +2399,12 @@ ref_type Array::bptree_insert(size_t elem_ndx, TreeInsert<TreeTraits>& state)
     if (child_is_leaf) {
         REALM_ASSERT_3(elem_ndx_in_child, <=, REALM_MAX_BPNODE_SIZE);
         new_sibling_ref =
-            TreeTraits::leaf_insert(MemRef(child_header, child_ref), childs_parent,
+            TreeTraits::leaf_insert(MemRef(child_header, child_ref, m_alloc), childs_parent,
                                     child_ref_ndx, m_alloc, elem_ndx_in_child, state); // Throws
     }
     else {
         Array child(m_alloc);
-        child.init_from_mem(MemRef(child_header, child_ref));
+        child.init_from_mem(MemRef(child_header, child_ref, m_alloc));
         child.set_parent(&childs_parent, child_ref_ndx);
         new_sibling_ref = child.bptree_insert(elem_ndx_in_child, state); // Throws
     }

--- a/src/realm/array_basic_tpl.hpp
+++ b/src/realm/array_basic_tpl.hpp
@@ -56,7 +56,7 @@ inline MemRef BasicArray<T>::create_array(size_t size, Allocator& alloc)
     bool has_refs = false;
     bool context_flag = false;
     int width = sizeof (T);
-    init_header(mem.m_addr, is_inner_bptree_node, has_refs, context_flag, wtype_Multiply,
+    init_header(mem.get_addr(), is_inner_bptree_node, has_refs, context_flag, wtype_Multiply,
                 width, size, byte_size);
 
     return mem;

--- a/src/realm/array_binary.cpp
+++ b/src/realm/array_binary.cpp
@@ -184,16 +184,16 @@ MemRef ArrayBinary::create_array(size_t size, Allocator& alloc, BinaryData value
         bool context_flag = false;
         int64_t value = 0;
         MemRef mem = ArrayInteger::create_array(type_Normal, context_flag, size, value, alloc); // Throws
-        dg_2.reset(mem.m_ref);
-        int64_t v = from_ref(mem.m_ref);
+        dg_2.reset(mem.get_ref());
+        int64_t v = from_ref(mem.get_ref());
         top.add(v); // Throws
         dg_2.release();
     }
     {
         size_t blobs_size = 0;
         MemRef mem = ArrayBlob::create_array(blobs_size, alloc); // Throws
-        dg_2.reset(mem.m_ref);
-        int64_t v = from_ref(mem.m_ref);
+        dg_2.reset(mem.get_ref());
+        int64_t v = from_ref(mem.get_ref());
         top.add(v); // Throws
         dg_2.release();
     }
@@ -205,8 +205,8 @@ MemRef ArrayBinary::create_array(size_t size, Allocator& alloc, BinaryData value
         bool context_flag = false;
         int64_t value = values.is_null() ? 1 : 0;
         MemRef mem = ArrayInteger::create_array(type_Normal, context_flag, size, value, alloc); // Throws
-        dg_2.reset(mem.m_ref);
-        int64_t v = from_ref(mem.m_ref);
+        dg_2.reset(mem.get_ref());
+        int64_t v = from_ref(mem.get_ref());
         top.add(v); // Throws
         dg_2.release();
     }

--- a/src/realm/array_binary.hpp
+++ b/src/realm/array_binary.hpp
@@ -151,7 +151,7 @@ inline void ArrayBinary::init_from_ref(ref_type ref) noexcept
 {
     REALM_ASSERT(ref);
     char* header = get_alloc().translate(ref);
-    init_from_mem(MemRef(header, ref));
+    init_from_mem(MemRef(header, ref, m_alloc));
 }
 
 inline void ArrayBinary::init_from_parent() noexcept

--- a/src/realm/array_integer.cpp
+++ b/src/realm/array_integer.cpp
@@ -96,7 +96,7 @@ void ArrayIntNull::init_from_ref(ref_type ref) noexcept
 {
     REALM_ASSERT_DEBUG(ref);
     char* header = m_alloc.translate(ref);
-    init_from_mem(MemRef{header, ref});
+    init_from_mem(MemRef{header, ref, m_alloc});
 }
 
 void ArrayIntNull::init_from_mem(MemRef mem) noexcept

--- a/src/realm/array_string_long.cpp
+++ b/src/realm/array_string_long.cpp
@@ -232,16 +232,16 @@ MemRef ArrayStringLong::create_array(size_t size, Allocator& alloc, bool nullabl
         bool context_flag = false;
         int_fast64_t value = 0;
         MemRef mem = ArrayInteger::create_array(type_Normal, context_flag, size, value, alloc); // Throws
-        dg_2.reset(mem.m_ref);
-        int64_t v(mem.m_ref); // FIXME: Dangerous cast (unsigned -> signed)
+        dg_2.reset(mem.get_ref());
+        int64_t v(mem.get_ref()); // FIXME: Dangerous cast (unsigned -> signed)
         top.add(v); // Throws
         dg_2.release();
     }
     {
         size_t blobs_size = 0;
         MemRef mem = ArrayBlob::create_array(blobs_size, alloc); // Throws
-        dg_2.reset(mem.m_ref);
-        int64_t v(mem.m_ref); // FIXME: Dangerous cast (unsigned -> signed)
+        dg_2.reset(mem.get_ref());
+        int64_t v(mem.get_ref()); // FIXME: Dangerous cast (unsigned -> signed)
         top.add(v); // Throws
         dg_2.release();
     }
@@ -250,8 +250,8 @@ MemRef ArrayStringLong::create_array(size_t size, Allocator& alloc, bool nullabl
         bool context_flag = false;
         int64_t value = 0; // initialize all rows to realm::null()
         MemRef mem = ArrayInteger::create_array(type_Normal, context_flag, size, value, alloc); // Throws
-        dg_2.reset(mem.m_ref);
-        int64_t v(mem.m_ref); // FIXME: Dangerous cast (unsigned -> signed)
+        dg_2.reset(mem.get_ref());
+        int64_t v(mem.get_ref()); // FIXME: Dangerous cast (unsigned -> signed)
         top.add(v); // Throws
         dg_2.release();
     }

--- a/src/realm/array_string_long.hpp
+++ b/src/realm/array_string_long.hpp
@@ -127,7 +127,7 @@ inline void ArrayStringLong::init_from_ref(ref_type ref) noexcept
 {
     REALM_ASSERT(ref);
     char* header = get_alloc().translate(ref);
-    init_from_mem(MemRef(header, ref));
+    init_from_mem(MemRef(header, ref, m_alloc));
     m_nullable = (Array::size() == 3);
 }
 

--- a/src/realm/bptree.hpp
+++ b/src/realm/bptree.hpp
@@ -279,7 +279,7 @@ BpTree<T>::BpTree(BpTreeBase::unattached_tag) : BpTreeBase(nullptr)
 template<class T>
 std::unique_ptr<Array> BpTree<T>::create_root_from_mem(Allocator& alloc, MemRef mem)
 {
-    const char* header = mem.m_addr;
+    const char* header = mem.get_addr();
     std::unique_ptr<Array> new_root;
     bool is_inner_bptree_node = Array::get_is_inner_bptree_node_from_header(header);
 
@@ -312,7 +312,7 @@ std::unique_ptr<Array> BpTree<T>::create_root_from_mem(Allocator& alloc, MemRef 
 template<class T>
 std::unique_ptr<Array> BpTree<T>::create_root_from_ref(Allocator& alloc, ref_type ref)
 {
-    MemRef mem = MemRef{alloc.translate(ref), ref};
+    MemRef mem = MemRef{alloc.translate(ref), ref, alloc};
     return create_root_from_mem(alloc, mem);
 }
 
@@ -431,7 +431,7 @@ T BpTree<T>::get(size_t ndx) const noexcept
 
     // Use direct getter to avoid initializing leaf array:
     std::pair<MemRef, size_t> p = root().get_bptree_leaf(ndx);
-    const char* leaf_header = p.first.m_addr;
+    const char* leaf_header = p.first.get_addr();
     size_t ndx_in_leaf = p.second;
     return LeafType::get(leaf_header, ndx_in_leaf);
 }

--- a/src/realm/column.hpp
+++ b/src/realm/column.hpp
@@ -1369,7 +1369,7 @@ public:
     ref_type create_leaf(size_t size) override
     {
         MemRef mem = BpTree<T>::create_leaf(m_leaf_type, size, m_value, m_alloc); // Throws
-        return mem.m_ref;
+        return mem.get_ref();
     }
 private:
     const T m_value;

--- a/src/realm/column_backlink.cpp
+++ b/src/realm/column_backlink.cpp
@@ -459,7 +459,7 @@ void BacklinkColumn::get_backlinks(std::vector<VerifyPair>& pairs)
 std::pair<ref_type, size_t> BacklinkColumn::get_to_dot_parent(size_t ndx_in_parent) const
 {
     std::pair<MemRef, size_t> p = get_root_array()->get_bptree_leaf(ndx_in_parent);
-    return std::make_pair(p.first.m_ref, p.second);
+    return std::make_pair(p.first.get_ref(), p.second);
 }
 
 #endif // REALM_DEBUG

--- a/src/realm/column_binary.hpp
+++ b/src/realm/column_binary.hpp
@@ -208,7 +208,7 @@ inline BinaryData BinaryColumn::get(size_t ndx) const noexcept
 
     // Non-leaf root
     std::pair<MemRef, size_t> p = m_array->get_bptree_leaf(ndx);
-    const char* leaf_header = p.first.m_addr;
+    const char* leaf_header = p.first.get_addr();
     size_t ndx_in_leaf = p.second;
     Allocator& alloc = m_array->get_alloc();
     bool is_big = Array::get_context_flag_from_header(leaf_header);

--- a/src/realm/column_linklist.cpp
+++ b/src/realm/column_linklist.cpp
@@ -744,7 +744,7 @@ void LinkListColumn::verify(const Table& table, size_t col_ndx) const
 std::pair<ref_type, size_t> LinkListColumn::get_to_dot_parent(size_t ndx_in_parent) const
 {
     std::pair<MemRef, size_t> p = get_root_array()->get_bptree_leaf(ndx_in_parent);
-    return std::make_pair(p.first.m_ref, p.second);
+    return std::make_pair(p.first.get_ref(), p.second);
 }
 
 #endif // REALM_DEBUG

--- a/src/realm/column_table.cpp
+++ b/src/realm/column_table.cpp
@@ -245,7 +245,7 @@ void SubtableColumnBase::SubtableMap::refresh_accessor_tree(size_t spec_ndx_in_p
 std::pair<ref_type, size_t> SubtableColumnBase::get_to_dot_parent(size_t ndx_in_parent) const
 {
     std::pair<MemRef, size_t> p = get_root_array()->get_bptree_leaf(ndx_in_parent);
-    return std::make_pair(p.first.m_ref, p.second);
+    return std::make_pair(p.first.get_ref(), p.second);
 }
 
 #endif

--- a/src/realm/column_timestamp.cpp
+++ b/src/realm/column_timestamp.cpp
@@ -64,7 +64,7 @@ public:
     ref_type create_leaf(size_t size) override
     {
         MemRef mem = BT::create_leaf(Array::type_Normal, size, m_value, m_alloc); // Throws
-        return mem.m_ref;
+        return mem.get_ref();
     }
 private:
     const typename BT::value_type m_value;

--- a/src/realm/group_writer.cpp
+++ b/src/realm/group_writer.cpp
@@ -211,6 +211,11 @@ ref_type GroupWriter::write_group()
     REALM_ASSERT_3(reserve_size, >, max_free_space_needed);
     int_fast64_t value_4 = int_fast64_t(reserve_pos + max_free_space_needed); // FIXME: Problematic unsigned -> signed conversion
 
+#ifdef REALM_MEMORY_DEBUG
+    m_free_positions.m_no_relocation = true;
+    m_free_lengths.m_no_relocation = true;
+#endif
+
     // Ensure that this arrays does not reposition itself
     m_free_positions.ensure_minimum_width(value_4); // Throws
 

--- a/src/realm/spec.cpp
+++ b/src/realm/spec.cpp
@@ -93,8 +93,8 @@ MemRef Spec::create_empty_spec(Allocator& alloc)
         // One type for each column
         bool context_flag = false;
         MemRef mem = Array::create_empty_array(Array::type_Normal, context_flag, alloc); // Throws
-        dg_2.reset(mem.m_ref);
-        int_fast64_t v(mem.m_ref); // FIXME: Dangerous case: unsigned -> signed
+        dg_2.reset(mem.get_ref());
+        int_fast64_t v(mem.get_ref()); // FIXME: Dangerous case: unsigned -> signed
         spec_set.add(v); // Throws
         dg_2.release();
     }
@@ -102,8 +102,8 @@ MemRef Spec::create_empty_spec(Allocator& alloc)
         size_t size = 0;
         // One name for each column
         MemRef mem = ArrayString::create_array(size, alloc); // Throws
-        dg_2.reset(mem.m_ref);
-        int_fast64_t v = mem.m_ref; // FIXME: Dangerous case: unsigned -> signed
+        dg_2.reset(mem.get_ref());
+        int_fast64_t v = mem.get_ref(); // FIXME: Dangerous case: unsigned -> signed
         spec_set.add(v); // Throws
         dg_2.release();
     }
@@ -111,8 +111,8 @@ MemRef Spec::create_empty_spec(Allocator& alloc)
         // One attrib set for each column
         bool context_flag = false;
         MemRef mem = Array::create_empty_array(Array::type_Normal, context_flag, alloc); // Throws
-        dg_2.reset(mem.m_ref);
-        int_fast64_t v = mem.m_ref; // FIXME: Dangerous case: unsigned -> signed
+        dg_2.reset(mem.get_ref());
+        int_fast64_t v = mem.get_ref(); // FIXME: Dangerous case: unsigned -> signed
         spec_set.add(v); // Throws
         dg_2.release();
     }
@@ -142,16 +142,16 @@ void Spec::insert_column(size_t column_ndx, ColumnType type, StringData name, Co
             bool context_flag = false;
             MemRef subspecs_mem =
                 Array::create_empty_array(Array::type_HasRefs, context_flag, alloc); // Throws
-            _impl::DeepArrayRefDestroyGuard dg(subspecs_mem.m_ref, alloc);
+            _impl::DeepArrayRefDestroyGuard dg(subspecs_mem.get_ref(), alloc);
             if (m_top.size() == 3) {
-                int_fast64_t v(subspecs_mem.m_ref); // FIXME: Dangerous cast (unsigned -> signed)
+                int_fast64_t v(subspecs_mem.get_ref()); // FIXME: Dangerous cast (unsigned -> signed)
                 m_top.add(v); // Throws
             }
             else {
-                int_fast64_t v(subspecs_mem.m_ref); // FIXME: Dangerous cast (unsigned -> signed)
+                int_fast64_t v(subspecs_mem.get_ref()); // FIXME: Dangerous cast (unsigned -> signed)
                 m_top.set(3, v); // Throws
             }
-            m_subspecs.init_from_ref(subspecs_mem.m_ref);
+            m_subspecs.init_from_ref(subspecs_mem.get_ref());
             m_subspecs.set_parent(&m_top, 3);
             dg.release();
         }
@@ -159,9 +159,9 @@ void Spec::insert_column(size_t column_ndx, ColumnType type, StringData name, Co
         if (type == col_type_Table) {
             // Add a new empty spec to `m_subspecs`
             MemRef subspec_mem = create_empty_spec(alloc); // Throws
-            _impl::DeepArrayRefDestroyGuard dg(subspec_mem.m_ref, alloc);
+            _impl::DeepArrayRefDestroyGuard dg(subspec_mem.get_ref(), alloc);
             size_t subspec_ndx = get_subspec_ndx(column_ndx);
-            int_fast64_t v(subspec_mem.m_ref); // FIXME: Dangerous cast (unsigned -> signed)
+            int_fast64_t v(subspec_mem.get_ref()); // FIXME: Dangerous cast (unsigned -> signed)
             m_subspecs.insert(subspec_ndx, v); // Throws
             dg.release();
         }

--- a/src/realm/table.cpp
+++ b/src/realm/table.cpp
@@ -1976,16 +1976,16 @@ ref_type Table::create_empty_table(Allocator& alloc)
 
     {
         MemRef mem = Spec::create_empty_spec(alloc); // Throws
-        dg_2.reset(mem.m_ref);
-        int_fast64_t v(mem.m_ref); // FIXME: Dangerous case (unsigned -> signed)
+        dg_2.reset(mem.get_ref());
+        int_fast64_t v(mem.get_ref()); // FIXME: Dangerous case (unsigned -> signed)
         top.add(v); // Throws
         dg_2.release();
     }
     {
         bool context_flag = false;
         MemRef mem = Array::create_empty_array(Array::type_HasRefs, context_flag, alloc); // Throws
-        dg_2.reset(mem.m_ref);
-        int_fast64_t v(mem.m_ref); // FIXME: Dangerous case (unsigned -> signed)
+        dg_2.reset(mem.get_ref());
+        int_fast64_t v(mem.get_ref()); // FIXME: Dangerous case (unsigned -> signed)
         top.add(v); // Throws
         dg_2.release();
     }
@@ -2045,7 +2045,7 @@ ref_type Table::clone_columns(Allocator& alloc) const
         ref_type new_col_ref;
         const ColumnBase* col = &get_column_base(col_ndx);
         MemRef mem = col->clone_deep(alloc);
-        new_col_ref = mem.m_ref;
+        new_col_ref = mem.get_ref();
         new_columns.add(int_fast64_t(new_col_ref)); // Throws
     }
     return new_columns.get_ref();
@@ -2056,7 +2056,7 @@ ref_type Table::clone(Allocator& alloc) const
 {
     if (m_top.is_attached()) {
         MemRef mem = m_top.clone_deep(alloc); // Throws
-        return mem.m_ref;
+        return mem.get_ref();
     }
 
     Array new_top(alloc);
@@ -2065,15 +2065,15 @@ ref_type Table::clone(Allocator& alloc) const
     _impl::DeepArrayRefDestroyGuard dg_2(alloc);
     {
         MemRef mem = m_spec.m_top.clone_deep(alloc); // Throws
-        dg_2.reset(mem.m_ref);
-        int_fast64_t v(mem.m_ref); // FIXME: Dangerous cast (unsigned -> signed)
+        dg_2.reset(mem.get_ref());
+        int_fast64_t v(mem.get_ref()); // FIXME: Dangerous cast (unsigned -> signed)
         new_top.add(v); // Throws
         dg_2.release();
     }
     {
         MemRef mem = m_columns.clone_deep(alloc); // Throws
-        dg_2.reset(mem.m_ref);
-        int_fast64_t v(mem.m_ref); // FIXME: Dangerous cast (unsigned -> signed)
+        dg_2.reset(mem.get_ref());
+        int_fast64_t v(mem.get_ref()); // FIXME: Dangerous cast (unsigned -> signed)
         new_top.add(v); // Throws
         dg_2.release();
     }

--- a/src/realm/table_view.hpp
+++ b/src/realm/table_view.hpp
@@ -890,7 +890,7 @@ inline TableViewBase::TableViewBase(const TableViewBase& tv):
     // RAII idiom (nor should it).
     Allocator& alloc = m_row_indexes.get_alloc();
     MemRef mem = tv.m_row_indexes.get_root_array()->clone_deep(alloc); // Throws
-    _impl::DeepArrayRefDestroyGuard ref_guard(mem.m_ref, alloc);
+    _impl::DeepArrayRefDestroyGuard ref_guard(mem.get_ref(), alloc);
     if (m_table)
         m_table->register_view(this); // Throws
     m_row_indexes.get_root_array()->init_from_mem(mem);

--- a/src/realm/util/file.hpp
+++ b/src/realm/util/file.hpp
@@ -569,7 +569,7 @@ public:
     File::Map<T>& operator=(File::Map<T>&& other)
     {
         if (m_addr) unmap();
-        m_addr = other.m_addr;
+        m_addr = other.get_addr();
         m_size = other.m_size;
         other.m_addr = 0;
         other.m_size = 0;

--- a/test/test_all.cpp
+++ b/test/test_all.cpp
@@ -210,6 +210,12 @@ void display_build_config()
     const char* with_debug =
         Version::has_feature(feature_Debug) ? "Enabled" : "Disabled";
 
+#ifdef REALM_MEMORY_DEBUG
+    const char* trigger_relocations = "Enabled";
+#else
+    const char* trigger_relocations = "Disabled";
+#endif
+
 #if REALM_ENABLE_ENCRYPTION
     bool always_encrypt = is_always_encrypt_enabled();
     const char* encryption = always_encrypt ?
@@ -242,6 +248,7 @@ void display_build_config()
         "Encryption: "<<encryption<<"\n"
         "\n"
         "REALM_MAX_BPNODE_SIZE = "<<REALM_MAX_BPNODE_SIZE<<"\n"
+        "REALM_MEMORY_DEBUG = " << trigger_relocations << "\n"
         "\n"
         // Be aware that ps3/xbox have sizeof (void*) = 4 && sizeof (size_t) == 8
         // We decide to print size_t here

--- a/test/test_alloc.cpp
+++ b/test/test_alloc.cpp
@@ -77,23 +77,23 @@ TEST(Alloc_1)
     MemRef mr3 = alloc.alloc(256);
 
     // Set size in headers (needed for Alloc::free())
-    set_capacity(mr1.m_addr, 8);
-    set_capacity(mr2.m_addr, 16);
-    set_capacity(mr3.m_addr, 256);
+    set_capacity(mr1.get_addr(), 8);
+    set_capacity(mr2.get_addr(), 16);
+    set_capacity(mr3.get_addr(), 256);
 
     // Are pointers 64bit aligned
-    CHECK_EQUAL(0, intptr_t(mr1.m_addr) & 0x7);
-    CHECK_EQUAL(0, intptr_t(mr2.m_addr) & 0x7);
-    CHECK_EQUAL(0, intptr_t(mr3.m_addr) & 0x7);
+    CHECK_EQUAL(0, intptr_t(mr1.get_addr()) & 0x7);
+    CHECK_EQUAL(0, intptr_t(mr2.get_addr()) & 0x7);
+    CHECK_EQUAL(0, intptr_t(mr3.get_addr()) & 0x7);
 
     // Do refs translate correctly
-    CHECK_EQUAL(static_cast<void*>(mr1.m_addr), alloc.translate(mr1.m_ref));
-    CHECK_EQUAL(static_cast<void*>(mr2.m_addr), alloc.translate(mr2.m_ref));
-    CHECK_EQUAL(static_cast<void*>(mr3.m_addr), alloc.translate(mr3.m_ref));
+    CHECK_EQUAL(static_cast<void*>(mr1.get_addr()), alloc.translate(mr1.get_ref()));
+    CHECK_EQUAL(static_cast<void*>(mr2.get_addr()), alloc.translate(mr2.get_ref()));
+    CHECK_EQUAL(static_cast<void*>(mr3.get_addr()), alloc.translate(mr3.get_ref()));
 
-    alloc.free_(mr3.m_ref, mr3.m_addr);
-    alloc.free_(mr2.m_ref, mr2.m_addr);
-    alloc.free_(mr1.m_ref, mr1.m_addr);
+    alloc.free_(mr3.get_ref(), mr3.get_addr());
+    alloc.free_(mr2.get_ref(), mr2.get_addr());
+    alloc.free_(mr1.get_ref(), mr1.get_addr());
 
     // SlabAlloc destructor will verify that all is free'd
 }
@@ -249,15 +249,15 @@ TEST(Alloc_Fuzzy)
             siz *= 8;
             MemRef r = alloc.alloc(siz);
             refs.push_back(r);
-            set_capacity(r.m_addr, siz);
+            set_capacity(r.get_addr(), siz);
 
             // write some data to the allcoated area so that we can verify it later
-            memset(r.m_addr + 3, static_cast<char>(reinterpret_cast<intptr_t>(r.m_addr)), siz - 3);
+            memset(r.get_addr() + 3, static_cast<char>(reinterpret_cast<intptr_t>(r.get_addr())), siz - 3);
         }
         else if(refs.size() > 0) {
             // free random entry
             size_t entry = rand() % refs.size();
-            alloc.free_(refs[entry].m_ref, refs[entry].m_addr);
+            alloc.free_(refs[entry].get_ref(), refs[entry].get_addr());
             refs.erase(refs.begin() + entry);
         }
 
@@ -265,17 +265,17 @@ TEST(Alloc_Fuzzy)
             // free everything when we have 10 allocations, or when we exit, to not leak
             while(refs.size() > 0) {
                 MemRef r = refs[0];
-                size_t siz = get_capacity(r.m_addr);
+                size_t siz = get_capacity(r.get_addr());
 
                 // verify that all the data we wrote during allocation is intact
                 for (size_t c = 3; c < siz; c++) {
-                    if (r.m_addr[c] != static_cast<char>(reinterpret_cast<intptr_t>(r.m_addr))) {
+                    if (r.get_addr()[c] != static_cast<char>(reinterpret_cast<intptr_t>(r.get_addr()))) {
                         // faster than using 'CHECK' for each character, which is slow
                         CHECK(false);
                     }
                 }
 
-                alloc.free_(r.m_ref, r.m_addr);
+                alloc.free_(r.get_ref(), r.get_addr());
                 refs.erase(refs.begin());
             }
 

--- a/test/test_destroy_guard.cpp
+++ b/test/test_destroy_guard.cpp
@@ -76,7 +76,7 @@ public:
         REALM_ASSERT(!addr);
         addr = new char[size]; // Throws
         m_offset += size;
-        return MemRef(addr, ref);
+        return MemRef(addr, ref, *this);
     }
 
     void do_free(ref_type ref, const char* addr) noexcept override
@@ -181,7 +181,7 @@ TEST(DestroyGuard_ArrayShallow)
         {
             bool context_flag = false;
             MemRef child_mem = Array::create_empty_array(Array::type_Normal, context_flag, alloc);
-            int_fast64_t v(child_mem.m_ref);
+            int_fast64_t v(child_mem.get_ref());
             root.add(v);
         }
     }
@@ -240,7 +240,7 @@ TEST(DestroyGuard_ArrayDeep)
                 bool context_flag = false;
                 MemRef child_mem =
                     Array::create_empty_array(Array::type_Normal, context_flag, alloc);
-                int_fast64_t v(child_mem.m_ref);
+                int_fast64_t v(child_mem.get_ref());
                 root.add(v);
             }
         }
@@ -258,8 +258,8 @@ TEST(DestroyGuard_ArrayRefDeep)
         {
             bool context_flag = false;
             MemRef mem = Array::create_empty_array(Array::type_Normal, context_flag, alloc);
-            DeepArrayRefDestroyGuard dg(mem.m_ref, alloc);
-            CHECK_EQUAL(mem.m_ref, dg.get());
+            DeepArrayRefDestroyGuard dg(mem.get_ref(), alloc);
+            CHECK_EQUAL(mem.get_ref(), dg.get());
         }
         CHECK(alloc.empty());
     }
@@ -269,8 +269,8 @@ TEST(DestroyGuard_ArrayRefDeep)
         {
             bool context_flag = false;
             MemRef mem = Array::create_empty_array(Array::type_Normal, context_flag, alloc);
-            DeepArrayRefDestroyGuard dg(mem.m_ref, alloc);
-            CHECK_EQUAL(mem.m_ref, dg.release());
+            DeepArrayRefDestroyGuard dg(mem.get_ref(), alloc);
+            CHECK_EQUAL(mem.get_ref(), dg.release());
         }
         CHECK(!alloc.empty());
         alloc.clear();
@@ -282,9 +282,9 @@ TEST(DestroyGuard_ArrayRefDeep)
             bool context_flag = false;
             DeepArrayRefDestroyGuard dg(alloc);
             MemRef mem_1 = Array::create_empty_array(Array::type_Normal, context_flag, alloc);
-            dg.reset(mem_1.m_ref);
+            dg.reset(mem_1.get_ref());
             MemRef mem_2 = Array::create_empty_array(Array::type_Normal, context_flag, alloc);
-            dg.reset(mem_2.m_ref);
+            dg.reset(mem_2.get_ref());
         }
         CHECK(alloc.empty());
     }
@@ -299,7 +299,7 @@ TEST(DestroyGuard_ArrayRefDeep)
                 bool context_flag = false;
                 MemRef child_mem =
                     Array::create_empty_array(Array::type_Normal, context_flag, alloc);
-                int_fast64_t v(child_mem.m_ref);
+                int_fast64_t v(child_mem.get_ref());
                 root.add(v);
                 root_ref = root.get_ref();
             }


### PR DESCRIPTION
commit c382ed7eb6ac95b1a94bb803a815d4b4389ff455
Author: Lasse Reinhold lr@tightdb.com
Date:   Mon May 30 15:40:51 2016 +0200

```
space
```

commit 79a68aad7ae1e87dc4440f22211e6a0e8878e3c7
Author: Lasse Reinhold lr@tightdb.com
Date:   Mon May 30 15:39:33 2016 +0200

```
wip
```

commit 1574e5e458c83f1ea5cdc78ce3ade6c4b02e02ab
Merge: 836f72b 74c7f1c
Author: Lasse Reinhold lr@tightdb.com
Date:   Mon May 30 15:37:28 2016 +0200

```
Merge branch 'master' of https://github.com/realm/realm-core into lr/relocation

Conflicts:
    src/realm/group_writer.cpp
```

commit 836f72bcf5f52b83baf0d237cb8b29d2767d0509
Author: Lasse Reinhold lr@tightdb.com
Date:   Mon May 30 15:32:58 2016 +0200

```
small fixes
```

commit 1907020d44d6fb042433339230c0ab06c32936cb
Author: Lasse Reinhold lr@tightdb.com
Date:   Mon May 30 15:14:42 2016 +0200

```
wip
```

commit 9b8b783a0b1ef102396040e3a0bdb1734ae30e1b
Author: Lasse Reinhold lr@tightdb.com
Date:   Mon May 30 14:56:27 2016 +0200

```
wrapped access to MemRef::get/set ref/addr
```

commit 70d78a334911bad5fbdc78b38df069f48e136714
Author: Lasse Reinhold lr@tightdb.com
Date:   Mon May 23 11:33:32 2016 +0200

```
Debug tests to see if there are any use-after-free bugs
```

commit d17d6c1424171b958ee1550abc9771e71ec559a1
Merge: 99b78e7 5b2cf3c
Author: Lasse Reinhold lr@tightdb.com
Date:   Wed May 18 16:13:01 2016 +0200

```
Merge branch 'lr/corruption' of https://github.com/realm/realm-core into lr/relocation
```

commit 99b78e741df49c7bcc7f19f56082d447ef57f3e1
Author: Lasse Reinhold lr@tightdb.com
Date:   Wed May 18 16:12:26 2016 +0200

```
wip
```

commit 5b2cf3cb45d81f4baea22419a140d4f20da67320
Author: Lasse Reinhold lr@tightdb.com
Date:   Wed May 18 15:54:16 2016 +0200

```
Reverted the fix (did not fix anything) but leaved the asserts
```

commit be37d0d3aef9eaca4b3bb4b6f2bceb0d3cfb9a2b
Author: Lasse Reinhold lr@tightdb.com
Date:   Wed May 18 15:38:13 2016 +0200

```
release_notes.md
```

commit 9d20ac0dc3e4dfab6a49bebde95090d99f3560a1
Merge: a00e9fa e46c818
Author: Lasse Reinhold lr@tightdb.com
Date:   Wed May 18 15:20:10 2016 +0200

```
Merge branch 'lr/corruption' of https://github.com/realm/realm-core into lr/relocation

Conflicts:
    src/realm/group_writer.cpp
```

commit a00e9fa1808404fa9709af384f9ef7cda4718d95
Author: Lasse Reinhold lr@tightdb.com
Date:   Wed May 18 15:18:06 2016 +0200

```
[WIP] tests for relocation bugs [WIP]
```

commit e46c81828b88e421c238793751f56ecbfce30b80
Author: Lasse Reinhold lr@tightdb.com
Date:   Wed May 18 15:09:48 2016 +0200

```
off by one fix
```

commit 18c9eeb15648a62e88985b515b0fe795e4df6e3e
Author: Lasse Reinhold lr@realm.io
Date:   Wed May 18 15:06:14 2016 +0200

```
Update group_writer.cpp
```

commit 1cedeade93c517af8138d68e1713e78a83551108
Author: Lasse Reinhold lr@tightdb.com
Date:   Wed May 18 14:54:53 2016 +0200

```
whitespace
```

commit a161475ab7efd0970b7ff978b05d7bd34b220e9d
Author: Lasse Reinhold lr@tightdb.com
Date:   Wed May 18 14:52:55 2016 +0200

```
*Maybe* fixed a bug that could cause corrupted database files
```
