### PR TITLE
Improve performance of the 5 -> 6 file format upgrade

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,8 @@
   implementation). The utilized lock-file flag
   (`SharedInfo::sync_agent_present`) was added a long time ago, but the
   completion of detection mechanism got postponed until now.
+* Improve performance of write transactions which free a large amount of
+  existing data.
 
 -----------
 

--- a/src/realm/alloc_slab.cpp
+++ b/src/realm/alloc_slab.cpp
@@ -494,10 +494,6 @@ void SlabAlloc::consolidate_free_read_only()
             prev = it;
             continue;
         }
-        if (std::any_of(m_slabs.begin(), m_slabs.end(), SlabRefEndEq(prev->ref + prev->size))) {
-            prev = it;
-            continue;
-        }
 
         prev->size += it->size;
         it->size = 0;

--- a/src/realm/alloc_slab.cpp
+++ b/src/realm/alloc_slab.cpp
@@ -416,12 +416,14 @@ void SlabAlloc::do_free(ref_type ref, const char* addr) noexcept
 
     m_free_space_state = free_space_Dirty;
 
+#ifdef REALM_DEBUG
     // Check for double free
     for (auto& c : free_space) {
         if ((ref >= c.ref && ref < (c.ref + c.size)) || (ref < c.ref && ref_end > c.ref)) {
-            REALM_ASSERT_RELEASE(!"Double Free");
+            REALM_ASSERT(!"Double Free");
         }
     }
+#endif
 
     // Check if we can merge with adjacent succeeding free block
     typedef chunks::iterator iter;

--- a/src/realm/alloc_slab.cpp
+++ b/src/realm/alloc_slab.cpp
@@ -426,33 +426,35 @@ void SlabAlloc::do_free(ref_type ref, const char* addr) noexcept
     // Check if we can merge with adjacent succeeding free block
     typedef chunks::iterator iter;
     iter merged_with = free_space.end();
