### PR TITLE
Switch to building releases for Apple platforms with Xcode 9.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,7 +18,7 @@
 -----------
 
 ### Internals
-* None.
+* The release binaries for Apple platforms are now built with Xcode 9.2 (up from 8.3.3).
 
 ----------------------------------------------
 

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -442,7 +442,7 @@ def doBuildMacOs(String buildType, boolean runTests) {
             def buildTests = runTests ? '' : '-DREALM_NO_TESTS=1'
 
             dir("build-macos-${buildType}") {
-                withEnv(['DEVELOPER_DIR=/Applications/Xcode-8.3.3.app/Contents/Developer/']) {
+                withEnv(['DEVELOPER_DIR=/Applications/Xcode-9.2.app/Contents/Developer/']) {
                     // This is a dirty trick to work around a bug in xcode
                     // It will hang if launched on the same project (cmake trying the compiler out)
                     // in parallel.
@@ -505,7 +505,7 @@ def doBuildAppleDevice(String sdk, String buildType) {
         node('osx') {
             getArchive()
 
-            withEnv(['DEVELOPER_DIR=/Applications/Xcode-8.3.3.app/Contents/Developer/',
+            withEnv(['DEVELOPER_DIR=/Applications/Xcode-9.2.app/Contents/Developer/',
                      'XCODE10_DEVELOPER_DIR=/Applications/Xcode-10.app/Contents/Developer/']) {
                 retry(3) {
                     timeout(time: 15, unit: 'MINUTES') {


### PR DESCRIPTION
Xcode 8.3.3 will be going away from the CI machines soon (it no longer runs on macOS 10.14) so we need to move up to the oldest version still supported.