### PR TITLE
Various updates

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,8 +4,7 @@
 * None.
 
 ### Fixed
-* <How to hit and notice issue? what was the impact?> ([#????](https://github.com/realm/realm-core/issues/????), since v?.?.?)
-* None.
+* Opening a file where the size is a multiplum of 64 MB will crash. ([#3418](https://github.com/realm/realm-core/issues/3418), since v6.0.0-alpha.0)
  
 ### Breaking changes
 * None.

--- a/src/realm/list.hpp
+++ b/src/realm/list.hpp
@@ -129,6 +129,11 @@ public:
         return m_col_key;
     }
 
+    bool operator==(const ConstLstBase& other) const
+    {
+        return get_key() == other.get_key() && get_col_key() == other.get_col_key();
+    }
+
 protected:
     template <class>
     friend class LstIterator;

--- a/src/realm/obj.cpp
+++ b/src/realm/obj.cpp
@@ -48,6 +48,11 @@ ConstObj::ConstObj(const ClusterTree* tree_top, MemRef mem, ObjKey key, size_t r
     m_storage_version = tree_top->get_storage_version(m_instance_version);
 }
 
+ObjectID ConstObj::get_object_id() const
+{
+    return m_table->get_object_id(m_key);
+}
+
 const ClusterTree* ConstObj::get_tree_top() const
 {
     return &m_table->m_clusters;

--- a/src/realm/obj.hpp
+++ b/src/realm/obj.hpp
@@ -33,6 +33,7 @@ class Replication;
 class TableView;
 class ConstLstBase;
 class LstBase;
+struct ObjectID;
 
 template <class>
 class ConstLstIf;
@@ -75,6 +76,8 @@ public:
     {
         return m_key;
     }
+
+    ObjectID get_object_id() const;
 
     const Table* get_table() const
     {

--- a/src/realm/query.cpp
+++ b/src/realm/query.cpp
@@ -1724,8 +1724,9 @@ Query& Query::and_query(Query&& q)
         add_node(std::move(q.m_groups[0].m_root_node));
 
         if (q.m_source_link_list) {
-            REALM_ASSERT(!m_source_link_list || m_source_link_list == q.m_source_link_list);
+            REALM_ASSERT(!m_source_link_list || *m_source_link_list == *q.m_source_link_list);
             m_source_link_list = std::move(q.m_source_link_list);
+            m_view = m_source_link_list.get();
         }
     }
 


### PR DESCRIPTION
**Modify assert in Query::and_query**
In Core-5 you could get away with just comparing the pointers to the
linklist as the accessor object would be cached and reused. This is
not the case on Core-6 so now we just ensure that the tho lists are
referring to the same column in the same object.

**Fix opening a file with the size being a multiplum of 64MB**

**Add ConstObj::get_object_id()**