### PR TITLE
Avoid parsing the transaction log when it isn't needed

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 # NEXT RELEASE
 
 ### Enhancements
-* None.
+* Improve the performance of advancing transaction read versions when not using a transaction log observer or schema changehandler.
 
 ### Fixed
 * <How to hit and notice issue? what was the impact?> ([#????](https://github.com/realm/realm-core/issues/????), since v?.?.?)

--- a/src/realm/db.hpp
+++ b/src/realm/db.hpp
@@ -572,22 +572,22 @@ public:
     void rollback_and_continue_as_read(O* observer);
     void rollback_and_continue_as_read()
     {
-        _impl::NullInstructionObserver o;
-        rollback_and_continue_as_read(&o);
+        _impl::NullInstructionObserver* o = nullptr;
+        rollback_and_continue_as_read(o);
     }
     template <class O>
     void advance_read(O* observer, VersionID target_version = VersionID());
     void advance_read(VersionID target_version = VersionID())
     {
-        _impl::NullInstructionObserver o;
-        advance_read(&o, target_version);
+        _impl::NullInstructionObserver* o = nullptr;
+        advance_read(o, target_version);
     }
     template <class O>
     bool promote_to_write(O* observer, bool nonblocking = false);
     bool promote_to_write(bool nonblocking = false)
     {
-        _impl::NullInstructionObserver o;
-        return promote_to_write(&o, nonblocking);
+        _impl::NullInstructionObserver* o = nullptr;
+        return promote_to_write(o, nonblocking);
     }
     TransactionRef freeze();
     // Frozen transactions are created by freeze() or DB::start_frozen()

--- a/src/realm/group.cpp
+++ b/src/realm/group.cpp
@@ -1675,9 +1675,11 @@ void Group::advance_transact(ref_type new_top_ref, size_t new_file_size, _impl::
     // This is no longer needed in Core, but we need to compute "schema_changed",
     // for the benefit of ObjectStore.
     bool schema_changed = false;
-    _impl::TransactLogParser parser; // Throws
-    TransactAdvancer advancer(*this, schema_changed);
-    parser.parse(in, advancer); // Throws
+    if (has_schema_change_notification_handler()) {
+        _impl::TransactLogParser parser; // Throws
+        TransactAdvancer advancer(*this, schema_changed);
+        parser.parse(in, advancer); // Throws
+    }
 
     m_top.detach();                                 // Soft detach
     bool create_group_when_missing = false;         // See Group::attach_shared().


### PR DESCRIPTION
https://github.com/realm/realm-cocoa/issues/6629 reported a case where the transaction log parsing managed to be an overwhelming majority of the runtime.

The parsing done for schema change notifications only needs to be done if there's actually a schema change handler set.

Passing a non-null NullInstructionObserver when no observer is supplied results in the transaction log being parsed just for the null observer, which obviously doesn't do anything useful with it.