### PR TITLE
fixed a (benign) race related to row management

### DIFF
--- a/release_notes.md
+++ b/release_notes.md
@@ -44,7 +44,9 @@
   debugging. Also, the terminate handler (in `util/terminate.cpp`) writes out
   the name of the terminating thread if the name is available.
 * Fixed doxygen warnings.
-
+* Removed ("deleted") the default copy constructor for RowBase. This constructor
+  was used by accident by derived classes, which led to a data race. Said race was
+  benign, but would be reported by the thread sanitizer.
 ----------------------------------------------
 
 # 1.5.1 Release notes

--- a/src/realm/row.hpp
+++ b/src/realm/row.hpp
@@ -232,6 +232,7 @@ protected:
     {
     }
 
+    RowBase(const RowBase&) = delete;
     using HandoverPatch = RowBaseHandoverPatch;
 
     RowBase(const RowBase& source, HandoverPatch& patch);
@@ -740,7 +741,7 @@ inline BasicRow<T>::BasicRow() noexcept
 
 template <class T>
 inline BasicRow<T>::BasicRow(const BasicRow<T>& row) noexcept
-    : RowBase(row)
+    : RowBase()
 {
     attach(const_cast<Table*>(row.m_table.get()), row.m_row_ndx);
 }


### PR DESCRIPTION
This PR fixes a (benign) race exposed by Row copying.

When copying a BasicRow we inadvertently used the default copy constructor generated for the base class RowBase. The default copy constructor would faithfully copy all member variables including the m_next and m_prev pointers which are part of the Row accessor chain. The copied pointers would never be used, but immediately overwritten. However, reading the pointers from the source object for copying was not interlocked with other management of the accessor chain and thus constituted a race.

The race was reported by the thread sanitizer, but it could not have caused a bug to end users.

This PR fixes the bug by deleting the copy constructor for RowBase and handling all the setup in the copy constructor for BasicRow.
