### PR TITLE
assert to protect file integrity in case of corrupted freelist

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,9 @@
 -----------
 
 ### Internals
-* None.
+* Improved assertion checking in release mode in order to detect any corruption
+  of our freelist earlier and prevent bogus allocations from a corrupted freelist
+  from leading to subsequent corruption of other parts of the file.
 
 ----------------------------------------------
 


### PR DESCRIPTION
A corrupted freelist could lead to wrong allocations of space in the file potentially causing valid data to be overwritten. The added asserts will cause the process to fail earlier in cases where the wrong allocations are unaligned, potentially preserving more of the file.
