### PR TITLE
Fixed a reallocation corner case found by AFL.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,8 @@
 ### Bugfixes
 
 * Fixed an assertion on a corner case of reallocation on large arrays.
+  PR [#2500](https://github.com/realm/realm-core/pull/2500).
+  Fixes issue [#2451](https://github.com/realm/realm-core/issues/2451).
 
 ### Breaking changes
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ### Bugfixes
 
-* Lorem ipsum.
+* Fixed an assertion on a corner case of reallocation on large arrays.
 
 ### Breaking changes
 

--- a/src/realm/array.cpp
+++ b/src/realm/array.cpp
@@ -1717,9 +1717,9 @@ void Array::alloc(size_t init_size, size_t width)
             // field in the header.
             size_t new_capacity_bytes = capacity_bytes * 2;
             if (new_capacity_bytes < capacity_bytes) // overflow detected, clamp to max
-                new_capacity_bytes = max_array_payload;
-            if (new_capacity_bytes > max_array_payload) // cap at max allowed allocation
-                new_capacity_bytes = max_array_payload;
+                new_capacity_bytes = max_array_payload_aligned;
+            if (new_capacity_bytes > max_array_payload_aligned) // cap at max allowed allocation
+                new_capacity_bytes = max_array_payload_aligned;
             capacity_bytes = new_capacity_bytes;
 
             // If doubling is not enough, expand enough to fit

--- a/src/realm/array.hpp
+++ b/src/realm/array.hpp
@@ -101,7 +101,8 @@ inline T no0(T v)
 const size_t npos = size_t(-1);
 
 // Maximum number of bytes that the payload of an array can be
-const size_t max_array_payload = 0x00ffffffL;
+const size_t max_array_payload         = 0x00ffffffL;
+const size_t max_array_payload_aligned = 0x00fffff0L;
 
 /// Alias for realm::npos.
 const size_t not_found = npos;

--- a/src/realm/array.hpp
+++ b/src/realm/array.hpp
@@ -102,7 +102,7 @@ const size_t npos = size_t(-1);
 
 // Maximum number of bytes that the payload of an array can be
 const size_t max_array_payload         = 0x00ffffffL;
-const size_t max_array_payload_aligned = 0x00fffff0L;
+const size_t max_array_payload_aligned = 0x00fffff8L;
 
 /// Alias for realm::npos.
 const size_t not_found = npos;

--- a/test/test_lang_bind_helper.cpp
+++ b/test/test_lang_bind_helper.cpp
@@ -12918,4 +12918,30 @@ TEST(LangBindHelper_CopyOnWriteOverflow)
     }
 }
 
+TEST(LangBindHelper_BinaryReallocOverMax)
+{
+    SHARED_GROUP_TEST_PATH(path);
+    const char* key = crypt_key();
+    std::unique_ptr<Replication> hist_w(make_in_realm_history(path));
+    SharedGroup sg_w(*hist_w, SharedGroupOptions(key));
+    Group& g = const_cast<Group&>(sg_w.begin_write());
+
+    g.add_table("table");
+    g.get_table(0)->add_column(type_Binary, "binary_col", false);
+    g.get_table(0)->insert_empty_row(0, 1);
+
+    // The sizes of these binaries were found with AFL. Essentially we must hit
+    // the case where doubling the allocated memory goes above max_array_payload
+    // and hits the condition to clamp to the maximum.
+    std::string blob1(8877637, static_cast<unsigned char>(133));
+    std::string blob2(15994373, static_cast<unsigned char>(133));
+    BinaryData dataAlloc(blob1);
+    BinaryData dataRealloc(blob2);
+
+    g.get_table(0)->set_binary(0, 0, dataAlloc);
+    g.get_table(0)->set_binary(0, 0, dataRealloc);
+    g.verify();
+}
+
+
 #endif


### PR DESCRIPTION
This was found with AFL. 
Requests to reallocate memory should pass an aligned size. Otherwise we hit the assertion in `SlabAlloc::do_realloc` line 511: 

`REALM_ASSERT((new_size & 0x7) == 0); // only allow sizes that are multiples of 8`

The case where it is not aligned is when doubling the existing memory goes past the maximum size allowed `max_array_payload` so we choose to clamp to the maximum. The fix is just to clamp to the maximum aligned value.