### PR TITLE
Array::alloc() shouldn't break class invariants

### DIFF
--- a/src/realm/array.hpp
+++ b/src/realm/array.hpp
@@ -147,9 +147,7 @@ public:
     {
     }
 
-    ~Array() noexcept override
-    {
-    }
+    ~Array() noexcept override {}
 
     /// Create a new integer array of the specified type and size, and filled
     /// with the specified value, and attach this accessor to it. This does not
@@ -211,6 +209,13 @@ public:
 
     Type get_type() const noexcept;
 
+    /// The meaning of 'width' depends on the context in which this
+    /// array is used.
+    size_t get_width() const noexcept
+    {
+        REALM_ASSERT_3(m_width, ==, get_width_from_header(get_header()));
+        return m_width;
+    }
 
     static void add_to_column(IntegerColumn* column, int64_t value);
     static void add_to_column(KeyColumn* column, int64_t value);
@@ -253,6 +258,14 @@ public:
 
     int64_t front() const noexcept;
     int64_t back() const noexcept;
+
+    void alloc(size_t init_size, size_t new_width)
+    {
+        REALM_ASSERT_3(m_width, ==, get_width_from_header(get_header()));
+        REALM_ASSERT_3(m_size, ==, get_size_from_header(get_header()));
+        Node::alloc(init_size, new_width);
+        update_width_cache_from_header();
+    }
 
     /// Remove the element at the specified index, and move elements at higher
     /// indexes to the next lower index.
@@ -687,9 +700,7 @@ public:
     class ToDotHandler {
     public:
         virtual void to_dot(MemRef leaf_mem, ArrayParent*, size_t ndx_in_parent, std::ostream&) = 0;
-        ~ToDotHandler()
-        {
-        }
+        ~ToDotHandler() {}
     };
     void bptree_to_dot(std::ostream&, ToDotHandler&) const;
     void to_dot_parent_edge(std::ostream&) const;
@@ -703,23 +714,15 @@ protected:
 protected:
     // This returns the minimum value ("lower bound") of the representable values
     // for the given bit width. Valid widths are 0, 1, 2, 4, 8, 16, 32, and 64.
-    template <size_t width>
-    static int_fast64_t lbound_for_width() noexcept;
-
     static int_fast64_t lbound_for_width(size_t width) noexcept;
 
     // This returns the maximum value ("inclusive upper bound") of the representable values
     // for the given bit width. Valid widths are 0, 1, 2, 4, 8, 16, 32, and 64.
-    template <size_t width>
-    static int_fast64_t ubound_for_width() noexcept;
-
     static int_fast64_t ubound_for_width(size_t width) noexcept;
 
-    template <size_t width>
-    void set_width() noexcept;
-    void set_width(size_t) noexcept;
-
 private:
+    void update_width_cache_from_header() noexcept;
+
     void do_ensure_minimum_width(int_fast64_t);
 
     template <size_t w>
@@ -779,8 +782,9 @@ private:
     const VTable* m_vtable = nullptr;
 
 protected:
-    int64_t m_lbound; // min number that can be stored with current m_width
-    int64_t m_ubound; // max number that can be stored with current m_width
+    uint_least8_t m_width = 0; // Size of an element (meaning depend on type of array).
+    int64_t m_lbound;          // min number that can be stored with current m_width
+    int64_t m_ubound;          // max number that can be stored with current m_width
 
     bool m_is_inner_bptree_node; // This array is an inner node of B+-tree.
     bool m_has_refs;             // Elements whose first bit is zero are refs to subarrays.
