### PR TITLE
put back max_binary_size

### DIFF
--- a/src/realm/table.hpp
+++ b/src/realm/table.hpp
@@ -472,6 +472,7 @@ public:
     /// modifications will in general both be retained during synchronization.
 
     static const size_t max_string_size = 0xFFFFF8 - Array::header_size - 1;
+    static const size_t max_binary_size = 0xFFFFF8 - Array::header_size;
 
     void set_int(size_t column_ndx, size_t row_ndx, int_fast64_t value, bool is_default = false);
     void set_int_unique(size_t column_ndx, size_t row_ndx, int_fast64_t value);


### PR DESCRIPTION
Putting back the definition of max_binary_size
