### PR TITLE
Fallout of stability improvements in RMP, and a rename

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,11 +2,13 @@
 
 ### Bugfixes
 
-* Lorem ipsum.
+* Extra SetUnique instructions are no longer generated in the transaction log
+  when a conflict was resolved locally.
 
 ### Breaking changes
 
-* Lorem ipsum.
+* The ChangeLinkTargets instruction was a misnomer and has been renamed to
+  MergeRows.
 
 ### Enhancements
 
@@ -17,6 +19,8 @@
 ### Internals
 
 * Android builds: upgraded to OpenSSL 1.0.1u.
+* The behavior of MergeRows (formerly ChangeLinkTargets) has been simplified to
+  be semantically equivalent to a row swap.
 
 ----------------------------------------------
 

--- a/src/realm/column.hpp
+++ b/src/realm/column.hpp
@@ -281,7 +281,7 @@ public:
     /// See Table::adj_acc_move_over()
     virtual void adj_acc_move_over(size_t from_row_ndx, size_t to_row_ndx) noexcept;
     virtual void adj_acc_swap_rows(size_t row_ndx_1, size_t row_ndx_2) noexcept;
-    virtual void adj_acc_subsume_row(size_t old_row_ndx, size_t new_row_ndx) noexcept;
+    virtual void adj_acc_merge_rows(size_t old_row_ndx, size_t new_row_ndx) noexcept;
     virtual void adj_acc_clear_root_table() noexcept;
 
     enum {
@@ -843,7 +843,7 @@ inline void ColumnBase::adj_acc_swap_rows(size_t, size_t) noexcept
     // Noop
 }
 
-inline void ColumnBase::adj_acc_subsume_row(size_t, size_t) noexcept
+inline void ColumnBase::adj_acc_merge_rows(size_t, size_t) noexcept
 {
     // Noop
 }

--- a/src/realm/column_linklist.cpp
+++ b/src/realm/column_linklist.cpp
@@ -473,7 +473,7 @@ void LinkListColumn::adj_acc_swap_rows(size_t row_ndx_1, size_t row_ndx_2) noexc
 }
 
 
-void LinkListColumn::adj_acc_subsume_row(size_t old_row_ndx, size_t new_row_ndx) noexcept
+void LinkListColumn::adj_acc_merge_rows(size_t old_row_ndx, size_t new_row_ndx) noexcept
 {
     prune_list_accessor_tombstones();
 

--- a/src/realm/column_linklist.hpp
+++ b/src/realm/column_linklist.hpp
@@ -79,7 +79,7 @@ public:
     void adj_acc_erase_row(size_t) noexcept override;
     void adj_acc_move_over(size_t, size_t) noexcept override;
     void adj_acc_swap_rows(size_t, size_t) noexcept override;
-    void adj_acc_subsume_row(size_t, size_t) noexcept override;
+    void adj_acc_merge_rows(size_t, size_t) noexcept override;
     void refresh_accessor_tree(size_t, const Spec&) override;
 
     void verify() const override;

--- a/src/realm/group.cpp
+++ b/src/realm/group.cpp
@@ -1371,11 +1371,11 @@ public:
         return true;
     }
 
-    bool change_link_targets(size_t row_ndx, size_t new_row_ndx) noexcept
+    bool merge_rows(size_t row_ndx, size_t new_row_ndx) noexcept
     {
         typedef _impl::TableFriend tf;
         if (m_table)
-            tf::adj_acc_subsume_row(*m_table, row_ndx, new_row_ndx);
+            tf::adj_acc_merge_rows(*m_table, row_ndx, new_row_ndx);
         return true;
     }
 

