### PR TITLE
Valgrind test

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -73,7 +73,7 @@ jobWrapper {
             iosDebug                : doBuildAppleDevice('ios', 'MinSizeDebug'),
             androidArm64Debug       : doAndroidBuildInDocker('arm64-v8a', 'Debug', false),
             threadSanitizer         : doCheckSanity('Debug', '1000', 'thread'),
-            addressSanitizer        : doCheckSanity('Debug', '1000', 'address'),
+            addressSanitizer        : doCheckSanity('Debug', '1000', 'address')
         ]
         if (releaseTesting) {
             extendedChecks = [
@@ -311,7 +311,7 @@ def doCheckValgrind() {
                         sh """
                            mkdir build-dir
                            cd build-dir
-                           cmake -D CMAKE_BUILD_TYPE=Debug -D REALM_VALGRIND=ON -D REALM_ENABLE_ALLOC_SET_ZERO=ON -D REALM_MAX_BPNODE_SIZE=1000 -G Ninja ..
+                           cmake -D CMAKE_BUILD_TYPE=RelWithDebInfo -D REALM_VALGRIND=ON -D REALM_ENABLE_ALLOC_SET_ZERO=ON -D REALM_MAX_BPNODE_SIZE=1000 -G Ninja ..
                         """
                         runAndCollectWarnings(script: "cd build-dir && ninja")
                         sh """

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -317,7 +317,7 @@ def doCheckValgrind() {
                         sh """
                             cd build-dir/test
                             valgrind --version
-                            valgrind --tool=memcheck --leak-check=full --undef-value-errors=yes --track-origins=yes --child-silent-after-fork=no --trace-children=yes --xml=yes --suppressions=${workspace}/test/valgrind.suppress --xml-file=${workspace}/build-dir/test/realm-tests-dbg.memreport --error-exitcode=1 ./realm-tests --no-error-exitcode
+                            valgrind --tool=memcheck --leak-check=full --undef-value-errors=yes --track-origins=yes --child-silent-after-fork=no --trace-children=yes --suppressions=${workspace}/test/valgrind.suppress --error-exitcode=1 ./realm-tests --no-error-exitcode
                         """
                     } finally {
                         recordTests("Linux-ValgrindDebug")

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -65,15 +65,15 @@ jobWrapper {
 
     stage('Checking') {
         parallelExecutors = [
-            checkLinuxDebug         : doCheckInDocker('Debug'),
-            checkLinuxDebugNoEncryp : doCheckInDocker('Debug', '4', 'OFF'),
-            checkMacOsRelease       : doBuildMacOs('Release', true),
-            checkWin32Debug         : doBuildWindows('Debug', false, 'Win32', true),
-            checkWin64Release       : doBuildWindows('Release', false, 'x64', true),
-            iosDebug                : doBuildAppleDevice('ios', 'MinSizeDebug'),
-            androidArm64Debug       : doAndroidBuildInDocker('arm64-v8a', 'Debug', false),
-            threadSanitizer         : doCheckSanity('Debug', '1000', 'thread'),
-            addressSanitizer        : doCheckSanity('Debug', '1000', 'address')
+            checkLinuxDebug         : doCheckInDocker('Debug')
+           // checkLinuxDebugNoEncryp : doCheckInDocker('Debug', '4', 'OFF'),
+           // checkMacOsRelease       : doBuildMacOs('Release', true),
+           // checkWin32Debug         : doBuildWindows('Debug', false, 'Win32', true),
+           // checkWin64Release       : doBuildWindows('Release', false, 'x64', true),
+           // iosDebug                : doBuildAppleDevice('ios', 'MinSizeDebug'),
+           // androidArm64Debug       : doAndroidBuildInDocker('arm64-v8a', 'Debug', false),
+           // threadSanitizer         : doCheckSanity('Debug', '1000', 'thread'),
+           // addressSanitizer        : doCheckSanity('Debug', '1000', 'address')
         ]
         if (releaseTesting) {
             extendedChecks = [

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -10,171 +10,173 @@ tokens = "${env.JOB_NAME}".tokenize('/')
 org = tokens[tokens.size()-3]
 repo = tokens[tokens.size()-2]
 branch = tokens[tokens.size()-1]
+valgrindCheck = true // FIXME: default to false
 
 jobWrapper {
-    timeout(time: 5, unit: 'HOURS') {
-        stage('gather-info') {
-            node('docker') {
-                getSourceArchive()
-                stash includes: '**', name: 'core-source', useDefaultExcludes: false
+    stage('gather-info') {
+        node('docker') {
+            getSourceArchive()
+            stash includes: '**', name: 'core-source', useDefaultExcludes: false
 
-                dependencies = readProperties file: 'dependencies.list'
-                echo "Version in dependencies.list: ${dependencies.VERSION}"
+            dependencies = readProperties file: 'dependencies.list'
+            echo "Version in dependencies.list: ${dependencies.VERSION}"
 
-                gitTag = readGitTag()
-                gitSha = sh(returnStdout: true, script: 'git rev-parse HEAD').trim().take(8)
-                gitDescribeVersion = sh(returnStdout: true, script: 'git describe --tags').trim()
+            gitTag = readGitTag()
+            gitSha = sh(returnStdout: true, script: 'git rev-parse HEAD').trim().take(8)
+            gitDescribeVersion = sh(returnStdout: true, script: 'git describe --tags').trim()
 
-                echo "Git tag: ${gitTag ?: 'none'}"
-                if (!gitTag) {
-                    echo "No tag given for this build"
-                    setBuildName(gitSha)
+            echo "Git tag: ${gitTag ?: 'none'}"
+            if (!gitTag) {
+                echo "No tag given for this build"
+                setBuildName(gitSha)
+            } else {
+                if (gitTag != "v${dependencies.VERSION}") {
+                    error "Git tag '${gitTag}' does not match v${dependencies.VERSION}"
                 } else {
-                    if (gitTag != "v${dependencies.VERSION}") {
-                        error "Git tag '${gitTag}' does not match v${dependencies.VERSION}"
-                    } else {
-                        echo "Building release: '${gitTag}'"
-                        setBuildName("Tag ${gitTag}")
-                    }
+                    echo "Building release: '${gitTag}'"
+                    setBuildName("Tag ${gitTag}")
                 }
-            }
-
-            isPullRequest = !!env.CHANGE_TARGET
-            targetBranch = isPullRequest ? env.CHANGE_TARGET : "none"
-            currentBranch = env.BRANCH_NAME
-            println "Building branch: ${currentBranch}"
-            println "Target branch: ${targetBranch}"
-
-            releaseTesting = targetBranch.contains('release')
-            isPublishingRun = false
-            valgrindCheck = true // FIXME: default to false
-            if (gitTag) {
-                isPublishingRun = currentBranch.contains('release')
-            }
-
-            echo "Pull request: ${isPullRequest ? 'yes' : 'no'}"
-            echo "Release Run: ${releaseTesting ? 'yes' : 'no'}"
-            echo "Publishing Run: ${isPublishingRun ? 'yes' : 'no'}"
-
-            if (['master'].contains(env.BRANCH_NAME)) {
-                // If we're on master, instruct the docker image builds to push to the
-                // cache registry
-                env.DOCKER_PUSH = "1"
-                valgrindCheck = true
             }
         }
 
-        stage('Checking') {
-            parallelExecutors = [
-                checkLinuxDebug         : doCheckInDocker('Debug'),
-                checkLinuxDebugNoEncryp : doCheckInDocker('Debug', '4', 'OFF'),
-                checkMacOsRelease       : doBuildMacOs('Release', true),
-                checkWin32Debug         : doBuildWindows('Debug', false, 'Win32', true),
-                checkWin64Release       : doBuildWindows('Release', false, 'x64', true),
-                iosDebug                : doBuildAppleDevice('ios', 'MinSizeDebug'),
-                androidArm64Debug       : doAndroidBuildInDocker('arm64-v8a', 'Debug', false),
-                threadSanitizer         : doCheckSanity('Debug', '1000', 'thread'),
-                addressSanitizer        : doCheckSanity('Debug', '1000', 'address'),
+        isPullRequest = !!env.CHANGE_TARGET
+        targetBranch = isPullRequest ? env.CHANGE_TARGET : "none"
+        currentBranch = env.BRANCH_NAME
+        println "Building branch: ${currentBranch}"
+        println "Target branch: ${targetBranch}"
+
+        releaseTesting = targetBranch.contains('release')
+        isPublishingRun = false
+        if (gitTag) {
+            isPublishingRun = currentBranch.contains('release')
+        }
+
+        echo "Pull request: ${isPullRequest ? 'yes' : 'no'}"
+        echo "Release Run: ${releaseTesting ? 'yes' : 'no'}"
+        echo "Publishing Run: ${isPublishingRun ? 'yes' : 'no'}"
+
+        if (['master'].contains(env.BRANCH_NAME)) {
+            // If we're on master, instruct the docker image builds to push to the
+            // cache registry
+            env.DOCKER_PUSH = "1"
+            valgrindCheck = true
+        }
+    }
+
+    stage('Checking') {
+        parallelExecutors = [
+            checkLinuxDebug         : doCheckInDocker('Debug'),
+            checkLinuxDebugNoEncryp : doCheckInDocker('Debug', '4', 'OFF'),
+            checkMacOsRelease       : doBuildMacOs('Release', true),
+            checkWin32Debug         : doBuildWindows('Debug', false, 'Win32', true),
+            checkWin64Release       : doBuildWindows('Release', false, 'x64', true),
+            iosDebug                : doBuildAppleDevice('ios', 'MinSizeDebug'),
+            androidArm64Debug       : doAndroidBuildInDocker('arm64-v8a', 'Debug', false),
+            threadSanitizer         : doCheckSanity('Debug', '1000', 'thread'),
+            addressSanitizer        : doCheckSanity('Debug', '1000', 'address'),
+        ]
+        if (releaseTesting) {
+            extendedChecks = [
+                checkLinuxRelease       : doCheckInDocker('Release'),
+                checkMacOsDebug         : doBuildMacOs('Debug', true),
+                buildUwpx64Debug        : doBuildWindows('Debug', true, 'x64', false),
+                androidArmeabiRelease   : doAndroidBuildInDocker('armeabi-v7a', 'Release', true),
+                coverage                : doBuildCoverage(),
+                performance             : buildPerformance()
             ]
-            if (releaseTesting) {
-                extendedChecks = [
-                    checkLinuxRelease       : doCheckInDocker('Release'),
-                    checkMacOsDebug         : doBuildMacOs('Debug', true),
-                    buildUwpx64Debug        : doBuildWindows('Debug', true, 'x64', false),
-                    androidArmeabiRelease   : doAndroidBuildInDocker('armeabi-v7a', 'Release', true),
-                    coverage                : doBuildCoverage(),
-                    performance             : buildPerformance()
-                ]
-                parallelExecutors.putAll(extendedChecks)
+            parallelExecutors.putAll(extendedChecks)
+        }
+        parallel parallelExecutors
+    }
+
+    if (isPublishingRun) {
+        stage('BuildPackages') {
+            parallelExecutors = [
+                buildMacOsDebug     : doBuildMacOs('Debug', false),
+                buildMacOsRelease   : doBuildMacOs('Release', false),
+
+                buildWin32Debug     : doBuildWindows('Debug', false, 'Win32', false),
+                buildWin32Release   : doBuildWindows('Release', false, 'Win32', false),
+                buildWin64Debug     : doBuildWindows('Debug', false, 'x64', false),
+                buildWin64Release   : doBuildWindows('Release', false, 'x64', false),
+                buildUwpWin32Debug  : doBuildWindows('Debug', true, 'Win32', false),
+                buildUwpWin32Release: doBuildWindows('Release', true, 'Win32', false),
+                buildUwpx64Debug    : doBuildWindows('Debug', true, 'x64', false),
+                buildUwpx64Release  : doBuildWindows('Release', true, 'x64', false),
+                buildUwpArmDebug    : doBuildWindows('Debug', true, 'ARM', false),
+                buildUwpArmRelease  : doBuildWindows('Release', true, 'ARM', false),
+
+                buildLinuxDebug     : doBuildLinux('Debug'),
+                buildLinuxRelease   : doBuildLinux('Release'),
+                buildLinuxRelAssert : doBuildLinux('RelAssert'),
+                buildLinuxASAN      : doBuildLinuxClang("RelASAN"),
+                buildLinuxTSAN      : doBuildLinuxClang("RelTSAN")
+            ]
+
+            androidAbis = ['armeabi-v7a', 'x86', 'mips', 'x86_64', 'arm64-v8a']
+            androidBuildTypes = ['Debug', 'Release']
+
+            for (abi in androidAbis) {
+                for (buildType in androidBuildTypes) {
+                    parallelExecutors["android-${abi}-${buildType}"] = doAndroidBuildInDocker(abi, buildType, false)
+                }
             }
-            if (valgrindCheck) {
-                extendedChecks = [
-                    valgrindLinuxDebug      : doCheckValgrind(),
-                ]
-                parallelExecutors.putAll(extendedChecks)
+
+            appleSdks = ['ios', 'tvos', 'watchos']
+            appleBuildTypes = ['MinSizeDebug', 'Release']
+
+            for (sdk in appleSdks) {
+                for (buildType in appleBuildTypes) {
+                    parallelExecutors["${sdk}${buildType}"] = doBuildAppleDevice(sdk, buildType)
+                }
             }
+
             parallel parallelExecutors
         }
-
-        if (isPublishingRun) {
-            stage('BuildPackages') {
-                parallelExecutors = [
-                    buildMacOsDebug     : doBuildMacOs('Debug', false),
-                    buildMacOsRelease   : doBuildMacOs('Release', false),
-
-                    buildWin32Debug     : doBuildWindows('Debug', false, 'Win32', false),
-                    buildWin32Release   : doBuildWindows('Release', false, 'Win32', false),
-                    buildWin64Debug     : doBuildWindows('Debug', false, 'x64', false),
-                    buildWin64Release   : doBuildWindows('Release', false, 'x64', false),
-                    buildUwpWin32Debug  : doBuildWindows('Debug', true, 'Win32', false),
-                    buildUwpWin32Release: doBuildWindows('Release', true, 'Win32', false),
-                    buildUwpx64Debug    : doBuildWindows('Debug', true, 'x64', false),
-                    buildUwpx64Release  : doBuildWindows('Release', true, 'x64', false),
-                    buildUwpArmDebug    : doBuildWindows('Debug', true, 'ARM', false),
-                    buildUwpArmRelease  : doBuildWindows('Release', true, 'ARM', false),
-
-                    buildLinuxDebug     : doBuildLinux('Debug'),
-                    buildLinuxRelease   : doBuildLinux('Release'),
-                    buildLinuxRelAssert : doBuildLinux('RelAssert'),
-                    buildLinuxASAN      : doBuildLinuxClang("RelASAN"),
-                    buildLinuxTSAN      : doBuildLinuxClang("RelTSAN")
-                ]
-
-                androidAbis = ['armeabi-v7a', 'x86', 'mips', 'x86_64', 'arm64-v8a']
-                androidBuildTypes = ['Debug', 'Release']
-
-                for (abi in androidAbis) {
-                    for (buildType in androidBuildTypes) {
-                        parallelExecutors["android-${abi}-${buildType}"] = doAndroidBuildInDocker(abi, buildType, false)
+        stage('Aggregate') {
+            parallel (
+                cocoa: {
+                    node('docker') {
+                        getArchive()
+                        for (cocoaStash in cocoaStashes) {
+                            unstash name: cocoaStash
+                        }
+                        sh 'tools/build-cocoa.sh'
+                        archiveArtifacts('realm-core-cocoa*.tar.xz')
+                        def stashName = 'cocoa'
+                        stash includes: 'realm-core-cocoa*.tar.xz', name: stashName
+                        publishingStashes << stashName
+                    }
+                },
+                android: {
+                    node('docker') {
+                        getArchive()
+                        for (androidStash in androidStashes) {
+                            unstash name: androidStash
+                        }
+                        sh 'tools/build-android.sh'
+                        archiveArtifacts('realm-core-android*.tar.gz')
+                        def stashName = 'android'
+                        stash includes: 'realm-core-android*.tar.gz', name: stashName
+                        publishingStashes << stashName
                     }
                 }
+            )
+        }
+        stage('publish-packages') {
+            parallel(
+                others: doPublishLocalArtifacts()
+            )
+        }
+    }
+}
 
-                appleSdks = ['ios', 'tvos', 'watchos']
-                appleBuildTypes = ['MinSizeDebug', 'Release']
-
-                for (sdk in appleSdks) {
-                    for (buildType in appleBuildTypes) {
-                        parallelExecutors["${sdk}${buildType}"] = doBuildAppleDevice(sdk, buildType)
-                    }
-                }
-
-                parallel parallelExecutors
-            }
-            stage('Aggregate') {
-                parallel (
-                    cocoa: {
-                        node('docker') {
-                            getArchive()
-                            for (cocoaStash in cocoaStashes) {
-                                unstash name: cocoaStash
-                            }
-                            sh 'tools/build-cocoa.sh'
-                            archiveArtifacts('realm-core-cocoa*.tar.xz')
-                            def stashName = 'cocoa'
-                            stash includes: 'realm-core-cocoa*.tar.xz', name: stashName
-                            publishingStashes << stashName
-                        }
-                    },
-                    android: {
-                        node('docker') {
-                            getArchive()
-                            for (androidStash in androidStashes) {
-                                unstash name: androidStash
-                            }
-                            sh 'tools/build-android.sh'
-                            archiveArtifacts('realm-core-android*.tar.gz')
-                            def stashName = 'android'
-                            stash includes: 'realm-core-android*.tar.gz', name: stashName
-                            publishingStashes << stashName
-                        }
-                    }
-                )
-            }
-            stage('publish-packages') {
-                parallel(
-                    others: doPublishLocalArtifacts()
-                )
-            }
+timeout(time: 6, unit: 'HOURS') {
+    if (valgrindCheck) {
+        stage('Valgrind') {
+            parallel(
+                valgrind: doCheckValgrind()
+            )
         }
     }
 }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -71,8 +71,7 @@ jobWrapper {
             iosDebug                : doBuildAppleDevice('ios', 'MinSizeDebug'),
             androidArm64Debug       : doAndroidBuildInDocker('arm64-v8a', 'Debug', false),
             threadSanitizer         : doCheckSanity('Debug', '1000', 'thread'),
-            addressSanitizer        : doCheckSanity('Debug', '1000', 'address'),
-            valgrind                : doCheckValgrind()
+            addressSanitizer        : doCheckSanity('Debug', '1000', 'address')
         ]
         if (releaseTesting) {
             extendedChecks = [
@@ -81,7 +80,8 @@ jobWrapper {
                 buildUwpx64Debug        : doBuildWindows('Debug', true, 'x64', false),
                 androidArmeabiRelease   : doAndroidBuildInDocker('armeabi-v7a', 'Release', true),
                 coverage                : doBuildCoverage(),
-                performance             : buildPerformance()
+                performance             : buildPerformance(),
+                valgrind                : doCheckValgrind()
             ]
             parallelExecutors.putAll(extendedChecks)
         }

--- a/src/realm/row.hpp
+++ b/src/realm/row.hpp
@@ -236,7 +236,7 @@ class Group;
 class RowBase {
 protected:
     TableRef m_table; // nullptr if detached.
-    size_t m_row_ndx; // Undefined if detached.
+    size_t m_row_ndx = -1; // Undefined if detached.
 
     void attach(Table*, size_t row_ndx) noexcept;
     void reattach(Table*, size_t row_ndx) noexcept;

--- a/test/test_destructor_thread_safety.cpp
+++ b/test/test_destructor_thread_safety.cpp
@@ -174,7 +174,8 @@ TEST(ThreadSafety_RowDestruction)
 }
 
 // Tests thread safety of subtable desctruction
-TEST(ThreadSafety_SubTableDestruction)
+// This test takes too long when run with valgrind
+TEST_IF(ThreadSafety_SubTableDestruction, !running_with_valgrind)
 {
     std::vector<TableRef> ptrs;
     Mutex mutex;

--- a/test/test_index_string.cpp
+++ b/test/test_index_string.cpp
@@ -1786,7 +1786,8 @@ std::string create_random_a_string(size_t max_len) {
 }
 
 
-TEST_TYPES(StringIndex_Insensitive_Fuzz, string_column, nullable_string_column, enum_column, nullable_enum_column)
+// Excluded when run with valgrind because it takes a long time
+TEST_TYPES_IF(StringIndex_Insensitive_Fuzz, !running_with_valgrind, string_column, nullable_string_column, enum_column, nullable_enum_column)
 {
     const size_t max_str_len = 9;
     const size_t iters = 3;

--- a/test/test_lang_bind_helper.cpp
+++ b/test/test_lang_bind_helper.cpp
@@ -10309,29 +10309,6 @@ TEST(LangBindHelper_RacingAttachers)
     }
 }
 
-void some_external_function(size_t leak_size)
-{
-    size_t *leaked = new size_t(leak_size);
-    std::cout << "address of leak is : " << leaked << " size: " << leak_size << std::endl;
-}
-
-TEST(LangBindHelper_IntentionalMemoryLeak)
-{
-    // FIXME: this is only to trigger valgrind and ensure the stack trace is readable
-    SHARED_GROUP_TEST_PATH(path);
-    std::unique_ptr<Replication> hist(make_in_realm_history(path));
-    SharedGroup sg(*hist, SharedGroupOptions(crypt_key()));
-    Group& g = sg.begin_write();
-    some_external_function(1000);
-    auto table = g.add_table("table");
-    table->add_column(type_Int, "first");
-    sg.commit();
-    sg.begin_read();
-    table = g.get_table("table");
-    CHECK(bool(table));
-    sg.end_read();
-}
-
 // This test takes a very long time when running with valgrind
 TEST_IF(LangBindHelper_HandoverBetweenThreads, !running_with_valgrind)
 {

--- a/test/test_lang_bind_helper.cpp
+++ b/test/test_lang_bind_helper.cpp
@@ -10309,8 +10309,8 @@ TEST(LangBindHelper_RacingAttachers)
     }
 }
 
-
-TEST(LangBindHelper_HandoverBetweenThreads)
+// This test takes a very long time when running with valgrind
+TEST_IF(LangBindHelper_HandoverBetweenThreads, !running_with_valgrind)
 {
     SHARED_GROUP_TEST_PATH(path);
     std::unique_ptr<Replication> hist(make_in_realm_history(path));

--- a/test/test_lang_bind_helper.cpp
+++ b/test/test_lang_bind_helper.cpp
@@ -10309,6 +10309,29 @@ TEST(LangBindHelper_RacingAttachers)
     }
 }
 
+void some_external_function(size_t leak_size)
+{
+    size_t *leaked = new size_t(leak_size);
+    std::cout << "address of leak is : " << leaked << " size: " << leak_size << std::endl;
+}
+
+TEST(LangBindHelper_IntentionalMemoryLeak)
+{
+    // FIXME: this is only to trigger valgrind and ensure the stack trace is readable
+    SHARED_GROUP_TEST_PATH(path);
+    std::unique_ptr<Replication> hist(make_in_realm_history(path));
+    SharedGroup sg(*hist, SharedGroupOptions(crypt_key()));
+    Group& g = sg.begin_write();
+    some_external_function(1000);
+    auto table = g.add_table("table");
+    table->add_column(type_Int, "first");
+    sg.commit();
+    sg.begin_read();
+    table = g.get_table("table");
+    CHECK(bool(table));
+    sg.end_read();
+}
+
 // This test takes a very long time when running with valgrind
 TEST_IF(LangBindHelper_HandoverBetweenThreads, !running_with_valgrind)
 {

--- a/valgrind.Dockerfile
+++ b/valgrind.Dockerfile
@@ -1,0 +1,39 @@
+FROM ubuntu:18.04
+
+# One dependency per line in alphabetical order.
+# This should help avoiding duplicates and make the file easier to update.
+RUN apt-get update && apt-get install -y \
+    build-essential \
+    curl \
+    gcovr \
+    git \
+    g++-7 \
+    lcov \
+    libprocps-dev \
+    libssl-dev \
+    ninja-build \
+    pandoc \
+    # cheetah is required to build core < v1.0.0 benchmarks
+    python-cheetah \
+    python-matplotlib \
+    python-pip \
+    pkg-config \
+    s3cmd \
+    tar \
+    unzip \
+    valgrind \
+    wget \
+    && rm -rf /var/lib/apt/lists/*
+
+RUN pip install diff_cover
+
+RUN cd /opt \
+    && wget https://cmake.org/files/v3.7/cmake-3.7.2-Linux-x86_64.tar.gz \
+    && tar zxvf cmake-3.7.2-Linux-x86_64.tar.gz
+
+ENV PATH "$PATH:/opt/cmake-3.7.2-Linux-x86_64/bin"
+
+VOLUME /source
+VOLUME /out
+
+WORKDIR /source

--- a/valgrind.Dockerfile
+++ b/valgrind.Dockerfile
@@ -2,7 +2,7 @@ FROM ubuntu:18.04
 
 # One dependency per line in alphabetical order.
 # This should help avoiding duplicates and make the file easier to update.
-RUN apt-get update && apt-get install -y \
+RUN apt-get update && DEBIAN_FRONTEND=noninteractive apt-get install -y \
     build-essential \
     curl \
     gcovr \


### PR DESCRIPTION
Our old valgrind job hasn't run for a long time because it was not dockerized. But we had a small memory leak recently and this would have helped us catch that. So this PR will make valgrind run on every release during the extended check phase.

The Jenkinsfile diff is mostly unreadable, but the change there is just to remove a top level `timeout` wrapper which was useless because the surrounding `jobwrapper` already has a [hard coded](https://github.com/realm/ci/blob/master/vars/jobWrapper.groovy#L5) timeout of 2 hours.

I've verified that a leak will fail the valgrind check, and will print the leak to the console. It takes about 40 minutes to test a `RelWithDebInfo` build, which is why I decided to put it into the extended release checks rather than for every PR since right now our PR's typically pass CI in < 20 minutes.