### PR TITLE
Fix FunctionRef copying

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 # NEXT RELEASE
 
 ### Enhancements
-* None.
+* Slightly improve performance of most operations which read data from the Realm file.
 
 ### Fixed
 * <How to hit and notice issue? what was the impact?> ([#????](https://github.com/realm/realm-core/issues/????), since v?.?.?)

--- a/src/realm/util/function_ref.hpp
+++ b/src/realm/util/function_ref.hpp
@@ -25,6 +25,15 @@
 namespace realm {
 namespace util {
 
+#ifdef _WIN32
+// VC++ warns about multiple copy constructors, but we want both const and
+// non-const version to ensure they're a better match than the wrapping
+// constructor. We could instead use enable_if to make the wrapping constructor
+// ineligible, but that tends to do bad things to compile times.
+#pragma warning(push)
+#pragma warning(disable : 4521 4522)
+#endif
+
 /// A lightweight non-owning reference to a callable.
 ///
 /// This type is similar to std::function, but unlike std::function holds a reference to the callable rather than
@@ -53,10 +62,36 @@ public:
     FunctionRef(ThisType&&) noexcept = default;
     ThisType& operator=(ThisType&&) noexcept = default;
 #else
+#ifdef _WIN32
+    // VC++ incorrectly rejects multiple versions of a defaulted special member function
+    constexpr FunctionRef(ThisType& o) noexcept
+        : m_obj(o.m_obj)
+        , m_callback(o.m_callback)
+    {
+    }
+    constexpr ThisType& operator=(ThisType& o) noexcept
+    {
+        m_obj = o.m_obj;
+        m_callback = o.m_callback;
+        return *this;
+    }
+    constexpr FunctionRef(ThisType const& o) noexcept
+        : m_obj(o.m_obj)
+        , m_callback(o.m_callback)
+    {
+    }
+    constexpr ThisType& operator=(ThisType const& o) noexcept
+    {
+        m_obj = o.m_obj;
+        m_callback = o.m_callback;
+        return *this;
+    }
+#else
     constexpr FunctionRef(ThisType&) noexcept = default;
-    constexpr FunctionRef(ThisType const&) noexcept = default;
     constexpr ThisType& operator=(ThisType&) noexcept = default;
+    constexpr FunctionRef(ThisType const&) noexcept = default;
     constexpr ThisType& operator=(const ThisType&) noexcept = default;
+#endif
     constexpr FunctionRef(ThisType&&) noexcept = default;
     constexpr ThisType& operator=(ThisType&&) noexcept = default;
 #endif
@@ -95,5 +130,9 @@ constexpr void swap(FunctionRef<R(Args...)>& lhs, FunctionRef<R(Args...)>& rhs) 
 
 } // namespace util
 } // namespace realm
+
+#ifdef _WIN32
+#pragma warning(pop)
+#endif
 
 #endif

--- a/src/realm/util/function_ref.hpp
+++ b/src/realm/util/function_ref.hpp
@@ -40,20 +40,25 @@ class FunctionRef;
 template <typename Return, typename... Args>
 class FunctionRef<Return(Args...)> {
 public:
+    using ThisType = FunctionRef<Return(Args...)>;
     // A FunctionRef is never empty, and so cannot be default-constructed.
     constexpr FunctionRef() noexcept = delete;
 
     // FunctionRef is copyable and moveable.
 #if defined(__GNUC__) && __GNUC__ == 4 && __GNUC_MINOR__ <= 9 && !defined(__clang__)
-    FunctionRef(FunctionRef<Return(Args...)> const&) noexcept = default;
-    FunctionRef<Return(Args...)>& operator=(const FunctionRef<Return(Args...)>&) noexcept = default;
-    FunctionRef(FunctionRef<Return(Args...)>&&) noexcept = default;
-    FunctionRef<Return(Args...)>& operator=(FunctionRef<Return(Args...)>&&) noexcept = default;
+    FunctionRef(ThisType&) noexcept = default;
+    FunctionRef(ThisType const&) noexcept = default;
+    ThisType& operator=(ThisType&) noexcept = default;
+    ThisType& operator=(const ThisType&) noexcept = default;
+    FunctionRef(ThisType&&) noexcept = default;
+    ThisType& operator=(ThisType&&) noexcept = default;
 #else
-    constexpr FunctionRef(FunctionRef<Return(Args...)> const&) noexcept = default;
-    constexpr FunctionRef<Return(Args...)>& operator=(const FunctionRef<Return(Args...)>&) noexcept = default;
-    constexpr FunctionRef(FunctionRef<Return(Args...)>&&) noexcept = default;
-    constexpr FunctionRef<Return(Args...)>& operator=(FunctionRef<Return(Args...)>&&) noexcept = default;
+    constexpr FunctionRef(ThisType&) noexcept = default;
+    constexpr FunctionRef(ThisType const&) noexcept = default;
+    constexpr ThisType& operator=(ThisType&) noexcept = default;
+    constexpr ThisType& operator=(const ThisType&) noexcept = default;
+    constexpr FunctionRef(ThisType&&) noexcept = default;
+    constexpr ThisType& operator=(ThisType&&) noexcept = default;
 #endif
 
     // Construct a FunctionRef which wraps the given callable.
@@ -66,7 +71,7 @@ public:
     {
     }
 
-    constexpr void swap(FunctionRef<Return(Args...)>& rhs) noexcept
+    constexpr void swap(ThisType& rhs) noexcept
     {
         std::swap(m_obj, rhs.m_obj);
         std::swap(m_callback, rhs.m_callback);


### PR DESCRIPTION
Mutable lvalue function refs were getting wrapped in another function ref rather than copied because the templated constructor was the best match. This didn't cause any correctness problems but was sometimes annoying when debugging
and caused a small perf hit (~5% on the benchmarks where the difference is statistically significant).