### PR TITLE
STLAllocator: Fixups for GCC 4.9

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,7 +17,8 @@
 -----------
 
 ### Internals
-* None.
+* Added better compatibility for custom allocators with standard library
+  containers on GCC 4.9.
 
 ----------------------------------------------
 

--- a/test/test_alloc.cpp
+++ b/test/test_alloc.cpp
@@ -518,7 +518,7 @@ using MyVector = std::vector<T, STLAllocator<T>>;
 template <class T>
 using MyList = std::list<T, STLAllocator<T>>;
 template <class K, class V>
-using MyUnorderedMap = std::unordered_map<K, V, std::hash<K>, std::equal_to<K>, STLAllocator<char>>;
+using MyUnorderedMap = std::unordered_map<K, V, std::hash<K>, std::equal_to<K>, STLAllocator<std::pair<const K, V>>>;
 } // unnamed namespace
 
 namespace std {

--- a/test/test_alloc.cpp
+++ b/test/test_alloc.cpp
@@ -408,6 +408,10 @@ public:
     {
         return m_ptr - m_freed == m_buffer.get();
     }
+    size_t get_allocated() const noexcept
+    {
+        return m_ptr - m_buffer.get();
+    }
 
 private:
     size_t m_size;
@@ -442,6 +446,19 @@ TEST(Allocator_MakeUnique)
         CHECK_EQUAL(ptr2->size(), 5);
     }
     CHECK(alloc.check());
+}
+
+TEST(Allocator_MoveAssignmentNoCopy)
+{
+    MyAllocator alloc;
+    std::vector<char, STLAllocator<char, MyAllocator>> vec1(1000, char(123), alloc);
+    CHECK_EQUAL(alloc.get_allocated(), 1000);
+    // Move-construction
+    auto vec2 = std::move(vec1);
+    CHECK_EQUAL(alloc.get_allocated(), 1000);
+    std::vector<char, STLAllocator<char, MyAllocator>> vec3(alloc);
+    vec2 = std::move(vec2);
+    CHECK_EQUAL(alloc.get_allocated(), 1000);
 }
 
 TEST(Allocator_Polymorphic)

--- a/test/test_alloc.cpp
+++ b/test/test_alloc.cpp
@@ -460,7 +460,7 @@ TEST(Allocator_MoveAssignmentNoCopy)
     auto vec2 = std::move(vec1);
     CHECK_EQUAL(alloc.get_allocated(), 1000);
     std::vector<char, STLAllocator<char, MyAllocator>> vec3(alloc);
-    vec2 = std::move(vec2);
+    vec2 = std::move(vec3);
     CHECK_EQUAL(alloc.get_allocated(), 1000);
 }
 

--- a/test/test_alloc.cpp
+++ b/test/test_alloc.cpp
@@ -454,14 +454,17 @@ TEST(Allocator_MakeUnique)
 TEST(Allocator_MoveAssignmentNoCopy)
 {
     MyAllocator alloc;
-    std::vector<char, STLAllocator<char, MyAllocator>> vec1(1000, char(123), alloc);
-    CHECK_EQUAL(alloc.get_allocated(), 1000);
+    std::vector<char, STLAllocator<char, MyAllocator>> vec1(100, char(123), alloc);
+    // FIXME: This check is weird because MSVC's std::vector apparently
+    // allocates an extra 8 bytes in Debug mode on move-assignment/construction!
+    // Presumably, this is due to debug-iterators.
+    CHECK_LESS(alloc.get_allocated(), 200);
     // Move-construction
     auto vec2 = std::move(vec1);
-    CHECK_EQUAL(alloc.get_allocated(), 1000);
+    CHECK_LESS(alloc.get_allocated(), 200);
     std::vector<char, STLAllocator<char, MyAllocator>> vec3(alloc);
     vec2 = std::move(vec3);
-    CHECK_EQUAL(alloc.get_allocated(), 1000);
+    CHECK_LESS(alloc.get_allocated(), 200);
 }
 
 TEST(Allocator_Polymorphic)


### PR DESCRIPTION
GCC 4.9 requires some allocator interface methods to be defined, even though the standard says they are optional. Newer compilers do not have this requirement.

I have also added some more tests.