### PR TITLE
Fix warnings in coverage build with clang.

### DIFF
--- a/src/project.mk
+++ b/src/project.mk
@@ -53,8 +53,13 @@ endif
 
 PROJECT_CFLAGS_DEBUG = -DREALM_DEBUG
 PROJECT_CFLAGS_COVER = -DREALM_DEBUG -DREALM_COVER \
-                       -fno-inline -fno-inline-small-functions \
-                       -fno-default-inline -fno-elide-constructors
+                       -fno-elide-constructors
+
+ifeq ($(COMPILER_IS),gcc)
+  PROJECT_CFLAGS_COVER += -fno-inline \
+                          -fno-inline-small-functions \
+                          -fno-default-inline
+endif
 
 # Load dynamic configuration
 ifneq ($(REALM_HAVE_CONFIG),)


### PR DESCRIPTION
Some of the flags we used in coverage builds are not supported by clang and gave warnings when building. We should only apply them to GCC coverage builds.