### PR TITLE
Fsa/fragmentation test

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,26 @@
+# NEXT RELEASE
+
+### Bugfixes
+
+* None.
+
+### Breaking changes
+
+* None.
+
+### Enhancements
+
+* Improved scalability for in-file freelist handling. This reduces
+  commit overhead on large transactions.
+
+-----------
+
+### Internals
+
+* None.
+
+----------------------------------------------
+
 # 5.6.2 Release notes
 
 ### Bugfixes

--- a/src/realm/group_writer.cpp
+++ b/src/realm/group_writer.cpp
@@ -273,17 +273,27 @@ GroupWriter::MapWindow* GroupWriter::get_window(ref_type start_ref, size_t size)
     return m_map_windows[0].get();
 }
 
+#define REALM_ALLOC_DEBUG 0
+
 ref_type GroupWriter::write_group()
 {
 #if REALM_METRICS
     std::unique_ptr<MetricTimer> fsync_timer = Metrics::report_write_time(m_group);
 #endif // REALM_METRICS
 
+#if REALM_ALLOC_DEBUG
     std::cout << "Commit nr " << m_current_version << "   ( from " << m_readlock_version << " )" << std::endl;
     std::cout << "    In-file freelist before merge: " << m_free_positions.size();
+#endif
+    read_in_freelist();
     merge_free_space(); // Throws
+    // now recreate the freelist for allocation. Note that the blocks not free yet are left
+    // out and merged in later. No allocation can happen from these blocks anyway.
+    recreate_freelist();
+#if REALM_ALLOC_DEBUG
     std::cout << "    In-file freelist after merge:  " << m_free_positions.size() << std::endl;
     std::cout << "    Allocating file space for data:" << std::endl;
+#endif
     Array& top = m_group.m_top;
     bool is_shared = m_group.m_is_shared;
     REALM_ASSERT_3(m_free_positions.size(), ==, m_free_lengths.size());
@@ -320,8 +330,10 @@ ref_type GroupWriter::write_group()
         }
     }
 
+#if REALM_ALLOC_DEBUG
     std::cout << "    Allocating file space for freelists:" << std::endl;
-
+#endif
+    
     // We now have a bit of a chicken-and-egg problem. We need to write the
     // free-lists to the file, but the act of writing them will consume free
     // space, and thereby change the free-lists. To solve this problem, we
@@ -342,12 +354,14 @@ ref_type GroupWriter::write_group()
     m_free_lengths.copy_on_write();   // Throws
     if (is_shared)
         m_free_versions.copy_on_write();                                            // Throws
+#if REALM_ALLOC_DEBUG
     std::cout << "        In-mem freelist before consolidation: " << m_group.m_alloc.m_free_read_only.size();
     m_group.m_alloc.consolidate_free_read_only();                                   // Throws
     std::cout << "    In-mem freelist after consolidation:  " << m_group.m_alloc.m_free_read_only.size() << std::endl;
+#endif
     const SlabAlloc::chunks& new_free_space = m_group.m_alloc.get_free_read_only(); // Throws
     max_free_list_size += new_free_space.size();
-
+    max_free_list_size += m_not_free_in_file.size();
     // The final allocation of free space (i.e., the call to
     // reserve_free_space() below) may add extra entries to the free-lists.
     // We reserve room for the worst case scenario, which is as follows:
@@ -383,32 +397,26 @@ ref_type GroupWriter::write_group()
     // clobering the previous database version. Note, however, that this risk
     // would only have been present in the non-transactional case where there is
     // no version tracking on the free-space chunks.
+#if REALM_ALLOC_DEBUG
     std::cout << "    Freelist size after allocations: " << m_free_positions.size() << std::endl;