--- a/src/realm/impl/transact_log.hpp
+++ b/src/realm/impl/transact_log.hpp
@@ -57,7 +57,7 @@ enum Instruction {
     instr_InsertEmptyRows = 13,
     instr_EraseRows = 14, // Remove (multiple) rows
     instr_SwapRows = 15,
-    instr_ChangeLinkTargets = 16, // Replace links pointing to row A with links to row B
+    instr_MergeRows = 16, // Replace links pointing to row A with links to row B
     instr_ClearTable = 17,        // Remove all rows in selected table
     instr_OptimizeTable = 18,
     instr_SelectDescriptor = 19, // Select descriptor from currently selected root table
@@ -167,7 +167,7 @@ public:
     {
         return true;
     }
-    bool change_link_targets(size_t, size_t)
+    bool merge_rows(size_t, size_t)
     {
         return true;
     }
@@ -339,7 +339,7 @@ public:
     bool insert_empty_rows(size_t row_ndx, size_t num_rows_to_insert, size_t prior_num_rows, bool unordered);
     bool erase_rows(size_t row_ndx, size_t num_rows_to_erase, size_t prior_num_rows, bool unordered);
     bool swap_rows(size_t row_ndx_1, size_t row_ndx_2);
-    bool change_link_targets(size_t row_ndx, size_t new_row_ndx);
+    bool merge_rows(size_t row_ndx, size_t new_row_ndx);
     bool clear_table();
 
     bool set_int(size_t col_ndx, size_t row_ndx, int_fast64_t, Instruction = instr_Set, size_t = 0);
@@ -482,7 +482,7 @@ public:
                     bool is_move_last_over);
 
     void swap_rows(const Table*, size_t row_ndx_1, size_t row_ndx_2);
-    void change_link_targets(const Table*, size_t row_ndx, size_t new_row_ndx);
+    void merge_rows(const Table*, size_t row_ndx, size_t new_row_ndx);
     void add_search_index(const Table*, size_t col_ndx);
     void remove_search_index(const Table*, size_t col_ndx);
     void set_link_type(const Table*, size_t col_ndx, LinkType);
@@ -1442,16 +1442,16 @@ inline void TransactLogConvenientEncoder::swap_rows(const Table* t, size_t row_n
     m_encoder.swap_rows(row_ndx_1, row_ndx_2);
 }
 
-inline bool TransactLogEncoder::change_link_targets(size_t row_ndx, size_t new_row_ndx)
+inline bool TransactLogEncoder::merge_rows(size_t row_ndx, size_t new_row_ndx)
 {
-    append_simple_instr(instr_ChangeLinkTargets, util::tuple(row_ndx, new_row_ndx)); // Throws
+    append_simple_instr(instr_MergeRows, util::tuple(row_ndx, new_row_ndx)); // Throws
     return true;
 }
 
-inline void TransactLogConvenientEncoder::change_link_targets(const Table* t, size_t row_ndx, size_t new_row_ndx)
+inline void TransactLogConvenientEncoder::merge_rows(const Table* t, size_t row_ndx, size_t new_row_ndx)
 {
     select_table(t); // Throws
-    m_encoder.change_link_targets(row_ndx, new_row_ndx);
+    m_encoder.merge_rows(row_ndx, new_row_ndx);
 }
 
 inline bool TransactLogEncoder::add_search_index(size_t col_ndx)
@@ -1872,10 +1872,10 @@ void TransactLogParser::parse_one(InstructionHandler& handler)
                 parser_error();
             return;
         }
-        case instr_ChangeLinkTargets: {
+        case instr_MergeRows: {
             size_t row_ndx = read_int<size_t>();                    // Throws
             size_t new_row_ndx = read_int<size_t>();                // Throws
-            if (!handler.change_link_targets(row_ndx, new_row_ndx)) // Throws
+            if (!handler.merge_rows(row_ndx, new_row_ndx)) // Throws
                 parser_error();
             return;
         }
@@ -2423,7 +2423,7 @@ public:
         return true;
     }
 
