### PR TITLE
Correctly update queries on indexed string columns going from multiple matches to one

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,8 +5,8 @@
 
 ### Fixed
 * <How to hit and notice issue? what was the impact?> ([#????](https://github.com/realm/realm-core/issues/????), since v?.?.?)
-* None.
- 
+* Rerunning a query on an indexed string column which previously had more than one match and now has one match would sometimes throw a "key not found" exception ([Cocoa #6536](https://github.com/realm/realm-cocoa/issues/6536), since 5.0.0),
+
 ### Breaking changes
 * None.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@
 
 ### Fixed
 * <How to hit and notice issue? what was the impact?> ([#????](https://github.com/realm/realm-core/issues/????), since v?.?.?)
-* Rerunning a query on an indexed string column which previously had more than one match and now has one match would sometimes throw a "key not found" exception ([Cocoa #6536](https://github.com/realm/realm-cocoa/issues/6536), since 5.0.0),
+* Rerunning an equals query on an indexed string column which previously had more than one match and now has one match would sometimes throw a "key not found" exception ([Cocoa #6536](https://github.com/realm/realm-cocoa/issues/6536), since 6.0.2),
 
 ### Breaking changes
 * None.

--- a/src/realm/query_engine.cpp
+++ b/src/realm/query_engine.cpp
@@ -285,6 +285,7 @@ void StringNode<Equal>::_search_index_init()
         auto index = ParentNode::m_table.unchecked_ptr()->get_search_index(ParentNode::m_condition_column_key);
         fr = index->find_all_no_copy(StringData(StringNodeBase::m_value), res);
 
+        m_index_matches.reset();
         switch (fr) {
             case FindRes_single:
                 m_actual_key = ObjKey(res.payload);
@@ -298,7 +299,6 @@ void StringNode<Equal>::_search_index_init()
                 m_actual_key = ObjKey(m_index_matches->get(m_results_start));
                 break;
             case FindRes_not_found:
-                m_index_matches.reset();
                 m_results_end = 0;
                 break;
         }


### PR DESCRIPTION
When one run of a query on an indexed string column matched multiple objects and then a subsequent one matched one, m_index_matches was not set back to null and so would incorrectly continue to be used in index_based_aggregate().

This would result in either incorrect results (if the first matching object was mutated to no longer match) or throwing "key not found" if the first matching object was deleted.

Fixes https://github.com/realm/realm-cocoa/issues/6536.