-    for (const auto& free_space : new_free_space) {
-        ref_type ref = free_space.ref;
-        size_t size = free_space.size;
-        // We always want to keep the list of free space in sorted order (by
-        // ascending position) to facilitate merge of adjacent segments. We
-        // can find the correct insert postion by binary search
-        size_t ndx = m_free_positions.lower_bound_int(ref);
-        if (ndx > 0) {
-            ref_type prev_ref = to_ref(m_free_positions.get(ndx - 1));
-            size_t prev_size = to_size_t(m_free_lengths.get(ndx - 1));
-            REALM_ASSERT_RELEASE_EX(prev_ref + prev_size <= ref, prev_ref, prev_size, ref, ndx, m_free_positions.size());
-        }
-        if (ndx < m_free_positions.size()) {
-            ref_type after_ref = to_ref(m_free_positions.get(ndx));
-            REALM_ASSERT_RELEASE_EX(ref + size <= after_ref, ref, size, after_ref, ndx, m_free_positions.size());
-        }
-        m_free_positions.insert(ndx, ref); // Throws
-        m_free_lengths.insert(ndx, size);  // Throws
+#endif
+    // do not preserve order of freelist, just append new blocks. Order will be restored
+    // anyway by the merge_free_lists in the start of next commit.
+    for (const auto& free_space : m_not_free_in_file) {
+        m_free_positions.add(free_space.ref);
+        m_free_lengths.add(free_space.size);
         if (is_shared)
-            m_free_versions.insert(ndx, m_current_version); // Throws
-        // Adjust reserve_ndx if necessary
-        if (ndx <= reserve_ndx)
-            ++reserve_ndx;
+            m_free_versions.add(free_space.released_at_version);
     }
+    for (const auto& free_space : new_free_space) {
+        m_free_positions.add(free_space.ref);
+        m_free_lengths.add(free_space.size);
+        if (is_shared)
+            m_free_versions.add(m_current_version);
+    }
+#if REALM_ALLOC_DEBUG
     std::cout << "    Freelist size after merge: " << m_free_positions.size() << "   freelist space required: " << max_free_space_needed << std::endl;
+#endif
     // Before we calculate the actual sizes of the free-list arrays, we must
     // make sure that the final adjustments of the free lists (i.e., the
     // deduction of the actually used space from the reserved chunk,) will not
@@ -506,52 +514,78 @@ size_t GroupWriter::get_free_space() {
     }
 }
 
