### PR TITLE
Use the CPH macOS slaves since the LV ones use a buggy version of CMake

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -363,7 +363,7 @@ def buildPerformance() {
 def doBuildMacOs(String buildType) {
     def sdk = 'macosx'
     return {
-        node('macos || osx_vegas') {
+        node('macos') {
             getArchive()
 
             dir("build-macos-${buildType}") {
@@ -403,7 +403,7 @@ def doBuildMacOs(String buildType) {
 
 def doBuildAppleDevice(String sdk, String buildType) {
     return {
-        node('macos || osx_vegas') {
+        node('macos') {
             getArchive()
 
             withEnv(['DEVELOPER_DIR=/Applications/Xcode-8.2.app/Contents/Developer/']) {


### PR DESCRIPTION
This is just cherry-picking 0b150af3812523aa7db to get the release to build.