### PR TITLE
Add libffi-dev to ubuntu16 dockerfile dependencies

### DIFF
--- a/packaging/ubuntu-1604/base-image/Dockerfile
+++ b/packaging/ubuntu-1604/base-image/Dockerfile
@@ -6,6 +6,7 @@ RUN apt-get update -y && apt-get install -y \
     build-essential \
     curl \
     git \
+    libffi-dev \
     ninja-build \
     ruby \
     ruby-dev \


### PR DESCRIPTION
Ubuntu 16 packaging in the Dockerfile is now [failing consistently](https://ci.realm.io/blue/organizations/jenkins/realm%2Frealm-core/detail/release%2F5.3.0/6/pipeline/84) with this error message:
```
Building native extensions.  This could take a while...
ERROR:  Error installing fpm:
	ERROR: Failed to build gem native extension.
    current directory: /var/lib/gems/2.3.0/gems/ffi-1.9.21/ext/ffi_c
/usr/bin/ruby2.3 -r ./siteconf20180215-3941-z0q39.rb extconf.rb
checking for ffi.h... no
...
```

I attempt to fix this by manually install `libffi-dev` onto the image.