### PR TITLE
Mark all move constructors/assignment operators as noexcept

### DIFF
--- a/src/realm/alloc_slab.cpp
+++ b/src/realm/alloc_slab.cpp
@@ -1210,8 +1210,7 @@ void SlabAlloc::update_reader_view(size_t file_size)
             size_t section_size = file_size - section_start_offset;
             requires_new_translation = true;
             // save the old mapping/keep it open
-            OldMapping oldie(m_youngest_live_version, m_mappings[mapping_index]);
-            m_old_mappings.emplace_back(std::move(oldie));
+            m_old_mappings.emplace_back(m_youngest_live_version, std::move(m_mappings[mapping_index]));
             m_mappings[mapping_index] =
                 util::File::Map<char>(m_file, section_start_offset, File::access_ReadOnly, section_size);
             m_mapping_version++;
@@ -1228,8 +1227,7 @@ void SlabAlloc::update_reader_view(size_t file_size)
                 size_t section_reservation = get_section_base(old_num_sections) - section_start_offset;
                 REALM_ASSERT(section_size == section_reservation);
                 // save the old mapping/keep it open
-                OldMapping oldie(m_youngest_live_version, m_mappings[mapping_index]);
-                m_old_mappings.emplace_back(std::move(oldie));
+                m_old_mappings.emplace_back(m_youngest_live_version, std::move(m_mappings[mapping_index]));
                 m_mappings[mapping_index] =
                     util::File::Map<char>(m_file, section_start_offset, File::access_ReadOnly, section_size);
                 m_mapping_version++;

