### PR TITLE
Deprecate Table::add_column_link()

### DIFF
--- a/src/realm/object-store/object_store.cpp
+++ b/src/realm/object-store/object_store.cpp
@@ -111,7 +111,12 @@ ColKey add_column(Group& group, Table& table, Property const& property)
         auto target_name = ObjectStore::table_name_for_object_type(property.object_type);
         TableRef link_table = group.get_table(target_name);
         REALM_ASSERT(link_table);
-        return table.add_column_link(is_array(property.type) ? type_LinkList : type_Link, property.name, *link_table);
+        if (is_array(property.type)) {
+            return table.add_column_list(*link_table, property.name);
+        }
+        else {
+            return table.add_column(*link_table, property.name);
+        }
     }
     else if (is_array(property.type)) {
         return table.add_column_list(to_core_type(property.type & ~PropertyType::Flags), property.name,

--- a/src/realm/sync/instruction_applier.cpp
+++ b/src/realm/sync/instruction_applier.cpp
@@ -455,8 +455,12 @@ void InstructionApplier::operator()(const Instruction::AddColumn& instr)
                 bad_transaction_log("AddColumn(Link) '%1.%2' to table '%3' which doesn't exist", table->get_name(),
                                     col_name, target_table_name);
             }
-            DataType type = instr.list ? type_LinkList : type_Link;
-            table->add_column_link(type, col_name, *target);
+            if (instr.list) {
+                table->add_column_list(*target, col_name);
+            }
+            else {
+                table->add_column(*target, col_name);
+            }
         }
         else {
             table->add_column(type_TypedLink, col_name);

--- a/src/realm/table.hpp
+++ b/src/realm/table.hpp
@@ -124,9 +124,13 @@ public:
     static const size_t max_column_name_length = 63;
     static const uint64_t max_num_columns = 0xFFFFUL; // <-- must be power of two -1
     ColKey add_column(DataType type, StringData name, bool nullable = false);
+    ColKey add_column(Table& target, StringData name);
     ColKey add_column_list(DataType type, StringData name, bool nullable = false);
+    ColKey add_column_list(Table& target, StringData name);
 
-    ColKey add_column_link(DataType type, StringData name, Table& target);
+    [[deprecated("Use add_column(Table&) or add_column_list(Table&) instead.")]] //
+    ColKey
+    add_column_link(DataType type, StringData name, Table& target);
 
     void remove_column(ColKey col_key);
     void rename_column(ColKey col_key, StringData new_name);

--- a/test/bench-sync/bench_transform.cpp
+++ b/test/bench-sync/bench_transform.cpp
@@ -165,7 +165,7 @@ void connected_objects(TestContext& test_context, BenchmarkResults& results)
         auto make_instructions = [](Peer& peer) {
             peer.start_transaction();
             TableRef t = sync::create_table_with_primary_key(*peer.group, "class_t", type_String, "pk");
-            auto col_key = t->add_column_link(type_Link, "l", *t);
+            auto col_key = t->add_column(*t, "l");
 
             // Everything links to this object!
             auto first_key = sync::create_object_with_primary_key(*peer.group, *t, "Hello").get_key();

--- a/test/benchmark-common-tasks/main.cpp
+++ b/test/benchmark-common-tasks/main.cpp
@@ -374,7 +374,7 @@ struct BenchmarkQueryStringOverLinks : BenchmarkWithStringsFewDup {
         TableRef t = tr.add_table("Links");
         id_col_ndx = t->add_column(type_Int, "id");
         TableRef strings = tr.get_table(name());
-        link_col_ndx = t->add_column_link(type_Link, "myLink", *strings);
+        link_col_ndx = t->add_column(*strings, "myLink");
         const size_t num_links = strings->size();
 
 #ifdef REALM_CLUSTER_IF
@@ -560,7 +560,7 @@ struct BenchmarkQueryTimestampGreaterOverLinks : BenchmarkQueryTimestampGreater 
         TableRef t = tr.add_table("Links");
         id_col_ndx = t->add_column(type_Int, "id");
         TableRef timestamps = tr.get_table(name());
-        link_col_ndx = t->add_column_link(type_Link, "myLink", *timestamps);
+        link_col_ndx = t->add_column(*timestamps, "myLink");
         const size_t num_timestamps = timestamps->size();
 #ifdef REALM_CLUSTER_IF
         auto target = timestamps->begin();
@@ -1594,7 +1594,7 @@ struct BenchmarkGetLinkList : Benchmark {
         std::string n = std::string(name()) + "_Destination";
         TableRef destination_table = tr.add_table(n);
         TableRef table = tr.add_table(name());
-        m_col_link = table->add_column_link(type_LinkList, "linklist", *destination_table);
+        m_col_link = table->add_column_list(*destination_table, "linklist");
 #ifdef REALM_CLUSTER_IF
         table->create_objects(rows, m_keys);
 #else

--- a/test/client/peer.cpp
+++ b/test/client/peer.cpp
@@ -515,7 +515,7 @@ void Peer::add_query(const std::string& class_name, const std::string& query)
         const std::string& matches_column_name = class_to_matches_column_name(class_name, buffer);
         ColKey col_ndx_matches = result_sets->get_column_key(matches_column_name);
         if (!col_ndx_matches) {
-            result_sets->add_column_link(type_LinkList, matches_column_name, *queryable);
+            result_sets->add_column_list(*queryable, matches_column_name);
         }
         else {
             if (result_sets->get_column_type(col_ndx_matches) != type_LinkList) {

--- a/test/fuzz_group.cpp
+++ b/test/fuzz_group.cpp
@@ -430,7 +430,7 @@ void parse_and_apply_instructions(std::string& in, const std::string& path, util
                     *log << "wt->get_table(" << table_key_1 << ")->add_column_link(type_Link, \"" << name
                          << "\", *wt->get_table(" << table_key_2 << "));";
                 }
-                auto col = t1->add_column_link(type_Link, name, *t2);
+                auto col = t1->add_column(*t2, name);
                 if (log) {
                     *log << " // -> " << col << "\n";
                 }
@@ -445,7 +445,7 @@ void parse_and_apply_instructions(std::string& in, const std::string& path, util
                     *log << "wt->get_table(" << table_key_1 << ")->add_column_link(type_LinkList, \"" << name
                          << "\", *wt->get_table(" << table_key_2 << "));";
                 }
-                auto col = t1->add_column_link(type_LinkList, name, *t2);
+                auto col = t1->add_column_list(*t2, name);
                 if (log) {
                     *log << " // -> " << col << "\n";
                 }

--- a/test/fuzz_tester.hpp
+++ b/test/fuzz_tester.hpp
@@ -327,11 +327,12 @@ private:
                       << "\", *client_" << client.local_file_ident << "->group->get_table(\"A\"));\n";
         }
 
-        ColKey col_key = table->add_column_link(type, name, *link_target_table);
         if (type == type_LinkList) {
+            ColKey col_key = table->add_column_list(*link_target_table, name);
             m_link_list_columns.push_back(col_key);
         }
         else {
+            ColKey col_key = table->add_column(*link_target_table, name);
             m_unstructured_columns.push_back(col_key);
         }
     }

--- a/test/object-store/migrations.cpp
+++ b/test/object-store/migrations.cpp
@@ -2133,7 +2133,7 @@ TEST_CASE("migration: Manual")
                           [&](SharedRealm, SharedRealm realm, Schema&) {
                               auto table = get_table(realm, "link origin");
                               table->remove_column(table->get_column_keys()[1]);
-                              table->add_column_link(type_Link, "object", *table);
+                              table->add_column(*table, "object");
                           });
     }
     SECTION("change linklist target")
@@ -2142,7 +2142,7 @@ TEST_CASE("migration: Manual")
                           [&](SharedRealm, SharedRealm realm, Schema&) {
                               auto table = get_table(realm, "link origin");
                               table->remove_column(table->get_column_keys()[2]);
-                              table->add_column_link(type_LinkList, "array", *table);
+                              table->add_column_list(*table, "array");
                           });
     }
     SECTION("make property optional")

--- a/test/object-store/schema.cpp
+++ b/test/object-store/schema.cpp
@@ -129,8 +129,8 @@ TEST_CASE("ObjectSchema")
         table->add_column(type_ObjectId, "object id");
         table->add_column(type_Decimal, "decimal");
 
-        table->add_column_link(type_Link, "object", *target);
-        table->add_column_link(type_LinkList, "array", *target);
+        table->add_column(*target, "object");
+        table->add_column_list(*target, "array");
 
         table->add_column(type_Int, "int?", true);
         table->add_column(type_Bool, "bool?", true);

--- a/test/sync_fixtures.hpp
+++ b/test/sync_fixtures.hpp
@@ -1192,7 +1192,7 @@ inline ObjKey add_partial_sync_subscription(Transaction& g, TableRef table, Stri
         std::stringstream ss;
         ss << "matches_" << table->get_name();
         std::string matches_col_name = ss.str();
-        matches_col = result_sets->add_column_link(type_LinkList, matches_col_name, *table);
+        matches_col = result_sets->add_column_list(*table, matches_col_name);
     }
 
     Obj result_set = result_sets->create_object();

