### PR TITLE
Add Lst::find_all()

### DIFF
--- a/src/realm/bplustree.hpp
+++ b/src/realm/bplustree.hpp
@@ -522,6 +522,21 @@ public:
         return result;
     }
 
+    template <typename Func>
+    void find_all(T value, Func&& callback) const noexcept
+    {
+        auto func = [&callback, value](BPlusTreeNode* node, size_t offset) {
+            LeafNode* leaf = static_cast<LeafNode*>(node);
+            size_t i = -1, sz = leaf->size();
+            while ((i = leaf->find_first(value, i + 1, sz)) < sz) {
+                callback(i + offset);
+            }
+            return false;
+        };
+
+        m_root->bptree_traverse(func);
+    }
+
     void dump_values(std::ostream& o, int level) const
     {
         std::string indent(" ", level * 2);

--- a/src/realm/list.hpp
+++ b/src/realm/list.hpp
@@ -377,6 +377,12 @@ public:
             return not_found;
         return m_tree->find_first(value);
     }
+    template <typename Func>
+    void find_all(T value, Func&& func) const
+    {
+        if (m_valid && init_from_parent())
+            m_tree->find_all(value, std::forward<Func>(func));
+    }
     const BPlusTree<T>& get_tree() const
     {
         return *m_tree;
@@ -835,6 +841,7 @@ public:
     }
 
     using Lst<ObjKey>::find_first;
+    using Lst<ObjKey>::find_all;
 
     TableView get_sorted_view(SortDescriptor order) const;
     TableView get_sorted_view(ColKey column_key, bool ascending = true) const;

--- a/test/test_links.cpp
+++ b/test/test_links.cpp
@@ -919,6 +919,9 @@ TEST(Links_LinkList_FindByOrigin)
     CHECK_EQUAL(not_found, links->find_first(key2));
     CHECK_EQUAL(not_found, links2->find_first(key2));
 
+    links->find_all(key2, [&](size_t) { CHECK(false); });
+    links2->find_all(key2, [&](size_t) { CHECK(false); });
+
     links->add(key2);
     links->add(key1);
     links->add(key0);
@@ -930,10 +933,24 @@ TEST(Links_LinkList_FindByOrigin)
     CHECK_EQUAL(1, links2->find_first(key1));
     CHECK_EQUAL(2, links2->find_first(key0));
 
+    int calls = 0;
+    links->find_all(key2, [&](size_t i) { CHECK_EQUAL(i, 0); ++calls; });
+    CHECK_EQUAL(calls, 1);
+    calls = 0;
+    links2->find_all(key0, [&](size_t i) { CHECK_EQUAL(i, 2); ++calls; });
+    CHECK_EQUAL(calls, 1);
+
     links->remove(0);
 
     CHECK_EQUAL(not_found, links->find_first(key2));
     CHECK_EQUAL(not_found, links2->find_first(key2));
+
+    links->add(key0);
+    links->add(key0);
+
+    calls = 0;
+    links->find_all(key0, [&](size_t i) { CHECK(i >= 1); ++calls; });
+    CHECK_EQUAL(calls, 3);
 }
 
 


### PR DESCRIPTION
There's a few spots where we want to be able to efficiently find all of the indexes in a list that a value appears.