### PR TITLE
Fix util::File::copy() and add util::File::compare().

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,11 @@
 
 ### Breaking changes
 
-* Lorem ipsum. 
+* The return type of `util::File::copy()` has been changed from `bool` to
+  `void`. Errors are now reported via `File::AccessError` exceptions. This
+  greatly increases the utility and robustness of `util::File::copy()`, as it
+  now catches all errors, and reports them in the same style as the other
+  functions in `util::File`.
 
 ### Enhancements
 
@@ -22,6 +26,7 @@
   completion of detection mechanism got postponed until now.
 * Improve performance of write transactions which free a large amount of
   existing data.
+* Added `util::File::compare()` for comparing two files for equality.
 
 -----------
 

--- a/src/realm/util/file.cpp
+++ b/src/realm/util/file.cpp
@@ -999,27 +999,38 @@ void File::move(const std::string& old_path, const std::string& new_path)
 }
 
 
-bool File::copy(std::string source, std::string destination)
+void File::copy(const std::string& origin_path, const std::string& target_path)
 {
-    // Quick and dirty file copy, only used for unit tests. Todo, make more robust if used by Core.
-    char buf[1024];
-    size_t read;
-    File::try_remove(destination);
-    FILE* src = fopen(source.c_str(), "rb");
-    if (!src)
-        return false;
-
-    FILE* dst = fopen(destination.c_str(), "wb");
-    if (!dst) {
-        fclose(src);
-        return false;
+    File origin_file{origin_path, mode_Read};  // Throws
+    File target_file{target_path, mode_Write}; // Throws
+    size_t buffer_size = 4096;
+    std::unique_ptr<char[]> buffer = std::make_unique<char[]>(buffer_size); // Throws
+    for (;;) {
+        size_t n = origin_file.read(buffer.get(), buffer_size); // Throws
+        target_file.write(buffer.get(), n); // Throws
+        if (n < buffer_size)
+            break;
     }
+}
 
-    while ((read = fread(buf, 1, 1024, src))) {
-        fwrite(buf, 1, read, dst);
+
+bool File::compare(const std::string& path_1, const std::string& path_2)
+{
+    File file_1{path_1}; // Throws
+    File file_2{path_2}; // Throws
+    size_t buffer_size = 4096;
+    std::unique_ptr<char[]> buffer_1 = std::make_unique<char[]>(buffer_size); // Throws
+    std::unique_ptr<char[]> buffer_2 = std::make_unique<char[]>(buffer_size); // Throws
+    for (;;) {
+        size_t n_1 = file_1.read(buffer_1.get(), buffer_size); // Throws
+        size_t n_2 = file_2.read(buffer_2.get(), buffer_size); // Throws
+        if (n_1 != n_2)
+            return false;
+        if (!std::equal(buffer_1.get(), buffer_1.get() + n_1, buffer_2.get()))
+            return false;
+        if (n_1 < buffer_size)
+            break;
     }
-    fclose(src);
-    fclose(dst);
     return true;
 }
 

--- a/src/realm/util/file.hpp
+++ b/src/realm/util/file.hpp
@@ -416,7 +416,13 @@ public:
     /// provides the information to unambiguously distinguish that
     /// particular reason).
     static void move(const std::string& old_path, const std::string& new_path);
-    static bool copy(std::string source, std::string destination);
+
+    /// Copy the file at the specified origin path to the specified target path.
+    static void copy(const std::string& origin_path, const std::string& target_path);
+
+    /// Compare the two files at the specified paths for equality. Returns true
+    /// if, and only if they are equal.
+    static bool compare(const std::string& path_1, const std::string& path_2);
 
     /// Check whether two open file descriptors refer to the same
     /// underlying file, that is, if writing via one of them, will

--- a/test/test_upgrade_database.cpp
+++ b/test/test_upgrade_database.cpp
@@ -89,7 +89,7 @@ TEST(Upgrade_Database_2_3)
     // Automatic upgrade from Group
     {
         // Make a copy of the version 2 database so that we keep the original file intact and unmodified
-        CHECK_OR_RETURN(File::copy(path, temp_copy));
+        File::copy(path, temp_copy);
 
         // Open copy. Group constructor will upgrade automatically if needed, also even though user requested ReadOnly. Todo,
         // discuss if this is OK.
@@ -124,7 +124,7 @@ TEST(Upgrade_Database_2_3)
     // Prohibit automatic upgrade by SharedGroup
     {
         // Make a copy of the version 2 database so that we keep the original file intact and unmodified
-        CHECK_OR_RETURN(File::copy(path, temp_copy));
+        File::copy(path, temp_copy);
 
         bool no_create = false;
         SharedGroupOptions::Durability durability = SharedGroupOptions::Durability::Full;
@@ -138,7 +138,7 @@ TEST(Upgrade_Database_2_3)
     // Automatic upgrade from SharedGroup
     {
         // Make a copy of the version 2 database so that we keep the original file intact and unmodified
-        CHECK_OR_RETURN(File::copy(path, temp_copy));
+        File::copy(path, temp_copy);
 
         SharedGroup sg(temp_copy);
         ReadTransaction rt(sg);
@@ -188,7 +188,7 @@ TEST(Upgrade_Database_2_3)
     // Begin from scratch; see if we can upgrade file and then use a write transaction
     {
         // Make a copy of the version 2 database so that we keep the original file intact and unmodified
-        CHECK_OR_RETURN(File::copy(path, temp_copy));
+        File::copy(path, temp_copy);
 
         SharedGroup sg(temp_copy);
         WriteTransaction rt(sg);
@@ -232,7 +232,7 @@ TEST(Upgrade_Database_2_3)
 
     // Automatic upgrade from SharedGroup with replication
     {
-        CHECK_OR_RETURN(File::copy(path, temp_copy));
+        File::copy(path, temp_copy);
 
         std::unique_ptr<Replication> hist = make_in_realm_history(temp_copy);
         SharedGroup sg(*hist);
@@ -292,7 +292,7 @@ TEST(Upgrade_Database_2_Backwards_Compatible)
     // Make a copy of the database so that we keep the original file intact and unmodified
     SHARED_GROUP_TEST_PATH(temp_copy);
 
-    CHECK_OR_RETURN(File::copy(path, temp_copy));
+    File::copy(path, temp_copy);
     SharedGroup g(temp_copy, 0);
 
     using sgf = _impl::SharedGroupFriend;
@@ -433,7 +433,7 @@ TEST(Upgrade_Database_2_Backwards_Compatible_WriteTransaction)
 
     SHARED_GROUP_TEST_PATH(temp_copy);
 
-    CHECK_OR_RETURN(File::copy(path, temp_copy));
+    File::copy(path, temp_copy);
     SharedGroup g(temp_copy, 0);
 
     using sgf = _impl::SharedGroupFriend;
@@ -574,7 +574,7 @@ TEST(Upgrade_Database_Binary)
     // Make a copy of the database so that we keep the original file intact and unmodified
     SHARED_GROUP_TEST_PATH(temp_copy);
 
-    CHECK_OR_RETURN(File::copy(path, temp_copy));
+    File::copy(path, temp_copy);
     SharedGroup g(temp_copy, 0);
 
     WriteTransaction wt(g);
@@ -666,7 +666,7 @@ TEST(Upgrade_Database_Strings_With_NUL)
     // Make a copy of the database so that we keep the original file intact and unmodified
     SHARED_GROUP_TEST_PATH(temp_copy);
 
-    CHECK_OR_RETURN(File::copy(path, temp_copy));
+    File::copy(path, temp_copy);
     SharedGroup g(temp_copy, 0);
 
     WriteTransaction wt(g);
@@ -729,7 +729,7 @@ TEST(Upgrade_Database_2_3_Writes_New_File_Format)
                        util::to_string(REALM_MAX_BPNODE_SIZE) + "_1.realm";
     CHECK_OR_RETURN(File::exists(path));
     SHARED_GROUP_TEST_PATH(temp_copy);
-    CHECK_OR_RETURN(File::copy(path, temp_copy));
+    File::copy(path, temp_copy);
     SharedGroup sg1(temp_copy);
     SharedGroup sg2(temp_copy); // verify that the we can open another shared group, and it won't deadlock
     using sgf = _impl::SharedGroupFriend;
@@ -749,7 +749,7 @@ TEST(Upgrade_Database_2_3_Writes_New_File_Format_new)
                        util::to_string(REALM_MAX_BPNODE_SIZE) + "_1.realm";
     CHECK_OR_RETURN(File::exists(path));
     SHARED_GROUP_TEST_PATH(temp_copy);
-    CHECK_OR_RETURN(File::copy(path, temp_copy));
+    File::copy(path, temp_copy);
 
     util::Thread t[10];
 
@@ -777,7 +777,7 @@ TEST(Upgrade_InRealmHistory)
     SHARED_GROUP_TEST_PATH(temp_path);
 
     {
-        CHECK_OR_RETURN(File::copy(path, temp_path));
+        File::copy(path, temp_path);
         std::unique_ptr<Replication> hist = make_in_realm_history(temp_path);
         SharedGroup sg(*hist);
         using sgf = _impl::SharedGroupFriend;
@@ -787,7 +787,7 @@ TEST(Upgrade_InRealmHistory)
     // Try again, but do it in two steps (2->3, 3->6).
     {
         File::remove(temp_path);
-        CHECK_OR_RETURN(File::copy(path, temp_path));
+        File::copy(path, temp_path);
         bool no_create = true;
         {
             SharedGroup sg(temp_path, no_create);
@@ -812,7 +812,7 @@ TEST(Upgrade_DatabaseWithCallback)
     SHARED_GROUP_TEST_PATH(temp_copy);
 
     // Make a copy of the version 4 database so that we keep the original file intact and unmodified
-    CHECK_OR_RETURN(File::copy(path, temp_copy));
+    File::copy(path, temp_copy);
 
     // Constructing this SharedGroup will trigger Table::upgrade_olddatetime() for all tables because the file is
     // in version 3
@@ -849,7 +849,7 @@ TEST(Upgrade_DatabaseWithCallbackWithException)
     SHARED_GROUP_TEST_PATH(temp_copy);
 
     // Make a copy of the version 4 database so that we keep the original file intact and unmodified
-    CHECK_OR_RETURN(File::copy(path, temp_copy));
+    File::copy(path, temp_copy);
 
     // Constructing this SharedGroup will trigger Table::upgrade_olddatetime() for all tables because the file is
     // in version 3
@@ -911,7 +911,7 @@ TEST(Upgrade_Database_4_5_DateTime1)
         SHARED_GROUP_TEST_PATH(temp_copy);
 
         // Make a copy of the version 4 database so that we keep the original file intact and unmodified
-        CHECK_OR_RETURN(File::copy(path, temp_copy));
+        File::copy(path, temp_copy);
 
         // Constructing this SharedGroup will trigger Table::upgrade_olddatetime() for all tables because the file is
         // in version 4
@@ -1026,7 +1026,7 @@ TEST(Upgrade_Database_5_6_StringIndex)
 
         // Make a copy of the version 4 database so that we keep the
         // original file intact and unmodified
-        CHECK_OR_RETURN(File::copy(path, temp_copy));
+        File::copy(path, temp_copy);
 
         // Constructing this SharedGroup will trigger an upgrade
         // for all tables because the file is in version 4


### PR DESCRIPTION
When `util::File::copy()` was added, it was apparently done as a quick hack, and error handling was improper.

Errors are now reported via `File::AccessError` exceptions. This greatly increases the utility and robustness of `util::File::copy()`.

I added `util::File::compare()` because I needed it to test `util::File::copy()`, but I think it has general utility, so I'll leave it in.

@jedelbo @ironage 