### PR TITLE
Allow querying for NULL in non-nullable string columns

### DIFF
--- a/src/realm/column_string.cpp
+++ b/src/realm/column_string.cpp
@@ -939,8 +939,12 @@ void StringColumn::find_all(IntegerColumn& result, StringData value, size_t begi
 
 FindRes StringColumn::find_all_no_copy(StringData value, InternalFindResult& result) const
 {
-    REALM_ASSERT_DEBUG(!(!m_nullable && value.is_null()));
     REALM_ASSERT(m_search_index);
+
+    if (value.is_null() && !m_nullable) {
+        // Early out if looking for null but we aren't nullable.
+        return FindRes::FindRes_not_found;
+    }
 
     return m_search_index->find_all_no_copy(value, result);
 }


### PR DESCRIPTION
There was a debug assertion in `StringColumn::find_all_no_copy` that was hit when running with a debug Core, because a binding tried to run a query that was looking for NULLs on a non-nullable column.

Crashing when looking for NULL on a non-nullable column does not seem like the right thing to do. This changes the assertion to an early-out.

@ironage @rrrlasse @radu-tutueanu 