### PR TITLE
Fix an incorrect debug mode assertion

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@
 
 ### Fixed
 * <How to hit and notice issue? what was the impact?> ([#????](https://github.com/realm/realm-core/issues/????), since v?.?.?)
-* None.
+* Fixed an incorrect debug mode assertion which could be triggered when generating the description of an IncludeDescriptor.
  
 ### Breaking changes
 * None.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@
 ### Fixed
 * <How to hit and notice issue? what was the impact?> ([#????](https://github.com/realm/realm-core/issues/????), since v?.?.?)
 * Fixed an incorrect debug mode assertion which could be triggered when generating the description of an IncludeDescriptor.
- 
+  ([PR #3276](https://github.com/realm/realm-core/pull/3276) since v5.18.0). 
 ### Breaking changes
 * None.
 

--- a/src/realm/views.cpp
+++ b/src/realm/views.cpp
@@ -403,7 +403,7 @@ std::string IncludeDescriptor::get_description(ConstTableRef attached_table) con
             size_t col_ndx = chain[j]->get_column_index();
             if (ConstTableRef from_table = m_backlink_sources[i][j]) { // backlink
                 REALM_ASSERT_DEBUG(col_ndx < from_table->get_column_count());
-                REALM_ASSERT_DEBUG(from_table->get_link_target(col_ndx) == cur_link_table);
+                REALM_ASSERT_DEBUG(from_table->get_link_target(col_ndx)->get_name() == cur_link_table->get_name());
                 description += basic_serialiser.get_backlink_column_name(from_table, col_ndx);
                 cur_link_table = from_table;
             }


### PR DESCRIPTION
Table comparison is the wrong thing to do here because the implementation of `Table::operator==` checks for data equality across all rows. What was meant is that this is the same table, regardless of the data contained in it. A more lightweight check is now used just verifying name equality.

It's causing the object store tests to fail in https://github.com/realm/realm-object-store/pull/782