### PR TITLE
Expose metrics query table name

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
   prevents excessive memory growth if users turn on metrics but don't use it.
 * Metrics transaction objects now store the number of decrypted pages currently in memory.
 * SharedGroup::get_stats includes an optional parameter to get size of currently locked memory.
+* Metrics now exposes the table name of queries which have been run.
 
 ### Fixed
 * In cases where the main thread would exit before other threads, we could destroy a mutex

--- a/src/realm/metrics/query_info.cpp
+++ b/src/realm/metrics/query_info.cpp
@@ -36,6 +36,7 @@ QueryInfo::QueryInfo(const Query* query, QueryType type)
     REALM_ASSERT(group);
 
     m_description = query->get_description();
+    m_table_name = query->m_table->get_name();
 }
 
 QueryInfo::~QueryInfo() noexcept
@@ -45,6 +46,11 @@ QueryInfo::~QueryInfo() noexcept
 std::string QueryInfo::get_description() const
 {
     return m_description;
+}
+
+std::string QueryInfo::get_table_name() const
+{
+    return m_table_name;
 }
 
 QueryInfo::QueryType QueryInfo::get_type() const

--- a/src/realm/metrics/query_info.hpp
+++ b/src/realm/metrics/query_info.hpp
@@ -53,6 +53,7 @@ public:
     ~QueryInfo() noexcept;
 
     std::string get_description() const;
+    std::string get_table_name() const;
     QueryType get_type() const;
     double get_query_time() const;
 
@@ -61,6 +62,7 @@ public:
 
 private:
     std::string m_description;
+    std::string m_table_name;
     QueryType m_type;
     std::shared_ptr<MetricTimerResult> m_query_time;
 };

--- a/test/test_metrics.cpp
+++ b/test/test_metrics.cpp
@@ -316,8 +316,10 @@ TEST(Metrics_QueryEqual)
 
     for (size_t i = 0; i < 7; ++i) {
         std::string description = queries->at(i).get_description();
+        std::string table_name = queries->at(i).get_table_name();
         CHECK_EQUAL(find_count(description, column_names[i]), 1);
         CHECK_GREATER_EQUAL(find_count(description, query_search_term), 1);
+        CHECK_EQUAL(table_name, "person");
     }
 }
 


### PR DESCRIPTION
This was forgotten in the original implementation. The query text is only really useful if tied together with the table name that it was run against.