### PR TITLE
Protect all of read_barrier with a mutex

### DIFF
--- a/src/realm/util/encrypted_file_mapping.hpp
+++ b/src/realm/util/encrypted_file_mapping.hpp
@@ -50,7 +50,7 @@ public:
 
     // Make sure that memory in the specified range is synchronized with any
     // changes made globally visible through call to write_barrier
-    void read_barrier(const void* addr, size_t size, UniqueLock& lock, Header_to_size header_to_size);
+    void read_barrier(const void* addr, size_t size, Header_to_size header_to_size);
 
     // Ensures that any changes made to memory in the specified range
     // becomes visible to any later calls to read_barrier()
@@ -96,7 +96,7 @@ private:
 };
 
 
-inline void EncryptedFileMapping::read_barrier(const void* addr, size_t size, UniqueLock& lock,
+inline void EncryptedFileMapping::read_barrier(const void* addr, size_t size,
                                                Header_to_size header_to_size)
 {
     size_t first_accessed_page = reinterpret_cast<uintptr_t>(addr) >> m_page_shift;
@@ -104,8 +104,6 @@ inline void EncryptedFileMapping::read_barrier(const void* addr, size_t size, Un
 
     // make sure the first page is available
     if (!m_up_to_date_pages[first_idx]) {
-        if (!lock.holds_lock())
-            lock.lock();
         refresh_page(first_idx);
     }
 
@@ -120,8 +118,6 @@ inline void EncryptedFileMapping::read_barrier(const void* addr, size_t size, Un
 
     for (size_t idx = first_idx + 1; idx <= last_idx; ++idx) {
         if (!m_up_to_date_pages[idx]) {
-            if (!lock.holds_lock())
-                lock.lock();
             refresh_page(idx);
         }
     }

--- a/src/realm/util/file_mapper.hpp
+++ b/src/realm/util/file_mapper.hpp
@@ -70,8 +70,8 @@ extern util::Mutex& mapping_mutex;
 inline void do_encryption_read_barrier(const void* addr, size_t size, HeaderToSize header_to_size,
                                        EncryptedFileMapping* mapping)
 {
-    UniqueLock lock(mapping_mutex, defer_lock_tag());
-    mapping->read_barrier(addr, size, lock, header_to_size);
+    LockGuard lock(mapping_mutex);
+    mapping->read_barrier(addr, size, header_to_size);
 }
 
 inline void do_encryption_write_barrier(const void* addr, size_t size, EncryptedFileMapping* mapping)


### PR DESCRIPTION
The thread sanitiser warned about a race condition on `EncryptedFileMapping::m_up_to_date_pages` [here](https://github.com/realm/realm-core/blob/master/src/realm/util/encrypted_file_mapping.hpp#L106)  where other threads could write to it. This could lead to a scenario where `m_up_to_date_pages[first_idx]` is out of date while the rest of the pages are updated. I think it could be a problem if the first page contains the encryption IV for a later page which has actually been updated, or if data lies across the first and second page.

Since I haven't been able to reproduce the error through a core unit test I hope @beeender can test this branch with the sample app that is crashing in #2383 (or guide me how to do it?)

This could have some negative impact on performance if an app has many reader threads (though I don't think it should be too big of a deal), I will look at performance tomorrow.

@finnschiermer do you think this could be the cause?