### PR TITLE
Fix reported race in fastrand

### DIFF
--- a/src/realm/utilities.cpp
+++ b/src/realm/utilities.cpp
@@ -239,11 +239,14 @@ int fast_popcount64(int64_t x)
 }
 
 // Mutex only to make Helgrind happy
-// If it was declared inside fastrand() then it could have a race being initialised and
+// If it was declared as a static inside fastrand() then it could have a race being initialised and
 // being locked because a static inside a function is constructed the first time execution
 // hits the function declaration (lazily). To avoid that race we declare it outside the function
-// which means it will be constructed on program start.
-static util::Mutex fastrand_mutex;
+// which means it will be constructed on program start. Post C++11, there should be no race on a
+// construction of a local static, but tsan seems to report this as a false positive sometimes.
+namespace {
+util::Mutex fastrand_mutex;
+} // end anonymous namespace
 
 // A fast, thread safe, mediocre-quality random number generator named Xorshift
 uint64_t fastrand(uint64_t max, bool is_seed)


### PR DESCRIPTION
I got a sporadic failure on the t-san check with the following trace:

```
/home/jenkins/workspace/realm_realm-core_PR-2845-LO6ERV62KWBA3GBMEDDVGR24XM4VCQIMVORXIIZMCO4XFNUOCKJA@6/test/test_thread.cpp:943: Begin Thread_CondvarAtomicWaitUnlock
==================
WARNING: ThreadSanitizer: data race (pid=1352)
  Atomic read of size 1 at 0x0000016c6960 by thread T4 (mutexes: write M24502):
    #0 pthread_mutex_lock <null> (libtsan.so.0+0x000000037286)
    #1 realm::util::Mutex::lock() ../src/realm/util/thread.hpp:489 (realm-tests+0x000001281fb9)
    #2 realm::util::LockGuard::LockGuard(realm::util::Mutex&) ../src/realm/util/thread.hpp:526 (realm-tests+0x000001281fb9)
    #3 realm::fastrand(unsigned long, bool) /home/jenkins/workspace/realm_realm-core_PR-2845-LO6ERV62KWBA3GBMEDDVGR24XM4VCQIMVORXIIZMCO4XFNUOCKJA@6/src/realm/utilities.cpp:246 (realm-tests+0x000001281fb9)
    #4 operator() /home/jenkins/workspace/realm_realm-core_PR-2845-LO6ERV62KWBA3GBMEDDVGR24XM4VCQIMVORXIIZMCO4XFNUOCKJA@6/test/test_thread.cpp:984 (realm-tests+0x000000e67893)
    #5 _M_invoke<> /usr/include/c++/5/functional:1531 (realm-tests+0x000000e67893)
    #6 operator() /usr/include/c++/5/functional:1520 (realm-tests+0x000000e67893)
    #7 _M_run /usr/include/c++/5/thread:115 (realm-tests+0x000000e67893)
    #8 <null> <null> (libstdc++.so.6+0x0000000b8c7f)

  Previous write of size 8 at 0x0000016c6960 by thread T2 (mutexes: write M24501):
    #0 realm::util::Mutex::Mutex() ../src/realm/util/thread.hpp:451 (realm-tests+0x0000012820f8)
    #1 realm::fastrand(unsigned long, bool) /home/jenkins/workspace/realm_realm-core_PR-2845-LO6ERV62KWBA3GBMEDDVGR24XM4VCQIMVORXIIZMCO4XFNUOCKJA@6/src/realm/utilities.cpp:245 (realm-tests+0x0000012820f8)
    #2 operator() /home/jenkins/workspace/realm_realm-core_PR-2845-LO6ERV62KWBA3GBMEDDVGR24XM4VCQIMVORXIIZMCO4XFNUOCKJA@6/test/test_thread.cpp:984 (realm-tests+0x000000e67893)
    #3 _M_invoke<> /usr/include/c++/5/functional:1531 (realm-tests+0x000000e67893)
    #4 operator() /usr/include/c++/5/functional:1520 (realm-tests+0x000000e67893)
    #5 _M_run /usr/include/c++/5/thread:115 (realm-tests+0x000000e67893)
    #6 <null> <null> (libstdc++.so.6+0x0000000b8c7f)

  Location is global 'realm::fastrand(unsigned long, bool)::m' of size 40 at 0x0000016c6960 (realm-tests+0x0000016c6960)

  Mutex M24502 (0x7fe4b0e839d0) created at:
    #0 pthread_mutex_init <null> (libtsan.so.0+0x0000000280b5)
    #1 realm::util::Mutex::init_as_process_shared(bool) /home/jenkins/workspace/realm_realm-core_PR-2845-LO6ERV62KWBA3GBMEDDVGR24XM4VCQIMVORXIIZMCO4XFNUOCKJA@6/src/realm/util/thread.cpp:149 (realm-tests+0x000001280110)
    #2 Realm_UnitTest__Thread_CondvarAtomicWaitUnlock::test_run()::{lambda()#1}::operator()() const [clone .constprop.303] <null> (realm-tests+0x000000e6ea71)
    #3 _M_invoke<> /usr/include/c++/5/functional:1531 (realm-tests+0x000000e6fe16)
    #4 operator() /usr/include/c++/5/functional:1520 (realm-tests+0x000000e6fe16)
    #5 _M_run /usr/include/c++/5/thread:115 (realm-tests+0x000000e6fe16)
    #6 <null> <null> (libstdc++.so.6+0x0000000b8c7f)

  Mutex M24501 (0x7fe4b06829d0) created at:
    #0 pthread_mutex_init <null> (libtsan.so.0+0x0000000280b5)
    #1 realm::util::Mutex::init_as_process_shared(bool) /home/jenkins/workspace/realm_realm-core_PR-2845-LO6ERV62KWBA3GBMEDDVGR24XM4VCQIMVORXIIZMCO4XFNUOCKJA@6/src/realm/util/thread.cpp:149 (realm-tests+0x000001280110)
    #2 Realm_UnitTest__Thread_CondvarAtomicWaitUnlock::test_run()::{lambda()#1}::operator()() const [clone .constprop.303] <null> (realm-tests+0x000000e6ea71)
    #3 _M_invoke<> /usr/include/c++/5/functional:1531 (realm-tests+0x000000e6fe16)
    #4 operator() /usr/include/c++/5/functional:1520 (realm-tests+0x000000e6fe16)
    #5 _M_run /usr/include/c++/5/thread:115 (realm-tests+0x000000e6fe16)
    #6 <null> <null> (libstdc++.so.6+0x0000000b8c7f)

  Thread T4 (tid=1593, running) created by thread T1 at:
    #0 pthread_create <null> (libtsan.so.0+0x000000027577)
    #1 std::thread::_M_start_thread(std::shared_ptr<std::thread::_Impl_base>, void (*)()) <null> (libstdc++.so.6+0x0000000b8dc2)
    #2 _M_invoke<> /usr/include/c++/5/functional:1531 (realm-tests+0x000000e6fe16)
    #3 operator() /usr/include/c++/5/functional:1520 (realm-tests+0x000000e6fe16)
    #4 _M_run /usr/include/c++/5/thread:115 (realm-tests+0x000000e6fe16)
    #5 <null> <null> (libstdc++.so.6+0x0000000b8c7f)

  Thread T2 (tid=1592, running) created by thread T3 at:
    #0 pthread_create <null> (libtsan.so.0+0x000000027577)
    #1 std::thread::_M_start_thread(std::shared_ptr<std::thread::_Impl_base>, void (*)()) <null> (libstdc++.so.6+0x0000000b8dc2)
    #2 _M_invoke<> /usr/include/c++/5/functional:1531 (realm-tests+0x000000e6fe16)
    #3 operator() /usr/include/c++/5/functional:1520 (realm-tests+0x000000e6fe16)
    #4 _M_run /usr/include/c++/5/thread:115 (realm-tests+0x000000e6fe16)
    #5 <null> <null> (libstdc++.so.6+0x0000000b8c7f)

SUMMARY: ThreadSanitizer: data race ??:0 pthread_mutex_lock
```

It looks like it occurs on that `Thread_CondvarAtomicWaitUnlock` test if two threads call `fastrand()` and it's mutex hasn't been constructed yet. Moving the mutex outside the function should cause the construction to occur at program start and then solve the race. 

Note that this function is only called from test code, so the race shouldn't be affecting any users.