### PR TITLE
Better error messaging when parsing queries which request args OOB

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ### Bugfixes
 
-* None.
+* More readable error message in the query parser when requesting an a bad argument.
 
 ### Breaking changes
 

--- a/src/realm/parser/query_builder.hpp
+++ b/src/realm/parser/query_builder.hpp
@@ -112,8 +112,15 @@ private:
 
     const ValueType& at(size_t index) const
     {
-        if (index >= m_count)
-            throw std::out_of_range("vector");
+        if (index >= m_count) {
+            std::string error_message;
+            if (m_count) {
+                error_message = util::format("Request for argument at index %1 but only %2 argument%3 provided", index, m_count, m_count == 1 ? " is" : "s are");
+            } else {
+                error_message = util::format("Request for argument at index %1 but no arguments are provided", index);
+            }
+            throw std::out_of_range(error_message);
+        }
         return m_arguments[index];
     }
 

--- a/test/test_parser.cpp
+++ b/test/test_parser.cpp
@@ -1133,8 +1133,14 @@ TEST(Parser_substitution)
     // double digit index
     verify_query_sub(test_context, t, "age == $10", args, num_args, 1);
 
+    std::string message;
     // referencing a parameter outside of the list size throws
-    CHECK_THROW_ANY(verify_query_sub(test_context, t, "age > $0", args, /*num_args*/ 0, 0));
+    CHECK_THROW_ANY_GET_MESSAGE(verify_query_sub(test_context, t, "age > $0", args, /*num_args*/ 0, 0), message);
+    CHECK_EQUAL(message, "Request for argument at index 0 but no arguments are provided");
+    CHECK_THROW_ANY_GET_MESSAGE(verify_query_sub(test_context, t, "age > $1", args, /*num_args*/ 1, 0), message);
+    CHECK_EQUAL(message, "Request for argument at index 1 but only 1 argument is provided");
+    CHECK_THROW_ANY_GET_MESSAGE(verify_query_sub(test_context, t, "age > $2", args, /*num_args*/ 2, 0), message);
+    CHECK_EQUAL(message, "Request for argument at index 2 but only 2 arguments are provided");
 
     // invalid types
     // int


### PR DESCRIPTION
Requested by https://github.com/realm/realm-js/issues/1808
The error message was probably supposed to be something like "vector index out of bounds" but somehow got lost in the move from object store to core.