### PR TITLE
Improve the collection of warnings during CI builds

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -290,10 +290,10 @@ def buildDiffCoverage() {
 
 def buildPerformance() {
   return {
-    getArchive()
     // Select docker-cph-X.  We want docker, metal (brix) and only one executor
     // (exclusive), if the machine changes also change REALM_BENCH_MACHID below
     node('docker && brix && exclusive') {
+      getArchive()
       def buildEnv = buildDockerEnv('ci/realm-core:snapshot')
       // REALM_BENCH_DIR tells the gen_bench_hist.sh script where to place results
       // REALM_BENCH_MACHID gives the results an id - results are organized by hardware to prevent mixing cached results with runs on different machines

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -290,6 +290,7 @@ def buildDiffCoverage() {
 
 def buildPerformance() {
   return {
+    getArchive()
     // Select docker-cph-X.  We want docker, metal (brix) and only one executor
     // (exclusive), if the machine changes also change REALM_BENCH_MACHID below
     node('docker && brix && exclusive') {

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -293,7 +293,7 @@ def buildPerformance() {
     // Select docker-cph-X.  We want docker, metal (brix) and only one executor
     // (exclusive), if the machine changes also change REALM_BENCH_MACHID below
     node('docker && brix && exclusive') {
-      getArchive()
+      getSourceArchive()
       def buildEnv = buildDockerEnv('ci/realm-core:snapshot')
       // REALM_BENCH_DIR tells the gen_bench_hist.sh script where to place results
       // REALM_BENCH_MACHID gives the results an id - results are organized by hardware to prevent mixing cached results with runs on different machines


### PR DESCRIPTION
The current implementation is faulty in the way that each time the warning collection step is invoked, it does not analyze only the result of the building step, but the whole console log up to that
point, including the other parallel branches. This results in incorrect and confusing results.