### PR TITLE
Fix string index based case insensitive searches for strings containing numbers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,10 @@
 
 ### Bugfixes
 
-* Lorem ipsum.
+* Fix for incorrect, redundant string index tree traversal for case insensitive searches
+  for strings with some characters being identical in upper and lower case (e.g. numbers).
+  PR [#2578](https://github.com/realm/realm-core/pull/2578),
+  Cocoa issue [#4895](https://github.com/realm/realm-cocoa/issues/4895)
 
 ### Breaking changes
 

--- a/src/realm/index_string.cpp
+++ b/src/realm/index_string.cpp
@@ -349,14 +349,14 @@ key_type generate_key(key_type upper, key_type lower, int permutation) {
 }
 
 
-struct WorkList {
+struct SearchList {
     struct Item {
         const char* header;
         size_t string_offset;
         key_type key;
     };
 
-    WorkList(const util::Optional<std::string>& upper_value, const util::Optional<std::string>& lower_value)
+    SearchList(const util::Optional<std::string>& upper_value, const util::Optional<std::string>& lower_value)
         : m_upper_value(upper_value)
         , m_lower_value(lower_value)
     {
@@ -417,13 +417,13 @@ void IndexArray::index_string_all_ins(StringData value, IntegerColumn& result, C
 
     const util::Optional<std::string> upper_value = case_map(value, true);
     const util::Optional<std::string> lower_value = case_map(value, false);
-    WorkList work_list(upper_value, lower_value);
+    SearchList search_list(upper_value, lower_value);
 
     const char* top_header = get_header_from_data(m_data);
-    work_list.add_all_for_level(top_header, 0);
+    search_list.add_all_for_level(top_header, 0);
 
-    while (!work_list.empty()) {
-        WorkList::Item item = work_list.get_next();
+    while (!search_list.empty()) {
+        SearchList::Item item = search_list.get_next();
 
         const char* const header = item.header;
         const size_t string_offset = item.string_offset;
@@ -452,7 +452,7 @@ void IndexArray::index_string_all_ins(StringData value, IntegerColumn& result, C
         if (is_inner_node) {
             // Set vars for next iteration
             const char* const inner_header = m_alloc.translate(to_ref(ref));
-            work_list.add_next(inner_header, string_offset, key);
+            search_list.add_next(inner_header, string_offset, key);
             continue;
         }
 
@@ -486,7 +486,7 @@ void IndexArray::index_string_all_ins(StringData value, IntegerColumn& result, C
         }
 
         // Recurse into sub-index;
-        work_list.add_all_for_level(sub_header, string_offset + 4);
+        search_list.add_all_for_level(sub_header, string_offset + 4);
     }
 }
 

--- a/src/realm/index_string.cpp
+++ b/src/realm/index_string.cpp
@@ -321,7 +321,7 @@ void IndexArray::from_list_all(StringData value, IntegerColumn& result, const In
 
 namespace {
 
-// Helper functions for index_string_all_ins for generating permutations of index keys
+// Helper functions for SearchList (index_string_all_ins) for generating permutations of index keys
 
 // replicates the 4 least significant bits each times 8
 // eg: abcd -> aaaaaaaabbbbbbbbccccccccdddddddd
@@ -349,6 +349,8 @@ key_type generate_key(key_type upper, key_type lower, int permutation) {
 }
 
 
+// Helper structure for IndexArray::index_string_all_ins to generate and keep track of search key permutations,
+// when traversing the trees.
 struct SearchList {
     struct Item {
         const char* header;
@@ -363,6 +365,7 @@ struct SearchList {
         m_keys_seen.reserve(num_permutations);
     }
 
+    // Add all unique keys for this level to the internal work stack
     void add_all_for_level(const char* header, size_t string_offset)
     {
         m_keys_seen.clear();
@@ -392,6 +395,7 @@ struct SearchList {
         return item;
     }
 
+    // Add a single entry to the internal work stack. Used to traverse the inner trees (same key)
     void add_next(const char* header, size_t string_offset, key_type key)
     {
         m_items.push_back({header, string_offset, key});

--- a/src/realm/index_string.cpp
+++ b/src/realm/index_string.cpp
@@ -321,7 +321,7 @@ void IndexArray::from_list_all(StringData value, IntegerColumn& result, const In
 
 namespace {
 
-// Helper functions for index_string<index_FindAll_ins> for generating permutations of index keys
+// Helper functions for index_string_all_ins for generating permutations of index keys
 
 // replicates the 4 least significant bits each times 8
 // eg: abcd -> aaaaaaaabbbbbbbbccccccccdddddddd
@@ -375,7 +375,8 @@ void IndexArray::index_string_all_ins(StringData value, IntegerColumn& result, C
         const key_type upper_key = StringIndex::create_key(upper_value, string_offset);
         const key_type lower_key = StringIndex::create_key(lower_value, string_offset);
         for (int p = 0; p < num_permutations; ++p) {
-            // this might still be incorrect due to unicode characters crossing the 4 byte key size
+            // this might still be incorrect due to multi-byte unicode characters (crossing the 4 byte key size)
+            // being combined incorrectly.
             const key_type key = generate_key(upper_key, lower_key, p);
             const bool new_key = std::find(keys_seen.cbegin(), keys_seen.cend(), key) == keys_seen.cend();
             if (new_key) {

--- a/test/test_index_string.cpp
+++ b/test/test_index_string.cpp
@@ -1969,4 +1969,30 @@ TEST_TYPES(StringIndex_Insensitive_VeryLongStrings, non_nullable, nullable)
 }
 
 
+// Bug with case insensitive search on numbers that gives duplicate results
+TEST_TYPES(StringIndex_Insensitive_Numbers, non_nullable, nullable)
+{
+    constexpr bool nullable = TEST_TYPE::value;
+
+    ref_type ref = StringColumn::create(Allocator::get_default());
+    StringColumn col(Allocator::get_default(), ref, nullable);
+    const StringIndex& ndx = *col.create_search_index();
+
+    constexpr const char* number_string_16 = "1111111111111111";
+    constexpr const char* number_string_17 = "11111111111111111";
+
+    col.add(number_string_16);
+    col.add(number_string_17);
+
+    ref_type results_ref = IntegerColumn::create(Allocator::get_default());
+    IntegerColumn results(Allocator::get_default(), results_ref);
+
+    ndx.find_all(results, number_string_16, true);
+    CHECK_EQUAL(results.size(), 1);
+
+    results.destroy();
+    col.destroy();
+}
+
+
 #endif // TEST_INDEX_STRING

--- a/test/test_query.cpp
+++ b/test/test_query.cpp
@@ -10259,4 +10259,23 @@ TEST(Query_ColumnDeletionLinks)
     CHECK_LOGIC_ERROR(q3.count(), LogicError::column_does_not_exist);
 }
 
+
+TEST(Query_CaseInsensitiveIndexEquality_CommonNumericPrefix)
+{
+    Table table;
+    size_t col_ndx = table.add_column(type_String, "id");
+    table.add_search_index(col_ndx);
+
+    table.add_empty_row(2);
+    table.set_string(col_ndx, 0, "111111111111111111111111");
+    table.set_string(col_ndx, 1, "111111111111111111111112");
+
+    Query q = table.where().equal(col_ndx, "111111111111111111111111", false);
+    CHECK_EQUAL(q.count(), 1);
+    TableView tv = q.find_all();
+    CHECK_EQUAL(tv.size(), 1);
+    CHECK_EQUAL(tv[0].get_index(), 0);
+}
+
+
 #endif // TEST_QUERY


### PR DESCRIPTION
The index tree traversal incorrectly (and redundantly) searched for non-unique keys, due to some characters being identical in the upper and lower case version of the search string (e.g. numbers).

This has now been fixed by filtering out identical _keys_, that is the 4-byte chunks of the search string that makes up the prefix tree that is our string index.

Related to https://github.com/realm/realm-cocoa/issues/4895