### PR TITLE
Reduce binary size of query_builder.cpp and query.cpp

### DIFF
--- a/src/realm/parser/query_builder.cpp
+++ b/src/realm/parser/query_builder.cpp
@@ -37,131 +37,129 @@ using namespace query_builder;
 
 namespace {
 
+REALM_NOINLINE REALM_COLD REALM_NORETURN void throw_logic_error(const char* msg)
+{
+    throw std::logic_error(msg);
+}
+REALM_NOINLINE REALM_COLD REALM_NORETURN void throw_logic_error(std::string msg)
+{
+    throw std::logic_error(std::move(msg));
+}
+REALM_NOINLINE REALM_COLD REALM_NORETURN void throw_runtime_error(const char* msg)
+{
+    throw std::runtime_error(msg);
+}
+REALM_NOINLINE REALM_COLD REALM_NORETURN void throw_runtime_error(std::string msg)
+{
+    throw std::runtime_error(std::move(msg));
+}
+
 template <typename T, parser::Expression::KeyPathOp OpType, typename ExpressionType>
-void do_add_null_comparison_to_query(Query&, Predicate::Operator,
-                                     const CollectionOperatorExpression<OpType, ExpressionType>&)
+REALM_FORCEINLINE Query do_make_null_comparison_query(Predicate::Operator,
+                                                      const CollectionOperatorExpression<OpType, ExpressionType>&)
 {
-    throw std::logic_error("Comparing a collection aggregate operation to 'null' is not supported.");
+    throw_logic_error("Comparing a collection aggregate operation to 'null' is not supported.");
 }
 
-template<typename T>
-void do_add_null_comparison_to_query(Query &, Predicate::Operator, const ValueExpression &)
+template <typename T>
+REALM_FORCEINLINE Query do_make_null_comparison_query(Predicate::Operator, const ValueExpression&)
 {
-    throw std::logic_error("Comparing a value to 'null' is not supported.");
+    throw_logic_error("Comparing a value to 'null' is not supported.");
 }
 
-template<typename T>
-void do_add_null_comparison_to_query(Query &query, Predicate::Operator op, const PropertyExpression &expr)
+template <typename T>
+Query do_make_null_comparison_query(Predicate::Operator op, const PropertyExpression& expr)
 {
     Columns<T> column = expr.link_chain_getter().template column<T>(expr.get_dest_col_key());
     switch (op) {
         case Predicate::Operator::NotEqual:
-            query.and_query(column != realm::null());
-            break;
+            return column != realm::null();
         case Predicate::Operator::In:
-            REALM_FALLTHROUGH;
         case Predicate::Operator::Equal:
-            query.and_query(column == realm::null());
-            break;
+            return column == realm::null();
         default:
-            throw std::logic_error("Only 'equal' and 'not equal' operators supported when comparing against 'null'.");
+            throw_logic_error("Only 'equal' and 'not equal' operators supported when comparing against 'null'.");
     }
 }
 
 template <typename T>
-void do_add_null_comparison_to_query(Query& query, Predicate::Operator op, const PrimitiveListExpression& expr)
+Query do_make_null_comparison_query(Predicate::Operator op, const PrimitiveListExpression& expr)
 {
     Columns<Lst<T>> column = expr.value_of_type_for_query<T>();
     switch (op) {
         case Predicate::Operator::NotEqual:
-            query.and_query(column != realm::null());
-            break;
+            return column != realm::null();
         case Predicate::Operator::In:
-            REALM_FALLTHROUGH;
         case Predicate::Operator::Equal:
-            query.and_query(column == realm::null());
-            break;
+            return column == realm::null();
         default:
-            throw std::logic_error("Only 'equal' and 'not equal' operators supported when comparing against 'null'.");
+            throw_logic_error("Only 'equal' and 'not equal' operators supported when comparing against 'null'.");
     }
 }
 
 template <>
-void do_add_null_comparison_to_query<Link>(Query&, Predicate::Operator, const PrimitiveListExpression&)
+REALM_FORCEINLINE Query do_make_null_comparison_query<Link>(Predicate::Operator, const PrimitiveListExpression&)
 {
-    throw std::logic_error("Invalid query, list of primitive links is not a valid Realm contruct");
+    throw_logic_error("Invalid query, list of primitive links is not a valid Realm contruct");
 }
 
-template<>
-void do_add_null_comparison_to_query<Link>(Query &query, Predicate::Operator op, const PropertyExpression &expr)
+template <>
+Query do_make_null_comparison_query<Link>(Predicate::Operator op, const PropertyExpression& expr)
 {
     REALM_ASSERT_DEBUG(!expr.dest_type_is_backlink()); // this case should be handled at a higher layer
     switch (op) {
-        case Predicate::Operator::NotEqual:
-            query.Not();
-            REALM_FALLTHROUGH;
+        case Predicate::Operator::NotEqual: {
+            Columns<Link> column = expr.value_of_type_for_query<Link>();
+            return column != realm::null();
+        }
         case Predicate::Operator::In:
-            REALM_FALLTHROUGH;
         case Predicate::Operator::Equal: {
             Columns<Link> column = expr.value_of_type_for_query<Link>();
-            query.and_query(column == realm::null());
-            break;
+            return column == realm::null();
         }
         default:
-            throw std::logic_error("Only 'equal' and 'not equal' operators supported for object comparison.");
+            throw_logic_error("Only 'equal' and 'not equal' operators supported for object comparison.");
     }
 }
 
 // add a clause for numeric constraints based on operator type
 template <typename A, typename B>
-void add_numeric_constraint_to_query(Query& query,
-                                     Predicate::Operator operatorType,
-                                     A lhs,
-                                     B rhs)
+Query make_numeric_constraint_query(Predicate::Operator operatorType, A lhs, B rhs)
 {
     switch (operatorType) {
         case Predicate::Operator::LessThan:
-            query.and_query(lhs < rhs);
-            break;
+            return lhs < rhs;
         case Predicate::Operator::LessThanOrEqual:
-            query.and_query(lhs <= rhs);
-            break;
+            return lhs <= rhs;
         case Predicate::Operator::GreaterThan:
-            query.and_query(lhs > rhs);
-            break;
+            return lhs > rhs;
         case Predicate::Operator::GreaterThanOrEqual:
-            query.and_query(lhs >= rhs);
-            break;
+            return lhs >= rhs;
         case Predicate::Operator::In:
-            REALM_FALLTHROUGH;
         case Predicate::Operator::Equal:
-            query.and_query(lhs == rhs);
-            break;
+            return lhs == rhs;
         case Predicate::Operator::NotEqual:
-            query.and_query(lhs != rhs);
-            break;
+            return lhs != rhs;
         default:
-            throw std::logic_error("Unsupported operator for numeric queries.");
+            throw_logic_error("Unsupported operator for numeric queries.");
     }
 }
 
 template <typename A, typename B>
-void add_bool_constraint_to_query(Query &query, Predicate::Operator operatorType, A lhs, B rhs) {
+Query make_bool_constraint_query(Predicate::Operator operatorType, A lhs, B rhs)
+{
     switch (operatorType) {
         case Predicate::Operator::In:
-            REALM_FALLTHROUGH;
         case Predicate::Operator::Equal:
-            query.and_query(lhs == rhs);
-            break;
+            return lhs == rhs;
         case Predicate::Operator::NotEqual:
-            query.and_query(lhs != rhs);
-            break;
+            return lhs != rhs;
         default:
-            throw std::logic_error("Unsupported operator for numeric queries.");
+            throw_logic_error("Unsupported operator for numeric queries.");
     }
 }
 
-std::string operator_description(const Predicate::Operator& op)
+const char* operator_description(const Predicate::Operator& op)
 {
     switch (op) {
         case Predicate::Operator::None:
@@ -197,31 +195,25 @@ std::string operator_description(const Predicate::Operator& op)
 template <typename LHS, typename RHS>
 std::enable_if_t<realm::is_any<LHS, Columns<String>, Columns<Lst<String>>>::value &&
                      realm::is_any<RHS, StringData, Columns<String>>::value,
-                 void>
-add_string_constraint_to_query(Query& query, const Predicate::Comparison& cmp, LHS&& lhs, RHS&& rhs)
+                 Query>
+make_string_constraint_query(const Predicate::Comparison& cmp, LHS&& lhs, RHS&& rhs)
 {
     bool case_sensitive = (cmp.option != Predicate::OperatorOption::CaseInsensitive);
     switch (cmp.op) {
         case Predicate::Operator::BeginsWith:
-            query.and_query(lhs.begins_with(rhs, case_sensitive));
-            break;
+            return lhs.begins_with(rhs, case_sensitive);
         case Predicate::Operator::EndsWith:
-            query.and_query(lhs.ends_with(rhs, case_sensitive));
-            break;
+            return lhs.ends_with(rhs, case_sensitive);
         case Predicate::Operator::Contains:
-            query.and_query(lhs.contains(rhs, case_sensitive));
-            break;
+            return lhs.contains(rhs, case_sensitive);
         case Predicate::Operator::Equal:
-            query.and_query(lhs.equal(rhs, case_sensitive));
-            break;
+            return lhs.equal(rhs, case_sensitive);
         case Predicate::Operator::NotEqual:
-            query.and_query(lhs.not_equal(rhs, case_sensitive));
-            break;
+            return lhs.not_equal(rhs, case_sensitive);
         case Predicate::Operator::Like:
-            query.and_query(lhs.like(rhs, case_sensitive));
-            break;
+            return lhs.like(rhs, case_sensitive);
         default:
-            throw std::logic_error(
+            throw_logic_error(
                 util::format("Unsupported operator '%1' for string queries.", operator_description(cmp.op)));
     }
 }
@@ -232,72 +224,64 @@ template <typename LHS, typename RHS>
 std::enable_if_t<(realm::is_any<LHS, StringData>::value &&
                   realm::is_any<RHS, Columns<String>, Columns<Lst<String>>>::value) ||
                      (std::is_same_v<LHS, Columns<String>> && std::is_same_v<RHS, Columns<Lst<String>>>),
-                 void>
-add_string_constraint_to_query(Query& query, const Predicate::Comparison& cmp, LHS&& lhs, RHS&& rhs)
+                 Query>
+make_string_constraint_query(const Predicate::Comparison& cmp, LHS&& lhs, RHS&& rhs)
 {
     bool case_sensitive = (cmp.option != Predicate::OperatorOption::CaseInsensitive);
     switch (cmp.op) {
         case Predicate::Operator::In:
-            REALM_FALLTHROUGH;
         case Predicate::Operator::Equal:
-            query.and_query(rhs.equal(lhs, case_sensitive));
-            break;
+            return rhs.equal(lhs, case_sensitive);
         case Predicate::Operator::NotEqual:
-            query.and_query(rhs.not_equal(lhs, case_sensitive));
-            break;
+            return rhs.not_equal(lhs, case_sensitive);
             // operators CONTAINS, BEGINSWITH, ENDSWITH, LIKE are not supported in this direction
             // These queries are not the same: "'asdf' CONTAINS string_property" vs "string_property CONTAINS 'asdf'"
         default:
-            throw std::logic_error(
+            throw_logic_error(
                 util::format("Unsupported query comparison '%1' for a single string vs a string property.",
                              operator_description(cmp.op)));
     }
 }
 
-void add_string_constraint_to_query(Query&, const Predicate::Comparison&, Columns<Lst<String>>&&,
-                                    Columns<Lst<String>>&&)
+REALM_FORCEINLINE Query make_string_constraint_query(const Predicate::Comparison&, Columns<Lst<String>>&&,
+                                                     Columns<Lst<String>>&&)
 {
-    throw std::logic_error("Comparing two primitive string lists against each other is not implemented yet.");
+    throw_logic_error("Comparing two primitive string lists against each other is not implemented yet.");
 }
 
 
 template <typename LHS, typename RHS>
-std::enable_if_t<(std::is_same_v<LHS, Columns<Lst<BinaryData>>> && std::is_same_v<RHS, Columns<Lst<BinaryData>>>),
-                 void>
-add_binary_constraint_to_query(Query&, const Predicate::Comparison&, RHS&&, LHS&&)
+REALM_FORCEINLINE
+    std::enable_if_t<(std::is_same_v<LHS, Columns<Lst<BinaryData>>> && std::is_same_v<RHS, Columns<Lst<BinaryData>>>),
+                     Query>
+    make_binary_constraint_query(const Predicate::Comparison&, RHS&&, LHS&&)
 {
-    throw std::logic_error("Unsupported operation for binary comparison.");
+    throw_logic_error("Unsupported operation for binary comparison.");
 }
 
 // (column OR list of primitives) vs (literal OR column)
 template <typename LHS, typename RHS>
 std::enable_if_t<realm::is_any<LHS, Columns<BinaryData>, Columns<Lst<BinaryData>>>::value &&
                      realm::is_any<RHS, BinaryData, Columns<BinaryData>>::value,
-                 void>
-add_binary_constraint_to_query(Query& query, const Predicate::Comparison& cmp, LHS&& column, RHS&& value)
+                 Query>
+make_binary_constraint_query(const Predicate::Comparison& cmp, LHS&& column, RHS&& value)
 {
     bool case_sensitive = (cmp.option != Predicate::OperatorOption::CaseInsensitive);
     switch (cmp.op) {
         case Predicate::Operator::BeginsWith:
-            query.and_query(column.begins_with(value, case_sensitive));
-            break;
+            return column.begins_with(value, case_sensitive);
         case Predicate::Operator::EndsWith:
-            query.and_query(column.ends_with(value, case_sensitive));
-            break;
+            return column.ends_with(value, case_sensitive);
         case Predicate::Operator::Contains:
-            query.and_query(column.contains(value, case_sensitive));
-            break;
+            return column.contains(value, case_sensitive);
         case Predicate::Operator::Equal:
-            query.and_query(column.equal(value, case_sensitive));
-            break;
+            return column.equal(value, case_sensitive);
         case Predicate::Operator::NotEqual:
-            query.and_query(column.not_equal(value, case_sensitive));
-            break;
+            return column.not_equal(value, case_sensitive);
         case Predicate::Operator::Like:
-            query.and_query(column.like(value, case_sensitive));
-            break;
+            return column.like(value, case_sensitive);
         default:
-            throw std::logic_error("Unsupported operator for binary queries.");
+            throw_logic_error("Unsupported operator for binary queries.");
     }
 }
 
@@ -306,135 +290,115 @@ template <typename LHS, typename RHS>
 std::enable_if_t<(realm::is_any<LHS, BinaryData>::value &&
                   realm::is_any<RHS, Columns<BinaryData>, Columns<Lst<BinaryData>>>::value) ||
                      (std::is_same_v<LHS, Columns<BinaryData>> && std::is_same_v<RHS, Columns<Lst<BinaryData>>>),
-                 void>
-add_binary_constraint_to_query(realm::Query& query, const Predicate::Comparison& cmp, LHS&& value, RHS&& column)
+                 Query>
+make_binary_constraint_query(const Predicate::Comparison& cmp, LHS&& value, RHS&& column)
 {
     switch (cmp.op) {
         case Predicate::Operator::In:
-            REALM_FALLTHROUGH;
         case Predicate::Operator::Equal:
-            query.and_query(column == value);
-            break;
+            return column == value;
         case Predicate::Operator::NotEqual:
-            query.and_query(column != value);
-            break;
+            return column != value;
         default:
-            throw std::logic_error("Substring comparison not supported for keypath substrings.");
+            throw_logic_error("Substring comparison not supported for keypath substrings.");
     }
 }
 
 template <typename LHS, typename RHS>
-void add_link_constraint_to_query(realm::Query &,
-                                  Predicate::Operator,
-                                  const LHS &,
-                                  const RHS &) {
-    throw std::runtime_error("Object comparisons are currently only supported between a property and an argument.");
+REALM_FORCEINLINE Query make_link_constraint_query(Predicate::Operator, const LHS&, const RHS&)
+{
+    throw_runtime_error("Object comparisons are currently only supported between a property and an argument.");
 }
 
 template <>
-void add_link_constraint_to_query(realm::Query &query,
-                                  Predicate::Operator op,
-                                  const PropertyExpression &prop_expr,
-                                  const ValueExpression &value_expr) {
+Query make_link_constraint_query(Predicate::Operator op, const PropertyExpression& prop_expr,
+                                 const ValueExpression& value_expr)
+{
     ObjKey obj_key = value_expr.arguments->object_index_for_argument(string_to<int>(value_expr.value->s));
     realm_precondition(prop_expr.link_chain.size() == 1, "KeyPath queries not supported for object comparisons.");
     switch (op) {
-        case Predicate::Operator::NotEqual:
-            query.Not();
-            REALM_FALLTHROUGH;
+        case Predicate::Operator::NotEqual: {
+            ColKey col = prop_expr.get_dest_col_key();
+            return Query().Not().links_to(col, obj_key);
+        }
         case Predicate::Operator::In:
-            REALM_FALLTHROUGH;
         case Predicate::Operator::Equal: {
             ColKey col = prop_expr.get_dest_col_key();
-            query.links_to(col, obj_key);
-            break;
+            return Query().links_to(col, obj_key);
         }
         default:
-            throw std::logic_error("Only 'equal' and 'not equal' operators supported for object comparison.");
+            throw_logic_error("Only 'equal' and 'not equal' operators supported for object comparison.");
     }
 }
 
 template <>
-void add_link_constraint_to_query(realm::Query &query,
-                                  Predicate::Operator op,
-                                  const ValueExpression &value_expr,
-                                  const PropertyExpression &prop_expr) {
+Query make_link_constraint_query(Predicate::Operator op, const ValueExpression& value_expr,
+                                 const PropertyExpression& prop_expr)
+{
     // since equality is commutative we can just call the above function to the same effect
-    add_link_constraint_to_query(query, op, prop_expr, value_expr);
+    return make_link_constraint_query(op, prop_expr, value_expr);
 }
 
 template <typename A, typename B, typename KnownType, typename PossibleMixedType>
-void add_mixed_type_numeric_comparison_to_query(Query& query, const Predicate::Comparison& cmp, A& lhs, B& rhs)
+Query make_mixed_type_numeric_comparison_query(const Predicate::Comparison& cmp, A& lhs, B& rhs)
 {
     if constexpr (std::is_same_v<B, ValueExpression>) {
         if (rhs.template is_type<PossibleMixedType>()) {
-            add_numeric_constraint_to_query(query, cmp.op, lhs.template value_of_type_for_query<KnownType>(),
-                                            rhs.template value_of_type_for_query<PossibleMixedType>());
-            return;
+            return make_numeric_constraint_query(cmp.op, lhs.template value_of_type_for_query<KnownType>(),
+                                                 rhs.template value_of_type_for_query<PossibleMixedType>());
         }
     }
     if constexpr (std::is_same_v<A, ValueExpression>) {
         if (lhs.template is_type<PossibleMixedType>()) {
-            add_numeric_constraint_to_query(query, cmp.op, lhs.template value_of_type_for_query<PossibleMixedType>(),
-                                            rhs.template value_of_type_for_query<KnownType>());
-            return;
+            return make_numeric_constraint_query(cmp.op, lhs.template value_of_type_for_query<PossibleMixedType>(),
+                                                 rhs.template value_of_type_for_query<KnownType>());
         }
     }
-    add_numeric_constraint_to_query(query, cmp.op, lhs.template value_of_type_for_query<KnownType>(),
-                                    rhs.template value_of_type_for_query<KnownType>());
+    return make_numeric_constraint_query(cmp.op, lhs.template value_of_type_for_query<KnownType>(),
+                                         rhs.template value_of_type_for_query<KnownType>());
 }
 
 template <typename A, typename B>
-void do_add_comparison_to_query(Query& query, const Predicate::Comparison& cmp, A& lhs, B& rhs, DataType type)
+Query do_make_comparison_query(const Predicate::Comparison& cmp, A& lhs, B& rhs, DataType type)
 {
     switch (type) {
         case type_Bool:
-            add_bool_constraint_to_query(query, cmp.op,
-                                         lhs. template value_of_type_for_query<bool>(),
-                                         rhs. template value_of_type_for_query<bool>());
-            break;
+            return make_bool_constraint_query(cmp.op, lhs.template value_of_type_for_query<bool>(),
+                                              rhs.template value_of_type_for_query<bool>());
         case type_Timestamp:
-            add_mixed_type_numeric_comparison_to_query<A, B, Timestamp, ObjectId>(query, cmp, lhs, rhs);
-            break;
+            return make_mixed_type_numeric_comparison_query<A, B, Timestamp, ObjectId>(cmp, lhs, rhs);
         case type_Double:
-            add_numeric_constraint_to_query(query, cmp.op, lhs.template value_of_type_for_query<Double>(),
-                                            rhs.template value_of_type_for_query<Double>());
-            break;
+            return make_numeric_constraint_query(cmp.op, lhs.template value_of_type_for_query<Double>(),
+                                                 rhs.template value_of_type_for_query<Double>());
         case type_Float:
-            add_numeric_constraint_to_query(query, cmp.op, lhs.template value_of_type_for_query<Float>(),
-                                            rhs.template value_of_type_for_query<Float>());
-            break;
+            return make_numeric_constraint_query(cmp.op, lhs.template value_of_type_for_query<Float>(),
+                                                 rhs.template value_of_type_for_query<Float>());
         case type_Int:
-            add_numeric_constraint_to_query(query, cmp.op, lhs.template value_of_type_for_query<Int>(),
-                                            rhs.template value_of_type_for_query<Int>());
-            break;
+            return make_numeric_constraint_query(cmp.op, lhs.template value_of_type_for_query<Int>(),
+                                                 rhs.template value_of_type_for_query<Int>());
         case type_String:
-            add_string_constraint_to_query(query, cmp, lhs.template value_of_type_for_query<String>(),
-                                           rhs.template value_of_type_for_query<String>());
-            break;
+            return make_string_constraint_query(cmp, lhs.template value_of_type_for_query<String>(),
+                                                rhs.template value_of_type_for_query<String>());
         case type_Binary:
-            add_binary_constraint_to_query(query, cmp, lhs.template value_of_type_for_query<Binary>(),
-                                           rhs.template value_of_type_for_query<Binary>());
-            break;
+            return make_binary_constraint_query(cmp, lhs.template value_of_type_for_query<Binary>(),
+                                                rhs.template value_of_type_for_query<Binary>());
         case type_Link:
-            add_link_constraint_to_query(query, cmp.op, lhs, rhs);
-            break;
+            return make_link_constraint_query(cmp.op, lhs, rhs);
         case type_ObjectId:
-            add_mixed_type_numeric_comparison_to_query<A, B, ObjectId, Timestamp>(query, cmp, lhs, rhs);
-            break;
+            return make_mixed_type_numeric_comparison_query<A, B, ObjectId, Timestamp>(cmp, lhs, rhs);
         case type_Decimal:
-            add_numeric_constraint_to_query(query, cmp.op, lhs.template value_of_type_for_query<Decimal128>(),
-                                            rhs.template value_of_type_for_query<Decimal128>());
-            break;
+            return make_numeric_constraint_query(cmp.op, lhs.template value_of_type_for_query<Decimal128>(),
+                                                 rhs.template value_of_type_for_query<Decimal128>());
         default:
-            throw std::logic_error(util::format("Object type '%1' not supported", data_type_to_str(type)));
+            throw_logic_error(util::format("Object type '%1' not supported", data_type_to_str(type)));
     }
 }
 
 template <>
-void do_add_comparison_to_query(Query&, const Predicate::Comparison&, ValueExpression&, ValueExpression&, DataType)
+REALM_FORCEINLINE Query do_make_comparison_query(const Predicate::Comparison&, ValueExpression&, ValueExpression&,
+                                                 DataType)
 {
-    throw std::runtime_error("Invalid predicate: comparison between two literals is not supported.");
+    throw_runtime_error("Invalid predicate: comparison between two literals is not supported.");
 }
 
 enum class NullLocation {
@@ -443,254 +407,196 @@ enum class NullLocation {
 };
 
 template <class T>
-void do_add_null_comparison_to_query(Query& query, const Predicate::Comparison& cmp, const T& expr, DataType type,
-                                     NullLocation location)
+Query do_make_null_comparison_query(const Predicate::Comparison& cmp, const T& expr, DataType type,
+                                    NullLocation location)
 {
     if constexpr (std::is_same_v<T, PropertyExpression>) {
         if (expr.dest_type_is_backlink()) {
-            throw std::logic_error("Comparing linking object properties to 'null' is not supported");
+            throw_logic_error("Comparing linking object properties to 'null' is not supported");
         }
     }
     if (type == type_LinkList) {
-        throw std::logic_error("Comparing a list property to 'null' is not supported");
+        throw_logic_error("Comparing a list property to 'null' is not supported");
     }
     switch (type) {
         case realm::type_Bool:
-            do_add_null_comparison_to_query<bool>(query, cmp.op, expr);
-            break;
+            return do_make_null_comparison_query<bool>(cmp.op, expr);
         case realm::type_Timestamp:
-            do_add_null_comparison_to_query<Timestamp>(query, cmp.op, expr);
-            break;
+            return do_make_null_comparison_query<Timestamp>(cmp.op, expr);
         case realm::type_Double:
-            do_add_null_comparison_to_query<Double>(query, cmp.op, expr);
-            break;
+            return do_make_null_comparison_query<Double>(cmp.op, expr);
         case realm::type_Float:
-            do_add_null_comparison_to_query<Float>(query, cmp.op, expr);
-            break;
+            return do_make_null_comparison_query<Float>(cmp.op, expr);
         case realm::type_Int:
-            do_add_null_comparison_to_query<Int>(query, cmp.op, expr);
-            break;
+            return do_make_null_comparison_query<Int>(cmp.op, expr);
         case realm::type_String: {
             if (location == NullLocation::NullOnLHS) {
-                add_string_constraint_to_query(query, cmp, StringData(), expr. template value_of_type_for_query<String>());
+                return make_string_constraint_query(cmp, StringData(),
+                                                    expr.template value_of_type_for_query<String>());
             }
             else {
-                add_string_constraint_to_query(query, cmp, expr. template value_of_type_for_query<String>(), StringData());
+                return make_string_constraint_query(cmp, expr.template value_of_type_for_query<String>(),
+                                                    StringData());
             }
-            break;
         }
         case realm::type_Binary: {
             if (location == NullLocation::NullOnLHS) {
-                add_binary_constraint_to_query(query, cmp, BinaryData(), expr. template value_of_type_for_query<Binary>());
+                return make_binary_constraint_query(cmp, BinaryData(),
+                                                    expr.template value_of_type_for_query<Binary>());
             }
             else {
-                add_binary_constraint_to_query(query, cmp, expr. template value_of_type_for_query<Binary>(), BinaryData());
+                return make_binary_constraint_query(cmp, expr.template value_of_type_for_query<Binary>(),
+                                                    BinaryData());
             }
-            break;
         }
         case realm::type_ObjectId:
-            do_add_null_comparison_to_query<ObjectId>(query, cmp.op, expr);
-            break;
+            return do_make_null_comparison_query<ObjectId>(cmp.op, expr);
         case realm::type_Decimal:
-            do_add_null_comparison_to_query<Decimal128>(query, cmp.op, expr);
-            break;
+            return do_make_null_comparison_query<Decimal128>(cmp.op, expr);
         case realm::type_Link:
-            do_add_null_comparison_to_query<Link>(query, cmp.op, expr);
-            break;
+            return do_make_null_comparison_query<Link>(cmp.op, expr);
         default:
-            throw std::logic_error(util::format("Object type '%1' not supported", util::data_type_to_str(type)));
+            throw_logic_error(util::format("Object type '%1' not supported", util::data_type_to_str(type)));
     }
 }
 
-void add_null_comparison_to_query(Query& query, const Predicate::Comparison& cmp, ExpressionContainer& exp,
-                                  NullLocation location)
+Query make_null_comparison_query(const Predicate::Comparison& cmp, ExpressionContainer& exp, NullLocation location)
 {
     switch (exp.type) {
         case ExpressionContainer::ExpressionInternal::exp_Value:
-            throw std::runtime_error("Unsupported query comparing 'null' and a literal. A comparison must include at least one keypath.");
+            throw_runtime_error(
+                "Unsupported query comparing 'null' and a literal. A comparison must include at least one keypath.");
         case ExpressionContainer::ExpressionInternal::exp_Property:
-            do_add_null_comparison_to_query(query, cmp, exp.get_property(), exp.get_property().get_dest_type(),
-                                            location);
-            break;
+            return do_make_null_comparison_query(cmp, exp.get_property(), exp.get_property().get_dest_type(),
+                                                 location);
         case ExpressionContainer::ExpressionInternal::exp_PrimitiveList:
-            do_add_null_comparison_to_query(query, cmp, exp.get_primitive_list(),
-                                            exp.get_primitive_list().get_dest_type(), location);
-            break;
+            return do_make_null_comparison_query(cmp, exp.get_primitive_list(),
+                                                 exp.get_primitive_list().get_dest_type(), location);
         case ExpressionContainer::ExpressionInternal::exp_OpMin:
-            do_add_null_comparison_to_query(query, cmp, exp.get_min(), exp.get_min().operative_col_type, location);
-            break;
+            return do_make_null_comparison_query(cmp, exp.get_min(), exp.get_min().operative_col_type, location);
         case ExpressionContainer::ExpressionInternal::exp_OpMax:
-            do_add_null_comparison_to_query(query, cmp, exp.get_max(), exp.get_max().operative_col_type, location);
-            break;
+            return do_make_null_comparison_query(cmp, exp.get_max(), exp.get_max().operative_col_type, location);
         case ExpressionContainer::ExpressionInternal::exp_OpSum:
-            do_add_null_comparison_to_query(query, cmp, exp.get_sum(), exp.get_sum().operative_col_type, location);
-            break;
+            return do_make_null_comparison_query(cmp, exp.get_sum(), exp.get_sum().operative_col_type, location);
         case ExpressionContainer::ExpressionInternal::exp_OpAvg:
-            do_add_null_comparison_to_query(query, cmp, exp.get_avg(), exp.get_avg().operative_col_type, location);
-            break;
+            return do_make_null_comparison_query(cmp, exp.get_avg(), exp.get_avg().operative_col_type, location);
         case ExpressionContainer::ExpressionInternal::exp_OpMinPrimitive:
-            do_add_null_comparison_to_query(query, cmp, exp.get_primitive_min(),
-                                            exp.get_primitive_min().operative_col_type, location);
-            break;
+            return do_make_null_comparison_query(cmp, exp.get_primitive_min(),
+                                                 exp.get_primitive_min().operative_col_type, location);
         case ExpressionContainer::ExpressionInternal::exp_OpMaxPrimitive:
-            do_add_null_comparison_to_query(query, cmp, exp.get_primitive_max(),
-                                            exp.get_primitive_max().operative_col_type, location);
-            break;
+            return do_make_null_comparison_query(cmp, exp.get_primitive_max(),
+                                                 exp.get_primitive_max().operative_col_type, location);
         case ExpressionContainer::ExpressionInternal::exp_OpSumPrimitive:
-            do_add_null_comparison_to_query(query, cmp, exp.get_primitive_sum(),
-                                            exp.get_primitive_sum().operative_col_type, location);
-            break;
+            return do_make_null_comparison_query(cmp, exp.get_primitive_sum(),
+                                                 exp.get_primitive_sum().operative_col_type, location);
         case ExpressionContainer::ExpressionInternal::exp_OpAvgPrimitive:
-            do_add_null_comparison_to_query(query, cmp, exp.get_primitive_avg(),
-                                            exp.get_primitive_avg().operative_col_type, location);
-            break;
+            return do_make_null_comparison_query(cmp, exp.get_primitive_avg(),
+                                                 exp.get_primitive_avg().operative_col_type, location);
         case ExpressionContainer::ExpressionInternal::exp_SubQuery:
-            REALM_FALLTHROUGH;
         case ExpressionContainer::ExpressionInternal::exp_OpCount:
-            REALM_FALLTHROUGH;
         case ExpressionContainer::ExpressionInternal::exp_OpBacklinkCount:
-            REALM_FALLTHROUGH;
         case ExpressionContainer::ExpressionInternal::exp_OpSizeString:
-            REALM_FALLTHROUGH;
         case ExpressionContainer::ExpressionInternal::exp_OpSizeBinary:
-            REALM_FALLTHROUGH;
         case ExpressionContainer::ExpressionInternal::exp_OpCountPrimitive:
-            throw std::runtime_error("Invalid predicate: comparison between 'null' and @size or @count");
+            throw_runtime_error("Invalid predicate: comparison between 'null' and @size or @count");
         case realm::parser::ExpressionContainer::ExpressionInternal::exp_OpSizeStringPrimitive:
-            REALM_FALLTHROUGH;
         case realm::parser::ExpressionContainer::ExpressionInternal::exp_OpSizeBinaryPrimitive:
-            throw std::runtime_error("Invalid predicate: comparison between primitive list '.length' and 'null'");
+            throw_runtime_error("Invalid predicate: comparison between primitive list '.length' and 'null'");
     }
+    throw_logic_error("unreachable");
 }
 
 template <typename LHS_T>
-void internal_add_comparison_to_query(Query& query, LHS_T& lhs, const Predicate::Comparison& cmp,
-                                      ExpressionContainer& rhs, DataType comparison_type)
+Query internal_make_comparison_query(LHS_T& lhs, const Predicate::Comparison& cmp, ExpressionContainer& rhs,
+                                     DataType comparison_type)
 {
     switch (rhs.type) {
         case ExpressionContainer::ExpressionInternal::exp_Value:
-            do_add_comparison_to_query(query, cmp, lhs, rhs.get_value(), comparison_type);
-            return;
+            return do_make_comparison_query(cmp, lhs, rhs.get_value(), comparison_type);
         case ExpressionContainer::ExpressionInternal::exp_Property:
-            do_add_comparison_to_query(query, cmp, lhs, rhs.get_property(), comparison_type);
-            return;
+            return do_make_comparison_query(cmp, lhs, rhs.get_property(), comparison_type);
         case ExpressionContainer::ExpressionInternal::exp_OpMin:
-            do_add_comparison_to_query(query, cmp, lhs, rhs.get_min(), comparison_type);
-            return;
+            return do_make_comparison_query(cmp, lhs, rhs.get_min(), comparison_type);
         case ExpressionContainer::ExpressionInternal::exp_OpMax:
-            do_add_comparison_to_query(query, cmp, lhs, rhs.get_max(), comparison_type);
-            return;
+            return do_make_comparison_query(cmp, lhs, rhs.get_max(), comparison_type);
         case ExpressionContainer::ExpressionInternal::exp_OpSum:
-            do_add_comparison_to_query(query, cmp, lhs, rhs.get_sum(), comparison_type);
-            return;
+            return do_make_comparison_query(cmp, lhs, rhs.get_sum(), comparison_type);
         case ExpressionContainer::ExpressionInternal::exp_OpAvg:
-            do_add_comparison_to_query(query, cmp, lhs, rhs.get_avg(), comparison_type);
-            return;
+            return do_make_comparison_query(cmp, lhs, rhs.get_avg(), comparison_type);
         case ExpressionContainer::ExpressionInternal::exp_OpCount:
-            do_add_comparison_to_query(query, cmp, lhs, rhs.get_count(), comparison_type);
-            return;
+            return do_make_comparison_query(cmp, lhs, rhs.get_count(), comparison_type);
         case ExpressionContainer::ExpressionInternal::exp_OpBacklinkCount:
-            do_add_comparison_to_query(query, cmp, lhs, rhs.get_backlink_count(), comparison_type);
-            return;
+            return do_make_comparison_query(cmp, lhs, rhs.get_backlink_count(), comparison_type);
         case ExpressionContainer::ExpressionInternal::exp_OpSizeString:
-            do_add_comparison_to_query(query, cmp, lhs, rhs.get_size_string(), comparison_type);
-            return;
+            return do_make_comparison_query(cmp, lhs, rhs.get_size_string(), comparison_type);
         case ExpressionContainer::ExpressionInternal::exp_OpSizeBinary:
-            do_add_comparison_to_query(query, cmp, lhs, rhs.get_size_binary(), comparison_type);
-            return;
+            return do_make_comparison_query(cmp, lhs, rhs.get_size_binary(), comparison_type);
         case realm::parser::ExpressionContainer::ExpressionInternal::exp_SubQuery:
-            do_add_comparison_to_query(query, cmp, lhs, rhs.get_subexpression(), comparison_type);
-            return;
+            return do_make_comparison_query(cmp, lhs, rhs.get_subexpression(), comparison_type);
         case realm::parser::ExpressionContainer::ExpressionInternal::exp_PrimitiveList:
-            do_add_comparison_to_query(query, cmp, lhs, rhs.get_primitive_list(), comparison_type);
-            return;
+            return do_make_comparison_query(cmp, lhs, rhs.get_primitive_list(), comparison_type);
         case realm::parser::ExpressionContainer::ExpressionInternal::exp_OpMinPrimitive:
-            do_add_comparison_to_query(query, cmp, lhs, rhs.get_primitive_min(), comparison_type);
-            return;
+            return do_make_comparison_query(cmp, lhs, rhs.get_primitive_min(), comparison_type);
         case realm::parser::ExpressionContainer::ExpressionInternal::exp_OpMaxPrimitive:
-            do_add_comparison_to_query(query, cmp, lhs, rhs.get_primitive_max(), comparison_type);
-            return;
+            return do_make_comparison_query(cmp, lhs, rhs.get_primitive_max(), comparison_type);
         case realm::parser::ExpressionContainer::ExpressionInternal::exp_OpSumPrimitive:
-            do_add_comparison_to_query(query, cmp, lhs, rhs.get_primitive_sum(), comparison_type);
-            return;
+            return do_make_comparison_query(cmp, lhs, rhs.get_primitive_sum(), comparison_type);
         case realm::parser::ExpressionContainer::ExpressionInternal::exp_OpAvgPrimitive:
-            do_add_comparison_to_query(query, cmp, lhs, rhs.get_primitive_avg(), comparison_type);
-            return;
+            return do_make_comparison_query(cmp, lhs, rhs.get_primitive_avg(), comparison_type);
         case realm::parser::ExpressionContainer::ExpressionInternal::exp_OpCountPrimitive:
-            do_add_comparison_to_query(query, cmp, lhs, rhs.get_primitive_count(), comparison_type);
-            return;
+            return do_make_comparison_query(cmp, lhs, rhs.get_primitive_count(), comparison_type);
         case realm::parser::ExpressionContainer::ExpressionInternal::exp_OpSizeStringPrimitive:
-            do_add_comparison_to_query(query, cmp, lhs, rhs.get_primitive_string_length(), comparison_type);
-            return;
+            return do_make_comparison_query(cmp, lhs, rhs.get_primitive_string_length(), comparison_type);
         case realm::parser::ExpressionContainer::ExpressionInternal::exp_OpSizeBinaryPrimitive:
-            do_add_comparison_to_query(query, cmp, lhs, rhs.get_primitive_binary_length(), comparison_type);
-            return;
+            return do_make_comparison_query(cmp, lhs, rhs.get_primitive_binary_length(), comparison_type);
     }
+    throw_logic_error("unreachable");
 }
 
-void add_comparison_to_query(Query& query, ExpressionContainer& lhs, const Predicate::Comparison& cmp,
-                             ExpressionContainer& rhs)
+Query make_comparison_query(ExpressionContainer& lhs, const Predicate::Comparison& cmp, ExpressionContainer& rhs)
 {
     DataType comparison_type = lhs.get_comparison_type(rhs);
     switch (lhs.type) {
         case ExpressionContainer::ExpressionInternal::exp_Value:
-            internal_add_comparison_to_query(query, lhs.get_value(), cmp, rhs, comparison_type);
-            return;
+            return internal_make_comparison_query(lhs.get_value(), cmp, rhs, comparison_type);
         case ExpressionContainer::ExpressionInternal::exp_Property:
-            internal_add_comparison_to_query(query, lhs.get_property(), cmp, rhs, comparison_type);
-            return;
+            return internal_make_comparison_query(lhs.get_property(), cmp, rhs, comparison_type);
         case ExpressionContainer::ExpressionInternal::exp_OpMin:
-            internal_add_comparison_to_query(query, lhs.get_min(), cmp, rhs, comparison_type);
-            return;
+            return internal_make_comparison_query(lhs.get_min(), cmp, rhs, comparison_type);
         case ExpressionContainer::ExpressionInternal::exp_OpMax:
-            internal_add_comparison_to_query(query, lhs.get_max(), cmp, rhs, comparison_type);
-            return;
+            return internal_make_comparison_query(lhs.get_max(), cmp, rhs, comparison_type);
         case ExpressionContainer::ExpressionInternal::exp_OpSum:
-            internal_add_comparison_to_query(query, lhs.get_sum(), cmp, rhs, comparison_type);
-            return;
+            return internal_make_comparison_query(lhs.get_sum(), cmp, rhs, comparison_type);
         case ExpressionContainer::ExpressionInternal::exp_OpAvg:
-            internal_add_comparison_to_query(query, lhs.get_avg(), cmp, rhs, comparison_type);
-            return;
+            return internal_make_comparison_query(lhs.get_avg(), cmp, rhs, comparison_type);
         case ExpressionContainer::ExpressionInternal::exp_OpCount:
-            internal_add_comparison_to_query(query, lhs.get_count(), cmp, rhs, comparison_type);
-            return;
+            return internal_make_comparison_query(lhs.get_count(), cmp, rhs, comparison_type);
         case ExpressionContainer::ExpressionInternal::exp_OpBacklinkCount:
-            internal_add_comparison_to_query(query, lhs.get_backlink_count(), cmp, rhs, comparison_type);
-            return;
+            return internal_make_comparison_query(lhs.get_backlink_count(), cmp, rhs, comparison_type);
         case ExpressionContainer::ExpressionInternal::exp_OpSizeString:
-            internal_add_comparison_to_query(query, lhs.get_size_string(), cmp, rhs, comparison_type);
-            return;
+            return internal_make_comparison_query(lhs.get_size_string(), cmp, rhs, comparison_type);
         case ExpressionContainer::ExpressionInternal::exp_OpSizeBinary:
-            internal_add_comparison_to_query(query, lhs.get_size_binary(), cmp, rhs, comparison_type);
-            return;
+            return internal_make_comparison_query(lhs.get_size_binary(), cmp, rhs, comparison_type);
         case realm::parser::ExpressionContainer::ExpressionInternal::exp_SubQuery:
-            internal_add_comparison_to_query(query, lhs.get_subexpression(), cmp, rhs, comparison_type);
-            return;
+            return internal_make_comparison_query(lhs.get_subexpression(), cmp, rhs, comparison_type);
         case realm::parser::ExpressionContainer::ExpressionInternal::exp_PrimitiveList:
-            internal_add_comparison_to_query(query, lhs.get_primitive_list(), cmp, rhs, comparison_type);
-            return;
+            return internal_make_comparison_query(lhs.get_primitive_list(), cmp, rhs, comparison_type);
         case realm::parser::ExpressionContainer::ExpressionInternal::exp_OpMinPrimitive:
-            internal_add_comparison_to_query(query, lhs.get_primitive_min(), cmp, rhs, comparison_type);
-            return;
+            return internal_make_comparison_query(lhs.get_primitive_min(), cmp, rhs, comparison_type);
         case realm::parser::ExpressionContainer::ExpressionInternal::exp_OpMaxPrimitive:
-            internal_add_comparison_to_query(query, lhs.get_primitive_max(), cmp, rhs, comparison_type);
-            return;
+            return internal_make_comparison_query(lhs.get_primitive_max(), cmp, rhs, comparison_type);
         case realm::parser::ExpressionContainer::ExpressionInternal::exp_OpSumPrimitive:
-            internal_add_comparison_to_query(query, lhs.get_primitive_sum(), cmp, rhs, comparison_type);
-            return;
+            return internal_make_comparison_query(lhs.get_primitive_sum(), cmp, rhs, comparison_type);
         case realm::parser::ExpressionContainer::ExpressionInternal::exp_OpAvgPrimitive:
-            internal_add_comparison_to_query(query, lhs.get_primitive_avg(), cmp, rhs, comparison_type);
-            return;
+            return internal_make_comparison_query(lhs.get_primitive_avg(), cmp, rhs, comparison_type);
         case realm::parser::ExpressionContainer::ExpressionInternal::exp_OpCountPrimitive:
-            internal_add_comparison_to_query(query, lhs.get_primitive_count(), cmp, rhs, comparison_type);
-            return;
+            return internal_make_comparison_query(lhs.get_primitive_count(), cmp, rhs, comparison_type);
         case realm::parser::ExpressionContainer::ExpressionInternal::exp_OpSizeStringPrimitive:
-            internal_add_comparison_to_query(query, lhs.get_primitive_string_length(), cmp, rhs, comparison_type);
-            return;
+            return internal_make_comparison_query(lhs.get_primitive_string_length(), cmp, rhs, comparison_type);
         case realm::parser::ExpressionContainer::ExpressionInternal::exp_OpSizeBinaryPrimitive:
-            internal_add_comparison_to_query(query, lhs.get_primitive_binary_length(), cmp, rhs, comparison_type);
-            return;
+            return internal_make_comparison_query(lhs.get_primitive_binary_length(), cmp, rhs, comparison_type);
     }
+    throw_logic_error("unreachable");
 }
 
 // precheck some expressions to make sure we support them and if not, provide a meaningful error message
@@ -739,7 +645,7 @@ void preprocess_for_comparison_types(Predicate::Comparison& cmpr, ExpressionCont
 
     if (lhs.type == ExpressionContainer::ExpressionInternal::exp_PrimitiveList &&
         rhs.type == ExpressionContainer::ExpressionInternal::exp_PrimitiveList) {
-        throw std::logic_error(
+        throw_logic_error(
             util::format("Ordered comparison between two primitive lists is not implemented yet ('%1' and '%2')",
                          cmpr.expr[0].s, cmpr.expr[1].s));
     }
@@ -780,14 +686,14 @@ bool is_property_operation(parser::Expression::Type type)
     return type == parser::Expression::Type::KeyPath || type == parser::Expression::Type::SubQuery;
 }
 
-void add_comparison_to_query(Query& query, const Predicate& pred, Arguments& args, parser::KeyPathMapping& mapping)
+Query make_comparison_query(Query& query, const Predicate& pred, Arguments& args, parser::KeyPathMapping& mapping)
 {
     Predicate::Comparison cmpr = pred.cmpr;
     auto lhs_type = cmpr.expr[0].type, rhs_type = cmpr.expr[1].type;
 
     if (!is_property_operation(lhs_type) && !is_property_operation(rhs_type)) {
         // value vs value expressions are not supported (ex: 2 < 3 or null != null)
-        throw std::logic_error("Predicate expressions must compare a keypath and another keypath or a constant value");
+        throw_logic_error("Predicate expressions must compare a keypath and another keypath or a constant value");
     }
     ExpressionContainer lhs(query, cmpr.expr[0], args, mapping);
     ExpressionContainer rhs(query, cmpr.expr[1], args, mapping);
@@ -795,13 +701,13 @@ void add_comparison_to_query(Query& query, const Predicate& pred, Arguments& arg
     preprocess_for_comparison_types(cmpr, lhs, rhs);
 
     if (lhs.is_null()) {
-        add_null_comparison_to_query(query, cmpr, rhs, NullLocation::NullOnLHS);
+        return make_null_comparison_query(cmpr, rhs, NullLocation::NullOnLHS);
     }
     else if (rhs.is_null()) {
-        add_null_comparison_to_query(query, cmpr, lhs, NullLocation::NullOnRHS);
+        return make_null_comparison_query(cmpr, lhs, NullLocation::NullOnRHS);
     }
     else {
-        add_comparison_to_query(query, lhs, cmpr, rhs);
+        return make_comparison_query(lhs, cmpr, rhs);
     }
 }
 
@@ -837,7 +743,7 @@ void update_query_with_predicate(Query& query, const Predicate& pred, Arguments&
             break;
 
         case Predicate::Type::Comparison: {
-            add_comparison_to_query(query, pred, arguments, mapping);
+            query.and_query(make_comparison_query(query, pred, arguments, mapping));
             break;
         }
         case Predicate::Type::True:
@@ -849,7 +755,7 @@ void update_query_with_predicate(Query& query, const Predicate& pred, Arguments&
             break;
 
         default:
-            throw std::logic_error("Invalid predicate type");
+            throw_logic_error("Invalid predicate type");
     }
 }
 } // anonymous namespace
@@ -892,7 +798,7 @@ void apply_ordering(DescriptorOrdering& ordering, ConstTableRef target, const pa
                 for (size_t ndx_in_path = 0; ndx_in_path < path.size(); ++ndx_in_path) {
                     ColKey col_key = cur_table->get_column_key(path[ndx_in_path]);
                     if (!col_key) {
-                        throw std::runtime_error(util::format(
+                        throw_runtime_error(util::format(
                             "No property '%1' found on object type '%2' specified in '%3' clause", path[ndx_in_path],
                             cur_table->get_name(), is_distinct ? "distinct" : "sort"));
                     }

--- a/src/realm/query.cpp
+++ b/src/realm/query.cpp
@@ -249,6 +249,11 @@ Query& Query::like(ColKey column_key, BinaryData b, bool case_sensitive)
 
 namespace {
 
+REALM_NOINLINE REALM_COLD REALM_NORETURN void throw_type_mismatch_error()
+{
+    throw LogicError{LogicError::type_mismatch};
+}
+
 template <class Node>
 struct MakeConditionNode {
     static std::unique_ptr<ParentNode> make(ColKey col_key, typename Node::TConditionValue value)
@@ -270,9 +275,9 @@ struct MakeConditionNode {
     }
 
     template <class T>
-    static std::unique_ptr<ParentNode> make(ColKey, T)
+    REALM_FORCEINLINE static std::unique_ptr<ParentNode> make(ColKey, T&&)
     {
-        throw LogicError{LogicError::type_mismatch};
+        throw_type_mismatch_error();
     }
 };
 
@@ -284,9 +289,9 @@ struct MakeConditionNode<IntegerNode<ArrayInteger, Cond>> {
     }
 
     template <class T>
-    static std::unique_ptr<ParentNode> make(ColKey, T)
+    REALM_FORCEINLINE static std::unique_ptr<ParentNode> make(ColKey, T&&)
     {
-        throw LogicError{LogicError::type_mismatch};
+        throw_type_mismatch_error();
     }
 };
 
@@ -303,9 +308,9 @@ struct MakeConditionNode<StringNode<Cond>> {
     }
 
     template <class T>
-    static std::unique_ptr<ParentNode> make(ColKey, T)
+    REALM_FORCEINLINE static std::unique_ptr<ParentNode> make(ColKey, T&&)
     {
-        throw LogicError{LogicError::type_mismatch};
+        throw_type_mismatch_error();
     }
 };
 
@@ -348,7 +353,7 @@ std::unique_ptr<ParentNode> make_condition_node(const Table& table, ColKey colum
             return MakeConditionNode<ObjectIdNode<Cond>>::make(column_key, value);
         }
         default: {
-            throw LogicError{LogicError::type_mismatch};
+            throw_type_mismatch_error();
         }
     }
 }
@@ -386,7 +391,7 @@ std::unique_ptr<ParentNode> make_size_condition_node(const Table& table, ColKey 
                 return std::unique_ptr<ParentNode>{new SizeListNode<ObjKey, Cond>(value, column_key)};
             }
             default: {
-                throw LogicError{LogicError::type_mismatch};
+                throw_type_mismatch_error();
             }
         }
     }
@@ -398,7 +403,7 @@ std::unique_ptr<ParentNode> make_size_condition_node(const Table& table, ColKey 
             return std::unique_ptr<ParentNode>{new SizeNode<BinaryData, Cond>(value, column_key)};
         }
         default: {
-            throw LogicError{LogicError::type_mismatch};
+            throw_type_mismatch_error();
         }
     }
 }
@@ -406,7 +411,7 @@ std::unique_ptr<ParentNode> make_size_condition_node(const Table& table, ColKey 
 } // anonymous namespace
 
 template <typename TConditionFunction, class T>
-Query& Query::add_condition(ColKey column_key, T value)
+REALM_FORCEINLINE Query& Query::add_condition(ColKey column_key, T value)
 {
     auto node = make_condition_node<TConditionFunction>(*m_table, column_key, value);
     add_node(std::move(node));

--- a/src/realm/query_expression.hpp
+++ b/src/realm/query_expression.hpp
@@ -1386,7 +1386,7 @@ public:
 
     // Below import and export methods are for type conversion between float, double, int64_t, etc.
     template <class D>
-    std::enable_if_t<std::is_convertible<T, D>::value> REALM_FORCEINLINE export2(ValueBase& destination) const
+    REALM_FORCEINLINE std::enable_if_t<std::is_convertible<T, D>::value> export2(ValueBase& destination) const
     {
         Value<D>& d = static_cast<Value<D>&>(destination);
         d.init(ValueBase::m_from_link_list, ValueBase::m_values, D());
@@ -1408,7 +1408,7 @@ public:
 
     // we specialize here to convert between null and ObjectId without having a constructor from null
     template <class D>
-    std::enable_if_t<IsNullToObjectId<T, D>> REALM_FORCEINLINE export2(ValueBase& destination) const
+    REALM_FORCEINLINE std::enable_if_t<IsNullToObjectId<T, D>> export2(ValueBase& destination) const
     {
         Value<D>& d = static_cast<Value<D>&>(destination);
         d.init(ValueBase::m_from_link_list, ValueBase::m_values, D());
@@ -1420,7 +1420,7 @@ public:
     // we specialize here because the conversion from ObjectId to Timestamp has been made explicit in order to catch
     // wrong auto conversions
     template <class D>
-    std::enable_if_t<IsObjectIdToTimestamp<T, D>> REALM_FORCEINLINE export2(ValueBase& destination) const
+    REALM_FORCEINLINE std::enable_if_t<IsObjectIdToTimestamp<T, D>> export2(ValueBase& destination) const
     {
         Value<D>& d = static_cast<Value<D>&>(destination);
         d.init(ValueBase::m_from_link_list, ValueBase::m_values, D());
@@ -1435,8 +1435,9 @@ public:
     }
 
     template <class D>
-    std::enable_if_t<!std::is_convertible<T, D>::value && !IsNullToObjectId<T, D> && !IsObjectIdToTimestamp<T, D>>
-        REALM_FORCEINLINE export2(ValueBase&) const
+    REALM_FORCEINLINE
+        std::enable_if_t<!std::is_convertible<T, D>::value && !IsNullToObjectId<T, D> && !IsObjectIdToTimestamp<T, D>>
+        export2(ValueBase&) const
     {
         // export2 is instantiated for impossible conversions like T=StringData, D=int64_t. These are never
         // performed at runtime but would result in a compiler error if we did not provide this implementation.

--- a/src/realm/util/features.h
+++ b/src/realm/util/features.h
@@ -183,7 +183,16 @@
 #endif
 
 
-#if defined(__GNUC__) || defined(__HP_aCC)
+#if REALM_HAS_CPP_ATTRIBUTE(gnu::cold)
+#define REALM_COLD [[gnu::cold]]
+#else
+#define REALM_COLD
+#endif
+
+
+#if REALM_HAS_CPP_ATTRIBUTE(gnu::noinline)
+#define REALM_NOINLINE [[gnu::noinline]]
+#elif defined(__GNUC__) || defined(__HP_aCC)
 #define REALM_NOINLINE __attribute__((noinline))
 #elif defined(_MSC_VER)
 #define REALM_NOINLINE __declspec(noinline)


### PR DESCRIPTION
480k reduction on realm-java arm64 build with parser

* pull throwing of exceptions out to non-templated functions
* convert templated functions in query_builder.cpp to return Query so the code
  to add it to the tree is only needed once.
* FORCEINLINE overloads for invalid combinations
  * Counterintutively, this actually shrinks the binary because the compiler
    is able to directly call the `throw_foo_error` function, which propagates
    the information about it never returning. It is also able to redirect
    branches that lead there to the same instructions, which it wasn't able to
    do previously because each template instantiation was considered a
    different function, even though they did the same thing.