### PR TITLE
Fix bug in Queries with two OR nodes at different nesting levels

### DIFF
--- a/src/realm/query.cpp
+++ b/src/realm/query.cpp
@@ -1271,8 +1271,7 @@ void Query::handle_pending_not()
 Query& Query::Or()
 {
     auto& current_group = m_groups.back();
-    OrNode* or_node = dynamic_cast<OrNode*>(current_group.m_root_node.get());
-    if (!or_node) {
+    if (current_group.m_state != QueryGroup::State::OrConditionChildren) {
         // Reparent the current group's nodes within an OrNode.
         add_node(std::unique_ptr<ParentNode>(new OrNode(std::move(current_group.m_root_node))));
     }

--- a/src/realm/table.hpp
+++ b/src/realm/table.hpp
@@ -782,8 +782,33 @@ public:
         return Query(*this, lv);
     }
 
-    Table& link(size_t link_column);
+    //@{
+    /// WARNING: The link() and backlink() methods will alter a state on the Table object and return a reference to itself.
+    /// Be aware if assigning the return value of link() to a variable; this might be an error!
+
+    /// This is an error:
+
+    /// Table& cats = owners->link(1);
+    /// auto& dogs = owners->link(2);
+
+    /// Query q = person_table->where()
+    /// .and_query(cats.column<String>(5).equal("Fido"))
+    /// .Or()
+    /// .and_query(dogs.column<String>(6).equal("Meowth"));
+
+    /// Instead, do this:
+
+    /// Query q = owners->where()
+    /// .and_query(person_table->link(1).column<String>(5).equal("Fido"))
+    /// .Or()
+    /// .and_query(person_table->link(2).column<String>(6).equal("Meowth"));
+
+    /// The two calls to link() in the errorneous example will append the two values 0 and 1 to an internal vector in the
+    /// owners table, and we end up with three references to that same table: owners, cats and dogs. They are all the same
+    /// table, its vector has the values {0, 1}, so a query would not make any sense.
+    Table& link(size_t link_column);    
     Table& backlink(const Table& origin, size_t origin_col_ndx);
+    //@}
 
     // Optimizing. enforce == true will enforce enumeration of all string columns;
     // enforce == false will auto-evaluate if they should be enumerated or not
@@ -1967,7 +1992,6 @@ SubQuery<T> Table::column(const Table& origin, size_t origin_col_ndx, Query subq
     return SubQuery<T>(column<T>(origin, origin_col_ndx), std::move(subquery));
 }
 
-// For use by queries
 inline Table& Table::link(size_t link_column)
 {
     m_link_chain.push_back(link_column);


### PR DESCRIPTION
* Fix bug in Queries with two OR nodes at different nesting levels

Applying this fix to master instead of develop (Original PR: #2953)