### PR TITLE
If prealloc fails on APFS, fallback to manually allocated the file space

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,8 @@
 
 ### Bugfixes
 
-* None.
+* Fix sporadic failures of disk preallocation on APFS.
+  PR [#3028](https://github.com/realm/realm-core/pull/3028).
 
 ### Breaking changes
 

--- a/test/test_file.cpp
+++ b/test/test_file.cpp
@@ -459,6 +459,37 @@ TEST(File_PreallocResizing)
 
 }
 
+TEST(File_PreallocResizingAPFSBug)
+{
+    TEST_PATH(path);
+    File file(path, File::mode_Write);
+    CHECK(file.is_attached());
+    file.write("aaaaaaaaaaaaaaaaaaaa"); // 20 a's
+    // calling prealloc on a newly created file would sometimes fail on APFS with EINVAL via fcntl(F_PREALLOCATE)
+    // this may not be the only way to trigger the error, but it does seem to be timing dependant.
+    file.prealloc(100);
+    CHECK_EQUAL(file.get_size(), 100);
+
+    // let's write past the first prealloc block (@ 4096) and verify it reads correctly too.
+    file.write("aaaaa");
+    // this will change the file size, but likely won't preallocate more space since the first call to prealloc
+    // will probably have allocated a whole 4096 block.
+    file.prealloc(200);
+    CHECK_EQUAL(file.get_size(), 200);
+    file.write("aa");
+    file.prealloc(5020); // expands to another 4096 block
+    constexpr size_t insert_pos = 5000;
+    const char* insert_str = "hello";
+    file.seek(insert_pos);
+    file.write(insert_str);
+    file.seek(insert_pos);
+    CHECK_EQUAL(file.get_size(), 5020);
+    constexpr size_t input_size = 6;
+    char input[input_size];
+    file.read(input, input_size);
+    CHECK_EQUAL(strncmp(input, insert_str, input_size), 0);
+}
+
 
 #ifndef _WIN32
 TEST(File_GetUniqueID)


### PR DESCRIPTION
On APFS we observe that sometimes `fcntl(F_PREALLOCATE)` fails. It seems to be related to timing. If this happens we'll fall back to manually consuming this space like we do for windows/android.

See https://github.com/realm/realm-core/issues/3005