### PR TITLE
Use strict vector checks in debug mode

### DIFF
--- a/src/realm/column.hpp
+++ b/src/realm/column.hpp
@@ -90,7 +90,7 @@ public:
     ColumnRandIterator<ColumnDataType> operator--(int);
     ColumnRandIterator<ColumnDataType> operator+(ptrdiff_t movement);
     ColumnRandIterator<ColumnDataType> operator-(ptrdiff_t movement);
-    ptrdiff_t operator-(const ColumnRandIterator<ColumnDataType>& rawIterator);
+    ptrdiff_t operator-(const ColumnRandIterator<ColumnDataType>& right) const;
     const ColumnDataType operator*() const;
     const ColumnDataType operator->() const;
     const ColumnDataType operator[](ptrdiff_t offset) const;
@@ -1811,9 +1811,9 @@ ColumnRandIterator<ColumnDataType> ColumnRandIterator<ColumnDataType>::operator-
 }
 
 template <class ColumnDataType>
-ptrdiff_t ColumnRandIterator<ColumnDataType>::operator-(const ColumnRandIterator<ColumnDataType>& other)
+ptrdiff_t ColumnRandIterator<ColumnDataType>::operator-(const ColumnRandIterator<ColumnDataType>& right) const
 {
-    return m_col_ndx - other.m_col_ndx;
+    return m_col_ndx - right.m_col_ndx;
 }
 
 template <class ColumnDataType>


### PR DESCRIPTION
- Enable inline checking of vectors in debug mode by defining `_GLIBCXX_DEBUG`
- This catches and fixes a problem with the `ColumnRandIterator<ColumnDataType>` not being const when the vector code calling it expects it to be. Specifically we get:

```
In file included from /usr/include/c++/5/debug/debug.h:127:0,
                 from /usr/include/c++/5/bits/stl_iterator_base_funcs.h:65,
                 from /usr/include/c++/5/bits/stl_algobase.h:66,
                 from /usr/include/c++/5/bits/char_traits.h:39,
                 from /usr/include/c++/5/string:40,
                 from /usr/include/c++/5/bits/locale_classes.h:40,
                 from /usr/include/c++/5/bits/ios_base.h:41,
                 from /usr/include/c++/5/iomanip:40,
                 from /home/parallels/Documents/code/realm-core/src/realm/index_string.cpp:20:
/usr/include/c++/5/debug/functions.h: In instantiation of ‘bool __gnu_debug::__valid_range_aux2(const _RandomAccessIterator&, const _RandomAccessIterator&, std::random_access_iterator_tag) [with _RandomAccessIterator = realm::ColumnRandIterator<long int>]’:
/usr/include/c++/5/debug/functions.h:137:32:   required from ‘bool __gnu_debug::__valid_range_aux(const _InputIterator&, const _InputIterator&, std::__false_type) [with _InputIterator = realm::ColumnRandIterator<long int>]’
/usr/include/c++/5/debug/functions.h:150:31:   required from ‘bool __gnu_debug::__valid_range(const _InputIterator&, const _InputIterator&) [with _InputIterator = realm::ColumnRandIterator<long int>]’
/usr/include/c++/5/bits/stl_algo.h:2028:7:   required from ‘_FIter std::lower_bound(_FIter, _FIter, const _Tp&, _Compare) [with _FIter = realm::ColumnRandIterator<long int>; _Tp = realm::StringData; _Compare = realm::SortedListComparator]’
/home/parallels/Documents/code/realm-core/src/realm/index_string.cpp:71:68:   required from here
/usr/include/c++/5/debug/functions.h:109:21: error: no match for ‘operator-’ (operand types are ‘const realm::ColumnRandIterator<long int>’ and ‘const realm::ColumnRandIterator<long int>’)
     { return __last - __first >= 0; }
                     ^
In file included from /home/parallels/Documents/code/realm-core/src/realm/index_string.cpp:28:0:
/home/parallels/Documents/code/realm-core/src/realm/column.hpp:1814:11: note: candidate: ptrdiff_t realm::ColumnRandIterator<T>::operator-(const realm::ColumnRandIterator<T>&) [with ColumnDataType = long int; ptrdiff_t = long int] <near match>
 ptrdiff_t ColumnRandIterator<ColumnDataType>::operator-(const ColumnRandIterator<ColumnDataType>& right)
           ^
```

I'm not sure why this wasn't causing any problems, my guess is that compilers just used the non-const method anyway because it didn't actually change the object even though it wasn't marked const.

Thanks to @rrrlasse for catching this problem.