### PR TITLE
Clean up mutex in unit test

### DIFF
--- a/test/test_shared.cpp
+++ b/test/test_shared.cpp
@@ -605,6 +605,7 @@ TEST(Shared_try_begin_write)
         t->add_empty_row(1000);
         thread_obtains_write_lock.lock();
         sg2.commit();
+        thread_obtains_write_lock.unlock();
     };
 
     thread_obtains_write_lock.lock();


### PR DESCRIPTION
Fixes #2588.
@rrrlasse I think this should fix it without ifdefing out the whole test, can you check?
Does windows now have support for `RobustMutex::try_lock` ?