### PR TITLE
[MSVC] work around a compiler regression in VS2019

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,7 @@
 -----------
 
 ### Internals
-* None.
+* Work around an issue with MSVC in Visual Studio 2019 where Release optimizations crash the compiler because of a regression in 64bit atomic loads on 32bit Windows.
 
 ----------------------------------------------
 

--- a/src/realm/alloc.hpp
+++ b/src/realm/alloc.hpp
@@ -241,9 +241,9 @@ protected:
         return m_content_versioning_counter.load(std::memory_order_acquire);
     }
 
-    inline void bump_content_version() noexcept
+    inline uint_fast64_t bump_content_version() noexcept
     {
-        m_content_versioning_counter.fetch_add(1, std::memory_order_acq_rel);
+        return m_content_versioning_counter.fetch_add(1, std::memory_order_acq_rel) + 1;
     }
 
     inline uint_fast64_t get_instance_version() noexcept

--- a/src/realm/cluster_tree.hpp
+++ b/src/realm/cluster_tree.hpp
@@ -88,8 +88,7 @@ public:
 
     uint64_t bump_content_version()
     {
-        m_alloc.bump_content_version();
-        return m_alloc.get_content_version();
+        return m_alloc.bump_content_version();
     }
     void bump_storage_version()
     {

--- a/src/realm/group.hpp
+++ b/src/realm/group.hpp
@@ -991,7 +991,7 @@ inline ConstTableRef Group::get_table(TableKey key) const
     return ConstTableRef(table, table ? table->m_alloc.get_instance_version() : 0);
 }
 
-inline TableRef Group::get_table(StringData name)
+REALM_NOINLINE inline TableRef Group::get_table(StringData name)
 {
     if (!is_attached())
         throw LogicError(LogicError::detached_accessor);


### PR DESCRIPTION
Work around an issue with MSVC in Visual Studio 2019 where Release optimizations crash the compiler because of a regression in 64bit atomic loads on 32bit Windows.

Many thanks to @RedBeard0531 who actually researched the issue and the fix.