### PR TITLE
Disable call to millisleep during file upgrade

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,7 +16,7 @@
 
 ### Internals
 
-* Lorem ipsum.
+* Disabled a sleep in debug mode that was impairing external tests.
 
 ----------------------------------------------
 

--- a/src/realm/group_shared.cpp
+++ b/src/realm/group_shared.cpp
@@ -1539,7 +1539,12 @@ void SharedGroup::upgrade_file_format(bool allow_file_format_upgrade,
 // a simple thread barrier that makes sure the threads meet here, to
 // increase the likelyhood of detecting any potential race problems.
 // See the unit test for details.
-        millisleep(200);
+//
+// NOTE: This sleep has been disabled because no problems have been found with
+// this code in a long while, and it was dramatically slowing down a unit test
+// in realm-sync.
+
+        // millisleep(200);
 #endif
 
         WriteTransaction wt(*this);


### PR DESCRIPTION
This sleep was causing unit tests in `realm-sync` to take very long to finish due to recent changes.

The sleep existed to exercise a particular critical section in the code, but there have been no bugs in this code for a long while.