### PR TITLE
Introduce and use FunctionRef where it is safe

### DIFF
--- a/src/realm/CMakeLists.txt
+++ b/src/realm/CMakeLists.txt
@@ -157,6 +157,7 @@ set(REALM_INSTALL_UTIL_HEADERS
     util/fifo_helper.hpp
     util/file.hpp
     util/file_mapper.hpp
+    util/function_ref.hpp
     util/hex_dump.hpp
     util/inspect.hpp
     util/interprocess_condvar.hpp

--- a/src/realm/bplustree.cpp
+++ b/src/realm/bplustree.cpp
@@ -74,10 +74,10 @@ public:
         return size_t(back()) >> 1;
     }
 
-    ref_type bptree_insert(size_t n, State& state, InsertFunc&) override;
-    void bptree_access(size_t n, AccessFunc&) override;
-    size_t bptree_erase(size_t n, EraseFunc&) override;
-    bool bptree_traverse(TraverseFunc&) override;
+    ref_type bptree_insert(size_t n, State& state, InsertFunc) override;
+    void bptree_access(size_t n, AccessFunc) override;
+    size_t bptree_erase(size_t n, EraseFunc) override;
+    bool bptree_traverse(TraverseFunc) override;
     void verify() const override;
 
     // Other modifiers
@@ -150,7 +150,7 @@ BPlusTreeNode::~BPlusTreeNode()
 
 /****************************** BPlusTreeLeaf ********************************/
 
-ref_type BPlusTreeLeaf::bptree_insert(size_t ndx, State& state, InsertFunc& func)
+ref_type BPlusTreeLeaf::bptree_insert(size_t ndx, State& state, InsertFunc func)
 {
     size_t leaf_size = get_node_size();
     REALM_ASSERT_DEBUG(leaf_size <= REALM_MAX_BPNODE_SIZE);
@@ -180,17 +180,17 @@ ref_type BPlusTreeLeaf::bptree_insert(size_t ndx, State& state, InsertFunc& func
     return new_leaf->get_ref();
 }
 
-void BPlusTreeLeaf::bptree_access(size_t ndx, AccessFunc& func)
+void BPlusTreeLeaf::bptree_access(size_t ndx, AccessFunc func)
 {
     func(this, ndx);
 }
 
-size_t BPlusTreeLeaf::bptree_erase(size_t ndx, EraseFunc& func)
+size_t BPlusTreeLeaf::bptree_erase(size_t ndx, EraseFunc func)
 {
     return func(this, ndx);
 }
 
-bool BPlusTreeLeaf::bptree_traverse(TraverseFunc& func)
+bool BPlusTreeLeaf::bptree_traverse(TraverseFunc func)
 {
     return func(this, 0);
 }
@@ -230,7 +230,7 @@ void BPlusTreeInner::init_from_mem(MemRef mem)
     }
 }
 
-void BPlusTreeInner::bptree_access(size_t n, AccessFunc& func)
+void BPlusTreeInner::bptree_access(size_t n, AccessFunc func)
 {
     size_t child_ndx;
     size_t child_offset;
@@ -262,7 +262,7 @@ void BPlusTreeInner::bptree_access(size_t n, AccessFunc& func)
     }
 }
 
