### PR TITLE
Erase embedded objects when parent object is erased by sync

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 * <How to hit and notice issue? what was the impact?> ([#????](https://github.com/realm/realm-core/issues/????), since v?.?.?)
 * We would allow converting a table to embedded table in spite some objects had no links to them. ([#3729](https://github.com/realm/realm-core/issues/3729), since v6.1.0-alpha.5)
 * If you upgrade from a realm file with file format version 6 (Realm Core v2.4.0 or earlier) the upgrade will result in a crash ([#3764](https://github.com/realm/realm-core/issues/3764), since v6.0.0-alpha.0)
+* Receiving an EraseObject instruction from server would not cause any embedded objects to be erased.  ([RSYNC-128](https://jira.mongodb.org/browse/RSYNC-128), since v6.1.0-alpha.5)
  
 ### Breaking changes
 * None.

--- a/src/realm/table.cpp
+++ b/src/realm/table.cpp
@@ -3010,7 +3010,7 @@ void Table::remove_object(ObjKey key)
     if (has_any_embedded_objects() || (g && g->has_cascade_notification_handler())) {
         CascadeState state(CascadeState::Mode::Strong, g);
         state.m_to_be_deleted.emplace_back(m_key, key);
-        nullify_links(state);
+        m_clusters.nullify_links(key, state);
         remove_recursive(state);
     }
     else {
@@ -3040,8 +3040,8 @@ void Table::invalidate_object(ObjKey key)
         auto tombstone = get_or_create_tombstone(key, init_values);
         tombstone.assign_pk_and_backlinks(obj);
     }
-    CascadeState state(CascadeState::Mode::None);
-    m_clusters.erase(key, state);
+
+    remove_object(key);
 }
 
 void Table::remove_object_recursive(ObjKey key)

--- a/test/test_table.cpp
+++ b/test/test_table.cpp
@@ -5319,6 +5319,17 @@ TEST(Table_EmbeddedObjectCreateAndDestroy)
         CHECK(table->size() == 0);
         // do not commit
     }
+    {
+        // Sync operations
+        auto tr = sg->start_write();
+        auto table = tr->get_table("myEmbeddedStuff");
+        auto parent = tr->get_table("myParentStuff");
+        CHECK(table->size() == 2);
+        auto first = parent->begin();
+        first->invalidate();
+        CHECK(table->size() == 0);
+        // do not commit
+    }
 }
 
 TEST(Table_EmbeddedObjectCreateAndDestroyList)

--- a/test/test_unresolved_links.cpp
+++ b/test/test_unresolved_links.cpp
@@ -160,7 +160,9 @@ TEST(Unresolved_InvalidateObject)
 {
     Group g;
 
+    auto wheels = g.add_embedded_table("Wheels");
     auto cars = g.add_table_with_primary_key("Car", type_String, "model");
+    auto col_wheels = cars->add_column_link(type_LinkList, "wheels", *wheels);
     auto col_price = cars->add_column(type_Decimal, "price");
     auto dealers = g.add_table("Dealer");
     auto col_has = dealers->add_column_link(type_LinkList, "stock", *cars);
@@ -175,8 +177,17 @@ TEST(Unresolved_InvalidateObject)
     members.add(dealer1.get_key());
     members.add(dealer2.get_key());
 
-    auto skoda = cars->create_object_with_primary_key("Skoda Fabia").set(col_price, Decimal128("149999.5"));
-    auto tesla = cars->create_object_with_primary_key("Tesla 10").set(col_price, Decimal128("499999.5"));
+    auto create_car = [&](const char* name, const char* price) {
+        Obj car = cars->create_object_with_primary_key(name).set(col_price, Decimal128(price));
+        auto list = car.get_linklist(col_wheels);
+        for (int i = 0; i < 4; i++) {
+            list.create_and_insert_linked_object(i);
+        }
+        return car;
+    };
+
+    auto skoda = create_car("Skoda Fabia", "149999.5");
+    auto tesla = create_car("Tesla 10", "499999.5");
 
     auto stock = dealer1.get_linklist(col_has);
     stock.add(tesla.get_key());
@@ -185,6 +196,7 @@ TEST(Unresolved_InvalidateObject)
     CHECK_EQUAL(stock.size(), 2);
     CHECK_EQUAL(members.size(), 2);
     CHECK_EQUAL(cars->size(), 2);
+    CHECK_EQUAL(wheels->size(), 8);
 
     // Tesla goes to the grave. Too expensive
     cars->invalidate_object(tesla.get_key());
@@ -195,6 +207,7 @@ TEST(Unresolved_InvalidateObject)
     CHECK_EQUAL(stock.size(), 1);
     CHECK_EQUAL(stock.get(0), skoda.get_key());
     CHECK_EQUAL(cars->size(), 1);
+    CHECK_EQUAL(wheels->size(), 4);
 
     // One dealer goes bankrupt
     dealer2.invalidate();
@@ -202,9 +215,10 @@ TEST(Unresolved_InvalidateObject)
     CHECK_EQUAL(dealers->nb_unresolved(), 1);
 
     // resurrect the tesla
-    cars->create_object_with_primary_key("Tesla 10").set(col_price, Decimal128("399999.5"));
+    create_car("Tesla 10", "399999.5");
     CHECK_EQUAL(stock.size(), 2);
     CHECK_EQUAL(cars->size(), 2);
+    CHECK_EQUAL(wheels->size(), 8);
 }
 
 TEST(Unresolved_LinkList)


### PR DESCRIPTION
Fixes https://jira.mongodb.org/browse/RSYNC-128