### PR TITLE
Fix Group::commit() for Realm file with history

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,7 +16,9 @@
 
 ### Internals
 
-* Lorem ipsum.
+* Fix an assert that prevented Group::commit() from discarding history from a
+  Realm file opened in nonshared mode (via `Group::open()`, as opposed to
+  `SharedGroup::open()`).
 
 ----------------------------------------------
 

--- a/src/realm/group.hpp
+++ b/src/realm/group.hpp
@@ -139,6 +139,15 @@ public:
     /// change the association between the Group instance and the file
     /// that was specified in the call to open().
     ///
+    /// A Realm file that contains a history (see Replication::HistoryType) may
+    /// be opened via Group::open(), as long as the application can ensure that
+    /// there is no concurrent access to the file (see below for more on
+    /// concurrency), but if the file is modified via Group::commit() the
+    /// history will be discarded. To retain the history, the application must
+    /// instead access the file in shared mode, i.e., via SharedGroup, and
+    /// supply the right kind of replication plugin (see
+    /// Replication::get_history_type()).
+    ///
     /// A file that is passed to Group::open(), may not be modified by
     /// a third party until after the Group object is
     /// destroyed. Behavior is undefined if a file is modified by a

--- a/src/realm/group_shared.hpp
+++ b/src/realm/group_shared.hpp
@@ -54,10 +54,15 @@ struct IncompatibleLockFile : std::runtime_error {
     }
 };
 
-/// Thrown by SharedGroup::open() if the realm database was generated with a
-/// format for Realm Mobile Platform but is being opened as a Realm Mobile
-/// Database or vice versa, or of the history schema in the Realm file could not
-/// be upgraded to the needed version.
+/// Thrown by SharedGroup::open() if the type of history
+/// (Replication::HistoryType) in the opened Realm file is incompatible with the
+/// mode in which the Realm file is opened. For example, if there is a mismatch
+/// between the history type in the file, and the history type associated with
+/// the replication plugin passed to SharedGroup::open().
+///
+/// This exception will also be thrown if the history schema version is lower
+/// than required, and no migration is possible
+/// (Replication::is_upgradable_history_schema()).
 struct IncompatibleHistories : util::File::AccessError {
     IncompatibleHistories(const std::string& msg, const std::string& path)
         : util::File::AccessError("Incompatible histories. " + msg, path)

--- a/test/test_lang_bind_helper.cpp
+++ b/test/test_lang_bind_helper.cpp
@@ -13178,4 +13178,37 @@ TEST(LangBindHelper_MixedTimestampTransaction)
 }
 
 
+TEST(LangBindHelper_NonsharedAccessToRealmWithHistory)
+{
+    // Create a Realm file with a history (history_type !=
+    // Reaplication::hist_None).
+    SHARED_GROUP_TEST_PATH(path);
+    {
+        std::unique_ptr<Replication> history(make_in_realm_history(path));
+        SharedGroup sg{*history};
+        WriteTransaction wt{sg};
+        wt.add_table("foo");
+        wt.commit();
+    }
+
+    // Since the stored history type is now Replication::hist_InRealm, it should
+    // now be impossible to open in shared mode with no replication plugin
+    // (Replication::hist_None).
+    CHECK_THROW(SharedGroup{path}, IncompatibleHistories);
+
+    // Now modify the file in nonshared mode, which will discard the history (as
+    // nonshared mode does not understand how to update it correctly).
+    {
+        const char* crypt_key = nullptr;
+        Group group{path, crypt_key, Group::mode_ReadWriteNoCreate};
+        group.commit();
+    }
+
+    // Check the the history was actually discarded (reset to
+    // Replication::hist_None).
+    SharedGroup sg{path};
+    ReadTransaction rt{sg};
+    CHECK(rt.has_table("foo"));
+}
+
 #endif


### PR DESCRIPTION
In this PR:
 - Fix an assert that prevented Group::commit() from discarding history from a Realm file opened in nonshared mode (via `Group::open()`, as opposed to via `SharedGroup::open()`).
 - Improve documentation relating to history check when opening a Realm file.
 - Add unit test `LangBindHelper_NonsharedAccessToRealmWithHistory`.

These changes were motivated by a need to use Group::open() for the purpose of sync server side migration.

@jedelbo @finnschiermer 