### PR TITLE
Performance support for cmake

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -3,7 +3,7 @@
 cocoaStashes = []
 androidStashes = []
 
-timeout(time: 1, unit: 'HOURS') {
+timeout(time: 5, unit: 'HOURS') {
     stage('gather-info') {
         node('docker') {
             getSourceArchive()

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -316,15 +316,6 @@ def buildPerformance() {
     node('docker && brix && exclusive') {
       getSourceArchive()
 
-      def gitTag = readGitTag()
-      def gitSha = readGitSha()
-
-      if (gitTag == "") {
-        setBuildName(gitSha)
-      } else {
-        setBuildName("Tag ${gitTag}")
-      }
-
       def buildEnv = buildDockerEnv('ci/realm-core:snapshot')
       // REALM_BENCH_DIR tells the gen_bench_hist.sh script where to place results
       // REALM_BENCH_MACHID gives the results an id - results are organized by hardware to prevent mixing cached results with runs on different machines

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -1,5 +1,8 @@
 add_subdirectory(util)
 add_subdirectory(fuzzy)
+add_subdirectory(benchmark-common-tasks)
+add_subdirectory(benchmark-crud)
+# FIXME: Add other benchmarks
 
 set(NORMAL_TESTS
     test_all.cpp
@@ -105,12 +108,3 @@ target_include_directories(realm-tests PUBLIC ${EXTRA_TEST_CFLAGS})
 
 add_test(NAME RealmTests COMMAND realm-tests)
 
-add_executable(realm-benchmark-common-tasks benchmark-common-tasks/main.cpp benchmark-common-tasks/compatibility.cpp)
-target_link_libraries(realm-benchmark-common-tasks ${PLATFORM_LIBRARIES} test-util)
-add_test(RealmBenchmarkCommonTasks realm-benchmark-common-tasks)
-
-add_executable(realm-benchmark-crud benchmark-crud/main.cpp)
-target_link_libraries(realm-benchmark-crud ${PLATFORM_LIBRARIES} test-util)
-add_test(RealmBenchmarkCrud realm-benchmark-crud)
-
-# FIXME: Add other benchmarks

--- a/test/bench/gen_bench.sh
+++ b/test/bench/gen_bench.sh
@@ -109,7 +109,7 @@ else
         cd ../..
     else
         rootdir=$(git rev-parse --show-toplevel)
-        sh ./util/build_core.sh "${remoteref}" "${rootdir}"
+        REALM_BENCH_CHECKOUT_ONLY=1 sh ./util/build_core.sh "${remoteref}" "${rootdir}"
         if [ ! -d "core-builds/${remoteref}" ]; then
             echo "fatal error: core checkout failed on ref: ${remoteref}"
             ls -lah
@@ -135,6 +135,11 @@ else
     fi
     # input 1: path to top level of checkout to build, input 2: destination for results
     sh "${build_bench_script}" . bench_results
+    ret=$?
+    if [ $ret -gt 0 ]; then
+        echo "Error building benchmarks! Exiting."
+        exit 1
+    fi
     echo "writing results to ${outputfile}"
     # print common header
     head -n 1 "bench_results/benchmark-common-tasks/results.latest.csv" > "${outputfile}"

--- a/test/bench/gen_bench.sh
+++ b/test/bench/gen_bench.sh
@@ -1,6 +1,6 @@
 #!/bin/sh
 #
-# See ./util/gen_bench.sh --help for documentation.
+# See ./gen_bench.sh --help for documentation.
 
 
 #The first line of the file "benchmark_version" holds the
@@ -84,7 +84,6 @@ if [ $ret -gt 0 ]; then
 fi
 unixtime=$(git show -s --format=%at ${remoteref})
 
-
 if [ -z "$REALM_BENCH_DIR" ]; then
     REALM_BENCH_DIR=~/.realm/core/benchmarks
 fi
@@ -104,6 +103,7 @@ if [ -f "${outputfile}" ]; then
     echo "found results, skipping ${outputfile}"
 else
     headref=$(git rev-parse HEAD)
+    build_bench_script=$(pwd)/util/build_benchmarks.sh
     if [ "${headref}" = "${remoteref}" ]; then
         echo "building HEAD"
         cd ../..
@@ -133,14 +133,14 @@ else
         cp benchmark_results.hpp benchmark_results.cpp "../bench/core-builds/${remoteref}/src/test/util/"
         cd "../bench/core-builds/${remoteref}/src/"
     fi
-    sh build.sh benchmark-common-tasks
-    sh build.sh benchmark-crud
+    # input 1: path to top level of checkout to build, input 2: destination for results
+    sh "${build_bench_script}" . bench_results
     echo "writing results to ${outputfile}"
     # print common header
-    head -n 1 "test/benchmark-common-tasks/results.latest.csv" > "${outputfile}"
+    head -n 1 "bench_results/benchmark-common-tasks/results.latest.csv" > "${outputfile}"
     # print contents, add _EncryptionOff tag to names without encryption (backwards compatibility)
-    tail -n +2 "test/benchmark-common-tasks/results.latest.csv" | perl -wpe "s/^\"(((?!EncryptionO[nf]+).)*)\"/\"\$1_EncryptionOff\"/" >> "${outputfile}"
-    tail -n +2 "test/benchmark-crud/results.latest.csv" | perl -wpe "s/^\"(((?!EncryptionO[nf]+).)*)\"/\"\$1_EncryptionOff\"/" >> "${outputfile}"
+    tail -n +2 "bench_results/benchmark-common-tasks/results.latest.csv" | perl -wpe "s/^\"(((?!EncryptionO[nf]+).)*)\"/\"\$1_EncryptionOff\"/" >> "${outputfile}"
+    tail -n +2 "bench_results/benchmark-crud/results.latest.csv" | perl -wpe "s/^\"(((?!EncryptionO[nf]+).)*)\"/\"\$1_EncryptionOff\"/" >> "${outputfile}"
 
     if [ "${headref}" != "${remoteref}" ]; then
         cd ../..

--- a/test/bench/util/build_benchmarks.sh
+++ b/test/bench/util/build_benchmarks.sh
@@ -1,0 +1,111 @@
+#!/bin/sh
+#
+# See ./util/build-benchmarks.sh --help for documentation.
+
+showUsage () {
+  cat <<EOF
+Usage: $0 [-h|--help] [dir] [dest]
+EOF
+}
+
+showHelp () {
+  echo ""
+  showUsage
+  echo ""
+  cat <<EOF
+./util/build-benchmarks.sh
+
+This script builds and runs benchmarks used in the performance scripts.
+This is currently benchmark-common-tasks and benchmark-crud.
+It assumes that the current directory is the top level to build from,
+unless [dir] is specified.
+It will copy the benchmark results into named folders in [dest] which
+is set to "benchmark_results" by default.
+
+Examples:
+
+$ ./test/bench/util/build_benchmarks.sh  # builds from current directory
+$ ./util/build_benchmarks.sh ../..       # builds benchmarks from top dir
+$ ./util/build_benchmarks.sh ../.. res   # builds benchmkars from top dir into res
+
+EOF
+}
+
+while [ $# -gt 0 ]; do
+  case "$1" in
+    -h | --help )
+      showHelp
+      exit 0
+      ;;
+    * )
+      break
+      ;;
+  esac
+done
+
+if [ $# -gt 2 ]; then
+  showUsage
+  exit 1
+elif [ $# -eq 0 ]; then
+  directory=$(pwd)
+  dest=$(pwd)"/benchmark_results"
+elif [ $# -eq 1 ]; then
+  directory=$1
+  dest=$(pwd)"/benchmark_results"
+elif [ $# -eq 2 ]; then
+  directory=$1
+  dest=$2
+fi
+
+pushd "${directory}"
+
+build_system="shell"
+if [ -e "CMakeLists.txt" ] && [ ! -e "build.sh" ]; then
+  build_system="cmake"
+fi
+
+if [ "$build_system" == "cmake" ]; then
+  # for cmake we operate in a separate build directory
+  mkdir -p build
+  pushd build
+  cmake ..
+  make realm-benchmark-common-tasks
+  # -x flag checks if the file exists and is executable
+  if [ -x test/benchmark-common-tasks/realm-benchmark-common-tasks ]; then
+    pushd test/benchmark-common-tasks
+    ./realm-benchmark-common-tasks
+    popd
+  else
+    echo "Could not run benchmark-common-tasks!"
+    exit 1
+  fi
+  make realm-benchmark-crud
+  if [ -x test/benchmark-crud/realm-benchmark-crud ]; then
+    pushd test/benchmark-crud
+    ./realm-benchmark-crud
+    popd
+  else
+    echo "Could not run benchmark-crud!"
+    exit 1
+  fi
+  popd # build
+
+  result_prefix="build"
+
+elif [ "$build_system" == "shell" ]; then
+  sh build.sh benchmark-common-tasks
+  sh build.sh benchmark-crud
+  result_prefix="."
+else
+  echo "Unknown build system!"
+  exit 1
+fi
+
+popd # ${directory}
+
+# copy result files to destination
+mkdir -p "${dest}/benchmark-common-tasks"
+mkdir -p "${dest}/benchmark-crud"
+cp "${directory}/${result_prefix}"/test/benchmark-common-tasks/results* "${dest}/benchmark-common-tasks/"
+cp "${directory}/${result_prefix}"/test/benchmark-crud/results* "${dest}/benchmark-crud/"
+

--- a/test/bench/util/build_benchmarks.sh
+++ b/test/bench/util/build_benchmarks.sh
@@ -71,16 +71,17 @@ if [ "$build_system" == "cmake" ]; then
   cmake ..
   make realm-benchmark-common-tasks
   # -x flag checks if the file exists and is executable
-  if [ -x test/benchmark-common-tasks/realm-benchmark-common-tasks ]; then
+  if [ -x ./test/benchmark-common-tasks/realm-benchmark-common-tasks ]; then
     pushd test/benchmark-common-tasks
     ./realm-benchmark-common-tasks
     popd
   else
     echo "Could not run benchmark-common-tasks!"
+    pwd
     exit 1
   fi
   make realm-benchmark-crud
-  if [ -x test/benchmark-crud/realm-benchmark-crud ]; then
+  if [ -x ./test/benchmark-crud/realm-benchmark-crud ]; then
     pushd test/benchmark-crud
     ./realm-benchmark-crud
     popd

--- a/test/bench/util/build_core.sh
+++ b/test/bench/util/build_core.sh
@@ -1,6 +1,6 @@
 #!/bin/sh
 #
-# See ./util/build-core.sh --help for documentation.
+# See ./util/build_core.sh --help for documentation.
 
 builddir=./core-builds
 
@@ -15,7 +15,7 @@ showHelp () {
   showUsage
   echo ""
   cat <<EOF
-./util/build-core.sh
+./util/build_core.sh
 
 This script builds the given version of core (branch, commit, or tag) in a
 dedicated ${builddir} directory. This enables, for instance, comparing the
@@ -27,12 +27,15 @@ existing repository as an alternate will require fewer objects to be
 copied from the repository being cloned, reducing network and local
 storage costs.
 
+You can set the environment variable REALM_BENCH_CHECKOUT_ONLY if you 
+just want the checkout and don't want to actually build all of core.
+
 Examples:
 
-$ ./util/build-core.sh master # master is assumed by default.
-$ ./util/build-core.sh tags/v0.97.3 # Tags must be prefixed with "tags/".
-$ ./util/build-core.sh ea310804 # Can be a short commit ID.
-$ ./util/build-core.sh 32b3b79d2ab90e784ad5f14f201d682be9746781
+$ ./util/build_core.sh master # master is assumed by default.
+$ ./util/build_core.sh tags/v0.97.3 # Tags must be prefixed with "tags/".
+$ ./util/build_core.sh ea310804 # Can be a short commit ID.
+$ ./util/build_core.sh 32b3b79d2ab90e784ad5f14f201d682be9746781
 
 This results in directories:
 
@@ -147,5 +150,7 @@ else
   checkout
 fi
 
-build
+if [ -z "$REALM_BENCH_CHECKOUT_ONLY" ]; then
+  build
+fi
 

--- a/test/bench/util/build_core.sh
+++ b/test/bench/util/build_core.sh
@@ -85,6 +85,50 @@ checkout () {
   fi
 
   git checkout "${remoteref}"
+  build_system="shell"
+  if [ -e "CMakeLists.txt" ] && [ ! -e "build.sh" ]; then
+    build_system="cmake"
+  fi
+}
+
+clean () {
+  if [ "$build_system" == "cmake" ]; then
+    mkdir -p build
+    pushd build
+    cmake ..
+    make clean
+    popd
+  elif [ "$build_system" == "shell" ]; then
+    sh build.sh clean
+  else
+    echo "Unknown build system!"
+    exit 1
+  fi
+}
+
+configure () {
+  if [ "$build_system" == "cmake" ]; then
+    : # this was taken care of by cmake
+  elif [ "$build_system" == "shell" ]; then
+    sh build.sh config "${basedir}"
+  else
+    echo "Unknown build system!"
+    exit 1
+  fi
+}
+
+build () {
+  if [ "$build_system" == "cmake" ]; then
+    mkdir -p build
+    pushd build
+    make
+    popd
+  elif [ "$build_system" == "shell" ]; then
+    sh build.sh build
+  else
+    echo "Unknown build system!"
+    exit 1
+  fi
 }
 
 if [ ! -d "${srcdir}" ]; then
@@ -95,13 +139,13 @@ if [ ! -d "${srcdir}" ]; then
   fi
   cd "${srcdir}"
   checkout
-  sh build.sh clean
-  sh build.sh config "${basedir}"
+  clean
+  configure
 else
   cd "${srcdir}"
   git fetch
   checkout
 fi
 
-sh build.sh build
-sh build.sh install
+build
+

--- a/test/benchmark-common-tasks/CMakeLists.txt
+++ b/test/benchmark-common-tasks/CMakeLists.txt
@@ -1,0 +1,3 @@
+add_executable(realm-benchmark-common-tasks main.cpp compatibility.cpp)
+target_link_libraries(realm-benchmark-common-tasks ${PLATFORM_LIBRARIES} test-util)
+add_test(RealmBenchmarkCommonTasks realm-benchmark-common-tasks)

--- a/test/benchmark-crud/CMakeLists.txt
+++ b/test/benchmark-crud/CMakeLists.txt
@@ -1,0 +1,3 @@
+add_executable(realm-benchmark-crud main.cpp)
+target_link_libraries(realm-benchmark-crud ${PLATFORM_LIBRARIES} test-util)
+add_test(RealmBenchmarkCrud realm-benchmark-crud)


### PR DESCRIPTION
This enables the performance scripts to checkout, build, and benchmark versions of core using either cmake or a build.sh type system.

Each benchmark program now gets its own subdirectory in CMake because results are written to the same directory in files that would overwrite each other and get mixed up between benchmark programs.

The Jenkinsfile code is copied from master verbatim.

Build time should decrease because I made an optimisation to not bother building the whole test suite since we only care about the benchmarks.