### PR TITLE
Add an optional output key to compact

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@
 
 ### Enhancements
 
-* None.
+* Allow compact to take an optional output encryption key.
 
 -----------
 

--- a/src/realm/group_shared.hpp
+++ b/src/realm/group_shared.hpp
@@ -413,7 +413,7 @@ public:
     ///
     /// WARNING / FIXME: compact() should NOT be exposed publicly on Windows
     /// because it's not crash safe! It may corrupt your database if something fails
-    bool compact(bool bump_version_number = false);
+    bool compact(bool bump_version_number = false, util::Optional<const char*>output_encryption_key = util::none);
 
 #ifdef REALM_DEBUG
     void test_ringbuf();

--- a/src/realm/group_shared.hpp
+++ b/src/realm/group_shared.hpp
@@ -407,13 +407,18 @@ public:
     /// The name of the temporary file is formed by appending
     /// ".tmp_compaction_space" to the name of the database
     ///
+    /// If the output_encryption_key is `none` then the file's existing key will
+    /// be used (if any). If the output_encryption_key is nullptr, the resulting
+    /// file will be unencrypted. Any other value will change the encryption of
+    /// the file to the new 64 byte key.
+    ///
     /// FIXME: This function is not yet implemented in an exception-safe manner,
     /// therefore, if it throws, the application should not attempt to
     /// continue. If may not even be safe to destroy the SharedGroup object.
     ///
     /// WARNING / FIXME: compact() should NOT be exposed publicly on Windows
     /// because it's not crash safe! It may corrupt your database if something fails
-    bool compact(bool bump_version_number = false, util::Optional<const char*>output_encryption_key = util::none);
+    bool compact(bool bump_version_number = false, util::Optional<const char*> output_encryption_key = util::none);
 
 #ifdef REALM_DEBUG
     void test_ringbuf();

--- a/test/test_shared.cpp
+++ b/test/test_shared.cpp
@@ -3443,7 +3443,7 @@ NONCONCURRENT_TEST(Shared_BigAllocations)
     sg.close();
 }
 
-NONCONCURRENT_TEST_IF(Shared_CompactEncrypt, REALM_ENABLE_ENCRYPTION)
+TEST_IF(Shared_CompactEncrypt, REALM_ENABLE_ENCRYPTION)
 {
     SHARED_GROUP_TEST_PATH(path);
     const char* key1 = "KdrL2ieWyspILXIPetpkLD6rQYKhYnS6lvGsgk4qsJAMr1adQnKsYo3oTEYJDIfa";

--- a/test/test_shared.cpp
+++ b/test/test_shared.cpp
@@ -3443,6 +3443,42 @@ NONCONCURRENT_TEST(Shared_BigAllocations)
     sg.close();
 }
 
+NONCONCURRENT_TEST_IF(Shared_CompactEncrypt, REALM_ENABLE_ENCRYPTION)
+{
+    SHARED_GROUP_TEST_PATH(path);
+    const char* key1 = "KdrL2ieWyspILXIPetpkLD6rQYKhYnS6lvGsgk4qsJAMr1adQnKsYo3oTEYJDIfa";
+    const char* key2 = "ti6rOKviXrwxSGMPVk35Dp9Q4eku8Cu8YTtnnZKAejOTNIEv7TvXrYdjOPSNexMR";
+    {
+        SharedGroup sg(path, false, SharedGroupOptions(key1));
+        Group& g = sg.begin_write();
+        TableRef t = g.add_table("table");
+        sg.commit();
+
+        CHECK(sg.compact());
+        const Group& rg = sg.begin_read();
+        CHECK(rg.has_table("table"));
+        sg.end_read();
+
+        bool bump_version_number = true;
+        CHECK(sg.compact(bump_version_number, key2));
+        const Group& rg2 = sg.begin_read();
+        CHECK(rg2.has_table("table"));
+        sg.end_read();
+
+        CHECK(sg.compact(bump_version_number, nullptr));
+        const Group& rg3 = sg.begin_read();
+        CHECK(rg3.has_table("table"));
+        sg.end_read();
+    }
+    {
+        SharedGroup sg(path, true, SharedGroupOptions());
+        const Group& rg = sg.begin_read();
+        CHECK(rg.has_table("table"));
+        sg.end_read();
+    }
+}
+
+
 // Repro case for: Assertion failed: top_size == 3 || top_size == 5 || top_size == 7 [0, 3, 0, 5, 0, 7]
 NONCONCURRENT_TEST(Shared_BigAllocationsMinimized)
 {


### PR DESCRIPTION
This is to support changing encryption keys in a robust manner handled by core itself.