--- a/src/realm/alloc_slab.hpp
+++ b/src/realm/alloc_slab.hpp
@@ -543,19 +543,18 @@ private:
 
     // Description of to-be-deleted memory mapping
     struct OldMapping {
-        OldMapping(uint64_t version, util::File::Map<char>& map)
+        OldMapping(uint64_t version, util::File::Map<char>&& map) noexcept
             : replaced_at_version(version)
-            , mapping()
+            , mapping(std::move(map))
         {
-            mapping = std::move(map);
         }
-        OldMapping(OldMapping&& other)
+        OldMapping(OldMapping&& other) noexcept
             : replaced_at_version(other.replaced_at_version)
             , mapping()
         {
             mapping = std::move(other.mapping);
         }
-        void operator=(OldMapping&& other)
+        void operator=(OldMapping&& other) noexcept
         {
             replaced_at_version = other.replaced_at_version;
             mapping = std::move(other.mapping);
@@ -564,7 +563,7 @@ private:
         util::File::Map<char> mapping;
     };
     struct OldRefTranslation {
-        OldRefTranslation(uint64_t v, RefTranslation* m)
+        OldRefTranslation(uint64_t v, RefTranslation* m) noexcept
         {
             replaced_at_version = v;
             translations = m;

--- a/src/realm/bplustree.cpp
+++ b/src/realm/bplustree.cpp
@@ -664,7 +664,7 @@ BPlusTreeBase& BPlusTreeBase::operator=(const BPlusTreeBase& rhs)
     return *this;
 }
 
-BPlusTreeBase& BPlusTreeBase::operator=(BPlusTreeBase&& rhs)
+BPlusTreeBase& BPlusTreeBase::operator=(BPlusTreeBase&& rhs) noexcept
 {
     // Destroy current tree
     destroy();

--- a/src/realm/bplustree.hpp
+++ b/src/realm/bplustree.hpp
@@ -131,7 +131,7 @@ public:
     virtual ~BPlusTreeBase();
 
     BPlusTreeBase& operator=(const BPlusTreeBase& rhs);
-    BPlusTreeBase& operator=(BPlusTreeBase&& rhs);
+    BPlusTreeBase& operator=(BPlusTreeBase&& rhs) noexcept;
 
     Allocator& get_alloc() const
     {
@@ -365,7 +365,7 @@ public:
         *this = other;
     }
 
-    BPlusTree(BPlusTree&& other)
+    BPlusTree(BPlusTree&& other) noexcept
         : BPlusTree(other.get_alloc())
     {
         *this = std::move(other);
@@ -379,7 +379,7 @@ public:
         return *this;
     }
 
-    BPlusTree& operator=(BPlusTree&& rhs)
+    BPlusTree& operator=(BPlusTree&& rhs) noexcept
     {
         this->BPlusTreeBase::operator=(std::move(rhs));
         return *this;

--- a/src/realm/keys.hpp
+++ b/src/realm/keys.hpp
@@ -28,32 +28,32 @@ namespace realm {
 
 struct TableKey {
     static constexpr uint32_t null_value = uint32_t(-1) >> 1; // free top bit
-    constexpr TableKey()
+    constexpr TableKey() noexcept
         : value(null_value)
     {
     }
-    explicit TableKey(uint32_t val)
+    explicit TableKey(uint32_t val) noexcept
         : value(val)
     {
     }
-    TableKey& operator=(uint32_t val)
+    TableKey& operator=(uint32_t val) noexcept
     {
         value = val;
         return *this;
     }
-    bool operator==(const TableKey& rhs) const
+    bool operator==(const TableKey& rhs) const noexcept
     {
         return value == rhs.value;
     }
-    bool operator!=(const TableKey& rhs) const
+    bool operator!=(const TableKey& rhs) const noexcept
     {
         return value != rhs.value;
     }
-    bool operator<(const TableKey& rhs) const
+    bool operator<(const TableKey& rhs) const noexcept
     {
         return value < rhs.value;
     }
-    explicit operator bool() const
+    explicit operator bool() const noexcept
     {
         return value != null_value;
     }
@@ -92,57 +92,57 @@ struct ColKey {
         unsigned val;
     };
 
-    constexpr ColKey()
+    constexpr ColKey() noexcept
         : value(uint64_t(-1) >> 1) // free top bit
     {
     }
-    constexpr explicit ColKey(int64_t val)
+    constexpr explicit ColKey(int64_t val) noexcept
         : value(val)
     {
     }
-    explicit ColKey(Idx index, ColumnType type, ColumnAttrMask attrs, unsigned tag)
+    explicit ColKey(Idx index, ColumnType type, ColumnAttrMask attrs, unsigned tag) noexcept
         : ColKey((index.val & 0xFFFFUL) | ((type & 0x3FUL) << 16) | ((attrs.m_value & 0xFFUL) << 22) |
                  ((tag & 0xFFFFFFFFUL) << 30))
     {
     }
-    ColKey& operator=(int64_t val)
+    ColKey& operator=(int64_t val) noexcept
     {
         value = val;
         return *this;
     }
-    bool operator==(const ColKey& rhs) const
+    bool operator==(const ColKey& rhs) const noexcept
     {
         return value == rhs.value;
     }
-    bool operator!=(const ColKey& rhs) const
+    bool operator!=(const ColKey& rhs) const noexcept
     {
         return value != rhs.value;
     }
-    bool operator<(const ColKey& rhs) const
+    bool operator<(const ColKey& rhs) const noexcept
     {
         return value < rhs.value;
     }
-    bool operator>(const ColKey& rhs) const
+    bool operator>(const ColKey& rhs) const noexcept
     {
         return value > rhs.value;
     }
-    explicit operator bool() const
+    explicit operator bool() const noexcept
     {
         return value != ColKey().value;
     }
-    Idx get_index() const
+    Idx get_index() const noexcept
     {
         return Idx{static_cast<unsigned>(value) & 0xFFFFU};
     }
-    ColumnType get_type() const
+    ColumnType get_type() const noexcept
     {
         return ColumnType((static_cast<unsigned>(value) >> 16) & 0x3F);
     }
-    ColumnAttrMask get_attrs() const
+    ColumnAttrMask get_attrs() const noexcept
     {
         return ColumnAttrMask((static_cast<unsigned>(value) >> 22) & 0xFF);
     }
-    unsigned get_tag() const
+    unsigned get_tag() const noexcept
     {
         return (value >> 30) & 0xFFFFFFFFUL;
     }
@@ -156,36 +156,36 @@ inline std::ostream& operator<<(std::ostream& os, ColKey ck)
 }
 
 struct ObjKey {
-    constexpr ObjKey()
+    constexpr ObjKey() noexcept
         : value(-1)
     {
     }
-    explicit constexpr ObjKey(int64_t val)
+    explicit constexpr ObjKey(int64_t val) noexcept
         : value(val)
     {
     }
-    ObjKey& operator=(int64_t val)
+    ObjKey& operator=(int64_t val) noexcept
     {
         value = val;
         return *this;
     }
-    bool operator==(const ObjKey& rhs) const
+    bool operator==(const ObjKey& rhs) const noexcept
     {
         return value == rhs.value;
     }
-    bool operator!=(const ObjKey& rhs) const
+    bool operator!=(const ObjKey& rhs) const noexcept
     {
         return value != rhs.value;
     }
-    bool operator<(const ObjKey& rhs) const
+    bool operator<(const ObjKey& rhs) const noexcept
     {
         return value < rhs.value;
     }
-    bool operator>(const ObjKey& rhs) const
+    bool operator>(const ObjKey& rhs) const noexcept
     {
         return value > rhs.value;
     }
-    explicit operator bool() const
+    explicit operator bool() const noexcept
     {
         return value != -1;
     }
@@ -193,10 +193,7 @@ struct ObjKey {
 
 private:
     // operator bool will enable casting to integer. Prevent this.
-    operator int64_t() const
-    {
-        return 0;
-    }
+    operator int64_t() const = delete;
 };
 
 class ObjKeys : public std::vector<ObjKey> {
@@ -237,13 +234,9 @@ inline std::string to_string(ColKey ck)
 namespace std {
 
 template <>
-
 struct hash<realm::ObjKey> {
-
     size_t operator()(realm::ObjKey key) const
-
     {
-
         return std::hash<uint64_t>{}(key.value);
     }
 };

--- a/src/realm/list.hpp
+++ b/src/realm/list.hpp
@@ -419,7 +419,7 @@ protected:
         }
     }
 
-    ConstLstIf(ConstLstIf&& other)
+    ConstLstIf(ConstLstIf&& other) noexcept
         : ConstLstBase(ColKey{}, nullptr)
         , m_tree(std::move(other.m_tree))
         , m_valid(other.m_valid)
@@ -458,7 +458,7 @@ template <class T>
 class ConstLst : public ConstLstIf<T> {
 public:
     ConstLst(const ConstObj& owner, ColKey col_key);
-    ConstLst(ConstLst&& other)
+    ConstLst(ConstLst&& other) noexcept
         : ConstLstBase(other.m_col_key, &m_obj)
         , ConstLstIf<T>(std::move(other))
         , m_obj(std::move(other.m_obj))
@@ -510,7 +510,7 @@ public:
     }
     Lst(const Obj& owner, ColKey col_key);
     Lst(const Lst& other);
-    Lst(Lst&& other);
+    Lst(Lst&& other) noexcept;
 
     Lst& operator=(const Lst& other);
     Lst& operator=(const BPlusTree<T>& other);
@@ -727,7 +727,7 @@ Lst<T>::Lst(const Lst<T>& other)
 }
 
 template <class T>
-Lst<T>::Lst(Lst<T>&& other)
+Lst<T>::Lst(Lst<T>&& other) noexcept
     : ConstLstBase(other.m_col_key, &m_obj)
     , ConstLstIf<T>(std::move(other))
     , m_obj(std::move(other.m_obj))
@@ -778,7 +778,7 @@ public:
     {
         this->init_from_parent();
     }
-    ConstLnkLst(ConstLnkLst&& other)
+    ConstLnkLst(ConstLnkLst&& other) noexcept
         : ConstLstBase(other.m_col_key, &m_obj)
         , ConstLstIf<ObjKey>(std::move(other))
         , m_obj(std::move(other.m_obj))
@@ -814,7 +814,7 @@ public:
         , ObjList(this->m_tree.get(), m_obj.get_target_table(m_col_key))
     {
     }
-    LnkLst(LnkLst&& other)
+    LnkLst(LnkLst&& other) noexcept
         : ConstLstBase(other.m_col_key, &m_obj)
         , Lst<ObjKey>(std::move(other))
         , ObjList(this->m_tree.get(), m_obj.get_target_table(m_col_key))

--- a/src/realm/query.cpp
+++ b/src/realm/query.cpp
@@ -146,8 +146,8 @@ Query& Query::operator=(const Query& source)
     return *this;
 }
 
-Query::Query(Query&&) = default;
-Query& Query::operator=(Query&&) = default;
+Query::Query(Query&&) noexcept = default;
+Query& Query::operator=(Query&&) noexcept = default;
 
 Query::~Query() noexcept = default;
 

--- a/src/realm/query.hpp
+++ b/src/realm/query.hpp
@@ -95,8 +95,8 @@ public:
     Query(const Query& copy);
     Query& operator=(const Query& source);
 
-    Query(Query&&);
-    Query& operator=(Query&&);
+    Query(Query&&) noexcept;
+    Query& operator=(Query&&) noexcept;
 
     // Find links that point to a specific target row
     Query& links_to(ColKey column_key, ObjKey target_key);

--- a/src/realm/query_expression.hpp
+++ b/src/realm/query_expression.hpp
@@ -2176,7 +2176,7 @@ public:
     {
     }
 
-    Columns(Columns&& other)
+    Columns(Columns&& other) noexcept
         : SimpleQuerySupport(other)
     {
     }
@@ -3669,8 +3669,8 @@ public:
         return *this;
     }
 
-    UnaryOperator(UnaryOperator&&) = default;
-    UnaryOperator& operator=(UnaryOperator&&) = default;
+    UnaryOperator(UnaryOperator&&) noexcept = default;
+    UnaryOperator& operator=(UnaryOperator&&) noexcept = default;
 
     // See comment in base class
     void set_base_table(ConstTableRef table) override
@@ -3748,8 +3748,8 @@ public:
         return *this;
     }
 
-    Operator(Operator&&) = default;
-    Operator& operator=(Operator&&) = default;
+    Operator(Operator&&) noexcept = default;
+    Operator& operator=(Operator&&) noexcept = default;
 
     // See comment in base class
     void set_base_table(ConstTableRef table) override

--- a/src/realm/util/file.hpp
+++ b/src/realm/util/file.hpp
@@ -721,7 +721,7 @@ public:
     Map& operator=(const Map&) = delete;
 
     /// Move the mapping from another Map object to this Map object
-    File::Map<T>& operator=(File::Map<T>&& other)
+    File::Map<T>& operator=(File::Map<T>&& other) noexcept
     {
         if (m_addr)
             unmap();
@@ -737,6 +737,10 @@ public:
         other.m_encrypted_mapping = nullptr;
 #endif
         return *this;
+    }
+    Map(Map&& other) noexcept
+    {
+        *this = std::move(other);
     }
 
     /// See File::map().

--- a/src/realm/util/optional.hpp
+++ b/src/realm/util/optional.hpp
@@ -83,7 +83,7 @@ public:
 
     constexpr Optional();
     constexpr Optional(None);
-    Optional(Optional<T>&& other);
+    Optional(Optional<T>&& other) noexcept;
     Optional(const Optional<T>& other);
 
     constexpr Optional(T&& value);
@@ -93,9 +93,9 @@ public:
     constexpr Optional(InPlace tag, Args&&...);
     // FIXME: std::optional specifies an std::initializer_list constructor overload as well.
 
-    Optional<T>& operator=(None);
-    Optional<T>& operator=(Optional<T>&& other);
-    Optional<T>& operator=(const Optional<T>& other);
+    Optional<T>& operator=(None) noexcept;
+    Optional<T>& operator=(Optional<T>&& other) noexcept(std::is_nothrow_move_assignable<T>::value);
+    Optional<T>& operator=(const Optional<T>& other) noexcept(std::is_nothrow_copy_assignable<T>::value);
 
     template <class U, class = typename std::enable_if<_impl::TypeIsAssignableToOptional<T, U>::value>::type>
     Optional<T>& operator=(U&& value);
@@ -170,23 +170,23 @@ public:
     } // FIXME: Was a delegating constructor, but not fully supported in VS2015
     Optional(const Optional<T&>& other) = default;
     template <class U>
-    Optional(const Optional<U&>& other)
+    Optional(const Optional<U&>& other) noexcept
         : m_ptr(other.m_ptr)
     {
     }
     template <class U>
-    Optional(std::reference_wrapper<U> ref)
+    Optional(std::reference_wrapper<U> ref) noexcept
         : m_ptr(&ref.get())
     {
     }
 
-    constexpr Optional(T& init_value)
+    constexpr Optional(T& init_value) noexcept
         : m_ptr(&init_value)
     {
     }
     Optional(T&& value) = delete; // Catches accidental references to rvalue temporaries.
 
-    Optional<T&>& operator=(None)
+    Optional<T&>& operator=(None) noexcept
     {
         m_ptr = nullptr;
         return *this;
@@ -198,13 +198,13 @@ public:
     }
 
     template <class U>
-    Optional<T&>& operator=(std::reference_wrapper<U> ref)
+    Optional<T&>& operator=(std::reference_wrapper<U> ref) noexcept
     {
         m_ptr = &ref.get();
         return *this;
     }
 
-    explicit constexpr operator bool() const
+    explicit constexpr operator bool() const noexcept
     {
         return m_ptr;
     }
@@ -288,7 +288,7 @@ constexpr Optional<T>::Optional(None)
 }
 
 template <class T>