-    bool change_link_targets(size_t row_ndx, size_t new_row_ndx)
+    bool merge_rows(size_t row_ndx, size_t new_row_ndx)
     {
         static_cast<void>(row_ndx);
         static_cast<void>(new_row_ndx);

--- a/src/realm/replication.cpp
+++ b/src/realm/replication.cpp
@@ -309,15 +309,15 @@ public:
         return true;
     }
 
-    bool change_link_targets(size_t row_ndx, size_t new_row_ndx)
+    bool merge_rows(size_t row_ndx, size_t new_row_ndx)
     {
         if (REALM_UNLIKELY(REALM_COVER_NEVER(!m_table)))
             return false;
         if (REALM_UNLIKELY(REALM_COVER_NEVER(row_ndx >= m_table->size() || new_row_ndx >= m_table->size())))
             return false;
-        log("table->change_link_targets(%1, %2);", row_ndx, new_row_ndx); // Throws
+        log("table->merge_rows(%1, %2);", row_ndx, new_row_ndx); // Throws
         using tf = _impl::TableFriend;
-        tf::do_change_link_targets(*m_table, row_ndx, new_row_ndx); // Throws
+        tf::do_merge_rows(*m_table, row_ndx, new_row_ndx); // Throws
         return true;
     }
 

--- a/src/realm/table.cpp
+++ b/src/realm/table.cpp
@@ -2362,38 +2362,28 @@ void Table::do_swap_rows(size_t row_ndx_1, size_t row_ndx_2)
 
 void Table::do_change_link_targets(size_t row_ndx, size_t new_row_ndx)
 {
-    // Replace links through backlink columns.
-    //
     // This bypasses handling of cascading rows, and we have decided that this is OK, because
     // ChangeLinkTargets is always followed by MoveLastOver, so breaking the last strong link
     // to a row that is being subsumed will have no observable effect, while honoring the
     // cascading behavior would complicate the calling code somewhat (having to take
     // into account whether or not the row was removed as a consequence of cascade, leading
     // to bugs in case this was forgotten).
-    size_t backlink_col_start = m_spec.get_public_column_count();
-    size_t backlink_col_end = m_spec.get_column_count();
-    for (size_t col_ndx = backlink_col_start; col_ndx < backlink_col_end; ++col_ndx) {
-        REALM_ASSERT(m_spec.get_column_type(col_ndx) == col_type_BackLink);
 
-        auto& col = get_column_backlink(col_ndx);
-        auto& origin_table = col.get_origin_table();
-        size_t origin_col_ndx = col.get_origin_column_index();
-        ColumnType origin_col_type = origin_table.get_real_column_type(origin_col_ndx);
-        while (col.get_backlink_count(row_ndx) > 0) {
-            size_t origin_row_ndx = col.get_backlink(row_ndx, 0);
 
-            if (origin_col_type == col_type_Link) {
-                origin_table.set_link(origin_col_ndx, origin_row_ndx, new_row_ndx);
-            }
-            else if (origin_col_type == col_type_LinkList) {
-                LinkViewRef links = origin_table.get_linklist(origin_col_ndx, origin_row_ndx);
-                for (size_t j = 0; j < links->size(); ++j) {
-                    if (links->get(j).get_index() == row_ndx) {
-                        links->set(j, new_row_ndx);
-                    }
-                }
-            }
+    // Since new_row_ndx is guaranteed to be empty at this point, simply swap
+    // the rows to get the desired behavior.
+
+    size_t row_ndx_1 = row_ndx, row_ndx_2 = new_row_ndx;
+    if (row_ndx_1 > row_ndx_2)
+        std::swap(row_ndx_1, row_ndx_2);
+    size_t num_cols = m_spec.get_column_count();
+    for (size_t col_ndx = 0; col_ndx != num_cols; ++col_ndx) {
+        ColumnBase& col = get_column_base(col_ndx);
+        if (get_column_type(col_ndx) == type_LinkList) {
+            LinkListColumn& link_list_col = static_cast<LinkListColumn&>(col);
+            REALM_ASSERT(!link_list_col.has_links(new_row_ndx));
         }
+        col.swap_rows(row_ndx_1, row_ndx_2);
     }
 
     adj_row_acc_subsume_row(row_ndx, new_row_ndx);
@@ -2814,7 +2804,7 @@ Timestamp Table::get(size_t col_ndx, size_t ndx) const noexcept
 
 
 template <class ColType, class T>
-size_t Table::do_find_unique(ColType& col, size_t ndx, T&& value)
+size_t Table::do_find_unique(ColType& col, size_t ndx, T&& value, bool& conflict)
 {
     size_t winner = size_t(-1);
 
@@ -2827,6 +2817,8 @@ size_t Table::do_find_unique(ColType& col, size_t ndx, T&& value)
         else
             break;
     }
+
+    conflict = true;
 
     REALM_ASSERT(winner != not_found);
     REALM_ASSERT(winner != ndx);
@@ -2859,17 +2851,17 @@ size_t Table::do_find_unique(ColType& col, size_t ndx, T&& value)
 }
 
 template <class ColType>
-size_t Table::do_set_unique_null(ColType& col, size_t ndx)
+size_t Table::do_set_unique_null(ColType& col, size_t ndx, bool& conflict)
 {
-    ndx = do_find_unique(col, ndx, null{});
+    ndx = do_find_unique(col, ndx, null{}, conflict);
     col.set_null(ndx);
     return ndx;
 }
 
 template <class ColType, class T>
-size_t Table::do_set_unique(ColType& col, size_t ndx, T&& value)
+size_t Table::do_set_unique(ColType& col, size_t ndx, T&& value, bool& conflict)
 {
-    ndx = do_find_unique(col, ndx, value);
+    ndx = do_find_unique(col, ndx, value, conflict);
     col.set(ndx, value);
     return ndx;
 }
@@ -2894,17 +2886,21 @@ size_t Table::set_int_unique(size_t col_ndx, size_t ndx, int_fast64_t value)
 
     bump_version();
 
+    bool conflict = false;
+
     if (is_nullable(col_ndx)) {
         auto& col = get_column_int_null(col_ndx);
-        ndx = do_set_unique(col, ndx, value); // Throws
+        ndx = do_set_unique(col, ndx, value, conflict); // Throws
     }
     else {
         auto& col = get_column(col_ndx);
-        ndx = do_set_unique(col, ndx, value); // Throws
+        ndx = do_set_unique(col, ndx, value, conflict); // Throws
     }
 
-    if (Replication* repl = get_repl())
-        repl->set_int(this, col_ndx, ndx, value, _impl::instr_SetUnique); // Throws
+    if (!conflict) {
+        if (Replication* repl = get_repl())
+            repl->set_int(this, col_ndx, ndx, value, _impl::instr_SetUnique); // Throws
+    }
 
     return ndx;
 }
@@ -3146,18 +3142,21 @@ size_t Table::set_string_unique(size_t col_ndx, size_t ndx, StringData value)
     ColumnType actual_type = get_real_column_type(col_ndx);
     REALM_ASSERT(actual_type == ColumnType::col_type_String || actual_type == ColumnType::col_type_StringEnum);
 
+    bool conflict = false;
     // FIXME: String and StringEnum columns should have a common base class
     if (actual_type == ColumnType::col_type_String) {
         StringColumn& col = get_column_string(col_ndx);
-        ndx = do_set_unique(col, ndx, value); // Throws
+        ndx = do_set_unique(col, ndx, value, conflict); // Throws
     }
     else {
         StringEnumColumn& col = get_column_string_enum(col_ndx);
-        ndx = do_set_unique(col, ndx, value); // Throws
+        ndx = do_set_unique(col, ndx, value, conflict); // Throws
     }
 
-    if (Replication* repl = get_repl())
-        repl->set_string(this, col_ndx, ndx, value, _impl::instr_SetUnique); // Throws
+    if (!conflict) {
+        if (Replication* repl = get_repl())
+            repl->set_string(this, col_ndx, ndx, value, _impl::instr_SetUnique); // Throws
+    }
 
     return ndx;
 }
