### PR TITLE
Improve performance of looking up table entries by index

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 # NEXT RELEASE
 
 ### Enhancements
-* None.
+* Improve performance of looking up objects in a Table by index. ([#3423](https://github.com/realm/realm-core/pull/3423))
 
 ### Fixed
 * <How to hit and notice issue? what was the impact?> ([#????](https://github.com/realm/realm-core/issues/????), since v?.?.?)

--- a/src/realm/array.hpp
+++ b/src/realm/array.hpp
@@ -643,6 +643,11 @@ public:
 
     static void get_three(const char* data, size_t ndx, ref_type& v0, ref_type& v1, ref_type& v2) noexcept;
 
+    static RefOrTagged get_as_ref_or_tagged(const char* header, size_t ndx) noexcept
+    {
+        return get(header, ndx);
+    }
+
     /// Get the number of bytes currently in use by this array. This
     /// includes the array header, but it does not include allocated
     /// bytes corresponding to excess capacity. The result is

--- a/src/realm/cluster.hpp
+++ b/src/realm/cluster.hpp
@@ -199,6 +199,7 @@ public:
     {
         return 0;
     }
+    static size_t node_size_from_header(Allocator& alloc, const char* header);
     size_t node_size() const override
     {
         if (!is_attached()) {


### PR DESCRIPTION
Creating a `Cluster` isn't particularly slow, but in the hot loop in `ClusterNodeInner::get()` it still ended up being most of the run time. The benchmark results of this change are:

```
Req runs:   10  IterateTableByIndexNoPrimaryKey (MemOnly, EncryptionOff):     min  84.32ms (-53.58%)           max  87.02ms (-53.27%)           med  84.90ms (-53.90%)           avg  85.18ms (-53.65%)           stddev  1.01ms (-44.11%)      
Req runs:   10  IterateTableByIndexIntPrimaryKey (MemOnly, EncryptionOff):     min  69.98ms (-58.83%)           max  73.74ms (-57.01%)           med  71.84ms (-57.87%)           avg  71.42ms (-58.13%)           stddev  1.10ms (+114.74%)     
Req runs:   10  IterateTableByIndexStringPrimaryKey (MemOnly, EncryptionOff):     min 110.29ms (-47.42%)           max 111.85ms (-47.22%)           med 110.76ms (-47.43%)           avg 110.85ms (-47.38%)           stddev   486us (-27.48%)      
```

This is enough to make the aggressively bad Cocoa perf test (which does `[IntObject.allObjects objectAtIndex:i]` and so defeats optimizations around using an iterator) no longer significantly regress compared to core 5.