### PR TITLE
Fix incorrect query results on a LnkLst that does not match table order

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@
 ### Fixed
 * Fixed opening Realms on Apple devices where the file resided on a filesystem that does not support preallocation, such as ExFAT. ([cocoa-6508](https://github.com/realm/realm-cocoa/issues/6508)).
 * Fixed wrong initialization of (part of) the Table accessor. ([#3701](https://github.com/realm/realm-core/issues/3701)). This bug may have caused a faulty file format upgrade to v6 or v10.
+* Fixed incorrect results when querying on a LnkLst where the target property over a link has an index and the LnkLst has a different order from the target table. ([Cocoa #6540](https://github.com/realm/realm-cocoa/issues/6540), since 5.23.6.
+
 ### Breaking changes
 * None.
 

--- a/src/realm/keys.hpp
+++ b/src/realm/keys.hpp
@@ -181,9 +181,17 @@ struct ObjKey {
     {
         return value < rhs.value;
     }
+    bool operator<=(const ObjKey& rhs) const noexcept
+    {
+        return value <= rhs.value;
+    }
     bool operator>(const ObjKey& rhs) const noexcept
     {
         return value > rhs.value;
+    }
+    bool operator>=(const ObjKey& rhs) const noexcept
+    {
+        return value >= rhs.value;
     }
     explicit operator bool() const noexcept
     {

--- a/src/realm/query.cpp
+++ b/src/realm/query.cpp
@@ -1861,7 +1861,6 @@ TableVersions Query::sync_view_if_needed() const
 QueryGroup::QueryGroup(const QueryGroup& other)
     : m_root_node(other.m_root_node ? other.m_root_node->clone() : nullptr)
     , m_pending_not(other.m_pending_not)
-    , m_subtable_column(other.m_subtable_column)
     , m_state(other.m_state)
 {
 }
@@ -1871,8 +1870,6 @@ QueryGroup& QueryGroup::operator=(const QueryGroup& other)
     if (this != &other) {
         m_root_node = other.m_root_node ? other.m_root_node->clone() : nullptr;
         m_pending_not = other.m_pending_not;
-        m_subtable_column = other.m_subtable_column;
-        m_state = other.m_state;
     }
     return *this;
 }

--- a/src/realm/query.hpp
+++ b/src/realm/query.hpp
@@ -76,7 +76,6 @@ struct QueryGroup {
     std::unique_ptr<ParentNode> m_root_node;
 
     bool m_pending_not = false;
-    size_t m_subtable_column = not_found;
     State m_state = State::Default;
 };
 

--- a/src/realm/query_expression.hpp
+++ b/src/realm/query_expression.hpp
@@ -3901,10 +3901,17 @@ public:
     size_t find_first(size_t start, size_t end) const override
     {
         if (m_has_matches) {
-            if (m_index_get < m_index_end && start < end) {
-                ObjKey first_key = m_cluster->get_real_key(start);
-                auto actual_key = m_matches[m_index_get];
+            if (m_index_end == 0 || start >= end)
+                return not_found;
 
+            ObjKey first_key = m_cluster->get_real_key(start);
+            ObjKey actual_key;
+
+            // Sequential lookup optimization: when the query isn't constrained
+            // to a LnkLst we'll get find_first() requests in ascending order,
+            // so we can do a simple linear scan.
+            if (m_index_get < m_index_end && m_matches[m_index_get] <= first_key) {
+                actual_key = m_matches[m_index_get];
                 // skip through keys which are in "earlier" leafs than the one selected by start..end:
                 while (first_key > actual_key) {
                     m_index_get++;
@@ -3912,16 +3919,23 @@ public:
                         return not_found;
                     actual_key = m_matches[m_index_get];
                 }
-                // if actual key is bigger than last key, it is not in this leaf
-                ObjKey last_key = m_cluster->get_real_key(end - 1);
-                if (actual_key > last_key)
-                    return not_found;
-
-                // key is known to be in this leaf, so find key whithin leaf keys
-                return m_cluster->lower_bound_key(ObjKey(actual_key.value - m_cluster->get_offset()));
-
             }
-            return not_found;
+            // Otherwise if we get requests out of order we have to do a more
+            // expensive binary search
+            else {
+                auto it = std::lower_bound(m_matches.begin(), m_matches.end(), first_key);
+                if (it == m_matches.end())
+                    return not_found;
+                actual_key = *it;
+            }
+
+            // if actual key is bigger than last key, it is not in this leaf
+            ObjKey last_key = start + 1 == end ? first_key : m_cluster->get_real_key(end - 1);
+            if (actual_key > last_key)
+                return not_found;
+
+            // key is known to be in this leaf, so find key whithin leaf keys
+            return m_cluster->lower_bound_key(ObjKey(actual_key.value - m_cluster->get_offset()));
         }
 
         size_t match;


### PR DESCRIPTION
The optimization added in #3432 to use the search index when performing equality queries over a link assumed that Queries would be evaluated in ascending table order, which is not always the case when the query is being performed on a link list.

Fixes realm/realm-cocoa#6540.