### PR TITLE
Eliminate some wasted work in build-cocoa.sh

### DIFF
--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -81,8 +81,6 @@ file(GLOB REQUIRED_TEST_FILES
      "*.json"
      "*.realm"
      "expect_string.txt")
-file(COPY ${REQUIRED_TEST_FILES}
-     DESTINATION ${CMAKE_CURRENT_BINARY_DIR})
 
 # FIXME: Benchmarks
 
@@ -98,6 +96,9 @@ if(CMAKE_GENERATOR STREQUAL Xcode)
     set_target_properties(realm-tests PROPERTIES
                           MACOSX_BUNDLE YES
                           RESOURCE "${REQUIRED_TEST_FILES}")
+else()
+file(COPY ${REQUIRED_TEST_FILES}
+     DESTINATION ${CMAKE_CURRENT_BINARY_DIR})
 endif()
 
 target_link_libraries(realm-tests

--- a/tools/build-cocoa.sh
+++ b/tools/build-cocoa.sh
@@ -42,6 +42,7 @@ if [[ ! -z $BUILD ]]; then
                 cmake -D CMAKE_TOOLCHAIN_FILE="../tools/cmake/${p}.toolchain.cmake" \
                       -D CMAKE_BUILD_TYPE="${prefix}${bt}" \
                       -D REALM_VERSION="$(git describe)" \
+                      -D REALM_BUILD_LIB_ONLY=1 \
                       -G Xcode ..
                 cmake --build . --config "${prefix}${bt}" --target package
             )


### PR DESCRIPTION
Only build the library itself and not all the tests etc. Knocks off about 2/3 of the build time on my machine.