### PR TITLE
Make the release script work on Mac and Linux

### DIFF
--- a/tools/release-init.sh
+++ b/tools/release-init.sh
@@ -5,8 +5,8 @@
 # Description of release procedure can be found at https://github.com/realm/realm-wiki/wiki/Releasing-Realm-Core
 #
 
-realm_version=$(echo "$1" | sed -r -n '/^[0-9].[0-9].[0-9](-.*)?$/p')
-if [ -z ${realm_version} ]; then
+realm_version=$(echo "$1" | egrep '^[0-9].[0-9].[0-9](-.*)?$')
+if [ -z "${realm_version}" ]; then
     echo Wrong version format: "$1"
     exit 1
 fi
@@ -18,9 +18,11 @@ git push -u origin release/${realm_version}
 git checkout -b prepare-$realm_version
 
 # update dependencies.list
-sed -i "s/^VERSION.*/VERSION=${realm_version}/" ${project_dir}/dependencies.list
+sed -i.bak -e "s/^VERSION.*/VERSION=${realm_version}/" "${project_dir}/dependencies.list"
+rm "${project_dir}/dependencies.list.bak" || exit 1
 
 RELEASE_HEADER="# $realm_version Release notes" || exit 1
-sed -i "1s/.*/$RELEASE_HEADER/" ${project_dir}/CHANGELOG.md || exit 1
+sed -i.bak -e "1s/.*/$RELEASE_HEADER/" "${project_dir}/CHANGELOG.md" || exit 1
+rm "${project_dir}/CHANGELOG.md.bak" || exit 1
 
-echo Ready to make ${realm_version}
+echo Ready to make "${realm_version}"

--- a/tools/release-tag.sh
+++ b/tools/release-tag.sh
@@ -11,7 +11,7 @@ if [ $# != 1 ]; then
 fi
 
 project_dir=$(git rev-parse --show-toplevel)
-realm_version=$(grep VERSION ${project_dir}/dependencies.list | cut -f 2 -d=)
+realm_version=$(grep VERSION "${project_dir}/dependencies.list" | cut -f 2 -d=)
 tag=v${realm_version}
-git tag -m \""$1"\" ${tag}
-git push origin ${tag}
+git tag -m \""$1"\" "${tag}"
+git push origin "${tag}"


### PR DESCRIPTION
`sed -r` is not supported on Mac, the equivalent is `sed -E` which is not supported on Linux 😢 I switched to use `egrep` which is available on both.

`sed -i -e` was also needed to make the inplace replacement command work on both systems.