### PR TITLE
Fix a destruction race.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ### Bugfixes
 
-* Lorem ipsum.
+* Fix a race involving destruction order of InterprocessMutex static variables.
 
 ### Breaking changes
 

--- a/src/realm/util/interprocess_mutex.cpp
+++ b/src/realm/util/interprocess_mutex.cpp
@@ -22,7 +22,8 @@
 
 using namespace realm::util;
 
-std::map<File::UniqueID, std::weak_ptr<InterprocessMutex::LockInfo>> InterprocessMutex::s_info_map;
-Mutex InterprocessMutex::s_mutex;
+std::once_flag InterprocessMutex::static_flag;
+std::map<File::UniqueID, std::weak_ptr<InterprocessMutex::LockInfo>>* InterprocessMutex::s_info_map;
+Mutex* InterprocessMutex::s_mutex;
 
 #endif

--- a/src/realm/util/interprocess_mutex.cpp
+++ b/src/realm/util/interprocess_mutex.cpp
@@ -22,7 +22,7 @@
 
 using namespace realm::util;
 
-std::once_flag InterprocessMutex::static_flag;
+std::once_flag InterprocessMutex::s_init_flag;
 std::map<File::UniqueID, std::weak_ptr<InterprocessMutex::LockInfo>>* InterprocessMutex::s_info_map;
 Mutex* InterprocessMutex::s_mutex;
 

--- a/src/realm/util/interprocess_mutex.hpp
+++ b/src/realm/util/interprocess_mutex.hpp
@@ -95,8 +95,18 @@ private:
     /// InterprocessMutex created on the same file (same inode on POSIX) share the same LockInfo.
     /// LockInfo will be saved in a static map as a weak ptr and use the UniqueID as the key.
     /// Operations on the map need to be protected by s_mutex
-    static std::map<File::UniqueID, std::weak_ptr<LockInfo>> s_info_map;
-    static Mutex s_mutex;
+    static std::map<File::UniqueID, std::weak_ptr<LockInfo>>* s_info_map;
+    static Mutex* s_mutex;
+    /// We control the order of initialization of these static variables,
+    /// creating them on the heap so that they last for the enitre lifetime
+    /// of the process. The destructor on these is never called, but the
+    /// process will clean up the memory when exiting. It would not be enough
+    /// to count instances of InterprocessMutex and clean up these statics when
+    /// the count reaches zero because the process could create more
+    /// InterprocessMutexes before the process ends, so we really need these
+    /// variables for the entire lifetime of the proces.
+    static std::once_flag static_flag;
+    static void static_initialisation();
 
     /// Only used for release_shared_part
     std::string m_filename;
@@ -112,9 +122,11 @@ private:
     friend class InterprocessCondVar;
 };
 
-
 inline InterprocessMutex::InterprocessMutex()
 {
+#ifdef REALM_ROBUST_MUTEX_EMULATION
+    std::call_once(static_flag, static_initialisation);
+#endif
 }
 
 inline InterprocessMutex::~InterprocessMutex() noexcept
@@ -138,13 +150,18 @@ inline void InterprocessMutex::free_lock_info()
     if (!m_lock_info)
         return;
 
-    std::lock_guard<Mutex> guard(s_mutex);
+    std::lock_guard<Mutex> guard(*s_mutex);
 
     m_lock_info.reset();
-    if (s_info_map[m_fileuid].expired()) {
-        s_info_map.erase(m_fileuid);
+    if ((*s_info_map)[m_fileuid].expired()) {
+        s_info_map->erase(m_fileuid);
     }
     m_filename.clear();
+}
+
+inline void InterprocessMutex::static_initialisation() {
+    s_mutex = new Mutex();
+    s_info_map = new std::map<File::UniqueID, std::weak_ptr<LockInfo>>();
 }
 #endif
 
