### PR TITLE
Fix ObjectId indexed query for null

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 ### Fixed
 * <How to hit and notice issue? what was the impact?> ([#????](https://github.com/realm/realm-core/issues/????), since v?.?.?)
 * Fix queries for null on non-nullable indexed integer columns returning results for zero entries. (Since v6)
+* Fix queries for null on a indexed ObjectId column returning results for the zero ObjectId. (Since v10)
  
 ### Breaking changes
 * None.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@
 
 ### Fixed
 * <How to hit and notice issue? what was the impact?> ([#????](https://github.com/realm/realm-core/issues/????), since v?.?.?)
-* None.
+* Fix queries for null on non-nullable indexed integer columns returning results for zero entries. (Since v6)
  
 ### Breaking changes
 * None.

--- a/src/realm/column_type_traits.hpp
+++ b/src/realm/column_type_traits.hpp
@@ -231,6 +231,12 @@ struct ColumnTypeTraits<Decimal128> {
 };
 
 template <typename T>
+struct ObjectTypeTraits {
+    constexpr static bool self_contained_null =
+        realm::is_any_v<T, StringData, BinaryData, Decimal128, Timestamp, Mixed>;
+};
+
+template <typename T>
 using ColumnClusterLeafType = typename ColumnTypeTraits<T>::cluster_leaf_type;
 template <typename T>
 using ColumnSumType = typename ColumnTypeTraits<T>::sum_type;

--- a/src/realm/query_expression.hpp
+++ b/src/realm/query_expression.hpp
@@ -3603,6 +3603,10 @@ public:
         std::vector<ObjKey> ret;
         std::vector<ObjKey> result;
 
+        if (value.is_null() && !m_nullable) {
+            return ret;
+        }
+
         if (m_nullable && std::is_same_v<T, int64_t>) {
             util::Optional<int64_t> val;
             if (!value.is_null()) {
@@ -3780,7 +3784,7 @@ private:
     mutable ColKey m_column_key;
 
     // set to false by default for stand-alone Columns declaration that are not yet associated with any table
-    // or oclumn. Call init() to update it or use a constructor that takes table + column index as argument.
+    // or column. Call init() to update it or use a constructor that takes table + column index as argument.
     bool m_nullable = false;
     ExpressionComparisonType m_comparison_type = ExpressionComparisonType::Any;
 };

--- a/test/test_parser.cpp
+++ b/test/test_parser.cpp
@@ -2207,6 +2207,7 @@ TEST_TYPES(Parser_list_of_primitive_types, Int, Optional<Int>, Bool, Optional<Bo
 {
     Group g;
     TableRef t = g.add_table("table");
+    TestValueGenerator gen;
 
     using underlying_type = typename util::RemoveOptional<TEST_TYPE>::type;
     constexpr bool is_optional = !std::is_same<underlying_type, TEST_TYPE>::value;
@@ -2214,12 +2215,11 @@ TEST_TYPES(Parser_list_of_primitive_types, Int, Optional<Int>, Bool, Optional<Bo
     auto col_link = t->add_column_link(type_Link, "link", *t);
 
     auto obj1 = t->create_object();
-    std::vector<TEST_TYPE> values =
-        values_from_int<TEST_TYPE, underlying_type>({0, 9, 4, 2, 7, 4, 1, 8, 11, 3, 4, 5, 22});
+    std::vector<TEST_TYPE> values = gen.values_from_int<TEST_TYPE>({0, 9, 4, 2, 7, 4, 1, 8, 11, 3, 4, 5, 22});
     obj1.set_list_values(col, values);
     auto obj2 = t->create_object(); // empty list
     auto obj3 = t->create_object(); // {1}
-    underlying_type value_1 = convert_for_test<underlying_type>(1);
+    underlying_type value_1 = gen.convert_for_test<underlying_type>(1);
     obj3.get_list<TEST_TYPE>(col).add(value_1);
     auto obj4 = t->create_object(); // {1, 1}
     obj4.get_list<TEST_TYPE>(col).add(value_1);
@@ -2229,7 +2229,7 @@ TEST_TYPES(Parser_list_of_primitive_types, Int, Optional<Int>, Bool, Optional<Bo
         obj5.get_list<TEST_TYPE>(col).add(none);
     }
     else {
-        obj5.get_list<TEST_TYPE>(col).add(convert_for_test<underlying_type>(0));
+        obj5.get_list<TEST_TYPE>(col).add(gen.convert_for_test<underlying_type>(0));
     }
     for (auto it = t->begin(); it != t->end(); ++it) {
         it->set<ObjKey>(col_link, it->get_key()); // self links

--- a/test/test_table.cpp
+++ b/test/test_table.cpp
@@ -4232,6 +4232,44 @@ TEST(Table_SearchIndexFindAll)
     CHECK_EQUAL(tv.size(), 6);
 }
 
+TEST(Table_QueryNullOnNonNullSearchIndex)
+{
+    Group g;
+    TableRef t = g.add_table("table");
+    ColKey col0 = t->add_column(type_Int, "value", false);
+    ColKey col_link = t->add_column_link(type_Link, "link", *t);
+    t->add_search_index(col0);
+
+    std::vector<Int> values = {0, 9, 4, 2, 7};
+
+    for (Int v : values) {
+        auto obj = t->create_object();
+        obj.set(col0, v);
+        obj.set(col_link, obj.get_key());
+    }
+
+    for (Int v : values) {
+        Query q0 = t->column<Int>(col0) == v;
+        CHECK_EQUAL(q0.count(), 1);
+        Query q1 = t->link(col_link).column<Int>(col0) == v;
+        CHECK_EQUAL(q1.count(), 1);
+        Query q2 = t->link(col_link).link(col_link).column<Int>(col0) == v;
+        CHECK_EQUAL(q2.count(), 1);
+        Query q3 = t->where().equal(col0, v);
+        CHECK_EQUAL(q3.count(), 1);
+    }
+
+    {
+        Query q0 = t->column<Int>(col0) == realm::null();
+        CHECK_EQUAL(q0.count(), 0);
+        Query q1 = t->link(col_link).column<Int>(col0) == realm::null();
+        CHECK_EQUAL(q1.count(), 0);
+        Query q2 = t->link(col_link).link(col_link).column<Int>(col0) == realm::null();
+        CHECK_EQUAL(q2.count(), 0);
+    }
+}
+
+
 namespace {
 
 template <class T, bool nullable>

--- a/test/test_types_helper.hpp
+++ b/test/test_types_helper.hpp
@@ -20,24 +20,47 @@
 #define REALM_TEST_TYPES_HELPER_HPP
 
 #include <realm.hpp>
+#include <realm/column_type_traits.hpp>
 
 namespace realm {
 namespace test_util {
 
-template <typename T>
-inline T convert_for_test(int64_t v)
+struct TestValueGenerator {
+    template <typename T>
+    inline T convert_for_test(int64_t v)
+    {
+        return static_cast<T>(v);
+    }
+
+    template <typename T>
+    std::vector<T> values_from_int(const std::vector<int64_t>& values)
+    {
+        std::vector<T> ret;
+        for (size_t i = 0; i < values.size(); ++i) {
+            ret.push_back(convert_for_test<typename util::RemoveOptional<T>::type>(values[i]));
+        }
+        return ret;
+    }
+
+private:
+    std::vector<util::StringBuffer> m_buffer_space;
+};
+
+
+template <>
+inline bool TestValueGenerator::convert_for_test<bool>(int64_t v)
 {
-    return static_cast<T>(v);
+    return v % 2 == 0;
 }
 
 template <>
-inline Timestamp convert_for_test<Timestamp>(int64_t v)
+inline Timestamp TestValueGenerator::convert_for_test<Timestamp>(int64_t v)
 {
     return Timestamp{v, 0};
 }
 
 template <>
-inline ObjectId convert_for_test<ObjectId>(int64_t v)
+inline ObjectId TestValueGenerator::convert_for_test<ObjectId>(int64_t v)
 {
     static const char hex_digits[] = "0123456789abcdef";
     std::string value;
@@ -53,20 +76,83 @@ inline ObjectId convert_for_test<ObjectId>(int64_t v)
 }
 
 template <>
-inline util::Optional<ObjectId> convert_for_test(int64_t v)
+inline util::Optional<ObjectId> TestValueGenerator::convert_for_test<util::Optional<ObjectId>>(int64_t v)
 {
     return util::Optional<ObjectId>(convert_for_test<ObjectId>(v));
 }
 
-template <typename T, typename U>
-std::vector<T> values_from_int(const std::vector<int64_t>& values)
+template <>
+inline StringData TestValueGenerator::convert_for_test<StringData>(int64_t t)
 {
-    std::vector<T> ret;
-    for (size_t i = 0; i < values.size(); ++i) {
-        ret.push_back(convert_for_test<U>(values[i]));
-    }
-    return ret;
+    std::string str = util::format("string %1", t);
+    util::StringBuffer b;
+    b.append(str);
+    m_buffer_space.emplace_back(std::move(b));
+    return StringData(m_buffer_space[m_buffer_space.size() - 1].data(), str.size());
 }
+
+template <>
+inline BinaryData TestValueGenerator::convert_for_test<BinaryData>(int64_t t)
+{
+    std::string str = util::format("string %1", t);
+    util::StringBuffer b;
+    b.append(str);
+    m_buffer_space.emplace_back(std::move(b));
+    return BinaryData(m_buffer_space[m_buffer_space.size() - 1].data(), str.size());
+}
+
+enum class ColumnState { Normal = 0, Nullable = 1, Indexed = 2, NullableIndexed = 3 };
+
+template <ColumnState s>
+constexpr static bool col_state_is_nullable = (s == ColumnState::Nullable || s == ColumnState::NullableIndexed);
+
+template <ColumnState s>
+constexpr static bool col_state_is_indexed = (s == ColumnState::Indexed || s == ColumnState::NullableIndexed);
+
+template <typename T, ColumnState state = ColumnState::Normal, typename Enable = void>
+struct Prop {
+    static constexpr bool is_nullable = col_state_is_nullable<state>;
+    static constexpr bool is_indexed = col_state_is_indexed<state>;
+    static constexpr DataType data_type = ColumnTypeTraits<T>::id;
+    using type = T;
+    using underlying_type = type;
+    static type default_value()
+    {
+        return ColumnTypeTraits<type>::cluster_leaf_type::default_value(is_nullable);
+    }
+    static underlying_type default_non_nullable_value()
+    {
+        return ColumnTypeTraits<underlying_type>::cluster_leaf_type::default_value(false);
+    }
+};
+
+template <typename T, ColumnState state>
+struct Prop<T, state,
+            std::enable_if_t<col_state_is_nullable<state> && !ObjectTypeTraits<T>::self_contained_null, void>> {
+    static constexpr bool is_nullable = col_state_is_nullable<state>;
+    static constexpr bool is_indexed = col_state_is_indexed<state>;
+    static constexpr DataType data_type = ColumnTypeTraits<T>::id;
+    using type = typename util::Optional<T>;
+    using underlying_type = T;
+    static type default_value()
+    {
+        if constexpr (realm::is_any_v<type, util::Optional<float>, util::Optional<double>>) {
+            return type(); // optional float/double would return NaN and for consistency we want to operate on null
+        }
+        return ColumnTypeTraits<type>::cluster_leaf_type::default_value(is_nullable);
+    }
+    static underlying_type default_non_nullable_value()
+    {
+        return ColumnTypeTraits<underlying_type>::cluster_leaf_type::default_value(false);
+    }
+};
+
+template <typename T>
+using Nullable = Prop<T, ColumnState::Nullable>;
+template <typename T>
+using Indexed = Prop<T, ColumnState::Indexed>;
+template <typename T>
+using NullableIndexed = Prop<T, ColumnState::NullableIndexed>;
 
 struct less {
     template <typename T>


### PR DESCRIPTION
I've created some test type wrappers that will allow us to more easily template our tests for every type, in the hopes that this will reduce the likelihood of having uncovered corner cases like this.

The templated tests revealed an inconsistency that we don't provide query expression support for BinaryData == or != for `null` so I added those in as well.

The first commit is the cherry-picked fix from https://github.com/realm/realm-core/pull/3947 (so that the merge from master to v10 isn't so bad).