### PR TITLE
Use a rowing ptr as basis for allocation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,9 @@
 
 ### Enhancements
 
-* None.
+* Change the allocation scheme to (hopefully) perform better in scenarios
+  with high fragmentation.
+  PR [#2963](https://github.com/realm/realm-core/pull/2963)
 
 -----------
 

--- a/src/realm/group_writer.cpp
+++ b/src/realm/group_writer.cpp
@@ -648,10 +648,6 @@ std::pair<size_t, size_t> GroupWriter::reserve_free_space(size_t size)
     typedef std::pair<size_t, size_t> Chunk;
     Chunk chunk;
     bool found;
-    // Since we do a first-fit search for small chunks, the top pieces are
-    // likely to get smaller and smaller. So when we are looking for bigger
-    // chunks we are likely to find them faster by skipping the first half of
-    // the list.
     size_t end = m_free_lengths.size();
     if (m_alloc_position >= end)
         m_alloc_position = 0;

--- a/src/realm/group_writer.hpp
+++ b/src/realm/group_writer.hpp
@@ -87,6 +87,7 @@ private:
     ArrayInteger m_free_versions;  // 6th slot in Group::m_top
     uint64_t m_current_version;
     uint64_t m_readlock_version;
+    uint64_t m_alloc_position;
 
     // Currently cached memory mappings. We keep as many as 16 1MB windows
     // open for writing. The allocator will favor sequential allocation

--- a/src/realm/group_writer.hpp
+++ b/src/realm/group_writer.hpp
@@ -87,7 +87,7 @@ private:
     ArrayInteger m_free_versions;  // 6th slot in Group::m_top
     uint64_t m_current_version;
     uint64_t m_readlock_version;
-    uint64_t m_alloc_position;
+    size_t m_alloc_position;
 
     // Currently cached memory mappings. We keep as many as 16 1MB windows
     // open for writing. The allocator will favor sequential allocation


### PR DESCRIPTION
This PR uses a rowing "pointer" as basis for first-fit allocation. There is some chance that this approach will work better than the current approach in scenarios with high fragmentation. This is experimental.