### PR TITLE
Introduced REALM_ENABLE_MEMDEBUG flag that catches any reference to a…

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -639,6 +639,11 @@ case "$MODE" in
             enable_assertions="yes"
         fi
 
+        enable_memdebug="no"
+        if [ "$REALM_ENABLE_MEMDEBUG" ]; then
+            enable_memdebug="yes"
+        fi
+		
         # Find Xcode
         xcode_home="none"
         xcodeselect="xcode-select"
@@ -703,6 +708,7 @@ INSTALL_LIBEXECDIR    = $install_libexecdir
 MAX_BPNODE_SIZE       = $max_bpnode_size
 MAX_BPNODE_SIZE_DEBUG = $max_bpnode_size_debug
 ENABLE_ASSERTIONS     = $enable_assertions
+ENABLE_MEMDEBUG       = $enable_memdebug
 ENABLE_ALLOC_SET_ZERO = $enable_alloc_set_zero
 ENABLE_ENCRYPTION     = $enable_encryption
 XCODE_HOME            = $xcode_home

--- a/src/realm/alloc.cpp
+++ b/src/realm/alloc.cpp
@@ -58,7 +58,7 @@ public:
 #if REALM_ENABLE_ALLOC_SET_ZERO
         std::fill(addr, addr+size, 0);
 #endif
-        return MemRef(addr, reinterpret_cast<size_t>(addr));
+        return MemRef(addr, reinterpret_cast<size_t>(addr), *this);
     }
 
     MemRef do_realloc(ref_type, const char* addr, size_t old_size,
@@ -74,7 +74,7 @@ public:
 #else
         static_cast<void>(old_size);
 #endif
-        return MemRef(new_addr, reinterpret_cast<size_t>(new_addr));
+        return MemRef(new_addr, reinterpret_cast<size_t>(new_addr), *this);
     }
 
     void do_free(ref_type, const char* addr) noexcept override
@@ -100,4 +100,20 @@ Allocator& Allocator::get_default() noexcept
 {
     static DefaultAllocator default_alloc;
     return default_alloc;
+}
+
+MemRef Allocator::do_realloc(ref_type ref, const char* addr, size_t old_size,
+                             size_t new_size)
+{
+    // Allocate new space
+    MemRef new_mem = do_alloc(new_size); // Throws
+
+    // Copy existing contents
+    char* new_addr = new_mem.get_addr();
+    std::copy(addr, addr+old_size, new_addr);
+
+    // Free old chunk
+    do_free(ref, addr);
+
+    return new_mem;
 }

--- a/src/realm/alloc.hpp
+++ b/src/realm/alloc.hpp
@@ -41,13 +41,26 @@ ref_type to_ref(int_fast64_t) noexcept;
 
 class MemRef {
 public:
-    char* m_addr;
-    ref_type m_ref;
 
     MemRef() noexcept;
     ~MemRef() noexcept;
-    MemRef(char* addr, ref_type ref) noexcept;
+
+    MemRef(char* addr, ref_type ref, Allocator& alloc) noexcept;
     MemRef(ref_type ref, Allocator& alloc) noexcept;
+
+    char* get_addr();
+    ref_type get_ref();
+    void set_ref(ref_type ref);
+    void set_addr(char* addr);
+
+private:
+    char* m_addr;
+    ref_type m_ref;
+#if REALM_ENABLE_MEMDEBUG
+    // Allocator that created m_ref. Used to verify that the ref is valid whenever you call 
+    // get_ref()/get_addr and that it e.g. has not been free'ed
+    const Allocator* m_alloc = nullptr;
+#endif
 };
 
 
@@ -86,7 +99,7 @@ public:
     /// would conflict with a macro on the Windows platform.
     void free_(ref_type, const char* addr) noexcept;
 
-    /// Shorthand for free_(mem.m_ref, mem.m_addr).
+    /// Shorthand for free_(mem.get_ref(), mem.get_addr()).
     void free_(MemRef mem) noexcept;
 
     /// Calls do_translate().
@@ -295,18 +308,57 @@ inline MemRef::~MemRef() noexcept
 {
 }
 
-inline MemRef::MemRef(char* addr, ref_type ref) noexcept:
+inline MemRef::MemRef(char* addr, ref_type ref, Allocator& alloc) noexcept:
     m_addr(addr),
     m_ref(ref)
 {
+    static_cast<void>(alloc);
+#if REALM_ENABLE_MEMDEBUG
+    m_alloc = &alloc;
+#endif
 }
 
 inline MemRef::MemRef(ref_type ref, Allocator& alloc) noexcept:
     m_addr(alloc.translate(ref)),
     m_ref(ref)
 {
+    static_cast<void>(alloc);
+#if REALM_ENABLE_MEMDEBUG
+    m_alloc = &alloc;
+#endif
 }
 
+inline char* MemRef::get_addr()
+{
+#if REALM_ENABLE_MEMDEBUG
+    // Asserts if the ref has been freed
+    m_alloc->translate(m_ref);
+#endif
+    return m_addr;
+}
+
+inline ref_type MemRef::get_ref()
+{
+#if REALM_ENABLE_MEMDEBUG
+    // Asserts if the ref has been freed
+    m_alloc->translate(m_ref);
+#endif
+    return m_ref;
+}
+
+inline void MemRef::set_ref(ref_type ref)
+{
+#if REALM_ENABLE_MEMDEBUG
+    // Asserts if the ref has been freed
+    m_alloc->translate(ref);
+#endif
+    m_ref = ref;
+}
+
+inline void MemRef::set_addr(char* addr)
+{
+    m_addr = addr;
+}
 
 inline MemRef Allocator::alloc(size_t size)
 {
@@ -334,7 +386,7 @@ inline void Allocator::free_(ref_type ref, const char* addr) noexcept
 
 inline void Allocator::free_(MemRef mem) noexcept
 {
-    free_(mem.m_ref, mem.m_addr);
+    free_(mem.get_ref(), mem.get_addr());
 }
 
 inline char* Allocator::translate(ref_type ref) const noexcept

--- a/src/realm/alloc_slab.cpp
+++ b/src/realm/alloc_slab.cpp
@@ -222,6 +222,19 @@ MemRef SlabAlloc::do_alloc(size_t size)
         iter rend = m_free_space.rend();
         for (iter i = m_free_space.rbegin(); i != rend; ++i) {
             if (size <= i->size) {
+
+#if REALM_ENABLE_MEMDEBUG
+                // Pick a *random* match instead of just the first. This will increase the chance of catching
+                // use-after-free bugs in Core. It's chosen such that the mathematical average of all picked 
+                // positions is the middle of the list. 
+                iter j = i;
+                while (j != rend && (size > j->size || fastrand() % (m_free_space.size() / 2 + 1) != 0)) {
+                    j++;
+                }
+                if (j != rend)
+                    i = j;
+#endif
+
                 ref_type ref = i->ref;
                 size_t rest = i->size - size;
 
@@ -248,7 +261,7 @@ MemRef SlabAlloc::do_alloc(size_t size)
 #ifdef REALM_SLAB_ALLOC_DEBUG
                 malloc_debug_map[ref] = malloc(1);
 #endif
-                return MemRef(addr, ref);
+                return MemRef(addr, ref, *this);
             }
         }
     }
@@ -301,7 +314,7 @@ MemRef SlabAlloc::do_alloc(size_t size)
     malloc_debug_map[ref] = malloc(1);
 #endif
 
-    return MemRef(slab.addr, ref);
+    return MemRef(slab.addr, ref, *this);
 }
 
 
