### PR TITLE
Merge master to develop

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,22 +2,7 @@
 
 ### Bugfixes
 
-* Attempting to open a small unencrypted Realm file with an encryption key would
-  produce an empty encrypted Realm file. Fixed by detecting the case and
-  throwing an exception.
-  PR [#2645](https://github.com/realm/realm-core/pull/2645)
-* Querying SharedGroup::wait_for_change() immediately after a commit()
-  would return instead of waiting for the next change.
-  PR [#2563](https://github.com/realm/realm-core/pull/2563).
-* Opening a second SharedGroup may trigger a file format upgrade if the history
-  schema version is non-zero.
-  Fixes issue [#2724](https://github.com/realm/realm-core/issues/2724).
-  PR [#2726](https://github.com/realm/realm-core/pull/2726).
-* Fix incorrect results from TableView::find_first().
-* Fix crash on rollback of Table::optimize(). Currently unused by bindings.
-  PR [#2753](https://github.com/realm/realm-core/pull/2753).
-* Update frozen TableViews when Table::swap() is called.
-  PR [#2757](https://github.com/realm/realm-core/pull/2757).
+* Lorem ipsum.
 
 ### Breaking changes
 
@@ -63,9 +48,6 @@
 * Add more overloads with realm::null - PR [#2669](https://github.com/realm/realm-core/pull/2669)
   - `size_t Table::find_first(size_t col_ndx, null)`
   - `OutputStream& operator<<(OutputStream& os, const null&)`
-* Add method to get total count of backlinks for a row
-  PR [#2672](https://github.com/realm/realm-core/pull/2672).
-* Add try_remove_dir() and try_remove_dir_recursive() functions.
 
 -----------
 
@@ -82,6 +64,43 @@
 * Implemented inter-process CondVars on Windows (Win32 + UWP). They should be
   fair and robust.
   PR [#2497](https://github.com/realm/realm-core/pull/2497).
+* The archives produced by the packaging process for Mac builds are now
+  .tar.gz files rather than .tar.xz files, with the exception of the aggregate
+  realm-core-cocoa-VERSION.tar.xz archive, which remains as a .tar.xz file.
+
+----------------------------------------------
+
+# 2.9.0 Release notes
+
+### Bugfixes
+
+* Attempting to open a small unencrypted Realm file with an encryption key would
+  produce an empty encrypted Realm file. Fixed by detecting the case and
+  throwing an exception.
+  PR [#2645](https://github.com/realm/realm-core/pull/2645)
+* Querying SharedGroup::wait_for_change() immediately after a commit()
+  would return instead of waiting for the next change.
+  PR [#2563](https://github.com/realm/realm-core/pull/2563).
+* Opening a second SharedGroup may trigger a file format upgrade if the history
+  schema version is non-zero.
+  Fixes issue [#2724](https://github.com/realm/realm-core/issues/2724).
+  PR [#2726](https://github.com/realm/realm-core/pull/2726).
+* Fix incorrect results from TableView::find_first().
+* Fix crash on rollback of Table::optimize(). Currently unused by bindings.
+  PR [#2753](https://github.com/realm/realm-core/pull/2753).
+* Update frozen TableViews when Table::swap() is called.
+  PR [#2757](https://github.com/realm/realm-core/pull/2757).
+
+### Enhancements
+
+* Add method to get total count of backlinks for a row.
+  PR [#2672](https://github.com/realm/realm-core/pull/2672).
+* Add try_remove_dir() and try_remove_dir_recursive() functions.
+
+-----------
+
+### Internals
+
 * On Apple platforms, use `os_log` instead of `asl_log` when possible.
   PR [#2722](https://github.com/realm/realm-core/pull/2722).
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -136,7 +136,7 @@ endif()
 install(FILES LICENSE CHANGELOG.md DESTINATION . COMPONENT devel)
 
 if(APPLE)
-    set(CPACK_GENERATOR "TXZ")
+    set(CPACK_GENERATOR "TGZ")
 elseif(ANDROID)
     set(CPACK_GENERATOR "TGZ")
 else()

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -391,10 +391,10 @@ def doBuildMacOs(String buildType) {
                             """)
                 }
             }
-            archiveArtifacts("build-macos-${buildType}/*.tar.xz")
+            archiveArtifacts("build-macos-${buildType}/*.tar.gz")
 
             def stashName = "macos___${buildType}"
-            stash includes:"build-macos-${buildType}/*.tar.xz", name:stashName
+            stash includes:"build-macos-${buildType}/*.tar.gz", name:stashName
             cocoaStashes << stashName
             publishingStashes << stashName
         }
@@ -416,9 +416,9 @@ def doBuildAppleDevice(String sdk, String buildType) {
                     }
                 }
             }
-            archiveArtifacts("build-${sdk}-${buildType}/*.tar.xz")
+            archiveArtifacts("build-${sdk}-${buildType}/*.tar.gz")
             def stashName = "${sdk}___${buildType}"
-            stash includes:"build-${sdk}-${buildType}/*.tar.xz", name:stashName
+            stash includes:"build-${sdk}-${buildType}/*.tar.gz", name:stashName
             cocoaStashes << stashName
             if(gitTag) {
                 publishingStashes << stashName

--- a/tools/build-cocoa.sh
+++ b/tools/build-cocoa.sh
@@ -11,7 +11,7 @@ function usage {
     echo "Arguments:"
     echo "   -b : build from source. If absent it will expect prebuilt packages"
     echo "   -m : build for macOS only"
-    echo "   -c : copy core to the specified folder"
+    echo "   -c : copy core to the specified folder instead of packaging it"
     exit 1;
 }
 
@@ -39,9 +39,12 @@ if [[ ! -z $BUILD ]]; then
             mkdir -p "${folder_name}"
             (
                 cd "${folder_name}" || exit 1
+                rm -f realm-core-*-devel.tar.gz
                 cmake -D CMAKE_TOOLCHAIN_FILE="../tools/cmake/${p}.toolchain.cmake" \
                       -D CMAKE_BUILD_TYPE="${prefix}${bt}" \
                       -D REALM_VERSION="$(git describe)" \
+                      -D REALM_SKIP_SHARED_LIB=ON \
+                      -D REALM_BUILD_LIB_ONLY=ON \
                       -G Xcode ..
                 cmake --build . --config "${prefix}${bt}" --target package
             )
@@ -52,32 +55,33 @@ fi
 rm -rf core
 mkdir core
 
-filename=$(find "build-macos-Release" -maxdepth 1 -type f -name "realm-core-Release-*-Darwin-devel.tar.xz")
-tar -C core -Jxvf "${filename}" include LICENSE CHANGELOG.md
+filename=$(find "build-macos-Release" -maxdepth 1 -type f -name "realm-core-Release-*-Darwin-devel.tar.gz")
+tar -C core -zxvf "${filename}" include LICENSE CHANGELOG.md
 
 for bt in "${BUILD_TYPES[@]}"; do
     [[ "$bt" = "Release" ]] && suffix="" || suffix="-dbg"
     for p in "${PLATFORMS[@]}"; do
         [[ $p = "macos" ]] && infix="macosx" || infix="${p}"
         [[ $p != "macos" && $bt = "Debug" ]] && prefix="MinSize" || prefix=""
-        filename=$(find "build-${p}-${prefix}${bt}" -maxdepth 1 -type f -name "realm-core-*-devel.tar.xz")
+        filename=$(find "build-${p}-${prefix}${bt}" -maxdepth 1 -type f -name "realm-core-*-devel.tar.gz")
         if [[ -z $filename ]]; then
-            filename=$(find "build-${p}-${prefix}${bt}" -maxdepth 1 -type f -name "realm-core-*.tar.xz")
+            filename=$(find "build-${p}-${prefix}${bt}" -maxdepth 1 -type f -name "realm-core-*.tar.gz")
         fi
-        tar -C core -Jxvf "${filename}" "lib/librealm${suffix}.a"
+        tar -C core -zxvf "${filename}" "lib/librealm${suffix}.a"
         mv "core/lib/librealm${suffix}.a" "core/librealm-${infix}${suffix}.a"
         rm -rf core/lib
     done
 done
 
-ln -s core/librealm-macosx.a core/librealm.a
-ln -s core/librealm-macosx-dbg.a core/librealm-dbg.a
+ln -s librealm-macosx.a core/librealm.a
+ln -s librealm-macosx-dbg.a core/librealm-dbg.a
 
 if [[ ! -z $COPY ]]; then
     rm -rf "${DESTINATION}/core"
+    mkdir -p "${DESTINATION}"
     cp -R core "${DESTINATION}"
+else
+    v=$(git describe --tags)
+    rm -f "realm-core-cocoa-${v}.tar.xz"
+    tar -cJvf "realm-core-cocoa-${v}.tar.xz" core
 fi
-
-v=$(git describe --tags)
-rm -f "realm-core-cocoa-${v}.tar.xz"
-tar -cJvf "realm-core-cocoa-${v}.tar.xz" core

--- a/tools/cross_compile.sh
+++ b/tools/cross_compile.sh
@@ -116,6 +116,6 @@ else
     mkdir -p install/lib
     cp "src/realm/${BUILD_TYPE}/librealm${suffix}.a" install/lib
     cd install || exit 1
-    tar -cvJf "realm-core-${BUILD_TYPE}-${VERSION}-${SDK}os.tar.xz" lib include
-    mv ./*.tar.xz ..
+    tar -cvzf "realm-core-${BUILD_TYPE}-${VERSION}-${SDK}os.tar.gz" lib include
+    mv ./*.tar.gz ..
 fi


### PR DESCRIPTION
Fixes conflicts in CHANGELOG.md by creating the 2.9.0 release section as on master. This should allow future commits to master to merge to develop automatically without conflict.

Replaces #2770, #2771, and #2773.