### PR TITLE
Remove contiguous mapping requirement

### DIFF
--- a/src/realm/alloc.cpp
+++ b/src/realm/alloc.cpp
@@ -140,12 +140,9 @@ char* Allocator::translate(ref_type ref) const noexcept
                 if (!txl.primary_mapping_limit.compare_exchange_weak(mapping_limit, offset + size,
                                                                      std::memory_order_acq_rel))
                     return translate(ref); // hopefully tail recursion optimization eliminates stack growth..
-                std::cout << "pushed " << idx << " to size " << offset + size << std::endl;
             }
             else {
                 // array crosses over into next mapping, we have to get/add a xover mapping for it.
-                std::cout << "adding xover mapping at index " << idx << " for " << offset << ", " << size
-                          << std::endl;
                 const_cast<Allocator*>(this)->get_or_add_xover_mapping(txl, idx, offset, size);
                 return translate(ref);
             }

--- a/src/realm/alloc.cpp
+++ b/src/realm/alloc.cpp
@@ -144,6 +144,7 @@ char* Allocator::translate(ref_type ref) const noexcept
             }
             else {
                 // array crosses over into next mapping, we have to add a xover mapping for it.
+                std::cout << "adding xover mapping " << idx << " for " << offset << ", " << size << std::endl;
                 REALM_ASSERT(false); // unimplemented!
             }
         }

--- a/src/realm/alloc.cpp
+++ b/src/realm/alloc.cpp
@@ -117,48 +117,46 @@ Allocator& Allocator::get_default() noexcept
     return default_alloc;
 }
 
