### PR TITLE
No need to branch.

### DIFF
--- a/src/realm/array_string.cpp
+++ b/src/realm/array_string.cpp
@@ -86,11 +86,7 @@ void ArrayString::set(size_t ndx, StringData value)
         }
 
         // Calc min column width
-        size_t new_width;
-        if (m_width == 0 && value.size() == 0)
-            new_width = ::round_up(1); // Entire Array is nulls; expand to m_width > 0
-        else
-            new_width = ::round_up(value.size() + 1);
+        size_t new_width = ::round_up(value.size() + 1);
 
         // FIXME: Should we try to avoid double copying when realloc fails to preserve the address?
         alloc(m_size, new_width); // Throws


### PR DESCRIPTION
`m_width` is not used for the calculation, so that can be discarded from condition. For `value.size() = 0`, we have `::round_up(0 + 1) = ::round_up(1)`. No need for `if`.

@rrrlasse @danielpovlsen @ironage 