### PR TITLE
Try new Jenkins syntax to add to Path.

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -120,7 +120,7 @@ def doBuildCocoa(def isPublishingRun, def isPublishingLatestRun) {
 
       try {
         withEnv([
-          'PATH=$PATH:/usr/local/bin',
+          'PATH+PREPEND=/usr/local/bin',
           'REALM_ENABLE_ENCRYPTION=yes',
           'REALM_ENABLE_ASSERTIONS=yes',
           'MAKEFLAGS=CFLAGS_DEBUG\\=-Oz',


### PR DESCRIPTION
To try and fix this error after Jenkins upgrade:

`Warning: JENKINS-41339 probably bogus PATH=$PATH:/usr/local/bin; perhaps you meant to use ‘PATH+EXTRA=/something/bin’?`