### PR TITLE
Make ArrayBlob::replace safe

### DIFF
--- a/src/realm/array_blob.cpp
+++ b/src/realm/array_blob.cpp
@@ -131,13 +131,25 @@ ref_type ArrayBlob::replace(size_t begin, size_t end, const char* data, size_t d
         if (begin != m_size) {
             const char* old_begin = m_data + end;
             const char* old_end = m_data + m_size;
+            const char* blob_end = m_data + m_size;
+
+            bool new_data_is_in_same_blob = data > modify_begin && data < blob_end;
+
             if (remove_size < add_size) { // expand gap
                 char* new_end = m_data + new_size;
                 std::copy_backward(old_begin, old_end, new_end);
+                if (new_data_is_in_same_blob) {
+                    auto adjust_data = new_end - old_end;
+                    data += adjust_data;
+                }
             }
             else if (add_size < remove_size) { // shrink gap
                 char* new_begin = modify_begin + add_size;
                 realm::safe_copy_n(old_begin, old_end - old_begin, new_begin);
+                if (new_data_is_in_same_blob) {
+                    auto adjust_data = new_begin - old_begin;
+                    data += adjust_data;
+                }
             }
         }
 

--- a/src/realm/column_binary.cpp
+++ b/src/realm/column_binary.cpp
@@ -404,34 +404,19 @@ void BinaryColumn::swap_rows(size_t row_ndx_1, size_t row_ndx_2)
     REALM_ASSERT_3(row_ndx_2, <=, size());
     REALM_ASSERT_DEBUG(row_ndx_1 != row_ndx_2);
 
-    // FIXME: Do this in a way that avoids the intermediate copying.
-
     BinaryData value_1 = get(row_ndx_1);
     BinaryData value_2 = get(row_ndx_2);
 
-    if (value_1.is_null() && value_2.is_null()) {
-        return;
-    }
-
-    std::unique_ptr<char[]> buffer_1(new char[value_1.size()]); // Throws
-    std::unique_ptr<char[]> buffer_2(new char[value_2.size()]); // Throws
-    realm::safe_copy_n(value_1.data(), value_1.size(), buffer_1.get());
-    realm::safe_copy_n(value_2.data(), value_2.size(), buffer_2.get());
-
     if (value_1.is_null()) {
-        set(row_ndx_2, BinaryData());
+        if (!value_2.is_null()) {
+            set(row_ndx_1, value_2);
+            set(row_ndx_2, BinaryData());
+        }
     }
     else {
-        BinaryData copy{buffer_1.get(), value_1.size()};
-        set(row_ndx_2, copy);
-    }
-
-    if (value_2.is_null()) {
-        set(row_ndx_1, BinaryData());
-    }
-    else {
-        BinaryData copy{buffer_2.get(), value_2.size()};
-        set(row_ndx_1, copy);
+        std::string copy_of_1{value_1};
+        set(row_ndx_1, value_2);
+        set(row_ndx_2, BinaryData(copy_of_1));
     }
 }
 

--- a/test/test_array_string_long.cpp
+++ b/test/test_array_string_long.cpp
@@ -108,6 +108,14 @@ TEST_TYPES(ArrayStringLong_Basic, non_nullable, nullable)
     CHECK_EQUAL("", c.get(4));
     CHECK_EQUAL("", c.get(5));
 
+    c.add("hi");
+    c.add("hello");
+
+    // Test that you can set a value obtained from the same blob
+    c.set(0, c.get(6));
+    CHECK_EQUAL("hi", c.get(0));
+    c.set(0, c.get(7));
+    CHECK_EQUAL("hello", c.get(0));
 
     // TEST(ArrayStringLong_Add)
 

--- a/test/test_column_binary.cpp
+++ b/test/test_column_binary.cpp
@@ -431,6 +431,13 @@ TEST(BinaryColumn_SwapRows)
         CHECK_EQUAL(c.get(2), BinaryData("baz"));
         CHECK_EQUAL(c.size(), 3); // size should not change
 
+        // swap back
+        c.swap_rows(1, 2);
+
+        CHECK_EQUAL(c.get(1), BinaryData("baz"));
+        CHECK_EQUAL(c.get(2), BinaryData("quux"));
+        CHECK_EQUAL(c.size(), 3); // size should not change
+
         c.destroy();
     }
 
@@ -461,6 +468,7 @@ TEST(BinaryColumn_SwapRows)
         c.add(BinaryData("foo"));
         c.add(BinaryData("bar"));
         c.add(BinaryData());
+        c.add(BinaryData("baz"));
 
         CHECK(c.get(2).is_null());
 
@@ -468,7 +476,16 @@ TEST(BinaryColumn_SwapRows)
 
         CHECK(c.get(1).is_null());
         CHECK_EQUAL(c.get(2).data(), BinaryData("bar").data());
-        CHECK_EQUAL(c.size(), 3); // size should not change
+        CHECK_EQUAL(c.get(3).data(), BinaryData("baz").data());
+        CHECK_EQUAL(c.size(), 4); // size should not change
+
+        // swap back
+        c.swap_rows(2, 1);
+
+        CHECK(c.get(2).is_null());
+        CHECK_EQUAL(c.get(1).data(), BinaryData("bar").data());
+        CHECK_EQUAL(c.get(3).data(), BinaryData("baz").data());
+        CHECK_EQUAL(c.size(), 4); // size should not change
 
         c.destroy();
     }

--- a/test/test_index_string.cpp
+++ b/test/test_index_string.cpp
@@ -1719,11 +1719,8 @@ TEST(StringIndex_Fuzzy)
             size_t r1 = fastrand() % t->size();
             size_t r2 = fastrand() % t->size();
 
-            std::string str1 = t->get_string(0, r2);
-            std::string str2 = t->get_string(0, r2);
-
-            t->set_string(0, r1, StringData(str1));
-            t->set_string(1, r1, StringData(str2));
+            t->set_string(0, r1, t->get_string(0, r2));
+            t->set_string(1, r1, t->get_string(0, r2));
 
             r1 = fastrand() % t->size();
             r2 = fastrand() % t->size();


### PR DESCRIPTION
Before this was not possible because the data was moved before copy took place. Now we adjust the position from where to copy from.