### PR TITLE
Implement ClusterTree::verify()

### DIFF
--- a/src/realm/array.cpp
+++ b/src/realm/array.cpp
@@ -1759,6 +1759,23 @@ void Array::report_memory_usage_2(MemUsageHandler& handler) const
     }
 }
 
+void Array::verify() const
+{
+#ifdef REALM_DEBUG
+    REALM_ASSERT(is_attached());
+
+    REALM_ASSERT(m_width == 0 || m_width == 1 || m_width == 2 || m_width == 4 || m_width == 8 || m_width == 16 ||
+                 m_width == 32 || m_width == 64);
+
+    if (!get_parent())
+        return;
+
+    // Check that parent is set correctly
+    ref_type ref_in_parent = get_ref_from_parent();
+    REALM_ASSERT_3(ref_in_parent, ==, m_ref);
+#endif
+}
+
 
 #ifdef REALM_DEBUG
 
@@ -1771,21 +1788,6 @@ void Array::print() const
         std::cout << get(i);
     }
     std::cout << "\n";
-}
-
-void Array::verify() const
-{
-    REALM_ASSERT(is_attached());
-
-    REALM_ASSERT(m_width == 0 || m_width == 1 || m_width == 2 || m_width == 4 || m_width == 8 || m_width == 16 ||
-                 m_width == 32 || m_width == 64);
-
-    if (!get_parent())
-        return;
-
-    // Check that parent is set correctly
-    ref_type ref_in_parent = get_ref_from_parent();
-    REALM_ASSERT_3(ref_in_parent, ==, m_ref);
 }
 
 namespace {

--- a/src/realm/array.hpp
+++ b/src/realm/array.hpp
@@ -675,9 +675,10 @@ public:
 
     void stats(MemStats& stats_dest) const noexcept;
 
+    void verify() const;
+
 #ifdef REALM_DEBUG
     void print() const;
-    void verify() const;
     typedef size_t (*LeafVerifier)(MemRef, Allocator&);
     void verify_bptree(LeafVerifier) const;
     typedef void (*LeafDumper)(MemRef, Allocator&, std::ostream&, int level);

--- a/src/realm/array_backlink.cpp
+++ b/src/realm/array_backlink.cpp
@@ -215,7 +215,7 @@ void ArrayBacklink::verify() const
         }
     }
 
-    // Verify that each foward link has a corresponding backlink
+    // Verify that each forward link has a corresponding backlink
     auto verify_backlink = [&](ObjKey src, ObjKey target_key) {
         if (!target_key) {
             return;

--- a/src/realm/array_backlink.hpp
+++ b/src/realm/array_backlink.hpp
@@ -79,6 +79,7 @@ public:
     {
         Array::truncate_and_destroy_children(0);
     }
+    void verify() const;
 };
 }
 

--- a/src/realm/array_binary.cpp
+++ b/src/realm/array_binary.cpp
@@ -207,3 +207,15 @@ bool ArrayBinary::upgrade_leaf(size_t value_size)
     m_is_big = true;
     return true;
 }
+
+void ArrayBinary::verify() const
+{
+#ifdef REALM_DEBUG
+    if (!m_is_big) {
+        static_cast<ArraySmallBlobs*>(m_arr)->verify();
+    }
+    else {
+        static_cast<ArrayBigBlobs*>(m_arr)->verify();
+    }
+#endif
+}

--- a/src/realm/array_binary.hpp
+++ b/src/realm/array_binary.hpp
@@ -83,6 +83,8 @@ public:
     /// slower.
     static BinaryData get(const char* header, size_t ndx, Allocator& alloc) noexcept;
 
+    void verify() const;
+
 private:
     static constexpr size_t small_blob_max_size = 64;
 

--- a/src/realm/array_integer.cpp
+++ b/src/realm/array_integer.cpp
@@ -70,6 +70,15 @@ bool ArrayInteger::minmax(size_t from, size_t to, uint64_t maxdiff, int64_t* min
     }
 }
 
+void ArrayRef::verify() const
+{
+#ifdef REALM_DEBUG
+    Array::verify();
+    REALM_ASSERT(has_refs());
+#endif
+}
+
+
 MemRef ArrayIntNull::create_array(Type type, bool context_flag, size_t size, Allocator& alloc)
 {
     // Create an array with null value as the first element

--- a/src/realm/array_integer.hpp
+++ b/src/realm/array_integer.hpp
@@ -105,9 +105,9 @@ public:
     {
     }
 
-    void create()
+    void create(size_t sz = 0)
     {
-        ArrayInteger::create(type_HasRefs);
+        Array::create(type_HasRefs, false, sz, 0);
     }
 
     void add(ref_type value)
@@ -129,6 +129,7 @@ public:
     {
         return to_ref(Array::get(ndx));
     }
+    void verify() const;
 };
 
 class ArrayIntNull : public Array, public ArrayPayload {

--- a/src/realm/array_key.hpp
+++ b/src/realm/array_key.hpp
@@ -42,6 +42,9 @@ public:
     using Array::erase;
     using Array::clear;
     using Array::destroy;
+#ifdef REALM_DEBUG
+    using Array::verify;
+#endif
 
     ArrayKeyBase(Allocator& allocator)
         : Array(allocator)

--- a/src/realm/array_key.hpp
+++ b/src/realm/array_key.hpp
@@ -42,9 +42,7 @@ public:
     using Array::erase;
     using Array::clear;
     using Array::destroy;
-#ifdef REALM_DEBUG
     using Array::verify;
-#endif
 
     ArrayKeyBase(Allocator& allocator)
         : Array(allocator)

--- a/src/realm/array_string.cpp
+++ b/src/realm/array_string.cpp
@@ -424,3 +424,23 @@ ArrayString::Type ArrayString::upgrade_leaf(size_t value_size)
 
     return m_type;
 }
