### PR TITLE
Copy object store's true and false expressions down to core

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,7 +20,8 @@
 
 ### Internals
 
-* Lorem ipsum.
+* Moved object store's true and false query expressions down to core.
+  PR [#2857](https://github.com/realm/realm-core/pull/2857).
 
 ----------------------------------------------
 

--- a/src/realm/query_expression.hpp
+++ b/src/realm/query_expression.hpp
@@ -1104,6 +1104,7 @@ struct OperatorOptionalAdapter {
 struct TrueExpression : Expression {
     size_t find_first(size_t start, size_t end) const override
     {
+        REALM_ASSERT(start <= end);
         if (start != end)
             return start;
 

--- a/src/realm/query_expression.hpp
+++ b/src/realm/query_expression.hpp
@@ -1100,6 +1100,62 @@ struct OperatorOptionalAdapter {
     }
 };
 
+
+struct TrueExpression : Expression {
+    size_t find_first(size_t start, size_t end) const override
+    {
+        if (start != end)
+            return start;
+
+        return realm::not_found;
+    }
+    void set_base_table(const Table*) override
+    {
+    }
+    const Table* get_base_table() const override
+    {
+        return nullptr;
+    }
+    void verify_column() const override
+    {
+    }
+    std::string description() const override
+    {
+        return "TRUEPREDICATE";
+    }
+    std::unique_ptr<Expression> clone(QueryNodeHandoverPatches*) const override
+    {
+        return std::unique_ptr<Expression>(new TrueExpression(*this));
+    }
+};
+
+
+struct FalseExpression : Expression {
+    size_t find_first(size_t, size_t) const override
+    {
+        return realm::not_found;
+    }
+    void set_base_table(const Table*) override
+    {
+    }
+    void verify_column() const override
+    {
+    }
+    std::string description() const override
+    {
+        return "FALSEPREDICATE";
+    }
+    const Table* get_base_table() const override
+    {
+        return nullptr;
+    }
+    std::unique_ptr<Expression> clone(QueryNodeHandoverPatches*) const override
+    {
+        return std::unique_ptr<Expression>(new FalseExpression(*this));
+    }
+};
+
+
 // Stores N values of type T. Can also exchange data with other ValueBase of different types
 template <class T>
 class Value : public ValueBase, public Subexpr2<T> {

--- a/test/test_metrics.cpp
+++ b/test/test_metrics.cpp
@@ -375,6 +375,8 @@ TEST(Metrics_QueryOrAndNot)
     Query not_and_or = !(and_or);
     Query not_or_nested = !(or_nested);
     Query not_and_nested = !(and_nested);
+    Query and_true = q0 && std::unique_ptr<realm::Expression>(new TrueExpression);
+    Query and_false = q0 && std::unique_ptr<realm::Expression>(new FalseExpression);
 
     simple_and.find_all();
     simple_or.find_all();
@@ -389,12 +391,14 @@ TEST(Metrics_QueryOrAndNot)
     not_and_or.find_all();
     not_or_nested.find_all();
     not_and_nested.find_all();
+    and_true.find_all();
+    and_false.find_all();
 
     std::shared_ptr<Metrics> metrics = sg.get_metrics();
     CHECK(metrics);
     std::unique_ptr<Metrics::QueryInfoList> queries = metrics->take_queries();
     CHECK(queries);
-    CHECK_EQUAL(queries->size(), 13);
+    CHECK_EQUAL(queries->size(), 15);
 
     std::string and_description = queries->at(0).get_description();
     CHECK_EQUAL(find_count(and_description, " and "), 1);
@@ -463,6 +467,14 @@ TEST(Metrics_QueryOrAndNot)
     std::string not_and_nested_description = queries->at(12).get_description();
     CHECK_EQUAL(find_count(not_and_nested_description, and_nested_description), 1);
     CHECK_EQUAL(find_count(not_and_nested_description, "not"), 1);
+
+    std::string and_true_description = queries->at(13).get_description();
+    CHECK_EQUAL(find_count(and_true_description, "and"), 1);
+    CHECK_EQUAL(find_count(and_true_description, "TRUEPREDICATE"), 1);
+
+    std::string and_false_description = queries->at(14).get_description();
+    CHECK_EQUAL(find_count(and_false_description, "and"), 1);
+    CHECK_EQUAL(find_count(and_false_description, "FALSEPREDICATE"), 1);
 }
 
 


### PR DESCRIPTION
These were implemented in the object-store [here](https://github.com/realm/realm-object-store/blob/master/src/parser/query_builder.cpp#L55).

I'll make a PR to the object store to remove them and link it to this change too.