### PR TITLE
Build the generic Linux build on Centos 6

### DIFF
--- a/packaging/generic/base-image/Dockerfile
+++ b/packaging/generic/base-image/Dockerfile
@@ -1,20 +1,12 @@
-FROM ubuntu:16.04
+FROM centos:6
 
-ARG PACKAGECLOUD_URL
-
-RUN apt-get update && apt-get install -y \
-  build-essential \
-  g++-4.9 \
-  git \
-  libssl-dev \
-  ninja-build \
-  tar \
-  wget \
-  && apt-get clean \
-  && rm -rf /var/lib/apt/lists/*
-
-RUN cd /opt \
-    && wget https://cmake.org/files/v3.7/cmake-3.7.2-Linux-x86_64.tar.gz \
-    && tar zxvf cmake-3.7.2-Linux-x86_64.tar.gz
-
-ENV PATH "$PATH:/opt/cmake-3.7.2-Linux-x86_64/bin"
+# Install EPEL & devtoolset
+# On CentOS6, there is a bug with OverlayFS and Docker. It is needed to touch
+# /var/lib/rpm/* in order to work around this issue.
+# Link: https://github.com/docker/docker/issues/10180
+RUN touch /var/lib/rpm/* \
+ && yum -y install \
+      epel-release \
+      centos-release-scl-rh \
+ && yum-config-manager --enable rhel-server-rhscl-6-rpms \
+ && yum clean all

--- a/packaging/generic/base-image/Dockerfile
+++ b/packaging/generic/base-image/Dockerfile
@@ -8,5 +8,4 @@ RUN touch /var/lib/rpm/* \
  && yum -y install \
       epel-release \
       centos-release-scl-rh \
- && yum-config-manager --enable rhel-server-rhscl-6-rpms \
  && yum clean all

--- a/packaging/generic/build-image/Dockerfile
+++ b/packaging/generic/build-image/Dockerfile
@@ -1,3 +1,35 @@
 FROM ci/realm-core:generic-base
 
+# whatever is required for building should be installed in this image; just
+# like BuildRequires: for RPM specs
+# On CentOS6, there is a bug with OverlayFS and Docker. It is needed to touch
+# /var/lib/rpm/* in order to work around this issue.
+# Link: https://github.com/docker/docker/issues/10180
+RUN touch /var/lib/rpm/* \
+    && yum -y install \
+        chrpath \
+        devtoolset-3-binutils \
+        devtoolset-3-gcc \
+        devtoolset-3-gcc-c++ \
+        git \
+        openssl-devel \
+        unzip \
+        wget \
+        which \
+    && yum clean all
+
+# Install CMake
+RUN cd /opt \
+    && wget https://cmake.org/files/v3.7/cmake-3.7.2-Linux-x86_64.tar.gz \
+    && tar zxvf cmake-3.7.2-Linux-x86_64.tar.gz
+
+ENV PATH "$PATH:/opt/cmake-3.7.2-Linux-x86_64/bin"
+
+# Install ninja
+RUN wget https://github.com/ninja-build/ninja/releases/download/v1.7.2/ninja-linux.zip \
+    && unzip ninja-linux.zip \
+    && chmod a+x ninja \
+    && mv ninja /usr/bin
+
+ENTRYPOINT ["/bin/bash", "/inside/docker-entrypoint.sh"]
 CMD ["/bin/bash", "/inside/build-package"]

--- a/packaging/generic/build-image/inside/build-package
+++ b/packaging/generic/build-image/inside/build-package
@@ -7,8 +7,6 @@ set -e
 # to delete them from our host.
 trap 'code=$?; chown -R --reference /inside/build-package /out/; exit $code' EXIT
 
-source /opt/rh/devtoolset-3/enable
-
 name="realm-core-${VERSION}"
 
 # If we're not releasing, append the iteration to the existing version

--- a/packaging/generic/build-image/inside/build-package
+++ b/packaging/generic/build-image/inside/build-package
@@ -7,6 +7,8 @@ set -e
 # to delete them from our host.
 trap 'code=$?; chown -R --reference /inside/build-package /out/; exit $code' EXIT
 
+source /opt/rh/devtoolset-3/enable
+
 name="realm-core-${VERSION}"
 
 # If we're not releasing, append the iteration to the existing version

--- a/packaging/generic/build-image/inside/docker-entrypoint.sh
+++ b/packaging/generic/build-image/inside/docker-entrypoint.sh
@@ -1,0 +1,3 @@
+#!/bin/bash
+
+scl enable devtoolset-3 -- "$@"


### PR DESCRIPTION
Centos 6 includes the oldest libc version we currently support (2.12), so it's a good idea to build the generic Linux image with it.