-void Allocator::x_translate_bump(RefTranslation& txl, size_t idx, size_t offset) const noexcept
-{
-    // there is no xover mapping and this ref might need one...
-    // establish array size to determine if array crosses into next mapping
-    char* addr = txl.mapping_addr + offset;
-#if REALM_ENABLE_ENCRYPTION
-    realm::util::encryption_read_barrier(addr, NodeHeader::header_size, txl.encrypted_mapping, nullptr);
-#endif
-    auto size = NodeHeader::get_byte_size_from_header(addr);
-    if (offset + size <= 1 << section_shift) {
-        size_t mapping_limit = txl.primary_mapping_limit.load(std::memory_order_relaxed);
-        // array fits inside primary mapping, no new mapping needed, just move the limit
-        // take into account that another thread may attempt to change / have changed it concurrently,
-        // by re evaluating whether we still need to bump. In case of conflict we back off and retry.
-        if (offset + size > mapping_limit) {
-            txl.primary_mapping_limit.compare_exchange_strong(mapping_limit, offset + size,
-                                                              std::memory_order_relaxed);
-        }
-    }
-    else {
-        // array crosses over into next mapping, we have to get/add a xover mapping for it.
-        const_cast<Allocator*>(this)->get_or_add_xover_mapping(txl, idx, offset, size);
-    }
-}
-
+// This function is called to handle translation of a ref which is above the limit for its
+// memory mapping. This requires one of three:
+// * bumping the limit of the mapping. (if the entire array is inside the mapping)
+// * adding a cross-over mapping. (if the array crosses a mapping boundary)
+// * using an already established cross-over mapping. (do)
+// this can proceed concurrently with other calls to translate()
 char* Allocator::x_translate_extended(RefTranslation* ref_translation_ptr, ref_type ref) const noexcept
 {
     size_t idx = get_section_index(ref);
     RefTranslation& txl = ref_translation_ptr[idx];
     size_t offset = ref - get_section_base(idx);
-    if (txl.xover_mapping_addr.load(std::memory_order_relaxed) == nullptr) {
-        // bump the limit / add xover mapping and retry:
-        x_translate_bump(txl, idx, offset);
+    char* addr = txl.mapping_addr + offset;
+#if REALM_ENABLE_ENCRYPTION
+    realm::util::encryption_read_barrier(addr, NodeHeader::header_size, txl.encrypted_mapping, nullptr);
+#endif
+    auto size = NodeHeader::get_byte_size_from_header(addr);
+    bool crosses_mapping = offset + size > (1 << section_shift);
+    if (REALM_LIKELY(!crosses_mapping)) {
+        // Array fits inside primary mapping, no new mapping needed, just move the limit on
+        // use of the existing primary mapping.
+        // Take into account that another thread may attempt to change / have changed it concurrently,
+        // by re-evaluating whether we still need to bump. In case of conflict we back off.
+        size_t mapping_limit = txl.primary_mapping_limit.load(std::memory_order_relaxed);
+        if (offset + size > mapping_limit) {
+            txl.primary_mapping_limit.compare_exchange_weak(mapping_limit, offset + size, std::memory_order_relaxed);
+        }
+        // retry with (potentially) increased limit - this tail recursive call is a camouflaged
+        // loop going back over x_translate(), from which it will eventually exit as it finds
+        // an increased limit on the primary mapping.
         return x_translate(ref_translation_ptr, ref);
     }
     else {
-        auto xover_mapping_addr = txl.xover_mapping_addr.load(std::memory_order_relaxed);
-        auto xover_mapping_base = txl.xover_mapping_base.load(std::memory_order_relaxed);
-        auto xover_encrypted_mapping = txl.xover_encrypted_mapping.load(std::memory_order_relaxed);
-        // back off in case of only partial setup of xover mapping
-        if (xover_mapping_addr && xover_mapping_base && xover_encrypted_mapping) {
-            char* addr;
+        // we need a cross-over mapping. If one is already established, use that.
+        auto xover_mapping_addr = txl.xover_mapping_addr.load(std::memory_order_acquire);
+        auto xover_mapping_base = txl.xover_mapping_base;
+#if REALM_ENABLE_ENCRYPTION
+        auto xover_encrypted_mapping = txl.xover_encrypted_mapping;
+#endif
+        // back off in case of missing setup of the xover mapping
+        if (xover_mapping_addr) {
             // array is inside the established xover mapping:
             addr = xover_mapping_addr + (offset - xover_mapping_base);
 #if REALM_ENABLE_ENCRYPTION
@@ -167,42 +165,13 @@ char* Allocator::x_translate_extended(RefTranslation* ref_translation_ptr, ref_t
 #endif
             return addr;
         }
-        else {
-            // not a valid xover mapping established, we need to retry
-            return x_translate(ref_translation_ptr, ref);
-        }
-    }
-}
-
-
-inline char* Allocator::x_translate(RefTranslation* ref_translation_ptr, ref_type ref) const noexcept
-{
-    size_t idx = get_section_index(ref);
-    RefTranslation& txl = ref_translation_ptr[idx];
-    size_t offset = ref - get_section_base(idx);
-    size_t mapping_limit = txl.primary_mapping_limit.load(std::memory_order_relaxed);
-    if (offset < mapping_limit) {
-        // the mapping limit may grow concurrently, but that will not affect this code path
-        char* addr = txl.mapping_addr + offset;
-#if REALM_ENABLE_ENCRYPTION
-        realm::util::encryption_read_barrier(addr, NodeHeader::header_size, txl.encrypted_mapping,
-                                             NodeHeader::get_byte_size_from_header);
-#endif
-        return addr;
-    }
-    else {
+        // we need to establish a xover mapping - or wait for another thread to finish
+        // establishing one:
+        const_cast<Allocator*>(this)->get_or_add_xover_mapping(txl, idx, offset, size);
+        // retry with new mapping. This is guaranteed to find a valid mapping and return
+        // without an additional recursive call.
         return x_translate_extended(ref_translation_ptr, ref);
     }
 }
 
-char* Allocator::translate(ref_type ref) const noexcept
-{
-    auto ref_translation_ptr = m_ref_translation_ptr.load(std::memory_order_acquire);
-    if (ref_translation_ptr) {
-        return x_translate(ref_translation_ptr, ref);
-    }
-    else {
-        return do_translate(ref);
-    }
-}
 }

--- a/src/realm/alloc.hpp
+++ b/src/realm/alloc.hpp
@@ -220,7 +220,7 @@ protected:
     virtual void get_or_add_xover_mapping(RefTranslation&, size_t, size_t, size_t)
     {
         REALM_ASSERT(false);
-    };
+    }
     Allocator() noexcept;
     size_t get_section_index(size_t pos) const noexcept;
     inline size_t get_section_base(size_t index) const noexcept;
@@ -326,7 +326,7 @@ public:
     }
 
 protected:
