### PR TITLE
Don’t build exec targets in LIB_ONLY builds

### DIFF
--- a/src/realm/CMakeLists.txt
+++ b/src/realm/CMakeLists.txt
@@ -336,8 +336,10 @@ install(FILES ${PROJECT_BINARY_DIR}/src/realm/util/config.h
         COMPONENT devel)
 
 add_subdirectory(parser)
-add_subdirectory(exec)
 add_subdirectory(object-store)
 if (REALM_ENABLE_SYNC)
     add_subdirectory(sync)
+endif()
+if(NOT REALM_BUILD_LIB_ONLY)
+    add_subdirectory(exec)
 endif()

--- a/src/realm/exec/CMakeLists.txt
+++ b/src/realm/exec/CMakeLists.txt
@@ -1,5 +1,5 @@
 
-if(NOT APPLE AND NOT ANDROID AND NOT CMAKE_SYSTEM_NAME MATCHES "^Windows" AND NOT REALM_BUILD_LIB_ONLY)
+if(NOT APPLE AND NOT ANDROID AND NOT CMAKE_SYSTEM_NAME MATCHES "^Windows")
     # FIXME add_executable(RealmImporter importer_tool.cpp importer.cpp importer.hpp)
     # set_target_properties(RealmImporter PROPERTIES
     #     OUTPUT_NAME "realm-importer"


### PR DESCRIPTION
The SDKs don't need those targets when using Core as a submodule.