### PR TITLE
Encrypted remap

### DIFF
--- a/src/realm/util/file.cpp
+++ b/src/realm/util/file.cpp
@@ -894,7 +894,7 @@ void* File::remap(void* old_addr, size_t old_size, AccessMode a, size_t new_size
     return new_addr;
 #else
     static_cast<void>(map_flags);
-    return realm::util::mremap(m_fd, file_offset, old_addr, old_size, a, new_size);
+    return realm::util::mremap(m_fd, file_offset, old_addr, old_size, a, new_size, m_encryption_key.get());
 #endif
 }
 

--- a/src/realm/util/file_mapper.cpp
+++ b/src/realm/util/file_mapper.cpp
@@ -282,10 +282,11 @@ void munmap(void* addr, size_t size) noexcept
     }
 }
 
-void* mremap(int fd, size_t file_offset, void* old_addr, size_t old_size, File::AccessMode a, size_t new_size)
+void* mremap(int fd, size_t file_offset, void* old_addr, size_t old_size, File::AccessMode a,
+             size_t new_size, const char* encryption_key)
 {
 #if REALM_ENABLE_ENCRYPTION
-    {
+    if (encryption_key) {
         LockGuard lock(mapping_mutex);
         size_t rounded_old_size = round_up_to_page_size(old_size);
         if (mapping_and_addr* m = find_mapping_for_addr(old_addr, rounded_old_size)) {
@@ -304,7 +305,14 @@ void* mremap(int fd, size_t file_offset, void* old_addr, size_t old_size, File::
             }
             return new_addr;
         }
+        // If we are using encryption, we must have used mmap and the mapping
+        // must have been added to the cache therefore find_mapping_for_addr()
+        // will succeed. Otherwise we would continue to mmap it below without
+        // the encryption key which is an error.
+        REALM_UNREACHABLE();
     }
+#else
+    static_cast<void>(encryption_key);
 #endif
 
 #ifdef _GNU_SOURCE

--- a/src/realm/util/file_mapper.hpp
+++ b/src/realm/util/file_mapper.hpp
@@ -28,7 +28,7 @@ namespace util {
 
 void* mmap(int fd, size_t size, File::AccessMode access, size_t offset, const char* encryption_key);
 void munmap(void* addr, size_t size) noexcept;
-void* mremap(int fd, size_t file_offset, void* old_addr, size_t old_size, File::AccessMode a, size_t new_size);
+void* mremap(int fd, size_t file_offset, void* old_addr, size_t old_size, File::AccessMode a, size_t new_size, const char* encryption_key);
 void msync(void* addr, size_t size);
 
 // A function which may be given to encryption_read_barrier. If present, the read barrier is a

--- a/test/test_lang_bind_helper.cpp
+++ b/test/test_lang_bind_helper.cpp
@@ -12184,7 +12184,7 @@ TEST(LangBindHelper_InRealmHistory_Downgrade)
     {
         // In-Realm history
         std::unique_ptr<Replication> hist = make_in_realm_history(path);
-        SharedGroup sg(*hist, SharedGroupOptions(crypt_key()));
+        SharedGroup sg(*hist);
         WriteTransaction wt(sg);
         wt.commit();
     }


### PR DESCRIPTION
Passing the encryption key down to `mremap()` allows us to only obtain the mutex if the key is used, so this should speed up the case when encryption has been compiled in but we are not actually using it.
This also allows us to check for and throw when an encryption key is used but we can't find the mapping in the cache. If this ever happened, we would fall through and mmap using `nullptr` as the encryption key meaning it wouldn't be added to the mappings either. We should throw if this ever happens (it shouldn't).
Testing with variations of encryption enabled showed an error in a test case, it is fixed here as well.