### PR TITLE
Fix several warnings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,7 @@
 -----------
 
 ### Internals
-* None.
+* Fixed several warnings found by newer clang compilers. ([#3393](https://github.com/realm/realm-core/issues/3393)).
 
 ----------------------------------------------
 

--- a/src/realm/group.cpp
+++ b/src/realm/group.cpp
@@ -714,9 +714,9 @@ void Group::rename_table(size_t table_ndx, StringData new_name, bool require_uni
 
 class Group::DefaultTableWriter : public Group::TableWriter {
 public:
-    DefaultTableWriter(const Group& group, bool write_history)
+    DefaultTableWriter(const Group& group, bool has_write_history)
         : m_group(group)
-        , m_write_history(write_history)
+        , m_write_history(has_write_history)
     {
     }
     ref_type write_names(_impl::OutputStream& out) override

--- a/src/realm/index_string.cpp
+++ b/src/realm/index_string.cpp
@@ -754,9 +754,9 @@ void StringIndex::TreeInsert(size_t row_ndx, key_type key, size_t offset, String
 {
     NodeChange nc = do_insert(row_ndx, key, offset, value);
     switch (nc.type) {
-        case NodeChange::ChangeType::change_None:
+        case NodeChange::change_None:
             return;
-        case NodeChange::ChangeType::change_InsertBefore: {
+        case NodeChange::change_InsertBefore: {
             StringIndex new_node(inner_node_tag(), m_array->get_alloc());
             new_node.node_add_key(nc.ref1);
             new_node.node_add_key(get_ref());
@@ -764,7 +764,7 @@ void StringIndex::TreeInsert(size_t row_ndx, key_type key, size_t offset, String
             m_array->update_parent();
             return;
         }
-        case NodeChange::ChangeType::change_InsertAfter: {
+        case NodeChange::change_InsertAfter: {
             StringIndex new_node(inner_node_tag(), m_array->get_alloc());
             new_node.node_add_key(get_ref());
             new_node.node_add_key(nc.ref1);
@@ -772,7 +772,7 @@ void StringIndex::TreeInsert(size_t row_ndx, key_type key, size_t offset, String
             m_array->update_parent();
             return;
         }
-        case NodeChange::ChangeType::change_Split: {
+        case NodeChange::change_Split: {
             StringIndex new_node(inner_node_tag(), m_array->get_alloc());
             new_node.node_add_key(nc.ref1);
             new_node.node_add_key(nc.ref2);
@@ -808,32 +808,32 @@ StringIndex::NodeChange StringIndex::do_insert(size_t row_ndx, key_type key, siz
 
         // Insert item
         NodeChange nc = target.do_insert(row_ndx, key, offset, value);
-        if (nc.type == NodeChange::ChangeType::change_None) {
+        if (nc.type == NodeChange::change_None) {
             // update keys
             key_type last_key = target.get_last_key();
             keys.set(node_ndx, last_key);
-            return NodeChange::ChangeType::change_None; // no new nodes
+            return NodeChange::change_None; // no new nodes
         }
 
-        if (nc.type == NodeChange::ChangeType::change_InsertAfter) {
+        if (nc.type == NodeChange::change_InsertAfter) {
             ++node_ndx;
             ++refs_ndx;
         }
 
         // If there is room, just update node directly
         if (keys.size() < REALM_MAX_BPNODE_SIZE) {
-            if (nc.type == NodeChange::ChangeType::change_Split) {
+            if (nc.type == NodeChange::change_Split) {
                 node_insert_split(node_ndx, nc.ref2);
             }
             else {
                 node_insert(node_ndx, nc.ref1); // ::INSERT_BEFORE/AFTER
             }
-            return NodeChange::ChangeType::change_None;
+            return NodeChange::change_None;
         }
 
         // Else create new node
         StringIndex new_node(inner_node_tag(), alloc);
-        if (nc.type == NodeChange::ChangeType::change_Split) {
+        if (nc.type == NodeChange::change_Split) {
             // update offset for left node
             key_type last_key = target.get_last_key();
             keys.set(node_ndx, last_key);
@@ -848,11 +848,11 @@ StringIndex::NodeChange StringIndex::do_insert(size_t row_ndx, key_type key, siz
 
         switch (node_ndx) {
             case 0: // insert before
-                return NodeChange(NodeChange::ChangeType::change_InsertBefore, new_node.get_ref());
+                return NodeChange(NodeChange::change_InsertBefore, new_node.get_ref());
             case REALM_MAX_BPNODE_SIZE: // insert after
-                if (nc.type == NodeChange::ChangeType::change_Split)
-                    return NodeChange(NodeChange::ChangeType::change_Split, get_ref(), new_node.get_ref());
-                return NodeChange(NodeChange::ChangeType::change_InsertAfter, new_node.get_ref());
+                if (nc.type == NodeChange::change_Split)
+                    return NodeChange(NodeChange::change_Split, get_ref(), new_node.get_ref());
+                return NodeChange(NodeChange::change_InsertAfter, new_node.get_ref());
             default: // split
                 // Move items after split to new node
                 size_t len = m_array->size();
@@ -862,7 +862,7 @@ StringIndex::NodeChange StringIndex::do_insert(size_t row_ndx, key_type key, siz
                 }
                 keys.truncate(node_ndx);
                 m_array->truncate(refs_ndx);
-                return NodeChange(NodeChange::ChangeType::change_Split, get_ref(), new_node.get_ref());
+                return NodeChange(NodeChange::change_Split, get_ref(), new_node.get_ref());
         }
     }
     else {
@@ -877,7 +877,7 @@ StringIndex::NodeChange StringIndex::do_insert(size_t row_ndx, key_type key, siz
         // See if we can fit entry into current leaf
         // Works if there is room or it can join existing entries
         if (leaf_insert(row_ndx, key, offset, value, noextend))
-            return NodeChange::ChangeType::change_None;
+            return NodeChange::change_None;
 
         // Create new list for item (a leaf)
         StringIndex new_list(m_target_column, alloc);
@@ -888,11 +888,11 @@ StringIndex::NodeChange StringIndex::do_insert(size_t row_ndx, key_type key, siz
 
         // insert before
         if (ndx == 0)
-            return NodeChange(NodeChange::ChangeType::change_InsertBefore, new_list.get_ref());
+            return NodeChange(NodeChange::change_InsertBefore, new_list.get_ref());
 
         // insert after
         if (ndx == old_offsets_size)
-            return NodeChange(NodeChange::ChangeType::change_InsertAfter, new_list.get_ref());
+            return NodeChange(NodeChange::change_InsertAfter, new_list.get_ref());
 
         // split
         Array new_keys(alloc);
@@ -908,7 +908,7 @@ StringIndex::NodeChange StringIndex::do_insert(size_t row_ndx, key_type key, siz
         old_keys.truncate(ndx);
         m_array->truncate(ndx + 1);
 
-        return NodeChange(NodeChange::ChangeType::change_Split, get_ref(), new_list.get_ref());
+        return NodeChange(NodeChange::change_Split, get_ref(), new_list.get_ref());
     }
 }
 

--- a/src/realm/index_string.cpp
+++ b/src/realm/index_string.cpp
@@ -754,9 +754,9 @@ void StringIndex::TreeInsert(size_t row_ndx, key_type key, size_t offset, String
 {
     NodeChange nc = do_insert(row_ndx, key, offset, value);
     switch (nc.type) {
-        case NodeChange::ChangeType::none:
+        case NodeChange::ChangeType::change_None:
             return;
-        case NodeChange::ChangeType::insert_before: {
+        case NodeChange::ChangeType::change_InsertBefore: {
             StringIndex new_node(inner_node_tag(), m_array->get_alloc());
             new_node.node_add_key(nc.ref1);
             new_node.node_add_key(get_ref());
@@ -764,7 +764,7 @@ void StringIndex::TreeInsert(size_t row_ndx, key_type key, size_t offset, String
             m_array->update_parent();
             return;
         }
-        case NodeChange::ChangeType::insert_after: {
+        case NodeChange::ChangeType::change_InsertAfter: {
             StringIndex new_node(inner_node_tag(), m_array->get_alloc());
             new_node.node_add_key(get_ref());
             new_node.node_add_key(nc.ref1);
@@ -772,7 +772,7 @@ void StringIndex::TreeInsert(size_t row_ndx, key_type key, size_t offset, String
             m_array->update_parent();
             return;
         }
-        case NodeChange::ChangeType::split: {
+        case NodeChange::ChangeType::change_Split: {
             StringIndex new_node(inner_node_tag(), m_array->get_alloc());
             new_node.node_add_key(nc.ref1);
             new_node.node_add_key(nc.ref2);
@@ -808,32 +808,32 @@ StringIndex::NodeChange StringIndex::do_insert(size_t row_ndx, key_type key, siz
 
         // Insert item
         NodeChange nc = target.do_insert(row_ndx, key, offset, value);
-        if (nc.type == NodeChange::ChangeType::none) {
+        if (nc.type == NodeChange::ChangeType::change_None) {
             // update keys
             key_type last_key = target.get_last_key();
             keys.set(node_ndx, last_key);
-            return NodeChange::ChangeType::none; // no new nodes
+            return NodeChange::ChangeType::change_None; // no new nodes
         }
 
-        if (nc.type == NodeChange::ChangeType::insert_after) {
+        if (nc.type == NodeChange::ChangeType::change_InsertAfter) {
             ++node_ndx;
             ++refs_ndx;
         }
 
         // If there is room, just update node directly
         if (keys.size() < REALM_MAX_BPNODE_SIZE) {
-            if (nc.type == NodeChange::ChangeType::split) {
+            if (nc.type == NodeChange::ChangeType::change_Split) {
                 node_insert_split(node_ndx, nc.ref2);
             }
             else {
                 node_insert(node_ndx, nc.ref1); // ::INSERT_BEFORE/AFTER
             }
-            return NodeChange::ChangeType::none;
+            return NodeChange::ChangeType::change_None;
         }
 
         // Else create new node
         StringIndex new_node(inner_node_tag(), alloc);
-        if (nc.type == NodeChange::ChangeType::split) {
+        if (nc.type == NodeChange::ChangeType::change_Split) {
             // update offset for left node
             key_type last_key = target.get_last_key();
             keys.set(node_ndx, last_key);
@@ -848,11 +848,11 @@ StringIndex::NodeChange StringIndex::do_insert(size_t row_ndx, key_type key, siz
 
         switch (node_ndx) {
             case 0: // insert before
-                return NodeChange(NodeChange::ChangeType::insert_before, new_node.get_ref());
+                return NodeChange(NodeChange::ChangeType::change_InsertBefore, new_node.get_ref());
             case REALM_MAX_BPNODE_SIZE: // insert after
-                if (nc.type == NodeChange::ChangeType::split)
-                    return NodeChange(NodeChange::ChangeType::split, get_ref(), new_node.get_ref());
-                return NodeChange(NodeChange::ChangeType::insert_after, new_node.get_ref());
+                if (nc.type == NodeChange::ChangeType::change_Split)
+                    return NodeChange(NodeChange::ChangeType::change_Split, get_ref(), new_node.get_ref());
+                return NodeChange(NodeChange::ChangeType::change_InsertAfter, new_node.get_ref());
             default: // split
                 // Move items after split to new node
                 size_t len = m_array->size();
@@ -862,7 +862,7 @@ StringIndex::NodeChange StringIndex::do_insert(size_t row_ndx, key_type key, siz
                 }
                 keys.truncate(node_ndx);
                 m_array->truncate(refs_ndx);
-                return NodeChange(NodeChange::ChangeType::split, get_ref(), new_node.get_ref());
+                return NodeChange(NodeChange::ChangeType::change_Split, get_ref(), new_node.get_ref());
         }
     }
     else {
@@ -877,7 +877,7 @@ StringIndex::NodeChange StringIndex::do_insert(size_t row_ndx, key_type key, siz
         // See if we can fit entry into current leaf
         // Works if there is room or it can join existing entries
         if (leaf_insert(row_ndx, key, offset, value, noextend))
-            return NodeChange::ChangeType::none;
+            return NodeChange::ChangeType::change_None;
 
         // Create new list for item (a leaf)
         StringIndex new_list(m_target_column, alloc);
@@ -888,11 +888,11 @@ StringIndex::NodeChange StringIndex::do_insert(size_t row_ndx, key_type key, siz
 
         // insert before
         if (ndx == 0)
-            return NodeChange(NodeChange::ChangeType::insert_before, new_list.get_ref());
+            return NodeChange(NodeChange::ChangeType::change_InsertBefore, new_list.get_ref());
 
         // insert after
         if (ndx == old_offsets_size)
-            return NodeChange(NodeChange::ChangeType::insert_after, new_list.get_ref());
+            return NodeChange(NodeChange::ChangeType::change_InsertAfter, new_list.get_ref());
 
         // split
         Array new_keys(alloc);
@@ -908,7 +908,7 @@ StringIndex::NodeChange StringIndex::do_insert(size_t row_ndx, key_type key, siz
         old_keys.truncate(ndx);
         m_array->truncate(ndx + 1);
 
-        return NodeChange(NodeChange::ChangeType::split, get_ref(), new_list.get_ref());
+        return NodeChange(NodeChange::ChangeType::change_Split, get_ref(), new_list.get_ref());
     }
 }
 

--- a/src/realm/index_string.hpp
+++ b/src/realm/index_string.hpp
@@ -226,7 +226,7 @@ private:
     struct NodeChange {
         size_t ref1;
         size_t ref2;
-        enum ChangeType { none, insert_before, insert_after, split } type;
+        enum class ChangeType { none, insert_before, insert_after, split } type;
         NodeChange(ChangeType t, size_t r1 = 0, size_t r2 = 0)
             : ref1(r1)
             , ref2(r2)
@@ -236,7 +236,7 @@ private:
         NodeChange()
             : ref1(0)
             , ref2(0)
-            , type(none)
+            , type(ChangeType::none)
         {
         }
     };

--- a/src/realm/index_string.hpp
+++ b/src/realm/index_string.hpp
@@ -226,7 +226,7 @@ private:
     struct NodeChange {
         size_t ref1;
         size_t ref2;
-        enum class ChangeType { none, insert_before, insert_after, split } type;
+        enum class ChangeType { change_None, change_InsertBefore, change_InsertAfter, change_Split } type;
         NodeChange(ChangeType t, size_t r1 = 0, size_t r2 = 0)
             : ref1(r1)
             , ref2(r2)
@@ -236,7 +236,7 @@ private:
         NodeChange()
             : ref1(0)
             , ref2(0)
-            , type(ChangeType::none)
+            , type(ChangeType::change_None)
         {
         }
     };

--- a/src/realm/index_string.hpp
+++ b/src/realm/index_string.hpp
@@ -226,7 +226,7 @@ private:
     struct NodeChange {
         size_t ref1;
         size_t ref2;
-        enum class ChangeType { change_None, change_InsertBefore, change_InsertAfter, change_Split } type;
+        enum ChangeType { change_None, change_InsertBefore, change_InsertAfter, change_Split } type;
         NodeChange(ChangeType t, size_t r1 = 0, size_t r2 = 0)
             : ref1(r1)
             , ref2(r2)
@@ -236,7 +236,7 @@ private:
         NodeChange()
             : ref1(0)
             , ref2(0)
-            , type(ChangeType::change_None)
+            , type(change_None)
         {
         }
     };

--- a/src/realm/query_expression.hpp
+++ b/src/realm/query_expression.hpp
@@ -2118,8 +2118,8 @@ public:
             }
             else {
                 std::vector<size_t> links = m_link_map.get_links(index);
-                constexpr bool only_unary_links = false;
-                Value<T> v = make_value_for_link<T>(only_unary_links, links.size());
+                constexpr bool has_only_unary_links = false;
+                Value<T> v = make_value_for_link<T>(has_only_unary_links, links.size());
                 for (size_t t = 0; t < links.size(); t++) {
                     size_t link_to = links[t];
                     v.m_storage.set(t, m_link_map.target_table()->template get<T>(col, link_to));


### PR DESCRIPTION
Fixes https://github.com/realm/realm-core/issues/3393

The issues are:

```
In file included from /home/jenkins/workspace/realm_realm-core_release_5.23.5@2/src/realm/query_expression.cpp:19:0:
/home/jenkins/workspace/realm_realm-core_release_5.23.5@2/src/realm/query_expression.hpp: In member function 'void realm::SimpleQuerySupport< <template-parameter-1-1> >::evaluate(size_t, realm::ValueBase&)':
/home/jenkins/workspace/realm_realm-core_release_5.23.5@2/src/realm/query_expression.hpp:2121:32: warning: declaration of 'only_unary_links' shadows a member of 'this' [-Wshadow]
                 constexpr bool only_unary_links = false;
                                ^
```
^ Fixed by changing the local variable name.

```
/home/jenkins/workspace/realm_realm-core_release_5.23.5@2/src/realm/group.cpp: In constructor 'realm::Group::DefaultTableWriter::DefaultTableWriter(const realm::Group&, bool)':
/home/jenkins/workspace/realm_realm-core_release_5.23.5@2/src/realm/group.cpp:718:9: warning: declaration of 'write_history' shadows a member of 'this' [-Wshadow]
         : m_group(group)
```
^ Fixed by changing the variable name.

```
../src/realm/index_string.hpp:229:27: warning: declaration shadows a variable in namespace 'realm::util' [-Wshadow]
        enum ChangeType { none, insert_before, insert_after, split } type;
                          ^
../src/realm/util/optional.hpp:47:23: note: previous declaration is here
static constexpr None none{0};
                      ^
1 warning generated.
```
^ Fixed by using a prefix on the enum names, which now aligns with the coding style guide.