### PR TITLE
Fix bug in Queries with two OR nodes at different nesting levels

### DIFF
--- a/src/realm/query.cpp
+++ b/src/realm/query.cpp
@@ -1242,7 +1242,6 @@ void Query::handle_pending_not()
 Query& Query::Or()
 {
     auto& current_group = m_groups.back();
-    OrNode* or_node = dynamic_cast<OrNode*>(current_group.m_root_node.get());
     if (current_group.m_state != QueryGroup::State::OrConditionChildren) {
         // Reparent the current group's nodes within an OrNode.
         add_node(std::unique_ptr<ParentNode>(new OrNode(std::move(current_group.m_root_node))));

--- a/src/realm/query.cpp
+++ b/src/realm/query.cpp
@@ -1243,7 +1243,7 @@ Query& Query::Or()
 {
     auto& current_group = m_groups.back();
     OrNode* or_node = dynamic_cast<OrNode*>(current_group.m_root_node.get());
-    if (!or_node) {
+    if (current_group.m_state != QueryGroup::State::OrConditionChildren) {
         // Reparent the current group's nodes within an OrNode.
         add_node(std::unique_ptr<ParentNode>(new OrNode(std::move(current_group.m_root_node))));
     }


### PR DESCRIPTION
@bdash can you verify this fix? It's a bit hard to see what's going on.

In the old code, the `or_node` variable was true when the second Or() was invoked (because it saw the first Or() node in `current_group.m_root_node.get()`. So all three conditions of the query ended up in `m_conditions` of the first Or().

@kneth @beeender please carefully read the source code comment I have added to table.hpp for the link() and backlink() methods.