### PR TITLE
Fix asan issue reported by clang 5

### DIFF
--- a/test/test_destroy_guard.cpp
+++ b/test/test_destroy_guard.cpp
@@ -180,10 +180,10 @@ TEST(DestroyGuard_General)
         bool destroyed_flag_1 = false;
         bool destroyed_flag_2 = false;
         {
-            DestroyGuard<Foo> dg;
             Foo foo_1(&destroyed_flag_1);
-            dg.reset(&foo_1);
             Foo foo_2(&destroyed_flag_2);
+            DestroyGuard<Foo> dg;
+            dg.reset(&foo_1);
             dg.reset(&foo_2);
             CHECK(destroyed_flag_1);
         }


### PR DESCRIPTION
Fixes #2870.

I generated the full stack with symbols by using `ASAN_SYMBOLIZER_PATH=path-to/clang5/bin/llvm-symbolizer ASAN_OPTIONS=symbolize=1`

The problem is that the variable that the destroy guard was reset to was initialised on the stack after the destroy guard itself. When the destructors are called, `foo_2` was destructed before the guard and this creates an access to bad memory. The fix is to just initialise `foo_2` before the guard.

<details>

```
=================================================================
==26641==ERROR: AddressSanitizer: stack-use-after-scope on address 0x7ffdce87fe40 at pc 0x0000007bf16d bp 0x7ffdce87fc80 sp 0x7ffdce87fc78
READ of size 8 at 0x7ffdce87fe40 thread T0
    #0 0x7bf16c in (anonymous namespace)::Foo::destroy() /home/parallels/Documents/code/realm-core/build-clang5/../test/test_destroy_guard.cpp:71:10
    #1 0x7bc95e in Realm_UnitTest__DestroyGuard_General::test_run() /home/parallels/Documents/code/realm-core/build-clang5/../test/test_destroy_guard.cpp:189:9
    #2 0x7c2cc9 in realm::test_util::unit_test::RegisterTest<Realm_UnitTest__DestroyGuard_General>::run_test(realm::test_util::unit_test::TestContext&) /home/parallels/Documents/code/realm-core/build-clang5/../test/util/unit_test.hpp:565:14
    #3 0x1bdaa36 in realm::test_util::unit_test::TestList::ThreadContextImpl::run(realm::test_util::unit_test::TestList::SharedContextImpl::Entry, realm::util::UniqueLock&) /home/parallels/Documents/code/realm-core/build-clang5/../test/util/unit_test.cpp:665:9
    #4 0x1bda407 in realm::test_util::unit_test::TestList::ThreadContextImpl::nonconcur_run() /home/parallels/Documents/code/realm-core/build-clang5/../test/util/unit_test.cpp:649:9
    #5 0x1bd90de in realm::test_util::unit_test::TestList::run(realm::test_util::unit_test::TestList::Config) /home/parallels/Documents/code/realm-core/build-clang5/../test/util/unit_test.cpp:562:24
    #6 0x580495 in (anonymous namespace)::run_tests(realm::util::Logger*) /home/parallels/Documents/code/realm-core/build-clang5/../test/test_all.cpp:498:25
    #7 0x57e5f4 in test_all(int, char**, realm::util::Logger*) /home/parallels/Documents/code/realm-core/build-clang5/../test/test_all.cpp:554:20
    #8 0x7f0e41a4882f in __libc_start_main /build/glibc-bfm8X4/glibc-2.23/csu/../csu/libc-start.c:291
    #9 0x4af788 in _start (/home/parallels/Documents/code/realm-core/build-clang5/test/realm-tests+0x4af788)

Address 0x7ffdce87fe40 is located in stack of thread T0 at offset 416 in frame
    #0 0x7bc49f in Realm_UnitTest__DestroyGuard_General::test_run() /home/parallels/Documents/code/realm-core/build-clang5/../test/test_destroy_guard.cpp:157

  This frame has 15 object(s):
    [32, 33) 'destroyed_flag' (line 160)
    [48, 56) 'foo' (line 162)
    [80, 88) 'dg' (line 163)
    [112, 120) 'ref.tmp' (line 164)
    [144, 152) 'ref.tmp2' (line 164)
    [176, 177) 'destroyed_flag7' (line 170)
    [192, 200) 'foo8' (line 172)
    [224, 232) 'dg9' (line 173)
    [256, 264) 'ref.tmp12' (line 174)
    [288, 296) 'ref.tmp13' (line 174)
    [320, 321) 'destroyed_flag_1' (line 180)
    [336, 337) 'destroyed_flag_2' (line 181)
    [352, 360) 'dg20' (line 183)
    [384, 392) 'foo_1' (line 184)
    [416, 424) 'foo_2' (line 186) <== Memory access at offset 416 is inside this variable
HINT: this may be a false positive if your program uses some custom stack unwind mechanism or swapcontext
      (longjmp and C++ exceptions *are* supported)
SUMMARY: AddressSanitizer: stack-use-after-scope /home/parallels/Documents/code/realm-core/build-clang5/../test/test_destroy_guard.cpp:71:10 in (anonymous namespace)::Foo::destroy()
Shadow bytes around the buggy address:
  0x100039d07f70: 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00
  0x100039d07f80: 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00
  0x100039d07f90: 00 00 00 00 f1 f1 f1 f1 f8 f2 f8 f2 f2 f2 f8 f2
  0x100039d07fa0: f2 f2 f8 f2 f2 f2 f8 f2 f2 f2 f8 f2 f8 f2 f2 f2
  0x100039d07fb0: f8 f2 f2 f2 f8 f2 f2 f2 f8 f2 f2 f2 01 f2 01 f2
=>0x100039d07fc0: 00 f2 f2 f2 f8 f2 f2 f2[f8]f3 f3 f3 00 00 00 00
  0x100039d07fd0: 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00
  0x100039d07fe0: 00 00 00 00 f1 f1 f1 f1 00 f3 f3 f3 00 00 00 00
  0x100039d07ff0: 00 00 00 00 00 00 00 00 f1 f1 f1 f1 00 00 00 f2
  0x100039d08000: f2 f2 f2 f2 00 00 00 00 00 00 f2 f2 f2 f2 00 00
  0x100039d08010: 00 f2 f2 f2 f2 f2 f8 f8 f8 f8 f2 f2 f2 f2 f8 f2
Shadow byte legend (one shadow byte represents 8 application bytes):
  Addressable:           00
  Partially addressable: 01 02 03 04 05 06 07 
  Heap left redzone:       fa
  Freed heap region:       fd
  Stack left redzone:      f1
  Stack mid redzone:       f2
  Stack right redzone:     f3
  Stack after return:      f5
  Stack use after scope:   f8
  Global redzone:          f9
  Global init order:       f6
  Poisoned by user:        f7
  Container overflow:      fc
  Array cookie:            ac
  Intra object redzone:    bb
  ASan internal:           fe
  Left alloca redzone:     ca
  Right alloca redzone:    cb
==26641==ABORTING
```

</details> 