-void GroupWriter::merge_free_space()
+void GroupWriter::read_in_freelist()
 {
     bool is_shared = m_group.m_is_shared;
+    size_t limit = m_free_lengths.size();
+    for (size_t idx = 0; idx < limit; ++idx) {
+        FreeSpaceEntry entry;
+        entry.ref = m_free_positions.get(idx);
+        entry.size = m_free_lengths.get(idx);
+        if (is_shared)
+            entry.released_at_version = m_free_versions.get(idx);
+        else
+            entry.released_at_version = 0;
 
-    if (m_free_lengths.is_empty())
-        return;
-
-    size_t n = m_free_lengths.size() - 1;
-    for (size_t i = 0; i < n; ++i) {
-        size_t i2 = i + 1;
-        size_t pos1 = to_size_t(m_free_positions.get(i));
-        size_t size1 = to_size_t(m_free_lengths.get(i));
-        size_t pos2 = to_size_t(m_free_positions.get(i2));
-        REALM_ASSERT_RELEASE_EX(pos1 + size1 <= pos2, pos1, size1, pos2);
-        if (pos2 == pos1 + size1) {
-            // If this is a shared db, we can only merge
-            // segments where no part is currently in use
-            if (is_shared) {
-                size_t v1 = to_size_t(m_free_versions.get(i));
-                if (v1 >= m_readlock_version)
-                    continue;
-                size_t v2 = to_size_t(m_free_versions.get(i2));
-                if (v2 >= m_readlock_version)
-                    continue;
-            }
-
-            // FIXME: Performing a series of calls to Array::erase() is
-            // unnecessarily expensive because we have to shift the contents
-            // above i2 multiple times in general. A more efficient way would be
-            // to use assigments only, and then make a final call to
-            // Array::truncate() when the new size is know.
-
-            // Merge
-            size_t size2 = to_size_t(m_free_lengths.get(i2));
-            size_t new_size = size1 + size2;
-            REALM_ASSERT_RELEASE_EX(new_size > size1 && new_size > size2, size1, size2, new_size);
-            m_free_lengths.set(i, new_size);
-            m_free_positions.erase(i2);
-            m_free_lengths.erase(i2);
-            if (is_shared)
-                m_free_versions.erase(i2);
-
-            --n;
-            --i; // May underflow, but that is ok
-        }
+        if (entry.released_at_version < m_readlock_version)
+            m_free_in_file.push_back(entry);
+        else
+            m_not_free_in_file.push_back(entry);
     }
+}
+
+void GroupWriter::recreate_freelist()
+{
+    bool is_shared = m_group.m_is_shared;
+    m_free_positions.clear();
+    m_free_lengths.clear();
+    if (is_shared)
+        m_free_versions.clear();
+    for (auto& e : m_free_in_file) {
+        m_free_positions.add(e.ref);
+        m_free_lengths.add(e.size);
+        if (is_shared)
+            m_free_versions.add(e.released_at_version);
+    }
+    m_free_in_file.clear();
+}
+
+void GroupWriter::sort_freelist()
+{
+    std::sort(begin(m_free_in_file), end(m_free_in_file), [](auto& a, auto& b) { return a.ref < b.ref; });
+}
+
+void GroupWriter::merge_adjacent_entries_in_freelist()
+{
+    if (m_free_in_file.size() == 0) return;
+    // Combine any adjacent chunks in the freelist
+    auto prev = m_free_in_file.begin();
+    for (auto it = m_free_in_file.begin() + 1; it != m_free_in_file.end(); ++it) {
+        if (prev->ref + prev->size != it->ref) {
+            prev = it;
+            continue;
+        }
+
+        prev->size += it->size;
+        it->size = 0;
+    }
+}
+
+void GroupWriter::filter_empty_entries_in_freelist()
+{
+    // Remove all of the now zero-size chunks from the free list
+    m_free_in_file.erase(
+        std::remove_if(begin(m_free_in_file), end(m_free_in_file), [](auto& chunk) { return chunk.size == 0; }),
+        end(m_free_in_file));
+
+
+}
+
+void GroupWriter::merge_free_space()
+{
+    sort_freelist();
+    merge_adjacent_entries_in_freelist();
+    filter_empty_entries_in_freelist();
 }
 
 
@@ -716,7 +750,9 @@ std::pair<size_t, size_t> GroupWriter::extend_free_space(size_t requested_size)
     // lock at this time, and in non-transactional mode it is the responsibility
     // of the user to ensure non-concurrent file mutation.
     m_alloc.resize_file(new_file_size); // Throws
+#if REALM_ALLOC_DEBUG
     std::cout << "        ** File extension to " << new_file_size << "     after request for " << requested_size << std::endl;
+#endif
     //    m_file_map.remap(m_alloc.get_file(), File::access_ReadWrite, new_file_size); // Throws
 
     size_t chunk_ndx = m_free_positions.size();

--- a/src/realm/group_writer.hpp
+++ b/src/realm/group_writer.hpp
@@ -89,6 +89,19 @@ private:
     uint64_t m_readlock_version;
     size_t m_alloc_position;
 
+    struct FreeSpaceEntry {
+        uint64_t ref;
+        uint64_t released_at_version;
+        uint32_t size;
+    };
+    std::vector<FreeSpaceEntry> m_free_in_file;
+    std::vector<FreeSpaceEntry> m_not_free_in_file;
+
+    void sort_freelist();
+    void merge_adjacent_entries_in_freelist();
+    void filter_empty_entries_in_freelist();
+    void read_in_freelist();
+    void recreate_freelist();
     // Currently cached memory mappings. We keep as many as 16 1MB windows
     // open for writing. The allocator will favor sequential allocation
     // from a modest number of windows, depending upon fragmentation, so

--- a/src/realm/group_writer.hpp
+++ b/src/realm/group_writer.hpp
@@ -92,7 +92,7 @@ private:
     struct FreeSpaceEntry {
         uint64_t ref;
         uint64_t released_at_version;
-        uint32_t size;
+        uint64_t size;
     };
     std::vector<FreeSpaceEntry> m_free_in_file;
     std::vector<FreeSpaceEntry> m_not_free_in_file;

--- a/test/test_lang_bind_helper.cpp
+++ b/test/test_lang_bind_helper.cpp
@@ -9044,13 +9044,15 @@ void multiple_trackers_writer_thread(std::string path)
     for (int i = 0; i < 10; ++i) {
         WriteTransaction wt(sg);
         auto tr = wt.get_table("table");
-        size_t idx = 1 + random.draw_int_mod(tr->size() - 1);
+        for (int k = 0; k < 2500000; ++k) {
+            size_t idx = 1 + random.draw_int_mod(tr->size() - 1);
 
-        if (tr->get_int(0, idx) == 42) {
-            // do nothing
-        }
-        else {
-            insert(tr, idx, 0);
+            if (tr->get_int(0, idx) == 42) {
+                // do nothing
+            }
+            else {
+                insert(tr, idx, 0x10000 + idx);
+            }
         }
         wt.commit();
         std::this_thread::yield();
@@ -9091,7 +9093,7 @@ void multiple_trackers_reader_thread(TestContext& test_context, std::string path
 } // anonymous namespace
 
 
-TEST(LangBindHelper_ImplicitTransactions_MultipleTrackers)
+ONLY(LangBindHelper_ImplicitTransactions_MultipleTrackers)
 {
     const int write_thread_count = 7;
     const int read_thread_count = 3; // must be less than 42 for correct operation
@@ -9144,6 +9146,10 @@ TEST(LangBindHelper_ImplicitTransactions_MultipleTrackers)
 
     // cleanup
     sg.end_read(); // FIXME: What cleanup? This seems out of place!?
+    WriteTransaction wt2(sg);
+    wt2.commit();
+    WriteTransaction wt3(sg);
+    wt3.commit();
 }
 
 #ifndef _WIN32

--- a/test/test_lang_bind_helper.cpp
+++ b/test/test_lang_bind_helper.cpp
@@ -9041,7 +9041,7 @@ void multiple_trackers_writer_thread(std::string path)
     Random random(random_int<unsigned long>());
     std::unique_ptr<Replication> hist(make_in_realm_history(path));
     SharedGroup sg(*hist, SharedGroupOptions(crypt_key()));
-    for (int i = 0; i < 10; ++i) {
+    for (int i = 0; i < 100; ++i) {
         WriteTransaction wt(sg);
         auto tr = wt.get_table("table");
         for (int k = 0; k < 2500000; ++k) {
@@ -9093,10 +9093,10 @@ void multiple_trackers_reader_thread(TestContext& test_context, std::string path
 } // anonymous namespace
 
 
-ONLY(LangBindHelper_ImplicitTransactions_MultipleTrackers)
+TEST(LangBindHelper_ImplicitTransactions_MultipleTrackers)
 {
-    const int write_thread_count = 7;
-    const int read_thread_count = 3; // must be less than 42 for correct operation
+    const int write_thread_count = 3;
+    const int read_thread_count = 1; // must be less than 42 for correct operation
 
     SHARED_GROUP_TEST_PATH(path);
 

--- a/test/test_lang_bind_helper.cpp
+++ b/test/test_lang_bind_helper.cpp
@@ -9041,18 +9041,16 @@ void multiple_trackers_writer_thread(std::string path)
     Random random(random_int<unsigned long>());
     std::unique_ptr<Replication> hist(make_in_realm_history(path));
     SharedGroup sg(*hist, SharedGroupOptions(crypt_key()));
-    for (int i = 0; i < 100; ++i) {
+    for (int i = 0; i < 10; ++i) {
         WriteTransaction wt(sg);
         auto tr = wt.get_table("table");
-        for (int k = 0; k < 2500000; ++k) {
-            size_t idx = 1 + random.draw_int_mod(tr->size() - 1);
+        size_t idx = 1 + random.draw_int_mod(tr->size() - 1);
 
-            if (tr->get_int(0, idx) == 42) {
-                // do nothing
-            }
-            else {
-                insert(tr, idx, 0x10000 + idx);
-            }
+        if (tr->get_int(0, idx) == 42) {
+            // do nothing
+        }
+        else {
+            insert(tr, idx, 0);
         }
         wt.commit();
         std::this_thread::yield();
@@ -9095,8 +9093,8 @@ void multiple_trackers_reader_thread(TestContext& test_context, std::string path
 
 TEST(LangBindHelper_ImplicitTransactions_MultipleTrackers)
 {
-    const int write_thread_count = 3;
-    const int read_thread_count = 1; // must be less than 42 for correct operation
+    const int write_thread_count = 7;
+    const int read_thread_count = 3; // must be less than 42 for correct operation
 
     SHARED_GROUP_TEST_PATH(path);
 
@@ -9146,10 +9144,6 @@ TEST(LangBindHelper_ImplicitTransactions_MultipleTrackers)
 
     // cleanup
     sg.end_read(); // FIXME: What cleanup? This seems out of place!?
-    WriteTransaction wt2(sg);
-    wt2.commit();
-    WriteTransaction wt3(sg);
-    wt3.commit();
 }
 
 #ifndef _WIN32


### PR DESCRIPTION
This PR improves the handling of freelists during commit, most notably by eliminating the use of Array:insert or Array::erase during freelist merges. This changes runtime cost from O(n^2), -- or worse --
to O(n log n).

It moves the freelist into std::vector's and uses the standard library for manipulation.

This also simplifies GroupWriter::write_group().
