### PR TITLE
Collection/Replication refactor

### DIFF
--- a/src/realm/CMakeLists.txt
+++ b/src/realm/CMakeLists.txt
@@ -22,6 +22,7 @@ set(REALM_SOURCES
     bplustree.cpp
     chunked_binary.cpp
     cluster.cpp
+    collection.cpp
     column_binary.cpp
     decimal128.cpp
     disable_sync_to_disk.cpp
@@ -124,6 +125,7 @@ set(REALM_INSTALL_GENERAL_HEADERS
     chunked_binary.hpp
     cluster.hpp
     cluster_tree.hpp
+    collection.hpp
     column_binary.hpp
     column_integer.hpp
     column_fwd.hpp
@@ -325,7 +327,7 @@ endif()
 
 # GCC<5.1 does not adhere to the C++11 ABI for std::string but some systems
 # still produce non-compliant C++11 ABI even with newer version of GCC (Centos 6 for example).
-# This performs a linking test and communicates to dependencies built with newer compilers 
+# This performs a linking test and communicates to dependencies built with newer compilers
 # that the old ABI should be used.
 if(UNIX AND NOT APPLE AND CMAKE_CXX_COMPILER_ID STREQUAL "GNU")
     try_compile(USES_OLD_ABI ${RealmCore_BINARY_DIR}/abitest ${RealmCore_SOURCE_DIR}/tools/cmake/abitest abitest)
@@ -407,7 +409,7 @@ if(UNIX AND NOT APPLE)
     if (REALM_ENABLE_SYNC)
 	    target_link_libraries(Storage PUBLIC OpenSSL::SSL)
     endif()
-    
+
     if(NOT REALM_SKIP_SHARED_LIB)
         target_link_libraries(StorageShared PUBLIC OpenSSL::Crypto)
     endif()

--- a/src/realm/alloc.hpp
+++ b/src/realm/alloc.hpp
@@ -310,7 +310,7 @@ private:
     friend class Group;
     friend class WrappedAllocator;
     friend class Obj;
-    friend class ConstLstBase;
+    friend class CollectionBase;
 };
 
 

--- a/src/realm/array_integer.hpp
+++ b/src/realm/array_integer.hpp
@@ -22,6 +22,7 @@
 #include <realm/array.hpp>
 #include <realm/util/safe_int_ops.hpp>
 #include <realm/util/optional.hpp>
+#include <realm/array_key.hpp>
 
 namespace realm {
 

--- a/src/realm/cluster.cpp
+++ b/src/realm/cluster.cpp
@@ -47,7 +47,7 @@ constexpr int node_shift_factor = 2;
 #endif
 
 constexpr size_t cluster_node_size = 1 << node_shift_factor;
-}
+} // namespace
 
 /*
  * Node-splitting is done in the way that if the new element comes after all the
@@ -205,7 +205,7 @@ private:
     // and setting it to 0 thereafter
     void adjust_keys_first_child(int64_t adj);
 };
-}
+} // namespace realm
 
 void ClusterNode::IteratorState::clear()
 {
@@ -236,9 +236,7 @@ ClusterNodeInner::ClusterNodeInner(Allocator& allocator, const ClusterTree& tree
 {
 }
 
-ClusterNodeInner::~ClusterNodeInner()
-{
-}
+ClusterNodeInner::~ClusterNodeInner() {}
 
 void ClusterNodeInner::create(int sub_tree_depth)
 {
@@ -311,8 +309,9 @@ T ClusterNodeInner::recurse(ChildInfo& child_info, F func)
 
 MemRef ClusterNodeInner::ensure_writeable(ObjKey key)
 {
-    return recurse<MemRef>(
-        key, [](ClusterNode* node, ChildInfo& child_info) { return node->ensure_writeable(child_info.key); });
+    return recurse<MemRef>(key, [](ClusterNode* node, ChildInfo& child_info) {
+        return node->ensure_writeable(child_info.key);
+    });
 }
 
 ref_type ClusterNodeInner::insert(ObjKey key, const FieldValues& init_values, ClusterNode::State& state)
@@ -372,8 +371,10 @@ bool ClusterNodeInner::try_get(ObjKey key, ClusterNode::State& state) const
     if (!find_child(key, child_info)) {
         return false;
     }
-    return const_cast<ClusterNodeInner*>(this)->recurse<bool>(
-        child_info, [&state](const ClusterNode* node, ChildInfo& info) { return node->try_get(info.key, state); });
+    return const_cast<ClusterNodeInner*>(this)->recurse<bool>(child_info,
+                                                              [&state](const ClusterNode* node, ChildInfo& info) {
+                                                                  return node->try_get(info.key, state);
+                                                              });
 }
 
 ObjKey ClusterNodeInner::get(size_t ndx, ClusterNode::State& state) const
@@ -1153,9 +1154,7 @@ void Cluster::move(size_t ndx, ClusterNode* new_node, int64_t offset)
     m_keys.truncate(ndx);
 }
 
-Cluster::~Cluster()
-{
-}
+Cluster::~Cluster() {}
 
 const Table* Cluster::get_owning_table() const
 {
@@ -2155,8 +2154,9 @@ Obj ClusterTree::insert(ObjKey k, const FieldValues& values)
     const Table* table = get_owner();
 
     // Sort ColKey according to index
-    std::sort(init_values.begin(), init_values.end(),
-              [](auto& a, auto& b) { return a.col_key.get_index().val < b.col_key.get_index().val; });
+    std::sort(init_values.begin(), init_values.end(), [](auto& a, auto& b) {
+        return a.col_key.get_index().val < b.col_key.get_index().val;
+    });
 
     insert_fast(k, init_values, state);
 
@@ -2229,12 +2229,7 @@ Obj ClusterTree::insert(ObjKey k, const FieldValues& values)
             auto pk_col = table->get_primary_key_column();
             for (const auto& v : values) {
                 if (v.col_key != pk_col) {
-                    if (v.value.is_null()) {
-                        repl->set_null(table, v.col_key, k, _impl::instr_Set);
-                    }
-                    else {
-                        repl->set(table, v.col_key, k, v.value, _impl::instr_Set);
-                    }
+                    repl->set(table, v.col_key, k, v.value, _impl::instr_Set);
                 }
             }
         }
@@ -2369,7 +2364,9 @@ void ClusterTree::enumerate_string_column(ColKey col_key)
         return false; // Continue
     };
 
-    auto upgrade = [col_key, &keys](Cluster* cluster) { cluster->upgrade_string_to_enum(col_key, keys); };
+    auto upgrade = [col_key, &keys](Cluster* cluster) {
+        cluster->upgrade_string_to_enum(col_key, keys);
+    };
 
     // Populate 'keys' array
     traverse(collect_strings);

--- a/src/realm/collection.cpp
+++ b/src/realm/collection.cpp
@@ -1,0 +1,27 @@
+#include <realm/collection.hpp>
+
+namespace realm {
+
+CollectionBase::CollectionBase(const Obj& owner, ColKey col_key)
+    : m_obj(owner)
+    , m_col_key(col_key)
+{
+    if (!(col_key.get_attrs().test(col_attr_List))) {
+        throw LogicError(LogicError::list_type_mismatch);
+    }
+    m_nullable = col_key.is_nullable();
+}
+
+CollectionBase::~CollectionBase() {}
+
+ref_type CollectionBase::get_child_ref(size_t) const noexcept
+{
+    try {
+        return to_ref(m_obj._get<int64_t>(m_col_key.get_index()));
+    }
+    catch (const KeyNotFound&) {
+        return ref_type(0);
+    }
+}
+
+} // namespace realm

--- a/src/realm/collection.hpp
+++ b/src/realm/collection.hpp
@@ -1,0 +1,565 @@
+#ifndef REALM_COLLECTION_HPP
+#define REALM_COLLECTION_HPP
+
+#include <realm/obj.hpp>
+
+#include <iosfwd>      // std::ostream
+#include <type_traits> // std::void_t
+
+namespace realm {
+
+// To be used in query for size. Adds nullability to size so that
+// it can be put in a NullableVector
+struct SizeOfList {
+    static constexpr size_t null_value = size_t(-1);
+
+    SizeOfList(size_t s = null_value)
+        : sz(s)
+    {
+    }
+    bool is_null()
+    {
+        return sz == null_value;
+    }
+    void set_null()
+    {
+        sz = null_value;
+    }
+    size_t size() const
+    {
+        return sz;
+    }
+    size_t sz = null_value;
+};
+
+template <class T>
+inline void check_column_type(ColKey col)
+{
+    if (col && col.get_type() != ColumnTypeTraits<T>::column_id) {
+        throw LogicError(LogicError::list_type_mismatch);
+    }
+}
+
+template <>
+inline void check_column_type<Int>(ColKey col)
+{
+    if (col && (col.get_type() != col_type_Int || col.get_attrs().test(col_attr_Nullable))) {
+        throw LogicError(LogicError::list_type_mismatch);
+    }
+}
+
+template <>
+inline void check_column_type<util::Optional<Int>>(ColKey col)
+{
+    if (col && (col.get_type() != col_type_Int || !col.get_attrs().test(col_attr_Nullable))) {
+        throw LogicError(LogicError::list_type_mismatch);
+    }
+}
+
+template <>
+inline void check_column_type<ObjKey>(ColKey col)
+{
+    if (col && col.get_type() != col_type_LinkList) {
+        throw LogicError(LogicError::list_type_mismatch);
+    }
+}
+
+template <class T, class Enable = void>
+struct MaxHelper {
+    template <class U>
+    static Mixed eval(U&, size_t*)
+    {
+        return Mixed{};
+    }
+};
+
+template <class T>
+struct MaxHelper<T, std::void_t<ColumnMinMaxType<T>>> {
+    template <class U>
+    static Mixed eval(U& tree, size_t* return_ndx)
+    {
+        return Mixed(bptree_maximum<T>(tree, return_ndx));
+    }
+};
+
+template <class T, class Enable = void>
+class SumHelper {
+public:
+    template <class U>
+    static Mixed eval(U&, size_t* return_cnt)
+    {
+        if (return_cnt)
+            *return_cnt = 0;
+        return Mixed{};
+    }
+};
+
+template <class T>
+class SumHelper<T, std::void_t<ColumnSumType<T>>> {
+public:
+    template <class U>
+    static Mixed eval(U& tree, size_t* return_cnt)
+    {
+        return Mixed(bptree_sum<T>(tree, return_cnt));
+    }
+};
+
+template <class T, class = void>
+struct AverageHelper {
+    template <class U>
+    static Mixed eval(U&, size_t* return_cnt)
+    {
+        if (return_cnt)
+            *return_cnt = 0;
+        return Mixed{};
+    }
+};
+
+template <class T>
+struct AverageHelper<T, std::void_t<ColumnSumType<T>>> {
+    template <class U>
+    static Mixed eval(U& tree, size_t* return_cnt)
+    {
+        return Mixed(bptree_average<T>(tree, return_cnt));
+    }
+};
+
+inline std::ostream& operator<<(std::ostream& ostr, SizeOfList size_of_list)
+{
+    if (size_of_list.is_null()) {
+        ostr << "null";
+    }
+    else {
+        ostr << size_of_list.sz;
+    }
+    return ostr;
+}
+
+class CollectionBase : public ArrayParent {
+public:
+    virtual ~CollectionBase();
+    /*
+     * Operations that makes sense without knowing the specific type
+     * can be made virtual.
+     */
+    virtual size_t size() const = 0;
+    virtual bool is_null(size_t ndx) const = 0;
+    virtual Mixed get_any(size_t ndx) const = 0;
+
+    virtual Mixed min(size_t* return_ndx = nullptr) const = 0;
+    virtual Mixed max(size_t* return_ndx = nullptr) const = 0;
+    virtual Mixed sum(size_t* return_cnt = nullptr) const = 0;
+    virtual Mixed avg(size_t* return_cnt = nullptr) const = 0;
+
+    // Modifies a vector of indices so that they refer to values sorted according
+    // to the specified sort order
+    virtual void sort(std::vector<size_t>& indices, bool ascending = true) const = 0;
+    // Modifies a vector of indices so that they refer to distinct values.
+    // If 'sort_order' is supplied, the indices will refer to values in sort order,
+    // otherwise the indices will be in original order.
+    virtual void distinct(std::vector<size_t>& indices, util::Optional<bool> sort_order = util::none) const = 0;
+
+    bool is_empty() const;
+    ObjKey get_key() const;
+    bool is_attached() const;
+    bool has_changed() const;
+    void update_child_ref(size_t, ref_type new_ref) override;
+    ConstTableRef get_table() const;
+    ColKey get_col_key() const;
+    bool operator==(const CollectionBase& other) const;
+
+protected:
+    friend class Transaction;
+
+    Obj m_obj;
+    ColKey m_col_key;
+    bool m_nullable = false;
+
+    mutable std::vector<size_t> m_deleted;
+    mutable uint_fast64_t m_content_version = 0;
+    mutable uint_fast64_t m_last_content_version = 0;
+
+    CollectionBase() = default;
+    CollectionBase(const Obj& owner, ColKey col_key);
+    CollectionBase& operator=(const CollectionBase& other);
+
+    virtual bool init_from_parent() const = 0;
+
+    ref_type get_child_ref(size_t) const noexcept override;
+
+    void update_if_needed() const;
+    void update_content_version() const;
+    // Increase index by one. I we land on and index that is deleted, keep
+    // increasing until we get to a valid entry.
+    size_t incr(size_t ndx) const;
+    /// Decrease index by one. If we land on an index that is deleted, keep decreasing until we get to a valid entry.
+    size_t decr(size_t ndx) const;
+    /// Convert from virtual to real index
+    size_t adjust(size_t ndx) const;
+    void adj_remove(size_t ndx);
+};
+
+/// This class defines the interface to ConstList, except for the constructor
+/// The ConstList class has the Obj member m_obj, which should not be
+/// inherited from Lst<T>.
+template <class T, class Interface = CollectionBase>
+class Collection : public Interface {
+public:
+    struct iterator;
+
+    /**
+     * Only member functions not referring to an index in the list will check if
+     * the object is up-to-date. The logic is that the user must always check the
+     * size before referring to a particular index, and size() will check for update.
+     */
+    size_t size() const override
+    {
+        if (!is_attached())
+            return 0;
+        update_if_needed();
+        if (!m_valid)
+            return 0;
+
+        return m_tree->size();
+    }
+    bool is_null(size_t ndx) const final
+    {
+        return m_nullable && get(ndx) == BPlusTree<T>::default_value(true);
+    }
+    Mixed get_any(size_t ndx) const final
+    {
+        return Mixed(get(ndx));
+    }
+
+    // Ensure that `Interface` implements `CollectionBase`.
+    using Interface::avg;
+    using Interface::distinct;
+    using Interface::is_attached;
+    using Interface::max;
+    using Interface::min;
+    using Interface::size;
+    using Interface::sort;
+    using Interface::sum;
+    using Interface::update_content_version;
+    using Interface::update_if_needed;
+
+    T get(size_t ndx) const
+    {
+        if (ndx >= Collection::size()) {
+            throw std::out_of_range("Index out of range");
+        }
+        return m_tree->get(ndx);
+    }
+    T operator[](size_t ndx) const
+    {
+        return get(ndx);
+    }
+    iterator begin() const
+    {
+        return iterator(this, 0);
+    }
+    iterator end() const
+    {
+        return iterator(this, Collection::size() + m_deleted.size());
+    }
+    size_t find_first(T value) const
+    {
+        if (!m_valid && !init_from_parent())
+            return not_found;
+        return m_tree->find_first(value);
+    }
+    template <typename Func>
+    void find_all(T value, Func&& func) const
+    {
+        if (m_valid && init_from_parent())
+            m_tree->find_all(value, std::forward<Func>(func));
+    }
+    const BPlusTree<T>& get_tree() const
+    {
+        return *m_tree;
+    }
+
+protected:
+    mutable std::unique_ptr<BPlusTree<T>> m_tree;
+    mutable bool m_valid = false;
+
+    using Interface::m_col_key;
+    using Interface::m_deleted;
+    using Interface::m_nullable;
+    using Interface::m_obj;
+
+    Collection() = default;
+
+    Collection(const Obj& obj, ColKey col_key)
+        : Interface(obj, col_key)
+        , m_tree(new BPlusTree<T>(obj.get_alloc()))
+    {
+        check_column_type<T>(m_col_key);
+
+        m_tree->set_parent(this, 0); // ndx not used, implicit in m_owner
+    }
+
+    Collection(const Collection& other)
+        : Interface(static_cast<const Interface&>(other))
+        , m_valid(other.m_valid)
+    {
+        if (other.m_tree) {
+            Allocator& alloc = other.m_tree->get_alloc();
+            m_tree = std::make_unique<BPlusTree<T>>(alloc);
+            m_tree->set_parent(this, 0);
+            if (m_valid)
+                m_tree->init_from_ref(other.m_tree->get_ref());
+        }
+    }
+
+    Collection& operator=(const Collection& other)
+    {
+        if (this != &other) {
+            CollectionBase::operator=(other);
+            m_valid = other.m_valid;
+            m_deleted.clear();
+            m_tree = nullptr;
+
+            if (other.m_tree) {
+                Allocator& alloc = other.m_tree->get_alloc();
+                m_tree = std::make_unique<BPlusTree<T>>(alloc);
+                m_tree->set_parent(this, 0);
+                if (m_valid)
+                    m_tree->init_from_ref(other.m_tree->get_ref());
+            }
+        }
+        return *this;
+    }
+
+    bool init_from_parent() const override
+    {
+        m_valid = m_tree->init_from_parent();
+        update_content_version();
+        return m_valid;
+    }
+
+    void ensure_writeable()
+    {
+        if (m_obj.ensure_writeable()) {
+            init_from_parent();
+        }
+    }
+};
+
+/*
+ * This class implements a forward iterator over the elements in a Lst.
+ *
+ * The iterator is stable against deletions in the list. If you try to
+ * dereference an iterator that points to an element, that is deleted, the
+ * call will throw.
+ *
+ * Values are read into a member variable (m_val). This is the only way to
+ * implement operator-> and operator* returning a pointer and a reference resp.
+ * There is no overhead compared to the alternative where operator* would have
+ * to return T by value.
+ */
+template <class T, class Interface>
+struct Collection<T, Interface>::iterator {
+    typedef std::bidirectional_iterator_tag iterator_category;
+    typedef const T value_type;
+    typedef ptrdiff_t difference_type;
+    typedef const T* pointer;
+    typedef const T& reference;
+
+    iterator(const Collection<T, Interface>* l, size_t ndx)
+        : m_list(l)
+        , m_ndx(ndx)
+    {
+    }
+    pointer operator->() const
+    {
+        m_val = m_list->get(m_list->adjust(m_ndx));
+        return &m_val;
+    }
+    reference operator*() const
+    {
+        return *operator->();
+    }
+    iterator& operator++()
+    {
+        m_ndx = m_list->incr(m_ndx);
+        return *this;
+    }
+    iterator operator++(int)
+    {
+        iterator tmp(*this);
+        operator++();
+        return tmp;
+    }
+    iterator& operator--()
+    {
+        m_ndx = m_list->decr(m_ndx);
+        return *this;
+    }
+    iterator operator--(int)
+    {
+        iterator tmp(*this);
+        operator--();
+        return tmp;
+    }
+
+    bool operator!=(const iterator& rhs) const
+    {
+        return m_ndx != rhs.m_ndx;
+    }
+
+    bool operator==(const iterator& rhs) const
+    {
+        return m_ndx == rhs.m_ndx;
+    }
+
+private:
+    friend class Lst<T>;
+    friend class Collection<T, Interface>;
+
+    mutable T m_val;
+    const Collection<T, Interface>* m_list;
+    size_t m_ndx;
+};
+
+
+// Implementation:
+
+inline CollectionBase& CollectionBase::operator=(const CollectionBase& other)
+{
+    m_obj = other.m_obj;
+    m_col_key = other.m_col_key;
+    m_nullable = other.m_nullable;
+    return *this;
+}
+
+inline bool CollectionBase::is_empty() const
+{
+    return size() == 0;
+}
+
+inline ObjKey CollectionBase::get_key() const
+{
+    return m_obj.get_key();
+}
+
+inline bool CollectionBase::is_attached() const
+{
+    return m_obj.is_valid();
+}
+
+inline bool CollectionBase::has_changed() const
+{
+    update_if_needed();
+    if (m_last_content_version != m_content_version) {
+        m_last_content_version = m_content_version;
+        return true;
+    }
+    return false;
+}
+
+inline void CollectionBase::update_child_ref(size_t, ref_type new_ref)
+{
+    m_obj.set_int(CollectionBase::m_col_key, from_ref(new_ref));
+}
+
+inline ConstTableRef CollectionBase::get_table() const
+{
+    return m_obj.get_table();
+}
+
+inline ColKey CollectionBase::get_col_key() const
+{
+    return m_col_key;
+}
+
+inline bool CollectionBase::operator==(const CollectionBase& other) const
+{
+    return get_key() == other.get_key() && get_col_key() == other.get_col_key();
+}
+
+inline void CollectionBase::update_if_needed() const
+{
+    auto content_version = m_obj.get_alloc().get_content_version();
+    if (m_obj.update_if_needed() || content_version != m_content_version) {
+        init_from_parent();
+    }
+}
+
+inline void CollectionBase::update_content_version() const
+{
+    m_content_version = m_obj.get_alloc().get_content_version();
+}
+
+inline size_t CollectionBase::incr(size_t ndx) const
+{
+    // Increase index by one. If we land on and index that is deleted, keep
+    // increasing until we get to a valid entry.
+    ndx++;
+    if (!m_deleted.empty()) {
+        auto it = m_deleted.begin();
+        auto end = m_deleted.end();
+        while (it != end && *it < ndx) {
+            ++it;
+        }
+        // If entry is deleted, increase further
+        while (it != end && *it == ndx) {
+            ++it;
+            ++ndx;
+        }
+    }
+    return ndx;
+}
+
+inline size_t CollectionBase::decr(size_t ndx) const
+{
+    REALM_ASSERT(ndx != 0);
+    ndx--;
+    if (!m_deleted.empty()) {
+        auto it = m_deleted.rbegin();
+        auto rend = m_deleted.rend();
+        while (it != rend && *it > ndx) {
+            ++it;
+        }
+        // If entry is deleted, decrease further
+        while (it != rend && *it == ndx) {
+            ++it;
+            --ndx;
+        }
+    }
+    return ndx;
+}
+
+inline size_t CollectionBase::adjust(size_t ndx) const
+{
+    // Convert from virtual to real index
+    if (!m_deleted.empty()) {
+        // Optimized for the case where the iterator is past that last deleted entry
+        auto it = m_deleted.rbegin();
+        auto end = m_deleted.rend();
+        while (it != end && *it >= ndx) {
+            if (*it == ndx) {
+                throw std::out_of_range("Element was deleted");
+            }
+            ++it;
+        }
+        auto diff = end - it;
+        ndx -= diff;
+    }
+    return ndx;
+}
+
+inline void CollectionBase::adj_remove(size_t ndx)
+{
+    auto it = m_deleted.begin();
+    auto end = m_deleted.end();
+    while (it != end && *it <= ndx) {
+        ++ndx;
+        ++it;
+    }
+    m_deleted.insert(it, ndx);
+}
+
+} // namespace realm
+
+#endif // REALM_COLLECTION_HPP

