### PR TITLE
Make copy_on_write when setting context flag in BplusTree<ObjKey>

### DIFF
--- a/src/realm/array.hpp
+++ b/src/realm/array.hpp
@@ -1182,7 +1182,7 @@ inline bool Array::get_context_flag() const noexcept
 inline void Array::set_context_flag(bool value) noexcept
 {
     if (m_context_flag != value) {
-        REALM_ASSERT(!is_read_only());
+        copy_on_write();
         m_context_flag = value;
         set_context_flag_in_header(value, get_header());
     }

--- a/src/realm/bplustree.cpp
+++ b/src/realm/bplustree.cpp
@@ -34,7 +34,11 @@ void BPlusTreeNode::set_context_flag(bool cf) noexcept
 {
     auto ref = get_ref();
     MemRef mem(ref, m_tree->get_alloc());
-    Array::set_context_flag_in_header(cf, mem.get_addr());
+    if (Array::get_context_flag_from_header(mem.get_addr()) != cf) {
+        Array arr(m_tree->get_alloc());
+        arr.init_from_mem(mem);
+        arr.set_context_flag(cf);
+    }
 }
 
 


### PR DESCRIPTION
If we are replacing the root with an inner node, that node may not be writeable.