### PR TITLE
Added macOS slave to Jenkinsfile

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -115,7 +115,7 @@ def buildDockerEnv(name) {
 
 def doBuildCocoa(def isPublishingRun, def isPublishingLatestRun) {
   return {
-    node('osx_vegas') {
+    node('macos || osx_vegas') {
       getArchive()
 
       try {
@@ -311,7 +311,7 @@ def doBuildNodeInDocker(def isPublishingRun, def isPublishingLatestRun) {
 
 def doBuildNodeInOsx(def isPublishingRun, def isPublishingLatestRun) {
   return {
-    node('osx_vegas') {
+    node('macos || osx_vegas') {
       getArchive()
 
       def environment = ['REALM_ENABLE_ENCRYPTION=yes', 'REALM_ENABLE_ASSERTIONS=yes']
@@ -342,7 +342,7 @@ def doBuildNodeInOsx(def isPublishingRun, def isPublishingLatestRun) {
 
 def doBuildOsxDylibs(def isPublishingRun, def isPublishingLatestRun) {
   return {
-    node('osx_vegas') {
+    node('macos || osx_vegas') {
       getSourceArchive()
       def version = get_version()
 

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -115,7 +115,7 @@ def buildDockerEnv(name) {
 
 def doBuildCocoa(def isPublishingRun, def isPublishingLatestRun) {
   return {
-    node('macos || osx_vegas') {
+    node('macos') {
       getArchive()
 
       try {
@@ -311,7 +311,7 @@ def doBuildNodeInDocker(def isPublishingRun, def isPublishingLatestRun) {
 
 def doBuildNodeInOsx(def isPublishingRun, def isPublishingLatestRun) {
   return {
-    node('macos || osx_vegas') {
+    node('macos') {
       getArchive()
 
       def environment = ['REALM_ENABLE_ENCRYPTION=yes', 'REALM_ENABLE_ASSERTIONS=yes']
@@ -342,7 +342,7 @@ def doBuildNodeInOsx(def isPublishingRun, def isPublishingLatestRun) {
 
 def doBuildOsxDylibs(def isPublishingRun, def isPublishingLatestRun) {
   return {
-    node('macos || osx_vegas') {
+    node('macos') {
       getSourceArchive()
       def version = get_version()
 

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -115,7 +115,7 @@ def buildDockerEnv(name) {
 
 def doBuildCocoa(def isPublishingRun, def isPublishingLatestRun) {
   return {
-    node('macos') {
+    node('macos || osx_vegas') {
       getArchive()
 
       try {
@@ -311,7 +311,7 @@ def doBuildNodeInDocker(def isPublishingRun, def isPublishingLatestRun) {
 
 def doBuildNodeInOsx(def isPublishingRun, def isPublishingLatestRun) {
   return {
-    node('macos') {
+    node('macos || osx_vegas') {
       getArchive()
 
       def environment = ['REALM_ENABLE_ENCRYPTION=yes', 'REALM_ENABLE_ASSERTIONS=yes']
@@ -342,7 +342,7 @@ def doBuildNodeInOsx(def isPublishingRun, def isPublishingLatestRun) {
 
 def doBuildOsxDylibs(def isPublishingRun, def isPublishingLatestRun) {
   return {
-    node('macos') {
+    node('macos || osx_vegas') {
       getSourceArchive()
       def version = get_version()
 


### PR DESCRIPTION
Add `macos` as a label to the Mac builds in order to rely on newer slaves in CPH.