### PR TITLE
Fix timestamp null description

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 
 ### Fixed
 * Chained OR equals queries on an unindexed string column failed to match any results if any of the strings were 64 bytes or longer. ([PR #3386](https://github.com/realm/realm-core/pull/3386), since 5.17.0).
+* Fixed serialization of a query which looks for a null timestamp. This only affects query based sync. ([PR #3389](https://github.com/realm/realm-core/pull/3388), since v5.23.2).
 
 ### Breaking changes
 * None.

--- a/src/realm/util/serializer.cpp
+++ b/src/realm/util/serializer.cpp
@@ -99,6 +99,9 @@ std::string print_value<>(StringData data)
 template <>
 std::string print_value<>(realm::Timestamp t)
 {
+    if (t.is_null()) {
+        return "NULL";
+    }
     std::stringstream ss;
     ss << "T" << t.get_seconds() << ":" << t.get_nanoseconds();
     return ss.str();

--- a/test/test_parser.cpp
+++ b/test/test_parser.cpp
@@ -3193,5 +3193,28 @@ TEST(Parser_ChainedIntEqualQueries)
     verify_query(test_context, table, query, populated_data.size());
 }
 
+ONLY(Parser_TimestampNullable)
+{
+    Group g;
+    TableRef table = g.add_table("table");
+    size_t a_col_ndx = table->add_column(type_Timestamp, "a", false);
+    size_t b_col_ndx = table->add_column(type_Timestamp, "b", false);
+    table->add_empty_row(2);
+    table->set_timestamp(a_col_ndx, 0, Timestamp(7, 0));
+    table->set_timestamp(a_col_ndx, 1, Timestamp(7, 0));
+    table->set_timestamp(b_col_ndx, 0, Timestamp(17, 0));
+    table->set_timestamp(b_col_ndx, 1, Timestamp(17, 0));
+
+    Query q = table->where()
+      .equal(b_col_ndx, Timestamp(200, 0))
+      .group()
+      .equal(a_col_ndx, Timestamp(100, 0))
+      .Or()
+      .equal(a_col_ndx, Timestamp(realm::null()))
+      .end_group();
+    std::string description = q.get_description();
+    CHECK_EQUAL(description, "(b == T200:0 and (a == T100:0 or NULL == a)");
+}
+
 
 #endif // TEST_PARSER

--- a/test/test_parser.cpp
+++ b/test/test_parser.cpp
@@ -3193,7 +3193,7 @@ TEST(Parser_ChainedIntEqualQueries)
     verify_query(test_context, table, query, populated_data.size());
 }
 
-ONLY(Parser_TimestampNullable)
+TEST(Parser_TimestampNullable)
 {
     Group g;
     TableRef table = g.add_table("table");
@@ -3213,7 +3213,8 @@ ONLY(Parser_TimestampNullable)
       .equal(a_col_ndx, Timestamp(realm::null()))
       .end_group();
     std::string description = q.get_description();
-    CHECK_EQUAL(description, "(b == T200:0 and (a == T100:0 or NULL == a)");
+    CHECK(description.find("NULL") != std::string::npos);
+    CHECK_EQUAL(description, "b == T200:0 and (a == T100:0 or a == NULL)");
 }
 
 


### PR DESCRIPTION
The timestamp optimization (https://github.com/realm/realm-core/pull/3351) started using a different code path for serialization of timestamps in a query. Thanks @kneth for the reproduction! Fixes #3388.