### PR TITLE
[DO NOT MERGE] Benchmark Obj::get_int variants

### DIFF
--- a/src/realm/obj.hpp
+++ b/src/realm/obj.hpp
@@ -243,6 +243,9 @@ public:
 
     void assign_pk_and_backlinks(const Obj& other);
 
+    template <typename U>
+    U _get(ColKey::Idx col_ndx) const;
+
 private:
     friend class ArrayBacklink;
     friend class CascadeState;
@@ -282,9 +285,6 @@ private:
     TableRef get_target_table(ColKey col_key) const;
     TableRef get_target_table(ObjLink link) const;
     const Spec& get_spec() const;
-
-    template <typename U>
-    U _get(ColKey::Idx col_ndx) const;
 
     template <class T>
     int cmp(const Obj& other, ColKey::Idx col_ndx) const;

--- a/test/test_table.cpp
+++ b/test/test_table.cpp
@@ -99,9 +99,7 @@ namespace {
 // both non-nullable:
 template <typename T1, typename T2>
 struct value_copier {
-    value_copier(bool)
-    {
-    }
+    value_copier(bool) {}
     T2 operator()(T1 from_value, bool = false)
     {
         return from_value;
@@ -146,9 +144,7 @@ struct value_copier<Optional<T1>, T2> {
 // identical to non-specialized case, but specialization needed to avoid capture by 2 previous decls
 template <typename T1, typename T2>
 struct value_copier<Optional<T1>, Optional<T2>> {
-    value_copier(bool)
-    {
-    }
+    value_copier(bool) {}
     Optional<T2> operator()(Optional<T1> from_value, bool)
     {
         return from_value;
@@ -241,7 +237,7 @@ struct value_copier<Timestamp, Timestamp> {
         return from_value;
     }
 };
-}
+} // namespace
 
 #ifdef JAVA_MANY_COLUMNS_CRASH
 
@@ -432,9 +428,9 @@ TEST(Table_DateTimeMinMax)
 
     auto col = table->add_column(type_Timestamp, "time", true);
 
-    // We test different code paths of the internal Core minmax method. First a null value as initial "best candidate",
-    // then non-null first. For each case we then try both a substitution of best candidate, then non-substitution. 4
-    // permutations in total.
+    // We test different code paths of the internal Core minmax method. First a null value as initial "best
+    // candidate", then non-null first. For each case we then try both a substitution of best candidate, then
+    // non-substitution. 4 permutations in total.
 
     std::vector<Obj> objs(3);
     objs[0] = table->create_object();
@@ -518,8 +514,8 @@ TEST(Table_MinMaxSingleNullRow)
 
         table->create_object();
 
-        CHECK(table->maximum_timestamp(date_col).is_null());               // max on table
-        table->where().find_all().maximum_timestamp(date_col, &key);       // max on tableview
+        CHECK(table->maximum_timestamp(date_col).is_null());         // max on table
+        table->where().find_all().maximum_timestamp(date_col, &key); // max on tableview
         CHECK(key == null_key);
         table->where().maximum_timestamp(date_col, &key); // max on query
         CHECK(key == null_key);
@@ -550,8 +546,8 @@ TEST(Table_MinMaxSingleNullRow)
 
         table->create_object();
 
-        CHECK(table->minimum_timestamp(date_col).is_null());               // max on table
-        table->where().find_all().minimum_timestamp(date_col, &key);       // max on tableview
+        CHECK(table->minimum_timestamp(date_col).is_null());         // max on table
+        table->where().find_all().minimum_timestamp(date_col, &key); // max on tableview
         CHECK(key == null_key);
         table->where().minimum_timestamp(date_col, &key); // max on query
         CHECK(key == null_key);
@@ -650,8 +646,7 @@ TEST(TableView_AggregateBugs)
 TEST(Table_AggregateFuzz)
 {
     // Tests sum, avg, min, max on Table, TableView, Query, for types float, Timestamp, int
-    for(int iter = 0; iter < 50 + 1000 * TEST_DURATION; iter++)
-    {
+    for (int iter = 0; iter < 50 + 1000 * TEST_DURATION; iter++) {
         Group g;
         TableRef table = g.add_table("test_table");
 
@@ -830,7 +825,6 @@ TEST(Table_AggregateFuzz)
 
             i = table->where().find_all().sum_int(int_col);
             CHECK_EQUAL(i, sum);
-
         }
 
         // Test methods on Query
@@ -2264,8 +2258,9 @@ TEST(Table_NullableChecks)
 
     Obj obj = t.create_object();
     StringData sd; // construct a null reference
-    Timestamp ts; // null
-    BinaryData bd;; // null
+    Timestamp ts;  // null
+    BinaryData bd;
+    ; // null
     obj.set(str_col, sd);
     obj.set(int_col, realm::null());
     obj.set(bool_col, realm::null());
@@ -3568,7 +3563,7 @@ TEST(Table_object_seq_rnd)
 {
 #ifdef PERFORMACE_TESTING
     size_t rows = 1'000'000;
-    int runs = 100;     // runs for building scenario
+    int runs = 100; // runs for building scenario
 #else
     size_t rows = 100'000;
     int runs = 100;
@@ -4503,7 +4498,7 @@ struct Tester {
 
 template <class T, bool nullable>
 ColKey Tester<T, nullable>::col;
-}
+} // namespace
 
 // The run() method will first add lots of objects, and then remove them. This will test
 // both node splits and empty leaf destruction and get good search index code coverage
@@ -4584,10 +4579,26 @@ std::string generate_value()
     return str;
 }
 
-template<> bool generate_value() { return test_util::random_int<int>() & 0x1; }
-template<> float generate_value() { return float(1.0 * test_util::random_int<int>() / (test_util::random_int<int>(1, 1000))); }
-template<> double generate_value() { return 1.0 * test_util::random_int<int>() / (test_util::random_int<int>(1, 1000)); }
-template<> Timestamp generate_value() { return Timestamp(test_util::random_int<int>(0, 1000000), test_util::random_int<int>(0, 1000000000)); }
+template <>
+bool generate_value()
+{
+    return test_util::random_int<int>() & 0x1;
+}
+template <>
+float generate_value()
+{
+    return float(1.0 * test_util::random_int<int>() / (test_util::random_int<int>(1, 1000)));
+}
+template <>
+double generate_value()
+{
+    return 1.0 * test_util::random_int<int>() / (test_util::random_int<int>(1, 1000));
+}
+template <>
+Timestamp generate_value()
+{
+    return Timestamp(test_util::random_int<int>(0, 1000000), test_util::random_int<int>(0, 1000000000));
+}
 template <>
 Decimal128 generate_value()
 {
@@ -5190,7 +5201,8 @@ TEST(Table_Column_Conversions)
 
 }
 */
-TEST(Table_MultipleObjs) {
+TEST(Table_MultipleObjs)
+{
     SHARED_GROUP_TEST_PATH(path);
 
     std::unique_ptr<Replication> hist(make_in_realm_history(path));
@@ -5592,6 +5604,71 @@ TEST(Table_IndexOnMixed)
     CHECK_EQUAL(foos->find_first<Mixed>(col, 1), k7);
     CHECK_EQUAL(foos->find_first<Mixed>(col, true), k8);
     CHECK_EQUAL(foos->find_first<Mixed>(col, bar.get_link()), k9);
+}
+
+TEST(Obj_GetIntPerformance)
+{
+    Group g;
+    auto foos = g.add_table("foo");
+    auto col = foos->add_column(type_Int, "int");
+
+    const size_t nb_rows = 100000;
+    const size_t nb_ops = 100000;
+
+    Obj o;
+    for (size_t i = 0; i < nb_rows; ++i) {
+        auto obj = foos->create_object();
+        obj.set(col, 123123);
+        if (i == nb_rows / 2) {
+            o = obj;
+        }
+    }
+
+    CALLGRIND_START_INSTRUMENTATION;
+
+    std::cout << nb_ops << " Obj::get_any()" << std::endl;
+
+    {
+        auto t1 = steady_clock::now();
+        int64_t x = 0;
+        for (size_t i = 0; i < nb_ops; ++i) {
+            auto v = o.get_any(col);
+            if (!v.is_null() && v.get_type() == type_Int) {
+                x += v.get<int64_t>();
+            }
+        }
+        auto t2 = steady_clock::now();
+        std::cout << "   result: " << x << std::endl;
+        std::cout << "   get time: " << duration_cast<nanoseconds>(t2 - t1).count() / nb_ops << " ns/op" << std::endl;
+    }
+
+    std::cout << nb_ops << " Obj::get<int64_t>()" << std::endl;
+
+    {
+        auto t1 = steady_clock::now();
+        int64_t x = 0;
+        for (size_t i = 0; i < nb_ops; ++i) {
+            x += o.get<int64_t>(col);
+        }
+        auto t2 = steady_clock::now();
+        std::cout << "   result: " << x << std::endl;
+        std::cout << "   get time: " << duration_cast<nanoseconds>(t2 - t1).count() / nb_ops << " ns/op" << std::endl;
+    }
+
+    std::cout << nb_ops << " Obj::_get<int64_t>()" << std::endl;
+
+    {
+        auto t1 = steady_clock::now();
+        int64_t x = 0;
+        for (size_t i = 0; i < nb_ops; ++i) {
+            x += o._get<int64_t>(col.get_index());
+        }
+        auto t2 = steady_clock::now();
+        std::cout << "   result: " << x << std::endl;
+        std::cout << "   get time: " << duration_cast<nanoseconds>(t2 - t1).count() / nb_ops << " ns/op" << std::endl;
+    }
+
+    CALLGRIND_STOP_INSTRUMENTATION;
 }
 
 #endif // TEST_TABLE

--- a/test/test_table.cpp
+++ b/test/test_table.cpp
@@ -99,7 +99,9 @@ namespace {
 // both non-nullable:
 template <typename T1, typename T2>
 struct value_copier {
-    value_copier(bool) {}
+    value_copier(bool)
+    {
+    }
     T2 operator()(T1 from_value, bool = false)
     {
         return from_value;
@@ -144,7 +146,9 @@ struct value_copier<Optional<T1>, T2> {
 // identical to non-specialized case, but specialization needed to avoid capture by 2 previous decls
 template <typename T1, typename T2>
 struct value_copier<Optional<T1>, Optional<T2>> {
-    value_copier(bool) {}
+    value_copier(bool)
+    {
+    }
     Optional<T2> operator()(Optional<T1> from_value, bool)
     {
         return from_value;
@@ -237,7 +241,7 @@ struct value_copier<Timestamp, Timestamp> {
         return from_value;
     }
 };
-} // namespace
+}
 
 #ifdef JAVA_MANY_COLUMNS_CRASH
 
@@ -428,9 +432,9 @@ TEST(Table_DateTimeMinMax)
 
     auto col = table->add_column(type_Timestamp, "time", true);
 
-    // We test different code paths of the internal Core minmax method. First a null value as initial "best
-    // candidate", then non-null first. For each case we then try both a substitution of best candidate, then
-    // non-substitution. 4 permutations in total.
+    // We test different code paths of the internal Core minmax method. First a null value as initial "best candidate",
+    // then non-null first. For each case we then try both a substitution of best candidate, then non-substitution. 4
+    // permutations in total.
 
     std::vector<Obj> objs(3);
     objs[0] = table->create_object();
@@ -514,8 +518,8 @@ TEST(Table_MinMaxSingleNullRow)
 
         table->create_object();
 
-        CHECK(table->maximum_timestamp(date_col).is_null());         // max on table
-        table->where().find_all().maximum_timestamp(date_col, &key); // max on tableview
+        CHECK(table->maximum_timestamp(date_col).is_null());               // max on table
+        table->where().find_all().maximum_timestamp(date_col, &key);       // max on tableview
         CHECK(key == null_key);
         table->where().maximum_timestamp(date_col, &key); // max on query
         CHECK(key == null_key);
@@ -546,8 +550,8 @@ TEST(Table_MinMaxSingleNullRow)
 
         table->create_object();
 
-        CHECK(table->minimum_timestamp(date_col).is_null());         // max on table
-        table->where().find_all().minimum_timestamp(date_col, &key); // max on tableview
+        CHECK(table->minimum_timestamp(date_col).is_null());               // max on table
+        table->where().find_all().minimum_timestamp(date_col, &key);       // max on tableview
         CHECK(key == null_key);
         table->where().minimum_timestamp(date_col, &key); // max on query
         CHECK(key == null_key);
@@ -646,7 +650,8 @@ TEST(TableView_AggregateBugs)
 TEST(Table_AggregateFuzz)
 {
     // Tests sum, avg, min, max on Table, TableView, Query, for types float, Timestamp, int
-    for (int iter = 0; iter < 50 + 1000 * TEST_DURATION; iter++) {
+    for(int iter = 0; iter < 50 + 1000 * TEST_DURATION; iter++)
+    {
         Group g;
         TableRef table = g.add_table("test_table");
 
@@ -825,6 +830,7 @@ TEST(Table_AggregateFuzz)
 
             i = table->where().find_all().sum_int(int_col);
             CHECK_EQUAL(i, sum);
+
         }
 
         // Test methods on Query
@@ -2258,9 +2264,8 @@ TEST(Table_NullableChecks)
 
     Obj obj = t.create_object();
     StringData sd; // construct a null reference
-    Timestamp ts;  // null
-    BinaryData bd;
-    ; // null
+    Timestamp ts; // null
+    BinaryData bd;; // null
     obj.set(str_col, sd);
     obj.set(int_col, realm::null());
     obj.set(bool_col, realm::null());
@@ -3563,7 +3568,7 @@ TEST(Table_object_seq_rnd)
 {
 #ifdef PERFORMACE_TESTING
     size_t rows = 1'000'000;
-    int runs = 100; // runs for building scenario
+    int runs = 100;     // runs for building scenario
 #else
     size_t rows = 100'000;
     int runs = 100;
@@ -4498,7 +4503,7 @@ struct Tester {
 
 template <class T, bool nullable>
 ColKey Tester<T, nullable>::col;
-} // namespace
+}
 
 // The run() method will first add lots of objects, and then remove them. This will test
 // both node splits and empty leaf destruction and get good search index code coverage
@@ -4579,26 +4584,10 @@ std::string generate_value()
     return str;
 }
 
-template <>
-bool generate_value()
-{
-    return test_util::random_int<int>() & 0x1;
-}
-template <>
-float generate_value()
-{
-    return float(1.0 * test_util::random_int<int>() / (test_util::random_int<int>(1, 1000)));
-}
-template <>
-double generate_value()
-{
-    return 1.0 * test_util::random_int<int>() / (test_util::random_int<int>(1, 1000));
-}
-template <>
-Timestamp generate_value()
-{
-    return Timestamp(test_util::random_int<int>(0, 1000000), test_util::random_int<int>(0, 1000000000));
-}
+template<> bool generate_value() { return test_util::random_int<int>() & 0x1; }
+template<> float generate_value() { return float(1.0 * test_util::random_int<int>() / (test_util::random_int<int>(1, 1000))); }
+template<> double generate_value() { return 1.0 * test_util::random_int<int>() / (test_util::random_int<int>(1, 1000)); }
+template<> Timestamp generate_value() { return Timestamp(test_util::random_int<int>(0, 1000000), test_util::random_int<int>(0, 1000000000)); }
 template <>
 Decimal128 generate_value()
 {
@@ -5201,8 +5190,7 @@ TEST(Table_Column_Conversions)
 
 }
 */
-TEST(Table_MultipleObjs)
-{
+TEST(Table_MultipleObjs) {
     SHARED_GROUP_TEST_PATH(path);
 
     std::unique_ptr<Replication> hist(make_in_realm_history(path));


### PR DESCRIPTION
This adds a benchmark to the test suite for various ways of getting an integer from an object.

This is intended to demonstrate the performance difference between getting an integer directly with `Obj::get<int64_t>(col)` (returning `int64_t`) and getting a type-erased integer with `Obj::get_any(col)` (returning `Mixed`). For comparison, the low-level private function `Obj::_get<int64_t>()` is also benchmarked.

Output on my machine (AMD Ryzen 9 3950X, running Ubuntu 20.04.1 under WSL2, Clang 10 without LTO):

```
100000 Obj::get_any()
   result: 12312300000
   get time: 11 ns/op
100000 Obj::get<int64_t>()
   result: 12312300000
   get time: 10 ns/op
100000 Obj::_get<int64_t>()
   result: 12312300000
   get time: 5 ns/op
```