### PR TITLE
Fix a thread sanitizer false positive

### DIFF
--- a/src/realm/alloc_slab.cpp
+++ b/src/realm/alloc_slab.cpp
@@ -1321,7 +1321,8 @@ void SlabAlloc::extend_fast_mapping_with_slab(char* address)
 #else
     new_fast_mapping[m_translation_table_size - 1] = {address};
 #endif
-    m_ref_translation_ptr = new_fast_mapping;
+    m_ref_translation_ptr.store(new_fast_mapping, std::memory_order_release);
+    REALM_TSAN_ANNOTATE_HAPPENS_BEFORE(new_fast_mapping);
 }
 
 void SlabAlloc::rebuild_translations(bool requires_new_translation, size_t old_num_sections)

--- a/src/realm/util/features.h
+++ b/src/realm/util/features.h
@@ -341,4 +341,16 @@
 #  define REALM_SANITIZE_THREAD 0
 #endif
 
+#if REALM_SANITIZE_THREAD
+#define REALM_TSAN_ANNOTATE_HAPPENS_BEFORE(addr)                                                                     \
+    AnnotateHappensBefore(__FILE__, __LINE__, reinterpret_cast<void*>(addr))
+#define REALM_TSAN_ANNOTATE_HAPPENS_AFTER(addr)                                                                      \
+    AnnotateHappensAfter(__FILE__, __LINE__, reinterpret_cast<void*>(addr))
+extern "C" void AnnotateHappensBefore(const char* f, int l, void* addr);
+extern "C" void AnnotateHappensAfter(const char* f, int l, void* addr);
+#else
+#define REALM_TSAN_ANNOTATE_HAPPENS_BEFORE(addr)
+#define REALM_TSAN_ANNOTATE_HAPPENS_AFTER(addr)
+#endif
+
 #endif /* REALM_UTIL_FEATURES_H */


### PR DESCRIPTION
TSan complains about reading the elements of the m_ref_translation_ptr array being a data race because the write to the element in the array could be reordered to after the write to m_ref_translation_ptr. This is a false-positive as release-acquire ordering on m_ref_translation_ptr prevents this.

To fix this, add explicit annotations to help tsan out. Only reading m_ref_translation_ptr once inside Allocator::translate() is needed for this, but also is a trivial optimization (each access of m_ref_translation_ptr is a memory read while accessing the non-atomic local isn't).