### PR TITLE
Make FIFO files world readable on Android.

### DIFF
--- a/.idea/.gitignore
+++ b/.idea/.gitignore
@@ -1,3 +1,0 @@
-
-# Default ignored files
-/workspace.xml

--- a/.idea/.gitignore
+++ b/.idea/.gitignore
@@ -1,0 +1,3 @@
+
+# Default ignored files
+/workspace.xml

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@
 
 ### Fixed
 * <How to hit and notice issue? what was the impact?> ([#????](https://github.com/realm/realm-core/issues/????), since v?.?.?)
-* None.
+* Named pipes on Android are now created with 0666 permissions instead of 0600. This fixes a bug on Huawei devices which caused named pipes to change owners during app upgrades causing subsequent `ACCESS DENIED` errors. This should have not practical security implications. (Issue [#3328](https://github.com/realm/realm-core/pull/3328))
  
 ### Breaking changes
 * None.

--- a/src/realm/CMakeLists.txt
+++ b/src/realm/CMakeLists.txt
@@ -48,6 +48,7 @@ set(REALM_SOURCES
     util/base64.cpp
     util/basic_system_errors.cpp
     util/encrypted_file_mapping.cpp
+    util/fifo_helper.cpp
     util/file.cpp
     util/file_mapper.cpp
     util/interprocess_condvar.cpp
@@ -159,6 +160,7 @@ set(REALM_INSTALL_UTIL_HEADERS
     util/cf_ptr.hpp
     util/encrypted_file_mapping.hpp
     util/features.h
+    util/fifo_helper.hpp
     util/file.hpp
     util/file_mapper.hpp
     util/hex_dump.hpp

--- a/src/realm/util/fifo_helper.cpp
+++ b/src/realm/util/fifo_helper.cpp
@@ -91,8 +91,9 @@ bool try_create_fifo(const std::string& path)
         return false;
     }
 }
-#endif
 
 } // namespace util
 } // namespace realm
+#endif
+
 

--- a/src/realm/util/fifo_helper.cpp
+++ b/src/realm/util/fifo_helper.cpp
@@ -28,7 +28,7 @@ namespace util {
 void create_fifo(std::string path, const std::string tmp_dir)
 {
 #ifdef _WIN32
-    throw std::system_error("mkfifo is not supported on Windows");
+    throw std::logic_error("mkfifo is not supported on Windows");
 #else
 #ifdef REALM_ANDROID
     // Upgrading apps on Android Huawai devices sometimes leave FIFO files with the wrong

--- a/src/realm/util/fifo_helper.cpp
+++ b/src/realm/util/fifo_helper.cpp
@@ -18,21 +18,18 @@
 
 #include <realm/util/fifo_helper.hpp>
 
-#include <fcntl.h>
 #include <sstream>
 #include <system_error>
 #include <sys/stat.h>
-#include <sys/types.h>
-
-#ifdef _WIN32
-#include <Windows.h>
-#endif
 
 namespace realm {
 namespace util {
 
 void create_fifo(std::string path, const std::string tmp_dir)
 {
+#ifdef _WIN32
+    throw std::system_error("mkfifo is not supported on Windows");
+#else
 #ifdef REALM_ANDROID
     // Upgrading apps on Android Huawai devices sometimes leave FIFO files with the wrong
     // file owners. This results in the Android sandbox preventing Realm from opening the
@@ -80,6 +77,7 @@ void create_fifo(std::string path, const std::string tmp_dir)
             }
         }
     }
+#endif
 }
 
 } // namespace util

--- a/src/realm/util/fifo_helper.cpp
+++ b/src/realm/util/fifo_helper.cpp
@@ -80,6 +80,16 @@ void create_fifo(std::string path, const std::string tmp_dir)
 #endif
 }
 
+bool try_create_fifo(const std::string& path)
+{
+    try {
+        create_fifo(path);
+        return true;
+    } catch (...) {
+        return false;
+    }
+}
+
 } // namespace util
 } // namespace realm
 

--- a/src/realm/util/fifo_helper.cpp
+++ b/src/realm/util/fifo_helper.cpp
@@ -19,6 +19,7 @@
 #include <realm/util/fifo_helper.hpp>
 
 #include <sstream>
