### PR TITLE
Parser improvements

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,8 @@
 
 ### Enhancements
 
-* None.
+* Allow an arbitrary prefix on backlink class names of @links queries.
+  This will allow users to query unnamed backlinks using the `@links.Class.property` syntax.
 
 -----------
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,8 @@
     - Allow an arbitrary prefix on backlink class names of @links queries.
       This will allow users to query unnamed backlinks using the `@links.Class.property` syntax.
     - Case insensitive `nil` is now recognised as a synonym to `NULL`.
+    - Add support for `@links.@count` which gives the count of all backlinks to an object.
+      See Issue [#3003](https://github.com/realm/realm-core/issues/3003).
 
 -----------
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,8 +10,10 @@
 
 ### Enhancements
 
-* Allow an arbitrary prefix on backlink class names of @links queries.
-  This will allow users to query unnamed backlinks using the `@links.Class.property` syntax.
+* Parser improvements:
+    - Allow an arbitrary prefix on backlink class names of @links queries.
+      This will allow users to query unnamed backlinks using the `@links.Class.property` syntax.
+    - Case insensitive `nil` is now recognised as a synonym to `NULL`.
 
 -----------
 

--- a/src/realm/parser/collection_operator_expression.hpp
+++ b/src/realm/parser/collection_operator_expression.hpp
@@ -192,12 +192,12 @@ typename std::enable_if_t<realm::is_any<RetType, Int, Float, Double>::value> >{
     {
         if (expr.pe.link_chain.empty() || expr.pe.get_dest_ndx() == realm::npos) {
             // here we are operating on the current table from a "@links.@count" query with no link keypath prefix
-            return expr.table_getter()->get_backlink_count<Int>();
+            return expr.table_getter()->template get_backlink_count<Int>();
         } else {
             if (expr.pe.dest_type_is_backlink()) {
-                return expr.table_getter()->template column<Link>(*expr.pe.get_dest_table(), expr.pe.get_dest_ndx()).backlink_count<Int>();
+                return expr.table_getter()->template column<Link>(*expr.pe.get_dest_table(), expr.pe.get_dest_ndx()).template backlink_count<Int>();
             } else {
-                return expr.table_getter()->template column<Link>(expr.pe.get_dest_ndx()).backlink_count<Int>();
+                return expr.table_getter()->template column<Link>(expr.pe.get_dest_ndx()).template backlink_count<Int>();
             }
         }
     }

--- a/src/realm/parser/collection_operator_expression.hpp
+++ b/src/realm/parser/collection_operator_expression.hpp
@@ -48,7 +48,8 @@ struct CollectionOperatorExpression
 
         const bool requires_suffix_path = !(OpType == parser::Expression::KeyPathOp::SizeString
                                             || OpType == parser::Expression::KeyPathOp::SizeBinary
-                                            || OpType == parser::Expression::KeyPathOp::Count);
+                                            || OpType == parser::Expression::KeyPathOp::Count
+                                            || OpType == parser::Expression::KeyPathOp::BacklinkCount);
 
         if (requires_suffix_path) {
             Table* pre_link_table = pe.table_getter();
@@ -88,7 +89,9 @@ struct CollectionOperatorExpression
             post_link_col_type = element.col_type;
         }
         else {  // !requires_suffix_path
-            post_link_col_type = pe.get_dest_type();
+            if (!pe.link_chain.empty()) {
+                post_link_col_type = pe.get_dest_type();
+            }
 
             realm_precondition(suffix_path.empty(),
                          util::format("An extraneous property '%1' was found for operation '%2'",
@@ -180,6 +183,26 @@ struct CollectionOperatorGetter<RetType, parser::Expression::KeyPathOp::Count,
         }
     }
 };
+
+
+template <typename RetType>
+struct CollectionOperatorGetter<RetType, parser::Expression::KeyPathOp::BacklinkCount,
+typename std::enable_if_t<realm::is_any<RetType, Int, Float, Double>::value> >{
+    static BacklinkCount<Int> convert(const CollectionOperatorExpression<parser::Expression::KeyPathOp::BacklinkCount>& expr)
+    {
+        if (expr.pe.link_chain.empty() || expr.pe.get_dest_ndx() == realm::npos) {
+            // here we are operating on the current table from a "@links.@count" query with no link keypath prefix
+            return expr.table_getter()->get_backlink_count<Int>();
+        } else {
+            if (expr.pe.dest_type_is_backlink()) {
+                return expr.table_getter()->template column<Link>(*expr.pe.get_dest_table(), expr.pe.get_dest_ndx()).backlink_count<Int>();
+            } else {
+                return expr.table_getter()->template column<Link>(expr.pe.get_dest_ndx()).backlink_count<Int>();
+            }
+        }
+    }
+};
+
 
 template <>
 struct CollectionOperatorGetter<Int, parser::Expression::KeyPathOp::SizeString>{

--- a/src/realm/parser/expression_container.hpp
+++ b/src/realm/parser/expression_container.hpp
@@ -45,6 +45,7 @@ public:
     CollectionOperatorExpression<parser::Expression::KeyPathOp::Sum>& get_sum();
     CollectionOperatorExpression<parser::Expression::KeyPathOp::Avg>& get_avg();
     CollectionOperatorExpression<parser::Expression::KeyPathOp::Count>& get_count();
+    CollectionOperatorExpression<parser::Expression::KeyPathOp::BacklinkCount>& get_backlink_count();
     CollectionOperatorExpression<parser::Expression::KeyPathOp::SizeString>& get_size_string();
     CollectionOperatorExpression<parser::Expression::KeyPathOp::SizeBinary>& get_size_binary();
     SubqueryExpression& get_subexpression();
@@ -63,6 +64,7 @@ public:
         exp_OpCount,
         exp_OpSizeString,
         exp_OpSizeBinary,
+        exp_OpBacklinkCount,
         exp_SubQuery
     };
 

--- a/src/realm/parser/keypath_mapping.cpp
+++ b/src/realm/parser/keypath_mapping.cpp
@@ -85,8 +85,8 @@ KeyPathElement KeyPathMapping::process_next_path(ConstTableRef table, KeyPath& k
     // Process backlinks which consumes 3 parts of the keypath
     if (is_backlinks_prefix(keypath[index])) {
         realm_precondition(index + 2 < keypath.size(), "'@links' must be proceeded by type name and a property name");
-
-        Table::BacklinkOrigin info = table->find_backlink_origin(keypath[index + 1], keypath[index + 2]);
+        std::string origin_table_name = m_backlink_class_prefix + keypath[index + 1];
+        Table::BacklinkOrigin info = table->find_backlink_origin(origin_table_name, keypath[index + 2]);
         realm_precondition(bool(info), util::format("No property '%1' found in type '%2' which links to type '%3'",
                   keypath[index + 2], get_printable_table_name(keypath[index + 1]), get_printable_table_name(*table)));
 
@@ -94,7 +94,7 @@ KeyPathElement KeyPathMapping::process_next_path(ConstTableRef table, KeyPath& k
             throw BacklinksRestrictedError(util::format(
                 "Querying over backlinks is disabled but backlinks were found in the inverse relationship of property '%1' on type '%2'",
                 keypath[index + 2], get_printable_table_name(keypath[index + 1])));
-       }
+        }
 
         index = index + 3;
         KeyPathElement element;
@@ -124,6 +124,11 @@ KeyPathElement KeyPathMapping::process_next_path(ConstTableRef table, KeyPath& k
 void KeyPathMapping::set_allow_backlinks(bool allow)
 {
     m_allow_backlinks = allow;
+}
+
+void KeyPathMapping::set_backlink_class_prefix(std::string prefix)
+{
+    m_backlink_class_prefix = prefix;
 }
 
 Table* KeyPathMapping::table_getter(TableRef table, const std::vector<KeyPathElement>& links)

--- a/src/realm/parser/keypath_mapping.cpp
+++ b/src/realm/parser/keypath_mapping.cpp
@@ -84,6 +84,17 @@ KeyPathElement KeyPathMapping::process_next_path(ConstTableRef table, KeyPath& k
 
     // Process backlinks which consumes 3 parts of the keypath
     if (is_backlinks_prefix(keypath[index])) {
+        if (index + 1 == keypath.size()) {
+            // we do support @links.@count and @links.@size so if @links is the end, that's what we are doing
+            // any other operation on @links would have thrown a predicate error from the parser level
+            index = index + 1;
+            KeyPathElement element;
+            element.table = table;
+            element.col_ndx = realm::npos; // unused
+            element.col_type = type_LinkList;
+            element.is_backlink = false;
+            return element;
+        }
         realm_precondition(index + 2 < keypath.size(), "'@links' must be proceeded by type name and a property name");
         std::string origin_table_name = m_backlink_class_prefix + keypath[index + 1];
         Table::BacklinkOrigin info = table->find_backlink_origin(origin_table_name, keypath[index + 2]);

--- a/src/realm/parser/keypath_mapping.hpp
+++ b/src/realm/parser/keypath_mapping.hpp
@@ -61,9 +61,11 @@ public:
     bool has_mapping(ConstTableRef table, std::string name);
     KeyPathElement process_next_path(ConstTableRef table, KeyPath& path, size_t& index);
     void set_allow_backlinks(bool allow);
+    void set_backlink_class_prefix(std::string prefix);
     static Table* table_getter(TableRef table, const std::vector<KeyPathElement>& links);
 protected:
     bool m_allow_backlinks;
+    std::string m_backlink_class_prefix;
     std::unordered_map<std::pair<ConstTableRef, std::string>, std::string, TableAndColHash> m_mapping;
 };
 

--- a/src/realm/parser/parser.cpp
+++ b/src/realm/parser/parser.cpp
@@ -93,17 +93,21 @@ struct avg : TAOCPP_PEGTL_ISTRING(".@avg.") {};
 struct count : string_token_t(".@count") {};
 struct size : string_token_t(".@size") {};
 struct backlinks : string_token_t("@links") {};
+struct one_key_path : seq< sor< alpha, one< '_', '$' > >, star< sor< alnum, one< '_', '-', '$' > > > > {};
+struct backlink_path : seq< backlinks, dot, one_key_path, dot, one_key_path > {};
+struct backlink_count : seq< disable< backlinks >, sor< disable< count >, disable< size > > > {};
 
 struct single_collection_operators : sor< count, size > {};
 struct key_collection_operators : sor< min, max, sum, avg > {};
 
 // key paths
-struct key_path : list< sor< backlinks, seq< sor< alpha, one< '_', '$' > >, star< sor< alnum, one< '_', '-', '$' > > > > >, one< '.' > > {};
+struct key_path : list< sor< backlink_path, one_key_path >, one< '.' > > {};
 
 struct key_path_prefix : disable< key_path > {};
 struct key_path_suffix : disable< key_path > {};
 struct collection_operator_match : sor< seq< key_path_prefix, key_collection_operators, key_path_suffix >,
-                                   seq< key_path_prefix, single_collection_operators > > {};
+                                        seq< opt< key_path_prefix, dot >, backlink_count >,
+                                        seq< key_path_prefix, single_collection_operators > > {};
 
 // argument
 struct argument_index : plus< digit > {};
@@ -336,7 +340,7 @@ template<> struct action< or_op >
 template<> struct action< rule > {                                  \
     template< typename Input >                                      \
     static void apply(const Input& in, ParserState& state) {        \
-    DEBUG_PRINT_TOKEN(in.string() + #rule);                             \
+        DEBUG_PRINT_TOKEN("expression:" + in.string() + #rule);     \
         state.add_expression(Expression(type, in.string())); }};
 
 EXPRESSION_ACTION(dq_string_content, Expression::Type::String)
@@ -521,7 +525,7 @@ template<> struct action< subquery >
 template<> struct action< rule > {                                  \
 template< typename Input >                                          \
     static void apply(const Input& in, ParserState& state) {        \
-        DEBUG_PRINT_TOKEN(in.string());                             \
+        DEBUG_PRINT_TOKEN("operation: " + in.string());             \
         state.pending_op = type; }};
 
 
@@ -531,11 +535,12 @@ COLLECTION_OPERATION_ACTION(sum, Expression::KeyPathOp::Sum)
 COLLECTION_OPERATION_ACTION(avg, Expression::KeyPathOp::Avg)
 COLLECTION_OPERATION_ACTION(count, Expression::KeyPathOp::Count)
 COLLECTION_OPERATION_ACTION(size, Expression::KeyPathOp::SizeString)
+COLLECTION_OPERATION_ACTION(backlink_count, Expression::KeyPathOp::BacklinkCount)
 
 template<> struct action< key_path_prefix > {
     template< typename Input >
     static void apply(const Input& in, ParserState& state) {
-        DEBUG_PRINT_TOKEN(in.string());
+        DEBUG_PRINT_TOKEN("key_path_prefix: " + in.string());
         state.collection_key_path_prefix = in.string();
     }
 };
@@ -543,7 +548,7 @@ template<> struct action< key_path_prefix > {
 template<> struct action< key_path_suffix > {
     template< typename Input >
     static void apply(const Input& in, ParserState& state) {
-        DEBUG_PRINT_TOKEN(in.string());
+        DEBUG_PRINT_TOKEN("key_path_suffix: " + in.string());
         state.collection_key_path_suffix = in.string();
     }
 };

--- a/src/realm/parser/parser.cpp
+++ b/src/realm/parser/parser.cpp
@@ -82,7 +82,7 @@ struct timestamp : sor< internal_timestamp, readable_timestamp > {};
 
 struct true_value : string_token_t("true") {};
 struct false_value : string_token_t("false") {};
-struct null_value : string_token_t("null") {};
+struct null_value : seq< sor< string_token_t("null"), string_token_t("nil") > > {};
 
 // following operators must allow proceeding string characters
 struct min : TAOCPP_PEGTL_ISTRING(".@min.") {};

--- a/src/realm/parser/parser.hpp
+++ b/src/realm/parser/parser.hpp
@@ -32,7 +32,7 @@ struct Predicate;
 struct Expression
 {
     enum class Type { None, Number, String, KeyPath, Argument, True, False, Null, Timestamp, Base64, SubQuery } type;
-    enum class KeyPathOp { None, Min, Max, Avg, Sum, Count, SizeString, SizeBinary } collection_op;
+    enum class KeyPathOp { None, Min, Max, Avg, Sum, Count, SizeString, SizeBinary, BacklinkCount } collection_op;
     std::string s;
     std::vector<std::string> time_inputs;
     std::string op_suffix;

--- a/src/realm/parser/parser_utils.cpp
+++ b/src/realm/parser/parser_utils.cpp
@@ -42,11 +42,6 @@ const char* type_to_str<Int>()
     return "Int";
 }
 template <>
-const char* type_to_str<int>()
-{
-    return "Int";
-}
-template <>
 const char* type_to_str<Float>()
 {
     return "Float";

--- a/src/realm/parser/parser_utils.cpp
+++ b/src/realm/parser/parser_utils.cpp
@@ -42,6 +42,11 @@ const char* type_to_str<Int>()
     return "Int";
 }
 template <>
+const char* type_to_str<int>()
+{
+    return "Int";
+}
+template <>
 const char* type_to_str<Float>()
 {
     return "Float";
@@ -120,6 +125,8 @@ const char* collection_operator_to_str(parser::Expression::KeyPathOp op)
             return "@size";
         case parser::Expression::KeyPathOp::SizeBinary:
             return "@size";
+        case parser::Expression::KeyPathOp::BacklinkCount:
+            return "@links.@count";
         case parser::Expression::KeyPathOp::Count:
             return "@count";
     }

--- a/src/realm/parser/parser_utils.hpp
+++ b/src/realm/parser/parser_utils.hpp
@@ -48,8 +48,6 @@ const char* type_to_str<bool>();
 template <>
 const char* type_to_str<Int>();
 template <>
-const char* type_to_str<int>();
-template <>
 const char* type_to_str<Float>();
 template <>
 const char* type_to_str<Double>();
@@ -78,7 +76,7 @@ T stot(std::string const& s) {
     T value;
     iss >> value;
     if (iss.fail()) {
-        throw std::invalid_argument(util::format("Cannot convert string '%1' to type '%2'", s, type_to_str<T>()));
+        throw std::invalid_argument(util::format("Cannot convert string '%1'", s));
     }
     return value;
 }

--- a/src/realm/parser/parser_utils.hpp
+++ b/src/realm/parser/parser_utils.hpp
@@ -48,6 +48,8 @@ const char* type_to_str<bool>();
 template <>
 const char* type_to_str<Int>();
 template <>
+const char* type_to_str<int>();
+template <>
 const char* type_to_str<Float>();
 template <>
 const char* type_to_str<Double>();
@@ -76,7 +78,7 @@ T stot(std::string const& s) {
     T value;
     iss >> value;
     if (iss.fail()) {
-        throw std::invalid_argument(util::format("Cannot convert string '%1'", s));
+        throw std::invalid_argument(util::format("Cannot convert string '%1' to type '%2'", s, type_to_str<T>()));
     }
     return value;
 }

--- a/src/realm/parser/property_expression.cpp
+++ b/src/realm/parser/property_expression.cpp
@@ -41,7 +41,11 @@ PropertyExpression::PropertyExpression(Query &q, const std::string &key_path_str
                                       element.table->get_column_name(element.col_ndx),
                                       get_printable_table_name(*element.table)));
             if (element.table == cur_table) {
-                cur_table = element.table->get_link_target(element.col_ndx); // advance through forward link
+                if (element.col_ndx == realm::npos) {
+                    cur_table = element.table;
+                } else {
+                    cur_table = element.table->get_link_target(element.col_ndx); // advance through forward link
+                }
             } else {
                 cur_table = element.table; // advance through backlink
             }

--- a/src/realm/parser/query_builder.cpp
+++ b/src/realm/parser/query_builder.cpp
@@ -458,6 +458,8 @@ void add_null_comparison_to_query(Query &query, Predicate::Comparison cmp, Expre
             REALM_FALLTHROUGH;
         case ExpressionContainer::ExpressionInternal::exp_OpCount:
             REALM_FALLTHROUGH;
+        case ExpressionContainer::ExpressionInternal::exp_OpBacklinkCount:
+            REALM_FALLTHROUGH;
         case ExpressionContainer::ExpressionInternal::exp_OpSizeString:
             REALM_FALLTHROUGH;
         case ExpressionContainer::ExpressionInternal::exp_OpSizeBinary:
@@ -489,6 +491,9 @@ void internal_add_comparison_to_query(Query& query, LHS_T& lhs, Predicate::Compa
             return;
         case ExpressionContainer::ExpressionInternal::exp_OpCount:
             do_add_comparison_to_query(query, cmp, lhs, rhs.get_count(), comparison_type);
+            return;
+        case ExpressionContainer::ExpressionInternal::exp_OpBacklinkCount:
+            do_add_comparison_to_query(query, cmp, lhs, rhs.get_backlink_count(), comparison_type);
             return;
         case ExpressionContainer::ExpressionInternal::exp_OpSizeString:
             do_add_comparison_to_query(query, cmp, lhs, rhs.get_size_string(), comparison_type);
@@ -526,6 +531,9 @@ void add_comparison_to_query(Query &query, ExpressionContainer& lhs, Predicate::
             return;
         case ExpressionContainer::ExpressionInternal::exp_OpCount:
             internal_add_comparison_to_query(query, lhs.get_count(), cmp, rhs, comparison_type);
+            return;
+        case ExpressionContainer::ExpressionInternal::exp_OpBacklinkCount:
+            internal_add_comparison_to_query(query, lhs.get_backlink_count(), cmp, rhs, comparison_type);
             return;
         case ExpressionContainer::ExpressionInternal::exp_OpSizeString:
             internal_add_comparison_to_query(query, lhs.get_size_string(), cmp, rhs, comparison_type);

--- a/src/realm/parser/value_expression.cpp
+++ b/src/realm/parser/value_expression.cpp
@@ -179,6 +179,11 @@ Int ValueExpression::value_of_type_for_query<Int>()
     if (value->type == parser::Expression::Type::Argument) {
         return arguments->long_for_argument(stot<int>(value->s));
     }
+    // We can allow string types here in case people have numbers in their strings like "int == '23'"
+    // it's just a convienence but if the string conversion fails we'll throw from the stot function.
+    if (value->type != parser::Expression::Type::Number && value->type != parser::Expression::Type::String) {
+        throw std::logic_error("Attempting to compare a numeric property to a non-numeric value");
+    }
     return stot<long long>(value->s);
 }
 

--- a/src/realm/table.hpp
+++ b/src/realm/table.hpp
@@ -41,6 +41,8 @@
 namespace realm {
 
 class BacklinkColumn;
+template <class>
+class BacklinkCount;
 class BinaryColumy;
 class ConstTableView;
 class Group;
@@ -338,6 +340,9 @@ public:
     Columns<T> column(size_t column); // FIXME: Should this one have been declared noexcept?
     template <class T>
     Columns<T> column(const Table& origin, size_t origin_column_ndx);
+    // BacklinkCount is a total count per row and therefore not attached to a specific column
+    template <class T>
+    BacklinkCount<T> get_backlink_count();
 
     template <class T>
     SubQuery<T> column(size_t column, Query subquery);
@@ -1980,6 +1985,14 @@ inline Columns<T> Table::column(const Table& origin, size_t origin_col_ndx)
     link_chain.push_back(backlink_col_ndx);
 
     return Columns<T>(backlink_col_ndx, this, std::move(link_chain));
+}
+
+template <class T>
+inline BacklinkCount<T> Table::get_backlink_count()
+{
+    std::vector<size_t> link_chain = std::move(m_link_chain);
+    m_link_chain.clear();
+    return BacklinkCount<T>(this, std::move(link_chain));
 }
 
 template <class T>

--- a/test/test_parser.cpp
+++ b/test/test_parser.cpp
@@ -99,6 +99,7 @@ static std::vector<std::string> valid_queries = {
     "truelove = false",
     "true = falsey",
     "nullified = null",
+    "nullified = nil",
     "_ = a",
     "_a = _.aZ",
     "a09._br.z = __-__.Z-9",
@@ -421,12 +422,14 @@ TEST(Parser_basic_serialisation)
     Query q = t->where();
 
     verify_query(test_context, t, "time == NULL", 1);
+    verify_query(test_context, t, "time == NIL", 1);
     verify_query(test_context, t, "time != NULL", 4);
     verify_query(test_context, t, "time > T0:0", 3);
     verify_query(test_context, t, "time == T1:2", 1);
     verify_query(test_context, t, "time > 2017-12-1@12:07:53", 1);
     verify_query(test_context, t, "time == 2017-12-01@12:07:53:505", 1);
     verify_query(test_context, t, "buddy == NULL", 4);
+    verify_query(test_context, t, "buddy == nil", 4);
     verify_query(test_context, t, "buddy != NULL", 1);
     verify_query(test_context, t, "buddy <> NULL", 1);
     verify_query(test_context, t, "age > 2", 2);
@@ -626,6 +629,7 @@ TEST(Parser_StringOperations)
     verify_query(test_context, t, "father.name like[c] \"?O?\"", 2);
 
     verify_query(test_context, t, "name == NULL", 1);
+    verify_query(test_context, t, "name == nil", 1);
     verify_query(test_context, t, "NULL == name", 1);
     verify_query(test_context, t, "name != NULL", 5);
     verify_query(test_context, t, "NULL != name", 5);
@@ -694,6 +698,7 @@ TEST(Parser_Timestamps)
 
     verify_query(test_context, t, "T2017-12-04 == NULL", 3);
     verify_query(test_context, t, "T2017-12-04 != NULL", 2);
+    verify_query(test_context, t, "T2017-12-04 != NIL", 2);
     verify_query(test_context, t, "linked.T2017-12-04 == NULL", 3); // null links count as a match for null here
     verify_query(test_context, t, "linked != NULL && linked.T2017-12-04 == NULL", 0);
     verify_query(test_context, t, "linked.T2017-12-04 != NULL", 2);
@@ -703,7 +708,9 @@ TEST(Parser_Timestamps)
     verify_query(test_context, t, "T2017-12-04 == 2017-12-04@0:0:0", 0);
 
     verify_query(test_context, t, "birthday == NULL", 0);
+    verify_query(test_context, t, "birthday == NIL", 0);
     verify_query(test_context, t, "birthday != NULL", 5);
+    verify_query(test_context, t, "birthday != NIL", 5);
     verify_query(test_context, t, "birthday == T0:0", 3);
     verify_query(test_context, t, "birthday == 1970-1-1@0:0:0:0", 3); // epoch is default non-null Timestamp
 
@@ -773,6 +780,10 @@ TEST(Parser_NullableBinaries)
     verify_query(test_context, items, "data != NULL", 5);
     verify_query(test_context, items, "nullable_data == NULL", 2);
     verify_query(test_context, items, "nullable_data != NULL", 3);
+    verify_query(test_context, items, "data == NIL", 0);
+    verify_query(test_context, items, "data != NIL", 5);
+    verify_query(test_context, items, "nullable_data == NIL", 2);
+    verify_query(test_context, items, "nullable_data != NIL", 3);
 
     verify_query(test_context, items, "nullable_data CONTAINS 'f'", 2);
     verify_query(test_context, items, "nullable_data BEGINSWITH 'f'", 1);

--- a/test/test_parser.cpp
+++ b/test/test_parser.cpp
@@ -1892,7 +1892,7 @@ TEST(Parser_BacklinkCount)
     std::string message;
     // backlink count requires comparison to a numeric type
     CHECK_THROW_ANY_GET_MESSAGE(verify_query(test_context, items, "@links.@count == 'string'", -1), message);
-    CHECK_EQUAL(message, "Cannot convert string 'string' to type 'Int'");
+    CHECK_EQUAL(message, "Cannot convert string 'string'");
     CHECK_THROW_ANY_GET_MESSAGE(verify_query(test_context, items, "@links.@count == 2018-04-09@14:21:0", -1), message);
     CHECK_EQUAL(message, "Attempting to compare a numeric property to a non-numeric value");
 

--- a/test/test_parser.cpp
+++ b/test/test_parser.cpp
@@ -1768,6 +1768,22 @@ TEST(Parser_Backlinks)
     p = realm::parser::parse("purchasers.@max.money >= 20").predicate;
     CHECK_THROW_ANY_GET_MESSAGE(realm::query_builder::apply_predicate(q, p, args, mapping), message);
     CHECK_EQUAL(message, "Querying over backlinks is disabled but backlinks were found in the inverse relationship of property 'items' on type 'Person'");
+
+    // check that arbitrary aliasing for named backlinks works with a arbitrary prefix
+    parser::KeyPathMapping mapping_with_prefix;
+    mapping_with_prefix.set_backlink_class_prefix("class_");
+    mapping_with_prefix.add_mapping(items, "purchasers", "@links.Person.items");
+    mapping_with_prefix.add_mapping(t, "money", "account_balance");
+
+    q = items->where();
+    p = realm::parser::parse("purchasers.@count > 2").predicate;
+    realm::query_builder::apply_predicate(q, p, args, mapping_with_prefix);
+    CHECK_EQUAL(q.count(), 2);
+
+    q = items->where();
+    p = realm::parser::parse("purchasers.@max.money >= 20").predicate;
+    realm::query_builder::apply_predicate(q, p, args, mapping_with_prefix);
+    CHECK_EQUAL(q.count(), 3);
 }
 
 


### PR DESCRIPTION

- Allow an arbitrary prefix on backlink class names of @links queries. This will allow users to query unnamed backlinks using the `@links.Class.property` syntax because we can now hide the `class_` prefix from the binding level. It's a non-breaking change because the feature has to be explicitly set by bindings.
- Case insensitive `nil` is now recognised as a synonym to `NULL`. It's NSPredicate syntax and we had some users trying to use it.
- Add support for `@links.@count` which gives the count of all backlinks to an object. This fixes  #3003.