### PR TITLE
Add Timestamp helper methods

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,11 @@
 # NEXT RELEASE
 
 ### Enhancements
-* None.
+* Added `Timestamp::now()`, `Timestamp::epoch()`, `Timestamp::min()`, `Timestamp::max()`, 
+  `Timestamp::from_milliseconds()` as factory methods for creating timestamps.
+* Added `Timestamp::add_seconds(int64_t)`, `Timestamp::add_milliseconds(int64_t)` and 
+  `Timestamp::add_nanoseconds(int64_t)` and `Timestamp::to_milliseconds()` as helper methods
+  when working with timestamps. 
 
 ### Fixed
 * <How to hit and notice issue? what was the impact?> ([#????](https://github.com/realm/realm-core/issues/????), since v?.?.?)

--- a/src/realm/timestamp.hpp
+++ b/src/realm/timestamp.hpp
@@ -87,10 +87,9 @@ public:
     static Timestamp now()
     {
         auto now = std::chrono::system_clock::now();
-        int64_t ns_since_epoch = std::chrono::duration_cast<std::chrono::nanoseconds>(now.time_since_epoch()).count();
-        int64_t s_arg = ns_since_epoch / static_cast<int64_t>(realm::Timestamp::nanoseconds_per_second);
-        int32_t ns_arg = ns_since_epoch % Timestamp::nanoseconds_per_second;
-        return Timestamp(s_arg, ns_arg);
+        auto sec = std::chrono::time_point_cast<std::chrono::seconds>(now);
+        auto ns = static_cast<int32_t>(std::chrono::duration_cast<std::chrono::nanoseconds>(now - sec).count());
+        return {sec.time_since_epoch().count(), ns};
     }
 
     // Returns a timestamp representing the UNIX Epoch.

--- a/src/realm/timestamp.hpp
+++ b/src/realm/timestamp.hpp
@@ -19,6 +19,7 @@
 #ifndef REALM_TIMESTAMP_HPP
 #define REALM_TIMESTAMP_HPP
 
+#include <chrono>
 #include <cstdint>
 #include <ostream>
 #include <realm/util/assert.hpp>

--- a/src/realm/timestamp.hpp
+++ b/src/realm/timestamp.hpp
@@ -146,7 +146,8 @@ public:
         if (final_nanoseconds <= -nanoseconds_per_second) {
             extra_seconds--;
             final_nanoseconds += nanoseconds_per_second;
-        } else if (final_nanoseconds >= nanoseconds_per_second) {
+        }
+        else if (final_nanoseconds >= nanoseconds_per_second) {
             extra_seconds++;
             final_nanoseconds -= nanoseconds_per_second;
         }
@@ -154,9 +155,8 @@ public:
         // Adjust seconds while also checking for overflow since the combined nanosecond value could also cause
         // overflow in the seconds field.
         int64_t final_seconds = m_seconds;
-        if (util::int_add_with_overflow_detect(final_seconds, extra_seconds)) {
+        if (util::int_add_with_overflow_detect(final_seconds, extra_seconds))
             return (extra_seconds < 0) ? min() : max();
-        }
 
         return Timestamp(final_seconds, final_nanoseconds);
     }
@@ -175,12 +175,10 @@ public:
     // returns INT64_MAX. If it overflows in negative direction it returns INT64_MIN.
     int64_t to_milliseconds() const
     {
-        if (m_seconds > INT64_MAX/1000) {
+        if (m_seconds > INT64_MAX/1000)
             return INT64_MAX;
-        }
-        if (m_seconds < INT64_MIN/1000) {
+        if (m_seconds < INT64_MIN/1000)
             return INT64_MIN;
-        }
         int64_t ms = m_seconds * 1000; // This will never overflow
         if (util::int_add_with_overflow_detect(ms, m_nanoseconds/1000000))
             return (ms < 0) ? INT64_MIN : INT64_MAX;

--- a/test/test_column_timestamp.cpp
+++ b/test/test_column_timestamp.cpp
@@ -702,7 +702,6 @@ TEST_TYPES(Timestamp_Conversions, std::true_type, std::false_type)
 
 TEST_TYPES(Timestamp_factory_methods, std::true_type, std::false_type)
 {
-
     auto epoch = Timestamp::epoch();
     CHECK(epoch.get_seconds() == 0);
     CHECK(epoch.get_nanoseconds() == 0);
@@ -772,7 +771,6 @@ TEST_TYPES(Timestamp_conversion_methods, std::true_type, std::false_type)
     CHECK(Timestamp(1, 500001 /* ~5 microsec.*/).to_milliseconds() == 1000);
     CHECK(Timestamp(-1, -500000 /* 5 microsec.*/).to_milliseconds() == -1000);
     CHECK(Timestamp(-1, -500001 /* ~5 microsec.*/).to_milliseconds() == -1000);
-
 }
 
 

--- a/test/test_column_timestamp.cpp
+++ b/test/test_column_timestamp.cpp
@@ -736,29 +736,29 @@ TEST_TYPES(Timestamp_factory_methods, std::true_type, std::false_type)
 TEST_TYPES(Timestamp_modifier_methods, std::true_type, std::false_type)
 {
     // Seconds
-//    CHECK(Timestamp::max().add_seconds(1) == Timestamp::max());
-//    CHECK(Timestamp::min().add_seconds(-1) == Timestamp::min());
-//    CHECK(Timestamp::epoch().add_seconds(0) == Timestamp::epoch());
-//    CHECK(Timestamp::epoch().add_seconds(1) == Timestamp(1, 0));
-//    CHECK(Timestamp::epoch().add_seconds(-1) == Timestamp(-1, 0));
-//
-//    // Milliseconds
-//    CHECK(Timestamp::max().add_milliseconds(1) == Timestamp::max());
-//    CHECK(Timestamp::min().add_milliseconds(-1) == Timestamp::min());
-//    CHECK(Timestamp::epoch().add_milliseconds(0) == Timestamp::epoch());
-//    CHECK(Timestamp::epoch().add_milliseconds(1100) == Timestamp(1, 100000000));
-//    CHECK(Timestamp::epoch().add_milliseconds(-1100) == Timestamp( -1, -100000000));
-//
-//    // Nanoseconds
+    CHECK(Timestamp::max().add_seconds(1) == Timestamp::max());
+    CHECK(Timestamp::min().add_seconds(-1) == Timestamp::min());
+    CHECK(Timestamp::epoch().add_seconds(0) == Timestamp::epoch());
+    CHECK(Timestamp::epoch().add_seconds(1) == Timestamp(1, 0));
+    CHECK(Timestamp::epoch().add_seconds(-1) == Timestamp(-1, 0));
+
+    // Milliseconds
+    CHECK(Timestamp::max().add_milliseconds(1) == Timestamp::max());
+    CHECK(Timestamp::min().add_milliseconds(-1) == Timestamp::min());
+    CHECK(Timestamp::epoch().add_milliseconds(0) == Timestamp::epoch());
+    CHECK(Timestamp::epoch().add_milliseconds(1100) == Timestamp(1, 100000000));
+    CHECK(Timestamp::epoch().add_milliseconds(-1100) == Timestamp( -1, -100000000));
+
+    // Nanoseconds
     CHECK(Timestamp::max().add_nanoseconds(1) == Timestamp::max());
-//    CHECK(Timestamp::min().add_nanoseconds(-1) == Timestamp::min());
-//    CHECK(Timestamp::epoch().add_nanoseconds(0) == Timestamp::epoch());
-//    CHECK(Timestamp::epoch().add_nanoseconds(1100000000) == Timestamp(1, 100000000));
-//    CHECK(Timestamp::epoch().add_nanoseconds(-1100000000) == Timestamp( -1, -100000000));
-//    CHECK(Timestamp(0, Timestamp::nanoseconds_per_second - 1).add_nanoseconds(1) == Timestamp(1, 0));
-//    CHECK(Timestamp(0, -Timestamp::nanoseconds_per_second + 1).add_nanoseconds(-1) == Timestamp(-1, 0));
-//    CHECK(Timestamp(INT64_MAX, Timestamp::nanoseconds_per_second - 1).add_nanoseconds(1) == Timestamp::max());
-//    CHECK(Timestamp(INT64_MIN, -Timestamp::nanoseconds_per_second + 1).add_nanoseconds(-1) == Timestamp::min());
+    CHECK(Timestamp::min().add_nanoseconds(-1) == Timestamp::min());
+    CHECK(Timestamp::epoch().add_nanoseconds(0) == Timestamp::epoch());
+    CHECK(Timestamp::epoch().add_nanoseconds(1100000000) == Timestamp(1, 100000000));
+    CHECK(Timestamp::epoch().add_nanoseconds(-1100000000) == Timestamp( -1, -100000000));
+    CHECK(Timestamp(0, Timestamp::nanoseconds_per_second - 1).add_nanoseconds(1) == Timestamp(1, 0));
+    CHECK(Timestamp(0, -Timestamp::nanoseconds_per_second + 1).add_nanoseconds(-1) == Timestamp(-1, 0));
+    CHECK(Timestamp(INT64_MAX, Timestamp::nanoseconds_per_second - 1).add_nanoseconds(1) == Timestamp::max());
+    CHECK(Timestamp(INT64_MIN, -Timestamp::nanoseconds_per_second + 1).add_nanoseconds(-1) == Timestamp::min());
 }
 
 TEST_TYPES(Timestamp_conversion_methods, std::true_type, std::false_type)


### PR DESCRIPTION
I needed a bunch of utility methods when doing some timestamp manipulation in ObjectStore, and those helper methods really fit better in Core.