### PR TITLE
Prepare for introduction of sync server history

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,10 +14,14 @@
 ### Breaking changes
 
 * Disable copying of various classes to prevent incorrect use at compile time.
+* History type enumeration value `Replication::hist_Sync` renamed to
+  `Replication::hist_SyncClient`.
 
 ### Enhancements
 
-* Lorem ipsum.
+* New history type enumeration value `Replication::hist_SyncServer`. This allows
+  for the sync server to start using the same kind of in-Realm history scheme as
+  is currently used by clients.
 
 -----------
 

--- a/src/realm/group_shared.cpp
+++ b/src/realm/group_shared.cpp
@@ -974,12 +974,20 @@ void SharedGroup::do_open(const std::string& path, bool no_create_file, bool is_
                         if (!good_history_type)
                             throw IncompatibleHistories("Expected a Realm with no or in-realm history", path);
                         break;
-                    case Replication::hist_Sync:
-                        good_history_type = ((stored_history_type == Replication::hist_Sync) ||
+                    case Replication::hist_SyncClient:
+                        good_history_type = ((stored_history_type == Replication::hist_SyncClient) ||
                                              (stored_history_type == Replication::hist_None && top_ref == 0));
                         if (!good_history_type)
                             throw IncompatibleHistories(
                                 "Expected an empty Realm or a Realm written by Realm Mobile Platform", path);
+                        break;
+                    case Replication::hist_SyncServer:
+                        good_history_type = ((stored_history_type == Replication::hist_SyncServer) ||
+                                             (stored_history_type == Replication::hist_None && top_ref == 0));
+                        if (!good_history_type)
+                            throw IncompatibleHistories("Expected a Realm containining "
+                                                        "a server-side history", path);
+                        break;
                 }
                 if (Replication* repl = gf::get_replication(m_group))
                     repl->initiate_session(version); // Throws

--- a/src/realm/replication.hpp
+++ b/src/realm/replication.hpp
@@ -229,9 +229,13 @@ public:
         /// (_impl::InRealmHistory).
         hist_InRealm = 2,
 
-        /// In-Realm history supporting continuous transactions and inter-client
-        /// synchronization (_impl::SyncHistory).
-        hist_Sync = 3
+        /// In-Realm history supporting continuous transactions and client-side
+        /// synchronization protocol (realm::sync::ClientHistory).
+        hist_SyncClient = 3,
+
+        /// In-Realm history supporting continuous transactions and server-side
+        /// synchronization protocol (realm::_impl::ServerHistory).
+        hist_SyncServer = 4
     };
 
     /// Returns the type of history maintained by this Replication
@@ -302,13 +306,16 @@ public:
     /// remains in the Realm file, there are practical complications, and for
     /// that reason, such switching shall not be supported.
     ///
-    /// The \ref hist_Sync history type can only be used if the stored history
-    /// type is also \ref hist_Sync, or when there is no top array
-    /// yet. Additionally, when the stored history type is \ref hist_Sync, then
-    /// all subsequent sesssions must have the same type. These restrictions
-    /// apply because such a history needs to be maintained persistently across
-    /// sessions. That is, the contents of such a history is not obsolete at the
-    /// end of the session, and is in general needed during subsequent sessions.
+    /// The \ref hist_SyncClient history type can only be used if the stored
+    /// history type is also \ref hist_SyncClient, or when there is no top array
+    /// yet. Likewise, the \ref hist_SyncServer history type can only be used if
+    /// the stored history type is also \ref hist_SyncServer, or when there is
+    /// no top array yet. Additionally, when the stored history type is \ref
+    /// hist_SyncClient or \ref hist_SyncServer, then all subsequent sessions
+    /// must have the same type. These restrictions apply because such a history
+    /// needs to be maintained persistently across sessions. That is, the
+    /// contents of such a history is not obsolete at the end of the session,
+    /// and is in general needed during subsequent sessions.
     ///
     /// In general, if there is no stored history type (no top array) at the
     /// beginning of a new session, or if the stored type disagrees with what is
@@ -343,7 +350,8 @@ public:
     ///   hist_None          hist_None        hist_None, hist_OutOfRealm, hist_InRealm
     ///   hist_OutOfRealm    hist_None        hist_None, hist_OutOfRealm, hist_InRealm
     ///   hist_InRealm       hist_InRealm     hist_InRealm
-    ///   hist_Sync          hist_Sync        hist_Sync
+    ///   hist_SyncClient    hist_SyncClient  hist_SyncClient
+    ///   hist_SyncServer    hist_SyncServer  hist_SyncServer
     ///
     /// </pre>
     ///


### PR DESCRIPTION
Changes:
- History type enumeration value `Replication::hist_Sync` renamed to `Replication::hist_SyncClient`.
- New history type enumeration value `Replication::hist_SyncServer`. This allows for the sync server to start using the same kind of in-Realm history scheme as is currently used by clients.

Prerequisite for https://github.com/realm/realm-core/pull/2481.

@jedelbo @finnschiermer 