### PR TITLE
Actually include the macos libraries in the package

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 ### Fixed
 * <How to hit and notice issue? what was the impact?> ([#????](https://github.com/realm/realm-core/issues/????), since v?.?.?)
 * Fix an assertion failure when DB::call_with_lock() was called when the management directory did not exist on iOS (since 6.0.21).
+* The non-xcframework Apple release package did not include macOS libraries (since 6.0.22).
  
 ### Breaking changes
 * None.

--- a/tools/build-cocoa.sh
+++ b/tools/build-cocoa.sh
@@ -109,11 +109,16 @@ for bt in "${BUILD_TYPES[@]}"; do
     done
 
     mkdir -p out
-    combine_libraries "iphoneos${suffix}" "iphonesimulator${suffix}" "ios${suffix}"
-    combine_libraries "watchos${suffix}" "watchsimulator${suffix}" "watchos${suffix}"
-    combine_libraries "appletvos${suffix}" "appletvsimulator${suffix}" "tvos${suffix}"
+    mv core/librealm-parser* out
+    mv core/librealm-macosx* out
+    if [[ -z $MACOS_ONLY ]]; then
+        mv core/librealm-maccatalyst* out
+        combine_libraries "iphoneos${suffix}" "iphonesimulator${suffix}" "ios${suffix}"
+        combine_libraries "watchos${suffix}" "watchsimulator${suffix}" "watchos${suffix}"
+        combine_libraries "appletvos${suffix}" "appletvsimulator${suffix}" "tvos${suffix}"
+    fi
 done
-rm core/*.a
+rm -f core/*.a
 mv out/*.a core
 rmdir out
 


### PR DESCRIPTION
#3859 accidentally made it so that the package used by realm-js and cocoapods did not include a macos library.