### PR TITLE
Use -fsigned-char to build

### DIFF
--- a/src/project.mk
+++ b/src/project.mk
@@ -78,6 +78,8 @@ endif
 
 ifneq ($(REALM_ANDROID),)
   PROJECT_CFLAGS += -fPIC -DPIC -fvisibility=hidden
+  # android.toolchain.cmake has `-fsigned-char` by default, we have to use the same
+  # to avoid lto linking problems.
   CFLAGS_OPTIM = -Os -flto -ffunction-sections -fdata-sections -DNDEBUG -fsigned-char
   ifeq ($(ENABLE_ENCRYPTION),yes)
     PROJECT_CFLAGS += -I../../openssl/include


### PR DESCRIPTION
This is found when compiling realm-java with cmake. The different
default sets on different targets cause linking failed with lto enabled.
