### PR TITLE
Document naming convention for public variables.

### DIFF
--- a/doc/development/coding_style_guide.cpp
+++ b/doc/development/coding_style_guide.cpp
@@ -93,6 +93,10 @@ namespace my_namespace {
 template<class T>
 class MyClass: public Base {
 public:
+
+    // Public member variables do not have a 'm_' prefix.
+    int baz;
+
     MyClass(...):
         Base(...),
         m_bar(7),
@@ -100,9 +104,6 @@ public:
     {
         // ...
     }
-
-    // Public member variables do not have a 'm_' prefix.
-    int baz;
 
 private:
     // Static member variables have prefix 's_'.


### PR DESCRIPTION
During some recent refactoring, I looked for naming conventions of public member variables in the style guide but didn't find any. I only saw that the `m_` prefix should be used and I (incorrectly) assumed that this should hold for public variables as well. 

@realm/core @tgoyne 