--- a/test/test_client_reset_diff.cpp
+++ b/test/test_client_reset_diff.cpp
@@ -112,7 +112,7 @@ TEST(ClientResetDiff_TransferGroup)
 
         {
             TableRef table = create_table_with_primary_key(wt, "class_table_6", type_String, "pk_string");
-            auto col_ndx = table->add_column_link(type_LinkList, "target<ObjKey>", *table);
+            auto col_ndx = table->add_column_list(*table, "target<ObjKey>");
             table->add_column(type_Bool, "something");
 
             Obj obj_a = sync::create_object_with_primary_key(wt, *table, "aaa");
@@ -165,9 +165,9 @@ TEST(ClientResetDiff_TransferGroup)
         {
             TableRef table_3 = group.get_table("class_table_3");
             TableRef table_4 = group.get_table("class_table_4");
-            auto col_3 = table_3->add_column_link(type_LinkList, "target_link3", *table_4);
-            auto col_4 = table_4->add_column_link(type_LinkList, "target_link4", *table_3);
-            auto col_4a = table_4->add_column_link(type_LinkList, "target_link4a", *table_4);
+            auto col_3 = table_3->add_column_list(*table_4, "target_link3");
+            auto col_4 = table_4->add_column_list(*table_3, "target_link4");
+            auto col_4a = table_4->add_column_list(*table_4, "target_link4a");
 
             Obj obj_3 = sync::create_object_with_primary_key(wt, *table_3, 111);
             Obj obj_4 = sync::create_object_with_primary_key(wt, *table_4, StringData{"abc"});
@@ -199,7 +199,7 @@ TEST(ClientResetDiff_TransferGroup)
         {
             TableRef table = create_table_with_primary_key(wt, "class_table_6", type_String, "pk_string");
             table->add_column(type_Int, "something");
-            auto col_ndx = table->add_column_link(type_LinkList, "target_link", *table);
+            auto col_ndx = table->add_column_list(*table, "target_link");
 
             // Opposite order such that the row indices are different.
             Obj obj_f = sync::create_object_with_primary_key(wt, *table, "fff");
@@ -492,7 +492,7 @@ TEST(ClientResetDiff_FailedLocalRecovery)
         TableRef table_0 = create_table_with_primary_key(wt, "class_table_0", type_String, "pk_string");
         TableRef table_1 = create_table_with_primary_key(wt, "class_table_1", type_Int, "pk_int");
 
-        table_0->add_column_link(type_LinkList, "linklist", *table_1);
+        table_0->add_column_list(*table_1, "linklist");
 
         wt.commit();
     }
@@ -510,11 +510,11 @@ TEST(ClientResetDiff_FailedLocalRecovery)
         CHECK_EQUAL(table_2->get_column_count(), 1);
 
         TableRef table_3 = create_table_with_primary_key(wt, "class_table_3", type_String, "pk_string");
-        table_3->add_column_link(type_Link, "links", *table_0);
+        table_3->add_column(*table_0, "links");
         table_3->add_column_list(type_Int, "array_int");
 
         // The target table differs for the same column in remote and local.
-        table_0->add_column_link(type_LinkList, "linklist", *table_2);
+        table_0->add_column_list(*table_2, "linklist");
 
         create_object_with_primary_key(wt, *table_0, "aaa");
         CHECK_EQUAL(table_0->size(), 1);
@@ -578,7 +578,7 @@ TEST(ClientResetDiff_ClientVersion)
     auto create_schema_and_objects = [&](Transaction& wt) {
         TableRef table = create_table_with_primary_key(wt, "class_table", type_String, "pk_string");
         auto col_int = table->add_column(type_Int, "int");
-        auto col_ll = table->add_column_link(type_LinkList, "linklist", *table);
+        auto col_ll = table->add_column_list(*table, "linklist");
         table->add_column_list(type_String, "array");
 
         Obj obj_a = create_object_with_primary_key(wt, *table, "aaa").set(col_int, 100);
@@ -955,7 +955,7 @@ TEST(ClientResetDiff_NonSyncTables)
         WriteTransaction wt{sg};
 
         TableRef table = create_table_with_primary_key(wt, "class_table", type_String, "pk_string");
-        auto col_ndx = table->add_column_link(type_Link, "link", *table);
+        auto col_ndx = table->add_column(*table, "link");
 
         Obj obj_a = sync::create_object_with_primary_key(wt, *table, "aaa");
         Obj obj_b = sync::create_object_with_primary_key(wt, *table, "bbb");
@@ -1055,18 +1055,18 @@ TEST(ClientResetDiff_Links)
         TableRef table_1 = create_table_with_primary_key(wt, "class_table_1", type_String, "pk_string");
         TableRef table_2 = create_table_with_primary_key(wt, "class_table_2", type_Int, "pk_int");
 
-        auto col_link_00 = table_0->add_column_link(type_Link, "link_0", *table_0);
-        auto col_link_01 = table_0->add_column_link(type_Link, "link_1", *table_1);
-        auto col_link_02 = table_0->add_column_link(type_Link, "link_2", *table_2);
+        auto col_link_00 = table_0->add_column(*table_0, "link_0");
+        auto col_link_01 = table_0->add_column(*table_1, "link_1");
+        auto col_link_02 = table_0->add_column(*table_2, "link_2");
         auto col_str_0 = table_0->add_column(type_String, "string");
 
-        auto col_link_10 = table_1->add_column_link(type_Link, "link_0", *table_0);
-        auto col_link_11 = table_1->add_column_link(type_Link, "link_1", *table_1);
-        auto col_link_12 = table_1->add_column_link(type_Link, "link_2", *table_2);
+        auto col_link_10 = table_1->add_column(*table_0, "link_0");
+        auto col_link_11 = table_1->add_column(*table_1, "link_1");
+        auto col_link_12 = table_1->add_column(*table_2, "link_2");
 
-        auto col_link_20 = table_2->add_column_link(type_Link, "link_0", *table_0);
-        auto col_link_21 = table_2->add_column_link(type_Link, "link_1", *table_1);
-        auto col_link_22 = table_2->add_column_link(type_Link, "link_2", *table_2);
+        auto col_link_20 = table_2->add_column(*table_0, "link_0");
+        auto col_link_21 = table_2->add_column(*table_1, "link_1");
+        auto col_link_22 = table_2->add_column(*table_2, "link_2");
 
         Obj remote_0 = create_object(wt, *table_0).set(col_str_0, "remote_0");
         Obj remote_1 = create_object(wt, *table_0).set(col_str_0, "remote_1");
@@ -1129,18 +1129,18 @@ TEST(ClientResetDiff_Links)
         TableRef table_2 = create_table_with_primary_key(wt, "class_table_2", type_Int, "pk_int");
 
         // Same columns in different order.
-        auto col_link_01 = table_0->add_column_link(type_Link, "link_1", *table_1);
-        auto col_link_00 = table_0->add_column_link(type_Link, "link_0", *table_0);
+        auto col_link_01 = table_0->add_column(*table_1, "link_1");
+        auto col_link_00 = table_0->add_column(*table_0, "link_0");
         auto col_str_0 = table_0->add_column(type_String, "string");
-        auto col_link_02 = table_0->add_column_link(type_Link, "link_2", *table_2);
+        auto col_link_02 = table_0->add_column(*table_2, "link_2");
 
-        auto col_link_11 = table_1->add_column_link(type_Link, "link_1", *table_1);
-        auto col_link_12 = table_1->add_column_link(type_Link, "link_2", *table_2);
-        auto col_link_10 = table_1->add_column_link(type_Link, "link_0", *table_0);
+        auto col_link_11 = table_1->add_column(*table_1, "link_1");
+        auto col_link_12 = table_1->add_column(*table_2, "link_2");
+        auto col_link_10 = table_1->add_column(*table_0, "link_0");
 
-        auto col_link_22 = table_2->add_column_link(type_Link, "link_2", *table_2);
-        auto col_link_21 = table_2->add_column_link(type_Link, "link_1", *table_1);
-        auto col_link_20 = table_2->add_column_link(type_Link, "link_0", *table_0);
+        auto col_link_22 = table_2->add_column(*table_2, "link_2");
+        auto col_link_21 = table_2->add_column(*table_1, "link_1");
+        auto col_link_20 = table_2->add_column(*table_0, "link_0");
 
         // Objects.
         Obj local_0 = create_object(wt, *table_0).set(col_str_0, "local_0");

--- a/test/test_client_reset_query_based.cpp
+++ b/test/test_client_reset_query_based.cpp
@@ -83,7 +83,7 @@ TEST_IF(ClientResetQueryBased_1, false)
                 CHECK(col_key_query);
                 CHECK(col_key_matches_property);
                 CHECK(col_key_status);
-                result_sets->add_column_link(type_LinkList, "values", *table);
+                result_sets->add_column_list(*table, "values");
                 Obj res = create_object(wt, *result_sets);
                 res.set(col_key_matches_property, "values");
                 res.set(col_key_query, "value = 1100");

--- a/test/test_embedded_objects.cpp
+++ b/test/test_embedded_objects.cpp
@@ -19,7 +19,7 @@ TEST(EmbeddedObjects_Basic)
     client_1->create_schema([](WriteTransaction& tr) {
         TableRef top = sync::create_table_with_primary_key(tr, "class_Top", type_Int, "pk");
         TableRef sub = tr.add_embedded_table("class_Sub");
-        top->add_column_link(type_Link, "sub", *sub);
+        top->add_column(*sub, "sub");
         sub->add_column(type_Int, "i");
     });
 
@@ -50,7 +50,7 @@ TEST(EmbeddedObjects_ArrayOfObjects)
     client_1->create_schema([](WriteTransaction& tr) {
         TableRef top = sync::create_table_with_primary_key(tr, "class_Top", type_Int, "pk");
         TableRef sub = tr.add_embedded_table("class_Sub");
-        top->add_column_link(type_LinkList, "sub", *sub);
+        top->add_column_list(*sub, "sub");
         sub->add_column(type_Int, "i");
     });
 
@@ -84,8 +84,8 @@ TEST(EmbeddedObjects_NestedArray)
     client_1->create_schema([](WriteTransaction& tr) {
         TableRef threads = sync::create_table_with_primary_key(tr, "class_ForumThread", type_Int, "pk");
         TableRef comments = tr.add_embedded_table("class_Comment");
-        threads->add_column_link(type_LinkList, "comments", *comments);
-        comments->add_column_link(type_LinkList, "replies", *comments);
+        threads->add_column_list(*comments, "comments");
+        comments->add_column_list(*comments, "replies");
         comments->add_column(type_Int, "message");
     });
 
@@ -144,7 +144,7 @@ TEST(EmbeddedObjects_ImplicitErase)
         client_1->create_schema([](WriteTransaction& tr) {
             TableRef top = sync::create_table_with_primary_key(tr, "class_Top", type_Int, "pk");
             TableRef sub = tr.add_embedded_table("class_Sub");
-            top->add_column_link(type_Link, "sub", *sub);
+            top->add_column(*sub, "sub");
             sub->add_column(type_Int, "i");
         });
 
@@ -194,7 +194,7 @@ TEST(EmbeddedObjects_SetDefaultNullIgnored)
         client_1->create_schema([](WriteTransaction& tr) {
             TableRef top = sync::create_table_with_primary_key(tr, "class_Top", type_Int, "pk");
             TableRef sub = tr.add_embedded_table("class_Sub");
-            top->add_column_link(type_Link, "sub", *sub);
+            top->add_column(*sub, "sub");
             sub->add_column(type_Int, "i");
         });
 
@@ -245,7 +245,7 @@ TEST(EmbeddedObjects_DiscardThroughImplicitErase)
         client_1->create_schema([](WriteTransaction& tr) {
             TableRef top = sync::create_table_with_primary_key(tr, "class_Top", type_Int, "pk");
             TableRef sub = tr.add_embedded_table("class_Sub");
-            top->add_column_link(type_Link, "sub", *sub);
+            top->add_column(*sub, "sub");
             sub->add_column(type_Int, "i");
 
             auto top_obj = top->create_object_with_primary_key(123);
@@ -294,8 +294,8 @@ TEST(EmbeddedObjects_AdjustPathOnInsert)
     client_1->create_schema([](WriteTransaction& tr) {
         TableRef top = sync::create_table_with_primary_key(tr, "class_Top", type_Int, "pk");
         TableRef sub = tr.add_embedded_table("class_Sub");
-        top->add_column_link(type_LinkList, "sub", *sub);
-        sub->add_column_link(type_LinkList, "sub", *sub);
+        top->add_column_list(*sub, "sub");
+        sub->add_column_list(*sub, "sub");
         sub->add_column(type_Int, "i");
 
         auto top_obj = top->create_object_with_primary_key(123);
@@ -368,8 +368,8 @@ TEST(EmbeddedObjects_AdjustPathOnErase)
     client_1->create_schema([](WriteTransaction& tr) {
         TableRef top = sync::create_table_with_primary_key(tr, "class_Top", type_Int, "pk");
         TableRef sub = tr.add_embedded_table("class_Sub");
-        top->add_column_link(type_LinkList, "sub", *sub);
-        sub->add_column_link(type_LinkList, "sub", *sub);
+        top->add_column_list(*sub, "sub");
+        sub->add_column_list(*sub, "sub");
         sub->add_column(type_Int, "i");
 
         auto top_obj = top->create_object_with_primary_key(123);
@@ -447,7 +447,7 @@ TEST(EmbeddedObjects_CreateEraseCreateSequencePreservesObject)
             auto table = sync::create_table_with_primary_key(tr, "class_table", type_Int, "pk");
             auto embedded = tr.add_embedded_table("class_embedded");
             embedded->add_column(type_Int, "int");
-            table->add_column_link(type_Link, "embedded", *embedded);
+            table->add_column(*embedded, "embedded");
             auto obj = table->create_object_with_primary_key(123);
             // Note: embedded object is NULL at this stage.
         });
@@ -514,8 +514,8 @@ TEST(EmbeddedObjects_CreateEraseCreateSequencePreservesObject_Nested)
             auto table = sync::create_table_with_primary_key(tr, "class_table", type_Int, "pk");
             auto embedded = tr.add_embedded_table("class_embedded");
             embedded->add_column(type_Int, "int");
-            embedded->add_column_link(type_Link, "embedded", *embedded);
-            table->add_column_link(type_Link, "embedded", *embedded);
+            embedded->add_column(*embedded, "embedded");
+            table->add_column(*embedded, "embedded");
             auto obj = table->create_object_with_primary_key(123);
             // Note: embedded object is NULL at this stage.
         });

--- a/test/test_encrypt_transform.cpp
+++ b/test/test_encrypt_transform.cpp
@@ -188,7 +188,7 @@ TEST_IF(EncryptTransform_ServerHistory, false)
             col_ndx_result_set_query = result_sets->get_column_key("query");
             col_ndx_result_set_matches_property = result_sets->get_column_key("matches_property");
             // 0 = uninitialized, 1 = initialized, -1 = query parsing failed
-            result_sets->add_column_link(type_LinkList, "people", *people);
+            result_sets->add_column_list(*people, "people");
             Obj res = result_sets->create_object();
             res.set(col_ndx_result_set_query, "age < 10");
             res.set(col_ndx_result_set_matches_property, "people");

--- a/test/test_group.cpp
+++ b/test/test_group.cpp
@@ -400,7 +400,7 @@ TEST(Group_AddTableWithLinks)
     TableRef a = group.add_table("a");
     TableRef b = group.add_table("b");
     auto c0 = a->add_column(type_Int, "foo");
-    auto c1 = b->add_column_link(type_Link, "bar", *a);
+    auto c1 = b->add_column(*a, "bar");
 
     auto a_key = a->get_key();
     CHECK_EQUAL(b->get_opposite_table_key(c1), a_key);
@@ -576,10 +576,10 @@ TEST(Group_RemoveTableWithColumns)
     CHECK_EQUAL(5, group.size());
 
     alpha->add_column(type_Int, "alpha-1");
-    auto col_link = beta->add_column_link(type_Link, "beta-1", *delta);
-    gamma->add_column_link(type_Link, "gamma-1", *gamma);
+    auto col_link = beta->add_column(*delta, "beta-1");
+    gamma->add_column(*gamma, "gamma-1");
     delta->add_column(type_Int, "delta-1");
-    epsilon->add_column_link(type_Link, "epsilon-1", *delta);
+    epsilon->add_column(*delta, "epsilon-1");
 
     Obj obj = delta->create_object();
     ObjKey k = obj.get_key();
@@ -636,13 +636,13 @@ TEST(Group_RemoveTableMovesTableWithLinksOver)
     TableRef third = group.add_table("gamma");
     TableRef fourth = group.add_table("delta");
 
-    auto one = first->add_column_link(type_Link, "one", *third);
+    auto one = first->add_column(*third, "one");
 
-    auto two = third->add_column_link(type_Link, "two", *fourth);
-    auto three = third->add_column_link(type_Link, "three", *third);
+    auto two = third->add_column(*fourth, "two");
+    auto three = third->add_column(*third, "three");
 
-    auto four = fourth->add_column_link(type_Link, "four", *first);
-    auto five = fourth->add_column_link(type_Link, "five", *third);
+    auto four = fourth->add_column(*first, "four");
+    auto five = fourth->add_column(*third, "five");
 
     std::vector<ObjKey> first_keys;
     std::vector<ObjKey> third_keys;
@@ -728,14 +728,14 @@ TEST(Group_RemoveLinkTable)
 {
     Group group;
     TableRef table = group.add_table("table");
-    table->add_column_link(type_Link, "link", *table);
+    table->add_column(*table, "link");
     group.remove_table(table->get_key());
     CHECK(group.is_empty());
     CHECK(!table);
     TableRef origin = group.add_table("origin");
     TableRef target = group.add_table("target");
     target->add_column(type_Int, "int");
-    origin->add_column_link(type_Link, "link", *target);
+    origin->add_column(*target, "link");
     CHECK_THROW(group.remove_table(target->get_key()), CrossTableLinkTarget);
     group.remove_table(origin->get_key());
     CHECK_EQUAL(1, group.size());
@@ -1310,7 +1310,7 @@ TEST(Group_CommitLinkListChange)
     Group group(path, crypt_key(), Group::mode_ReadWrite);
     TableRef origin = group.add_table("origin");
     TableRef target = group.add_table("target");
-    auto col_link = origin->add_column_link(type_LinkList, "links", *target);
+    auto col_link = origin->add_column_list(*target, "links");
     target->add_column(type_Int, "integers");
     auto k = target->create_object().get_key();
     origin->create_object().get_linklist(col_link).add(k);
@@ -1353,8 +1353,8 @@ TEST(Group_CascadeNotify_SimpleWeak)
     TableRef t = g.add_table("target");
     t->add_column(type_Int, "int");
     TableRef origin = g.add_table("origin");
-    auto col_link = origin->add_column_link(type_Link, "link", *t);
-    auto col_link_list = origin->add_column_link(type_LinkList, "linklist", *t);
+    auto col_link = origin->add_column(*t, "link");
+    auto col_link_list = origin->add_column_list(*t, "linklist");
 
     std::vector<ObjKey> t_keys;
     t->create_objects(100, t_keys);
@@ -1452,8 +1452,8 @@ TEST(Group_CascadeNotify_TableClearWeak)
     TableRef t = g.add_table("target");
     t->add_column(type_Int, "int");
     TableRef origin = g.add_table("origin");
-    auto col_link = origin->add_column_link(type_Link, "link", *t);
-    auto col_link_list = origin->add_column_link(type_LinkList, "linklist", *t);
+    auto col_link = origin->add_column(*t, "link");
+    auto col_link_list = origin->add_column_list(*t, "linklist");
 
     std::vector<ObjKey> t_keys, o_keys;
     t->create_objects(10, t_keys);
@@ -1511,8 +1511,8 @@ TEST(Group_CascadeNotify_TableViewClearWeak)
     TableRef t = g.add_table("target");
     t->add_column(type_Int, "int");
     TableRef origin = g.add_table("origin");
-    auto col_link = origin->add_column_link(type_Link, "link", *t);
-    auto col_link_list = origin->add_column_link(type_LinkList, "linklist", *t);
+    auto col_link = origin->add_column(*t, "link");
+    auto col_link_list = origin->add_column_list(*t, "linklist");
 
     std::vector<ObjKey> t_keys, o_keys;
     t->create_objects(10, t_keys);
@@ -1574,9 +1574,9 @@ TEST(Group_CascadeNotify_TreeCascade)
     Group g(path, 0, Group::mode_ReadWrite);
     TableRef t = g.add_embedded_table("table");
     TableRef parent = g.add_table("parent");
-    auto left = t->add_column_link(type_Link, "left", *t);
-    auto right = t->add_column_link(type_Link, "right", *t);
-    auto col = parent->add_column_link(type_Link, "root", *t);
+    auto left = t->add_column(*t, "left");
+    auto right = t->add_column(*t, "right");
+    auto col = parent->add_column(*t, "root");
     auto outer_root = parent->create_object();
     auto root = outer_root.create_and_set_linked_object(col);
     make_tree(*t, root, left, right, 0);
@@ -1602,7 +1602,7 @@ TEST(Group_ChangeEmbeddedness)
     Group g;
     TableRef t = g.add_table("table");
     TableRef parent = g.add_table("parent");
-    auto col = parent->add_column_link(type_Link, "child", *t);
+    auto col = parent->add_column(*t, "child");
     auto p1 = parent->create_object();
     auto p2 = parent->create_object();
     auto p3 = parent->create_object();
@@ -1792,8 +1792,8 @@ TEST(Group_RemoveRecursive)
     TableKey target_key = target->get_key();
 
     target->add_column(type_Int, "integers", true);
-    auto link_col_t = target->add_column_link(type_Link, "links", *target);
-    auto link_col_o = origin->add_column_link(type_Link, "links", *target);
+    auto link_col_t = target->add_column(*target, "links");
+    auto link_col_o = origin->add_column(*target, "links");
 
     // Delete one at a time
     ObjKey key_target = target->create_object().get_key();
@@ -1903,8 +1903,8 @@ TEST(Group_StringPrimaryKeyCol)
     g.validate_primary_columns();
 
     auto table1 = g.add_table("class_bar");
-    auto col_link = table1->add_column_link(type_Link, "link", *table);
-    auto col_linklist = table1->add_column_link(type_LinkList, "linklist", *table);
+    auto col_link = table1->add_column(*table, "link");
+    auto col_linklist = table1->add_column_list(*table, "linklist");
     Obj origin_obj = table1->create_object();
     origin_obj.set(col_link, k);
     auto ll = origin_obj.get_linklist(col_linklist);

--- a/test/test_index_string.cpp
+++ b/test/test_index_string.cpp
@@ -256,8 +256,8 @@ TEST(StringIndex_NonIndexable)
     Group group;
     TableRef table = group.add_table("table");
     TableRef target_table = group.add_table("target");
-    table->add_column_link(type_Link, "link", *target_table);
-    table->add_column_link(type_LinkList, "linkList", *target_table);
+    table->add_column(*target_table, "link");
+    table->add_column_list(*target_table, "linkList");
     table->add_column(type_Double, "double");
     table->add_column(type_Float, "float");
     table->add_column(type_Binary, "binary");

--- a/test/test_instruction_replication.cpp
+++ b/test/test_instruction_replication.cpp
@@ -212,7 +212,7 @@ TEST(InstructionReplication_CreateEmbedded)
         TableRef car = sync::create_table_with_primary_key(wt, "class_Car", type_String, "id", false);
         auto wheel = wt.add_embedded_table("class_Wheel");
         auto col_position = wheel->add_column(type_String, "position");
-        auto col_wheels = car->add_column_link(type_LinkList, "wheels", *wheel);
+        auto col_wheels = car->add_column_list(*wheel, "wheels");
         Obj volvo = car->create_object_with_primary_key("Volvo");
 
         auto list = volvo.get_linklist(col_wheels);
@@ -269,7 +269,7 @@ TEST(InstructionReplication_EraseObject)
         TableRef foo = wt.get_or_add_table("class_foo");
         ColKey col_ndx = foo->add_column(type_Int, "i");
         TableRef bar = wt.get_or_add_table("class_bar");
-        ColKey col_link = bar->add_column_link(type_Link, "link", *foo);
+        ColKey col_link = bar->add_column(*foo, "link");
 
         Obj obj = foo->create_object().set(col_ndx, 123);
         // Create link to object soon to be deleted
@@ -301,8 +301,8 @@ TEST(InstructionReplication_InvalidateObject)
         TableRef foo = wt.get_or_add_table("class_foo");
         ColKey col_ndx = foo->add_column(type_Int, "i");
         TableRef bar = wt.get_or_add_table("class_bar");
-        ColKey col_link = bar->add_column_link(type_Link, "link", *foo);
-        ColKey col_linklist = bar->add_column_link(type_LinkList, "linklist", *foo);
+        ColKey col_link = bar->add_column(*foo, "link");
+        ColKey col_linklist = bar->add_column_list(*foo, "linklist");
 
         Obj obj = foo->create_object().set(col_ndx, 123);
         // Create link to object soon to be deleted
@@ -338,7 +338,7 @@ TEST(InstructionReplication_SetLink)
         TableRef foo = sync::create_table(wt, "class_foo");
         TableRef bar = sync::create_table(wt, "class_bar");
         ColKey foo_i = foo->add_column(type_Int, "i");
-        ColKey bar_l = bar->add_column_link(type_Link, "l", *foo);
+        ColKey bar_l = bar->add_column(*foo, "l");
 
         auto foo_1 = foo->create_object().set(foo_i, 123).get_key();
         auto foo_2 = foo->create_object().set(foo_i, 456).get_key();
@@ -433,7 +433,7 @@ TEST(InstructionReplication_LinkLists)
         TableRef foo = sync::create_table(wt, "class_foo");
         TableRef bar = sync::create_table(wt, "class_bar");
         ColKey foo_i = foo->add_column(type_Int, "i");
-        ColKey bar_ll = bar->add_column_link(type_LinkList, "ll", *foo);
+        ColKey bar_ll = bar->add_column_list(*foo, "ll");
 
         ObjKey foo_1 = foo->create_object().set(foo_i, 123).get_key();
         ObjKey foo_2 = foo->create_object().set(foo_i, 456).get_key();

--- a/test/test_json.cpp
+++ b/test/test_json.cpp
@@ -252,8 +252,8 @@ TEST(Json_LinkList1)
     table3->create_object().set_all(800, "test");
     auto k32 = table3->create_object().set_all(900, "hi").get_key();
 
-    ColKey col_link2 = table1->add_column_link(type_LinkList, "linkA", *table2);
-    ColKey col_link3 = table1->add_column_link(type_LinkList, "linkB", *table3);
+    ColKey col_link2 = table1->add_column_list(*table2, "linkA");
+    ColKey col_link3 = table1->add_column_list(*table3, "linkB");
 
     // set some links
     auto ll0 = obj0.get_linklist(col_link2); // Links to table 2
@@ -316,8 +316,8 @@ TEST(Json_LinkListCycle)
 
     auto t20 = table2->create_object().set_all("foo");
 
-    auto col_link1 = table1->add_column_link(type_LinkList, "linkA", *table2);
-    auto col_link2 = table2->add_column_link(type_LinkList, "linkB", *table1);
+    auto col_link1 = table1->add_column_list(*table2, "linkA");
+    auto col_link2 = table2->add_column_list(*table1, "linkB");
 
     // set some links
     auto links1 = t10.get_linklist(col_link1);
@@ -372,8 +372,8 @@ TEST(Json_LinkCycles)
 
     auto t20 = table2->create_object().set_all("foo");
 
-    ColKey col_link1 = table1->add_column_link(type_Link, "linkA", *table2);
-    ColKey col_link2 = table2->add_column_link(type_Link, "linkB", *table1);
+    ColKey col_link1 = table1->add_column(*table2, "linkA");
+    ColKey col_link2 = table2->add_column(*table1, "linkB");
 
     // set some links
     table1->begin()->set(col_link1, t20.get_key());

--- a/test/test_lang_bind_helper.cpp
+++ b/test/test_lang_bind_helper.cpp
@@ -508,7 +508,7 @@ TEST(LangBindHelper_AdvanceReadTransact_Basics)
         foo_w->add_column(type_Timestamp, "t");
         foo_w->add_column(type_Decimal, "dec");
         foo_w->add_column(type_ObjectId, "oid");
-        foo_w->add_column_link(type_Link, "link", *foo_w);
+        foo_w->add_column(*foo_w, "link");
         cols = foo_w->get_column_keys();
         auto obj1 = foo_w->create_object();
         auto obj0 = foo_w->get_object(k0);
@@ -908,7 +908,7 @@ TEST(LangBindHelper_AdvanceReadTransact_LinkColumnInNewTable)
         WriteTransaction wt(sg_w);
         TableRef a_w = wt.get_table("a");
         TableRef b_w = wt.get_or_add_table("b");
-        b_w->add_column_link(type_Link, "foo", *a_w);
+        b_w->add_column(*a_w, "foo");
         wt.commit();
     }
 
@@ -1086,7 +1086,7 @@ TEST(LangBindHelper_AdvanceReadTransact_LinkView)
         TableRef origin = wt.add_table("origin");
         TableRef target = wt.add_table("target");
         target->add_column(type_Int, "value");
-        auto col = origin->add_column_link(type_LinkList, "list", *target);
+        auto col = origin->add_column_list(*target, "list");
         // origin->add_search_index(0);
         std::vector<ObjKey> keys;
         target->create_objects(10, keys);
@@ -1242,7 +1242,7 @@ TEST(LangBindHelper_ConcurrentLinkViewDeletes)
         WriteTransaction wt(sg);
         TableRef origin = wt.add_table("origin");
         TableRef target = wt.add_table("target");
-        ck = origin->add_column_link(type_LinkList, "ll", *target);
+        ck = origin->add_column_list(*target, "ll");
         origin->create_objects(table_size, o_keys);
         target->create_objects(table_size, t_keys);
         wt.commit();
@@ -1293,7 +1293,7 @@ TEST(LangBindHelper_AdvanceReadTransact_InsertLink)
         WriteTransaction wt(sg);
         TableRef origin_w = wt.add_table("origin");
         TableRef target_w = wt.add_table("target");
-        col = origin_w->add_column_link(type_Link, "", *target_w);
+        col = origin_w->add_column(*target_w, "");
         target_w->add_column(type_Int, "");
         target_key = target_w->create_object().get_key();
         wt.commit();
@@ -1334,7 +1334,7 @@ TEST(LangBindHelper_AdvanceReadTransact_LinkToNeighbour)
         WriteTransaction wt(sg);
         TableRef table = wt.add_table("table");
         table->add_column(type_Int, "integers");
-        col = table->add_column_link(type_Link, "links", *table);
+        col = table->add_column(*table, "links");
         table->create_objects(10, keys);
         wt.commit();
     }
@@ -1371,10 +1371,10 @@ TEST(LangBindHelper_AdvanceReadTransact_RemoveTableWithColumns)
         TableRef delta_w = wt.add_table("delta");
         TableRef epsilon_w = wt.add_table("epsilon");
         alpha_w->add_column(type_Int, "alpha-1");
-        beta_w->add_column_link(type_Link, "beta-1", *delta_w);
-        gamma_w->add_column_link(type_Link, "gamma-1", *gamma_w);
+        beta_w->add_column(*delta_w, "beta-1");
+        gamma_w->add_column(*gamma_w, "gamma-1");
         delta_w->add_column(type_Int, "delta-1");
-        epsilon_w->add_column_link(type_Link, "epsilon-1", *delta_w);
+        epsilon_w->add_column(*delta_w, "epsilon-1");
         wt.commit();
     }
     rt->advance_read();
@@ -1461,7 +1461,7 @@ TEST(LangBindHelper_AdvanceReadTransact_CascadeRemove_ColumnLink)
         WriteTransaction wt(sg);
         auto origin = wt.add_table("origin");
         auto target = wt.add_embedded_table("target");
-        col = origin->add_column_link(type_Link, "o_1", *target);
+        col = origin->add_column(*target, "o_1");
         target->add_column(type_Int, "t_1");
         wt.commit();
     }
@@ -1546,7 +1546,7 @@ TEST(LangBindHelper_AdvanceReadTransact_CascadeRemove_ColumnLinkList)
         WriteTransaction wt(sg);
         auto origin = wt.add_table("origin");
         auto target = wt.add_embedded_table("target");
-        col = origin->add_column_link(type_LinkList, "o_1", *target);
+        col = origin->add_column_list(*target, "o_1");
         target->add_column(type_Int, "t_1");
         wt.commit();
     }
@@ -2067,8 +2067,8 @@ TEST_TYPES(LangBindHelper_AdvanceReadTransact_TransactLog, AdvanceReadTransact, 
         // Add a table with some links
         WriteTransaction wt(sg);
         TableRef table = wt.add_table("link origin");
-        c2 = table->add_column_link(type_Link, "link", *wt.get_table("table 1"));
-        c3 = table->add_column_link(type_LinkList, "linklist", *wt.get_table("table 2"));
+        c2 = table->add_column(*wt.get_table("table 1"), "link");
+        c3 = table->add_column_list(*wt.get_table("table 2"), "linklist");
         Obj o = table->create_object();
         o.set(c2, o.get_key());
         o.get_linklist(c3).add(o.get_key());
@@ -2357,8 +2357,8 @@ TEST(LangBindHelper_RollbackCircularReferenceRemoval)
         group->promote_to_write();
         TableRef alpha = group->get_or_add_table("alpha");
         TableRef beta = group->get_or_add_table("beta");
-        ca = alpha->add_column_link(type_Link, "beta-1", *beta);
-        cb = beta->add_column_link(type_Link, "alpha-1", *alpha);
+        ca = alpha->add_column(*beta, "beta-1");
+        cb = beta->add_column(*alpha, "alpha-1");
         group->commit_and_continue_as_read();
     }
     group->verify();
@@ -2430,9 +2430,9 @@ TEST(LangBindHelper_TableLinkingRemovalIssue)
         TableRef t2 = group->get_or_add_table("t2");
         TableRef t3 = group->get_or_add_table("t3");
         TableRef t4 = group->get_or_add_table("t4");
-        t1->add_column_link(type_Link, "l12", *t2);
-        t2->add_column_link(type_Link, "l23", *t3);
-        t3->add_column_link(type_Link, "l34", *t4);
+        t1->add_column(*t2, "l12");
+        t2->add_column(*t3, "l23");
+        t3->add_column(*t4, "l34");
         group->commit_and_continue_as_read();
     }
     group->verify();
