### PR TITLE
Mixed timestamp enhancements.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,7 +17,8 @@
 
 ### Enhancements
 
-* Lorem ipsum.
+* Support setting Mixed(Timestamp) through the transaction logs.
+* Implement comparison of Mixed objects containing Timestamp types.
 
 -----------
 

--- a/src/realm/impl/transact_log.hpp
+++ b/src/realm/impl/transact_log.hpp
@@ -2234,8 +2234,9 @@ inline StringData TransactLogParser::read_string(util::StringBuffer& buf)
 
 inline Timestamp TransactLogParser::read_timestamp()
 {
-    REALM_ASSERT(false);
-    return Timestamp{};
+    int64_t seconds = read_int<int64_t>();     // Throws
+    int32_t nanoseconds = read_int<int32_t>(); // Throws
+    return Timestamp(seconds, nanoseconds);
 }
 
 

--- a/src/realm/mixed.hpp
+++ b/src/realm/mixed.hpp
@@ -238,6 +238,11 @@ bool operator!=(Wrap<Mixed>, OldDateTime) noexcept;
 bool operator==(OldDateTime, Wrap<Mixed>) noexcept;
 bool operator!=(OldDateTime, Wrap<Mixed>) noexcept;
 
+// Compare mixed with Timestamp
+bool operator==(Wrap<Mixed>, Timestamp) noexcept;
+bool operator!=(Wrap<Mixed>, Timestamp) noexcept;
+bool operator==(Timestamp, Wrap<Mixed>) noexcept;
+bool operator!=(Timestamp, Wrap<Mixed>) noexcept;
 
 // Implementation:
 
@@ -394,14 +399,11 @@ inline void Mixed::set_olddatetime(OldDateTime v) noexcept
     m_date = v.get_olddatetime();
 }
 
-// LCOV_EXCL_START
 inline void Mixed::set_timestamp(Timestamp v) noexcept
 {
-    REALM_ASSERT(false && "not yet implemented");
     m_type = type_Timestamp;
     m_timestamp = v;
 }
-// LCOV_EXCL_STOP
 
 // LCOV_EXCL_START
 template <class Ch, class Tr>
@@ -649,6 +651,28 @@ inline bool operator==(OldDateTime a, Wrap<Mixed> b) noexcept
 inline bool operator!=(OldDateTime a, Wrap<Mixed> b) noexcept
 {
     return type_OldDateTime != Mixed(b).get_type() || a != OldDateTime(Mixed(b).get_olddatetime());
+}
+
+// Compare mixed with Timestamp
+
+inline bool operator==(Wrap<Mixed> a, Timestamp b) noexcept
+{
+    return Mixed(a).get_type() == type_Timestamp && Timestamp(Mixed(a).get_timestamp()) == b;
+}
+
+inline bool operator!=(Wrap<Mixed> a, Timestamp b) noexcept
+{
+    return Mixed(a).get_type() != type_Timestamp || Timestamp(Mixed(a).get_timestamp()) != b;
+}
+
+inline bool operator==(Timestamp a, Wrap<Mixed> b) noexcept
+{
+    return type_Timestamp == Mixed(b).get_type() && a == Timestamp(Mixed(b).get_timestamp());
+}
+
+inline bool operator!=(Timestamp a, Wrap<Mixed> b) noexcept
+{
+    return type_Timestamp != Mixed(b).get_type() || a != Timestamp(Mixed(b).get_timestamp());
 }
 
 

--- a/test/test_column_mixed.cpp
+++ b/test/test_column_mixed.cpp
@@ -590,4 +590,97 @@ TEST(MixedColumn_SwapRows)
     }
 }
 
+TEST(Mixed_CompareRawTypes)
+{
+    Mixed m;
+    {
+        int64_t equal = 0;
+        int64_t not_equal = 1;
+        m.set_int(equal);
+        CHECK(m == equal);
+        CHECK(m != not_equal);
+        CHECK(equal == m);
+        CHECK(not_equal != m);
+    }
+    {
+        bool equal = false;
+        bool not_equal = true;
+        m.set_bool(equal);
+        CHECK(m == equal);
+        CHECK(m != not_equal);
+        CHECK(equal == m);
+        CHECK(not_equal != m);
+    }
+    {
+        float equal = 1.1f;
+        float not_equal = 1.11f;
+        m.set_float(equal);
+        CHECK(m == equal);
+        CHECK(m != not_equal);
+        CHECK(equal == m);
+        CHECK(not_equal != m);
+    }
+    {
+        double equal = 2.77;
+        double not_equal = 2.89;
+        m.set_double(equal);
+        CHECK(m == equal);
+        CHECK(m != not_equal);
+        CHECK(equal == m);
+        CHECK(not_equal != m);
+    }
+    {
+        char equal_chars [] = { "hello world" };
+        char not_equal_chars [] = { "hello" };
+        StringData equal(equal_chars);
+        StringData not_equal(not_equal_chars);
+        m.set_string(equal);
+        // StringData
+        CHECK(m == equal);
+        CHECK(m != not_equal);
+        CHECK(equal == m);
+        CHECK(not_equal != m);
+        // char *
+        CHECK(m == equal_chars);
+        CHECK(m != not_equal_chars);
+        CHECK(equal_chars == m);
+        CHECK(not_equal_chars != m);
+        // const char *
+        const char* const_equal = equal_chars;
+        const char* const_not_equal = not_equal_chars;
+        CHECK(m == const_equal);
+        CHECK(m != const_not_equal);
+        CHECK(const_equal == m);
+        CHECK(const_not_equal != m);
+    }
+    {
+        BinaryData equal("data");
+        BinaryData not_equal("beta");
+        m.set_binary(equal);
+        CHECK(m == equal);
+        CHECK(m != not_equal);
+        CHECK(equal == m);
+        CHECK(not_equal != m);
+    }
+    {
+        OldDateTime equal(26);
+        OldDateTime not_equal(27);
+        m.set_olddatetime(equal);
+        CHECK(m == equal);
+        CHECK(m != not_equal);
+        CHECK(equal == m);
+        CHECK(not_equal != m);
+    }
+    {
+        Timestamp equal(23, 24);
+        Timestamp not_equal(23, 25);
+        m.set_timestamp(equal);
+        CHECK(m == equal);
+        CHECK(m != not_equal);
+        CHECK(equal == m);
+        CHECK(not_equal != m);
+    }
+}
+
+
 #endif // TEST_COLUMN_MIXED


### PR DESCRIPTION
These changes are motivated by fuzz testing of `Mixed(Timestamp)` types from #2490.

No binding code should be using a `Mixed(Timestamp)` type, so these changes mostly cover our bases for this in the future, but the main point is that we allow the fuzz tester to try all combinations of Mixed types. It is in our public interface so until Mixed is removed (if ever) we should support these operations and test them.