### PR TITLE
Add a helper function to allow declaring an overload set using lambdas

### DIFF
--- a/Visual Studio/Realm.vcxproj
+++ b/Visual Studio/Realm.vcxproj
@@ -2498,6 +2498,7 @@
     <ClInclude Include="..\src\realm\util\memory_stream.hpp" />
     <ClInclude Include="..\src\realm\util\misc_errors.hpp" />
     <ClInclude Include="..\src\realm\util\optional.hpp" />
+    <ClInclude Include="..\src\realm\util\overload.hpp" />
     <ClInclude Include="..\src\realm\util\priority_queue.hpp" />
     <ClInclude Include="..\src\realm\util\shared_ptr.hpp" />
     <ClInclude Include="..\src\realm\util\terminate.hpp" />

--- a/realm.xcodeproj/project.pbxproj
+++ b/realm.xcodeproj/project.pbxproj
@@ -344,6 +344,11 @@
 		52F2E0E317D5F92F00415958 /* test_column_large.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 52F2E0E217D5F92F00415958 /* test_column_large.cpp */; };
 		52F2E0E517D5F93D00415958 /* test_strings.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 52F2E0E417D5F93D00415958 /* test_strings.cpp */; };
 		52F6359416B43C79006117C4 /* alloc.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 52F6359316B43C79006117C4 /* alloc.cpp */; };
+		5D0D11CC1E81A6E00085D363 /* overload.hpp in Headers */ = {isa = PBXBuildFile; fileRef = 5D0D11CB1E81A6E00085D363 /* overload.hpp */; };
+		5D0D11CD1E81A6E70085D363 /* overload.hpp in Headers */ = {isa = PBXBuildFile; fileRef = 5D0D11CB1E81A6E00085D363 /* overload.hpp */; };
+		5D0D11CE1E81A6E70085D363 /* overload.hpp in Headers */ = {isa = PBXBuildFile; fileRef = 5D0D11CB1E81A6E00085D363 /* overload.hpp */; };
+		5D0D11D11E81AAC20085D363 /* test_util_overload.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 5D0D11CF1E81A9F00085D363 /* test_util_overload.cpp */; };
+		5D0D11D21E81AAC60085D363 /* test_util_overload.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 5D0D11CF1E81A9F00085D363 /* test_util_overload.cpp */; };
 		5D16ACBA1E663E4500209768 /* string_data.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 5D16ACB91E663E4500209768 /* string_data.cpp */; };
 		5D16ACBB1E663E5D00209768 /* string_data.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 5D16ACB91E663E4500209768 /* string_data.cpp */; };
 		5D16ACBC1E663E5D00209768 /* string_data.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 5D16ACB91E663E4500209768 /* string_data.cpp */; };
@@ -911,6 +916,8 @@
 		52F2E0E217D5F92F00415958 /* test_column_large.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = test_column_large.cpp; path = large_tests/test_column_large.cpp; sourceTree = "<group>"; };
 		52F2E0E417D5F93D00415958 /* test_strings.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = test_strings.cpp; path = large_tests/test_strings.cpp; sourceTree = "<group>"; };
 		52F6359316B43C79006117C4 /* alloc.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = alloc.cpp; path = realm/alloc.cpp; sourceTree = "<group>"; };
+		5D0D11CB1E81A6E00085D363 /* overload.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; path = overload.hpp; sourceTree = "<group>"; };
+		5D0D11CF1E81A9F00085D363 /* test_util_overload.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = test_util_overload.cpp; sourceTree = "<group>"; };
 		5D16ACB91E663E4500209768 /* string_data.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = string_data.cpp; path = realm/string_data.cpp; sourceTree = "<group>"; };
 		5D3205831C880F4B00864053 /* call_with_tuple.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; path = call_with_tuple.hpp; sourceTree = "<group>"; };
 		5D3205851C880F4B00864053 /* miscellaneous.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; path = miscellaneous.hpp; sourceTree = "<group>"; };
@@ -1334,6 +1341,7 @@
 				B6F92D3A1D4611D900887B4E /* test_util_file.cpp */,
 				65F666EB1BFD012900749FA2 /* test_util_inspect.cpp */,
 				651D389B1D25440A006DBCC5 /* test_util_logger.cpp */,
