### PR TITLE
Make TableRef's constructors explicitly noexcept

### DIFF
--- a/src/realm/table_ref.cpp
+++ b/src/realm/table_ref.cpp
@@ -31,7 +31,7 @@ TableRef TableRef::unsafe_create(Table* t_ptr)
     return TableRef(t_ptr, t_ptr ? t_ptr->get_instance_version() : 0);
 }
 
-ConstTableRef::operator bool() const
+ConstTableRef::operator bool() const noexcept
 {
     return m_table != nullptr && m_table->get_instance_version() == m_instance_version;
 }

--- a/src/realm/table_ref.hpp
+++ b/src/realm/table_ref.hpp
@@ -20,7 +20,6 @@
 #define REALM_TABLE_REF_HPP
 
 #include <cstddef>
-#include <algorithm>
 #include <ostream>
 namespace realm {
 
@@ -30,17 +29,13 @@ class TableRef;
 
 class ConstTableRef {
 public:
-    ~ConstTableRef()
-    {
-    }
-    ConstTableRef(const TableRef& other);
-    ConstTableRef(std::nullptr_t) {}
+    ConstTableRef() noexcept {}
+    ConstTableRef(std::nullptr_t) noexcept {}
+    ConstTableRef(const TableRef& other) noexcept;
+
     const Table* operator->() const;
     const Table& operator*() const;
-    ConstTableRef()
-    {
-    }
-    operator bool() const;
+    operator bool() const noexcept;
     const Table* unchecked_ptr() const
     {
         return m_table;
@@ -80,16 +75,20 @@ protected:
 
 class TableRef : public ConstTableRef {
 public:
+    TableRef() noexcept
+        : ConstTableRef()
+    {
+    }
+    TableRef(std::nullptr_t) noexcept
+        : ConstTableRef()
+    {
+    }
+
     Table* operator->() const;
     Table& operator*() const;
     Table* unchecked_ptr() const
     {
         return m_table;
-    }
-    TableRef(std::nullptr_t) {}
-    TableRef()
-        : ConstTableRef()
-    {
     }
     static TableRef unsafe_create(Table* t_ptr);
 
@@ -105,7 +104,7 @@ private:
 };
 
 
-inline ConstTableRef::ConstTableRef(const TableRef& other)
+inline ConstTableRef::ConstTableRef(const TableRef& other) noexcept
     : m_table(other.m_table)
     , m_instance_version(other.m_instance_version)
 {

--- a/test/test_group.cpp
+++ b/test/test_group.cpp
@@ -400,8 +400,8 @@ TEST(Group_AddTable)
 TEST(Group_AddTable2)
 {
     Group group;
-    TableRef a = group.add_table("a");
-    TableRef b = group.add_table("b");
+    group.add_table("a");
+    group.add_table("b");
     CHECK_EQUAL(2, group.size());
     CHECK_THROW(group.add_table("b"), TableNameInUse);
     CHECK_EQUAL(2, group.size());

--- a/test/test_lang_bind_helper.cpp
+++ b/test/test_lang_bind_helper.cpp
@@ -146,7 +146,7 @@ TEST(Transactions_ConcurrentFrozenTableGetByName)
         for (int j = 0; j < 3000; ++j) {
             std::string name = "Table" + to_string(j);
             table_names[j] = name;
-            auto table = wt->add_table(name);
+            wt->add_table(name);
         }
         wt->commit_and_continue_as_read();
         frozen = wt->freeze();
@@ -154,7 +154,7 @@ TEST(Transactions_ConcurrentFrozenTableGetByName)
     auto runner = [&](int first, int last) {
         millisleep(1);
         for (int j = first; j < last; ++j) {
-            auto table = frozen->get_table(table_names[j]);
+            frozen->get_table(table_names[j]);
         }
     };
     std::thread threads[1000];
@@ -411,7 +411,7 @@ TEST(LangBindHelper_AdvanceReadTransact_Basics)
     // Try to advance after a propper rollback
     {
         WriteTransaction wt(sg_w);
-        TableRef foo_w = wt.add_table("bad");
+        wt.add_table("bad");
         // Implicit rollback
     }
     rt->advance_read();
@@ -825,7 +825,7 @@ TEST(LangBindHelper_AdvanceReadTransact_LinkColumnInNewTable)
     DBRef sg_w = DB::create(hist, DBOptions(crypt_key()));
     {
         WriteTransaction wt(sg_w);
-        TableRef a = wt.get_or_add_table("a");
+        wt.get_or_add_table("a");
         wt.commit();
     }
 
@@ -839,7 +839,9 @@ TEST(LangBindHelper_AdvanceReadTransact_LinkColumnInNewTable)
         b_w->add_column_link(type_Link, "foo", *a_w);
         wt.commit();
     }
+
     rt->advance_read();
+    CHECK(a_r);
     rt->verify();
 }
 
@@ -1184,7 +1186,6 @@ TEST(LangBindHelper_ConcurrentLinkViewDeletes)
     deleter.start([&] { deleter_thread(queue); });
     for (int i = 0; i < max_refs; ++i) {
         TableRef origin = rt->get_table("origin");
-        TableRef target = rt->get_table("target");
         int ndx = random.draw_int_mod(table_size);
         Obj o = origin->get_object(o_keys[ndx]);
         LnkLstPtr lw = o.get_linklist_ptr(ck);
@@ -1235,6 +1236,8 @@ TEST(LangBindHelper_AdvanceReadTransact_InsertLink)
         wt.commit();
     }
     rt->advance_read();
+    CHECK(origin);
+    CHECK(target);
     rt->verify();
 }
 
@@ -2277,7 +2280,7 @@ TEST(LangBindHelper_RollbackAndContinueAsRead)
         {
             // rollback of group level table insertion
             group->promote_to_write();
-            TableRef o = group->get_or_add_table("nullermand");
+            group->get_or_add_table("nullermand");
             TableRef o2 = group->get_table("nullermand");
             REALM_ASSERT(o2);
             group->rollback_and_continue_as_read();
@@ -2324,7 +2327,7 @@ TEST(LangBindHelper_RollbackAndContinueAsReadGroupLevelTableRemoval)
     auto reader = sg->start_read();
     {
         reader->promote_to_write();
-        TableRef origin = reader->get_or_add_table("a_table");
+        reader->get_or_add_table("a_table");
         reader->commit_and_continue_as_read();
     }
     reader->verify();
@@ -2469,6 +2472,8 @@ TEST(LangBindHelper_RollbackTableRemove)
         CHECK_EQUAL(2, group->size());
         TableRef alpha = group->get_table("alpha");
         TableRef beta = group->get_table("beta");
+        CHECK(alpha);
+        CHECK(beta);
         group->remove_table("beta");
         CHECK_NOT(group->has_table("beta"));
         group->rollback_and_continue_as_read();
@@ -2524,7 +2529,7 @@ TEST(LangBindHelper_ContinuousTransactions_RollbackTableRemoval)
     DBRef sg = DB::create(*hist, DBOptions(crypt_key()));
     auto group = sg->start_read();
     group->promote_to_write();
-    TableRef filler = group->get_or_add_table("filler");
+    group->get_or_add_table("filler");
     TableRef table = group->get_or_add_table("table");
     auto col = table->add_column(type_Int, "i");
     Obj o = table->create_object();
@@ -3018,7 +3023,7 @@ TEST(LangBindHelper_ImplicitTransactions_MultipleTrackers)
         auto table_b = wt.add_table("B");
         table_b->add_column(type_Int, "bussemand");
         table_b->create_object().set_all(99);
-        auto table_c = wt.add_table("C");
+        wt.add_table("C");
         wt.commit();
     }
     // FIXME: Use separate arrays for reader and writer threads for safety and readability.
@@ -3234,7 +3239,6 @@ TEST(LangBindHelper_ImplicitTransactions_ContinuedUseOfLinkList)
     group_w->verify();
 
     group->advance_read();
-    ConstTableRef table = group->get_table("table");
     auto link_list = obj.get_linklist(col);
     CHECK_EQUAL(1, link_list.size());
     group->verify();
@@ -5063,7 +5067,6 @@ TEST_IF(LangBindHelper_HandoverFuzzyTest, TEST_DURATION > 0)
 
     auto rt = sg->start_read();
     // Create and export query
-    TableRef owner = rt->get_table("Owner");
     TableRef dog = rt->get_table("Dog");
 
     realm::Query query = dog->link(c3).column<String>(c0) == "owner" + to_string(rand() % numberOfOwner);
@@ -5163,7 +5166,6 @@ TEST(LangBindHelper_TableViewClear)
     {
         tr->promote_to_write();
 
-        TableRef history = tr->get_table("history");
         TableRef line = tr->get_table("line");
 
         //    number_of_line = 2;
@@ -5447,7 +5449,7 @@ TEST(LangbindHelper_GroupWriter_EdgeCaseAssert)
     t2->add_column_link(type_LinkList, "dtkiipajqdsfglbptieibknaoeeohqdlhftqmlriphobspjr", *t1);
     std::vector<ObjKey> keys;
     t1->create_objects(375, keys);
-    auto t3 = g_w->add_table("pnsidlijqeddnsgaesiijrrqedkdktmfekftogjccerhpeil");
+    g_w->add_table("pnsidlijqeddnsgaesiijrrqedkdktmfekftogjccerhpeil");
     g_r->close();
     g_w->commit();
     REALM_ASSERT_RELEASE(sg->compact());

--- a/test/test_metrics.cpp
+++ b/test/test_metrics.cpp
@@ -355,7 +355,7 @@ TEST(Metrics_QueryOrAndNot)
 
     auto wt = sg->start_write();
     TableRef person = wt->get_table(person_table_name);
-    TableRef pet = wt->get_table(pet_table_name);
+    wt->get_table(pet_table_name);
     CHECK(bool(person));
 
     CHECK_EQUAL(person->get_column_count(), 8);
@@ -562,7 +562,7 @@ TEST(Metrics_LinkListQueries)
 
     auto wt = sg->start_write();
     TableRef person = wt->get_table(person_table_name);
-    TableRef pet = wt->get_table(pet_table_name);
+    wt->get_table(pet_table_name);
     CHECK(bool(person));
 
     CHECK_EQUAL(person->get_column_count(), 8);
@@ -1012,7 +1012,7 @@ NONCONCURRENT_TEST(Metrics_NumDecryptedPagesWithoutEncryption)
 
     {
         auto tr = sg->start_write();
-        auto table = tr->add_table("table");
+        tr->add_table("table");
 
         // we need this here because other unit tests might be using encryption and we need a guarantee
         // that the global pages are from this shared group only.
@@ -1057,7 +1057,7 @@ NONCONCURRENT_TEST_IF(Metrics_NumDecryptedPagesWithEncryption, REALM_ENABLE_ENCR
 
     {
         auto tr = sg->start_write();
-        auto table = tr->add_table("table");
+        tr->add_table("table");
 
         NoPageReclaimGovernor gov;
         realm::util::set_page_reclaim_governor(&gov);


### PR DESCRIPTION
This enables slightly better codegen and lowers the (small) overhead of passing
them around instead of raw pointers.

Change-Id: I3a5ae4b871fdee4ef312e424223e49ed554cd30d