### PR TITLE
Don't preserve non-sync history when writing to a new file

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,8 @@
 
 ### Bugfixes
 
-* None.
+* Don't write history information in `SharedGroup::compact()` for
+  non-syncronized Realms.
 
 ### Breaking changes
 

--- a/src/realm/group.cpp
+++ b/src/realm/group.cpp
@@ -724,8 +724,8 @@ public:
                                                              history_type,
                                                              history_schema_version);
             REALM_ASSERT(history_type != Replication::hist_None);
-            if (history_type == Replication::hist_OutOfRealm) {
-                return info; // Cannot write out-of-Realm history, report as none.
+            if (history_type != Replication::hist_SyncClient && history_type != Replication::hist_SyncServer) {
+                return info; // Only sync history should be preserved when writing to a new file
             }
             info.type = history_type;
             info.version = history_schema_version;


### PR DESCRIPTION
It will never actually be used and just pointlessly makes the file larger.

Motivated by https://github.com/realm/realm-cocoa/issues/5799.