### PR TITLE
Remove TSAN false positives caused by double-mapped paged

### DIFF
--- a/test/test_lang_bind_helper.cpp
+++ b/test/test_lang_bind_helper.cpp
@@ -133,7 +133,6 @@ TEST(Transactions_Frozen)
 }
 
 
-
 TEST(Transactions_ConcurrentFrozenTableGetByName)
 {
     SHARED_GROUP_TEST_PATH(path);
@@ -1183,7 +1182,7 @@ void deleter_thread(ConcurrentQueue<LnkLstPtr>& queue)
         // just let 'r' die
     }
 }
-}
+} // namespace
 
 TEST(LangBindHelper_ConcurrentLinkViewDeletes)
 {
@@ -1742,9 +1741,7 @@ private:
     ObjKey m_current_linkview_row;
 
 public:
-    void parse_complete()
-    {
-    }
+    void parse_complete() {}
 
     bool select_table(TableKey t)
     {
@@ -3719,9 +3716,7 @@ struct HandoverControl {
         m_has_feedback = false;
     }
     HandoverControl(const HandoverControl&) = delete;
-    HandoverControl()
-    {
-    }
+    HandoverControl() {}
 };
 
 void handover_writer(DBRef db)
@@ -3848,7 +3843,9 @@ void attacher(std::string path, ColKey col)
 } // anonymous namespace
 
 
-TEST(LangBindHelper_RacingAttachers)
+// Disable with TSAN because it needs to synchronize between multiple DBs, and TSAN isn't able to track
+// acquire/release across multiple mappings of the same underlying memory.
+TEST_IF(LangBindHelper_RacingAttachers, !running_with_tsan)
 {
     const int num_attachers = 10;
     SHARED_GROUP_TEST_PATH(path);
@@ -4083,13 +4080,14 @@ TEST(LangBindHelper_HandoverTableViewWithQueryOnLink)
 }
 
 
