### PR TITLE
Query serialisation part 3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,14 @@
 
 ### Enhancements
 
-* None.
+* Parser improvements:
+    - Support subquery count expressions, for example: "SUBQUERY(list, $x, $x.price > 5 && $x.colour == 'blue').@count > 1"
+        - Subqueries can be nested, but all properties must start with the closest variable (no parent scope properties)
+    - Support queries over unnamed backlinks, for example: "@links.class_Person.items.cost > 10"
+        - Backlinks can be used like lists in expressions including: min, max, sum, avg, count/size, and subqueries
+    - Keypath substitution is supported to allow querying over named backlinks and property aliases, see `KeyPathMapping`
+    - Parsing backlinks can be disabled at runtime by configuring `KeyPathMapping::set_allow_backlinks`
+    PR [#2989](https://github.com/realm/realm-core/pull/2989).
 
 -----------
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,8 @@
         - Backlinks can be used like lists in expressions including: min, max, sum, avg, count/size, and subqueries
     - Keypath substitution is supported to allow querying over named backlinks and property aliases, see `KeyPathMapping`
     - Parsing backlinks can be disabled at runtime by configuring `KeyPathMapping::set_allow_backlinks`
+    - Support for ANY/SOME/ALL/NONE on list properties (parser only). For example: `ALL items.price > 10`
+    - Support for operator 'IN' on list properties (parser only). For example: `'milk' IN ingredients.name`
     PR [#2989](https://github.com/realm/realm-core/pull/2989).
 
 -----------

--- a/src/realm/CMakeLists.txt
+++ b/src/realm/CMakeLists.txt
@@ -134,20 +134,24 @@ set(REALM_INSTALL_GENERAL_HEADERS
 
 set(REALM_PARSER_SOURCES
     parser/expression_container.cpp
+    parser/keypath_mapping.cpp
     parser/parser.cpp
     parser/parser_utils.cpp
     parser/property_expression.cpp
     parser/query_builder.cpp
+    parser/subquery_expression.cpp
     parser/value_expression.cpp
 ) # REALM_PARSER_SOURCES
 
 set(REALM_PARSER_HEADERS
     parser/collection_operator_expression.hpp
     parser/expression_container.hpp
+    parser/keypath_mapping.hpp
     parser/parser.hpp
     parser/parser_utils.hpp
     parser/property_expression.hpp
     parser/query_builder.hpp
+    parser/subquery_expression.hpp
     parser/value_expression.hpp
 ) # REALM_PARSER_HEADERS
 

--- a/src/realm/parser/collection_operator_expression.hpp
+++ b/src/realm/parser/collection_operator_expression.hpp
@@ -59,7 +59,7 @@ struct CollectionOperatorExpression
             } else {
                 list_property_name = pre_link_table->get_column_name(pe.get_dest_ndx());
             }
-            precondition(pe.get_dest_type() == type_LinkList || pe.dest_type_is_backlink(),
+            realm_precondition(pe.get_dest_type() == type_LinkList || pe.dest_type_is_backlink(),
                          util::format("The '%1' operation must be used on a list property, but '%2' is not a list",
                                       util::collection_operator_to_str(OpType), list_property_name));
 
@@ -74,13 +74,13 @@ struct CollectionOperatorExpression
 
             KeyPath suffix_key_path = key_path_from_string(suffix_path);
 
-            precondition(suffix_path.size() > 0 && suffix_key_path.size() > 0,
+            realm_precondition(suffix_path.size() > 0 && suffix_key_path.size() > 0,
                          util::format("A property from object '%1' must be provided to perform operation '%2'",
                                       printable_post_link_table_name, util::collection_operator_to_str(OpType)));
             size_t index = 0;
             KeyPathElement element = mapping.process_next_path(post_link_table, suffix_key_path, index);
 
-            precondition(suffix_key_path.size() == 1,
+            realm_precondition(suffix_key_path.size() == 1,
                          util::format("Unable to use '%1' because collection aggreate operations are only supported "
                                       "for direct properties at this time", suffix_path));
 
@@ -90,7 +90,7 @@ struct CollectionOperatorExpression
         else {  // !requires_suffix_path
             post_link_col_type = pe.get_dest_type();
 
-            precondition(suffix_path.empty(),
+            realm_precondition(suffix_path.empty(),
                          util::format("An extraneous property '%1' was found for operation '%2'",
                                       suffix_path, util::collection_operator_to_str(OpType)));
         }

--- a/src/realm/parser/collection_operator_expression.hpp
+++ b/src/realm/parser/collection_operator_expression.hpp
@@ -118,11 +118,7 @@ struct CollectionOperatorGetter {
 
 template <typename RetType>
 struct CollectionOperatorGetter<RetType, parser::Expression::KeyPathOp::Min,
-typename std::enable_if_t<
-std::is_same<RetType, Int>::value ||
-std::is_same<RetType, Float>::value ||
-std::is_same<RetType, Double>::value
-> >{
+typename std::enable_if_t<realm::is_any<RetType, Int, Float, Double>::value> >{
     static SubColumnAggregate<RetType, aggregate_operations::Minimum<RetType> > convert(const CollectionOperatorExpression<parser::Expression::KeyPathOp::Min>& expr)
     {
         if (expr.pe.dest_type_is_backlink()) {
@@ -135,11 +131,7 @@ std::is_same<RetType, Double>::value
 
 template <typename RetType>
 struct CollectionOperatorGetter<RetType, parser::Expression::KeyPathOp::Max,
-typename std::enable_if_t<
-std::is_same<RetType, Int>::value ||
-std::is_same<RetType, Float>::value ||
-std::is_same<RetType, Double>::value
-> >{
+typename std::enable_if_t<realm::is_any<RetType, Int, Float, Double>::value> >{
     static SubColumnAggregate<RetType, aggregate_operations::Maximum<RetType> > convert(const CollectionOperatorExpression<parser::Expression::KeyPathOp::Max>& expr)
     {
         if (expr.pe.dest_type_is_backlink()) {
@@ -152,11 +144,7 @@ std::is_same<RetType, Double>::value
 
 template <typename RetType>
 struct CollectionOperatorGetter<RetType, parser::Expression::KeyPathOp::Sum,
-typename std::enable_if_t<
-std::is_same<RetType, Int>::value ||
-std::is_same<RetType, Float>::value ||
-std::is_same<RetType, Double>::value
-> >{
+typename std::enable_if_t<realm::is_any<RetType, Int, Float, Double>::value> >{
     static SubColumnAggregate<RetType, aggregate_operations::Sum<RetType> > convert(const CollectionOperatorExpression<parser::Expression::KeyPathOp::Sum>& expr)
     {
         if (expr.pe.dest_type_is_backlink()) {
@@ -169,11 +157,7 @@ std::is_same<RetType, Double>::value
 
 template <typename RetType>
 struct CollectionOperatorGetter<RetType, parser::Expression::KeyPathOp::Avg,
-typename std::enable_if_t<
-std::is_same<RetType, Int>::value ||
-std::is_same<RetType, Float>::value ||
-std::is_same<RetType, Double>::value
-> >{
+typename std::enable_if_t<realm::is_any<RetType, Int, Float, Double>::value> >{
     static SubColumnAggregate<RetType, aggregate_operations::Average<RetType> > convert(const CollectionOperatorExpression<parser::Expression::KeyPathOp::Avg>& expr)
     {
         if (expr.pe.dest_type_is_backlink()) {
@@ -186,11 +170,7 @@ std::is_same<RetType, Double>::value
 
 template <typename RetType>
 struct CollectionOperatorGetter<RetType, parser::Expression::KeyPathOp::Count,
-    typename std::enable_if_t<
-    std::is_same<RetType, Int>::value ||
-    std::is_same<RetType, Float>::value ||
-    std::is_same<RetType, Double>::value
-    > >{
+    typename std::enable_if_t<realm::is_any<RetType, Int, Float, Double>::value> >{
     static LinkCount convert(const CollectionOperatorExpression<parser::Expression::KeyPathOp::Count>& expr)
     {
         if (expr.pe.dest_type_is_backlink()) {

--- a/src/realm/parser/expression_container.cpp
+++ b/src/realm/parser/expression_container.cpp
@@ -80,7 +80,8 @@ ExpressionContainer::ExpressionContainer(Query& query, const parser::Expression&
         // from all query keypaths. This only works because core does not support anything else (such as referencing
         // other properties of the parent table).
         // This means that every keypath must start with the variable, we require it to be there and remove it.
-        mapping.add_mapping(exp.get_subquery().get_table(), e.subquery_var, "");
+        bool did_add = mapping.add_mapping(exp.get_subquery().get_table(), e.subquery_var, "");
+        realm_precondition(did_add, util::format("Unable to create a subquery expression with variable '%1' since an identical variable already exists in this context", e.subquery_var));
         query_builder::apply_predicate(exp.get_subquery(), *e.subquery, args, mapping);
         mapping.remove_mapping(exp.get_subquery().get_table(), e.subquery_var);
         storage = std::move(exp);

--- a/src/realm/parser/expression_container.cpp
+++ b/src/realm/parser/expression_container.cpp
@@ -31,36 +31,36 @@ ExpressionContainer::ExpressionContainer(Query& query, const parser::Expression&
         switch (e.collection_op) {
             case parser::Expression::KeyPathOp::Min:
                 type = ExpressionInternal::exp_OpMin;
-                storage = CollectionOperatorExpression<parser::Expression::KeyPathOp::Min>(std::move(pe), e.op_suffix);
+                storage = CollectionOperatorExpression<parser::Expression::KeyPathOp::Min>(std::move(pe), e.op_suffix, mapping);
                 break;
             case parser::Expression::KeyPathOp::Max:
                 type = ExpressionInternal::exp_OpMax;
-                storage = CollectionOperatorExpression<parser::Expression::KeyPathOp::Max>(std::move(pe), e.op_suffix);
+                storage = CollectionOperatorExpression<parser::Expression::KeyPathOp::Max>(std::move(pe), e.op_suffix, mapping);
                 break;
             case parser::Expression::KeyPathOp::Sum:
                 type = ExpressionInternal::exp_OpSum;
-                storage = CollectionOperatorExpression<parser::Expression::KeyPathOp::Sum>(std::move(pe), e.op_suffix);
+                storage = CollectionOperatorExpression<parser::Expression::KeyPathOp::Sum>(std::move(pe), e.op_suffix, mapping);
                 break;
             case parser::Expression::KeyPathOp::Avg:
                 type = ExpressionInternal::exp_OpAvg;
-                storage = CollectionOperatorExpression<parser::Expression::KeyPathOp::Avg>(std::move(pe), e.op_suffix);
+                storage = CollectionOperatorExpression<parser::Expression::KeyPathOp::Avg>(std::move(pe), e.op_suffix, mapping);
                 break;
             case parser::Expression::KeyPathOp::Count:
                 REALM_FALLTHROUGH;
             case parser::Expression::KeyPathOp::SizeString:
                 REALM_FALLTHROUGH;
             case parser::Expression::KeyPathOp::SizeBinary:
-                if (pe.col_type == type_LinkList || pe.col_type == type_Link) {
+                if (pe.get_dest_type() == type_LinkList || pe.get_dest_type() == type_Link) {
                     type = ExpressionInternal::exp_OpCount;
-                    storage = CollectionOperatorExpression<parser::Expression::KeyPathOp::Count>(std::move(pe), e.op_suffix);
+                    storage = CollectionOperatorExpression<parser::Expression::KeyPathOp::Count>(std::move(pe), e.op_suffix, mapping);
                 }
-                else if (pe.col_type == type_String) {
+                else if (pe.get_dest_type() == type_String) {
                     type = ExpressionInternal::exp_OpSizeString;
-                    storage = CollectionOperatorExpression<parser::Expression::KeyPathOp::SizeString>(std::move(pe), e.op_suffix);
+                    storage = CollectionOperatorExpression<parser::Expression::KeyPathOp::SizeString>(std::move(pe), e.op_suffix, mapping);
                 }
-                else if (pe.col_type == type_Binary) {
+                else if (pe.get_dest_type() == type_Binary) {
                     type = ExpressionInternal::exp_OpSizeBinary;
-                    storage = CollectionOperatorExpression<parser::Expression::KeyPathOp::SizeBinary>(std::move(pe), e.op_suffix);
+                    storage = CollectionOperatorExpression<parser::Expression::KeyPathOp::SizeBinary>(std::move(pe), e.op_suffix, mapping);
                 }
                 else {
                     throw std::runtime_error("Invalid query: @size and @count can only operate on types list, binary, or string");
@@ -152,7 +152,7 @@ DataType ExpressionContainer::check_type_compatibility(DataType other_type)
             self_type = other_type; // we'll try to parse the value as other_type and fail there if not possible
             break;
         case ExpressionInternal::exp_Property:
-            self_type = get_property().col_type; // must match
+            self_type = get_property().get_dest_type(); // must match
             break;
         case ExpressionInternal::exp_OpMin:
             self_type = get_min().post_link_col_type;
@@ -204,9 +204,9 @@ bool is_count_type(ExpressionContainer::ExpressionInternal exp_type)
 DataType ExpressionContainer::get_comparison_type(ExpressionContainer& rhs) {
     // check for strongly typed expressions first
     if (type == ExpressionInternal::exp_Property) {
-        return rhs.check_type_compatibility(get_property().col_type);
+        return rhs.check_type_compatibility(get_property().get_dest_type());
     } else if (rhs.type == ExpressionInternal::exp_Property) {
-        return check_type_compatibility(rhs.get_property().col_type);
+        return check_type_compatibility(rhs.get_property().get_dest_type());
     } else if (type == ExpressionInternal::exp_OpMin) {
         return rhs.check_type_compatibility(get_min().post_link_col_type);
     } else if (type == ExpressionInternal::exp_OpMax) {

--- a/src/realm/parser/expression_container.cpp
+++ b/src/realm/parser/expression_container.cpp
@@ -24,10 +24,10 @@
 namespace realm {
 namespace parser {
 
-ExpressionContainer::ExpressionContainer(Query& query, const parser::Expression& e, query_builder::Arguments& args)
+ExpressionContainer::ExpressionContainer(Query& query, const parser::Expression& e, query_builder::Arguments& args, parser::KeyPathMapping& mapping)
 {
     if (e.type == parser::Expression::Type::KeyPath) {
-        PropertyExpression pe(query, e.s);
+        PropertyExpression pe(query, e.s, mapping);
         switch (e.collection_op) {
             case parser::Expression::KeyPathOp::Min:
                 type = ExpressionInternal::exp_OpMin;
@@ -71,6 +71,19 @@ ExpressionContainer::ExpressionContainer(Query& query, const parser::Expression&
                 storage = std::move(pe);
                 break;
         }
+    }
+    else if (e.type == parser::Expression::Type::SubQuery) {
+        REALM_ASSERT_DEBUG(e.subquery);
+        type = ExpressionInternal::exp_SubQuery;
+        SubqueryExpression exp(query, e.subquery_path, e.subquery_var, mapping);
+        // The least invasive way to do the variable substituion is to simply remove the variable prefix
+        // from all query keypaths. This only works because core does not support anything else (such as referencing
+        // other properties of the parent table).
+        // This means that every keypath must start with the variable, we require it to be there and remove it.
+        mapping.add_mapping(exp.get_subquery().get_table(), e.subquery_var, "");
+        query_builder::apply_predicate(exp.get_subquery(), *e.subquery, args, mapping);
+        mapping.remove_mapping(exp.get_subquery().get_table(), e.subquery_var);
+        storage = std::move(exp);
     }
     else {
         type = ExpressionInternal::exp_Value;
@@ -125,6 +138,12 @@ CollectionOperatorExpression<parser::Expression::KeyPathOp::SizeBinary>& Express
     return util::any_cast<CollectionOperatorExpression<parser::Expression::KeyPathOp::SizeBinary>&>(storage);
 }
 
+SubqueryExpression& ExpressionContainer::get_subexpression()
+{
+    REALM_ASSERT_DEBUG(type == ExpressionInternal::exp_SubQuery);
+    return util::any_cast<SubqueryExpression&>(storage);
+}
+
 DataType ExpressionContainer::check_type_compatibility(DataType other_type)
 {
     util::Optional<DataType> self_type;
@@ -147,6 +166,8 @@ DataType ExpressionContainer::check_type_compatibility(DataType other_type)
         case ExpressionInternal::exp_OpAvg:
             self_type = get_avg().post_link_col_type;
             break;
+        case ExpressionInternal::exp_SubQuery:
+            REALM_FALLTHROUGH;
         case ExpressionInternal::exp_OpCount:
             // linklist count can handle any numeric type
             if (other_type == type_Int || other_type == type_Double || other_type == type_Float) {
@@ -176,7 +197,8 @@ bool is_count_type(ExpressionContainer::ExpressionInternal exp_type)
 {
     return exp_type == ExpressionContainer::ExpressionInternal::exp_OpCount
         || exp_type == ExpressionContainer::ExpressionInternal::exp_OpSizeString
-        || exp_type == ExpressionContainer::ExpressionInternal::exp_OpSizeBinary;
+        || exp_type == ExpressionContainer::ExpressionInternal::exp_OpSizeBinary
+        || exp_type == ExpressionContainer::ExpressionInternal::exp_SubQuery;
 }
 
 DataType ExpressionContainer::get_comparison_type(ExpressionContainer& rhs) {

--- a/src/realm/parser/expression_container.hpp
+++ b/src/realm/parser/expression_container.hpp
@@ -25,6 +25,7 @@
 #include "parser.hpp"
 #include "property_expression.hpp"
 #include "query_builder.hpp"
+#include "subquery_expression.hpp"
 #include "value_expression.hpp"
 
 namespace realm {
@@ -33,7 +34,7 @@ namespace parser {
 class ExpressionContainer
 {
 public:
-    ExpressionContainer(Query& query, const parser::Expression& e, query_builder::Arguments& args);
+    ExpressionContainer(Query& query, const parser::Expression& e, query_builder::Arguments& args, parser::KeyPathMapping& mapping);
 
     bool is_null();
 
@@ -46,6 +47,7 @@ public:
     CollectionOperatorExpression<parser::Expression::KeyPathOp::Count>& get_count();
     CollectionOperatorExpression<parser::Expression::KeyPathOp::SizeString>& get_size_string();
     CollectionOperatorExpression<parser::Expression::KeyPathOp::SizeBinary>& get_size_binary();
+    SubqueryExpression& get_subexpression();
 
     DataType check_type_compatibility(DataType type);
     DataType get_comparison_type(ExpressionContainer& rhs);
@@ -60,7 +62,8 @@ public:
         exp_OpAvg,
         exp_OpCount,
         exp_OpSizeString,
-        exp_OpSizeBinary
+        exp_OpSizeBinary,
+        exp_SubQuery
     };
 
     ExpressionInternal type;

--- a/src/realm/parser/keypath_mapping.cpp
+++ b/src/realm/parser/keypath_mapping.cpp
@@ -17,8 +17,6 @@
 ////////////////////////////////////////////////////////////////////////////
 
 #include "keypath_mapping.hpp"
-#include "parser_utils.hpp"
-
 
 namespace realm {
 namespace parser {
@@ -27,30 +25,93 @@ KeyPathMapping::KeyPathMapping()
 {
 }
 
-void KeyPathMapping::add_mapping(TableRef table, std::string name, std::string alias)
+void KeyPathMapping::add_mapping(ConstTableRef table, std::string name, std::string alias)
 {
     m_mapping[{table, name}] = alias;
 }
 
-std::string KeyPathMapping::process_keypath(TableRef table, std::string path)
-{
-    KeyPath keypath = key_path_from_string(path);
-    if (keypath.size() == 0) {
-        return path;
-    }
-    auto it = m_mapping.find({table, keypath[0]});
-    if (it != m_mapping.end()) {
-        keypath[0] = it->second;
-    }
-    return key_path_to_string(keypath);
-}
-
-void KeyPathMapping::remove_mapping(TableRef table, std::string name)
+void KeyPathMapping::remove_mapping(ConstTableRef table, std::string name)
 {
     auto it = m_mapping.find({table, name});
     REALM_ASSERT_DEBUG(it != m_mapping.end());
     m_mapping.erase(it);
 }
+
+// This may be premature optimisation, but it'll be super fast and it doesn't
+// bother dragging in anything locale specific for case insensitive comparisons.
+bool is_backlinks_prefix(std::string s) {
+    return s.size() == 6 && s[0] == '@'
+        && (s[1] == 'l' || s[1] == 'L')
+        && (s[2] == 'i' || s[2] == 'I')
+        && (s[3] == 'n' || s[3] == 'N')
+        && (s[4] == 'k' || s[4] == 'K')
+        && (s[5] == 's' || s[5] == 'S');
+}
+
+KeyPathElement KeyPathMapping::process_next_path(ConstTableRef table, KeyPath& keypath, size_t& index)
+{
+    REALM_ASSERT_DEBUG(index < keypath.size());
+
+    // Perform substitution if the alias is found in the mapping
+    auto it = m_mapping.find({table, keypath[index]});
+    if (it != m_mapping.end()) {
+        // the alias needs to be mapped because it might be more than a single path
+        // for example named backlinks must alias to @links.class_Name.property
+        KeyPath mapped_path = key_path_from_string(it->second);
+        keypath.erase(keypath.begin() + index);
+        keypath.insert(keypath.begin() + index, mapped_path.begin(), mapped_path.end());
+    }
+
+    // Process backlinks which consumes 3 parts of the keypath
+    if (is_backlinks_prefix(keypath[index])) {
+        precondition(index + 2 < keypath.size(), "'@links' must be proceeded by type name and a property name");
+
+        Table::BacklinkOrigin info = table->find_backlink_origin(keypath[index + 1], keypath[index + 2]);
+        precondition(bool(info), util::format("No property '%1' found in type '%2' which links to type '%3'",
+                    keypath[index + 2], get_printable_table_name(keypath[index + 1]), get_printable_table_name(*table)))
+        index = index + 3;
+        KeyPathElement element;
+        element.table = info->first;
+        element.col_ndx = info->second;
+        element.col_type = type_LinkList; // backlinks should be operated on as a list
+        element.is_backlink = true;
+        return element;
+    }
+
+    // Process a single property
+    size_t col_ndx = table->get_column_index(keypath[index]);
+    precondition(col_ndx != realm::not_found,
+                 util::format("No property '%1' on object of type '%2'", keypath[index], get_printable_table_name(*table)));
+
+    DataType cur_col_type = table->get_column_type(col_ndx);
+
+    index++;
+    KeyPathElement element;
+    element.table = table;
+    element.col_ndx =  col_ndx;
+    element.col_type = cur_col_type;
+    element.is_backlink = false;
+    return element;
+}
+
+
+Table* KeyPathMapping::table_getter(TableRef table, const std::vector<KeyPathElement>& links)
+{
+    if (links.empty()) {
+        return table.get();
+    }
+    // mutates m_link_chain on table
+    for (size_t i = 0; i < links.size() - 1; i++) {
+        if (links[i].is_backlink) {
+            table->backlink(*links[i].table, links[i].col_ndx);
+        }
+        else {
+            table->link(links[i].col_ndx);
+        }
+    }
+    return table.get();
+}
+
 
 } // namespace parser
 } // namespace realm

--- a/src/realm/parser/keypath_mapping.cpp
+++ b/src/realm/parser/keypath_mapping.cpp
@@ -52,6 +52,11 @@ void KeyPathMapping::remove_mapping(ConstTableRef table, std::string name)
     m_mapping.erase(it);
 }
 
+bool KeyPathMapping::has_mapping(ConstTableRef table, std::string name)
+{
+    return m_mapping.find({table, name}) != m_mapping.end();
+}
+
 // This may be premature optimisation, but it'll be super fast and it doesn't
 // bother dragging in anything locale specific for case insensitive comparisons.
 bool is_backlinks_prefix(std::string& s) {

--- a/src/realm/parser/keypath_mapping.cpp
+++ b/src/realm/parser/keypath_mapping.cpp
@@ -65,10 +65,10 @@ KeyPathElement KeyPathMapping::process_next_path(ConstTableRef table, KeyPath& k
 
     // Process backlinks which consumes 3 parts of the keypath
     if (is_backlinks_prefix(keypath[index])) {
-        precondition(index + 2 < keypath.size(), "'@links' must be proceeded by type name and a property name");
+        realm_precondition(index + 2 < keypath.size(), "'@links' must be proceeded by type name and a property name");
 
         Table::BacklinkOrigin info = table->find_backlink_origin(keypath[index + 1], keypath[index + 2]);
-        precondition(bool(info), util::format("No property '%1' found in type '%2' which links to type '%3'",
+        realm_precondition(bool(info), util::format("No property '%1' found in type '%2' which links to type '%3'",
                   keypath[index + 2], get_printable_table_name(keypath[index + 1]), get_printable_table_name(*table)));
 
         if (!m_allow_backlinks) {
@@ -88,7 +88,7 @@ KeyPathElement KeyPathMapping::process_next_path(ConstTableRef table, KeyPath& k
 
     // Process a single property
     size_t col_ndx = table->get_column_index(keypath[index]);
-    precondition(col_ndx != realm::not_found,
+    realm_precondition(col_ndx != realm::not_found,
                  util::format("No property '%1' on object of type '%2'", keypath[index], get_printable_table_name(*table)));
 
     DataType cur_col_type = table->get_column_type(col_ndx);

--- a/src/realm/parser/keypath_mapping.hpp
+++ b/src/realm/parser/keypath_mapping.hpp
@@ -58,6 +58,7 @@ public:
     // returns true if added, false if duplicate key already exists
     bool add_mapping(ConstTableRef table, std::string name, std::string alias);
     void remove_mapping(ConstTableRef table, std::string name);
+    bool has_mapping(ConstTableRef table, std::string name);
     KeyPathElement process_next_path(ConstTableRef table, KeyPath& path, size_t& index);
     void set_allow_backlinks(bool allow);
     static Table* table_getter(TableRef table, const std::vector<KeyPathElement>& links);

--- a/src/realm/parser/keypath_mapping.hpp
+++ b/src/realm/parser/keypath_mapping.hpp
@@ -16,36 +16,32 @@
 //
 ////////////////////////////////////////////////////////////////////////////
 
-#ifndef REALM_PROPERTY_EXPRESSION_HPP
-#define REALM_PROPERTY_EXPRESSION_HPP
+#ifndef REALM_KEYPATH_MAPPING_HPP
+#define REALM_KEYPATH_MAPPING_HPP
 
-#include <realm/parser/keypath_mapping.hpp>
-#include <realm/query.hpp>
 #include <realm/table.hpp>
+
+#include <map>
+#include <string>
 
 namespace realm {
 namespace parser {
 
-struct PropertyExpression
+// This class holds state which allows aliasing variable names in key paths used in queries.
+// It is currently used to allow variable naming in subqueries such as 'SUBQUERY(list, $obj, $obj.intCol = 5).@count'
+// It could also be concievably used to allow querying named backlinks if bindings provide the mappings themselves.
+class KeyPathMapping
 {
-    std::vector<size_t> indexes;
-    size_t col_ndx;
-    DataType col_type;
-    Query &query;
-
-    PropertyExpression(Query &q, const std::string &key_path_string, parser::KeyPathMapping& mapping);
-
-    Table* table_getter() const;
-
-    template <typename RetType>
-    auto value_of_type_for_query() const
-    {
-        return this->table_getter()->template column<RetType>(this->col_ndx);
-    }
+public:
+    KeyPathMapping();
+    void add_mapping(TableRef table, std::string name, std::string alias);
+    void remove_mapping(TableRef table, std::string name);
+    std::string process_keypath(TableRef table, std::string path);
+protected:
+    std::map<std::pair<TableRef, std::string>, std::string> m_mapping;
 };
 
 } // namespace parser
 } // namespace realm
 
-#endif // REALM_PROPERTY_EXPRESSION_HPP
-
+#endif // REALM_KEYPATH_MAPPING_HPP

--- a/src/realm/parser/keypath_mapping.hpp
+++ b/src/realm/parser/keypath_mapping.hpp
@@ -21,11 +21,23 @@
 
 #include <realm/table.hpp>
 
+#include "parser_utils.hpp"
+
 #include <map>
 #include <string>
 
 namespace realm {
 namespace parser {
+
+struct KeyPathElement
+{
+    ConstTableRef table;
+    size_t col_ndx;
+    DataType col_type;
+    bool is_backlink;
+};
+
+Table* table_getter(const std::vector<KeyPathElement>& links);
 
 // This class holds state which allows aliasing variable names in key paths used in queries.
 // It is currently used to allow variable naming in subqueries such as 'SUBQUERY(list, $obj, $obj.intCol = 5).@count'
@@ -34,11 +46,12 @@ class KeyPathMapping
 {
 public:
     KeyPathMapping();
-    void add_mapping(TableRef table, std::string name, std::string alias);
-    void remove_mapping(TableRef table, std::string name);
-    std::string process_keypath(TableRef table, std::string path);
+    void add_mapping(ConstTableRef table, std::string name, std::string alias);
+    void remove_mapping(ConstTableRef table, std::string name);
+    KeyPathElement process_next_path(ConstTableRef table, KeyPath& path, size_t& index);
+    static Table* table_getter(TableRef table, const std::vector<KeyPathElement>& links);
 protected:
-    std::map<std::pair<TableRef, std::string>, std::string> m_mapping;
+    std::map<std::pair<ConstTableRef, std::string>, std::string> m_mapping;
 };
 
 } // namespace parser

--- a/src/realm/parser/keypath_mapping.hpp
+++ b/src/realm/parser/keypath_mapping.hpp
@@ -37,11 +37,15 @@ struct KeyPathElement
     bool is_backlink;
 };
 
-Table* table_getter(const std::vector<KeyPathElement>& links);
+class BacklinksRestrictedError : public std::runtime_error {
+public:
+    BacklinksRestrictedError(const std::string& msg) : std::runtime_error(msg) {}
+    /// runtime_error::what() returns the msg provided in the constructor.
+};
 
 // This class holds state which allows aliasing variable names in key paths used in queries.
-// It is currently used to allow variable naming in subqueries such as 'SUBQUERY(list, $obj, $obj.intCol = 5).@count'
-// It could also be concievably used to allow querying named backlinks if bindings provide the mappings themselves.
+// It is used to allow variable naming in subqueries such as 'SUBQUERY(list, $obj, $obj.intCol = 5).@count'
+// It can also be used to allow querying named backlinks if bindings provide the mappings themselves.
 class KeyPathMapping
 {
 public:
@@ -49,8 +53,10 @@ public:
     void add_mapping(ConstTableRef table, std::string name, std::string alias);
     void remove_mapping(ConstTableRef table, std::string name);
     KeyPathElement process_next_path(ConstTableRef table, KeyPath& path, size_t& index);
+    void set_allow_backlinks(bool allow);
     static Table* table_getter(TableRef table, const std::vector<KeyPathElement>& links);
 protected:
+    bool m_allow_backlinks;
     std::map<std::pair<ConstTableRef, std::string>, std::string> m_mapping;
 };
 

--- a/src/realm/parser/parser.cpp
+++ b/src/realm/parser/parser.cpp
@@ -86,12 +86,13 @@ struct avg : TAOCPP_PEGTL_ISTRING(".@avg.") {};
 // these operators are normal strings (no proceeding string characters)
 struct count : string_token_t(".@count") {};
 struct size : string_token_t(".@size") {};
+struct backlinks : string_token_t("@links") {};
 
 struct single_collection_operators : sor< count, size > {};
 struct key_collection_operators : sor< min, max, sum, avg > {};
 
 // key paths
-struct key_path : list< seq< sor< alpha, one< '_' >, one< '$' > >, star< sor< alnum, one< '_', '-', '$' > > > >, one< '.' > > {};
+struct key_path : list< sor< backlinks, seq< sor< alpha, one< '_', '$' > >, star< sor< alnum, one< '_', '-', '$' > > > > >, one< '.' > > {};
 
 struct key_path_prefix : disable< key_path > {};
 struct key_path_suffix : disable< key_path > {};
@@ -104,7 +105,6 @@ struct argument : seq< one< '$' >, argument_index > {};
 
 struct pred;
 // subquery eg: SUBQUERY(items, $x, $x.name CONTAINS 'a' && $x.price > 5).@count
-//struct sub_conditions : disable< pred > {};
 struct subq_prefix : seq< string_token_t("subquery"), star< blank >, one< '(' > > {};
 struct subq_suffix : one< ')' > {};
 struct sub_path : disable < key_path > {};

--- a/src/realm/parser/parser.cpp
+++ b/src/realm/parser/parser.cpp
@@ -123,7 +123,6 @@ struct agg_target : seq< key_path > {};
 struct agg_any : seq< sor< string_token_t("any"), string_token_t("some") >, plus<blank>, agg_target, pad< sor< string_oper, symbolic_oper >, blank >, expr > {};
 struct agg_all : seq< string_token_t("all"), plus<blank>, agg_target, pad< sor< string_oper, symbolic_oper >, blank >, expr > {};
 struct agg_none : seq< string_token_t("none"), plus<blank>, agg_target, pad< sor< string_oper, symbolic_oper >, blank >, expr > {};
-//struct agg_in : seq< pad< expr, blank>, string_token_t("in"), plus< blank >, agg_target > {};
 struct agg_shortcut_pred : sor< agg_any, agg_all, agg_none > {};
 
 // expressions and operators
@@ -161,7 +160,7 @@ struct symbolic_oper : sor< noteq, lteq, lt, gteq, gt, eq, in > {};
 struct comparison_pred : seq< expr, pad< sor< string_oper, symbolic_oper >, blank >, expr > {};
 
 // we need to alias the group tokens because these are also used in other expressions above and we have to match
-// the predicae group tokens without also matching () in other expressions.
+// the predicate group tokens without also matching () in other expressions.
 struct begin_pred_group : one< '(' > {};
 struct end_pred_group : one< ')' > {};
 

--- a/src/realm/parser/parser.hpp
+++ b/src/realm/parser/parser.hpp
@@ -25,13 +25,18 @@
 namespace realm {
 
 namespace parser {
+
+struct Predicate;
+
 struct Expression
 {
-    enum class Type { None, Number, String, KeyPath, Argument, True, False, Null, Timestamp, Base64 } type;
+    enum class Type { None, Number, String, KeyPath, Argument, True, False, Null, Timestamp, Base64, SubQuery } type;
     enum class KeyPathOp { None, Min, Max, Avg, Sum, Count, SizeString, SizeBinary } collection_op;
     std::string s;
     std::vector<std::string> time_inputs;
     std::string op_suffix;
+    std::string subquery_path, subquery_var;
+    std::shared_ptr<Predicate> subquery;
     Expression(Type t = Type::None, std::string input = "") : type(t), collection_op(KeyPathOp::None), s(input) {}
     Expression(std::vector<std::string>&& timestamp) : type(Type::Timestamp), collection_op(KeyPathOp::None), time_inputs(timestamp) {}
     Expression(std::string prefix, KeyPathOp op, std::string suffix) : type(Type::KeyPath), collection_op(op), s(prefix), op_suffix(suffix) {}

--- a/src/realm/parser/parser.hpp
+++ b/src/realm/parser/parser.hpp
@@ -66,7 +66,8 @@ struct Predicate
         BeginsWith,
         EndsWith,
         Contains,
-        Like
+        Like,
+        In
     };
 
     enum class OperatorOption

--- a/src/realm/parser/parser.hpp
+++ b/src/realm/parser/parser.hpp
@@ -19,8 +19,9 @@
 #ifndef REALM_PARSER_HPP
 #define REALM_PARSER_HPP
 
-#include <vector>
+#include <memory>
 #include <string>
+#include <vector>
 
 namespace realm {
 

--- a/src/realm/parser/parser.hpp
+++ b/src/realm/parser/parser.hpp
@@ -75,11 +75,20 @@ struct Predicate
         CaseInsensitive,
     };
 
+    enum class ComparisonType
+    {
+        Unspecified,
+        Any,
+        All,
+        None,
+    };
+
     struct Comparison
     {
         Operator op = Operator::None;
         OperatorOption option = OperatorOption::None;
         Expression expr[2] = {{Expression::Type::None, ""}, {Expression::Type::None, ""}};
+        ComparisonType compare_type = ComparisonType::Unspecified;
     };
 
     struct Compound

--- a/src/realm/parser/parser_utils.cpp
+++ b/src/realm/parser/parser_utils.cpp
@@ -126,6 +126,21 @@ const char* collection_operator_to_str(parser::Expression::KeyPathOp op)
     return "";
 }
 
+const char* comparison_type_to_str(parser::Predicate::ComparisonType type)
+{
+    switch (type) {
+        case parser::Predicate::ComparisonType::Unspecified:
+            return "";
+        case parser::Predicate::ComparisonType::All:
+            return "ALL";
+        case parser::Predicate::ComparisonType::None:
+            return "NONE";
+        case parser::Predicate::ComparisonType::Any:
+            return "ANY";
+    }
+    return "";
+}
+
 using KeyPath = std::vector<std::string>;
 
 KeyPath key_path_from_string(const std::string &s) {

--- a/src/realm/parser/parser_utils.cpp
+++ b/src/realm/parser/parser_utils.cpp
@@ -152,15 +152,20 @@ std::string key_path_to_string(const KeyPath& keypath)
     return path;
 }
 
-StringData get_printable_table_name(const Table& table)
+StringData get_printable_table_name(StringData name)
 {
-    StringData name = table.get_name();
     // the "class_" prefix is an implementation detail of the object store that shouldn't be exposed to users
     static const std::string prefix = "class_";
     if (name.size() > prefix.size() && strncmp(name.data(), prefix.data(), prefix.size()) == 0) {
         name = StringData(name.data() + prefix.size(), name.size() - prefix.size());
     }
     return name;
+}
+
+StringData get_printable_table_name(const Table& table)
+{
+    StringData name = table.get_name();
+    return get_printable_table_name(name);
 }
 
 } // namespace utils

--- a/src/realm/parser/parser_utils.cpp
+++ b/src/realm/parser/parser_utils.cpp
@@ -138,6 +138,20 @@ KeyPath key_path_from_string(const std::string &s) {
     return key_path;
 }
 
+std::string key_path_to_string(const KeyPath& keypath)
+{
+    std::string path = "";
+    for (size_t i = 0; i < keypath.size(); ++i) {
+        if (!keypath[i].empty()) {
+            path += keypath[i];
+            if (i < keypath.size() - 1) {
+                path += serializer::value_separator;
+            }
+        }
+    }
+    return path;
+}
+
 StringData get_printable_table_name(const Table& table)
 {
     StringData name = table.get_name();

--- a/src/realm/parser/parser_utils.hpp
+++ b/src/realm/parser/parser_utils.hpp
@@ -37,7 +37,7 @@ namespace util {
 // check a precondition and throw an exception if it is not met
 // this should be used iff the condition being false indicates a bug in the caller
 // of the function checking its preconditions
-#define precondition(condition, message) if (!REALM_LIKELY(condition)) { throw std::logic_error(message); }
+#define realm_precondition(condition, message) if (!REALM_LIKELY(condition)) { throw std::logic_error(message); }
 
 
 template <typename T>

--- a/src/realm/parser/parser_utils.hpp
+++ b/src/realm/parser/parser_utils.hpp
@@ -61,8 +61,8 @@ template <>
 const char* type_to_str<Link>();
 
 const char* data_type_to_str(DataType type);
-
 const char* collection_operator_to_str(parser::Expression::KeyPathOp op);
+const char* comparison_type_to_str(parser::Predicate::ComparisonType type);
 
 using KeyPath = std::vector<std::string>;
 KeyPath key_path_from_string(const std::string &s);

--- a/src/realm/parser/parser_utils.hpp
+++ b/src/realm/parser/parser_utils.hpp
@@ -67,6 +67,7 @@ const char* collection_operator_to_str(parser::Expression::KeyPathOp op);
 using KeyPath = std::vector<std::string>;
 KeyPath key_path_from_string(const std::string &s);
 std::string key_path_to_string(const KeyPath& keypath);
+StringData get_printable_table_name(StringData name);
 StringData get_printable_table_name(const Table& table);
 
 template<typename T>

--- a/src/realm/parser/parser_utils.hpp
+++ b/src/realm/parser/parser_utils.hpp
@@ -66,6 +66,7 @@ const char* collection_operator_to_str(parser::Expression::KeyPathOp op);
 
 using KeyPath = std::vector<std::string>;
 KeyPath key_path_from_string(const std::string &s);
+std::string key_path_to_string(const KeyPath& keypath);
 StringData get_printable_table_name(const Table& table);
 
 template<typename T>

--- a/src/realm/parser/property_expression.cpp
+++ b/src/realm/parser/property_expression.cpp
@@ -36,7 +36,7 @@ PropertyExpression::PropertyExpression(Query &q, const std::string &key_path_str
     while (index < key_path.size()) {
         KeyPathElement element = mapping.process_next_path(cur_table, key_path, index);
         if (index != key_path.size()) {
-            precondition(element.col_type == type_Link || element.col_type == type_LinkList,
+            realm_precondition(element.col_type == type_Link || element.col_type == type_LinkList,
                          util::format("Property '%1' is not a link in object of type '%2'",
                                       element.table->get_column_name(element.col_ndx),
                                       get_printable_table_name(*element.table)));

--- a/src/realm/parser/property_expression.hpp
+++ b/src/realm/parser/property_expression.hpp
@@ -28,10 +28,12 @@ namespace parser {
 
 struct PropertyExpression
 {
-    std::vector<size_t> indexes;
-    size_t col_ndx;
-    DataType col_type;
     Query &query;
+    std::vector<KeyPathElement> link_chain;
+    DataType get_dest_type() const;
+    size_t get_dest_ndx() const;
+    ConstTableRef get_dest_table() const;
+    bool dest_type_is_backlink() const;
 
     PropertyExpression(Query &q, const std::string &key_path_string, parser::KeyPathMapping& mapping);
 
@@ -40,9 +42,34 @@ struct PropertyExpression
     template <typename RetType>
     auto value_of_type_for_query() const
     {
-        return this->table_getter()->template column<RetType>(this->col_ndx);
+        return this->table_getter()->template column<RetType>(get_dest_ndx());
     }
 };
+
+inline DataType PropertyExpression::get_dest_type() const
+{
+    REALM_ASSERT_DEBUG(link_chain.size() > 0);
+    return link_chain.back().col_type;
+}
+
+inline bool PropertyExpression::dest_type_is_backlink() const
+{
+    REALM_ASSERT_DEBUG(link_chain.size() > 0);
+    return link_chain.back().is_backlink;
+}
+
+inline size_t PropertyExpression::get_dest_ndx() const
+{
+    REALM_ASSERT_DEBUG(link_chain.size() > 0);
+    return link_chain.back().col_ndx;
+}
+
+inline ConstTableRef PropertyExpression::get_dest_table() const
+{
+    REALM_ASSERT_DEBUG(link_chain.size() > 0);
+    return link_chain.back().table;
+}
+
 
 } // namespace parser
 } // namespace realm

--- a/src/realm/parser/query_builder.cpp
+++ b/src/realm/parser/query_builder.cpp
@@ -67,7 +67,7 @@ void do_add_null_comparison_to_query(Query &query, Predicate::Operator op, const
 template<>
 void do_add_null_comparison_to_query<Link>(Query &query, Predicate::Operator op, const PropertyExpression &expr)
 {
-    precondition(expr.link_chain.size() == 1, "KeyPath queries not supported for object comparisons.");
+    realm_precondition(expr.link_chain.size() == 1, "KeyPath queries not supported for object comparisons.");
     switch (op) {
         case Predicate::Operator::NotEqual:
             query.Not();
@@ -288,7 +288,7 @@ void add_link_constraint_to_query(realm::Query &query,
                                   const PropertyExpression &prop_expr,
                                   const ValueExpression &value_expr) {
     size_t row_index = value_expr.arguments->object_index_for_argument(stot<int>(value_expr.value->s));
-    precondition(prop_expr.link_chain.size() == 1, "KeyPath queries not supported for object comparisons.");
+    realm_precondition(prop_expr.link_chain.size() == 1, "KeyPath queries not supported for object comparisons.");
     switch (op) {
         case Predicate::Operator::NotEqual:
             query.Not();
@@ -617,7 +617,7 @@ void apply_predicate(Query &query, const Predicate &predicate, Arguments &argume
 
     // Test the constructed query in core
     std::string validateMessage = query.validate();
-    precondition(validateMessage.empty(), validateMessage.c_str());
+    realm_precondition(validateMessage.empty(), validateMessage.c_str());
 }
 
 struct EmptyArgContext

--- a/src/realm/parser/query_builder.cpp
+++ b/src/realm/parser/query_builder.cpp
@@ -389,7 +389,7 @@ enum class NullLocation {
 template <class T>
 void do_add_null_comparison_to_query(Query &query, Predicate::Comparison cmp, const T &expr, DataType type, NullLocation location)
 {
-    if (type == type_LinkList) { // when backlinks are supported, this should check those as well
+    if (type == type_LinkList) { // this handles backlinks as well since they are set to type LinkList
         throw std::logic_error("Comparing a list property to 'null' is not supported");
     }
     switch (type) {

--- a/src/realm/parser/query_builder.cpp
+++ b/src/realm/parser/query_builder.cpp
@@ -640,7 +640,7 @@ void apply_predicate(Query &query, const Predicate &predicate)
     apply_predicate(query, predicate, args);
 }
 
-void apply_ordering(DescriptorOrdering& ordering, TableRef target, const parser::DescriptorOrderingState& state, Arguments&)
+void apply_ordering(DescriptorOrdering& ordering, ConstTableRef target, const parser::DescriptorOrderingState& state, Arguments&)
 {
     for (const DescriptorOrderingState::SingleOrderingState& cur_ordering : state.orderings) {
         std::vector<std::vector<size_t>> property_indices;
@@ -648,7 +648,7 @@ void apply_ordering(DescriptorOrdering& ordering, TableRef target, const parser:
         for (const DescriptorOrderingState::PropertyState& cur_property : cur_ordering.properties) {
             KeyPath path = key_path_from_string(cur_property.key_path);
             std::vector<size_t> indices;
-            TableRef cur_table = target;
+            ConstTableRef cur_table = target;
             for (size_t ndx_in_path = 0; ndx_in_path < path.size(); ++ndx_in_path) {
                 size_t col_ndx = cur_table->get_column_index(path[ndx_in_path]);
                 if (col_ndx == realm::not_found) {
@@ -673,7 +673,7 @@ void apply_ordering(DescriptorOrdering& ordering, TableRef target, const parser:
     }
 }
 
-void apply_ordering(DescriptorOrdering& ordering, TableRef target, const parser::DescriptorOrderingState& state)
+void apply_ordering(DescriptorOrdering& ordering, ConstTableRef target, const parser::DescriptorOrderingState& state)
 {
     EmptyArgContext ctx;
     std::string empty_string;

--- a/src/realm/parser/query_builder.hpp
+++ b/src/realm/parser/query_builder.hpp
@@ -48,7 +48,6 @@ namespace query_builder {
 class Arguments;
 
 void apply_predicate(Query& query, const parser::Predicate& predicate, Arguments& arguments, parser::KeyPathMapping = parser::KeyPathMapping());
-void apply_predicate(Query& query, const parser::Predicate& predicate); // zero out of string args version
 
 void apply_ordering(DescriptorOrdering& ordering, ConstTableRef target, const parser::DescriptorOrderingState& state, Arguments& arguments);
 void apply_ordering(DescriptorOrdering& ordering, ConstTableRef target, const parser::DescriptorOrderingState& state);
@@ -82,7 +81,9 @@ public:
     virtual Timestamp timestamp_for_argument(size_t argument_index) = 0;
     virtual size_t object_index_for_argument(size_t argument_index) = 0;
     virtual bool is_argument_null(size_t argument_index) = 0;
-    util::StringBuffer buffer_space; // dynamic conversion space with lifetime tied to this
+    // dynamic conversion space with lifetime tied to this
+    // it is used for storing literal binary/string data
+    std::vector<util::StringBuffer> buffer_space;
 };
 
 template<typename ValueType, typename ContextType>
@@ -122,6 +123,25 @@ private:
         return m_ctx.template unbox<T>(at(index));
     }
 };
+
+class NoArgsError : public std::runtime_error {
+public:
+    NoArgsError() : std::runtime_error("Attempt to retreive an argument when no arguments were given") {}
+};
+
+class NoArguments : public Arguments {
+public:
+    bool bool_for_argument(size_t) { throw NoArgsError(); }
+    long long long_for_argument(size_t) { throw NoArgsError(); }
+    float float_for_argument(size_t) { throw NoArgsError(); }
+    double double_for_argument(size_t) { throw NoArgsError(); }
+    StringData string_for_argument(size_t) { throw NoArgsError(); }
+    BinaryData binary_for_argument(size_t) { throw NoArgsError(); }
+    Timestamp timestamp_for_argument(size_t) { throw NoArgsError(); }
+    size_t object_index_for_argument(size_t) { throw NoArgsError(); }
+    bool is_argument_null(size_t) { throw NoArgsError(); }
+};
+
 } // namespace query_builder
 } // namespace realm
 

--- a/src/realm/parser/query_builder.hpp
+++ b/src/realm/parser/query_builder.hpp
@@ -50,8 +50,8 @@ class Arguments;
 void apply_predicate(Query& query, const parser::Predicate& predicate, Arguments& arguments, parser::KeyPathMapping = parser::KeyPathMapping());
 void apply_predicate(Query& query, const parser::Predicate& predicate); // zero out of string args version
 
-void apply_ordering(DescriptorOrdering& ordering, TableRef target, const parser::DescriptorOrderingState& state, Arguments& arguments);
-void apply_ordering(DescriptorOrdering& ordering, TableRef target, const parser::DescriptorOrderingState& state);
+void apply_ordering(DescriptorOrdering& ordering, ConstTableRef target, const parser::DescriptorOrderingState& state, Arguments& arguments);
+void apply_ordering(DescriptorOrdering& ordering, ConstTableRef target, const parser::DescriptorOrderingState& state);
 
 
 struct AnyContext

--- a/src/realm/parser/query_builder.hpp
+++ b/src/realm/parser/query_builder.hpp
@@ -24,6 +24,7 @@
 #include <vector>
 
 #include <realm/binary_data.hpp>
+#include <realm/parser/keypath_mapping.hpp>
 #include <realm/null.hpp>
 #include <realm/string_data.hpp>
 #include <realm/timestamp.hpp>
@@ -46,7 +47,7 @@ namespace parser {
 namespace query_builder {
 class Arguments;
 
-void apply_predicate(Query& query, const parser::Predicate& predicate, Arguments& arguments);
+void apply_predicate(Query& query, const parser::Predicate& predicate, Arguments& arguments, parser::KeyPathMapping = parser::KeyPathMapping());
 void apply_predicate(Query& query, const parser::Predicate& predicate); // zero out of string args version
 
 void apply_ordering(DescriptorOrdering& ordering, TableRef target, const parser::DescriptorOrderingState& state, Arguments& arguments);

--- a/src/realm/parser/subquery_expression.cpp
+++ b/src/realm/parser/subquery_expression.cpp
@@ -36,7 +36,7 @@ SubqueryExpression::SubqueryExpression(Query &q, const std::string &key_path_str
     while (index < key_path.size()) {
         KeyPathElement element = mapping.process_next_path(cur_table, key_path, index);
         if (index != key_path.size()) {
-            precondition(element.col_type == type_Link || element.col_type == type_LinkList,
+            realm_precondition(element.col_type == type_Link || element.col_type == type_LinkList,
                          util::format("Property '%1' is not a link in object of type '%2'",
                                       element.table->get_column_name(element.col_ndx),
                                       get_printable_table_name(*element.table)));
@@ -53,7 +53,7 @@ SubqueryExpression::SubqueryExpression(Query &q, const std::string &key_path_str
             } else {
                 dest_type = data_type_to_str(element.col_type);
             }
-            precondition(element.col_type == type_LinkList,
+            realm_precondition(element.col_type == type_LinkList,
                          util::format("A subquery must operate on a list property, but '%1' is type '%2'",
                                       element.table->get_column_name(element.col_ndx),
                                       dest_type));

--- a/src/realm/parser/subquery_expression.hpp
+++ b/src/realm/parser/subquery_expression.hpp
@@ -1,0 +1,86 @@
+////////////////////////////////////////////////////////////////////////////
+//
+// Copyright 2015 Realm Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+////////////////////////////////////////////////////////////////////////////
+
+#ifndef REALM_SUBQUERY_EXPRESSION_HPP
+#define REALM_SUBQUERY_EXPRESSION_HPP
+
+#include <realm/parser/keypath_mapping.hpp>
+#include <realm/query.hpp>
+#include <realm/query_expression.hpp>
+#include <realm/table.hpp>
+
+#include "parser_utils.hpp"
+
+namespace realm {
+namespace parser {
+
+template <typename RetType, class Enable = void>
+struct SubqueryGetter;
+
+struct SubqueryExpression
+{
+    std::vector<size_t> indexes;
+    std::string var_name;
+    size_t col_ndx;
+    DataType col_type;
+    Query &query;
+    Query subquery;
+
+    SubqueryExpression(Query &q, const std::string &key_path_string, const std::string &variable_name, parser::KeyPathMapping &mapping);
+    Query& get_subquery();
+
+    Table* table_getter() const;
+
+    template <typename T>
+    auto value_of_type_for_query() const
+    {
+        return SubqueryGetter<T>::convert(*this);
+    }
+};
+
+
+// Certain operations are disabled for some types (eg. a sum of timestamps is invalid).
+// The operations that are supported have a specialisation with std::enable_if for that type below
+// any type/operation combination that is not specialised will get the runtime error from the following
+// default implementation. The return type is just a dummy to make things compile.
+template <typename RetType, class Enable>
+struct SubqueryGetter {
+    static Columns<RetType> convert(const SubqueryExpression&) {
+        throw std::runtime_error(util::format("Predicate error: comparison of type '%1' with result of a subquery count is not supported.",
+                                              type_to_str<RetType>()));
+    }
+};
+
+template <typename RetType>
+struct SubqueryGetter<RetType,
+typename std::enable_if_t<
+std::is_same<RetType, Int>::value ||
+std::is_same<RetType, Float>::value ||
+std::is_same<RetType, Double>::value
+> >{
+    static SubQueryCount convert(const SubqueryExpression& expr)
+    {
+        return expr.table_getter()->template column<LinkList>(expr.col_ndx, expr.subquery).count();
+    }
+};
+
+} // namespace parser
+} // namespace realm
+
+#endif // REALM_SUBQUERY_EXPRESSION_HPP
+

--- a/src/realm/parser/subquery_expression.hpp
+++ b/src/realm/parser/subquery_expression.hpp
@@ -94,11 +94,7 @@ struct SubqueryGetter {
 
 template <typename RetType>
 struct SubqueryGetter<RetType,
-typename std::enable_if_t<
-std::is_same<RetType, Int>::value ||
-std::is_same<RetType, Float>::value ||
-std::is_same<RetType, Double>::value
-> >{
+typename std::enable_if_t<realm::is_any<RetType, Int, Float, Double>::value> >{
     static SubQueryCount convert(const SubqueryExpression& expr)
     {
         if (expr.dest_type_is_backlink()) {

--- a/src/realm/parser/value_expression.cpp
+++ b/src/realm/parser/value_expression.cpp
@@ -100,7 +100,7 @@ StringData from_base64(const std::string& input, util::StringBuffer& decode_buff
 
 
 ValueExpression::ValueExpression(Query& query, query_builder::Arguments* args, const parser::Expression* v)
-: value(*v)
+: value(v)
 , arguments(args) {
     table_getter = [&] {
         auto& tbl = query.get_table();
@@ -110,11 +110,11 @@ ValueExpression::ValueExpression(Query& query, query_builder::Arguments* args, c
 
 bool ValueExpression::is_null()
 {
-    if (value.type == parser::Expression::Type::Null) {
+    if (value->type == parser::Expression::Type::Null) {
         return true;
     }
-    else if (value.type == parser::Expression::Type::Argument) {
-        return arguments->is_argument_null(stot<int>(value.s));
+    else if (value->type == parser::Expression::Type::Argument) {
+        return arguments->is_argument_null(stot<int>(value->s));
     }
     return false;
 }
@@ -122,11 +122,11 @@ bool ValueExpression::is_null()
 template <>
 Timestamp ValueExpression::value_of_type_for_query<Timestamp>()
 {
-    if (value.type == parser::Expression::Type::Argument) {
-        return arguments->timestamp_for_argument(stot<int>(value.s));
-    } else if (value.type == parser::Expression::Type::Timestamp) {
-        return from_timestamp_values(value.time_inputs);
-    } else if (value.type == parser::Expression::Type::Null) {
+    if (value->type == parser::Expression::Type::Argument) {
+        return arguments->timestamp_for_argument(stot<int>(value->s));
+    } else if (value->type == parser::Expression::Type::Timestamp) {
+        return from_timestamp_values(value->time_inputs);
+    } else if (value->type == parser::Expression::Type::Null) {
         return Timestamp(realm::null());
     }
     throw std::logic_error("Attempting to compare Timestamp property to a non-Timestamp value");
@@ -135,14 +135,14 @@ Timestamp ValueExpression::value_of_type_for_query<Timestamp>()
 template <>
 bool ValueExpression::value_of_type_for_query<bool>()
 {
-    if (value.type == parser::Expression::Type::Argument) {
-        return arguments->bool_for_argument(stot<int>(value.s));
+    if (value->type == parser::Expression::Type::Argument) {
+        return arguments->bool_for_argument(stot<int>(value->s));
     }
-    if (value.type != parser::Expression::Type::True && value.type != parser::Expression::Type::False) {
-        if (value.type == parser::Expression::Type::Number) {
+    if (value->type != parser::Expression::Type::True && value->type != parser::Expression::Type::False) {
+        if (value->type == parser::Expression::Type::Number) {
             // As a special exception we can handle 0 and 1.
             // Our bool values are actually stored as integers {0, 1}
-            int64_t number_value = stot<int64_t>(value.s);
+            int64_t number_value = stot<int64_t>(value->s);
             if (number_value == 0) {
                 return false;
             }
@@ -152,48 +152,51 @@ bool ValueExpression::value_of_type_for_query<bool>()
         }
         throw std::logic_error("Attempting to compare bool property to a non-bool value");
     }
-    return value.type == parser::Expression::Type::True;
+    return value->type == parser::Expression::Type::True;
 }
 
 template <>
 Double ValueExpression::value_of_type_for_query<Double>()
 {
-    if (value.type == parser::Expression::Type::Argument) {
-        return arguments->double_for_argument(stot<int>(value.s));
+    if (value->type == parser::Expression::Type::Argument) {
+        return arguments->double_for_argument(stot<int>(value->s));
     }
-    return stot<double>(value.s);
+    return stot<double>(value->s);
 }
 
 template <>
 Float ValueExpression::value_of_type_for_query<Float>()
 {
-    if (value.type == parser::Expression::Type::Argument) {
-        return arguments->float_for_argument(stot<int>(value.s));
+    if (value->type == parser::Expression::Type::Argument) {
+        return arguments->float_for_argument(stot<int>(value->s));
     }
-    return stot<float>(value.s);
+    return stot<float>(value->s);
 }
 
 template <>
 Int ValueExpression::value_of_type_for_query<Int>()
 {
-    if (value.type == parser::Expression::Type::Argument) {
-        return arguments->long_for_argument(stot<int>(value.s));
+    if (value->type == parser::Expression::Type::Argument) {
+        return arguments->long_for_argument(stot<int>(value->s));
     }
-    return stot<long long>(value.s);
+    return stot<long long>(value->s);
 }
 
 template <>
 StringData ValueExpression::value_of_type_for_query<StringData>()
 {
-    if (value.type == parser::Expression::Type::Argument) {
-        return arguments->string_for_argument(stot<int>(value.s));
+    if (value->type == parser::Expression::Type::Argument) {
+        return arguments->string_for_argument(stot<int>(value->s));
     }
-    else if (value.type == parser::Expression::Type::String) {
-        return value.s;
+    else if (value->type == parser::Expression::Type::String) {
+        arguments->buffer_space.push_back({});
+        arguments->buffer_space.back().append(value->s);
+        return StringData(arguments->buffer_space.back().data(), arguments->buffer_space.back().size());
     }
-    else if (value.type == parser::Expression::Type::Base64) {
+    else if (value->type == parser::Expression::Type::Base64) {
         // the return value points to data in the lifetime of args
-        return from_base64(value.s, arguments->buffer_space);
+        arguments->buffer_space.push_back({});
+        return from_base64(value->s, arguments->buffer_space.back());
     }
     throw std::logic_error("Attempting to compare String property to a non-String value");
 }
@@ -201,14 +204,18 @@ StringData ValueExpression::value_of_type_for_query<StringData>()
 template <>
 BinaryData ValueExpression::value_of_type_for_query<BinaryData>()
 {
-    if (value.type == parser::Expression::Type::Argument) {
-        return arguments->binary_for_argument(stot<int>(value.s));
+    if (value->type == parser::Expression::Type::Argument) {
+        return arguments->binary_for_argument(stot<int>(value->s));
     }
-    else if (value.type == parser::Expression::Type::String) {
-        return BinaryData(value.s);
+    else if (value->type == parser::Expression::Type::String) {
+        arguments->buffer_space.push_back({});
+        arguments->buffer_space.back().append(value->s);
+        return BinaryData(arguments->buffer_space.back().data(), arguments->buffer_space.back().size());
     }
-    else if (value.type == parser::Expression::Type::Base64) {
-        StringData converted = from_base64(value.s, arguments->buffer_space);
+    else if (value->type == parser::Expression::Type::Base64) {
+        // the return value points to data in the lifetime of args
+        arguments->buffer_space.push_back({});
+        StringData converted = from_base64(value->s, arguments->buffer_space[arguments->buffer_space.size() - 1]);
         // returning a pointer to data in the lifetime of args
         return BinaryData(converted.data(), converted.size());
     }

--- a/src/realm/parser/value_expression.hpp
+++ b/src/realm/parser/value_expression.hpp
@@ -27,7 +27,7 @@ namespace parser {
 
 struct ValueExpression
 {
-    const parser::Expression value;
+    const parser::Expression* value;
     query_builder::Arguments* arguments;
     std::function<Table *()> table_getter;
 

--- a/src/realm/parser/value_expression.hpp
+++ b/src/realm/parser/value_expression.hpp
@@ -27,7 +27,7 @@ namespace parser {
 
 struct ValueExpression
 {
-    const parser::Expression* value;
+    const parser::Expression value;
     query_builder::Arguments* arguments;
     std::function<Table *()> table_getter;
 

--- a/src/realm/query.cpp
+++ b/src/realm/query.cpp
@@ -1599,17 +1599,23 @@ std::string Query::validate()
     return root_node()->validate(); // errors detected by QueryEngine
 }
 
-std::string Query::get_description() const
+std::string Query::get_description(util::serializer::SerialisationState& state) const
 {
     if (root_node()) {
         if (m_view) {
             throw SerialisationError("Serialisation of a query constrianed by a view is not currently supported");
         }
-        return root_node()->describe_expression();
+        return root_node()->describe_expression(state);
     }
     // An empty query returns all results and one way to indicate this
     // is to serialise TRUEPREDICATE which is functionally equivilent
     return "TRUEPREDICATE";
+}
+
+std::string Query::get_description() const
+{
+    util::serializer::SerialisationState state;
+    return get_description(state);
 }
 
 void Query::init() const

--- a/src/realm/query.hpp
+++ b/src/realm/query.hpp
@@ -42,6 +42,7 @@
 #include <realm/link_view_fwd.hpp>
 #include <realm/descriptor_fwd.hpp>
 #include <realm/row.hpp>
+#include <realm/util/serializer.hpp>
 
 namespace realm {
 
@@ -343,6 +344,7 @@ public:
     std::string validate();
 
     std::string get_description() const;
+    std::string get_description(util::serializer::SerialisationState& state) const;
 
 private:
     Query(Table& table, TableViewBase* tv = nullptr);

--- a/src/realm/query_engine.cpp
+++ b/src/realm/query_engine.cpp
@@ -544,10 +544,10 @@ void ExpressionNode::table_changed()
     m_expression->set_base_table(m_table.get());
 }
 
-std::string ExpressionNode::describe() const
+std::string ExpressionNode::describe(util::serializer::SerialisationState& state) const
 {
     if (m_expression) {
-        return m_expression->description();
+        return m_expression->description(state);
     }
     else {
         return "empty expression";

--- a/src/realm/query_engine.hpp
+++ b/src/realm/query_engine.hpp
@@ -268,20 +268,7 @@ public:
 
     virtual void verify_column() const = 0;
 
-    virtual std::string describe_column() const
-    {
-        return describe_column(m_condition_column_idx);
-    }
-
-    virtual std::string describe_column(size_t col_ndx) const
-    {
-        if (m_table && col_ndx != npos) {
-            return std::string(m_table->get_column_name(col_ndx));
-        }
-        return "";
-    }
-
-    virtual std::string describe() const
+    virtual std::string describe(util::serializer::SerialisationState&) const
     {
         return "";
     }
@@ -291,12 +278,12 @@ public:
         return "matches";
     }
 
-    virtual std::string describe_expression() const
+    virtual std::string describe_expression(util::serializer::SerialisationState& state) const
     {
         std::string s;
-        s = describe();
+        s = describe(state);
         if (m_child) {
-            s = s + " and " + m_child->describe_expression();
+            s = s + " and " + m_child->describe_expression(state);
         }
         return s;
     }
@@ -413,13 +400,7 @@ public:
             return m_condition->validate();
     }
 
-    virtual std::string describe_column() const override
-    {
-        REALM_ASSERT(m_column != nullptr);
-        return ParentNode::describe_column(m_column->get_column_index());
-    }
-
-    std::string describe() const override
+    std::string describe(util::serializer::SerialisationState&) const override
     {
         throw SerialisationError("Serialising a query which contains a subtable expression is currently unsupported.");
     }
@@ -684,12 +665,6 @@ protected:
         do_verify_column(m_condition_column);
     }
 
-    virtual std::string describe_column() const override
-    {
-        REALM_ASSERT(m_condition_column != nullptr);
-        return ParentNode::describe_column(m_condition_column->get_column_index());
-    }
-
     void init() override
     {
         ColumnNodeBase::init();
@@ -819,9 +794,10 @@ public:
         return not_found;
     }
 
-    virtual std::string describe() const override
+    virtual std::string describe(util::serializer::SerialisationState& state) const override
     {
-        return this->describe_column() + " " + describe_condition() + " " + util::serializer::print_value(IntegerNodeBase<ColType>::m_value);
+        return state.describe_column(ParentNode::m_table, IntegerNodeBase<ColType>::m_condition_column->get_column_index())
+            + " " + describe_condition() + " " + util::serializer::print_value(IntegerNodeBase<ColType>::m_value);
     }
 
     virtual std::string describe_condition() const override
@@ -957,15 +933,11 @@ public:
             return find(false);
     }
 
-    virtual std::string describe_column() const override
+    virtual std::string describe(util::serializer::SerialisationState& state) const override
     {
         REALM_ASSERT(m_condition_column.m_column != nullptr);
-        return ParentNode::describe_column(m_condition_column.m_column->get_column_index());
-    }
-
-    virtual std::string describe() const override
-    {
-        return describe_column() + " " + describe_condition() + " " + util::serializer::print_value(FloatDoubleNode::m_value);
+        return state.describe_column(ParentNode::m_table, m_condition_column.m_column->get_column_index())
+            + " " + describe_condition() + " " + util::serializer::print_value(FloatDoubleNode::m_value);
     }
     virtual std::string describe_condition() const override
     {
@@ -1096,15 +1068,11 @@ public:
         return not_found;
     }
 
-    virtual std::string describe_column() const override
+    virtual std::string describe(util::serializer::SerialisationState& state) const override
     {
         REALM_ASSERT(m_condition_column != nullptr);
-        return ParentNode::describe_column(m_condition_column->get_column_index());
-    }
-
-    virtual std::string describe() const override
-    {
-        return describe_column() + " " + TConditionFunction::description() + " "
+        return state.describe_column(ParentNode::m_table, m_condition_column->get_column_index())
+            + " " + TConditionFunction::description() + " "
             + util::serializer::print_value(BinaryNode::m_value.get());
     }
 
@@ -1168,15 +1136,11 @@ public:
         return ret;
     }
 
-    virtual std::string describe_column() const override
+    virtual std::string describe(util::serializer::SerialisationState& state) const override
     {
         REALM_ASSERT(m_condition_column != nullptr);
-        return ParentNode::describe_column(m_condition_column->get_column_index());
-    }
-
-    virtual std::string describe() const override
-    {
-        return describe_column() + " " + TConditionFunction::description() + " " + util::serializer::print_value(TimestampNode::m_value);
+        return state.describe_column(ParentNode::m_table, m_condition_column->get_column_index())
+            + " " + TConditionFunction::description() + " " + util::serializer::print_value(TimestampNode::m_value);
     }
 
     std::unique_ptr<ParentNode> clone(QueryNodeHandoverPatches* patches) const override
@@ -1248,19 +1212,15 @@ public:
             m_condition_column_idx = m_condition_column->get_column_index();
     }
 
-    virtual std::string describe_column() const override
+    virtual std::string describe(util::serializer::SerialisationState& state) const override
     {
         REALM_ASSERT(m_condition_column != nullptr);
-        return ParentNode::describe_column(m_condition_column->get_column_index());
-    }
-
-    virtual std::string describe() const override
-    {
         StringData sd;
         if (bool(StringNodeBase::m_value)) {
             sd = StringData(StringNodeBase::m_value.value());
         }
-        return this->describe_column() + " " + describe_condition() + " " + util::serializer::print_value(sd);
+        return state.describe_column(ParentNode::m_table, m_condition_column->get_column_index())
+            + " " + describe_condition() + " " + util::serializer::print_value(sd);
     }
 
 protected:
@@ -1681,7 +1641,7 @@ public:
             condition->verify_column();
         }
     }
-    std::string describe() const override
+    std::string describe(util::serializer::SerialisationState& state) const override
     {
         if (m_conditions.size() >= 2) {
 
@@ -1689,7 +1649,7 @@ public:
         std::string s;
         for (size_t i = 0; i < m_conditions.size(); ++i) {
             if (m_conditions[i]) {
-                s += m_conditions[i]->describe_expression();
+                s += m_conditions[i]->describe_expression(state);
                 if (i != m_conditions.size() - 1) {
                     s += " or ";
                 }
@@ -1861,10 +1821,10 @@ public:
         return "";
     }
 
-    virtual std::string describe() const override
+    virtual std::string describe(util::serializer::SerialisationState& state) const override
     {
         if (m_condition) {
-            return "!(" + m_condition->describe_expression() + ")";
+            return "!(" + m_condition->describe_expression(state) + ")";
         }
         return "!()";
     }
@@ -1939,17 +1899,12 @@ public:
         do_verify_column(m_getter2.m_column, m_condition_column_idx2);
     }
 
-    virtual std::string describe_column() const override
-    {
-        REALM_ASSERT(m_condition_column != nullptr);
-        return ParentNode::describe_column(m_condition_column->get_column_index());
-    }
-
-    virtual std::string describe() const override
+    virtual std::string describe(util::serializer::SerialisationState& state) const override
     {
         REALM_ASSERT(m_getter1.m_column != nullptr && m_getter2.m_column != nullptr);
-        return ParentNode::describe_column(m_getter1.m_column->get_column_index()) + " " + describe_condition() + " "
-             + ParentNode::describe_column(m_getter2.m_column->get_column_index());
+        return state.describe_column(ParentNode::m_table, m_getter1.m_column->get_column_index())
+            + " " + describe_condition() + " "
+            + state.describe_column(ParentNode::m_table,m_getter2.m_column->get_column_index());
     }
 
     virtual std::string describe_condition() const override
@@ -2054,7 +2009,7 @@ public:
     void table_changed() override;
     void verify_column() const override;
 
-    virtual std::string describe() const override;
+    virtual std::string describe(util::serializer::SerialisationState& state) const override;
 
     std::unique_ptr<ParentNode> clone(QueryNodeHandoverPatches* patches) const override;
     void apply_handover_patch(QueryNodeHandoverPatches& patches, Group& group) override;
@@ -2093,13 +2048,7 @@ public:
         do_verify_column(m_column, m_origin_column);
     }
 
-    virtual std::string describe_column() const override
-    {
-        REALM_ASSERT(m_column != nullptr);
-        return ParentNode::describe_column(m_column->get_column_index());
-    }
-
-    virtual std::string describe() const override
+    virtual std::string describe(util::serializer::SerialisationState&) const override
     {
         throw SerialisationError("Serialising a query which links to an object is currently unsupported.");
         // We can do something like the following when core gets stable keys

--- a/src/realm/query_expression.hpp
+++ b/src/realm/query_expression.hpp
@@ -398,7 +398,7 @@ public:
     virtual void set_base_table(const Table* table) = 0;
     virtual void verify_column() const = 0;
     virtual const Table* get_base_table() const = 0;
-    virtual std::string description() const = 0;
+    virtual std::string description(util::serializer::SerialisationState& state) const = 0;
 
     virtual std::unique_ptr<Expression> clone(QueryNodeHandoverPatches*) const = 0;
     virtual void apply_handover_patch(QueryNodeHandoverPatches&, Group&)
@@ -435,7 +435,7 @@ public:
     }
 
     virtual void verify_column() const = 0;
-    virtual std::string description() const = 0;
+    virtual std::string description(util::serializer::SerialisationState& state) const = 0;
 
     // Recursively fetch tables of columns in expression tree. Used when user first builds a stand-alone expression
     // and
@@ -1145,7 +1145,7 @@ struct TrueExpression : Expression {
     void verify_column() const override
     {
     }
-    std::string description() const override
+    std::string description(util::serializer::SerialisationState&) const override
     {
         return "TRUEPREDICATE";
     }
@@ -1167,7 +1167,7 @@ struct FalseExpression : Expression {
     void verify_column() const override
     {
     }
-    std::string description() const override
+    std::string description(util::serializer::SerialisationState&) const override
     {
         return "FALSEPREDICATE";
     }
@@ -1226,7 +1226,7 @@ public:
     {
     }
 
-    virtual std::string description() const override
+    virtual std::string description(util::serializer::SerialisationState&) const override
     {
         if (ValueBase::m_from_link_list) {
             return util::serializer::print_value(util::to_string(ValueBase::m_values)
@@ -1909,6 +1909,11 @@ public:
         return m_tables.back();
     }
 
+    bool links_exist() const
+    {
+        return !m_link_columns.empty();
+    }
+
     std::vector<const ColumnBase*> m_link_columns;
 
 private:
@@ -2072,17 +2077,9 @@ public:
         return m_link_map.m_link_columns.size() > 0;
     }
 
-    virtual std::string description() const override
+    virtual std::string description(util::serializer::SerialisationState& state) const override
     {
-        std::string desc;
-        if (links_exist()) {
-            desc = m_link_map.description() + util::serializer::value_separator;
-        }
-        const Table* target_table = m_link_map.target_table();
-        if (target_table && target_table->is_attached()) {
-            desc += std::string(target_table->get_column_name(m_column_ndx));
-        }
-        return desc;
+        return state.describe_columns(m_link_map, m_column_ndx);
     }
 
     std::unique_ptr<Subexpr> clone(QueryNodeHandoverPatches* patches = nullptr) const override
@@ -2294,9 +2291,9 @@ public:
         return not_found;
     }
 
-    virtual std::string description() const override
+    virtual std::string description(util::serializer::SerialisationState& state) const override
     {
-        return m_link_map.description() + (has_links ? " != NULL" : " == NULL");
+        return state.describe_columns(m_link_map, realm::npos) + (has_links ? " != NULL" : " == NULL");
     }
 
     std::unique_ptr<Expression> clone(QueryNodeHandoverPatches* patches) const override
@@ -2352,9 +2349,9 @@ public:
         destination.import(Value<Int>(false, 1, count));
     }
 
-    virtual std::string description() const override
+    virtual std::string description(util::serializer::SerialisationState& state) const override
     {
-        return m_link_map.description() + util::serializer::value_separator + "@count";
+        return state.describe_columns(m_link_map, realm::npos) + util::serializer::value_separator + "@count";
     }
 
 private:
@@ -2411,10 +2408,10 @@ public:
         }
     }
 
-    std::string description() const override
+    std::string description(util::serializer::SerialisationState& state) const override
     {
         if (m_expr) {
-            return m_expr->description() + util::serializer::value_separator + "@size";
+            return m_expr->description(state) + util::serializer::value_separator + "@size";
         }
         return "@size";
     }
@@ -2475,7 +2472,7 @@ public:
         }
     }
 
-    virtual std::string description() const override
+    virtual std::string description(util::serializer::SerialisationState&) const override
     {
         throw SerialisationError("Serialising a query which links to an object is currently unsupported.");
         // TODO: we can do something like the following when core gets stable keys:
@@ -2570,9 +2567,9 @@ public:
         m_link_map.verify_columns();
     }
 
-    std::string description() const override
+    std::string description(util::serializer::SerialisationState& state) const override
     {
-        return m_link_map.description();
+        return state.describe_columns(m_link_map, realm::npos);
     }
 
     std::unique_ptr<Subexpr> clone(QueryNodeHandoverPatches* patches) const override
@@ -2634,9 +2631,9 @@ public:
         m_link_map.target_table()->verify_column(m_column_ndx, m_column);
     }
 
-    std::string description() const override
+    std::string description(util::serializer::SerialisationState&) const override
     {
-        return m_link_map.description();
+        throw SerialisationError("Serialisation of query expressions involving subtables is not yet supported.");
     }
 
     std::unique_ptr<Subexpr> clone(QueryNodeHandoverPatches* patches) const override
@@ -2757,19 +2754,9 @@ public:
         destination.import(v);
     }
 
-    virtual std::string description() const override
+    virtual std::string description(util::serializer::SerialisationState&) const override
     {
-        const Table* table = get_base_table();
-        if (table && table->is_attached()) {
-            if (m_subtable_column.m_column) {
-                return std::string(table->get_column_name(m_subtable_column.m_column_ndx));
-
-            }
-            else {
-                return std::string(table->get_column_name(m_column_ndx));
-            }
-        }
-        return "";
+        throw SerialisationError("Serialisation of subtable expressions is not yet supported.");
     }
 
     ListColumnAggregate<T, aggregate_operations::Minimum<T>> min() const
@@ -2889,13 +2876,9 @@ public:
         destination.import(v);
     }
 
-    virtual std::string description() const override
+    virtual std::string description(util::serializer::SerialisationState&) const override
     {
-        const Table* table = get_base_table();
-        if (table && table->is_attached()) {
-            return std::string(table->get_column_name(m_column_ndx)) + util::serializer::value_separator + Operation::description() + "()";
-        }
-        return "";
+        throw SerialisationError("Serialisation of queries involving subtable expressions is not yet supported.");
     }
 
 private:
@@ -3135,18 +3118,9 @@ public:
         }
     }
 
-    virtual std::string description() const override
+    virtual std::string description(util::serializer::SerialisationState& state) const override
     {
-        std::string desc = "";
-        if (links_exist()) {
-            desc = m_link_map.description() + util::serializer::value_separator;
-        }
-        const Table* target_table = m_link_map.target_table();
-        if (target_table && target_table->is_attached() && m_column_ndx != npos) {
-            desc += std::string(target_table->get_column_name(m_column_ndx));
-            return desc;
-        }
-        return "";
+        return state.describe_columns(m_link_map, m_column_ndx);
     }
 
     // Load values from Column into destination
@@ -3237,7 +3211,7 @@ public:
         REALM_ASSERT(false);
     }
 
-    virtual std::string description() const override
+    virtual std::string description(util::serializer::SerialisationState&) const override
     {
         return ""; // by itself there are no conditions, see SubColumnAggregate
     }
@@ -3338,9 +3312,9 @@ public:
         }
     }
 
-    virtual std::string description() const override
+    virtual std::string description(util::serializer::SerialisationState& state) const override
     {
-        return m_link_map.description() + util::serializer::value_separator + Operation::description() + util::serializer::value_separator + m_column.description();
+        return state.describe_columns(m_link_map, realm::npos) + util::serializer::value_separator + Operation::description() + util::serializer::value_separator + m_column.description(state);
     }
 
 private:
@@ -3387,11 +3361,15 @@ public:
         destination.import(Value<Int>(false, 1, size_t(count)));
     }
 
-    virtual std::string description() const override
+    virtual std::string description(util::serializer::SerialisationState& state) const override
     {
-        throw SerialisationError("Serialising a subquery expression is currently unsupported.");
-        //return m_link_map.description() + util::serializer::value_separator + "SUBQUERY(" + m_query.get_description() + ")"
-        //    + util::serializer::value_separator + "@count";
+        REALM_ASSERT(m_link_map.base_table() != nullptr);
+        std::string var_name = state.get_variable_name(m_link_map.base_table()->get_table_ref());
+        state.subquery_prefix_list.push_back(var_name);
+        std::string desc = "SUBQUERY(" + m_link_map.description() + ", " + var_name + ", " + m_query.get_description(state) + ")"
+            + util::serializer::value_separator + "@count";
+        state.subquery_prefix_list.pop_back();
+        return desc;
     }
 
     std::unique_ptr<Subexpr> clone(QueryNodeHandoverPatches* patches) const override
@@ -3609,10 +3587,10 @@ public:
         destination.import(result);
     }
 
-    virtual std::string description() const override
+    virtual std::string description(util::serializer::SerialisationState& state) const override
     {
         if (m_left) {
-            return m_left->description();
+            return m_left->description(state);
         }
         return "";
     }
@@ -3700,15 +3678,15 @@ public:
         destination.import(result);
     }
 
-    virtual std::string description() const override
+    virtual std::string description(util::serializer::SerialisationState& state) const override
     {
         std::string s;
         if (m_left) {
-            s += m_left->description();
+            s += m_left->description(state);
         }
         s += (" " + oper::description() + " ");
         if (m_right) {
-            s += m_right->description();
+            s += m_right->description(state);
         }
         return s;
     }
@@ -3790,7 +3768,7 @@ public:
         return not_found; // no match
     }
 
-    virtual std::string description() const override
+    virtual std::string description(util::serializer::SerialisationState& state) const override
     {
         if (std::is_same<TCond, BeginsWith>::value
             || std::is_same<TCond, BeginsWithIns>::value
@@ -3802,11 +3780,11 @@ public:
             || std::is_same<TCond, LikeIns>::value) {
             // these string conditions have the arguments reversed but the order is important
             // operations ==, and != can be reversed because the produce the same results both ways
-            return util::serializer::print_value(m_right->description() + " " + TCond::description()
-                                                 + " " + m_left->description());
+            return util::serializer::print_value(m_right->description(state) + " " + TCond::description()
+                                                 + " " + m_left->description(state));
         }
-        return util::serializer::print_value(m_left->description() + " " + TCond::description()
-                                             + " " + m_right->description());
+        return util::serializer::print_value(m_left->description(state) + " " + TCond::description()
+                                             + " " + m_right->description(state));
     }
 
     std::unique_ptr<Expression> clone(QueryNodeHandoverPatches* patches) const override

--- a/src/realm/query_expression.hpp
+++ b/src/realm/query_expression.hpp
@@ -3314,7 +3314,8 @@ public:
 
     virtual std::string description(util::serializer::SerialisationState& state) const override
     {
-        return state.describe_columns(m_link_map, realm::npos) + util::serializer::value_separator + Operation::description() + util::serializer::value_separator + m_column.description(state);
+        util::serializer::SerialisationState empty_state;
+        return state.describe_columns(m_link_map, realm::npos) + util::serializer::value_separator + Operation::description() + util::serializer::value_separator + m_column.description(empty_state);
     }
 
 private:
@@ -3364,9 +3365,10 @@ public:
     virtual std::string description(util::serializer::SerialisationState& state) const override
     {
         REALM_ASSERT(m_link_map.base_table() != nullptr);
+        std::string target = state.describe_columns(m_link_map, realm::npos);
         std::string var_name = state.get_variable_name(m_link_map.base_table()->get_table_ref());
         state.subquery_prefix_list.push_back(var_name);
-        std::string desc = "SUBQUERY(" + m_link_map.description() + ", " + var_name + ", " + m_query.get_description(state) + ")"
+        std::string desc = "SUBQUERY(" + target + ", " + var_name + ", " + m_query.get_description(state) + ")"
             + util::serializer::value_separator + "@count";
         state.subquery_prefix_list.pop_back();
         return desc;

--- a/src/realm/query_expression.hpp
+++ b/src/realm/query_expression.hpp
@@ -1855,17 +1855,12 @@ public:
         }
     }
 
-    virtual std::string description() const
+    virtual std::string description(util::serializer::SerialisationState& state) const
     {
         std::string s;
         for (size_t i = 0; i < m_link_column_indexes.size(); ++i) {
             if (i < m_tables.size() && m_tables[i]) {
-                if (m_link_types[i] == col_type_BackLink) {
-                    throw SerialisationError("Serialising a query which contains backlinks is currently unsupported.");
-                    //s += "backlink";
-                } else if (m_link_column_indexes[i] < m_tables[i]->get_column_count()) {
-                    s += std::string(m_tables[i]->get_column_name(m_link_column_indexes[i]));
-                }
+                s += state.get_column_name(m_tables[i]->get_table_ref(), m_link_column_indexes[i]);
                 if (i != m_link_column_indexes.size() - 1) {
                     s += util::serializer::value_separator;
                 }

--- a/src/realm/table.cpp
+++ b/src/realm/table.cpp
@@ -2032,6 +2032,24 @@ size_t Table::get_size_from_ref(ref_type spec_ref, ref_type columns_ref, Allocat
     return size;
 }
 
+Table::BacklinkOrigin Table::find_backlink_origin(StringData origin_table_name, StringData origin_col_name) const noexcept
+{
+    size_t backlink_columns_begin = m_spec->first_backlink_column_index();
+    size_t backlink_columns_end = backlink_columns_begin + m_spec->backlink_column_count();
+
+    for (size_t i = backlink_columns_begin; i != backlink_columns_end; ++i) {
+        const BacklinkColumn& backlink_col = get_column_backlink(i);
+        ConstTableRef origin_table = backlink_col.get_origin_table().get_table_ref();
+        const LinkColumnBase& link_col = backlink_col.get_origin_column();
+        size_t link_col_ndx = link_col.get_column_index();
+        if (origin_table->get_name() == origin_table_name
+            && origin_table->get_column_name(link_col_ndx) == origin_col_name) {
+            return BacklinkOrigin{{origin_table, link_col_ndx}};
+        }
+    }
+    return BacklinkOrigin{};
+}
+
 
 ref_type Table::create_empty_table(Allocator& alloc)
 {

--- a/src/realm/table.hpp
+++ b/src/realm/table.hpp
@@ -173,6 +173,8 @@ public:
     DataType get_column_type(size_t column_ndx) const noexcept;
     StringData get_column_name(size_t column_ndx) const noexcept;
     size_t get_column_index(StringData name) const noexcept;
+    typedef util::Optional<std::pair<ConstTableRef, size_t>> BacklinkOrigin;
+    BacklinkOrigin find_backlink_origin(StringData origin_table_name, StringData origin_col_name) const noexcept;
     //@}
 
     //@{

--- a/src/realm/table.hpp
+++ b/src/realm/table.hpp
@@ -1568,6 +1568,7 @@ private:
     friend class ParentNode;
     template <class>
     friend class SequentialGetter;
+    friend struct util::serializer::SerialisationState;
     friend class RowBase;
     friend class LinksToNode;
     friend class LinkMap;

--- a/src/realm/util/serializer.cpp
+++ b/src/realm/util/serializer.cpp
@@ -112,7 +112,7 @@ std::string SerialisationState::get_variable_name(ConstTableRef table) {
     char add_char = start_char;
 
     auto next_guess = [&]() {
-        add_char = (((add_char + 1) - 'a') % 26) + 'a';
+        add_char = (((add_char + 1) - 'a') % ('z' - 'a' + 1)) + 'a';
         if (add_char == start_char) {
             guess_prefix += add_char;
         }
@@ -122,7 +122,7 @@ std::string SerialisationState::get_variable_name(ConstTableRef table) {
         std::string guess = guess_prefix + add_char;
         bool found_duplicate = false;
         for (size_t i = 0; i < subquery_prefix_list.size(); ++i) {
-            if (guess.compare(subquery_prefix_list[i]) == 0) {
+            if (guess == subquery_prefix_list[i]) {
                 found_duplicate = true;
                 break;
             }

--- a/src/realm/util/serializer.cpp
+++ b/src/realm/util/serializer.cpp
@@ -112,7 +112,7 @@ std::string SerialisationState::get_variable_name(ConstTableRef table) {
     char add_char = start_char;
 
     auto next_guess = [&]() {
-        add_char = ((++add_char - 'a') % 26) + 'a';
+        add_char = (((add_char + 1) - 'a') % 26) + 'a';
         if (add_char == start_char) {
             guess_prefix += add_char;
         }

--- a/src/realm/util/serializer.hpp
+++ b/src/realm/util/serializer.hpp
@@ -19,10 +19,12 @@
 #ifndef REALM_UTIL_SERIALIZER_HPP
 #define REALM_UTIL_SERIALIZER_HPP
 
+#include <realm/table_ref.hpp>
 #include <realm/util/optional.hpp>
 
 #include <string>
 #include <sstream>
+#include <vector>
 
 namespace realm {
 
@@ -30,6 +32,7 @@ class BinaryData;
 struct null;
 class StringData;
 class Timestamp;
+class LinkMap;
 
 namespace util {
 namespace serializer {
@@ -69,6 +72,14 @@ std::string print_value(Optional<T> value)
         return "NULL";
     }
 }
+
+struct SerialisationState
+{
+    std::string describe_column(ConstTableRef table, size_t col_ndx);
+    std::string describe_columns(const LinkMap& link_map, size_t target_col_ndx);
+    std::string get_variable_name(ConstTableRef table);
+    std::vector<std::string> subquery_prefix_list;
+};
 
 } // namespace serializer
 } // namespace util

--- a/src/realm/util/serializer.hpp
+++ b/src/realm/util/serializer.hpp
@@ -77,6 +77,7 @@ struct SerialisationState
 {
     std::string describe_column(ConstTableRef table, size_t col_ndx);
     std::string describe_columns(const LinkMap& link_map, size_t target_col_ndx);
+    std::string get_column_name(ConstTableRef table, size_t col_ndx);
     std::string get_variable_name(ConstTableRef table);
     std::vector<std::string> subquery_prefix_list;
 };

--- a/test/test_metrics.cpp
+++ b/test/test_metrics.cpp
@@ -492,7 +492,7 @@ TEST(Metrics_LinkQueries)
     q0.find_all();
     q1.find_all();
     q2.find_all();
-    CHECK_THROW(q3.find_all(), SerialisationError);
+    q3.find_all();;
 
     std::shared_ptr<Metrics> metrics = sg.get_metrics();
     CHECK(metrics);
@@ -502,8 +502,7 @@ TEST(Metrics_LinkQueries)
     // FIXME: q3 adds 6 queries: the find_all() + 1 sub query per row in person
     // that's how subqueries across links are executed currently so it is accurate
     // but not sure if this is acceptable for how we track queries
-    // CHECK_EQUAL(queries->size(), 10);
-    CHECK_EQUAL(queries->size(), 3);
+    CHECK_EQUAL(queries->size(), 10);
 
     std::string null_links_description = queries->at(0).get_description();
     CHECK_EQUAL(find_count(null_links_description, "NULL"), 1);
@@ -519,13 +518,12 @@ TEST(Metrics_LinkQueries)
     CHECK_EQUAL(find_count(count_link_description, pet_link_col_name), 1);
     CHECK_EQUAL(find_count(count_link_description, "=="), 1);
 
-//    CHECK_THROW(queries->at(3), SerialisationError);
-//    std::string link_subquery_description = queries->at(3).get_description();
-//    CHECK_EQUAL(find_count(link_subquery_description, "@count"), 1);
-//    CHECK_EQUAL(find_count(link_subquery_description, pet_link_col_name), 1);
-//    CHECK_EQUAL(find_count(link_subquery_description, "=="), 1);
-//    CHECK_EQUAL(find_count(link_subquery_description, column_names[0]), 1);
-//    CHECK_EQUAL(find_count(link_subquery_description, ">"), 1);
+    std::string link_subquery_description = queries->at(3).get_description();
+    CHECK_EQUAL(find_count(link_subquery_description, "@count"), 1);
+    CHECK_EQUAL(find_count(link_subquery_description, pet_link_col_name), 1);
+    CHECK_EQUAL(find_count(link_subquery_description, "=="), 1);
+    CHECK_EQUAL(find_count(link_subquery_description, column_names[0]), 1);
+    CHECK_EQUAL(find_count(link_subquery_description, ">"), 1);
 }
 
 
@@ -569,14 +567,14 @@ TEST(Metrics_LinkListQueries)
     q2.find_all();
     CHECK_THROW(q3.find_all(), SerialisationError);
     q4.find_all();
-    CHECK_THROW(q5.find_all(), SerialisationError);
+    q5.find_all();
 
     std::shared_ptr<Metrics> metrics = sg.get_metrics();
     CHECK(metrics);
     std::unique_ptr<Metrics::QueryInfoList> queries = metrics->take_queries();
     CHECK(queries);
 
-    CHECK_EQUAL(queries->size(), 4);
+    CHECK_EQUAL(queries->size(), 16);
 
     std::string null_links_description = queries->at(0).get_description();
     CHECK_EQUAL(find_count(null_links_description, "NULL"), 1);
@@ -601,11 +599,11 @@ TEST(Metrics_LinkListQueries)
     // the query system can choose to flip the argument order and operators so that >= might be <=
     CHECK_EQUAL(find_count(sum_link_description, "<=") + find_count(sum_link_description, ">="), 1);
 
-//    std::string link_subquery_description = queries->at(4).get_description();
-//    CHECK_EQUAL(find_count(link_subquery_description, "@count"), 1);
-//    CHECK_EQUAL(find_count(link_subquery_description, column_names[ll_col_ndx]), 1);
-//    CHECK_EQUAL(find_count(link_subquery_description, "=="), 2);
-//    CHECK_EQUAL(find_count(link_subquery_description, column_names[str_col_ndx]), 1);
+    std::string link_subquery_description = queries->at(4).get_description();
+    CHECK_EQUAL(find_count(link_subquery_description, "@count"), 1);
+    CHECK_EQUAL(find_count(link_subquery_description, column_names[ll_col_ndx]), 1);
+    CHECK_EQUAL(find_count(link_subquery_description, "=="), 2);
+    CHECK_EQUAL(find_count(link_subquery_description, column_names[str_col_ndx]), 1);
 }
 
 
@@ -673,13 +671,13 @@ TEST(Metrics_SubQueries)
     Query q2 = table->column<SubTable>(1).list<String>().begins_with("Str");
     Query q3 = table->column<SubTable>(1).list<String>() == "Str_0";
 
-    q0.find_all();
-    q1.find_all();
-    q2.find_all();
-    q3.find_all();
+    CHECK_THROW(q0.find_all(), SerialisationError);
+    CHECK_THROW(q1.find_all(), SerialisationError);
+    CHECK_THROW(q2.find_all(), SerialisationError);
+    CHECK_THROW(q3.find_all(), SerialisationError);
 
     sg.commit();
-
+/*
     std::shared_ptr<Metrics> metrics = sg.get_metrics();
     CHECK(metrics);
     std::unique_ptr<Metrics::QueryInfoList> queries = metrics->take_queries();
@@ -702,6 +700,7 @@ TEST(Metrics_SubQueries)
     std::string str_equal_description = queries->at(3).get_description();
     CHECK_EQUAL(find_count(str_equal_description, "=="), 1);
     CHECK_EQUAL(find_count(str_equal_description, str_col_name), 1);
+*/
 }
 
 

--- a/test/test_parser.cpp
+++ b/test/test_parser.cpp
@@ -1766,6 +1766,13 @@ TEST(Parser_Backlinks)
     p = realm::parser::parse("purchasers.@max.money >= 20").predicate;
     realm::query_builder::apply_predicate(q, p, args, mapping);
     CHECK_EQUAL(q.count(), 3);
+
+    // disable parsing backlink queries
+    mapping.set_allow_backlinks(false);
+    q = items->where();
+    p = realm::parser::parse("purchasers.@max.money >= 20").predicate;
+    CHECK_THROW_ANY_GET_MESSAGE(realm::query_builder::apply_predicate(q, p, args, mapping), message);
+    CHECK_EQUAL(message, "Querying over backlinks is disabled but backlinks were found in the inverse relationship of property 'items' on type 'Person'");
 }
 
 

--- a/test/test_parser.cpp
+++ b/test/test_parser.cpp
@@ -317,17 +317,18 @@ TEST(Parser_grammar_analysis)
 
 Query verify_query(test_util::unit_test::TestContext& test_context, TableRef t, std::string query_string, size_t num_results) {
     Query q = t->where();
+    realm::query_builder::NoArguments args;
 
-    realm::parser::Predicate p = realm::parser::parse(query_string).predicate;
-    realm::query_builder::apply_predicate(q, p);
+    parser::ParserResult res = realm::parser::parse(query_string);
+    realm::query_builder::apply_predicate(q, res.predicate, args);
 
     CHECK_EQUAL(q.count(), num_results);
     std::string description = q.get_description();
     //std::cerr << "original: " << query_string << "\tdescribed: " << description << "\n";
     Query q2 = t->where();
 
-    realm::parser::Predicate p2 = realm::parser::parse(description).predicate;
-    realm::query_builder::apply_predicate(q2, p2);
+    parser::ParserResult res2 = realm::parser::parse(description);
+    realm::query_builder::apply_predicate(q2, res2.predicate, args);
 
     CHECK_EQUAL(q2.count(), num_results);
     return q2;
@@ -350,7 +351,8 @@ TEST(Parser_empty_input)
     CHECK(!empty_description.empty());
     CHECK_EQUAL(0, empty_description.compare("TRUEPREDICATE"));
     realm::parser::Predicate p = realm::parser::parse(empty_description).predicate;
-    realm::query_builder::apply_predicate(q, p);
+    query_builder::NoArguments args;
+    realm::query_builder::apply_predicate(q, p, args);
     CHECK_EQUAL(q.count(), 5);
 
     verify_query(test_context, t, "TRUEPREDICATE", 5);
@@ -1030,7 +1032,7 @@ void verify_query_sub(test_util::unit_test::TestContext& test_context, TableRef 
     Query q2 = t->where();
 
     realm::parser::Predicate p2 = realm::parser::parse(description).predicate;
-    realm::query_builder::apply_predicate(q2, p2);
+    realm::query_builder::apply_predicate(q2, p2, args);
 
     CHECK_EQUAL(q2.count(), num_results);
 }
@@ -1310,14 +1312,15 @@ TEST(Parser_string_binary_encoding)
         std::string binary_description = qbin.get_description();
         //std::cerr << "original: " << buff << "\tdescribed: " << string_description << "\n";
 
+        query_builder::NoArguments args;
         Query qstr2 = t->where();
         realm::parser::Predicate pstr2 = realm::parser::parse(string_description).predicate;
-        realm::query_builder::apply_predicate(qstr2, pstr2);
+        realm::query_builder::apply_predicate(qstr2, pstr2, args);
         CHECK_EQUAL(qstr2.count(), num_results);
 
         Query qbin2 = t->where();
         realm::parser::Predicate pbin2 = realm::parser::parse(binary_description).predicate;
-        realm::query_builder::apply_predicate(qbin2, pbin2);
+        realm::query_builder::apply_predicate(qbin2, pbin2, args);
         CHECK_EQUAL(qbin2.count(), num_results);
     }
 }
@@ -1510,9 +1513,10 @@ TEST(Parser_SortAndDistinctSerialisation)
 TableView get_sorted_view(TableRef t, std::string query_string)
 {
     Query q = t->where();
+    query_builder::NoArguments args;
 
     parser::ParserResult result = realm::parser::parse(query_string);
-    realm::query_builder::apply_predicate(q, result.predicate);
+    realm::query_builder::apply_predicate(q, result.predicate, args);
     DescriptorOrdering ordering;
     realm::query_builder::apply_ordering(ordering, t, result.ordering);
 
@@ -1524,7 +1528,7 @@ TableView get_sorted_view(TableRef t, std::string query_string)
     Query q2 = t->where();
 
     parser::ParserResult result2 = realm::parser::parse(combined);
-    realm::query_builder::apply_predicate(q2, result2.predicate);
+    realm::query_builder::apply_predicate(q2, result2.predicate, args);
     DescriptorOrdering ordering2;
     realm::query_builder::apply_ordering(ordering2, t, result2.ordering);
 

--- a/test/test_parser.cpp
+++ b/test/test_parser.cpp
@@ -1937,8 +1937,12 @@ TEST(Parser_Subquery)
     verify_query(test_context, t, "SUBQUERY(fav_item.allergens, $x, $x.name CONTAINS[c] 'dairy').@count > 0", 2);
     // nested subquery
     verify_query(test_context, t, "SUBQUERY(items, $x, SUBQUERY($x.allergens, $allergy, $allergy.name CONTAINS[c] 'dairy').@count > 0).@count > 0", 3);
-    // target property must be a list
+    // nested subquery operating on the same table with same variable is not allowed
     std::string message;
+    CHECK_THROW_ANY_GET_MESSAGE(verify_query(test_context, t, "SUBQUERY(items, $x, SUBQUERY($x.discount.@links.class_Items.discount, $x, $x.price > 5).@count > 0).@count > 0", 2), message);
+    CHECK_EQUAL(message, "Unable to create a subquery expression with variable '$x' since an identical variable already exists in this context");
+
+    // target property must be a list
     CHECK_THROW_ANY_GET_MESSAGE(verify_query(test_context, t, "SUBQUERY(account_balance, $x, TRUEPREDICATE).@count > 0", 3), message);
     CHECK_EQUAL(message, "A subquery must operate on a list property, but 'account_balance' is type 'Double'");
     CHECK_THROW_ANY_GET_MESSAGE(verify_query(test_context, t, "SUBQUERY(fav_item, $x, TRUEPREDICATE).@count > 0", 3), message);


### PR DESCRIPTION
This adds support for subquery expressions and backlinks to the query serialiser and parser.
It also sets up the architecture for key path aliasing which could be useful for querying over named backlinks or when bindings allow referencing properties by other user defined names.

This is part of https://github.com/realm/realm-core/issues/2943