### PR TITLE
REALM_NODISCARD macro

### DIFF
--- a/src/realm/util/buffer.hpp
+++ b/src/realm/util/buffer.hpp
@@ -95,7 +95,7 @@ public:
     void reserve_extra(size_t used_size, size_t min_extra_capacity);
 
     /// Release the internal buffer to the caller.
-    std::unique_ptr<T[], STLDeleter<T[], Allocator>> release() noexcept;
+    REALM_NODISCARD std::unique_ptr<T[], STLDeleter<T[], Allocator>> release() noexcept;
 
     friend void swap(Buffer& a, Buffer& b) noexcept
     {
@@ -160,7 +160,7 @@ public:
     /// buffer may be larger than the amount of data appended to this buffer.
     /// Callers should call `size()` prior to releasing the buffer to know the
     /// usable/logical size.
-    Buffer<T, Allocator> release() noexcept;
+    REALM_NODISCARD Buffer<T, Allocator> release() noexcept;
 
 private:
     util::Buffer<T, Allocator> m_buffer;

--- a/src/realm/util/features.h
+++ b/src/realm/util/features.h
@@ -188,6 +188,16 @@
 #endif
 
 
+// FIXME: Change this to use [[nodiscard]] in C++17.
+#if defined(__GNUC__) || defined(__HP_aCC)
+#define REALM_NODISCARD __attribute__((warn_unused_result))
+#elif defined(_MSC_VER)
+#define REALM_NODISCARD _Check_return_
+#else
+#define REALM_NODISCARD
+#endif
+
+
 /* Thread specific data (only for POD types) */
 #if defined __clang__
 #define REALM_THREAD_LOCAL __thread


### PR DESCRIPTION
As a temporary measure until we get C++17 `[[nodiscard]]`.

The intent is to annotate functions where it is usually a bug to ignore the return value. If the return value of a function annotated with `REALM_NODISCARD` is ignored, the compiler will emit a warning.