### PR TITLE
Remove toggle for disallowing duplicates in the string index.

### DIFF
--- a/src/realm/column.cpp
+++ b/src/realm/column.cpp
@@ -361,12 +361,10 @@ void ColumnBaseWithIndex::destroy_search_index() noexcept
     m_search_index.reset();
 }
 
-void ColumnBaseWithIndex::set_search_index_ref(ref_type ref, ArrayParent* parent, size_t ndx_in_parent,
-                                               bool allow_duplicate_valaues)
+void ColumnBaseWithIndex::set_search_index_ref(ref_type ref, ArrayParent* parent, size_t ndx_in_parent)
 {
     REALM_ASSERT(!m_search_index);
-    m_search_index.reset(
-        new StringIndex(ref, parent, ndx_in_parent, this, !allow_duplicate_valaues, get_alloc())); // Throws
+    m_search_index.reset(new StringIndex(ref, parent, ndx_in_parent, this, get_alloc())); // Throws
 }
 
 

--- a/src/realm/column.hpp
+++ b/src/realm/column.hpp
@@ -208,8 +208,7 @@ public:
     virtual void destroy_search_index() noexcept;
     virtual const StringIndex* get_search_index() const noexcept;
     virtual StringIndex* get_search_index() noexcept;
-    virtual void set_search_index_ref(ref_type, ArrayParent*, size_t ndx_in_parent, bool allow_duplicate_values);
-    virtual void set_search_index_allow_duplicate_values(bool) noexcept;
+    virtual void set_search_index_ref(ref_type, ArrayParent*, size_t ndx_in_parent);
 
     virtual Allocator& get_alloc() const noexcept = 0;
 
@@ -503,8 +502,7 @@ public:
         return m_search_index.get();
     }
     void destroy_search_index() noexcept override;
-    void set_search_index_ref(ref_type ref, ArrayParent* parent, size_t ndx_in_parent,
-                              bool allow_duplicate_valaues) final;
+    void set_search_index_ref(ref_type ref, ArrayParent* parent, size_t ndx_in_parent) final;
     StringIndex* create_search_index() override = 0;
 
 protected:
@@ -805,11 +803,7 @@ inline StringIndex* ColumnBase::get_search_index() noexcept
     return nullptr;
 }
 
-inline void ColumnBase::set_search_index_ref(ref_type, ArrayParent*, size_t, bool)
-{
-}
-
-inline void ColumnBase::set_search_index_allow_duplicate_values(bool) noexcept
+inline void ColumnBase::set_search_index_ref(ref_type, ArrayParent*, size_t)
 {
 }
 

--- a/src/realm/column_string.cpp
+++ b/src/realm/column_string.cpp
@@ -244,18 +244,10 @@ std::unique_ptr<StringIndex> StringColumn::release_search_index() noexcept
 }
 
 
-void StringColumn::set_search_index_ref(ref_type ref, ArrayParent* parent, size_t ndx_in_parent,
-                                        bool allow_duplicate_valaues)
+void StringColumn::set_search_index_ref(ref_type ref, ArrayParent* parent, size_t ndx_in_parent)
 {
     REALM_ASSERT(!m_search_index);
-    m_search_index.reset(
-        new StringIndex(ref, parent, ndx_in_parent, this, !allow_duplicate_valaues, m_array->get_alloc())); // Throws
-}
-
-
-void StringColumn::set_search_index_allow_duplicate_values(bool allow) noexcept
-{
-    m_search_index->set_allow_duplicate_values(allow);
+    m_search_index.reset(new StringIndex(ref, parent, ndx_in_parent, this, m_array->get_alloc())); // Throws
 }
 
 

--- a/src/realm/column_string.hpp
+++ b/src/realm/column_string.hpp
@@ -92,8 +92,7 @@ public:
     // Search index
     StringData get_index_data(size_t ndx, StringIndex::StringConversionBuffer& buffer) const noexcept final;
     bool has_search_index() const noexcept override;
-    void set_search_index_ref(ref_type, ArrayParent*, size_t, bool) override;
-    void set_search_index_allow_duplicate_values(bool) noexcept override;
+    void set_search_index_ref(ref_type, ArrayParent*, size_t) override;
     StringIndex* get_search_index() noexcept override;
     const StringIndex* get_search_index() const noexcept override;
     std::unique_ptr<StringIndex> release_search_index() noexcept;

