### PR TITLE
Implement File::get_unique_id() for Windows

### DIFF
--- a/src/realm/util/file.hpp
+++ b/src/realm/util/file.hpp
@@ -19,6 +19,7 @@
 #ifndef REALM_UTIL_FILE_HPP
 #define REALM_UTIL_FILE_HPP
 
+#include <array>
 #include <cstddef>
 #include <cstdint>
 #include <memory>
@@ -474,12 +475,12 @@ public:
 
 
     struct UniqueID {
-#ifdef _WIN32 // Windows version
-// FIXME: This is not implemented for Windows
-#else
         // NDK r10e has a bug in sys/stat.h dev_t ino_t are 4 bytes,
         // but stat.st_dev and st_ino are 8 bytes. So we just use uint64 instead.
         uint_fast64_t device;
+#ifdef _WIN32 // Windows version
+        std::array<char, 16> inode;
+#else
         uint_fast64_t inode;
 #endif
     };
@@ -1195,11 +1196,7 @@ inline File::Exists::Exists(const std::string& msg, const std::string& path)
 
 inline bool operator==(const File::UniqueID& lhs, const File::UniqueID& rhs)
 {
-#ifdef _WIN32 // Windows version
-    throw std::runtime_error("Not yet supported");
-#else // POSIX version
     return lhs.device == rhs.device && lhs.inode == rhs.inode;
-#endif
 }
 
 inline bool operator!=(const File::UniqueID& lhs, const File::UniqueID& rhs)
@@ -1209,9 +1206,6 @@ inline bool operator!=(const File::UniqueID& lhs, const File::UniqueID& rhs)
 
 inline bool operator<(const File::UniqueID& lhs, const File::UniqueID& rhs)
 {
-#ifdef _WIN32 // Windows version
-    throw std::runtime_error("Not yet supported");
-#else // POSIX version
     if (lhs.device < rhs.device)
         return true;
     if (lhs.device > rhs.device)
@@ -1219,7 +1213,6 @@ inline bool operator<(const File::UniqueID& lhs, const File::UniqueID& rhs)
     if (lhs.inode < rhs.inode)
         return true;
     return false;
-#endif
 }
 
 inline bool operator>(const File::UniqueID& lhs, const File::UniqueID& rhs)

--- a/test/test_file.cpp
+++ b/test/test_file.cpp
@@ -71,8 +71,7 @@ TEST(File_ExistsAndRemove)
     CHECK(!File::try_remove(path));
 }
 
-// FIXME: Not yet supported on Windows 10 UWP
-#if !REALM_UWP
+#if !REALM_UWP // Not implementable on UWP
 TEST(File_IsSame)
 {
     TEST_PATH(path_1);
@@ -403,7 +402,7 @@ TEST(File_Move)
     CHECK_NOT(file_2.is_attached());
 }
 
-#ifndef _WIN32
+#if !REALM_UWP // Not implementable on UWP
 TEST(File_GetUniqueID)
 {
     TEST_PATH(path_1);
@@ -446,6 +445,6 @@ TEST(File_GetUniqueID)
     CHECK_NOT(uid4_1 < uid4_2);
     CHECK_NOT(uid4_2 < uid4_1);
 }
-#endif
+#endif // !REALM_UWP
 
 #endif // TEST_FILE


### PR DESCRIPTION
Needed for some objectstore tests which are currently just duplicating the functionality to work around it not being implemented here.