### PR TITLE
Silence g++ warning about memcpy on non-trivial type

### DIFF
--- a/src/realm/decimal128.cpp
+++ b/src/realm/decimal128.cpp
@@ -231,14 +231,14 @@ void Decimal128::from_string(const char* ps)
 Decimal128 to_decimal128(const BID_UINT128& val)
 {
     Decimal128 tmp;
-    memcpy(&tmp, &val, sizeof(Decimal128));
+    memcpy(tmp.raw(), &val, sizeof(BID_UINT128));
     return tmp;
 }
 
 BID_UINT128 to_BID_UINT128(const Decimal128& val)
 {
     BID_UINT128 ret;
-    memcpy(&ret, &val, sizeof(Decimal128));
+    memcpy(&ret, val.raw(), sizeof(BID_UINT128));
     return ret;
 }
 

--- a/src/realm/decimal128.hpp
+++ b/src/realm/decimal128.hpp
@@ -79,6 +79,10 @@ public:
     {
         return &m_value;
     }
+    Bid128* raw()
+    {
+        return &m_value;
+    }
     void unpack(Bid128& coefficient, int& exponent, bool& sign) const noexcept;
 
 private:


### PR DESCRIPTION
Warning:

```
../src/realm/decimal128.cpp: In function ‘realm::Decimal128 realm::to_decimal128(const BID_UINT128&)’:
../src/realm/decimal128.cpp:234:42: warning: ‘void* memcpy(void*, const void*, size_t)’ copying an object of non-trivial type ‘class realm::Decimal128’ from an array of ‘const struct BID_UINT128’ [-Wclass-memaccess]
  234 |     memcpy(&tmp, &val, sizeof(Decimal128));
      |
```