@@ -3502,12 +3501,16 @@ void Table::set_null_unique(size_t col_ndx, size_t row_ndx)
 
     bump_version();
 
+    bool conflict = false;
+
     // Only valid for int columns; use `set_string_unique` to set null strings
     auto& col = get_column_int_null(col_ndx);
-    row_ndx = do_set_unique_null(col, row_ndx); // Throws
+    row_ndx = do_set_unique_null(col, row_ndx, conflict); // Throws
 
-    if (Replication* repl = get_repl())
-        repl->set_null(this, col_ndx, row_ndx, _impl::instr_SetUnique); // Throws
+    if (!conflict) {
+        if (Replication* repl = get_repl())
+            repl->set_null(this, col_ndx, row_ndx, _impl::instr_SetUnique); // Throws
+    }
 }
 
 void Table::set_null(size_t col_ndx, size_t row_ndx, bool is_default)

--- a/src/realm/table.hpp
+++ b/src/realm/table.hpp
@@ -956,11 +956,11 @@ private:
     void do_clear(bool broken_reciprocal_backlinks);
     size_t do_set_link(size_t col_ndx, size_t row_ndx, size_t target_row_ndx);
     template <class ColType, class T>
-    size_t do_find_unique(ColType& col, size_t ndx, T&& value);
+    size_t do_find_unique(ColType& col, size_t ndx, T&& value, bool& conflict);
     template <class ColType>
