### PR TITLE
Fix typo and link

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -16,7 +16,7 @@ When filing an issue, please provide as much of the following information as pos
 
 ## Contributing Enhancements
 
-We love contributions to Realm! If you'd like to contribute code, documentation, or any other improvements, please [file a Pull Request](https://github.com/realm/realm-core/pulls) on our GitHub repository. Make sure to accept our [CLA](#cla) and to follow our [style guide](https://github.com/realm/realm-core/doc/development/coding_style_guide.cpp).
+We love contributions to Realm! If you'd like to contribute code, documentation, or any other improvements, please [file a Pull Request](https://github.com/realm/realm-core/pulls) on our GitHub repository. Make sure to accept our [CLA](#cla) and to follow our [style guide](doc/development/coding_style_guide.cpp).
 
 ### Commit Messages
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 ![Realm](doc/logo.png)
 
-Realm is a mobile database that runs directly inside phones, tablets or wearables - checkout [realm.io](https://realm.io). 
+Realm is a mobile database that runs directly inside phones, tablets or wearables - check out [realm.io](https://realm.io). 
 
 This repository holds the source code for the core database component used by all the Realm Mobile Database products:
 [realm-java](https://github.com/realm/realm-java), [realm-cocoa](https://github.com/realm/realm-cocoa), [realm-js](https://github.com/realm/realm-js) and [realm-dotnet](https://github.com/realm/realm-dotnet). Realm Core is not in itself an "end-user" product with a publicly stable and supported API. It is the intention to build a publicly supported C++ API (see [this issue](https://github.com/realm/realm-core/issues/1954)), but that will be a separate product and likely build on top of [realm-object-store](https://github.com/realm/realm-object-store).


### PR DESCRIPTION
Hi realm-core team!

I fixed typo and a link. This pull request has 2 commits:
- Fix typo in README.md.
- In CONTRIBUTING.md file, the link to style guide (coding_style_guide.cpp)  is not set correctly. It shows just blank page. Use relative link to fix the link since it is linked to internal file in the repository. ([Reference to relative link](https://help.github.com/articles/relative-links-in-readmes/))

Can I please ask you to review this PR? It would be great if you could merge it :) Thanks!

---
I read CONTRIBUTING.md, and submitted Realm Contributor Licensing Agreement.

