### PR TITLE
Track realm file sizes with increasing transactions

### DIFF
--- a/test/bench/benchmark_version
+++ b/test/bench/benchmark_version
@@ -1,4 +1,4 @@
-v8
+v10
 
 The first line of this file describes the current benchmarking tool version.
 It is used as a folder prefix to handle storing multiple versions of performance results.


### PR DESCRIPTION
This is built on top of the single stats work (#2714), so it is tracked to merge into that branch.

This adds a graph showing the size of a Realm file with various numbers of transactions per release. It is meant to show how moving the transactions into the realm file has increased the overall size, it should shed light on #2343.