### PR TITLE
Fsa/chunked blob interface

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,10 @@
 * Attempts to open a Realm file with a different history type (Mobile Platform vs
   Mobile Database) now throws an IncompatibleHistories exception instead of a
   InvalidDatabase (as requested in issue #2275).
+* Announcing what will later be a breaking change:
+  Deprecated Table::get_binary() and added Table::get_binary_at(). Once get_binary()
+  is removed, we are free to split blobs into smaller chunks.
+  This should reduce fragmentation.
 
 ### Enhancements
 

--- a/src/realm/table.cpp
+++ b/src/realm/table.cpp
@@ -3243,6 +3243,13 @@ BinaryData Table::get_binary(size_t col_ndx, size_t ndx) const noexcept
 }
 
 
+BinaryData Table::get_binary_at(size_t col_ndx, size_t ndx, size_t& pos) const noexcept
+{
+    return get_column<BinaryColumn, col_type_Binary>(col_ndx).get_at(ndx, pos);
+}
+
+
+
 void Table::set_binary(size_t col_ndx, size_t ndx, BinaryData value, bool is_default)
 {
     if (REALM_UNLIKELY(!is_attached()))

--- a/src/realm/table.hpp
+++ b/src/realm/table.hpp
@@ -407,10 +407,19 @@ public:
     float get_float(size_t column_ndx, size_t row_ndx) const noexcept;
     double get_double(size_t column_ndx, size_t row_ndx) const noexcept;
     StringData get_string(size_t column_ndx, size_t row_ndx) const noexcept;
+
+    /// Deprecated. This method will be removed in the near future.
+    /// Instead, get_binary_at() should be used.
     BinaryData get_binary(size_t column_ndx, size_t row_ndx) const noexcept;
     Mixed get_mixed(size_t column_ndx, size_t row_ndx) const noexcept;
     DataType get_mixed_type(size_t column_ndx, size_t row_ndx) const noexcept;
     Timestamp get_timestamp(size_t column_ndx, size_t row_ndx) const noexcept;
+
+    /// Return data from position 'pos' and onwards. If the blob is distributed
+    /// across multiple arrays, you will only get data from one array. 'pos' 
+    /// will be updated to be an index to next available data. It will be 0 
+    /// if no more data. This method replaces get_binary().
+    BinaryData get_binary_at(size_t col_ndx, size_t ndx, size_t& pos) const noexcept;
 
     template <class T>
     T get(size_t c, size_t r) const noexcept;


### PR DESCRIPTION
For discussion, @jedelbo 

This PR deprecates Table::get_binary() and adds Table::get_binary_at().
Table::get_binary() requires us to keep all blobs in contiguous memory, which
restricts our freedom to address fragmentation. The new Table::get_binary_at(),
which is merely exposing the already existing BinaryColumn::get_at(), instead
forces the user to be able to read a blob in multiple parts. This gives us freedom
to break down larger blobs into smaller.

This is part of addressing #2343