### PR TITLE
Fix the Swift package build

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -529,6 +529,9 @@ def doBuildMacOs(String buildType, boolean runTests) {
                     runAndCollectWarnings(parser: 'clang', script: 'ninja package')
                 }
             }
+            withEnv(['DEVELOPER_DIR=/Applications/Xcode-11.app/Contents/Developer/']) {
+                runAndCollectWarnings(parser: 'clang', script: 'xcrun swift build')
+            }
 
             archiveArtifacts("build-macosx-${buildType}/*.tar.gz")
 

--- a/Package.swift
+++ b/Package.swift
@@ -14,6 +14,10 @@ let package = Package(
         .library(
             name: "RealmCore",
             targets: ["RealmCore"]),
+        .library(
+            name: "RealmCoreDynamic",
+            type: .dynamic,
+            targets: ["RealmCore"]),
     ],
     targets: [
         .target(
@@ -25,7 +29,20 @@ let package = Package(
                 "realm/metrics",
                 "realm/exec",
                 "win32",
-                "external"
+            ],
+            sources: [
+                "realm",
+                "external/IntelRDFPMathLib20U2/LIBRARY/src/bid128.c",
+                "external/IntelRDFPMathLib20U2/LIBRARY/src/bid128_compare.c",
+                "external/IntelRDFPMathLib20U2/LIBRARY/src/bid128_div.c",
+                "external/IntelRDFPMathLib20U2/LIBRARY/src/bid128_add.c",
+                "external/IntelRDFPMathLib20U2/LIBRARY/src/bid128_fma.c",
+                "external/IntelRDFPMathLib20U2/LIBRARY/src/bid64_to_bid128.c",
+                "external/IntelRDFPMathLib20U2/LIBRARY/src/bid_convert_data.c",
+                "external/IntelRDFPMathLib20U2/LIBRARY/src/bid_decimal_data.c",
+                "external/IntelRDFPMathLib20U2/LIBRARY/src/bid_decimal_globals.c",
+                "external/IntelRDFPMathLib20U2/LIBRARY/src/bid_from_int.c",
+                "external/IntelRDFPMathLib20U2/LIBRARY/src/bid_round.c"
             ],
             publicHeadersPath: ".",
             cxxSettings: [


### PR DESCRIPTION
The decimal128 library needs to be added to the spm package. I also made it so that the spm build is actually tested on CI so that this sort of thing'll be caught in the future.