### PR TITLE
Use -fsigned-char to build

### DIFF
--- a/src/project.mk
+++ b/src/project.mk
@@ -10,7 +10,7 @@ endif
 
 CFLAGS_DEBUG += -fno-elide-constructors
 CFLAGS_PTHREADS += -pthread
-CFLAGS_GENERAL += -Wextra -pedantic -Wundef -Wshadow
+CFLAGS_GENERAL += -Wextra -pedantic -Wundef -Wshadow -fsigned-char
 CFLAGS_CXX = -std=c++14
 
 # Avoid a warning from Clang when linking on OS X. By default,
@@ -78,7 +78,7 @@ endif
 
 ifneq ($(REALM_ANDROID),)
   PROJECT_CFLAGS += -fPIC -DPIC -fvisibility=hidden
-  CFLAGS_OPTIM = -Os -flto -ffunction-sections -fdata-sections -DNDEBUG
+  CFLAGS_OPTIM = -Os -flto -ffunction-sections -fdata-sections -DNDEBUG -fsigned-char
   ifeq ($(ENABLE_ENCRYPTION),yes)
     PROJECT_CFLAGS += -I../../openssl/include
   endif


### PR DESCRIPTION
This is found when compiling realm-java with cmake. The different
default sets on different targets cause linking failed with lto enabled.

Although currently this is only a problem for android, but it would be
good to have this option for all targets to avoid we have some uncertain
builds.
