### PR TITLE
Fix large refs on certain 32-bit platforms

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ### Bugfixes
 
-* Lorem ipsum.
+* Fix storage of very large refs (MSB set) on 32-bit platforms.
 
 ### Breaking changes
 

--- a/src/realm/alloc.hpp
+++ b/src/realm/alloc.hpp
@@ -297,14 +297,26 @@ inline int_fast64_t from_ref(ref_type v) noexcept
 {
     // Check that v is divisible by 8 (64-bit aligned).
     REALM_ASSERT_DEBUG(v % 8 == 0);
-    return util::from_twos_compl<int_fast64_t>(v);
+
+    static_assert(std::is_same<ref_type, size_t>::value,
+                  "If ref_type changes, from_ref and to_ref should probably be updated");
+
+    // Make sure that we preserve the bit pattern of the ref_type (without sign extension).
+    return util::from_twos_compl<int_fast64_t>(uint_fast64_t(v));
 }
 
 inline ref_type to_ref(int_fast64_t v) noexcept
 {
-    REALM_ASSERT_DEBUG(!util::int_cast_has_overflow<ref_type>(v));
     // Check that v is divisible by 8 (64-bit aligned).
     REALM_ASSERT_DEBUG(v % 8 == 0);
+
+    // C++11 standard, paragraph 4.7.2 [conv.integral]:
+    // If the destination type is unsigned, the resulting value is the least unsigned integer congruent to the source
+    // integer (modulo 2n where n is the number of bits used to represent the unsigned type). [ Note: In a two’s
+    // complement representation, this conversion is conceptual and there is no change in the bit pattern (if there is
+    // no truncation). — end note ]
+    static_assert(std::is_unsigned<ref_type>::value,
+                  "If ref_type changes, from_ref and to_ref should probably be updated");
     return ref_type(v);
 }
 

--- a/test/test_alloc.cpp
+++ b/test/test_alloc.cpp
@@ -300,4 +300,27 @@ TEST(Alloc_Fuzzy)
     }
 }
 
+
+// This test reproduces the sporadic issue that was seen for large refs (addresses)
+// on 32-bit iPhone 5 Simulator runs on certain host machines.
+TEST(Alloc_ToAndFromRef)
+{
+    constexpr size_t ref_type_width = sizeof(ref_type) * 8;
+    constexpr ref_type interesting_refs[] = {
+        0,
+        8,
+        ref_type(1ULL << (ref_type_width - 1)), // 32-bit: 0x80000000, 64-bit: 0x8000000000000000
+        ref_type(3ULL << (ref_type_width - 2)), // 32-bit: 0xC0000000, 64-bit: 0xC000000000000000
+    };
+
+    constexpr size_t num_interesting_refs = sizeof(interesting_refs) / sizeof(interesting_refs[0]);
+    for (size_t i = 0; i < num_interesting_refs; ++i) {
+        ref_type ref = interesting_refs[i];
+        int_fast64_t ref_as_int = from_ref(ref);
+        ref_type back_to_ref = to_ref(ref_as_int);
+        CHECK_EQUAL(ref, back_to_ref);
+    }
+
+}
+
 #endif // TEST_ALLOC


### PR DESCRIPTION
Large refs (with MSB set) on 32-bit platforms were converted to _signed_ `int_fast64_t` before stored in an array (in `from_ref`). However, this was not handled symmetrically in `to_ref`, which would trigger an assert. Moreover, a lot of places these conversion functions were not even used, resulting in a lot of new issues. I tried to find them all in #2245, but have not yet managed to succeed.

In this PR, I propose storing these refs directly (keep them unsigned) and accepting the array bit width expansion in the case of large refs. This seems to be the quickest - and safest - solution for now. For a longer term solution, we should consider switching the `ref_type` to a fixed 64-bit type instead.

@rrrlasse @ironage @finnschiermer 