### PR TITLE
ColumnRandIterator completeness

### DIFF
--- a/src/realm/column.hpp
+++ b/src/realm/column.hpp
@@ -76,7 +76,7 @@ template <typename ColumnDataType>
 class ColumnRandIterator : public std::iterator<std::random_access_iterator_tag, ColumnDataType, ptrdiff_t, size_t> {
 public:
     ColumnRandIterator(const Column<ColumnDataType>* src_col, size_t ndx = 0);
-    operator bool() const;
+    explicit operator bool() const noexcept;
     bool operator==(const ColumnRandIterator<ColumnDataType>& other) const;
     bool operator!=(const ColumnRandIterator<ColumnDataType>& other) const;
     ColumnRandIterator<ColumnDataType>& operator+=(const ptrdiff_t& movement);
@@ -1702,7 +1702,7 @@ ColumnRandIterator<ColumnDataType>::ColumnRandIterator(const Column<ColumnDataTy
 }
 
 template <class ColumnDataType>
-ColumnRandIterator<ColumnDataType>::operator bool() const
+ColumnRandIterator<ColumnDataType>::operator bool() const noexcept
 {
     return col_ndx >= 0 && col_ndx < cached_column_size;
 }

--- a/src/realm/column.hpp
+++ b/src/realm/column.hpp
@@ -1843,6 +1843,12 @@ size_t ColumnRandIterator<ColumnDataType>::get_col_ndx() const
     return col_ndx;
 }
 
+template <class ColumnDataType>
+std::ostream& operator<<(std::ostream& out, const ColumnRandIterator<ColumnDataType>& it)
+{
+    out << "ColumnRandIterator at index: " << it.get_col_ndx();
+    return out;
+}
 
 } // namespace realm
 

--- a/src/realm/column.hpp
+++ b/src/realm/column.hpp
@@ -76,12 +76,12 @@ template <typename ColumnDataType>
 class ColumnRandIterator : public std::iterator<std::random_access_iterator_tag, ColumnDataType, ptrdiff_t, size_t> {
 public:
     ColumnRandIterator(const Column<ColumnDataType>* src_col, size_t ndx = 0);
-    bool operator==(const ColumnRandIterator<ColumnDataType>& other) const;
-    bool operator!=(const ColumnRandIterator<ColumnDataType>& other) const;
-    bool operator<(const ColumnRandIterator<ColumnDataType>& other) const;
-    bool operator>(const ColumnRandIterator<ColumnDataType>& other) const;
-    bool operator<=(const ColumnRandIterator<ColumnDataType>& other) const;
-    bool operator>=(const ColumnRandIterator<ColumnDataType>& other) const;
+    bool operator==(const ColumnRandIterator<ColumnDataType>& rhs) const;
+    bool operator!=(const ColumnRandIterator<ColumnDataType>& rhs) const;
+    bool operator<(const ColumnRandIterator<ColumnDataType>& rhs) const;
+    bool operator>(const ColumnRandIterator<ColumnDataType>& rhs) const;
+    bool operator<=(const ColumnRandIterator<ColumnDataType>& rhs) const;
+    bool operator>=(const ColumnRandIterator<ColumnDataType>& rhs) const;
     ColumnRandIterator<ColumnDataType>& operator+=(ptrdiff_t movement);
     ColumnRandIterator<ColumnDataType>& operator-=(ptrdiff_t movement);
     ColumnRandIterator<ColumnDataType>& operator++();
@@ -1704,39 +1704,39 @@ ColumnRandIterator<ColumnDataType>::ColumnRandIterator(const Column<ColumnDataTy
 }
 
 template <class ColumnDataType>
-bool ColumnRandIterator<ColumnDataType>::operator==(const ColumnRandIterator<ColumnDataType>& other) const
+bool ColumnRandIterator<ColumnDataType>::operator==(const ColumnRandIterator<ColumnDataType>& rhs) const
 {
-    return (m_col_ndx == other.m_col_ndx);
+    return (m_col_ndx == rhs.m_col_ndx);
 }
 
 template <class ColumnDataType>
-bool ColumnRandIterator<ColumnDataType>::operator!=(const ColumnRandIterator<ColumnDataType>& other) const
+bool ColumnRandIterator<ColumnDataType>::operator!=(const ColumnRandIterator<ColumnDataType>& rhs) const
 {
-    return !(*this == other);
+    return !(*this == rhs);
 }
 
 template <class ColumnDataType>
-bool ColumnRandIterator<ColumnDataType>::operator<(const ColumnRandIterator<ColumnDataType>& other) const
+bool ColumnRandIterator<ColumnDataType>::operator<(const ColumnRandIterator<ColumnDataType>& rhs) const
 {
-    return m_col_ndx < other.m_col_ndx;
+    return m_col_ndx < rhs.m_col_ndx;
 }
 
 template <class ColumnDataType>
-bool ColumnRandIterator<ColumnDataType>::operator>(const ColumnRandIterator<ColumnDataType>& other) const
+bool ColumnRandIterator<ColumnDataType>::operator>(const ColumnRandIterator<ColumnDataType>& rhs) const
 {
-    return m_col_ndx > other.m_col_ndx;
+    return rhs < *this;
 }
 
 template <class ColumnDataType>
-bool ColumnRandIterator<ColumnDataType>::operator<=(const ColumnRandIterator<ColumnDataType>& other) const
+bool ColumnRandIterator<ColumnDataType>::operator<=(const ColumnRandIterator<ColumnDataType>& rhs) const
 {
-    return m_col_ndx <= other.m_col_ndx;
+    return !(rhs < *this);
 }
 
 template <class ColumnDataType>
-bool ColumnRandIterator<ColumnDataType>::operator>=(const ColumnRandIterator<ColumnDataType>& other) const
+bool ColumnRandIterator<ColumnDataType>::operator>=(const ColumnRandIterator<ColumnDataType>& rhs) const
 {
-    return m_col_ndx >= other.m_col_ndx;
+    return !(*this < rhs);
 }
 
 template <class ColumnDataType>

--- a/src/realm/column.hpp
+++ b/src/realm/column.hpp
@@ -95,7 +95,7 @@ public:
     ptrdiff_t operator-(const ColumnRandIterator<ColumnDataType>& rawIterator);
     const ColumnDataType operator*() const;
     const ColumnDataType operator->() const;
-    const ColumnDataType operator[](const ptrdiff_t& ndx) const;
+    const ColumnDataType operator[](const ptrdiff_t& offset) const;
     size_t get_col_ndx() const;
 protected:
     size_t col_ndx;
@@ -1832,9 +1832,9 @@ const ColumnDataType ColumnRandIterator<ColumnDataType>::operator->() const
 }
 
 template <class ColumnDataType>
