### PR TITLE
Better performance of an IncludeDescriptor

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,8 +4,8 @@
 * Add a Swift Package Manager packgae ([#3308](https://github.com/realm/realm-core/pull/3308)).
 
 ### Fixed
-* <How to hit and notice issue? what was the impact?> ([#????](https://github.com/realm/realm-core/issues/????), since v?.?.?)
-* None.
+* Constructing an `IncludeDescriptor` made unnecessary table comparisons. This resulted in poor performance for subscriptions
+  using the `includeLinkingObjects` functionality. ([#3311](https://github.com/realm/realm-core/issues/3311), since v5.18.0)
  
 ### Breaking changes
 * None.

--- a/src/realm/views.cpp
+++ b/src/realm/views.cpp
@@ -342,12 +342,12 @@ IncludeDescriptor::IncludeDescriptor(const Table& table, const std::vector<std::
         size_t link_ndx = 0;
         for (auto link : links) {
             if (bool(link.from)) { // backlink
-                REALM_ASSERT(cur_table == link.from->get_link_target(link.column_ndx));
+                REALM_ASSERT_DEBUG(cur_table->get_name() == link.from->get_link_target(link.column_ndx)->get_name());
                 auto& col = tf::get_column(*link.from, link.column_ndx);
                 columns.push_back(&col);
                 backlink_source.push_back(link.from);
                 if (auto link_col = dynamic_cast<const LinkColumnBase*>(&col)) { // LinkColumn and ListColumn
-                    if (link_col->get_target_table() != *cur_table) {
+                    if (link_col->get_target_table().get_name() != cur_table->get_name()) {
                         // the link does not point to the last table in the chain
                         throw InvalidPathError(util::format("Invalid INCLUDE path at [%1, %2]: this link does not "
                                                             "connect to the previous table ('%3').",


### PR DESCRIPTION
Table equality is evaluated by comparing every row, which is a very expensive operation. The intent of the code which checks for table equality can be replaced by checking the table name.

This was discovered by a [customer](https://github.com/realm/engineering/issues/70) using the `includeLinkingObjects` feature of subscriptions.