### PR TITLE
Fix warnings when building with -Wdocumentation

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -75,7 +75,7 @@ else()
     if(ANDROID)
         set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wno-uninitialized")
     elseif(${CMAKE_CXX_COMPILER_ID} MATCHES ".*[Cc]lang")
-        set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wunreachable-code -Wshorten-64-to-32 -Wold-style-cast -Wconditional-uninitialized -Wextra-semi -Wno-nested-anon-types")
+        set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wunreachable-code -Wshorten-64-to-32 -Wold-style-cast -Wconditional-uninitialized -Wextra-semi -Wno-nested-anon-types -Wdocumentation")
     endif()
 
     # This warning is too agressive. It warns about moves that are not redundant on older

--- a/src/realm/array.hpp
+++ b/src/realm/array.hpp
@@ -383,26 +383,16 @@ public:
     //@}
 
     /// \brief Search the \c Array for a value greater or equal than \a target,
-    /// starting the search at the \a start index. If \a indirection is
-    /// provided, use it as a look-up table to iterate over the \c Array.
+    /// starting the search at the \a start index.
     ///
-    /// If \a indirection is not provided, then the \c Array must be sorted in
-    /// ascending order. If \a indirection is provided, then its values should
-    /// point to indices in this \c Array in such a way that iteration happens
-    /// in ascending order.
+    /// The \c Array must be sorted in ascending order.
     ///
     /// Behaviour is undefined if:
-    /// - a value in \a indirection is out of bounds for this \c Array;
-    /// - \a indirection does not contain at least as many elements as this \c
-    ///   Array;
     /// - sorting conditions are not respected;
-    /// - \a start is greater than the number of elements in this \c Array or
-    ///   \a indirection (if provided).
+    /// - \a start is greater than the number of elements in this \c Array
     ///
     /// \param target the smallest value to search for
     /// \param start the offset at which to start searching in the array
-    /// \param indirection an \c Array containing valid indices of values in
-    ///        this \c Array, sorted in ascending order
     /// \return the index of the value if found, or realm::not_found otherwise
     size_t find_gte(const int64_t target, size_t start, size_t end = size_t(-1)) const;
 

--- a/src/realm/group_writer.hpp
+++ b/src/realm/group_writer.hpp
@@ -170,7 +170,6 @@ private:
 
     /// Search only a range of the free list for a block as big as the
     /// specified size. Return a pair with index and size of the found chunk.
-    /// \param found indicates whether a suitable block was found.
     FreeListElement search_free_space_in_part_of_freelist(size_t size);
 
     /// Extend the file to ensure that a chunk of free space of the

--- a/src/realm/impl/transact_log.hpp
+++ b/src/realm/impl/transact_log.hpp
@@ -365,8 +365,6 @@ public:
     virtual void create_object(const Table*, ObjKey);
     virtual void create_object_with_primary_key(const Table*, GlobalKey, Mixed);
     virtual void remove_object(const Table*, ObjKey);
-    /// \param prior_num_rows The number of rows in the table prior to the
-    /// modification.
     virtual void set_link_type(const Table*, ColKey col_key, LinkType);
     virtual void clear_table(const Table*, size_t prior_num_rows);
 

--- a/src/realm/replication.hpp
+++ b/src/realm/replication.hpp
@@ -168,13 +168,14 @@ public:
     /// _impl::History::update_early_from_top_ref() was called during the
     /// transition from a read transaction to the current write transaction.
     ///
-    /// \return prepare_commit() returns the version of the new snapshot
-    /// produced by the transaction.
-    ///
     /// \throw Interrupted Thrown by initiate_transact() and prepare_commit() if
     /// a blocking operation was interrupted.
 
     void initiate_transact(Group& group, version_type current_version, bool history_updated);
+    /// \param current_version The version of the snapshot that the current
+    /// transaction is based on.
+    /// \return prepare_commit() returns the version of the new snapshot
+    /// produced by the transaction.
     version_type prepare_commit(version_type current_version);
     void finalize_commit() noexcept;
     void abort_transact() noexcept;

--- a/src/realm/util/base64.hpp
+++ b/src/realm/util/base64.hpp
@@ -27,11 +27,11 @@ namespace realm {
 namespace util {
 
 
-/// base64_encode() encodes the bnary data in \param in_buffer of size \param in_buffer_size.
-/// The encoded data is placed in \param out_buffer. The size of \param \out_buffer is passed in
-/// \param out_buffer_size. The output buffer \param out_buffer must be
+/// base64_encode() encodes the bnary data in \param in_buffer of size \param in_buffer_size .
+/// The encoded data is placed in \param out_buffer . The size of \param \out_buffer is passed in
+/// \param out_buffer_size . The output buffer out_buffer must be
 /// large enough to hold the base64 encoded data. The size can be obtained from the function
-/// base64_encoded_size. \param out_buffer_size is only used to assert that the output buffer is
+/// base64_encoded_size. out_buffer_size is only used to assert that the output buffer is
 /// large enough.
 size_t base64_encode(const char *in_buffer, size_t in_buffer_size, char* out_buffer, size_t out_buffer_size) noexcept;
 

--- a/src/realm/util/buffer.hpp
+++ b/src/realm/util/buffer.hpp
@@ -81,7 +81,7 @@ public:
     void set_size(size_t new_size);
 
     /// \param new_size Specifies the new buffer size.
-    /// \param copy_begin, copy_end Specifies a range of element
+    /// \param copy_begin copy_end Specifies a range of element
     /// values to be retained. \a copy_end must be less than, or equal
     /// to size().
     ///

--- a/src/realm/util/sha_crypto.hpp
+++ b/src/realm/util/sha_crypto.hpp
@@ -25,8 +25,8 @@ namespace realm {
 namespace util {
 
 /// The digest functions calculate the message digest of the input in \param
-/// in_buffer of size \param in_buffer_size. The digest is placed in \param
-/// out_buffer. The caller must guarantee that the output buffer is large
+/// in_buffer of size \param in_buffer_size . The digest is placed in \param
+/// out_buffer . The caller must guarantee that the output buffer is large
 /// enough to contain the digest.
 ///
 /// The functions throw if the underlying platform dependent implementations

--- a/test/util/jsmn.hpp
+++ b/test/util/jsmn.hpp
@@ -30,13 +30,13 @@ enum jsmnerr {
 
 /**
  * JSON token description.
- * @param       type    type (object, array, string etc.)
- * @param       start   start position in JSON data string
- * @param       end     end position in JSON data string
  */
 typedef struct {
+    /// type (object, array, string etc.)
     jsmntype_t type;
+    /// start position in JSON data string
     int start;
+    /// end position in JSON data string
     int end;
     int size;
 #ifdef JSMN_PARENT_LINKS


### PR DESCRIPTION
When using xcframeworks Cocoa can no longer use -isystem to ignore warnings from core headers, so these now pop up when building Cocoa.