### PR TITLE
Copied Jenkinsfile from master

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -538,7 +538,7 @@ def doPublishGeneric() {
         unstash "packages-generic"
       }
       dir("core/v${version}/linux") {
-        sh "mv ${topdir}/packaging/out/generic/realm-core-${version}.tgz realm-core-${version}.tgz"
+        sh "mv ${topdir}/packaging/out/generic/realm-core-*.tgz ./"
       }
 
       step([


### PR DESCRIPTION
Will resolve any issues in another commit to keep a clean(er) history.

**Update:** The `Jenkinsfile` was first copied from `master`. Then 3 commits, that were originally only on the `next-major` branch, was cherry-picked back unto this PR.

Fixes #2111 
