### PR TITLE
Remove unused function set_termination_notification_callback

### DIFF
--- a/src/realm/util/terminate.cpp
+++ b/src/realm/util/terminate.cpp
@@ -89,11 +89,6 @@ void (*termination_notification_callback)(const char*) noexcept = nullptr;
 namespace realm {
 namespace util {
 
-void set_termination_notification_callback(void (*callback)(const char*) noexcept) noexcept
-{
-    termination_notification_callback = callback;
-}
-
 // LCOV_EXCL_START
 REALM_NORETURN static void terminate_internal(std::stringstream& ss) noexcept
 {

--- a/src/realm/util/terminate.hpp
+++ b/src/realm/util/terminate.hpp
@@ -29,17 +29,6 @@
 
 namespace realm {
 namespace util {
-/// Install a custom termination notification callback. This will only be called as a result of
-/// Realm crashing internally, i.e. a failed assertion or an otherwise irrecoverable error
-/// condition. The termination notification callback is supplied with a zero-terminated string
-/// containing information relevant for debugging the issue leading to the crash.
-///
-/// The termination notification callback is shared by all threads, which is another way of saying
-/// that it must be reentrant, in case multiple threads crash simultaneously.
-///
-/// Furthermore, the provided callback must be `noexcept`, indicating that if an exception
-/// is thrown in the callback, the process is terminated with a call to `std::terminate`.
-void set_termination_notification_callback(void (*callback)(const char* message) noexcept) noexcept;
 
 REALM_NORETURN void terminate(const char* message, const char* file, long line,
                               std::initializer_list<Printable>&& = {}) noexcept;


### PR DESCRIPTION
Fixes compiler warning (Clang 4.0). The function's mangled name will change from C++14 to C++17 causing possible compatibility issues across that boundary.

Fixes #2553.