### PR TITLE
Fix a bug in the history schema upgrade logic left behind by PR #2637

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@
   would return instead of waiting for the next change.
   PR [#2563](https://github.com/realm/realm-core/pull/2563).
 * Fix a bug in the history schema upgrade logic left behind by PR #2637.
-  PR [#????](https://github.com/realm/realm-core/pull/????)
+  PR [#2729](https://github.com/realm/realm-core/pull/2729)
 
 ### Breaking changes
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@
 * Querying SharedGroup::wait_for_change() immediately after a commit()
   would return instead of waiting for the next change.
   PR [#2563](https://github.com/realm/realm-core/pull/2563).
+* Fix a bug in the history schema upgrade logic left behind by PR #2637.
+  PR [#????](https://github.com/realm/realm-core/pull/????)
 
 ### Breaking changes
 

--- a/src/realm/group_shared.cpp
+++ b/src/realm/group_shared.cpp
@@ -1124,7 +1124,18 @@ void SharedGroup::do_open(const std::string& path, bool no_create_file, bool is_
                 // Even though this session participant is not the session
                 // initiator, it may be the one that has to perform the history
                 // schema upgrade. See upgrade_file_format().
-                stored_hist_schema_version = gf::get_history_schema_version(alloc, top_ref);
+                if (top_ref != 0) {
+                    stored_hist_schema_version = gf::get_history_schema_version(alloc, top_ref);
+                }
+                else {
+                    // When `top_ref == 0`, there is no history yet, but the
+                    // type and initial version of the history has been decided
+                    // by the session initiator. Note: Due to a preceding check,
+                    // `openers_hist_schema_version` is known to be equal to the
+                    // initial version decided by the session initiator
+                    // (`info->history_schema_version`).
+                    stored_hist_schema_version = openers_hist_schema_version;
+                }
             }
 
 #ifndef _WIN32


### PR DESCRIPTION
Fixes https://github.com/realm/realm-core/issues/2724

@jedelbo @bdash 

Note, this is an alternative to the fix proposed by @jedelbo here: https://github.com/realm/realm-core/pull/2726