### PR TITLE
Clean up some things within TableView's implementation

### DIFF
--- a/src/realm/link_view.cpp
+++ b/src/realm/link_view.cpp
@@ -321,16 +321,10 @@ void LinkView::sort(const SortDescriptor& order)
 
 TableView LinkView::get_sorted_view(SortDescriptor order) const
 {
-    TableView v(m_origin_column->get_target_table()); // sets m_table
-    v.m_last_seen_version = m_origin_table->m_version;
-    // sets m_linkview_source to indicate that this TableView was generated from a LinkView
-    v.m_linkview_source = shared_from_this();
-    if (m_row_indexes.is_attached()) {
-        for (size_t t = 0; t < m_row_indexes.size(); t++) // todo, simpler way?
-            v.m_row_indexes.add(get(t).get_index());
-        v.sort(std::move(order));
-    }
-    return v;
+    TableView tv(m_origin_column->get_target_table(), shared_from_this());
+    tv.do_sync();
+    tv.sort(std::move(order));
+    return tv;
 }
 
 TableView LinkView::get_sorted_view(size_t column_index, bool ascending) const

--- a/src/realm/query.cpp
+++ b/src/realm/query.cpp
@@ -1454,11 +1454,6 @@ size_t Query::find_internal(size_t start, size_t end) const
         return r;
 }
 
-bool Query::comp(const std::pair<size_t, size_t>& a, const std::pair<size_t, size_t>& b)
-{
-    return a.first < b.first;
-}
-
 void Query::add_node(std::unique_ptr<ParentNode> node)
 {
     REALM_ASSERT(node);

--- a/src/realm/query.hpp
+++ b/src/realm/query.hpp
@@ -338,8 +338,6 @@ private:
     void handle_pending_not();
     void set_table(TableRef tr);
 
-    static bool comp(const std::pair<size_t, size_t>& a, const std::pair<size_t, size_t>& b);
-
 public:
     using HandoverPatch = QueryHandoverPatch;
 

--- a/src/realm/table.cpp
+++ b/src/realm/table.cpp
@@ -4028,8 +4028,8 @@ TableView Table::get_distinct_view(size_t col_ndx)
 {
     REALM_ASSERT(!m_columns.is_attached() || col_ndx < m_columns.size());
 
-    TableView tv(*this);
-    tv.sync_distinct_view(col_ndx);
+    TableView tv(TableView::DistinctView, *this, col_ndx);
+    tv.do_sync();
     return tv;
 }
 

--- a/src/realm/table.cpp
+++ b/src/realm/table.cpp
@@ -4403,14 +4403,7 @@ TableView Table::get_range_view(size_t begin, size_t end)
 {
     REALM_ASSERT(!m_columns.is_attached() || end <= size());
 
-    TableView ctv(*this);
-    if (m_columns.is_attached()) {
-        IntegerColumn& refs = ctv.m_row_indexes;
-        for (size_t i = begin; i < end; ++i) {
-            refs.add(i);
-        }
-    }
-    return ctv;
+    return where().find_all(begin, end);
 }
 
 ConstTableView Table::get_range_view(size_t begin, size_t end) const

--- a/src/realm/table_view.cpp
+++ b/src/realm/table_view.cpp
@@ -765,13 +765,11 @@ void TableViewBase::do_sync()
             m_row_indexes.clear();
         else
             m_row_indexes.init_from_ref(Allocator::get_default(), IntegerColumn::create(Allocator::get_default()));
+
         // if m_query had a TableView filter, then sync it. If it had a LinkView filter, no sync is needed
         if (m_query.m_view)
             m_query.m_view->sync_if_needed();
 
-        // find_all needs to call size() on the tableview. But if we're
-        // out of sync, size() will then call do_sync and we'll have an infinite regress
-        // SO: fake that we're up to date BEFORE calling find_all.
         m_query.find_all(*(const_cast<TableViewBase*>(this)), m_start, m_end, m_limit);
     }
     m_num_detached_refs = 0;

