### PR TITLE
Clean up safe_int_ops.hpp

### DIFF
--- a/src/realm/alloc.hpp
+++ b/src/realm/alloc.hpp
@@ -344,7 +344,7 @@ inline int_fast64_t from_ref(ref_type v) noexcept
                   "If ref_type changes, from_ref and to_ref should probably be updated");
 
     // Make sure that we preserve the bit pattern of the ref_type (without sign extension).
-    return util::from_twos_compl<int_fast64_t>(uint_fast64_t(v));
+    return int_fast64_t(uint_fast64_t(v));
 }
 
 inline ref_type to_ref(int_fast64_t v) noexcept

--- a/src/realm/array.hpp
+++ b/src/realm/array.hpp
@@ -696,7 +696,7 @@ public:
 #endif
 
     Array& operator=(const Array&) = delete; // not allowed
-    Array(const Array&) = delete; // not allowed
+    Array(const Array&) = delete;            // not allowed
 protected:
     typedef bool (*CallbackDummy)(int64_t);
 
@@ -1055,8 +1055,7 @@ inline RefOrTagged RefOrTagged::make_ref(ref_type ref) noexcept
 inline RefOrTagged RefOrTagged::make_tagged(uint_fast64_t i) noexcept
 {
     REALM_ASSERT(i < (1ULL << 63));
-    int_fast64_t value = util::from_twos_compl<int_fast64_t>((i << 1) | 1);
-    return RefOrTagged(value);
+    return RefOrTagged((i << 1) | 1);
 }
 
 inline RefOrTagged::RefOrTagged(int_fast64_t value) noexcept
@@ -1605,7 +1604,8 @@ bool Array::find_optimized(int64_t value, size_t start, size_t end, size_t basei
             baseindex--;
         }
         else {
-            // We were called by find() of a nullable array. So skip first entry, take nulls in count, etc, etc. Fixme:
+            // We were called by find() of a nullable array. So skip first entry, take nulls in count, etc, etc.
+            // Fixme:
             // Huge speed optimizations are possible here! This is a very simple generic method.
             auto null_value = get(0);
             for (; start2 < end; start2++) {

--- a/src/realm/array_integer.cpp
+++ b/src/realm/array_integer.cpp
@@ -113,7 +113,7 @@ int64_t next_null_candidate(int64_t previous_candidate)
     // Increment by a prime number. This guarantees that we will
     // eventually hit every possible integer in the 2^64 range.
     x += 0xfffffffbULL;
-    return util::from_twos_compl<int64_t>(x);
+    return int64_t(x);
 }
 }
 

--- a/src/realm/array_integer.hpp
+++ b/src/realm/array_integer.hpp
@@ -271,14 +271,7 @@ inline void ArrayInteger::set(size_t ndx, int64_t value)
 
 inline void ArrayInteger::set_uint(size_t ndx, uint_fast64_t value) noexcept
 {
-    // When a value of a signed type is converted to an unsigned type, the C++
-    // standard guarantees that negative values are converted from the native
-    // representation to 2's complement, but the effect of conversions in the
-    // opposite direction is left unspecified by the
-    // standard. `realm::util::from_twos_compl()` is used here to perform the
-    // correct opposite unsigned-to-signed conversion, which reduces to a no-op
-    // when 2's complement is the native representation of negative values.
-    set(ndx, util::from_twos_compl<int_fast64_t>(value));
+    set(ndx, int_fast64_t(value));
 }
 
 inline bool ArrayInteger::compare(const ArrayInteger& a) const noexcept

