### PR TITLE
Aggregate functions must skip detached rows

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@
 
 * Remove the BinaryData constructor taking a temporary object to prevent some
   errors in unit tests at compile time.
+* Avoid assertions in aggregate functions for the timestamp type.
 
 ----------------------------------------------
 

--- a/src/realm/table_view.cpp
+++ b/src/realm/table_view.cpp
@@ -291,6 +291,7 @@ Timestamp TableViewBase::minmax_timestamp(size_t column_ndx, size_t* return_ndx)
 {
     C compare = C();
     Timestamp best = Timestamp{};
+    TimestampColumn& column = m_table->get_column_timestamp(column_ndx);
     size_t ndx = npos;
     for (size_t t = 0; t < size(); t++) {
         int64_t signed_row_ndx = m_row_indexes.get(t);
@@ -299,7 +300,7 @@ Timestamp TableViewBase::minmax_timestamp(size_t column_ndx, size_t* return_ndx)
         if (signed_row_ndx == detached_ref)
             continue;
 
-        Timestamp ts = get_timestamp(column_ndx, t);
+        auto ts = column.get(signed_row_ndx);
         // Because realm::Greater(non-null, null) == false, we need to pick the initial 'best' manually when we see
         // the first non-null entry
         if ((ndx == npos && !ts.is_null()) || compare(ts, best, ts.is_null(), best.is_null())) {
@@ -427,6 +428,7 @@ size_t TableViewBase::count_double(size_t column_ndx, double target) const
 
 size_t TableViewBase::count_timestamp(size_t column_ndx, Timestamp target) const
 {
+    TimestampColumn& column = m_table->get_column_timestamp(column_ndx);
     size_t count = 0;
     for (size_t t = 0; t < size(); t++) {
         int64_t signed_row_ndx = m_row_indexes.get(t);
@@ -434,8 +436,9 @@ size_t TableViewBase::count_timestamp(size_t column_ndx, Timestamp target) const
         // skip detached references:
         if (signed_row_ndx == detached_ref)
             continue;
-        
-        Timestamp ts = get_timestamp(column_ndx, t);
+
+        auto ts = column.get(signed_row_ndx);
+
         realm::Equal e;
         if (e(ts, target, ts.is_null(), target.is_null())) {
             count++;

--- a/src/realm/table_view.cpp
+++ b/src/realm/table_view.cpp
@@ -293,6 +293,12 @@ Timestamp TableViewBase::minmax_timestamp(size_t column_ndx, size_t* return_ndx)
     Timestamp best = Timestamp{};
     size_t ndx = npos;
     for (size_t t = 0; t < size(); t++) {
+        int64_t signed_row_ndx = m_row_indexes.get(t);
+
+        // skip detached references:
+        if (signed_row_ndx == detached_ref)
+            continue;
+
         Timestamp ts = get_timestamp(column_ndx, t);
         // Because realm::Greater(non-null, null) == false, we need to pick the initial 'best' manually when we see
         // the first non-null entry
@@ -423,6 +429,12 @@ size_t TableViewBase::count_timestamp(size_t column_ndx, Timestamp target) const
 {
     size_t count = 0;
     for (size_t t = 0; t < size(); t++) {
+        int64_t signed_row_ndx = m_row_indexes.get(t);
+
+        // skip detached references:
+        if (signed_row_ndx == detached_ref)
+            continue;
+        
         Timestamp ts = get_timestamp(column_ndx, t);
         realm::Equal e;
         if (e(ts, target, ts.is_null(), target.is_null())) {

--- a/test/test_table_view.cpp
+++ b/test/test_table_view.cpp
@@ -3431,4 +3431,26 @@ TEST(TableView_InsertColumnsAfterSort)
     CHECK_EQUAL(tv.get_int(2, 10), 0);
 }
 
+TEST(TableView_TimestampMaxRemoveRow)
+{
+    Table table;
+    table.add_column(type_Timestamp, "time");
+    for (size_t i = 0; i < 10; ++i) {
+        table.add_empty_row();
+        table.set_timestamp(0, i, Timestamp(i, 0));
+    }
+
+    TableView tv = table.where().find_all();
+    CHECK_EQUAL(tv.size(), 10);
+    CHECK_EQUAL(tv.maximum_timestamp(0), Timestamp(9, 0));
+
+    table.move_last_over(9);
+    CHECK_EQUAL(tv.size(), 10); // not changed since sync_if_needed hasn't been called
+    CHECK_EQUAL(tv.maximum_timestamp(0), Timestamp(8, 0)); // but aggregate functions skip removed rows
+
+    tv.sync_if_needed();
+    CHECK_EQUAL(tv.size(), 9);
+    CHECK_EQUAL(tv.maximum_timestamp(0), Timestamp(8, 0));    
+}
+
 #endif // TEST_TABLE_VIEW


### PR DESCRIPTION
@beeender enabled assertions and ran Realm Java's unit tests - and discovered an assertions.

Aggregate functions can survive if rows are deleted, but we forgot to update the timestamp column type.

@rrrlasse @finnschiermer @danielpovlsen 