### PR TITLE
Some improvements to build-cocoa.sh

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,7 +16,9 @@
 
 ### Internals
 
-* Lorem ipsum.
+* The archives produced by the packaging process for Mac builds are now
+  .tar.gz files rather than .tar.xz files, with the exception of the aggregate
+  realm-core-cocoa-VERSION.tar.xz archive, which remains as a .tar.xz file.
 
 ----------------------------------------------
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -140,7 +140,7 @@ endif()
 install(FILES LICENSE CHANGELOG.md DESTINATION . COMPONENT devel)
 
 if(APPLE)
-    set(CPACK_GENERATOR "TXZ")
+    set(CPACK_GENERATOR "TGZ")
 elseif(ANDROID)
     set(CPACK_GENERATOR "TGZ")
 else()

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -391,10 +391,10 @@ def doBuildMacOs(String buildType) {
                             """)
                 }
             }
-            archiveArtifacts("build-macos-${buildType}/*.tar.xz")
+            archiveArtifacts("build-macos-${buildType}/*.tar.gz")
 
             def stashName = "macos___${buildType}"
-            stash includes:"build-macos-${buildType}/*.tar.xz", name:stashName
+            stash includes:"build-macos-${buildType}/*.tar.gz", name:stashName
             cocoaStashes << stashName
             publishingStashes << stashName
         }
@@ -416,9 +416,9 @@ def doBuildAppleDevice(String sdk, String buildType) {
                     }
                 }
             }
-            archiveArtifacts("build-${sdk}-${buildType}/*.tar.xz")
+            archiveArtifacts("build-${sdk}-${buildType}/*.tar.gz")
             def stashName = "${sdk}___${buildType}"
-            stash includes:"build-${sdk}-${buildType}/*.tar.xz", name:stashName
+            stash includes:"build-${sdk}-${buildType}/*.tar.gz", name:stashName
             cocoaStashes << stashName
             if(gitTag) {
                 publishingStashes << stashName

--- a/tools/build-cocoa.sh
+++ b/tools/build-cocoa.sh
@@ -71,8 +71,8 @@ for bt in "${BUILD_TYPES[@]}"; do
     done
 done
 
-ln -s core/librealm-macosx.a core/librealm.a
-ln -s core/librealm-macosx-dbg.a core/librealm-dbg.a
+ln -s librealm-macosx.a core/librealm.a
+ln -s librealm-macosx-dbg.a core/librealm-dbg.a
 
 if [[ ! -z $COPY ]]; then
     rm -rf "${DESTINATION}/core"

--- a/tools/build-cocoa.sh
+++ b/tools/build-cocoa.sh
@@ -39,6 +39,7 @@ if [[ ! -z $BUILD ]]; then
             mkdir -p "${folder_name}"
             (
                 cd "${folder_name}" || exit 1
+                rm -f realm-core-*-devel.tar.gz
                 cmake -D CMAKE_TOOLCHAIN_FILE="../tools/cmake/${p}.toolchain.cmake" \
                       -D CMAKE_BUILD_TYPE="${prefix}${bt}" \
                       -D REALM_VERSION="$(git describe)" \

--- a/tools/build-cocoa.sh
+++ b/tools/build-cocoa.sh
@@ -11,7 +11,7 @@ function usage {
     echo "Arguments:"
     echo "   -b : build from source. If absent it will expect prebuilt packages"
     echo "   -m : build for macOS only"
-    echo "   -c : copy core to the specified folder"
+    echo "   -c : copy core to the specified folder instead of packaging it"
     exit 1;
 }
 
@@ -78,8 +78,8 @@ if [[ ! -z $COPY ]]; then
     rm -rf "${DESTINATION}/core"
     mkdir -p "${DESTINATION}"
     cp -R core "${DESTINATION}"
+else
+    v=$(git describe --tags)
+    rm -f "realm-core-cocoa-${v}.tar.xz"
+    tar -cJvf "realm-core-cocoa-${v}.tar.xz" core
 fi
-
-v=$(git describe --tags)
-rm -f "realm-core-cocoa-${v}.tar.xz"
-tar -cJvf "realm-core-cocoa-${v}.tar.xz" core

--- a/tools/build-cocoa.sh
+++ b/tools/build-cocoa.sh
@@ -43,6 +43,7 @@ if [[ ! -z $BUILD ]]; then
                       -D CMAKE_BUILD_TYPE="${prefix}${bt}" \
                       -D REALM_VERSION="$(git describe)" \
                       -D REALM_SKIP_SHARED_LIB=ON \
+                      -D REALM_BUILD_LIB_ONLY=ON \
                       -G Xcode ..
                 cmake --build . --config "${prefix}${bt}" --target package
             )

--- a/tools/build-cocoa.sh
+++ b/tools/build-cocoa.sh
@@ -42,6 +42,7 @@ if [[ ! -z $BUILD ]]; then
                 cmake -D CMAKE_TOOLCHAIN_FILE="../tools/cmake/${p}.toolchain.cmake" \
                       -D CMAKE_BUILD_TYPE="${prefix}${bt}" \
                       -D REALM_VERSION="$(git describe)" \
+                      -D REALM_SKIP_SHARED_LIB=ON \
                       -G Xcode ..
                 cmake --build . --config "${prefix}${bt}" --target package
             )

--- a/tools/build-cocoa.sh
+++ b/tools/build-cocoa.sh
@@ -76,6 +76,7 @@ ln -s core/librealm-macosx-dbg.a core/librealm-dbg.a
 
 if [[ ! -z $COPY ]]; then
     rm -rf "${DESTINATION}/core"
+    mkdir -p "${DESTINATION}"
     cp -R core "${DESTINATION}"
 fi
 

--- a/tools/build-cocoa.sh
+++ b/tools/build-cocoa.sh
@@ -53,19 +53,19 @@ fi
 rm -rf core
 mkdir core
 
-filename=$(find "build-macos-Release" -maxdepth 1 -type f -name "realm-core-Release-*-Darwin-devel.tar.xz")
-tar -C core -Jxvf "${filename}" include LICENSE CHANGELOG.md
+filename=$(find "build-macos-Release" -maxdepth 1 -type f -name "realm-core-Release-*-Darwin-devel.tar.gz")
+tar -C core -zxvf "${filename}" include LICENSE CHANGELOG.md
 
 for bt in "${BUILD_TYPES[@]}"; do
     [[ "$bt" = "Release" ]] && suffix="" || suffix="-dbg"
     for p in "${PLATFORMS[@]}"; do
         [[ $p = "macos" ]] && infix="macosx" || infix="${p}"
         [[ $p != "macos" && $bt = "Debug" ]] && prefix="MinSize" || prefix=""
-        filename=$(find "build-${p}-${prefix}${bt}" -maxdepth 1 -type f -name "realm-core-*-devel.tar.xz")
+        filename=$(find "build-${p}-${prefix}${bt}" -maxdepth 1 -type f -name "realm-core-*-devel.tar.gz")
         if [[ -z $filename ]]; then
-            filename=$(find "build-${p}-${prefix}${bt}" -maxdepth 1 -type f -name "realm-core-*.tar.xz")
+            filename=$(find "build-${p}-${prefix}${bt}" -maxdepth 1 -type f -name "realm-core-*.tar.gz")
         fi
-        tar -C core -Jxvf "${filename}" "lib/librealm${suffix}.a"
+        tar -C core -zxvf "${filename}" "lib/librealm${suffix}.a"
         mv "core/lib/librealm${suffix}.a" "core/librealm-${infix}${suffix}.a"
         rm -rf core/lib
     done

--- a/tools/cross_compile.sh
+++ b/tools/cross_compile.sh
@@ -116,6 +116,6 @@ else
     mkdir -p install/lib
     cp "src/realm/${BUILD_TYPE}/librealm${suffix}.a" install/lib
     cd install || exit 1
-    tar -cvJf "realm-core-${BUILD_TYPE}-${VERSION}-${SDK}os.tar.xz" lib include
-    mv ./*.tar.xz ..
+    tar -cvzf "realm-core-${BUILD_TYPE}-${VERSION}-${SDK}os.tar.gz" lib include
+    mv ./*.tar.gz ..
 fi


### PR DESCRIPTION
* Don't build shared libraries.
* Ensure that the files are copied into the expected location.
* Use .tar.gz for the intermediate archives, as they're much faster to work with.
* Have `-c` skip creating the .tar.xz archive, since it's typically not needed when `-c` is used.

I'm not 100% sure that build-cocoa.sh is the only thing that cares about the value of `CPACK_GENERATOR`. If it isn't, we'll need to take a different approach.

These changes reduce the time taken for `./tools/build-cocoa.sh -m -b -c /tmp/path` when no source changes have been made from ~75 seconds to ~10 seconds.