### PR TITLE
List of primitives

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@
 
 * Now supports case insensitive queries for UWP.
 * Upgraded Visual Studio project to version 2017.
+* Support for 'list of primitives' (issue #1881).
 
 -----------
 

--- a/src/realm/exceptions.cpp
+++ b/src/realm/exceptions.cpp
@@ -84,6 +84,8 @@ const char* LogicError::what() const noexcept
                    "the SharedGroup constructor) was not consistent across the session";
         case table_has_no_columns:
             return "Table has no columns";
+        case type_not_supported:
+            return "Only list of simple types are supported";
     }
     return "Unknown error";
 }

--- a/src/realm/exceptions.hpp
+++ b/src/realm/exceptions.hpp
@@ -200,7 +200,9 @@ public:
         mixed_history_type,
 
         /// Adding rows to a table with no columns is not supported.
-        table_has_no_columns
+        table_has_no_columns,
+        /// Only simple types are supported
+        type_not_supported
     };
 
     LogicError(ErrorKind message);

--- a/src/realm/table.cpp
+++ b/src/realm/table.cpp
@@ -293,9 +293,8 @@ void Table::insert_column_link(size_t col_ndx, DataType type, StringData name, T
 
 size_t Table::add_column_list(DataType type, StringData name)
 {
-    DescriptorRef subdesc;
-    size_t ndx = add_column(type_Table, name, &subdesc);
-    subdesc->add_column(type, "list");
+    size_t ndx = get_column_count();
+    insert_column_list(ndx, type, name);
     return ndx;
 }
 
@@ -303,7 +302,24 @@ void Table::insert_column_list(size_t column_ndx, DataType type, StringData name
 {
     DescriptorRef subdesc;
     insert_column(column_ndx, type_Table, name, &subdesc);
-    subdesc->add_column(type, "list");
+    switch (type) {
+        case type_Int:
+        case type_Bool:
+        case type_Float:
+        case type_Double:
+        case type_String:
+        case type_Binary:
+        case type_Timestamp:
+            subdesc->add_column(type, "list");
+            break;
+        case type_OldDateTime:
+        case type_Table:
+        case type_Mixed:
+        case type_Link:
+        case type_LinkList:
+            throw LogicError(LogicError::type_not_supported);
+            break;
+    }
 }
 
 size_t Table::get_backlink_count(size_t row_ndx, const Table& origin, size_t origin_col_ndx) const noexcept
@@ -2949,13 +2965,6 @@ void Table::set(size_t col_ndx, size_t ndx, int_fast64_t value, bool is_default)
 void Table::set_int(size_t column_ndx, size_t row_ndx, int_fast64_t value, bool is_default)
 {
     set<int_fast64_t>(column_ndx, row_ndx, value, is_default);
-}
-
-TableView Table::get_list(size_t c, size_t r)
-{
-    TableRef subtable = get_subtable(c, r);
-    TableView tv = subtable->where().find_all();
-    return tv;
 }
 
 void Table::add_int(size_t col_ndx, size_t ndx, int_fast64_t value)

--- a/src/realm/table.cpp
+++ b/src/realm/table.cpp
@@ -263,7 +263,7 @@
 /// since the latter it an invariant.
 
 
-using namespace realm;
+namespace realm {
 using namespace realm::util;
 
 const int_fast64_t realm::Table::max_integer;
@@ -291,6 +291,20 @@ void Table::insert_column_link(size_t col_ndx, DataType type, StringData name, T
     get_descriptor()->insert_column_link(col_ndx, type, name, target, link_type); // Throws
 }
 
+size_t Table::add_column_list(DataType type, StringData name)
+{
+    DescriptorRef subdesc;
+    size_t ndx = add_column(type_Table, name, &subdesc);
+    subdesc->add_column(type, "list");
+    return ndx;
+}
+
+void Table::insert_column_list(size_t column_ndx, DataType type, StringData name)
+{
+    DescriptorRef subdesc;
+    insert_column(column_ndx, type_Table, name, &subdesc);
+    subdesc->add_column(type, "list");
+}
 
 size_t Table::get_backlink_count(size_t row_ndx, const Table& origin, size_t origin_col_ndx) const noexcept
 {
@@ -2683,8 +2697,6 @@ size_t Table::get_index_in_group() const noexcept
     return index_in_parent;
 }
 
-namespace realm {
-
 template <>
 bool Table::get(size_t col_ndx, size_t ndx) const noexcept
 {
@@ -2812,9 +2824,6 @@ Timestamp Table::get(size_t col_ndx, size_t ndx) const noexcept
 }
 
 
-} // namespace realm;
-
-
 template <class ColType, class T>
 size_t Table::do_find_unique(ColType& col, size_t ndx, T&& value, bool& conflict)
 {
@@ -2917,7 +2926,8 @@ size_t Table::set_int_unique(size_t col_ndx, size_t ndx, int_fast64_t value)
     return ndx;
 }
 
-void Table::set_int(size_t col_ndx, size_t ndx, int_fast64_t value, bool is_default)
+template <>
+void Table::set(size_t col_ndx, size_t ndx, int_fast64_t value, bool is_default)
 {
     REALM_ASSERT_3(col_ndx, <, get_column_count());
     REALM_ASSERT_3(ndx, <, m_size);
@@ -2934,6 +2944,18 @@ void Table::set_int(size_t col_ndx, size_t ndx, int_fast64_t value, bool is_defa
 
     if (Replication* repl = get_repl())
         repl->set_int(this, col_ndx, ndx, value, is_default ? _impl::instr_SetDefault : _impl::instr_Set); // Throws
+}
+
+void Table::set_int(size_t column_ndx, size_t row_ndx, int_fast64_t value, bool is_default)
+{
+    set<int_fast64_t>(column_ndx, row_ndx, value, is_default);
+}
+
+TableView Table::get_list(size_t c, size_t r)
+{
+    TableRef subtable = get_subtable(c, r);
+    TableView tv = subtable->where().find_all();
+    return tv;
 }
 
 void Table::add_int(size_t col_ndx, size_t ndx, int_fast64_t value)
@@ -2974,7 +2996,8 @@ Timestamp Table::get_timestamp(size_t col_ndx, size_t ndx) const noexcept
 }
 
 
-void Table::set_timestamp(size_t col_ndx, size_t ndx, Timestamp value, bool is_default)
+template <>
+void Table::set(size_t col_ndx, size_t ndx, Timestamp value, bool is_default)
 {
     REALM_ASSERT_3(col_ndx, <, get_column_count());
     REALM_ASSERT_3(get_real_column_type(col_ndx), ==, col_type_Timestamp);
@@ -2996,14 +3019,18 @@ void Table::set_timestamp(size_t col_ndx, size_t ndx, Timestamp value, bool is_d
     }
 }
 
+void Table::set_timestamp(size_t col_ndx, size_t ndx, Timestamp value, bool is_default)
+{
+    set<Timestamp>(col_ndx, ndx, value, is_default);
+}
 
 bool Table::get_bool(size_t col_ndx, size_t ndx) const noexcept
 {
     return get<bool>(col_ndx, ndx);
 }
 
-
-void Table::set_bool(size_t col_ndx, size_t ndx, bool value, bool is_default)
+template <>
+void Table::set(size_t col_ndx, size_t ndx, bool value, bool is_default)
 {
     REALM_ASSERT_3(col_ndx, <, get_column_count());
     REALM_ASSERT_3(get_real_column_type(col_ndx), ==, col_type_Bool);
@@ -3023,6 +3050,10 @@ void Table::set_bool(size_t col_ndx, size_t ndx, bool value, bool is_default)
         repl->set_bool(this, col_ndx, ndx, value, is_default ? _impl::instr_SetDefault : _impl::instr_Set); // Throws
 }
 
+void Table::set_bool(size_t column_ndx, size_t row_ndx, bool value, bool is_default)
+{
+    set<bool>(column_ndx, row_ndx, value, is_default);
+}
 
 OldDateTime Table::get_olddatetime(size_t col_ndx, size_t ndx) const noexcept
 {
@@ -3051,14 +3082,13 @@ void Table::set_olddatetime(size_t col_ndx, size_t ndx, OldDateTime value, bool 
                               is_default ? _impl::instr_SetDefault : _impl::instr_Set); // Throws
 }
 
-
 float Table::get_float(size_t col_ndx, size_t ndx) const noexcept
 {
     return get<float>(col_ndx, ndx);
 }
 
-
-void Table::set_float(size_t col_ndx, size_t ndx, float value, bool is_default)
+template <>
+void Table::set(size_t col_ndx, size_t ndx, float value, bool is_default)
 {
     REALM_ASSERT_3(col_ndx, <, get_column_count());
     REALM_ASSERT_3(ndx, <, m_size);
@@ -3071,14 +3101,18 @@ void Table::set_float(size_t col_ndx, size_t ndx, float value, bool is_default)
         repl->set_float(this, col_ndx, ndx, value, is_default ? _impl::instr_SetDefault : _impl::instr_Set); // Throws
 }
 
+void Table::set_float(size_t column_ndx, size_t row_ndx, float value, bool is_default)
+{
+    set<float>(column_ndx, row_ndx, value, is_default);
+}
 
 double Table::get_double(size_t col_ndx, size_t ndx) const noexcept
 {
     return get<double>(col_ndx, ndx);
 }
 
-
-void Table::set_double(size_t col_ndx, size_t ndx, double value, bool is_default)
+template <>
+void Table::set(size_t col_ndx, size_t ndx, double value, bool is_default)
 {
     REALM_ASSERT_3(col_ndx, <, get_column_count());
     REALM_ASSERT_3(ndx, <, m_size);
@@ -3092,14 +3126,18 @@ void Table::set_double(size_t col_ndx, size_t ndx, double value, bool is_default
                          is_default ? _impl::instr_SetDefault : _impl::instr_Set); // Throws
 }
 
+void Table::set_double(size_t column_ndx, size_t row_ndx, double value, bool is_default)
+{
+    set<double>(column_ndx, row_ndx, value, is_default);
+}
 
 StringData Table::get_string(size_t col_ndx, size_t ndx) const noexcept
 {
     return get<StringData>(col_ndx, ndx);
 }
 
-
-void Table::set_string(size_t col_ndx, size_t ndx, StringData value, bool is_default)
+template <>
+void Table::set(size_t col_ndx, size_t ndx, StringData value, bool is_default)
 {
     if (REALM_UNLIKELY(!is_attached()))
         throw LogicError(LogicError::detached_accessor);
@@ -3123,6 +3161,11 @@ void Table::set_string(size_t col_ndx, size_t ndx, StringData value, bool is_def
     if (Replication* repl = get_repl())
         repl->set_string(this, col_ndx, ndx, value,
                          is_default ? _impl::instr_SetDefault : _impl::instr_Set); // Throws
+}
+
+void Table::set_string(size_t column_ndx, size_t row_ndx, StringData value, bool is_default)
+{
+    set<StringData>(column_ndx, row_ndx, value, is_default);
 }
 
 
@@ -3242,8 +3285,8 @@ BinaryData Table::get_binary(size_t col_ndx, size_t ndx) const noexcept
     return get<BinaryData>(col_ndx, ndx);
 }
 
-
-void Table::set_binary(size_t col_ndx, size_t ndx, BinaryData value, bool is_default)
+template <>
+void Table::set(size_t col_ndx, size_t ndx, BinaryData value, bool is_default)
 {
     if (REALM_UNLIKELY(!is_attached()))
         throw LogicError(LogicError::detached_accessor);
@@ -3269,6 +3312,11 @@ void Table::set_binary(size_t col_ndx, size_t ndx, BinaryData value, bool is_def
     if (Replication* repl = get_repl())
         repl->set_binary(this, col_ndx, ndx, value,
                          is_default ? _impl::instr_SetDefault : _impl::instr_Set); // Throws
+}
+
+void Table::set_binary(size_t column_ndx, size_t row_ndx, BinaryData value, bool is_default)
+{
+    set<BinaryData>(column_ndx, row_ndx, value, is_default);
 }
 
 
@@ -6263,3 +6311,5 @@ void Table::dump_node_structure(std::ostream& out, int level) const
 }
 
 #endif // LCOV_EXCL_STOP ignore debug functions
+
+} // namespace realm

--- a/src/realm/table.hpp
+++ b/src/realm/table.hpp
@@ -208,6 +208,10 @@ public:
     size_t add_column_link(DataType type, StringData name, Table& target, LinkType link_type = link_Weak);
     void insert_column_link(size_t column_ndx, DataType type, StringData name, Table& target,
                             LinkType link_type = link_Weak);
+
+    size_t add_column_list(DataType type, StringData name);
+    void insert_column_list(size_t column_ndx, DataType type, StringData name);
+
     void remove_column(size_t column_ndx);
     void rename_column(size_t column_ndx, StringData new_name);
     //@}
@@ -502,6 +506,17 @@ public:
     void nullify_link(size_t column_ndx, size_t row_ndx);
     void set_null(size_t column_ndx, size_t row_ndx, bool is_default = false);
     void set_null_unique(size_t col_ndx, size_t row_ndx);
+
+    template <class T>
+    void set(size_t c, size_t r, T value, bool is_default = false);
+
+    template <class T>
+    void set_list(size_t c, size_t r, const std::vector<T>& list);
+
+    TableView get_list(size_t column_ndx, size_t row_ndx);
+
+    template <class T>
+    std::vector<T> get_list(size_t column_ndx, size_t row_ndx);
 
     void add_int(size_t column_ndx, size_t row_ndx, int_fast64_t value);
 
@@ -2012,6 +2027,31 @@ inline void Table::set_ndx_in_parent(size_t ndx_in_parent) noexcept
         // Subtable with shared descriptor
         m_columns.set_ndx_in_parent(ndx_in_parent);
     }
+}
+
+template <class T>
+void Table::set_list(size_t c, size_t r, const std::vector<T>& list)
+{
+    size_t sz = list.size();
+    TableRef subtable = get_subtable(c, r);
+    subtable->clear();
+    subtable->add_empty_row(sz);
+    for (size_t i = 0; i < sz; i++) {
+        T value = list[i];
+        subtable->set(0, i, value);
+    }
+}
+
+template <class T>
+std::vector<T> Table::get_list(size_t c, size_t r)
+{
+    std::vector<T> vec;
+    TableRef subtable = get_subtable(c, r);
+    size_t sz = subtable->size();
+    for (size_t i = 0; i < sz; i++) {
+        vec.push_back(subtable->get<T>(0, i));
+    }
+    return vec;
 }
 
 // This class groups together information about the target of a link column

