### PR TITLE
Disable test on x86 Windows

### DIFF
--- a/test/test_lang_bind_helper.cpp
+++ b/test/test_lang_bind_helper.cpp
@@ -133,7 +133,8 @@ TEST(Transactions_Frozen)
 }
 
 
-
+// disable this test on x86 Windows
+#if !(defined(_WIN32) && defined(_M_IX86))
 TEST(Transactions_ConcurrentFrozenTableGetByName)
 {
     SHARED_GROUP_TEST_PATH(path);
@@ -164,6 +165,7 @@ TEST(Transactions_ConcurrentFrozenTableGetByName)
     for (int j = 0; j < 1000; ++j)
         threads[j].join();
 }
+#endif
 
 
 TEST(Transactions_ConcurrentFrozenTableGetByKey)


### PR DESCRIPTION
When building for Windows on x86 from a x86_64 host the Visual Studio 2019 compiler crashes with:
```
test\test_lang_bind_helper.cpp(159): fatal error C1001: Internal compiler error. [C:\jenkins\workspace\realm_realm-core_next-major\build-dir\test\CoreTests.vcxproj]
  (compiler file 'd:\agent\_work\1\s\src\vctools\Compiler\Utc\src\p2\main.c', line 182)
   To work around this problem, try simplifying or changing the program near the locations listed above.
  If possible please provide a repro here: https://developercommunity.visualstudio.com
  Please choose the Technical Support command on the Visual C++
   Help menu, or open the Technical Support help file for more information
    CL!CloseTypeServerPDB()+0x7784
    CL!CloseTypeServerPDB()+0x7784
```