### PR TITLE
Tweak some Optional tests so they're compatible with VS2017, and reenable them

### DIFF
--- a/test/test_optional.cpp
+++ b/test/test_optional.cpp
@@ -281,19 +281,14 @@ TEST(Optional_ConstExpr)
     CHECK_EQUAL(bool(c), true);
     constexpr int d = *c;
     CHECK_EQUAL(1, d);
-// FIXME: Visual Studio 2015's constexpr support isn't sufficient to allow this to compile.
-#ifndef _WIN32
     constexpr bool e = bool(Optional<int>{1});
     CHECK_EQUAL(true, e);
     constexpr bool f = bool(Optional<int>{none});
     CHECK_EQUAL(false, f);
-#endif
     constexpr int g = b.value_or(1234);
     CHECK_EQUAL(1234, g);
 }
 
-// FIXME: Visual Studio 2015's constexpr support isn't sufficient to allow Optional<T&> to compile.
-#ifndef _WIN32
 TEST(Optional_ReferenceConstExpr)
 {
     // Should compile:
@@ -308,7 +303,6 @@ TEST(Optional_ReferenceConstExpr)
     constexpr bool f = bool(Optional<const int&>{none});
     CHECK_EQUAL(false, f);
 }
-#endif
 
 // Disabled for compliance with std::optional
 // TEST(Optional_VoidIsEquivalentToBool)

--- a/test/test_optional.cpp
+++ b/test/test_optional.cpp
@@ -283,9 +283,9 @@ TEST(Optional_ConstExpr)
     CHECK_EQUAL(1, d);
 // FIXME: Visual Studio 2015's constexpr support isn't sufficient to allow this to compile.
 #ifndef _WIN32
-    constexpr bool e{Optional<int>{1}};
+    constexpr bool e = bool(Optional<int>{1});
     CHECK_EQUAL(true, e);
-    constexpr bool f{Optional<int>{none}};
+    constexpr bool f = bool(Optional<int>{none});
     CHECK_EQUAL(false, f);
 #endif
     constexpr int g = b.value_or(1234);
@@ -303,9 +303,9 @@ TEST(Optional_ReferenceConstExpr)
     CHECK_EQUAL(bool(c), true);
     constexpr int d = *c;
     CHECK_EQUAL(0, d);
-    constexpr bool e{Optional<const int&>{global_i}};
+    constexpr bool e = bool(Optional<const int&>{global_i});
     CHECK_EQUAL(true, e);
-    constexpr bool f{Optional<const int&>{none}};
+    constexpr bool f = bool(Optional<const int&>{none});
     CHECK_EQUAL(false, f);
 }
 #endif


### PR DESCRIPTION
The latest Visual Studio 2017 RC rejects `constexpr bool e{<some Optional>}` with an error about there being no conversion from `Optional<T>` to `const bool`.  This seems to be a bug, so [I've reported it to Microsoft](https://developercommunity.visualstudio.com/content/problem/20100/cannotconvert-from-s-to-const-bool-when-initializi.html). Since this exact syntax isn't relevant to what we're trying to test we can instead use `constexpr bool e = bool(<some Optional>)` to test the relevant behavior.

While making this change I noticed that the tests involving constexpr and optional references now pass, so I've taken the liberty of enabling them on Windows as well.