### PR TITLE
Explicitly instantiate Table::find_first

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@
   PR [#2622](https://github.com/realm/realm-core/pull/2622).
 * Fix crash in large (>4GB) encrypted Realm files.
   PR [#2572](https://github.com/realm/realm-core/pull/2572).
+* Fix missing symbols for some overloads of Table::find_first
+  in some configurations.
 
 ### Breaking changes
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
   PR [#2572](https://github.com/realm/realm-core/pull/2572).
 * Fix missing symbols for some overloads of Table::find_first
   in some configurations.
+  PR [#2624](https://github.com/realm/realm-core/pull/2624).
 
 ### Breaking changes
 

--- a/src/realm/table.cpp
+++ b/src/realm/table.cpp
@@ -3954,6 +3954,15 @@ size_t Table::find_first(size_t col_ndx, util::Optional<double> value) const
 {
     return value ? find_first(col_ndx, *value) : find_first_null(col_ndx);
 }
+
+// Explicitly instantiate the generic case of the template for the types we care about.
+template size_t Table::find_first(size_t col_ndx, bool) const;
+template size_t Table::find_first(size_t col_ndx, int64_t) const;
+template size_t Table::find_first(size_t col_ndx, float) const;
+template size_t Table::find_first(size_t col_ndx, double) const;
+template size_t Table::find_first(size_t col_ndx, util::Optional<bool>) const;
+template size_t Table::find_first(size_t col_ndx, util::Optional<int64_t>) const;
+
 } // namespace realm
 
 size_t Table::find_first_link(size_t target_row_index) const


### PR DESCRIPTION
A number of overloads of `Table::find_first` were not making it into the prebuilt core release for Node. Adding explicit instantiations ensures they do.

This is needed for realm/realm-js#1023.