+				5D0D11CF1E81A9F00085D363 /* test_util_overload.cpp */,
 				651D389C1D25440A006DBCC5 /* test_util_scope_exit.cpp */,
 				65F666EC1BFD012900749FA2 /* test_util_stringbuffer.cpp */,
 				B67A2D381D1D5C1F00F0A0E7 /* test_util_to_string.cpp */,
@@ -1473,6 +1481,7 @@
 				485231131B2E9118003C72AF /* misc_errors.hpp */,
 				5D3205851C880F4B00864053 /* miscellaneous.hpp */,
 				65F35E0D1B32FBDC006AE5A9 /* optional.hpp */,
+				5D0D11CB1E81A6E00085D363 /* overload.hpp */,
 				F44F0AD61BB9502C000C4ABA /* priority_queue.hpp */,
 				52D7C4711852A01700633748 /* safe_int_ops.hpp */,
 				65F667001BFD01DC00749FA2 /* scope_exit.hpp */,
@@ -1665,6 +1674,7 @@
 				5D3205891C880F4B00864053 /* miscellaneous.hpp in Headers */,
 				365CCE5F157CC37D00172BF8 /* mixed.hpp in Headers */,
 				650FBA3D1C84954C00F8771B /* null.hpp in Headers */,
+				5D0D11CC1E81A6E00085D363 /* overload.hpp in Headers */,
 				52D6E069175BDBDD00B423E5 /* number_names.hpp in Headers */,
 				365CCE56157CC37D00172BF8 /* olddatetime.hpp in Headers */,
 				3620DF1218B6CA7B003AD498 /* output_stream.hpp in Headers */,
@@ -1742,6 +1752,7 @@
 				4142C9771623478700B3B902 /* query_engine.hpp in Headers */,
 				4142C9861623478700B3B902 /* realm.hpp in Headers */,
 				C0552C571B45CEA8007FF3AA /* simulated_failure.hpp in Headers */,
+				5D0D11CD1E81A6E70085D363 /* overload.hpp in Headers */,
 				4142C9791623478700B3B902 /* spec.hpp in Headers */,
 				4142C9801623478700B3B902 /* table.hpp in Headers */,
 				4142C97D1623478700B3B902 /* table_ref.hpp in Headers */,
@@ -1824,6 +1835,7 @@
 				C008FF931B67F02F0042669E /* type_traits.hpp in Headers */,
 				C008FF941B67F02F0042669E /* utilities.hpp in Headers */,
 				C008FF951B67F02F0042669E /* version.hpp in Headers */,
+				5D0D11CE1E81A6E70085D363 /* overload.hpp in Headers */,
 				D4AC5C2F1D5BAFD700E3D29D /* version_id.hpp in Headers */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -2234,6 +2246,7 @@
 				3F838D0D1D35A1ED004625B7 /* test_array.cpp in Sources */,
 				3F838D0E1D35A1ED004625B7 /* test_array_binary.cpp in Sources */,
 				3F838D0F1D35A1ED004625B7 /* test_array_blob.cpp in Sources */,
+				5D0D11D11E81AAC20085D363 /* test_util_overload.cpp in Sources */,
 				3F838D101D35A1ED004625B7 /* test_array_blobs_big.cpp in Sources */,
 				3F838D111D35A1ED004625B7 /* test_array_float.cpp in Sources */,
 				3F838D121D35A1ED004625B7 /* test_array_integer.cpp in Sources */,
@@ -2515,6 +2528,7 @@
 				3F838D021D35A1EA004625B7 /* test_util_stringbuffer.cpp in Sources */,
 				3F838D031D35A1EA004625B7 /* test_util_to_string.cpp in Sources */,
 				3F838D041D35A1EA004625B7 /* test_util_type_list.cpp in Sources */,
+				5D0D11D21E81AAC60085D363 /* test_util_overload.cpp in Sources */,
 				3F838D061D35A1EA004625B7 /* test_version.cpp in Sources */,
 				F45013BA1B01022800CD4A7E /* ViewController.mm in Sources */,
 			);

