### PR TITLE
Record backtrace when throwing certain exceptions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,7 +16,11 @@
 
 ### Internals
 
-* None.
+* Most exception types now report the stack trace of the point where they were
+  thrown in their `what()` message. This is intended to aid debugging.
+  Additionally, assertion failures on Linux now report their stack traces as
+  well, similar to Apple platforms. Recording stack traces is only supported on
+  Linux (non-Android) and Apple platforms for now.
 
 ----------------------------------------------
 

--- a/src/realm/CMakeLists.txt
+++ b/src/realm/CMakeLists.txt
@@ -43,6 +43,7 @@ set(REALM_SOURCES
     table.cpp
     table_view.cpp
     unicode.cpp
+    util/backtrace.cpp
     util/base64.cpp
     util/basic_system_errors.cpp
     util/encrypted_file_mapping.cpp
@@ -169,6 +170,7 @@ set(REALM_INSTALL_IMPL_HEADERS
 set(REALM_INSTALL_UTIL_HEADERS
     util/any.hpp
     util/assert.hpp
+    util/backtrace.hpp
     util/base64.hpp
     util/basic_system_errors.hpp
     util/bind_ptr.hpp

--- a/src/realm/exceptions.cpp
+++ b/src/realm/exceptions.cpp
@@ -19,11 +19,35 @@
 #include <realm/exceptions.hpp>
 #include <realm/version.hpp>
 
+#include <sstream>
+
 using namespace realm;
+using namespace realm::_impl;
+
+const char* ExceptionWithBacktraceBase::materialize_message() const noexcept
+{
+    if (m_message_with_backtrace) {
+        return m_message_with_backtrace->c_str();
+    }
+
+    const char* msg = message();
+
+    try {
+        std::stringstream ss;
+        ss << msg << "\n";
+        ss << "Exception backtrace:\n";
+        m_backtrace.print(ss);
+        m_message_with_backtrace = ss.str();
+        return m_message_with_backtrace->c_str();
+    }
+    catch (...) {
+        return msg;
+    }
+}
 
 // LCOV_EXCL_START (LogicError is not a part of the public API, so code may never
 // rely on the contents of these strings, as they are deliberately unspecified.)
-const char* LogicError::what() const noexcept
+const char* LogicError::message() const noexcept
 {
     switch (m_kind) {
         case string_too_big:

--- a/src/realm/exceptions.hpp
+++ b/src/realm/exceptions.hpp
@@ -69,9 +69,6 @@ public:
     {
         return Base::what();
     }
-
-private:
-    util::Backtrace m_backtrace;
 };
 
 /// Thrown by various functions to indicate that a specified table does not

--- a/src/realm/exceptions.hpp
+++ b/src/realm/exceptions.hpp
@@ -32,9 +32,14 @@ class ExceptionWithBacktraceBase {
 public:
     ExceptionWithBacktraceBase()
         : m_backtrace(util::Backtrace::capture())
-    {}
-    const util::Backtrace& backtrace() const noexcept { return m_backtrace; }
+    {
+    }
+    const util::Backtrace& backtrace() const noexcept
+    {
+        return m_backtrace;
+    }
     virtual const char* message() const noexcept = 0;
+
 protected:
     util::Backtrace m_backtrace;
     mutable util::Optional<std::string> m_message_with_backtrace;
@@ -112,7 +117,8 @@ public:
     inline ExceptionWithBacktrace(Args&&... args)
         : Base(std::forward<Args>(args)...)
         , _impl::ExceptionWithBacktraceBase() // backtrace captured here
-    {}
+    {
+    }
 
     /// Return the message of the exception, including the backtrace of where
     /// the exception was thrown.
@@ -400,7 +406,7 @@ inline OutOfDiskSpace::OutOfDiskSpace(const std::string& msg)
 }
 
 inline SerialisationError::SerialisationError(const std::string& msg)
-: ExceptionWithBacktrace<std::runtime_error>(msg)
+    : ExceptionWithBacktrace<std::runtime_error>(msg)
 {
 }
 

--- a/src/realm/exceptions.hpp
+++ b/src/realm/exceptions.hpp
@@ -58,14 +58,14 @@ public:
 
     /// Return the message of the exception, including the backtrace of where
     /// the exception was thrown.
-    const char* what() const noexcept override final
+    const char* what() const noexcept final
     {
         return materialize_message();
     }
 
     /// Return the message of the exception without the backtrace. The default
     /// implementation calls `Base::what()`.
-    virtual const char* message() const noexcept override
+    const char* message() const noexcept override
     {
         return Base::what();
     }

--- a/src/realm/exceptions.hpp
+++ b/src/realm/exceptions.hpp
@@ -45,8 +45,66 @@ protected:
     const char* materialize_message() const noexcept;
 };
 
-}
+} // namespace _impl
 
+
+/// Base class for exceptions that record a stack trace of where they were
+/// thrown.
+///
+/// The template argument is expected to be an exception type conforming to the
+/// standard library exception API (`std::exception` and friends).
+///
+/// It is possible to opt in to exception backtraces in two ways, (a) as part of
+/// the exception type, in which case the backtrace will always be included for
+/// all exceptions of that type, or (b) at the call-site of an opaque exception
+/// type, in which case it is up to the throw-site to decide whether a backtrace
+/// should be included.
+///
+/// Example (a):
+/// ```
+///     class MyException : ExceptionWithBacktrace<std::exception> {
+///     public:
+///         const char* message() const noexcept override
+///         {
+///             return "MyException error message";
+///         }
+///     };
+///
+///     ...
+///
+///     try {
+///         throw MyException{};
+///     }
+///     catch (const MyException& ex) {
+///         // Print the backtrace without the message:
+///         std::cerr << ex.backtrace() << "\n";
+///         // Print the exception message and the backtrace:
+///         std::cerr << ex.what() << "\n";
+///         // Print the exception message without the backtrace:
+///         std::cerr << ex.message() << "\n";
+///     }
+/// ```
+///
+/// Example (b):
+/// ```
+///     class MyException : std::exception {
+///     public:
+///         const char* what() const noexcept override
+///         {
+///             return "MyException error message";
+///         }
+///     };
+///
+///     ...
+///
+///     try {
+///         throw ExceptionWithBacktrace<MyException>{};
+///     }
+///     catch (const MyException& ex) {
+///         // Print the exception message and the backtrace:
+///         std::cerr << ex.what() << "\n";
+///     }
+/// ```
 template <class Base = std::runtime_error>
 class ExceptionWithBacktrace : public Base, public _impl::ExceptionWithBacktraceBase {
 public:

--- a/src/realm/util/backtrace.cpp
+++ b/src/realm/util/backtrace.cpp
@@ -41,12 +41,14 @@ Backtrace::~Backtrace()
     std::free(m_memory);
 }
 
-Backtrace::Backtrace(Backtrace&& other) noexcept : Backtrace()
+Backtrace::Backtrace(Backtrace&& other) noexcept
+    : Backtrace()
 {
     *this = std::move(other);
 }
 
-Backtrace::Backtrace(const Backtrace& other) noexcept : Backtrace()
+Backtrace::Backtrace(const Backtrace& other) noexcept
+    : Backtrace()
 {
     *this = other;
 }

--- a/src/realm/util/backtrace.cpp
+++ b/src/realm/util/backtrace.cpp
@@ -84,7 +84,12 @@ Backtrace& Backtrace::operator=(const Backtrace& other) noexcept
     char* p = static_cast<char*>(new_memory) + sizeof(char*) * m_len;
     for (size_t i = 0; i < m_len; ++i) {
         *(new_strs++) = p;
-        p = ::stpcpy(p, other.m_strs[i]) + 1;
+        // FIXME: stpcpy() is not supported on Android, so we gotta manually
+        // calculate the end of the destination here.
+        size_t len = std::strlen(other.m_strs[i]);
+        std::memcpy(p, other.m_strs[i], len);
+        p[len] = '\0';
+        p += len + 1;
     }
     std::free(m_memory);
     m_memory = new_memory;

--- a/src/realm/util/backtrace.cpp
+++ b/src/realm/util/backtrace.cpp
@@ -112,7 +112,7 @@ Backtrace Backtrace::capture() noexcept
         // Translate the backtrace to symbols (and exclude the call to the
         // capture() function from the trace).
         --frames;
-        void* memory = ::backtrace_symbols(callstack + 1, frames );
+        void* memory = ::backtrace_symbols(callstack + 1, frames);
         if (REALM_UNLIKELY(memory == nullptr)) {
             return Backtrace(nullptr, &g_backtrace_symbolicate_error, 1);
         }

--- a/src/realm/util/backtrace.cpp
+++ b/src/realm/util/backtrace.cpp
@@ -68,7 +68,7 @@ Backtrace& Backtrace::operator=(const Backtrace& other) noexcept
     m_len = other.m_len;
     size_t required_memory = sizeof(char*) * m_len;
     for (size_t i = 0; i < m_len; ++i) {
-        required_memory += std::strlen(m_strs[i]) + 1;
+        required_memory += std::strlen(other.m_strs[i]) + 1;
     }
 
     void* new_memory = std::malloc(required_memory);
@@ -84,7 +84,7 @@ Backtrace& Backtrace::operator=(const Backtrace& other) noexcept
     char* p = static_cast<char*>(new_memory) + sizeof(char*) * m_len;
     for (size_t i = 0; i < m_len; ++i) {
         *(new_strs++) = p;
-        p = std::strcpy(p, other.m_strs[i]);
+        p = ::stpcpy(p, other.m_strs[i]) + 1;
     }
     std::free(m_memory);
     m_memory = new_memory;
@@ -126,7 +126,7 @@ Backtrace Backtrace::capture() noexcept
 void Backtrace::print(std::ostream& os) const
 {
     for (size_t i = 0; i < m_len; ++i) {
-        os << "[#" << i << "]: " << m_strs[i];
+        os << m_strs[i];
         if (i + 1 != m_len) {
             os << "\n";
         }

--- a/src/realm/util/backtrace.cpp
+++ b/src/realm/util/backtrace.cpp
@@ -1,0 +1,65 @@
+#include <realm/util/backtrace.hpp>
+#include <realm/util/features.h>
+
+#include <ostream>
+
+#if REALM_PLATFORM_APPLE || (defined(__linux__) && !REALM_ANDROID)
+#include <execinfo.h>
+#include <cstdlib>
+#include <cstring>
+#endif
+
+using namespace realm::util;
+
+static const size_t g_backtrace_depth = 128;
+static const char* g_backtrace_error = "<error getting backtrace>";
+static const char* g_backtrace_symbolicate_error = "<error symbolicating backtrace>";
+static const char* g_backtrace_unsupported_error = "<backtrace unsupported on this platform>";
+
+Backtrace::~Backtrace()
+{
+    // std::free(nullptr) is guaranteed to silently do nothing.
+    std::free(const_cast<char**>(m_strs));
+}
+
+
+Backtrace Backtrace::capture() noexcept
+{
+#if REALM_PLATFORM_APPLE || (defined(__linux__) && !REALM_ANDROID)
+    static_cast<void>(g_backtrace_unsupported_error);
+    void* callstack[g_backtrace_depth];
+    int frames = ::backtrace(callstack, g_backtrace_depth);
+    const char** strs;
+    if (REALM_UNLIKELY(frames <= 0)) {
+        strs = static_cast<const char**>(std::malloc(sizeof(char*)));
+        strs[0] = g_backtrace_error;
+        frames = 1;
+    }
+    else {
+        strs = const_cast<const char**>(::backtrace_symbols(callstack, frames));
+        if (REALM_UNLIKELY(strs == nullptr)) {
+            strs = static_cast<const char**>(std::malloc(sizeof(char*)));
+            strs[0] = g_backtrace_symbolicate_error;
+            frames = 1;
+        }
+    }
+    return Backtrace{strs, size_t(frames)};
+#else
+    static_cast<void>(g_backtrace_error);
+    static_cast<void>(g_backtrace_symbolicate_error);
+    const char** strs = static_cast<const char**>(std::malloc(sizeof(char*)));
+    strs[0] = g_backtrace_unsupported_error;
+    return Backtrace{strs, 1};
+#endif
+}
+
+
+void Backtrace::print(std::ostream& os) const
+{
+    for (size_t i = 0; i < m_len; ++i) {
+        os << "[#" << i << "]: " << m_strs[i];
+        if (i + 1 != m_len) {
+            os << "\n";
+        }
+    }
+}

--- a/src/realm/util/backtrace.cpp
+++ b/src/realm/util/backtrace.cpp
@@ -1,25 +1,96 @@
+/*************************************************************************
+ *
+ * Copyright 2018 Realm Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ **************************************************************************/
+
 #include <realm/util/backtrace.hpp>
 #include <realm/util/features.h>
 
 #include <ostream>
+#include <cstdlib>
+#include <cstring>
 
 #if REALM_PLATFORM_APPLE || (defined(__linux__) && !REALM_ANDROID)
 #include <execinfo.h>
-#include <cstdlib>
-#include <cstring>
 #endif
 
 using namespace realm::util;
 
 static const size_t g_backtrace_depth = 128;
-static const char* g_backtrace_error = "<error getting backtrace>";
+static const char* g_backtrace_error = "<error calculating backtrace>";
+static const char* g_backtrace_alloc_error = "<error allocating backtrace>";
 static const char* g_backtrace_symbolicate_error = "<error symbolicating backtrace>";
-static const char* g_backtrace_unsupported_error = "<backtrace unsupported on this platform>";
+static const char* g_backtrace_unsupported_error = "<backtrace not supported on this platform>";
 
 Backtrace::~Backtrace()
 {
     // std::free(nullptr) is guaranteed to silently do nothing.
-    std::free(const_cast<char**>(m_strs));
+    std::free(m_memory);
+}
+
+Backtrace::Backtrace(Backtrace&& other) noexcept : Backtrace()
+{
+    *this = std::move(other);
+}
+
+Backtrace::Backtrace(const Backtrace& other) noexcept : Backtrace()
+{
+    *this = other;
+}
+
+Backtrace& Backtrace::operator=(Backtrace&& other) noexcept
+{
+    std::swap(m_memory, other.m_memory);
+    std::swap(m_strs, other.m_strs);
+    std::swap(m_len, other.m_len);
+    return *this;
+}
+
+Backtrace& Backtrace::operator=(const Backtrace& other) noexcept
+{
+    // For this class to work as a member of an exception, it has to define a
+    // copy-constructor, because std::current_exception() may copy the exception
+    // object.
+
+    m_len = other.m_len;
+    size_t required_memory = sizeof(char*) * m_len;
+    for (size_t i = 0; i < m_len; ++i) {
+        required_memory += std::strlen(m_strs[i]) + 1;
+    }
+
+    void* new_memory = std::malloc(required_memory);
+    if (new_memory == nullptr) {
+        std::free(m_memory);
+        m_memory = nullptr;
+        m_strs = &g_backtrace_alloc_error;
+        m_len = 1;
+        return *this;
+    }
+
+    char** new_strs = static_cast<char**>(new_memory);
+    char* p = static_cast<char*>(new_memory) + sizeof(char*) * m_len;
+    for (size_t i = 0; i < m_len; ++i) {
+        *(new_strs++) = p;
+        p = std::strcpy(p, other.m_strs[i]);
+    }
+    std::free(m_memory);
+    m_memory = new_memory;
+    m_strs = static_cast<char* const*>(m_memory);
+    m_len = other.m_len;
+    return *this;
 }
 
 
@@ -29,27 +100,25 @@ Backtrace Backtrace::capture() noexcept
     static_cast<void>(g_backtrace_unsupported_error);
     void* callstack[g_backtrace_depth];
     int frames = ::backtrace(callstack, g_backtrace_depth);
-    const char** strs;
-    if (REALM_UNLIKELY(frames <= 0)) {
-        strs = static_cast<const char**>(std::malloc(sizeof(char*)));
-        strs[0] = g_backtrace_error;
-        frames = 1;
+    if (REALM_UNLIKELY(frames <= 1)) {
+        return Backtrace(nullptr, &g_backtrace_error, 1);
     }
     else {
-        strs = const_cast<const char**>(::backtrace_symbols(callstack, frames));
-        if (REALM_UNLIKELY(strs == nullptr)) {
-            strs = static_cast<const char**>(std::malloc(sizeof(char*)));
-            strs[0] = g_backtrace_symbolicate_error;
-            frames = 1;
+        // Translate the backtrace to symbols (and exclude the call to the
+        // capture() function from the trace).
+        --frames;
+        void* memory = ::backtrace_symbols(callstack + 1, frames );
+        if (REALM_UNLIKELY(memory == nullptr)) {
+            return Backtrace(nullptr, &g_backtrace_symbolicate_error, 1);
+        }
+        else {
+            return Backtrace{memory, size_t(frames)};
         }
     }
-    return Backtrace{strs, size_t(frames)};
 #else
     static_cast<void>(g_backtrace_error);
     static_cast<void>(g_backtrace_symbolicate_error);
-    const char** strs = static_cast<const char**>(std::malloc(sizeof(char*)));
-    strs[0] = g_backtrace_unsupported_error;
-    return Backtrace{strs, 1};
+    return Backtrace(nullptr, &g_backtrace_unsupported_error, 1);
 #endif
 }
 

--- a/src/realm/util/backtrace.hpp
+++ b/src/realm/util/backtrace.hpp
@@ -43,7 +43,9 @@ struct Backtrace {
     void print(std::ostream&) const;
 
     /// Construct an empty stack trace.
-    Backtrace() noexcept {}
+    Backtrace() noexcept
+    {
+    }
 
     /// Move constructor. This operation cannot fail.
     Backtrace(Backtrace&&) noexcept;
@@ -66,12 +68,14 @@ private:
         : m_memory(memory)
         , m_strs(strs)
         , m_len(len)
-    {}
+    {
+    }
     Backtrace(void* memory, size_t len)
         : m_memory(memory)
         , m_strs(static_cast<char* const*>(memory))
         , m_len(len)
-    {}
+    {
+    }
 
     // m_memory is a pointer to the memory block returned by
     // `backtrace_symbols()`. It is usually equal to `m_strs`, except in the

--- a/src/realm/util/backtrace.hpp
+++ b/src/realm/util/backtrace.hpp
@@ -26,15 +26,39 @@
 namespace realm {
 namespace util {
 
+/// Backtrace encapsulates a stack trace, usually as captured by `backtrace()`
+/// and `backtrace_symbols()` (or platform-specific equivalents).
 struct Backtrace {
+    /// Capture a symbolicated stack trace, excluding the call to `capture()`
+    /// itself. If any error occurs while capturing the stack trace or
+    /// translating symbol names, a `Backtrace` object is returned containing a
+    /// single line describing the error.
+    ///
+    /// This function only allocates memory as part of calling
+    /// `backtrace_symbols()` (or the current platform's equivalent).
     static Backtrace capture() noexcept;
+
+    /// Print the backtrace to the stream. Each line is separated by a newline.
+    /// The format of the output is unspecified.
     void print(std::ostream&) const;
 
+    /// Construct an empty stack trace.
     Backtrace() noexcept {}
+
+    /// Move constructor. This operation cannot fail.
     Backtrace(Backtrace&&) noexcept;
+
+    /// Copy constructor. See the copy assignment operator.
     Backtrace(const Backtrace&) noexcept;
+
     ~Backtrace();
+
+    /// Move assignment operator. This operation cannot fail.
     Backtrace& operator=(Backtrace&&) noexcept;
+
+    /// Copy assignment operator. Copying a `Backtrace` object may result in a
+    /// memory allocation. If such an allocation fails, the backtrace is
+    /// replaced with a single line describing the error.
     Backtrace& operator=(const Backtrace&) noexcept;
 
 private:
@@ -49,8 +73,19 @@ private:
         , m_len(len)
     {}
 
+    // m_memory is a pointer to the memory block returned by
+    // `backtrace_symbols()`. It is usually equal to `m_strs`, except in the
+    // case where an error has occurred and `m_strs` points to statically
+    // allocated memory describing the error.
+    //
+    // When `m_memory` is non-null, the memory is owned by this object.
     void* m_memory = nullptr;
+
+    // A pointer to a list of string pointers describing the stack trace (same
+    // format as returned by `backtrace_symbols()`).
     const char* const* m_strs = nullptr;
+
+    // Number of entries in this stack trace.
     size_t m_len = 0;
 };
 

--- a/src/realm/util/backtrace.hpp
+++ b/src/realm/util/backtrace.hpp
@@ -30,11 +30,25 @@ struct Backtrace {
     static Backtrace capture() noexcept;
     void print(std::ostream&) const;
 
-    Backtrace() {}
+    Backtrace() noexcept {}
+    Backtrace(Backtrace&&) noexcept;
+    Backtrace(const Backtrace&) noexcept;
     ~Backtrace();
+    Backtrace& operator=(Backtrace&&) noexcept;
+    Backtrace& operator=(const Backtrace&) noexcept;
 private:
-    Backtrace(const char** strs, size_t len) : m_strs(strs), m_len(len) {}
+    Backtrace(void* memory, const char* const* strs, size_t len)
+        : m_memory(memory)
+        , m_strs(strs)
+        , m_len(len)
+    {}
+    Backtrace(void* memory, size_t len)
+        : m_memory(memory)
+        , m_strs(static_cast<char* const*>(memory))
+        , m_len(len)
+    {}
 
+    void* m_memory = nullptr;
     const char* const* m_strs = nullptr;
     size_t m_len = 0;
 };

--- a/src/realm/util/backtrace.hpp
+++ b/src/realm/util/backtrace.hpp
@@ -36,6 +36,7 @@ struct Backtrace {
     ~Backtrace();
     Backtrace& operator=(Backtrace&&) noexcept;
     Backtrace& operator=(const Backtrace&) noexcept;
+
 private:
     Backtrace(void* memory, const char* const* strs, size_t len)
         : m_memory(memory)

--- a/src/realm/util/backtrace.hpp
+++ b/src/realm/util/backtrace.hpp
@@ -1,0 +1,51 @@
+/*************************************************************************
+ *
+ * Copyright 2018 Realm Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ **************************************************************************/
+
+#ifndef REALM_UTIL_BACKTRACE_HPP
+#define REALM_UTIL_BACKTRACE_HPP
+
+#include <vector>
+#include <string>
+#include <iosfwd>
+
+namespace realm {
+namespace util {
+
+struct Backtrace {
+    static Backtrace capture() noexcept;
+    void print(std::ostream&) const;
+
+    Backtrace() {}
+    ~Backtrace();
+private:
+    Backtrace(const char** strs, size_t len) : m_strs(strs), m_len(len) {}
+
+    const char* const* m_strs = nullptr;
+    size_t m_len = 0;
+};
+
+} // namespace util
+} // namespace realm
+
+inline std::ostream& operator<<(std::ostream& os, const realm::util::Backtrace& bt)
+{
+    bt.print(os);
+    return os;
+}
+
+#endif // REALM_UTIL_BACKTRACE_HPP

--- a/src/realm/util/terminate.cpp
+++ b/src/realm/util/terminate.cpp
@@ -22,6 +22,7 @@
 #include <sstream>
 #include <realm/util/features.h>
 #include <realm/util/thread.hpp>
+#include <realm/util/backtrace.hpp>
 
 #if REALM_PLATFORM_APPLE
 
@@ -105,16 +106,7 @@ namespace util {
 // LCOV_EXCL_START
 REALM_NORETURN static void terminate_internal(std::stringstream& ss) noexcept
 {
-
-#if REALM_PLATFORM_APPLE
-    void* callstack[128];
-    int frames = backtrace(callstack, 128);
-    char** strs = backtrace_symbols(callstack, frames);
-    for (int i = 0; i < frames; ++i) {
-        ss << strs[i] << '\n';
-    }
-    free(strs);
-#endif
+    util::Backtrace::capture().print(ss);
 
     ss << "!!! IMPORTANT: Please send this log and info about Realm SDK version and other relevant reproduction info to help@realm.io.";
     if (termination_notification_callback) {

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -58,6 +58,7 @@ set(NORMAL_TESTS
     test_upgrade_database.cpp
     test_utf8.cpp
     test_util_any.cpp
+    test_util_backtrace.cpp
     test_util_base64.cpp
     test_util_error.cpp
     test_util_file.cpp

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -133,7 +133,7 @@ target_link_libraries(CoreTests
                       TestUtil QueryParser ${EXTRA_TEST_LIBS} ${PLATFORM_LIBRARIES}
 )
 
-if("${CMAKE_CXX_COMPILER_ID}" STREQUAL "GNU")
+if(UNIX AND NOT APPLE)
     # This enables symbols in backtraces
     target_link_libraries(CoreTests "-rdynamic")
 endif()

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -133,6 +133,11 @@ target_link_libraries(CoreTests
                       TestUtil QueryParser ${EXTRA_TEST_LIBS} ${PLATFORM_LIBRARIES}
 )
 
+if("${CMAKE_CXX_COMPILER_ID}" STREQUAL "GNU")
+    # This enables symbols in backtraces
+    target_link_libraries(CoreTests "-rdynamic")
+endif()
+
 target_include_directories(CoreTests PUBLIC ${EXTRA_TEST_CFLAGS})
 
 add_test(NAME RealmTests COMMAND realm-tests)

--- a/test/test_util_backtrace.cpp
+++ b/test/test_util_backtrace.cpp
@@ -17,7 +17,7 @@ TEST(Backtrace_LogicError)
     try {
         throw_logic_error(LogicError::string_too_big);
     }
-    catch (LogicError err)
+    catch (const LogicError& err)
     {
 #if REALM_PLATFORM_APPLE || (defined(__linux__) && !REALM_ANDROID)
         CHECK(StringData{err.what()}.contains("throw_logic_error"));

--- a/test/test_util_backtrace.cpp
+++ b/test/test_util_backtrace.cpp
@@ -17,8 +17,7 @@ TEST(Backtrace_LogicError)
     try {
         throw_logic_error(LogicError::string_too_big);
     }
-    catch (const LogicError& err)
-    {
+    catch (const LogicError& err) {
 #if REALM_PLATFORM_APPLE || (defined(__linux__) && !REALM_ANDROID)
         CHECK(StringData{err.what()}.contains("throw_logic_error"));
 #endif

--- a/test/test_util_backtrace.cpp
+++ b/test/test_util_backtrace.cpp
@@ -1,0 +1,28 @@
+#include "test.hpp"
+
+#include <realm/util/backtrace.hpp>
+#include <realm/exceptions.hpp>
+#include <realm/string_data.hpp>
+
+using namespace realm;
+using namespace realm::util;
+
+REALM_NOINLINE void throw_logic_error(LogicError::ErrorKind kind)
+{
+    throw LogicError{kind};
+}
+
+TEST(Backtrace_LogicError)
+{
+    try {
+        throw_logic_error(LogicError::string_too_big);
+    }
+    catch (LogicError err)
+    {
+#if REALM_PLATFORM_APPLE || (defined(__linux__) && !REALM_ANDROID)
+        CHECK(StringData{err.what()}.contains("throw_logic_error"));
+#endif
+        LogicError copy = err;
+        CHECK_EQUAL(StringData{copy.what()}, StringData{err.what()});
+    }
+}


### PR DESCRIPTION
This feature has been requested (and implemented) by the Sync team, for the purposes of aiding robustness and debuggability in server environments (after-the-fact crashes in particular).

Included in this PR:

- A new utility class, `util::Backtrace`, which captures and encapsulates a stack trace. It is exceedingly paranoid about failures, in order to avoid a snowball effect in error scenarios.
- A wrapper base class for exceptions, `ExceptionWithBacktrace<T>`, where `T` is a fundamental exception type, such as `std::exception` or `std::runtime_error`. Custom exception types can inherit from `ExceptionWithBacktrace<T>` to get backtrace information included "for free". The `what()` method of derived classes will include the backtrace of where the exception was thrown. If the exception provides a custom implementation of `what()`, they should override the new `message()` instead (`what()` is `final` on `ExceptionWithBacktrace<T>`).
- When `realm::terminate()` is called as part of an assertion failure on Linux, the backtrace is now printed in the same was as we currently do on Apple platforms. This backtrace will only contain useful information if the binary is linked with the `-rdynamic` option (which I have enabled for the `realm-tests` binary).
- A unit test that verifies that backtraces, when supported, are useful.

Not included:

- Backtrace detection on Windows and Android platforms.