### PR TITLE
[HELP-17413] Sync: Validate prior_size more aggressively

### DIFF
--- a/src/realm/sync/instruction_applier.cpp
+++ b/src/realm/sync/instruction_applier.cpp
@@ -571,7 +571,7 @@ void InstructionApplier::operator()(const Instruction::ArrayErase& instr)
 {
     auto& list = get_list(instr, "ArrayErase");
 
-    if (instr.index() > instr.prior_size) {
+    if (instr.index() >= instr.prior_size) {
         bad_transaction_log("ArrayErase: Invalid index (index = %1, prior_size = %2)", instr.index(),
                             instr.prior_size);
     }

--- a/src/realm/sync/instruction_replication.cpp
+++ b/src/realm/sync/instruction_replication.cpp
@@ -474,6 +474,7 @@ void SyncReplication::list_move(const CollectionBase& view, size_t from_ndx, siz
         Instruction::ArrayMove instr;
         populate_path_instr(instr, view, uint32_t(from_ndx));
         instr.ndx_2 = uint32_t(to_ndx);
+        instr.prior_size = uint32_t(view.size());
         emit(instr);
     }
 }

--- a/src/realm/sync/transform.cpp
+++ b/src/realm/sync/transform.cpp
@@ -1597,10 +1597,11 @@ DEFINE_MERGE(Instruction::EraseColumn, Instruction::Update)
 DEFINE_MERGE(Instruction::ArrayInsert, Instruction::Update)
 {
     if (same_container(left, right)) {
-        REALM_MERGE_ASSERT(right.is_array_update());
+        REALM_ASSERT(right.is_array_update());
+
         REALM_MERGE_ASSERT(left.prior_size == right.prior_size);
         REALM_MERGE_ASSERT(left.index() <= left.prior_size);
-        REALM_MERGE_ASSERT(right.index() <= right.prior_size);
+        REALM_MERGE_ASSERT(right.index() < right.prior_size);
         right.prior_size += 1;
         if (right.index() >= left.index()) {
             right.index() += 1; // --->
@@ -1611,9 +1612,10 @@ DEFINE_MERGE(Instruction::ArrayInsert, Instruction::Update)
 DEFINE_MERGE(Instruction::ArrayMove, Instruction::Update)
 {
     if (same_container(left, right)) {
-        REALM_MERGE_ASSERT(right.is_array_update());
-        REALM_MERGE_ASSERT(left.index() <= left.prior_size);
-        REALM_MERGE_ASSERT(right.index() <= right.prior_size);
+        REALM_ASSERT(right.is_array_update());
+
+        REALM_MERGE_ASSERT(left.index() < left.prior_size);
+        REALM_MERGE_ASSERT(right.index() < right.prior_size);
 
         // FIXME: This marks both sides as dirty, even when they are unmodified.
         merge_get_vs_move(right.index(), left.index(), left.ndx_2);
@@ -1623,10 +1625,11 @@ DEFINE_MERGE(Instruction::ArrayMove, Instruction::Update)
 DEFINE_MERGE(Instruction::ArrayErase, Instruction::Update)
 {
     if (same_container(left, right)) {
-        REALM_MERGE_ASSERT(right.is_array_update());
+        REALM_ASSERT(right.is_array_update());
+
         REALM_MERGE_ASSERT(left.prior_size == right.prior_size);
-        REALM_MERGE_ASSERT(left.index() <= left.prior_size);
-        REALM_MERGE_ASSERT(right.index() <= right.prior_size);
+        REALM_MERGE_ASSERT(left.index() < left.prior_size);
+        REALM_MERGE_ASSERT(right.index() < right.prior_size);
 
         right.prior_size -= 1;
 
@@ -1813,7 +1816,7 @@ DEFINE_MERGE(Instruction::ArrayErase, Instruction::ArrayInsert)
 {
     if (same_container(left, right)) {
         REALM_MERGE_ASSERT(left.prior_size == right.prior_size);
-        REALM_MERGE_ASSERT(left.index() <= left.prior_size);
+        REALM_MERGE_ASSERT(left.index() < left.prior_size);
         REALM_MERGE_ASSERT(right.index() <= right.prior_size);
 
         left.prior_size++;
@@ -1845,8 +1848,10 @@ DEFINE_MERGE(Instruction::ArrayMove, Instruction::ArrayMove)
 {
     if (same_container(left, right)) {
         REALM_MERGE_ASSERT(left.prior_size == right.prior_size);
-        REALM_MERGE_ASSERT(left.index() <= left.prior_size);
-        REALM_MERGE_ASSERT(right.index() <= right.prior_size);
+        REALM_MERGE_ASSERT(left.index() < left.prior_size);
+        REALM_MERGE_ASSERT(right.index() < right.prior_size);
+        REALM_MERGE_ASSERT(left.ndx_2 < left.prior_size);
+        REALM_MERGE_ASSERT(right.ndx_2 < right.prior_size);
 
         if (left.index() < right.index()) {
             right.index() -= 1; // <---
@@ -1928,8 +1933,8 @@ DEFINE_MERGE(Instruction::ArrayErase, Instruction::ArrayMove)
 {
     if (same_container(left, right)) {
         REALM_MERGE_ASSERT(left.prior_size == right.prior_size);
-        REALM_MERGE_ASSERT(left.index() <= left.prior_size);
-        REALM_MERGE_ASSERT(right.index() <= right.prior_size);
+        REALM_MERGE_ASSERT(left.index() < left.prior_size);
+        REALM_MERGE_ASSERT(right.index() < right.prior_size);
 
         if (left.index() == right.index()) {
             // CONFLICT: Removal of a moved element.
@@ -1991,8 +1996,8 @@ DEFINE_MERGE(Instruction::ArrayErase, Instruction::ArrayErase)
 {
     if (same_path(left, right)) {
         REALM_MERGE_ASSERT(left.prior_size == right.prior_size);
-        REALM_MERGE_ASSERT(left.index() <= left.prior_size);
-        REALM_MERGE_ASSERT(right.index() <= right.prior_size);
+        REALM_MERGE_ASSERT(left.index() < left.prior_size);
+        REALM_MERGE_ASSERT(right.index() < right.prior_size);
 
         left.prior_size -= 1;
         right.prior_size -= 1;

--- a/src/realm/sync/transform.cpp
+++ b/src/realm/sync/transform.cpp
@@ -1599,6 +1599,8 @@ DEFINE_MERGE(Instruction::ArrayInsert, Instruction::Update)
     if (same_container(left, right)) {
         REALM_MERGE_ASSERT(right.is_array_update());
         REALM_MERGE_ASSERT(left.prior_size == right.prior_size);
+        REALM_MERGE_ASSERT(left.index() <= left.prior_size);
+        REALM_MERGE_ASSERT(right.index() <= right.prior_size);
         right.prior_size += 1;
         if (right.index() >= left.index()) {
             right.index() += 1; // --->
@@ -1610,6 +1612,9 @@ DEFINE_MERGE(Instruction::ArrayMove, Instruction::Update)
 {
     if (same_container(left, right)) {
         REALM_MERGE_ASSERT(right.is_array_update());
+        REALM_MERGE_ASSERT(left.index() <= left.prior_size);
+        REALM_MERGE_ASSERT(right.index() <= right.prior_size);
+
         // FIXME: This marks both sides as dirty, even when they are unmodified.
         merge_get_vs_move(right.index(), left.index(), left.ndx_2);
     }
@@ -1620,6 +1625,9 @@ DEFINE_MERGE(Instruction::ArrayErase, Instruction::Update)
     if (same_container(left, right)) {
         REALM_MERGE_ASSERT(right.is_array_update());
         REALM_MERGE_ASSERT(left.prior_size == right.prior_size);
+        REALM_MERGE_ASSERT(left.index() <= left.prior_size);
+        REALM_MERGE_ASSERT(right.index() <= right.prior_size);
+
         right.prior_size -= 1;
 
         if (left.index() == right.index()) {
@@ -1805,6 +1813,9 @@ DEFINE_MERGE(Instruction::ArrayErase, Instruction::ArrayInsert)
 {
     if (same_container(left, right)) {
         REALM_MERGE_ASSERT(left.prior_size == right.prior_size);
+        REALM_MERGE_ASSERT(left.index() <= left.prior_size);
+        REALM_MERGE_ASSERT(right.index() <= right.prior_size);
+
         left.prior_size++;
         right.prior_size--;
         if (right.index() <= left.index()) {
@@ -1833,6 +1844,10 @@ DEFINE_NESTED_MERGE(Instruction::ArrayMove)
 DEFINE_MERGE(Instruction::ArrayMove, Instruction::ArrayMove)
 {
     if (same_container(left, right)) {
+        REALM_MERGE_ASSERT(left.prior_size == right.prior_size);
+        REALM_MERGE_ASSERT(left.index() <= left.prior_size);
+        REALM_MERGE_ASSERT(right.index() <= right.prior_size);
+
         if (left.index() < right.index()) {
             right.index() -= 1; // <---
         }
@@ -1912,6 +1927,10 @@ DEFINE_MERGE(Instruction::ArrayMove, Instruction::ArrayMove)
 DEFINE_MERGE(Instruction::ArrayErase, Instruction::ArrayMove)
 {
     if (same_container(left, right)) {
+        REALM_MERGE_ASSERT(left.prior_size == right.prior_size);
+        REALM_MERGE_ASSERT(left.index() <= left.prior_size);
+        REALM_MERGE_ASSERT(right.index() <= right.prior_size);
+
         if (left.index() == right.index()) {
             // CONFLICT: Removal of a moved element.
             //
@@ -1972,6 +1991,9 @@ DEFINE_MERGE(Instruction::ArrayErase, Instruction::ArrayErase)
 {
     if (same_path(left, right)) {
         REALM_MERGE_ASSERT(left.prior_size == right.prior_size);
+        REALM_MERGE_ASSERT(left.index() <= left.prior_size);
+        REALM_MERGE_ASSERT(right.index() <= right.prior_size);
+
         left.prior_size -= 1;
         right.prior_size -= 1;
 
@@ -2008,6 +2030,8 @@ DEFINE_NESTED_MERGE(Instruction::ArrayClear)
 DEFINE_MERGE(Instruction::ArrayClear, Instruction::ArrayClear)
 {
     if (same_path(left, right)) {
+        REALM_MERGE_ASSERT(left.prior_size == right.prior_size);
+
         // CONFLICT: Two clears of the same list.
         //
         // RESOLUTION: Discard the clear with the lower timestamp. This has the

--- a/src/realm/sync/transform.cpp
+++ b/src/realm/sync/transform.cpp
@@ -1597,7 +1597,7 @@ DEFINE_MERGE(Instruction::EraseColumn, Instruction::Update)
 DEFINE_MERGE(Instruction::ArrayInsert, Instruction::Update)
 {
     if (same_container(left, right)) {
-        REALM_ASSERT(right.is_array_update());
+        REALM_MERGE_ASSERT(right.is_array_update());
         REALM_MERGE_ASSERT(left.prior_size == right.prior_size);
         right.prior_size += 1;
         if (right.index() >= left.index()) {
@@ -1609,7 +1609,7 @@ DEFINE_MERGE(Instruction::ArrayInsert, Instruction::Update)
 DEFINE_MERGE(Instruction::ArrayMove, Instruction::Update)
 {
     if (same_container(left, right)) {
-        REALM_ASSERT(right.is_array_update());
+        REALM_MERGE_ASSERT(right.is_array_update());
         // FIXME: This marks both sides as dirty, even when they are unmodified.
         merge_get_vs_move(right.index(), left.index(), left.ndx_2);
     }
@@ -1618,7 +1618,7 @@ DEFINE_MERGE(Instruction::ArrayMove, Instruction::Update)
 DEFINE_MERGE(Instruction::ArrayErase, Instruction::Update)
 {
     if (same_container(left, right)) {
-        REALM_ASSERT(right.is_array_update());
+        REALM_MERGE_ASSERT(right.is_array_update());
         REALM_MERGE_ASSERT(left.prior_size == right.prior_size);
         right.prior_size -= 1;
 

--- a/test/test_changeset_encoding.cpp
+++ b/test/test_changeset_encoding.cpp
@@ -195,6 +195,7 @@ TEST(ChangesetEncoding_ArrayInsert)
     instr.path.push_back(changeset.intern_string("lol"));
     instr.path.push_back(5);
     instr.value = Payload{changeset.append_string("Hello, World!")};
+    instr.prior_size = 123;
     changeset.push_back(instr);
 
     auto parsed = encode_then_parse(changeset);
@@ -213,6 +214,7 @@ TEST(ChangesetEncoding_ArrayMove)
     instr.path.push_back(234);
     instr.path.push_back(changeset.intern_string("lol"));
     instr.path.push_back(5);
+    instr.prior_size = 123;
     changeset.push_back(instr);
 
     auto parsed = encode_then_parse(changeset);
@@ -231,6 +233,7 @@ TEST(ChangesetEncoding_ArrayErase)
     instr.path.push_back(234);
     instr.path.push_back(changeset.intern_string("lol"));
     instr.path.push_back(5);
+    instr.prior_size = 123;
     changeset.push_back(instr);
 
     auto parsed = encode_then_parse(changeset);
@@ -249,6 +252,7 @@ TEST(ChangesetEncoding_ArrayClear)
     instr.path.push_back(234);
     instr.path.push_back(changeset.intern_string("lol"));
     instr.path.push_back(5);
+    instr.prior_size = 123;
     changeset.push_back(instr);
 
     auto parsed = encode_then_parse(changeset);


### PR DESCRIPTION
A bunch of places were missing checks on `prior_size` for array instructions, and this revealed that `ArrayMove::prior_size` was never populated.