### PR TITLE
Add method to get total backlink count for a row

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,6 +40,7 @@
 * Add more overloads with realm::null - PR [#2669](https://github.com/realm/realm-core/pull/2669)
   - `size_t Table::find_first(size_t col_ndx, null)`
   - `OutputStream& operator<<(OutputStream& os, const null&)`
+* Add method to get total count of backlinks for a row
 
 -----------
 

--- a/src/realm/row.hpp
+++ b/src/realm/row.hpp
@@ -129,6 +129,7 @@ public:
     void move_last_over();
     //@}
 
+    size_t get_backlink_count() const noexcept;
     size_t get_backlink_count(const Table& src_table, size_t src_col_ndx) const noexcept;
     size_t get_backlink(const Table& src_table, size_t src_col_ndx, size_t backlink_ndx) const noexcept;
 
@@ -643,6 +644,12 @@ template <class T, class R>
 inline void RowFuncs<T, R>::move_last_over()
 {
     table()->move_last_over(row_ndx()); // Throws
+}
+
+template <class T, class R>
+inline size_t RowFuncs<T, R>::get_backlink_count() const noexcept
+{
+    return table()->get_backlink_count(row_ndx());
 }
 
 template <class T, class R>

--- a/src/realm/spec.hpp
+++ b/src/realm/spec.hpp
@@ -86,7 +86,11 @@ public:
     // Links
     size_t get_opposite_link_table_ndx(size_t column_ndx) const noexcept;
     void set_opposite_link_table_ndx(size_t column_ndx, size_t table_ndx);
+
+    // Backlinks
     bool has_backlinks() const noexcept;
+    size_t first_backlink_column_index() const noexcept;
+    size_t backlink_column_count() const noexcept;
     void set_backlink_origin_column(size_t backlink_col_ndx, size_t origin_col_ndx);
     size_t get_origin_column_ndx(size_t backlink_col_ndx) const noexcept;
     size_t find_backlink_column(size_t origin_table_ndx, size_t origin_col_ndx) const noexcept;
@@ -357,6 +361,16 @@ inline bool Spec::has_backlinks() const noexcept
     // Fixme: It's bad design that backlinks are stored and recognized like this. Backlink columns
     // should be a column type like any other, and we should find another way to hide them away from
     // the user.
+}
+
+inline size_t Spec::first_backlink_column_index() const noexcept
+{
+    return m_names.size();
+}
+
+inline size_t Spec::backlink_column_count() const noexcept
+{
+    return m_types.size() - m_names.size();
 }
 
 // Spec will have a subspec when it contains a column which is one of:

