### PR TITLE
Fix handover of detached constraining view

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ### Bugfixes
 
+* Fixed a bug in handover of detached linked lists. (issue #2378).
 * Fixed various bugs in aggregate methods of Table, TableView and Query for nullable columns
   (max, min, avg, sum). The results of avg and sum could be wrong and the returned index of
   the min and max rows could be wrong. Non-nullable columns might not have been affected.

--- a/src/realm/impl/transact_log.cpp
+++ b/src/realm/impl/transact_log.cpp
@@ -126,12 +126,12 @@ bool TransactLogEncoder::select_link_list(size_t col_ndx, size_t row_ndx, size_t
 void TransactLogConvenientEncoder::do_select_link_list(const LinkView& list)
 {
     select_table(list.m_origin_table.get());
-    size_t col_ndx = list.m_origin_column.get_column_index();
+    size_t col_ndx = list.m_origin_column->get_column_index();
     size_t row_ndx = list.get_origin_row_index();
 
     size_t* link_target_path_begin;
     size_t* link_target_path_end;
-    record_subtable_path(list.m_origin_column.get_target_table(), link_target_path_begin, link_target_path_end);
+    record_subtable_path(list.m_origin_column->get_target_table(), link_target_path_begin, link_target_path_end);
     size_t link_target_levels = (link_target_path_end - link_target_path_begin) / 2;
     static_cast<void>(link_target_levels);
     REALM_ASSERT_3(link_target_levels, ==, 0);

--- a/src/realm/link_view.cpp
+++ b/src/realm/link_view.cpp
@@ -27,11 +27,17 @@ using namespace realm;
 
 void LinkView::generate_patch(const ConstLinkViewRef& ref, std::unique_ptr<HandoverPatch>& patch)
 {
-    if (bool(ref) && ref->is_attached()) {
-        patch.reset(new HandoverPatch);
-        Table::generate_patch(ref->m_origin_table.get(), patch->m_table);
-        patch->m_col_num = ref->m_origin_column.get_column_index();
-        patch->m_row_ndx = ref->get_origin_row_index();
+    if (bool(ref)) {
+        if (ref->is_attached()) {
+            patch.reset(new HandoverPatch);
+            Table::generate_patch(ref->m_origin_table.get(), patch->m_table);
+            patch->m_col_num = ref->m_origin_column->get_column_index();
+            patch->m_row_ndx = ref->get_origin_row_index();
+        }
+        else {
+            patch.reset(new HandoverPatch);
+            patch->m_table = nullptr;
+        }
     }
     else
         patch.reset();
@@ -41,10 +47,17 @@ void LinkView::generate_patch(const ConstLinkViewRef& ref, std::unique_ptr<Hando
 LinkViewRef LinkView::create_from_and_consume_patch(std::unique_ptr<HandoverPatch>& patch, Group& group)
 {
     if (patch) {
-        TableRef tr = Table::create_from_and_consume_patch(patch->m_table, group);
-        LinkViewRef result = tr->get_linklist(patch->m_col_num, patch->m_row_ndx);
-        patch.reset();
-        return result;
+        if (patch->m_table) {
+            TableRef tr = Table::create_from_and_consume_patch(patch->m_table, group);
+            LinkViewRef result = tr->get_linklist(patch->m_col_num, patch->m_row_ndx);
+            patch.reset();
+            return result;
+        }
+        else {
+            LinkViewRef result = LinkView::create_detached();
+            patch.reset();
+            return result;
+        }
     }
     else
         return LinkViewRef();
@@ -64,7 +77,7 @@ void LinkView::do_insert(size_t link_ndx, size_t target_row_ndx)
     REALM_ASSERT(is_attached());
     REALM_ASSERT_7(m_row_indexes.is_attached(), ==, true, ||, link_ndx, ==, 0);
     REALM_ASSERT_7(m_row_indexes.is_attached(), ==, false, ||, link_ndx, <=, m_row_indexes.size());
-    REALM_ASSERT_3(target_row_ndx, <, m_origin_column.get_target_table().size());
+    REALM_ASSERT_3(target_row_ndx, <, m_origin_column->get_target_table().size());
     typedef _impl::TableFriend tf;
     tf::bump_version(*m_origin_table);
 
@@ -73,13 +86,13 @@ void LinkView::do_insert(size_t link_ndx, size_t target_row_ndx)
     // if there are no links yet, we have to create list
     if (!m_row_indexes.is_attached()) {
         REALM_ASSERT_3(link_ndx, ==, 0);
-        ref_type ref = IntegerColumn::create(m_origin_column.get_alloc()); // Throws
-        m_origin_column.set_row_ref(origin_row_ndx, ref);                  // Throws
+        ref_type ref = IntegerColumn::create(m_origin_column->get_alloc()); // Throws
+        m_origin_column->set_row_ref(origin_row_ndx, ref);                  // Throws
         m_row_indexes.init_from_parent();                                  // re-attach
     }
 
     m_row_indexes.insert(link_ndx, target_row_ndx);               // Throws
-    m_origin_column.add_backlink(target_row_ndx, origin_row_ndx); // Throws
+    m_origin_column->add_backlink(target_row_ndx, origin_row_ndx); // Throws
 }
 
 
@@ -87,16 +100,16 @@ void LinkView::set(size_t link_ndx, size_t target_row_ndx)
 {
     REALM_ASSERT(is_attached());
     REALM_ASSERT_7(m_row_indexes.is_attached(), ==, true, &&, link_ndx, <, m_row_indexes.size());
-    REALM_ASSERT_3(target_row_ndx, <, m_origin_column.get_target_table().size());
+    REALM_ASSERT_3(target_row_ndx, <, m_origin_column->get_target_table().size());
 
     if (Replication* repl = get_repl())
         repl->link_list_set(*this, link_ndx, target_row_ndx); // Throws
 
     size_t old_target_row_ndx = do_set(link_ndx, target_row_ndx); // Throws
-    if (m_origin_column.m_weak_links)
+    if (m_origin_column->m_weak_links)
         return;
 
-    Table& target_table = m_origin_column.get_target_table();
+    Table& target_table = m_origin_column->get_target_table();
     size_t num_remaining = target_table.get_num_strong_backlinks(old_target_row_ndx);
     if (num_remaining > 0)
         return;
@@ -118,8 +131,8 @@ size_t LinkView::do_set(size_t link_ndx, size_t target_row_ndx)
 {
     size_t old_target_row_ndx = to_size_t(m_row_indexes.get(link_ndx));
     size_t origin_row_ndx = get_origin_row_index();
-    m_origin_column.remove_backlink(old_target_row_ndx, origin_row_ndx); // Throws
-    m_origin_column.add_backlink(target_row_ndx, origin_row_ndx);        // Throws
+    m_origin_column->remove_backlink(old_target_row_ndx, origin_row_ndx); // Throws
+    m_origin_column->add_backlink(target_row_ndx, origin_row_ndx);        // Throws
     m_row_indexes.set(link_ndx, target_row_ndx);                         // Throws
     typedef _impl::TableFriend tf;
     tf::bump_version(*m_origin_table);
@@ -187,10 +200,10 @@ void LinkView::remove(size_t link_ndx)
         repl->link_list_erase(*this, link_ndx); // Throws
 
     size_t target_row_ndx = do_remove(link_ndx); // Throws
-    if (m_origin_column.m_weak_links)
+    if (m_origin_column->m_weak_links)
         return;
 
-    Table& target_table = m_origin_column.get_target_table();
+    Table& target_table = m_origin_column->get_target_table();
     size_t num_remaining = target_table.get_num_strong_backlinks(target_row_ndx);
     if (num_remaining > 0)
         return;
@@ -212,7 +225,7 @@ size_t LinkView::do_remove(size_t link_ndx)
 {
     size_t target_row_ndx = to_size_t(m_row_indexes.get(link_ndx));
     size_t origin_row_ndx = get_origin_row_index();
-    m_origin_column.remove_backlink(target_row_ndx, origin_row_ndx); // Throws
+    m_origin_column->remove_backlink(target_row_ndx, origin_row_ndx); // Throws
     m_row_indexes.erase(link_ndx);                                   // Throws
     typedef _impl::TableFriend tf;
     tf::bump_version(*m_origin_table);
@@ -230,7 +243,7 @@ void LinkView::clear()
     if (Replication* repl = get_repl())
         repl->link_list_clear(*this); // Throws
 
-    if (m_origin_column.m_weak_links) {
+    if (m_origin_column->m_weak_links) {
         bool broken_reciprocal_backlinks = false;
         do_clear(broken_reciprocal_backlinks); // Throws
         return;
@@ -238,15 +251,15 @@ void LinkView::clear()
 
     size_t origin_row_ndx = get_origin_row_index();
     CascadeState state;
-    state.stop_on_link_list_column = &m_origin_column;
+    state.stop_on_link_list_column = m_origin_column;
     state.stop_on_link_list_row_ndx = origin_row_ndx;
 
     typedef _impl::TableFriend tf;
     size_t num_links = m_row_indexes.size();
     for (size_t link_ndx = 0; link_ndx < num_links; ++link_ndx) {
         size_t target_row_ndx = to_size_t(m_row_indexes.get(link_ndx));
-        m_origin_column.remove_backlink(target_row_ndx, origin_row_ndx); // Throws
-        Table& target_table = m_origin_column.get_target_table();
+        m_origin_column->remove_backlink(target_row_ndx, origin_row_ndx); // Throws
+        Table& target_table = m_origin_column->get_target_table();
         size_t num_remaining = target_table.get_num_strong_backlinks(target_row_ndx);
         if (num_remaining > 0)
             continue;
@@ -275,12 +288,12 @@ void LinkView::do_clear(bool broken_reciprocal_backlinks)
         size_t num_links = m_row_indexes.size();
         for (size_t link_ndx = 0; link_ndx < num_links; ++link_ndx) {
             size_t target_row_ndx = to_size_t(m_row_indexes.get(link_ndx));
-            m_origin_column.remove_backlink(target_row_ndx, origin_row_ndx); // Throws
+            m_origin_column->remove_backlink(target_row_ndx, origin_row_ndx); // Throws
         }
     }
 
     m_row_indexes.destroy();
-    m_origin_column.set_row_ref(origin_row_ndx, 0); // Throws
+    m_origin_column->set_row_ref(origin_row_ndx, 0); // Throws
 
     typedef _impl::TableFriend tf;
     tf::bump_version(*m_origin_table);
@@ -289,7 +302,7 @@ void LinkView::do_clear(bool broken_reciprocal_backlinks)
 
 void LinkView::sort(size_t column_index, bool ascending)
 {
-    sort(SortDescriptor(m_origin_column.get_target_table(), {{column_index}}, {ascending}));
+    sort(SortDescriptor(m_origin_column->get_target_table(), {{column_index}}, {ascending}));
 }
 
 
@@ -304,7 +317,7 @@ void LinkView::sort(const SortDescriptor& order)
 
 TableView LinkView::get_sorted_view(SortDescriptor order) const
 {
-    TableView v(m_origin_column.get_target_table()); // sets m_table
+    TableView v(m_origin_column->get_target_table()); // sets m_table
     v.m_last_seen_version = m_origin_table->m_version;
     // sets m_linkview_source to indicate that this TableView was generated from a LinkView
     v.m_linkview_source = shared_from_this();
@@ -318,7 +331,7 @@ TableView LinkView::get_sorted_view(SortDescriptor order) const
 
 TableView LinkView::get_sorted_view(size_t column_index, bool ascending) const
 {
-    TableView v = get_sorted_view(SortDescriptor(m_origin_column.get_target_table(), {{column_index}}, {ascending}));
+    TableView v = get_sorted_view(SortDescriptor(m_origin_column->get_target_table(), {{column_index}}, {ascending}));
     return v;
 }
 
@@ -364,7 +377,7 @@ void LinkView::do_nullify_link(size_t old_target_row_ndx)
     if (m_row_indexes.is_empty()) {
         m_row_indexes.destroy();
         size_t origin_row_ndx = get_origin_row_index();
-        m_origin_column.set_row_ref(origin_row_ndx, 0);
+        m_origin_column->set_row_ref(origin_row_ndx, 0);
     }
 }
 

--- a/src/realm/link_view.cpp
+++ b/src/realm/link_view.cpp
@@ -56,7 +56,7 @@ LinkViewRef LinkView::create_from_and_consume_patch(std::unique_ptr<HandoverPatc
             return result;
         }
         else {
-            // We end up here if we're handing over a detached linkview.
+            // We end up here if we're handing over a detached LinkView.
             // This is indicated by a patch with a null m_table.
             LinkViewRef result = LinkView::create_detached();
             patch.reset();
@@ -92,10 +92,10 @@ void LinkView::do_insert(size_t link_ndx, size_t target_row_ndx)
         REALM_ASSERT_3(link_ndx, ==, 0);
         ref_type ref = IntegerColumn::create(m_origin_column->get_alloc()); // Throws
         m_origin_column->set_row_ref(origin_row_ndx, ref);                  // Throws
-        m_row_indexes.init_from_parent();                                  // re-attach
+        m_row_indexes.init_from_parent();                                   // re-attach
     }
 
-    m_row_indexes.insert(link_ndx, target_row_ndx);               // Throws
+    m_row_indexes.insert(link_ndx, target_row_ndx);                // Throws
     m_origin_column->add_backlink(target_row_ndx, origin_row_ndx); // Throws
 }
 
@@ -137,7 +137,7 @@ size_t LinkView::do_set(size_t link_ndx, size_t target_row_ndx)
     size_t origin_row_ndx = get_origin_row_index();
     m_origin_column->remove_backlink(old_target_row_ndx, origin_row_ndx); // Throws
     m_origin_column->add_backlink(target_row_ndx, origin_row_ndx);        // Throws
-    m_row_indexes.set(link_ndx, target_row_ndx);                         // Throws
+    m_row_indexes.set(link_ndx, target_row_ndx);                          // Throws
     typedef _impl::TableFriend tf;
     tf::bump_version(*m_origin_table);
     return old_target_row_ndx;
@@ -201,7 +201,7 @@ void LinkView::remove(size_t link_ndx)
     REALM_ASSERT_7(m_row_indexes.is_attached(), ==, true, &&, link_ndx, <, m_row_indexes.size());
 
     if (Replication* repl = get_repl())
-        repl->link_list_erase(*this, link_ndx); // Throws
+        repl->link_list_erase(*this, link_ndx);  // Throws
 
     size_t target_row_ndx = do_remove(link_ndx); // Throws
     if (m_origin_column->m_weak_links)
@@ -230,7 +230,7 @@ size_t LinkView::do_remove(size_t link_ndx)
     size_t target_row_ndx = to_size_t(m_row_indexes.get(link_ndx));
     size_t origin_row_ndx = get_origin_row_index();
     m_origin_column->remove_backlink(target_row_ndx, origin_row_ndx); // Throws
-    m_row_indexes.erase(link_ndx);                                   // Throws
+    m_row_indexes.erase(link_ndx);                                    // Throws
     typedef _impl::TableFriend tf;
     tf::bump_version(*m_origin_table);
     return target_row_ndx;

--- a/src/realm/link_view.cpp
+++ b/src/realm/link_view.cpp
@@ -35,6 +35,8 @@ void LinkView::generate_patch(const ConstLinkViewRef& ref, std::unique_ptr<Hando
             patch->m_row_ndx = ref->get_origin_row_index();
         }
         else {
+            // if the LinkView has become detached, indicate it by passing
+            // a handover patch with a nullptr in m_table.
             patch.reset(new HandoverPatch);
             patch->m_table = nullptr;
         }
@@ -54,6 +56,8 @@ LinkViewRef LinkView::create_from_and_consume_patch(std::unique_ptr<HandoverPatc
             return result;
         }
         else {
+            // We end up here if we're handing over a detached linkview.
+            // This is indicated by a patch with a null m_table.
             LinkViewRef result = LinkView::create_detached();
             patch.reset();
             return result;

--- a/src/realm/link_view.hpp
+++ b/src/realm/link_view.hpp
@@ -121,7 +121,7 @@ private:
     };
 
     TableRef m_origin_table;
-    LinkListColumn& m_origin_column;
+    LinkListColumn* m_origin_column;
 
     using HandoverPatch = LinkViewHandoverPatch;
     static void generate_patch(const ConstLinkViewRef& ref, std::unique_ptr<HandoverPatch>& patch);
@@ -152,6 +152,7 @@ private:
 #endif
     // allocate using make_shared:
     static std::shared_ptr<LinkView> create(Table* origin_table, LinkListColumn&, size_t row_ndx);
+    static std::shared_ptr<LinkView> create_detached();
 
     friend class _impl::LinkListFriend;
     friend class LinkListColumn;
@@ -164,6 +165,7 @@ private:
     // because ctor_cookie is private
 public:
     LinkView(const ctor_cookie&, Table* origin_table, LinkListColumn&, size_t row_ndx);
+    LinkView(const ctor_cookie&);
 };
 
 
@@ -172,10 +174,21 @@ public:
 inline LinkView::LinkView(const ctor_cookie&, Table* origin_table, LinkListColumn& column, size_t row_ndx)
     : RowIndexes(IntegerColumn::unattached_root_tag(), column.get_alloc()) // Throws
     , m_origin_table(origin_table->get_table_ref())
-    , m_origin_column(column)
+    , m_origin_column(&column)
 {
-    m_row_indexes.set_parent(&m_origin_column, row_ndx);
+    m_row_indexes.set_parent(m_origin_column, row_ndx);
     m_row_indexes.init_from_parent();
+}
+
+// create a detached linkview. Only partially initialized, as it will never be used for
+// anything, but indicating that it is detached.
+inline LinkView::LinkView(const ctor_cookie&)
+    : RowIndexes(IntegerColumn::unattached_root_tag(), Allocator::get_default()) // Throws
+    , m_origin_table(TableRef())
+    , m_origin_column(nullptr)
+{
+//    m_row_indexes.set_parent(&m_origin_column, row_ndx);
+//    m_row_indexes.init_from_parent();
 }
 
 inline std::shared_ptr<LinkView> LinkView::create(Table* origin_table, LinkListColumn& column, size_t row_ndx)
@@ -183,11 +196,16 @@ inline std::shared_ptr<LinkView> LinkView::create(Table* origin_table, LinkListC
     return std::make_shared<LinkView>(ctor_cookie(), origin_table, column, row_ndx);
 }
 
+inline std::shared_ptr<LinkView> LinkView::create_detached()
+{
+    return std::make_shared<LinkView>(ctor_cookie());
+}
+
 inline LinkView::~LinkView() noexcept
 {
     if (is_attached()) {
         repl_unselect();
-        m_origin_column.unregister_linkview();
+        m_origin_column->unregister_linkview();
     }
 }
 
@@ -228,8 +246,8 @@ inline size_t LinkView::size() const noexcept
 
 inline bool LinkView::operator==(const LinkView& link_list) const noexcept
 {
-    Table& target_table_1 = m_origin_column.get_target_table();
-    Table& target_table_2 = link_list.m_origin_column.get_target_table();
+    Table& target_table_1 = m_origin_column->get_target_table();
+    Table& target_table_2 = link_list.m_origin_column->get_target_table();
     if (target_table_1.get_index_in_group() != target_table_2.get_index_in_group())
         return false;
     if (!m_row_indexes.is_attached() || m_row_indexes.is_empty()) {
@@ -254,7 +272,7 @@ inline Table::RowExpr LinkView::get(size_t link_ndx) noexcept
     REALM_ASSERT(m_row_indexes.is_attached());
     REALM_ASSERT_3(link_ndx, <, m_row_indexes.size());
 
-    Table& target_table = m_origin_column.get_target_table();
+    Table& target_table = m_origin_column->get_target_table();
     size_t target_row_ndx = to_size_t(m_row_indexes.get(link_ndx));
     return target_table[target_row_ndx];
 }
@@ -279,7 +297,7 @@ inline void LinkView::add(size_t target_row_ndx)
 inline size_t LinkView::find(size_t target_row_ndx, size_t start) const noexcept
 {
     REALM_ASSERT(is_attached());
-    REALM_ASSERT_3(target_row_ndx, <, m_origin_column.get_target_table().size());
+    REALM_ASSERT_3(target_row_ndx, <, m_origin_column->get_target_table().size());
     REALM_ASSERT_3(start, <=, size());
 
     if (!m_row_indexes.is_attached())
@@ -317,12 +335,12 @@ inline void LinkView::set_origin_row_index(size_t row_ndx) noexcept
 
 inline const Table& LinkView::get_target_table() const noexcept
 {
-    return m_origin_column.get_target_table();
+    return m_origin_column->get_target_table();
 }
 
 inline Table& LinkView::get_target_table() noexcept
 {
-    return m_origin_column.get_target_table();
+    return m_origin_column->get_target_table();
 }
 
 inline void LinkView::refresh_accessor_tree(size_t new_row_ndx) noexcept

--- a/src/realm/link_view.hpp
+++ b/src/realm/link_view.hpp
@@ -180,7 +180,7 @@ inline LinkView::LinkView(const ctor_cookie&, Table* origin_table, LinkListColum
     m_row_indexes.init_from_parent();
 }
 
-// create a detached linkview. Only partially initialized, as it will never be used for
+// create a detached LinkView. Only partially initialized, as it will never be used for
 // anything, but indicating that it is detached.
 inline LinkView::LinkView(const ctor_cookie&)
     : RowIndexes(IntegerColumn::unattached_root_tag(), Allocator::get_default()) // Throws

--- a/src/realm/link_view.hpp
+++ b/src/realm/link_view.hpp
@@ -187,8 +187,6 @@ inline LinkView::LinkView(const ctor_cookie&)
     , m_origin_table(TableRef())
     , m_origin_column(nullptr)
 {
-//    m_row_indexes.set_parent(&m_origin_column, row_ndx);
-//    m_row_indexes.init_from_parent();
 }
 
 inline std::shared_ptr<LinkView> LinkView::create(Table* origin_table, LinkListColumn& column, size_t row_ndx)

--- a/test/test_lang_bind_helper.cpp
+++ b/test/test_lang_bind_helper.cpp
@@ -9774,7 +9774,7 @@ TEST(LangBindHelper_SubqueryHandoverQueryCreatedFromDeletedLinkView)
 
             CHECK(tv.is_in_sync());
             CHECK(tv.is_attached());
-            CHECK_EQUAL(0, tv.size()); // FAILED. The query is built from a link view which has been deleted.
+            CHECK_EQUAL(0, tv.size()); 
         }
     }
 }

--- a/test/test_lang_bind_helper.cpp
+++ b/test/test_lang_bind_helper.cpp
@@ -9744,19 +9744,19 @@ TEST(LangBindHelper_SubqueryHandoverQueryCreatedFromDeletedLinkView)
             TableView tv1;
             LangBindHelper::promote_to_write(sg_w);
             TableRef table = group_w.add_table("table");
-            auto sub_table = group_w.add_table("sub_table");
-            sub_table->add_column(type_Int, "int");
-            sub_table->add_empty_row();
-            sub_table->set_int(0, 0, 42);
+            auto table2 = group_w.add_table("table2");
+            table2->add_column(type_Int, "int");
+            table2->add_empty_row();
+            table2->set_int(0, 0, 42);
 
-            table->add_column_link(type_LinkList, "first", *sub_table);
+            table->add_column_link(type_LinkList, "first", *table2);
             table->add_empty_row();
             auto link_view = table->get_linklist(0, 0);
 
             link_view->add(0);
             LangBindHelper::commit_and_continue_as_read(sg_w);
 
-            Query qq = sub_table->where(link_view);
+            Query qq = table2->where(link_view);
             CHECK_EQUAL(qq.count(), 1);
             LangBindHelper::promote_to_write(sg_w);
             table->clear();

--- a/test/test_lang_bind_helper.cpp
+++ b/test/test_lang_bind_helper.cpp
@@ -9724,6 +9724,61 @@ TEST(LangBindHelper_HandoverQuery)
 }
 
 
+TEST(LangBindHelper_SubqueryHandoverQueryCreatedFromDeletedLinkView)
+{
+    SHARED_GROUP_TEST_PATH(path);
+    std::unique_ptr<Replication> hist(make_in_realm_history(path));
+    SharedGroup sg(*hist, SharedGroupOptions(crypt_key()));
+    sg.begin_read();
+
+    std::unique_ptr<Replication> hist_w(make_in_realm_history(path));
+    SharedGroup sg_w(*hist_w, SharedGroupOptions(crypt_key()));
+    Group& group_w = const_cast<Group&>(sg_w.begin_read());
+
+    SharedGroup::VersionID vid;
+    {
+        // Untyped interface
+        std::unique_ptr<SharedGroup::Handover<TableView>> handover1;
+        std::unique_ptr<SharedGroup::Handover<Query>> handoverQuery;
+        {
+            TableView tv1;
+            LangBindHelper::promote_to_write(sg_w);
+            TableRef table = group_w.add_table("table");
+            auto sub_table = group_w.add_table("sub_table");
+            sub_table->add_column(type_Int, "int");
+            sub_table->add_empty_row();
+            sub_table->set_int(0, 0, 42);
+
+            table->add_column_link(type_LinkList, "first", *sub_table);
+            table->add_empty_row();
+            auto link_view = table->get_linklist(0, 0);
+
+            link_view->add(0);
+            LangBindHelper::commit_and_continue_as_read(sg_w);
+
+            Query qq = sub_table->where(link_view);
+            CHECK_EQUAL(qq.count(), 1);
+            LangBindHelper::promote_to_write(sg_w);
+            table->clear();
+            LangBindHelper::commit_and_continue_as_read(sg_w);
+            CHECK_EQUAL(qq.count(), 0);
+            handoverQuery = sg_w.export_for_handover(qq, ConstSourcePayload::Copy);
+            vid = sg_w.get_version_of_current_transaction();
+        }
+        {
+            LangBindHelper::advance_read(sg, vid);
+            sg_w.close();
+
+            std::unique_ptr<Query> q(sg.import_from_handover(move(handoverQuery)));
+            realm::TableView tv = q->find_all();
+
+            CHECK(tv.is_in_sync());
+            CHECK(tv.is_attached());
+            CHECK_EQUAL(0, tv.size()); // FAILED. The query is built from a link view which has been deleted.
+        }
+    }
+}
+
 TEST(LangBindHelper_SubqueryHandoverDependentViews)
 {
     SHARED_GROUP_TEST_PATH(path);


### PR DESCRIPTION
Handover of a detached LinkView used to constrain a query did not work. The detached LinkView was inadvertently transformed into no LinkView, which has a different meaning. This is demonstrated in #2378. The testcase provided there is included in this PR.

This PR fixes #2378  by allowing handover of a detached LinkView.

LinkView holds a member variable m_origin_column which was originally a *reference* to a column. Since there is no column available when creating a new detached LinkView, m_origin_column had to be changed to a *pointer* instead, allowing it to be nullptr.