### PR TITLE
Simplify table and object creation replication interface

### DIFF
--- a/src/realm/cluster.cpp
+++ b/src/realm/cluster.cpp
@@ -2139,10 +2139,10 @@ Obj ClusterTree::insert(ObjKey k, const FieldValues& values)
         };
         get_owner()->for_each_public_column(insert_in_column);
 
-        if (!table->is_embedded()) {
-            if (Replication* repl = table->get_repl()) {
-                repl->create_object(table, k);
-                for (const auto& v : values) {
+        if (Replication* repl = table->get_repl()) {
+            auto pk_col = table->get_primary_key_column();
+            for (const auto& v : values) {
+                if (v.col_key != pk_col) {
                     if (v.value.is_null()) {
                         repl->set_null(table, v.col_key, k, _impl::instr_Set);
                     }

--- a/src/realm/group.cpp
+++ b/src/realm/group.cpp
@@ -751,7 +751,7 @@ TableRef Group::add_table_with_primary_key(StringData name, DataType pk_type, St
     if (Replication* repl = *get_repl())
         repl->add_class_with_primary_key(table->get_key(), name, pk_type, pk_name, nullable);
 
-    return TableRef(table, table ? table->m_alloc.get_instance_version() : 0);
+    return TableRef(table, table->m_alloc.get_instance_version());
 }
 
 Table* Group::do_add_table(StringData name, bool is_embedded, bool do_repl)

--- a/src/realm/group.cpp
+++ b/src/realm/group.cpp
@@ -738,18 +738,23 @@ TableRef Group::add_table_with_primary_key(StringData name, DataType pk_type, St
         throw LogicError(LogicError::detached_accessor);
     check_table_name_uniqueness(name);
 
-    if (Replication* repl = *get_repl())
-        repl->add_class_with_primary_key(name, pk_type, pk_name, nullable);
+    auto table = do_add_table(name, false, false);
 
-    auto table = do_add_table(name);
-
-    ColKey pk_col = table->add_column(pk_type, pk_name, nullable);
+    // Add pk column - without replication
+    ColumnAttrMask attr;
+    if (nullable)
+        attr.set(col_attr_Nullable);
+    ColKey pk_col = table->generate_col_key(ColumnType(pk_type), attr);
+    table->do_insert_root_column(pk_col, ColumnType(pk_type), pk_name);
     table->do_set_primary_key_column(pk_col);
+
+    if (Replication* repl = *get_repl())
+        repl->add_class_with_primary_key(table->get_key(), name, pk_type, pk_name, nullable);
 
     return TableRef(table, table ? table->m_alloc.get_instance_version() : 0);
 }
 
-Table* Group::do_add_table(StringData name)
+Table* Group::do_add_table(StringData name, bool is_embedded, bool do_repl)
 {
     if (!m_is_writable)
         throw LogicError(LogicError::wrong_transact_state);
@@ -767,39 +772,7 @@ Table* Group::do_add_table(StringData name)
     bool gen_null_tag = (j == m_tables.size()); // new tags start at zero
     uint32_t tag = gen_null_tag ? 0 : uint32_t(rot.get_as_int());
     TableKey key = TableKey((tag << 16) | j);
-    create_and_insert_table(key, name);
-    Table* table = create_table_accessor(j);
 
-    return table;
-}
-
-
-Table* Group::do_get_or_add_table(StringData name, bool is_embedded, bool* was_added)
-{
-    REALM_ASSERT(m_table_names.is_attached());
-    auto table = do_get_table(name);
-    if (table) {
-        if (was_added)
-            *was_added = false;
-        return table;
-    }
-    else {
-        Replication* repl = *get_repl();
-        if (repl && name.begins_with(g_class_name_prefix))
-            repl->add_class(name, is_embedded);
-
-        table = do_add_table(name);
-        if (is_embedded)
-            table->do_set_embedded(true);
-        if (was_added)
-            *was_added = true;
-        return table;
-    }
-}
-
-
-void Group::create_and_insert_table(TableKey key, StringData name)
-{
     if (REALM_UNLIKELY(name.size() > max_table_name_length))
         throw LogicError(LogicError::table_name_too_long);
 
@@ -807,8 +780,8 @@ void Group::create_and_insert_table(TableKey key, StringData name)
     size_t table_ndx = key2ndx(key);
     ref_type ref = Table::create_empty_table(m_alloc, key); // Throws
     REALM_ASSERT_3(m_tables.size(), ==, m_table_names.size());
-    size_t prior_num_tables = m_tables.size();
-    RefOrTagged rot = RefOrTagged::make_ref(ref);
+
+    rot = RefOrTagged::make_ref(ref);
     REALM_ASSERT(m_table_accessors.size() == m_tables.size());
 
     if (table_ndx == m_tables.size()) {
@@ -822,9 +795,17 @@ void Group::create_and_insert_table(TableKey key, StringData name)
         m_table_names.set(table_ndx, name); // Throws
     }
 
-    if (Replication* repl = *get_repl())
-        repl->insert_group_level_table(key, prior_num_tables, name); // Throws
+    Replication* repl = *get_repl();
+    if (do_repl && repl && name.begins_with(g_class_name_prefix))
+        repl->add_class(key, name, is_embedded);
+
     ++m_num_tables;
+
+    Table* table = create_table_accessor(j);
+    if (is_embedded)
+        table->do_set_embedded(true);
+
+    return table;
 }
 
 

--- a/src/realm/impl/transact_log.cpp
+++ b/src/realm/impl/transact_log.cpp
@@ -29,10 +29,29 @@ TransactLogConvenientEncoder::TransactLogConvenientEncoder(TransactLogStream& st
 
 TransactLogConvenientEncoder::~TransactLogConvenientEncoder() {}
 
-void TransactLogConvenientEncoder::add_class(StringData, bool) {}
-void TransactLogConvenientEncoder::add_class_with_primary_key(StringData, DataType, StringData, bool) {}
-void TransactLogConvenientEncoder::create_object(const Table*, GlobalKey) {}
-void TransactLogConvenientEncoder::create_object_with_primary_key(const Table*, GlobalKey, Mixed) {}
+void TransactLogConvenientEncoder::add_class(TableKey table_key, StringData, bool)
+{
+    unselect_all();
+    m_encoder.insert_group_level_table(table_key); // Throws
+}
+
+void TransactLogConvenientEncoder::add_class_with_primary_key(TableKey tk, StringData, DataType, StringData, bool)
+{
+    unselect_all();
+    m_encoder.insert_group_level_table(tk); // Throws
+}
+
+void TransactLogConvenientEncoder::create_object(const Table* t, GlobalKey id)
+{
+    select_table(t);                              // Throws
+    m_encoder.create_object(id.get_local_key(0)); // Throws
+}
+
+void TransactLogConvenientEncoder::create_object_with_primary_key(const Table* t, GlobalKey id, Mixed)
+{
+    select_table(t);                                                                       // Throws
+    m_encoder.create_object(_impl::TableFriend::global_to_local_object_id_hashed(*t, id)); // Throws
+}
 
 bool TransactLogEncoder::select_table(TableKey key)
 {

--- a/src/realm/table.hpp
+++ b/src/realm/table.hpp
@@ -1455,6 +1455,10 @@ public:
     {
         return table.create_linked_object(id);
     }
+    static ObjKey global_to_local_object_id_hashed(const Table& table, GlobalKey global_id)
+    {
+        return table.global_to_local_object_id_hashed(global_id);
+    }
 };
 
 } // namespace realm


### PR DESCRIPTION
Only call one function in the replication interface when creating
a table and when creating an object.

The following functions will be called:

    add_class (table key, name, embedded)
    add_class_with_primary_key (table key, name, pk_type, pk_name, pk_nullable)
    create_object (table, GlobalKey)
    create_object_with_primary_key (table, GlobalKey, pk value)

Should be seen in relation to https://github.com/realm/realm-sync/pull/3280