-    size_t do_set_unique_null(ColType& col, size_t ndx);
+    size_t do_set_unique_null(ColType& col, size_t ndx, bool& conflict);
     template <class ColType, class T>
-    size_t do_set_unique(ColType& column, size_t row_ndx, T&& value);
+    size_t do_set_unique(ColType& column, size_t row_ndx, T&& value, bool& conflict);
 
     void upgrade_file_format(size_t target_file_format_version);
 

--- a/src/realm/table.hpp
+++ b/src/realm/table.hpp
@@ -398,7 +398,7 @@ public:
     /// \sa Table::set_int_unique()
     /// \sa Table::set_string_unique()
     /// \sa Table::set_null_unique()
-    void change_link_targets(size_t row_ndx, size_t new_row_ndx);
+    void merge_rows(size_t row_ndx, size_t new_row_ndx);
 
     // Get cell values. Will assert if the requested type does not match the column type
     int64_t get_int(size_t column_ndx, size_t row_ndx) const noexcept;
@@ -448,7 +448,7 @@ public:
     /// are intended to be used in the implementation of primary key support. They
     /// check if the given column already contains one or more values that are
     /// equal to \a value, and if there are conflicts, it calls
-    /// Table::change_link_targets() for the row_ndx to be replaced by the
+    /// Table::merge_rows() for the row_ndx to be replaced by the
     /// existing row, followed by a Table::move_last_over() of row_ndx. The
     /// return value is always a row index of a row that contains \a value in
     /// the specified column, possibly different from \a row_ndx if a conflict
@@ -952,7 +952,7 @@ private:
     void do_remove(size_t row_ndx, bool broken_reciprocal_backlinks);
     void do_move_last_over(size_t row_ndx, bool broken_reciprocal_backlinks);
     void do_swap_rows(size_t row_ndx_1, size_t row_ndx_2);
-    void do_change_link_targets(size_t row_ndx, size_t new_row_ndx);
+    void do_merge_rows(size_t row_ndx, size_t new_row_ndx);
     void do_clear(bool broken_reciprocal_backlinks);
     size_t do_set_link(size_t col_ndx, size_t row_ndx, size_t target_row_ndx);
     template <class ColType, class T>
