### PR TITLE
Minor preprocessor / define fixes

### DIFF
--- a/src/realm/util/features.h
+++ b/src/realm/util/features.h
@@ -234,6 +234,8 @@
 
 #if REALM_ANDROID || REALM_IOS || REALM_WATCHOS
 #define REALM_MOBILE 1
+#else
+#define REALM_MOBILE 0
 #endif
 
 

--- a/src/realm/util/terminate.cpp
+++ b/src/realm/util/terminate.cpp
@@ -30,7 +30,7 @@
 #include <CoreFoundation/CoreFoundation.h>
 #endif
 
-#ifdef __ANDROID__
+#if REALM_ANDROID
 #include <android/log.h>
 #endif
 

--- a/test/test_all.cpp
+++ b/test/test_all.cpp
@@ -414,7 +414,7 @@ bool run_tests(util::Logger* logger)
     // Set up reporter
     std::ofstream xml_file;
     bool xml;
-#ifdef REALM_MOBILE
+#if REALM_MOBILE
     xml = true;
 #else
     const char* xml_str = getenv("UNITTEST_XML");


### PR DESCRIPTION
Some time ago we decided to have our `REALM_` macros to be always defined. While doing #2245 I stumbled across these and just fixed them.

@ironage