--- a/src/realm/column_string_enum.cpp
+++ b/src/realm/column_string_enum.cpp
@@ -313,12 +313,6 @@ StringData StringEnumColumn::get_index_data(size_t ndx, StringIndex::StringConve
 }
 
 
-void StringEnumColumn::set_search_index_allow_duplicate_values(bool allow) noexcept
-{
-    m_search_index->set_allow_duplicate_values(allow);
-}
-
-
 void StringEnumColumn::install_search_index(std::unique_ptr<StringIndex> index) noexcept
 {
     REALM_ASSERT(!m_search_index);

--- a/src/realm/column_string_enum.hpp
+++ b/src/realm/column_string_enum.hpp
@@ -111,7 +111,6 @@ public:
 
     // Search index
     StringData get_index_data(size_t ndx, StringIndex::StringConversionBuffer& buffer) const noexcept final;
-    void set_search_index_allow_duplicate_values(bool) noexcept override;
     bool supports_search_index() const noexcept final
     {
         return true;

--- a/src/realm/column_timestamp.cpp
+++ b/src/realm/column_timestamp.cpp
@@ -276,12 +276,10 @@ void TimestampColumn::destroy_search_index() noexcept
     m_search_index.reset();
 }
 
-void TimestampColumn::set_search_index_ref(ref_type ref, ArrayParent* parent, size_t ndx_in_parent,
-                                           bool allow_duplicate_values)
+void TimestampColumn::set_search_index_ref(ref_type ref, ArrayParent* parent, size_t ndx_in_parent)
 {
     REALM_ASSERT(!m_search_index);
-    m_search_index.reset(
-        new StringIndex(ref, parent, ndx_in_parent, this, !allow_duplicate_values, get_alloc())); // Throws
+    m_search_index.reset(new StringIndex(ref, parent, ndx_in_parent, this, get_alloc())); // Throws
 }
 
 

--- a/src/realm/column_timestamp.hpp
+++ b/src/realm/column_timestamp.hpp
@@ -65,8 +65,7 @@ public:
         return m_search_index.get();
     }
     void destroy_search_index() noexcept override;
-    void set_search_index_ref(ref_type ref, ArrayParent* parent, size_t ndx_in_parent,
-                              bool allow_duplicate_values) final;
+    void set_search_index_ref(ref_type ref, ArrayParent* parent, size_t ndx_in_parent) final;
     void populate_search_index();
     StringIndex* create_search_index() override;
     bool supports_search_index() const noexcept final

--- a/src/realm/index_string.hpp
+++ b/src/realm/index_string.hpp
@@ -93,8 +93,7 @@ private:
 class StringIndex {
 public:
     StringIndex(ColumnBase* target_column, Allocator&);
-    StringIndex(ref_type, ArrayParent*, size_t ndx_in_parent, ColumnBase* target_column, bool allow_duplicate_values,
-                Allocator&);
+    StringIndex(ref_type, ArrayParent*, size_t ndx_in_parent, ColumnBase* target_column, Allocator&);
     ~StringIndex() noexcept
     {
     }
@@ -149,9 +148,6 @@ public:
     void distinct(IntegerColumn& result) const;
     bool has_duplicate_values() const noexcept;
 
-    /// By default, duplicate values are allowed.
-    void set_allow_duplicate_values(bool) noexcept;
-
     void verify() const;
 #ifdef REALM_DEBUG
     void verify_entries(const StringColumn& column) const;
@@ -196,7 +192,6 @@ private:
     // If the header flag is set, references point to a sub-StringIndex (nesting).
     std::unique_ptr<IndexArray> m_array;
     ColumnBase* m_target_column;
-    bool m_deny_duplicate_values;
 
     struct inner_node_tag {
     };
@@ -346,15 +341,13 @@ inline StringData to_str(T&& value, StringIndex::StringConversionBuffer& buffer)
 inline StringIndex::StringIndex(ColumnBase* target_column, Allocator& alloc)
     : m_array(create_node(alloc, true)) // Throws
     , m_target_column(target_column)
-    , m_deny_duplicate_values(false)
 {
 }
 
 inline StringIndex::StringIndex(ref_type ref, ArrayParent* parent, size_t ndx_in_parent, ColumnBase* target_column,
-                                bool deny_duplicate_values, Allocator& alloc)
+                                Allocator& alloc)
     : m_array(new IndexArray(alloc))
     , m_target_column(target_column)