@@ -2463,7 +2463,7 @@ TEST(LangBindHelper_RollbackTableRemove)
         group->promote_to_write();
         TableRef alpha = group->get_or_add_table("alpha");
         TableRef beta = group->get_or_add_table("beta");
-        beta->add_column_link(type_Link, "alpha-1", *alpha);
+        beta->add_column(*alpha, "alpha-1");
         group->commit_and_continue_as_read();
     }
     group->verify();
@@ -2494,8 +2494,8 @@ TEST(LangBindHelper_RollbackTableRemove2)
         TableRef b = group->get_or_add_table("b");
         TableRef c = group->get_or_add_table("c");
         TableRef d = group->get_or_add_table("d");
-        c->add_column_link(type_Link, "a", *a);
-        d->add_column_link(type_Link, "b", *b);
+        c->add_column(*a, "a");
+        d->add_column(*b, "b");
         group->commit_and_continue_as_read();
     }
     group->verify();
@@ -2553,7 +2553,7 @@ TEST(LangBindHelper_RollbackAndContinueAsReadLinkColumnRemove)
         group->promote_to_write();
         t = group->get_or_add_table("a_table");
         t2 = group->get_or_add_table("b_table");
-        col = t->add_column_link(type_Link, "bruno", *t2);
+        col = t->add_column(*t2, "bruno");
         CHECK_EQUAL(1, t->get_column_count());
         group->commit_and_continue_as_read();
     }
@@ -2609,7 +2609,7 @@ TEST(LangBindHelper_RollbackAndContinueAsReadLinkList)
     group->promote_to_write();
     TableRef origin = group->add_table("origin");
     TableRef target = group->add_table("target");
-    auto col0 = origin->add_column_link(type_LinkList, "", *target);
+    auto col0 = origin->add_column_list(*target, "");
     target->add_column(type_Int, "");
     auto o0 = origin->create_object();
     auto t0 = target->create_object();
@@ -2645,7 +2645,7 @@ TEST(LangBindHelper_RollbackAndContinueAsRead_Links)
     group->promote_to_write();
     TableRef origin = group->add_table("origin");
     TableRef target = group->add_table("target");
-    auto col0 = origin->add_column_link(type_Link, "", *target);
+    auto col0 = origin->add_column(*target, "");
     target->add_column(type_Int, "");
     auto o0 = origin->create_object();
     auto t0 = target->create_object();
@@ -2680,7 +2680,7 @@ TEST(LangBindHelper_RollbackAndContinueAsRead_LinkLists)
     group->promote_to_write();
     TableRef origin = group->add_table("origin");
     TableRef target = group->add_table("target");
-    auto col0 = origin->add_column_link(type_LinkList, "", *target);
+    auto col0 = origin->add_column_list(*target, "");
     target->add_column(type_Int, "");
     auto o0 = origin->create_object();
     auto t0 = target->create_object();
@@ -2730,9 +2730,9 @@ TEST(LangBindHelper_RollbackAndContinueAsRead_TableClear)
     TableRef origin = group->add_table("origin");
     TableRef target = group->add_table("target");
 
-    auto c1 = origin->add_column_link(type_LinkList, "linklist", *target);
+    auto c1 = origin->add_column_list(*target, "linklist");
     target->add_column(type_Int, "int");
-    auto c2 = origin->add_column_link(type_Link, "link", *target);
+    auto c2 = origin->add_column(*target, "link");
 
     Obj t = target->create_object();
     Obj o = origin->create_object();
@@ -2813,8 +2813,8 @@ TEST(LangBindHelper_RollbackAndContinueAsRead_TransactLog)
         // Add a table with some links
         WriteTransaction wt(sg);
         TableRef table = wt.add_table("link origin");
-        c2 = table->add_column_link(type_Link, "link", *wt.get_table("table 1"));
-        c3 = table->add_column_link(type_LinkList, "linklist", *wt.get_table("table 2"));
+        c2 = table->add_column(*wt.get_table("table 1"), "link");
+        c3 = table->add_column_list(*wt.get_table("table 2"), "linklist");
         Obj o = table->create_object();
         o.set(c2, o.get_key());
         o.get_linklist(c3).add(o.get_key());
@@ -2925,7 +2925,7 @@ TEST(LangBindHelper_ImplicitTransactions_LinkList)
     auto group = sg->start_write();
     TableRef origin = group->add_table("origin");
     TableRef target = group->add_table("target");
-    auto col = origin->add_column_link(type_LinkList, "", *target);
+    auto col = origin->add_column_list(*target, "");
     target->add_column(type_Int, "");
     auto O0 = origin->create_object();
     auto T0 = target->create_object();
@@ -3221,7 +3221,7 @@ TEST(LangBindHelper_ImplicitTransactions_ContinuedUseOfLinkList)
     auto group_w = sg->start_write();
 
     TableRef table_w = group_w->add_table("table");
-    auto col = table_w->add_column_link(type_LinkList, "flubber", *table_w);
+    auto col = table_w->add_column_list(*table_w, "flubber");
     auto obj = table_w->create_object();
     auto link_list_w = obj.get_linklist(col);
     link_list_w.add(obj.get_key());
@@ -3389,7 +3389,7 @@ TEST(LangBindHelper_SubqueryHandoverQueryCreatedFromDeletedLinkView)
         table2->add_column(type_Int, "int");
         auto key = table2->create_object().set_all(42).get_key();
 
-        auto col = table->add_column_link(type_LinkList, "first", *table2);
+        auto col = table->add_column_list(*table2, "first");
         auto obj = table->create_object();
         auto link_view = obj.get_linklist(col);
 
@@ -4007,7 +4007,7 @@ TEST(LangBindHelper_HandoverTableViewWithLnkLst)
             ok1 = table1->create_object().set_all(100, "alfa").get_key();
             ok2 = table1->create_object().set_all(200, "beta").get_key();
 
-            col_link2 = table2->add_column_link(type_LinkList, "linklist", *table1);
+            col_link2 = table2->add_column_list(*table1, "linklist");
 
             auto o = table2->create_object();
             auto lvr = o.get_linklist(col_link2);
@@ -4074,7 +4074,7 @@ TEST(LangBindHelper_HandoverTableViewWithQueryOnLink)
             TableRef table1 = group_w->add_table("table1");
             TableRef table2 = group_w->add_table("table2");
             table1->add_column(type_Int, "col1");
-            auto col_link = table2->add_column_link(type_Link, "link", *table1);
+            auto col_link = table2->add_column(*table1, "link");
 
             target = table1->create_object().set_all(300).get_key();
             auto o = table2->create_object().set_all(target);
@@ -4276,7 +4276,7 @@ TEST(LangBindHelper_HandoverLinkView)
     auto to2 = table1->create_object().set_all(100, "alfa");
     auto to3 = table1->create_object().set_all(200, "beta");
 
-    ColKey col_link2 = table2->add_column_link(type_LinkList, "linklist", *table1);
+    ColKey col_link2 = table2->add_column_list(*table1, "linklist");
 
     auto o1 = table2->create_object();
     auto o2 = table2->create_object();
@@ -4420,7 +4420,7 @@ TEST(LangBindHelper_HandoverTableViewFromBacklink)
     source->add_column(type_Int, "int");
 
     TableRef links = group_w->add_table("links");
-    ColKey col = links->add_column_link(type_Link, "link", *source);
+    ColKey col = links->add_column(*source, "link");
 
     std::vector<ObjKey> dummies;
     source->create_objects(100, dummies);
@@ -4463,7 +4463,7 @@ TEST(LangBindHelper_HandoverOutOfSyncTableViewFromBacklinksToDeletedRow)
     target->add_column(type_Int, "int");
 
     TableRef links = group_w->add_table("links");
-    auto col = links->add_column_link(type_Link, "link", *target);
+    auto col = links->add_column(*target, "link");
 
     auto obj_t = target->create_object().set_all(0);
 
@@ -4517,7 +4517,7 @@ TEST(LangBindHelper_HandoverWithLinkQueries)
     auto o21 = table2->create_object().set_all(500, "world");
     auto o22 = table2->create_object().set_all(600, "!");
 
-    ColKey col_link2 = table1->add_column_link(type_LinkList, "link", *table2);
+    ColKey col_link2 = table1->add_column_list(*table2, "link");
 
     // set some links
     auto links1 = o10.get_linklist(col_link2);
@@ -4581,7 +4581,7 @@ TEST(LangBindHelper_HandoverQueryLinksTo)
         TableRef source = group_w->add_table("source");
         TableRef target = group_w->add_table("target");
 
-        ColKey col_link = source->add_column_link(type_Link, "link", *target);
+        ColKey col_link = source->add_column(*target, "link");
         ColKey col_name = target->add_column(type_String, "name");
 
         std::vector<ObjKey> keys;
@@ -4673,7 +4673,7 @@ TEST(LangBindHelper_HandoverQuerySubQuery)
         TableRef source = group_w->add_table("source");
         TableRef target = group_w->add_table("target");
 
-        ColKey col_link = source->add_column_link(type_Link, "link", *target);
+        ColKey col_link = source->add_column(*target, "link");
         ColKey col_name = target->add_column(type_String, "name");
 
         std::vector<ObjKey> keys;
@@ -5013,10 +5013,10 @@ TEST_IF(LangBindHelper_HandoverFuzzyTest, TEST_DURATION > 0)
         TableRef dog = rt->add_table("Dog");
 
         c0 = owner->add_column(type_String, "name");
-        c1 = owner->add_column_link(type_LinkList, "link", *dog);
+        c1 = owner->add_column_list(*dog, "link");
 
         c2 = dog->add_column(type_String, "name");
-        c3 = dog->add_column_link(type_Link, "link", *owner);
+        c3 = dog->add_column(*owner, "link");
 
         for (size_t i = 0; i < numberOfOwner; i++) {
 
@@ -5128,7 +5128,7 @@ TEST(LangBindHelper_TableViewClear)
 
         col0 = history->add_column(type_Int, "id");
         col1 = history->add_column(type_Int, "parent");
-        col2 = history->add_column_link(type_LinkList, "lines", *line);
+        col2 = history->add_column_list(*line, "lines");
         history->add_search_index(col1);
 
         colA = line->add_column(type_Int, "id");
@@ -5274,7 +5274,7 @@ TEST(LangBindHelper_RollbackInsertZeroRows)
     auto t0 = g->add_table("t0");
     auto t1 = g->add_table("t1");
 
-    auto col = t0->add_column_link(type_Link, "t0_link_to_t1", *t1);
+    auto col = t0->add_column(*t1, "t0_link_to_t1");
     auto o0 = t0->create_object();
     auto o1 = t0->create_object();
     auto v0 = t1->create_object();
@@ -5314,7 +5314,7 @@ TEST(LangBindHelper_RollbackRemoveZeroRows)
     auto t0 = g->add_table("t0");
     auto t1 = g->add_table("t1");
 
-    auto col = t0->add_column_link(type_Link, "t0_link_to_t1", *t1);
+    auto col = t0->add_column(*t1, "t0_link_to_t1");
     auto o0 = t0->create_object();
     auto o1 = t0->create_object();
     auto v0 = t1->create_object();
@@ -5448,7 +5448,7 @@ TEST(LangbindHelper_GroupWriter_EdgeCaseAssert)
     auto t1 = g_w->add_table("dgrpnpgmjbchktdgagmqlihjckcdhpjccsjhnqlcjnbterse");
     auto t2 = g_w->add_table("pknglaqnckqbffehqfgjnrepcfohoedkhiqsiedlotmaqitm");
     t1->add_column(type_Double, "ggotpkoshbrcrmmqbagbfjetajlrrlbpjhhqrngfgdteilmj", true);
-    t2->add_column_link(type_LinkList, "dtkiipajqdsfglbptieibknaoeeohqdlhftqmlriphobspjr", *t1);
+    t2->add_column_list(*t1, "dtkiipajqdsfglbptieibknaoeeohqdlhftqmlriphobspjr");
     std::vector<ObjKey> keys;
     t1->create_objects(375, keys);
     g_w->add_table("pnsidlijqeddnsgaesiijrrqedkdktmfekftogjccerhpeil");
@@ -5481,7 +5481,7 @@ TEST(LangBindHelper_Bug2321)
         target->add_column(type_Int, "data");
         target->create_objects(REALM_MAX_BPNODE_SIZE + 2, target_keys);
         TableRef origin = group.add_table("origin");
-        col = origin->add_column_link(type_LinkList, "_link", *target);
+        col = origin->add_column_list(*target, "_link");
         origin->create_objects(2, origin_keys);
         wt.commit();
     }
