### PR TITLE
Fix a memory leak when indexed int queries are run more than once

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,8 +6,9 @@
 ### Fixed
 * Fixed the metrics throwing an exception when a query cannot be serialised. Now it reports the exception message as the description.
  ([#3031](https://github.com/realm/realm-sync/issues/3031), since v3.2.0)
-* Queries involving an indexed int column which were constrained by a LinkList with an order differenet from the table's order would
+* Queries involving an indexed int column which were constrained by a LinkList with an order different from the table's order would
   give incorrect results. ([#3307](https://github.com/realm/realm-core/issues/3307), since v3.19.0)
+* Queries involving an indexed int column had a memory leak if run multiple times. ([#6186](https://github.com/realm/realm-cocoa/issues/6186)), since v3.19.0)
 
 ### Breaking changes
 * None.


### PR DESCRIPTION
The results of the index search are stored in a temporary `IntegerColumn` which is created and populated during `init()`. However, we only freed this memory in the destructor of the `IntegerNode` (which has a lifetime of the Query object). We also need to deallocate the results when the query is run again which is every `init()`.

I also changed the results to be a unique pointer to an integer column, which is an optimization so that an empty `IntegerColumn` is not constructed and destructed unnecessarily when the query node is created.

I believe this will fix https://github.com/realm/realm-cocoa/issues/6186 and maybe https://github.com/realm/realm-cocoa/issues/6167