### PR TITLE
Remove "no_prealloc_tag" constructors

### DIFF
--- a/src/realm/array.hpp
+++ b/src/realm/array.hpp
@@ -267,11 +267,6 @@ public:
     /// Create an array accessor in the unattached state.
     explicit Array(Allocator&) noexcept;
 
-    // Fastest way to instantiate an array, if you just want to utilize its
-    // methods
-    struct no_prealloc_tag {};
-    explicit Array(no_prealloc_tag) noexcept;
-
     ~Array() noexcept override {}
 
     enum Type {
@@ -1540,15 +1535,6 @@ inline Array::Array(Allocator& allocator) noexcept:
     m_alloc(allocator)
 {
 }
-
-// Fastest way to instantiate an Array. For use with GetDirect() that only fills out m_width, m_data
-// and a few other basic things needed for read-only access. Or for use if you just want a way to call
-// some methods written in Array.*
-inline Array::Array(no_prealloc_tag) noexcept:
-    m_alloc(*static_cast<Allocator*>(0))
-{
-}
-
 
 inline void Array::create(Type type, bool context_flag, size_t length, int_fast64_t value)
 {

--- a/src/realm/array_basic.hpp
+++ b/src/realm/array_basic.hpp
@@ -30,7 +30,6 @@ template<class T>
 class BasicArray: public Array {
 public:
     explicit BasicArray(Allocator&) noexcept;
-    explicit BasicArray(no_prealloc_tag) noexcept;
     ~BasicArray() noexcept override {}
 
     T get(size_t ndx) const noexcept;

--- a/src/realm/array_basic_tpl.hpp
+++ b/src/realm/array_basic_tpl.hpp
@@ -36,13 +36,6 @@ inline BasicArray<T>::BasicArray(Allocator& allocator) noexcept:
 }
 
 template<class T>
-inline BasicArray<T>::BasicArray(no_prealloc_tag) noexcept:
-    Array(no_prealloc_tag())
-{
-}
-
-
-template<class T>
 inline MemRef BasicArray<T>::create_array(size_t init_size, Allocator& allocator)
 {
     size_t byte_size_0 = calc_aligned_byte_size(init_size); // Throws

--- a/src/realm/array_integer.hpp
+++ b/src/realm/array_integer.hpp
@@ -31,7 +31,6 @@ class ArrayInteger: public Array {
 public:
     typedef int64_t value_type;
 
-    explicit ArrayInteger(no_prealloc_tag) noexcept;
     explicit ArrayInteger(Allocator&) noexcept;
     ~ArrayInteger() noexcept override {}
 
@@ -74,7 +73,6 @@ class ArrayIntNull: public Array {
 public:
     using value_type = util::Optional<int64_t>;
 
-    explicit ArrayIntNull(no_prealloc_tag) noexcept;
     explicit ArrayIntNull(Allocator&) noexcept;
     ~ArrayIntNull() noexcept override;
 
@@ -191,12 +189,6 @@ private:
 
 // Implementation:
 
-inline ArrayInteger::ArrayInteger(Array::no_prealloc_tag) noexcept:
-    Array(Array::no_prealloc_tag())
-{
-    m_is_inner_bptree_node = false;
-}
-
 inline ArrayInteger::ArrayInteger(Allocator& allocator) noexcept:
     Array(allocator)
 {
@@ -283,11 +275,6 @@ inline size_t ArrayInteger::upper_bound(int64_t value) const noexcept
     return upper_bound_int(value);
 }
 
-
-inline
-ArrayIntNull::ArrayIntNull(no_prealloc_tag tag) noexcept: Array(tag)
-{
-}
 
 inline
 ArrayIntNull::ArrayIntNull(Allocator& allocator) noexcept: Array(allocator)

--- a/src/realm/array_string.hpp
+++ b/src/realm/array_string.hpp
@@ -48,7 +48,6 @@ public:
     // Constructor defaults to non-nullable because we use non-nullable ArrayString so many places internally in core
     // (data which isn't user payload) where null isn't needed.
     explicit ArrayString(Allocator&, bool nullable = false) noexcept;
-    explicit ArrayString(no_prealloc_tag) noexcept;
     ~ArrayString() noexcept override {}
 
     bool is_null(size_t ndx) const;
@@ -115,14 +114,6 @@ private:
 // Creates new array (but invalid, call init_from_ref() to init)
 inline ArrayString::ArrayString(Allocator& allocator, bool nullable) noexcept:
 Array(allocator), m_nullable(nullable)
-{
-}
-
-// Fastest way to instantiate an Array. For use with GetDirect() that only fills out m_width, m_data
-// and a few other basic things needed for read-only access. Or for use if you just want a way to call
-// some methods written in ArrayString.*
-inline ArrayString::ArrayString(no_prealloc_tag) noexcept:
-    Array(*static_cast<Allocator*>(nullptr))
 {
 }
 


### PR DESCRIPTION
Not used. Odd concept. Array object not fully functional as m_alloc is
invalid.

@rrrlasse @finnschiermer 
