### PR TITLE
Fix rollback on mixed binary/string.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,8 @@
 ### Bugfixes
 
 * Fixed a crash when rolling back a transaction which set binary or string data
- inside a Mixed type.
+  inside a Mixed type.
+  PR [#2501](https://github.com/realm/realm-core/pull/2501).
 
 ### Breaking changes
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,8 @@
 
 ### Bugfixes
 
-* Lorem ipsum.
+* Fixed a crash when rolling back a transaction which set binary or string data
+ inside a Mixed type.
 
 ### Breaking changes
 

--- a/src/realm/column_mixed_tpl.hpp
+++ b/src/realm/column_mixed_tpl.hpp
@@ -467,16 +467,8 @@ inline void MixedColumn::refresh_accessor_tree(size_t col_ndx, const Spec& spec)
     get_root_array()->init_from_parent();
     m_types->refresh_accessor_tree(col_ndx, spec); // Throws
     m_data->refresh_accessor_tree(col_ndx, spec);  // Throws
-    if (m_binary_data) {
-        REALM_ASSERT_3(get_root_array()->size(), >=, 3);
-        m_binary_data->refresh_accessor_tree(col_ndx, spec); // Throws
-    }
-    if (m_timestamp_data) {
-        REALM_ASSERT_3(get_root_array()->size(), >=, 4);
-        m_timestamp_data->refresh_accessor_tree(col_ndx, spec); // Throws
-    }
 
-
+    m_binary_data.reset();
     // See if m_binary_data needs to be created.
     if (get_root_array()->size() >= 3) {
         ref_type ref = get_root_array()->get_as_ref(2);
@@ -484,6 +476,7 @@ inline void MixedColumn::refresh_accessor_tree(size_t col_ndx, const Spec& spec)
         m_binary_data->set_parent(get_root_array(), 2);
     }
 
+    m_timestamp_data.reset();
     // See if m_timestamp_data needs to be created.
     if (get_root_array()->size() >= 4) {
         ref_type ref = get_root_array()->get_as_ref(3);
@@ -492,6 +485,15 @@ inline void MixedColumn::refresh_accessor_tree(size_t col_ndx, const Spec& spec)
         // publicly supported
         m_timestamp_data.reset(new TimestampColumn(true /*fixme*/, get_alloc(), ref)); // Throws
         m_timestamp_data->set_parent(get_root_array(), 3);
+    }
+
+    if (m_binary_data) {
+        REALM_ASSERT_3(get_root_array()->size(), >=, 3);
+        m_binary_data->refresh_accessor_tree(col_ndx, spec); // Throws
+    }
+    if (m_timestamp_data) {
+        REALM_ASSERT_3(get_root_array()->size(), >=, 4);
+        m_timestamp_data->refresh_accessor_tree(col_ndx, spec); // Throws
     }
 }
 

--- a/test/test_lang_bind_helper.cpp
+++ b/test/test_lang_bind_helper.cpp
@@ -12918,7 +12918,7 @@ TEST(LangBindHelper_CopyOnWriteOverflow)
     }
 }
 
-ONLY(LangBindHelper_MixedStringRollback)
+TEST(LangBindHelper_MixedStringRollback)
 {
     SHARED_GROUP_TEST_PATH(path);
     const char* key = crypt_key();

--- a/test/test_lang_bind_helper.cpp
+++ b/test/test_lang_bind_helper.cpp
@@ -12926,28 +12926,20 @@ TEST(LangBindHelper_MixedStringRollback)
     SharedGroup sg_w(*hist_w, SharedGroupOptions(key));
     Group& g = const_cast<Group&>(sg_w.begin_write());
 
-    g.add_table("table");
-    g.get_table(0)->add_column(type_Mixed, "mixed_column", false);
-    g.get_table(0)->add_empty_row();
+    TableRef t = g.add_table("table");
+    t->add_column(type_Mixed, "mixed_column", false);
+    t->add_empty_row();
     LangBindHelper::commit_and_continue_as_read(sg_w);
 
     // try with string
     LangBindHelper::promote_to_write(sg_w);
-    {
-        StringData str_data("any string data");
-        Mixed mixed(str_data);
-        g.get_table(0)->set_mixed(0, 0, mixed);
-    }
+    t->set_mixed(0, 0, StringData("any string data"));
     LangBindHelper::rollback_and_continue_as_read(sg_w);
     g.verify();
 
     // do the same with binary data
     LangBindHelper::promote_to_write(sg_w);
-    {
-        BinaryData bin_data("any binary data");
-        Mixed mixed(bin_data);
-        g.get_table(0)->set_mixed(0, 0, mixed);
-    }
+    t->set_mixed(0, 0, BinaryData("any binary data"));
     LangBindHelper::rollback_and_continue_as_read(sg_w);
     g.verify();
 }


### PR DESCRIPTION
Rolling back a transaction which set a Mixed type containing a `StringData` or `BinaryData` would cause an assertion failure because the accessor was not reset while the underlying array structure had made what the accessor referred to disappear. 

The same problem existed for `Timestamp` but I am sure a `Mixed(Timestamp)` has not existed in user data.

This was discovered through AFL after adding instructions for `Mixed` types and has been cherry-picked from #2490 by request, to analyse separately from that PR.