### PR TITLE
Fix encrypted unit test when running without encryption

### DIFF
--- a/test/test_lang_bind_helper.cpp
+++ b/test/test_lang_bind_helper.cpp
@@ -13257,7 +13257,7 @@ TEST(LangBindHelper_MixedTimestampTransaction)
 
 // This test verifies that small unencrypted files are treated correctly if
 // opened as encrypted. 
-#ifdef REALM_ENABLE_ENCRYPTION
+#if REALM_ENABLE_ENCRYPTION
 TEST(LangBindHelper_OpenAsEncrypted)
 {
 


### PR DESCRIPTION
The macro is always defined as either 0 or 1.
I found this because I was running the unit tests without encryption enabled at compile time and it produced a failure in that test.