### PR TITLE
Add getSourceArchive again 

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -502,7 +502,7 @@ def getDeviceNames(String commandOutput) {
 def doBuildPackage(distribution, fileType) {
   return {
     node('docker') {
-      getArchive()
+      getSourceArchive()
 
       withCredentials([[$class: 'StringBinding', credentialsId: 'packagecloud-sync-devel-master-token', variable: 'PACKAGECLOUD_MASTER_TOKEN']]) {
         sh "sh packaging/package.sh ${distribution}"
@@ -519,7 +519,7 @@ def doBuildPackage(distribution, fileType) {
 def doPublish(distribution, fileType, distroName, distroVersion) {
   return {
     node {
-      getArchive()
+      getSourceArchive()
       packaging = load './packaging/publish.groovy'
 
       dir('packaging/out') {
@@ -535,7 +535,7 @@ def doPublish(distribution, fileType, distroName, distroVersion) {
 def doPublishGeneric() {
   return {
     node {
-      getArchive()
+      getSourceArchive()
       def version = get_version()
       def topdir = pwd()
       dir('packaging/out') {
@@ -576,4 +576,10 @@ def getArchive() {
     sh 'rm -rf *'
     unstash 'core-source'
     sh 'unzip -o -q core.zip'
+}
+
+def getSourceArchive() {
+  checkout scm
+  sh 'git clean -ffdx -e .????????'
+  sh 'git submodule update --init'
 }


### PR DESCRIPTION
@emanuelez @alebsack 

These jobs assume they are running in a git repository. We should probably change the way we do things, but this should be a fast fix.
