### PR TITLE
Support query limits

### DIFF
--- a/src/realm/handover_defs.hpp
+++ b/src/realm/handover_defs.hpp
@@ -60,6 +60,8 @@ struct QueryHandoverPatch {
 struct DescriptorOrderingHandoverPatch {
     std::vector<std::vector<std::vector<size_t>>> columns;
     std::vector<std::vector<bool>> ascending;
+    size_t limit;
+    bool has_limit;
 };
 
 struct TableViewHandoverPatch {

--- a/src/realm/parser/parser.cpp
+++ b/src/realm/parser/parser.cpp
@@ -25,6 +25,10 @@
 #include <pegtl/contrib/tracer.hpp>
 
 #include <realm/util/assert.hpp>
+#include <realm/util/optional.hpp>
+
+#include <realm/parser/parser_utils.hpp>
+
 // String tokens can't be followed by [A-z0-9_].
 #define string_token_t(s) seq< TAOCPP_PEGTL_ISTRING(s), not_at< identifier_other > >
 
@@ -154,7 +158,9 @@ struct sort_param : seq< star< blank >, descriptor_property, plus< blank >, sor<
 struct sort : seq< sort_prefix, sort_param, star< seq< one< ',' >, sort_param > >, one< ')' > > {};
 struct distinct_param : seq< star< blank >, descriptor_property, star< blank > > {};
 struct distinct : seq < distinct_prefix, distinct_param, star< seq< one< ',' >, distinct_param > >, one< ')' > > {};
-struct descriptor_ordering : sor< sort, distinct > {};
+struct limit_param : disable < int_num > {};
+struct limit : seq < string_token_t("limit"), star< blank >, one< '(' >, star< blank >, limit_param, star < blank >, one < ')' > > {};
+struct predicate_suffix_modifier : sor< sort, distinct, limit > {};
 
 struct string_oper : seq< sor< contains, begins, ends, like>, star< blank >, opt< case_insensitive > > {};
 // "=" is equality and since other operators can start with "=" we must check equal last
@@ -173,7 +179,7 @@ struct true_pred : string_token_t("truepredicate") {};
 struct false_pred : string_token_t("falsepredicate") {};
 
 struct not_pre : seq< sor< one< '!' >, string_token_t("not") > > {};
-struct atom_pred : seq< opt< not_pre >, pad< sor<group_pred, true_pred, false_pred, agg_shortcut_pred, comparison_pred>, blank >, star< pad< descriptor_ordering, blank > > > {};
+struct atom_pred : seq< opt< not_pre >, pad< sor<group_pred, true_pred, false_pred, agg_shortcut_pred, comparison_pred>, blank >, star< pad< predicate_suffix_modifier, blank > > > {};
 
 struct and_op : pad< sor< two< '&' >, string_token_t("and") >, blank > {};
 struct or_op : pad< sor< two< '|' >, string_token_t("or") >, blank > {};
@@ -196,6 +202,7 @@ struct ParserState
     std::string subquery_path, subquery_var;
     std::vector<Predicate> subqueries;
     Predicate::ComparisonType pending_comparison_type;
+    realm::util::Optional<size_t> limit_modifier;
 
     Predicate *current_group()
     {
@@ -470,6 +477,25 @@ template<> struct action< distinct >
     }
 };
 
+template<> struct action< limit_param >
+{
+    template< typename Input >
+    static bool apply(const Input& in, ParserState & state)
+    {
+        DEBUG_PRINT_TOKEN(in.string() + " LIMIT PARAM");
+        if (bool(state.limit_modifier)) {
+            // if we already have limit set we disallow a second LIMIT
+            return false;
+        }
+        try {
+            state.limit_modifier = realm::util::stot<size_t>(in.string());
+        } catch (...) {
+            return false;
+        }
+        return true;
+    }
+};
+
 template<> struct action< sub_path >
 {
     template< typename Input >
@@ -674,6 +700,9 @@ struct error_message_control : tao::pegtl::normal< Rule >
 
 template<>
 const std::string error_message_control< chars >::error_message = "Invalid characters in string constant.";
+
+template<>
+const std::string error_message_control< limit_param >::error_message = "Invalid Predicate. 'LIMIT' may only be used once and accepts one positive integer parameter eg: 'LIMIT(10)'";
 
 template< typename Rule>
 const std::string error_message_control< Rule >::error_message = "Invalid predicate.";

--- a/src/realm/parser/parser.hpp
+++ b/src/realm/parser/parser.hpp
@@ -23,6 +23,8 @@
 #include <string>
 #include <vector>
 
+#include <realm/util/optional.hpp>
+
 namespace realm {
 
 namespace parser {
@@ -120,6 +122,8 @@ struct DescriptorOrderingState
     std::vector<SingleOrderingState> orderings;
 };
 
+typedef realm::util::Optional<size_t> ParserLimit;
+
 struct ParserResult
 {
     ParserResult(Predicate p, DescriptorOrderingState o)
@@ -127,6 +131,7 @@ struct ParserResult
     , ordering(o) {}
     Predicate predicate;
     DescriptorOrderingState ordering;
+    ParserLimit limit;
 };
 
 ParserResult parse(const std::string &query);

--- a/src/realm/parser/parser.hpp
+++ b/src/realm/parser/parser.hpp
@@ -107,6 +107,8 @@ struct Predicate
     Predicate(Type t, bool n = false) : type(t), negate(n) {}
 };
 
+typedef realm::util::Optional<size_t> LimitDescriptor;
+
 struct DescriptorOrderingState
 {
     struct PropertyState
@@ -120,9 +122,8 @@ struct DescriptorOrderingState
         bool is_distinct;
     };
     std::vector<SingleOrderingState> orderings;
+    LimitDescriptor limit;
 };
-
-typedef realm::util::Optional<size_t> ParserLimit;
 
 struct ParserResult
 {
@@ -131,7 +132,6 @@ struct ParserResult
     , ordering(o) {}
     Predicate predicate;
     DescriptorOrderingState ordering;
-    ParserLimit limit;
 };
 
 ParserResult parse(const std::string &query);

--- a/src/realm/parser/query_builder.cpp
+++ b/src/realm/parser/query_builder.cpp
@@ -803,6 +803,9 @@ void apply_ordering(DescriptorOrdering& ordering, ConstTableRef target, const pa
             ordering.append_sort(SortDescriptor{*target.get(), property_indices, ascendings});
         }
     }
