### PR TITLE
Disable LTO for Android

### DIFF
--- a/src/project.mk
+++ b/src/project.mk
@@ -75,7 +75,7 @@ ifneq ($(REALM_HAVE_CONFIG),)
 endif
 
 ifneq ($(REALM_ANDROID),)
-  PROJECT_CFLAGS += -fPIC -DPIC
+  PROJECT_CFLAGS += -fPIC -DPIC -Wno-maybe-uninitialized
   # android.toolchain.cmake has `-fsigned-char` by default, we have to use the same
   # to avoid lto linking problems.
   CFLAGS_OPTIM = -Os -ffunction-sections -fdata-sections -DNDEBUG -fsigned-char -fvisibility=hidden

--- a/src/project.mk
+++ b/src/project.mk
@@ -78,7 +78,7 @@ ifneq ($(REALM_ANDROID),)
   PROJECT_CFLAGS += -fPIC -DPIC
   # android.toolchain.cmake has `-fsigned-char` by default, we have to use the same
   # to avoid lto linking problems.
-  CFLAGS_OPTIM = -Os -DNDEBUG -fsigned-char -fvisibility=hidden
+  CFLAGS_OPTIM = -Os -ffunction-sections -fdata-sections -DNDEBUG -fsigned-char -fvisibility=hidden
   ifeq ($(ENABLE_ENCRYPTION),yes)
     PROJECT_CFLAGS += -I../../openssl/include
   endif

--- a/src/project.mk
+++ b/src/project.mk
@@ -78,7 +78,7 @@ ifneq ($(REALM_ANDROID),)
   PROJECT_CFLAGS += -fPIC -DPIC
   # android.toolchain.cmake has `-fsigned-char` by default, we have to use the same
   # to avoid lto linking problems.
-  CFLAGS_OPTIM = -Os -flto -ffunction-sections -fdata-sections -DNDEBUG -fsigned-char -fvisibility=hidden
+  CFLAGS_OPTIM = -Os -DNDEBUG -fsigned-char -fvisibility=hidden
   ifeq ($(ENABLE_ENCRYPTION),yes)
     PROJECT_CFLAGS += -I../../openssl/include
   endif


### PR DESCRIPTION
While experimenting with various configuration related to https://github.com/realm/realm-java/issues/3651, I noticed that LTO is enabled. We have disabled it for Android since it increases linking time and not effectively reduces size (it might increase size).

For ARM v7 stripped `.so` file distributed with apps:

* with LTO: 1,852,944 bytes
* without LTO: 1,840,660 bytes

Yes, small increase when using LTO (partially).

@danielpovlsen @finnschiermer @beeender @ironage 
