### PR TITLE
Unnest `VersionID` and move to separate file

### DIFF
--- a/realm.xcodeproj/project.pbxproj
+++ b/realm.xcodeproj/project.pbxproj
@@ -534,6 +534,9 @@
 		C0552C571B45CEA8007FF3AA /* simulated_failure.hpp in Headers */ = {isa = PBXBuildFile; fileRef = C08FE2B71B45BD750037AFCE /* simulated_failure.hpp */; };
 		C08FE2B81B45BD750037AFCE /* simulated_failure.cpp in Sources */ = {isa = PBXBuildFile; fileRef = C08FE2B61B45BD750037AFCE /* simulated_failure.cpp */; };
 		C08FE2B91B45BD750037AFCE /* simulated_failure.hpp in Headers */ = {isa = PBXBuildFile; fileRef = C08FE2B71B45BD750037AFCE /* simulated_failure.hpp */; };
+		D4AC5C2D1D5BACD600E3D29D /* version_id.hpp in Headers */ = {isa = PBXBuildFile; fileRef = D4AC5C2B1D5BACD600E3D29D /* version_id.hpp */; };
+		D4AC5C2E1D5BAFD600E3D29D /* version_id.hpp in Headers */ = {isa = PBXBuildFile; fileRef = D4AC5C2B1D5BACD600E3D29D /* version_id.hpp */; };
+		D4AC5C2F1D5BAFD700E3D29D /* version_id.hpp in Headers */ = {isa = PBXBuildFile; fileRef = D4AC5C2B1D5BACD600E3D29D /* version_id.hpp */; };
 		F43098B21B021C04000A2333 /* bptree.cpp in Sources */ = {isa = PBXBuildFile; fileRef = F43098B01B021C04000A2333 /* bptree.cpp */; };
 		F43098B31B021C04000A2333 /* bptree.cpp in Sources */ = {isa = PBXBuildFile; fileRef = F43098B01B021C04000A2333 /* bptree.cpp */; };
 		F43098B41B021C04000A2333 /* bptree.hpp in Headers */ = {isa = PBXBuildFile; fileRef = F43098B11B021C04000A2333 /* bptree.hpp */; };
@@ -1033,6 +1036,7 @@
 		C008FF991B67F02F0042669E /* liblibrealm watchos.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = "liblibrealm watchos.a"; sourceTree = BUILT_PRODUCTS_DIR; };
 		C08FE2B61B45BD750037AFCE /* simulated_failure.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = simulated_failure.cpp; sourceTree = "<group>"; };
 		C08FE2B71B45BD750037AFCE /* simulated_failure.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; path = simulated_failure.hpp; sourceTree = "<group>"; };
+		D4AC5C2B1D5BACD600E3D29D /* version_id.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; name = version_id.hpp; path = realm/version_id.hpp; sourceTree = "<group>"; };
 		F43098B01B021C04000A2333 /* bptree.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = bptree.cpp; path = realm/bptree.cpp; sourceTree = "<group>"; };
 		F43098B11B021C04000A2333 /* bptree.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; name = bptree.hpp; path = realm/bptree.hpp; sourceTree = "<group>"; };
 		F44D4CE51B381D27009ADAB9 /* input_stream.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; path = input_stream.hpp; sourceTree = "<group>"; };
@@ -1307,6 +1311,7 @@
 				365CCE33157CC37D00172BF8 /* utilities.hpp */,
 				80ADCCE718A23DD00049D472 /* version.cpp */,
 				80ADCCE818A23DD00049D472 /* version.hpp */,
+				D4AC5C2B1D5BACD600E3D29D /* version_id.hpp */,
 				42F862D119BDE3460053C134 /* views.cpp */,
 				42F862D219BDE3460053C134 /* views.hpp */,
 			);
@@ -1746,6 +1751,7 @@
 				52D7C4911852A01700633748 /* utf8.hpp in Headers */,
 				365CCE76157CC37D00172BF8 /* utilities.hpp in Headers */,
 				80ADCCEB18A23DD00049D472 /* version.hpp in Headers */,
+				D4AC5C2D1D5BACD600E3D29D /* version_id.hpp in Headers */,
 				42F862D419BDE3460053C134 /* views.hpp in Headers */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -1781,6 +1787,7 @@
 				4142C9701623478700B3B902 /* group_writer.hpp in Headers */,
 				4142C9881623478700B3B902 /* index_string.hpp in Headers */,
 				F44D4CE91B381D27009ADAB9 /* input_stream.hpp in Headers */,