-    virtual void get_or_add_xover_mapping(RefTranslation& txl, size_t index, size_t offset, size_t size)
+    void get_or_add_xover_mapping(RefTranslation& txl, size_t index, size_t offset, size_t size) override
     {
         m_alloc->get_or_add_xover_mapping(txl, index, offset, size);
     }

--- a/src/realm/alloc.hpp
+++ b/src/realm/alloc.hpp
@@ -184,7 +184,8 @@ protected:
                 encrypted_mapping = from.encrypted_mapping;
                 xover_encrypted_mapping = from.xover_encrypted_mapping;
 #endif
-                xover_mapping_addr.store(from.xover_mapping_addr, std::memory_order_release);
+                xover_mapping_addr.store(from.xover_mapping_addr.load(std::memory_order_relaxed),
+                                         std::memory_order_release);
             }
             return *this;
         }

--- a/src/realm/alloc.hpp
+++ b/src/realm/alloc.hpp
@@ -160,7 +160,10 @@ protected:
     struct RefTranslation {
         char* mapping_addr;
         std::atomic<size_t> primary_mapping_limit;
-        size_t xover_mapping_base = 0;
+        // any xover mapping must stretch past the end of the primary mapping, and it can at most
+        // hold the largest array supported, which is 16MB. Consequently, accesses to the first
+        // part of the primary mapping does not need to be checked.
+        size_t xover_mapping_base = (1 << section_shift) - 16 * 1024 * 1024;
         char* xover_mapping_addr = 0;
 #if REALM_ENABLE_ENCRYPTION
         util::EncryptedFileMapping* encrypted_mapping = nullptr;

--- a/src/realm/alloc.hpp
+++ b/src/realm/alloc.hpp
@@ -217,7 +217,10 @@ protected:
     /// then entirely the responsibility of the caller that the memory
     /// is not modified by way of the returned memory pointer.
     virtual char* do_translate(ref_type ref) const noexcept = 0;
-
+    virtual void get_or_add_xover_mapping(RefTranslation&, size_t, size_t, size_t)
+    {
+        REALM_ASSERT(false);
+    };
     Allocator() noexcept;
     size_t get_section_index(size_t pos) const noexcept;
     inline size_t get_section_base(size_t index) const noexcept;
@@ -320,6 +323,12 @@ public:
     {
         switch_underlying_allocator(*m_alloc);
         set_read_only(!writable);
+    }
+
+protected:
+    virtual void get_or_add_xover_mapping(RefTranslation& txl, size_t index, size_t offset, size_t size)
+    {
+        m_alloc->get_or_add_xover_mapping(txl, index, offset, size);
     }
 
 private:

--- a/src/realm/alloc.hpp
+++ b/src/realm/alloc.hpp
@@ -171,7 +171,10 @@ protected:
         {
             primary_mapping_limit.store(0);
         }
-        RefTranslation() : RefTranslation(nullptr) {}
+        RefTranslation()
+            : RefTranslation(nullptr)
+        {
+        }
         RefTranslation& operator=(const RefTranslation& from)
         {
             if (&from != this) {
@@ -186,7 +189,6 @@ protected:
             }
             return *this;
         }
-
     };
     // This pointer may be changed concurrently with access, so make sure it is
     // atomic!

--- a/src/realm/alloc_slab.cpp
+++ b/src/realm/alloc_slab.cpp
@@ -819,7 +819,8 @@ ref_type SlabAlloc::attach_file(const std::string& file_path, Config& cfg)
     }
     catch (...) {
         note_reader_end(this);
-        throw;
+        // we end up here if any of the file or mapping operations fail.
+        throw InvalidDatabase("Realm file initial open failed", path);
     }
     m_baseline = 0;
     auto handler = [this]() noexcept { note_reader_end(this); };

