### PR TITLE
Fix `REALM_METRICS` compile time inconsistency

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,9 @@
 -----------
 
 ### Internals
-* None.
+* Fixed an inconsistency in the use of the `REALM_METRICS` compile time option. Now core consumers are able
+  to use `SharedGroup::get_metrics()` regardless of whether or not metrics are compiled in. A null pointer
+  is returned if the feature has been disabled at compile time.
 
 ----------------------------------------------
 

--- a/src/realm/CMakeLists.txt
+++ b/src/realm/CMakeLists.txt
@@ -204,13 +204,11 @@ set(REALM_INSTALL_ALL_HEADERS
     ${REALM_METRICS_HEADERS}
 )
 
-if(REALM_METRICS)
-    list(APPEND REALM_SOURCES
-        metrics/metrics.cpp
-        metrics/metric_timer.cpp
-        metrics/query_info.cpp
-        metrics/transaction_info.cpp)
-endif()
+list(APPEND REALM_SOURCES
+    metrics/metrics.cpp
+    metrics/metric_timer.cpp
+    metrics/query_info.cpp
+    metrics/transaction_info.cpp)
 
 if(NOT MSVC)
     list(APPEND REALM_SOURCES util/interprocess_mutex.cpp)

--- a/src/realm/group_shared.cpp
+++ b/src/realm/group_shared.cpp
@@ -2032,12 +2032,14 @@ void SharedGroup::unpin_version(VersionID token)
     release_read_lock(read_lock);
 }
 
-#if REALM_METRICS
 std::shared_ptr<Metrics> SharedGroup::get_metrics()
 {
+#if REALM_METRICS
     return m_metrics;
-}
+#else
+    return nullptr;
 #endif // REALM_METRICS
+}
 
 void SharedGroup::do_begin_read(VersionID version_id, bool writable)
 {

--- a/src/realm/group_shared.hpp
+++ b/src/realm/group_shared.hpp
@@ -545,9 +545,7 @@ public:
     // Release pinned version (not thread safe)
     void unpin_version(VersionID version);
 
-#if REALM_METRICS
     std::shared_ptr<metrics::Metrics> get_metrics();
-#endif // REALM_METRICS
 
     // Try to grab a exclusive lock of the given realm path's lock file. If the lock
     // can be acquired, the callback will be executed with the lock and then return true.

--- a/src/realm/metrics/metric_timer.cpp
+++ b/src/realm/metrics/metric_timer.cpp
@@ -23,8 +23,6 @@
 #include <iostream>
 #include <sstream>
 
-#if REALM_METRICS
-
 using namespace realm;
 using namespace realm::metrics;
 
@@ -142,5 +140,3 @@ void MetricTimer::format(double seconds_float, std::ostream& out)
         }
     }
 }
-
-#endif // REALM_METRICS

--- a/src/realm/metrics/metric_timer.hpp
+++ b/src/realm/metrics/metric_timer.hpp
@@ -25,8 +25,6 @@
 #include <memory>
 #include <ostream>
 
-#if REALM_METRICS
-
 namespace realm {
 namespace metrics {
 
@@ -97,7 +95,5 @@ inline std::ostream& operator<<(std::ostream& out, const MetricTimer& timer)
 
 } // namespace metrics
 } // namespace realm
-
-#endif // REALM_METRICS
 
 #endif // REALM_METRIC_TIMER_HPP

--- a/src/realm/metrics/metrics.cpp
+++ b/src/realm/metrics/metrics.cpp
@@ -19,8 +19,6 @@
 #include <realm/group.hpp>
 #include <realm/metrics/metrics.hpp>
 
-#if REALM_METRICS
-
 using namespace realm;
 using namespace realm::metrics;
 
@@ -135,7 +133,3 @@ std::unique_ptr<Metrics::TransactionInfoList> Metrics::take_transactions()
     values.swap(m_transaction_info);
     return values;
 }
-
-
-
-#endif // REALM_METRICS

--- a/src/realm/metrics/metrics.hpp
+++ b/src/realm/metrics/metrics.hpp
@@ -32,8 +32,6 @@ class Group;
 
 namespace metrics {
 
-#if REALM_METRICS
-
 class Metrics {
 public:
     Metrics(size_t max_history_size);
@@ -69,15 +67,6 @@ private:
     size_t m_max_num_queries;
     size_t m_max_num_transactions;
 };
-
-
-#else
-
-class Metrics
-{
-};
-
-#endif // REALM_METRICS
 
 } // namespace metrics
 } // namespace realm

