### PR TITLE
Add version_id.hpp to Makefile

### DIFF
--- a/src/realm/Makefile
+++ b/src/realm/Makefile
@@ -79,6 +79,7 @@ lang_bind_helper.hpp \
 realm_nmmintrin.h \
 importer.hpp \
 version.hpp \
+version_id.hpp \
 unicode.hpp \
 history.hpp \
 commit_log.hpp \


### PR DESCRIPTION
I forgot to do this in https://github.com/realm/realm-core/pull/2032, and it breaks using Core from Realm Cocoa.

@bdash 
