### PR TITLE
Remove file format version handling from allocator

### DIFF
--- a/src/realm/alloc.cpp
+++ b/src/realm/alloc.cpp
@@ -60,15 +60,6 @@ public:
     DefaultAllocator()
     {
         m_baseline = 1; // Zero is not available
-
-        // Please see Allocator::get_file_format_version() for information about
-        // the following determination of the file format version.
-        int current_file_format_version = 0; // Undecided
-        int history_type = Replication::hist_None;
-        using gf = _impl::GroupFriend;
-        m_file_format_version =
-            gf::get_target_file_format_version_for_session(current_file_format_version,
-                                                           history_type);
     }
 
     MemRef do_alloc(const size_t size) override

--- a/src/realm/alloc.hpp
+++ b/src/realm/alloc.hpp
@@ -138,87 +138,10 @@ public:
 
     Replication* get_replication() noexcept;
 
-    /// \brief The version of the format of the node structure (in file or in
-    /// memory) in use by Realm objects associated with this allocator.
-    ///
-    /// Every allocator contains a file format version field, which is returned
-    /// by this function. In some cases (as mentioned below) the file format can
-    /// change.
-    ///
-    /// A value of zero means that the file format is not yet decided. This is
-    /// only possible for empty Realms where top-ref is zero.
-    ///
-    /// For the default allocator (get_default()), the file format version field
-    /// can never change, is never zero, and is set to whatever
-    /// Group::get_target_file_format_version_for_session() would return if the
-    /// original file format version was undecided and the request history type
-    /// was Replication::hist_None.
-    ///
-    /// For the slab allocator (AllocSlab), the file format version field is set
-    /// to the file format version specified by the attached file (or attached
-    /// memory buffer) at the time of attachment. If no file (or buffer) is
-    /// currently attached, the returned value has no meaning. If the Realm file
-    /// format is later upgraded, the file format version filed must be updated
-    /// to reflect that fact.
-    ///
-    /// In shared mode (when a Realm file is opened via a SharedGroup instance)
-    /// it can happen that the file format is upgraded asyncronously (via
-    /// another SharedGroup instance), and in that case the file format version
-    /// field of the allocator can get out of date, but only for a short
-    /// while. It is always garanteed to be, and remain up to date after the
-    /// opening process completes (when SharedGroup::do_open() returns).
-    ///
-    /// An empty Realm file (one whose top-ref is zero) may specify a file
-    /// format version of zero to indicate that the format is not yet
-    /// decided. In that case, this function will return zero immediately after
-    /// AllocSlab::attach_file() returns. It shall be guaranteed, however, that
-    /// the zero is changed to a proper file format version before the opening
-    /// process completes (Group::open() or SharedGroup::open()). It is the duty
-    /// of the caller of AllocSlab::attach_file() to ensure this.
-    ///
-    /// File format versions:
-    ///
-    ///   1 Initial file format version
-    ///
-    ///   2 Various changes.
-    ///
-    ///   3 Supporting null on string columns broke the file format in following
-    ///     way: Index appends an 'X' character to all strings except the null
-    ///     string, to be able to distinguish between null and empty
-    ///     string. Bumped to 3 because of null support of String columns and
-    ///     because of new format of index.
-    ///
-    ///   4 Introduction of optional in-Realm history of changes (additional
-    ///     entries in Group::m_top). Since this change is not forward
-    ///     compatible, the file format version had to be bumped. This change is
-    ///     implemented in a way that achieves backwards compatibility with
-    ///     version 3 (and in turn with version 2).
-    ///
-    ///   5 Introduced the new Timestamp column type that replaces DateTime.
-    ///     When opening an older database file, all DateTime columns will be
-    ///     automatically upgraded Timestamp columns.
-    ///
-    ///   6 Introduced a new structure for the StringIndex. Moved the commit
-    ///     logs into the Realm file. Changes to the transaction log format
-    ///     including reshuffling instructions. This is the format used in
-    ///     milestone 2.0.0.
-    ///
-    ///   7 Introduced "history schema version" as 10th entry in top array.
-    ///
-    /// IMPORTANT: When introducing a new file format version, be sure to review
-    /// the file validity checks in AllocSlab::validate_buffer(), the file
-    /// format selection logic in
-    /// Group::get_target_file_format_version_for_session(), and the file format
-    /// upgrade logic in Group::upgrade_file_format().
-    int get_file_format_version() const noexcept;
-
 protected:
     size_t m_baseline = 0; // Separation line between immutable and mutable refs.
 
     Replication* m_replication = nullptr;