@@ -1321,7 +1321,7 @@ private:
     void adj_acc_insert_rows(size_t row_ndx, size_t num_rows) noexcept;
     void adj_acc_erase_row(size_t row_ndx) noexcept;
     void adj_acc_swap_rows(size_t row_ndx_1, size_t row_ndx_2) noexcept;
-    void adj_acc_subsume_row(size_t old_row_ndx, size_t new_row_ndx) noexcept;
+    void adj_acc_merge_rows(size_t old_row_ndx, size_t new_row_ndx) noexcept;
 
     /// Adjust this table accessor and its subordinates after move_last_over()
     /// (or its inverse).
@@ -1361,7 +1361,7 @@ private:
     void adj_row_acc_insert_rows(size_t row_ndx, size_t num_rows) noexcept;
     void adj_row_acc_erase_row(size_t row_ndx) noexcept;
     void adj_row_acc_swap_rows(size_t row_ndx_1, size_t row_ndx_2) noexcept;
-    void adj_row_acc_subsume_row(size_t old_row_ndx, size_t new_row_ndx) noexcept;
+    void adj_row_acc_merge_rows(size_t old_row_ndx, size_t new_row_ndx) noexcept;
 
     /// Called by adj_acc_move_over() to adjust row accessors.
     void adj_row_acc_move_over(size_t from_row_ndx, size_t to_row_ndx) noexcept;
@@ -2191,9 +2191,9 @@ public:
         table.do_swap_rows(row_ndx_1, row_ndx_2); // Throws
     }
 
-    static void do_change_link_targets(Table& table, size_t row_ndx, size_t new_row_ndx)
+    static void do_merge_rows(Table& table, size_t row_ndx, size_t new_row_ndx)
     {
-        table.do_change_link_targets(row_ndx, new_row_ndx); // Throws
+        table.do_merge_rows(row_ndx, new_row_ndx); // Throws
     }
 
     static void do_clear(Table& table)
@@ -2299,9 +2299,9 @@ public:
         table.adj_acc_swap_rows(row_ndx_1, row_ndx_2);
     }
 
-    static void adj_acc_subsume_row(Table& table, size_t row_ndx_1, size_t row_ndx_2) noexcept
+    static void adj_acc_merge_rows(Table& table, size_t row_ndx_1, size_t row_ndx_2) noexcept
     {
-        table.adj_acc_subsume_row(row_ndx_1, row_ndx_2);
+        table.adj_acc_merge_rows(row_ndx_1, row_ndx_2);
     }
 
     static void adj_acc_move_over(Table& table, size_t from_row_ndx, size_t to_row_ndx) noexcept

--- a/test/test_lang_bind_helper.cpp
+++ b/test/test_lang_bind_helper.cpp
@@ -3508,8 +3508,8 @@ TEST(LangBindHelper_AdvanceReadTransact_ChangeLinkTargets)
         WriteTransaction wt(sg_w);
         TableRef t0 = wt.get_table("t0");
         TableRef t1 = wt.get_table("t1");
-        t0->change_link_targets(0, 2);
-        t1->change_link_targets(0, 2);
+        t0->merge_rows(0, 2);
+        t1->merge_rows(0, 2);
         wt.commit();
     }
 
@@ -7743,7 +7743,7 @@ public:
     {
         return false;
     }
-    bool change_link_targets(size_t, size_t)
+    bool merge_rows(size_t, size_t)
     {
         return false;
     }
@@ -9533,7 +9533,7 @@ TEST(LangBindHelper_ImplicitTransactions_UpdateAccessorsOnChangeLinkTargets)
 
     // Check that row accessors are detached.
     LangBindHelper::promote_to_write(sg);
-    t0->change_link_targets(0, 9);
+    t0->merge_rows(0, 9);
     LangBindHelper::commit_and_continue_as_read(sg);
 
     CHECK(r.is_attached());
