### PR TITLE
Add a templated version of Table::set()

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,7 +15,8 @@
 
 * Add a templated version of Table::set() to go with Table::get().
 * Add TableView::find_first_timestamp().
-* Add TableView::find_first<T>()/
+* Add TableView::find_first<T>().
+* Make Table::find_first<T>() public and add support for most column types.
 
 -----------
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,7 @@
 
 ### Enhancements
 
-* Lorem ipsum.
+* Add a templated version of Table::set() to go with Table::get().
 
 -----------
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@
 * Add TableView::find_first<T>().
 * Make Table::find_first<T>() public and add support for most column types.
 * Add wrappers for Table::set<T>() to Row.
+* Add support for all column types in Table::get<T>().
 
 -----------
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@
 * Add TableView::find_first_timestamp().
 * Add TableView::find_first<T>().
 * Make Table::find_first<T>() public and add support for most column types.
+* Add wrappers for Table::set<T>() to Row.
 
 -----------
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,8 @@
 ### Enhancements
 
 * Add a templated version of Table::set() to go with Table::get().
+* Add TableView::find_first_timestamp().
+* Add TableView::find_first<T>()/
 
 -----------
 

--- a/src/realm/row.hpp
+++ b/src/realm/row.hpp
@@ -193,14 +193,17 @@ private:
 template <class T>
 class BasicRowExpr : public RowFuncs<T, BasicRowExpr<T>> {
 public:
-    BasicRowExpr() noexcept;
+    BasicRowExpr() noexcept = default;
 
     template <class U>
     BasicRowExpr(const BasicRowExpr<U>&) noexcept;
 
+    template <class U>
+    BasicRowExpr(const BasicRow<U>&) noexcept;
+
 private:
-    T* m_table;       // nullptr if detached.
-    size_t m_row_ndx; // Undefined if detached.
+    T* m_table = nullptr;       // nullptr if detached.
+    size_t m_row_ndx = 0; // Undefined if detached.
 
     BasicRowExpr(T*, size_t init_row_ndx) noexcept;
 
@@ -212,12 +215,12 @@ private:
     // from RowFuncs.
     friend class RowFuncs<T, BasicRowExpr<T>>;
 
-    // Make m_table and m_col_ndx accessible from BasicRowExpr(const
+    // Make m_table and m_row_ndx accessible from BasicRowExpr(const
     // BasicRowExpr<U>&) for any U.
     template <class>
     friend class BasicRowExpr;
 
-    // Make m_table and m_col_ndx accessible from
+    // Make m_table and m_row_ndx accessible from
     // BasicRow::BaicRow(BasicRowExpr<U>) for any U.
     template <class>
     friend class BasicRow;
@@ -320,10 +323,15 @@ private:
     // from RowFuncs.
     friend class RowFuncs<T, BasicRow<T>>;
 
-    // Make m_table and m_col_ndx accessible from BasicRow(const BasicRow<U>&)
+    // Make m_table and m_row_ndx accessible from BasicRow(const BasicRow<U>&)
     // for any U.
     template <class>
     friend class BasicRow;
+
+    // Make m_table and m_row_ndx accessible from BasicRowExpr(const
+    // BasicRow<U>&) for any U.
+    template <class>
+    friend class BasicRowExpr;
 
 public:
     std::unique_ptr<BasicRow<T>> clone_for_handover(std::unique_ptr<HandoverPatch>& patch) const
@@ -730,17 +738,18 @@ inline size_t RowFuncs<T, R>::row_ndx() const noexcept
 
 
 template <class T>
-inline BasicRowExpr<T>::BasicRowExpr() noexcept
-    : m_table(0)
-    , m_row_ndx(0)
+template <class U>
+inline BasicRowExpr<T>::BasicRowExpr(const BasicRowExpr<U>& expr) noexcept
+    : m_table(expr.m_table)
+    , m_row_ndx(expr.m_row_ndx)
 {
 }
 
 template <class T>
 template <class U>
-inline BasicRowExpr<T>::BasicRowExpr(const BasicRowExpr<U>& expr) noexcept
-    : m_table(expr.m_table)
-    , m_row_ndx(expr.m_row_ndx)
+inline BasicRowExpr<T>::BasicRowExpr(const BasicRow<U>& row) noexcept
+    : m_table(row.m_table.get())
+    , m_row_ndx(row.m_row_ndx)
 {
 }
 

--- a/src/realm/row.hpp
+++ b/src/realm/row.hpp
@@ -91,6 +91,7 @@ public:
     size_t get_link_count(size_t col_ndx) const noexcept;
     Mixed get_mixed(size_t col_ndx) const noexcept;
     DataType get_mixed_type(size_t col_ndx) const noexcept;
+
     template <typename U>
     U get(size_t col_ndx) const noexcept;
 
@@ -112,6 +113,12 @@ public:
     void set_mixed_subtable(size_t col_ndx, const Table* value);
     void set_null(size_t col_ndx);
     void set_null_unique(size_t col_ndx);
+
+    template <typename U>
+    void set(size_t col_ndx, U&& value, bool is_default = false);
+
+    template <typename U>
+    void set_unique(size_t col_ndx, U&& value);
 
     void insert_substring(size_t col_ndx, size_t pos, StringData);
     void remove_substring(size_t col_ndx, size_t pos, size_t size);
@@ -590,6 +597,20 @@ template <class T, class R>
 inline void RowFuncs<T, R>::set_null_unique(size_t col_ndx)
 {
     table()->set_null_unique(col_ndx, row_ndx()); // Throws
+}
+
+template <class T, class R>
+template <class U>
+inline void RowFuncs<T, R>::set(size_t col_ndx, U&& value, bool is_default)
+{
+    table()->set(col_ndx, row_ndx(), std::forward<U>(value), is_default); // Throws
+}
+
+template <class T, class R>
+template <class U>
+inline void RowFuncs<T, R>::set_unique(size_t col_ndx, U&& value)
+{
+    table()->set_unique(col_ndx, row_ndx(), std::forward<U>(value)); // Throws
 }
 
 template <class T, class R>

--- a/src/realm/table.cpp
+++ b/src/realm/table.cpp
@@ -2722,14 +2722,20 @@ bool Table::get(size_t col_ndx, size_t ndx) const noexcept
     REALM_ASSERT_3(get_real_column_type(col_ndx), ==, col_type_Bool);
     REALM_ASSERT_3(ndx, <, m_size);
 
-    if (is_nullable(col_ndx)) {
-        const IntNullColumn& col = get_column_int_null(col_ndx);
-        return col.get(ndx).value_or(0) != 0;
-    }
-    else {
-        const IntegerColumn& col = get_column(col_ndx);
-        return col.get(ndx) != 0;
-    }
+    const IntegerColumn& col = get_column(col_ndx);
+    return col.get(ndx) != 0;
+}
+
+template <>
+util::Optional<bool> Table::get(size_t col_ndx, size_t ndx) const noexcept
+{
+    REALM_ASSERT_3(col_ndx, <, get_column_count());
+    REALM_ASSERT_3(get_real_column_type(col_ndx), ==, col_type_Bool);
+    REALM_ASSERT_3(ndx, <, m_size);
+
+    const IntNullColumn& col = get_column_int_null(col_ndx);
+    auto value = col.get(ndx);
+    return value ? util::some<bool>(*value != 0) : util::none;
 }
 
 template <>
@@ -2739,14 +2745,19 @@ int64_t Table::get(size_t col_ndx, size_t ndx) const noexcept
     REALM_ASSERT_3(get_real_column_type(col_ndx), ==, col_type_Int);
     REALM_ASSERT_3(ndx, <, m_size);
 
