### PR TITLE
Fix LinkView::refresh_accessor_tree

### DIFF
--- a/src/realm/bptree.hpp
+++ b/src/realm/bptree.hpp
@@ -438,9 +438,10 @@ inline BpTreeNode& BpTreeBase::root_as_node()
 
 inline const BpTreeNode& BpTreeBase::root_as_node() const
 {
+    Array* arr = m_root.get();
     REALM_ASSERT_DEBUG(!root_is_leaf());
-    REALM_ASSERT_DEBUG(dynamic_cast<const BpTreeNode*>(m_root.get()) != nullptr);
-    return static_cast<const BpTreeNode&>(root());
+    REALM_ASSERT_DEBUG(dynamic_cast<const BpTreeNode*>(arr) != nullptr);
+    return static_cast<const BpTreeNode&>(*arr);
 }
 
 inline void BpTreeBase::set_parent(ArrayParent* parent, size_t ndx_in_parent) noexcept
@@ -706,11 +707,16 @@ template <class T>
 void BpTree<T>::init_from_parent()
 {
     ref_type ref = root().get_ref_from_parent();
-    ArrayParent* parent = m_root->get_parent();
-    size_t ndx_in_parent = m_root->get_ndx_in_parent();
-    auto new_root = create_root_from_ref(get_alloc(), ref);
-    new_root->set_parent(parent, ndx_in_parent);
-    m_root = std::move(new_root);
+    if (ref) {
+        ArrayParent* parent = m_root->get_parent();
+        size_t ndx_in_parent = m_root->get_ndx_in_parent();
+        auto new_root = create_root_from_ref(get_alloc(), ref);
+        new_root->set_parent(parent, ndx_in_parent);
+        m_root = std::move(new_root);
+    }
+    else {
+        m_root->detach();
+    }
 }
 
 template <class T>

--- a/src/realm/link_view.hpp
+++ b/src/realm/link_view.hpp
@@ -174,10 +174,8 @@ inline LinkView::LinkView(const ctor_cookie&, Table* origin_table, LinkListColum
     , m_origin_table(origin_table->get_table_ref())
     , m_origin_column(column)
 {
-    Array& root = *m_row_indexes.get_root_array();
-    root.set_parent(&column, row_ndx);
-    if (ref_type ref = root.get_ref_from_parent())
-        m_row_indexes.init_from_ref(column.get_alloc(), ref);
+    m_row_indexes.set_parent(&m_origin_column, row_ndx);
+    m_row_indexes.init_from_parent();
 }
 
 inline std::shared_ptr<LinkView> LinkView::create(Table* origin_table, LinkListColumn& column, size_t row_ndx)
@@ -329,14 +327,8 @@ inline Table& LinkView::get_target_table() noexcept
 
 inline void LinkView::refresh_accessor_tree(size_t new_row_ndx) noexcept
 {
-    Array& root = *m_row_indexes.get_root_array();
-    root.set_ndx_in_parent(new_row_ndx);
-    if (ref_type ref = root.get_ref_from_parent()) {
-        root.init_from_ref(ref);
-    }
-    else {
-        root.detach();
-    }
+    set_origin_row_index(new_row_ndx);
+    m_row_indexes.init_from_parent();
 }
 
 inline void LinkView::update_from_parent(size_t old_baseline) noexcept


### PR DESCRIPTION
The problem occurred when refreshing a link view accessor from a leaf to a node. We should take into
account that we need to create another class when the root is an inner node.

Fixes issue #2321 