@@ -9545,7 +9545,7 @@ TEST(LangBindHelper_ImplicitTransactions_UpdateAccessorsOnChangeLinkTargets)
     TableRef mt0 = t1->get_subtable(3, 0);
     CHECK_EQUAL(l0->get_origin_row_index(), 0);
     LangBindHelper::promote_to_write(sg);
-    t1->change_link_targets(0, 9);
+    t1->merge_rows(0, 9);
     LangBindHelper::commit_and_continue_as_read(sg);
 
     CHECK(l0->is_attached());

--- a/test/test_replication.cpp
+++ b/test/test_replication.cpp
@@ -3527,9 +3527,9 @@ TEST(Replication_RenameGroupLevelTable_MoveGroupLevelTable_RenameColumn_MoveColu
 }
 
 
-TEST(Replication_ChangeLinkTargets)
+TEST(Replication_MergeRows)
 {
-    // Test that ChangeLinkTargets has the same effect whether called directly
+    // Test that MergeRows has the same effect whether called directly
     // or applied via TransactLogApplier.
 
     SHARED_GROUP_TEST_PATH(path_1);
@@ -3550,7 +3550,7 @@ TEST(Replication_ChangeLinkTargets)
         t0->add_empty_row(2);
         t1->add_empty_row(2);
         t1->set_link(0, 0, 0);
-        t0->change_link_targets(0, 1);
+        t0->merge_rows(0, 1);
         wt.commit();
     }
     repl.replay_transacts(sg_2, replay_logger);

--- a/test/test_table.cpp
+++ b/test/test_table.cpp
@@ -1662,7 +1662,7 @@ TEST(Table_SetUniqueLoserAccessorUpdates)
 }
 
 
-TEST(Table_AccessorsUpdateAfterChangeLinkTargets)
+TEST(Table_AccessorsUpdateAfterMergeRows)
 {
     Group g;
     TableRef origin = g.add_table("origin");
@@ -1685,7 +1685,7 @@ TEST(Table_AccessorsUpdateAfterChangeLinkTargets)
     CHECK_EQUAL(row_0.get_index(), 0);
     CHECK_EQUAL(row_1.get_index(), 1);
 
-    origin->change_link_targets(1, 2);
+    origin->merge_rows(1, 2);
 
     CHECK(row_0.is_attached());
     CHECK(row_1.is_attached());
@@ -6876,7 +6876,7 @@ TEST(Table_MixedCrashValues)
 }
 
 
-TEST(Table_ChangeLinkTargets_Links)
+TEST(Table_MergeRows_Links)
 {
     Group g;
 
@@ -6893,14 +6893,14 @@ TEST(Table_ChangeLinkTargets_Links)
 
     Row replaced_row = t1->get(0);
     CHECK_EQUAL(t1->get_backlink_count(0, *t0, 0), 1);
-    t1->change_link_targets(0, 9);
+    t1->merge_rows(0, 9);
     CHECK(replaced_row.is_attached());
     CHECK_EQUAL(t0->get_link(0, 0), 9);
     CHECK_EQUAL(t1->get_backlink_count(0, *t0, 0), 0);
 }
 
 
