### PR TITLE
Fix a crash when reimporting a Query into the same SharedGroup as it was exported from

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,8 @@
 ### Bugfixes
 
 * Fix a race involving destruction order of InterprocessMutex static variables.
+* Fix a crash when a Query is reimported into the SharedGroup it was exported
+  for handover from.
 
 ### Breaking changes
 

--- a/src/realm/query_engine.hpp
+++ b/src/realm/query_engine.hpp
@@ -240,7 +240,7 @@ public:
         , m_dT(from.m_dT)
         , m_probes(from.m_probes)
         , m_matches(from.m_matches)
-        , m_table(from.m_table)
+        , m_table(patches ? ConstTableRef{} : from.m_table)
     {
     }
 
@@ -300,10 +300,8 @@ protected:
                      const QueryNodeHandoverPatches* patches)
     {
         if (src.m_column) {
-            if (patches) {
+            if (patches)
                 dst_idx = src.m_column->get_column_index();
-                REALM_ASSERT_DEBUG(dst_idx < m_table->get_column_count());
-            }
             else
                 dst.init(src.m_column);
         }

--- a/src/realm/query_expression.hpp
+++ b/src/realm/query_expression.hpp
@@ -1630,11 +1630,12 @@ public:
     LinkMap(LinkMap const& other, QueryNodeHandoverPatches* patches)
         : LinkMap(other)
     {
-        if (!patches || m_link_column_indexes.empty())
+        if (!patches)
             return;
 
         m_link_column_indexes.clear();
         const Table* table = m_base_table;
+        m_base_table = nullptr;
         for (auto column : m_link_columns) {
             m_link_column_indexes.push_back(column->get_column_index());
             if (table->get_real_column_type(m_link_column_indexes.back()) == col_type_BackLink)
@@ -1964,12 +1965,12 @@ public:
     {
         return string_compare<Contains, ContainsIns>(*this, col, case_sensitive);
     }
-    
+
     Query like(StringData sd, bool case_sensitive = true)
     {
         return string_compare<StringData, Like, LikeIns>(*this, sd, case_sensitive);
     }
-    
+
     Query like(const Columns<StringData>& col, bool case_sensitive = true)
     {
         return string_compare<Like, LikeIns>(*this, col, case_sensitive);
@@ -2459,9 +2460,11 @@ public:
     template <class ColType2 = ColType>
     void evaluate_internal(size_t index, ValueBase& destination)
     {
+        REALM_ASSERT_DEBUG(m_sg.get());
+        REALM_ASSERT_DEBUG(dynamic_cast<SequentialGetter<ColType2>*>(m_sg.get()));
+
         using U = typename ColType2::value_type;
         auto sgc = static_cast<SequentialGetter<ColType2>*>(m_sg.get());
-        REALM_ASSERT_DEBUG(dynamic_cast<SequentialGetter<ColType2>*>(m_sg.get()));
         REALM_ASSERT_DEBUG(sgc->m_column);
 
         if (links_exist()) {


### PR DESCRIPTION
`m_table` needs to not be set on the handover Query in order for the column
references to be updated properly when re-importing it into the same
SharedGroup. This could theoretically cause problems when exporting and
importing into a different SharedGroup, but it's very unlikely (it'd require
that the source SharedGroup be destroyed and then the target one happen to
allocate the equivalent Table at the same memory address).

The removed assertion was not actually asserting anything sensible (`m_table`
was previously the same table as it was getting the column index from, so it
wasn't an interesting assert, and now is null so the assert would just crash).