### PR TITLE
Refactoring ArrayBlob

### DIFF
--- a/src/realm/array.cpp
+++ b/src/realm/array.cpp
@@ -600,6 +600,21 @@ void Array::add_positive_local(int64_t value)
 }
 */
 
+size_t Array::blob_size() const noexcept
+{
+    if (get_context_flag()) {
+        size_t total_size = 0;
+        for (size_t i = 0; i < size(); ++i) {
+            char* header = m_alloc.translate(Array::get_as_ref(i));
+            total_size += Array::get_size_from_header(header);
+        }
+        return total_size;
+    }
+    else {
+        return m_size;
+    }
+}
+
 void Array::insert(size_t ndx, int_fast64_t value)
 {
     REALM_ASSERT_DEBUG(ndx <= m_size);

--- a/src/realm/array.hpp
+++ b/src/realm/array.hpp
@@ -344,10 +344,15 @@ public:
     bool is_empty() const noexcept;
     Type get_type() const noexcept;
 
+
     static void add_to_column(IntegerColumn* column, int64_t value);
 
     void insert(size_t ndx, int_fast64_t value);
     void add(int_fast64_t value);
+
+    // Used from ArrayBlob
+    size_t blob_size() const noexcept;
+    ref_type blob_replace(size_t begin, size_t end, const char* data, size_t data_size, bool add_zero_term);
 
     /// This function is guaranteed to not throw if the current width is
     /// sufficient for the specified value (e.g. if you have called

--- a/src/realm/array_blob.hpp
+++ b/src/realm/array_blob.hpp
@@ -64,7 +64,6 @@ public:
     /// initialized to zero.
     static MemRef create_array(size_t init_size, Allocator&);
 
-    size_t blob_size() const noexcept;
 #ifdef REALM_DEBUG
     void verify() const;
     void to_dot(std::ostream&, StringData title = StringData()) const;

--- a/src/realm/array_blobs_big.cpp
+++ b/src/realm/array_blobs_big.cpp
@@ -58,7 +58,6 @@ void ArrayBigBlobs::set(size_t ndx, BinaryData value, bool add_zero_term)
     REALM_ASSERT_3(ndx, <, size());
     REALM_ASSERT_7(value.size(), ==, 0, ||, value.data(), !=, 0);
 
-    ArrayBlob blob(m_alloc);
     ref_type ref = get_as_ref(ndx);
 
     if (ref == 0 && value.is_null()) {
@@ -72,11 +71,25 @@ void ArrayBigBlobs::set(size_t ndx, BinaryData value, bool add_zero_term)
         return;
     }
     else if (ref != 0 && value.data() != nullptr) {
-        blob.init_from_ref(ref);
-        blob.set_parent(this, ndx);
-        ref_type new_ref = blob.replace(0, blob.blob_size(), value.data(), value.size(), add_zero_term); // Throws
-        if (new_ref != ref) {
-            Array::set_as_ref(ndx, new_ref);
+        char* header = m_alloc.translate(ref);
+        if (Array::get_context_flag_from_header(header)) {
+            Array arr(m_alloc);
+            arr.init_from_mem(MemRef(header, ref, m_alloc));
+            arr.set_parent(this, ndx);
+            ref_type new_ref =
+                arr.blob_replace(0, arr.blob_size(), value.data(), value.size(), add_zero_term); // Throws
+            if (new_ref != ref) {
+                Array::set_as_ref(ndx, new_ref);
+            }
+        }
+        else {
+            ArrayBlob blob(m_alloc);
+            blob.init_from_mem(MemRef(header, ref, m_alloc));
+            blob.set_parent(this, ndx);
+            ref_type new_ref = blob.replace(0, blob.blob_size(), value.data(), value.size(), add_zero_term); // Throws
+            if (new_ref != ref) {
+                Array::set_as_ref(ndx, new_ref);
+            }
         }
         return;
     }


### PR DESCRIPTION
Moving some code out of ArrayBlob that in reality should always be executed in context of an Array object. This also removed a cast that was really confusing.