### PR TITLE
Stop defining _FILE_OFFSETS_BITS and use readdir64 instead where available

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -18,7 +18,7 @@ include(SpecialtyBuilds)
 include(GetVersion)
 include(CheckCXXCompilerFlag)
 include(CheckCXXSourceRuns)
-include(CheckTypeSize)
+include(CheckSymbolExists)
 
 # Get accurate git-describe version
 git_describe(REALM_VERSION)
@@ -182,13 +182,12 @@ elseif(ANDROID)
     list(APPEND PLATFORM_LIBRARIES log android)
 endif()
 
-if(UNIX AND NOT ANDROID)
-    # Use large-file APIs by default even on 32-bit platforms
-    # Does not work for Android: https://android.googlesource.com/platform/bionic/+/master/docs/32-bit-abi.md
-    check_type_size(off_t SIZEOF_OFF_T)
-    if(SIZEOF_OFF_T EQUAL "4")
-        add_compile_definitions("_FILE_OFFSET_BITS=64")
-    endif()
+if(UNIX)
+    # Enable access to large file APIs, but don't make them the default.
+    add_compile_definitions("_LARGEFILE_SOURCE" "_LARGEFILE64_SOURCE")
+    set(CMAKE_REQUIRED_DEFINITIONS "-D_LARGEFILE_SOURCE" "-D_LARGEFILE64_SOURCE")
+    # Use readdir64 if available.
+    check_symbol_exists(readdir64 "dirent.h" REALM_HAVE_READDIR64)
 endif()
 
 # Find dependencies

--- a/src/realm/util/config.h.in
+++ b/src/realm/util/config.h.in
@@ -5,6 +5,7 @@
 #cmakedefine01 HAVE_MALLOC_H
 
 // Realm-specific configuration
+#cmakedefine REALM_HAVE_READDIR64
 #cmakedefine REALM_MAX_BPNODE_SIZE @REALM_MAX_BPNODE_SIZE@
 #cmakedefine01 REALM_ENABLE_ASSERTIONS
 #cmakedefine01 REALM_ENABLE_ALLOC_SET_ZERO


### PR DESCRIPTION
This is a more narrowly scoped solution. It doesn't change any other code to
support 64-bit file offsets. This also means that consumers don't need to set
a compatible _FILE_OFFSETS_BITS in order to call core functions that take
off_t arguments.