### PR TITLE
Build the Cocoa package with -fvisibility-inlines-hidden

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -288,7 +288,7 @@ build_apple()
     for x in $sdks; do
         sdk="$(printf "%s\n" "$x" | cut -d: -f1)" || exit 1
         archs="$(printf "%s\n" "$x" | cut -d: -f2 | sed 's/,/ /g')" || exit 1
-        cflags_arch="-stdlib=libc++ -m$os_name-version-min=$min_version"
+        cflags_arch="-stdlib=libc++ -m$os_name-version-min=$min_version -fvisibility-inlines-hidden"
         for y in $archs; do
             word_list_append "cflags_arch" "-arch $y" || exit 1
         done


### PR DESCRIPTION
Mostly just to bring it in line with Xcode's default settings, as otherwise it produces warnings when building a dynamic framework using the core library (although it's unclear as to why it's [only recently started to produce those warnings](https://github.com/realm/realm-object-store/issues/281)). It does reduce the compiled size by a not very interesting amount (~30 KB).