### PR TITLE
Simplify methods involved in add_column...

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,7 @@
 -----------
 
 ### Internals
-* None.
+* Table::insert_column and Table::insert_column_link methods are removed.
 
 ----------------------------------------------
 

--- a/src/realm/impl/transact_log.hpp
+++ b/src/realm/impl/transact_log.hpp
@@ -312,8 +312,7 @@ public:
     virtual void insert_group_level_table(TableKey table_key, size_t num_tables, StringData name);
     virtual void erase_group_level_table(TableKey table_key, size_t num_tables);
     virtual void rename_group_level_table(TableKey table_key, StringData new_name);
-    virtual void insert_column(const Table*, ColKey col_key, DataType type, StringData name, Table* target_table,
-                               bool nullable = false, bool listtype = false);
+    virtual void insert_column(const Table*, ColKey col_key, DataType type, StringData name, Table* target_table);
     virtual void erase_column(const Table*, ColKey col_key);
     virtual void rename_column(const Table*, ColKey col_key, StringData name);
 
@@ -756,8 +755,7 @@ inline bool TransactLogEncoder::insert_column(ColKey col_key)
     return true;
 }
 
-inline void TransactLogConvenientEncoder::insert_column(const Table* t, ColKey col_key, DataType, StringData, Table*,
-                                                        bool, bool)
+inline void TransactLogConvenientEncoder::insert_column(const Table* t, ColKey col_key, DataType, StringData, Table*)
 {
     select_table(t);                  // Throws
     m_encoder.insert_column(col_key); // Throws

--- a/src/realm/keys.hpp
+++ b/src/realm/keys.hpp
@@ -105,6 +105,14 @@ struct ColKey {
                  ((tag & 0xFFFFFFFFUL) << 30))
     {
     }
+    bool is_nullable()
+    {
+        return get_attrs().test(col_attr_Nullable);
+    }
+    bool is_list()
+    {
+        return get_attrs().test(col_attr_List);
+    }
     ColKey& operator=(int64_t val) noexcept
     {
         value = val;

--- a/src/realm/table.hpp
+++ b/src/realm/table.hpp
@@ -129,11 +129,6 @@ public:
 
     ColKey add_column_link(DataType type, StringData name, Table& target);
 
-    // Pass a default ColKey() as first argument to have a new colkey generated
-    // Requesting a specific ColKey may fail with invalidkey exception, if the key is already in use
-    // We recommend allowing Core to choose the ColKey.
-    ColKey insert_column(ColKey col_key, DataType type, StringData name, bool nullable = false);
-    ColKey insert_column_link(ColKey col_key, DataType type, StringData name, Table& target);
     void remove_column(ColKey col_key);
     void rename_column(ColKey col_key, StringData new_name);
     bool valid_column(ColKey col_key) const noexcept;
@@ -709,16 +704,14 @@ private:
 
     void set_key(TableKey key);
 
-    ColKey do_insert_column(ColKey col_key, DataType type, StringData name, Table* target_table,
-                            bool nullable = false, bool listtype = false);
+    ColKey do_insert_column(ColKey col_key, DataType type, StringData name, Table* target_table);
 
     struct InsertSubtableColumns;
     struct EraseSubtableColumns;
     struct RenameSubtableColumns;
 
     void erase_root_column(ColKey col_key);
-    ColKey do_insert_root_column(ColKey col_key, ColumnType, StringData name, bool nullable = false,
-                                 bool listtype = false);
+    ColKey do_insert_root_column(ColKey col_key, ColumnType, StringData name);
     void do_erase_root_column(ColKey col_key);
 
     void set_opposite_column(ColKey col_key, TableKey opposite_table, ColKey opposite_column);


### PR DESCRIPTION
The ColKey should be calculated earlier in the process. No need to
pass information down to lowest layer via flags, when the same
information can be provided in the ColKey parameter. Will make it
easier to add more attributes later.

The insert_column... methods are not needed.