### PR TITLE
Fix AFL scripts to work with CMake

### DIFF
--- a/build-afl.sh
+++ b/build-afl.sh
@@ -1,1 +1,0 @@
-#!/usr/bin/env bash

--- a/test/fuzzy/README.md
+++ b/test/fuzzy/README.md
@@ -1,10 +1,21 @@
 # How to Run the Fuzz Tests
 
+## Prerequisites
+
+You should install the latest version of the American Fuzzy Lop (AFL) tool.
+You can sometimes find this tool from your native package manager:
+
+- On Mac OS X: brew install afl-fuzz
+- On Ubuntu: apt-get install afl-clang
+
+If it is not available natively or you want a more recent version,
+check http://lcamtuf.coredump.cx/afl/ for release notes and install instructions.
+
 ## The Simple Way
 
 `sh simple_start.sh`
 
-Builds `realm-core` and the fuzz target with `afl-g++` on Linux (or `afl-clang++` on OS X) and starts N instances of `afl-fuzz`, where N is the number of logical CPU processors.
+Builds `realm-core` and the fuzz target with `afl-clang++` and starts N instances of `afl-fuzz`, where N is the number of logical CPU processors.
 
 `sh simple_stop.sh`
 

--- a/test/fuzzy/simple_start.sh
+++ b/test/fuzzy/simple_start.sh
@@ -3,6 +3,6 @@
 # Start as many fuzzers as we have CPU logical processors. Use the default executable
 
 num_fuzzers="$(getconf _NPROCESSORS_ONLN)"
-executable_path="./fuzz-group"
+executable_path="fuzz-group"
 
 sh start_parallel_fuzzer.sh "$num_fuzzers" "$executable_path"

--- a/test/fuzzy/simple_start.sh
+++ b/test/fuzzy/simple_start.sh
@@ -1,8 +1,8 @@
-#!/bin/sh
+#!/bin/bash
 
 # Start as many fuzzers as we have CPU logical processors. Use the default executable
-
+DIR=$(dirname ${BASH_SOURCE[0]})
 num_fuzzers="$(getconf _NPROCESSORS_ONLN)"
 executable_path="fuzz-group"
 
-sh start_parallel_fuzzer.sh "$num_fuzzers" "$executable_path"
+${DIR}/start_parallel_fuzzer.sh "$num_fuzzers" "$executable_path"

--- a/test/fuzzy/simple_stop.sh
+++ b/test/fuzzy/simple_stop.sh
@@ -2,7 +2,7 @@
 
 # Stop the fuzzers and use the default executable to convert any found crashes and hangs to cpp unit tests
 
-executable_path="./fuzz-group"
+executable_path="fuzz-group"
 unit_tests_path="findings/cpp_unit_tests/"
 
 bash stop_parallel_fuzzer.sh "$executable_path" "$unit_tests_path"

--- a/test/fuzzy/simple_stop.sh
+++ b/test/fuzzy/simple_stop.sh
@@ -1,8 +1,9 @@
-#!/bin/sh
+#!/bin/bash
 
 # Stop the fuzzers and use the default executable to convert any found crashes and hangs to cpp unit tests
 
+DIR=$(dirname ${BASH_SOURCE[0]})
 executable_path="fuzz-group"
-unit_tests_path="findings/cpp_unit_tests/"
+unit_tests_path="cpp_unit_tests/"
 
-bash stop_parallel_fuzzer.sh "$executable_path" "$unit_tests_path"
+${DIR}/stop_parallel_fuzzer.sh "$executable_path" "$unit_tests_path"

--- a/test/fuzzy/start_parallel_fuzzer.sh
+++ b/test/fuzzy/start_parallel_fuzzer.sh
@@ -1,9 +1,8 @@
 #!/usr/bin/env bash
 
 SCRIPT=$(basename "${BASH_SOURCE[0]}")
-DIR=$(cd "$(dirname ${BASH_SOURCE[0]})" && pwd)
-ROOTDIR=$(dirname $(dirname ${DIR}))
-BUILD_DIR="build_afl"
+ROOT_DIR=$(git rev-parse --show-toplevel)
+BUILD_DIR="build.afl"
 
 if [ "$#" -ne 2 ]; then
     echo "Usage: ${SCRIPT} <num_fuzzers> <fuzz_test>"
@@ -38,55 +37,57 @@ fi
 
 echo "Building..."
 
