### PR TITLE
Emit remove_object() instructions for embedded objects

### DIFF
--- a/src/realm/cluster.cpp
+++ b/src/realm/cluster.cpp
@@ -1373,10 +1373,8 @@ size_t Cluster::erase(ObjKey key, CascadeState& state)
     ObjKey real_key = get_real_key(ndx);
     auto table = m_tree_top.get_owner();
     const_cast<Table*>(table)->free_local_id_after_hash_collision(real_key);
-    if (!table->is_embedded()) {
-        if (Replication* repl = table->get_repl()) {
-            repl->remove_object(table, real_key);
-        }
+    if (Replication* repl = table->get_repl()) {
+        repl->remove_object(table, real_key);
     }
 
     std::vector<ColKey> backlink_column_keys;


### PR DESCRIPTION
The object store notification code needs these to report cascaded deletions of embedded objects. We don't want to emit sync instructions for this, but the sync replication code can handle filtering them out.