### PR TITLE
Add Unicode path support for Windows

### DIFF
--- a/src/realm/util/file.cpp
+++ b/src/realm/util/file.cpp
@@ -73,6 +73,21 @@ std::string get_last_error_msg(const char* prefix, DWORD err)
     return buffer.str();
 }
 
+std::wstring string_to_wstring(const std::string& str)
+{
+    if (str.empty())
+        return std::wstring();
+    int wstr_size = MultiByteToWideChar(CP_UTF8, 0, str.c_str(), -1, NULL, 0);
+    std::wstring wstr;
+    if (wstr_size) {
+        wstr.resize(wstr_size);
+        if (MultiByteToWideChar(CP_UTF8, 0, str.c_str(), -1, &wstr[0], wstr_size)) {
+            return wstr;
+        }
+    }
+    return std::wstring();
+}
+
 #endif
 
 size_t get_page_size()
@@ -124,14 +139,9 @@ namespace util {
 bool try_make_dir(const std::string& path)
 {
 #ifdef _WIN32
-    int w_path_size = MultiByteToWideChar(CP_UTF8, 0, path.c_str(), -1, NULL, 0);
-    wchar_t* w_path = new wchar_t[w_path_size];
-    MultiByteToWideChar(CP_UTF8, 0, path.c_str(), -1, w_path, w_path_size);
-    if (CreateDirectoryW(w_path, NULL) != 0) {
-        delete w_path;
+    std::wstring w_path = string_to_wstring(path);
+    if (CreateDirectoryW(w_path.c_str(), NULL) != 0)
         return true;
-    }
-    delete w_path;
     DWORD dw_err = GetLastError();
     int err = (int)dw_err;
     std::string msg;
@@ -177,14 +187,9 @@ void remove_dir(const std::string& path)
 bool try_remove_dir(const std::string& path)
 {
 #ifdef _WIN32
-    int w_path_size = MultiByteToWideChar(CP_UTF8, 0, path.c_str(), -1, NULL, 0);
-    wchar_t* w_path = new wchar_t[w_path_size];
-    MultiByteToWideChar(CP_UTF8, 0, path.c_str(), -1, w_path, w_path_size);
-    if (RemoveDirectoryW(w_path) != 0) {
-        delete w_path;
+    std::wstring w_path = string_to_wstring(path);
+    if (RemoveDirectoryW(w_path.c_str()) != 0)
         return true;
-    }
-    delete w_path;
     DWORD dw_err = GetLastError();
     int err = (int)dw_err;
     std::string msg;

--- a/src/realm/util/file.cpp
+++ b/src/realm/util/file.cpp
@@ -177,14 +177,25 @@ void remove_dir(const std::string& path)
 bool try_remove_dir(const std::string& path)
 {
 #ifdef _WIN32
-    if (_rmdir(path.c_str()) == 0)
+    int w_path_size = MultiByteToWideChar(CP_UTF8, 0, path.c_str(), -1, NULL, 0);
+    wchar_t* w_path = new wchar_t[w_path_size];
+    MultiByteToWideChar(CP_UTF8, 0, path.c_str(), -1, w_path, w_path_size);
+    if (RemoveDirectoryW(w_path) != 0) {
+        delete w_path;
         return true;
+    }
+    delete w_path;
+    DWORD dw_err = GetLastError();
+    int err = (int)dw_err;
+    std::string msg;
+    FormatMessage(FORMAT_MESSAGE_ALLOCATE_BUFFER | FORMAT_MESSAGE_FROM_SYSTEM | FORMAT_MESSAGE_IGNORE_INSERTS, NULL,
+                  dw_err, MAKELANGID(LANG_NEUTRAL, SUBLANG_DEFAULT), (LPTSTR)&msg, 0, NULL);
 #else // POSIX
     if (::rmdir(path.c_str()) == 0)
         return true;
-#endif
     int err = errno; // Eliminate any risk of clobbering
     std::string msg = get_errno_msg("remove_dir() failed: ", err);
+#endif
     switch (err) {
         case EACCES:
         case EROFS:

--- a/test/test_util_file.cpp
+++ b/test/test_util_file.cpp
@@ -112,6 +112,47 @@ TEST(Utils_File_dir)
     CHECK(dir_exists);
 }
 
+TEST(Utils_File_dir_unicode)
+{
+  // Test make_dir and remove_dir with paths that include special characters
+  // This would previously fail on Windows
+  std::string dir_name = File::resolve("temporäreDatei", test_util::get_test_path_prefix());
+
+  // Create directory
+  bool dir_exists = File::is_dir(dir_name);
+  CHECK_NOT(dir_exists);
+
+  make_dir(dir_name);
+  try {
+      make_dir(dir_name);
+  }
+  catch (const File::Exists& e) {
+      CHECK_EQUAL(e.get_path(), dir_name);
+      dir_exists = File::is_dir(dir_name);
+  }
+  CHECK(dir_exists);
+
+  // Remove directory
+  remove_dir(dir_name);
+  try {
+      remove_dir(dir_name);
+  }
+  catch (const File::NotFound& e) {
+      CHECK_EQUAL(e.get_path(), dir_name);
+      dir_exists = false;
+  }
+  CHECK_NOT(dir_exists);
+
+  // try_remove_dir missing directory
+  dir_exists = try_remove_dir(dir_name);
+  CHECK_NOT(dir_exists);
+
+  // try_remove_dir existing directory
+  make_dir(dir_name);
+  dir_exists = try_remove_dir(dir_name);
+  CHECK(dir_exists);
+}
+
 TEST(Utils_File_resolve)
 {
     std::string res;

--- a/test/util/test_path.hpp
+++ b/test/util/test_path.hpp
@@ -26,7 +26,7 @@
 #define TEST_PATH_HELPER(class_name, var_name, suffix)                                                               \
     class_name var_name(realm::test_util::get_test_path(test_context.get_test_name(), "." #var_name "." suffix))
 
-#define TEST_PATH(var_name) TEST_PATH_HELPER(realm::test_util::TestPathGuard, var_name, "test");
+#define TEST_PATH(var_name) TEST_PATH_HELPER(realm::test_util::TestPathGuard, var_name, "temporäre");
 
 #define TEST_DIR(var_name) TEST_PATH_HELPER(realm::test_util::TestDirGuard, var_name, "test-dir");
 


### PR DESCRIPTION
On Windows, Realm files and directories cannot be created if the path includes non-Latin characters (see https://github.com/realm/realm-js/issues/2319). Attempting to do so leads to errors such as `Unable to open a realm at path <path>: make_dir() failed: No such file or directory Path:.`. This PR allows Realms to be created in paths with non-Latin characters by using APIs such as [`_wmkdir`](https://docs.microsoft.com/en-us/cpp/c-runtime-library/reference/mkdir-wmkdir?view=vs-2019) instead of `_mkdir`.