### PR TITLE
Deep copy realm file path for better valgrind suppression.

### DIFF
--- a/src/realm/alloc_slab.cpp
+++ b/src/realm/alloc_slab.cpp
@@ -630,7 +630,7 @@ util::Mutex& all_files_mutex = *new util::Mutex;
 }
 
 
-ref_type SlabAlloc::attach_file(const std::string& path, Config& cfg)
+ref_type SlabAlloc::attach_file(const std::string& file_path, Config& cfg)
 {
     // ExceptionSafety: If this function throws, it must leave the allocator in
     // the detached state.
@@ -647,6 +647,13 @@ ref_type SlabAlloc::attach_file(const std::string& path, Config& cfg)
     REALM_ASSERT(cfg.is_shared || !cfg.session_initiator);
     // clear_file can be set *only* if we're the first session.
     REALM_ASSERT(cfg.session_initiator || !cfg.clear_file);
+
+    // Create a deep copy of the file_path string, otherwise it can appear that
+    // users are leaking paths because string assignment operator implementations might
+    // actually be reference counting with copy-on-write. If our all_files map
+    // holds onto these references (since it is still reachable memory) it can appear
+    // as a leak in the user application, but it is actually us (and that's ok).
+    const std::string path = file_path.c_str();
 
     using namespace realm::util;
     File::AccessMode access = cfg.read_only ? File::access_ReadOnly : File::access_ReadWrite;

--- a/src/realm/alloc_slab.hpp
+++ b/src/realm/alloc_slab.hpp
@@ -130,7 +130,7 @@ public:
     /// before the Realm opening process completes, and the decided file format
     /// must be set in the allocator by calling set_file_format_version().
     ///
-    /// Except for \a path, the parameters are passed in through a
+    /// Except for \a file_path, the parameters are passed in through a
     /// configuration object.
     ///
     /// \return The `ref` of the root node, or zero if there is none.
@@ -145,7 +145,7 @@ public:
     ///
     /// \throw util::File::AccessError
     /// \throw SlabAlloc::Retry
-    ref_type attach_file(const std::string& path, Config& cfg);
+    ref_type attach_file(const std::string& file_path, Config& cfg);
 
     /// Get the attached file. Only valid when called on an allocator with
     /// an attached file.

--- a/test/valgrind.suppress
+++ b/test/valgrind.suppress
@@ -39,16 +39,12 @@
    ...
 }
 {
-   <Static test list holds on to unit test strings>
+   <SlabAlloc makes a deep copy of the realm file_path string which is still reachable as the keys of the all_files map>
    Memcheck:Leak
-   match-leak-kinds: reachable
    fun:_Znwm
    fun:_ZNSs4_Rep9_S_createEmmRKSaIcE
-   fun:_ZN5realm9test_util13get_test_pathERKNS0_9unit_test11TestContextERKSs
    ...
-   fun:_ZN5realm9test_util9unit_test8TestList17ThreadContextImpl3runENS2_17SharedContextImpl5EntryERNS_4util10UniqueLockE
-   fun:_ZN5realm9test_util9unit_test8TestList17ThreadContextImpl3runEv
-   fun:_ZZN5realm9test_util9unit_test8TestList3runENS2_6ConfigEENKUliE_clEi
+   fun:_ZN5realm9SlabAlloc11attach_fileERKSsRNS0_6ConfigE
    ...
 }
 {


### PR DESCRIPTION
The previous suppression would cancel any reachable memory from strings generated in the test framework but these reachable memory locations would still show up if the file paths are generated from some different application (e.g. realm sync tests). This is a more robust way of suppressing the memory warning because it no longer matters where the strings were allocated, the slab_alloc makes it's own deep copy of the path so we know where exactly to suppress.

The reachable memory is generated by std::string::create when the file path is born. The std::string assignment and copy implementations are most likely trying to optimise by not actually copying the data but by reference counting with copy-on-write machinery. Apparently this implementation is not allowed any more since C++11 but gcc4.9 (what we use on CI) must still be doing it. I found [this post](http://stackoverflow.com/a/4751624) which contains a useful example of what's happening.