-    if (is_nullable(col_ndx)) {
-        const IntNullColumn& col = get_column<IntNullColumn, col_type_Int>(col_ndx);
-        return col.get(ndx).value_or(0);
-    }
-    else {
-        const IntegerColumn& col = get_column<IntegerColumn, col_type_Int>(col_ndx);
-        return col.get(ndx);
-    }
+    const IntegerColumn& col = get_column<IntegerColumn, col_type_Int>(col_ndx);
+    return col.get(ndx);
+}
+
+template <>
+util::Optional<int64_t> Table::get(size_t col_ndx, size_t ndx) const noexcept
+{
+    REALM_ASSERT_3(col_ndx, <, get_column_count());
+    REALM_ASSERT_3(get_real_column_type(col_ndx), ==, col_type_Int);
+    REALM_ASSERT_3(ndx, <, m_size);
+
+    const IntNullColumn& col = get_column<IntNullColumn, col_type_Int>(col_ndx);
+    return col.get(ndx);
 }
 
 template <>
@@ -2774,11 +2785,19 @@ float Table::get(size_t col_ndx, size_t ndx) const noexcept
     REALM_ASSERT_3(ndx, <, m_size);
 
     const FloatColumn& col = get_column<FloatColumn, col_type_Float>(col_ndx);
+    return col.get(ndx);
+}
+
+template <>
+util::Optional<float> Table::get(size_t col_ndx, size_t ndx) const noexcept
+{
+    REALM_ASSERT_3(col_ndx, <, get_column_count());
+    REALM_ASSERT_3(get_real_column_type(col_ndx), ==, col_type_Float);
+    REALM_ASSERT_3(ndx, <, m_size);
+
+    const FloatColumn& col = get_column<FloatColumn, col_type_Float>(col_ndx);
     float f = col.get(ndx);
-    if (null::is_null_float(f))
-        return 0.0f;
-    else
-        return f;
+    return null::is_null_float(f) ? util::none : util::make_optional(f);
 }
 
 template <>
@@ -2789,11 +2808,19 @@ double Table::get(size_t col_ndx, size_t ndx) const noexcept
     REALM_ASSERT_3(ndx, <, m_size);
 
     const DoubleColumn& col = get_column<DoubleColumn, col_type_Double>(col_ndx);
+    return col.get(ndx);
+}
+
+template <>
+util::Optional<double> Table::get(size_t col_ndx, size_t ndx) const noexcept
+{
+    REALM_ASSERT_3(col_ndx, <, get_column_count());
+    REALM_ASSERT_3(get_real_column_type(col_ndx), ==, col_type_Double);
+    REALM_ASSERT_3(ndx, <, m_size);
+
+    const DoubleColumn& col = get_column<DoubleColumn, col_type_Double>(col_ndx);
     double d = col.get(ndx);
-    if (null::is_null_float(d))
-        return 0.0;
-    else
-        return d;
+    return null::is_null_float(d) ? util::none : util::make_optional(d);
 }
 
 template <>
@@ -2876,6 +2903,14 @@ Mixed Table::get(size_t col_ndx, size_t ndx) const noexcept
     }
     REALM_ASSERT(false);
     return Mixed(int64_t(0));
+}
+
+template<>
+Table::RowExpr Table::get(size_t col_ndx, size_t row_ndx) const noexcept
+{
+    REALM_ASSERT_3(row_ndx, <, m_size);
+    const LinkColumn& col = get_column_link(col_ndx);
+    return RowExpr(&col.get_target_table(), col.get_link(row_ndx));
 }
 
 template <>

--- a/src/realm/table.cpp
+++ b/src/realm/table.cpp
@@ -2841,6 +2841,416 @@ Timestamp Table::get(size_t col_ndx, size_t ndx) const noexcept
     return col.get(ndx);
 }
 
