### PR TITLE
Optimize queries comparing a constant value over links

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@
 ### Internals
 * Changed the metrics timers to more precisely report in nanoseconds, instead of seconds. ([#3359](https://github.com/realm/realm-core/issues/3359))
 * Better performance when cloud query metrics are turned on, by not acquiring a backtrace on query serialization errors (permissions queries). ([#3361](https://github.com/realm/realm-core/issues/3361)).
+* Performance improved for queries comparing a constant value to a property over unary link path (eg: "someLink.Id == 42"). ([#3670](https://github.com/realm/realm-core/issues/3370))
 
 ----------------------------------------------
 

--- a/src/realm/data_type.hpp
+++ b/src/realm/data_type.hpp
@@ -25,6 +25,7 @@ namespace realm {
 
 class StringData;
 class BinaryData;
+class Timestamp;
 
 typedef int64_t Int;
 typedef bool Bool;
@@ -32,6 +33,7 @@ typedef float Float;
 typedef double Double;
 typedef realm::StringData String;
 typedef realm::BinaryData Binary;
+typedef realm::Timestamp Timestamp;
 
 
 // Note: Value assignments must be kept in sync with <realm/column_type.h>

--- a/src/realm/query_expression.hpp
+++ b/src/realm/query_expression.hpp
@@ -3950,8 +3950,10 @@ private:
         : m_left(other.m_left->clone(patches))
         , m_right(other.m_right->clone(patches))
         , m_left_is_const(other.m_left_is_const)
-        , m_left_value(other.m_left_value)
     {
+        if (m_left_is_const) {
+            m_left->evaluate(-1/*unused*/, m_left_value);
+        }
     }
 
     std::unique_ptr<TLeft> m_left;

--- a/src/realm/query_expression.hpp
+++ b/src/realm/query_expression.hpp
@@ -1215,7 +1215,7 @@ public:
     {
     }
 
-    virtual std::string description(util::serializer::SerialisationState&) const override
+    std::string description(util::serializer::SerialisationState&) const override
     {
         if (ValueBase::m_from_link_list) {
             return util::serializer::print_value(util::to_string(ValueBase::m_values)
@@ -1227,7 +1227,7 @@ public:
         return "";
     }
 
-    virtual bool has_constant_evaluation() const override
+    bool has_constant_evaluation() const override
     {
         return true;
     }

--- a/src/realm/query_expression.hpp
+++ b/src/realm/query_expression.hpp
@@ -1397,7 +1397,7 @@ public:
         size_t sz = right->ValueBase::m_values;
         bool left_is_null = left->m_storage.is_null(0);
         for (size_t m = 0; m < sz; m++) {
-            if (c(left->m_storage[0], right->m_storage[m], left_is_null, right->m_storage.is_null(0)))
+            if (c(left->m_storage[0], right->m_storage[m], left_is_null, right->m_storage.is_null(m)))
                 return right->m_from_link_list ? 0 : m;
         }
 
@@ -3235,7 +3235,7 @@ public:
             sgc->cache_next(index);
             size_t colsize = sgc->m_column->size();
 
-            // Now load `ValueBase::chunck_size` rows from from the leaf into m_storage. If it's an integer
+            // Now load `ValueBase::chunk_size` rows from from the leaf into m_storage. If it's an integer
             // leaf, then it contains the method get_chunk() which copies these values in a super fast way (first
             // case of the `if` below. Otherwise, copy the values one by one in a for-loop (the `else` case).
             if (std::is_same<U, int64_t>::value && index + ValueBase::chunk_size <= sgc->m_leaf_end) {

--- a/src/realm/table.hpp
+++ b/src/realm/table.hpp
@@ -1602,8 +1602,6 @@ private:
     template <class T>
     friend class Columns;
     friend class Columns<StringData>;
-    template <class TCond, class T>
-    friend class CompareColumnPathToValueBase;
     friend class ParentNode;
     template <class>
     friend class SequentialGetter;

--- a/src/realm/table.hpp
+++ b/src/realm/table.hpp
@@ -1602,6 +1602,8 @@ private:
     template <class T>
     friend class Columns;
     friend class Columns<StringData>;
+    template <class TCond, class T>
+    friend class CompareColumnPathToValueBase;
     friend class ParentNode;
     template <class>
     friend class SequentialGetter;

--- a/test/benchmark-common-tasks/main.cpp
+++ b/test/benchmark-common-tasks/main.cpp
@@ -1412,15 +1412,15 @@ int benchmark_common_tasks_main()
     BENCH(BenchmarkQueryIntEquality);
     BENCH(BenchmarkQueryIntEqualityIndexed);*/
     BENCH(BenchmarkQueryTimestampGreaterOverLinks);
-    //BENCH(BenchmarkQueryTimestampGreater);
-    /*BENCH(BenchmarkQueryTimestampGreaterEqual);
+    BENCH(BenchmarkQueryTimestampGreater);
+    BENCH(BenchmarkQueryTimestampGreaterEqual);
     BENCH(BenchmarkQueryTimestampLess);
     BENCH(BenchmarkQueryTimestampLessEqual);
     BENCH(BenchmarkQueryTimestampEqual);
     BENCH(BenchmarkQueryTimestampNotEqual);
     BENCH(BenchmarkQueryTimestampNotNull);
     BENCH(BenchmarkQueryTimestampEqualNull);
-*/
+
 #undef BENCH
     return 0;
 }

--- a/test/benchmark-common-tasks/main.cpp
+++ b/test/benchmark-common-tasks/main.cpp
@@ -1425,7 +1425,6 @@ int benchmark_common_tasks_main()
 
 #define BENCH(B) run_benchmark<B>(results)
 
-    /*
     BENCH(BenchmarkUnorderedTableViewClear);
     BENCH(BenchmarkEmptyCommit);
     BENCH(AddTable);
@@ -1457,7 +1456,7 @@ int benchmark_common_tasks_main()
     BENCH(BenchmarkQueryChainedOrInts);
     BENCH(BenchmarkQueryChainedOrIntsIndexed);
     BENCH(BenchmarkQueryIntEquality);
-    BENCH(BenchmarkQueryIntEqualityIndexed);*/
+    BENCH(BenchmarkQueryIntEqualityIndexed);
     BENCH(BenchmarkQueryStringOverLinks);
     BENCH(BenchmarkQueryTimestampGreaterOverLinks);
     BENCH(BenchmarkQueryTimestampGreater);

--- a/test/test_query.cpp
+++ b/test/test_query.cpp
@@ -12120,4 +12120,23 @@ TEST(Query_IntIndexOverLinkViewNotInTableOrder)
     CHECK_EQUAL(0, child_table->where().equal(col_child_id, 3).find());
     CHECK_EQUAL(1, child_table->where().equal(col_child_id, 2).find());
 }
+
+TEST(Query_MixedTypeQuery)
+{
+    Group g;
+    auto table = g.add_table("Foo");
+    auto col_int = table->add_column(type_Int, "int");
+    auto col_double = table->add_column(type_Double, "double");
+    for (int64_t i = 0; i < 100; i++) {
+        auto ndx = table->add_empty_row();
+        table->set_int(col_int, ndx, i);
+        table->set_double(col_double, ndx, 100. - i);
+    }
+
+    auto tv = (table->column<Int>(col_int) > 9.5).find_all();
+    CHECK_EQUAL(tv.size(), 90);
+    auto tv1 = (table->column<Int>(col_int) > table->column<Double>(col_double)).find_all();
+    CHECK_EQUAL(tv1.size(), 49);
+}
+
 #endif // TEST_QUERY


### PR DESCRIPTION
Although not timestamp specific, these changes are for https://jira.mongodb.org/browse/RCORE-4

There are three optimizations here:
1) If comparing to a constant value (applies to `Value<T>`) then do not evaluate this condition every time, only once.
2) If comparing to a link chain property which contains only unary links (ie there are no lists in the path) then we know there will only be one result or null; do not construct and destruct dynamic memory (vectors) for the results.
3) The default storage size of a `Value<T>` constructed by default or for a constant is changed from 8 to 1. Previously, a `Columns` expression would get the next 8 values in the column but only actually use the first one, so we save 7 memory fetches here.

Benchmark results on master:
```
QueryStringOverLinks (MemOnly, EncryptionOff):   min 279.96ms     max 287.08ms     median 284.84ms     avg 283.80ms     stddev   2.46ms
QueryStringOverLinks (MemOnly, EncryptionOn):    min 288.33ms     max 365.90ms     median 297.05ms     avg 303.09ms     stddev  23.55ms
QueryStringOverLinks (Full   , EncryptionOff):   min 284.85ms     max 293.21ms     median 289.10ms     avg 289.08ms     stddev   2.37ms
QueryStringOverLinks (Full   , EncryptionOn):    min 287.63ms     max 295.68ms     median 292.51ms     avg 291.84ms     stddev   2.63ms

QueryTimestampGreaterOverLinks (MemOnly, EncryptionOff):   min  86.87ms     max 100.71ms     median  91.86ms     avg  91.74ms     stddev   5.47ms
QueryTimestampGreaterOverLinks (MemOnly, EncryptionOn):    min  87.30ms     max  90.59ms     median  89.09ms     avg  88.89ms     stddev   1.10ms
QueryTimestampGreaterOverLinks (Full   , EncryptionOff):   min  88.47ms     max 105.86ms     median  92.54ms     avg  93.70ms     stddev   5.57ms
QueryTimestampGreaterOverLinks (Full   , EncryptionOn):    min  86.65ms     max  97.04ms     median  89.25ms     avg  90.18ms     stddev   3.44ms
```

Benchmark results on this branch:
```
QueryStringOverLinks (MemOnly, EncryptionOff):   min 104.39ms     max 139.03ms     median 124.59ms     avg 119.43ms     stddev  10.54ms
QueryStringOverLinks (MemOnly, EncryptionOn):    min 100.67ms     max 111.67ms     median 109.91ms     avg 106.67ms     stddev   4.39ms
QueryStringOverLinks (Full   , EncryptionOff):   min  99.47ms     max 108.40ms     median 106.73ms     avg 104.63ms     stddev   3.25ms
QueryStringOverLinks (Full   , EncryptionOn):    min  98.85ms     max 108.21ms     median 101.07ms     avg 101.89ms     stddev   3.08ms

QueryTimestampGreaterOverLinks (MemOnly, EncryptionOff):   min  41.33ms     max  44.04ms     median  43.08ms     avg  42.57ms     stddev   1.02ms
QueryTimestampGreaterOverLinks (MemOnly, EncryptionOn):    min  40.97ms     max  47.47ms     median  43.59ms     avg  43.29ms     stddev   2.10ms
QueryTimestampGreaterOverLinks (Full   , EncryptionOff):   min  41.10ms     max  56.60ms     median  42.15ms     avg  45.41ms     stddev   6.36ms
QueryTimestampGreaterOverLinks (Full   , EncryptionOn):    min  41.81ms     max  46.98ms     median  42.55ms     avg  43.29ms     stddev   1.99ms
```