### PR TITLE
fix incorrect init of m_opposite_xx subarrays in Table

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@
 
 ### Fixed
 * Fixed opening Realms on Apple devices where the file resided on a filesystem that does not support preallocation, such as ExFAT. ([cocoa-6508](https://github.com/realm/realm-cocoa/issues/6508)).
- 
+* Fixed wrong initialization of (part of) the Table accessor. ([#3701](https://github.com/realm/realm-core/issues/3701)). This bug may have caused a faulty file format upgrade to v6 or v10.
 ### Breaking changes
 * None.
 

--- a/src/realm/table.cpp
+++ b/src/realm/table.cpp
@@ -476,10 +476,10 @@ void Table::init(ref_type top_ref, ArrayParent* parent, size_t ndx_in_parent, bo
         MemRef mem = Array::create_array(Array::type_HasRefs, context_flag, nb_columns, 0, m_top.get_alloc());
         m_index_refs.init_from_mem(mem);
         m_index_refs.update_parent();
-        mem = Array::create_array(Array::type_Normal, context_flag, nb_columns, 0, m_top.get_alloc());
+        mem = Array::create_array(Array::type_Normal, context_flag, nb_columns, TableKey().value, m_top.get_alloc());
         m_opposite_table.init_from_mem(mem);
         m_opposite_table.update_parent();
-        mem = Array::create_array(Array::type_Normal, context_flag, nb_columns, 0, m_top.get_alloc());
+        mem = Array::create_array(Array::type_Normal, context_flag, nb_columns, ColKey().value, m_top.get_alloc());
         m_opposite_column.init_from_mem(mem);
         m_opposite_column.update_parent();
     }
@@ -752,8 +752,8 @@ void Table::do_erase_root_column(ColKey col_key)
         delete m_index_accessors[col_ndx];
         m_index_accessors[col_ndx] = nullptr;
     }
-    m_opposite_table.set(col_ndx, 0);
-    m_opposite_column.set(col_ndx, 0);
+    m_opposite_table.set(col_ndx, TableKey().value);
+    m_opposite_column.set(col_ndx, ColKey().value);
     m_index_accessors[col_ndx] = nullptr;
     m_clusters.remove_column(col_key);
     size_t spec_ndx = colkey2spec_ndx(col_key);


### PR DESCRIPTION
The initial value for TableKeys and ColKeys in the m_opposite_xxx members of the table accessor was incorrectly set to 0 instead of -1.