--- a/src/realm/collection.hpp
+++ b/src/realm/collection.hpp
@@ -65,6 +65,24 @@ inline void check_column_type<ObjKey>(ColKey col)
     }
 }
 
+template <class T, class = void>
+struct MinHelper {
+    template <class U>
+    static Mixed eval(U&, size_t*)
+    {
+        return Mixed{};
+    }
+};
+
+template <class T>
+struct MinHelper<T, std::void_t<ColumnMinMaxType<T>>> {
+    template <class U>
+    static Mixed eval(U& tree, size_t* return_ndx)
+    {
+        return Mixed(bptree_minimum<T>(tree, return_ndx));
+    }
+};
+
 template <class T, class Enable = void>
 struct MaxHelper {
     template <class U>
@@ -139,6 +157,8 @@ inline std::ostream& operator<<(std::ostream& ostr, SizeOfList size_of_list)
 class CollectionBase : public ArrayParent {
 public:
     virtual ~CollectionBase();
+    CollectionBase(const CollectionBase&) = default;
+
     /*
      * Operations that makes sense without knowing the specific type
      * can be made virtual.

--- a/src/realm/collection.hpp
+++ b/src/realm/collection.hpp
@@ -2,6 +2,7 @@
 #define REALM_COLLECTION_HPP
 
 #include <realm/obj.hpp>
+#include <realm/bplustree.hpp>
 
 #include <iosfwd>      // std::ostream
 #include <type_traits> // std::void_t

--- a/src/realm/db.cpp
+++ b/src/realm/db.cpp
@@ -2595,8 +2595,8 @@ TableRef Transaction::import_copy_of(ConstTableRef original)
 
 LnkLst Transaction::import_copy_of(const LnkLst& original)
 {
-    if (Obj obj = import_copy_of(original.m_obj)) {
-        ColKey ck = original.m_col_key;
+    if (Obj obj = import_copy_of(original.CollectionBase::m_obj)) {
+        ColKey ck = original.CollectionBase::m_col_key;
         return obj.get_linklist(ck);
     }
     return LnkLst();
@@ -2615,8 +2615,8 @@ LnkLstPtr Transaction::import_copy_of(const LnkLstPtr& original)
 {
     if (!bool(original))
         return nullptr;
-    if (Obj obj = import_copy_of(original->m_obj)) {
-        ColKey ck = original->m_col_key;
+    if (Obj obj = import_copy_of(original->CollectionBase::m_obj)) {
+        ColKey ck = original->CollectionBase::m_col_key;
         return obj.get_linklist_ptr(ck);
     }
     return std::make_unique<LnkLst>();

--- a/src/realm/group.cpp
+++ b/src/realm/group.cpp
@@ -378,7 +378,9 @@ void Transaction::upgrade_file_format(int target_file_format_version)
             table_keys.push_back(table->get_key());
         }
 
-        auto commit_and_continue = [this]() { commit_and_continue_writing(); };
+        auto commit_and_continue = [this]() {
+            commit_and_continue_writing();
+        };
         for (auto k : table_keys) {
             get_table(k)->migrate_column_info(commit_and_continue);
         }
@@ -462,7 +464,7 @@ void Group::open(ref_type top_ref, const std::string& file_path)
     bool create_group_when_missing = true;
     bool writable = create_group_when_missing;
     attach(top_ref, writable, create_group_when_missing); // Throws
-    dg.release();                               // Do not detach after all
+    dg.release();                                         // Do not detach after all
 }
 
 void Group::open(const std::string& file_path, const char* encryption_key, OpenMode mode)
@@ -581,7 +583,7 @@ void Group::attach(ref_type top_ref, bool writable, bool create_group_when_missi
 {
     REALM_ASSERT(!m_top.is_attached());
     if (create_group_when_missing)
-    	REALM_ASSERT(writable);
+        REALM_ASSERT(writable);
 
     // If this function throws, it must leave the group accesor in a the
     // unattached state.
@@ -840,8 +842,8 @@ Table* Group::create_table_accessor(size_t table_ndx)
         table->init(ref, this, table_ndx, m_is_writable, is_frozen());
     }
     else {
-        std::unique_ptr<Table> new_table(new Table(get_repl(), m_alloc));             // Throws
-        new_table->init(ref, this, table_ndx, m_is_writable, is_frozen());            // Throws
+        std::unique_ptr<Table> new_table(new Table(get_repl(), m_alloc));  // Throws
+        new_table->init(ref, this, table_ndx, m_is_writable, is_frozen()); // Throws
         table = new_table.release();
     }
     // must be atomic to allow concurrent probing of the m_table_accessors vector.
@@ -1337,7 +1339,7 @@ size_t size_of_tree_from_ref(ref_type ref, Allocator& alloc)
     else
         return 0;
 }
-}
+} // namespace
 
 size_t Group::compute_aggregated_byte_size(SizeAggregateControl ctrl) const noexcept
 {
@@ -1471,7 +1473,7 @@ public:
         return true; // No-op
     }
 
-    bool select_list(ColKey, ObjKey) noexcept
+    bool select_collection(ColKey, ObjKey) noexcept
     {
         return true; // No-op
     }
@@ -1628,10 +1630,10 @@ void Group::advance_transact(ref_type new_top_ref, size_t new_file_size, _impl::
     TransactAdvancer advancer(*this, schema_changed);
     parser.parse(in, advancer); // Throws
 
-    m_top.detach();                                 // Soft detach
-    bool create_group_when_missing = false;         // See Group::attach_shared().
+    m_top.detach();                                           // Soft detach
+    bool create_group_when_missing = false;                   // See Group::attach_shared().
     attach(new_top_ref, writable, create_group_when_missing); // Throws
-    refresh_dirty_accessors();                      // Throws
+    refresh_dirty_accessors();                                // Throws
 
     if (schema_changed)
         send_schema_change_notification();
@@ -1645,9 +1647,9 @@ void Group::prepare_top_for_history(int history_type, int history_schema_version
         while (m_top.size() < s_hist_type_ndx) {
             m_top.add(0); // Throws
         }
-        ref_type history_ref = 0; // No history yet
-        m_top.add(RefOrTagged::make_tagged(history_type)); // Throws
-        m_top.add(RefOrTagged::make_ref(history_ref)); // Throws
+        ref_type history_ref = 0;                                    // No history yet
+        m_top.add(RefOrTagged::make_tagged(history_type));           // Throws
+        m_top.add(RefOrTagged::make_ref(history_ref));               // Throws
         m_top.add(RefOrTagged::make_tagged(history_schema_version)); // Throws
         m_top.add(RefOrTagged::make_tagged(file_ident));             // Throws
     }
@@ -1731,7 +1733,7 @@ public:
                 ref_type prev_ref_end = i_1->ref + i_1->size;
                 REALM_ASSERT_3(prev_ref_end, <=, i_2->ref);
                 if (i_2->ref == prev_ref_end) { // in-file
-                    i_1->size += i_2->size; // Merge
+                    i_1->size += i_2->size;     // Merge
                 }
                 else {
                     *++i_1 = *i_2;
@@ -1881,7 +1883,9 @@ void Group::verify() const
 
     // Check the consistency of the allocation of the mutable memory that has
     // been marked as free
-    m_alloc.for_all_free_entries([&](ref_type ref, size_t sz) { mem_usage_2.add_mutable(ref, sz); });
+    m_alloc.for_all_free_entries([&](ref_type ref, size_t sz) {
+        mem_usage_2.add_mutable(ref, sz);
+    });
     mem_usage_2.canonicalize();
     mem_usage_1.add(mem_usage_2);
     mem_usage_1.canonicalize();

--- a/src/realm/history.cpp
+++ b/src/realm/history.cpp
@@ -21,6 +21,7 @@
 #include <realm/db.hpp>
 #include <realm/replication.hpp>
 #include <realm/history.hpp>
+#include <realm/array_key.hpp>
 
 using namespace realm;
 

--- a/src/realm/impl/transact_log.cpp
+++ b/src/realm/impl/transact_log.cpp
@@ -92,7 +92,8 @@ void TransactLogConvenientEncoder::list_clear(const CollectionBase& list)
 
 void TransactLogConvenientEncoder::link_list_nullify(const Lst<ObjKey>& list, size_t link_ndx)
 {
-    list_erase(list, link_ndx);
+    select_collection(list);
+    m_encoder.list_erase(link_ndx);
 }
 
 REALM_NORETURN

--- a/src/realm/impl/transact_log.cpp
+++ b/src/realm/impl/transact_log.cpp
@@ -18,6 +18,7 @@
 
 #include <realm/global_key.hpp>
 #include <realm/impl/transact_log.hpp>
+#include <realm/list.hpp>
 
 namespace realm {
 namespace _impl {
@@ -66,27 +67,32 @@ void TransactLogConvenientEncoder::do_select_table(const Table* table)
     m_selected_table = table;
 }
 
-bool TransactLogEncoder::select_list(ColKey col_key, ObjKey key)
+bool TransactLogEncoder::select_collection(ColKey col_key, ObjKey key)
 {
     append_simple_instr(instr_SelectList, col_key, key.value); // Throws
     return true;
 }
 
 
-void TransactLogConvenientEncoder::do_select_list(const ConstLstBase& list)
+void TransactLogConvenientEncoder::do_select_collection(const CollectionBase& list)
 {
     select_table(list.get_table().unchecked_ptr());
     ColKey col_key = list.get_col_key();
-    ObjKey key = list.ConstLstBase::get_key();
+    ObjKey key = list.CollectionBase::get_key();
 
-    m_encoder.select_list(col_key, key); // Throws
-    m_selected_list = LinkListId(list.get_table()->get_key(), key, col_key);
+    m_encoder.select_collection(col_key, key); // Throws
+    m_selected_list = CollectionId(list.get_table()->get_key(), key, col_key);
 }
 
-void TransactLogConvenientEncoder::list_clear(const ConstLstBase& list)
+void TransactLogConvenientEncoder::list_clear(const CollectionBase& list)
 {
-    select_list(list);                 // Throws
+    select_collection(list);           // Throws
     m_encoder.list_clear(list.size()); // Throws
+}
+
+void TransactLogConvenientEncoder::link_list_nullify(const Lst<ObjKey>& list, size_t link_ndx)
+{
+    list_erase(list, link_ndx);
 }
 
 REALM_NORETURN

--- a/src/realm/keys.hpp
+++ b/src/realm/keys.hpp
@@ -113,11 +113,11 @@ struct ColKey {
                  ((tag & 0xFFFFFFFFUL) << 30))
     {
     }
-    bool is_nullable()
+    bool is_nullable() const
     {
         return get_attrs().test(col_attr_Nullable);
     }
-    bool is_list()
+    bool is_list() const
     {
         return get_attrs().test(col_attr_List);
     }

--- a/src/realm/list.cpp
+++ b/src/realm/list.cpp
@@ -104,79 +104,7 @@ LstBasePtr Obj::get_listbase_ptr(ColKey col_key) const
     return {};
 }
 
-/********************************* LstBase **********************************/
-
-void LstBase::swap_repl(Replication* repl, size_t ndx1, size_t ndx2) const
-{
-    if (ndx2 < ndx1)
-        std::swap(ndx1, ndx2);
-    repl->list_move(*this, ndx2, ndx1);
-    if (ndx1 + 1 != ndx2)
-        repl->list_move(*this, ndx1 + 1, ndx2);
-}
-
-
-template <class T>
-Lst<T>::Lst(const Obj& obj, ColKey col_key)
-    : Collection<T, LstBase>(obj, col_key)
-{
-    if (m_obj) {
-        Collection<T, LstBase>::init_from_parent();
-    }
-}
-
 /****************************** Lst aggregates *******************************/
-
-// This will be defined when using C++17
-template <typename... Ts>
-struct make_void {
-    typedef void type;
-};
-template <typename... Ts>
-using void_t = typename make_void<Ts...>::type;
-
-
-template <class T, class = void>
-struct MinHelper {
-    template <class U>
-    static Mixed eval(U&, size_t*)
-    {
-        return Mixed{};
-    }
-};
-
-template <class T>
-struct MinHelper<T, void_t<ColumnMinMaxType<T>>> {
-    template <class U>
-    static Mixed eval(U& tree, size_t* return_ndx)
-    {
-        return Mixed(bptree_minimum<T>(tree, return_ndx));
-    }
-};
-
-template <class T>
-Mixed Lst<T>::min(size_t* return_ndx) const
-{
-    return MinHelper<T>::eval(*m_tree, return_ndx);
-}
-
-template <class T>
-Mixed Lst<T>::max(size_t* return_ndx) const
-{
-    return MaxHelper<T>::eval(*m_tree, return_ndx);
-}
-
-template <class T>
-Mixed Lst<T>::sum(size_t* return_cnt) const
-{
-    return SumHelper<T>::eval(*m_tree, return_cnt);
-}
-
-template <class T>
-Mixed Lst<T>::avg(size_t* return_cnt) const
-{
-    return AverageHelper<T>::eval(*m_tree, return_cnt);
-}
 
 template <class T>
 void Lst<T>::sort(std::vector<size_t>& indices, bool ascending) const
@@ -225,26 +153,6 @@ void Lst<T>::distinct(std::vector<size_t>& indices, util::Optional<bool> sort_or
     }
 }
 
-
-/************************* template instantiations ***************************/
-
-template Lst<int64_t>::Lst(const Obj& obj, ColKey col_key);
-template Lst<util::Optional<Int>>::Lst(const Obj& obj, ColKey col_key);
-template Lst<bool>::Lst(const Obj& obj, ColKey col_key);
-template Lst<util::Optional<bool>>::Lst(const Obj& obj, ColKey col_key);
-template Lst<float>::Lst(const Obj& obj, ColKey col_key);
-template Lst<util::Optional<float>>::Lst(const Obj& obj, ColKey col_key);
-template Lst<double>::Lst(const Obj& obj, ColKey col_key);
-template Lst<util::Optional<double>>::Lst(const Obj& obj, ColKey col_key);
-template Lst<StringData>::Lst(const Obj& obj, ColKey col_key);
-template Lst<BinaryData>::Lst(const Obj& obj, ColKey col_key);
-template Lst<Timestamp>::Lst(const Obj& obj, ColKey col_key);
-template Lst<ObjKey>::Lst(const Obj& obj, ColKey col_key);
-template Lst<Decimal128>::Lst(const Obj& obj, ColKey col_key);
-template Lst<ObjectId>::Lst(const Obj& obj, ColKey col_key);
-template Lst<util::Optional<ObjectId>>::Lst(const Obj& obj, ColKey col_key);
-template Lst<Mixed>::Lst(const Obj& obj, ColKey col_key);
-template Lst<ObjLink>::Lst(const Obj& obj, ColKey col_key);
 
 /********************************* Lst<Key> *********************************/
 
@@ -596,24 +504,9 @@ void LnkLst::sync_if_needed() const
     }
 }
 
