### PR TITLE
Improve durability on windows

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,7 +16,8 @@
 
 ### Internals
 
-* Lorem ipsum.
+* Improve crash durability on windows.
+  PR [#2845](https://github.com/realm/realm-core/pull/2845).
 
 ----------------------------------------------
 

--- a/src/realm/util/file.cpp
+++ b/src/realm/util/file.cpp
@@ -923,9 +923,9 @@ void* File::remap(void* old_addr, size_t old_size, AccessMode a, size_t new_size
 }
 
 
-void File::sync_map(void* addr, size_t size)
+void File::sync_map(FileDesc fd, void* addr, size_t size)
 {
-    realm::util::msync(addr, size);
+    realm::util::msync(fd, addr, size);
 }
 
 

--- a/src/realm/util/file.hpp
+++ b/src/realm/util/file.hpp
@@ -1064,7 +1064,6 @@ inline bool File::try_lock_shared()
 inline File::MapBase::MapBase() noexcept
 {
     m_addr = nullptr;
-    m_fd = 0;
 }
 
 inline File::MapBase::~MapBase() noexcept

--- a/src/realm/util/file_mapper.cpp
+++ b/src/realm/util/file_mapper.cpp
@@ -497,9 +497,11 @@ void msync(FileDesc fd, void* addr, size_t size)
     // for a discussion of this related to core data.
 
 #ifdef _WIN32
+    // FlushViewOfFile() is asynchronous and won't flush metadata (file size, etc)
     if (!FlushViewOfFile(addr, size)) {
         throw std::runtime_error("FlushViewOfFile() failed");
     }
+    // Block until data and metadata is written physically to the media
     if (!FlushFileBuffers(fd)) {
         throw std::runtime_error("FlushFileBuffers() failed");
     }

--- a/src/realm/util/file_mapper.hpp
+++ b/src/realm/util/file_mapper.hpp
@@ -31,7 +31,7 @@ void* mmap(FileDesc fd, size_t size, File::AccessMode access, size_t offset, con
 void munmap(void* addr, size_t size) noexcept;
 void* mremap(FileDesc fd, size_t file_offset, void* old_addr, size_t old_size, File::AccessMode a, size_t new_size,
              const char* encryption_key);
-void msync(void* addr, size_t size);
+void msync(FileDesc fd, void* addr, size_t size);
 
 // A function which may be given to encryption_read_barrier. If present, the read barrier is a
 // a barrier for a full array. If absent, the read barrier is a barrier only for the address


### PR DESCRIPTION
The `FlushViewOfFile` function returns immediately without waiting for the data to be written to disk.