### PR TITLE
Fix changing primary keys in existing tables

### DIFF
--- a/src/realm/cluster.cpp
+++ b/src/realm/cluster.cpp
@@ -1575,6 +1575,7 @@ void Cluster::dump_objects(int64_t key_offset, std::string lead) const
         for (size_t j = 1; j < size(); j++) {
             if (m_tree_top.get_spec().get_column_attr(j - 1).test(col_attr_List)) {
                 std::cout << ", list";
+                continue;
             }
 
             switch (m_tree_top.get_spec().get_column_type(j - 1)) {

--- a/src/realm/group.cpp
+++ b/src/realm/group.cpp
@@ -1909,12 +1909,12 @@ void Group::verify() const
 #endif
 }
 
-void Group::validate_primary_column_uniqueness() const
+void Group::validate_primary_columns()
 {
     auto table_keys = this->get_table_keys();
     for (auto tk : table_keys) {
         auto table = get_table(tk);
-        table->validate_primary_column_uniqueness();
+        table->validate_primary_column();
     }
 }
 

--- a/src/realm/group.hpp
+++ b/src/realm/group.hpp
@@ -543,7 +543,7 @@ public:
     size_t get_used_space() const noexcept;
 
     void verify() const;
-    void validate_primary_column_uniqueness() const;
+    void validate_primary_columns();
 #ifdef REALM_DEBUG
     void print() const;
     void print_free() const;

--- a/src/realm/list.hpp
+++ b/src/realm/list.hpp
@@ -490,6 +490,7 @@ public:
     }
     virtual void set_null(size_t ndx) = 0;
     virtual void insert_null(size_t ndx) = 0;
+    virtual void insert_any(size_t ndx, Mixed val) = 0;
     virtual void resize(size_t new_size) = 0;
     virtual void remove(size_t from, size_t to) = 0;
     virtual void move(size_t from, size_t to) = 0;
@@ -533,6 +534,16 @@ public:
     void insert_null(size_t ndx) override
     {
         insert(ndx, BPlusTree<T>::default_value(m_nullable));
+    }
+
+    void insert_any(size_t ndx, Mixed val) override
+    {
+        if (val.is_null()) {
+            insert_null(ndx);
+        }
+        else {
+            insert(ndx, val.get<typename RemoveOptional<T>::type>());
+        }
     }
 
     void resize(size_t new_size) override

--- a/src/realm/obj.cpp
+++ b/src/realm/obj.cpp
@@ -1090,6 +1090,43 @@ bool Obj::remove_backlink(ColKey col_key, ObjKey old_key, CascadeState& state)
     return false;
 }
 
+void Obj::assign(const ConstObj& other, bool only_diff)
+{
+    REALM_ASSERT(get_table() == other.get_table());
+    auto cols = m_table->get_column_keys();
+    auto pk_col = m_table->get_primary_key_column();
+    for (auto col : cols) {
+        if (col != pk_col) {
+            if (col.get_attrs().test(col_attr_List)) {
+                // TODO: implement
+            }
+            else {
+                auto type = col.get_type();
+                Mixed val = other.get_any(col);
+                if (!only_diff || val != get_any(col)) {
+                    switch (type) {
+                        case col_type_String: {
+                            // Need to take copy. Values might be in same cluster
+                            std::string str{val.get_string()};
+                            this->set(col, str);
+                            break;
+                        }
+                        case col_type_Binary: {
+                            // Need to take copy. Values might be in same cluster
+                            std::string str{val.get_binary()};
+                            this->set(col, BinaryData(str));
+                            break;
+                        }
+                        default:
+                            this->set(col, val);
+                            break;
+                    }
+                }
+            }
+        }
+    }
+}
+
 
 template int64_t ConstObj::get<int64_t>(ColKey col_key) const;
 template util::Optional<int64_t> ConstObj::get<util::Optional<int64_t>>(ColKey col_key) const;

