### PR TITLE
Add `add_int()` to `RowFuncs`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@
 * Avoid copying copy-on-write data structures when the write does not actually
   change the existing value.
 * Improve performance of deleting all rows in a TableView.
+* Allow the `add_int()` API to be called on a `Row`.
 
 -----------
 

--- a/src/realm/row.hpp
+++ b/src/realm/row.hpp
@@ -96,6 +96,7 @@ public:
 
     void set_int(size_t col_ndx, int_fast64_t value);
     void set_int_unique(size_t col_ndx, int_fast64_t value);
+    void add_int(size_t col_ndx, int_fast64_t value);
     void set_bool(size_t col_ndx, bool value);
     void set_float(size_t col_ndx, float value);
     void set_double(size_t col_ndx, double value);
@@ -493,6 +494,12 @@ template <class T, class R>
 inline void RowFuncs<T, R>::set_int_unique(size_t col_ndx, int_fast64_t value)
 {
     table()->set_int_unique(col_ndx, row_ndx(), value); // Throws
+}
+
+template <class T, class R>
+inline void RowFuncs<T, R>::add_int(size_t col_ndx, int_fast64_t value)
+{
+    table()->add_int(col_ndx, row_ndx(), value); // Throws
 }
 
 template <class T, class R>


### PR DESCRIPTION
Related to https://github.com/realm/realm-object-store/issues/357: supporting counters within bindings.

Who should I ask to review this?