### PR TITLE
added specific exception for incompatible histories

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,9 @@
 
 ### Breaking changes
 
-* Lorem ipsum.
+* Attempts to open a Realm file with a different history type (Mobile Platform vs
+  Mobile Database) now throws an IncompatibleHistories exception instead of a
+  InvalidDatabase (as requested in issue #2275).
 
 ### Enhancements
 

--- a/src/realm/group_shared.cpp
+++ b/src/realm/group_shared.cpp
@@ -947,18 +947,22 @@ void SharedGroup::do_open(const std::string& path, bool no_create_file, bool is_
                     case Replication::hist_None:
                     case Replication::hist_OutOfRealm:
                         good_history_type = (stored_history_type == Replication::hist_None);
+                        if (!good_history_type)
+                            throw IncompatibleHistories("Expected a Realm without history", path);
                         break;
                     case Replication::hist_InRealm:
                         good_history_type = (stored_history_type == Replication::hist_InRealm ||
                                              stored_history_type == Replication::hist_None);
+                        if (!good_history_type)
+                            throw IncompatibleHistories("Expected a Realm with no or in-realm history", path);
                         break;
                     case Replication::hist_Sync:
                         good_history_type = ((stored_history_type == Replication::hist_Sync) ||
                                              (stored_history_type == Replication::hist_None && top_ref == 0));
+                        if (!good_history_type)
+                            throw IncompatibleHistories(
+                                "Expected an empty Realm or a Realm written by Realm Mobile Platform", path);
                 }
-                if (!good_history_type)
-                    throw InvalidDatabase("Bad or incompatible history type", path);
-
                 if (Replication* repl = gf::get_replication(m_group))
                     repl->initiate_session(version); // Throws
 

--- a/src/realm/group_shared.hpp
+++ b/src/realm/group_shared.hpp
@@ -54,6 +54,15 @@ struct IncompatibleLockFile : std::runtime_error {
     }
 };
 
+/// Thrown by SharedGroup::open() if the realm database was generated with
+/// a format for Realm Mobile Platform but is being opened as a Realm
+/// Mobile Database or vice versa.
+struct IncompatibleHistories : util::File::AccessError {
+    IncompatibleHistories(const std::string& msg, const std::string& path)
+        : util::File::AccessError("Incompatible histories. " + msg, path)
+    {
+    }
+};
 
 /// A SharedGroup facilitates transactions.
 ///

--- a/test/test_lang_bind_helper.cpp
+++ b/test/test_lang_bind_helper.cpp
@@ -12137,7 +12137,7 @@ TEST(LangBindHelper_InRealmHistory_Downgrade)
     }
     {
         // No history
-        CHECK_THROW(SharedGroup(path), InvalidDatabase);
+        CHECK_THROW(SharedGroup(path), IncompatibleHistories);
     }
 }
 


### PR DESCRIPTION
This PR adds an exception to specifically indicate that a Realm is being opened with an incompatible history type. Requested by PR #2275 