@@ -399,7 +412,7 @@ MemRef SlabAlloc::do_realloc(size_t ref, const char* addr, size_t old_size, size
     MemRef new_mem = do_alloc(new_size); // Throws
 
     // Copy existing segment
-    char* new_addr = new_mem.m_addr;
+    char* new_addr = new_mem.get_addr();
     std::copy(addr, addr+old_size, new_addr);
 
     // Add old segment to freelist
@@ -408,7 +421,7 @@ MemRef SlabAlloc::do_realloc(size_t ref, const char* addr, size_t old_size, size
 #ifdef REALM_DEBUG
     if (REALM_COVER_NEVER(m_debug_out)) {
         std::cerr << "Realloc orig_ref: " << ref << " old_size: " << old_size << " "
-            "new_ref: " << new_mem.m_ref << " new_size: " << new_size << "\n";
+            "new_ref: " << new_mem.get_ref() << " new_size: " << new_size << "\n";
     }
 #endif // REALM_DEBUG
 

--- a/src/realm/array.cpp
+++ b/src/realm/array.cpp
@@ -180,7 +180,7 @@ size_t Array::bit_width(int64_t v)
 
 void Array::init_from_mem(MemRef mem) noexcept
 {
-    char* header = mem.m_addr;
+    char* header = mem.get_addr();
     // Parse header
     m_is_inner_bptree_node = get_is_inner_bptree_node_from_header(header);
     m_has_refs             = get_hasrefs_from_header(header);
@@ -189,7 +189,7 @@ void Array::init_from_mem(MemRef mem) noexcept
     m_size                 = get_size_from_header(header);
 
     // Capacity is how many items there are room for
-    bool is_read_only = m_alloc.is_read_only(mem.m_ref);
+    bool is_read_only = m_alloc.is_read_only(mem.get_ref());
     if (is_read_only) {
         m_capacity = m_size;
     }
@@ -202,9 +202,8 @@ void Array::init_from_mem(MemRef mem) noexcept
         m_capacity = calc_item_count(byte_capacity, m_width);
     }
 
-    m_ref = mem.m_ref;
+    m_ref = mem.get_ref();
     m_data = get_data_from_header(header);
-
     set_width(m_width);
 }
 
@@ -301,8 +300,8 @@ MemRef Array::slice_and_clone_children(size_t offset, size_t size, Allocator& ta
         ref_type ref = to_ref(value);
         Allocator& alloc = get_alloc();
         MemRef new_mem = clone(MemRef(ref, alloc), alloc, target_alloc); // Throws
-        dg_2.reset(new_mem.m_ref);
-        value = new_mem.m_ref; // FIXME: Dangerous cast (unsigned -> signed)
+        dg_2.reset(new_mem.get_ref());
+        value = new_mem.get_ref(); // FIXME: Dangerous cast (unsigned -> signed)
         slice.add(value); // Throws
         dg_2.release();
     }
@@ -1507,7 +1506,7 @@ size_t Array::calc_item_count(size_t bytes, size_t width) const noexcept
 
 MemRef Array::clone(MemRef mem, Allocator& alloc, Allocator& target_alloc)
 {
-    const char* header = mem.m_addr;
+    const char* header = mem.get_addr();
     if (!get_hasrefs_from_header(header)) {
         // This array has no subarrays, so we can make a byte-for-byte
         // copy, which is more efficient.
@@ -1517,7 +1516,7 @@ MemRef Array::clone(MemRef mem, Allocator& alloc, Allocator& target_alloc)
 
         // Create the new array
         MemRef clone_mem = target_alloc.alloc(size); // Throws
-        char* clone_header = clone_mem.m_addr;
+        char* clone_header = clone_mem.get_addr();
 
         // Copy contents
         const char* src_begin = header;
@@ -1560,8 +1559,8 @@ MemRef Array::clone(MemRef mem, Allocator& alloc, Allocator& target_alloc)
 
         ref_type ref = to_ref(value);
         MemRef new_mem = clone(MemRef(ref, alloc), alloc, target_alloc); // Throws
-        dg_2.reset(new_mem.m_ref);
-        value = new_mem.m_ref; // FIXME: Dangerous cast (unsigned -> signed)
+        dg_2.reset(new_mem.get_ref());
+        value = new_mem.get_ref(); // FIXME: Dangerous cast (unsigned -> signed)
         new_array.add(value); // Throws
         dg_2.release();
     }
@@ -1572,40 +1571,54 @@ MemRef Array::clone(MemRef mem, Allocator& alloc, Allocator& target_alloc)
 
 void Array::copy_on_write()
 {
-    if (!m_alloc.is_read_only(m_ref))
-        return;
+#if REALM_ENABLE_MEMDEBUG
+    // We want to relocate this array regardless if there is a need or not, in order to catch use-after-free bugs.
+    // Only exception is inside GroupWriter::write_group() (see explanation at the definition of the m_no_relocation
+    // member)
+    if (!m_no_relocation) { 
+#else        
+    if (m_alloc.is_read_only(m_ref)) {
+#endif
+        // Calculate size in bytes (plus a bit of matchcount room for expansion)
+        size_t size = calc_byte_len(m_size, m_width);
+        size_t rest = (~size & 0x7) + 1;
+        if (rest < 8)
+            size += rest; // 64bit blocks
+        size_t new_size = size + 64;
 
-    // Calculate size in bytes (plus a bit of matchcount room for expansion)
-    size_t size = calc_byte_len(m_size, m_width);
-    size_t rest = (~size & 0x7) + 1;
-    if (rest < 8)
-        size += rest; // 64bit blocks
-    size_t new_size = size + 64;
+        // Create new copy of array
+        MemRef mref = m_alloc.alloc(new_size); // Throws
+        const char* old_begin = get_header_from_data(m_data);
+        const char* old_end = get_header_from_data(m_data) + size;
+        char* new_begin = mref.get_addr();
+        std::copy(old_begin, old_end, new_begin);
 
-    // Create new copy of array
-    MemRef mref = m_alloc.alloc(new_size); // Throws
-    const char* old_begin = get_header_from_data(m_data);
-    const char* old_end   = get_header_from_data(m_data) + size;
-    char* new_begin = mref.m_addr;
-    std::copy(old_begin, old_end, new_begin);
+        ref_type old_ref = m_ref;
 
-    ref_type old_ref = m_ref;
+        // Update internal data
+        m_ref = mref.get_ref();
+        m_data = get_data_from_header(new_begin);
+        m_capacity = calc_item_count(new_size, m_width);
+        REALM_ASSERT_DEBUG(m_capacity > 0);
 
-    // Update internal data
-    m_ref = mref.m_ref;
-    m_data = get_data_from_header(new_begin);
-    m_capacity = calc_item_count(new_size, m_width);
-    REALM_ASSERT_DEBUG(m_capacity > 0);
+        // Update capacity in header. Uses m_data to find header, so
+        // m_data must be initialized correctly first.
+        set_header_capacity(new_size);
 
-    // Update capacity in header. Uses m_data to find header, so
-    // m_data must be initialized correctly first.
-    set_header_capacity(new_size);
+        update_parent();
 
-    update_parent();
+#if REALM_ENABLE_MEMDEBUG
+        if (!m_alloc.is_read_only(old_ref)) {
+            // Overwrite free'd array with 0x77. We cannot overwrite the header because free_() needs to know the size
+            // of the allocated block in order to free it. This size is computed from the width and size header fields.
+            memset(const_cast<char*>(old_begin) + header_size, 0x77, old_end - old_begin - header_size);
+        }
+#endif
 
-    // Mark original as deleted, so that the space can be reclaimed in
-    // future commits, when no versions are using it anymore
-    m_alloc.free_(old_ref, old_begin);
+        // Mark original as deleted, so that the space can be reclaimed in
+        // future commits, when no versions are using it anymore
+        m_alloc.free_(old_ref, old_begin);
+    }
 }
 
 
@@ -1713,7 +1726,7 @@ MemRef Array::create(Type type, bool context_flag, WidthType width_type, size_t 
     // address of that member
     size_t byte_size = std::max(byte_size_0, initial_capacity+0);
     MemRef mem = alloc.alloc(byte_size); // Throws
-    char* header = mem.m_addr;
+    char* header = mem.get_addr();
 
     init_header(header, is_inner_bptree_node, has_refs, context_flag, width_type,
                 width, size, byte_size);
@@ -1768,13 +1781,14 @@ void Array::alloc(size_t size, size_t width)
             char* header = get_header_from_data(m_data);
             MemRef mem_ref = m_alloc.realloc_(m_ref, header, orig_capacity_bytes,
                                               capacity_bytes); // Throws
-            header = mem_ref.m_addr;
+            
+            header = mem_ref.get_addr();
             set_header_width(int(width), header);
             set_header_size(size, header);
             set_header_capacity(capacity_bytes, header);
 
             // Update this accessor and its ancestors
-            m_ref      = mem_ref.m_ref;
+            m_ref      = mem_ref.get_ref();
             m_data     = get_data_from_header(header);
             m_capacity = calc_item_count(capacity_bytes, width);
             // FIXME: Trouble when this one throws. We will then leave
@@ -2104,7 +2118,6 @@ ref_type Array::bptree_leaf_insert(size_t ndx, int64_t value, TreeInsertBase& st
     return new_leaf.get_ref();
 }
 
-
 #ifdef REALM_DEBUG  // LCOV_EXCL_START ignore debug functions
 
 void Array::print() const
@@ -2191,7 +2204,7 @@ VerifyBptreeResult verify_bptree(const Array& node, Array::LeafVerifier leaf_ver
         size_t elems_in_child;
         int leaf_level_of_child;
         if (child_is_leaf) {
-            elems_in_child = (*leaf_verifier)(MemRef(child_header, child_ref), alloc);
+            elems_in_child = (*leaf_verifier)(MemRef(child_header, child_ref, alloc), alloc);
             // Verify invar:bptree-nonempty-leaf
             REALM_ASSERT_3(elems_in_child, >= , 1);
             leaf_level_of_child = 0;
@@ -2458,7 +2471,7 @@ void Array::report_memory_usage_2(MemUsageHandler& handler) const
         char* header = m_alloc.translate(ref);
         bool has_refs = get_hasrefs_from_header(header);
         if (has_refs) {
-            MemRef mem(header, ref);
+            MemRef mem(header, ref, m_alloc);
             subarray.init_from_mem(mem);
             subarray.report_memory_usage_2(handler);
             used = subarray.get_byte_size();
@@ -3104,7 +3117,7 @@ bool foreach_bptree_leaf(Array& node, size_t node_offset, size_t node_size,
     child_info.m_mem = MemRef(node.get_as_ref(child_info.m_ndx_in_parent), alloc);
     child_info.m_offset = child_offset;
     bool children_are_leaves =
-        !Array::get_is_inner_bptree_node_from_header(child_info.m_mem.m_addr);
+        !Array::get_is_inner_bptree_node_from_header(child_info.m_mem.get_addr());
     for (;;) {
         child_info.m_size = elems_per_child;
         bool is_last_child = child_ndx == num_children - 1;
@@ -3168,7 +3181,7 @@ void simplified_foreach_bptree_leaf(Array& node, Handler handler)
     child_info.m_offset = 0;
     child_info.m_size   = 0;
     bool children_are_leaves =
-        !Array::get_is_inner_bptree_node_from_header(child_info.m_mem.m_addr);
+        !Array::get_is_inner_bptree_node_from_header(child_info.m_mem.get_addr());
     for (;;) {
         if (children_are_leaves) {
             const Array::NodeInfo& const_child_info = child_info;
@@ -3206,7 +3219,7 @@ void destroy_singlet_bptree_branch(MemRef mem, Allocator& alloc,
 {
     MemRef mem_2 = mem;
     for (;;) {
-        const char* header = mem_2.m_addr;
+        const char* header = mem_2.get_addr();
         bool is_leaf = !Array::get_is_inner_bptree_node_from_header(header);
         if (is_leaf) {
             handler.destroy_leaf(mem_2);
@@ -3222,8 +3235,8 @@ void destroy_singlet_bptree_branch(MemRef mem, Allocator& alloc,
 
         destroy_inner_bptree_node(mem_2, first_value, alloc);
 
-        mem_2.m_ref  = child_ref;
-        mem_2.m_addr = alloc.translate(child_ref);
+        mem_2.set_ref(child_ref);
+        mem_2.set_addr(alloc.translate(child_ref));
         // inform encryption layer on next loop iteration
     }
 }
@@ -3234,7 +3247,7 @@ void elim_superfluous_bptree_root(Array* root, MemRef parent_mem,
 {
     Allocator& alloc = root->get_alloc();
     char* child_header = alloc.translate(child_ref);
-    MemRef child_mem(child_header, child_ref);
+    MemRef child_mem(child_header, child_ref, alloc);
     bool child_is_leaf = !Array::get_is_inner_bptree_node_from_header(child_header);
     if (child_is_leaf) {
         handler.replace_root_by_leaf(child_mem); // Throws
@@ -3305,7 +3318,7 @@ std::pair<MemRef, size_t> Array::get_bptree_leaf(size_t ndx) const noexcept
         char* child_header = m_alloc.translate(child_ref);
         bool child_is_leaf = !get_is_inner_bptree_node_from_header(child_header);
         if (child_is_leaf) {
-            MemRef mem(child_header, child_ref);
+            MemRef mem(child_header, child_ref, m_alloc);
             return std::make_pair(mem, ndx_in_child);
         }
         ndx_2 = ndx_in_child;
@@ -3382,7 +3395,7 @@ void Array::update_bptree_elem(size_t elem_ndx, UpdateHandler& handler)
     size_t child_ref_ndx = 1 + child_ndx;
     ref_type child_ref = get_as_ref(child_ref_ndx);
     char* child_header = m_alloc.translate(child_ref);
-    MemRef child_mem(child_header, child_ref);
+    MemRef child_mem(child_header, child_ref, m_alloc);
     bool child_is_leaf = !get_is_inner_bptree_node_from_header(child_header);
     if (child_is_leaf) {
         handler.update(child_mem, this, child_ref_ndx, ndx_in_child); // Throws
@@ -3429,7 +3442,7 @@ void Array::erase_bptree_elem(Array* root, size_t elem_ndx, EraseHandler& handle
         destroy_inner_bptree_node(root_mem, first_value, alloc);
         char* child_header = alloc.translate(child_ref);
         // destroy_singlet.... will take care of informing the encryption layer
-        MemRef child_mem(child_header, child_ref);
+        MemRef child_mem(child_header, child_ref, alloc);
         destroy_singlet_bptree_branch(child_mem, alloc, handler);
         return;
     }
@@ -3494,7 +3507,7 @@ bool Array::do_erase_bptree_elem(size_t elem_ndx, EraseHandler& handler)
     size_t child_ref_ndx = 1 + child_ndx;
     ref_type child_ref = get_as_ref(child_ref_ndx);
     char* child_header = m_alloc.translate(child_ref);
-    MemRef child_mem(child_header, child_ref);
+    MemRef child_mem(child_header, child_ref, m_alloc);
     bool child_is_leaf = !get_is_inner_bptree_node_from_header(child_header);
     bool destroy_child;
     if (child_is_leaf) {
@@ -3517,7 +3530,7 @@ bool Array::do_erase_bptree_elem(size_t elem_ndx, EraseHandler& handler)
         child_ref = get_as_ref(child_ref_ndx);
         child_header = m_alloc.translate(child_ref);
         // destroy_singlet.... will take care of informing the encryption layer
-        child_mem = MemRef(child_header, child_ref);
+        child_mem = MemRef(child_header, child_ref, m_alloc);
         erase(child_ref_ndx); // Throws
         destroy_singlet_bptree_branch(child_mem, m_alloc, handler);
         // If the erased element is the last one, we did not attach

--- a/src/realm/array_basic_tpl.hpp
+++ b/src/realm/array_basic_tpl.hpp
@@ -56,7 +56,7 @@ inline MemRef BasicArray<T>::create_array(size_t size, Allocator& alloc)
     bool has_refs = false;
     bool context_flag = false;
     int width = sizeof (T);
-    init_header(mem.m_addr, is_inner_bptree_node, has_refs, context_flag, wtype_Multiply,
+    init_header(mem.get_addr(), is_inner_bptree_node, has_refs, context_flag, wtype_Multiply,
                 width, size, byte_size);
 
     return mem;

--- a/src/realm/array_binary.cpp
+++ b/src/realm/array_binary.cpp
@@ -180,16 +180,16 @@ MemRef ArrayBinary::create_array(size_t size, Allocator& alloc, BinaryData value
         bool context_flag = false;
         int64_t value = 0;
         MemRef mem = ArrayInteger::create_array(type_Normal, context_flag, size, value, alloc); // Throws
-        dg_2.reset(mem.m_ref);
-        int64_t v = from_ref(mem.m_ref);
+        dg_2.reset(mem.get_ref());
+        int64_t v = from_ref(mem.get_ref());
         top.add(v); // Throws
         dg_2.release();
     }
     {
         size_t blobs_size = 0;
         MemRef mem = ArrayBlob::create_array(blobs_size, alloc); // Throws
-        dg_2.reset(mem.m_ref);
-        int64_t v = from_ref(mem.m_ref);
+        dg_2.reset(mem.get_ref());
+        int64_t v = from_ref(mem.get_ref());
         top.add(v); // Throws
         dg_2.release();
     }
@@ -201,8 +201,8 @@ MemRef ArrayBinary::create_array(size_t size, Allocator& alloc, BinaryData value
         bool context_flag = false;
         int64_t value = values.is_null() ? 1 : 0;
         MemRef mem = ArrayInteger::create_array(type_Normal, context_flag, size, value, alloc); // Throws
-        dg_2.reset(mem.m_ref);
-        int64_t v = from_ref(mem.m_ref);
+        dg_2.reset(mem.get_ref());
+        int64_t v = from_ref(mem.get_ref());
         top.add(v); // Throws
         dg_2.release();
     }

--- a/src/realm/array_binary.hpp
+++ b/src/realm/array_binary.hpp
@@ -151,7 +151,7 @@ inline void ArrayBinary::init_from_ref(ref_type ref) noexcept
 {
     REALM_ASSERT(ref);
     char* header = get_alloc().translate(ref);
-    init_from_mem(MemRef(header, ref));
+    init_from_mem(MemRef(header, ref, m_alloc));
 }
 
 inline void ArrayBinary::init_from_parent() noexcept

--- a/src/realm/array_integer.cpp
+++ b/src/realm/array_integer.cpp
@@ -96,7 +96,7 @@ void ArrayIntNull::init_from_ref(ref_type ref) noexcept
 {
     REALM_ASSERT_DEBUG(ref);
     char* header = m_alloc.translate(ref);
-    init_from_mem(MemRef{header, ref});
+    init_from_mem(MemRef{header, ref, m_alloc});
 }
 
 void ArrayIntNull::init_from_mem(MemRef mem) noexcept

--- a/src/realm/array_string_long.cpp
+++ b/src/realm/array_string_long.cpp
@@ -226,16 +226,16 @@ MemRef ArrayStringLong::create_array(size_t size, Allocator& alloc, bool nullabl
         bool context_flag = false;
         int_fast64_t value = 0;
         MemRef mem = ArrayInteger::create_array(type_Normal, context_flag, size, value, alloc); // Throws
-        dg_2.reset(mem.m_ref);
-        int64_t v(mem.m_ref); // FIXME: Dangerous cast (unsigned -> signed)
+        dg_2.reset(mem.get_ref());
+        int64_t v(mem.get_ref()); // FIXME: Dangerous cast (unsigned -> signed)
         top.add(v); // Throws
         dg_2.release();
     }
     {
         size_t blobs_size = 0;
         MemRef mem = ArrayBlob::create_array(blobs_size, alloc); // Throws
-        dg_2.reset(mem.m_ref);
-        int64_t v(mem.m_ref); // FIXME: Dangerous cast (unsigned -> signed)
+        dg_2.reset(mem.get_ref());
+        int64_t v(mem.get_ref()); // FIXME: Dangerous cast (unsigned -> signed)
         top.add(v); // Throws
         dg_2.release();
     }
@@ -244,8 +244,8 @@ MemRef ArrayStringLong::create_array(size_t size, Allocator& alloc, bool nullabl
         bool context_flag = false;
         int64_t value = 0; // initialize all rows to realm::null()
         MemRef mem = ArrayInteger::create_array(type_Normal, context_flag, size, value, alloc); // Throws
-        dg_2.reset(mem.m_ref);
-        int64_t v(mem.m_ref); // FIXME: Dangerous cast (unsigned -> signed)
+        dg_2.reset(mem.get_ref());
+        int64_t v(mem.get_ref()); // FIXME: Dangerous cast (unsigned -> signed)
         top.add(v); // Throws
         dg_2.release();
     }

--- a/src/realm/array_string_long.hpp
+++ b/src/realm/array_string_long.hpp
@@ -127,7 +127,7 @@ inline void ArrayStringLong::init_from_ref(ref_type ref) noexcept
 {
     REALM_ASSERT(ref);
     char* header = get_alloc().translate(ref);
-    init_from_mem(MemRef(header, ref));
+    init_from_mem(MemRef(header, ref, m_alloc));
     m_nullable = (Array::size() == 3);
 }
 

--- a/src/realm/bptree.hpp
+++ b/src/realm/bptree.hpp
@@ -279,7 +279,7 @@ BpTree<T>::BpTree(BpTreeBase::unattached_tag) : BpTreeBase(nullptr)
 template<class T>
 std::unique_ptr<Array> BpTree<T>::create_root_from_mem(Allocator& alloc, MemRef mem)
 {
-    const char* header = mem.m_addr;
+    const char* header = mem.get_addr();
     std::unique_ptr<Array> new_root;
     bool is_inner_bptree_node = Array::get_is_inner_bptree_node_from_header(header);
 
@@ -312,7 +312,7 @@ std::unique_ptr<Array> BpTree<T>::create_root_from_mem(Allocator& alloc, MemRef 
 template<class T>
 std::unique_ptr<Array> BpTree<T>::create_root_from_ref(Allocator& alloc, ref_type ref)
 {
-    MemRef mem = MemRef{alloc.translate(ref), ref};
+    MemRef mem = MemRef{alloc.translate(ref), ref, alloc};
     return create_root_from_mem(alloc, mem);
 }
 
@@ -431,7 +431,7 @@ T BpTree<T>::get(size_t ndx) const noexcept
 
     // Use direct getter to avoid initializing leaf array:
     std::pair<MemRef, size_t> p = root().get_bptree_leaf(ndx);
-    const char* leaf_header = p.first.m_addr;
+    const char* leaf_header = p.first.get_addr();
     size_t ndx_in_leaf = p.second;
     return LeafType::get(leaf_header, ndx_in_leaf);
 }

--- a/src/realm/column.hpp
+++ b/src/realm/column.hpp
@@ -1386,7 +1386,7 @@ public:
     ref_type create_leaf(size_t size) override
     {
         MemRef mem = BpTree<T>::create_leaf(m_leaf_type, size, m_value, m_alloc); // Throws
-        return mem.m_ref;
+        return mem.get_ref();
     }
 private:
     const T m_value;

--- a/src/realm/column_backlink.cpp
+++ b/src/realm/column_backlink.cpp
@@ -458,7 +458,7 @@ void BacklinkColumn::get_backlinks(std::vector<VerifyPair>& pairs)
 std::pair<ref_type, size_t> BacklinkColumn::get_to_dot_parent(size_t ndx_in_parent) const
 {
     std::pair<MemRef, size_t> p = get_root_array()->get_bptree_leaf(ndx_in_parent);
-    return std::make_pair(p.first.m_ref, p.second);
+    return std::make_pair(p.first.get_ref(), p.second);
 }
 
 #endif // LCOV_EXCL_STOP ignore debug functions

--- a/src/realm/column_binary.cpp
+++ b/src/realm/column_binary.cpp
@@ -28,7 +28,7 @@ BinaryColumn::BinaryColumn(Allocator& alloc, ref_type ref, bool nullable):
     m_nullable(nullable)
 {
     char* header = alloc.translate(ref);
-    MemRef mem(header, ref);
+    MemRef mem(header, ref, alloc);
     bool root_is_leaf = !Array::get_is_inner_bptree_node_from_header(header);
     if (root_is_leaf) {
         bool is_big = Array::get_context_flag_from_header(header);
@@ -63,7 +63,7 @@ struct SetLeafElem: Array::UpdateHandler {
     void update(MemRef mem, ArrayParent* parent, size_t ndx_in_parent,
                 size_t elem_ndx_in_leaf) override
     {
-        bool is_big = Array::get_context_flag_from_header(mem.m_addr);
+        bool is_big = Array::get_context_flag_from_header(mem.get_addr());
         if (is_big) {
             ArrayBigBlobs leaf(m_alloc, false);
             leaf.init_from_mem(mem);
@@ -175,7 +175,7 @@ ref_type BinaryColumn::leaf_insert(MemRef leaf_mem, ArrayParent& parent,
                                    Array::TreeInsert<BinaryColumn>& state)
 {
     InsertState& state_2 = static_cast<InsertState&>(state);
-    bool is_big = Array::get_context_flag_from_header(leaf_mem.m_addr);
+    bool is_big = Array::get_context_flag_from_header(leaf_mem.get_addr());
     if (is_big) {
         ArrayBigBlobs leaf(alloc, false);
         leaf.init_from_mem(leaf_mem);
@@ -207,7 +207,7 @@ public:
                          size_t leaf_ndx_in_parent,
                          size_t elem_ndx_in_leaf) override
     {
-        bool is_big = Array::get_context_flag_from_header(leaf_mem.m_addr);
+        bool is_big = Array::get_context_flag_from_header(leaf_mem.get_addr());
         if (!is_big) {
             // Small blobs
             ArrayBinary leaf(m_column.get_alloc());
@@ -244,7 +244,7 @@ public:
     void replace_root_by_leaf(MemRef leaf_mem) override
     {
         Array* leaf;
-        bool is_big = Array::get_context_flag_from_header(leaf_mem.m_addr);
+        bool is_big = Array::get_context_flag_from_header(leaf_mem.get_addr());
         if (!is_big) {
             // Small blobs
             ArrayBinary* leaf_2 = new ArrayBinary(m_column.get_alloc()); // Throws
@@ -429,7 +429,7 @@ public:
     ref_type create_leaf(size_t size) override
     {
         MemRef mem = ArrayBinary::create_array(size, m_alloc, m_defaults); // Throws
-        return mem.m_ref;
+        return mem.get_ref();
     }
 private:
     Allocator& m_alloc;
@@ -448,7 +448,7 @@ public:
     MemRef slice_leaf(MemRef leaf_mem, size_t offset, size_t size,
                       Allocator& target_alloc) override
     {
-        bool is_big = Array::get_context_flag_from_header(leaf_mem.m_addr);
+        bool is_big = Array::get_context_flag_from_header(leaf_mem.get_addr());
         if (!is_big) {
             // Small blobs
             ArrayBinary leaf(m_alloc);
@@ -514,8 +514,8 @@ void BinaryColumn::update_from_ref(ref_type ref)
     // is of type Array.
 
     MemRef root_mem(ref, m_array->get_alloc());
-    bool new_root_is_leaf  = !Array::get_is_inner_bptree_node_from_header(root_mem.m_addr);
-    bool new_root_is_small = !Array::get_context_flag_from_header(root_mem.m_addr);
+    bool new_root_is_leaf  = !Array::get_is_inner_bptree_node_from_header(root_mem.get_addr());
+    bool new_root_is_small = !Array::get_context_flag_from_header(root_mem.get_addr());
     bool old_root_is_leaf  = !m_array->is_inner_bptree_node();
     bool old_root_is_small = !m_array->get_context_flag();
 
@@ -577,7 +577,7 @@ namespace {
 
 size_t verify_leaf(MemRef mem, Allocator& alloc)
 {
-    bool is_big = Array::get_context_flag_from_header(mem.m_addr);
+    bool is_big = Array::get_context_flag_from_header(mem.get_addr());
     if (!is_big) {
         // Small blobs
         ArrayBinary leaf(alloc);
@@ -630,7 +630,7 @@ void BinaryColumn::leaf_to_dot(MemRef leaf_mem, ArrayParent* parent, size_t ndx_
                                std::ostream& out) const
 {
     bool is_strings = false; // FIXME: Not necessarily the case
-    bool is_big = Array::get_context_flag_from_header(leaf_mem.m_addr);
+    bool is_big = Array::get_context_flag_from_header(leaf_mem.get_addr());
     if (!is_big) {
         // Small blobs
         ArrayBinary leaf(m_array->get_alloc());
@@ -653,7 +653,7 @@ void leaf_dumper(MemRef mem, Allocator& alloc, std::ostream& out, int level)
 {
     size_t leaf_size;
     const char* leaf_type;
-    bool is_big = Array::get_context_flag_from_header(mem.m_addr);
+    bool is_big = Array::get_context_flag_from_header(mem.get_addr());
     if (!is_big) {
         // Small blobs
         ArrayBinary leaf(alloc);

--- a/src/realm/column_binary.hpp
+++ b/src/realm/column_binary.hpp
@@ -208,7 +208,7 @@ inline BinaryData BinaryColumn::get(size_t ndx) const noexcept
 
     // Non-leaf root
     std::pair<MemRef, size_t> p = m_array->get_bptree_leaf(ndx);
-    const char* leaf_header = p.first.m_addr;
+    const char* leaf_header = p.first.get_addr();
     size_t ndx_in_leaf = p.second;
     Allocator& alloc = m_array->get_alloc();
     bool is_big = Array::get_context_flag_from_header(leaf_header);

--- a/src/realm/column_linklist.cpp
+++ b/src/realm/column_linklist.cpp
@@ -744,7 +744,7 @@ void LinkListColumn::verify(const Table& table, size_t col_ndx) const
 std::pair<ref_type, size_t> LinkListColumn::get_to_dot_parent(size_t ndx_in_parent) const
 {
     std::pair<MemRef, size_t> p = get_root_array()->get_bptree_leaf(ndx_in_parent);
-    return std::make_pair(p.first.m_ref, p.second);
+    return std::make_pair(p.first.get_ref(), p.second);
 }
 
 #endif // LCOV_EXCL_STOP ignore debug functions

--- a/src/realm/column_string.cpp
+++ b/src/realm/column_string.cpp
@@ -54,7 +54,7 @@ StringColumn::StringColumn(Allocator& alloc, ref_type ref, bool nullable):
     m_nullable(nullable)
 {
     char* header = alloc.translate(ref);
-    MemRef mem(header, ref);
+    MemRef mem(header, ref, alloc);
 
     // Within an StringColumn the leaves can be of different
     // type optimized for the lengths of the strings contained
@@ -143,7 +143,7 @@ StringData StringColumn::get(size_t ndx) const noexcept
 
     // Non-leaf root
     std::pair<MemRef, size_t> p = m_array->get_bptree_leaf(ndx);
-    const char* leaf_header = p.first.m_addr;
+    const char* leaf_header = p.first.get_addr();
     size_t ndx_in_leaf = p.second;
     bool long_strings = Array::get_hasrefs_from_header(leaf_header);
     if (!long_strings) {
@@ -291,9 +291,9 @@ public:
     void update(MemRef mem, ArrayParent* parent, size_t ndx_in_parent,
                 size_t elem_ndx_in_leaf) override
     {
-        bool long_strings = Array::get_hasrefs_from_header(mem.m_addr);
+        bool long_strings = Array::get_hasrefs_from_header(mem.get_addr());
         if (long_strings) {
-            bool is_big = Array::get_context_flag_from_header(mem.m_addr);
+            bool is_big = Array::get_context_flag_from_header(mem.get_addr());
             if (is_big) {
                 ArrayBigBlobs leaf(m_alloc, m_nullable);
                 leaf.init_from_mem(mem);
@@ -402,7 +402,7 @@ public:
                          size_t leaf_ndx_in_parent,
                          size_t elem_ndx_in_leaf) override
     {
-        bool long_strings = Array::get_hasrefs_from_header(leaf_mem.m_addr);
+        bool long_strings = Array::get_hasrefs_from_header(leaf_mem.get_addr());
         if (!long_strings) {
             // Small strings
             ArrayString leaf(m_column.get_alloc(), m_nullable);
@@ -418,7 +418,7 @@ public:
             leaf.erase(ndx); // Throws
             return false;
         }
-        bool is_big = Array::get_context_flag_from_header(leaf_mem.m_addr);
+        bool is_big = Array::get_context_flag_from_header(leaf_mem.get_addr());
         if (!is_big) {
             // Medium strings
             ArrayStringLong leaf(m_column.get_alloc(), m_nullable);
@@ -455,7 +455,7 @@ public:
     void replace_root_by_leaf(MemRef leaf_mem) override
     {
         std::unique_ptr<Array> leaf;
-        bool long_strings = Array::get_hasrefs_from_header(leaf_mem.m_addr);
+        bool long_strings = Array::get_hasrefs_from_header(leaf_mem.get_addr());
         if (!long_strings) {
             // Small strings
             ArrayString* leaf_2 = new ArrayString(m_column.get_alloc(), m_nullable); // Throws
@@ -463,7 +463,7 @@ public:
             leaf.reset(leaf_2);
         }
         else {
-            bool is_big = Array::get_context_flag_from_header(leaf_mem.m_addr);
+            bool is_big = Array::get_context_flag_from_header(leaf_mem.get_addr());
             if (!is_big) {
                 // Medium strings
                 ArrayStringLong* leaf_2 = new ArrayStringLong(m_column.get_alloc(), m_nullable); // Throws
@@ -712,7 +712,7 @@ size_t StringColumn::count(StringData value) const
         std::pair<MemRef, size_t> p = m_array->get_bptree_leaf(begin);
         MemRef leaf_mem = p.first;
         REALM_ASSERT_3(p.second, ==, 0);
-        bool long_strings = Array::get_hasrefs_from_header(leaf_mem.m_addr);
+        bool long_strings = Array::get_hasrefs_from_header(leaf_mem.get_addr());
         if (!long_strings) {
             // Small strings
             ArrayString leaf(m_array->get_alloc(), m_nullable);
@@ -721,7 +721,7 @@ size_t StringColumn::count(StringData value) const
             begin += leaf.size();
             continue;
         }
-        bool is_big = Array::get_context_flag_from_header(leaf_mem.m_addr);
+        bool is_big = Array::get_context_flag_from_header(leaf_mem.get_addr());
         if (!is_big) {
             // Medium strings
             ArrayStringLong leaf(m_array->get_alloc(), m_nullable);
@@ -785,7 +785,7 @@ size_t StringColumn::find_first(StringData value, size_t begin, size_t end) cons
         MemRef leaf_mem = p.first;
         size_t ndx_in_leaf = p.second, end_in_leaf;
         size_t leaf_offset = ndx_in_tree - ndx_in_leaf;
-        bool long_strings = Array::get_hasrefs_from_header(leaf_mem.m_addr);
+        bool long_strings = Array::get_hasrefs_from_header(leaf_mem.get_addr());
         if (!long_strings) {
             // Small strings
             ArrayString leaf(m_array->get_alloc(), m_nullable);
@@ -796,7 +796,7 @@ size_t StringColumn::find_first(StringData value, size_t begin, size_t end) cons
                 return leaf_offset + ndx;
         }
         else {
-            bool is_big = Array::get_context_flag_from_header(leaf_mem.m_addr);
+            bool is_big = Array::get_context_flag_from_header(leaf_mem.get_addr());
             if (!is_big) {
                 // Medium strings
                 ArrayStringLong leaf(m_array->get_alloc(), m_nullable);
@@ -873,7 +873,7 @@ void StringColumn::find_all(IntegerColumn& result, StringData value, size_t begi
         MemRef leaf_mem = p.first;
         size_t ndx_in_leaf = p.second, end_in_leaf;
         size_t leaf_offset = ndx_in_tree - ndx_in_leaf;
-        bool long_strings = Array::get_hasrefs_from_header(leaf_mem.m_addr);
+        bool long_strings = Array::get_hasrefs_from_header(leaf_mem.get_addr());
         if (!long_strings) {
             // Small strings
             ArrayString leaf(m_array->get_alloc(), m_nullable);
@@ -882,7 +882,7 @@ void StringColumn::find_all(IntegerColumn& result, StringData value, size_t begi
             leaf.find_all(result, value, leaf_offset, ndx_in_leaf, end_in_leaf); // Throws
         }
         else {
-            bool is_big = Array::get_context_flag_from_header(leaf_mem.m_addr);
+            bool is_big = Array::get_context_flag_from_header(leaf_mem.get_addr());
             if (!is_big) {
                 // Medium strings
                 ArrayStringLong leaf(m_array->get_alloc(), m_nullable);
@@ -1118,9 +1118,9 @@ ref_type StringColumn::leaf_insert(MemRef leaf_mem, ArrayParent& parent, size_t 
                                    Allocator& alloc, size_t insert_ndx,
                                    Array::TreeInsert<StringColumn>& state)
 {
-    bool long_strings = Array::get_hasrefs_from_header(leaf_mem.m_addr);
+    bool long_strings = Array::get_hasrefs_from_header(leaf_mem.get_addr());
     if (long_strings) {
-        bool is_big = Array::get_context_flag_from_header(leaf_mem.m_addr);
+        bool is_big = Array::get_context_flag_from_header(leaf_mem.get_addr());
         if (is_big) {
             ArrayBigBlobs leaf(alloc, state.m_nullable);
             leaf.init_from_mem(leaf_mem);
@@ -1264,9 +1264,9 @@ StringColumn::LeafType StringColumn::get_block(size_t ndx, ArrayParent** ap, siz
 
     std::pair<MemRef, size_t> p = m_array->get_bptree_leaf(ndx);
     off = ndx - p.second;
-    bool long_strings = Array::get_hasrefs_from_header(p.first.m_addr);
+    bool long_strings = Array::get_hasrefs_from_header(p.first.get_addr());
     if (long_strings) {
-        if (Array::get_context_flag_from_header(p.first.m_addr)) {
+        if (Array::get_context_flag_from_header(p.first.get_addr())) {
             ArrayBigBlobs* asb2 = new ArrayBigBlobs(alloc, m_nullable);
             asb2->init_from_mem(p.first);
             *ap = asb2;
@@ -1293,7 +1293,7 @@ public:
     ref_type create_leaf(size_t size) override
     {
         MemRef mem = ArrayString::create_array(size, m_alloc); // Throws
-        return mem.m_ref;
+        return mem.get_ref();
     }
 private:
     Allocator& m_alloc;
@@ -1316,14 +1316,14 @@ public:
     MemRef slice_leaf(MemRef leaf_mem, size_t offset, size_t size,
                       Allocator& target_alloc) override
     {
-        bool long_strings = Array::get_hasrefs_from_header(leaf_mem.m_addr);
+        bool long_strings = Array::get_hasrefs_from_header(leaf_mem.get_addr());
         if (!long_strings) {
             // Small strings
             ArrayString leaf(m_alloc, m_nullable);
             leaf.init_from_mem(leaf_mem);
             return leaf.slice(offset, size, target_alloc); // Throws
         }
-        bool is_big = Array::get_context_flag_from_header(leaf_mem.m_addr);
+        bool is_big = Array::get_context_flag_from_header(leaf_mem.get_addr());
         if (!is_big) {
             // Medium strings
             ArrayStringLong leaf(m_alloc, m_nullable);
@@ -1409,9 +1409,9 @@ void StringColumn::refresh_root_accessor()
 
     ref_type root_ref = m_array->get_ref_from_parent();
     MemRef root_mem(root_ref, m_array->get_alloc());
-    bool new_root_is_leaf   = !Array::get_is_inner_bptree_node_from_header(root_mem.m_addr);
-    bool new_root_is_small  = !Array::get_hasrefs_from_header(root_mem.m_addr);
-    bool new_root_is_medium = !Array::get_context_flag_from_header(root_mem.m_addr);
+    bool new_root_is_leaf   = !Array::get_is_inner_bptree_node_from_header(root_mem.get_addr());
+    bool new_root_is_small  = !Array::get_hasrefs_from_header(root_mem.get_addr());
+    bool new_root_is_medium = !Array::get_context_flag_from_header(root_mem.get_addr());
     bool old_root_is_leaf   = !m_array->is_inner_bptree_node();
     bool old_root_is_small  = !m_array->has_refs();
     bool old_root_is_medium = !m_array->get_context_flag();
@@ -1489,7 +1489,7 @@ size_t verify_leaf(MemRef mem, Allocator& alloc)
 {
     // fixme, null support (validation will still run for nullable leafs, but just not include
     // any validation of the null properties)
-    bool long_strings = Array::get_hasrefs_from_header(mem.m_addr);
+    bool long_strings = Array::get_hasrefs_from_header(mem.get_addr());
     if (!long_strings) {
         // Small strings
         ArrayString leaf(alloc, false);
@@ -1497,7 +1497,7 @@ size_t verify_leaf(MemRef mem, Allocator& alloc)
         leaf.verify();
         return leaf.size();
     }
-    bool is_big = Array::get_context_flag_from_header(mem.m_addr);
+    bool is_big = Array::get_context_flag_from_header(mem.get_addr());
     if (!is_big) {
         // Medium strings
         ArrayStringLong leaf(alloc, false);
@@ -1580,7 +1580,7 @@ void StringColumn::to_dot(std::ostream& out, StringData title) const
 void StringColumn::leaf_to_dot(MemRef leaf_mem, ArrayParent* parent, size_t ndx_in_parent,
                                        std::ostream& out) const
 {
-    bool long_strings = Array::get_hasrefs_from_header(leaf_mem.m_addr);
+    bool long_strings = Array::get_hasrefs_from_header(leaf_mem.get_addr());
     if (!long_strings) {
         // Small strings
         ArrayString leaf(m_array->get_alloc(), m_nullable);
@@ -1589,7 +1589,7 @@ void StringColumn::leaf_to_dot(MemRef leaf_mem, ArrayParent* parent, size_t ndx_
         leaf.to_dot(out);
         return;
     }
-    bool is_big = Array::get_context_flag_from_header(leaf_mem.m_addr);
+    bool is_big = Array::get_context_flag_from_header(leaf_mem.get_addr());
     if (!is_big) {
         // Medium strings
         ArrayStringLong leaf(m_array->get_alloc(), m_nullable);
@@ -1614,7 +1614,7 @@ void leaf_dumper(MemRef mem, Allocator& alloc, std::ostream& out, int level)
     // todo, support null (will now just show up in dump as empty strings)
     size_t leaf_size;
     const char* leaf_type;
-    bool long_strings = Array::get_hasrefs_from_header(mem.m_addr);
+    bool long_strings = Array::get_hasrefs_from_header(mem.get_addr());
     if (!long_strings) {
         // Small strings
         ArrayString leaf(alloc, false);
@@ -1623,7 +1623,7 @@ void leaf_dumper(MemRef mem, Allocator& alloc, std::ostream& out, int level)
         leaf_type = "Small strings leaf";
     }
     else {
-        bool is_big = Array::get_context_flag_from_header(mem.m_addr);
+        bool is_big = Array::get_context_flag_from_header(mem.get_addr());
         if (!is_big) {
             // Medium strings
             ArrayStringLong leaf(alloc, false);

--- a/src/realm/column_table.cpp
+++ b/src/realm/column_table.cpp
@@ -242,7 +242,7 @@ void SubtableColumnBase::SubtableMap::refresh_accessor_tree(size_t spec_ndx_in_p
 std::pair<ref_type, size_t> SubtableColumnBase::get_to_dot_parent(size_t ndx_in_parent) const
 {
     std::pair<MemRef, size_t> p = get_root_array()->get_bptree_leaf(ndx_in_parent);
-    return std::make_pair(p.first.m_ref, p.second);
+    return std::make_pair(p.first.get_ref(), p.second);
 }
 
 #endif // LCOV_EXCL_STOP ignore debug functions

--- a/src/realm/column_timestamp.cpp
+++ b/src/realm/column_timestamp.cpp
@@ -64,7 +64,7 @@ public:
     ref_type create_leaf(size_t size) override
     {
         MemRef mem = BT::create_leaf(Array::type_Normal, size, m_value, m_alloc); // Throws
-        return mem.m_ref;
+        return mem.get_ref();
     }
 private:
     const typename BT::value_type m_value;

--- a/src/realm/group_writer.cpp
+++ b/src/realm/group_writer.cpp
@@ -214,6 +214,11 @@ ref_type GroupWriter::write_group()
     REALM_ASSERT_3(reserve_size, >, max_free_space_needed);
     int_fast64_t value_4 = int_fast64_t(reserve_pos + max_free_space_needed); // FIXME: Problematic unsigned -> signed conversion
 
+#if REALM_ENABLE_MEMDEBUG
+    m_free_positions.m_no_relocation = true;
+    m_free_lengths.m_no_relocation = true;
+#endif
+
     // Ensure that this arrays does not reposition itself
     m_free_positions.ensure_minimum_width(value_4); // Throws
 

--- a/src/realm/spec.cpp
+++ b/src/realm/spec.cpp
@@ -94,8 +94,8 @@ MemRef Spec::create_empty_spec(Allocator& alloc)
         // One type for each column
         bool context_flag = false;
         MemRef mem = Array::create_empty_array(Array::type_Normal, context_flag, alloc); // Throws
-        dg_2.reset(mem.m_ref);
-        int_fast64_t v(mem.m_ref); // FIXME: Dangerous case: unsigned -> signed
+        dg_2.reset(mem.get_ref());
+        int_fast64_t v(mem.get_ref()); // FIXME: Dangerous case: unsigned -> signed
         spec_set.add(v); // Throws
         dg_2.release();
     }
@@ -103,8 +103,8 @@ MemRef Spec::create_empty_spec(Allocator& alloc)
         size_t size = 0;
         // One name for each column
         MemRef mem = ArrayString::create_array(size, alloc); // Throws
-        dg_2.reset(mem.m_ref);
-        int_fast64_t v = mem.m_ref; // FIXME: Dangerous case: unsigned -> signed
+        dg_2.reset(mem.get_ref());
+        int_fast64_t v = mem.get_ref(); // FIXME: Dangerous case: unsigned -> signed
         spec_set.add(v); // Throws
         dg_2.release();
     }
@@ -112,8 +112,8 @@ MemRef Spec::create_empty_spec(Allocator& alloc)
         // One attrib set for each column
         bool context_flag = false;
         MemRef mem = Array::create_empty_array(Array::type_Normal, context_flag, alloc); // Throws
-        dg_2.reset(mem.m_ref);
-        int_fast64_t v = mem.m_ref; // FIXME: Dangerous case: unsigned -> signed
+        dg_2.reset(mem.get_ref());
+        int_fast64_t v = mem.get_ref(); // FIXME: Dangerous case: unsigned -> signed
         spec_set.add(v); // Throws
         dg_2.release();
     }
@@ -143,16 +143,16 @@ void Spec::insert_column(size_t column_ndx, ColumnType type, StringData name, Co
             bool context_flag = false;
             MemRef subspecs_mem =
                 Array::create_empty_array(Array::type_HasRefs, context_flag, alloc); // Throws
-            _impl::DeepArrayRefDestroyGuard dg(subspecs_mem.m_ref, alloc);
+            _impl::DeepArrayRefDestroyGuard dg(subspecs_mem.get_ref(), alloc);
             if (m_top.size() == 3) {
-                int_fast64_t v(subspecs_mem.m_ref); // FIXME: Dangerous cast (unsigned -> signed)
+                int_fast64_t v(subspecs_mem.get_ref()); // FIXME: Dangerous cast (unsigned -> signed)
                 m_top.add(v); // Throws
             }
             else {
-                int_fast64_t v(subspecs_mem.m_ref); // FIXME: Dangerous cast (unsigned -> signed)
+                int_fast64_t v(subspecs_mem.get_ref()); // FIXME: Dangerous cast (unsigned -> signed)
                 m_top.set(3, v); // Throws
             }
-            m_subspecs.init_from_ref(subspecs_mem.m_ref);
+            m_subspecs.init_from_ref(subspecs_mem.get_ref());
             m_subspecs.set_parent(&m_top, 3);
             dg.release();
         }
@@ -160,9 +160,9 @@ void Spec::insert_column(size_t column_ndx, ColumnType type, StringData name, Co
         if (type == col_type_Table) {
             // Add a new empty spec to `m_subspecs`
             MemRef subspec_mem = create_empty_spec(alloc); // Throws
-            _impl::DeepArrayRefDestroyGuard dg(subspec_mem.m_ref, alloc);
+            _impl::DeepArrayRefDestroyGuard dg(subspec_mem.get_ref(), alloc);
             size_t subspec_ndx = get_subspec_ndx(column_ndx);
-            int_fast64_t v(subspec_mem.m_ref); // FIXME: Dangerous cast (unsigned -> signed)
+            int_fast64_t v(subspec_mem.get_ref()); // FIXME: Dangerous cast (unsigned -> signed)
             m_subspecs.insert(subspec_ndx, v); // Throws
             dg.release();
         }

--- a/src/realm/table.cpp
+++ b/src/realm/table.cpp
@@ -1975,16 +1975,16 @@ ref_type Table::create_empty_table(Allocator& alloc)
 
     {
         MemRef mem = Spec::create_empty_spec(alloc); // Throws
-        dg_2.reset(mem.m_ref);
-        int_fast64_t v(mem.m_ref); // FIXME: Dangerous case (unsigned -> signed)
+        dg_2.reset(mem.get_ref());
+        int_fast64_t v(mem.get_ref()); // FIXME: Dangerous case (unsigned -> signed)
         top.add(v); // Throws
         dg_2.release();
     }
     {
         bool context_flag = false;
         MemRef mem = Array::create_empty_array(Array::type_HasRefs, context_flag, alloc); // Throws
-        dg_2.reset(mem.m_ref);
-        int_fast64_t v(mem.m_ref); // FIXME: Dangerous case (unsigned -> signed)
+        dg_2.reset(mem.get_ref());
+        int_fast64_t v(mem.get_ref()); // FIXME: Dangerous case (unsigned -> signed)
         top.add(v); // Throws
         dg_2.release();
     }
@@ -2044,7 +2044,7 @@ ref_type Table::clone_columns(Allocator& alloc) const
         ref_type new_col_ref;
         const ColumnBase* col = &get_column_base(col_ndx);
         MemRef mem = col->clone_deep(alloc);
-        new_col_ref = mem.m_ref;
+        new_col_ref = mem.get_ref();
         new_columns.add(int_fast64_t(new_col_ref)); // Throws
     }
     return new_columns.get_ref();
@@ -2055,7 +2055,7 @@ ref_type Table::clone(Allocator& alloc) const
 {
     if (m_top.is_attached()) {
         MemRef mem = m_top.clone_deep(alloc); // Throws
-        return mem.m_ref;
+        return mem.get_ref();
     }
 
     Array new_top(alloc);
@@ -2064,15 +2064,15 @@ ref_type Table::clone(Allocator& alloc) const
     _impl::DeepArrayRefDestroyGuard dg_2(alloc);
     {
         MemRef mem = m_spec.m_top.clone_deep(alloc); // Throws
-        dg_2.reset(mem.m_ref);
-        int_fast64_t v(mem.m_ref); // FIXME: Dangerous cast (unsigned -> signed)
+        dg_2.reset(mem.get_ref());
+        int_fast64_t v(mem.get_ref()); // FIXME: Dangerous cast (unsigned -> signed)
         new_top.add(v); // Throws
         dg_2.release();
     }
     {
         MemRef mem = m_columns.clone_deep(alloc); // Throws
-        dg_2.reset(mem.m_ref);
-        int_fast64_t v(mem.m_ref); // FIXME: Dangerous cast (unsigned -> signed)
+        dg_2.reset(mem.get_ref());
+        int_fast64_t v(mem.get_ref()); // FIXME: Dangerous cast (unsigned -> signed)
         new_top.add(v); // Throws
         dg_2.release();
     }

--- a/src/realm/table_view.hpp
+++ b/src/realm/table_view.hpp
@@ -875,7 +875,7 @@ inline TableViewBase::TableViewBase(const TableViewBase& tv):
     // RAII idiom (nor should it).
     Allocator& alloc = m_row_indexes.get_alloc();
     MemRef mem = tv.m_row_indexes.get_root_array()->clone_deep(alloc); // Throws
-    _impl::DeepArrayRefDestroyGuard ref_guard(mem.m_ref, alloc);
+    _impl::DeepArrayRefDestroyGuard ref_guard(mem.get_ref(), alloc);
     if (m_table)
         m_table->register_view(this); // Throws
     m_row_indexes.get_root_array()->init_from_mem(mem);
@@ -957,7 +957,7 @@ inline TableViewBase& TableViewBase::operator=(const TableViewBase& tv)
 
     Allocator& alloc = m_row_indexes.get_alloc();
     MemRef mem = tv.m_row_indexes.get_root_array()->clone_deep(alloc); // Throws
-    _impl::DeepArrayRefDestroyGuard ref_guard(mem.m_ref, alloc);
+    _impl::DeepArrayRefDestroyGuard ref_guard(mem.get_ref(), alloc);
     m_row_indexes.destroy();
     m_row_indexes.get_root_array()->init_from_mem(mem);
     ref_guard.release();

--- a/src/realm/util/config.sh
+++ b/src/realm/util/config.sh
@@ -73,6 +73,13 @@ else
     enable_assertions="0"
 fi
 
+enable_memdebug="$(get_config_param "ENABLE_MEMDEBUG")" || exit 1
+if [ "$enable_memdebug" = "yes" ]; then
+    enable_memdebug="1"
+else
+    enable_memdebug="0"
+fi
+
 cat >"$target" <<EOF
 /*************************************************************************
  *
@@ -100,4 +107,5 @@ cat >"$target" <<EOF
 #define REALM_ENABLE_ALLOC_SET_ZERO $enable_alloc_set_zero
 #define REALM_ENABLE_ENCRYPTION     $enable_encryption
 #define REALM_ENABLE_ASSERTIONS     $enable_assertions
+#define REALM_ENABLE_MEMDEBUG       $enable_memdebug
 EOF

--- a/src/realm/util/features.h
+++ b/src/realm/util/features.h
@@ -45,6 +45,10 @@
 #    define REALM_ENABLE_ASSERTIONS     0
 #  endif
 
+#  ifndef REALM_ENABLE_MEMDEBUG
+#    define REALM_ENABLE_MEMDEBUG       0
+#  endif
+
 #  ifndef _WIN32
 #    define REALM_INSTALL_PREFIX      "/usr/local"
 #    define REALM_INSTALL_EXEC_PREFIX REALM_INSTALL_PREFIX

--- a/src/realm/util/file.hpp
+++ b/src/realm/util/file.hpp
@@ -569,7 +569,7 @@ public:
     File::Map<T>& operator=(File::Map<T>&& other)
     {
         if (m_addr) unmap();
-        m_addr = other.m_addr;
+        m_addr = other.get_addr();
         m_size = other.m_size;
         other.m_addr = 0;
         other.m_size = 0;

--- a/test/test_all.cpp
+++ b/test/test_all.cpp
@@ -208,6 +208,12 @@ void display_build_config()
     const char* with_debug =
         Version::has_feature(feature_Debug) ? "Enabled" : "Disabled";
 
+#if REALM_ENABLE_MEMDEBUG
+    const char* memdebug = "Enabled";
+#else
+    const char* memdebug = "Disabled";
+#endif
+
 #if REALM_ENABLE_ENCRYPTION
     bool always_encrypt = is_always_encrypt_enabled();
     const char* encryption = always_encrypt ?
@@ -240,6 +246,7 @@ void display_build_config()
         "Encryption: "<<encryption<<"\n"
         "\n"
         "REALM_MAX_BPNODE_SIZE = "<<REALM_MAX_BPNODE_SIZE<<"\n"
+        "REALM_MEMDEBUG = " << memdebug << "\n"
         "\n"
         // Be aware that ps3/xbox have sizeof (void*) = 4 && sizeof (size_t) == 8
         // We decide to print size_t here

--- a/test/test_alloc.cpp
+++ b/test/test_alloc.cpp
@@ -77,23 +77,23 @@ TEST(Alloc_1)
     MemRef mr3 = alloc.alloc(256);
 
     // Set size in headers (needed for Alloc::free())
-    set_capacity(mr1.m_addr, 8);
-    set_capacity(mr2.m_addr, 16);
-    set_capacity(mr3.m_addr, 256);
+    set_capacity(mr1.get_addr(), 8);
+    set_capacity(mr2.get_addr(), 16);
+    set_capacity(mr3.get_addr(), 256);
 
     // Are pointers 64bit aligned
-    CHECK_EQUAL(0, intptr_t(mr1.m_addr) & 0x7);
-    CHECK_EQUAL(0, intptr_t(mr2.m_addr) & 0x7);
-    CHECK_EQUAL(0, intptr_t(mr3.m_addr) & 0x7);
+    CHECK_EQUAL(0, intptr_t(mr1.get_addr()) & 0x7);
+    CHECK_EQUAL(0, intptr_t(mr2.get_addr()) & 0x7);
+    CHECK_EQUAL(0, intptr_t(mr3.get_addr()) & 0x7);
 
     // Do refs translate correctly
-    CHECK_EQUAL(static_cast<void*>(mr1.m_addr), alloc.translate(mr1.m_ref));
-    CHECK_EQUAL(static_cast<void*>(mr2.m_addr), alloc.translate(mr2.m_ref));
-    CHECK_EQUAL(static_cast<void*>(mr3.m_addr), alloc.translate(mr3.m_ref));
+    CHECK_EQUAL(static_cast<void*>(mr1.get_addr()), alloc.translate(mr1.get_ref()));
+    CHECK_EQUAL(static_cast<void*>(mr2.get_addr()), alloc.translate(mr2.get_ref()));
+    CHECK_EQUAL(static_cast<void*>(mr3.get_addr()), alloc.translate(mr3.get_ref()));
 
-    alloc.free_(mr3.m_ref, mr3.m_addr);
-    alloc.free_(mr2.m_ref, mr2.m_addr);
-    alloc.free_(mr1.m_ref, mr1.m_addr);
+    alloc.free_(mr3.get_ref(), mr3.get_addr());
+    alloc.free_(mr2.get_ref(), mr2.get_addr());
+    alloc.free_(mr1.get_ref(), mr1.get_addr());
 
     // SlabAlloc destructor will verify that all is free'd
 }
@@ -249,15 +249,15 @@ TEST(Alloc_Fuzzy)
             siz *= 8;
             MemRef r = alloc.alloc(siz);
             refs.push_back(r);
-            set_capacity(r.m_addr, siz);
+            set_capacity(r.get_addr(), siz);
 
             // write some data to the allcoated area so that we can verify it later
-            memset(r.m_addr + 3, static_cast<char>(reinterpret_cast<intptr_t>(r.m_addr)), siz - 3);
+            memset(r.get_addr() + 3, static_cast<char>(reinterpret_cast<intptr_t>(r.get_addr())), siz - 3);
         }
         else if(refs.size() > 0) {
             // free random entry
             size_t entry = rand() % refs.size();
-            alloc.free_(refs[entry].m_ref, refs[entry].m_addr);
+            alloc.free_(refs[entry].get_ref(), refs[entry].get_addr());
             refs.erase(refs.begin() + entry);
         }
 
@@ -265,17 +265,17 @@ TEST(Alloc_Fuzzy)
             // free everything when we have 10 allocations, or when we exit, to not leak
             while(refs.size() > 0) {
                 MemRef r = refs[0];
-                size_t siz = get_capacity(r.m_addr);
+                size_t siz = get_capacity(r.get_addr());
 
                 // verify that all the data we wrote during allocation is intact
                 for (size_t c = 3; c < siz; c++) {
-                    if (r.m_addr[c] != static_cast<char>(reinterpret_cast<intptr_t>(r.m_addr))) {
+                    if (r.get_addr()[c] != static_cast<char>(reinterpret_cast<intptr_t>(r.get_addr()))) {
                         // faster than using 'CHECK' for each character, which is slow
                         CHECK(false);
                     }
                 }
 
-                alloc.free_(r.m_ref, r.m_addr);
+                alloc.free_(r.get_ref(), r.get_addr());
                 refs.erase(refs.begin());
             }
 

--- a/test/test_destroy_guard.cpp
+++ b/test/test_destroy_guard.cpp
@@ -76,7 +76,7 @@ public:
         REALM_ASSERT(!addr);
         addr = new char[size]; // Throws
         m_offset += size;
-        return MemRef(addr, ref);
+        return MemRef(addr, ref, *this);
     }
 
     MemRef do_realloc(ref_type, const char*, size_t, size_t) override
@@ -188,7 +188,7 @@ TEST(DestroyGuard_ArrayShallow)
         {
             bool context_flag = false;
             MemRef child_mem = Array::create_empty_array(Array::type_Normal, context_flag, alloc);
-            int_fast64_t v(child_mem.m_ref);
+            int_fast64_t v(child_mem.get_ref());
             root.add(v);
         }
     }
@@ -247,7 +247,7 @@ TEST(DestroyGuard_ArrayDeep)
                 bool context_flag = false;
                 MemRef child_mem =
                     Array::create_empty_array(Array::type_Normal, context_flag, alloc);
-                int_fast64_t v(child_mem.m_ref);
+                int_fast64_t v(child_mem.get_ref());
                 root.add(v);
             }
         }
@@ -265,8 +265,8 @@ TEST(DestroyGuard_ArrayRefDeep)
         {
             bool context_flag = false;
             MemRef mem = Array::create_empty_array(Array::type_Normal, context_flag, alloc);
-            DeepArrayRefDestroyGuard dg(mem.m_ref, alloc);
-            CHECK_EQUAL(mem.m_ref, dg.get());
+            DeepArrayRefDestroyGuard dg(mem.get_ref(), alloc);
+            CHECK_EQUAL(mem.get_ref(), dg.get());
         }
         CHECK(alloc.empty());
     }
@@ -276,8 +276,8 @@ TEST(DestroyGuard_ArrayRefDeep)
         {
             bool context_flag = false;
             MemRef mem = Array::create_empty_array(Array::type_Normal, context_flag, alloc);
-            DeepArrayRefDestroyGuard dg(mem.m_ref, alloc);
-            CHECK_EQUAL(mem.m_ref, dg.release());
+            DeepArrayRefDestroyGuard dg(mem.get_ref(), alloc);
+            CHECK_EQUAL(mem.get_ref(), dg.release());
         }
         CHECK(!alloc.empty());
         alloc.clear();
@@ -289,9 +289,9 @@ TEST(DestroyGuard_ArrayRefDeep)
             bool context_flag = false;
             DeepArrayRefDestroyGuard dg(alloc);
             MemRef mem_1 = Array::create_empty_array(Array::type_Normal, context_flag, alloc);
-            dg.reset(mem_1.m_ref);
+            dg.reset(mem_1.get_ref());
             MemRef mem_2 = Array::create_empty_array(Array::type_Normal, context_flag, alloc);
-            dg.reset(mem_2.m_ref);
+            dg.reset(mem_2.get_ref());
         }
         CHECK(alloc.empty());
     }
@@ -306,7 +306,7 @@ TEST(DestroyGuard_ArrayRefDeep)
                 bool context_flag = false;
                 MemRef child_mem =
                     Array::create_empty_array(Array::type_Normal, context_flag, alloc);
-                int_fast64_t v(child_mem.m_ref);
+                int_fast64_t v(child_mem.get_ref());
                 root.add(v);
                 root_ref = root.get_ref();
             }


### PR DESCRIPTION
… destroyed or relocated array. Slows down speed of a factor 5-6.