--- a/src/realm/table.hpp
+++ b/src/realm/table.hpp
@@ -513,8 +513,6 @@ public:
     template <class T>
     void set_list(size_t c, size_t r, const std::vector<T>& list);
 
-    TableView get_list(size_t column_ndx, size_t row_ndx);
-
     template <class T>
     std::vector<T> get_list(size_t column_ndx, size_t row_ndx);
 
@@ -2045,9 +2043,10 @@ void Table::set_list(size_t c, size_t r, const std::vector<T>& list)
 template <class T>
 std::vector<T> Table::get_list(size_t c, size_t r)
 {
-    std::vector<T> vec;
     TableRef subtable = get_subtable(c, r);
     size_t sz = subtable->size();
+    std::vector<T> vec;
+    vec.reserve(sz);
     for (size_t i = 0; i < sz; i++) {
         vec.push_back(subtable->get<T>(0, i));
     }

--- a/src/realm/table.hpp
+++ b/src/realm/table.hpp
@@ -68,9 +68,6 @@ class TableFriend;
 
 class Replication;
 
-template <typename T>
-class List;
-
 /// FIXME: Table assignment (from any group to any group) could be made aliasing
 /// safe as follows: Start by cloning source table into target allocator. On
 /// success, assign, and then deallocate any previous structure at the target.
@@ -514,6 +511,9 @@ public:
 
     template <class T>
     void set_list(size_t c, size_t r, const std::vector<T>& list);
+
+    template <typename T>
+    class List;
 
     /// The object returned here is only valid during the current transaction
     /// It cannot be updated or handed over.
@@ -1458,7 +1458,7 @@ private:
 };
 
 template <typename T>
