### PR TITLE
"Fix" sorting float columns containing NaN

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@
 * Subtable accessors could be double-deleted if the last reference was released from a different
   thread at the wrong time. This would typically manifest as "pthread_mutex_destroy() failed", but
   could also result in other kinds of crashes. ([Cocoa #6333](https://github.com/realm/realm-cocoa/issues/6333)).
+* Sorting float or double columns containing NaN values had inconsistent results and would sometimes
+  crash due to out-of-bounds memory accesses. ([Cocoa #6357](https://github.com/realm/realm-cocoa/issues/6357)).
 
 ### Breaking changes
 * None.

--- a/test/test_table.cpp
+++ b/test/test_table.cpp
@@ -1841,6 +1841,34 @@ TEST(Table_Sorted_Query_where)
 #endif
 }
 
+TEST_TYPES(Table_SortFloat, float, double)
+{
+    Table table;
+    auto col = table.add_column(std::is_same<TEST_TYPE, float>::value ? type_Float : type_Double, "value", true);
+    table.add_empty_row(900);
+    for (size_t i = 0; i < table.size(); i += 3) {
+        table.set(col, i, static_cast<TEST_TYPE>(-500.0 + i));
+        table.set_null(col, i + 1);
+        char nan_tag[] = {char('0' + i % 10), 0};
+        table.set(col, i + 2, static_cast<TEST_TYPE>(nan(nan_tag)));
+    }
+
+    TableView sorted = table.get_sorted_view(SortDescriptor{table, {{col}}, {true}});
+    CHECK_EQUAL(table.size(), sorted.size());
+
+    // nans should appear first (because the tag is less than the tag we use for nulls),
+    // followed by nulls, folllowed by the rest of the values in ascending order
+    for (size_t i = 0; i < 300; ++i) {
+        CHECK(std::isnan(sorted.get(i).get<TEST_TYPE>(col)));
+    }
+    for (size_t i = 300; i < 600; ++i) {
+        CHECK(sorted.get(i).is_null(col));
+    }
+    for (size_t i = 600; i + i < 900; ++i) {
+        CHECK_GREATER(sorted.get(i + 1).get<TEST_TYPE>(col), sorted.get(i).get<TEST_TYPE>(col));
+    }
+}
+
 TEST(Table_Multi_Sort)
 {
     Table table;


### PR DESCRIPTION
Not handling NaN in the sort comparator results in it violating one of std::sort's preconditions (that the data have a total ordering), which with libc++'s implementation can result in out-of-bounds reads.

Fix this by generalizing the behavior for nulls (which we store as a tagged NaN) to all NaNs and using int comparisons to sort so that the NaNs are ordered.

See https://github.com/realm/realm-cocoa/issues/6357.