### PR TITLE
simulated_failure shouldn't use thread_local on Android

### DIFF
--- a/src/realm/impl/simulated_failure.cpp
+++ b/src/realm/impl/simulated_failure.cpp
@@ -9,7 +9,7 @@
 #include <realm/util/basic_system_errors.hpp>
 #include <realm/impl/simulated_failure.hpp>
 
-#if REALM_PLATFORM_APPLE
+#if REALM_PLATFORM_APPLE || REALM_ANDROID
 #  define USE_PTHREADS_IMPL 1
 #else
 #  define USE_PTHREADS_IMPL 0


### PR DESCRIPTION
Fixes https://github.com/realm/realm-dotnet/issues/582

This causes a crash in the unit tests of the dotnet binding. Apparently `thread_local` has issues on Android.
