### PR TITLE
Re-introduce the cloning of tags refspecs in CI

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -542,7 +542,7 @@ def getSourceArchive() {
           $class           : 'GitSCM',
           branches         : scm.branches,
           gitTool          : 'native git',
-          extensions       : scm.extensions + [[$class: 'CleanCheckout']],
+          extensions       : scm.extensions + [[$class: 'CleanCheckout'], [$class: 'CloneOption', depth: 0, noTags: false, reference: '', shallow: false]],
           userRemoteConfigs: scm.userRemoteConfigs
         ]
     )


### PR DESCRIPTION
Without this fix the initial CI stage will fail on `git describe --tags`