### PR TITLE
Get and set sys_tmp_dir

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,10 @@
 
 ### Bugfixes
 
-* Lorem ipsum.
+* Added SharedGroupOptions::set_sys_tmp_dir() and
+  SharedGroupOptions::set_sys_tmp_dir() to solve crash when compacting a Realm
+  file on Android external storage which is caused by invalid default sys_tmp_dir.
+  (https://github.com/realm/realm-java/issues/4140)
 
 ### Breaking changes
 

--- a/src/realm/group_shared.cpp
+++ b/src/realm/group_shared.cpp
@@ -684,11 +684,11 @@ void spawn_daemon(const std::string& file)
 } // anonymous namespace
 
 #if !REALM_UWP
-const std::string SharedGroupOptions::sys_tmp_dir = getenv("TMPDIR") ? getenv("TMPDIR") : "";
+std::string SharedGroupOptions::sys_tmp_dir = getenv("TMPDIR") ? getenv("TMPDIR") : "";
 #else
 // FIXME: getenv not supported on UWP. You must provide a temp path manually to the
 // SharedGroupOptions and pass it to the SharedGroup constructor.
-const std::string SharedGroupOptions::sys_tmp_dir = "";
+std::string SharedGroupOptions::sys_tmp_dir = "";
 #endif
 
 // NOTES ON CREATION AND DESTRUCTION OF SHARED MUTEXES:

--- a/src/realm/group_shared_options.hpp
+++ b/src/realm/group_shared_options.hpp
@@ -89,6 +89,8 @@ struct SharedGroupOptions {
 
     /// sys_tmp_dir will be used if the temp_dir is empty when creating SharedGroupOptions.
     /// It must be writable and allowed to create pipe/fifo file on it.
+    /// set_sys_tmp_dir is not a thread-safe call and it is only supposed to be called once
+    //  when process starts.
     static void set_sys_tmp_dir(const std::string& dir) noexcept { sys_tmp_dir = dir; }
     static std::string get_sys_tmp_dir() noexcept { return sys_tmp_dir; }
 

--- a/src/realm/group_shared_options.hpp
+++ b/src/realm/group_shared_options.hpp
@@ -87,8 +87,13 @@ struct SharedGroupOptions {
     /// This string should include a trailing slash '/'.
     std::string temp_dir;
 
+    /// sys_tmp_dir will be used if the temp_dir is empty when creating SharedGroupOptions.
+    /// It must be writable and allowed to create pipe/fifo file on it.
+    static void set_sys_tmp_dir(const std::string& dir) noexcept { sys_tmp_dir = dir; }
+    static std::string get_sys_tmp_dir() noexcept { return sys_tmp_dir; }
+
 private:
-    const static std::string sys_tmp_dir;
+    static std::string sys_tmp_dir;
 };
 
 } // end namespace realm

--- a/test/test_shared.cpp
+++ b/test/test_shared.cpp
@@ -3061,7 +3061,7 @@ TEST(Shared_Bptree_insert_failure)
     g.get_table(0)->add_empty_row(396);
 }
 
-TEST(SharedGroupOptions_tmp_dir)
+NONCONCURRENT_TEST(SharedGroupOptions_tmp_dir)
 {
     const std::string initial_system_dir = SharedGroupOptions::get_sys_tmp_dir();
 

--- a/test/test_shared.cpp
+++ b/test/test_shared.cpp
@@ -3061,4 +3061,25 @@ TEST(Shared_Bptree_insert_failure)
     g.get_table(0)->add_empty_row(396);
 }
 
+TEST(SharedGroupOptions_tmp_dir)
+{
+    const std::string initial_system_dir = SharedGroupOptions::get_sys_tmp_dir();
+
+    const std::string test_dir = "/test-temp";
+    SharedGroupOptions::set_sys_tmp_dir(test_dir);
+    CHECK(SharedGroupOptions::get_sys_tmp_dir().compare(test_dir) == 0);
+
+    // Without specifying the temp dir, sys_tmp_dir should be used.
+    SharedGroupOptions options;
+    CHECK(options.temp_dir.compare(test_dir) == 0);
+
+    // Should use the specified temp dir.
+    const std::string test_dir2 = "/test2-temp";
+    SharedGroupOptions options2(SharedGroupOptions::Durability::Full, nullptr, true,
+            std::function<void(int, int)>(), test_dir2);
+    CHECK(options2.temp_dir.compare(test_dir2) == 0);
+
+    SharedGroupOptions::set_sys_tmp_dir(initial_system_dir);
+}
+
 #endif // TEST_SHARED


### PR DESCRIPTION
When compacting the Realm on external storage for Android, SharedGroup
always uses the default sys_tmp_dir which is invalid for Android. Thus
we need an API for setting the default sys_tmp_dir for bindings.
The getters is also required since ObjectStore may use it to create
pipe/fifo.

To solve java issue https://github.com/realm/realm-java/issues/4140
Part of #2411