-
-    /// See get_file_format_version().
-    int m_file_format_version = 0;
 
     ref_type m_debug_watch = 0;
 
@@ -445,12 +368,6 @@ inline Replication* Allocator::get_replication() noexcept
 {
     return m_replication;
 }
-
-inline int Allocator::get_file_format_version() const noexcept
-{
-    return m_file_format_version;
-}
-
 
 } // namespace realm
 

--- a/src/realm/alloc_slab.cpp
+++ b/src/realm/alloc_slab.cpp
@@ -608,19 +608,23 @@ int SlabAlloc::get_committed_file_format_version() const noexcept
     return file_format_version;
 }
 
+bool SlabAlloc::is_file_on_streaming_form(const Header& header)
+{
+    int slot_selector = ((header.m_flags & SlabAlloc::flags_SelectBit) != 0 ? 1 : 0);
+    uint_fast64_t ref = uint_fast64_t(header.m_top_ref[slot_selector]);
+    return (slot_selector == 0 && ref == 0xFFFFFFFFFFFFFFFFULL);
+}
+
 ref_type SlabAlloc::get_top_ref(const char* buffer, size_t len)
 {
     const Header& header = reinterpret_cast<const Header&>(*buffer);
     int slot_selector = ((header.m_flags & SlabAlloc::flags_SelectBit) != 0 ? 1 : 0);
-    m_file_format_version = header.m_file_format[slot_selector];
-    uint_fast64_t ref = uint_fast64_t(header.m_top_ref[slot_selector]);
-    m_file_on_streaming_form = (slot_selector == 0 && ref == 0xFFFFFFFFFFFFFFFFULL);
-    if (m_file_on_streaming_form) {
+    if (is_file_on_streaming_form(header)) {
         const StreamingFooter& footer = *(reinterpret_cast<const StreamingFooter*>(buffer + len) - 1);
         return ref_type(footer.m_top_ref);
     }
     else {
-        return ref_type(ref);
+        return to_ref(header.m_top_ref[slot_selector]);
     }
 }
 
@@ -686,11 +690,9 @@ ref_type SlabAlloc::attach_file(const std::string& file_path, Config& cfg)
     // from the earlier mapping.
     if (m_file_mappings->m_success) {
         m_data = m_file_mappings->m_initial_mapping.get_addr();
-        m_file_format_version = get_committed_file_format_version();
         m_initial_chunk_size = m_file_mappings->m_initial_mapping.get_size();
         m_attach_mode = cfg.is_shared ? attach_SharedFile : attach_UnsharedFile;
         m_free_space_state = free_space_Invalid;
-        m_file_on_streaming_form = false;
         if (m_file_mappings->m_num_global_mappings > 0) {
             size_t mapping_index = m_file_mappings->m_num_global_mappings;
             size_t section_index = mapping_index + m_file_mappings->m_first_additional_mapping;
@@ -761,7 +763,7 @@ ref_type SlabAlloc::attach_file(const std::string& file_path, Config& cfg)
 
         if (!cfg.skip_validate) {
             // Verify the data structures
-            validate_buffer(map.get_addr(), size, path, cfg.is_shared); // Throws
+            validate_buffer(map.get_addr(), size, path); // Throws
         }
 
         top_ref = get_top_ref(map.get_addr(), size);
@@ -792,8 +794,8 @@ ref_type SlabAlloc::attach_file(const std::string& file_path, Config& cfg)
     // a later commit would have to do it. That would require coordination with
     // anybody concurrently joining the session, so it seems easier to do it at
     // session initialization, even if it means writing the database during open.
-    if (cfg.session_initiator && m_file_on_streaming_form) {
-        const Header& header = *reinterpret_cast<const Header*>(m_data);
+    const Header& header = *reinterpret_cast<const Header*>(m_data);
+    if (cfg.session_initiator && is_file_on_streaming_form(header)) {
         const StreamingFooter& footer = *(reinterpret_cast<const StreamingFooter*>(m_data + size) - 1);
         // Don't compare file format version fields as they are allowed to differ.
         // Also don't compare reserved fields (todo, is it correct to ignore?)
@@ -818,8 +820,9 @@ ref_type SlabAlloc::attach_file(const std::string& file_path, Config& cfg)
             realm::util::encryption_read_barrier(writable_map, 0);
             writable_header.m_flags |= flags_SelectBit;
             realm::util::encryption_write_barrier(writable_map, 0);
-            m_file_on_streaming_form = false;
             writable_map.sync();
+
+            realm::util::encryption_read_barrier(m_file_mappings->m_initial_mapping, 0, sizeof(Header));
         }
     }
 
@@ -867,6 +870,8 @@ ref_type SlabAlloc::attach_file(const std::string& file_path, Config& cfg)
                 m_baseline = size;
                 m_initial_chunk_size = size;
                 m_file_mappings->m_first_additional_mapping = get_section_index(m_initial_chunk_size);
+
+                realm::util::encryption_read_barrier(m_file_mappings->m_initial_mapping, 0, sizeof(Header));
             }
             else {
                 // Getting here, we have a file of a size that will not work, and without being
@@ -894,8 +899,7 @@ ref_type SlabAlloc::attach_buffer(const char* data, size_t size)
 
     // Verify the data structures
     std::string path; // No path
-    bool is_shared = false;
-    validate_buffer(data, size, path, is_shared); // Throws
+    validate_buffer(data, size, path); // Throws
 
     ref_type top_ref = get_top_ref(data, size);
 
@@ -917,7 +921,6 @@ void SlabAlloc::attach_empty()
 
     REALM_ASSERT(!is_attached());
 
-    m_file_format_version = 0; // Not yet decided
     m_attach_mode = attach_OwnedBuffer;
     m_data = nullptr; // Empty buffer
 
@@ -930,7 +933,7 @@ void SlabAlloc::attach_empty()
 }
 
 
-void SlabAlloc::validate_buffer(const char* data, size_t size, const std::string& path, bool is_shared)
+void SlabAlloc::validate_buffer(const char* data, size_t size, const std::string& path)
 {
     // Verify that size is sane and 8-byte aligned
     if (REALM_UNLIKELY(size < sizeof(Header) || size % 8 != 0))
@@ -960,48 +963,6 @@ void SlabAlloc::validate_buffer(const char* data, size_t size, const std::string
         throw InvalidDatabase("Bad Realm file header (#2)", path);
     if (REALM_UNLIKELY(top_ref >= size))
         throw InvalidDatabase("Bad Realm file header (#3)", path);
-
-    // Check file format version. For information about the differences between
-    // particular file format versions, refer to the documentation for
-    // get_file_format_version().
-    bool bad_file_format = true;
-    int file_format_version = int(header.m_file_format[slot_selector]);
-    if (file_format_version == 0) { // Not yet decided
-        if (top_ref == 0)
-            bad_file_format = false;
-    }
-    else if (is_shared) {
-        // In shared mode (Realm file opened via a SharedGroup instance) this
-        // version of the core library is able to open Realms using file format
-        // versions 2, 3, 4, 5, 6, and 7. Version 2, 3, 4, 5, and 6 files need
-        // to be upgraded. Please see Allocator::get_file_format_version() for
-        // information about the individual file format verions.
-        switch (file_format_version) {
-            case 2:
-            case 3:
-            case 4:
-            case 5:
-            case 6:
-            case 7:
-                bad_file_format = false;
-        }
-    }
-    else {
-        // In non-shared mode (Realm file opened via a Group instance) this
-        // version of the core library is only able to open Realms using file
-        // format version 6 or 7. Since a Realm file cannot be upgraded when
-        // opened in this mode (we may be unable to write to the file), no
-        // earlier versions can be opened. Please see
-        // Allocator::get_file_format_version() for information about the
-        // individual file format verions.
-        switch (file_format_version) {
-            case 6:
-            case 7:
-                bad_file_format = false;
-        }
-    }
-    if (REALM_UNLIKELY(bad_file_format))
-        throw InvalidDatabase("Unsupported Realm file format version", path);
 }
 
 
@@ -1206,12 +1167,6 @@ void SlabAlloc::reserve_disk_space(size_t size)
     if (!disable_sync)
         m_file_mappings->m_file.sync(); // Throws
 }
-
-void SlabAlloc::set_file_format_version(int file_format_version) noexcept
-{
-    m_file_format_version = file_format_version;
-}
-
 
 void SlabAlloc::verify() const
 {

--- a/src/realm/alloc_slab.hpp
+++ b/src/realm/alloc_slab.hpp
@@ -126,14 +126,6 @@ public:
     /// instance), the caller (SharedGroup::do_open()) must take steps to ensure
     /// cross-process mutual exclusion.
     ///
-    /// If the attached file contains an empty Realm (one whose top-ref is
-    /// zero), the file format version may remain undecided upon return from
-    /// this function. The file format is undecided if, and only if
-    /// get_file_format_version() returns zero. The caller is required to check
-    /// for this case, and decide on a file format version. This must happen
-    /// before the Realm opening process completes, and the decided file format
-    /// must be set in the allocator by calling set_file_format_version().
-    ///
     /// Except for \a file_path, the parameters are passed in through a
     /// configuration object.
     ///
@@ -157,14 +149,6 @@ public:
 
     /// Attach this allocator to the specified memory buffer.
     ///
-    /// If the attached buffer contains an empty Realm (one whose top-ref is
-    /// zero), the file format version may remain undecided upon return from
-    /// this function. The file format is undecided if, and only if
-    /// get_file_format_version() returns zero. The caller is required to check
-    /// for this case, and decide on a file format version. This must happen
-    /// before the Realm opening process completes, and the decided file format
-    /// must be set in the allocator by calling set_file_format_version().
-    ///
     /// It is an error to call this function on an attached
     /// allocator. Doing so will result in undefined behavor.
     ///
@@ -180,12 +164,6 @@ public:
     int get_committed_file_format_version() const noexcept;
 
     /// Attach this allocator to an empty buffer.
-    ///
-    /// Upon return from this function, the file format is undecided
-    /// (get_file_format_version() returns zero). The caller is required to
-    /// decide on a file format version. This must happen before the Realm
-    /// opening process completes, and the decided file format must be set in
-    /// the allocator by calling set_file_format_version().
     ///
     /// It is an error to call this function on an attached
     /// allocator. Doing so will result in undefined behavor.
@@ -304,18 +282,6 @@ public:
     /// call to SlabAlloc::alloc() corresponds to a mutation event.
     bool is_free_space_clean() const noexcept;
 
-    /// \brief Update the file format version field of the allocator.
-    ///
-    /// This must be done during the opening of the Realm if the stored file
-    /// format version is zero (empty Realm), or after the file format is
-    /// upgraded.
-    ///
-    /// Note that this does not modify the attached file, only the "cached"
-    /// value subsequenty returned by get_file_format_version().
-    ///
-    /// \sa get_file_format_version()
-    void set_file_format_version(int) noexcept;
-
     void verify() const override;
 #ifdef REALM_DEBUG
     void enable_debug(bool enable)
@@ -407,7 +373,6 @@ private:
     std::unique_ptr<size_t[]> m_section_bases;
     size_t m_num_section_bases = 0;
     AttachMode m_attach_mode = attach_None;
-    bool m_file_on_streaming_form = false;
     enum FeeeSpaceState {
         free_space_Clean,
         free_space_Dirty,
@@ -447,11 +412,12 @@ private:
     /// Throws InvalidDatabase if the file is not a Realm file, if the file is
     /// corrupted, or if the specified encryption key is incorrect. This
     /// function will not detect all forms of corruption, though.
-    void validate_buffer(const char* data, size_t len, const std::string& path, bool is_shared);
+    void validate_buffer(const char* data, size_t len, const std::string& path);
 
+    static bool is_file_on_streaming_form(const Header& header);
     /// Read the top_ref from the given buffer and set m_file_on_streaming_form
     /// if the buffer contains a file in streaming form
-    ref_type get_top_ref(const char* data, size_t len);
+    static ref_type get_top_ref(const char* data, size_t len);
 
     class ChunkRefEq;
     class ChunkRefEndEq;

--- a/src/realm/group.cpp
+++ b/src/realm/group.cpp
@@ -66,9 +66,7 @@ Group::Group()
 {
     init_array_parents();
     m_alloc.attach_empty(); // Throws
-    Replication::HistoryType history_type = Replication::hist_None;
-    int file_format_version = get_target_file_format_version_for_session(0, history_type);
-    m_alloc.set_file_format_version(file_format_version);
+    m_file_format_version = get_target_file_format_version_for_session(0, Replication::hist_None);
     ref_type top_ref = 0; // Instantiate a new empty group
     bool create_group_when_missing = true;
     attach(top_ref, create_group_when_missing); // Throws
@@ -77,13 +75,13 @@ Group::Group()
 
 int Group::get_file_format_version() const noexcept
 {
-    return m_alloc.get_file_format_version();
+    return m_file_format_version;
 }
 
 
 void Group::set_file_format_version(int file_format) noexcept
 {
-    m_alloc.set_file_format_version(file_format);
+    m_file_format_version = file_format;
 }
 
 
@@ -127,8 +125,8 @@ void Group::upgrade_file_format(int target_file_format_version)
     int current_file_format_version = get_file_format_version();
     REALM_ASSERT(current_file_format_version < target_file_format_version);
 
-    // SlabAlloc::validate_buffer() must ensure this. Be sure to revisit the
-    // following upgrade logic when SlabAlloc::validate_buffer() is changed (or
+    // SharedGroup::do_open() must ensure this. Be sure to revisit the
+    // following upgrade logic when SharedGroup::do_open() is changed (or
     // vice versa).
     REALM_ASSERT_EX(current_file_format_version == 2 || current_file_format_version == 3 ||
                     current_file_format_version == 4 || current_file_format_version == 5 ||
@@ -177,9 +175,55 @@ void Group::upgrade_file_format(int target_file_format_version)
 
     // NOTE: Additional future upgrade steps go here.
 
-    set_file_format_version(target_file_format_version);
+    m_file_format_version = target_file_format_version;
 }
 
+void Group::open(ref_type top_ref, const std::string& file_path)
+{
+    SlabAlloc::DetachGuard dg(m_alloc);
+
+    // Select file format if it is still undecided.
+    m_file_format_version = m_alloc.get_committed_file_format_version();
+
+    bool file_format_ok = false;
+    // In non-shared mode (Realm file opened via a Group instance) this version
+    // of the core library is only able to open Realms using file format version
+    // 6 or 7. Since a Realm file cannot be upgraded when opened in this mode
+    // (we may be unable to write to the file), no earlier versions can be opened.
+    // Please see Group::get_file_format_version() for information about the
+    // individual file format versions.
+    switch (m_file_format_version) {
+        case 0:
+            file_format_ok = (top_ref == 0);
+            break;
+        case 6:
+        case 7:
+            file_format_ok = true;
+            break;
+    }
+    if (REALM_UNLIKELY(!file_format_ok))
+        throw InvalidDatabase("Unsupported Realm file format version", file_path);
+
+    Replication::HistoryType history_type = Replication::hist_None;
+    int target_file_format_version = get_target_file_format_version_for_session(m_file_format_version, history_type);
+    if (m_file_format_version == 0) {
+        set_file_format_version(target_file_format_version);
+    }
+    else {
+        // From a technical point of view, we could upgrade the Realm file
+        // format in memory here, but since upgrading can be expensive, it is
+        // currently disallowed.
+        REALM_ASSERT(target_file_format_version == m_file_format_version);
+    }
+
+    // Make all dynamically allocated memory (space beyond the attached file) as
+    // available free-space.
+    reset_free_space_tracking(); // Throws
+
+    bool create_group_when_missing = true;
+    attach(top_ref, create_group_when_missing); // Throws
+    dg.release();                               // Do not detach after all
+}
 
 void Group::open(const std::string& file_path, const char* encryption_key, OpenMode mode)
 {
@@ -191,30 +235,8 @@ void Group::open(const std::string& file_path, const char* encryption_key, OpenM
     cfg.no_create = mode == mode_ReadWriteNoCreate;
     cfg.encryption_key = encryption_key;
     ref_type top_ref = m_alloc.attach_file(file_path, cfg); // Throws
-    SlabAlloc::DetachGuard dg(m_alloc);
 
-    // Select file format if it is still undecided.
-    int current_file_format_version = get_file_format_version();
-    Replication::HistoryType history_type = Replication::hist_None;
-    int target_file_format_version =
-        get_target_file_format_version_for_session(current_file_format_version, history_type);
-    if (current_file_format_version == 0) {
-        set_file_format_version(target_file_format_version);
-    }
-    else {
-        // From a technical point of view, we could upgrade the Realm file
-        // format in memory here, but since upgrading can be expensive, it is
-        // currently disallowed by the SlabAlloc::validate_buffer().
-        REALM_ASSERT(target_file_format_version == current_file_format_version);
-    }
-
-    // Make all dynamically allocated memory (space beyond the attached file) as
-    // available free-space.
-    reset_free_space_tracking(); // Throws
-
-    bool create_group_when_missing = true;
-    attach(top_ref, create_group_when_missing); // Throws
-    dg.release();                               // Do not detach after all
+    open(top_ref, file_path);
 }
 
 
@@ -226,30 +248,8 @@ void Group::open(BinaryData buffer, bool take_ownership)
         throw LogicError(LogicError::wrong_group_state);
 
     ref_type top_ref = m_alloc.attach_buffer(buffer.data(), buffer.size()); // Throws
-    SlabAlloc::DetachGuard dg(m_alloc);
 
-    // Select file format if it is still undecided.
-    int current_file_format_version = get_file_format_version();
-    Replication::HistoryType history_type = Replication::hist_None;
-    int target_file_format_version =
-        get_target_file_format_version_for_session(current_file_format_version, history_type);
-    if (current_file_format_version == 0) {
-        set_file_format_version(target_file_format_version);
-    }
-    else {
-        // From a technical point of view, we could upgrade the Realm file
-        // format in memory here, but since upgrading can be expensive, it is
-        // currently disallowed by the SlabAlloc::validate_buffer().
-        REALM_ASSERT(target_file_format_version == current_file_format_version);
-    }
-
-    // Make all dynamically allocated memory (space beyond the attached file) as
-    // available free-space.
-    reset_free_space_tracking(); // Throws
-
-    bool create_group_when_missing = true;
-    attach(top_ref, create_group_when_missing); // Throws
-    dg.release();                               // Do not detach after all
+    open(top_ref, {});
 
     if (take_ownership)
         m_alloc.own_buffer();
@@ -775,7 +775,7 @@ void Group::write(std::ostream& out, bool pad_for_encryption, uint_fast64_t vers
     REALM_ASSERT(is_attached());
     DefaultTableWriter table_writer(*this);
     bool no_top_array = !m_top.is_attached();
-    write(out, m_alloc, table_writer, no_top_array, pad_for_encryption, version_number); // Throws
+    write(out, m_file_format_version, table_writer, no_top_array, pad_for_encryption, version_number); // Throws
 }
 
 void Group::write(const std::string& path, const char* encryption_key) const
@@ -828,14 +828,20 @@ BinaryData Group::write_to_mem() const
 }
 
 
-void Group::write(std::ostream& out, const Allocator& alloc, TableWriter& table_writer, bool no_top_array,
+void Group::write(std::ostream& out, int file_format_version, TableWriter& table_writer, bool no_top_array,
                   bool pad_for_encryption, uint_fast64_t version_number)
 {
     _impl::OutputStream out_2(out);
 
     // Write the file header
     SlabAlloc::Header streaming_header;
-    int file_format_version = (no_top_array ? 0 : alloc.get_file_format_version());
+    if (no_top_array) {
+        file_format_version = 0;
+    }
+    else if (file_format_version == 0) {
+        // Use current file format version
+        file_format_version = get_target_file_format_version_for_session(0, Replication::hist_None);
+    }
     SlabAlloc::init_streaming_header(&streaming_header, file_format_version);
     out_2.write(reinterpret_cast<const char*>(&streaming_header), sizeof streaming_header);
 
@@ -859,7 +865,6 @@ void Group::write(std::ostream& out, const Allocator& alloc, TableWriter& table_
         ref_type tables_ref = table_writer.write_tables(out_2); // Throws
         SlabAlloc new_alloc;
         new_alloc.attach_empty(); // Throws
-        new_alloc.set_file_format_version(alloc.get_file_format_version());
         Array top(new_alloc);
         top.create(Array::type_HasRefs); // Throws
         _impl::ShallowArrayDestroyGuard dg_top(&top);
@@ -1872,7 +1877,7 @@ void Group::advance_transact(ref_type new_top_ref, size_t new_file_size, _impl::
 void Group::prepare_history_parent(Array& history_root, int history_type,
                                    int history_schema_version)
 {
-    REALM_ASSERT(m_alloc.get_file_format_version() >= 7);
+    REALM_ASSERT(m_file_format_version >= 7);
     if (m_top.size() < 10) {
         REALM_ASSERT(m_top.size() <= 7);
         while (m_top.size() < 7) {

--- a/src/realm/group.hpp
+++ b/src/realm/group.hpp
@@ -527,6 +527,7 @@ public:
 private:
     SlabAlloc m_alloc;
 
+    int m_file_format_version;
     /// `m_top` is the root node (or top array) of the Realm, and has the
     /// following layout:
     ///
@@ -588,6 +589,8 @@ private:
 
     void init_array_parents() noexcept;
 
+    void open(ref_type top_ref, const std::string& file_path);
+
     /// If `top_ref` is not zero, attach this group accessor to the specified
     /// underlying node structure. If `top_ref` is zero and \a
     /// create_group_when_missing is true, create a new node structure that
@@ -638,8 +641,8 @@ private:
     class TableWriter;
     class DefaultTableWriter;
 
-    static void write(std::ostream&, const Allocator&, TableWriter&, bool no_top_array, bool pad_for_encryption,
-                      uint_fast64_t version_number);
+    static void write(std::ostream&, int file_format_version, TableWriter&, bool no_top_array,
+                      bool pad_for_encryption, uint_fast64_t version_number);
 
     typedef void (*DescSetter)(Table&);
     typedef bool (*DescMatcher)(const Spec&);
@@ -673,6 +676,66 @@ private:
     template <class F>
     void update_table_indices(F&& map_function);
 
+    /// \brief The version of the format of the node structure (in file or in
+    /// memory) in use by Realm objects associated with this group.
+    ///
+    /// Every group contains a file format version field, which is returned
+    /// by this function. The file format version field is set to the file format
+    /// version specified by the attached file (or attached memory buffer) at the
+    /// time of attachment and the value is used to determine if a file format
+    /// upgrade is required.
+    ///
+    /// A value of zero means that the file format is not yet decided. This is
+    /// only possible for empty Realms where top-ref is zero. (When group is created
+    /// with the unattached_tag). The version number will then be determined in the
+    /// subsequent call to Group::open.
+    ///
+    /// In shared mode (when a Realm file is opened via a SharedGroup instance)
+    /// it can happen that the file format is upgraded asyncronously (via
+    /// another SharedGroup instance), and in that case the file format version
+    /// field can get out of date, but only for a short while. It is always
+    /// guaranteed to be, and remain up to date after the opening process completes
+    /// (when SharedGroup::do_open() returns).
+    ///
+    /// An empty Realm file (one whose top-ref is zero) may specify a file
+    /// format version of zero to indicate that the format is not yet
+    /// decided. In that case the file format version must be changed to a proper
+    /// before the opening process completes (Group::open() or SharedGroup::open()).
+    ///
+    /// File format versions:
+    ///
+    ///   1 Initial file format version
+    ///
+    ///   2 Various changes.
+    ///
+    ///   3 Supporting null on string columns broke the file format in following
+    ///     way: Index appends an 'X' character to all strings except the null
+    ///     string, to be able to distinguish between null and empty
+    ///     string. Bumped to 3 because of null support of String columns and
+    ///     because of new format of index.
+    ///
+    ///   4 Introduction of optional in-Realm history of changes (additional
+    ///     entries in Group::m_top). Since this change is not forward
+    ///     compatible, the file format version had to be bumped. This change is
+    ///     implemented in a way that achieves backwards compatibility with
+    ///     version 3 (and in turn with version 2).
+    ///
+    ///   5 Introduced the new Timestamp column type that replaces DateTime.
+    ///     When opening an older database file, all DateTime columns will be
+    ///     automatically upgraded Timestamp columns.
+    ///
+    ///   6 Introduced a new structure for the StringIndex. Moved the commit
+    ///     logs into the Realm file. Changes to the transaction log format
+    ///     including reshuffling instructions. This is the format used in
+    ///     milestone 2.0.0.
+    ///
+    ///   7 Introduced "history schema version" as 10th entry in top array.
+    ///
+    /// IMPORTANT: When introducing a new file format version, be sure to review
+    /// the file validity checks in Group::open() and SharedGroup::do_open, the file
+    /// format selection logic in
+    /// Group::get_target_file_format_version_for_session(), and the file format
+    /// upgrade logic in Group::upgrade_file_format().
     int get_file_format_version() const noexcept;
     void set_file_format_version(int) noexcept;
     int get_committed_file_format_version() const noexcept;

--- a/src/realm/group_writer.cpp
+++ b/src/realm/group_writer.cpp
@@ -779,7 +779,7 @@ void GroupWriter::commit(ref_type new_top_ref)
     int slot_selector = ((new_flags & SlabAlloc::flags_SelectBit) != 0 ? 1 : 0);
 
     // Update top ref and file format version
-    int file_format_version = m_alloc.get_file_format_version();
+    int file_format_version = m_group.get_file_format_version();
     using type_1 = std::remove_reference<decltype(file_header.m_file_format[0])>::type;
     REALM_ASSERT(!util::int_cast_has_overflow<type_1>(file_format_version));
     file_header.m_top_ref[slot_selector] = new_top_ref;

--- a/src/realm/table.cpp
+++ b/src/realm/table.cpp
@@ -4718,7 +4718,8 @@ void Table::write(std::ostream& out, size_t offset, size_t slice_size, StringDat
     bool no_top_array = false;
     bool pad_for_encryption = false;
     uint_fast64_t version_number = 0;
-    Group::write(out, get_alloc(), writer, no_top_array, pad_for_encryption, version_number); // Throws
+    int file_format_version = 0;
+    Group::write(out, file_format_version, writer, no_top_array, pad_for_encryption, version_number); // Throws
 }
 
 


### PR DESCRIPTION
Confine the handling of file format version to the Group/SharedGroup
complex. There is no logic in having the allocator involved in this.