### PR TITLE
Use MemRef instead of ref_type in BpTree constructor

### DIFF
--- a/src/realm/bptree.hpp
+++ b/src/realm/bptree.hpp
@@ -249,15 +249,15 @@ public:
     BpTree();
     explicit BpTree(BpTreeBase::unattached_tag);
     explicit BpTree(Allocator& alloc);
-    REALM_DEPRECATED("Initialize with ref instead") explicit BpTree(std::unique_ptr<Array> init_root)
+    REALM_DEPRECATED("Initialize with MemRef instead") explicit BpTree(std::unique_ptr<Array> init_root)
         : BpTreeBase(std::move(init_root))
     {
 
     }
-    explicit BpTree(Allocator& alloc, ref_type ref)
+    explicit BpTree(Allocator& alloc, MemRef mem)
         : BpTreeBase(std::unique_ptr<Array>(new LeafType(alloc)))
     {
-        init_from_ref(alloc, ref);
+        init_from_mem(alloc, mem);
     }
     BpTree(BpTree&&) = default;
     BpTree& operator=(BpTree&&) = default;
@@ -285,7 +285,7 @@ public:
     size_t find_first(T value, size_t begin = 0, size_t end = npos) const;
     void find_all(IntegerColumn& out_indices, T value, size_t begin = 0, size_t end = npos) const;
 
-    static ref_type create_leaf(Array::Type leaf_type, size_t size, T value, Allocator&);
+    static MemRef create_leaf(Array::Type leaf_type, size_t size, T value, Allocator&);
 
     /// See LeafInfo for information about what to put in the inout_leaf
     /// parameter.
@@ -1139,11 +1139,11 @@ ref_type BpTree<T>::write(size_t slice_offset, size_t slice_size, size_t table_s
 }
 
 template <class T>
-ref_type BpTree<T>::create_leaf(Array::Type leaf_type, size_t size, T value, Allocator& alloc)
+MemRef BpTree<T>::create_leaf(Array::Type leaf_type, size_t size, T value, Allocator& alloc)
 {
     bool context_flag = false;
     MemRef mem = LeafType::create_array(leaf_type, context_flag, size, std::move(value), alloc);
-    return mem.get_ref();
+    return mem;
 }
 
 template <class T>

--- a/src/realm/column.hpp
+++ b/src/realm/column.hpp
@@ -1140,6 +1140,12 @@ Column<T>::Column(unattached_root_tag, Allocator& alloc)
 }
 
 template <class T>
+Column<T>::Column(std::unique_ptr<Array> root) noexcept
+    : m_tree(std::move(root))
+{
+}
+
+template <class T>
 Column<T>::~Column() noexcept
 {
 }
@@ -1564,8 +1570,8 @@ public:
     }
     ref_type create_leaf(size_t size) override
     {
-        ref_type ref = BpTree<T>::create_leaf(m_leaf_type, size, m_value, m_alloc); // Throws
-        return ref;
+        MemRef mem = BpTree<T>::create_leaf(m_leaf_type, size, m_value, m_alloc); // Throws
+        return mem.get_ref();
     }
 
 private:

--- a/src/realm/column_timestamp.cpp
+++ b/src/realm/column_timestamp.cpp
@@ -61,8 +61,8 @@ public:
 
     ref_type create_leaf(size_t size) override
     {
-        ref_type ref =  BT::create_leaf(Array::type_Normal, size, m_value, m_alloc); // Throws
-        return ref;
+        MemRef mem =  BT::create_leaf(Array::type_Normal, size, m_value, m_alloc); // Throws
+        return mem.get_ref();
     }
 
 private:


### PR DESCRIPTION
No need to convert to ref_type as it is costly to convert back again.

@kspangsege 