### PR TITLE
Android parser libs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ### Bugfixes
 
-* None.
+* Include the parser libs in the published android packages.
 
 ### Breaking changes
 

--- a/tools/build-android.sh
+++ b/tools/build-android.sh
@@ -46,8 +46,9 @@ for bt in "${BUILD_TYPES[@]}"; do
     [[ "$bt" = "Release" ]] && suffix="" || suffix="-dbg"
     for p in "${PLATFORMS[@]}"; do
         filename=$(find "build-android-${p}-${bt}" -maxdepth 1 -type f -name "realm-core-*-devel.tar.gz")
-        tar -C core-android -zxvf "${filename}" "lib/librealm${suffix}.a"
+        tar -C core-android -zxvf "${filename}" "lib/librealm${suffix}.a" "lib/librealm-parser${suffix}.a"
         mv "core-android/lib/librealm${suffix}.a" "core-android/librealm-android-${p}${suffix}.a"
+        mv "core-android/lib/librealm-parser${suffix}.a" "core-android/librealm-parser-android-${p}${suffix}.a"
         rm -rf core-android/lib
     done
 done


### PR DESCRIPTION
Another fix to the packaging steps because the parser libs were found missing from the android packages (`realm-core-android-v5.1.1.tar.gz`).