### PR TITLE
Throw an exception instead of overflowing large refs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,9 @@
   PR [#2561](https://github.com/realm/realm-core/pull/2561).
 * New replication instruction: instr_AddRowWithKey
 * Add the old table size to the instr_TableClear replication instruction.
+* Throw a MaxAddressBreached exception in some places instead of wrapping around.
+  This would mostly affect large Realm files on 32 bit OS.
+  PR [#2792](https://github.com/realm/realm-core/pull/2792).
 
 ### Enhancements
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,9 +21,10 @@
   PR [#2561](https://github.com/realm/realm-core/pull/2561).
 * New replication instruction: instr_AddRowWithKey
 * Add the old table size to the instr_TableClear replication instruction.
-* Throw a MaxAddressBreached exception in some places instead of wrapping around.
-  This would mostly affect large Realm files on 32 bit OS.
-  PR [#2792](https://github.com/realm/realm-core/pull/2792).
+* Throw a MaximumFileSizeExceeded exception during commits or allocations
+  instead of causing corruption or asserting. This would most likely be
+  seen when creating large Realm files on 32 bit OS.
+  PR [#2795](https://github.com/realm/realm-core/pull/2795).
 
 ### Enhancements
 

--- a/src/realm/alloc_slab.cpp
+++ b/src/realm/alloc_slab.cpp
@@ -90,10 +90,13 @@ SlabAlloc::SlabAlloc()
     m_section_shifts = log2(m_initial_section_size);
     size_t max = std::numeric_limits<size_t>::max();
     m_num_section_bases = 1 + get_section_index(max);
-    m_section_bases.reset(new size_t[m_num_section_bases]);
+    // Allocate one more element than necessary, this is so that get_upper_section_boundary() still functions
+    // as expected on addresses in the last working base.
+    m_section_bases.reset(new size_t[m_num_section_bases + 1]);
     for (size_t i = 0; i < m_num_section_bases; ++i) {
         m_section_bases[i] = compute_section_base(i);
     }
+    m_section_bases[m_num_section_bases] = max;
 }
 
 util::File& SlabAlloc::get_file()

--- a/src/realm/alloc_slab.hpp
+++ b/src/realm/alloc_slab.hpp
@@ -300,6 +300,36 @@ protected:
     void do_free(ref_type, const char*) noexcept override;
     char* do_translate(ref_type) const noexcept override;
 
+    /// Returns the first section boundary *above* the given position.
+    size_t get_upper_section_boundary(size_t start_pos) const noexcept;
+
+    /// Returns the first section boundary *at or below* the given position.
+    size_t get_lower_section_boundary(size_t start_pos) const noexcept;
+
+    /// Returns true if the given position is at a section boundary
+    bool matches_section_boundary(size_t pos) const noexcept;
+
+    /// Returns the index of the section holding a given address.
+    /// The section index is determined solely by the minimal section size,
+    /// and does not necessarily reflect the mapping. A mapping may
+    /// cover multiple sections - the initial mapping often does.
+    size_t get_section_index(size_t pos) const noexcept;
+
+    /// Reverse: get the base offset of a section at a given index. Since the
+    /// computation is very time critical, this method just looks it up in
+    /// a table. The actual computation and setup of that table is done
+    /// during initialization with the help of compute_section_base() below.
+    inline size_t get_section_base(size_t index) const noexcept;
+
+    /// Actually compute the starting offset of a section. Only used to initialize
+    /// a table of predefined results, which are then used by get_section_base().
+    size_t compute_section_base(size_t index) const noexcept;
+
+    /// Find a possible allocation of 'request_size' that will fit into a section
+    /// which is inside the range from 'start_pos' to 'start_pos'+'free_chunk_size'
+    /// If found return the position, if not return 0.
+    size_t find_section_in_range(size_t start_pos, size_t free_chunk_size, size_t request_size) const noexcept;
+
 private:
     void internal_invalidate_cache() noexcept;
     enum AttachMode {
@@ -432,36 +462,6 @@ private:
     {
         m_replication = r;
     }
-
-    /// Returns the first section boundary *above* the given position.
-    size_t get_upper_section_boundary(size_t start_pos) const noexcept;
-
-    /// Returns the first section boundary *at or below* the given position.
-    size_t get_lower_section_boundary(size_t start_pos) const noexcept;
-
-    /// Returns true if the given position is at a section boundary
-    bool matches_section_boundary(size_t pos) const noexcept;
-
-    /// Returns the index of the section holding a given address.
-    /// The section index is determined solely by the minimal section size,
-    /// and does not necessarily reflect the mapping. A mapping may
-    /// cover multiple sections - the initial mapping often does.
-    size_t get_section_index(size_t pos) const noexcept;
-
-    /// Reverse: get the base offset of a section at a given index. Since the
-    /// computation is very time critical, this method just looks it up in
-    /// a table. The actual computation and setup of that table is done
-    /// during initialization with the help of compute_section_base() below.
-    inline size_t get_section_base(size_t index) const noexcept;
-
-    /// Actually compute the starting offset of a section. Only used to initialize
-    /// a table of predefined results, which are then used by get_section_base().
-    size_t compute_section_base(size_t index) const noexcept;
-
-    /// Find a possible allocation of 'request_size' that will fit into a section
-    /// which is inside the range from 'start_pos' to 'start_pos'+'free_chunk_size'
-    /// If found return the position, if not return 0.
-    size_t find_section_in_range(size_t start_pos, size_t free_chunk_size, size_t request_size) const noexcept;
 
     friend class Group;
     friend class SharedGroup;

--- a/src/realm/exceptions.hpp
+++ b/src/realm/exceptions.hpp
@@ -86,9 +86,9 @@ public:
 };
 
 /// Thrown when creating references that are too large to be contained in our ref_type (size_t)
-class MaxAddressBreached : public std::runtime_error {
+class MaximumFileSizeExceeded : public std::runtime_error {
 public:
-    MaxAddressBreached(const std::string& msg);
+    MaximumFileSizeExceeded(const std::string& msg);
     /// runtime_error::what() returns the msg provided in the constructor.
 };
 
@@ -272,7 +272,7 @@ inline AddressSpaceExhausted::AddressSpaceExhausted(const std::string& msg)
 {
 }
 
-inline MaxAddressBreached::MaxAddressBreached(const std::string& msg)
+inline MaximumFileSizeExceeded::MaximumFileSizeExceeded(const std::string& msg)
     : std::runtime_error(msg)
 {
 }

--- a/src/realm/exceptions.hpp
+++ b/src/realm/exceptions.hpp
@@ -85,6 +85,13 @@ public:
     /// runtime_error::what() returns the msg provided in the constructor.
 };
 
+/// Thrown when creating references that are too large to be contained in our ref_type (size_t)
+class MaxAddressBreached : public std::runtime_error {
+public:
+    MaxAddressBreached(const std::string& msg);
+    /// runtime_error::what() returns the msg provided in the constructor.
+};
+
 
 /// The \c LogicError exception class is intended to be thrown only when
 /// applications (or bindings) violate rules that are stated (or ought to have
@@ -261,6 +268,11 @@ inline const char* MultipleSyncAgents::what() const noexcept
 // LCOV_EXCL_STOP
 
 inline AddressSpaceExhausted::AddressSpaceExhausted(const std::string& msg)
+    : std::runtime_error(msg)
+{
+}
+
+inline MaxAddressBreached::MaxAddressBreached(const std::string& msg)
     : std::runtime_error(msg)
 {
 }

--- a/src/realm/group_writer.cpp
+++ b/src/realm/group_writer.cpp
@@ -689,8 +689,8 @@ std::pair<size_t, size_t> GroupWriter::extend_free_space(size_t requested_size)
     size_t logical_file_size = to_size_t(m_group.m_top.get(2) / 2);
     size_t new_file_size = logical_file_size;
     if (REALM_UNLIKELY(int_add_with_overflow_detect(new_file_size, requested_size))) {
-        throw MaxAddressBreached("GroupWriter cannot extend free space: " + util::to_string(logical_file_size) + " + "
-                                 + util::to_string(requested_size));
+        throw MaximumFileSizeExceeded("GroupWriter cannot extend free space: " + util::to_string(logical_file_size)
+                                      + " + " + util::to_string(requested_size));
     }
 
     if (!alloc.matches_section_boundary(new_file_size)) {

--- a/test/test_alloc.cpp
+++ b/test/test_alloc.cpp
@@ -305,6 +305,62 @@ TEST(Alloc_Fuzzy)
     }
 }
 
+namespace {
+
+class TestSlabAlloc : public SlabAlloc
+{
+
+public:
+    size_t test_get_upper_section_boundary(size_t start_pos)
+    {
+        return get_upper_section_boundary(start_pos);
+    }
+    size_t test_get_lower_section_boundary(size_t start_pos)
+    {
+        return get_lower_section_boundary(start_pos);
+    }
+    size_t test_get_section_base(size_t index)
+    {
+        return get_section_base(index);
+    }
+    size_t test_get_section_index(size_t ref) {
+        return get_section_index(ref);
+    }
+};
+
+} // end anonymous namespace
+
+
+ONLY(Alloc_MaxSectionBoundaryOverflow)
+{
+    TestSlabAlloc alloc;
+
+    size_t first_bound_lower = alloc.test_get_lower_section_boundary(0);
+    size_t first_bound_upper = alloc.test_get_upper_section_boundary(0);
+    CHECK_EQUAL(first_bound_lower, 0);
+    CHECK_EQUAL(alloc.test_get_lower_section_boundary(1), first_bound_lower);
+    CHECK_LESS(first_bound_lower, first_bound_upper);
+
+    size_t max = std::numeric_limits<size_t>::max();
+
+    size_t last_1_bound_lower = alloc.test_get_lower_section_boundary(max - 1);
+    size_t last_1_bound_upper = alloc.test_get_upper_section_boundary(max - 1);
+    CHECK_LESS(last_1_bound_lower, last_1_bound_upper);
+
+    size_t last_bound_lower = alloc.test_get_lower_section_boundary(max);
+    size_t last_bound_upper = alloc.test_get_upper_section_boundary(max);
+    CHECK_LESS(last_bound_lower, last_bound_upper);
+
+    size_t max_index = alloc.test_get_section_index(max);
+    for (size_t i = 0; i <= max_index; ++i) {
+        size_t lowest_ref_in_section = alloc.test_get_section_base(i);
+        size_t lower_boundary = alloc.test_get_lower_section_boundary(lowest_ref_in_section);
+        size_t upper_boundary = alloc.test_get_upper_section_boundary(lowest_ref_in_section);
+        CHECK_EQUAL(lowest_ref_in_section, lower_boundary);
+        CHECK_LESS(lower_boundary, upper_boundary);
+    }
+}
+
 
 // This test reproduces the sporadic issue that was seen for large refs (addresses)
 // on 32-bit iPhone 5 Simulator runs on certain host machines.

--- a/test/test_alloc.cpp
+++ b/test/test_alloc.cpp
@@ -331,7 +331,7 @@ public:
 } // end anonymous namespace
 
 
-ONLY(Alloc_MaxSectionBoundaryOverflow)
+TEST(Alloc_MaxSectionBoundaryOverflow)
 {
     TestSlabAlloc alloc;
 


### PR DESCRIPTION
If approved, this will replace #2791. 
It checks the point of addition for overflow in a `size_t` or `ref_type` during allocation and throws a new exception instead of wrapping the addresses.
I added some debug prints to the existing assertions that we have reports of to help us understand what is going on if they aren't stopped by this.

Related to #2723.