### PR TITLE
Use strict warnings when using clang

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -60,7 +60,7 @@ else()
     # TODO: Remove this when fixed
     if(ANDROID)
         set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wno-maybe-uninitialized -Wno-uninitialized")
-    elseif("${CMAKE_CXX_COMPILER_ID}" STREQUAL "Clang")
+    elseif(${CMAKE_CXX_COMPILER_ID} MATCHES ".*[Cc]lang")
         set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wunreachable-code -Wshorten-64-to-32 -Wold-style-cast -Wconditional-uninitialized -Wextra-semi -Wno-nested-anon-types")
     endif()
 endif()

--- a/src/realm/table.cpp
+++ b/src/realm/table.cpp
@@ -4859,7 +4859,7 @@ inline void out_olddatetime(std::ostream& out, OldDateTime value)
 inline void out_timestamp(std::ostream& out, Timestamp value)
 {
     // FIXME: Do we want to output the full precision to json?
-    time_t rawtime = value.get_seconds();
+    time_t rawtime = time_t(value.get_seconds());
     struct tm* t = gmtime(&rawtime);
     if (t) {
         // We need a buffer for formatting dates (and binary to hex). Max


### PR DESCRIPTION
The CMake regex for checking if we are compiling with clang was too strict and not adding compilation flags when it should have. Adding the flags produced a warning when compiling for watchOS which is fixed here as well.

This is cherry-picked from #2700 to separate ideas.