### PR TITLE
Prevent `stdin` being accidentally closed during `~InterProcessCondVar()`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ### Bugfixes
 
-* Lorem ipsum.
+* Prevent `stdin` from being accidentally closed during `~InterProcessCondVar()`.
 
 ### Breaking changes
 

--- a/src/realm/util/interprocess_condvar.cpp
+++ b/src/realm/util/interprocess_condvar.cpp
@@ -87,7 +87,6 @@ void InterprocessCondVar::set_shared_part(SharedPart& shared_part, std::string b
                                           std::string tmp_path)
 {
     close();
-    uses_emulation = true;
     m_shared_part = &shared_part;
     static_cast<void>(base_path);
     static_cast<void>(condvar_name);
@@ -168,6 +167,7 @@ void InterprocessCondVar::set_shared_part(SharedPart& shared_part, std::string b
     }
 
 #endif
+    uses_emulation = true;
 }
 
 


### PR DESCRIPTION
`InterProcessCondVar::set_shared_part()` sets a certain flag (`uses_emulation`) before filling the file descriptor fields. If it then fails to set the file descriptors, later the destructor will try to close them, which leads to `close(0)` and lots of terrible stuff to happen everywhere.

The PR moves `uses_emulation = true` to the bottom of the method, where the file descriptors are valid.