### PR TITLE
Improve performance of reading query results

### DIFF
--- a/src/realm/list.cpp
+++ b/src/realm/list.cpp
@@ -541,14 +541,12 @@ LnkLst::LnkLst(const Obj& owner, ColKey col_key)
 {
 }
 
-TableVersions LnkLst::get_dependencies() const
+void LnkLst::get_dependencies(TableVersions& versions) const
 {
-    TableVersions versions;
     if (is_attached()) {
         auto table = get_table();
         versions.emplace_back(table->get_key(), table->get_content_version());
     }
-    return versions;
 }
 
 TableVersions LnkLst::sync_if_needed() const

--- a/src/realm/list.cpp
+++ b/src/realm/list.cpp
@@ -549,16 +549,11 @@ void LnkLst::get_dependencies(TableVersions& versions) const
     }
 }
 
-TableVersions LnkLst::sync_if_needed() const
+void LnkLst::sync_if_needed() const
 {
-    TableVersions versions;
     if (this->is_attached()) {
         const_cast<LnkLst*>(this)->update_if_needed();
-        auto table = get_table();
-        auto version = table->get_content_version();
-        versions.emplace_back(table->get_key(), version);
     }
-    return versions;
 }
 
 namespace realm {

--- a/src/realm/list.hpp
+++ b/src/realm/list.hpp
@@ -841,7 +841,7 @@ private:
     friend class ConstTableView;
     friend class Query;
     void get_dependencies(TableVersions&) const override;
-    TableVersions sync_if_needed() const override;
+    void sync_if_needed() const override;
 };
 
 template <typename U>

--- a/src/realm/list.hpp
+++ b/src/realm/list.hpp
@@ -840,7 +840,7 @@ private:
     friend class DB;
     friend class ConstTableView;
     friend class Query;
-    TableVersions get_dependencies() const override;
+    void get_dependencies(TableVersions&) const override;
     TableVersions sync_if_needed() const override;
 };
 

--- a/src/realm/obj.cpp
+++ b/src/realm/obj.cpp
@@ -134,7 +134,8 @@ bool ConstObj::is_valid() const
 {
     // Cache valid state. If once invalid, it can never become valid again
     if (m_valid)
-        m_valid = (m_table->get_instance_version() == m_instance_version) && m_table->is_valid(m_key);
+        m_valid = (m_table->get_instance_version() == m_instance_version)
+               && (m_table->get_storage_version(m_instance_version) == m_storage_version || m_table->is_valid(m_key));
 
     return m_valid;
 }

--- a/src/realm/obj_list.cpp
+++ b/src/realm/obj_list.cpp
@@ -121,3 +121,10 @@ void ObjList::assign(KeyColumn* key_values, const Table* parent)
     m_key_values = key_values;
     m_table = ConstTableRef(parent);
 }
+
+TableVersions ObjList::get_dependency_versions() const
+{
+    TableVersions ret;
+    get_dependencies(ret);
+    return ret;
+}

--- a/src/realm/obj_list.hpp
+++ b/src/realm/obj_list.hpp
@@ -84,8 +84,11 @@ public:
     template <class T>
     size_t find_first(ColKey column_key, T value);
 
+    // Get the versions of all tables which this list depends on
+    TableVersions get_dependency_versions() const;
+
     // These three methods are overridden by TableView and ObjList/LnkLst.
-    virtual TableVersions sync_if_needed() const = 0;
+    virtual void sync_if_needed() const = 0;
     virtual void get_dependencies(TableVersions&) const = 0;
     virtual bool is_in_sync() const = 0;
     void check_cookie() const

--- a/src/realm/obj_list.hpp
+++ b/src/realm/obj_list.hpp
@@ -86,7 +86,7 @@ public:
 
     // These three methods are overridden by TableView and ObjList/LnkLst.
     virtual TableVersions sync_if_needed() const = 0;