--- a/src/realm/alloc_slab.cpp
+++ b/src/realm/alloc_slab.cpp
@@ -1014,7 +1014,7 @@ ref_type SlabAlloc::validate_header(const Header* header, const StreamingFooter*
     int slot_selector = ((header->m_flags & SlabAlloc::flags_SelectBit) != 0 ? 1 : 0);
 
     // Top-ref must always point within buffer
-    uint_fast64_t top_ref = uint_fast64_t(header->m_top_ref[slot_selector]);
+    ref_type top_ref = uint_fast64_t(header->m_top_ref[slot_selector]);
     if (slot_selector == 0 && top_ref == 0xFFFFFFFFFFFFFFFFULL) {
         if (REALM_UNLIKELY(size < sizeof(Header) + sizeof(StreamingFooter))) {
             std::string msg = "Invalid streaming format size (" + util::to_string(size) + ")";

--- a/src/realm/alloc_slab.cpp
+++ b/src/realm/alloc_slab.cpp
@@ -193,6 +193,8 @@ MemRef SlabAlloc::do_alloc(size_t size)
     REALM_ASSERT_EX(0 < size, size, get_file_path_for_assertions());
     REALM_ASSERT_EX((size & 0x7) == 0, size, get_file_path_for_assertions()); // only allow sizes that are multiples of 8
     REALM_ASSERT_EX(is_attached(), get_file_path_for_assertions());
+    // This limits the size of any array to ensure it can fit within a memory section.
+    // NOTE: This limit is lower than the limit set by the encoding in node_header.hpp
     REALM_ASSERT_EX(size < (1 << section_shift), size, get_file_path_for_assertions());
 
     // If we failed to correctly record free space, new allocations cannot be

--- a/src/realm/alloc_slab.cpp
+++ b/src/realm/alloc_slab.cpp
@@ -819,7 +819,7 @@ ref_type SlabAlloc::attach_file(const std::string& file_path, Config& cfg)
     }
     catch (...) {
         note_reader_end(this);
-        throw;
+        throw InvalidDatabase("File open failed ", path);
     }
     m_baseline = 0;
     auto handler = [this]() noexcept { note_reader_end(this); };

--- a/src/realm/alloc_slab.hpp
+++ b/src/realm/alloc_slab.hpp
@@ -580,7 +580,7 @@ private:
     // and in use by older transactions. These translations are in m_old_mappings.
     struct MapEntry {
         util::File::Map<char> primary_mapping;
-        size_t primary_mapping_limit;
+        size_t primary_mapping_limit = 0;
         util::File::Map<char> xover_mapping;
     };
     std::vector<MapEntry> m_mappings;
@@ -602,7 +602,7 @@ private:
     // Add a translation covering a new section in the slab area. The translation is always
     // added at the end.
     void extend_fast_mapping_with_slab(char* address);
-    virtual void get_or_add_xover_mapping(RefTranslation& txl, size_t index, size_t offset, size_t size);
+    void get_or_add_xover_mapping(RefTranslation& txl, size_t index, size_t offset, size_t size) override;
 
     const char* m_data = nullptr;
     size_t m_initial_section_size = 0;

--- a/src/realm/alloc_slab.hpp
+++ b/src/realm/alloc_slab.hpp
@@ -655,7 +655,10 @@ private:
     /// Throws InvalidDatabase if the file is not a Realm file, if the file is
     /// corrupted, or if the specified encryption key is incorrect. This
     /// function will not detect all forms of corruption, though.
-    void validate_header(const char* data, size_t len, const std::string& path);
+    /// Returns the top_ref for the latest commit.
+    ref_type validate_header(const char* data, size_t len, const std::string& path);
+    ref_type validate_header(const Header* header, const StreamingFooter* footer, size_t size,
+                             const std::string& path);
     void throw_header_exception(std::string msg, const Header& header, const std::string& path);
 
     static bool is_file_on_streaming_form(const Header& header);

--- a/src/realm/alloc_slab.hpp
+++ b/src/realm/alloc_slab.hpp
@@ -580,7 +580,7 @@ private:
     // and in use by older transactions. These translations are in m_old_mappings.
     struct MapEntry {
         util::File::Map<char> primary_mapping;
-        size_t primary_mapping_limit = 0;
+        size_t lowest_possible_xover_offset = 0;
         util::File::Map<char> xover_mapping;
     };
     std::vector<MapEntry> m_mappings;

--- a/src/realm/node_header.hpp
+++ b/src/realm/node_header.hpp
@@ -25,6 +25,9 @@ namespace realm {
 
 const size_t max_array_size = 0x00ffffffL;            // Maximum number of elements in an array
 const size_t max_array_payload_aligned = 0x07ffffc0L; // Maximum number of bytes that the payload of an array can be
+// Even though the encoding supports arrays with size up to max_array_payload_aligned,
+// the maximum allocation size is smaller as it must fit within a memory section
+// (a contiguous virtual address range). This limitation is enforced in SlabAlloc::do_alloc().
 
 class NodeHeader {
 public:

--- a/src/realm/util/file_mapper.hpp
+++ b/src/realm/util/file_mapper.hpp
@@ -113,13 +113,13 @@ void do_encryption_write_barrier(const void* addr, size_t size, EncryptedFileMap
 void inline encryption_read_barrier(const void* addr, size_t size, EncryptedFileMapping* mapping,
                                     HeaderToSize header_to_size = nullptr)
 {
-    if (mapping)
+    if (REALM_UNLIKELY(mapping))
         do_encryption_read_barrier(addr, size, header_to_size, mapping);
 }
 
 void inline encryption_write_barrier(const void* addr, size_t size, EncryptedFileMapping* mapping)
 {
-    if (mapping)
+    if (REALM_UNLIKELY(mapping))
         do_encryption_write_barrier(addr, size, mapping);
 }
 

--- a/test/test_destroy_guard.cpp
+++ b/test/test_destroy_guard.cpp
@@ -144,6 +144,10 @@ public:
     void verify() const override
     {
     }
+    void get_or_add_xover_mapping(RefTranslation&, size_t, size_t, size_t) override
+    {
+        REALM_ASSERT(false);
+    }
 
 private:
     ref_type m_offset;

--- a/test/test_lang_bind_helper.cpp
+++ b/test/test_lang_bind_helper.cpp
@@ -5947,7 +5947,7 @@ TEST(LangBindHelper_ArrayXoverMapping)
         std::cout << "writing" << std::endl;
         auto tbl = tr->add_table("my_table");
         my_col = tbl->add_column(type_String, "my_col");
-        std::string s(1000000,'a');
+        std::string s(1000000, 'a');
         for (auto i = 0; i < 100; ++i)
             tbl->create_object().set_all(s);
         std::cout << "committing..." << std::endl;

--- a/test/test_lang_bind_helper.cpp
+++ b/test/test_lang_bind_helper.cpp
@@ -5960,16 +5960,21 @@ TEST(LangBindHelper_ArrayXoverMapping)
     ColKey my_col;
     {
         auto tr = db->start_write();
+        std::cout << "writing" << std::endl;
         auto tbl = tr->add_table("my_table");
         my_col = tbl->add_column(type_String, "my_col");
         std::string s(1000000,'a');
-        for (auto i = 0; i < 1000; ++i)
+        for (auto i = 0; i < 100; ++i)
             tbl->create_object().set_all(s);
+        std::cout << "committing..." << std::endl;
         tr->commit();
     }
+    std::cout << "compacting..." << std::endl;
     REALM_ASSERT(db->compact());
+    std::cout << "reopening..." << std::endl;
     {
         auto tr = db->start_read();
+        std::cout << "rereading..." << std::endl;
         auto tbl = tr->get_table("my_table");
         for (auto i = 0; i < 1000; ++i) {
             auto o = tbl->get_object(i);

--- a/test/test_lang_bind_helper.cpp
+++ b/test/test_lang_bind_helper.cpp
@@ -5952,4 +5952,32 @@ TEST(LangBindHelper_SearchIndexAccessor)
     tr->commit();
 }
 
+TEST(LangBindHelper_ArrayXoverMapping)
+{
+    SHARED_GROUP_TEST_PATH(path);
+    auto hist = make_in_realm_history(path);
+    DBRef db = DB::create(*hist);
+    ColKey my_col;
+    {
+        auto tr = db->start_write();
+        auto tbl = tr->add_table("my_table");
+        my_col = tbl->add_column(type_String, "my_col");
+        std::string s(1000000,'a');
+        for (auto i = 0; i < 1000; ++i)
+            tbl->create_object().set_all(s);
+        tr->commit();
+    }
+    REALM_ASSERT(db->compact());
+    {
+        auto tr = db->start_read();
+        auto tbl = tr->get_table("my_table");
+        for (auto i = 0; i < 1000; ++i) {
+            auto o = tbl->get_object(i);
+            StringData str = o.get<String>(my_col);
+            for (auto j = 0; j < 1000000; ++j)
+                REALM_ASSERT(str[j] == 'a');
+        }
+    }
+}
+
 #endif

--- a/test/test_lang_bind_helper.cpp
+++ b/test/test_lang_bind_helper.cpp
@@ -5976,7 +5976,7 @@ TEST(LangBindHelper_ArrayXoverMapping)
         auto tr = db->start_read();
         std::cout << "rereading..." << std::endl;
         auto tbl = tr->get_table("my_table");
-        for (auto i = 0; i < 1000; ++i) {
+        for (auto i = 0; i < 100; ++i) {
             auto o = tbl->get_object(i);
             StringData str = o.get<String>(my_col);
             for (auto j = 0; j < 1000000; ++j)

--- a/test/test_lang_bind_helper.cpp
+++ b/test/test_lang_bind_helper.cpp
@@ -5944,21 +5944,16 @@ TEST(LangBindHelper_ArrayXoverMapping)
     ColKey my_col;
     {
         auto tr = db->start_write();
-        std::cout << "writing" << std::endl;
         auto tbl = tr->add_table("my_table");
         my_col = tbl->add_column(type_String, "my_col");
         std::string s(1000000, 'a');
         for (auto i = 0; i < 100; ++i)
             tbl->create_object().set_all(s);
-        std::cout << "committing..." << std::endl;
         tr->commit();
     }
-    std::cout << "compacting..." << std::endl;
     REALM_ASSERT(db->compact());
-    std::cout << "reopening..." << std::endl;
     {
         auto tr = db->start_read();
-        std::cout << "rereading..." << std::endl;
         auto tbl = tr->get_table("my_table");
         for (auto i = 0; i < 100; ++i) {
             auto o = tbl->get_object(i);

--- a/test/test_lang_bind_helper.cpp
+++ b/test/test_lang_bind_helper.cpp
@@ -5946,7 +5946,7 @@ TEST(LangBindHelper_ArrayXoverMapping)
         auto tr = db->start_write();
         auto tbl = tr->add_table("my_table");
         my_col = tbl->add_column(type_String, "my_col");
-        std::string s(1000000, 'a');
+        std::string s(1'000'000, 'a');
         for (auto i = 0; i < 100; ++i)
             tbl->create_object().set_all(s);
         tr->commit();
@@ -5958,7 +5958,7 @@ TEST(LangBindHelper_ArrayXoverMapping)
         for (auto i = 0; i < 100; ++i) {
             auto o = tbl->get_object(i);
             StringData str = o.get<String>(my_col);
-            for (auto j = 0; j < 1000000; ++j)
+            for (auto j = 0; j < 1'000'000; ++j)
                 REALM_ASSERT(str[j] == 'a');
         }
     }

--- a/test/test_table.cpp
+++ b/test/test_table.cpp
@@ -3625,7 +3625,7 @@ TEST(Table_QuickSort2)
 TEST(Table_object_sequential)
 {
 #ifdef PERFORMACE_TESTING
-    int nb_rows = 10000000;
+    int nb_rows = 10'000'000;
     int num_runs = 1;
 #else
     int nb_rows = 1024;
@@ -3774,10 +3774,10 @@ TEST(Table_object_sequential)
 TEST(Table_object_seq_rnd)
 {
 #ifdef PERFORMACE_TESTING
-    size_t rows = 1000000;
+    size_t rows = 1'000'000;
     int runs = 100;     // runs for building scenario
 #else
-    size_t rows = 50000;
+    size_t rows = 50'000;
     int runs = 1;
 #endif
     int64_t next_key = 0;
@@ -3889,7 +3889,7 @@ TEST(Table_object_seq_rnd)
 TEST(Table_object_random)
 {
 #ifdef PERFORMACE_TESTING
-    int nb_rows = 1000000;
+    int nb_rows = 1'000'000;
     int num_runs = 10;
 #else
     int nb_rows = 1024;

--- a/test/test_table.cpp
+++ b/test/test_table.cpp
@@ -46,7 +46,7 @@ using namespace std::chrono;
 #include "test_table_helper.hpp"
 
 // #include <valgrind/callgrind.h>
-// #define PERFORMACE_TESTING
+//#define PERFORMACE_TESTING
 
 using namespace realm;
 using namespace realm::util;
@@ -3661,7 +3661,12 @@ TEST(Table_object_sequential)
         CHECK_EQUAL(table->size(), nb_rows);
         wt.commit();
     }
-
+    {
+        auto t1 = steady_clock::now();
+        sg->compact();
+        auto t2 = steady_clock::now();
+        std::cout << "  compaction time: " << duration_cast<milliseconds>(t2 - t1).count() << " ms" << std::endl;
+    }
     {
         ReadTransaction rt(sg);
         auto table = rt.get_table("test");
@@ -3769,7 +3774,7 @@ TEST(Table_object_sequential)
 TEST(Table_object_seq_rnd)
 {
 #ifdef PERFORMACE_TESTING
-    size_t rows = 100000;
+    size_t rows = 1000000;
     int runs = 100;     // runs for building scenario
 #else
     size_t rows = 50000;
@@ -3811,10 +3816,16 @@ TEST(Table_object_seq_rnd)
     // scenario established!
     int nb_rows = int(key_values.size());
 #ifdef PERFORMACE_TESTING
-    int num_runs = 100; // runs for timing access
+    int num_runs = 10; // runs for timing access
 #else
     int num_runs = 1; // runs for timing access
 #endif
+    {
+        auto t1 = steady_clock::now();
+        sg->compact();
+        auto t2 = steady_clock::now();
+        std::cout << "  compaction time: " << duration_cast<milliseconds>(t2 - t1).count() << " ms" << std::endl;
+    }
     std::cout << "Scenario has " << nb_rows << " rows. Timing...." << std::endl;
     {
         ReadTransaction rt(sg);
@@ -3878,8 +3889,8 @@ TEST(Table_object_seq_rnd)
 TEST(Table_object_random)
 {
 #ifdef PERFORMACE_TESTING
-    int nb_rows = 100000;
-    int num_runs = 100;
+    int nb_rows = 1000000;
+    int num_runs = 10;
 #else
     int nb_rows = 1024;
     int num_runs = 1;
@@ -3930,6 +3941,12 @@ TEST(Table_object_random)
 
         CHECK_EQUAL(table->size(), nb_rows);
         wt.commit();
+    }
+    {
+        auto t1 = steady_clock::now();
+        sg->compact();
+        auto t2 = steady_clock::now();
+        std::cout << "  compaction time: " << duration_cast<milliseconds>(t2 - t1).count() << " ms" << std::endl;
     }
 
     {


### PR DESCRIPTION
This PR removes the requirement to have a contiguous memory mapping of the entire realm file.

It works by dynamically detecting whenever an attempt is made to access a memory block that crosses a memory mapping boundary. It then adds a dedicated additional memory mapping for that particular memory block (the "cross-over" mapping).

Note to reviewer: this is tricky code because a) it has to provide "mostly lock-free" concurrent access to the ref translation table and b) the translation code is the hottest code path in Core.

The code is very carefully tuned to avoid performance degradation.