### PR TITLE
Fix incorrect query results for NOT on a LinkList

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,8 +4,7 @@
 * None.
 
 ### Fixed
-* <How to hit and notice issue? what was the impact?> ([#????](https://github.com/realm/realm-core/issues/????), since v?.?.?)
-* None.
+* A NOT query on a LinkList would incorrectly match rows which have a row index one less than a correctly matching row which appeared earlier in the LinkList. ([Cocoa #6289](https://github.com/realm/realm-cocoa/issues/6289), since 0.87.6).
  
 ### Breaking changes
 * None.

--- a/src/realm/query_engine.cpp
+++ b/src/realm/query_engine.cpp
@@ -590,7 +590,7 @@ size_t NotNode::find_first_overlap_lower(size_t start, size_t end)
         result = m_first_in_known_range;
     }
     update_known(start, m_known_range_end, result);
-    return result;
+    return result < end ? result : not_found;
 }
 
 size_t NotNode::find_first_overlap_upper(size_t start, size_t end)

--- a/test/test_query.cpp
+++ b/test/test_query.cpp
@@ -12294,5 +12294,26 @@ TEST(Query_LinksWithIndex)
     CHECK_EQUAL(q.find(), 4);
 }
 
+TEST(Query_NotImmediatelyBeforeKnownRange)
+{
+    Group g;
+    TableRef parent = g.add_table("parent");
+    TableRef child = g.add_table("child");
+    parent->add_column_link(type_LinkList, "list", *child);
+    child->add_column(type_String, "value");
+    child->add_search_index(0);
+
+    parent->add_empty_row();
+    child->add_empty_row(2);
+    child->set_string_unique(0, 0, "a");
+    child->set_string_unique(0, 1, "b");
+    auto list = parent->get_linklist(0, 0);
+    list->insert(0, 0);
+    list->insert(0, 1);
+
+    Query q = child->where(list).Not().equal(0, "a");
+    CHECK_EQUAL(q.count(), 1);
+}
+
 
 #endif // TEST_QUERY


### PR DESCRIPTION
NOT queries cache information about what range of rows has already been checked, and when checking a range of rows immediately before the cached range which does not contain any matches, find_first() would return the first row within the cached range which matched. Since this wasn't not_found, this was considered a match even though it wasn't in the range [start, end).

See https://github.com/realm/realm-cocoa/issues/6289.