+template <>
+Mixed Table::get(size_t col_ndx, size_t ndx) const noexcept
+{
+    REALM_ASSERT_3(col_ndx, <, m_columns.size());
+    REALM_ASSERT_3(ndx, <, m_size);
+
+    const MixedColumn& col = get_column_mixed(col_ndx);
+
+    DataType type = col.get_type(ndx);
+    switch (type) {
+        case type_Int:
+            return Mixed(col.get_int(ndx));
+        case type_Bool:
+            return Mixed(col.get_bool(ndx));
+        case type_OldDateTime:
+            return Mixed(OldDateTime(col.get_olddatetime(ndx)));
+        case type_Timestamp:
+            return Mixed(col.get_timestamp(ndx));
+        case type_Float:
+            return Mixed(col.get_float(ndx));
+        case type_Double:
+            return Mixed(col.get_double(ndx));
+        case type_String:
+            return Mixed(col.get_string(ndx)); // Throws
+        case type_Binary:
+            return Mixed(col.get_binary(ndx)); // Throws
+        case type_Table:
+            return Mixed::subtable_tag();
+        case type_Mixed:
+        case type_Link:
+        case type_LinkList:
+            break;
+    }
+    REALM_ASSERT(false);
+    return Mixed(int64_t(0));
+}
+
+template <>
+size_t Table::set_unique(size_t col_ndx, size_t ndx, int_fast64_t value)
+{
+    REALM_ASSERT_3(col_ndx, <, get_column_count());
+    REALM_ASSERT_3(ndx, <, m_size);
+
+    if (!has_search_index(col_ndx)) {
+        throw LogicError{LogicError::no_search_index};
+    }
+
+    // FIXME: See the definition of check_lists_are_empty() for an explanation
+    // of why this is needed.
+    check_lists_are_empty(ndx); // Throws
+
+    bump_version();
+
+    bool conflict = false;
+
+    if (is_nullable(col_ndx)) {
+        auto& col = get_column_int_null(col_ndx);
+        ndx = do_set_unique(col, ndx, value, conflict); // Throws
+    }
+    else {
+        auto& col = get_column(col_ndx);
+        ndx = do_set_unique(col, ndx, value, conflict); // Throws
+    }
+
+    if (!conflict) {
+        if (Replication* repl = get_repl())
+            repl->set_int(this, col_ndx, ndx, value, _impl::instr_SetUnique); // Throws
+    }
+
+    return ndx;
+}
+
+template<>
+size_t Table::set_unique(size_t col_ndx, size_t ndx, StringData value)
+{
+    if (REALM_UNLIKELY(value.size() > max_string_size))
+        throw LogicError(LogicError::string_too_big);
+    if (REALM_UNLIKELY(!is_attached()))
+        throw LogicError(LogicError::detached_accessor);
+    if (REALM_UNLIKELY(ndx >= m_size))
+        throw LogicError(LogicError::row_index_out_of_range);
+    // For a degenerate subtable, `m_cols.size()` is zero, even when it has a
+    // column, however, the previous row index check guarantees that `m_size >
+    // 0`, and since `m_size` is also zero for a degenerate subtable, the table
+    // cannot be degenerate if we got this far.
+
+    if (!is_nullable(col_ndx) && value.is_null())
+        throw LogicError(LogicError::column_not_nullable);
+
+    if (!has_search_index(col_ndx))
+        throw LogicError(LogicError::no_search_index);
+
+    // FIXME: See the definition of check_lists_are_empty() for an explanation
+    // of why this is needed
+    check_lists_are_empty(ndx); // Throws
+
+    bump_version();
+
+    ColumnType actual_type = get_real_column_type(col_ndx);
+    REALM_ASSERT(actual_type == ColumnType::col_type_String || actual_type == ColumnType::col_type_StringEnum);
+
+    bool conflict = false;
+    // FIXME: String and StringEnum columns should have a common base class
+    if (actual_type == ColumnType::col_type_String) {
+        StringColumn& col = get_column_string(col_ndx);
+        ndx = do_set_unique(col, ndx, value, conflict); // Throws
+    }
+    else {
+        StringEnumColumn& col = get_column_string_enum(col_ndx);
+        ndx = do_set_unique(col, ndx, value, conflict); // Throws
+    }
+
+    if (!conflict) {
+        if (Replication* repl = get_repl())
+            repl->set_string(this, col_ndx, ndx, value, _impl::instr_SetUnique); // Throws
+    }
+
+    return ndx;
+}
+
+template<>
+void Table::set(size_t col_ndx, size_t ndx, int_fast64_t value, bool is_default)
+{
+    REALM_ASSERT_3(col_ndx, <, get_column_count());
+    REALM_ASSERT_3(ndx, <, m_size);
+    bump_version();
+
+    if (is_nullable(col_ndx)) {
+        auto& col = get_column_int_null(col_ndx);
+        col.set(ndx, value);
+    }
+    else {
+        auto& col = get_column(col_ndx);
+        col.set(ndx, value);
+    }
+
+    if (Replication* repl = get_repl())
+        repl->set_int(this, col_ndx, ndx, value, is_default ? _impl::instr_SetDefault : _impl::instr_Set); // Throws
+}
+
+template<>
+void Table::set(size_t col_ndx, size_t ndx, Timestamp value, bool is_default)
+{
+    REALM_ASSERT_3(col_ndx, <, get_column_count());
+    REALM_ASSERT_3(get_real_column_type(col_ndx), ==, col_type_Timestamp);
+    REALM_ASSERT_3(ndx, <, m_size);
+    bump_version();
+
+    if (!is_nullable(col_ndx) && value.is_null())
+        throw LogicError(LogicError::column_not_nullable);
+
+    TimestampColumn& col = get_column<TimestampColumn, col_type_Timestamp>(col_ndx);
+    col.set(ndx, value);
+
+    if (Replication* repl = get_repl()) {
+        if (value.is_null())
+            repl->set_null(this, col_ndx, ndx, is_default ? _impl::instr_SetDefault : _impl::instr_Set); // Throws
+        else
+            repl->set_timestamp(this, col_ndx, ndx, value,
+                                is_default ? _impl::instr_SetDefault : _impl::instr_Set); // Throws
+    }
+}
+
+template<>
+void Table::set(size_t col_ndx, size_t ndx, bool value, bool is_default)
+{
+    REALM_ASSERT_3(col_ndx, <, get_column_count());
+    REALM_ASSERT_3(get_real_column_type(col_ndx), ==, col_type_Bool);
+    REALM_ASSERT_3(ndx, <, m_size);
+    bump_version();
+
+    if (is_nullable(col_ndx)) {
+        IntNullColumn& col = get_column_int_null(col_ndx);
+        col.set(ndx, value ? 1 : 0);
+    }
+    else {
+        IntegerColumn& col = get_column(col_ndx);
+        col.set(ndx, value ? 1 : 0);
+    }
+
+    if (Replication* repl = get_repl())
+        repl->set_bool(this, col_ndx, ndx, value, is_default ? _impl::instr_SetDefault : _impl::instr_Set); // Throws
+}
+
+template<>
+void Table::set(size_t col_ndx, size_t ndx, OldDateTime value, bool is_default)
+{
+    REALM_ASSERT_3(col_ndx, <, get_column_count());
+    REALM_ASSERT_3(get_real_column_type(col_ndx), ==, col_type_OldDateTime);
+    REALM_ASSERT_3(ndx, <, m_size);
+    bump_version();
+
+    if (is_nullable(col_ndx)) {
+        IntNullColumn& col = get_column_int_null(col_ndx);
+        col.set(ndx, value.get_olddatetime());
+    }
+    else {
+        IntegerColumn& col = get_column(col_ndx);
+        col.set(ndx, value.get_olddatetime());
+    }
+
+    if (Replication* repl = get_repl())
+        repl->set_olddatetime(this, col_ndx, ndx, value,
+                              is_default ? _impl::instr_SetDefault : _impl::instr_Set); // Throws
+}
+
+template<>
+void Table::set(size_t col_ndx, size_t ndx, float value, bool is_default)
+{
+    REALM_ASSERT_3(col_ndx, <, get_column_count());
+    REALM_ASSERT_3(ndx, <, m_size);
+    bump_version();
+
+    FloatColumn& col = get_column_float(col_ndx);
+    col.set(ndx, value);
+
+    if (Replication* repl = get_repl())
+        repl->set_float(this, col_ndx, ndx, value, is_default ? _impl::instr_SetDefault : _impl::instr_Set); // Throws
+}
+
+template<>
+void Table::set(size_t col_ndx, size_t ndx, double value, bool is_default)
+{
+    REALM_ASSERT_3(col_ndx, <, get_column_count());
+    REALM_ASSERT_3(ndx, <, m_size);
+    bump_version();
+
+    DoubleColumn& col = get_column_double(col_ndx);
+    col.set(ndx, value);
+
+    if (Replication* repl = get_repl())
+        repl->set_double(this, col_ndx, ndx, value,
+                         is_default ? _impl::instr_SetDefault : _impl::instr_Set); // Throws
+}
+
+template<>
+void Table::set(size_t col_ndx, size_t ndx, StringData value, bool is_default)
+{
+    if (REALM_UNLIKELY(!is_attached()))
+        throw LogicError(LogicError::detached_accessor);
+    if (REALM_UNLIKELY(ndx >= m_size))
+        throw LogicError(LogicError::row_index_out_of_range);
+    // For a degenerate subtable, `m_cols.size()` is zero, even when it has
+    // columns, however, the previous row index check guarantees that `m_size >
+    // 0`, and since `m_size` is also zero for a degenerate subtable, the table
+    // cannot be degenerate if we got this far.
+    if (REALM_UNLIKELY(col_ndx >= m_cols.size()))
+        throw LogicError(LogicError::column_index_out_of_range);
+    if (!is_nullable(col_ndx) && value.is_null())
+        throw LogicError(LogicError::column_not_nullable);
+    if (REALM_UNLIKELY(value.size() > max_string_size))
+        throw LogicError(LogicError::string_too_big);
+
+    bump_version();
+    ColumnBase& col = get_column_base(col_ndx);
+    col.set_string(ndx, value); // Throws
+
+    if (Replication* repl = get_repl())
+        repl->set_string(this, col_ndx, ndx, value,
+                         is_default ? _impl::instr_SetDefault : _impl::instr_Set); // Throws
+}
+
+template<>
+void Table::set(size_t col_ndx, size_t ndx, BinaryData value, bool is_default)
+{
+    if (REALM_UNLIKELY(value.size() > ArrayBlob::max_binary_size))
+        throw LogicError(LogicError::binary_too_big);
+    set_binary_big(col_ndx, ndx, value, is_default);
+}
+
+template<>
+void Table::set(size_t col_ndx, size_t ndx, Mixed value, bool is_default)
+{
+    REALM_ASSERT_3(col_ndx, <, get_column_count());
+    REALM_ASSERT_3(ndx, <, m_size);
+    bump_version();
+
+    MixedColumn& col = get_column_mixed(col_ndx);
+    DataType type = value.get_type();
+
+    switch (type) {
+        case type_Int:
+            col.set_int(ndx, value.get_int()); // Throws
+            break;
+        case type_Bool:
+            col.set_bool(ndx, value.get_bool()); // Throws
+            break;
+        case type_OldDateTime:
+            col.set_olddatetime(ndx, value.get_olddatetime()); // Throws
+            break;
+        case type_Timestamp:
+            col.set_timestamp(ndx, value.get_timestamp()); // Throws
+            break;
+        case type_Float:
+            col.set_float(ndx, value.get_float()); // Throws
+            break;
+        case type_Double:
+            col.set_double(ndx, value.get_double()); // Throws
+            break;
+        case type_String:
+            if (REALM_UNLIKELY(value.get_string().size() > max_string_size))
+                throw LogicError(LogicError::string_too_big);
+            col.set_string(ndx, value.get_string()); // Throws
+            break;
+        case type_Binary:
+            if (REALM_UNLIKELY(value.get_binary().size() > ArrayBlob::max_binary_size))
+                throw LogicError(LogicError::binary_too_big);
+            col.set_binary(ndx, value.get_binary()); // Throws
+            break;
+        case type_Table:
+            col.set_subtable(ndx, nullptr); // Throws
+            break;
+        case type_Mixed:
+        case type_Link:
+        case type_LinkList:
+            REALM_ASSERT(false);
+            break;
+    }
+
+    if (Replication* repl = get_repl())
+        repl->set_mixed(this, col_ndx, ndx, value, is_default ? _impl::instr_SetDefault : _impl::instr_Set); // Throws
+}
+
+template<>
+size_t Table::set_unique(size_t col_ndx, size_t row_ndx, null)
+{
+    if (!is_nullable(col_ndx)) {
+        throw LogicError{LogicError::column_not_nullable};
+    }
+    REALM_ASSERT(!is_link_type(m_spec.get_column_type(col_ndx))); // Use nullify_link().
+    REALM_ASSERT_3(col_ndx, <, get_column_count());
+    REALM_ASSERT_3(row_ndx, <, m_size);
+
+    if (!has_search_index(col_ndx)) {
+        throw LogicError{LogicError::no_search_index};
+    }
+
+    // FIXME: See the definition of check_lists_are_empty() for an explanation
+    // of why this is needed.
+    check_lists_are_empty(row_ndx); // Throws
+
+    bump_version();
+
+    bool conflict = false;
+
+    // Only valid for int columns; use `set_string_unique` to set null strings
+    auto& col = get_column_int_null(col_ndx);
+    row_ndx = do_set_unique_null(col, row_ndx, conflict); // Throws
+
+    if (!conflict) {
+        if (Replication* repl = get_repl())
+            repl->set_null(this, col_ndx, row_ndx, _impl::instr_SetUnique); // Throws
+    }
+
+    return row_ndx;
+}
+
+template<>
+void Table::set(size_t col_ndx, size_t row_ndx, null, bool is_default)
+{
+    if (!is_nullable(col_ndx)) {
+        throw LogicError{LogicError::column_not_nullable};
+    }
+    REALM_ASSERT(!is_link_type(m_spec.get_column_type(col_ndx))); // Use nullify_link().
+    REALM_ASSERT_3(col_ndx, <, get_column_count());
+    REALM_ASSERT_3(row_ndx, <, m_size);
+
+    bump_version();
+    ColumnBase& col = get_column_base(col_ndx);
+    col.set_null(row_ndx);
+
+    if (Replication* repl = get_repl())
+        repl->set_null(this, col_ndx, row_ndx, is_default ? _impl::instr_SetDefault : _impl::instr_Set); // Throws
+}
+
+template<>
+void Table::set(size_t col_ndx, size_t row_ndx, util::Optional<bool> value, bool is_default)
+{
+    if (value)
+        set(col_ndx, row_ndx, *value, is_default);
+    else
+        set(col_ndx, row_ndx, null(), is_default);
+}
+
+template<>
+void Table::set(size_t col_ndx, size_t row_ndx, util::Optional<int64_t> value, bool is_default)
+{
+    if (value)
+        set(col_ndx, row_ndx, *value, is_default);
+    else
+        set(col_ndx, row_ndx, null(), is_default);
+}
+
+template<>
+void Table::set(size_t col_ndx, size_t row_ndx, util::Optional<float> value, bool is_default)
+{
+    if (value)
+        set(col_ndx, row_ndx, *value, is_default);
+    else
+        set(col_ndx, row_ndx, null(), is_default);
+}
+
+template<>
+void Table::set(size_t col_ndx, size_t row_ndx, util::Optional<double> value, bool is_default)
+{
+    if (value)
+        set(col_ndx, row_ndx, *value, is_default);
+    else
+        set(col_ndx, row_ndx, null(), is_default);
+}
 
 } // namespace realm;
 
