### PR TITLE
[RSYNC-124] Dictionary / Mixed tombstone handling

### DIFF
--- a/src/realm/keys.hpp
+++ b/src/realm/keys.hpp
@@ -266,11 +266,12 @@ public:
     }
     explicit operator bool() const
     {
-        return m_table_key.operator bool();
+        return bool(m_table_key) && bool(m_obj_key);
     }
     bool is_null() const
     {
-        return !m_table_key.operator bool();
+        return !bool(*this);
+    }
     }
     bool operator==(const ObjLink& other) const
     {

--- a/src/realm/keys.hpp
+++ b/src/realm/keys.hpp
@@ -272,6 +272,9 @@ public:
     {
         return !bool(*this);
     }
+    bool is_unresolved() const
+    {
+        return m_obj_key.is_unresolved();
     }
     bool operator==(const ObjLink& other) const
     {

--- a/src/realm/mixed.hpp
+++ b/src/realm/mixed.hpp
@@ -172,6 +172,7 @@ public:
     ObjLink get_link() const;
 
     bool is_null() const;
+    bool is_unresolved_link() const;
     int compare(const Mixed& b) const;
     bool operator==(const Mixed& other) const
     {
@@ -482,6 +483,20 @@ inline ObjLink Mixed::get_link() const
 inline bool Mixed::is_null() const
 {
     return (m_type == 0);
+}
+
+inline bool Mixed::is_unresolved_link() const
+{
+    if (is_null()) {
+        return false;
+    }
+    else if (get_type() == type_TypedLink) {
+        return get<ObjLink>().is_unresolved();
+    }
+    else if (get_type() == type_Link) {
+        return get<ObjKey>().is_unresolved();
+    }
+    return false;
 }
 
 std::ostream& operator<<(std::ostream& out, const Mixed& m);

--- a/test/test_dictionary.cpp
+++ b/test/test_dictionary.cpp
@@ -321,9 +321,8 @@ TEST(Dictionary_Tombstones)
 
     a.invalidate();
 
-    // FIXME: Dictionaries currently expose tombstones.
-    // CHECK_EQUAL(dict.size(), 1);
-    // CHECK(dict.find("a") == dict.end());
+    CHECK_EQUAL(dict.size(), 2);
+    CHECK((*dict.find("a")).second.is_unresolved_link());
 
     CHECK(dict.find("b") != dict.end());
 }

--- a/test/test_dictionary.cpp
+++ b/test/test_dictionary.cpp
@@ -303,3 +303,27 @@ TEST(Dictionary_Performance)
     std::cout << "    insertion: " << duration_cast<nanoseconds>(t2 - t1).count() / nb_reps << " ns/val" << std::endl;
     std::cout << "    lookup: " << duration_cast<nanoseconds>(t3 - t2).count() / nb_reps << " ns/val" << std::endl;
 }
+
+TEST(Dictionary_Tombstones)
+{
+    Group g;
+    auto foos = g.add_table_with_primary_key("class_Foo", type_Int, "id");
+    auto bars = g.add_table_with_primary_key("class_Bar", type_String, "id");
+    ColKey col_dict = foos->add_column_dictionary(type_String, "dict", type_Mixed);
+
+    auto foo = foos->create_object_with_primary_key(123);
+    auto a = bars->create_object_with_primary_key("a");
+    auto b = bars->create_object_with_primary_key("b");
+
+    auto dict = foo.get_dictionary(col_dict);
+    dict.insert("a", a);
+    dict.insert("b", b);
+
+    a.invalidate();
+
+    // FIXME: Dictionaries currently expose tombstones.
+    // CHECK_EQUAL(dict.size(), 1);
+    // CHECK(dict.find("a") == dict.end());
+
+    CHECK(dict.find("b") != dict.end());
+}

--- a/test/test_sync.cpp
+++ b/test/test_sync.cpp
@@ -7966,4 +7966,120 @@ TEST(Sync_Dictionary)
     }
 }
 
