### PR TITLE
Reduce initial size of memory mappings used for slab

### DIFF
--- a/src/realm/alloc_slab.cpp
+++ b/src/realm/alloc_slab.cpp
@@ -166,7 +166,7 @@ SlabAlloc::Slab::~Slab()
 {
     total_slab_allocated.fetch_sub(size, std::memory_order_relaxed);
     if (addr)
-        util::munmap(addr, 1UL << section_shift);
+        util::munmap(addr, size);
 }
 
 void SlabAlloc::detach() noexcept
@@ -413,7 +413,7 @@ SlabAlloc::FreeBlock* SlabAlloc::allocate_block(int size)
         block = pop_freelist_entry(list);
     }
     else {
-        block = grow_slab();
+        block = grow_slab(size);
     }
     FreeBlock* remaining = break_block(block, size);
     if (remaining)
@@ -481,15 +481,21 @@ SlabAlloc::FreeBlock* SlabAlloc::merge_blocks(FreeBlock* first, FreeBlock* last)
     return first;
 }
 
-SlabAlloc::FreeBlock* SlabAlloc::grow_slab()
+SlabAlloc::FreeBlock* SlabAlloc::grow_slab(int size)
 {
-    // Allocate new slab. We allocate a full section but use mmap, so it'll
-    // be paged in on demand.
-    size_t new_size = 1UL << section_shift;
+    // Allocate new slab.
+    // - Allways allocate at least 1MB
+    // - Double allocation amount, but
+    // - Never allocate more than a full section (64MB)
+    size_t already_allocated = get_allocated_size();
+    size_t new_size = 1024*1024;
+    if (size > new_size) new_size = size;
+    if (new_size < already_allocated) new_size = already_allocated;
+    if (new_size > 64 * 1024 * 1024) new_size = 64 * 1024 * 1024;
 
     ref_type ref;
     if (m_slabs.empty()) {
-        ref = align_size_to_section_boundary(m_baseline.load(std::memory_order_relaxed));
+        ref = m_baseline.load(std::memory_order_relaxed);
     }
     else {
         // Find size of memory that has been modified (through copy-on-write) in current write transaction
@@ -497,7 +503,7 @@ SlabAlloc::FreeBlock* SlabAlloc::grow_slab()
         REALM_ASSERT_DEBUG_EX(curr_ref_end >= m_baseline, curr_ref_end, m_baseline, get_file_path_for_assertions());
         ref = curr_ref_end;
     }
-
+    ref = align_size_to_section_boundary(ref);
     size_t ref_end = ref;
     if (REALM_UNLIKELY(int_add_with_overflow_detect(ref_end, new_size))) {
         throw MaximumFileSizeExceeded("AllocSlab slab ref_end size overflow: " + util::to_string(ref) + " + " +
@@ -505,7 +511,6 @@ SlabAlloc::FreeBlock* SlabAlloc::grow_slab()
     }
 
     REALM_ASSERT(matches_section_boundary(ref));
-    REALM_ASSERT(matches_section_boundary(ref_end));
 
     std::lock_guard<std::mutex> lock(m_mapping_mutex);
     // Create new slab and add to list of slabs

--- a/src/realm/alloc_slab.cpp
+++ b/src/realm/alloc_slab.cpp
@@ -1103,7 +1103,6 @@ void SlabAlloc::reset_free_space_tracking()
             m_slabs.pop_back();
         }
         else {
-            std::cerr << "Break" << std::endl;
             break;
         }
     }

--- a/src/realm/alloc_slab.hpp
+++ b/src/realm/alloc_slab.hpp
@@ -505,7 +505,7 @@ private:
 
     // grow the slab area.
     // returns a free block large enough to handle the request.
-    FreeBlock* grow_slab();
+    FreeBlock* grow_slab(int size);
     // create a single free chunk with "BetweenBlocks" at both ends and a
     // single free chunk between them. This free chunk will be of size:
     //   slab_size - 2 * sizeof(BetweenBlocks)
@@ -798,6 +798,12 @@ void SlabAlloc::for_all_free_entries(Func f) const
                 bb = reinterpret_cast<BetweenBlocks*>(reinterpret_cast<char*>(bb) + sizeof(BetweenBlocks) - size);
                 ref -= size;
             }
+        }
+        // any gaps in ref-space is reported as a free block to the validator:
+        auto next_ref = align_size_to_section_boundary(ref);
+        if (next_ref > ref) {
+            f(ref, next_ref - ref);
+            ref = next_ref;
         }
     }
 }

--- a/src/realm/alloc_slab.hpp
+++ b/src/realm/alloc_slab.hpp
@@ -634,6 +634,8 @@ private:
         free_space_Dirty,
         free_space_Invalid,
     };
+    constexpr static int minimal_alloc = 128 * 1024;
+    constexpr static int maximal_alloc = 1 << section_shift;
 
     /// When set to free_space_Invalid, the free lists are no longer
     /// up-to-date. This happens if do_free() or

--- a/src/realm/alloc_slab.hpp
+++ b/src/realm/alloc_slab.hpp
@@ -619,9 +619,6 @@ private:
     // Add a translation covering a new section in the slab area. The translation is always
     // added at the end.
     void extend_fast_mapping_with_slab(char* address);
-    // Remove last entry from mapping. It is assumed that it will contain the address given.
-    // if this is not the case, the mapping will not be removed and false will be returned
-    bool reduce_fast_mapping_with_slab(char* address);
     // Prepare the initial mapping for a file which requires use of the compatibility mapping
     void setup_compatibility_mapping(size_t file_size);
 

--- a/src/realm/group.cpp
+++ b/src/realm/group.cpp
@@ -1857,7 +1857,7 @@ void Group::verify() const
 
     // Check the consistency of the allocation of the mutable memory that has
     // been marked as free
-    m_alloc.for_all_free_entries([&](ref_type ref, int sz) { mem_usage_2.add_mutable(ref, sz); });
+    m_alloc.for_all_free_entries([&](ref_type ref, size_t sz) { mem_usage_2.add_mutable(ref, sz); });
     mem_usage_2.canonicalize();
     mem_usage_1.add(mem_usage_2);
     mem_usage_1.canonicalize();

--- a/test/test_lang_bind_helper.cpp
+++ b/test/test_lang_bind_helper.cpp
@@ -336,6 +336,7 @@ TEST(LangBindHelper_AdvanceReadTransact_Basics)
     rt->advance_read();
     CHECK(version != foo->get_content_version());
     rt->verify();
+    cols = foo->get_column_keys();
     CHECK_EQUAL(2, foo->get_column_count());
     CHECK_EQUAL(type_Int, foo->get_column_type(cols[0]));
     CHECK_EQUAL(type_String, foo->get_column_type(cols[1]));


### PR DESCRIPTION
This PR reduces the amount of scratch memory initially allocated for slab. It also no longer does a reservation of virtual address space to have it readily available for later expansion of the slab area. This significantly reduces use of virtual address space during write transactions, especially for write transactions with little data.