### PR TITLE
Ignore temporary unit test files

### DIFF
--- a/test/.gitignore
+++ b/test/.gitignore
@@ -18,3 +18,6 @@
 
 # Jenkins unit test reports
 /unit-test-report.xml
+
+# Temporary unit test files
+/*.path.realm*


### PR DESCRIPTION
Ignore temporary unit test files to prevent some Git tools from accidentally locking them and cause problems during testing.

@rrrlasse @finnschiermer Please review.
