### PR TITLE
Testing large numbers

### DIFF
--- a/test/test_decimal128.cpp
+++ b/test/test_decimal128.cpp
@@ -47,6 +47,9 @@ TEST(Decimal_Basics)
     test_str(".00000001000000000", "1.000000000E-8");
     test_str("+Infinity", "Inf");
     test_str("-INF", "-Inf");
+    test_str("9.99e6144", "9.99E6144");  // largest decimal128
+    test_str("1.701e38", "1.701E38");    // largest float
+    test_str("1.797e308", "1.797E308");  // largest double
 
     Decimal128 pi = Decimal128("3.141592653589793238"); // 19 significant digits
     CHECK_EQUAL(pi.to_string(), "3.141592653589793238");

--- a/test/test_decimal128.cpp
+++ b/test/test_decimal128.cpp
@@ -50,6 +50,7 @@ TEST(Decimal_Basics)
     test_str("9.99e6144", "9.99E6144");  // largest decimal128
     test_str("1.701e38", "1.701E38");    // largest float
     test_str("1.797e308", "1.797E308");  // largest double
+    test_str("9.990000000000000000000000000000000E+6144", "9.99E6144"); // from BSON.Decimal128
 
     Decimal128 pi = Decimal128("3.141592653589793238"); // 19 significant digits
     CHECK_EQUAL(pi.to_string(), "3.141592653589793238");


### PR DESCRIPTION
Realm JavaScript and MongoDB Realm Studio are hitting the limitation of 19 digits (https://github.com/realm/realm-core/blob/v10/src/realm/decimal128.cpp#L31). 

The limit for BSON's Decimal128 is 34 digits (source: https://developer.mongodb.com/quickstart/bson-data-types-decimal128).