### PR TITLE
Fixing a few compiler warnings.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@
 ### Internals
 
 * Restore -fvisibility-inlines-hidden for the binaries for Apple platforms.
+* Remove a few warnings at compile time.
 
 ----------------------------------------------
 

--- a/src/realm/index_string.cpp
+++ b/src/realm/index_string.cpp
@@ -515,7 +515,6 @@ void IndexArray::index_string_all(StringData value, IntegerColumn& result, Colum
     const char* header;
     uint_least8_t width = m_width;
     bool is_inner_node = m_is_inner_bptree_node;
-    typedef StringIndex::key_type key_type;
     size_t stringoffset = 0;
 
     // Create 4 byte index key

--- a/src/realm/util/file_mapper.cpp
+++ b/src/realm/util/file_mapper.cpp
@@ -374,10 +374,7 @@ void* mmap(FileDesc fd, size_t size, File::AccessMode access, size_t offset, con
     }
 }
 
-#ifdef _MSC_VER
-#pragma warning(disable : 4297) // throw in noexcept
-#endif
-void munmap(void* addr, size_t size) noexcept
+void munmap(void* addr, size_t size)
 {
 #if REALM_ENABLE_ENCRYPTION
     remove_mapping(addr, size);
@@ -394,9 +391,6 @@ void munmap(void* addr, size_t size) noexcept
     }
 #endif
 }
-#ifdef _MSC_VER
-#pragma warning(default : 4297)
-#endif
 
 void* mremap(FileDesc fd, size_t file_offset, void* old_addr, size_t old_size, File::AccessMode a, size_t new_size,
              const char* encryption_key)

--- a/src/realm/util/file_mapper.hpp
+++ b/src/realm/util/file_mapper.hpp
@@ -28,7 +28,7 @@ namespace realm {
 namespace util {
 
 void* mmap(FileDesc fd, size_t size, File::AccessMode access, size_t offset, const char* encryption_key);
-void munmap(void* addr, size_t size) noexcept;
+void munmap(void* addr, size_t size);
 void* mremap(FileDesc fd, size_t file_offset, void* old_addr, size_t old_size, File::AccessMode a, size_t new_size,
              const char* encryption_key);
 void msync(FileDesc fd, void* addr, size_t size);

--- a/test/test_lang_bind_helper.cpp
+++ b/test/test_lang_bind_helper.cpp
@@ -13564,7 +13564,7 @@ TEST(LangBindHelper_callWithLock)
         CHECK(realm_path.compare(path) == 0);
     };
 
-    SharedGroup::CallbackWithLock callback_not_called = [this, &path](const std::string&) {
+    SharedGroup::CallbackWithLock callback_not_called = [=](const std::string&) {
         CHECK(false);
     };
 


### PR DESCRIPTION
I have been observing a few warning when building core, and I just want to get rid of them.