### PR TITLE
Fix creating encrypted files on macOS

### DIFF
--- a/src/realm/util/file.cpp
+++ b/src/realm/util/file.cpp
@@ -688,18 +688,31 @@ void File::prealloc(size_t size)
     // Mostly Linux only
     prealloc_if_supported(0, size);
 
-#elif REALM_PLATFORM_APPLE // Non-atomic fallback
+#else // Non-atomic fallback
+    if (size <= to_size_t(get_size())) {
+        return;
+    }
+
+    size_t new_size = size;
+    if (m_encryption_key) {
+        new_size = static_cast<size_t>(data_size_to_encrypted_size(size));
+        if (new_size < size) {
+            throw std::runtime_error("File size overflow: data_size_to_encrypted_size(" + realm::util::to_string(size) + ") == " + realm::util::to_string(new_size));
+        }
+    }
+
+#if REALM_PLATFORM_APPLE
     // posix_fallocate() is not supported on MacOS or iOS
-    fstore_t store = { F_ALLOCATEALL, F_PEOFPOSMODE, 0, static_cast<off_t>(size), 0 };
+    fstore_t store = { F_ALLOCATEALL, F_PEOFPOSMODE, 0, static_cast<off_t>(new_size), 0 };
     int ret = fcntl(m_fd, F_PREALLOCATE, &store);
     if (ret == -1) {
         int err = errno;
         std::string msg = get_errno_msg("fcntl() inside prealloc() failed: ", err);
         throw OutOfDiskSpace(msg);
     }
-    
+
     do {
-        ret = ftruncate(m_fd, size);
+        ret = ftruncate(m_fd, new_size);
     } while (ret == -1 && errno == EINTR);
 
     if (ret != 0) {
@@ -708,29 +721,21 @@ void File::prealloc(size_t size)
         throw OutOfDiskSpace(msg);
     }
 #elif REALM_ANDROID || defined(_WIN32)
-    if (size > to_size_t(get_size())) {
-        size_t new_size = size;
-        if (m_encryption_key) {
-            new_size = static_cast<size_t>(data_size_to_encrypted_size(size));
-            if (new_size < size) {
-                throw std::runtime_error("File size overflow: data_size_to_encrypted_size(" + realm::util::to_string(size) + ") == " + realm::util::to_string(new_size));
-            }
-        }
-
-        constexpr size_t chunk_size = 4096;
-        int64_t original_size = get_size_static(m_fd);
-        seek(original_size);
-        size_t num_bytes = size_t(new_size - original_size);
-        std::string zeros(chunk_size, '\0');
-        while (num_bytes > 0) {
-            size_t t = num_bytes > chunk_size ? chunk_size : num_bytes;
-            write_static(m_fd, zeros.c_str(), t);
-            num_bytes -= t;
-        }
+    constexpr size_t chunk_size = 4096;
+    int64_t original_size = get_size_static(m_fd);
+    seek(original_size);
+    size_t num_bytes = size_t(new_size - original_size);
+    std::string zeros(chunk_size, '\0');
+    while (num_bytes > 0) {
+        size_t t = num_bytes > chunk_size ? chunk_size : num_bytes;
+        write_static(m_fd, zeros.c_str(), t);
+        num_bytes -= t;
     }
 #else
     #error Please check if/how your OS supports file preallocation
 #endif
+
+#endif // !(_POSIX_C_SOURCE >= 200112L)
 }
 
 


### PR DESCRIPTION
The allocation size was not adjusted for the additional pages needed for encryption headers, resulting in the call to `m_file.prealloc(initial_size)` during file initialization truncating away the previously-written data. This corrects that oversight, and also makes `File::prealloc()` a no-op if the size is smaller than the file's current size, to match the `posix_fallocate()` behavior.

No changelog entry because this was just introduced a few hours ago in https://github.com/realm/realm-core/pull/2973 and has not yet appeared in a release.