### PR TITLE
Fsa/improved page governor

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,8 +14,9 @@
         * 1/4 of physical memory available on the platform as reported by "/proc/meminfo"
         * 1/4 of allowed memory available as indicated by "/sys/fs/cgroup/memory/memory_limit_in_bytes"
         * 1/2 of what is used by the buffer cache as indicated by "/sys/fs/cgroup/memory/memory.stat"
-        * A target directly specified as "target <number of bytes>" in a local file "page_governor.cfg"
-  if none of the above is available, or if a target of 0 is given, the feature is disabled.
+        * A target directly specified as "target <number of bytes>" in a configuration file specified
+          by the environment variable REALM_PAGE_GOVERNOR_CFG.
+  if none of the above is available, or if a target of -1 is given, the feature is disabled.
   ([#3123] https://github.com/realm/realm-core/issues/3123)
  
 ### Breaking changes

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,9 +10,12 @@
   A page reclaim daemon thread has been added, which will work to release decrypted pages back to
   the operating system. To control it, a governing function can be installed. The governing function
   sets the target for the page reclaimer. If no governing function is installed, the system will attempt
-  to keep the memory usage below 1/4 of the memory available. The system will try to determine the amount
-  of memory available from /proc/meminfo or from the cgroup file system. If the amount of memory available
-  cannot be determined, the feature is disabled.
+  to keep the memory usage below any of the following:
+        * 1/4 of physical memory available on the platform as reported by "/proc/meminfo"
+        * 1/4 of allowed memory available as indicated by "/sys/fs/cgroup/memory/memory_limit_in_bytes"
+        * 1/2 of what is used by the buffer cache as indicated by "/sys/fs/cgroup/memory/memory.stat"
+        * A target directly specified as "target <number of bytes>" in a local file "page_governor.cfg"
+  if none of the above is available, or if a target of 0 is given, the feature is disabled.
   ([#3123] https://github.com/realm/realm-core/issues/3123)
  
 ### Breaking changes

--- a/src/realm/util/file_mapper.cpp
+++ b/src/realm/util/file_mapper.cpp
@@ -113,7 +113,7 @@ unsigned int file_reclaim_index = 0;
 
 // helpers
 
-int64_t fetch_value_in_file(std::string fname, const char* scan_pattern)
+int64_t fetch_value_in_file(const std::string& fname, const char* scan_pattern)
 {
     std::ifstream file(fname);
     if (file) {
@@ -139,18 +139,18 @@ int64_t fetch_value_in_file(std::string fname, const char* scan_pattern)
 
 class DefaultGovernor : public PageReclaimGovernor {
 public:
-	int64_t pick_lowest_valid(int64_t a, int64_t b) {
-		if (a == no_match)
-			return b;
-		if (b == no_match)
-			return a;
-		return std::min(a,b);
-	}
-	int64_t pick_if_valid(int64_t source, int64_t target) {
-		if (source == no_match)
-			return no_match;
-		return target;
-	}
+    int64_t pick_lowest_valid(int64_t a, int64_t b) {
+        if (a == no_match)
+            return b;
+        if (b == no_match)
+            return a;
+        return std::min(a,b);
+    }
+    int64_t pick_if_valid(int64_t source, int64_t target) {
+        if (source == no_match)
+            return no_match;
+        return target;
+    }
 
 	int64_t get_current_target(size_t load) override
     {
@@ -178,14 +178,14 @@ public:
         return target;
     }
     DefaultGovernor() {
-    	auto cfg_name = getenv("REALM_PAGE_GOVERNOR_CFG");
-    	if (cfg_name) {
-    		m_cfg_file_name = cfg_name;
-    	}
+        auto cfg_name = getenv("REALM_PAGE_GOVERNOR_CFG");
+        if (cfg_name) {
+            m_cfg_file_name = cfg_name;
+        }
     }
 private:
     std::string m_cfg_file_name;
-    int64_t m_target;
+    int64_t m_target = 0;
     int m_refresh_count = 0;
 };
 

--- a/src/realm/util/file_mapper.cpp
+++ b/src/realm/util/file_mapper.cpp
@@ -112,7 +112,8 @@ std::vector<mappings_for_file>& mappings_by_file = *new std::vector<mappings_for
 unsigned int file_reclaim_index = 0;
 
 // helpers
-size_t fetch_value_in_file(const char* fname, const char* scan_pattern)
+
+int64_t fetch_value_in_file(const char* fname, const char* scan_pattern)
 {
     std::ifstream file(fname);
     if (file) {
@@ -128,7 +129,7 @@ size_t fetch_value_in_file(const char* fname, const char* scan_pattern)
             return strtol(ibuf.c_str(), nullptr, 10);
         }
     }
-    return 0;
+    return PageReclaimGovernor::no_match;
 }
 
 
@@ -138,33 +139,48 @@ size_t fetch_value_in_file(const char* fname, const char* scan_pattern)
 
 class DefaultGovernor : public PageReclaimGovernor {
 public:
-    size_t get_current_target(size_t load) override
+	int64_t get_lowest(int64_t a, int64_t b) {
+		if (a == no_match)
+			return b;
+		if (b == no_match)
+			return a;
+		return std::min(a,b);
+	}
+	int64_t target_if_valid(int64_t source, int64_t target) {
+		if (source == no_match)
+			return no_match;
+		return target;
+	}
+
+	int64_t get_current_target(size_t load) override
     {
         static_cast<void>(load);
+        std::cout << "\rLoad: " << load << "   Target: " << m_target << "       ";
         if (m_refresh_count > 0) {
             --m_refresh_count;
             return m_target;
         }
-        size_t target;
-        auto from_proc = fetch_value_in_file("/proc/meminfo", "MemTotal:[[:space:]]+([[:digit:]]+) kB") * 1024;
-        auto from_cgroup = fetch_value_in_file("/sys/fs/cgroup/memory/memory.limit_in_bytes", "^([[:digit:]]+)");
-        auto cache_use = fetch_value_in_file("/sys/fs/cgroup/memory/memory.stat", "cache ([[:digit:]]+)");
-        if (from_proc != 0 && from_cgroup != 0) {
-            target = std::min(from_proc, from_cgroup) / 4;
+        int64_t target;
+        auto local_spec = fetch_value_in_file("page_governor.cfg", "target ([[:digit:]]+)");
+        if (local_spec != no_match) { // overrides everything!
+            target = local_spec;
         }
         else {
-            // one of them is zero, just pick the other one
-            target = std::max(from_proc, from_cgroup) / 4;
+            // no local spec, try to deduce something reasonable from platform info
+            auto from_proc = fetch_value_in_file("/proc/meminfo", "MemTotal:[[:space:]]+([[:digit:]]+) kB") * 1024;
+            auto from_cgroup = fetch_value_in_file("/sys/fs/cgroup/memory/memory.limit_in_bytes", "^([[:digit:]]+)");
+            auto cache_use = fetch_value_in_file("/sys/fs/cgroup/memory/memory.stat", "cache ([[:digit:]]+)");
+            target = target_if_valid(from_proc, from_proc / 4);
+            target = get_lowest(target, target_if_valid(from_cgroup, from_cgroup / 4));
+            target = get_lowest(target, target_if_valid(cache_use, cache_use / 2));
         }
-        if (cache_use != 0 && target > cache_use / 2)
-            target = cache_use / 2;
         m_target = target;
         m_refresh_count = 10; // refresh every 10 seconds
         return target;
     }
 
 private:
-    size_t m_target;
+    int64_t m_target;
     int m_refresh_count = 0;
 };
 
@@ -189,7 +205,10 @@ void set_page_reclaim_governor(PageReclaimGovernor* new_governor)
 struct DefaultGovernorInstaller {
     DefaultGovernorInstaller()
     {
-        set_page_reclaim_governor(&default_governor);
+    	if (default_governor.get_current_target(0) != PageReclaimGovernor::no_match) {
+    		// only install if the governor is able to compute a target.
+    		set_page_reclaim_governor(&default_governor);
+    	}
     }
 };
 
@@ -317,14 +336,14 @@ void reclaim_pages()
         load = collect_total_workload();
     }
     // callback to governor without mutex held
-    size_t target = governor->get_current_target(load * page_size()) / page_size();
+    int64_t target = governor->get_current_target(load * page_size()) / page_size();
     {
         UniqueLock lock(mapping_mutex);
-        if (target == 0) // temporarily disabled by governor returning 0
+        if (target == PageReclaimGovernor::no_match) // temporarily disabled by governor returning 0
             return;
         if (mappings_by_file.size() == 0)
             return;
-        size_t work_limit = get_work_limit(load, target);
+        size_t work_limit = get_work_limit(load, size_t(target));
         if (work_limit == 0)
             return; // nothing to do
         if (file_reclaim_index >= mappings_by_file.size())

--- a/src/realm/util/file_mapper.hpp
+++ b/src/realm/util/file_mapper.hpp
@@ -43,8 +43,10 @@ class EncryptedFileMapping;
 class PageReclaimGovernor {
 public:
     // Called by the page reclaimer with the current load (in bytes) and
-    // must return the target load (also in bytes)
-    virtual size_t get_current_target(size_t current_load) = 0;
+    // must return the target load (also in bytes). Returns no_match if no
+	// target can be set
+	static constexpr int64_t no_match = -1;
+    virtual int64_t get_current_target(size_t current_load) = 0;
 };
 
 

--- a/test/test_all.cpp
+++ b/test/test_all.cpp
@@ -223,7 +223,7 @@ void set_random_seed()
 
 class AggressiveGovernor : public PageReclaimGovernor {
 public:
-    virtual size_t get_current_target(size_t) override
+    int64_t get_current_target(size_t) override
     {
         return 4096;
     }

--- a/test/test_transactions.cpp
+++ b/test/test_transactions.cpp
@@ -854,9 +854,9 @@ class ExampleGovernor : public util::PageReclaimGovernor {
 	}
 
 public:
-	virtual size_t get_current_target(size_t load) override
+	int64_t get_current_target(size_t load) override
 	{
-		return file_control_governor(load);
+		return int64_t(file_control_governor(load));
 	}
 };
 


### PR DESCRIPTION
Improvements to the page reclaim governor. Allows a configuration file. Will not waste a thread if targets cannot be computed anyway (e.g. MacOS).