### PR TITLE
Disable the test which is causing valgrind to fail.

### DIFF
--- a/test/test_shared.cpp
+++ b/test/test_shared.cpp
@@ -2956,6 +2956,10 @@ TEST(Shared_VersionOfBoundSnapshot)
     }
 }
 
+
+// This test is valid, but because it requests all available memory,
+// it does not play nicely with valgrind and so is disabled.
+/*
 #if !defined(_WIN32)
 // Check what happens when Realm cannot allocate more virtual memory
 // We should throw an AddressSpaceExhausted exception.
@@ -2978,10 +2982,10 @@ NONCONCURRENT_TEST(Shared_OutOfMemory)
     sg.close();
 
     std::vector<std::pair<void*, size_t>> memory_list;
-    // Reserve enough for 500 Gb, but in practice the vector is only ever around size 10.
+    // Reserve enough for 5*100000 Gb, but in practice the vector is only ever around size 10.
     // Do this here to avoid the (small) chance that adding to the vector will request new virtual memory
     memory_list.reserve(500);
-    size_t chunk_size = 1024 * 1024 * 1024;
+    size_t chunk_size = size_t(1024) * 1024 * 1024 * 100000;
     while (chunk_size > string_length) {
         void* addr = ::mmap(nullptr, chunk_size, PROT_READ | PROT_WRITE, MAP_ANON | MAP_PRIVATE, -1, 0);
         if (addr == MAP_FAILED) {
@@ -2993,7 +2997,6 @@ NONCONCURRENT_TEST(Shared_OutOfMemory)
     }
 
     bool expected_exception_caught = false;
-
     // Attempt to open Realm, should fail because we hold too much already.
     try {
         SharedGroup sg2(path, false, SharedGroup::durability_Full, crypt_key());
@@ -3001,7 +3004,6 @@ NONCONCURRENT_TEST(Shared_OutOfMemory)
     catch (AddressSpaceExhausted& e) {
         expected_exception_caught = true;
     }
-
     CHECK(expected_exception_caught);
 
     // Release memory manually.
@@ -3019,7 +3021,8 @@ NONCONCURRENT_TEST(Shared_OutOfMemory)
     }
     CHECK(!expected_exception_caught);
 }
-#endif // win32
+#endif // !win32
+*/
 
 // Run some (repeatable) random checks through the fuzz tester.
 // For a comprehensive fuzz test, afl should be run. To do this see test/fuzzy/README.md


### PR DESCRIPTION
This test allocates all available memory to check how we handle mmap failures. However, it has caused valgrind to fail sporadically so this disables the test.

```
==25216==     Valgrind's memory management: out of memory:
==25216==        initialiseSector(TC)'s request for 27597024 bytes failed.
==25216==        68585365504 bytes have already been allocated.
==25216==     Valgrind cannot continue.  Sorry.
```

@finnschiermer @teotwaki 
