### PR TITLE
Restore -fvisibility-inlines-hidden for Cocoa builds

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,7 +16,7 @@
 
 ### Internals
 
-* None.
+* Restore -fvisibility-inlines-hidden for the binaries for Apple platforms.
 
 ----------------------------------------------
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -54,6 +54,8 @@ set(CMAKE_CXX_EXTENSIONS OFF)
 if(ANDROID)
     # TODO: Core APIs should always built for internal usage. But there seems to be issues with cocoa. Enable it only for Android for now.
     set(CMAKE_CXX_VISIBILITY_PRESET hidden)
+elseif(APPLE)
+    set(CMAKE_VISIBILITY_INLINES_HIDDEN 1)
 endif()
 
 # Set global warnings settings


### PR DESCRIPTION
This was incorrectly dropped in the switch to the cmake build.