### PR TITLE
test new warnings plugin

### DIFF
--- a/src/realm/obj.cpp
+++ b/src/realm/obj.cpp
@@ -79,6 +79,7 @@ Allocator& ConstObj::_get_alloc() const
 {
     // Bypass check of table instance version. To be used only in contexts,
     // where instance version match has already been established (e.g _get<>)
+    bool unused_var = false;
     return m_table.unchecked_ptr()->m_alloc;
 }
 

--- a/src/realm/obj.cpp
+++ b/src/realm/obj.cpp
@@ -79,7 +79,6 @@ Allocator& ConstObj::_get_alloc() const
 {
     // Bypass check of table instance version. To be used only in contexts,
     // where instance version match has already been established (e.g _get<>)
-    bool unused_var = false;
     return m_table.unchecked_ptr()->m_alloc;
 }
 


### PR DESCRIPTION
Fixes https://github.com/realm/realm-core/issues/3103
The new functionality is added in https://github.com/realm/ci/pull/288, but this core PR adds more descriptive names to each warning collection phase. Builds are failed if warnings are detected, and reported along with the source code line. Previously, it was very tedious to find out why a build was failing and what the warning was because you'd usually have to manually look through the entire log of the build for the output. Now you'll see the output as below:
![Screen Shot 2020-05-11 at 5 59 51 PM](https://user-images.githubusercontent.com/2826060/81632972-6bcfb600-93c0-11ea-8bf1-3b35b9734327.png)
