### PR TITLE
Add some helper functions for Decimal128

### DIFF
--- a/src/realm/decimal128.cpp
+++ b/src/realm/decimal128.cpp
@@ -16,12 +16,15 @@
  *
  **************************************************************************/
 
+#include <realm/decimal128.hpp>
+
+#include <realm/string_data.hpp>
+#include <realm/util/to_string.hpp>
+
 #include <external/IntelRDFPMathLib20U2/LIBRARY/src/bid_conf.h>
 #include <external/IntelRDFPMathLib20U2/LIBRARY/src/bid_functions.h>
-#include <realm/decimal128.hpp>
 #include <cstring>
 #include <stdexcept>
-#include <sstream>
 
 namespace {
 constexpr int DECIMAL_EXPONENT_BIAS_128 = 6176;
@@ -33,13 +36,13 @@ namespace realm {
 // This is a cut down version of bid128_from_string() from the IntelRDFPMathLib20U2 library.
 // If we can live with only 19 significant digits, we can avoid a lot of complex code
 // as the significant can be stored in w[0] only.
-void Decimal128::from_string(const char* ps)
+Decimal128::ParseError Decimal128::from_string(const char* ps) noexcept
 {
     m_value.w[0] = 0;
     // if null string, return NaN
     if (!ps) {
         m_value.w[1] = 0x7c00000000000000ull;
-        return;
+        return ParseError::Invalid;
     }
     // eliminate leading white space
     while ((*ps == ' ') || (*ps == '\t'))
@@ -64,14 +67,14 @@ void Decimal128::from_string(const char* ps)
             chr = tolower(chr);
         if (inf == "inf" || inf == "infinity") {
             m_value.w[1] = 0x7800000000000000ull | sign_x;
-            return;
+            return ParseError::None;
         }
     }
 
     // if c isn't a decimal point or a decimal digit, return NaN
     if (!(c == '.' || (c >= '0' && c <= '9'))) {
         m_value.w[1] = 0x7c00000000000000ull | sign_x;
-        return;
+        return ParseError::Invalid;
     }
 
     bool rdx_pt_enc = false;
@@ -105,14 +108,14 @@ void Decimal128::from_string(const char* ps)
                     if (!*(ps + 1)) {
                         uint64_t tmp = right_radix_leading_zeros;
                         m_value.w[1] = (0x3040000000000000ull - (tmp << 49)) | sign_x;
-                        return;
+                        return ParseError::None;
                     }
                     ps = ps + 1;
                 }
                 else {
                     // if 2 radix points, return NaN
                     m_value.w[1] = 0x7c00000000000000ull | sign_x;
-                    return;
+                    return ParseError::Invalid;
                 }
             }
             else if (!*(ps)) {
@@ -120,7 +123,7 @@ void Decimal128::from_string(const char* ps)
                     right_radix_leading_zeros = 6176;
                 uint64_t tmp = right_radix_leading_zeros;
                 m_value.w[1] = (0x3040000000000000ull - (tmp << 49)) | sign_x;
-                return;
+                return ParseError::None;
             }
         }
     }
