### PR TITLE
Fsa/fix non contiguous mapping

### DIFF
--- a/src/realm/alloc.cpp
+++ b/src/realm/alloc.cpp
@@ -101,6 +101,10 @@ public:
     }
 
     void verify() const override {}
+    void get_or_add_xover_mapping(RefTranslation&, size_t, size_t, size_t) override
+    {
+        REALM_ASSERT(false);
+    }
 };
 
 // This variable is declared such that get_default() can return it. It could be a static local variable, but
@@ -115,5 +119,50 @@ namespace realm {
 Allocator& Allocator::get_default() noexcept
 {
     return default_alloc;
+}
+
+// This function is called to handle translation of a ref which is above the limit for its
+// memory mapping. This requires one of three:
+// * bumping the limit of the mapping. (if the entire array is inside the mapping)
+// * adding a cross-over mapping. (if the array crosses a mapping boundary)
+// * using an already established cross-over mapping. (ditto)
+// this can proceed concurrently with other calls to translate()
+char* Allocator::translate_less_critical(RefTranslation* ref_translation_ptr, ref_type ref) const noexcept
+{
+    size_t idx = get_section_index(ref);
+    RefTranslation& txl = ref_translation_ptr[idx];
+    size_t offset = ref - get_section_base(idx);
+    char* addr = txl.mapping_addr + offset;
+#if REALM_ENABLE_ENCRYPTION
+    realm::util::encryption_read_barrier(addr, NodeHeader::header_size, txl.encrypted_mapping, nullptr);
+#endif
+    auto size = NodeHeader::get_byte_size_from_header(addr);
+    bool crosses_mapping = offset + size > (1 << section_shift);
+    // Move the limit on use of the existing primary mapping.
+    // Take into account that another thread may attempt to change / have changed it concurrently,
+    size_t lowest_possible_xover_offset = txl.lowest_possible_xover_offset.load(std::memory_order_relaxed);
+    auto new_lowest_possible_xover_offset = offset + (crosses_mapping ? 0 : size);
+    while (new_lowest_possible_xover_offset > lowest_possible_xover_offset) {
+        if (txl.lowest_possible_xover_offset.compare_exchange_weak(
+                lowest_possible_xover_offset, new_lowest_possible_xover_offset, std::memory_order_relaxed))
+            break;
+    }
+    if (REALM_LIKELY(!crosses_mapping)) {
+        // Array fits inside primary mapping, no new mapping needed.
+        return addr;
+    }
+    else {
+        // we need a cross-over mapping. If one is already established, use that.
+        auto xover_mapping_addr = txl.xover_mapping_addr.load(std::memory_order_acquire);
+        if (!xover_mapping_addr) {
+            // we need to establish a xover mapping - or wait for another thread to finish
+            // establishing one:
+            const_cast<Allocator*>(this)->get_or_add_xover_mapping(txl, idx, offset, size);
+            // reload (can be relaxed since the call above synchronizes on a mutex)
+            xover_mapping_addr = txl.xover_mapping_addr.load(std::memory_order_relaxed);
+        }
+        // array is now known to be inside the established xover mapping:
+        return xover_mapping_addr + (offset - txl.xover_mapping_base);
+    }
 }
 }