-    virtual TableVersions get_dependencies() const = 0;
+    virtual void get_dependencies(TableVersions&) const = 0;
     virtual bool is_in_sync() const = 0;
     void check_cookie() const
     {

--- a/src/realm/query.cpp
+++ b/src/realm/query.cpp
@@ -1408,15 +1408,13 @@ TableView Query::find_all(const DescriptorOrdering& descriptor)
 #if REALM_METRICS
     std::unique_ptr<MetricTimer> metric_timer = QueryInfo::track(this, QueryInfo::type_FindAll);
 #endif
+    if (descriptor.is_empty()) {
+        return find_all();
+    }
+
     const size_t default_start = 0;
     const size_t default_end = size_t(-1);
     const size_t default_limit = size_t(-1);
-
-    if (descriptor.is_empty()) {
-        TableView ret(*m_table, *this, default_start, default_end, default_limit);
-        find_all(ret);
-        return ret;
-    }
 
     bool only_limit = true;
     size_t min_limit = size_t(-1);
@@ -1432,9 +1430,7 @@ TableView Query::find_all(const DescriptorOrdering& descriptor)
         }
     }
     if (only_limit) {
-        TableView ret(*m_table, *this, default_start, default_end, min_limit);
-        find_all(ret, default_start, default_end, min_limit);
-        return ret;
+        return find_all(default_start, default_end, min_limit);
     }
 
     TableView ret(*m_table, *this, default_start, default_end, default_limit);

--- a/src/realm/query.cpp
+++ b/src/realm/query.cpp
@@ -1769,9 +1769,8 @@ Query Query::operator!()
     return q;
 }
 
-TableVersions Query::get_outside_versions() const
+void Query::get_outside_versions(TableVersions& versions) const
 {
-    TableVersions versions;
     if (m_table) {
         if (m_table_keys.empty()) {
             // Store primary table info
@@ -1793,13 +1792,9 @@ TableVersions Query::get_outside_versions() const
             }
         }
         if (m_view) {
-            TableVersions view_versions = m_view->get_dependencies();
-            for (auto e : view_versions) {
-                versions.push_back(e);
-            }
+            m_view->get_dependencies(versions);
         }
     }
-    return versions;
 }
 
 TableVersions Query::sync_view_if_needed() const
@@ -1807,7 +1802,9 @@ TableVersions Query::sync_view_if_needed() const
     if (m_view) {
         m_view->sync_if_needed();
     }
-    return get_outside_versions();
+    TableVersions ret;
+    get_outside_versions(ret);
+    return ret;
 }
 
 QueryGroup::QueryGroup(const QueryGroup& other)

--- a/src/realm/query.hpp
+++ b/src/realm/query.hpp
@@ -263,7 +263,7 @@ public:
         return m_table;
     }
 
-    TableVersions get_outside_versions() const;
+    void get_outside_versions(TableVersions&) const;
 
     // True if matching rows are guaranteed to be returned in table order.
     bool produces_results_in_table_order() const

--- a/src/realm/table_view.cpp
+++ b/src/realm/table_view.cpp
@@ -54,7 +54,7 @@ ConstTableView::ConstTableView(const ConstTableView& src, Transaction* tr, Paylo
     */
 
     if (was_in_sync)
-        m_last_seen_versions = get_dependencies();
+        m_last_seen_versions = get_dependency_versions();
     else
         m_last_seen_versions.clear();
     m_table = tr->import_copy_of(src.m_table);
@@ -403,7 +403,7 @@ bool ConstTableView::depends_on_deleted_object() const
 }
 
 // Return version of whatever this TableView depends on
