### PR TITLE
mkfifo in tmp again if fails with EPERM

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@
 
 ### Breaking changes
 
-* Lorem ipsum.
+* Lorem ipsum. 
 
 ### Enhancements
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@
 * Fix a race involving destruction order of InterprocessMutex static variables.
 * Fix a crash when a Query is reimported into the SharedGroup it was exported
   for handover from.
+* Fix a crash when calling mkfifo on Android 4.x external storage. On 4.x devices,
+  errno is EPERM instead of EACCES.
 
 ### Breaking changes
 

--- a/src/realm/util/interprocess_condvar.cpp
+++ b/src/realm/util/interprocess_condvar.cpp
@@ -100,7 +100,7 @@ void InterprocessCondVar::set_shared_part(SharedPart& shared_part, std::string b
     int ret = mkfifo(m_resource_path.c_str(), 0600);
     if (ret == -1) {
         int err = errno;
-        if (err == ENOTSUP || err == EACCES) {
+        if (err == ENOTSUP || err == EACCES || err == EPERM) {
             // Filesystem doesn't support named pipes, so try putting it in tmp instead
             // Hash collisions are okay here because they just result in doing
             // extra work, as opposed to correctness problems


### PR DESCRIPTION
mkfifo on Android 4.x has a different behaviour when mkfifo fails by
creating on the external storage. 4.x fails with errno EPERM but the
on recent Android devices it fails with EACCES.