### PR TITLE
IncludeDescriptor() should take TableRef, not Table&

### DIFF
--- a/src/realm/parser/query_builder.cpp
+++ b/src/realm/parser/query_builder.cpp
@@ -873,7 +873,7 @@ void apply_ordering(DescriptorOrdering& ordering, ConstTableRef target, const pa
                 }
                 properties.emplace_back(std::move(links));
             }
-            ordering.append_include(IncludeDescriptor{*target, properties});
+            ordering.append_include(IncludeDescriptor{target, properties});
             mapping.set_allow_backlinks(backlink_paths_allowed);
         }
         else {

--- a/src/realm/sort_descriptor.cpp
+++ b/src/realm/sort_descriptor.cpp
@@ -352,7 +352,6 @@ IncludeDescriptor::IncludeDescriptor(ConstTableRef table, const std::vector<std:
 {
     m_column_keys.resize(column_links.size());
     m_backlink_sources.resize(column_links.size());
-    using tf = _impl::TableFriend;
     Group* group = table->get_parent_group();
     for (size_t i = 0; i < m_column_keys.size(); ++i) { // for each path:
         auto& columns = m_column_keys[i];

--- a/src/realm/sort_descriptor.cpp
+++ b/src/realm/sort_descriptor.cpp
@@ -347,13 +347,13 @@ void BaseDescriptor::Sorter::cache_first_column(IndexPairs& v)
     }
 }
 
-IncludeDescriptor::IncludeDescriptor(const Table& table, const std::vector<std::vector<LinkPathPart>>& column_links)
+IncludeDescriptor::IncludeDescriptor(ConstTableRef table, const std::vector<std::vector<LinkPathPart>>& column_links)
     : ColumnsDescriptor()
 {
     m_column_keys.resize(column_links.size());
     m_backlink_sources.resize(column_links.size());
     using tf = _impl::TableFriend;
-    Group* group(tf::get_parent_group(table));
+    Group* group = table->get_parent_group();
     for (size_t i = 0; i < m_column_keys.size(); ++i) { // for each path:
         auto& columns = m_column_keys[i];
         auto& links = column_links[i];
@@ -362,7 +362,7 @@ IncludeDescriptor::IncludeDescriptor(const Table& table, const std::vector<std::
 
         columns.reserve(links.size());
         backlink_source.reserve(links.size());
-        const Table* cur_table = &table;
+        ConstTableRef cur_table = table;
         size_t link_ndx = 0;
         for (auto link : links) {  // follow path, one link at a time:
             auto col_type = link.column_key.get_type();
@@ -370,7 +370,7 @@ IncludeDescriptor::IncludeDescriptor(const Table& table, const std::vector<std::
             backlink_source.push_back(link.from);
             if (TableKey from_table_key = link.from) { // backlink
                 // must point back to cur_table:
-                Table* from_table = group->get_table(from_table_key);
+                TableRef from_table = group->get_table(from_table_key);
                 REALM_ASSERT_DEBUG(cur_table == from_table->get_opposite_table(link.column_key));
                 if (Table::is_link_type(col_type)) {
                     // FIXME: How can this ever be true - ref assert above...

--- a/src/realm/sort_descriptor.hpp
+++ b/src/realm/sort_descriptor.hpp
@@ -254,7 +254,7 @@ public:
     // This constructor may throw an InvalidPathError exception if the path is not valid.
     // A valid path consists of any number of connected link/list/backlink paths and always ends with a backlink
     // column.
-    IncludeDescriptor(const Table& table, const std::vector<std::vector<LinkPathPart>>& link_paths);
+    IncludeDescriptor(ConstTableRef table, const std::vector<std::vector<LinkPathPart>>& link_paths);
     ~IncludeDescriptor() = default;
     std::string get_description(ConstTableRef attached_table) const override;
     std::unique_ptr<BaseDescriptor> clone() const override;

--- a/src/realm/table.hpp
+++ b/src/realm/table.hpp
@@ -972,6 +972,7 @@ private:
     friend class ColKeyIterator;
     friend class ConstObj;
     friend class Obj;
+    friend class IncludeDescriptor;
 };
 
 class ColKeyIterator {

--- a/test/test_query.cpp
+++ b/test/test_query.cpp
@@ -3709,7 +3709,7 @@ TEST(Query_DescriptorsWillApply)
     CHECK(!ordering.will_apply_include());
     CHECK(!ordering.will_limit_to_zero());
 
-    ordering.append_include(IncludeDescriptor(*t1, {{LinkPathPart{t1_link_col, t1}}}));
+    ordering.append_include(IncludeDescriptor(t1, {{LinkPathPart{t1_link_col, t1}}}));
     CHECK(ordering.will_apply_sort());
     CHECK(ordering.will_apply_distinct());
     CHECK(ordering.will_apply_limit());
@@ -4142,7 +4142,7 @@ TEST(Query_SortDistinctOrderThroughHandover)
         tv.sort(SortDescriptor({{t1_int_col}}, {false}));
         tv.distinct(DistinctDescriptor({{t1_str_col}}));
         tv.limit(LimitDescriptor(0));
-        tv.include(IncludeDescriptor(*t1, {{{t1_link_col, t1}}}));
+        tv.include(IncludeDescriptor(t1, {{{t1_link_col, t1}}}));
         CHECK_EQUAL(tv.size(), results.size());
         auto tr = g->duplicate();
         auto tv2 = tr->import_copy_of(tv, PayloadPolicy::Stay);
@@ -4529,7 +4529,7 @@ TEST(Query_IncludeDescriptorSelfLinks)
     { // test single backlink path from the same table: INCLUDE(@links.t1.t1_link_self)
         TableView tv = t1->where().less(t1_int_col, 6).find_all();
         tv.sort(t1_int_col);
-        tv.include(IncludeDescriptor(*t1, {{{t1_link_self_col, t1}}}));
+        tv.include(IncludeDescriptor(t1, {{{t1_link_self_col, t1}}}));
 
         IncludeDescriptor includes = tv.get_include_descriptors();
         std::vector<size_t> expected_values;
@@ -4555,7 +4555,7 @@ TEST(Query_IncludeDescriptorSelfLinks)
     { // test a backlink chain of size two from the same table: INCLUDE(t1_link_self.@links.t1.t1_link_self)
         TableView tv = t1->where().less(t1_int_col, 6).find_all();
         tv.sort(t1_int_col);
-        tv.include(IncludeDescriptor(*t1, {{{t1_link_self_col}, {t1_link_self_col, t1}}}));
+        tv.include(IncludeDescriptor(t1, {{{t1_link_self_col}, {t1_link_self_col, t1}}}));
 
         IncludeDescriptor includes = tv.get_include_descriptors();
         std::vector<size_t> expected_values;
@@ -4577,7 +4577,7 @@ TEST(Query_IncludeDescriptorSelfLinks)
       // INCLUDE(t1_link_self.t1_link_self.@links.t1.t1_link_self)
         TableView tv = t1->where().less(t1_int_col, 6).find_all();
         tv.sort(t1_int_col);
-        tv.include(IncludeDescriptor(*t1, {{{t1_link_self_col}, {t1_link_self_col}, {t1_link_self_col, t1}}}));
+        tv.include(IncludeDescriptor(t1, {{{t1_link_self_col}, {t1_link_self_col}, {t1_link_self_col, t1}}}));
 
         IncludeDescriptor includes = tv.get_include_descriptors();
         std::vector<size_t> expected_values;
@@ -4646,7 +4646,7 @@ TEST(Query_IncludeDescriptorOtherLinks)
     { // test single backlink path from t2: INCLUDE(@links.t2.t2_link_t1)
         TableView tv = t1->where().less(t1_int_col, 6).find_all();
         tv.sort(t1_int_col);
-        tv.include(IncludeDescriptor(*t1, {{{t2_link_t1_col, t2}}}));
+        tv.include(IncludeDescriptor(t1, {{{t2_link_t1_col, t2}}}));
 
         IncludeDescriptor includes = tv.get_include_descriptors();
         std::vector<size_t> expected_t2_values;
@@ -4729,7 +4729,7 @@ TEST(Query_IncludeDescriptorOtherLists)
     { // test single backlink path from t2 list: INCLUDE(@links.t2.t2_list_t1_col)
         TableView tv = t1->where().less(t1_int_col, 6).find_all();
         tv.sort(t1_int_col);
-        tv.include(IncludeDescriptor(*t1, {{{t2_list_t1_col, t2}}}));
+        tv.include(IncludeDescriptor(t1, {{{t2_list_t1_col, t2}}}));
 
         IncludeDescriptor includes = tv.get_include_descriptors();
         std::vector<size_t> expected_t2_values;
@@ -4876,7 +4876,7 @@ TEST(Query_IncludeDescriptorLinkAndListTranslation)
     };
 
     DescriptorOrdering ordering;
-    ordering.append_include(IncludeDescriptor(*t1, {{{t1_link_t2_col}, {t2_list_t3_col}, {t4_link_t3_col, t4}}}));
+    ordering.append_include(IncludeDescriptor(t1, {{{t1_link_t2_col}, {t2_list_t3_col}, {t4_link_t3_col, t4}}}));
     ordering.append_sort(SortDescriptor({{t1_int_col}}));
     check_include(ordering);
 }


### PR DESCRIPTION
We generally want users of Core to use the checking smart ptr, TableRef, instead of a raw Table&.
