### PR TITLE
Fix <filesystem> error on latest Visual Studio

### DIFF
--- a/src/realm/util/file.hpp
+++ b/src/realm/util/file.hpp
@@ -33,6 +33,7 @@
 #endif
 
 #if defined(_MSC_VER) && _MSC_VER >= 1900 // compiling with at least Visual Studio 2015
+#define _SILENCE_EXPERIMENTAL_FILESYSTEM_DEPRECATION_WARNING // switch to <filesystem> once we switch to C++17
 #include <experimental/filesystem>
 namespace std {
     namespace filesystem = std::experimental::filesystem::v1;

--- a/test/test_thread.cpp
+++ b/test/test_thread.cpp
@@ -543,7 +543,7 @@ TEST(Thread_MutexTryLock)
     // basic same thread try_lock
     CHECK(m.try_lock());
     CHECK(m.owns_lock());
-    CHECK_THROW(m.try_lock(), std::system_error); // already locked: Resource deadlock avoided
+    CHECK_THROW(static_cast<void>(m.try_lock()), std::system_error); // already locked: Resource deadlock avoided
     m.unlock();
 
     bool init_done = false;


### PR DESCRIPTION
The latest Visual Studio 2019 comes with the implementation of the final `std::filesystem` draft and so the `<filesystem>` include is present. The `<experimental/filesystem>` include is now deprecated and we must silence the deprecation notice. We should migrate to `<filesystem>` once we switch to C++ 17.