### PR TITLE
improve performance of data change management

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,10 @@
 
 ### Enhancements
 
-* None.
+* Avoid excessive bumping of counters in the version management machinery that is
+  responsible for supporting live queries. We now prune version bumping earlier if
+  when we have sequences of changes without queries in between.
+  PR [#2962](https://github.com/realm/realm-core/pull/2962)
 
 -----------
 

--- a/src/realm/alloc.hpp
+++ b/src/realm/alloc.hpp
@@ -183,6 +183,7 @@ protected:
     // that can make sync_if_needed() re-run queries even though it is not required.
     // It must be atomic because it's shared.
     std::atomic<uint_fast64_t> m_table_versioning_counter;
+    std::atomic<uint_fast64_t> m_latest_observed_counter;
 
     /// Bump the global version counter. This method should be called when
     /// version bumping is initiated. Then following calls to should_propagate_version()
@@ -194,13 +195,24 @@ protected:
     /// to control propagation of version updates on tables within the group.
     bool should_propagate_version(uint_fast64_t& local_version) noexcept;
 
+    /// Note the current global version has been observed.
+    void observe_version() noexcept;
+
     friend class Table;
     friend class Group;
 };
 
 inline void Allocator::bump_global_version() noexcept
 {
-    m_table_versioning_counter += 1;
+    if (m_latest_observed_counter == m_table_versioning_counter)
+        m_table_versioning_counter += 1;
+}
+
+
+inline void Allocator::observe_version() noexcept
+{
+    if (m_latest_observed_counter != m_table_versioning_counter)
+        m_latest_observed_counter.store(m_table_versioning_counter, std::memory_order_relaxed);
 }
 
 
@@ -358,6 +370,7 @@ inline bool Allocator::is_read_only(ref_type ref) const noexcept
 inline Allocator::Allocator() noexcept
 {
     m_table_versioning_counter = 0;
+    m_latest_observed_counter = 0;
 }
 
 inline Allocator::~Allocator() noexcept

--- a/src/realm/table.hpp
+++ b/src/realm/table.hpp
@@ -1082,10 +1082,10 @@ private:
     // Upgrades OldDateTime columns to Timestamp columns
     void upgrade_olddatetime();
 
-    // indicate that the current global state version has been "observed". Until this
-    // happens, bumping of the globalt version counter can be bypassed, as any query
+    // Indicate that the current global state version has been "observed". Until this
+    // happens, bumping of the global version counter can be bypassed, as any query
     // checking for a version change will see the older version change anyways.
-    // Also returns the table-local version
+    // Also returns the table-local version.
     uint64_t observe_version() const noexcept;
 
     /// Update the version of this table and all tables which have links to it.

--- a/src/realm/table.hpp
+++ b/src/realm/table.hpp
@@ -1082,6 +1082,12 @@ private:
     // Upgrades OldDateTime columns to Timestamp columns
     void upgrade_olddatetime();
 
+    // indicate that the current global state version has been "observed". Until this
+    // happens, bumping of the globalt version counter can be bypassed, as any query
+    // checking for a version change will see the older version change anyways.
+    // Also returns the table-local version
+    uint64_t observe_version() const noexcept;
+
     /// Update the version of this table and all tables which have links to it.
     /// This causes all views referring to those tables to go out of sync, so that
     /// calls to sync_if_needed() will bring the view up to date by reexecuting the
@@ -1612,6 +1618,12 @@ protected:
 
 inline uint_fast64_t Table::get_version_counter() const noexcept
 {
+    return observe_version();
+}
+
+inline uint64_t Table::observe_version() const noexcept
+{
+    m_top.get_alloc().observe_version();
     return m_version;
 }
 

--- a/src/realm/table_view.cpp
+++ b/src/realm/table_view.cpp
@@ -506,12 +506,12 @@ uint64_t TableViewBase::outside_version() const
 
     if (m_linkview_source) {
         // m_linkview_source is set when this TableView was created by LinkView::get_as_sorted_view().
-        return m_linkview_source->is_attached() ? m_linkview_source->get_origin_table().m_version : max;
+        return m_linkview_source->is_attached() ? m_linkview_source->get_origin_table().observe_version() : max;
     }
 
     if (m_linked_column) {
         // m_linked_column is set when this TableView was created by Table::get_backlink_view().
-        return m_linked_row ? m_linked_row.get_table()->m_version : max;
+        return m_linked_row ? m_linked_row.get_table()->observe_version() : max;
     }
 
     if (m_query.m_table) {
@@ -519,7 +519,7 @@ uint64_t TableViewBase::outside_version() const
 
         if (auto* view = dynamic_cast<LinkView*>(m_query.m_view)) {
             // This TableView depends on Query that is restricted by a LinkView (with where(&link_view))
-            return view->is_attached() ? view->get_origin_table().m_version : max;
+            return view->is_attached() ? view->get_origin_table().observe_version() : max;
         }
 
         if (auto* view = dynamic_cast<TableView*>(m_query.m_view)) {
@@ -529,7 +529,7 @@ uint64_t TableViewBase::outside_version() const
     }
 
     // This TableView was either created by Table::get_distinct_view(), or a Query that is not restricted to a view.
-    return m_table->m_version;
+    return m_table->observe_version();
 }
 
 bool TableViewBase::is_in_sync() const

--- a/test/test_table.cpp
+++ b/test/test_table.cpp
@@ -8240,6 +8240,7 @@ TEST(Table_addRowsToTableWithNoColumns)
     CHECK(u->is_null_link(0, 0));
 }
 
+
 TEST(Table_getVersionCounterAfterRowAccessor)
 {
     Table t;


### PR DESCRIPTION
This PR improves the performance in situations where version bumping due to changes are not really required, because any query depending on seeing such changes would note an earlier bump anyway. In this case, we now prune version bumping earlier than before. The hope is that this improves performance in scenarios with many changes without any queries in between. It is likely only noticeable if there are many tables with links or backlinks to each other.