### PR TITLE
Chained sort behaviour fix

### DIFF
--- a/src/realm/views.cpp
+++ b/src/realm/views.cpp
@@ -86,12 +86,12 @@ std::unique_ptr<CommonDescriptor> SortDescriptor::clone() const
 
 void SortDescriptor::merge_with(SortDescriptor&& other)
 {
-    m_columns.insert(m_columns.end(),
+    m_columns.insert(m_columns.begin(),
                      std::make_move_iterator(other.m_columns.begin()),
                      std::make_move_iterator(other.m_columns.end()));
     // Do not use a move iterator on a vector of bools!
     // It will form a reference to a temporary and return incorrect results.
-    m_ascending.insert(m_ascending.end(),
+    m_ascending.insert(m_ascending.begin(),
                        other.m_ascending.begin(),
                        other.m_ascending.end());
 }

--- a/test/test_query.cpp
+++ b/test/test_query.cpp
@@ -4542,8 +4542,9 @@ TEST(Query_CompoundDescriptors) {
     // 4 | 2        "A"     |
     // 5 | 2        "A"     |
 
-    {   // sorting twice should be the same as a single sort with both criteria
-        ResultList results = {{2, 3}, {2, 4}, {2, 5}, {1, 2}, {1, 0}, {1, 1}};
+    {   // sorting twice should the same as a single sort with both criteria
+        // but reversed: sort(a).sort(b) == sort(b, a)
+        ResultList results = {{2, 3}, {1, 2}, {2, 4}, {2, 5}, {1, 0}, {1, 1}};
         TableView tv = t1->where().find_all();
         tv.sort(SortDescriptor(*t1, {{t1_int_col}}, {false}));
         tv.sort(SortDescriptor(*t1, {{t1_str_col}}, {false}));
@@ -4556,7 +4557,7 @@ TEST(Query_CompoundDescriptors) {
         check_across_handover(results, std::move(hp));
 
         tv = t1->where().find_all();
-        tv.sort(SortDescriptor(*t1, {{t1_int_col}, {t1_str_col}}, {false, false}));
+        tv.sort(SortDescriptor(*t1, {{t1_str_col}, {t1_int_col}}, {false, false}));
         CHECK_EQUAL(tv.size(), results.size());
         for (size_t i = 0; i < tv.size(); ++i) {
             CHECK_EQUAL(tv.get_int(0, i), results[i].first);


### PR DESCRIPTION
Thanks to @bdash for pointing out that the behaviour of chained sorts was incorrect.

This fixes `sort(a).sort(b)`  to be equivalent to `sort(b, a)` instead of incorrectly being `sort(a, b)`
(Previous releases of core would consider `sort(a).sort(b)` to just be `sort(b)`.)

The use case is that user queries should respect the last sort operation to be the most important.

I didn't add a note to the changelog since this feature hasn't been released yet.