### PR TITLE
Allow constructing a StringData from a temporary std::string

### DIFF
--- a/src/realm/string_data.hpp
+++ b/src/realm/string_data.hpp
@@ -97,10 +97,6 @@ public:
     template <class T, class A>
     operator std::basic_string<char, T, A>() const;
 
-    // StringData does not store data, callers must manage their own strings.
-    template <class T, class A>
-    StringData(const std::basic_string<char, T, A>&&) = delete;
-
     template <class T, class A>
     StringData(const util::Optional<std::basic_string<char, T, A>>&);
 


### PR DESCRIPTION
This is important for the primary use case of being a universal receiver argument type:

```cpp
std::string make_string();
void take_string(StringData input);
take_string(make_string()); // <--- should compile!
```

See https://quuxplusone.github.io/blog/2019/03/11/value-category-is-not-lifetime/ for more details about why this should be considered an anti-pattern.