### PR TITLE
Fsa/fix page reclaimer control

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,8 +7,10 @@
 ### Fixed
 * <How to hit and notice issue? what was the impact?> ([#????](https://github.com/realm/realm-core/issues/????), since v?.?.?)
 * Slab usage was reported wrong by SlabAlloc::get_total_slab_size() ([#3284](https://github.com/realm/realm-core/pull/3284)
+  This caused ROS to report "18 exabytes" of memory used for slab.
 * The control of the page reclaimer did not limit the page reclaimers workload correctly. This could lead
-  to the reclaimer not running as much as intended. It also caused reporting of odd metrics for the reclaimer.
+  to the reclaimer not running as much as intended. This is not believed to have been visible to end users.
+  This bug also caused ROS to occasionally report odd metrics for the reclaimer.
   ([#3285](https://github.com/realm/realm-core/pull/3285))
 * When opening an encrypted file via SharedGroup::open(), it could wrongly fail and indicate a file corruption
   although the file was ok.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 
 ### Fixed
 * <How to hit and notice issue? what was the impact?> ([#????](https://github.com/realm/realm-core/issues/????), since v?.?.?)
+* Slab usage was reported wrong ([#3284](https://github.com/realm/realm-core/pull/3284)
 * When opening an encrypted file via SharedGroup::open(), it could wrongly fail and indicate a file corruption
   although the file was ok.
   ([#3267](https://github.com/realm/realm-core/issues/3267), since core v5.12.2)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@
 
 ### Fixed
 * <How to hit and notice issue? what was the impact?> ([#????](https://github.com/realm/realm-core/issues/????), since v?.?.?)
-* Slab usage was reported wrong ([#3284](https://github.com/realm/realm-core/pull/3284)
+* Slab usage was reported wrong by SlabAlloc::get_total_slab_size() ([#3284](https://github.com/realm/realm-core/pull/3284)
 * The control of the page reclaimer did not limit the page reclaimers workload correctly. This could lead
   to the reclaimer not running as much as intended. It also caused reporting of odd metrics for the reclaimer.
   ([#3285](https://github.com/realm/realm-core/pull/3285))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@
 ### Fixed
 * <How to hit and notice issue? what was the impact?> ([#????](https://github.com/realm/realm-core/issues/????), since v?.?.?)
 * Slab usage was reported wrong ([#3284](https://github.com/realm/realm-core/pull/3284)
+* The control of the page reclaimer did not limit the page reclaimers workload correctly. This could lead
+  to the reclaimer not running as much as intended. It also caused reporting of odd metrics for the reclaimer.
+  ([#3285](https://github.com/realm/realm-core/pull/3285))
 * When opening an encrypted file via SharedGroup::open(), it could wrongly fail and indicate a file corruption
   although the file was ok.
   ([#3267](https://github.com/realm/realm-core/issues/3267), since core v5.12.2)

--- a/src/realm/alloc_slab.hpp
+++ b/src/realm/alloc_slab.hpp
@@ -387,6 +387,7 @@ private:
             , addr(std::move(slab.addr))
             , size(slab.size)
         {
+            slab.size = 0;
         }
         ~Slab();
     };

--- a/src/realm/util/file_mapper.cpp
+++ b/src/realm/util/file_mapper.cpp
@@ -169,6 +169,7 @@ public:
             auto from_proc = fetch_value_in_file("/proc/meminfo", "MemTotal:[[:space:]]+([[:digit:]]+) kB") * 1024;
             auto from_cgroup = fetch_value_in_file("/sys/fs/cgroup/memory/memory.limit_in_bytes", "^([[:digit:]]+)");
             auto cache_use = fetch_value_in_file("/sys/fs/cgroup/memory/memory.stat", "cache ([[:digit:]]+)");
+            std::cout << " -< " << from_proc << " : " << from_cgroup << " : " << cache_use << " >-" << std::endl;
             target = pick_if_valid(from_proc, from_proc / 4);
             target = pick_lowest_valid(target, pick_if_valid(from_cgroup, from_cgroup / 4));
             target = pick_lowest_valid(target, pick_if_valid(cache_use, cache_use));
@@ -177,21 +178,24 @@ public:
     }
 
     std::function<int64_t()> current_target_getter(size_t load) override
-    {
+    {/*
         static_cast<void>(load);
         if (m_refresh_count > 0) {
             --m_refresh_count;
             return std::bind([](int64_t target_copy) { return target_copy; }, m_target);
         }
+        m_refresh_count = 10;
+     */
         return std::bind(get_target_from_system, m_cfg_file_name);
     }
 
     void report_target_result(int64_t target) override
     {
-        m_target = target;
+        m_target = target;/*
         if (m_refresh_count == 0) {
             m_refresh_count = 10; // refresh every 10 seconds
         }
+                          */
     }
 
     DefaultGovernor() {
@@ -382,6 +386,7 @@ void reclaim_pages()
     int64_t target = PageReclaimGovernor::no_match;
     if (runnable) {
         target = runnable() / page_size();
+        std::cout << " -- " << load << " - " << target << std::endl;
     }
     {
         UniqueLock lock(mapping_mutex);

--- a/src/realm/util/file_mapper.cpp
+++ b/src/realm/util/file_mapper.cpp
@@ -316,7 +316,7 @@ const std::vector<work_limit_desc> control_table = {{0.5f, 0.001f},  {0.75f, 0.0
 
 size_t get_work_limit(size_t decrypted_pages, size_t target)
 {
-    if (target < 1)
+    if (target == 0)
         target = 1;
     float load = 1.0f * decrypted_pages / target;
     float akku = 0.0f;

--- a/src/realm/util/file_mapper.cpp
+++ b/src/realm/util/file_mapper.cpp
@@ -169,7 +169,6 @@ public:
             auto from_proc = fetch_value_in_file("/proc/meminfo", "MemTotal:[[:space:]]+([[:digit:]]+) kB") * 1024;
             auto from_cgroup = fetch_value_in_file("/sys/fs/cgroup/memory/memory.limit_in_bytes", "^([[:digit:]]+)");
             auto cache_use = fetch_value_in_file("/sys/fs/cgroup/memory/memory.stat", "cache ([[:digit:]]+)");
-            std::cout << " -< " << from_proc << " : " << from_cgroup << " : " << cache_use << " >-" << std::endl;
             target = pick_if_valid(from_proc, from_proc / 4);
             target = pick_lowest_valid(target, pick_if_valid(from_cgroup, from_cgroup / 4));
             target = pick_lowest_valid(target, pick_if_valid(cache_use, cache_use));
@@ -387,7 +386,6 @@ void reclaim_pages()
         UniqueLock lock(mapping_mutex);
         reclaimer_workload = 0;
         reclaimer_target = size_t(target / page_size());
-
         // Putting the target back into the govenor object will allow the govenor
         // to return a getter producing this value again next time it is called
         governor->report_target_result(target);

--- a/src/realm/util/file_mapper.cpp
+++ b/src/realm/util/file_mapper.cpp
@@ -316,6 +316,8 @@ const std::vector<work_limit_desc> control_table = {{0.5f, 0.001f},  {0.75f, 0.0
 
 size_t get_work_limit(size_t decrypted_pages, size_t target)
 {
+    if (target < 1)
+        target = 1;
     float load = 1.0f * decrypted_pages / target;
     float akku = 0.0f;
     for (const auto& e : control_table) {


### PR DESCRIPTION
We mistakenly divided the target with page size on each run of the reclaimer. 
Also, we did not correctly handle computation of the reclaimers work limit when the
target number of decrypted pages was 0.
This led to incorrect operation in the sense that the reclaimer would run less than intended.
