### PR TITLE
Specialised exception for OutOfDiskSpace

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,7 +18,10 @@
 
 ### Internals
 
-* Lorem ipsum.
+* A specialised exception realm::OutOfDiskSpace is thrown instead of a generic
+  runtime exception when writing fails because the disk is full or the user exceeds
+  the allotted disk quota.
+  PR [#2861](https://github.com/realm/realm-core/pull/2861).
 
 ----------------------------------------------
 

--- a/src/realm/exceptions.hpp
+++ b/src/realm/exceptions.hpp
@@ -92,6 +92,13 @@ public:
     /// runtime_error::what() returns the msg provided in the constructor.
 };
 
+/// Thrown when writing fails because the disk is full.
+class OutOfDiskSpace : public std::runtime_error {
+public:
+    OutOfDiskSpace(const std::string& msg);
+    /// runtime_error::what() returns the msg provided in the constructor.
+};
+
 
 /// The \c LogicError exception class is intended to be thrown only when
 /// applications (or bindings) violate rules that are stated (or ought to have
@@ -274,6 +281,11 @@ inline AddressSpaceExhausted::AddressSpaceExhausted(const std::string& msg)
 
 inline MaximumFileSizeExceeded::MaximumFileSizeExceeded(const std::string& msg)
     : std::runtime_error(msg)
+{
+}
+
+inline OutOfDiskSpace::OutOfDiskSpace(const std::string& msg)
+: std::runtime_error(msg)
 {
 }
 

--- a/src/realm/util/file.cpp
+++ b/src/realm/util/file.cpp
@@ -639,6 +639,9 @@ void File::resize(SizeType size)
     if (m_encryption_key)
         size = data_size_to_encrypted_size(size);
 
+    // Windows docs say "it is not an error to set the file pointer to a position beyond the end of the file."
+    // so seeking with SetFilePointerEx() will not error out even if there is no disk space left.
+    // In this scenario though, the following call to SedEndOfFile() will fail if there is no disk space left.
     seek(size);
 
     if (!SetEndOfFile(m_fd)) {


### PR DESCRIPTION
By request, we now specialise `OutOfDiskSpace` from a generic runtime exception.
This can occur if the disk is full, or the user exceeds his disk quota.

I've tested it for when compact fails on a full disk (mac) since this is the case it is requested for.

@rrrlasse can you especially double check the windows section please?