### PR TITLE
Removed incorrect and unused string type traits

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,8 @@
 
 * Improve crash durability on windows.
   PR [#2845](https://github.com/realm/realm-core/pull/2845).
+* Removed incorrect string column type traits, which could cause errors.
+  They were unused. PR [#2846](https://github.com/realm/realm-core/pull/2846).
 
 ----------------------------------------------
 

--- a/src/realm/column_type_traits.hpp
+++ b/src/realm/column_type_traits.hpp
@@ -106,12 +106,8 @@ struct ColumnTypeTraits<util::Optional<OldDateTime>> : ColumnTypeTraits<util::Op
 
 template <>
 struct ColumnTypeTraits<StringData> {
-    using column_type = StringEnumColumn;
-    using leaf_type = ArrayInteger;
-    using sum_type = int64_t;
     static const DataType id = type_String;
     static const ColumnType column_id = col_type_String;
-    static const ColumnType real_column_type = col_type_String;
 };
 
 template <>


### PR DESCRIPTION
These traits are not always true. Columns holding strings can be of type `StringColumn` or `StringEnumColumn`, the leaf type depends on how big the strings are, and a sum operation doesn't make sense.

These column type traits are used in the query system and the relevant functions that make use of this information should all be overridden for the string type. If a specialised function is not provided, I would rather get a compiler error because these types are undefined than potentially use the wrong type.