### PR TITLE
removed note for fix that was released already (in 2.1.4)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,9 +2,7 @@
 
 ### Bugfixes
 
-* Fixed a race between destruction of a global mutex as part of main thread exit
-  and attempt to lock it on a background thread, or conversely attempt to lock a
-  mutex after it has been destroyed. (PR #2238, fixes issues #2238, #2137, #2009)
+* Lorem Ipsum.
 
 ### Breaking changes
 


### PR DESCRIPTION
A fix released in 2.1.4 was still mentioned at the top of CHANGELOG.md.