### PR TITLE
Don't open a condition variable's pipe twice when once will do

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,8 @@
 
 ### Enhancements
 
-* Lorem ipsum.
+* Use only a single file descriptor in our emulation of interprocess condition variables
+  on most platforms rather than two.
 
 -----------
 

--- a/src/realm/util/interprocess_condvar.cpp
+++ b/src/realm/util/interprocess_condvar.cpp
@@ -84,6 +84,7 @@ InterprocessCondVar::~InterprocessCondVar() noexcept
     close();
 }
 
+#ifdef REALM_CONDVAR_EMULATION
 static void make_non_blocking(int fd)
 {
     // Make reading or writing from the file descriptor return -1 when the file descriptor's buffer is empty
@@ -93,6 +94,7 @@ static void make_non_blocking(int fd)
         throw std::system_error(errno, std::system_category());
     }
 }
+#endif
 
 void InterprocessCondVar::set_shared_part(SharedPart& shared_part, std::string base_path, std::string condvar_name,
                                           std::string tmp_path)

--- a/src/realm/util/interprocess_condvar.cpp
+++ b/src/realm/util/interprocess_condvar.cpp
@@ -64,14 +64,16 @@ InterprocessCondVar::InterprocessCondVar()
 
 void InterprocessCondVar::close() noexcept
 {
-    if (uses_emulation) { // true if emulating a process shared condvar
-        uses_emulation = false;
 #ifdef REALM_CONDVAR_EMULATION
+    if (m_fd_read != -1) {
         ::close(m_fd_read);
-        ::close(m_fd_write);
-#endif
-        return; // we don't need to clean up the SharedPart
+        m_fd_read = -1;
     }
+    if (m_fd_write != -1) {
+        ::close(m_fd_write);
+        m_fd_write = -1;
+    }
+#endif
     // we don't do anything to the shared part, other CondVars may share it
     m_shared_part = nullptr;
 }
@@ -82,6 +84,15 @@ InterprocessCondVar::~InterprocessCondVar() noexcept
     close();
 }
 
+static void make_non_blocking(int fd)
+{
+    // Make reading or writing from the file descriptor return -1 when the file descriptor's buffer is empty
+    // rather than blocking until there's data available.
+    int ret = fcntl(fd, F_SETFL, O_NONBLOCK);
+    if (ret == -1) {
+        throw std::system_error(errno, std::system_category());
+    }
+}
 
 void InterprocessCondVar::set_shared_part(SharedPart& shared_part, std::string base_path, std::string condvar_name,
                                           std::string tmp_path)
@@ -128,15 +139,11 @@ void InterprocessCondVar::set_shared_part(SharedPart& shared_part, std::string b
         }
     }
 
-    m_fd_write = open(m_resource_path.c_str(), O_RDWR);
-    if (m_fd_write == -1) {
-        throw std::system_error(errno, std::system_category());
-    }
-
-    m_fd_read = open(m_resource_path.c_str(), O_RDONLY);
+    m_fd_read = open(m_resource_path.c_str(), O_RDWR);
     if (m_fd_read == -1) {
         throw std::system_error(errno, std::system_category());
     }
+    m_fd_write = -1;
 
 #else // !REALM_TVOS
 
@@ -152,22 +159,14 @@ void InterprocessCondVar::set_shared_part(SharedPart& shared_part, std::string b
 
 #endif // REALM_TVOS
 
-    // Make writing to the pipe return -1 when the pipe's buffer is full
-    // rather than blocking until there's space available
-    ret = fcntl(m_fd_write, F_SETFL, O_NONBLOCK);
-    if (ret == -1) {
-        throw std::system_error(errno, std::system_category());
+    if (m_fd_read != -1) {
+        make_non_blocking(m_fd_read);
+    }
+    if (m_fd_write != -1) {
+        make_non_blocking(m_fd_write);
     }
 
-    // Make reading from the pipe return -1 when the pipe's buffer is empty
-    // rather than blocking until there's data available
-    ret = fcntl(m_fd_read, F_SETFL, O_NONBLOCK);
-    if (ret == -1) {
-        throw std::system_error(errno, std::system_category());
-    }
-
-#endif
-    uses_emulation = true;
+#endif // REALM_CONDVAR_EMULATION
 }
 
 
@@ -307,7 +306,7 @@ void InterprocessCondVar::notify() noexcept
 #ifdef REALM_CONDVAR_EMULATION
     if (m_shared_part->wait_counter > m_shared_part->signal_counter) {
         m_shared_part->signal_counter++;
-        notify_fd(m_fd_write);
+        notify_fd(m_fd_write != -1 ? m_fd_write : m_fd_read);
     }
 #else
     m_shared_part->notify();
@@ -326,7 +325,7 @@ void InterprocessCondVar::notify_all() noexcept
 #ifdef REALM_CONDVAR_EMULATION
     while (m_shared_part->wait_counter > m_shared_part->signal_counter) {
         m_shared_part->signal_counter++;
-        notify_fd(m_fd_write);
+        notify_fd(m_fd_write != -1 ? m_fd_write : m_fd_read);
     }
 #else
     m_shared_part->notify_all();

--- a/src/realm/util/interprocess_condvar.hpp
+++ b/src/realm/util/interprocess_condvar.hpp
@@ -108,11 +108,11 @@ private:
 #ifdef REALM_CONDVAR_EMULATION
     // keep the path to allocated system resource so we can remove them again
     std::string m_resource_path;
-    // pipe used for emulation
-    int m_fd_read;
-    int m_fd_write;
+    // pipe used for emulation. When using a named pipe, m_fd_read is read-write and m_fd_write is unused.
+    // When using an anonymous pipe (currently only for tvOS) m_fd_read is read-only and m_fd_write is write-only.
+    int m_fd_read = -1;
+    int m_fd_write = -1;
 #endif
-    bool uses_emulation = false;
 };
 
 


### PR DESCRIPTION
When using a named pipe for a condition variable we can use the same file descriptor for both reading and writing. It's only necessary to use multiple file descriptors on tvOS, where we are forced to use an anonymous pipe instead.