### PR TITLE
Update the devtoolset from 3 to 6

### DIFF
--- a/packaging/centos-6/build-image/Dockerfile
+++ b/packaging/centos-6/build-image/Dockerfile
@@ -13,9 +13,9 @@ RUN touch /var/lib/rpm/* \
         which \
         chrpath \
         openssl-devel \
-        devtoolset-3-gcc \
-        devtoolset-3-gcc-c++ \
-        devtoolset-3-binutils \
+        devtoolset-6-gcc \
+        devtoolset-6-gcc-c++ \
+        devtoolset-6-binutils \
     && yum clean all
 
 # Install CMake

--- a/packaging/centos-6/build-image/inside/docker-entrypoint.sh
+++ b/packaging/centos-6/build-image/inside/docker-entrypoint.sh
@@ -1,3 +1,3 @@
 #!/bin/bash
 
-scl enable devtoolset-3 -- "$@"
+scl enable devtoolset-6 -- "$@"

--- a/packaging/centos-7/build-image/Dockerfile
+++ b/packaging/centos-7/build-image/Dockerfile
@@ -8,9 +8,9 @@ RUN yum -y install \
         which \
         chrpath \
         openssl-devel \
-        devtoolset-3-gcc \
-        devtoolset-3-gcc-c++ \
-        devtoolset-3-binutils
+        devtoolset-6-gcc \
+        devtoolset-6-gcc-c++ \
+        devtoolset-6-binutils
 
 ENTRYPOINT ["/bin/bash", "/inside/docker-entrypoint.sh"]
 CMD ["/bin/bash", "/inside/build-package"]

--- a/packaging/centos-7/build-image/inside/docker-entrypoint.sh
+++ b/packaging/centos-7/build-image/inside/docker-entrypoint.sh
@@ -1,3 +1,3 @@
 #!/bin/bash
 
-scl enable devtoolset-3 -- "$@"
+scl enable devtoolset-6 -- "$@"

--- a/packaging/generic/build-image/Dockerfile
+++ b/packaging/generic/build-image/Dockerfile
@@ -8,9 +8,9 @@ FROM ci/realm-core:generic-base
 RUN touch /var/lib/rpm/* \
     && yum -y install \
         chrpath \
-        devtoolset-3-binutils \
-        devtoolset-3-gcc \
-        devtoolset-3-gcc-c++ \
+        devtoolset-6-binutils \
+        devtoolset-6-gcc \
+        devtoolset-6-gcc-c++ \
         git \
         openssl-devel \
         unzip \

--- a/packaging/generic/build-image/inside/docker-entrypoint.sh
+++ b/packaging/generic/build-image/inside/docker-entrypoint.sh
@@ -1,3 +1,3 @@
 #!/bin/bash
 
-scl enable devtoolset-3 -- "$@"
+scl enable devtoolset-6 -- "$@"


### PR DESCRIPTION
Centos6 removed the packages for devtoolsets 3, 4 and 5
devtoolset-6 still uses glibc 2.12 and ships with gcc 6.3