### PR TITLE
Remove definition of TableView destructor

### DIFF
--- a/src/realm/table_view.hpp
+++ b/src/realm/table_view.hpp
@@ -462,7 +462,6 @@ public:
     using TableViewBase::TableViewBase;
 
     TableView() = default;
-    ~TableView() noexcept = default;
 
     // Rows
     typedef BasicRowExpr<Table> RowExpr;


### PR DESCRIPTION
Having the destructor defined, prevents the generation of at least the
move constructor and move assignment operator. This is not a problem
in released code, as the need for those functions are most probably
optimized out. In debug mode, however, we have a fundamentally different
behavior, where the copy constructors are used where we would expect move
constructor. Also the comments hints that the class is moveable.