-    , m_deny_duplicate_values(deny_duplicate_values)
 {
     REALM_ASSERT_EX(Array::get_context_flag_from_header(alloc.translate(ref)), ref, size_t(alloc.translate(ref)));
     m_array->init_from_ref(ref);
@@ -364,13 +357,7 @@ inline StringIndex::StringIndex(ref_type ref, ArrayParent* parent, size_t ndx_in
 inline StringIndex::StringIndex(inner_node_tag, Allocator& alloc)
     : m_array(create_node(alloc, false)) // Throws
     , m_target_column(nullptr)
-    , m_deny_duplicate_values(false)
 {
-}
-
-inline void StringIndex::set_allow_duplicate_values(bool allow) noexcept
-{
-    m_deny_duplicate_values = !allow;
 }
 
 // Byte order of the key is *reversed*, so that for the integer index, the least significant

--- a/src/realm/table.cpp
+++ b/src/realm/table.cpp
@@ -5890,13 +5890,11 @@ void Table::refresh_column_accessors(size_t col_ndx_begin)
         }
 
         if (column_has_search_index) {
-            bool allow_duplicate_values = true;
             if (col->has_search_index()) {
-                col->set_search_index_allow_duplicate_values(allow_duplicate_values);
             }
             else {
                 ref_type ref = m_columns.get_as_ref(ndx_in_parent + 1);
-                col->set_search_index_ref(ref, &m_columns, ndx_in_parent + 1, allow_duplicate_values); // Throws
+                col->set_search_index_ref(ref, &m_columns, ndx_in_parent + 1); // Throws
             }
         }
 

--- a/test/test_index_string.cpp
+++ b/test/test_index_string.cpp
@@ -1383,53 +1383,6 @@ TEST(StringIndex_MoveLastOver_DoUpdateRef)
     col.destroy();
 }
 
-TEST(StringIndex_Deny_Duplicates)
-{
-    ref_type ref = StringColumn::create(Allocator::get_default());
-    StringColumn col(Allocator::get_default(), ref, true);
-    StringData duplicate("duplicate");
-    // create subindex of repeated elements on a leaf
-    size_t num_repeats = 100;
-    for (size_t i = 0; i < num_repeats; ++i) {
-        col.add(duplicate);
-    }
-
-    // Create a new index on column
-    const StringIndex& ndx = *col.create_search_index();
-
-    CHECK(ndx.has_duplicate_values());
-
-    col.set_search_index_allow_duplicate_values(false);
-    CHECK(ndx.has_duplicate_values());
-
-    size_t ndx_count = ndx.count(duplicate);
-    CHECK_THROW(col.add(duplicate), realm::LogicError);
-    CHECK(ndx_count == ndx.count(duplicate));
-
-    col.clear();
-    CHECK(!ndx.has_duplicate_values());
-
-    col.add(duplicate);
-    CHECK_THROW(col.add(duplicate), realm::LogicError);
-    CHECK(!ndx.has_duplicate_values());
-
-    col.clear();
-    col.set_search_index_allow_duplicate_values(true);
-    CHECK(!ndx.has_duplicate_values());
-
-    // Populate tree with duplicates through insert() at back
-    for (size_t i = 0; i < num_repeats; ++i) {
-        col.insert(col.size(), duplicate);
-    }
-    CHECK(ndx.has_duplicate_values());
-    CHECK(col.get(0) == duplicate);
-    CHECK(col.get(col.size() - 1) == duplicate);
-    CHECK(col.count(duplicate) == num_repeats);
-
-    col.destroy();
-}
-
-
 TEST(StringIndex_MaxBytes)
 {
     std::string std_max(StringIndex::s_max_offset, 'a');


### PR DESCRIPTION
This is small cleanup of seemingly unused functionality. This change was done before Christmas, but never pushed. Yay / nay?