### PR TITLE
Use Markdown syntax to make links to PRs and issues

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,7 @@
 ### Enhancements
 
 * Use only a single file descriptor in our emulation of interprocess condition variables
-  on most platforms rather than two.
+  on most platforms rather than two. PR [#2460](https://github.com/realm/realm-core/pull/2460). Fixes Cocoa issue [#4676](https://github.com/realm/realm-cocoa/issues/4676).
 
 -----------
 
@@ -27,19 +27,19 @@
 * Fixed race condition bug that could cause crashes and corrupted data
   under rare circumstances with heavy load from multiple threads accessing
   encrypted data. (sometimes pieces of data from earlier commits could be seen).
-  PR #2465 fixes issue #2383
+  PR [#2465](https://github.com/realm/realm-core/pull/2465). Fixes issue [#2383](https://github.com/realm/realm-core/issues/2383).
 * Added SharedGroupOptions::set_sys_tmp_dir() and
   SharedGroupOptions::set_sys_tmp_dir() to solve crash when compacting a Realm
   file on Android external storage which is caused by invalid default sys_tmp_dir.
-  (issue #4140)
+  PR [#2445](https://github.com/realm/realm-core/pull/2445). Fixes Java issue [#4140](https://github.com/realm/realm-java/issues/4140).
 
 -----------
 
 ### Internals
 
 * Remove the BinaryData constructor taking a temporary object to prevent some
-  errors in unit tests at compile time.
-* Avoid assertions in aggregate functions for the timestamp type.
+  errors in unit tests at compile time. PR [#2446](https://github.com/realm/realm-core/pull/2446).
+* Avoid assertions in aggregate functions for the timestamp type. PR [#2466](https://github.com/realm/realm-core/pull/2466).
 
 ----------------------------------------------
 


### PR DESCRIPTION
This is a proposal to have (working) links in our `CHANGELOG.md`. Currently we have a mix of PR / issues numbers and/or links in plain text. I propose we use Markdown syntax to have real links and make a habit of always referencing the PR - and if meaningful also a link to the issue in this or the bindings' repo(s).

Only the latest and NEXT release sections have been fixed in this PR.