### PR TITLE
Don't report test progress by default on Windows

### DIFF
--- a/test/test_all.cpp
+++ b/test/test_all.cpp
@@ -414,11 +414,7 @@ bool run_tests(util::Logger* logger)
     }
     else {
         const char* str = getenv("UNITTEST_PROGRESS");
-#ifdef _MSC_VER
-        bool report_progress = true;
-#else
         bool report_progress = str && strlen(str) != 0;
-#endif
         reporter.reset(new CustomReporter(report_progress));
     }
     config.reporter = reporter.get();


### PR DESCRIPTION
The extra output makes it difficult to see which tests failed in the output window.

This appears to have been enabled in a28533a8f2a30e6b495efea1c09793cbb00f24e8 without any explanation as to why.

/cc @rrrlasse
