### PR TITLE
Fsa/encrypted crash with no encryption

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,8 +5,7 @@
 
 ### Fixed
 * <How to hit and notice issue? what was the impact?> ([#????](https://github.com/realm/realm-core/issues/????), since v?.?.?)
-* None.
- 
+* Fix bug in memory mapping management. This bug could result in multiple different asserts as well as segfaults. In many cases stack backtraces would include members of the EncyptedFileMapping near the top - even if encryption was not used at all. In other cases asserts or crashes would be in methods reading an array header or array element. In all cases the application would terminate immediately. ([#3838](https://github.com/realm/realm-core/pull/3838), since v6)
 ### Breaking changes
 * None.
 

--- a/src/realm/alloc_slab.cpp
+++ b/src/realm/alloc_slab.cpp
@@ -1355,6 +1355,10 @@ void SlabAlloc::purge_old_mappings(uint64_t oldest_live_version, uint64_t younge
     m_youngest_live_version = youngest_live_version;
 }
 
+void SlabAlloc::init_mapping_management(uint64_t currently_live_version)
+{
+    m_youngest_live_version = currently_live_version;
+}
 
 const SlabAlloc::Chunks& SlabAlloc::get_free_read_only() const
 {

--- a/src/realm/alloc_slab.hpp
+++ b/src/realm/alloc_slab.hpp
@@ -301,6 +301,7 @@ public:
     /// ref->ptr translation changes, and is used by Group to enforce re-translation.
     void update_reader_view(size_t file_size);
     void purge_old_mappings(uint64_t oldest_live_version, uint64_t youngest_live_version);
+    void init_mapping_management(uint64_t currently_live_version);
 
     /// Get an ID for the current mapping version. This ID changes whenever any part
     /// of an existing mapping is changed. Such a change requires all refs to be

--- a/src/realm/db.cpp
+++ b/src/realm/db.cpp
@@ -1147,9 +1147,7 @@ void DB::do_open(const std::string& path, bool no_create_file, bool is_backend, 
                 info->number_of_versions = 1;
 
                 info->latest_version_number = version;
-                // there isn't really any old mappings to purge, but this has the side effect of properly
-                // setting up the memory mapping machinery.
-                alloc.purge_old_mappings(version, version);
+                alloc.init_mapping_management(version);
 
                 SharedInfo* r_info = m_reader_map.get_addr();
                 size_t file_size = alloc.get_baseline();
@@ -1225,9 +1223,7 @@ void DB::do_open(const std::string& path, bool no_create_file, bool is_backend, 
                 // We need to setup the allocators version information, as it is needed
                 // to correctly age and later reclaim memory mappings.
                 version_type version = info->latest_version_number;
-                // there isn't really any old mappings to purge, but this has the side effect of properly
-                // setting up the memory mapping machinery.
-                alloc.purge_old_mappings(version, version);
+                alloc.init_mapping_management(version);
             }
 
             m_new_commit_available.set_shared_part(info->new_commit_available, m_lockfile_prefix, "new_commit",
@@ -1466,9 +1462,7 @@ bool DB::compact(bool bump_version_number, util::Optional<const char*> output_en
         cfg.encryption_key = write_key;
         ref_type top_ref;
         top_ref = m_alloc.attach_file(m_db_path, cfg);
-        // there isn't really any old mappings to purge, but this has the side effect of properly
-        // setting up the memory mapping machinery.
-        m_alloc.purge_old_mappings(info->latest_version_number, info->latest_version_number);
+        m_alloc.init_mapping_management(info->latest_version_number);
         info->number_of_versions = 1;
         SharedInfo* r_info = m_reader_map.get_addr();
         size_t file_size = m_alloc.get_baseline();

--- a/src/realm/db.cpp
+++ b/src/realm/db.cpp
@@ -1147,7 +1147,9 @@ void DB::do_open(const std::string& path, bool no_create_file, bool is_backend, 
                 info->number_of_versions = 1;
 
                 info->latest_version_number = version;
-                alloc.m_youngest_live_version = version;
+                // there isn't really any old mappings to purge, but this has the side effect of properly
+                // setting up the memory mapping machinery.
+                alloc.purge_old_mappings(version, version);
 
                 SharedInfo* r_info = m_reader_map.get_addr();
                 size_t file_size = alloc.get_baseline();
@@ -1219,6 +1221,13 @@ void DB::do_open(const std::string& path, bool no_create_file, bool is_backend, 
                 // See upgrade_file_format(). However we cannot get the actual value
                 // at this point as the allocator is not synchronized with the file.
                 // The value will be read in a ReadTransaction later.
+
+                // We need to setup the allocators version information, as it is needed
+                // to correctly age and later reclaim memory mappings.
+                version_type version = info->latest_version_number;
+                // there isn't really any old mappings to purge, but this has the side effect of properly
+                // setting up the memory mapping machinery.
+                alloc.purge_old_mappings(version, version);
             }
 
             m_new_commit_available.set_shared_part(info->new_commit_available, m_lockfile_prefix, "new_commit",
@@ -1431,6 +1440,10 @@ bool DB::compact(bool bump_version_number, util::Optional<const char*> output_en
             REALM_ASSERT_3(rc.version, ==, info->latest_version_number);
             static_cast<void>(rc); // rc unused if ENABLE_ASSERTION is unset
         }
+        // if we've written a file with a bumped version number, we need to update the lock file to match.
+        if (bump_version_number) {
+            ++info->latest_version_number;
+        }
         // We need to release any shared mapping *before* releasing the control mutex.
         // When someone attaches to the new database file, they *must* *not* see and
         // reuse any existing memory mapping of the stale file.
@@ -1453,9 +1466,10 @@ bool DB::compact(bool bump_version_number, util::Optional<const char*> output_en
         cfg.encryption_key = write_key;
         ref_type top_ref;
         top_ref = m_alloc.attach_file(m_db_path, cfg);
-        m_alloc.m_youngest_live_version = info->latest_version_number;
+        // there isn't really any old mappings to purge, but this has the side effect of properly
+        // setting up the memory mapping machinery.
+        m_alloc.purge_old_mappings(info->latest_version_number, info->latest_version_number);
         info->number_of_versions = 1;
-        // info->latest_version_number is unchanged
         SharedInfo* r_info = m_reader_map.get_addr();
         size_t file_size = m_alloc.get_baseline();
         r_info->init_versioning(top_ref, file_size, info->latest_version_number);

--- a/test/test_shared.cpp
+++ b/test/test_shared.cpp
@@ -546,6 +546,67 @@ TEST(Shared_ReadOverRead)
     CHECK_EQUAL(table2->get_object(0).get<int64_t>("col"), 1);
 }
 
+TEST(Shared_ReadOverReadAfterCompact)
+{
+    SHARED_GROUP_TEST_PATH(path);
+    DBRef sg = DB::create(path);
+    {
+        WriteTransaction wt(sg);
+        auto table = wt.add_table("table");
+        table->add_column(type_Int, "col");
+        table->create_object().set_all(1);
+        wt.commit();
+    }
+    sg->compact();
+    DBRef sg2 = DB::create(path);
+    auto rt = sg->start_read();
+    auto rt2 = sg2->start_read();
+    auto table = rt->get_table("table");
+    for (int i = 2; i < 4; ++i) {
+        WriteTransaction wt(sg);
+        wt.get_table("table")->create_object().set_all(i);
+        wt.commit();
+    }
+    CHECK_EQUAL(table->size(), 1);
+    CHECK_EQUAL(table->get_object(0).get<int64_t>("col"), 1);
+
+    auto table2 = rt2->get_table("table");
+    for (int i = 2; i < 4; ++i) {
+        WriteTransaction wt(sg2);
+        wt.get_table("table")->create_object().set_all(i);
+        wt.commit();
+    }
+    CHECK_EQUAL(table2->size(), 1);
+    CHECK_EQUAL(table2->get_object(0).get<int64_t>("col"), 1);
+}
+
+
+TEST(Shared_ReadOverRead2)
+{
+    SHARED_GROUP_TEST_PATH(path);
+    {
+        DBRef sg = DB::create(path);
+        {
+            WriteTransaction wt(sg);
+            auto table = wt.add_table("table");
+            table->add_column(type_Int, "col");
+            table->create_object().set_all(1);
+            wt.commit();
+        }
+    }
+    DBRef sg3 = DB::create(path);
+    DBRef sg2 = DB::create(path);
+    auto rt2 = sg2->start_read();
+    auto table2 = rt2->get_table("table");
+    for (int i = 2; i < 4; ++i) {
+        WriteTransaction wt(sg2);
+        wt.get_table("table")->create_object().set_all(i);
+        wt.commit();
+    }
+    CHECK_EQUAL(table2->size(), 1);
+    CHECK_EQUAL(table2->get_object(0).get<int64_t>("col"), 1);
+}
+
 
 TEST(Shared_EncryptedRemap)
 {


### PR DESCRIPTION
The versioning information which drives memory mapping management was only properly updated for the session initiator.
This fix adds updating to all paths where a file is attached (session initiator, not initiator and as part of compact()).