### PR TITLE
AFL improvements

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -75,7 +75,7 @@ benchmark-history-types: check-norun/subdir/src
 .PHONY: lcov
 lcov: check-cover
 	lcov --capture --directory . --output-file /tmp/realm.lcov
-	lcov --extract /tmp/realm.lcov '$(abspath .)/src/*' --output-file /tmp/realm-clean.lcov
+	lcov --extract /tmp/realm.lcov '$(abspath .)/src/*' --extract /tmp/realm.lcov '$(abspath .)/test/fuzz_group*' --output-file /tmp/realm-clean.lcov
 	rm -fr cover_html
 	genhtml --prefix $(abspath .) --output-directory cover_html /tmp/realm-clean.lcov
 

--- a/test/fuzz_group.cpp
+++ b/test/fuzz_group.cpp
@@ -69,6 +69,7 @@ enum INS {
     REMOVE_COLUMN,
     SET,
     REMOVE_ROW,
+    MERGE_ROWS,
     ADD_COLUMN_LINK,
     ADD_COLUMN_LINK_LIST,
     CLEAR_TABLE,
@@ -591,6 +592,22 @@ void parse_and_apply_instructions(std::string& in, const std::string& path, util
                         *log << "g.get_table(" << table_ndx << ")->remove(" << row_ndx << ");\n";
                     }
                     t->remove(row_ndx);
+                }
+            }
+            else if (instr == MERGE_ROWS && g.size() > 0) {
+                size_t table_ndx = get_next(s) % g.size();
+                TableRef t = g.get_table(table_ndx);
+                if (t->size() > 1) {
+                    size_t row_ndx1 = get_next(s) % t->size();
+                    size_t row_ndx2 = get_next(s) % t->size();
+                    if (row_ndx1 == row_ndx2) {
+                        row_ndx2 = (row_ndx2 + 1) % t->size();
+                    }
+
+                    if (log) {
+                        *log << "g.get_table(" << table_ndx << ")->merge_rows(" << row_ndx1 << ", " << row_ndx2 << ");\n";
+                    }
+                    t->merge_rows(row_ndx1, row_ndx2);
                 }
             }
             else if (instr == MOVE_LAST_OVER && g.size() > 0) {

--- a/test/fuzz_group.cpp
+++ b/test/fuzz_group.cpp
@@ -161,35 +161,35 @@ Mixed construct_mixed(State& s, util::Optional<std::ostream&> log)
         case 0: {
             bool b = get_next(s) % 2;
             if (log) {
-                *log << "Mixed mixed(" << (b ? "true" : "false") << ");";
+                *log << "Mixed mixed(" << (b ? "true" : "false") << ");\n";
             }
             return Mixed(b);
         }
         case 1: {
             int64_t value = get_int64(s);
             if (log) {
-                *log << "Mixed mixed((int64_t)(" << value << "));";
+                *log << "Mixed mixed((int64_t)(" << value << "));\n";
             }
             return Mixed(value);
         }
         case 2: {
             float value = get_next(s);
             if (log) {
-                *log << "Mixed mixed((float)(" << value << "));";
+                *log << "Mixed mixed((float)(" << value << "));\n";
             }
             return Mixed(value);
         }
         case 3: {
             double value = get_next(s);
             if (log) {
-                *log << "Mixed mixed((double)(" << value << "));";
+                *log << "Mixed mixed((double)(" << value << "));\n";
             }
             return Mixed(value);
         }
         case 4: {
             std::string str = create_string(get_next(s));
             if (log) {
-                *log << "Mixed mixed(StringData(\"" << str << "\"));";
+                *log << "Mixed mixed(StringData(\"" << str << "\"));\n";
             }
             return Mixed(StringData(str));
         }
@@ -199,21 +199,21 @@ Mixed construct_mixed(State& s, util::Optional<std::ostream&> log)
             std::string blob(blob_size, static_cast<unsigned char>(rand_char));
             if (log) {
                 *log << "std::string blob(" << blob_size << ", static_cast<unsigned char>(" << rand_char << "));\n"
-                     << "Mixed mixed(BinaryData(blob));";
+                     << "Mixed mixed(BinaryData(blob));\n";
             }
             return Mixed(BinaryData(blob));
         }
         case 6: {
             int64_t time = get_int64(s);
             if (log) {
-                *log << "Mixed mixed(OldDateTime(" << time << "));";
+                *log << "Mixed mixed(OldDateTime(" << time << "));\n";
             }
             return Mixed(OldDateTime(time));
         }
         case 7: {
             std::pair<int64_t, int32_t> values = get_timestamp_values(s);
             if (log) {
-                *log << "Mixed mixed(Timestamp{" << values.first << ", " << values.second << "});";
+                *log << "Mixed mixed(Timestamp{" << values.first << ", " << values.second << "});\n";
             }
             return Mixed(Timestamp{values.first, values.second});
         }
@@ -674,7 +674,7 @@ void parse_and_apply_instructions(std::string& in, const std::string& path, util
                             }
                             Mixed mixed = construct_mixed(s, log);
                             if (log) {
-                                *log << "\ng.get_table(" << table_ndx << ")->set_mixed(" << col_ndx << ", "
+                                *log << "g.get_table(" << table_ndx << ")->set_mixed(" << col_ndx << ", "
                                      << row_ndx << ", mixed);\n}\n";
                             }
                             t->set_mixed(col_ndx, row_ndx, mixed);
