### PR TITLE
Mark getDeviceNames method as NonCPS

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -494,12 +494,12 @@ def get_version() {
   }
 }
 
-@NonCPS
 def getDeviceNames(String commandOutput) {
   def deviceNames = []
-  for (line in commandOutput.split('\n')) {
-    if (line.contains('\t')) {
-      deviceNames << line.split('\t')[0].trim()
+  def lines = commandOutput.split('\n')
+  for (i = 0; i < lines.size(); ++i) {
+    if (lines[i].contains('\t')) {
+      deviceNames << lines[i].split('\t')[0].trim()
     }
   }
   return deviceNames


### PR DESCRIPTION
@alebsack @emanuelez 

This solves the issue with  `java.io.NotSerializableException: java.util.AbstractList$Itr` here https://ci.realm.io/job/realm/job/realm-core/job/next-major/56/console.

Though I do not know what changed and made this fail.
