### PR TITLE
Add arm simulator slices to the xcframework

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ### Enhancements
 * Added an enum to `DescriptorOrdering::append_sort` which allows users to choose the merge order of how sorts are applied. The default is the historical behaviour sor this is not a breaking change. ([#3869](https://github.com/realm/realm-core/issues/3869))
+* Add arm64 simulator slices to the xcframework release package.
 
 ### Fixed
 * <How to hit and notice issue? what was the impact?> ([#????](https://github.com/realm/realm-core/issues/????), since v?.?.?)

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -100,7 +100,7 @@ jobWrapper {
             checkMacOsRelease       : doBuildMacOs('Release', true),
             checkWin32Release       : doBuildWindows('Release', false, 'Win32', true),
             checkWin32DebugUWP      : doBuildWindows('Debug', true, 'Win32', true),
-            iosDebug                : doBuildAppleDevice('ios', 'MinSizeDebug'),
+            iosDebug                : doBuildAppleDevice('iphoneos', 'MinSizeDebug'),
             androidArm64Debug       : doAndroidBuildInDocker('arm64-v8a', 'Debug', false),
             threadSanitizer         : doCheckSanity('Debug', '1000', 'thread'),
             addressSanitizer        : doCheckSanity('Debug', '1000', 'address'),
@@ -155,7 +155,9 @@ jobWrapper {
                 }
             }
 
-            appleSdks = ['ios', 'tvos', 'watchos']
+            appleSdks = ['iphoneos', 'iphonesimulator',
+                         'appletvos', 'appletvsimulator',
+                         'watchos', 'watchsimulator']
             appleBuildTypes = ['MinSizeDebug', 'Release']
 
             for (sdk in appleSdks) {
@@ -599,8 +601,7 @@ def doBuildAppleDevice(String sdk, String buildType) {
         node('osx') {
             getArchive()
 
-            withEnv(['DEVELOPER_DIR=/Applications/Xcode-11.app/Contents/Developer/',
-                     'XCODE12_DEVELOPER_DIR=/Applications/Xcode-12.app/Contents/Developer/']) {
+            withEnv(['DEVELOPER_DIR=/Applications/Xcode-11.app/Contents/Developer/']) {
                 retry(3) {
                     timeout(time: 45, unit: 'MINUTES') {
                         sh """

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -601,7 +601,13 @@ def doBuildAppleDevice(String sdk, String buildType) {
         node('osx') {
             getArchive()
 
-            withEnv(['DEVELOPER_DIR=/Applications/Xcode-11.app/Contents/Developer/']) {
+            // Builds for Apple devices have to be done with the oldest Xcode
+            // version we support because bitcode is not backwards-compatible.
+            // This doesn't apply to simulators, and Xcode 12 supports more
+            // architectures than 11, so we want to use 12 for simulator builds.
+            def xcodeVersion = sdk.contains('simulator') ? '12' : '11'
+
+            withEnv(["DEVELOPER_DIR=/Applications/Xcode-${xcodeVersion}.app/Contents/Developer/"]) {
                 retry(3) {
                     timeout(time: 45, unit: 'MINUTES') {
                         sh """

--- a/tools/build-cocoa.sh
+++ b/tools/build-cocoa.sh
@@ -83,6 +83,12 @@ function combine_libraries {
     local device_suffix="$1"
     local simulator_suffix="$2"
     local output_suffix="$3"
+
+    # Remove the arm64 slice from the simulator library if it exists as we
+    # can't have two arm64 slices in the universal library
+    lipo "core/librealm-${simulator_suffix}.a" -remove arm64 -output "core/librealm-${simulator_suffix}.a" || true
+    lipo "core/librealm-parser-${simulator_suffix}.a" -remove arm64 -output "core/librealm-parser-${simulator_suffix}.a" || true
+
     lipo "core/librealm-${device_suffix}.a" \
          "core/librealm-${simulator_suffix}.a" \
          -create -output "out/librealm-${output_suffix}.a"


### PR DESCRIPTION
The addition of the arm64 simulators for apple silicon machines invalidates the whole concept of simulator+device universal libraries, so this updates the build scripts to not rely on them. Instead of a single job which produces a combined simulator+device library, they are now separate jobs and the universal library (without the arm64 slice) is assembled during the packaging step. The xcframework package consumes these directly without lipoing anything.

Building the arm64 simulator slices just requires switching to Xcode 12. Fortunately, while libraries for devices built with Xcode 12 don't work with Xcode 11 (because bitcode is not backwards-compatible), it works fine for simulator libraries and we can just build for all simulator platforms with 12.

`xcodebuild -create-framework` currently has strange issues with arm64 simulator slices and can't determine the library's architecture if one is present. Work around this by assembling the xcframework manually, which is pretty ugly but luckily not all that complicated.