### PR TITLE
Allow calling DB::call_with_lock() when the management directory doesn't exist

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@
 
 ### Fixed
 * <How to hit and notice issue? what was the impact?> ([#????](https://github.com/realm/realm-core/issues/????), since v?.?.?)
-* None.
+* Fix an assertion failure when DB::call_with_lock() was called when the management directory did not exist on iOS (since 6.0.21).
  
 ### Breaking changes
 * None.

--- a/test/test_lang_bind_helper.cpp
+++ b/test/test_lang_bind_helper.cpp
@@ -5869,8 +5869,6 @@ TEST(LangBindHelper_callWithLock)
 
     // call_with_lock should run the callback if the lock file doesn't exist.
     CHECK_NOT(File::exists(path.get_lock_path()));
-    // make sure the management dir exists...
-    try_make_dir(std::string(path) + ".management");
     CHECK(DB::call_with_lock(path, callback));
     CHECK(File::exists(path.get_lock_path()));
 


### PR DESCRIPTION
When deleting a Realm file which doesn't actually exist we'll call DB::call_with_lock() without the management directory existing. Fortunately the directory not existing indicates that no readers exist, so this is fine when acquiring an exclusive lock.