### PR TITLE
Fix unbound growth of freelist

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,8 @@
 
 ### Fixed
 * <How to hit and notice issue? what was the impact?> ([#????](https://github.com/realm/realm-core/issues/????), since v?.?.?)
-* None.
+* Freelist would keep growing with a decreased commit performance as a result.
+  ([2927](https://github.com/realm/realm-sync/issues/2927))
  
 ### Breaking changes
 * None.

--- a/src/realm/group_writer.cpp
+++ b/src/realm/group_writer.cpp
@@ -394,11 +394,10 @@ ref_type GroupWriter::write_group()
     // at the most 5x16 = 80 extension steps, each adding one entry to the free list.
     // (a smaller upper bound could likely be derived here, but it's not that important)
     max_free_list_size += 80;
-    // Try to make the guess a bit less pessimistic in case of young databases
-    int max_size_per_entry =
-        (m_alloc.m_baseline < 0x10000 ? 8 : 16) + (is_shared ? (m_current_version < 0x10000 ? 2 : 8) : 0);
+
+    int num_free_lists = is_shared ? 3 : 2;
     size_t max_free_space_needed =
-        Array::get_max_byte_size(top.size()) + Array::header_size + max_free_list_size * max_size_per_entry;
+        Array::get_max_byte_size(top.size()) + num_free_lists * Array::get_max_byte_size(max_free_list_size);
 
 #if REALM_ALLOC_DEBUG
     std::cout << "    Allocating file space for freelists:" << std::endl;

--- a/test/test_lang_bind_helper.cpp
+++ b/test/test_lang_bind_helper.cpp
@@ -9354,14 +9354,15 @@ TEST(LangBindHelper_ImplicitTransactions_NoExtremeFileSpaceLeaks)
 // the miminum filesize (after a commit) is one or two pages, depending on the
 // page size.
 // FIXME: Due to the rather pessimistic calculation of the max_free_space_needed in
+// the file now grows to 4 * page_size
 #if REALM_ENABLE_ENCRYPTION
     if (crypt_key())
         // Encrypted files are always at least a 4096 byte header plus payload
-        CHECK_LESS_EQUAL(File(path).get_size(), 2 * page_size() + 4096);
+        CHECK_LESS_EQUAL(File(path).get_size(), 4 * page_size() + 4096);
     else
-        CHECK_LESS_EQUAL(File(path).get_size(), 2 * page_size());
+        CHECK_LESS_EQUAL(File(path).get_size(), 4 * page_size());
 #else
-    CHECK_LESS_EQUAL(File(path).get_size(), 2 * page_size());
+    CHECK_LESS_EQUAL(File(path).get_size(), 4 * page_size());
 #endif // REALM_ENABLE_ENCRYPTION
 }
 

--- a/test/test_lang_bind_helper.cpp
+++ b/test/test_lang_bind_helper.cpp
@@ -9353,6 +9353,7 @@ TEST(LangBindHelper_ImplicitTransactions_NoExtremeFileSpaceLeaks)
 
 // the miminum filesize (after a commit) is one or two pages, depending on the
 // page size.
+// FIXME: Due to the rather pessimistic calculation of the max_free_space_needed in
 #if REALM_ENABLE_ENCRYPTION
     if (crypt_key())
         // Encrypted files are always at least a 4096 byte header plus payload


### PR DESCRIPTION
Problem with previous algorithm was that it produced more small blocks
than could afterwards be consumed. So we would have an ever increasing
number of small blocks.

Instead of using the first block that is just big enough the algorithm
is changed so that we will accept either a perfect match or a block that
has at least twice the size as the size that is requested.