### PR TITLE
Fix a valgrind error when cloning StringNodeBase

### DIFF
--- a/src/realm/query_engine.hpp
+++ b/src/realm/query_engine.hpp
@@ -982,7 +982,7 @@ public:
 protected:
     util::Optional<std::string> m_value;
 
-    const ColumnBase* m_condition_column;
+    const ColumnBase* m_condition_column = nullptr;
     ColumnType m_column_type;
 
     // Used for linear scan through short/long-string


### PR DESCRIPTION
The copy constructor branches on m_condition_column, so it needs to be initialized for the sake of the case where it's cloned before being used.

Fixes #2039.

@finnschiermer 
