### PR TITLE
Report whether create_object_with_primary_key() created a new object

### DIFF
--- a/src/realm/table.hpp
+++ b/src/realm/table.hpp
@@ -276,8 +276,9 @@ public:
     Obj create_object(ObjKey key = {}, const FieldValues& = {});
     // Create an object with specific GlobalKey.
     Obj create_object(GlobalKey object_id, const FieldValues& = {});
-    // Create an object with primary key
-    Obj create_object_with_primary_key(const Mixed& primary_key);
+    // Create an object with primary key. If an object with the given primary key already exists, it
+    // will be returned and did_create (if supplied) will be set to false.
+    Obj create_object_with_primary_key(const Mixed& primary_key, bool* did_create = nullptr);
     /// Create a number of objects and add corresponding keys to a vector
     void create_objects(size_t number, std::vector<ObjKey>& keys);
     /// Create a number of objects with keys supplied

--- a/test/test_table.cpp
+++ b/test/test_table.cpp
@@ -3982,6 +3982,33 @@ TEST(Table_CollisionMapping)
     }
 }
 
+TEST(Table_CreateObjectWithPrimaryKeyDidCreate)
+{
+    SHARED_GROUP_TEST_PATH(path);
+    DBRef sg = DB::create(path);
+
+    auto wt = sg->start_write();
+    TableRef string_table = wt->add_table_with_primary_key("string pk", type_String, "pk");
+
+    bool did_create = false;
+    string_table->create_object_with_primary_key(StringData("1"), &did_create);
+    CHECK(did_create);
+    string_table->create_object_with_primary_key(StringData("1"), &did_create);
+    CHECK_NOT(did_create);
+    string_table->create_object_with_primary_key(StringData("2"), &did_create);
+    CHECK(did_create);
+
+    TableRef int_table = wt->add_table_with_primary_key("int pk", type_Int, "pk");
+
+    did_create = false;
+    int_table->create_object_with_primary_key(1, &did_create);
+    CHECK(did_create);
+    int_table->create_object_with_primary_key(1, &did_create);
+    CHECK_NOT(did_create);
+    int_table->create_object_with_primary_key(2, &did_create);
+    CHECK(did_create);
+}
+
 TEST(Table_PrimaryKeyString)
 {
 #ifdef REALM_DEBUG


### PR DESCRIPTION
The object store code which calls this needs to know if it's populating a new object or modifying an existing one. Currently it does that by looking up the object first and only calling create_object_with_primary_key() if it doesn't exist, which results in some duplicated code and a redundant lookup.