### PR TITLE
Revert "Version bump to 3.0.0-rc1"

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,24 +11,6 @@
 
 ### Breaking changes
 
-* Lorem ipsum.
-
-### Enhancements
-
-* Lorem ipsum.
-
------------
-
-### Internals
-
-* win32+UWP: Switched from pthread-win32 to native API PR [#2602](https://github.com/realm/realm-core/pull/2602)
-
-----------------------------------------------
-
-# 3.0.0-rc1 Release notes
-
-### Breaking changes
-
 * Support for size query on LinkedList removed. This is perhaps not so 
   breaking after all since it is probably not used.
 * Replication interface changed. The search index functions now operate
@@ -62,6 +44,7 @@
   the Visual C++ runtime libraries, removing the onus on end-users to have the correct runtime redistributable package
   or satellite assembly pack installed. Libraries that link against Core on Windows will have to adjust their compiler flags accordingly.
   PR [#2611](https://github.com/realm/realm-core/pull/2611)
+* win32+UWP: Switched from pthread-win32 to native API PR [#2602](https://github.com/realm/realm-core/pull/2602)
   
 ----------------------------------------------
 

--- a/dependencies.list
+++ b/dependencies.list
@@ -1,2 +1,2 @@
 PACKAGE_NAME=realm-core
-VERSION=3.0.0-rc1
+VERSION=2.8.1

--- a/src/realm/version.hpp
+++ b/src/realm/version.hpp
@@ -24,10 +24,10 @@
 #include <realm/util/features.h>
 
 
-#define REALM_VER_MAJOR 3
-#define REALM_VER_MINOR 0
-#define REALM_VER_PATCH 0
-#define REALM_VER_EXTRA "rc1"
+#define REALM_VER_MAJOR 2
+#define REALM_VER_MINOR 8
+#define REALM_VER_PATCH 1
+#define REALM_VER_EXTRA ""
 #define REALM_PRODUCT_NAME "realm-core"
 
 #define REALM_VER_STRING                                                                                             \

--- a/test/test_version.cpp
+++ b/test/test_version.cpp
@@ -70,8 +70,7 @@ TEST(Version_General)
     CHECK_EQUAL(true, Version::is_at_least(0, 1, 9));
     CHECK_EQUAL(true, Version::is_at_least(1, 0, 0));
     CHECK_EQUAL(true, Version::is_at_least(2, 0, 0));
-    CHECK_EQUAL(true, Version::is_at_least(3, 0, 0));
-    CHECK_EQUAL(false, Version::is_at_least(4, 0, 0));
+    CHECK_EQUAL(false, Version::is_at_least(3, 0, 0));
     CHECK_EQUAL(false, Version::is_at_least(REALM_VER_MAJOR, 99, 0));
     CHECK_EQUAL(false, Version::is_at_least(REALM_VER_MAJOR, REALM_VER_MINOR, 99));
 }


### PR DESCRIPTION
This reverts commit 5171bdb7f24b47a0d161f3500ba97f8671b05364.

Trying to get back to smooth automated merges.