--- a/src/realm/Makefile
+++ b/src/realm/Makefile
@@ -18,6 +18,7 @@ util/basic_system_errors.hpp \
 util/thread.hpp \
 util/file.hpp \
 util/optional.hpp \
+util/overload.hpp \
 util/utf8.hpp \
 util/priority_queue.hpp \
 util/interprocess_condvar.hpp \

--- a/src/realm/util/overload.hpp
+++ b/src/realm/util/overload.hpp
@@ -1,0 +1,70 @@
+/*************************************************************************
+ *
+ * Copyright 2017 Realm Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ **************************************************************************/
+
+#ifndef REALM_UTIL_OVERLOAD_HPP
+#define REALM_UTIL_OVERLOAD_HPP
+
+#include <utility>
+
+namespace realm {
+
+namespace _impl {
+
+template<typename Fn, typename... Fns>
+struct Overloaded;
+
+} // namespace _impl
+
+
+namespace util {
+
+// Declare an overload set using lambdas or other function objects.
+// A minimal version of C++ Library Evolution Working Group proposal P0051R2.
+
+template<typename... Fns>
+_impl::Overloaded<Fns...> overload(Fns&&... f)
+{
+    return _impl::Overloaded<Fns...>(std::forward<Fns>(f)...);
+}
+
+} // namespace util
+
+
+namespace _impl {
+
+template<typename Fn, typename... Fns>
+struct Overloaded : Fn, Overloaded<Fns...> {
+    template<typename U, typename... Rest>
+    Overloaded(U&& fn, Rest&&... rest) : Fn(std::forward<U>(fn)), Overloaded<Fns...>(std::forward<Rest>(rest)...) { }
+
+    using Fn::operator();
+    using Overloaded<Fns...>::operator();
+};
+
+template<typename Fn>
+struct Overloaded<Fn> : Fn {
+    template<typename U>
+    Overloaded(U&& fn) : Fn(std::forward<U>(fn)) { }
+
+    using Fn::operator();
+};
+
+} // namespace _impl
+} // namespace realm
+
+#endif // REALM_UTIL_OVERLOAD_HPP

--- a/test/test_util_overload.cpp
+++ b/test/test_util_overload.cpp
@@ -1,0 +1,69 @@
+/*************************************************************************
+ *
+ * Copyright 2017 Realm Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ **************************************************************************/
+
+#include "testsettings.hpp"
+
+#include <realm/util/overload.hpp>
+
+#include "test.hpp"
+
+using namespace realm;
+
+// Test independence and thread-safety
+// -----------------------------------
+//
+// All tests must be thread safe and independent of each other. This
+// is required because it allows for both shuffling of the execution
+// order and for parallelized testing.
+//
+// In particular, avoid using std::rand() since it is not guaranteed
+// to be thread safe. Instead use the API offered in
+// `test/util/random.hpp`.
+//
+// All files created in tests must use the TEST_PATH macro (or one of
+// its friends) to obtain a suitable file system path. See
+// `test/util/test_path.hpp`.
+//
+//
+// Debugging and the ONLY() macro
+// ------------------------------
+//
+// A simple way of disabling all tests except one called `Foo`, is to
+// replace TEST(Foo) with ONLY(Foo) and then recompile and rerun the
+// test suite. Note that you can also use filtering by setting the
+// environment varible `UNITTEST_FILTER`. See `README.md` for more on
+// this.
+//
+// Another way to debug a particular test, is to copy that test into
+// `experiments/testcase.cpp` and then run `sh build.sh
+// check-testcase` (or one of its friends) from the command line.
+
+namespace {
+
+TEST(Util_Overload_Basics)
+{
+    auto f = util::overload([](int i) { return i; },
+                            [](std::string s) { return s; },
+                            [](double d1, double d2) { return d1 + d2; });
+
+    CHECK_EQUAL(1, f(1));
+    CHECK_EQUAL("hello", f("hello"));
+    CHECK_EQUAL(5.0, f(3.0, 2.0));
+}
+
+} // unnamed namespace


### PR DESCRIPTION
This is a minimal version of [C++ Library Evolution Working Group proposal P0051R2](http://open-std.org/JTC1/SC22/WG21/docs/papers/2016/p0051r2.pdf). There are places in the object store and in the Cocoa binding where this would improve the code.