### PR TITLE
Add compute_aggregated_byte_size() to classes Group and Table

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,13 +10,15 @@
 
 ### Enhancements
 
-* Lorem ipsum.
+* Add `Group::compute_aggregated_byte_size()` and
+  `Table::compute_aggregated_byte_size()` for debugging/diagnostics purposes.
 
 -----------
 
 ### Internals
 
-* Lorem ipsum.
+* Make `Array::stats()` available in release mode builds (not just in debug mode
+  builds).
 
 ----------------------------------------------
 

--- a/src/realm/array.hpp
+++ b/src/realm/array.hpp
@@ -117,12 +117,13 @@ class ArrayWriterBase;
 }
 
 
-#ifdef REALM_DEBUG
 struct MemStats {
     size_t allocated = 0;
     size_t used = 0;
     size_t array_count = 0;
 };
+
+#ifdef REALM_DEBUG
 template <class C, class T>
 std::basic_ostream<C, T>& operator<<(std::basic_ostream<C, T>& out, MemStats stats);
 #endif
@@ -845,17 +846,20 @@ public:
     /// FIXME: Belongs in IntegerArray
     static size_t calc_aligned_byte_size(size_t size, int width);
 
+    class MemUsageHandler {
+    public:
+        virtual void handle(ref_type ref, size_t allocated, size_t used) = 0;
+    };
+
+    void report_memory_usage(MemUsageHandler&) const;
+
+    void stats(MemStats& stats_dest) const noexcept;
+
 #ifdef REALM_DEBUG
     void print() const;
     void verify() const;
     typedef size_t (*LeafVerifier)(MemRef, Allocator&);
     void verify_bptree(LeafVerifier) const;
-    class MemUsageHandler {
-    public:
-        virtual void handle(ref_type ref, size_t allocated, size_t used) = 0;
-    };
-    void report_memory_usage(MemUsageHandler&) const;
-    void stats(MemStats& stats_dest) const;
     typedef void (*LeafDumper)(MemRef, Allocator&, std::ostream&, int level);
     void dump_bptree_structure(std::ostream&, int level, LeafDumper) const;
     void to_dot(std::ostream&, StringData title = StringData()) const;
@@ -1007,9 +1011,7 @@ protected:
     /// log2. Posssible results {0, 1, 2, 4, 8, 16, 32, 64}
     static size_t bit_width(int64_t value);
 
-#ifdef REALM_DEBUG
     void report_memory_usage_2(MemUsageHandler&) const;
-#endif
 
 private:
     Getter m_getter = nullptr; // cached to avoid indirection

--- a/src/realm/group.cpp
+++ b/src/realm/group.cpp
@@ -1027,6 +1027,16 @@ bool Group::operator==(const Group& g) const
 }
 
 
+size_t Group::compute_aggregated_byte_size() const noexcept
+{
+    if (!is_attached())
+        return 0;
+    MemStats stats_2;
+    m_top.stats(stats_2);
+    return stats_2.allocated;
+}
+
+
 void Group::to_string(std::ostream& out) const
 {
     // Calculate widths

--- a/src/realm/group.hpp
+++ b/src/realm/group.hpp
@@ -510,6 +510,16 @@ public:
         return !(*this == g);
     }
 
+    /// Compute the sum of the sizes in number of bytes of all the array nodes
+    /// that currently make up this group. When this group represents a snapshot
+    /// in a Realm file (such as during a read transaction via a SharedGroup
+    /// instance), this function computes the footprint of that snapshot withing
+    /// the Realm file.
+    ///
+    /// If this group accessor is the detached state, this function returns
+    /// zero.
+    std::size_t compute_aggregated_byte_size() const noexcept;
+
     void verify() const;
 #ifdef REALM_DEBUG
     void print() const;
@@ -901,6 +911,15 @@ void Group::to_json(S& out, size_t link_depth, std::map<std::string, std::string
     }
 
     out << "}";
+}
+
+inline std::size_t Group::compute_aggregated_byte_size() const noexcept
+{
+    if (!is_attached())
+        return 0;
+    MemStats stats_2;
+    m_top.stats(stats_2);
+    return stats_2.allocated;
 }
 
 inline void Group::init_array_parents() noexcept

