### PR TITLE
Support for list-of-primitives

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@
 
 * Now supports case insensitive queries for UWP.
 * Upgraded Visual Studio project to version 2017.
+* Support for 'list of primitives' (issue #1881).
 
 -----------
 

--- a/src/realm/array_direct.hpp
+++ b/src/realm/array_direct.hpp
@@ -22,8 +22,6 @@
 #include <realm/utilities.hpp>
 #include <realm/alloc.hpp>
 
-using namespace realm::util;
-
 // clang-format off
 /* wid == 16/32 likely when accessing offsets in B tree */
 #define REALM_TEMPEX(fun, wid, arg) \

--- a/src/realm/column.hpp
+++ b/src/realm/column.hpp
@@ -966,9 +966,9 @@ typename ColumnTypeTraits<T>::sum_type Column<T>::sum(size_t start, size_t end, 
 {
     using sum_type = typename ColumnTypeTraits<T>::sum_type;
     if (nullable)
-        return aggregate<T, sum_type, act_Sum, NotNull>(*this, 0, start, end, limit, return_ndx);
+        return aggregate<T, sum_type, act_Sum, realm::NotNull>(*this, 0, start, end, limit, return_ndx);
     else
-        return aggregate<T, sum_type, act_Sum, None>(*this, 0, start, end, limit, return_ndx);
+        return aggregate<T, sum_type, act_Sum, realm::None>(*this, 0, start, end, limit, return_ndx);
 }
 
 template <class T>

--- a/src/realm/exceptions.cpp
+++ b/src/realm/exceptions.cpp
@@ -86,6 +86,8 @@ const char* LogicError::what() const noexcept
             return "Table has no columns";
         case column_does_not_exist:
             return "Column does not exist";
+        case type_not_supported:
+            return "Only list of simple types are supported";
     }
     return "Unknown error";
 }

--- a/src/realm/exceptions.hpp
+++ b/src/realm/exceptions.hpp
@@ -203,7 +203,10 @@ public:
         table_has_no_columns,
 
         /// Referring to a column that has been deleted.
-        column_does_not_exist
+        column_does_not_exist,
+
+        /// Only simple types are supported
+        type_not_supported
     };
 
     LogicError(ErrorKind message);

--- a/src/realm/handover_defs.hpp
+++ b/src/realm/handover_defs.hpp
@@ -31,7 +31,10 @@ struct RowBaseHandoverPatch;
 struct TableViewHandoverPatch;
 
 struct TableHandoverPatch {
+    bool m_is_sub_table;
     size_t m_table_num;
+    size_t m_col_ndx;
+    size_t m_row_ndx;
 };
 
 struct LinkViewHandoverPatch {

--- a/src/realm/query.cpp
+++ b/src/realm/query.cpp
@@ -230,7 +230,13 @@ void Query::apply_patch(HandoverPatch& patch, Group& dest_group)
     // not going through Table::create_from_and_consume_patch because we need to use
     // set_table() to update all table references
     if (patch.m_table) {
-        set_table(dest_group.get_table(patch.m_table->m_table_num));
+        if (patch.m_table->m_is_sub_table) {
+            auto parent_table = dest_group.get_table(patch.m_table->m_table_num);
+            set_table(parent_table->get_subtable(patch.m_table->m_col_ndx, patch.m_table->m_row_ndx));
+        }
+        else {
+            set_table(dest_group.get_table(patch.m_table->m_table_num));
+        }
     }
     REALM_ASSERT(patch.m_node_data.empty());
 }
