### PR TITLE
Fix history schema version check when opening a Realm file

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,10 @@
 
 ### Bugfixes
 
-* Lorem ipsum.
+* Now rejecting a Realm file specifying a history schema version that is newer
+  than the one expected by the code.
+* No longer triggering a history schema upgrade when opening an empty Realm file
+  (when `top_ref` is zero).
 
 ### Breaking changes
 


### PR DESCRIPTION
Cherry-picked from #2637, targeting `master`.