+				D4AC5C2E1D5BAFD600E3D29D /* version_id.hpp in Headers */,
 				4142C9731623478700B3B902 /* lang_bind_helper.hpp in Headers */,
 				4142C9751623478700B3B902 /* mixed.hpp in Headers */,
 				4142C96F1623478700B3B902 /* olddatetime.hpp in Headers */,
@@ -1855,6 +1862,7 @@
 				5DC597341B854CBA0020D712 /* column_type_traits.hpp in Headers */,
 				48A048331C7F7A55000FFD12 /* continuous_transactions_history.hpp in Headers */,
 				C008FF7C1B67F02F0042669E /* data_type.hpp in Headers */,
+				D4AC5C2F1D5BAFD700E3D29D /* version_id.hpp in Headers */,
 				C008FF7E1B67F02F0042669E /* group.hpp in Headers */,
 				C008FF7F1B67F02F0042669E /* group_shared.hpp in Headers */,
 				C008FF801B67F02F0042669E /* group_writer.hpp in Headers */,

--- a/src/realm/group_shared.hpp
+++ b/src/realm/group_shared.hpp
@@ -35,6 +35,7 @@
 #include <realm/handover_defs.hpp>
 #include <realm/impl/transact_log.hpp>
 #include <realm/replication.hpp>
+#include <realm/version_id.hpp>
 
 namespace realm {
 
@@ -279,25 +280,7 @@ public:
     // Transactions:
 
     using version_type = _impl::History::version_type;
-
-    struct VersionID {
-        version_type version = std::numeric_limits<version_type>::max();
-        uint_fast32_t index   = 0;
-
-        VersionID() {}
-        VersionID(version_type initial_version, uint_fast32_t initial_index)
-        {
-            version = initial_version;
-            index = initial_index;
-        }
-
-        bool operator==(const VersionID& other) { return version == other.version; }
-        bool operator!=(const VersionID& other) { return version != other.version; }
-        bool operator<(const VersionID& other) { return version < other.version; }
-        bool operator<=(const VersionID& other) { return version <= other.version; }
-        bool operator>(const VersionID& other) { return version > other.version; }
-        bool operator>=(const VersionID& other) { return version >= other.version; }
-    };
+    using VersionID = realm::VersionID;
 
     /// Thrown by begin_read() if the specified version does not correspond to a
     /// bound (or tethered) snapshot.

--- a/src/realm/version_id.hpp
+++ b/src/realm/version_id.hpp
@@ -1,0 +1,49 @@
+/*************************************************************************
+ *
+ * Copyright 2016 Realm Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ **************************************************************************/
+
+#ifndef REALM_VERSION_ID_HPP
+#define REALM_VERSION_ID_HPP
+
+#include <realm/impl/continuous_transactions_history.hpp>
+
+namespace realm {
+
+using version_type = _impl::History::version_type;
+
+struct VersionID {
+    version_type version = std::numeric_limits<version_type>::max();
+    uint_fast32_t index   = 0;
+
+    VersionID() {}
+    VersionID(version_type initial_version, uint_fast32_t initial_index)
+    {
+        version = initial_version;
+        index = initial_index;
+    }
+
+    bool operator==(const VersionID& other) { return version == other.version; }
+    bool operator!=(const VersionID& other) { return version != other.version; }
+    bool operator<(const VersionID& other) { return version < other.version; }
+    bool operator<=(const VersionID& other) { return version <= other.version; }
+    bool operator>(const VersionID& other) { return version > other.version; }
+    bool operator>=(const VersionID& other) { return version >= other.version; }
+};
+
+} // namespace realm
+
+#endif // REALM_VERSION_ID_HPP


### PR DESCRIPTION
In order to avoid dragging `group_shared.hpp` and all of its dependencies into `shared_realm.hpp`, https://github.com/realm/realm-object-store/pull/116 defined its own `VersionID` type as well as some slightly gross conversions between the two types. It would be great if `VersionID` was in its own header file so this was not necessary.

Duplicated type in Object Store: https://github.com/realm/realm-object-store/pull/116/files#diff-4d344943bb20e4505258929b6f4707f3R231
