### PR TITLE
Ignore files produced by GNU Global.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,9 @@
 *~
 cscope.*
 tags
+GPATH
+GRTAGS
+GTAGS
 
 /cover_html
 /gcovr.xml


### PR DESCRIPTION
I have switched to GNU Global, and I would like to see a cleaner `git status`. If you're an Emacs user, pop by my desk for a demo ;-)