### PR TITLE
Update a failing test

### DIFF
--- a/test/test_transactions.cpp
+++ b/test/test_transactions.cpp
@@ -164,8 +164,8 @@ TEST_IF(Transactions_LargeUpgrade, TEST_DURATION > 0)
         util::File f(path, util::File::mode_Update);
         util::File::Map<Header> headerMap(f, util::File::access_ReadWrite);
         auto* header = headerMap.get_addr();
-        // at least one of the versions in the header must be 10.
-        CHECK(header->m_file_format[1] == 10 || header->m_file_format[0] == 10);
+        // at least one of the versions in the header must be 11.
+        CHECK(header->m_file_format[1] == 11 || header->m_file_format[0] == 11);
         header->m_file_format[1] = header->m_file_format[0] = 9; // downgrade (both) to previous version
         headerMap.sync();
     }


### PR DESCRIPTION
This test is only run on master and not on PRs so it's been failing ever since the file format version was bumped.