### PR TITLE
Fix initialisation of nullable float columns

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,8 @@
 
 ### Bugfixes
 
-* Lorem ipsum.
+* When adding a nullable column of type Float while other columns existed
+  already, the values of the new column would be non-null. This is now fixed.
 
 ### Breaking changes
 

--- a/src/realm/null.hpp
+++ b/src/realm/null.hpp
@@ -122,7 +122,7 @@ struct null {
         int64_t double_nan = 0x7ff80000000000aa;
         i = std::is_same<T, float>::value ? 0x7fc000aa : static_cast<decltype(i)>(double_nan);
         T d = type_punning<T, decltype(i)>(i);
-        REALM_ASSERT_DEBUG(std::isnan(static_cast<double>(d)));
+        REALM_ASSERT_DEBUG(std::isnan(d));
         REALM_ASSERT_DEBUG(!is_signaling(d));
         return d;
     }

--- a/src/realm/table.cpp
+++ b/src/realm/table.cpp
@@ -2055,7 +2055,7 @@ ref_type Table::create_column(ColumnType col_type, size_t size, bool nullable, A
         case col_type_Timestamp:
             return TimestampColumn::create(alloc, size, nullable); // Throws
         case col_type_Float: {
-            float default_value = nullable ? null::get_null_float<Float>() : 0.0;
+            float default_value = nullable ? null::get_null_float<Float>() : 0.0f;
             return FloatColumn::create(alloc, Array::type_Normal, size, default_value); // Throws
         }
         case col_type_Double: {

--- a/src/realm/table.cpp
+++ b/src/realm/table.cpp
@@ -2054,12 +2054,14 @@ ref_type Table::create_column(ColumnType col_type, size_t size, bool nullable, A
             }
         case col_type_Timestamp:
             return TimestampColumn::create(alloc, size, nullable); // Throws
-        case col_type_Float:
-            return FloatColumn::create(alloc, Array::type_Normal, size,
-                                       nullable ? null::get_null_float<Float>() : 0.0); // Throws
-        case col_type_Double:
-            return DoubleColumn::create(alloc, Array::type_Normal, size,
-                                        nullable ? null::get_null_float<Double>() : 0.0); // Throws
+        case col_type_Float: {
+            float default_value = nullable ? null::get_null_float<Float>() : 0.0;
+            return FloatColumn::create(alloc, Array::type_Normal, size, default_value); // Throws
+        }
+        case col_type_Double: {
+            double default_value = nullable ? null::get_null_float<Double>() : 0.0;
+            return DoubleColumn::create(alloc, Array::type_Normal, size, default_value); // Throws
+        }
         case col_type_String:
             return StringColumn::create(alloc, size); // Throws
         case col_type_Binary:

--- a/src/realm/table.cpp
+++ b/src/realm/table.cpp
@@ -2055,6 +2055,9 @@ ref_type Table::create_column(ColumnType col_type, size_t size, bool nullable, A
         case col_type_Timestamp:
             return TimestampColumn::create(alloc, size, nullable); // Throws
         case col_type_Float: {
+            // NOTE: It's very important that 0.0f has the "f" suffix, else the expression will
+            // turn into a double and back to float and lose its null-bits on iOS! Dangerous
+            // bugs because the bits will be preserved on many other platform and go undetected
             float default_value = nullable ? null::get_null_float<Float>() : 0.0f;
             return FloatColumn::create(alloc, Array::type_Normal, size, default_value); // Throws
         }

--- a/test/test_column_float.cpp
+++ b/test/test_column_float.cpp
@@ -510,8 +510,8 @@ TEST_TYPES(DoubleFloatColumn_InitOfEmptyColumnNullable, std::true_type, std::fal
     Table t;
     t.add_column(type_Int, "unused");
     t.add_empty_row();
-    t.add_column(type_Double, "f", nullable_toggle);
-    t.add_column(type_Float, "d", nullable_toggle);
+    t.add_column(type_Double, "d", nullable_toggle);
+    t.add_column(type_Float, "f", nullable_toggle);
     CHECK(t.is_null(1, 0) == nullable_toggle);
     CHECK(t.is_null(2, 0) == nullable_toggle);
     if (nullable_toggle) {

--- a/test/test_column_float.cpp
+++ b/test/test_column_float.cpp
@@ -514,6 +514,12 @@ TEST_TYPES(DoubleFloatColumn_InitOfEmptyColumnNullable, std::true_type, std::fal
     t.add_column(type_Float, "d", nullable_toggle);
     CHECK(t.is_null(1, 0) == nullable_toggle);
     CHECK(t.is_null(2, 0) == nullable_toggle);
+    if (nullable_toggle) {
+        t.set_null(1, 0);
+        t.set_null(2, 0);
+        CHECK(t.is_null(1, 0));
+        CHECK(t.is_null(2, 0));
+    }
 }
 
 TEST(FloatColumn_InitOfEmptyColumn)


### PR DESCRIPTION
`DoubleFloatColumn_InitOfEmptyColumnNullable` failed for nullable float columns (`test_column_float.cpp:516`) on both 32- and 64-bit _devices_ (iPhone 5 and iPhone 6s Plus). Unintentional promotion to double and back modified our NaN's bit pattern.

Extracted from #2245.

@rrrlasse @ironage Please review.