### PR TITLE
Update format version comments.

### DIFF
--- a/src/realm/alloc.hpp
+++ b/src/realm/alloc.hpp
@@ -197,10 +197,10 @@ public:
     ///     When opening an older database file, all DateTime columns will be
     ///     automatically upgraded Timestamp columns.
     ///
-    ///   6 Introduced a new non-compatible structure for StringIndex. Moved the
-    ///     commit logs into the Realm file. Changes to the transaction log
-    ///     format, including reshuffling instructions. This is the format used
-    ///     in milestone 2.0.0.
+    ///   6 Introduced a new structure for the StringIndex. Moved the commit
+    ///     logs into the Realm file. Changes to the transaction log format
+    ///     including reshuffling instructions. This is the format used in
+    ///     milestone 2.0.0.
     ///
     /// IMPORTANT: When introducing a new file format version, be sure to review
     /// the file validity checks in AllocSlab::validate_buffer(), the file


### PR DESCRIPTION
The PR that bumped the file format only involved the StringIndex changes, however the new version also protects against all other changes from the next-major branch. I think it is important to note that the StringIndex format was not the only breaking change that the new version protects.

@finnschiermer @danielpovlsen
