### PR TITLE
Fix error in Group::write

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,8 @@
 
 ### Fixed
 * <How to hit and notice issue? what was the impact?> ([#????](https://github.com/realm/realm-core/issues/????), since v?.?.?)
-* None.
+* Writing a snapshot to file via Group::write() could produce a file with some parts not
+  reachable from top array (a memory leak). ([#2911](https://github.com/realm/realm-sync/issues/2911))
  
 ### Breaking changes
 * None.

--- a/src/realm/group.cpp
+++ b/src/realm/group.cpp
@@ -873,7 +873,6 @@ void Group::write(std::ostream& out, int file_format_version, TableWriter& table
         // into a separate file.
         ref_type names_ref = table_writer.write_names(out_2);   // Throws
         ref_type tables_ref = table_writer.write_tables(out_2); // Throws
-        TableWriter::HistoryInfo history_info = table_writer.write_history(out_2); // Throws
         SlabAlloc new_alloc;
         new_alloc.attach_empty(); // Throws
         Array top(new_alloc);
@@ -888,6 +887,8 @@ void Group::write(std::ostream& out, int file_format_version, TableWriter& table
 
         int top_size = 3;
         if (version_number) {
+            TableWriter::HistoryInfo history_info = table_writer.write_history(out_2); // Throws
+
             Array free_list(new_alloc);
             Array size_list(new_alloc);
             Array version_list(new_alloc);


### PR DESCRIPTION
If Group::write() was called on a realm with client history without
specifying a version number, the history would be dumped, but not
included in the top array. This would lead to a memory leak.

Fixes https://github.com/realm/realm-sync/issues/2911