### PR TITLE
Fix json serialisation of null values

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,8 +4,7 @@
 * None.
 
 ### Fixed
-* <How to hit and notice issue? what was the impact?> ([#????](https://github.com/realm/realm-core/issues/????), since v?.?.?)
-* None.
+* Null values were not printed correctly when using json serialisation. ([PR #3399](https://github.com/realm/realm-core/issues/3399)).
  
 ### Breaking changes
 * None.

--- a/test/expected_json_nulls.json
+++ b/test/expected_json_nulls.json
@@ -1,0 +1,1 @@
+[{"str_col":"Hello","bool_col":false,"int_col":1,"timestamp_col":"1970-01-01 00:00:01"},{"str_col":null,"bool_col":null,"int_col":null,"timestamp_col":null}]

--- a/test/test_json.cpp
+++ b/test/test_json.cpp
@@ -520,6 +520,32 @@ TEST(Json_LinkCycles)
     CHECK(json_test(ss.str(), "expected_json_link_cycles5", generate_all));
 }
 
+TEST(Json_Nulls)
+{
+    Group group;
+
+    TableRef table1 = group.add_table("table1");
+
+    constexpr bool is_nullable = true;
+    size_t str_col_ndx = table1->add_column(type_String, "str_col", is_nullable);
+    size_t bool_col_ndx = table1->add_column(type_Bool, "bool_col", is_nullable);
+    size_t int_col_ndx = table1->add_column(type_Int, "int_col", is_nullable);
+    size_t timestamp_col_ndx = table1->add_column(type_Timestamp, "timestamp_col", is_nullable);
+
+    // add one row, populated manually
+    size_t row_1_ndx = table1->add_empty_row();
+    table1->set_string(str_col_ndx, row_1_ndx, "Hello");
+    table1->set_bool(bool_col_ndx, row_1_ndx, false);
+    table1->set_int(int_col_ndx, row_1_ndx, 1);
+    table1->set_timestamp(timestamp_col_ndx, row_1_ndx, Timestamp{1, 1});
+    // add one row with default null values
+    table1->add_empty_row();
+
+    std::stringstream ss;
+    table1->to_json(ss);
+    CHECK(json_test(ss.str(), "expected_json_nulls", generate_all));
+}
+
 } // anonymous namespace
 
 #endif // TEST_TABLE


### PR DESCRIPTION
The change in Table::to_json_row just checks for null before proceeding to serialize values as per normal. The diff looks awful, but everything is just indented without modification.