### PR TITLE
include <realm/util/safe_int_ops.hpp> in alloc.hpp

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 * Fix a race condition in encrypted files which can lead to
   crashes on devices using OpenSSL (Android).
   PR [#2616](https://github.com/realm/realm-core/pull/2616).
+* Add #include <realm/util/safe_int_ops.hpp> in alloc.hpp
 
 ### Enhancements
 

--- a/src/realm/alloc.hpp
+++ b/src/realm/alloc.hpp
@@ -26,6 +26,7 @@
 #include <realm/util/features.h>
 #include <realm/util/terminate.hpp>
 #include <realm/util/assert.hpp>
+#include <realm/util/safe_int_ops.hpp>
 
 namespace realm {
 


### PR DESCRIPTION
A missing include because alloc.hpp calls from_twos_compl