### PR TITLE
optimize alloc::translate, also possibly remove a tsan false positive

### DIFF
--- a/src/realm/alloc.hpp
+++ b/src/realm/alloc.hpp
@@ -497,15 +497,15 @@ inline Allocator::~Allocator() noexcept
 
 inline char* Allocator::translate(ref_type ref) const noexcept
 {
-    if (m_ref_translation_ptr) {
+    if (auto ref_translation_ptr = m_ref_translation_ptr.load(std::memory_order_acquire)) {
         char* base_addr;
         size_t idx = get_section_index(ref);
-        base_addr = m_ref_translation_ptr[idx].mapping_addr;
+        base_addr = ref_translation_ptr[idx].mapping_addr;
         size_t offset = ref - get_section_base(idx);
         auto addr = base_addr + offset;
 #if REALM_ENABLE_ENCRYPTION
         realm::util::encryption_read_barrier(addr, NodeHeader::header_size,
-                                             m_ref_translation_ptr[idx].encrypted_mapping,
+                                             ref_translation_ptr[idx].encrypted_mapping,
                                              NodeHeader::get_byte_size_from_header);
 #endif
         return addr;


### PR DESCRIPTION
Improve performance of alloc::translate by avoiding a few memory accesses.

Potentially also fix a thread sanitizer false positive (the now removed reloads would always reload
the exact same value, but the thread sanitizer might not see that).

Inspired by https://github.com/realm/realm-core/pull/3584