### PR TITLE
Use the stashed workspace instead of a new clone

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -392,7 +392,7 @@ def doBuildNodeInOsx(def isPublishingRun, def isPublishingLatestRun) {
 def doBuildOsxDylibs(def isPublishingRun, def isPublishingLatestRun) {
   return {
     node('macos || osx_vegas') {
-      getSourceArchive()
+      getArchive()
       def version = get_version()
 
       def environment = ['REALM_ENABLE_ENCRYPTION=yes', 'REALM_ENABLE_ASSERTIONS=yes', 'UNITTEST_SHUFFLE=1',

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -65,7 +65,7 @@ try {
         buildNodeOsx: doBuildNodeInOsx(isPublishingRun, isPublishingLatestRun),
         buildAndroid: doBuildAndroid(isPublishingRun),
         buildWindows: doBuildWindows(version, isPublishingRun),
-        buildOsxDylibs: doBuildOsxDylibs(isPublishingRun, isPublishingLatestRun),
+        buildOsxDylibs: doBuildOsxDylibs(version, isPublishingRun, isPublishingLatestRun),
         addressSanitizer: doBuildInDocker('jenkins-pipeline-address-sanitizer')
         //threadSanitizer: doBuildInDocker('jenkins-pipeline-thread-sanitizer')
       ]
@@ -389,11 +389,10 @@ def doBuildNodeInOsx(def isPublishingRun, def isPublishingLatestRun) {
   }
 }
 
-def doBuildOsxDylibs(def isPublishingRun, def isPublishingLatestRun) {
+def doBuildOsxDylibs(def version, def isPublishingRun, def isPublishingLatestRun) {
   return {
     node('macos || osx_vegas') {
       getArchive()
-      def version = get_version()
 
       def environment = ['REALM_ENABLE_ENCRYPTION=yes', 'REALM_ENABLE_ASSERTIONS=yes', 'UNITTEST_SHUFFLE=1',
         'UNITTEST_XML=1', 'UNITTEST_THREADS=1']


### PR DESCRIPTION
Use the stashed workspace instead of a new clone. Both an improvement and a workaround for the known issue with VMware Fusion, NAT, git clone issue that sometimes stalls our CI.