### PR TITLE
Add missing update_if_needed() to ConstLst::find_first()

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@
 
 ### Fixed
 * <How to hit and notice issue? what was the impact?> ([#????](https://github.com/realm/realm-core/issues/????), since v?.?.?)
-* None.
+* Calling ConstLst::find_first() immediately after advance_read() would give incorrect results ([Cocoa #6606](https://github.com/realm/realm-cocoa/issues/6606), since 6.0.0).
  
 ### Breaking changes
 * None.

--- a/src/realm/list.hpp
+++ b/src/realm/list.hpp
@@ -375,6 +375,7 @@ public:
     {
         if (!m_valid && !init_from_parent())
             return not_found;
+        update_if_needed();
         return m_tree->find_first(value);
     }
     template <typename Func>

--- a/test/test_lang_bind_helper.cpp
+++ b/test/test_lang_bind_helper.cpp
@@ -1071,7 +1071,6 @@ TEST(LangBindHelper_AdvanceReadTransact_LinkView)
         TableRef target = wt.add_table("target");
         target->add_column(type_Int, "value");
         auto col = origin->add_column_link(type_LinkList, "list", *target);
-        // origin->add_search_index(0);
         std::vector<ObjKey> keys;
         target->create_objects(10, keys);
 
@@ -1098,6 +1097,19 @@ TEST(LangBindHelper_AdvanceReadTransact_LinkView)
     auto ll2 = obj1.get_linklist(col_link); // lv2[0] -> target[2]
     CHECK_EQUAL(ll1.size(), 1);
     CHECK_EQUAL(ll2.size(), 1);
+
+    ObjKey ll1_target = ll1.get_object(0).get_key();
+    CHECK_EQUAL(ll1.find_first(ll1_target), 0);
+
+    {
+        WriteTransaction wt(sg_w);
+        wt.get_table("origin")->get_object(ObjKey(0)).get_linklist(col_link).clear();
+        wt.commit();
+    }
+    rt->advance_read();
+    rt->verify();
+
+    CHECK_EQUAL(ll1.find_first(ll1_target), not_found);
 }
 
 namespace {


### PR DESCRIPTION
find_first() doesn't require bounds checking, so we don't call size() before it and it needs to handling updating itself.

Fixes https://github.com/realm/realm-cocoa/issues/6606.