### PR TITLE
.realm file checksum

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,9 +2,7 @@
 
 ### Bugfixes
 
-* Fixed a race between destruction of a global mutex as part of main thread exit
-  and attempt to lock it on a background thread, or conversely attempt to lock a
-  mutex after it has been destroyed. (PR #2238, fixes issues #2238, #2137, #2009)
+* Lorem ipsum.
 
 ### Breaking changes
 

--- a/Visual Studio/Realm.vcxproj
+++ b/Visual Studio/Realm.vcxproj
@@ -70,7 +70,7 @@
     <ConfigurationType>Application</ConfigurationType>
     <CharacterSet>Unicode</CharacterSet>
     <WholeProgramOptimization>false</WholeProgramOptimization>
-    <PlatformToolset>v120</PlatformToolset>
+    <PlatformToolset>v140</PlatformToolset>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='csv importer|Win32'" Label="Configuration">
     <ConfigurationType>Application</ConfigurationType>

--- a/src/realm/alloc.hpp
+++ b/src/realm/alloc.hpp
@@ -27,6 +27,8 @@
 #include <realm/util/terminate.hpp>
 #include <realm/util/assert.hpp>
 #include <realm/util/safe_int_ops.hpp>
+#include <realm/util/file.hpp>
+
 
 namespace realm {
 
@@ -123,6 +125,11 @@ public:
 
     virtual void verify() const = 0;
 
+    virtual void update_checksum() { return; }
+    virtual void invalidate_checksum() { return; }
+    virtual bool verify_checksum() { return true; }
+
+
 #ifdef REALM_DEBUG
     /// Terminate the program precisely when the specified 'ref' is
     /// freed (or reallocated). You can use this to detect whether the
@@ -208,6 +215,8 @@ public:
     /// Group::get_target_file_format_version_for_session(), and the file format
     /// upgrade logic in Group::upgrade_file_format().
     int get_file_format_version() const noexcept;
+
+    util::File get_file() const { return util::File(); }
 
 protected:
     size_t m_baseline = 0; // Separation line between immutable and mutable refs.

--- a/src/realm/alloc.hpp
+++ b/src/realm/alloc.hpp
@@ -127,7 +127,7 @@ public:
 
     virtual void update_checksum() { return; }
     virtual void invalidate_checksum() { return; }
-    virtual bool verify_checksum() { return true; }
+    virtual bool verify_checksum() noexcept { return true; }
 
 
 #ifdef REALM_DEBUG

--- a/src/realm/alloc_slab.cpp
+++ b/src/realm/alloc_slab.cpp
@@ -1252,7 +1252,7 @@ bool SlabAlloc::verify_checksum()
     try {
         // map() can fail if non-Realm process shortens the file size between get_size() and map(). We then
         // return false which means checksum error
-        map = (char*)get_file().map(File::access_ReadWrite, checksum_offset + 1);
+        map = static_cast<char*>(get_file().map(File::access_ReadWrite, checksum_offset + 1));
     }
     catch (...) {
         return false;

--- a/src/realm/alloc_slab.cpp
+++ b/src/realm/alloc_slab.cpp
@@ -1174,7 +1174,7 @@ char SlabAlloc::compute_checksum()
 
     try {
         // map() can fail if non-Realm process shortens the file size between get_size() and map()
-        map = (char*)get_file().map(File::access_ReadWrite, fsiz - aligned_tail_offset, 0, aligned_tail_offset);
+        map = static_cast<char*>(get_file().map(File::access_ReadWrite, fsiz - aligned_tail_offset, 0, aligned_tail_offset));
     }
     catch (...) {
         return ignore_checksum;
@@ -1194,7 +1194,7 @@ char SlabAlloc::compute_checksum()
 
     try {
         // map() can fail if non-Realm process shortens the file size between get_size() and map()
-        map = (char*)get_file().map(File::access_ReadWrite, head_size);
+        map = static_cast<char*>(get_file().map(File::access_ReadWrite, head_size));
     }
     catch (...) {
         return ignore_checksum;
@@ -1221,7 +1221,7 @@ void SlabAlloc::update_checksum()
     if (!get_file().is_attached())
         return;
 
-    char* map = (char*)get_file().map(File::access_ReadWrite, checksum_offset + 1);
+    char* map = static_cast<char*>(get_file().map(File::access_ReadWrite, checksum_offset + 1));
     char c = compute_checksum();
     reinterpret_cast<Header*>(map)->m_checksum = c;
     get_file().unmap(map, checksum_offset + 1);
@@ -1232,7 +1232,7 @@ void SlabAlloc::invalidate_checksum()
     if (!get_file().is_attached())
         return;
 
-    char* p = (char*)get_file().map(File::access_ReadWrite, checksum_offset + 1);
+    char* p = static_cast<char*>(get_file().map(File::access_ReadWrite, checksum_offset + 1));
     reinterpret_cast<Header*>(p)->m_checksum = ignore_checksum;
     get_file().unmap(p, checksum_offset + 1);
 }

--- a/src/realm/alloc_slab.cpp
+++ b/src/realm/alloc_slab.cpp
@@ -1158,7 +1158,7 @@ void SlabAlloc::set_file_format_version(int file_format_version) noexcept
 }
 
 // Meant to be noexcept (called inside our assert macro)
-char SlabAlloc::compute_checksum()
+char SlabAlloc::compute_checksum() noexcept
 {
     // Compute checksum of first 128 bytes + last 128 bytes, such that summed areas will
     // *not* overlap if file is too short
@@ -1237,11 +1237,11 @@ void SlabAlloc::invalidate_checksum()
     get_file().unmap(p, checksum_offset + 1);
 }
 
-// Meant to be noexcept (called from our assert macro). If another thread is inside commit(), we have a .realm 
+// Must be noexcept because it's called inside our assert. If another thread is inside commit(), we have a .realm 
 // file which may be inconsistent because it's only written partly to disk. We attempt to detect this by
 // making commit() write a flag that indicates that it's currently busy, so any checksum verification should
 // be skipped.
-bool SlabAlloc::verify_checksum()
+bool SlabAlloc::verify_checksum() noexcept
 {
     if (!get_file().is_attached())
         return true;

--- a/src/realm/alloc_slab.hpp
+++ b/src/realm/alloc_slab.hpp
@@ -317,7 +317,7 @@ public:
     
     // Compute checksum of .realm file and compare with the value in its
     // header
-    bool verify_checksum() override;
+    bool verify_checksum() noexcept override;
 
     void verify() const override;
 
@@ -387,7 +387,7 @@ private:
         uint64_t m_magic_cookie;
     };
 
-    char compute_checksum();
+    char compute_checksum() noexcept;
 
     static_assert(sizeof(Header) == 24, "Bad header size");
     static_assert(sizeof(StreamingFooter) == 16, "Bad footer size");

--- a/src/realm/alloc_slab.hpp
+++ b/src/realm/alloc_slab.hpp
@@ -28,6 +28,7 @@
 #include <realm/util/file.hpp>
 #include <realm/alloc.hpp>
 #include <realm/disable_sync_to_disk.hpp>
+#include <realm/utilities.hpp>
 
 namespace realm {
 
@@ -307,7 +308,19 @@ public:
     /// \sa get_file_format_version()
     void set_file_format_version(int) noexcept;
 
+    // Compute checksum of .realm file and write it to its header
+    void update_checksum() override;
+    
+    // Call while modifying the file during commit() when pages are written.
+    // This will make verify_checksum() a no-op.
+    void invalidate_checksum() override;
+    
+    // Compute checksum of .realm file and compare with the value in its
+    // header
+    bool verify_checksum() override;
+
     void verify() const override;
+
 #ifdef REALM_DEBUG
     void enable_debug(bool enable)
     {
@@ -317,6 +330,8 @@ public:
     void print() const;
 #endif
     struct MappedFile;
+
+    static const char ignore_checksum = '*';
 
 protected:
     MemRef do_alloc(const size_t size) override;
@@ -361,7 +376,7 @@ private:
         // Info-block 8-bytes
         uint8_t m_mnemonic[4];    // "T-DB"
         uint8_t m_file_format[2]; // See `library_file_format`
-        uint8_t m_reserved;
+        uint8_t m_checksum;
         // bit 0 of m_flags is used to select between the two top refs.
         uint8_t m_flags;
     };
@@ -372,6 +387,8 @@ private:
         uint64_t m_magic_cookie;
     };
 
+    char compute_checksum();
+
     static_assert(sizeof(Header) == 24, "Bad header size");
     static_assert(sizeof(StreamingFooter) == 16, "Bad footer size");
 
@@ -379,6 +396,7 @@ private:
     static void init_streaming_header(Header*, int file_format_version);
 
     static const uint_fast64_t footer_magic_cookie = 0x3034125237E526C8ULL;
+    static const size_t checksum_offset = offsetof(Header, m_checksum);
 
     // The mappings are shared, if they are from a file
     std::shared_ptr<MappedFile> m_file_mappings;

--- a/src/realm/array.cpp
+++ b/src/realm/array.cpp
@@ -1150,7 +1150,7 @@ int64_t Array::sum(size_t start, size_t end) const
 {
     if (end == size_t(-1))
         end = m_size;
-    REALM_ASSERT_11(start, <, m_size, &&, end, <=, m_size, &&, start, <, end);
+    REALM_ASSERT_EX_CRC(start < m_size && end <= m_size && start < end, start, m_size, end);
 
     if (w == 0)
         return 0;

--- a/src/realm/bptree.cpp
+++ b/src/realm/bptree.cpp
@@ -402,6 +402,7 @@ std::pair<MemRef, size_t> BpTreeNode::get_bptree_leaf(size_t ndx) const noexcept
         bool child_is_leaf = !get_is_inner_bptree_node_from_header(child_header);
         if (child_is_leaf) {
             MemRef mem(child_header, child_ref, m_alloc);
+            REALM_ASSERT_EX_CRC(Array::get_size_from_header(mem.get_addr()) <= REALM_BPARRAY_SIZE, Array::get_size_from_header(mem.get_addr()));
             return std::make_pair(mem, ndx_in_child);
         }
         ndx_2 = ndx_in_child;

--- a/src/realm/bptree.hpp
+++ b/src/realm/bptree.hpp
@@ -475,6 +475,7 @@ inline Array& BpTreeBase::root() noexcept
 inline size_t BpTreeNode::get_bptree_size() const noexcept
 {
     REALM_ASSERT_DEBUG(is_inner_bptree_node());
+    REALM_ASSERT_EX_CRC(Array::size() <= REALM_BPARRAY_SIZE, Array::size());
     int_fast64_t v = back();
     return size_t(v / 2); // v = 1 + 2*total_elems_in_tree
 }
@@ -531,6 +532,7 @@ ref_type BpTreeNode::bptree_append(TreeInsert<TreeTraits>& state)
     // present. Consider this carefully.
 
     REALM_ASSERT_DEBUG(size() >= 1 + 1 + 1); // At least one child
+    REALM_ASSERT_EX_CRC(Array::size() <= REALM_BPARRAY_SIZE, size(), Array::size());
 
     ArrayParent& childs_parent = *this;
     size_t child_ref_ndx = size() - 2;
@@ -672,6 +674,7 @@ std::unique_ptr<Array> BpTree<T>::create_root_from_mem(Allocator& alloc, MemRef 
         leaf->init_from_mem(mem);
         new_root = std::move(leaf);
     }
+    REALM_ASSERT_EX_CRC(new_root.get()->size() <= REALM_BPARRAY_SIZE, new_root.get()->size());
     return new_root;
 }
 
@@ -1150,6 +1153,7 @@ void BpTree<T>::get_leaf(size_t ndx, size_t& ndx_in_leaf, LeafInfo& inout_leaf_i
     std::pair<MemRef, size_t> p = root_as_node().get_bptree_leaf(ndx);
     inout_leaf_info.fallback->init_from_mem(p.first);
     ndx_in_leaf = p.second;
+
     *inout_leaf_info.out_leaf = inout_leaf_info.fallback;
 }
 

--- a/src/realm/group.cpp
+++ b/src/realm/group.cpp
@@ -314,7 +314,7 @@ void Group::attach(ref_type top_ref, bool create_group_when_missing)
         // The 3rd slot in m_top is
         // `RefOrTagged::make_tagged(logical_file_size)`, and the logical file
         // size must never exceed actual file size.
-        REALM_ASSERT_3(m_top.get_as_ref_or_tagged(2).get_as_int(), <=, m_alloc.get_baseline());
+        REALM_ASSERT_EX_CRC(m_top.get_as_ref_or_tagged(2).get_as_int() <= m_alloc.get_baseline(), m_top.get_as_ref_or_tagged(2).get_as_int(), m_alloc.get_baseline());
     }
     else if (create_group_when_missing) {
         create_empty_group(); // Throws

--- a/src/realm/group.hpp
+++ b/src/realm/group.hpp
@@ -425,6 +425,8 @@ public:
     /// this is not the case when working with proper transactions.
     void commit();
 
+    SlabAlloc& get_alloc() { return m_alloc; }
+
     //@{
     /// Some operations on Tables in a Group can cause indirect changes to other
     /// fields, including in other Tables in the same Group. Specifically,

--- a/src/realm/group_shared.cpp
+++ b/src/realm/group_shared.cpp
@@ -1148,6 +1148,9 @@ bool SharedGroup::compact()
         bool disable_sync = get_disable_sync_to_disk();
         if (!disable_sync)
             file.sync(); // Throws
+
+        m_group.get_alloc().update_checksum();
+
 #ifndef _WIN32
         util::File::move(tmp_path, m_db_path);
 #endif
@@ -1597,6 +1600,7 @@ SharedGroup::version_type SharedGroup::commit()
     REALM_ASSERT(m_group.is_attached());
 
     version_type new_version = do_commit(); // Throws
+
     do_end_write();
     do_end_read();
 
@@ -1717,6 +1721,9 @@ Replication::version_type SharedGroup::do_commit()
 
     version_type current_version = r_info->get_current_version_unchecked();
     version_type new_version = current_version + 1;
+
+    m_group.get_alloc().invalidate_checksum();
+
     if (Replication* repl = m_group.get_replication()) {
         // If Replication::prepare_commit() fails, then the entire transaction
         // fails. The application then has the option of terminating the
@@ -1735,6 +1742,9 @@ Replication::version_type SharedGroup::do_commit()
     else {
         low_level_commit(new_version); // Throws
     }
+
+    m_group.get_alloc().update_checksum();
+
     return new_version;
 }
 

--- a/src/realm/group_writer.cpp
+++ b/src/realm/group_writer.cpp
@@ -770,6 +770,7 @@ void GroupWriter::commit(ref_type new_top_ref)
     REALM_ASSERT(!util::int_cast_has_overflow<type_1>(file_format_version));
     file_header.m_top_ref[slot_selector] = new_top_ref;
     file_header.m_file_format[slot_selector] = type_1(file_format_version);
+    file_header.m_checksum = SlabAlloc::ignore_checksum;
 
     // When running the test suite, device synchronization is disabled
     bool disable_sync = get_disable_sync_to_disk();

--- a/src/realm/util/assert.hpp
+++ b/src/realm/util/assert.hpp
@@ -32,8 +32,13 @@
     (REALM_LIKELY(condition) ? static_cast<void>(0)                                                                  \
                              : realm::util::terminate("Assertion failed: " #condition, __FILE__, __LINE__))
 
+#define REALM_ASSERT_RELEASE_CRC(condition)                                                                          \
+    (REALM_LIKELY(condition) ? static_cast<void>(0)                                                                  \
+                             : realm::util::terminate("Assertion failed: " #condition, __FILE__, __LINE__))
+
 #if REALM_ASSERTIONS_ENABLED
 #define REALM_ASSERT(condition) REALM_ASSERT_RELEASE(condition)
+#define REALM_ASSERT_CRC(condition) REALM_ASSERT_RELEASE_CRC(condition)
 #else
 #define REALM_ASSERT(condition) static_cast<void>(sizeof bool(condition))
 #endif
@@ -51,10 +56,19 @@
                              : realm::util::terminate_with_info("Assertion failed: " #condition, __LINE__, __FILE__, \
                                                                 REALM_STRINGIFY((__VA_ARGS__)), __VA_ARGS__))
 
+#define REALM_ASSERT_RELEASE_EX_CRC(condition, ...)                                                                  \
+    (REALM_LIKELY(condition) ? static_cast<void>(0)                                                                  \
+                             : realm::util::terminate_with_info((get_alloc().verify_checksum() ?                     \
+                                ("Assertion failed: " #condition) :                                                  \
+                                ("Realm file may be corrupted by non-Realm code/process: " #condition)),             \
+                            __LINE__, __FILE__, REALM_STRINGIFY((__VA_ARGS__)), __VA_ARGS__))
+
 #ifdef REALM_DEBUG
 #define REALM_ASSERT_DEBUG_EX REALM_ASSERT_RELEASE_EX
+#define REALM_ASSERT_DEBUG_EX_CRC REALM_ASSERT_RELEASE_EX_CRC
 #else
 #define REALM_ASSERT_DEBUG_EX(condition, ...) static_cast<void>(sizeof bool(condition))
+#define REALM_ASSERT_DEBUG_EX_CRC(condition, ...) static_cast<void>(sizeof bool(condition))
 #endif
 
 // Becase the assert is used in noexcept methods, it's a bad idea to allocate
@@ -63,6 +77,7 @@
 #if REALM_ENABLE_ASSERTIONS || defined(REALM_DEBUG)
 
 #define REALM_ASSERT_EX REALM_ASSERT_RELEASE_EX
+#define REALM_ASSERT_EX_CRC REALM_ASSERT_RELEASE_EX_CRC
 
 #define REALM_ASSERT_3(left, cmp, right)                                                                             \
     (REALM_LIKELY((left)cmp(right)) ? static_cast<void>(0)                                                           \
@@ -88,6 +103,7 @@
                                   __FILE__, __LINE__, left1, right1, left2, right2, left3, right3))
 #else
 #define REALM_ASSERT_EX(condition, ...) static_cast<void>(sizeof bool(condition))
+#define REALM_ASSERT_EX_CRC(condition, ...) static_cast<void>(sizeof bool(condition))
 #define REALM_ASSERT_3(left, cmp, right) static_cast<void>(sizeof bool((left)cmp(right)))
 #define REALM_ASSERT_7(left1, cmp1, right1, logical, left2, cmp2, right2)                                            \
     static_cast<void>(sizeof bool(((left1)cmp1(right1))logical((left2)cmp2(right2))))

--- a/src/realm/util/features.h
+++ b/src/realm/util/features.h
@@ -65,6 +65,11 @@
 #define REALM_MAX_BPNODE_SIZE 1000
 #endif
 
+// Maximum size of the basic Array objects which are part of a bptree. The number 
+// includes all "hidden" entries such as the magic value for nullable arrays, meta
+// entries for nodes that are on "compact form", etc. Note that an Array that is
+// *not* part of a bptree can be much larger.
+#define REALM_BPARRAY_SIZE (REALM_MAX_BPNODE_SIZE + 2)
 
 #define REALM_QUOTE_2(x) #x
 #define REALM_QUOTE(x) REALM_QUOTE_2(x)

--- a/src/realm/util/file_mapper.hpp
+++ b/src/realm/util/file_mapper.hpp
@@ -65,7 +65,7 @@ void inline encryption_write_barrier(const void* addr, size_t size, EncryptedFil
 }
 
 
-extern util::Mutex& mapping_mutex;
+extern util::Mutex mapping_mutex;
 
 inline void do_encryption_read_barrier(const void* addr, size_t size, HeaderToSize header_to_size,
                                        EncryptedFileMapping* mapping)

--- a/src/realm/util/thread.hpp
+++ b/src/realm/util/thread.hpp
@@ -103,6 +103,7 @@ public:
 
     struct process_shared_tag {
     };
+
     /// Initialize this mutex for use across multiple processes. When
     /// constructed this way, the instance may be placed in memory
     /// shared by multiple processes, as well as in a memory mapped

--- a/src/realm/utilities.cpp
+++ b/src/realm/utilities.cpp
@@ -21,6 +21,7 @@
 #include <cstdint>
 #include <atomic>
 #include <fstream>
+#include <iostream>
 
 #ifdef _WIN32
 #define NOMINMAX
@@ -74,6 +75,11 @@ signed char avx_support = -1;
 
 StringCompareCallback string_compare_callback = nullptr;
 string_compare_method_t string_compare_method = STRING_COMPARE_CORE;
+
+
+
+
+
 
 void cpuid_init()
 {
@@ -305,6 +311,12 @@ void process_mem_usage(double& vm_usage, double& resident_set)
 #endif
 }
 #endif
+
+
+
+
+
+
 
 } // namespace realm
 

--- a/src/realm/utilities.hpp
+++ b/src/realm/utilities.hpp
@@ -30,9 +30,14 @@
 #include <intrin.h>
 #endif
 
+#include <realm/util/file.hpp>
 #include <realm/util/features.h>
 #include <realm/util/assert.hpp>
 #include <realm/util/safe_int_ops.hpp>
+
+
+using namespace realm::util;
+
 
 // GCC defines __i386__ and __x86_64__
 #if (defined(__X86__) || defined(__i386__) || defined(i386) || defined(_M_IX86) || defined(__386__) ||               \

--- a/test/test_group.cpp
+++ b/test/test_group.cpp
@@ -2190,6 +2190,100 @@ TEST(Group_CascadeNotify_Simple)
     CHECK(called);
 }
 
+/*
+TEST(Group_CRC)
+{
+    GROUP_TEST_PATH(path);
+    
+    char c = 0;
+
+    Group g(path, 0, Group::mode_ReadWrite);
+    TableRef t = g.add_table("target");
+    t->add_column(type_Int, "int");
+    t->add_empty_row(100000);
+
+    realm::util::File file;
+    file.open(path, File::access_ReadWrite, File::create_Never, 0);
+
+    for (size_t i = 0; i < 100000; i++) {
+        // byte sized arrays so we get small arrays and high array "denisty" in the .realm file
+        t.get()->set_int(0, i, 100);
+    }
+
+    g.commit();
+
+    file.seek(22);
+    file.write(&c, 1);
+    file.sync();
+
+
+    for (size_t i = 0; i < 100000; i++) {
+        // byte sized arrays so we get small arrays and high array "denisty" in the .realm file
+        file.seek(fastrand() % 128);
+        c = fastrand();
+        file.write(&c, 1);
+        // Polute start which is contained in crc
+        file.seek(120);
+        file.write(&c, 1);
+        file.sync();
+        t.get()->sum_int(0);
+        std::cerr << ".";
+    }
+
+
+}
+*/
+
+
+
+
+/*
+ONLY(Group_CRC1)
+{
+    GROUP_TEST_PATH(path);
+    std::string tmpfile = std::string(path.c_str()) + ".tmp";
+
+    {
+        Group g(path, 0, Group::mode_ReadWrite);
+        TableRef t = g.add_table("target");
+        t->add_column(type_Int, "int");
+        t->add_empty_row(1000000);
+
+        for (size_t i = 0; i < 1000000; i++) {
+            // byte sized arrays so we get small arrays and high array "denisty" in the .realm file
+            t.get()->set_int(0, i, 100);
+        }
+
+        g.commit();
+    }
+
+
+    auto async = [&]() {
+        for (;;) {
+            std::cerr << "c";
+            util::File::copy(path, tmpfile);
+            std::cerr << "d";
+        }
+    };
+
+    Thread copier;
+    copier.start([=] { async(); });
+
+    millisleep(rand() % 100);
+
+    for (;;) {
+        try {
+            std::cerr << "o";
+            Group g(tmpfile, 0, Group::mode_ReadWrite);
+            std::cerr << g.get_table(0).get()->get_name();
+        }
+        catch (...) {}
+
+    }
+
+}
+*/
+
 
 TEST(Group_CascadeNotify_TableClear)
 {


### PR DESCRIPTION
This PR makes it possible to find out if an assert happens due to a bug in Core or due to file corruption from the outside.

It adds a simple checksum to .realm files (sum of first and last 128 bytes). Must be fast because it's updated after each commit(), so we cannot process the entire file.

If a file is being corrupted by a non-Realm process/code (such as in https://github.com/realm/realm-core/issues/2018), core will assert with a "Realm file may be corrupted by non-Realm code/process" message.

I have first identified the asserts that are most likely to trigger upon various corruption and replaced them by a new assert macro (ends with _CRC) that performs a checksum test of the file. If the checksum mismatches, it adds the above notification text to the original assert message and then terminates like usual.

You may argue that we should not do any work inside an assertion because we're on unstable gound. I've tried not to touch any Realm Core objects and only work on stand-alone File objects. Also, everything is supposed to be noexcept (have not verified that yet, but it's the intention in the final version).

Please give your thoughts and inputs. @realm/core @simonask @teotwaki @kspangsege @danielpovlsen  and whoever
