### PR TITLE
Performance scripts update

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -13,6 +13,8 @@ RUN apt-get update && apt-get install -y \
     libssl-dev \
     ninja-build \
     pandoc \
+    # cheetah is required to build core < v1.0.0 benchmarks
+    python-cheetah \
     python-matplotlib \
     python-pip \
     pkg-config \

--- a/test/bench/revs_to_benchmark.txt
+++ b/test/bench/revs_to_benchmark.txt
@@ -33,10 +33,11 @@ tags/v2.5.1
 tags/v2.6.0
 tags/v2.7.0
 tags/v2.8.0
-tags/v2.8.1
 tags/v2.8.6
 tags/v2.9.0
-tags/v2.9.2
 tags/v3.0.0
 tags/v3.1.0
 tags/v3.2.0
+tags/v4.0.0
+tags/v5.0.0
+tags/v5.1.0

--- a/test/benchmark-common-tasks/collect_stats.py
+++ b/test/benchmark-common-tasks/collect_stats.py
@@ -4,7 +4,6 @@ import getopt
 
 def get_zero_bytes_of_file(filename):
     count = 0
-    print "entering::"
     with open(filename, "rb") as f:
         byte = f.read(1)
         while byte:
@@ -23,27 +22,38 @@ def get_library_size(rootBuildDir):
     return get_file_size(os.path.join(rootBuildDir, "src/realm/librealm.a"))
 
 
-def get_loc(directory, recursive=True):
+def get_loc(directory, recursive=True, exclusions=()):
     loc = 0
     for root, dirs, files in os.walk(directory, followlinks=False):
         if (recursive is False and root != directory):
             continue
+        if (any(exclusion in root for exclusion in exclusions)):
+            continue
+        dir_total = 0
         for filename in files:
             if (filename.endswith('.hpp') or filename.endswith('.cpp')):
                 fullpath = os.path.join(root, filename)
                 with open(fullpath, 'r') as f:
                     # use strip to exclude empty lines
-                    loc += len(list(filter(lambda x: x.strip(), f)))
+                    cur_loc = len(list(filter(lambda x: x.strip(), f)))
+                    #print("found %s lines in file: %s" % (cur_loc, fullpath))
+                    loc += cur_loc
+                    dir_total += cur_loc
+        #print("Directory total: %s (%s)" % (dir_total, root))
     return loc
 
 
 def get_lines_of_code(rootSourceDir):
-    return get_loc(os.path.join(rootSourceDir, "src"))
+    exclude_dirs = ("src/external/pegtl", "src/win32/kalven-sha2")
+    src_loc = get_loc(os.path.join(rootSourceDir, "src"), recursive=True, exclusions=exclude_dirs)
+    print("Lines of source code: %s" % src_loc)
+    return src_loc
 
 
 def get_lines_of_test_code(rootSourceDir):
     loc = get_loc(os.path.join(rootSourceDir, "test"), recursive=False)
     loc += get_loc(os.path.join(rootSourceDir, "test/util"), recursive=False)
+    print("Lines of test code: %s" % loc)
     return loc
 
 


### PR DESCRIPTION
- Update the versions to benchmark with recent versions
- Exclude pegtl and win32/kalven-sha2 from source code count
- Include cheetah in Docker images to build old core versions