-Optional<T>::Optional(Optional<T>&& other)
+Optional<T>::Optional(Optional<T>&& other) noexcept
     : Storage(none)
 {
     if (other.m_engaged) {
@@ -336,14 +336,14 @@ void Optional<T>::clear()
 }
 
 template <class T>
-Optional<T>& Optional<T>::operator=(None)
+Optional<T>& Optional<T>::operator=(None) noexcept
 {
     clear();
     return *this;
 }
 
 template <class T>
-Optional<T>& Optional<T>::operator=(Optional<T>&& other)
+Optional<T>& Optional<T>::operator=(Optional<T>&& other) noexcept(std::is_nothrow_move_assignable<T>::value)
 {
     if (m_engaged) {
         if (other.m_engaged) {
@@ -363,7 +363,7 @@ Optional<T>& Optional<T>::operator=(Optional<T>&& other)
 }
 
 template <class T>
-Optional<T>& Optional<T>::operator=(const Optional<T>& other)
+Optional<T>& Optional<T>::operator=(const Optional<T>& other) noexcept(std::is_nothrow_copy_assignable<T>::value)
 {
     if (m_engaged) {
         if (other.m_engaged) {

--- a/src/realm/util/thread.hpp
+++ b/src/realm/util/thread.hpp
@@ -65,7 +65,7 @@ public:
     Thread(const Thread&) = delete;
     Thread& operator=(const Thread&) = delete;
 
-    Thread(Thread&&);
+    Thread(Thread&&) noexcept;
 
     /// This method is an extension of the API provided by
     /// std::thread. This method exists because proper move semantics
@@ -427,7 +427,7 @@ inline Thread::Thread(F func)
     func2.release();
 }
 
-inline Thread::Thread(Thread&& thread)
+inline Thread::Thread(Thread&& thread) noexcept
 {
 #ifndef _WIN32
     m_id = thread.m_id;


### PR DESCRIPTION
This is required for std::vector<> to actually use the move constructors rather than copying. A bunch of these probably don't matter, but it was easier to use clang-tidy to just fix them all than to figure out which ones actually do need it.

The specific motivation for this is that adding a ColKey member to Property made Property no longer nothrow_move_constructable which resulted in some nontrivial copies instead of moves.