### PR TITLE
Allow version number on Group::write

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,8 @@
 
 ### Enhancements
 
-* None.
+* Allow a version number in Group::write which will cause a file with (sync)
+  history to be written.
 
 -----------
 

--- a/src/realm/alloc_slab.cpp
+++ b/src/realm/alloc_slab.cpp
@@ -966,7 +966,7 @@ ref_type SlabAlloc::attach_file(const std::string& file_path, Config& cfg)
         m_file_mappings->m_first_additional_mapping = get_section_index(m_initial_chunk_size);
         m_attach_mode = cfg.is_shared ? attach_SharedFile : attach_UnsharedFile;
     }
-    catch (DecryptionFailed) {
+    catch (const DecryptionFailed&) {
         throw InvalidDatabase("Realm file decryption failed", path);
     }
     // make sure that any call to begin_read cause any slab to be placed in free

--- a/src/realm/group.cpp
+++ b/src/realm/group.cpp
@@ -755,12 +755,7 @@ void Group::write(std::ostream& out, bool pad_for_encryption, uint_fast64_t vers
     write(out, m_file_format_version, table_writer, no_top_array, pad_for_encryption, version_number); // Throws
 }
 
-void Group::write(const std::string& path, const char* encryption_key) const
-{
-    write(path, encryption_key, 0);
-}
-
-void Group::write(const std::string& path, const char* encryption_key, uint_fast64_t version_number) const
+void Group::write(const std::string& path, const char* encryption_key, uint64_t version_number) const
 {
     File file;
     int flags = 0;

--- a/src/realm/group.hpp
+++ b/src/realm/group.hpp
@@ -371,12 +371,16 @@ public:
     /// \param encryption_key 32-byte key used to encrypt the database file,
     /// or nullptr to disable encryption.
     ///
+    /// \param version If different from 0, the new file will be a full fledged
+    /// realm file with free list and history info. The version of the commit
+    /// will be set to the value given here.
+    ///
     /// \throw util::File::AccessError If the file could not be
     /// opened. If the reason corresponds to one of the exception
     /// types that are derived from util::File::AccessError, the
     /// derived exception type is thrown. In particular,
     /// util::File::Exists will be thrown if the file exists already.
-    void write(const std::string& file, const char* encryption_key = nullptr) const;
+    void write(const std::string& file, const char* encryption_key = nullptr, uint64_t version = 0) const;
 
     /// Write this database to a memory buffer.
     ///
@@ -686,7 +690,6 @@ private:
 
     void mark_all_table_accessors() noexcept;
 
-    void write(const std::string& file, const char* encryption_key, uint_fast64_t version_number) const;
     void write(util::File& file, const char* encryption_key, uint_fast64_t version_number) const;
     void write(std::ostream&, bool pad, uint_fast64_t version_numer) const;
 

--- a/src/realm/group_shared.cpp
+++ b/src/realm/group_shared.cpp
@@ -1320,7 +1320,7 @@ void SharedGroup::do_open(const std::string& path, bool no_create_file, bool is_
 
 // WARNING / FIXME: compact() should NOT be exposed publicly on Windows because it's not crash safe! It may
 // corrupt your database if something fails
-bool SharedGroup::compact()
+bool SharedGroup::compact(bool bump_version_number)
 {
     // Verify that the database file is attached
     if (is_attached() == false) {
@@ -1353,7 +1353,8 @@ bool SharedGroup::compact()
         try {
             File file;
             file.open(tmp_path, File::access_ReadWrite, File::create_Must, 0);
-            m_group.write(file, m_key, info->latest_version_number); // Throws
+            int incr = bump_version_number ? 1 : 0;
+            m_group.write(file, m_key, info->latest_version_number + incr); // Throws
             // Data needs to be flushed to the disk before renaming.
             bool disable_sync = get_disable_sync_to_disk();
             if (!disable_sync)

--- a/src/realm/group_shared.hpp
+++ b/src/realm/group_shared.hpp
@@ -413,7 +413,7 @@ public:
     ///
     /// WARNING / FIXME: compact() should NOT be exposed publicly on Windows
     /// because it's not crash safe! It may corrupt your database if something fails
-    bool compact();
+    bool compact(bool bump_version_number = false);
 
 #ifdef REALM_DEBUG
     void test_ringbuf();


### PR DESCRIPTION
This will allow Sync to write a file with new encryption key, but
will full content, ie. including history.