### PR TITLE
Don't add the shared library to the CMake export set

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -146,14 +146,19 @@ if(NOT REALM_BUILD_LIB_ONLY AND NOT REALM_NO_TESTS)
     add_subdirectory(test)
 endif()
 
-# CPack
+# Install the licence and changelog files
 install(FILES LICENSE CHANGELOG.md DESTINATION "doc/realm" COMPONENT devel)
+
+# Make the project importable from the build directory
 export(TARGETS realm FILE realm-config.cmake)
+
+# Make the project importable from the install directory
 install(EXPORT realm
         FILE realm-config.cmake
         DESTINATION ${CMAKE_INSTALL_LIBDIR}/cmake/realm
         COMPONENT devel)
 
+# CPack
 if(APPLE)
     set(CPACK_GENERATOR "TGZ")
 elseif(ANDROID)

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -557,7 +557,7 @@ def doPublishGeneric() {
                 unstash 'packages-generic'
                 withCredentials([[$class: 'FileBinding', credentialsId: 'c0cc8f9e-c3f1-4e22-b22f-6568392e26ae', variable: 's3cfg_config_file']]) {
                     sh 'find . -type f -name "*.tgz" -exec s3cmd -c $s3cfg_config_file put {} s3://static.realm.io/downloads/core/ \\;'
-                    sh "find . -type f -name \"*.tgz\" -exec s3cmd -c $s3cfg_config_file put {} s3://static.realm.io/downloads/core/${gitDescribeVersion}/linux \\;"
+                    sh "find . -type f -name \"*.tgz\" -exec s3cmd -c $s3cfg_config_file put {} s3://static.realm.io/downloads/core/${gitDescribeVersion}/linux/ \\;"
                 }
             }
 

--- a/src/realm/CMakeLists.txt
+++ b/src/realm/CMakeLists.txt
@@ -337,7 +337,7 @@ install(FILES ${PROJECT_BINARY_DIR}/src/realm/util/config.h
         COMPONENT devel)
 
 if(NOT REALM_SKIP_SHARED_LIB)
-    install(TARGETS realm-shared EXPORT realm
+    install(TARGETS realm-shared
             LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR} COMPONENT runtime
             RUNTIME DESTINATION ${CMAKE_INSTALL_LIBDIR} COMPONENT runtime)
 endif()


### PR DESCRIPTION
This was producing .cmake files in the packages which were not usable from downstream projects