### PR TITLE
Offer facilities to prevent multiple sync agents per Realm file access session

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,11 @@
 ### Enhancements
 
 * Added support for LIKE queries (wildcard with ? and *)
+* Offer facilities to prevent multiple sync agents per Realm file access session
+  (`Replication::is_sync_agent()` to be overridden by sync-specific
+  implementation). The utilized lock-file flag
+  (`SharedInfo::sync_agent_present`) was added a long time ago, but the
+  completion of detection mechanism got postoponed until now.
 
 -----------
 

--- a/src/realm/exceptions.hpp
+++ b/src/realm/exceptions.hpp
@@ -68,6 +68,16 @@ public:
     const char* what() const noexcept override;
 };
 
+
+/// Thrown when a sync agent attempts to join a session in which there is
+/// already a sync agent. A session may only contain one sync agent at any given
+/// time.
+class MultipleSyncAgents : public std::exception {
+public:
+    const char* what() const noexcept override;
+};
+
+
 /// Thrown when memory can no longer be mapped to. When mmap/remap fails.
 class AddressSpaceExhausted : public std::runtime_error {
 public:
@@ -230,6 +240,11 @@ inline const char* DescriptorMismatch::what() const noexcept
 inline const char* FileFormatUpgradeRequired::what() const noexcept
 {
     return "Database upgrade required but prohibited";
+}
+
+inline const char* MultipleSyncAgents::what() const noexcept
+{
+    return "Multiple sync agents attempted to join the same session";
 }
 
 // LCOV_EXCL_STOP

--- a/src/realm/replication.hpp
+++ b/src/realm/replication.hpp
@@ -360,6 +360,12 @@ public:
     /// returns \ref hist_None.
     virtual _impl::History* get_history() = 0;
 
+    /// Returns false by default, but must return true if, and only if this
+    /// history object represents a session participant that is a sync
+    /// agent. This is used to enforce the "maximum one sync agent per session"
+    /// constraint.
+    virtual bool is_sync_agent() const noexcept;
+
     virtual ~Replication() noexcept
     {
     }
@@ -485,6 +491,11 @@ inline void Replication::interrupt() noexcept
 inline void Replication::clear_interrupt() noexcept
 {
     do_clear_interrupt();
+}
+
+inline bool Replication::is_sync_agent() const noexcept
+{
+    return false;
 }
 
 inline TrivialReplication::TrivialReplication(const std::string& database_file)


### PR DESCRIPTION
@jedelbo @ironage , can I ask you guys to review?

This PR provides (completes) the facilities needed to detect attempts at adding multiple concurrent sync agents to a single Realm file access session. This is not allowed as it will generally lead to corruption. Now we have a chance to detect if somebody makes this occur by mistake.