### PR TITLE
Add headers to cmake generated xcode projects

### DIFF
--- a/src/realm/CMakeLists.txt
+++ b/src/realm/CMakeLists.txt
@@ -179,11 +179,20 @@ set(REALM_OTHER_UTIL_HEADERS
     util/errno.hpp
 ) # REALM_OTHER_UTIL_HEADERS
 
+set(REALM_INSTALL_ALL_HEADERS
+    ${REALM_INSTALL_GENERAL_HEADERS}
+    ${REALM_INSTALL_UTIL_HEADERS}
+    ${REALM_INSTALL_IMPL_HEADERS}
+    ${REALM_OTHER_UTIL_HEADERS}
+)
+
 if(NOT MSVC)
     list(APPEND REALM_SOURCES util/interprocess_mutex.cpp)
 endif()
 
-add_library(realm-objects OBJECT ${REALM_SOURCES})
+# We add the headers to the library only so they show up in dev
+# environments. It won't actually affect compilation process.
+add_library(realm-objects OBJECT ${REALM_SOURCES} ${REALM_INSTALL_ALL_HEADERS})
 target_compile_definitions(realm-objects PUBLIC
   "PIC"
   "$<$<CXX_COMPILER_ID:MSVC>:_CRT_SECURE_NO_WARNINGS>"


### PR DESCRIPTION
This makes Xcode generated projects display the list of header files. Previously only the sources were available from an Xcode project.

According to [this article](https://www.johnlamp.net/cmake-tutorial-2-ide-integration.html), "Both Xcode and CMake know not to compile header files so there would be no actual effect on the build."

CMake organises the headers separately from the sources as shown below:
![screen shot 2017-07-10 at 11 49 52](https://user-images.githubusercontent.com/2826060/28034409-f2bb724e-6565-11e7-9da7-eeb829b0bd4b.png)