### PR TITLE
Add ability to produce xcframework

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 # NEXT RELEASE
 
 ### Enhancements
-* Added the ability to produce an XCFramework, usage: `sh ./tools/build-cocoa -x`
+* Added the ability to produce an XCFramework, usage: `sh ./tools/build-cocoa.sh -x`
 
 ### Fixed
 * <How to hit and notice issue? what was the impact?> ([#????](https://github.com/realm/realm-core/issues/????), since v?.?.?)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 # NEXT RELEASE
 
 ### Enhancements
-* None.
+* Added the ability to produce an XCFramework, usage: `sh ./tools/build-cocoa -x`
 
 ### Fixed
 * <How to hit and notice issue? what was the impact?> ([#????](https://github.com/realm/realm-core/issues/????), since v?.?.?)

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -170,12 +170,12 @@ jobWrapper {
         stage('Aggregate') {
             parallel (
                 cocoa: {
-                    node('docker') {
+                    node('osx') {
                         getArchive()
                         for (cocoaStash in cocoaStashes) {
                             unstash name: cocoaStash
                         }
-                        sh 'tools/build-cocoa.sh'
+                        sh 'tools/build-cocoa.sh -x'
                         archiveArtifacts('realm-core-cocoa*.tar.xz')
                         def stashName = 'cocoa'
                         stash includes: 'realm-core-cocoa*.tar.xz', name: stashName
@@ -602,7 +602,7 @@ def doBuildAppleDevice(String sdk, String buildType) {
 
             withEnv(['DEVELOPER_DIR=/Applications/Xcode-11.app/Contents/Developer/']) {
                 retry(3) {
-                    timeout(time: 15, unit: 'MINUTES') {
+                    timeout(time: 45, unit: 'MINUTES') {
                         sh """
                             rm -rf build-*
                             tools/cross_compile.sh -o ${sdk} -t ${buildType} -v ${gitDescribeVersion}

--- a/tools/build-cocoa.sh
+++ b/tools/build-cocoa.sh
@@ -7,21 +7,23 @@ SCRIPT=$(basename "${BASH_SOURCE[0]}")
 VERSION=$(git describe)
 
 function usage {
-    echo "Usage: ${SCRIPT} [-b] [-m] [-c <realm-cocoa-folder>] [-f <cmake-flags>]"
+    echo "Usage: ${SCRIPT} [-b] [-m] [-x] [-c <realm-cocoa-folder>] [-f <cmake-flags>]"
     echo ""
     echo "Arguments:"
     echo "   -b : build from source. If absent it will expect prebuilt packages"
     echo "   -m : build for macOS only"
+    echo "   -x : build as an xcframework"
     echo "   -c : copy core to the specified folder instead of packaging it"
     echo "   -f : additional configuration flags to pass to cmake"
     exit 1;
 }
 
 # Parse the options
-while getopts ":bmc:f:" opt; do
+while getopts ":bmxc:f:" opt; do
     case "${opt}" in
         b) BUILD=1;;
         m) MACOS_ONLY=1;;
+        x) BUILD_XCFRAMEWORK=1;;
         c) COPY=1
            DESTINATION=${OPTARG};;
         f) CMAKE_FLAGS=${OPTARG};;
@@ -83,10 +85,56 @@ for bt in "${BUILD_TYPES[@]}"; do
         mv "core/lib/librealm${suffix}.a" "core/librealm-${p}${suffix}.a"
         tar -C core -zxvf "${filename}" "lib/librealm-parser${suffix}.a"
         mv "core/lib/librealm-parser${suffix}.a" "core/librealm-parser-${p}${suffix}.a"
+
+        # extract arch slices for iOS, Watch, TV
+        if [[ "$p" != "macosx" && "$p" != "maccatalyst" ]]; then
+            case "${p}" in
+                ios) SDK="iphone";;
+                watchos) SDK="watch";;
+                tvos) SDK="appletv";;
+            esac
+            tar -C core -zxvf "${filename}" "lib/librealm-${SDK}-device${suffix}.a"
+            mv "core/lib/librealm-${SDK}-device${suffix}.a" "core/librealm-${SDK}-device${suffix}.a"
+            tar -C core -zxvf "${filename}" "lib/librealm-parser-${SDK}-device${suffix}.a"
+            mv "core/lib/librealm-parser-${SDK}-device${suffix}.a" "core/librealm-parser-${SDK}-device${suffix}.a"
+            tar -C core -zxvf "${filename}" "lib/librealm-${SDK}-simulator${suffix}.a"
+            mv "core/lib/librealm-${SDK}-simulator${suffix}.a" "core/librealm-${SDK}-simulator${suffix}.a"
+            tar -C core -zxvf "${filename}" "lib/librealm-parser-${SDK}-simulator${suffix}.a"
+            mv "core/lib/librealm-parser-${SDK}-simulator${suffix}.a" "core/librealm-parser-${SDK}-simulator${suffix}.a"
+        fi
         rm -rf core/lib
     done
 done
 
+# Produce xcframeworks
+if [[ ! -z $BUILD_XCFRAMEWORK ]]; then
+    for bt in "${BUILD_TYPES[@]}"; do
+        make_core_xcframework=()
+        [[ "$bt" = "Release" ]] && suffix="" || suffix="-dbg"
+        for p in "${PLATFORMS[@]}"; do
+            if [[ "$p" == "macosx" ]]; then
+                build_dir="core/librealm-macosx${suffix}.a"
+                make_core_xcframework+=( -library ${build_dir} -headers core/include/)
+            elif [[ "$p" == "maccatalyst" ]]; then
+                build_dir="core/librealm-maccatalyst${suffix}.a"
+                make_core_xcframework+=( -library ${build_dir} -headers core/include/)
+            else
+                case "${p}" in
+                    ios) SDK="iphone";;
+                    watchos) SDK="watch";;
+                    tvos) SDK="appletv";;
+                esac
+                build_dir_device="core/librealm-${SDK}-device${suffix}.a"
+                build_dir_simulator="core/librealm-${SDK}-simulator${suffix}.a"
+                make_core_xcframework+=( -library ${build_dir_device} -headers core/include/)
+                make_core_xcframework+=( -library ${build_dir_simulator} -headers core/include/)
+            fi
+        done
+        xcodebuild -create-xcframework "${make_core_xcframework[@]}" -output core/realm-core${suffix}.xcframework
+    done
+fi
+
+# Package artifacts
 if [[ ! -z $COPY ]]; then
     rm -rf "${DESTINATION}/core"
     mkdir -p "${DESTINATION}"

--- a/tools/cmake/Utilities.cmake
+++ b/tools/cmake/Utilities.cmake
@@ -48,3 +48,30 @@ macro(set_target_xcode_attributes _target)
             XCODE_ATTRIBUTE_GCC_OPTIMIZATION_LEVEL_RelMinSize "3"
     )
 endmacro()
+
+include(GNUInstallDirs)
+macro(install_arch_slices_for_platform _platform)
+    if(NOT "${CMAKE_BUILD_TYPE}" STREQUAL "Release")
+        set(BUILD_SUFFIX "-dbg")
+    endif()
+    # Device builds will contain '-device' so it does not collide with the fat libs
+    install(FILES ${CMAKE_CURRENT_BINARY_DIR}/src/realm/${CMAKE_BUILD_TYPE}-${_platform}os/librealm${BUILD_SUFFIX}.a
+            DESTINATION ${CMAKE_INSTALL_LIBDIR}/ RENAME librealm-${_platform}-device${BUILD_SUFFIX}.a
+            COMPONENT devel
+    )
+
+    install(FILES ${CMAKE_CURRENT_BINARY_DIR}/src/realm/${CMAKE_BUILD_TYPE}-${_platform}simulator/librealm${BUILD_SUFFIX}.a
+            DESTINATION ${CMAKE_INSTALL_LIBDIR}/ RENAME librealm-${_platform}-simulator${BUILD_SUFFIX}.a
+            COMPONENT devel
+    )
+
+    install(FILES ${CMAKE_CURRENT_BINARY_DIR}/src/realm/parser/${CMAKE_BUILD_TYPE}-${_platform}os/librealm-parser${BUILD_SUFFIX}.a
+            DESTINATION ${CMAKE_INSTALL_LIBDIR}/ RENAME librealm-parser-${_platform}-device${BUILD_SUFFIX}.a
+            COMPONENT devel
+    )
+
+    install(FILES ${CMAKE_CURRENT_BINARY_DIR}/src/realm/parser/${CMAKE_BUILD_TYPE}-${_platform}simulator/librealm-parser${BUILD_SUFFIX}.a
+            DESTINATION ${CMAKE_INSTALL_LIBDIR}/ RENAME librealm-parser-${_platform}-simulator${BUILD_SUFFIX}.a
+            COMPONENT devel
+    )
+endmacro()

--- a/tools/cmake/ios.toolchain.cmake
+++ b/tools/cmake/ios.toolchain.cmake
@@ -1,4 +1,5 @@
 include("${CMAKE_CURRENT_LIST_DIR}/Utilities.cmake")
+include(GNUInstallDirs)
 
 check_generator("Xcode")
 
@@ -25,5 +26,10 @@ set(CMAKE_XCODE_ATTRIBUTE_ARCHS_iphoneos_RelWithDebInfo "armv7 arm64")
 set(CMAKE_XCODE_ATTRIBUTE_ARCHS_iphoneos_MinSizeRel "armv7 arm64")
 
 set(CMAKE_XCODE_ATTRIBUTE_ENABLE_BITCODE[sdk=iphone*] "YES")
+set(CMAKE_XCODE_ATTRIBUTE_REALM_ALIGN_FLAG "")
+set(CMAKE_XCODE_ATTRIBUTE_REALM_ALIGN_FLAG[arch=armv7] "-fno-aligned-new")
+set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} $(REALM_ALIGN_FLAG)")
 
 set_bitcode_attributes()
+
+install_arch_slices_for_platform("iphone")

--- a/tools/cmake/tvos.toolchain.cmake
+++ b/tools/cmake/tvos.toolchain.cmake
@@ -24,3 +24,5 @@ set(CMAKE_XCODE_ATTRIBUTE_CODE_SIGNING_REQUIRED "NO")
 set(CMAKE_XCODE_ATTRIBUTE_ENABLE_BITCODE[sdk=appletv*] "YES")
 
 set_bitcode_attributes()
+
+install_arch_slices_for_platform("appletv")

--- a/tools/cmake/watchos.toolchain.cmake
+++ b/tools/cmake/watchos.toolchain.cmake
@@ -24,3 +24,5 @@ set(CMAKE_XCODE_ATTRIBUTE_CODE_SIGNING_REQUIRED "NO")
 set(CMAKE_XCODE_ATTRIBUTE_ENABLE_BITCODE[sdk=watch*] "YES")
 
 set_bitcode_attributes()
+
+install_arch_slices_for_platform("watch")


### PR DESCRIPTION
This PR adds the functionality needed to produce an `xcframework` which will be consumed Cocoa. It works by adding an additional step in `tools/build-cocoa.sh` that grabs builds of `librealm` for each architecture,  platform and build type, then places them in a temporary folder and performs `xcodebuild create-xcframework`. This will produce two `.xcframeworks` that are then added to the `core` folder.

The two `.xcframeworks` produced are:

- `realm-core-dbg.xcframework`
- `realm-core.xcframework`