### PR TITLE
Automate Address & Thread sanitization

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -104,18 +104,10 @@ option(REALM_ENABLE_ASSERTIONS "Enable assertions in release mode." OFF)
 option(REALM_ENABLE_ALLOC_SET_ZERO "Zero all allocations." OFF)
 option(REALM_ENABLE_ENCRYPTION "Enable encryption." ON)
 option(REALM_ENABLE_MEMDEBUG "Add additional memory checks" OFF)
-option(REALM_SANITIZE_ADDRESS "Enable the GCC/Clang address sanitizer." OFF)
-option(REALM_SANITIZE_THREAD "Enable the GCC/Clang thread sanitizer." OFF)
 set(REALM_MAX_BPNODE_SIZE "1000" CACHE STRING "Max B+ tree node size.")
 
 if (CMAKE_SYSTEM_NAME MATCHES "^Windows")
 	set(REALM_ENABLE_ENCRYPTION OFF)
-endif()
-
-if(REALM_SANITIZE_THREAD)
-    set(CMAKE_CXX_FLAGS "-fsanitize=thread")
-elseif(REALM_SANITIZE_ADDRESS)
-    set(CMAKE_CXX_FLAGS "-fsanitize=address")
 endif()
 
 check_include_files(malloc.h HAVE_MALLOC_H)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -98,6 +98,7 @@ endif()
 # Find dependencies
 set(THREADS_PREFER_PTHREAD_FLAG ON)
 find_package(Threads REQUIRED)
+list(APPEND PLATFORM_LIBRARIES Threads::Threads)
 
 # Options (passed to CMake)
 option(REALM_ENABLE_ASSERTIONS "Enable assertions in release mode." OFF)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -104,10 +104,18 @@ option(REALM_ENABLE_ASSERTIONS "Enable assertions in release mode." OFF)
 option(REALM_ENABLE_ALLOC_SET_ZERO "Zero all allocations." OFF)
 option(REALM_ENABLE_ENCRYPTION "Enable encryption." ON)
 option(REALM_ENABLE_MEMDEBUG "Add additional memory checks" OFF)
+option(REALM_SANITIZE_ADDRESS "Enable the GCC/Clang address sanitizer." OFF)
+option(REALM_SANITIZE_THREAD "Enable the GCC/Clang thread sanitizer." OFF)
 set(REALM_MAX_BPNODE_SIZE "1000" CACHE STRING "Max B+ tree node size.")
 
 if (CMAKE_SYSTEM_NAME MATCHES "^Windows")
 	set(REALM_ENABLE_ENCRYPTION OFF)
