### PR TITLE
Fix crash on rollback of optimise

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,8 @@
   Fixes issue [#2724](https://github.com/realm/realm-core/issues/2724).
   PR [#2726](https://github.com/realm/realm-core/pull/2726).
 * Fix incorrect results from TableView::find_first().
+* Fix crash on rollback of Table::optimize(). Currently unused by bindings.
+  PR [#2753](https://github.com/realm/realm-core/pull/2753).
 
 ### Breaking changes
 

--- a/src/realm/table.cpp
+++ b/src/realm/table.cpp
@@ -5965,6 +5965,20 @@ void Table::refresh_column_accessors(size_t col_ndx_begin)
                 // before the refresh operation is complete.
                 m_cols[col_ndx] = nullptr;
             }
+        } else if (dynamic_cast<StringEnumColumn*>(col) != nullptr) {
+            // If the current column accessor is StringEnumColumn, but the
+            // underlying column has changed to a StringColumn (which can occur
+            // in a rollback), then we need to replace the accessor with an
+            // instance of StringColumn.
+            ColumnType col_type = m_spec.get_column_type(col_ndx);
+            if (col_type == col_type_String) {
+                delete col;
+                col = nullptr;
+                // We need to store null in `m_cols` to avoid a crash during
+                // destruction of the table accessor in case an error occurs
+                // before the refresh operation is complete.
+                m_cols[col_ndx] = nullptr;
+            }
         }
 
         if (col) {

--- a/test/fuzz_group.cpp
+++ b/test/fuzz_group.cpp
@@ -91,6 +91,7 @@ enum INS {
     MOVE_COLUMN,
     SET_UNIQUE,
     IS_NULL,
+    OPTIMIZE_TABLE,
 
     COUNT
 };
@@ -760,6 +761,15 @@ void parse_and_apply_instructions(std::string& in, const std::string& path, util
                     }
                     t->swap_rows(row_ndx1, row_ndx2);
                 }
+            }
+            else if (instr == OPTIMIZE_TABLE && g.size() > 0) {
+                size_t table_ndx = get_next(s) % g.size();
+                TableRef t = g.get_table(table_ndx);
+                // Force creation of a string enum column
+                if (log) {
+                    *log << "g.get_table(" << table_ndx << ")->optimize(true);\n";
+                }
+                g.get_table(table_ndx)->optimize(true);
             }
             else if (instr == COMMIT) {
                 if (log) {

--- a/test/fuzzy/start_parallel_fuzzer.sh
+++ b/test/fuzzy/start_parallel_fuzzer.sh
@@ -64,7 +64,7 @@ mkdir -p "${FINDINGS_DIR}"
 
 # see also stop_parallel_fuzzer.sh
 time_out="1000" # ms
-memory="100" # MB
+memory="1000" # MB
 
 # if we have only one fuzzer
 if [ "${num_fuzzers}" -eq 1 ]; then

--- a/test/test_lang_bind_helper.cpp
+++ b/test/test_lang_bind_helper.cpp
@@ -13082,6 +13082,26 @@ TEST(LangBindHelper_MixedStringRollback)
 }
 
 
+TEST(LangBindHelper_RollbackOptimize)
+{
+    SHARED_GROUP_TEST_PATH(path);
+    const char* key = crypt_key();
+    std::unique_ptr<Replication> hist_w(make_in_realm_history(path));
+    SharedGroup sg_w(*hist_w, SharedGroupOptions(key));
+    Group& g = sg_w.begin_write();
+
+    g.insert_table(0, "t0");
+    g.get_table(0)->add_column(type_String, "str_col_0", true);
+    LangBindHelper::commit_and_continue_as_read(sg_w);
+    g.verify();
+    LangBindHelper::promote_to_write(sg_w);
+    g.verify();
+    g.get_table(0)->add_empty_row(198);
+    g.get_table(0)->optimize(true);
+    LangBindHelper::rollback_and_continue_as_read(sg_w);
+}
+
+
 TEST(LangBindHelper_BinaryReallocOverMax)
 {
     SHARED_GROUP_TEST_PATH(path);


### PR DESCRIPTION
If a transaction containing a call to optimise is rolled back we would crash when trying to refresh the accessor tree because we were still operating on a `StringEnumColumn` while the underlying spec had been reverted to a `StringColumn`. This can only be triggered by cancelling a transaction, it can't be triggered by advancing a transaction because there is no way to "unoptimise" a table (ie. once a column has changed to a `StringEnumColumn` there is no way to undo this). 

It looks like the only code calling `Table::optimize` is Object-Store's version of [compact](https://github.com/realm/realm-object-store/blob/b6b206760c0f1da77ff59eebcec8f5674084990f/src/shared_realm.cpp#L630).

Replaces #1789. Possibly (but unlikely) related to #2746.