### PR TITLE
Deprecate Array type parameters in Column<T> and BpTree<T> constructors

### DIFF
--- a/src/realm/bptree.hpp
+++ b/src/realm/bptree.hpp
@@ -249,7 +249,7 @@ public:
     BpTree();
     explicit BpTree(BpTreeBase::unattached_tag);
     explicit BpTree(Allocator& alloc);
-    [[deprecated("Initialize with ref instead")]] explicit BpTree(std::unique_ptr<Array> init_root)
+    REALM_DEPRECATED("Initialize with ref instead") explicit BpTree(std::unique_ptr<Array> init_root)
         : BpTreeBase(std::move(init_root))
     {
 

--- a/src/realm/column.hpp
+++ b/src/realm/column.hpp
@@ -532,7 +532,7 @@ public:
         , m_tree(Allocator::get_default())
     {
     }
-    explicit Column(std::unique_ptr<Array> root) noexcept;
+    [[deprecated]] explicit Column(std::unique_ptr<Array> root) noexcept;
     Column(Allocator&, ref_type, size_t column_ndx = npos);
     Column(unattached_root_tag, Allocator&);
     Column(Column&&) noexcept = default;
@@ -1140,12 +1140,6 @@ Column<T>::Column(unattached_root_tag, Allocator& alloc)
 }
 
 template <class T>
-Column<T>::Column(std::unique_ptr<Array> root) noexcept
-    : m_tree(std::move(root))
-{
-}
-
-template <class T>
 Column<T>::~Column() noexcept
 {
 }
@@ -1570,8 +1564,7 @@ public:
     }
     ref_type create_leaf(size_t size) override
     {
-        MemRef mem = BpTree<T>::create_leaf(m_leaf_type, size, m_value, m_alloc); // Throws
-        return mem.get_ref();
+        return BpTree<T>::create_leaf(m_leaf_type, size, m_value, m_alloc); // Throws
     }
 
 private:

--- a/src/realm/column.hpp
+++ b/src/realm/column.hpp
@@ -532,7 +532,7 @@ public:
         , m_tree(Allocator::get_default())
     {
     }
-    [[deprecated]] explicit Column(std::unique_ptr<Array> root) noexcept;
+    REALM_DEPRECATED("Initialize with ref instead") explicit Column(std::unique_ptr<Array> root) noexcept;
     Column(Allocator&, ref_type, size_t column_ndx = npos);
     Column(unattached_root_tag, Allocator&);
     Column(Column&&) noexcept = default;
@@ -1564,7 +1564,8 @@ public:
     }
     ref_type create_leaf(size_t size) override
     {
-        return BpTree<T>::create_leaf(m_leaf_type, size, m_value, m_alloc); // Throws
+        ref_type ref = BpTree<T>::create_leaf(m_leaf_type, size, m_value, m_alloc); // Throws
+        return ref;
     }
 
 private:

--- a/src/realm/column_timestamp.cpp
+++ b/src/realm/column_timestamp.cpp
@@ -61,7 +61,8 @@ public:
 
     ref_type create_leaf(size_t size) override
     {
-        return BT::create_leaf(Array::type_Normal, size, m_value, m_alloc); // Throws
+        ref_type ref =  BT::create_leaf(Array::type_Normal, size, m_value, m_alloc); // Throws
+        return ref;
     }
 
 private:

--- a/src/realm/column_timestamp.cpp
+++ b/src/realm/column_timestamp.cpp
@@ -61,8 +61,7 @@ public:
 
     ref_type create_leaf(size_t size) override
     {
-        MemRef mem = BT::create_leaf(Array::type_Normal, size, m_value, m_alloc); // Throws
-        return mem.get_ref();
+        return BT::create_leaf(Array::type_Normal, size, m_value, m_alloc); // Throws
     }
 
 private:

--- a/src/realm/util/features.h
+++ b/src/realm/util/features.h
@@ -155,6 +155,14 @@
 #define REALM_UNUSED
 #endif
 
+/* The way to specify that a function is deprecated
+ * not be used. Use it to suppress a warning from the compiler. */
+#if __GNUC__
+#define REALM_DEPRECATED(x) [[deprecated(x)]]
+#else
+#define REALM_DEPRECATED(x) __declspec(deprecated(x))
+#endif
+
 
 #if __GNUC__ || defined __INTEL_COMPILER
 #define REALM_UNLIKELY(expr) __builtin_expect(!!(expr), 0)


### PR DESCRIPTION
Exposing Array type through the public interface is exposing the
implementation. We might not use Array as the fundamental BpTree
building block forever.

If you use the deprecated function, you can instead do like this:

```
ref_type ref = BpTree<int>::create_leaf(Array::type_Normal, 0, 0, alloc);
_impl::DeepArrayRefDestroyGuard dg_2(ref, alloc);
auto bp_tree = std::make_unique<BpTree<int>>(alloc, ref); // Throws
bp_tree->set_parent(...);
bp_tree->root().update_parent(); // Throws
dg_2.release(); // Ownership transferred
```

@kspangsege This could solve the problem we discussed yesterday
@finnschiermer 
