### PR TITLE
Remove a BinaryData constructor

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,7 +16,8 @@
 
 ### Internals
 
-* Lorem ipsum.
+* Remove the BinaryData constructor taking a temporary object to prevent some
+  errors in unit tests at compile time.
 
 ----------------------------------------------
 

--- a/src/realm/binary_data.hpp
+++ b/src/realm/binary_data.hpp
@@ -57,6 +57,10 @@ public:
     template <class T, class A>
     explicit BinaryData(const std::basic_string<char, T, A>&);
 
+    // BinaryData does not store data, callers must manage their own strings.
+    template <class T, class A>
+    BinaryData(const std::basic_string<char, T, A>&&) = delete;
+
     template <class T, class A>
     explicit operator std::basic_string<char, T, A>() const;
 

--- a/src/realm/string_data.hpp
+++ b/src/realm/string_data.hpp
@@ -92,7 +92,7 @@ public:
 
     // StringData does not store data, callers must manage their own strings.
     template <class T, class A>
-    StringData(std::basic_string<char, T, A>&&) = delete;
+    StringData(const std::basic_string<char, T, A>&&) = delete;
 
     template <class T, class A>
     StringData(const util::Optional<std::basic_string<char, T, A>>&);


### PR DESCRIPTION
This tell us about errors like the following in unit tests at compile time:
`BinaryData data(std::string(45, 'y'))`
If data is referenced again, it's pointers into memory would be invalid as the object it refers to has been destructed. BinaryData should only be a wrapper around external data, it doesn't store anything itself. This is similar to how the same StringData constructor has been removed. I made that one const to catch more cases too.

Note that we still allow code like `BinaryData data("test string", 11);` because that string should always be addressable since it is compiled into the data section of the binary.