### PR TITLE
Add a fast-path for setting a link to its current value

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@
 * Add Table::add_row_with_keys(), which allows
   sync::create_object_with_primary_key() to avoid updating the index twice when
   creating an object with a string primary key.
+* Improved the performance of setting a link to its current value.
 
 -----------
 

--- a/src/realm/column_link.hpp
+++ b/src/realm/column_link.hpp
@@ -117,6 +117,8 @@ inline size_t LinkColumn::set_link(size_t row_ndx, size_t target_row_ndx)
 {
     int_fast64_t old_value = LinkColumnBase::get(row_ndx);
     size_t old_target_row_ndx = to_size_t(old_value) - size_t(1);
+    if (old_target_row_ndx == target_row_ndx)
+        return old_target_row_ndx; // Nothing to do
     if (old_value != 0)
         m_backlink_column->remove_one_backlink(old_target_row_ndx, row_ndx); // Throws
 

--- a/src/realm/table.cpp
+++ b/src/realm/table.cpp
@@ -3771,7 +3771,7 @@ void Table::set_link(size_t col_ndx, size_t row_ndx, size_t target_row_ndx, bool
                        is_default ? _impl::instr_SetDefault : _impl::instr_Set); // Throws
 
     size_t old_target_row_ndx = do_set_link(col_ndx, row_ndx, target_row_ndx); // Throws
-    if (old_target_row_ndx == realm::npos)
+    if (old_target_row_ndx == realm::npos || old_target_row_ndx == target_row_ndx)
         return;
 
     if (col.get_weak_links())


### PR DESCRIPTION
Removing and then re-adding the backlink is potentially very slow. It's unclear if this is actually the cause of the problem we're seeing, but it's an easy improvement.