### PR TITLE
CFNetwork framework no longer needed in core context

### DIFF
--- a/src/project.mk
+++ b/src/project.mk
@@ -33,11 +33,9 @@ ifeq ($(COMPILER_IS),clang)
   CFLAGS_GENERAL += -Wextra-semi
 endif
 
-# CoreFoundation is required for Apple specific logging. CoreFoundation and
-# CFNetwork are required for Apple specific event loop
-# (realm/util/event_loop_apple.cpp).
+# CoreFoundation is required for logging
 ifeq ($(OS),Darwin)
-  PROJECT_LDFLAGS += -framework CoreFoundation -framework CFNetwork
+  PROJECT_LDFLAGS += -framework CoreFoundation
 endif
 
 # Android logging


### PR DESCRIPTION
@ironage 

Note, this is a relic from before `util/event_loop_apple_cf.cpp` was moved to the sync repo.
