### PR TITLE
Make column type indicate value type of dictionary

### DIFF
--- a/src/realm/cluster.cpp
+++ b/src/realm/cluster.cpp
@@ -1068,7 +1068,8 @@ void Cluster::verify() const
             }
             for (size_t n = 0; n < sz; n++) {
                 if (arr.get(n)) {
-                    DictionaryClusterTree cluster(&arr, col_type, get_alloc(), n);
+                    auto key_type = get_owning_table()->get_dictionary_key_type(col_key);
+                    DictionaryClusterTree cluster(&arr, key_type, get_alloc(), n);
                     cluster.init_from_parent();
                     cluster.verify();
                 }

--- a/src/realm/dictionary.hpp
+++ b/src/realm/dictionary.hpp
@@ -38,6 +38,7 @@ public:
     Dictionary(const Obj& obj, ColKey col_key);
     Dictionary(const Dictionary& other)
         : CollectionBase(other)
+        , m_key_type(other.m_key_type)
     {
         *this = other;
     }
@@ -46,6 +47,7 @@ public:
 
     // Overriding members of CollectionBase:
     size_t size() const final;
+    DataType get_key_data_type() const;
     DataType get_value_data_type() const;
     bool is_null(size_t ndx) const final;
     Mixed get_any(size_t ndx) const final;
@@ -85,6 +87,7 @@ public:
 
 private:
     mutable DictionaryClusterTree* m_clusters = nullptr;
+    DataType m_key_type = type_String;
 
     bool init_from_parent() const final;
     Mixed do_get(ClusterNode::State&&) const;
@@ -104,7 +107,7 @@ private:
     friend class Dictionary;
     using ClusterTree::Iterator::get_position;
 
-    ColumnType m_key_type;
+    DataType m_key_type;
 
     Iterator(const Dictionary* dict, size_t pos);
 };

--- a/src/realm/dictionary_cluster_tree.hpp
+++ b/src/realm/dictionary_cluster_tree.hpp
@@ -27,7 +27,7 @@ class DictionaryClusterTree : public ClusterTree {
 public:
     static constexpr ColKey s_values_col = ColKey(ColKey::Idx{1}, col_type_Mixed, ColumnAttrMask(), 0);
 
-    DictionaryClusterTree(ArrayParent* owner, ColumnType, Allocator& alloc, size_t ndx);
+    DictionaryClusterTree(ArrayParent* owner, DataType, Allocator& alloc, size_t ndx);
     ~DictionaryClusterTree() override;
 
     void destroy()

--- a/src/realm/spec.cpp
+++ b/src/realm/spec.cpp
@@ -438,15 +438,6 @@ ColKey Spec::find_backlink_column(TableKey origin_table_key, size_t spec_ndx) co
     return ColKey{m_keys.get(col_ndx)};
 }
 
-DataType Spec::get_public_column_type(size_t ndx) const noexcept
-{
-    REALM_ASSERT(ndx < get_column_count());
-
-    ColumnType type = get_column_type(ndx);
-
-    return DataType(type);
-}
-
 namespace {
 
 template <class T>

--- a/src/realm/spec.hpp
+++ b/src/realm/spec.hpp
@@ -54,7 +54,6 @@ public:
     // Column info
     size_t get_column_count() const noexcept;
     size_t get_public_column_count() const noexcept;
-    DataType get_public_column_type(size_t column_ndx) const noexcept;
     ColumnType get_column_type(size_t column_ndx) const noexcept;
     StringData get_column_name(size_t column_ndx) const noexcept;
 
@@ -63,8 +62,8 @@ public:
 
     // Column Attributes
     ColumnAttrMask get_column_attr(size_t column_ndx) const noexcept;
-    void set_value_type(size_t column_ndx, DataType value_type);
-    DataType get_value_type(size_t column_ndx) const;
+    void set_dictionary_key_type(size_t column_ndx, DataType key_type);
+    DataType get_dictionary_key_type(size_t column_ndx) const;
 
     // Auto Enumerated string columns
     void upgrade_string_to_enum(size_t column_ndx, ref_type keys_ref);
@@ -237,13 +236,13 @@ inline ColumnAttrMask Spec::get_column_attr(size_t ndx) const noexcept
     return ColumnAttrMask(m_attr.get(ndx) & 0xFF);
 }
 
