### PR TITLE
Insert an exit in openssl/config

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -240,6 +240,10 @@ download_openssl()
     # dependencies due to being written in asm
     sed '/OPENSSL_cleanse/d' 'openssl/crypto/sha/sha256.c' > sha_tmp
     mv sha_tmp 'openssl/crypto/sha/sha256.c'
+
+    # openssl/config won't report failure which cause the script silently using the previous lib instead which is wrong.
+    # Insert an exit to the config script to make sure the build stops when fails.
+    sed -i '/echo \"This system (\$OUT) is not supported\. See file INSTALL for details\.\"/a \ \ exit 1' openssl/config || exit 1
 }
 
 # Setup OS specific stuff


### PR DESCRIPTION
When config fails, the build will continue silently and use the previous
target results which is wrong.

We always have a problem that the openssl for armeabi-v7a, it fails
during the config stage. But instead of stop building, it will just use
the armeabi library which was just built previously.

Investigation of openssl armeabi-v7a build failure is needed.
Simply change the checking in openssl/config from armv[7-9]_-_-android
to arm-v[7-9]_-_-android could make it compile, but failure happens in
the final link stage.
