### PR TITLE
Build with Xcode 8.2 instead of Xcode 7.3.1

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -128,7 +128,7 @@ def doBuildCocoa(def isPublishingRun, def isPublishingLatestRun) {
           'UNITTEST_REANDOM_SEED=random',
           'UNITTEST_XML=1',
           'UNITTEST_THREADS=1',
-          'DEVELOPER_DIR=/Applications/Xcode-7.3.1.app/Contents/Developer/'
+          'DEVELOPER_DIR=/Applications/Xcode-8.2.app/Contents/Developer/'
         ]) {
             sh '''
               dir=$(pwd)


### PR DESCRIPTION
I don't think Xcode 7.3.1 is available on the macOS slaves anymore. In sync we moved to 8.2.

cc @jpsim 