### PR TITLE
Fix enums add zero rows

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
 ### Bugfixes
 
 * Fix an issue where adding zero rows would add the default value to the keys
-  of any string enum columns. 
+  of any string enum columns. Not affecting end users.
   PR [#2956](https://github.com/realm/realm-core/pull/2956).
 
 ### Breaking changes
@@ -18,7 +18,7 @@
 
 ### Internals
 
-* Lorem ipsum.
+* None
 
 ----------------------------------------------
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,9 @@
 
 ### Bugfixes
 
-* Lorem ipsum.
+* Fix an issue where adding zero rows would add the default value to the keys
+  of any string enum columns. 
+  PR [#2956](https://github.com/realm/realm-core/pull/2956).
 
 ### Breaking changes
 

--- a/src/realm/column_string_enum.cpp
+++ b/src/realm/column_string_enum.cpp
@@ -117,6 +117,9 @@ void StringEnumColumn::do_insert(size_t row_ndx, StringData value, size_t num_ro
 
 void StringEnumColumn::do_insert(size_t row_ndx, StringData value, size_t num_rows, bool is_append)
 {
+    if (num_rows == 0)
+        return; // do not add a key if no rows are actually being inserted
+
     size_t key_ndx = get_key_ndx_or_add(value);
     size_t row_ndx_2 = is_append ? realm::npos : row_ndx;
     int64_t value_2 = int64_t(key_ndx);

--- a/src/realm/column_string_enum.cpp
+++ b/src/realm/column_string_enum.cpp
@@ -103,6 +103,9 @@ void StringEnumColumn::set(size_t ndx, StringData value)
 
 void StringEnumColumn::do_insert(size_t row_ndx, StringData value, size_t num_rows)
 {
+    if (num_rows == 0)
+        return; // do not add a key if no rows are actually being inserted
+
     size_t key_ndx = get_key_ndx_or_add(value);
     int64_t value_2 = int64_t(key_ndx);
     insert_without_updating_index(row_ndx, value_2, num_rows); // Throws


### PR DESCRIPTION
This was discovered by external fuzz testing.

The method `get_key_ndx_or_add()` would add the default string to the keys and not to the index if the number of rows to insert was zero.

This does not affect our users since enum columns haven't yet been released (see https://github.com/realm/realm-object-store/pull/501).