### PR TITLE
Always mark link columns as nullable in the spec

### DIFF
--- a/src/realm/table.cpp
+++ b/src/realm/table.cpp
@@ -1785,7 +1785,8 @@ void Table::remove_search_index(size_t col_ndx)
 bool Table::is_nullable(size_t col_ndx) const
 {
     REALM_ASSERT_DEBUG(col_ndx < m_spec.get_column_count());
-    return (m_spec.get_column_attr(col_ndx) & col_attr_Nullable);
+    return (m_spec.get_column_attr(col_ndx) & col_attr_Nullable) ||
+        m_spec.get_column_type(col_ndx) == col_type_Link;
 }
 
 const ColumnBase& Table::get_column_base(size_t ndx) const noexcept

--- a/test/test_table.cpp
+++ b/test/test_table.cpp
@@ -6497,17 +6497,6 @@ TEST(Table_RemoveSubstring)
     }
 }
 
-
-TEST(Table_NullableLinkColumn)
-{
-    Group g;
-    TableRef t1 = g.add_table("t1");
-    t1->add_column_link(type_Link, "l", *t1);
-
-    CHECK(t1->is_nullable(0));
-}
-
-
 TEST(Table_RowAccessor_Null)
 {
     Table table;


### PR DESCRIPTION
Via Sync it was possible to create Link columns with and without the `col_attr_Nullable` flag set in the Spec. Link columns, however, must always be nullable (and have always been nullable). This makes sure that link columns always have the `col_attr_Nullable` flag set in the Spec.

/cc @ironage @finnschiermer 
