### PR TITLE
Clear Spec's Subspec array when it is detached

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,8 @@
 ### Bugfixes
 
 * Fixed handle leak on Windows (https://github.com/realm/realm-core/pull/2781)
+* Fixed a use-after-free when a TableRef for a table containing a subtable
+  outlives the owning group.
 
 ### Breaking changes
 

--- a/src/realm/spec.cpp
+++ b/src/realm/spec.cpp
@@ -31,6 +31,12 @@ Spec::~Spec() noexcept
     }
 }
 
+void Spec::detach() noexcept
+{
+    m_top.detach();
+    m_subspec_ptrs.clear();
+}
+
 bool Spec::init(ref_type ref) noexcept
 {
     // Needs only initialization if not previously initialized

--- a/src/realm/spec.hpp
+++ b/src/realm/spec.hpp
@@ -107,6 +107,7 @@ public:
     bool operator!=(const Spec&) const noexcept;
     //@}
 
+    void detach() noexcept;
     void destroy() noexcept;
 
     size_t get_ndx_in_parent() const noexcept;
@@ -135,11 +136,7 @@ private:
     Array m_subspecs;     // 4th slot in m_top (optional)
     Array m_enumkeys;     // 5th slot in m_top (optional)
     struct SubspecPtr {
-        SubspecPtr()
-            : m_is_spec_ptr(false)
-        {
-        }
-        SubspecPtr(bool is_spec_ptr)
+        SubspecPtr(bool is_spec_ptr = false)
             : m_is_spec_ptr(is_spec_ptr)
         {
         }

--- a/src/realm/table.hpp
+++ b/src/realm/table.hpp
@@ -956,7 +956,7 @@ private:
         void detach()
         {
             if (m_is_managed) {
-                m_p->m_top.detach();
+                m_p->detach();
             }
         }
         SpecPtr& operator=(Spec* ptr)

--- a/test/test_group.cpp
+++ b/test/test_group.cpp
@@ -903,8 +903,8 @@ TEST(Group_TableAccessorLeftBehind)
     TableRef table;
     TableRef subtable;
     {
-        Group group;
-        table = group.add_table("test");
+        auto group = std::make_unique<Group>();
+        table = group->add_table("test");
         CHECK(table->is_attached());
         table->add_column(type_Table, "sub");
         table->add_empty_row();


### PR DESCRIPTION
Fixes a use-after-free when a TableRef for a table with a subtable column outlives the owning Group.

This was actually hit by an existing test, but valgrind and asan did not report it due to that the invalid access was to memory on the stack. Moving the `Group` to a heap allocation is enough to make valgrind report the following error:

```
Invalid read of size 8
   at 0x1010BC85C: realm::Allocator::get_replication() (alloc.hpp:369)
   by 0x10139D0C6: realm::Spec::~Spec() (spec.cpp:29)
   by 0x10139D1D4: realm::Spec::~Spec() (spec.cpp:27)
   by 0x1013A524A: realm::Spec::SubspecPtr::~SubspecPtr() (memory:2537)
   by 0x1013A00F4: realm::Spec::SubspecPtr::~SubspecPtr() (spec.hpp:137)
   by 0x1013A4EEB: std::__1::__vector_base<realm::Spec::SubspecPtr, std::__1::allocator<realm::Spec::SubspecPtr> >::~__vector_base() (memory:1807)
   by 0x1013A4E14: std::__1::vector<realm::Spec::SubspecPtr, std::__1::allocator<realm::Spec::SubspecPtr> >::~vector() (vector:458)
   by 0x10139D1B4: std::__1::vector<realm::Spec::SubspecPtr, std::__1::allocator<realm::Spec::SubspecPtr> >::~vector() (vector:458)
   by 0x10139D0FC: realm::Spec::~Spec() (spec.cpp:32)
   by 0x10139D1D4: realm::Spec::~Spec() (spec.cpp:27)
   by 0x100170EAB: realm::Table::SpecPtr::optionally_delete() (table.hpp:997)
   by 0x100170E50: realm::Table::SpecPtr::~SpecPtr() (table.hpp:948)
 Address 0x10a6c2b18 is 24 bytes inside a block of size 6,848 free'd
   at 0x102BF39F3: free (in /usr/local/Cellar/valgrind/3.13.0/lib/valgrind/vgpreload_memcheck-amd64-darwin.so)
   by 0x1010FE231: realm::Group::~Group() (group.cpp:251)
   by 0x10021FA3D: Realm_UnitTest__Group_TableAccessorLeftBehind::test_run() (memory:2537)
   by 0x10023F284: realm::test_util::unit_test::RegisterTest<Realm_UnitTest__Group_TableAccessorLeftBehind>::run_test(realm::test_util::unit_test::TestContext&) (unit_test.hpp:565)
   by 0x100E3A334: realm::test_util::unit_test::TestList::ThreadContextImpl::run(realm::test_util::unit_test::TestList::SharedContextImpl::Entry, realm::util::UniqueLock&) (unit_test.cpp:665)
   by 0x100E39C8F: realm::test_util::unit_test::TestList::ThreadContextImpl::nonconcur_run() (unit_test.cpp:649)
   by 0x100E37B3D: realm::test_util::unit_test::TestList::run(realm::test_util::unit_test::TestList::Config) (unit_test.cpp:562)
   by 0x1000604B3: (anonymous namespace)::run_tests(realm::util::Logger*) (test_all.cpp:498)
   by 0x10005A3E0: test_all(int, char**, realm::util::Logger*) (test_all.cpp:554)
   by 0x100059AFC: main (main.mm:33)
 Block was alloc'd at
   at 0x102BF3616: malloc (in /usr/local/Cellar/valgrind/3.13.0/lib/valgrind/vgpreload_memcheck-amd64-darwin.so)
   by 0x104C97E2D: operator new(unsigned long) (in /usr/lib/libc++abi.dylib)
   by 0x10021F33F: Realm_UnitTest__Group_TableAccessorLeftBehind::test_run() (memory:3153)
   by 0x10023F284: realm::test_util::unit_test::RegisterTest<Realm_UnitTest__Group_TableAccessorLeftBehind>::run_test(realm::test_util::unit_test::TestContext&) (unit_test.hpp:565)
   by 0x100E3A334: realm::test_util::unit_test::TestList::ThreadContextImpl::run(realm::test_util::unit_test::TestList::SharedContextImpl::Entry, realm::util::UniqueLock&) (unit_test.cpp:665)
   by 0x100E39C8F: realm::test_util::unit_test::TestList::ThreadContextImpl::nonconcur_run() (unit_test.cpp:649)
   by 0x100E37B3D: realm::test_util::unit_test::TestList::run(realm::test_util::unit_test::TestList::Config) (unit_test.cpp:562)
   by 0x1000604B3: (anonymous namespace)::run_tests(realm::util::Logger*) (test_all.cpp:498)
   by 0x10005A3E0: test_all(int, char**, realm::util::Logger*) (test_all.cpp:554)
   by 0x100059AFC: main (main.mm:33)
```