--- a/src/realm/group.hpp
+++ b/src/realm/group.hpp
@@ -513,12 +513,12 @@ public:
     /// Compute the sum of the sizes in number of bytes of all the array nodes
     /// that currently make up this group. When this group represents a snapshot
     /// in a Realm file (such as during a read transaction via a SharedGroup
-    /// instance), this function computes the footprint of that snapshot withing
+    /// instance), this function computes the footprint of that snapshot within
     /// the Realm file.
     ///
     /// If this group accessor is the detached state, this function returns
     /// zero.
-    std::size_t compute_aggregated_byte_size() const noexcept;
+    size_t compute_aggregated_byte_size() const noexcept;
 
     void verify() const;
 #ifdef REALM_DEBUG
@@ -911,15 +911,6 @@ void Group::to_json(S& out, size_t link_depth, std::map<std::string, std::string
     }
 
     out << "}";
-}
-
-inline std::size_t Group::compute_aggregated_byte_size() const noexcept
-{
-    if (!is_attached())
-        return 0;
-    MemStats stats_2;
-    m_top.stats(stats_2);
-    return stats_2.allocated;
 }
 
 inline void Group::init_array_parents() noexcept

--- a/src/realm/table.cpp
+++ b/src/realm/table.cpp
@@ -5289,6 +5289,17 @@ void Table::to_string_row(size_t row_ndx, std::ostream& out, const std::vector<s
 }
 
 
+size_t Table::compute_aggregated_byte_size() const noexcept
+{
+    if (!is_attached())
+        return 0;
+    const Array& real_top = (m_top.is_attached() ? m_top : m_columns);
+    MemStats stats_2;
+    real_top.stats(stats_2);
+    return stats_2.allocated;
+}
+
+
 bool Table::compare_rows(const Table& t) const
 {
     // Table accessors attached to degenerate subtables have no column

--- a/src/realm/table.hpp
+++ b/src/realm/table.hpp
@@ -832,6 +832,14 @@ public:
     /// function is mainly intended for debugging purposes.
     bool is_degenerate() const noexcept;
 
+    /// Compute the sum of the sizes in number of bytes of all the array nodes
+    /// that currently make up this table. See also
+    /// Group::compute_aggregate_byte_size().
+    ///
+    /// If this table accessor is the detached state, this function returns
+    /// zero.
+    std::size_t compute_aggregated_byte_size() const noexcept;
+
     // Debug
     void verify() const;
 #ifdef REALM_DEBUG
@@ -1965,6 +1973,16 @@ inline bool Table::operator!=(const Table& t) const
 inline bool Table::is_degenerate() const noexcept
 {
     return !m_columns.is_attached();
+}
+
+inline std::size_t Table::compute_aggregated_byte_size() const noexcept
+{
+    if (!is_attached())
+        return 0;
+    const Array& real_top = (m_top.is_attached() ? m_top : m_columns);
+    MemStats stats_2;
+    real_top.stats(stats_2);
+    return stats_2.allocated;
 }
 
 inline void Table::set_into_mixed(Table* parent, size_t col_ndx, size_t row_ndx) const

--- a/src/realm/table.hpp
+++ b/src/realm/table.hpp
@@ -838,7 +838,7 @@ public:
     ///
     /// If this table accessor is the detached state, this function returns
     /// zero.
-    std::size_t compute_aggregated_byte_size() const noexcept;
+    size_t compute_aggregated_byte_size() const noexcept;
 
     // Debug
     void verify() const;
@@ -1973,16 +1973,6 @@ inline bool Table::operator!=(const Table& t) const
 inline bool Table::is_degenerate() const noexcept
 {
     return !m_columns.is_attached();
-}
-
-inline std::size_t Table::compute_aggregated_byte_size() const noexcept
-{
-    if (!is_attached())
-        return 0;
-    const Array& real_top = (m_top.is_attached() ? m_top : m_columns);
-    MemStats stats_2;
-    real_top.stats(stats_2);
-    return stats_2.allocated;
 }
 
 inline void Table::set_into_mixed(Table* parent, size_t col_ndx, size_t row_ndx) const


### PR DESCRIPTION
These functions compute the aggregated number of bytes of all the array nodes that make up a group or table respectively. In case of group, the result includes the sizes of all the tables in the group.

The purpose of these is mainly problem solving and diagnostics.