### PR TITLE
Parser improvements

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,8 @@
 
 ### Internals
 * For convenience, `parser::parse` now accepts a `StringData` type instead of just `std::string`.
+* Parsing a query which uses the 'between' operator now gives a better error message indicating
+  that support is not yet implemented.
 
 ----------------------------------------------
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,7 @@
 -----------
 
 ### Internals
-* None.
+* For convenience, `parser::parse` now accepts a `StringData` type instead of just `std::string`.
 
 ----------------------------------------------
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,8 @@
 # NEXT RELEASE
 
 ### Enhancements
-* None.
+* The parser now supports readable timestamps with a 'T' separator in addition to the originally supported "@" separator.
+  For example: "startDate > 1981-11-01T23:59:59:1". ([#3198](https://github.com/realm/realm-core/issues/3198)).
 
 ### Fixed
 * <How to hit and notice issue? what was the impact?> ([#????](https://github.com/realm/realm-core/issues/????), since v?.?.?)
@@ -15,7 +16,7 @@
 ### Internals
 * For convenience, `parser::parse` now accepts a `StringData` type instead of just `std::string`.
 * Parsing a query which uses the 'between' operator now gives a better error message indicating
-  that support is not yet implemented.
+  that support is not yet implemented. ([#3198](https://github.com/realm/realm-core/issues/3198)).
 
 ----------------------------------------------
 

--- a/src/realm/parser/parser.cpp
+++ b/src/realm/parser/parser.cpp
@@ -147,6 +147,7 @@ struct contains : string_token_t("contains") {};
 struct begins : string_token_t("beginswith") {};
 struct ends : string_token_t("endswith") {};
 struct like : string_token_t("like") {};
+struct between : string_token_t("between") {};
 
 struct sort_prefix : seq< string_token_t("sort"), star< blank >, one< '(' > > {};
 struct distinct_prefix : seq< string_token_t("distinct"), star< blank >, one< '(' > > {};
@@ -163,7 +164,7 @@ struct predicate_suffix_modifier : sor< sort, distinct, limit > {};
 
 struct string_oper : seq< sor< contains, begins, ends, like>, star< blank >, opt< case_insensitive > > {};
 // "=" is equality and since other operators can start with "=" we must check equal last
-struct symbolic_oper : sor< noteq, lteq, lt, gteq, gt, eq, in > {};
+struct symbolic_oper : sor< noteq, lteq, lt, gteq, gt, eq, in, between > {};
 
 // predicates
 struct comparison_pred : seq< expr, pad< sor< string_oper, symbolic_oper >, blank >, expr > {};
@@ -641,6 +642,16 @@ OPERATOR_ACTION(begins, Predicate::Operator::BeginsWith)
 OPERATOR_ACTION(ends, Predicate::Operator::EndsWith)
 OPERATOR_ACTION(contains, Predicate::Operator::Contains)
 OPERATOR_ACTION(like, Predicate::Operator::Like)
+
+template<> struct action< between >
+{
+    template< typename Input >
+    static void apply(const Input& in, ParserState&)
+    {
+        const static std::string message = "Invalid Predicate. The 'between' operator is not supported yet, please rewrite the expression using '>' and '<'.";
+        throw tao::pegtl::parse_error(message, in);
+    }
+};
 
 template<> struct action< case_insensitive >
 {

--- a/src/realm/parser/parser.cpp
+++ b/src/realm/parser/parser.cpp
@@ -78,8 +78,9 @@ struct first_timestamp_number : disable< timestamp_number > {};
 struct internal_timestamp : seq< one< 'T' >, first_timestamp_number, one< ':' >, timestamp_number > {};
 // T2017-09-28@23:12:60:288833
 // YYYY-MM-DD@HH:MM:SS:NANOS nanos optional
+// or the above with 'T' in place of '@'
 struct readable_timestamp : seq< first_timestamp_number, one< '-' >, timestamp_number, one< '-' >,
-    timestamp_number, one< '@' >, timestamp_number, one< ':' >, timestamp_number, one< ':' >,
+    timestamp_number, one< '@', 'T' >, timestamp_number, one< ':' >, timestamp_number, one< ':' >,
     timestamp_number, opt< seq< one< ':' >, timestamp_number > > > {};
 struct timestamp : sor< internal_timestamp, readable_timestamp > {};
 

--- a/src/realm/parser/parser.hpp
+++ b/src/realm/parser/parser.hpp
@@ -22,6 +22,7 @@
 #include <memory>
 #include <string>
 #include <vector>
+#include <realm/string_data.hpp>
 
 namespace realm {
 
@@ -130,7 +131,9 @@ struct ParserResult
     DescriptorOrderingState ordering;
 };
 
-ParserResult parse(const std::string &query);
+ParserResult parse(const char* query); // assumes c-style null termination
+ParserResult parse(const std::string& query);
+ParserResult parse(const realm::StringData& query);
 
 // run the analysis tool to check for cycles in the grammar
 // returns the number of problems found and prints some info to std::cout

--- a/test/test_parser.cpp
+++ b/test/test_parser.cpp
@@ -712,66 +712,78 @@ TEST(Parser_Timestamps)
     t->set_link(link_col_ndx, 2, 0);
 
     Query q = t->where();
-    verify_query(test_context, t, "T399 == NULL", 1);
-    verify_query(test_context, t, "T399 != NULL", 4);
-    verify_query(test_context, t, "linked.T399 == NULL", 4); // null links count as a match for null here
-    verify_query(test_context, t, "linked != NULL && linked.T399 == NULL", 1);
-    verify_query(test_context, t, "linked.T399 != NULL", 1);
-    verify_query(test_context, t, "linked != NULL && linked.T399 != NULL", 1);
-    verify_query(test_context, t, "T399 == T399:0", 0);
-    verify_query(test_context, t, "linked.T399 == T399:0", 0);
-    verify_query(test_context, t, "T399 == 2017-12-04@0:0:0", 0);
+    auto verify_with_format = [&](const char* separator) {
+        verify_query(test_context, t, "T399 == NULL", 1);
+        verify_query(test_context, t, "T399 != NULL", 4);
+        verify_query(test_context, t, "linked.T399 == NULL", 4); // null links count as a match for null here
+        verify_query(test_context, t, "linked != NULL && linked.T399 == NULL", 1);
+        verify_query(test_context, t, "linked.T399 != NULL", 1);
+        verify_query(test_context, t, "linked != NULL && linked.T399 != NULL", 1);
+        verify_query(test_context, t, "T399 == T399:0", 0);
+        verify_query(test_context, t, "linked.T399 == T399:0", 0);
+        verify_query(test_context, t, std::string("T399 == 2017-12-04") + separator + "0:0:0", 0);
 
-    verify_query(test_context, t, "T2017-12-04 == NULL", 3);
-    verify_query(test_context, t, "T2017-12-04 != NULL", 2);
-    verify_query(test_context, t, "T2017-12-04 != NIL", 2);
-    verify_query(test_context, t, "linked.T2017-12-04 == NULL", 3); // null links count as a match for null here
-    verify_query(test_context, t, "linked != NULL && linked.T2017-12-04 == NULL", 0);
-    verify_query(test_context, t, "linked.T2017-12-04 != NULL", 2);
-    verify_query(test_context, t, "linked != NULL && linked.T2017-12-04 != NULL", 2);
-    verify_query(test_context, t, "T2017-12-04 == T399:0", 0);
-    verify_query(test_context, t, "linked.T2017-12-04 == T399:0", 0);
-    verify_query(test_context, t, "T2017-12-04 == 2017-12-04@0:0:0", 0);
+        verify_query(test_context, t, "T2017-12-04 == NULL", 3);
+        verify_query(test_context, t, "T2017-12-04 != NULL", 2);
+        verify_query(test_context, t, "T2017-12-04 != NIL", 2);
+        verify_query(test_context, t, "linked.T2017-12-04 == NULL", 3); // null links count as a match for null here
+        verify_query(test_context, t, "linked != NULL && linked.T2017-12-04 == NULL", 0);
+        verify_query(test_context, t, "linked.T2017-12-04 != NULL", 2);
+        verify_query(test_context, t, "linked != NULL && linked.T2017-12-04 != NULL", 2);
+        verify_query(test_context, t, "T2017-12-04 == T399:0", 0);
+        verify_query(test_context, t, "linked.T2017-12-04 == T399:0", 0);
+        verify_query(test_context, t, "T2017-12-04 == 2017-12-04@0:0:0", 0);
 
-    verify_query(test_context, t, "birthday == NULL", 0);
-    verify_query(test_context, t, "birthday == NIL", 0);
-    verify_query(test_context, t, "birthday != NULL", 5);
-    verify_query(test_context, t, "birthday != NIL", 5);
-    verify_query(test_context, t, "birthday == T0:0", 3);
-    verify_query(test_context, t, "birthday == 1970-1-1@0:0:0:0", 3); // epoch is default non-null Timestamp
+        verify_query(test_context, t, "birthday == NULL", 0);
+        verify_query(test_context, t, "birthday == NIL", 0);
+        verify_query(test_context, t, "birthday != NULL", 5);
+        verify_query(test_context, t, "birthday != NIL", 5);
+        verify_query(test_context, t, "birthday == T0:0", 3);
+        verify_query(test_context, t, std::string("birthday == 1970-1-1") + separator + "0:0:0:0", 3); // epoch is default non-null Timestamp
 
 #ifndef _WIN32 // windows native functions do not support pre epoch conversions, other platforms stop at ~1901
-    verify_query(test_context, t, "birthday == 1969-12-31@23:59:59:1", 1); // just before epoch
-    verify_query(test_context, t, "birthday > 1905-12-31@23:59:59", 5);
-    verify_query(test_context, t, "birthday > 1905-12-31@23:59:59:2020", 5);
+        verify_query(test_context, t, std::string("birthday == 1969-12-31") + separator + "23:59:59:1", 1); // just before epoch
+        verify_query(test_context, t, std::string("birthday > 1905-12-31") + separator + "23:59:59", 5);
+        verify_query(test_context, t, std::string("birthday > 1905-12-31") + separator + "23:59:59:2020", 5);
 #endif
 
-    // two column timestamps
-    verify_query(test_context, t, "birthday == T399", 1); // a null entry matches
+        // two column timestamps
+        verify_query(test_context, t, "birthday == T399", 1); // a null entry matches
 
-    // dates pre 1900 are not supported by functions like timegm
-    CHECK_THROW_ANY(verify_query(test_context, t, "birthday > 1800-12-31@23:59:59", 0));
-    CHECK_THROW_ANY(verify_query(test_context, t, "birthday > 1800-12-31@23:59:59:2020", 4));
+        // dates pre 1900 are not supported by functions like timegm
+        CHECK_THROW_ANY(verify_query(test_context, t, std::string("birthday > 1800-12-31") + separator + "23:59:59", 0));
+        CHECK_THROW_ANY(verify_query(test_context, t, std::string("birthday > 1800-12-31") + separator + "23:59:59:2020", 4));
 
-    // negative nanoseconds are not allowed
-    CHECK_THROW_ANY(verify_query(test_context, t, "birthday == T-1:1", 0));
-    CHECK_THROW_ANY(verify_query(test_context, t, "birthday == T1:-1", 0));
-    CHECK_THROW_ANY(verify_query(test_context, t, "birthday == 1970-1-1@0:0:1:-1", 0));
-    CHECK_THROW_ANY(verify_query(test_context, t, "birthday == 1969-12-31@23:59:59:-1", 1));
-    CHECK_THROW_ANY(verify_query(test_context, t, "birthday == 1970-1-1@0:0:0:-1", 1));
+        // negative nanoseconds are not allowed
+        CHECK_THROW_ANY(verify_query(test_context, t, "birthday == T-1:1", 0));
+        CHECK_THROW_ANY(verify_query(test_context, t, "birthday == T1:-1", 0));
+        CHECK_THROW_ANY(verify_query(test_context, t, std::string("birthday == 1970-1-1") + separator + "0:0:1:-1", 0));
+        CHECK_THROW_ANY(verify_query(test_context, t, std::string("birthday == 1969-12-31") + separator + "23:59:59:-1", 1));
+        CHECK_THROW_ANY(verify_query(test_context, t, std::string("birthday == 1970-1-1") + separator + "0:0:0:-1", 1));
 
-    // Invalid predicate
-    CHECK_THROW_ANY(verify_query(test_context, t, "birthday == T1:", 0));
-    CHECK_THROW_ANY(verify_query(test_context, t, "birthday == T:1", 0));
-    CHECK_THROW_ANY(verify_query(test_context, t, "birthday == 1970-1-1", 0));
-    CHECK_THROW_ANY(verify_query(test_context, t, "birthday == 1970-1-1@", 0));
-    CHECK_THROW_ANY(verify_query(test_context, t, "birthday == 1970-1-1@0", 0));
-    CHECK_THROW_ANY(verify_query(test_context, t, "birthday == 1970-1-1@0:", 0));
-    CHECK_THROW_ANY(verify_query(test_context, t, "birthday == 1970-1-1@0:0", 0));
-    CHECK_THROW_ANY(verify_query(test_context, t, "birthday == 1970-1-1@0:0:", 0));
-    CHECK_THROW_ANY(verify_query(test_context, t, "birthday == 1970-1-1@0:0:0:", 0));
-    CHECK_THROW_ANY(verify_query(test_context, t, "birthday == 1970-1-1@0:0:0:0:", 0));
-    CHECK_THROW_ANY(verify_query(test_context, t, "birthday == 1970-1-1@0:0:0:0:0", 0));
+        // Invalid predicate
+        CHECK_THROW_ANY(verify_query(test_context, t, "birthday == T1:", 0));
+        CHECK_THROW_ANY(verify_query(test_context, t, "birthday == T:1", 0));
+        CHECK_THROW_ANY(verify_query(test_context, t, "birthday == 1970-1-1", 0));
+        CHECK_THROW_ANY(verify_query(test_context, t, std::string("birthday == 1970-1-1") + separator, 0));
+        CHECK_THROW_ANY(verify_query(test_context, t, std::string("birthday == 1970-1-1") + separator + "0", 0));
+        CHECK_THROW_ANY(verify_query(test_context, t, std::string("birthday == 1970-1-1") + separator + "0:", 0));
+        CHECK_THROW_ANY(verify_query(test_context, t, std::string("birthday == 1970-1-1") + separator + "0:0", 0));
+        CHECK_THROW_ANY(verify_query(test_context, t, std::string("birthday == 1970-1-1") + separator + "0:0:", 0));
+        CHECK_THROW_ANY(verify_query(test_context, t, std::string("birthday == 1970-1-1") + separator + "0:0:0:", 0));
+        CHECK_THROW_ANY(verify_query(test_context, t, std::string("birthday == 1970-1-1") + separator + "0:0:0:0:", 0));
+        CHECK_THROW_ANY(verify_query(test_context, t, std::string("birthday == 1970-1-1") + separator + "0:0:0:0:0", 0));
+    };
+
+    // both versions are allowed
+    verify_with_format("@");
+    verify_with_format("T");
+
+    // using both separators at the same time is an error
+    CHECK_THROW_ANY(verify_query(test_context, t, "birthday == 1970-1-1T@0:0:0:0", 3));
+    CHECK_THROW_ANY(verify_query(test_context, t, "birthday == 1970-1-1@T0:0:0:0", 3));
+    // omitting the separator is an error
+    CHECK_THROW_ANY(verify_query(test_context, t, "birthday == 1970-1-10:0:0:0:0", 0));
 }
 
 

--- a/test/test_parser.cpp
+++ b/test/test_parser.cpp
@@ -2668,7 +2668,8 @@ TEST(Parser_OperatorIN)
 
 // we won't support full object comparisons until we have stable keys in core, but as an exception
 // we allow comparison with null objects because we can serialise that and bindings use it to check agains nulls.
-TEST(Parser_RowIndex) {
+TEST(Parser_RowIndex)
+{
     Group g;
     TableRef table = g.add_table("table");
     size_t int_col_ndx = table->add_column(type_Int, "ints", true);
@@ -2692,6 +2693,29 @@ TEST(Parser_RowIndex) {
     CHECK_EQUAL(q1.count(), 2);
 
     CHECK_THROW_ANY(verify_query(test_context, table, "link == link", 3));
+}
+
+TEST(Parser_Between)
+{
+    Group g;
+    TableRef table = g.add_table("table");
+    size_t int_col_ndx = table->add_column(type_Int, "age", true);
+    size_t between_col_ndx = table->add_column(type_Int, "between", true);
+    table->add_empty_row(3);
+    for (size_t i = 0; i < table->size(); ++i) {
+        table->set_int(int_col_ndx, i, i + 24);
+        table->set_int(between_col_ndx, i, i);
+    }
+
+    // normal querying on a property named "between" is allowed.
+    verify_query(test_context, table, "between == 0", 1);
+    verify_query(test_context, table, "between > 0", 2);
+    verify_query(test_context, table, "between <= 3", 3);
+
+    // operator between is not supported yet, but we at least use a friendly error message.
+    std::string message;
+    CHECK_THROW_ANY_GET_MESSAGE(verify_query(test_context, table, "age between {20, 25}", 1), message);
+    CHECK(message.find("Invalid Predicate. The 'between' operator is not supported yet, please rewrite the expression using '>' and '<'.") != std::string::npos);
 }
 
 #endif // TEST_PARSER


### PR DESCRIPTION
Fixes #3198.

Also provides a solution to the "FIXME:" [in sync](https://github.com/realm/realm-sync/blob/develop/src/realm/noinst/partial_sync.cpp#L1039) about not being able to parse a `StringData` type directly.