### PR TITLE
Support handover of a TableView on a subtable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@
 
 * Now supports case insensitive queries for UWP.
 * Upgraded Visual Studio project to version 2017.
+* Support handover of TableViews and Queries based on SubTables
 
 -----------
 

--- a/src/realm/handover_defs.hpp
+++ b/src/realm/handover_defs.hpp
@@ -31,7 +31,10 @@ struct RowBaseHandoverPatch;
 struct TableViewHandoverPatch;
 
 struct TableHandoverPatch {
+    bool m_is_sub_table;
     size_t m_table_num;
+    size_t m_col_ndx;
+    size_t m_row_ndx;
 };
 
 struct LinkViewHandoverPatch {

--- a/src/realm/query.cpp
+++ b/src/realm/query.cpp
@@ -201,7 +201,8 @@ void Query::set_table(TableRef tr)
     m_table = tr;
     if (m_table) {
         fetch_descriptor();
-        if (ParentNode* root = root_node())
+        ParentNode* root = root_node();
+        if (root && !m_table->is_degenerate())
             root->set_table(*m_table);
     }
     else {

--- a/src/realm/query.cpp
+++ b/src/realm/query.cpp
@@ -230,7 +230,13 @@ void Query::apply_patch(HandoverPatch& patch, Group& dest_group)
     // not going through Table::create_from_and_consume_patch because we need to use
     // set_table() to update all table references
     if (patch.m_table) {
-        set_table(dest_group.get_table(patch.m_table->m_table_num));
+        if (patch.m_table->m_is_sub_table) {
+            auto parent_table = dest_group.get_table(patch.m_table->m_table_num);
+            set_table(parent_table->get_subtable(patch.m_table->m_col_ndx, patch.m_table->m_row_ndx));
+        }
+        else {
+            set_table(dest_group.get_table(patch.m_table->m_table_num));
+        }
     }
     REALM_ASSERT(patch.m_node_data.empty());
 }
@@ -795,6 +801,9 @@ R Query::aggregate(R (ColType::*aggregateMethod)(size_t start, size_t end, size_
                    size_t column_ndx, size_t* resultcount, size_t start, size_t end, size_t limit,
                    size_t* return_ndx) const
 {
+    if (!m_table->is_attached()) {
+        throw LogicError{LogicError::detached_accessor};
+    }
     if (limit == 0 || m_table->is_degenerate()) {
         if (resultcount)
             *resultcount = 0;

--- a/src/realm/table.cpp
+++ b/src/realm/table.cpp
@@ -5956,9 +5956,19 @@ void Table::generate_patch(const Table* table, std::unique_ptr<HandoverPatch>& p
     if (table) {
         patch.reset(new Table::HandoverPatch);
         patch->m_table_num = table->get_index_in_group();
-        // must be group level table!
-        if (patch->m_table_num == npos) {
-            throw std::runtime_error("Table handover failed: not a group level table");
+        patch->m_is_sub_table = (patch->m_table_num == npos);
+
+        if (patch->m_is_sub_table) {
+            auto col = dynamic_cast<SubtableColumn*>(table->m_columns.get_parent());
+            if (col) {
+                Table* parent_table = col->m_table;
+                patch->m_table_num = parent_table->get_index_in_group();
+                patch->m_col_ndx = col->get_column_index();
+                patch->m_row_ndx = table->m_columns.get_ndx_in_parent();
+            }
+            else {
+                throw std::runtime_error("Table handover failed: not a group level table");
+            }
         }
     }
     else {
@@ -5970,7 +5980,14 @@ void Table::generate_patch(const Table* table, std::unique_ptr<HandoverPatch>& p
 TableRef Table::create_from_and_consume_patch(std::unique_ptr<HandoverPatch>& patch, Group& group)
 {
     if (patch) {
-        TableRef result(group.get_table(patch->m_table_num));
+        TableRef result;
+        if (patch->m_is_sub_table) {
+            auto parent_table = group.get_table(patch->m_table_num);
+            result = parent_table->get_subtable(patch->m_col_ndx, patch->m_row_ndx);
+        }
+        else {
+            result = group.get_table(patch->m_table_num);
+        }
         patch.reset();
         return result;
     }

--- a/src/realm/table.cpp
+++ b/src/realm/table.cpp
@@ -5963,6 +5963,8 @@ void Table::generate_patch(const Table* table, std::unique_ptr<HandoverPatch>& p
             if (col) {
                 Table* parent_table = col->m_table;
                 patch->m_table_num = parent_table->get_index_in_group();
+                if (patch->m_table_num == npos)
+                    throw std::runtime_error("Table handover failed: only first level subtables supported");
                 patch->m_col_ndx = col->get_column_index();
                 patch->m_row_ndx = table->m_columns.get_ndx_in_parent();
             }


### PR DESCRIPTION
It is now possible to handover a TableVies based on a sub-table.

Throw if running a query on a detached table. Could be the case
if you have created a query on a sub-table that later is deleted.
