### PR TITLE
Only open the balance mutex if async writes are enabled

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,8 @@
 
 ### Enhancements
 
-* None.
+* Reduced the number of files opened when the async commit daemon is not used.
+  PR [#3022](https://github.com/realm/realm-core/pull/3022).
 
 -----------
 

--- a/src/realm/group_shared.cpp
+++ b/src/realm/group_shared.cpp
@@ -977,7 +977,8 @@ void SharedGroup::do_open(const std::string& path, bool no_create_file, bool is_
 
         m_writemutex.set_shared_part(info->shared_writemutex, m_lockfile_prefix, "write");
 #ifdef REALM_ASYNC_DAEMON
-        m_balancemutex.set_shared_part(info->shared_balancemutex, m_lockfile_prefix, "balance");
+        if (info->durability == static_cast<uint16_t>(Durability::Async))
+            m_balancemutex.set_shared_part(info->shared_balancemutex, m_lockfile_prefix, "balance");
 #endif
         m_controlmutex.set_shared_part(info->shared_controlmutex, m_lockfile_prefix, "control");
 


### PR DESCRIPTION
It's not used otherwise, and eats up a fd.