### PR TITLE
Fix incorrect updating of subspecs when moving link columns

### DIFF
--- a/src/realm/spec.cpp
+++ b/src/realm/spec.cpp
@@ -257,7 +257,7 @@ void Spec::move_column(size_t from_ndx, size_t to_ndx)
     if (type == col_type_Table || tf::is_link_type(type)) {
         // Table columns and link type columns have a single subspec.
         size_t old_subspec_ndx = get_subspec_ndx(from_ndx);
-        size_t new_subspec_ndx = get_subspec_ndx_after(to_ndx);
+        size_t new_subspec_ndx = get_subspec_ndx_after(to_ndx, from_ndx);
         if (old_subspec_ndx != new_subspec_ndx) {
             m_subspecs.move_rotate(old_subspec_ndx, new_subspec_ndx);
         }
@@ -278,17 +278,21 @@ size_t Spec::get_subspec_ndx(size_t column_ndx) const noexcept
                    get_column_type(column_ndx) == col_type_LinkList ||
                    get_column_type(column_ndx) == col_type_BackLink );
 
-    return get_subspec_ndx_after(column_ndx);
+    return get_subspec_ndx_after(column_ndx, column_ndx);
 }
 
 
-size_t Spec::get_subspec_ndx_after(size_t column_ndx) const noexcept
+size_t Spec::get_subspec_ndx_after(size_t column_ndx, size_t skip_column_ndx) const noexcept
 {
     REALM_ASSERT(column_ndx <= get_column_count());
     // The m_subspecs array only keep info for subtables so we need to
     // count up to it's position
     size_t subspec_ndx = 0;
     for (size_t i = 0; i != column_ndx; ++i) {
+        if (i == skip_column_ndx) {
+            continue;
+        }
+
         ColumnType type = ColumnType(m_types.get(i));
         if (type == col_type_Table || type == col_type_Link || type == col_type_LinkList) {
             ++subspec_ndx;

--- a/src/realm/spec.hpp
+++ b/src/realm/spec.hpp
@@ -175,7 +175,7 @@ private:
 
     ColumnInfo get_column_info(size_t column_ndx) const noexcept;
 
-    size_t get_subspec_ndx_after(size_t column_ndx) const noexcept;
+    size_t get_subspec_ndx_after(size_t column_ndx, size_t skip_column_ndx) const noexcept;
     bool has_subspec() const noexcept;
 
     // Returns false if the spec has no columns, otherwise it returns

--- a/test/test_table.cpp
+++ b/test/test_table.cpp
@@ -2329,6 +2329,30 @@ TEST(Table_SpecMoveColumns)
 }
 
 
+TEST(Table_SpecMoveLinkColumn)
+{
+    using df = _impl::DescriptorFriend;
+
+    Group group;
+    TableRef target = group.add_table("target");
+    target->add_column(type_Int, "a");
+
+    TableRef origin = group.add_table("origin");
+    origin->add_column_link(type_Link, "a", *target);
+    origin->add_column(type_Int, "b");
+
+    origin->add_empty_row(2);
+    target->add_empty_row(2);
+    origin->set_link(0, 0, 1);
+
+    df::move_column(*origin->get_descriptor(), 0, 1);
+
+    CHECK_EQUAL(origin->get_link(1, 0), 1);
+    CHECK_EQUAL(target->get_backlink_count(0, *origin, 1), 0);
+    CHECK_EQUAL(target->get_backlink_count(1, *origin, 1), 1);
+}
+
+
 TEST(Table_SpecMoveColumnsWithIndexes)
 {
     using df = _impl::DescriptorFriend;


### PR DESCRIPTION
When the new column index is greater than the old column index the new subspec
index would include the pre-move column index in the calculation, resulting in
an assertion failure in the specific scenario tested, and incorrect results in
other scenarios.
