### PR TITLE
Add a Dockerfile for Clang 5

### DIFF
--- a/clang.Dockerfile
+++ b/clang.Dockerfile
@@ -1,0 +1,29 @@
+FROM ubuntu:16.04
+
+# Setup the LLVM repository
+RUN echo deb http://apt.llvm.org/xenial/ llvm-toolchain-xenial-5.0 main > /etc/apt/sources.list.d/clang.list
+
+# This forces dpkg not to call sync() after package extraction and speeds up install
+RUN echo "force-unsafe-io" > /etc/dpkg/dpkg.cfg.d/02apt-speedup
+
+# No need for the apt cache in a container
+RUN echo "Acquire::http {No-Cache=True;};" > /etc/apt/apt.conf.d/no-cache
+
+# Download the GBG key to use the LLVM repo
+ADD https://apt.llvm.org/llvm-snapshot.gpg.key /tmp/llvm.key
+
+# Add the key
+RUN apt-key add /tmp/llvm.key
+
+# Install clang and everything needed to build core
+RUN apt-get update \
+    && apt-get install -y clang-5.0 \
+                       cmake \
+                       libprocps4-dev \
+                       libssl-dev \
+                       ninja-build \
+    && rm -rf /var/lib/apt/lists/*
+
+# Make clang the default compiler
+ENV CC /usr/bin/clang-5.0
+ENV CXX /usr/bin/clang++-5.0

--- a/doc/development/sanitizers.md
+++ b/doc/development/sanitizers.md
@@ -1,0 +1,22 @@
+It's useful to use the latest version of clang to test core with dynamic analyzers.
+
+To do this:
+
+1. Build the image
+```
+docker build -f clang.Dockerfile -t realm-core-clang:snapshot .
+```
+2. Run the image
+```
+docker run -ti -v $(pwd):/tmp -w /tmp realm-core-clang:snapshot bash
+```
+
+Now you can build core and run the tests as usual. An example for the address sanitizer:
+```
+mkdir build
+cd build
+cmake -G Ninja -D REALM_ASAN=ON ..
+ninja
+cd test
+./realm-test
+```


### PR DESCRIPTION
This is useful especially to use the advanced sanitizers available in Clang 5

To use this:

1. Build the image
```
docker build -f clang.Dockerfile -t realm-core-clang:snapshot .
```
2. Run the image
```
docker run -ti -v $(pwd):/tmp -w /tmp realm-core-clang:snapshot bash
```

Now you can build core and run the tests as usual. An example for the address sanitizer:
```
mkdir build
cd build
cmake -G Ninja -D REALM_ASAN=ON ..
ninja
cd test
./realm-test
```