### PR TITLE
Subtable move_row

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,8 @@
 
 ### Bugfixes
 
-* Lorem ipsum.
+* Fix possible corruption or crashes when a `move_row` operates on a subtable.
+  PR [#2927](https://github.com/realm/realm-core/pull/2926).
 
 ### Breaking changes
 

--- a/src/realm/column_table.hpp
+++ b/src/realm/column_table.hpp
@@ -114,6 +114,7 @@ protected:
                               _impl::TableFriend::AccessorUpdater&);
         void recursive_mark() noexcept;
         void refresh_accessor_tree();
+        void verify(const SubtableColumn& parent);
 
     private:
         struct SubtableEntry {
@@ -535,8 +536,33 @@ void SubtableColumnBase::SubtableMap::adj_swap_rows(size_t row_ndx_1, size_t row
 template <bool fix_ndx_in_parent>
 void SubtableColumnBase::SubtableMap::adj_move_row(size_t from_ndx, size_t to_ndx) noexcept
 {
-    adj_erase_rows<fix_ndx_in_parent>(from_ndx, 1);
-    adj_insert_rows<fix_ndx_in_parent>(to_ndx, 1);
+    using tf = _impl::TableFriend;
+    for (auto& entry : m_entries) {
+        if (entry.m_subtable_ndx == from_ndx) {
+            entry.m_subtable_ndx = to_ndx;
+            if (fix_ndx_in_parent)
+                tf::set_ndx_in_parent(*(entry.m_table), entry.m_subtable_ndx);
+        }
+        else {
+            if (from_ndx < to_ndx) {
+                // shift the range (from, to] down one
+                if (entry.m_subtable_ndx <= to_ndx && entry.m_subtable_ndx > from_ndx) {
+                    entry.m_subtable_ndx--;
+                    if (fix_ndx_in_parent) {
+                        tf::set_ndx_in_parent(*(entry.m_table), entry.m_subtable_ndx);
+                    }
+                }
+            } else if (from_ndx > to_ndx) {
+                // shift the range (from, to] up one
+                if (entry.m_subtable_ndx >= to_ndx && entry.m_subtable_ndx < from_ndx) {
+                    entry.m_subtable_ndx++;
+                    if (fix_ndx_in_parent) {
+                        tf::set_ndx_in_parent(*(entry.m_table), entry.m_subtable_ndx);
+                    }
+                }
+            }
+        }
+    }
 }
 
 inline void SubtableColumnBase::SubtableMap::adj_set_null(size_t row_ndx) noexcept

--- a/src/realm/column_table.hpp
+++ b/src/realm/column_table.hpp
@@ -399,6 +399,7 @@ inline void SubtableColumnBase::adj_acc_swap_rows(size_t row_ndx_1, size_t row_n
 
 inline void SubtableColumnBase::adj_acc_move_row(size_t from_ndx, size_t to_ndx) noexcept
 {
+    std::lock_guard<std::recursive_mutex> lg(m_subtable_map_lock);
     const bool fix_ndx_in_parent = false;
     m_subtable_map.adj_move_row<fix_ndx_in_parent>(from_ndx, to_ndx);
 }
@@ -534,14 +535,8 @@ void SubtableColumnBase::SubtableMap::adj_swap_rows(size_t row_ndx_1, size_t row
 template <bool fix_ndx_in_parent>
 void SubtableColumnBase::SubtableMap::adj_move_row(size_t from_ndx, size_t to_ndx) noexcept
 {
-    if (from_ndx < to_ndx) {
-        adj_insert_rows<fix_ndx_in_parent>(to_ndx, 1);
-        adj_erase_rows<fix_ndx_in_parent>(from_ndx, 1);
-    }
-    else {
-        adj_erase_rows<fix_ndx_in_parent>(from_ndx, 1);
-        adj_insert_rows<fix_ndx_in_parent>(to_ndx, 1);
-    }
+    adj_erase_rows<fix_ndx_in_parent>(from_ndx, 1);
+    adj_insert_rows<fix_ndx_in_parent>(to_ndx, 1);
 }
 
 inline void SubtableColumnBase::SubtableMap::adj_set_null(size_t row_ndx) noexcept


### PR DESCRIPTION
This case was found by our fuzz testing friends:)
The problem is that a subtable accessor could be given the wrong `m_ndx_in_parent` after a `move_row` operation.
I also added missing accessor lock on `SubtableColumnBase::adj_acc_move_row`.

Interestingly, in release mode this can cause a familiar error during commit: 
`../src/realm/group_writer.cpp:392: [realm-core-4.0.3] Assertion failed: ref + size <= after_ref with (ref, size, after_ref, ndx, m_free_positions.size()) =  [232, 312, 232, 2, 4]`
In debug mode it can cause:
`../src/realm/alloc_slab.cpp:440: [realm-core-4.0.3] Assertion failed: false && "Double Free"`
Depending on which operations follow.