### PR TITLE
Expose move_column to the public API

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,8 @@
 
 ### Enhancements
 
-* Lorem ipsum.
+* Expose `Table::move_column` to the public API.
+  PR [#2925](https://github.com/realm/realm-core/pull/2925).
 
 -----------
 

--- a/src/realm/descriptor.hpp
+++ b/src/realm/descriptor.hpp
@@ -217,6 +217,20 @@ public:
     /// \sa Table::rename_column()
     void rename_column(size_t col_ndx, StringData new_name);
 
+    /// Change the ordering of existing columns.
+    ///
+    /// This function modifies the dynamic type of all the tables that share
+    /// this descriptor. The consequences of specifying column indexes that
+    /// are out of range are undefined.
+    ///
+    /// \param from_ndx The index of an existing column which should be moved.
+    ///
+    /// \param to_ndx The index of the destination that the column should be moved to.
+    ///
+    /// \sa Table::add_column()
+    /// \sa Table::remove_column()
+    void move_column(size_t from_ndx, size_t to_ndx);
+
     /// If the descriptor is describing a subtable column, the add_search_index()
     /// and remove_search_index() will add or remove search indexes of *all*
     /// subtables of the subtable column. This may take a while if there are many
@@ -514,8 +528,6 @@ private:
     // subdescriptor if that accessor exists, otherwise this function
     // return null.
     DescriptorRef get_subdesc_accessor(size_t column_ndx) noexcept;
-
-    void move_column(size_t from_ndx, size_t to_ndx);
 
     void adj_insert_column(size_t col_ndx) noexcept;
     void adj_erase_column(size_t col_ndx) noexcept;

--- a/src/realm/table.cpp
+++ b/src/realm/table.cpp
@@ -405,6 +405,13 @@ void Table::rename_column(size_t col_ndx, StringData name)
 }
 
 
+void Table::move_column(size_t from_ndx, size_t to_ndx)
+{
+    REALM_ASSERT(!has_shared_type());
+    get_descriptor()->move_column(from_ndx, to_ndx);
+}
+
+
 DescriptorRef Table::get_descriptor()
 {
     REALM_ASSERT(is_attached());

--- a/src/realm/table.hpp
+++ b/src/realm/table.hpp
@@ -216,6 +216,7 @@ public:
                             LinkType link_type = link_Weak);
     void remove_column(size_t column_ndx);
     void rename_column(size_t column_ndx, StringData new_name);
+    void move_column(size_t from_ndx, size_t to_ndx);
     //@}
 
     //@{

