### PR TITLE
Add overload.hpp and test back into CMakeLists

### DIFF
--- a/src/realm/CMakeLists.txt
+++ b/src/realm/CMakeLists.txt
@@ -161,6 +161,7 @@ set(REALM_INSTALL_UTIL_HEADERS
     util/misc_errors.hpp
     util/miscellaneous.hpp
     util/optional.hpp
+    util/overload.hpp
     util/priority_queue.hpp
     util/safe_int_ops.hpp
     util/scope_exit.hpp

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -55,6 +55,7 @@ set(NORMAL_TESTS
     test_util_inspect.cpp
     test_util_logger.cpp
     test_util_memory_stream.cpp
+    test_util_overload.cpp
     test_util_scope_exit.cpp
     test_util_stringbuffer.cpp
     test_util_to_string.cpp


### PR DESCRIPTION
Not sure if I set up this PR correctly, or who I should add, but I did make sure the test suite builds and runs the overload test correctly.