### PR TITLE
Fix dotnet-cocoa upload

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -210,7 +210,7 @@ def doBuildDotNetOsx(def isPublishingRun) {
       } finally {
         collectCompilerWarnings('clang')
         withCredentials([[$class: 'FileBinding', credentialsId: 'c0cc8f9e-c3f1-4e22-b22f-6568392e26ae', variable: 's3cfg_config_file']]) {
-          sh 's3cmd -c $s3cfg_config_file put realm-core-dotnet-cocoa-latest.tar.bz2 s3://static.realm.io/downloads/core'
+          sh 's3cmd -c $s3cfg_config_file put --multipart-chunk-size-mb 5 realm-core-dotnet-cocoa-latest.tar.bz2 s3://static.realm.io/downloads/core'
         }
       }
     }
@@ -292,7 +292,7 @@ def doBuildNodeInDocker(def isPublishingRun) {
   return {
     node('docker') {
       getArchive()
-      
+
       def buildEnv = buildDockerEnv('ci/realm-core:snapshot')
       def environment = ['REALM_ENABLE_ENCRYPTION=yes', 'REALM_ENABLE_ASSERTIONS=yes']
       withEnv(environment) {

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -612,7 +612,7 @@ def doPublishGeneric() {
 def doPublishLocalArtifacts() {
   // TODO create a Dockerfile for an image only containing s3cmd
   return {
-    node('dk01') {
+    node('aws') {
       unstash 'cocoa-package'
       unstash 'dotnet-package'
       unstash 'node-linux-package'


### PR DESCRIPTION
@ironage @danielpovlsen 

This should at least fix the fails for the PRs. Looks like a bug in s3cmd.
@emanuelez Not sure if we should do the same at the publish step, the android and cocoa tar balls are pretty big, this would slow down the process a lot.

```
Downloads s3cmd put realm-core-dotnet-cocoa-test.tar.bz2 s3://static.realm.io/downloads/core
upload: 'realm-core-dotnet-cocoa-test.tar.bz2' -> 's3://static.realm.io/downloads/core'  [1 of 1]
  5308416 of 11602593    45% in    3s  1591.92 kB/s  failed
WARNING: Upload failed: /downloads/core ([Errno 32] Broken pipe)
WARNING: Retrying on lower speed (throttle=0.00)
WARNING: Waiting 3 sec...
upload: 'realm-core-dotnet-cocoa-test.tar.bz2' -> 's3://static.realm.io/downloads/core'  [1 of 1]
  8781824 of 11602593    75% in    2s     3.05 MB/s  failed
WARNING: Upload failed: /downloads/core ([Errno 32] Broken pipe)
WARNING: Retrying on lower speed (throttle=0.01)
WARNING: Waiting 6 sec...
upload: 'realm-core-dotnet-cocoa-test.tar.bz2' -> 's3://static.realm.io/downloads/core'  [1 of 1]
  7798784 of 11602593    67% in    3s     2.33 MB/s  failed
WARNING: Upload failed: /downloads/core ([Errno 32] Broken pipe)
WARNING: Retrying on lower speed (throttle=0.05)
WARNING: Waiting 9 sec...
^CSee ya!

# Now it works !!!!

➜  Downloads s3cmd put --multipart-chunk-size-mb 5 realm-core-dotnet-cocoa-test.tar.bz2 s3://static.realm.io/downloads/core
upload: 'realm-core-dotnet-cocoa-test.tar.bz2' -> 's3://static.realm.io/downloads/core'  [part 1 of 3, 5MB] [1 of 1]
 5242880 of 5242880   100% in    2s  1845.54 kB/s  done
upload: 'realm-core-dotnet-cocoa-test.tar.bz2' -> 's3://static.realm.io/downloads/core'  [part 2 of 3, 5MB] [1 of 1]
 5242880 of 5242880   100% in    4s  1131.37 kB/s  done
upload: 'realm-core-dotnet-cocoa-test.tar.bz2' -> 's3://static.realm.io/downloads/core'  [part 3 of 3, 1090kB] [1 of 1]
 1116833 of 1116833   100% in    1s   900.51 kB/s  done

# Still does not work without changing the chunk size

➜  Downloads s3cmd put realm-core-dotnet-cocoa-test.tar.bz2 s3://static.realm.io/downloads/core                            
upload: 'realm-core-dotnet-cocoa-test.tar.bz2' -> 's3://static.realm.io/downloads/core'  [1 of 1]
  5570560 of 11602593    48% in    3s  1727.10 kB/s  failed
WARNING: Upload failed: /downloads/core ([Errno 32] Broken pipe)
WARNING: Retrying on lower speed (throttle=0.00)
WARNING: Waiting 3 sec...
upload: 'realm-core-dotnet-cocoa-test.tar.bz2' -> 's3://static.realm.io/downloads/core'  [1 of 1]
  4653056 of 11602593    40% in    4s  1073.56 kB/s  failed
WARNING: Upload failed: /downloads/core ([Errno 32] Broken pipe)
WARNING: Retrying on lower speed (throttle=0.01)
WARNING: Waiting 6 sec...
^CSee ya!
```