### PR TITLE
RCORE-335 Support replacing SortDescriptors in DescriptorOrdering

### DIFF
--- a/src/realm/sort_descriptor.hpp
+++ b/src/realm/sort_descriptor.hpp
@@ -205,7 +205,9 @@ public:
         /// If another sort has just been applied, merge after it to take secondary precedence
         /// this is used to construct sorts in a builder pattern where the first applied sort remains the most
         /// important
-        prepend
+        prepend,
+        /// Replace this sort descriptor with another
+        replace
     };
 
     void merge(SortDescriptor&& other, MergeMode mode);

--- a/test/test_query.cpp
+++ b/test/test_query.cpp
@@ -3812,6 +3812,22 @@ TEST(Query_FindWithDescriptorOrdering)
         }
     }
     {
+        // applying sort, then a limit, and then sort with replace - the end result should reflect the limit
+        // and then the second sort descriptor only
+        DescriptorOrdering ordering;
+        ordering.append_sort(SortDescriptor({{t1_str_col}}, {true}));
+        ordering.append_limit(LimitDescriptor(5));
+        ordering.append_sort(SortDescriptor({{t1_int_col}}, {true}), SortDescriptor::MergeMode::replace);
+        TableView tv = t1->where().find_all(ordering);
+        ResultList expected = {{1, k0}, {1, k1}, {1, k2}, {2, k3}, {2, k4}};
+        CHECK_EQUAL(tv.size(), expected.size());
+        CHECK_EQUAL(t1->where().count(ordering), expected.size());
+        for (size_t i = 0; i < tv.size(); ++i) {
+            CHECK_EQUAL(tv[i].get<Int>(t1_int_col), expected[i].first);
+            CHECK_EQUAL(tv.get_key(i), expected[i].second);
+        }
+    }
+    {
         // applying sort and limit
         DescriptorOrdering ordering;
         ordering.append_sort(SortDescriptor({{t1_str_col}}, {false}));


### PR DESCRIPTION
This adds a replace mode to SortDescriptor::MergeMode so callers can clear out all the sort descriptors and replace them with a new one.