--- a/src/realm/alloc.hpp
+++ b/src/realm/alloc.hpp
@@ -158,10 +158,46 @@ protected:
     // The ref translation splits the full ref-space (both below and above baseline)
     // into equal chunks.
     struct RefTranslation {
-        char* mapping_addr;
+        char* mapping_addr = nullptr;
+        std::atomic<size_t> lowest_possible_xover_offset = 0;
+
+        // member 'xover_mapping_addr' is used for memory synchronization of the fields
+        // 'xover_mapping_base' and 'xover_encrypted_mapping'. It also imposes an ordering
+        // on 'lowest_possible_xover_offset' such that once a non-null value of 'xover_mapping_addr'
+        // has been acquired, 'lowest_possible_xover_offset' will never change.
+        std::atomic<char*> xover_mapping_addr = nullptr;
+        size_t xover_mapping_base = 0;
 #if REALM_ENABLE_ENCRYPTION
-        util::EncryptedFileMapping* encrypted_mapping;
+        util::EncryptedFileMapping* encrypted_mapping = nullptr;
+        util::EncryptedFileMapping* xover_encrypted_mapping = nullptr;
 #endif
+        explicit RefTranslation(char* addr)
+            : mapping_addr(addr)
+        {
+        }
+        RefTranslation() = default;
+        RefTranslation& operator=(const RefTranslation& from)
+        {
+            if (&from != this) {
+                mapping_addr = from.mapping_addr;
+#if REALM_ENABLE_ENCRYPTION
+                encrypted_mapping = from.encrypted_mapping;
+#endif
+                const auto local_xover_mapping_addr = from.xover_mapping_addr.load(std::memory_order_acquire);
+
+                // This must be loaded after xover_mapping_addr to ensure it isn't stale.
+                lowest_possible_xover_offset.store(from.lowest_possible_xover_offset, std::memory_order_relaxed);
+
+                if (local_xover_mapping_addr) {
+                    xover_mapping_base = from.xover_mapping_base;
+#if REALM_ENABLE_ENCRYPTION
+                    xover_encrypted_mapping = from.xover_encrypted_mapping;
+#endif
+                    xover_mapping_addr.store(local_xover_mapping_addr, std::memory_order_release);
+                }
+            }
+            return *this;
+        }
     };
     // This pointer may be changed concurrently with access, so make sure it is
     // atomic!
@@ -192,7 +228,9 @@ protected:
     /// then entirely the responsibility of the caller that the memory
     /// is not modified by way of the returned memory pointer.
     virtual char* do_translate(ref_type ref) const noexcept = 0;
-
+    char* translate_critical(RefTranslation*, ref_type ref) const noexcept;
+    char* translate_less_critical(RefTranslation*, ref_type ref) const noexcept;
+    virtual void get_or_add_xover_mapping(RefTranslation&, size_t, size_t, size_t) = 0;
     Allocator() noexcept;
     size_t get_section_index(size_t pos) const noexcept;
     inline size_t get_section_base(size_t index) const noexcept;
@@ -295,6 +333,12 @@ public:
     {
         switch_underlying_allocator(*m_alloc);
         set_read_only(!writable);
+    }
+
+protected:
+    void get_or_add_xover_mapping(RefTranslation& txl, size_t index, size_t offset, size_t size) override
+    {
+        m_alloc->get_or_add_xover_mapping(txl, index, offset, size);
     }
 
 private:
@@ -495,24 +539,39 @@ inline Allocator::~Allocator() noexcept
 {
 }
 
