### PR TITLE
Use GetCurrentProcessId() on Win32 and fix compilation error.

### DIFF
--- a/src/realm/util/thread.cpp
+++ b/src/realm/util/thread.cpp
@@ -153,9 +153,7 @@ void Mutex::init_as_process_shared(bool robust_if_available)
         REALM_ASSERT_RELEASE("CreateMutexA() failed" && false);
 
     m_cached_handle = h;
-    m_cached_pid = _getpid();
-    m_cached_windows_pid = GetCurrentProcessId();
-
+    m_cached_pid = GetCurrentProcessId();
     return;
 #endif
 

--- a/src/realm/util/thread.hpp
+++ b/src/realm/util/thread.hpp
@@ -175,8 +175,7 @@ private:
     // We need to translate the name to a HANDLE in order to pass it to the Windows API. This translation is
     // expensive, so we cache the translation for each process (each process has its own HANDLE for the same mutex)
     HANDLE m_cached_handle;
-    int m_cached_pid;
-    DWORD m_cached_windows_pid;
+    DWORD m_cached_pid;
 #endif
 
     friend class CondVar;
@@ -477,7 +476,7 @@ inline Mutex::Mutex(process_shared_tag)
 inline Mutex::~Mutex() noexcept
 {
 #ifdef _WIN32
-    if (m_is_shared && m_cached_pid == _getpid()) {
+    if (m_is_shared && m_cached_pid == GetCurrentProcessId()) {
         CloseHandle(m_cached_handle);
     }
     else {
@@ -517,7 +516,7 @@ inline void Mutex::lock() noexcept
     else {
         DWORD d;
         HANDLE h;
-        int pid = _getpid();
+        DWORD pid = GetCurrentProcessId();
 
         if (m_cached_pid != pid)
             h = OpenMutexA(MUTEX_ALL_ACCESS, 1, m_shared_name);
@@ -553,7 +552,7 @@ inline bool Mutex::try_lock() noexcept
     else {
         DWORD d;
         HANDLE h;
-        int pid = _getpid();
+        DWORD pid = GetCurrentProcessId();
 
         if (m_cached_pid != pid)
             h = OpenMutexA(MUTEX_ALL_ACCESS, 1, m_shared_name);
@@ -595,7 +594,7 @@ inline void Mutex::unlock() noexcept
     else {
         BOOL d;
         HANDLE h;
-        int pid = _getpid();
+        DWORD pid = GetCurrentProcessId();
 
         if (m_cached_pid != pid)
             h = OpenMutexA(MUTEX_ALL_ACCESS, 1, m_shared_name);


### PR DESCRIPTION
Fix compilation error introduced in PR #2602.