### PR TITLE
Emit the correct instruction for add_row_with_key(none)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,9 @@
 * Compacting a realm into an encrypted file could take a really long time. The process is now optimized by adjusting the write
   buffer size relative to the used space in the realm.
   ([#2754](https://github.com/realm/realm-sync/issues/2754))
- 
+* Creating an object after creating an object with the int primary key of "null" would hit an assertion failure.
+  ([#3227](https://github.com/realm/realm-core/pull/3227)).
+
 ### Breaking changes
 * None.
 

--- a/src/realm/table.cpp
+++ b/src/realm/table.cpp
@@ -2251,7 +2251,7 @@ size_t Table::add_row_with_key(size_t key_col_ndx, util::Optional<int64_t> key)
             repl->add_row_with_key(this, row_ndx, prior_num_rows, key_col_ndx, *key); // Throws
         else {
             repl->insert_empty_rows(this, row_ndx, 1, prior_num_rows); // Throws
-            repl->set_null(this, key_col_ndx, row_ndx);
+            repl->set_null(this, key_col_ndx, row_ndx, _impl::instr_SetUnique);
         }
     }
 


### PR DESCRIPTION
The add_row_with_key instruction can't express a null int key, so instead we emit a row insert plus set null. This needs to set the variant as SetUnique for sync to handle this properly.

I don't think this bug has any observable effects for a non-sync realm so there's nothing to test here.