### PR TITLE
No longer disable unit test console output when setting envvar UNITTEST_XML

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,7 +16,10 @@
 
 ### Internals
 
-* Lorem ipsum.
+* Setting environment variable `UNITTEST_XML` to a nonempty value will no longer
+  disable the normal console output while running the test suite. Instead, in
+  that case, reporting will happen both to the console and to the JUnit XML
+  file.
 
 ----------------------------------------------
 

--- a/how-to-build.md
+++ b/how-to-build.md
@@ -183,9 +183,10 @@ These are the available variables:
  - Set `UNITTEST_KEEP_FILES` to a non-empty value to disable automatic removal
    of test files.
 
- - Set `UNITTEST_XML` to a non-empty value to dump the test results to an XML
-   file. For details, see `realm::test_util::unit_test::create_xml_reporter()`
-   in `test/util/unit_test.hpp`.
+ - Set `UNITTEST_XML` to a non-empty value to dump the test results to a JUnit
+   XML file. For details, see
+   `realm::test_util::unit_test::create_junit_reporter()` in
+   `test/util/unit_test.hpp`.
 
  - Set `UNITTEST_LOG_LEVEL` to adjust the log level threshold for custom intra
    test logging. Valid values are `all`, `trace`, `debug`, `info`, `warn`,

--- a/test/test_all.cpp
+++ b/test/test_all.cpp
@@ -420,19 +420,26 @@ bool run_tests(util::Logger* logger)
     const char* xml_str = getenv("UNITTEST_XML");
     xml = (xml_str && strlen(xml_str) != 0);
 #endif
-    std::unique_ptr<Reporter> reporter;
+    std::vector<std::unique_ptr<Reporter>> reporters;
+    {
+        const char* str = getenv("UNITTEST_PROGRESS");
+        bool report_progress = str && strlen(str) != 0;
+        std::unique_ptr<Reporter> reporter =
+            std::make_unique<CustomReporter>(report_progress);
+        reporters.push_back(std::move(reporter));
+    }
     if (xml) {
         std::string path = get_test_path_prefix();
         std::string xml_path = path + "unit-test-report.xml";
         xml_file.open(xml_path.c_str());
-        reporter.reset(create_junit_reporter(xml_file));
+        std::unique_ptr<Reporter> reporter_1 =
+            create_junit_reporter(xml_file);
+        std::unique_ptr<Reporter> reporter_2 =
+            create_twofold_reporter(*reporters.back(), *reporter_1);
+        reporters.push_back(std::move(reporter_1));
+        reporters.push_back(std::move(reporter_2));
     }
-    else {
-        const char* str = getenv("UNITTEST_PROGRESS");
-        bool report_progress = str && strlen(str) != 0;
-        reporter.reset(new CustomReporter(report_progress));
-    }
-    config.reporter = reporter.get();
+    config.reporter = reporters.back().get();
 
     // Set up filter
     const char* filter_str = getenv("UNITTEST_FILTER");
@@ -441,7 +448,7 @@ bool run_tests(util::Logger* logger)
         filter_str = test_only;
     std::unique_ptr<Filter> filter;
     if (filter_str && strlen(filter_str) != 0)
-        filter.reset(create_wildcard_filter(filter_str));
+        filter = create_wildcard_filter(filter_str);
     config.filter = filter.get();
 
     // Set intra test log level threshold
@@ -490,8 +497,7 @@ bool run_tests(util::Logger* logger)
     if (test_only)
         std::cout << "\n*** BE AWARE THAT MOST TESTS WERE EXCLUDED DUE TO USING 'ONLY' MACRO ***\n";
 
-    if (!xml)
-        std::cout << "\n";
+    std::cout << "\n";
 
     return success;
 }

--- a/test/util/unit_test.cpp
+++ b/test/util/unit_test.cpp
@@ -18,7 +18,6 @@
 
 #include <cstdlib>
 #include <functional>
-#include <memory>
 #include <stdexcept>
 #include <map>
 #include <string>
@@ -71,7 +70,7 @@ public:
     {
     }
 
-    ~XmlReporter() noexcept
+    ~XmlReporter() noexcept override
     {
     }
 
@@ -158,6 +157,7 @@ protected:
     std::ostream& m_out;
 };
 
+
 class JUnitReporter : public XmlReporter
 {
 public:
@@ -166,7 +166,7 @@ public:
     {
     }
 
-    ~JUnitReporter() noexcept
+    ~JUnitReporter() noexcept override
     {
     }
     void summary(const SharedContext& context, const Summary& results_summary) override
@@ -216,6 +216,45 @@ public:
         m_out << "  </testsuite>\n</testsuites>\n";
     }
 };
