### PR TITLE
Don't throw when copying an invalidated ConstIterator

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@
 
 ### Fixed
 * <How to hit and notice issue? what was the impact?> ([#????](https://github.com/realm/realm-core/issues/????), since v?.?.?)
-* None.
+* We no longer throw when an invalid ConstIterator is copied ([#698](https://github.com/realm/realm-cocoa/issues/6597), since v6.0)
  
 ### Breaking changes
 * None.

--- a/src/realm/cluster.cpp
+++ b/src/realm/cluster.cpp
@@ -2298,9 +2298,8 @@ auto ClusterTree::ConstIterator::operator[](size_t n) -> reference
 ClusterTree::ConstIterator::pointer Table::ConstIterator::operator->() const
 {
     if (m_leaf_invalid || m_storage_version != m_tree.get_storage_version(m_instance_version)) {
-        m_position = const_cast<ClusterTree::ConstIterator*>(this)->get_position();
         ObjKey k = load_leaf(m_key);
-        m_leaf_invalid = (k != m_key);
+        m_leaf_invalid = !k || (k != m_key);
         if (m_leaf_invalid) {
             throw std::runtime_error("Outdated iterator");
         }

--- a/src/realm/cluster.cpp
+++ b/src/realm/cluster.cpp
@@ -2233,12 +2233,7 @@ ClusterTree::ConstIterator::ConstIterator(const ConstIterator& other)
     , m_leaf_invalid(other.m_leaf_invalid)
     , m_position(other.m_position)
 {
-    if (m_key) {
-        auto k = load_leaf(m_key);
-        if (k != m_key)
-            throw std::runtime_error("ConstIterator copy failed");
-    }
-    m_leaf_start_pos = m_position -  m_state.m_current_index;
+    m_leaf_start_pos = m_position - m_state.m_current_index;
 }
 
 size_t ClusterTree::ConstIterator::get_position()

--- a/src/realm/cluster.cpp
+++ b/src/realm/cluster.cpp
@@ -2265,7 +2265,7 @@ ObjKey ClusterTree::ConstIterator::load_leaf(ObjKey key) const
 
 auto ClusterTree::ConstIterator::operator[](size_t n) -> reference
 {
-    if (m_storage_version != m_tree.get_storage_version(m_instance_version)) {
+    if (m_leaf_invalid || m_storage_version != m_tree.get_storage_version(m_instance_version)) {
         // reload
         m_position = get_position(); // Will throw if base object is deleted
         load_leaf(m_key);
@@ -2298,6 +2298,7 @@ auto ClusterTree::ConstIterator::operator[](size_t n) -> reference
 ClusterTree::ConstIterator::pointer Table::ConstIterator::operator->() const
 {
     if (m_leaf_invalid || m_storage_version != m_tree.get_storage_version(m_instance_version)) {
+        m_position = const_cast<ClusterTree::ConstIterator*>(this)->get_position();
         ObjKey k = load_leaf(m_key);
         m_leaf_invalid = (k != m_key);
         if (m_leaf_invalid) {

--- a/test/test_shared.cpp
+++ b/test/test_shared.cpp
@@ -3754,6 +3754,13 @@ TEST(Shared_ConstObjectIterator)
     CHECK_EQUAL(i3->get<int64_t>(col), 7);
     ++i3;
     CHECK_EQUAL(i3->get<int64_t>(col), 8);
+    reader.reset();
+    // Verify that we can copy a ConstIterator - even an invalid one
+    TransactionRef writer = sg->start_write();
+    TableRef t4 = writer->get_table("Foo");
+    auto i4 = t4->begin();
+    t4->clear();
+    auto i5(i4);
 }
 
 TEST(Shared_ConstList)

--- a/test/test_shared.cpp
+++ b/test/test_shared.cpp
@@ -3770,6 +3770,7 @@ TEST(Shared_ConstObjectIterator)
     // so, should still throw
     CHECK_THROW(*i5, std::runtime_error);
     CHECK_THROW(i5[0], std::runtime_error);
+    CHECK(i5 == t4->end());
 }
 
 TEST(Shared_ConstList)

--- a/test/test_shared.cpp
+++ b/test/test_shared.cpp
@@ -3761,6 +3761,15 @@ TEST(Shared_ConstObjectIterator)
     auto i4 = t4->begin();
     t4->clear();
     auto i5(i4);
+    // dereferencing an invalid iterator will throw
+    CHECK_THROW(*i5, std::runtime_error);
+    CHECK_THROW(i5[0], std::runtime_error);
+    // but moving it will not, it just stays invalid
+    ++i5;
+    i5 += 3;
+    // so, should still throw
+    CHECK_THROW(*i5, std::runtime_error);
+    CHECK_THROW(i5[0], std::runtime_error);
 }
 
 TEST(Shared_ConstList)


### PR DESCRIPTION
Iterators should not throw when copied, even if they are no longer valid.

Potentially fixes https://github.com/realm/realm-cocoa/issues/6597.