-#ifdef _WIN32
-// For some strange reason these functions needs to be explicitly instantiated
-// on Visual Studio 2017. Otherwise the code is not generated.
-template void Lst<ObjKey>::add(ObjKey target_key);
-template void Lst<ObjKey>::insert(size_t ndx, ObjKey target_key);
-template ObjKey Lst<ObjKey>::remove(size_t ndx);
-template void Lst<ObjKey>::clear();
-template void Lst<ObjKey>::do_insert(size_t ndx, ObjKey target_key);
-template void Lst<ObjKey>::do_set(size_t ndx, ObjKey target_key);
-template void Lst<ObjKey>::do_remove(size_t ndx);
-
-template void Lst<ObjLink>::do_insert(size_t ndx, ObjLink target_key);
-template void Lst<ObjLink>::do_set(size_t ndx, ObjLink target_key);
-template void Lst<ObjLink>::do_remove(size_t ndx);
-
-template void Lst<Mixed>::do_insert(size_t ndx, Mixed target_key);
-template void Lst<Mixed>::do_set(size_t ndx, Mixed target_key);
-template void Lst<Mixed>::do_remove(size_t ndx);
-#endif
+// Force instantiation:
+template class Lst<ObjKey>;
+template class Lst<Mixed>;
+template class Lst<ObjLink>;
 
 } // namespace realm

--- a/src/realm/list.hpp
+++ b/src/realm/list.hpp
@@ -580,7 +580,7 @@ inline void LnkLst::remove(size_t from, size_t to)
 
 inline void LnkLst::clear()
 {
-    // Lst<ObjKey>::clear();
+    Lst<ObjKey>::clear();
     m_unresolved.clear();
 }
 

--- a/src/realm/list.hpp
+++ b/src/realm/list.hpp
@@ -92,11 +92,7 @@ public:
     Lst& operator=(const Lst& other);
     Lst& operator=(const BPlusTree<T>& other);
 
-    void create()
-    {
-        m_tree->create();
-        m_valid = true;
-    }
+    void create();
 
     // Overriding members of CollectionBase:
     Mixed min(size_t* return_ndx = nullptr) const final;
@@ -106,116 +102,21 @@ public:
     void sort(std::vector<size_t>& indices, bool ascending = true) const final;
     void distinct(std::vector<size_t>& indices, util::Optional<bool> sort_order = util::none) const final;
 
-    void set_null(size_t ndx) override
-    {
-        set(ndx, BPlusTree<T>::default_value(m_nullable));
-    }
+    // Overriding members of LstBase:
+    void set_null(size_t ndx) override;
+    void insert_null(size_t ndx) override;
+    void insert_any(size_t ndx, Mixed val) override;
+    void resize(size_t new_size) override;
+    void remove(size_t from, size_t to) override;
+    void move(size_t from, size_t to) override;
+    void swap(size_t ndx1, size_t ndx2) override;
+    void clear() override;
 
-    void insert_null(size_t ndx) override
-    {
-        insert(ndx, BPlusTree<T>::default_value(m_nullable));
-    }
-
-    void insert_any(size_t ndx, Mixed val) override
-    {
-        if constexpr (std::is_same_v<T, Mixed>) {
-            insert(ndx, val);
-        }
-        else {
-            if (val.is_null()) {
-                insert_null(ndx);
-            }
-            else {
-                insert(ndx, val.get<typename util::RemoveOptional<T>::type>());
-            }
-        }
-    }
-
-    void resize(size_t new_size) override
-    {
-        update_if_needed();
-        size_t current_size = m_tree->size();
-        while (new_size > current_size) {
-            insert_null(current_size++);
-        }
-        remove(new_size, current_size);
-        m_obj.bump_both_versions();
-    }
-
-    void add(T value)
-    {
-        insert(size(), value);
-    }
-
+    void add(T value);
     T set(size_t ndx, T value);
-
     void insert(size_t ndx, T value);
-
-    T remove(const LstIterator<T>& it)
-    {
-        return remove(CollectionBase::adjust(it.m_ndx));
-    }
-
+    T remove(const LstIterator<T>& it);
     T remove(size_t ndx);
-
-    void remove(size_t from, size_t to) override
-    {
-        while (from < to) {
-            remove(--to);
-        }
-    }
-
-    void move(size_t from, size_t to) override
-    {
-        REALM_ASSERT_DEBUG(!update_if_needed());
-        if (from != to) {
-            this->ensure_writeable();
-            if (Replication* repl = this->m_obj.get_replication()) {
-                repl->list_move(*this, from, to);
-            }
-            if (to > from) {
-                to++;
-            }
-            else {
-                from++;
-            }
-            // We use swap here as it handles the special case for StringData where
-            // 'to' and 'from' points into the same array. In this case you cannot
-            // set an entry with the result of a get from another entry in the same
-            // leaf.
-            m_tree->insert(to, BPlusTree<T>::default_value(m_nullable));
-            m_tree->swap(from, to);
-            m_tree->erase(from);
-
-            m_obj.bump_content_version();
-        }
-    }
-
-    void swap(size_t ndx1, size_t ndx2) override
-    {
-        REALM_ASSERT_DEBUG(!update_if_needed());
-        if (ndx1 != ndx2) {
-            if (Replication* repl = this->m_obj.get_replication()) {
-                LstBase::swap_repl(repl, ndx1, ndx2);
-            }
-            m_tree->swap(ndx1, ndx2);
-            m_obj.bump_content_version();
-        }
-    }
-
-    void clear() override
-    {
-        ensure_created();
-        update_if_needed();
-        this->ensure_writeable();
-        if (size() > 0) {
-            if (Replication* repl = this->m_obj.get_replication()) {
-                repl->list_clear(*this);
-            }
-            m_tree->clear();
-            m_obj.bump_content_version();
-        }
-    }
 
     using Collection<T, LstBase>::m_col_key;
 
@@ -225,37 +126,173 @@ protected:
     using Collection<T, LstBase>::m_obj;
     using Collection<T, LstBase>::init_from_parent;
 
-    bool update_if_needed()
-    {
-        if (m_obj.update_if_needed()) {
-            return init_from_parent();
-        }
-        return false;
-    }
-    void ensure_created()
-    {
-        if (!m_valid && m_obj.is_valid()) {
-            create();
-        }
-    }
-    void do_set(size_t ndx, T value)
-    {
-        m_tree->set(ndx, value);
-    }
-    void do_insert(size_t ndx, T value)
-    {
-        m_tree->insert(ndx, value);
-    }
-    void do_remove(size_t ndx)
-    {
-        m_tree->erase(ndx);
-    }
+    bool update_if_needed();
+    void ensure_created();
+    void do_set(size_t ndx, T value);
+    void do_insert(size_t ndx, T value);
+    void do_remove(size_t ndx);
 };
 
+// Specialization of Lst<ObjKey>:
+template <>
+void Lst<ObjKey>::clear();
+template <>
+void Lst<ObjKey>::do_set(size_t, ObjKey);
+template <>
+void Lst<ObjKey>::do_insert(size_t, ObjKey);
+template <>
+void Lst<ObjKey>::do_remove(size_t);
+extern template class Lst<ObjKey>;
+
+// Specialization of Lst<Mixed>:
+template <>
+void Lst<Mixed>::do_set(size_t, Mixed);
+template <>
+void Lst<Mixed>::do_insert(size_t, Mixed);
+template <>
+void Lst<Mixed>::do_remove(size_t);
+extern template class Lst<Mixed>;
+
+// Specialization of Lst<ObjLink>:
+template <>
+void Lst<ObjLink>::do_set(size_t, ObjLink);
+template <>
+void Lst<ObjLink>::do_insert(size_t, ObjLink);
+template <>
+void Lst<ObjLink>::do_remove(size_t);
+extern template class Lst<ObjLink>;
+
+class LnkLst : public Lst<ObjKey>, public ObjList {
+public:
+    LnkLst() = default;
+
+    LnkLst(const Obj& owner, ColKey col_key);
+    LnkLst(const LnkLst& other)
+        : Lst<ObjKey>(other)
+        , m_unresolved(other.m_unresolved)
+    {
+    }
+    LnkLst& operator=(const LnkLst& other)
+    {
+        Lst<ObjKey>::operator=(other);
+        m_unresolved = other.m_unresolved;
+        return *this;
+    }
+
+    LnkLstPtr clone() const
+    {
+        if (m_obj.is_valid()) {
+            return std::make_unique<LnkLst>(m_obj, m_col_key);
+        }
+        else {
+            return std::make_unique<LnkLst>();
+        }
+    }
+    TableRef get_target_table() const override
+    {
+        return m_obj.get_target_table(m_col_key);
+    }
+    bool is_in_sync() const override
+    {
+        return true;
+    }
+    size_t size() const override
+    {
+        auto full_sz = Lst<ObjKey>::size();
+        return full_sz - m_unresolved.size();
+    }
+
+    bool has_unresolved() const noexcept
+    {
+        return !m_unresolved.empty();
+    }
+
+    bool is_obj_valid(size_t) const noexcept override
+    {
+        // A link list cannot contain null values
+        return true;
+    }
+
+    Obj get_object(size_t ndx) const override;
+
+    Obj operator[](size_t ndx)
+    {
+        return get_object(ndx);
+    }
+
+    using Lst<ObjKey>::find_first;
+    using Lst<ObjKey>::find_all;
+    void add(ObjKey value)
+    {
+        insert(size(), value);
+    }
+    void set(size_t ndx, ObjKey value);
+    void insert(size_t ndx, ObjKey value);
+    ObjKey get(size_t ndx) const;
+    ObjKey get_key(size_t ndx) const override;
+    void remove(size_t ndx);
+    void remove(size_t from, size_t to) override;
+    void clear() override;
+    // Create a new object in insert a link to it
+    Obj create_and_insert_linked_object(size_t ndx);
+    // Create a new object and link it. If an embedded object
+    // is already set, it will be removed. TBD: If a non-embedded
+    // object is already set, we throw LogicError (to prevent
+    // dangling objects, since they do not delete automatically
+    // if they are not embedded...)
+    Obj create_and_set_linked_object(size_t ndx);
+    // to be implemented:
+    Obj clear_linked_object(size_t ndx);
+
+    TableView get_sorted_view(SortDescriptor order) const;
+    TableView get_sorted_view(ColKey column_key, bool ascending = true) const;
+    void remove_target_row(size_t link_ndx);
+    void remove_all_target_rows();
+
+private:
+    friend class ConstTableView;
+    friend class Query;
+
+    // Sorted set of indices containing unresolved links.
+    mutable std::vector<size_t> m_unresolved;
+
+    void get_dependencies(TableVersions&) const override;
+    void sync_if_needed() const override;
+    bool init_from_parent() const override;
+};
+
+
+// Implementation:
+
+inline void LstBase::swap_repl(Replication* repl, size_t ndx1, size_t ndx2) const
+{
+    if (ndx2 < ndx1)
+        std::swap(ndx1, ndx2);
+    repl->list_move(*this, ndx2, ndx1);
+    if (ndx1 + 1 != ndx2)
+        repl->list_move(*this, ndx1 + 1, ndx2);
+}
+
 template <class T>
-Lst<T>::Lst(const Lst<T>& other)
+inline Lst<T>::Lst(const Lst<T>& other)
     : Collection<T, LstBase>(other)
 {
+}
+
+template <class T>
+inline Lst<T>::Lst(const Obj& obj, ColKey col_key)
+    : Collection<T, LstBase>(obj, col_key)
+{
+    if (m_obj) {
+        Collection<T, LstBase>::init_from_parent();
+    }
+}
+
+template <class T>
+inline void Lst<T>::create()
+{
+    m_tree->create();
+    m_valid = true;
 }
 
 template <class T>
@@ -329,158 +366,161 @@ void Lst<T>::insert(size_t ndx, T value)
     m_obj.bump_content_version();
 }
 
-template <>
-void Lst<ObjKey>::do_set(size_t ndx, ObjKey target_key);
+template <class T>
+void Lst<T>::set_null(size_t ndx)
+{
+    set(ndx, BPlusTree<T>::default_value(m_nullable));
+}
 
-template <>
-void Lst<ObjKey>::do_insert(size_t ndx, ObjKey target_key);
+template <class T>
+void Lst<T>::insert_null(size_t ndx)
+{
+    insert(ndx, BPlusTree<T>::default_value(m_nullable));
+}
 
-template <>
-void Lst<ObjKey>::do_remove(size_t ndx);
+template <class T>
+void Lst<T>::insert_any(size_t ndx, Mixed val)
+{
+    if constexpr (std::is_same_v<T, Mixed>) {
+        insert(ndx, val);
+    }
+    else {
+        if (val.is_null()) {
+            insert_null(ndx);
+        }
+        else {
+            insert(ndx, val.get<typename util::RemoveOptional<T>::type>());
+        }
+    }
+}
 
-template <>
-void Lst<ObjKey>::clear();
+template <class T>
+void Lst<T>::resize(size_t new_size)
+{
+    update_if_needed();
+    size_t current_size = m_tree->size();
+    while (new_size > current_size) {
+        insert_null(current_size++);
+    }
+    remove(new_size, current_size);
+    m_obj.bump_both_versions();
+}
 
-template <>
-void Lst<ObjLink>::do_set(size_t ndx, ObjLink target_key);
+template <class T>
+void Lst<T>::add(T value)
+{
+    insert(size(), value);
+}
 
