### PR TITLE
Avoid array placement new

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,7 +16,8 @@
 -----------
 
 ### Internals
-* None.
+* Fixed a bug in the use of placement new on MSVC, where the implementation is
+  buggy. This bug only affected version 5.11.0.
 
 ----------------------------------------------
 

--- a/src/realm/util/allocator.hpp
+++ b/src/realm/util/allocator.hpp
@@ -227,11 +227,20 @@ auto make_unique(Allocator& allocator, size_t count)
 {
     using T = std::remove_extent_t<Tv>;
     void* memory = allocator.allocate(sizeof(T) * count, alignof(T)); // Throws
-    T* ptr;
+    T* ptr = reinterpret_cast<T*>(memory);
+    size_t constructed = 0;
     try {
-        ptr = new (memory) T[count]; // Throws
+        // FIXME: Can't use array placement new, because MSVC has a buggy
+        // implementation of it. :-(
+        while (constructed < count) {
+            new (&ptr[constructed]) T; // Throws
+            ++constructed;
+        }
     }
     catch (...) {
+        for (size_t i = 0; i < constructed; ++i) {
+            ptr[i].~T();
+        }
         allocator.free(memory, sizeof(T) * count);
         throw;
     }


### PR DESCRIPTION
As it turns out, MSVC has a buggy placement `operator new[]`. It trashes memory and returns an unaligned pointer!

I have reworked `util::make_unique<T[]>` to manually construct elements using the single-element placement new.