@@ -795,6 +801,9 @@ R Query::aggregate(R (ColType::*aggregateMethod)(size_t start, size_t end, size_
                    size_t column_ndx, size_t* resultcount, size_t start, size_t end, size_t limit,
                    size_t* return_ndx) const
 {
+    if (!m_table->is_attached()) {
+        throw LogicError{LogicError::detached_accessor};
+    }
     if (limit == 0 || m_table->is_degenerate()) {
         if (resultcount)
             *resultcount = 0;

--- a/test/test_lang_bind_helper.cpp
+++ b/test/test_lang_bind_helper.cpp
@@ -10503,6 +10503,91 @@ TEST(LangBindHelper_HandoverTableViewWithLinkView)
     }
 }
 
+TEST(Query_ListOfPrimitivesHandover)
+{
+    SHARED_GROUP_TEST_PATH(path);
+    std::unique_ptr<Replication> hist(make_in_realm_history(path));
+    SharedGroup sg(*hist);
+    auto& group = sg.begin_read();
+
+    std::unique_ptr<Replication> hist_w(make_in_realm_history(path));
+    SharedGroup sg_w(*hist_w, SharedGroupOptions(crypt_key()));
+    Group& group_w = const_cast<Group&>(sg_w.begin_read());
+    SharedGroup::VersionID vid;
+
+    std::unique_ptr<SharedGroup::Handover<TableView>> handover;
+    {
+        LangBindHelper::promote_to_write(sg_w);
+
+        TableRef t = group_w.add_table("table");
+        size_t int_col = t->add_column_list(type_Int, "integers", true);
+
+        t->add_empty_row(10);
+        t->set_list(int_col, 0, std::vector<int64_t>({1, 2, 3}));
+        t->set_list(int_col, 1, std::vector<int64_t>({1, 3, 5, 7}));
+        t->set_list(int_col, 2, std::vector<int64_t>({100, 400, 200, 500, 300}));
+
+        auto q = t->get_list<Int>(int_col, 2)->self() > 225;
+        auto tv = q.find_all();
+
+        LangBindHelper::commit_and_continue_as_read(sg_w);
+        vid = sg_w.get_version_of_current_transaction();
+        handover = sg_w.export_for_handover(tv, ConstSourcePayload::Stay);
+    }
+
+    LangBindHelper::advance_read(sg, vid);
+    auto tv = sg.import_from_handover(std::move(handover));
+    tv->sync_if_needed();
+    CHECK_EQUAL(tv->size(), 3);
+    CHECK_EQUAL(tv->get_int(0, 0), 400);
+
+    {
+        LangBindHelper::promote_to_write(sg_w);
+
+        TableRef t = group_w.get_or_add_table("table");
+        auto l = t->get_list<Int>(0, 2);
+        l->insert(0, 600);
+        t->remove(0);
+        // tv is now associated with row 1
+
+        LangBindHelper::commit_and_continue_as_read(sg_w);
+    }
+
+    LangBindHelper::advance_read(sg);
+    tv->sync_if_needed();
+    CHECK_EQUAL(tv->size(), 4);
+    CHECK_EQUAL(tv->get_int(0, 0), 600);
+    auto list = group.get_table("table")->get_list<Int>(0, 0);
+    auto q = list->where();
+    auto sum = q.sum_int(0);
+    CHECK_EQUAL(sum, 16);
+
+    {
+        LangBindHelper::promote_to_write(sg_w);
+
+        TableRef t = group_w.get_or_add_table("table");
+        // Remove the row, tv is associated with
+        t->remove(1);
+
+        LangBindHelper::commit_and_continue_as_read(sg_w);
+    }
+    LangBindHelper::advance_read(sg);
+    CHECK(!tv->is_attached());
+
+    {
+        LangBindHelper::promote_to_write(sg_w);
+
+        TableRef t = group_w.get_or_add_table("table");
+        // Remove the row, g is associated with
+        t->remove(0);
+
+        LangBindHelper::commit_and_continue_as_read(sg_w);
+    }
+    LangBindHelper::advance_read(sg);
+    sum = 0;
+    CHECK_LOGIC_ERROR(sum = q.sum_int(0), LogicError::detached_accessor);
+    CHECK_EQUAL(sum, 0);
+}
 
 TEST(LangBindHelper_HandoverTableRef)
 {

--- a/test/test_table.cpp
+++ b/test/test_table.cpp
@@ -7840,5 +7840,97 @@ TEST_TYPES(Table_ColumnSizeFromRef, std::true_type, std::false_type)
     check_column_sizes(10 * REALM_MAX_BPNODE_SIZE);
 }
 
+TEST(Table_ListOfPrimitives)
+{
+    Group g;
+    TableRef t = g.add_table("table");
+    size_t int_col = t->add_column_list(type_Int, "integers", true);
+    size_t bool_col = t->add_column_list(type_Bool, "booleans");
+    size_t string_col = t->add_column_list(type_String, "strings");
+    size_t double_col = t->add_column_list(type_Double, "doubles");
+    size_t timestamp_col = t->add_column_list(type_Timestamp, "timestamps");
+    t->add_empty_row();
+
+    std::vector<int_fast64_t> integer_list = {1, 2, 3, 4};
+    t->set_list(int_col, 0, integer_list);
+
+    std::vector<bool> bool_list = {false, false, true, false, true};
+    t->set_list(bool_col, 0, bool_list);
+
+    std::vector<StringData> string_list = {"monday", "tuesday", "thursday", "friday", "saturday", "sunday"};
+    t->set_list(string_col, 0, string_list);
+
+    std::vector<double> double_list = {898742.09382, 3.14159265358979, 2.71828182845904};
+    t->set_list(double_col, 0, double_list);
+
+    time_t seconds_since_epoc = time(nullptr);
+    std::vector<Timestamp> timestamp_list = {Timestamp(seconds_since_epoc, 0), Timestamp(seconds_since_epoc + 60, 0)};
+    t->set_list(timestamp_col, 0, timestamp_list);
+
+    auto int_vec = t->get_list<int_fast64_t>(int_col, 0);
+    std::vector<int> vec(int_vec->size());
+    std::copy(int_vec->begin(), int_vec->end(), vec.begin());
+    CHECK_EQUAL(integer_list.size(), int_vec->size());
+    unsigned j = 0;
+    // {1, 2, 3, 4}
+    for (auto i : *int_vec) {
+        CHECK_EQUAL(vec[j], i);
+        CHECK_EQUAL(integer_list[j++], i);
+    }
+    auto f = std::find(int_vec->begin(), int_vec->end(), 3);
+    CHECK_EQUAL(3, *f++);
+    CHECK_EQUAL(4, *f);
+    CHECK_EQUAL(3, int_vec->remove(2));
+    // {1, 2, 4}
+    CHECK_EQUAL(integer_list.size() - 1, int_vec->size());
+    CHECK_EQUAL(4, (*int_vec)[2]);
+    int_vec->resize(6);
+    // {1, 2, 4, null, null, null}
+    CHECK(int_vec->is_null(5));
+    int_vec->swap(0, 1);
+    // {2, 1, 4, null, null, null}
+    CHECK_EQUAL(2, (*int_vec)[0]);
+    CHECK_EQUAL(1, (*int_vec)[1]);
+    int_vec->remove(0, 2);
+    // {4, null, null, null}
+    CHECK_EQUAL(4, (*int_vec)[0]);
+    int_vec->resize(2);
+    // {4, null}
+    CHECK_EQUAL(2, int_vec->size());
+    CHECK_EQUAL(4, (*int_vec)[0]);
+    CHECK(int_vec->is_null(1));
+
+    int_vec->clear();
+    int_vec = t->get_list<int_fast64_t>(int_col, 0);
+    CHECK_EQUAL(0, int_vec->size());
+
+    auto bool_vec = t->get_list<bool>(bool_col, 0);
+    CHECK_EQUAL(bool_list.size(), bool_vec->size());
+    for (unsigned i = 0; i < bool_vec->size(); i++) {
+        CHECK_EQUAL(bool_list[i], (*bool_vec)[i]);
+    }
+
+    auto string_vec = t->get_list<StringData>(string_col, 0);
+    CHECK_EQUAL(string_list.size(), string_vec->size());
+    for (unsigned i = 0; i < string_vec->size(); i++) {
+        CHECK_EQUAL(string_list[i], (*string_vec)[i]);
+    }
+
+    string_vec->insert(2, "Wednesday");
+    CHECK_EQUAL(string_list.size() + 1, string_vec->size());
+    CHECK_EQUAL(StringData("Wednesday"), string_vec->get(2));
+
+    auto double_vec = t->get_list<double>(double_col, 0);
+    CHECK_EQUAL(double_list.size(), double_vec->size());
+    for (unsigned i = 0; i < double_vec->size(); i++) {
+        CHECK_EQUAL(double_list[i], double_vec->get(i));
+    }
+
+    auto timestamp_vec = t->get_list<Timestamp>(timestamp_col, 0);
+    CHECK_EQUAL(timestamp_list.size(), timestamp_vec->size());
+    for (unsigned i = 0; i < timestamp_vec->size(); i++) {
+        CHECK_EQUAL(timestamp_list[i], timestamp_vec->get(i));
+    }
+}
 
 #endif // TEST_TABLE


### PR DESCRIPTION
A column that should hold list of primitives is created as a sub-table column where the sub-tables have only one column. A new function - Table::add_column_list - is added for the purpose of creating such a column.

You can get an accessor object to a specific list element by calling the Table::get_list<T> function. The object is of class List<T>, where T is the type of the elements in the list. You access and manipulate the list through this object.

Fixes #1881