### PR TITLE
Missing NAMESPACE for generated realm-config.cmake

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -173,6 +173,7 @@ export(TARGETS Core QueryParser NAMESPACE Realm:: FILE realm-config.cmake)
 
 # Make the project importable from the install directory
 install(EXPORT realm
+        NAMESPACE Realm::
         FILE realm-config.cmake
         DESTINATION ${CMAKE_INSTALL_LIBDIR}/cmake/realm
         COMPONENT devel)


### PR DESCRIPTION
I messed up in #3020 by forgetting to set the `NAMESPACE Realm::` option for the generated `realm-config.cmake`, meaning that consumers of Core would have to use the target `Core` instead of `Realm::Core`. We're all learning.

This fixes it.