### PR TITLE
Add missing wrappers to Row

### DIFF
--- a/src/realm/row.hpp
+++ b/src/realm/row.hpp
@@ -92,12 +92,15 @@ public:
     size_t get_link_count(size_t col_ndx) const noexcept;
     Mixed get_mixed(size_t col_ndx) const noexcept;
     DataType get_mixed_type(size_t col_ndx) const noexcept;
+    template<typename U> U get(size_t col_ndx) const noexcept;
 
     void set_int(size_t col_ndx, int_fast64_t value);
+    void set_int_unique(size_t col_ndx, int_fast64_t value);
     void set_bool(size_t col_ndx, bool value);
     void set_float(size_t col_ndx, float value);
     void set_double(size_t col_ndx, double value);
     void set_string(size_t col_ndx, StringData value);
+    void set_string_unique(size_t col_ndx, StringData value);
     void set_binary(size_t col_ndx, BinaryData value);
     void set_olddatetime(size_t col_ndx, OldDateTime value);
     void set_timestamp(size_t col_ndx, Timestamp value);
@@ -476,9 +479,22 @@ inline DataType RowFuncs<T,R>::get_mixed_type(size_t col_ndx) const noexcept
 }
 
 template<class T, class R>
+template<class U>
+inline U RowFuncs<T,R>::get(size_t col_ndx) const noexcept
+{
+    return table()->template get<U>(col_ndx, row_ndx());
+}
+
+template<class T, class R>
 inline void RowFuncs<T,R>::set_int(size_t col_ndx, int_fast64_t value)
 {
     table()->set_int(col_ndx, row_ndx(), value); // Throws
+}
+
+template<class T, class R>
+inline void RowFuncs<T,R>::set_int_unique(size_t col_ndx, int_fast64_t value)
+{
+    table()->set_int_unique(col_ndx, row_ndx(), value); // Throws
 }
 
 template<class T, class R>
@@ -503,6 +519,12 @@ template<class T, class R>
 inline void RowFuncs<T,R>::set_string(size_t col_ndx, StringData value)
 {
     table()->set_string(col_ndx, row_ndx(), value); // Throws
+}
+
+template<class T, class R>
+inline void RowFuncs<T,R>::set_string_unique(size_t col_ndx, StringData value)
+{
+    table()->set_string_unique(col_ndx, row_ndx(), value); // Throws
 }
 
 template<class T, class R>


### PR DESCRIPTION
`get<>()`, `set_int_unique()`, and `set_string_unique()` were added to `Table` but not wrapped in `Row`.
