### PR TITLE
Enable encryption on watchOS

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,8 @@
 
 ### Enhancements
 
-* Lorem ipsum.
+* Enable encryption on watchOS.
+  Cocoa issue [#2876](https://github.com/realm/realm-cocoa/issues/2876).
 
 -----------
 

--- a/src/realm/util/features.h
+++ b/src/realm/util/features.h
@@ -232,9 +232,6 @@
 #if TARGET_OS_WATCH == 1
 /* Device (Apple Watch) or simulator. */
 #define REALM_WATCHOS 1
-/* The necessary signal handling / mach exception APIs are all unavailable */
-#undef REALM_ENABLE_ENCRYPTION
-#define REALM_ENABLE_ENCRYPTION 0
 #else
 #define REALM_WATCHOS 0
 #endif


### PR DESCRIPTION
Ever since the encryption refactoring in core 0.95 to avoid mach signals for encryption, this has been possible but the checks preventing its use were never removed.

Addresses https://github.com/realm/realm-cocoa/issues/2876.