### PR TITLE
Add a Swift Package Manager package

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -81,3 +81,7 @@ Thumbs.db
 # Ignore python compiled files
 *.pyc
 /test/android/jni/#Android.mk#
+
+# Swift package manager
+/.swiftpm
+/.build

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 # NEXT RELEASE
 
 ### Enhancements
-* None.
+* Add a Swift Package Manager packgae ([#3308](https://github.com/realm/realm-core/pull/3308)).
 
 ### Fixed
 * <How to hit and notice issue? what was the impact?> ([#????](https://github.com/realm/realm-core/issues/????), since v?.?.?)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -118,7 +118,7 @@ check_include_files(malloc.h HAVE_MALLOC_H)
 configure_file(src/realm/util/config.h.in src/realm/util/config.h)
 
 # Configure source code to use right version number
-configure_file(src/realm/version.hpp.in src/realm/version.hpp)
+configure_file(src/realm/version_numbers.hpp.in src/realm/version_numbers.hpp)
 
 set(DEPRECATED_CONFIG_FILE "${RealmCore_SOURCE_DIR}/src/realm/util/config.h")
 if(EXISTS "${DEPRECATED_CONFIG_FILE}")

--- a/Package.swift
+++ b/Package.swift
@@ -1,0 +1,46 @@
+// swift-tools-version:5.0
+
+import PackageDescription
+import Foundation
+
+let versionStr = "5.22.0"
+let versionPieces = versionStr.split(separator: "-")
+let versionCompontents = versionPieces[0].split(separator: ".")
+let versionExtra = versionPieces.count > 1 ? versionPieces[1] : ""
+
+let package = Package(
+    name: "RealmCore",
+    products: [
+        .library(
+            name: "RealmCore",
+            targets: ["RealmCore"]),
+    ],
+    targets: [
+        .target(
+            name: "RealmCore",
+            path: "src",
+            exclude: [
+                "realm/tools",
+                "realm/parser",
+                "realm/metrics",
+                "realm/exec",
+                "win32",
+                "external"
+            ],
+            publicHeadersPath: ".",
+            cxxSettings: [
+                .headerSearchPath("src"),
+                .define("REALM_NO_CONFIG"),
+                .define("REALM_INSTALL_LIBEXECDIR", to: ""),
+                .define("REALM_ENABLE_ASSERTIONS", to: "1"),
+                .define("REALM_ENABLE_ENCRYPTION", to: "1"),
+
+                .define("REALM_VERSION_MAJOR", to: String(versionCompontents[0])),
+                .define("REALM_VERSION_MINOR", to: String(versionCompontents[1])),
+                .define("REALM_VERSION_PATCH", to: String(versionCompontents[2])),
+                .define("REALM_VERSION_EXTRA", to: "\"\(versionExtra)\""),
+                .define("REALM_VERSION_STRING", to: "\"\(versionStr)\""),
+            ]),
+    ],
+    cxxLanguageStandard: .cxx14
+)

--- a/src/realm/CMakeLists.txt
+++ b/src/realm/CMakeLists.txt
@@ -129,6 +129,7 @@ set(REALM_INSTALL_GENERAL_HEADERS
     timestamp.hpp
     unicode.hpp
     utilities.hpp
+    version.hpp
     version_id.hpp
     views.hpp
 ) # REALM_INSTALL_GENERAL_HEADERS
@@ -368,7 +369,7 @@ install(FILES ${REALM_OTHER_UTIL_HEADERS}
 install(FILES ${REALM_METRICS_HEADERS}
         DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}/realm/metrics
         COMPONENT devel)
-install(FILES ${PROJECT_BINARY_DIR}/src/realm/version.hpp
+install(FILES ${PROJECT_BINARY_DIR}/src/realm/version_numbers.hpp
         DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}/realm
         COMPONENT devel)
 install(FILES ${PROJECT_BINARY_DIR}/src/realm/util/config.h

--- a/src/realm/util/features.h
+++ b/src/realm/util/features.h
@@ -27,7 +27,9 @@
 #define NOMINMAX
 #endif
 
+#ifndef REALM_NO_CONFIG
 #include <realm/util/config.h>
+#endif
 
 /* The maximum number of elements in a B+-tree node. Applies to inner nodes and
  * to leaves. The minimum allowable value is 2.

--- a/src/realm/version.hpp
+++ b/src/realm/version.hpp
@@ -1,0 +1,55 @@
+/*************************************************************************
+ *
+ * Copyright 2016 Realm Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ **************************************************************************/
+
+#ifndef REALM_VERSION_HPP
+#define REALM_VERSION_HPP
+
+#include <string>
+
+#ifndef REALM_VERSION_MAJOR
+#include <realm/version_numbers.hpp>
+#endif
+
+#define REALM_PRODUCT_NAME "realm-core"
+#define REALM_VER_CHUNK "[" REALM_PRODUCT_NAME "-" REALM_VERSION_STRING "]"
+
+namespace realm {
+
+enum Feature {
+    feature_Debug,
+    feature_Replication,
+};
+
+class StringData;
+
+class Version {
+public:
+    static int get_major() { return REALM_VERSION_MAJOR; }
+    static int get_minor() { return REALM_VERSION_MINOR; }
+    static int get_patch() { return REALM_VERSION_PATCH; }
+    static StringData get_extra();
+    static std::string get_version();
+    static bool is_at_least(int major, int minor, int patch, StringData extra);
+    static bool is_at_least(int major, int minor, int patch);
+    static bool has_feature(Feature feature);
+};
+
+
+} // namespace realm
+
+#endif // REALM_VERSION_HPP

--- a/src/realm/version_numbers.hpp.in
+++ b/src/realm/version_numbers.hpp.in
@@ -16,10 +16,8 @@
  *
  **************************************************************************/
 
-#ifndef REALM_VERSION_HPP
-#define REALM_VERSION_HPP
-
-#include <string>
+#ifndef REALM_VERSION_NUMBERS_HPP
+#define REALM_VERSION_NUMBERS_HPP
 
 // Do not use `cmakedefine` here, as certain versions can be 0, which CMake
 // interprets as being undefined.
@@ -29,31 +27,4 @@
 #define REALM_VERSION_EXTRA "@CONFIG_VERSION_TWEAK@"
 #define REALM_VERSION_STRING "@CONFIG_VERSION@"
 
-#define REALM_PRODUCT_NAME "realm-core"
-#define REALM_VER_CHUNK "[" REALM_PRODUCT_NAME "-" REALM_VERSION_STRING "]"
-
-namespace realm {
-
-enum Feature {
-    feature_Debug,
-    feature_Replication,
-};
-
-class StringData;
-
-class Version {
-public:
-    static int get_major() { return REALM_VERSION_MAJOR; }
-    static int get_minor() { return REALM_VERSION_MINOR; }
-    static int get_patch() { return REALM_VERSION_PATCH; }
-    static StringData get_extra();
-    static std::string get_version();
-    static bool is_at_least(int major, int minor, int patch, StringData extra);
-    static bool is_at_least(int major, int minor, int patch);
-    static bool has_feature(Feature feature);
-};
-
-
-} // namespace realm
-
-#endif // REALM_VERSION_HPP
+#endif // REALM_VERSION_NUMBERS_HPP

--- a/tools/release-init.sh
+++ b/tools/release-init.sh
@@ -21,6 +21,10 @@ git checkout -b prepare-$realm_version
 sed -i.bak -e "s/^VERSION.*/VERSION=${realm_version}/" "${project_dir}/dependencies.list"
 rm "${project_dir}/dependencies.list.bak" || exit 1
 
+# update Package.swift
+sed -i.bak -e "s/^let versionStr =.*/let versionStr = \"${realm_version}\"/" "${project_dir}/Package.swift"
+rm "${project_dir}/Package.swift.bak" || exit 1
+
 RELEASE_HEADER="# $realm_version Release notes" || exit 1
 sed -i.bak -e "1s/.*/$RELEASE_HEADER/" "${project_dir}/CHANGELOG.md" || exit 1
 rm "${project_dir}/CHANGELOG.md.bak" || exit 1


### PR DESCRIPTION
This is required for Cocoa to support SPM, as it only supports purely building from source with only SPM-based dependencies.

SPM doesn't have any concept of a "configure" step, so I pushed the part of version.hpp that cmake modifies into a separate header that isn't included when building with SPM and instead hardcoded the version number in package.swift. It can't simply read the version from dependencies.list because the package is evaluated in a sandbox with no access to any other files in the repository. The release script takes care of updating this additional copy of the version, so this shouldn't be a problem.