### PR TITLE
Pack openssl with android build

### DIFF
--- a/src/realm/CMakeLists.txt
+++ b/src/realm/CMakeLists.txt
@@ -287,6 +287,10 @@ if(REALM_ENABLE_ENCRYPTION AND UNIX AND NOT APPLE)
         set(OPENSSL_ROOT_DIR "${CMAKE_BINARY_DIR}/${OPENSSL_FILENAME}")
         set(OPENSSL_INCLUDE_DIR "${OPENSSL_ROOT_DIR}/include")
         set(OPENSSL_CRYPTO_LIBRARY "${OPENSSL_ROOT_DIR}/lib/libcrypto.a")
+        install(
+            DIRECTORY ${OPENSSL_ROOT_DIR}
+            DESTINATION .
+            COMPONENT devel)
     endif()
     find_package(OpenSSL REQUIRED)
     target_include_directories(realm-objects PUBLIC ${OPENSSL_INCLUDE_DIR})


### PR DESCRIPTION
So sync and java binding don't have to download openssl again.
And it avoids sync & binding using the different openssl version.

needed by https://github.com/realm/realm-sync/pull/1722