### PR TITLE
Lr/aliasing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,7 +16,9 @@
 
 ### Internals
 
-* Lorem ipsum.
+* Disabled strict aliasing due to warning from gcc 7.x (see
+  https://github.com/realm/realm-core/issues/2665). We have so far been unable
+  to determine if it's a bug in gcc or in Core.
 
 ----------------------------------------------
 

--- a/src/project.mk
+++ b/src/project.mk
@@ -10,7 +10,7 @@ endif
 
 CFLAGS_DEBUG += -fno-elide-constructors
 CFLAGS_PTHREADS += -pthread
-CFLAGS_GENERAL += -Wextra -pedantic -Wundef -Wshadow
+CFLAGS_GENERAL += -Wextra -pedantic -Wundef -Wshadow -fno-strict-aliasing
 CFLAGS_CXX = -std=c++14
 
 # Avoid a warning from Clang when linking on OS X. By default,


### PR DESCRIPTION
Disabled strict aliasing due to warning from gcc 7.x (see https://github.com/realm/realm-core/issues/2665). We have so far been unable to determine if it's a bug in gcc or in Core (see discussion in above issue)

Aliasing bugs are extremely time consuming to debug - they give random assertions, crashes, etc, but only on some permutations of compiler + architecture + arbitrary randomness.

This PR decreases performance only slightly: From ~18.30s to 18.70s for release mode unit tests in 1 thread (ran them 3 times each and variation is actually small, less than  0.10s)