### PR TITLE
New valgrind suppressions

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -3041,7 +3041,7 @@ EOF
         # Run by Jenkins. Relies on the WORKSPACE environment variable provided by Jenkins itself
         REALM_ENABLE_ALLOC_SET_ZERO=1 sh build.sh config || exit 1
         sh build.sh clean || exit 1
-        VALGRIND_FLAGS="--tool=memcheck --leak-check=full --undef-value-errors=yes --track-origins=yes --child-silent-after-fork=no --trace-children=yes --xml=yes --xml-file=${WORKSPACE}/realm-tests-dbg.%p.memreport" sh build.sh memcheck || exit 1
+        VALGRIND_FLAGS="--tool=memcheck --leak-check=full --undef-value-errors=yes --track-origins=yes --child-silent-after-fork=no --trace-children=yes --xml=yes --suppressions=${WORKSPACE}/valgrind.suppress --xml-file=${WORKSPACE}/realm-tests-dbg.%p.memreport" sh build.sh memcheck || exit 1
         exit 0
         ;;
 

--- a/test/valgrind.suppress
+++ b/test/valgrind.suppress
@@ -1,57 +1,65 @@
 {
-   <valgrind open problem>
-   drd:ConflictingAccess
-   fun:open
+   <AllocSlab::all_files and AllocSlab::all_files_mutex intentionally not destructed to prevent races>
+   Memcheck:Leak
+   match-leak-kinds: reachable
+   fun:_Znwm
+   fun:_GLOBAL__sub_I_alloc_slab.cpp
+   fun:call_init.part.0
+   fun:call_init
+   fun:_dl_init
    ...
-   obj:/usr/lib/valgrind/vgpreload_drd-amd64-linux.so
-   fun:start_thread
-   fun:clone
 }
 {
-   <valgrind close problem>
-   drd:ConflictingAccess
-   fun:close
+   <Entries added to the AllocSlab::all_files map are not freed namely `p = std::make_shared<MappedFile>();`>
+   Memcheck:Leak
+   match-leak-kinds: reachable
+   fun:_Znwm
+   fun:_ZNSt8_Rb_treeISsSt4pairIKSsSt8weak_ptrIN5realm9SlabAlloc10MappedFileEEESt10_Select1stIS7_ESt4lessISsESaIS7_EE22_M_emplace_hint_uniqueIIRKSt21piecewise_construct_tSt5tupleIIRS1_EESI_IIEEEEESt17_Rb_tree_iteratorIS7_ESt23_Rb_tree_const_iteratorIS7_EDpOT_
+   fun:_ZN5realm9SlabAlloc11attach_fileERKSsRNS0_6ConfigE
+   fun:_ZN5realm5Group4openERKSsPKcNS0_8OpenModeE
    ...
-   obj:/usr/lib/valgrind/vgpreload_drd-amd64-linux.so
-   fun:start_thread
-   fun:clone
 }
 {
-   <valgrind waitpid problem (presumed)>
-   drd:ConflictingAccess
-   fun:waitpid
-   fun:_Z12spawn_daemonRKSs
+   <std weak pointer allocated for entries in AllocSlab::all_files as above>
+   Memcheck:Leak
+   match-leak-kinds: reachable
+   fun:_Znwm
+   fun:_ZNSt8_Rb_treeISsSt4pairIKSsSt8weak_ptrIN5realm9SlabAlloc10MappedFileEEESt10_Select1stIS7_ESt4lessISsESaIS7_EE22_M_emplace_hint_uniqueIIRKSt21piecewise_construct_tSt5tupleIIRS1_EESI_IIEEEEESt17_Rb_tree_iteratorIS7_ESt23_Rb_tree_const_iteratorIS7_EDpOT_
+   fun:_ZN5realm9SlabAlloc11attach_fileERKSsRNS0_6ConfigE
+   fun:_ZN5realm11SharedGroup7do_openERKSsbbNS_18SharedGroupOptionsE
+   fun:_ZN5realm11SharedGroupC2ERKSsbNS_18SharedGroupOptionsE.constprop.432
    ...
-   obj:/usr/lib/valgrind/vgpreload_drd-amd64-linux.so
-   fun:start_thread
-   fun:clone
 }
 {
-   <valgrind fork problem (presumed)>
-   drd:ConflictingAccess
-   fun:__reclaim_stacks
-   fun:fork
-   fun:_Z12spawn_daemonRKSs
+   <We construct shared pointers with new. This covers two instances: `m_local_mappings.reset(new ...` and `new_mappings.reset(new ...`>
+   Memcheck:Leak
+   match-leak-kinds: reachable
+   fun:_Znwm
+   fun:_ZN5realm9SlabAlloc11attach_fileERKSsRNS0_6ConfigE
    ...
-   obj:/usr/lib/valgrind/vgpreload_drd-amd64-linux.so
-   fun:start_thread
-   fun:clone
 }
 {
-   <mutex destruction - presumed valgrind problem>
-   drd:MutexErr
-   fun:pthread_mutex_destroy
-   fun:_ZN7realm11SharedGroup16do_async_commitsEv
-   fun:_ZN7realm11SharedGroup4openERKSsbNS0_15DurabilityLevelEb
-   fun:main
+   <Static test list holds on to unit test strings>
+   Memcheck:Leak
+   match-leak-kinds: reachable
+   fun:_Znwm
+   fun:_ZNSs4_Rep9_S_createEmmRKSaIcE
+   fun:_ZN5realm9test_util13get_test_pathERKNS0_9unit_test11TestContextERKSs
+   ...
+   fun:_ZN5realm9test_util9unit_test8TestList17ThreadContextImpl3runENS2_17SharedContextImpl5EntryERNS_4util10UniqueLockE
+   fun:_ZN5realm9test_util9unit_test8TestList17ThreadContextImpl3runEv
+   fun:_ZZN5realm9test_util9unit_test8TestList3runENS2_6ConfigEENKUliE_clEi
+   ...
 }
 {
-   <valgrind fsync problem (presumed)>
-   drd:ConflictingAccess
-   fun:fsync
-   fun:_ZN7realm4File4syncEv
-   fun:_ZN7realm11GroupWriter17extend_free_spaceEm
-   fun:_ZN7realm11GroupWriter18reserve_free_spaceEm
-   fun:_ZN7realm11GroupWriter14get_free_spaceEm
+   <Supposed valgrind false positives>
+   Memcheck:Leak
+   match-leak-kinds: reachable
+   fun:malloc
+   obj:/usr/lib/x86_64-linux-gnu/libstdc++.so.6.0.21
+   fun:call_init.part.0
+   fun:call_init
+   fun:_dl_init
+   obj:/lib/x86_64-linux-gnu/ld-2.21.so
    ...
 }