@@ -2908,64 +3318,6 @@ size_t Table::do_set_unique(ColType& col, size_t ndx, T&& value, bool& conflict)
     return ndx;
 }
 
-int64_t Table::get_int(size_t col_ndx, size_t ndx) const noexcept
-{
-    return get<int64_t>(col_ndx, ndx);
-}
-
-size_t Table::set_int_unique(size_t col_ndx, size_t ndx, int_fast64_t value)
-{
-    REALM_ASSERT_3(col_ndx, <, get_column_count());
-    REALM_ASSERT_3(ndx, <, m_size);
-
-    if (!has_search_index(col_ndx)) {
-        throw LogicError{LogicError::no_search_index};
-    }
-
-    // FIXME: See the definition of check_lists_are_empty() for an explanation
-    // of why this is needed.
-    check_lists_are_empty(ndx); // Throws
-
-    bump_version();
-
-    bool conflict = false;
-
-    if (is_nullable(col_ndx)) {
-        auto& col = get_column_int_null(col_ndx);
-        ndx = do_set_unique(col, ndx, value, conflict); // Throws
-    }
-    else {
-        auto& col = get_column(col_ndx);
-        ndx = do_set_unique(col, ndx, value, conflict); // Throws
-    }
-
-    if (!conflict) {
-        if (Replication* repl = get_repl())
-            repl->set_int(this, col_ndx, ndx, value, _impl::instr_SetUnique); // Throws
-    }
-
-    return ndx;
-}
-
-void Table::set_int(size_t col_ndx, size_t ndx, int_fast64_t value, bool is_default)
-{
-    REALM_ASSERT_3(col_ndx, <, get_column_count());
-    REALM_ASSERT_3(ndx, <, m_size);
-    bump_version();
-
-    if (is_nullable(col_ndx)) {
-        auto& col = get_column_int_null(col_ndx);
-        col.set(ndx, value);
-    }
-    else {
-        auto& col = get_column(col_ndx);
-        col.set(ndx, value);
-    }
-
-    if (Replication* repl = get_repl())
-        repl->set_int(this, col_ndx, ndx, value, is_default ? _impl::instr_SetDefault : _impl::instr_Set); // Throws
-}
-
 void Table::add_int(size_t col_ndx, size_t ndx, int_fast64_t value)
 {
     REALM_ASSERT_3(col_ndx, <, get_column_count());
@@ -2996,211 +3348,6 @@ void Table::add_int(size_t col_ndx, size_t ndx, int_fast64_t value)
 
     if (Replication* repl = get_repl())
         repl->add_int(this, col_ndx, ndx, value); // Throws
-}
-
-Timestamp Table::get_timestamp(size_t col_ndx, size_t ndx) const noexcept
-{
-    return get<Timestamp>(col_ndx, ndx);
-}
-
-
-void Table::set_timestamp(size_t col_ndx, size_t ndx, Timestamp value, bool is_default)
-{
-    REALM_ASSERT_3(col_ndx, <, get_column_count());
-    REALM_ASSERT_3(get_real_column_type(col_ndx), ==, col_type_Timestamp);
-    REALM_ASSERT_3(ndx, <, m_size);
-    bump_version();
-
-    if (!is_nullable(col_ndx) && value.is_null())
-        throw LogicError(LogicError::column_not_nullable);
-
-    TimestampColumn& col = get_column<TimestampColumn, col_type_Timestamp>(col_ndx);
-    col.set(ndx, value);
-
-    if (Replication* repl = get_repl()) {
-        if (value.is_null())
-            repl->set_null(this, col_ndx, ndx, is_default ? _impl::instr_SetDefault : _impl::instr_Set); // Throws
-        else
-            repl->set_timestamp(this, col_ndx, ndx, value,
-                                is_default ? _impl::instr_SetDefault : _impl::instr_Set); // Throws
-    }
-}
-
-
-bool Table::get_bool(size_t col_ndx, size_t ndx) const noexcept
-{
-    return get<bool>(col_ndx, ndx);
-}
-
-
-void Table::set_bool(size_t col_ndx, size_t ndx, bool value, bool is_default)
-{
-    REALM_ASSERT_3(col_ndx, <, get_column_count());
-    REALM_ASSERT_3(get_real_column_type(col_ndx), ==, col_type_Bool);
-    REALM_ASSERT_3(ndx, <, m_size);
-    bump_version();
-
-    if (is_nullable(col_ndx)) {
-        IntNullColumn& col = get_column_int_null(col_ndx);
-        col.set(ndx, value ? 1 : 0);
-    }
-    else {
-        IntegerColumn& col = get_column(col_ndx);
-        col.set(ndx, value ? 1 : 0);
-    }
-
-    if (Replication* repl = get_repl())
-        repl->set_bool(this, col_ndx, ndx, value, is_default ? _impl::instr_SetDefault : _impl::instr_Set); // Throws
-}
-
-
-OldDateTime Table::get_olddatetime(size_t col_ndx, size_t ndx) const noexcept
-{
-    return get<OldDateTime>(col_ndx, ndx);
-}
-
-
-void Table::set_olddatetime(size_t col_ndx, size_t ndx, OldDateTime value, bool is_default)
-{
-    REALM_ASSERT_3(col_ndx, <, get_column_count());
-    REALM_ASSERT_3(get_real_column_type(col_ndx), ==, col_type_OldDateTime);
-    REALM_ASSERT_3(ndx, <, m_size);
-    bump_version();
-
-    if (is_nullable(col_ndx)) {
-        IntNullColumn& col = get_column_int_null(col_ndx);
-        col.set(ndx, value.get_olddatetime());
-    }
-    else {
-        IntegerColumn& col = get_column(col_ndx);
-        col.set(ndx, value.get_olddatetime());
-    }
-
-    if (Replication* repl = get_repl())
-        repl->set_olddatetime(this, col_ndx, ndx, value,
-                              is_default ? _impl::instr_SetDefault : _impl::instr_Set); // Throws
-}
-
-
-float Table::get_float(size_t col_ndx, size_t ndx) const noexcept
-{
-    return get<float>(col_ndx, ndx);
-}
-
-
-void Table::set_float(size_t col_ndx, size_t ndx, float value, bool is_default)
-{
-    REALM_ASSERT_3(col_ndx, <, get_column_count());
-    REALM_ASSERT_3(ndx, <, m_size);
-    bump_version();
-
-    FloatColumn& col = get_column_float(col_ndx);
-    col.set(ndx, value);
-
-    if (Replication* repl = get_repl())
-        repl->set_float(this, col_ndx, ndx, value, is_default ? _impl::instr_SetDefault : _impl::instr_Set); // Throws
-}
-
-
-double Table::get_double(size_t col_ndx, size_t ndx) const noexcept
-{
-    return get<double>(col_ndx, ndx);
-}
-
-
-void Table::set_double(size_t col_ndx, size_t ndx, double value, bool is_default)
-{
-    REALM_ASSERT_3(col_ndx, <, get_column_count());
-    REALM_ASSERT_3(ndx, <, m_size);
-    bump_version();
-
-    DoubleColumn& col = get_column_double(col_ndx);
-    col.set(ndx, value);
-
-    if (Replication* repl = get_repl())
-        repl->set_double(this, col_ndx, ndx, value,
-                         is_default ? _impl::instr_SetDefault : _impl::instr_Set); // Throws
-}
-
-
-StringData Table::get_string(size_t col_ndx, size_t ndx) const noexcept
-{
-    return get<StringData>(col_ndx, ndx);
-}
-
-
-void Table::set_string(size_t col_ndx, size_t ndx, StringData value, bool is_default)
-{
-    if (REALM_UNLIKELY(!is_attached()))
-        throw LogicError(LogicError::detached_accessor);
-    if (REALM_UNLIKELY(ndx >= m_size))
-        throw LogicError(LogicError::row_index_out_of_range);
-    // For a degenerate subtable, `m_cols.size()` is zero, even when it has
-    // columns, however, the previous row index check guarantees that `m_size >
-    // 0`, and since `m_size` is also zero for a degenerate subtable, the table
-    // cannot be degenerate if we got this far.
-    if (REALM_UNLIKELY(col_ndx >= m_cols.size()))
-        throw LogicError(LogicError::column_index_out_of_range);
-    if (!is_nullable(col_ndx) && value.is_null())
-        throw LogicError(LogicError::column_not_nullable);
-    if (REALM_UNLIKELY(value.size() > max_string_size))
-        throw LogicError(LogicError::string_too_big);
-
-    bump_version();
-    ColumnBase& col = get_column_base(col_ndx);
-    col.set_string(ndx, value); // Throws
-
-    if (Replication* repl = get_repl())
-        repl->set_string(this, col_ndx, ndx, value,
-                         is_default ? _impl::instr_SetDefault : _impl::instr_Set); // Throws
-}
-
-
-size_t Table::set_string_unique(size_t col_ndx, size_t ndx, StringData value)
-{
-    if (REALM_UNLIKELY(value.size() > max_string_size))
-        throw LogicError(LogicError::string_too_big);
-    if (REALM_UNLIKELY(!is_attached()))
-        throw LogicError(LogicError::detached_accessor);
-    if (REALM_UNLIKELY(ndx >= m_size))
-        throw LogicError(LogicError::row_index_out_of_range);
-    // For a degenerate subtable, `m_cols.size()` is zero, even when it has a
-    // column, however, the previous row index check guarantees that `m_size >
-    // 0`, and since `m_size` is also zero for a degenerate subtable, the table
-    // cannot be degenerate if we got this far.
-
-    if (!is_nullable(col_ndx) && value.is_null())
-        throw LogicError(LogicError::column_not_nullable);
-
-    if (!has_search_index(col_ndx))
-        throw LogicError(LogicError::no_search_index);
-
-    // FIXME: See the definition of check_lists_are_empty() for an explanation
-    // of why this is needed
-    check_lists_are_empty(ndx); // Throws
-
-    bump_version();
-
-    ColumnType actual_type = get_real_column_type(col_ndx);
-    REALM_ASSERT(actual_type == ColumnType::col_type_String || actual_type == ColumnType::col_type_StringEnum);
-
-    bool conflict = false;
-    // FIXME: String and StringEnum columns should have a common base class
-    if (actual_type == ColumnType::col_type_String) {
-        StringColumn& col = get_column_string(col_ndx);
-        ndx = do_set_unique(col, ndx, value, conflict); // Throws
-    }
-    else {
-        StringEnumColumn& col = get_column_string_enum(col_ndx);
-        ndx = do_set_unique(col, ndx, value, conflict); // Throws
-    }
-
-    if (!conflict) {
-        if (Replication* repl = get_repl())
-            repl->set_string(this, col_ndx, ndx, value, _impl::instr_SetUnique); // Throws
-    }
-
-    return ndx;
 }
 
 void Table::insert_substring(size_t col_ndx, size_t row_ndx, size_t pos, StringData value)
