### PR TITLE
Reduce overengineering of Lst implementation

### DIFF
--- a/src/realm/db.cpp
+++ b/src/realm/db.cpp
@@ -2593,9 +2593,9 @@ TableRef Transaction::import_copy_of(ConstTableRef original)
     return get_table(tk);
 }
 
-LnkLst Transaction::import_copy_of(const ConstLnkLst& original)
+LnkLst Transaction::import_copy_of(const LnkLst& original)
 {
-    if (Obj obj = import_copy_of(*original.m_const_obj)) {
+    if (Obj obj = import_copy_of(original.m_obj)) {
         ColKey ck = original.m_col_key;
         return obj.get_linklist(ck);
     }
@@ -2604,7 +2604,7 @@ LnkLst Transaction::import_copy_of(const ConstLnkLst& original)
 
 LstBasePtr Transaction::import_copy_of(const LstBase& original)
 {
-    if (Obj obj = import_copy_of(*original.m_const_obj)) {
+    if (Obj obj = import_copy_of(original.m_obj)) {
         ColKey ck = original.get_col_key();
         return obj.get_listbase_ptr(ck);
     }
@@ -2615,25 +2615,12 @@ LnkLstPtr Transaction::import_copy_of(const LnkLstPtr& original)
 {
     if (!bool(original))
         return nullptr;
-    if (Obj obj = import_copy_of(*original->m_const_obj)) {
-        ColKey ck = original->m_col_key;
-        return obj.get_linklist_ptr(ck);
-
-    }
-    return std::make_unique<LnkLst>();
-}
-
-LnkLstPtr Transaction::import_copy_of(const ConstLnkLstPtr& original)
-{
-    if (!bool(original))
-        return nullptr;
-    if (Obj obj = import_copy_of(*original->m_const_obj)) {
+    if (Obj obj = import_copy_of(original->m_obj)) {
         ColKey ck = original->m_col_key;
         return obj.get_linklist_ptr(ck);
     }
     return std::make_unique<LnkLst>();
 }
-
 
 std::unique_ptr<Query> Transaction::import_copy_of(Query& query, PayloadPolicy policy)
 {

--- a/src/realm/db.hpp
+++ b/src/realm/db.hpp
@@ -596,10 +596,9 @@ public:
     // direct handover of accessor instances
     Obj import_copy_of(const Obj& original);
     TableRef import_copy_of(const ConstTableRef original);
-    LnkLst import_copy_of(const ConstLnkLst& original);
+    LnkLst import_copy_of(const LnkLst& original);
     LstBasePtr import_copy_of(const LstBase& original);
     LnkLstPtr import_copy_of(const LnkLstPtr& original);
-    LnkLstPtr import_copy_of(const ConstLnkLstPtr& original);
 
     // handover of the heavier Query and TableView
     std::unique_ptr<Query> import_copy_of(Query&, PayloadPolicy);

--- a/src/realm/obj.hpp
+++ b/src/realm/obj.hpp
@@ -39,21 +39,13 @@ template <class>
 class ConstLstIf;
 
 template <class>
-class ConstLst;
-
-template <class>
 class Lst;
 template <class T>
 using LstPtr = std::unique_ptr<Lst<T>>;
-template <class T>
-using ConstLstPtr = std::unique_ptr<const Lst<T>>;
-using ConstLstBasePtr = std::unique_ptr<ConstLstBase>;
 using LstBasePtr = std::unique_ptr<LstBase>;
 
 class LnkLst;
-class ConstLnkLst;
 using LnkLstPtr = std::unique_ptr<LnkLst>;
-using ConstLnkLstPtr = std::unique_ptr<const LnkLst>;
 
 // 'Object' would have been a better name, but it clashes with a class in ObjectStore
 class Obj {
@@ -258,7 +250,6 @@ private:
     friend class CascadeState;
     friend class Cluster;
     friend class ColumnListBase;
-    friend class ConstLnkLst;
     friend class ConstLstBase;
     friend class ConstTableView;
     template <class>

--- a/src/realm/object-store/list.cpp
+++ b/src/realm/object-store/list.cpp
@@ -191,7 +191,7 @@ size_t List::find(Obj const& o) const
         return not_found;
     validate(o);
 
-    return as<Obj>().ConstLstIf<ObjKey>::find_first(o.get_key());
+    return as<Obj>().find_first(o.get_key());
 }
 
 size_t List::find(Query&& q) const
@@ -199,7 +199,7 @@ size_t List::find(Query&& q) const
     verify_attached();
     if (m_type == PropertyType::Object) {
         ObjKey key = get_query().and_query(std::move(q)).find();
-        return key ? as<Obj>().ConstLstIf<ObjKey>::find_first(key) : not_found;
+        return key ? as<Obj>().find_first(key) : not_found;
     }
     throw std::runtime_error("not implemented");
 }

--- a/src/realm/table_view.hpp
+++ b/src/realm/table_view.hpp
@@ -171,7 +171,7 @@ public:
     ConstTableView(ConstTableRef parent);
     ConstTableView(ConstTableRef parent, Query& query, size_t start, size_t end, size_t limit);
     ConstTableView(ConstTableRef parent, ColKey column, const Obj& obj);
-    ConstTableView(ConstTableRef parent, ConstLnkLstPtr link_list);
+    ConstTableView(ConstTableRef parent, LnkLstPtr link_list);
 
     enum DistinctViewTag { DistinctView };
     ConstTableView(DistinctViewTag, ConstTableRef parent, ColKey column_key);
@@ -387,7 +387,7 @@ protected:
     ConstTableRef m_linked_table;
 
     // If this TableView was created from a LnkLst, then this reference points to it. Otherwise it's 0
-    mutable ConstLnkLstPtr m_linklist_source;
+    mutable LnkLstPtr m_linklist_source;
 
     // m_distinct_column_source != ColKey() if this view was created from distinct values in a column of m_table.
     ColKey m_distinct_column_source;
@@ -480,7 +480,7 @@ public:
 private:
     TableView(TableRef parent);
     TableView(TableRef parent, Query& query, size_t start, size_t end, size_t limit);
-    TableView(TableRef parent, ConstLnkLstPtr);
+    TableView(TableRef parent, LnkLstPtr);
     TableView(DistinctViewTag, TableRef parent, ColKey column_key);
 
     friend class ConstTableView;
@@ -542,7 +542,7 @@ inline ConstTableView::ConstTableView(DistinctViewTag, ConstTableRef parent, Col
     }
 }
 
-inline ConstTableView::ConstTableView(ConstTableRef parent, ConstLnkLstPtr link_list)
+inline ConstTableView::ConstTableView(ConstTableRef parent, LnkLstPtr link_list)
     : m_table(parent) // Throws
     , m_linklist_source(std::move(link_list))
     , m_key_values(Allocator::get_default())
@@ -700,7 +700,7 @@ inline TableView::TableView(TableRef parent, Query& query, size_t start, size_t 
 {
 }
 
-inline TableView::TableView(TableRef parent, ConstLnkLstPtr link_list)
+inline TableView::TableView(TableRef parent, LnkLstPtr link_list)
     : ConstTableView(parent, std::move(link_list))
 {
 }

--- a/test/benchmark-common-tasks/main.cpp
+++ b/test/benchmark-common-tasks/main.cpp
@@ -1607,7 +1607,7 @@ struct BenchmarkGetLinkList : Benchmark {
     {
         ConstTableRef table = m_table;
 #ifdef REALM_CLUSTER_IF
-        std::vector<ConstLnkLstPtr> linklists(rows);
+        std::vector<LnkLstPtr> linklists(rows);
         for (size_t i = 0; i < rows; ++i) {
             auto obj = table->get_object(m_keys[i]);
             linklists[i] = obj.get_linklist_ptr(m_col_link);

--- a/test/test_transform.cpp
+++ b/test/test_transform.cpp
@@ -1870,10 +1870,7 @@ TEST(Transform_DanglingLinks)
         CHECK_EQUAL(links.size(), 0);
 
         // ... But the real list should contain 1 tombstone.
-        //
-        // FIXME: `Obj` does not provide a method to get a `Lst<ObjKey>` that
-        // isn't actually a `LnkLst`.
-        auto keys = ConstLst<ObjKey>(obj, table->get_column_key("links"));
+        auto keys = obj.get_list<ObjKey>(table->get_column_key("links"));
         CHECK_EQUAL(keys.size(), 1);
     });
 }


### PR DESCRIPTION
Move m_obj attribute to ConstLstBase class.
Prevent creating ConstLst objects.
Remove ConstLnkLst
Remove move-constructors - not obvious where they could be useful.