--- a/src/realm/metrics/query_info.cpp
+++ b/src/realm/metrics/query_info.cpp
@@ -22,14 +22,13 @@
 #include <realm/query.hpp>
 #include <realm/query_engine.hpp>
 
-#if REALM_METRICS
-
 using namespace realm;
 using namespace realm::metrics;
 
 QueryInfo::QueryInfo(const Query* query, QueryType type)
     : m_type(type)
 {
+#if REALM_METRICS
     REALM_ASSERT(query);
 
     const Group* group = query->m_table->get_parent_group();
@@ -37,6 +36,9 @@ QueryInfo::QueryInfo(const Query* query, QueryType type)
 
     m_description = query->get_description();
     m_table_name = query->m_table->get_name();
+#else
+    static_cast<void>(query);
+#endif
 }
 
 QueryInfo::~QueryInfo() noexcept
@@ -68,6 +70,7 @@ double QueryInfo::get_query_time() const
 
 std::unique_ptr<MetricTimer> QueryInfo::track(const Query* query, QueryType type)
 {
+#if REALM_METRICS
     REALM_ASSERT_DEBUG(query);
 
     if (!bool(query->m_table) || !query->m_table->is_attached()) {
@@ -89,6 +92,11 @@ std::unique_ptr<MetricTimer> QueryInfo::track(const Query* query, QueryType type
     metrics->add_query(info);
 
     return std::make_unique<MetricTimer>(info.m_query_time);
+#else
+    static_cast<void>(query);
+    static_cast<void>(type);
+    return nullptr;
+#endif
 }
 
 QueryInfo::QueryType QueryInfo::type_from_action(Action action)
@@ -118,5 +126,3 @@ QueryInfo::QueryType QueryInfo::type_from_action(Action action)
     };
     REALM_UNREACHABLE();
 }
-
-#endif // REALM_METRICS

--- a/src/realm/metrics/query_info.hpp
+++ b/src/realm/metrics/query_info.hpp
@@ -27,8 +27,6 @@
 #include <realm/util/features.h>
 #include <realm/metrics/metric_timer.hpp>
 
-#if REALM_METRICS
-
 namespace realm {
 
 class Query; // forward declare in namespace realm
@@ -70,5 +68,4 @@ private:
 } // namespace metrics
 } // namespace realm
 
-#endif // REALM_METRICS
 #endif // REALM_QUERY_INFO_HPP

--- a/src/realm/metrics/transaction_info.cpp
+++ b/src/realm/metrics/transaction_info.cpp
@@ -18,8 +18,6 @@
 
 #include <realm/metrics/transaction_info.hpp>
 
-#if REALM_METRICS
-
 using namespace realm;
 using namespace metrics;
 
@@ -31,10 +29,12 @@ TransactionInfo::TransactionInfo(TransactionInfo::TransactionType type)
     , m_num_versions(0)
     , m_num_decrypted_pages(0)
 {
+#if REALM_METRICS
     if (m_type == write_transaction) {
         m_fsync_time = std::make_shared<MetricTimerResult>();
         m_write_time = std::make_shared<MetricTimerResult>();
     }
+#endif
 }
 
 TransactionInfo::~TransactionInfo() noexcept
@@ -106,5 +106,3 @@ void TransactionInfo::finish_timer()
 {
     m_transaction_time.report_seconds(m_transact_timer.get_elapsed_time());
 }
-
-#endif // REALM_METRICS

--- a/src/realm/metrics/transaction_info.hpp
+++ b/src/realm/metrics/transaction_info.hpp
@@ -25,8 +25,6 @@
 #include <realm/metrics/metric_timer.hpp>
 #include <realm/util/features.h>
 
-#if REALM_METRICS
-
 namespace realm {
 namespace metrics {
 
@@ -74,7 +72,5 @@ private:
 
 } // namespace metrics
 } // namespace realm
-
-#endif // REALM_METRICS
 
 #endif // REALM_TRANSACTION_INFO_HPP


### PR DESCRIPTION
`SharedGroup:: get_metrics()` and all of the `Metrics` methods should be available to core users regardless of if the feature has been enabled or not with `REALM_METRICS`. This allows users to query the core metrics without worrying about guarding their code with `REALM_METRICS` compile time defines.

Since by default, `REALM_METRICS` is enabled, this change does not affect any bindings.