-const ColumnDataType ColumnRandIterator<ColumnDataType>::operator[](const ptrdiff_t& ndx) const
+const ColumnDataType ColumnRandIterator<ColumnDataType>::operator[](const ptrdiff_t& offset) const
 {
-    return col->get(ndx);
+    return col->get(col_ndx + offset);
 }
 
 template <class ColumnDataType>

--- a/src/realm/column.hpp
+++ b/src/realm/column.hpp
@@ -76,9 +76,14 @@ template <typename ColumnDataType>
 class ColumnRandIterator : public std::iterator<std::random_access_iterator_tag, ColumnDataType, ptrdiff_t, size_t> {
 public:
     ColumnRandIterator(const Column<ColumnDataType>* src_col, size_t ndx = 0);
+    ColumnRandIterator();
     explicit operator bool() const noexcept;
     bool operator==(const ColumnRandIterator<ColumnDataType>& other) const;
     bool operator!=(const ColumnRandIterator<ColumnDataType>& other) const;
+    bool operator<(const ColumnRandIterator<ColumnDataType>& other) const;
+    bool operator>(const ColumnRandIterator<ColumnDataType>& other) const;
+    bool operator<=(const ColumnRandIterator<ColumnDataType>& other) const;
+    bool operator>=(const ColumnRandIterator<ColumnDataType>& other) const;
     ColumnRandIterator<ColumnDataType>& operator+=(const ptrdiff_t& movement);
     ColumnRandIterator<ColumnDataType>& operator-=(const ptrdiff_t& movement);
     ColumnRandIterator<ColumnDataType>& operator++();
@@ -89,8 +94,9 @@ public:
     ColumnRandIterator<ColumnDataType> operator-(const ptrdiff_t& movement);
     ptrdiff_t operator-(const ColumnRandIterator<ColumnDataType>& rawIterator);
     const ColumnDataType operator*() const;
+    const ColumnDataType operator->() const;
+    const ColumnDataType operator[](const ptrdiff_t& ndx) const;
     size_t get_col_ndx() const;
-
 protected:
     size_t col_ndx;
     size_t cached_column_size;
@@ -1702,6 +1708,14 @@ ColumnRandIterator<ColumnDataType>::ColumnRandIterator(const Column<ColumnDataTy
 }
 
 template <class ColumnDataType>
+ColumnRandIterator<ColumnDataType>::ColumnRandIterator()
+    : col_ndx(size_t(-1))
+    , cached_column_size(0)
+    , col(nullptr)
+{
+}
+
+template <class ColumnDataType>
 ColumnRandIterator<ColumnDataType>::operator bool() const noexcept
 {
     return col_ndx >= 0 && col_ndx < cached_column_size;
@@ -1717,6 +1731,30 @@ template <class ColumnDataType>
 bool ColumnRandIterator<ColumnDataType>::operator!=(const ColumnRandIterator<ColumnDataType>& other) const
 {
     return !(*this == other);
+}
+
+template <class ColumnDataType>
+bool ColumnRandIterator<ColumnDataType>::operator<(const ColumnRandIterator<ColumnDataType>& other) const
+{
+    return col_ndx < other.col_ndx;
+}
+
+template <class ColumnDataType>
+bool ColumnRandIterator<ColumnDataType>::operator>(const ColumnRandIterator<ColumnDataType>& other) const
+{
+    return col_ndx > other.col_ndx;
+}
+
+template <class ColumnDataType>
+bool ColumnRandIterator<ColumnDataType>::operator<=(const ColumnRandIterator<ColumnDataType>& other) const
+{
+    return col_ndx <= other.col_ndx;
+}
+
+template <class ColumnDataType>
+bool ColumnRandIterator<ColumnDataType>::operator>=(const ColumnRandIterator<ColumnDataType>& other) const
+{
+    return col_ndx >= other.col_ndx;
 }
 
 template <class ColumnDataType>
@@ -1785,6 +1823,18 @@ template <class ColumnDataType>
 const ColumnDataType ColumnRandIterator<ColumnDataType>::operator*() const
 {
     return col->get(col_ndx);
+}
+
+template <class ColumnDataType>
+const ColumnDataType ColumnRandIterator<ColumnDataType>::operator->() const
+{
+    return col->get(col_ndx);
+}
+
+template <class ColumnDataType>
+const ColumnDataType ColumnRandIterator<ColumnDataType>::operator[](const ptrdiff_t& ndx) const
+{
+    return col->get(ndx);
 }
 
 template <class ColumnDataType>

--- a/src/realm/column.hpp
+++ b/src/realm/column.hpp
@@ -76,31 +76,28 @@ template <typename ColumnDataType>
 class ColumnRandIterator : public std::iterator<std::random_access_iterator_tag, ColumnDataType, ptrdiff_t, size_t> {
 public:
     ColumnRandIterator(const Column<ColumnDataType>* src_col, size_t ndx = 0);
-    ColumnRandIterator();
-    explicit operator bool() const noexcept;
     bool operator==(const ColumnRandIterator<ColumnDataType>& other) const;
     bool operator!=(const ColumnRandIterator<ColumnDataType>& other) const;
     bool operator<(const ColumnRandIterator<ColumnDataType>& other) const;
     bool operator>(const ColumnRandIterator<ColumnDataType>& other) const;
     bool operator<=(const ColumnRandIterator<ColumnDataType>& other) const;
     bool operator>=(const ColumnRandIterator<ColumnDataType>& other) const;
-    ColumnRandIterator<ColumnDataType>& operator+=(const ptrdiff_t& movement);
-    ColumnRandIterator<ColumnDataType>& operator-=(const ptrdiff_t& movement);
+    ColumnRandIterator<ColumnDataType>& operator+=(ptrdiff_t movement);
+    ColumnRandIterator<ColumnDataType>& operator-=(ptrdiff_t movement);
     ColumnRandIterator<ColumnDataType>& operator++();
     ColumnRandIterator<ColumnDataType>& operator--();
     ColumnRandIterator<ColumnDataType> operator++(int);
     ColumnRandIterator<ColumnDataType> operator--(int);
-    ColumnRandIterator<ColumnDataType> operator+(const ptrdiff_t& movement);
-    ColumnRandIterator<ColumnDataType> operator-(const ptrdiff_t& movement);
+    ColumnRandIterator<ColumnDataType> operator+(ptrdiff_t movement);
+    ColumnRandIterator<ColumnDataType> operator-(ptrdiff_t movement);
     ptrdiff_t operator-(const ColumnRandIterator<ColumnDataType>& rawIterator);
     const ColumnDataType operator*() const;
     const ColumnDataType operator->() const;
-    const ColumnDataType operator[](const ptrdiff_t& offset) const;
+    const ColumnDataType operator[](ptrdiff_t offset) const;
     size_t get_col_ndx() const;
 protected:
-    size_t col_ndx;
-    size_t cached_column_size;
-    const Column<ColumnDataType>* col;
+    size_t m_col_ndx;
+    const Column<ColumnDataType>* m_col;
 };
 
 /// Base class for all column types.
@@ -1701,30 +1698,15 @@ void Column<T>::dump_node_structure(const Array& root, std::ostream& out, int le
 
 template <class ColumnDataType>
 ColumnRandIterator<ColumnDataType>::ColumnRandIterator(const Column<ColumnDataType>* src_col, size_t ndx)
-    : col_ndx(ndx)
-    , col(src_col)
+    : m_col_ndx(ndx)
+    , m_col(src_col)
 {
-    cached_column_size = col->size();
-}
-
-template <class ColumnDataType>
-ColumnRandIterator<ColumnDataType>::ColumnRandIterator()
-    : col_ndx(size_t(-1))
-    , cached_column_size(0)
-    , col(nullptr)
-{
-}
-
-template <class ColumnDataType>
-ColumnRandIterator<ColumnDataType>::operator bool() const noexcept
-{
-    return col_ndx >= 0 && col_ndx < cached_column_size;
 }
 
 template <class ColumnDataType>
 bool ColumnRandIterator<ColumnDataType>::operator==(const ColumnRandIterator<ColumnDataType>& other) const
 {
-    return (col_ndx == other.col_ndx);
+    return (m_col_ndx == other.m_col_ndx);
 }
 
 template <class ColumnDataType>
@@ -1736,52 +1718,52 @@ bool ColumnRandIterator<ColumnDataType>::operator!=(const ColumnRandIterator<Col
 template <class ColumnDataType>
 bool ColumnRandIterator<ColumnDataType>::operator<(const ColumnRandIterator<ColumnDataType>& other) const
 {
-    return col_ndx < other.col_ndx;
+    return m_col_ndx < other.m_col_ndx;
 }
 
 template <class ColumnDataType>
 bool ColumnRandIterator<ColumnDataType>::operator>(const ColumnRandIterator<ColumnDataType>& other) const
 {
-    return col_ndx > other.col_ndx;
+    return m_col_ndx > other.m_col_ndx;
 }
 
 template <class ColumnDataType>
 bool ColumnRandIterator<ColumnDataType>::operator<=(const ColumnRandIterator<ColumnDataType>& other) const
 {
-    return col_ndx <= other.col_ndx;
+    return m_col_ndx <= other.m_col_ndx;
 }
 
 template <class ColumnDataType>
 bool ColumnRandIterator<ColumnDataType>::operator>=(const ColumnRandIterator<ColumnDataType>& other) const
 {
-    return col_ndx >= other.col_ndx;
+    return m_col_ndx >= other.m_col_ndx;
 }
 
 template <class ColumnDataType>
-ColumnRandIterator<ColumnDataType>& ColumnRandIterator<ColumnDataType>::operator+=(const ptrdiff_t& movement)
+ColumnRandIterator<ColumnDataType>& ColumnRandIterator<ColumnDataType>::operator+=(ptrdiff_t movement)
 {
-    col_ndx += movement;
+    m_col_ndx += movement;
     return (*this);
 }
 
 template <class ColumnDataType>
-ColumnRandIterator<ColumnDataType>& ColumnRandIterator<ColumnDataType>::operator-=(const ptrdiff_t& movement)
+ColumnRandIterator<ColumnDataType>& ColumnRandIterator<ColumnDataType>::operator-=(ptrdiff_t movement)
 {
-    col_ndx -= movement;
+    m_col_ndx -= movement;
     return (*this);
 }
 
 template <class ColumnDataType>
 ColumnRandIterator<ColumnDataType>& ColumnRandIterator<ColumnDataType>::operator++()
 {
-    ++col_ndx;
+    ++m_col_ndx;
     return (*this);
 }
 
 template <class ColumnDataType>
 ColumnRandIterator<ColumnDataType>& ColumnRandIterator<ColumnDataType>::operator--()
 {
-    --col_ndx;
+    --m_col_ndx;
     return (*this);
 }
 
@@ -1789,7 +1771,7 @@ template <class ColumnDataType>
 ColumnRandIterator<ColumnDataType> ColumnRandIterator<ColumnDataType>::operator++(int)
 {
     auto temp(*this);
-    ++col_ndx;
+    ++m_col_ndx;
     return temp;
 }
 
@@ -1797,50 +1779,50 @@ template <class ColumnDataType>
 ColumnRandIterator<ColumnDataType> ColumnRandIterator<ColumnDataType>::operator--(int)
 {
     auto temp(*this);
-    --col_ndx;
+    --m_col_ndx;
     return temp;
 }
 
 template <class ColumnDataType>
-ColumnRandIterator<ColumnDataType> ColumnRandIterator<ColumnDataType>::operator+(const ptrdiff_t& movement)
+ColumnRandIterator<ColumnDataType> ColumnRandIterator<ColumnDataType>::operator+(ptrdiff_t movement)
 {
-    return ColumnRandIterator(col, col_ndx + movement);
+    return ColumnRandIterator(m_col, m_col_ndx + movement);
 }
 
 template <class ColumnDataType>
-ColumnRandIterator<ColumnDataType> ColumnRandIterator<ColumnDataType>::operator-(const ptrdiff_t& movement)
+ColumnRandIterator<ColumnDataType> ColumnRandIterator<ColumnDataType>::operator-(ptrdiff_t movement)
 {
-    return ColumnRandIterator(col, col_ndx - movement);
+    return ColumnRandIterator(m_col, m_col_ndx - movement);
 }
 
 template <class ColumnDataType>
 ptrdiff_t ColumnRandIterator<ColumnDataType>::operator-(const ColumnRandIterator<ColumnDataType>& other)
 {
-    return col_ndx - other.col_ndx;
+    return m_col_ndx - other.m_col_ndx;
 }
 
 template <class ColumnDataType>
 const ColumnDataType ColumnRandIterator<ColumnDataType>::operator*() const
 {
-    return col->get(col_ndx);
+    return m_col->get(m_col_ndx);
 }
 
 template <class ColumnDataType>
 const ColumnDataType ColumnRandIterator<ColumnDataType>::operator->() const
 {
-    return col->get(col_ndx);
+    return m_col->get(m_col_ndx);
 }
 
 template <class ColumnDataType>
-const ColumnDataType ColumnRandIterator<ColumnDataType>::operator[](const ptrdiff_t& offset) const
+const ColumnDataType ColumnRandIterator<ColumnDataType>::operator[](ptrdiff_t offset) const
 {
-    return col->get(col_ndx + offset);
+    return m_col->get(m_col_ndx + offset);
 }
 
 template <class ColumnDataType>
 size_t ColumnRandIterator<ColumnDataType>::get_col_ndx() const
 {
-    return col_ndx;
+    return m_col_ndx;
 }
 
 template <class ColumnDataType>

--- a/test/test_column.cpp
+++ b/test/test_column.cpp
@@ -1226,8 +1226,6 @@ TEST_TYPES(Column_Iterators, std::true_type, std::false_type)
     auto realm_end = c.cend();
 
     CHECK_EQUAL(std_end - std_it, realm_end - realm_it);
-    CHECK(realm_it);
-    CHECK(!realm_end);
 
     while(std_it != std_end) {
         CHECK_EQUAL(*std_it, *realm_it);

--- a/test/test_column.cpp
+++ b/test/test_column.cpp
@@ -1314,6 +1314,8 @@ TEST_TYPES(Column_Iterators, std::true_type, std::false_type)
     CHECK(realm_next >= realm_it);
     CHECK(realm_next >= realm_next);
     CHECK(!(realm_it >= realm_next));
+
+    c.destroy();
 }
 
 #endif // TEST_COLUMN


### PR DESCRIPTION
I made the `ColumnRandIterator::operator bool()` explicit (and noexcept) which causes Microsoft Visual Studio Community 2015 (Version 14.0.25431.01 Update 3) to produce a compiler error for missing `operator<`. The `bool()` operator was erroneously (and implicitly) used to compare two iterators (`a < b`) as bools(!), which caused the `Column_SwapRows` unit test in `test_column.cpp` to crash.

TODO: Implement `operator<` (and more?).

cc: @ironage @rrrlasse