### PR TITLE
Optimize query

### DIFF
--- a/src/realm/column_table.hpp
+++ b/src/realm/column_table.hpp
@@ -209,9 +209,16 @@ public:
     /// wrapped in some instantiation of BasicTableRef<>.
     Table* get_subtable_ptr(size_t subtable_ndx);
 
+    /// This is to be used by the query system that does not need to
+    /// modify the subtable. Will return a ref object containing a
+    /// nullptr if there is no table object yet.
     ConstTableRef get(size_t subtable_ndx) const
     {
-        return ConstTableRef(get_subtable_ptr(subtable_ndx));
+        int64_t ref = IntegerColumn::get(subtable_ndx);
+        if (ref)
+            return ConstTableRef(get_subtable_ptr(subtable_ndx));
+        else
+            return {};
     }
 
     const Table* get_subtable_ptr(size_t subtable_ndx) const;

--- a/src/realm/query_engine.hpp
+++ b/src/realm/query_engine.hpp
@@ -939,9 +939,11 @@ public:
     {
         for (size_t s = start; s < end; ++s) {
             TConditionValue v = m_condition_column->get(s);
-            int64_t sz = m_size_operator(v);
-            if (TConditionFunction()(sz, m_value, !bool(v)))
-                return s;
+            if (v) {
+                int64_t sz = m_size_operator(v);
+                if (TConditionFunction()(sz, m_value))
+                    return s;
+            }
         }
         return not_found;
     }

--- a/src/realm/query_expression.cpp
+++ b/src/realm/query_expression.cpp
@@ -44,15 +44,14 @@ void Columns<SubTable>::evaluate_internal(size_t index, ValueBase& destination, 
         if (m_link_map.only_unary_links()) {
             ConstTableRef val;
             if (sz == 1) {
-                val = ConstTableRef(m_column->get_subtable_ptr(links[0]));
+                val = m_column->get(links[0]);
             }
             d->init(false, 1, val);
         }
         else {
             d->init(true, sz);
             for (size_t t = 0; t < sz; t++) {
-                const Table* table = m_column->get_subtable_ptr(links[t]);
-                d->m_storage.set(t, ConstTableRef(table));
+                d->m_storage.set(t, m_column->get(links[t]));
             }
         }
     }
@@ -62,8 +61,7 @@ void Columns<SubTable>::evaluate_internal(size_t index, ValueBase& destination, 
         d->init(false, rows);
 
         for (size_t t = 0; t < rows; t++) {
-            const Table* table = m_column->get_subtable_ptr(index + t);
-            d->m_storage.set(t, ConstTableRef(table));
+            d->m_storage.set(t, m_column->get(index + t));
         }
     }
 }

--- a/src/realm/query_expression.hpp
+++ b/src/realm/query_expression.hpp
@@ -2139,9 +2139,6 @@ public:
     size_t find_first(size_t start, size_t end) const override
     {
         for (; start < end;) {
-            std::vector<size_t> l = m_link_map.get_links(start);
-            // We have found a Link which is NULL, or LinkList with 0 entries. Return it as match.
-
             FindNullLinks fnl;
             m_link_map.map_links(start, fnl);
             if (fnl.m_has_link == has_links)
@@ -2914,9 +2911,7 @@ public:
                 REALM_ASSERT_3(ValueBase::default_size, ==, 8);
 
                 auto sgc_2 = static_cast<SequentialGetter<ColType>*>(m_sg.get());
-                sgc_2->m_leaf_ptr->get_chunk(
-                    index - sgc->m_leaf_start,
-                    static_cast<Value<int64_t>*>(static_cast<ValueBase*>(&v))->m_storage.m_first);
+                sgc_2->m_leaf_ptr->get_chunk(index - sgc->m_leaf_start, v.m_storage.m_first);
 
                 destination.import(v);
             }


### PR DESCRIPTION
Only create subtable accessor if table is created

- When running a query, we should not create degenerated subtable accessors, but rather a ConstTableRef containing a nullptr.

About performance impact from this change: If you have a subtable column where most of the entries are null, then there is a big performance improvement (~ 300 %).