### PR TITLE
Specify the CC environment variable rather than CXX when building for Apple platforms

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -311,7 +311,7 @@ build_apple()
             fi
         fi
         tag="$sdk$platform_suffix"
-        CXX="xcrun -sdk $sdk c++" $MAKE -C "src/realm" "librealm-$tag.a" "librealm-$tag-dbg.a" BASE_DENOM="$tag" CFLAGS_ARCH="$cflags_arch" COMPILER_IS_GCC_LIKE=YES || exit 1
+        CC="xcrun -sdk $sdk clang" $MAKE -C "src/realm" "librealm-$tag.a" "librealm-$tag-dbg.a" BASE_DENOM="$tag" CFLAGS_ARCH="$cflags_arch" COMPILER_IS_GCC_LIKE=YES || exit 1
         mkdir "$temp_dir/platforms/$tag" || exit 1
         cp "src/realm/librealm-$tag.a"     "$temp_dir/platforms/$tag/librealm.a"     || exit 1
         cp "src/realm/librealm-$tag-dbg.a" "$temp_dir/platforms/$tag/librealm-dbg.a" || exit 1


### PR DESCRIPTION
`CC` is used as the value for the C++, Objective-C and Objective-C++ compilers if specified, while `CXX` is only used for C++. This was resulting in C, Objecive-C and Objective-C++ code building with  the wrong SDK when building using `build-cocoa` and the subcommands that it delegates to.
