### PR TITLE
Add an explicit instantiation of Table::find_first for BinaryData

### DIFF
--- a/src/realm/table.cpp
+++ b/src/realm/table.cpp
@@ -3975,6 +3975,7 @@ template size_t Table::find_first(size_t col_ndx, float) const;
 template size_t Table::find_first(size_t col_ndx, double) const;
 template size_t Table::find_first(size_t col_ndx, util::Optional<bool>) const;
 template size_t Table::find_first(size_t col_ndx, util::Optional<int64_t>) const;
+template size_t Table::find_first(size_t col_ndx, BinaryData) const;
 
 } // namespace realm
 


### PR DESCRIPTION
Other explicit instantiations were added in #2624, but `BinaryData` was overlooked.

Needed to address realm/realm-object-store#526.