### PR TITLE
Add support for "like" (wildcard) queries

### DIFF
--- a/src/realm/query.cpp
+++ b/src/realm/query.cpp
@@ -765,6 +765,14 @@ Query& Query::not_equal(size_t column_ndx, StringData value, bool case_sensitive
         add_condition<NotEqualIns>(column_ndx, value);
     return *this;
 }
+Query& Query::like(size_t column_ndx, StringData value, bool case_sensitive)
+{
+    if (case_sensitive)
+        add_condition<Like>(column_ndx, value);
+    else
+        add_condition<LikeIns>(column_ndx, value);
+    return *this;
+}
 
 
 // Aggregates =================================================================================

--- a/src/realm/query.hpp
+++ b/src/realm/query.hpp
@@ -210,6 +210,7 @@ public:
     Query& begins_with(size_t column_ndx, StringData value, bool case_sensitive = true);
     Query& ends_with(size_t column_ndx, StringData value, bool case_sensitive = true);
     Query& contains(size_t column_ndx, StringData value, bool case_sensitive = true);
+    Query& like(size_t column_ndx, StringData value, bool case_sensitive = true);
 
     // These are shortcuts for equal(StringData(c_str)) and
     // not_equal(StringData(c_str)), and are needed to avoid unwanted

--- a/src/realm/query_conditions.hpp
+++ b/src/realm/query_conditions.hpp
@@ -85,7 +85,7 @@ struct Contains : public HackClass {
     static const int condition = -1;
 };
 
