### PR TITLE
Fix deadlocks on exFAT

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@
 
 ### Fixed
 * <How to hit and notice issue? what was the impact?> ([#????](https://github.com/realm/realm-core/issues/????), since v?.?.?)
-* None.
+* Fix deadlocks when writing to a Realm file on an exFAT partition from macOS. ([Cocoa #6691](https://github.com/realm/realm-cocoa/issues/6691)).
  
 ### Breaking changes
 * None.

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -42,7 +42,6 @@ jobWrapper {
             if (isPullRequest) {
                 targetSHA1 = sh(returnStdout: true, script: "git merge-base origin/${targetBranch} HEAD").trim()
             }
- 
         }
 
         currentBranch = env.BRANCH_NAME

--- a/src/realm/util/interprocess_mutex.hpp
+++ b/src/realm/util/interprocess_mutex.hpp
@@ -219,6 +219,8 @@ inline void InterprocessMutex::set_shared_part(SharedPart& shared_part, const st
     // Always use mod_Write to open file and retreive the uid in case other process
     // deletes the file.
     m_lock_info->m_file.open(m_filename, File::mode_Write);
+    // exFAT does not allocate a unique id for the file until it's non-empty
+    m_lock_info->m_file.resize(1);
     m_fileuid = m_lock_info->m_file.get_unique_id();
 
     (*s_info_map)[m_fileuid] = m_lock_info;

--- a/test/main.cpp
+++ b/test/main.cpp
@@ -17,6 +17,7 @@
  **************************************************************************/
 
 #include "test_all.hpp"
+#include "util/test_path.hpp"
 #ifdef _WIN32
 #include <Windows.h>
 
@@ -48,6 +49,9 @@ int main(int argc, char* argv[])
     if (chdir(directory) < 0) {
         fprintf(stderr, "Failed to change directory.\n");
         return 1;
+    }
+    if (argc > 1) {
+        realm::test_util::set_test_path_prefix(argv[1]);
     }
 #endif
 

--- a/test/test_file.cpp
+++ b/test/test_file.cpp
@@ -82,16 +82,20 @@ TEST(File_IsSame)
 {
     TEST_PATH(path_1);
     TEST_PATH(path_2);
-    {
-        File f1(path_1, File::mode_Write);
-        File f2(path_1, File::mode_Read);
-        File f3(path_2, File::mode_Write);
 
-        CHECK(f1.is_same_file(f1));
-        CHECK(f1.is_same_file(f2));
-        CHECK(!f1.is_same_file(f3));
-        CHECK(!f2.is_same_file(f3));
-    }
+    // exFAT does not allocate inode numbers until the file is first non-empty,
+    // so all never-written-to files appear to be the same file
+    File(path_1, File::mode_Write).resize(1);
+    File(path_2, File::mode_Write).resize(1);
+
+    File f1(path_1, File::mode_Append);
+    File f2(path_1, File::mode_Read);
+    File f3(path_2, File::mode_Append);
+
+    CHECK(f1.is_same_file(f1));
+    CHECK(f1.is_same_file(f2));
+    CHECK(!f1.is_same_file(f3));
+    CHECK(!f2.is_same_file(f3));
 }
 
 
@@ -504,6 +508,10 @@ TEST(File_GetUniqueID)
     file1_1.open(path_1, File::mode_Write);
     file1_2.open(path_1, File::mode_Read);
     file2_1.open(path_2, File::mode_Write);
+
+    // exFAT does not allocate inode numbers until the file is first non-empty
+    file1_1.resize(1);
+    file2_1.resize(1);
 
     File::UniqueID uid1_1 = file1_1.get_unique_id();
     File::UniqueID uid1_2 = file1_2.get_unique_id();

--- a/test/test_group.cpp
+++ b/test/test_group.cpp
@@ -245,6 +245,9 @@ TEST(Group_Permissions)
         std::cout << "Group_Permissions test skipped because you are running it as root\n\n";
         return;
     }
+    if (test_util::test_dir_is_exfat()) {
+        return;
+    }
 
     GROUP_TEST_PATH(path);
     {

--- a/test/test_util_file.cpp
+++ b/test/test_util_file.cpp
@@ -194,6 +194,9 @@ TEST(Utils_File_resolve)
 #ifndef _WIN32 // An open file cannot be deleted on Windows
 TEST(Utils_File_remove_open)
 {
+    if (test_util::test_dir_is_exfat())
+        return;
+
     std::string file_name = File::resolve("FooBar", test_util::get_test_path_prefix());
     File f(file_name, File::mode_Write);
 

--- a/test/util/test_path.cpp
+++ b/test/util/test_path.cpp
@@ -24,7 +24,7 @@
 
 #include "test_path.hpp"
 
-#ifdef REALM_PLATFORM_APPLE
+#if REALM_PLATFORM_APPLE
 #include <sys/mount.h>
 #include <sys/param.h>
 #endif
@@ -89,7 +89,7 @@ std::string get_test_path_prefix()
 
 bool test_dir_is_exfat()
 {
-#ifdef REALM_PLATFORM_APPLE
+#if REALM_PLATFORM_APPLE
     if (test_util::get_test_path_prefix().empty())
         return false;
 

--- a/test/util/test_path.cpp
+++ b/test/util/test_path.cpp
@@ -90,6 +90,9 @@ std::string get_test_path_prefix()
 bool test_dir_is_exfat()
 {
 #ifdef REALM_PLATFORM_APPLE
+    if (test_util::get_test_path_prefix().empty())
+        return false;
+
     struct statfs fsbuf;
     int ret = statfs(test_util::get_test_path_prefix().c_str(), &fsbuf);
     REALM_ASSERT_RELEASE(ret == 0);

--- a/test/util/test_path.cpp
+++ b/test/util/test_path.cpp
@@ -24,6 +24,11 @@
 
 #include "test_path.hpp"
 
+#ifdef REALM_PLATFORM_APPLE
+#include <sys/mount.h>
+#include <sys/param.h>
+#endif
+
 using namespace realm::util;
 
 namespace {
@@ -80,6 +85,20 @@ void set_test_path_prefix(const std::string& prefix)
 std::string get_test_path_prefix()
 {
     return path_prefix;
+}
+
+bool test_dir_is_exfat()
+{
+#ifdef REALM_PLATFORM_APPLE
+    struct statfs fsbuf;
+    int ret = statfs(test_util::get_test_path_prefix().c_str(), &fsbuf);
+    REALM_ASSERT_RELEASE(ret == 0);
+    // The documentation and headers helpfully don't list any of the values of
+    // f_type or provide constants for them
+    return fsbuf.f_type == 28 /* exFAT */;
+#else
+    return false;
+#endif
 }
 
 std::string get_test_resource_path()

--- a/test/util/test_path.hpp
+++ b/test/util/test_path.hpp
@@ -67,6 +67,11 @@ std::string get_test_path(const std::string& path, const std::string& suffix);
 /// prior to any execution of the TEST_PATH or TEST_DIR family of macros.
 void set_test_path_prefix(const std::string&);
 
+/// Check if get_test_path_prefix() will give a path located on an exFAT
+/// filesystem, which does not support all of the features a typical unix
+/// filesystem does.
+bool test_dir_is_exfat();
+
 
 /// This function is thread-safe as long as there are no concurrent invocations
 /// of set_test_resource_path().

--- a/tools/run-tests-on-exfat.sh
+++ b/tools/run-tests-on-exfat.sh
@@ -1,0 +1,28 @@
+#!/usr/bin/env bash
+
+set -e
+
+readonly build_dir="$PWD"
+readonly dmg_file="$build_dir/exfat.dmg"
+
+if ! [ -f "$build_dir/test/realm-tests" ]; then
+    echo 'Run this script from the build directory after building tests'
+    exit 1
+fi
+
+function cleanup() {
+    rm -f "$dmg_file"
+    if [ -n "$device" ]; then
+        hdiutil detach "$device"
+    fi
+}
+trap cleanup EXIT
+
+rm -f "$dmg_file"
+hdiutil create -fs exFAT -size 100MB "$dmg_file"
+hdiutil_out=$(hdiutil attach exfat.dmg)
+device=$(echo "$hdiutil_out" | head -n1 | cut -f1 | awk '{$1=$1};1')
+path=$(echo "$hdiutil_out" | tail -n1 | cut -f3)
+
+./test/realm-tests "$path/"
+


### PR DESCRIPTION
exFAT doesn't actually allocate an inode for a file until it's non-empty, which results in our checks based on that to fail. The most immediate implication of this was that all interprocess mutexes ended up sharing a single local mutex and deadlocking if more than one is ever locked at once.

exFAT also doesn't support some file permissions-related things so a few tests need to be skipped when running on it, but none of them appear to be functionality we depend on.

Fixes https://github.com/realm/realm-cocoa/issues/6691.