### PR TITLE
Improve performance of NOT IN on indexed properties

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 # NEXT RELEASE
 
 ### Enhancements
-* None.
+* Greatly improve performance of NOT IN queries on indexed string or int columns.
 
 ### Fixed
 * <How to hit and notice issue? what was the impact?> ([#????](https://github.com/realm/realm-core/issues/????), since v?.?.?)

--- a/src/realm/query.cpp
+++ b/src/realm/query.cpp
@@ -1695,7 +1695,7 @@ void Query::init() const
 {
     m_table.check();
     if (ParentNode* root = root_node()) {
-        root->init();
+        root->init(m_view == nullptr);
         std::vector<ParentNode*> vec;
         root->gather_children(vec);
     }

--- a/test/benchmark-common-tasks/main.cpp
+++ b/test/benchmark-common-tasks/main.cpp
@@ -1092,43 +1092,70 @@ struct BenchmarkQuery : BenchmarkWithStrings {
     }
 };
 
-struct BenchmarkQueryChainedOrStrings : BenchmarkWithStringsTable {
-    const size_t num_queried_matches = 1000;
+struct BenchmarkWithStringsTableForIn : BenchmarkWithStringsTable {
+    const size_t num_queried_matches = 200;
     const size_t num_rows = BASE_SIZE;
     std::vector<std::string> values_to_query;
-    const char* name() const
-    {
-        return "QueryChainedOrStrings";
-    }
 
-    void before_all(DBRef group)
+    void create_table(DBRef group, bool index)
     {
         BenchmarkWithStringsTable::before_all(group);
         WrtTrans tr(group);
         TableRef t = tr.get_table(name());
         REALM_ASSERT(num_rows > num_queried_matches);
         for (size_t i = 0; i < num_rows; ++i) {
-            std::stringstream ss;
-            ss << i;
-            auto s = ss.str();
-#ifdef REALM_CLUSTER_IF
-            t->create_object().set(m_col, s);
-#else
-            t->add_empty_row();
-            t->set_string(0, i, s);
-#endif
+            t->create_object().set(m_col, util::to_string(i));
         }
-        // t->add_search_index(0);
+        if (index)
+            t->add_search_index(m_col);
         for (size_t i = 0; i < num_queried_matches; ++i) {
             size_t ndx_to_match = (num_rows / num_queried_matches) * i;
-#ifdef REALM_CLUSTER_IF
             auto obj = t->get_object(ndx_to_match);
             values_to_query.push_back(obj.get<String>(m_col));
-#else
-            values_to_query.push_back(t->get_string(0, ndx_to_match));
-#endif
         }
         tr.commit();
+    }
+};
+
+template <bool index>
+struct BenchmarkQueryNotChainedOrStrings : BenchmarkWithStringsTableForIn {
+    const char* name() const
+    {
+        return index ? "QueryNotChainedOrStringsIndexed" : "QueryNotChainedOrStrings";
+    }
+
+    void before_all(DBRef group)
+    {
+        create_table(group, index);
+    }
+
+    void operator()(DBRef)
+    {
+        ConstTableRef table = m_table;
+        Query query = table->where();
+        query.Not();
+        query.group();
+        for (size_t i = 0; i < values_to_query.size(); ++i) {
+            query.Or().equal(m_col, values_to_query[i]);
+        }
+        query.end_group();
+        TableView results = query.find_all();
+        REALM_ASSERT_EX(results.size() == num_rows - num_queried_matches, results.size(),
+                        num_rows - num_queried_matches, values_to_query.size());
+        static_cast<void>(results);
+    }
+};
+
+template <bool index>
+struct BenchmarkQueryChainedOrStrings : BenchmarkWithStringsTableForIn {
+    const char* name() const
+    {
+        return index ? "QueryChainedOrStringsIndexed" : "QueryChainedOrStrings";
+    }
+
+    void before_all(DBRef group)
+    {
+        create_table(group, index);
     }
 
     void operator()(DBRef)
@@ -1986,7 +2013,10 @@ int benchmark_common_tasks_main()
 
     BENCH(BenchmarkQueryInsensitiveString);
     BENCH(BenchmarkQueryInsensitiveStringIndexed);
-    BENCH(BenchmarkQueryChainedOrStrings);
+    BENCH(BenchmarkQueryChainedOrStrings<false>);
+    BENCH(BenchmarkQueryChainedOrStrings<true>);
+    BENCH(BenchmarkQueryNotChainedOrStrings<false>);
+    BENCH(BenchmarkQueryNotChainedOrStrings<true>);
     BENCH(BenchmarkQueryChainedOrInts);
     BENCH(BenchmarkQueryChainedOrIntsIndexed);
     BENCH(BenchmarkQueryIntEquality);


### PR DESCRIPTION
The relevant benchmarks:

```
Req runs:   96  QueryChainedOrStrings (MemOnly, EncryptionOff):                   min   5.05ms (-0.43%)            max      6ms (+8.36%)            med   5.17ms (-0.46%)            avg   5.17ms (-0.77%)            stddev   103us (+9.04%)       
Req runs:  231  QueryChainedOrStringsIndexed (MemOnly, EncryptionOff):            min   2.05ms (-0.01%)            max   3.30ms (+29.51%)           med   2.17ms (+1.65%)            avg   2.25ms (+3.88%)            stddev   212us (+91.60%)      
Req runs:   26  QueryNotChainedOrStrings (MemOnly, EncryptionOff):                min  17.80ms (-1.37%)            max  18.97ms (-0.73%)            med  18.25ms (-1.32%)            avg  18.30ms (-1.21%)            stddev   254us (-10.64%)      
Req runs:   26  QueryNotChainedOrStringsIndexed (MemOnly, EncryptionOff):         min  17.95ms (-94.99%)           max  25.28ms (-93.03%)           med  18.47ms (-94.85%)           avg  18.78ms (-94.78%)           stddev  1.39ms (-32.00%)      
Req runs:  144  QueryChainedOrInts (MemOnly, EncryptionOff):                      min   3.37ms (-12.84%)           max   5.07ms (-6.86%)            med   3.44ms (-12.88%)           avg   3.46ms (-13.00%)           stddev   149us (-22.00%)      
Req runs:   15  QueryChainedOrIntsIndexed (MemOnly, EncryptionOff):               min  30.48ms (+0.23%)            max  31.68ms (-1.15%)            med  30.97ms (+0.51%)            avg  31.06ms (+0.77%)            stddev   347us (-6.22%)       
```

We normally don't combine equals nodes inside OR when the expression is on an indexed property because that would change the query from O(M log N) to O(N), which is typically not an improvement. However, inside of a Not group or when a query is limited to a view we evaluate a single row at a time rather than searching ranges, which means that such queries are inherently O(N\*M) regardless of what the query nodes do internally. As a result, we do want to combine OR chains in that case even if there's an index.

Fixes https://github.com/realm/realm-cocoa/issues/4564.