### PR TITLE
Remove the merge_rows instruction from fuzz testing

### DIFF
--- a/test/fuzz_group.cpp
+++ b/test/fuzz_group.cpp
@@ -72,7 +72,6 @@ enum INS {
     REMOVE_COLUMN,
     SET,
     REMOVE_ROW,
-    MERGE_ROWS,
     ADD_COLUMN_LINK,
     ADD_COLUMN_LINK_LIST,
     CLEAR_TABLE,
@@ -736,34 +735,6 @@ void parse_and_apply_instructions(std::string& in, const std::string& path, util
                         *log << "g.get_table(" << table_ndx << ")->remove(" << row_ndx << ");\n";
                     }
                     t->remove(row_ndx);
-                }
-            }
-            else if (instr == MERGE_ROWS && g.size() > 0) {
-                size_t table_ndx = get_next(s) % g.size();
-                TableRef t = g.get_table(table_ndx);
-                if (t->size() > 1) {
-                    size_t row_ndx1 = get_next(s) % t->size();
-                    size_t row_ndx2 = get_next(s) % t->size();
-                    if (row_ndx1 == row_ndx2) {
-                        row_ndx2 = (row_ndx2 + 1) % t->size();
-                    }
-                    // A restriction of merge_rows is that any linklists in the
-                    // "to" row must be empty because merging lists is not defined.
-                    for (size_t col_ndx = 0; col_ndx != t->get_column_count(); ++col_ndx) {
-                        if (t->get_column_type(col_ndx) == DataType::type_LinkList) {
-                            if (!t->get_linklist(col_ndx, row_ndx2)->is_empty()) {
-                                if (log) {
-                                    *log << "g.get_table(" << table_ndx << ")->get_linklist("
-                                    << col_ndx << ", " << row_ndx2 << ")->clear();\n";
-                                }
-                                t->get_linklist(col_ndx, row_ndx2)->clear();
-                            }
-                        }
-                    }
-                    if (log) {
-                        *log << "g.get_table(" << table_ndx << ")->merge_rows(" << row_ndx1 << ", " << row_ndx2 << ");\n";
-                    }
-                    t->merge_rows(row_ndx1, row_ndx2);
                 }
             }
             else if (instr == MOVE_LAST_OVER && g.size() > 0) {


### PR DESCRIPTION
As discussed, it is currently not supported to roll back a `merge_rows` instruction. This operation is only used by sync and will be deprecated soon. We shouldn't fuzz it because we can generate "impossible" transactions that will be false positive crashes.