-class List {
+class Table::List {
 public:
     class Iterator : public std::iterator<std::input_iterator_tag, T> {
     public:
@@ -2117,7 +2117,7 @@ void Table::set_list(size_t c, size_t r, const std::vector<T>& list)
 }
 
 template <class T>
-List<T> Table::get_list(size_t c, size_t r)
+Table::List<T> Table::get_list(size_t c, size_t r)
 {
     return List<T>(get_subtable(c, r));
 }

--- a/src/realm/timestamp.hpp
+++ b/src/realm/timestamp.hpp
@@ -21,7 +21,6 @@
 
 #include <cstdint>
 #include <ostream>
-#include <chrono>
 #include <realm/util/assert.hpp>
 
 namespace realm {
@@ -75,15 +74,6 @@ public:
     Timestamp(realm::null)
         : m_is_null(true)
     {
-    }
-    template <class T>
-    Timestamp(std::chrono::time_point<T> t)
-        : m_is_null(false)
-    {
-        auto time_since_epoc = t.time_since_epoch();
-        uint64_t nano_seconds = std::chrono::duration_cast<std::chrono::nanoseconds>(time_since_epoc).count();
-        m_seconds = nano_seconds / nanoseconds_per_second;
-        m_nanoseconds = nano_seconds % nanoseconds_per_second;
     }
     Timestamp()
         : Timestamp(null{})

--- a/src/realm/timestamp.hpp
+++ b/src/realm/timestamp.hpp
@@ -21,6 +21,7 @@
 
 #include <cstdint>
 #include <ostream>
+#include <chrono>
 #include <realm/util/assert.hpp>
 
 namespace realm {
@@ -74,6 +75,15 @@ public:
     Timestamp(realm::null)
         : m_is_null(true)
     {
+    }
+    template <class T>
+    Timestamp(std::chrono::time_point<T> t)
+        : m_is_null(false)
+    {
+        auto time_since_epoc = t.time_since_epoch();
+        uint64_t nano_seconds = std::chrono::duration_cast<std::chrono::nanoseconds>(time_since_epoc).count();
+        m_seconds = nano_seconds / nanoseconds_per_second;
+        m_nanoseconds = nano_seconds % nanoseconds_per_second;
     }
     Timestamp()
         : Timestamp(null{})

--- a/test/test_table.cpp
+++ b/test/test_table.cpp
@@ -7861,11 +7861,19 @@ TEST(Table_ListOfPrimitives)
     t->set_list(timestamp_col, 0, timestamp_list);
 
     auto int_vec = t->get_list<int_fast64_t>(int_col, 0);
+    std::vector<int> vec(int_vec.size());
+    std::copy(int_vec.begin(), int_vec.end(), vec.begin());
     CHECK_EQUAL(integer_list.size(), int_vec.size());
-    for (unsigned i = 0; i < int_vec.size(); i++) {
-        CHECK_EQUAL(integer_list[i], int_vec[i]);
+    unsigned j = 0;
+    for (auto i : int_vec) {
+        CHECK_EQUAL(vec[j], i);
+        CHECK_EQUAL(integer_list[j++], i);
     }
-    t->set_list(0, 0, std::vector<int_fast64_t>());
+    CHECK_EQUAL(3, int_vec.remove(2));
+    CHECK_EQUAL(integer_list.size() - 1, int_vec.size());
+    CHECK_EQUAL(4, int_vec[2]);
+
+    int_vec.clear();
     int_vec = t->get_list<int_fast64_t>(int_col, 0);
     CHECK_EQUAL(0, int_vec.size());
 
@@ -7880,6 +7888,10 @@ TEST(Table_ListOfPrimitives)
     for (unsigned i = 0; i < string_vec.size(); i++) {
         CHECK_EQUAL(string_list[i], string_vec[i]);
     }
+
+    string_vec.insert(2, "Wednesday");
+    CHECK_EQUAL(string_list.size() + 1, string_vec.size());
+    CHECK_EQUAL(StringData("Wednesday"), string_vec[2]);
 
     auto double_vec = t->get_list<double>(double_col, 0);
     CHECK_EQUAL(double_list.size(), double_vec.size());

--- a/test/test_table.cpp
+++ b/test/test_table.cpp
@@ -7837,11 +7837,11 @@ TEST(Table_ListOfPrimitives)
 {
     Group g;
     TableRef t = g.add_table("table");
-    auto int_col = t->add_column_list(type_Int, "integers");
-    auto bool_col = t->add_column_list(type_Bool, "booleans");
-    auto string_col = t->add_column_list(type_String, "strings");
-    auto double_col = t->add_column_list(type_Double, "doubles");
-    auto timestamp_col = t->add_column_list(type_Timestamp, "timestamps");
+    size_t int_col = t->add_column_list(type_Int, "integers");
+    size_t bool_col = t->add_column_list(type_Bool, "booleans");
+    size_t string_col = t->add_column_list(type_String, "strings");
+    size_t double_col = t->add_column_list(type_Double, "doubles");
+    size_t timestamp_col = t->add_column_list(type_Timestamp, "timestamps");
     t->add_empty_row();
 
     std::vector<int_fast64_t> integer_list = {1, 2, 3, 4};
@@ -7856,52 +7856,41 @@ TEST(Table_ListOfPrimitives)
     std::vector<double> double_list = {898742.09382, 3.14159265358979, 2.71828182845904};
     t->set_list(double_col, 0, double_list);
 
-    auto now = std::chrono::system_clock::now();
-    std::chrono::minutes one_minute(1);
-    std::vector<Timestamp> timestamp_list = {now, now + one_minute};
+    time_t seconds_since_epoc = time(nullptr);
+    std::vector<Timestamp> timestamp_list = {Timestamp(seconds_since_epoc, 0), Timestamp(seconds_since_epoc + 60, 0)};
     t->set_list(timestamp_col, 0, timestamp_list);
 
-    TableView res = t->get_list(int_col, 0);
-    auto vec = t->get_list<int_fast64_t>(int_col, 0);
-    CHECK_EQUAL(integer_list.size(), res.size());
-    for (unsigned i = 0; i < res.size(); i++) {
-        CHECK_EQUAL(integer_list[i], res.get_int(0, i));
-        CHECK_EQUAL(integer_list[i], vec[i]);
+    auto int_vec = t->get_list<int_fast64_t>(int_col, 0);
+    CHECK_EQUAL(integer_list.size(), int_vec.size());
+    for (unsigned i = 0; i < int_vec.size(); i++) {
+        CHECK_EQUAL(integer_list[i], int_vec[i]);
     }
     t->set_list(0, 0, std::vector<int_fast64_t>());
-    res = t->get_list(int_col, 0);
-    CHECK_EQUAL(0, res.size());
+    int_vec = t->get_list<int_fast64_t>(int_col, 0);
+    CHECK_EQUAL(0, int_vec.size());
 
-    res = t->get_list(bool_col, 0);
-    CHECK_EQUAL(bool_list.size(), res.size());
-    for (unsigned i = 0; i < res.size(); i++) {
-        CHECK_EQUAL(bool_list[i], res.get_bool(0, i));
+    auto bool_vec = t->get_list<bool>(bool_col, 0);
+    CHECK_EQUAL(bool_list.size(), bool_vec.size());
+    for (unsigned i = 0; i < bool_vec.size(); i++) {
+        CHECK_EQUAL(bool_list[i], bool_vec[i]);
     }
 
-    res = t->get_list(string_col, 0);
-    CHECK_EQUAL(string_list.size(), res.size());
-    for (unsigned i = 0; i < res.size(); i++) {
-        CHECK_EQUAL(string_list[i], res.get_string(0, i));
+    auto string_vec = t->get_list<StringData>(string_col, 0);
+    CHECK_EQUAL(string_list.size(), string_vec.size());
+    for (unsigned i = 0; i < string_vec.size(); i++) {
+        CHECK_EQUAL(string_list[i], string_vec[i]);
     }
 
-    Row r = t->get(0);
-    TableRef subtable = r.get_subtable(string_col);
-    subtable->insert_empty_row(2);
-    subtable->set_string(0, 2, "wednesday");
-    res.sync_if_needed();
-    CHECK_EQUAL(string_list.size() + 1, res.size());
-    CHECK_EQUAL(StringData("wednesday"), res.get_string(0, 2));
-
-    res = t->get_list(double_col, 0);
-    CHECK_EQUAL(double_list.size(), res.size());
-    for (unsigned i = 0; i < res.size(); i++) {
-        CHECK_EQUAL(double_list[i], res.get_double(0, i));
+    auto double_vec = t->get_list<double>(double_col, 0);
+    CHECK_EQUAL(double_list.size(), double_vec.size());
+    for (unsigned i = 0; i < double_vec.size(); i++) {
+        CHECK_EQUAL(double_list[i], double_vec[i]);
     }
 
-    res = t->get_list(timestamp_col, 0);
-    CHECK_EQUAL(timestamp_list.size(), res.size());
-    for (unsigned i = 0; i < res.size(); i++) {
-        CHECK_EQUAL(timestamp_list[i], res.get_timestamp(0, i));
+    auto timestamp_vec = t->get_list<Timestamp>(timestamp_col, 0);
+    CHECK_EQUAL(timestamp_list.size(), timestamp_vec.size());
+    for (unsigned i = 0; i < timestamp_vec.size(); i++) {
+        CHECK_EQUAL(timestamp_list[i], timestamp_vec[i]);
     }
 }
 


### PR DESCRIPTION
Just a simple implementation to check if the direction is right.

A column that should hold list of primitives is created as a sub-table column where the sub-table has only one column. A new function - Table::add_column_list - is added for the purpose of creating such a column. Some helper functions that will allow you to manipulate the list are also supplied. The unit test shows how to use.

The object returned by get_list is of a new class List<T> and implements a lazy read of the individual elements. Insert and remove operations are also provided on this class.

Relates to #1881 
<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/realm/realm-core/2400)
<!-- Reviewable:end -->