+    if (bool(state.limit)) {
+        ordering.set_limit(*state.limit);
+    }
 }
 
 void apply_ordering(DescriptorOrdering& ordering, ConstTableRef target, const parser::DescriptorOrderingState& state)
@@ -810,6 +813,7 @@ void apply_ordering(DescriptorOrdering& ordering, ConstTableRef target, const pa
     NoArguments args;
     apply_ordering(ordering, target, state, args);
 }
+
 
 } // namespace query_builder
 } // namespace realm

--- a/src/realm/views.hpp
+++ b/src/realm/views.hpp
@@ -116,6 +116,10 @@ public:
     bool descriptor_is_distinct(size_t index) const;
     bool is_empty() const { return m_descriptors.empty(); }
     size_t size() const { return m_descriptors.size(); }
+    bool has_limit() const { return bool(m_limit); }
+    size_t get_limit() const { return *m_limit; } // throws
+    bool value_exceeds_limit(size_t test_value) const { return bool(m_limit) && test_value > *m_limit; }
+    void set_limit(size_t new_limit) { m_limit = new_limit; }
     const CommonDescriptor* operator[](size_t ndx) const;
     bool will_apply_sort() const;
     bool will_apply_distinct() const;
@@ -127,6 +131,7 @@ public:
     static DescriptorOrdering create_from_and_consume_patch(HandoverPatch&, Table const&);
 
 private:
+    realm::util::Optional<size_t> m_limit;
     std::vector<std::unique_ptr<CommonDescriptor>> m_descriptors;
 };
 

--- a/test/test_parser.cpp
+++ b/test/test_parser.cpp
@@ -197,6 +197,16 @@ static std::vector<std::string> valid_queries = {
     "a == b and c==d sort(a ASC, b DESC) DISTINCT(p) sort(c ASC, d DESC) DISTINCT(q.r)",
     "a == b  sort(     a   ASC  ,  b DESC) and c==d   DISTINCT(   p )  sort(   c   ASC  ,  d   DESC  )  DISTINCT(   q.r ,   p)   ",
 
+    // limit
+    "a=b LIMIT(1)",
+    "a=b LIMIT ( 1 )",
+    "a=b LIMIT( 1234567890 )",
+    "a=b LIMIT(1) && c=d",
+    "a=b && c=d || e=f LIMIT(1)",
+    "a=b LIMIT(1) SORT(a ASC) DISTINCT(b)",
+    "a=b SORT(a ASC) LIMIT(1) DISTINCT(b)",
+    "a=b SORT(a ASC) DISTINCT(b) LIMIT(1)",
+
     // subquery expression
     "SUBQUERY(items, $x, $x.name == 'Tom').@size > 0",
     "SUBQUERY(items, $x, $x.name == 'Tom').@count > 0",
@@ -279,6 +289,22 @@ static std::vector<std::string> invalid_queries = {
     "a=b DISTINCT(p", // no braces
     "a=b sort(p.q DESC a ASC)", // missing comma
     "a=b DISTINCT(p q)", // missing comma
+
+    // limit
+    "LIMIT(1)", // no query conditions
+    "a=b LIMIT", // no params
+    "a=b LIMIT()", // no params
+    "a=b LIMIT(2", // missing end paren
+    "a=b LIMIT2)", // missing open paren
+    "a=b LIMIT(-1)", // negative limit
+    "a=b LIMIT(2.7)", // input must be an integer
+    "a=b LIMIT(0xFFEE)", // input must be an integer
+    "a=b LIMIT(word)", // non numeric limit
+    "a=b LIMIT(11asdf)", // non numeric limit
+    "a=b LIMIT(1, 1)", // only accept one input
+    "a=b LIMIT(1) b=c LIMIT(2)", // only one limit allowed
+    "a=b LIMIT(1) LIMIT(2)", // only one limit allowed
+    "LIMIT(1) a=b LIMIT(2)", // only one limit allowed
 
     // subquery
     "SUBQUERY(items, $x, $x.name == 'Tom') > 0", // missing .@count


### PR DESCRIPTION
This allows syntax like "LIMIT(10)" on queries.
It reuses the `DescriptorOrdering` class, so simply upgrading sync and the js binding will add the enhancement without needing anything extra. Though, other bindings will need to create a new API to hook into the `DescriptorOrdering::set_limit()` function to use it.

There could be some unexpected behaviour in the current implementation if the table being queried on  has links to itself. Currently the limit could be disrespected and we should decide what should really happen in this case.

Also unknown, is how consumers want to retrieve the total number of results if the limit was not applied or if that information is even necessary.