-const TableVersions& ConstTableView::get_dependencies() const
+const TableVersions& ConstTableView::get_dependency_versions() const
 {
     m_get_dependencies_buffer.clear();
     get_dependencies(m_get_dependencies_buffer);
@@ -445,7 +445,7 @@ bool ConstTableView::is_in_sync() const
 {
     check_cookie();
 
-    return !m_table ? false : m_last_seen_versions == get_dependencies();
+    return !m_table ? false : m_last_seen_versions == get_dependency_versions();
 }
 
 void ConstTableView::sync_if_needed() const
@@ -462,7 +462,7 @@ void TableView::remove(size_t row_ndx)
     REALM_ASSERT(m_table);
     REALM_ASSERT(row_ndx < m_key_values->size());
 
-    bool sync_to_keep = m_last_seen_versions == get_dependencies();
+    bool sync_to_keep = m_last_seen_versions == get_dependency_versions();
 
     ObjKey key = m_key_values->get(row_ndx);
 
@@ -475,7 +475,7 @@ void TableView::remove(size_t row_ndx)
     // It is important to not accidentally bring us in sync, if we were
     // not in sync to start with:
     if (sync_to_keep)
-        m_last_seen_versions = get_dependencies();
+        m_last_seen_versions = get_dependency_versions();
 
     // Adjustment of row indexes greater than the removed index is done by
     // adj_row_acc_move_over or adj_row_acc_erase_row as sideeffect of the actual
@@ -487,7 +487,7 @@ void TableView::clear()
 {
     REALM_ASSERT(m_table);
 
-    bool sync_to_keep = m_last_seen_versions == get_dependencies();
+    bool sync_to_keep = m_last_seen_versions == get_dependency_versions();
 
     _impl::TableFriend::batch_erase_rows(get_parent(), *m_key_values); // Throws
 
@@ -496,7 +496,7 @@ void TableView::clear()
     // It is important to not accidentally bring us in sync, if we were
     // not in sync to start with:
     if (sync_to_keep)
-        m_last_seen_versions = get_dependencies();
+        m_last_seen_versions = get_dependency_versions();
 }
 
 void ConstTableView::distinct(ColKey column)
@@ -612,7 +612,7 @@ void ConstTableView::do_sync()
 
     do_sort(m_descriptor_ordering);
 
-    m_last_seen_versions = get_dependencies();
+    m_last_seen_versions = get_dependency_versions();
 }
 
 bool ConstTableView::is_in_table_order() const

--- a/src/realm/table_view.cpp
+++ b/src/realm/table_view.cpp
@@ -403,11 +403,16 @@ bool ConstTableView::depends_on_deleted_object() const
 }
 
 // Return version of whatever this TableView depends on
-TableVersions ConstTableView::get_dependencies() const
+const TableVersions& ConstTableView::get_dependencies() const
+{
+    m_get_dependencies_buffer.clear();
+    get_dependencies(m_get_dependencies_buffer);
+    return m_get_dependencies_buffer;
+}
+
+void ConstTableView::get_dependencies(TableVersions& ret) const
 {
     check_cookie();
-
-    TableVersions ret;
 
     if (m_linklist_source) {
         // m_linkview_source is set when this TableView was created by LinkView::get_as_sorted_view().
@@ -423,7 +428,7 @@ TableVersions ConstTableView::get_dependencies() const
         }
     }
     else if (m_query.m_table) {
-        ret = m_query.get_outside_versions();
+        m_query.get_outside_versions(ret);
     }
     else {
         // This TableView was created by Table::get_distinct_view()
@@ -434,8 +439,6 @@ TableVersions ConstTableView::get_dependencies() const
     if (m_table) {
         m_descriptor_ordering.get_versions(m_table->get_parent_group(), ret);
     }
-
-    return ret;
 }
 
 bool ConstTableView::is_in_sync() const

--- a/src/realm/table_view.cpp
+++ b/src/realm/table_view.cpp
@@ -521,7 +521,7 @@ void ConstTableView::limit(LimitDescriptor lim)
     do_sync();
 }
 
-void ConstTableView::apply_descriptor_ordering(DescriptorOrdering new_ordering)
+void ConstTableView::apply_descriptor_ordering(const DescriptorOrdering& new_ordering)
 {
     m_descriptor_ordering = new_ordering;
     m_descriptor_ordering.collect_dependencies(m_table);

--- a/src/realm/table_view.cpp
+++ b/src/realm/table_view.cpp
@@ -448,13 +448,12 @@ bool ConstTableView::is_in_sync() const
     return !m_table ? false : m_last_seen_versions == get_dependencies();
 }
 
-TableVersions ConstTableView::sync_if_needed() const
+void ConstTableView::sync_if_needed() const
 {
     if (!is_in_sync()) {
         // FIXME: Is this a reasonable handling of constness?
         const_cast<ConstTableView*>(this)->do_sync();
     }
-    return m_last_seen_versions;
 }
 
 

--- a/src/realm/table_view.hpp
+++ b/src/realm/table_view.hpp
@@ -301,7 +301,7 @@ public:
     //
     // This will make the TableView empty and in sync with the highest possible table version
     // if the TableView depends on an object (LinkView or row) that has been deleted.
-    TableVersions sync_if_needed() const override;
+    void sync_if_needed() const override;
 
     // Sort m_key_values according to one column
     void sort(ColKey column, bool ascending = true);

