### PR TITLE
bugfix: move constructor for Slab must cleanup

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 
 ### Fixed
 * <How to hit and notice issue? what was the impact?> ([#????](https://github.com/realm/realm-core/issues/????), since v?.?.?)
+* Slab usage was reported wrong ([#3284](https://github.com/realm/realm-core/pull/3284)
 * When opening an encrypted file via SharedGroup::open(), it could wrongly fail and indicate a file corruption
   although the file was ok.
   ([#3267](https://github.com/realm/realm-core/issues/3267), since core v5.12.2)

--- a/src/realm/alloc_slab.hpp
+++ b/src/realm/alloc_slab.hpp
@@ -387,6 +387,7 @@ private:
             , addr(std::move(slab.addr))
             , size(slab.size)
         {
+            slab.size = 0;
         }
         ~Slab();
     };


### PR DESCRIPTION
Fixes https://github.com/realm/realm-sync/issues/2961