### PR TITLE
Add missing symbol for Obj::set<Optional<ObjectId>>

### DIFF
--- a/src/realm/list.cpp
+++ b/src/realm/list.cpp
@@ -401,12 +401,12 @@ template ConstLst<util::Optional<bool>>::ConstLst(const ConstObj& obj, ColKey co
 template ConstLst<float>::ConstLst(const ConstObj& obj, ColKey col_key);
 template ConstLst<util::Optional<float>>::ConstLst(const ConstObj& obj, ColKey col_key);
 template ConstLst<double>::ConstLst(const ConstObj& obj, ColKey col_key);
-template ConstLst<Decimal128>::ConstLst(const ConstObj& obj, ColKey col_key);
 template ConstLst<util::Optional<double>>::ConstLst(const ConstObj& obj, ColKey col_key);
 template ConstLst<StringData>::ConstLst(const ConstObj& obj, ColKey col_key);
 template ConstLst<BinaryData>::ConstLst(const ConstObj& obj, ColKey col_key);
 template ConstLst<Timestamp>::ConstLst(const ConstObj& obj, ColKey col_key);
 template ConstLst<ObjKey>::ConstLst(const ConstObj& obj, ColKey col_key);
+template ConstLst<Decimal128>::ConstLst(const ConstObj& obj, ColKey col_key);
 template ConstLst<ObjectId>::ConstLst(const ConstObj& obj, ColKey col_key);
 template ConstLst<util::Optional<ObjectId>>::ConstLst(const ConstObj& obj, ColKey col_key);
 
@@ -417,12 +417,12 @@ template Lst<util::Optional<bool>>::Lst(const Obj& obj, ColKey col_key);
 template Lst<float>::Lst(const Obj& obj, ColKey col_key);
 template Lst<util::Optional<float>>::Lst(const Obj& obj, ColKey col_key);
 template Lst<double>::Lst(const Obj& obj, ColKey col_key);
-template Lst<Decimal128>::Lst(const Obj& obj, ColKey col_key);
 template Lst<util::Optional<double>>::Lst(const Obj& obj, ColKey col_key);
 template Lst<StringData>::Lst(const Obj& obj, ColKey col_key);
 template Lst<BinaryData>::Lst(const Obj& obj, ColKey col_key);
 template Lst<Timestamp>::Lst(const Obj& obj, ColKey col_key);
 template Lst<ObjKey>::Lst(const Obj& obj, ColKey col_key);
+template Lst<Decimal128>::Lst(const Obj& obj, ColKey col_key);
 template Lst<ObjectId>::Lst(const Obj& obj, ColKey col_key);
 template Lst<util::Optional<ObjectId>>::Lst(const Obj& obj, ColKey col_key);
 }

--- a/src/realm/obj.hpp
+++ b/src/realm/obj.hpp
@@ -442,6 +442,12 @@ inline Obj& Obj::set(ColKey col_key, Optional<double> value, bool is_default)
     return value ? set(col_key, *value, is_default) : set_null(col_key, is_default);
 }
 
+template <>
+inline Obj& Obj::set(ColKey col_key, Optional<ObjectId> value, bool is_default)
+{
+    return value ? set(col_key, *value, is_default) : set_null(col_key, is_default);
+}
+
 template <typename U>
 Obj& Obj::set_list_values(ColKey col_key, const std::vector<U>& values)
 {


### PR DESCRIPTION
And beef up the list of primitives tests to cover more types.