-#ifdef LEGACY_TESTS   // (not useful as std unittest)
+#ifdef LEGACY_TESTS // (not useful as std unittest)
 namespace {
 
-void do_write_work(std::string path, size_t id, size_t num_rows) {
+void do_write_work(std::string path, size_t id, size_t num_rows)
+{
     const size_t num_iterations = 5000000; // this makes it run for a loooong time
     const size_t payload_length_small = 10;
-    const size_t payload_length_large = 5000; // > 4096 == page_size
+    const size_t payload_length_large = 5000;   // > 4096 == page_size
     Random random(random_int<unsigned long>()); // Seed from slow global generator
     const char* key = crypt_key(true);
     for (size_t rep = 0; rep < num_iterations; ++rep) {
@@ -4114,7 +4112,8 @@ void do_write_work(std::string path, size_t id, size_t num_rows) {
     }
 }
 
-void do_read_verify(std::string path) {
+void do_read_verify(std::string path)
+{
     Random random(random_int<unsigned long>()); // Seed from slow global generator
     const char* key = crypt_key(true);
     while (true) {
@@ -4130,7 +4129,8 @@ void do_read_verify(std::string path) {
             StringData c = t->get_string(1, r);
             if (c == "stop reading") {
                 return;
-            } else {
+            }
+            else {
                 REALM_ASSERT_EX(c.size() == 1, c.size());
             }
             REALM_ASSERT_EX(t->get_name() == StringData("class_Table_Emulation_Name"), t->get_name().data());
@@ -4160,7 +4160,7 @@ TEST_IF(Thread_AsynchronousIODataConsistency, false)
     SHARED_GROUP_TEST_PATH(path);
     const int num_writer_threads = 2;
     const int num_reader_threads = 2;
-    const int num_rows = 200; //2 + REALM_MAX_BPNODE_SIZE;
+    const int num_rows = 200; // 2 + REALM_MAX_BPNODE_SIZE;
     const char* key = crypt_key(true);
     std::unique_ptr<Replication> hist(make_in_realm_history(path));
     DBRef sg = DB::create(*hist, DBOptions(key));
@@ -4190,7 +4190,7 @@ TEST_IF(Thread_AsynchronousIODataConsistency, false)
 
     {
         WriteTransaction wt(sg);
-        Group &group = wt.get_group();
+        Group& group = wt.get_group();
         TableRef t = rt->get_table("class_Table_Emulation_Name");
         t->set_string(1, 0, "stop reading");
         wt.commit();
@@ -4901,9 +4901,9 @@ TEST(LangBindHelper_CloseDBvsTransactions)
     CHECK_THROW(sg->close(), LogicError);
     tr1->rollback();
     // closing the DB explicitly while there are open read transactions will fail
-    CHECK_THROW(sg->close(), LogicError); 
+    CHECK_THROW(sg->close(), LogicError);
     // unless we explicitly ask for it to succeed()
-    sg->close(true); 
+    sg->close(true);
     CHECK(!sg->is_attached());
     CHECK(!tr0->is_attached());
     CHECK(!tr1->is_attached());
@@ -5005,8 +5005,8 @@ TEST_IF(LangBindHelper_HandoverFuzzyTest, TEST_DURATION > 0)
         }
         rt->verify();
         {
-        	realm::Query query = dog->link(c3).column<String>(c0) == "owner" + to_string(rand() % numberOfOwner);
-        	query.find_all(); // <-- fails
+            realm::Query query = dog->link(c3).column<String>(c0) == "owner" + to_string(rand() % numberOfOwner);
+            query.find_all(); // <-- fails
         }
         rt->commit();
     }
@@ -5020,7 +5020,7 @@ TEST_IF(LangBindHelper_HandoverFuzzyTest, TEST_DURATION > 0)
             vector_mutex.lock();
             if (qs.size() > 0) {
 
-            	auto t = vids[0];
+                auto t = vids[0];
                 vids.erase(vids.begin());
                 auto q = std::move(qs[0]);
                 qs.erase(qs.begin());
@@ -5055,7 +5055,7 @@ TEST_IF(LangBindHelper_HandoverFuzzyTest, TEST_DURATION > 0)
         rt->commit_and_continue_as_read();
         if (qs.size() < 100) {
             for (size_t t = 0; t < 5; t++) {
-            	auto t2 = rt->duplicate();
+                auto t2 = rt->duplicate();
                 qs.push_back(t2->import_copy_of(query, PayloadPolicy::Move));
                 vids.push_back(t2);
             }
@@ -5536,7 +5536,7 @@ TEST(LangBindHelper_Bug2295)
     CHECK_EQUAL(lv1.size(), i);
 }
 
-#ifdef LEGACY_TESTS   // FIXME: Requires get_at() method to be available on ConstObj.
+#ifdef LEGACY_TESTS // FIXME: Requires get_at() method to be available on ConstObj.
 ONLY(LangBindHelper_BigBinary)
 {
     SHARED_GROUP_TEST_PATH(path);
@@ -5657,7 +5657,8 @@ TEST(LangBindHelper_OpenAsEncrypted)
         bool is_okay = false;
         try {
             DBRef sg_encrypt = DB::create(*hist_encrypt, DBOptions(key));
-        } catch (std::runtime_error&) {
+        }
+        catch (std::runtime_error&) {
             is_okay = true;
         }
         CHECK(is_okay);

--- a/test/test_shared.cpp
+++ b/test/test_shared.cpp
@@ -161,7 +161,7 @@ DWORD winfork(std::string unit_test_name)
     CloseHandle(process.hThread);
     return process.dwProcessId;
 }
-}
+} // namespace
 #endif
 
 
@@ -190,7 +190,7 @@ std::vector<ColKey> test_table_add_columns(TableRef t)
     res.push_back(t->add_column(type_Timestamp, "fifth"));
     return res;
 }
-}
+} // namespace
 
 void writer(DBRef sg, uint64_t id)
 {
@@ -205,7 +205,8 @@ void writer(DBRef sg, uint64_t id)
             auto t1 = tr->get_table("test");
             ColKeys _cols = t1->get_column_keys();
             std::vector<ColKey> cols;
-            for (auto e : _cols) cols.push_back(e);
+            for (auto e : _cols)
+                cols.push_back(e);
             Obj obj = t1->get_object(ObjKey(id));
             done = obj.get<Bool>(cols[2]);
             if (i & 1) {
@@ -439,7 +440,8 @@ TEST(Shared_CompactingOnTheFly)
             auto t1 = wt.add_table("test");
             test_table_add_columns(t1);
             ColKeys _cols = t1->get_column_keys();
-            for (auto e : _cols) cols.push_back(e);
+            for (auto e : _cols)
+                cols.push_back(e);
             for (int i = 0; i < 100; ++i) {
                 t1->create_object(ObjKey(i)).set_all(0, i, false, "test");
             }
@@ -810,7 +812,6 @@ TEST(Shared_try_begin_write)
     bool init_complete = false;
 
     auto do_async = [&]() {
-
         auto tr = sg->start_write(true);
         bool success = bool(tr);
         CHECK(success);
@@ -834,7 +835,7 @@ TEST(Shared_try_begin_write)
 
     // wait for the thread to start a write transaction
     std::unique_lock<std::mutex> lock(cv_lock);
-    cv.wait(lock, [&]{ return init_complete; });
+    cv.wait(lock, [&] { return init_complete; });
 
     // Try to also obtain a write lock. This should fail but not block.
     auto tr = sg->start_write(true);
@@ -1317,7 +1318,6 @@ TEST(Many_ConcurrentReaders)
 }
 
 
-
 TEST(Shared_WritesSpecialOrder)
 {
     SHARED_GROUP_TEST_PATH(path);
@@ -1366,10 +1366,8 @@ TEST(Shared_WritesSpecialOrder)
 
 namespace {
 
-void writer_threads_thread(TestContext& test_context, std::string path, ObjKey key)
+void writer_threads_thread(TestContext& test_context, const DBRef& sg, ObjKey key)
 {
-    // Open shared db
-    DBRef sg = DB::create(path, false, DBOptions(crypt_key()));
 
     for (size_t i = 0; i < 100; ++i) {
         // Increment cell
@@ -1427,7 +1425,7 @@ TEST(Shared_WriterThreads)
 
         // Create all threads
         for (int i = 0; i < thread_count; ++i)
-            threads[i].start([this, &path, i] { writer_threads_thread(test_context, path, ObjKey(i)); });
+            threads[i].start([this, &sg, i] { writer_threads_thread(test_context, sg, ObjKey(i)); });
 
         // Wait for all threads to complete
         for (int i = 0; i < thread_count; ++i)
@@ -2098,7 +2096,7 @@ TEST_IF(Shared_AsyncMultiprocess, allow_async)
 
 #endif // !defined(_WIN32) && !REALM_PLATFORM_APPLE
 
-#if 0  // FIXME: Reenable when it can pass reliably
+#if 0 // FIXME: Reenable when it can pass reliably
 #ifdef _WIN32
 
 TEST(Shared_WaitForChangeAfterOwnCommit)
@@ -2493,7 +2491,8 @@ TEST(Shared_EncryptionKeyCheck)
     bool ok = false;
     try {
         DBRef sg_2 = DB::create(path, false, DBOptions());
-    } catch (std::runtime_error&) {
+    }
+    catch (std::runtime_error&) {
         ok = true;
     }
     CHECK(ok);
@@ -2509,7 +2508,8 @@ TEST(Shared_EncryptionKeyCheck_2)
     bool ok = false;
     try {
         DBRef sg_2 = DB::create(path, false, DBOptions(crypt_key(true)));
-    } catch (std::runtime_error&) {
+    }
+    catch (std::runtime_error&) {
         ok = true;
     }
     CHECK(ok);
@@ -3400,7 +3400,7 @@ TEST(Shared_LockFileOfWrongSizeThrows)
         CHECK(f.is_attached());
 
         size_t wrong_size = 100; // < sizeof(SharedInfo)
-        f.resize(wrong_size); // ftruncate will fill with 0, which will set the init_complete flag to 0.
+        f.resize(wrong_size);    // ftruncate will fill with 0, which will set the init_complete flag to 0.
         f.seek(0);
 
         // On Windows, we implement a shared lock on a file by locking the first byte of the file. Since
@@ -3676,7 +3676,7 @@ TEST_IF(Shared_DecryptExisting, REALM_ENABLE_ENCRYPTION)
     // Page size of system that reads the .realm file must be the same as on the system
     // that created it, because we are running with encryption
     std::string path = test_util::get_test_resource_path() + "test_shared_decrypt_" +
-                        realm::util::to_string(page_size() / 1024) + "k_page.realm";
+                       realm::util::to_string(page_size() / 1024) + "k_page.realm";
 
 #if 0 // set to 1 to generate the .realm file
     {

--- a/test/test_shared.cpp
+++ b/test/test_shared.cpp
@@ -1390,7 +1390,8 @@ void writer_threads_thread(TestContext& test_context, const DBRef& sg, ObjKey ke
         // read and write transactions
         {
             ReadTransaction rt(sg);
-            rt.get_group().verify();
+            // rt.get_group().verify(); // verify() is not supported on a read transaction
+            // concurrently with writes.
             auto t = rt.get_table("test");
             auto cols = t->get_column_keys();
             int64_t v = t->get_object(key).get<Int>(cols[0]);


### PR DESCRIPTION
TSAN doesn't understand when we double map a page and use the same memory from
different threads at different addresses.