### PR TITLE
Clear cached history object in commit_and_continue_as_read

### DIFF
--- a/src/realm/db.cpp
+++ b/src/realm/db.cpp
@@ -2038,6 +2038,7 @@ DB::version_type Transaction::commit_and_continue_as_read()
     // Remap file if it has grown, and update refs in underlying node structure
     remap_and_update_refs(m_read_lock.m_top_ref, m_read_lock.m_file_size, false); // Throws
 
+    m_history = nullptr;
     set_transact_stage(DB::transact_Reading);
 
     return version;

--- a/src/realm/list.hpp
+++ b/src/realm/list.hpp
@@ -575,11 +575,13 @@ public:
         ensure_created();
         update_if_needed();
         ensure_writeable();
-        if (Replication* repl = this->m_const_obj->get_replication()) {
-            ConstLstBase::clear_repl(repl);
+        if (size() > 0) {
+            if (Replication* repl = this->m_const_obj->get_replication()) {
+                ConstLstBase::clear_repl(repl);
+            }
+            m_tree->clear();
+            m_obj.bump_content_version();
         }
-        m_tree->clear();
-        m_obj.bump_content_version();
     }
 
 protected:

--- a/src/realm/obj.cpp
+++ b/src/realm/obj.cpp
@@ -605,6 +605,13 @@ void ConstObj::to_json(std::ostream& out, size_t link_depth, std::map<std::strin
     out << "}";
 }
 
+std::string ConstObj::to_string() const
+{
+    std::ostringstream ostr;
+    to_json(ostr, 0, nullptr);
+    return ostr.str();
+}
+
 /*********************************** Obj *************************************/
 
 bool Obj::ensure_writeable()

--- a/src/realm/obj.hpp
+++ b/src/realm/obj.hpp
@@ -160,6 +160,8 @@ public:
         to_json(out, link_depth, *renames, followed);
     }
 
+    std::string to_string() const;
+
 protected:
     friend class ColumnListBase;
     friend class ConstLstBase;


### PR DESCRIPTION
Otherwise we can continue to use the single write history
object although we are in a read transaction.