### PR TITLE
Always call realm::util::terminate() from REALM_UNREACHABLE()

### DIFF
--- a/src/realm/util/assert.hpp
+++ b/src/realm/util/assert.hpp
@@ -95,12 +95,11 @@
     static_cast<void>(sizeof bool(((left1)cmp1(right1))logical1((left2)cmp2(right2)) logical2((left3)cmp3(right3))))
 #endif
 
+#define REALM_UNREACHABLE() realm::util::terminate("Unreachable code", __FILE__, __LINE__)
 #ifdef REALM_COVER
-#define REALM_UNREACHABLE()
 #define REALM_COVER_NEVER(x) false
 #define REALM_COVER_ALWAYS(x) true
 #else
-#define REALM_UNREACHABLE() realm::util::terminate("Unreachable code", __FILE__, __LINE__)
 #define REALM_COVER_NEVER(x) (x)
 #define REALM_COVER_ALWAYS(x) (x)
 #endif


### PR DESCRIPTION
Always call `realm::util::terminate()` from `REALM_UNREACHABLE()`  to avoid `noreturn` warnings in coverage mode.

@jedelbo @simonask 