### PR TITLE
std::hash implementation for StringData

### DIFF
--- a/src/realm/string_data.cpp
+++ b/src/realm/string_data.cpp
@@ -135,7 +135,7 @@ struct Murmur2OrCityHash;
 
 template <>
 struct Murmur2OrCityHash<8> {
-    size_t operator()(const unsigned char* data, size_t len) const noexcept
+    uint_least64_t operator()(const unsigned char* data, size_t len) const noexcept
     {
         return cityhash_64(data, len);
     }
@@ -143,7 +143,7 @@ struct Murmur2OrCityHash<8> {
 
 template <>
 struct Murmur2OrCityHash<4> {
-    size_t operator()(const unsigned char* data, size_t len) const noexcept
+    uint_least32_t operator()(const unsigned char* data, size_t len) const noexcept
     {
         return murmur2_32(data, len);
     }
@@ -168,7 +168,7 @@ uint_least64_t load8(const unsigned char* data)
 
 size_t realm::murmur2_or_cityhash(const unsigned char* data, size_t len) noexcept
 {
-    return Murmur2OrCityHash<>{}(data, len);
+    return size_t(Murmur2OrCityHash<>{}(data, len));
 }
 
 uint_least32_t realm::murmur2_32(const unsigned char* data, size_t len) noexcept

--- a/src/realm/string_data.cpp
+++ b/src/realm/string_data.cpp
@@ -230,8 +230,7 @@ struct CityHash64 {
         }
         uint_least64_t x = load8(data + len - 40);
         uint_least64_t y = load8(data + len - 16) + load8(data + len - 56);
-        uint_least64_t z = z = hash_len_16(load8(data + len - 48) + len,
-                                           load8(data + len - 24));
+        uint_least64_t z = hash_len_16(load8(data + len - 48) + len, load8(data + len - 24));
         pair v = weak_hash_len_32_with_seeds(data + len - 64, len, z);
         pair w = weak_hash_len_32_with_seeds(data + len - 32, y + k1, x);
         x = x * k1 + load8(data);

--- a/src/realm/string_data.cpp
+++ b/src/realm/string_data.cpp
@@ -135,7 +135,7 @@ struct Murmur2OrCityHash;
 
 template <>
 struct Murmur2OrCityHash<8> {
-    uint_least64_t operator()(const unsigned char* data, size_t len) const noexcept
+    inline uint_least64_t operator()(const unsigned char* data, size_t len) const noexcept
     {
         return cityhash_64(data, len);
     }
@@ -143,20 +143,20 @@ struct Murmur2OrCityHash<8> {
 
 template <>
 struct Murmur2OrCityHash<4> {
-    uint_least32_t operator()(const unsigned char* data, size_t len) const noexcept
+    inline uint_least32_t operator()(const unsigned char* data, size_t len) const noexcept
     {
         return murmur2_32(data, len);
     }
 };
 
-uint_least32_t load4(const unsigned char* data)
+inline uint_least32_t load4(const unsigned char* data)
 {
     uint_least32_t word = 0;
     std::memcpy(&word, data, 4);
     return word;
 }
 
-uint_least64_t load8(const unsigned char* data)
+inline uint_least64_t load8(const unsigned char* data)
 {
     uint_least64_t word = 0;
     std::memcpy(&word, data, 8);

--- a/src/realm/string_data.cpp
+++ b/src/realm/string_data.cpp
@@ -127,3 +127,246 @@ bool StringData::matchlike_ins(const StringData& text, const StringData& pattern
 {
     return ::matchlike<true>(text, pattern_upper, &pattern_lower);
 }
+
+
+namespace {
+template <size_t = sizeof(void*)>
+struct Murmur2OrCityHash;
+
+template <>
+struct Murmur2OrCityHash<8> {
+    size_t operator()(const unsigned char* data, size_t len) const noexcept
+    {
+        return cityhash_64(data, len);
+    }
+};
+
+template <>
+struct Murmur2OrCityHash<4> {
+    size_t operator()(const unsigned char* data, size_t len) const noexcept
+    {
+        return murmur2_32(data, len);
+    }
+};
+
+uint_least32_t load4(const unsigned char* data)
+{
+    uint_least32_t word = 0;
+    std::memcpy(&word, data, 4);
+    return word;
+}
+
+uint_least64_t load8(const unsigned char* data)
+{
+    uint_least64_t word = 0;
+    std::memcpy(&word, data, 8);
+    return word;
+}
+
+} // unnamed namespace
+
+
+size_t realm::murmur2_or_cityhash(const unsigned char* data, size_t len) noexcept
+{
+    return Murmur2OrCityHash<>{}(data, len);
+}
+
+uint_least32_t realm::murmur2_32(const unsigned char* data, size_t len) noexcept
+{
+    // This implementation is copied from libc++.
+    // See: https://github.com/llvm-mirror/libcxx/blob/master/include/utility
+
+    REALM_ASSERT_DEBUG(len <= std::numeric_limits<uint_least32_t>::max());
+
+    const uint_least32_t m = 0x5bd1e995UL;
+    const uint_least32_t r = 24;
+    uint_least32_t h = uint_least32_t(len);
+
+    for (; len >= 4; data += 4, len -= 4) {
+        uint_least32_t k = load4(data);
+        k *= m;
+        k ^= k >> r;
+        k *= m;
+        h *= m;
+        h ^= k;
+    }
+
+    switch (len) {
+        case 3:
+            h ^= data[2] << 16;
+        case 2:
+            h ^= data[1] << 8;
+        case 1:
+            h ^= data[0];
+            h *= m;
+    }
+    h ^= h >> 13;
+    h *= m;
+    h ^= h >> 15;
+    return h;
+}
+
+namespace {
+struct CityHash64 {
+    // This implementation is copied from libc++.
+    // See: https://github.com/llvm-mirror/libcxx/blob/master/include/utility
+
+    static const uint_least64_t k0 = 0xc3a5c85c97cb3127ULL;
+    static const uint_least64_t k1 = 0xb492b66fbe98f273ULL;
+    static const uint_least64_t k2 = 0x9ae16a3b2f90404fULL;
+    static const uint_least64_t k3 = 0xc949d7c7509e6557ULL;
+    using pair = std::pair<uint_least64_t, uint_least64_t>;
+
+    uint_least64_t operator()(const unsigned char* data, size_t len) const noexcept
+    {
+        if (len <= 32) {
+            if (len <= 16) {
+                return hash_len_0_to_16(data, len);
+            } else {
+                return hash_len_17_to_32(data, len);
+            }
+        } else if (len <= 64) {
+            return hash_len_33_to_64(data, len);
+        }
+        uint_least64_t x = load8(data + len - 40);
+        uint_least64_t y = load8(data + len - 16) + load8(data + len - 56);
+        uint_least64_t z = z = hash_len_16(load8(data + len - 48) + len,
+                                           load8(data + len - 24));
+        pair v = weak_hash_len_32_with_seeds(data + len - 64, len, z);
+        pair w = weak_hash_len_32_with_seeds(data + len - 32, y + k1, x);
+        x = x * k1 + load8(data);
+
+        // Decrease len to the nearest multiple of 64, and operate on 64-byte
+        // chunks.
+        len = (len - 1) & ~static_cast<uint_least64_t>(63);
+        do {
+            x = rotate(x + y + v.first + load8(data + 8), 37) * k1;
+            y = rotate(y + v.second + load8(data + 48), 42) * k1;
+            x ^= w.second;
+            y += v.first + load8(data + 40);
+            z = rotate(z + w.first, 33) * k1;
+            v = weak_hash_len_32_with_seeds(data, v.second * k1, x + w.first);
+            w = weak_hash_len_32_with_seeds(data + 32, z + w.second,
+                                            y + load8(data + 16));
+            std::swap(z, x);
+            data += 64;
+            len -= 64;
+        } while (len != 0);
+        return hash_len_16(
+            hash_len_16(v.first, w.first) + shift_mix(y) * k1 + z,
+            hash_len_16(v.second, w.second) + x);
+    }
+
+    static uint_least64_t hash_len_0_to_16(const unsigned char* data, size_t len) noexcept
+    {
+        if (len > 8) {
+            const auto a = load8(data);
+            const auto b = load8(data + len - 8);
+            return hash_len_16(a, rotate_by_at_least_1(b + len, int(len))) ^ b;
+        }
+        if (len >= 4) {
+            const auto a = load4(data);
+            const auto b = load4(data + len - 4);
+            return hash_len_16(len + (a << 3), b);
+        }
+        if (len > 0) {
+            const auto a = data[0];
+            const auto b = data[len >> 1];
+            const auto c = data[len - 1];
+            const auto y = static_cast<uint_least32_t>(a) + 
+                (static_cast<uint_least32_t>(b) << 8);
+            const auto z = static_cast<uint_least32_t>(len) +
+                (static_cast<uint_least32_t>(c) << 2);
+            return shift_mix(y * k2 ^z * k3) * k2;
+        }
+        return k2;
+    }
+
+    static uint_least64_t hash_len_17_to_32(const unsigned char* data, size_t len) noexcept
+    {
+        const auto a = load8(data) * k1;
+        const auto b = load8(data + 8);
+        const auto c = load8(data + len - 8) * k2;
+        const auto d = load8(data + len - 16) * k0;
+        return hash_len_16(rotate(a - b, 43) + rotate(c, 30) + d,
+                           a + rotate(b ^ k3, 20) - c + len);
+    }
+
+    static uint_least64_t hash_len_33_to_64(const unsigned char* data, size_t len) noexcept
+    {
+        uint_least64_t z = load8(data + 24);
+        uint_least64_t a = load8(data) + (len + load8(data + len - 16)) * k0;
+        uint_least64_t b = rotate(a + z, 52);
+        uint_least64_t c = rotate(a, 37);
+        a += load8(data + 8);
+        c += rotate(a, 7);
+        a += load8(data + 16);
+        uint_least64_t vf = a + z;
+        uint_least64_t vs = b + rotate(a, 31) + c;
+        a = load8(data + 16) + load8(data + len - 32);
+        z += load8(data + len - 8);
+        b = rotate(a + z, 52);
+        c = rotate(a, 37);
+        a += load8(data + len - 24);
+        c += rotate(a, 7);
+        a += load8(data + len - 16);
+        uint_least64_t wf = a + z;
+        uint_least64_t ws = b + rotate(a, 31) + c;
+        uint_least64_t r = shift_mix((vf + ws) * k2 + (wf + vs) * k0);
+        return shift_mix(r * k0 + vs) * k2;
+    }
+
+    static uint_least64_t hash_len_16(uint_least64_t u, uint_least64_t v) noexcept
+    {
+        const uint_least64_t mul = 0x9ddfea08eb382d69ULL;
+        uint_least64_t a = (u ^ v) * mul;
+        a ^= (a >> 47);
+        uint_least64_t b = (v ^ a) * mul;
+        b ^= (b >> 47);
+        b *= mul;
+        return b;
+    }
+
+    static pair weak_hash_len_32_with_seeds(uint_least64_t w, uint_least64_t x,
+                                            uint_least64_t y, uint_least64_t z,
+                                            uint_least64_t a, uint_least64_t b) noexcept
+    {
+        a += w;
+        b = rotate(b + a + z, 21);
+        const uint_least64_t c = a;
+        a += x;
+        a += y;
+        b += rotate(a, 44);
+        return pair{a + z, b + c};
+    }
+
+    static pair weak_hash_len_32_with_seeds(const unsigned char* data,
+                                            uint_least64_t a, uint_least64_t b) noexcept
+    {
+        return weak_hash_len_32_with_seeds(load8(data), load8(data + 8),
+                                           load8(data + 16), load8(data + 24),
+                                           a, b);
+    }
+
+    static inline uint_least64_t rotate(uint_least64_t val, int shift) noexcept
+    {
+        return shift == 0 ? val : rotate_by_at_least_1(val, shift);
+    }
+
+    static inline uint_least64_t rotate_by_at_least_1(uint_least64_t val, int shift) noexcept
+    {
+        return (val >> shift) | (val << (64 - shift));
+    }
+
+    static inline uint_least64_t shift_mix(uint_least64_t val) noexcept
+    {
+        return val ^ (val >> 47);
+    }
+};
+} // unnamed namespace
+
+uint_least64_t realm::cityhash_64(const unsigned char* data, size_t len) noexcept
+{
+    return CityHash64{}(data, len);
+}
+

--- a/src/realm/string_data.hpp
+++ b/src/realm/string_data.hpp
@@ -34,6 +34,15 @@
 
 namespace realm {
 
+/// Selects CityHash64 on 64-bit platforms, and Murmur2 on 32-bit platforms.
+/// This is what libc++ does, and it is a good general choice for a
+/// non-cryptographic hash function (suitable for std::unordered_map etc.).
+size_t murmur2_or_cityhash(const unsigned char* data, size_t len) noexcept;
+
+uint_least32_t murmur2_32(const unsigned char* data, size_t len) noexcept;
+uint_least64_t cityhash_64(const unsigned char* data, size_t len) noexcept;
+
+
 /// A reference to a chunk of character data.
 ///
 /// An instance of this class can be thought of as a type tag on a region of
@@ -155,6 +164,10 @@ public:
     friend std::basic_ostream<C, T>& operator<<(std::basic_ostream<C, T>&, const StringData&);
 
     explicit operator bool() const noexcept;
+
+    /// If the StringData is NULL, the hash is 0. Otherwise, the function
+    /// `murmur2_or_cityhash()` is called on the data.
+    size_t hash() const noexcept;
 
 private:
     const char* m_data;
@@ -374,6 +387,24 @@ inline StringData::operator bool() const noexcept
     return !is_null();
 }
 
+inline size_t StringData::hash() const noexcept
+{
+    if (is_null())
+        return 0;
+    auto data = reinterpret_cast<const unsigned char*>(m_data);
+    return murmur2_or_cityhash(data, m_size);
+}
+
 } // namespace realm
+
+namespace std {
+template <>
+struct hash<::realm::StringData> {
+    size_t operator()(const ::realm::StringData& str) const noexcept
+    {
+        return str.hash();
+    }
+};
+} // namespace std
 
 #endif // REALM_STRING_HPP

--- a/src/realm/string_data.hpp
+++ b/src/realm/string_data.hpp
@@ -400,7 +400,7 @@ inline size_t StringData::hash() const noexcept
 namespace std {
 template <>
 struct hash<::realm::StringData> {
-    size_t operator()(const ::realm::StringData& str) const noexcept
+    inline size_t operator()(const ::realm::StringData& str) const noexcept
     {
         return str.hash();
     }

--- a/test/test_string_data.cpp
+++ b/test/test_string_data.cpp
@@ -494,4 +494,73 @@ TEST(StringData_STL_Stream)
     CHECK_EQUAL(s, out.str());
 }
 
+
+#include <utility>
+
+
+TEST(StringData_Hash_Murmur2)
+{
+    const StringData input{"Hello, World!"};
+    const uint_least32_t expected = 0x2da26fc3UL;
+    const uint_least32_t hash = realm::murmur2_32(reinterpret_cast<const unsigned char*>(input.data()), input.size());
+    CHECK_EQUAL(expected, hash);
+}
+
+
+TEST(StringData_Hash_CityHash64)
+{
+    const std::pair<StringData, uint_least64_t> input_expected[] = {
+        {"a", 0x2420662cd003acfaULL},
+        {"aa", 0x399e7b6e03c39ba5ULL},
+        {"aaa", 0xfd1e1bf6b98869f4ULL},
+        {"aaaa", 0xd5378b18ac18d2f5ULL},
+        {"aaaaa", 0x1eae3ece6232e798ULL},
+        {"aaaaaa", 0x16224fd26dc53ac2ULL},
+        {"aaaaaaa", 0x4988c89a088f7ca9ULL},
+        {"aaaaaaaa", 0xe8cc4a1995ae9819ULL},
+        {"aaaaaaaaaaaaa", 0x2b2315430bd3bf66ULL},
+        {"aaaaaaaaaaaaaaaa", 0x181cfc20a52d75f2ULL},
+        {"aaaaaaaaaaaaaaaaaaaaa", 0x247f926a3f0922d6ULL},
+        {"aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa", 0xad037c34caf51646ULL},
+        {"aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa", 0x61960b27221e6b95ULL},
+        {"aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa", 0x50d2b3ae5db609ebULL},
+        {"Hello, World!", 0x3d880bd14a5a7954ULL},
+    };
+    const size_t num_checks = 15;
+    for (size_t i = 0; i < num_checks; ++i) {
+        const auto data = reinterpret_cast<const unsigned char*>(input_expected[i].first.data());
+        const uint_least64_t hash = realm::cityhash_64(data, input_expected[i].first.size());
+
+        // With libc++ (on macOS), use this line to generate a reference hash:
+        //const uint_least64_t hash = std::__murmur2_or_cityhash<uint_least64_t, 64>{}(data, input_expected[i].first.size());
+
+        if (!CHECK_EQUAL(hash, input_expected[i].second)) {
+            std::cerr << "Failed input string: " << input_expected[i].first
+                << ", hex expected: " << std::hex << input_expected[i].second
+                << ", hex got: " << std::hex << hash << "\n";
+        }
+    }
+}
+
+
+TEST(StringData_Hash_SelectsAppropriateAlgorithmForArchitecture)
+{
+    const StringData input = "Hello, World!";
+    size_t hash = input.hash();
+    if (sizeof(void*) == 4) {
+        // Murmur2 on 32-bit platforms
+        CHECK_EQUAL(hash, 0x2da26fc3UL);
+    }
+    else if (sizeof(void*) == 8) {
+        // CityHash64 on 64-bit platforms
+        const uint_least64_t expected = 0x3d880bd14a5a7954ULL;
+
+        // With libc++ (on macOS), use this line to generate a reference hash:
+        //auto expected = std::__murmur2_or_cityhash<uint_least64_t, 64>{}(reinterpret_cast<const unsigned char*>(input.data()), input.size());
+
+        CHECK_EQUAL(uint_least64_t{hash}, expected);
+    }
+}
+
 #endif
+


### PR DESCRIPTION
Fixes #2929 

I have copied what libc++ does for `std::string`. On 64-bit platforms, CityHash64 is used. On 32-bit platforms, Murmur2 is used.

CityHash is competitive with very fast hash functions, such as XXHash.

Note: This can all go away once we switch to C++17, where the standard library is required to provide an implementation of `std::hash` for `std::string_view`.

The problem this solves is that we can't currently use `StringData` as the key type in `std::unordered_map`, but have to always use `std::string`, which is suboptimal because it needs to own its data.

To reviewers: Please do not feel obligated to review the details in the implementation of CityHash64. It's pretty long. ;-) It should be a straight up copy of the implementation in libc++ (with adjustments for code style).