### PR TITLE
Bug fixed in GroupWriter::write_group(), bad maximum size of top array

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,9 @@
 
 ### Bugfixes
 
-* Lorem ipsum.
+* Bug fixed in `GroupWriter::write_group()` where the maximum size of the top
+  array was calculated incorrectly. This bug had the potential to cause
+  corruption in Realm files.
 
 ### Breaking changes
 

--- a/src/realm/group_writer.cpp
+++ b/src/realm/group_writer.cpp
@@ -342,11 +342,9 @@ ref_type GroupWriter::write_group()
     max_free_list_size += 80;
 
     int num_free_lists = is_shared ? 3 : 2;
-    int max_top_size = 3 + num_free_lists;
-    if (is_shared)
-        ++max_top_size; // database version (a.k.a. transaction number)
     size_t max_free_space_needed =
-        Array::get_max_byte_size(max_top_size) + num_free_lists * Array::get_max_byte_size(max_free_list_size);
+        Array::get_max_byte_size(top.size()) +
+        num_free_lists * Array::get_max_byte_size(max_free_list_size);
 
     // Reserve space for remaining arrays. We ask for one extra byte beyond the
     // maximum number that is required. This ensures that even if we end up


### PR DESCRIPTION
Bug fixed in `GroupWriter::write_group()` where the maximum size of the top array was calculated incorrectly. This bug had the potential to cause corruption in Realm files.

This bug is my fault. It happened during the introduction of in-Realm histories.

@finnschiermer @ironage 