### PR TITLE
Print stacktraces before the end of the job in order to give a chance to the BFA plugin

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -6,141 +6,147 @@ cocoaStashes = []
 androidStashes = []
 publishingStashes = []
 
-timeout(time: 5, unit: 'HOURS') {
-    stage('gather-info') {
-        node('docker') {
-            getSourceArchive()
-            stash includes: '**', name: 'core-source', useDefaultExcludes: false
+try {
+  timeout(time: 5, unit: 'HOURS') {
+      stage('gather-info') {
+          node('docker') {
+              getSourceArchive()
+              stash includes: '**', name: 'core-source', useDefaultExcludes: false
 
-            dependencies = readProperties file: 'dependencies.list'
-            echo "Version in dependencies.list: ${dependencies.VERSION}"
+              dependencies = readProperties file: 'dependencies.list'
+              echo "Version in dependencies.list: ${dependencies.VERSION}"
 
-            gitTag = readGitTag()
-            gitSha = sh(returnStdout: true, script: 'git rev-parse HEAD').trim().take(8)
-            gitDescribeVersion = sh(returnStdout: true, script: 'git describe --tags').trim()
+              gitTag = readGitTag()
+              gitSha = sh(returnStdout: true, script: 'git rev-parse HEAD').trim().take(8)
+              gitDescribeVersion = sh(returnStdout: true, script: 'git describe --tags').trim()
 
-            echo "Git tag: ${gitTag ?: 'none'}"
-            if (!gitTag) {
-                echo "No tag given for this build"
-                setBuildName(gitSha)
-            } else {
-                if (gitTag != "v${dependencies.VERSION}") {
-                    error "Git tag '${gitTag}' does not match v${dependencies.VERSION}"
-                } else {
-                    echo "Building release: '${gitTag}'"
-                    setBuildName("Tag ${gitTag}")
-                }
-            }
-        }
+              echo "Git tag: ${gitTag ?: 'none'}"
+              if (!gitTag) {
+                  echo "No tag given for this build"
+                  setBuildName(gitSha)
+              } else {
+                  if (gitTag != "v${dependencies.VERSION}") {
+                      error "Git tag '${gitTag}' does not match v${dependencies.VERSION}"
+                  } else {
+                      echo "Building release: '${gitTag}'"
+                      setBuildName("Tag ${gitTag}")
+                  }
+              }
+          }
 
-        echo "Publishing Run: ${gitTag ? 'yes' : 'no'}"
+          echo "Publishing Run: ${gitTag ? 'yes' : 'no'}"
 
-        if (['master'].contains(env.BRANCH_NAME)) {
-            // If we're on master, instruct the docker image builds to push to the
-            // cache registry
-            env.DOCKER_PUSH = "1"
-        }
-    }
+          if (['master'].contains(env.BRANCH_NAME)) {
+              // If we're on master, instruct the docker image builds to push to the
+              // cache registry
+              env.DOCKER_PUSH = "1"
+          }
+      }
 
-    stage('check') {
-        parallelExecutors = [checkLinuxRelease   : doBuildInDocker('Release'),
-                             checkLinuxDebug     : doBuildInDocker('Debug'),
-                             buildMacOsDebug     : doBuildMacOs('Debug'),
-                             buildMacOsRelease   : doBuildMacOs('Release'),
-                             buildWin32Debug     : doBuildWindows('Debug', false, 'Win32'),
-                             buildWin32Release   : doBuildWindows('Release', false, 'Win32'),
-                             buildWin64Debug     : doBuildWindows('Debug', false, 'x64'),
-                             buildWin64Release   : doBuildWindows('Release', false, 'x64'),
-                             buildUwpWin32Debug  : doBuildWindows('Debug', true, 'Win32'),
-                             buildUwpWin32Release: doBuildWindows('Release', true, 'Win32'),
-                             buildUwpx64Debug    : doBuildWindows('Debug', true, 'x64'),
-                             buildUwpx64Release  : doBuildWindows('Release', true, 'x64'),
-                             buildUwpArmDebug    : doBuildWindows('Debug', true, 'ARM'),
-                             buildUwpArmRelease  : doBuildWindows('Release', true, 'ARM'),
-                             packageGeneric      : doBuildPackage('generic', 'tgz'),
-                             packageCentos7      : doBuildPackage('centos-7', 'rpm'),
-                             packageCentos6      : doBuildPackage('centos-6', 'rpm'),
-                             packageUbuntu1604   : doBuildPackage('ubuntu-1604', 'deb'),
-                             threadSanitizer     : doBuildInDocker('Debug', 'thread'),
-                             addressSanitizer    : doBuildInDocker('Debug', 'address')
-            ]
+      stage('check') {
+          throw IllegalStateException("This is just a test!")
+          parallelExecutors = [checkLinuxRelease   : doBuildInDocker('Release'),
+                               checkLinuxDebug     : doBuildInDocker('Debug'),
+                               buildMacOsDebug     : doBuildMacOs('Debug'),
+                               buildMacOsRelease   : doBuildMacOs('Release'),
+                               buildWin32Debug     : doBuildWindows('Debug', false, 'Win32'),
+                               buildWin32Release   : doBuildWindows('Release', false, 'Win32'),
+                               buildWin64Debug     : doBuildWindows('Debug', false, 'x64'),
+                               buildWin64Release   : doBuildWindows('Release', false, 'x64'),
+                               buildUwpWin32Debug  : doBuildWindows('Debug', true, 'Win32'),
+                               buildUwpWin32Release: doBuildWindows('Release', true, 'Win32'),
+                               buildUwpx64Debug    : doBuildWindows('Debug', true, 'x64'),
+                               buildUwpx64Release  : doBuildWindows('Release', true, 'x64'),
+                               buildUwpArmDebug    : doBuildWindows('Debug', true, 'ARM'),
+                               buildUwpArmRelease  : doBuildWindows('Release', true, 'ARM'),
+                               packageGeneric      : doBuildPackage('generic', 'tgz'),
+                               packageCentos7      : doBuildPackage('centos-7', 'rpm'),
+                               packageCentos6      : doBuildPackage('centos-6', 'rpm'),
+                               packageUbuntu1604   : doBuildPackage('ubuntu-1604', 'deb'),
+                               threadSanitizer     : doBuildInDocker('Debug', 'thread'),
+                               addressSanitizer    : doBuildInDocker('Debug', 'address')
+              ]
 
-        androidAbis = ['armeabi-v7a', 'x86', 'mips', 'x86_64', 'arm64-v8a']
-        androidBuildTypes = ['Debug', 'Release']
+          androidAbis = ['armeabi-v7a', 'x86', 'mips', 'x86_64', 'arm64-v8a']
+          androidBuildTypes = ['Debug', 'Release']
 
-        for (def i = 0; i < androidAbis.size(); i++) {
-            def abi = androidAbis[i]
-            for (def j = 0; j < androidBuildTypes.size(); j++) {
-                def buildType = androidBuildTypes[j]
-                parallelExecutors["android-${abi}-${buildType}"] = doAndroidBuildInDocker(abi, buildType, abi == 'armeabi-v7a' && buildType == 'Release')
-            }
-        }
+          for (def i = 0; i < androidAbis.size(); i++) {
+              def abi = androidAbis[i]
+              for (def j = 0; j < androidBuildTypes.size(); j++) {
+                  def buildType = androidBuildTypes[j]
+                  parallelExecutors["android-${abi}-${buildType}"] = doAndroidBuildInDocker(abi, buildType, abi == 'armeabi-v7a' && buildType == 'Release')
+              }
+          }
 
-        appleSdks = ['ios', 'tvos', 'watchos']
-        appleBuildTypes = ['MinSizeDebug', 'Release']
+          appleSdks = ['ios', 'tvos', 'watchos']
+          appleBuildTypes = ['MinSizeDebug', 'Release']
 
-        for (def i = 0; i < appleSdks.size(); i++) {
-            def sdk = appleSdks[i]
-            for (def j = 0; j < appleBuildTypes.size(); j++) {
-                def buildType = appleBuildTypes[j]
-                parallelExecutors["${sdk}${buildType}"] = doBuildAppleDevice(sdk, buildType)
-            }
-        }
+          for (def i = 0; i < appleSdks.size(); i++) {
+              def sdk = appleSdks[i]
+              for (def j = 0; j < appleBuildTypes.size(); j++) {
+                  def buildType = appleBuildTypes[j]
+                  parallelExecutors["${sdk}${buildType}"] = doBuildAppleDevice(sdk, buildType)
+              }
+          }
 
-        if (env.CHANGE_TARGET) {
-            parallelExecutors['diffCoverage'] = buildDiffCoverage()
-            parallelExecutors['performance'] = buildPerformance()
-        }
+          if (env.CHANGE_TARGET) {
+              parallelExecutors['diffCoverage'] = buildDiffCoverage()
+              parallelExecutors['performance'] = buildPerformance()
+          }
 
-        parallel parallelExecutors
-    }
+          parallel parallelExecutors
+      }
 
-    stage('Aggregate') {
-        parallel (
-          cocoa: {
-                node('docker') {
-                    getArchive()
-                    for (int i = 0; i < cocoaStashes.size(); i++) {
-                        unstash name:cocoaStashes[i]
-                    }
-                    sh 'tools/build-cocoa.sh'
-                    archiveArtifacts('realm-core-cocoa*.tar.xz')
-                    if(gitTag) {
-                        def stashName = 'cocoa'
-                        stash includes: 'realm-core-cocoa*.tar.xz', name: stashName
-                        publishingStashes << stashName
-                    }
-                }
-            },
-          android: {
-                node('docker') {
-                    getArchive()
-                    for (int i = 0; i < androidStashes.size(); i++) {
-                        unstash name:androidStashes[i]
-                    }
-                    sh 'tools/build-android.sh'
-                    archiveArtifacts('realm-core-android*.tar.gz')
-                    if(gitTag) {
-                        def stashName = 'android'
-                        stash includes: 'realm-core-android*.tar.gz', name: stashName
-                        publishingStashes << stashName
-                    }
-                }
-            }
-        )
-    }
+      stage('Aggregate') {
+          parallel (
+            cocoa: {
+                  node('docker') {
+                      getArchive()
+                      for (int i = 0; i < cocoaStashes.size(); i++) {
+                          unstash name:cocoaStashes[i]
+                      }
+                      sh 'tools/build-cocoa.sh'
+                      archiveArtifacts('realm-core-cocoa*.tar.xz')
+                      if(gitTag) {
+                          def stashName = 'cocoa'
+                          stash includes: 'realm-core-cocoa*.tar.xz', name: stashName
+                          publishingStashes << stashName
+                      }
+                  }
+              },
+            android: {
+                  node('docker') {
+                      getArchive()
+                      for (int i = 0; i < androidStashes.size(); i++) {
+                          unstash name:androidStashes[i]
+                      }
+                      sh 'tools/build-android.sh'
+                      archiveArtifacts('realm-core-android*.tar.gz')
+                      if(gitTag) {
+                          def stashName = 'android'
+                          stash includes: 'realm-core-android*.tar.gz', name: stashName
+                          publishingStashes << stashName
+                      }
+                  }
+              }
+          )
+      }
 
-    if (gitTag) {
-        stage('publish-packages') {
-            parallel(
-                generic: doPublishGeneric(),
-                centos7: doPublish('centos-7', 'rpm', 'el', 7),
-                centos6: doPublish('centos-6', 'rpm', 'el', 6),
-                ubuntu1604: doPublish('ubuntu-1604', 'deb', 'ubuntu', 'xenial'),
-                others: doPublishLocalArtifacts()
-            )
-        }
-    }
+      if (gitTag) {
+          stage('publish-packages') {
+              parallel(
+                  generic: doPublishGeneric(),
+                  centos7: doPublish('centos-7', 'rpm', 'el', 7),
+                  centos6: doPublish('centos-6', 'rpm', 'el', 6),
+                  ubuntu1604: doPublish('ubuntu-1604', 'deb', 'ubuntu', 'xenial'),
+                  others: doPublishLocalArtifacts()
+              )
+          }
+      }
+  }
+} catch (Exception all) {
+  all.printStackTrace()
+  throw all
 }
 
 def buildDockerEnv(name) {

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -44,7 +44,7 @@ try {
       }
 
       stage('check') {
-          throw IllegalStateException("This is just a test!")
+          throw new IllegalStateException("This is just a test!")
           parallelExecutors = [checkLinuxRelease   : doBuildInDocker('Release'),
                                checkLinuxDebug     : doBuildInDocker('Debug'),
                                buildMacOsDebug     : doBuildMacOs('Debug'),

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -145,7 +145,11 @@ try {
       }
   }
 } catch (Exception all) {
-  all.printStackTrace()
+  ByteArrayOutputStream baos = new ByteArrayOutputStream()
+  PrintStream ps = new PrintStream(baos)
+  all.printStackTrace(ps)
+  String content = new String(baos.toByteArray(), StandardCharsets.UTF_8)
+  echo content
   throw all
 }
 

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -44,7 +44,6 @@ jobWrapper {
       }
 
       stage('check') {
-          throw new IllegalStateException("This is just a test!")
           parallelExecutors = [checkLinuxRelease   : doBuildInDocker('Release'),
                                checkLinuxDebug     : doBuildInDocker('Debug'),
                                buildMacOsDebug     : doBuildMacOs('Debug'),

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -6,7 +6,7 @@ cocoaStashes = []
 androidStashes = []
 publishingStashes = []
 
-try {
+jobWrapper {
   timeout(time: 5, unit: 'HOURS') {
       stage('gather-info') {
           node('docker') {
@@ -144,13 +144,6 @@ try {
           }
       }
   }
-} catch (Exception all) {
-  ByteArrayOutputStream baos = new ByteArrayOutputStream()
-  PrintStream ps = new PrintStream(baos)
-  all.printStackTrace(ps)
-  String content = new String(baos.toByteArray(), StandardCharsets.UTF_8)
-  echo content
-  throw all
 }
 
 def buildDockerEnv(name) {


### PR DESCRIPTION
This PR adds a `jobWrapper` step around the whole job, which will allow to print stacktraces before the build failure analyzer is executed. `jobWrapper` defined in the `ci` repo, in order to make it usable in other repos.