### PR TITLE
Use a build system agnostic gcc warning parser

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -183,7 +183,7 @@ def doBuildInDocker(String buildType, String sanitizeMode='') {
                            cd build-dir
                            cmake -D CMAKE_BUILD_TYPE=${buildType} ${sanitizeFlags} -G Ninja ..
                         """
-                        runAndCollectWarnings(script: "cd build-dir && ninja")
+                        runAndCollectWarnings(parser:'gcc_any', script: "cd build-dir && ninja")
                         sh """
                            cd build-dir/test
                            ./realm-tests
@@ -210,7 +210,7 @@ def doAndroidBuildInDocker(String abi, String buildType, boolean runTestsInEmula
             withEnv(environment) {
                 if(!runTestsInEmulator) {
                     buildEnv.inside {
-                        runAndCollectWarnings(script: "tools/cross_compile.sh -o android -a ${abi} -t ${buildType} -v ${gitDescribeVersion}")
+                        runAndCollectWarnings(parser:'gcc_any', script: "tools/cross_compile.sh -o android -a ${abi} -t ${buildType} -v ${gitDescribeVersion}")
                         dir(buildDir) {
                             archiveArtifacts('realm-*.tar.gz')
                         }
@@ -223,7 +223,7 @@ def doAndroidBuildInDocker(String abi, String buildType, boolean runTestsInEmula
                 } else {
                     docker.image('tracer0tong/android-emulator').withRun('-e ARCH=armeabi-v7a') { emulator ->
                         buildEnv.inside("--link ${emulator.id}:emulator") {
-                            runAndCollectWarnings(script: "tools/cross_compile.sh -o android -a ${abi} -t ${buildType} -v ${gitDescribeVersion}")
+                            runAndCollectWarnings(parser:'gcc_any', script: "tools/cross_compile.sh -o android -a ${abi} -t ${buildType} -v ${gitDescribeVersion}")
                             dir(buildDir) {
                                 archiveArtifacts('realm-*.tar.gz')
                             }


### PR DESCRIPTION
This is testing https://github.com/realm/ci/pull/258 to see if this warnings parser will catch our cmake gcc warnings. Currently, a core PR with warnings in gcc but not in clang will pass all green through CI even though those warnings appear in the full log.