-template <>
-void Lst<ObjLink>::do_insert(size_t ndx, ObjLink target_key);
+template <class T>
+T Lst<T>::remove(const LstIterator<T>& it)
+{
+    return remove(CollectionBase::adjust(it.m_ndx));
+}
 
-template <>
-void Lst<ObjLink>::do_remove(size_t ndx);
+template <class T>
+void Lst<T>::remove(size_t from, size_t to)
+{
+    while (from < to) {
+        remove(--to);
+    }
+}
 
-template <>
-void Lst<Mixed>::do_set(size_t ndx, Mixed target_key);
+template <class T>
+void Lst<T>::move(size_t from, size_t to)
+{
+    REALM_ASSERT_DEBUG(!update_if_needed());
+    if (from != to) {
+        this->ensure_writeable();
+        if (Replication* repl = this->m_obj.get_replication()) {
+            repl->list_move(*this, from, to);
+        }
+        if (to > from) {
+            to++;
+        }
+        else {
+            from++;
+        }
+        // We use swap here as it handles the special case for StringData where
+        // 'to' and 'from' points into the same array. In this case you cannot
+        // set an entry with the result of a get from another entry in the same
+        // leaf.
+        m_tree->insert(to, BPlusTree<T>::default_value(m_nullable));
+        m_tree->swap(from, to);
+        m_tree->erase(from);
 
-template <>
-void Lst<Mixed>::do_insert(size_t ndx, Mixed target_key);
+        m_obj.bump_content_version();
+    }
+}
 
-template <>
-void Lst<Mixed>::do_remove(size_t ndx);
+template <class T>
+void Lst<T>::swap(size_t ndx1, size_t ndx2)
+{
+    REALM_ASSERT_DEBUG(!update_if_needed());
+    if (ndx1 != ndx2) {
+        if (Replication* repl = this->m_obj.get_replication()) {
+            LstBase::swap_repl(repl, ndx1, ndx2);
+        }
+        m_tree->swap(ndx1, ndx2);
+        m_obj.bump_content_version();
+    }
+}
+
+template <class T>
+void Lst<T>::clear()
+{
+    static_assert(!std::is_same_v<T, ObjKey>);
+    ensure_created();
+    update_if_needed();
+    this->ensure_writeable();
+    if (size() > 0) {
+        if (Replication* repl = this->m_obj.get_replication()) {
+            repl->list_clear(*this);
+        }
+        m_tree->clear();
+        m_obj.bump_content_version();
+    }
+}
+
+template <class T>
+inline bool Lst<T>::update_if_needed()
+{
+    if (m_obj.update_if_needed()) {
+        return init_from_parent();
+    }
+    return false;
+}
+
+template <class T>
+inline void Lst<T>::ensure_created()
+{
+    if (!m_valid && m_obj.is_valid()) {
+        create();
+    }
+}
+
+template <class T>
+inline void Lst<T>::do_set(size_t ndx, T value)
+{
+    m_tree->set(ndx, value);
+}
+
+template <class T>
+inline void Lst<T>::do_insert(size_t ndx, T value)
+{
+    m_tree->insert(ndx, value);
+}
+
+template <class T>
+inline void Lst<T>::do_remove(size_t ndx)
+{
+    m_tree->erase(ndx);
+}
 
 // Translate from userfacing index to internal index.
 size_t virtual2real(const std::vector<size_t>& vec, size_t ndx);
 // Scan through the list to find unresolved links
 void update_unresolved(std::vector<size_t>& vec, const BPlusTree<ObjKey>& tree);
-
-
-class LnkLst : public Lst<ObjKey>, public ObjList {
-public:
-    LnkLst() = default;
-
-    LnkLst(const Obj& owner, ColKey col_key);
-    LnkLst(const LnkLst& other)
-        : Lst<ObjKey>(other)
-        , m_unresolved(other.m_unresolved)
-    {
-    }
-    LnkLst& operator=(const LnkLst& other)
-    {
-        Lst<ObjKey>::operator=(other);
-        m_unresolved = other.m_unresolved;
-        return *this;
-    }
-
-    LnkLstPtr clone() const
-    {
-        if (m_obj.is_valid()) {
-            return std::make_unique<LnkLst>(m_obj, m_col_key);
-        }
-        else {
-            return std::make_unique<LnkLst>();
-        }
-    }
-    TableRef get_target_table() const override
-    {
-        return m_obj.get_target_table(m_col_key);
-    }
-    bool is_in_sync() const override
-    {
-        return true;
-    }
-    size_t size() const override
-    {
-        auto full_sz = Lst<ObjKey>::size();
-        return full_sz - m_unresolved.size();
-    }
-
-    bool has_unresolved() const noexcept
-    {
-        return !m_unresolved.empty();
-    }
-
-    bool is_obj_valid(size_t) const noexcept override
-    {
-        // A link list cannot contain null values
-        return true;
-    }
-
-    Obj get_object(size_t ndx) const override;
-
-    Obj operator[](size_t ndx)
-    {
-        return get_object(ndx);
-    }
-
-    using Lst<ObjKey>::find_first;
-    using Lst<ObjKey>::find_all;
-    void add(ObjKey value)
-    {
-        insert(size(), value);
-    }
-    void set(size_t ndx, ObjKey value);
-    void insert(size_t ndx, ObjKey value);
-    ObjKey get(size_t ndx) const
-    {
-        return Lst<ObjKey>::get(virtual2real(m_unresolved, ndx));
-    }
-    ObjKey get_key(size_t ndx) const override
-    {
-        return get(ndx);
-    }
-    void remove(size_t ndx)
-    {
-        Lst<ObjKey>::remove(virtual2real(m_unresolved, ndx));
-    }
-    void remove(size_t from, size_t to) override
-    {
-        while (from < to) {
-            remove(--to);
-        }
-    }
-    void clear() override
-    {
-        Lst<ObjKey>::clear();
-        m_unresolved.clear();
-    }
-    // Create a new object in insert a link to it
-    Obj create_and_insert_linked_object(size_t ndx);
-    // Create a new object and link it. If an embedded object
-    // is already set, it will be removed. TBD: If a non-embedded
-    // object is already set, we throw LogicError (to prevent
-    // dangling objects, since they do not delete automatically
-    // if they are not embedded...)
-    Obj create_and_set_linked_object(size_t ndx);
-    // to be implemented:
-    Obj clear_linked_object(size_t ndx);
-
-    TableView get_sorted_view(SortDescriptor order) const;
-    TableView get_sorted_view(ColKey column_key, bool ascending = true) const;
-    void remove_target_row(size_t link_ndx);
-    void remove_all_target_rows();
-
-private:
-    friend class ConstTableView;
-    friend class Query;
-
-    // Sorted set of indices containing unresolved links.
-    mutable std::vector<size_t> m_unresolved;
-
-    void get_dependencies(TableVersions&) const override;
-    void sync_if_needed() const override;
-    bool init_from_parent() const override;
-};
 
 
 template <typename U>
@@ -516,6 +556,34 @@ inline LnkLst Obj::get_linklist(StringData col_name) const
     return get_linklist(get_column_key(col_name));
 }
 
+inline ObjKey LnkLst::get(size_t ndx) const
+{
+    return Lst<ObjKey>::get(virtual2real(m_unresolved, ndx));
+}
+
+inline ObjKey LnkLst::get_key(size_t ndx) const
+{
+    return get(ndx);
+}
+
+inline void LnkLst::remove(size_t ndx)
+{
+    Lst<ObjKey>::remove(virtual2real(m_unresolved, ndx));
+}
+
+inline void LnkLst::remove(size_t from, size_t to)
+{
+    while (from < to) {
+        remove(--to);
+    }
+}
+
+inline void LnkLst::clear()
+{
+    // Lst<ObjKey>::clear();
+    m_unresolved.clear();
+}
+
 template <class T>
 inline ColumnSumType<T> list_sum(const Collection<T, LstBase>& list, size_t* return_cnt = nullptr)
 {
@@ -539,6 +607,31 @@ inline ColumnAverageType<T> list_average(const Collection<T, LstBase>& list, siz
 {
     return bptree_average(list.get_tree(), return_cnt);
 }
+
+template <class T>
+Mixed Lst<T>::min(size_t* return_ndx) const
+{
+    return MinHelper<T>::eval(*m_tree, return_ndx);
+}
+
+template <class T>
+Mixed Lst<T>::max(size_t* return_ndx) const
+{
+    return MaxHelper<T>::eval(*m_tree, return_ndx);
+}
+
+template <class T>
+Mixed Lst<T>::sum(size_t* return_cnt) const
+{
+    return SumHelper<T>::eval(*m_tree, return_cnt);
+}
+
+template <class T>
+Mixed Lst<T>::avg(size_t* return_cnt) const
+{
+    return AverageHelper<T>::eval(*m_tree, return_cnt);
+}
+
 } // namespace realm
 
 #endif /* REALM_LIST_HPP */

--- a/src/realm/obj.cpp
+++ b/src/realm/obj.cpp
@@ -663,7 +663,9 @@ void Obj::traverse_path(Visitor v, PathSizer ps, size_t path_length) const
 Obj::FatPath Obj::get_fat_path() const
 {
     FatPath result;
-    auto sizer = [&](size_t size) { result.reserve(size); };
+    auto sizer = [&](size_t size) {
+        result.reserve(size);
+    };
     auto step = [&](const Obj& o2, ColKey col, size_t idx) -> void {
         result.push_back({o2, col, idx});
     };
@@ -675,7 +677,9 @@ Obj::Path Obj::get_path() const
 {
     Path result;
     bool top_done = false;
-    auto sizer = [&](size_t size) { result.path_from_top.reserve(size); };
+    auto sizer = [&](size_t size) {
+        result.path_from_top.reserve(size);
+    };
     auto step = [&](const Obj& o2, ColKey col, size_t idx) -> void {
         if (!top_done) {
             top_done = true;
@@ -1043,8 +1047,8 @@ Obj& Obj::set<int64_t>(ColKey col_key, int64_t value, bool is_default)
     }
 
     if (Replication* repl = get_replication()) {
-        repl->set_int(m_table.unchecked_ptr(), col_key, m_key, value,
-                      is_default ? _impl::instr_SetDefault : _impl::instr_Set); // Throws
+        repl->set(m_table.unchecked_ptr(), col_key, m_key, value,
+                  is_default ? _impl::instr_SetDefault : _impl::instr_Set); // Throws
     }
 
     return *this;
@@ -1262,7 +1266,7 @@ inline void check_range(const BinaryData& val)
     if (REALM_UNLIKELY(val.size() > ArrayBlob::max_binary_size))
         throw LogicError(LogicError::binary_too_big);
 }
-}
+} // namespace
 
 // helper functions for filtering out calls to set_spec()
 template <class T>
@@ -1312,8 +1316,8 @@ Obj& Obj::set(ColKey col_key, T value, bool is_default)
     values.set(m_row_ndx, value);
 
     if (Replication* repl = get_replication())
-        repl->set<T>(m_table.unchecked_ptr(), col_key, m_key, value,
-                     is_default ? _impl::instr_SetDefault : _impl::instr_Set); // Throws
+        repl->set(m_table.unchecked_ptr(), col_key, m_key, value,
+                  is_default ? _impl::instr_SetDefault : _impl::instr_Set); // Throws
 
     return *this;
 }
@@ -1717,8 +1721,8 @@ Obj& Obj::set_null(ColKey col_key, bool is_default)
     }
 
     if (Replication* repl = get_replication())
-        repl->set_null(m_table.unchecked_ptr(), col_key, m_key,
-                       is_default ? _impl::instr_SetDefault : _impl::instr_Set); // Throws
+        repl->set(m_table.unchecked_ptr(), col_key, m_key, util::none,
+                  is_default ? _impl::instr_SetDefault : _impl::instr_Set); // Throws
 
     return *this;
 }

--- a/src/realm/obj.hpp
+++ b/src/realm/obj.hpp
@@ -31,12 +31,9 @@ namespace realm {
 
 class Replication;
 class TableView;
-class ConstLstBase;
+class CollectionBase;
 class LstBase;
 struct GlobalKey;
-
-template <class>
-class ConstLstIf;
 
 template <class>
 class Lst;
@@ -250,8 +247,10 @@ private:
     friend class CascadeState;
     friend class Cluster;
     friend class ColumnListBase;
-    friend class ConstLstBase;
+    friend class CollectionBase;
     friend class ConstTableView;
+    template <class, class>
+    friend class Collection;
     template <class>
     friend class Lst;
     friend class LnkLst;
@@ -449,6 +448,6 @@ inline Obj& Obj::set_all(Head v, Tail... tail)
 {
     return _set(0, v, tail...);
 }
-}
+} // namespace realm
 
 #endif // REALM_OBJ_HPP

--- a/src/realm/object-store/impl/collection_notifier.cpp
+++ b/src/realm/object-store/impl/collection_notifier.cpp
@@ -22,6 +22,7 @@
 #include "shared_realm.hpp"
 
 #include <realm/db.hpp>
+#include <realm/list.hpp>
 
 using namespace realm;
 using namespace realm::_impl;

--- a/src/realm/replication.cpp
+++ b/src/realm/replication.cpp
@@ -44,9 +44,7 @@ public:
     {
     }
 
-    ~InputStreamImpl() noexcept
-    {
-    }
+    ~InputStreamImpl() noexcept {}
 
     bool next_block(const char*& begin, const char*& end) override
     {
@@ -63,45 +61,6 @@ public:
 };
 
 } // anonymous namespace
-
-template <>
-void Replication::set(const Table* table, ColKey col_key, ObjKey key, Mixed value, _impl::Instruction variant)
-{
-    switch (value.get_type()) {
-        case type_Int:
-            set_int(table, col_key, key, value.get<Int>(), variant);
-            break;
-        case type_Bool:
-            set_bool(table, col_key, key, value.get<Bool>(), variant);
-            break;
-        case type_Float:
-            set_float(table, col_key, key, value.get<Float>(), variant);
-            break;
-        case type_Double:
-            set_double(table, col_key, key, value.get<Double>(), variant);
-            break;
-        case type_String:
-            set_string(table, col_key, key, value.get<String>(), variant);
-            break;
-        case type_Binary:
-            set_binary(table, col_key, key, value.get<Binary>(), variant);
-            break;
-        case type_Timestamp:
-            set_timestamp(table, col_key, key, value.get<Timestamp>(), variant);
-            break;
-        case type_Decimal:
-            set_decimal(table, col_key, key, value.get<Decimal128>(), variant);
-            break;
-        case type_ObjectId:
-            set_object_id(table, col_key, key, value.get<ObjectId>(), variant);
-            break;
-        case type_Link:
-            set_link(table, col_key, key, value.get<ObjKey>(), variant);
-            break;
-        default:
-            break;
-    }
-}
 
 std::string TrivialReplication::get_database_path() const
 {
@@ -133,15 +92,8 @@ void TrivialReplication::do_finalize_commit() noexcept
     finalize_changeset();
 }
 
-void TrivialReplication::do_abort_transact() noexcept
-{
-}
+void TrivialReplication::do_abort_transact() noexcept {}
 
-void TrivialReplication::do_interrupt() noexcept
-{
-}
+void TrivialReplication::do_interrupt() noexcept {}
 
-void TrivialReplication::do_clear_interrupt() noexcept
-{
-}
-
+void TrivialReplication::do_clear_interrupt() noexcept {}

--- a/src/realm/replication.hpp
+++ b/src/realm/replication.hpp
@@ -336,9 +336,6 @@ public:
     /// constraint.
     virtual bool is_sync_agent() const noexcept;
 
-    template <class T>
-    void set(const Table*, ColKey col_key, ObjKey key, T value, _impl::Instruction variant);
-
     ~Replication() override;
 
 protected:
@@ -392,9 +389,7 @@ public:
 
 class TrivialReplication : public Replication {
 public:
-    ~TrivialReplication() noexcept
-    {
-    }
+    ~TrivialReplication() noexcept {}
 
     std::string get_database_path() const override;
 
@@ -469,96 +464,6 @@ inline bool Replication::is_sync_agent() const noexcept
 {
     return false;
 }
-
-template <>
-inline void Replication::set(const Table* table, ColKey col_key, ObjKey key, StringData value,
-                             _impl::Instruction variant)
-{
-    set_string(table, col_key, key, value, variant);
-}
-
-template <>
-inline void Replication::set(const Table* table, ColKey col_key, ObjKey key, BinaryData value,
-                             _impl::Instruction variant)
-{
-    set_binary(table, col_key, key, value, variant);
-}
-
-template <>
-inline void Replication::set(const Table* table, ColKey col_key, ObjKey key, Timestamp value,
-                             _impl::Instruction variant)
-{
-    if (value.is_null()) {
-        set_null(table, col_key, key, variant);
-    }
-    else {
-        set_timestamp(table, col_key, key, value, variant);
-    }
-}
-
-template <>
-inline void Replication::set(const Table* table, ColKey col_key, ObjKey key, ObjectId value,
-                             _impl::Instruction variant)
-{
-    set_object_id(table, col_key, key, value, variant);
-}
-
-template <>
-inline void Replication::set(const Table* table, ColKey col_key, ObjKey key, bool value, _impl::Instruction variant)
-{
-    set_bool(table, col_key, key, value, variant);
-}
-
-template <>
-inline void Replication::set(const Table* table, ColKey col_key, ObjKey key, float value, _impl::Instruction variant)
-{
-    set_float(table, col_key, key, value, variant);
-}
-
-template <>
-inline void Replication::set(const Table* table, ColKey col_key, ObjKey key, double value, _impl::Instruction variant)
-{
-    set_double(table, col_key, key, value, variant);
-}
-
-template <>
-inline void Replication::set(const Table* table, ColKey col_key, ObjKey key, Decimal128 value,
-                             _impl::Instruction variant)
-{
-    if (value.is_null()) {
-        set_null(table, col_key, key, variant);
-    }
-    else {
-        set_decimal(table, col_key, key, value, variant);
-    }
-}
-
-template <>
-inline void Replication::set(const Table* table, ColKey col_key, ObjKey key, ObjKey target_key,
-                             _impl::Instruction variant)
-{
-    if (target_key) {
-        set_link(table, col_key, key, target_key, variant);
-    }
-    else {
-        nullify_link(table, col_key, key);
-    }
-}
-
-template <>
-inline void Replication::set(const Table* table, ColKey col_key, ObjKey key, ObjLink target_obj,
-                             _impl::Instruction variant)
-{
-    if (target_obj) {
-        set_typed_link(table, col_key, key, target_obj, variant);
-    }
-    else {
-        nullify_link(table, col_key, key);
-    }
-}
-
-template <>
-void Replication::set(const Table* table, ColKey col_key, ObjKey key, Mixed value, _impl::Instruction variant);
 
 inline TrivialReplication::TrivialReplication(const std::string& database_file)
     : Replication(m_stream)

--- a/src/realm/sort_descriptor.cpp
+++ b/src/realm/sort_descriptor.cpp
@@ -20,6 +20,7 @@
 #include <realm/table.hpp>
 #include <realm/db.hpp>
 #include <realm/util/assert.hpp>
+#include <realm/list.hpp>
 
 using namespace realm;
 
@@ -206,8 +207,9 @@ void DistinctDescriptor::execute(IndexPairs& v, const Sorter& predicate, const B
     using IP = ColumnsDescriptor::IndexPair;
     // Remove all rows which have a null link along the way to the distinct columns
     if (predicate.has_links()) {
-        auto nulls =
-            std::remove_if(v.begin(), v.end(), [&](const IP& index) { return predicate.any_is_null(index); });
+        auto nulls = std::remove_if(v.begin(), v.end(), [&](const IP& index) {
+            return predicate.any_is_null(index);
+        });
         v.erase(nulls, v.end());
     }
 
@@ -215,15 +217,18 @@ void DistinctDescriptor::execute(IndexPairs& v, const Sorter& predicate, const B
     std::sort(v.begin(), v.end(), std::ref(predicate));
 
     // Move duplicates to the back - "not less than" is "equal" since they're sorted
-    auto duplicates =
-        std::unique(v.begin(), v.end(), [&](const IP& a, const IP& b) { return !predicate(a, b, false); });
+    auto duplicates = std::unique(v.begin(), v.end(), [&](const IP& a, const IP& b) {
+        return !predicate(a, b, false);
+    });
     // Erase the duplicates
     v.erase(duplicates, v.end());
     bool will_be_sorted_next = next && next->get_type() == DescriptorType::Sort;
     if (!will_be_sorted_next) {
         // Restore the original order, this is either the original
         // tableview order or the order of the previous sort
-        std::sort(v.begin(), v.end(), [](const IP& a, const IP& b) { return a.index_in_view < b.index_in_view; });
+        std::sort(v.begin(), v.end(), [](const IP& a, const IP& b) {
+            return a.index_in_view < b.index_in_view;
+        });
     }
 }
 
@@ -316,7 +321,6 @@ bool BaseDescriptor::Sorter::operator()(IndexPair i, IndexPair j, bool total_ord
         if (c) {
             return m_columns[t].ascending ? c < 0 : c > 0;
         }
-
     }
     // make sort stable by using original index as final comparison
     return total_ordering ? i.index_in_view < j.index_in_view : 0;
@@ -363,7 +367,7 @@ IncludeDescriptor::IncludeDescriptor(ConstTableRef table, const std::vector<std:
         backlink_source.reserve(links.size());
         ConstTableRef cur_table = table;
         size_t link_ndx = 0;
-        for (auto link : links) {  // follow path, one link at a time:
+        for (auto link : links) { // follow path, one link at a time:
             auto col_type = link.column_key.get_type();
             columns.push_back(link.column_key);
             backlink_source.push_back(link.from);
@@ -651,7 +655,8 @@ util::Optional<size_t> DescriptorOrdering::remove_all_limits()
                 min_limit = limit->get_limit();
             }
             it = m_descriptors.erase(it);
-        } else {
+        }
+        else {
             ++it;
         }
     }

--- a/src/realm/sync/changeset.cpp
+++ b/src/realm/sync/changeset.cpp
@@ -2,6 +2,7 @@
 
 #if REALM_DEBUG
 #include <iostream>
+#include <iomanip>
 #include <sstream>
 #endif // REALM_DEBUG
 

--- a/src/realm/sync/changeset.cpp
+++ b/src/realm/sync/changeset.cpp
@@ -249,7 +249,7 @@ void Changeset::verify() const
                     verify_path(path_instr->path);
                 }
 
-                if (auto set_instr = instr->get_if<Instruction::Set>()) {
+                if (auto set_instr = instr->get_if<Instruction::Update>()) {
                     verify_payload(set_instr->value);
                 }
                 else if (auto insert_instr = instr->get_if<Instruction::ArrayInsert>()) {
@@ -305,12 +305,12 @@ void Changeset::Reflector::operator()(const Instruction::EraseTable& p) const
     table_instr(p);
 }
 
-void Changeset::Reflector::operator()(const Instruction::Set& p) const
+void Changeset::Reflector::operator()(const Instruction::Update& p) const
 {
     m_tracer.name("Set");
     path_instr(p);
     m_tracer.field("value", p.value);
-    if (p.is_array_set()) {
+    if (p.is_array_update()) {
         m_tracer.field("prior_size", p.prior_size);
     }
     else {

--- a/src/realm/sync/changeset_encoder.cpp
+++ b/src/realm/sync/changeset_encoder.cpp
@@ -31,13 +31,13 @@ void ChangesetEncoder::operator()(const Instruction::EraseObject& instr)
     append(Instruction::Type::EraseObject, instr.table, instr.object);
 }
 
-void ChangesetEncoder::operator()(const Instruction::Set& instr)
+void ChangesetEncoder::operator()(const Instruction::Update& instr)
 {
-    if (instr.is_array_set()) {
-        append_path_instr(Instruction::Type::Set, instr, instr.value, instr.prior_size);
+    if (instr.is_array_update()) {
+        append_path_instr(Instruction::Type::Update, instr, instr.value, instr.prior_size);
     }
     else {
-        append_path_instr(Instruction::Type::Set, instr, instr.value, instr.is_default);
+        append_path_instr(Instruction::Type::Update, instr, instr.value, instr.is_default);
     }
 }
 

--- a/src/realm/sync/changeset_parser.cpp
+++ b/src/realm/sync/changeset_parser.cpp
@@ -303,14 +303,14 @@ void ChangesetParser::State::parse_one()
             m_handler(instr);
             return;
         }
-        case Instruction::Type::Set: {
-            Instruction::Set instr;
+        case Instruction::Type::Update: {
+            Instruction::Update instr;
             read_path_instr(instr);
             instr.value = read_payload();
 
             // If the last path element is a string, we are setting a field. Otherwise, we are setting an array
             // element.
-            if (!instr.is_array_set()) {
+            if (!instr.is_array_update()) {
                 instr.is_default = read_bool();
             }
             else {

--- a/src/realm/sync/dump_command.cpp
+++ b/src/realm/sync/dump_command.cpp
@@ -66,9 +66,9 @@ public:
     std::string format_timestamp(Timestamp);
     std::string format_object_id(ObjectId);
     std::string format_decimal(Decimal128);
-    std::string format_list(ConstLstBase&);
+    std::string format_list(CollectionBase&);
     std::string format_link(ObjKey);
-    std::string format_link_list(const ConstLnkLst&);
+    std::string format_link_list(const LnkLst&);
 
     template <DataType>
     std::string format_cell(const Obj& obj, ColKey col_key);
@@ -156,7 +156,7 @@ std::string Formatter::format_decimal(Decimal128 id)
     return id.to_string();
 }
 
-std::string Formatter::format_list(ConstLstBase& list)
+std::string Formatter::format_list(CollectionBase& list)
 {
     m_out.reset();
     m_out << format_num_rows(list.size());
@@ -170,7 +170,7 @@ std::string Formatter::format_link(ObjKey key)
     return std::string{m_out.data(), m_out.size()};
 }
 
-std::string Formatter::format_link_list(const ConstLnkLst& list)
+std::string Formatter::format_link_list(const LnkLst& list)
 {
     m_out.reset();
     m_out << format_num_links(list.size());
@@ -517,6 +517,12 @@ int main(int argc, char* argv[])
                             case type_Decimal:
                                 formatter.format_column<type_Decimal>(*table, col_ndx, col);
                                 break;
+                            case type_Mixed:
+                                formatter.format_column<type_Mixed>(*table, col_ndx, col);
+                                break;
+                            case type_TypedLink:
+                                formatter.format_column<type_TypedLink>(*table, col_ndx, col);
+                                break;
                             case type_Link:
                                 formatter.format_column<type_Link>(*table, col_ndx, col);
                                 break;
@@ -525,7 +531,6 @@ int main(int argc, char* argv[])
                                 break;
                             case type_OldDateTime:
                             case type_OldTable:
-                            case type_OldMixed:
                                 break;
                         }
                     }

--- a/src/realm/sync/hist_command.cpp
+++ b/src/realm/sync/hist_command.cpp
@@ -435,7 +435,7 @@ public:
         return modify_object(Instruction::Type::EraseObject, instr.object);
     }
 
-    bool operator()(Instruction::Set& instr) noexcept
+    bool operator()(Instruction::Update& instr) noexcept
     {
         select_property(instr);
         return modify_property(Instruction::Type::Set, &instr.payload);

--- a/src/realm/sync/instruction_applier.cpp
+++ b/src/realm/sync/instruction_applier.cpp
@@ -293,9 +293,9 @@ void InstructionApplier::set_value(const SetTargetInfo& info, const Instruction:
 }
 
 
-void InstructionApplier::operator()(const Instruction::Set& instr)
+void InstructionApplier::operator()(const Instruction::Update& instr)
 {
-    if (!instr.is_array_set()) {
+    if (!instr.is_array_update()) {
         auto path = get_field(instr, "Set");
         // FIXME: Would use structured bindings, but they cannot be captured by lamdas.
         auto obj = std::move(std::get<0>(path));

--- a/src/realm/sync/instruction_replication.cpp
+++ b/src/realm/sync/instruction_replication.cpp
@@ -82,6 +82,10 @@ Instruction::Payload SyncReplication::as_payload(Mixed value)
             REALM_TERMINATE("as_payload() needs table/collection for links");
             break;
         }
+        case type_Mixed:
+            [[fallthrough]];
+        case type_OldTable:
+            [[fallthrough]];
         case type_OldDateTime:
             [[fallthrough]];
         case type_LinkList: {

--- a/src/realm/sync/instruction_replication.cpp
+++ b/src/realm/sync/instruction_replication.cpp
@@ -2,6 +2,7 @@
 #include <realm/db.hpp>
 #include <realm/sync/transform.hpp> // TransformError
 #include <realm/sync/object.hpp>
+#include <realm/list.hpp>
 
 namespace realm {
 namespace sync {
@@ -36,25 +37,97 @@ void SyncReplication::do_initiate_transact(Group& group, version_type current_ve
     reset();
 }
 
-template <class T>
-auto SyncReplication::as_payload(T value)
+Instruction::Payload SyncReplication::as_payload(Mixed value)
 {
-    return Instruction::Payload{value};
+    if (value.is_null()) {
+        return Instruction::Payload{};
+    }
+
+    switch (value.get_type()) {
+        case type_Int: {
+            return Instruction::Payload{value.get<int64_t>()};
+        }
+        case type_Bool: {
+            return Instruction::Payload{value.get<bool>()};
+        }
+        case type_Float: {
+            return Instruction::Payload{value.get<float>()};
+        }
+        case type_Double: {
+            return Instruction::Payload{value.get<double>()};
+        }
+        case type_String: {
+            auto str = value.get<StringData>();
+            auto range = m_encoder.add_string_range(str);
+            return Instruction::Payload{range};
+        }
+        case type_Binary: {
+            auto binary = value.get<BinaryData>();
+            auto range = m_encoder.add_string_range(StringData{binary.data(), binary.size()});
+            const bool is_binary = true;
+            return Instruction::Payload{range, is_binary};
+        }
+        case type_Timestamp: {
+            return Instruction::Payload{value.get<Timestamp>()};
+        }
+        case type_Decimal: {
+            return Instruction::Payload{value.get<Decimal128>()};
+        }
+        case type_ObjectId: {
+            return Instruction::Payload{value.get<ObjectId>()};
+        }
+        case type_TypedLink:
+            [[fallthrough]];
+        case type_Link: {
+            REALM_TERMINATE("as_payload() needs table/collection for links");
+            break;
+        }
+        case type_OldDateTime:
+            [[fallthrough]];
+        case type_LinkList: {
+            REALM_TERMINATE("Invalid payload type");
+            break;
+        }
+    }
+    return Instruction::Payload{};
 }
 
-template <>
-auto SyncReplication::as_payload(StringData value)
+Instruction::Payload SyncReplication::as_payload(const CollectionBase& collection, Mixed value)
 {
-    auto range = m_encoder.add_string_range(value);
-    return Instruction::Payload{range};
+    return as_payload(*collection.get_table(), collection.get_col_key(), value);
 }
 
-template <>
-auto SyncReplication::as_payload(BinaryData value)
+Instruction::Payload SyncReplication::as_payload(const Table& table, ColKey col_key, Mixed value)
 {
-    auto range = m_encoder.add_string_range(StringData{value.data(), value.size()});
-    const bool is_binary = true;
-    return Instruction::Payload{range, is_binary};
+    if (value.get_type() == type_Link) {
+        ConstTableRef target_table = table.get_link_target(col_key);
+        if (target_table->is_embedded()) {
+            // FIXME: Include target table name to support Mixed of Embedded Objects.
+            return Instruction::Payload::ObjectValue{};
+        }
+
+        Instruction::Payload::Link link;
+        link.target_table = emit_class_name(*target_table);
+        link.target = primary_key_for_object(*target_table, value.get<ObjKey>());
+        return Instruction::Payload{link};
+    }
+    else if (value.get_type() == type_TypedLink) {
+        auto obj_link = value.get<ObjLink>();
+        ConstTableRef target_table = m_transaction->get_table(obj_link.get_table_key());
+        REALM_ASSERT(target_table);
+
+        if (target_table->is_embedded()) {
+            REALM_TERMINATE("Dynamically typed embedded objects not supported yet.");
+        }
+
+        Instruction::Payload::Link link;
+        link.target_table = emit_class_name(*target_table);
+        link.target = primary_key_for_object(*target_table, obj_link.get_obj_key());
+        return Instruction::Payload{link};
+    }
+    else {
+        return as_payload(value);
+    }
 }
 
 InternString SyncReplication::emit_class_name(StringData table_name)
@@ -299,49 +372,28 @@ void SyncReplication::rename_column(const Table*, ColKey, StringData)
     unsupported_instruction();
 }
 
-template <class T>
-void SyncReplication::set(const Table* table, ColKey col, ObjKey key, T value, _impl::Instruction variant)
+void SyncReplication::list_set(const CollectionBase& list, size_t ndx, Mixed value)
 {
-    if (select_table(*table)) {
-        Instruction::Set instr;
-        populate_path_instr(instr, *table, key, col);
-        instr.value = as_payload(value);
-        instr.is_default = (variant == _impl::instr_SetDefault);
-        emit(instr);
-    }
-}
-
-template <class T>
-void SyncReplication::list_set(const ConstLstBase& list, size_t ndx, T value)
-{
-    if (select_list(list)) {
-        Instruction::Set instr;
+    if (select_collection(list)) {
+        Instruction::Update instr;
         populate_path_instr(instr, list, uint32_t(ndx));
-        REALM_ASSERT(instr.is_array_set());
-        instr.value = as_payload(value);
+        REALM_ASSERT(instr.is_array_update());
+        instr.value = as_payload(list, value);
         instr.prior_size = uint32_t(list.size());
         emit(instr);
     }
 }
 
-template <class T>
-void SyncReplication::list_insert(const ConstLstBase& list, size_t ndx, T value)
+void SyncReplication::list_insert(const CollectionBase& list, size_t ndx, Mixed value)
 {
-    if (select_list(list)) {
+    if (select_collection(list)) {
         auto sz = uint32_t(list.size());
         Instruction::ArrayInsert instr;
         populate_path_instr(instr, list, uint32_t(ndx));
-        instr.value = as_payload(value);
+        instr.value = as_payload(list, value);
         instr.prior_size = sz;
         emit(instr);
     }
-}
-
-void SyncReplication::set_int(const Table* table, ColKey col, ObjKey ndx, int_fast64_t value,
-                              _impl::Instruction variant)
-{
-    TrivialReplication::set_int(table, col, ndx, value, variant);
-    set(table, col, ndx, value, variant);
 }
 
 void SyncReplication::add_int(const Table* table, ColKey col, ObjKey ndx, int_fast64_t value)
@@ -358,377 +410,24 @@ void SyncReplication::add_int(const Table* table, ColKey col, ObjKey ndx, int_fa
     }
 }
 
-void SyncReplication::set_bool(const Table* table, ColKey col, ObjKey ndx, bool value, _impl::Instruction variant)
+void SyncReplication::set(const Table* table, ColKey col, ObjKey key, Mixed value, _impl::Instruction variant)
 {
-    TrivialReplication::set_bool(table, col, ndx, value, variant);
-    set(table, col, ndx, value, variant);
-}
+    TrivialReplication::set(table, col, key, value, variant);
 
-void SyncReplication::set_float(const Table* table, ColKey col, ObjKey ndx, float value, _impl::Instruction variant)
-{
-    TrivialReplication::set_float(table, col, ndx, value, variant);
-    set(table, col, ndx, value, variant);
-}
-
-void SyncReplication::set_double(const Table* table, ColKey col, ObjKey ndx, double value, _impl::Instruction variant)
-{
-    TrivialReplication::set_double(table, col, ndx, value, variant);
-    set(table, col, ndx, value, variant);
-}
-
-void SyncReplication::set_string(const Table* table, ColKey col, ObjKey ndx, StringData value,
-                                 _impl::Instruction variant)
-{
-    TrivialReplication::set_string(table, col, ndx, value, variant);
-
-    if (value.is_null()) {
-        set(table, col, ndx, realm::util::none, variant);
-    }
-    else {
-        set(table, col, ndx, value, variant);
-    }
-}
-
-void SyncReplication::set_binary(const Table* table, ColKey col, ObjKey ndx, BinaryData value,
-                                 _impl::Instruction variant)
-{
-    TrivialReplication::set_binary(table, col, ndx, value, variant);
-
-    if (value.is_null()) {
-        set(table, col, ndx, realm::util::none, variant);
-    }
-    else {
-        set(table, col, ndx, value, variant);
-    }
-}
-
-void SyncReplication::set_timestamp(const Table* table, ColKey col, ObjKey ndx, Timestamp value,
-                                    _impl::Instruction variant)
-{
-    TrivialReplication::set_timestamp(table, col, ndx, value, variant);
-    set(table, col, ndx, value, variant);
-}
-
-void SyncReplication::set_object_id(const Table* table, ColKey col, ObjKey ndx, ObjectId value,
-                                    _impl::Instruction variant)
-{
-    TrivialReplication::set_object_id(table, col, ndx, value, variant);
-    set(table, col, ndx, value, variant);
-}
-
-void SyncReplication::set_decimal(const Table* table, ColKey col, ObjKey ndx, Decimal128 value,
-                                  _impl::Instruction variant)
-{
-    TrivialReplication::set_decimal(table, col, ndx, value, variant);
-    set(table, col, ndx, value, variant);
-}
-
-void SyncReplication::set_link(const Table* table, ColKey col, ObjKey ndx, ObjKey value, _impl::Instruction variant)
-{
-    TrivialReplication::set_link(table, col, ndx, value, variant);
-
-    if (value.is_unresolved()) {
-        // If link is unresolved, it should not be communicated
+    if (value.get_type() == type_Link && value.get<ObjKey>().is_unresolved()) {
+        // If link is unresolved, it should not be communicated.
         return;
     }
-    if (select_table(*table)) {
-        if (value) {
-            Instruction::Payload::Link link;
-            ConstTableRef link_target_table = table->get_link_target(col);
-            if (link_target_table->is_embedded()) {
-                using Payload = Instruction::Payload;
-
-                Instruction::Set instr;
-                populate_path_instr(instr, *table, ndx, col);
-                if (value) {
-                    instr.value = Payload::ObjectValue{};
-                }
-                else {
-                    instr.value = Payload{util::none};
-                }
-                emit(instr);
-            }
-            else {
-                link.target_table = emit_class_name(*link_target_table);
-                link.target = primary_key_for_object(*link_target_table, value);
-                set(table, col, ndx, link, variant);
-            }
-        }
-        else {
-            set(table, col, ndx, realm::util::none, variant);
-        }
-    }
-}
-
-void SyncReplication::set_typed_link(const Table* table, ColKey col, ObjKey ndx, ObjLink value,
-                                     _impl::Instruction variant)
-{
-    TrivialReplication::set_typed_link(table, col, ndx, value, variant);
 
     if (select_table(*table)) {
-        if (value) {
-            Instruction::Payload::Link link;
-            ConstTableRef link_target_table = m_transaction->get_table(value.get_table_key());
-            REALM_ASSERT(link_target_table);
-
-            if (link_target_table->is_embedded()) {
-                REALM_TERMINATE("Mixed with embedded objects not supported yet.");
-            }
-
-            link.target_table = emit_class_name(*link_target_table);
-            link.target = primary_key_for_object(*link_target_table, value.get_obj_key());
-            set(table, col, ndx, link, variant);
-        }
-        else {
-            set(table, col, ndx, realm::util::none, variant);
-        }
-    }
-}
-
-void SyncReplication::set_null(const Table* table, ColKey col, ObjKey ndx, _impl::Instruction variant)
-{
-    TrivialReplication::set_null(table, col, ndx, variant);
-    set(table, col, ndx, realm::util::none, variant);
-}
-
-void SyncReplication::insert_substring(const Table*, ColKey, ObjKey, size_t, StringData)
-{
-    unsupported_instruction();
-}
-
-void SyncReplication::erase_substring(const Table*, ColKey, ObjKey, size_t, size_t)
-{
-    unsupported_instruction();
-}
-
-void SyncReplication::list_set_null(const ConstLstBase& list, size_t ndx)
-{
-    TrivialReplication::list_set_null(list, ndx);
-    list_set(list, ndx, util::none);
-}
-
-void SyncReplication::list_set_int(const ConstLstBase& list, size_t ndx, int64_t value)
-{
-    TrivialReplication::list_set_int(list, ndx, value);
-    list_set(list, ndx, value);
-}
-
-void SyncReplication::list_set_bool(const ConstLstBase& list, size_t ndx, bool value)
-{
-    TrivialReplication::list_set_bool(list, ndx, value);
-    list_set(list, ndx, value);
-}
-
-void SyncReplication::list_set_float(const ConstLstBase& list, size_t ndx, float value)
-{
-    TrivialReplication::list_set_float(list, ndx, value);
-    list_set(list, ndx, value);
-}
-
-void SyncReplication::list_set_double(const ConstLstBase& list, size_t ndx, double value)
-{
-    TrivialReplication::list_set_double(list, ndx, value);
-    list_set(list, ndx, value);
-}
-
-void SyncReplication::list_set_string(const ConstLstBase& list, size_t ndx, StringData value)
-{
-    TrivialReplication::list_set_string(list, ndx, value);
-    list_set(list, ndx, value);
-}
-
-void SyncReplication::list_set_binary(const ConstLstBase& list, size_t ndx, BinaryData value)
-{
-    TrivialReplication::list_set_binary(list, ndx, value);
-    list_set(list, ndx, value);
-}
-
-void SyncReplication::list_set_timestamp(const ConstLstBase& list, size_t ndx, Timestamp value)
-{
-    TrivialReplication::list_set_timestamp(list, ndx, value);
-    list_set(list, ndx, value);
-}
-
-void SyncReplication::list_set_object_id(const ConstLstBase& list, size_t ndx, ObjectId value)
-{
-    TrivialReplication::list_set_object_id(list, ndx, value);
-    list_set(list, ndx, value);
-}
-
-void SyncReplication::list_set_decimal(const ConstLstBase& list, size_t ndx, Decimal128 value)
-{
-    TrivialReplication::list_set_decimal(list, ndx, value);
-    list_set(list, ndx, value);
-}
-
-void SyncReplication::list_set_typed_link(const ConstLstBase& list, size_t ndx, ObjLink value)
-{
-    TrivialReplication::list_set_typed_link(list, ndx, value);
-
-    if (select_list(list)) {
-        Instruction::Set instr;
-        populate_path_instr(instr, list, uint32_t(ndx));
-        REALM_ASSERT(instr.is_array_set());
-
-        ConstTableRef target_table = m_transaction->get_table(value.get_table_key());
-        REALM_ASSERT(target_table);
-
-        if (target_table->is_embedded()) {
-            REALM_TERMINATE("Mixed with embedded objects not supported yet.");
-        }
-        else {
-            Instruction::Payload::Link link;
-            link.target_table = emit_class_name(*target_table);
-            link.target = primary_key_for_object(*target_table, value.get_obj_key());
-            instr.value = Instruction::Payload{link};
-        }
-        instr.prior_size = uint32_t(list.size());
+        Instruction::Update instr;
+        populate_path_instr(instr, *table, key, col);
+        instr.value = as_payload(*table, col, value);
+        instr.is_default = (variant == _impl::instr_SetDefault);
         emit(instr);
     }
 }
 
-void SyncReplication::list_set_link(const Lst<ObjKey>& list, size_t ndx, ObjKey value)
-{
-    TrivialReplication::list_set_link(list, ndx, value);
-
-    if (value.is_unresolved()) {
-        // If link is unresolved, it should not be communicated
-        return;
-    }
-    if (select_list(list)) {
-        Instruction::Set instr;
-        populate_path_instr(instr, list, uint32_t(ndx));
-        REALM_ASSERT(instr.is_array_set());
-
-        ConstTableRef target_table = list.get_table()->get_link_target(list.get_col_key());
-        if (target_table->is_embedded()) {
-            if (value) {
-                instr.value = Instruction::Payload::ObjectValue{};
-            }
-            else {
-                // ArraySet(null) is not yet supported by Core, so this will
-                // never happen in practice. The only way to erase an embedded
-                // object in a list is to remove the entry.
-                instr.value = Instruction::Payload{};
-            }
-        }
-        else {
-            Instruction::Payload::Link link;
-            link.target_table = emit_class_name(*target_table);
-            link.target = primary_key_for_object(*target_table, value);
-            instr.value = Instruction::Payload{link};
-        }
-        instr.prior_size = uint32_t(list.size());
-        emit(instr);
-    }
-}
-
-void SyncReplication::list_insert_null(const ConstLstBase& list, size_t ndx)
-{
-    TrivialReplication::list_insert_null(list, ndx);
-    list_insert(list, ndx, util::none);
-}
-
-void SyncReplication::list_insert_int(const ConstLstBase& list, size_t ndx, int64_t value)
-{
-    TrivialReplication::list_insert_int(list, ndx, value);
-    list_insert(list, ndx, value);
-}
-
-void SyncReplication::list_insert_bool(const ConstLstBase& list, size_t ndx, bool value)
-{
-    TrivialReplication::list_insert_bool(list, ndx, value);
-    list_insert(list, ndx, value);
-}
-
-void SyncReplication::list_insert_float(const ConstLstBase& list, size_t ndx, float value)
-{
-    TrivialReplication::list_insert_float(list, ndx, value);
-    list_insert(list, ndx, value);
-}
-
-void SyncReplication::list_insert_double(const ConstLstBase& list, size_t ndx, double value)
-{
-    TrivialReplication::list_insert_double(list, ndx, value);
-    list_insert(list, ndx, value);
-}
-
-void SyncReplication::list_insert_string(const ConstLstBase& list, size_t ndx, StringData value)
-{
-    TrivialReplication::list_insert_string(list, ndx, value);
-    list_insert(list, ndx, value);
-}
-
-void SyncReplication::list_insert_binary(const ConstLstBase& list, size_t ndx, BinaryData value)
-{
-    TrivialReplication::list_insert_binary(list, ndx, value);
-    list_insert(list, ndx, value);
-}
-
-void SyncReplication::list_insert_timestamp(const ConstLstBase& list, size_t ndx, Timestamp value)
-{
-    TrivialReplication::list_insert_timestamp(list, ndx, value);
-    list_insert(list, ndx, value);
-}
-
-void SyncReplication::list_insert_object_id(const ConstLstBase& list, size_t ndx, ObjectId value)
-{
-    TrivialReplication::list_insert_object_id(list, ndx, value);
-    list_insert(list, ndx, value);
-}
-
-void SyncReplication::list_insert_decimal(const ConstLstBase& list, size_t ndx, Decimal128 value)
-{
-    TrivialReplication::list_insert_decimal(list, ndx, value);
-    list_insert(list, ndx, value);
-}
-
-void SyncReplication::list_insert_typed_link(const ConstLstBase& list, size_t ndx, ObjLink value)
-{
-    TrivialReplication::list_insert_typed_link(list, ndx, value);
-
-    if (select_list(list)) {
-        Instruction::ArrayInsert instr;
-        populate_path_instr(instr, list, uint32_t(ndx));
-
-        ConstTableRef target_table = m_transaction->get_table(value.get_table_key());
-        REALM_ASSERT(target_table);
-
-        if (target_table->is_embedded()) {
-            REALM_TERMINATE("Mixed with embedded objects not supported yet.");
-        }
-        else {
-            Instruction::Payload::Link link;
-            link.target_table = emit_class_name(*target_table);
-            link.target = primary_key_for_object(*target_table, value.get_obj_key());
-            instr.value = Instruction::Payload{link};
-        }
-        instr.prior_size = uint32_t(list.size());
-        emit(instr);
-    }
-}
-
-void SyncReplication::list_insert_link(const Lst<ObjKey>& list, size_t ndx, ObjKey value)
-{
-    TrivialReplication::list_insert_link(list, ndx, value);
-
-    if (select_list(list)) {
-        Instruction::ArrayInsert instr;
-        populate_path_instr(instr, list, uint32_t(ndx));
-        ConstTableRef target_table = list.get_table()->get_link_target(list.get_col_key());
-        if (target_table->is_embedded()) {
-            instr.value = Instruction::Payload::ObjectValue{};
-        }
-        else {
-            auto link = Instruction::Payload::Link{emit_class_name(*target_table),
-                                                   primary_key_for_object(*target_table, value)};
-            instr.value = Instruction::Payload{link};
-        }
-        instr.prior_size = uint32_t(list.size());
-
-        emit(instr);
-    }
-}
 
 void SyncReplication::remove_object(const Table* table, ObjKey row_ndx)
 {
@@ -750,10 +449,10 @@ void SyncReplication::remove_object(const Table* table, ObjKey row_ndx)
 }
 
 
-void SyncReplication::list_move(const ConstLstBase& view, size_t from_ndx, size_t to_ndx)
+void SyncReplication::list_move(const CollectionBase& view, size_t from_ndx, size_t to_ndx)
 {
     TrivialReplication::list_move(view, from_ndx, to_ndx);
-    if (select_list(view)) {
+    if (select_collection(view)) {
         Instruction::ArrayMove instr;
         populate_path_instr(instr, view, uint32_t(from_ndx));
         instr.ndx_2 = uint32_t(to_ndx);
@@ -761,11 +460,11 @@ void SyncReplication::list_move(const ConstLstBase& view, size_t from_ndx, size_
     }
 }
 
-void SyncReplication::list_erase(const ConstLstBase& view, size_t ndx)
+void SyncReplication::list_erase(const CollectionBase& view, size_t ndx)
 {
     size_t prior_size = view.size();
     TrivialReplication::list_erase(view, ndx);
-    if (select_list(view)) {
+    if (select_collection(view)) {
         Instruction::ArrayErase instr;
         populate_path_instr(instr, view, uint32_t(ndx));
         instr.prior_size = uint32_t(prior_size);
@@ -773,11 +472,11 @@ void SyncReplication::list_erase(const ConstLstBase& view, size_t ndx)
     }
 }
 
-void SyncReplication::list_clear(const ConstLstBase& view)
+void SyncReplication::list_clear(const CollectionBase& view)
 {
     size_t prior_size = view.size();
     TrivialReplication::list_clear(view);
-    if (select_list(view)) {
+    if (select_collection(view)) {
         Instruction::ArrayClear instr;
         populate_path_instr(instr, view);
         instr.prior_size = uint32_t(prior_size);
@@ -790,9 +489,9 @@ void SyncReplication::nullify_link(const Table* table, ColKey col_ndx, ObjKey nd
     TrivialReplication::nullify_link(table, col_ndx, ndx);
 
     if (select_table(*table)) {
-        Instruction::Set instr;
+        Instruction::Update instr;
         populate_path_instr(instr, *table, ndx, col_ndx);
-        REALM_ASSERT(!instr.is_array_set());
+        REALM_ASSERT(!instr.is_array_update());
         instr.value = Instruction::Payload{realm::util::none};
         instr.is_default = false;
         emit(instr);
@@ -803,7 +502,7 @@ void SyncReplication::link_list_nullify(const Lst<ObjKey>& view, size_t ndx)
 {
     size_t prior_size = view.size();
     TrivialReplication::link_list_nullify(view, ndx);
-    if (select_list(view)) {
+    if (select_collection(view)) {
         Instruction::ArrayErase instr;
         populate_path_instr(instr, view, uint32_t(ndx));
         instr.prior_size = uint32_t(prior_size);
@@ -839,7 +538,7 @@ bool SyncReplication::select_table(const Table& table)
     }
 }
 
-bool SyncReplication::select_list(const ConstLstBase& view)
+bool SyncReplication::select_collection(const CollectionBase& view)
 {
     return select_table(*view.get_table());
 }
@@ -946,7 +645,7 @@ void SyncReplication::populate_path_instr(Instruction::PathInstruction& instr, c
     }
 }
 
-void SyncReplication::populate_path_instr(Instruction::PathInstruction& instr, const ConstLstBase& list)
+void SyncReplication::populate_path_instr(Instruction::PathInstruction& instr, const CollectionBase& list)
 {
     ConstTableRef source_table = list.get_table();
     ObjKey source_obj = list.get_key();
@@ -954,7 +653,8 @@ void SyncReplication::populate_path_instr(Instruction::PathInstruction& instr, c
     populate_path_instr(instr, *source_table, source_obj, source_field);
 }
 
-void SyncReplication::populate_path_instr(Instruction::PathInstruction& instr, const ConstLstBase& list, uint32_t ndx)
+void SyncReplication::populate_path_instr(Instruction::PathInstruction& instr, const CollectionBase& list,
+                                          uint32_t ndx)
 {
     populate_path_instr(instr, list);
     instr.path.m_path.push_back(ndx);

--- a/src/realm/sync/instruction_replication.hpp
+++ b/src/realm/sync/instruction_replication.hpp
@@ -77,54 +77,17 @@ public:
     void erase_column(const Table*, ColKey col_key) override;
     void rename_column(const Table*, ColKey col_key, StringData name) override;
 
-    void set_int(const Table*, ColKey col_key, ObjKey key, int_fast64_t value, _impl::Instruction variant) override;
     void add_int(const Table*, ColKey col_key, ObjKey key, int_fast64_t value) override;
-    void set_bool(const Table*, ColKey col_key, ObjKey key, bool value, _impl::Instruction variant) override;
-    void set_float(const Table*, ColKey col_key, ObjKey key, float value, _impl::Instruction variant) override;
-    void set_double(const Table*, ColKey col_key, ObjKey key, double value, _impl::Instruction variant) override;
-    void set_string(const Table*, ColKey col_key, ObjKey key, StringData value, _impl::Instruction variant) override;
-    void set_binary(const Table*, ColKey col_key, ObjKey key, BinaryData value, _impl::Instruction variant) override;
-    void set_timestamp(const Table*, ColKey col_key, ObjKey key, Timestamp value,
-                       _impl::Instruction variant) override;
-    void set_object_id(const Table*, ColKey col_key, ObjKey key, ObjectId value, _impl::Instruction variant) override;
-    void set_decimal(const Table*, ColKey col_key, ObjKey key, Decimal128 value, _impl::Instruction variant) override;
-    void set_link(const Table*, ColKey col_key, ObjKey key, ObjKey value, _impl::Instruction variant) override;
-    void set_typed_link(const Table*, ColKey col_key, ObjKey key, ObjLink value, _impl::Instruction variant) override;
-    void set_null(const Table*, ColKey col_key, ObjKey key, _impl::Instruction variant) override;
-    void insert_substring(const Table*, ColKey col_key, ObjKey key, size_t pos, StringData) override;
-    void erase_substring(const Table*, ColKey col_key, ObjKey key, size_t pos, size_t size) override;
+    void set(const Table*, ColKey col_key, ObjKey key, Mixed value, _impl::Instruction variant) override;
 
-    void list_set_null(const ConstLstBase& list, size_t ndx) override;
-    void list_set_int(const ConstLstBase& list, size_t list_ndx, int64_t value) override;
-    void list_set_bool(const ConstLstBase& list, size_t list_ndx, bool value) override;
-    void list_set_float(const ConstLstBase& list, size_t list_ndx, float value) override;
-    void list_set_double(const ConstLstBase& list, size_t list_ndx, double value) override;
-    void list_set_string(const ConstLstBase& list, size_t list_ndx, StringData value) override;
-    void list_set_binary(const ConstLstBase& list, size_t list_ndx, BinaryData value) override;
-    void list_set_timestamp(const ConstLstBase& list, size_t list_ndx, Timestamp value) override;
-    void list_set_object_id(const ConstLstBase& list, size_t list_ndx, ObjectId value) override;
-    void list_set_decimal(const ConstLstBase& list, size_t list_ndx, Decimal128 value) override;
-    void list_set_typed_link(const ConstLstBase& list, size_t list_ndx, ObjLink value) override;
+    void list_set(const CollectionBase& list, size_t list_ndx, Mixed value) override;
+    void list_insert(const CollectionBase& list, size_t list_ndx, Mixed value) override;
+    void list_move(const CollectionBase&, size_t from_link_ndx, size_t to_link_ndx) override;
+    void list_erase(const CollectionBase&, size_t link_ndx) override;
+    void list_clear(const CollectionBase&) override;
 
-    void list_insert_int(const ConstLstBase& list, size_t list_ndx, int64_t value) override;
-    void list_insert_bool(const ConstLstBase& list, size_t list_ndx, bool value) override;
-    void list_insert_float(const ConstLstBase& list, size_t list_ndx, float value) override;
-    void list_insert_double(const ConstLstBase& list, size_t list_ndx, double value) override;
-    void list_insert_string(const ConstLstBase& list, size_t list_ndx, StringData value) override;
-    void list_insert_binary(const ConstLstBase& list, size_t list_ndx, BinaryData value) override;
-    void list_insert_timestamp(const ConstLstBase& list, size_t list_ndx, Timestamp value) override;
-    void list_insert_object_id(const ConstLstBase& list, size_t list_ndx, ObjectId value) override;
-    void list_insert_decimal(const ConstLstBase& list, size_t list_ndx, Decimal128 value) override;
-    void list_insert_typed_link(const ConstLstBase& list, size_t list_ndx, ObjLink value) override;
 
     void remove_object(const Table*, ObjKey) override;
-
-    void list_insert_null(const ConstLstBase&, size_t ndx) override;
-    void list_set_link(const Lst<ObjKey>&, size_t link_ndx, ObjKey value) override;
-    void list_insert_link(const Lst<ObjKey>&, size_t link_ndx, ObjKey value) override;
-    void list_move(const ConstLstBase&, size_t from_link_ndx, size_t to_link_ndx) override;
-    void list_erase(const ConstLstBase&, size_t link_ndx) override;
-    void list_clear(const ConstLstBase&) override;
 
     //@{
 
@@ -164,26 +127,21 @@ private:
 
     // Returns true and populates m_last_class_name if instructions for the
     // owning table should be emitted.
-    bool select_list(const ConstLstBase&); // returns true if table behavior != ignored
+    bool select_collection(const CollectionBase&); // returns true if table behavior != ignored
 
     InternString emit_class_name(StringData table_name);
     InternString emit_class_name(const Table& table);
     Instruction::Payload::Type get_payload_type(DataType) const;
 
-    template <class T>
-    void set(const Table*, ColKey col_key, ObjKey row_ndx, T payload, _impl::Instruction variant);
-    template <class T>
-    void list_set(const ConstLstBase& Lst, size_t ndx, T payload);
-    template <class T>
-    void list_insert(const ConstLstBase& Lst, size_t ndx, T payload);
-    template <class T>
-    auto as_payload(T value);
+    Instruction::Payload as_payload(Mixed value);
+    Instruction::Payload as_payload(const CollectionBase& collection, Mixed value);
+    Instruction::Payload as_payload(const Table& table, ColKey col_key, Mixed value);
 
     Instruction::PrimaryKey as_primary_key(Mixed);
     Instruction::PrimaryKey primary_key_for_object(const Table&, ObjKey key);
     void populate_path_instr(Instruction::PathInstruction&, const Table&, ObjKey key, ColKey field);
-    void populate_path_instr(Instruction::PathInstruction&, const ConstLstBase&);
-    void populate_path_instr(Instruction::PathInstruction&, const ConstLstBase&, uint32_t ndx);
+    void populate_path_instr(Instruction::PathInstruction&, const CollectionBase&);
+    void populate_path_instr(Instruction::PathInstruction&, const CollectionBase&, uint32_t ndx);
 
     // Cache information for the purpose of avoiding excessive string comparisons / interning
     // lookups.

--- a/src/realm/sync/instructions.hpp
+++ b/src/realm/sync/instructions.hpp
@@ -30,7 +30,7 @@ namespace sync {
     X(EraseColumn)                                                                                                   \
     X(CreateObject)                                                                                                  \
     X(EraseObject)                                                                                                   \
-    X(Set)                                                                                                           \
+    X(Update)                                                                                                        \
     X(AddInteger)                                                                                                    \
     X(ArrayInsert)                                                                                                   \
     X(ArrayMove)                                                                                                     \
@@ -468,30 +468,30 @@ struct EraseObject : ObjectInstruction {
     }
 };
 
-struct Set : PathInstruction {
+struct Update : PathInstruction {
     using PathInstruction::PathInstruction;
 
-    // Note: For "ArraySet", the path ends with an integer.
+    // Note: For "ArrayUpdate", the path ends with an integer.
     Payload value;
     union {
         bool is_default;     // For fields
-        uint32_t prior_size; // For "ArraySet"
+        uint32_t prior_size; // For "ArrayUpdate"
     };
 
-    Set()
+    Update()
         : prior_size(0)
     {
     }
 
-    bool is_array_set() const noexcept
+    bool is_array_update() const noexcept
     {
         return path.is_array_index();
     }
 
-    bool operator==(const Set& rhs) const noexcept
+    bool operator==(const Update& rhs) const noexcept
     {
         return PathInstruction::operator==(rhs) && value == rhs.value &&
-               (is_array_set() ? is_default == rhs.is_default : prior_size == rhs.prior_size);
+               (is_array_update() ? is_default == rhs.is_default : prior_size == rhs.prior_size);
     }
 };
 
@@ -572,7 +572,7 @@ struct Instruction {
         EraseTable = 1,
         CreateObject = 2,
         EraseObject = 3,
-        Set = 4, // Note: Also covers ArraySet
+        Update = 4, // Note: Also covers ArrayUpdate
         AddInteger = 5,
         AddColumn = 6,
         EraseColumn = 7,
@@ -841,11 +841,11 @@ struct Instruction::Visitor {
         return lambda(instr);
     }
 
-    auto operator()(const Instruction::Vector&) -> decltype(lambda(std::declval<const Instruction::Set&>()))
+    auto operator()(const Instruction::Vector&) -> decltype(lambda(std::declval<const Instruction::Update&>()))
     {
         REALM_TERMINATE("visiting instruction vector");
     }
-    auto operator()(Instruction::Vector&) -> decltype(lambda(std::declval<Instruction::Set&>()))
+    auto operator()(Instruction::Vector&) -> decltype(lambda(std::declval<Instruction::Update&>()))
     {
         REALM_TERMINATE("visiting instruction vector");
     }

--- a/src/realm/sync/noinst/changeset_index.cpp
+++ b/src/realm/sync/noinst/changeset_index.cpp
@@ -212,7 +212,7 @@ size_t get_object_ids_in_instruction(const Changeset& changeset, const sync::Ins
     if (auto obj_instr = instr.get_if<Instruction::ObjectInstruction>()) {
         ids[0] = {changeset.get_string(obj_instr->table), changeset.get_key(obj_instr->object)};
 
-        if (auto set_instr = instr.get_if<Instruction::Set>()) {
+        if (auto set_instr = instr.get_if<Instruction::Update>()) {
             auto& p = *set_instr;
             if (p.value.type == Instruction::Payload::Type::Link) {
                 ids[1] = {changeset.get_string(p.value.data.link.target_table),

--- a/src/realm/sync/noinst/client_history_impl.cpp
+++ b/src/realm/sync/noinst/client_history_impl.cpp
@@ -1458,7 +1458,7 @@ void ClientHistoryImpl::fix_up_client_file_ident_in_stored_changesets(Transactio
 
                 // Fix up the payload for Set and ArrayInsert.
                 Instruction::Payload* payload = nullptr;
-                if (auto set_instr = instr->get_if<Instruction::Set>()) {
+                if (auto set_instr = instr->get_if<Instruction::Update>()) {
                     payload = &set_instr->value;
                 }
                 else if (auto list_insert_instr = instr->get_if<Instruction::ArrayInsert>()) {

--- a/src/realm/sync/noinst/client_history_impl.hpp
+++ b/src/realm/sync/noinst/client_history_impl.hpp
@@ -5,6 +5,7 @@
 #include <realm/util/optional.hpp>
 #include <realm/sync/history.hpp>
 #include <realm/sync/noinst/object_id_history_state.hpp>
+#include <realm/array_integer.hpp>
 
 namespace realm {
 namespace _impl {

--- a/src/realm/sync/noinst/client_reset.cpp
+++ b/src/realm/sync/noinst/client_reset.cpp
@@ -461,7 +461,7 @@ bool copy_linklist(LnkLst& ll_src, LnkLst& ll_dst, std::function<ObjKey(ObjKey)>
 //         }
 //     }
 
-//     void operator()(const Instruction::Set& instr)
+//     void operator()(const Instruction::Update& instr)
 //     {
 //         if (REALM_COVER_NEVER(!selected_table))
 //             return;

--- a/src/realm/sync/noinst/compact_changesets.cpp
+++ b/src/realm/sync/noinst/compact_changesets.cpp
@@ -133,7 +133,7 @@ void ChangesetCompactor::add_changeset(Changeset& changeset)
                 break;
             }
             case Instruction::Type::Set: {
-                auto& set = instr->get_as<Instruction::Set>();
+                auto& set = instr->get_as<Instruction::Update>();
                 auto& info = m_objects[selected_table][set.object]; // Throws
                 if (set.payload.type == type_Link) {
                     StringData link_target_table = changeset.get_string(set.payload.data.link.target_table);
@@ -343,7 +343,7 @@ void ChangesetCompactor::compact_live_object(ObjectInfo& info)
                 if (instr->type == Instruction::Type::Set) {
                     // If a previous Set instruction existed for this field, discard it
                     // and record the position of this instruction instead.
-                    auto& set = instr->get_as<Instruction::Set>();
+                    auto& set = instr->get_as<Instruction::Update>();
                     StringData field = changeset.get_string(set.field);
                     auto it = last_set_instructions.find(field);
 

--- a/src/realm/sync/noinst/server_history.cpp
+++ b/src/realm/sync/noinst/server_history.cpp
@@ -2906,7 +2906,7 @@ void ServerHistory::fixup_state_and_changesets_for_assigned_file_ident(Transacti
 
                 // Fix up the payload for Set and ArrayInsert.
                 Instruction::Payload* payload = nullptr;
-                if (auto set_instr = instr->get_if<Instruction::Set>()) {
+                if (auto set_instr = instr->get_if<Instruction::Update>()) {
                     payload = &set_instr->value;
                 }
                 else if (auto list_insert_instr = instr->get_if<Instruction::ArrayInsert>()) {

--- a/src/realm/sync/noinst/server_history.hpp
+++ b/src/realm/sync/noinst/server_history.hpp
@@ -24,6 +24,8 @@
 #include <realm/sync/instruction_replication.hpp>
 #include <realm/sync/permissions.hpp>
 #include <realm/sync/noinst/object_id_history_state.hpp>
+#include <realm/array_integer.hpp>
+#include <realm/array_ref.hpp>
 
 namespace realm {
 namespace sync {

--- a/src/realm/sync/noinst/vacuum_command.cpp
+++ b/src/realm/sync/noinst/vacuum_command.cpp
@@ -7,9 +7,9 @@
 
 #include <realm/util/logger.hpp>
 #include <realm/util/load_file.hpp>
-#include <realm/noinst/vacuum.hpp>
-#include <realm/noinst/server_history.hpp>
-#include <realm/noinst/command_line_util.hpp>
+#include <realm/sync/noinst/vacuum.hpp>
+#include <realm/sync/noinst/server_history.hpp>
+#include <realm/sync/noinst/command_line_util.hpp>
 
 using namespace realm;
 using namespace realm::sync;

--- a/src/realm/sync/server_command.cpp
+++ b/src/realm/sync/server_command.cpp
@@ -8,7 +8,7 @@
 #include <realm/util/file.hpp>
 #include <realm/util/load_file.hpp>
 #include <realm/util/timestamp_logger.hpp>
-#include <realm/noinst/reopening_file_logger.hpp>
+#include <realm/sync/noinst/reopening_file_logger.hpp>
 #include <realm/sync/metrics.hpp>
 #include <realm/sync/server.hpp>
 #include <realm/sync/server_configuration.hpp>

--- a/src/realm/sync/server_index_command.cpp
+++ b/src/realm/sync/server_index_command.cpp
@@ -8,7 +8,7 @@
 #include <iostream>
 
 #include <realm/util/load_file.hpp>
-#include <realm/noinst/server_history.hpp>
+#include <realm/sync/noinst/server_history.hpp>
 #include <realm/db.hpp>
 #include <realm/sync/version.hpp>
 

--- a/src/realm/table.cpp
+++ b/src/realm/table.cpp
@@ -1704,8 +1704,9 @@ void Table::batch_erase_rows(const KeyColumn& keys)
 
     if (has_any_embedded_objects() || (g && g->has_cascade_notification_handler())) {
         CascadeState state(CascadeState::Mode::Strong, g);
-        std::for_each(vec.begin(), vec.end(),
-                      [this, &state](ObjKey k) { state.m_to_be_deleted.emplace_back(m_key, k); });
+        std::for_each(vec.begin(), vec.end(), [this, &state](ObjKey k) {
+            state.m_to_be_deleted.emplace_back(m_key, k);
+        });
         nullify_links(state);
         remove_recursive(state);
     }
@@ -3305,7 +3306,7 @@ ObjectId remove_optional<Optional<ObjectId>>(Optional<ObjectId> val)
 {
     return val.value();
 }
-}
+} // namespace
 
 template <class F, class T>
 void Table::change_nullability(ColKey key_from, ColKey key_to, bool throw_on_null)

--- a/src/realm/table.hpp
+++ b/src/realm/table.hpp
@@ -306,7 +306,10 @@ public:
     bool is_group_level() const noexcept;
 
     /// A Table accessor obtained from a frozen transaction is also frozen.
-    bool is_frozen() const noexcept { return m_is_frozen; }
+    bool is_frozen() const noexcept
+    {
+        return m_is_frozen;
+    }
 
     /// If this table is a group-level table, then this function returns the
     /// index of this table within the group. Otherwise it returns realm::npos.
@@ -594,13 +597,13 @@ private:
     {
         m_alloc.update_from_underlying_allocator(writable);
     }
-    Spec m_spec;            // 1st slot in m_top
-    ClusterTree m_clusters; // 3rd slot in m_top
+    Spec m_spec;                               // 1st slot in m_top
+    ClusterTree m_clusters;                    // 3rd slot in m_top
     std::unique_ptr<ClusterTree> m_tombstones; // 13th slot in m_top
-    TableKey m_key;     // 4th slot in m_top
-    Array m_index_refs; // 5th slot in m_top
-    Array m_opposite_table;  // 7th slot in m_top
-    Array m_opposite_column; // 8th slot in m_top
+    TableKey m_key;                            // 4th slot in m_top
+    Array m_index_refs;                        // 5th slot in m_top
+    Array m_opposite_table;                    // 7th slot in m_top
+    Array m_opposite_column;                   // 8th slot in m_top
     std::vector<StringIndex*> m_index_accessors;
     ColKey m_primary_key_col;
     Replication* const* m_repl;
@@ -1018,7 +1021,6 @@ inline void Table::bump_content_version() const noexcept
 {
     m_alloc.bump_content_version();
 }
-
 
 
 inline size_t Table::get_column_count() const noexcept

--- a/test/object-store/transaction_log_parsing.cpp
+++ b/test/object-store/transaction_log_parsing.cpp
@@ -57,7 +57,7 @@ public:
         _impl::CollectionChangeBuilder c;
         _impl::TransactionChangeInfo info{};
         info.tables[m_table_key.value];
-        info.lists.push_back({m_table_key, m_list.ConstLstBase::get_key().value, m_list.get_col_key().value, &c});
+        info.lists.push_back({m_table_key, m_list.CollectionBase::get_key().value, m_list.get_col_key().value, &c});
         _impl::transaction::advance(*m_group, info);
 
         if (info.lists.empty()) {

--- a/test/object-store/transaction_log_parsing.cpp
+++ b/test/object-store/transaction_log_parsing.cpp
@@ -30,7 +30,7 @@
 #include "object_schema.hpp"
 #include "schema.hpp"
 
-#include <realm/db.hpp>
+#include <realm.hpp>
 #include <realm/history.hpp>
 
 using namespace realm;

--- a/test/test_changeset_encoding.cpp
+++ b/test/test_changeset_encoding.cpp
@@ -94,15 +94,15 @@ TEST(ChangesetEncoding_CreateObject)
     CHECK(**changeset.begin() == instr);
 }
 
-TEST(ChangesetEncoding_Set_Field)
+TEST(ChangesetEncoding_Update_Field)
 {
     Changeset changeset;
-    Set instr;
+    sync::instr::Update instr;
     instr.table = changeset.intern_string("Foo");
     instr.object = PrimaryKey{123};
     instr.field = changeset.intern_string("bar");
     instr.is_default = true;
-    CHECK(!instr.is_array_set());
+    CHECK(!instr.is_array_update());
     changeset.push_back(instr);
 
     auto parsed = encode_then_parse(changeset);
@@ -110,10 +110,10 @@ TEST(ChangesetEncoding_Set_Field)
     CHECK(**changeset.begin() == instr);
 }
 
-TEST(ChangesetEncoding_Set_Deep)
+TEST(ChangesetEncoding_Update_Deep)
 {
     Changeset changeset;
-    Set instr;
+    sync::instr::Update instr;
     instr.table = changeset.intern_string("Foo");
     instr.object = PrimaryKey{123};
     instr.field = changeset.intern_string("bar");
@@ -121,7 +121,7 @@ TEST(ChangesetEncoding_Set_Deep)
     instr.path.push_back(changeset.intern_string("baz"));
     instr.path.push_back(changeset.intern_string("lol"));
     instr.path.push_back(changeset.intern_string("boo"));
-    CHECK(!instr.is_array_set());
+    CHECK(!instr.is_array_update());
     changeset.push_back(instr);
 
     auto parsed = encode_then_parse(changeset);
@@ -129,16 +129,16 @@ TEST(ChangesetEncoding_Set_Deep)
     CHECK(**changeset.begin() == instr);
 }
 
-TEST(ChangesetEncoding_Set_ArraySet)
+TEST(ChangesetEncoding_Update_ArrayUpdate)
 {
     Changeset changeset;
-    Set instr;
+    sync::instr::Update instr;
     instr.table = changeset.intern_string("Foo");
     instr.object = PrimaryKey{123};
     instr.field = changeset.intern_string("bar");
     instr.prior_size = 500;
     instr.path.push_back(123);
-    CHECK(instr.is_array_set());
+    CHECK(instr.is_array_update());
     CHECK_EQUAL(instr.index(), 123);
     changeset.push_back(instr);
 
@@ -147,10 +147,10 @@ TEST(ChangesetEncoding_Set_ArraySet)
     CHECK(**changeset.begin() == instr);
 }
 
-TEST(ChangesetEncoding_Set_ArraySet_Deep)
+TEST(ChangesetEncoding_Update_ArrayUpdate_Deep)
 {
     Changeset changeset;
-    Set instr;
+    sync::instr::Update instr;
     instr.table = changeset.intern_string("Foo");
     instr.object = PrimaryKey{123};
     instr.field = changeset.intern_string("bar");
@@ -159,7 +159,7 @@ TEST(ChangesetEncoding_Set_ArraySet_Deep)
     instr.path.push_back(changeset.intern_string("lol"));
     instr.path.push_back(changeset.intern_string("boo"));
     instr.path.push_back(123);
-    CHECK(instr.is_array_set());
+    CHECK(instr.is_array_update());
     CHECK_EQUAL(instr.index(), 123);
     changeset.push_back(instr);
 

--- a/test/test_compact_changesets.cpp
+++ b/test/test_compact_changesets.cpp
@@ -50,21 +50,21 @@ TEST_IF(CompactChangesets_RedundantSets, false)
 
     auto table = changeset.intern_string("Test");
 
-    Instruction::Set set1;
+    Instruction::Update set1;
     set1.table = table;
     set1.object = GlobalKey{1, 1};
     set1.field = changeset.intern_string("foo");
     set1.value = Instruction::Payload(int64_t(123));
     push(set1);
 
-    Instruction::Set set2;
+    Instruction::Update set2;
     set2.table = table;
     set2.object = GlobalKey{1, 1};
     set2.field = changeset.intern_string("foo");
     set2.value = Instruction::Payload(int64_t(345));
     push(set2);
 
-    Instruction::Set set3;
+    Instruction::Update set3;
     set3.table = table;
     set3.object = GlobalKey{1, 1};
     set3.field = changeset.intern_string("foo");
@@ -92,7 +92,7 @@ TEST_IF(CompactChangesets_DiscardsCreateErasePair, false)
     create_object.object = GlobalKey{1, 1};
     push(create_object);
 
-    Instruction::Set set;
+    Instruction::Update set;
     set.table = table;
     set.object = GlobalKey{1, 1};
     set.field = changeset.intern_string("foo");
@@ -126,7 +126,7 @@ TEST_IF(CompactChangesets_LinksRescueObjects, false)
     create_object.object = GlobalKey{1, 1};
     push(create_object);
 
-    Instruction::Set set;
+    Instruction::Update set;
     set.table = table;
     set.field = changeset.intern_string("foo");
     set.object = GlobalKey{1, 1};
@@ -221,7 +221,7 @@ TEST_IF(CompactChangesets_EraseRecreate, false)
     create_1.object = GlobalKey{1, 1};
     push(create_1);
 
-    Instruction::Set set_1;
+    Instruction::Update set_1;
     set_1.table = table;
     set_1.object = GlobalKey{1, 1};
     set_1.field = field;
@@ -238,7 +238,7 @@ TEST_IF(CompactChangesets_EraseRecreate, false)
     create_2.object = GlobalKey{1, 1};
     push(create_2);
 
-    Instruction::Set set_2;
+    Instruction::Update set_2;
     set_2.table = table;
     set_2.object = GlobalKey{1, 1};
     set_2.field = field;
@@ -269,7 +269,7 @@ TEST(CompactChangesets_PrimaryKeysRescueObjects)
     push(create_object);
 
 
-    Instruction::Set set;
+    Instruction::Update set;
     set.field = changeset.intern_string("foo");
     set.object = object_id_for_primary_key(123);
     set.payload = Instruction::Payload{int64_t(123)};
@@ -359,7 +359,7 @@ TEST_IF(CompactChangesets_Measure, false)
 
         auto set_foo_foo = [](B& builder, R& random, StringData& selected_table) {
             select_table("class_Foo", builder, selected_table);
-            Instruction::Set set;
+            Instruction::Update set;
             set.object = make_object_id(random);
             set.field = builder.intern_string("foo");
             set.payload = Instruction::Payload(random.draw_int<int64_t>(0, 10));
@@ -368,7 +368,7 @@ TEST_IF(CompactChangesets_Measure, false)
 
         auto set_foo_bar = [](B& builder, R& random, StringData& selected_table) {
             select_table("class_Foo", builder, selected_table);
-            Instruction::Set set;
+            Instruction::Update set;
             set.object = make_object_id(random);
             set.field = builder.intern_string("bar");
             set.payload = Instruction::Payload(builder.add_string_range(
@@ -380,7 +380,7 @@ TEST_IF(CompactChangesets_Measure, false)
 
         auto set_bar_foo = [](B& builder, R& random, StringData& selected_table) {
             select_table("class_Bar", builder, selected_table);
-            Instruction::Set set;
+            Instruction::Update set;
             set.object = make_object_id(random);
             set.field = builder.intern_string("foo");
             Instruction::Payload::Link link;
@@ -392,7 +392,7 @@ TEST_IF(CompactChangesets_Measure, false)
 
         auto set_bar_bar = [](B& builder, R& random, StringData& selected_table) {
             select_table("class_Bar", builder, selected_table);
-            Instruction::Set set;
+            Instruction::Update set;
             set.object = make_object_id(random);
             set.field = builder.intern_string("bar");
             set.payload = Instruction::Payload(random.draw_int<int64_t>(0, 10));

--- a/test/test_links.cpp
+++ b/test/test_links.cpp
@@ -781,7 +781,7 @@ TEST(Links_LinkList_Inserts)
     auto obj = origin->create_object();
     auto links = obj.get_linklist_ptr(col_link);
     auto links2 = obj.get_linklist_ptr(col_link);
-    auto k0 = links->ConstLstBase::get_key();
+    auto k0 = links->CollectionBase::get_key();
 
     CHECK_EQUAL(0, links->size());
     CHECK_EQUAL(0, links2->size());
@@ -832,7 +832,7 @@ TEST(Links_LinkList_Backlinks)
 
     Obj origin_obj = origin->create_object();
     auto links = origin_obj.get_linklist_ptr(col_link);
-    auto k0 = links->ConstLstBase::get_key();
+    auto k0 = links->CollectionBase::get_key();
 
     // add several links to a single linklist
     links->add(key2);
@@ -866,8 +866,8 @@ TEST(Links_LinkList_Backlinks)
     auto links2 = origin->create_object().get_linklist_ptr(col_link);
     links1->add(obj1.get_key());
     links2->add(obj0.get_key());
-    auto k1 = links1->ConstLstBase::get_key();
-    auto k2 = links2->ConstLstBase::get_key();
+    auto k1 = links1->CollectionBase::get_key();
+    auto k2 = links2->CollectionBase::get_key();
 
     // Verify backlinks
     CHECK_EQUAL(1, obj0.get_backlink_count(*origin, col_link));

--- a/test/test_sync.cpp
+++ b/test/test_sync.cpp
@@ -30,6 +30,7 @@
 #include <realm/sync/protocol.hpp>
 #include <realm/sync/client.hpp>
 #include <realm/sync/server.hpp>
+#include <realm/list.hpp>
 
 #include "sync_fixtures.hpp"
 

--- a/test/test_table.cpp
+++ b/test/test_table.cpp
@@ -3198,7 +3198,7 @@ TEST(Table_ListOps)
 TEST(Table_ListOfPrimitives)
 {
     Group g;
-    std::vector<ConstLstBase*> lists;
+    std::vector<CollectionBase*> lists;
     TableRef t = g.add_table("table");
     ColKey int_col = t->add_column_list(type_Int, "integers");
     ColKey bool_col = t->add_column_list(type_Bool, "booleans");

--- a/test/test_transactions.cpp
+++ b/test/test_transactions.cpp
@@ -30,6 +30,7 @@
 #include <realm/history.hpp>
 #include <realm/util/file.hpp>
 #include <realm/db.hpp>
+#include <realm/list.hpp>
 
 #include "util/crypt_key.hpp"
 #include "util/thread_wrapper.hpp"
@@ -39,8 +40,8 @@
 
 using namespace realm;
 using namespace realm::util;
-using test_util::unit_test::TestContext;
 using realm::test_util::crypt_key;
+using test_util::unit_test::TestContext;
 
 
 // Test independence and thread-safety
@@ -335,7 +336,7 @@ void verifier_thread_advance(TestContext& test_context, int limit, DBRef db, Tab
         done = (a >= limit);
     }
 }
-}
+} // namespace
 
 TEST(Transactions_Threaded)
 {
@@ -361,8 +362,12 @@ TEST(Transactions_Threaded)
     std::thread writers[num_threads];
     std::thread verifiers[num_threads];
     for (int i = 0; i < num_threads; ++i) {
-        verifiers[i] = std::thread([&] { verifier_thread(test_context, num_threads * num_iterations, db, tk); });
-        writers[i] = std::thread([&] { writer_thread(test_context, num_iterations, db, tk); });
+        verifiers[i] = std::thread([&] {
+            verifier_thread(test_context, num_threads * num_iterations, db, tk);
+        });
+        writers[i] = std::thread([&] {
+            writer_thread(test_context, num_iterations, db, tk);
+        });
     }
     for (int i = 0; i < num_threads; ++i) {
         writers[i].join();
@@ -394,9 +399,12 @@ TEST(Transactions_ThreadedAdvanceRead)
     std::thread writers[num_threads];
     std::thread verifiers[num_threads];
     for (int i = 0; i < num_threads; ++i) {
-        verifiers[i] =
-            std::thread([&] { verifier_thread_advance(test_context, num_threads * num_iterations, db, tk); });
-        writers[i] = std::thread([&] { writer_thread(test_context, num_iterations, db, tk); });
+        verifiers[i] = std::thread([&] {
+            verifier_thread_advance(test_context, num_threads * num_iterations, db, tk);
+        });
+        writers[i] = std::thread([&] {
+            writer_thread(test_context, num_iterations, db, tk);
+        });
     }
     for (int i = 0; i < num_threads; ++i) {
         writers[i].join();
@@ -435,7 +443,6 @@ TEST(Transactions_ListOfBinary)
         rt->verify();
     }
 }
-
 
 
 TEST(Transactions_RollbackCreateObject)

--- a/test/util/compare_groups.cpp
+++ b/test/util/compare_groups.cpp
@@ -6,6 +6,7 @@
 #include <realm/group.hpp>
 #include <realm/table.hpp>
 #include <realm/sync/object.hpp>
+#include <realm/list.hpp>
 
 #include "compare_groups.hpp"
 


### PR DESCRIPTION
As part of Set/Dictionary/Mixed, the following things were refactored:

- [x] `Instruction::Set` renamed to `Instruction::Update` (Sync; no protocol impact)
- [x] Base classes for lists refactored into generic `CollectionBase` and `Collection<T, ...>`. Also got rid of virtual inheritance.
- [x] Replication interface changed to use `Mixed` for all values, rather than specific methods for each value type (`set(Mixed)` rather than `set_int(...)`, `set_string(...)`, etc.).
- [x] Include order changed such that the replication interface can be called from headers (useful for templates such as `Lst<T>`). Specifically, `list.hpp` is no longer implicitly included by `obj.hpp`.
- [x] Clang-format of some files that seemed to have fallen through the cracks.