### PR TITLE
Add support for the 64-bit watchOS simulator

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 # NEXT RELEASE
 
 ### Enhancements
-* None.
+* Add support for the 64-bit watchOS simulator.
 
 ### Fixed
 * <How to hit and notice issue? what was the impact?> ([#????](https://github.com/realm/realm-core/issues/????), since v?.?.?)

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -600,7 +600,8 @@ def doBuildAppleDevice(String sdk, String buildType) {
         node('osx') {
             getArchive()
 
-            withEnv(['DEVELOPER_DIR=/Applications/Xcode-11.app/Contents/Developer/']) {
+            withEnv(['DEVELOPER_DIR=/Applications/Xcode-11.app/Contents/Developer/',
+                     'XCODE12_DEVELOPER_DIR=/Applications/Xcode-12.app/Contents/Developer/']) {
                 retry(3) {
                     timeout(time: 45, unit: 'MINUTES') {
                         sh """

--- a/tools/build-cocoa.sh
+++ b/tools/build-cocoa.sh
@@ -112,10 +112,10 @@ if [[ -n $BUILD_XCFRAMEWORK ]]; then
         for p in "${PLATFORMS[@]}"; do
             if [[ "$p" == "macosx" ]]; then
                 build_dir="core/librealm-macosx${suffix}.a"
-                make_core_xcframework+=( -library "${build_dir}")
+                make_core_xcframework+=( -library "${build_dir}" -headers core/include)
             elif [[ "$p" == "maccatalyst" ]]; then
                 build_dir="core/librealm-maccatalyst${suffix}.a"
-                make_core_xcframework+=( -library "${build_dir}")
+                make_core_xcframework+=( -library "${build_dir}" -headers core/include)
             else
                 build_dir="core/librealm-${p}${suffix}.a"
                 output_prefix="xcf-tmp/librealm-${p}${suffix}"
@@ -130,11 +130,10 @@ if [[ -n $BUILD_XCFRAMEWORK ]]; then
                 done
                 extract_slices "$build_dir" "${output_prefix}-device.a" "$device"
                 extract_slices "$build_dir" "${output_prefix}-simulator.a" "$simulator"
-                make_core_xcframework+=( -library "${output_prefix}-device.a")
-                make_core_xcframework+=( -library "${output_prefix}-simulator.a")
+                make_core_xcframework+=( -library "${output_prefix}-device.a" -headers core/include)
+                make_core_xcframework+=( -library "${output_prefix}-simulator.a" -headers core/include)
             fi
         done
-        make_core_xcframework+=( -headers core/include)
         xcodebuild -create-xcframework "${make_core_xcframework[@]}" -output core/realm-core${suffix}.xcframework
         rm -rf xcf-tmp
     done

--- a/tools/build-cocoa.sh
+++ b/tools/build-cocoa.sh
@@ -55,7 +55,7 @@ function build_macos {
     )
 }
 
-if [[ ! -z $BUILD ]]; then
+if [[ -n $BUILD ]]; then
     for bt in "${BUILD_TYPES[@]}"; do
         build_macos macosx "$bt"
     done
@@ -65,7 +65,7 @@ if [[ ! -z $BUILD ]]; then
         done
         for os in ios watchos tvos; do
             for bt in "${BUILD_TYPES[@]}"; do
-                tools/cross_compile.sh -o $os -t $bt -v $(git describe) -f "${CMAKE_FLAGS}"
+                tools/cross_compile.sh -o "$os" -t "$bt" -v "$(git describe)" -f "${CMAKE_FLAGS}"
             done
         done
     fi
@@ -85,57 +85,63 @@ for bt in "${BUILD_TYPES[@]}"; do
         mv "core/lib/librealm${suffix}.a" "core/librealm-${p}${suffix}.a"
         tar -C core -zxvf "${filename}" "lib/librealm-parser${suffix}.a"
         mv "core/lib/librealm-parser${suffix}.a" "core/librealm-parser-${p}${suffix}.a"
-
-        # extract arch slices for iOS, Watch, TV
-        if [[ "$p" != "macosx" && "$p" != "maccatalyst" ]]; then
-            case "${p}" in
-                ios) SDK="iphone";;
-                watchos) SDK="watch";;
-                tvos) SDK="appletv";;
-            esac
-            tar -C core -zxvf "${filename}" "lib/librealm-${SDK}-device${suffix}.a"
-            mv "core/lib/librealm-${SDK}-device${suffix}.a" "core/librealm-${SDK}-device${suffix}.a"
-            tar -C core -zxvf "${filename}" "lib/librealm-parser-${SDK}-device${suffix}.a"
-            mv "core/lib/librealm-parser-${SDK}-device${suffix}.a" "core/librealm-parser-${SDK}-device${suffix}.a"
-            tar -C core -zxvf "${filename}" "lib/librealm-${SDK}-simulator${suffix}.a"
-            mv "core/lib/librealm-${SDK}-simulator${suffix}.a" "core/librealm-${SDK}-simulator${suffix}.a"
-            tar -C core -zxvf "${filename}" "lib/librealm-parser-${SDK}-simulator${suffix}.a"
-            mv "core/lib/librealm-parser-${SDK}-simulator${suffix}.a" "core/librealm-parser-${SDK}-simulator${suffix}.a"
-        fi
-        rm -rf core/lib
     done
 done
 
+function extract_slices {
+    local input="$1"
+    local output="$2"
+    local archs="$3"
+
+    # create-xcframework does not like fat libraries with a single arch but
+    # also doesn't like two thin libraries for one platform, so we have to
+    # create different types of libraries depending on the arch count
+    if [ $(wc -w <<< "$archs") == 2 ]; then
+        archs=$(sed 's/extract/thin/' <<< "$archs")
+    fi
+    lipo $archs -output "$output" "$input"
+}
+
 # Produce xcframeworks
-if [[ ! -z $BUILD_XCFRAMEWORK ]]; then
+if [[ -n $BUILD_XCFRAMEWORK ]]; then
     for bt in "${BUILD_TYPES[@]}"; do
         make_core_xcframework=()
         [[ "$bt" = "Release" ]] && suffix="" || suffix="-dbg"
+        rm -rf xcf-tmp
+        mkdir xcf-tmp
         for p in "${PLATFORMS[@]}"; do
             if [[ "$p" == "macosx" ]]; then
                 build_dir="core/librealm-macosx${suffix}.a"
-                make_core_xcframework+=( -library ${build_dir} -headers core/include/)
+                make_core_xcframework+=( -library "${build_dir}")
             elif [[ "$p" == "maccatalyst" ]]; then
                 build_dir="core/librealm-maccatalyst${suffix}.a"
-                make_core_xcframework+=( -library ${build_dir} -headers core/include/)
+                make_core_xcframework+=( -library "${build_dir}")
             else
-                case "${p}" in
-                    ios) SDK="iphone";;
-                    watchos) SDK="watch";;
-                    tvos) SDK="appletv";;
-                esac
-                build_dir_device="core/librealm-${SDK}-device${suffix}.a"
-                build_dir_simulator="core/librealm-${SDK}-simulator${suffix}.a"
-                make_core_xcframework+=( -library ${build_dir_device} -headers core/include/)
-                make_core_xcframework+=( -library ${build_dir_simulator} -headers core/include/)
+                build_dir="core/librealm-${p}${suffix}.a"
+                output_prefix="xcf-tmp/librealm-${p}${suffix}"
+                device=''
+                simulator=''
+                for arch in $(lipo -archs "$build_dir"); do
+                    if [[ "$arch" == arm* ]]; then
+                        device+="-extract $arch "
+                    else
+                        simulator+="-extract $arch "
+                    fi
+                done
+                extract_slices "$build_dir" "${output_prefix}-device.a" "$device"
+                extract_slices "$build_dir" "${output_prefix}-simulator.a" "$simulator"
+                make_core_xcframework+=( -library "${output_prefix}-device.a")
+                make_core_xcframework+=( -library "${output_prefix}-simulator.a")
             fi
         done
+        make_core_xcframework+=( -headers core/include)
         xcodebuild -create-xcframework "${make_core_xcframework[@]}" -output core/realm-core${suffix}.xcframework
+        rm -rf xcf-tmp
     done
 fi
 
 # Package artifacts
-if [[ ! -z $COPY ]]; then
+if [[ -n $COPY ]]; then
     rm -rf "${DESTINATION}/core"
     mkdir -p "${DESTINATION}"
     cp -R core "${DESTINATION}"

--- a/tools/cmake/Utilities.cmake
+++ b/tools/cmake/Utilities.cmake
@@ -49,29 +49,3 @@ macro(set_target_xcode_attributes _target)
     )
 endmacro()
 
-include(GNUInstallDirs)
-macro(install_arch_slices_for_platform _platform)
-    if(NOT "${CMAKE_BUILD_TYPE}" STREQUAL "Release")
-        set(BUILD_SUFFIX "-dbg")
-    endif()
-    # Device builds will contain '-device' so it does not collide with the fat libs
-    install(FILES ${CMAKE_CURRENT_BINARY_DIR}/src/realm/${CMAKE_BUILD_TYPE}-${_platform}os/librealm${BUILD_SUFFIX}.a
-            DESTINATION ${CMAKE_INSTALL_LIBDIR}/ RENAME librealm-${_platform}-device${BUILD_SUFFIX}.a
-            COMPONENT devel
-    )
-
-    install(FILES ${CMAKE_CURRENT_BINARY_DIR}/src/realm/${CMAKE_BUILD_TYPE}-${_platform}simulator/librealm${BUILD_SUFFIX}.a
-            DESTINATION ${CMAKE_INSTALL_LIBDIR}/ RENAME librealm-${_platform}-simulator${BUILD_SUFFIX}.a
-            COMPONENT devel
-    )
-
-    install(FILES ${CMAKE_CURRENT_BINARY_DIR}/src/realm/parser/${CMAKE_BUILD_TYPE}-${_platform}os/librealm-parser${BUILD_SUFFIX}.a
-            DESTINATION ${CMAKE_INSTALL_LIBDIR}/ RENAME librealm-parser-${_platform}-device${BUILD_SUFFIX}.a
-            COMPONENT devel
-    )
-
-    install(FILES ${CMAKE_CURRENT_BINARY_DIR}/src/realm/parser/${CMAKE_BUILD_TYPE}-${_platform}simulator/librealm-parser${BUILD_SUFFIX}.a
-            DESTINATION ${CMAKE_INSTALL_LIBDIR}/ RENAME librealm-parser-${_platform}-simulator${BUILD_SUFFIX}.a
-            COMPONENT devel
-    )
-endmacro()

--- a/tools/cmake/ios.toolchain.cmake
+++ b/tools/cmake/ios.toolchain.cmake
@@ -1,5 +1,4 @@
 include("${CMAKE_CURRENT_LIST_DIR}/Utilities.cmake")
-include(GNUInstallDirs)
 
 check_generator("Xcode")
 
@@ -31,5 +30,3 @@ set(CMAKE_XCODE_ATTRIBUTE_REALM_ALIGN_FLAG[arch=armv7] "-fno-aligned-new")
 set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} $(REALM_ALIGN_FLAG)")
 
 set_bitcode_attributes()
-
-install_arch_slices_for_platform("iphone")

--- a/tools/cmake/tvos.toolchain.cmake
+++ b/tools/cmake/tvos.toolchain.cmake
@@ -24,5 +24,3 @@ set(CMAKE_XCODE_ATTRIBUTE_CODE_SIGNING_REQUIRED "NO")
 set(CMAKE_XCODE_ATTRIBUTE_ENABLE_BITCODE[sdk=appletv*] "YES")
 
 set_bitcode_attributes()
-
-install_arch_slices_for_platform("appletv")

--- a/tools/cmake/watchos.toolchain.cmake
+++ b/tools/cmake/watchos.toolchain.cmake
@@ -24,5 +24,3 @@ set(CMAKE_XCODE_ATTRIBUTE_CODE_SIGNING_REQUIRED "NO")
 set(CMAKE_XCODE_ATTRIBUTE_ENABLE_BITCODE[sdk=watch*] "YES")
 
 set_bitcode_attributes()
-
-install_arch_slices_for_platform("watch")

--- a/tools/cross_compile.sh
+++ b/tools/cross_compile.sh
@@ -94,6 +94,19 @@ else
               -G Xcode ..
     }
 
+    if [ "${OS}" == "watchos" ] && [ -n "${XCODE12_DEVELOPER_DIR}" ]; then
+        mkdir -p "build-${OS}-${BUILD_TYPE}-64"
+        pushd "build-${OS}-${BUILD_TYPE}-64" || exit 1
+        (
+            export DEVELOPER_DIR="$XCODE12_DEVELOPER_DIR"
+            configure_xcode
+            xcodebuild -sdk "${SDK}simulator" -configuration "${BUILD_TYPE}" ARCHS='x86_64'
+        )
+        WATCHOS_EXTRA_LIB="$(pwd)/src/realm/${BUILD_TYPE}-${SDK}simulator/librealm${suffix}.a"
+        popd
+    fi
+
+
     mkdir -p "build-${OS}-${BUILD_TYPE}"
     cd "build-${OS}-${BUILD_TYPE}" || exit 1
 
@@ -109,7 +122,8 @@ else
     lipo -create \
          -output "src/realm/${BUILD_TYPE}/librealm${suffix}.a" \
          "src/realm/${BUILD_TYPE}-${SDK}os/librealm${suffix}.a" \
-         "src/realm/${BUILD_TYPE}-${SDK}simulator/librealm${suffix}.a"
+         "src/realm/${BUILD_TYPE}-${SDK}simulator/librealm${suffix}.a" \
+         ${WATCHOS_EXTRA_LIB}
     lipo -create \
          -output "src/realm/parser/${BUILD_TYPE}/librealm-parser${suffix}.a" \
          "src/realm/parser/${BUILD_TYPE}-${SDK}os/librealm-parser${suffix}.a" \


### PR DESCRIPTION
Xcode 12 finally added a 64-bit watchOS simulator, so we now need to build for that platform as well. This uses the same logic as we used when they added 64-bit watchOS devices; the new arch needs to be built with Xcode 12, but the old arches need to continue to be built with Xcode 11 due to bitcode not being backwards-compatible.