### PR TITLE
Fix history schema version check when opening a second SharedGroup

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,10 @@
 * Querying SharedGroup::wait_for_change() immediately after a commit()
   would return instead of waiting for the next change.
   PR [#2563](https://github.com/realm/realm-core/pull/2563).
+* Opening a second SharedGroup may trigger a file format upgrade if the history
+  schema version is non-zero.
+  Fixes issue [#2724](https://github.com/realm/realm-core/issues/2724).
+  PR [#2726](https://github.com/realm/realm-core/pull/2726).
 
 ### Breaking changes
 

--- a/src/realm/alloc_slab.cpp
+++ b/src/realm/alloc_slab.cpp
@@ -715,9 +715,14 @@ ref_type SlabAlloc::attach_file(const std::string& file_path, Config& cfg)
             }
         }
         else {
+            // TODO: m_file_mappings->m_initial_mapping.get_size() may not represent the actual file size
             m_baseline = m_file_mappings->m_initial_mapping.get_size();
         }
         ref_type top_ref = 0;
+        // top_ref is useless unless in shared mode as the allocator is not updated to reflect
+        // the maybe updated file. So it cannot be used to translate the ref.
+        // cfg.read_only implies !cfg.is_shared, so one check if enough
+        REALM_ASSERT_DEBUG(!(cfg.read_only && cfg.is_shared));
         if (cfg.read_only)
             top_ref = get_top_ref(m_data, to_size_t(m_file_mappings->m_file.get_size()));
         return top_ref;

--- a/src/realm/group_shared.cpp
+++ b/src/realm/group_shared.cpp
@@ -775,7 +775,7 @@ void SharedGroup::do_open(const std::string& path, bool no_create_file, bool is_
     }
 
     int target_file_format_version;
-    int stored_hist_schema_version;
+    int stored_hist_schema_version = -1; // Signals undetermined
 
     for (;;) {
         m_file.open(m_lockfile_path, File::access_ReadWrite, File::create_Auto, 0); // Throws
@@ -1032,7 +1032,8 @@ void SharedGroup::do_open(const std::string& path, bool no_create_file, bool is_
                         break;
                 }
 
-                REALM_ASSERT(stored_hist_schema_version <= openers_hist_schema_version);
+                REALM_ASSERT(stored_hist_schema_version >= 0 &&
+                             stored_hist_schema_version <= openers_hist_schema_version);
                 if (stored_hist_schema_version > openers_hist_schema_version)
                     throw IncompatibleHistories("Unexpected future history schema version", path);
                 bool need_hist_schema_upgrade =
@@ -1121,10 +1122,11 @@ void SharedGroup::do_open(const std::string& path, bool no_create_file, bool is_
                 if (info->sync_agent_present && opener_is_sync_agent)
                     throw MultipleSyncAgents{};
 
-                // Even though this session participant is not the session
-                // initiator, it may be the one that has to perform the history
-                // schema upgrade. See upgrade_file_format().
-                stored_hist_schema_version = gf::get_history_schema_version(alloc, top_ref);
+                // Even though this session participant is not the session initiator,
+                // it may be the one that has to perform the history schema upgrade.
+                // See upgrade_file_format(). However we cannot get the actual value
+                // at this point as the allocator is not synchronized with the file.
+                // The value will be read in a ReadTransaction later.
             }
 
 #ifndef _WIN32
@@ -1197,6 +1199,11 @@ void SharedGroup::do_open(const std::string& path, bool no_create_file, bool is_
     // Upgrade file format and/or history schema
     try {
         using gf = _impl::GroupFriend;
+        if (stored_hist_schema_version == -1) {
+            // current_hist_schema_version has not been read. Read it now
+            ReadTransaction rt(*this);
+            stored_hist_schema_version = gf::get_history_schema_version(m_group.m_alloc, m_read_lock.m_top_ref);
+        }
         int current_file_format_version = gf::get_file_format_version(m_group);
         if (current_file_format_version == 0) {
             // If the current file format is still undecided, no upgrade is


### PR DESCRIPTION
The root cause of the error is found to be the fact that SlabAlloc::attach_file would return 0 in case the caller is not session initiating. The fix is to read the stored history schema version in a read transaction.

Fixes #2724 