### PR TITLE
Fix bug when moving a StringEnumColumn

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,9 @@
 
 ### Bugfixes
 
-* Lorem ipsum.
+* Fix possible corruption when moving a StringEnumColumn.
+  Currently unused by bindings.
+  PR [#2924](https://github.com/realm/realm-core/pull/2924).
 
 ### Breaking changes
 

--- a/src/realm/spec.cpp
+++ b/src/realm/spec.cpp
@@ -385,9 +385,11 @@ void Spec::move_column(size_t from_ndx, size_t to_ndx)
 
         size_t from_enums_ndx = get_enumkeys_ndx(from_ndx);
         size_t to_enums_ndx = get_enumkeys_ndx(to_ndx);
-        if (to_enums_ndx >= m_enumkeys.size()) {
-            to_enums_ndx = m_enumkeys.size() - 1;
+        ColumnType to_type = ColumnType(m_types.get(to_ndx));
+        if (to_ndx > from_ndx && to_type != col_type_StringEnum) {
+            to_enums_ndx -= 1;
         }
+
         m_enumkeys.move_rotate(from_enums_ndx, to_enums_ndx);
     }
 


### PR DESCRIPTION
This code is really tricky, I've fixed a bug here before without catching this one. Libfuzzer found this case where the sparse array `m_enumkeys` gets the wrong index applied to the move operation.