### PR TITLE
Randomize parameter IV in CCCryptorCreate

### DIFF
--- a/src/realm/util/encrypted_file_mapping.cpp
+++ b/src/realm/util/encrypted_file_mapping.cpp
@@ -145,8 +145,16 @@ AESCryptor::AESCryptor(const uint8_t* key)
       m_dst_buffer(new char[block_size])
 {
 #if REALM_PLATFORM_APPLE
-    CCCryptorCreate(kCCEncrypt, kCCAlgorithmAES, 0 /* options */, key, kCCKeySizeAES256, 0 /* IV */, &m_encr);
-    CCCryptorCreate(kCCDecrypt, kCCAlgorithmAES, 0 /* options */, key, kCCKeySizeAES256, 0 /* IV */, &m_decr);
+    // Randomize IV
+    void *iv = 0;
+    unsigned char u_iv[kCCKeySizeAES256];
+    for (size_t i = 0; i < sizeof(iv); ++i) {
+        u_iv[i] = arc4random() % 255;
+    }
+    iv = u_iv;
+    // Encrypt
+    CCCryptorCreate(kCCEncrypt, kCCAlgorithmAES, 0 /* options */, key, kCCKeySizeAES256, iv, &m_encr);
+    CCCryptorCreate(kCCDecrypt, kCCAlgorithmAES, 0 /* options */, key, kCCKeySizeAES256, iv, &m_decr);
 #elif defined(_WIN32)
     BCRYPT_ALG_HANDLE hAesAlg = NULL;
     int ret;

--- a/src/realm/util/encrypted_file_mapping.cpp
+++ b/src/realm/util/encrypted_file_mapping.cpp
@@ -145,14 +145,11 @@ AESCryptor::AESCryptor(const uint8_t* key)
       m_dst_buffer(new char[block_size])
 {
 #if REALM_PLATFORM_APPLE
-    // Randomize IV
-    void *iv = 0;
+    // A random iv is passed to CCCryptorReset. Here, in CCCryptorCreate, iv
+    // is randomized only to make happy some security static analyzer tools
     unsigned char u_iv[kCCKeySizeAES256];
-    for (size_t i = 0; i < sizeof(iv); ++i) {
-        u_iv[i] = arc4random() % 255;
-    }
-    iv = u_iv;
-    // Encrypt
+    arc4random_buf(u_iv, kCCKeySizeAES256);
+    void *iv = u_iv;
     CCCryptorCreate(kCCEncrypt, kCCAlgorithmAES, 0 /* options */, key, kCCKeySizeAES256, iv, &m_encr);
     CCCryptorCreate(kCCDecrypt, kCCAlgorithmAES, 0 /* options */, key, kCCKeySizeAES256, iv, &m_decr);
 #elif defined(_WIN32)


### PR DESCRIPTION
I am trying to solve #2899 
Randomizing IV parameter in function CCCryptorCreate helps to prevent replay attacks and cryptanalytic attacks. 
This code is based on J, Zdziarski's book "Hacking and Securing iOS Applications" (example code in ch10/stateful_crypt.m)


I have a question... Do you know how can I tell realm-cocoa to pull my branch or use this binary?
- I need this so I can check old database is not broken, etc 
- and for submitting to a static analyzer to confirm the security vulnerability is gone