-ref_type BPlusTreeInner::bptree_insert(size_t ndx, State& state, InsertFunc& func)
+ref_type BPlusTreeInner::bptree_insert(size_t ndx, State& state, InsertFunc func)
 {
     size_t child_ndx;
     size_t child_offset;
@@ -313,7 +313,7 @@ ref_type BPlusTreeInner::bptree_insert(size_t ndx, State& state, InsertFunc& fun
     return insert_child(child_ndx, new_sibling_ref, state);
 }
 
-size_t BPlusTreeInner::bptree_erase(size_t n, EraseFunc& func)
+size_t BPlusTreeInner::bptree_erase(size_t n, EraseFunc func)
 {
     ensure_offsets();
 
@@ -419,7 +419,7 @@ size_t BPlusTreeInner::bptree_erase(size_t n, EraseFunc& func)
     return num_children;
 }
 
-bool BPlusTreeInner::bptree_traverse(TraverseFunc& func)
+bool BPlusTreeInner::bptree_traverse(TraverseFunc func)
 {
     size_t sz = get_node_size();
     for (size_t i = 0; i < sz; i++) {
@@ -709,7 +709,7 @@ void BPlusTreeBase::replace_root(std::unique_ptr<BPlusTreeNode> new_root)
     m_root = std::move(new_root);
 }
 
-void BPlusTreeBase::bptree_insert(size_t n, BPlusTreeNode::InsertFunc& func)
+void BPlusTreeBase::bptree_insert(size_t n, BPlusTreeNode::InsertFunc func)
 {
     size_t bptree_size = m_root->get_tree_size();
     if (n == bptree_size) {
@@ -735,7 +735,7 @@ void BPlusTreeBase::bptree_insert(size_t n, BPlusTreeNode::InsertFunc& func)
     }
 }
 
-void BPlusTreeBase::bptree_erase(size_t n, BPlusTreeNode::EraseFunc& func)
+void BPlusTreeBase::bptree_erase(size_t n, BPlusTreeNode::EraseFunc func)
 {
     size_t root_size = m_root->bptree_erase(n, func);
     while (!m_root->is_leaf() && root_size == 1) {

--- a/src/realm/cluster.cpp
+++ b/src/realm/cluster.cpp
@@ -1932,9 +1932,7 @@ void ClusterTree::enumerate_string_column(ColKey col_key)
         return false; // Continue
     };
 
-    auto upgrade = [col_key, &keys](Cluster* cluster) {
-        cluster->upgrade_string_to_enum(col_key, keys);
-    };
+    auto upgrade = [col_key, &keys](Cluster* cluster) { cluster->upgrade_string_to_enum(col_key, keys); };
 
     // Populate 'keys' array
     traverse(collect_strings);

--- a/src/realm/cluster_tree.hpp
+++ b/src/realm/cluster_tree.hpp
@@ -34,7 +34,6 @@ public:
     static MemRef create_empty_cluster(Allocator& alloc);
 
     ClusterTree(ClusterTree&&) = default;
-    ClusterTree& operator=(ClusterTree&&) = default;
 
     // Disable copying, this is not allowed.
     ClusterTree& operator=(const ClusterTree&) = delete;

--- a/src/realm/cluster_tree.hpp
+++ b/src/realm/cluster_tree.hpp
@@ -20,6 +20,7 @@
 #define REALM_CLUSTER_TREE_HPP
 
 #include <realm/obj.hpp>
+#include <realm/util/function_ref.hpp>
 
 namespace realm {
 
@@ -27,8 +28,8 @@ class ClusterTree {
 public:
     class ConstIterator;
     class Iterator;
-    using TraverseFunction = std::function<bool(const Cluster*)>;
-    using UpdateFunction = std::function<void(Cluster*)>;
+    using TraverseFunction = util::FunctionRef<bool(const Cluster*)>;
+    using UpdateFunction = util::FunctionRef<void(Cluster*)>;
 
     ClusterTree(Table* owner, Allocator& alloc);
     static MemRef create_empty_cluster(Allocator& alloc);
@@ -139,9 +140,9 @@ public:
     bool get_leaf(ObjKey key, ClusterNode::IteratorState& state) const noexcept;
     // Visit all leaves and call the supplied function. Stop when function returns true.
     // Not allowed to modify the tree
-    bool traverse(TraverseFunction& func) const;
+    bool traverse(TraverseFunction func) const;
     // Visit all leaves and call the supplied function. The function can modify the leaf.
-    void update(UpdateFunction& func);
+    void update(UpdateFunction func);
 
     void enumerate_string_column(ColKey col_key);
     void dump_objects()

--- a/src/realm/column_binary.cpp
+++ b/src/realm/column_binary.cpp
@@ -34,7 +34,7 @@ BinaryData BinaryColumn::get_at(size_t ndx, size_t& pos) const noexcept
     else {
         BinaryData value;
 
-        BPlusTreeNode::AccessFunc func = [&value, &pos](BPlusTreeNode* node, size_t ndx_in_leaf) {
+        auto func = [&value, &pos](BPlusTreeNode* node, size_t ndx_in_leaf) {
             LeafNode* leaf = static_cast<LeafNode*>(node);
             value = leaf->get_at(ndx_in_leaf, pos);
         };

--- a/src/realm/query.cpp
+++ b/src/realm/query.cpp
@@ -900,8 +900,7 @@ R Query::aggregate(ColKey column_key, size_t* resultcount, ObjKey* return_ndx) c
             auto node = root_node();
             bool nullable = m_table->is_nullable(column_key);
 
-            using TRV = ClusterTree::TraverseFunction;
-            TRV f = [column_key, nullable, &leaf, &node, &st, this](const Cluster* cluster) {
+            auto f = [column_key, nullable, &leaf, &node, &st, this](const Cluster* cluster) {
                 size_t e = cluster->node_size();
                 node->set_cluster(cluster);
                 cluster->init_leaf(column_key, &leaf);
@@ -1236,7 +1235,7 @@ ObjKey Query::find()
     else {
         auto node = root_node();
         ObjKey key;
-        ClusterTree::TraverseFunction f = [&node, &key](const Cluster* cluster) {
+        auto f = [&node, &key](const Cluster* cluster) {
             size_t end = cluster->node_size();
             node->set_cluster(cluster);
             size_t res = node->find_first(0, end);
@@ -1279,7 +1278,7 @@ void Query::find_all(ConstTableView& ret, size_t begin, size_t end, size_t limit
         if (!has_conditions()) {
             KeyColumn* refs = ret.m_key_values;
 
-            ClusterTree::TraverseFunction f = [&begin, &end, &limit, refs](const Cluster* cluster) {
+            auto f = [&begin, &end, &limit, refs](const Cluster* cluster) {
                 size_t e = cluster->node_size();
                 if (begin < e) {
                     if (e > end) {
@@ -1307,7 +1306,7 @@ void Query::find_all(ConstTableView& ret, size_t begin, size_t end, size_t limit
             auto node = root_node();
             QueryState<int64_t> st(act_FindAll, ret.m_key_values, limit);
 
-            ClusterTree::TraverseFunction f = [&begin, &end, &node, &st, this](const Cluster* cluster) {
+            auto f = [&begin, &end, &node, &st, this](const Cluster* cluster) {
                 size_t e = cluster->node_size();
                 if (begin < e) {
                     if (e > end) {
@@ -1376,7 +1375,7 @@ size_t Query::do_count(size_t limit) const
         auto node = root_node();
         QueryState<int64_t> st(act_Count, limit);
 
-        ClusterTree::TraverseFunction f = [&node, &st, this](const Cluster* cluster) {
+        auto f = [&node, &st, this](const Cluster* cluster) {
             size_t e = cluster->node_size();
             node->set_cluster(cluster);
             st.m_key_offset = cluster->get_offset();

--- a/src/realm/sort_descriptor.cpp
+++ b/src/realm/sort_descriptor.cpp
@@ -466,7 +466,7 @@ void IncludeDescriptor::append(const IncludeDescriptor& other)
 
 void IncludeDescriptor::report_included_backlinks(
     const Table* origin, ObjKey obj,
-    std::function<void(const Table*, const std::unordered_set<ObjKey>&)> reporter) const
+    util::FunctionRef<void(const Table*, const std::unordered_set<ObjKey>&)> reporter) const
 {
     REALM_ASSERT_DEBUG(origin);
     REALM_ASSERT_DEBUG(obj);

--- a/src/realm/sort_descriptor.hpp
+++ b/src/realm/sort_descriptor.hpp
@@ -265,7 +265,7 @@ public:
     void append(const IncludeDescriptor& other);
     void
     report_included_backlinks(const Table* origin, ObjKey object,
-                              std::function<void(const Table*, const std::unordered_set<ObjKey>&)> reporter) const;
+                              util::FunctionRef<void(const Table*, const std::unordered_set<ObjKey>&)> reporter) const;
 
     Sorter sorter(Table const&, const IndexPairs&) const override
     {

--- a/src/realm/sort_descriptor.hpp
+++ b/src/realm/sort_descriptor.hpp
@@ -263,9 +263,9 @@ public:
         return DescriptorType::Include;
     }
     void append(const IncludeDescriptor& other);
-    void
-    report_included_backlinks(const Table* origin, ObjKey object,
-                              util::FunctionRef<void(const Table*, const std::unordered_set<ObjKey>&)> reporter) const;
+    void report_included_backlinks(
+        const Table* origin, ObjKey object,
+        util::FunctionRef<void(const Table*, const std::unordered_set<ObjKey>&)> reporter) const;
 
     Sorter sorter(Table const&, const IndexPairs&) const override
     {

--- a/src/realm/table.cpp
+++ b/src/realm/table.cpp
@@ -2999,8 +2999,7 @@ void Table::change_nullability(ColKey key_from, ColKey key_to, bool throw_on_nul
 {
     Allocator& allocator = this->get_alloc();
     bool from_nullability = is_nullable(key_from);
-    auto func = [key_from, key_to, throw_on_null, from_nullability,
-                                        &allocator](Cluster* cluster) {
+    auto func = [key_from, key_to, throw_on_null, from_nullability, &allocator](Cluster* cluster) {
         size_t sz = cluster->node_size();
 
         typename ColumnTypeTraits<F>::cluster_leaf_type from_arr(allocator);
@@ -3032,8 +3031,7 @@ void Table::change_nullability_list(ColKey key_from, ColKey key_to, bool throw_o
 {
     Allocator& allocator = this->get_alloc();
     bool from_nullability = is_nullable(key_from);
-    auto func = [key_from, key_to, throw_on_null, from_nullability,
-                                        &allocator](Cluster* cluster) {
+    auto func = [key_from, key_to, throw_on_null, from_nullability, &allocator](Cluster* cluster) {
         size_t sz = cluster->node_size();
 
         ArrayInteger from_arr(allocator);

--- a/src/realm/table.hpp
+++ b/src/realm/table.hpp
@@ -27,6 +27,7 @@
 #include <mutex>
 
 #include <realm/util/features.h>
+#include <realm/util/function_ref.hpp>
 #include <realm/util/thread.hpp>
 #include <realm/table_ref.hpp>
 #include <realm/list.hpp>
@@ -314,7 +315,7 @@ public:
         return m_clusters.dump_objects();
     }
 
-    bool traverse_clusters(ClusterTree::TraverseFunction& func) const
+    bool traverse_clusters(ClusterTree::TraverseFunction func) const
     {
         return m_clusters.traverse(func);
     }
@@ -712,14 +713,14 @@ private:
     void populate_search_index(ColKey col_key);
 
     // Migration support
-    void migrate_column_info(std::function<void()>);
-    void migrate_indexes(std::function<void()>);
-    void migrate_subspec(std::function<void()>);
-    void convert_links_from_ndx_to_key(std::function<void()>);
+    void migrate_column_info(util::FunctionRef<void()>);
+    void migrate_indexes(util::FunctionRef<void()>);
+    void migrate_subspec(util::FunctionRef<void()>);
+    void convert_links_from_ndx_to_key(util::FunctionRef<void()>);
     ref_type get_oid_column_ref() const;
-    void create_columns(std::function<void()>);
-    void migrate_objects(std::function<void()>);
-    void migrate_links(std::function<void()>);
+    void create_columns(util::FunctionRef<void()>);
+    void migrate_objects(util::FunctionRef<void()>);
+    void migrate_links(util::FunctionRef<void()>);
     void finalize_migration();
 
     /// Disable copying assignment.

--- a/src/realm/table_tpl.hpp
+++ b/src/realm/table_tpl.hpp
@@ -33,7 +33,7 @@ R Table::aggregate(ColKey column_key, T value, size_t* resultcount, ObjKey* retu
     QueryState<ResultType> st(action);
     LeafType leaf(get_alloc());
 
-    ClusterTree::TraverseFunction f = [value, &leaf, column_key, &st, nullable](const Cluster* cluster) {
+    auto f = [value, &leaf, column_key, &st, nullable](const Cluster* cluster) {
         // direct aggregate on the leaf
         cluster->init_leaf(column_key, &leaf);
         Aggregate<action, T> aggr(leaf, nullable);

--- a/src/realm/util/file.hpp
+++ b/src/realm/util/file.hpp
@@ -43,9 +43,10 @@ namespace std {
 #endif
 
 #include <realm/utilities.hpp>
+#include <realm/util/assert.hpp>
 #include <realm/util/backtrace.hpp>
 #include <realm/util/features.h>
-#include <realm/util/assert.hpp>
+#include <realm/util/function_ref.hpp>
 #include <realm/util/safe_int_ops.hpp>
 
 
@@ -526,7 +527,7 @@ public:
     /// string is interpreted as a relative path.
     static std::string resolve(const std::string& path, const std::string& base_dir);
 
-    using ForEachHandler = std::function<bool(const std::string& file, const std::string& dir)>;
+    using ForEachHandler = util::FunctionRef<bool(const std::string& file, const std::string& dir)>;
 
     /// Scan the specified directory recursivle, and report each file
     /// (nondirectory entry) via the specified handler.

--- a/src/realm/util/function_ref.hpp
+++ b/src/realm/util/function_ref.hpp
@@ -44,10 +44,17 @@ public:
     constexpr FunctionRef() noexcept = delete;
 
     // FunctionRef is copyable and moveable.
+#if defined(__GNUC__) && __GNUC__ == 4 && __GNUC_MINOR__ <= 9 && !defined(__clang__)
+    FunctionRef(FunctionRef<Return(Args...)> const&) noexcept = default;
+    FunctionRef<Return(Args...)>& operator=(const FunctionRef<Return(Args...)>&) noexcept = default;
+    FunctionRef(FunctionRef<Return(Args...)>&&) noexcept = default;
+    FunctionRef<Return(Args...)>& operator=(FunctionRef<Return(Args...)>&&) noexcept = default;
+#else
     constexpr FunctionRef(FunctionRef<Return(Args...)> const&) noexcept = default;
     constexpr FunctionRef<Return(Args...)>& operator=(const FunctionRef<Return(Args...)>&) noexcept = default;
     constexpr FunctionRef(FunctionRef<Return(Args...)>&&) noexcept = default;
     constexpr FunctionRef<Return(Args...)>& operator=(FunctionRef<Return(Args...)>&&) noexcept = default;
+#endif
 
     // Construct a FunctionRef which wraps the given callable.
     template <typename F>

--- a/src/realm/util/function_ref.hpp
+++ b/src/realm/util/function_ref.hpp
@@ -59,10 +59,10 @@ public:
     // Construct a FunctionRef which wraps the given callable.
     template <typename F>
     constexpr FunctionRef(F&& f) noexcept
-    : m_obj(const_cast<void*>(reinterpret_cast<const void*>(std::addressof(f))))
-    , m_callback([](void* obj, Args... args) -> Return {
-        return (*reinterpret_cast<typename std::add_pointer<F>::type>(obj))(std::forward<Args>(args)...);
-    })
+        : m_obj(const_cast<void*>(reinterpret_cast<const void*>(std::addressof(f))))
+        , m_callback([](void* obj, Args... args) -> Return {
+            return (*reinterpret_cast<typename std::add_pointer<F>::type>(obj))(std::forward<Args>(args)...);
+        })
     {
     }
 

--- a/src/realm/util/function_ref.hpp
+++ b/src/realm/util/function_ref.hpp
@@ -1,0 +1,87 @@
+/*************************************************************************
+ *
+ * Copyright 2019 Realm Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ **************************************************************************/
+
+#ifndef REALM_UTIL_FUNCTION_REF_HPP
+#define REALM_UTIL_FUNCTION_REF_HPP
+
+#include <functional>
+#include <utility>
+
+namespace realm {
+namespace util {
+
+/// A lightweight non-owning reference to a callable.
+///
+/// This type is similar to std::function, but unlike std::function holds a reference to the callable rather than
+/// making a copy of it. This means that it will never require a heap allocation, and produces significantly smaller
+/// binaries due to the template machinery being much simpler. This type should only ever be used as a function
+/// parameter that is not stored past when the function returns. All other uses (including trying to store it in a
+/// std::function) are very unlikely to be correct.
+///
+/// This implements a subset of P0792R5, which hopefully will be incorportated into a future version of the standard
+/// library.
+template <typename Signature>
+class FunctionRef;
+template <typename Return, typename... Args>
+class FunctionRef<Return(Args...)> {
+public:
+    // A FunctionRef is never empty, and so cannot be default-constructed.
+    constexpr FunctionRef() noexcept = delete;
+
+    // FunctionRef is copyable and moveable.
+    constexpr FunctionRef(FunctionRef<Return(Args...)> const&) noexcept = default;
+    constexpr FunctionRef<Return(Args...)>& operator=(const FunctionRef<Return(Args...)>&) noexcept = default;
+    constexpr FunctionRef(FunctionRef<Return(Args...)>&&) noexcept = default;
+    constexpr FunctionRef<Return(Args...)>& operator=(FunctionRef<Return(Args...)>&&) noexcept = default;
+
+    // Construct a FunctionRef which wraps the given callable.
+    template <typename F>
+    constexpr FunctionRef(F&& f) noexcept
+    : m_obj(const_cast<void*>(reinterpret_cast<const void*>(std::addressof(f))))
+    , m_callback([](void* obj, Args... args) -> Return {
+        return (*reinterpret_cast<typename std::add_pointer<F>::type>(obj))(std::forward<Args>(args)...);
+    })
+    {
+    }
+
+    constexpr void swap(FunctionRef<Return(Args...)>& rhs) noexcept
+    {
+        std::swap(m_obj, rhs.m_obj);
+        std::swap(m_callback, rhs.m_callback);
+    }
+
+    Return operator()(Args... args) const
+    {
+        return m_callback(m_obj, std::forward<Args>(args)...);
+    }
+
+private:
+    void* m_obj;
+    Return (*m_callback)(void*, Args...);
+};
+
+template <typename R, typename... Args>
+constexpr void swap(FunctionRef<R(Args...)>& lhs, FunctionRef<R(Args...)>& rhs) noexcept
+{
+    lhs.swap(rhs);
+}
+
+} // namespace util
+} // namespace realm
+
+#endif

--- a/test/test_lang_bind_helper.cpp
+++ b/test/test_lang_bind_helper.cpp
@@ -1288,7 +1288,7 @@ TEST(LangBindHelper_AdvanceReadTransact_CascadeRemove_ColumnLink)
     ObjKey target_key0, target_key1;
     ConstObj target_obj0, target_obj1;
 
-    auto perform_change = [&](std::function<void(Table&)> func) {
+    auto perform_change = [&](util::FunctionRef<void(Table&)> func) {
         // Ensure there are two rows in each table, with each row in `origin`
         // pointing to the corresponding row in `target`
         {
@@ -1378,7 +1378,7 @@ TEST(LangBindHelper_AdvanceReadTransact_CascadeRemove_ColumnLinkList)
 
     ConstRow target_row_0, target_row_1;
 
-    auto perform_change = [&](std::function<void(Table&)> func) {
+    auto perform_change = [&](util::FunctionRef<void(Table&)> func) {
         // Ensure there are two rows in each table, with the first row in `origin`
         // linking to the first row in `target`, and the second row in `origin`
         // linking to both rows in `target`
@@ -1439,7 +1439,7 @@ TEST(LangBindHelper_AdvanceReadTransact_CascadeRemove_ColumnLinkList)
     ObjKey target_key0, target_key1;
     ConstObj target_obj0, target_obj1;
 
-    auto perform_change = [&](std::function<void(Table&)> func) {
+    auto perform_change = [&](util::FunctionRef<void(Table&)> func) {
         // Ensure there are two rows in each table, with each row in `origin`
         // pointing to the corresponding row in `target`
         {

--- a/test/test_query_big.cpp
+++ b/test/test_query_big.cpp
@@ -443,8 +443,8 @@ TEST(Query_TableInitialization)
 
     enum class Mode { Direct, Link, LinkList };
 
-    // note: using std::function<> rather than auto&& here for the sake of compilation speed
-    auto test_query_expression = [&](std::function<Table&()> get_table, Mode mode) {
+    // note: using FunctionRef rather than auto&& here for the sake of compilation speed
+    auto test_query_expression = [&](util::FunctionRef<Table&()> get_table, Mode mode) {
         auto test_operator = [&](auto&& op, auto&& column, auto&& v) {
             if (mode != Mode::LinkList)
                 helper([&](Query&, auto&& test) { test(op(column(), column())); });

--- a/test/test_table.cpp
+++ b/test/test_table.cpp
@@ -3294,7 +3294,7 @@ TEST(Table_object_forward_iterator)
     }
 
     size_t tree_size = 0;
-    ClusterTree::TraverseFunction f = [&tree_size](const Cluster* cluster) {
+    auto f = [&tree_size](const Cluster* cluster) {
         tree_size += cluster->node_size();
         return false;
     };


### PR DESCRIPTION
FunctionRef is a simple type-erased function wrapper which holds a pointer to the wrapped thing rather than copying it.

This ended up not having any runtime performance benefits (at least with libc++) because in practice most of the objects wrapped in std::functions are small enough to fit in the small-function buffer and not need an extra heap allocation. However, it does knock 15% off the size of the library due to how much simpler it is than the std::function machinery and helps compile times a bit too.

_      | Compile Time | Library Size | Test Executable Size | Realm.framework
-------|--------------|--------------|----------------------|----------------
Before |         710s |      7385 KB |            18907 KB  |       9948 KB
After  |         663s |      6293 KB |            18305 KB  |       8718 KB
Change |        -6.6% |       -14.8% |             -602 KB  |       -1230 KB
Core 5 |         730s |      5998 KB |            20664 KB  |        8839 KB