### PR TITLE
Release slab as soon as possible after commit

### DIFF
--- a/src/realm/group_shared.cpp
+++ b/src/realm/group_shared.cpp
@@ -1794,6 +1794,11 @@ SharedGroup::version_type SharedGroup::commit()
     release_read_lock(lock_after_commit);
     
     do_end_write();
+
+    // Free memory that was allocated during the write transaction.
+    using gf = _impl::GroupFriend;
+    gf::reset_free_space_tracking(m_group); // Throws
+
     do_end_read();
     m_read_lock = lock_after_commit;
     m_transact_stage = transact_Ready;


### PR DESCRIPTION
We now release slab immediately after commit. Without this change, slab is kept allocated for each open realm file between commits. Even though the data in the slab is never referenced again, it is "dirty" and will count against the kernels limit on dirty pages (require backing in physical memory). This may be of importance in settings where many realm files are open.

Inspired by #2812, though it is not known at the moment if it fixes it.