### PR TITLE
Add array_direct.hpp to installed headers

### DIFF
--- a/src/realm/Makefile
+++ b/src/realm/Makefile
@@ -36,6 +36,7 @@ utilities.hpp \
 alloc.hpp \
 alloc_slab.hpp \
 array.hpp \
+array_direct.hpp \
 array_integer.hpp \
 array_string.hpp \
 bptree.hpp \

--- a/src/realm/array.hpp
+++ b/src/realm/array.hpp
@@ -55,7 +55,7 @@ Searching: The main finding function is:
 #include <realm/string_data.hpp>
 #include <realm/query_conditions.hpp>
 #include <realm/column_fwd.hpp>
-#include "array_direct.hpp"
+#include <realm/array_direct.hpp>
 
 /*
     MMX: mmintrin.h


### PR DESCRIPTION
This is included in array.hpp so it needs to exist.