@@ -5532,7 +5532,7 @@ TEST(LangBindHelper_Bug2295)
         target->add_column(type_Int, "data");
         target->create_objects(REALM_MAX_BPNODE_SIZE + 2, target_keys);
         TableRef origin = group.add_table("origin");
-        col = origin->add_column_link(type_LinkList, "_link", *target);
+        col = origin->add_column_list(*target, "_link");
         origin->create_objects(2, origin_keys);
         wt.commit();
     }
@@ -5894,7 +5894,7 @@ TEST(LangBindHelper_ImportDetachedLinkList)
         WriteTransaction wt(db);
         auto persons = wt.add_table("person");
         auto dogs = wt.add_table("dog");
-        col_pet = persons->add_column_link(type_LinkList, "pet", *dogs);
+        col_pet = persons->add_column_list(*dogs, "pet");
         col_addr = persons->add_column_list(type_String, "address");
         col_name = dogs->add_column(type_String, "name");
         col_age = dogs->add_column(type_Int, "age");

--- a/test/test_link_query_view.cpp
+++ b/test/test_link_query_view.cpp
@@ -56,7 +56,7 @@ void check_table_view(test_util::unit_test::TestContext& test_context, const cha
         }
     }
 }
-}
+} // namespace
 
 // void CHECK_TABLE_VIEW(const TableView&, std::initializer_list<size_t>);
 #define CHECK_TABLE_VIEW(_tv, ...)                                                                                   \
@@ -80,7 +80,7 @@ TEST(LinkList_Basic1)
     auto o1 = table1->create_object().set_all(200, "!", BinaryData("", 0));
     auto o2 = table1->create_object().set_all(300, "bar", BinaryData());
 
-    auto col_link2 = table2->add_column_link(type_Link, "link", *table1);
+    auto col_link2 = table2->add_column(*table1, "link");
     auto o20 = table2->create_object().set_all(o1.get_key());
     auto o21 = table2->create_object().set_all(o2.get_key());
 
@@ -146,7 +146,7 @@ TEST(LinkList_MissingDeepCopy)
     auto o2 = table1->create_object().set_all(200, "!");
     auto o3 = table1->create_object().set_all(300, "bar");
 
-    auto col_link2 = table2->add_column_link(type_Link, "link", *table1);
+    auto col_link2 = table2->add_column(*table1, "link");
     auto o20 = table2->create_object().set_all(o2.get_key());
     auto o21 = table2->create_object().set_all(o3.get_key());
 
@@ -182,7 +182,7 @@ TEST(LinkList_Basic2)
     auto o21 = table2->create_object().set_all(500, "world");
     auto o22 = table2->create_object().set_all(600, "!");
 
-    auto col_link2 = table1->add_column_link(type_LinkList, "link", *table2);
+    auto col_link2 = table1->add_column_list(*table2, "link");
 
     // set some links
     LnkLst links1;
@@ -250,7 +250,7 @@ TEST(LinkList_QuerySingle)
     auto o1 = table2->create_object().set_all(500, "world");
     auto o2 = table2->create_object().set_all(600, "!");
 
-    auto col_link2 = table1->add_column_link(type_Link, "link", *table2);
+    auto col_link2 = table1->add_column(*table2, "link");
 
     // set some links
 
@@ -287,7 +287,7 @@ TEST(LinkList_TableViewTracking)
     auto o1 = table1->create_object().set_all(200, "!");
     auto o2 = table1->create_object().set_all(300, "bar");
 
-    auto col_link2 = table2->add_column_link(type_Link, "link", *table1);
+    auto col_link2 = table2->add_column(*table1, "link");
     table2->create_object().set_all(o1.get_key());
     table2->create_object().set_all(o2.get_key());
     table2->create_object().set_all(o0.get_key());
@@ -331,8 +331,8 @@ TEST(LinkList_QueryFindLinkTarget)
     auto o22 = table2->create_object().set_all(500, "world");
     auto o23 = table2->create_object().set_all(600, "!");
 
-    auto col_link2 = table1->add_column_link(type_Link, "link", *table2);
-    auto col_link3 = table1->add_column_link(type_LinkList, "links", *table2);
+    auto col_link2 = table1->add_column(*table2, "link");
+    auto col_link3 = table1->add_column_list(*table2, "links");
 
     // set some links
 
@@ -444,11 +444,11 @@ TEST(LinkList_MultiLinkQuery)
     TableRef table3 = group.add_table("table3");
     TableRef table4 = group.add_table("table4");
 
-    ColKey col_linklist2 = table1->add_column_link(type_LinkList, "link", *table2);
-    ColKey col_link2 = table1->add_column_link(type_Link, "linkl", *table2);
+    ColKey col_linklist2 = table1->add_column_list(*table2, "link");
+    ColKey col_link2 = table1->add_column(*table2, "linkl");
 
-    ColKey col_link3 = table2->add_column_link(type_Link, "link", *table3);
-    ColKey col_linklist3 = table2->add_column_link(type_LinkList, "linkl", *table3);
+    ColKey col_link3 = table2->add_column(*table3, "link");
+    ColKey col_linklist3 = table2->add_column_list(*table3, "linkl");
 
     ColKey c40 = table4->add_column(type_Int, "int");
 
@@ -459,8 +459,8 @@ TEST(LinkList_MultiLinkQuery)
     ColKey c31 = table3->add_column(type_String, "string");
     ColKey c32 = table3->add_column(type_Float, "float");
 
-    ColKey col_link4 = table3->add_column_link(type_Link, "link", *table4);
-    ColKey col_linklist4 = table3->add_column_link(type_LinkList, "linkl", *table4);
+    ColKey col_link4 = table3->add_column(*table4, "link");
+    ColKey col_linklist4 = table3->add_column_list(*table4, "linkl");
 
     // add some rows
     table3->create_object(ObjKey(0)).set_all(100, "foo", 100.0f);
@@ -658,7 +658,7 @@ TEST(LinkList_SortLinkView)
     auto col_double = table1->add_column(type_Double, "doubles");
     auto col_str2 = table1->add_column(type_String, "str2");
     auto col_date = table1->add_column(type_Timestamp, "ts");
-    auto col_link2 = table2->add_column_link(type_LinkList, "linklist", *table1);
+    auto col_link2 = table2->add_column_list(*table1, "linklist");
 
     // add some rows - all columns in different sort order
     ObjKey key0 = table1->create_object().set_all(100, "alfa", 200.f, 200., "alfa", Timestamp(200, 300)).get_key();
@@ -756,7 +756,7 @@ TEST(Link_EmptySortedView)
     TableRef source = group.add_table("source");
     TableRef destination = group.add_table("destination");
 
-    auto col_link_list = source->add_column_link(type_LinkList, "link", *destination);
+    auto col_link_list = source->add_column_list(*destination, "link");
     auto ll = source->create_object().get_linklist(col_link_list);
 
     CHECK_EQUAL(ll.size(), 0);
@@ -784,12 +784,12 @@ TEST(Link_FindNullLink)
     Obj obj_1_1 = table1->create_object().set_all(200, "!");
     Obj obj_1_2 = table1->create_object().set_all(300, "bar");
 
-    auto col_link1 = table1->add_column_link(type_Link, "link", *table0);
+    auto col_link1 = table1->add_column(*table0, "link");
     obj_1_0.set(col_link1, k0);
     obj_1_2.set(col_link1, k0);
 
-    auto col_link2 = table2->add_column_link(type_Link, "link", *table1);
-    auto col_linklist2 = table2->add_column_link(type_LinkList, "link_list", *table1);
+    auto col_link2 = table2->add_column(*table1, "link");
+    auto col_linklist2 = table2->add_column_list(*table1, "link_list");
     Obj obj_2_0 = table2->create_object();
     Obj obj_2_1 = table2->create_object();
     Obj obj_2_2 = table2->create_object();
@@ -862,7 +862,7 @@ TEST(Link_FindNotNullLink)
 
     TableRef t0 = g.add_table("t0");
     TableRef t1 = g.add_table("t1");
-    auto col_link = t0->add_column_link(type_Link, "link", *t1);
+    auto col_link = t0->add_column(*t1, "link");
     auto col_int = t1->add_column(type_Int, "int");
 
     std::vector<ObjKey> keys0;
@@ -904,8 +904,8 @@ TEST(LinkList_FindNotNullLink)
     TableRef items = g.add_table("ListItem");
     TableRef datas = g.add_table("ListItemData");
 
-    auto col_linklist = lists->add_column_link(type_LinkList, "listItems", *items);
-    auto col_link = items->add_column_link(type_Link, "localData", *datas);
+    auto col_linklist = lists->add_column_list(*items, "listItems");
+    auto col_link = items->add_column(*datas, "localData");
     auto col_str = datas->add_column(type_String, "title");
 
     Obj obj0 = lists->create_object();
@@ -945,7 +945,7 @@ TEST(Link_FirstResultPastRow1000)
 
     TableRef data_table = g.add_table("data_table");
     TableRef link_table = g.add_table("link_table");
-    auto col_link = link_table->add_column_link(type_Link, "link", *data_table);
+    auto col_link = link_table->add_column(*data_table, "link");
 
     Obj obj = data_table->create_object();
     std::vector<ObjKey> keys;
@@ -968,7 +968,7 @@ TEST(LinkList_QueryOnLinkList)
     // add some more columns to target and origin
     auto col_int = target->add_column(type_Int, "col1");
     target->add_column(type_String, "str1");
-    auto col_link2 = origin->add_column_link(type_LinkList, "linklist", *target);
+    auto col_link2 = origin->add_column_list(*target, "linklist");
 
     // add some rows
     ObjKey key0 = target->create_object().set_all(300, "delta").get_key();
@@ -1002,7 +1002,7 @@ TEST(LinkList_QueryOnLinkList)
     Query q1 = origin->link(col_link2).column<Int>(col_int) == 300;
 
     // tv.m_table == target
-    tv = q.find_all(); // tv = { 0, 2 }
+    tv = q.find_all();   // tv = { 0, 2 }
     tv1 = q1.find_all(); // tv = { 0, 2 }
 
     TableView tv2 = list_ptr->get_sorted_view(col_int);
@@ -1061,7 +1061,7 @@ TEST(LinkList_QueryOnLinkListWithDuplicates)
     TableRef target = group.add_table("target");
     auto int_col = target->add_column(type_Int, "col1");
     TableRef origin = group.add_table("origin");
-    auto link_col = origin->add_column_link(type_LinkList, "linklist", *target);
+    auto link_col = origin->add_column_list(*target, "linklist");
 
     std::vector<ObjKey> target_keys;
     target->create_objects(3, target_keys);
@@ -1106,7 +1106,7 @@ TEST(LinkList_QueryOnIndexedPropertyOfLinkListSingleMatch)
     data_table->add_search_index(c0);
 
     TableRef link_table = group.add_table("link");
-    auto c1 = link_table->add_column_link(type_LinkList, "col", *data_table);
+    auto c1 = link_table->add_column_list(*data_table, "col");
 
     auto k0 = data_table->create_object().set_all("a").get_key();
     auto k1 = data_table->create_object().set_all("b").get_key();
@@ -1138,7 +1138,7 @@ TEST(LinkList_QueryLinkNull)
 
     TableRef data_table = group.add_table("data");
     auto c0 = data_table->add_column(type_String, "string", true);
-    auto c1 = data_table->add_column_link(type_Link, "link", *data_table);
+    auto c1 = data_table->add_column(*data_table, "link");
     auto c2 = data_table->add_column(type_Int, "int", true);
     auto c3 = data_table->add_column(type_Double, "double", true);
     auto c4 = data_table->add_column(type_Timestamp, "date", true);
@@ -1225,7 +1225,7 @@ TEST(LinkList_QueryOnIndexedPropertyOfLinkListMultipleMatches)
     data_table->add_search_index(c0);
 
     TableRef link_table = group.add_table("link");
-    auto c1 = link_table->add_column_link(type_LinkList, "col", *data_table);
+    auto c1 = link_table->add_column_list(*data_table, "col");
 
     // Ensure that the results from the index don't fit in a single leaf
     const size_t count = round_up(std::max(REALM_MAX_BPNODE_SIZE * 8, 100), 4);
@@ -1297,7 +1297,7 @@ TEST(LinkList_QueryUnsortedListWithOr)
     auto int_col = data_table->add_column(type_Int, "col");
 
     TableRef link_table = group.add_table("link");
-    auto link_col = link_table->add_column_link(type_LinkList, "col", *data_table);
+    auto link_col = link_table->add_column_list(*data_table, "col");
 
     const size_t count = 5;
     ObjKeys data_keys;
@@ -1332,8 +1332,8 @@ TEST(BackLink_Query_TableViewSyncsWhenNeeded)
     TableRef target = group.add_table("target");
 
     ColKey col_int = source->add_column(type_Int, "id");
-    ColKey col_link = source->add_column_link(type_Link, "link", *target);
-    ColKey col_linklist = source->add_column_link(type_LinkList, "linklist", *target);
+    ColKey col_link = source->add_column(*target, "link");
+    ColKey col_linklist = source->add_column_list(*target, "linklist");
 
     target->add_column(type_Int, "id");
 
@@ -1416,7 +1416,7 @@ TEST(BackLink_Query_Link)
     auto k2 = target->create_object().set_all(2).get_key();
     auto k3 = target->create_object().set_all(3).get_key();
 
-    auto col_link = source->add_column_link(type_Link, "link", *target);
+    auto col_link = source->add_column(*target, "link");
     auto col_int = source->add_column(type_Int, "int");
     auto col_double = source->add_column(type_Double, "double");
     auto col_string = source->add_column(type_String, "string");
@@ -1479,7 +1479,7 @@ TEST(BackLink_Query_LinkList)
     auto k3 = target->create_object().set_all(3).get_key();
     auto k4 = target->create_object().set_all(4).get_key();
 
-    auto col_linklist = source->add_column_link(type_LinkList, "linklist", *target);
+    auto col_linklist = source->add_column_list(*target, "linklist");
     auto col_int = source->add_column(type_Int, "int");
     auto col_double = source->add_column(type_Double, "double");
     auto col_string = source->add_column(type_String, "string");
@@ -1544,7 +1544,7 @@ TEST(BackLink_Query_MultipleLevels)
 
     auto col_name = people->add_column(type_String, "name");
     auto col_age = people->add_column(type_Int, "age");
