### PR TITLE
Compact exceptions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@
 
 * Compact now throws an exception if writing fails for some reason
   instead of ignoring errors and possibly causing corruption.
+  In particular, this solves file truncation causing "bad header" exceptions
+  after a compact operation on a file system that is running out of disk space.
   PR [#2852](https://github.com/realm/realm-core/pull/2852).
 
 ### Breaking changes

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,9 @@
 
 ### Bugfixes
 
-* Lorem ipsum.
+* Compact now throws an exception if writing fails for some reason
+  instead of ignoring errors and possibly causing corruption.
+  PR [#2852](https://github.com/realm/realm-core/pull/2852).
 
 ### Breaking changes
 

--- a/src/realm/group.cpp
+++ b/src/realm/group.cpp
@@ -810,7 +810,10 @@ void Group::write(File& file, const char* encryption_key, uint_fast64_t version_
     file.set_encryption_key(encryption_key);
     File::Streambuf streambuf(&file);
     std::ostream out(&streambuf);
+    out.exceptions(std::ios_base::failbit | std::ios_base::badbit);
     write(out, encryption_key != 0, version_number);
+    int sync_status = streambuf.pubsync();
+    REALM_ASSERT(sync_status == 0);
 }
 
 BinaryData Group::write_to_mem() const

--- a/src/realm/group_shared.cpp
+++ b/src/realm/group_shared.cpp
@@ -1320,7 +1320,7 @@ bool SharedGroup::compact()
         // so it becomes the database file, replacing the old one in the process.
         File file;
         file.open(tmp_path, File::access_ReadWrite, File::create_Must, 0);
-        m_group.write(file, m_key, info->latest_version_number);
+        m_group.write(file, m_key, info->latest_version_number); // Throws
         // Data needs to be flushed to the disk before renaming.
         bool disable_sync = get_disable_sync_to_disk();
         if (!disable_sync)

--- a/src/realm/group_shared.cpp
+++ b/src/realm/group_shared.cpp
@@ -1318,13 +1318,20 @@ bool SharedGroup::compact()
 
         // Compact by writing a new file holding only live data, then renaming the new file
         // so it becomes the database file, replacing the old one in the process.
-        File file;
-        file.open(tmp_path, File::access_ReadWrite, File::create_Must, 0);
-        m_group.write(file, m_key, info->latest_version_number); // Throws
-        // Data needs to be flushed to the disk before renaming.
-        bool disable_sync = get_disable_sync_to_disk();
-        if (!disable_sync)
-            file.sync(); // Throws
+        try {
+            File file;
+            file.open(tmp_path, File::access_ReadWrite, File::create_Must, 0);
+            m_group.write(file, m_key, info->latest_version_number); // Throws
+            // Data needs to be flushed to the disk before renaming.
+            bool disable_sync = get_disable_sync_to_disk();
+            if (!disable_sync)
+                file.sync(); // Throws
+            }
+        catch (...)
+        {
+            File::try_remove(tmp_path);
+            throw;
+        }
 #ifndef _WIN32
         util::File::move(tmp_path, m_db_path);
 #endif

--- a/src/realm/util/file.hpp
+++ b/src/realm/util/file.hpp
@@ -1235,8 +1235,10 @@ inline File::Streambuf::pos_type File::Streambuf::seekpos(pos_type pos, std::ios
 inline void File::Streambuf::flush()
 {
     size_t n = pptr() - pbase();
-    m_file.write(pbase(), n);
-    setp(m_buffer.get(), epptr());
+    if (n > 0) {
+        m_file.write(pbase(), n);
+        setp(m_buffer.get(), epptr());
+    }
 }
 
 inline File::AccessError::AccessError(const std::string& msg, const std::string& path)


### PR DESCRIPTION
We need to check for errors when writing to the output stream. Our implementation of `File::Streambuf` flushes the file buffer in the destructor and silently ignores exceptions thrown there intentionally (it is bad practice to throw exceptions from a destructor because it may cause an application abort if this happens more than once). Instead of letting the destructor trigger the disk sync, we can call `std::streambuf::pubsync()` manually which will throw exceptions if applicable. 

I tested this by creating a 1MB ramdisk and mostly filling it with a file (`mkfile -v 290k testfile`) then running a compact operation on a realm file that fills most of the rest of the disk. I observed that the compact version of the file was written to fill the rest of the disk but cut off when there was no space left. Because we didn't check errors on the output stream, we swapped the partially written file in as if it succeeded and the next time it is opened I received an error: `InvalidDatabase("Bad Realm file header (#1)"` because the footer at the end was not written. With the changes in this PR, compact now throws `std::runtime_error: write(): failed: No space left on device` and the file is not swapped in to the original path. On failure the temporary file is also removed, giving whatever little disk space is available back instead of failing with %100 disk space used.

Should fix #2796 by allowing devs to handle the exception instead of potentially silently causing corruption. In the compact case, compact will fail with an exception and the original file will remain in place untouched (not compacted but not corrupt).