### PR TITLE
Use C++11's non-deterministic random number generator

### DIFF
--- a/test/test_all.cpp
+++ b/test/test_all.cpp
@@ -65,7 +65,7 @@ using namespace realm::test_util;
 using namespace realm::test_util::unit_test;
 
 // Random seed for various random number generators used by fuzzying unit tests.
-unsigned long unit_test_random_seed;
+unsigned int unit_test_random_seed;
 
 namespace {
 

--- a/test/test_shared.cpp
+++ b/test/test_shared.cpp
@@ -51,7 +51,7 @@
 
 #include "test.hpp"
 
-extern unsigned long unit_test_random_seed;
+extern unsigned int unit_test_random_seed;
 
 using namespace realm;
 using namespace realm::util;

--- a/test/util/random.cpp
+++ b/test/util/random.cpp
@@ -23,7 +23,7 @@ namespace realm {
 namespace test_util {
 
 
-unsigned long produce_nondeterministic_random_seed()
+unsigned int produce_nondeterministic_random_seed()
 {
     std::random_device rd;
     return rd();

--- a/test/util/random.cpp
+++ b/test/util/random.cpp
@@ -16,15 +16,6 @@
  *
  **************************************************************************/
 
-#include <ctime>
-
-#ifdef _WIN32
-#define NOMINMAX
-#include <windows.h>
-#else
-#include <unistd.h>
-#endif
-
 #include "random.hpp"
 
 
@@ -34,16 +25,8 @@ namespace test_util {
 
 unsigned long produce_nondeterministic_random_seed()
 {
-    typedef unsigned long ulong;
-    ulong value = ulong(time(nullptr));
-
-#ifdef _WIN32
-    value ^= ulong(GetCurrentProcessId());
-#else
-    value ^= ulong(getpid());
-#endif
-
-    return value;
+    std::random_device rd;
+    return rd();
 }
 
 

--- a/test/util/random.hpp
+++ b/test/util/random.hpp
@@ -61,7 +61,7 @@ void random_seed(unsigned long) noexcept;
 /// pseudorandom number genrator.
 ///
 /// This function is thread safe.
-unsigned long produce_nondeterministic_random_seed();
+unsigned int produce_nondeterministic_random_seed();
 
 
 /// Simple pseudorandom number generator.


### PR DESCRIPTION
Use C++11's non-deterministic random number generator, `std::random_device` in place of our own `time() ^ getpid()` solution.

Also fixes warnings in Visual Studio re. redefinition of `NOMINMAX`.

@rrrlasse @ironage 

( other fixes extracted into separate issue #2210 )