### PR TITLE
Make posix_fallocate robust against interruption, report right errors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,9 @@
 
 ### Bugfixes
 
-* Lorem ipsum.
+* Make calls to posix_fallocate() robust against interruption and report
+  the correct error on failure.
+  PR [#2905](https://github.com/realm/realm-core/pull/2905).
 
 ### Breaking changes
 


### PR DESCRIPTION
man posix_fallocate states:
```
posix_fallocate() returns zero on success, or an error number on failure.  Note that errno is not set.
```
With this in mind, we should report the return value and not the value in `errno`.

Additionally, `EINTR` is reported as a return code in fedora 24 (but strangely not mentioned in ubuntu 16). If it is interrupted, we can retry. It is hard to guess what the result of an interrupted `posix_fallocate` call would result in if not retried; the file would not be the expected size so this may fix errors like #2258.