+TEST(Sync_Dictionary_Links)
+{
+    SHARED_GROUP_TEST_PATH(path_1);
+    SHARED_GROUP_TEST_PATH(path_2);
+
+    TEST_DIR(dir);
+    fixtures::ClientServerFixture fixture{dir, test_context};
+    fixture.start();
+
+    auto history_1 = make_client_replication(path_1);
+    auto history_2 = make_client_replication(path_2);
+
+    auto db_1 = DB::create(*history_1);
+    auto db_2 = DB::create(*history_2);
+
+    Session session_1 = fixture.make_session(path_1);
+    Session session_2 = fixture.make_session(path_2);
+    fixture.bind_session(session_1, "/test");
+    fixture.bind_session(session_2, "/test");
+
+    // Test that we can transmit links.
+
+    ColKey col_dict;
+
+    {
+        WriteTransaction tr{db_1};
+        auto& g = tr.get_group();
+        auto foos = g.add_table_with_primary_key("class_Foo", type_Int, "id");
+        auto bars = g.add_table_with_primary_key("class_Bar", type_String, "id");
+        col_dict = foos->add_column_dictionary(type_String, "dict", type_Mixed);
+
+        auto foo = foos->create_object_with_primary_key(123);
+        auto a = bars->create_object_with_primary_key("a");
+        auto b = bars->create_object_with_primary_key("b");
+
+        auto dict = foo.get_dictionary(col_dict);
+        dict.insert("a", a);
+        dict.insert("b", b);
+
+        session_1.nonsync_transact_notify(tr.commit());
+    }
+
+    session_1.wait_for_upload_complete_or_client_stopped();
+    session_2.wait_for_download_complete_or_client_stopped();
+
+    {
+        ReadTransaction tr{db_2};
+
+        auto foos = tr.get_table("class_Foo");
+        auto bars = tr.get_table("class_Bar");
+
+        CHECK_EQUAL(foos->size(), 1);
+        CHECK_EQUAL(bars->size(), 2);
+
+        auto foo = foos->get_object_with_primary_key(123);
+        auto a = bars->get_object_with_primary_key("a");
+        auto b = bars->get_object_with_primary_key("b");
+
+        auto dict = foo.get_dictionary(foos->get_column_key("dict"));
+        CHECK_EQUAL(dict.size(), 2);
+
+        auto dict_a = dict.get("a");
+        auto dict_b = dict.get("b");
+        CHECK(dict_a == Mixed{a.get_link()});
+        CHECK(dict_b == Mixed{b.get_link()});
+    }
+
+    // Test that we can create tombstones for objects in dictionaries.
+
+    {
+        WriteTransaction tr{db_1};
+        auto& g = tr.get_group();
+
+        auto bars = g.get_table("class_Bar");
+        auto a = bars->get_object_with_primary_key("a");
+        a.invalidate();
+
+        auto foos = g.get_table("class_Foo");
+        auto foo = foos->get_object_with_primary_key(123);
+        auto dict = foo.get_dictionary(col_dict);
+
+        // FIXME: Dictionaries currently expose tombstones.
+        // CHECK_EQUAL(dict.size(), 1);
+        // CHECK(dict.find("a") == dict.end());
+
+        CHECK(dict.find("b") != dict.end());
+
+        session_1.nonsync_transact_notify(tr.commit());
+    }
+
+    session_1.wait_for_upload_complete_or_client_stopped();
+    session_2.wait_for_download_complete_or_client_stopped();
+
+    {
+        ReadTransaction tr{db_2};
+
+        auto foos = tr.get_table("class_Foo");
+        auto bars = tr.get_table("class_Bar");
+
+        CHECK_EQUAL(foos->size(), 1);
+        CHECK_EQUAL(bars->size(), 1);
+
+        auto b = bars->get_object_with_primary_key("b");
+
+        auto foo = foos->get_object_with_primary_key(123);
+        auto dict = foo.get_dictionary(col_dict);
+
+        // FIXME: Dictionaries currently expose tombstones.
+        // CHECK_EQUAL(dict.size(), 1);
+        // CHECK(dict.find("a") == dict.end());
+
+        CHECK(dict.find("b") != dict.end());
+        CHECK((*dict.find("b")).second == Mixed{b.get_link()});
+    }
+}
+
 } // unnamed namespace

--- a/test/test_sync.cpp
+++ b/test/test_sync.cpp
@@ -8047,9 +8047,8 @@ TEST(Sync_Dictionary_Links)
         auto foo = foos->get_object_with_primary_key(123);
         auto dict = foo.get_dictionary(col_dict);
 
-        // FIXME: Dictionaries currently expose tombstones.
-        // CHECK_EQUAL(dict.size(), 1);
-        // CHECK(dict.find("a") == dict.end());
+        CHECK_EQUAL(dict.size(), 2);
+        CHECK((*dict.find("a")).second.is_unresolved_link());
 
         CHECK(dict.find("b") != dict.end());
 
@@ -8073,9 +8072,8 @@ TEST(Sync_Dictionary_Links)
         auto foo = foos->get_object_with_primary_key(123);
         auto dict = foo.get_dictionary(col_dict);
 
-        // FIXME: Dictionaries currently expose tombstones.
-        // CHECK_EQUAL(dict.size(), 1);
-        // CHECK(dict.find("a") == dict.end());
+        CHECK_EQUAL(dict.size(), 2);
+        CHECK((*dict.find("a")).second.is_unresolved_link());
 
         CHECK(dict.find("b") != dict.end());
         CHECK((*dict.find("b")).second == Mixed{b.get_link()});


### PR DESCRIPTION
This PR fixes some holes in tombstone handling for Dictionaries and Mixed.

Also added some commented-out unit tests in preparation for solving the problem that Dictionaries (as well as lists of Mixed and TypedLink) expose tombstones.