### PR TITLE
Do not read uninitialized values in BasicArray<T>::create_array

### DIFF
--- a/src/realm/array_basic_tpl.hpp
+++ b/src/realm/array_basic_tpl.hpp
@@ -65,10 +65,11 @@ inline MemRef BasicArray<T>::create_array(Array::Type type, bool context_flag, s
     if (init_size) {
         BasicArray<T> tmp(allocator);
         tmp.init_from_mem(mem);
-        for (size_t i = 0; i < init_size; ++i) {
-            tmp.set(i, value);
+        T* p = reinterpret_cast<T*>(tmp.m_data);
+        T* end = p + init_size;
+        while (p < end) {
+            *p++ = value;
         }
-        return tmp.get_mem();
     }
     return mem;
 }


### PR DESCRIPTION
Just write values to array. This will remove some issues reported by valgrind.