### PR TITLE
reenable 'LangBindHelper_CompactLargeEncryptedFile' unittest on Android

### DIFF
--- a/test/test_lang_bind_helper.cpp
+++ b/test/test_lang_bind_helper.cpp
@@ -4839,7 +4839,6 @@ TEST(LangBindHelper_Compact)
     }
 }
 
-#if !REALM_ANDROID // FIXME
 TEST(LangBindHelper_CompactLargeEncryptedFile)
 {
     SHARED_GROUP_TEST_PATH(path);
@@ -4871,7 +4870,6 @@ TEST(LangBindHelper_CompactLargeEncryptedFile)
         CHECK_EQUAL(N, table->size());
     }
 }
-#endif
 
 TEST(LangBindHelper_CloseDBvsTransactions)
 {


### PR DESCRIPTION
Re-enables disabled unittest.