@@ -3266,13 +3413,6 @@ void Table::remove_substring(size_t col_ndx, size_t row_ndx, size_t pos, size_t 
     }
 }
 
-
-BinaryData Table::get_binary(size_t col_ndx, size_t ndx) const noexcept
-{
-    return get<BinaryData>(col_ndx, ndx);
-}
-
-
 void Table::set_binary_big(size_t col_ndx, size_t ndx, BinaryData value, bool is_default)
 {
     if (REALM_UNLIKELY(!is_attached()))
@@ -3304,49 +3444,6 @@ BinaryData Table::get_binary_at(size_t col_ndx, size_t ndx, size_t& pos) const n
     return get_column<BinaryColumn, col_type_Binary>(col_ndx).get_at(ndx, pos);
 }
 
-void Table::set_binary(size_t col_ndx, size_t ndx, BinaryData value, bool is_default)
-{
-    if (REALM_UNLIKELY(value.size() > ArrayBlob::max_binary_size))
-        throw LogicError(LogicError::binary_too_big);
-    set_binary_big(col_ndx, ndx, value, is_default);
-}
-
-Mixed Table::get_mixed(size_t col_ndx, size_t ndx) const noexcept
-{
-    REALM_ASSERT_3(col_ndx, <, m_columns.size());
-    REALM_ASSERT_3(ndx, <, m_size);
-
-    const MixedColumn& col = get_column_mixed(col_ndx);
-
-    DataType type = col.get_type(ndx);
-    switch (type) {
-        case type_Int:
-            return Mixed(col.get_int(ndx));
-        case type_Bool:
-            return Mixed(col.get_bool(ndx));
-        case type_OldDateTime:
-            return Mixed(OldDateTime(col.get_olddatetime(ndx)));
-        case type_Timestamp:
-            return Mixed(col.get_timestamp(ndx));
-        case type_Float:
-            return Mixed(col.get_float(ndx));
-        case type_Double:
-            return Mixed(col.get_double(ndx));
-        case type_String:
-            return Mixed(col.get_string(ndx)); // Throws
-        case type_Binary:
-            return Mixed(col.get_binary(ndx)); // Throws
-        case type_Table:
-            return Mixed::subtable_tag();
-        case type_Mixed:
-        case type_Link:
-        case type_LinkList:
-            break;
-    }
-    REALM_ASSERT(false);
-    return Mixed(int64_t(0));
-}
-
 
 DataType Table::get_mixed_type(size_t col_ndx, size_t ndx) const noexcept
 {
@@ -3355,59 +3452,6 @@ DataType Table::get_mixed_type(size_t col_ndx, size_t ndx) const noexcept
 
     const MixedColumn& col = get_column_mixed(col_ndx);
     return col.get_type(ndx);
-}
-
-
-void Table::set_mixed(size_t col_ndx, size_t ndx, Mixed value, bool is_default)
-{
-    REALM_ASSERT_3(col_ndx, <, get_column_count());
-    REALM_ASSERT_3(ndx, <, m_size);
-    bump_version();
-
-    MixedColumn& col = get_column_mixed(col_ndx);
-    DataType type = value.get_type();
-
-    switch (type) {
-        case type_Int:
-            col.set_int(ndx, value.get_int()); // Throws
-            break;
-        case type_Bool:
-            col.set_bool(ndx, value.get_bool()); // Throws
-            break;
-        case type_OldDateTime:
-            col.set_olddatetime(ndx, value.get_olddatetime()); // Throws
-            break;
-        case type_Timestamp:
-            col.set_timestamp(ndx, value.get_timestamp()); // Throws
-            break;
-        case type_Float:
-            col.set_float(ndx, value.get_float()); // Throws
-            break;
-        case type_Double:
-            col.set_double(ndx, value.get_double()); // Throws
-            break;
-        case type_String:
-            if (REALM_UNLIKELY(value.get_string().size() > max_string_size))
-                throw LogicError(LogicError::string_too_big);
-            col.set_string(ndx, value.get_string()); // Throws
-            break;
-        case type_Binary:
-            if (REALM_UNLIKELY(value.get_binary().size() > ArrayBlob::max_binary_size))
-                throw LogicError(LogicError::binary_too_big);
-            col.set_binary(ndx, value.get_binary()); // Throws
-            break;
-        case type_Table:
-            col.set_subtable(ndx, nullptr); // Throws
-            break;
-        case type_Mixed:
-        case type_Link:
-        case type_LinkList:
-            REALM_ASSERT(false);
-            break;
-    }
-
-    if (Replication* repl = get_repl())
-        repl->set_mixed(this, col_ndx, ndx, value, is_default ? _impl::instr_SetDefault : _impl::instr_Set); // Throws
 }
 
 
