### PR TITLE
Fix building for iOS/watchOS/tvOS with build-cocoa

### DIFF
--- a/tools/cmake/tvos.toolchain.cmake
+++ b/tools/cmake/tvos.toolchain.cmake
@@ -8,6 +8,11 @@ set_common_xcode_attributes()
 
 set(REALM_SKIP_SHARED_LIB ON)
 
+# CMake special-cases the compiler detection for iOS in a way that happens
+# to also work for tvOS, so use the iphoneos base SDK to opt-in to that and
+# then override the platform to tvOS below
+set(CMAKE_OSX_SYSROOT "iphoneos")
+
 set(CMAKE_XCODE_ATTRIBUTE_SUPPORTED_PLATFORMS "appletvos appletvsimulator")
 set(CMAKE_XCODE_EFFECTIVE_PLATFORMS "-appletvos;-appletvsimulator")
 set(CMAKE_XCODE_ATTRIBUTE_TVOS_DEPLOYMENT_TARGET "9.0")

--- a/tools/cmake/watchos.toolchain.cmake
+++ b/tools/cmake/watchos.toolchain.cmake
@@ -8,6 +8,11 @@ set_common_xcode_attributes()
 
 set(REALM_SKIP_SHARED_LIB ON)
 
+# CMake special-cases the compiler detection for iOS in a way that happens
+# to also work for watchOS, so use the iphoneos base SDK to opt-in to that and
+# then override the platform to watchOS below
+set(CMAKE_OSX_SYSROOT "iphoneos")
+
 set(CMAKE_XCODE_ATTRIBUTE_SUPPORTED_PLATFORMS "watchos watchsimulator")
 set(CMAKE_XCODE_EFFECTIVE_PLATFORMS "-watchos;-watchsimulator")
 set(CMAKE_XCODE_ATTRIBUTE_WATCHOS_DEPLOYMENT_TARGET "2.0")


### PR DESCRIPTION
cross_compile.sh does additional packaging work which is required to actually produce a working library, so use that from `build-cocoa.sh` as the Jenkinsfile does.