### PR TITLE
Add build-time option REALM_DEBUG_EXTREME

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -86,6 +86,8 @@ if(CMAKE_SYSTEM_NAME MATCHES "^Windows")
     add_definitions(-D_SCL_SECURE_NO_WARNINGS -DWIN32_LEAN_AND_MEAN)
 endif()
 
+option(REALM_DEBUG_EXTREME "Enable extreme debug runtime checks in debug builds (debug iterators, stack checks, etc.)" OFF)
+
 if(MSVC)
     add_compile_options(
         /MP # Enable multi-processor compilation
@@ -103,7 +105,7 @@ if(MSVC)
 
             # Disable runtime stack bound checks, because these slow down unit tests
             # disproportionately.
-            if(${flag_var} MATCHES "/RTC")
+            if(NOT REALM_DEBUG_EXTREME AND ${flag_var} MATCHES "/RTC")
                 string(REGEX REPLACE "/RTC(su|[1su])" "" ${flag_var} "${${flag_var}}")
             endif()
         endforeach()

--- a/src/realm/CMakeLists.txt
+++ b/src/realm/CMakeLists.txt
@@ -285,6 +285,35 @@ target_compile_definitions(Core PUBLIC
   "$<$<CXX_COMPILER_ID:MSVC>:_SCL_SECURE_NO_WARNINGS>"
 )
 
+if(REALM_DEBUG_EXTREME)
+    if("${CMAKE_CXX_COMPILER_ID}" STREQUAL "MSVC")
+        target_compile_definitions(CoreObjects PRIVATE
+            "_ITERATOR_DEBUG_LEVEL=2"
+        )
+        target_compile_definitions(Core PUBLIC
+            "_ITERATOR_DEBUG_LEVEL=2"
+        )
+    elseif("${CMAKE_CXX_COMPILER_ID}" STREQUAL "GNU")
+        target_compile_definitions(CoreObjects PRIVATE
+            "_GLIBCXX_DEBUG"
+            "_GLIBCXX_SANITIZE_VECTOR"
+        )
+        target_compile_definitions(Core PUBLIC
+            "_GLIBCXX_DEBUG"
+            "_GLIBCXX_SANITIZE_VECTOR"
+        )
+    elseif("${CMAKE_CXX_COMPILER_ID}" STREQUAL "Clang")
+        target_compile_definitions(CoreObjects PRIVATE
+            "_LIBCPP_DEBUG=1"
+        )
+        target_compile_definitions(Core PUBLIC
+            "_LIBCPP_DEBUG=1"
+        )
+    else()
+        message(WARNING "No extreme debug flags for compiler ID '${CMAKE_COMPILER_ID}'.")
+    endif()
+endif(REALM_DEBUG_EXTREME)
+
 # GCC 4.9 does not adhere to the C++11 ABI for std::string. This communicates
 # to dependencies built with newer compilers that the old ABI should be used.
 # Note: We cannot use generator expressions to perform this check, because it


### PR DESCRIPTION
This turns on iterator debugging (and other debug checks) for Core and for dependents on Core.

Supported compilers are GCC, Clang and MSVC.

Invoke CMake like this:

```
$ cmake <path> -DCMAKE_BUILD_TYPE=Debug -DREALM_DEBUG_EXTREME=ON
```

Users of the resulting library will also be built with extreme debugging.