### PR TITLE
Switching to -Os

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -945,7 +945,8 @@ EOF
                 (cd openssl && mv Makefile Makefile.dep && sed -e 's/\-mandroid//g' Makefile.dep > Makefile) || exit 1
                 DEPFLAGS="$(grep DEPFLAG= Makefile | head -1 | cut -f2 -d=)"
                 $MAKE -C "openssl" DEPFLAG="$DEPFLAGS -I$temp_dir/sysroot/usr/include -I$temp_dir/sysroot/usr/include/linux -I$temp_dir/include/c++/4.9/tr1 -I$temp_dir/include/c++/4.9" depend || exit 1
-                (cd openssl && mv Makefile.dep Makefile) || exit 1
+                # -O3 seems to be buggy on Android
+                (cd openssl && sed -e 's/O3/Os/g' Makefile.dep > Makefile && rm -f Makefile.dep) || exit 1
                 PATH="$path" CC="$cc" CFLAGS="$cflags_arch" PERL="perl" $MAKE -C "openssl" build_crypto || exit 1
                 cp "openssl/libcrypto.a" "$ANDROID_DIR/$libcrypto_name" || exit 1
             fi

--- a/release_notes.md
+++ b/release_notes.md
@@ -53,6 +53,7 @@
   (#1478)
 * New feature in the unit test framework: Ability to specify log level
   threshold for custom intra test logging (`UNITTEST_LOG_LEVEL`).
+* Switch from `-O3` to `-Os` to compile OpenSSL: https://github.com/android-ndk/ndk/issues/110
 
 ----------------------------------------------
 


### PR DESCRIPTION
Switching to `-Os` to compile OpenSSL on Android. It has been reported by other projects that `-O3` might produce wrong code (https://github.com/android-ndk/ndk/issues/110).

Results below are for `.so` file distributed to Android devices. The microbenchmark is done as part of the Java unit tests.

| `-O3` | `-Os` | Architecture |
| --- | --- | --- |
| 1939432 | 1931240 | arm64-v8a/librealm-jni.so |
| 1193412 | 1189316 | armeabi/librealm-jni.so |
| 1177036 | 1168844 | armeabi-v7a/librealm-jni.so |
| 2434612 | 2434608 | mips/librealm-jni.so |
| 1877484 | 1877484 | x86/librealm-jni.so |
| 2087176 | 2083080 | x86_64/librealm-jni.so |

Size is a bit smaller for `-Os`.

| `-O3` | `-Os` | Microbenchmark |
| --- | --- | --- |
| 2.78 | 2.77 | writeDouble |
| 4.26 | 4.12 | writeLong |
| 17.13 | 14.96 | writeString |

I believe that it shows that performance is about the same.

This changes _does not_ solved the issue with compacting encrypted Realms.

Closes #1920

@realm/java @ironage @danielpovlsen @finnschiermer 
