### PR TITLE
SwapRows + MLO hits an assert when updating backlinks

### DIFF
--- a/test/test_table.cpp
+++ b/test/test_table.cpp
@@ -6497,6 +6497,25 @@ TEST(Table_RemoveSubstring)
     }
 }
 
+
+TEST(Table_SwapRowsThenMoveLastOverWithBacklinks)
+{
+    Group g;
+    TableRef t1 = g.add_table("t1");
+    TableRef t2 = g.add_table("t2");
+    t1->add_column(type_Int, "i");
+    t2->add_column_link(type_Link, "l", *t1);
+
+    t1->add_empty_row(2);
+    t2->add_empty_row(2);
+
+    t2->set_link(0, 0, 0);
+    t2->set_link(0, 1, 1);
+    t2->swap_rows(0, 1);
+    t2->move_last_over(0);
+}
+
+
 TEST(Table_RowAccessor_Null)
 {
     Table table;


### PR DESCRIPTION
I probably introduced this bug myself back in October 2015, but it has only been hit now in connection with Sync.

I'm unsure how to approach fixing the bug. @ironage, are you able to help me?

The unit test in this PR should assert immediately. There probably is a problem with the handling of the the swap_rows in ColumnBacklink. 

This is the assertion:

```
column_backlink.cpp:109: [realm-core-2.0.0] Assertion failed: to_size_t(value >> 1) == origin_row_ndx [1, 0]
```
