### PR TITLE
Optimize get free space size

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,11 @@
 # NEXT RELEASE
 
 ### Enhancements
-* None.
+* Added Group::get_used_space() which will return the size of the data taken up by the current
+  commit. This is in contrast to the number returned by SharedGroup::get_stats() which will
+  return the size of the last commit done in that SharedGroup. If the commits are the same, 
+  the number will of course be the same. 
+  Issue [#259](https://github.com/realm/realm-core-private/issues/259)
 
 ### Fixed
 * <How to hit and notice issue? what was the impact?> ([#????](https://github.com/realm/realm-core/issues/????), since v?.?.?)

--- a/src/realm/group.cpp
+++ b/src/realm/group.cpp
@@ -1041,6 +1041,7 @@ size_t Group::compute_aggregated_byte_size(SizeAggregateControl ctrl) const noex
         m_table_names.stats(stats);
         m_tables.stats(stats);
         used = stats.allocated + m_top.get_byte_size();
+        used += sizeof(SlabAlloc::Header);
     }
     if (ctrl & SizeAggregateControl::size_of_freelists) {
         if (m_top.size() >= 6) {

--- a/src/realm/group.cpp
+++ b/src/realm/group.cpp
@@ -1062,6 +1062,17 @@ size_t Group::compute_aggregated_byte_size(SizeAggregateControl ctrl) const noex
     return used;
 }
 
+size_t Group::get_used_space() const noexcept
+{
+    size_t logical_file_size = (size_t(m_top.get(2)) >> 1);
+
+    REALM_ASSERT(m_top.size() > 4);
+    Array free_lengths(const_cast<SlabAlloc&>(m_alloc));
+    free_lengths.init_from_ref(ref_type(m_top.get(4)));
+
+    return logical_file_size - size_t(free_lengths.sum());
+}
+
 
 void Group::to_string(std::ostream& out) const
 {

--- a/src/realm/group.hpp
+++ b/src/realm/group.hpp
@@ -529,6 +529,11 @@ public:
     /// If this group accessor is the detached state, this function returns
     /// zero.
     size_t compute_aggregated_byte_size(SizeAggregateControl ctrl = SizeAggregateControl::size_of_all) const noexcept;
+    /// Return the size taken up by the current snapshot. This is in contrast to
+    /// the number returned by SharedGroup::get_stats() which will return the
+    /// size of the last snapshot done in that SharedGroup. If the snapshots are
+    /// identical, the numbers will of course be equal.
+    size_t get_used_space() const noexcept;
 
     void verify() const;
 #ifdef REALM_DEBUG

--- a/src/realm/group_shared.cpp
+++ b/src/realm/group_shared.cpp
@@ -2278,7 +2278,7 @@ void SharedGroup::low_level_commit(uint_fast64_t new_version)
     out.set_versions(new_version, oldest_version);
     // Recursively write all changed arrays to end of file
     ref_type new_top_ref = out.write_group(); // Throws
-    m_free_space = out.get_free_space();
+    m_free_space = out.get_free_space_size();
     m_used_space = out.get_file_size() - m_free_space;
     // std::cout << "Writing version " << new_version << ", Topptr " << new_top_ref
     //     << " Read lock at version " << oldest_version << std::endl;

--- a/src/realm/group_writer.cpp
+++ b/src/realm/group_writer.cpp
@@ -159,6 +159,7 @@ GroupWriter::GroupWriter(Group& group)
     , m_free_lengths(m_alloc)
     , m_free_versions(m_alloc)
     , m_current_version(0)
+    , m_free_space_size(0)
 {
     m_map_windows.reserve(num_map_windows);
 #if REALM_IOS
@@ -417,7 +418,7 @@ ref_type GroupWriter::write_group()
     // Now, let's update the realm-style freelists, which will later be written to file.
     // Function returns index of element holding the space reserved for the free
     // lists in the file.
-    size_t reserve_ndx = recreate_freelist(reserve_pos);
+    size_t reserve_ndx = recreate_freelist(reserve_pos, m_free_space_size);
 
 #if REALM_ALLOC_DEBUG
     std::cout << "    Freelist size after merge: " << m_free_positions.size()
@@ -489,6 +490,7 @@ ref_type GroupWriter::write_group()
 
     m_free_positions.set(reserve_ndx, value_8); // Throws
     m_free_lengths.set(reserve_ndx, value_9);   // Throws
+    m_free_space_size += rest;
 
     // The free-list now have their final form, so we can write them to the file
     // char* start_addr = m_file_map.get_addr() + reserve_ref;
@@ -508,17 +510,6 @@ ref_type GroupWriter::write_group()
     return top_ref;
 }
 
-size_t GroupWriter::get_free_space() {
-    if (m_free_lengths.is_attached()) {
-        size_t sum = 0;
-        for (size_t j = 0; j < m_free_lengths.size(); ++j) {
-            sum += to_size_t(m_free_lengths.get(j));
-        }
-        return sum;
-    } else {
-        return 0;
-    }
-}
 
 void GroupWriter::read_in_freelist()
 {
@@ -562,7 +553,7 @@ void GroupWriter::read_in_freelist()
     }
 }
 
-size_t GroupWriter::recreate_freelist(size_t reserve_pos)
+size_t GroupWriter::recreate_freelist(size_t reserve_pos, size_t& free_space_size)
 {
     REALM_ASSERT(m_free_in_file.empty());
 
@@ -590,6 +581,7 @@ size_t GroupWriter::recreate_freelist(size_t reserve_pos)
     size_t reserve_ndx = realm::npos;
     size_t prev_ref = 0;
     size_t prev_size = 0;
+    free_space_size = 0;
     auto limit = m_free_in_file.size();
     for (size_t i = 0; i < limit; ++i) {
         const auto& free_space = m_free_in_file[i];
@@ -597,6 +589,11 @@ size_t GroupWriter::recreate_freelist(size_t reserve_pos)
         REALM_ASSERT_RELEASE_EX(prev_ref + prev_size <= ref, prev_ref, prev_size, ref, i, limit);
         if (reserve_pos == ref) {
             reserve_ndx = i;
+        }
+        else {
+            // The reserved chunk should not be counted in now. We don't know how much of it
+            // will eventually be used.
+            free_space_size += free_space.size;
         }
         m_free_positions.add(free_space.ref);
         m_free_lengths.add(free_space.size);

--- a/src/realm/group_writer.hpp
+++ b/src/realm/group_writer.hpp
@@ -78,7 +78,11 @@ public:
     void dump();
 #endif
 
-    size_t get_free_space();
+    size_t get_free_space_size()
+    {
+        return m_free_space_size;
+    }
+
 private:
     class MapWindow;
     Group& m_group;
@@ -89,6 +93,7 @@ private:
     uint64_t m_current_version;
     uint64_t m_readlock_version;
     size_t m_window_alignment;
+    size_t m_free_space_size;
 
     struct FreeSpaceEntry {
         FreeSpaceEntry(size_t r, size_t s, uint64_t v)
@@ -110,7 +115,7 @@ private:
     // Merge adjacent chunks
     void merge_adjacent_entries_in_freelist();
     void read_in_freelist();
-    size_t recreate_freelist(size_t reserve_pos);
+    size_t recreate_freelist(size_t reserve_pos, size_t& free_space_size);
     // Currently cached memory mappings. We keep as many as 16 1MB windows
     // open for writing. The allocator will favor sequential allocation
     // from a modest number of windows, depending upon fragmentation, so

--- a/test/test_lang_bind_helper.cpp
+++ b/test/test_lang_bind_helper.cpp
@@ -407,6 +407,12 @@ TEST(LangBindHelper_AdvanceReadTransact_Basics)
     }
     LangBindHelper::advance_read(sg);
     group.verify();
+
+    size_t free_space, used_space;
+    sg_w.get_stats(free_space, used_space);
+    auto state_size = group.compute_aggregated_byte_size(Group::SizeAggregateControl::size_of_all);
+    CHECK_EQUAL(used_space, state_size);
+
     CHECK_EQUAL(2, group.size());
     CHECK(foo->is_attached());
     CHECK_EQUAL(2, foo->get_column_count());
@@ -515,6 +521,8 @@ TEST(LangBindHelper_AdvanceReadTransact_CreateManyTables)
     std::unique_ptr<Replication> hist(realm::make_in_realm_history(path));
     SharedGroup sg(*hist, SharedGroupOptions(crypt_key()));
     ReadTransaction rt(sg);
+    const Group& group = rt.get_group();
+    size_t free_space, used_space;
 
     {
         std::unique_ptr<Replication> hist_w(realm::make_in_realm_history(path));
@@ -528,9 +536,13 @@ TEST(LangBindHelper_AdvanceReadTransact_CreateManyTables)
             wt.add_table(str);
         }
         wt.commit();
+        sg_w.get_stats(free_space, used_space);
     }
 
     LangBindHelper::advance_read(sg);
+    auto state_size =
+        group.compute_aggregated_byte_size(Group::SizeAggregateControl(Group::SizeAggregateControl::size_of_all));
+    CHECK_EQUAL(used_space, state_size);
 }
 
 

--- a/test/test_lang_bind_helper.cpp
+++ b/test/test_lang_bind_helper.cpp
@@ -540,9 +540,11 @@ TEST(LangBindHelper_AdvanceReadTransact_CreateManyTables)
     }
 
     LangBindHelper::advance_read(sg);
-    auto state_size =
+    auto size_all =
         group.compute_aggregated_byte_size(Group::SizeAggregateControl(Group::SizeAggregateControl::size_of_all));
-    CHECK_EQUAL(used_space, state_size);
+    CHECK_EQUAL(used_space, size_all);
+    auto used_space1 = group.get_used_space();
+    CHECK_EQUAL(used_space, used_space1);
 }
 
 


### PR DESCRIPTION
This PR builds on the experience that it is quite fast to calculate the size of the history and freelist part of the full state AND relatively fast to calculate the free space size. The state size is now calculated as `filesize` - `free space size` - `history size` - `freelist size`

Fixes https://github.com/realm/realm-core-private/issues/259