### PR TITLE
Query serialization part 2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,9 @@
 
 ### Bugfixes
 
-* None.
+* Fix a crash when distinct is applied on two or more properties where
+  the properties contain a link and non-link column.
+  PR [#2979](https://github.com/realm/realm-core/pull/2979).
 
 ### Breaking changes
 
@@ -10,7 +12,26 @@
 
 ### Enhancements
 
-* None.
+* Parser improvements:
+    - Support for comparing two columns of the same type. For example:
+        - `wins > losses`
+        - `account_balance > purchases.@sum.price`
+        - `purchases.@count > max_allowed_items`
+        - `team_name CONTAINS[c] location.city_name`
+    - Support for sort and distinct clauses
+        - At least one query filter is required
+        - Columns are a comma separated value list
+        - Order of sorting can be `ASC, ASCENDING, DESC, DESCENDING` (case insensitive)
+        - `SORT(property1 ASC, property2 DESC)`
+        - `DISTINCT(property1, property2)`
+        - Any number of sort/distinct expressions can be indicated
+    - Better support for NULL synonym in binary and string expressions:
+        - `name == NULL` finds null strings
+        - `data == NULL` finds null binary data
+    - Binary properties can now be queried over links
+    - Binary properties now support the full range of string operators
+      (BEGINSWITH, ENDSWITH, CONTAINS, LIKE)
+    PR [#2979](https://github.com/realm/realm-core/pull/2979).
 
 -----------
 

--- a/src/realm/CMakeLists.txt
+++ b/src/realm/CMakeLists.txt
@@ -133,13 +133,23 @@ set(REALM_INSTALL_GENERAL_HEADERS
 ) # REALM_INSTALL_GENERAL_HEADERS
 
 set(REALM_PARSER_SOURCES
+    parser/collection_operator_expression.cpp
+    parser/expression_container.cpp
     parser/parser.cpp
+    parser/parser_utils.cpp
+    parser/property_expression.cpp
     parser/query_builder.cpp
+    parser/value_expression.cpp
 ) # REALM_PARSER_SOURCES
 
 set(REALM_PARSER_HEADERS
+    parser/collection_operator_expression.hpp
+    parser/expression_container.hpp
     parser/parser.hpp
+    parser/parser_utils.hpp
+    parser/property_expression.hpp
     parser/query_builder.hpp
+    parser/value_expression.hpp
 ) # REALM_PARSER_HEADERS
 
 set(REALM_INSTALL_IMPL_HEADERS

--- a/src/realm/CMakeLists.txt
+++ b/src/realm/CMakeLists.txt
@@ -133,7 +133,6 @@ set(REALM_INSTALL_GENERAL_HEADERS
 ) # REALM_INSTALL_GENERAL_HEADERS
 
 set(REALM_PARSER_SOURCES
-    parser/collection_operator_expression.cpp
     parser/expression_container.cpp
     parser/parser.cpp
     parser/parser_utils.cpp

--- a/src/realm/data_type.hpp
+++ b/src/realm/data_type.hpp
@@ -19,6 +19,8 @@
 #ifndef REALM_DATA_TYPE_HPP
 #define REALM_DATA_TYPE_HPP
 
+#include <stdint.h>
+
 namespace realm {
 
 class StringData;

--- a/src/realm/exceptions.hpp
+++ b/src/realm/exceptions.hpp
@@ -100,6 +100,12 @@ public:
 };
 
 
+class SerialisationError : public std::runtime_error {
+public:
+    SerialisationError(const std::string& msg);
+    /// runtime_error::what() returns the msg provided in the constructor.
+};
+
 /// The \c LogicError exception class is intended to be thrown only when
 /// applications (or bindings) violate rules that are stated (or ought to have
 /// been stated) in the documentation of the public API, and only in cases
@@ -285,6 +291,11 @@ inline MaximumFileSizeExceeded::MaximumFileSizeExceeded(const std::string& msg)
 }
 
 inline OutOfDiskSpace::OutOfDiskSpace(const std::string& msg)
+: std::runtime_error(msg)
+{
+}
+
+inline SerialisationError::SerialisationError(const std::string& msg)
 : std::runtime_error(msg)
 {
 }

--- a/src/realm/parser/collection_operator_expression.hpp
+++ b/src/realm/parser/collection_operator_expression.hpp
@@ -1,0 +1,189 @@
+////////////////////////////////////////////////////////////////////////////
+//
+// Copyright 2015 Realm Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+////////////////////////////////////////////////////////////////////////////
+
+#ifndef REALM_COLLECTION_OPERATOR_EXPRESSION_HPP
+#define REALM_COLLECTION_OPERATOR_EXPRESSION_HPP
+
+#include "property_expression.hpp"
+#include "parser.hpp"
+#include "parser_utils.hpp"
+
+#include <realm/query_expression.hpp>
+
+namespace realm {
+namespace parser {
+
+template <typename RetType, parser::Expression::KeyPathOp AggOpType, class Enable = void>
+struct CollectionOperatorGetter;
+
+template <parser::Expression::KeyPathOp OpType>
+struct CollectionOperatorExpression
+{
+    static constexpr parser::Expression::KeyPathOp operation_type = OpType;
+    std::function<Table *()> table_getter;
+    PropertyExpression pe;
+    size_t post_link_col_ndx;
+    DataType post_link_col_type;
+
+    CollectionOperatorExpression(PropertyExpression&& exp, std::string suffix_path)
+    : pe(std::move(exp))
+    , post_link_col_ndx(realm::not_found)
+    {
+        table_getter = std::bind(&PropertyExpression::table_getter, pe);
+
+        const bool requires_suffix_path = !(OpType == parser::Expression::KeyPathOp::SizeString
+                                            || OpType == parser::Expression::KeyPathOp::SizeBinary
+                                            || OpType == parser::Expression::KeyPathOp::Count);
+
+        if (requires_suffix_path) {
+            Table* pre_link_table = pe.table_getter();
+            REALM_ASSERT(pre_link_table);
+            StringData list_property_name = pre_link_table->get_column_name(pe.col_ndx);
+            precondition(pe.col_type == type_LinkList,
+                         util::format("The '%1' operation must be used on a list property, but '%2' is not a list",
+                                      util::collection_operator_to_str(OpType), list_property_name));
+
+            TableRef post_link_table = pe.table_getter()->get_link_target(pe.col_ndx);
+            REALM_ASSERT(post_link_table);
+            StringData printable_post_link_table_name = get_printable_table_name(*post_link_table);
+
+            KeyPath suffix_key_path = key_path_from_string(suffix_path);
+            precondition(suffix_path.size() > 0 && suffix_key_path.size() > 0,
+                         util::format("A property from object '%1' must be provided to perform operation '%2'",
+                                      printable_post_link_table_name, util::collection_operator_to_str(OpType)));
+
+            precondition(suffix_key_path.size() == 1,
+                         util::format("Unable to use '%1' because collection aggreate operations are only supported "
+                                      "for direct properties at this time", suffix_path));
+
+            post_link_col_ndx = pe.table_getter()->get_link_target(pe.col_ndx)->get_column_index(suffix_key_path[0]);
+
+            precondition(post_link_col_ndx != realm::not_found,
+                         util::format("No property '%1' on object of type '%2'",
+                                      suffix_path, printable_post_link_table_name));
+            post_link_col_type = pe.table_getter()->get_link_target(pe.col_ndx)->get_column_type(post_link_col_ndx);
+        }
+        else {  // !requires_suffix_path
+            post_link_col_type = pe.col_type;
+
+            precondition(suffix_path.empty(),
+                         util::format("An extraneous property '%1' was found for operation '%2'",
+                                      suffix_path, util::collection_operator_to_str(OpType)));
+        }
+    }
+    template <typename T>
+    auto value_of_type_for_query() const
+    {
+        return CollectionOperatorGetter<T, OpType>::convert(*this);
+    }
+};
+
+
+// Certain operations are disabled for some types (eg. a sum of timestamps is invalid).
+// The operations that are supported have a specialisation with std::enable_if for that type below
+// any type/operation combination that is not specialised will get the runtime error from the following
+// default implementation. The return type is just a dummy to make things compile.
+template <typename RetType, parser::Expression::KeyPathOp AggOpType, class Enable>
+struct CollectionOperatorGetter {
+    static Columns<RetType> convert(const CollectionOperatorExpression<AggOpType>& op) {
+        throw std::runtime_error(util::format("Predicate error: comparison of type '%1' with result of '%2' is not supported.",
+                                              type_to_str<RetType>(),
+                                              collection_operator_to_str(op.operation_type)));
+    }
+};
+
+template <typename RetType>
+struct CollectionOperatorGetter<RetType, parser::Expression::KeyPathOp::Min,
+typename std::enable_if_t<
+std::is_same<RetType, Int>::value ||
+std::is_same<RetType, Float>::value ||
+std::is_same<RetType, Double>::value
+> >{
+    static SubColumnAggregate<RetType, aggregate_operations::Minimum<RetType> > convert(const CollectionOperatorExpression<parser::Expression::KeyPathOp::Min>& expr)
+    {
+        return expr.table_getter()->template column<Link>(expr.pe.col_ndx).template column<RetType>(expr.post_link_col_ndx).min();
+    }
+};
+
+template <typename RetType>
+struct CollectionOperatorGetter<RetType, parser::Expression::KeyPathOp::Max,
+typename std::enable_if_t<
+std::is_same<RetType, Int>::value ||
+std::is_same<RetType, Float>::value ||
+std::is_same<RetType, Double>::value
+> >{
+    static SubColumnAggregate<RetType, aggregate_operations::Maximum<RetType> > convert(const CollectionOperatorExpression<parser::Expression::KeyPathOp::Max>& expr)
+    {
+        return expr.table_getter()->template column<Link>(expr.pe.col_ndx).template column<RetType>(expr.post_link_col_ndx).max();
+    }
+};
+
+template <typename RetType>
+struct CollectionOperatorGetter<RetType, parser::Expression::KeyPathOp::Sum,
+typename std::enable_if_t<
+std::is_same<RetType, Int>::value ||
+std::is_same<RetType, Float>::value ||
+std::is_same<RetType, Double>::value
+> >{
+    static SubColumnAggregate<RetType, aggregate_operations::Sum<RetType> > convert(const CollectionOperatorExpression<parser::Expression::KeyPathOp::Sum>& expr)
+    {
+        return expr.table_getter()->template column<Link>(expr.pe.col_ndx).template column<RetType>(expr.post_link_col_ndx).sum();
+    }
+};
+
+template <typename RetType>
+struct CollectionOperatorGetter<RetType, parser::Expression::KeyPathOp::Avg,
+typename std::enable_if_t<
+std::is_same<RetType, Int>::value ||
+std::is_same<RetType, Float>::value ||
+std::is_same<RetType, Double>::value
+> >{
+    static SubColumnAggregate<RetType, aggregate_operations::Average<RetType> > convert(const CollectionOperatorExpression<parser::Expression::KeyPathOp::Avg>& expr)
+    {
+        return expr.table_getter()->template column<Link>(expr.pe.col_ndx).template column<RetType>(expr.post_link_col_ndx).average();
+    }
+};
+
+template <>
+struct CollectionOperatorGetter<Int, parser::Expression::KeyPathOp::Count>{
+    static LinkCount convert(const CollectionOperatorExpression<parser::Expression::KeyPathOp::Count>& expr)
+    {
+        return expr.table_getter()->template column<Link>(expr.pe.col_ndx).count();
+    }
+};
+
+template <>
+struct CollectionOperatorGetter<Int, parser::Expression::KeyPathOp::SizeString>{
+    static SizeOperator<Size<String> > convert(const CollectionOperatorExpression<parser::Expression::KeyPathOp::SizeString>& expr)
+    {
+        return expr.table_getter()->template column<String>(expr.pe.col_ndx).size();
+    }
+};
+
+template <>
+struct CollectionOperatorGetter<Int, parser::Expression::KeyPathOp::SizeBinary>{
+    static SizeOperator<Size<Binary> > convert(const CollectionOperatorExpression<parser::Expression::KeyPathOp::SizeBinary>& expr)
+    {
+        return expr.table_getter()->template column<Binary>(expr.pe.col_ndx).size();
+    }
+};
+
+} // namespace parser
+} // namespace realm
+
+#endif // REALM_COLLECTION_OPERATOR_EXPRESSION_HPP

--- a/src/realm/parser/collection_operator_expression.hpp
+++ b/src/realm/parser/collection_operator_expression.hpp
@@ -159,8 +159,13 @@ std::is_same<RetType, Double>::value
     }
 };
 
-template <>
-struct CollectionOperatorGetter<Int, parser::Expression::KeyPathOp::Count>{
+template <typename RetType>
+struct CollectionOperatorGetter<RetType, parser::Expression::KeyPathOp::Count,
+    typename std::enable_if_t<
+    std::is_same<RetType, Int>::value ||
+    std::is_same<RetType, Float>::value ||
+    std::is_same<RetType, Double>::value
+    > >{
     static LinkCount convert(const CollectionOperatorExpression<parser::Expression::KeyPathOp::Count>& expr)
     {
         return expr.table_getter()->template column<Link>(expr.pe.col_ndx).count();

--- a/src/realm/parser/expression_container.cpp
+++ b/src/realm/parser/expression_container.cpp
@@ -203,11 +203,11 @@ DataType ExpressionContainer::get_comparison_type(ExpressionContainer& rhs) {
         return check_type_compatibility(rhs.get_avg().post_link_col_type);
     } else if (is_count_type(type) && is_count_type(rhs.type)) {
         return type_Int;
-        // check weakly typed expressions last, we return type_Double for count/size because at this point the
+        // check weakly typed expressions last, we return type_Int for count/size because at this point the
         // comparison is between a @count/@size and a value which is untyped. The value should be numeric if the query
-        // is well formed but we don't know what type it actually is so we assume double to get a precise comparison.
+        // is well formed but we don't know what type it actually is so we will perform int promotion in a conversion.
     } else if (is_count_type(type) || is_count_type(rhs.type)) {
-        return type_Double;
+        return type_Int;
     }
 
     throw std::runtime_error("Unsupported query (type undeductable). A comparison must include at lease one keypath.");

--- a/src/realm/parser/expression_container.cpp
+++ b/src/realm/parser/expression_container.cpp
@@ -50,7 +50,7 @@ ExpressionContainer::ExpressionContainer(Query& query, const parser::Expression&
             case parser::Expression::KeyPathOp::SizeString:
                 REALM_FALLTHROUGH;
             case parser::Expression::KeyPathOp::SizeBinary:
-                if (pe.col_type == type_LinkList) {
+                if (pe.col_type == type_LinkList || pe.col_type == type_Link) {
                     type = ExpressionInternal::exp_OpCount;
                     storage = CollectionOperatorExpression<parser::Expression::KeyPathOp::Count>(std::move(pe), e.op_suffix);
                 }

--- a/src/realm/parser/expression_container.cpp
+++ b/src/realm/parser/expression_container.cpp
@@ -1,0 +1,176 @@
+////////////////////////////////////////////////////////////////////////////
+//
+// Copyright 2015 Realm Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+////////////////////////////////////////////////////////////////////////////
+
+#include <vector>
+#include <string>
+
+#include "expression_container.hpp"
+
+namespace realm {
+namespace parser {
+
+ExpressionContainer::ExpressionContainer(Query& query, const parser::Expression& e, query_builder::Arguments& args)
+{
+    if (e.type == parser::Expression::Type::KeyPath) {
+        PropertyExpression pe(query, e.s);
+        switch (e.collection_op) {
+            case parser::Expression::KeyPathOp::Min:
+                type = ExpressionInternal::exp_OpMin;
+                storage = CollectionOperatorExpression<parser::Expression::KeyPathOp::Min>(std::move(pe), e.op_suffix);
+                break;
+            case parser::Expression::KeyPathOp::Max:
+                type = ExpressionInternal::exp_OpMax;
+                storage = CollectionOperatorExpression<parser::Expression::KeyPathOp::Max>(std::move(pe), e.op_suffix);
+                break;
+            case parser::Expression::KeyPathOp::Sum:
+                type = ExpressionInternal::exp_OpSum;
+                storage = CollectionOperatorExpression<parser::Expression::KeyPathOp::Sum>(std::move(pe), e.op_suffix);
+                break;
+            case parser::Expression::KeyPathOp::Avg:
+                type = ExpressionInternal::exp_OpAvg;
+                storage = CollectionOperatorExpression<parser::Expression::KeyPathOp::Avg>(std::move(pe), e.op_suffix);
+                break;
+            case parser::Expression::KeyPathOp::Count:
+                REALM_FALLTHROUGH;
+            case parser::Expression::KeyPathOp::SizeString:
+                REALM_FALLTHROUGH;
+            case parser::Expression::KeyPathOp::SizeBinary:
+                if (pe.col_type == type_LinkList) {
+                    type = ExpressionInternal::exp_OpCount;
+                    storage = CollectionOperatorExpression<parser::Expression::KeyPathOp::Count>(std::move(pe), e.op_suffix);
+                }
+                else if (pe.col_type == type_String) {
+                    type = ExpressionInternal::exp_OpSizeString;
+                    storage = CollectionOperatorExpression<parser::Expression::KeyPathOp::SizeString>(std::move(pe), e.op_suffix);
+                }
+                else if (pe.col_type == type_Binary) {
+                    type = ExpressionInternal::exp_OpSizeBinary;
+                    storage = CollectionOperatorExpression<parser::Expression::KeyPathOp::SizeBinary>(std::move(pe), e.op_suffix);
+                }
+                else {
+                    throw std::runtime_error("Invalid query: @size and @count can only operate on types list, binary, or string");
+                }
+                break;
+            case parser::Expression::KeyPathOp::None:
+                type = ExpressionInternal::exp_Property;
+                storage = std::move(pe);
+                break;
+        }
+    }
+    else {
+        type = ExpressionInternal::exp_Value;
+        storage = ValueExpression(query, &args, &e);
+    }
+}
+
+PropertyExpression& ExpressionContainer::get_property()
+{
+    REALM_ASSERT_DEBUG(type == ExpressionInternal::exp_Property);
+    return util::any_cast<PropertyExpression&>(storage);
+}
+
+ValueExpression& ExpressionContainer::get_value()
+{
+    REALM_ASSERT_DEBUG(type == ExpressionInternal::exp_Value);
+    return util::any_cast<ValueExpression&>(storage);
+}
+CollectionOperatorExpression<parser::Expression::KeyPathOp::Min>& ExpressionContainer::get_min()
+{
+    REALM_ASSERT_DEBUG(type == ExpressionInternal::exp_OpMin);
+    return util::any_cast<CollectionOperatorExpression<parser::Expression::KeyPathOp::Min>&>(storage);
+}
+CollectionOperatorExpression<parser::Expression::KeyPathOp::Max>& ExpressionContainer::get_max()
+{
+    REALM_ASSERT_DEBUG(type == ExpressionInternal::exp_OpMax);
+    return util::any_cast<CollectionOperatorExpression<parser::Expression::KeyPathOp::Max>&>(storage);
+}
+CollectionOperatorExpression<parser::Expression::KeyPathOp::Sum>& ExpressionContainer::get_sum()
+{
+    REALM_ASSERT_DEBUG(type == ExpressionInternal::exp_OpSum);
+    return util::any_cast<CollectionOperatorExpression<parser::Expression::KeyPathOp::Sum>&>(storage);
+}
+CollectionOperatorExpression<parser::Expression::KeyPathOp::Avg>& ExpressionContainer::get_avg()
+{
+    REALM_ASSERT_DEBUG(type == ExpressionInternal::exp_OpAvg);
+    return util::any_cast<CollectionOperatorExpression<parser::Expression::KeyPathOp::Avg>&>(storage);
+}
+CollectionOperatorExpression<parser::Expression::KeyPathOp::Count>& ExpressionContainer::get_count()
+{
+    REALM_ASSERT_DEBUG(type == ExpressionInternal::exp_OpCount);
+    return util::any_cast<CollectionOperatorExpression<parser::Expression::KeyPathOp::Count>&>(storage);
+}
+CollectionOperatorExpression<parser::Expression::KeyPathOp::SizeString>& ExpressionContainer::get_size_string()
+{
+    REALM_ASSERT_DEBUG(type == ExpressionInternal::exp_OpSizeString);
+    return util::any_cast<CollectionOperatorExpression<parser::Expression::KeyPathOp::SizeString>&>(storage);
+}
+CollectionOperatorExpression<parser::Expression::KeyPathOp::SizeBinary>& ExpressionContainer::get_size_binary()
+{
+    REALM_ASSERT_DEBUG(type == ExpressionInternal::exp_OpSizeBinary);
+    return util::any_cast<CollectionOperatorExpression<parser::Expression::KeyPathOp::SizeBinary>&>(storage);
+}
+
+DataType ExpressionContainer::get_comparison_type(ExpressionContainer& rhs) {
+    if (type == ExpressionInternal::exp_Property) {
+        return get_property().col_type;
+    } else if (rhs.type == ExpressionInternal::exp_Property) {
+        return rhs.get_property().col_type;
+    } else if (type == ExpressionInternal::exp_OpMin) {
+        return get_min().post_link_col_type;
+    } else if (type == ExpressionInternal::exp_OpMax) {
+        return get_max().post_link_col_type;
+    } else if (type == ExpressionInternal::exp_OpSum) {
+        return get_sum().post_link_col_type;
+    } else if (type == ExpressionInternal::exp_OpAvg) {
+        return get_avg().post_link_col_type;
+    } else if (type == ExpressionInternal::exp_OpCount) {
+        return type_Int;
+    } else if (type == ExpressionInternal::exp_OpSizeString) {
+        return type_Int;
+    } else if (type == ExpressionInternal::exp_OpSizeBinary) {
+        return type_Int;
+    }
+    // rhs checks
+    else if (rhs.type == ExpressionInternal::exp_OpMin) {
+        return rhs.get_min().post_link_col_type;
+    } else if (rhs.type == ExpressionInternal::exp_OpMax) {
+        return rhs.get_max().post_link_col_type;
+    } else if (rhs.type == ExpressionInternal::exp_OpSum) {
+        return rhs.get_sum().post_link_col_type;
+    } else if (rhs.type == ExpressionInternal::exp_OpAvg) {
+        return rhs.get_avg().post_link_col_type;
+    } else if (rhs.type == ExpressionInternal::exp_OpCount) {
+        return type_Int;
+    } else if (rhs.type == ExpressionInternal::exp_OpSizeString) {
+        return type_Int;
+    } else if (rhs.type == ExpressionInternal::exp_OpSizeBinary) {
+        return type_Int;
+    }
+
+    throw std::runtime_error("Unsupported query (type undeductable). A comparison must include at lease one keypath");
+}
+
+bool ExpressionContainer::is_null() {
+    if (type == ExpressionInternal::exp_Value) {
+        return get_value().is_null();
+    }
+    return false;
+}
+
+} // namespace parser
+} // namespace realm

--- a/src/realm/parser/expression_container.hpp
+++ b/src/realm/parser/expression_container.hpp
@@ -1,0 +1,73 @@
+////////////////////////////////////////////////////////////////////////////
+//
+// Copyright 2015 Realm Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+////////////////////////////////////////////////////////////////////////////
+
+#ifndef REALM_EXPRESSION_CONTAINER_HPP
+#define REALM_EXPRESSION_CONTAINER_HPP
+
+#include <realm/util/any.hpp>
+
+#include "collection_operator_expression.hpp"
+#include "parser.hpp"
+#include "property_expression.hpp"
+#include "query_builder.hpp"
+#include "value_expression.hpp"
+
+namespace realm {
+namespace parser {
+
+class ExpressionContainer
+{
+public:
+    ExpressionContainer(Query& query, const parser::Expression& e, query_builder::Arguments& args);
+
+    bool is_null();
+
+    PropertyExpression& get_property();
+    ValueExpression& get_value();
+    CollectionOperatorExpression<parser::Expression::KeyPathOp::Min>& get_min();
+    CollectionOperatorExpression<parser::Expression::KeyPathOp::Max>& get_max();
+    CollectionOperatorExpression<parser::Expression::KeyPathOp::Sum>& get_sum();
+    CollectionOperatorExpression<parser::Expression::KeyPathOp::Avg>& get_avg();
+    CollectionOperatorExpression<parser::Expression::KeyPathOp::Count>& get_count();
+    CollectionOperatorExpression<parser::Expression::KeyPathOp::SizeString>& get_size_string();
+    CollectionOperatorExpression<parser::Expression::KeyPathOp::SizeBinary>& get_size_binary();
+
+    DataType get_comparison_type(ExpressionContainer& rhs);
+
+    enum class ExpressionInternal
+    {
+        exp_Value,
+        exp_Property,
+        exp_OpMin,
+        exp_OpMax,
+        exp_OpSum,
+        exp_OpAvg,
+        exp_OpCount,
+        exp_OpSizeString,
+        exp_OpSizeBinary
+    };
+
+    ExpressionInternal type;
+private:
+    util::Any storage;
+};
+
+} // namespace parser
+} // namespace realm
+
+#endif // REALM_EXPRESSION_CONTAINER_HPP

--- a/src/realm/parser/expression_container.hpp
+++ b/src/realm/parser/expression_container.hpp
@@ -47,6 +47,7 @@ public:
     CollectionOperatorExpression<parser::Expression::KeyPathOp::SizeString>& get_size_string();
     CollectionOperatorExpression<parser::Expression::KeyPathOp::SizeBinary>& get_size_binary();
 
+    DataType check_type_compatibility(DataType type);
     DataType get_comparison_type(ExpressionContainer& rhs);
 
     enum class ExpressionInternal

--- a/src/realm/parser/parser.cpp
+++ b/src/realm/parser/parser.cpp
@@ -344,7 +344,7 @@ COLLECTION_OPERATION_ACTION(max, Expression::KeyPathOp::Max)
 COLLECTION_OPERATION_ACTION(sum, Expression::KeyPathOp::Sum)
 COLLECTION_OPERATION_ACTION(avg, Expression::KeyPathOp::Avg)
 COLLECTION_OPERATION_ACTION(count, Expression::KeyPathOp::Count)
-COLLECTION_OPERATION_ACTION(size, Expression::KeyPathOp::Size)
+COLLECTION_OPERATION_ACTION(size, Expression::KeyPathOp::SizeString)
 
 template<> struct action< key_path_prefix > {
     template< typename Input >

--- a/src/realm/parser/parser.cpp
+++ b/src/realm/parser/parser.cpp
@@ -122,8 +122,10 @@ struct distinct_prefix : seq< string_token_t("distinct"), star< blank >, one< '(
 struct ascending : seq< sor< string_token_t("ascending"), string_token_t("asc") > > {};
 struct descending : seq< sor< string_token_t("descending"), string_token_t("desc") > > {};
 struct descriptor_property : disable< key_path > {};
-struct sort : seq< sort_prefix, plus< star< blank >, descriptor_property, plus< blank >, sor< ascending, descending > >, star< blank >, one< ')' > > {};
-struct distinct : seq < distinct_prefix, plus< star< blank >, descriptor_property >, star< blank >, one< ')' > > {};
+struct sort_param : seq< star< blank >, descriptor_property, plus< blank >, sor< ascending, descending >, star< blank > > {};
+struct sort : seq< sort_prefix, sort_param, star< seq< one< ',' >, sort_param > >, one< ')' > > {};
+struct distinct_param : seq< star< blank >, descriptor_property, star< blank > > {};
+struct distinct : seq < distinct_prefix, distinct_param, star< seq< one< ',' >, distinct_param > >, one< ')' > > {};
 struct descriptor_ordering : sor< sort, distinct > {};
 
 struct string_oper : seq< sor< contains, begins, ends, like>, star< blank >, opt< case_insensitive > > {};

--- a/src/realm/parser/parser.cpp
+++ b/src/realm/parser/parser.cpp
@@ -471,11 +471,6 @@ Predicate parse(const std::string &query)
 {
     DEBUG_PRINT_TOKEN(query);
 
-    if (query.empty()) {
-        // an empty query should return all results
-        return Predicate(Predicate::Type::True);
-    }
-
     Predicate out_predicate(Predicate::Type::And);
 
     ParserState state;

--- a/src/realm/parser/parser.cpp
+++ b/src/realm/parser/parser.cpp
@@ -471,6 +471,11 @@ Predicate parse(const std::string &query)
 {
     DEBUG_PRINT_TOKEN(query);
 
+    if (query.empty()) {
+        // an empty query should return all results
+        return Predicate(Predicate::Type::True);
+    }
+
     Predicate out_predicate(Predicate::Type::And);
 
     ParserState state;

--- a/src/realm/parser/parser.hpp
+++ b/src/realm/parser/parser.hpp
@@ -89,7 +89,31 @@ struct Predicate
     Predicate(Type t, bool n = false) : type(t), negate(n) {}
 };
 
-Predicate parse(const std::string &query);
+struct DescriptorOrderingState
+{
+    struct PropertyState
+    {
+        std::string key_path;
+        bool ascending;
+    };
+    struct SingleOrderingState
+    {
+        std::vector<PropertyState> properties;
+        bool is_distinct;
+    };
+    std::vector<SingleOrderingState> orderings;
+};
+
+struct ParserResult
+{
+    ParserResult(Predicate p, DescriptorOrderingState o)
+    : predicate(p)
+    , ordering(o) {}
+    Predicate predicate;
+    DescriptorOrderingState ordering;
+};
+
+ParserResult parse(const std::string &query);
 
 // run the analysis tool to check for cycles in the grammar
 // returns the number of problems found and prints some info to std::cout

--- a/src/realm/parser/parser.hpp
+++ b/src/realm/parser/parser.hpp
@@ -28,7 +28,7 @@ namespace parser {
 struct Expression
 {
     enum class Type { None, Number, String, KeyPath, Argument, True, False, Null, Timestamp, Base64 } type;
-    enum class KeyPathOp { None, Min, Max, Avg, Sum, Count, Size } collection_op;
+    enum class KeyPathOp { None, Min, Max, Avg, Sum, Count, SizeString, SizeBinary } collection_op;
     std::string s;
     std::vector<std::string> time_inputs;
     std::string op_suffix;

--- a/src/realm/parser/parser_utils.cpp
+++ b/src/realm/parser/parser_utils.cpp
@@ -1,0 +1,153 @@
+////////////////////////////////////////////////////////////////////////////
+//
+// Copyright 2015 Realm Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+////////////////////////////////////////////////////////////////////////////
+
+#include "parser_utils.hpp"
+
+#include <sstream>
+#include <typeinfo>
+
+#include <realm/table.hpp>
+
+namespace realm {
+namespace util {
+
+template <typename T>
+const char* type_to_str()
+{
+    return typeid(T).name();
+}
+template <>
+const char* type_to_str<bool>()
+{
+    return "Bool";
+}
+template <>
+const char* type_to_str<Int>()
+{
+    return "Int";
+}
+template <>
+const char* type_to_str<Float>()
+{
+    return "Float";
+}
+template <>
+const char* type_to_str<Double>()
+{
+    return "Double";
+}
+template <>
+const char* type_to_str<String>()
+{
+    return "String";
+}
+template <>
+const char* type_to_str<Binary>()
+{
+    return "Binary";
+}
+template <>
+const char* type_to_str<Timestamp>()
+{
+    return "Timestamp";
+}
+template <>
+const char* type_to_str<Link>()
+{
+    return "Link";
+}
+
+const char* data_type_to_str(DataType type)
+{
+    switch (type) {
+        case type_Int:
+            return "Int";
+        case type_Bool:
+            return "Bool";
+        case type_Float:
+            return "Float";
+        case type_Double:
+            return "Double";
+        case type_String:
+            return "String";
+        case type_Binary:
+            return "Binary";
+        case type_OldDateTime:
+            return "DateTime";
+        case type_Timestamp:
+            return "Timestamp";
+        case type_Table:
+            return "Table";
+        case type_Mixed:
+            return "Mixed";
+        case type_Link:
+            return "Link";
+        case type_LinkList:
+            return "LinkList";
+    }
+    return "type_Unknown"; // LCOV_EXCL_LINE
+}
+
+const char* collection_operator_to_str(parser::Expression::KeyPathOp op)
+{
+    switch (op) {
+        case parser::Expression::KeyPathOp::None:
+            return "NONE";
+        case parser::Expression::KeyPathOp::Min:
+            return "@min";
+        case parser::Expression::KeyPathOp::Max:
+            return "@max";
+        case parser::Expression::KeyPathOp::Sum:
+            return "@sum";
+        case parser::Expression::KeyPathOp::Avg:
+            return "@avg";
+        case parser::Expression::KeyPathOp::SizeString:
+            return "@size";
+        case parser::Expression::KeyPathOp::SizeBinary:
+            return "@size";
+        case parser::Expression::KeyPathOp::Count:
+            return "@count";
+    }
+    return "";
+}
+
+using KeyPath = std::vector<std::string>;
+
+KeyPath key_path_from_string(const std::string &s) {
+    std::stringstream ss(s);
+    std::string item;
+    KeyPath key_path;
+    while (std::getline(ss, item, '.')) {
+        key_path.push_back(item);
+    }
+    return key_path;
+}
+
+StringData get_printable_table_name(const Table& table)
+{
+    StringData name = table.get_name();
+    // the "class_" prefix is an implementation detail of the object store that shouldn't be exposed to users
+    static const std::string prefix = "class_";
+    if (name.size() > prefix.size() && strncmp(name.data(), prefix.data(), prefix.size()) == 0) {
+        name = StringData(name.data() + prefix.size(), name.size() - prefix.size());
+    }
+    return name;
+}
+
+} // namespace utils
+} // namespace realm

--- a/src/realm/parser/parser_utils.hpp
+++ b/src/realm/parser/parser_utils.hpp
@@ -24,6 +24,7 @@
 #include "parser.hpp"
 
 #include <sstream>
+#include <stdexcept>
 
 namespace realm {
 

--- a/src/realm/parser/parser_utils.hpp
+++ b/src/realm/parser/parser_utils.hpp
@@ -1,0 +1,84 @@
+////////////////////////////////////////////////////////////////////////////
+//
+// Copyright 2015 Realm Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+////////////////////////////////////////////////////////////////////////////
+
+#ifndef REALM_PARSER_UTILS_HPP
+#define REALM_PARSER_UTILS_HPP
+
+#include <realm/data_type.hpp>
+#include <realm/util/to_string.hpp>
+#include "parser.hpp"
+
+#include <sstream>
+
+namespace realm {
+
+class Table;
+class Timestamp;
+struct Link;
+
+namespace util {
+
+// check a precondition and throw an exception if it is not met
+// this should be used iff the condition being false indicates a bug in the caller
+// of the function checking its preconditions
+#define precondition(condition, message) if (!REALM_LIKELY(condition)) { throw std::logic_error(message); }
+
+
+template <typename T>
+const char* type_to_str();
+
+template <>
+const char* type_to_str<bool>();
+template <>
+const char* type_to_str<Int>();
+template <>
+const char* type_to_str<Float>();
+template <>
+const char* type_to_str<Double>();
+template <>
+const char* type_to_str<String>();
+template <>
+const char* type_to_str<Binary>();
+template <>
+const char* type_to_str<Timestamp>();
+template <>
+const char* type_to_str<Link>();
+
+const char* data_type_to_str(DataType type);
+
+const char* collection_operator_to_str(parser::Expression::KeyPathOp op);
+
+using KeyPath = std::vector<std::string>;
+KeyPath key_path_from_string(const std::string &s);
+StringData get_printable_table_name(const Table& table);
+
+template<typename T>
+T stot(std::string const& s) {
+    std::istringstream iss(s);
+    T value;
+    iss >> value;
+    if (iss.fail()) {
+        throw std::invalid_argument(util::format("Cannot convert string '%1'", s));
+    }
+    return value;
+}
+
+} // namespace utils
+} // namespace realm
+
+#endif // REALM_PARSER_UTILS_HPP

--- a/src/realm/parser/property_expression.cpp
+++ b/src/realm/parser/property_expression.cpp
@@ -1,0 +1,66 @@
+////////////////////////////////////////////////////////////////////////////
+//
+// Copyright 2015 Realm Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+////////////////////////////////////////////////////////////////////////////
+
+#include "property_expression.hpp"
+#include "parser_utils.hpp"
+
+#include <realm/table.hpp>
+
+#include <sstream>
+
+namespace realm {
+namespace parser {
+
+PropertyExpression::PropertyExpression(Query &q, const std::string &key_path_string)
+: query(q)
+{
+    KeyPath key_path = key_path_from_string(key_path_string);
+    TableRef cur_table = query.get_table();
+    for (size_t index = 0; index < key_path.size(); index++) {
+        size_t cur_col_ndx = cur_table->get_column_index(key_path[index]);
+
+        StringData object_name = get_printable_table_name(*cur_table);
+
+        precondition(cur_col_ndx != realm::not_found,
+                     util::format("No property '%1' on object of type '%2'", key_path[index], object_name));
+
+        DataType cur_col_type = cur_table->get_column_type(cur_col_ndx);
+        if (index != key_path.size() - 1) {
+            precondition(cur_col_type == type_Link || cur_col_type == type_LinkList,
+                         util::format("Property '%1' is not a link in object of type '%2'", key_path[index], object_name));
+            indexes.push_back(cur_col_ndx);
+            cur_table = cur_table->get_link_target(cur_col_ndx);
+        }
+        else {
+            col_ndx = cur_col_ndx;
+            col_type = cur_col_type;
+        }
+    }
+}
+
+Table* PropertyExpression::table_getter() const
+{
+    auto& tbl = query.get_table();
+    for (size_t col : indexes) {
+        tbl->link(col); // mutates m_link_chain on table
+    }
+    return tbl.get();
+}
+
+} // namespace parser
+} // namespace realm

--- a/src/realm/parser/property_expression.hpp
+++ b/src/realm/parser/property_expression.hpp
@@ -1,0 +1,50 @@
+////////////////////////////////////////////////////////////////////////////
+//
+// Copyright 2015 Realm Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+////////////////////////////////////////////////////////////////////////////
+
+#ifndef REALM_PROPERTY_EXPRESSION_HPP
+#define REALM_PROPERTY_EXPRESSION_HPP
+
+#include <realm/query.hpp>
+#include <realm/table.hpp>
+
+namespace realm {
+namespace parser {
+
+struct PropertyExpression
+{
+    std::vector<size_t> indexes;
+    size_t col_ndx;
+    DataType col_type;
+    Query &query;
+
+    PropertyExpression(Query &q, const std::string &key_path_string);
+
+    Table* table_getter() const;
+
+    template <typename RetType>
+    auto value_of_type_for_query() const
+    {
+        return this->table_getter()->template column<RetType>(this->col_ndx);
+    }
+};
+
+} // namespace parser
+} // namespace realm
+
+#endif // REALM_PROPERTY_EXPRESSION_HPP
+

--- a/src/realm/parser/query_builder.cpp
+++ b/src/realm/parser/query_builder.cpp
@@ -594,6 +594,12 @@ namespace query_builder {
 
 void apply_predicate(Query &query, const Predicate &predicate, Arguments &arguments)
 {
+
+    if (predicate.type == Predicate::Type::True && !predicate.negate) {
+        // early out for a predicate which should return all results
+        return;
+    }
+
     update_query_with_predicate(query, predicate, arguments);
 
     // Test the constructed query in core

--- a/src/realm/parser/query_builder.cpp
+++ b/src/realm/parser/query_builder.cpp
@@ -385,10 +385,10 @@ void add_binary_constraint_to_query(realm::Query &query,
                                     Columns<Binary> &&column) {
     switch (op) {
         case Predicate::Operator::Equal:
-            query.equal(column.column_ndx(), BinaryData(value));
+            query.and_query(column == value);
             break;
         case Predicate::Operator::NotEqual:
-            query.not_equal(column.column_ndx(), BinaryData(value));
+            query.and_query(column != value);
             break;
         default:
             throw std::logic_error("Substring comparison not supported for keypath substrings.");
@@ -765,14 +765,14 @@ void do_add_null_comparison_to_query(Query &query, Predicate::Operator op, const
 template<>
 void do_add_null_comparison_to_query<Binary>(Query &query, Predicate::Operator op, const PropertyExpression &expr)
 {
-    precondition(expr.indexes.empty(), "KeyPath queries not supported for data comparisons.");
     Columns<Binary> column = expr.table_getter()->template column<Binary>(expr.col_ndx);
+    BinaryData null_binary;
     switch (op) {
         case Predicate::Operator::NotEqual:
-            query.not_equal(expr.col_ndx, realm::null());
+            query.and_query(column != null_binary);
             break;
         case Predicate::Operator::Equal:
-            query.equal(expr.col_ndx, realm::null());
+            query.and_query(column == null_binary);
             break;
         default:
             throw std::logic_error("Only 'equal' and 'not equal' operators supported when comparing against 'null'.");

--- a/src/realm/parser/query_builder.hpp
+++ b/src/realm/parser/query_builder.hpp
@@ -40,14 +40,17 @@ using RowExpr = BasicRowExpr<Table>;
 
 namespace parser {
     struct Predicate;
+    struct DescriptorOrderingState;
 }
 
 namespace query_builder {
 class Arguments;
 
 void apply_predicate(Query& query, const parser::Predicate& predicate, Arguments& arguments);
-
 void apply_predicate(Query& query, const parser::Predicate& predicate); // zero out of string args version
+
+void apply_ordering(DescriptorOrdering& ordering, TableRef target, const parser::DescriptorOrderingState& state, Arguments& arguments);
+void apply_ordering(DescriptorOrdering& ordering, TableRef target, const parser::DescriptorOrderingState& state);
 
 
 struct AnyContext

--- a/src/realm/parser/value_expression.cpp
+++ b/src/realm/parser/value_expression.cpp
@@ -1,0 +1,219 @@
+////////////////////////////////////////////////////////////////////////////
+//
+// Copyright 2015 Realm Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+////////////////////////////////////////////////////////////////////////////
+
+#include "value_expression.hpp"
+#include "parser_utils.hpp"
+
+#include <realm/util/base64.hpp>
+
+#include <sstream>
+#include <time.h>
+
+namespace realm {
+namespace parser {
+
+Timestamp get_timestamp_if_valid(int64_t seconds, int32_t nanoseconds) {
+    const bool both_non_negative = seconds >= 0 && nanoseconds >= 0;
+    const bool both_non_positive = seconds <= 0 && nanoseconds <= 0;
+    if (both_non_negative || both_non_positive) {
+        return Timestamp(seconds, nanoseconds);
+    }
+    throw std::runtime_error("Invalid timestamp format");
+}
+
+Timestamp from_timestamp_values(std::vector<std::string> const& time_inputs) {
+
+    if (time_inputs.size() == 2) {
+        // internal format seconds, nanoseconds
+        int64_t seconds = stot<int64_t>(time_inputs[0]);
+        int32_t nanoseconds = stot<int32_t>(time_inputs[1]);
+        return get_timestamp_if_valid(seconds, nanoseconds);
+    }
+    else if (time_inputs.size() == 6 || time_inputs.size() == 7) {
+        // readable format YYYY-MM-DD-HH:MM:SS:NANOS nanos optional
+        tm created{};
+        created.tm_year = stot<int>(time_inputs[0]) - 1900; // epoch offset (see man mktime)
+        created.tm_mon = stot<int>(time_inputs[1]) - 1; // converts from 1-12 to 0-11
+        created.tm_mday = stot<int>(time_inputs[2]);
+        created.tm_hour = stot<int>(time_inputs[3]);
+        created.tm_min = stot<int>(time_inputs[4]);
+        created.tm_sec = stot<int>(time_inputs[5]);
+
+        if (created.tm_year < 0) {
+            // platform timegm functions do not throw errors, they return -1 which is also a valid time
+            throw std::logic_error("Conversion of dates before 1900 is not supported.");
+        }
+
+        int64_t seconds = platform_timegm(created); // UTC time
+        int32_t nanoseconds = 0;
+        if (time_inputs.size() == 7) {
+            nanoseconds = stot<int32_t>(time_inputs[6]);
+            if (nanoseconds < 0) {
+                throw std::logic_error("The nanoseconds of a Timestamp cannot be negative.");
+            }
+            if (seconds < 0) { // seconds determines the sign of the nanoseconds part
+                nanoseconds *= -1;
+            }
+        }
+        return get_timestamp_if_valid(seconds, nanoseconds);
+    }
+    throw std::runtime_error("Unexpected timestamp format.");
+}
+
+StringData from_base64(const std::string& input, util::StringBuffer& decode_buffer)
+{
+    // expects wrapper tokens B64"..."
+    if (input.size() < 5
+        || !(input[0] == 'B' || input[0] == 'b')
+        || input[1] != '6' || input[2] != '4'
+        || input[3] != '"' || input[input.size() - 1] != '"') {
+        throw std::runtime_error("Unexpected base64 format");
+    }
+    const size_t encoded_size = input.size() - 5;
+    size_t buffer_size = util::base64_decoded_size(encoded_size);
+    decode_buffer.resize(buffer_size);
+    StringData window(input.data() + 4, encoded_size);
+    util::Optional<size_t> decoded_size = util::base64_decode(window, decode_buffer.data(), buffer_size);
+    if (!decoded_size) {
+        throw std::runtime_error("Invalid base64 value");
+    }
+    REALM_ASSERT_DEBUG_EX(*decoded_size <= encoded_size, *decoded_size, encoded_size);
+    decode_buffer.resize(*decoded_size); // truncate
+    StringData output_window(decode_buffer.data(), decode_buffer.size());
+    return output_window;
+}
+
+
+ValueExpression::ValueExpression(Query& query, query_builder::Arguments* args, const parser::Expression* v)
+: value(v)
+, arguments(args) {
+    table_getter = [&] {
+        auto& tbl = query.get_table();
+        return tbl.get();
+    };
+}
+
+bool ValueExpression::is_null()
+{
+    if (value->type == parser::Expression::Type::Null) {
+        return true;
+    }
+    else if (value->type == parser::Expression::Type::Argument) {
+        return arguments->is_argument_null(stot<int>(value->s));
+    }
+    return false;
+}
+
+template <>
+Timestamp ValueExpression::value_of_type_for_query<Timestamp>()
+{
+    if (value->type == parser::Expression::Type::Argument) {
+        return arguments->timestamp_for_argument(stot<int>(value->s));
+    } else if (value->type == parser::Expression::Type::Timestamp) {
+        return from_timestamp_values(value->time_inputs);
+    } else if (value->type == parser::Expression::Type::Null) {
+        return Timestamp(realm::null());
+    }
+    throw std::logic_error("Attempting to compare Timestamp property to a non-Timestamp value");
+}
+
+template <>
+bool ValueExpression::value_of_type_for_query<bool>()
+{
+    if (value->type == parser::Expression::Type::Argument) {
+        return arguments->bool_for_argument(stot<int>(value->s));
+    }
+    if (value->type != parser::Expression::Type::True && value->type != parser::Expression::Type::False) {
+        if (value->type == parser::Expression::Type::Number) {
+            // As a special exception we can handle 0 and 1.
+            // Our bool values are actually stored as integers {0, 1}
+            int64_t number_value = stot<int64_t>(value->s);
+            if (number_value == 0) {
+                return false;
+            }
+            else if (number_value == 1) {
+                return true;
+            }
+        }
+        throw std::logic_error("Attempting to compare bool property to a non-bool value");
+    }
+    return value->type == parser::Expression::Type::True;
+}
+
+template <>
+Double ValueExpression::value_of_type_for_query<Double>()
+{
+    if (value->type == parser::Expression::Type::Argument) {
+        return arguments->double_for_argument(stot<int>(value->s));
+    }
+    return stot<double>(value->s);
+}
+
+template <>
+Float ValueExpression::value_of_type_for_query<Float>()
+{
+    if (value->type == parser::Expression::Type::Argument) {
+        return arguments->float_for_argument(stot<int>(value->s));
+    }
+    return stot<float>(value->s);
+}
+
+template <>
+Int ValueExpression::value_of_type_for_query<Int>()
+{
+    if (value->type == parser::Expression::Type::Argument) {
+        return arguments->long_for_argument(stot<int>(value->s));
+    }
+    return stot<long long>(value->s);
+}
+
+template <>
+StringData ValueExpression::value_of_type_for_query<StringData>()
+{
+    if (value->type == parser::Expression::Type::Argument) {
+        return arguments->string_for_argument(stot<int>(value->s));
+    }
+    else if (value->type == parser::Expression::Type::String) {
+        return value->s;
+    }
+    else if (value->type == parser::Expression::Type::Base64) {
+        // the return value points to data in the lifetime of args
+        return from_base64(value->s, arguments->buffer_space);
+    }
+    throw std::logic_error("Attempting to compare String property to a non-String value");
+}
+
+template <>
+BinaryData ValueExpression::value_of_type_for_query<BinaryData>()
+{
+    if (value->type == parser::Expression::Type::Argument) {
+        return arguments->binary_for_argument(stot<int>(value->s));
+    }
+    else if (value->type == parser::Expression::Type::String) {
+        return BinaryData(value->s);
+    }
+    else if (value->type == parser::Expression::Type::Base64) {
+        StringData converted = from_base64(value->s, arguments->buffer_space);
+        // returning a pointer to data in the lifetime of args
+        return BinaryData(converted.data(), converted.size());
+    }
+    throw std::logic_error("Binary properties must be compared against a binary argument.");
+}
+
+} // namespace parser
+} // namespace realm

--- a/src/realm/parser/value_expression.cpp
+++ b/src/realm/parser/value_expression.cpp
@@ -46,7 +46,7 @@ Timestamp from_timestamp_values(std::vector<std::string> const& time_inputs) {
     }
     else if (time_inputs.size() == 6 || time_inputs.size() == 7) {
         // readable format YYYY-MM-DD-HH:MM:SS:NANOS nanos optional
-        tm created{};
+        struct tm created = tm();
         created.tm_year = stot<int>(time_inputs[0]) - 1900; // epoch offset (see man mktime)
         created.tm_mon = stot<int>(time_inputs[1]) - 1; // converts from 1-12 to 0-11
         created.tm_mday = stot<int>(time_inputs[2]);

--- a/src/realm/parser/value_expression.hpp
+++ b/src/realm/parser/value_expression.hpp
@@ -1,0 +1,43 @@
+////////////////////////////////////////////////////////////////////////////
+//
+// Copyright 2015 Realm Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+////////////////////////////////////////////////////////////////////////////
+
+#ifndef REALM_VALUE_EXPRESSION_HPP
+#define REALM_VALUE_EXPRESSION_HPP
+
+#include "parser.hpp"
+#include "query_builder.hpp"
+
+namespace realm {
+namespace parser {
+
+struct ValueExpression
+{
+    const parser::Expression* value;
+    query_builder::Arguments* arguments;
+    std::function<Table *()> table_getter;
+
+    ValueExpression(Query& query, query_builder::Arguments* args, const parser::Expression* v);
+    bool is_null();
+    template <typename RetType>
+    RetType value_of_type_for_query();
+};
+
+} // namespace parser
+} // namespace realm
+
+#endif // REALM_VALUE_EXPRESSION_HPP

--- a/src/realm/query.cpp
+++ b/src/realm/query.cpp
@@ -1604,7 +1604,7 @@ std::string Query::get_description() const
     if (root_node()) {
         return root_node()->describe_expression();
     }
-    return "";
+    return "TRUEPREDICATE";
 }
 
 void Query::init() const

--- a/src/realm/query.cpp
+++ b/src/realm/query.cpp
@@ -252,29 +252,58 @@ void Query::add_expression_node(std::unique_ptr<Expression> expression)
 }
 
 // Binary
-Query& Query::equal(size_t column_ndx, BinaryData b)
+Query& Query::equal(size_t column_ndx, BinaryData b, bool case_sensitive)
 {
-    add_condition<Equal>(column_ndx, b);
+    if (case_sensitive) {
+        add_condition<Equal>(column_ndx, b);
+    } else {
+        add_condition<EqualIns>(column_ndx, b);
+    }
     return *this;
 }
-Query& Query::not_equal(size_t column_ndx, BinaryData b)
+Query& Query::not_equal(size_t column_ndx, BinaryData b, bool case_sensitive)
 {
-    add_condition<NotEqual>(column_ndx, b);
+    if (case_sensitive) {
+        add_condition<NotEqual>(column_ndx, b);
+    } else {
+        add_condition<NotEqualIns>(column_ndx, b);
+    }
     return *this;
 }
-Query& Query::begins_with(size_t column_ndx, BinaryData b)
+Query& Query::begins_with(size_t column_ndx, BinaryData b, bool case_sensitive)
 {
-    add_condition<BeginsWith>(column_ndx, b);
+    if (case_sensitive) {
+        add_condition<BeginsWith>(column_ndx, b);
+    } else {
+        add_condition<BeginsWithIns>(column_ndx, b);
+    }
     return *this;
 }
-Query& Query::ends_with(size_t column_ndx, BinaryData b)
+Query& Query::ends_with(size_t column_ndx, BinaryData b, bool case_sensitive)
 {
-    add_condition<EndsWith>(column_ndx, b);
+    if (case_sensitive) {
+        add_condition<EndsWith>(column_ndx, b);
+    } else {
+        add_condition<EndsWithIns>(column_ndx, b);
+    }
     return *this;
 }
-Query& Query::contains(size_t column_ndx, BinaryData b)
+Query& Query::contains(size_t column_ndx, BinaryData b, bool case_sensitive)
 {
-    add_condition<Contains>(column_ndx, b);
+    if (case_sensitive) {
+        add_condition<Contains>(column_ndx, b);
+    } else {
+        add_condition<ContainsIns>(column_ndx, b);
+    }
+    return *this;
+}
+Query& Query::like(size_t column_ndx, BinaryData b, bool case_sensitive)
+{
+    if (case_sensitive) {
+        add_condition<Like>(column_ndx, b);
+    } else {
+        add_condition<LikeIns>(column_ndx, b);
+    }
     return *this;
 }
 

--- a/src/realm/query.cpp
+++ b/src/realm/query.cpp
@@ -1602,8 +1602,13 @@ std::string Query::validate()
 std::string Query::get_description() const
 {
     if (root_node()) {
+        if (m_view) {
+            throw SerialisationError("Serialisation of a query constrianed by a view is not currently supported");
+        }
         return root_node()->describe_expression();
     }
+    // An empty query returns all results and one way to indicate this
+    // is to serialise TRUEPREDICATE which is functionally equivilent
     return "TRUEPREDICATE";
 }
 

--- a/src/realm/query.hpp
+++ b/src/realm/query.hpp
@@ -232,11 +232,12 @@ public:
     Query& not_equal(size_t column_ndx, const char* c_str, bool case_sensitive = true);
 
     // Conditions: binary data
-    Query& equal(size_t column_ndx, BinaryData value);
-    Query& not_equal(size_t column_ndx, BinaryData value);
-    Query& begins_with(size_t column_ndx, BinaryData value);
-    Query& ends_with(size_t column_ndx, BinaryData value);
-    Query& contains(size_t column_ndx, BinaryData value);
+    Query& equal(size_t column_ndx, BinaryData value, bool case_sensitive = true);
+    Query& not_equal(size_t column_ndx, BinaryData value, bool case_sensitive = true);
+    Query& begins_with(size_t column_ndx, BinaryData value, bool case_sensitive = true);
+    Query& ends_with(size_t column_ndx, BinaryData value, bool case_sensitive = true);
+    Query& contains(size_t column_ndx, BinaryData value, bool case_sensitive = true);
+    Query& like(size_t column_ndx, BinaryData b, bool case_sensitive = true);
 
     // Negation
     Query& Not();

--- a/src/realm/query_conditions.hpp
+++ b/src/realm/query_conditions.hpp
@@ -100,14 +100,21 @@ struct Like : public HackClass {
     {
         return v2.like(v1);
     }
+    bool operator()(BinaryData b1, const char*, const char*, BinaryData b2, bool = false, bool = false) const
+    {
+        StringData s1(b1.data(), b1.size());
+        StringData s2(b2.data(), b2.size());
+        return s2.like(s1);
+    }
     bool operator()(StringData v1, StringData v2, bool = false, bool = false) const
     {
         return v2.like(v1);
     }
-    bool operator()(BinaryData, BinaryData, bool = false, bool = false) const
+    bool operator()(BinaryData b1, BinaryData b2, bool = false, bool = false) const
     {
-        REALM_ASSERT(false);
-        return false;
+        StringData s1(b1.data(), b1.size());
+        StringData s2(b2.data(), b2.size());
+        return s2.like(s1);
     }
 
     template <class A, class B>
@@ -314,6 +321,12 @@ struct ContainsIns : public HackClass {
         std::string v1_lower = case_map(v1, false, IgnoreErrors);
         return search_case_fold(v2, v1_upper.c_str(), v1_lower.c_str(), v1.size()) != v2.size();
     }
+    bool operator()(BinaryData b1, BinaryData b2, bool = false, bool = false) const
+    {
+        StringData s1(b1.data(), b1.size());
+        StringData s2(b2.data(), b2.size());
+        return this->operator()(s1, s2, false, false);
+    }
     
     // Case insensitive Boyer-Moore version
     bool operator()(StringData v1, const char* v1_upper, const char* v1_lower, const std::array<uint8_t, 256> &charmap, StringData v2) const
@@ -365,6 +378,16 @@ struct LikeIns : public HackClass {
 
         return string_like_ins(v2, v1_lower, v1_upper);
     }
+    bool operator()(BinaryData b1, const char* b1_upper, const char* b1_lower, BinaryData b2, bool = false,
+                    bool = false) const
+    {
+        if (b2.is_null() || b1.is_null()) {
+            return (b2.is_null() && b1.is_null());
+        }
+        StringData s2(b2.data(), b2.size());
+
+        return string_like_ins(s2, b1_lower, b1_upper);
+    }
 
     // Slow version, used if caller hasn't stored an upper and lower case version
     bool operator()(StringData v1, StringData v2, bool = false, bool = false) const
@@ -376,6 +399,18 @@ struct LikeIns : public HackClass {
         std::string v1_upper = case_map(v1, true, IgnoreErrors);
         std::string v1_lower = case_map(v1, false, IgnoreErrors);
         return string_like_ins(v2, v1_lower, v1_upper);
+    }
+    bool operator()(BinaryData b1, BinaryData b2, bool = false, bool = false) const
+    {
+        if (b2.is_null() || b1.is_null()) {
+            return (b2.is_null() && b1.is_null());
+        }
+        StringData s1(b1.data(), b1.size());
+        StringData s2(b2.data(), b2.size());
+
+        std::string s1_upper = case_map(s1, true, IgnoreErrors);
+        std::string s1_lower = case_map(s1, false, IgnoreErrors);
+        return string_like_ins(s2, s1_lower, s1_upper);
     }
 
     template <class A, class B>
@@ -425,6 +460,12 @@ struct BeginsWithIns : public HackClass {
         std::string v1_upper = case_map(v1, true, IgnoreErrors);
         std::string v1_lower = case_map(v1, false, IgnoreErrors);
         return equal_case_fold(v2.prefix(v1.size()), v1_upper.c_str(), v1_lower.c_str());
+    }
+    bool operator()(BinaryData b1, BinaryData b2, bool = false, bool = false) const
+    {
+        StringData s1(b1.data(), b1.size());
+        StringData s2(b2.data(), b2.size());
+        return this->operator()(s1, s2, false, false);
     }
 
     template <class A, class B>
@@ -476,6 +517,12 @@ struct EndsWithIns : public HackClass {
         std::string v1_lower = case_map(v1, false, IgnoreErrors);
         return equal_case_fold(v2.suffix(v1.size()), v1_upper.c_str(), v1_lower.c_str());
     }
+    bool operator()(BinaryData b1, BinaryData b2, bool = false, bool = false) const
+    {
+        StringData s1(b1.data(), b1.size());
+        StringData s2(b2.data(), b2.size());
+        return this->operator()(s1, s2, false, false);
+    }
 
     template <class A, class B>
     bool operator()(A, B) const
@@ -525,6 +572,12 @@ struct EqualIns : public HackClass {
         std::string v1_lower = case_map(v1, false, IgnoreErrors);
         return equal_case_fold(v2, v1_upper.c_str(), v1_lower.c_str());
     }
+    bool operator()(BinaryData b1, BinaryData b2, bool = false, bool = false) const
+    {
+        StringData s1(b1.data(), b1.size());
+        StringData s2(b2.data(), b2.size());
+        return this->operator()(s1, s2, false, false);
+    }
 
     template <class A, class B>
     bool operator()(A, B) const
@@ -572,6 +625,12 @@ struct NotEqualIns : public HackClass {
         std::string v1_upper = case_map(v1, true, IgnoreErrors);
         std::string v1_lower = case_map(v1, false, IgnoreErrors);
         return !equal_case_fold(v2, v1_upper.c_str(), v1_lower.c_str());
+    }
+    bool operator()(BinaryData b1, BinaryData b2, bool = false, bool = false) const
+    {
+        StringData s1(b1.data(), b1.size());
+        StringData s2(b2.data(), b2.size());
+        return this->operator()(s1, s2, false, false);
     }
 
     template <class A, class B>

--- a/src/realm/query_engine.hpp
+++ b/src/realm/query_engine.hpp
@@ -1939,6 +1939,24 @@ public:
         do_verify_column(m_getter2.m_column, m_condition_column_idx2);
     }
 
+    virtual std::string describe_column() const override
+    {
+        REALM_ASSERT(m_condition_column != nullptr);
+        return ParentNode::describe_column(m_condition_column->get_column_index());
+    }
+
+    virtual std::string describe() const override
+    {
+        REALM_ASSERT(m_getter1.m_column != nullptr && m_getter2.m_column != nullptr);
+        return ParentNode::describe_column(m_getter1.m_column->get_column_index()) + " " + describe_condition() + " "
+             + ParentNode::describe_column(m_getter2.m_column->get_column_index());
+    }
+
+    virtual std::string describe_condition() const override
+    {
+        return TConditionFunction::description();
+    }
+
     void init() override
     {
         ParentNode::init();

--- a/src/realm/query_engine.hpp
+++ b/src/realm/query_engine.hpp
@@ -421,7 +421,7 @@ public:
 
     std::string describe() const override
     {
-        return "subtable expression";
+        throw SerialisationError("Serialising a query which contains a subtable expression is currently unsupported.");
     }
 
 
@@ -2101,7 +2101,9 @@ public:
 
     virtual std::string describe() const override
     {
-        return describe_column() + " " + describe_condition() + " " + util::serializer::print_value(m_target_row.get_index());
+        throw SerialisationError("Serialising a query which links to an object is currently unsupported.");
+        // We can do something like the following when core gets stable keys
+        //return describe_column() + " " + describe_condition() + " " + util::serializer::print_value(m_target_row.get_index());
     }
     virtual std::string describe_condition() const override
     {

--- a/src/realm/query_engine.hpp
+++ b/src/realm/query_engine.hpp
@@ -412,6 +412,13 @@ public:
         else
             return m_condition->validate();
     }
+
+    virtual std::string describe_column() const override
+    {
+        REALM_ASSERT(m_column != nullptr);
+        return ParentNode::describe_column(m_column->get_column_index());
+    }
+
     std::string describe() const override
     {
         return "subtable expression";
@@ -675,6 +682,12 @@ protected:
     void verify_column() const override
     {
         do_verify_column(m_condition_column);
+    }
+
+    virtual std::string describe_column() const override
+    {
+        REALM_ASSERT(m_condition_column != nullptr);
+        return ParentNode::describe_column(m_condition_column->get_column_index());
     }
 
     void init() override
@@ -944,9 +957,15 @@ public:
             return find(false);
     }
 
+    virtual std::string describe_column() const override
+    {
+        REALM_ASSERT(m_condition_column.m_column != nullptr);
+        return ParentNode::describe_column(m_condition_column.m_column->get_column_index());
+    }
+
     virtual std::string describe() const override
     {
-        return this->describe_column() + " " + describe_condition() + " " + util::serializer::print_value(FloatDoubleNode::m_value);
+        return describe_column() + " " + describe_condition() + " " + util::serializer::print_value(FloatDoubleNode::m_value);
     }
     virtual std::string describe_condition() const override
     {
@@ -1077,9 +1096,15 @@ public:
         return not_found;
     }
 
+    virtual std::string describe_column() const override
+    {
+        REALM_ASSERT(m_condition_column != nullptr);
+        return ParentNode::describe_column(m_condition_column->get_column_index());
+    }
+
     virtual std::string describe() const override
     {
-        return this->describe_column() + " " + TConditionFunction::description() + " "
+        return describe_column() + " " + TConditionFunction::description() + " "
             + util::serializer::print_value(BinaryNode::m_value.get());
     }
 
@@ -1143,9 +1168,15 @@ public:
         return ret;
     }
 
+    virtual std::string describe_column() const override
+    {
+        REALM_ASSERT(m_condition_column != nullptr);
+        return ParentNode::describe_column(m_condition_column->get_column_index());
+    }
+
     virtual std::string describe() const override
     {
-        return this->describe_column() + " " + TConditionFunction::description() + " " + util::serializer::print_value(TimestampNode::m_value);
+        return describe_column() + " " + TConditionFunction::description() + " " + util::serializer::print_value(TimestampNode::m_value);
     }
 
     std::unique_ptr<ParentNode> clone(QueryNodeHandoverPatches* patches) const override
@@ -1215,6 +1246,12 @@ public:
     {
         if (m_condition_column && patches)
             m_condition_column_idx = m_condition_column->get_column_index();
+    }
+
+    virtual std::string describe_column() const override
+    {
+        REALM_ASSERT(m_condition_column != nullptr);
+        return ParentNode::describe_column(m_condition_column->get_column_index());
     }
 
     virtual std::string describe() const override
@@ -2038,9 +2075,15 @@ public:
         do_verify_column(m_column, m_origin_column);
     }
 
+    virtual std::string describe_column() const override
+    {
+        REALM_ASSERT(m_column != nullptr);
+        return ParentNode::describe_column(m_column->get_column_index());
+    }
+
     virtual std::string describe() const override
     {
-        return this->describe_column(m_origin_column) + " " + describe_condition() + " " + util::serializer::print_value(m_target_row.get_index());
+        return describe_column() + " " + describe_condition() + " " + util::serializer::print_value(m_target_row.get_index());
     }
     virtual std::string describe_condition() const override
     {

--- a/src/realm/query_expression.cpp
+++ b/src/realm/query_expression.cpp
@@ -125,4 +125,68 @@ Query Subexpr2<StringData>::like(const Subexpr2<StringData>& col, bool case_sens
 {
     return string_compare<Like, LikeIns>(*this, col, case_sensitive);
 }
+
+
+// BinaryData
+
+Query Subexpr2<BinaryData>::equal(BinaryData sd, bool case_sensitive)
+{
+    return binary_compare<BinaryData, Equal, EqualIns>(*this, sd, case_sensitive);
+}
+
+Query Subexpr2<BinaryData>::equal(const Subexpr2<BinaryData>& col, bool case_sensitive)
+{
+    return binary_compare<Equal, EqualIns>(*this, col, case_sensitive);
+}
+
+Query Subexpr2<BinaryData>::not_equal(BinaryData sd, bool case_sensitive)
+{
+    return binary_compare<BinaryData, NotEqual, NotEqualIns>(*this, sd, case_sensitive);
+}
+
+Query Subexpr2<BinaryData>::not_equal(const Subexpr2<BinaryData>& col, bool case_sensitive)
+{
+    return binary_compare<NotEqual, NotEqualIns>(*this, col, case_sensitive);
+}
+
+Query Subexpr2<BinaryData>::begins_with(BinaryData sd, bool case_sensitive)
+{
+    return binary_compare<BinaryData, BeginsWith, BeginsWithIns>(*this, sd, case_sensitive);
+}
+
+Query Subexpr2<BinaryData>::begins_with(const Subexpr2<BinaryData>& col, bool case_sensitive)
+{
+    return binary_compare<BeginsWith, BeginsWithIns>(*this, col, case_sensitive);
+}
+
+Query Subexpr2<BinaryData>::ends_with(BinaryData sd, bool case_sensitive)
+{
+    return binary_compare<BinaryData, EndsWith, EndsWithIns>(*this, sd, case_sensitive);
+}
+
+Query Subexpr2<BinaryData>::ends_with(const Subexpr2<BinaryData>& col, bool case_sensitive)
+{
+    return binary_compare<EndsWith, EndsWithIns>(*this, col, case_sensitive);
+}
+
+Query Subexpr2<BinaryData>::contains(BinaryData sd, bool case_sensitive)
+{
+    return binary_compare<BinaryData, Contains, ContainsIns>(*this, sd, case_sensitive);
+}
+
+Query Subexpr2<BinaryData>::contains(const Subexpr2<BinaryData>& col, bool case_sensitive)
+{
+    return binary_compare<Contains, ContainsIns>(*this, col, case_sensitive);
+}
+
+Query Subexpr2<BinaryData>::like(BinaryData sd, bool case_sensitive)
+{
+    return binary_compare<BinaryData, Like, LikeIns>(*this, sd, case_sensitive);
+}
+
+Query Subexpr2<BinaryData>::like(const Subexpr2<BinaryData>& col, bool case_sensitive)
+{
+    return binary_compare<Like, LikeIns>(*this, col, case_sensitive);
+}
+
 }

--- a/src/realm/query_expression.hpp
+++ b/src/realm/query_expression.hpp
@@ -181,14 +181,20 @@ inline int only_numeric(const BinaryData&)
 }
 
 template <class T>
-inline StringData only_string(T in)
+inline StringData only_string_op_types(T in)
 {
     REALM_ASSERT(false);
     static_cast<void>(in);
     return StringData();
 }
 
-inline StringData only_string(StringData in)
+inline BinaryData only_string_op_types(BinaryData in)
+{
+    return in;
+}
+
+template <>
+inline StringData only_string_op_types<StringData>(StringData in)
 {
     return in;
 }
@@ -506,25 +512,25 @@ Query create(L left, const Subexpr2<R>& right)
         else if (std::is_same<Cond, GreaterEqual>::value)
             q.less_equal(column->column_ndx(), _impl::only_numeric<R>(left));
         else if (std::is_same<Cond, EqualIns>::value)
-            q.equal(column->column_ndx(), _impl::only_string(left), false);
+            q.equal(column->column_ndx(), _impl::only_string_op_types(left), false);
         else if (std::is_same<Cond, NotEqualIns>::value)
-            q.not_equal(column->column_ndx(), _impl::only_string(left), false);
+            q.not_equal(column->column_ndx(), _impl::only_string_op_types(left), false);
         else if (std::is_same<Cond, BeginsWith>::value)
-            q.begins_with(column->column_ndx(), _impl::only_string(left));
+            q.begins_with(column->column_ndx(), _impl::only_string_op_types(left));
         else if (std::is_same<Cond, BeginsWithIns>::value)
-            q.begins_with(column->column_ndx(), _impl::only_string(left), false);
+            q.begins_with(column->column_ndx(), _impl::only_string_op_types(left), false);
         else if (std::is_same<Cond, EndsWith>::value)
-            q.ends_with(column->column_ndx(), _impl::only_string(left));
+            q.ends_with(column->column_ndx(), _impl::only_string_op_types(left));
         else if (std::is_same<Cond, EndsWithIns>::value)
-            q.ends_with(column->column_ndx(), _impl::only_string(left), false);
+            q.ends_with(column->column_ndx(), _impl::only_string_op_types(left), false);
         else if (std::is_same<Cond, Contains>::value)
-            q.contains(column->column_ndx(), _impl::only_string(left));
+            q.contains(column->column_ndx(), _impl::only_string_op_types(left));
         else if (std::is_same<Cond, ContainsIns>::value)
-            q.contains(column->column_ndx(), _impl::only_string(left), false);
+            q.contains(column->column_ndx(), _impl::only_string_op_types(left), false);
         else if (std::is_same<Cond, Like>::value)
-            q.like(column->column_ndx(), _impl::only_string(left));
+            q.like(column->column_ndx(), _impl::only_string_op_types(left));
         else if (std::is_same<Cond, LikeIns>::value)
-            q.like(column->column_ndx(), _impl::only_string(left), false);
+            q.like(column->column_ndx(), _impl::only_string_op_types(left), false);
         else {
             // query_engine.hpp does not support this Cond. Please either add support for it in query_engine.hpp or
             // fallback to using use 'return new Compare<>' instead.
@@ -788,6 +794,24 @@ public:
     Query like(StringData sd, bool case_sensitive = true);
     Query like(const Subexpr2<StringData>& col, bool case_sensitive = true);
 };
+
+template <>
+class Subexpr2<BinaryData> : public Subexpr, public Overloads<BinaryData, BinaryData> {
+public:
+    Query equal(BinaryData sd, bool case_sensitive = true);
+    Query equal(const Subexpr2<BinaryData>& col, bool case_sensitive = true);
+    Query not_equal(BinaryData sd, bool case_sensitive = true);
+    Query not_equal(const Subexpr2<BinaryData>& col, bool case_sensitive = true);
+    Query begins_with(BinaryData sd, bool case_sensitive = true);
+    Query begins_with(const Subexpr2<BinaryData>& col, bool case_sensitive = true);
+    Query ends_with(BinaryData sd, bool case_sensitive = true);
+    Query ends_with(const Subexpr2<BinaryData>& col, bool case_sensitive = true);
+    Query contains(BinaryData sd, bool case_sensitive = true);
+    Query contains(const Subexpr2<BinaryData>& col, bool case_sensitive = true);
+    Query like(BinaryData sd, bool case_sensitive = true);
+    Query like(const Subexpr2<BinaryData>& col, bool case_sensitive = true);
+};
+
 
 /*
 This class is used to store N values of type T = {int64_t, bool, OldDateTime or StringData}, and allows an entry
@@ -2142,6 +2166,26 @@ Query string_compare(const Subexpr2<StringData>& left, const Subexpr2<StringData
     else
         return make_expression<Compare<I, StringData>>(right.clone(), left.clone());
 }
+
+template <class T, class S, class I>
+Query binary_compare(const Subexpr2<BinaryData>& left, T right, bool case_sensitive)
+{
+    BinaryData data(right);
+    if (case_sensitive)
+        return create<S>(data, left);
+    else
+        return create<I>(data, left);
+}
+
+template <class S, class I>
+Query binary_compare(const Subexpr2<BinaryData>& left, const Subexpr2<BinaryData>& right, bool case_sensitive)
+{
+    if (case_sensitive)
+        return make_expression<Compare<S, BinaryData>>(right.clone(), left.clone());
+    else
+        return make_expression<Compare<I, BinaryData>>(right.clone(), left.clone());
+}
+
 
 // Columns<String> == Columns<String>
 inline Query operator==(const Columns<StringData>& left, const Columns<StringData>& right)

--- a/src/realm/query_expression.hpp
+++ b/src/realm/query_expression.hpp
@@ -218,7 +218,7 @@ struct Plus {
     }
     static std::string description()
     {
-        return "plus";
+        return "+";
     }
     typedef T type;
 };
@@ -231,7 +231,7 @@ struct Minus {
     }
     static std::string description()
     {
-        return "minus";
+        return "-";
     }
     typedef T type;
 };
@@ -244,7 +244,7 @@ struct Div {
     }
     static std::string description()
     {
-        return "divided by";
+        return "/";
     }
     typedef T type;
 };
@@ -257,7 +257,7 @@ struct Mul {
     }
     static std::string description()
     {
-        return "multiplied by";
+        return "*";
     }
     typedef T type;
 };
@@ -271,7 +271,7 @@ struct Pow {
     }
     static std::string description()
     {
-        return "to the power of";
+        return "^";
     }
     typedef T type;
 };
@@ -3658,7 +3658,7 @@ public:
         if (m_left) {
             s += m_left->description();
         }
-        s += oper::description();
+        s += (" " + oper::description() + " ");
         if (m_right) {
             s += m_right->description();
         }

--- a/src/realm/query_expression.hpp
+++ b/src/realm/query_expression.hpp
@@ -1861,7 +1861,8 @@ public:
         for (size_t i = 0; i < m_link_column_indexes.size(); ++i) {
             if (i < m_tables.size() && m_tables[i]) {
                 if (m_link_types[i] == col_type_BackLink) {
-                    s += "backlink";
+                    throw SerialisationError("Serialising a query which contains backlinks is currently unsupported.");
+                    //s += "backlink";
                 } else if (m_link_column_indexes[i] < m_tables[i]->get_column_count()) {
                     s += std::string(m_tables[i]->get_column_name(m_link_column_indexes[i]));
                 }
@@ -2476,10 +2477,12 @@ public:
 
     virtual std::string description() const override
     {
-        if (!m_row.is_attached()) {
-            return util::serializer::print_value("detached object");
-        }
-        return util::serializer::print_value(m_row.get_index());
+        throw SerialisationError("Serialising a query which links to an object is currently unsupported.");
+        // TODO: we can do something like the following when core gets stable keys:
+        //if (!m_row.is_attached()) {
+        //    return util::serializer::print_value("detached object");
+        //}
+        //return util::serializer::print_value(m_row.get_index());
     }
 
     std::unique_ptr<Subexpr> clone(QueryNodeHandoverPatches* patches) const override
@@ -3386,8 +3389,9 @@ public:
 
     virtual std::string description() const override
     {
-        return m_link_map.description() + util::serializer::value_separator + "SUBQUERY(" + m_query.get_description() + ")"
-            + util::serializer::value_separator + "@count";
+        throw SerialisationError("Serialising a subquery expression is currently unsupported.");
+        //return m_link_map.description() + util::serializer::value_separator + "SUBQUERY(" + m_query.get_description() + ")"
+        //    + util::serializer::value_separator + "@count";
     }
 
     std::unique_ptr<Subexpr> clone(QueryNodeHandoverPatches* patches) const override

--- a/src/realm/table.hpp
+++ b/src/realm/table.hpp
@@ -1905,15 +1905,15 @@ inline Columns<T> Table::column(size_t column_ndx)
 
     realm::DataType ct = table->get_column_type(column_ndx);
     if (std::is_same<T, int64_t>::value && ct != type_Int)
-        throw(LogicError::type_mismatch);
+        throw LogicError(LogicError::type_mismatch);
     else if (std::is_same<T, bool>::value && ct != type_Bool)
-        throw(LogicError::type_mismatch);
+        throw LogicError(LogicError::type_mismatch);
     else if (std::is_same<T, realm::OldDateTime>::value && ct != type_OldDateTime)
-        throw(LogicError::type_mismatch);
+        throw LogicError(LogicError::type_mismatch);
     else if (std::is_same<T, float>::value && ct != type_Float)
-        throw(LogicError::type_mismatch);
+        throw LogicError(LogicError::type_mismatch);
     else if (std::is_same<T, double>::value && ct != type_Double)
-        throw(LogicError::type_mismatch);
+        throw LogicError(LogicError::type_mismatch);
 
     if (std::is_same<T, Link>::value || std::is_same<T, LinkList>::value || std::is_same<T, BackLink>::value) {
         link_chain.push_back(column_ndx);

--- a/src/realm/table_view.cpp
+++ b/src/realm/table_view.cpp
@@ -710,6 +710,11 @@ void TableViewBase::apply_descriptor_ordering(DescriptorOrdering new_ordering)
     do_sync();
 }
 
+std::string TableViewBase::get_descriptor_ordering_description() const
+{
+    return m_descriptor_ordering.get_description(m_table);
+}
+
 // Sort according to one column
 void TableViewBase::sort(size_t column, bool ascending)
 {

--- a/src/realm/table_view.hpp
+++ b/src/realm/table_view.hpp
@@ -305,6 +305,10 @@ public:
     // calling sort and distinct. This is a convenience method for bindings.
     void apply_descriptor_ordering(DescriptorOrdering new_ordering);
 
+    // Gets a readable and parsable string which completely describes the sort and
+    // distinct operations applied to this view.
+    std::string get_descriptor_ordering_description() const;
+
     // Returns whether the rows are guaranteed to be in table order.
     // This is true only of unsorted TableViews created from either:
     // - Table::find_all()

--- a/src/realm/views.cpp
+++ b/src/realm/views.cpp
@@ -183,7 +183,7 @@ std::vector<bool> SortDescriptor::export_order() const
 
 std::string SortDescriptor::get_description(TableRef attached_table) const
 {
-    std::string description = "SORT BY ";
+    std::string description = "SORT(";
     for (size_t i = 0; i < m_columns.size(); ++i) {
         const size_t chain_size = m_columns[i].size();
         TableRef cur_link_table = attached_table;
@@ -200,18 +200,22 @@ std::string SortDescriptor::get_description(TableRef attached_table) const
         description += " ";
         if (i < m_ascending.size()) {
             if (m_ascending[i]) {
-                description += "ASC ";
+                description += "ASC";
             } else {
-                description += "DESC ";
+                description += "DESC";
             }
         }
+        if (i < m_columns.size() - 1) {
+            description += " ";
+        }
     }
+    description += ")";
     return description;
 }
 
 std::string CommonDescriptor::get_description(TableRef attached_table) const
 {
-    std::string description = "DISTINCT ";
+    std::string description = "DISTINCT(";
     for (size_t i = 0; i < m_columns.size(); ++i) {
         const size_t chain_size = m_columns[i].size();
         TableRef cur_link_table = attached_table;
@@ -225,8 +229,11 @@ std::string CommonDescriptor::get_description(TableRef attached_table) const
                 cur_link_table = cur_link_table->get_link_target(col_ndx);
             }
         }
-        description += " ";
+        if (i < m_columns.size() - 1) {
+            description += " ";
+        }
     }
+    description += ")";
     return description;
 }
 
@@ -351,6 +358,9 @@ std::string DescriptorOrdering::get_description(TableRef target_table) const
     for (auto it = m_descriptors.begin(); it != m_descriptors.end(); ++it) {
         REALM_ASSERT_DEBUG(bool(*it));
         description += (*it)->get_description(target_table);
+        if (it != m_descriptors.end() - 1) {
+            description += " ";
+        }
     }
     return description;
 }

--- a/src/realm/views.cpp
+++ b/src/realm/views.cpp
@@ -113,7 +113,7 @@ public:
     bool any_is_null(IndexPair i) const
     {
         return std::any_of(m_columns.begin(), m_columns.end(),
-                           [=](auto&& col) { return col.is_null[i.index_in_view]; });
+                           [=](auto&& col) { return col.is_null.empty() ? false : col.is_null[i.index_in_view]; });
     }
 
 private:
@@ -206,7 +206,7 @@ std::string SortDescriptor::get_description(TableRef attached_table) const
             }
         }
         if (i < m_columns.size() - 1) {
-            description += " ";
+            description += ", ";
         }
     }
     description += ")";
@@ -230,7 +230,7 @@ std::string CommonDescriptor::get_description(TableRef attached_table) const
             }
         }
         if (i < m_columns.size() - 1) {
-            description += " ";
+            description += ", ";
         }
     }
     description += ")";

--- a/src/realm/views.hpp
+++ b/src/realm/views.hpp
@@ -69,6 +69,7 @@ public:
     {
         return {};
     }
+    virtual std::string get_description(TableRef attached_table) const;
 
 protected:
     std::vector<std::vector<const ColumnBase*>> m_columns;
@@ -92,6 +93,7 @@ public:
 
     // handover support
     std::vector<bool> export_order() const override;
+    std::string get_description(TableRef attached_table) const override;
 
 private:
     std::vector<bool> m_ascending;
@@ -117,6 +119,7 @@ public:
     const CommonDescriptor* operator[](size_t ndx) const;
     bool will_apply_sort() const;
     bool will_apply_distinct() const;
+    std::string get_description(TableRef target_table) const;
 
     // handover support
     using HandoverPatch = std::unique_ptr<DescriptorOrderingHandoverPatch>;

--- a/test/test_metrics.cpp
+++ b/test/test_metrics.cpp
@@ -304,29 +304,19 @@ TEST(Metrics_QueryEqual)
     q4.find_all();
     q5.find_all();
     q6.find_all();
-    q7.find_all();
-    q8.find_all();
+    CHECK_THROW(q7.find_all(), SerialisationError);
+    CHECK_THROW(q8.find_all(), SerialisationError);
 
     std::shared_ptr<Metrics> metrics = sg.get_metrics();
     CHECK(metrics);
     std::unique_ptr<Metrics::QueryInfoList> queries = metrics->take_queries();
     CHECK(queries);
-    CHECK_EQUAL(queries->size(), 9);
+    CHECK_EQUAL(queries->size(), 7);
 
     for (size_t i = 0; i < 7; ++i) {
         std::string description = queries->at(i).get_description();
         CHECK_EQUAL(find_count(description, column_names[i]), 1);
         CHECK_GREATER_EQUAL(find_count(description, query_search_term), 1);
-    }
-    {
-        std::string description = queries->at(7).get_description();
-        CHECK_EQUAL(find_count(description, column_names[7]), 1);
-        CHECK_EQUAL(find_count(description, "links to"), 1);
-    }
-    {
-        std::string description = queries->at(8).get_description();
-        CHECK_EQUAL(find_count(description, "owner"), 1);
-        CHECK_EQUAL(find_count(description, "links to"), 1);
     }
 }
 
@@ -502,7 +492,7 @@ TEST(Metrics_LinkQueries)
     q0.find_all();
     q1.find_all();
     q2.find_all();
-    q3.find_all();
+    CHECK_THROW(q3.find_all(), SerialisationError);
 
     std::shared_ptr<Metrics> metrics = sg.get_metrics();
     CHECK(metrics);
@@ -512,7 +502,8 @@ TEST(Metrics_LinkQueries)
     // FIXME: q3 adds 6 queries: the find_all() + 1 sub query per row in person
     // that's how subqueries across links are executed currently so it is accurate
     // but not sure if this is acceptable for how we track queries
-    CHECK_EQUAL(queries->size(), 10);
+    // CHECK_EQUAL(queries->size(), 10);
+    CHECK_EQUAL(queries->size(), 3);
 
     std::string null_links_description = queries->at(0).get_description();
     CHECK_EQUAL(find_count(null_links_description, "NULL"), 1);
@@ -528,12 +519,13 @@ TEST(Metrics_LinkQueries)
     CHECK_EQUAL(find_count(count_link_description, pet_link_col_name), 1);
     CHECK_EQUAL(find_count(count_link_description, "=="), 1);
 
-    std::string link_subquery_description = queries->at(3).get_description();
-    CHECK_EQUAL(find_count(link_subquery_description, "@count"), 1);
-    CHECK_EQUAL(find_count(link_subquery_description, pet_link_col_name), 1);
-    CHECK_EQUAL(find_count(link_subquery_description, "=="), 1);
-    CHECK_EQUAL(find_count(link_subquery_description, column_names[0]), 1);
-    CHECK_EQUAL(find_count(link_subquery_description, ">"), 1);
+//    CHECK_THROW(queries->at(3), SerialisationError);
+//    std::string link_subquery_description = queries->at(3).get_description();
+//    CHECK_EQUAL(find_count(link_subquery_description, "@count"), 1);
+//    CHECK_EQUAL(find_count(link_subquery_description, pet_link_col_name), 1);
+//    CHECK_EQUAL(find_count(link_subquery_description, "=="), 1);
+//    CHECK_EQUAL(find_count(link_subquery_description, column_names[0]), 1);
+//    CHECK_EQUAL(find_count(link_subquery_description, ">"), 1);
 }
 
 
@@ -575,18 +567,16 @@ TEST(Metrics_LinkListQueries)
     q0.find_all();
     q1.find_all();
     q2.find_all();
-    q3.find_all();
+    CHECK_THROW(q3.find_all(), SerialisationError);
     q4.find_all();
-    q5.find_all();
+    CHECK_THROW(q5.find_all(), SerialisationError);
 
     std::shared_ptr<Metrics> metrics = sg.get_metrics();
     CHECK(metrics);
     std::unique_ptr<Metrics::QueryInfoList> queries = metrics->take_queries();
     CHECK(queries);
 
-    // q4 adds a subquery which is executed once per link in the linklist column
-    size_t num_total_links = 11;
-    CHECK_EQUAL(queries->size(), 6 + num_total_links);
+    CHECK_EQUAL(queries->size(), 4);
 
     std::string null_links_description = queries->at(0).get_description();
     CHECK_EQUAL(find_count(null_links_description, "NULL"), 1);
@@ -602,22 +592,20 @@ TEST(Metrics_LinkListQueries)
     CHECK_EQUAL(find_count(count_link_description, column_names[ll_col_ndx]), 1);
     CHECK_EQUAL(find_count(count_link_description, "=="), 1);
 
-    std::string equal_link_description = queries->at(3).get_description();
-    CHECK_EQUAL(find_count(equal_link_description, column_names[ll_col_ndx]), 1);
-    CHECK_EQUAL(find_count(equal_link_description, "links to"), 1);
+    //CHECK_THROW(queries->at(3), SerialisationError);
 
-    std::string sum_link_description = queries->at(4).get_description();
+    std::string sum_link_description = queries->at(3).get_description();
     CHECK_EQUAL(find_count(sum_link_description, "@sum"), 1);
     CHECK_EQUAL(find_count(sum_link_description, column_names[ll_col_ndx]), 1);
     CHECK_EQUAL(find_count(sum_link_description, column_names[double_col_ndx]), 1);
     // the query system can choose to flip the argument order and operators so that >= might be <=
     CHECK_EQUAL(find_count(sum_link_description, "<=") + find_count(sum_link_description, ">="), 1);
 
-    std::string link_subquery_description = queries->at(5).get_description();
-    CHECK_EQUAL(find_count(link_subquery_description, "@count"), 1);
-    CHECK_EQUAL(find_count(link_subquery_description, column_names[ll_col_ndx]), 1);
-    CHECK_EQUAL(find_count(link_subquery_description, "=="), 2);
-    CHECK_EQUAL(find_count(link_subquery_description, column_names[str_col_ndx]), 1);
+//    std::string link_subquery_description = queries->at(4).get_description();
+//    CHECK_EQUAL(find_count(link_subquery_description, "@count"), 1);
+//    CHECK_EQUAL(find_count(link_subquery_description, column_names[ll_col_ndx]), 1);
+//    CHECK_EQUAL(find_count(link_subquery_description, "=="), 2);
+//    CHECK_EQUAL(find_count(link_subquery_description, column_names[str_col_ndx]), 1);
 }
 
 

--- a/test/test_parser.cpp
+++ b/test/test_parser.cpp
@@ -689,6 +689,13 @@ TEST(Parser_TwoColumnExpressionBasics)
     verify_query(test_context, table, "doubles == doubles", 3);
     verify_query(test_context, table, "strings == strings", 3);
     verify_query(test_context, table, "ints == link.@count", 2); // row 0 has 0 links, row 1 has 1 link
+
+    // type mismatch
+    CHECK_THROW_ANY(verify_query(test_context, table, "doubles == ints", 0));
+    CHECK_THROW_ANY(verify_query(test_context, table, "doubles == strings", 0));
+    CHECK_THROW_ANY(verify_query(test_context, table, "ints == doubles", 0));
+    CHECK_THROW_ANY(verify_query(test_context, table, "strings == doubles", 0));
+
 }
 
 

--- a/test/test_parser.cpp
+++ b/test/test_parser.cpp
@@ -259,7 +259,7 @@ Query verify_query(test_util::unit_test::TestContext& test_context, TableRef t, 
 
     CHECK_EQUAL(q.count(), num_results);
     std::string description = q.get_description();
-    std::cerr << "original: " << query_string << "\tdescribed: " << description << "\n";
+    //std::cerr << "original: " << query_string << "\tdescribed: " << description << "\n";
     Query q2 = t->where();
 
     realm::parser::Predicate p2 = realm::parser::parse(description);
@@ -267,6 +267,24 @@ Query verify_query(test_util::unit_test::TestContext& test_context, TableRef t, 
 
     CHECK_EQUAL(q2.count(), num_results);
     return q2;
+}
+
+
+TEST(Parser_empty_input)
+{
+    Group g;
+    std::string table_name = "table";
+    TableRef t = g.add_table(table_name);
+    t->add_column(type_Int, "int_col");
+    t->add_empty_row(5);
+
+    verify_query(test_context, t, "", 5);
+
+    verify_query(test_context, t, "TRUEPREDICATE", 5);
+    verify_query(test_context, t, "!TRUEPREDICATE", 0);
+
+    verify_query(test_context, t, "FALSEPREDICATE", 0);
+    verify_query(test_context, t, "!FALSEPREDICATE", 5);
 }
 
 

--- a/test/test_parser.cpp
+++ b/test/test_parser.cpp
@@ -278,7 +278,16 @@ TEST(Parser_empty_input)
     t->add_column(type_Int, "int_col");
     t->add_empty_row(5);
 
-    verify_query(test_context, t, "", 5);
+    // an empty query string is an invalid predicate
+    CHECK_THROW_ANY(verify_query(test_context, t, "", 5));
+
+    Query q = t->where(); // empty query
+    std::string empty_description = q.get_description();
+    CHECK(!empty_description.empty());
+    CHECK_EQUAL(0, empty_description.compare("TRUEPREDICATE"));
+    realm::parser::Predicate p = realm::parser::parse(empty_description);
+    realm::query_builder::apply_predicate(q, p);
+    CHECK_EQUAL(q.count(), 5);
 
     verify_query(test_context, t, "TRUEPREDICATE", 5);
     verify_query(test_context, t, "!TRUEPREDICATE", 0);

--- a/test/test_parser.cpp
+++ b/test/test_parser.cpp
@@ -561,6 +561,9 @@ TEST(Parser_Timestamps)
     verify_query(test_context, t, "birthday > 1905-12-31@23:59:59:2020", 5);
 #endif
 
+    // two column timestamps
+    verify_query(test_context, t, "birthday == T399", 1); // a null entry matches
+
     // dates pre 1900 are not supported by functions like timegm
     CHECK_THROW_ANY(verify_query(test_context, t, "birthday > 1800-12-31@23:59:59", 0));
     CHECK_THROW_ANY(verify_query(test_context, t, "birthday > 1800-12-31@23:59:59:2020", 4));
@@ -575,7 +578,6 @@ TEST(Parser_Timestamps)
     // Invalid predicate
     CHECK_THROW_ANY(verify_query(test_context, t, "birthday == T1:", 0));
     CHECK_THROW_ANY(verify_query(test_context, t, "birthday == T:1", 0));
-    CHECK_THROW_ANY(verify_query(test_context, t, "birthday == T399", 0));
     CHECK_THROW_ANY(verify_query(test_context, t, "birthday == 1970-1-1", 0));
     CHECK_THROW_ANY(verify_query(test_context, t, "birthday == 1970-1-1@", 0));
     CHECK_THROW_ANY(verify_query(test_context, t, "birthday == 1970-1-1@0", 0));
@@ -659,31 +661,33 @@ TEST(Parser_OverColumnIndexChanges)
 }
 
 
-ONLY(Parser_TwoColumnExpressions)
-{
-    Group g;
-    TableRef table = g.add_table("table");
-    size_t int_col_ndx = table->add_column(type_Int, "ints", true);
-    size_t double_col_ndx = table->add_column(type_Double, "doubles");
-    size_t string_col_ndx = table->add_column(type_String, "strings");
-    table->add_empty_row(3);
-    for (size_t i = 0; i < table->size(); ++i) {
-        table->set_int(int_col_ndx, i, i);
-        table->set_double(double_col_ndx, i, double(i));
-        std::string str(i, 'a');
-        table->set_string(string_col_ndx, i, StringData(str));
-    }
-
-    Query q = table->where().and_query(table->column<Int>(int_col_ndx) == table->column<String>(string_col_ndx).size());
-    CHECK_EQUAL(q.count(), 3);
-    std::string desc = q.get_description();
-
-    //verify_query(test_context, table, "ints == ints", 3);
-    verify_query(test_context, table, "ints == strings.@count", 3);
-    verify_query(test_context, table, "ints == NULL", 0);
-    verify_query(test_context, table, "doubles == doubles", 3);
-    verify_query(test_context, table, "strings == strings", 3);
-}
+//ONLY(Parser_TwoColumnExpressions)
+//{
+//    Group g;
+//    TableRef table = g.add_table("table");
+//    size_t int_col_ndx = table->add_column(type_Int, "ints", true);
+//    size_t double_col_ndx = table->add_column(type_Double, "doubles");
+//    size_t string_col_ndx = table->add_column(type_String, "strings");
+//    table->add_empty_row(3);
+//    for (size_t i = 0; i < table->size(); ++i) {
+//        table->set_int(int_col_ndx, i, i);
+//        table->set_double(double_col_ndx, i, double(i));
+//        std::string str(i, 'a');
+//        table->set_string(string_col_ndx, i, StringData(str));
+//    }
+//
+//    Query q = table->where().and_query(table->column<Int>(int_col_ndx) == table->column<String>(string_col_ndx).size());
+//    CHECK_EQUAL(q.count(), 3);
+//    std::string desc = q.get_description();
+//
+//    verify_query(test_context, table, "ints == 0", 1);
+//    verify_query(test_context, table, "ints == ints", 3);
+////    verify_query(test_context, table, "ints == ints.@max)
+//    verify_query(test_context, table, "ints == strings.@count", 3);
+//    verify_query(test_context, table, "ints == NULL", 0);
+//    verify_query(test_context, table, "doubles == doubles", 3);
+//    verify_query(test_context, table, "strings == strings", 3);
+//}
 
 
 void verify_query_sub(test_util::unit_test::TestContext& test_context, TableRef t, std::string query_string, const util::Any* arg_list, size_t num_args, size_t num_results) {

--- a/test/test_parser.cpp
+++ b/test/test_parser.cpp
@@ -869,7 +869,8 @@ TEST(Parser_TwoColumnAggregates)
 
     verify_query(test_context, t, "items.@count < account_balance", 3); // linklist count vs double
     verify_query(test_context, t, "items.@count > 3", 2);   // linklist count vs literal int
-    verify_query(test_context, t, "items.@count == 3.1", 0); // linklist count vs literal double
+    // linklist count vs literal double, integer promotion done here so this is true!
+    verify_query(test_context, t, "items.@count == 3.1", 1);
 
     // two string counts is allowed (int comparison)
     verify_query(test_context, items, "discount.promotion.@count > name.@count", 2);

--- a/test/test_parser.cpp
+++ b/test/test_parser.cpp
@@ -661,33 +661,35 @@ TEST(Parser_OverColumnIndexChanges)
 }
 
 
-//ONLY(Parser_TwoColumnExpressions)
-//{
-//    Group g;
-//    TableRef table = g.add_table("table");
-//    size_t int_col_ndx = table->add_column(type_Int, "ints", true);
-//    size_t double_col_ndx = table->add_column(type_Double, "doubles");
-//    size_t string_col_ndx = table->add_column(type_String, "strings");
-//    table->add_empty_row(3);
-//    for (size_t i = 0; i < table->size(); ++i) {
-//        table->set_int(int_col_ndx, i, i);
-//        table->set_double(double_col_ndx, i, double(i));
-//        std::string str(i, 'a');
-//        table->set_string(string_col_ndx, i, StringData(str));
-//    }
-//
-//    Query q = table->where().and_query(table->column<Int>(int_col_ndx) == table->column<String>(string_col_ndx).size());
-//    CHECK_EQUAL(q.count(), 3);
-//    std::string desc = q.get_description();
-//
-//    verify_query(test_context, table, "ints == 0", 1);
-//    verify_query(test_context, table, "ints == ints", 3);
-////    verify_query(test_context, table, "ints == ints.@max)
-//    verify_query(test_context, table, "ints == strings.@count", 3);
-//    verify_query(test_context, table, "ints == NULL", 0);
-//    verify_query(test_context, table, "doubles == doubles", 3);
-//    verify_query(test_context, table, "strings == strings", 3);
-//}
+TEST(Parser_TwoColumnExpressionBasics)
+{
+    Group g;
+    TableRef table = g.add_table("table");
+    size_t int_col_ndx = table->add_column(type_Int, "ints", true);
+    size_t double_col_ndx = table->add_column(type_Double, "doubles");
+    size_t string_col_ndx = table->add_column(type_String, "strings");
+    size_t link_col_ndx = table->add_column_link(type_Link, "link", *table);
+    table->add_empty_row(3);
+    for (size_t i = 0; i < table->size(); ++i) {
+        table->set_int(int_col_ndx, i, i);
+        table->set_double(double_col_ndx, i, double(i));
+        std::string str(i, 'a');
+        table->set_string(string_col_ndx, i, StringData(str));
+    }
+    table->set_link(link_col_ndx, 1, 0);
+
+    Query q = table->where().and_query(table->column<Int>(int_col_ndx) == table->column<String>(string_col_ndx).size());
+    CHECK_EQUAL(q.count(), 3);
+    std::string desc = q.get_description();
+
+    verify_query(test_context, table, "ints == 0", 1);
+    verify_query(test_context, table, "ints == ints", 3);
+    verify_query(test_context, table, "ints == strings.@count", 3);
+    verify_query(test_context, table, "ints == NULL", 0);
+    verify_query(test_context, table, "doubles == doubles", 3);
+    verify_query(test_context, table, "strings == strings", 3);
+    verify_query(test_context, table, "ints == link.@count", 2); // row 0 has 0 links, row 1 has 1 link
+}
 
 
 void verify_query_sub(test_util::unit_test::TestContext& test_context, TableRef t, std::string query_string, const util::Any* arg_list, size_t num_args, size_t num_results) {


### PR DESCRIPTION
This adds several stability fixes and support for comparisons between two properties (#2964).
To support two property expressions, a structural refactoring was required where each expression type is broken out to a separate file and controlled by a new `ExpressionContainer` class.