@@ -158,12 +175,12 @@ inline void InterprocessMutex::set_shared_part(SharedPart& shared_part, const st
 
     m_filename = path + "." + mutex_name + ".mx";
 
-    std::lock_guard<Mutex> guard(s_mutex);
+    std::lock_guard<Mutex> guard(*s_mutex);
 
     // Try to get the file uid if the file exists
     if (File::get_unique_id(m_filename, m_fileuid)) {
-        auto result = s_info_map.find(m_fileuid);
-        if (result != s_info_map.end()) {
+        auto result = s_info_map->find(m_fileuid);
+        if (result != s_info_map->end()) {
             // File exists and the lock info has been created in the map.
             m_lock_info = result->second.lock();
             return;
@@ -177,7 +194,7 @@ inline void InterprocessMutex::set_shared_part(SharedPart& shared_part, const st
     m_lock_info->m_file.open(m_filename, File::mode_Write);
     m_fileuid = m_lock_info->m_file.get_unique_id();
 
-    s_info_map[m_fileuid] = m_lock_info;
+    (*s_info_map)[m_fileuid] = m_lock_info;
 #else
     m_shared_part = &shared_part;
     static_cast<void>(path);
@@ -192,14 +209,14 @@ inline void InterprocessMutex::set_shared_part(SharedPart& shared_part, File&& l
 
     free_lock_info();
 
-    std::lock_guard<Mutex> guard(s_mutex);
+    std::lock_guard<Mutex> guard(*s_mutex);
 
     m_fileuid = lock_file.get_unique_id();
-    auto result = s_info_map.find(m_fileuid);
-    if (result == s_info_map.end()) {
+    auto result = s_info_map->find(m_fileuid);
+    if (result == s_info_map->end()) {
         m_lock_info = std::make_shared<LockInfo>();
         m_lock_info->m_file = std::move(lock_file);
-        s_info_map[m_fileuid] = m_lock_info;
+        (*s_info_map)[m_fileuid] = m_lock_info;
     }
     else {
         // File exists and the lock info has been created in the map.


### PR DESCRIPTION
This fix places the static mutex variables of `InterprocessMutex` onto the heap. They will not be destructed at all, fixing the problem of them automatically being destructed before the `InterprocessMutex` instances were destructed. This may cause a problem for valgrind, but it could be legitimately suppressed. To guarantee that the static variables are available on the first use, they are allocated by a `std::call_once` call which is thread safe.

@finnschiermer @jedelbo 

This should fix the stack trace reported by @alazier below:
```
util/thread.cpp:217: [realm-core-2.1.4] pthread_mutex_lock() failed: Invalid mutex object provided
0   realm-node.node                     0x00000001041c1ea8 _ZN5realm4utilL18terminate_internalERNSt3__118basic_stringstreamIcNS1_11char_traitsIcEENS1_9allocatorIcEEEE + 40
1   realm-node.node                     0x00000001041c21a5 _ZN5realm4util9terminateEPKcS2_lOSt16initializer_listINS0_9PrintableEE + 517
2   realm-node.node                     0x00000001041c29fa _ZN5realm4util5Mutex11lock_failedEi + 122
3   realm-node.node                     0x00000001042a62aa _ZN5realm4util17InterprocessMutex14free_lock_infoEv + 170
4   realm-node.node                     0x00000001042a3f67 _ZN5realm11SharedGroupD2Ev + 119
5   realm-node.node                     0x000000010415fe9c _ZN5realm5_impl16RealmCoordinatorD2Ev + 236
6   libc++.1.dylib                      0x00007fff8ced3cb8 _ZNSt3__119__shared_weak_count16__release_sharedEv + 44
7   realm-node.node                     0x000000010414d81c _ZN5realm5RealmD2Ev + 84
8   libc++.1.dylib                      0x00007fff8ced3cb8 _ZNSt3__119__shared_weak_count16__release_sharedEv + 44
9   realm-node.node                     0x000000010412ca38 _ZN5realm14GlobalNotifierD2Ev + 236
10  realm-node.node                     0x0000000104101611 _ZNSt3__110unique_ptrIN5realm14GlobalNotifierENS_14default_deleteIS2_EEED1Ev + 29
11  libsystem_c.dylib                   0x00007fff8f3c4463 __cxa_finalize_ranges + 345
12  libsystem_c.dylib                   0x00007fff8f3c4767 exit + 55
13  node                                0x000000010067256e _ZN4node11MemoryUsageERKN2v820FunctionCallbackInfoINS0_5ValueEEE + 0
14  node                                0x0000000100180dff _ZN2v88internal25FunctionCallbackArguments4CallEPFvRKNS_20FunctionCallbackInfoINS_5ValueEEEE + 159
15  node                                0x00000001001aa465 _ZN2v88internalL19HandleApiCallHelperILb0EEENS0_11MaybeHandleINS0_6ObjectEEEPNS0_7IsolateERNS0_12_GLOBAL__N_116BuiltinArgumentsILNS0_21BuiltinExtraArgumentsE1EEE + 1253
16  node                                0x00000001001accd1 _ZN2v88internalL21Builtin_HandleApiCallEiPPNS0_6ObjectEPNS0_7IsolateE + 65
17  ???                                 0x000020b69f80839b 0x0 + 35968732136347
18  ???                                 0x000020b69f9fb863 0x0 + 35968734181475
19  ???                                 0x000020b69f808297 0x0 + 35968732136087
```