### PR TITLE
Publish a TSAN build

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -295,7 +295,7 @@ def doBuildLinuxTSAN() {
                 sh """
                    mkdir build-dir
                    cd build-dir
-                   cmake -D CMAKE_BUILD_TYPE=RelWithDebInfo -D REALM_TSAN=ON -D REALM_NO_TESTS=1 -G Ninja ..
+                   cmake -D CMAKE_BUILD_TYPE=RelTSAN -D REALM_NO_TESTS=1 -G Ninja ..
                    ninja
                    cpack -G TGZ
                 """

--- a/tools/cmake/SpecialtyBuilds.cmake
+++ b/tools/cmake/SpecialtyBuilds.cmake
@@ -8,6 +8,11 @@ if (CMAKE_BUILD_TYPE MATCHES "RelASAN")
     set(CMAKE_CXX_FLAGS_RELASAN "${CMAKE_CXX_FLAGS_RELWITHDEBINFO} -O1")
 endif()
 
+if (CMAKE_BUILD_TYPE MATCHES "RelTSAN")
+    set(REALM_TSAN ON CACHE BOOL "Build with address sanitizer")
+    set(CMAKE_CXX_FLAGS_RELTSAN "${CMAKE_CXX_FLAGS_RELWITHDEBINFO} -O1")
+endif()
+
 # -------------
 # Coverage
 # -------------


### PR DESCRIPTION
This enables downstream projects to use TSAN themselves. The build is produced for linux with clang 6 and only on core publishing runs.
It is a dependency of https://github.com/realm/realm-sync/pull/2852