### PR TITLE
Fix missing semicolon in src/realm/util/thread.hpp

### DIFF
--- a/src/realm/util/thread.hpp
+++ b/src/realm/util/thread.hpp
@@ -736,7 +736,7 @@ inline void CondVar::wait(RobustMutex& m, Func recover_func, const struct timesp
             if (r == ERROR_TIMEOUT)
                 return;
         } else {
-            r = 0
+            r = 0;
         }
 #else
         r = pthread_cond_timedwait(&m_impl, &m.m_impl, tp);


### PR DESCRIPTION
I have found this in realm-core 5.4.2 and it's still present.