### PR TITLE
Initialise distance in SizeNode.

### DIFF
--- a/src/realm/query_engine.hpp
+++ b/src/realm/query_engine.hpp
@@ -929,6 +929,12 @@ public:
         do_verify_column(m_condition_column);
     }
 
+    void init() override
+    {
+        ParentNode::init();
+        m_dD = 10.0;
+    }
+
     size_t find_first_local(size_t start, size_t end) override
     {
         for (size_t s = start; s < end; ++s) {


### PR DESCRIPTION
Otherwise the `m_dD` of `ParentNode` will be used uninitialised.
Please check that it is initialised to the correct value.

This should fix the valgrind error here: https://ci.realm.io/job/core_valgrind/654/