### PR TITLE
Silence implicit cast warning.

### DIFF
--- a/src/realm/array.cpp
+++ b/src/realm/array.cpp
@@ -185,7 +185,7 @@ void Array::init_from_mem(MemRef mem) noexcept
     m_is_inner_bptree_node = get_is_inner_bptree_node_from_header(header);
     m_has_refs             = get_hasrefs_from_header(header);
     m_context_flag         = get_context_flag_from_header(header);
-    m_width                = uint_least8_t(get_width_from_header(header));
+    m_width                = get_width_from_header(header);
     m_size                 = get_size_from_header(header);
 
     // Capacity is how many items there are room for
@@ -2780,7 +2780,7 @@ size_t Array::index_string(StringData value, IntegerColumn& result, ref_type& re
 
     const char* data = m_data;
     const char* header;
-    size_t width = m_width;
+    uint_least8_t width = m_width;
     bool is_inner_node = m_is_inner_bptree_node;
     typedef StringIndex::key_type key_type;
     key_type key;
@@ -2852,7 +2852,7 @@ top:
             if (sub_isleaf) {
                 if (count)
                     sub_count = get_size_from_header(sub_header);
-                const size_t sub_width = get_width_from_header(sub_header);
+                const uint_least8_t sub_width = get_width_from_header(sub_header);
                 const char* sub_data = get_data_from_header(sub_header);
                 const size_t first_row_ref = to_size_t(get_direct(sub_data, sub_width, 0));
 
@@ -2995,7 +2995,7 @@ inline std::pair<size_t, size_t> find_bptree_child(int_fast64_t first_value, siz
         // Case 2/2: Offsets array (general form)
         ref_type offsets_ref = to_ref(first_value);
         char* offsets_header = alloc.translate(offsets_ref);
-        size_t offsets_width = Array::get_width_from_header(offsets_header);
+        uint_least8_t offsets_width = Array::get_width_from_header(offsets_header);
         std::pair<size_t, size_t> p;
         REALM_TEMPEX(p = find_child_from_offsets, offsets_width, (offsets_header, ndx));
         child_ndx    = p.first;
@@ -3213,7 +3213,7 @@ void destroy_singlet_bptree_branch(MemRef mem, Allocator& alloc,
         }
 
         const char* data = Array::get_data_from_header(header);
-        size_t width = Array::get_width_from_header(header);
+        uint_least8_t width = Array::get_width_from_header(header);
         size_t ndx = 0;
         std::pair<int_fast64_t, int_fast64_t> p = get_two(data, width, ndx);
         int_fast64_t first_value = p.first;
@@ -3293,7 +3293,7 @@ std::pair<MemRef, size_t> Array::get_bptree_leaf(size_t ndx) const noexcept
     REALM_ASSERT(is_inner_bptree_node());
 
     size_t ndx_2 = ndx;
-    size_t width = m_width;
+    uint_least8_t width = m_width;
     const char* data = m_data;
 
     for (;;) {
@@ -3572,7 +3572,7 @@ void Array::create_bptree_offsets(Array& offsets, int_fast64_t first_value)
 int_fast64_t Array::get(const char* header, size_t ndx) noexcept
 {
     const char* data = get_data_from_header(header);
-    size_t width = get_width_from_header(header);
+    uint_least8_t width = get_width_from_header(header);
     return get_direct(data, width, ndx);
 }
 
@@ -3580,7 +3580,7 @@ int_fast64_t Array::get(const char* header, size_t ndx) noexcept
 std::pair<int64_t, int64_t> Array::get_two(const char* header, size_t ndx) noexcept
 {
     const char* data = get_data_from_header(header);
-    size_t width = get_width_from_header(header);
+    uint_least8_t width = get_width_from_header(header);
     std::pair<int64_t, int64_t> p = ::get_two(data, width, ndx);
     return std::make_pair(p.first, p.second);
 }
@@ -3589,6 +3589,6 @@ std::pair<int64_t, int64_t> Array::get_two(const char* header, size_t ndx) noexc
 void Array::get_three(const char* header, size_t ndx, ref_type& v0, ref_type& v1, ref_type& v2) noexcept
 {
     const char* data = get_data_from_header(header);
-    size_t width = get_width_from_header(header);
+    uint_least8_t width = get_width_from_header(header);
     ::get_three(data, width, ndx, v0, v1, v2);
 }

--- a/src/realm/array.hpp
+++ b/src/realm/array.hpp
@@ -991,7 +991,7 @@ public:
     static bool get_hasrefs_from_header(const char*) noexcept;
     static bool get_context_flag_from_header(const char*) noexcept;
     static WidthType get_wtype_from_header(const char*) noexcept;
-    static size_t get_width_from_header(const char*) noexcept;
+    static uint_least8_t get_width_from_header(const char*) noexcept;
     static size_t get_size_from_header(const char*) noexcept;
 
     static Type get_type_from_header(const char*) noexcept;
@@ -1073,7 +1073,7 @@ protected:
     bool get_hasrefs_from_header() const noexcept;
     bool get_context_flag_from_header() const noexcept;
     WidthType get_wtype_from_header() const noexcept;
-    size_t get_width_from_header() const noexcept;
+    uint_least8_t get_width_from_header() const noexcept;
     size_t get_size_from_header() const noexcept;
 
     // Undefined behavior if m_alloc.is_read_only(m_ref) returns true
@@ -1839,11 +1839,11 @@ inline Array::WidthType Array::get_wtype_from_header(const char* header) noexcep
     const uchar* h = reinterpret_cast<const uchar*>(header);
     return WidthType((int(h[4]) & 0x18) >> 3);
 }
-inline size_t Array::get_width_from_header(const char* header) noexcept
+inline uint_least8_t Array::get_width_from_header(const char* header) noexcept
 {
     typedef unsigned char uchar;
     const uchar* h = reinterpret_cast<const uchar*>(header);
-    return size_t((1 << (int(h[4]) & 0x07)) >> 1);
+    return uint_least8_t((1 << (int(h[4]) & 0x07)) >> 1);
 }
 inline size_t Array::get_size_from_header(const char* header) noexcept
 {
@@ -1889,7 +1889,7 @@ inline Array::WidthType Array::get_wtype_from_header() const noexcept
 {
     return get_wtype_from_header(get_header_from_data(m_data));
 }
-inline size_t Array::get_width_from_header() const noexcept
+inline uint_least8_t Array::get_width_from_header() const noexcept
 {
     return get_width_from_header(get_header_from_data(m_data));
 }
@@ -2063,7 +2063,7 @@ inline size_t Array::get_byte_size() const noexcept
 inline size_t Array::get_byte_size_from_header(const char* header) noexcept
 {
     size_t size = get_size_from_header(header);
-    uint_least8_t width = uint_least8_t(get_width_from_header(header));
+    uint_least8_t width = get_width_from_header(header);
     WidthType wtype = get_wtype_from_header(header);
     size_t num_bytes = calc_byte_size(wtype, size, width);
 

--- a/src/realm/array_string.hpp
+++ b/src/realm/array_string.hpp
@@ -171,7 +171,7 @@ inline void ArrayString::add()
 inline StringData ArrayString::get(const char* header, size_t ndx, bool nullable) noexcept
 {
     REALM_ASSERT(ndx < get_size_from_header(header));
-    size_t width = get_width_from_header(header);
+    uint_least8_t width = get_width_from_header(header);
     const char* data = get_data_from_header(header) + (ndx * width);
 
     if (width == 0)


### PR DESCRIPTION
Xcode reported the following warning: `Implicit conversion loses integer precision: size_t to uint_least8_t`

We assume certain restraints on width so I just cast explicitly.

@jedelbo @finnschiermer