-TEST(Table_ChangeLinkTargets_LinkLists)
+TEST(Table_MergeRows_LinkLists)
 {
     Group g;
 
@@ -6919,7 +6919,7 @@ TEST(Table_ChangeLinkTargets_LinkLists)
 
     Row replaced_row = t1->get(0);
     CHECK_EQUAL(t1->get_backlink_count(0, *t0, 0), 2);
-    t1->change_link_targets(0, 9);
+    t1->merge_rows(0, 9);
     CHECK(replaced_row.is_attached());
     CHECK_EQUAL(t1->get_backlink_count(0, *t0, 0), 0);
     CHECK_EQUAL(t0->get_linklist(0, 0)->size(), 2);
@@ -7084,7 +7084,7 @@ TEST(Table_DetachedAccessor)
     CHECK_LOGIC_ERROR(table->clear(), LogicError::detached_accessor);
     CHECK_LOGIC_ERROR(table->add_search_index(0), LogicError::detached_accessor);
     CHECK_LOGIC_ERROR(table->remove_search_index(0), LogicError::detached_accessor);
-    CHECK_LOGIC_ERROR(table->change_link_targets(0, 1), LogicError::detached_accessor);
+    CHECK_LOGIC_ERROR(table->merge_rows(0, 1), LogicError::detached_accessor);
     CHECK_LOGIC_ERROR(table->swap_rows(0, 1), LogicError::detached_accessor);
     CHECK_LOGIC_ERROR(table->set_string(1, 0, ""), LogicError::detached_accessor);
     CHECK_LOGIC_ERROR(table->set_string_unique(1, 0, ""), LogicError::detached_accessor);

--- a/test/test_table.cpp
+++ b/test/test_table.cpp
@@ -6884,18 +6884,19 @@ TEST(Table_MergeRows_Links)
     TableRef t1 = g.add_table("t1");
     t0->add_column_link(type_Link, "link", *t1);
     t1->add_column(type_Int, "int");
-    t0->add_empty_row(10);
-    t1->add_empty_row(10);
-    for (int i = 0; i < 10; ++i) {
+    t0->add_empty_row(2);
+    t1->add_empty_row(2);
+    for (int i = 0; i < 2; ++i) {
         t0->set_link(0, i, i);
         t1->set_int(0, i, i);
     }
+    t1->add_empty_row();
 
     Row replaced_row = t1->get(0);
     CHECK_EQUAL(t1->get_backlink_count(0, *t0, 0), 1);
-    t1->merge_rows(0, 9);
+    t1->merge_rows(0, 2);
     CHECK(replaced_row.is_attached());
-    CHECK_EQUAL(t0->get_link(0, 0), 9);
+    CHECK_EQUAL(t0->get_link(0, 0), 2);
     CHECK_EQUAL(t1->get_backlink_count(0, *t0, 0), 0);
 }
 
@@ -6916,18 +6917,19 @@ TEST(Table_MergeRows_LinkLists)
         links->add((i + 1) % 10);
         t1->set_int(0, i, i);
     }
+    t1->add_empty_row();
 
     Row replaced_row = t1->get(0);
     CHECK_EQUAL(t1->get_backlink_count(0, *t0, 0), 2);
-    t1->merge_rows(0, 9);
+    t1->merge_rows(0, 10);
     CHECK(replaced_row.is_attached());
     CHECK_EQUAL(t1->get_backlink_count(0, *t0, 0), 0);
     CHECK_EQUAL(t0->get_linklist(0, 0)->size(), 2);
-    CHECK_EQUAL(t0->get_linklist(0, 0)->get(0).get_index(), 9);
+    CHECK_EQUAL(t0->get_linklist(0, 0)->get(0).get_index(), 10);
     CHECK_EQUAL(t0->get_linklist(0, 0)->get(1).get_index(), 1);
     CHECK_EQUAL(t0->get_linklist(0, 9)->size(), 2);
     CHECK_EQUAL(t0->get_linklist(0, 9)->get(0).get_index(), 9);
-    CHECK_EQUAL(t0->get_linklist(0, 9)->get(1).get_index(), 9);
+    CHECK_EQUAL(t0->get_linklist(0, 9)->get(1).get_index(), 10);
 }
 
 // Minimal test case causing an assertion error because


### PR DESCRIPTION
This changes the following:

- The misnomer `ChangeLinkTargets` is renamed to something that properly describes its purpose, even if the implementation can only live up to its promises under very particular circumstances.
- The behavior of `MergeRows` is simplified to be equivalent of `SwapRows` on the storage layer (but accessors are still updated through a separate mechanism, `adj_acc_merge_rows`).
- `SetUnique` instructions with local conflicts (which never happen in real life due to PK conflict detection) do not generate extra instructions.

**NOTE:** Due to the rename, this is an API-breaking change.