### PR TITLE
Benchmark insensitive queries

### DIFF
--- a/test/bench/benchmark_version
+++ b/test/bench/benchmark_version
@@ -1,4 +1,4 @@
-v3
+v4
 
 The first line of this file describes the current benchmarking tool version.
 It is used as a folder prefix to handle storing multiple versions of performance results.

--- a/test/bench/benchmark_version
+++ b/test/bench/benchmark_version
@@ -1,4 +1,4 @@
-v6
+v7
 
 The first line of this file describes the current benchmarking tool version.
 It is used as a folder prefix to handle storing multiple versions of performance results.

--- a/test/bench/benchmark_version
+++ b/test/bench/benchmark_version
@@ -1,4 +1,4 @@
-v4
+v5
 
 The first line of this file describes the current benchmarking tool version.
 It is used as a folder prefix to handle storing multiple versions of performance results.

--- a/test/bench/benchmark_version
+++ b/test/bench/benchmark_version
@@ -1,4 +1,4 @@
-v5
+v6
 
 The first line of this file describes the current benchmarking tool version.
 It is used as a folder prefix to handle storing multiple versions of performance results.

--- a/test/bench/revs_to_benchmark.txt
+++ b/test/bench/revs_to_benchmark.txt
@@ -27,7 +27,7 @@ tags/v2.0.1
 tags/v2.1.0
 tags/v2.2.0
 tags/v2.3.0
-tags/v2.3.1
-tags/v2.3.2
 tags/v2.3.3
 tags/v2.4.0
+tags/v2.5.1
+tags/v2.6.0

--- a/test/benchmark-common-tasks/main.cpp
+++ b/test/benchmark-common-tasks/main.cpp
@@ -21,7 +21,7 @@
 #include <sstream>
 
 #include <realm.hpp>
-#include <realm/query_expression.hpp>
+#include <realm/query_expression.hpp> // only needed to compile on v2.6.0
 #include <realm/string_data.hpp>
 #include <realm/util/file.hpp>
 
@@ -670,10 +670,10 @@ struct BenchmarkQueryInsensitiveString : BenchmarkWithStringsTable {
     }
 };
 
-struct BenchmarkQueryInsensitiveIndexedString  : BenchmarkQueryInsensitiveString {
+struct BenchmarkQueryInsensitiveStringIndexed : BenchmarkQueryInsensitiveString {
     const char* name() const
     {
-        return "BenchmarkQueryInsensitiveIndexedString";
+        return "QueryInsensitiveStringIndexed";
     }
     void before_all(SharedGroup& group)
     {
@@ -944,7 +944,7 @@ int benchmark_common_tasks_main()
     BENCH(BenchmarkSetLongString);
     BENCH(BenchmarkGetLinkList);
     BENCH(BenchmarkQueryInsensitiveString);
-    BENCH(BenchmarkQueryInsensitiveIndexedString);
+    BENCH(BenchmarkQueryInsensitiveStringIndexed);
 
 #undef BENCH
     return 0;

--- a/test/benchmark-common-tasks/main.cpp
+++ b/test/benchmark-common-tasks/main.cpp
@@ -608,7 +608,7 @@ struct BenchmarkQueryInsensitiveString : BenchmarkWithStringsTable {
         for (size_t c = 0; c < length; ++c) {
             bool lowercase = (rand() % 2) == 0;
             // choose characters from a-z or A-Z
-            ss << (rand() % 26) + (lowercase ? 97 : 65);
+            ss << char((rand() % 26) + (lowercase ? 97 : 65));
         }
         return ss.str();
     }

--- a/test/benchmark-common-tasks/main.cpp
+++ b/test/benchmark-common-tasks/main.cpp
@@ -16,7 +16,6 @@
  *
  **************************************************************************/
 
-#include <cctype>
 #include <iostream>
 #include <sstream>
 
@@ -613,22 +612,17 @@ struct BenchmarkQueryInsensitiveString : BenchmarkWithStringsTable {
         return ss.str();
     }
 
-    std::string shuffle_case(std::string input)
+    std::string shuffle_case(std::string str)
     {
-        for (size_t i = 0; i < input.size(); ++i) {
-            bool upper = (rand() % 2) == 0;
-            int c = input[i];
-            if (upper) {
-                c = std::toupper(c);
+        for (size_t i = 0; i < str.size(); ++i) {
+            char c = str[i];
+            if ((c >= 'A' && c <= 'Z') || (c >= 'a' && c <= 'z')) {
+                bool change_case = (rand() % 2) == 0;
+                c ^= change_case ? 0x20 : 0;
             }
-            else {
-                c = std::tolower(c);
-            }
-            if (c > 0) {
-                input[i] = c;
-            }
+            str[i] = c;
         }
-        return input;
+        return str;
     }
 
     size_t rand() {

--- a/test/benchmark-common-tasks/main.cpp
+++ b/test/benchmark-common-tasks/main.cpp
@@ -631,9 +631,17 @@ struct BenchmarkQueryInsensitiveString : BenchmarkWithStringsTable {
         return input;
     }
 
+    size_t rand() {
+        return seeded_rand.draw_int<size_t>();
+    }
+
     void before_all(SharedGroup& group)
     {
         BenchmarkWithStringsTable::before_all(group);
+
+        // chosen by fair dice roll, guaranteed to be random
+        static const unsigned long seed = 4;
+        seeded_rand.seed(seed);
 
         WriteTransaction tr(group);
         TableRef t = tr.get_table("StringOnly");
@@ -649,6 +657,7 @@ struct BenchmarkQueryInsensitiveString : BenchmarkWithStringsTable {
     }
     std::string needle;
     bool successful = false;
+    Random seeded_rand;
 
     void before_each(SharedGroup& group)
     {


### PR DESCRIPTION
A stab at benchmarking the case insensitive queries, one with an index and one without.

- bump the benchmark version so that the performance reruns the suite for all previous core versions
- updated the versions to benchmark with the new release and removed some minor versions
