### PR TITLE
fix a race involving the page reclaimer and 2 unittests for the metrics

### DIFF
--- a/test/test_metrics.cpp
+++ b/test/test_metrics.cpp
@@ -979,7 +979,7 @@ class NoPageReclaimGovernor : public realm::util::PageReclaimGovernor {
 public:
     NoPageReclaimGovernor()
     {
-        has_run_once = will_run.get_future();
+        has_run_twice = will_run.get_future();
     }
 
     std::function<int64_t()> current_target_getter(size_t) override
@@ -989,15 +989,15 @@ public:
 
     void report_target_result(int64_t) override
     {
-        if (!has_run) {
+        if (run_count > 1) { // need to run twice before we're done
             will_run.set_value();
-            has_run = true;
         }
+        ++run_count;
     }
 
-    std::future<void> has_run_once;
+    std::future<void> has_run_twice;
     std::promise<void> will_run;
-    bool has_run = false;
+    int run_count = 0;
 };
 
 // this test relies on the global state of the number of decrypted pages and therefore must be run in isolation
@@ -1018,8 +1018,8 @@ NONCONCURRENT_TEST(Metrics_NumDecryptedPagesWithoutEncryption)
         // that the global pages are from this shared group only.
         NoPageReclaimGovernor gov;
         realm::util::set_page_reclaim_governor(&gov);
-        CHECK(gov.has_run_once.valid());
-        gov.has_run_once.wait_for(std::chrono::seconds(2));
+        CHECK(gov.has_run_twice.valid());
+        gov.has_run_twice.wait_for(std::chrono::seconds(2));
 
         tr->commit();
     }
@@ -1061,8 +1061,8 @@ NONCONCURRENT_TEST_IF(Metrics_NumDecryptedPagesWithEncryption, REALM_ENABLE_ENCR
 
         NoPageReclaimGovernor gov;
         realm::util::set_page_reclaim_governor(&gov);
-        CHECK(gov.has_run_once.valid());
-        gov.has_run_once.wait_for(std::chrono::seconds(2));
+        CHECK(gov.has_run_twice.valid());
+        gov.has_run_twice.wait_for(std::chrono::seconds(2));
 
         tr->commit();
     }


### PR DESCRIPTION
In the two affected tests, it was possible for the page reclaimer to collect workload data before the tests started and then report the collected data to the new governor installed by the tests. This would cause the governor to work on the stale data and they'd be reported to the metrics system, causing the tests to fail.

By requiring 2 calls to the new governor before reporting, we can ensure that the data used are collected during the actual test - not stale data previous tests.