### PR TITLE
Fix a race condition in subtable accessor deletion

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,9 @@
 
 ### Fixed
 * macOS binaries were built with the incorrect deployment target (10.14 rather than 10.9). ([Cocoa #6299](https://github.com/realm/realm-cocoa/issues/6299), since 5.23.4).
+* Subtable accessors could be double-deleted if the last reference was released from a different
+  thread at the wrong time. This would typically manifest as "pthread_mutex_destroy() failed", but
+  could also result in other kinds of crashes. ([Cocoa #6333](https://github.com/realm/realm-cocoa/issues/6333)).
 
 ### Breaking changes
 * None.

--- a/src/realm/table.hpp
+++ b/src/realm/table.hpp
@@ -1270,6 +1270,7 @@ private:
 
     void bind_ptr() const noexcept;
     void unbind_ptr() const noexcept;
+    bool has_references() const noexcept;
 
     void register_view(const TableViewBase* view);
     void unregister_view(const TableViewBase* view) noexcept;
@@ -1738,6 +1739,11 @@ inline void Table::unbind_ptr() const noexcept
     else {
         delete this;
     }
+}
+
+inline bool Table::has_references() const noexcept
+{
+    return m_ref_count.load() > 0;
 }
 
 inline void Table::register_view(const TableViewBase* view)
@@ -2787,6 +2793,11 @@ public:
     static void unregister_view(Table& table, const TableViewBase* view) noexcept
     {
         table.unregister_view(view);
+    }
+
+    static bool has_references(const Table& table) noexcept
+    {
+        return table.has_references();
     }
 };
 


### PR DESCRIPTION
The following sequence of events would double-delete the Table:

1. Thread A enters SubtableColumnBase::SubtableMap::refresh_accessor_tree(), holding m_subtable_map_lock.
2. Thread B releases the last reference to a Table in that SubtableMap.
3. Thread B blocks on acquiring m_subtable_map_lock in unbind_ref().
4. Thread A reaches that Table in the iteration and acquires a strong reference (0 -> 1).
5. Thread A finishes with that Table and releases the reference (1 -> 0).
6. Thread A deletes the Table due to the refcount going to 0.
7. Thread A releases m_subtable_map_lock.
8. Thread B acquires m_subtable_map_lock.
9. Thread B rechecks the (now deleted) Table's refcount and sees 0.
10. Thread B tries to delete the already deleted Table.

Fix this by not acquiring and releasing a strong reference to the Table if the refcount is already 0.

I couldn't figure out a way to reasonable test this. [The repro case supplied by the user](https://github.com/realm/realm-cocoa/issues/6333) just does a bunch of things on a bunch of threads and crashes eventually.