### PR TITLE
Fix a race between SharedGroup::compact() and SharedGroup::do_open()

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,10 @@
 
 ### Bugfixes
 
-* Lorem ipsum.
+* Fix a race between SharedGroup::compact() and SharedGroup::open(). The race could
+  cause asserts indicating file corruption even if no corruption is caused. It is also
+  possible that it could cause real file corruption, though that is much less likely.
+  PR [#2892](https://github.com/realm/realm-core/pull/2892)
 
 ### Breaking changes
 

--- a/src/realm/group_shared.cpp
+++ b/src/realm/group_shared.cpp
@@ -1288,9 +1288,6 @@ void SharedGroup::do_open(const std::string& path, bool no_create_file, bool is_
 // corrupt your database if something fails
 bool SharedGroup::compact()
 {
-    // FIXME: ExcetionSafety: This function must be rewritten with exception
-    // safety in mind.
-
     // Verify that the database file is attached
     if (is_attached() == false) {
         throw std::runtime_error(m_db_path + ": compact must be done on an open/attached SharedGroup");
@@ -1349,7 +1346,7 @@ bool SharedGroup::compact()
         // When someone attaches to the new database file, they *must* *not* see and
         // reuse any existing memory mapping of the stale file.
         m_group.m_alloc.detach();
-        
+
 #ifdef _WIN32
         util::File::copy(tmp_path, m_db_path);
 #else
@@ -1407,9 +1404,6 @@ void SharedGroup::close_internal(std::unique_lock<InterprocessMutex> lock) noexc
             is_sync_agent = repl->is_sync_agent();
 
         if (!lock.owns_lock())
-        //std::lock_guard<InterprocessMutex> lock(m_controlmutex);
-        //std::unique_lock<InterprocessMutex> lock(m_controlmutex, std::defer_lock);
-        //if (!already_locked)
             lock.lock();
 
         if (m_group.m_alloc.is_attached())

--- a/src/realm/group_shared.cpp
+++ b/src/realm/group_shared.cpp
@@ -1303,7 +1303,7 @@ bool SharedGroup::compact()
     std::string tmp_path = m_db_path + ".tmp_compaction_space";
     {
         SharedInfo* info = m_file_map.get_addr();
-        std::lock_guard<InterprocessMutex> lock(m_controlmutex); // Throws
+        std::unique_lock<InterprocessMutex> lock(m_controlmutex); // Throws
         if (info->num_participants > 1)
             return false;
 
@@ -1337,9 +1337,6 @@ bool SharedGroup::compact()
             }
             throw;
         }
-#ifndef _WIN32
-        util::File::move(tmp_path, m_db_path);
-#endif
         {
             SharedInfo* r_info = m_reader_map.get_addr();
             Ringbuffer::ReadCount& rc = const_cast<Ringbuffer::ReadCount&>(r_info->readers.get_last());
@@ -1352,12 +1349,15 @@ bool SharedGroup::compact()
         // When someone attaches to the new database file, they *must* *not* see and
         // reuse any existing memory mapping of the stale file.
         m_group.m_alloc.detach();
-    }
-    close();
+        
 #ifdef _WIN32
-    util::File::copy(tmp_path, m_db_path);
+        util::File::copy(tmp_path, m_db_path);
+#else
+        util::File::move(tmp_path, m_db_path);
 #endif
+        close_internal(/* with lock held: */ std::move(lock));
 
+    }
     SharedGroupOptions new_options;
     new_options.durability = dura;
     new_options.encryption_key = m_key;
@@ -1380,6 +1380,11 @@ SharedGroup::~SharedGroup() noexcept
 
 void SharedGroup::close() noexcept
 {
+    close_internal(std::unique_lock<InterprocessMutex>(m_controlmutex, std::defer_lock));
+}
+
+void SharedGroup::close_internal(std::unique_lock<InterprocessMutex> lock) noexcept
+{
     if (!is_attached())
         return;
 
@@ -1401,7 +1406,11 @@ void SharedGroup::close() noexcept
         if (Replication* repl = m_group.get_replication())
             is_sync_agent = repl->is_sync_agent();
 
-        std::lock_guard<InterprocessMutex> lock(m_controlmutex);
+        if (!lock.owns_lock())
+        //std::lock_guard<InterprocessMutex> lock(m_controlmutex);
+        //std::unique_lock<InterprocessMutex> lock(m_controlmutex, std::defer_lock);
+        //if (!already_locked)
+            lock.lock();
 
         if (m_group.m_alloc.is_attached())
             m_group.m_alloc.detach();
@@ -1429,6 +1438,7 @@ void SharedGroup::close() noexcept
             if (Replication* repl = gf::get_replication(m_group))
                 repl->terminate_session();
         }
+        lock.unlock();
     }
 #ifdef REALM_ASYNC_DAEMON
     m_room_to_write.close();

--- a/src/realm/group_shared.hpp
+++ b/src/realm/group_shared.hpp
@@ -683,6 +683,7 @@ private:
     /// finish up the process of starting a write transaction. Internal use only.
     void finish_begin_write();
 
+    void close_internal(std::unique_lock<InterprocessMutex>) noexcept;
     friend class _impl::SharedGroupFriend;
 };
 


### PR DESCRIPTION
@ironage found a race :-)...this is an initial fix.

The flow in compact() allowed another thread (or process) to observe the shared variable "num_participants" as 1 at a point during compact, where that observation would lead the other thread to assume it could trust the lockfile. However the lockfile becomes invalid after compact.

The fix is to hold the interprocess mutex all the way through compact() ensuring that all changes to num_participants are done before it is exposed to other threads.

