### PR TITLE
Add pre-commit hook to prevent ill-formatted commits

### DIFF
--- a/tools/pre-commit
+++ b/tools/pre-commit
@@ -1,0 +1,15 @@
+#!/bin/bash
+
+# This pre-commit hook prevents us from creating commits that contains ill-formatted files
+
+VIOLATING_FILES=$(git clang-format --diff | grep "\-\-\- a/" | sed 's!\-\-\- a/!!')
+
+if [ "${VIOLATING_FILES}" ]; then
+  echo "Commit violates formatting rules"
+  echo "Offending files:"
+	for i in ${VIOLATING_FILES}; do
+	  echo "   " $i
+  done
+  echo "run 'git clang-format'"
+  exit 1
+fi


### PR DESCRIPTION
The hook is not yet forced into the git configuration.

You can copy the hook into .git/hooks yourself. It uses `git clang-format` command, so you might want to check that this command works before installing the hook.

Unfortunately the hook checks the workarea files and not the staged files, so it is in principle still possible to create a commit with ill-formed files, if you have correctly formatted files that are not yet added.

@danielpovlsen 