+
+
+class ManifoldReporter : public Reporter {
+public:
+    ManifoldReporter(std::initializer_list<Reporter*> subreporters)
+    {
+        for (Reporter* r: subreporters)
+            m_subreporters.push_back(r);
+    }
+
+    void begin(const TestContext& context) override
+    {
+        for (Reporter* r: m_subreporters)
+            r->begin(context);
+    }
+
+    void fail(const TestContext& context, const char* file_name, long line_number,
+              const std::string& message) override
+    {
+        for (Reporter* r: m_subreporters)
+            r->fail(context, file_name, line_number, message);
+    }
+
+    void end(const TestContext& context, double elapsed_seconds) override
+    {
+        for (Reporter* r: m_subreporters)
+            r->end(context, elapsed_seconds);
+    }
+
+    void summary(const SharedContext& context, const Summary& results_summary) override
+    {
+        for (Reporter* r: m_subreporters)
+            r->summary(context, results_summary);
+    }
+
+protected:
+    std::vector<Reporter*> m_subreporters;
+};
+
 
 class WildcardFilter : public Filter {
 public:
@@ -933,20 +972,26 @@ void SimpleReporter::summary(const SharedContext& context, const Summary& result
     }
 }
 
-Reporter* create_junit_reporter(std::ostream& out)
+std::unique_ptr<Reporter> create_junit_reporter(std::ostream& out)
 {
-    return new JUnitReporter(out);
+    return std::make_unique<JUnitReporter>(out);
 }
 
-Reporter* create_xml_reporter(std::ostream& out)
+std::unique_ptr<Reporter> create_xml_reporter(std::ostream& out)
 {
-    return new XmlReporter(out);
+    return std::make_unique<XmlReporter>(out);
+}
+
+std::unique_ptr<Reporter> create_twofold_reporter(Reporter& subreporter_1, Reporter& subreporter_2)
+{
+    using list = std::initializer_list<Reporter*>;
+    return std::make_unique<ManifoldReporter>(list{&subreporter_1, &subreporter_2});
 }
 
 
-Filter* create_wildcard_filter(const std::string& filter)
+std::unique_ptr<Filter> create_wildcard_filter(const std::string& filter)
 {
-    return new WildcardFilter(filter);
+    return std::make_unique<WildcardFilter>(filter);
 }
 
 

--- a/test/util/unit_test.hpp
+++ b/test/util/unit_test.hpp
@@ -22,6 +22,7 @@
 #include <stddef.h>
 #include <cmath>
 #include <cstring>
+#include <memory>
 #include <algorithm>
 #include <vector>
 #include <list>
@@ -359,15 +360,17 @@ protected:
 };
 
 
-/// Generates output that is compatible with the XML output of
-/// UnitTest++. Caller receives ownership of the returned reporter.
-Reporter* create_xml_reporter(std::ostream&);
-/// Generates output that is compatible with the XML output of
-/// JUnit. See http://llg.cubic.org/docs/junit/
-Reporter* create_junit_reporter(std::ostream&);
+/// Generates output that is compatible with the XML output of UnitTest++.
+std::unique_ptr<Reporter> create_xml_reporter(std::ostream&);
+
+/// Generates output that is compatible with the XML output of JUnit. See
+/// http://llg.cubic.org/docs/junit/
+std::unique_ptr<Reporter> create_junit_reporter(std::ostream&);
+
+std::unique_ptr<Reporter> create_twofold_reporter(Reporter& subreporter_1, Reporter& subreporter_2);
 
 /// Run only those tests whose name is both included and not
-/// excluded. Caller receives ownership of the returned filter.
+/// excluded.
 ///
 /// EBNF:
 ///
@@ -389,7 +392,7 @@ Reporter* create_junit_reporter(std::ostream&);
 /// whose names start with `Bar`. Another example is `Foo* - Foo2 *X`,
 /// which will include all tests whose names start with `Foo`, except
 /// `Foo2` and those whose names end with an `X`.
-Filter* create_wildcard_filter(const std::string&);
+std::unique_ptr<Filter> create_wildcard_filter(const std::string&);
 
 
 class TestContext {


### PR DESCRIPTION
My agenda is really to make this change for sync, but since sync tracks cores version of the unit test framework, I needed to make the changes core-side first.

@ironage 

Part of fixing https://github.com/realm/realm-sync/issues/1131