### PR TITLE
Fix warnings reported by GCC 8

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,8 @@
 -----------
 
 ### Internals
-* None.
+* Fixed warnings reported by GCC 8.
+* Replaced call to the deprecated `readdir_r()` with `readdir()`.
 
 ----------------------------------------------
 

--- a/src/realm/column_string_enum.cpp
+++ b/src/realm/column_string_enum.cpp
@@ -31,11 +31,11 @@
 using namespace realm;
 using namespace realm::util;
 
-StringEnumColumn::StringEnumColumn(Allocator& alloc, ref_type ref, ref_type keys_ref, bool nullable,
+StringEnumColumn::StringEnumColumn(Allocator& alloc, ref_type ref, ref_type keys_ref, bool is_nullable,
                                    size_t column_ndx)
     : IntegerColumn(alloc, ref, column_ndx)         // Throws
-    , m_keys(alloc, keys_ref, nullable, column_ndx) // Throws
-    , m_nullable(nullable)
+    , m_keys(alloc, keys_ref, is_nullable, column_ndx) // Throws
+    , m_nullable(is_nullable)
 {
 }
 

--- a/src/realm/query_engine.hpp
+++ b/src/realm/query_engine.hpp
@@ -744,11 +744,11 @@ public:
     {
     }
 
-    void aggregate_local_prepare(Action action, DataType col_id, bool nullable) override
+    void aggregate_local_prepare(Action action, DataType col_id, bool is_nullable) override
     {
         this->m_fastmode_disabled = (col_id == type_Float || col_id == type_Double);
         this->m_action = action;
-        this->m_find_callback_specialized = get_specialized_callback(action, col_id, nullable);
+        this->m_find_callback_specialized = get_specialized_callback(action, col_id, is_nullable);
     }
 
     size_t aggregate_local(QueryStateBase* st, size_t start, size_t end, size_t local_limit,
@@ -813,21 +813,21 @@ public:
 protected:
     using TFind_callback_specialized = typename BaseType::TFind_callback_specialized;
 
-    static TFind_callback_specialized get_specialized_callback(Action action, DataType col_id, bool nullable)
+    static TFind_callback_specialized get_specialized_callback(Action action, DataType col_id, bool is_nullable)
     {
         switch (action) {
             case act_Count:
-                return get_specialized_callback_2_int<act_Count>(col_id, nullable);
+                return get_specialized_callback_2_int<act_Count>(col_id, is_nullable);
             case act_Sum:
-                return get_specialized_callback_2<act_Sum>(col_id, nullable);
+                return get_specialized_callback_2<act_Sum>(col_id, is_nullable);
             case act_Max:
-                return get_specialized_callback_2<act_Max>(col_id, nullable);
+                return get_specialized_callback_2<act_Max>(col_id, is_nullable);
             case act_Min:
-                return get_specialized_callback_2<act_Min>(col_id, nullable);
+                return get_specialized_callback_2<act_Min>(col_id, is_nullable);
             case act_FindAll:
-                return get_specialized_callback_2_int<act_FindAll>(col_id, nullable);
+                return get_specialized_callback_2_int<act_FindAll>(col_id, is_nullable);
             case act_CallbackIdx:
-                return get_specialized_callback_2_int<act_CallbackIdx>(col_id, nullable);
+                return get_specialized_callback_2_int<act_CallbackIdx>(col_id, is_nullable);
             default:
                 break;
         }
@@ -836,15 +836,15 @@ protected:
     }
 
     template <Action TAction>
-    static TFind_callback_specialized get_specialized_callback_2(DataType col_id, bool nullable)
+    static TFind_callback_specialized get_specialized_callback_2(DataType col_id, bool is_nullable)
     {
         switch (col_id) {
             case type_Int:
-                return get_specialized_callback_3<TAction, type_Int>(nullable);
+                return get_specialized_callback_3<TAction, type_Int>(is_nullable);
             case type_Float:
-                return get_specialized_callback_3<TAction, type_Float>(nullable);
+                return get_specialized_callback_3<TAction, type_Float>(is_nullable);
             case type_Double:
-                return get_specialized_callback_3<TAction, type_Double>(nullable);
+                return get_specialized_callback_3<TAction, type_Double>(is_nullable);
             default:
                 break;
         }
@@ -853,19 +853,19 @@ protected:
     }
 
     template <Action TAction>
-    static TFind_callback_specialized get_specialized_callback_2_int(DataType col_id, bool nullable)
+    static TFind_callback_specialized get_specialized_callback_2_int(DataType col_id, bool is_nullable)
     {
         if (col_id == type_Int) {
-            return get_specialized_callback_3<TAction, type_Int>(nullable);
+            return get_specialized_callback_3<TAction, type_Int>(is_nullable);
         }
         REALM_ASSERT(false); // Invalid aggregate source column
         return nullptr;
     }
 
     template <Action TAction, DataType TDataType>
-    static TFind_callback_specialized get_specialized_callback_3(bool nullable)
+    static TFind_callback_specialized get_specialized_callback_3(bool is_nullable)
     {
-        if (nullable) {
+        if (is_nullable) {
             return &BaseType::template find_callback_specialization<TConditionFunction, TAction, TDataType, true>;
         }
         else {

--- a/src/realm/string_data.cpp
+++ b/src/realm/string_data.cpp
@@ -194,8 +194,10 @@ uint_least32_t realm::murmur2_32(const unsigned char* data, size_t len) noexcept
     switch (len) {
         case 3:
             h ^= data[2] << 16;
+            REALM_FALLTHROUGH;
         case 2:
             h ^= data[1] << 8;
+            REALM_FALLTHROUGH;
         case 1:
             h ^= data[0];
             h *= m;

--- a/src/realm/util/features.h
+++ b/src/realm/util/features.h
@@ -71,6 +71,8 @@
 
 #if REALM_HAS_CPP_ATTRIBUTE(clang::fallthrough)
 #define REALM_FALLTHROUGH [[clang::fallthrough]]
+#elif REALM_HAS_CPP_ATTRIBUTE(gnu::fallthrough)
+#define REALM_FALLTHROUGH [[gnu::fallthrough]]
 #elif REALM_HAS_CPP_ATTRIBUTE(fallthrough)
 #define REALM_FALLTHROUGH [[fallthrough]]
 #else

--- a/src/realm/util/memory_stream.hpp
+++ b/src/realm/util/memory_stream.hpp
@@ -116,11 +116,11 @@ inline MemoryInputStreambuf::~MemoryInputStreambuf() noexcept
 {
 }
 
-inline void MemoryInputStreambuf::set_buffer(const char* begin, const char* end) noexcept
+inline void MemoryInputStreambuf::set_buffer(const char* b, const char* e) noexcept
 {
-    m_begin = begin;
-    m_end = end;
-    m_curr = begin;
+    m_begin = b;
+    m_end = e;
+    m_curr = b;
 }
 
 
@@ -132,9 +132,9 @@ inline MemoryOutputStreambuf::~MemoryOutputStreambuf() noexcept
 {
 }
 
-inline void MemoryOutputStreambuf::set_buffer(char* begin, char* end) noexcept
+inline void MemoryOutputStreambuf::set_buffer(char* b, char* e) noexcept
 {
-    setp(begin, end);
+    setp(b, e);
 }
 
 inline size_t MemoryOutputStreambuf::size() const noexcept
@@ -152,31 +152,31 @@ inline MemoryInputStream::~MemoryInputStream() noexcept
 {
 }
 
-inline void MemoryInputStream::set_buffer(const char* begin, const char* end) noexcept
+inline void MemoryInputStream::set_buffer(const char* b, const char* e) noexcept
 {
-    m_streambuf.set_buffer(begin, end);
+    m_streambuf.set_buffer(b, e);
     clear();
 }
 
 template <size_t N> inline void MemoryInputStream::set_buffer(const char (&buffer)[N]) noexcept
 {
-    const char* begin = buffer;
-    const char* end = begin + N;
-    set_buffer(begin, end);
+    const char* b = buffer;
+    const char* e = b + N;
+    set_buffer(b, e);
 }
 
 inline void MemoryInputStream::set_string(const std::string& str) noexcept
 {
-    const char* begin = str.data();
-    const char* end = begin + str.size();
-    set_buffer(begin, end);
+    const char* b = str.data();
+    const char* e = b + str.size();
+    set_buffer(b, e);
 }
 
 inline void MemoryInputStream::set_c_string(const char* c_str) noexcept
 {
-    const char* begin = c_str;
-    const char* end = begin + traits_type::length(c_str);
-    set_buffer(begin, end);
+    const char* b = c_str;
+    const char* e = b + traits_type::length(c_str);
+    set_buffer(b, e);
 }
 
 
@@ -189,9 +189,9 @@ inline MemoryOutputStream::~MemoryOutputStream() noexcept
 {
 }
 
-inline void MemoryOutputStream::set_buffer(char* begin, char* end) noexcept
+inline void MemoryOutputStream::set_buffer(char* b, char* e) noexcept
 {
-    m_streambuf.set_buffer(begin, end);
+    m_streambuf.set_buffer(b, e);
     clear();
 }
 

--- a/test/test_thread.cpp
+++ b/test/test_thread.cpp
@@ -865,9 +865,9 @@ NONCONCURRENT_TEST(Thread_CondvarNotifyAllWakeup)
     std::mutex control_mutex;
     std::condition_variable control_cv;
 
-    const int num_waiters = 10;
+    const size_t num_waiters = 10;
     Thread waiters[num_waiters];
-    for (int i = 0; i < num_waiters; ++i) {
+    for (size_t i = 0; i < num_waiters; ++i) {
         waiters[i].start(std::bind(waiter, &mutex, &changed, &control_mutex, &control_cv, &num_threads_holding_lock));
     }
     {
@@ -880,7 +880,7 @@ NONCONCURRENT_TEST(Thread_CondvarNotifyAllWakeup)
     changed.notify_all();
     mutex.unlock();
 
-    for (int i = 0; i < num_waiters; ++i) {
+    for (size_t i = 0; i < num_waiters; ++i) {
         waiters[i].join();
     }
     changed.release_shared_part();

--- a/test/test_upgrade_database.cpp
+++ b/test/test_upgrade_database.cpp
@@ -609,11 +609,13 @@ TEST_IF(Upgrade_Database_Strings_With_NUL, REALM_MAX_BPNODE_SIZE == 4 || REALM_M
         switch (test_num) {
             case 0:
                 t->set_string(0, reserved_row_index, StringData("12345678901234567890")); // length == 20
+                break;
             case 1:
                 t->set_string(
                     0, reserved_row_index,
                     StringData(
                         "1234567890123456789012345678901234567890123456789012345678901234567890")); // length == 70
+                break;
             default:
                 break;
         }


### PR DESCRIPTION
- Adds `REALM_FALLTHROUGH` in the appropriate places.
- Fixes some integer comparison.
- Replaces `readdir_r()` with `readdir()`. `readdir_r()` is deprecated in glibc.
- Fixes a bunch of shadowing warnings.