### PR TITLE
Fix a crash on startup on macOS 10.10 and 10.11

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@
 
 ### Fixed
 * <How to hit and notice issue? what was the impact?> ([#????](https://github.com/realm/realm-core/issues/????), since v?.?.?)
-* None.
+* Fix a crash on startup on macOS 10.10 and 10.11. ([Cocoa #6403](https://github.com/realm/realm-cocoa/issues/6403), since 2.9.0).
  
 ### Breaking changes
 * None.

--- a/src/realm/util/features.h
+++ b/src/realm/util/features.h
@@ -262,29 +262,6 @@
 #define REALM_TVOS 0
 #endif
 
-// asl_log is deprecated in favor of os_log as of the following versions:
-// macos(10.12), ios(10.0), watchos(3.0), tvos(10.0)
-// versions are defined in /usr/include/Availability.h
-// __MAC_10_12   101200
-// __IPHONE_10_0 100000
-// __WATCHOS_3_0  30000
-// __TVOS_10_0   100000
-#if REALM_PLATFORM_APPLE \
-    && ( \
-        (REALM_IOS && defined(__IPHONE_OS_VERSION_MIN_REQUIRED) \
-         && __IPHONE_OS_VERSION_MIN_REQUIRED >= 100000) \
-     || (REALM_TVOS && defined(__TV_OS_VERSION_MIN_REQUIRED) \
-         &&  __TV_OS_VERSION_MIN_REQUIRED >= 100000) \
-     || (REALM_WATCHOS && defined(__WATCH_OS_VERSION_MIN_REQUIRED) \
-         && __WATCH_OS_VERSION_MIN_REQUIRED >= 30000) \
-     || (defined(__MAC_OS_X_VERSION_MIN_REQUIRED) \
-         && __MAC_OS_X_VERSION_MIN_REQUIRED >= 101200) \
-       )
-#define REALM_APPLE_OS_LOG 1
-#else
-#define REALM_APPLE_OS_LOG 0
-#endif
-
 #if REALM_ANDROID || REALM_IOS || REALM_WATCHOS || REALM_TVOS || REALM_UWP
 #define REALM_MOBILE 1
 #else

--- a/src/realm/util/terminate.cpp
+++ b/src/realm/util/terminate.cpp
@@ -26,11 +26,8 @@
 
 #if REALM_PLATFORM_APPLE
 
-#if REALM_APPLE_OS_LOG
 #include <os/log.h>
-#else
 #include <asl.h>
-#endif
 
 #include <dlfcn.h>
 #include <execinfo.h>
@@ -62,14 +59,18 @@ void nslog(const char* message) noexcept
     // Standard error goes nowhere for applications managed by launchd,
     // so log to ASL/unified logging system logs as well.
     fputs(message, stderr);
-#if REALM_APPLE_OS_LOG
-    // The unified logging system considers dynamic strings to be private in
-    // order to protect users. This means we must specify "%{public}s" to get
-    // the message here. See `man os_log` for more details.
-    os_log_error(OS_LOG_DEFAULT, "%{public}s", message);
-#else
-    asl_log(nullptr, nullptr, ASL_LEVEL_ERR, "%s", message);
-#endif
+    if (__builtin_available(iOS 10.0, macOS 10.12, tvOS 10.0, watchOS 3.0, *)) {
+        // The unified logging system considers dynamic strings to be private in
+        // order to protect users. This means we must specify "%{public}s" to get
+        // the message here. See `man os_log` for more details.
+        os_log_error(OS_LOG_DEFAULT, "%{public}s", message);
+    }
+    else {
+        REALM_DIAG_PUSH();
+        REALM_DIAG(ignored "-Wdeprecated");
+        asl_log(nullptr, nullptr, ASL_LEVEL_ERR, "%s", message);
+        REALM_DIAG_POP();
+    }
     // Log the message to Crashlytics if it's loaded into the process
     void* addr = dlsym(RTLD_DEFAULT, "CLSLog");
     if (addr) {


### PR DESCRIPTION
We have to check if os_log is available at runtime, not at compile time.

Fixes https://github.com/realm/realm-cocoa/issues/6403.