### PR TITLE
String index improvements

### DIFF
--- a/src/realm/index_string.cpp
+++ b/src/realm/index_string.cpp
@@ -75,15 +75,15 @@ size_t IndexArray::from_list<index_FindFirst>(StringData value, IntegerColumn& r
     if (lower == it_end)
         return not_found;
 
-    const size_t first_row_ref = to_size_t(*lower);
+    const size_t first_row_ndx = to_size_t(*lower);
 
     // The buffer is needed when for when this is an integer index.
     StringIndex::StringConversionBuffer buffer;
-    StringData str = column->get_index_data(first_row_ref, buffer);
+    StringData str = column->get_index_data(first_row_ndx, buffer);
     if (str != value)
         return not_found;
 
-    return first_row_ref;
+    return first_row_ndx;
 }
 
 template <>
@@ -100,11 +100,11 @@ size_t IndexArray::from_list<index_Count>(StringData value, IntegerColumn& resul
     if (lower == it_end)
         return 0;
 
-    const size_t first_row_ref = to_size_t(*lower);
+    const size_t first_row_ndx = to_size_t(*lower);
 
     // The buffer is needed when for when this is an integer index.
     StringIndex::StringConversionBuffer buffer;
-    StringData str = column->get_index_data(first_row_ref, buffer);
+    StringData str = column->get_index_data(first_row_ndx, buffer);
     if (str != value)
         return 0;
 
@@ -127,11 +127,11 @@ size_t IndexArray::from_list<index_FindAll>(StringData value, IntegerColumn& res
     if (lower == it_end)
         return size_t(FindRes_not_found);
 
-    const size_t first_row_ref = to_size_t(*lower);
+    const size_t first_row_ndx = to_size_t(*lower);
 
     // The buffer is needed when for when this is an integer index.
     StringIndex::StringConversionBuffer buffer;
-    StringData str = column->get_index_data(first_row_ref, buffer);
+    StringData str = column->get_index_data(first_row_ndx, buffer);
     if (str != value)
         return size_t(FindRes_not_found);
 
@@ -139,8 +139,8 @@ size_t IndexArray::from_list<index_FindAll>(StringData value, IntegerColumn& res
 
     // Copy all matches into result column
     for (IntegerColumn::const_iterator it = lower; it != upper; ++it) {
-        const size_t cur_row_ref = to_size_t(*it);
-        result.add(cur_row_ref);
+        const size_t cur_row_ndx = to_size_t(*it);
+        result.add(cur_row_ndx);
     }
 
     return size_t(FindRes_column);
@@ -159,11 +159,11 @@ size_t IndexArray::from_list<index_FindAll_nocopy>(StringData value, IntegerColu
     if (lower == it_end)
         return size_t(FindRes_not_found);
 
-    const size_t first_row_ref = to_size_t(*lower);
+    const size_t first_row_ndx = to_size_t(*lower);
 
     // The buffer is needed when for when this is an integer index.
     StringIndex::StringConversionBuffer buffer;
-    StringData str = column->get_index_data(first_row_ref, buffer);
+    StringData str = column->get_index_data(first_row_ndx, buffer);
     if (str != value)
         return size_t(FindRes_not_found);
 
@@ -177,8 +177,8 @@ size_t IndexArray::from_list<index_FindAll_nocopy>(StringData value, IntegerColu
     }
 
     // Check string value at upper, if equal return matches in (lower, upper]
-    const size_t last_row_ref = to_size_t(*upper);
-    str = column->get_index_data(last_row_ref, buffer);
+    const size_t last_row_ndx = to_size_t(*upper);
+    str = column->get_index_data(last_row_ndx, buffer);
     if (str == value) {
         result_ref.payload = rows.get_ref();
         result_ref.start_ndx = lower.get_col_ndx();
@@ -265,17 +265,17 @@ size_t IndexArray::index_string(StringData value, IntegerColumn& result, Interna
 
         // Literal row index (tagged)
         if (ref & 1) {
-            size_t row_ref = size_t(uint64_t(ref) >> 1);
+            size_t row_ndx = size_t(uint64_t(ref) >> 1);
 
             // The buffer is needed when for when this is an integer index.
             StringIndex::StringConversionBuffer buffer;
-            StringData str = column->get_index_data(row_ref, buffer);
+            StringData str = column->get_index_data(row_ndx, buffer);
             if (str == value) {
-                result_ref.payload = row_ref;
+                result_ref.payload = row_ndx;
                 if (all)
-                    result.add(row_ref);
+                    result.add(row_ndx);
 
-                return first ? row_ref : get_count ? 1 : FindRes_single;
+                return first ? row_ndx : get_count ? 1 : FindRes_single;
             }
             return local_not_found;
         }

--- a/src/realm/index_string.cpp
+++ b/src/realm/index_string.cpp
@@ -197,7 +197,7 @@ size_t IndexArray::from_list<index_FindAll_nocopy>(StringData value, IntegerColu
     return size_t(FindRes_column);
 }
 
-template <IndexMethod method, class T>
+template <IndexMethod method>
 size_t IndexArray::index_string(StringData value, IntegerColumn& result, InternalFindResult& result_ref,
                                 ColumnBase* column) const
 {
@@ -310,28 +310,28 @@ size_t IndexArray::index_string_find_first(StringData value, ColumnBase* column)
 {
     InternalFindResult dummy;
     IntegerColumn dummycol;
-    return index_string<index_FindFirst, StringData>(value, dummycol, dummy, column);
+    return index_string<index_FindFirst>(value, dummycol, dummy, column);
 }
 
 
 void IndexArray::index_string_find_all(IntegerColumn& result, StringData value, ColumnBase* column) const
 {
     InternalFindResult dummy;
-    index_string<index_FindAll, StringData>(value, result, dummy, column);
+    index_string<index_FindAll>(value, result, dummy, column);
 }
 
 FindRes IndexArray::index_string_find_all_no_copy(StringData value, ColumnBase* column,
                                                   InternalFindResult& result) const
 {
     IntegerColumn dummy;
-    return static_cast<FindRes>(index_string<index_FindAll_nocopy, StringData>(value, dummy, result, column));
+    return static_cast<FindRes>(index_string<index_FindAll_nocopy>(value, dummy, result, column));
 }
 
 size_t IndexArray::index_string_count(StringData value, ColumnBase* column) const
 {
     IntegerColumn dummy1;
     InternalFindResult dummy2;
-    return index_string<index_Count, StringData>(value, dummy1, dummy2, column);
+    return index_string<index_Count>(value, dummy1, dummy2, column);
 }
 
 IndexArray* StringIndex::create_node(Allocator& alloc, bool is_leaf)

--- a/src/realm/index_string.cpp
+++ b/src/realm/index_string.cpp
@@ -295,10 +295,8 @@ size_t IndexArray::index_string(StringData value, IntegerColumn& result, Interna
         width = get_width_from_header(header);
         is_inner_node = get_is_inner_bptree_node_from_header(header);
 
-        if (value.size() - stringoffset >= 4)
-            stringoffset += 4;
-        else
-            stringoffset += value.size() - stringoffset + 1;
+        // Go to next key part of the string. If the offset exceeds the string length, the key will be 0
+        stringoffset += 4;
 
         // Update 4 byte index key
         key = StringIndex::create_key(value, stringoffset);

--- a/src/realm/index_string.cpp
+++ b/src/realm/index_string.cpp
@@ -219,7 +219,7 @@ size_t IndexArray::index_string(StringData value, IntegerColumn& result, Interna
     // result_ref.result with the results in the bounds start_ndx, and end_ndx
     constexpr bool allnocopy(method == index_FindAll_nocopy);
 
-    constexpr size_t local_not_found = (allnocopy || all) ? FindRes_not_found : first ? not_found : 0;
+    constexpr size_t local_not_found = (allnocopy || all) ? size_t(FindRes_not_found) : first ? not_found : 0;
 
     const char* data = m_data;
     const char* header;

--- a/src/realm/index_string.cpp
+++ b/src/realm/index_string.cpp
@@ -202,22 +202,22 @@ size_t IndexArray::index_string(StringData value, IntegerColumn& result, Interna
                                 ColumnBase* column) const
 {
     // Return`realm::not_found`, or an index to the (any) match
-    bool first(method == index_FindFirst);
+    constexpr bool first(method == index_FindFirst);
     // Return 0, or the number of items that match the specified `value`
-    bool get_count(method == index_Count);
+    constexpr bool get_count(method == index_Count);
     // Place all row indexes containing `value` into `result`
     // Returns one of FindRes_not_found[==0] if no matches found
     // Returns FindRes_single, if one match found: the result row literal is
     // both placed in `result_ref.payload` and added to `column`
     // Returns FindRes_column, if more than one match found: the matching row
     // literals are copied into `column`
-    bool all(method == index_FindAll);
+    constexpr bool all(method == index_FindAll);
     // Same as `index_FindAll` but does not copy matching rows into `column`
     // returns FindRes_not_found if there are no matches
     // returns FindRes_single and the row index (literal) in result_ref.payload
     // or returns FindRes_column and the reference to a column of duplicates in
     // result_ref.result with the results in the bounds start_ndx, and end_ndx
-    bool allnocopy(method == index_FindAll_nocopy);
+    constexpr bool allnocopy(method == index_FindAll_nocopy);
 
     const char* data = m_data;
     const char* header;

--- a/src/realm/index_string.cpp
+++ b/src/realm/index_string.cpp
@@ -224,11 +224,10 @@ size_t IndexArray::index_string(StringData value, IntegerColumn& result, Interna
     uint_least8_t width = m_width;
     bool is_inner_node = m_is_inner_bptree_node;
     typedef StringIndex::key_type key_type;
-    key_type key;
     size_t stringoffset = 0;
 
     // Create 4 byte index key
-    key = StringIndex::create_key(value, stringoffset);
+    key_type key = StringIndex::create_key(value, stringoffset);
 
     for (;;) {
         // Get subnode table

--- a/src/realm/index_string.hpp
+++ b/src/realm/index_string.hpp
@@ -84,7 +84,7 @@ private:
     size_t from_list(StringData value, IntegerColumn& result, InternalFindResult& result_ref,
                      const IntegerColumn& rows, ColumnBase* column) const;
 
-    template <IndexMethod method, class T>
+    template <IndexMethod method>
     size_t index_string(StringData value, IntegerColumn& result, InternalFindResult& result_ref,
                         ColumnBase* column) const;
 };

--- a/src/realm/utilities.hpp
+++ b/src/realm/utilities.hpp
@@ -178,12 +178,6 @@ ReturnType type_punning(OriginalType variable) noexcept
 // Also see the comments in Array::index_string()
 enum FindRes {
     // Indicate that no results were found in the search
-    // Do not change this from 0. There are several places in the find method,
-    // (Array::index_string) which can skip a conditional (of the search type)
-    // if and only if FindRes_not_found is the same as returning a value of 0
-    // for when the search method is a count of the value. ie. we can return a
-    // result of 0 regardless of if we are counting the values or if we are
-    // returning a column or a single index; 0 means no results in all cases.
     FindRes_not_found,
     // Indicates a single result is found
     FindRes_single,


### PR DESCRIPTION
Extracted from another branch to keep PRs clean.

Probably easier to review commit by commit.

The most significant change here is probably the simplification of selecting the next string offset for the key generation (4c7fc5c). When the end of the search string is reached, which happens immediately for strings of less than 4 bytes, the old code set the next key offset to be the string length + 1.:
```C++
stringoffset += value.size() - stringoffset + 1; // stringoffset = value.size() + 1;
```
Unfortunately that would trigger an unsigned int (`size_t`) underflow at the next iteration at the line:
```C++
if (value.size() - stringoffset >= 4) // (size_t(-1) >= size_t(4)) == true
    stringoffset += 4; // value.size() + 1 + 4
```
Again, setting the offset further outside the bounds of the string. However, `StringIndex::create_key` handles this case just fine, so instead of having this complex (and slightly buggy) branch, I've changed the offset to always increment by 4.

A long explanation for something that should be simple. Phew.