### PR TITLE
Fix a race setting the encryption governor

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,9 @@
   while it was still in use on other threads. This would cause a crash during shutdown.
   This bug was introduced by https://github.com/realm/realm-core/pull/3185, which was part
   of release 5.12.5
+* Fix a race between the encryption page reclaim governor running and setting a governor.
+  This only affects applications which actually set the governor to something custom (likely none).
+  ([#3239](https://github.com/realm/realm-core/issues/3239), since v5.12.2)
 
 ### Breaking changes
 * None.

--- a/src/realm/util/file_mapper.hpp
+++ b/src/realm/util/file_mapper.hpp
@@ -64,7 +64,10 @@ void set_page_reclaim_governor(PageReclaimGovernor* governor);
 
 // Use the default governor. The default governor is used automatically if nothing else is set, so
 // this funciton is mostly useful for tests where changing back to the default could be desirable.
-void set_page_reclaim_governor_to_default();
+inline void set_page_reclaim_governor_to_default()
+{
+    set_page_reclaim_governor(nullptr);
+}
 
 // Retrieves the number of in memory decrypted pages, across all open files.
 size_t get_num_decrypted_pages();
@@ -118,10 +121,6 @@ inline void do_encryption_write_barrier(const void* addr, size_t size, Encrypted
 #else
 
 void inline set_page_reclaim_governor(PageReclaimGovernor*)
-{
-}
-
-void inline set_page_reclaim_governor_to_default()
 {
 }
 

--- a/src/realm/util/file_mapper.hpp
+++ b/src/realm/util/file_mapper.hpp
@@ -24,6 +24,8 @@
 #include <realm/util/thread.hpp>
 #include <realm/util/encrypted_file_mapping.hpp>
 
+#include <functional>
+
 namespace realm {
 namespace util {
 
@@ -46,7 +48,8 @@ public:
     // must return the target load (also in bytes). Returns no_match if no
 	// target can be set
 	static constexpr int64_t no_match = -1;
-    virtual int64_t get_current_target(size_t current_load) = 0;
+    virtual std::function<int64_t()> current_target_getter(size_t load) = 0;
+    virtual void report_target_result(int64_t) = 0;
 };
 
 // Set a page reclaim governor. The governor is an object with a method which will be called periodically

--- a/test/test_all.cpp
+++ b/test/test_all.cpp
@@ -223,9 +223,12 @@ void set_random_seed()
 
 class AggressiveGovernor : public PageReclaimGovernor {
 public:
-    int64_t get_current_target(size_t) override
+    std::function<int64_t()> current_target_getter(size_t) override
     {
-        return 4096;
+        return []() { return 4096; };
+    }
+    void report_target_result(int64_t) override
+    {
     }
 };
 

--- a/test/test_metrics.cpp
+++ b/test/test_metrics.cpp
@@ -936,11 +936,16 @@ public:
     {
         has_run_once = will_run.get_future();
     }
-    int64_t get_current_target(size_t)
+    std::function<int64_t()> current_target_getter(size_t) override
+    {
+        return []() { return realm::util::PageReclaimGovernor::no_match; };
+    }
+
+    void report_target_result(int64_t) override
     {
         will_run.set_value();
-        return no_match;
     }
+
     std::future<void> has_run_once;
     std::promise<void> will_run;
 };

--- a/test/test_transactions.cpp
+++ b/test/test_transactions.cpp
@@ -806,13 +806,16 @@ void preparations(SharedGroup& sg_w)
 // illustration of possible governor function which takes total system load into account
 class ExampleGovernor : public util::PageReclaimGovernor {
 public:
-    size_t get_current_target(size_t load) override
+    std::function<int64_t()> current_target_getter(size_t load) override
     {
-        return file_control_governor(load);
+        return std::bind(file_control_governor, load);
+    }
+    void report_target_result(int64_t) override
+    {
     }
 
 private:
-    size_t system_memory_governor(size_t load) {
+    static size_t system_memory_governor(size_t load) {
         try {
             auto file = fopen("/proc/meminfo","r");
             if (file == nullptr)
@@ -842,7 +845,7 @@ private:
         }
     }
 
-    size_t file_control_governor(size_t load) {
+    static size_t file_control_governor(size_t load) {
         try {
             auto file = fopen("governor.txt", "r");
             if (file == nullptr)


### PR DESCRIPTION
There is a race between setting the governor and the governor running (caught by tsan here: https://ci.realm.io/blue/organizations/jenkins/realm%2Frealm-core/detail/PR-3238/1/pipeline).

The problem was one function that was not being run under the protection of the mutex. I changed the governor interface to return a `std::function` which can be invoked without the mutex. This lets us protect the governor, but also allows the potentially long operations of getting the limit from various system files to be run asynchronously without blocking Realm encryption/decryption.

I don't think this race hits users because as far as I know, no binding is setting a custom governor. But the tsan tests should run clean.