### PR TITLE
Fixes for: Run non-concurrent tests on the main thread

### DIFF
--- a/test/test_index_string.cpp
+++ b/test/test_index_string.cpp
@@ -1338,7 +1338,8 @@ TEST(StringIndex_Deny_Duplicates)
 // for the col.destroy() method to complete recursivly.
 // Non-concurrent tests run on the main process thread and they
 // do not have this stack size limitation.
-NONCONCURRENT_TEST(StringIndex_InsertLongPrefix) {
+NONCONCURRENT_TEST(StringIndex_InsertLongPrefix)
+{
     ref_type ref = StringColumn::create(Allocator::get_default());
     StringColumn col(Allocator::get_default(), ref, true);
 

--- a/test/util/unit_test.hpp
+++ b/test/util/unit_test.hpp
@@ -51,7 +51,8 @@
     TEST_EX(name, realm::test_util::unit_test::get_default_test_list(), enabled, true)
 
 /// Add a test that must neither execute concurrently with other tests, nor with
-/// itself.
+/// itself. These tests will always be executed by the thread that calls
+/// TestList::run().
 #define NONCONCURRENT_TEST(name) \
     NONCONCURRENT_TEST_IF(name, true)
 


### PR DESCRIPTION
Proposed changes for https://github.com/realm/realm-core/pull/1862

This avoids bumping the number of threads to one higher than is asked for (from the point of view of the progress reporting), and it maintains the "illusion" of the noncuncurrent tests running in the same test thread (thread context) as the regular test that finishes last. 

@ironage 
