### PR TITLE
Improve verification of link and linklist columns

### DIFF
--- a/src/realm/CMakeLists.txt
+++ b/src/realm/CMakeLists.txt
@@ -12,6 +12,7 @@ set(REALM_SOURCES
     array_blobs_big.cpp
     array_decimal128.cpp
     array_integer.cpp
+    array_key.cpp
     array_mixed.cpp
     array_object_id.cpp
     array_unsigned.cpp

--- a/src/realm/array_backlink.cpp
+++ b/src/realm/array_backlink.cpp
@@ -184,10 +184,10 @@ void ArrayBacklink::verify() const
     REALM_ASSERT(dynamic_cast<Cluster*>(get_parent()));
     auto cluster = static_cast<Cluster*>(get_parent());
     const Table* target_table = cluster->get_owning_table();
-    ColKey target_col_key = cluster->get_col_key(get_ndx_in_parent());
+    ColKey backlink_col_key = cluster->get_col_key(get_ndx_in_parent());
 
-    TableRef src_table = target_table->get_opposite_table(target_col_key);
-    ColKey src_col_key = target_table->get_opposite_column(target_col_key);
+    TableRef src_table = target_table->get_opposite_table(backlink_col_key);
+    ColKey src_col_key = target_table->get_opposite_column(backlink_col_key);
 
     // Verify that each backlink has a corresponding forward link
     ColumnAttrMask src_attr = src_col_key.get_attrs();
@@ -202,34 +202,6 @@ void ArrayBacklink::verify() const
             else {
                 REALM_ASSERT(src_obj.get<ObjKey>(src_col_key) == target_key);
             }
-        }
-    }
-
-    // Verify that each forward link has a corresponding backlink
-    auto verify_backlink = [&](ObjKey src, ObjKey target_key) {
-        if (!target_key) {
-            return;
-        }
-        REALM_ASSERT(target_table->is_valid(target_key));
-        Obj target = target_table->get_object(target_key);
-        size_t cnt = target.get_backlink_count(*src_table, src_col_key);
-        REALM_ASSERT(cnt > 0);
-        for (size_t i = 0; i < cnt; ++i) {
-            if (target.get_backlink(target_col_key, i)  == src) {
-                return;
-            }
-        }
-        REALM_ASSERT(false);
-    };
-    for (auto src_obj : *src_table) {
-        if (src_attr.test(col_attr_List)) {
-            auto list = src_obj.get_list<ObjKey>(src_col_key);
-            for (size_t i = 0; i < list.size(); ++i) {
-                verify_backlink(src_obj.get_key(), list.get(i));
-            }
-        }
-        else {
-            verify_backlink(src_obj.get_key(), src_obj.get<ObjKey>(src_col_key));
         }
     }
 #endif

--- a/src/realm/array_key.cpp
+++ b/src/realm/array_key.cpp
@@ -1,0 +1,111 @@
+/*************************************************************************
+ *
+ * Copyright 2016 Realm Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ **************************************************************************/
+
+#include <realm/array_key.hpp>
+#include <realm/table.hpp>
+
+namespace realm {
+
+// This is used for linklists
+template <>
+void ArrayKeyBase<0>::verify() const
+{
+#ifdef REALM_DEBUG
+    Array::verify();
+    // We have to get parent until we reach the containing cluster
+    auto parent = get_parent();
+    size_t origin_obj_ndx;
+    size_t origin_col_ndx = get_ndx_in_parent();
+    Cluster* cluster = nullptr;
+    do {
+        REALM_ASSERT(parent);
+        auto arr = dynamic_cast<Array*>(parent);
+        REALM_ASSERT(arr);
+        parent = arr->get_parent();
+        // When we reach the cluster, the previous value of
+        // origin_col_ndx will be the object index in the cluster.
+        origin_obj_ndx = origin_col_ndx;
+        // When we reach the cluster, arr will point to the ArrayRef leaf and the
+        // origin_col_ndx will give the position in the cluster array.
+        origin_col_ndx = arr->get_ndx_in_parent();
+        cluster = dynamic_cast<Cluster*>(parent);
+    } while (parent && !cluster);
+
+    REALM_ASSERT(cluster);
+    const Table* origin_table = cluster->get_owning_table();
+    ObjKey origin_key = cluster->get_real_key(origin_obj_ndx);
+    ColKey link_col_key = cluster->get_col_key(origin_col_ndx);
+
+    TableRef target_table = origin_table->get_opposite_table(link_col_key);
+
+    auto verify_link = [origin_table, link_col_key, origin_key](ConstObj& target_obj) {
+        auto cnt = target_obj.get_backlink_count(*origin_table, link_col_key);
+        for (size_t i = 0; i < cnt; i++) {
+            if (target_obj.get_backlink(*origin_table, link_col_key, i) == origin_key)
+                return;
+        }
+        REALM_ASSERT(false);
+    };
+
+    // Verify that forward link has a corresponding backlink
+    for (size_t i = 0; i < size(); ++i) {
+        if (ObjKey target_key = get(i)) {
+            ConstObj target_obj = target_key.is_unresolved() ? target_table->get_tombstone(target_key)
+                                                             : target_table->get_object(target_key);
+            verify_link(target_obj);
+        }
+    }
+#endif
+}
+
+// This is used for single links
+template <>
+void ArrayKeyBase<1>::verify() const
+{
+#ifdef REALM_DEBUG
+    Array::verify();
+    REALM_ASSERT(dynamic_cast<Cluster*>(get_parent()));
+    auto cluster = static_cast<Cluster*>(get_parent());
+    const Table* origin_table = cluster->get_owning_table();
+    ColKey link_col_key = cluster->get_col_key(get_ndx_in_parent());
+
+    ConstTableRef target_table = origin_table->get_opposite_table(link_col_key);
+
+    auto verify_link = [origin_table, link_col_key](ConstObj& target_obj, ObjKey origin_key) {
+        auto cnt = target_obj.get_backlink_count(*origin_table, link_col_key);
+        for (size_t i = 0; i < cnt; i++) {
+            if (target_obj.get_backlink(*origin_table, link_col_key, i) == origin_key)
+                return;
+        }
+        REALM_ASSERT(false);
+    };
+
+    // Verify that forward link has a corresponding backlink
+    for (size_t i = 0; i < size(); ++i) {
+        if (ObjKey target_key = get(i)) {
+            ObjKey origin_key = cluster->get_real_key(i);
+
+            ConstObj target_obj = target_key.is_unresolved() ? target_table->get_tombstone(target_key)
+                                                             : target_table->get_object(target_key);
+            verify_link(target_obj, origin_key);
+        }
+    }
+#endif
+}
+
+} // namespace realm

