### PR TITLE
Improve ASAN and TSAN build modes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,7 +16,11 @@
 
 ### Internals
 
-* Lorem ipsum.
+* Improve ASAN and TSAN build modes (`sh build.sh asan` and `sh build.sh tsan`)
+  such that they do not clobber the files produced during regular builds, and
+  also do not clobber each others files. Also `UNITTEST_THREADS` and
+  `UNITTEST_PROGRESS` options are no longer hard-coded in ASAN and TSAN build
+  modes.
 
 ----------------------------------------------
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,7 @@
   also do not clobber each others files. Also `UNITTEST_THREADS` and
   `UNITTEST_PROGRESS` options are no longer hard-coded in ASAN and TSAN build
   modes.
+  PR [#2660](https://github.com/realm/realm-core/pull/2660).
 
 ----------------------------------------------
 

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -186,6 +186,10 @@ def doBuildInDocker(String command) {
 
       def buildEnv = buildDockerEnv('ci/realm-core:snapshot')
       def environment = environment()
+      if (command.contains('sanitizer')) {
+          environment << 'UNITTEST_THREADS=1'
+          environment << 'UNITTEST_PROGRESS=1'
+      }
       withEnv(environment) {
         buildEnv.inside {
           sh 'sh build.sh config'

--- a/build.sh
+++ b/build.sh
@@ -1130,17 +1130,9 @@ EOF
         # To get symbolized stack traces (file names and line numbers) with GCC, you at least version 4.9.
         check_mode="$(printf "%s\n" "$MODE" | sed 's/asan/check/')" || exit 1
         auto_configure || exit 1
-        touch "$CONFIG_MK" || exit 1 # Force complete rebuild
         export ASAN_OPTIONS="detect_odr_violation=2"
         export REALM_HAVE_CONFIG="1"
-        error=""
-        if ! UNITTEST_THREADS="1" UNITTEST_PROGRESS="1" $MAKE EXTRA_CFLAGS="-fsanitize=address" EXTRA_LDFLAGS="-fsanitize=address" "$check_mode"; then
-            error="1"
-        fi
-        touch "$CONFIG_MK" || exit 1 # Force complete rebuild
-        if [ "$error" ]; then
-            exit 1
-        fi
+        $MAKE BASE_DENOM="asan" EXTRA_CFLAGS="-fsanitize=address" EXTRA_LDFLAGS="-fsanitize=address" "$check_mode" || exit 1
         echo "Test passed"
         exit 0
         ;;
@@ -1150,16 +1142,8 @@ EOF
         # To get symbolized stack traces (file names and line numbers) with GCC, you at least version 4.9.
         check_mode="$(printf "%s\n" "$MODE" | sed 's/tsan/check/')" || exit 1
         auto_configure || exit 1
-        touch "$CONFIG_MK" || exit 1 # Force complete rebuild
         export REALM_HAVE_CONFIG="1"
-        error=""
-        if ! UNITTEST_THREADS="1" UNITTEST_PROGRESS="1" $MAKE EXTRA_CFLAGS="-fsanitize=thread" EXTRA_LDFLAGS="-fsanitize=thread" "$check_mode"; then
-            error="1"
-        fi
-        touch "$CONFIG_MK" || exit 1 # Force complete rebuild
-        if [ "$error" ]; then
-            exit 1
-        fi
+        $MAKE BASE_DENOM="tsan" EXTRA_CFLAGS="-fsanitize=thread" EXTRA_LDFLAGS="-fsanitize=thread" "$check_mode" || exit 1
         echo "Test passed"
         exit 0
         ;;

--- a/src/realm/.gitignore
+++ b/src/realm/.gitignore
@@ -14,6 +14,22 @@
 /impl/*.gcno
 /impl/*.gcda
 
+# ASAN
+/*-asan
+/*-asan-noinst
+/*-asan-dbg
+/*-asan-dbg-noinst
+/*-asan-cov
+/*-asan-cov-noinst
+
+# TSAN
+/*-tsan
+/*-tsan-noinst
+/*-tsan-dbg
+/*-tsan-dbg-noinst
+/*-tsan-cov
+/*-tsan-cov-noinst
+
 /librealm*.a
 /librealm*.so
 /librealm*.so.*

--- a/test/.gitignore
+++ b/test/.gitignore
@@ -9,6 +9,22 @@
 /large_tests/*.gcno
 /large_tests/*.gcda
 
+# ASAN
+/*-asan
+/*-asan-noinst
+/*-asan-dbg
+/*-asan-dbg-noinst
+/*-asan-cov
+/*-asan-cov-noinst
+
+# TSAN
+/*-tsan
+/*-tsan-noinst
+/*-tsan-dbg
+/*-tsan-dbg-noinst
+/*-tsan-cov
+/*-tsan-cov-noinst
+
 /realm-tests
 /realm-tests-dbg
 /realm-tests-cov

--- a/test/util/.gitignore
+++ b/test/util/.gitignore
@@ -6,6 +6,4 @@
 /*.gcno
 /*.gcda
 
-/test-util.a
-/test-util-dbg.a
-/test-util-cov.a
+/test-util*.a


### PR DESCRIPTION
Improve ASAN and TSAN build modes (`sh build.sh asan` and `sh build.sh tsan`) such that they do not clobber the files produced during regular builds, and also do not clobber each others files. Also `UNITTEST_THREADS` and `UNITTEST_PROGRESS` options are no longer hard-coded in ASAN and TSAN build modes.

Following recent similar change in sync repo: https://github.com/realm/realm-sync/pull/1405

@finnschiermer  @simonask @emanuelez 