### PR TITLE
Fix `int_multiply_with_overflow_detect()`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,10 @@
 * Make calls to posix_fallocate() robust against interruption and report
   the correct error on failure.
   PR [#2905](https://github.com/realm/realm-core/pull/2905).
+* Fix an error in `int_multiply_with_overflow_detect()` which would report
+  overflow when no overflow should occur. This could cause out of memory
+  exceptions when the `TransactLogParser` reads strings or binary data > 2GB.
+  PR [#2906](https://github.com/realm/realm-core/pull/2906).
 
 ### Breaking changes
 

--- a/src/realm/util/safe_int_ops.hpp
+++ b/src/realm/util/safe_int_ops.hpp
@@ -159,7 +159,9 @@ inline bool int_multiply_with_overflow_detect(L& lval, R rval) noexcept;
 /// can be used.
 ///
 /// \param i Must be non-negative and such that <tt>L(1)>>i</tt> has a
-/// value that is defined by the C++03 standard.
+/// value that is defined by the C++03 standard. In particular, the
+/// value of i must not exceed the number of bits of storage type T as
+/// shifting by this amount is not defined by the standard.
 ///
 /// This function makes absolutely no assumptions about the platform
 /// except that it complies with at least C++03.
@@ -554,7 +556,7 @@ inline bool int_multiply_with_overflow_detect(L& lval, R rval) noexcept
     static_assert(lim_l::is_integer && lim_r::is_integer, "Both types must be integers");
     REALM_ASSERT(int_greater_than_or_equal(lval, 0));
     REALM_ASSERT(int_greater_than(rval, 0));
-    if (int_less_than(lim_r::max() / rval, lval))
+    if (int_less_than(lim_l::max() / rval, lval))
         return true;
     lval = L(lval * rval);
     return false;

--- a/test/test_safe_int_ops.cpp
+++ b/test/test_safe_int_ops.cpp
@@ -161,6 +161,22 @@ TEST(SafeIntOps_AddWithOverflowDetect)
         rval = -1;
         CHECK(int_add_with_overflow_detect(lval, rval));
         CHECK_EQUAL(lval, std::numeric_limits<size_t>::min());
+
+        // lval::bits < rval::bits
+        unsigned char lval2 = std::numeric_limits<unsigned char>::max();
+        int64_t rval2 = 1;
+        CHECK(int_add_with_overflow_detect(lval2, rval2));
+        CHECK_EQUAL(lval2, std::numeric_limits<unsigned char>::max());
+
+        lval2 = std::numeric_limits<unsigned char>::max() - 1;
+        rval2 = 1;
+        CHECK(!int_add_with_overflow_detect(lval2, rval2));
+        CHECK_EQUAL(lval2, std::numeric_limits<unsigned char>::max());
+
+        lval2 = 0;
+        rval2 = std::numeric_limits<unsigned char>::max() + 1;
+        CHECK(int_add_with_overflow_detect(lval2, rval2));
+        CHECK_EQUAL(lval2, 0);
     }
     {   // unsigned and unsigned
         size_t lval = std::numeric_limits<size_t>::max();
@@ -275,6 +291,22 @@ TEST(SafeIntOps_SubtractWithOverflowDetect)
         rval = -1;
         CHECK(int_subtract_with_overflow_detect(lval, rval));
         CHECK_EQUAL(lval, std::numeric_limits<size_t>::max());
+
+        // lval::bits < rval::bits
+        unsigned char lval2 = 0;
+        int64_t rval2 = 1;
+        CHECK(int_subtract_with_overflow_detect(lval2, rval2));
+        CHECK_EQUAL(lval2, 0);
+
+        lval2 = std::numeric_limits<unsigned char>::max();
+        rval2 = std::numeric_limits<unsigned char>::max();
+        CHECK(!int_subtract_with_overflow_detect(lval2, rval2));
+        CHECK_EQUAL(lval2, 0);
+
+        lval2 = std::numeric_limits<unsigned char>::max();
+        rval2 = std::numeric_limits<unsigned char>::max() + 1;
+        CHECK(int_subtract_with_overflow_detect(lval2, rval2));
+        CHECK_EQUAL(lval2, std::numeric_limits<unsigned char>::max());
     }
     {   // unsigned and unsigned
         size_t lval = std::numeric_limits<size_t>::min();

--- a/test/test_safe_int_ops.cpp
+++ b/test/test_safe_int_ops.cpp
@@ -81,15 +81,420 @@ using unit_test::TestContext;
 // only if make_unsigned<S>::type(s < 0 ?  -1-s : s) <
 // (U(1)<<(lim_u::digits-1)).
 
-// FIXME: Test realm::util::int_shift_left_with_overflow_detect().
-
-// FIXME: Test realm::util::int_cast_with_overflow_detect().
-
 
 TEST(SafeIntOps_AddWithOverflowDetect)
 {
-    int lval = 255;
-    CHECK(!int_add_with_overflow_detect(lval, char(10)));
+    {   // signed and signed
+        int lval = 255;
+        char rval = 10;
+        CHECK(!int_add_with_overflow_detect(lval, rval));
+        CHECK_EQUAL(lval, 255 + 10);
+
+        rval = 1;
+        lval = std::numeric_limits<int>::max();
+        CHECK(int_add_with_overflow_detect(lval, rval));    // does overflow
+        CHECK_EQUAL(lval, std::numeric_limits<int>::max()); // unchanged
+
+        rval = 1;
+        lval = std::numeric_limits<int>::max() - 1;
+        CHECK(!int_add_with_overflow_detect(lval, rval));   // does not overflow
+        CHECK_EQUAL(lval, std::numeric_limits<int>::max()); // changed
+
+        rval = 0;
+        lval = std::numeric_limits<int>::max();
+        CHECK(!int_add_with_overflow_detect(lval, rval));   // does not overflow
+        CHECK_EQUAL(lval, std::numeric_limits<int>::max()); // unchanged
+
+        rval = -1;
+        lval = std::numeric_limits<int>::min();
+        CHECK(int_add_with_overflow_detect(lval, rval));    // does overflow
+        CHECK_EQUAL(lval, std::numeric_limits<int>::min()); // unchanged
+    }
+    {   // signed and unsigned
+        char lval = std::numeric_limits<char>::max();
+        size_t rval = 0;
+        CHECK(!int_add_with_overflow_detect(lval, rval));
+        CHECK_EQUAL(lval, std::numeric_limits<char>::max());
+
+        lval = std::numeric_limits<char>::max();
+        rval = 1;
+        CHECK(int_add_with_overflow_detect(lval, rval));
+        CHECK_EQUAL(lval, std::numeric_limits<char>::max());
+
+        lval = 0;
+        rval = std::numeric_limits<char>::max();
+        CHECK(!int_add_with_overflow_detect(lval, rval));
+        CHECK_EQUAL(lval, std::numeric_limits<char>::max());
+
+        lval = -1;
+        rval = std::numeric_limits<char>::max() + 1;
+        CHECK(!int_add_with_overflow_detect(lval, rval));
+        CHECK_EQUAL(lval, std::numeric_limits<char>::max());
+
+        lval = -1;
+        rval = std::numeric_limits<char>::max() + 2;
+        CHECK(int_add_with_overflow_detect(lval, rval));
+        CHECK_EQUAL(lval, -1);
+    }
+    {   // unsigned and signed
+        size_t lval = std::numeric_limits<size_t>::max();
+        char rval = 0;
+        CHECK(!int_add_with_overflow_detect(lval, rval));
+        CHECK_EQUAL(lval, std::numeric_limits<size_t>::max());
+
+        lval = std::numeric_limits<size_t>::max();
+        rval = 1;
+        CHECK(int_add_with_overflow_detect(lval, rval));
+        CHECK_EQUAL(lval, std::numeric_limits<size_t>::max());
+
+        lval = std::numeric_limits<size_t>::max();
+        rval = -1;
+        CHECK(!int_add_with_overflow_detect(lval, rval));
+        CHECK_EQUAL(lval, std::numeric_limits<size_t>::max() - 1);
+
+        lval = std::numeric_limits<size_t>::min();
+        rval = 0;
+        CHECK(!int_add_with_overflow_detect(lval, rval));
+        CHECK_EQUAL(lval, std::numeric_limits<size_t>::min());
+
+        lval = std::numeric_limits<size_t>::min();
+        rval = -1;
+        CHECK(int_add_with_overflow_detect(lval, rval));
+        CHECK_EQUAL(lval, std::numeric_limits<size_t>::min());
+    }
+    {   // unsigned and unsigned
+        size_t lval = std::numeric_limits<size_t>::max();
+        size_t rval = 0;
+        CHECK(!int_add_with_overflow_detect(lval, rval));
+        CHECK_EQUAL(lval, std::numeric_limits<size_t>::max());
+
+        lval = std::numeric_limits<size_t>::max();
+        rval = 1;
+        CHECK(int_add_with_overflow_detect(lval, rval));
+        CHECK_EQUAL(lval, std::numeric_limits<size_t>::max());
+
+        lval = 0;
+        rval = std::numeric_limits<size_t>::max();
+        CHECK(!int_add_with_overflow_detect(lval, rval));
+        CHECK_EQUAL(lval, std::numeric_limits<size_t>::max());
+
+        lval = 1;
+        rval = std::numeric_limits<size_t>::max();
+        CHECK(int_add_with_overflow_detect(lval, rval));
+        CHECK_EQUAL(lval, 1);
+
+        lval = std::numeric_limits<size_t>::max();
+        rval = std::numeric_limits<size_t>::max();
+        CHECK(int_add_with_overflow_detect(lval, rval));
+        CHECK_EQUAL(lval, std::numeric_limits<size_t>::max());
+    }
+}
+
+
+TEST(SafeIntOps_SubtractWithOverflowDetect)
+{
+    {   // signed and signed
+        int lval = std::numeric_limits<int>::max() - 1;
+        char rval = -10;
+        CHECK(int_subtract_with_overflow_detect(lval, rval));   // does overflow
+        CHECK_EQUAL(lval, std::numeric_limits<int>::max() - 1); // unchanged
+
+        rval = -1;
+        lval = std::numeric_limits<int>::max();
+        CHECK(int_subtract_with_overflow_detect(lval, rval));   // does overflow
+        CHECK_EQUAL(lval, std::numeric_limits<int>::max());     // unchanged
+
+        rval = 0;
+        lval = std::numeric_limits<int>::max();
+        CHECK(!int_subtract_with_overflow_detect(lval, rval));  // does not overflow
+        CHECK_EQUAL(lval, std::numeric_limits<int>::max());     // unchanged
+
+        rval = 0;
+        lval = std::numeric_limits<int>::min();
+        CHECK(!int_subtract_with_overflow_detect(lval, rval));  // does not overflow
+        CHECK_EQUAL(lval, std::numeric_limits<int>::min());     // unchanged
+
+        rval = 1;
+        lval = std::numeric_limits<int>::min();
+        CHECK(int_subtract_with_overflow_detect(lval, rval));   // does overflow
+        CHECK_EQUAL(lval, std::numeric_limits<int>::min());     // unchanged
+    }
+    {   // signed and unsigned
+        char lval = std::numeric_limits<char>::min();
+        size_t rval = 0;
+        CHECK(!int_subtract_with_overflow_detect(lval, rval));
+        CHECK_EQUAL(lval, std::numeric_limits<char>::min());
+
+        lval = std::numeric_limits<char>::min();
+        rval = 1;
+        CHECK(int_subtract_with_overflow_detect(lval, rval));
+        CHECK_EQUAL(lval, std::numeric_limits<char>::min());
+
+        lval = std::numeric_limits<char>::min() + 1;
+        rval = 1;
+        CHECK(!int_subtract_with_overflow_detect(lval, rval));
+        CHECK_EQUAL(lval, std::numeric_limits<char>::min());
+
+        lval = std::numeric_limits<char>::min() + 1;
+        rval = 2;
+        CHECK(int_subtract_with_overflow_detect(lval, rval));
+        CHECK_EQUAL(lval, std::numeric_limits<char>::min() + 1);
+
+        lval = 0;
+        rval = -1 * std::numeric_limits<char>::min();
+        CHECK(!int_subtract_with_overflow_detect(lval, rval));
+        CHECK_EQUAL(lval, std::numeric_limits<char>::min());
+
+        lval = -1;
+        rval = -1 * std::numeric_limits<char>::min();
+        CHECK(int_subtract_with_overflow_detect(lval, rval));
+        CHECK_EQUAL(lval, -1);
+    }
+    {   // unsigned and signed
+        size_t lval = std::numeric_limits<size_t>::min();
+        char rval = 0;
+        CHECK(!int_subtract_with_overflow_detect(lval, rval));
+        CHECK_EQUAL(lval, std::numeric_limits<size_t>::min());
+
+        lval = std::numeric_limits<size_t>::min();
+        rval = 1;
+        CHECK(int_subtract_with_overflow_detect(lval, rval));
+        CHECK_EQUAL(lval, std::numeric_limits<size_t>::min());
+
+        lval = std::numeric_limits<size_t>::max();
+        rval = 1;
+        CHECK(!int_subtract_with_overflow_detect(lval, rval));
+        CHECK_EQUAL(lval, std::numeric_limits<size_t>::max() - 1);
+
+        lval = std::numeric_limits<size_t>::max();
+        rval = 0;
+        CHECK(!int_subtract_with_overflow_detect(lval, rval));
+        CHECK_EQUAL(lval, std::numeric_limits<size_t>::max());
+
+        lval = std::numeric_limits<size_t>::max();
+        rval = -1;
+        CHECK(int_subtract_with_overflow_detect(lval, rval));
+        CHECK_EQUAL(lval, std::numeric_limits<size_t>::max());
+    }
+    {   // unsigned and unsigned
+        size_t lval = std::numeric_limits<size_t>::min();
+        size_t rval = 0;
+        CHECK(!int_subtract_with_overflow_detect(lval, rval));
+        CHECK_EQUAL(lval, std::numeric_limits<size_t>::min());
+
+        lval = std::numeric_limits<size_t>::min();
+        rval = 1;
+        CHECK(int_subtract_with_overflow_detect(lval, rval));
+        CHECK_EQUAL(lval, std::numeric_limits<size_t>::min());
+
+        lval = 0;
+        rval = std::numeric_limits<size_t>::max();
+        CHECK(int_subtract_with_overflow_detect(lval, rval));
+        CHECK_EQUAL(lval, 0);
+
+        lval = std::numeric_limits<size_t>::max() - 1;
+        rval = std::numeric_limits<size_t>::max();
+        CHECK(int_subtract_with_overflow_detect(lval, rval));
+        CHECK_EQUAL(lval, std::numeric_limits<size_t>::max() - 1);
+
+        lval = std::numeric_limits<size_t>::max();
+        rval = std::numeric_limits<size_t>::max();
+        CHECK(!int_subtract_with_overflow_detect(lval, rval));
+        CHECK_EQUAL(lval, 0);
+    }
+}
+
+
+TEST(SafeIntOps_Comparisons)
+{
+    int lval = 0;
+    unsigned char rval = 0;
+    CHECK(int_equal_to(lval, rval));
+    CHECK(!int_not_equal_to(lval, rval));
+    CHECK(!int_less_than(lval, rval));
+    CHECK(int_less_than_or_equal(lval, rval));
+    CHECK(!int_greater_than(lval, rval));
+    CHECK(int_greater_than_or_equal(lval, rval));
+
+    lval = std::numeric_limits<int>::max();
+    rval = std::numeric_limits<unsigned char>::max();
+    CHECK(!int_equal_to(lval, rval));
+    CHECK(int_not_equal_to(lval, rval));
+    CHECK(!int_less_than(lval, rval));
+    CHECK(!int_less_than_or_equal(lval, rval));
+    CHECK(int_greater_than(lval, rval));
+    CHECK(int_greater_than_or_equal(lval, rval));
+}
+
+
+TEST(SafeIntOps_MultiplyOverflow)
+{
+    int lval = 256;
+    char rval = 2;
+    CHECK(!int_multiply_with_overflow_detect(lval, rval));
+    CHECK_EQUAL(lval, 512);
+
+    lval = std::numeric_limits<int>::max();
+    rval = 2;
+    CHECK(int_multiply_with_overflow_detect(lval, rval));
+    CHECK_EQUAL(lval, std::numeric_limits<int>::max());
+
+    char lval2 = 2;
+    int rval2 = 63;
+    CHECK(!int_multiply_with_overflow_detect(lval2, rval2));
+    CHECK_EQUAL(lval2, 126);
+
+    lval2 = 2;
+    rval2 = 64; // numeric_limits<char>::max() is 127
+    CHECK(int_multiply_with_overflow_detect(lval2, rval2));
+    CHECK_EQUAL(lval2, 2);
+}
+
+
+TEST(SafeIntOps_IntCast)
+{
+    int64_t signed_int = std::numeric_limits<char>::max() + 1;
+    char signed_char = 0;
+    CHECK(int_cast_with_overflow_detect(signed_int, signed_char));
+    CHECK_EQUAL(signed_char, 0);
+
+    signed_int = std::numeric_limits<char>::max();
+    signed_char = 0;
+    CHECK(!int_cast_with_overflow_detect(signed_int, signed_char));
+    CHECK_EQUAL(signed_char, std::numeric_limits<char>::max());
+
+    signed_int = std::numeric_limits<char>::min();
+    signed_char = 0;
+    CHECK(!int_cast_with_overflow_detect(signed_int, signed_char));
+    CHECK_EQUAL(signed_int, signed_char);
+
+    signed_int = std::numeric_limits<char>::min() - 1;
+    signed_char = 0;
+    CHECK(int_cast_with_overflow_detect(signed_int, signed_char));
+    CHECK_EQUAL(signed_char, 0);
+
+    signed_char = std::numeric_limits<char>::max();
+    signed_int = 0;
+    CHECK(!int_cast_with_overflow_detect(signed_char, signed_int));
+    CHECK_EQUAL(signed_int, signed_char);
+
+    signed_char = std::numeric_limits<char>::min();
+    signed_int = 0;
+    CHECK(!int_cast_with_overflow_detect(signed_char, signed_int));
+    CHECK_EQUAL(signed_int, signed_char);
+}
+
+
+TEST(SafeIntOps_ShiftLeft)
+{
+    size_t uint = 1;
+    CHECK(!int_shift_left_with_overflow_detect(uint, 0));
+    CHECK_EQUAL(uint, 1);
+
+    uint = 0;
+    CHECK(!int_shift_left_with_overflow_detect(uint, 1));
+    CHECK_EQUAL(uint, 0);
+
+    uint = 1;
+    CHECK(!int_shift_left_with_overflow_detect(uint, 1));
+    CHECK_EQUAL(uint, 2);
+
+    uint = 1;
+    CHECK(!int_shift_left_with_overflow_detect(uint, std::numeric_limits<size_t>::digits - 1));
+    CHECK_EQUAL(uint, size_t(1) << (std::numeric_limits<size_t>::digits - 1));
+
+// Shifting by 64 (or greater) is not defined behaviour.
+// With clang, the following does not overflow and gives uint == 1
+//    uint = 1;
+//    CHECK(int_shift_left_with_overflow_detect(uint, std::numeric_limits<size_t>::digits));
+//    CHECK_EQUAL(uint, 1);
+
+    uint = 2;
+    CHECK(int_shift_left_with_overflow_detect(uint, std::numeric_limits<size_t>::digits - 1));
+    CHECK_EQUAL(uint, 2);
+
+    uint = std::numeric_limits<size_t>::max();
+    CHECK(int_shift_left_with_overflow_detect(uint, 1));
+    CHECK_EQUAL(uint, std::numeric_limits<size_t>::max());
+
+    int signed_int = 1;
+    CHECK(!int_shift_left_with_overflow_detect(signed_int, 0));
+    CHECK_EQUAL(signed_int, 1);
+
+    signed_int = 0;
+    CHECK(!int_shift_left_with_overflow_detect(signed_int, 1));
+    CHECK_EQUAL(signed_int, 0);
+
+    signed_int = 1;
+    CHECK(!int_shift_left_with_overflow_detect(signed_int, 1));
+    CHECK_EQUAL(signed_int, 2);
+
+    signed_int = 1;
+    CHECK(!int_shift_left_with_overflow_detect(signed_int, std::numeric_limits<int>::digits - 1));
+    CHECK_EQUAL(signed_int, int(1) << (std::numeric_limits<int>::digits - 1));
+
+    signed_int = 2;
+    CHECK(int_shift_left_with_overflow_detect(signed_int, std::numeric_limits<int>::digits - 1));
+    CHECK_EQUAL(signed_int, 2);
+
+    signed_int = std::numeric_limits<int>::max();
+    CHECK(int_shift_left_with_overflow_detect(signed_int, 1));
+    CHECK_EQUAL(signed_int, std::numeric_limits<int>::max());
+}
+
+
+TEST(SafeIntOps_IsNegative)
+{
+    size_t uint = 0;
+    CHECK(!is_negative(uint));
+
+    uint = size_t(-1);
+    CHECK(!is_negative(uint));
+
+    char c = 0;
+    CHECK(!is_negative(c));
+
+    c = 1;
+    CHECK(!is_negative(c));
+
+    c = std::numeric_limits<char>::max();
+    CHECK(!is_negative(c));
+
+    c = char(-1);
+    CHECK(is_negative(c));
+
+    c = std::numeric_limits<char>::min();
+    CHECK(is_negative(c));
+}
+
+
+TEST(SafeIntOps_CastToUnsigned)
+{
+    size_t from_unsigned = size_t(-1);
+    size_t to_unsigned = cast_to_unsigned<size_t>(from_unsigned);
+    CHECK_EQUAL(to_unsigned, from_unsigned);
+
+    int from_signed = 1;
+    bool to_bool = cast_to_unsigned<bool>(from_signed);
+    CHECK_EQUAL(to_bool, true);
+
+    from_signed = 2;
+    to_bool = cast_to_unsigned<bool>(from_signed);
+    CHECK_EQUAL(to_bool, false);
+    to_unsigned = cast_to_unsigned<size_t>(from_signed);
+    CHECK_EQUAL(to_unsigned, 2);
+
+    from_signed = -1;
+    to_bool = cast_to_unsigned<bool>(from_signed);
+    CHECK_EQUAL(to_bool, true);
+    to_unsigned = cast_to_unsigned<size_t>(from_signed);
+    CHECK_EQUAL(to_unsigned, size_t(-1));
+
+    from_signed = -2;
+    to_bool = cast_to_unsigned<bool>(from_signed);
+    CHECK_EQUAL(to_bool, false);
+    to_unsigned = cast_to_unsigned<size_t>(from_signed);
+    CHECK_EQUAL(to_unsigned, size_t(-2));
 }
 
 

--- a/test/test_safe_int_ops.cpp
+++ b/test/test_safe_int_ops.cpp
@@ -387,35 +387,35 @@ TEST(SafeIntOps_IntCast)
 
 TEST(SafeIntOps_ShiftLeft)
 {
-    size_t uint = 1;
-    CHECK(!int_shift_left_with_overflow_detect(uint, 0));
-    CHECK_EQUAL(uint, 1);
+    size_t unsigned_int = 1;
+    CHECK(!int_shift_left_with_overflow_detect(unsigned_int, 0));
+    CHECK_EQUAL(unsigned_int, 1);
 
-    uint = 0;
-    CHECK(!int_shift_left_with_overflow_detect(uint, 1));
-    CHECK_EQUAL(uint, 0);
+    unsigned_int = 0;
+    CHECK(!int_shift_left_with_overflow_detect(unsigned_int, 1));
+    CHECK_EQUAL(unsigned_int, 0);
 
-    uint = 1;
-    CHECK(!int_shift_left_with_overflow_detect(uint, 1));
-    CHECK_EQUAL(uint, 2);
+    unsigned_int = 1;
+    CHECK(!int_shift_left_with_overflow_detect(unsigned_int, 1));
+    CHECK_EQUAL(unsigned_int, 2);
 
-    uint = 1;
-    CHECK(!int_shift_left_with_overflow_detect(uint, std::numeric_limits<size_t>::digits - 1));
-    CHECK_EQUAL(uint, size_t(1) << (std::numeric_limits<size_t>::digits - 1));
+    unsigned_int = 1;
+    CHECK(!int_shift_left_with_overflow_detect(unsigned_int, std::numeric_limits<size_t>::digits - 1));
+    CHECK_EQUAL(unsigned_int, size_t(1) << (std::numeric_limits<size_t>::digits - 1));
 
 // Shifting by 64 (or greater) is not defined behaviour.
-// With clang, the following does not overflow and gives uint == 1
-//    uint = 1;
-//    CHECK(int_shift_left_with_overflow_detect(uint, std::numeric_limits<size_t>::digits));
-//    CHECK_EQUAL(uint, 1);
+// With clang, the following does not overflow and gives unsigned_int == 1
+//    unsigned_int = 1;
+//    CHECK(int_shift_left_with_overflow_detect(unsigned_int, std::numeric_limits<size_t>::digits));
+//    CHECK_EQUAL(unsigned_int, 1);
 
-    uint = 2;
-    CHECK(int_shift_left_with_overflow_detect(uint, std::numeric_limits<size_t>::digits - 1));
-    CHECK_EQUAL(uint, 2);
+    unsigned_int = 2;
+    CHECK(int_shift_left_with_overflow_detect(unsigned_int, std::numeric_limits<size_t>::digits - 1));
+    CHECK_EQUAL(unsigned_int, 2);
 
-    uint = std::numeric_limits<size_t>::max();
-    CHECK(int_shift_left_with_overflow_detect(uint, 1));
-    CHECK_EQUAL(uint, std::numeric_limits<size_t>::max());
+    unsigned_int = std::numeric_limits<size_t>::max();
+    CHECK(int_shift_left_with_overflow_detect(unsigned_int, 1));
+    CHECK_EQUAL(unsigned_int, std::numeric_limits<size_t>::max());
 
     int signed_int = 1;
     CHECK(!int_shift_left_with_overflow_detect(signed_int, 0));
@@ -445,11 +445,11 @@ TEST(SafeIntOps_ShiftLeft)
 
 TEST(SafeIntOps_IsNegative)
 {
-    size_t uint = 0;
-    CHECK(!is_negative(uint));
+    size_t unsigned_int = 0;
+    CHECK(!is_negative(unsigned_int));
 
-    uint = size_t(-1);
-    CHECK(!is_negative(uint));
+    unsigned_int = size_t(-1);
+    CHECK(!is_negative(unsigned_int));
 
     char c = 0;
     CHECK(!is_negative(c));

--- a/test/test_util_stringbuffer.cpp
+++ b/test/test_util_stringbuffer.cpp
@@ -168,4 +168,19 @@ TEST(Utils_StringBuffer)
 }
 }
 
+
+// This test requests a string of 2.14 GB and so is disabled for normal CI runs.
+// There was a bug in int_multiply_with_overflow_detect (used in StringBuffer::reserve())
+// which would cause appending to any string longer than half of std::numeric_limits<int>::max()
+// to request buffer space for std::numeric_limits<size_t>::max() which is *much* larger.
+TEST_IF(Utils_StringBufferLargeResize, TEST_DURATION > 0)
+{
+    StringBuffer sb;
+    std::string long_str((std::numeric_limits<int>::max() / 2) + 1, 'a');
+    sb.append(long_str);
+    sb.append("hello world");
+    // with the bug, you would probably get a std::bad_alloc exception instead of failing the following check
+    CHECK_NOT_EQUAL(sb.size(), std::numeric_limits<size_t>::max());
+}
+
 #endif


### PR DESCRIPTION
Adds unit tests for the safe int ops functions.
This revealed a bug in `int_multiply_with_overflow_detect()`.

@simonask I started this because you said there was an error on [line 457](https://github.com/realm/realm-core/blob/master/src/realm/util/safe_int_ops.hpp#L457) but I couldn't see anything wrong there - can you double check?