-inline void Spec::set_value_type(size_t ndx, DataType value_type)
+inline void Spec::set_dictionary_key_type(size_t ndx, DataType key_type)
 {
     ColumnAttrMask attr = get_column_attr(ndx);
-    m_attr.set(ndx, attr.m_value | (int64_t(value_type) << 8));
+    m_attr.set(ndx, attr.m_value | (int64_t(key_type) << 8));
 }
 
-inline DataType Spec::get_value_type(size_t ndx) const
+inline DataType Spec::get_dictionary_key_type(size_t ndx) const
 {
     REALM_ASSERT(ndx < get_column_count());
     return DataType(m_attr.get(ndx) >> 8);

--- a/src/realm/sync/changeset.cpp
+++ b/src/realm/sync/changeset.cpp
@@ -389,7 +389,7 @@ void Changeset::Reflector::operator()(const Instruction::AddColumn& p) const
         m_tracer.field("target_table", p.link_target_table);
     }
     if (p.collection_type == Instruction::AddColumn::CollectionType::Dictionary) {
-        m_tracer.field("value_type", p.value_type);
+        m_tracer.field("key_type", p.key_type);
     }
 }
 

--- a/src/realm/sync/changeset_encoder.cpp
+++ b/src/realm/sync/changeset_encoder.cpp
@@ -166,16 +166,16 @@ void ChangesetEncoder::operator()(const Instruction::AddInteger& instr)
 
 void ChangesetEncoder::operator()(const Instruction::AddColumn& instr)
 {
+    bool is_dictionary = (instr.collection_type == Instruction::AddColumn::CollectionType::Dictionary);
     // Mixed columns are always nullable.
-    REALM_ASSERT(instr.type != Instruction::Payload::Type::Null || instr.nullable);
-
+    REALM_ASSERT(instr.type != Instruction::Payload::Type::Null || instr.nullable || is_dictionary);
     append(Instruction::Type::AddColumn, instr.table, instr.field, instr.type, instr.nullable, instr.collection_type);
 
     if (instr.type == Instruction::Payload::Type::Link) {
         append_value(instr.link_target_table);
     }
-    if (instr.collection_type == Instruction::AddColumn::CollectionType::Dictionary) {
-        append_value(instr.value_type);
+    if (is_dictionary) {
+        append_value(instr.key_type);
     }
 }
 

--- a/src/realm/sync/changeset_parser.cpp
+++ b/src/realm/sync/changeset_parser.cpp
@@ -364,10 +364,10 @@ void ChangesetParser::State::parse_one()
                 instr.link_target_table = read_intern_string();
             }
             if (instr.collection_type == Instruction::AddColumn::CollectionType::Dictionary) {
-                instr.value_type = read_payload_type();
+                instr.key_type = read_payload_type();
             }
             else {
-                instr.value_type = Instruction::Payload::Type::Null;
+                instr.key_type = Instruction::Payload::Type::Null;
             }
             m_handler(instr);
             return;

--- a/src/realm/sync/instruction_applier.cpp
+++ b/src/realm/sync/instruction_applier.cpp
@@ -412,7 +412,7 @@ void InstructionApplier::operator()(const Instruction::AddColumn& instr)
         bad_transaction_log("AddColumn '%1.%3' which already exists", table->get_name(), col_name);
     }
 
-    if (instr.collection_type == CollectionType::Dictionary && instr.type != Type::String) {
+    if (instr.collection_type == CollectionType::Dictionary && instr.key_type != Type::String) {
         bad_transaction_log("AddColumn '%1.%3' adding dictionary column with non-string keys", table->get_name(),
                             col_name);
     }
@@ -421,20 +421,8 @@ void InstructionApplier::operator()(const Instruction::AddColumn& instr)
         bad_transaction_log("AddColumn '%1.%3' adding dictinoary with nullable keys", table->get_name(), col_name);
     }
 