@@ -3531,54 +3575,6 @@ bool Table::is_null(size_t col_ndx, size_t row_ndx) const noexcept
         return false;
     auto& col = get_column_base(col_ndx);
     return col.is_null(row_ndx);
-}
-
-void Table::set_null_unique(size_t col_ndx, size_t row_ndx)
-{
-    if (!is_nullable(col_ndx)) {
-        throw LogicError{LogicError::column_not_nullable};
-    }
-    REALM_ASSERT(!is_link_type(m_spec.get_column_type(col_ndx))); // Use nullify_link().
-    REALM_ASSERT_3(col_ndx, <, get_column_count());
-    REALM_ASSERT_3(row_ndx, <, m_size);
-
-    if (!has_search_index(col_ndx)) {
-        throw LogicError{LogicError::no_search_index};
-    }
-
-    // FIXME: See the definition of check_lists_are_empty() for an explanation
-    // of why this is needed.
-    check_lists_are_empty(row_ndx); // Throws
-
-    bump_version();
-
-    bool conflict = false;
-
-    // Only valid for int columns; use `set_string_unique` to set null strings
-    auto& col = get_column_int_null(col_ndx);
-    row_ndx = do_set_unique_null(col, row_ndx, conflict); // Throws
-
-    if (!conflict) {
-        if (Replication* repl = get_repl())
-            repl->set_null(this, col_ndx, row_ndx, _impl::instr_SetUnique); // Throws
-    }
-}
-
-void Table::set_null(size_t col_ndx, size_t row_ndx, bool is_default)
-{
-    if (!is_nullable(col_ndx)) {
-        throw LogicError{LogicError::column_not_nullable};
-    }
-    REALM_ASSERT(!is_link_type(m_spec.get_column_type(col_ndx))); // Use nullify_link().
-    REALM_ASSERT_3(col_ndx, <, get_column_count());
-    REALM_ASSERT_3(row_ndx, <, m_size);
-
-    bump_version();
-    ColumnBase& col = get_column_base(col_ndx);
-    col.set_null(row_ndx);
-
-    if (Replication* repl = get_repl())
-        repl->set_null(this, col_ndx, row_ndx, is_default ? _impl::instr_SetDefault : _impl::instr_Set); // Throws
 }
 
 

--- a/src/realm/table.hpp
+++ b/src/realm/table.hpp
@@ -2050,9 +2050,13 @@ inline void Table::set_ndx_in_parent(size_t ndx_in_parent) noexcept
 // Declare our explicit specializations so that the inline wrappers don't try
 // to instantiate them
 template<> int64_t Table::get<int64_t>(size_t, size_t) const noexcept;
+template<> util::Optional<int64_t> Table::get<util::Optional<int64_t>>(size_t, size_t) const noexcept;
 template<> bool Table::get<bool>(size_t, size_t) const noexcept;
+template<> Optional<bool> Table::get<Optional<bool>>(size_t, size_t) const noexcept;
 template<> float Table::get<float>(size_t, size_t) const noexcept;
+template<> util::Optional<float> Table::get<util::Optional<float>>(size_t, size_t) const noexcept;
 template<> double Table::get<double>(size_t, size_t) const noexcept;
+template<> util::Optional<double> Table::get<util::Optional<double>>(size_t, size_t) const noexcept;
 template<> OldDateTime Table::get<OldDateTime>(size_t, size_t) const noexcept;
 template<> Timestamp Table::get<Timestamp>(size_t, size_t) const noexcept;
 template<> StringData Table::get<StringData>(size_t, size_t) const noexcept;
@@ -2074,9 +2078,13 @@ template<> size_t Table::set_unique<int64_t>(size_t, size_t, int64_t);
 template<> size_t Table::set_unique<StringData>(size_t, size_t, StringData);
 template<> size_t Table::set_unique<null>(size_t, size_t, null);
 
+
 inline int64_t Table::get_int(size_t col_ndx, size_t ndx) const noexcept
 {
-    return get<int64_t>(col_ndx, ndx);
+    if (is_nullable(col_ndx))
+        return get<util::Optional<int64_t>>(col_ndx, ndx).value_or(0);
+    else
+        return get<int64_t>(col_ndx, ndx);
 }
 
 inline size_t Table::set_int_unique(size_t col_ndx, size_t ndx, int_fast64_t value)
