### PR TITLE
performance report bug

### DIFF
--- a/test/bench/revs_to_benchmark.txt
+++ b/test/bench/revs_to_benchmark.txt
@@ -19,3 +19,5 @@ tags/v10.0.0-alpha.4
 tags/v10.0.0-alpha.5
 tags/v10.0.0-alpha.6
 tags/v10.0.0-alpha.8
+tags/v10.0.0-beta.3
+tags/v10.0.0-beta.4


### PR DESCRIPTION
Aims to fix the error: `parse error while processing semver of v6.0.18-316-gd49905aedinvalid literal for int() with base 10: 'gd49905aed'` as seen in the performance report logs of https://github.com/realm/realm-core/pull/3852