### PR TITLE
Speed up unit tests on Windows

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -95,10 +95,22 @@ if(MSVC)
         foreach(flag_var
             CMAKE_CXX_FLAGS CMAKE_CXX_FLAGS_DEBUG CMAKE_CXX_FLAGS_RELEASE
             CMAKE_CXX_FLAGS_MINSIZEREL CMAKE_CXX_FLAGS_RELWITHDEBINFO)
-           if(${flag_var} MATCHES "/MD")
-              string(REGEX REPLACE "/MD" "/MT" ${flag_var} "${${flag_var}}")
-           endif()
+            if(${flag_var} MATCHES "/MD")
+                string(REGEX REPLACE "/MD" "/MT" ${flag_var} "${${flag_var}}")
+            endif()
+
+            # Disable runtime stack bound checks, because these slow down unit tests
+            # disproportionately.
+            if(${flag_var} MATCHES "/RTC")
+                string(REGEX REPLACE "/RTC(su|[1su])" "" ${flag_var} "${${flag_var}}")
+            endif()
         endforeach()
+
+        # Let the compiler optimize debug builds ever so slightly.
+        # /Ob1: This allows the compiler to inline functions marked __inline.
+        # /Oi:  This enables (faster) intrinsic functions.
+        string(REPLACE "/Ob0" "/Ob1" CMAKE_CXX_FLAGS_DEBUG "${CMAKE_CXX_FLAGS_DEBUG}")
+        string(CONCAT CMAKE_CXX_FLAGS_DEBUG "/Oi " "${CMAKE_CXX_FLAGS_DEBUG}")
     endif()
 endif()
 


### PR DESCRIPTION
A little while ago I made Sync's unit tests run much faster on Windows by slightly reducing the amount of debug facilities that MSVC enabled by default (including very expensive iterator checks and a stack-pointer validity check for every function call).

I have copied those changes into Core's build system.