### PR TITLE
P_tmpdir should not be used on Android

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,8 @@
   participate in overload resolution in unqualified ADL contexts like
   `make_error_code(_impl::SimulatedFailure::sync_client__read_head)` and `ec ==
   _impl::SimulatedFailure::sync_client__read_head`.
+* `P_tmpdir` should not be used on Android. A better default name for temporary
+  folders has been introduced.
 
 ----------------------------------------------
 

--- a/src/realm/util/file.cpp
+++ b/src/realm/util/file.cpp
@@ -183,7 +183,11 @@ std::string make_temp_dir()
 #else // POSIX.1-2008 version
 
     StringBuffer buffer;
+#if REALM_ANDROID
+    buffer.append_c_str("/data/local/tmp/realm_XXXXXX");
+#else
     buffer.append_c_str(P_tmpdir "/realm_XXXXXX");
+#endif
     if (mkdtemp(buffer.c_str()) == 0)
         throw std::runtime_error("mkdtemp() failed"); // LCOV_EXCL_LINE
     return buffer.str();


### PR DESCRIPTION
`P_tmpdir` is defined in `stdio.h` but its value is `/tmp/`. Since that directory is typically not writable on an Android device, `/data/local/tmp` is a better choice.

See also https://code.google.com/p/android/issues/detail?id=74497