### PR TITLE
Move release notes

### DIFF
--- a/release_notes.md
+++ b/release_notes.md
@@ -7,7 +7,12 @@
 ### Breaking changes
 
 * Changed the format of the StringIndex structure to not recursivly store
-  strings past a certain depth. This is a file format breaking change. (#2153)
+  strings past a certain depth. This fixes crashes when storing strings
+  with a long common prefix in an index. This is a file format breaking change.
+  The file format has been incremented and old Realm files must upgrade.
+  The upgrade will rebuild any StringIndexes to the new format automatically
+  so other than the upgrade, this change should be effectivly invisible to
+  the bindings. (see #2153)
 
 ### Enhancements
 


### PR DESCRIPTION
These notes were merged silently into the incorrect section. Github will show no conflicts because the surrounding text is identical, but we have made a new release since adding the release notes.

@radu-tutueanu @jedelbo 
