### PR TITLE
fcntl not supported on some filesystems

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,8 +4,7 @@
 * None.
 
 ### Fixed
-* <How to hit and notice issue? what was the impact?> ([#????](https://github.com/realm/realm-core/issues/????), since v?.?.?)
-* None.
+* Fixed opening Realms on Apple devices where the file resided on a filesystem that does not support preallocation, such as ExFAT. ([cocoa-6508](https://github.com/realm/realm-cocoa/issues/6508)).
  
 ### Breaking changes
 * None.


### PR DESCRIPTION
Fixes https://github.com/realm/realm-cocoa/issues/6508.

This fix was tested manually on an external ExFAT storage device from a mac where I could also replicate the reported bug.

Using `fcntl` is an optimization, so this fix is a "defensive" way to allow for yet another error case. But another way to fix this, would be to always try the fallback if anything fails, regardless of the error. If reviewers would prefer the latter, I'd be happy to open it up further.