### PR TITLE
workaround a bug in flock on macos by busy-waiting

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,9 @@
 
 ### Bugfixes
 
-* Lorem ipsum.
+* Work around a bug in macOS which could cause a deadlock when trying to obtain a shared lock
+  using flock(). PR [#2552](https://github.com/realm/realm-core/pull/2552),
+  issue [#2434](https://github.com/realm/realm-core/issues/2434).
 
 ### Breaking changes
 

--- a/src/realm/group_shared.cpp
+++ b/src/realm/group_shared.cpp
@@ -822,11 +822,7 @@ void SharedGroup::do_open(const std::string& path, bool no_create_file, bool is_
         // macOS has a bug which can cause a hang waiting to obtain a lock, even
         // if the lock is already open in shared mode, so we work around it by
         // busy waiting. This should occur only briefly during session initialization.
-        for (;;) {
-            bool got_lock = m_file.try_lock_shared();
-            if (got_lock) {
-                break;
-            }
+        while (!m_file.try_lock_shared()) {
             sched_yield();
         }
 #else

--- a/src/realm/group_shared.cpp
+++ b/src/realm/group_shared.cpp
@@ -818,8 +818,8 @@ void SharedGroup::do_open(const std::string& path, bool no_create_file, bool is_
         }
 
         // We hold the shared lock from here until we close the file!
-#if REALM_IOS
-        // iOS has a bug which can cause a hang waiting to obtain a lock, even
+#if REALM_PLATFORM_APPLE
+        // macOS has a bug which can cause a hang waiting to obtain a lock, even
         // if the lock is already open in shared mode, so we work around it by
         // busy waiting. This should occur only briefly during session initialization.
         for (;;) {

--- a/src/realm/group_shared.cpp
+++ b/src/realm/group_shared.cpp
@@ -818,8 +818,20 @@ void SharedGroup::do_open(const std::string& path, bool no_create_file, bool is_
         }
 
         // We hold the shared lock from here until we close the file!
+#if REALM_IOS
+        // iOS has a bug which can cause a hang waiting to obtain a lock, even
+        // if the lock is already open in shared mode, so we work around it by
+        // busy waiting. This should occur only briefly during session initialization.
+        for (;;) {
+            bool got_lock = m_file.try_lock_shared();
+            if (got_lock) {
+                break;
+            }
+            sched_yield();
+        }
+#else
         m_file.lock_shared(); // Throws
-
+#endif
         // If the file is not completely initialized at this point in time, the
         // preceeding initialization attempt must have failed. We know that an
         // initialization process was in progress, because this thread (or


### PR DESCRIPTION
macos has a bug (releasing an exclusive lock will only wake ONE thread waiting for a shared lock). In use cases where locks are held briefly, this does not cause problems, but in our use case --- where we hold shared locks for the full duration of having the database open --- it does.

This PR works around the bug by busy waiting on the shared lock.

Fixes #2434 