### PR TITLE
Fix upgrade bug when having string primary key column

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@
 
 ### Fixed
 * <How to hit and notice issue? what was the impact?> ([#????](https://github.com/realm/realm-core/issues/????), since v?.?.?)
-* None.
+* Fix upgrade bug. Could cause assertions like "Assertion failed: ref != 0" during opning of a realm. ([#6644](https://github.com/realm/realm-cocoa/issues/6644), since V6.0.7)
  
 ### Breaking changes
 * None.

--- a/src/realm/table.cpp
+++ b/src/realm/table.cpp
@@ -1163,6 +1163,7 @@ void Table::create_columns(util::FunctionRef<void()> commit_and_continue)
 
 void Table::migrate_objects(ColKey pk_col_key, util::FunctionRef<void()> commit_and_continue)
 {
+    size_t nb_columns = m_spec.get_public_column_count();
     ref_type top_ref = m_top.get_as_ref(top_position_for_columns);
     if (!top_ref) {
         // All objects migrated
@@ -1173,6 +1174,11 @@ void Table::migrate_objects(ColKey pk_col_key, util::FunctionRef<void()> commit_
     col_refs.set_parent(&m_top, top_position_for_columns);
     col_refs.init_from_ref(top_ref);
 
+    if (nb_columns > col_refs.size()) {
+        // We have created !ROW_INDEX column. We are done here
+        return;
+    }
+
     /************************ Create column accessors ************************/
 
     std::map<ColKey, std::unique_ptr<BPlusTreeBase>> column_accessors;
@@ -1180,7 +1186,6 @@ void Table::migrate_objects(ColKey pk_col_key, util::FunctionRef<void()> commit_
     std::map<ColKey, std::unique_ptr<BPlusTree<int64_t>>> list_accessors;
     std::vector<size_t> cols_to_destroy;
     bool has_link_columns = false;
-    size_t nb_columns = m_spec.get_public_column_count();
 
     // helper function to determine the number of objects in the table
     size_t number_of_objects = (nb_columns == 0) ? 0 : size_t(-1);


### PR DESCRIPTION
The bug would surface if the upgrade process was interrupted and then
resumed.

Fixes https://github.com/realm/realm-cocoa/issues/6644