### PR TITLE
Prepare for prefix search

### DIFF
--- a/src/realm/index_string.cpp
+++ b/src/realm/index_string.cpp
@@ -446,9 +446,8 @@ key_type generate_key(key_type upper, key_type lower, int permutation) {
 }
 
 
-template<>
-size_t IndexArray::index_string<index_FindAll_ins>(StringData value, IntegerColumn& result,
-                                                   InternalFindResult& result_ref, ColumnBase* column) const {
+size_t IndexArray::index_string_all_ins(StringData value, IntegerColumn& result,
+                                        InternalFindResult& result_ref, ColumnBase* column) const {
     using key_type = StringIndex::key_type;
     struct WorkItem {
         const char* header;
@@ -578,7 +577,7 @@ void IndexArray::index_string_find_all(IntegerColumn& result, StringData value, 
 {
     InternalFindResult dummy;
     if (case_insensitive) {
-        index_string<index_FindAll_ins>(value, result, dummy, column);
+        index_string_all_ins(value, result, dummy, column);
     } else {
         index_string_all(value, result, dummy, column);
     }

--- a/src/realm/index_string.cpp
+++ b/src/realm/index_string.cpp
@@ -234,9 +234,8 @@ size_t IndexArray::from_list<index_FindAll_ins>(StringData upper_value, IntegerC
 }
 
 
-template <>
-size_t IndexArray::index_string<index_FindAll>(StringData value, IntegerColumn& result,
-                                               InternalFindResult& result_ref, ColumnBase* column) const
+size_t IndexArray::index_string_all(StringData value, IntegerColumn& result,
+                                    InternalFindResult& result_ref, ColumnBase* column) const
 {
     const char* data = m_data;
     const char* header;
@@ -582,7 +581,7 @@ void IndexArray::index_string_find_all(IntegerColumn& result, StringData value, 
     if (case_insensitive) {
         index_string<index_FindAll_ins>(value, result, dummy, column);
     } else {
-        index_string<index_FindAll>(value, result, dummy, column);
+        index_string_all(value, result, dummy, column);
     }
 }
 

--- a/src/realm/index_string.cpp
+++ b/src/realm/index_string.cpp
@@ -197,9 +197,8 @@ size_t IndexArray::from_list<index_FindAll_nocopy>(StringData value, IntegerColu
 }
 
 
-template <>
-size_t IndexArray::from_list<index_FindAll_ins>(StringData upper_value, IntegerColumn& result, InternalFindResult& /*result_ref*/,
-                                                const IntegerColumn& rows, ColumnBase* column) const
+size_t IndexArray::from_list_all_ins(StringData upper_value, IntegerColumn& result, InternalFindResult& /*result_ref*/,
+                                     const IntegerColumn& rows, ColumnBase* column) const
 {
     // The buffer is needed when for when this is an integer index.
     StringIndex::StringConversionBuffer buffer;
@@ -544,7 +543,7 @@ size_t IndexArray::index_string<index_FindAll_ins>(StringData value, IntegerColu
         // List of row indices with common prefix up to this point, in sorted order.
         if (!sub_isindex) {
             const IntegerColumn sub(m_alloc, to_ref(ref));
-            from_list<index_FindAll_ins>(upper_value, result, result_ref, sub, column);
+            from_list_all_ins(upper_value, result, result_ref, sub, column);
             continue;
         }
 

--- a/src/realm/index_string.cpp
+++ b/src/realm/index_string.cpp
@@ -543,8 +543,8 @@ void IndexArray::index_string_all_ins(StringData value, IntegerColumn& result, C
 
 size_t IndexArray::index_string_find_first(StringData value, ColumnBase* column) const
 {
-    InternalFindResult dummy;
-    return index_string<index_FindFirst>(value, dummy, column);
+    InternalFindResult unused;
+    return index_string<index_FindFirst>(value, unused, column);
 }
 
 
@@ -565,8 +565,8 @@ FindRes IndexArray::index_string_find_all_no_copy(StringData value, ColumnBase* 
 
 size_t IndexArray::index_string_count(StringData value, ColumnBase* column) const
 {
-    InternalFindResult dummy2;
-    return index_string<index_Count>(value, dummy2, column);
+    InternalFindResult unused;
+    return index_string<index_Count>(value, unused, column);
 }
 
 IndexArray* StringIndex::create_node(Allocator& alloc, bool is_leaf)

--- a/src/realm/index_string.cpp
+++ b/src/realm/index_string.cpp
@@ -197,8 +197,8 @@ size_t IndexArray::from_list<index_FindAll_nocopy>(StringData value, IntegerColu
 }
 
 
-size_t IndexArray::from_list_all_ins(StringData upper_value, IntegerColumn& result, InternalFindResult& /*result_ref*/,
-                                     const IntegerColumn& rows, ColumnBase* column) const
+void IndexArray::from_list_all_ins(StringData upper_value, IntegerColumn& result, InternalFindResult& /*result_ref*/,
+                                   const IntegerColumn& rows, ColumnBase* column) const
 {
     // The buffer is needed when for when this is an integer index.
     StringIndex::StringConversionBuffer buffer;
@@ -209,14 +209,14 @@ size_t IndexArray::from_list_all_ins(StringData upper_value, IntegerColumn& resu
     if (first_str == last_str) {
         auto first_str_upper = case_map(first_str, true);
         if (first_str_upper != upper_value) {
-            return size_t(FindRes_not_found); // is ignored
+            return;
         }
 
         for (IntegerColumn::const_iterator it = rows.cbegin(); it != rows.cend(); ++it) {
             const size_t row_ndx = to_size_t(*it);
             result.add(row_ndx);
         }
-        return size_t(FindRes_column); // is ignored
+        return;
     }
 
     // special case for very long strings, where they might have a common prefix and end up in the
@@ -229,7 +229,7 @@ size_t IndexArray::from_list_all_ins(StringData upper_value, IntegerColumn& resu
             result.add(row_ndx);
     }
 
-    return size_t(FindRes_column); // is ignored
+    return;
 }
 
 
@@ -446,8 +446,8 @@ key_type generate_key(key_type upper, key_type lower, int permutation) {
 }
 
 
-size_t IndexArray::index_string_all_ins(StringData value, IntegerColumn& result,
-                                        InternalFindResult& result_ref, ColumnBase* column) const {
+void IndexArray::index_string_all_ins(StringData value, IntegerColumn& result,
+                                      InternalFindResult& result_ref, ColumnBase* column) const {
     using key_type = StringIndex::key_type;
     struct WorkItem {
         const char* header;
@@ -549,16 +549,6 @@ size_t IndexArray::index_string_all_ins(StringData value, IntegerColumn& result,
         // Recurse into sub-index;
         const size_t sub_string_offset = string_offset + 4;
         work_list.push_back({sub_header, sub_string_offset, -1});
-    }
-
-    switch (result.size()) {
-        case 0:
-            return FindRes_not_found;
-        case 1:
-            result_ref.payload = to_size_t(result.get(0)); // unsure if this is necessary
-            return FindRes_single;
-        default:
-            return FindRes_column;
     }
 }
 

--- a/src/realm/index_string.cpp
+++ b/src/realm/index_string.cpp
@@ -62,11 +62,9 @@ StringData GetIndexData<Timestamp>::get_index_data(const Timestamp& dt, StringIn
 }
 
 template <>
-size_t IndexArray::from_list<index_FindFirst>(StringData value, InternalFindResult& result_ref,
+size_t IndexArray::from_list<index_FindFirst>(StringData value, InternalFindResult& /* result_ref */,
                                               const IntegerColumn& rows, ColumnBase* column) const
 {
-    static_cast<void>(result_ref);
-
     SortedListComparator slc(*column);
 
     IntegerColumn::const_iterator it_end = rows.cend();
@@ -86,11 +84,9 @@ size_t IndexArray::from_list<index_FindFirst>(StringData value, InternalFindResu
 }
 
 template <>
-size_t IndexArray::from_list<index_Count>(StringData value, InternalFindResult& result_ref, const IntegerColumn& rows,
-                                          ColumnBase* column) const
+size_t IndexArray::from_list<index_Count>(StringData value, InternalFindResult& /* result_ref */,
+                                          const IntegerColumn& rows, ColumnBase* column) const
 {
-    static_cast<void>(result_ref);
-
     SortedListComparator slc(*column);
 
     IntegerColumn::const_iterator it_end = rows.cend();

--- a/src/realm/index_string.cpp
+++ b/src/realm/index_string.cpp
@@ -62,10 +62,9 @@ StringData GetIndexData<Timestamp>::get_index_data(const Timestamp& dt, StringIn
 }
 
 template <>
-size_t IndexArray::from_list<index_FindFirst>(StringData value, IntegerColumn& result, InternalFindResult& result_ref,
+size_t IndexArray::from_list<index_FindFirst>(StringData value, InternalFindResult& result_ref,
                                               const IntegerColumn& rows, ColumnBase* column) const
 {
-    static_cast<void>(result);
     static_cast<void>(result_ref);
 
     SortedListComparator slc(*column);
@@ -87,10 +86,9 @@ size_t IndexArray::from_list<index_FindFirst>(StringData value, IntegerColumn& r
 }
 
 template <>
-size_t IndexArray::from_list<index_Count>(StringData value, IntegerColumn& result, InternalFindResult& result_ref,
-                                          const IntegerColumn& rows, ColumnBase* column) const
+size_t IndexArray::from_list<index_Count>(StringData value, InternalFindResult& result_ref, const IntegerColumn& rows,
+                                          ColumnBase* column) const
 {
-    static_cast<void>(result);
     static_cast<void>(result_ref);
 
     SortedListComparator slc(*column);
@@ -144,12 +142,9 @@ void IndexArray::from_list_all(StringData value, IntegerColumn& result, const In
 }
 
 template <>
-size_t IndexArray::from_list<index_FindAll_nocopy>(StringData value, IntegerColumn& result,
-                                                   InternalFindResult& result_ref, const IntegerColumn& rows,
-                                                   ColumnBase* column) const
+size_t IndexArray::from_list<index_FindAll_nocopy>(StringData value, InternalFindResult& result_ref,
+                                                   const IntegerColumn& rows, ColumnBase* column) const
 {
-    static_cast<void>(result);
-
     SortedListComparator slc(*column);
     IntegerColumn::const_iterator it_end = rows.cend();
     IntegerColumn::const_iterator lower = std::lower_bound(rows.cbegin(), it_end, value, slc);
@@ -314,8 +309,7 @@ void IndexArray::index_string_all(StringData value, IntegerColumn& result, Colum
 
 
 template <IndexMethod method>
-size_t IndexArray::index_string(StringData value, IntegerColumn& result, InternalFindResult& result_ref,
-                                ColumnBase* column) const
+size_t IndexArray::index_string(StringData value, InternalFindResult& result_ref, ColumnBase* column) const
 {
     // Return`realm::not_found`, or an index to the (any) match
     constexpr bool first(method == index_FindFirst);
@@ -392,7 +386,7 @@ size_t IndexArray::index_string(StringData value, IntegerColumn& result, Interna
         // List of row indices with common prefix up to this point, in sorted order.
         if (!sub_isindex) {
             const IntegerColumn sub(m_alloc, to_ref(ref));
-            return from_list<method>(value, result, result_ref, sub, column);
+            return from_list<method>(value, result_ref, sub, column);
         }
 
         // Recurse into sub-index;
@@ -554,8 +548,7 @@ void IndexArray::index_string_all_ins(StringData value, IntegerColumn& result, C
 size_t IndexArray::index_string_find_first(StringData value, ColumnBase* column) const
 {
     InternalFindResult dummy;
-    IntegerColumn dummycol;
-    return index_string<index_FindFirst>(value, dummycol, dummy, column);
+    return index_string<index_FindFirst>(value, dummy, column);
 }
 
 
@@ -571,15 +564,13 @@ void IndexArray::index_string_find_all(IntegerColumn& result, StringData value, 
 FindRes IndexArray::index_string_find_all_no_copy(StringData value, ColumnBase* column,
                                                   InternalFindResult& result) const
 {
-    IntegerColumn dummy;
-    return static_cast<FindRes>(index_string<index_FindAll_nocopy>(value, dummy, result, column));
+    return static_cast<FindRes>(index_string<index_FindAll_nocopy>(value, result, column));
 }
 
 size_t IndexArray::index_string_count(StringData value, ColumnBase* column) const
 {
-    IntegerColumn dummy1;
     InternalFindResult dummy2;
-    return index_string<index_Count>(value, dummy1, dummy2, column);
+    return index_string<index_Count>(value, dummy2, column);
 }
 
 IndexArray* StringIndex::create_node(Allocator& alloc, bool is_leaf)

--- a/src/realm/index_string.cpp
+++ b/src/realm/index_string.cpp
@@ -114,11 +114,9 @@ size_t IndexArray::from_list<index_Count>(StringData value, IntegerColumn& resul
     return cnt;
 }
 
-void IndexArray::from_list_all(StringData value, IntegerColumn& result,InternalFindResult& result_ref,
-                               const IntegerColumn& rows, ColumnBase* column) const
+void IndexArray::from_list_all(StringData value, IntegerColumn& result, const IntegerColumn& rows,
+                               ColumnBase* column) const
 {
-    static_cast<void>(result_ref);
-
     SortedListComparator slc(*column);
 
     IntegerColumn::const_iterator it_end = rows.cend();
@@ -197,8 +195,8 @@ size_t IndexArray::from_list<index_FindAll_nocopy>(StringData value, IntegerColu
 }
 
 
-void IndexArray::from_list_all_ins(StringData upper_value, IntegerColumn& result, InternalFindResult& /*result_ref*/,
-                                   const IntegerColumn& rows, ColumnBase* column) const
+void IndexArray::from_list_all_ins(StringData upper_value, IntegerColumn& result, const IntegerColumn& rows,
+                                   ColumnBase* column) const
 {
     // The buffer is needed when for when this is an integer index.
     StringIndex::StringConversionBuffer buffer;
@@ -233,8 +231,7 @@ void IndexArray::from_list_all_ins(StringData upper_value, IntegerColumn& result
 }
 
 
-void IndexArray::index_string_all(StringData value, IntegerColumn& result,
-                                  InternalFindResult& result_ref, ColumnBase* column) const
+void IndexArray::index_string_all(StringData value, IntegerColumn& result, ColumnBase* column) const
 {
     const char* data = m_data;
     const char* header;
@@ -286,7 +283,6 @@ void IndexArray::index_string_all(StringData value, IntegerColumn& result,
             StringIndex::StringConversionBuffer buffer;
             StringData str = column->get_index_data(row_ndx, buffer);
             if (str == value) {
-                result_ref.payload = row_ndx;
                 result.add(row_ndx);
                 return;
             }
@@ -299,7 +295,7 @@ void IndexArray::index_string_all(StringData value, IntegerColumn& result,
         // List of row indices with common prefix up to this point, in sorted order.
         if (!sub_isindex) {
             const IntegerColumn sub(m_alloc, to_ref(ref));
-            return from_list_all(value, result, result_ref, sub, column);
+            return from_list_all(value, result, sub, column);
         }
 
         // Recurse into sub-index;
@@ -446,8 +442,8 @@ key_type generate_key(key_type upper, key_type lower, int permutation) {
 }
 
 
-void IndexArray::index_string_all_ins(StringData value, IntegerColumn& result,
-                                      InternalFindResult& result_ref, ColumnBase* column) const {
+void IndexArray::index_string_all_ins(StringData value, IntegerColumn& result, ColumnBase* column) const
+{
     using key_type = StringIndex::key_type;
     struct WorkItem {
         const char* header;
@@ -542,7 +538,7 @@ void IndexArray::index_string_all_ins(StringData value, IntegerColumn& result,
         // List of row indices with common prefix up to this point, in sorted order.
         if (!sub_isindex) {
             const IntegerColumn sub(m_alloc, to_ref(ref));
-            from_list_all_ins(upper_value, result, result_ref, sub, column);
+            from_list_all_ins(upper_value, result, sub, column);
             continue;
         }
 
@@ -565,11 +561,10 @@ size_t IndexArray::index_string_find_first(StringData value, ColumnBase* column)
 
 void IndexArray::index_string_find_all(IntegerColumn& result, StringData value, ColumnBase* column, bool case_insensitive) const
 {
-    InternalFindResult dummy;
     if (case_insensitive) {
-        index_string_all_ins(value, result, dummy, column);
+        index_string_all_ins(value, result, column);
     } else {
-        index_string_all(value, result, dummy, column);
+        index_string_all(value, result, column);
     }
 }
 

--- a/src/realm/index_string.cpp
+++ b/src/realm/index_string.cpp
@@ -114,8 +114,8 @@ size_t IndexArray::from_list<index_Count>(StringData value, IntegerColumn& resul
     return cnt;
 }
 
-size_t IndexArray::from_list_all(StringData value, IntegerColumn& result, InternalFindResult& result_ref,
-                                 const IntegerColumn& rows, ColumnBase* column) const
+void IndexArray::from_list_all(StringData value, IntegerColumn& result,InternalFindResult& result_ref,
+                               const IntegerColumn& rows, ColumnBase* column) const
 {
     static_cast<void>(result_ref);
 
@@ -124,7 +124,7 @@ size_t IndexArray::from_list_all(StringData value, IntegerColumn& result, Intern
     IntegerColumn::const_iterator it_end = rows.cend();
     IntegerColumn::const_iterator lower = std::lower_bound(rows.cbegin(), it_end, value, slc);
     if (lower == it_end)
-        return size_t(FindRes_not_found);
+        return;
 
     const size_t first_row_ndx = to_size_t(*lower);
 
@@ -132,7 +132,7 @@ size_t IndexArray::from_list_all(StringData value, IntegerColumn& result, Intern
     StringIndex::StringConversionBuffer buffer;
     StringData str = column->get_index_data(first_row_ndx, buffer);
     if (str != value)
-        return size_t(FindRes_not_found);
+        return;
 
     IntegerColumn::const_iterator upper = std::upper_bound(lower, it_end, value, slc);
 
@@ -142,7 +142,7 @@ size_t IndexArray::from_list_all(StringData value, IntegerColumn& result, Intern
         result.add(cur_row_ndx);
     }
 
-    return size_t(FindRes_column);
+    return;
 }
 
 template <>
@@ -233,8 +233,8 @@ size_t IndexArray::from_list_all_ins(StringData upper_value, IntegerColumn& resu
 }
 
 
-size_t IndexArray::index_string_all(StringData value, IntegerColumn& result,
-                                    InternalFindResult& result_ref, ColumnBase* column) const
+void IndexArray::index_string_all(StringData value, IntegerColumn& result,
+                                  InternalFindResult& result_ref, ColumnBase* column) const
 {
     const char* data = m_data;
     const char* header;
@@ -258,7 +258,7 @@ size_t IndexArray::index_string_all(StringData value, IntegerColumn& result,
 
         // If key is outside range, we know there can be no match
         if (pos == offsets_size)
-            return size_t(FindRes_not_found);
+            return;
 
         // Get entry under key
         size_t pos_refs = pos + 1; // first entry in refs points to offsets
@@ -276,7 +276,7 @@ size_t IndexArray::index_string_all(StringData value, IntegerColumn& result,
         key_type stored_key = key_type(get_direct<32>(offsets_data, pos));
 
         if (stored_key != key)
-            return size_t(FindRes_not_found);
+            return;
 
         // Literal row index (tagged)
         if (ref & 1) {
@@ -288,9 +288,9 @@ size_t IndexArray::index_string_all(StringData value, IntegerColumn& result,
             if (str == value) {
                 result_ref.payload = row_ndx;
                 result.add(row_ndx);
-                return FindRes_single;
+                return;
             }
-            return size_t(FindRes_not_found);
+            return;
         }
 
         const char* sub_header = m_alloc.translate(to_ref(ref));

--- a/src/realm/index_string.cpp
+++ b/src/realm/index_string.cpp
@@ -114,9 +114,8 @@ size_t IndexArray::from_list<index_Count>(StringData value, IntegerColumn& resul
     return cnt;
 }
 
-template <>
-size_t IndexArray::from_list<index_FindAll>(StringData value, IntegerColumn& result, InternalFindResult& result_ref,
-                                            const IntegerColumn& rows, ColumnBase* column) const
+size_t IndexArray::from_list_all(StringData value, IntegerColumn& result, InternalFindResult& result_ref,
+                                 const IntegerColumn& rows, ColumnBase* column) const
 {
     static_cast<void>(result_ref);
 
@@ -302,7 +301,7 @@ size_t IndexArray::index_string<index_FindAll>(StringData value, IntegerColumn& 
         // List of row indices with common prefix up to this point, in sorted order.
         if (!sub_isindex) {
             const IntegerColumn sub(m_alloc, to_ref(ref));
-            return from_list<index_FindAll>(value, result, result_ref, sub, column);
+            return from_list_all(value, result, result_ref, sub, column);
         }
 
         // Recurse into sub-index;

--- a/src/realm/index_string.hpp
+++ b/src/realm/index_string.hpp
@@ -84,8 +84,8 @@ private:
     size_t from_list(StringData value, IntegerColumn& result, InternalFindResult& result_ref,
                      const IntegerColumn& rows, ColumnBase* column) const;
 
-    size_t from_list_all(StringData value, IntegerColumn& result, InternalFindResult& result_ref,
-                         const IntegerColumn& rows, ColumnBase* column) const;
+    void from_list_all(StringData value, IntegerColumn& result, InternalFindResult& result_ref,
+                       const IntegerColumn& rows, ColumnBase* column) const;
 
     size_t from_list_all_ins(StringData value, IntegerColumn& result, InternalFindResult& result_ref,
                              const IntegerColumn& rows, ColumnBase* column) const;
@@ -94,8 +94,8 @@ private:
     size_t index_string(StringData value, IntegerColumn& result, InternalFindResult& result_ref,
                         ColumnBase* column) const;
 
-    size_t index_string_all(StringData value, IntegerColumn& result, InternalFindResult& result_ref,
-                            ColumnBase* column) const;
+    void index_string_all(StringData value, IntegerColumn& result, InternalFindResult& result_ref,
+                          ColumnBase* column) const;
 
     size_t index_string_all_ins(StringData value, IntegerColumn& result, InternalFindResult& result_ref,
                                 ColumnBase* column) const;

--- a/src/realm/index_string.hpp
+++ b/src/realm/index_string.hpp
@@ -96,6 +96,9 @@ private:
 
     size_t index_string_all(StringData value, IntegerColumn& result, InternalFindResult& result_ref,
                             ColumnBase* column) const;
+
+    size_t index_string_all_ins(StringData value, IntegerColumn& result, InternalFindResult& result_ref,
+                                ColumnBase* column) const;
 };
 
 

--- a/src/realm/index_string.hpp
+++ b/src/realm/index_string.hpp
@@ -84,21 +84,18 @@ private:
     size_t from_list(StringData value, IntegerColumn& result, InternalFindResult& result_ref,
                      const IntegerColumn& rows, ColumnBase* column) const;
 
-    void from_list_all(StringData value, IntegerColumn& result, InternalFindResult& result_ref,
-                       const IntegerColumn& rows, ColumnBase* column) const;
+    void from_list_all(StringData value, IntegerColumn& result, const IntegerColumn& rows, ColumnBase* column) const;
 
-    void from_list_all_ins(StringData value, IntegerColumn& result, InternalFindResult& result_ref,
-                           const IntegerColumn& rows, ColumnBase* column) const;
+    void from_list_all_ins(StringData value, IntegerColumn& result, const IntegerColumn& rows,
+                           ColumnBase* column) const;
 
     template <IndexMethod method>
     size_t index_string(StringData value, IntegerColumn& result, InternalFindResult& result_ref,
                         ColumnBase* column) const;
 
-    void index_string_all(StringData value, IntegerColumn& result, InternalFindResult& result_ref,
-                          ColumnBase* column) const;
+    void index_string_all(StringData value, IntegerColumn& result, ColumnBase* column) const;
 
-    void index_string_all_ins(StringData value, IntegerColumn& result, InternalFindResult& result_ref,
-                              ColumnBase* column) const;
+    void index_string_all_ins(StringData value, IntegerColumn& result, ColumnBase* column) const;
 };
 
 

--- a/src/realm/index_string.hpp
+++ b/src/realm/index_string.hpp
@@ -81,8 +81,8 @@ public:
 
 private:
     template <IndexMethod>
-    size_t from_list(StringData value, IntegerColumn& result, InternalFindResult& result_ref,
-                     const IntegerColumn& rows, ColumnBase* column) const;
+    size_t from_list(StringData value, InternalFindResult& result_ref, const IntegerColumn& rows,
+                     ColumnBase* column) const;
 
     void from_list_all(StringData value, IntegerColumn& result, const IntegerColumn& rows, ColumnBase* column) const;
 
@@ -90,8 +90,7 @@ private:
                            ColumnBase* column) const;
 
     template <IndexMethod method>
-    size_t index_string(StringData value, IntegerColumn& result, InternalFindResult& result_ref,
-                        ColumnBase* column) const;
+    size_t index_string(StringData value, InternalFindResult& result_ref, ColumnBase* column) const;
 
     void index_string_all(StringData value, IntegerColumn& result, ColumnBase* column) const;
 

--- a/src/realm/index_string.hpp
+++ b/src/realm/index_string.hpp
@@ -87,6 +87,9 @@ private:
     size_t from_list_all(StringData value, IntegerColumn& result, InternalFindResult& result_ref,
                          const IntegerColumn& rows, ColumnBase* column) const;
 
+    size_t from_list_all_ins(StringData value, IntegerColumn& result, InternalFindResult& result_ref,
+                             const IntegerColumn& rows, ColumnBase* column) const;
+
     template <IndexMethod method>
     size_t index_string(StringData value, IntegerColumn& result, InternalFindResult& result_ref,
                         ColumnBase* column) const;

--- a/src/realm/index_string.hpp
+++ b/src/realm/index_string.hpp
@@ -87,8 +87,8 @@ private:
     void from_list_all(StringData value, IntegerColumn& result, InternalFindResult& result_ref,
                        const IntegerColumn& rows, ColumnBase* column) const;
 
-    size_t from_list_all_ins(StringData value, IntegerColumn& result, InternalFindResult& result_ref,
-                             const IntegerColumn& rows, ColumnBase* column) const;
+    void from_list_all_ins(StringData value, IntegerColumn& result, InternalFindResult& result_ref,
+                           const IntegerColumn& rows, ColumnBase* column) const;
 
     template <IndexMethod method>
     size_t index_string(StringData value, IntegerColumn& result, InternalFindResult& result_ref,
@@ -97,8 +97,8 @@ private:
     void index_string_all(StringData value, IntegerColumn& result, InternalFindResult& result_ref,
                           ColumnBase* column) const;
 
-    size_t index_string_all_ins(StringData value, IntegerColumn& result, InternalFindResult& result_ref,
-                                ColumnBase* column) const;
+    void index_string_all_ins(StringData value, IntegerColumn& result, InternalFindResult& result_ref,
+                              ColumnBase* column) const;
 };
 
 

--- a/src/realm/index_string.hpp
+++ b/src/realm/index_string.hpp
@@ -90,6 +90,9 @@ private:
     template <IndexMethod method>
     size_t index_string(StringData value, IntegerColumn& result, InternalFindResult& result_ref,
                         ColumnBase* column) const;
+
+    size_t index_string_all(StringData value, IntegerColumn& result, InternalFindResult& result_ref,
+                            ColumnBase* column) const;
 };
 
 

--- a/src/realm/index_string.hpp
+++ b/src/realm/index_string.hpp
@@ -84,6 +84,9 @@ private:
     size_t from_list(StringData value, IntegerColumn& result, InternalFindResult& result_ref,
                      const IntegerColumn& rows, ColumnBase* column) const;
 
+    size_t from_list_all(StringData value, IntegerColumn& result, InternalFindResult& result_ref,
+                         const IntegerColumn& rows, ColumnBase* column) const;
+
     template <IndexMethod method>
     size_t index_string(StringData value, IntegerColumn& result, InternalFindResult& result_ref,
                         ColumnBase* column) const;

--- a/src/realm/utilities.hpp
+++ b/src/realm/utilities.hpp
@@ -188,7 +188,6 @@ enum FindRes {
 enum IndexMethod {
     index_FindFirst,
     index_FindAll_nocopy,
-    index_FindAll_ins,
     index_Count,
 };
 

--- a/src/realm/utilities.hpp
+++ b/src/realm/utilities.hpp
@@ -187,7 +187,6 @@ enum FindRes {
 
 enum IndexMethod {
     index_FindFirst,
-    index_FindAll,
     index_FindAll_nocopy,
     index_FindAll_ins,
     index_Count,


### PR DESCRIPTION
This is a number of refactoring to prepare for the search index support for the different combinations of case sensitive / case insensitive / prefix / full string searches. The idea is that the current "find all" (aka those that return results in a column) functions will be merged to support all use cases.

Each commit here corresponds to a simple change (that in a better world would be done by a tool). Should be trivial to review commit by commit.