### PR TITLE
Add back log level prefixes ('ERROR: ', ...)

### DIFF
--- a/src/realm/Makefile
+++ b/src/realm/Makefile
@@ -125,6 +125,7 @@ DEV_PROGRAMS     = realm-config
 
 librealm_a_SOURCES = \
 util/encrypted_file_mapping.cpp \
+util/logger.hpp \
 util/misc_errors.cpp \
 util/basic_system_errors.cpp \
 util/file.cpp \

--- a/src/realm/util/logger.cpp
+++ b/src/realm/util/logger.cpp
@@ -1,0 +1,40 @@
+/*************************************************************************
+ *
+ * Copyright 2016 Realm Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ **************************************************************************/
+
+#include <realm/util/logger.hpp>
+
+const char* realm::util::Logger::get_level_prefix(Level level) noexcept
+{
+    switch (level) {
+        case Level::all:
+        case Level::trace:
+        case Level::debug:
+        case Level::detail:
+        case Level::info:
+            break;
+        case Level::warn:
+            return "WARNING: ";
+        case Level::error:
+            return "ERROR: ";
+        case Level::fatal:
+            return "FATAL: ";
+        case Level::off:
+            break;
+    }
+    return "";
+}

--- a/src/realm/util/logger.hpp
+++ b/src/realm/util/logger.hpp
@@ -93,6 +93,8 @@ protected:
 
     virtual void do_log(Level, std::string message) = 0;
 
+    static const char* get_level_prefix(Level) noexcept;
+
 private:
     struct State;
     template<class> struct Subst;
@@ -429,9 +431,9 @@ inline Logger::Level RootLogger::get() const noexcept
     return m_level_threshold;
 }
 
-inline void StderrLogger::do_log(Level, std::string message)
+inline void StderrLogger::do_log(Level level, std::string message)
 {
-    std::cerr << message << '\n'; // Throws
+    std::cerr << get_level_prefix(level) << message << '\n'; // Throws
     std::cerr.flush(); // Throws
 }
 
@@ -440,9 +442,9 @@ inline StreamLogger::StreamLogger(std::ostream& out) noexcept:
 {
 }
 
-inline void StreamLogger::do_log(Level, std::string message)
+inline void StreamLogger::do_log(Level level, std::string message)
 {
-    m_out << message << '\n'; // Throws
+    m_out << get_level_prefix(level) << message << '\n'; // Throws
     m_out.flush(); // Throws
 }
 


### PR DESCRIPTION
 Add back log level prefixes ('ERROR: ', ...) after they were removed recently from the logging sites.

@alebsack @radu-tutueanu 
