### PR TITLE
Patch CMake generated Xcode project dependency quirk

### DIFF
--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -92,7 +92,15 @@ else()
     set(MAIN_FILE main.cpp)
 endif()
 
-add_executable(realm-tests ${TESTS} ${MAIN_FILE} ${REQUIRED_TEST_FILES})
+# here we add the realm-objects dependency directly to patch
+# a quirk when generating Xcode projects. Otherwise changing
+# a source file in the Realm library would not rebuild the
+# static library when the unit tests are rerun.
+add_executable(realm-tests
+               $<TARGET_OBJECTS:realm-objects>
+               ${TESTS}
+               ${MAIN_FILE}
+               ${REQUIRED_TEST_FILES})
 
 if(CMAKE_GENERATOR STREQUAL Xcode)
     set_target_properties(realm-tests PROPERTIES


### PR DESCRIPTION
Fixes #2731.

We have a dependency chain of targets: `realm-tests -> test-util -> realm -> realm-objects`
If a source file of the library was changed, the target `realm-objects` was being compiled but the static library `realm` wasn't being regenerated. Due to some other quirk with Xcode generated projects, there must be some source file in the list of dependencies of a static library which is why we have the `placeholder.cpp` file in the first place ([further details](https://github.com/realm/realm-core/blob/master/src/realm/placeholder.cpp#L1)). I observed that if I changed the file `placeholder.cpp` (by adding another empty line for example) then the static library was regenerated correctly when running the tests. This makes me conclude that somehow the dependency list for Xcode projects is broken when using `$<TARGET_OBJECTS:realm-objects>` As a workaround, I added the `$<TARGET_OBJECTS:realm-objects>` directly to the `realm-tests` dependencies. Now, when a Realm source file is changed, the `realm-objects` target is updated along with the `realm` static library when running the unit tests in Xcode.

Building the project with make seems unaffected by these changes (but it works in the first place).