### PR TITLE
Fix compilation with GCC 6

### DIFF
--- a/src/realm/util/file.cpp
+++ b/src/realm/util/file.cpp
@@ -1197,7 +1197,7 @@ void File::set_encryption_key(const char* key)
     if (key) {
         char* buffer = new char[64];
         memcpy(buffer, key, 64);
-        m_encryption_key.reset(buffer);
+        m_encryption_key.reset(static_cast<const char*>(buffer));
     }
     else {
         m_encryption_key.reset();


### PR DESCRIPTION
GCC 6 includes support for the C++17 changes to the `std::unique_ptr::reset()` signature, which breaks current usage. It's probably a bug in libstdc++, but this constitutes a workaround. :)