--- a/test/fuzz_group.cpp
+++ b/test/fuzz_group.cpp
@@ -556,10 +556,10 @@ void parse_and_apply_instructions(std::string& in, const std::string& path, util
                     size_t col_ndx1 = get_next(s) % t->get_column_count();
                     size_t col_ndx2 = get_next(s) % t->get_column_count();
                     if (log) {
-                        *log << "_impl::TableFriend::move_column(*(g.get_table(" << table_ndx
-                             << ")->get_descriptor()), " << col_ndx1 << ", " << col_ndx2 << ");\n";
+                        *log << "g.get_table(" << table_ndx << ")->move_column(" << col_ndx1 << ", "
+                             << col_ndx2 << ");\n";
                     }
-                    _impl::TableFriend::move_column(*(t->get_descriptor()), col_ndx1, col_ndx2);
+                    t->move_column(col_ndx1, col_ndx2);
                 }
             }
             else if (instr == ADD_SEARCH_INDEX && g.size() > 0) {

--- a/test/test_lang_bind_helper.cpp
+++ b/test/test_lang_bind_helper.cpp
@@ -1221,11 +1221,9 @@ TEST(LangBindHelper_AdvanceReadTransact_MixedColumn)
     {
         WriteTransaction wt(sg_w);
         TableRef table_w = wt.get_table("t");
-        DescriptorRef desc_w = table_w->get_descriptor();
-        using tf = _impl::TableFriend;
-        tf::move_column(*desc_w, 7, 2); // FIXME: Not yet publicly exposed
-        tf::move_column(*desc_w, 8, 4);
-        tf::move_column(*desc_w, 2, 7);
+        table_w->move_column(7, 2);
+        table_w->move_column(8, 4);
+        table_w->move_column(2, 7);
         wt.commit();
     }
     LangBindHelper::advance_read(sg);
@@ -1415,10 +1413,8 @@ TEST(LangBindHelper_AdvanceReadTransact_SearchIndex)
     {
         WriteTransaction wt(sg_w);
         TableRef table_w = wt.get_table("t");
-        DescriptorRef desc_w = table_w->get_descriptor();
-        using tf = _impl::TableFriend;
-        tf::move_column(*desc_w, 2, 5); // FIXME: Not yet publicly exposed
-        tf::move_column(*desc_w, 1, 6);
+        table_w->move_column(2, 5);
+        table_w->move_column(1, 6);
         wt.commit();
     }
     LangBindHelper::advance_read(sg);
@@ -12972,7 +12968,7 @@ TEST(LangBindHelper_RollbackMoveSame)
     g.verify();
     LangBindHelper::promote_to_write(sg_w);
     g.verify();
-    _impl::TableFriend::move_column(*(g.get_table(1)->get_descriptor()), 0, 0);
+    g.get_table(1)->move_column(0, 0);
     LangBindHelper::rollback_and_continue_as_read(sg_w);
     g.verify();
 }
@@ -13001,7 +12997,7 @@ TEST(LangBindHelper_ColumnMoveUpdatesLinkedTables)
     g_r.verify();
     LangBindHelper::promote_to_write(sg_w);
 
-    _impl::TableFriend::move_column(*(t0->get_descriptor()), 0, 1);
+    t0->move_column(0, 1);
     LangBindHelper::commit_and_continue_as_read(sg_w);
     g.verify();
     LangBindHelper::advance_read(sg_r);

--- a/test/test_replication.cpp
+++ b/test/test_replication.cpp
@@ -3634,7 +3634,7 @@ TEST(Replication_RenameGroupLevelTable_MoveGroupLevelTable_RenameColumn_MoveColu
         wt.get_group().rename_table("foo", "bar");
         auto bar = wt.get_table("bar");
         bar->rename_column(0, "b");
-        _impl::TableFriend::move_column(*bar->get_descriptor(), 1, 0);
+        bar->move_column(1, 0);
         wt.get_group().move_table(1, 0);
         wt.commit();
     }

--- a/test/test_table.cpp
+++ b/test/test_table.cpp
@@ -7095,7 +7095,7 @@ TEST(Table_MultipleLinkColumnsToSelf)
     t->insert_column_link(1, type_LinkList, "f", *t);
     t->add_empty_row();
     t->get_linklist(1, 0)->add(0);
-    _impl::TableFriend::move_column(*t->get_descriptor(), 0, 1);
+    t->move_column(0, 1);
     g.verify();
     t->get_linklist(0, 0)->add(0);
     g.verify();
@@ -7111,7 +7111,7 @@ TEST(Table_MultipleLinkColumnsToOther)
     t->insert_column_link(1, type_LinkList, "f", *t);
     t->add_empty_row();
     t->get_linklist(1, 0)->add(0);
-    _impl::TableFriend::move_column(*t->get_descriptor(), 0, 1);
+    t->move_column(0, 1);
     g.verify();
     t->get_linklist(0, 0)->add(0);
     g.verify();
@@ -7127,7 +7127,7 @@ TEST(Table_MultipleLinkColumnsMoveTables)
     t->insert_column_link(1, type_LinkList, "f", *t);
     t->add_empty_row();
     t->get_linklist(1, 0)->add(0);