### PR DESCRIPTION
We recently changed the design for the lifetime of some memory so that it is intentionally not cleaned up by us. This was to avoid race conditions on destruction. We should suppress these warnings so we get a clean valgrind run to tell if there are any new leaks.

Apparently the existing suppressions file was unused by Jenkins. It was also really old, so I wiped it and added new valid suppressions. I've gone over the source of each allocation that is now suppressed and I believe they are all intentional. It would be nice if @finnschiermer or @rrrlasse could confirm these though (the description tag of each suppression shows the source of the allocation but if you want a stack trace just ask).

Fixes #2304 

Here's the end output from a local run of the unit test suite on my machine for curiosity sake:
```
==19281== 
==19281== HEAP SUMMARY:
==19281==     in use at exit: 128,201 bytes in 639 blocks
==19281==   total heap usage: 6,428,570 allocs, 6,427,931 frees, 1,493,647,808 bytes allocated
==19281== 
==19281== LEAK SUMMARY:
==19281==    definitely lost: 0 bytes in 0 blocks
==19281==    indirectly lost: 0 bytes in 0 blocks
==19281==      possibly lost: 0 bytes in 0 blocks
==19281==    still reachable: 9,912 bytes in 177 blocks
==19281==                       of which reachable via heuristic:
==19281==                         stdstring          : 16,401 bytes in 212 blocks
==19281==         suppressed: 118,289 bytes in 462 blocks
==19281== Reachable blocks (those to which a pointer was found) are not shown.
==19281== To see them, rerun with: --leak-check=full --show-leak-kinds=all
==19281== 
==19281== For counts of detected and suppressed errors, rerun with: -v
==19281== ERROR SUMMARY: 0 errors from 0 contexts (suppressed: 0 from 0)
```