### PR TITLE
Support adding search index to subtable columns

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,7 +27,7 @@
   this version will not be able to open .realm files of this Core version if
   this Core version has added such indexes. Adding or removing an index will
   take place for *all* subtables in a subtable column. There is no way to add
-  or remove it form single individual subtables.
+  or remove it from single individual subtables.
   PR [#2561](https://github.com/realm/realm-core/pull/2561)
 
 -----------

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@
 
 * Support for size query on LinkedList removed. This is perhaps not so 
   breaking after all since it is probably not used.
+* Replication interface changed. The search index functions now operate
+  on a descriptor and not a table.
 
 ### Enhancements
 
@@ -15,6 +17,13 @@
   Query q = table->column<SubTable>(0).list<Int>() == 5;
   Query q = table->column<SubTable>(0).list<Int>().min() >= 2;
   Query q = table->column<SubTable>(1).list<String>().begins_with("Bar");
+* Support for search index on subtable columns. Only one level of subtables
+  are currently supported, that is, you cannot create a search index in a
+  subtable of a subtable (will throw exception). NOTE: Core versions prior to
+  this version will not be able to open .realm files of this Core version if
+  this Core version has added such indexes. Adding or removing an index will
+  take place for *all* subtables in a subtable column. There is no way to add
+  or remove it form single individual subtables.
 
 -----------
 

--- a/src/realm/column_mixed_tpl.hpp
+++ b/src/realm/column_mixed_tpl.hpp
@@ -500,8 +500,7 @@ inline void MixedColumn::refresh_accessor_tree(size_t col_ndx, const Spec& spec)
 inline void MixedColumn::RefsColumn::refresh_accessor_tree(size_t col_ndx, const Spec& spec)
 {
     SubtableColumnBase::refresh_accessor_tree(col_ndx, spec); // Throws
-    size_t spec_ndx_in_parent = 0;                            // Ignored because these are root tables
-    m_subtable_map.refresh_accessor_tree(spec_ndx_in_parent); // Throws
+    m_subtable_map.refresh_accessor_tree();                   // Throws
 }
 
 } // namespace realm

--- a/src/realm/column_table.hpp
+++ b/src/realm/column_table.hpp
@@ -107,7 +107,7 @@ protected:
         void update_accessors(const size_t* col_path_begin, const size_t* col_path_end,
                               _impl::TableFriend::AccessorUpdater&);
         void recursive_mark() noexcept;
-        void refresh_accessor_tree(size_t spec_ndx_in_parent);
+        void refresh_accessor_tree();
 
     private:
         struct SubtableEntry {
@@ -199,6 +199,9 @@ public:
     ~SubtableColumn() noexcept override
     {
     }
+
+    // Overriding method in Table::Parent
+    Spec* get_subtable_spec() noexcept override;
 
     size_t get_subtable_size(size_t ndx) const noexcept;
 
@@ -588,17 +591,22 @@ inline void SubtableColumn::refresh_accessor_tree(size_t col_ndx, const Spec& sp
 {
     SubtableColumnBase::refresh_accessor_tree(col_ndx, spec); // Throws
     m_subspec_ndx = spec.get_subspec_ndx(col_ndx);
-    m_subtable_map.refresh_accessor_tree(m_subspec_ndx); // Throws
+    m_subtable_map.refresh_accessor_tree(); // Throws
 }
 
 inline size_t SubtableColumn::get_subspec_ndx() const noexcept
 {
     if (REALM_UNLIKELY(m_subspec_ndx == realm::npos)) {
         typedef _impl::TableFriend tf;
-        const Spec& spec = tf::get_spec(*m_table);
-        m_subspec_ndx = spec.get_subspec_ndx(get_column_index());
+        m_subspec_ndx = tf::get_spec(*m_table).get_subspec_ndx(get_column_index());
     }
     return m_subspec_ndx;
+}
+
+inline Spec* SubtableColumn::get_subtable_spec() noexcept
+{
+    typedef _impl::TableFriend tf;
+    return tf::get_spec(*m_table).get_subtable_spec(get_column_index());
 }
 
 

--- a/src/realm/descriptor.cpp
+++ b/src/realm/descriptor.cpp
@@ -25,6 +25,26 @@
 using namespace realm;
 using namespace realm::util;
 
+bool Descriptor::has_search_index(size_t column_ndx) const noexcept
+{
+    if (REALM_UNLIKELY(column_ndx >= m_spec->get_column_count()))
+        return false;
+
+    int attr = m_spec->get_column_attr(column_ndx);
+    return attr & col_attr_Indexed;
+}
+
+void Descriptor::add_search_index(size_t column_ndx)
+{
+    typedef _impl::TableFriend tf;
+    tf::add_search_index(*this, column_ndx); // Throws
+}
+
+void Descriptor::remove_search_index(size_t column_ndx)
+{
+    typedef _impl::TableFriend tf;
+    tf::remove_search_index(*this, column_ndx); // Throws
+}
 
 DescriptorRef Descriptor::get_subdescriptor(size_t column_ndx)
 {

--- a/src/realm/descriptor.cpp
+++ b/src/realm/descriptor.cpp
@@ -37,12 +37,10 @@ DescriptorRef Descriptor::get_subdescriptor(size_t column_ndx)
     // Create a new descriptor accessor
     {
         DescriptorRef subdesc;
-        SubspecRef subspec_ref = m_spec->get_subtable_spec(column_ndx);
-        std::unique_ptr<Spec> subspec(new Spec(subspec_ref));             // Throws
+        Spec* subspec = m_spec->get_subtable_spec(column_ndx);
         subdesc = std::make_shared<Descriptor>(Descriptor::PrivateTag()); // Throws
         m_subdesc_map.push_back(subdesc_entry(column_ndx, subdesc));      // Throws
-        subdesc->attach(m_root_table.get(), shared_from_this(), subspec.get());
-        subspec.release();
+        subdesc->attach(m_root_table.get(), shared_from_this(), subspec);
         return subdesc;
     }
 }
@@ -65,7 +63,6 @@ Descriptor::~Descriptor() noexcept
     if (!is_attached())
         return;
     if (m_parent) {
-        delete m_spec;
         m_parent.reset();
     }
     m_root_table.reset();
@@ -77,7 +74,6 @@ void Descriptor::detach() noexcept
     REALM_ASSERT(is_attached());
     detach_subdesc_accessors();
     if (m_parent) {
-        delete m_spec;
         m_parent.reset();
     }
     m_root_table.reset();

--- a/src/realm/descriptor.cpp
+++ b/src/realm/descriptor.cpp
@@ -27,7 +27,7 @@ using namespace realm::util;
 
 bool Descriptor::has_search_index(size_t column_ndx) const noexcept
 {
-    if (REALM_UNLIKELY(column_ndx >= m_spec->get_column_count()))
+    if (REALM_UNLIKELY(column_ndx >= m_spec->get_public_column_count()))
         return false;
 
     int attr = m_spec->get_column_attr(column_ndx);

--- a/src/realm/descriptor.hpp
+++ b/src/realm/descriptor.hpp
@@ -217,6 +217,14 @@ public:
     /// \sa Table::rename_column()
     void rename_column(size_t col_ndx, StringData new_name);
 
+    /// If the descriptor is describing a subtable column, the add_search_index()
+    /// and remove_search_index() will add or remove search indexes of *all*
+    /// subtables of the subtable column. This may take a while if there are many
+    /// subtables with many rows each.
+    bool has_search_index(size_t column_ndx) const noexcept;
+    void add_search_index(size_t column_ndx);
+    void remove_search_index(size_t column_ndx);
+
     /// There are two kinds of links, 'weak' and 'strong'. A strong link is one
     /// that implies ownership, i.e., that the origin row (parent) owns the
     /// target row (child). Simply stated, this means that when the origin row

--- a/src/realm/descriptor.hpp
+++ b/src/realm/descriptor.hpp
@@ -334,11 +334,6 @@ public:
     //@}
 
     //@{
-    /// Returns the contained spec.
-    Spec* get_spec() const;
-    //@}
-
-    //@{
     /// Get the table associated with the root descriptor.
     ///
     /// \sa get_parent()
@@ -691,11 +686,6 @@ inline DescriptorRef Descriptor::get_parent() noexcept
 inline ConstDescriptorRef Descriptor::get_parent() const noexcept
 {
     return const_cast<Descriptor*>(this)->get_parent();
-}
-
-inline Spec* Descriptor::get_spec() const
-{
-    return m_spec;
 }
 
 inline TableRef Descriptor::get_root_table() noexcept

--- a/src/realm/descriptor.hpp
+++ b/src/realm/descriptor.hpp
@@ -326,6 +326,11 @@ public:
     //@}
 
     //@{
+    /// Returns the contained spec.
+    Spec* get_spec() const;
+    //@}
+
+    //@{
     /// Get the table associated with the root descriptor.
     ///
     /// \sa get_parent()
@@ -678,6 +683,11 @@ inline DescriptorRef Descriptor::get_parent() noexcept
 inline ConstDescriptorRef Descriptor::get_parent() const noexcept
 {
     return const_cast<Descriptor*>(this)->get_parent();
+}
+
+inline Spec* Descriptor::get_spec() const
+{
+    return m_spec;
 }
 
 inline TableRef Descriptor::get_root_table() noexcept

--- a/src/realm/exceptions.cpp
+++ b/src/realm/exceptions.cpp
@@ -89,6 +89,8 @@ const char* LogicError::what() const noexcept
             return "Table has no columns";
         case column_does_not_exist:
             return "Column does not exist";
+        case subtable_of_subtable_index:
+            return "Search index on a subtable of a subtable is not yet supported";
     }
     return "Unknown error";
 }

--- a/src/realm/exceptions.hpp
+++ b/src/realm/exceptions.hpp
@@ -208,7 +208,10 @@ public:
         table_has_no_columns,
 
         /// Referring to a column that has been deleted.
-        column_does_not_exist
+        column_does_not_exist,
+
+        /// You can not add index on a subtable of a subtable
+        subtable_of_subtable_index
     };
 
     LogicError(ErrorKind message);

--- a/src/realm/impl/transact_log.hpp
+++ b/src/realm/impl/transact_log.hpp
@@ -507,8 +507,8 @@ public:
 
     virtual void swap_rows(const Table*, size_t row_ndx_1, size_t row_ndx_2);
     virtual void merge_rows(const Table*, size_t row_ndx, size_t new_row_ndx);
-    virtual void add_search_index(const Table*, size_t col_ndx);
-    virtual void remove_search_index(const Table*, size_t col_ndx);
+    virtual void add_search_index(const Descriptor&, size_t col_ndx);
+    virtual void remove_search_index(const Descriptor&, size_t col_ndx);
     virtual void set_link_type(const Table*, size_t col_ndx, LinkType);
     virtual void clear_table(const Table*);
     virtual void optimize_table(const Table*);
@@ -1508,9 +1508,9 @@ inline bool TransactLogEncoder::add_search_index(size_t col_ndx)
     return true;
 }
 
-inline void TransactLogConvenientEncoder::add_search_index(const Table* t, size_t col_ndx)
+inline void TransactLogConvenientEncoder::add_search_index(const Descriptor& desc, size_t col_ndx)
 {
-    select_table(t);                     // Throws
+    select_desc(desc);                   // Throws
     m_encoder.add_search_index(col_ndx); // Throws
 }
 
@@ -1521,9 +1521,9 @@ inline bool TransactLogEncoder::remove_search_index(size_t col_ndx)
     return true;
 }
 
-inline void TransactLogConvenientEncoder::remove_search_index(const Table* t, size_t col_ndx)
+inline void TransactLogConvenientEncoder::remove_search_index(const Descriptor& desc, size_t col_ndx)
 {
-    select_table(t);                        // Throws
+    select_desc(desc);                      // Throws
     m_encoder.remove_search_index(col_ndx); // Throws
 }
 

--- a/src/realm/index_string.cpp
+++ b/src/realm/index_string.cpp
@@ -589,6 +589,10 @@ IndexArray* StringIndex::create_node(Allocator& alloc, bool is_leaf)
     return top.release();
 }
 
