### PR TITLE
Rename targets to modern conventions, and put them in the Realm:: namespace

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,7 +16,8 @@
 
 ### Internals
 
-* None.
+* Exported CMake targets have been renamed to "modern" conventions, e.g.
+  `Realm::Core` and `Realm::QueryParser`.
 
 ----------------------------------------------
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -157,7 +157,7 @@ endif()
 install(FILES LICENSE CHANGELOG.md DESTINATION "doc/realm" COMPONENT devel)
 
 # Make the project importable from the build directory
-export(TARGETS realm realm-parser FILE realm-config.cmake)
+export(TARGETS Core QueryParser NAMESPACE Realm:: FILE realm-config.cmake)
 
 # Make the project importable from the install directory
 install(EXPORT realm

--- a/src/realm/CMakeLists.txt
+++ b/src/realm/CMakeLists.txt
@@ -237,20 +237,20 @@ endif()
 
 # We add the headers to the library only so they show up in dev
 # environments. It won't actually affect compilation process.
-add_library(realm-objects OBJECT ${REALM_SOURCES} ${REALM_INSTALL_ALL_HEADERS})
-target_compile_definitions(realm-objects PUBLIC
+add_library(CoreObjects OBJECT ${REALM_SOURCES} ${REALM_INSTALL_ALL_HEADERS})
+target_compile_definitions(CoreObjects PUBLIC
   "PIC"
   "$<$<CXX_COMPILER_ID:MSVC>:_CRT_SECURE_NO_WARNINGS>"
   "$<$<CXX_COMPILER_ID:MSVC>:_SCL_SECURE_NO_WARNINGS>")
 
-  set(REALM_OBJECT_FILES $<TARGET_OBJECTS:realm-objects>)
+  set(REALM_OBJECT_FILES $<TARGET_OBJECTS:CoreObjects>)
 
 if(COMMAND set_target_xcode_attributes)
-    set_target_xcode_attributes(realm-objects)
+    set_target_xcode_attributes(CoreObjects)
 endif()
 
 if(CMAKE_SYSTEM_NAME MATCHES "^Windows")
-    add_dependencies(realm-objects sha_win32 getopt_win32)
+    add_dependencies(CoreObjects sha_win32 getopt_win32)
     list(APPEND REALM_OBJECT_FILES $<TARGET_OBJECTS:sha_win32>)
 elseif(ANDROID)
     list(APPEND REALM_EXTRA_LIBS atomic)
@@ -261,9 +261,9 @@ if(CMAKE_GENERATOR STREQUAL Xcode)
     # The placeholder file is needed in order to make builds work on Xcode
     # The issue is described in the last sentence here:
     # https://cmake.org/cmake/help/v3.7/command/add_library.html#object-libraries
-    # Another problem is that Xcode does not see changes in the realm-objects
+    # Another problem is that Xcode does not see changes in the CoreObjects
     # target, to solve this we trigger rebuiliding the library by making
-    # placeholder.cpp depend on all the sources rather than realm-objects.
+    # placeholder.cpp depend on all the sources rather than CoreObjects.
     set(REALM_XCODE_DEPENDENCY "placeholder.cpp")
     add_custom_command(
         OUTPUT ${REALM_XCODE_DEPENDENCY}
@@ -273,31 +273,34 @@ if(CMAKE_GENERATOR STREQUAL Xcode)
 endif()
 
 
-add_library(realm STATIC ${REALM_OBJECT_FILES} ${REALM_XCODE_DEPENDENCY})
+add_library(Core STATIC ${REALM_OBJECT_FILES} ${REALM_XCODE_DEPENDENCY})
+set_target_properties(Core PROPERTIES LIBRARY_OUTPUT_NAME "realm")
+add_library(realm ALIAS Core)
 
-target_include_directories(realm INTERFACE
+target_include_directories(Core INTERFACE
                            $<BUILD_INTERFACE:${CMAKE_SOURCE_DIR}/src> $<BUILD_INTERFACE:${CMAKE_BINARY_DIR}/src>
                            $<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}>)
 
-target_link_libraries(realm INTERFACE ${REALM_EXTRA_LIBS} ${CMAKE_THREAD_LIBS_INIT})
+target_link_libraries(Core INTERFACE ${REALM_EXTRA_LIBS} ${CMAKE_THREAD_LIBS_INIT})
 
 if(ANDROID OR CMAKE_SYSTEM_NAME MATCHES "^Windows")
     set(REALM_SKIP_SHARED_LIB ON)
 endif()
 
 if(NOT REALM_SKIP_SHARED_LIB)
-    add_library(realm-shared SHARED ${REALM_OBJECT_FILES} ${REALM_XCODE_DEPENDENCY})
+    add_library(CoreShared SHARED ${REALM_OBJECT_FILES} ${REALM_XCODE_DEPENDENCY})
+    add_library(realm-shared ALIAS CoreShared)
 
-    target_include_directories(realm-shared INTERFACE
+    target_include_directories(CoreShared INTERFACE
                                $<BUILD_INTERFACE:${CMAKE_SOURCE_DIR}/src> $<BUILD_INTERFACE:${CMAKE_BINARY_DIR}/src>
                                $<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}>)
 
     set_target_properties(
-            realm-shared PROPERTIES
+            CoreShared PROPERTIES
             LIBRARY_OUTPUT_NAME realm
     )
 
-    target_link_libraries(realm-shared PRIVATE ${REALM_EXTRA_LIBS} ${CMAKE_THREAD_LIBS_INIT}
+    target_link_libraries(CoreShared PRIVATE ${REALM_EXTRA_LIBS} ${CMAKE_THREAD_LIBS_INIT}
     )
 endif()
 
@@ -322,26 +325,26 @@ if(REALM_ENABLE_ENCRYPTION AND UNIX AND NOT APPLE)
             COMPONENT devel)
     endif()
     find_package(OpenSSL REQUIRED)
-    target_include_directories(realm-objects PUBLIC ${OPENSSL_INCLUDE_DIR})
-    target_link_libraries(realm INTERFACE OpenSSL::Crypto)
+    target_include_directories(CoreObjects PUBLIC ${OPENSSL_INCLUDE_DIR})
+    target_link_libraries(Core INTERFACE OpenSSL::Crypto)
     if(NOT REALM_SKIP_SHARED_LIB)
-        target_link_libraries(realm-shared PRIVATE OpenSSL::Crypto)
+        target_link_libraries(CoreShared PRIVATE OpenSSL::Crypto)
     endif()
 endif()
 
 if(APPLE)
-    target_link_libraries(realm INTERFACE "-framework Foundation")
+    target_link_libraries(Core INTERFACE "-framework Foundation")
     if(NOT REALM_SKIP_SHARED_LIB)
-        target_link_libraries(realm-shared PRIVATE ${Foundation})
+        target_link_libraries(CoreShared PRIVATE ${Foundation})
     endif()
 endif(APPLE)
 
-install(TARGETS realm EXPORT realm
+install(TARGETS Core EXPORT realm
         ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR} COMPONENT devel)
 
 # include .pdb files with debug symbols on Windows
 if(CMAKE_GENERATOR MATCHES "^Visual Studio")
-    install(FILES ${CMAKE_CURRENT_BINARY_DIR}/realm-objects.dir/$<CONFIG>/realm-objects.pdb
+    install(FILES ${CMAKE_CURRENT_BINARY_DIR}/CoreObjects.dir/$<CONFIG>/CoreObjects.pdb
             DESTINATION ${CMAKE_INSTALL_LIBDIR}
             COMPONENT devel
             OPTIONAL)
@@ -370,7 +373,7 @@ install(FILES ${PROJECT_BINARY_DIR}/src/realm/util/config.h
         COMPONENT devel)
 
 if(NOT REALM_SKIP_SHARED_LIB)
-    install(TARGETS realm-shared
+    install(TARGETS CoreShared
             LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR} COMPONENT runtime
             RUNTIME DESTINATION ${CMAKE_INSTALL_LIBDIR} COMPONENT runtime)
 endif()
@@ -384,48 +387,56 @@ if(ANDROID)
             COMPONENT devel)
 endif()
 
-add_library(realm-parser STATIC ${REALM_PARSER_SOURCES} ${REALM_PARSER_HEADERS})
-target_link_libraries(realm-parser PUBLIC realm)
-target_include_directories(realm-parser PRIVATE ${PEGTL_INCLUDE_DIR})
+add_library(QueryParser STATIC ${REALM_PARSER_SOURCES} ${REALM_PARSER_HEADERS})
+add_library(realm-parser ALIAS QueryParser)
+target_link_libraries(QueryParser PUBLIC Core)
+target_include_directories(QueryParser PRIVATE ${PEGTL_INCLUDE_DIR})
+set_target_properties(QueryParser PROPERTIES LIBRARY_OUTPUT_NAME "realm-parser")
 install(FILES ${REALM_PARSER_HEADERS}
         DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}/realm/parser
         COMPONENT devel)
-install(TARGETS realm-parser EXPORT realm
+install(TARGETS QueryParser EXPORT realm
         ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR} COMPONENT devel)
 if(NOT REALM_SKIP_SHARED_LIB)
-    add_library(realm-parser-shared SHARED ${REALM_PARSER_SOURCES} ${REALM_PARSER_HEADERS})
-    add_dependencies(realm-parser-shared realm-shared)
-    target_link_libraries(realm-parser-shared PRIVATE realm-shared)
-    target_include_directories(realm-parser-shared PRIVATE ${PEGTL_INCLUDE_DIR})
-    target_include_directories(realm-parser-shared INTERFACE
+    add_library(QueryParserShared SHARED ${REALM_PARSER_SOURCES} ${REALM_PARSER_HEADERS})
+    add_dependencies(QueryParserShared CoreShared)
+    target_link_libraries(QueryParserShared PRIVATE CoreShared)
+    target_include_directories(QueryParserShared PRIVATE ${PEGTL_INCLUDE_DIR})
+    target_include_directories(QueryParserShared INTERFACE
                                $<BUILD_INTERFACE:${CMAKE_SOURCE_DIR}/src> $<BUILD_INTERFACE:${CMAKE_BINARY_DIR}/src>
                                $<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}>)
-    set_target_properties(realm-parser-shared PROPERTIES
-                          LIBRARY_OUTPUT_NAME realm-parser
+    set_target_properties(QueryParserShared PROPERTIES
+                          LIBRARY_OUTPUT_NAME "realm-parser"
     )
-    install(TARGETS realm-parser-shared
+    install(TARGETS QueryParserShared
             LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR} COMPONENT runtime
             RUNTIME DESTINATION ${CMAKE_INSTALL_LIBDIR} COMPONENT runtime)
 endif()
 
 if(NOT APPLE AND NOT ANDROID AND NOT CMAKE_SYSTEM_NAME MATCHES "^Windows" AND NOT REALM_BUILD_LIB_ONLY)
-    add_executable(realm-config config_tool.cpp)
-    set_target_properties(realm-config PROPERTIES DEBUG_POSTFIX ${CMAKE_DEBUG_POSTFIX})
+    add_executable(RealmConfig config_tool.cpp)
+    set_target_properties(RealmConfig PROPERTIES
+        OUTPUT_NAME "realm-config"
+        DEBUG_POSTFIX ${CMAKE_DEBUG_POSTFIX})
 
-    add_executable(realm-importer importer_tool.cpp importer.cpp importer.hpp)
-    set_target_properties(realm-importer PROPERTIES DEBUG_POSTFIX ${CMAKE_DEBUG_POSTFIX})
-    target_link_libraries(realm-importer realm)
+    add_executable(RealmImporter importer_tool.cpp importer.cpp importer.hpp)
+    set_target_properties(RealmImporter PROPERTIES
+        OUTPUT_NAME "realm-importer"
+        DEBUG_POSTFIX ${CMAKE_DEBUG_POSTFIX})
+    target_link_libraries(RealmImporter realm)
 
-    add_executable(realm-trawler realm_trawler.cpp)
-    set_target_properties(realm-trawler PROPERTIES DEBUG_POSTFIX ${CMAKE_DEBUG_POSTFIX})
+    add_executable(RealmTrawler realm_trawler.cpp)
+    set_target_properties(RealmTrawler PROPERTIES
+        OUTPUT_NAME "realm-trawler"
+        DEBUG_POSTFIX ${CMAKE_DEBUG_POSTFIX})
 
-    install(TARGETS realm-config realm-importer
+    install(TARGETS RealmConfig RealmImporter
             COMPONENT runtime
             DESTINATION ${CMAKE_INSTALL_BINDIR})
 
     add_executable(realmd realmd.cpp)
     set_target_properties(realmd PROPERTIES DEBUG_POSTFIX ${CMAKE_DEBUG_POSTFIX})
-    target_link_libraries(realmd realm)
+    target_link_libraries(realmd Core)
     install(TARGETS realmd
             COMPONENT runtime
             DESTINATION ${CMAKE_INSTALL_LIBEXECDIR})

--- a/src/realm/CMakeLists.txt
+++ b/src/realm/CMakeLists.txt
@@ -274,7 +274,7 @@ endif()
 
 
 add_library(Core STATIC ${REALM_OBJECT_FILES} ${REALM_XCODE_DEPENDENCY})
-set_target_properties(Core PROPERTIES LIBRARY_OUTPUT_NAME "realm")
+set_target_properties(Core PROPERTIES OUTPUT_NAME "realm")
 add_library(realm ALIAS Core)
 
 target_include_directories(Core INTERFACE
@@ -297,7 +297,7 @@ if(NOT REALM_SKIP_SHARED_LIB)
 
     set_target_properties(
             CoreShared PROPERTIES
-            LIBRARY_OUTPUT_NAME realm
+            OUTPUT_NAME "realm"
     )
 
     target_link_libraries(CoreShared PRIVATE ${REALM_EXTRA_LIBS} ${CMAKE_THREAD_LIBS_INIT}
@@ -391,7 +391,7 @@ add_library(QueryParser STATIC ${REALM_PARSER_SOURCES} ${REALM_PARSER_HEADERS})
 add_library(realm-parser ALIAS QueryParser)
 target_link_libraries(QueryParser PUBLIC Core)
 target_include_directories(QueryParser PRIVATE ${PEGTL_INCLUDE_DIR})
-set_target_properties(QueryParser PROPERTIES LIBRARY_OUTPUT_NAME "realm-parser")
+set_target_properties(QueryParser PROPERTIES OUTPUT_NAME "realm-parser")
 install(FILES ${REALM_PARSER_HEADERS}
         DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}/realm/parser
         COMPONENT devel)
@@ -406,7 +406,7 @@ if(NOT REALM_SKIP_SHARED_LIB)
                                $<BUILD_INTERFACE:${CMAKE_SOURCE_DIR}/src> $<BUILD_INTERFACE:${CMAKE_BINARY_DIR}/src>
                                $<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}>)
     set_target_properties(QueryParserShared PROPERTIES
-                          LIBRARY_OUTPUT_NAME "realm-parser"
+                          OUTPUT_NAME "realm-parser"
     )
     install(TARGETS QueryParserShared
             LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR} COMPONENT runtime

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -119,19 +119,20 @@ if (MSVC)
     set_source_files_properties(test_query.cpp PROPERTIES COMPILE_FLAGS /bigobj)
 endif()
 
-add_executable(realm-tests ${TESTS} ${MAIN_FILE} ${REQUIRED_TEST_FILES} ${REALM_TEST_HEADERS})
+add_executable(CoreTests ${TESTS} ${MAIN_FILE} ${REQUIRED_TEST_FILES} ${REALM_TEST_HEADERS})
+set_target_properties(CoreTests PROPERTIES OUTPUT_NAME "realm-tests")
 
 if(CMAKE_GENERATOR STREQUAL Xcode)
-    set_target_properties(realm-tests PROPERTIES
+    set_target_properties(CoreTests PROPERTIES
                           MACOSX_BUNDLE YES
                           RESOURCE "${REQUIRED_TEST_FILES}")
 endif()
 
-target_link_libraries(realm-tests
-                      test-util realm-parser ${EXTRA_TEST_LIBS} ${PLATFORM_LIBRARIES}
+target_link_libraries(CoreTests
+                      TestUtil QueryParser ${EXTRA_TEST_LIBS} ${PLATFORM_LIBRARIES}
 )
 
-target_include_directories(realm-tests PUBLIC ${EXTRA_TEST_CFLAGS})
+target_include_directories(CoreTests PUBLIC ${EXTRA_TEST_CFLAGS})
 
 add_test(NAME RealmTests COMMAND realm-tests)
 

--- a/test/benchmark-common-tasks/CMakeLists.txt
+++ b/test/benchmark-common-tasks/CMakeLists.txt
@@ -1,9 +1,9 @@
 add_executable(realm-benchmark-common-tasks main.cpp compatibility.cpp)
-target_link_libraries(realm-benchmark-common-tasks ${PLATFORM_LIBRARIES} test-util)
+target_link_libraries(realm-benchmark-common-tasks ${PLATFORM_LIBRARIES} TestUtil)
 add_test(RealmBenchmarkCommonTasks realm-benchmark-common-tasks)
 
 add_executable(realm-stats stats.cpp)
-target_link_libraries(realm-stats ${PLATFORM_LIBRARIES} realm)
+target_link_libraries(realm-stats ${PLATFORM_LIBRARIES} Core)
 file(COPY "collect_stats.py"
      DESTINATION ${CMAKE_CURRENT_BINARY_DIR})
 

--- a/test/benchmark-crud/CMakeLists.txt
+++ b/test/benchmark-crud/CMakeLists.txt
@@ -1,3 +1,3 @@
 add_executable(realm-benchmark-crud main.cpp)
-target_link_libraries(realm-benchmark-crud ${PLATFORM_LIBRARIES} test-util)
+target_link_libraries(realm-benchmark-crud ${PLATFORM_LIBRARIES} TestUtil)
 add_test(RealmBenchmarkCrud realm-benchmark-crud)

--- a/test/fuzzy/CMakeLists.txt
+++ b/test/fuzzy/CMakeLists.txt
@@ -29,12 +29,12 @@ file(COPY ${AFL_SEEDS}
 
 
 add_executable(fuzz-transact-log ${TEST_AFL_TRANSACT_LOG})
-target_link_libraries(fuzz-transact-log ${PLATFORM_LIBRARIES} test-util realm)
+target_link_libraries(fuzz-transact-log ${PLATFORM_LIBRARIES} TestUtil Core)
 
 add_executable(fuzz-group ${TEST_AFL_SOURCES})
-target_link_libraries(fuzz-group ${PLATFORM_LIBRARIES} test-util realm)
+target_link_libraries(fuzz-group ${PLATFORM_LIBRARIES} TestUtil Core)
 
 if(REALM_LIBFUZZER)
     add_executable(realm-libfuzzer ${TEST_LIBFUZZER_SOURCES})
-    target_link_libraries(realm-libfuzzer ${PLATFORM_LIBRARIES} test-util realm)
+    target_link_libraries(realm-libfuzzer ${PLATFORM_LIBRARIES} TestUtil Core)
 endif()

--- a/test/util/CMakeLists.txt
+++ b/test/util/CMakeLists.txt
@@ -17,7 +17,7 @@ set(TEST_UTIL_SOURCES
     jsmn.cpp
 ) # TEST_UTIL_SOURCES
 
-add_library(test-util ${TEST_UTIL_SOURCES})
+add_library(TestUtil ${TEST_UTIL_SOURCES})
 
-target_link_libraries(test-util realm)
+target_link_libraries(TestUtil Core)
 


### PR DESCRIPTION
The build targets in CMake have been renamed. The file names of the resulting build products are unchanged (or should be).

The following targets are now produced and exported by the build system:

- `Realm::Core` (previously `realm`)
- `Realm::CoreShared` (previously `realm-shared`)
- `Realm::QueryParser` (previously `realm-parser`)
- `Realm::QueryParserShared` (previously `realm-parser-shared`)
- `Realm::RealmConfig` (previously `realm-config`)
- `Realm::RealmImporter` (previously `realm-importer`)
- `Realm::RealmTrawler` (previously `realm-trawler`)
- `Realm::realmd` (previously `realmd`)

Aliases have been set up for the old names to avoid excessive breakage. However, the targets exported in `realm-config.cmake` are the new ones.