+endif()
+
+if(REALM_SANITIZE_THREAD)
+    set(CMAKE_CXX_FLAGS "-fsanitize=thread")
+elseif(REALM_SANITIZE_ADDRESS)
+    set(CMAKE_CXX_FLAGS "-fsanitize=address")
 endif()
 
 check_include_files(malloc.h HAVE_MALLOC_H)

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -163,10 +163,10 @@ def doBuildInDocker(String buildType, String sanitizeMode) {
             environment << 'UNITTEST_PROGRESS=1'
             if (sanitizeMode.contains('thread')) {
                 environment << 'UNITTEST_THREADS=1'
-                sanitizeFlags = '-D REALM_SANITIZE_THREAD=ON'
+                sanitizeFlags = '-D REALM_TSAN=ON'
             } else if (sanitizeMode.contains('address')) {
                 environment << 'UNITTEST_THREADS=1'
-                sanitizeFlags = '-D REALM_SANITIZE_ADDRESS=ON'
+                sanitizeFlags = '-D REALM_ASAN=ON'
             }
             withEnv(environment) {
                 buildEnv.inside {

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -43,8 +43,8 @@ timeout(time: 5, unit: 'HOURS') {
     }
 
     stage('check') {
-        parallelExecutors = [checkLinuxRelease   : doBuildInDocker('Release', ''),
-                             checkLinuxDebug     : doBuildInDocker('Debug', ''),
+        parallelExecutors = [checkLinuxRelease   : doBuildInDocker('Release'),
+                             checkLinuxDebug     : doBuildInDocker('Debug'),
                              buildMacOsDebug     : doBuildMacOs('Debug'),
                              buildMacOsRelease   : doBuildMacOs('Release'),
                              buildWin32Debug     : doBuildWindows('Debug', false, 'Win32'),
@@ -152,7 +152,7 @@ def buildDockerEnv(name) {
     return docker.image(name)
 }
 
-def doBuildInDocker(String buildType, String sanitizeMode) {
+def doBuildInDocker(String buildType, String sanitizeMode='') {
     return {
         node('docker') {
             getArchive()

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -158,9 +158,9 @@ def doBuildInDocker(String buildType) {
 
             def buildEnv = docker.build 'realm-core:snapshot'
             def environment = environment()
+            environment << 'UNITTEST_PROGRESS=1'
             if (buildType.contains('sanitizer')) {
                 environment << 'UNITTEST_THREADS=1'
-                environment << 'UNITTEST_PROGRESS=1'
             }
             withEnv(environment) {
                 buildEnv.inside {
@@ -193,6 +193,7 @@ def doAndroidBuildInDocker(String abi, String buildType, boolean runTestsInEmula
             def buildDir = "build-${stashName}".replaceAll('___', '-')
             def buildEnv = docker.build('realm-core-android:snapshot', '-f android.Dockerfile .')
             def environment = environment()
+            environment << 'UNITTEST_PROGRESS=1'
             withEnv(environment) {
                 if(!runTestsInEmulator) {
                     buildEnv.inside {
@@ -276,6 +277,7 @@ def buildDiffCoverage() {
 
             def buildEnv = buildDockerEnv('ci/realm-core:snapshot')
             def environment = environment()
+            environment << 'UNITTEST_PROGRESS=1'
             withEnv(environment) {
                 buildEnv.inside {
                     sh '''

--- a/test/fuzz_group.cpp
+++ b/test/fuzz_group.cpp
@@ -207,7 +207,7 @@ Mixed construct_mixed(State& s, util::Optional<std::ostream&> log, std::string& 
         }
         case 5: {
             size_t rand_char = get_next(s);
-            size_t blob_size = get_int64(s) % ArrayBlob::max_binary_size;
+            size_t blob_size = static_cast<uint64_t>(get_int64(s)) % ArrayBlob::max_binary_size;
             buffer = std::string(blob_size, static_cast<unsigned char>(rand_char));
             if (log) {
                 *log << "std::string blob(" << blob_size << ", static_cast<unsigned char>(" << rand_char << "));\n"

--- a/test/test_shared.cpp
+++ b/test/test_shared.cpp
@@ -2414,8 +2414,8 @@ TEST(Shared_EncryptionKeyCheck_3)
 {
     SHARED_GROUP_TEST_PATH(path);
     const char* first_key = crypt_key(true);
-    char second_key[32];
-    memcpy(second_key, first_key, 32);
+    char second_key[64];
+    memcpy(second_key, first_key, 64);
     second_key[3] = ~second_key[3];
     SharedGroup sg(path, false, SharedGroupOptions(first_key));
     bool ok = false;

--- a/test/test_shared.cpp
+++ b/test/test_shared.cpp
@@ -19,6 +19,7 @@
 #include "testsettings.hpp"
 #ifdef TEST_SHARED
 
+#include <condition_variable>
 #include <streambuf>
 #include <fstream>
 #include <tuple>
@@ -593,6 +594,8 @@ TEST(Shared_try_begin_write)
     // Create a new shared db
     SharedGroup sg(path, false, SharedGroupOptions(crypt_key()));
     std::mutex thread_obtains_write_lock;
+    std::condition_variable cv;
+    std::mutex cv_lock;
     bool init_complete = false;
 
     auto do_async = [&]() {
@@ -601,7 +604,11 @@ TEST(Shared_try_begin_write)
         bool success = sg2.try_begin_write(gw);
         CHECK(success);
         CHECK(gw != nullptr);
-        init_complete = true;
+        {
+            std::lock_guard<std::mutex> lock(cv_lock);
+            init_complete = true;
+        }
+        cv.notify_one();
         TableRef t = gw->add_table(StringData("table"));
         t->insert_column(0, type_String, StringData("string_col"));
         t->add_empty_row(1000);
@@ -615,7 +622,8 @@ TEST(Shared_try_begin_write)
     async_writer.start(do_async);
 
     // wait for the thread to start a write transaction
-    while (!init_complete) { millisleep(1); }
+    std::unique_lock<std::mutex> lock(cv_lock);
+    cv.wait(lock, [&]{ return init_complete; });
 
     // Try to also obtain a write lock. This should fail but not block.
     Group* g = nullptr;

--- a/tools/cmake/SpecialtyBuilds.cmake
+++ b/tools/cmake/SpecialtyBuilds.cmake
@@ -44,7 +44,6 @@ if(REALM_ASAN)
                 "The Address Sanitizer is not yet supported on Visual Studio builds")
     else()
         set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -fsanitize=address -O1 -g")
-        set(CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS} -fsanitize=address")
     endif()
 endif()
 
@@ -58,7 +57,6 @@ if(REALM_TSAN)
                 "The Thread Sanitizer is not yet supported on Visual Studio builds")
     else()
         set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -fsanitize=thread -O2 -g -fPIE")
-        set(CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS} -fsanitize=thread")
         # According to the clang docs, if -fsanitize=thread is specified then compiling
         # and linking with PIE is turned on automatically.
         if (CMAKE_COMPILER_IS_GNUXX)

--- a/tools/cmake/SpecialtyBuilds.cmake
+++ b/tools/cmake/SpecialtyBuilds.cmake
@@ -43,7 +43,7 @@ if(REALM_ASAN)
         message(FATAL_ERROR
                 "The Address Sanitizer is not yet supported on Visual Studio builds")
     else()
-        set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -fsanitize=address -fno-omit-frame-pointern -O1 -g")
+        set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -fsanitize=address -fno-omit-frame-pointer -O1 -g")
         set(CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS} -fsanitize=address")
     endif()
 endif()
@@ -57,8 +57,13 @@ if(REALM_TSAN)
         message(FATAL_ERROR
                 "The Thread Sanitizer is not yet supported on Visual Studio builds")
     else()
-        set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -fsanitize=thread -fno-omit-frame-pointer -O2 -g -fPIE -pie")
+        set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -fsanitize=thread -fno-omit-frame-pointer -O2 -g -fPIE")
         set(CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS} -fsanitize=thread")
+        # According to the clang docs, if -fsanitize=thread is specified then compiling
+        # and linking with PIE is turned on automatically.
+        if (CMAKE_COMPILER_IS_GNUXX)
+            set(CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS} -pie")
+        endif()
     endif()
 endif()
 

--- a/tools/cmake/SpecialtyBuilds.cmake
+++ b/tools/cmake/SpecialtyBuilds.cmake
@@ -43,7 +43,7 @@ if(REALM_ASAN)
         message(FATAL_ERROR
                 "The Address Sanitizer is not yet supported on Visual Studio builds")
     else()
-        set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -fsanitize=address -fno-omit-frame-pointer -O1 -g")
+        set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -fsanitize=address -O1 -g")
         set(CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS} -fsanitize=address")
     endif()
 endif()
@@ -57,7 +57,7 @@ if(REALM_TSAN)
         message(FATAL_ERROR
                 "The Thread Sanitizer is not yet supported on Visual Studio builds")
     else()
-        set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -fsanitize=thread -fno-omit-frame-pointer -O2 -g -fPIE")
+        set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -fsanitize=thread -O2 -g -fPIE")
         set(CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS} -fsanitize=thread")
         # According to the clang docs, if -fsanitize=thread is specified then compiling
         # and linking with PIE is turned on automatically.


### PR DESCRIPTION
- Add support for building with thread and address sanitizers via cmake
- Automate these build modes so CI will run them for each PR
- Fix several errors/races in unit tests reported in these modes
- Track which unit tests are run by enabling `UNITTEST_PROGRESS` when testing