### PR TITLE
LangBindHelper::get_backlink_table()

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,8 @@
   * Make `Table::find_first<T>()` public and add support for most column types.
   * Add wrappers for `Table::set<T>()` to `Row`.
   * Add support for all column types in `Table::get<T>()`.
+* Add `LangBindHelper::get_backlink_table()` to help bindings to follow backlinks.
+  PR [#2597](https://github.com/realm/realm-core/pull/2597).
 
 -----------
 

--- a/src/realm/lang_bind_helper.hpp
+++ b/src/realm/lang_bind_helper.hpp
@@ -100,6 +100,8 @@ public:
     static const LinkViewRef& get_linklist_ptr(Row&, size_t col_ndx);
     static void unbind_linklist_ptr(const LinkViewRef&);
 
+    static Table& get_backlink_table(const Table*, size_t col_ndx);
+
     using VersionID = SharedGroup::VersionID;
 
     /// \defgroup lang_bind_helper_transactions Continuous Transactions
@@ -373,6 +375,11 @@ inline SharedGroup::version_type LangBindHelper::get_version_of_latest_snapshot(
 {
     using sgf = _impl::SharedGroupFriend;
     return sgf::get_version_of_latest_snapshot(sg); // Throws
+}
+
+inline Table& LangBindHelper::get_backlink_table(const Table* t, size_t col_ndx)
+{
+    return t->get_column_backlink(col_ndx).get_origin_table();
 }
 
 } // namespace realm

--- a/test/test_lang_bind_helper.cpp
+++ b/test/test_lang_bind_helper.cpp
@@ -13058,4 +13058,20 @@ TEST(LangBindHelper_MixedTimestampTransaction)
 }
 
 
+TEST(LangBindHelper_GetBacklinkTable)
+{
+    Group group;
+
+    TableRef table_a = group.add_table("A");
+    TableRef table_b = group.add_table("B");
+
+    size_t col_str_a = table_a->add_column(type_String, "str_a");
+    size_t col_lnk_a = table_a->add_column_link(type_LinkList, "link_a", *table_b);
+
+    table_b->add_column(type_String, "str_b");
+
+    CHECK(&LangBindHelper::get_backlink_table(table_b.get(), col_lnk_a) == table_a.get());
+}
+
+
 #endif

--- a/test/test_link_query_view.cpp
+++ b/test/test_link_query_view.cpp
@@ -2037,4 +2037,85 @@ TEST(BackLink_Query_MultipleLevelsAndTables)
     CHECK_TABLE_VIEW(q.find_all(), {1});
 }
 
+TEST(Backlink_Query_IsNull)
+{
+    /*
+      +---------------+
+      | string | link |
+      +---------------+
+      | hello  | A[0] |
+      | null   | A[1] |
+      | world  | A[2] |
+      +---------------+
+    */
+    Group group;
+
+    TableRef table = group.add_table("A");
+
+    table->add_column(type_String, "string", true);
+    table->add_column_link(type_Link, "link", *table);
+
+    auto add_row = [&](Table& table, StringData value) {
+        size_t row = table.add_empty_row();
+        table.set_string(0, row, value);
+        table.set_link(1, row, row);
+    };
+
+    add_row(*table, "hello");
+    add_row(*table, realm::null());
+    add_row(*table, "world");
+
+    auto tableview = (table->backlink(*table, 1).column<String>(0) == realm::null()).find_all();
+    CHECK_EQUAL(1, tableview.size());
+}
+
+TEST(Backlink_Query_LinkList_IsNull)
+{
+    /*
+      +---------------------+
+      | string | link       |
+      +---------------------+
+      | hello  | A[0]       |
+      | null   | A[1], A[0] |
+      | world  | A[2]       |
+      | null   | A[3]       |
+      | hello  | A[4], A[2] |
+      +---------------------+
+    */
+    Group group;
+
+    TableRef table = group.add_table("A");
+
+    table->add_column(type_String, "string", true);
+    table->add_column_link(type_LinkList, "link", *table);
+
+    auto add_row = [&](Table& table, StringData value) {
+        size_t row = table.add_empty_row();
+        table.set_string(0, row, value);
+        auto links = table.get_linklist(1, row);
+        links->add(row);
+        if (row == 1) {
+            links->add(0);
+        }
+        if (row == 4) {
+            links->add(2);
+        }
+    };
+
+    add_row(*table, "hello");
+    add_row(*table, realm::null());
+    add_row(*table, "world");
+    add_row(*table, realm::null());
+    add_row(*table, "hello");
+
+    auto tableview_hello = (table->backlink(*table, 1).column<String>(0) == "hello").find_all();
+    CHECK_EQUAL(3, tableview_hello.size());
+
+    auto tableview_world = (table->backlink(*table, 1).column<String>(0) == "world").find_all();
+    CHECK_EQUAL(1, tableview_world.size());
+
+    auto tableview_null = (table->backlink(*table, 1).column<String>(0) == realm::null()).find_all();
+    CHECK_EQUAL(3, tableview_null.size());
+}
+
 #endif


### PR DESCRIPTION
I believe we need `LangBindHelper::get_backlink_table()` to finalize backlink support in Realm Java. I have also added a couple of unit tests to "document" backlink behaviour.