### PR TITLE
Add option to Group::write to strip history

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,8 @@
 ### Enhancements
 * Improved performance of encryption and decryption significantly by utilizing hardware optimized encryption functions.
   ([#293](https://github.com/realm/realm-core-private/issues/293))
+* Added the ability to write a Group with the history stripped.
+  ([#3245](https://github.com/realm/realm-core/pull/3245))
 
 ### Fixed
 * <How to hit and notice issue? what was the impact?> ([#????](https://github.com/realm/realm-core/issues/????), since v?.?.?)

--- a/src/realm/group.cpp
+++ b/src/realm/group.cpp
@@ -714,8 +714,9 @@ void Group::rename_table(size_t table_ndx, StringData new_name, bool require_uni
 
 class Group::DefaultTableWriter : public Group::TableWriter {
 public:
-    DefaultTableWriter(const Group& group)
+    DefaultTableWriter(const Group& group, bool write_history)
         : m_group(group)
+        , m_write_history(write_history)
     {
     }
     ref_type write_names(_impl::OutputStream& out) override
@@ -746,7 +747,8 @@ public:
                                                              history_type,
                                                              history_schema_version);
             REALM_ASSERT(history_type != Replication::hist_None);
-            if (history_type != Replication::hist_SyncClient && history_type != Replication::hist_SyncServer) {
+            if (!m_write_history ||
+                (history_type != Replication::hist_SyncClient && history_type != Replication::hist_SyncServer)) {
                 return info; // Only sync history should be preserved when writing to a new file
             }
             info.type = history_type;
@@ -762,30 +764,32 @@ public:
 
 private:
     const Group& m_group;
+    bool m_write_history;
 };
 
 void Group::write(std::ostream& out, bool pad) const
 {
-    write(out, pad, 0);
+    write(out, pad, 0, true);
 }
 
-void Group::write(std::ostream& out, bool pad_for_encryption, uint_fast64_t version_number) const
+void Group::write(std::ostream& out, bool pad_for_encryption, uint_fast64_t version_number, bool write_history) const
 {
     REALM_ASSERT(is_attached());
-    DefaultTableWriter table_writer(*this);
+    DefaultTableWriter table_writer(*this, write_history);
     bool no_top_array = !m_top.is_attached();
     write(out, m_file_format_version, table_writer, no_top_array, pad_for_encryption, version_number); // Throws
 }
 
-void Group::write(const std::string& path, const char* encryption_key, uint64_t version_number) const
+void Group::write(const std::string& path, const char* encryption_key, uint64_t version_number,
+                  bool write_history) const
 {
     File file;
     int flags = 0;
     file.open(path, File::access_ReadWrite, File::create_Must, flags);
-    write(file, encryption_key, version_number);
+    write(file, encryption_key, version_number, write_history);
 }
 
-void Group::write(File& file, const char* encryption_key, uint_fast64_t version_number) const
+void Group::write(File& file, const char* encryption_key, uint_fast64_t version_number, bool write_history) const
 {
     REALM_ASSERT(file.get_size() == 0);
 
@@ -802,7 +806,7 @@ void Group::write(File& file, const char* encryption_key, uint_fast64_t version_
 
     std::ostream out(&streambuf);
     out.exceptions(std::ios_base::failbit | std::ios_base::badbit);
-    write(out, encryption_key != 0, version_number);
+    write(out, encryption_key != 0, version_number, write_history);
     int sync_status = streambuf.pubsync();
     REALM_ASSERT(sync_status == 0);
 }

--- a/src/realm/group.hpp
+++ b/src/realm/group.hpp
@@ -380,7 +380,8 @@ public:
     /// types that are derived from util::File::AccessError, the
     /// derived exception type is thrown. In particular,
     /// util::File::Exists will be thrown if the file exists already.
-    void write(const std::string& file, const char* encryption_key = nullptr, uint64_t version = 0) const;
+    void write(const std::string& file, const char* encryption_key = nullptr, uint64_t version = 0,
+               bool write_history = true) const;
 
     /// Write this database to a memory buffer.
     ///
@@ -695,8 +696,8 @@ private:
 
     void mark_all_table_accessors() noexcept;
 
-    void write(util::File& file, const char* encryption_key, uint_fast64_t version_number) const;
-    void write(std::ostream&, bool pad, uint_fast64_t version_numer) const;
+    void write(util::File& file, const char* encryption_key, uint_fast64_t version_number, bool write_history) const;
+    void write(std::ostream&, bool pad, uint_fast64_t version_numer, bool write_history) const;
 
     Replication* get_replication() const noexcept;
     void set_replication(Replication*) noexcept;

--- a/src/realm/group_shared.cpp
+++ b/src/realm/group_shared.cpp
@@ -1370,7 +1370,7 @@ bool SharedGroup::compact(bool bump_version_number, util::Optional<const char*> 
             File file;
             file.open(tmp_path, File::access_ReadWrite, File::create_Must, 0);
             int incr = bump_version_number ? 1 : 0;
-            m_group.write(file, write_key, info->latest_version_number + incr); // Throws
+            m_group.write(file, write_key, info->latest_version_number + incr, true); // Throws
             // Data needs to be flushed to the disk before renaming.
             bool disable_sync = get_disable_sync_to_disk();
             if (!disable_sync && dura != Durability::Unsafe)


### PR DESCRIPTION
Fast way for Sync to make a snapshot file.^

Fixes #3243 