### PR TITLE
Move the canonical definition of version_type to reduce header dependencies

### DIFF
--- a/src/realm/impl/continuous_transactions_history.hpp
+++ b/src/realm/impl/continuous_transactions_history.hpp
@@ -23,6 +23,7 @@
 #include <memory>
 
 #include <realm/column_binary.hpp>
+#include <realm/version_id.hpp>
 
 namespace realm {
 
@@ -34,7 +35,7 @@ namespace _impl {
 /// transactions.
 class History {
 public:
-    using version_type = uint_fast64_t;
+    using version_type = VersionID::version_type;
 
     /// May be called during a read transaction to gain early access to the
     /// history as it appears in a new snapshot that succeeds the one bound in

--- a/src/realm/version_id.hpp
+++ b/src/realm/version_id.hpp
@@ -19,13 +19,12 @@
 #ifndef REALM_VERSION_ID_HPP
 #define REALM_VERSION_ID_HPP
 
-#include <realm/impl/continuous_transactions_history.hpp>
+#include <limits>
 
 namespace realm {
 
-using version_type = _impl::History::version_type;
-
 struct VersionID {
+    using version_type = uint_fast64_t;
     version_type version = std::numeric_limits<version_type>::max();
     uint_fast32_t index   = 0;
 


### PR DESCRIPTION
This makes version_id.hpp depend only on <limits> rather than half of core just for a single typedef.