@@ -709,7 +709,7 @@ void parse_and_apply_instructions(std::string& in, const std::string& path, util
                             if (!t->get_linklist(col_ndx, row_ndx2)->is_empty()) {
                                 if (log) {
                                     *log << "g.get_table(" << table_ndx << ")->get_linklist("
-                                    << col_ndx << ", " << row_ndx2 << ")->clear();";
+                                    << col_ndx << ", " << row_ndx2 << ")->clear();\n";
                                 }
                                 t->get_linklist(col_ndx, row_ndx2)->clear();
                             }

--- a/test/fuzz_group.cpp
+++ b/test/fuzz_group.cpp
@@ -475,12 +475,32 @@ void parse_and_apply_instructions(std::string& in, const std::string& path, util
                             }
                         }
                         else if (type == type_Int) {
+                            bool add_int = get_next(s) % 2 == 0;
                             int64_t value = get_int64(s);
-                            if (log) {
-                                *log << "g.get_table(" << table_ndx << ")->set_int(" << col_ndx << ", " << row_ndx
-                                     << ", " << value << ");\n";
+                            if (add_int) {
+                                if (log) {
+                                    *log << "try { g.get_table(" << table_ndx << ")->add_int(" << col_ndx
+                                    << ", " << row_ndx << ", " << value
+                                    << "); } catch (const LogicError& le) { CHECK(le.kind() == "
+                                    "LogicError::illegal_combination); }\n";
+                                }
+                                try {
+                                    t->add_int(col_ndx, row_ndx, value);
+                                }
+                                catch (const LogicError& le) {
+                                    if (le.kind() != LogicError::illegal_combination) {
+                                        throw;
+                                    }
+                                }
                             }
-                            t->set_int(col_ndx, row_ndx, get_next(s));
+                            else {
+                                if (log) {
+                                    *log << "g.get_table(" << table_ndx << ")->set_int(" << col_ndx << ", " << row_ndx
+                                    << ", " << value << ");\n";
+                                }
+                                t->set_int(col_ndx, row_ndx, get_next(s));
+                            }
+
                         }
                         else if (type == type_Bool) {
                             bool value = get_next(s) % 2 == 0;

--- a/test/fuzz_group.cpp
+++ b/test/fuzz_group.cpp
@@ -65,6 +65,7 @@ enum INS {
     INSERT_ROW,
     ADD_EMPTY_ROW,
     INSERT_COLUMN,
+    RENAME_COLUMN,
     ADD_COLUMN,
     REMOVE_COLUMN,
     SET,
@@ -336,6 +337,19 @@ void parse_and_apply_instructions(std::string& in, const std::string& path, util
                         *log << "g.get_table(" << table_ndx << ")->remove_column(" << col_ndx << ");\n";
                     }
                     t->remove_column(col_ndx);
+                }
+            }
+            else if (instr == RENAME_COLUMN && g.size() > 0) {
+                size_t table_ndx = get_next(s) % g.size();
+                TableRef t = g.get_table(table_ndx);
+                if (t->get_column_count() > 0) {
+                    size_t col_ndx = get_next(s) % t->get_column_count();
+                    std::string name = create_column_name(s);
+                    if (log) {
+                        *log << "g.get_table(" << table_ndx << ")->rename_column("
+                             << col_ndx << ", " << name << ");\n";
+                    }
+                    t->rename_column(col_ndx, name);
                 }
             }
             else if (instr == MOVE_COLUMN && g.size() > 0) {

--- a/test/fuzz_group.cpp
+++ b/test/fuzz_group.cpp
@@ -617,7 +617,19 @@ void parse_and_apply_instructions(std::string& in, const std::string& path, util
                     if (row_ndx1 == row_ndx2) {
                         row_ndx2 = (row_ndx2 + 1) % t->size();
                     }
-
+                    // A restriction of merge_rows is that any linklists in the
+                    // "to" row must be empty because merging lists is not defined.
+                    for (size_t col_ndx = 0; col_ndx != t->get_column_count(); ++col_ndx) {
+                        if (t->get_column_type(col_ndx) == DataType::type_LinkList) {
+                            if (!t->get_linklist(col_ndx, row_ndx2)->is_empty()) {
+                                if (log) {
+                                    *log << "g.get_table(" << table_ndx << ")->get_linklist("
+                                    << col_ndx << ", " << row_ndx2 << ")->clear();";
+                                }
+                                t->get_linklist(col_ndx, row_ndx2)->clear();
+                            }
+                        }
+                    }
                     if (log) {
                         *log << "g.get_table(" << table_ndx << ")->merge_rows(" << row_ndx1 << ", " << row_ndx2 << ");\n";
                     }


### PR DESCRIPTION
Adds the following instructions to AFL:
- add_int
- merge_rows
- rename_column
- setting mixed types

This revealed a bug when rolling back a transaction involving a `Mixed` type which contained a `StringData` or a `BinaryData`. The problem is fixed here and a test case added for it.

Other small changes:
- Include the `fuzz_group.cpp` file in coverage reports to allow analysis of what instructions are run.
- Assert immediately when constructing a `Mixed` type with the new `Timestamp` because it is missing some critical functionality and not supported at this point.

Fixes #1636.