### PR TITLE
Fix realm-parser CMake export

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@
 
 ### Enhancements
 
-* Lorem ipsum.
+* Add a CMake import target for the `realm-parser` library.
 
 -----------
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -157,7 +157,7 @@ endif()
 install(FILES LICENSE CHANGELOG.md DESTINATION "doc/realm" COMPONENT devel)
 
 # Make the project importable from the build directory
-export(TARGETS realm FILE realm-config.cmake)
+export(TARGETS realm realm-parser FILE realm-config.cmake)
 
 # Make the project importable from the install directory
 install(EXPORT realm

--- a/src/realm/CMakeLists.txt
+++ b/src/realm/CMakeLists.txt
@@ -372,8 +372,8 @@ if(ANDROID)
 endif()
 
 add_library(realm-parser STATIC ${REALM_PARSER_SOURCES} ${REALM_PARSER_HEADERS})
-add_dependencies(realm-parser realm)
-target_include_directories(realm-parser PUBLIC ${PEGTL_INCLUDE_DIR})
+target_link_libraries(realm-parser PUBLIC realm)
+target_include_directories(realm-parser PRIVATE ${PEGTL_INCLUDE_DIR})
 install(FILES ${REALM_PARSER_HEADERS}
         DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}/realm/parser
         COMPONENT devel)
@@ -383,7 +383,7 @@ if(NOT REALM_SKIP_SHARED_LIB)
     add_library(realm-parser-shared SHARED ${REALM_PARSER_SOURCES} ${REALM_PARSER_HEADERS})
     add_dependencies(realm-parser-shared realm-shared)
     target_link_libraries(realm-parser-shared PRIVATE realm-shared)
-    target_include_directories(realm-parser-shared PUBLIC ${PEGTL_INCLUDE_DIR})
+    target_include_directories(realm-parser-shared PRIVATE ${PEGTL_INCLUDE_DIR})
     target_include_directories(realm-parser-shared INTERFACE
                                $<BUILD_INTERFACE:${CMAKE_SOURCE_DIR}/src> $<BUILD_INTERFACE:${CMAKE_BINARY_DIR}/src>
                                $<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}>)

--- a/src/realm/CMakeLists.txt
+++ b/src/realm/CMakeLists.txt
@@ -377,7 +377,7 @@ target_include_directories(realm-parser PUBLIC ${PEGTL_INCLUDE_DIR})
 install(FILES ${REALM_PARSER_HEADERS}
         DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}/realm/parser
         COMPONENT devel)
-install(TARGETS realm-parser EXPORT realm-parser
+install(TARGETS realm-parser EXPORT realm
         ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR} COMPONENT devel)
 if(NOT REALM_SKIP_SHARED_LIB)
     add_library(realm-parser-shared SHARED ${REALM_PARSER_SOURCES} ${REALM_PARSER_HEADERS})


### PR DESCRIPTION
The `install` command for `realm-parser` was using `EXPORT realm-parser` instead of `EXPORT realm` and this caused the `install(EXPORT realm)` command to not pick up realm-parser and create an `IMPORT` target for it in the exported `realm-config.cmake` file.