### PR TITLE
Fix rebuilding pk columns with a null key

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,8 +4,7 @@
 * `Table::contains_unique_values(ColKey) -> bool` function added
 
 ### Fixed
-* <How to hit and notice issue? what was the impact?> ([#????](https://github.com/realm/realm-core/issues/????), since v?.?.?)
-* None.
+* Fixed an assertion failure when rebuilding a table with a null primary key, since 6.0.0-beta.2 ([#3528](https://github.com/realm/realm-core/issues/3528)).
  
 ### Breaking changes
 * We now require uniqieness on table names.

--- a/src/realm/obj.cpp
+++ b/src/realm/obj.cpp
@@ -1096,7 +1096,6 @@ void Obj::assign(const ConstObj& other)
     auto cols = m_table->get_column_keys();
     for (auto col : cols) {
         if (col.get_attrs().test(col_attr_List)) {
-            // TODO: implement
             auto src_list = other.get_listbase_ptr(col);
             auto dst_list = get_listbase_ptr(col);
             auto sz = src_list->size();
@@ -1108,6 +1107,10 @@ void Obj::assign(const ConstObj& other)
         }
         else {
             Mixed val = other.get_any(col);
+            if (val.is_null()) {
+                this->set_null(col);
+                continue;
+            }
             switch (val.get_type()) {
                 case type_String: {
                     // Need to take copy. Values might be in same cluster

--- a/test/test_group.cpp
+++ b/test/test_group.cpp
@@ -2119,6 +2119,32 @@ TEST(Group_SetColumnWithDuplicateValuesToPrimaryKey)
     CHECK_EQUAL(table->get_primary_key_column(), ColKey());
 }
 
+TEST(Group_SetColumnWithNullPrimaryKeyy)
+{
+    Group g;
+    TableRef table = g.add_table("table");
+    ColKey string_col = table->add_column(type_String, "string", true);
+
+    std::vector<ObjKey> keys;
+    table->create_objects(2, keys);
+    table->get_object(keys[0]).set(string_col, {"first"});
+    table->get_object(keys[1]).set(string_col, {});
+    CHECK(!table->get_object(keys[0]).is_null(string_col));
+    CHECK_EQUAL(table->get_object(keys[0]).get<StringData>(string_col), "first");
+    CHECK(table->get_object(keys[1]).is_null(string_col));
+    CHECK(table->get_primary_key_column() != string_col);
+    CHECK_EQUAL(table->size(), 2);
+    table->set_primary_key_column(string_col);
+    CHECK_EQUAL(table->get_primary_key_column(), string_col);
+    ObjKey first = table->find_first_string(string_col, "first");
+    ObjKey second = table->find_first_null(string_col);
+    ObjKey third = table->find_first_string(string_col, "not found");
+    CHECK(bool(first));
+    CHECK(bool(second));
+    CHECK(!bool(third));
+    CHECK_EQUAL(table->size(), 2);
+}
+
 TEST(Group_ChangeIntPrimaryKeyValuesInMigration)
 {
     Group g;


### PR DESCRIPTION
This issue is causing the following assertion failure in the js tests when upgrading to core v6.0.0-beta.2: 
```
transaction() for: /var/tmp//realm_Y7NFqw/realm-object-server/io.realm.object-server-utility/metadata/sync_metadata.realm
read_group() for: /var/tmp//realm_Y7NFqw/realm-object-server/io.realm.object-server-utility/metadata/sync_metadata.realm
../src/realm/mixed.hpp:152: [realm-core-6.0.0-beta.2] Assertion failed: m_type
0   realm.node                          0x00000001061183dc _ZN5realm4utilL18terminate_internalERNSt3__118basic_stringstreamIcNS1_11char_traitsIcEENS1_9allocatorIcEEEE + 28
1   realm.node                          0x0000000106118696 _ZN5realm4util9terminateEPKcS2_lOSt16initializer_listINS0_9PrintableEE + 390
2   realm.node                          0x0000000105fe639c _ZN5realm3Obj6assignERKNS_8ConstObjE + 1084
3   realm.node                          0x00000001060dab11 _ZN5realm5Table28rebuild_table_with_pk_columnEv + 449
4   realm.node                          0x0000000105f7af72 _ZN5realm5Group15remove_pk_tableEv + 1106
5   realm.node                          0x0000000105f7bb3b _ZN5realm11Transaction19upgrade_file_formatEi + 1179
6   realm.node                          0x0000000105f86fbd _ZN5realm2DB19upgrade_file_formatEbiii + 333
7   realm.node                          0x0000000105f846d7 _ZN5realm2DB7do_openERKNSt3__112basic_stringIcNS1_11char_traitsIcEENS1_9allocatorIcEEEEbbNS_9DBOptionsE + 4279
8   realm.node                          0x0000000105f87693 _ZN5realm2DB4openERNS_11ReplicationENS_9DBOptionsE + 243
9   realm.node                          0x0000000105f8c30b _ZN5realm2DB6createERNS_11ReplicationENS_9DBOptionsE + 347
10  realm.node                          0x0000000105cfed3c _ZN5realm5_impl19ClientStateDownload19finalize_async_openEv + 700
11  realm.node                          0x0000000105cfd093 _ZN5realm5_impl19ClientStateDownload13receive_stateEyxyyyNS_10BinaryDataE + 1939
12  realm.node                          0x0000000105d18cfd _ZN5realm5_impl14ClientImplBase7Session21receive_state_messageEyxyyyNS_10BinaryDataE + 509
13  realm.node                          0x0000000105d18acf _ZN5realm5_impl14ClientImplBase10Connection21receive_state_messageEyyxyyyNS_10BinaryDataE + 335
14  realm.node                          0x0000000105d1561e _ZN5realm5_impl14ClientProtocol22parse_message_receivedINS0_14ClientImplBase10ConnectionEEEvRT_PKcm + 5262
15  realm.node                          0x0000000105d10224 _ZN5realm5_impl14ClientImplBase10Connection33websocket_binary_message_receivedEPKcm + 52
16  realm.node                          0x0000000105d42640 _ZN12_GLOBAL__N_19WebSocket17frame_reader_loopEv + 2416
17  realm.node                          0x0000000105d1fb53 _ZN5realm4util7network7Service9AsyncOper29do_recycle_and_execute_helperINSt3__18functionIFvNS5_10error_codeEmEEEJS7_mEEEvbRbT_DpT0_ + 163
18  realm.node                          0x0000000105d1f987 _ZN5realm4util7network7Service9AsyncOper22do_recycle_and_executeINSt3__18functionIFvNS5_10error_codeEmEEEJRS7_RmEEEvbRT_DpOT0_ + 135
19  realm.node                          0x0000000105d20164 _ZN5realm4util7network7Service14BasicStreamOpsINS1_6SocketEE16BufferedReadOperINSt3__18functionIFvNS7_10error_codeEmEEEE19recycle_and_executeEv + 212
20  realm.node                          0x0000000105d324cc _ZN5realm4util7network7Service4Impl3runEv + 476
21  realm.node                          0x0000000105d4fb2a _ZN5realm4sync6Client3runEv + 26
22  realm.node                          0x0000000105ccf44f _ZNSt3__114__thread_proxyINS_5tupleIJNS_10unique_ptrINS_15__thread_structENS_14default_deleteIS3_EEEEZN5realm5_impl10SyncClientC1ENS2_INS7_4util6LoggerENS4_ISB_EEEENS7_4sync6Client13ReconnectModeEbRKNS_12basic_stringIcNS_11char_traitsIcEENS_9allocatorIcEEEEEUlvE_EEEEEPvSR_ + 42
23  libsystem_pthread.dylib             0x00007fff5fe812eb _pthread_body + 126
24  libsystem_pthread.dylib             0x00007fff5fe84249 _pthread_start + 66
25  libsystem_pthread.dylib             0x00007fff5fe8040d thread_start + 13!!! IMPORTANT: Please send this log and info about Realm SDK version and other relevant reproduction info to help@realm.io.sh: line 1: 12195 Abort trap: 6           npm run js-tests
npm ERR! code ELIFECYCLE
npm ERR! errno 134
npm ERR! realm-tests-jasmine@0.0.1 test: `npm run check-typescript && npm run js-tests`
npm ERR! Exit status 134
npm ERR!
npm ERR! Failed at the realm-tests-jasmine@0.0.1 test script.
npm ERR! This is probably not a problem with npm. There is likely additional logging output above.

npm ERR! A complete log of this run can be found in:
npm ERR!     /Users/js/.npm/_logs/2019-12-19T00_04_26_921Z-debug.log
stopping server
server is running. killing it
shutting down running simulators
```

I believe the realm causing this is the following:
```
./realm2json-6 /var/tmp//realm_GFas9P/realm-object-server/io.realm.object-server-utility/metadata/sync_metadata.realm
{
"metadata":[{"_key":0,"version":2}]
,"class_ClientMetadata":[{"_key":0,"uuid":"609cde5f-174a-42b9-b085-3fe0d103bdad"}]
,"class_FileActionMetadata":[]
,"class_UserMetadata":[]
}
```