### PR TITLE
Disable some tests on Windows

### DIFF
--- a/Visual Studio/Realm.vcxproj
+++ b/Visual Studio/Realm.vcxproj
@@ -1220,7 +1220,7 @@
       <AdditionalOptions>WS2_32.lib %(AdditionalOptions)</AdditionalOptions>
     </Link>
     <Lib>
-      <AdditionalOptions>/DPTW32_STATIC_LIB WS2_32.lib %(AdditionalOptions)</AdditionalOptions>
+      <AdditionalOptions>WS2_32.lib %(AdditionalOptions)</AdditionalOptions>
     </Lib>
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
@@ -1373,7 +1373,7 @@
       <AdditionalOptions>WS2_32.lib %(AdditionalOptions)</AdditionalOptions>
     </Link>
     <Lib>
-      <AdditionalOptions>/DPTW32_STATIC_LIB WS2_32.lib %(AdditionalOptions)</AdditionalOptions>
+      <AdditionalOptions>WS2_32.lib %(AdditionalOptions)</AdditionalOptions>
     </Lib>
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Static library, release|ARM'">
@@ -1403,7 +1403,7 @@
       <AdditionalOptions>WS2_32.lib %(AdditionalOptions)</AdditionalOptions>
     </Link>
     <Lib>
-      <AdditionalOptions>/DPTW32_STATIC_LIB WS2_32.lib %(AdditionalOptions)</AdditionalOptions>
+      <AdditionalOptions>WS2_32.lib %(AdditionalOptions)</AdditionalOptions>
     </Lib>
   </ItemDefinitionGroup>
   <ItemGroup>

--- a/test/test_optional.cpp
+++ b/test/test_optional.cpp
@@ -281,10 +281,13 @@ TEST(Optional_ConstExpr)
     CHECK_EQUAL(bool(c), true);
     constexpr int d = *c;
     CHECK_EQUAL(1, d);
+// FIXME: Visual Studio 2015's constexpr support isn't sufficient to allow this to compile.
+#ifndef _WIN32
     constexpr bool e{Optional<int>{1}};
     CHECK_EQUAL(true, e);
     constexpr bool f{Optional<int>{none}};
     CHECK_EQUAL(false, f);
+#endif
     constexpr int g = b.value_or(1234);
     CHECK_EQUAL(1234, g);
 }


### PR DESCRIPTION
constexpr support isn't sufficient on Visual Studio