### PR TITLE
Fix use of wrong allocator when running query over links

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@
 
 ### Fixed
 * <How to hit and notice issue? what was the impact?> ([#????](https://github.com/realm/realm-core/issues/????), since v?.?.?)
-* None.
+* When querying a table where links are part of the condition, the application may crash if objects has recently been added to the target table. ([#7118](https://github.com/realm/realm-java/issues/7118), since v6.0.0)
  
 ### Breaking changes
 * None.

--- a/src/realm/query_expression.hpp
+++ b/src/realm/query_expression.hpp
@@ -1844,7 +1844,7 @@ public:
 
     void set_cluster(const Cluster* cluster)
     {
-        Allocator& alloc = m_tables.back()->get_alloc();
+        Allocator& alloc = get_base_table()->get_alloc();
         m_array_ptr = nullptr;
         switch (m_link_types[0]) {
             case col_type_Link:


### PR DESCRIPTION
If we use the wrong allocator to translate refs belonging to a table
m_ref_translation_ptr may not point to the most recent mapping.

Fixes https://github.com/realm/realm-java/issues/7118