### PR TITLE
Use composition rather than inheritance

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -262,7 +262,9 @@
   indexes into the Table in all cases. Also, any `begin` and `end` arguments could point into 
   eitherthe View or the Table. These now always point into the Table. Also see 
   https://github.com/realm/realm-core/issues/1565
-
+* Moved get_uncommitted_changes from History class to Replication class. This removes the
+  need to call TrivialReplication::get_uncommitted_changes from a decendant of History.
+  
 ### Enhancements
 
 * Accessors pointing to subsumed rows are updated to the new row rather than detached.

--- a/src/realm/array.hpp
+++ b/src/realm/array.hpp
@@ -168,6 +168,32 @@ protected:
     friend class Array;
 };
 
+template <class T>
+class SimpleParent : public ArrayParent {
+public:
+    SimpleParent(T& t)
+        : m_target(t)
+    {
+    }
+
+    void update_child_ref(size_t child_ndx, ref_type new_ref) override
+    {
+        m_target.set(child_ndx, new_ref); // Throws
+    }
+    ref_type get_child_ref(size_t child_ndx) const noexcept override
+    {
+        return m_target.get_as_ref(child_ndx);
+    }
+
+    std::pair<ref_type, size_t> get_to_dot_parent(size_t ndx_in_parent) const override
+    {
+        return m_target.get_to_dot_parent(ndx_in_parent);
+    }
+
+private:
+    T& m_target;
+};
+
 struct TreeInsertBase {
     size_t m_split_offset;
     size_t m_split_size;

--- a/src/realm/column.hpp
+++ b/src/realm/column.hpp
@@ -696,6 +696,7 @@ public:
     void verify() const override;
     void to_dot(std::ostream&, StringData title) const override;
     void do_dump_node_structure(std::ostream&, int) const override;
+    std::pair<ref_type, size_t> get_to_dot_parent(size_t ndx_in_parent) const;
 #ifdef REALM_DEBUG
     using ColumnBase::verify;
     void tree_to_dot(std::ostream&) const;
@@ -744,7 +745,6 @@ protected:
 #ifdef REALM_DEBUG
     static void dump_node_structure(const Array& root, std::ostream&, int level);
 #endif
-    std::pair<ref_type, size_t> get_to_dot_parent(size_t ndx_in_parent) const;
 
 private:
     class EraseLeafElem;

--- a/src/realm/column_backlink.hpp
+++ b/src/realm/column_backlink.hpp
@@ -34,7 +34,7 @@ namespace realm {
 /// The individual values in the column are either refs to Columns containing
 /// the row indexes in the origin table that links to it, or in the case where
 /// there is a single link, a tagged ref encoding the origin row position.
-class BacklinkColumn : public IntegerColumn, public ArrayParent {
+class BacklinkColumn : public IntegerColumn {
 public:
     BacklinkColumn(Allocator&, ref_type, size_t col_ndx = npos);
     ~BacklinkColumn() noexcept override
@@ -90,13 +90,6 @@ public:
     };
     void get_backlinks(std::vector<VerifyPair>&); // Sorts
 #endif
-
-protected:
-    // ArrayParent overrides
-    void update_child_ref(size_t child_ndx, ref_type new_ref) override;
-    ref_type get_child_ref(size_t child_ndx) const noexcept override;
-
-    std::pair<ref_type, size_t> get_to_dot_parent(size_t) const override;
 
 private:
     TableRef m_origin_table;

--- a/src/realm/column_linklist.cpp
+++ b/src/realm/column_linklist.cpp
@@ -389,18 +389,6 @@ LinkViewRef LinkListColumn::get_ptr(size_t row_ndx) const
     return create_view(*it);
 }
 
-void LinkListColumn::update_child_ref(size_t child_ndx, ref_type new_ref)
-{
-    LinkColumnBase::set(child_ndx, new_ref);
-}
-
-
-ref_type LinkListColumn::get_child_ref(size_t child_ndx) const noexcept
-{
-    return LinkColumnBase::get_as_ref(child_ndx);
-}
-
-
 void LinkListColumn::to_json_row(size_t row_ndx, std::ostream& out) const
 {
     LinkViewRef links1 = const_cast<LinkListColumn*>(this)->get(row_ndx);
@@ -783,12 +771,6 @@ void LinkListColumn::verify(const Table& table, size_t col_ndx) const
     static_cast<void>(table);
     static_cast<void>(col_ndx);
 #endif
-}
-
-
-std::pair<ref_type, size_t> LinkListColumn::get_to_dot_parent(size_t ndx_in_parent) const
-{
-    return IntegerColumn::get_to_dot_parent(ndx_in_parent);
 }
 
 // LCOV_EXCL_STOP ignore debug functions

--- a/src/realm/column_linklist.hpp
+++ b/src/realm/column_linklist.hpp
@@ -42,7 +42,7 @@ class TransactLogConvenientEncoder;
 /// The individual values in the column are either refs to Columns containing the
 /// row positions in the target table, or in the case where they are empty, a zero
 /// ref.
-class LinkListColumn : public LinkColumnBase, public ArrayParent {
+class LinkListColumn : public LinkColumnBase {
 public:
     using LinkColumnBase::LinkColumnBase;
     LinkListColumn(Allocator& alloc, ref_type ref, Table* table, size_t column_ndx);
@@ -120,10 +120,6 @@ private:
     void add_backlink(size_t target_row, size_t source_row);
     void remove_backlink(size_t target_row, size_t source_row);
 
-    // ArrayParent overrides
-    void update_child_ref(size_t child_ndx, ref_type new_ref) override;
-    ref_type get_child_ref(size_t child_ndx) const noexcept override;
-
     // These helpers are needed because of the way the B+-tree of links is
     // traversed in cascade_break_backlinks_to() and
     // cascade_break_backlinks_to_all_rows().
@@ -146,8 +142,6 @@ private:
 
     void prune_list_accessor_tombstones() noexcept;
     void validate_list_accessors() const noexcept;
-
-    std::pair<ref_type, size_t> get_to_dot_parent(size_t) const override;
 
     friend class BacklinkColumn;
     friend class LinkView;

--- a/src/realm/history.cpp
+++ b/src/realm/history.cpp
@@ -27,7 +27,7 @@ using namespace realm;
 
 namespace {
 
-class InRealmHistoryImpl : public TrivialReplication, private _impl::InRealmHistory {
+class InRealmHistoryImpl : public TrivialReplication {
 public:
     using version_type = TrivialReplication::version_type;
 
@@ -40,7 +40,7 @@ public:
     {
         TrivialReplication::initialize(sg); // Throws
         using sgf = _impl::SharedGroupFriend;
-        _impl::InRealmHistory::initialize(sgf::get_group(sg)); // Throws
+        m_history.initialize(sgf::get_group(sg)); // Throws
     }
 
     void initiate_session(version_type) override
@@ -56,9 +56,9 @@ public:
     version_type prepare_changeset(const char* data, size_t size, version_type orig_version) override
     {
         if (!is_history_updated())
-            update_from_parent(orig_version); // Throws
+            m_history.update_from_parent(orig_version); // Throws
         BinaryData changeset(data, size);
-        version_type new_version = add_changeset(changeset); // Throws
+        version_type new_version = m_history.add_changeset(changeset); // Throws
         return new_version;
     }
 
@@ -75,13 +75,10 @@ public:
 
     _impl::History* get_history() override
     {
-        return this;
+        return &m_history;
     }
-
-    BinaryData get_uncommitted_changes() noexcept override
-    {
-        return TrivialReplication::get_uncommitted_changes();
-    }
+private:
+    _impl::InRealmHistory m_history;
 };
 
 } // unnamed namespace

--- a/src/realm/impl/continuous_transactions_history.hpp
+++ b/src/realm/impl/continuous_transactions_history.hpp
@@ -128,18 +128,6 @@ public:
     /// of histories are stored inside the Realm file.
     virtual void set_oldest_bound_version(version_type version) = 0;
 
-    /// Get the list of uncommited changes accumulated so far in the current
-    /// write transaction.
-    ///
-    /// The callee retains ownership of the referenced memory. The ownership is
-    /// not handed over the the caller.
-    ///
-    /// This function may be called only during a write transaction (prior to
-    /// initiation of commit operation). In that case, the caller may assume that the
-    /// returned memory reference stays valid for the remainder of the transaction (up
-    /// until initiation of the commit operation).
-    virtual BinaryData get_uncommitted_changes() noexcept = 0;
-
     virtual void verify() const = 0;
 
     virtual ~History() noexcept

--- a/src/realm/impl/transact_log.hpp
+++ b/src/realm/impl/transact_log.hpp
@@ -653,21 +653,21 @@ public:
 
 inline void TransactLogBufferStream::transact_log_reserve(size_t n, char** inout_new_begin, char** out_new_end)
 {
-    char* data = m_buffer.data();
-    REALM_ASSERT(*inout_new_begin >= data);
-    REALM_ASSERT(*inout_new_begin <= (data + m_buffer.size()));
-    size_t size = *inout_new_begin - data;
-    m_buffer.reserve_extra(size, n);
-    data = m_buffer.data(); // May have changed
-    *inout_new_begin = data + size;
-    *out_new_end = data + m_buffer.size();
+    char* buf = m_buffer.data();
+    REALM_ASSERT(*inout_new_begin >= buf);
+    REALM_ASSERT(*inout_new_begin <= (buf + m_buffer.size()));
+    size_t sz = *inout_new_begin - buf;
+    m_buffer.reserve_extra(sz, n);
+    buf = m_buffer.data(); // May have changed
+    *inout_new_begin = buf + sz;
+    *out_new_end = buf + m_buffer.size();
 }
 
-inline void TransactLogBufferStream::transact_log_append(const char* data, size_t size, char** out_new_begin,
+inline void TransactLogBufferStream::transact_log_append(const char* buf, size_t sz, char** out_new_begin,
                                                          char** out_new_end)
 {
-    transact_log_reserve(size, out_new_begin, out_new_end);
-    *out_new_begin = std::copy(data, data + size, *out_new_begin);
+    transact_log_reserve(sz, out_new_begin, out_new_end);
+    *out_new_begin = std::copy(buf, buf + sz, *out_new_begin);
 }
 
 inline TransactLogEncoder::TransactLogEncoder(TransactLogStream& stream)

--- a/src/realm/impl/transact_log.hpp
+++ b/src/realm/impl/transact_log.hpp
@@ -86,14 +86,20 @@ enum Instruction {
 
 class TransactLogStream {
 public:
+    virtual ~TransactLogStream()
+    {
+    }
+
     /// Ensure contiguous free space in the transaction log
     /// buffer. This method must update `out_free_begin`
     /// and `out_free_end` such that they refer to a chunk
     /// of free space whose size is at least \a n.
     ///
-    /// \param n The required amount of contiguous free space. Must be
+    /// \param size The required amount of contiguous free space. Must be
     /// small (probably not greater than 1024)
-    /// \param n Must be small (probably not greater than 1024)
+    /// \param out_free_begin must point to current write position which must be inside earlier
+    /// allocated area. Will be updated to point to new writing position.
+    /// \param out_free_end Will be updated to point to end of allocated area.
     virtual void transact_log_reserve(size_t size, char** out_free_begin, char** out_free_end) = 0;
 
     /// Copy the specified data into the transaction log buffer. This
@@ -112,8 +118,22 @@ public:
     void transact_log_reserve(size_t size, char** out_free_begin, char** out_free_end) override;
     void transact_log_append(const char* data, size_t size, char** out_free_begin, char** out_free_end) override;
 
-    const char* transact_log_data() const;
+    const char* data() const
+    {
+        return m_buffer.data();
+    }
 
+    char* data()
+    {
+        return m_buffer.data();
+    }
+
+    size_t size()
+    {
+        return m_buffer.size();
+    }
+
+private:
     util::Buffer<char> m_buffer;
 };
 
@@ -648,11 +668,6 @@ inline void TransactLogBufferStream::transact_log_append(const char* data, size_
 {
     transact_log_reserve(size, out_new_begin, out_new_end);
     *out_new_begin = std::copy(data, data + size, *out_new_begin);
-}
-
-inline const char* TransactLogBufferStream::transact_log_data() const
-{
-    return m_buffer.data();
 }
 
 inline TransactLogEncoder::TransactLogEncoder(TransactLogStream& stream)
@@ -2694,8 +2709,8 @@ private:
 
     size_t transact_log_size() const
     {
-        REALM_ASSERT_3(m_encoder.write_position(), >=, m_buffer.transact_log_data());
-        return m_encoder.write_position() - m_buffer.transact_log_data();
+        REALM_ASSERT_3(m_encoder.write_position(), >=, m_buffer.data());
+        return m_encoder.write_position() - m_buffer.data();
     }
 
     void append_instruction()
@@ -2745,7 +2760,7 @@ public:
         // push any pending select_table or select_descriptor into the buffer
         reverser.sync_table();
 
-        m_buffer = reverser.m_buffer.transact_log_data();
+        m_buffer = reverser.m_buffer.data();
         m_current = m_instr_order.size();
     }
 

--- a/src/realm/link_view.hpp
+++ b/src/realm/link_view.hpp
@@ -122,6 +122,7 @@ private:
 
     TableRef m_origin_table;
     LinkListColumn& m_origin_column;
+    SimpleParent<LinkListColumn> m_bridge;
 
     using HandoverPatch = LinkViewHandoverPatch;
     static void generate_patch(const ConstLinkViewRef& ref, std::unique_ptr<HandoverPatch>& patch);
@@ -173,8 +174,9 @@ inline LinkView::LinkView(const ctor_cookie&, Table* origin_table, LinkListColum
     : RowIndexes(IntegerColumn::unattached_root_tag(), column.get_alloc()) // Throws
     , m_origin_table(origin_table->get_table_ref())
     , m_origin_column(column)
+    , m_bridge(column)
 {
-    m_row_indexes.set_parent(&m_origin_column, row_ndx);
+    m_row_indexes.set_parent(&m_bridge, row_ndx);
     m_row_indexes.init_from_parent();
 }
 

--- a/src/realm/replication.cpp
+++ b/src/realm/replication.cpp
@@ -839,15 +839,15 @@ void TrivialReplication::initialize(SharedGroup&)
 
 void TrivialReplication::do_initiate_transact(version_type, bool history_updated)
 {
-    char* data = m_transact_log_buffer.data();
-    size_t size = m_transact_log_buffer.size();
+    char* data = m_stream.data();
+    size_t size = m_stream.size();
     set_buffer(data, data + size);
     m_history_updated = history_updated;
 }
 
 Replication::version_type TrivialReplication::do_prepare_commit(version_type orig_version)
 {
-    char* data = m_transact_log_buffer.data();
+    char* data = m_stream.data();
     size_t size = write_position() - data;
     version_type new_version = prepare_changeset(data, size, orig_version); // Throws
     return new_version;
@@ -868,10 +868,4 @@ void TrivialReplication::do_interrupt() noexcept
 
 void TrivialReplication::do_clear_interrupt() noexcept
 {
-}
-
-void TrivialReplication::transact_log_append(const char* data, size_t size, char** new_begin, char** new_end)
-{
-    internal_transact_log_reserve(size, new_begin, new_end);
-    *new_begin = std::copy(data, data + size, *new_begin);
 }

--- a/src/realm/replication.hpp
+++ b/src/realm/replication.hpp
@@ -50,7 +50,7 @@ class Logger;
 
 /// Replication is enabled by passing an instance of an implementation of this
 /// class to the SharedGroup constructor.
-class Replication : public _impl::TransactLogConvenientEncoder, protected _impl::TransactLogStream {
+class Replication : public _impl::TransactLogConvenientEncoder {
 public:
     // Be sure to keep this type aligned with what is actually used in
     // SharedGroup.
@@ -383,7 +383,10 @@ public:
     }
 
 protected:
-    Replication();
+    Replication(_impl::TransactLogStream& stream)
+        : _impl::TransactLogConvenientEncoder(stream)
+    {
+    }
 
 
     //@{
@@ -435,7 +438,11 @@ public:
 protected:
     typedef Replication::version_type version_type;
 
-    TrivialReplication(const std::string& database_file);
+    TrivialReplication(const std::string& database_file)
+        : Replication(m_stream)
+        , m_database_file(database_file)
+    {
+    }
 
     virtual version_type prepare_changeset(const char* data, size_t size, version_type orig_version) = 0;
     virtual void finalize_changeset() noexcept = 0;
@@ -454,25 +461,17 @@ protected:
     void do_abort_transact() noexcept override;
     void do_interrupt() noexcept override;
     void do_clear_interrupt() noexcept override;
-    void transact_log_reserve(size_t n, char** new_begin, char** new_end) override;
-    void transact_log_append(const char* data, size_t size, char** new_begin, char** new_end) override;
 
 private:
     const std::string m_database_file;
-    util::Buffer<char> m_transact_log_buffer;
-    bool m_history_updated;
-    void internal_transact_log_reserve(size_t, char** new_begin, char** new_end);
+    bool m_history_updated = false;
+    _impl::TransactLogBufferStream m_stream;
 
     size_t transact_log_size();
 };
 
 
 // Implementation:
-
-inline Replication::Replication()
-    : _impl::TransactLogConvenientEncoder(static_cast<_impl::TransactLogStream&>(*this))
-{
-}
 
 inline void Replication::initiate_transact(version_type current_version, bool history_updated)
 {
@@ -510,11 +509,6 @@ inline bool Replication::is_sync_agent() const noexcept
     return false;
 }
 
-inline TrivialReplication::TrivialReplication(const std::string& database_file)
-    : m_database_file(database_file)
-{
-}
-
 inline bool TrivialReplication::is_history_updated() const noexcept
 {
     return m_history_updated;
@@ -522,29 +516,14 @@ inline bool TrivialReplication::is_history_updated() const noexcept
 
 inline BinaryData TrivialReplication::get_uncommitted_changes() const noexcept
 {
-    const char* data = m_transact_log_buffer.data();
+    const char* data = m_stream.data();
     size_t size = write_position() - data;
     return BinaryData(data, size);
 }
 
 inline size_t TrivialReplication::transact_log_size()
 {
-    return write_position() - m_transact_log_buffer.data();
-}
-
-inline void TrivialReplication::transact_log_reserve(size_t n, char** new_begin, char** new_end)
-{
-    internal_transact_log_reserve(n, new_begin, new_end);
-}
-
-inline void TrivialReplication::internal_transact_log_reserve(size_t n, char** new_begin, char** new_end)
-{
-    char* data = m_transact_log_buffer.data();
-    size_t size = write_position() - data;
-    m_transact_log_buffer.reserve_extra(size, n);
-    data = m_transact_log_buffer.data(); // May have changed
-    *new_begin = data + size;
-    *new_end = data + m_transact_log_buffer.size();
+    return write_position() - m_stream.data();
 }
 
 } // namespace realm

--- a/src/realm/replication.hpp
+++ b/src/realm/replication.hpp
@@ -181,6 +181,18 @@ public:
 
     //@}
 
+    /// Get the list of uncommited changes accumulated so far in the current
+    /// write transaction.
+    ///
+    /// The callee retains ownership of the referenced memory. The ownership is
+    /// not handed over the the caller.
+    ///
+    /// This function may be called only during a write transaction (prior to
+    /// initiation of commit operation). In that case, the caller may assume that the
+    /// returned memory reference stays valid for the remainder of the transaction (up
+    /// until initiation of the commit operation).
+    virtual BinaryData get_uncommitted_changes() const noexcept = 0;
+
 
     /// Interrupt any blocking call to a function in this class. This function
     /// may be called asyncronously from any thread, but it may not be called

--- a/src/realm/replication.hpp
+++ b/src/realm/replication.hpp
@@ -451,7 +451,7 @@ protected:
 
     bool is_history_updated() const noexcept;
 
-    BinaryData get_uncommitted_changes() const noexcept;
+    BinaryData get_uncommitted_changes() const noexcept override;
 
     std::string get_database_path() override;
     void initialize(SharedGroup&) override;

--- a/test/test_lang_bind_helper.cpp
+++ b/test/test_lang_bind_helper.cpp
@@ -219,12 +219,6 @@ public:
         // No-op
     }
 
-    BinaryData get_uncommitted_changes() noexcept override
-    {
-        REALM_ASSERT(false);
-        return BinaryData(); // FIXME: Not yet implemented
-    }
-
     void verify() const override
     {
         // No-op


### PR DESCRIPTION
Thus pull request converts a few inheritance relations to containment relations. The code gets easier to read when you use objects of other classes instead of just 'being' those classes.

This PR will need `get_uncommitted_changes()` to be removed from `HistoryImpl` in Sync.

@finnschiermer @ironage