### PR TITLE
Prevent copy errors at compile time.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,7 @@
 
 * Remove the BinaryData constructor taking a temporary object to prevent some
   errors in unit tests at compile time.
+* Disable copying of various classes to prevent incorrect use at compile time.
 
 ----------------------------------------------
 

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -471,7 +471,7 @@ def doBuildAndroid(def isPublishingRun) {
           }
         }
 
-        node('android-hub') {
+        node('fastlinux') {
             sh 'rm -rf *'
             unstash 'android'
 

--- a/src/realm/alloc.hpp
+++ b/src/realm/alloc.hpp
@@ -121,6 +121,10 @@ public:
 
     virtual ~Allocator() noexcept;
 
+    // Disable copying. Copying an allocator can produce double frees.
+    Allocator(const Allocator&) = delete;
+    Allocator& operator=(const Allocator&) = delete;
+
     virtual void verify() const = 0;
 
 #ifdef REALM_DEBUG

--- a/src/realm/alloc_slab.cpp
+++ b/src/realm/alloc_slab.cpp
@@ -74,6 +74,9 @@ struct SlabAlloc::MappedFile {
     /// Indicates if attaching to the file was succesfull
     bool m_success = false;
 
+    MappedFile() {}
+    MappedFile(const MappedFile&) = delete;
+    MappedFile& operator=(const MappedFile&) = delete;
     ~MappedFile()
     {
         m_file.close();

--- a/src/realm/alloc_slab.hpp
+++ b/src/realm/alloc_slab.hpp
@@ -60,6 +60,10 @@ public:
     ~SlabAlloc() noexcept override;
     SlabAlloc();
 
+    // Disable copying. Copying an allocator can produce double frees.
+    SlabAlloc(const SlabAlloc&) = delete;
+    SlabAlloc& operator=(const SlabAlloc&) = delete;
+
     /// \struct Config
     /// \brief Storage for combining setup flags for initialization to
     /// the SlabAlloc.

--- a/src/realm/array.hpp
+++ b/src/realm/array.hpp
@@ -874,8 +874,8 @@ public:
     // The encryption layer relies on headers always fitting within a single page.
     static_assert(header_size == 8, "Header must always fit in entirely on a page");
 
-private:
-    Array& operator=(const Array&); // not allowed
+    Array& operator=(const Array&) = delete; // not allowed
+    Array(const Array&) = delete; // not allowed
 protected:
     typedef bool (*CallbackDummy)(int64_t);
 

--- a/src/realm/array_basic.hpp
+++ b/src/realm/array_basic.hpp
@@ -33,6 +33,10 @@ public:
     {
     }
 
+    // Disable copying, this is not allowed.
+    BasicArray& operator=(const BasicArray&) = delete;
+    BasicArray(const BasicArray&) = delete;
+
     T get(size_t ndx) const noexcept;
     bool is_null(size_t ndx) const noexcept;
     void add(T value);

--- a/src/realm/array_binary.hpp
+++ b/src/realm/array_binary.hpp
@@ -60,6 +60,10 @@ public:
     {
     }
 
+    // Disable copying, this is not allowed.
+    ArrayBinary& operator=(const ArrayBinary&) = delete;
+    ArrayBinary(const ArrayBinary&) = delete;
+
     /// Create a new empty binary array and attach this accessor to
     /// it. This does not modify the parent reference information of
     /// this accessor.

--- a/src/realm/array_blob.hpp
+++ b/src/realm/array_blob.hpp
@@ -33,6 +33,10 @@ public:
     {
     }
 
+    // Disable copying, this is not allowed.
+    ArrayBlob& operator=(const ArrayBlob&) = delete;
+    ArrayBlob(const ArrayBlob&) = delete;
+
     const char* get(size_t index) const noexcept;
     BinaryData get_at(size_t& pos) const noexcept;
     bool is_null(size_t index) const noexcept;

--- a/src/realm/array_blobs_big.hpp
+++ b/src/realm/array_blobs_big.hpp
@@ -30,6 +30,10 @@ public:
 
     explicit ArrayBigBlobs(Allocator&, bool nullable) noexcept;
 
+    // Disable copying, this is not allowed.
+    ArrayBigBlobs& operator=(const ArrayBigBlobs&) = delete;
+    ArrayBigBlobs(const ArrayBigBlobs&) = delete;
+
     BinaryData get(size_t ndx) const noexcept;
     BinaryData get_at(size_t ndx, size_t& pos) const noexcept;
     void set(size_t ndx, BinaryData value, bool add_zero_term = false);

--- a/src/realm/array_integer.hpp
+++ b/src/realm/array_integer.hpp
@@ -34,6 +34,10 @@ public:
     {
     }
 
+    // Disable copying, this is not allowed.
+    ArrayInteger& operator=(const ArrayInteger&) = delete;
+    ArrayInteger(const ArrayInteger&) = delete;
+
     void create(Type type = type_Normal, bool context_flag = false);
 
     void add(int64_t value);

--- a/src/realm/array_string_long.hpp
+++ b/src/realm/array_string_long.hpp
@@ -34,6 +34,10 @@ public:
     {
     }
 
+    // Disable copying, this is not allowed.
+    ArrayStringLong& operator=(const ArrayStringLong&) = delete;
+    ArrayStringLong(const ArrayStringLong&) = delete;
+
     /// Create a new empty long string array and attach this accessor to
     /// it. This does not modify the parent reference information of
     /// this accessor.

--- a/src/realm/bptree.hpp
+++ b/src/realm/bptree.hpp
@@ -180,6 +180,10 @@ public:
     struct unattached_tag {
     };
 
+    // Disable copying, this is not allowed.
+    BpTreeBase& operator=(const BpTreeBase&) = delete;
+    BpTreeBase(const BpTreeBase&) = delete;
+
     // Accessor concept:
     Allocator& get_alloc() const noexcept;
     void destroy() noexcept;
@@ -261,6 +265,11 @@ public:
     }
     BpTree(BpTree&&) = default;
     BpTree& operator=(BpTree&&) = default;
+
+    // Disable copying, this is not allowed.
+    BpTree& operator=(const BpTree&) = delete;
+    BpTree(const BpTree&) = delete;
+
     void init_from_ref(Allocator& alloc, ref_type ref);
     void init_from_mem(Allocator& alloc, MemRef mem);
     void init_from_parent();

--- a/src/realm/column.hpp
+++ b/src/realm/column.hpp
@@ -196,6 +196,10 @@ public:
     {
     }
 
+    // Disable copying, this is not supported.
+    ColumnBase& operator=(const ColumnBase&) = delete;
+    ColumnBase(const ColumnBase&) = delete;
+
     // Getter function for index. For integer index, the caller must supply a
     // buffer that we can store the extracted value in (it may be bitpacked, so
     // we cannot return a pointer in to the Array as we do with String index).

--- a/src/realm/group.hpp
+++ b/src/realm/group.hpp
@@ -102,6 +102,7 @@ public:
 
     // FIXME: Implement a proper copy constructor (fairly trivial).
     Group(const Group&) = delete;
+    Group& operator=(const Group&) = delete;
 
     ~Group() noexcept override;
 

--- a/src/realm/group_shared.hpp
+++ b/src/realm/group_shared.hpp
@@ -171,6 +171,11 @@ public:
 
     ~SharedGroup() noexcept;
 
+    // Disable copying to prevent accessor errors. If you really want another
+    // instance, open another SharedGroup object on the same file.
+    SharedGroup(const SharedGroup&) = delete;
+    SharedGroup& operator=(const SharedGroup&) = delete;
+
     /// Attach this SharedGroup instance to the specified database file.
     ///
     /// While at least one instance of SharedGroup exists for a specific

--- a/src/realm/impl/destroy_guard.hpp
+++ b/src/realm/impl/destroy_guard.hpp
@@ -39,6 +39,10 @@ public:
 
     ~DestroyGuard() noexcept;
 
+    // Default implementations of copy/assign can trigger multiple destructions
+    DestroyGuard(const DestroyGuard&) = delete;
+    DestroyGuard& operator=(const DestroyGuard&) = delete;
+
     void reset(T*) noexcept;
 
     T* get() const noexcept;
@@ -62,6 +66,10 @@ public:
 
     ~DeepArrayDestroyGuard() noexcept;
 
+    // Default implementations of copy/assign can trigger multiple destructions
+    DeepArrayDestroyGuard(const DeepArrayDestroyGuard&) = delete;
+    DeepArrayDestroyGuard& operator=(const DeepArrayDestroyGuard&) = delete;
+
     void reset(Array*) noexcept;
 
     Array* get() const noexcept;
@@ -82,6 +90,10 @@ public:
     DeepArrayRefDestroyGuard(ref_type, Allocator&) noexcept;
 
     ~DeepArrayRefDestroyGuard() noexcept;
+
+    // Default implementations of copy/assign can trigger multiple destructions
+    DeepArrayRefDestroyGuard(const DeepArrayRefDestroyGuard&) = delete;
+    DeepArrayRefDestroyGuard& operator=(const DeepArrayRefDestroyGuard&) = delete;
 
     void reset(ref_type) noexcept;
 

--- a/src/realm/spec.cpp
+++ b/src/realm/spec.cpp
@@ -536,8 +536,8 @@ bool Spec::operator==(const Spec& spec) const noexcept
             case col_type_Table: {
                 // Sub tables must be compared recursively
                 const size_t subspec_index = get_subspec_ndx(col_ndx);
-                const Spec& lhs = const_cast<Spec&>(*this).get_subspec_by_ndx(subspec_index);
-                const Spec& rhs = const_cast<Spec&>(spec).get_subspec_by_ndx(subspec_index);
+                Spec lhs(SubspecRef(SubspecRef::const_cast_tag(), get_subspec_by_ndx(subspec_index)));
+                Spec rhs(SubspecRef(SubspecRef::const_cast_tag(), spec.get_subspec_by_ndx(subspec_index)));
                 if (lhs != rhs)
                     return false;
                 break;

--- a/src/realm/spec.cpp
+++ b/src/realm/spec.cpp
@@ -536,8 +536,8 @@ bool Spec::operator==(const Spec& spec) const noexcept
             case col_type_Table: {
                 // Sub tables must be compared recursively
                 const size_t subspec_index = get_subspec_ndx(col_ndx);
-                const Spec lhs = Spec(const_cast<Spec&>(*this).get_subspec_by_ndx(subspec_index));
-                const Spec rhs = Spec(const_cast<Spec&>(spec).get_subspec_by_ndx(subspec_index));
+                const Spec& lhs = const_cast<Spec&>(*this).get_subspec_by_ndx(subspec_index);
+                const Spec& rhs = const_cast<Spec&>(spec).get_subspec_by_ndx(subspec_index);
                 if (lhs != rhs)
                     return false;
                 break;

--- a/src/realm/table.hpp
+++ b/src/realm/table.hpp
@@ -984,7 +984,7 @@ private:
     /// assign() would not check for spec compatibility. This would
     /// make it ideal as a basis for implementing operator=() for
     /// typed tables.
-    Table& operator=(const Table&);
+    Table& operator=(const Table&) = delete;
 
     /// Used when constructing an accessor whose lifetime is going to be managed
     /// by reference counting. The lifetime of accessors of free-standing tables

--- a/src/realm/util/encrypted_file_mapping.hpp
+++ b/src/realm/util/encrypted_file_mapping.hpp
@@ -41,6 +41,10 @@ public:
     EncryptedFileMapping(SharedFileInfo& file, size_t file_offset, void* addr, size_t size, File::AccessMode access);
     ~EncryptedFileMapping();
 
+    // Default implementations of copy/assign can trigger multiple destructions
+    EncryptedFileMapping(const EncryptedFileMapping&) = delete;
+    EncryptedFileMapping& operator=(const EncryptedFileMapping&) = delete;
+
     // Write all dirty pages to disk and mark them read-only
     // Does not call fsync
     void flush() noexcept;

--- a/src/realm/util/file.hpp
+++ b/src/realm/util/file.hpp
@@ -115,6 +115,11 @@ public:
     File(File&&) noexcept;
     File& operator=(File&&) noexcept;
 
+    // Disable copying by l-value. Copying an open file will create a scenario
+    // where the same file descriptor will be opened once but closed twice.
+    File(const File&) = delete;
+    File& operator=(const File&) = delete;
+
     /// Calling this function on an instance that is already attached
     /// to an open file has undefined behavior.
     ///
@@ -524,6 +529,11 @@ private:
         MapBase() noexcept;
         ~MapBase() noexcept;
 
+        // Disable copying. Copying an opened MapBase will create a scenario
+        // where the same memory will be mapped once but unmapped twice.
+        MapBase(const MapBase&) = delete;
+        MapBase& operator=(const MapBase&) = delete;
+
         void map(const File&, AccessMode, size_t size, int map_flags, size_t offset = 0);
         void remap(const File&, AccessMode, size_t size, int map_flags);
         void unmap() noexcept;
@@ -555,6 +565,9 @@ public:
     {
         m_file.unlock();
     }
+    // Disable copying. It is not how this class should be used.
+    ExclusiveLock(const ExclusiveLock&) = delete;
+    ExclusiveLock& operator=(const ExclusiveLock&) = delete;
 
 private:
     File& m_file;
@@ -571,6 +584,9 @@ public:
     {
         m_file.unlock();
     }
+    // Disable copying. It is not how this class should be used.
+    SharedLock(const SharedLock&) = delete;
+    SharedLock& operator=(const SharedLock&) = delete;
 
 private:
     File& m_file;
@@ -606,6 +622,11 @@ public:
     Map() noexcept;
 
     ~Map() noexcept;
+
+    // Disable copying. Copying an opened Map will create a scenario
+    // where the same memory will be mapped once but unmapped twice.
+    Map(const Map&) = delete;
+    Map& operator=(const Map&) = delete;
 
     /// Move the mapping from another Map object to this Map object
     File::Map<T>& operator=(File::Map<T>&& other)
@@ -702,6 +723,11 @@ public:
     {
         m_file = nullptr;
     }
+    // Disallow the default implementation of copy/assign, this is not how this
+    // class is intended to be used. For example we could get unexpected
+    // behaviour if one CloseGuard is copied and released but the other is not.
+    CloseGuard(const CloseGuard&) = delete;
+    CloseGuard& operator=(const CloseGuard&) = delete;
 
 private:
     File* m_file;
@@ -723,6 +749,11 @@ public:
     {
         m_file = nullptr;
     }
+    // Disallow the default implementation of copy/assign, this is not how this
+    // class is intended to be used. For example we could get unexpected
+    // behaviour if one UnlockGuard is copied and released but the other is not.
+    UnlockGuard(const UnlockGuard&) = delete;
+    UnlockGuard& operator=(const UnlockGuard&) = delete;
 
 private:
     File* m_file;
@@ -745,6 +776,11 @@ public:
     {
         m_map = nullptr;
     }
+    // Disallow the default implementation of copy/assign, this is not how this
+    // class is intended to be used. For example we could get unexpected
+    // behaviour if one UnmapGuard is copied and released but the other is not.
+    UnmapGuard(const UnmapGuard&) = delete;
+    UnmapGuard& operator=(const UnmapGuard&) = delete;
 
 private:
     MapBase* m_map;
@@ -757,6 +793,10 @@ public:
     explicit Streambuf(File*);
     ~Streambuf() noexcept;
 
+    // Disable copying
+    Streambuf(const Streambuf&) = delete;
+    Streambuf& operator=(const Streambuf&) = delete;
+
 private:
     static const size_t buffer_size = 4096;
 
@@ -767,10 +807,6 @@ private:
     int sync() override;
     pos_type seekpos(pos_type, std::ios_base::openmode) override;
     void flush();
-
-    // Disable copying
-    Streambuf(const Streambuf&);
-    Streambuf& operator=(const Streambuf&);
 };
 
 

--- a/src/realm/util/interprocess_condvar.hpp
+++ b/src/realm/util/interprocess_condvar.hpp
@@ -52,6 +52,11 @@ public:
     InterprocessCondVar();
     ~InterprocessCondVar() noexcept;
 
+    // Disable copying. Copying an open file will create a scenario
+    // where the same file descriptor will be opened once but closed twice.
+    InterprocessCondVar(const InterprocessCondVar&) = delete;
+    InterprocessCondVar& operator=(const InterprocessCondVar&) = delete;
+
 /// To use the InterprocessCondVar, you also must place a structure of type
 /// InterprocessCondVar::SharedPart in memory shared by multiple processes
 /// or in a memory mapped file, and use set_shared_part() to associate

--- a/src/realm/util/interprocess_mutex.hpp
+++ b/src/realm/util/interprocess_mutex.hpp
@@ -50,6 +50,11 @@ public:
     InterprocessMutex();
     ~InterprocessMutex() noexcept;
 
+    // Disable copying. Copying a locked Mutex will create a scenario
+    // where the same file descriptor will be locked once but unlocked twice.
+    InterprocessMutex(const InterprocessMutex&) = delete;
+    InterprocessMutex& operator=(const InterprocessMutex&) = delete;
+
 #ifdef REALM_ROBUST_MUTEX_EMULATION
     struct SharedPart {
     };
@@ -90,7 +95,11 @@ private:
     struct LockInfo {
         File m_file;
         Mutex m_local_mutex;
+        LockInfo() {}
         ~LockInfo() noexcept;
+        // Disable copying.
+        LockInfo(const LockInfo&) = delete;
+        LockInfo& operator=(const LockInfo&) = delete;
     };
     /// InterprocessMutex created on the same file (same inode on POSIX) share the same LockInfo.
     /// LockInfo will be saved in a static map as a weak ptr and use the UniqueID as the key.
@@ -146,7 +155,7 @@ inline InterprocessMutex::LockInfo::~LockInfo() noexcept
 
 inline void InterprocessMutex::free_lock_info()
 {
-    // It has not been inited yet.
+    // It has not been initiated yet.
     if (!m_lock_info)
         return;
 

--- a/src/realm/util/interprocess_mutex.hpp
+++ b/src/realm/util/interprocess_mutex.hpp
@@ -155,7 +155,7 @@ inline InterprocessMutex::LockInfo::~LockInfo() noexcept
 
 inline void InterprocessMutex::free_lock_info()
 {
-    // It has not been initiated yet.
+    // It has not been initialized yet.
     if (!m_lock_info)
         return;
 

--- a/src/realm/util/thread.hpp
+++ b/src/realm/util/thread.hpp
@@ -59,6 +59,10 @@ public:
     template <class F>
     explicit Thread(F func);
 
+    // Disable copying. It is an error to copy this Thread class.
+    Thread(const Thread&) = delete;
+    Thread& operator=(const Thread&) = delete;
+
     /// This method is an extension of the API provided by
     /// std::thread. This method exists because proper move semantics
     /// is unavailable in C++03. If move semantics had been available,
@@ -115,6 +119,10 @@ public:
     /// or deleting the file) without first calling the destructor is
     /// legal and will not cause any system resources to be leaked.
     Mutex(process_shared_tag);
+
+    // Disable copying.
+    Mutex(const Mutex&) = delete;
+    Mutex& operator=(const Mutex&) = delete;
 
     friend class LockGuard;
     friend class UniqueLock;

--- a/src/realm/views.hpp
+++ b/src/realm/views.hpp
@@ -84,6 +84,10 @@ public:
 #endif
     }
 
+    // Disable copying, this is not supported.
+    RowIndexes& operator=(const RowIndexes&) = delete;
+    RowIndexes(const RowIndexes&) = delete;
+
     // Return a column of the table that m_row_indexes are pointing at (which is the target table for LinkList and
     // parent table for TableView)
     virtual const ColumnBase& get_column_base(size_t index) const = 0;


### PR DESCRIPTION
This will prevent incorrect use internally and by bindings at compile time by explicitly deleting the compiler generated copy constructors and assignment operators.

Each one deleted in this PR could have caused some pretty serious issues if it was used.