+ref_type StringIndex::create_empty(Allocator& alloc)
+{
+    return StringIndex(nullptr, alloc).get_ref(); // Throws
+}
 
 void StringIndex::set_target(ColumnBase* target_column) noexcept
 {
@@ -1643,7 +1647,7 @@ void StringIndex::to_dot_2(std::ostream& out, StringData title) const
     ref_type ref = get_ref();
 
     out << "subgraph cluster_string_index" << ref << " {" << std::endl;
-    out << " label = \"String index";
+    out << " label = \"Search index";
     if (title.size() != 0)
         out << "\\n'" << title << "'";
     out << "\";" << std::endl;

--- a/src/realm/index_string.hpp
+++ b/src/realm/index_string.hpp
@@ -105,6 +105,9 @@ public:
     ~StringIndex() noexcept
     {
     }
+
+    static ref_type create_empty(Allocator& alloc);
+
     void set_target(ColumnBase* target_column) noexcept;
 
     // Accessor concept:
@@ -162,6 +165,7 @@ public:
     void do_dump_node_structure(std::ostream&, int) const;
     void to_dot() const;
     void to_dot(std::ostream&, StringData title = StringData()) const;
+    void to_dot_2(std::ostream&, StringData title = StringData()) const;
 #endif
 
     typedef int32_t key_type;
@@ -252,7 +256,6 @@ private:
 
 #ifdef REALM_DEBUG
     static void dump_node_structure(const Array& node, std::ostream&, int level);
-    void to_dot_2(std::ostream&, StringData title = StringData()) const;
     static void array_to_dot(std::ostream&, const Array&);
     static void keys_to_dot(std::ostream&, const Array&, StringData title = StringData());
 #endif

--- a/src/realm/query.cpp
+++ b/src/realm/query.cpp
@@ -868,9 +868,6 @@ R Query::aggregate(R (ColType::*aggregateMethod)(size_t start, size_t end, size_
                    size_t column_ndx, size_t* resultcount, size_t start, size_t end, size_t limit,
                    size_t* return_ndx) const
 {
-    if (!m_table->is_attached()) {
-        throw LogicError{LogicError::detached_accessor};
-    }
     if (limit == 0 || m_table->is_degenerate()) {
         if (resultcount)
             *resultcount = 0;

--- a/src/realm/replication.cpp
+++ b/src/realm/replication.cpp
@@ -384,7 +384,7 @@ public:
     {
         if (REALM_LIKELY(REALM_COVER_ALWAYS(m_desc))) {
             if (REALM_LIKELY(REALM_COVER_ALWAYS(col_ndx < m_desc->get_column_count()))) {
-                log("table->remove_search_index(%1);", col_ndx); // Throws
+                log("desc->remove_search_index(%1);", col_ndx); // Throws
                 using tf = _impl::TableFriend;
                 tf::remove_search_index(*m_desc, col_ndx); // Throws
                 return true;

--- a/src/realm/replication.cpp
+++ b/src/realm/replication.cpp
@@ -369,13 +369,12 @@ public:
 
     bool add_search_index(size_t col_ndx)
     {
-        if (REALM_LIKELY(REALM_COVER_ALWAYS(m_table && m_table->is_attached()))) {
-            if (REALM_LIKELY(REALM_COVER_ALWAYS(!m_table->has_shared_type()))) {
-                if (REALM_LIKELY(REALM_COVER_ALWAYS(col_ndx < m_table->get_column_count()))) {
-                    log("table->add_search_index(%1);", col_ndx); // Throws
-                    m_table->add_search_index(col_ndx);           // Throws
-                    return true;
-                }
+        if (REALM_LIKELY(REALM_COVER_ALWAYS(m_desc))) {
+            if (REALM_LIKELY(REALM_COVER_ALWAYS(col_ndx < m_desc->get_column_count()))) {
+                log("desc->add_search_index(%1);", col_ndx); // Throws
+                using tf = _impl::TableFriend;
+                tf::add_search_index(*m_desc, col_ndx); // Throws
+                return true;
             }
         }
         return false;
@@ -383,13 +382,12 @@ public:
 
     bool remove_search_index(size_t col_ndx)
     {
-        if (REALM_LIKELY(REALM_COVER_ALWAYS(m_table && m_table->is_attached()))) {
-            if (REALM_LIKELY(REALM_COVER_ALWAYS(!m_table->has_shared_type()))) {
-                if (REALM_LIKELY(REALM_COVER_ALWAYS(col_ndx < m_table->get_column_count()))) {
-                    log("table->remove_search_index(%1);", col_ndx); // Throws
-                    m_table->remove_search_index(col_ndx);           // Throws
-                    return true;
-                }
+        if (REALM_LIKELY(REALM_COVER_ALWAYS(m_desc))) {
+            if (REALM_LIKELY(REALM_COVER_ALWAYS(col_ndx < m_desc->get_column_count()))) {
+                log("table->remove_search_index(%1);", col_ndx); // Throws
+                using tf = _impl::TableFriend;
+                tf::remove_search_index(*m_desc, col_ndx); // Throws
+                return true;
             }
         }
         return false;

--- a/src/realm/spec.cpp
+++ b/src/realm/spec.cpp
@@ -23,7 +23,6 @@
 
 using namespace realm;
 
-
 Spec::~Spec() noexcept
 {
     if (m_top.is_attached()) {
@@ -50,6 +49,7 @@ void Spec::init(MemRef mem) noexcept
     // from initialized children to uninitialized
     m_subspecs.detach();
     m_enumkeys.detach();
+    m_subspec_ptrs.clear();
 
     // Subspecs array is only there and valid when there are subtables
     // if there are enumkey, but no subtables yet it will be a zero-ref
@@ -57,6 +57,7 @@ void Spec::init(MemRef mem) noexcept
         ref_type ref = m_top.get_as_ref(3);
         m_subspecs.init_from_ref(ref);
         m_subspecs.set_parent(&m_top, 3);
+        m_subspec_ptrs.resize(m_subspecs.size());
     }
 
     // Enumkeys array is only there when there are StringEnum columns
@@ -66,6 +67,17 @@ void Spec::init(MemRef mem) noexcept
     }
 
     update_has_strong_link_columns();
+}
+
+Spec* Spec::get_subspec_by_ndx(size_t subspec_ndx) noexcept
+{
+    if (!m_subspec_ptrs[subspec_ndx]) {
+        Spec* spec = new Spec(get_alloc());
+        spec->set_parent(&m_subspecs, subspec_ndx);
+        spec->init_from_parent();
+        m_subspec_ptrs[subspec_ndx] = std::unique_ptr<Spec>(spec);
+    }
+    return m_subspec_ptrs[subspec_ndx].get();
 }
 
 
@@ -181,6 +193,7 @@ void Spec::insert_column(size_t column_ndx, ColumnType type, StringData name, Co
             size_t subspec_ndx = get_subspec_ndx(column_ndx);
             int_fast64_t v(from_ref(subspec_mem.get_ref()));
             m_subspecs.insert(subspec_ndx, v); // Throws
+            m_subspec_ptrs.insert(m_subspec_ptrs.begin() + subspec_ndx, std::unique_ptr<Spec>());
             dg.release();
         }
         else if (type == col_type_Link || type == col_type_LinkList) {
@@ -189,6 +202,7 @@ void Spec::insert_column(size_t column_ndx, ColumnType type, StringData name, Co
             // don't know it yet we just store zero (null ref).
             size_t subspec_ndx = get_subspec_ndx(column_ndx);
             m_subspecs.insert(subspec_ndx, 0); // Throws
+            m_subspec_ptrs.insert(m_subspec_ptrs.begin() + subspec_ndx, std::unique_ptr<Spec>());
         }
         else if (type == col_type_BackLink) {
             // Store group-level table index of origin table and index of origin
@@ -198,6 +212,8 @@ void Spec::insert_column(size_t column_ndx, ColumnType type, StringData name, Co
             size_t subspec_ndx = get_subspec_ndx(column_ndx);
             m_subspecs.insert(subspec_ndx, 0); // Throws
             m_subspecs.insert(subspec_ndx, 1); // Throws
+            m_subspec_ptrs.insert(m_subspec_ptrs.begin() + subspec_ndx, std::unique_ptr<Spec>());
+            m_subspec_ptrs.insert(m_subspec_ptrs.begin() + subspec_ndx, std::unique_ptr<Spec>());
         }
     }
 
@@ -220,15 +236,19 @@ void Spec::erase_column(size_t column_ndx)
         subspec_top.init_from_ref(subspec_ref);
         subspec_top.destroy_deep();    // recursively delete entire subspec
         m_subspecs.erase(subspec_ndx); // Throws
+        m_subspec_ptrs.erase(m_subspec_ptrs.begin() + subspec_ndx);
     }
     else if (tf::is_link_type(type)) {
         size_t subspec_ndx = get_subspec_ndx(column_ndx);
         m_subspecs.erase(subspec_ndx); // origin table index  : Throws
+        m_subspec_ptrs.erase(m_subspec_ptrs.begin() + subspec_ndx);
     }
     else if (type == col_type_BackLink) {
         size_t subspec_ndx = get_subspec_ndx(column_ndx);
         m_subspecs.erase(subspec_ndx); // origin table index  : Throws
         m_subspecs.erase(subspec_ndx); // origin column index : Throws
+        m_subspec_ptrs.erase(m_subspec_ptrs.begin() + subspec_ndx);
+        m_subspec_ptrs.erase(m_subspec_ptrs.begin() + subspec_ndx);
     }
     else if (type == col_type_StringEnum) {
         // Enum columns do also have a separate key list
@@ -285,6 +305,19 @@ void Spec::move_column(size_t from_ndx, size_t to_ndx)
         }
         if (old_subspec_ndx != new_subspec_ndx) {
             m_subspecs.move_rotate(old_subspec_ndx, new_subspec_ndx);
+
+            SubspecPtrs::iterator first, middle, last;
+            if (old_subspec_ndx < new_subspec_ndx) {
+                first = m_subspec_ptrs.begin() + old_subspec_ndx;
+                middle = first + 1;
+                last = m_subspec_ptrs.begin() + new_subspec_ndx + 1;
+            }
+            else {
+                first = m_subspec_ptrs.begin() + new_subspec_ndx;
+                middle = m_subspec_ptrs.begin() + old_subspec_ndx;
+                last = middle + 1;
+            }
+            std::rotate(first, middle, last);
         }
     }
 
@@ -536,9 +569,9 @@ bool Spec::operator==(const Spec& spec) const noexcept
             case col_type_Table: {
                 // Sub tables must be compared recursively
                 const size_t subspec_index = get_subspec_ndx(col_ndx);
-                Spec lhs(SubspecRef(SubspecRef::const_cast_tag(), get_subspec_by_ndx(subspec_index)));
-                Spec rhs(SubspecRef(SubspecRef::const_cast_tag(), spec.get_subspec_by_ndx(subspec_index)));
-                if (lhs != rhs)
+                const Spec* lhs = get_subspec_by_ndx(subspec_index);
+                const Spec* rhs = spec.get_subspec_by_ndx(subspec_index);
+                if (*lhs != *rhs)
                     return false;
                 break;
             }

--- a/src/realm/spec.hpp
+++ b/src/realm/spec.hpp
@@ -29,12 +29,9 @@
 namespace realm {
 
 class Table;
-class SubspecRef;
-class ConstSubspecRef;
 
 class Spec {
 public:
-    Spec(SubspecRef) noexcept;
     ~Spec() noexcept;
 
     Allocator& get_alloc() const noexcept;
@@ -59,8 +56,8 @@ public:
     // reference, it is the responsibility of the application that the
     // parent Spec object (this) is kept alive for at least as long as
     // the new Spec object.
-    SubspecRef get_subtable_spec(size_t column_ndx) noexcept;
-    ConstSubspecRef get_subtable_spec(size_t column_ndx) const noexcept;
+    Spec* get_subtable_spec(size_t column_ndx) noexcept;
+    const Spec* get_subtable_spec(size_t column_ndx) const noexcept;
     //@}
 
     // Column info
@@ -78,8 +75,8 @@ public:
 
     size_t get_subspec_ndx(size_t column_ndx) const noexcept;
     ref_type get_subspec_ref(size_t subspec_ndx) const noexcept;
-    SubspecRef get_subspec_by_ndx(size_t subspec_ndx) noexcept;
-    ConstSubspecRef get_subspec_by_ndx(size_t subspec_ndx) const noexcept;
+    Spec* get_subspec_by_ndx(size_t subspec_ndx) noexcept;
+    const Spec* get_subspec_by_ndx(size_t subspec_ndx) const noexcept;
 
     // Auto Enumerated string columns
     void upgrade_string_to_enum(size_t column_ndx, ref_type keys_ref, ArrayParent*& keys_parent, size_t& keys_ndx);
@@ -134,13 +131,14 @@ private:
     ArrayInteger m_attr;  // 3rd slot in m_top
     Array m_subspecs;     // 4th slot in m_top (optional)
     Array m_enumkeys;     // 5th slot in m_top (optional)
+    using SubspecPtrs = std::vector<std::unique_ptr<Spec>>;
+    SubspecPtrs m_subspec_ptrs;
     bool m_has_strong_link_columns;
 
     Spec(Allocator&) noexcept; // Unattached
 
     void init(ref_type) noexcept;
     void init(MemRef) noexcept;
-    void init(SubspecRef) noexcept;
     void update_has_strong_link_columns() noexcept;
 
     // Similar in function to Array::init_from_parent().
@@ -184,52 +182,6 @@ private:
     friend class Table;
 };
 
-
-class SubspecRef {
-public:
-    struct const_cast_tag {
-    };
-    SubspecRef(const_cast_tag, ConstSubspecRef r) noexcept;
-    ~SubspecRef() noexcept
-    {
-    }
-    Allocator& get_alloc() const noexcept
-    {
-        return m_parent->get_alloc();
-    }
-
-private:
-    Array* const m_parent;
-    size_t const m_ndx_in_parent;
-
-    SubspecRef(Array* parent, size_t ndx_in_parent) noexcept;
-
-    friend class Spec;
-    friend class ConstSubspecRef;
-};
-
-class ConstSubspecRef {
-public:
-    ConstSubspecRef(SubspecRef r) noexcept;
-    ~ConstSubspecRef() noexcept
-    {
-    }
-    Allocator& get_alloc() const noexcept
-    {
-        return m_parent->get_alloc();
-    }
-
-private:
-    const Array* const m_parent;
-    size_t const m_ndx_in_parent;
-
-    ConstSubspecRef(const Array* parent, size_t ndx_in_parent) noexcept;
-
-    friend class Spec;
-    friend class SubspecRef;
-};
-
-
 // Implementation:
 
 inline Allocator& Spec::get_alloc() const noexcept
@@ -251,17 +203,6 @@ inline ref_type Spec::get_subspec_ref(size_t subspec_ndx) const noexcept
     return m_subspecs.get_as_ref(subspec_ndx);
 }
 
-inline Spec::Spec(SubspecRef r) noexcept
-    : m_top(r.m_parent->get_alloc())
-    , m_types(r.m_parent->get_alloc())
-    , m_names(r.m_parent->get_alloc())
-    , m_attr(r.m_parent->get_alloc())
-    , m_subspecs(r.m_parent->get_alloc())
-    , m_enumkeys(r.m_parent->get_alloc())
-{
-    init(r);
-}
-
 // Uninitialized Spec (call init() to init)
 inline Spec::Spec(Allocator& alloc) noexcept
     : m_top(alloc)
@@ -273,28 +214,20 @@ inline Spec::Spec(Allocator& alloc) noexcept
 {
 }
 
-inline SubspecRef Spec::get_subtable_spec(size_t column_ndx) noexcept
+inline Spec* Spec::get_subtable_spec(size_t column_ndx) noexcept
 {
     REALM_ASSERT(column_ndx < get_column_count());
     REALM_ASSERT(get_column_type(column_ndx) == col_type_Table);
     size_t subspec_ndx = get_subspec_ndx(column_ndx);
-    return SubspecRef(&m_subspecs, subspec_ndx);
+    return get_subspec_by_ndx(subspec_ndx);
 }
 
-inline ConstSubspecRef Spec::get_subtable_spec(size_t column_ndx) const noexcept
+inline const Spec* Spec::get_subtable_spec(size_t column_ndx) const noexcept
 {
-    REALM_ASSERT(column_ndx < get_column_count());
-    REALM_ASSERT(get_column_type(column_ndx) == col_type_Table);
-    size_t subspec_ndx = get_subspec_ndx(column_ndx);
-    return ConstSubspecRef(&m_subspecs, subspec_ndx);
+    return get_subtable_spec(column_ndx);
 }
 
-inline SubspecRef Spec::get_subspec_by_ndx(size_t subspec_ndx) noexcept
-{
-    return SubspecRef(&m_subspecs, subspec_ndx);
-}
-
-inline ConstSubspecRef Spec::get_subspec_by_ndx(size_t subspec_ndx) const noexcept
+inline const Spec* Spec::get_subspec_by_ndx(size_t subspec_ndx) const noexcept
 {
     return const_cast<Spec*>(this)->get_subspec_by_ndx(subspec_ndx);
 }
@@ -303,13 +236,6 @@ inline void Spec::init(ref_type ref) noexcept
 {
     MemRef mem(ref, get_alloc());
     init(mem);
-}
-
-inline void Spec::init(SubspecRef r) noexcept
-{
-    m_top.set_parent(r.m_parent, r.m_ndx_in_parent);
-    ref_type ref = r.m_parent->get_as_ref(r.m_ndx_in_parent);
-    init(ref);
 }
 
 inline void Spec::init_from_parent() noexcept
@@ -444,32 +370,6 @@ inline bool Spec::operator!=(const Spec& s) const noexcept
 {
     return !(*this == s);
 }
-
-
-inline SubspecRef::SubspecRef(Array* parent, size_t ndx_in_parent) noexcept
-    : m_parent(parent)
-    , m_ndx_in_parent(ndx_in_parent)
-{
-}
-
-inline SubspecRef::SubspecRef(const_cast_tag, ConstSubspecRef r) noexcept
-    : m_parent(const_cast<Array*>(r.m_parent))
-    , m_ndx_in_parent(r.m_ndx_in_parent)
-{
-}
-
-inline ConstSubspecRef::ConstSubspecRef(const Array* parent, size_t ndx_in_parent) noexcept
-    : m_parent(parent)
-    , m_ndx_in_parent(ndx_in_parent)
-{
-}
-
-inline ConstSubspecRef::ConstSubspecRef(SubspecRef r) noexcept
-    : m_parent(r.m_parent)
-    , m_ndx_in_parent(r.m_ndx_in_parent)
-{
-}
-
 
 } // namespace realm
 

--- a/src/realm/spec.hpp
+++ b/src/realm/spec.hpp
@@ -57,7 +57,6 @@ public:
     // parent Spec object (this) is kept alive for at least as long as
     // the new Spec object.
     Spec* get_subtable_spec(size_t column_ndx) noexcept;
-    const Spec* get_subtable_spec(size_t column_ndx) const noexcept;
     //@}
 
     // Column info
@@ -131,7 +130,19 @@ private:
     ArrayInteger m_attr;  // 3rd slot in m_top
     Array m_subspecs;     // 4th slot in m_top (optional)
     Array m_enumkeys;     // 5th slot in m_top (optional)
-    using SubspecPtrs = std::vector<std::unique_ptr<Spec>>;
+    struct SubspecPtr {
+        SubspecPtr()
+            : m_is_spec_ptr(false)
+        {
+        }
+        SubspecPtr(bool is_spec_ptr)
+            : m_is_spec_ptr(is_spec_ptr)
+        {
+        }
+        std::unique_ptr<Spec> m_spec;
+        bool m_is_spec_ptr;
+    };
+    using SubspecPtrs = std::vector<SubspecPtr>;
     SubspecPtrs m_subspec_ptrs;
     bool m_has_strong_link_columns;
 
@@ -140,6 +151,7 @@ private:
     void init(ref_type) noexcept;
     void init(MemRef) noexcept;
     void update_has_strong_link_columns() noexcept;
+    void update_subspec_ptrs();
 
     // Similar in function to Array::init_from_parent().
     void init_from_parent() noexcept;
@@ -220,11 +232,6 @@ inline Spec* Spec::get_subtable_spec(size_t column_ndx) noexcept
     REALM_ASSERT(get_column_type(column_ndx) == col_type_Table);
     size_t subspec_ndx = get_subspec_ndx(column_ndx);
     return get_subspec_by_ndx(subspec_ndx);
-}
-
-inline const Spec* Spec::get_subtable_spec(size_t column_ndx) const noexcept
-{
-    return const_cast<Spec*>(this)->get_subtable_spec(column_ndx);
 }
 
 inline const Spec* Spec::get_subspec_by_ndx(size_t subspec_ndx) const noexcept

--- a/src/realm/spec.hpp
+++ b/src/realm/spec.hpp
@@ -224,7 +224,7 @@ inline Spec* Spec::get_subtable_spec(size_t column_ndx) noexcept
 
 inline const Spec* Spec::get_subtable_spec(size_t column_ndx) const noexcept
 {
-    return get_subtable_spec(column_ndx);
+    return const_cast<Spec*>(this)->get_subtable_spec(column_ndx);
 }
 
 inline const Spec* Spec::get_subspec_by_ndx(size_t subspec_ndx) const noexcept

--- a/src/realm/table.cpp
+++ b/src/realm/table.cpp
@@ -248,7 +248,7 @@
 ///    (Table::m_columns).
 ///
 ///  - The top array accessor of spec objects of subtables with shared
-///    descriptor (Table::m_spec.m_top).
+///    descriptor (Table::m_spec->m_top).
 ///
 ///  - The root array accessor of table level columns
 ///    (*Table::m_cols[]->m_array).
@@ -295,7 +295,7 @@ void Table::insert_column_link(size_t col_ndx, DataType type, StringData name, T
 size_t Table::get_backlink_count(size_t row_ndx, const Table& origin, size_t origin_col_ndx) const noexcept
 {
     size_t origin_table_ndx = origin.get_index_in_group();
-    size_t backlink_col_ndx = m_spec.find_backlink_column(origin_table_ndx, origin_col_ndx);
+    size_t backlink_col_ndx = m_spec->find_backlink_column(origin_table_ndx, origin_col_ndx);
     const BacklinkColumn& backlink_col = get_column_backlink(backlink_col_ndx);
     return backlink_col.get_backlink_count(row_ndx);
 }
@@ -305,7 +305,7 @@ size_t Table::get_backlink(size_t row_ndx, const Table& origin, size_t origin_co
     noexcept
 {
     size_t origin_table_ndx = origin.get_index_in_group();
-    size_t backlink_col_ndx = m_spec.find_backlink_column(origin_table_ndx, origin_col_ndx);
+    size_t backlink_col_ndx = m_spec->find_backlink_column(origin_table_ndx, origin_col_ndx);
     const BacklinkColumn& backlink_col = get_column_backlink(backlink_col_ndx);
     return backlink_col.get_backlink(row_ndx, backlink_ndx);
 }
@@ -325,7 +325,7 @@ void Table::connect_opposite_link_columns(size_t link_col_ndx, Table& target_tab
 size_t Table::get_num_strong_backlinks(size_t row_ndx) const noexcept
 {
     size_t sum = 0;
-    size_t col_ndx_begin = m_spec.get_public_column_count();
+    size_t col_ndx_begin = m_spec->get_public_column_count();
     size_t col_ndx_end = m_cols.size();
     for (size_t i = col_ndx_begin; i < col_ndx_end; ++i) {
         const BacklinkColumn& backlink_col = get_column_backlink(i);
@@ -340,7 +340,7 @@ size_t Table::get_num_strong_backlinks(size_t row_ndx) const noexcept
 
 void Table::cascade_break_backlinks_to(size_t row_ndx, CascadeState& state)
 {
-    size_t num_cols = m_spec.get_column_count();
+    size_t num_cols = m_spec->get_column_count();
     for (size_t col_ndx = 0; col_ndx != num_cols; ++col_ndx) {
         ColumnBase& col = get_column_base(col_ndx);
         col.cascade_break_backlinks_to(row_ndx, state); // Throws
@@ -350,7 +350,7 @@ void Table::cascade_break_backlinks_to(size_t row_ndx, CascadeState& state)
 
 void Table::cascade_break_backlinks_to_all_rows(CascadeState& state)
 {
-    size_t num_cols = m_spec.get_column_count();
+    size_t num_cols = m_spec->get_column_count();
     for (size_t col_ndx = 0; col_ndx != num_cols; ++col_ndx) {
         ColumnBase& col = get_column_base(col_ndx);
         col.cascade_break_backlinks_to_all_rows(m_size, state); // Throws
@@ -422,7 +422,7 @@ DescriptorRef Table::get_descriptor()
         typedef _impl::DescriptorFriend df;
         desc = df::create(); // Throws
         DescriptorRef parent = nullptr;
-        df::attach(*desc, this, parent, &m_spec);
+        df::attach(*desc, this, parent, m_spec.get());
         m_descriptor = desc;
     }
     return desc;
@@ -504,13 +504,14 @@ void Table::init(ref_type top_ref, ArrayParent* parent, size_t ndx_in_parent, bo
     REALM_ASSERT_3(m_top.size(), ==, 2);
 
     size_t spec_ndx_in_parent = 0;
-    m_spec.set_parent(&m_top, spec_ndx_in_parent);
-    m_spec.init_from_parent();
+    m_spec.manage(new Spec(get_alloc()));
+    m_spec->set_parent(&m_top, spec_ndx_in_parent);
+    m_spec->init_from_parent();
     size_t columns_ndx_in_parent = 1;
     m_columns.set_parent(&m_top, columns_ndx_in_parent);
     m_columns.init_from_parent();
 
-    size_t num_cols = m_spec.get_column_count();
+    size_t num_cols = m_spec->get_column_count();
     m_cols.resize(num_cols); // Throws
 
     if (!skip_create_column_accessors) {
@@ -520,13 +521,13 @@ void Table::init(ref_type top_ref, ArrayParent* parent, size_t ndx_in_parent, bo
 }
 
 
-void Table::init(ConstSubspecRef shared_spec, ArrayParent* parent_column, size_t parent_row_ndx)
+void Table::init(Spec* shared_spec, ArrayParent* parent_column, size_t parent_row_ndx)
 {
     m_mark = false;
 
     m_version = 0;
 
-    m_spec.init(SubspecRef(SubspecRef::const_cast_tag(), shared_spec));
+    m_spec = shared_spec;
     m_columns.set_parent(parent_column, parent_row_ndx);
 
     // A degenerate subtable has no underlying columns array and no column
@@ -535,7 +536,7 @@ void Table::init(ConstSubspecRef shared_spec, ArrayParent* parent_column, size_t
     if (columns_ref != 0) {
         m_columns.init_from_ref(columns_ref);
 
-        size_t num_cols = m_spec.get_column_count();
+        size_t num_cols = m_spec->get_column_count();
         m_cols.resize(num_cols); // Throws
     }
 
@@ -744,7 +745,7 @@ void Table::do_erase_column(Descriptor& desc, size_t col_ndx)
     // handler as an individual operation, and precede the column removal
     // operation in order to get the right behaviour in
     // Group::advance_transact().
-    if (root_table.m_spec.get_public_column_count() == 1)
+    if (root_table.m_spec->get_public_column_count() == 1)
         root_table.clear(); // Throws
 
     if (Replication* repl = root_table.get_repl())
@@ -827,7 +828,7 @@ void Table::insert_root_column(size_t col_ndx, DataType type, StringData name, L
 {
     using tf = _impl::TableFriend;
 
-    REALM_ASSERT_3(col_ndx, <=, m_spec.get_public_column_count());
+    REALM_ASSERT_3(col_ndx, <=, m_spec->get_public_column_count());
 
     do_insert_root_column(col_ndx, ColumnType(type), name, nullable); // Throws
     adj_insert_column(col_ndx);                                       // Throws
@@ -843,7 +844,7 @@ void Table::insert_root_column(size_t col_ndx, DataType type, StringData name, L
     // the target table below.
     if (link_target.is_valid()) {
         size_t target_table_ndx = link_target.m_target_table->get_index_in_group();
-        m_spec.set_opposite_link_table_ndx(col_ndx, target_table_ndx); // Throws
+        m_spec->set_opposite_link_table_ndx(col_ndx, target_table_ndx); // Throws
         link_target.m_target_table->mark();
     }
 
@@ -866,12 +867,12 @@ void Table::insert_root_column(size_t col_ndx, DataType type, StringData name, L
 
 void Table::erase_root_column(size_t col_ndx)
 {
-    REALM_ASSERT_3(col_ndx, <, m_spec.get_public_column_count());
+    REALM_ASSERT_3(col_ndx, <, m_spec->get_public_column_count());
 
     // For link columns we need to erase the backlink column first in case the
     // target table is the same as the origin table (because the backlink column
     // occurs after regular columns.)
-    ColumnType col_type = m_spec.get_column_type(col_ndx);
+    ColumnType col_type = m_spec->get_column_type(col_ndx);
     if (is_link_type(col_type)) {
         Table* link_target_table = get_link_target_table_accessor(col_ndx);
         size_t origin_table_ndx = get_index_in_group();
@@ -888,8 +889,8 @@ void Table::erase_root_column(size_t col_ndx)
 
 void Table::move_root_column(size_t from, size_t to)
 {
-    REALM_ASSERT_3(from, <, m_spec.get_public_column_count());
-    REALM_ASSERT_3(to, <, m_spec.get_public_column_count());
+    REALM_ASSERT_3(from, <, m_spec->get_public_column_count());
+    REALM_ASSERT_3(to, <, m_spec->get_public_column_count());
 
     if (from == to)
         return;
@@ -906,9 +907,9 @@ void Table::move_root_column(size_t from, size_t to)
 
 void Table::do_insert_root_column(size_t ndx, ColumnType type, StringData name, bool nullable)
 {
-    m_spec.insert_column(ndx, type, name, nullable ? col_attr_Nullable : col_attr_None); // Throws
+    m_spec->insert_column(ndx, type, name, nullable ? col_attr_Nullable : col_attr_None); // Throws
 
-    Spec::ColumnInfo info = m_spec.get_column_info(ndx);
+    Spec::ColumnInfo info = m_spec->get_column_info(ndx);
     size_t ndx_in_parent = info.m_column_ref_ndx;
     ref_type col_ref = create_column(type, m_size, nullable, m_columns.get_alloc()); // Throws
     m_columns.insert(ndx_in_parent, col_ref);                                        // Throws
@@ -917,8 +918,8 @@ void Table::do_insert_root_column(size_t ndx, ColumnType type, StringData name, 
 
 void Table::do_erase_root_column(size_t ndx)
 {
-    Spec::ColumnInfo info = m_spec.get_column_info(ndx);
-    m_spec.erase_column(ndx); // Throws
+    Spec::ColumnInfo info = m_spec->get_column_info(ndx);
+    m_spec->erase_column(ndx); // Throws
 
     // Remove ref from m_columns, and destroy node structure
     size_t ndx_in_parent = info.m_column_ref_ndx;
@@ -938,9 +939,9 @@ void Table::do_erase_root_column(size_t ndx)
 
 void Table::do_move_root_column(size_t from_ndx, size_t to_ndx)
 {
-    Spec::ColumnInfo from_info = m_spec.get_column_info(from_ndx);
-    Spec::ColumnInfo to_info = m_spec.get_column_info(to_ndx);
-    m_spec.move_column(from_ndx, to_ndx);
+    Spec::ColumnInfo from_info = m_spec->get_column_info(from_ndx);
+    Spec::ColumnInfo to_info = m_spec->get_column_info(to_ndx);
+    m_spec->move_column(from_ndx, to_ndx);
 
     size_t from = from_info.m_column_ref_ndx;
     size_t to = to_info.m_column_ref_ndx;
@@ -971,14 +972,14 @@ void Table::do_set_link_type(size_t col_ndx, LinkType link_type)
             break;
     }
 
-    ColumnAttr attr = m_spec.get_column_attr(col_ndx);
+    ColumnAttr attr = m_spec->get_column_attr(col_ndx);
     ColumnAttr new_attr = attr;
     new_attr = ColumnAttr(new_attr & ~col_attr_StrongLinks);
     if (!weak_links)
         new_attr = ColumnAttr(new_attr | col_attr_StrongLinks);
     if (new_attr == attr)
         return;
-    m_spec.set_column_attr(col_ndx, new_attr);
+    m_spec->set_column_attr(col_ndx, new_attr);
 
     LinkColumnBase& col = get_column_link_base(col_ndx);
     col.set_weak_links(weak_links);
@@ -993,15 +994,15 @@ void Table::insert_backlink_column(size_t origin_table_ndx, size_t origin_col_nd
     REALM_ASSERT_3(backlink_col_ndx, <=, m_cols.size());
     do_insert_root_column(backlink_col_ndx, col_type_BackLink, "");         // Throws
     adj_insert_column(backlink_col_ndx);                                    // Throws
-    m_spec.set_opposite_link_table_ndx(backlink_col_ndx, origin_table_ndx); // Throws
-    m_spec.set_backlink_origin_column(backlink_col_ndx, origin_col_ndx);    // Throws
+    m_spec->set_opposite_link_table_ndx(backlink_col_ndx, origin_table_ndx); // Throws
+    m_spec->set_backlink_origin_column(backlink_col_ndx, origin_col_ndx);    // Throws
     refresh_column_accessors(backlink_col_ndx);                             // Throws
 }
 
 
 void Table::erase_backlink_column(size_t origin_table_ndx, size_t origin_col_ndx)
 {
-    size_t backlink_col_ndx = m_spec.find_backlink_column(origin_table_ndx, origin_col_ndx);
+    size_t backlink_col_ndx = m_spec->find_backlink_column(origin_table_ndx, origin_col_ndx);
     REALM_ASSERT_3(backlink_col_ndx, !=, realm::not_found);
     do_erase_root_column(backlink_col_ndx); // Throws
     adj_erase_column(backlink_col_ndx);
@@ -1032,21 +1033,21 @@ void Table::update_link_target_tables(size_t old_col_ndx_begin, size_t new_col_n
     std::vector<std::tuple<Table*, size_t, size_t>> update_backlink_columns;
 
     for (size_t new_col_ndx = new_col_ndx_begin; new_col_ndx < num_cols; ++new_col_ndx) {
-        ColumnType type = m_spec.get_column_type(new_col_ndx);
+        ColumnType type = m_spec->get_column_type(new_col_ndx);
         if (!is_link_type(type))
             continue;
         LinkColumnBase* link_col = static_cast<LinkColumnBase*>(m_cols[new_col_ndx]);
         Table* target_table = &link_col->get_target_table();
-        Spec& target_spec = target_table->m_spec;
+        Spec* target_spec = target_table->m_spec.get();
         size_t origin_table_ndx = get_index_in_group();
         size_t old_col_ndx = old_col_ndx_begin + (new_col_ndx - new_col_ndx_begin);
-        size_t backlink_col_ndx = target_spec.find_backlink_column(origin_table_ndx, old_col_ndx);
+        size_t backlink_col_ndx = target_spec->find_backlink_column(origin_table_ndx, old_col_ndx);
         update_backlink_columns.emplace_back(target_table, backlink_col_ndx, new_col_ndx); // Throws
     }
 
     for (auto& t : update_backlink_columns) {
-        Spec& target_spec = std::get<0>(t)->m_spec;
-        target_spec.set_backlink_origin_column(std::get<1>(t), std::get<2>(t));
+        Spec* target_spec = std::get<0>(t)->m_spec.get();
+        target_spec->set_backlink_origin_column(std::get<1>(t), std::get<2>(t));
     }
 }
 
@@ -1073,14 +1074,14 @@ void Table::update_link_target_tables_after_column_move(size_t moved_from, size_
     // and then we actually update them in the second pass.
     //
     // Tuples are: (target spec, backlink column index, new column index).
-    std::vector<std::tuple<Spec&, size_t, size_t>> update_backlink_columns;
-    update_backlink_columns.reserve(m_spec.get_public_column_count());
+    std::vector<std::tuple<Spec*, size_t, size_t>> update_backlink_columns;
+    update_backlink_columns.reserve(m_spec->get_public_column_count());
 
     // Update backlink columns pointing to the column that was moved.
-    if (is_link_type(m_spec.get_column_type(moved_to))) {
+    if (is_link_type(m_spec->get_column_type(moved_to))) {
         LinkColumnBase* link_col = static_cast<LinkColumnBase*>(m_cols[moved_to]);
-        Spec& target_spec = link_col->get_target_table().m_spec;
-        size_t backlink_col_ndx = target_spec.find_backlink_column(origin_table_ndx, moved_from);
+        Spec* target_spec = link_col->get_target_table().m_spec.get();
+        size_t backlink_col_ndx = target_spec->find_backlink_column(origin_table_ndx, moved_from);
         update_backlink_columns.emplace_back(target_spec, backlink_col_ndx, moved_to);
     }
 
@@ -1089,31 +1090,31 @@ void Table::update_link_target_tables_after_column_move(size_t moved_from, size_
     if (moved_from < moved_to) {
         // Moved up:
         for (size_t col_ndx = moved_from; col_ndx < moved_to; ++col_ndx) {
-            if (!is_link_type(m_spec.get_column_type(col_ndx)))
+            if (!is_link_type(m_spec->get_column_type(col_ndx)))
                 continue;
             LinkColumnBase* link_col = static_cast<LinkColumnBase*>(m_cols[col_ndx]);
-            Spec& target_spec = link_col->get_target_table().m_spec;
+            Spec* target_spec = link_col->get_target_table().m_spec.get();
             size_t old_col_ndx = col_ndx + 1;
-            size_t backlink_col_ndx = target_spec.find_backlink_column(origin_table_ndx, old_col_ndx);
+            size_t backlink_col_ndx = target_spec->find_backlink_column(origin_table_ndx, old_col_ndx);
             update_backlink_columns.emplace_back(target_spec, backlink_col_ndx, col_ndx);
         }
     }
     else if (moved_from > moved_to) {
         // Moved down:
         for (size_t col_ndx = moved_to + 1; col_ndx <= moved_from; ++col_ndx) {
-            if (!is_link_type(m_spec.get_column_type(col_ndx)))
+            if (!is_link_type(m_spec->get_column_type(col_ndx)))
                 continue;
             LinkColumnBase* link_col = static_cast<LinkColumnBase*>(m_cols[col_ndx]);
-            Spec& target_spec = link_col->get_target_table().m_spec;
+            Spec* target_spec = link_col->get_target_table().m_spec.get();
             size_t old_col_ndx = col_ndx - 1;
-            size_t backlink_col_ndx = target_spec.find_backlink_column(origin_table_ndx, old_col_ndx);
+            size_t backlink_col_ndx = target_spec->find_backlink_column(origin_table_ndx, old_col_ndx);
             update_backlink_columns.emplace_back(target_spec, backlink_col_ndx, col_ndx);
         }
     }
 
     for (auto& t : update_backlink_columns) {
-        Spec& target_spec = std::get<0>(t);
-        target_spec.set_backlink_origin_column(std::get<1>(t), std::get<2>(t));
+        Spec* target_spec = std::get<0>(t);
+        target_spec->set_backlink_origin_column(std::get<1>(t), std::get<2>(t));
     }
 }
 
@@ -1202,7 +1203,7 @@ void Table::update_subtables(const size_t* col_path_begin, const size_t* col_pat
         if (subtable) {
             // If it exists, we need to refresh its shared spec accessor since
             // parts of the underlying shared spec may have been relocated.
-            subtable->m_spec.init_from_parent();
+            subtable->m_spec->init_from_parent();
         }
         if (is_parent_of_modify_level) {
             // The subtables of the parent at this level are the ones that need
@@ -1289,17 +1290,17 @@ void Table::create_degen_subtab_columns()
     m_columns.update_parent();             // Throws
 
     Allocator& alloc = m_columns.get_alloc();
-    size_t num_cols = m_spec.get_column_count();
+    size_t num_cols = m_spec->get_column_count();
     for (size_t i = 0; i < num_cols; ++i) {
-        ColumnType type = m_spec.get_column_type(i);
-        bool nullable = (m_spec.get_column_attr(i) & col_attr_Nullable) != 0;
+        ColumnType type = m_spec->get_column_type(i);
+        bool nullable = (m_spec->get_column_attr(i) & col_attr_Nullable) != 0;
         size_t init_size = 0;
         ref_type ref = create_column(type, init_size, nullable, alloc); // Throws
         m_columns.add(int_fast64_t(ref));                               // Throws
 
         // So far, only root tables can have search indexes, and this is not a
         // root table.
-        REALM_ASSERT_3(m_spec.get_column_attr(i) & ~col_attr_Nullable, ==, col_attr_None);
+        REALM_ASSERT_3(m_spec->get_column_attr(i) & ~col_attr_Nullable, ==, col_attr_None);
     }
 
     m_cols.resize(num_cols);
@@ -1315,7 +1316,7 @@ void Table::detach() noexcept
 
     if (Replication* repl = get_repl())
         repl->on_table_destroyed(this);
-    m_spec.m_top.detach();
+    m_spec.detach();
 
     discard_desc_accessor();
 
@@ -1448,7 +1449,7 @@ ColumnBase* Table::create_column_accessor(ColumnType col_type, size_t col_ndx, s
         case col_type_StringEnum: {
             ArrayParent* keys_parent;
             size_t keys_ndx_in_parent;
-            ref_type keys_ref = m_spec.get_enumkeys_ref(col_ndx, &keys_parent, &keys_ndx_in_parent);
+            ref_type keys_ref = m_spec->get_enumkeys_ref(col_ndx, &keys_parent, &keys_ndx_in_parent);
             StringEnumColumn* col_2 = new StringEnumColumn(alloc, ref, keys_ref, nullable, col_ndx); // Throws
             col_2->get_keys().set_parent(keys_parent, keys_ndx_in_parent);
             col = col_2;
@@ -1514,7 +1515,7 @@ Table::~Table() noexcept
 
     if (Replication* repl = get_repl())
         repl->on_table_destroyed(this);
-    m_spec.m_top.detach();
+    m_spec.detach();
 
     if (!m_top.is_attached()) {
         // This is a subtable with a shared spec, and its lifetime is managed by
@@ -1712,14 +1713,15 @@ void Table::add_search_index(size_t col_ndx)
     }
 
     // The index goes in the list of column refs immediate after the owning column
-    size_t index_pos = m_spec.get_column_info(col_ndx).m_column_ref_ndx + 1;
+    size_t index_pos = m_spec->get_column_info(col_ndx).m_column_ref_ndx + 1;
     index->set_parent(&m_columns, index_pos);
     m_columns.insert(index_pos, index->get_ref()); // Throws
 
     // Mark the column as having an index
-    int attr = m_spec.get_column_attr(col_ndx);
+    Spec* spec = get_descriptor()->get_spec();
+    int attr = spec->get_column_attr(col_ndx);
     attr |= col_attr_Indexed;
-    m_spec.set_column_attr(col_ndx, ColumnAttr(attr)); // Throws
+    spec->set_column_attr(col_ndx, ColumnAttr(attr)); // Throws
 
     // Update column accessors for all columns after the one we just added an
     // index for, as their position in `m_columns` has changed
@@ -1750,13 +1752,14 @@ void Table::remove_search_index(size_t col_ndx)
     col.destroy_search_index();
 
     // The index is always immediately after the column in m_columns
-    size_t index_pos = m_spec.get_column_info(col_ndx).m_column_ref_ndx + 1;
+    size_t index_pos = m_spec->get_column_info(col_ndx).m_column_ref_ndx + 1;
     m_columns.erase(index_pos);
 
     // Mark the column as no longer having an index
-    int attr = m_spec.get_column_attr(col_ndx);
+    Spec* spec = get_descriptor()->get_spec();
+    int attr = spec->get_column_attr(col_ndx);
     attr &= ~col_attr_Indexed;
-    m_spec.set_column_attr(col_ndx, ColumnAttr(attr)); // Throws
+    spec->set_column_attr(col_ndx, ColumnAttr(attr)); // Throws
 
     // Update column accessors for all columns after the one we just removed the
     // index for, as their position in `m_columns` has changed
@@ -1810,22 +1813,27 @@ void Table::remove_search_index(size_t col_ndx)
 
 bool Table::is_nullable(size_t col_ndx) const
 {
-    REALM_ASSERT_DEBUG(col_ndx < m_spec.get_column_count());
-    return (m_spec.get_column_attr(col_ndx) & col_attr_Nullable) || m_spec.get_column_type(col_ndx) == col_type_Link;
+    if (!is_attached()) {
+        throw LogicError{LogicError::detached_accessor};
+    }
+
+    REALM_ASSERT_DEBUG(col_ndx < m_spec->get_column_count());
+    return (m_spec->get_column_attr(col_ndx) & col_attr_Nullable) ||
+           m_spec->get_column_type(col_ndx) == col_type_Link;
 }
 
 const ColumnBase& Table::get_column_base(size_t ndx) const noexcept
 {
-    REALM_ASSERT_DEBUG(ndx < m_spec.get_column_count());
-    REALM_ASSERT_DEBUG(m_cols.size() == m_spec.get_column_count());
+    REALM_ASSERT_DEBUG(ndx < m_spec->get_column_count());
+    REALM_ASSERT_DEBUG(m_cols.size() == m_spec->get_column_count());
     return *m_cols[ndx];
 }
 
 ColumnBase& Table::get_column_base(size_t ndx)
 {
-    REALM_ASSERT_DEBUG(ndx < m_spec.get_column_count());
+    REALM_ASSERT_DEBUG(ndx < m_spec->get_column_count());
     instantiate_before_change();
-    REALM_ASSERT_DEBUG(m_cols.size() == m_spec.get_column_count());
+    REALM_ASSERT_DEBUG(m_cols.size() == m_spec->get_column_count());
     return *m_cols[ndx];
 }
 
@@ -1932,7 +1940,7 @@ TimestampColumn& Table::get_column_timestamp(size_t ndx)
 const LinkColumnBase& Table::get_column_link_base(size_t ndx) const noexcept
 {
     const ColumnBase& col_base = get_column_base(ndx);
-    REALM_ASSERT(m_spec.get_column_type(ndx) == col_type_Link || m_spec.get_column_type(ndx) == col_type_LinkList);
+    REALM_ASSERT(m_spec->get_column_type(ndx) == col_type_Link || m_spec->get_column_type(ndx) == col_type_LinkList);
     const LinkColumnBase& col_link_base = static_cast<const LinkColumnBase&>(col_base);
     return col_link_base;
 }
@@ -1940,7 +1948,7 @@ const LinkColumnBase& Table::get_column_link_base(size_t ndx) const noexcept
 LinkColumnBase& Table::get_column_link_base(size_t ndx)
 {
     ColumnBase& col_base = get_column_base(ndx);
-    REALM_ASSERT(m_spec.get_column_type(ndx) == col_type_Link || m_spec.get_column_type(ndx) == col_type_LinkList);
+    REALM_ASSERT(m_spec->get_column_type(ndx) == col_type_Link || m_spec->get_column_type(ndx) == col_type_LinkList);
     LinkColumnBase& col_link_base = static_cast<LinkColumnBase&>(col_base);
     return col_link_base;
 }
@@ -2110,7 +2118,7 @@ ref_type Table::clone(Allocator& alloc) const
     new_top.create(Array::type_HasRefs); // Throws
     _impl::DeepArrayRefDestroyGuard dg_2(alloc);
     {
-        MemRef mem = m_spec.m_top.clone_deep(alloc); // Throws
+        MemRef mem = m_spec->m_top.clone_deep(alloc); // Throws
         dg_2.reset(mem.get_ref());
         int_fast64_t v(from_ref(mem.get_ref()));
         new_top.add(v); // Throws
@@ -2134,7 +2142,7 @@ void Table::insert_empty_row(size_t row_ndx, size_t num_rows)
     REALM_ASSERT_DEBUG(row_ndx <= m_size);
     REALM_ASSERT_DEBUG(num_rows <= std::numeric_limits<size_t>::max() - row_ndx);
 
-    size_t num_cols = m_spec.get_column_count();
+    size_t num_cols = m_spec->get_column_count();
     if (REALM_UNLIKELY(num_cols == 0)) {
         throw LogicError(LogicError::table_has_no_columns);
     }
@@ -2163,7 +2171,7 @@ void Table::erase_row(size_t row_ndx, bool is_move_last_over)
     REALM_ASSERT(is_attached());
     REALM_ASSERT_3(row_ndx, <, m_size);
 
-    bool skip_cascade = !m_spec.has_strong_link_columns();
+    bool skip_cascade = !m_spec->has_strong_link_columns();
 
     // FIXME: Is this really necessary? Waiting for clarification from Thomas
     // Goyne.
@@ -2226,7 +2234,7 @@ void Table::batch_erase_rows(const IntegerColumn& row_indexes, bool is_move_last
 {
     REALM_ASSERT(is_attached());
 
-    bool skip_cascade = !m_spec.has_strong_link_columns();
+    bool skip_cascade = !m_spec->has_strong_link_columns();
 
     // FIXME: Is this really necessary? Waiting for clarification from Thomas
     // Goyne.
@@ -2306,8 +2314,8 @@ void Table::batch_erase_rows(const IntegerColumn& row_indexes, bool is_move_last
 // directly with broken_reciprocal_backlinks=false.
 void Table::do_remove(size_t row_ndx, bool broken_reciprocal_backlinks)
 {
-    size_t num_cols = m_spec.get_column_count();
-    size_t num_public_cols = m_spec.get_public_column_count();
+    size_t num_cols = m_spec->get_column_count();
+    size_t num_public_cols = m_spec->get_public_column_count();
 
     // We must start with backlink columns in case the corresponding link
     // columns are in the same table so that the link columns are not updated
@@ -2348,8 +2356,8 @@ void Table::do_remove(size_t row_ndx, bool broken_reciprocal_backlinks)
 // directly with broken_reciprocal_backlinks=false.
 void Table::do_move_last_over(size_t row_ndx, bool broken_reciprocal_backlinks)
 {
-    size_t num_cols = m_spec.get_column_count();
-    size_t num_public_cols = m_spec.get_public_column_count();
+    size_t num_cols = m_spec->get_column_count();
+    size_t num_public_cols = m_spec->get_public_column_count();
 
     // We must start with backlink columns in case the corresponding link
     // columns are in the same table so that the link columns are not updated
@@ -2392,7 +2400,7 @@ void Table::do_swap_rows(size_t row_ndx_1, size_t row_ndx_2)
 {
     REALM_ASSERT(row_ndx_1 < row_ndx_2);
 
-    size_t num_cols = m_spec.get_column_count();
+    size_t num_cols = m_spec->get_column_count();
     for (size_t col_ndx = 0; col_ndx != num_cols; ++col_ndx) {
         ColumnBase& col = get_column_base(col_ndx);
         col.swap_rows(row_ndx_1, row_ndx_2);
@@ -2418,7 +2426,7 @@ void Table::do_merge_rows(size_t row_ndx, size_t new_row_ndx)
     size_t row_ndx_1 = row_ndx, row_ndx_2 = new_row_ndx;
     if (row_ndx_1 > row_ndx_2)
         std::swap(row_ndx_1, row_ndx_2);
-    size_t num_cols = m_spec.get_column_count();
+    size_t num_cols = m_spec->get_column_count();
     for (size_t col_ndx = 0; col_ndx != num_cols; ++col_ndx) {
         ColumnBase& col = get_column_base(col_ndx);
         if (get_column_type(col_ndx) == type_LinkList) {
@@ -2470,7 +2478,7 @@ void Table::clear()
 // directly with broken_reciprocal_backlinks=false.
 void Table::do_clear(bool broken_reciprocal_backlinks)
 {
-    size_t num_cols = m_spec.get_column_count();
+    size_t num_cols = m_spec->get_column_count();
     for (size_t col_ndx = 0; col_ndx != num_cols; ++col_ndx) {
         ColumnBase& col = get_column_base(col_ndx);
         col.clear(m_size, broken_reciprocal_backlinks); // Throws
@@ -3538,7 +3546,7 @@ void Table::set_null_unique(size_t col_ndx, size_t row_ndx)
     if (!is_nullable(col_ndx)) {
         throw LogicError{LogicError::column_not_nullable};
     }
-    REALM_ASSERT(!is_link_type(m_spec.get_column_type(col_ndx))); // Use nullify_link().
+    REALM_ASSERT(!is_link_type(m_spec->get_column_type(col_ndx))); // Use nullify_link().
     REALM_ASSERT_3(col_ndx, <, get_column_count());
     REALM_ASSERT_3(row_ndx, <, m_size);
 
@@ -3569,7 +3577,7 @@ void Table::set_null(size_t col_ndx, size_t row_ndx, bool is_default)
     if (!is_nullable(col_ndx)) {
         throw LogicError{LogicError::column_not_nullable};
     }
-    REALM_ASSERT(!is_link_type(m_spec.get_column_type(col_ndx))); // Use nullify_link().
+    REALM_ASSERT(!is_link_type(m_spec->get_column_type(col_ndx))); // Use nullify_link().
     REALM_ASSERT_3(col_ndx, <, get_column_count());
     REALM_ASSERT_3(row_ndx, <, m_size);
 
@@ -4562,10 +4570,10 @@ void Table::optimize(bool enforce)
             if (!res)
                 continue;
 
-            Spec::ColumnInfo info = m_spec.get_column_info(i);
+            Spec::ColumnInfo info = m_spec->get_column_info(i);
             ArrayParent* keys_parent;
             size_t keys_ndx_in_parent;
-            m_spec.upgrade_string_to_enum(i, keys_ref, keys_parent, keys_ndx_in_parent);
+            m_spec->upgrade_string_to_enum(i, keys_ref, keys_parent, keys_ndx_in_parent);
 
             // Upgrading the column may have moved the
             // refs to keylists in other columns so we
@@ -4579,7 +4587,7 @@ void Table::optimize(bool enforce)
             }
 
             // Indexes are also in m_columns, so we need adjusted pos
-            size_t ndx_in_parent = m_spec.get_column_ndx_in_parent(i);
+            size_t ndx_in_parent = m_spec->get_column_ndx_in_parent(i);
 
             // Replace column
             StringEnumColumn* e = new StringEnumColumn(alloc, ref, keys_ref, is_nullable(i), i); // Throws
@@ -4635,7 +4643,7 @@ public:
         // write it to the output stream
         ref_type spec_ref;
         {
-            MemRef mem = m_table.m_spec.m_top.clone_deep(alloc); // Throws
+            MemRef mem = m_table.m_spec->m_top.clone_deep(alloc); // Throws
             Spec spec(alloc);
             spec.init(mem); // Throws
             _impl::DestroyGuard<Spec> dg(&spec);
@@ -4732,7 +4740,7 @@ void Table::update_from_parent(size_t old_baseline) noexcept
             return;
     }
 
-    m_spec.update_from_parent(old_baseline);
+    m_spec->update_from_parent(old_baseline);
 
     if (!m_columns.is_attached())
         return; // Degenerate subtable
@@ -5454,15 +5462,19 @@ StringData Table::Parent::get_child_name(size_t) const noexcept
 
 Group* Table::Parent::get_parent_group() noexcept
 {
-    return 0;
+    return nullptr;
 }
 
 
 Table* Table::Parent::get_parent_table(size_t*) noexcept
 {
-    return 0;
+    return nullptr;
 }
 
+Spec* Table::Parent::get_subtable_spec() noexcept
+{
+    return nullptr;
+}
 
 void Table::adj_acc_insert_rows(size_t row_ndx, size_t num_rows) noexcept
 {
@@ -5812,12 +5824,12 @@ void Table::refresh_accessor_tree()
         // Root table (free-standing table, group-level table, or subtable with
         // independent descriptor)
         m_top.init_from_parent();
-        m_spec.init_from_parent();
+        m_spec->init_from_parent();
         m_columns.init_from_parent();
     }
     else {
         // Subtable with shared descriptor
-        m_spec.init_from_parent();
+        refresh_spec_accessor();
 
         // If the underlying table was degenerate, then `m_cols` must still be
         // empty.
@@ -5827,7 +5839,7 @@ void Table::refresh_accessor_tree()
         if (columns_ref != 0) {
             if (!m_columns.is_attached()) {
                 // The underlying table is no longer degenerate
-                size_t num_cols = m_spec.get_column_count();
+                size_t num_cols = m_spec->get_column_count();
                 m_cols.resize(num_cols); // Throws
             }
             m_columns.init_from_ref(columns_ref);
@@ -5843,12 +5855,26 @@ void Table::refresh_accessor_tree()
     m_mark = false;
 }
 
+void Table::refresh_spec_accessor()
+{
+    REALM_ASSERT(is_attached());
+    if (!m_top.is_attached()) {
+        // this is only relevant for subtables
+
+        ArrayParent* array_parent = m_columns.get_parent();
+        REALM_ASSERT(dynamic_cast<Parent*>(array_parent));
+        Parent* table_parent = static_cast<Parent*>(array_parent);
+
+        Spec* subspec = table_parent->get_subtable_spec();
+        m_spec = subspec;
+    }
+}
 
 void Table::refresh_column_accessors(size_t col_ndx_begin)
 {
     // Index of column in Table::m_columns, which is not always equal to the
     // 'logical' column index.
-    size_t ndx_in_parent = m_spec.get_column_ndx_in_parent(col_ndx_begin);
+    size_t ndx_in_parent = m_spec->get_column_ndx_in_parent(col_ndx_begin);
 
     size_t col_ndx_end = m_cols.size();
     for (size_t col_ndx = col_ndx_begin; col_ndx != col_ndx_end; ++col_ndx) {
@@ -5856,7 +5882,7 @@ void Table::refresh_column_accessors(size_t col_ndx_begin)
 
         // If there is no search index accessor, but the column has been
         // equipped with a search index, create the accessor now.
-        ColumnAttr attr = m_spec.get_column_attr(col_ndx);
+        ColumnAttr attr = m_spec->get_column_attr(col_ndx);
         bool column_has_search_index = (attr & col_attr_Indexed) != 0;
 
         if (!column_has_search_index && col)
@@ -5866,7 +5892,7 @@ void Table::refresh_column_accessors(size_t col_ndx_begin)
         // column has been upgraded to an enumerated strings column, then we
         // need to replace the accessor with an instance of StringEnumColumn.
         if (dynamic_cast<StringColumn*>(col) != nullptr) {
-            ColumnType col_type = m_spec.get_column_type(col_ndx);
+            ColumnType col_type = m_spec->get_column_type(col_ndx);
             if (col_type == col_type_StringEnum) {
                 delete col;
                 col = 0;
@@ -5880,10 +5906,10 @@ void Table::refresh_column_accessors(size_t col_ndx_begin)
         if (col) {
             // Refresh the column accessor
             col->set_ndx_in_parent(ndx_in_parent);
-            col->refresh_accessor_tree(col_ndx, m_spec); // Throws
+            col->refresh_accessor_tree(col_ndx, *m_spec); // Throws
         }
         else {
-            ColumnType col_type = m_spec.get_column_type(col_ndx);
+            ColumnType col_type = m_spec->get_column_type(col_ndx);
             col = create_column_accessor(col_type, col_ndx, ndx_in_parent); // Throws
             m_cols[col_ndx] = col;
             // In the case of a link-type column, we must establish a connection
@@ -5900,20 +5926,20 @@ void Table::refresh_column_accessors(size_t col_ndx_begin)
                 LinkColumnBase* link_col = static_cast<LinkColumnBase*>(col);
                 link_col->set_weak_links(weak_links);
                 Group& group = *get_parent_group();
-                size_t target_table_ndx = m_spec.get_opposite_link_table_ndx(col_ndx);
+                size_t target_table_ndx = m_spec->get_opposite_link_table_ndx(col_ndx);
                 Table& target_table = gf::get_table(group, target_table_ndx); // Throws
                 if (!target_table.is_marked() && &target_table != this) {
                     size_t origin_ndx_in_group = m_top.get_ndx_in_parent();
-                    size_t backlink_col_ndx = target_table.m_spec.find_backlink_column(origin_ndx_in_group, col_ndx);
+                    size_t backlink_col_ndx = target_table.m_spec->find_backlink_column(origin_ndx_in_group, col_ndx);
                     connect_opposite_link_columns(col_ndx, target_table, backlink_col_ndx);
                 }
             }
             else if (col_type == col_type_BackLink) {
                 Group& group = *get_parent_group();
-                size_t origin_table_ndx = m_spec.get_opposite_link_table_ndx(col_ndx);
+                size_t origin_table_ndx = m_spec->get_opposite_link_table_ndx(col_ndx);
                 Table& origin_table = gf::get_table(group, origin_table_ndx); // Throws
                 if (!origin_table.is_marked() || &origin_table == this) {
-                    size_t link_col_ndx = m_spec.get_origin_column_ndx(col_ndx);
+                    size_t link_col_ndx = m_spec->get_origin_column_ndx(col_ndx);
                     origin_table.connect_opposite_link_columns(link_col_ndx, *this, col_ndx);
                 }
             }
@@ -5945,7 +5971,7 @@ void Table::refresh_column_accessors(size_t col_ndx_begin)
 
 void Table::refresh_link_target_accessors(size_t col_ndx_begin)
 {
-    REALM_ASSERT_3(col_ndx_begin, <=, m_spec.get_public_column_count());
+    REALM_ASSERT_3(col_ndx_begin, <=, m_spec->get_public_column_count());
     typedef _impl::GroupFriend gf;
 
     Group* group = get_parent_group();
@@ -5954,19 +5980,19 @@ void Table::refresh_link_target_accessors(size_t col_ndx_begin)
     // of refresh_column_accessors(), so the case of free standing tables is already handled.
     if (group) {
         size_t origin_ndx_in_group = m_top.get_ndx_in_parent();
-        size_t col_ndx_end = m_spec.get_public_column_count(); // No need to check backlink columns
+        size_t col_ndx_end = m_spec->get_public_column_count(); // No need to check backlink columns
 
         for (size_t col_ndx = col_ndx_begin; col_ndx != col_ndx_end; ++col_ndx) {
-            ColumnType col_type = m_spec.get_column_type(col_ndx);
+            ColumnType col_type = m_spec->get_column_type(col_ndx);
             if (is_link_type(col_type)) {
-                size_t target_table_ndx = m_spec.get_opposite_link_table_ndx(col_ndx);
+                size_t target_table_ndx = m_spec->get_opposite_link_table_ndx(col_ndx);
                 Table& target_table = gf::get_table(*group, target_table_ndx); // Throws
                 ColumnBase* col = m_cols[col_ndx];
                 if (col && !target_table.is_marked() && (&target_table != this)) {
                     LinkColumnBase* link_col = static_cast<LinkColumnBase*>(col);
                     BacklinkColumn& backlink_col = link_col->get_backlink_column();
-                    size_t backlink_col_ndx = target_table.m_spec.find_backlink_column(origin_ndx_in_group, col_ndx);
-                    backlink_col.refresh_accessor_tree(backlink_col_ndx, target_table.m_spec);
+                    size_t backlink_col_ndx = target_table.m_spec->find_backlink_column(origin_ndx_in_group, col_ndx);
+                    backlink_col.refresh_accessor_tree(backlink_col_ndx, *target_table.m_spec);
                 }
             }
         }
@@ -5977,7 +6003,7 @@ void Table::refresh_link_target_accessors(size_t col_ndx_begin)
 bool Table::is_cross_table_link_target() const noexcept
 {
     size_t n = m_cols.size();
-    for (size_t i = m_spec.get_public_column_count(); i < n; ++i) {
+    for (size_t i = m_spec->get_public_column_count(); i < n; ++i) {
         REALM_ASSERT(dynamic_cast<BacklinkColumn*>(m_cols[i]));
         BacklinkColumn& backlink_col = static_cast<BacklinkColumn&>(*m_cols[i]);
         Table& origin = backlink_col.get_origin_table();
@@ -6045,7 +6071,7 @@ void Table::verify() const
     if (m_top.is_attached())
         m_top.verify();
     m_columns.verify();
-    m_spec.verify();
+    m_spec->verify();
 
 
     // Verify row accessors
@@ -6061,11 +6087,11 @@ void Table::verify() const
 
     // Verify column accessors
     {
-        size_t n = m_spec.get_column_count();
+        size_t n = m_spec->get_column_count();
         REALM_ASSERT_3(n, ==, m_cols.size());
         for (size_t i = 0; i != n; ++i) {
             const ColumnBase& col = get_column_base(i);
-            size_t ndx_in_parent = m_spec.get_column_ndx_in_parent(i);
+            size_t ndx_in_parent = m_spec->get_column_ndx_in_parent(i);
             REALM_ASSERT_3(ndx_in_parent, ==, col.get_ndx_in_parent());
             col.verify(*this, i);
             REALM_ASSERT_3(col.size(), ==, m_size);
@@ -6085,7 +6111,7 @@ void Table::to_dot(std::ostream& out, StringData title) const
             out << "\\n'" << title << "'";
         out << "\";" << std::endl;
         m_top.to_dot(out, "table_top");
-        m_spec.to_dot(out);
+        m_spec->to_dot(out);
     }
     else {
         out << "subgraph cluster_table_" << m_columns.get_ref() << " {" << std::endl;
@@ -6119,11 +6145,11 @@ void Table::print() const
 {
     // Table header
     std::cout << "Table (name = \"" << std::string(get_name()) << "\",  size = " << m_size << ")\n    ";
-    size_t column_count = m_spec.get_column_count(); // We can print backlinks too.
+    size_t column_count = m_spec->get_column_count(); // We can print backlinks too.
     for (size_t i = 0; i < column_count; ++i) {
         std::string name = "backlink";
         if (i < get_column_count()) {
-            name = m_spec.get_column_name(i);
+            name = m_spec->get_column_name(i);
         }
         std::cout << std::left << std::setw(10) << std::string(name).substr(0, 10) << " ";
     }
@@ -6152,21 +6178,21 @@ void Table::print() const
                 std::cout << "String     ";
                 break;
             case col_type_Link: {
-                size_t target_table_ndx = m_spec.get_opposite_link_table_ndx(i);
+                size_t target_table_ndx = m_spec->get_opposite_link_table_ndx(i);
                 ConstTableRef target_table = get_parent_group()->get_table(target_table_ndx);
                 const StringData target_name = target_table->get_name();
                 std::cout << "L->" << std::setw(7) << std::string(target_name).substr(0, 7) << " ";
                 break;
             }
             case col_type_LinkList: {
-                size_t target_table_ndx = m_spec.get_opposite_link_table_ndx(i);
+                size_t target_table_ndx = m_spec->get_opposite_link_table_ndx(i);
                 ConstTableRef target_table = get_parent_group()->get_table(target_table_ndx);
                 const StringData target_name = target_table->get_name();
                 std::cout << "LL->" << std::setw(6) << std::string(target_name).substr(0, 6) << " ";
                 break;
             }
             case col_type_BackLink: {
-                size_t target_table_ndx = m_spec.get_opposite_link_table_ndx(i);
+                size_t target_table_ndx = m_spec->get_opposite_link_table_ndx(i);
                 ConstTableRef target_table = get_parent_group()->get_table(target_table_ndx);
                 const StringData target_name = target_table->get_name();
                 std::cout << "BL->" << std::setw(6) << std::string(target_name).substr(0, 6) << " ";

--- a/src/realm/table.hpp
+++ b/src/realm/table.hpp
@@ -831,7 +831,7 @@ public:
     /// where it takes up a minimal amout of space. This function returns true
     /// if, and only if the table accessor is attached to such a subtable. This
     /// function is mainly intended for debugging purposes.
-    bool is_degenerate() const noexcept;
+    bool is_degenerate() const;
 
     // Debug
     void verify() const;
@@ -2029,7 +2029,7 @@ inline bool Table::operator!=(const Table& t) const
     return !(*this == t); // Throws
 }
 
-inline bool Table::is_degenerate() const noexcept
+inline bool Table::is_degenerate() const
 {
     if (!is_attached()) {
         throw LogicError{LogicError::detached_accessor};

--- a/src/realm/table.hpp
+++ b/src/realm/table.hpp
@@ -220,21 +220,22 @@ public:
     /// added to the specified column. Rather than throwing, it returns false if
     /// the table accessor is detached or the specified index is out of range.
     ///
-    /// add_search_index() adds a search index to the specified column of this
+    /// add_search_index() adds a search index to the specified column of the
     /// table. It has no effect if a search index has already been added to the
     /// specified column (idempotency).
     ///
     /// remove_search_index() removes the search index from the specified column
-    /// of this table. It has no effect if the specified column has no search
+    /// of the table. It has no effect if the specified column has no search
     /// index. The search index cannot be removed from the primary key of a
     /// table.
     ///
     /// This table must be a root table; that is, it must have an independent
     /// descriptor. Freestanding tables, group-level tables, and subtables in a
     /// column of type 'mixed' are all examples of root tables. See add_column()
-    /// for more on this.
+    /// for more on this. If you want to manipulate subtable indexes, you must use
+    /// the Descriptor interface.
     ///
-    /// \param column_ndx The index of a column of this table.
+    /// \param column_ndx The index of a column of the table.
 
     bool has_search_index(size_t column_ndx) const noexcept;
     void add_search_index(size_t column_ndx);
@@ -1022,6 +1023,9 @@ private:
     template <class ColType, class T>
     size_t do_set_unique(ColType& column, size_t row_ndx, T&& value, bool& conflict);
 
+    void _add_search_index(size_t column_ndx);
+    void _remove_search_index(size_t column_ndx);
+
     void upgrade_file_format(size_t target_file_format_version);
 
     // Upgrades OldDateTime columns to Timestamp columns
@@ -1079,6 +1083,9 @@ private:
     static void do_erase_column(Descriptor&, size_t col_ndx);
     static void do_rename_column(Descriptor&, size_t col_ndx, StringData name);
     static void do_move_column(Descriptor&, size_t col_ndx_1, size_t col_ndx_2);
+
+    static void do_add_search_index(Descriptor&, size_t col_ndx);
+    static void do_remove_search_index(Descriptor&, size_t col_ndx);
 
     struct InsertSubtableColumns;
     struct EraseSubtableColumns;
@@ -2315,6 +2322,16 @@ public:
     static void rename_column(Descriptor& desc, size_t column_ndx, StringData name)
     {
         Table::do_rename_column(desc, column_ndx, name); // Throws
+    }
+
+    static void add_search_index(Descriptor& desc, size_t column_ndx)
+    {
+        Table::do_add_search_index(desc, column_ndx); // Throws
+    }
+
+    static void remove_search_index(Descriptor& desc, size_t column_ndx)
+    {
+        Table::do_remove_search_index(desc, column_ndx); // Throws
     }
 
     static void move_column(Descriptor& desc, size_t col_ndx_1, size_t col_ndx_2)

--- a/src/realm/table.hpp
+++ b/src/realm/table.hpp
@@ -948,6 +948,11 @@ private:
         {
             return m_p != nullptr;
         }
+        bool is_managed() const
+        {
+            return m_is_managed;
+        }
+
     private:
         Spec* m_p = nullptr;
         bool m_is_managed = false;

--- a/test/test_group.cpp
+++ b/test/test_group.cpp
@@ -1723,6 +1723,15 @@ TEST(Group_CommitSubtable)
     subtable = table->get_subtable(0, 0);
     subtable->add_empty_row();
     group.commit();
+    group.verify();
+
+    TableRef table1 = group.add_table("other");
+    table1->add_column_link(type_LinkList, "linkList", *table);
+    group.commit();
+    group.verify();
+    table->insert_column_link(0, type_Link, "link", *table);
+    group.commit();
+    group.verify();
 }
 
 

--- a/test/test_lang_bind_helper.cpp
+++ b/test/test_lang_bind_helper.cpp
@@ -1554,6 +1554,17 @@ TEST(LangBindHelper_AdvanceReadTransact_RegularSubtables)
     }
     LangBindHelper::advance_read(sg);
     group.verify();
+    // Check that subtable accessors are updated with respect to spec reference
+    {
+        WriteTransaction wt(sg_w);
+        TableRef parent_w = wt.get_table("parent");
+        DescriptorRef subdesc;
+        parent_w->add_column(type_Table, "c", &subdesc);
+        subdesc->add_column(type_Int, "y");
+        wt.commit();
+    }
+    LangBindHelper::advance_read(sg);
+    group.verify();
     CHECK_EQUAL(3, parent->size());
     CHECK(subtab_0_0->is_attached());
     CHECK(subtab_0_1->is_attached());
@@ -1572,6 +1583,7 @@ TEST(LangBindHelper_AdvanceReadTransact_RegularSubtables)
     {
         WriteTransaction wt(sg_w);
         TableRef parent_w = wt.get_table("parent");
+        parent_w->remove_column(2);
         parent_w->insert_column(0, type_Table, "dummy_1");
         parent_w->insert_empty_row(0);
         TableRef subtab_0_0_w = parent_w->get_subtable(1, 1);

--- a/test/test_table.cpp
+++ b/test/test_table.cpp
@@ -2815,6 +2815,194 @@ TEST(Table_Spec)
     }
 }
 
+TEST(Table_SubtableIndex)
+{
+    GROUP_TEST_PATH(path);
+
+    {
+        Group group;
+        DescriptorRef sub_1;
+        TableRef table = group.add_table("test");
+
+        // Create specification with sub-table
+        table->add_column(type_String, "first");
+        table->add_column(type_Table, "second", &sub_1);
+
+        sub_1->add_column(type_Int, "sub_first");
+        sub_1->add_column(type_String, "sub_second");
+
+        // Add search index to `degenerate` subtable (subtable which does not yet exist because it has
+        // no rows yet, so it's just a 0-ref in the ColumnTable object). Important to test because the
+        // search index is then constructed in a different place in the source code
+        sub_1->add_search_index(0);
+        CHECK(sub_1->has_search_index(0));
+        sub_1->remove_search_index(0);
+        CHECK(!sub_1->has_search_index(0));
+        sub_1->add_search_index(0);
+        CHECK(sub_1->has_search_index(0));
+
+        CHECK_EQUAL(2, table->get_column_count());
+
+        // Add two rows to parent table
+        table->add_empty_row();
+        table->add_empty_row();
+        table->set_string(0, 0, "Hello");
+
+        // Add rows to first subtable
+        TableRef subtable = table->get_subtable(1, 0);
+        CHECK(subtable->is_empty());
+        subtable->add_empty_row();
+        subtable->set_int(0, 0, 42);
+        subtable->set_string(1, 0, "testsub1");
+        subtable->add_empty_row();
+        subtable->set_int(0, 1, 43);
+        subtable->set_string(1, 1, "testsub2");
+        CHECK_THROW_ANY(subtable->remove_search_index(0));
+        CHECK_THROW_ANY(subtable->add_search_index(0));
+
+        // Add rows to second subtable
+        subtable = table->get_subtable(1, 1);
+        CHECK(subtable->is_empty());
+        subtable->add_empty_row();
+        subtable->set_int(0, 0, 66);
+        subtable->set_string(1, 0, "testsub3");
+        subtable->add_empty_row();
+        subtable->set_int(0, 1, 77);
+        subtable->set_string(1, 1, "testsub4");
+
+        int64_t tt = subtable.get()->get_int(0, 0);
+        CHECK_EQUAL(tt, 66);
+
+        subtable = table->get_subtable(1, 0);
+        CHECK(subtable.get()->has_search_index(0));
+
+        size_t match;
+
+        match = subtable.get()->where().equal(0, 43).find();
+        CHECK_EQUAL(match, 1);
+        match = subtable.get()->where().equal(1, "testsub2").find();
+        CHECK_EQUAL(match, 1);
+
+        // group.verify();
+        // group.to_dot("group.dot");
+
+        subtable = table->get_subtable(1, 1);
+
+        match = subtable.get()->where().equal(0, 77).find();
+        CHECK_EQUAL(match, 1);
+
+        // Query column that follows indexed column to test if refresh_column_accessors()
+        // has worked
+        match = subtable.get()->where().equal(1, "testsub4").find();
+        CHECK_EQUAL(match, 1);
+
+        sub_1->remove_search_index(1);
+        CHECK(!subtable.get()->has_search_index(1));
+
+        // Query column that follows indexed column to test if refresh_column_accessors()
+        // has worked
+        match = subtable.get()->where().equal(1, "testsub4").find();
+        CHECK_EQUAL(match, 1);
+
+
+        match = subtable.get()->where().equal(0, 77).find();
+        CHECK_EQUAL(match, 1);
+
+        // Tests non-degenerate construction of index
+        sub_1->add_search_index(1);
+
+        match = subtable.get()->where().equal(0, 77).find();
+        CHECK_EQUAL(match, 1);
+        match = subtable.get()->where().equal(1, "testsub4").find();
+        CHECK_EQUAL(match, 1);
+
+        // Add more data and see if that works
+        subtable.get()->add_empty_row();
+        match = subtable.get()->where().equal(0, 0).find();
+        CHECK_EQUAL(match, 2);
+
+        group.write(path);
+    }
+
+    {
+        // Check persistence
+        Group g2(path);
+        DescriptorRef sub_1;
+        TableRef table = g2.get_table("test");
+
+        TableRef subtable = table->get_subtable(1, 0);
+        CHECK(subtable.get()->has_search_index(0));
+
+        size_t match;
+
+        match = subtable.get()->where().equal(0, 43).find();
+        CHECK_EQUAL(match, 1);
+        match = subtable.get()->where().equal(1, "testsub2").find();
+        CHECK_EQUAL(match, 1);
+
+        subtable = table->get_subtable(1, 1);
+
+        match = subtable.get()->where().equal(0, 77).find();
+        CHECK_EQUAL(match, 1);
+        match = subtable.get()->where().equal(1, "testsub4").find();
+        CHECK_EQUAL(match, 1);
+
+        DescriptorRef subsub;
+        DescriptorRef sub = table.get()->get_subdescriptor(1);
+        sub->add_column(type_Table, "foobar", &subsub);
+        CHECK_THROW_ANY(subsub->add_search_index(0));
+    }
+
+    {
+        // Check that you are not allowed to add index to subtable of subtable
+        Group g2(path);
+        DescriptorRef sub_1;
+        TableRef table = g2.get_table("test");
+        DescriptorRef subsub;
+        DescriptorRef sub = table.get()->get_subdescriptor(1);
+        sub->add_column(type_Table, "baz", &subsub);
+        CHECK_THROW_ANY(subsub->add_search_index(0));
+    }
+
+    {
+        // Check correct updating of other subtable accessors than the one you called add_search_index() on
+        Group g2(path);
+        DescriptorRef des;
+        TableRef table = g2.get_table("test");
+        TableRef sub1 = table->get_subtable(1, 0);
+        TableRef sub2 = table->get_subtable(1, 1);
+
+        size_t match;
+
+        des = table->get_subdescriptor(1);
+
+        des->remove_search_index(0);
+
+        CHECK(!sub1->has_search_index(0));
+        match = sub1->where().equal(1, "testsub2").find();
+        CHECK_EQUAL(match, 1);
+
+        CHECK(!sub2->has_search_index(0));
+        match = sub2->where().equal(1, "testsub4").find();
+        CHECK_EQUAL(match, 1);
+
+        des->add_search_index(0);
+
+        CHECK(sub1->has_search_index(0));
+        match = sub1->where().equal(1, "testsub2").find();
+        CHECK_EQUAL(match, 1);
+
+        CHECK(sub2->has_search_index(0));
+        match = sub2->where().equal(1, "testsub4").find();
+        CHECK_EQUAL(match, 1);
+
+        // Check what happens if user given column index is out of range
+        CHECK_THROW(des->add_search_index(100), LogicError);
+        CHECK_THROW(des->remove_search_index(100), LogicError);
+        CHECK(!des->has_search_index(100));
+    }
+}
+
 TEST(Table_SpecColumnPath)
 {
     Group group;

--- a/test/test_table.cpp
+++ b/test/test_table.cpp
@@ -6880,6 +6880,46 @@ TEST(Table_MultipleLinkColumnsMoveTablesCrossLinks)
 }
 
 
+TEST(Table_MoveSubtables)
+{
+    Group g;
+    TableRef t = g.add_table("A");
+    TableRef t2 = g.add_table("B");
+    {
+        DescriptorRef subdesc;
+
+        t->add_column(type_Table, "sub1", &subdesc);
+        subdesc->add_column(type_Int, "integers");
+
+        t->add_column_link(type_Link, "link", *t2);
+
+        t->add_column(type_Table, "sub2", &subdesc);
+        subdesc->add_column(type_String, "strings");
+    }
+
+    {
+        DescriptorRef sub1 = t->get_subdescriptor(0);
+        DescriptorRef sub2 = t->get_subdescriptor(2);
+        CHECK_EQUAL(sub1->get_column_name(0), "integers");
+        CHECK_EQUAL(sub2->get_column_name(0), "strings");
+    }
+    _impl::TableFriend::move_column(*t->get_descriptor(), 0, 2);
+    {
+        DescriptorRef sub1 = t->get_subdescriptor(2);
+        DescriptorRef sub2 = t->get_subdescriptor(1);
+        CHECK_EQUAL(sub1->get_column_name(0), "integers");
+        CHECK_EQUAL(sub2->get_column_name(0), "strings");
+    }
+    _impl::TableFriend::move_column(*t->get_descriptor(), 2, 0);
+    {
+        DescriptorRef sub1 = t->get_subdescriptor(0);
+        DescriptorRef sub2 = t->get_subdescriptor(2);
+        CHECK_EQUAL(sub1->get_column_name(0), "integers");
+        CHECK_EQUAL(sub2->get_column_name(0), "strings");
+    }
+}
+
+
 TEST(Table_AddColumnWithThreeLevelBptree)
 {
     Table table;


### PR DESCRIPTION
Make Table::m_spec a pointer into the spec/subspec structure

    We must follow the rule that we cannot have multiple accessor objects
    for the same file object. For this reason a subtable accessor cannot
    have its own spec accessor object. Rather should all accessors to
    objects in the same subtable column share the same Spec accessor object.
    
    So the Spec is changed from being embedded in the Table class to being
    referenced. The Spec objects are being managed in a tree with root in
    the root table Spec object. A new class - SpecPtr - is introduced to
    handle the ownership of the Spec object. Only if the table is a table
    with independent spec, the spec object should be deleted when the Table
    object is deleted.

 Support adding search index to subtable columns
    
    You add the search index using the Descriptor interface. The old
    Table interface is changed to use the Descriptor interface
    internally. The corresponding replication commands are changed
    accordingly.