-    if (instr.type == Type::Null) {
-        if (instr.collection_type == CollectionType::Single) {
-            table->add_column(type_Mixed, col_name);
-        }
-        else {
-            REALM_ASSERT(instr.collection_type == CollectionType::List);
-            table->add_column_list(type_Mixed, col_name);
-        }
-        return;
-    }
-
-
     if (instr.type != Type::Link) {
-        DataType type = get_data_type(instr.type);
+        DataType type = (instr.type == Type::Null) ? type_Mixed : get_data_type(instr.type);
         switch (instr.collection_type) {
             case CollectionType::Single: {
                 table->add_column(type, col_name, instr.nullable);
@@ -445,8 +433,8 @@ void InstructionApplier::operator()(const Instruction::AddColumn& instr)
                 break;
             }
             case CollectionType::Dictionary: {
-                DataType value_type = (instr.value_type == Type::Null) ? type_Mixed : get_data_type(instr.value_type);
-                table->add_column_dictionary(type, col_name, value_type);
+                DataType key_type = (instr.key_type == Type::Null) ? type_Mixed : get_data_type(instr.key_type);
+                table->add_column_dictionary(type, col_name, key_type);
                 break;
             }
             case CollectionType::Set: {

--- a/src/realm/sync/instruction_replication.cpp
+++ b/src/realm/sync/instruction_replication.cpp
@@ -348,19 +348,20 @@ void SyncReplication::insert_column(const Table* table, ColKey col_key, DataType
             instr.collection_type = CollectionType::List;
         }
         else if (col_key.is_dictionary()) {
-            REALM_ASSERT(type == type_String);
             instr.collection_type = CollectionType::Dictionary;
-            auto value_type = table->get_dictionary_value_type(col_key);
-            instr.value_type = get_payload_type(value_type);
+            auto key_type = table->get_dictionary_key_type(col_key);
+            REALM_ASSERT(key_type == type_String);
+            instr.key_type = get_payload_type(key_type);
         }
         else {
             REALM_ASSERT(!col_key.is_collection());
             instr.collection_type = CollectionType::Single;
-            instr.value_type = Instruction::Payload::Type::Null;
+            instr.key_type = Instruction::Payload::Type::Null;
         }
 
         // Mixed columns are always nullable.
-        REALM_ASSERT(instr.type != Instruction::Payload::Type::Null || instr.nullable);
+        REALM_ASSERT(instr.type != Instruction::Payload::Type::Null || instr.nullable ||
+                     instr.collection_type == CollectionType::Dictionary);
 
         if (instr.type == Instruction::Payload::Type::Link && target_table) {
             instr.link_target_table = emit_class_name(*target_table);

--- a/src/realm/sync/instructions.hpp
+++ b/src/realm/sync/instructions.hpp
@@ -469,7 +469,7 @@ struct AddColumn : TableInstruction {
     // `none` for Mixed columns. Mixed columns are always nullable.
     Payload::Type type;
     // `none` for other than dictionary columns
-    Payload::Type value_type;
+    Payload::Type key_type;
 
     bool nullable;
 
@@ -483,7 +483,7 @@ struct AddColumn : TableInstruction {
     bool operator==(const AddColumn& rhs) const noexcept
     {
         return TableInstruction::operator==(rhs) && field == rhs.field && type == rhs.type &&
-               value_type == rhs.value_type && nullable == rhs.nullable && collection_type == rhs.collection_type &&
+               key_type == rhs.key_type && nullable == rhs.nullable && collection_type == rhs.collection_type &&
                link_target_table == rhs.link_target_table;
     }
 };

--- a/src/realm/table.cpp
+++ b/src/realm/table.cpp
@@ -386,13 +386,13 @@ ColKey Table::add_column_link(DataType type, StringData name, Table& target)
     }
 }
 
-ColKey Table::add_column_dictionary(DataType type, StringData name, DataType value_type)
+ColKey Table::add_column_dictionary(DataType type, StringData name, DataType key_type)
 {
     Table* invalid_link = nullptr;
     ColumnAttrMask attr;
     attr.set(col_attr_Dictionary);
     ColKey col_key = generate_col_key(ColumnType(type), attr);
-    return do_insert_column(col_key, type, name, invalid_link, value_type); // Throws
+    return do_insert_column(col_key, type, name, invalid_link, key_type); // Throws
 }
 
 void Table::remove_recursive(CascadeState& cascade_state)
@@ -565,10 +565,9 @@ void Table::init(ref_type top_ref, ArrayParent* parent, size_t ndx_in_parent, bo
 }
 
 
-ColKey Table::do_insert_column(ColKey col_key, DataType type, StringData name, Table* target_table,
-                               DataType value_type)
+ColKey Table::do_insert_column(ColKey col_key, DataType type, StringData name, Table* target_table, DataType key_type)
 {
-    col_key = do_insert_root_column(col_key, ColumnType(type), name, value_type); // Throws
+    col_key = do_insert_root_column(col_key, ColumnType(type), name, key_type); // Throws
 
     // When the inserted column is a link-type column, we must also add a
     // backlink column to the target table.
@@ -838,7 +837,7 @@ void Table::erase_root_column(ColKey col_key)
 }
 
 
-ColKey Table::do_insert_root_column(ColKey col_key, ColumnType type, StringData name, DataType value_type)
+ColKey Table::do_insert_root_column(ColKey col_key, ColumnType type, StringData name, DataType key_type)
 {
     // if col_key specifies a key, it must be unused
     REALM_ASSERT(!col_key || !valid_column(col_key));
@@ -852,7 +851,7 @@ ColKey Table::do_insert_root_column(ColKey col_key, ColumnType type, StringData 
 
     m_spec.insert_column(spec_ndx, col_key, type, name, col_key.get_attrs().m_value); // Throws
     if (col_key.is_dictionary()) {
-        m_spec.set_value_type(spec_ndx, value_type);
+        m_spec.set_dictionary_key_type(spec_ndx, key_type);
     }
     auto col_ndx = col_key.get_index().val;
     build_column_mapping();

--- a/src/realm/table.hpp
+++ b/src/realm/table.hpp
@@ -110,7 +110,7 @@ public:
     DataType get_column_type(ColKey column_key) const;
     StringData get_column_name(ColKey column_key) const;
     ColumnAttrMask get_column_attr(ColKey column_key) const noexcept;
-    DataType get_dictionary_value_type(ColKey column_key) const noexcept;
+    DataType get_dictionary_key_type(ColKey column_key) const noexcept;
     ColKey get_column_key(StringData name) const noexcept;
     ColKeys get_column_keys() const;
     typedef util::Optional<std::pair<ConstTableRef, ColKey>> BacklinkOrigin;
@@ -132,7 +132,7 @@ public:
     ColKey add_column(Table& target, StringData name);
     ColKey add_column_list(DataType type, StringData name, bool nullable = false);
     ColKey add_column_list(Table& target, StringData name);
-    ColKey add_column_dictionary(DataType type, StringData name, DataType value_type);
+    ColKey add_column_dictionary(DataType type, StringData name, DataType key_type = type_String);
 
     [[deprecated("Use add_column(Table&) or add_column_list(Table&) instead.")]] //
     ColKey
@@ -664,14 +664,14 @@ private:
     void set_key(TableKey key);
 
     ColKey do_insert_column(ColKey col_key, DataType type, StringData name, Table* target_table,
-                            DataType value_type = DataType(0));
+                            DataType key_type = DataType(0));
 
     struct InsertSubtableColumns;
     struct EraseSubtableColumns;
     struct RenameSubtableColumns;
 
     void erase_root_column(ColKey col_key);
-    ColKey do_insert_root_column(ColKey col_key, ColumnType, StringData name, DataType value_type = DataType(0));
+    ColKey do_insert_root_column(ColKey col_key, ColumnType, StringData name, DataType key_type = DataType(0));
     void do_erase_root_column(ColKey col_key);
 
     bool has_any_embedded_objects();
@@ -1070,11 +1070,11 @@ inline ColumnAttrMask Table::get_column_attr(ColKey column_key) const noexcept
     return column_key.get_attrs();
 }
 
-inline DataType Table::get_dictionary_value_type(ColKey column_key) const noexcept
+inline DataType Table::get_dictionary_key_type(ColKey column_key) const noexcept
 {
     auto spec_ndx = colkey2spec_ndx(column_key);
     REALM_ASSERT_3(spec_ndx, <, get_column_count());
-    return m_spec.get_value_type(spec_ndx);
+    return m_spec.get_dictionary_key_type(spec_ndx);
 }
 
 

--- a/test/test_changeset_encoding.cpp
+++ b/test/test_changeset_encoding.cpp
@@ -61,7 +61,7 @@ TEST(ChangesetEncoding_AddColumn)
     instr.collection_type = AddColumn::CollectionType::List;
     instr.nullable = false;
     instr.link_target_table = changeset.intern_string("Bar");
-    instr.value_type = Payload::Type::Null;
+    instr.key_type = Payload::Type::Null;
     changeset.push_back(instr);
 
     auto parsed = encode_then_parse(changeset);

--- a/test/test_dictionary.cpp
+++ b/test/test_dictionary.cpp
@@ -80,7 +80,7 @@ TEST(Dictionary_Basics)
     };
 
     auto foo = g.add_table("foo");
-    auto col_dict = foo->add_column_dictionary(type_String, "dictionaries", type_Mixed);
+    auto col_dict = foo->add_column_dictionary(type_Mixed, "dictionaries");
 
     Obj obj1 = foo->create_object();
     Obj obj2 = foo->create_object();
@@ -134,7 +134,7 @@ TEST(Dictionary_Links)
 
     auto dogs = g.add_table_with_primary_key("dog", type_String, "name");
     auto persons = g.add_table_with_primary_key("person", type_String, "name");
-    auto col_dict = persons->add_column_dictionary(type_String, "dictionaries", type_TypedLink);
+    auto col_dict = persons->add_column_dictionary(type_TypedLink, "dictionaries");
 
     Obj adam = persons->create_object_with_primary_key("adam");
     Obj pluto = dogs->create_object_with_primary_key("pluto");
@@ -181,7 +181,7 @@ TEST(Dictionary_Transaction)
     {
         WriteTransaction wt(db);
         auto foo = wt.add_table("foo");
-        col_dict = foo->add_column_dictionary(type_String, "dictionaries", type_Mixed);
+        col_dict = foo->add_column_dictionary(type_Mixed, "dictionaries");
 
         Obj obj1 = foo->create_object();
         Obj obj2 = foo->create_object();

--- a/test/test_sync.cpp
+++ b/test/test_sync.cpp
@@ -7886,7 +7886,7 @@ TEST(Sync_Dictionary)
         WriteTransaction tr{db_1};
         auto& g = tr.get_group();
         auto foos = g.add_table_with_primary_key("class_Foo", type_Int, "id");
-        auto col_dict = foos->add_column_dictionary(type_String, "dict", type_Mixed);
+        auto col_dict = foos->add_column_dictionary(type_Mixed, "dict");
 
         auto foo = foos->create_object_with_primary_key(123);
 

--- a/test/test_transform.cpp
+++ b/test/test_transform.cpp
@@ -1888,7 +1888,7 @@ TEST(Transform_Dictionary)
         client_1->transaction([&](Peer& c) {
             auto& tr = *c.group;
             auto table = tr.add_table_with_primary_key("class_Table", type_Int, "id");
-            table->add_column_dictionary(type_String, "dict", type_String);
+            table->add_column_dictionary(type_Mixed, "dict");
             table->create_object_with_primary_key(0);
             table->create_object_with_primary_key(1);
         });


### PR DESCRIPTION
It was a mistake to make the type encoded in the column key indicate the key type - it should reflect the value type.