--- a/src/realm/impl/transact_log.hpp
+++ b/src/realm/impl/transact_log.hpp
@@ -620,7 +620,7 @@ template <class T>
 char* TransactLogEncoder::encode_int(char* ptr, T value)
 {
     static_assert(std::numeric_limits<T>::is_integer, "Integer required");
-    bool negative = util::is_negative(value);
+    bool negative = value < 0;
     if (negative) {
         // The following conversion is guaranteed by C++11 to never
         // overflow (contrast this with "-value" which indeed could
@@ -632,7 +632,7 @@ char* TransactLogEncoder::encode_int(char* ptr, T value)
     }
     // At this point 'value' is always a positive number. Also, small
     // negative numbers have been converted to small positive numbers.
-    REALM_ASSERT(!util::is_negative(value));
+    REALM_ASSERT(value >= 0);
     // One sign bit plus number of value bits
     const int num_bits = 1 + std::numeric_limits<T>::digits;
     // Only the first 7 bits are available per byte. Had it not been
@@ -1182,8 +1182,6 @@ void TransactLogParser::parse_one(InstructionHandler& handler)
     char instr_ch = 0; // silence a warning
     if (!read_char(instr_ch))
         parser_error(); // Throws
-    //    std::cerr << "parsing " << util::promote(instr) << " @ " << std::hex << long(m_input_begin) << std::dec <<
-    //    "\n";
     Instruction instr = Instruction(instr_ch);
     switch (instr) {
         case instr_Set: {

--- a/src/realm/util/hex_dump.hpp
+++ b/src/realm/util/hex_dump.hpp
@@ -34,7 +34,8 @@ namespace util {
 template <class T>
 std::string hex_dump(const T* data, size_t size, const char* separator = " ", int min_digits = -1)
 {
-    using U = typename std::make_unsigned<T>::type;
+    // Note: common_type with int so character types print as numbers, rather than directly writing bytes.
+    using U = std::make_unsigned_t<std::common_type<T, int>>;
 
     if (min_digits < 0)
         min_digits = (std::numeric_limits<U>::digits + 3) / 4;
@@ -43,7 +44,7 @@ std::string hex_dump(const T* data, size_t size, const char* separator = " ", in
     for (const T* i = data; i != data + size; ++i) {
         if (i != data)
             out << separator;
-        out << std::setw(min_digits) << std::setfill('0') << std::hex << std::uppercase << util::promote(U(*i));
+        out << std::setw(min_digits) << std::setfill('0') << std::hex << std::uppercase << U(*i);
     }
     return out.str();
 }

--- a/src/realm/util/safe_int_ops.hpp
+++ b/src/realm/util/safe_int_ops.hpp
@@ -22,6 +22,7 @@
 #ifdef _WIN32
 #undef max // collides with numeric_limits::max called later in this header file
 #undef min // collides with numeric_limits::min called later in this header file
+#include <safeint.h>
 #endif
 
 #include <limits>
@@ -32,32 +33,6 @@
 
 namespace realm {
 namespace util {
-
-
-/// Perform integral or floating-point promotion on the argument. This
-/// is useful for example when printing a number of arbitrary numeric
-/// type to 'stdout', since it will convert values of character-like
-/// types to regular integer types, which will then be printed as
-/// numbers rather characters.
-template <class T>
-typename Promote<T>::type promote(T value) noexcept;
-
-
-/// This function allows you to test for a negative value in any
-/// numeric type, even when the type is unsigned. Normally, when the
-/// type is unsigned, such a test will produce a compiler warning.
-template <class T>
-bool is_negative(T value) noexcept;
-
-
-/// Cast the specified value to the specified unsigned type reducing
-/// the value (or in case of negative values, the two's complement
-/// representation) modulo `2**N` where `N` is the number of value
-/// bits (or digits) in the unsigned target type. This is usefull in
-/// cases where the target type may be `bool`, but need not be `bool`.
-template <class To, class From>
-To cast_to_unsigned(From) noexcept;
-
 
 //@{
 
@@ -79,9 +54,6 @@ To cast_to_unsigned(From) noexcept;
 /// These functions check at compile time that both types have valid
 /// specializations of std::numeric_limits<> and that both are indeed
 /// integers.
-///
-/// These functions make absolutely no assumptions about the platform
-/// except that it complies with at least C++03.
 
 template <class A, class B>
 inline bool int_equal_to(A, B) noexcept;
@@ -116,9 +88,6 @@ inline bool int_greater_than_or_equal(A, B) noexcept;
 /// These functions check at compile time that both types have valid
 /// specializations of std::numeric_limits<> and that both are indeed
 /// integers.
-///
-/// These functions make absolutely no assumptions about the platform
-/// except that it complies with at least C++03.
 
 template <class L, class R>
 inline bool int_add_with_overflow_detect(L& lval, R rval) noexcept;
@@ -144,9 +113,6 @@ inline bool int_subtract_with_overflow_detect(L& lval, R rval) noexcept;
 /// This function checks at compile time that both types have valid
 /// specializations of std::numeric_limits<> and that both are indeed
 /// integers.
-///
-/// This function makes absolutely no assumptions about the platform
-/// except that it complies with at least C++03.
 template <class L, class R>
 inline bool int_multiply_with_overflow_detect(L& lval, R rval) noexcept;
 
@@ -162,9 +128,6 @@ inline bool int_multiply_with_overflow_detect(L& lval, R rval) noexcept;
 /// value that is defined by the C++03 standard. In particular, the
 /// value of i must not exceed the number of bits of storage type T as
 /// shifting by this amount is not defined by the standard.
-///
-/// This function makes absolutely no assumptions about the platform
-/// except that it complies with at least C++03.
 template <class T>
 inline bool int_shift_left_with_overflow_detect(T& lval, int i) noexcept;
 
@@ -191,287 +154,59 @@ bool int_cast_with_overflow_detect(From from, To& to) noexcept;
 
 //@}
 
-
-/// Convert negative values from two's complement representation to the
-/// platforms native representation.
-///
-/// If `To` is an unsigned type, this function does nothing beyond casting the
-/// specified value to `To`. Otherwise, `To` is a signed type, and negative
-/// values will be converted from two's complement representation in unsigned
-/// `From` to the platforms native representation in `To`.
-///
-/// For signed `To` the result is well-defined if, and only if the value with
-/// the specified two's complement representation is representable in the
-/// specified signed type. While this is generally the case when using
-/// corresponding signed/unsigned type pairs, it is not guaranteed by the
-/// standard. However, if you know that the signed type has at least as many
-/// value bits as the unsigned type, then the result is always
-/// well-defined. Note that a 'value bit' in this context is the same as a
-/// 'digit' from the point of view of `std::numeric_limits`.
-///
-/// On platforms that use two's complement representation of negative values,
-/// this function is expected to be completely optimized away. This has been
-/// observed to be true with both GCC 4.8 and Clang 3.2.
-///
-/// Note that the **opposite** direction (from the platforms native
-/// representation to two's complement) is trivially handled by casting the
-/// signed value to a value of a sufficiently wide unsigned integer type. An
-/// unsigned type will be sufficiently wide if it has at least one more value
-/// bit than the signed type.
-///
-/// Interestingly, the C++ language offers no direct way of doing what this
-/// function does, yet, this function is implemented in a way that makes no
-/// assumption about the underlying platform except what is guaranteed by C++11.
-///
-/// \tparam From The unsigned type used to store the two's complement
-/// representation.
-///
-/// \tparam To A signed or unsigned integer type.
-template <class To, class From>
-To from_twos_compl(From twos_compl) noexcept;
-
-
-// Implementation:
-
-template <class T>
-inline typename Promote<T>::type promote(T value) noexcept
-{
-    typedef typename Promote<T>::type promoted_type;
-    promoted_type value_2 = promoted_type(value);
-    return value_2;
-}
-
 } // namespace util
 
 namespace _impl {
 
-template <class T, bool is_signed>
-struct IsNegative {
-    static bool test(T value) noexcept
-    {
-        return value < 0;
-    }
-};
-template <class T>
-struct IsNegative<T, false> {
-    static bool test(T) noexcept
-    {
-        return false;
-    }
-};
+template <class L, class R, typename = void>
+struct SafeIntBinopsImpl;
 
-template <class To>
-struct CastToUnsigned {
-    template <class From>
-    static To cast(From value) noexcept
-    {
-        return To(value);
-    }
-};
-template <>
-struct CastToUnsigned<bool> {
-    template <class From>
-    static bool cast(From value) noexcept
-    {
-        return bool(unsigned(value) & 1);
-    }
-};
-
-template <class L, class R, bool l_signed, bool r_signed>
-struct SafeIntBinopsImpl {
-};
-
-// (unsigned, unsigned) (all size combinations)
-//
-// This implementation utilizes the fact that overflow in unsigned
-// arithmetic is guaranteed to be handled by reduction modulo 2**N
-// where N is the number of bits in the unsigned type. The purpose of
-// the bitwise 'and' with lim_l::max() is to make a cast to bool
-// behave the same way as casts to other unsigned integer types.
-// Finally, this implementation uses the fact that if modular addition
-// overflows, then the result must be a value that is less than both
-// operands. Also, if modular subtraction overflows, then the result
-// must be a value that is greater than the first operand.
+// (both signed or both unsigned)
 template <class L, class R>
-struct SafeIntBinopsImpl<L, R, false, false> {
-    typedef std::numeric_limits<L> lim_l;
-    typedef std::numeric_limits<R> lim_r;
-    static const int needed_bits_l = lim_l::digits;
-    static const int needed_bits_r = lim_r::digits;
-    static const int needed_bits = needed_bits_l >= needed_bits_r ? needed_bits_l : needed_bits_r;
-    typedef typename util::FastestUnsigned<needed_bits>::type common_unsigned;
+struct SafeIntBinopsImpl<L, R, std::enable_if_t<std::is_signed_v<L> == std::is_signed_v<R>>> {
+    using common = std::common_type_t<L, R>;
     static bool equal(L l, R r) noexcept
     {
-        return common_unsigned(l) == common_unsigned(r);
+        return common(l) == common(r);
     }
     static bool less(L l, R r) noexcept
     {
-        return common_unsigned(l) < common_unsigned(r);
-    }
-    static bool add(L& lval, R rval) noexcept
-    {
-        L lval_2 = util::cast_to_unsigned<L>(lval + rval);
-        bool overflow = common_unsigned(lval_2) < common_unsigned(rval);
-        if (REALM_UNLIKELY(overflow))
-            return true;
-        lval = lval_2;
-        return false;
-    }
-    static bool sub(L& lval, R rval) noexcept
-    {
-        common_unsigned lval_2 = common_unsigned(lval) - common_unsigned(rval);
-        bool overflow = lval_2 > common_unsigned(lval);
-        if (REALM_UNLIKELY(overflow))
-            return true;
-        lval = util::cast_to_unsigned<L>(lval_2);
-        return false;
+        return common(l) < common(r);
     }
 };
 
-// (unsigned, signed) (all size combinations)
+// (unsigned, signed)
 template <class L, class R>
-struct SafeIntBinopsImpl<L, R, false, true> {
-    typedef std::numeric_limits<L> lim_l;
-    typedef std::numeric_limits<R> lim_r;
-    static const int needed_bits_l = lim_l::digits;
-    static const int needed_bits_r = lim_r::digits + 1;
-    static const int needed_bits = needed_bits_l >= needed_bits_r ? needed_bits_l : needed_bits_r;
-    typedef typename util::FastestUnsigned<needed_bits>::type common_unsigned;
-    typedef std::numeric_limits<common_unsigned> lim_cu;
+struct SafeIntBinopsImpl<L, R, std::enable_if_t<!std::is_signed_v<L> && std::is_signed_v<R>>> {
+    using lim_l = std::numeric_limits<L>;
+    using lim_r = std::numeric_limits<R>;
     static bool equal(L l, R r) noexcept
     {
-        return (lim_l::digits > lim_r::digits) ? r >= 0 && l == util::cast_to_unsigned<L>(r) : R(l) == r;
+        return (lim_l::digits > lim_r::digits) ? r >= 0 && l == L(r) : R(l) == r;
     }
     static bool less(L l, R r) noexcept
     {
-        return (lim_l::digits > lim_r::digits) ? r >= 0 && l < util::cast_to_unsigned<L>(r) : R(l) < r;
-    }
-    static bool add(L& lval, R rval) noexcept
-    {
-        common_unsigned lval_2 = lval + common_unsigned(rval);
-        bool overflow;
-        if (lim_l::digits < lim_cu::digits) {
-            overflow = common_unsigned(lval_2) > common_unsigned(lim_l::max());
-        }
-        else {
-            overflow = (lval_2 < common_unsigned(lval)) == (rval >= 0);
-        }
-        if (REALM_UNLIKELY(overflow))
-            return true;
-        lval = util::cast_to_unsigned<L>(lval_2);
-        return false;
-    }
-    static bool sub(L& lval, R rval) noexcept
-    {
-        common_unsigned lval_2 = lval - common_unsigned(rval);
-        bool overflow;
-        if (lim_l::digits < lim_cu::digits) {
-            overflow = common_unsigned(lval_2) > common_unsigned(lim_l::max());
-        }
-        else {
-            overflow = (common_unsigned(lval_2) > common_unsigned(lval)) == (rval >= 0);
-        }
-        if (REALM_UNLIKELY(overflow))
-            return true;
-        lval = util::cast_to_unsigned<L>(lval_2);
-        return false;
+        return (lim_l::digits > lim_r::digits) ? r >= 0 && l < L(r) : R(l) < r;
     }
 };
 
 // (signed, unsigned) (all size combinations)
 template <class L, class R>
-struct SafeIntBinopsImpl<L, R, true, false> {
-    typedef std::numeric_limits<L> lim_l;
-    typedef std::numeric_limits<R> lim_r;
-    static const int needed_bits_l = lim_l::digits + 1;
-    static const int needed_bits_r = lim_r::digits;
-    static const int needed_bits = needed_bits_l >= needed_bits_r ? needed_bits_l : needed_bits_r;
-    typedef typename util::FastestUnsigned<needed_bits>::type common_unsigned;
+struct SafeIntBinopsImpl<L, R, std::enable_if_t<std::is_signed_v<L> && !std::is_signed_v<R>>> {
     static bool equal(L l, R r) noexcept
     {
-        return (lim_l::digits < lim_r::digits) ? l >= 0 && util::cast_to_unsigned<R>(l) == r : l == L(r);
+        // r == l
+        return SafeIntBinopsImpl<R, L>::equal(r, l);
     }
     static bool less(L l, R r) noexcept
     {
-        return (lim_l::digits < lim_r::digits) ? l < 0 || util::cast_to_unsigned<R>(l) < r : l < L(r);
-    }
-    static bool add(L& lval, R rval) noexcept
-    {
-        common_unsigned max_add = common_unsigned(lim_l::max()) - common_unsigned(lval);
-        bool overflow = common_unsigned(rval) > max_add;
-        if (REALM_UNLIKELY(overflow))
-            return true;
-        lval = util::from_twos_compl<L>(common_unsigned(lval) + rval);
-        return false;
-    }
-    static bool sub(L& lval, R rval) noexcept
-    {
-        common_unsigned max_sub = common_unsigned(lval) - common_unsigned(lim_l::min());
-        bool overflow = common_unsigned(rval) > max_sub;
-        if (REALM_UNLIKELY(overflow))
-            return true;
-        lval = util::from_twos_compl<L>(common_unsigned(lval) - rval);
-        return false;
-    }
-};
-
-// (signed, signed) (all size combinations)
-template <class L, class R>
-struct SafeIntBinopsImpl<L, R, true, true> {
-    typedef std::numeric_limits<L> lim_l;
-    static bool equal(L l, R r) noexcept
-    {
-        return l == r;
-    }
-    static bool less(L l, R r) noexcept
-    {
-        return l < r;
-    }
-    static bool add(L& lval, R rval) noexcept
-    {
-        // Note that both subtractions below occur in a signed type
-        // that is at least as wide as both of the two types. Note
-        // also that any signed type guarantees that there is no
-        // overflow when subtracting two negative values or two
-        // non-negative value. See C99 (adopted as subset of C++11)
-        // section 6.2.6.2 "Integer types" paragraph 2.
-        if (rval < 0) {
-            if (REALM_UNLIKELY(lval < lim_l::min() - rval))
-                return true;
-        }
-        else {
-            if (REALM_UNLIKELY(lval > lim_l::max() - rval))
-                return true;
-        }
-        // The following statement has exactly the same effect as
-        // `lval += rval`.
-        lval = L(lval + rval);
-        return false;
-    }
-    static bool sub(L& lval, R rval) noexcept
-    {
-        // Note that both subtractions below occur in a signed type
-        // that is at least as wide as both of the two types. Note
-        // also that there can be no overflow when adding a negative
-        // value to a non-negative value, or when adding a
-        // non-negative value to a negative one.
-        if (rval < 0) {
-            if (REALM_UNLIKELY(lval > lim_l::max() + rval))
-                return true;
-        }
-        else {
-            if (REALM_UNLIKELY(lval < lim_l::min() + rval))
-                return true;
-        }
-        // The following statement has exactly the same effect as
-        // `lval += rval`.
-        lval = L(lval - rval);
-        return false;
+        // !(r == l || r < l)
+        return !(SafeIntBinopsImpl<R, L>::equal(r, l) || SafeIntBinopsImpl<R, L>::less(r, l));
     }
 };
 
 template <class L, class R>
-struct SafeIntBinops : SafeIntBinopsImpl<L, R, std::numeric_limits<L>::is_signed, std::numeric_limits<R>::is_signed> {
+struct SafeIntBinops : SafeIntBinopsImpl<L, R> {
     typedef std::numeric_limits<L> lim_l;
     typedef std::numeric_limits<R> lim_r;
     static_assert(lim_l::is_specialized && lim_r::is_specialized,
@@ -482,18 +217,6 @@ struct SafeIntBinops : SafeIntBinopsImpl<L, R, std::numeric_limits<L>::is_signed
 } // namespace _impl
 
 namespace util {
-
-template <class T>
-inline bool is_negative(T value) noexcept
-{
-    return _impl::IsNegative<T, std::numeric_limits<T>::is_signed>::test(value);
-}
-
-template <class To, class From>
-inline To cast_to_unsigned(From value) noexcept
-{
-    return _impl::CastToUnsigned<To>::cast(value);
-}
 
 template <class A, class B>
 inline bool int_equal_to(A a, B b) noexcept
@@ -534,32 +257,45 @@ inline bool int_greater_than_or_equal(A a, B b) noexcept
 template <class L, class R>
 inline bool int_add_with_overflow_detect(L& lval, R rval) noexcept
 {
-    return _impl::SafeIntBinops<L, R>::add(lval, rval);
+    // Note: MSVC returns true on success, while gcc/clang return true on overflow.
+    // Note: Both may write to destination on overflow, but our tests check that this doesn't happen.
+    auto old = lval;
+#ifdef _MSC_VER
+    auto overflow = !msl::utilities::SafeAdd(lval, rval, lval);
+#else
+    auto overflow = __builtin_add_overflow(lval, rval, &lval);
+#endif
+    if (REALM_UNLIKELY(overflow))
+        lval = old;
+    return overflow;
 }
 
 template <class L, class R>
 inline bool int_subtract_with_overflow_detect(L& lval, R rval) noexcept
 {
-    return _impl::SafeIntBinops<L, R>::sub(lval, rval);
+    auto old = lval;
+#ifdef _MSC_VER
+    auto overflow = !msl::utilities::SafeSubtract(lval, rval, lval);
+#else
+    auto overflow = __builtin_sub_overflow(lval, rval, &lval);
+#endif
+    if (REALM_UNLIKELY(overflow))
+        lval = old;
+    return overflow;
 }
 
 template <class L, class R>
 inline bool int_multiply_with_overflow_detect(L& lval, R rval) noexcept
 {
-    // FIXME: Check if the following optimizes better (if it works at all):
-    // L lval_2 = L(lval * rval);
-    // bool overflow  =  rval != 0  &&  (lval_2 / rval) != lval;
-    typedef std::numeric_limits<L> lim_l;
-    typedef std::numeric_limits<R> lim_r;
-    static_assert(lim_l::is_specialized && lim_r::is_specialized,
-                  "std::numeric_limits<> must be specialized for both types");
-    static_assert(lim_l::is_integer && lim_r::is_integer, "Both types must be integers");
-    REALM_ASSERT(int_greater_than_or_equal(lval, 0));
-    REALM_ASSERT(int_greater_than(rval, 0));
-    if (int_less_than(lim_l::max() / rval, lval))
-        return true;
-    lval = L(lval * rval);
-    return false;
+    auto old = lval;
+#ifdef _MSC_VER
+    auto overflow = !msl::utilities::SafeMultiply(lval, rval, lval);
+#else
+    auto overflow = __builtin_mul_overflow(lval, rval, &lval);
+#endif
+    if (REALM_UNLIKELY(overflow))
+        lval = old;
+    return overflow;
 }
 
 template <class T>
@@ -591,31 +327,6 @@ inline bool int_cast_with_overflow_detect(From from, To& to) noexcept
     }
     return true;
 }
-
-template <class To, class From>
-inline To from_twos_compl(From twos_compl) noexcept
-{
-    typedef std::numeric_limits<From> lim_f;
-    typedef std::numeric_limits<To> lim_t;
-    static_assert(lim_f::is_specialized && lim_t::is_specialized,
-                  "std::numeric_limits<> must be specialized for both types");
-    static_assert(lim_f::is_integer && lim_t::is_integer, "Both types must be integers");
-    static_assert(!lim_f::is_signed, "`From` must be unsigned");
-    To native;
-    int sign_bit_pos = lim_f::digits - 1;
-    From sign_bit = From(1) << sign_bit_pos;
-    bool non_negative = !lim_t::is_signed || (twos_compl & sign_bit) == 0;
-    if (non_negative) {
-        // Non-negative value
-        native = To(twos_compl);
-    }
-    else {
-        // Negative value
-        native = To(-1 - To(From(-1) - twos_compl));
-    }
-    return native;
-}
-
 
 } // namespace util
 } // namespace realm

--- a/test/experiments/query_expr.hpp
+++ b/test/experiments/query_expr.hpp
@@ -162,11 +162,7 @@ struct Compl {
         return "~";
     }
     template <class A>
-    struct Result {
-        typedef typename Promote<A>::type type;
-    };
-    template <class A>
-    static typename Result<A>::type eval(const A& a)
+    static auto eval(const A& a)
     {
         return ~a;
     }
@@ -181,11 +177,7 @@ struct Pos {
         return "+";
     }
     template <class A>
-    struct Result {
-        typedef typename Promote<A>::type type;
-    };
-    template <class A>
-    static typename Result<A>::type eval(const A& a)
+    static auto eval(const A& a)
     {
         return +a;
     }
@@ -198,11 +190,7 @@ struct Neg {
         return "-";
     }
     template <class A>
-    struct Result {
-        typedef typename Promote<A>::type type;
-    };
-    template <class A>
-    static typename Result<A>::type eval(const A& a)
+    static auto eval(const A& a)
     {
         return -a;
     }
@@ -316,12 +304,8 @@ struct Shl {
     {
         return "<<";
     }
-    template <class A, class>
-    struct Result {
-        typedef typename Promote<A>::type type;
-    };
     template <class A, class B>
-    static typename Result<A, B>::type eval(const A& a, const B& b)
+    static auto eval(const A& a, const B& b)
     {
         return a << b;
     }
@@ -333,12 +317,8 @@ struct Shr {
     {
         return ">>";
     }
-    template <class A, class>
-    struct Result {
-        typedef typename Promote<A>::type type;
-    };
     template <class A, class B>
-    static typename Result<A, B>::type eval(const A& a, const B& b)
+    static auto eval(const A& a, const B& b)
     {
         return a >> b;
     }

--- a/test/test_safe_int_ops.cpp
+++ b/test/test_safe_int_ops.cpp
@@ -73,18 +73,10 @@ using unit_test::TestContext;
 // values for each fundamental standard type, and also using 0 and -1
 // for signed types.
 
-// FIXME: Test realm::util::from_twos_compl(). For each type pair
-// (S,U), and for each super_int `i` in special set, if i.get_as<S>(s)
-// && two's compl of `s` can be stored in U without loss of
-// information, then CHECK_EQUAL(s, from_twos_compl(U(s))). Two's
-// compl of `s` can be stored in U without loss of information if, and
-// only if make_unsigned<S>::type(s < 0 ?  -1-s : s) <
-// (U(1)<<(lim_u::digits-1)).
-
 
 TEST(SafeIntOps_AddWithOverflowDetect)
 {
-    {   // signed and signed
+    { // signed and signed
         int lval = 255;
         char rval = 10;
         CHECK(!int_add_with_overflow_detect(lval, rval));
@@ -110,7 +102,7 @@ TEST(SafeIntOps_AddWithOverflowDetect)
         CHECK(int_add_with_overflow_detect(lval, rval));    // does overflow
         CHECK_EQUAL(lval, std::numeric_limits<int>::min()); // unchanged
     }
-    {   // signed and unsigned
+    { // signed and unsigned
         char lval = std::numeric_limits<char>::max();
         size_t rval = 0;
         CHECK(!int_add_with_overflow_detect(lval, rval));
@@ -136,7 +128,7 @@ TEST(SafeIntOps_AddWithOverflowDetect)
         CHECK(int_add_with_overflow_detect(lval, rval));
         CHECK_EQUAL(lval, -1);
     }
-    {   // unsigned and signed
+    { // unsigned and signed
         size_t lval = std::numeric_limits<size_t>::max();
         char rval = 0;
         CHECK(!int_add_with_overflow_detect(lval, rval));
@@ -178,7 +170,7 @@ TEST(SafeIntOps_AddWithOverflowDetect)
         CHECK(int_add_with_overflow_detect(lval2, rval2));
         CHECK_EQUAL(lval2, 0);
     }
-    {   // unsigned and unsigned
+    { // unsigned and unsigned
         size_t lval = std::numeric_limits<size_t>::max();
         size_t rval = 0;
         CHECK(!int_add_with_overflow_detect(lval, rval));
@@ -209,7 +201,7 @@ TEST(SafeIntOps_AddWithOverflowDetect)
 
 TEST(SafeIntOps_SubtractWithOverflowDetect)
 {
-    {   // signed and signed
+    { // signed and signed
         int lval = std::numeric_limits<int>::max() - 1;
         char rval = -10;
         CHECK(int_subtract_with_overflow_detect(lval, rval));   // does overflow
@@ -217,25 +209,25 @@ TEST(SafeIntOps_SubtractWithOverflowDetect)
 
         rval = -1;
         lval = std::numeric_limits<int>::max();
-        CHECK(int_subtract_with_overflow_detect(lval, rval));   // does overflow
-        CHECK_EQUAL(lval, std::numeric_limits<int>::max());     // unchanged
+        CHECK(int_subtract_with_overflow_detect(lval, rval)); // does overflow
+        CHECK_EQUAL(lval, std::numeric_limits<int>::max());   // unchanged
 
         rval = 0;
         lval = std::numeric_limits<int>::max();
-        CHECK(!int_subtract_with_overflow_detect(lval, rval));  // does not overflow
-        CHECK_EQUAL(lval, std::numeric_limits<int>::max());     // unchanged
+        CHECK(!int_subtract_with_overflow_detect(lval, rval)); // does not overflow
+        CHECK_EQUAL(lval, std::numeric_limits<int>::max());    // unchanged
 
         rval = 0;
         lval = std::numeric_limits<int>::min();
-        CHECK(!int_subtract_with_overflow_detect(lval, rval));  // does not overflow
-        CHECK_EQUAL(lval, std::numeric_limits<int>::min());     // unchanged
+        CHECK(!int_subtract_with_overflow_detect(lval, rval)); // does not overflow
+        CHECK_EQUAL(lval, std::numeric_limits<int>::min());    // unchanged
 
         rval = 1;
         lval = std::numeric_limits<int>::min();
-        CHECK(int_subtract_with_overflow_detect(lval, rval));   // does overflow
-        CHECK_EQUAL(lval, std::numeric_limits<int>::min());     // unchanged
+        CHECK(int_subtract_with_overflow_detect(lval, rval)); // does overflow
+        CHECK_EQUAL(lval, std::numeric_limits<int>::min());   // unchanged
     }
-    {   // signed and unsigned
+    { // signed and unsigned
         char lval = std::numeric_limits<char>::min();
         size_t rval = 0;
         CHECK(!int_subtract_with_overflow_detect(lval, rval));
@@ -266,7 +258,7 @@ TEST(SafeIntOps_SubtractWithOverflowDetect)
         CHECK(int_subtract_with_overflow_detect(lval, rval));
         CHECK_EQUAL(lval, -1);
     }
-    {   // unsigned and signed
+    { // unsigned and signed
         size_t lval = std::numeric_limits<size_t>::min();
         char rval = 0;
         CHECK(!int_subtract_with_overflow_detect(lval, rval));
@@ -308,7 +300,7 @@ TEST(SafeIntOps_SubtractWithOverflowDetect)
         CHECK(int_subtract_with_overflow_detect(lval2, rval2));
         CHECK_EQUAL(lval2, std::numeric_limits<unsigned char>::max());
     }
-    {   // unsigned and unsigned
+    { // unsigned and unsigned
         size_t lval = std::numeric_limits<size_t>::min();
         size_t rval = 0;
         CHECK(!int_subtract_with_overflow_detect(lval, rval));
@@ -435,11 +427,11 @@ TEST(SafeIntOps_ShiftLeft)
     CHECK(!int_shift_left_with_overflow_detect(unsigned_int, std::numeric_limits<size_t>::digits - 1));
     CHECK_EQUAL(unsigned_int, size_t(1) << (std::numeric_limits<size_t>::digits - 1));
 
-// Shifting by 64 (or greater) is not defined behaviour.
-// With clang, the following does not overflow and gives unsigned_int == 1
-//    unsigned_int = 1;
-//    CHECK(int_shift_left_with_overflow_detect(unsigned_int, std::numeric_limits<size_t>::digits));
-//    CHECK_EQUAL(unsigned_int, 1);
+    // Shifting by 64 (or greater) is not defined behaviour.
+    // With clang, the following does not overflow and gives unsigned_int == 1
+    //    unsigned_int = 1;
+    //    CHECK(int_shift_left_with_overflow_detect(unsigned_int, std::numeric_limits<size_t>::digits));
+    //    CHECK_EQUAL(unsigned_int, 1);
 
     unsigned_int = 2;
     CHECK(int_shift_left_with_overflow_detect(unsigned_int, std::numeric_limits<size_t>::digits - 1));
@@ -475,61 +467,6 @@ TEST(SafeIntOps_ShiftLeft)
 }
 
 
-TEST(SafeIntOps_IsNegative)
-{
-    size_t unsigned_int = 0;
-    CHECK(!is_negative(unsigned_int));
-
-    unsigned_int = size_t(-1);
-    CHECK(!is_negative(unsigned_int));
-
-    char c = 0;
-    CHECK(!is_negative(c));
-
-    c = 1;
-    CHECK(!is_negative(c));
-
-    c = std::numeric_limits<char>::max();
-    CHECK(!is_negative(c));
-
-    c = char(-1);
-    CHECK(is_negative(c));
-
-    c = std::numeric_limits<char>::min();
-    CHECK(is_negative(c));
-}
-
-
-TEST(SafeIntOps_CastToUnsigned)
-{
-    size_t from_unsigned = size_t(-1);
-    size_t to_unsigned = cast_to_unsigned<size_t>(from_unsigned);
-    CHECK_EQUAL(to_unsigned, from_unsigned);
-
-    int from_signed = 1;
-    bool to_bool = cast_to_unsigned<bool>(from_signed);
-    CHECK_EQUAL(to_bool, true);
-
-    from_signed = 2;
-    to_bool = cast_to_unsigned<bool>(from_signed);
-    CHECK_EQUAL(to_bool, false);
-    to_unsigned = cast_to_unsigned<size_t>(from_signed);
-    CHECK_EQUAL(to_unsigned, 2);
-
-    from_signed = -1;
-    to_bool = cast_to_unsigned<bool>(from_signed);
-    CHECK_EQUAL(to_bool, true);
-    to_unsigned = cast_to_unsigned<size_t>(from_signed);
-    CHECK_EQUAL(to_unsigned, size_t(-1));
-
-    from_signed = -2;
-    to_bool = cast_to_unsigned<bool>(from_signed);
-    CHECK_EQUAL(to_bool, false);
-    to_unsigned = cast_to_unsigned<size_t>(from_signed);
-    CHECK_EQUAL(to_unsigned, size_t(-2));
-}
-
-
 namespace {
 
 template <class T_1, class T_2>
@@ -560,7 +497,6 @@ void test_two_args(TestContext& test_context, const std::set<super_int>& values)
     iter_2 end_2 = values_2.end();
     for (iter_1 i_1 = values_1.begin(); i_1 != end_1; ++i_1) {
         for (iter_2 i_2 = values_2.begin(); i_2 != end_2; ++i_2) {
-            //            std::cout << "--> " << promote(*i_1) << " vs " << promote(*i_2) << "\n";
             // Comparisons
             {
                 T_1 v_1 = *i_1;
@@ -628,8 +564,7 @@ void test_two_args(TestContext& test_context, const std::set<super_int>& values)
 }
 
 
-typedef void types_00;
-typedef TypeAppend<types_00, bool>::type types_01;
+typedef void types_01;
 typedef TypeAppend<types_01, char>::type types_02;
 typedef TypeAppend<types_02, signed char>::type types_03;
 typedef TypeAppend<types_03, unsigned char>::type types_04;


### PR DESCRIPTION
1. C++ now guarantees two's complement
2. Use platform-provided overflow detection