### PR TITLE
fix for premature destruction of mutex

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,8 +9,11 @@
 
 ### Fixed
 * <How to hit and notice issue? what was the impact?> ([#????](https://github.com/realm/realm-core/issues/????), since v?.?.?)
-* None.
- 
+* In cases where the main thread would exit before other threads, we could destroy a mutex
+  while it was still in use on other threads. This would cause a crash during shutdown.
+  This bug was introduced by https://github.com/realm/realm-core/pull/3185, which was part
+  of release 5.12.5
+
 ### Breaking changes
 * None.
 

--- a/src/realm/util/file_mapper.cpp
+++ b/src/realm/util/file_mapper.cpp
@@ -106,7 +106,7 @@ struct mapping_and_addr {
     size_t size;
 };
 
-util::Mutex mapping_mutex;
+util::Mutex& mapping_mutex = *(new util::Mutex);
 std::vector<mapping_and_addr>& mappings_by_addr = *new std::vector<mapping_and_addr>;
 std::vector<mappings_for_file>& mappings_by_file = *new std::vector<mappings_for_file>;
 unsigned int file_reclaim_index = 0;

--- a/src/realm/util/file_mapper.hpp
+++ b/src/realm/util/file_mapper.hpp
@@ -97,7 +97,7 @@ void inline encryption_write_barrier(const void* addr, size_t size, EncryptedFil
 }
 
 
-extern util::Mutex mapping_mutex;
+extern util::Mutex& mapping_mutex;
 
 inline void do_encryption_read_barrier(const void* addr, size_t size, HeaderToSize header_to_size,
                                        EncryptedFileMapping* mapping)


### PR DESCRIPTION
Prevent destruction of mutex as part of main thread shutdown, while it is still in use by other threads.