-    auto col_children = people->add_column_link(type_LinkList, "children", *people);
+    auto col_children = people->add_column_list(*people, "children");
 
     auto add_person = [&](std::string name, int age, std::vector<ObjKey> children) {
         auto row = people->create_object();
@@ -1643,10 +1643,10 @@ TEST(BackLink_Query_MultipleLevelsAndTables)
     TableRef d = group.add_table("d");
 
     auto col_id = a->add_column(type_Int, "id");
-    auto col_a_to_b = a->add_column_link(type_Link, "link", *b);
+    auto col_a_to_b = a->add_column(*b, "link");
 
-    auto col_b_to_c = b->add_column_link(type_Link, "link", *c);
-    auto col_c_to_d = c->add_column_link(type_Link, "link", *d);
+    auto col_b_to_c = b->add_column(*c, "link");
+    auto col_c_to_d = c->add_column(*d, "link");
 
     d->add_column(type_Int, "id");
 

--- a/test/test_links.cpp
+++ b/test/test_links.cpp
@@ -56,7 +56,7 @@ TEST(Links_Columns)
     TableRef table2 = group.add_table("table2");
 
     // table1 can link to table2
-    table2->add_column_link(type_Link, "link", *table1);
+    table2->add_column(*table1, "link");
 
     // add some more columns to table1 and table2
     auto col_1 = table1->add_column(type_String, "col1");
@@ -72,7 +72,7 @@ TEST(Links_Columns)
     table2->create_objects(table_2_keys);
 
     table1->get_object(table_1_keys[0]).set<String>(col_1, "string1");
-    auto col_link2 = table1->add_column_link(type_Link, "link", *table2);
+    auto col_link2 = table1->add_column(*table2, "link");
 
     // set some links
     table1->get_object(table_1_keys[0]).set(col_link2, table_2_keys[1]);
@@ -125,7 +125,7 @@ TEST(Links_Basic)
 
         // create table with links to table1
         TableRef table2 = group.add_table("table2");
-        col_link = table2->add_column_link(type_Link, "link", *table1);
+        col_link = table2->add_column(*table1, "link");
         CHECK_EQUAL(table1, table2->get_link_target(col_link));
 
         // add a few links
@@ -206,7 +206,7 @@ TEST(Group_LinksToSameTable)
     TableRef table = g.add_table("target");
 
     table->add_column(type_Int, "integers", true);
-    auto link_col = table->add_column_link(type_Link, "links", *table);
+    auto link_col = table->add_column(*table, "links");
 
     // 3 rows linked together in a list
     std::vector<ObjKey> keys;
@@ -226,7 +226,7 @@ TEST(Links_SetLinkLogicErrors)
     Group group;
     TableRef origin = group.add_table("origin");
     TableRef target = group.add_table("target");
-    auto col0 = origin->add_column_link(type_Link, "a", *target);
+    auto col0 = origin->add_column(*target, "a");
     origin->add_column(type_Int, "b");
     Obj obj = origin->create_object();
     target->create_object(ObjKey(10));
@@ -258,7 +258,7 @@ TEST(Links_Deletes)
 
     // create table with links to table1
     TableRef table2 = group.add_table("table2");
-    auto col_link = table2->add_column_link(type_Link, "link", *TableRef(table1));
+    auto col_link = table2->add_column(*TableRef(table1), "link");
     CHECK_EQUAL(table1, table2->get_link_target(col_link));
 
     Obj obj0 = table1->create_object().set_all("test1", 1, true, int64_t(Mon));
@@ -340,7 +340,7 @@ TEST(Links_Multi)
 
     // create table with links to table1
     TableRef table2 = group.add_table("table2");
-    auto col_link = table2->add_column_link(type_Link, "link", *TableRef(table1));
+    auto col_link = table2->add_column(*TableRef(table1), "link");
     CHECK_EQUAL(table1, table2->get_link_target(col_link));
 
     // add a few links pointing to same row
@@ -405,8 +405,8 @@ TEST(Links_MultiToSame)
 
     // create table with multiple links to table1
     TableRef table2 = group.add_table("table2");
-    auto col_link1 = table2->add_column_link(type_Link, "link1", *table1);
-    auto col_link2 = table2->add_column_link(type_Link, "link2", *table1);
+    auto col_link1 = table2->add_column(*table1, "link1");
+    auto col_link2 = table2->add_column(*table1, "link2");
     CHECK_EQUAL(table1, table2->get_link_target(col_link1));
     CHECK_EQUAL(table1, table2->get_link_target(col_link2));
 
@@ -431,7 +431,7 @@ TEST(Links_LinkList_TableOps)
 
     // create table with links to table1
     TableRef origin = group.add_table("origin");
-    auto col_link = origin->add_column_link(type_LinkList, "links", *TableRef(target));
+    auto col_link = origin->add_column_list(*TableRef(target), "links");
     CHECK_EQUAL(target, origin->get_link_target(col_link));
 
     target->create_object().set_all("test1", 1, true, int64_t(Mon));
@@ -467,7 +467,7 @@ TEST(Links_LinkList_Construction)
 
     // create table with links to table1
     TableRef origin = group.add_table("origin");
-    auto col_link = origin->add_column_link(type_LinkList, "links", *table1);
+    auto col_link = origin->add_column_list(*table1, "links");
     CHECK_EQUAL(table1, origin->get_link_target(col_link));
 
     ObjKeys target_keys({4, 5, 6});
@@ -529,7 +529,7 @@ TEST(Links_LinkList_Basics)
 
     // create table with links to table1
     TableRef origin = group.add_table("origin");
-    auto col_link = origin->add_column_link(type_LinkList, "links", *TableRef(target));
+    auto col_link = origin->add_column_list(*TableRef(target), "links");
     origin->add_column(type_Int, "integers"); // Make sure the link column is not the only column
     CHECK_EQUAL(target, origin->get_link_target(col_link));
 
@@ -729,7 +729,7 @@ TEST(ListList_Clear)
     target->add_column(type_Int, "value");
 
     TableRef origin = group->add_table("origin");
-    auto col_link = origin->add_column_link(type_LinkList, "links", *target);
+    auto col_link = origin->add_column_list(*target, "links");
 
     ObjKey key0 = target->create_object().set_all(1).get_key();
     ObjKey key1 = target->create_object().set_all(2).get_key();
@@ -754,9 +754,9 @@ TEST(Links_AddBacklinkToTableWithEnumColumns)
     auto table = g.add_table("fshno");
     auto col = table->add_column(type_String, "strings", false);
     table->create_object();
-    table->add_column_link(type_Link, "link1", *table);
+    table->add_column(*table, "link1");
     table->enumerate_string_column(col);
-    table->add_column_link(type_Link, "link2", *table);
+    table->add_column(*table, "link2");
 }
 
 TEST(Links_LinkList_Inserts)
@@ -775,7 +775,7 @@ TEST(Links_LinkList_Inserts)
 
     // create table with links to target table
     TableRef origin = group.add_table("origin");
-    auto col_link = origin->add_column_link(type_LinkList, "links", *target);
+    auto col_link = origin->add_column_list(*target, "links");
     CHECK_EQUAL(target, origin->get_link_target(col_link));
 
     auto obj = origin->create_object();
@@ -827,7 +827,7 @@ TEST(Links_LinkList_Backlinks)
 
     // create table with links to target table
     TableRef origin = group.add_table("origin");
-    auto col_link = origin->add_column_link(type_LinkList, "links", *target);
+    auto col_link = origin->add_column_list(*target, "links");
     CHECK_EQUAL(target, origin->get_link_target(col_link));
 
     Obj origin_obj = origin->create_object();
@@ -915,7 +915,7 @@ TEST(Links_LinkList_FindByOrigin)
 
     // create table with links to target table
     TableRef origin = group.add_table("origin");
-    auto col_link = origin->add_column_link(type_LinkList, "links", *target);
+    auto col_link = origin->add_column_list(*target, "links");
     CHECK_EQUAL(target, origin->get_link_target(col_link));
 
     auto obj = origin->create_object();
@@ -969,8 +969,8 @@ TEST(Links_CircularAccessors)
         WriteTransaction wt(db);
         TableRef table1 = wt.add_table("table1");
         TableRef table2 = wt.add_table("table2");
-        col1 = table1->add_column_link(type_Link, "link", *table2);
-        col2 = table2->add_column_link(type_Link, "link", *table1);
+        col1 = table1->add_column(*table2, "link");
+        col2 = table2->add_column(*table1, "link");
         CHECK_EQUAL(table1, table2->get_link_target(col1));
         CHECK_EQUAL(table2, table1->get_link_target(col2));
         wt.commit();
@@ -1005,7 +1005,7 @@ TEST(Links_Transactions)
         // Create owners table
         TableRef owners = group.add_table("owners");
         owners->add_column(type_String, "name");
-        dog_col = owners->add_column_link(type_Link, "dog", *dogs);
+        dog_col = owners->add_column(*dogs, "dog");
 
         // Insert a single dog
         harvey_key = dogs->create_object().set_all("Harvey").get_key();
@@ -1062,7 +1062,7 @@ TEST(Links_RemoveTargetRows)
 
     // create table with links to target table
     TableRef origin = group.add_table("origin");
-    auto col_link = origin->add_column_link(type_LinkList, "links", *target);
+    auto col_link = origin->add_column_list(*target, "links");
 
     Obj obj = origin->create_object();
     auto links = obj.get_linklist(col_link);
@@ -1113,7 +1113,7 @@ TEST(Links_ClearColumnWithTwoLevelBptree)
     target->add_column(type_Int, "i5");
     Obj obj = target->create_object();
 
-    auto col = origin->add_column_link(type_LinkList, "", *target);
+    auto col = origin->add_column_list(*target, "");
     std::vector<ObjKey> keys;
     origin->create_objects(REALM_MAX_BPNODE_SIZE + 1, keys);
     origin->clear();
@@ -1127,7 +1127,7 @@ TEST(Links_ClearLinkListWithTwoLevelBptree)
     Group group;
     TableRef origin = group.add_table("origin");
     TableRef target = group.add_table("target");
-    auto col_link = origin->add_column_link(type_LinkList, "", *target);
+    auto col_link = origin->add_column_list(*target, "");
     ObjKey k = target->create_object().get_key();
     auto ll = origin->create_object().get_linklist(col_link);
     for (size_t i = 0; i < REALM_MAX_BPNODE_SIZE + 1; ++i)
@@ -1147,7 +1147,7 @@ TEST(Links_FormerMemLeakCase)
         TableRef target = wt.add_table("target");
         target->add_column(type_Int, "int");
         auto k = target->create_object().get_key();
-        auto col = origin->add_column_link(type_Link, "link", *target);
+        auto col = origin->add_column(*target, "link");
         origin->create_object().set(col, k);
         origin->create_object().set(col, k);
         wt.commit();
