### PR TITLE
Allocate one extra element in ref translation table

### DIFF
--- a/src/realm/alloc_slab.cpp
+++ b/src/realm/alloc_slab.cpp
@@ -1269,7 +1269,7 @@ size_t SlabAlloc::get_allocated_size() const noexcept
 void SlabAlloc::extend_fast_mapping_with_slab(char* address)
 {
     ++m_translation_table_size;
-    auto new_fast_mapping = new RefTranslation[m_translation_table_size];
+    auto new_fast_mapping = new RefTranslation[m_translation_table_size + 1]();
     for (size_t i = 0; i < m_translation_table_size - 1; ++i) {
         new_fast_mapping[i] = m_ref_translation_ptr[i];
     }
@@ -1296,7 +1296,7 @@ void SlabAlloc::rebuild_translations(bool requires_new_translation, size_t old_n
         if (m_translation_table_size)
             m_old_translations.emplace_back(m_youngest_live_version, m_ref_translation_ptr.load());
         m_translation_table_size = num_mappings + free_space_size + m_sections_in_compatibility_mapping;
-        new_translation_table = new RefTranslation[m_translation_table_size];
+        new_translation_table = new RefTranslation[m_translation_table_size + 1]();
         for (int i = 0; i < m_sections_in_compatibility_mapping; ++i) {
             new_translation_table[i].mapping_addr = m_compatibility_mapping.get_addr() + get_section_base(i);
             REALM_ASSERT(new_translation_table[i].mapping_addr);


### PR DESCRIPTION
If we have a +-1 error this could give a different error signature.