### PR TITLE
Include history refs in Group::write()

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,9 @@
 
 ### Enhancements
 
-* None.
+* `SharedGroup::compact()` now also compacts history information, which means
+  that Sync'ed Realm files can now be compacted (under the usual restrictions;
+  see `group_shared.hpp` for details).
 
 -----------
 

--- a/src/realm/group.cpp
+++ b/src/realm/group.cpp
@@ -709,6 +709,38 @@ public:
         return m_group.m_tables.write(out, deep, only_if_modified); // Throws
     }
 
+    HistoryInfo write_history(_impl::OutputStream& out) override
+    {
+        bool deep = true;                                           // Deep
+        bool only_if_modified = false;                              // Always
+        ref_type history_ref = _impl::GroupFriend::get_history_ref(m_group);
+        HistoryInfo info;
+        info.ref = 0;
+        info.type = 0;
+        info.version = 0;
+        if (history_ref) {
+            _impl::History::version_type version;
+            int history_type, history_schema_version;
+            _impl::GroupFriend::get_version_and_history_info(_impl::GroupFriend::get_alloc(m_group),
+                                                             m_group.m_top.get_ref(),
+                                                             version,
+                                                             history_type,
+                                                             history_schema_version);
+            REALM_ASSERT(history_type != Replication::hist_None);
+            if (history_type == Replication::hist_OutOfRealm) {
+                return info; // Cannot write out-of-Realm history, report as none.
+            }
+            info.type = history_type;
+            info.version = history_schema_version;
+            // FIXME: It's ugly that we have to instantiate a new array here,
+            // but it isn't obvious that Group should have history as a member.
+            Array history{const_cast<Allocator&>(_impl::GroupFriend::get_alloc(m_group))};
+            history.init_from_ref(history_ref);
+            info.ref = history.write(out, deep, only_if_modified); // Throws
+        }
+        return info;
+    }
+
 private:
     const Group& m_group;
 };
@@ -814,6 +846,7 @@ void Group::write(std::ostream& out, int file_format_version, TableWriter& table
         // into a separate file.
         ref_type names_ref = table_writer.write_names(out_2);   // Throws
         ref_type tables_ref = table_writer.write_tables(out_2); // Throws
+        TableWriter::HistoryInfo history_info = table_writer.write_history(out_2); // Throws
         SlabAlloc new_alloc;
         new_alloc.attach_empty(); // Throws
         Array top(new_alloc);
@@ -847,6 +880,13 @@ void Group::write(std::ostream& out, int file_format_version, TableWriter& table
             top.add(RefOrTagged::make_ref(version_list_ref));  // Throws
             top.add(RefOrTagged::make_tagged(version_number)); // Throws
             top_size = 7;
+
+            if (history_info.type != Replication::hist_None) {
+                top.add(RefOrTagged::make_tagged(history_info.type));
+                top.add(RefOrTagged::make_ref(history_info.ref));
+                top.add(RefOrTagged::make_tagged(history_info.version));
+                top_size = 10;
+            }
         }
         top_ref = out_2.get_ref_of_next_array();
 

--- a/src/realm/group.cpp
+++ b/src/realm/group.cpp
@@ -715,9 +715,6 @@ public:
         bool only_if_modified = false;                              // Always
         ref_type history_ref = _impl::GroupFriend::get_history_ref(m_group);
         HistoryInfo info;
-        info.ref = 0;
-        info.type = 0;
-        info.version = 0;
         if (history_ref) {
             _impl::History::version_type version;
             int history_type, history_schema_version;

--- a/src/realm/group.hpp
+++ b/src/realm/group.hpp
@@ -1120,9 +1120,9 @@ inline void Group::set_history_parent(Array& history_root) noexcept
 class Group::TableWriter {
 public:
     struct HistoryInfo {
-        ref_type ref;
-        int type;
-        int version;
+        ref_type ref = 0;
+        int type = 0;
+        int version = 0;
     };
 
     virtual ref_type write_names(_impl::OutputStream&) = 0;

--- a/src/realm/group.hpp
+++ b/src/realm/group.hpp
@@ -1119,8 +1119,15 @@ inline void Group::set_history_parent(Array& history_root) noexcept
 
 class Group::TableWriter {
 public:
+    struct HistoryInfo {
+        ref_type ref;
+        int type;
+        int version;
+    };
+
     virtual ref_type write_names(_impl::OutputStream&) = 0;
     virtual ref_type write_tables(_impl::OutputStream&) = 0;
+    virtual HistoryInfo write_history(_impl::OutputStream&) = 0;
     virtual ~TableWriter() noexcept
     {
     }

--- a/src/realm/table.cpp
+++ b/src/realm/table.cpp
@@ -4956,6 +4956,15 @@ public:
         return ref;
     }
 
+    HistoryInfo write_history(_impl::OutputStream&) override
+    {
+        HistoryInfo info;
+        info.ref = 0;
+        info.type = Replication::hist_None;
+        info.version = 0;
+        return info;
+    }
+
 private:
     const Table& m_table;
     const StringData m_table_name;

--- a/src/realm/table.cpp
+++ b/src/realm/table.cpp
@@ -4958,11 +4958,7 @@ public:
 
     HistoryInfo write_history(_impl::OutputStream&) override
     {
-        HistoryInfo info;
-        info.ref = 0;
-        info.type = Replication::hist_None;
-        info.version = 0;
-        return info;
+        return HistoryInfo{}; // Empty history
     }
 
 private:


### PR DESCRIPTION
This should enable offline file-compaction of sync'ed Realms (both on client and server).