### PR TITLE
Add the old table size to ClearTable instructions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@
   on a descriptor and not a table.
   PR [#2561](https://github.com/realm/realm-core/pull/2561).
 * New replication instruction: instr_AddRowWithKey
+* Add the old table size to the instr_TableClear replication instruction.
 
 ### Enhancements
 

--- a/src/realm/group.cpp
+++ b/src/realm/group.cpp
@@ -1390,7 +1390,7 @@ public:
         return true;
     }
 
-    bool clear_table() noexcept
+    bool clear_table(size_t) noexcept
     {
         typedef _impl::TableFriend tf;
         if (m_table)

--- a/src/realm/impl/transact_log.hpp
+++ b/src/realm/impl/transact_log.hpp
@@ -518,7 +518,7 @@ public:
     virtual void add_search_index(const Descriptor&, size_t col_ndx);
     virtual void remove_search_index(const Descriptor&, size_t col_ndx);
     virtual void set_link_type(const Table*, size_t col_ndx, LinkType);
-    virtual void clear_table(const Table*);
+    virtual void clear_table(const Table*, size_t prior_num_rows);
     virtual void optimize_table(const Table*);
 
     virtual void link_list_set(const LinkView&, size_t link_ndx, size_t value);
@@ -1568,10 +1568,10 @@ inline bool TransactLogEncoder::clear_table(size_t old_size)
     return true;
 }
 
-inline void TransactLogConvenientEncoder::clear_table(const Table* t)
+inline void TransactLogConvenientEncoder::clear_table(const Table* t, size_t prior_num_rows)
 {
     select_table(t);         // Throws
-    m_encoder.clear_table(t->size()); // Throws
+    m_encoder.clear_table(prior_num_rows); // Throws
 }
 
 inline bool TransactLogEncoder::optimize_table()

--- a/src/realm/impl/transact_log.hpp
+++ b/src/realm/impl/transact_log.hpp
@@ -173,7 +173,7 @@ public:
     {
         return true;
     }
-    bool clear_table()
+    bool clear_table(size_t)
     {
         return true;
     }
@@ -343,7 +343,7 @@ public:
     bool erase_rows(size_t row_ndx, size_t num_rows_to_erase, size_t prior_num_rows, bool unordered);
     bool swap_rows(size_t row_ndx_1, size_t row_ndx_2);
     bool merge_rows(size_t row_ndx, size_t new_row_ndx);
-    bool clear_table();
+    bool clear_table(size_t old_table_size);
 
     bool set_int(size_t col_ndx, size_t row_ndx, int_fast64_t, Instruction = instr_Set, size_t = 0);
     bool add_int(size_t col_ndx, size_t row_ndx, int_fast64_t);
@@ -1562,16 +1562,16 @@ inline void TransactLogConvenientEncoder::set_link_type(const Table* t, size_t c
 }
 
 
-inline bool TransactLogEncoder::clear_table()
+inline bool TransactLogEncoder::clear_table(size_t old_size)
 {
-    append_simple_instr(instr_ClearTable); // Throws
+    append_simple_instr(instr_ClearTable, old_size); // Throws
     return true;
 }
 
 inline void TransactLogConvenientEncoder::clear_table(const Table* t)
 {
     select_table(t);         // Throws
-    m_encoder.clear_table(); // Throws
+    m_encoder.clear_table(t->size()); // Throws
 }
 
 inline bool TransactLogEncoder::optimize_table()
@@ -1941,7 +1941,8 @@ void TransactLogParser::parse_one(InstructionHandler& handler)
             return;
         }
         case instr_ClearTable: {
-            if (!handler.clear_table()) // Throws
+            size_t old_size = read_int<size_t>();   // Throws
+            if (!handler.clear_table(old_size)) // Throws
                 parser_error();
             return;
         }
@@ -2586,10 +2587,10 @@ public:
         return true; // No-op
     }
 
-    bool clear_table()
+    bool clear_table(size_t old_size)
     {
-        // FIXME: Add a comment on why we call insert_empty_rows() inside clear_table()
-        m_encoder.insert_empty_rows(0, 0, 0, true);
+        bool unordered = false;
+        m_encoder.insert_empty_rows(0, old_size, 0, unordered);
         append_instruction();
         return true;
     }

--- a/src/realm/replication.cpp
+++ b/src/realm/replication.cpp
@@ -365,7 +365,7 @@ public:
         return true;
     }
 
-    bool clear_table()
+    bool clear_table(size_t)
     {
         if (REALM_LIKELY(REALM_COVER_ALWAYS(m_table && m_table->is_attached()))) {
             log("table->clear();"); // Throws

--- a/src/realm/table.cpp
+++ b/src/realm/table.cpp
@@ -2593,8 +2593,7 @@ void Table::clear()
     if (REALM_UNLIKELY(!is_attached()))
         throw LogicError(LogicError::detached_accessor);
 
-    if (Replication* repl = get_repl())
-        repl->clear_table(this); // Throws
+    size_t old_size = m_size;
 
     size_t table_ndx = get_index_in_group();
     if (table_ndx == realm::npos) {
@@ -2618,6 +2617,9 @@ void Table::clear()
 
         remove_backlink_broken_rows(state); // Throws
     }
+
+    if (Replication* repl = get_repl())
+        repl->clear_table(this, old_size); // Throws
 }
 
 

--- a/src/realm/table.cpp
+++ b/src/realm/table.cpp
@@ -2593,6 +2593,9 @@ void Table::clear()
     if (REALM_UNLIKELY(!is_attached()))
         throw LogicError(LogicError::detached_accessor);
 
+    if (Replication* repl = get_repl())
+        repl->clear_table(this); // Throws
+
     size_t table_ndx = get_index_in_group();
     if (table_ndx == realm::npos) {
         bool broken_reciprocal_backlinks = false;
@@ -2615,9 +2618,6 @@ void Table::clear()
 
         remove_backlink_broken_rows(state); // Throws
     }
-
-    if (Replication* repl = get_repl())
-        repl->clear_table(this); // Throws
 }
 
 

--- a/test/test_lang_bind_helper.cpp
+++ b/test/test_lang_bind_helper.cpp
@@ -7772,7 +7772,7 @@ public:
     {
         return false;
     }
-    bool clear_table() noexcept
+    bool clear_table(size_t) noexcept
     {
         return false;
     }


### PR DESCRIPTION
As with the old size in LinkListClear, this is needed only so that rolling back the clear can produce an insertion with the correct number of rows rather than zero, which is required for producing notifications for rollbacks.

The sync implications of this should be simple, as the similar case of clearing a LinkList is already handled, but if producing a correct value here is actually a problem then that's not the end of the world (it would allow removing some current hacks working around the lack of the size in the clear instruction in the non-rollback case).