-cd "${DIR}/../.." || exit
-rm -rf "${BUILD_DIR}"
-mkdir "${BUILD_DIR}"
+cd "${ROOT_DIR}" || exit
+mkdir -p "${BUILD_DIR}"
 cd "${BUILD_DIR}" || exit
-RAND_NODE_SIZE=$(python -c "import random; print (random.randint(4,999), 1000)[bool(random.randint(0,1))]")
+if [ -z ${REALM_MAX_BPNODE_SIZE} ]; then
+    REALM_MAX_BPNODE_SIZE=$(python -c "import random; print (random.randint(4,999), 1000)[bool(random.randint(0,1))]")
+fi
 cmake -D REALM_AFL=ON \
-      -D CMAKE_C_COMPILER=afl-clang \
-      -D CMAKE_CXX_COMPILER=afl-clang++ \
-      -D REALM_MAX_BPNODE_SIZE="${RAND_NODE_SIZE}" \
+      -D CMAKE_C_COMPILER=afl-gcc \
+      -D CMAKE_CXX_COMPILER=afl-g++ \
+      -D REALM_MAX_BPNODE_SIZE="${REALM_MAX_BPNODE_SIZE}" \
       -D REALM_ENABLE_ENCRYPTION=ON \
       -G Ninja \
       ..
+
 ninja "${fuzz_test}"
 
 echo "Cleaning up the findings directory"
 
 FINDINGS_DIR="findings"
+EXEC=$(find -name ${fuzz_test})
 
 pkill afl-fuzz
 rm -rf "${FINDINGS_DIR}"
-mkdir "${FINDINGS_DIR}"
+mkdir -p "${FINDINGS_DIR}"
 
 # see also stop_parallel_fuzzer.sh
 time_out="1000" # ms
 memory="100" # MB
 
-echo "Starting $num_fuzzers fuzzers in parallel"
-
 # if we have only one fuzzer
-if [ "$num_fuzzers" -eq 1 ]; then
+if [ "${num_fuzzers}" -eq 1 ]; then
     afl-fuzz -t "$time_out" \
              -m "$memory" \
-             -i "${ROOTDIR}/test/fuzzy/testcases" \
+             -i "${ROOT_DIR}/test/fuzzy/testcases" \
              -o "${FINDINGS_DIR}" \
-             "test/fuzzy/${fuzz_test}" @@
+             ${EXEC} @@
     exit 0
 fi
 
 # start the fuzzers in parallel
-for i in $(seq 1 "$num_fuzzers"); do
+echo "Starting $num_fuzzers fuzzers in parallel"
+for i in $(seq 1 ${num_fuzzers}); do
     [[ $i -eq 1 ]] && flag="-M" || flag="-S"
     afl-fuzz -t "$time_out" \
              -m "$memory" \
-             -i "${ROOTDIR}/test/fuzzy/testcases" \
+             -i "${ROOT_DIR}/test/fuzzy/testcases" \
              -o "${FINDINGS_DIR}" \
              "${flag}" "fuzzer$i" \
-             "test/fuzzy/${fuzz_test}" @@ --name "fuzzer$i" >/dev/null 2>&1 &
+             ${EXEC} @@ --name "fuzzer$i" >/dev/null 2>&1 &
 done
 
 echo
-echo "Use afl-whatsup ../../${BUILD_DIR}/${FINDINGS_DIR} to check progress"
+echo "Use 'afl-whatsup ${ROOT_DIR}/${BUILD_DIR}/${FINDINGS_DIR}' to check progress"
 echo

--- a/test/fuzzy/stop_parallel_fuzzer.sh
+++ b/test/fuzzy/stop_parallel_fuzzer.sh
@@ -1,31 +1,33 @@
 #!/usr/bin/env bash
 
 SCRIPT=$(basename "${BASH_SOURCE[0]}")
-DIR=$(cd "$(dirname ${BASH_SOURCE[0]})" && pwd)
-ROOT_DIR=$(dirname $(dirname "${DIR}"))
-BUILD_DIR="build_afl"
+cd "$(dirname ${BASH_SOURCE[0]})"
+FUZZPREFIX=$(git rev-parse --show-prefix)
+ROOT_DIR=$(git rev-parse --show-toplevel)
+BUILD_DIR="build.afl"
+FINDINGS_DIR=${ROOT_DIR}/${BUILD_DIR}/findings
 
 if [ "$#" -ne 2 ]; then
     echo "Usage: sh ${SCRIPT} executable_path (e.g. group) output_directory"
     exit 1
 fi
