### PR TITLE
Optimize timestamp queries: ==, !=, !NULL

### DIFF
--- a/src/realm/array.hpp
+++ b/src/realm/array.hpp
@@ -2219,19 +2219,38 @@ bool Array::find_optimized(int64_t value, size_t start, size_t end, size_t basei
         end = nullable_array ? size() - 1 : size();
 
     if (nullable_array) {
-        // We were called by find() of a nullable array. So skip first entry, take nulls in count, etc, etc. Fixme:
-        // Huge speed optimizations are possible here! This is a very simple generic method.
-        auto null_value = get(0);
-        for (; start2 < end; start2++) {
-            int64_t v = get<bitwidth>(start2 + 1);
-            bool value_is_null = (v == null_value);
-            if (c(v, value, value_is_null, find_null)) {
-                util::Optional<int64_t> v2(value_is_null ? util::none : util::make_optional(v));
-                if (!find_action<action, Callback>(start2 + baseindex, v2, state, callback))
-                    return false; // tell caller to stop aggregating/search
+        if (std::is_same<cond, Equal>::value) {
+            // In case of Equal it is safe to use the optimized logic. We just have to fetch the null value
+            // if this is what we are looking for. And we have to adjust the indexes to compensate for the
+            // null value at position 0.
+            if (find_null) {
+                value = get(0);
             }
+            else {
+                // If the value to search for is equal to the null value, the value cannot be in the array
+                if (value == get(0)) {
+                    return true;
+                }
+            }
+            start2++;
+            end++;
+            baseindex--;
         }
-        return true; // tell caller to continue aggregating/search (on next array leafs)
+        else {
+            // We were called by find() of a nullable array. So skip first entry, take nulls in count, etc, etc. Fixme:
+            // Huge speed optimizations are possible here! This is a very simple generic method.
+            auto null_value = get(0);
+            for (; start2 < end; start2++) {
+                int64_t v = get<bitwidth>(start2 + 1);
+                bool value_is_null = (v == null_value);
+                if (c(v, value, value_is_null, find_null)) {
+                    util::Optional<int64_t> v2(value_is_null ? util::none : util::make_optional(v));
+                    if (!find_action<action, Callback>(start2 + baseindex, v2, state, callback))
+                        return false; // tell caller to stop aggregating/search
+                }
+            }
+            return true; // tell caller to continue aggregating/search (on next array leafs)
+        }
     }
 
 

--- a/src/realm/array.hpp
+++ b/src/realm/array.hpp
@@ -2221,10 +2221,12 @@ bool Array::find_optimized(int64_t value, size_t start, size_t end, size_t basei
     if (nullable_array) {
         // We were called by find() of a nullable array. So skip first entry, take nulls in count, etc, etc. Fixme:
         // Huge speed optimizations are possible here! This is a very simple generic method.
+        auto null_value = get(0);
         for (; start2 < end; start2++) {
             int64_t v = get<bitwidth>(start2 + 1);
-            if (c(v, value, v == get(0), find_null)) {
-                util::Optional<int64_t> v2(v == get(0) ? util::none : util::make_optional(v));
+            bool value_is_null = (v == null_value);
+            if (c(v, value, value_is_null, find_null)) {
+                util::Optional<int64_t> v2(value_is_null ? util::none : util::make_optional(v));
                 if (!find_action<action, Callback>(start2 + baseindex, v2, state, callback))
                     return false; // tell caller to stop aggregating/search
             }

--- a/src/realm/query_engine.cpp
+++ b/src/realm/query_engine.cpp
@@ -759,9 +759,6 @@ size_t TimestampNode<GreaterEqual>::find_first_local(size_t start, size_t end)
 {
     REALM_ASSERT(this->m_table);
 
-    if (this->m_value.is_null()) {
-        return not_found;
-    }
     while (start < end) {
         size_t ret = this->find_first_local_seconds<GreaterEqual>(start, end);
 
@@ -770,6 +767,9 @@ size_t TimestampNode<GreaterEqual>::find_first_local(size_t start, size_t end)
 
         util::Optional<int64_t> seconds = get_seconds_and_cache(ret);
         if (!seconds) { // null equality
+            if (this->m_value.is_null()) {
+                return ret;
+            }
             start = ret + 1;
             continue;
         }
@@ -793,9 +793,6 @@ size_t TimestampNode<LessEqual>::find_first_local(size_t start, size_t end)
 {
     REALM_ASSERT(this->m_table);
 
-    if (this->m_value.is_null()) {
-        return not_found;
-    }
     while (start < end) {
         size_t ret = this->find_first_local_seconds<LessEqual>(start, end);
 
@@ -804,6 +801,9 @@ size_t TimestampNode<LessEqual>::find_first_local(size_t start, size_t end)
 
         util::Optional<int64_t> seconds = get_seconds_and_cache(ret);
         if (!seconds) { // null equality
+            if (this->m_value.is_null()) {
+                return ret;
+            }
             start = ret + 1;
             continue;
         }
@@ -857,17 +857,6 @@ size_t TimestampNode<NotEqual>::find_first_local(size_t start, size_t end)
 {
     REALM_ASSERT(this->m_table);
 
-    // in many scenarios it is likely that the first item is not equal do a quick first check
-    if (start < end) {
-        util::Optional<int64_t> seconds = get_seconds_and_cache(start);
-        if (seconds != m_needle_seconds
-            || (seconds && this->get_nanoseconds_and_cache(start) != m_value.get_nanoseconds())) {
-            return start;
-        }
-    }
-
-    ++start;
-
     if (m_value.is_null()) {
         if (REALM_UNLIKELY(!m_condition_column_is_nullable)) {
             return not_found;
@@ -878,14 +867,17 @@ size_t TimestampNode<NotEqual>::find_first_local(size_t start, size_t end)
     int64_t needle_seconds = m_value.get_seconds();
     while (start < end) {
         util::Optional<int64_t> seconds = get_seconds_and_cache(start);
-        if (!seconds || *seconds != needle_seconds) {
-            return start;
-        }
-        // We now know that neither m_value nor current value is null and that seconds part equals
-        // We are just missing to compare nanoseconds part
-        int32_t nanos = this->get_nanoseconds_and_cache(start);
-        if (nanos != m_value.get_nanoseconds()) {
-            return start;
+        // Null value does not match
+        if (seconds) {
+            if (*seconds != needle_seconds) {
+                return start;
+            }
+            // We now know that neither m_value nor current value is null and that seconds part equals
+            // We are just missing to compare nanoseconds part
+            int32_t nanos = this->get_nanoseconds_and_cache(start);
+            if (nanos != m_value.get_nanoseconds()) {
+                return start;
+            }
         }
         ++start;
     }

--- a/test/test_query.cpp
+++ b/test/test_query.cpp
@@ -10622,7 +10622,7 @@ TEST(Query_Timestamp)
     CHECK_EQUAL(match, 1);
 
     match = (first != Timestamp(0, 0)).count();
-    CHECK_EQUAL(match, 5);
+    CHECK_EQUAL(match, 4); // Null values does not 'not match'
 
     match = (first < Timestamp(-100, 0)).find();
     CHECK_EQUAL(match, 5);
@@ -10703,6 +10703,8 @@ TEST(Query_TimestampCount)
     CHECK_EQUAL((timestamps >= Timestamp(0, 3)).count(), 6);
     CHECK_EQUAL((timestamps < Timestamp(1, 3)).count(), 6);
     CHECK_EQUAL((timestamps <= Timestamp(1, 3)).count(), 7);
+    CHECK_EQUAL((timestamps == Timestamp(0, 2)).count(), 1);
+    CHECK_EQUAL((timestamps != Timestamp(0, 2)).count(), 8);
     CHECK_EQUAL((timestamps == Timestamp()).count(), 1);
     CHECK_EQUAL((timestamps != Timestamp()).count(), 9);
 }


### PR DESCRIPTION
Add TimestampNode specializations for: Equal, NotEqual, NotNull.

Here's the timestamp benchmarks for the naïve generic search: 
```
QueryTimestampGreater (MemOnly, EncryptionOff):     min  23.37ms (-50.62%)           max  25.34ms (-57.52%)           med  24.10ms (-56.46%)           avg  24.05ms (-55.09%)           stddev   588us (-86.42%)
QueryTimestampGreater (MemOnly, EncryptionOn):      min  23.34ms (-51.32%)           max  24.95ms (-64.54%)           med  23.79ms (-57.59%)           avg  23.81ms (-57.64%)           stddev   522us (-92.59%)
QueryTimestampGreater (Full   , EncryptionOff):     min  23.38ms (-50.77%)           max     25ms (-58.04%)           med  23.91ms (-56.68%)           avg  23.86ms (-54.99%)           stddev   517us (-88.96%)
QueryTimestampGreater (Full   , EncryptionOn):      min  23.40ms (-50.35%)           max  24.31ms (-59.61%)           med  23.52ms (-56.52%)           avg  23.59ms (-55.92%)           stddev   282us (-93.13%)

QueryTimestampGreaterEqual (MemOnly, EncryptionOff):   min  23.32ms     max  23.81ms     median  23.63ms     avg  23.55ms     stddev    176us
QueryTimestampGreaterEqual (MemOnly, EncryptionOn):    min  23.25ms     max  24.65ms     median  23.58ms     avg  23.63ms     stddev    414us
QueryTimestampGreaterEqual (Full   , EncryptionOff):   min  23.15ms     max  23.59ms     median  23.35ms     avg  23.33ms     stddev    115us
QueryTimestampGreaterEqual (Full   , EncryptionOn):    min  23.27ms     max  23.89ms     median  23.38ms     avg  23.41ms     stddev    187us

QueryTimestampLess (MemOnly, EncryptionOff):           min  23.29ms     max  23.74ms     median  23.40ms     avg  23.45ms     stddev    162us
QueryTimestampLess (MemOnly, EncryptionOn):            min  23.50ms     max  24.61ms     median  23.89ms     avg  23.89ms     stddev    334us
QueryTimestampLess (Full   , EncryptionOff):           min  23.38ms     max  25.02ms     median  24.61ms     avg  24.22ms     stddev    671us
QueryTimestampLess (Full   , EncryptionOn):            min  23.50ms     max  24.21ms     median  23.68ms     avg  23.71ms     stddev    207us

QueryTimestampLessEqual (MemOnly, EncryptionOff):      min  23.30ms     max  23.52ms     median  23.37ms     avg  23.38ms     stddev     84us
QueryTimestampLessEqual (MemOnly, EncryptionOn):       min  23.24ms     max  24.01ms     median  23.54ms     avg  23.50ms     stddev    253us
QueryTimestampLessEqual (Full   , EncryptionOff):      min  23.09ms     max  26.57ms     median  23.43ms     avg  24.04ms     stddev   1.31ms
QueryTimestampLessEqual (Full   , EncryptionOn):       min  23.47ms     max  24.22ms     median  24.08ms     avg  23.95ms     stddev    260us

QueryTimestampEqual (MemOnly, EncryptionOff):          min  18.65ms     max  19.37ms     median  18.75ms     avg  18.80ms     stddev    212us
QueryTimestampEqual (MemOnly, EncryptionOn):           min  18.71ms     max  19.80ms     median  19.08ms     avg  19.04ms     stddev    360us
QueryTimestampEqual (Full   , EncryptionOff):          min  18.92ms     max  19.52ms     median  19.24ms     avg  19.18ms     stddev    223us
QueryTimestampEqual (Full   , EncryptionOn):           min  18.66ms     max  19.19ms     median  18.81ms     avg  18.82ms     stddev    170us

QueryTimestampNotEqual (MemOnly, EncryptionOff):       min  38.87ms     max  40.61ms     median  39.43ms     avg  39.41ms     stddev    560us
QueryTimestampNotEqual (MemOnly, EncryptionOn):        min  38.65ms     max  40.54ms     median  39.53ms     avg  39.50ms     stddev    581us
QueryTimestampNotEqual (Full   , EncryptionOff):       min  39.06ms     max  72.66ms     median  44.69ms     avg  47.36ms     stddev  11.43ms
QueryTimestampNotEqual (Full   , EncryptionOn):        min  38.35ms     max  42.08ms     median  39.75ms     avg  39.65ms     stddev   1.19ms

QueryTimestampNotNull (MemOnly, EncryptionOff):        min  24.29ms     max  25.24ms     median  24.73ms     avg  24.67ms     stddev    281us
QueryTimestampNotNull (MemOnly, EncryptionOn):         min  24.28ms     max  24.78ms     median  24.52ms     avg  24.49ms     stddev    153us
QueryTimestampNotNull (Full   , EncryptionOff):        min  24.19ms     max  25.64ms     median  24.77ms     avg  24.77ms     stddev    461us
QueryTimestampNotNull (Full   , EncryptionOn):         min  24.27ms     max  24.68ms     median  24.47ms     avg  24.46ms     stddev    128us

QueryTimestampEqualNull (MemOnly, EncryptionOff):      min  21.10ms     max  22.17ms     median  21.48ms     avg  21.49ms     stddev    369us
QueryTimestampEqualNull (MemOnly, EncryptionOn):       min  21.08ms     max  22.87ms     median  21.33ms     avg  21.53ms     stddev    606us
QueryTimestampEqualNull (Full   , EncryptionOff):      min     21ms     max  21.47ms     median  21.08ms     avg  21.11ms     stddev    151us
QueryTimestampEqualNull (Full   , EncryptionOn):       min  21.07ms     max  23.57ms     median  21.30ms     avg  21.48ms     stddev    755us
```

And here's the timestamp benchmarks for this branch: 
```
QueryTimestampGreater (MemOnly, EncryptionOff):     min   7.06ms (-85.09%)           max   7.31ms (-87.74%)           med   7.17ms (-87.04%)           avg   7.17ms (-86.62%)           stddev    87us (-98.00%)
QueryTimestampGreater (MemOnly, EncryptionOn):      min   7.06ms (-85.28%)           max   7.23ms (-89.72%)           med   7.13ms (-87.28%)           avg   7.13ms (-87.32%)           stddev    61us (-99.14%)
QueryTimestampGreater (Full   , EncryptionOff):     min   7.05ms (-85.15%)           max   7.31ms (-87.73%)           med   7.12ms (-87.10%)           avg   7.13ms (-86.55%)           stddev    72us (-98.45%)
QueryTimestampGreater (Full   , EncryptionOn):      min   7.10ms (-84.95%)           max   7.37ms (-87.76%)           med   7.19ms (-86.70%)           avg   7.19ms (-86.56%)           stddev    94us (-97.70%)

QueryTimestampGreaterEqual (MemOnly, EncryptionOff):   min   7.20ms     max   7.69ms     median   7.31ms     avg   7.38ms     stddev    155us
QueryTimestampGreaterEqual (MemOnly, EncryptionOn):    min   7.20ms     max   7.36ms     median   7.28ms     avg   7.27ms     stddev     49us
QueryTimestampGreaterEqual (Full   , EncryptionOff):   min   7.20ms     max   7.92ms     median   7.28ms     avg   7.33ms     stddev    191us
QueryTimestampGreaterEqual (Full   , EncryptionOn):    min   7.81ms     max  23.72ms     median  10.88ms     avg  12.02ms     stddev   4.66ms

QueryTimestampLess (MemOnly, EncryptionOff):           min   6.54ms     max   7.68ms     median   6.75ms     avg   6.82ms     stddev    350us
QueryTimestampLess (MemOnly, EncryptionOn):            min   6.54ms     max   7.25ms     median   6.78ms     avg   6.78ms     stddev    186us
QueryTimestampLess (Full   , EncryptionOff):           min   6.58ms     max   8.57ms     median   7.54ms     avg   7.49ms     stddev    508us
QueryTimestampLess (Full   , EncryptionOn):            min   6.55ms     max   7.44ms     median   6.67ms     avg   6.70ms     stddev    240us

QueryTimestampLessEqual (MemOnly, EncryptionOff):      min   6.72ms     max   7.23ms     median   6.90ms     avg   6.91ms     stddev    123us
QueryTimestampLessEqual (MemOnly, EncryptionOn):       min   6.99ms     max   8.63ms     median   7.79ms     avg   7.72ms     stddev    578us
QueryTimestampLessEqual (Full   , EncryptionOff):      min   6.69ms     max   8.42ms     median   6.83ms     avg   7.01ms     stddev    526us
QueryTimestampLessEqual (Full   , EncryptionOn):       min   6.72ms     max   7.07ms     median   6.78ms     avg   6.82ms     stddev    108us

QueryTimestampEqual (MemOnly, EncryptionOff):          min   1.08ms     max   1.54ms     median   1.10ms     avg   1.12ms     stddev     71us
QueryTimestampEqual (MemOnly, EncryptionOn):           min   1.10ms     max   1.28ms     median   1.10ms     avg   1.11ms     stddev     30us
QueryTimestampEqual (Full   , EncryptionOff):          min   1.08ms     max   1.30ms     median   1.10ms     avg   1.11ms     stddev     39us
QueryTimestampEqual (Full   , EncryptionOn):           min   1.10ms     max   1.84ms     median   1.11ms     avg   1.15ms     stddev    110us

QueryTimestampNotEqual (MemOnly, EncryptionOff):       min  25.91ms     max  31.94ms     median  26.37ms     avg  27.03ms     stddev   1.89ms
QueryTimestampNotEqual (MemOnly, EncryptionOn):        min  25.75ms     max  28.38ms     median  26.68ms     avg  26.57ms     stddev    885us
QueryTimestampNotEqual (Full   , EncryptionOff):       min  25.94ms     max  27.66ms     median  26.72ms     avg  26.70ms     stddev    551us
QueryTimestampNotEqual (Full   , EncryptionOn):        min  25.54ms     max  26.70ms     median     26ms     avg  25.96ms     stddev    363us

QueryTimestampNotNull (MemOnly, EncryptionOff):        min  12.58ms     max  13.13ms     median  12.73ms     avg  12.76ms     stddev    172us
QueryTimestampNotNull (MemOnly, EncryptionOn):         min  12.74ms     max  13.64ms     median  13.10ms     avg  13.14ms     stddev    310us
QueryTimestampNotNull (Full   , EncryptionOff):        min  12.71ms     max  14.40ms     median  13.60ms     avg  13.38ms     stddev    584us
QueryTimestampNotNull (Full   , EncryptionOn):         min  12.75ms     max  13.73ms     median  13.38ms     avg  13.26ms     stddev    333us

QueryTimestampEqualNull (MemOnly, EncryptionOff):      min   3.66ms     max   4.07ms     median   3.75ms     avg   3.79ms     stddev    126us
QueryTimestampEqualNull (MemOnly, EncryptionOn):       min   3.66ms     max   3.91ms     median   3.68ms     avg   3.71ms     stddev     63us
QueryTimestampEqualNull (Full   , EncryptionOff):      min   3.65ms     max   3.78ms     median   3.68ms     avg   3.69ms     stddev     36us
QueryTimestampEqualNull (Full   , EncryptionOn):       min   3.67ms     max   3.86ms     median   3.72ms     avg   3.73ms     stddev     60us
```
