### PR TITLE
Fix potential problem in readdir() error handling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,9 @@
 
 ### Internals
 * Upgrade pegtl to 2.6.1. Several issues fixed.
+* A bug was fixed in `realm::util::DirScanner` that could cause it to sometimes
+  skip directory entries due to faulty error handling around `readdir()`. Since
+  5.12.5.
 
 ----------------------------------------------
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,9 @@
 
 ### Fixed
 * <How to hit and notice issue? what was the impact?> ([#????](https://github.com/realm/realm-core/issues/????), since v?.?.?)
-* None.
+* A bug was fixed in `realm::util::DirScanner` that could cause it to sometimes
+  skip directory entries due to faulty error handling around `readdir()`. Since
+  5.12.5. Issue [realm/realm-sync#2699](https://github.com/realm/realm-sync/issues/2699).
  
 ### Breaking changes
 * None.
@@ -15,9 +17,6 @@
 
 ### Internals
 * Upgrade pegtl to 2.6.1. Several issues fixed.
-* A bug was fixed in `realm::util::DirScanner` that could cause it to sometimes
-  skip directory entries due to faulty error handling around `readdir()`. Since
-  5.12.5.
 
 ----------------------------------------------
 

--- a/src/realm/util/file.cpp
+++ b/src/realm/util/file.cpp
@@ -1396,11 +1396,9 @@ bool DirScanner::next(std::string& name)
 
         struct dirent* dirent;
         do {
-            // readdir() does not seem to set errno=0 on success. The manpage
-            // recommends manually zeroing errno before calling it.
-            errno = 0;
             dirent = readdir(m_dirp);
-        } while (errno == EAGAIN);
+        }
+        while (!dirent && errno == EAGAIN);
         if (errno != 0) {
             throw std::system_error(errno, std::system_category(), "readdir() failed");
         }

--- a/src/realm/util/file.cpp
+++ b/src/realm/util/file.cpp
@@ -1385,6 +1385,10 @@ DirScanner::~DirScanner() noexcept
 
 bool DirScanner::next(std::string& name)
 {
+#if !defined(__linux__) && !REALM_PLATFORM_APPLE && !REALM_WINDOWS && !REALM_UWP && !REALM_ANDROID
+#error "readdir() is not known to be thread-safe on this platform"
+#endif
+
     if (!m_dirp)
         return false;
 

--- a/src/realm/util/file.cpp
+++ b/src/realm/util/file.cpp
@@ -1396,6 +1396,12 @@ bool DirScanner::next(std::string& name)
 
         struct dirent* dirent;
         do {
+            // readdir() signals both errors and end-of-stream by returning a
+            // null pointer. To distinguish between end-of-stream and errors,
+            // the manpage recommends setting errno specifically to 0 before
+            // calling it...
+            errno = 0;
+
             dirent = readdir(m_dirp);
         }
         while (!dirent && errno == EAGAIN);

--- a/src/realm/util/file.cpp
+++ b/src/realm/util/file.cpp
@@ -1409,11 +1409,12 @@ bool DirScanner::next(std::string& name)
             dirent = readdir(m_dirp);
         }
         while (!dirent && errno == EAGAIN);
-        if (errno != 0) {
-            throw std::system_error(errno, std::system_category(), "readdir() failed");
-        }
-        if (!dirent)
+
+        if (!dirent) {
+            if (errno != 0)
+                throw std::system_error(errno, std::generic_category(), "readdir() failed");
             return false; // End of stream
+        }
         const char* name_1 = dirent->d_name;
         std::string name_2 = name_1;
         if (name_2 != "." && name_2 != "..") {

--- a/src/realm/util/file.cpp
+++ b/src/realm/util/file.cpp
@@ -1407,8 +1407,7 @@ bool DirScanner::next(std::string& name)
             errno = 0;
 
             dirent = readdir(m_dirp);
-        }
-        while (!dirent && errno == EAGAIN);
+        } while (!dirent && errno == EAGAIN);
 
         if (!dirent) {
             if (errno != 0)


### PR DESCRIPTION
This fixes a potential problem introduced in #3174, which could theoretically result in `DirScanner` skipping entries under certain error conditions.

This is likely the root cause for realm/realm-sync#2699.

The hypothesis is as follows: If `readdir()` temporarily sets `errno`, or `errno` was already set to `EAGAIN` from a previous system call, the retry loop would skip over valid directory entries even if no error occurred. This is fixed by checking the return value of `readdir()` before checking `errno`.