+#include <system_error>
 #include <sys/stat.h>
 
 namespace realm {
@@ -26,7 +27,7 @@ namespace util {
 
 void create_fifo(std::string path, const std::string tmp_dir)
 {
-#if REALM_ANDROID
+#ifdef REALM_ANDROID
     // Upgrading apps on Android Huawai devices sometimes leave FIFO files with the wrong
     // file owners. This results in the Android sandbox preventing Realm from opening the
     // database file. To prevent this from happening we create all FIFO files with full permissions.

--- a/src/realm/util/fifo_helper.cpp
+++ b/src/realm/util/fifo_helper.cpp
@@ -22,6 +22,7 @@
 #include <sstream>
 #include <system_error>
 #include <sys/stat.h>
+#include <sys/types.h>
 
 #ifdef _WIN32
 #include <Windows.h>

--- a/src/realm/util/fifo_helper.cpp
+++ b/src/realm/util/fifo_helper.cpp
@@ -22,6 +22,8 @@
 #include <system_error>
 #include <sys/stat.h>
 
+// FIFOs do not work on Windows.
+#ifndef _WIN32
 namespace realm {
 namespace util {
 
@@ -38,9 +40,6 @@ void check_is_fifo(const std::string& path) {
 
 void create_fifo(std::string path)
 {
-#ifdef _WIN32
-    throw std::logic_error("mkfifo is not supported on Windows");
-#else
 #ifdef REALM_ANDROID
     // Upgrading apps on Android Huawai devices sometimes leave FIFO files with the wrong
     // file owners. This results in the Android sandbox preventing Realm from opening the
@@ -51,7 +50,7 @@ void create_fifo(std::string path)
     // full access to modify or copy files from there, so there should be no change from a pratical
     // security standpoint.
     // See more here: https://github.com/realm/realm-java/issues/3972#issuecomment-313675948
-    mode_t mode = 0600;
+    mode_t mode = 0666;
 #else
     mode_t mode = 0600;
 #endif
@@ -81,7 +80,6 @@ void create_fifo(std::string path)
             return check_is_fifo(path);
         }
     }
-#endif
 }
 
 bool try_create_fifo(const std::string& path)
@@ -93,6 +91,7 @@ bool try_create_fifo(const std::string& path)
         return false;
     }
 }
+#endif
 
 } // namespace util
 } // namespace realm

--- a/src/realm/util/fifo_helper.cpp
+++ b/src/realm/util/fifo_helper.cpp
@@ -23,23 +23,26 @@
 #include <sys/stat.h>
 
 // FIFOs do not work on Windows.
-#ifndef _WIN32
 namespace realm {
 namespace util {
 
 namespace {
-void check_is_fifo(const std::string& path) {
+void check_is_fifo(const std::string& path)
+{
+#ifndef _WIN32
     struct stat stat_buf;
     if (stat(path.c_str(), &stat_buf) == 0) {
         if ((stat_buf.st_mode & S_IFMT) != S_IFIFO) {
             throw std::runtime_error(path + " exists and it is not a fifo.");
         }
     }
+#endif
 }
 } // Anonymous namespace
 
 void create_fifo(std::string path)
 {
+#ifndef _WIN32
 #ifdef REALM_ANDROID
     // Upgrading apps on Android Huawai devices sometimes leave FIFO files with the wrong
     // file owners. This results in the Android sandbox preventing Realm from opening the
@@ -80,6 +83,7 @@ void create_fifo(std::string path)
             return check_is_fifo(path);
         }
     }
+#endif
 }
 
 bool try_create_fifo(const std::string& path)
@@ -94,6 +98,3 @@ bool try_create_fifo(const std::string& path)
 
 } // namespace util
 } // namespace realm
-#endif
-
-

--- a/src/realm/util/fifo_helper.cpp
+++ b/src/realm/util/fifo_helper.cpp
@@ -18,6 +18,7 @@
 
 #include <realm/util/fifo_helper.hpp>
 
+#include <fcntl.h>
 #include <sstream>
 #include <system_error>
 #include <sys/stat.h>

--- a/src/realm/util/fifo_helper.cpp
+++ b/src/realm/util/fifo_helper.cpp
@@ -23,6 +23,10 @@
 #include <system_error>
 #include <sys/stat.h>
 