@@ -2101,7 +2109,10 @@ inline void Table::set_timestamp(size_t col_ndx, size_t ndx, Timestamp value, bo
 
 inline bool Table::get_bool(size_t col_ndx, size_t ndx) const noexcept
 {
-    return get<bool>(col_ndx, ndx);
+    if (is_nullable(col_ndx))
+        return get<util::Optional<bool>>(col_ndx, ndx).value_or(false);
+    else
+        return get<bool>(col_ndx, ndx);
 }
 
 inline void Table::set_bool(size_t col_ndx, size_t ndx, bool value, bool is_default)
@@ -2121,7 +2132,8 @@ inline void Table::set_olddatetime(size_t col_ndx, size_t ndx, OldDateTime value
 
 inline float Table::get_float(size_t col_ndx, size_t ndx) const noexcept
 {
-    return get<float>(col_ndx, ndx);
+    float f = get<float>(col_ndx, ndx);
+    return null::is_null_float(f) ? 0.0f : f;
 }
 
 inline void Table::set_float(size_t col_ndx, size_t ndx, float value, bool is_default)
@@ -2131,7 +2143,8 @@ inline void Table::set_float(size_t col_ndx, size_t ndx, float value, bool is_de
 
 inline double Table::get_double(size_t col_ndx, size_t ndx) const noexcept
 {
-    return get<double>(col_ndx, ndx);
+    double d = get<double>(col_ndx, ndx);
+    return null::is_null_float(d) ? 0.0f : d;
 }
 
 inline void Table::set_double(size_t col_ndx, size_t ndx, double value, bool is_default)

--- a/src/realm/table.hpp
+++ b/src/realm/table.hpp
@@ -610,6 +610,9 @@ public:
     double average_double(size_t column_ndx, size_t* value_count = nullptr) const;
 
     // Searching
+    template <class T>
+    size_t find_first(size_t column_ndx, T value) const;
+
     size_t find_first_link(size_t target_row_index) const;
     size_t find_first_int(size_t column_ndx, int64_t value) const;
     size_t find_first_bool(size_t column_ndx, bool value) const;
@@ -681,8 +684,6 @@ public:
     uint_fast64_t get_version_counter() const noexcept;
 
 private:
-    template <class T>
-    size_t find_first(size_t column_ndx, T value) const; // called by above methods
     template <class T>
     TableView find_all(size_t column_ndx, T value);
 

--- a/src/realm/table.hpp
+++ b/src/realm/table.hpp
@@ -2144,7 +2144,7 @@ inline void Table::set_float(size_t col_ndx, size_t ndx, float value, bool is_de
 inline double Table::get_double(size_t col_ndx, size_t ndx) const noexcept
 {
     double d = get<double>(col_ndx, ndx);
-    return null::is_null_float(d) ? 0.0f : d;
+    return null::is_null_float(d) ? 0.0 : d;
 }
 
 inline void Table::set_double(size_t col_ndx, size_t ndx, double value, bool is_default)

--- a/src/realm/table.hpp
+++ b/src/realm/table.hpp
@@ -493,6 +493,12 @@ public:
     static constexpr int_fast64_t max_integer = std::numeric_limits<int64_t>::max();
     static constexpr int_fast64_t min_integer = std::numeric_limits<int64_t>::min();
 
+    template <class T>
+    void set(size_t c, size_t r, T value, bool is_default = false);
+
+    template <class T>
+    size_t set_unique(size_t c, size_t r, T value);
+
     void set_int(size_t column_ndx, size_t row_ndx, int_fast64_t value, bool is_default = false);
     size_t set_int_unique(size_t column_ndx, size_t row_ndx, int_fast64_t value);
     void set_bool(size_t column_ndx, size_t row_ndx, bool value, bool is_default = false);
@@ -2039,6 +2045,144 @@ inline void Table::set_ndx_in_parent(size_t ndx_in_parent) noexcept
         m_columns.set_ndx_in_parent(ndx_in_parent);
     }
 }
+
+// Declare our explicit specializations so that the inline wrappers don't try
+// to instantiate them
+template<> int64_t Table::get<int64_t>(size_t, size_t) const noexcept;
+template<> bool Table::get<bool>(size_t, size_t) const noexcept;
+template<> float Table::get<float>(size_t, size_t) const noexcept;
+template<> double Table::get<double>(size_t, size_t) const noexcept;
+template<> OldDateTime Table::get<OldDateTime>(size_t, size_t) const noexcept;
+template<> Timestamp Table::get<Timestamp>(size_t, size_t) const noexcept;
+template<> StringData Table::get<StringData>(size_t, size_t) const noexcept;
+template<> BinaryData Table::get<BinaryData>(size_t, size_t) const noexcept;
+template<> Mixed Table::get<Mixed>(size_t, size_t) const noexcept;
+
+template<> void Table::set<int64_t>(size_t, size_t, int64_t, bool);
+template<> void Table::set<bool>(size_t, size_t, bool, bool);
+template<> void Table::set<float>(size_t, size_t, float, bool);
+template<> void Table::set<double>(size_t, size_t, double, bool);
+template<> void Table::set<OldDateTime>(size_t, size_t, OldDateTime, bool);
+template<> void Table::set<Timestamp>(size_t, size_t, Timestamp, bool);
+template<> void Table::set<StringData>(size_t, size_t, StringData, bool);
+template<> void Table::set<BinaryData>(size_t, size_t, BinaryData, bool);
+template<> void Table::set<Mixed>(size_t, size_t, Mixed, bool);
+template<> void Table::set<null>(size_t, size_t, null, bool);
+
+template<> size_t Table::set_unique<int64_t>(size_t, size_t, int64_t);
+template<> size_t Table::set_unique<StringData>(size_t, size_t, StringData);
+template<> size_t Table::set_unique<null>(size_t, size_t, null);
+
+inline int64_t Table::get_int(size_t col_ndx, size_t ndx) const noexcept
+{
+    return get<int64_t>(col_ndx, ndx);
+}
+
+inline size_t Table::set_int_unique(size_t col_ndx, size_t ndx, int_fast64_t value)
+{
+    return set_unique(col_ndx, ndx, value);
+}
+
+inline void Table::set_int(size_t col_ndx, size_t ndx, int_fast64_t value, bool is_default)
+{
+    return set(col_ndx, ndx, value, is_default);
+}
+
+inline Timestamp Table::get_timestamp(size_t col_ndx, size_t ndx) const noexcept
+{
+    return get<Timestamp>(col_ndx, ndx);
+}
+
+inline void Table::set_timestamp(size_t col_ndx, size_t ndx, Timestamp value, bool is_default)
+{
+    return set(col_ndx, ndx, value, is_default);
+}
+
+inline bool Table::get_bool(size_t col_ndx, size_t ndx) const noexcept
+{
+    return get<bool>(col_ndx, ndx);
+}
+
+inline void Table::set_bool(size_t col_ndx, size_t ndx, bool value, bool is_default)
+{
+    return set(col_ndx, ndx, value, is_default);
+}
+
+inline OldDateTime Table::get_olddatetime(size_t col_ndx, size_t ndx) const noexcept
+{
+    return get<OldDateTime>(col_ndx, ndx);
+}
+
+inline void Table::set_olddatetime(size_t col_ndx, size_t ndx, OldDateTime value, bool is_default)
+{
+    return set(col_ndx, ndx, value, is_default);
+}
+
+inline float Table::get_float(size_t col_ndx, size_t ndx) const noexcept
+{
+    return get<float>(col_ndx, ndx);
+}
+
+inline void Table::set_float(size_t col_ndx, size_t ndx, float value, bool is_default)
+{
+    return set(col_ndx, ndx, value, is_default);
+}
+
+inline double Table::get_double(size_t col_ndx, size_t ndx) const noexcept
+{
+    return get<double>(col_ndx, ndx);
+}
+
+inline void Table::set_double(size_t col_ndx, size_t ndx, double value, bool is_default)
+{
+    return set(col_ndx, ndx, value, is_default);
+}
+
+inline StringData Table::get_string(size_t col_ndx, size_t ndx) const noexcept
+{
+    return get<StringData>(col_ndx, ndx);
+}
+
+inline void Table::set_string(size_t col_ndx, size_t ndx, StringData value, bool is_default)
+{
+    return set(col_ndx, ndx, value, is_default);
+}
+
+inline size_t Table::set_string_unique(size_t col_ndx, size_t ndx, StringData value)
+{
+    return set_unique(col_ndx, ndx, value);
+}
+
+inline BinaryData Table::get_binary(size_t col_ndx, size_t ndx) const noexcept
+{
+    return get<BinaryData>(col_ndx, ndx);
+}
+
+inline void Table::set_binary(size_t col_ndx, size_t ndx, BinaryData value, bool is_default)
+{
+    set(col_ndx, ndx, value, is_default);
+}
+
+inline Mixed Table::get_mixed(size_t col_ndx, size_t ndx) const noexcept
+{
+    return get<Mixed>(col_ndx, ndx);
+}
+
+inline void Table::set_mixed(size_t col_ndx, size_t ndx, Mixed value, bool is_default)
+{
+    set(col_ndx, ndx, value, is_default);
+}
+
+inline void Table::set_null(size_t col_ndx, size_t ndx, bool is_default)
+{
+    set(col_ndx, ndx, null(), is_default);
+}
+
+inline void Table::set_null_unique(size_t col_ndx, size_t ndx)
+{
+    set_unique(col_ndx, ndx, null());
+}
+
 
 // This class groups together information about the target of a link column
 // This is not a valid link if the target table == nullptr

--- a/src/realm/table_view.cpp
+++ b/src/realm/table_view.cpp
@@ -98,61 +98,31 @@ void TableViewBase::apply_patch(HandoverPatch& patch, Group& group)
 
 // Searching
 
-// find_*_integer() methods are used for all "kinds" of integer values (bool, int, OldDateTime)
-
-size_t TableViewBase::find_first_integer(size_t column_ndx, int64_t value) const
+template<typename T>
+size_t TableViewBase::find_first(size_t column_ndx, T value) const
 {
     check_cookie();
 
-    for (size_t i = 0; i < m_row_indexes.size(); i++)
-        if (is_row_attached(i) && get_int(column_ndx, i) == value)
+    for (size_t i = 0, size = m_row_indexes.size(); i < size; ++i) {
+        const int64_t real_ndx = m_row_indexes.get(i);
+        if (real_ndx != detached_ref && m_table->get<T>(column_ndx, i) == value)
             return i;
+    }
+
     return size_t(-1);
 }
 
-size_t TableViewBase::find_first_float(size_t column_ndx, float value) const
-{
-    check_cookie();
-
-    for (size_t i = 0; i < m_row_indexes.size(); i++)
-        if (is_row_attached(i) && get_float(column_ndx, i) == value)
-            return i;
-    return size_t(-1);
-}
-
-size_t TableViewBase::find_first_double(size_t column_ndx, double value) const
-{
-    check_cookie();
-
-    for (size_t i = 0; i < m_row_indexes.size(); i++)
-        if (is_row_attached(i) && get_double(column_ndx, i) == value)
-            return i;
-    return size_t(-1);
-}
-
-size_t TableViewBase::find_first_string(size_t column_ndx, StringData value) const
-{
-    check_cookie();
-
-    REALM_ASSERT_COLUMN_AND_TYPE(column_ndx, type_String);
-
-    for (size_t i = 0; i < m_row_indexes.size(); i++)
-        if (is_row_attached(i) && get_string(column_ndx, i) == value)
-            return i;
-    return size_t(-1);
-}
-
-size_t TableViewBase::find_first_binary(size_t column_ndx, BinaryData value) const
-{
-    check_cookie();
-
-    REALM_ASSERT_COLUMN_AND_TYPE(column_ndx, type_Binary);
-
-    for (size_t i = 0; i < m_row_indexes.size(); i++)
-        if (is_row_attached(i) && get_binary(column_ndx, i) == value)
-            return i;
-    return size_t(-1);
-}
+template size_t TableViewBase::find_first(size_t, int64_t) const;
+template size_t TableViewBase::find_first(size_t, util::Optional<int64_t>) const;
+template size_t TableViewBase::find_first(size_t, bool) const;
+template size_t TableViewBase::find_first(size_t, Optional<bool>) const;
+template size_t TableViewBase::find_first(size_t, float) const;
+template size_t TableViewBase::find_first(size_t, util::Optional<float>) const;
+template size_t TableViewBase::find_first(size_t, double) const;
+template size_t TableViewBase::find_first(size_t, util::Optional<double>) const;
+template size_t TableViewBase::find_first(size_t, Timestamp) const;
+template size_t TableViewBase::find_first(size_t, StringData) const;
+template size_t TableViewBase::find_first(size_t, BinaryData) const;
 
 
 // Aggregates ----------------------------------------------------
@@ -166,7 +136,7 @@ R TableViewBase::aggregate(R (ColType::*aggregateMethod)(size_t, size_t, size_t,
     static_cast<void>(aggregateMethod);
     check_cookie();
     size_t non_nulls = 0;
-            
+
     if (return_ndx)
         *return_ndx = npos;
 
@@ -205,7 +175,7 @@ R TableViewBase::aggregate(R (ColType::*aggregateMethod)(size_t, size_t, size_t,
     // with 'new' because it will lead to mem leak. The column keeps ownership
     // of the payload in array and will free it itself later, so we must not call destroy() on array.
     ArrType arr(column->get_alloc());
-    
+
     // FIXME: Speed optimization disabled because we need is_null() which is not available on all leaf types.
 
 /*
@@ -255,7 +225,7 @@ R TableViewBase::aggregate(R (ColType::*aggregateMethod)(size_t, size_t, size_t,
         else if (function != act_Count && !column->is_null(to_size_t(signed_row_ndx))){
             non_nulls++;
             R unpacked = static_cast<R>(util::unwrap(v));
-            
+
             if (function == act_Sum || function == act_Average) {
                 res += unpacked;
             }

--- a/src/realm/table_view.hpp
+++ b/src/realm/table_view.hpp
@@ -200,7 +200,10 @@ public:
     // Subtables
     size_t get_subtable_size(size_t column_ndx, size_t row_ndx) const noexcept;
 
-    // Searching (Int and String)
+    // Searching
+    template<typename T>
+    size_t find_first(size_t column_ndx, T value) const;
+
     size_t find_first_int(size_t column_ndx, int64_t value) const;
     size_t find_first_bool(size_t column_ndx, bool value) const;
     size_t find_first_olddatetime(size_t column_ndx, OldDateTime value) const;
@@ -208,6 +211,7 @@ public:
     size_t find_first_double(size_t column_ndx, double value) const;
     size_t find_first_string(size_t column_ndx, StringData value) const;
     size_t find_first_binary(size_t column_ndx, BinaryData value) const;
+    size_t find_first_timestamp(size_t column_ndx, Timestamp value) const;
 
     // Aggregate functions. count_target is ignored by all <int
     // function> except Count. Hack because of bug in optional
@@ -1107,6 +1111,36 @@ inline size_t TableViewBase::find_first_olddatetime(size_t column_ndx, OldDateTi
 {
     REALM_ASSERT_COLUMN_AND_TYPE(column_ndx, type_OldDateTime);
     return find_first_integer(column_ndx, int64_t(value.get_olddatetime()));
+}
+
+inline size_t TableViewBase::find_first_integer(size_t column_ndx, int64_t value) const
+{
+    return find_first<int64_t>(column_ndx, value);
+}
+
+inline size_t TableViewBase::find_first_float(size_t column_ndx, float value) const
+{
+    return find_first<float>(column_ndx, value);
+}
+
+inline size_t TableViewBase::find_first_double(size_t column_ndx, double value) const
+{
+    return find_first<double>(column_ndx, value);
+}
+
+inline size_t TableViewBase::find_first_string(size_t column_ndx, StringData value) const
+{
+    return find_first<StringData>(column_ndx, value);
+}
+
+inline size_t TableViewBase::find_first_binary(size_t column_ndx, BinaryData value) const
+{
+    return find_first<BinaryData>(column_ndx, value);
+}
+
+inline size_t TableViewBase::find_first_timestamp(size_t column_ndx, Timestamp value) const
+{
+    return find_first<Timestamp>(column_ndx, value);
 }
 
 


### PR DESCRIPTION
This follows the approach taken by Table::get() in making the templated function have the actual implementation and turning the existing non-template version into a wrapper. It also moves these wrappers to table.hpp as they'll trivially inline out of existence.

There are no changes to the bodies of the functions here other than moving where in the file they are.