### PR TITLE
Increase granularity of benchmark-crud to see standard deviations.

### DIFF
--- a/test/bench/benchmark_version
+++ b/test/bench/benchmark_version
@@ -1,4 +1,4 @@
-v2
+v3
 
 The first line of this file describes the current benchmarking tool version.
 It is used as a folder prefix to handle storing multiple versions of performance results.

--- a/test/benchmark-crud/main.cpp
+++ b/test/benchmark-crud/main.cpp
@@ -34,7 +34,7 @@ using namespace realm::test_util;
 
 namespace {
 
-inline int_fast64_t read(TableRef table, const std::vector<size_t> order)
+inline int_fast64_t read(TableRef table, const std::vector<size_t>& order)
 {
     int_fast64_t dummy = 0;
     size_t n = order.size();
@@ -43,14 +43,14 @@ inline int_fast64_t read(TableRef table, const std::vector<size_t> order)
     return dummy;
 }
 
-inline void write(TableRef table, const std::vector<size_t> order)
+inline void write(TableRef table, const std::vector<size_t>& order)
 {
     size_t n = order.size();
     for (size_t i = 0; i != n; ++i)
         table->set_int(0, order[i], 125);
 }
 
-inline void insert(TableRef table, const std::vector<size_t> order)
+inline void insert(TableRef table, const std::vector<size_t>& order)
 {
     size_t n = order.size();
     for (size_t i = 0; i != n; ++i) {
@@ -59,7 +59,7 @@ inline void insert(TableRef table, const std::vector<size_t> order)
     }
 }
 
-inline void erase(TableRef table, const std::vector<size_t> order)
+inline void erase(TableRef table, const std::vector<size_t>& order)
 {
     size_t n = order.size();
     for (size_t i = 0; i != n; ++i)
@@ -71,8 +71,8 @@ inline void erase(TableRef table, const std::vector<size_t> order)
 
 int main()
 {
-    const size_t target_size = 1100 * 1000L;
-    const int num_tables = 50;
+    const size_t target_size = 1100 * 100L;
+    const int num_tables = 500;
     std::cout << "Number of tables: " << num_tables << "\n";
     std::cout << "Elements per table: " << target_size << "\n";
 
@@ -112,60 +112,111 @@ int main()
 
     Timer timer_total(Timer::type_UserTime);
     Timer timer(Timer::type_UserTime);
+    const char *id, *desc;
     {
-        timer.reset();
-        for (int i = 0; i != num_tables; ++i)
+        id = "insert_end_compact";
+        desc = "Insert at end (compact)";
+        for (int i = 0; i != num_tables; ++i) {
+            timer.reset();
             insert(tables_1[i], rising_order);
-        results.submit_single("insert_end_compact", "Insert at end (compact)", timer);
-        timer.reset();
-        for (int i = 0; i != num_tables; ++i)
+            results.submit(id, timer);
+        }
+        results.finish(id, desc);
+
+        id = "read_sequential_compact";
+        desc = "Sequential read (compact)";
+        for (int i = 0; i != num_tables; ++i) {
+            timer.reset();
             dummy += read(tables_1[i], rising_order);
-        results.submit_single("read_seq_compact", "Sequential read (compact)", timer);
-        timer.reset();
-        for (int i = 0; i != num_tables; ++i)
+            results.submit(id, timer);
+        }
+        results.finish(id, desc);
+
+        id = "read_random_compact";
+        desc = "Random read (compact)";
+        for (int i = 0; i != num_tables; ++i) {
+            timer.reset();
             dummy += read(tables_1[i], random_order);
-        results.submit_single("read_ran_compact", "Random read (compact)", timer);
-        timer.reset();
-        for (int i = 0; i != num_tables; ++i)
+            results.submit(id, timer);
+        }
+        results.finish(id, desc);
+
+        id = "write_sequential_compact";
+        desc = "Sequential write (compact)";
+        for (int i = 0; i != num_tables; ++i) {
+            timer.reset();
             write(tables_1[i], rising_order);
-        results.submit_single("write_seq_compact", "Sequential write (compact)", timer);
-        timer.reset();
-        for (int i = 0; i != num_tables; ++i)
+            results.submit(id, timer);
+        }
+        results.finish(id, desc);
+
+        id = "write_random_compact";
+        desc = "Random write (compact)";
+        for (int i = 0; i != num_tables; ++i) {
+            timer.reset();
             write(tables_1[i], random_order);
-        results.submit_single("write_ran_compact", "Random write (compact)", timer);
-        timer.reset();
-        for (int i = 0; i != num_tables; ++i)
+            results.submit(id, timer);
+        }
+        results.finish(id, desc);
+
+        id = "erase_end_compact";
+        desc = "Erase from end (compact)";
+        for (int i = 0; i != num_tables; ++i) {
+            timer.reset();
             erase(tables_1[i], falling_order);
-        results.submit_single("erase_end_compact", "Erase from end (compact)", timer);
-    }
-    {
-        timer.reset();
-        for (int i = 0; i != num_tables; ++i)
-            insert(tables_2[i], random_insert_order);
-        results.submit_single("insert_ran_general", "Random insert (general)", timer);
-        timer.reset();
-        for (int i = 0; i != num_tables; ++i)
-            dummy += read(tables_2[0], rising_order);
-        results.submit_single("read_seq_general", "Sequential read (general)", timer);
-        timer.reset();
-        for (int i = 0; i != num_tables; ++i)
-            dummy += read(tables_2[0], random_order);
-        results.submit_single("read_ran_general", "Random read (general)", timer);
-        timer.reset();
-        for (int i = 0; i != num_tables; ++i)
-            write(tables_2[i], rising_order);
-        results.submit_single("write_seq_general", "Sequential write (general)", timer);
-        timer.reset();
-        for (int i = 0; i != num_tables; ++i)
-            write(tables_2[i], random_order);
-        results.submit_single("write_ran_general", "Random write (general)", timer);
-        timer.reset();
-        for (int i = 0; i != num_tables; ++i)
-            erase(tables_2[i], random_erase_order);
-        results.submit_single("erase_ran_general", "Random erase (general)", timer);
+            results.submit(id, timer);
+        }
+        results.finish(id, desc);
     }
 
-    results.submit_single("total_time", "Total time", timer_total);
+    // Start again using a random order (generalized).
+    {
+        id = "insert_random_general";
+        desc = "Random insert (general)";
+        for (int i = 0; i != num_tables; ++i) {
+            timer.reset();
+            insert(tables_2[i], random_insert_order);
+            results.submit(id, timer);
+        }
+        results.finish(id, desc);
+        id = "read_sequential_general";
+        desc = "Sequential read (general)";
+        for (int i = 0; i != num_tables; ++i) {
+            dummy += read(tables_2[0], rising_order);
+            results.submit(id, timer);
+        }
+        results.finish(id, desc);
+        id = "read_random_general";
+        desc = "Random read (general)";
+        for (int i = 0; i != num_tables; ++i) {
+            dummy += read(tables_2[0], random_order);
+            results.submit(id, timer);
+        }
+        results.finish(id, desc);
+        id = "write_sequential_general";
+        desc = "Sequential write (general)";
+        for (int i = 0; i != num_tables; ++i) {
+            write(tables_2[i], rising_order);
+            results.submit(id, timer);
+        }
+        results.finish(id, desc);
+        id = "write_random_general";
+        desc = "Random write (general)";
+        for (int i = 0; i != num_tables; ++i) {
+            write(tables_2[i], random_order);
+            results.submit(id, timer);
+        }
+        results.finish(id, desc);
+        id = "erase_random_general";
+        desc = "Random erase (general)";
+        for (int i = 0; i != num_tables; ++i) {
+            erase(tables_2[i], random_erase_order);
+            results.submit(id, timer);
+        }
+        results.finish(id, desc);
+    }
+
+    results.submit_single("crud_total_time", "Total time", timer_total);
 
     std::cout << "dummy = " << dummy << " (to avoid over-optimization)\n";
 }


### PR DESCRIPTION
Without changing the structure of these benchmarks too much, results are now tracked at the table level so that each iteration on a table counts as one benchmark result instead of over all tables.

To get a more accurate standard deviation without increasing duration, the number of rows in a table was decreased by a factor of ten, and the number of tables was increased by a factor of ten. This gives 500 iterations and actually decreases the overall run time.

The "total_time" tracks the amount of time for this whole CRUD suite and standard deviations is not something that is meaningful. I considered taking this metric out, but left it in because it could be useful to see this metric over time even with only a single value per run. It has been renamed to "crud_total_time" for a more descriptive name.