### PR TITLE
Build an arm64_32 slice for watchOS with Xcode 10

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@
 
 ### Enhancements
 
-* None.
+* Add an arm64_32 slice to the watchOS build.
 
 -----------
 

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -459,7 +459,8 @@ def doBuildAppleDevice(String sdk, String buildType) {
         node('osx') {
             getArchive()
 
-            withEnv(['DEVELOPER_DIR=/Applications/Xcode-8.3.3.app/Contents/Developer/']) {
+            withEnv(['DEVELOPER_DIR=/Applications/Xcode-8.3.3.app/Contents/Developer/',
+                     'XCODE10_DEVELOPER_DIR=/Applications/Xcode-10.app/Contents/Developer/']) {
                 retry(3) {
                     timeout(time: 15, unit: 'MINUTES') {
                         runAndCollectWarnings(parser:'clang', script: """

--- a/tools/cross_compile.sh
+++ b/tools/cross_compile.sh
@@ -77,24 +77,39 @@ if [ "${OS}" == "android" ]; then
     make -j "${CORES}" -l "${CORES}" VERBOSE=1
     make package
 else
-    mkdir -p "build-${OS}-${BUILD_TYPE}"
-    cd "build-${OS}-${BUILD_TYPE}" || exit 1
     case "${OS}" in
         ios) SDK="iphone";;
         watchos) SDK="watch";;
         tvos) SDK="appletv";;
     esac
-
     [[ "${BUILD_TYPE}" = "Release" ]] && suffix="" || suffix="-dbg"
 
-    cmake -D CMAKE_TOOLCHAIN_FILE="../tools/cmake/${OS}.toolchain.cmake" \
-          -D CMAKE_INSTALL_PREFIX="$(pwd)/install" \
-          -D CMAKE_BUILD_TYPE="${BUILD_TYPE}" \
-          -D REALM_NO_TESTS=1 \
-          -D REALM_VERSION="${VERSION}" \
-          -D CPACK_SYSTEM_NAME="${SDK}os" \
-          -G Xcode ..
+    function configure_xcode {
+        cmake -D CMAKE_TOOLCHAIN_FILE="../tools/cmake/${OS}.toolchain.cmake" \
+              -D CMAKE_INSTALL_PREFIX="$(pwd)/install" \
+              -D CMAKE_BUILD_TYPE="${BUILD_TYPE}" \
+              -D REALM_NO_TESTS=1 \
+              -D REALM_VERSION="${VERSION}" \
+              -D CPACK_SYSTEM_NAME="${SDK}os" \
+              -G Xcode ..
+    }
 
+    if [ "${OS}" == "watchos" ] && [ -n "${XCODE10_DEVELOPER_DIR}" ]; then
+        mkdir -p "build-${OS}-${BUILD_TYPE}-64"
+        pushd "build-${OS}-${BUILD_TYPE}-64" || exit 1
+        (
+            export DEVELOPER_DIR="$XCODE10_DEVELOPER_DIR"
+            configure_xcode
+            xcodebuild -sdk "${SDK}os" -configuration "${BUILD_TYPE}" ARCHS='arm64_32'
+        )
+        ARM64_32_LIB="$(pwd)/src/realm/${BUILD_TYPE}-${SDK}os/librealm${suffix}.a"
+        popd
+    fi
+
+    mkdir -p "build-${OS}-${BUILD_TYPE}"
+    cd "build-${OS}-${BUILD_TYPE}" || exit 1
+
+    configure_xcode
     xcodebuild -sdk "${SDK}os" \
                -configuration "${BUILD_TYPE}" \
                ONLY_ACTIVE_ARCH=NO
@@ -105,7 +120,8 @@ else
     lipo -create \
          -output "src/realm/${BUILD_TYPE}/librealm${suffix}.a" \
          "src/realm/${BUILD_TYPE}-${SDK}os/librealm${suffix}.a" \
-         "src/realm/${BUILD_TYPE}-${SDK}simulator/librealm${suffix}.a"
+         "src/realm/${BUILD_TYPE}-${SDK}simulator/librealm${suffix}.a" \
+         $ARM64_32_LIB
     lipo -create \
          -output "src/realm/${BUILD_TYPE}/librealm-parser${suffix}.a" \
          "src/realm/${BUILD_TYPE}-${SDK}os/librealm-parser${suffix}.a" \


### PR DESCRIPTION
The watch series 4 is a different architecture from previous watches so we need to add a slice for it to the watchos build. Awkwardly, this means that we need to use different versions of Xcode for different slices, as Xcode 9 can't use libraries built by Xcode 10.

This will currently fail to build on CI because Xcode 10 is not yet deployed on the workers.