-    _impl::TableFriend::move_column(*t->get_descriptor(), 0, 1);
+    t->move_column(0, 1);
     g.verify();
     t->get_linklist(0, 0)->add(0);
     g.verify();
@@ -7150,13 +7150,13 @@ TEST(Table_MultipleLinkColumnsMoveTablesCrossLinks)
     t->get_linklist(1, 0)->add(0);
     g.move_table(0, 1);
     g.verify();
-    _impl::TableFriend::move_column(*t->get_descriptor(), 1, 2);
+    t->move_column(1, 2);
     g.verify();
     t->get_linklist(2, 0)->add(0);
     g.verify();
     g.move_table(1, 0);
     g.verify();
-    _impl::TableFriend::move_column(*t->get_descriptor(), 1, 0);
+    t->move_column(1, 0);
     g.verify();
 }
 
@@ -7175,15 +7175,15 @@ TEST(Table_MoveEnumColumns)
     CHECK(t.get_string(0, 0) == "hello");
     CHECK(t.get_string(1, 0) == "world");
     t.verify();
-    _impl::TableFriend::move_column(*t.get_descriptor(), 1, 0);
+    t.move_column(1, 0);
     CHECK(t.get_string(0, 0) == "world");
     CHECK(t.get_string(1, 0) == "hello");
     t.verify();
-    _impl::TableFriend::move_column(*t.get_descriptor(), 0, 1);
+    t.move_column(0, 1);
     CHECK(t.get_string(0, 0) == "hello");
     CHECK(t.get_string(1, 0) == "world");
     t.verify();
-    _impl::TableFriend::move_column(*t.get_descriptor(), 1, 1);
+    t.move_column(1, 1);
     CHECK(t.get_string(0, 0) == "hello");
     CHECK(t.get_string(1, 0) == "world");
     t.verify();
@@ -7206,27 +7206,27 @@ TEST(LangBindHelper_StringEnumMoveOutOfBounds)
     t.set_string(0, 0, enum_0);
     t.set_string(1, 0, str_1);
 
-    _impl::TableFriend::move_column(*(t.get_descriptor()), 0, 1);
+    t.move_column(0, 1);
     t.verify();
     CHECK(t.get_string(0, 0) == str_1);
     CHECK(t.get_string(1, 0) == enum_0);
 
-    _impl::TableFriend::move_column(*(t.get_descriptor()), 1, 1);
+    t.move_column(1, 1);
     t.verify();
     CHECK(t.get_string(0, 0) == str_1);
     CHECK(t.get_string(1, 0) == enum_0);
 
-    _impl::TableFriend::move_column(*(t.get_descriptor()), 0, 0);
+    t.move_column(0, 0);
     t.verify();
     CHECK(t.get_string(0, 0) == str_1);
     CHECK(t.get_string(1, 0) == enum_0);
 
-    _impl::TableFriend::move_column(*(t.get_descriptor()), 1, 0);
+    t.move_column(1, 0);
     t.verify();
     CHECK(t.get_string(0, 0) == enum_0);
     CHECK(t.get_string(1, 0) == str_1);
 
-    _impl::TableFriend::move_column(*(t.get_descriptor()), 1, 0);
+    t.move_column(1, 0);
     t.verify();
     CHECK(t.get_string(0, 0) == str_1);
     CHECK(t.get_string(1, 0) == enum_0);
@@ -7236,37 +7236,37 @@ TEST(LangBindHelper_StringEnumMoveOutOfBounds)
     t.set_string(0, 0, enum_1);
     t.set_string(2, 0, str_2);
 
-    _impl::TableFriend::move_column(*(t.get_descriptor()), 2, 1);
+    t.move_column(2, 1);
     t.verify();
     CHECK(t.get_string(0, 0) == enum_1);
     CHECK(t.get_string(1, 0) == str_2);
     CHECK(t.get_string(2, 0) == enum_0);
 