-executable_path="$1"
+fuzz_test="$1"
 unit_tests_path="$2"
 
 echo "Killing all running fuzzers"
 pkill afl-fuzz
 
 echo "Cleaning up the queues to free disk space, inodes (this may take a while)"
-rm -rf "${ROOT_DIR}/${BUILD_DIR}/findings/*/queue"
+rm -rf "${FINDINGS_DIR}/*/queue"
 
 # Remove any previously minimized cases
-rm -rf "${ROOT_DIR}/${BUILD_DIR}/findings/*/*/*.minimized"
+rm -rf "${FINDINGS_DIR}/*/*/*.minimized"
 
 echo "Removing any leftover Realm files"
 find "${ROOT_DIR}/${BUILD_DIR}" -type f -name "fuzzer*.realm*" -delete
 
 # Find all interesting cases
-files=($(find "${ROOT_DIR}/${BUILD_DIR}/findings" \( -path "*/hangs/id:*" -or -path "*/crashes/id:*" \)))
+files=($(find ${FINDINGS_DIR} -path "*/hangs/id:*" -or -path "*/crashes/id:*"))
 
 num_files=${#files[@]}
 
@@ -36,9 +38,10 @@ fi
 
 # see also start_parallel_fuzzer.sh
 time_out="10000" # ms, 10x
-memory="100" # MB
+memory="300" # MB
 
-mkdir -p "$unit_tests_path"
+mkdir -p ${FINDINGS_DIR}/${unit_tests_path}
+EXEC=$(find ${ROOT_DIR}/${BUILD_DIR} -name ${fuzz_test})
 
 # This loop was deliberately changed into doing two things in order to get
 # cpp files as early as possible
@@ -46,11 +49,11 @@ echo "Minimizing and converting $num_files found crashes and hangs"
 for file in "${files[@]}"; do
 	# Let AFL try to minimize each input before converting to .cpp
 	minimized_file="$file.minimized"
-    afl-tmin -t "$time_out" -m "$memory" -i "$file" -o "$minimized_file" "${ROOT_DIR}/${BUILD_DIR}/test/fuzzy/$executable_path" @@
+    afl-tmin -t "$time_out" -m "$memory" -i "$file" -o "$minimized_file" "${EXEC}" @@
     test $? -eq 1 && exit 1 # terminate if afl-tmin is being terminated
 
     # Convert into cpp file
-    cpp_file="$unit_tests_path$(basename $file).cpp"
-    "${ROOT_DIR}/${BUILD_DIR}/test/fuzzy/$executable_path" "$minimized_file" --log > "$cpp_file"
+    cpp_file=${FINDINGS_DIR}/${unit_tests_path}$(basename $file).cpp
+    ${EXEC} ${minimized_file} --log > ${cpp_file}
     test $? -eq 1 && exit 1 # terminate if afl-tmin is being terminated
 done

--- a/test/fuzzy/stop_parallel_fuzzer.sh
+++ b/test/fuzzy/stop_parallel_fuzzer.sh
@@ -46,11 +46,11 @@ echo "Minimizing and converting $num_files found crashes and hangs"
 for file in "${files[@]}"; do
 	# Let AFL try to minimize each input before converting to .cpp
 	minimized_file="$file.minimized"
-    afl-tmin -t "$time_out" -m "$memory" -i "$file" -o "$minimized_file" "${ROOT_DIR}/${BUILD_DIR}/test/fuzzy/fuzz-$executable_path" @@
+    afl-tmin -t "$time_out" -m "$memory" -i "$file" -o "$minimized_file" "${ROOT_DIR}/${BUILD_DIR}/test/fuzzy/$executable_path" @@
     test $? -eq 1 && exit 1 # terminate if afl-tmin is being terminated
 
     # Convert into cpp file
     cpp_file="$unit_tests_path$(basename $file).cpp"
-    "${ROOT_DIR}/${BUILD_DIR}/test/fuzzy/fuzz-$executable_path" "$minimized_file" --log > "$cpp_file"
+    "${ROOT_DIR}/${BUILD_DIR}/test/fuzzy/$executable_path" "$minimized_file" --log > "$cpp_file"
     test $? -eq 1 && exit 1 # terminate if afl-tmin is being terminated
 done


### PR DESCRIPTION
Update the `simple_start.sh` and `simple_stop.sh` scripts to work with the CMake system.