### PR TITLE
Use a dispatch timer for the encrypted page reclaimer on Apple platforms

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 # NEXT RELEASE
 
 ### Enhancements
-* None.
+* Reduce the encrypted page reclaimer's impact on battery life on Apple platforms. ([PR #3461](https://github.com/realm/realm-core/pull/3461)).
 
 ### Fixed
 * macOS binaries were built with the incorrect deployment target (10.14 rather than 10.9). ([Cocoa #6299](https://github.com/realm/realm-cocoa/issues/6299), since 5.23.4).


### PR DESCRIPTION
This has two main benefits: it allows the OS to perform timer coalescing and schedule the wakeup to align with other timers, which improves battery life, and it uses the Background QOS priority, which tells the OS it should deprioritize running our task when the device is under heavy load.