### PR TITLE
Changed metrics timers to report in nanoseconds

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,7 @@
 -----------
 
 ### Internals
-* None.
+* Changed the metrics timers to more precisely report in nanoseconds, instead of seconds. ([#3359](https://github.com/realm/realm-core/issues/3359))
 
 ----------------------------------------------
 

--- a/src/realm/metrics/metric_timer.cpp
+++ b/src/realm/metrics/metric_timer.cpp
@@ -93,7 +93,7 @@ int64_t round_to_int64(double x)
 void MetricTimer::format(nanosecond_storage_t nanoseconds, std::ostream& out)
 {
     constexpr int64_t ns_per_second = 1'000'000'000;
-    int64_t rounded_minutes = round_to_int64(nanoseconds / (60 * ns_per_second));
+    int64_t rounded_minutes = round_to_int64(nanoseconds / (60.0 * ns_per_second));
     if (rounded_minutes > 60) {
         // 1h0m -> inf
         int64_t hours = rounded_minutes / 60;
@@ -101,7 +101,7 @@ void MetricTimer::format(nanosecond_storage_t nanoseconds, std::ostream& out)
         out << hours << "h" << minutes << "m";
     }
     else {
-        int64_t rounded_seconds = round_to_int64(nanoseconds / ns_per_second);
+        int64_t rounded_seconds = round_to_int64(nanoseconds / double(ns_per_second));
         if (rounded_seconds > 60) {
             // 1m0s -> 59m59s
             int64_t minutes = rounded_seconds / 60;
@@ -109,7 +109,7 @@ void MetricTimer::format(nanosecond_storage_t nanoseconds, std::ostream& out)
             out << minutes << "m" << seconds << "s";
         }
         else {
-            int64_t rounded_centies = round_to_int64(nanoseconds / 10'000'000);
+            int64_t rounded_centies = round_to_int64(nanoseconds / double(10'000'000));
             if (rounded_centies > 100) {
                 // 1s -> 59.99s
                 int64_t seconds = rounded_centies / 100;
@@ -121,7 +121,7 @@ void MetricTimer::format(nanosecond_storage_t nanoseconds, std::ostream& out)
                 out << 's';
             }
             else {
-                int64_t rounded_centi_ms = round_to_int64(nanoseconds / 10'000);
+                int64_t rounded_centi_ms = round_to_int64(nanoseconds / double(10'000));
                 if (rounded_centi_ms > 100) {
                     // 0.1ms -> 999.99ms
                     int64_t ms = rounded_centi_ms / 100;
@@ -134,7 +134,7 @@ void MetricTimer::format(nanosecond_storage_t nanoseconds, std::ostream& out)
                 }
                 else {
                     // 0 -> 999µs
-                    int64_t us = round_to_int64(nanoseconds / 1'000);
+                    int64_t us = round_to_int64(nanoseconds / double(1'000));
                     out << us << "us";
                 }
             }

--- a/src/realm/metrics/metric_timer.cpp
+++ b/src/realm/metrics/metric_timer.cpp
@@ -28,7 +28,7 @@ using namespace realm::metrics;
 
 
 MetricTimerResult::MetricTimerResult()
-    : m_elapsed_seconds(0)
+    : m_elapsed_nanoseconds(0)
 {
 }
 
@@ -36,14 +36,14 @@ MetricTimerResult::~MetricTimerResult()
 {
 }
 
-double MetricTimerResult::get_elapsed_seconds() const
+nanosecond_storage_t MetricTimerResult::get_elapsed_nanoseconds() const
 {
-    return m_elapsed_seconds;
+    return m_elapsed_nanoseconds;
 }
 
-void MetricTimerResult::report_seconds(double time)
+void MetricTimerResult::report_nanoseconds(nanosecond_storage_t time)
 {
-    m_elapsed_seconds = time;
+    m_elapsed_nanoseconds = time;
 }
 
 
@@ -56,7 +56,7 @@ MetricTimer::MetricTimer(std::shared_ptr<MetricTimerResult> destination)
 MetricTimer::~MetricTimer()
 {
     if (m_dest) {
-        m_dest->report_seconds(get_elapsed_time());
+        m_dest->report_nanoseconds(get_elapsed_nanoseconds());
     }
 }
 
@@ -65,16 +65,16 @@ MetricTimer::time_point MetricTimer::get_timer_ticks() const
     return clock_type::now();
 }
 
-double MetricTimer::calc_elapsed_seconds(MetricTimer::time_point begin, MetricTimer::time_point end) const
+nanosecond_storage_t MetricTimer::calc_elapsed_nanoseconds(MetricTimer::time_point begin, MetricTimer::time_point end) const
 {
-    std::chrono::duration<double> elapsed = end - begin;
+    std::chrono::duration<nanosecond_storage_t, std::nano> elapsed = end - begin;
     return elapsed.count();
 }
 
-std::string MetricTimer::format(double seconds)
+std::string MetricTimer::format(nanosecond_storage_t nanoseconds)
 {
     std::ostringstream out;
-    format(seconds, out);
+    format(nanoseconds, out);
     return out.str();
 }
 
@@ -90,9 +90,10 @@ int64_t round_to_int64(double x)
 } // end anonymous namespace
 
 // see also test/util/Timer.cpp
-void MetricTimer::format(double seconds_float, std::ostream& out)
+void MetricTimer::format(nanosecond_storage_t nanoseconds, std::ostream& out)
 {
-    int64_t rounded_minutes = round_to_int64(seconds_float / 60);
+    constexpr int64_t ns_per_second = 1'000'000'000;
+    int64_t rounded_minutes = round_to_int64(nanoseconds / (60 * ns_per_second));
     if (rounded_minutes > 60) {
         // 1h0m -> inf
         int64_t hours = rounded_minutes / 60;
@@ -100,7 +101,7 @@ void MetricTimer::format(double seconds_float, std::ostream& out)
         out << hours << "h" << minutes << "m";
     }
     else {
-        int64_t rounded_seconds = round_to_int64(seconds_float);
+        int64_t rounded_seconds = round_to_int64(nanoseconds / ns_per_second);
         if (rounded_seconds > 60) {
             // 1m0s -> 59m59s
             int64_t minutes = rounded_seconds / 60;
@@ -108,7 +109,7 @@ void MetricTimer::format(double seconds_float, std::ostream& out)
             out << minutes << "m" << seconds << "s";
         }
         else {
-            int64_t rounded_centies = round_to_int64(seconds_float * 100);
+            int64_t rounded_centies = round_to_int64(nanoseconds / 10'000'000);
             if (rounded_centies > 100) {
                 // 1s -> 59.99s
                 int64_t seconds = rounded_centies / 100;
@@ -120,7 +121,7 @@ void MetricTimer::format(double seconds_float, std::ostream& out)
                 out << 's';
             }
             else {
-                int64_t rounded_centi_ms = round_to_int64(seconds_float * 100000);
+                int64_t rounded_centi_ms = round_to_int64(nanoseconds / 10'000);
                 if (rounded_centi_ms > 100) {
                     // 0.1ms -> 999.99ms
                     int64_t ms = rounded_centi_ms / 100;
@@ -133,7 +134,7 @@ void MetricTimer::format(double seconds_float, std::ostream& out)
                 }
                 else {
                     // 0 -> 999µs
-                    int64_t us = round_to_int64(seconds_float * 1000000);
+                    int64_t us = round_to_int64(nanoseconds / 1'000);
                     out << us << "us";
                 }
             }

--- a/src/realm/metrics/metric_timer.hpp
+++ b/src/realm/metrics/metric_timer.hpp
@@ -28,16 +28,17 @@
 namespace realm {
 namespace metrics {
 
+using nanosecond_storage_t = int64_t;
 
 class MetricTimerResult
 {
 public:
     MetricTimerResult();
     ~MetricTimerResult();
-    double get_elapsed_seconds() const;
-    void report_seconds(double time);
+    nanosecond_storage_t get_elapsed_nanoseconds() const;
+    void report_nanoseconds(nanosecond_storage_t time);
 protected:
-    double m_elapsed_seconds;
+    nanosecond_storage_t m_elapsed_nanoseconds;
 };
 
 
@@ -48,16 +49,16 @@ public:
 
     void reset();
 
-    /// Returns elapsed time in seconds since last call to reset().
-    double get_elapsed_time() const;
+    /// Returns elapsed time in nanoseconds since last call to reset().
+    nanosecond_storage_t get_elapsed_nanoseconds() const;
     /// Same as get_elapsed_time().
-    operator double() const;
+    operator nanosecond_storage_t() const;
 
     /// Format the elapsed time on the form 0h00m, 00m00s, 00.00s, or
     /// 000.0ms depending on magnitude.
-    static void format(double seconds, std::ostream&);
+    static void format(nanosecond_storage_t nanoseconds, std::ostream&);
 
-    static std::string format(double seconds);
+    static std::string format(nanosecond_storage_t nanoseconds);
 
 private:
     using clock_type = std::chrono::high_resolution_clock;
@@ -67,7 +68,7 @@ private:
     std::shared_ptr<MetricTimerResult> m_dest;
 
     time_point get_timer_ticks() const;
-    double calc_elapsed_seconds(time_point begin, time_point end) const;
+    nanosecond_storage_t calc_elapsed_nanoseconds(time_point begin, time_point end) const;
 };
 
 
@@ -76,14 +77,14 @@ inline void MetricTimer::reset()
     m_start = get_timer_ticks();
 }
 
-inline double MetricTimer::get_elapsed_time() const
+inline nanosecond_storage_t MetricTimer::get_elapsed_nanoseconds() const
 {
-    return calc_elapsed_seconds(m_start, get_timer_ticks());
+    return calc_elapsed_nanoseconds(m_start, get_timer_ticks());
 }
 
-inline MetricTimer::operator double() const
+inline MetricTimer::operator nanosecond_storage_t() const
 {
-    return get_elapsed_time();
+    return get_elapsed_nanoseconds();
 }
 
 inline std::ostream& operator<<(std::ostream& out, const MetricTimer& timer)

--- a/src/realm/metrics/query_info.cpp
+++ b/src/realm/metrics/query_info.cpp
@@ -64,10 +64,10 @@ QueryInfo::QueryType QueryInfo::get_type() const
     return m_type;
 }
 
-double QueryInfo::get_query_time() const
+nanosecond_storage_t QueryInfo::get_query_time_nanoseconds() const
 {
     if (m_query_time) {
-        return m_query_time->get_elapsed_seconds();
+        return m_query_time->get_elapsed_nanoseconds();
     }
     return 0;
 }

--- a/src/realm/metrics/query_info.hpp
+++ b/src/realm/metrics/query_info.hpp
@@ -53,7 +53,7 @@ public:
     std::string get_description() const;
     std::string get_table_name() const;
     QueryType get_type() const;
-    double get_query_time() const;
+    nanosecond_storage_t get_query_time_nanoseconds() const;
 
     static std::unique_ptr<MetricTimer> track(const Query* query, QueryType type);
     static QueryType type_from_action(Action action);

--- a/src/realm/metrics/transaction_info.cpp
+++ b/src/realm/metrics/transaction_info.cpp
@@ -46,23 +46,23 @@ TransactionInfo::TransactionType TransactionInfo::get_transaction_type() const
     return m_type;
 }
 
-double TransactionInfo::get_transaction_time() const
+nanosecond_storage_t TransactionInfo::get_transaction_time_nanoseconds() const
 {
-    return m_transaction_time.get_elapsed_seconds();
+    return m_transaction_time.get_elapsed_nanoseconds();
 }
 
-double TransactionInfo::get_fsync_time() const
+nanosecond_storage_t TransactionInfo::get_fsync_time_nanoseconds() const
 {
     if (m_fsync_time) {
-        return m_fsync_time->get_elapsed_seconds();
+        return m_fsync_time->get_elapsed_nanoseconds();
     }
     return 0;
 }
 
-double TransactionInfo::get_write_time() const
+nanosecond_storage_t TransactionInfo::get_write_time_nanoseconds() const
 {
     if (m_write_time) {
-        return m_write_time->get_elapsed_seconds();
+        return m_write_time->get_elapsed_nanoseconds();
     }
     return 0;
 }
@@ -104,5 +104,5 @@ void TransactionInfo::update_stats(size_t disk_size, size_t free_space, size_t t
 
 void TransactionInfo::finish_timer()
 {
-    m_transaction_time.report_seconds(m_transact_timer.get_elapsed_time());
+    m_transaction_time.report_nanoseconds(m_transact_timer.get_elapsed_nanoseconds());
 }

--- a/src/realm/metrics/transaction_info.hpp
+++ b/src/realm/metrics/transaction_info.hpp
@@ -42,9 +42,9 @@ public:
 
     TransactionType get_transaction_type() const;
     // the transaction time is a total amount which includes fsync_time + write_time + user_time
-    double get_transaction_time() const;
-    double get_fsync_time() const;
-    double get_write_time() const;
+    nanosecond_storage_t get_transaction_time_nanoseconds() const;
+    nanosecond_storage_t get_fsync_time_nanoseconds() const;
+    nanosecond_storage_t get_write_time_nanoseconds() const;
     size_t get_disk_size() const;
     size_t get_free_space() const;
     size_t get_total_objects() const;

--- a/test/test_metrics.cpp
+++ b/test/test_metrics.cpp
@@ -751,27 +751,32 @@ TEST(Metrics_TransactionTimings)
     CHECK_EQUAL(transactions->size(), 4);
 
     for (auto t : *transactions) {
-        CHECK_GREATER(t.get_transaction_time(), 0);
+        CHECK_GREATER(t.get_transaction_time_nanoseconds(), 0);
 
         if (t.get_transaction_type() == TransactionInfo::read_transaction) {
-            CHECK_EQUAL(t.get_fsync_time(), 0.0);
-            CHECK_EQUAL(t.get_write_time(), 0.0);
+            CHECK_EQUAL(t.get_fsync_time_nanoseconds(), 0.0);
+            CHECK_EQUAL(t.get_write_time_nanoseconds(), 0.0);
         }
         else {
             if (!get_disable_sync_to_disk()) {
-                CHECK_NOT_EQUAL(t.get_fsync_time(), 0.0);
+                CHECK_NOT_EQUAL(t.get_fsync_time_nanoseconds(), 0.0);
             }
-            CHECK_NOT_EQUAL(t.get_write_time(), 0.0);
-            CHECK_LESS(t.get_fsync_time(), t.get_transaction_time());
-            CHECK_LESS(t.get_write_time(), t.get_transaction_time());
+            CHECK_NOT_EQUAL(t.get_write_time_nanoseconds(), 0.0);
+            CHECK_LESS(t.get_fsync_time_nanoseconds(), t.get_transaction_time_nanoseconds());
+            CHECK_LESS(t.get_write_time_nanoseconds(), t.get_transaction_time_nanoseconds());
         }
     }
-    // give a margin of 100ms for transactions
-    // this is causing sporadic CI failures so best not to assume any upper bound
-    CHECK_GREATER(transactions->at(2).get_transaction_time(), 0.060);
-    //CHECK_LESS(transactions->at(2).get_transaction_time(), 0.160);
-    CHECK_GREATER(transactions->at(3).get_transaction_time(), 0.080);
-    //CHECK_LESS(transactions->at(3).get_transaction_time(), 0.180);
+    // test that the timings reported are in the right ballpark
+    // read transaction
+    CHECK_EQUAL(transactions->at(2).get_transaction_type(), metrics::TransactionInfo::TransactionType::read_transaction);
+    CHECK_GREATER(transactions->at(2).get_transaction_time_nanoseconds(), 1'000); // > 1us
+    CHECK_LESS(transactions->at(2).get_transaction_time_nanoseconds(), 2'000'000'000); // < 2s
+    CHECK_EQUAL(transactions->at(2).get_fsync_time_nanoseconds(), 0); // no fsync on read
+    // write transaction
+    CHECK_EQUAL(transactions->at(3).get_transaction_type(), metrics::TransactionInfo::TransactionType::write_transaction);
+    CHECK_GREATER(transactions->at(3).get_transaction_time_nanoseconds(), 10'000); // > 10us
+    CHECK_LESS(transactions->at(3).get_transaction_time_nanoseconds(), 2'000'000'000); // <  2s
+    CHECK_GREATER(transactions->at(3).get_fsync_time_nanoseconds(), 0); // fsync on write takes some time
 }
 
 


### PR DESCRIPTION
This unit change is motivated by how we view these when enabled in grafana. We should report in the most precise units available and allow a view to convert the results into something less precise if desired.

There is also some question of if very small second double values (eg. 0.00000001) were being lost in the statsd->prometheus translation somewhere.

This will require some small code changes when sync updates, but I don't really consider this to be a breaking change because the stats work is still under development, so I marked it as internal.