### PR TITLE
Serialisation fix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,9 @@
 
 ### Bugfixes
 
-* None.
+* Fix null comparisons in queries not serialising properly in some cases.
+  Also explicitly disable list IN list comparisons since its not supported.
+  PR [#3037](https://github.com/realm/realm-core/pull/3037).
 
 ### Breaking changes
 

--- a/src/realm/query_expression.hpp
+++ b/src/realm/query_expression.hpp
@@ -343,25 +343,9 @@ struct RowIndex {
     {
         return !(*this == other);
     }
-    template <class C, class T>
-    friend std::basic_ostream<C, T>& operator<<(std::basic_ostream<C, T>&, const RowIndex&);
-
 private:
     util::Optional<size_t> m_row_index;
 };
-
-template <class C, class T>
-inline std::basic_ostream<C, T>& operator<<(std::basic_ostream<C, T>& out, const RowIndex& r)
-{
-    if (!r.is_attached()) {
-        out << "detached row";
-    } else if (r.is_null()) {
-        out << "null row";
-    } else {
-        out << r.m_row_index;
-    }
-    return out;
-}
 
 struct ValueBase {
     static const size_t default_size = 8;

--- a/src/realm/util/serializer.cpp
+++ b/src/realm/util/serializer.cpp
@@ -100,6 +100,15 @@ std::string print_value<>(realm::Timestamp t)
     return ss.str();
 }
 
+template <>
+std::string print_value<>(realm::RowIndex r)
+{
+    if (!r.is_attached() || !r.is_null()) {
+        throw SerialisationError("Serialisation of object comparisons is not supported");
+    }
+    // the remaining option is that it is NULL, and this we do know how to serialise
+    return "NULL";
+}
 
 // The variable name must be unique with respect to the already chosen variables at
 // this level of subquery nesting and with respect to the names of the columns in the table.

--- a/src/realm/util/serializer.hpp
+++ b/src/realm/util/serializer.hpp
@@ -30,6 +30,7 @@ namespace realm {
 
 class BinaryData;
 struct null;
+struct RowIndex;
 class StringData;
 class Timestamp;
 class LinkMap;
@@ -53,6 +54,7 @@ template <> std::string print_value<>(bool);
 template <> std::string print_value<>(realm::null);
 template <> std::string print_value<>(StringData);
 template <> std::string print_value<>(realm::Timestamp);
+template <> std::string print_value<>(realm::RowIndex);
 
 // General implementation for most types
 template <typename T>

--- a/test/test_parser.cpp
+++ b/test/test_parser.cpp
@@ -2334,6 +2334,9 @@ TEST(Parser_OperatorIN)
     CHECK_EQUAL(message, "The keypath following 'IN' must contain a list");
     CHECK_THROW_ANY_GET_MESSAGE(verify_query(test_context, t, "'dairy' in items.allergens.name", 1), message);
     CHECK_EQUAL(message, "The keypath following 'IN' must contain only one list");
-
+    // list property vs list property is not supported by core yet
+    CHECK_THROW_ANY_GET_MESSAGE(verify_query(test_context, t, "items.price IN items.price", 0), message);
+    CHECK_EQUAL(message, "The keypath preceeding 'IN' must not contain a list, list vs list comparisons are not currently supported");
 }
+
 #endif // TEST_PARSER


### PR DESCRIPTION
Fixes null comparison queries sometimes being serialised to "null row" instead of "NULL" which caused an "Invalid Predicate" error seen by a client when using such a query in partial sync.

Also I explicitly disable `list IN other_list` queries since core doesn't support many to many comparisons internally, if people did this previously the query would always return no results.