+
+void ArrayString::verify() const
+{
+#ifdef REALM_DEBUG
+    switch (m_type) {
+        case Type::small_strings:
+            static_cast<ArrayStringShort*>(m_arr)->verify();
+            break;
+        case Type::medium_strings:
+            static_cast<ArraySmallBlobs*>(m_arr)->verify();
+            break;
+        case Type::big_strings:
+            static_cast<ArrayBigBlobs*>(m_arr)->verify();
+            break;
+        case Type::enum_strings:
+            static_cast<ArrayInteger*>(m_arr)->verify();
+            break;
+    }
+#endif
+}

--- a/src/realm/array_string.hpp
+++ b/src/realm/array_string.hpp
@@ -109,6 +109,8 @@ public:
     /// slower.
     static StringData get(const char* header, size_t ndx, Allocator& alloc) noexcept;
 
+    void verify() const;
+
 private:
     static constexpr size_t small_string_max_size = 15;  // ArrayStringShort
     static constexpr size_t medium_string_max_size = 63; // ArrayStringLong

--- a/src/realm/array_timestamp.cpp
+++ b/src/realm/array_timestamp.cpp
@@ -234,4 +234,13 @@ size_t ArrayTimestamp::find_first<NotEqual>(Timestamp value, size_t begin, size_
     }
     return not_found;
 }
+
+void ArrayTimestamp::verify() const
+{
+#ifdef REALM_DEBUG
+    m_seconds.verify();
+    m_nanoseconds.verify();
+    REALM_ASSERT(m_seconds.size() == m_nanoseconds.size());
+#endif
+}
 } // namespace realm

--- a/src/realm/array_timestamp.hpp
+++ b/src/realm/array_timestamp.hpp
@@ -34,6 +34,9 @@ public:
     using Array::get_parent;
     using Array::get_ndx_in_parent;
     using Array::get_ref;
+#ifdef REALM_DEBUG
+    using Array::verify;
+#endif
 
     static Timestamp default_value(bool nullable)
     {

--- a/src/realm/array_timestamp.hpp
+++ b/src/realm/array_timestamp.hpp
@@ -34,9 +34,6 @@ public:
     using Array::get_parent;
     using Array::get_ndx_in_parent;
     using Array::get_ref;
-#ifdef REALM_DEBUG
-    using Array::verify;
-#endif
 
     static Timestamp default_value(bool nullable)
     {
@@ -105,6 +102,8 @@ public:
 
     size_t find_first(Timestamp value, size_t begin, size_t end) const noexcept;
 
+    void verify() const;
+
 private:
     ArrayIntNull m_seconds;
     ArrayInteger m_nanoseconds;
@@ -127,6 +126,7 @@ inline size_t ArrayTimestamp::find_first(Timestamp value, size_t begin, size_t e
 {
     return find_first<Equal>(value, begin, end);
 }
+
 
 template <>
 class QueryState<Timestamp> : public QueryStateBase {

--- a/src/realm/cluster.hpp
+++ b/src/realm/cluster.hpp
@@ -278,7 +278,7 @@ private:
     template <class T>
     void set_spec(T&, ColKey::Idx) const;
     template <class ArrayType>
-    void verify(ref_type ref, size_t index) const;
+    void verify(ref_type ref, size_t index, util::Optional<size_t>& sz) const;
 };
 
 }

--- a/src/realm/cluster.hpp
+++ b/src/realm/cluster.hpp
@@ -166,9 +166,6 @@ public:
     }
 
 protected:
-    friend class ArrayBacklink;
-    friend class ObjList;
-
     const ClusterTree& m_tree_top;
     ClusterKeyArray m_keys;
     uint64_t m_offset;
@@ -231,6 +228,9 @@ public:
         return size_t(key.value);
     }
 
+    const Table* get_owning_table() const;
+    ColKey get_col_key(size_t ndx_in_parent) const;
+
     void ensure_general_form() override;
     void insert_column(ColKey col) override; // Does not move columns!
     void remove_column(ColKey col) override; // Does not move columns - may leave a 'hole'
@@ -248,6 +248,7 @@ public:
     void init_leaf(ColKey col, ArrayPayload* leaf) const;
     void add_leaf(ColKey col, ref_type ref);
 
+    void verify() const;
     void dump_objects(int64_t key_offset, std::string lead) const override;
 
 private:
@@ -275,7 +276,9 @@ private:
     void do_erase_key(size_t ndx, ColKey col, CascadeState& state);
     void do_insert_key(size_t ndx, ColKey col, Mixed init_val, ObjKey origin_key);
     template <class T>
-    void set_spec(T&, ColKey::Idx);
+    void set_spec(T&, ColKey::Idx) const;
+    template <class ArrayType>
+    void verify(ref_type ref, size_t index) const;
 };
 
 }

--- a/src/realm/cluster_tree.hpp
+++ b/src/realm/cluster_tree.hpp
@@ -149,10 +149,7 @@ public:
     {
         m_root->dump_objects(0, "");
     }
-    void verify() const
-    {
-        // TODO: implement
-    }
+    void verify() const;
 
 private:
     friend class ConstObj;

--- a/src/realm/table.hpp
+++ b/src/realm/table.hpp
@@ -969,7 +969,6 @@ private:
     friend class Transaction;
     friend class Cluster;
     friend class ClusterTree;
-    friend class ArrayBacklink;
     friend class ColKeyIterator;
     friend class ConstObj;
     friend class Obj;


### PR DESCRIPTION
Currently just calls verify() on each of the columns and adds a verify() function to ArrayBacklink that checks that the backlink invariants hold.