@@ -1839,8 +1843,10 @@ size_t Array::find_zero(uint64_t v) const
 template <bool gt, size_t width>
 int64_t Array::find_gtlt_magic(int64_t v) const
 {
-    uint64_t mask1 = (width == 64 ? ~0ULL : ((1ULL << (width == 64 ? 0 : width)) -
-                                             1ULL)); // Warning free way of computing (1ULL << width) - 1
+    uint64_t mask1 =
+        (width == 64
+             ? ~0ULL
+             : ((1ULL << (width == 64 ? 0 : width)) - 1ULL)); // Warning free way of computing (1ULL << width) - 1
     uint64_t mask2 = mask1 >> 1;
     uint64_t magic = gt ? (~0ULL / no0(mask1) * (mask2 - v)) : (~0ULL / no0(mask1) * v);
     return magic;
@@ -1853,8 +1859,10 @@ bool Array::find_gtlt_fast(uint64_t chunk, uint64_t magic, QueryState<int64_t>* 
     // Tests if a a chunk of values contains values that are greater (if gt == true) or less (if gt == false) than v.
     // Fast, but limited to work when all values in the chunk are positive.
 
-    uint64_t mask1 = (width == 64 ? ~0ULL : ((1ULL << (width == 64 ? 0 : width)) -
-                                             1ULL)); // Warning free way of computing (1ULL << width) - 1
+    uint64_t mask1 =
+        (width == 64
+             ? ~0ULL
+             : ((1ULL << (width == 64 ? 0 : width)) - 1ULL)); // Warning free way of computing (1ULL << width) - 1
     uint64_t mask2 = mask1 >> 1;
     uint64_t m = gt ? (((chunk + magic) | chunk) & ~0ULL / no0(mask1) * (mask2 + 1))
                     : ((chunk - magic) & ~chunk & ~0ULL / no0(mask1) * (mask2 + 1));
@@ -2054,8 +2062,10 @@ inline bool Array::compare_equality(int64_t value, size_t start, size_t end, siz
     if (width != 32 && width != 64) {
         const int64_t* p = reinterpret_cast<const int64_t*>(m_data + (start * width / 8));
         const int64_t* const e = reinterpret_cast<int64_t*>(m_data + (end * width / 8)) - 1;
-        const uint64_t mask = (width == 64 ? ~0ULL : ((1ULL << (width == 64 ? 0 : width)) -
-                                                      1ULL)); // Warning free way of computing (1ULL << width) - 1
+        const uint64_t mask =
+            (width == 64
+                 ? ~0ULL
+                 : ((1ULL << (width == 64 ? 0 : width)) - 1ULL)); // Warning free way of computing (1ULL << width) - 1
         const uint64_t valuemask =
             ~0ULL / no0(mask) * (value & mask); // the "== ? :" is to avoid division by 0 compiler error
 
@@ -2393,8 +2403,9 @@ bool Array::compare_relation(int64_t value, size_t start, size_t end, size_t bas
                              Callback callback) const
 {
     REALM_ASSERT(start <= m_size && (end <= m_size || end == size_t(-1)) && start <= end);
-    uint64_t mask = (bitwidth == 64 ? ~0ULL : ((1ULL << (bitwidth == 64 ? 0 : bitwidth)) -
-                                               1ULL)); // Warning free way of computing (1ULL << width) - 1
+    uint64_t mask = (bitwidth == 64 ? ~0ULL
+                                    : ((1ULL << (bitwidth == 64 ? 0 : bitwidth)) -
+                                       1ULL)); // Warning free way of computing (1ULL << width) - 1
 
     size_t ee = round_up(start, 64 / no0(bitwidth));
     ee = ee > end ? end : ee;

--- a/src/realm/array_basic_tpl.hpp
+++ b/src/realm/array_basic_tpl.hpp
@@ -141,12 +141,13 @@ void BasicArray<T>::insert(size_t ndx, T value)
     copy_on_write(); // Throws
 
     // Make room for the new value
+    const auto old_size = m_size;
     alloc(m_size + 1, m_width); // Throws
 
     // Move values below insertion
-    if (ndx != m_size) {
+    if (ndx != old_size) {
         char* src_begin = m_data + ndx * m_width;
-        char* src_end = m_data + m_size * m_width;
+        char* src_end = m_data + old_size * m_width;
         char* dst_end = src_end + m_width;
         std::copy_backward(src_begin, src_end, dst_end);
     }
@@ -154,8 +155,6 @@ void BasicArray<T>::insert(size_t ndx, T value)
     // Set the value
     T* data = reinterpret_cast<T*>(m_data) + ndx;
     *data = value;
-
-    ++m_size;
 }
 
 template <class T>

--- a/src/realm/array_blob.cpp
+++ b/src/realm/array_blob.cpp
@@ -125,6 +125,7 @@ ref_type ArrayBlob::replace(size_t begin, size_t end, const char* data, size_t d
     REALM_ASSERT(!get_context_flag());
     size_t remove_size = end - begin;
     size_t add_size = add_zero_term ? data_size + 1 : data_size;
+    size_t old_size = m_size;
     size_t new_size = m_size - remove_size + add_size;
 
     // If size of BinaryData is below 'max_binary_size', the data is stored directly
@@ -151,9 +152,9 @@ ref_type ArrayBlob::replace(size_t begin, size_t end, const char* data, size_t d
 
     // Resize previous space to fit new data
     // (not needed if we append to end)
-    if (begin != m_size) {
+    if (begin != old_size) {
         const char* old_begin = m_data + end;
-        const char* old_end = m_data + m_size;
+        const char* old_end = m_data + old_size;
         if (remove_size < add_size) { // expand gap
             char* new_end = m_data + new_size;
             std::copy_backward(old_begin, old_end, new_end);
@@ -168,8 +169,6 @@ ref_type ArrayBlob::replace(size_t begin, size_t end, const char* data, size_t d
     modify_begin = realm::safe_copy_n(data, data_size, modify_begin);
     if (add_zero_term)
         *modify_begin = 0;
-
-    m_size = new_size;
 
     return get_ref();
 }

--- a/src/realm/array_decimal128.cpp
+++ b/src/realm/array_decimal128.cpp
@@ -33,14 +33,12 @@ void ArrayDecimal128::insert(size_t ndx, Decimal128 value)
     REALM_ASSERT(ndx <= m_size);
     // Allocate room for the new value
     alloc(m_size + 1, sizeof(Decimal128)); // Throws
-    m_width = sizeof(Decimal128);
 
     auto src = reinterpret_cast<Decimal128*>(m_data) + ndx;
     auto dst = src + 1;
 
     // Make gap for new value
-    memmove(dst, src, sizeof(Decimal128) * (m_size - ndx));
-    m_size += 1;
+    memmove(dst, src, sizeof(Decimal128) * (m_size - 1 - ndx));
 
     // Set new value
     *src = value;
@@ -66,12 +64,11 @@ void ArrayDecimal128::move(ArrayDecimal128& dst_arr, size_t ndx)
 {
     size_t elements_to_move = m_size - ndx;
     if (elements_to_move) {
-        dst_arr.alloc(dst_arr.m_size + elements_to_move, sizeof(Decimal128));
-        dst_arr.m_width = sizeof(Decimal128);
-        Decimal128* dst = reinterpret_cast<Decimal128*>(dst_arr.m_data) + dst_arr.m_size;
+        const auto old_dst_size = dst_arr.m_size;
+        dst_arr.alloc(old_dst_size + elements_to_move, sizeof(Decimal128));
+        Decimal128* dst = reinterpret_cast<Decimal128*>(dst_arr.m_data) + old_dst_size;
         Decimal128* src = reinterpret_cast<Decimal128*>(m_data) + ndx;
         memmove(dst, src, elements_to_move * sizeof(Decimal128));
-        dst_arr.m_size += elements_to_move;
     }
     truncate(ndx);
 }

--- a/src/realm/array_integer.hpp
+++ b/src/realm/array_integer.hpp
@@ -30,9 +30,7 @@ public:
     using value_type = int64_t;
 
     explicit ArrayInteger(Allocator&) noexcept;
-    ~ArrayInteger() noexcept override
-    {
-    }
+    ~ArrayInteger() noexcept override {}
 
     static value_type default_value(bool)
     {
@@ -328,9 +326,7 @@ inline ArrayIntNull::ArrayIntNull(Allocator& allocator) noexcept
 {
 }
 
-inline ArrayIntNull::~ArrayIntNull() noexcept
-{
-}
+inline ArrayIntNull::~ArrayIntNull() noexcept {}
 
 inline void ArrayIntNull::create(Type type, bool context_flag)
 {
@@ -662,6 +658,6 @@ inline size_t ArrayIntNull::find_first(value_type value, size_t begin, size_t en
 {
     return find_first<Equal>(value, begin, end);
 }
-}
+} // namespace realm
 
 #endif // REALM_ARRAY_INTEGER_HPP

--- a/src/realm/array_object_id.cpp
+++ b/src/realm/array_object_id.cpp
@@ -46,8 +46,6 @@ void ArrayObjectId::insert(size_t ndx, const ObjectId& value)
     // Allocate room for the new value
     const auto new_byte_size = calc_required_bytes(old_size + 1);
     alloc(new_byte_size, 1); // Throws
-    m_size = new_byte_size;
-    m_width = 1;
 
     auto dest = get_pos(old_size);
 
@@ -104,8 +102,6 @@ void ArrayObjectId::move(ArrayObjectId& dst_arr, size_t ndx)
     // Allocate room for the new value
     const auto new_dest_byte_size = calc_required_bytes(old_dst_size + n_to_move);
     dst_arr.alloc(new_dest_byte_size, 1); // Throws
-    dst_arr.m_width = 1;
-    dst_arr.m_size = new_dest_byte_size;
 
     // Initialize last null byte.
     const auto last_in_dst = get_pos(old_dst_size + n_to_move - 1);

--- a/src/realm/array_string_short.cpp
+++ b/src/realm/array_string_short.cpp
@@ -84,33 +84,34 @@ void ArrayStringShort::set(size_t ndx, StringData value)
     if (m_width <= value.size()) {
         // Calc min column width
         size_t new_width = ::round_up(value.size() + 1);
+        const size_t old_width = m_width;
         alloc(m_size, new_width); // Throws
 
         char* base = m_data;
         char* new_end = base + m_size * new_width;
 
         // Expand the old values in reverse order
-        if (0 < m_width) {
-            const char* old_end = base + m_size * m_width;
+        if (old_width > 0) {
+            const char* old_end = base + m_size * old_width;
             while (new_end != base) {
-                *--new_end = char(*--old_end + (new_width - m_width));
+                *--new_end = char(*--old_end + (new_width - old_width));
                 {
                     // extend 0-padding
-                    char* new_begin = new_end - (new_width - m_width);
+                    char* new_begin = new_end - (new_width - old_width);
                     std::fill(new_begin, new_end, 0);
                     new_end = new_begin;
                 }
                 {
                     // copy string payload
-                    const char* old_begin = old_end - (m_width - 1);
-                    if (static_cast<size_t>(old_end - old_begin) < m_width) // non-null string
+                    const char* old_begin = old_end - (old_width - 1);
+                    if (static_cast<size_t>(old_end - old_begin) < old_width) // non-null string
                         new_end = std::copy_backward(old_begin, old_end, new_end);
                     old_end = old_begin;
                 }
             }
         }
         else {
-            // m_width == 0. Expand to new width.
+            // old_width == 0. Expand to new width.
             while (new_end != base) {
                 REALM_ASSERT_3(new_width, <=, max_width);
                 *--new_end = static_cast<char>(new_width);
@@ -121,8 +122,6 @@ void ArrayStringShort::set(size_t ndx, StringData value)
                 }
             }
         }
-
-        m_width = uint_least8_t(new_width);
     }
     else if (is_read_only()) {
         if (get(ndx) == value)
@@ -160,12 +159,11 @@ void ArrayStringShort::insert(size_t ndx, StringData value)
     // bit complex.
 
     // Allocate room for the new value
+    const auto old_size = m_size;
     alloc(m_size + 1, m_width); // Throws
 
     // Make gap for new value
-    memmove(m_data + m_width * (ndx + 1), m_data + m_width * ndx, m_width * (m_size - ndx));
-
-    m_size++;
+    memmove(m_data + m_width * (ndx + 1), m_data + m_width * ndx, m_width * (old_size - ndx));
 
     // Set new value
     set(ndx, value);

--- a/src/realm/array_unsigned.cpp
+++ b/src/realm/array_unsigned.cpp
@@ -181,7 +181,9 @@ void ArrayUnsigned::insert(size_t ndx, uint64_t value)
 {
     REALM_ASSERT_DEBUG(m_width >= 8);
     bool do_expand = value > m_ubound;
-    uint8_t new_width = do_expand ? bit_width(value) : m_width;
+    const uint8_t old_width = m_width;
+    const uint8_t new_width = do_expand ? bit_width(value) : m_width;
+    const auto old_size = m_size;
 
     REALM_ASSERT_DEBUG(!do_expand || new_width > m_width);
     REALM_ASSERT_DEBUG(ndx <= m_size);
@@ -192,10 +194,10 @@ void ArrayUnsigned::insert(size_t ndx, uint64_t value)
 
     // Move values above insertion (may expand)
     if (do_expand) {
-        size_t i = m_size;
+        size_t i = old_size;
         while (i > ndx) {
             --i;
-            auto tmp = _get(i, m_width);
+            auto tmp = _get(i, old_width);
             _set(i + 1, new_width, tmp);
         }
     }
@@ -203,7 +205,7 @@ void ArrayUnsigned::insert(size_t ndx, uint64_t value)
         size_t w = (new_width >> 3);
 
         char* src_begin = m_data + ndx * w;
-        char* src_end = m_data + m_size * w;
+        char* src_end = m_data + old_size * w;
         char* dst = src_end + w;
 
         std::copy_backward(src_begin, src_end, dst);
@@ -217,14 +219,9 @@ void ArrayUnsigned::insert(size_t ndx, uint64_t value)
         size_t i = ndx;
         while (i != 0) {
             --i;
-            _set(i, new_width, _get(i, m_width));
+            _set(i, new_width, _get(i, old_width));
         }
-        set_width(new_width);
     }
-
-    // Update size
-    // (no need to do it in header as it has been done by Alloc)
-    ++m_size;
 }
 
 void ArrayUnsigned::erase(size_t ndx)
@@ -256,18 +253,17 @@ void ArrayUnsigned::set(size_t ndx, uint64_t value)
     copy_on_write(); // Throws
 
     if (value > m_ubound) {
-        uint8_t new_width = bit_width(value);
+        const uint8_t old_width = m_width;
+        const uint8_t new_width = bit_width(value);
 
         alloc(m_size, new_width); // Throws
 
         size_t i = m_size;
         while (i) {
             i--;
-            auto v = _get(i, m_width);
+            auto v = _get(i, old_width);
             _set(i, new_width, v);
         }
-
-        set_width(new_width);
     }
 
     _set(ndx, m_width, value);
@@ -280,6 +276,7 @@ void ArrayUnsigned::truncate(size_t ndx)
     set_header_size(m_size);
     if (ndx == 0) {
         set_width(8);
+        set_width_in_header(8, get_header());
     }
 }
 

--- a/src/realm/array_unsigned.hpp
+++ b/src/realm/array_unsigned.hpp
@@ -45,12 +45,6 @@ public:
 
     bool update_from_parent(size_t old_baseline) noexcept;
 
-    void init_from_mem(MemRef mem) noexcept
-    {
-        Node::init_from_mem(mem);
-        set_width(m_width);
-    }
-
     size_t lower_bound(uint64_t value) const noexcept;
     size_t upper_bound(uint64_t value) const noexcept;
 
@@ -68,13 +62,6 @@ public:
     // override value at index
     void set(size_t ndx, uint64_t value);
 
-    void adjust(size_t ndx, int64_t diff)
-    {
-        if (diff != 0) {
-            set(ndx, get(ndx) + diff); // Throws
-        }
-    }
-
     void adjust(size_t begin, size_t end, int64_t diff)
     {
         if (diff != 0) {
@@ -86,8 +73,35 @@ public:
 
     void truncate(size_t ndx);
 
+    /// The meaning of 'width' depends on the context in which this
+    /// array is used.
+    size_t get_width() const noexcept
+    {
+        return m_width;
+    }
+
 private:
-    uint64_t m_ubound; // max number that can be stored with current m_width
+    uint_least8_t m_width = 0; // Size of an element (meaning depend on type of array).
+    uint64_t m_ubound;         // max number that can be stored with current m_width
+
+    void init_from_mem(MemRef mem) noexcept
+    {
+        Node::init_from_mem(mem);
+        set_width(get_width_from_header(get_header()));
+    }
+
+    void adjust(size_t ndx, int64_t diff)
+    {
+        if (diff != 0) {
+            set(ndx, get(ndx) + diff); // Throws
+        }
+    }
+
+    void alloc(size_t init_size, size_t new_width)
+    {
+        Node::alloc(init_size, new_width);
+        set_width(uint8_t(new_width));
+    }
 
     void set_width(uint8_t width);
     uint8_t bit_width(uint64_t value);
@@ -96,6 +110,6 @@ private:
     uint64_t _get(size_t ndx, uint8_t width) const;
 };
 
-} // namespace
+} // namespace realm
 
 #endif /* REALM_ARRAY_UNSIGNED_HPP */

--- a/src/realm/node.cpp
+++ b/src/realm/node.cpp
@@ -115,6 +115,7 @@ void Node::alloc(size_t init_size, size_t new_width)
         set_width_in_header(int(new_width), header);
     }
     set_size_in_header(init_size, header);
+    m_size = init_size;
 }
 
 void Node::do_copy_on_write(size_t minimum_size)
@@ -122,7 +123,7 @@ void Node::do_copy_on_write(size_t minimum_size)
     const char* header = get_header_from_data(m_data);
 
     // Calculate size in bytes
-    size_t array_size = calc_byte_len(m_size, m_width);
+    size_t array_size = calc_byte_len(m_size, get_width_from_header(header));
     size_t new_size = std::max(array_size, minimum_size);
     new_size = (new_size + 0x7) & ~size_t(0x7); // 64bit blocks
     // Plus a bit of matchcount room for expansion

--- a/src/realm/node.hpp
+++ b/src/realm/node.hpp
@@ -45,9 +45,7 @@ const size_t not_found = npos;
 /// modified.
 class ArrayParent {
 public:
-    virtual ~ArrayParent() noexcept
-    {
-    }
+    virtual ~ArrayParent() noexcept {}
 
     virtual ref_type get_child_ref(size_t child_ndx) const noexcept = 0;
     virtual void update_child_ref(size_t child_ndx, ref_type new_ref) = 0;
@@ -116,9 +114,7 @@ public:
     {
     }
 
-    virtual ~Node()
-    {
-    }
+    virtual ~Node() {}
 
     /**************************** Initializers *******************************/
 
@@ -129,7 +125,6 @@ public:
         char* header = mem.get_addr();
         m_ref = mem.get_ref();
         m_data = get_data_from_header(header);
-        m_width = get_width_from_header(header);
         m_size = get_size_from_header(header);
 
         return header;
@@ -199,13 +194,6 @@ public:
         return ref;
     }
 
-    /// The meaning of 'width' depends on the context in which this
-    /// array is used.
-    size_t get_width() const noexcept
-    {
-        return m_width;
-    }
-
     /***************************** modifiers *********************************/
 
     /// Detach from the underlying array node. This method has no effect if the
@@ -273,8 +261,7 @@ protected:
 
     size_t m_ref;
     Allocator& m_alloc;
-    size_t m_size = 0;         // Number of elements currently stored.
-    uint_least8_t m_width = 0; // Size of an element (meaning depend on type of array).
+    size_t m_size = 0; // Number of elements currently stored.
 
 #if REALM_ENABLE_MEMDEBUG
     // If m_no_relocation is false, then copy_on_write() will always relocate this array, regardless if it's
@@ -332,9 +319,7 @@ public:
     {
         return false;
     }
-    virtual void set_spec(Spec*, size_t) const
-    {
-    }
+    virtual void set_spec(Spec*, size_t) const {}
 };
 
 
@@ -353,6 +338,6 @@ inline void Node::init_header(char* header, bool is_inner_bptree_node, bool has_
     set_size_in_header(size, header);
     set_capacity_in_header(capacity, header);
 }
-}
+} // namespace realm
 
 #endif /* REALM_NODE_HPP */


### PR DESCRIPTION
Now the size, width, and value bounds cache members are kept consistent with
the data in the array header. Previously Array::alloc() only update the
header, forcing every caller to update the cache members manually.