-// Does v2 contain somethin like v1 (wildcard matching)?
+// Does v2 contain something like v1 (wildcard matching)?
 struct Like : public HackClass {
     bool operator()(StringData v1, const char*, const char*, StringData v2, bool = false, bool = false) const { return v2.like(v1); }
     bool operator()(StringData v1, StringData v2, bool = false, bool = false) const { return v2.like(v1); }

--- a/src/realm/query_conditions.hpp
+++ b/src/realm/query_conditions.hpp
@@ -85,6 +85,19 @@ struct Contains : public HackClass {
     static const int condition = -1;
 };
 
+// Does v2 contain somethin like v1 (wildcard matching)?
+struct Like : public HackClass {
+    bool operator()(StringData v1, const char*, const char*, StringData v2, bool = false, bool = false) const { return v2.like(v1); }
+    bool operator()(StringData v1, StringData v2, bool = false, bool = false) const { return v2.like(v1); }
+    bool operator()(BinaryData, BinaryData, bool = false, bool = false) const { REALM_ASSERT(false); return false; }
+    
+    template<class A, class B> bool operator()(A, B) const { REALM_ASSERT(false); return false; }
+    template<class A, class B, class C, class D> bool operator()(A, B, C, D) const { REALM_ASSERT(false); return false; }
+    bool operator()(int64_t, int64_t, bool, bool) const { REALM_ASSERT(false); return false; }
+    
+    static const int condition = -1;
+};
+
 // Does v2 begin with v1?
 struct BeginsWith : public HackClass {
     bool operator()(StringData v1, const char*, const char*, StringData v2, bool = false, bool = false) const
@@ -260,6 +273,40 @@ struct ContainsIns : public HackClass {
         return false;
     }
 
+    static const int condition = -1;
+};
+
+// Does v2 contain something like v1 (wildcard matching)?
+struct LikeIns : public HackClass {
+    bool operator()(StringData v1, const char* v1_upper, const char* v1_lower, StringData v2, bool = false, bool = false) const
+    {
+        if (v2.is_null() && !v1.is_null())
+            return false;
+        
+        if (v1.size() == 0 && !v2.is_null())
+            return true;
+        
+        return string_like_ins(v2, v1_lower, v1_upper);
+    }
+    
+    // Slow version, used if caller hasn't stored an upper and lower case version
+    bool operator()(StringData v1, StringData v2, bool = false, bool = false) const
+    {
+        if (v2.is_null() && !v1.is_null())
+            return false;
+        
+        if (v1.size() == 0 && !v2.is_null())
+            return true;
+        
+        std::string v1_upper = case_map(v1, true, IgnoreErrors);
+        std::string v1_lower = case_map(v1, false, IgnoreErrors);
+        return string_like_ins(v2, v1_lower, v1_upper);
+    }
+    
+    template<class A, class B> bool operator()(A, B) const { REALM_ASSERT(false); return false; }
+    template<class A, class B, class C, class D> bool operator()(A, B, C, D) const { REALM_ASSERT(false); return false; }
+    bool operator()(int64_t, int64_t, bool, bool) const { REALM_ASSERT(false); return false; }
+    
     static const int condition = -1;
 };
 

--- a/src/realm/query_conditions.hpp
+++ b/src/realm/query_conditions.hpp
@@ -87,13 +87,36 @@ struct Contains : public HackClass {
 
 // Does v2 contain something like v1 (wildcard matching)?
 struct Like : public HackClass {
-    bool operator()(StringData v1, const char*, const char*, StringData v2, bool = false, bool = false) const { return v2.like(v1); }
-    bool operator()(StringData v1, StringData v2, bool = false, bool = false) const { return v2.like(v1); }
-    bool operator()(BinaryData, BinaryData, bool = false, bool = false) const { REALM_ASSERT(false); return false; }
+    bool operator()(StringData v1, const char*, const char*, StringData v2, bool = false, bool = false) const
+    {
+        return v2.like(v1);
+    }
+    bool operator()(StringData v1, StringData v2, bool = false, bool = false) const
+    {
+        return v2.like(v1);
+    }
+    bool operator()(BinaryData, BinaryData, bool = false, bool = false) const
+    {
+        REALM_ASSERT(false);
+        return false;
+    }
     
-    template<class A, class B> bool operator()(A, B) const { REALM_ASSERT(false); return false; }
-    template<class A, class B, class C, class D> bool operator()(A, B, C, D) const { REALM_ASSERT(false); return false; }
-    bool operator()(int64_t, int64_t, bool, bool) const { REALM_ASSERT(false); return false; }
+    template<class A, class B> bool operator()(A, B) const
+    {
+        REALM_ASSERT(false);
+        return false;
+    }
+    
+    template<class A, class B, class C, class D> bool operator()(A, B, C, D) const
+    {
+        REALM_ASSERT(false);
+        return false;
+    }
+    
+    bool operator()(int64_t, int64_t, bool, bool) const {
+        REALM_ASSERT(false);
+        return false;
+    }
     
     static const int condition = -1;
 };
@@ -280,11 +303,9 @@ struct ContainsIns : public HackClass {
 struct LikeIns : public HackClass {
     bool operator()(StringData v1, const char* v1_upper, const char* v1_lower, StringData v2, bool = false, bool = false) const
     {
-        if (v2.is_null() && !v1.is_null())
-            return false;
-        
-        if (v1.size() == 0 && !v2.is_null())
-            return true;
+        if (v2.is_null() || v1.is_null()) {
+            return (v2.is_null() && v1.is_null());
+        }
         
         return string_like_ins(v2, v1_lower, v1_upper);
     }
@@ -292,11 +313,9 @@ struct LikeIns : public HackClass {
     // Slow version, used if caller hasn't stored an upper and lower case version
     bool operator()(StringData v1, StringData v2, bool = false, bool = false) const
     {
-        if (v2.is_null() && !v1.is_null())
-            return false;
-        
-        if (v1.size() == 0 && !v2.is_null())
-            return true;
+        if (v2.is_null() || v1.is_null()) {
+            return (v2.is_null() && v1.is_null());
+        }
         
         std::string v1_upper = case_map(v1, true, IgnoreErrors);
         std::string v1_lower = case_map(v1, false, IgnoreErrors);

--- a/src/realm/query_expression.hpp
+++ b/src/realm/query_expression.hpp
@@ -478,6 +478,10 @@ Query create(L left, const Subexpr2<R>& right)
             q.contains(column->column_ndx(), only_string(left));
         else if (std::is_same<Cond, ContainsIns>::value)
             q.contains(column->column_ndx(), only_string(left), false);
+        else if (std::is_same<Cond, Like>::value)
+            q.like(column->column_ndx(), only_string(left));
+        else if (std::is_same<Cond, LikeIns>::value)
+            q.like(column->column_ndx(), only_string(left), false);
         else {
             // query_engine.hpp does not support this Cond. Please either add support for it in query_engine.hpp or
             // fallback to using use 'return new Compare<>' instead.

--- a/src/realm/query_expression.hpp
+++ b/src/realm/query_expression.hpp
@@ -1960,6 +1960,16 @@ public:
     {
         return string_compare<Contains, ContainsIns>(*this, col, case_sensitive);
     }
+    
+    Query like(StringData sd, bool case_sensitive = true)
+    {
+        return string_compare<StringData, Like, LikeIns>(*this, sd, case_sensitive);
+    }
+    
+    Query like(const Columns<StringData>& col, bool case_sensitive = true)
+    {
+        return string_compare<Like, LikeIns>(*this, col, case_sensitive);
+    }
 };
 
 

--- a/src/realm/string_data.hpp
+++ b/src/realm/string_data.hpp
@@ -305,8 +305,19 @@ inline bool StringData::matchhere(const StringData& text, const StringData& patt
         return false;
     if (pattern[p2] == '*')
         return matchstar(text, pattern, p1, p2+1);
-    if (pattern[p2] == '?' || pattern[p2] == text[p1])
+    if (pattern[p2] == text[p1])
         return matchhere(text, pattern, p1+1, p2+1);
+    if (pattern[p2] == '?') {
+        // utf-8 encoded characters may take up multiple bytes
+        if ((text[p1] & 0x80) == 0)
+            return matchhere(text, pattern, p1+1, p2+1);
+        else {
+            size_t p = 1;
+            while (p1+p != text.size() && (text[p1+p] & 0xc0) == 0x80)
+                ++p;
+            return matchhere(text, pattern, p1+p, p2+1);
+        }
+    }
     return false;
 }
 

--- a/src/realm/table_accessors.hpp
+++ b/src/realm/table_accessors.hpp
@@ -1887,6 +1887,12 @@ public:
         Base::m_query->m_impl.contains(col_idx, value, case_sensitive);
         return *Base::m_query;
     }
+
+    Query& like(StringData value, bool case_sensitive=true) const
+    {
+        Base::m_query->m_impl.like(col_idx, value, case_sensitive);
+        return *Base::m_query;
+    }
 };
 
 

--- a/src/realm/unicode.cpp
+++ b/src/realm/unicode.cpp
@@ -518,9 +518,9 @@ bool matchhere_ins(const StringData& text, const StringData& pattern_upper, cons
         return false;
     if (pattern_lower[p2] == '*')
         return matchstar_ins(text, pattern_lower, pattern_upper, p1, p2+1);
-        if (pattern_lower[p2] == '?' || pattern_lower[p2] == text[p1] || pattern_upper[p2] == text[p1])
-            return matchhere_ins(text, pattern_lower, pattern_upper, p1+1, p2+1);
-            return false;
+    if (pattern_lower[p2] == '?' || pattern_lower[p2] == text[p1] || pattern_upper[p2] == text[p1])
+        return matchhere_ins(text, pattern_lower, pattern_upper, p1+1, p2+1);
+    return false;
 }
 
 bool matchstar_ins(const StringData& text, const StringData& pattern_upper, const StringData& pattern_lower, size_t p1, size_t p2) noexcept

--- a/src/realm/unicode.cpp
+++ b/src/realm/unicode.cpp
@@ -502,6 +502,57 @@ size_t search_case_fold(StringData haystack, const char* needle_upper, const cha
     return haystack.size(); // Not found
 }
 
+// pre-declaration
+bool matchstar_ins(const StringData& text, const StringData& pattern_upper, const StringData& pattern_lower, size_t p1, size_t p2) noexcept;
+
+bool matchhere_ins(const StringData& text, const StringData& pattern_upper, const StringData& pattern_lower, size_t p1, size_t p2) noexcept
+{
+    if (p1 == text.size()) {
+        if (p2 == pattern_lower.size())
+            return true;
+        if (p2 == pattern_lower.size()-1 && pattern_lower[p2] == '*')
+            return true;
+        return false;
+    }
+    if (p2 == pattern_lower.size())
+        return false;
+    if (pattern_lower[p2] == '*')
+        return matchstar_ins(text, pattern_lower, pattern_upper, p1, p2+1);
+        if (pattern_lower[p2] == '?' || pattern_lower[p2] == text[p1] || pattern_upper[p2] == text[p1])
+            return matchhere_ins(text, pattern_lower, pattern_upper, p1+1, p2+1);
+            return false;
+}
+
+bool matchstar_ins(const StringData& text, const StringData& pattern_upper, const StringData& pattern_lower, size_t p1, size_t p2) noexcept
+{
+    do {
+        if (matchhere_ins(text, pattern_lower, pattern_upper, p1, p2))
+            return true;
+    }
+    while (p1++ != text.size());
+    return false;
+}
+
+bool string_like_ins(StringData text, StringData upper, StringData lower) noexcept
+{
+    if (text.is_null() || lower.is_null()) {
+        return (text.is_null() && lower.is_null());
+    }
+    
+    return matchhere_ins(text, lower, upper, 0, 0);
+}
+
+bool string_like_ins(StringData text, StringData pattern) noexcept
+{
+    if (text.is_null() || pattern.is_null()) {
+        return (text.is_null() && pattern.is_null());
+    }
+    
+    std::string upper = case_map(pattern, true, IgnoreErrors);
+    std::string lower = case_map(pattern, false, IgnoreErrors);
+    
+    return matchhere_ins(text, lower.c_str(), upper.c_str(), 0, 0);
+}
 
 } // namespace realm
 

--- a/src/realm/unicode.cpp
+++ b/src/realm/unicode.cpp
@@ -518,8 +518,19 @@ bool matchhere_ins(const StringData& text, const StringData& pattern_upper, cons
         return false;
     if (pattern_lower[p2] == '*')
         return matchstar_ins(text, pattern_lower, pattern_upper, p1, p2+1);
-    if (pattern_lower[p2] == '?' || pattern_lower[p2] == text[p1] || pattern_upper[p2] == text[p1])
+    if (pattern_lower[p2] == text[p1] || pattern_upper[p2] == text[p1])
         return matchhere_ins(text, pattern_lower, pattern_upper, p1+1, p2+1);
+    if (pattern_lower[p2] == '?') {
+        // utf-8 encoded characters may take up multiple bytes
+        if ((text[p1] & 0x80) == 0)
+            return matchhere_ins(text, pattern_lower, pattern_upper, p1+1, p2+1);
+        else {
+            size_t p = 1;
+            while (p1+p != text.size() && (text[p1+p] & 0xc0) == 0x80)
+                ++p;
+            return matchhere_ins(text, pattern_lower, pattern_upper, p1+p, p2+1);
+        }
+    }
     return false;
 }
 

--- a/src/realm/unicode.hpp
+++ b/src/realm/unicode.hpp
@@ -150,6 +150,10 @@ bool equal_case_fold(StringData haystack, const char* needle_upper, const char* 
 /// needle was not found.
 size_t search_case_fold(StringData haystack, const char* needle_upper, const char* needle_lower, size_t needle_size);
 
+/// Case insensitive wildcard matching ('?' for single char, '*' for zero or more chars)
+bool string_like_ins(StringData text, StringData pattern) noexcept;
+bool string_like_ins(StringData text, StringData upper, StringData lower) noexcept;
+
 } // namespace realm
 
 #endif // REALM_UNICODE_HPP

--- a/test/test_query.cpp
+++ b/test/test_query.cpp
@@ -558,6 +558,19 @@ TEST(Query_NextGen_StringConditions)
 
     m = table1->column<String>(0).ends_with(table1->column<String>(1), true).find();
     CHECK_EQUAL(m, 2);
+    
+    // Like (wildcard matching)
+    m = table1->column<String>(0).like("b*", false).find();
+    CHECK_EQUAL(m, 2);
+    
+    m = table1->column<String>(0).like("*r", false).find();
+    CHECK_EQUAL(m, 2);
+    
+    m = table1->column<String>(0).like("f?o", false).find();
+    CHECK_EQUAL(m, 0);
+    
+    m = (table1->column<String>(0).like("f*", false) && table1->column<String>(0) == "foo").find();
+    CHECK_EQUAL(m, 0);
 
     // Test various compare operations with null
     TableRef table2 = group.add_table("table2");

--- a/test/test_query.cpp
+++ b/test/test_query.cpp
@@ -5087,6 +5087,19 @@ TEST(Query_FindAllLike)
     CHECK_EQUAL(3, tv1.get_source_ndx(3));
 }
 
+TEST(Query_FindAllLikeStackOverflow)
+{
+    std::string str(100000, 'x');
+    StringData sd(str);
+
+    Table table;
+    table.add_column(type_String, "strings");
+    table.add_empty_row();
+    table.set_string(0, 0, sd);
+
+    table.where().like(0, sd).find();
+}
+
 TEST(Query_FindAllLikeCaseInsensitive)
 {
     TupleTableType ttt;

--- a/test/test_query.cpp
+++ b/test/test_query.cpp
@@ -560,6 +560,9 @@ TEST(Query_NextGen_StringConditions)
     CHECK_EQUAL(m, 2);
     
     // Like (wildcard matching)
+    m = table1->column<String>(0).like("b*", true).find();
+    CHECK_EQUAL(m, 2);
+    
     m = table1->column<String>(0).like("b*", false).find();
     CHECK_EQUAL(m, 2);
     
@@ -571,6 +574,9 @@ TEST(Query_NextGen_StringConditions)
     
     m = (table1->column<String>(0).like("f*", false) && table1->column<String>(0) == "foo").find();
     CHECK_EQUAL(m, 0);
+    
+    m = table1->column<String>(0).like(table1->column<String>(1), true).find();
+    CHECK_EQUAL(m, not_found);
 
     // Test various compare operations with null
     TableRef table2 = group.add_table("table2");
@@ -611,6 +617,9 @@ TEST(Query_NextGen_StringConditions)
 
     m = table2->column<String>(0).contains(StringData(""), false).count();
     CHECK_EQUAL(m, 4);
+    
+    m = table2->column<String>(0).like(StringData(""), false).count();
+    CHECK_EQUAL(m, 1);
 
     m = table2->column<String>(0).begins_with(StringData(""), false).count();
     CHECK_EQUAL(m, 4);
@@ -632,6 +641,9 @@ TEST(Query_NextGen_StringConditions)
 
     m = table2->column<String>(0).contains(realm::null(), false).count();
     CHECK_EQUAL(m, 4);
+    
+    m = table2->column<String>(0).like(realm::null(), false).count();
+    CHECK_EQUAL(m, 1);
 
     TableRef table3 = group.add_table(StringData("table3"));
     table3->add_column_link(type_Link, "link1", *table2);
@@ -671,6 +683,9 @@ TEST(Query_NextGen_StringConditions)
 
     m = table3->link(0).column<String>(0).contains(StringData(""), false).count();
     CHECK_EQUAL(m, 4);
+    
+    m = table3->link(0).column<String>(0).like(StringData(""), false).count();
+    CHECK_EQUAL(m, 1);
 
     m = table3->link(0).column<String>(0).begins_with(StringData(""), false).count();
     CHECK_EQUAL(m, 4);
@@ -692,6 +707,9 @@ TEST(Query_NextGen_StringConditions)
 
     m = table3->link(0).column<String>(0).contains(realm::null(), false).count();
     CHECK_EQUAL(m, 4);
+    
+    m = table3->link(0).column<String>(0).like(realm::null(), false).count();
+    CHECK_EQUAL(m, 1);
 }
 
 

--- a/test/test_query.cpp
+++ b/test/test_query.cpp
@@ -5035,6 +5035,48 @@ TEST(Query_FindAllContains)
     CHECK_EQUAL(3, tv1.get_source_ndx(3));
 }
 
+TEST(Query_FindAllLike)
+{
+    TupleTableType ttt;
+    
+    ttt.add(0, "foo");
+    ttt.add(0, "foobar");
+    ttt.add(0, "barfoo");
+    ttt.add(0, "barfoobaz");
+    ttt.add(0, "fo");
+    ttt.add(0, "fobar");
+    ttt.add(0, "barfo");
+    
+    TupleTableType::Query q1 = ttt.where().second.like("*foo*");
+    TupleTableType::View tv1 = q1.find_all();
+    CHECK_EQUAL(4, tv1.size());
+    CHECK_EQUAL(0, tv1.get_source_ndx(0));
+    CHECK_EQUAL(1, tv1.get_source_ndx(1));
+    CHECK_EQUAL(2, tv1.get_source_ndx(2));
+    CHECK_EQUAL(3, tv1.get_source_ndx(3));
+}
+
+TEST(Query_FindAllLikeCaseInsensitive)
+{
+    TupleTableType ttt;
+    
+    ttt.add(0, "Foo");
+    ttt.add(0, "FOOBAR");
+    ttt.add(0, "BaRfOo");
+    ttt.add(0, "barFOObaz");
+    ttt.add(0, "Fo");
+    ttt.add(0, "Fobar");
+    ttt.add(0, "baRFo");
+    
+    TupleTableType::Query q1 = ttt.where().second.like("*foo*", false);
+    TupleTableType::View tv1 = q1.find_all();
+    CHECK_EQUAL(4, tv1.size());
+    CHECK_EQUAL(0, tv1.get_source_ndx(0));
+    CHECK_EQUAL(1, tv1.get_source_ndx(1));
+    CHECK_EQUAL(2, tv1.get_source_ndx(2));
+    CHECK_EQUAL(3, tv1.get_source_ndx(3));
+}
+
 TEST(Query_Binary)
 {
     TupleTableTypeBin t;

--- a/test/test_string_data.cpp
+++ b/test/test_string_data.cpp
@@ -265,6 +265,7 @@ TEST(StringData_Like)
     StringData foobar("foobar");
     StringData foofoo("foofoo");
     StringData foobarfoo("foobarfoo");
+    StringData unicode("\xc3\xa6\xc3\xb8\xc3\xa5\xe6\x97\xa5\xe6\x9c\xac\xe8\xaa\x9etest"); // utf-8 "æøå日本語test"
     
     CHECK(null.like(null));
     CHECK(!null.like(""));
@@ -284,6 +285,11 @@ TEST(StringData_Like)
     CHECK(foobarfoo.like("foo*foo"));
     CHECK(!foobarfoo.like("foo*bar"));
     
+    CHECK(unicode.like("*test"));
+    CHECK(unicode.like("\xc3\xa6\xc3\xb8\xc3\xa5*")); // "æøå*"
+    CHECK(unicode.like("\xc3\xa6\xc3\xb8\xc3\xa5*test")); // "æøå*test"
+    CHECK(unicode.like("*\xe6\x97\xa5\xe6\x9c\xac\xe8\xaa\x9e*")); // "*日本語*"
+    
     CHECK(f.like("?"));
     CHECK(foo.like("?oo"));
     CHECK(foo.like("f?o"));
@@ -291,6 +297,11 @@ TEST(StringData_Like)
     CHECK(!empty.like("?"));
     CHECK(!foo.like("foo?"));
     CHECK(!foo.like("?foo"));
+    
+    CHECK(unicode.like("?\xc3\xb8\xc3\xa5\xe6\x97\xa5\xe6\x9c\xac\xe8\xaa\x9etest")); // "?øå日本語test"
+    CHECK(unicode.like("\xc3\xa6?\xc3\xa5\xe6\x97\xa5\xe6\x9c\xac\xe8\xaa\x9etest")); // "æ?å日本語test"));
+    CHECK(unicode.like("\xc3\xa6\xc3\xb8\xc3\xa5?\xe6\x9c\xac\xe8\xaa\x9etest"));     // "æøå?本語test"));
+    CHECK(unicode.like("\xc3\xa6?\xc3\xa5?\xe6\x9c\xac?test"));                       // "æ?å?本?t?s?"));
     
     CHECK(foo.like("?oo*"));
     CHECK(foo.like("*?o?"));
@@ -309,6 +320,7 @@ TEST(StringData_Like_CaseInsensitive)
     StringData foobar("FOOBAR");
     StringData foofoo("FOOfoo");
     StringData foobarfoo("FoObArFoO");
+    StringData unicode("\xc3\xa6\xc3\xb8\xc3\xa5\xe6\x97\xa5\xe6\x9c\xac\xe8\xaa\x9etest"); // utf-8 "æøå日本語test"
     
     CHECK(string_like_ins(null, null));
     CHECK(!string_like_ins(null, ""));
@@ -328,6 +340,11 @@ TEST(StringData_Like_CaseInsensitive)
     CHECK(string_like_ins(foobarfoo, "foo*foo"));
     CHECK(!string_like_ins(foobarfoo, "foo*bar"));
     
+    CHECK(string_like_ins(unicode, "*test"));
+    CHECK(string_like_ins(unicode, "\xc3\xa6\xc3\xb8\xc3\xa5*")); // "æøå*"
+    CHECK(string_like_ins(unicode, "\xc3\xa6\xc3\xb8\xc3\xa5*test")); // "æøå*test"
+    CHECK(string_like_ins(unicode, "*\xe6\x97\xa5\xe6\x9c\xac\xe8\xaa\x9e*")); // "*日本語*"
+    
     CHECK(string_like_ins(f,"?"));
     CHECK(string_like_ins(foo, "?oo"));
     CHECK(string_like_ins(foo, "f?o"));
@@ -335,6 +352,11 @@ TEST(StringData_Like_CaseInsensitive)
     CHECK(!string_like_ins(empty, "?"));
     CHECK(!string_like_ins(foo, "foo?"));
     CHECK(!string_like_ins(foo, "?foo"));
+    
+    CHECK(string_like_ins(unicode, "?\xc3\xb8\xc3\xa5\xe6\x97\xa5\xe6\x9c\xac\xe8\xaa\x9etest")); // "?øå日本語test"
+    CHECK(string_like_ins(unicode, "\xc3\xa6?\xc3\xa5\xe6\x97\xa5\xe6\x9c\xac\xe8\xaa\x9etest")); // "æ?å日本語test"));
+    CHECK(string_like_ins(unicode, "\xc3\xa6\xc3\xb8\xc3\xa5?\xe6\x9c\xac\xe8\xaa\x9etest"));     // "æøå?本語test"));
+    CHECK(string_like_ins(unicode, "\xc3\xa6?\xc3\xa5?\xe6\x9c\xac?test"));                       // "æ?å?本?t?s?"));
     
     CHECK(string_like_ins(foo, "?oo*"));
     CHECK(string_like_ins(foo, "*?o?"));

--- a/test/test_string_data.cpp
+++ b/test/test_string_data.cpp
@@ -25,6 +25,7 @@
 
 #include <realm.hpp>
 #include <realm/string_data.hpp>
+#include <realm/unicode.hpp>
 
 #include "test.hpp"
 
@@ -254,6 +255,91 @@ TEST(StringData_LexicographicCompare)
     CHECK((sd_9_22 <= sd_9_22) && !(sd_9_22 > sd_9_22));
 }
 
+TEST(StringData_Like)
+{
+    StringData null = realm::null();
+    StringData empty("");
+    StringData f("f");
+    StringData foo("foo");
+    StringData bar("bar");
+    StringData foobar("foobar");
+    StringData foofoo("foofoo");
+    StringData foobarfoo("foobarfoo");
+    
+    CHECK(null.like(null));
+    CHECK(!null.like(""));
+    CHECK(!null.like("*"));
+    CHECK(!null.like("?"));
+    CHECK(!empty.like(null));
+    
+    CHECK(empty.like(""));
+    CHECK(empty.like("*"));
+    
+    CHECK(f.like("*"));
+    CHECK(foo.like("foo*"));
+    CHECK(foo.like("*foo"));
+    CHECK(foobar.like("foo*"));
+    CHECK(foofoo.like("foo*foo"));
+    CHECK(foobarfoo.like("foo*foo"));
+    CHECK(!foobarfoo.like("foo*bar"));
+    
+    CHECK(f.like("?"));
+    CHECK(foo.like("?oo"));
+    CHECK(foo.like("f?o"));
+    CHECK(foo.like("fo?"));
+    CHECK(!empty.like("?"));
+    CHECK(!foo.like("foo?"));
+    CHECK(!foo.like("?foo"));
+    
+    CHECK(foo.like("?oo*"));
+    CHECK(foo.like("*?o?"));
+    CHECK(foobar.like("???*"));
+    CHECK(foofoo.like("?oo*?oo"));
+    CHECK(foobarfoo.like("?oo*?oo"));
+}
+
+TEST(StringData_Like_CaseInsensitive)
+{
+    StringData null = realm::null();
+    StringData empty("");
+    StringData f("f");
+    StringData foo("FoO");
+    StringData bar("bAr");
+    StringData foobar("FOOBAR");
+    StringData foofoo("FOOfoo");
+    StringData foobarfoo("FoObArFoO");
+    
+    CHECK(string_like_ins(null, null));
+    CHECK(!string_like_ins(null, ""));
+    CHECK(!string_like_ins(null, "*"));
+    CHECK(!string_like_ins(null, "?"));
+    CHECK(!string_like_ins("", null));
+    
+    CHECK(string_like_ins(empty, ""));
+    CHECK(string_like_ins(empty, "*"));
+    
+    CHECK(string_like_ins(f, "*"));
+    CHECK(string_like_ins(foo, "foo*"));
+    CHECK(string_like_ins(foo, "*foo"));
+    CHECK(string_like_ins(foobar, "foo*"));
+    CHECK(string_like_ins(foofoo, "foo*foo"));
+    CHECK(string_like_ins(foobarfoo, "foo*foo"));
+    CHECK(!string_like_ins(foobarfoo, "foo*bar"));
+    
+    CHECK(string_like_ins(f,"?"));
+    CHECK(string_like_ins(foo, "?oo"));
+    CHECK(string_like_ins(foo, "f?o"));
+    CHECK(string_like_ins(foo, "fo?"));
+    CHECK(!string_like_ins(empty, "?"));
+    CHECK(!string_like_ins(foo, "foo?"));
+    CHECK(!string_like_ins(foo, "?foo"));
+    
+    CHECK(string_like_ins(foo, "?oo*"));
+    CHECK(string_like_ins(foo, "*?o?"));
+    CHECK(string_like_ins(foobar, "???*"));
+    CHECK(string_like_ins(foofoo, "?oo*?oo"));
+    CHECK(string_like_ins(foobarfoo, "?oo*?oo"));
+}
 
 TEST(StringData_Substrings)
 {

--- a/test/test_string_data.cpp
+++ b/test/test_string_data.cpp
@@ -265,6 +265,7 @@ TEST(StringData_Like)
     StringData foobar("foobar");
     StringData foofoo("foofoo");
     StringData foobarfoo("foobarfoo");
+    StringData star_in_string("*bar");
     StringData unicode("\xc3\xa6\xc3\xb8\xc3\xa5\xe6\x97\xa5\xe6\x9c\xac\xe8\xaa\x9etest"); // utf-8 "æøå日本語test"
     
     CHECK(null.like(null));
@@ -284,6 +285,7 @@ TEST(StringData_Like)
     CHECK(foofoo.like("foo*foo"));
     CHECK(foobarfoo.like("foo*foo"));
     CHECK(!foobarfoo.like("foo*bar"));
+    CHECK(star_in_string.like("*ar"));
     
     CHECK(unicode.like("*test"));
     CHECK(unicode.like("\xc3\xa6\xc3\xb8\xc3\xa5*")); // "æøå*"
@@ -320,6 +322,7 @@ TEST(StringData_Like_CaseInsensitive)
     StringData foobar("FOOBAR");
     StringData foofoo("FOOfoo");
     StringData foobarfoo("FoObArFoO");
+    StringData star_in_string("*bar");
     StringData unicode("\xc3\xa6\xc3\xb8\xc3\xa5\xe6\x97\xa5\xe6\x9c\xac\xe8\xaa\x9etest"); // utf-8 "æøå日本語test"
     
     CHECK(string_like_ins(null, null));
@@ -339,6 +342,7 @@ TEST(StringData_Like_CaseInsensitive)
     CHECK(string_like_ins(foofoo, "foo*foo"));
     CHECK(string_like_ins(foobarfoo, "foo*foo"));
     CHECK(!string_like_ins(foobarfoo, "foo*bar"));
+    CHECK(string_like_ins(star_in_string, "*ar"));
     
     CHECK(string_like_ins(unicode, "*test"));
     CHECK(string_like_ins(unicode, "\xc3\xa6\xc3\xb8\xc3\xa5*")); // "æøå*"

--- a/test/test_string_data.cpp
+++ b/test/test_string_data.cpp
@@ -275,6 +275,7 @@ TEST(StringData_Like)
     CHECK(empty.like(""));
     CHECK(empty.like("*"));
     
+    CHECK(!f.like(""));
     CHECK(f.like("*"));
     CHECK(foo.like("foo*"));
     CHECK(foo.like("*foo"));
@@ -318,6 +319,7 @@ TEST(StringData_Like_CaseInsensitive)
     CHECK(string_like_ins(empty, ""));
     CHECK(string_like_ins(empty, "*"));
     
+    CHECK(!string_like_ins(f, ""));
     CHECK(string_like_ins(f, "*"));
     CHECK(string_like_ins(foo, "foo*"));
     CHECK(string_like_ins(foo, "*foo"));


### PR DESCRIPTION
This adds query support for simple wildcard matching (`?` for single character, `*` for multiple chars). It is not regex matching, more like the kind of wildcards you can use on the command line. This is needed to support the `LIKE` predicate in NSPredicates (which is different from `MATCHES` that _does_ use regex). The related Cocoa issue is: https://github.com/realm/realm-cocoa/issues/1490

I needed a wildcard matching for a project I was experimenting with, and I noticed that it was not implemented yet, so I just added it given that it was such a simple thing to implement. 

@rrrlasse @bdash 
