### PR TITLE
No backtrace for query serialization errors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,7 @@
 -----------
 
 ### Internals
-* None.
+* Better performance when cloud query metrics are turned on, by not acquiring a backtrace on query serialization errors (permissions queries). ([#3361](https://github.com/realm/realm-core/issues/3361)).
 
 ----------------------------------------------
 

--- a/src/realm/exceptions.hpp
+++ b/src/realm/exceptions.hpp
@@ -102,8 +102,13 @@ public:
     /// runtime_error::what() returns the msg provided in the constructor.
 };
 
-
-class SerialisationError : public ExceptionWithBacktrace<std::runtime_error> {
+// SerialisationError intentionally does not inherit ExceptionWithBacktrace
+// because the query-based-sync permissions queries generated on the server
+// use a LinksToNode which is not currently serialisable (this limitation can
+// be lifted in core 6 given stable ids). Coupled with query metrics which
+// serialize all queries, the capturing of the stack for these frequent
+// permission queries shows up in performance profiles.
+class SerialisationError : public std::runtime_error {
 public:
     SerialisationError(const std::string& msg);
     /// runtime_error::what() returns the msg provided in the constructor.
@@ -307,7 +312,7 @@ inline OutOfDiskSpace::OutOfDiskSpace(const std::string& msg)
 }
 
 inline SerialisationError::SerialisationError(const std::string& msg)
-    : ExceptionWithBacktrace<std::runtime_error>(msg)
+    : std::runtime_error(msg)
 {
 }
 

--- a/src/realm/metrics/query_info.cpp
+++ b/src/realm/metrics/query_info.cpp
@@ -37,7 +37,7 @@ QueryInfo::QueryInfo(const Query* query, QueryType type)
     try {
         m_description = query->get_description();
     } catch (const SerialisationError& e) {
-        m_description = e.message();
+        m_description = e.what();
     }
     m_table_name = query->m_table->get_name();
 #else


### PR DESCRIPTION
We run a lot of permissions queries in query based sync and these are currently not serializable because they use a `LinksToNode` to associate to a specific user and we don't have stable id's in core yet.

When query metrics are turned I noticed durning a cloud perf, that a not insignificant amount of time was being spent acquiring the backtrace for all these permissions queries which could not be serialized (~6% for a session which was servicing QBS). The simple thing to do is to not get the backtrace since it is not a critical error and is not used anyways.