-    _impl::TableFriend::move_column(*(t.get_descriptor()), 2, 1);
+    t.move_column(2, 1);
     t.verify();
     CHECK(t.get_string(0, 0) == enum_1);
     CHECK(t.get_string(1, 0) == enum_0);
     CHECK(t.get_string(2, 0) == str_2);
 
-    _impl::TableFriend::move_column(*(t.get_descriptor()), 0, 2);
+    t.move_column(0, 2);
     t.verify();
     CHECK(t.get_string(0, 0) == enum_0);
     CHECK(t.get_string(1, 0) == str_2);
     CHECK(t.get_string(2, 0) == enum_1);
 
-    _impl::TableFriend::move_column(*(t.get_descriptor()), 0, 2);
+    t.move_column(0, 2);
     t.verify();
     CHECK(t.get_string(0, 0) == str_2);
     CHECK(t.get_string(1, 0) == enum_1);
     CHECK(t.get_string(2, 0) == enum_0);
 
-    _impl::TableFriend::move_column(*(t.get_descriptor()), 2, 0);
+    t.move_column(2, 0);
     t.verify();
     CHECK(t.get_string(0, 0) == enum_0);
     CHECK(t.get_string(1, 0) == str_2);
     CHECK(t.get_string(2, 0) == enum_1);
 
-    _impl::TableFriend::move_column(*(t.get_descriptor()), 0, 2);
+    t.move_column(0, 2);
     t.verify();
     CHECK(t.get_string(0, 0) == str_2);
     CHECK(t.get_string(1, 0) == enum_1);
@@ -7275,19 +7275,19 @@ TEST(LangBindHelper_StringEnumMoveOutOfBounds)
     t.optimize(enforce);
     t.set_string(0, 0, enum_2);
 
-    _impl::TableFriend::move_column(*(t.get_descriptor()), 0, 2);
+    t.move_column(0, 2);
     t.verify();
     CHECK(t.get_string(0, 0) == enum_1);
     CHECK(t.get_string(1, 0) == enum_0);
     CHECK(t.get_string(2, 0) == enum_2);
 
-    _impl::TableFriend::move_column(*(t.get_descriptor()), 2, 0);
+    t.move_column(2, 0);
     t.verify();
     CHECK(t.get_string(0, 0) == enum_2);
     CHECK(t.get_string(1, 0) == enum_1);
     CHECK(t.get_string(2, 0) == enum_0);
 
-    _impl::TableFriend::move_column(*(t.get_descriptor()), 1, 2);
+    t.move_column(1, 2);
     t.verify();
     CHECK(t.get_string(0, 0) == enum_2);
     CHECK(t.get_string(1, 0) == enum_0);
@@ -7318,14 +7318,14 @@ TEST(Table_MoveSubtables)
         CHECK_EQUAL(sub1->get_column_name(0), "integers");
         CHECK_EQUAL(sub2->get_column_name(0), "strings");
     }
-    _impl::TableFriend::move_column(*t->get_descriptor(), 0, 2);
+    t->move_column(0, 2);
     {
         DescriptorRef sub1 = t->get_subdescriptor(2);
         DescriptorRef sub2 = t->get_subdescriptor(1);
         CHECK_EQUAL(sub1->get_column_name(0), "integers");
         CHECK_EQUAL(sub2->get_column_name(0), "strings");
     }
-    _impl::TableFriend::move_column(*t->get_descriptor(), 2, 0);
+    t->move_column(2, 0);
     {
         DescriptorRef sub1 = t->get_subdescriptor(0);
         DescriptorRef sub2 = t->get_subdescriptor(2);


### PR DESCRIPTION
Although `move_column` is currently only used by sync, it should be fully supported to prevent an asymmetric API. This also frees us from writing test code that uses the private API through `TableFriend` which is incorrect for tables which contain subtable columns (because the descriptor accessor lists must be updated and `TableFriend` bypasses the descriptor level of the API).