### PR TITLE
Fix queries on indexed int columns which are not in table order

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@
 ### Fixed
 * Fixed the metrics throwing an exception when a query cannot be serialised. Now it reports the exception message as the description.
  ([#3031](https://github.com/realm/realm-sync/issues/3031), since v3.2.0)
+* Queries involving an indexed int column which were constrained by a LinkList with an order differenet from the table's order would
+  give incorrect results. ([#3307](https://github.com/realm/realm-core/issues/3307), since v3.19.0)
 
 ### Breaking changes
 * None.

--- a/src/realm/query_engine.hpp
+++ b/src/realm/query_engine.hpp
@@ -927,6 +927,14 @@ public:
         REALM_ASSERT(this->m_table);
 
         if (has_search_index()) {
+            if (m_index_end == 0)
+                return not_found;
+
+            if (start <= m_index_last_start)
+                m_index_get = 0;
+            else
+                m_index_last_start = start;
+
             while (m_index_get < m_index_end) {
                 // m_results are stored in sorted ascending order, guaranteed by the string index
                 size_t ndx = size_t(m_result.get(m_index_get));
@@ -1010,6 +1018,7 @@ private:
     IntegerColumn m_result;
     size_t m_nb_needles = 0;
     size_t m_index_get = 0;
+    size_t m_index_last_start = 0;
     size_t m_index_end = 0;
 
     IntegerNode(const IntegerNode<ColType, Equal>& from, QueryNodeHandoverPatches* patches)


### PR DESCRIPTION
The query node incorrectly assumed that the start index would always be greater than the last-seen start index, which is correct for normal queries on a table but incorrect when the query is constrained by a linklist, as it then uses the linklist's order instead.

Fixes #3307.