@@ -138,7 +141,7 @@ void Decimal128::from_string(const char* ps)
         // investigate string (before radix point)
         while (c >= '0' && c <= '9') {
             if (ndigits_before == MAX_STRING_DIGITS) {
-                throw std::overflow_error("Too many digits before radix point");
+                return ParseError::TooLongBeforeRadix;
             }
             buffer[ndigits_before] = c;
             ps++;
@@ -156,7 +159,7 @@ void Decimal128::from_string(const char* ps)
         // investigate string (after radix point)
         while (c >= '0' && c <= '9') {
             if (ndigits_total == MAX_STRING_DIGITS) {
-                throw std::overflow_error("Too many digits");
+                return ParseError::TooLong;
             }
             buffer[ndigits_total] = c;
             ps++;
@@ -172,7 +175,7 @@ void Decimal128::from_string(const char* ps)
         if (c != 'e' && c != 'E') {
             // return NaN
             m_value.w[1] = 0x7c00000000000000ull;
-            return;
+            return ParseError::Invalid;
         }
         ps++;
         c = *ps;
@@ -183,7 +186,7 @@ void Decimal128::from_string(const char* ps)
         if (!((c >= '0' && c <= '9') || ((c == '+' || c == '-') && c1 >= '0' && c1 <= '9'))) {
             // return NaN
             m_value.w[1] = 0x7c00000000000000ull;
-            return;
+            return ParseError::Invalid;
         }
 
         if (c == '-') {
@@ -226,6 +229,7 @@ void Decimal128::from_string(const char* ps)
     m_value.w[0] = coeff;
     uint64_t tmp = dec_expon;
     m_value.w[1] = sign_x | (tmp << 49);
+    return ParseError::None;
 }
 
 Decimal128 to_decimal128(const BID_UINT128& val)
@@ -249,10 +253,7 @@ Decimal128::Decimal128()
 
 Decimal128::Decimal128(double val)
 {
-    std::stringstream ss;
-    ss.imbue(std::locale::classic());
-    ss << val;
-    from_string(ss.str().c_str());
+    from_string(util::to_string(val).c_str());
 }
 
 void Decimal128::from_int64_t(int64_t val)
@@ -303,9 +304,15 @@ Decimal128::Decimal128(Bid128 coefficient, int exponent, bool sign)
     m_value.w[1] |= (sign_x | (tmp << 49));
 }
 
-Decimal128::Decimal128(const std::string& init)
+Decimal128::Decimal128(StringData init)
 {
-    from_string(const_cast<char*>(init.c_str()));
+    auto ret = from_string(init.data());
+    if (ret == ParseError::TooLongBeforeRadix) {
+        throw std::overflow_error("Too many digits before radix point");
+    }
+    if (ret == ParseError::TooLong) {
+        throw std::overflow_error("Too many digits");
+    }
 }
 
 Decimal128::Decimal128(null) noexcept
@@ -466,6 +473,11 @@ Decimal128& Decimal128::operator+=(Decimal128 rhs)
     return *this;
 }
 
