### PR TITLE
Fix undefined behaviour in the parser when serialising some unprintable chars

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,8 @@
 
 ### Bugfixes
 
-* None.
+* Fix a crash on some platforms when using the query parser to look for a string or binary
+  object which has a certain combination of non-printable characters.
 
 ### Breaking changes
 

--- a/src/realm/util/serializer.cpp
+++ b/src/realm/util/serializer.cpp
@@ -57,9 +57,13 @@ std::string print_value<>(realm::null)
 }
 
 bool contains_invalids(StringData data) {
+    // the custom whitelist is different from std::isprint because it doesn't include quotations
     const static std::string whitelist = " {|}~:;<=>?@!#$%&()*+,-./[]^_`";
     for (size_t i = 0; i < data.size(); ++i) {
-        if (!std::isalnum(data.data()[i]) && whitelist.find(data.data()[i]) == std::string::npos) {
+        using unsigned_char_t = unsigned char;
+        char c = data.data()[i];
+        // std::isalnum takes an int, but is undefined for negative values so we must pass an unsigned char
+        if (!std::isalnum(unsigned_char_t(c)) && whitelist.find(c) == std::string::npos) {
             return true;
         }
     }


### PR DESCRIPTION
Found by @simonask in https://github.com/realm/realm-core-private/pull/181 in a Visual Studio debug build. This problem does not manifest on my dev system (mac/clang++) and since the "undefined behaviour" is up to the implementation of `std::isalnum` I would hope that release builds do the sane thing for negative inputs and just return false. So I'm not sure this is ever a problem in the wild.

I also found that the test to exercise this part of serialisation was incorrect due to an argument mixup and C++ automatically type converting them :(