--- a/src/realm/array_key.hpp
+++ b/src/realm/array_key.hpp
@@ -42,7 +42,6 @@ public:
     using Array::erase;
     using Array::clear;
     using Array::destroy;
-    using Array::verify;
 
     ArrayKeyBase(Allocator& allocator)
         : Array(allocator)
@@ -111,6 +110,7 @@ public:
         REALM_ASSERT(begin != realm::npos);
         Array::erase(begin);
     }
+    void verify() const;
 };
 
 class ArrayKey : public ArrayKeyBase<1> {

--- a/src/realm/bplustree.hpp
+++ b/src/realm/bplustree.hpp
@@ -117,9 +117,6 @@ public:
     void bptree_access(size_t n, AccessFunc) override;
     size_t bptree_erase(size_t n, EraseFunc) override;
     bool bptree_traverse(TraverseFunc) override;
-    void verify() const override
-    {
-    }
 };
 
 /*****************************************************************************/
@@ -322,6 +319,10 @@ public:
         {
             LeafNode* dst(static_cast<LeafNode*>(new_node));
             LeafArray::move(*dst, ndx);
+        }
+        void verify() const override
+        {
+            LeafArray::verify();
         }
     };
 

--- a/src/realm/table.hpp
+++ b/src/realm/table.hpp
@@ -278,6 +278,12 @@ public:
     // - turns the object into a tombstone if links exist
     // - otherwise works just as remove_object()
     void invalidate_object(ObjKey key);
+    ConstObj get_tombstone(ObjKey key) const
+    {
+        REALM_ASSERT(key.is_unresolved());
+        REALM_ASSERT(m_tombstones);
+        return m_tombstones->get(key);
+    }
 
     void clear();
     using Iterator = ClusterTree::Iterator;

--- a/test/test_unresolved_links.cpp
+++ b/test/test_unresolved_links.cpp
@@ -99,6 +99,7 @@ TEST(Unresolved_Basic)
     }
 
     rt->advance_read();
+    rt->verify();
     CHECK_EQUAL(cars->get_object_with_primary_key("Tesla 10").get_backlink_count(), 3);
     CHECK_EQUAL(stock.size(), 2);
     CHECK_EQUAL(cars->size(), 2);
@@ -115,6 +116,7 @@ TEST(Unresolved_Basic)
     }
 
     rt->advance_read();
+    rt->verify();
     CHECK_EQUAL(stock.size(), 1);
     CHECK_EQUAL(stock.get(0), cars->get_object_with_primary_key("Skoda Fabia").get_key());
     CHECK_EQUAL(cars->size(), 1);


### PR DESCRIPTION
Verify Link lists by ArrayKey::verify() and not at part of backlink verification.
Verify single links too.
Take unresolved links info account.