--- a/src/realm/table_view.hpp
+++ b/src/realm/table_view.hpp
@@ -347,7 +347,7 @@ protected:
     // - Table::get_backlink_view()
     // Return the version of the source it was created from.
     void get_dependencies(TableVersions&) const override;
-    const TableVersions& get_dependencies() const;
+    const TableVersions& get_dependency_versions() const;
 
     void do_sync();
 

--- a/src/realm/table_view.hpp
+++ b/src/realm/table_view.hpp
@@ -346,7 +346,8 @@ protected:
     // - Table::get_distinct_view()
     // - Table::get_backlink_view()
     // Return the version of the source it was created from.
-    TableVersions get_dependencies() const override;
+    void get_dependencies(TableVersions&) const override;
+    const TableVersions& get_dependencies() const;
 
     void do_sync();
 
@@ -375,6 +376,7 @@ protected:
     size_t m_limit = size_t(-1);
 
     mutable TableVersions m_last_seen_versions;
+    mutable TableVersions m_get_dependencies_buffer;
 
 private:
     KeyColumn m_table_view_key_values; // We should generally not use this name

--- a/src/realm/table_view.hpp
+++ b/src/realm/table_view.hpp
@@ -322,7 +322,7 @@ public:
 
     // Replace the order of sort and distinct operations, bypassing manually
     // calling sort and distinct. This is a convenience method for bindings.
-    void apply_descriptor_ordering(DescriptorOrdering new_ordering);
+    void apply_descriptor_ordering(const DescriptorOrdering& new_ordering);
 
     // Gets a readable and parsable string which completely describes the sort and
     // distinct operations applied to this view.


### PR DESCRIPTION
This is motivated by the following cocoa perf test:

```
- (void)testEnumerateAndAccessQuery {
    RLMRealm *realm = [self getStringObjects:500000];

    [self measureBlock:^{
        for (StringObject *so in [StringObject objectsInRealm:realm where:@"stringCol = 'a'"]) {
            (void)[so stringCol];
        }
    }];
}
```

```
Before:
/src/realm-cocoa/Realm/Tests/PerformanceTests.m:60: Test Case '-[PerformanceTests testEnumerateAndAccessQuery]' measured [Time, seconds] average: 0.429, relative standard deviation: 1.735%, values: [0.418693, 0.432813, 0.440526, 0.442753, 0.421909, 0.428277, 0.428224, 0.422819, 0.424795, 0.431140], performanceMetricID:com.apple.XCTPerformanceMetric_WallClockTime, baselineName: "core 5", baselineAverage: 0.283, maxPercentRegression: 10.000%, maxPercentRelativeStandardDeviation: 10.000%, maxRegression: 0.100, maxStandardDeviation: 0.100
/src/realm-cocoa/Realm/Tests/PerformanceTests.m:60: error: -[PerformanceTests testEnumerateAndAccessQuery] : failed: Time average is 52% worse (max allowed: 10%).

After:
/src/realm-cocoa/Realm/Tests/PerformanceTests.m:60: Test Case '-[PerformanceTests testEnumerateAndAccessQuery]' measured [Time, seconds] average: 0.271, relative standard deviation: 0.674%, values: [0.272499, 0.271413, 0.271469, 0.269368, 0.273126, 0.269821, 0.272845, 0.268375, 0.272500, 0.267900], performanceMetricID:com.apple.XCTPerformanceMetric_WallClockTime, baselineName: "core 5", baselineAverage: 0.283, maxPercentRegression: 10.000%, maxPercentRelativeStandardDeviation: 10.000%, maxRegression: 0.100, maxStandardDeviation: 0.100
```

The before profile looks like this:
![image](https://user-images.githubusercontent.com/408944/66678995-ff21ec80-ec21-11e9-8ea4-e8a76e9d0d64.png)

The following things jumped out at me:
1. 10.4% of runtime in TableView::is_in_sync(), the bulk of which was memory allocations and deallocations for TableVersions. There's also another 6% of TableVersion allocation/deallocation outside of that function.
2. The query was being run twice despite no data changing.
3. 10.3% in ConstObj::is_valid() even though nothing changed in between the call to get_object() and is_valid() (and checking if the object was still valid was half the runtime of reading a property).

After addressing all three of these and one non-core change (eliminating a redundant call to query.count() that was 2% of runtime) the perf test is slightly faster than the core 5 version rather than 50% slower.
