### PR TITLE
Fix incorrect results for long string or-equal queries

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,9 +4,8 @@
 * None.
 
 ### Fixed
-* <How to hit and notice issue? what was the impact?> ([#????](https://github.com/realm/realm-core/issues/????), since v?.?.?)
-* None.
- 
+* Chained OR equals queries on an unindexed string column failed to match any results if any of the strings were 64 bytes or longer. ([PR #3386](https://github.com/realm/realm-core/pull/3386), since 5.17.0).
+
 ### Breaking changes
 * None.
 

--- a/src/realm/array_string.hpp
+++ b/src/realm/array_string.hpp
@@ -54,6 +54,7 @@ public:
     bool is_null(size_t ndx) const;
     void set_null(size_t ndx);
     StringData get(size_t ndx) const noexcept;
+    StringData get_string(size_t ndx) const noexcept { return get(ndx); }
     void add();
     void add(StringData value);
     void set(size_t ndx, StringData value);

--- a/src/realm/array_string_long.hpp
+++ b/src/realm/array_string_long.hpp
@@ -57,6 +57,7 @@ public:
     size_t size() const noexcept;
 
     StringData get(size_t ndx) const noexcept;
+    StringData get_string(size_t ndx) const noexcept { return get(ndx); }
 
 
     void add(StringData value);

--- a/src/realm/query_engine.cpp
+++ b/src/realm/query_engine.cpp
@@ -350,9 +350,8 @@ void StringNode<Equal>::consume_condition(StringNode<Equal>* other)
 }
 
 // Requirements of template types:
-// ArrayType must support: size() -> size_t, and get(size_t) -> ElementType
-// ElementType must be convertable to a StringData via data() and size()
-template <class ArrayType, class ElementType>
+// ArrayType must support: size() -> size_t, and get_string(size_t) -> Stringdata
+template <class ArrayType>
 size_t StringNode<Equal>::find_first_in(ArrayType& array, size_t begin, size_t end)
 {
     if (m_needles.empty())
@@ -372,19 +371,17 @@ size_t StringNode<Equal>::find_first_in(ArrayType& array, size_t begin, size_t e
     // with N==100k
     if (m_needles.size() < 20) {
         for (size_t i = begin; i < end; ++i) {
-            ElementType element = array.get(i);
-            StringData value_2{element.data(), element.size()};
+            StringData element = array.get_string(i);
             for (auto it = m_needles.begin(); it != not_in_set; ++it) {
-                if (*it == value_2)
+                if (*it == element)
                     return i;
             }
         }
     }
     else {
         for (size_t i = begin; i < end; ++i) {
-            ElementType element = array.get(i);
-            StringData value_2{element.data(), element.size()};
-            if (m_needles.find(value_2) != not_in_set)
+            StringData element = array.get_string(i);
+            if (m_needles.find(element) != not_in_set)
                 return i;
         }
     }
@@ -415,14 +412,11 @@ size_t StringNode<Equal>::_find_first_local(size_t start, size_t end)
 
         if (multi_target_search) {
             if (m_leaf_type == StringColumn::leaf_type_Small)
-                s = find_first_in<const ArrayString&, StringData>(static_cast<const ArrayString&>(*m_leaf),
-                                                                  s - m_leaf_start, end2);
+                s = find_first_in(static_cast<const ArrayString&>(*m_leaf), s - m_leaf_start, end2);
             else if (m_leaf_type == StringColumn::leaf_type_Medium)
-                s = find_first_in<const ArrayStringLong&, StringData>(static_cast<const ArrayStringLong&>(*m_leaf),
-                                                                      s - m_leaf_start, end2);
+                s = find_first_in(static_cast<const ArrayStringLong&>(*m_leaf), s - m_leaf_start, end2);
             else
-                s = find_first_in<const ArrayBigBlobs&, BinaryData>(static_cast<const ArrayBigBlobs&>(*m_leaf),
-                                                                    s - m_leaf_start, end2);
+                s = find_first_in(static_cast<const ArrayBigBlobs&>(*m_leaf), s - m_leaf_start, end2);
         }
         else {
             if (m_leaf_type == StringColumn::leaf_type_Small)

--- a/src/realm/query_engine.hpp
+++ b/src/realm/query_engine.hpp
@@ -1887,7 +1887,7 @@ public:
     }
 
 private:
-    template <class ArrayType, class ElementType>
+    template <class ArrayType>
     size_t find_first_in(ArrayType& array, size_t begin, size_t end);
 
     size_t _find_first_local(size_t start, size_t end) override;

--- a/test/test_query.cpp
+++ b/test/test_query.cpp
@@ -12165,5 +12165,58 @@ TEST(Query_LinkListIntPastOneIsNull)
     CHECK_EQUAL(q.count(), 1);
 }
 
+TEST(Query_StringOrShortStrings)
+{
+    Group g;
+    TableRef table = g.add_table("table");
+    auto col_value = table->add_column(type_String, "value");
+
+    std::string strings[] = {"0", "1", "2"};
+    for (auto& str : strings) {
+        table->set_string(col_value, table->add_empty_row(), str);
+    }
+
+    for (auto& str : strings) {
+        Query q = table->where().group().equal(col_value, str).Or().equal(col_value, "not present").end_group();
+        CHECK_EQUAL(q.count(), 1);
+    }
+}
+
+TEST(Query_StringOrMediumStrings)
+{
+    Group g;
+    TableRef table = g.add_table("table");
+    auto col_value = table->add_column(type_String, "value");
+
+    std::string strings[] = {"0", "1", "2"};
+    for (auto& str : strings) {
+        str.resize(16, str[0]); // Make the strings long enough to require ArrayStringLong
+        table->set_string(col_value, table->add_empty_row(), str);
+    }
+
+    for (auto& str : strings) {
+        Query q = table->where().group().equal(col_value, str).Or().equal(col_value, "not present").end_group();
+        CHECK_EQUAL(q.count(), 1);
+    }
+}
+
+TEST(Query_StringOrLongStrings)
+{
+    Group g;
+    TableRef table = g.add_table("table");
+    auto col_value = table->add_column(type_String, "value");
+
+    std::string strings[] = {"0", "1", "2"};
+    for (auto& str : strings) {
+        str.resize(64, str[0]); // Make the strings long enough to require ArrayBigBlobs
+        table->set_string(col_value, table->add_empty_row(), str);
+    }
+
+    for (auto& str : strings) {
+        Query q = table->where().group().equal(col_value, str).Or().equal(col_value, "not present").end_group();
+        CHECK_EQUAL(q.count(), 1);
+    }
+}
+
 
 #endif // TEST_QUERY


### PR DESCRIPTION
BinaryData::size() includes the nul terminator while StringData::size() does not, so the BinaryData -> StringData conversion was incorrect and resulted in queries never matching when the low-level storage was ArrayBigBlobs.

Reported at https://github.com/realm/realm-cocoa/issues/6249.