### PR TITLE
Don't rename lib64 to lib in tarball

### DIFF
--- a/packaging/generic/build-image/inside/build-package
+++ b/packaging/generic/build-image/inside/build-package
@@ -38,5 +38,4 @@ ninja
 ninja install
 
 cd /dest
-mv "${name}/lib64" "${name}/lib"
 tar -zcf "/out/${name}.tgz" "${name}"


### PR DESCRIPTION
The rename was illegal because the `realm-config.cmake` file inside the tarball refers to the `lib64` dir.

There is probably a way to configure CMake to not put things in `lib64` if it is really necessary.