### PR TITLE
Add method DescriptorOrdering::remove_all_limits()

### DIFF
--- a/src/realm/views.cpp
+++ b/src/realm/views.cpp
@@ -354,6 +354,23 @@ void DescriptorOrdering::append_limit(LimitDescriptor limit)
     m_descriptors.emplace_back(new LimitDescriptor(std::move(limit)));
 }
 
+util::Optional<size_t> DescriptorOrdering::remove_all_limits()
+{
+    size_t min_limit = size_t(-1);
+    for (auto it = m_descriptors.begin(); it != m_descriptors.end();) {
+        if ((*it)->get_type() == DescriptorType::Limit) {
+            const LimitDescriptor* limit = static_cast<const LimitDescriptor*>(it->get());
+            if (limit->get_limit() < min_limit) {
+                min_limit = limit->get_limit();
+            }
+            it = m_descriptors.erase(it);
+        } else {
+            ++it;
+        }
+    }
+    return min_limit == size_t(-1) ? util::none : util::some<size_t>(min_limit);
+}
+
 bool DescriptorOrdering::descriptor_is_sort(size_t index) const
 {
     REALM_ASSERT(index < m_descriptors.size());

--- a/src/realm/views.hpp
+++ b/src/realm/views.hpp
@@ -154,6 +154,12 @@ public:
     void append_sort(SortDescriptor sort);
     void append_distinct(DistinctDescriptor distinct);
     void append_limit(LimitDescriptor limit);
+
+    /// Remove all LIMIT statements from this descriptor ordering, returning the
+    /// minimum LIMIT value that existed. If there was no LIMIT statement,
+    /// returns `none`.
+    util::Optional<size_t> remove_all_limits();
+
     bool descriptor_is_sort(size_t index) const;
     bool descriptor_is_distinct(size_t index) const;
     bool descriptor_is_limit(size_t index) const;


### PR DESCRIPTION
This is needed for partial sync to be able to postpone LIMIT to after permission checks.