### PR TITLE
fix int null query on indexed non-null column

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,8 @@
 ### Fixed
 * <How to hit and notice issue? what was the impact?> ([#????](https://github.com/realm/realm-core/issues/????), since v?.?.?)
 * Making a query in an indexed property may give a "Key not found" exception. ([#2025](https://github.com/realm/realm-dotnet/issues/2025), since v6.0.0)
- 
+* Fix queries for null on non-nullable indexed integer columns returning results for zero entries. (Since v6)
+
 ### Breaking changes
 * None.
 

--- a/src/realm/query_expression.hpp
+++ b/src/realm/query_expression.hpp
@@ -3126,6 +3126,10 @@ public:
         std::vector<ObjKey> ret;
         std::vector<ObjKey> result;
 
+        if (value.is_null() && !m_nullable) {
+            return ret;
+        }
+
         if (m_nullable && std::is_same<T, int64_t>::value) {
             util::Optional<int64_t> val;
             if (!value.is_null()) {
@@ -3298,7 +3302,7 @@ private:
     mutable ColKey m_column_key;
 
     // set to false by default for stand-alone Columns declaration that are not yet associated with any table
-    // or oclumn. Call init() to update it or use a constructor that takes table + column index as argument.
+    // or column. Call init() to update it or use a constructor that takes table + column index as argument.
     bool m_nullable = false;
 };
 


### PR DESCRIPTION
Queries for null on a non-nullable property shouldn't be returning anything. This is a small optimization for these types of queries on string/timestamp/binary and a fix for int.