-    {
-        iter i = find_if(free_space.begin(), free_space.end(), ChunkRefEq(ref_end));
-        if (i != free_space.end()) {
-            // No consolidation over slab borders
-            if (find_if(m_slabs.begin(), m_slabs.end(), SlabRefEndEq(ref_end)) == m_slabs.end()) {
-                i->ref = ref;
-                i->size += size;
-                merged_with = i;
+    if (!read_only) {
+        {
+            iter i = find_if(free_space.begin(), free_space.end(), ChunkRefEq(ref_end));
+            if (i != free_space.end()) {
+                // No consolidation over slab borders
+                if (find_if(m_slabs.begin(), m_slabs.end(), SlabRefEndEq(ref_end)) == m_slabs.end()) {
+                    i->ref = ref;
+                    i->size += size;
+                    merged_with = i;
+                }
             }
         }
-    }
 
-    // Check if we can merge with adjacent preceeding free block (not if that
-    // would cross slab boundary)
-    if (find_if(m_slabs.begin(), m_slabs.end(), SlabRefEndEq(ref)) == m_slabs.end()) {
-        iter i = find_if(free_space.begin(), free_space.end(), ChunkRefEndEq(ref));
-        if (i != free_space.end()) {
-            if (merged_with != free_space.end()) {
-                i->size += merged_with->size;
-                // Erase by "move last over"
-                *merged_with = free_space.back();
-                free_space.pop_back();
+        // Check if we can merge with adjacent preceeding free block (not if that
+        // would cross slab boundary)
+        if (find_if(m_slabs.begin(), m_slabs.end(), SlabRefEndEq(ref)) == m_slabs.end()) {
+            iter i = find_if(free_space.begin(), free_space.end(), ChunkRefEndEq(ref));
+            if (i != free_space.end()) {
+                if (merged_with != free_space.end()) {
+                    i->size += merged_with->size;
+                    // Erase by "move last over"
+                    *merged_with = free_space.back();
+                    free_space.pop_back();
+                }
+                else {
+                    i->size += size;
+                }
+                return;
             }
-            else {
-                i->size += size;
-            }
-            return;
         }
     }
 
@@ -468,6 +470,41 @@ void SlabAlloc::do_free(ref_type ref, const char* addr) noexcept
             m_free_space_state = free_space_Invalid;
         }
     }
+}
+
+
+void SlabAlloc::consolidate_free_read_only()
+{
+    if (REALM_COVER_NEVER(m_free_space_state == free_space_Invalid))
+        throw InvalidFreeSpace();
+    if (m_free_read_only.empty())
+        return;
+
+    std::sort(begin(m_free_read_only), end(m_free_read_only), [](auto& a, auto& b) {
+        return a.ref < b.ref;
+    });
+
+    // Combine any adjacent chunks in the freelist, except for when the chunks
+    // are on the edge of an allocation slab
+    auto prev = m_free_read_only.begin();
+    for (auto it = m_free_read_only.begin() + 1; it != m_free_read_only.end(); ++it) {
+        if (prev->ref + prev->size != it->ref) {
+            prev = it;
+            continue;
+        }
+        if (std::any_of(m_slabs.begin(), m_slabs.end(), SlabRefEndEq(prev->ref + prev->size))) {
+            prev = it;
+            continue;
+        }
+
+        prev->size += it->size;
+        it->size = 0;
+    }
+
+    // Remove all of the now zero-size chunks from the free list
+    m_free_read_only.erase(std::remove_if(begin(m_free_read_only), end(m_free_read_only),
+                                          [](auto& chunk) { return chunk.size == 0; }),
+                           end(m_free_read_only));
 }
 
 

--- a/src/realm/alloc_slab.hpp
+++ b/src/realm/alloc_slab.hpp
@@ -431,6 +431,8 @@ private:
     mutable size_t version = 1;
 
     /// Throws if free-lists are no longer valid.
+    void consolidate_free_read_only();
+    /// Throws if free-lists are no longer valid.
     const chunks& get_free_read_only() const;
 
     /// Throws InvalidDatabase if the file is not a Realm file, if the file is

--- a/src/realm/array.cpp
+++ b/src/realm/array.cpp
@@ -920,25 +920,6 @@ exit:
     return ret;
 }
 
-size_t Array::find_gte_unsorted(const int64_t target, size_t start, size_t end) const
-{
-    REALM_ASSERT(start < size());
-    if (end > m_size)
-        end = m_size;
-
-    REALM_TEMPEX(return find_gte_unsorted, m_width, (target, start, end));
-}
-
-template <size_t w>
-size_t Array::find_gte_unsorted(const int64_t target, size_t start, size_t end) const
-{
-    for (size_t idx = start; idx < end; ++idx) {
-        if (get<w>(idx) >= target)
-            return idx;
-    }
-    return not_found;
-}
-
 size_t Array::first_set_bit(unsigned int v) const
 {
 #if 0 && defined(USE_SSE42) && defined(_MSC_VER) && defined(REALM_PTR_64)

--- a/src/realm/array.cpp
+++ b/src/realm/array.cpp
@@ -920,6 +920,25 @@ exit:
     return ret;
 }
 
+size_t Array::find_gte_unsorted(const int64_t target, size_t start, size_t end) const
+{
+    REALM_ASSERT(start < size());
+    if (end > m_size)
+        end = m_size;
+
+    REALM_TEMPEX(return find_gte_unsorted, m_width, (target, start, end));
+}
+
+template <size_t w>
+size_t Array::find_gte_unsorted(const int64_t target, size_t start, size_t end) const
+{
+    for (size_t idx = start; idx < end; ++idx) {
+        if (get<w>(idx) >= target)
+            return idx;
+    }
+    return not_found;
+}
+
 size_t Array::first_set_bit(unsigned int v) const
 {
 #if 0 && defined(USE_SSE42) && defined(_MSC_VER) && defined(REALM_PTR_64)

--- a/src/realm/array.hpp
+++ b/src/realm/array.hpp
@@ -540,6 +540,16 @@ public:
     ///        this \c Array, sorted in ascending order
     /// \return the index of the value if found, or realm::not_found otherwise
     size_t find_gte(const int64_t target, size_t start, size_t end = size_t(-1)) const;
+
+    /// \brief Search the \c Array for a value greater or equal than \a target,
+    /// starting the search at the \a start index.
+    ///
+    /// \param target the smallest value to search for
+    /// \param start the offset at which to start searching in the array
+    /// \param end the offset at which to stop searching in the array
+    /// \return the index of the value if found, or realm::not_found otherwise
+    size_t find_gte_unsorted(const int64_t target, size_t start, size_t end = size_t(-1)) const;
+
     void preset(int64_t min, int64_t max, size_t num_items);
     void preset(size_t bitwidth, size_t num_items);
 
@@ -943,6 +953,9 @@ private:
 
     template <size_t w>
     size_t find_gte(const int64_t target, size_t start, size_t end) const;
+
+    template <size_t w>
+    size_t find_gte_unsorted(const int64_t target, size_t start, size_t end) const;
 
     template <size_t w>
     size_t adjust_ge(size_t start, size_t end, int_fast64_t limit, int_fast64_t diff);

--- a/src/realm/array.hpp
+++ b/src/realm/array.hpp
@@ -541,15 +541,6 @@ public:
     /// \return the index of the value if found, or realm::not_found otherwise
     size_t find_gte(const int64_t target, size_t start, size_t end = size_t(-1)) const;
 
-    /// \brief Search the \c Array for a value greater or equal than \a target,
-    /// starting the search at the \a start index.
-    ///
-    /// \param target the smallest value to search for
-    /// \param start the offset at which to start searching in the array
-    /// \param end the offset at which to stop searching in the array
-    /// \return the index of the value if found, or realm::not_found otherwise
-    size_t find_gte_unsorted(const int64_t target, size_t start, size_t end = size_t(-1)) const;
-
     void preset(int64_t min, int64_t max, size_t num_items);
     void preset(size_t bitwidth, size_t num_items);
 
@@ -953,9 +944,6 @@ private:
 
     template <size_t w>
     size_t find_gte(const int64_t target, size_t start, size_t end) const;
-
-    template <size_t w>
-    size_t find_gte_unsorted(const int64_t target, size_t start, size_t end) const;
 
     template <size_t w>
     size_t adjust_ge(size_t start, size_t end, int_fast64_t limit, int_fast64_t diff);

--- a/src/realm/group_writer.cpp
+++ b/src/realm/group_writer.cpp
@@ -332,6 +332,7 @@ ref_type GroupWriter::write_group()
     m_free_lengths.copy_on_write();   // Throws
     if (is_shared)
         m_free_versions.copy_on_write();                                            // Throws
+    m_group.m_alloc.consolidate_free_read_only();                                   // Throws
     const SlabAlloc::chunks& new_free_space = m_group.m_alloc.get_free_read_only(); // Throws
     max_free_list_size += new_free_space.size();
 
@@ -370,7 +371,7 @@ ref_type GroupWriter::write_group()
     // the free-lists any free space created during the current transaction (or
     // since last commit). Had we added it earlier, we would have risked
     // clobering the previous database version. Note, however, that this risk
-    // would only have been present in the non-transactionl case where there is
+    // would only have been present in the non-transactional case where there is
     // no version tracking on the free-space chunks.
     for (const auto& free_space : new_free_space) {
         ref_type ref = free_space.ref;

--- a/src/realm/group_writer.cpp
+++ b/src/realm/group_writer.cpp
@@ -587,7 +587,7 @@ std::pair<size_t, size_t> GroupWriter::search_free_space_in_part_of_freelist(siz
     bool is_shared = m_group.m_is_shared;
     SlabAlloc& alloc = m_group.m_alloc;
     for (size_t next_start = begin; next_start < end; ) {
-        size_t i = m_free_lengths.find_gte_unsorted(size, next_start);
+        size_t i = m_free_lengths.find_first<Greater>(size - 1, next_start);
         if (i == not_found) {
             break;
         }


### PR DESCRIPTION
And probably a bunch of other things since none of this is specific to the file format upgrade. Gives roughly a 10x performance improvement on the sample file sent in for https://github.com/realm/realm-cocoa/issues/4368 (goes from 10-15 seconds on my machine to 1.5 seconds).

Deferring the consolidation of the read-only free space until just before it's actually written to the file makes the best case slightly slower, since it'll always push_back() a new chunk rather than just updating the previous one when all of the chunks being freed are contiguous, but it makes the worst case O(N log N) rather than O(N^2). In practice in the happy case of upgrading a compacted Realm the time spent in the allocator is trivial in both versions.

Adding and using `Array::find_gte_unsorted()` rather than looping over the array calling `get()` cuts the amount of time spent in `GroupWriter::search_free_space_in_part_of_freelist()` by about 75%. After the optimizations it's still about 50% of the total runtime, so further optimizations here could be interesting.

This partially reverts bc8b146576bb8ccc146f59f2265a3668510b487d as the performance impact of it is not remotely acceptable for a release build.

@rrrlasse 