### PR TITLE
New feature test macros for ASAN and TSAN

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,8 @@
 -----------
 
 ### Internals
-* None.
+* Introduced new feature test macros for address and thread sanitizers in
+  `<realm/util/features.h>`.
 
 ----------------------------------------------
 

--- a/src/realm/util/features.h
+++ b/src/realm/util/features.h
@@ -313,4 +313,30 @@
 #define REALM_ARCHITECTURE_X86_64 0
 #endif
 
+// Address Sanitizer
+#if defined(__has_feature) // Clang
+#  if __has_feature(address_sanitizer)
+#    define REALM_SANITIZE_ADDRESS 1
+#  else
+#    define REALM_SANITIZE_ADDRESS 0
+#  endif
+#elif defined(__SANITIZE_ADDRESS__) && __SANITIZE_ADDRESS__ // GCC
+#  define REALM_SANITIZE_ADDRESS 1
+#else
+#  define REALM_SANITIZE_ADDRESS 0
+#endif
+
+// Thread Sanitizer
+#if defined(__has_feature) // Clang
+#  if __has_feature(thread_sanitizer)
+#    define REALM_SANITIZE_THREAD 1
+#  else
+#    define REALM_SANITIZE_THREAD 0
+#  endif
+#elif defined(__SANITIZE_THREAD__) && __SANITIZE_THREAD__ // GCC
+#  define REALM_SANITIZE_THREAD 1
+#else
+#  define REALM_SANITIZE_THREAD 0
+#endif
+
 #endif /* REALM_UTIL_FEATURES_H */


### PR DESCRIPTION
Added because they are needed in the context of the sync repository.