### PR TITLE
Fix potential issue with interrupted upgrade

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@
 ### Fixed
 * Fixed opening Realms on Apple devices where the file resided on a filesystem that does not support preallocation, such as ExFAT. ([cocoa-6508](https://github.com/realm/realm-cocoa/issues/6508)).
 * Fixed wrong initialization of (part of) the Table accessor. ([#3701](https://github.com/realm/realm-core/issues/3701)). This bug may have caused a faulty file format upgrade to v6 or v10.
+* Fixed potential issue that could occur when the upgrade process was interrupted. We don't have evidence that this has actually happened so we will not refer to any specific issue report.
+
 ### Breaking changes
 * None.
 


### PR DESCRIPTION
If the upgrade process was interrupted after the normal columns had been migrated
but before migration of the link columns, then the process would crash when it was
resumed.