### PR TITLE
Fix seekpos() and seekoff() in realm::util::MemoryInputStreambuf

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@
   when trying to start a write transaction, while simultaneously pinning an older
   version. (issue #2395)
 * Fixed a bug when deleting a column used in a query (#2408)
+* `seekpos()` and `seekoff()` in `realm::util::MemoryInputStreambuf` now behave
+  correctly when argument is out of range.
 
 ### Breaking changes
 

--- a/src/realm/util/memory_stream.cpp
+++ b/src/realm/util/memory_stream.cpp
@@ -16,13 +16,14 @@
  *
  **************************************************************************/
 
-#include <realm/util/assert.hpp>
+#include <cstdint>
+#include <limits>
+
 #include <realm/util/memory_stream.hpp>
 
 using namespace realm;
 using namespace realm::util;
-using pos_type = realm::util::MemoryInputStreambuf::pos_type;
-using off_type = realm::util::MemoryInputStreambuf::off_type;
+
 
 MemoryInputStreambuf::int_type MemoryInputStreambuf::underflow()
 {
@@ -31,12 +32,14 @@ MemoryInputStreambuf::int_type MemoryInputStreambuf::underflow()
     return traits_type::to_int_type(*m_curr);
 }
 
+
 MemoryInputStreambuf::int_type MemoryInputStreambuf::uflow()
 {
     if (m_curr == m_end)
         return traits_type::eof();
     return traits_type::to_int_type(*m_curr++);
 }
+
 
 MemoryInputStreambuf::int_type MemoryInputStreambuf::pbackfail(int_type ch)
 {
@@ -45,43 +48,74 @@ MemoryInputStreambuf::int_type MemoryInputStreambuf::pbackfail(int_type ch)
     return traits_type::to_int_type(*--m_curr);
 }
 
+
 std::streamsize MemoryInputStreambuf::showmanyc()
 {
-    return m_end - m_curr;
+    std::ptrdiff_t n = m_end - m_curr;
+    std::streamsize max = std::numeric_limits<std::streamsize>::max();
+    return (n <= max ? std::streamsize(n) : max);
 }
 
-pos_type MemoryInputStreambuf::seekoff(off_type off, std::ios_base::seekdir dir, std::ios_base::openmode which)
-{
-    REALM_ASSERT(which == std::ios_base::in);
 
-    switch (dir) {
-        case std::ios_base::beg:
-            m_curr = m_begin + off;
-            break;
-        case std::ios_base::cur:
-            m_curr += off;
-            break;
-        case std::ios_base::end:
-            m_curr = m_end - off;
-            break;
-        default:
-            break;
+auto MemoryInputStreambuf::seekoff(off_type offset, std::ios_base::seekdir dir,
+                                   std::ios_base::openmode which) -> pos_type
+{
+    return do_seekoff(offset, dir, which);
+}
+
+
+auto MemoryInputStreambuf::seekpos(pos_type pos, std::ios_base::openmode which) -> pos_type
+{
+    off_type offset = off_type(pos);
+    return do_seekoff(offset, std::ios_base::beg, which);
+}
+
+
+auto MemoryInputStreambuf::do_seekoff(off_type offset, std::ios_base::seekdir dir,
+                                      std::ios_base::openmode which) -> pos_type
+{
+    // off_type is guaranteed to be std::streamoff since traits_type is
+    // std::char_traits<char>. off_type is therefore guaranteed to be signed.
+    using off_lim = std::numeric_limits<off_type>;
+    static_assert(off_lim::is_signed, "");
+    // For this function to work properly, the size of the installed buffer must
+    // never exceed the maximum stream size (off_type). To avoid checking the
+    // size of the buffer at run time, we simply assume that pos_type is at
+    // least as wide as std::ptrdiff_t. While this constraint is not necessary,
+    // it is sufficient due to the requirement that the size of the installed
+    // buffer (set_buffer()) is less than the maximum value of std::ptrdiff_t.
+    static_assert(off_lim::max() >= std::numeric_limits<std::ptrdiff_t>::max(), "");
+    const char* anchor;
+    if (which == std::ios_base::in) {
+        // Note: For file streams, `offset` is understood as an index into the
+        // byte sequence that makes up the file (even when `char_type` is not
+        // `char`). However, since MemoryInputStreambuf generally has no
+        // underlying byte sequence (in particular when when `char_type` is not
+        // `char`), `offset` is taken to be an index into a sequence of elements
+        // of type `char_type`. This choice is consistent with GCC's
+        // implementation of `std::basic_istringstream`.
+        switch (dir) {
+            case std::ios_base::beg:
+                anchor = m_begin;
+                goto good;
+            case std::ios_base::cur:
+                anchor = m_curr;
+                goto good;
+            case std::ios_base::end:
+                anchor = m_end;
+                goto good;
+            default:
+                break;
+        }
+    }
+    goto bad;
+
+  good:
+    if (offset >= (m_begin - anchor) && offset <= (m_end - anchor)) {
+        m_curr = anchor + std::ptrdiff_t(offset);
+        return pos_type(off_type(m_curr - m_begin));
     }
 
-    if (m_curr < m_begin || m_curr > m_end)
-        return traits_type::eof();
-
-    return m_curr - m_begin;
-}
-
-pos_type MemoryInputStreambuf::seekpos(pos_type pos, std::ios_base::openmode which)
-{
-    REALM_ASSERT(which == std::ios_base::in);
-
-    m_curr = m_begin + static_cast<int64_t>(pos);
-
-    if (m_curr < m_begin || m_curr > m_end)
-        return traits_type::eof();
-
-    return pos;
+  bad:
+    return pos_type(off_type(-1)); // Error
 }

--- a/test/test_util_memory_stream.cpp
+++ b/test/test_util_memory_stream.cpp
@@ -53,11 +53,10 @@ using namespace realm;
 
 namespace {
 
-TEST(MemoryStream_Input)
+TEST(MemoryStream_InputBasic)
 {
-    const char buf[] = "123 4567";
     realm::util::MemoryInputStream in;
-    in.set_buffer(buf, buf + sizeof(buf) - 1);
+    in.set_c_string("123 4567");
     in.unsetf(std::ios_base::skipws);
 
     CHECK_EQUAL(in.eof(), false);
@@ -87,6 +86,99 @@ TEST(MemoryStream_Input)
     CHECK_EQUAL(number, 567);
     CHECK_EQUAL(in.eof(), true);
     CHECK_EQUAL(in.tellg(), -1);
+}
+
+
+TEST(MemoryStream_InputSeek)
+{
+    realm::util::MemoryInputStream in;
+
+    // No buffer
+    CHECK_EQUAL(0, in.tellg());
+    in.seekg(0);
+    CHECK(in);
+    CHECK_EQUAL(0, in.tellg());
+    in.seekg(0);
+    CHECK(in);
+    in.seekg(1); // Out of range
+    CHECK_NOT(in);
+    in.clear();
+    CHECK(in);
+    in.seekg(-1); // Out of range
+    CHECK_NOT(in);
+
+    // Absolute
+    in.set_c_string("AB");
+    CHECK_EQUAL(0, in.tellg());
+    in.seekg(0);
+    CHECK(in);
+    CHECK_EQUAL(0, in.tellg());
+    in.seekg(1);
+    CHECK(in);
+    CHECK_EQUAL(1, in.tellg());
+    in.seekg(2);
+    CHECK(in);
+    CHECK_EQUAL(2, in.tellg());
+    in.seekg(3); // Out of range
+    CHECK_NOT(in);
+    in.clear();
+    CHECK_EQUAL(2, in.tellg());
+    CHECK(in);
+    in.seekg(-1); // Out of range
+    CHECK_NOT(in);
+    in.clear();
+    CHECK_EQUAL(2, in.tellg());
+
+    // Relative
+    in.set_c_string("AB");
+    CHECK_EQUAL(0, in.tellg());
+    in.seekg(0, std::ios_base::beg);
+    CHECK(in);
+    CHECK_EQUAL(0, in.tellg());
+    in.seekg(0, std::ios_base::cur);
+    CHECK(in);
+    CHECK_EQUAL(0, in.tellg());
+    in.seekg(0, std::ios_base::end);
+    CHECK(in);
+    CHECK_EQUAL(2, in.tellg());
+    in.seekg(+1, std::ios_base::beg);
+    CHECK(in);
+    CHECK_EQUAL(1, in.tellg());
+    in.seekg(+1, std::ios_base::cur);
+    CHECK(in);
+    CHECK_EQUAL(2, in.tellg());
+    in.seekg(-1, std::ios_base::end);
+    CHECK(in);
+    CHECK_EQUAL(1, in.tellg());
+    in.seekg(-1, std::ios_base::cur);
+    CHECK(in);
+    CHECK_EQUAL(0, in.tellg());
+    in.seekg(-1, std::ios_base::beg); // Out of range
+    CHECK_NOT(in);
+    in.clear();
+    CHECK_EQUAL(0, in.tellg());
+    in.seekg(+3, std::ios_base::beg); // Out of range
+    CHECK_NOT(in);
+    in.clear();
+    CHECK_EQUAL(0, in.tellg());
+    in.seekg(+1, std::ios_base::cur);
+    in.seekg(-2, std::ios_base::cur); // Out of range
+    CHECK_NOT(in);
+    in.clear();
+    CHECK_EQUAL(1, in.tellg());
+    in.seekg(+2, std::ios_base::cur); // Out of range
+    CHECK_NOT(in);
+    in.clear();
+    CHECK_EQUAL(1, in.tellg());
+    in.seekg(+1, std::ios_base::cur);
+    in.seekg(-3, std::ios_base::end); // Out of range
+    CHECK_NOT(in);
+    in.clear();
+    CHECK_EQUAL(2, in.tellg());
+    in.seekg(+1, std::ios_base::end); // Out of range
+    CHECK_NOT(in);
+    in.clear();
+    CHECK_EQUAL(2, in.tellg());
 }
 
 } // unnamed namespace


### PR DESCRIPTION
`seekpos()` and `seekoff()` in `realm::util::MemoryInputStreambuf` now behave
  correctly when argument is out of range.

Fixes https://github.com/realm/realm-core/issues/2463.

@morten-krogh @ironage 