-inline char* Allocator::translate(ref_type ref) const noexcept
+// performance critical part of the translation process. Less critical code is in translate_less_critical.
+inline char* Allocator::translate_critical(RefTranslation* ref_translation_ptr, ref_type ref) const noexcept
 {
-    if (auto ref_translation_ptr = m_ref_translation_ptr.load(std::memory_order_acquire)) {
-        char* base_addr;
-        size_t idx = get_section_index(ref);
-        base_addr = ref_translation_ptr[idx].mapping_addr;
-        size_t offset = ref - get_section_base(idx);
-        auto addr = base_addr + offset;
+    size_t idx = get_section_index(ref);
+    RefTranslation& txl = ref_translation_ptr[idx];
+    size_t offset = ref - get_section_base(idx);
+    size_t lowest_possible_xover_offset = txl.lowest_possible_xover_offset.load(std::memory_order_relaxed);
+    if (REALM_LIKELY(offset < lowest_possible_xover_offset)) {
+        // the lowest possible xover offset may grow concurrently, but that will not affect this code path
+        char* addr = txl.mapping_addr + offset;
 #if REALM_ENABLE_ENCRYPTION
-        realm::util::encryption_read_barrier(addr, NodeHeader::header_size,
-                                             ref_translation_ptr[idx].encrypted_mapping,
+        realm::util::encryption_read_barrier(addr, NodeHeader::header_size, txl.encrypted_mapping,
                                              NodeHeader::get_byte_size_from_header);
 #endif
         return addr;
     }
-    else
-        return do_translate(ref);
+    else {
+        // the lowest possible xover offset may grow concurrently, but that will be handled inside the call
+        return translate_less_critical(ref_translation_ptr, ref);
+    }
 }
+
+inline char* Allocator::translate(ref_type ref) const noexcept
+{
+    auto ref_translation_ptr = m_ref_translation_ptr.load(std::memory_order_acquire);
+    if (REALM_LIKELY(ref_translation_ptr)) {
+        return translate_critical(ref_translation_ptr, ref);
+    }
+    else {
+        return do_translate(ref);
+    }
+}
+
 
 } // namespace realm
 

--- a/src/realm/alloc_slab.hpp
+++ b/src/realm/alloc_slab.hpp
@@ -305,8 +305,7 @@ public:
     /// Get an ID for the current mapping version. This ID changes whenever any part
     /// of an existing mapping is changed. Such a change requires all refs to be
     /// retranslated to new pointers. The allocator tries to avoid this, and we
-    /// believe it will only ever occur on Windows based platforms, and when a
-    /// compatibility mapping is used to read earlier file versions.
+    /// believe it will only ever occur on Windows based platforms.
     uint64_t get_mapping_version()
     {
         return m_mapping_version;
@@ -579,23 +578,12 @@ private:
 
     // mappings used by newest transactions - additional mappings may be open
     // and in use by older transactions. These translations are in m_old_mappings.
-    std::vector<util::File::Map<char>> m_mappings;
-    // The section nr for the first mapping in m_mappings. Will be 0 for newer file formats,
-    // but will be nonzero if a compatibility mapping is in use. In that case, the ref for
-    // the first mapping is the *last* section boundary in the file. Note: in this
-    // mode, the first mapping in m_mappings may overlap with the last part of the
-    // file, leading to aliasing.
-    int m_sections_in_compatibility_mapping = 0;
-    // if the file has an older format, it needs to be mapped by a single
-    // mapping. This is the compatibility mapping. As such files extend, additional
-    // mappings are added to m_mappings (above) - the compatibility mapping remains
-    // unchanged until the file is closed.
-    // Note: If the initial file is smaller than a single section, the compatibility
-    // mapping is not needed and not used. Hence, it is not possible for the first mapping
-    // in m_mappings to completely overlap the compatibility mapping. Hence, we do not
-    // need special logic to detect if the compatibility mapping can be unmapped.
-    util::File::Map<char> m_compatibility_mapping;
-
+    struct MapEntry {
+        util::File::Map<char> primary_mapping;
+        size_t lowest_possible_xover_offset = 0;
+        util::File::Map<char> xover_mapping;
+    };
+    std::vector<MapEntry> m_mappings;
     size_t m_translation_table_size = 0;
     uint64_t m_mapping_version = 1;
     uint64_t m_youngest_live_version = 1;
@@ -614,8 +602,7 @@ private:
     // Add a translation covering a new section in the slab area. The translation is always
     // added at the end.
     void extend_fast_mapping_with_slab(char* address);
-    // Prepare the initial mapping for a file which requires use of the compatibility mapping
-    void setup_compatibility_mapping(size_t file_size);
+    void get_or_add_xover_mapping(RefTranslation& txl, size_t index, size_t offset, size_t size) override;
 
     const char* m_data = nullptr;
     size_t m_initial_section_size = 0;
@@ -655,7 +642,10 @@ private:
     /// Throws InvalidDatabase if the file is not a Realm file, if the file is
     /// corrupted, or if the specified encryption key is incorrect. This
     /// function will not detect all forms of corruption, though.
-    void validate_header(const char* data, size_t len, const std::string& path);
+    /// Returns the top_ref for the latest commit.
+    ref_type validate_header(const char* data, size_t len, const std::string& path);
+    ref_type validate_header(const Header* header, const StreamingFooter* footer, size_t size,
+                             const std::string& path);
     void throw_header_exception(std::string msg, const Header& header, const std::string& path);
 
     static bool is_file_on_streaming_form(const Header& header);

--- a/src/realm/node_header.hpp
+++ b/src/realm/node_header.hpp
@@ -25,6 +25,9 @@ namespace realm {
 
 const size_t max_array_size = 0x00ffffffL;            // Maximum number of elements in an array
 const size_t max_array_payload_aligned = 0x07ffffc0L; // Maximum number of bytes that the payload of an array can be
+// Even though the encoding supports arrays with size up to max_array_payload_aligned,
+// the maximum allocation size is smaller as it must fit within a memory section
+// (a contiguous virtual address range). This limitation is enforced in SlabAlloc::do_alloc().
 
 class NodeHeader {
 public:

--- a/src/realm/util/file_mapper.hpp
+++ b/src/realm/util/file_mapper.hpp
@@ -113,13 +113,13 @@ void do_encryption_write_barrier(const void* addr, size_t size, EncryptedFileMap
 void inline encryption_read_barrier(const void* addr, size_t size, EncryptedFileMapping* mapping,
                                     HeaderToSize header_to_size = nullptr)
 {
-    if (mapping)
+    if (REALM_UNLIKELY(mapping))
         do_encryption_read_barrier(addr, size, header_to_size, mapping);
 }
 
 void inline encryption_write_barrier(const void* addr, size_t size, EncryptedFileMapping* mapping)
 {
-    if (mapping)
+    if (REALM_UNLIKELY(mapping))
         do_encryption_write_barrier(addr, size, mapping);
 }
 

--- a/test/test_destroy_guard.cpp
+++ b/test/test_destroy_guard.cpp
@@ -144,6 +144,10 @@ public:
     void verify() const override
     {
     }
+    void get_or_add_xover_mapping(RefTranslation&, size_t, size_t, size_t) override
+    {
+        REALM_ASSERT(false);
+    }
 
 private:
     ref_type m_offset;

--- a/test/test_lang_bind_helper.cpp
+++ b/test/test_lang_bind_helper.cpp
@@ -5933,4 +5933,32 @@ TEST(LangBindHelper_SearchIndexAccessor)
     tr->commit();
 }
 
+TEST(LangBindHelper_ArrayXoverMapping)
+{
+    SHARED_GROUP_TEST_PATH(path);
+    auto hist = make_in_realm_history(path);
+    DBRef db = DB::create(*hist);
+    ColKey my_col;
+    {
+        auto tr = db->start_write();
+        auto tbl = tr->add_table("my_table");
+        my_col = tbl->add_column(type_String, "my_col");
+        std::string s(1'000'000, 'a');
+        for (auto i = 0; i < 100; ++i)
+            tbl->create_object().set_all(s);
+        tr->commit();
+    }
+    REALM_ASSERT(db->compact());
+    {
+        auto tr = db->start_read();
+        auto tbl = tr->get_table("my_table");
+        for (auto i = 0; i < 100; ++i) {
+            auto o = tbl->get_object(i);
+            StringData str = o.get<String>(my_col);
+            for (auto j = 0; j < 1'000'000; ++j)
+                REALM_ASSERT(str[j] == 'a');
+        }
+    }
+}
+
 #endif

--- a/test/test_table.cpp
+++ b/test/test_table.cpp
@@ -3628,11 +3628,12 @@ TEST(Table_object_sequential)
     int nb_rows = 10'000'000;
     int num_runs = 1;
 #else
-    int nb_rows = 1024;
+    int nb_rows = 100'000;
     int num_runs = 1;
 #endif
     SHARED_GROUP_TEST_PATH(path);
-    DBRef sg = DB::create(path);
+    std::unique_ptr<Replication> hist(make_in_realm_history(path));
+    DBRef sg = DB::create(*hist, DBOptions(crypt_key()));
     ColKey c0;
     ColKey c1;
 
@@ -3777,14 +3778,15 @@ TEST(Table_object_seq_rnd)
     size_t rows = 1'000'000;
     int runs = 100;     // runs for building scenario
 #else
-    size_t rows = 50'000;
-    int runs = 1;
+    size_t rows = 100'000;
+    int runs = 100;
 #endif
     int64_t next_key = 0;
     std::vector<int64_t> key_values;
     std::set<int64_t> key_set;
     SHARED_GROUP_TEST_PATH(path);
-    DBRef sg = DB::create(path);
+    std::unique_ptr<Replication> hist(make_in_realm_history(path));
+    DBRef sg = DB::create(*hist, DBOptions(crypt_key()));
     ColKey c0;
     {
         std::cout << "Establishing scenario seq ins/rnd erase " << std::endl;
@@ -3892,11 +3894,12 @@ TEST(Table_object_random)
     int nb_rows = 1'000'000;
     int num_runs = 10;
 #else
-    int nb_rows = 1024;
+    int nb_rows = 100'000;
     int num_runs = 1;
 #endif
     SHARED_GROUP_TEST_PATH(path);
-    DBRef sg = DB::create(path);
+    std::unique_ptr<Replication> hist(make_in_realm_history(path));
+    DBRef sg = DB::create(*hist, DBOptions(crypt_key()));
     ColKey c0;
     ColKey c1;
     std::vector<int64_t> key_values;

--- a/test/test_table.cpp
+++ b/test/test_table.cpp
@@ -46,7 +46,7 @@ using namespace std::chrono;
 #include "test_table_helper.hpp"
 
 // #include <valgrind/callgrind.h>
-// #define PERFORMACE_TESTING
+//#define PERFORMACE_TESTING
 
 using namespace realm;
 using namespace realm::util;
@@ -3625,7 +3625,7 @@ TEST(Table_QuickSort2)
 TEST(Table_object_sequential)
 {
 #ifdef PERFORMACE_TESTING
-    int nb_rows = 10000000;
+    int nb_rows = 10'000'000;
     int num_runs = 1;
 #else
     int nb_rows = 1024;
@@ -3661,7 +3661,12 @@ TEST(Table_object_sequential)
         CHECK_EQUAL(table->size(), nb_rows);
         wt.commit();
     }
-
+    {
+        auto t1 = steady_clock::now();
+        sg->compact();
+        auto t2 = steady_clock::now();
+        std::cout << "  compaction time: " << duration_cast<milliseconds>(t2 - t1).count() << " ms" << std::endl;
+    }
     {
         ReadTransaction rt(sg);
         auto table = rt.get_table("test");
@@ -3769,10 +3774,10 @@ TEST(Table_object_sequential)
 TEST(Table_object_seq_rnd)
 {
 #ifdef PERFORMACE_TESTING
-    size_t rows = 100000;
+    size_t rows = 1'000'000;
     int runs = 100;     // runs for building scenario
 #else
-    size_t rows = 50000;
+    size_t rows = 50'000;
     int runs = 1;
 #endif
     int64_t next_key = 0;
@@ -3811,10 +3816,16 @@ TEST(Table_object_seq_rnd)
     // scenario established!
     int nb_rows = int(key_values.size());
 #ifdef PERFORMACE_TESTING
-    int num_runs = 100; // runs for timing access
+    int num_runs = 10; // runs for timing access
 #else
     int num_runs = 1; // runs for timing access
 #endif
+    {
+        auto t1 = steady_clock::now();
+        sg->compact();
+        auto t2 = steady_clock::now();
+        std::cout << "  compaction time: " << duration_cast<milliseconds>(t2 - t1).count() << " ms" << std::endl;
+    }
     std::cout << "Scenario has " << nb_rows << " rows. Timing...." << std::endl;
     {
         ReadTransaction rt(sg);
@@ -3878,8 +3889,8 @@ TEST(Table_object_seq_rnd)
 TEST(Table_object_random)
 {
 #ifdef PERFORMACE_TESTING
-    int nb_rows = 100000;
-    int num_runs = 100;
+    int nb_rows = 1'000'000;
+    int num_runs = 10;
 #else
     int nb_rows = 1024;
     int num_runs = 1;
@@ -3930,6 +3941,12 @@ TEST(Table_object_random)
 
         CHECK_EQUAL(table->size(), nb_rows);
         wt.commit();
+    }
+    {
+        auto t1 = steady_clock::now();
+        sg->compact();
+        auto t2 = steady_clock::now();
+        std::cout << "  compaction time: " << duration_cast<milliseconds>(t2 - t1).count() << " ms" << std::endl;
     }
 
     {


### PR DESCRIPTION
Fixes https://github.com/realm/realm-java/issues/6792 and https://github.com/realm/realm-java/issues/6790

Also brings back support for non-contiguous mapping, which had to be reverted due to above bugs.

Note to reviewer: no need to review the first commit, it has already been approved before. Bugfix is in second commit and straightforward (that commit also adjusts run length of a few unittests).
