### PR TITLE
Fix base branch name for performance scripts

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -309,7 +309,7 @@ def buildPerformance() {
           sh """
             cd test/bench
             mkdir -p core-benchmarks results
-            ./gen_bench_hist.sh ${env.BRANCH_NAME}
+            ./gen_bench_hist.sh ${env.CHANGE_TARGET}
             ./parse_bench_hist.py --local-html results/ core-benchmarks/
           """
           zip dir: 'test/bench', glob: 'core-benchmarks/**/*', zipFile: 'core-benchmarks.zip'

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -309,7 +309,7 @@ def buildPerformance() {
           sh """
             cd test/bench
             mkdir -p core-benchmarks results
-            ./gen_bench_hist.sh ${env.CHANGE_TARGET}
+            ./gen_bench_hist.sh origin/${env.CHANGE_TARGET}
             ./parse_bench_hist.py --local-html results/ core-benchmarks/
           """
           zip dir: 'test/bench', glob: 'core-benchmarks/**/*', zipFile: 'core-benchmarks.zip'

--- a/test/benchmark-common-tasks/main.cpp
+++ b/test/benchmark-common-tasks/main.cpp
@@ -20,6 +20,7 @@
 #include <sstream>
 
 #include <realm.hpp>
+#include <realm/query_expression.hpp> // only needed to compile on v2.6.0
 #include <realm/util/file.hpp>
 
 #include "compatibility.hpp"


### PR DESCRIPTION
Passing the target branch to the scripts makes them benchmark the last common commit at the divergence point of this pull request. This is especially nice when merging pull requests into a feature branch that is not master or develop. 

The wrong variable name was used here so there was an error in the performance script but it was not fatal because if the divergence point could not be understood then that version was just skipped.