### PR TITLE
Fix dev-dbg linux packages

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,7 +16,7 @@
 
 ### Internals
 
-* None.
+* The devel-dbg Linux packages now correctly include static libraries instead of shared ones.
 
 ----------------------------------------------
 

--- a/packaging/centos-6/build-image/inside/build-package
+++ b/packaging/centos-6/build-image/inside/build-package
@@ -142,5 +142,5 @@ fpm \
     -d "realm-devel = ${VERSION}-${ITERATION}.el6" \
     -d "openssl-devel" \
     -C "/prod" \
-    lib64/librealm-dbg.so=/usr/lib64/librealm-dbg.a \
-    lib64/librealm-parser-dbg.so=/usr/lib64/librealm-parser-dbg.a
+    lib64/librealm-dbg.a=/usr/lib64/librealm-dbg.a \
+    lib64/librealm-parser-dbg.a=/usr/lib64/librealm-parser-dbg.a

--- a/packaging/centos-7/build-image/inside/build-package
+++ b/packaging/centos-7/build-image/inside/build-package
@@ -143,5 +143,5 @@ fpm \
     -d "realm-devel = ${VERSION}-${ITERATION}.el7" \
     -d "openssl-devel" \
     -C "/prod" \
-    lib64/librealm-dbg.so=/usr/lib64/librealm-dbg.a \
-    lib64/librealm-parser-dbg.so=/usr/lib64/librealm-parser-dbg.a
+    lib64/librealm-dbg.a=/usr/lib64/librealm-dbg.a \
+    lib64/librealm-parser-dbg.a=/usr/lib64/librealm-parser-dbg.a

--- a/packaging/ubuntu-1604/build-image/inside/build-package
+++ b/packaging/ubuntu-1604/build-image/inside/build-package
@@ -132,5 +132,5 @@ fpm \
     -d "librealm-dev = ${VERSION}-${ITERATION}" \
     -d "libssl-dev" \
     -C "/prod" \
-    lib/librealm-dbg.so=/usr/lib/librealm-dbg.a \
-    lib/librealm-parser-dbg.so=/usr/lib/librealm-parser-dbg.a
+    lib/librealm-dbg.a=/usr/lib/librealm-dbg.a \
+    lib/librealm-parser-dbg.a=/usr/lib/librealm-parser-dbg.a


### PR DESCRIPTION
The static libraries in the dev-dbg linux packages were actually dynamic libraries.