### PR TITLE
Fix C++17 run-time error in realm

### DIFF
--- a/src/realm/query_conditions.hpp
+++ b/src/realm/query_conditions.hpp
@@ -282,11 +282,7 @@ struct NotEqual {
     }
 
     template <class A, class B, class C, class D>
-    bool operator()(A, B, C, D) const
-    {
-        REALM_ASSERT(false);
-        return false;
-    }
+    bool operator()(A, B, C, D) const = delete;
 
     static std::string description()
     {

--- a/src/realm/query_engine.cpp
+++ b/src/realm/query_engine.cpp
@@ -494,7 +494,7 @@ size_t StringNode<EqualIns>::_find_first_local(size_t start, size_t end)
     for (size_t s = start; s < end; ++s) {
         StringData t = get_string(s);
 
-        if (cond(StringData(m_value), m_ucase.c_str(), m_lcase.cstr(), t))
+        if (cond(StringData(m_value), m_ucase.c_str(), m_lcase.c_str(), t))
             return s;
     }
 

--- a/src/realm/query_engine.cpp
+++ b/src/realm/query_engine.cpp
@@ -494,7 +494,7 @@ size_t StringNode<EqualIns>::_find_first_local(size_t start, size_t end)
     for (size_t s = start; s < end; ++s) {
         StringData t = get_string(s);
 
-        if (cond(StringData(m_value), m_ucase.data(), m_lcase.data(), t))
+        if (cond(StringData(m_value), m_ucase.c_str(), m_lcase.cstr(), t))
             return s;
     }
 

--- a/src/realm/query_engine.hpp
+++ b/src/realm/query_engine.hpp
@@ -1500,7 +1500,7 @@ public:
         for (size_t s = start; s < end; ++s) {
             StringData t = get_string(s);
             
-            if (cond(StringData(m_value), m_ucase.data(), m_lcase.data(), t))
+            if (cond(StringData(m_value), m_ucase.c_str(), m_lcase.c_str(), t))
                 return s;
         }
         return not_found;
@@ -1650,7 +1650,7 @@ public:
             if (!bool(m_value)) {
                 return s;
             }
-            if (cond(StringData(m_value), m_ucase.data(), m_lcase.data(), m_charmap, t))
+            if (cond(StringData(m_value), m_ucase.c_str(), m_lcase.c_str(), m_charmap, t))
                 return s;
         }
         return not_found;


### PR DESCRIPTION
std::string::data can now return char* instead of const char*. This
caused template argument matching that expected const char* to fail.
Solution: Use c_str() at the call site to force const char*.

Also, fixed it so that the error would be compile-time instead of
run-time.