### PR TITLE
explicitly check for races in do_sync()

### DIFF
--- a/src/realm/table_view.cpp
+++ b/src/realm/table_view.cpp
@@ -554,6 +554,7 @@ void ConstTableView::sort(SortDescriptor order)
 
 void ConstTableView::do_sync()
 {
+    CriticalSection cs(m_race_detector);
     // This TableView can be "born" from 4 different sources:
     // - LinkView
     // - Query::find_all()

--- a/src/realm/table_view.hpp
+++ b/src/realm/table_view.hpp
@@ -389,6 +389,7 @@ private:
     ObjKey find_first_integer(ColKey column_key, int64_t value) const;
     template <class oper>
     Timestamp minmax_timestamp(ColKey column_key, ObjKey* return_key) const;
+    RaceDetector m_race_detector;
 
     friend class Table;
     friend class ConstObj;


### PR DESCRIPTION
Add explicit race detection in the heaviest part of TableView (the do_sync method).