### PR TITLE
VersionID comparison operators are now const qualified

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,7 @@
 -----------
 
 ### Internals
-* None.
+* VersionID comparison operators are now const qualified ([PR #3391](https://github.com/realm/realm-core/pull/3391)).
 
 ----------------------------------------------
 

--- a/src/realm/version_id.hpp
+++ b/src/realm/version_id.hpp
@@ -41,27 +41,27 @@ struct VersionID {
         index = initial_index;
     }
 
-    bool operator==(const VersionID& other)
+    bool operator==(const VersionID& other) const
     {
         return version == other.version;
     }
-    bool operator!=(const VersionID& other)
+    bool operator!=(const VersionID& other) const
     {
         return version != other.version;
     }
-    bool operator<(const VersionID& other)
+    bool operator<(const VersionID& other) const
     {
         return version < other.version;
     }
-    bool operator<=(const VersionID& other)
+    bool operator<=(const VersionID& other) const
     {
         return version <= other.version;
     }
-    bool operator>(const VersionID& other)
+    bool operator>(const VersionID& other) const
     {
         return version > other.version;
     }
-    bool operator>=(const VersionID& other)
+    bool operator>=(const VersionID& other) const
     {
         return version >= other.version;
     }


### PR DESCRIPTION
Motivated by some changes in object store which compare two const VersionID objects. It must have been an oversight that these methods were not const in the first place.