### PR TITLE
Fix deprecation warning about asl_log on new OSX

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,7 +23,8 @@
 
 ### Internals
 
-* Lorem ipsum.
+* On Apple platforms, use `os_log` instead of `asl_log` when possible.
+  PR [#2722](https://github.com/realm/realm-core/pull/2722).
 
 ----------------------------------------------
 

--- a/src/realm/util/features.h
+++ b/src/realm/util/features.h
@@ -189,6 +189,7 @@
 #if defined __APPLE__ && defined __MACH__
 #define REALM_PLATFORM_APPLE 1
 /* Apple OSX and iOS (Darwin). */
+#include <Availability.h>
 #include <TargetConditionals.h>
 #if TARGET_OS_IPHONE == 1
 /* Device (iPhone or iPad) or simulator. */
@@ -215,6 +216,28 @@
 #define REALM_TVOS 0
 #endif
 
+// asl_log is deprecated in favor of os_log as of the following versions:
+// macos(10.12), ios(10.0), watchos(3.0), tvos(10.0)
+// versions are defined in /usr/include/Availability.h
+// __MAC_10_12   101200
+// __IPHONE_10_0 100000
+// __WATCHOS_3_0  30000
+// __TVOS_10_0   100000
+#if REALM_PLATFORM_APPLE \
+    && ( \
+        (REALM_IOS && defined(__IPHONE_OS_VERSION_MIN_REQUIRED) \
+         && __IPHONE_OS_VERSION_MIN_REQUIRED >= 100000) \
+     || (REALM_TVOS && defined(__TV_OS_VERSION_MIN_REQUIRED) \
+         &&  __TV_OS_VERSION_MIN_REQUIRED >= 100000) \
+     || (REALM_WATCHOS && defined(__WATCH_OS_VERSION_MIN_REQUIRED) \
+         && __WATCH_OS_VERSION_MIN_REQUIRED >= 30000) \
+     || (defined(__MAC_OS_X_VERSION_MIN_REQUIRED) \
+         && __MAC_OS_X_VERSION_MIN_REQUIRED >= 101200) \
+       )
+#define REALM_APPLE_OS_LOG 1
+#else
+#define REALM_APPLE_OS_LOG 0
+#endif
 
 #if REALM_ANDROID || REALM_IOS || REALM_WATCHOS || REALM_TVOS
 #define REALM_MOBILE 1

--- a/src/realm/util/terminate.cpp
+++ b/src/realm/util/terminate.cpp
@@ -24,7 +24,13 @@
 #include <realm/util/thread.hpp>
 
 #if REALM_PLATFORM_APPLE
+
+#if REALM_APPLE_OS_LOG
+#include <os/log.h>
+#else
 #include <asl.h>
+#endif
+
 #include <dlfcn.h>
 #include <execinfo.h>
 #include <CoreFoundation/CoreFoundation.h>
@@ -52,10 +58,17 @@ namespace {
 #if REALM_PLATFORM_APPLE
 void nslog(const char* message) noexcept
 {
-    // Standard error goes nowhere for applications managed by launchd, so log to ASL as well.
+    // Standard error goes nowhere for applications managed by launchd,
+    // so log to ASL/unified logging system logs as well.
     fputs(message, stderr);
+#if REALM_APPLE_OS_LOG
+    // The unified logging system considers dynamic strings to be private in
+    // order to protect users. This means we must specify "%{public}s" to get
+    // the message here. See `man os_log` for more details.
+    os_log_error(OS_LOG_DEFAULT, "%{public}s", message);
+#else
     asl_log(nullptr, nullptr, ASL_LEVEL_ERR, "%s", message);
-
+#endif
     // Log the message to Crashlytics if it's loaded into the process
     void* addr = dlsym(RTLD_DEFAULT, "CLSLog");
     if (addr) {


### PR DESCRIPTION
This solves the deprecation warning on OSX 10.12 by upgrading to the recommended `os_log` function while still keeping compatibility for building on older systems.