### PR TITLE
Fix ADL use of make_error_code(SimulatedFailure::FailureType)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,7 +16,10 @@
 
 ### Internals
 
-* Lorem ipsum.
+* Make `_impl::make_error_code(_impl::SimulatedFailure::FailureType)`
+  participate in overload resolution in unqualified ADL contexts like
+  `make_error_code(_impl::SimulatedFailure::sync_client__read_head)` and `ec ==
+  _impl::SimulatedFailure::sync_client__read_head`.
 
 ----------------------------------------------
 

--- a/src/realm/impl/simulated_failure.hpp
+++ b/src/realm/impl/simulated_failure.hpp
@@ -88,8 +88,6 @@ private:
 #endif
 };
 
-std::error_code make_error_code(SimulatedFailure::FailureType) noexcept;
-
 
 class SimulatedFailure::OneShotPrimeGuard {
 public:
@@ -109,6 +107,24 @@ public:
 private:
     const FailureType m_type;
 };
+
+
+std::error_code make_error_code(SimulatedFailure::FailureType) noexcept;
+
+} // namespace _impl
+} // namespace realm
+
+namespace std {
+
+template<> struct is_error_code_enum<realm::_impl::SimulatedFailure::FailureType> {
+    static const bool value = true;
+};
+
+} // namespace std
+
+namespace realm {
+namespace _impl {
+
 
 
 // Implementation


### PR DESCRIPTION
Make `_impl::make_error_code(_impl::SimulatedFailure::FailureType)` participate in overload resolution in unqualified ADL contexts like `make_error_code(_impl::SimulatedFailure::sync_client__read_head)` and `ec == _impl::SimulatedFailure::sync_client__read_head`.

@ironage @jedelbo @finnschiermer 