### PR TITLE
Fix a deadlock when unsuspending apps on iOS 10-12

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@
 
 ### Fixed
 * <How to hit and notice issue? what was the impact?> ([#????](https://github.com/realm/realm-core/issues/????), since v?.?.?)
-* None.
+* Fix deadlocks when opening a Realm file in both the iOS simulator and Realm Studio (since 6.0.21).
  
 ### Breaking changes
 * None.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,8 @@
 
 ### Fixed
 * <How to hit and notice issue? what was the impact?> ([#????](https://github.com/realm/realm-core/issues/????), since v?.?.?)
-* Fix deadlocks when opening a Realm file in both the iOS simulator and Realm Studio (since 6.0.21).
+* Fix deadlocks when opening a Realm file in both the iOS simulator and Realm Studio ([Cocoa #6743](https://github.com/realm/realm-cocoa/issues/6743), since 6.0.21).
+* Fix Springboard deadlocking when an app is unsuspended while it has an open Realm file which is stored in an app group ([Cocoa #6749](https://github.com/realm/realm-cocoa/issues/6749), since 6.0.21).
  
 ### Breaking changes
 * None.

--- a/src/realm/util/features.h
+++ b/src/realm/util/features.h
@@ -240,8 +240,10 @@
 #if TARGET_OS_IPHONE == 1
 /* Device (iPhone or iPad) or simulator. */
 #define REALM_IOS 1
+#define REALM_IOS_DEVICE !TARGET_OS_SIMULATOR
 #else
 #define REALM_IOS 0
+#define REALM_IOS_DEVICE 0
 #endif
 #if TARGET_OS_WATCH == 1
 /* Device (Apple Watch) or simulator. */
@@ -258,6 +260,7 @@
 #else
 #define REALM_PLATFORM_APPLE 0
 #define REALM_IOS 0
+#define REALM_IOS_DEVICE 0
 #define REALM_WATCHOS 0
 #define REALM_TVOS 0
 #endif

--- a/src/realm/util/file.cpp
+++ b/src/realm/util/file.cpp
@@ -957,7 +957,7 @@ void File::sync()
 
 #ifndef _WIN32
 // little helper
-void _unlock(int m_fd)
+static void _unlock(int m_fd)
 {
     int r;
     do {
@@ -1000,8 +1000,9 @@ bool File::lock(bool exclusive, bool non_blocking)
 #else
 #ifdef REALM_FILELOCK_EMULATION
     // If we already have any form of lock, release it before trying to acquire a new
-    if (m_has_exclusive_lock || m_has_shared_lock)
+    if (m_has_exclusive_lock || has_shared_lock())
         unlock();
+
     // First obtain an exclusive lock on the file proper
     int operation = LOCK_EX;
     if (non_blocking)
@@ -1014,6 +1015,8 @@ bool File::lock(bool exclusive, bool non_blocking)
         return false;
     if (status != 0)
         throw std::system_error(errno, std::system_category(), "flock() failed");
+    m_has_exclusive_lock = true;
+
     // now use a named pipe to emulate locking in conjunction with using exclusive lock
     // on the file proper.
     // exclusively locked: we can't sucessfully write to the pipe.
@@ -1032,7 +1035,6 @@ bool File::lock(bool exclusive, bool non_blocking)
         if (exclusive && err == ENOENT) {
             // The management directory doesn't exist, so there's clearly no
             // readers. This can happen when calling DB::call_with_lock().
-            m_has_exclusive_lock = true;
             return true;
         }
         REALM_ASSERT_EX(err == EEXIST, err);
@@ -1048,13 +1050,12 @@ bool File::lock(bool exclusive, bool non_blocking)
             throw std::system_error(errno, std::system_category(), "opening lock fifo for writing failed");
         if (fd == -1) {
             // No reader was present so we have the exclusive lock!
-            m_has_exclusive_lock = true;
             return true;
         }
         else {
             ::close(fd);
             // shared locks exist. Back out. Release exclusive lock on file
-            _unlock(m_fd);
+            unlock();
             return false;
         }
     }
@@ -1062,12 +1063,13 @@ bool File::lock(bool exclusive, bool non_blocking)
         // lock shared. We need to release the real exclusive lock on the file,
         // but first we must mark the lock as shared by opening the pipe for reading
         // Open pipe for reading!
-        int fd = ::open(m_fifo_path.c_str(), O_RDONLY | O_NONBLOCK);
+        // Due to a bug in iOS 10-12 we need to open in read-write mode or the OS
+        // will deadlock when un-suspending the app.
+        int fd = ::open(m_fifo_path.c_str(), O_RDWR | O_NONBLOCK);
         if (fd == -1)
             throw std::system_error(errno, std::system_category(), "opening lock fifo for reading failed");
+        unlock();
         m_pipe_fd = fd;
-        m_has_shared_lock = true;
-        _unlock(m_fd);
         return true;
     }
 
@@ -1132,7 +1134,7 @@ void File::unlock() noexcept
     // Coming here with a shared lock, we must close the pipe that we have opened for reading.
     //   - we have to do that under the protection of a proper exclusive lock to serialize
     //     with anybody trying to obtain a lock concurrently.
-    if (m_has_shared_lock) {
+    if (has_shared_lock()) {
         // shared lock. We need to reacquire the exclusive lock on the file
         int status;
         do {
@@ -1142,13 +1144,9 @@ void File::unlock() noexcept
         // close the pipe (== release the shared lock)
         ::close(m_pipe_fd);
         m_pipe_fd = -1;
-        m_has_shared_lock = false;
-        _unlock(m_fd);
     }
-    if (m_has_exclusive_lock) {
-        m_has_exclusive_lock = false;
-        _unlock(m_fd);
-    }
+    _unlock(m_fd);
+    m_has_exclusive_lock = false;
 
 #else // BSD / Linux flock()
 

--- a/src/realm/util/file.hpp
+++ b/src/realm/util/file.hpp
@@ -54,7 +54,7 @@ namespace std {
 #include <realm/util/function_ref.hpp>
 #include <realm/util/safe_int_ops.hpp>
 
-#if REALM_IOS
+#if REALM_IOS_DEVICE
 #define REALM_FILELOCK_EMULATION
 #endif
 

--- a/src/realm/util/file.hpp
+++ b/src/realm/util/file.hpp
@@ -608,14 +608,13 @@ public:
 
 private:
 #ifdef _WIN32
-    void* m_fd;
-    bool m_have_lock; // Only valid when m_fd is not null
+    void* m_fd = nullptr;
+    bool m_have_lock = false; // Only valid when m_fd is not null
 #else
-    int m_fd;
+    int m_fd = -1;
 #ifdef REALM_FILELOCK_EMULATION
-    int m_pipe_fd; // -1 if no pipe has been allocated for emulation
+    int m_pipe_fd = -1; // -1 if no pipe has been allocated for emulation
     bool m_has_exclusive_lock = false;
-    bool m_has_shared_lock = false;
     std::string m_fifo_path;
 #endif
 #endif
@@ -624,6 +623,13 @@ private:
 
     bool lock(bool exclusive, bool non_blocking);
     void open_internal(const std::string& path, AccessMode, CreateMode, int flags, bool* success);
+
+#ifdef REALM_FILELOCK_EMULATION
+    bool has_shared_lock() const noexcept
+    {
+        return m_pipe_fd != -1;
+    }
+#endif
 
     struct MapBase {
         void* m_addr = nullptr;
@@ -988,29 +994,10 @@ private:
 
 inline File::File(const std::string& path, Mode m)
 {
-#ifdef _WIN32
-    m_fd = nullptr;
-#else
-    m_fd = -1;
-#ifdef REALM_FILELOCK_EMULATION
-    m_pipe_fd = -1;
-#endif
-#endif
-
     open(path, m);
 }
 
-inline File::File() noexcept
-{
-#ifdef _WIN32
-    m_fd = nullptr;
-#else
-    m_fd = -1;
-#ifdef REALM_FILELOCK_EMULATION
-    m_pipe_fd = -1;
-#endif
-#endif
-}
+inline File::File() noexcept = default;
 
 inline File::~File() noexcept
 {
@@ -1037,9 +1024,7 @@ inline File::File(File&& f) noexcept
 #ifdef REALM_FILELOCK_EMULATION
     m_pipe_fd = f.m_pipe_fd;
     m_has_exclusive_lock = f.m_has_exclusive_lock;
-    m_has_shared_lock = f.m_has_shared_lock;
     f.m_has_exclusive_lock = false;
-    f.m_has_shared_lock = false;
     f.m_pipe_fd = -1;
 #endif
     f.m_fd = -1;
@@ -1061,9 +1046,7 @@ inline File& File::operator=(File&& f) noexcept
     m_pipe_fd = f.m_pipe_fd;
     f.m_pipe_fd = -1;
     m_has_exclusive_lock = f.m_has_exclusive_lock;
-    m_has_shared_lock = f.m_has_shared_lock;
     f.m_has_exclusive_lock = false;
-    f.m_has_shared_lock = false;
 #endif
 #endif
     m_encryption_key = std::move(f.m_encryption_key);


### PR DESCRIPTION
Opening the pipe in read-only mode results in the OS process which launches apps deadlocking when unsuspending the app on iOS 10-12, so opening it in read-write mode.

This also makes the emulation only be used on device, as using it in the simulator makes it so that the file can't be opened in Studio at the same time.