### PR TITLE
Table::batch_erase_rows generates wrong instructions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,9 @@
 
 ### Bugfixes
 
-* Lorem ipsum.
+* Deleting rows through a `TableView` generated wrong instructions by way of
+  `Table::batch_erase_rows()`, which would only be noticed after reapplying the
+  transaction log to a separate Realm file or via synchronization.
 
 ### Breaking changes
 

--- a/src/realm/table.cpp
+++ b/src/realm/table.cpp
@@ -2266,17 +2266,17 @@ void Table::batch_erase_rows(const IntegerColumn& row_indexes, bool is_move_last
         auto rend = rows.rend();
         for (auto i = rows.rbegin(); i != rend; ++i) {
             size_t row_ndx = *i;
-            if (repl) {
-                size_t num_rows_to_erase = 1;
-                size_t prior_num_rows = m_size;
-                repl->erase_rows(this, row_ndx, num_rows_to_erase, prior_num_rows, is_move_last_over); // Throws
-            }
             bool broken_reciprocal_backlinks = false;
+            size_t prior_num_rows = m_size;
             if (is_move_last_over) {
                 do_move_last_over(row_ndx, broken_reciprocal_backlinks); // Throws
             }
             else {
                 do_remove(row_ndx, broken_reciprocal_backlinks); // Throws
+            }
+            if (repl) {
+                size_t num_rows_to_erase = 1;
+                repl->erase_rows(this, row_ndx, num_rows_to_erase, prior_num_rows, is_move_last_over); // Throws
             }
         }
         return;


### PR DESCRIPTION
Link nullification is a side-effect of deletion of target rows, and they used to be purely informational instructions for notification handlers. They also used to come after the `MoveLastOver` instruction of which they were a side-effect in the transaction log, but this was changed during the development of RMP, where the `LinkListNullify` and set-link nullification instructions now have an effect and are used to document effects of the merge logic in the merged transaction logs.

However, the semantics were only changed on the normal `Table::move_last_over` and `Table::clear` methods, not the method `Table::batch_erase_rows`, which happens to be invoked when deleting rows through a `TableView` (including when deleting the results of a `Query`). The result is that `LinkListNullify` is generated _after_ the `MoveLastOver` of which it is a side-effect, but the recipient of the instruction can not correctly apply it when it actually does something beyond notification.

This causes a "Bad transact log" error to be thrown when other clients receive the transaction log stream containing deletions performed through a `TableView`, but curiously not locally on the client that generated the deletion, because the transaction log is obviously never re-applied there.

However, the problem is easily reproducible outside of synchronization scenarios (see attached unit test), and the fix is trivial. Please review, /cc @ironage @teotwaki @jedelbo @finnschiermer