+#ifdef _WIN32
+#include <Windows.h>
+#endif
+
 namespace realm {
 namespace util {
 

--- a/src/realm/util/fifo_helper.cpp
+++ b/src/realm/util/fifo_helper.cpp
@@ -1,0 +1,80 @@
+/*************************************************************************
+ *
+ * Copyright 2019 Realm Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ **************************************************************************/
+
+#include <realm/util/fifo_helper.hpp>
+
+#include <sstream>
+#include <sys/stat.h>
+
+namespace realm {
+namespace util {
+
+void create_fifo(std::string path, const std::string tmp_dir)
+{
+#if REALM_ANDROID
+    // Upgrading apps on Android Huawai devices sometimes leave FIFO files with the wrong
+    // file owners. This results in the Android sandbox preventing Realm from opening the
+    // database file. To prevent this from happening we create all FIFO files with full permissions.
+    // This should be safe as the app is already running inside a protected part of the filesystem,
+    // so no outside users have access to the filesystem where these files are.
+    // It does make storing Realms on external storage slightly more unsafe, but users already have
+    // full access to modify or copy files from there, so there should be no change from a pratical
+    // security standpoint.
+    // See more here: https://github.com/realm/realm-java/issues/3972#issuecomment-313675948
+    mode_t mode = 0600;
+#else
+    mode_t mode = 0600;
+#endif
+
+    // Create and open the named pipe
+    int ret = mkfifo(path.c_str(), mode);
+    if (ret == -1) {
+        int err = errno;
+        if (err == ENOTSUP || err == EACCES || err == EPERM || err == EINVAL) {
+            // Filesystem doesn't support named pipes, so try putting it in tmp_dir instead
+            // Hash collisions are okay here because they just result in doing
+            // extra work, as opposed to correctness problems.
+            std::ostringstream ss;
+            ss << tmp_dir;
+            ss << "realm_" << std::hash<std::string>()(path) << ".cv";
+            path = ss.str();
+            ret = mkfifo(path.c_str(), mode);
+            err = errno;
+        }
+
+        // the fifo already existing isn't an error
+        if (ret == -1 && err != EEXIST) {
+            // Workaround for a mkfifo bug on Blackberry devices:
+            // When the fifo already exists, mkfifo fails with error ENOSYS which is not correct.
+            // In this case, we use stat to check if the path exists and it is a fifo.
+            struct stat stat_buf;
+            if (stat(path.c_str(), &stat_buf) == 0) {
+                if ((stat_buf.st_mode & S_IFMT) != S_IFIFO) {
+                    throw std::runtime_error(path + " exists and it is not a fifo.");
+                }
+            }
+            else {
+                throw std::system_error(err, std::system_category());
+            }
+        }
+    }
+}
+
+} // namespace util
+} // namespace realm
+

--- a/src/realm/util/fifo_helper.hpp
+++ b/src/realm/util/fifo_helper.hpp
@@ -36,6 +36,9 @@ namespace util {
 // If a FIFO already exists at the given location, this method does nothing.
 void create_fifo(std::string path, const std::string tmp_dir); // throws
 
+// Same as above, but returns `false` if the FIFO could not be created instead of throwing.
+bool try_create_fifo(const std::string& path);
+
 } // namespace util
 } // namespace realm
 

--- a/src/realm/util/fifo_helper.hpp
+++ b/src/realm/util/fifo_helper.hpp
@@ -25,14 +25,7 @@ namespace realm {
 namespace util {
 
 // Attempts to create a FIFO file at the location determined by `path`.
-// If the filesystem does not allow FIFO's at this location the path is hashed
-// and used as the file name for the FIFO which is then created in `tmp_path`.
-// This should usually be set to the systems global tmp folder.
-//
-// The `tmp_dir` must point to an existing writable directory. The path should end with a
-// trailing `/`.
-//
-// If creating the FIFO at both of these locations, an exception is thrown.
+// If creating the FIFO at this location fails, an exception is thrown.
 // If a FIFO already exists at the given location, this method does nothing.
 void create_fifo(std::string path); // throws
 

--- a/src/realm/util/fifo_helper.hpp
+++ b/src/realm/util/fifo_helper.hpp
@@ -1,0 +1,42 @@
+/*************************************************************************
+ *
+ * Copyright 2019 Realm Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ **************************************************************************/
+
+#ifndef REALM_UTIL_FIFO_HELPER_HPP
+#define REALM_UTIL_FIFO_HELPER_HPP
+
+#include <string>
+
+namespace realm {
+namespace util {
+
+// Attempts to create a FIFO file at the location determined by `path`.
+// If the filesystem does not allow FIFO's at this location the path is hashed
+// and used as the file name for the FIFO which is then created in `tmp_path`.
+// This should usually be set to the systems global tmp folder.
+//
+// The `tmp_dir` must point to an existing writable directory. The path should end with a
+// trailing `/`.
+//
+// If creating the FIFO at both of these locations, an exception is thrown.
+// If a FIFO already exists at the given location, this method does nothing.
+void create_fifo(std::string path, const std::string tmp_dir); // throws
+
+} // namespace util
+} // namespace realm
+
+#endif // REALM_UTIL_FIFO_HELPER_HPP

--- a/src/realm/util/fifo_helper.hpp
+++ b/src/realm/util/fifo_helper.hpp
@@ -34,10 +34,15 @@ namespace util {
 //
 // If creating the FIFO at both of these locations, an exception is thrown.
 // If a FIFO already exists at the given location, this method does nothing.
-void create_fifo(std::string path, const std::string tmp_dir); // throws
+void create_fifo(std::string path); // throws
 
 // Same as above, but returns `false` if the FIFO could not be created instead of throwing.
 bool try_create_fifo(const std::string& path);
+
+// Ensure that a path representing a directory ends with `/`
+inline std::string normalize_dir(const std::string& path) {
+    return (!path.empty() && path.back() != '/') ? path + '/' : path;
+}
 
 } // namespace util
 } // namespace realm

--- a/src/realm/util/interprocess_condvar.cpp
+++ b/src/realm/util/interprocess_condvar.cpp
@@ -17,6 +17,7 @@
  **************************************************************************/
 
 #include <realm/util/interprocess_condvar.hpp>
+#include <realm/util/fifo_helper.hpp>
 
 #include <fcntl.h>
 #include <system_error>
@@ -150,40 +151,7 @@ void InterprocessCondVar::set_shared_part(SharedPart& shared_part, std::string b
 
 #if !REALM_TVOS
     m_resource_path = base_path + "." + condvar_name + ".cv";
-
-    // Create and open the named pipe
-    int ret = mkfifo(m_resource_path.c_str(), 0600);
-    if (ret == -1) {
-        int err = errno;
-        if (err == ENOTSUP || err == EACCES || err == EPERM || err == EINVAL) {
-            // Filesystem doesn't support named pipes, so try putting it in tmp instead
-            // Hash collisions are okay here because they just result in doing
-            // extra work, as opposed to correctness problems
-            std::ostringstream ss;
-            ss << tmp_path;
-            ss << "realm_" << std::hash<std::string>()(m_resource_path) << ".cv";
-            m_resource_path = ss.str();
-            ret = mkfifo(m_resource_path.c_str(), 0600);
-            err = errno;
-        }
-
-        // the fifo already existing isn't an error
-        if (ret == -1 && err != EEXIST) {
-            // Workaround for a mkfifo bug on Blackberry devices:
-            // When the fifo already exists, mkfifo fails with error ENOSYS which is not correct.
-            // In this case, we use stat to check if the path exists and it is a fifo.
-            struct stat stat_buf;
-            if (stat(m_resource_path.c_str(), &stat_buf) == 0) {
-                if ((stat_buf.st_mode & S_IFMT) != S_IFIFO) {
-                    throw std::runtime_error(m_resource_path + " exists and it is not a fifo.");
-                }
-            }
-            else {
-                throw std::system_error(err, std::system_category());
-            }
-        }
-    }
-
+    create_fifo(m_resource_path, tmp_path); // throws
     m_fd_read = open(m_resource_path.c_str(), O_RDWR);
     if (m_fd_read == -1) {
         throw std::system_error(errno, std::system_category());


### PR DESCRIPTION
An attempt at fixing https://github.com/realm/realm-java/issues/5715

Object Store needs to be modified to use the same logic which is why it is moved to a separate header file.

Draft PR until I can verify this actually seems to work on Android (which is tricky).

TODO
- [x] Update changelog
- [x] Set mode to the correct value (probably 0x666)
- [x] Test change. It will be impossible to add a unit test that verifies the bug on Huawei devices are actually fixed.