### PR TITLE
Updating unit test StringIndex_Fuzzy

### DIFF
--- a/test/test_index_string.cpp
+++ b/test/test_index_string.cpp
@@ -1637,7 +1637,7 @@ TEST(StringIndex_Fuzzy)
     constexpr size_t chunkcount = 50;
     constexpr size_t rowcount = 100 + 1000 * TEST_DURATION;
 
-    for (size_t main_rounds = 0; main_rounds < 1 + 10 * TEST_DURATION; main_rounds++) {
+    for (size_t main_rounds = 0; main_rounds < 2 + 10 * TEST_DURATION; main_rounds++) {
 
         Group g;
 
@@ -1688,14 +1688,40 @@ TEST(StringIndex_Fuzzy)
                 }
             }
 
+
+            for (size_t r = 0; r < 5 + 1000 * TEST_DURATION; r++) {
+                size_t chunks;
+                if (fastrand() % 2 == 0)
+                    chunks = fastrand() % 4;
+                else
+                    chunks = 2;
+
+                std::string str;
+
+                for (size_t c = 0; c < chunks; c++) {
+                    str += strings[fastrand() % chunkcount];
+                }
+
+                TableView tv0 = (t->column<String>(0) == str).find_all();
+                TableView tv1 = (t->column<String>(1) == str).find_all();
+
+                CHECK_EQUAL(tv0.size(), tv1.size());
+
+                for (size_t v = 0; v < tv0.size(); v++) {
+                    CHECK_EQUAL(tv0.get_source_ndx(v), tv1.get_source_ndx(v));
+                }
+            }
             if (t->size() > 10)
                 t->remove(0);
 
             size_t r1 = fastrand() % t->size();
             size_t r2 = fastrand() % t->size();
 
-            t->set_string(0, r1, t->get_string(0, r2));
-            t->set_string(1, r1, t->get_string(1, r2));
+            std::string str1 = t->get_string(0, r2);
+            std::string str2 = t->get_string(0, r2);
+
+            t->set_string(0, r1, StringData(str1));
+            t->set_string(1, r1, StringData(str2));
 
             r1 = fastrand() % t->size();
             r2 = fastrand() % t->size();


### PR DESCRIPTION
This is an updated version of the unit test that was added in dc566f5b3.
The error that this test exposed was due to the way the test was
implemented. It inserted a value into the column which was the result of
a get from the same column. As we use StringData to hold the data to be
inserted, we have a direct pointer to where the string data is stored. In
this case we use long strings which means that many strings are stored in
the same blob. If the value to be replaced is stored in the same blob as
the new value and the old value comes first, then the new value will move
in memory before the copy is done because we need to adjust for the new
size. So the pointer we get passed in becomes stale and we get the wrong
value copied in (which will have no index).

The new test case is modified in the way that we first copy the content out
in some temporary strings before inserting them again.

@rrrlasse @ironage 
