### PR TITLE
Update TableViews in Table::swap_rows()

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@
 * Fix crash on rollback of Table::optimize(). Currently unused by bindings.
   PR [#2753](https://github.com/realm/realm-core/pull/2753).
 * Update frozen TableViews when Table::swap() is called.
+  PR [#2757](https://github.com/realm/realm-core/pull/2757).
 
 ### Breaking changes
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@
 * Fix incorrect results from TableView::find_first().
 * Fix crash on rollback of Table::optimize(). Currently unused by bindings.
   PR [#2753](https://github.com/realm/realm-core/pull/2753).
+* Update frozen TableViews when Table::swap() is called.
 
 ### Breaking changes
 

--- a/src/realm/table.cpp
+++ b/src/realm/table.cpp
@@ -5738,6 +5738,11 @@ void Table::adj_row_acc_swap_rows(size_t row_ndx_1, size_t row_ndx_2) noexcept
         }
         row = row->m_next;
     }
+
+    // Adjust rows in tableviews after row swap
+    for (auto& view : m_views) {
+        view->adj_row_acc_swap_rows(row_ndx_1, row_ndx_2);
+    }
 }
 
 

--- a/src/realm/table_view.cpp
+++ b/src/realm/table_view.cpp
@@ -597,6 +597,25 @@ void TableViewBase::adj_row_acc_move_over(size_t from_row_ndx, size_t to_row_ndx
 }
 
 
+void TableViewBase::adj_row_acc_swap_rows(size_t row_ndx_1, size_t row_ndx_2) noexcept
+{
+    // Always adjust only the earliest ref which matches either ndx_1 or ndx_2
+    // to avoid double-swapping the refs
+    size_t it_1 = m_row_indexes.find_first(row_ndx_1, 0);
+    size_t it_2 =  m_row_indexes.find_first(row_ndx_2, 0);
+    while (it_1 != not_found || it_2 != not_found) {
+        if (it_1 < it_2) {
+            m_row_indexes.set(it_1, row_ndx_2);
+            it_1 = m_row_indexes.find_first(row_ndx_1, it_1);
+        }
+        else {
+            m_row_indexes.set(it_2, row_ndx_1);
+            it_2 = m_row_indexes.find_first(row_ndx_2, it_2);
+        }
+    }
+}
+
+
 void TableViewBase::adj_row_acc_clear() noexcept
 {
     m_num_detached_refs = m_row_indexes.size();

--- a/src/realm/table_view.hpp
+++ b/src/realm/table_view.hpp
@@ -425,6 +425,7 @@ private:
     void adj_row_acc_insert_rows(size_t row_ndx, size_t num_rows) noexcept;
     void adj_row_acc_erase_row(size_t row_ndx) noexcept;
     void adj_row_acc_move_over(size_t from_row_ndx, size_t to_row_ndx) noexcept;
+    void adj_row_acc_swap_rows(size_t row_ndx_1, size_t row_ndx_2) noexcept;
     void adj_row_acc_clear() noexcept;
 };
 

--- a/test/test_lang_bind_helper.cpp
+++ b/test/test_lang_bind_helper.cpp
@@ -12575,6 +12575,63 @@ TEST(LangBindHelper_IsRowAttachedAfterClear)
 }
 
 
+TEST(LangBindHelper_TableViewUpdateAfterSwap)
+{
+    SHARED_GROUP_TEST_PATH(path);
+    std::unique_ptr<Replication> hist_r(make_in_realm_history(path));
+    std::unique_ptr<Replication> hist_w(make_in_realm_history(path));
+    SharedGroup sg_r(*hist_r, SharedGroupOptions(crypt_key()));
+    SharedGroup sg_w(*hist_w, SharedGroupOptions(crypt_key()));
+    Group& g = const_cast<Group&>(sg_w.begin_write());
+    Group& g_r = const_cast<Group&>(sg_r.begin_read());
+
+    TableRef t = g.add_table("t");
+    size_t col_id = t->add_column(type_Int, "id");
+
+    t->add_empty_row(10);
+    for (int i = 0; i < 10; ++i)
+        t->set_int(col_id, i, i);
+
+    LangBindHelper::commit_and_continue_as_read(sg_w);
+    g.verify();
+    LangBindHelper::advance_read(sg_r);
+    g_r.verify();
+
+    TableView tv = t->where().find_all();
+    TableView tv_r = g_r.get_table(0)->where().find_all();
+
+    LangBindHelper::promote_to_write(sg_w);
+    for (int i = 0; i < 5; ++i)
+        t->swap_rows(i, 9 - i);
+    LangBindHelper::commit_and_continue_as_read(sg_w);
+    g.verify();
+    LangBindHelper::advance_read(sg_r);
+    g_r.verify();
+
+    for (int i = 0; i < 10; ++i) {
+        CHECK_EQUAL(tv.get_int(0, i), i);
+        CHECK_EQUAL(tv_r.get_int(0, i), i);
+        CHECK_EQUAL(tv.get(i).get_index(), 9 - i);
+        CHECK_EQUAL(tv_r.get(i).get_index(), 9 - i);
+    }
+
+    LangBindHelper::promote_to_write(sg_w);
+    for (int i = 0; i < 5; ++i)
+        t->swap_rows(i, 9 - i);
+    for (int i = 0; i < 10; ++i) {
+        CHECK_EQUAL(tv.get_int(0, i), i);
+        CHECK_EQUAL(tv.get(i).get_index(), i);
+    }
+    LangBindHelper::rollback_and_continue_as_read(sg_w);
+    g.verify();
+
+    for (int i = 0; i < 10; ++i) {
+        CHECK_EQUAL(tv.get_int(0, i), i);
+        CHECK_EQUAL(tv.get(i).get_index(), 9 - i);
+    }
+}
+
+
 TEST(LangBindHelper_RollbackRemoveZeroRows)
 {
     SHARED_GROUP_TEST_PATH(path)


### PR DESCRIPTION
It's very hard to produce a call to `swap_rows()` at a time where this matters from the Cocoa binding, but it is theoretically possible and might be easier from other bindings.