### PR TITLE
Remove parameter exposing non-existent functionality

### DIFF
--- a/src/realm/column_string.cpp
+++ b/src/realm/column_string.cpp
@@ -848,13 +848,13 @@ size_t StringColumn::find_first(StringData value, size_t begin, size_t end) cons
 }
 
 
-void StringColumn::find_all(IntegerColumn& result, StringData value, size_t begin, size_t end, bool case_insensitive) const
+void StringColumn::find_all(IntegerColumn& result, StringData value, size_t begin, size_t end) const
 {
     REALM_ASSERT_3(begin, <=, size());
     REALM_ASSERT(end == npos || (begin <= end && end <= size()));
 
     if (m_search_index && begin == 0 && end == npos) {
-        m_search_index->find_all(result, value, case_insensitive); // Throws
+        m_search_index->find_all(result, value); // Throws
         return;
     }
 

--- a/src/realm/column_string.hpp
+++ b/src/realm/column_string.hpp
@@ -72,7 +72,7 @@ public:
 
     size_t count(StringData value) const;
     size_t find_first(StringData value, size_t begin = 0, size_t end = npos) const;
-    void find_all(IntegerColumn& result, StringData value, size_t begin = 0, size_t end = npos, bool case_insensitive = false) const;
+    void find_all(IntegerColumn& result, StringData value, size_t begin = 0, size_t end = npos) const;
     FindRes find_all_no_copy(StringData value, InternalFindResult& result) const;
 
     int compare_values(size_t, size_t) const noexcept override;

--- a/test/test_index_string.cpp
+++ b/test/test_index_string.cpp
@@ -1845,7 +1845,7 @@ TEST_TYPES(StringIndex_45, non_nullable, nullable)
 
     ref_type ref = StringColumn::create(Allocator::get_default());
     StringColumn col(Allocator::get_default(), ref, nullable);
-    col.create_search_index();
+    const StringIndex& ndx = *col.create_search_index();
     std::string a4 = std::string(4, 'a');
     std::string A5 = std::string(5, 'A');
 
@@ -1855,7 +1855,7 @@ TEST_TYPES(StringIndex_45, non_nullable, nullable)
     ref_type results_ref = IntegerColumn::create(Allocator::get_default());
     IntegerColumn res(Allocator::get_default(), results_ref);
 
-    col.find_all(res, A5, 0, realm::npos, true);
+    ndx.find_all(res, A5.c_str(), true);
     CHECK_EQUAL(res.size(), 0);
 
     res.destroy();
@@ -1896,7 +1896,7 @@ TEST_TYPES(StringIndex_Insensitive_Fuzz, non_nullable, nullable)
             col.add(str);
         }
 
-        col.create_search_index();
+        const StringIndex& ndx = *col.create_search_index();
 
         for (size_t t = 0; t < 1000; t++) {
             std::string needle = create_random_a_string(max_str_len);
@@ -1904,7 +1904,7 @@ TEST_TYPES(StringIndex_Insensitive_Fuzz, non_nullable, nullable)
             ref_type results_ref = IntegerColumn::create(Allocator::get_default());
             IntegerColumn res(Allocator::get_default(), results_ref);
 
-            col.find_all(res, needle, 0, realm::npos, true);
+            ndx.find_all(res, needle.c_str(), true);
 
             // Check that all items in 'res' point at a match in 'col'
             auto needle_upper = case_map(needle, true);
@@ -1954,7 +1954,7 @@ TEST_TYPES(StringIndex_Insensitive_VeryLongStrings, non_nullable, nullable)
     ref_type results_ref = IntegerColumn::create(Allocator::get_default());
     IntegerColumn results(Allocator::get_default(), results_ref);
 
-    col.find_all(results, long1, 0, realm::npos, true);
+    ndx.find_all(results, long1.c_str(), true);
     CHECK_EQUAL(results.size(), 4);
     results.clear();
     ndx.find_all(results, long2.c_str(), true);


### PR DESCRIPTION
`StringColumn::find_all(...)` does not support case insensitive searches. I accidentally added the parameter when doing the string index implementation for such searches. However, it only worked if there was an index on the column, otherwise the parameter would be ignored. To get the index optimised searches, the `StringIndex::find_all(...)` should be used directly.

This PR removes that parameter and changes the unit tests to use the `StringIndex` directly.