### PR TITLE
Assertion failed slabs end

### DIFF
--- a/test/test_lang_bind_helper.cpp
+++ b/test/test_lang_bind_helper.cpp
@@ -12218,10 +12218,10 @@ ONLY(LangBindHelper_AssertionFailedSlabsEnd)
     Group& g = const_cast<Group&>(sg_w.begin_write());
     Group& g_r = const_cast<Group&>(sg_r.begin_read());
 
-    try { g.insert_table(0, "hjnskmesdjafmchdhjamdjjrantsqprgmhkntjtbhmnqffil"); } catch (const TableNameInUse&) { }
-    g.get_table(0)->insert_column(0, DataType(10), "orbnieikeqkdcgjebnriinsbpnfodqfjpojbrpfelsidfcmg", true);
+    g.add_table("hjnskmesdjafmchdhjamdjjrantsqprgmhkntjtbhmnqffil");
+    g.get_table(0)->add_column(type_Double, "orbnieikeqkdcgjebnriinsbpnfodqfjpojbrpfelsidfcmg", true);
     g.get_table(0)->insert_empty_row(0, 255);
-    g.get_table(0)->insert_column(0, DataType(10), "qrsebrlirsrroejlfppsctimaroipinkgccfcmhbpmlbklsr", true);
+    g.get_table(0)->insert_column(0, type_Double, "qrsebrlirsrroejlfppsctimaroipinkgccfcmhbpmlbklsr", true);
     sg_r.close();
     sg_w.commit();
     REALM_ASSERT_RELEASE(sg_w.compact());


### PR DESCRIPTION
@finnschiermer 

Might be related to #1898

```
/Users/daniel/Development/realm-core/src/realm/alloc_slab.cpp:485: [realm-core-1.1.2] Assertion failed: i != m_slabs.end()
0   realm_unit_tests                    0x00000001011044a3 _ZN5realm4utilL18terminate_internalERNSt3__118basic_stringstreamIcNS1_11char_traitsIcEENS1_9allocatorIcEEEE + 35
1   realm_unit_tests                    0x0000000101104e48 _ZN5realm4util9terminateEPKcS2_lOSt16initializer_listINS0_9PrintableEE + 1528
2   realm_unit_tests                    0x0000000100b95f31 _ZNK5realm9SlabAlloc12do_translateEm + 2193
3   realm_unit_tests                    0x000000010002ce7f _ZNK5realm9Allocator9translateEm + 47
4   realm_unit_tests                    0x0000000100b92bab _ZN5realm9SlabAlloc8do_allocEm + 2539
5   realm_unit_tests                    0x0000000100059001 _ZN5realm9Allocator5allocEm + 65
6   realm_unit_tests                    0x0000000100ba3fa1 _ZN5realm5Array13copy_on_writeEv + 177
7   realm_unit_tests                    0x00000001000a09ee _ZN5realm10BasicArrayIdE6insertEmd + 110
8   realm_unit_tests                    0x0000000100154dd4 _ZN5realm10BasicArrayIdE18bptree_leaf_insertEmdRNS_5Array14TreeInsertBaseE + 180
9   realm_unit_tests                    0x0000000100154b06 _ZN5realm6BpTreeIdE13bptree_insertINS1_17LeafValueInserterEEEvmRNS_5Array10TreeInsertIT_EEm + 262
10  realm_unit_tests                    0x00000001001547dd _ZN5realm6BpTreeIdE6insertEmdm + 189
11  realm_unit_tests                    0x000000010015469a _ZN5realm6ColumnIdE6insertEmdm + 154
12  realm_unit_tests                    0x00000001001600f0 _ZN5realm6ColumnIdE11insert_rowsEmmmb + 320
13  realm_unit_tests                    0x00000001010bd488 _ZN5realm5Table16insert_empty_rowEmm + 488
14  realm_unit_tests                    0x00000001003d928a _ZN54Realm_UnitTest__LangBindHelper_AssertionFailedSlabsEnd8test_runEv + 3450
15  realm_unit_tests                    0x000000010046b1d5 _ZN5realm9test_util9unit_test12RegisterTestI54Realm_UnitTest__LangBindHelper_AssertionFailedSlabsEndE8run_testERNS1_11TestContextE + 37
16  realm_unit_tests                    0x0000000101126305 _ZN5realm9test_util9unit_test8TestList17ThreadContextImpl3runENS2_17SharedContextImpl5EntryERNS_4util10UniqueLockE + 197
17  realm_unit_tests                    0x0000000101125e47 _ZN5realm9test_util9unit_test8TestList17ThreadContextImpl13nonconcur_runEv + 599
18  realm_unit_tests                    0x0000000101124000 _ZN5realm9test_util9unit_test8TestList3runENS2_6ConfigE + 15152
19  realm_unit_tests                    0x000000010004413d _ZN12_GLOBAL__N_19run_testsEPN5realm4util6LoggerE + 16157
20  realm_unit_tests                    0x000000010003f2b1 _Z8test_alliPPcPN5realm4util6LoggerE + 177
21  realm_unit_tests                    0x000000010003f1f6 main + 38
22  libdyld.dylib                       0x00007fff9f3205ad start + 1
23  ???                                 0x0000000000000001 0x0 + 1
IMPORTANT: if you see this error, please send this log to help@realm.io.Program ended with exit code: 9
```
