### PR TITLE
Avoid calling Array::copy_on_write() when the value will not change

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,8 @@
 
 ### Enhancements
 
-* Lorem ipsum.
+* Avoid copying copy-on-write data structures when the write does not actually
+  change the existing value.
 
 -----------
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@
 
 * Avoid copying copy-on-write data structures when the write does not actually
   change the existing value.
+* Improve performance of deleting all rows in a TableView.
 
 -----------
 

--- a/src/realm/array.cpp
+++ b/src/realm/array.cpp
@@ -219,8 +219,7 @@ void Array::init_from_mem(MemRef mem) noexcept
     m_size = get_size_from_header(header);
 
     // Capacity is how many items there are room for
-    bool is_read_only = m_alloc.is_read_only(mem.get_ref());
-    if (is_read_only) {
+    if (m_alloc.is_read_only(mem.get_ref())) {
         m_capacity = m_size;
     }
     else {

--- a/src/realm/array.cpp
+++ b/src/realm/array.cpp
@@ -603,8 +603,6 @@ void Array::insert(size_t ndx, int_fast64_t value)
 {
     REALM_ASSERT_DEBUG(ndx <= m_size);
 
-    // Check if we need to copy before modifying
-    copy_on_write(); // Throws
 
     Getter old_getter = m_getter; // Save old getter before potential width expansion
 
@@ -729,8 +727,6 @@ void Array::truncate_and_destroy_children(size_t new_size)
 
 void Array::do_ensure_minimum_width(int_fast64_t value)
 {
-    // Check if we need to copy before modifying
-    copy_on_write(); // Throws
 
     // Make room for the new value
     size_t width = bit_width(value);
@@ -1611,14 +1607,14 @@ MemRef Array::clone(MemRef mem, Allocator& alloc, Allocator& target_alloc)
     return new_array.get_mem();
 }
 
-void Array::do_copy_on_write()
+void Array::do_copy_on_write(size_t minimum_size)
 {
     // Calculate size in bytes (plus a bit of matchcount room for expansion)
     size_t array_size = calc_byte_len(m_size, m_width);
-    size_t rest = (~array_size & 0x7) + 1;
+    size_t new_size = std::max(array_size + 64, minimum_size);
+    size_t rest = (~new_size & 0x7) + 1;
     if (rest < 8)
-        array_size += rest; // 64bit blocks
-    size_t new_size = array_size + 64;
+        new_size += rest; // 64bit blocks
 
     // Create new copy of array
     MemRef mref = m_alloc.alloc(new_size); // Throws
@@ -1697,21 +1693,21 @@ MemRef Array::create(Type type, bool context_flag, WidthType width_type, size_t 
     return mem;
 }
 
-
-// FIXME: It may be worth trying to combine this with copy_on_write()
-// to avoid two copies.
 void Array::alloc(size_t init_size, size_t width)
 {
     REALM_ASSERT(is_attached());
+
+    size_t needed_bytes = calc_byte_len(init_size, width);
+    // this method is not public and callers must (and currently do) ensure that
+    // needed_bytes are never larger than max_array_payload.
+    REALM_ASSERT_3(needed_bytes, <=, max_array_payload);
+
+    if (is_read_only())
+        do_copy_on_write(needed_bytes);
+
     REALM_ASSERT(!m_alloc.is_read_only(m_ref));
     REALM_ASSERT_3(m_capacity, >, 0);
     if (m_capacity < init_size || width != m_width) {
-        size_t needed_bytes = calc_byte_len(init_size, width);
-
-        // this method is not public and callers must (and currently do) ensure that
-        // needed_bytes are never larger than max_array_payload.
-        REALM_ASSERT_3(needed_bytes, <=, max_array_payload);
-
         size_t orig_capacity_bytes = get_capacity_from_header();
         size_t capacity_bytes = orig_capacity_bytes;
 

--- a/src/realm/array.hpp
+++ b/src/realm/array.hpp
@@ -979,6 +979,8 @@ protected:
 
     std::pair<ref_type, size_t> get_to_dot_parent(size_t ndx_in_parent) const override;
 
+    bool is_read_only() const noexcept;
+
 protected:
     // Getters and Setters for adaptive-packed arrays
     typedef int64_t (Array::*Getter)(size_t) const; // Note: getters must not throw
@@ -1942,6 +1944,12 @@ inline void Array::update_child_ref(size_t child_ndx, ref_type new_ref)
 inline ref_type Array::get_child_ref(size_t child_ndx) const noexcept
 {
     return get_as_ref(child_ndx);
+}
+
+inline bool Array::is_read_only() const noexcept
+{
+    REALM_ASSERT_DEBUG(is_attached());
+    return m_alloc.is_read_only(m_ref);
 }
 
 

--- a/src/realm/array.hpp
+++ b/src/realm/array.hpp
@@ -936,7 +936,7 @@ protected:
     void copy_on_write();
 
 private:
-    void do_copy_on_write();
+    void do_copy_on_write(size_t minimum_size=0);
     void do_ensure_minimum_width(int_fast64_t);
 
     template <size_t w>

--- a/src/realm/array_basic_tpl.hpp
+++ b/src/realm/array_basic_tpl.hpp
@@ -151,6 +151,8 @@ template <class T>
 inline void BasicArray<T>::set(size_t ndx, T value)
 {
     REALM_ASSERT_3(ndx, <, m_size);
+    if (get(ndx) == value)
+        return;
 
     // Check if we need to copy before modifying
     copy_on_write(); // Throws

--- a/src/realm/array_blob.cpp
+++ b/src/realm/array_blob.cpp
@@ -104,6 +104,9 @@ ref_type ArrayBlob::replace(size_t begin, size_t end, const char* data, size_t d
         size_t add_size = add_zero_term ? data_size + 1 : data_size;
         size_t new_size = m_size - remove_size + add_size;
 
+        if (remove_size == add_size && memcmp(m_data + begin, data, data_size) == 0)
+            return get_ref();
+
         // If size of BinaryData is below 'max_binary_size', the data is stored directly
         // in a single ArrayBlob. If more space is needed, the root blob will just contain
         // references to child blobs holding the actual data. Context flag will indicate

--- a/src/realm/array_blob.cpp
+++ b/src/realm/array_blob.cpp
@@ -104,9 +104,6 @@ ref_type ArrayBlob::replace(size_t begin, size_t end, const char* data, size_t d
         size_t add_size = add_zero_term ? data_size + 1 : data_size;
         size_t new_size = m_size - remove_size + add_size;
 
-        if (remove_size == add_size && memcmp(m_data + begin, data, data_size) == 0)
-            return get_ref();
-
         // If size of BinaryData is below 'max_binary_size', the data is stored directly
         // in a single ArrayBlob. If more space is needed, the root blob will just contain
         // references to child blobs holding the actual data. Context flag will indicate
@@ -121,7 +118,8 @@ ref_type ArrayBlob::replace(size_t begin, size_t end, const char* data, size_t d
             return reinterpret_cast<ArrayBlob*>(&new_root)->replace(begin, end, data, data_size, add_zero_term);
         }
 
-        copy_on_write(); // Throws
+        if (remove_size == add_size && is_read_only() && memcmp(m_data + begin, data, data_size) == 0)
+            return get_ref();
 
         // Reallocate if needed - also updates header
         alloc(new_size, 1); // Throws

--- a/src/realm/array_blobs_big.cpp
+++ b/src/realm/array_blobs_big.cpp
@@ -74,8 +74,8 @@ void ArrayBigBlobs::set(size_t ndx, BinaryData value, bool add_zero_term)
     else if (ref != 0 && value.data() != nullptr) {
         blob.init_from_ref(ref);
         blob.set_parent(this, ndx);
-        blob.clear();                                                           // Throws
-        ref_type new_ref = blob.add(value.data(), value.size(), add_zero_term); // Throws
+        ref_type new_ref = blob.replace(0, blob.size(),
+                                        value.data(), value.size(), add_zero_term); // Throws
         if (new_ref != ref) {
             Array::set_as_ref(ndx, new_ref);
         }

--- a/src/realm/group_writer.cpp
+++ b/src/realm/group_writer.cpp
@@ -227,13 +227,7 @@ GroupWriter::GroupWriter(Group& group)
     }
 }
 
-GroupWriter::~GroupWriter()
-{
-    for (auto& window : m_map_windows) {
-        delete window;
-    }
-    m_map_windows.clear();
-}
+GroupWriter::~GroupWriter() = default;
 
 size_t GroupWriter::get_file_size() const noexcept
 {
@@ -253,28 +247,23 @@ void GroupWriter::sync_all_mappings()
 // used policy. Entries in the cache are kept in MRU order.
 GroupWriter::MapWindow* GroupWriter::get_window(ref_type start_ref, size_t size)
 {
-    MapWindow* found_window = nullptr;
-    for (unsigned int i = 0; i < m_map_windows.size(); ++i) {
-        if (m_map_windows[i]->matches(start_ref, size) ||
-            m_map_windows[i]->extends_to_match(m_alloc.get_file(), start_ref, size)) {
-            found_window = m_map_windows[i];
-            // move matching window to top (to keep LRU order):
-            for (int k = i; k; --k)
-                m_map_windows[k] = m_map_windows[k - 1];
-            m_map_windows[0] = found_window;
-            return found_window;
-        }
+    auto match = std::find_if(m_map_windows.begin(), m_map_windows.end(), [=](auto& window) {
+        return window->matches(start_ref, size)
+            || window->extends_to_match(m_alloc.get_file(), start_ref, size);
+    });
+    if (match != m_map_windows.end()) {
+        // move matching window to top (to keep LRU order)
+        std::rotate(m_map_windows.begin(), match, match + 1);
+        return m_map_windows[0].get();
     }
     // no window found, make room for a new one at the top
     if (m_map_windows.size() == num_map_windows) {
-        MapWindow* last_window = m_map_windows.back();
-        last_window->sync();
-        delete last_window;
+        m_map_windows.back()->sync();
         m_map_windows.pop_back();
     }
-    MapWindow* new_window = new MapWindow(m_alloc.get_file(), start_ref, size);
-    m_map_windows.insert(m_map_windows.begin(), new_window);
-    return new_window;
+    auto new_window = std::make_unique<MapWindow>(m_alloc.get_file(), start_ref, size);
+    m_map_windows.insert(m_map_windows.begin(), std::move(new_window));
+    return m_map_windows[0].get();
 }
 
 ref_type GroupWriter::write_group()

--- a/src/realm/group_writer.hpp
+++ b/src/realm/group_writer.hpp
@@ -95,7 +95,7 @@ private:
     // needed, the least recently used is sync'ed and closed to make room
     // for a new one. The windows are kept in MRU (most recently used) order.
     const static int num_map_windows = 16;
-    std::vector<MapWindow*> m_map_windows;
+    std::vector<std::unique_ptr<MapWindow>> m_map_windows;
 
     // Get a suitable memory mapping for later access:
     // potentially adding it to the cache, potentially closing


### PR DESCRIPTION
This is currently mostly just an exploration into whether this is actually a useful thing to do.

A seemingly very common pattern in apps which talk to a REST API is to blindly update all fields in a Realm object with new values from the server, regardless of whether or not they've actually changed (because the server doesn't send that information, and checking would be a bunch of extra code).

I suspect that this extra churn could make realm file size growth noticeably worse, so the new test has a single table with 5000 rows, and then it makes a series of commits which each modify several columns of several rows, while self-assigning all other columns of those rows.

The current changes cut the file size 20-30% with small numbers of pinned versions and the total bytes written to disk by 40%:

### Before

Pinned Versions | File Size | Bytes Written
----------------|-----------|--------------
1 | 2097152 | 2654592
2 | 2359296 | 2655008
3 | 2621440 | 2655216
4 | 2883584 | 2655528

### After

Pinned Versions | File Size | Bytes Written
----------------|-----------|--------------
1 | 1703936 | 1550640
2 | 1966080 | 1551624
3 | 2097152 | 1552496
4 | 2097152 | 1553024

The rational for doing the checking in the low-level Array functions rather than at the column (or even binding) level is mainly to avoid any observable changes in behavior (skipping logging the no-op set to the transaction log would be a breaking change for sync and notifications), but also because it's probably faster (although I have not evaluated that at all yet) and it also turned out to be a very small number of changes to affect all column types.
