### PR TITLE
Fix error in two column query

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,8 @@
 
 ### Fixed
 * <How to hit and notice issue? what was the impact?> ([#????](https://github.com/realm/realm-core/issues/????), since v?.?.?)
-* None.
+* Making a query that compares two integer properties could cause a segmentation fault on the server.
+  ([#3253](https://github.com/realm/realm-core/issues/3253))
  
 ### Breaking changes
 * None.


### PR DESCRIPTION
If the arrays holding the values are aligned differently (one on 16
byte boundary and one not), it will cause a segmentation fault when
using the SSE instructions.

Fixes #3253 