### PR TITLE
Fix rollback of merge_rows with backlinks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,11 @@
 
 ### Bugfixes
 
-* Lorem ipsum.
+* Properly refresh table accessors connected by backlinks to a row that has had
+  a `merge_rows` instruction applied and then rolled back. This could have
+  caused corruption if this scenario was triggered but since sync does not use
+  the `merge_rows` instruction in this way, this is a preventative fix.
+  PR [#2503](https://github.com/realm/realm-core/pull/2503)
 
 ### Breaking changes
 

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -471,7 +471,7 @@ def doBuildAndroid(def isPublishingRun) {
           }
         }
 
-        node('android-hub') {
+        node('fastlinux') {
             sh 'rm -rf *'
             unstash 'android'
 

--- a/src/realm/column_backlink.hpp
+++ b/src/realm/column_backlink.hpp
@@ -71,6 +71,7 @@ public:
     void adj_acc_erase_row(size_t) noexcept override;
     void adj_acc_move_over(size_t, size_t) noexcept override;
     void adj_acc_swap_rows(size_t, size_t) noexcept override;
+    void adj_acc_merge_rows(size_t, size_t) noexcept override;
     void adj_acc_clear_root_table() noexcept override;
     void mark(int) noexcept override;
 
@@ -182,6 +183,14 @@ inline void BacklinkColumn::adj_acc_move_over(size_t from_row_ndx, size_t to_row
 inline void BacklinkColumn::adj_acc_swap_rows(size_t row_ndx_1, size_t row_ndx_2) noexcept
 {
     Column::adj_acc_swap_rows(row_ndx_1, row_ndx_2);
+
+    using tf = _impl::TableFriend;
+    tf::mark(*m_origin_table);
+}
+
+inline void BacklinkColumn::adj_acc_merge_rows(size_t old_row_ndx, size_t new_row_ndx) noexcept
+{
+    Column::adj_acc_merge_rows(old_row_ndx, new_row_ndx);
 
     using tf = _impl::TableFriend;
     tf::mark(*m_origin_table);

--- a/src/realm/impl/transact_log.hpp
+++ b/src/realm/impl/transact_log.hpp
@@ -2434,9 +2434,14 @@ public:
 
     bool merge_rows(size_t row_ndx, size_t new_row_ndx)
     {
-        static_cast<void>(row_ndx);
-        static_cast<void>(new_row_ndx);
         // There is no instruction we can generate here to change back.
+        // However, we do need to refresh accessors for any tables
+        // connected through backlinks, so we generate updates on each
+        // affected row by merging to itself.
+        m_encoder.merge_rows(row_ndx, row_ndx);
+        append_instruction();
+        m_encoder.merge_rows(new_row_ndx, new_row_ndx);
+        append_instruction();
         return true;
     }
 

--- a/test/test_lang_bind_helper.cpp
+++ b/test/test_lang_bind_helper.cpp
@@ -12918,4 +12918,34 @@ TEST(LangBindHelper_CopyOnWriteOverflow)
     }
 }
 
+
+TEST(LangBindHelper_RollbackMergeRowsWithBacklinks)
+{
+    SHARED_GROUP_TEST_PATH(path);
+    const char* key = crypt_key();
+    std::unique_ptr<Replication> hist_w(make_in_realm_history(path));
+    SharedGroup sg_w(*hist_w, SharedGroupOptions(key));
+    Group& g = const_cast<Group&>(sg_w.begin_write());
+
+    g.add_table("table1");
+    g.get_table(0)->add_column(type_Int, "int_col");
+    g.get_table(0)->add_empty_row(2);
+
+    g.add_table("table2");
+    g.get_table(1)->add_column_link(type_Link, "link_col", *g.get_table(0));
+    g.get_table(1)->add_empty_row(1);
+    g.get_table(1)->set_link(0, 0, 1);
+
+    LangBindHelper::commit_and_continue_as_read(sg_w);
+
+    g.verify();
+    LangBindHelper::promote_to_write(sg_w);
+    g.get_table(0)->merge_rows(0, 1);
+    g.verify();
+    LangBindHelper::rollback_and_continue_as_read(sg_w);
+
+    g.verify();
+}
+
+
 #endif


### PR DESCRIPTION
The failing test was found with AFL through #2490. 

The problem is that reversing a `merge_rows` instruction did not trigger a refresh of tables connected by backlinks. This means that after a rollback in this case, a connected table could have the incorrect address which could cause corruption in any following write.  i.e. in the attached test, we find that the last call to `g.verify()` would fail at `REALM_ASSERT_3(ref_in_parent, ==, m_ref);` of the second table because the accessor hasn't been refreshed. 

Note that if the rolled back transaction did contain any other instructions that caused the connected table to be refreshed it would be fine.

The way I propose to trigger a refresh here is to call `merge_rows` twice, merging each affected row into itself sequentially. This will be a no-op except to trigger marking connected tables through the newly implemented `BacklinkColumn::adj_acc_merge_rows`. I chose this solution because although I think the ideal way would be to add a new instruction to trigger a refresh on a table, this would be a file format breaking change.

@simonask what do you think?