### PR TITLE
Add _impl::GroupFriend::get_top_ref()

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,7 +16,7 @@
 
 ### Internals
 
-* Lorem ipsum.
+* `_impl::GroupFriend::get_top_ref()` was added.
 
 ----------------------------------------------
 

--- a/src/realm/group.hpp
+++ b/src/realm/group.hpp
@@ -1087,6 +1087,16 @@ public:
         return group.m_alloc;
     }
 
+    static const Allocator& get_alloc(const Group& group) noexcept
+    {
+        return group.m_alloc;
+    }
+
+    static ref_type get_top_ref(const Group& group) noexcept
+    {
+        return group.m_top.get_ref();
+    }
+
     static Table& get_table(Group& group, size_t ndx_in_group)
     {
         Group::DescMatcher desc_matcher = 0;                           // Do not check descriptor
@@ -1192,12 +1202,12 @@ public:
             group.create_empty_group(); // Throws
     }
 
-    static void get_version_and_history_info(Allocator& alloc, ref_type top_ref,
+    static void get_version_and_history_info(const Allocator& alloc, ref_type top_ref,
                                              _impl::History::version_type& version,
                                              int& history_type,
                                              int& history_schema_version) noexcept
     {
-        Array top(alloc);
+        Array top{const_cast<Allocator&>(alloc)};
         if (top_ref != 0)
             top.init_from_ref(top_ref);
         Group::get_version_and_history_info(top, version, history_type, history_schema_version);


### PR DESCRIPTION
In this PR:
 - `_impl::GroupFriend::get_top_ref()` was added.
 - `const Group&` overload of `_impl::GroupFriend::get_alloc()` was added.
 - Type of allocator argument changed from `Allocator&` to `const Allocator&` in `_impl::GroupFriend::get_version_and_history_info()`.

Motivation: For the purpose of migration, I needed to be able to fetch the history type and history schema version for a server-side Realm file opened via `Group::open()` in read-only mode. To this end, I needed to be able to call `_impl::GroupFriend::get_version_and_history_info()`, which takes allocator and `top_ref` arguments.

@jedelbo @finnschiermer 