### PR TITLE
Remap in transaction

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@
   SharedGroupOptions::set_sys_tmp_dir() to solve crash when compacting a Realm
   file on Android external storage which is caused by invalid default sys_tmp_dir.
   (https://github.com/realm/realm-java/issues/4140)
+* Fixed a race condition where asynchronous readers could read wrong data if
+  a write transaction triggered a file remapping.
 
 ### Breaking changes
 

--- a/src/realm/group_shared.cpp
+++ b/src/realm/group_shared.cpp
@@ -1795,14 +1795,14 @@ SharedGroup::version_type SharedGroup::commit_and_continue_as_read()
     VersionID version_id = VersionID();      // Latest available snapshot
     grab_read_lock(m_read_lock, version_id); // Throws
 
-    do_end_write();
-
     // Free memory that was allocated during the write transaction.
     using gf = _impl::GroupFriend;
     gf::reset_free_space_tracking(m_group); // Throws
 
     // Remap file if it has grown, and update refs in underlying node structure
     gf::remap_and_update_refs(m_group, m_read_lock.m_top_ref, m_read_lock.m_file_size); // Throws
+
+    do_end_write();
 
     m_transact_stage = transact_Reading;
 


### PR DESCRIPTION
This fix is thanks to @rrrlasse 

If a commit triggers a remap to the file, this should happen inside a write transaction.

It should fix #2383