### PR TITLE
Fix compilation when old query engine fallback is disabled

### DIFF
--- a/src/realm/query_expression.hpp
+++ b/src/realm/query_expression.hpp
@@ -206,9 +206,10 @@ int no_timestamp(const Timestamp&)
     REALM_ASSERT(false);
     return 0;
 }
-#endif // REALM_OLDQUERY_FALLBACK
 
 } // anonymous namespace
+
+#endif // REALM_OLDQUERY_FALLBACK
 
 template <class T>
 struct Plus {


### PR DESCRIPTION
This issue was introduced in b927788a0cb429b519fc32eb4e303631ef9b7fb4.