### PR TITLE
Add Table::add_row_with_keys()

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,9 @@
 
 ### Enhancements
 
-* None.
+* Add Table::add_row_with_keys(), which allows
+  sync::create_object_with_primary_key() to avoid updating the index twice when
+  creating an object with a string primary key.
 
 -----------
 

--- a/src/realm/table.hpp
+++ b/src/realm/table.hpp
@@ -394,7 +394,8 @@ public:
 
     size_t add_empty_row(size_t num_rows = 1);
     void insert_empty_row(size_t row_ndx, size_t num_rows = 1);
-    size_t add_row_with_key(size_t col_ndx, int64_t key);
+    size_t add_row_with_key(size_t col_ndx, util::Optional<int64_t> key);
+    size_t add_row_with_keys(size_t col_1_ndx, int64_t key1, size_t col_2_ndx, StringData key2);
     void remove(size_t row_ndx);
     void remove_recursive(size_t row_ndx);
     void remove_last();

--- a/test/test_table.cpp
+++ b/test/test_table.cpp
@@ -8363,6 +8363,28 @@ TEST(Table_KeyRow)
     CHECK_EQUAL(i, 1);
 }
 
+TEST(Table_KeysRow)
+{
+    Table table;
+    table.add_column(type_Int, "int");
+    table.add_column(type_String, "string", true);
+    table.add_search_index(0);
+    table.add_search_index(1);
+
+    table.add_row_with_keys(0, 123, 1, "Hello, ");
+    table.add_row_with_keys(0, 456, 1, StringData());
+
+    size_t i = table.find_first_int(0, 123);
+    CHECK_EQUAL(i, 0);
+    i = table.find_first_int(0, 456);
+    CHECK_EQUAL(i, 1);
+
+    i = table.find_first_string(1, "Hello, ");
+    CHECK_EQUAL(i, 0);
+    i = table.find_first_string(1, StringData());
+    CHECK_EQUAL(i, 1);
+}
+
 TEST(Table_getLinkType)
 {
     Group g;


### PR DESCRIPTION
This just does the bare minimum to support the combinations needed for creating objects for sync without double-updating the sync object id or objectstore pk columns.