@@ -1173,7 +1173,7 @@ TEST(Links_CascadeRemove_ColumnLink)
         Fixture()
         {
             target->add_column(type_Int, "t_1");
-            col_link = origin->add_column_link(type_Link, "o_1", *target);
+            col_link = origin->add_column(*target, "o_1");
             for (int i = 0; i < 3; ++i) {
                 auto oo = origin->create_object();
                 auto to = oo.create_and_set_linked_object(col_link);
@@ -1297,7 +1297,7 @@ TEST(Links_CascadeRemove_ColumnLinkList)
         Fixture()
         {
             target->add_column(type_Int, "t_1");
-            col_link = origin->add_column_link(type_LinkList, "o_1", *target);
+            col_link = origin->add_column_list(*target, "o_1");
             origin->create_objects(3, origin_keys);
             linklists.emplace_back(origin->get_object(origin_keys[0]).get_linklist_ptr(col_link));
             linklists.emplace_back(origin->get_object(origin_keys[1]).get_linklist_ptr(col_link));
@@ -1528,7 +1528,7 @@ TEST(Links_LinkList_Swap)
         ObjKeys tkeys;
         Fixture()
         {
-            auto col_link = origin->add_column_link(type_LinkList, "", *target);
+            auto col_link = origin->add_column_list(*target, "");
             target->add_column(type_Int, "");
             origin->create_objects(2, okeys);
             target->create_objects(2, tkeys);
@@ -1583,7 +1583,7 @@ TEST(Links_DetachedAccessor)
 {
     Group group;
     TableRef table = group.add_table("table");
-    auto col = table->add_column_link(type_LinkList, "l", *table);
+    auto col = table->add_column_list(*table, "l");
     Obj obj = table->create_object();
     auto link_list = obj.get_linklist(col);
     link_list.add(obj.get_key());

--- a/test/test_metrics.cpp
+++ b/test/test_metrics.cpp
@@ -221,7 +221,7 @@ void populate(DBRef sg)
     person->add_column(type_String, "name");
     person->add_column(type_Bool, "account_overdue");
     person->add_column(type_Binary, "data");
-    auto owes_col = person->add_column_link(type_LinkList, "owes_coffee_to", *person);
+    auto owes_col = person->add_column_list(*person, "owes_coffee_to");
 
     auto create_person = [&](int age, double paid, float weight, Timestamp dob, std::string name, bool overdue,
                              std::string data, std::vector<ObjKey> owes_coffee_to) {
@@ -241,7 +241,7 @@ void populate(DBRef sg)
     create_person(33, 29.28, 188.7f, Timestamp(33, 9), "Riley", false, "a208s", {k3, k3, k2, k1});
 
     pet->add_column(type_String, "name");
-    pet->add_column_link(type_Link, "owner", *person);
+    pet->add_column(*person, "owner");
 
     auto create_pet = [&](std::string name, ObjKey owner) { pet->create_object().set_all(name, owner); };
 

--- a/test/test_object_id.cpp
+++ b/test/test_object_id.cpp
@@ -260,8 +260,8 @@ TEST(ObjectId_Query)
 
         col_id = table->add_column(type_ObjectId, "alternative_id", true);
         col_int = table->add_column(type_Int, "int");
-        col_has = table->add_column_link(type_Link, "Has", *target);
-        col_owns = origin->add_column_link(type_Link, "Owns", *table);
+        col_has = table->add_column(*target, "Has");
+        col_owns = origin->add_column(*table, "Owns");
 
         ObjKeys target_keys;
         target->create_objects(16, target_keys);

--- a/test/test_parser.cpp
+++ b/test/test_parser.cpp
@@ -431,7 +431,7 @@ TEST(Parser_ConstrainedQuery)
     std::string table_name = "table";
     TableRef t = g.add_table(table_name);
     auto int_col = t->add_column(type_Int, "age");
-    auto list_col = t->add_column_link(type_LinkList, "self_list", *t);
+    auto list_col = t->add_column_list(*t, "self_list");
 
     Obj obj0 = t->create_object();
     Obj obj1 = t->create_object();
@@ -466,7 +466,7 @@ TEST(Parser_basic_serialisation)
     t->add_column(type_Double, "fees", true);
     t->add_column(type_Float, "float_fees", true);
     t->add_column(type_Bool, "licensed", true);
-    auto link_col = t->add_column_link(type_Link, "buddy", *t);
+    auto link_col = t->add_column(*t, "buddy");
     auto time_col = t->add_column(type_Timestamp, "time", true);
     t->add_search_index(int_col_key);
     std::vector<std::string> names = {"Billy", "Bob", "Joe", "Jane", "Joel"};
@@ -583,7 +583,7 @@ TEST(Parser_LinksToSameTable)
     TableRef t = g.add_table("class_Person");
     ColKey age_col = t->add_column(type_Int, "age");
     ColKey name_col = t->add_column(type_String, "name");
-    ColKey link_col = t->add_column_link(type_Link, "buddy", *t);
+    ColKey link_col = t->add_column(*t, "buddy");
     std::vector<std::string> names = {"Billy", "Bob", "Joe", "Jane", "Joel"};
     std::vector<ObjKey> people_keys;
     t->create_objects(names.size(), people_keys);
@@ -629,7 +629,7 @@ TEST(Parser_LinksToDifferentTable)
     TableRef items = g.add_table("class_Items");
     ColKey item_name_col = items->add_column(type_String, "name");
     ColKey item_price_col = items->add_column(type_Double, "price");
-    ColKey item_discount_col = items->add_column_link(type_Link, "discount", *discounts);
+    ColKey item_discount_col = items->add_column(*discounts, "discount");
     using item_t = std::pair<std::string, double>;
     std::vector<item_t> item_info = {{"milk", 5.5}, {"oranges", 4.0}, {"pizza", 9.5}, {"cereal", 6.5}};
     std::vector<ObjKey> item_keys;
@@ -645,7 +645,7 @@ TEST(Parser_LinksToDifferentTable)
 
     TableRef t = g.add_table("class_Person");
     ColKey id_col = t->add_column(type_Int, "customer_id");
-    ColKey items_col = t->add_column_link(type_LinkList, "items", *items);
+    ColKey items_col = t->add_column_list(*items, "items");
 
     Obj person0 = t->create_object();
     Obj person1 = t->create_object();
@@ -711,7 +711,7 @@ TEST(Parser_StringOperations)
     Group g;
     TableRef t = g.add_table("person");
     ColKey name_col = t->add_column(type_String, "name", true);
-    ColKey link_col = t->add_column_link(type_Link, "father", *t);
+    ColKey link_col = t->add_column(*t, "father");
     std::vector<std::string> names = {"Billy", "Bob", "Joe", "Jake", "Joel"};
     std::vector<ObjKey> people_keys;
     t->create_objects(names.size(), people_keys);
@@ -792,7 +792,7 @@ TEST(Parser_Timestamps)
     ColKey birthday_col = t->add_column(type_Timestamp, "birthday");          // disallow null
     ColKey internal_col = t->add_column(type_Timestamp, "T399", true);        // allow null
     ColKey readable_col = t->add_column(type_Timestamp, "T2017-12-04", true); // allow null
-    ColKey link_col = t->add_column_link(type_Link, "linked", *t);
+    ColKey link_col = t->add_column(*t, "linked");
     std::vector<ObjKey> keys;
     t->create_objects(5, keys);
 
@@ -915,7 +915,7 @@ TEST(Parser_NullableBinaries)
     items->get_object(item_keys[2]).set(binary_col, bd2);
     items->get_object(item_keys[2]).set(nullable_binary_col, bd2);
 
-    ColKey fav_item_col = people->add_column_link(type_Link, "fav_item", *items);
+    ColKey fav_item_col = people->add_column(*items, "fav_item");
     std::vector<ObjKey> people_keys;
     people->create_objects(5, people_keys);
     for (size_t i = 0; i < people_keys.size(); ++i) {
@@ -1036,7 +1036,7 @@ TEST(Parser_TwoColumnExpressionBasics)
     ColKey string_col = table->add_column(type_String, "strings");
     ColKey decimal_col = table->add_column(type_Decimal, "decimals");
     ColKey objectid_col = table->add_column(type_ObjectId, "objectids");
-    ColKey link_col = table->add_column_link(type_Link, "link", *table);
+    ColKey link_col = table->add_column(*table, "link");
     std::vector<ObjKey> keys;
     table->create_objects(3, keys);
     for (size_t i = 0; i < keys.size(); ++i) {
@@ -1101,7 +1101,7 @@ TEST(Parser_TwoColumnAggregates)
     ColKey item_price_col = items->add_column(type_Double, "price");
     ColKey item_price_float_col = items->add_column(type_Float, "price_float");
     ColKey item_price_decimal_col = items->add_column(type_Decimal, "price_decimal");
-    ColKey item_discount_col = items->add_column_link(type_Link, "discount", *discounts);
+    ColKey item_discount_col = items->add_column(*discounts, "discount");
     using item_t = std::pair<std::string, double>;
     std::vector<item_t> item_info = {{"milk", 5.5}, {"oranges", 4.0}, {"pizza", 9.5}, {"cereal", 6.5}};
     std::vector<ObjKey> item_keys;
@@ -1120,7 +1120,7 @@ TEST(Parser_TwoColumnAggregates)
     TableRef t = g.add_table("class_Person");
     ColKey id_col = t->add_column(type_Int, "customer_id");
     ColKey account_col = t->add_column(type_Double, "account_balance");
-    ColKey items_col = t->add_column_link(type_LinkList, "items", *items);
+    ColKey items_col = t->add_column_list(*items, "items");
     ColKey account_float_col = t->add_column(type_Float, "account_balance_float");
     ColKey account_decimal_col = t->add_column(type_Decimal, "account_balance_decimal");
 
@@ -1269,8 +1269,8 @@ TEST(Parser_substitution)
     ColKey binary_col = t->add_column(type_Binary, "binary", true);
     ColKey float_col = t->add_column(type_Float, "floats", true);
     ColKey nullable_double_col = t->add_column(type_Float, "nuldouble", true);
-    ColKey link_col = t->add_column_link(type_Link, "links", *t);
-    ColKey list_col = t->add_column_link(type_LinkList, "list", *t);
+    ColKey link_col = t->add_column(*t, "links");
+    ColKey list_col = t->add_column_list(*t, "list");
     std::vector<std::string> names = {"Billy", "Bob", "Joe", "Jane", "Joel"};
     std::vector<double> fees = {2.0, 2.23, 2.22, 2.25, 3.73};
     std::vector<ObjKey> obj_keys;
@@ -1655,7 +1655,7 @@ TEST(Parser_collection_aggregates)
     auto fail_col = courses->add_column(type_Float, "failure_percentage");
     auto int_col = people->add_column(type_Int, "age");
     auto str_col = people->add_column(type_String, "name");
-    auto courses_col = people->add_column_link(type_LinkList, "courses_taken", *courses);
+    auto courses_col = people->add_column_list(*courses, "courses_taken");
     auto binary_col = people->add_column(type_Binary, "hash");
     using info_t = std::pair<std::string, int64_t>;
     std::vector<info_t> person_info = {{"Billy", 18}, {"Bob", 17}, {"Joe", 19}, {"Jane", 20}, {"Joel", 18}};
@@ -1795,7 +1795,7 @@ TEST(Parser_NegativeAgg)
     TableRef t = g.add_table("class_Person");
     ColKey id_col = t->add_column(type_Int, "customer_id");
     ColKey account_col = t->add_column(type_Double, "account_balance");
-    ColKey items_col = t->add_column_link(type_LinkList, "items", *items);
+    ColKey items_col = t->add_column_list(*items, "items");
     ColKey account_float_col = t->add_column(type_Float, "account_balance_float");
     ColKey account_decimal_col = t->add_column(type_Decimal, "account_balance_decimal");
 
@@ -1870,8 +1870,8 @@ TEST(Parser_list_of_primitive_ints)
 
     TableRef t2 = g.add_table("table2");
 
-    auto col_link = t2->add_column_link(type_Link, "link", *t);
-    auto col_list = t2->add_column_link(type_LinkList, "list", *t);
+    auto col_link = t2->add_column(*t, "link");
+    auto col_list = t2->add_column_list(*t, "list");
     {
         // object with link to 1, list with {1}
         Obj obj0 = t2->create_object();
@@ -2133,7 +2133,7 @@ TEST_TYPES(Parser_list_of_primitive_element_lengths, StringData, BinaryData)
     constexpr bool nullable = true;
     auto col_list = t->add_column_list(ColumnTypeTraits<TEST_TYPE>::id, "values", nullable);
     t->add_column(type_Int, "length"); // "length" is still a usable column name
-    auto col_link = t->add_column_link(type_Link, "link", *t);
+    auto col_link = t->add_column(*t, "link");
 
     Obj obj_empty_list = t->create_object();
     Obj obj_with_null = t->create_object();
@@ -2211,7 +2211,7 @@ TEST_TYPES(Parser_list_of_primitive_types, Int, Optional<Int>, Bool, Optional<Bo
     using underlying_type = typename util::RemoveOptional<TEST_TYPE>::type;
     constexpr bool is_optional = !std::is_same<underlying_type, TEST_TYPE>::value;
     ColKey col = t->add_column_list(ColumnTypeTraits<TEST_TYPE>::id, "values", is_optional);
-    auto col_link = t->add_column_link(type_Link, "link", *t);
+    auto col_link = t->add_column(*t, "link");
 
     auto obj1 = t->create_object();
     std::vector<TEST_TYPE> values =
@@ -2272,7 +2272,7 @@ TEST(Parser_SortAndDistinctSerialisation)
 
     ColKey name_col = people->add_column(type_String, "name");
     ColKey age_col = people->add_column(type_Int, "age");
-    ColKey account_col = people->add_column_link(type_Link, "account", *accounts);
+    ColKey account_col = people->add_column(*accounts, "account");
 
     ColKey balance_col = accounts->add_column(type_Double, "balance");
     ColKey transaction_col = accounts->add_column(type_Int, "num_transactions");
@@ -2364,7 +2364,7 @@ TEST(Parser_SortAndDistinct)
 
     ColKey name_col = people->add_column(type_String, "name");
     ColKey age_col = people->add_column(type_Int, "age");
-    ColKey account_col = people->add_column_link(type_Link, "account", *accounts);
+    ColKey account_col = people->add_column(*accounts, "account");
 
     ColKey balance_col = accounts->add_column(type_Double, "balance");
     ColKey transaction_col = accounts->add_column(type_Int, "num_transactions");
@@ -2685,7 +2685,7 @@ TEST(Parser_IncludeDescriptor)
 
     auto name_col = people->add_column(type_String, "name");
     auto age_col = people->add_column(type_Int, "age");
-    auto account_col = people->add_column_link(type_Link, "account", *accounts);
+    auto account_col = people->add_column(*accounts, "account");
     static_cast<void>(age_col);     // silence warning
     static_cast<void>(account_col); // do
 
@@ -2758,16 +2758,16 @@ TEST(Parser_IncludeDescriptorMultiple)
     TableRef languages = g.add_table("language");
 
     auto name_col = people->add_column(type_String, "name");
-    auto account_col = people->add_column_link(type_Link, "account", *accounts);
+    auto account_col = people->add_column(*accounts, "account");
 
     auto balance_col = accounts->add_column(type_Double, "balance");
     auto transaction_col = accounts->add_column(type_Int, "num_transactions");
-    auto account_bank_col = accounts->add_column_link(type_Link, "bank", *banks);
+    auto account_bank_col = accounts->add_column(*banks, "bank");
 
     auto bank_name_col = banks->add_column(type_String, "name");
 
     auto language_name_col = languages->add_column(type_String, "name");
-    auto language_available_col = languages->add_column_link(type_LinkList, "available_from", *banks);
+    auto language_available_col = languages->add_column_list(*banks, "available_from");
 
     auto b0 = banks->create_object().set_all("Danske Bank");
     auto b1 = banks->create_object().set_all("RBC");
@@ -2937,7 +2937,7 @@ TEST(Parser_IncludeDescriptorDeepLinks)
     TableRef people = g.add_table("person");
 
     auto name_col = people->add_column(type_String, "name");
-    auto link_col = people->add_column_link(type_Link, "father", *people);
+    auto link_col = people->add_column(*people, "father");
 
     auto bones = people->create_object().set(name_col, "Bones");
     auto john = people->create_object().set(name_col, "John").set(link_col, bones.get_key());
@@ -2992,8 +2992,8 @@ TEST(Parser_Backlinks)
     ColKey id_col = t->add_column(type_Int, "customer_id");
     ColKey name_col = t->add_column(type_String, "name");
     ColKey account_col = t->add_column(type_Double, "account_balance");
-    ColKey items_col = t->add_column_link(type_LinkList, "items", *items);
-    ColKey fav_col = t->add_column_link(type_Link, "fav_item", *items);
+    ColKey items_col = t->add_column_list(*items, "items");
+    ColKey fav_col = t->add_column(*items, "fav_item");
     std::vector<ObjKey> people_keys;
     t->create_objects(3, people_keys);
     for (size_t i = 0; i < people_keys.size(); ++i) {
@@ -3124,7 +3124,7 @@ TEST(Parser_BacklinkCount)
 
     TableRef items = g.add_table("class_Items");
     items->add_column(type_Int, "item_id");
-    auto item_link_col = items->add_column_link(type_Link, "self", *items);
+    auto item_link_col = items->add_column(*items, "self");
     items->add_column(type_Double, "double_col");
 
     std::vector<int64_t> item_ids{5, 2, 12, 14, 20};
@@ -3136,8 +3136,8 @@ TEST(Parser_BacklinkCount)
 
     TableRef t = g.add_table("class_Person");
     auto id_col = t->add_column(type_Int, "customer_id");
-    auto items_col = t->add_column_link(type_LinkList, "items", *items);
-    auto fav_col = t->add_column_link(type_Link, "fav_item", *items);
+    auto items_col = t->add_column_list(*items, "items");
+    auto fav_col = t->add_column(*items, "fav_item");
     auto float_col = t->add_column(type_Float, "float_col");
 
     for (int i = 0; i < 3; ++i) {
@@ -3312,8 +3312,8 @@ TEST(Parser_Subquery)
     TableRef items = g.add_table("class_Items");
     ColKey item_name_col = items->add_column(type_String, "name");
     ColKey item_price_col = items->add_column(type_Double, "price");
-    ColKey item_discount_col = items->add_column_link(type_Link, "discount", *discounts);
-    ColKey item_contains_col = items->add_column_link(type_LinkList, "allergens", *ingredients);
+    ColKey item_discount_col = items->add_column(*discounts, "discount");
+    ColKey item_contains_col = items->add_column_list(*ingredients, "allergens");
     using item_t = std::pair<std::string, double>;
     std::vector<item_t> item_info = {{"milk", 5.5}, {"oranges", 4.0}, {"pizza", 9.5}, {"cereal", 6.5}};
     std::vector<ObjKey> item_keys;
@@ -3346,8 +3346,8 @@ TEST(Parser_Subquery)
     TableRef t = g.add_table("class_Person");
     ColKey id_col = t->add_column(type_Int, "customer_id");
     ColKey account_col = t->add_column(type_Double, "account_balance");
-    ColKey items_col = t->add_column_link(type_LinkList, "items", *items);
-    ColKey fav_col = t->add_column_link(type_Link, "fav_item", *items);
+    ColKey items_col = t->add_column_list(*items, "items");
+    ColKey fav_col = t->add_column(*items, "fav_item");
     std::vector<ObjKey> people_keys;
     t->create_objects(3, people_keys);
     for (size_t i = 0; i < t->size(); ++i) {
@@ -3474,7 +3474,7 @@ TEST_TYPES(Parser_AggregateShortcuts, std::true_type, std::false_type)
     TableRef items = g.add_table("class_Items");
     ColKey item_name_col = items->add_column(type_String, "name");
     ColKey item_price_col = items->add_column(type_Double, "price");
-    ColKey item_contains_col = items->add_column_link(type_LinkList, "allergens", *allergens);
+    ColKey item_contains_col = items->add_column_list(*allergens, "allergens");
     using item_t = std::pair<std::string, double>;
     std::vector<item_t> item_info = {{"milk", 5.5}, {"oranges", 4.0}, {"pizza", 9.5}, {"cereal", 6.5}};
     std::vector<ObjKey> items_keys;
@@ -3504,8 +3504,8 @@ TEST_TYPES(Parser_AggregateShortcuts, std::true_type, std::false_type)
     TableRef t = g.add_table("class_Person");
     ColKey id_col = t->add_column(type_Int, "customer_id");
     ColKey account_col = t->add_column(type_Double, "account_balance");
-    ColKey items_col = t->add_column_link(type_LinkList, "items", *items);
-    ColKey fav_col = t->add_column_link(type_Link, "fav_item", *items);
+    ColKey items_col = t->add_column_list(*items, "items");
+    ColKey fav_col = t->add_column(*items, "fav_item");
     std::vector<ObjKey> people_keys;
     t->create_objects(3, people_keys);
     for (size_t i = 0; i < people_keys.size(); ++i) {
@@ -3660,7 +3660,7 @@ TEST(Parser_OperatorIN)
     TableRef items = g.add_table("class_Items");
     ColKey item_name_col = items->add_column(type_String, "name");
     ColKey item_price_col = items->add_column(type_Double, "price");
-    ColKey item_contains_col = items->add_column_link(type_LinkList, "allergens", *allergens);
+    ColKey item_contains_col = items->add_column_list(*allergens, "allergens");
     using item_t = std::pair<std::string, double>;
     std::vector<item_t> item_info = {{"milk", 5.5}, {"oranges", 4.0}, {"pizza", 9.5}, {"cereal", 6.5}};
     std::vector<ObjKey> items_keys;
@@ -3690,8 +3690,8 @@ TEST(Parser_OperatorIN)
     TableRef t = g.add_table("class_Person");
     ColKey id_col = t->add_column(type_Int, "customer_id");
     ColKey account_col = t->add_column(type_Double, "account_balance");
-    ColKey items_col = t->add_column_link(type_LinkList, "items", *items);
-    ColKey fav_col = t->add_column_link(type_Link, "fav_item", *items);
+    ColKey items_col = t->add_column_list(*items, "items");
+    ColKey fav_col = t->add_column(*items, "fav_item");
     std::vector<ObjKey> people_keys;
     t->create_objects(3, people_keys);
     for (size_t i = 0; i < people_keys.size(); ++i) {
@@ -3754,7 +3754,7 @@ TEST(Parser_Object)
     Group g;
     TableRef table = g.add_table("table");
     auto int_col = table->add_column(type_Int, "ints", true);
-    auto link_col = table->add_column_link(type_Link, "link", *table);
+    auto link_col = table->add_column(*table, "link");
     for (size_t i = 0; i < 3; ++i) {
         table->create_object().set<int64_t>(int_col, i);
     }

--- a/test/test_query.cpp
+++ b/test/test_query.cpp
@@ -495,7 +495,7 @@ TEST(Query_NextGen_StringConditions)
     CHECK_EQUAL(cnt, 1);
 
     TableRef table3 = group.add_table(StringData("table3"));
-    auto col_link1 = table3->add_column_link(type_Link, "link1", *table2);
+    auto col_link1 = table3->add_column(*table2, "link1");
 
     table3->create_object().set(col_link1, key_2_0);
     table3->create_object().set(col_link1, key_2_1);
@@ -1495,8 +1495,8 @@ TEST(Query_Links)
 
     auto int_col = target2->add_column(type_Int, "integers");
     auto str_col = target1->add_column(type_String, "strings");
-    auto linklist_col = target1->add_column_link(type_LinkList, "linklist", *target2);
-    auto link_col = origin->add_column_link(type_Link, "link", *target1);
+    auto linklist_col = target1->add_column_list(*target2, "linklist");
+    auto link_col = origin->add_column(*target1, "link");
     auto double_col = origin->add_column(type_Double, "doubles");
 
     std::vector<ObjKey> origin_keys;
@@ -1555,12 +1555,12 @@ TEST(Query_size)
     auto string_col = table1->add_column(type_String, "strings");
     auto bin_col = table1->add_column(type_Binary, "binaries", true);
     auto int_list_col = table1->add_column_list(type_Int, "intlist");
-    auto linklist_col = table1->add_column_link(type_LinkList, "linklist", *table2);
+    auto linklist_col = table1->add_column_list(*table2, "linklist");
 
     auto int_col = table2->add_column(type_Int, "integers");
 
-    auto link_col = table3->add_column_link(type_Link, "link", *table1);
-    auto linklist_col1 = table3->add_column_link(type_LinkList, "linklist", *table1);
+    auto link_col = table3->add_column(*table1, "link");
+    auto linklist_col1 = table3->add_column_list(*table1, "linklist");
 
     std::vector<ObjKey> table1_keys;
     table1->create_objects(10, table1_keys);
@@ -1766,8 +1766,8 @@ TEST(Query_ListOfPrimitives)
     CHECK_EQUAL(tv.get_key(1), keys[1]);
 
     TableRef baa = g.add_table("baa");
-    auto col_link = baa->add_column_link(type_Link, "link", *table);
-    auto col_linklist = baa->add_column_link(type_LinkList, "linklist", *table);
+    auto col_link = baa->add_column(*table, "link");
+    auto col_linklist = baa->add_column_list(*table, "linklist");
     Obj obj0 = baa->create_object().set(col_link, keys[1]);
     Obj obj1 = baa->create_object().set(col_link, keys[0]);
 
@@ -3315,10 +3315,10 @@ TEST(Query_SortLinks)
 
     auto t1_int_col = t1->add_column(type_Int, "t1_int");
     auto t1_str_col = t1->add_column(type_String, "t1_string");
-    auto t1_link_t2_col = t1->add_column_link(type_Link, "t1_link_to_t2", *t2);
+    auto t1_link_t2_col = t1->add_column(*t2, "t1_link_to_t2");
     t2->add_column(type_Int, "t2_int");
     t2->add_column(type_String, "t2_string");
-    t2->add_column_link(type_Link, "t2_link_to_t1", *t1);
+    t2->add_column(*t1, "t2_link_to_t1");
 
     std::vector<ObjKey> t1_keys;
     std::vector<ObjKey> t2_keys;
@@ -3367,10 +3367,10 @@ TEST(Query_SortLinkChains)
     TableRef t3 = g.add_table("t3");
 
     auto t1_int_col = t1->add_column(type_Int, "t1_int");
-    auto t1_link_col = t1->add_column_link(type_Link, "t1_link_t2", *t2);
+    auto t1_link_col = t1->add_column(*t2, "t1_link_t2");
 
     auto t2_int_col = t2->add_column(type_Int, "t2_int");
-    auto t2_link_col = t2->add_column_link(type_Link, "t2_link_t3", *t3);
+    auto t2_link_col = t2->add_column(*t3, "t2_link_t3");
 
     auto t3_int_col = t3->add_column(type_Int, "t3_int", true);
     auto t3_str_col = t3->add_column(type_String, "t3_str");
@@ -3508,9 +3508,9 @@ TEST(Query_LinkChainSortErrors)
     TableRef t2 = g.add_table("t2");
 
     auto t1_int_col = t1->add_column(type_Int, "t1_int");
-    auto t1_linklist_col = t1->add_column_link(type_LinkList, "t1_linklist", *t2);
+    auto t1_linklist_col = t1->add_column_list(*t2, "t1_linklist");
     auto t2_string_col = t2->add_column(type_String, "t2_string");
-    t2->add_column_link(type_Link, "t2_link_t1", *t1); // add a backlink to t1
+    t2->add_column(*t1, "t2_link_t1"); // add a backlink to t1
 
     t1->create_object();
 
@@ -3630,7 +3630,7 @@ TEST(Query_DescriptorsWillApply)
     TableRef t1 = g.add_table("t1");
     auto t1_int_col = t1->add_column(type_Int, "t1_int");
     auto t1_str_col = t1->add_column(type_String, "t1_str");
-    auto t1_link_col = t1->add_column_link(type_Link, "t1_link", *t1);
+    auto t1_link_col = t1->add_column(*t1, "t1_link");
 
     t1->create_object();
 
@@ -3952,7 +3952,7 @@ TEST(Query_DistinctAndSort)
     TableRef t2 = g.add_table("t2");
     auto t1_int_col = t1->add_column(type_Int, "t1_int");
     auto t1_str_col = t1->add_column(type_String, "t1_str");
-    auto t1_link_col = t1->add_column_link(type_Link, "t1_link_t2", *t2);
+    auto t1_link_col = t1->add_column(*t2, "t1_link_t2");
     auto t2_int_col = t2->add_column(type_Int, "t2_int");
 
     ObjKeyVector t1_keys({0, 1, 2, 3, 4, 5});
@@ -4072,7 +4072,7 @@ TEST(Query_SortDistinctOrderThroughHandover)
     TableRef t1 = g->add_table("t1");
     auto t1_int_col = t1->add_column(type_Int, "t1_int");
     auto t1_str_col = t1->add_column(type_String, "t1_str");
-    auto t1_link_col = t1->add_column_link(type_Link, "t1_link", *t1);
+    auto t1_link_col = t1->add_column(*t1, "t1_link");
 
     ObjKey k0 = t1->create_object().set_all(100, "A").get_key();
     ObjKey k1 = t1->create_object().set_all(200, "A").get_key();
@@ -4311,10 +4311,10 @@ TEST(Query_DistinctThroughLinks)
     TableRef t3 = g.add_table("t3");
 
     auto t1_int_col = t1->add_column(type_Int, "t1_int");
-    auto t1_link_col = t1->add_column_link(type_Link, "t1_link_t2", *t2);
+    auto t1_link_col = t1->add_column(*t2, "t1_link_t2");
 
     auto t2_int_col = t2->add_column(type_Int, "t2_int");
-    auto t2_link_col = t2->add_column_link(type_Link, "t2_link_t3", *t3);
+    auto t2_link_col = t2->add_column(*t3, "t2_link_t3");
 
     auto t3_int_col = t3->add_column(type_Int, "t3_int", true);
     auto t3_str_col = t3->add_column(type_String, "t3_str");
@@ -4487,7 +4487,7 @@ TEST(Query_IncludeDescriptorSelfLinks)
     TableRef t1 = g.add_table("t1");
 
     auto t1_int_col = t1->add_column(type_Int, "t1_int");
-    auto t1_link_self_col = t1->add_column_link(type_Link, "t1_link_self", *t1);
+    auto t1_link_self_col = t1->add_column(*t1, "t1_link_self");
 
     ObjKeys obj_keys;
     t1->create_objects(7, obj_keys);
@@ -4603,7 +4603,7 @@ TEST(Query_IncludeDescriptorOtherLinks)
 
     auto t1_int_col = t1->add_column(type_Int, "t1_int");
     auto t2_int_col = t2->add_column(type_Int, "t2_int");
-    auto t2_link_t1_col = t2->add_column_link(type_Link, "t2_link_t1", *t1);
+    auto t2_link_t1_col = t2->add_column(*t1, "t2_link_t1");
 
     ObjKeys obj_keys;
     t1->create_objects(7, obj_keys);
@@ -4675,7 +4675,7 @@ TEST(Query_IncludeDescriptorOtherLists)
 
     auto t1_int_col = t1->add_column(type_Int, "t1_int");
     auto t2_int_col = t2->add_column(type_Int, "t2_int");
-    auto t2_list_t1_col = t2->add_column_link(type_LinkList, "t2_list_t1", *t1);
+    auto t2_list_t1_col = t2->add_column_list(*t1, "t2_list_t1");
 
     ObjKeys obj_keys;
     t1->create_objects(7, obj_keys);
@@ -4759,12 +4759,12 @@ TEST(Query_IncludeDescriptorLinkAndListTranslation)
     TableRef t4 = g.add_table("t4");
 
     auto t1_int_col = t1->add_column(type_Int, "t1_int");
-    auto t1_link_t2_col = t1->add_column_link(type_Link, "t1_link_t2", *t2);
+    auto t1_link_t2_col = t1->add_column(*t2, "t1_link_t2");
     auto t2_int_col = t2->add_column(type_Int, "t2_int");
-    auto t2_list_t3_col = t2->add_column_link(type_LinkList, "t2_list_t3", *t3);
+    auto t2_list_t3_col = t2->add_column_list(*t3, "t2_list_t3");
     auto t3_int_col = t3->add_column(type_Int, "t3_int");
     auto t4_int_col = t4->add_column(type_Int, "t4_int");
-    auto t4_link_t3_col = t4->add_column_link(type_Link, "t4_link_t3", *t3);
+    auto t4_link_t3_col = t4->add_column(*t3, "t4_link_t3");
 
     ObjKeys t1_keys;
     ObjKeys t2_keys;

--- a/test/test_query2.cpp
+++ b/test/test_query2.cpp
@@ -2613,8 +2613,8 @@ TEST(Query_LinkCounts)
 
     TableRef table2 = group.add_table("table2");
     auto col_int = table2->add_column(type_Int, "int");
-    auto col_link = table2->add_column_link(type_Link, "link", *table1);
-    auto col_linklist = table2->add_column_link(type_LinkList, "linklist", *table1);
+    auto col_link = table2->add_column(*table1, "link");
+    auto col_linklist = table2->add_column_list(*table1, "linklist");
 
     table2->create_object().set_all(0);
     table2->create_object().set_all(1, k1).get_linklist(col_linklist).add(k1);
@@ -2686,7 +2686,7 @@ TEST(Query_Link_Minimum)
     auto k3 = table1->create_object().get_key();
 
     TableRef table2 = group.add_table("table2");
-    auto col_linklist = table2->add_column_link(type_LinkList, "linklist", *table1);
+    auto col_linklist = table2->add_column_list(*table1, "linklist");
 
     // table2
     // 0: { }
@@ -2771,8 +2771,8 @@ TEST(Query_Link_MaximumSumAverage)
 
     TableRef table2 = group.add_table("table2");
     auto col_double = table2->add_column(type_Double, "double");
-    auto col_link = table2->add_column_link(type_Link, "link", *table1);
-    auto col_linklist = table2->add_column_link(type_LinkList, "linklist", *table1);
+    auto col_link = table2->add_column(*table1, "link");
+    auto col_linklist = table2->add_column_list(*table1, "linklist");
 
     // table2
     // 0: 456.0 ->0 { }
@@ -2976,7 +2976,7 @@ TEST(Query_OperatorsOverLink)
 
     TableRef table2 = group.add_table("table2");
     auto col_int2 = table2->add_column(type_Int, "int");
-    auto col_linklist = table2->add_column_link(type_LinkList, "linklist", *table1);
+    auto col_linklist = table2->add_column_list(*table1, "linklist");
 
     // table2
     // 0:  0 { }
@@ -3086,8 +3086,8 @@ TEST(Query_CompareLinkedColumnVsColumn)
 
     TableRef table2 = group.add_table("table2");
     auto col_int2 = table2->add_column(type_Int, "int");
-    auto col_link1 = table2->add_column_link(type_Link, "link1", *table1);
-    auto col_link2 = table2->add_column_link(type_Link, "link2", *table1);
+    auto col_link1 = table2->add_column(*table1, "link1");
+    auto col_link2 = table2->add_column(*table1, "link2");
 
     // table2
     // 0: 2 {   } { 0 }
@@ -3139,8 +3139,8 @@ TEST(Query_CompareThroughUnaryLinks)
     table1->get_object(keys[2]).set_all(8, 8.0, "def");
 
     TableRef table2 = group.add_table("table2");
-    auto col_link1 = table2->add_column_link(type_Link, "link1", *table1);
-    auto col_link2 = table2->add_column_link(type_Link, "link2", *table1);
+    auto col_link1 = table2->add_column(*table1, "link1");
+    auto col_link2 = table2->add_column(*table1, "link2");
 
     // table2
     // 0: {   } { 0 }
@@ -3193,7 +3193,7 @@ TEST(Query_DeepLink)
     TableRef table = group.add_table("test");
     table->add_column(type_Int, "int");
     auto col_bool = table->add_column(type_Bool, "bool");
-    auto col_linklist = table->add_column_link(type_LinkList, "list", *table);
+    auto col_linklist = table->add_column_list(*table, "list");
 
     for (int j = 0; j < N; ++j) {
         TableView view = table->where().find_all();
@@ -3218,7 +3218,7 @@ TEST(Query_LinksToDeletedOrMovedRow)
     TableRef source = group.add_table("source");
     TableRef target = group.add_table("target");
 
-    auto col_link = source->add_column_link(type_Link, "link", *target);
+    auto col_link = source->add_column(*target, "link");
     auto col_name = target->add_column(type_String, "name");
 
     ObjKeys keys({4, 6, 8});
@@ -3777,7 +3777,7 @@ TEST(Query_ReferDeletedLinkView)
     // They will no longer throw exceptions or crash.
     Group group;
     TableRef table = group.add_table("table");
-    auto col_link = table->add_column_link(type_LinkList, "children", *table);
+    auto col_link = table->add_column_list(*table, "children");
     auto col_int = table->add_column(type_Int, "age");
     auto links = table->create_object().set(col_int, 123).get_linklist(col_link);
     Query q = table->where(links);
@@ -3838,7 +3838,7 @@ TEST(Query_SubQueries)
     auto col_int_t = target->add_column(type_Int, "integers");
     auto col_string_t = target->add_column(type_String, "strings");
     // in order to use set_all, columns involved in set_all must be inserted first.
-    auto col_link_o = origin->add_column_link(type_LinkList, "link", *target);
+    auto col_link_o = origin->add_column_list(*target, "link");
 
 
     // add some rows
@@ -4151,7 +4151,7 @@ TEST(Query_SyncViewIfNeeded)
     TableRef source = group.add_table("source");
     TableRef target = group.add_table("target");
 
-    auto col_links = source->add_column_link(type_LinkList, "link", *target);
+    auto col_links = source->add_column_list(*target, "link");
     auto col_id = target->add_column(type_Int, "id");
 
     auto reset_table_contents = [&] {
@@ -4376,7 +4376,7 @@ TEST(Query_ArrayLeafRelocate)
 
         auto col_int = contact_type->add_column(type_Int, "id");
         auto col_str = contact_type->add_column(type_String, "str");
-        auto col_link = contact->add_column_link(type_LinkList, "link", *contact_type);
+        auto col_link = contact->add_column_list(*contact_type, "link");
 
         std::vector<ObjKey> contact_type_keys;
         std::vector<ObjKey> contact_keys;
@@ -4563,9 +4563,9 @@ TEST(Query_ColumnDeletionLinks)
     auto col_int0 = foobar->add_column(type_Int, "int");
 
     auto col_int1 = bar->add_column(type_Int, "int");
-    auto col_link0 = bar->add_column_link(type_Link, "link", *foobar);
+    auto col_link0 = bar->add_column(*foobar, "link");
 
-    auto col_link1 = foo->add_column_link(type_Link, "link", *bar);
+    auto col_link1 = foo->add_column(*bar, "link");
 
     std::vector<ObjKey> foobar_keys;
     std::vector<ObjKey> bar_keys;
@@ -4754,8 +4754,8 @@ TEST(Query_LinksTo)
     TableRef source = group.add_table("source");
     TableRef target = group.add_table("target");
 
-    auto col_link = source->add_column_link(type_Link, "link", *target);
-    auto col_linklist = source->add_column_link(type_LinkList, "linklist", *target);
+    auto col_link = source->add_column(*target, "link");
+    auto col_linklist = source->add_column_list(*target, "linklist");
 
     std::vector<ObjKey> target_keys;
     target->create_objects(10, target_keys);
@@ -4821,13 +4821,13 @@ TEST(Query_Group_bug)
     TableRef person_table = g.add_table("person");
 
     auto col_service_id = service_table->add_column(type_String, "id");
-    auto col_service_link = service_table->add_column_link(type_LinkList, "profiles", *profile_table);
+    auto col_service_link = service_table->add_column_list(*profile_table, "profiles");
 
     auto col_profile_id = profile_table->add_column(type_String, "role");
-    auto col_profile_link = profile_table->add_column_link(type_Link, "services", *service_table);
+    auto col_profile_link = profile_table->add_column(*service_table, "services");
 
     auto col_person_id = person_table->add_column(type_String, "id");
-    auto col_person_link = person_table->add_column_link(type_LinkList, "services", *service_table);
+    auto col_person_link = person_table->add_column_list(*service_table, "services");
 
     auto sk0 = service_table->create_object().set(col_service_id, "service_1").get_key();
     auto sk1 = service_table->create_object().set(col_service_id, "service_2").get_key();
@@ -5064,7 +5064,7 @@ TEST(Query_IntIndexOverLinkViewNotInTableOrder)
     auto k1 = child_table->create_object().set(col_child_id, 2).get_key();
 
     TableRef parent_table = g.add_table("parent");
-    auto col_parent_children = parent_table->add_column_link(type_LinkList, "children", *child_table);
+    auto col_parent_children = parent_table->add_column_list(*child_table, "children");
 
     auto parent_obj = parent_table->create_object();
     auto children = parent_obj.get_linklist(col_parent_children);
@@ -5106,7 +5106,7 @@ TEST(Query_LinkListIntPastOneIsNull)
     auto table_foo = g.add_table("Foo");
     auto table_bar = g.add_table("Bar");
     auto col_int = table_foo->add_column(type_Int, "int", true);
-    auto col_list = table_bar->add_column_link(type_LinkList, "foo_link", *table_foo);
+    auto col_list = table_bar->add_column_list(*table_foo, "foo_link");
     std::vector<util::Optional<int64_t>> values = {{0}, {1}, {2}, {util::none}};
     auto bar_obj = table_bar->create_object();
     auto list = bar_obj.get_linklist(col_list);
@@ -5129,7 +5129,7 @@ TEST(Query_LinkView_StrIndex)
     auto col_id = table_foo->get_column_key("id");
 
     auto table_bar = g.add_table("class_Bar");
-    auto col_list = table_bar->add_column_link(type_LinkList, "link", *table_foo);
+    auto col_list = table_bar->add_column_list(*table_foo, "link");
 
     auto foo = table_foo->create_object_with_primary_key("97625fdc-d3f8-4c45-9a4d-dc8c83c657a1");
     auto bar = table_bar->create_object();
@@ -5205,7 +5205,7 @@ TEST(Query_LinkViewAnd)
     auto k1 = child_table->create_object().set(col_child_id, 2).set(col_child_name, "Jeff").get_key();
 
     TableRef parent_table = g.add_table("parent");
-    auto col_parent_children = parent_table->add_column_link(type_LinkList, "children", *child_table);
+    auto col_parent_children = parent_table->add_column_list(*child_table, "children");
 
     auto parent_obj = parent_table->create_object();
     auto children = parent_obj.get_linklist(col_parent_children);
@@ -5231,17 +5231,17 @@ TEST(Query_LinksWithIndex)
     target->add_search_index(col_date);
 
     TableRef foo = g.add_table("foo");
-    auto col_foo = foo->add_column_link(type_LinkList, "linklist", *target);
+    auto col_foo = foo->add_column_list(*target, "linklist");
     auto col_location = foo->add_column(type_String, "location");
     auto col_score = foo->add_column(type_Int, "score");
     foo->add_search_index(col_location);
     foo->add_search_index(col_score);
 
     TableRef middle = g.add_table("middle");
-    auto col_link = middle->add_column_link(type_Link, "link", *target);
+    auto col_link = middle->add_column(*target, "link");
 
     TableRef origin = g.add_table("origin");
-    auto col_linklist = origin->add_column_link(type_LinkList, "linklist", *middle);
+    auto col_linklist = origin->add_column_list(*middle, "linklist");
 
     std::vector<StringData> strings{"Copenhagen", "Aarhus", "Odense", "Aalborg", "Faaborg"};
     auto now = std::chrono::system_clock::now();
@@ -5298,7 +5298,7 @@ TEST(Query_NotImmediatelyBeforeKnownRange)
     Group g;
     TableRef parent = g.add_table("parent");
     TableRef child = g.add_table("child");
-    auto col_link = parent->add_column_link(type_LinkList, "list", *child);
+    auto col_link = parent->add_column_list(*child, "list");
     auto col_str = child->add_column(type_String, "value");
     child->add_search_index(col_str);
 

--- a/test/test_query_big.cpp
+++ b/test/test_query_big.cpp
@@ -266,12 +266,12 @@ TEST(Query_TableInitialization)
     ColKey col_int = table.add_column(type_Int, "int");
     ColKey col_float = table.add_column(type_Float, "float");
     ColKey col_bool = table.add_column(type_Bool, "bool");
-    ColKey col_link = table.add_column_link(type_Link, "link", table);
+    ColKey col_link = table.add_column(table, "link");
     ColKey col_string_enum = table.add_column(type_String, "string enum");
     // FIXME table.optimize();
     ColKey col_double = table.add_column(type_Double, "double");
     ColKey col_string = table.add_column(type_String, "string");
-    ColKey col_list = table.add_column_link(type_LinkList, "list", table);
+    ColKey col_list = table.add_column_list(table, "list");
     ColKey col_binary = table.add_column(type_Binary, "binary");
     ColKey col_timestamp = table.add_column(type_Timestamp, "timestamp");
     ColKey col_string_indexed = table.add_column(type_String, "indexed string");

--- a/test/test_shared.cpp
+++ b/test/test_shared.cpp
@@ -1807,7 +1807,7 @@ TEST(Shared_ClearColumnWithLinksToSelf)
     {
         WriteTransaction wt(sg);
         TableRef test = wt.add_table("Test");
-        auto col = test->add_column_link(type_Link, "foo", *test);
+        auto col = test->add_column(*test, "foo");
         test->add_column(type_Int, "bar");
         ObjKeys keys;
         test->create_objects(400, keys);             // Ensure non root clusters
@@ -3783,7 +3783,7 @@ TEST(Shared_RemoveTableWithEnumAndLinkColumns)
         tk = table->get_key();
         auto col_key = table->add_column(DataType(2), "string_3", false);
         table->enumerate_string_column(col_key);
-        table->add_column_link(type_Link, "link_5", *table);
+        table->add_column(*table, "link_5");
         table->add_search_index(col_key);
         wt->commit();
     }
@@ -3932,7 +3932,7 @@ TEST_IF(Shared_LinksToSameCluster, REALM_ENABLE_ENCRYPTION)
         auto t = wt->add_table("Table_0");
         // Create more object that can be held in a single cluster
         t->create_objects(267, keys);
-        auto col = t->add_column_link(type_Link, "link_0", *wt->get_table("Table_0"));
+        auto col = t->add_column(*wt->get_table("Table_0"), "link_0");
 
         // Create two links
         Obj obj = t->get_object(keys[48]);

--- a/test/test_stable_ids.cpp
+++ b/test/test_stable_ids.cpp
@@ -178,7 +178,7 @@ TEST(StableIDs_ChangesGlobalObjectIdWhenPeerIdReceived)
         WriteTransaction wt{sg};
         TableRef t0 = sync::create_table(wt, "class_t0");
         TableRef t1 = sync::create_table(wt, "class_t1");
-        link_col = t0->add_column_link(type_Link, "link", *t1);
+        link_col = t0->add_column(*t1, "link");
 
         Obj t1_k1 = t1->create_object();
         Obj t0_k1 = t0->create_object().set(link_col, t1_k1.get_key());

--- a/test/test_sync.cpp
+++ b/test/test_sync.cpp
@@ -1238,7 +1238,7 @@ TEST(Sync_DetectSchemaMismatch_Links)
             WriteTransaction wt(sg_1);
             TableRef table = sync::create_table(wt, "class_foo");
             TableRef target = sync::create_table(wt, "class_bar");
-            table->add_column_link(type_Link, "column", *target);
+            table->add_column(*target, "column");
             auto new_version = wt.commit();
             session_1.nonsync_transact_notify(new_version);
         }
@@ -1247,7 +1247,7 @@ TEST(Sync_DetectSchemaMismatch_Links)
             WriteTransaction wt(sg_2);
             TableRef table = sync::create_table(wt, "class_foo");
             TableRef target = sync::create_table(wt, "class_baz");
-            table->add_column_link(type_Link, "column", *target);
+            table->add_column(*target, "column");
             auto new_version = wt.commit();
             session_2.nonsync_transact_notify(new_version);
         }
@@ -6499,7 +6499,7 @@ TEST(Sync_ContainerInsertAndSetLogCompaction)
         auto k1 = table_target->create_object().set(col_ndx, 456).get_key();
 
         TableRef table_source = create_table(wt, "class_source");
-        col_ndx = table_source->add_column_link(type_LinkList, "target_link", *table_target);
+        col_ndx = table_source->add_column_list(*table_target, "target_link");
         Obj obj = table_source->create_object();
         LnkLst ll = obj.get_linklist(col_ndx);
         ll.insert(0, k0);
@@ -7394,7 +7394,7 @@ TEST(Sync_LogCompaction_EraseObject_LinkList)
 
         TableRef table_source = create_table(wt, "class_source");
         TableRef table_target = create_table(wt, "class_target");
-        auto col_key = table_source->add_column_link(type_LinkList, "target_link", *table_target);
+        auto col_key = table_source->add_column_list(*table_target, "target_link");
 
         auto k0 = table_target->create_object().get_key();
         auto k1 = table_target->create_object().get_key();

--- a/test/test_sync_multiserver.cpp
+++ b/test/test_sync_multiserver.cpp
@@ -482,7 +482,7 @@ TEST(Sync_Multiserver_PartialSync)
             if (!col_ndx_result_set_matches_property)
                 col_ndx_result_set_matches_property = result_sets->add_column(type_String, "matches_property");
             // 0 = uninitialized, 1 = initialized, -1 = query parsing failed
-            result_sets->add_column_link(type_LinkList, "matches", *table);
+            result_sets->add_column_list(*table, "matches");
             Obj result_set = create_object(wt, *result_sets);
             result_set.set(col_ndx_result_set_query, "TRUEPREDICATE");
             result_set.set(col_ndx_result_set_matches_property, "matches");

--- a/test/test_table_view.cpp
+++ b/test/test_table_view.cpp
@@ -1150,8 +1150,8 @@ TEST(TableView_Backlinks)
     source->add_column(type_Int, "int");
 
     TableRef links = group.add_table("links");
-    auto col_link = links->add_column_link(type_Link, "link", *source);
-    auto col_linklist = links->add_column_link(type_LinkList, "link_list", *source);
+    auto col_link = links->add_column(*source, "link");
+    auto col_linklist = links->add_column_list(*source, "link_list");
 
     std::vector<ObjKey> keys;
     source->create_objects(3, keys);
@@ -1198,8 +1198,8 @@ TEST(TableView_BacklinksAfterMoveAssign)
     source->add_column(type_Int, "int");
 
     TableRef links = group.add_table("links");
-    auto col_link = links->add_column_link(type_Link, "link", *source);
-    auto col_linklist = links->add_column_link(type_LinkList, "link_list", *source);
+    auto col_link = links->add_column(*source, "link");
+    auto col_linklist = links->add_column_list(*source, "link_list");
 
     std::vector<ObjKey> keys;
     source->create_objects(3, keys);
@@ -1244,7 +1244,7 @@ TEST(TableView_SortOverLink)
     Group g;
     TableRef target = g.add_table("target");
     TableRef origin = g.add_table("origin");
-    auto col_link = origin->add_column_link(type_Link, "link", *target);
+    auto col_link = origin->add_column(*target, "link");
     auto col_int = origin->add_column(type_Int, "int");
     auto col_str = target->add_column(type_String, "s", true);
 
@@ -1295,8 +1295,8 @@ TEST(TableView_SortOverMultiLink)
     TableRef target = g.add_table("target");
     TableRef between = g.add_table("between");
     TableRef origin = g.add_table("origin");
-    auto col_link1 = origin->add_column_link(type_Link, "link", *between);
-    auto col_link2 = between->add_column_link(type_Link, "link", *target);
+    auto col_link1 = origin->add_column(*between, "link");
+    auto col_link2 = between->add_column(*target, "link");
     auto col_int = origin->add_column(type_Int, "int");
 
     auto col_str = target->add_column(type_String, "str");
@@ -1444,7 +1444,7 @@ TEST_TYPES(TableView_Distinct, DistinctDirect, DistinctOverLink)
     Group g;
     TableRef target = g.add_table("target");
     TableRef origin = g.add_table("origin");
-    auto col_link = origin->add_column_link(type_Link, "link", *target);
+    auto col_link = origin->add_column(*target, "link");
 
     Table& t = *target;
     auto col_str = t.add_column(type_String, "s", true);
@@ -1566,7 +1566,7 @@ TEST(TableView_DistinctOverNullLink)
     ObjKey k1 = target->create_object().set(col_int, 1).get_key();
 
     TableRef origin = g.add_table("origin");
-    auto col_link = origin->add_column_link(type_Link, "link", *target);
+    auto col_link = origin->add_column(*target, "link");
 
     origin->create_object().set(col_link, k0);
     origin->create_object().set(col_link, k1);
@@ -1612,7 +1612,7 @@ TEST(TableView_IsInTableOrder)
     TableRef source = g.add_table("source");
     TableRef target = g.add_table("target");
 
-    auto col_link = source->add_column_link(type_LinkList, "link", *target);
+    auto col_link = source->add_column_list(*target, "link");
     source->add_column(type_String, "name");
     auto col_id = target->add_column(type_Int, "id");
     target->add_search_index(col_id);

--- a/test/test_transform.cpp
+++ b/test/test_transform.cpp
@@ -248,7 +248,7 @@ TEST(Transform_LinkListSet_vs_MoveLastOver)
         TableRef foo = sync::create_table(transaction, "class_foo");
         foo->add_column(type_Int, "i");
         TableRef bar = sync::create_table(transaction, "class_bar");
-        bar->add_column_link(type_LinkList, "ll", *foo);
+        bar->add_column_list(*foo, "ll");
     };
     client_1->create_schema(create_schema);
     client_2->create_schema(create_schema);
@@ -291,7 +291,7 @@ TEST(Transform_LinkListInsert_vs_MoveLastOver)
         TableRef foo = sync::create_table(transaction, "class_foo");
         foo->add_column(type_Int, "i");
         TableRef bar = sync::create_table(transaction, "class_bar");
-        bar->add_column_link(type_LinkList, "ll", *foo);
+        bar->add_column_list(*foo, "ll");
     };
     client_1->create_schema(create_schema);
     client_2->create_schema(create_schema);
@@ -334,7 +334,7 @@ TEST(Transform_Experiment)
         TableRef t = sync::create_table(tr, "class_t");
         TableRef t2 = sync::create_table(tr, "class_t2");
         t2->add_column(type_Int, "i");
-        t->add_column_link(type_LinkList, "ll", *t2);
+        t->add_column_list(*t2, "ll");
     };
 
     client_1->create_schema(schema);
@@ -388,7 +388,7 @@ TEST(Transform_SelectLinkList)
         TableRef t = sync::create_table(tr, "class_t");
         TableRef t2 = sync::create_table(tr, "class_t2");
         t2->add_column(type_Int, "i");
-        t->add_column_link(type_LinkList, "ll", *t2);
+        t->add_column_list(*t2, "ll");
     };
 
     client_1->create_schema(schema);
@@ -474,7 +474,7 @@ TEST(Transform_AdjustSetLinkPayload)
         TableRef t = sync::create_table(tr, "class_t");
         t->add_column(type_Int, "i");
         TableRef l = sync::create_table(tr, "class_l");
-        l->add_column_link(type_Link, "l", *t);
+        l->add_column(*t, "l");
     };
 
     client_1->create_schema(schema);
@@ -528,7 +528,7 @@ TEST(Transform_AdjustLinkListSetPayload)
         TableRef t = sync::create_table(tr, "class_t");
         t->add_column(type_Int, "i");
         TableRef l = sync::create_table(tr, "class_ll");
-        l->add_column_link(type_LinkList, "ll", *t);
+        l->add_column_list(*t, "ll");
     };
 
     client_1->create_schema(schema);
@@ -623,7 +623,7 @@ TEST(Transform_MergeSetLinkAndMoveLastOver)
         TableRef t = sync::create_table(tr, "class_t");
         t->add_column(type_Int, "i");
         TableRef l = sync::create_table(tr, "class_l");
-        l->add_column_link(type_Link, "l", *t);
+        l->add_column(*t, "l");
     };
 
     client_1->create_schema(schema);
@@ -719,7 +719,7 @@ TEST(Transform_MergeLinkListsWithPrimaryKeys)
         TableRef t = sync::create_table_with_primary_key(tr, "class_t", type_Int, "i");
         TableRef t2 = sync::create_table(tr, "class_t2");
         t->add_column(type_String, "s");
-        t->add_column_link(type_LinkList, "ll", *t2);
+        t->add_column_list(*t2, "ll");
         t2->add_column(type_Int, "i2");
     };
 
@@ -908,7 +908,7 @@ TEST(Transform_EraseSelectedLinkView)
     auto init = [](WriteTransaction& tr) {
         TableRef origin = sync::create_table(tr, "class_origin");
         TableRef target = sync::create_table(tr, "class_target");
-        origin->add_column_link(type_LinkList, "ll", *target);
+        origin->add_column_list(*target, "ll");
         target->add_column(type_Int, "");
         origin->create_object();
         origin->create_object();
@@ -1419,7 +1419,7 @@ TEST(Transform_ErrorCase_LinkListDoubleMerge)
     client_1->transaction([](Peer& c) {
         TableRef a = sync::create_table_with_primary_key(*c.group, "class_a", type_Int, "pk");
         TableRef b = sync::create_table_with_primary_key(*c.group, "class_b", type_Int, "pk");
-        a->add_column_link(type_LinkList, "ll", *b);
+        a->add_column_list(*b, "ll");
         Obj a_obj = a->create_object_with_primary_key(123);
         Obj b_obj = b->create_object_with_primary_key(456);
         a_obj.get_linklist("ll").add(b_obj.get_key());
@@ -1428,7 +1428,7 @@ TEST(Transform_ErrorCase_LinkListDoubleMerge)
     client_2->transaction([](Peer& c) {
         TableRef a = sync::create_table_with_primary_key(*c.group, "class_a", type_Int, "pk");
         TableRef b = sync::create_table_with_primary_key(*c.group, "class_b", type_Int, "pk");
-        a->add_column_link(type_LinkList, "ll", *b);
+        a->add_column_list(*b, "ll");
         Obj a_obj = a->create_object_with_primary_key(123);
         Obj b_obj = b->create_object_with_primary_key(456);
         a_obj.get_linklist("ll").add(b_obj.get_key());
@@ -1454,7 +1454,7 @@ TEST(Transform_ArrayInsert_EraseObject)
     client_1->transaction([&k0, &k1](Peer& c) {
         TableRef source = sync::create_table(*c.group, "class_source");
         TableRef target = sync::create_table(*c.group, "class_target");
-        source->add_column_link(type_LinkList, "ll", *target);
+        source->add_column_list(*target, "ll");
         source->create_object();
         k0 = target->create_object().get_key();
         k1 = target->create_object().get_key();
@@ -1815,7 +1815,7 @@ TEST(Transform_DanglingLinks)
             auto& tr = *c.group;
             auto table = sync::create_table_with_primary_key(tr, "class_table", type_Int, "pk");
             auto table2 = sync::create_table_with_primary_key(tr, "class_table2", type_Int, "pk");
-            table->add_column_link(type_LinkList, "links", *table2);
+            table->add_column_list(*table2, "links");
             auto obj = table->create_object_with_primary_key(0);
             auto obj2 = table2->create_object_with_primary_key(0);
             obj.get_linklist("links").insert(0, obj2.get_key());

--- a/test/test_unresolved_links.cpp
+++ b/test/test_unresolved_links.cpp
@@ -51,11 +51,11 @@ TEST(Unresolved_Basic)
         auto cars = wt->add_table_with_primary_key("Car", type_String, "model");
         col_price = cars->add_column(type_Decimal, "price");
         auto persons = wt->add_table_with_primary_key("Person", type_String, "e-mail");
-        col_owns = persons->add_column_link(type_Link, "car", *cars);
+        col_owns = persons->add_column(*cars, "car");
         auto dealers = wt->add_table_with_primary_key("Dealer", type_Int, "cvr");
-        col_has = dealers->add_column_link(type_LinkList, "stock", *cars);
+        col_has = dealers->add_column_list(*cars, "stock");
         auto parts = wt->add_table("Parts"); // No primary key
-        col_part = cars->add_column_link(type_Link, "part", *parts);
+        col_part = cars->add_column(*parts, "part");
 
         auto finn = persons->create_object_with_primary_key("finn.schiermer-andersen@mongodb.com");
         auto mathias = persons->create_object_with_primary_key("mathias@10gen.com");
@@ -163,9 +163,9 @@ TEST(Unresolved_InvalidateObject)
     auto cars = g.add_table_with_primary_key("Car", type_String, "model");
     auto col_price = cars->add_column(type_Decimal, "price");
     auto dealers = g.add_table("Dealer");
-    auto col_has = dealers->add_column_link(type_LinkList, "stock", *cars);
+    auto col_has = dealers->add_column_list(*cars, "stock");
     auto organization = g.add_table("Organization");
-    auto col_members = organization->add_column_link(type_LinkList, "members", *dealers);
+    auto col_members = organization->add_column_list(*dealers, "members");
 
     auto dealer1 = dealers->create_object();
     auto dealer2 = dealers->create_object();
@@ -213,7 +213,7 @@ TEST(Unresolved_LinkList)
 
     auto cars = g.add_table_with_primary_key("Car", type_String, "model");
     auto dealers = g.add_table_with_primary_key("Dealer", type_Int, "cvr");
-    auto col_has = dealers->add_column_link(type_LinkList, "stock", *cars);
+    auto col_has = dealers->add_column_list(*cars, "stock");
 
     auto dealer = dealers->create_object_with_primary_key(18454033);
     auto stock1 = dealer.get_linklist(col_has);
@@ -252,9 +252,9 @@ TEST(Unresolved_QueryOverLinks)
     auto cars = g.add_table_with_primary_key("Car", type_String, "model");
     auto col_price = cars->add_column(type_Decimal, "price");
     auto persons = g.add_table_with_primary_key("Person", type_String, "e-mail");
-    auto col_owns = persons->add_column_link(type_Link, "car", *cars);
+    auto col_owns = persons->add_column(*cars, "car");
     auto dealers = g.add_table_with_primary_key("Dealer", type_Int, "cvr");
-    auto col_has = dealers->add_column_link(type_LinkList, "stock", *cars);
+    auto col_has = dealers->add_column_list(*cars, "stock");
 
     auto finn = persons->create_object_with_primary_key("finn.schiermer-andersen@mongodb.com");
     auto mathias = persons->create_object_with_primary_key("mathias@10gen.com");
@@ -305,7 +305,7 @@ TEST(Unresolved_PrimaryKeyInt)
 
     auto foo = g.add_table_with_primary_key("foo", type_Int, "id");
     auto bar = g.add_table("bar");
-    auto col = bar->add_column_link(type_Link, "link", *foo);
+    auto col = bar->add_column(*foo, "link");
 
     auto obj = bar->create_object();
     auto unres = foo->get_objkey_from_primary_key(5);
@@ -322,7 +322,7 @@ TEST(Unresolved_GarbageCollect)
 
     auto cars = g.add_table_with_primary_key("Car", type_String, "model");
     auto persons = g.add_table_with_primary_key("Person", type_String, "e-mail");
-    auto col_owns = persons->add_column_link(type_Link, "car", *cars);
+    auto col_owns = persons->add_column(*cars, "car");
 
     auto finn = persons->create_object_with_primary_key("finn.schiermer-andersen@mongodb.com");
     auto mathias = persons->create_object_with_primary_key("mathias@10gen.com");
@@ -340,7 +340,7 @@ TEST(Unresolved_GarbageCollect)
     // Try the same with linklists. Here you have to clear the lists in order to
     // remove the unresolved links
     auto dealers = g.add_table_with_primary_key("Dealer", type_Int, "cvr");
-    auto col_has = dealers->add_column_link(type_LinkList, "stock", *cars);
+    auto col_has = dealers->add_column_list(*cars, "stock");
     auto bilcentrum = dealers->create_object_with_primary_key(18454033);
     auto bilmekka = dealers->create_object_with_primary_key(26293995);
 
@@ -415,7 +415,7 @@ TEST(Unresolved_CondensedIndices)
     Group g;
     auto t1 = g.add_table_with_primary_key("Table", type_Int, "id");
     auto t2 = g.add_table_with_primary_key("Table2", type_Int, "id");
-    t1->add_column_link(type_LinkList, "t2s", *t2);
+    t1->add_column_list(*t2, "t2s");
 
     auto obj123 = t2->create_object_with_primary_key(123);
     auto obj456 = t2->create_object_with_primary_key(456);


### PR DESCRIPTION
The `Table::add_column_link()` method is not extensible to include sets and other collections, because it relies on the baggage of `type_LinkList`.

This PR deprecates `Table::add_column_link()` in favor of new overloads of `Table::add_column()` and `Table::add_column_list()`.

Apparently, this also caused some files to be clang-format'ed.