--- a/src/realm/obj.cpp
+++ b/src/realm/obj.cpp
@@ -1094,33 +1094,38 @@ void Obj::assign(const ConstObj& other, bool only_diff)
 {
     REALM_ASSERT(get_table() == other.get_table());
     auto cols = m_table->get_column_keys();
-    auto pk_col = m_table->get_primary_key_column();
     for (auto col : cols) {
-        if (col != pk_col) {
-            if (col.get_attrs().test(col_attr_List)) {
-                // TODO: implement
+        if (col.get_attrs().test(col_attr_List)) {
+            // TODO: implement
+            auto src_list = other.get_listbase_ptr(col);
+            auto dst_list = get_listbase_ptr(col);
+            auto sz = src_list->size();
+            dst_list->clear();
+            for (size_t i = 0; i < sz; i++) {
+                Mixed val = src_list->get_any(i);
+                dst_list->insert_any(i, val);
             }
-            else {
-                auto type = col.get_type();
-                Mixed val = other.get_any(col);
-                if (!only_diff || val != get_any(col)) {
-                    switch (type) {
-                        case col_type_String: {
-                            // Need to take copy. Values might be in same cluster
-                            std::string str{val.get_string()};
-                            this->set(col, str);
-                            break;
-                        }
-                        case col_type_Binary: {
-                            // Need to take copy. Values might be in same cluster
-                            std::string str{val.get_binary()};
-                            this->set(col, BinaryData(str));
-                            break;
-                        }
-                        default:
-                            this->set(col, val);
-                            break;
+        }
+        else {
+            auto type = col.get_type();
+            Mixed val = other.get_any(col);
+            if (!only_diff || val != get_any(col)) {
+                switch (type) {
+                    case col_type_String: {
+                        // Need to take copy. Values might be in same cluster
+                        std::string str{val.get_string()};
+                        this->set(col, str);
+                        break;
                     }
+                    case col_type_Binary: {
+                        // Need to take copy. Values might be in same cluster
+                        std::string str{val.get_binary()};
+                        this->set(col, BinaryData(str));
+                        break;
+                    }
+                    default:
+                        this->set(col, val);
+                        break;
                 }
             }
         }

--- a/src/realm/obj.hpp
+++ b/src/realm/obj.hpp
@@ -252,6 +252,8 @@ public:
     template <class Head, class... Tail>
     Obj& set_all(Head v, Tail... tail);
 
+    void assign(const ConstObj& other, bool only_diff = true);
+
     Obj get_linked_object(ColKey link_col_key);
 
     template <typename U>

--- a/src/realm/table.hpp
+++ b/src/realm/table.hpp
@@ -755,6 +755,7 @@ private:
 
     void set_opposite_column(ColKey col_key, TableKey opposite_table, ColKey opposite_column);
     void do_set_primary_key_column(ColKey col_key);
+    void validate_column_is_unique(ColKey col_key) const;
 
     ObjKey get_next_key();
     /// Some Object IDs are generated as a tuple of the client_file_ident and a

--- a/src/realm/table.hpp
+++ b/src/realm/table.hpp
@@ -133,7 +133,7 @@ public:
     // Primary key columns
     ColKey get_primary_key_column() const;
     void set_primary_key_column(ColKey col);
-    void validate_primary_column_uniqueness() const;
+    void validate_primary_column();
 
     //@{
     /// Convenience functions for manipulating the dynamic table type.
@@ -756,6 +756,7 @@ private:
     void set_opposite_column(ColKey col_key, TableKey opposite_table, ColKey opposite_column);
     void do_set_primary_key_column(ColKey col_key);
     void validate_column_is_unique(ColKey col_key) const;
+    void rebuild_table_with_pk_column();
 
     ObjKey get_next_key();
     /// Some Object IDs are generated as a tuple of the client_file_ident and a

--- a/src/realm/table.hpp
+++ b/src/realm/table.hpp
@@ -310,10 +310,7 @@ public:
         return m_clusters.get_ndx(key);
     }
 
-    void dump_objects()
-    {
-        return m_clusters.dump_objects();
-    }
+    void dump_objects();
 
     bool traverse_clusters(ClusterTree::TraverseFunction func) const
     {

--- a/test/test_group.cpp
+++ b/test/test_group.cpp
@@ -2117,4 +2117,20 @@ TEST(Group_StringPrimaryKeyCol)
     CHECK_NOT(table->has_search_index(col2));
 }
 
+TEST(Group_SetColumnWithDuplicateValuesToPrimaryKey)
+{
+    Group g;
+    TableRef table = g.add_table("table");
+    ColKey string_col = table->add_column(type_String, "string");
+    ColKey int_col = table->add_column(type_Int, "int");
+
+    std::vector<ObjKey> keys;
+    table->create_objects(2, keys);
+
+    CHECK_THROW(table->set_primary_key_column(string_col), DuplicatePrimaryKeyValueException);
+    CHECK_EQUAL(table->get_primary_key_column(), ColKey());
+    CHECK_THROW(table->set_primary_key_column(int_col), DuplicatePrimaryKeyValueException);
+    CHECK_EQUAL(table->get_primary_key_column(), ColKey());
+}
+
 #endif // TEST_GROUP

--- a/test/test_group.cpp
+++ b/test/test_group.cpp
@@ -2085,7 +2085,8 @@ TEST(Group_StringPrimaryKeyCol)
     k = table->find_first(col2, StringData("FooBar"));
     CHECK_EQUAL(k, obj2.get_key());
     k = table->find_first(col2, StringData("first"));
-    CHECK_EQUAL(k, obj1.get_key());
+    CHECK_NOT(obj1.is_valid());
+    CHECK_EQUAL(table->get_object(k).get<String>(col1), "Exactly!");
 
     // Changing PK should remove any existing index from the new PK
     table->add_search_index(primary_key_column);


### PR DESCRIPTION
Don't add indexes to string columns when setting them as the primary key (and remove any existing index) to match the behavior of creating new tables with string PKs.

Don't use ObjectIDs to validate PK uniqueness for non-indexed columns as changing the PK makes it so that the PK and object keys are no longer connected. This probably isn't otherwise an issue because ObjectIDs are only used for synced realms, and the PK can't be changed on synced tables anyway.