### PR TITLE
Fix null insensitive queries

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,9 @@
 * Fix corruption caused by `swap_rows()` and `move_column()` operations applied
   to a StringEnumColumn. Currently unused by bindings.
   PR [#2780](https://github.com/realm/realm-core/pull/2780).
+* Fix case insensitive contains query for null strings not returning all results and
+  Fix case insensitive equals query for null strings returning nothing when null strings exist.
+  PR [#2871](https://github.com/realm/realm-core/pull/2871).
 
 ### Breaking changes
 

--- a/src/realm/index_string.cpp
+++ b/src/realm/index_string.cpp
@@ -420,6 +420,12 @@ private:
 
 void IndexArray::index_string_all_ins(StringData value, IntegerColumn& result, ColumnBase* column) const
 {
+    if (value.is_null()) {
+        // we can't use case_map on null strings because it currently returns an
+        // empty string ("") in that case which is different than a null StringData
+        return index_string_all(value, result, column);
+    }
+
     const util::Optional<std::string> upper_value = case_map(value, true);
     const util::Optional<std::string> lower_value = case_map(value, false);
     SearchList search_list(upper_value, lower_value);

--- a/src/realm/query_engine.hpp
+++ b/src/realm/query_engine.hpp
@@ -1453,7 +1453,8 @@ public:
 
         for (size_t s = start; s < end; ++s) {
             StringData t = get_string(s);
-            // current (questionable?) behaviour is to return all results when querying for a null string
+            // The current behaviour is to return all results when querying for a null string.
+            // See comment above Query_NextGen_StringConditions on why every string including "" contains null.
             if (!bool(m_value)) {
                 return s;
             }

--- a/src/realm/query_engine.hpp
+++ b/src/realm/query_engine.hpp
@@ -1418,17 +1418,17 @@ public:
             m_ucase = std::move(*upper);
             m_lcase = std::move(*lower);
         }
-        
+
         if (v.size() == 0)
             return;
-        
+
         // Build a dictionary of char-to-last distances in the search string
         // (zero indicates that the char is not in needle)
         size_t last_char_pos = m_ucase.size()-1;
         for (size_t i = 0; i < last_char_pos; ++i) {
             // we never jump longer increments than 255 chars, even if needle is longer (to fit in one byte)
             uint8_t jump = last_char_pos-i < 255 ? static_cast<uint8_t>(last_char_pos-i) : 255;
-            
+
             unsigned char uc = m_ucase[i];
             unsigned char lc = m_lcase[i];
             m_charmap[uc] = jump;
@@ -1436,24 +1436,27 @@ public:
         }
 
     }
-    
+
     void init() override
     {
         clear_leaf_state();
-        
+
         m_dD = 100.0;
-        
+
         StringNodeBase::init();
     }
-    
-    
+
+
     size_t find_first_local(size_t start, size_t end) override
     {
         ContainsIns cond;
-        
+
         for (size_t s = start; s < end; ++s) {
             StringData t = get_string(s);
-            
+            // current (questionable?) behaviour is to return all results when querying for a null string
+            if (!bool(m_value)) {
+                return s;
+            }
             if (cond(StringData(m_value), m_ucase.data(), m_lcase.data(), m_charmap, t))
                 return s;
         }
@@ -1469,7 +1472,7 @@ public:
     {
         return std::unique_ptr<ParentNode>(new StringNode<ContainsIns>(*this, patches));
     }
-    
+
     StringNode(const StringNode& from, QueryNodeHandoverPatches* patches)
     : StringNodeBase(from, patches)
     , m_charmap(from.m_charmap)
@@ -1477,7 +1480,7 @@ public:
     , m_lcase(from.m_lcase)
     {
     }
-    
+
 protected:
     std::array<uint8_t, 256> m_charmap;
     std::string m_ucase;

--- a/test/test_query.cpp
+++ b/test/test_query.cpp
@@ -526,6 +526,13 @@ TEST(Query_NextGen_StringConditions)
     m = table2->column<String>(0).not_equal(realm::null()).count();
     CHECK_EQUAL(m, 4);
 
+    m = table2->column<String>(0).contains(realm::null()).count();
+    CHECK_EQUAL(m, 5);
+
+    m = table2->column<String>(0).like(realm::null()).count();
+    CHECK_EQUAL(m, 1);
+
+
 
     m = table2->column<String>(0).contains(StringData(""), false).count();
     CHECK_EQUAL(m, 4);
@@ -552,7 +559,7 @@ TEST(Query_NextGen_StringConditions)
     CHECK_EQUAL(m, 4);
 
     m = table2->column<String>(0).contains(realm::null(), false).count();
-    CHECK_EQUAL(m, 4);
+    CHECK_EQUAL(m, 5);
 
     m = table2->column<String>(0).like(realm::null(), false).count();
     CHECK_EQUAL(m, 1);

--- a/test/test_query.cpp
+++ b/test/test_query.cpp
@@ -10895,6 +10895,51 @@ TEST(Query_CaseInsensitiveIndexEquality_CommonNumericPrefix)
 }
 
 
+TEST_TYPES(Query_CaseInsensitiveNullable, std::true_type, std::false_type)
+{
+    Table table;
+    bool nullable = true;
+    constexpr bool with_index = TEST_TYPE::value;
+    size_t col_ndx = table.add_column(type_String, "id", nullable);
+    if (with_index) {
+        table.add_search_index(col_ndx);
+    }
+
+    table.add_empty_row(6);
+    table.set_string(col_ndx, 0, "test");
+    table.set_string(col_ndx, 1, "words");
+    table.set_null(col_ndx, 2);
+    table.set_null(col_ndx, 3);
+    table.set_string(col_ndx, 4, "");
+    table.set_string(col_ndx, 5, "");
+
+    bool case_sensitive = true;
+    StringData null_string;
+    Query q = table.where().equal(col_ndx, null_string, case_sensitive);
+    CHECK_EQUAL(q.count(), 2);
+    TableView tv = q.find_all();
+    CHECK_EQUAL(tv.size(), 2);
+    CHECK_EQUAL(tv[0].get_index(), 2);
+    CHECK_EQUAL(tv[1].get_index(), 3);
+    Query q2 = table.where().contains(col_ndx, null_string, case_sensitive);
+    CHECK_EQUAL(q2.count(), 6);
+    tv = q2.find_all();
+    CHECK_EQUAL(tv.size(), 6);
+
+    case_sensitive = false;
+    q = table.where().equal(col_ndx, null_string, case_sensitive);
+    CHECK_EQUAL(q.count(), 2);
+    tv = q.find_all();
+    CHECK_EQUAL(tv.size(), 2);
+    CHECK_EQUAL(tv[0].get_index(), 2);
+    CHECK_EQUAL(tv[1].get_index(), 3);
+    q2 = table.where().contains(col_ndx, null_string, case_sensitive);
+    CHECK_EQUAL(q2.count(), 6);
+    tv = q2.find_all();
+    CHECK_EQUAL(tv.size(), 6);
+}
+
+
 TEST_TYPES(Query_Rover, std::true_type, std::false_type)
 {
     constexpr bool nullable = TEST_TYPE::value;


### PR DESCRIPTION
Fixes #2867 where running a case insensitive "equals" query for null would return nothing even if nulls exist. The problem is that `case_map` function run on a null `StringData` would return the empty string (because of how we store our null `StringData` as an empty string with size 0). So I explicitly handle the case where the needle is null.

Also fixes another edge case that I saw where doing a case insensitive "contains" query for null would not return results that were in fact null. The case sensitive version of this query returns all results (including nulls).

These edge cases are tricky and it is another data point that we should spend the time to implement fuzz tests on our query code to verify results (see #1932).