--- a/src/realm/table_view.cpp
+++ b/src/realm/table_view.cpp
@@ -741,10 +741,10 @@ void TableViewBase::do_sync()
         for (size_t t = 0; t < m_linkview_source->size(); t++)
             m_row_indexes.add(m_linkview_source->get(t).get_index());
     }
-    else if (m_table && m_distinct_column_source != npos) {
+    else if (m_distinct_column_source != npos) {
         sync_distinct_view(m_distinct_column_source);
     }
-    else if (m_table && m_linked_column) {
+    else if (m_linked_column) {
         m_row_indexes.clear();
         if (m_linked_row.is_attached()) {
             size_t linked_row_ndx = m_linked_row.get_index();
@@ -783,17 +783,14 @@ bool TableViewBase::is_in_table_order() const
     else if (m_linkview_source) {
         return false;
     }
-    else if (m_table && m_linked_column) {
+    else if (m_distinct_column_source != npos) {
+        return !m_sorting_predicate;
+    }
+    else if (m_linked_column) {
         return false;
-    }
-    else if (!m_query.m_table) {
-        // TableView originated from Table::find_all().
-        return !m_sorting_predicate;
-    }
-    else if (m_query.produces_results_in_table_order()) {
-        return !m_sorting_predicate;
     }
     else {
-        return false;
+        REALM_ASSERT(m_query.m_table);
+        return m_query.produces_results_in_table_order() && !m_sorting_predicate;
     }
 }

--- a/src/realm/table_view.cpp
+++ b/src/realm/table_view.cpp
@@ -729,8 +729,12 @@ void TableViewBase::sort(SortDescriptor order)
 
 void TableViewBase::do_sync()
 {
-    // A TableView can be "born" from 4 different sources: LinkView, Table::get_distinct_view(),
-    // Table::find_all() or Query. Here we sync with the respective source.
+    // This TableView can be "born" from 4 different sources:
+    // - LinkView
+    // - Query::find_all()
+    // - Table::get_distinct_view()
+    // - Table::get_backlink_view()
+    // Here we sync with the respective source.
 
     if (m_linkview_source) {
         m_row_indexes.clear();

--- a/src/realm/table_view.cpp
+++ b/src/realm/table_view.cpp
@@ -675,21 +675,6 @@ void TableView::clear(RemoveMode underlying_mode)
         m_last_seen_version = outside_version();
 }
 
-void TableViewBase::sync_distinct_view(size_t column)
-{
-    m_row_indexes.clear();
-    m_num_detached_refs = 0;
-    m_distinct_column_source = column;
-    if (m_distinct_column_source != npos) {
-        REALM_ASSERT(m_table);
-        REALM_ASSERT(m_table->has_search_index(m_distinct_column_source));
-        if (!m_table->is_degenerate()) {
-            const ColumnBase& col = m_table->get_column_base(m_distinct_column_source);
-            col.get_search_index()->distinct(m_row_indexes);
-        }
-    }
-}
-
 void TableViewBase::distinct(size_t column)
 {
     distinct(SortDescriptor(*m_table, {{column}}));
@@ -732,7 +717,12 @@ void TableViewBase::do_sync()
             m_row_indexes.add(m_linkview_source->get(t).get_index());
     }
     else if (m_distinct_column_source != npos) {
-        sync_distinct_view(m_distinct_column_source);
+        m_row_indexes.clear();
+        REALM_ASSERT(m_table->has_search_index(m_distinct_column_source));
+        if (!m_table->is_degenerate()) {
+            const ColumnBase& col = m_table->get_column_base(m_distinct_column_source);
+            col.get_search_index()->distinct(m_row_indexes);
+        }
     }
     else if (m_linked_column) {
         m_row_indexes.clear();

--- a/src/realm/table_view.cpp
+++ b/src/realm/table_view.cpp
@@ -749,17 +749,9 @@ void TableViewBase::do_sync()
                 m_row_indexes.add(m_linked_column->get_backlink(linked_row_ndx, i));
         }
     }
-    // precondition: m_table is attached
-    else if (!m_query.m_table) {
-        // This case gets invoked if the TableView origined from Table::find_all(T value). It is temporarely disabled
-        // because it doesn't take the search parameter in count. FIXME/Todo
-        REALM_ASSERT(false);
-        // no valid query
-        m_row_indexes.clear();
-        for (size_t i = 0; i < m_table->size(); i++)
-            m_row_indexes.add(i);
-    }
     else {
+        REALM_ASSERT(m_query.m_table);
+
         // valid query, so clear earlier results and reexecute it.
         if (m_row_indexes.is_attached())
             m_row_indexes.clear();
@@ -770,7 +762,7 @@ void TableViewBase::do_sync()
         if (m_query.m_view)
             m_query.m_view->sync_if_needed();
 
-        m_query.find_all(*(const_cast<TableViewBase*>(this)), m_start, m_end, m_limit);
+        m_query.find_all(*const_cast<TableViewBase*>(this), m_start, m_end, m_limit);
     }
     m_num_detached_refs = 0;
 

--- a/src/realm/table_view.hpp
+++ b/src/realm/table_view.hpp
@@ -314,9 +314,8 @@ public:
     virtual std::unique_ptr<TableViewBase> clone() const = 0;
 
 protected:
-    // This TableView can be "born" from 5 different sources:
+    // This TableView can be "born" from 4 different sources:
     // - LinkView
-    // - Table::find_all()
     // - Query::find_all()
     // - Table::get_distinct_view()
     // - Table::get_backlink_view()

--- a/src/realm/table_view.hpp
+++ b/src/realm/table_view.hpp
@@ -243,8 +243,6 @@ public:
     Timestamp maximum_timestamp(size_t column_ndx, size_t* return_ndx = nullptr) const;
     size_t count_timestamp(size_t column_ndx, Timestamp target) const;
 
-    void apply_same_order(TableViewBase& order);
-
     // Simple pivot aggregate method. Experimental! Please do not
     // document method publicly.
     void aggregate(size_t group_by_column, size_t aggr_column, Table::AggrType op, Table& result) const;

--- a/test/test_table.cpp
+++ b/test/test_table.cpp
@@ -1540,6 +1540,13 @@ TEST(Table_Range)
     CHECK_EQUAL(10, tv.size());
     for (size_t i = 0; i < tv.size(); ++i)
         CHECK_EQUAL(int64_t(i + 10), tv.get_int(0, i));
+
+    for (size_t i = 0; i < 5; ++i)
+        table.insert_empty_row(0);
+
+    CHECK(tv.sync_if_needed());
+    for (size_t i = 0; i < tv.size(); ++i)
+        CHECK_EQUAL(int64_t(i + 5), tv.get_int(0, i));
 }
 
 TEST(Table_RangeConst)


### PR DESCRIPTION
Changes:
* Remove a comment that dates to when `TableViewBase::size` called `sync_if_needed()`.
* Remove two methods that are no longer used.
* Have `Table::get_range_view` delegate to `Query` so that the resulting `TableView` can be synced when needed.
* Remove an unused code path in `TableViewBase::do_sync`.
* Update some comments about where `TableView`s come from.
* Update the structure of `TableViewBase::is_in_table_order` to match that of `TableViewBase::do_sync` to make it clearer that they both handle the same cases.
* Update the structure of `TableViewBase::outside_version` to match that of `TableViewBase::do_sync` to make it clearer that they both handle the same cases.
* Replace `TableViewBase::sync_distinct_view` with a constructor.
* Add a constructor to create a `TableView` from a `LinkView`, rather than having `LinkView` mess with `TableView`'s internals.
