### PR TITLE
Don't mark space as free in rollback() until we're actually done with it

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ### Bugfixes
 
-* None.
+* Fix a use-after-free when an observer is passed to rollback_and_continue_as_read().
 
 ### Breaking changes
 

--- a/src/realm/group_shared.hpp
+++ b/src/realm/group_shared.hpp
@@ -1009,10 +1009,6 @@ inline void SharedGroup::rollback_and_continue_as_read(O* observer)
     if (!hist)
         throw LogicError(LogicError::no_history);
 
-    // Mark all managed space (beyond the attached file) as free.
-    using gf = _impl::GroupFriend;
-    gf::reset_free_space_tracking(m_group); // Throws
-
     BinaryData uncommitted_changes = hist->get_uncommitted_changes();
 
     // FIXME: We are currently creating two transaction log parsers, one here,
@@ -1028,6 +1024,10 @@ inline void SharedGroup::rollback_and_continue_as_read(O* observer)
         parser.parse(reversed_in, *observer); // Throws
         observer->parse_complete();           // Throws
     }
+
+    // Mark all managed space (beyond the attached file) as free.
+    using gf = _impl::GroupFriend;
+    gf::reset_free_space_tracking(m_group); // Throws
 
     ref_type top_ref = m_read_lock.m_top_ref;
     size_t file_size = m_read_lock.m_file_size;


### PR DESCRIPTION
This appears to have been the cause of some longstanding rare test failures that turned into very consistent test failures with the allocator changes.