--- a/src/realm/table.cpp
+++ b/src/realm/table.cpp
@@ -294,8 +294,8 @@ void Table::insert_column_link(size_t col_ndx, DataType type, StringData name, T
 
 size_t Table::get_backlink_count(size_t row_ndx) const noexcept
 {
-    size_t first_backlink_column = m_spec.first_backlink_column_index();
-    size_t last_backlink_column = first_backlink_column + m_spec.backlink_column_count();
+    size_t first_backlink_column = m_spec->first_backlink_column_index();
+    size_t last_backlink_column = first_backlink_column + m_spec->backlink_column_count();
     size_t ref_count = 0;
 
     for (size_t i = first_backlink_column; i != last_backlink_column; ++i) {

--- a/src/realm/table.cpp
+++ b/src/realm/table.cpp
@@ -292,6 +292,20 @@ void Table::insert_column_link(size_t col_ndx, DataType type, StringData name, T
 }
 
 
+size_t Table::get_backlink_count(size_t row_ndx) const noexcept
+{
+    size_t first_backlink_column = m_spec.first_backlink_column_index();
+    size_t last_backlink_column = first_backlink_column + m_spec.backlink_column_count();
+    size_t ref_count = 0;
+
+    for (size_t i = first_backlink_column; i != last_backlink_column; ++i) {
+        const BacklinkColumn& backlink_col = get_column_backlink(i);
+        ref_count += backlink_col.get_backlink_count(row_ndx);
+    }
+
+    return ref_count;
+}
+
 size_t Table::get_backlink_count(size_t row_ndx, const Table& origin, size_t origin_col_ndx) const noexcept
 {
     size_t origin_table_ndx = origin.get_index_in_group();

--- a/src/realm/table.cpp
+++ b/src/realm/table.cpp
@@ -294,11 +294,11 @@ void Table::insert_column_link(size_t col_ndx, DataType type, StringData name, T
 
 size_t Table::get_backlink_count(size_t row_ndx) const noexcept
 {
-    size_t first_backlink_column = m_spec->first_backlink_column_index();
-    size_t last_backlink_column = first_backlink_column + m_spec->backlink_column_count();
+    size_t backlink_columns_begin = m_spec->first_backlink_column_index();
+    size_t backlink_columns_end = backlink_columns_begin + m_spec->backlink_column_count();
     size_t ref_count = 0;
 
-    for (size_t i = first_backlink_column; i != last_backlink_column; ++i) {
+    for (size_t i = backlink_columns_begin; i != backlink_columns_end; ++i) {
         const BacklinkColumn& backlink_col = get_column_backlink(i);
         ref_count += backlink_col.get_backlink_count(row_ndx);
     }

--- a/src/realm/table.hpp
+++ b/src/realm/table.hpp
@@ -550,6 +550,7 @@ public:
     void clear_subtable(size_t column_ndx, size_t row_ndx);
 
     // Backlinks
+    size_t get_backlink_count(size_t row_ndx) const noexcept;
     size_t get_backlink_count(size_t row_ndx, const Table& origin, size_t origin_col_ndx) const noexcept;
     size_t get_backlink(size_t row_ndx, const Table& origin, size_t origin_col_ndx, size_t backlink_ndx) const
         noexcept;

--- a/test/test_table.cpp
+++ b/test/test_table.cpp
@@ -6230,6 +6230,10 @@ TEST(Table_RowAccessorLinks)
     CHECK(source_row_2.linklist_is_empty(1));
     CHECK_EQUAL(0, source_row_1.get_link_count(1));
     CHECK_EQUAL(0, source_row_2.get_link_count(1));
+    CHECK_EQUAL(0, target_table->get(7).get_backlink_count());
+    CHECK_EQUAL(0, target_table->get(13).get_backlink_count());
+    CHECK_EQUAL(0, target_table->get(11).get_backlink_count());
+    CHECK_EQUAL(0, target_table->get(15).get_backlink_count());
     CHECK_EQUAL(0, target_table->get(7).get_backlink_count(*origin_table, 0));
     CHECK_EQUAL(0, target_table->get(13).get_backlink_count(*origin_table, 0));
     CHECK_EQUAL(0, target_table->get(11).get_backlink_count(*origin_table, 1));
@@ -6265,12 +6269,18 @@ TEST(Table_RowAccessorLinks)
     CHECK(!source_row_2.linklist_is_empty(1));
     CHECK_EQUAL(1, source_row_1.get_link_count(1));
     CHECK_EQUAL(2, source_row_2.get_link_count(1));
+    CHECK_EQUAL(1, target_table->get(11).get_backlink_count());
+    CHECK_EQUAL(2, target_table->get(15).get_backlink_count());
     CHECK_EQUAL(1, target_table->get(11).get_backlink_count(*origin_table, 1));
     CHECK_EQUAL(2, target_table->get(15).get_backlink_count(*origin_table, 1));
     CHECK_EQUAL(1, target_table->get(11).get_backlink(*origin_table, 1, 0));
     size_t back_link_1 = target_table->get(15).get_backlink(*origin_table, 1, 0);
     size_t back_link_2 = target_table->get(15).get_backlink(*origin_table, 1, 1);
     CHECK((back_link_1 == 0 && back_link_2 == 1) || (back_link_1 == 1 && back_link_2 == 0));
+
+    // Links from multiple columns (count total)
+    source_row_1.set_link(0, 15);
+    CHECK_EQUAL(3, target_table->get(15).get_backlink_count());
 
     // Clear link lists
     link_list_1->clear();


### PR DESCRIPTION
Needed by users who wants to implement their own delete logic (like only delete the object if there are no other objects linking to it).