+bool Decimal128::is_valid_str(StringData str) noexcept
+{
+    return Decimal128().from_string(str.data()) == ParseError::None;
+}
+
 std::string Decimal128::to_string() const
 {
     /*
@@ -504,10 +516,7 @@ std::string Decimal128::to_string() const
         return ret;
     }
 
-    std::ostringstream ostr;
-    ostr << m_value.w[0];
-    auto digits = ostr.str();
-    ostr.clear();
+    auto digits = util::to_string(m_value.w[0]);
     int64_t exponen = m_value.w[1] & 0x7fffffffffffffffull;
     exponen >>= 49;
     exponen -= DECIMAL_EXPONENT_BIAS_128;
@@ -523,10 +532,8 @@ std::string Decimal128::to_string() const
         ret += digits.substr(digits_before);
     }
     if (exponen != 0) {
-        ostr.str("");
-        ostr << exponen;
         ret += 'E';
-        ret += ostr.str();
+        ret += util::to_string(exponen);
     }
 
     return ret;

--- a/src/realm/decimal128.hpp
+++ b/src/realm/decimal128.hpp
@@ -66,6 +66,8 @@ public:
     bool operator<=(const Decimal128& rhs) const;
     bool operator>=(const Decimal128& rhs) const;
 
+    int compare(const Decimal128& rhs) const;
+
     Decimal128 operator/(int64_t div) const;
     Decimal128 operator/(size_t div) const;
     Decimal128 operator/(int div) const;

--- a/src/realm/decimal128.hpp
+++ b/src/realm/decimal128.hpp
@@ -19,6 +19,8 @@
 #ifndef REALM_DECIMAL_HPP
 #define REALM_DECIMAL_HPP
 
+#include <realm/string_data.hpp>
+
 #include <string>
 #include <cstring>
 
@@ -45,13 +47,14 @@ public:
     explicit Decimal128(double);
     Decimal128(Bid128 coefficient, int exponent, bool sign);
     explicit Decimal128(Bid64);
-    explicit Decimal128(const std::string&);
+    explicit Decimal128(StringData);
     explicit Decimal128(Bid128 val)
     {
         m_value = val;
     }
     Decimal128(null) noexcept;
     static Decimal128 nan(const char*);
+    static bool is_valid_str(StringData) noexcept;
 
     bool is_null() const;
     bool is_nan() const;
@@ -90,7 +93,9 @@ public:
 private:
     Bid128 m_value;
 
-    void from_string(const char* ps);
+    enum class ParseError { None, Invalid, TooLongBeforeRadix, TooLong };
+
+    ParseError from_string(const char* ps) noexcept;
     void from_int64_t(int64_t val);
 };
 

--- a/src/realm/object_id.cpp
+++ b/src/realm/object_id.cpp
@@ -20,6 +20,7 @@
 #include <realm/string_data.hpp>
 #include <realm/util/assert.hpp>
 #include <atomic>
+#include <cctype>
 #include <chrono>
 #include <random>
 
@@ -48,15 +49,16 @@ static const char hex_digits[] = "0123456789abcdef";
 
 namespace realm {
 
-ObjectId::ObjectId() noexcept
+bool ObjectId::is_valid_str(StringData str) noexcept
 {
-    memset(m_bytes, 0, sizeof(m_bytes));
+    return str.size() == 24 &&
+           std::all_of(str.data(), str.data() + str.size(), [](unsigned char c) { return std::isxdigit(c); });
 }
 
-ObjectId::ObjectId(const char* init)
+ObjectId::ObjectId(const char* init) noexcept
 {
     char buf[3];
-    REALM_ASSERT(strlen(init) == 24);
+    REALM_ASSERT(is_valid_str(init));
 
     buf[2] = '\0';
 
@@ -68,7 +70,7 @@ ObjectId::ObjectId(const char* init)
     }
 }
 
-ObjectId::ObjectId(Timestamp d, int machine_id, int process_id)
+ObjectId::ObjectId(Timestamp d, int machine_id, int process_id) noexcept
 {
     auto sec = uint32_t(d.get_seconds());
     // Store in big endian so that memcmp can be used for comparison

--- a/src/realm/object_id.hpp
+++ b/src/realm/object_id.hpp
@@ -30,18 +30,23 @@ public:
     /**
      * Constructs an ObjectId with all bytes 0x00.
      */
-    ObjectId() noexcept;
+    ObjectId() noexcept = default;
     ObjectId(null) noexcept
         : ObjectId()
     {
     }
 
     /**
+     * Checks if the given string is a valid object id.
+     */
+    static bool is_valid_str(StringData) noexcept;
+
+    /**
      * Constructs an ObjectId from 24 hex characters.
      */
-    ObjectId(const char* init);
+    ObjectId(const char* init) noexcept;
 
-    ObjectId(Timestamp d, int machine_id = 0, int process_id = 0);
+    ObjectId(Timestamp d, int machine_id = 0, int process_id = 0) noexcept;
 
     /**
      * Generates a new ObjectId using the algorithm to attempt to avoid collisions.
@@ -78,7 +83,7 @@ public:
     size_t hash() const noexcept;
 
 private:
-    uint8_t m_bytes[12];
+    uint8_t m_bytes[12] = {};
 };
 
 inline std::ostream& operator<<(std::ostream& ostr, const ObjectId& id)

--- a/src/realm/util/to_string.cpp
+++ b/src/realm/util/to_string.cpp
@@ -43,6 +43,9 @@ void Printable::print(std::ostream& out, bool quote) const
         case Printable::Type::Int:
             out << m_int;
             break;
+        case Printable::Type::Double:
+            out << m_double;
+            break;
         case Printable::Type::String:
             if (quote) {
 #if __cplusplus >= 201402L

--- a/src/realm/util/to_string.hpp
+++ b/src/realm/util/to_string.hpp
@@ -72,6 +72,11 @@ public:
         , m_int(value)
     {
     }
+    Printable(double value)
+        : m_type(Type::Double)
+        , m_double(value)
+    {
+    }
     Printable(const char* value)
         : m_type(Type::String)
         , m_string(value)
@@ -94,12 +99,14 @@ private:
         Bool,
         Int,
         Uint,
+        Double,
         String,
     } m_type;
 
     union {
         uintmax_t m_uint;
         intmax_t m_int;
+        double m_double;
         const char* m_string;
     };
 };


### PR DESCRIPTION
We want to be able to validate is a string is a valid decimal128 without conflating NaN and invalid syntax. A bool-returning function also makes the code using it a bit less awkward than catching an exception would be.

The NSNumber API needs a 3-way compare function and I think it makes sense to push that logic down to here. Implementing the comparison operators on top of that cuts down on some duplicated code.

Using `util::to_string()` rather than `ostringstream` reduces the compiled size a bit.