### PR TITLE
Add single stats to performance reports

### DIFF
--- a/test/bench/benchmark_version
+++ b/test/bench/benchmark_version
@@ -1,4 +1,4 @@
-v7
+v8
 
 The first line of this file describes the current benchmarking tool version.
 It is used as a folder prefix to handle storing multiple versions of performance results.

--- a/test/bench/gen_bench_hist.sh
+++ b/test/bench/gen_bench_hist.sh
@@ -70,11 +70,11 @@ fi
 echo "HEAD"
 sh gen_bench.sh HEAD
 
-# remove csv files not generated in this run, namely other
-# HEAD versions. This means we only keep files noted in
+# remove csv and stats files not generated in this run, namely
+# other HEAD versions. This means we only keep files noted in
 # revs_to_benchmark. The git sha of HEAD is different per run.
 results_dir=$(head -n 1 recent_results.txt)
-for file in ${results_dir}/*.csv; do
+for file in ${results_dir}/*.csv ${results_dir}/*.stats; do
   grep -q -F "${file}" recent_results.txt || (rm "${file}" && echo "removed old result: ${file}")
 done
 

--- a/test/bench/report_generator.py
+++ b/test/bench/report_generator.py
@@ -12,6 +12,7 @@ from matplotlib.ticker import Formatter, MultipleLocator
 import numpy as np
 from os.path import basename, splitext
 
+
 class TagFormatter(Formatter):
     def __init__(self, tags):
         self.tags = tags
@@ -22,6 +23,7 @@ class TagFormatter(Formatter):
         if ind >= len(self.tags) or ind < 0:
             return ''
         return str(self.tags[ind])
+
 
 def writeReport(outputDirectory, summary, stats):
     html = """
@@ -40,31 +42,51 @@ def writeReport(outputDirectory, summary, stats):
             <title>Realm Core Performance</title>
             <div style="width:100%; text-align:center">
             <h1>Realm Core Performance</h1>
-            <p>These graphs show the relative performance of certain operations between versions. The purpose of this report is to allow reviewers to see if there have been any unintentional performace regressions in the code being reviewed. It would be meaningless and misleading to use the numbers shown here to compare to other databases.</p>
+            <p>These graphs show the relative performance of certain operations
+               between versions. The purpose of this report is to allow
+               reviewers to see if there have been any unintentional performace
+               regressions in the code being reviewed. It would be meaningless
+               and misleading to use the numbers shown here to compare to other
+               databases.
+             </p>
             <br> """
 
     # standard deviation summary graph
     summaryGraphName = makeSummaryGraph(outputDirectory, summary)
-    html += "<h1>Summary</h1><p>This summary graph shows the performance of each benchmark as compared to the mean of all other runs on previous versions. The red line indicates the threshold of 2 standard deviations from the mean. A benchmark is marked for further inspection if the PR under test takes longer than this threshold. The same line is shown on each of the individual graphs in the rest of this report.</p>"
-    html += "<img align=\"middle\" id=\"summary\" src=\"" + summaryGraphName + "\"/>"
+    html += ("<h1>Summary</h1>"
+             "<p>This summary graph shows the performance of each benchmark "
+             "as compared to the mean of all other runs on previous versions."
+             "The red line indicates the threshold of 2 standard deviations "
+             "from the mean. A benchmark is marked for further inspection if "
+             "the PR under test takes longer than this threshold. The same "
+             "line is shown on each of the individual graphs in the rest of "
+             "this report.</p>")
+    html += "<img align=\"middle\" id=\"summary\" src=\""
+    html += summaryGraphName + "\"/>"
 
     # generate color coded link summary
     html += "<ol>"
     for title, values in summary.iteritems():
-        html += "<li><a class=\"" + values['status'] + "\" href=#" + title + ">" + title + "</a></li>"
+        html += "<li><a class=\"" + values['status'] + "\" "
+        html += "href=#" + title + ">" + title + "</a></li>"
     for title, values in stats.iteritems():
-        html += "<li><a class=\"stat\" href=#" + title.replace(' ', '_') + ">" + title + "</a></li>"
+        html += "<li><a class=\"stat\" href=#"
+        html += title.replace(' ', '_') + ">" + title + "</a></li>"
     html += "</ol><br>"
 
     # generate each graph section
     for title, values in summary.iteritems():
-        html += "<h1 class=\"" + values['status'] + "\" id=\"" + title +"\">" + title + "</h1>"
-        html += "<p>Threshold:  " + str(values['threshold']) + " (2 standard deviations)</p>"
-        html += "<p>Last Value: " + str(values['last_value']) + " (" + str(values['last_std']) + " standard deviations)</p>"
+        html += "<h1 class=\"" + values['status']
+        html += "\" id=\"" + title + "\">" + title + "</h1>"
+        html += "<p>Threshold:  "
+        html += str(values['threshold']) + " (2 standard deviations)</p>"
+        html += "<p>Last Value: " + str(values['last_value'])
+        html += " (" + str(values['last_std']) + " standard deviations)</p>"
         html += "<img align=\"middle\" src=\"" + values['src'] + "\"/>"
 
     for title, values in stats.iteritems():
-        html += "<h1 class=\"stat\" id=\"" + title.replace(' ', '_') + "\">" + title + "</h1>"
+        html += "<h1 class=\"stat\" id=\""
+        html += title.replace(' ', '_') + "\">" + title + "</h1>"
         html += "<img align=\"middle\" src=\"" + values['src'] + "\"/>"
 
     html += """
@@ -75,9 +97,11 @@ def writeReport(outputDirectory, summary, stats):
     with open(outputDirectory + str('report.html'), 'w+') as reportFile:
         reportFile.write(html)
 
+
 def autoscale_based_on(ax, lines):
     ax.dataLim = mtransforms.Bbox.unit()
-    # call once with ignore=True to escape being limited to the unit bounding box
+    # call once with ignore=True to escape being
+    # limited to the unit bounding box
     fxy = np.vstack(lines[0].get_data()).T
     ax.dataLim.update_from_data_xy(fxy, ignore=True)
     for line in lines:
@@ -85,13 +109,14 @@ def autoscale_based_on(ax, lines):
         ax.dataLim.update_from_data_xy(xy, ignore=False)
     ax.autoscale_view()
 
+
 def getThreshold(points):
     # assumes that data has 2 or more points
     # remove the last value from computation since we are testing it
     data = points[:-1]
     mean = float(sum(data)) / max(len(data), 1)
     variance = 0
-    deviations = [ math.pow(x - mean, 2) for x in data ]
+    deviations = [math.pow(x - mean, 2) for x in data]
     variance = sum(deviations) / max(len(deviations), 1)
     std = math.sqrt(variance)
     # we define the warninng threshold as 2 standard deviations from the mean
@@ -102,10 +127,11 @@ def getThreshold(points):
     last_std = (last_value - mean) / std
     return [threshold, last_value, last_std]
 
+
 def makeSummaryGraph(outputDirectory, summary):
     summaryGraphName = "summary.png"
 
-    ratios = {title:summary[title]['last_std'] for title in summary}
+    ratios = {title: summary[title]['last_std'] for title in summary}
     ratios = OrderedDict(sorted(ratios.items(), reverse=True))
 
     # the y locations for the groups
@@ -135,13 +161,16 @@ def makeSummaryGraph(outputDirectory, summary):
 
     return summaryGraphName
 
+
 def generateStats(outputDirectory, statsfiles):
     summary = {}
-    colors = ['yellow', 'indigo', 'orange', 'lightblue', 'green', 'violet', 'orangered', 'gray', 'lightblue', 'limegreen', 'navy']
+    colors = ['yellow', 'indigo', 'orange', 'lightblue', 'green', 'violet',
+              'orangered', 'gray', 'lightblue', 'limegreen', 'navy']
     for index, fname in enumerate(statsfiles):
         bench_data = csv2rec(fname)
         bench_data = np.sort(bench_data, order='tag')
-        print "generating stats graph: " + str(index + 1) + "/" + str(len(statsfiles)) + " (" + fname + ")"
+        print ("generating stats graph: " + str(index + 1) +
+               "/" + str(len(statsfiles)) + " (" + fname + ")")
         formatter = TagFormatter(bench_data['tag'])
         fig, ax = plt.subplots()
         ax.xaxis.set_major_formatter(formatter)
@@ -152,7 +181,8 @@ def generateStats(outputDirectory, statsfiles):
         lines = []
         for ndx, col in enumerate(bench_data.dtype.names):
             if col not in exclusions:
-                line, = plt.plot(bench_data[col], lw=2.5, color=colors[ndx % len(colors)])
+                line, = plt.plot(bench_data[col], lw=2.5,
+                                 color=colors[ndx % len(colors)])
                 line.set_label(col)
                 lines.append(line)
         autoscale_based_on(ax, lines)
@@ -172,9 +202,11 @@ def generateStats(outputDirectory, statsfiles):
         summary[title] = {'title': title, 'src': imgName}
     return summary
 
+
 def generateReport(outputDirectory, csvFiles, statsfiles):
     metrics = ['min', 'max', 'med', 'avg']
-    colors = {'min': '#1f77b4', 'max': '#aec7e8', 'med': '#ff7f0e', 'avg': '#ffbb78', 'threshold': '#ff1111'}
+    colors = {'min': '#1f77b4', 'max': '#aec7e8', 'med': '#ff7f0e',
+              'avg': '#ffbb78', 'threshold': '#ff1111'}
 
     summary = {}
 
@@ -183,7 +215,8 @@ def generateReport(outputDirectory, csvFiles, statsfiles):
         # do not assume that the csv files are ordered correctly (they are not)
         bench_data = np.sort(bench_data, order='tag')
 
-        print "generating graph: " + str(index + 1) + "/" + str(len(csvFiles)) + " (" + fname + ")"
+        print ("generating graph: " + str(index + 1) + "/" +
+               str(len(csvFiles)) + " (" + fname + ")")
         formatter = TagFormatter(bench_data['tag'])
 
         fig, ax = plt.subplots()
@@ -218,10 +251,12 @@ def generateReport(outputDirectory, csvFiles, statsfiles):
         # refresh axis and don't store these in memory
         plt.close(fig)
         status = "fail" if last_value > threshold else "pass"
-        summary[title] = {'title': title, 'src': imgName, 'threshold': threshold,
-                          'last_value': last_value, 'last_std': last_std, 'status': status}
+        summary[title] = {'title': title, 'src': imgName,
+                          'threshold': threshold, 'last_value': last_value,
+                          'last_std': last_std, 'status': status}
 
-    stats = OrderedDict(sorted(generateStats(outputDirectory, statsfiles).items()))
+    stats = OrderedDict(sorted(generateStats(outputDirectory,
+                                             statsfiles).items()))
     summary = OrderedDict(sorted(summary.items()))
     writeReport(outputDirectory, summary, stats)
 

--- a/test/bench/revs_to_benchmark.txt
+++ b/test/bench/revs_to_benchmark.txt
@@ -31,3 +31,6 @@ tags/v2.3.3
 tags/v2.4.0
 tags/v2.5.1
 tags/v2.6.0
+tags/v2.7.0
+tags/v2.8.0
+tags/v3.0.0-rc1

--- a/test/bench/util/build_core.sh
+++ b/test/bench/util/build_core.sh
@@ -81,7 +81,7 @@ checkout () {
   # Check if given "ref" is a (remote) branch, and prepend origin/ if it is.
   # Otherwise, git-checkout will complain about updating paths and switching
   # branches at the same time.
-  if [ "$(git branch -r | grep -q "^\\s*origin/${ref}$")" ]; then
+  if git branch -r | grep -q "^\\s*origin/${ref}$"; then
     remoteref="origin/${ref}"
   else
     remoteref="${ref}"
@@ -95,13 +95,13 @@ checkout () {
 }
 
 clean () {
-  if [ "$build_system" == "cmake" ]; then
+  if [ "$build_system" = "cmake" ]; then
     mkdir -p build
-    pushd build
+    cd build || exit 1
     cmake ..
     make clean
-    popd
-  elif [ "$build_system" == "shell" ]; then
+    cd .. || exit 1
+  elif [ "$build_system" = "shell" ]; then
     sh build.sh clean
   else
     echo "Unknown build system!"
@@ -110,9 +110,9 @@ clean () {
 }
 
 configure () {
-  if [ "$build_system" == "cmake" ]; then
+  if [ "$build_system" = "cmake" ]; then
     : # this was taken care of by cmake
-  elif [ "$build_system" == "shell" ]; then
+  elif [ "$build_system" = "shell" ]; then
     sh build.sh config "${basedir}"
   else
     echo "Unknown build system!"
@@ -121,12 +121,12 @@ configure () {
 }
 
 build () {
-  if [ "$build_system" == "cmake" ]; then
+  if [ "$build_system" = "cmake" ]; then
     mkdir -p build
-    pushd build
+    cd build || exit 1
     make
-    popd
-  elif [ "$build_system" == "shell" ]; then
+    cd .. || exit 1
+  elif [ "$build_system" = "shell" ]; then
     sh build.sh build
   else
     echo "Unknown build system!"
@@ -140,12 +140,12 @@ if [ ! -d "${srcdir}" ]; then
   else
     git clone https://github.com/realm/realm-core.git --reference "${localrepo}" "${srcdir}"
   fi
-  cd "${srcdir}"
+  cd "${srcdir}" || exit 1
   checkout
   clean
   configure
 else
-  cd "${srcdir}"
+  cd "${srcdir}" || exit 1
   git fetch
   checkout
 fi

--- a/test/benchmark-common-tasks/CMakeLists.txt
+++ b/test/benchmark-common-tasks/CMakeLists.txt
@@ -1,3 +1,9 @@
 add_executable(realm-benchmark-common-tasks main.cpp compatibility.cpp)
 target_link_libraries(realm-benchmark-common-tasks ${PLATFORM_LIBRARIES} test-util)
 add_test(RealmBenchmarkCommonTasks realm-benchmark-common-tasks)
+
+add_executable(realm-stats stats.cpp)
+target_link_libraries(realm-stats ${PLATFORM_LIBRARIES} realm)
+file(COPY "collect_stats.py"
+     DESTINATION ${CMAKE_CURRENT_BINARY_DIR})
+

--- a/test/benchmark-common-tasks/collect_stats.py
+++ b/test/benchmark-common-tasks/collect_stats.py
@@ -1,30 +1,41 @@
-import os, sys, getopt
+import os
+import sys
+import getopt
+
 
 def get_file_size(filename):
     statinfo = os.stat(filename)
     return statinfo.st_size
 
-def get_library_size(rootBuildDir):
-    return get_file_size(os.path.join(rootBuildDir, "src/realm/librealm.a")) # same name on mac/linux
 
-def get_loc(directory, recursive = True):
+def get_library_size(rootBuildDir):
+    # librealm.a is the same binary name on mac/linux
+    return get_file_size(os.path.join(rootBuildDir, "src/realm/librealm.a"))
+
+
+def get_loc(directory, recursive=True):
     loc = 0
-    for root, dirs, files in os.walk(directory, followlinks = False):
-        if (recursive == False and root != directory): continue
+    for root, dirs, files in os.walk(directory, followlinks=False):
+        if (recursive is False and root != directory):
+            continue
         for filename in files:
             if (filename.endswith('.hpp') or filename.endswith('.cpp')):
                 fullpath = os.path.join(root, filename)
                 with open(fullpath, 'r') as f:
-                    loc += len(list(filter(lambda x: x.strip(), f))) # excludes empty lines
+                    # use strip to exclude empty lines
+                    loc += len(list(filter(lambda x: x.strip(), f)))
     return loc
+
 
 def get_lines_of_code(rootSourceDir):
     return get_loc(os.path.join(rootSourceDir, "src"))
 
+
 def get_lines_of_test_code(rootSourceDir):
-    loc = get_loc(os.path.join(rootSourceDir, "test"), recursive = False)
-    loc += get_loc(os.path.join(rootSourceDir, "test/util"), recursive = False)
+    loc = get_loc(os.path.join(rootSourceDir, "test"), recursive=False)
+    loc += get_loc(os.path.join(rootSourceDir, "test/util"), recursive=False)
     return loc
+
 
 def get_realm_sizes(rootBuildDir):
     pathPrefix = os.path.join(rootBuildDir, "test/benchmark-common-tasks/")
@@ -36,14 +47,20 @@ def get_realm_sizes(rootBuildDir):
         results.append((str(size) + " byte blob", get_file_size(name)))
     return results
 
+
 def format(description, values):
     return str(description) + ":" + str(values) + "\n"
 
+
 def do_collect_stats(rootBuildDir, rootSourceDir):
-    stats = [("Realm Library Size", [("librealm.a", get_library_size(rootBuildDir))]),
-             ("Size of a Realm File Containing Blobs of Different Sizes", get_realm_sizes(rootBuildDir)),
-             ("Lines of Code", [("Realm Code", get_lines_of_code(rootSourceDir)),
-                                ("Test Code", get_lines_of_test_code(rootSourceDir))])]
+    library_sizes = [("librealm.a", get_library_size(rootBuildDir))]
+    file_sizes = get_realm_sizes(rootBuildDir)
+    loc = [("Realm Code", get_lines_of_code(rootSourceDir)),
+           ("Test Code", get_lines_of_test_code(rootSourceDir))]
+    stats = [
+        ("Realm Library Size", library_sizes),
+        ("Size of a Realm File Containing Blobs", file_sizes),
+        ("Lines of Code", loc)]
     output = ""
     for s in stats:
         output += format(s[0], s[1])
@@ -52,16 +69,21 @@ def do_collect_stats(rootBuildDir, rootSourceDir):
     with open(outputDirectory + str('stats.txt'), 'w+') as outputFile:
         outputFile.write(output)
 
+
 def print_useage():
     print "This program gives statistics about the current realm-core build."
-    print "Two arguments are required, the source code root directory and the build root directory."
+    print "Two arguments are required: "
+    print "\t-the source code root directory"
+    print "\t-the build root directory."
     print "collect_stats.py -b <build-root-dir> -s <source-root-dir>"
+
 
 def main(argv):
     source = ''
     build = ''
     try:
-        opts, args = getopt.getopt(argv,"hb:s:",["build-root-dir=","source-root-dir="])
+        opts, args = getopt.getopt(argv, "hb:s:",
+                                   ["build-root-dir=", "source-root-dir="])
     except getopt.GetoptError:
         print_useage()
         sys.exit(2)
@@ -78,6 +100,7 @@ def main(argv):
         sys.exit(2)
 
     do_collect_stats(build, source)
+
 
 if __name__ == "__main__":
     main(sys.argv[1:])

--- a/test/benchmark-common-tasks/collect_stats.py
+++ b/test/benchmark-common-tasks/collect_stats.py
@@ -1,0 +1,84 @@
+import os, sys, getopt
+
+def get_file_size(filename):
+    statinfo = os.stat(filename)
+    return statinfo.st_size
+
+def get_library_size(rootBuildDir):
+    return get_file_size(os.path.join(rootBuildDir, "src/realm/librealm.a")) # same name on mac/linux
+
+def get_loc(directory, recursive = True):
+    loc = 0
+    for root, dirs, files in os.walk(directory, followlinks = False):
+        if (recursive == False and root != directory): continue
+        for filename in files:
+            if (filename.endswith('.hpp') or filename.endswith('.cpp')):
+                fullpath = os.path.join(root, filename)
+                with open(fullpath, 'r') as f:
+                    loc += len(list(filter(lambda x: x.strip(), f))) # excludes empty lines
+    return loc
+
+def get_lines_of_code(rootSourceDir):
+    return get_loc(os.path.join(rootSourceDir, "src"))
+
+def get_lines_of_test_code(rootSourceDir):
+    loc = get_loc(os.path.join(rootSourceDir, "test"), recursive = False)
+    loc += get_loc(os.path.join(rootSourceDir, "test/util"), recursive = False)
+    return loc
+
+def get_realm_sizes(rootBuildDir):
+    pathPrefix = os.path.join(rootBuildDir, "test/benchmark-common-tasks/")
+    results = []
+    sizes = [0, 1000, 2000, 4000, 8000, 10000]
+    for size in sizes:
+        name = str(size) + "bytes.realm"
+        os.system(pathPrefix + "realm-stats " + name + " " + str(size))
+        results.append((str(size) + " byte blob", get_file_size(name)))
+    return results
+
+def format(description, values):
+    return str(description) + ":" + str(values) + "\n"
+
+def do_collect_stats(rootBuildDir, rootSourceDir):
+    stats = [("Realm Library Size", [("librealm.a", get_library_size(rootBuildDir))]),
+             ("Size of a Realm File Containing Blobs of Different Sizes", get_realm_sizes(rootBuildDir)),
+             ("Lines of Code", [("Realm Code", get_lines_of_code(rootSourceDir)),
+                                ("Test Code", get_lines_of_test_code(rootSourceDir))])]
+    output = ""
+    for s in stats:
+        output += format(s[0], s[1])
+
+    outputDirectory = "./"
+    with open(outputDirectory + str('stats.txt'), 'w+') as outputFile:
+        outputFile.write(output)
+
+def print_useage():
+    print "This program gives statistics about the current realm-core build."
+    print "Two arguments are required, the source code root directory and the build root directory."
+    print "collect_stats.py -b <build-root-dir> -s <source-root-dir>"
+
+def main(argv):
+    source = ''
+    build = ''
+    try:
+        opts, args = getopt.getopt(argv,"hb:s:",["build-root-dir=","source-root-dir="])
+    except getopt.GetoptError:
+        print_useage()
+        sys.exit(2)
+    for opt, arg in opts:
+        if opt == '-h':
+            print_useage()
+            sys.exit()
+        elif opt in ("-b", "--build-root-dir"):
+            build = arg
+        elif opt in ("-s", "--source-root-dir"):
+            source = arg
+    if not source or not build:
+        print_useage()
+        sys.exit(2)
+
+    do_collect_stats(build, source)
+
+if __name__ == "__main__":
+    main(sys.argv[1:])
+

--- a/test/benchmark-common-tasks/compatibility_makefile
+++ b/test/benchmark-common-tasks/compatibility_makefile
@@ -1,0 +1,12 @@
+# This is the Makefile for the build.sh system
+# we need this so the performance scripts can
+# benchmark old core versions.
+check_PROGRAMS = bench-tasks realm-stats
+ 
+bench_tasks_SOURCES = main.cpp compatibility.cpp
+bench_tasks_LIBS = ../util/test-util.a
+
+realm_stats_SOURCES = stats.cpp
+realm_stats_LIBS = ../util/test-util.a
+ 
+include ../../src/generic.mk

--- a/test/benchmark-common-tasks/stats.cpp
+++ b/test/benchmark-common-tasks/stats.cpp
@@ -1,0 +1,55 @@
+#include <cstdlib>
+#include <stdio.h>
+#include <string>
+#include <iostream>
+
+#include "realm.hpp"
+
+using namespace realm;
+
+void print_useage(std::string program_name) {
+    std::cout << "This program will create a realm file with the \n"
+        << "specified name (first argument) in the current directory \n"
+        << "with a binary blob of the specified size (second argument).\n"
+        << "If a file with the same name exists, it will be overwritten.\n"
+        << "For example: \n"
+        << program_name << " simple_realm500.realm 500\n";
+}
+
+void delete_file_if_exists(std::string file_name)
+{
+    remove(file_name.c_str());
+}
+
+void create_realm_with_data(std::string file_name, size_t data_size)
+{
+    delete_file_if_exists(file_name);
+    SharedGroup sg(file_name);
+    Group& g = sg.begin_write();
+    TableRef table = g.add_table("t0");
+    table->add_column(type_Binary, "bin_col_0");
+    table->add_empty_row(1);
+    std::string blob(data_size, 'a');
+    BinaryData binary(blob.data(), data_size);
+    table->set_binary(0, 0, binary); // copies data into realm
+    sg.commit();
+    sg.close();
+}
+
+int main(int argc, const char* argv[])
+{
+    if (argc == 3) {
+        std::string file_name = argv[1];
+        long int data_size = atol(argv[2]);
+        if (data_size < 0) {
+            std::cout << "Error: Data size (second parameter) cannot be negative.\n";
+            print_useage(argv[0]);
+            return 1;
+        }
+        create_realm_with_data(file_name, static_cast<size_t>(data_size));
+    } else {
+        print_useage(argv[0]);
+        return 0;
+    }
+    return 0;
+}


### PR DESCRIPTION
On request, this is a squashed version of #2700 (minus #2713). I've kept the formatting commit because it is non-functional changes only which should make the review easier.

These changes add the infrastructure to support tracking single statistics of a build. The initial statistics included are:
- lines of code
- size of static library
- size of various realm files

You can view these new graphs in the performance reports generated for this pull request.