### PR TITLE
Package monorepo as xcframework

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -219,7 +219,6 @@ jobWrapper {
                         for (cocoaStash in cocoaStashes) {
                             unstash name: cocoaStash
                         }
-                        sh 'tools/build-cocoa.sh'
                         sh 'tools/build-cocoa.sh -x'
                         archiveArtifacts('realm-*-cocoa*.tar.gz')
                         archiveArtifacts('realm-*-cocoa*.tar.xz')

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -52,10 +52,10 @@ jobWrapper {
         releaseTesting = targetBranch.contains('release')
         isMaster = currentBranch.contains('master')
         longRunningTests = isMaster || currentBranch.contains('next-major')
-        isPublishingRun = false
-        if (gitTag) {
-            isPublishingRun = currentBranch.contains('release')
-        }
+        isPublishingRun = true//false
+        // if (gitTag) {
+        //     isPublishingRun = currentBranch.contains('release')
+        // }
 
         echo "Pull request: ${isPullRequest ? 'yes' : 'no'}"
         echo "Release Run: ${releaseTesting ? 'yes' : 'no'}"
@@ -95,61 +95,61 @@ jobWrapper {
         }
     }
 
-    stage('Checking') {
-        def buildOptions = [
-            buildType : "Debug",
-            maxBpNodeSize: "1000",
-            enableEncryption: "ON",
-            enableSync: "OFF",
-            runTests: true,
-        ]
-        def linuxOptionsNoEncrypt = [
-            buildType : "Debug",
-            maxBpNodeSize: "4",
-            enableEncryption: "OFF",
-            enableSync: "OFF",
-        ]
-        def armhfQemuTestOptions = [
-            emulator: 'LD_LIBRARY_PATH=/usr/arm-linux-gnueabihf/lib qemu-arm -cpu cortex-a7',
-        ]
-        def armhfNativeTestOptions = [
-            nativeNode: 'docker-arm',
-            nativeDocker: 'armhf-native.Dockerfile',
-            nativeDockerPlatform: 'linux/arm/v7',
-        ]
+    // stage('Checking') {
+    //     def buildOptions = [
+    //         buildType : "Debug",
+    //         maxBpNodeSize: "1000",
+    //         enableEncryption: "ON",
+    //         enableSync: "OFF",
+    //         runTests: true,
+    //     ]
+    //     def linuxOptionsNoEncrypt = [
+    //         buildType : "Debug",
+    //         maxBpNodeSize: "4",
+    //         enableEncryption: "OFF",
+    //         enableSync: "OFF",
+    //     ]
+    //     def armhfQemuTestOptions = [
+    //         emulator: 'LD_LIBRARY_PATH=/usr/arm-linux-gnueabihf/lib qemu-arm -cpu cortex-a7',
+    //     ]
+    //     def armhfNativeTestOptions = [
+    //         nativeNode: 'docker-arm',
+    //         nativeDocker: 'armhf-native.Dockerfile',
+    //         nativeDockerPlatform: 'linux/arm/v7',
+    //     ]
 
-        parallelExecutors = [
-            checkLinuxDebug         : doCheckInDocker(buildOptions),
-            checkLinuxRelease_4     : doCheckInDocker(buildOptions + [maxBpNodeSize: "4", buildType : "Release"]),
-            checkLinuxDebug_Sync    : doCheckInDocker(buildOptions + [enableSync : "ON"]),
-            checkLinuxDebugNoEncryp : doCheckInDocker(buildOptions + [enableEncryption: "OFF"]),
-            checkMacOsRelease_Sync  : doBuildMacOs(buildOptions + [buildType : "Release", enableSync : "ON"]),
-            checkWindows_x86_Release: doBuildWindows('Release', false, 'Win32', true),
-            checkWindows_x64_Debug  : doBuildWindows('Debug', false, 'x64', true),
-            buildUWP_x86_Release    : doBuildWindows('Release', true, 'Win32', false),
-            buildUWP_ARM_Debug      : doBuildWindows('Debug', true, 'ARM', false),
-            buildiosDebug           : doBuildAppleDevice('iphoneos', 'MinSizeDebug'),
-            buildandroidArm64Debug  : doAndroidBuildInDocker('arm64-v8a', 'Debug', false),
-            checkRaspberryPiQemu    : doLinuxCrossCompile('armhf', 'Debug', armhfQemuTestOptions),
-            checkRaspberryPiNative  : doLinuxCrossCompile('armhf', 'Debug', armhfNativeTestOptions),
-            threadSanitizer         : doCheckSanity(buildOptions + [enableSync : "ON", sanitizeMode : "thread"]),
-            addressSanitizer        : doCheckSanity(buildOptions + [enableSync : "ON", sanitizeMode : "address"]),
-            performance             : optionalBuildPerformance(releaseTesting), // always build performance on releases, otherwise make it optional
-        ]
-        if (releaseTesting) {
-            extendedChecks = [
-                checkRaspberryPiQemuRelease   : doLinuxCrossCompile('armhf', 'Release', armhfQemuTestOptions),
-                checkRaspberryPiNativeRelease : doLinuxCrossCompile('armhf', 'Release', armhfNativeTestOptions),
-                checkMacOsDebug               : doBuildMacOs('Debug', true),
-                buildUWP_x64_Debug            : doBuildWindows('Debug', true, 'x64', false),
-                androidArmeabiRelease         : doAndroidBuildInDocker('armeabi-v7a', 'Release', true),
-                coverage                      : doBuildCoverage(),
-                // valgrind                : doCheckValgrind()
-            ]
-            parallelExecutors.putAll(extendedChecks)
-        }
-        parallel parallelExecutors
-    }
+    //     parallelExecutors = [
+    //         checkLinuxDebug         : doCheckInDocker(buildOptions),
+    //         checkLinuxRelease_4     : doCheckInDocker(buildOptions + [maxBpNodeSize: "4", buildType : "Release"]),
+    //         checkLinuxDebug_Sync    : doCheckInDocker(buildOptions + [enableSync : "ON"]),
+    //         checkLinuxDebugNoEncryp : doCheckInDocker(buildOptions + [enableEncryption: "OFF"]),
+    //         checkMacOsRelease_Sync  : doBuildMacOs(buildOptions + [buildType : "Release", enableSync : "ON"]),
+    //         checkWindows_x86_Release: doBuildWindows('Release', false, 'Win32', true),
+    //         checkWindows_x64_Debug  : doBuildWindows('Debug', false, 'x64', true),
+    //         buildUWP_x86_Release    : doBuildWindows('Release', true, 'Win32', false),
+    //         buildUWP_ARM_Debug      : doBuildWindows('Debug', true, 'ARM', false),
+    //         buildiosDebug           : doBuildAppleDevice('iphoneos', 'MinSizeDebug'),
+    //         buildandroidArm64Debug  : doAndroidBuildInDocker('arm64-v8a', 'Debug', false),
+    //         checkRaspberryPiQemu    : doLinuxCrossCompile('armhf', 'Debug', armhfQemuTestOptions),
+    //         checkRaspberryPiNative  : doLinuxCrossCompile('armhf', 'Debug', armhfNativeTestOptions),
+    //         threadSanitizer         : doCheckSanity(buildOptions + [enableSync : "ON", sanitizeMode : "thread"]),
+    //         addressSanitizer        : doCheckSanity(buildOptions + [enableSync : "ON", sanitizeMode : "address"]),
+    //         performance             : optionalBuildPerformance(releaseTesting), // always build performance on releases, otherwise make it optional
+    //     ]
+    //     if (releaseTesting) {
+    //         extendedChecks = [
+    //             checkRaspberryPiQemuRelease   : doLinuxCrossCompile('armhf', 'Release', armhfQemuTestOptions),
+    //             checkRaspberryPiNativeRelease : doLinuxCrossCompile('armhf', 'Release', armhfNativeTestOptions),
+    //             checkMacOsDebug               : doBuildMacOs('Debug', true),
+    //             buildUWP_x64_Debug            : doBuildWindows('Debug', true, 'x64', false),
+    //             androidArmeabiRelease         : doAndroidBuildInDocker('armeabi-v7a', 'Release', true),
+    //             coverage                      : doBuildCoverage(),
+    //             // valgrind                : doCheckValgrind()
+    //         ]
+    //         parallelExecutors.putAll(extendedChecks)
+    //     }
+    //     parallel parallelExecutors
+    // }
 
     if (isPublishingRun) {
         stage('BuildPackages') {
@@ -168,14 +168,14 @@ jobWrapper {
                 buildLinuxTSAN      : doBuildLinuxClang("RelTSAN")
             ]
 
-            androidAbis = ['armeabi-v7a', 'x86', 'x86_64', 'arm64-v8a']
-            androidBuildTypes = ['Debug', 'Release']
+            // androidAbis = ['armeabi-v7a', 'x86', 'x86_64', 'arm64-v8a']
+            // androidBuildTypes = ['Debug', 'Release']
 
-            for (abi in androidAbis) {
-                for (buildType in androidBuildTypes) {
-                    parallelExecutors["android-${abi}-${buildType}"] = doAndroidBuildInDocker(abi, buildType, false)
-                }
-            }
+            // for (abi in androidAbis) {
+            //     for (buildType in androidBuildTypes) {
+            //         parallelExecutors["android-${abi}-${buildType}"] = doAndroidBuildInDocker(abi, buildType, false)
+            //     }
+            // }
 
             appleSdks = ['iphoneos', 'iphonesimulator',
                          'appletvos', 'appletvsimulator',
@@ -188,26 +188,26 @@ jobWrapper {
                 }
             }
 
-            linuxBuildTypes = ['Debug', 'Release', 'RelAssert']
-            linuxCrossCompileTargets = ['armhf']
+            // linuxBuildTypes = ['Debug', 'Release', 'RelAssert']
+            // linuxCrossCompileTargets = ['armhf']
 
-            for (buildType in linuxBuildTypes) {
-                parallelExecutors["buildLinux${buildType}"] = doBuildLinux(buildType)
-                for (target in linuxCrossCompileTargets) {
-                    parallelExecutors["crossCompileLinux-${target}-${buildType}"] = doLinuxCrossCompile(target, buildType)
-                }
-            }
+            // for (buildType in linuxBuildTypes) {
+            //     parallelExecutors["buildLinux${buildType}"] = doBuildLinux(buildType)
+            //     for (target in linuxCrossCompileTargets) {
+            //         parallelExecutors["crossCompileLinux-${target}-${buildType}"] = doLinuxCrossCompile(target, buildType)
+            //     }
+            // }
 
-            windowsBuildTypes = ['Debug', 'Release']
-            windowsPlatforms = ['Win32', 'x64']
+            // windowsBuildTypes = ['Debug', 'Release']
+            // windowsPlatforms = ['Win32', 'x64']
 
-            for (buildType in windowsBuildTypes) {
-                for (platform in windowsPlatforms) {
-                    parallelExecutors["buildWindows-${platform}-${buildType}"] = doBuildWindows(buildType, false, platform, false)
-                    parallelExecutors["buildWindowsUniversal-${platform}-${buildType}"] = doBuildWindows(buildType, true, platform, false)
-                }
-                parallelExecutors["buildWindowsUniversal-ARM-${buildType}"] = doBuildWindows(buildType, true, 'ARM', false)
-            }
+            // for (buildType in windowsBuildTypes) {
+            //     for (platform in windowsPlatforms) {
+            //         parallelExecutors["buildWindows-${platform}-${buildType}"] = doBuildWindows(buildType, false, platform, false)
+            //         parallelExecutors["buildWindowsUniversal-${platform}-${buildType}"] = doBuildWindows(buildType, true, platform, false)
+            //     }
+            //     parallelExecutors["buildWindowsUniversal-ARM-${buildType}"] = doBuildWindows(buildType, true, 'ARM', false)
+            // }
 
             parallel parallelExecutors
         }
@@ -228,20 +228,20 @@ jobWrapper {
                         publishingStashes << "cocoa-xz"
                         publishingStashes << "cocoa-gz"
                     }
-                },
-                android: {
-                    node('docker') {
-                        getArchive()
-                        for (androidStash in androidStashes) {
-                            unstash name: androidStash
-                        }
-                        sh 'tools/build-android.sh'
-                        archiveArtifacts('realm-core-android*.tar.gz')
-                        def stashName = 'android'
-                        stash includes: 'realm-core-android*.tar.gz', name: stashName
-                        publishingStashes << stashName
-                    }
-                }
+                }//,
+                // android: {
+                //     node('docker') {
+                //         getArchive()
+                //         for (androidStash in androidStashes) {
+                //             unstash name: androidStash
+                //         }
+                //         sh 'tools/build-android.sh'
+                //         archiveArtifacts('realm-core-android*.tar.gz')
+                //         def stashName = 'android'
+                //         stash includes: 'realm-core-android*.tar.gz', name: stashName
+                //         publishingStashes << stashName
+                //     }
+                // }
             )
         }
         stage('publish-packages') {

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -52,10 +52,10 @@ jobWrapper {
         releaseTesting = targetBranch.contains('release')
         isMaster = currentBranch.contains('master')
         longRunningTests = isMaster || currentBranch.contains('next-major')
-        isPublishingRun = true//false
-        // if (gitTag) {
-        //     isPublishingRun = currentBranch.contains('release')
-        // }
+        isPublishingRun = false
+        if (gitTag) {
+            isPublishingRun = currentBranch.contains('release')
+        }
 
         echo "Pull request: ${isPullRequest ? 'yes' : 'no'}"
         echo "Release Run: ${releaseTesting ? 'yes' : 'no'}"
@@ -95,61 +95,61 @@ jobWrapper {
         }
     }
 
-    // stage('Checking') {
-    //     def buildOptions = [
-    //         buildType : "Debug",
-    //         maxBpNodeSize: "1000",
-    //         enableEncryption: "ON",
-    //         enableSync: "OFF",
-    //         runTests: true,
-    //     ]
-    //     def linuxOptionsNoEncrypt = [
-    //         buildType : "Debug",
-    //         maxBpNodeSize: "4",
-    //         enableEncryption: "OFF",
-    //         enableSync: "OFF",
-    //     ]
-    //     def armhfQemuTestOptions = [
-    //         emulator: 'LD_LIBRARY_PATH=/usr/arm-linux-gnueabihf/lib qemu-arm -cpu cortex-a7',
-    //     ]
-    //     def armhfNativeTestOptions = [
-    //         nativeNode: 'docker-arm',
-    //         nativeDocker: 'armhf-native.Dockerfile',
-    //         nativeDockerPlatform: 'linux/arm/v7',
-    //     ]
+    stage('Checking') {
+        def buildOptions = [
+            buildType : "Debug",
+            maxBpNodeSize: "1000",
+            enableEncryption: "ON",
+            enableSync: "OFF",
+            runTests: true,
+        ]
+        def linuxOptionsNoEncrypt = [
+            buildType : "Debug",
+            maxBpNodeSize: "4",
+            enableEncryption: "OFF",
+            enableSync: "OFF",
+        ]
+        def armhfQemuTestOptions = [
+            emulator: 'LD_LIBRARY_PATH=/usr/arm-linux-gnueabihf/lib qemu-arm -cpu cortex-a7',
+        ]
+        def armhfNativeTestOptions = [
+            nativeNode: 'docker-arm',
+            nativeDocker: 'armhf-native.Dockerfile',
+            nativeDockerPlatform: 'linux/arm/v7',
+        ]
 
-    //     parallelExecutors = [
-    //         checkLinuxDebug         : doCheckInDocker(buildOptions),
-    //         checkLinuxRelease_4     : doCheckInDocker(buildOptions + [maxBpNodeSize: "4", buildType : "Release"]),
-    //         checkLinuxDebug_Sync    : doCheckInDocker(buildOptions + [enableSync : "ON"]),
-    //         checkLinuxDebugNoEncryp : doCheckInDocker(buildOptions + [enableEncryption: "OFF"]),
-    //         checkMacOsRelease_Sync  : doBuildMacOs(buildOptions + [buildType : "Release", enableSync : "ON"]),
-    //         checkWindows_x86_Release: doBuildWindows('Release', false, 'Win32', true),
-    //         checkWindows_x64_Debug  : doBuildWindows('Debug', false, 'x64', true),
-    //         buildUWP_x86_Release    : doBuildWindows('Release', true, 'Win32', false),
-    //         buildUWP_ARM_Debug      : doBuildWindows('Debug', true, 'ARM', false),
-    //         buildiosDebug           : doBuildAppleDevice('iphoneos', 'MinSizeDebug'),
-    //         buildandroidArm64Debug  : doAndroidBuildInDocker('arm64-v8a', 'Debug', false),
-    //         checkRaspberryPiQemu    : doLinuxCrossCompile('armhf', 'Debug', armhfQemuTestOptions),
-    //         checkRaspberryPiNative  : doLinuxCrossCompile('armhf', 'Debug', armhfNativeTestOptions),
-    //         threadSanitizer         : doCheckSanity(buildOptions + [enableSync : "ON", sanitizeMode : "thread"]),
-    //         addressSanitizer        : doCheckSanity(buildOptions + [enableSync : "ON", sanitizeMode : "address"]),
-    //         performance             : optionalBuildPerformance(releaseTesting), // always build performance on releases, otherwise make it optional
-    //     ]
-    //     if (releaseTesting) {
-    //         extendedChecks = [
-    //             checkRaspberryPiQemuRelease   : doLinuxCrossCompile('armhf', 'Release', armhfQemuTestOptions),
-    //             checkRaspberryPiNativeRelease : doLinuxCrossCompile('armhf', 'Release', armhfNativeTestOptions),
-    //             checkMacOsDebug               : doBuildMacOs('Debug', true),
-    //             buildUWP_x64_Debug            : doBuildWindows('Debug', true, 'x64', false),
-    //             androidArmeabiRelease         : doAndroidBuildInDocker('armeabi-v7a', 'Release', true),
-    //             coverage                      : doBuildCoverage(),
-    //             // valgrind                : doCheckValgrind()
-    //         ]
-    //         parallelExecutors.putAll(extendedChecks)
-    //     }
-    //     parallel parallelExecutors
-    // }
+        parallelExecutors = [
+            checkLinuxDebug         : doCheckInDocker(buildOptions),
+            checkLinuxRelease_4     : doCheckInDocker(buildOptions + [maxBpNodeSize: "4", buildType : "Release"]),
+            checkLinuxDebug_Sync    : doCheckInDocker(buildOptions + [enableSync : "ON"]),
+            checkLinuxDebugNoEncryp : doCheckInDocker(buildOptions + [enableEncryption: "OFF"]),
+            checkMacOsRelease_Sync  : doBuildMacOs(buildOptions + [buildType : "Release", enableSync : "ON"]),
+            checkWindows_x86_Release: doBuildWindows('Release', false, 'Win32', true),
+            checkWindows_x64_Debug  : doBuildWindows('Debug', false, 'x64', true),
+            buildUWP_x86_Release    : doBuildWindows('Release', true, 'Win32', false),
+            buildUWP_ARM_Debug      : doBuildWindows('Debug', true, 'ARM', false),
+            buildiosDebug           : doBuildAppleDevice('iphoneos', 'MinSizeDebug'),
+            buildandroidArm64Debug  : doAndroidBuildInDocker('arm64-v8a', 'Debug', false),
+            checkRaspberryPiQemu    : doLinuxCrossCompile('armhf', 'Debug', armhfQemuTestOptions),
+            checkRaspberryPiNative  : doLinuxCrossCompile('armhf', 'Debug', armhfNativeTestOptions),
+            threadSanitizer         : doCheckSanity(buildOptions + [enableSync : "ON", sanitizeMode : "thread"]),
+            addressSanitizer        : doCheckSanity(buildOptions + [enableSync : "ON", sanitizeMode : "address"]),
+            performance             : optionalBuildPerformance(releaseTesting), // always build performance on releases, otherwise make it optional
+        ]
+        if (releaseTesting) {
+            extendedChecks = [
+                checkRaspberryPiQemuRelease   : doLinuxCrossCompile('armhf', 'Release', armhfQemuTestOptions),
+                checkRaspberryPiNativeRelease : doLinuxCrossCompile('armhf', 'Release', armhfNativeTestOptions),
+                checkMacOsDebug               : doBuildMacOs('Debug', true),
+                buildUWP_x64_Debug            : doBuildWindows('Debug', true, 'x64', false),
+                androidArmeabiRelease         : doAndroidBuildInDocker('armeabi-v7a', 'Release', true),
+                coverage                      : doBuildCoverage(),
+                // valgrind                : doCheckValgrind()
+            ]
+            parallelExecutors.putAll(extendedChecks)
+        }
+        parallel parallelExecutors
+    }
 
     if (isPublishingRun) {
         stage('BuildPackages') {
@@ -168,14 +168,14 @@ jobWrapper {
                 buildLinuxTSAN      : doBuildLinuxClang("RelTSAN")
             ]
 
-            // androidAbis = ['armeabi-v7a', 'x86', 'x86_64', 'arm64-v8a']
-            // androidBuildTypes = ['Debug', 'Release']
+            androidAbis = ['armeabi-v7a', 'x86', 'x86_64', 'arm64-v8a']
+            androidBuildTypes = ['Debug', 'Release']
 
-            // for (abi in androidAbis) {
-            //     for (buildType in androidBuildTypes) {
-            //         parallelExecutors["android-${abi}-${buildType}"] = doAndroidBuildInDocker(abi, buildType, false)
-            //     }
-            // }
+            for (abi in androidAbis) {
+                for (buildType in androidBuildTypes) {
+                    parallelExecutors["android-${abi}-${buildType}"] = doAndroidBuildInDocker(abi, buildType, false)
+                }
+            }
 
             appleSdks = ['iphoneos', 'iphonesimulator',
                          'appletvos', 'appletvsimulator',
@@ -188,26 +188,26 @@ jobWrapper {
                 }
             }
 
-            // linuxBuildTypes = ['Debug', 'Release', 'RelAssert']
-            // linuxCrossCompileTargets = ['armhf']
+            linuxBuildTypes = ['Debug', 'Release', 'RelAssert']
+            linuxCrossCompileTargets = ['armhf']
 
-            // for (buildType in linuxBuildTypes) {
-            //     parallelExecutors["buildLinux${buildType}"] = doBuildLinux(buildType)
-            //     for (target in linuxCrossCompileTargets) {
-            //         parallelExecutors["crossCompileLinux-${target}-${buildType}"] = doLinuxCrossCompile(target, buildType)
-            //     }
-            // }
+            for (buildType in linuxBuildTypes) {
+                parallelExecutors["buildLinux${buildType}"] = doBuildLinux(buildType)
+                for (target in linuxCrossCompileTargets) {
+                    parallelExecutors["crossCompileLinux-${target}-${buildType}"] = doLinuxCrossCompile(target, buildType)
+                }
+            }
 
-            // windowsBuildTypes = ['Debug', 'Release']
-            // windowsPlatforms = ['Win32', 'x64']
+            windowsBuildTypes = ['Debug', 'Release']
+            windowsPlatforms = ['Win32', 'x64']
 
-            // for (buildType in windowsBuildTypes) {
-            //     for (platform in windowsPlatforms) {
-            //         parallelExecutors["buildWindows-${platform}-${buildType}"] = doBuildWindows(buildType, false, platform, false)
-            //         parallelExecutors["buildWindowsUniversal-${platform}-${buildType}"] = doBuildWindows(buildType, true, platform, false)
-            //     }
-            //     parallelExecutors["buildWindowsUniversal-ARM-${buildType}"] = doBuildWindows(buildType, true, 'ARM', false)
-            // }
+            for (buildType in windowsBuildTypes) {
+                for (platform in windowsPlatforms) {
+                    parallelExecutors["buildWindows-${platform}-${buildType}"] = doBuildWindows(buildType, false, platform, false)
+                    parallelExecutors["buildWindowsUniversal-${platform}-${buildType}"] = doBuildWindows(buildType, true, platform, false)
+                }
+                parallelExecutors["buildWindowsUniversal-ARM-${buildType}"] = doBuildWindows(buildType, true, 'ARM', false)
+            }
 
             parallel parallelExecutors
         }
@@ -229,20 +229,20 @@ jobWrapper {
                         publishingStashes << "cocoa-gz"
                         publishingStashes << "monorepo-xcframework-zip"
                     }
-                }//,
-                // android: {
-                //     node('docker') {
-                //         getArchive()
-                //         for (androidStash in androidStashes) {
-                //             unstash name: androidStash
-                //         }
-                //         sh 'tools/build-android.sh'
-                //         archiveArtifacts('realm-core-android*.tar.gz')
-                //         def stashName = 'android'
-                //         stash includes: 'realm-core-android*.tar.gz', name: stashName
-                //         publishingStashes << stashName
-                //     }
-                // }
+                },
+                android: {
+                    node('docker') {
+                        getArchive()
+                        for (androidStash in androidStashes) {
+                            unstash name: androidStash
+                        }
+                        sh 'tools/build-android.sh'
+                        archiveArtifacts('realm-core-android*.tar.gz')
+                        def stashName = 'android'
+                        stash includes: 'realm-core-android*.tar.gz', name: stashName
+                        publishingStashes << stashName
+                    }
+                }
             )
         }
         stage('publish-packages') {

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -225,8 +225,10 @@ jobWrapper {
                         archiveArtifacts('realm-*-cocoa*.tar.xz')
                         stash includes: 'realm-*-cocoa*.tar.xz', name: "cocoa-xz"
                         stash includes: 'realm-*-cocoa*.tar.gz', name: "cocoa-gz"
+                        stash includes: "realm-monorepo*.xcframework.zip", name: "monorepo-xcframework-zip"
                         publishingStashes << "cocoa-xz"
                         publishingStashes << "cocoa-gz"
+                        publishingStashes << "monorepo-xcframework-zip"
                     }
                 }//,
                 // android: {

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -224,10 +224,8 @@ jobWrapper {
                         archiveArtifacts('realm-*-cocoa*.tar.xz')
                         stash includes: 'realm-*-cocoa*.tar.xz', name: "cocoa-xz"
                         stash includes: 'realm-*-cocoa*.tar.gz', name: "cocoa-gz"
-                        stash includes: "realm-monorepo*.xcframework.zip", name: "monorepo-xcframework-zip"
                         publishingStashes << "cocoa-xz"
                         publishingStashes << "cocoa-gz"
-                        publishingStashes << "monorepo-xcframework-zip"
                     }
                 },
                 android: {

--- a/src/realm/object-store/CMakeLists.txt
+++ b/src/realm/object-store/CMakeLists.txt
@@ -155,4 +155,12 @@ if(REALM_ENABLE_SYNC)
     # Add the sync libraries separately to reduce merge conflicts.
     target_link_libraries(ObjectStore PUBLIC Sync)
     target_compile_definitions(ObjectStore PUBLIC REALM_ENABLE_SYNC=1)
+
+    set_target_properties(ObjectStore PROPERTIES OUTPUT_NAME "realm-object-store")
+    install(FILES ${HEADERS}
+            DESTINATION include/realm/ObjectStore
+            COMPONENT devel)
+    install(TARGETS ObjectStore EXPORT realm
+            ARCHIVE DESTINATION lib
+            COMPONENT devel)
 endif()

--- a/src/realm/object-store/CMakeLists.txt
+++ b/src/realm/object-store/CMakeLists.txt
@@ -158,7 +158,7 @@ if(REALM_ENABLE_SYNC)
 
     set_target_properties(ObjectStore PROPERTIES OUTPUT_NAME "realm-object-store")
     install(FILES ${HEADERS}
-            DESTINATION include/realm/ObjectStore
+            DESTINATION include/realm/object-store
             COMPONENT devel)
     install(TARGETS ObjectStore EXPORT realm
             ARCHIVE DESTINATION lib

--- a/src/realm/object-store/CMakeLists.txt
+++ b/src/realm/object-store/CMakeLists.txt
@@ -39,8 +39,9 @@ set(HEADERS
     results.hpp
     schema.hpp
     shared_realm.hpp
-    thread_safe_reference.hpp
+    thread_safe_reference.hpp)
 
+set(IMPL_HEADERS
     impl/apple/external_commit_helper.hpp
     impl/apple/keychain_helper.hpp
     impl/epoll/external_commit_helper.hpp
@@ -56,8 +57,9 @@ set(HEADERS
     impl/realm_coordinator.hpp
     impl/results_notifier.hpp
     impl/transact_log_handler.hpp
-    impl/weak_realm_notifier.hpp
+    impl/weak_realm_notifier.hpp)
 
+set(UTIL_HEADERS
     util/android/scheduler.hpp
     util/apple/scheduler.hpp
     util/generic/scheduler.hpp
@@ -73,7 +75,7 @@ set(HEADERS
     util/uuid.hpp)
 
 if(REALM_ENABLE_SYNC)
-    list(APPEND HEADERS
+    set(SYNC_HEADERS
         sync/app.hpp
         sync/app_utils.hpp
         sync/app_credentials.hpp
@@ -87,10 +89,13 @@ if(REALM_ENABLE_SYNC)
         sync/remote_mongo_client.hpp
         sync/remote_mongo_collection.hpp
         sync/remote_mongo_database.hpp
-        sync/push_client.hpp
+        sync/push_client.hpp)
+    set(SYNC_IMPL_HEADERS
         sync/impl/sync_client.hpp
         sync/impl/sync_file.hpp
-        sync/impl/sync_metadata.hpp
+        sync/impl/sync_metadata.hpp)
+    
+    set(BSON_HEADERS
         util/bson/bson.hpp
         util/bson/min_key.hpp
         util/bson/max_key.hpp
@@ -160,7 +165,24 @@ if(REALM_ENABLE_SYNC)
     install(FILES ${HEADERS}
             DESTINATION include/realm/object-store
             COMPONENT devel)
-    install(TARGETS ObjectStore EXPORT realm
-            ARCHIVE DESTINATION lib
+    install(FILES ${IMPL_HEADERS}
+            DESTINATION include/realm/object-store/impl
             COMPONENT devel)
+    install(FILES ${UTIL_HEADERS}
+            DESTINATION include/realm/object-store/util
+            COMPONENT devel)
+    if(REALM_ENABLE_SYNC)
+        install(FILES ${SYNC_HEADERS}
+                DESTINATION include/realm/object-store/sync
+                COMPONENT devel)
+        install(FILES ${SYNC_IMPL_HEADERS}
+                DESTINATION include/realm/object-store/sync/impl
+                COMPONENT devel)
+        install(FILES ${BSON_HEADERS}
+                DESTINATION include/realm/object-store/util/bson
+                COMPONENT devel)
+    endif()
+    install(TARGETS ObjectStore EXPORT realm
+        ARCHIVE DESTINATION lib
+        COMPONENT devel)
 endif()

--- a/src/realm/sync/CMakeLists.txt
+++ b/src/realm/sync/CMakeLists.txt
@@ -175,6 +175,9 @@ install(FILES ${UTIL_METERED_INSTALL_HEADERS}
 install(FILES ../../external/mpark/variant.hpp
         DESTINATION include/external/mpark
         COMPONENT devel)
+install(FILES ../../external/json/json.hpp
+        DESTINATION include/external/json
+        COMPONENT devel)
 
 if(REALM_BUILD_COMMANDLINE_TOOLS)
     add_executable(SyncWorker server_command.cpp)

--- a/tools/build-cocoa.sh
+++ b/tools/build-cocoa.sh
@@ -34,9 +34,11 @@ done
 shift $((OPTIND-1))
 
 readonly BUILD_TYPES=( Release MinSizeDebug )
-[[ -z $MACOS_ONLY ]] && PLATFORMS=( macosx maccatalyst iphoneos iphonesimulator watchos watchsimulator appletvos appletvsimulator ) || PLATFORMS=( macosx )
+# [[ -z $MACOS_ONLY ]] && PLATFORMS=( macosx maccatalyst iphoneos iphonesimulator watchos watchsimulator appletvos appletvsimulator ) || PLATFORMS=( macosx )
+[[ -z $MACOS_ONLY ]] && PLATFORMS=( macosx maccatalyst iphoneos iphonesimulator ) || PLATFORMS=( macosx )
 
-readonly device_platforms=( iphoneos iphonesimulator watchos watchsimulator appletvos appletvsimulator )
+# readonly device_platforms=( iphoneos iphonesimulator watchos watchsimulator appletvos appletvsimulator )
+readonly device_platforms=( iphoneos iphonesimulator )
 
 function build_macos {
     local platform="$1"
@@ -179,8 +181,8 @@ for bt in "${BUILD_TYPES[@]}"; do
 
     # merge the libraries for other Apple platforms
     combine_libraries "iphoneos${suffix}" "iphonesimulator${suffix}" "ios${suffix}"
-    combine_libraries "watchos${suffix}" "watchsimulator${suffix}" "watchos${suffix}"
-    combine_libraries "appletvos${suffix}" "appletvsimulator${suffix}" "tvos${suffix}"
+    # combine_libraries "watchos${suffix}" "watchsimulator${suffix}" "watchos${suffix}"
+    # combine_libraries "appletvos${suffix}" "appletvsimulator${suffix}" "tvos${suffix}"
     fi
 done
 
@@ -258,10 +260,10 @@ EOF
             add_to_xcframework "$xcf" "$library" "ios" "iphoneos" "$bt"
             add_to_xcframework "$xcf" "$library" "ios" "iphonesimulator" "$bt"
             add_to_xcframework "$xcf" "$library" "ios" "maccatalyst" "$bt"
-            add_to_xcframework "$xcf" "$library" "watchos" "watchos" "$bt"
-            add_to_xcframework "$xcf" "$library" "watchos" "watchsimulator" "$bt"
-            add_to_xcframework "$xcf" "$library" "tvos" "appletvos" "$bt"
-            add_to_xcframework "$xcf" "$library" "tvos" "appletvsimulator" "$bt"
+            # add_to_xcframework "$xcf" "$library" "watchos" "watchos" "$bt"
+            # add_to_xcframework "$xcf" "$library" "watchos" "watchsimulator" "$bt"
+            # add_to_xcframework "$xcf" "$library" "tvos" "appletvos" "$bt"
+            # add_to_xcframework "$xcf" "$library" "tvos" "appletvsimulator" "$bt"
         fi
 
         cat << EOF >> "$xcf/Info.plist"

--- a/tools/build-cocoa.sh
+++ b/tools/build-cocoa.sh
@@ -34,11 +34,9 @@ done
 shift $((OPTIND-1))
 
 readonly BUILD_TYPES=( Release MinSizeDebug )
-# [[ -z $MACOS_ONLY ]] && PLATFORMS=( macosx maccatalyst iphoneos iphonesimulator watchos watchsimulator appletvos appletvsimulator ) || PLATFORMS=( macosx )
-[[ -z $MACOS_ONLY ]] && PLATFORMS=( macosx maccatalyst iphoneos iphonesimulator ) || PLATFORMS=( macosx )
+[[ -z $MACOS_ONLY ]] && PLATFORMS=( macosx maccatalyst iphoneos iphonesimulator watchos watchsimulator appletvos appletvsimulator ) || PLATFORMS=( macosx )
 
-# readonly device_platforms=( iphoneos iphonesimulator watchos watchsimulator appletvos appletvsimulator )
-readonly device_platforms=( iphoneos iphonesimulator )
+readonly device_platforms=( iphoneos iphonesimulator watchos watchsimulator appletvos appletvsimulator )
 
 function build_macos {
     local platform="$1"
@@ -181,8 +179,8 @@ for bt in "${BUILD_TYPES[@]}"; do
 
     # merge the libraries for other Apple platforms
     combine_libraries "iphoneos${suffix}" "iphonesimulator${suffix}" "ios${suffix}"
-    # combine_libraries "watchos${suffix}" "watchsimulator${suffix}" "watchos${suffix}"
-    # combine_libraries "appletvos${suffix}" "appletvsimulator${suffix}" "tvos${suffix}"
+    combine_libraries "watchos${suffix}" "watchsimulator${suffix}" "watchos${suffix}"
+    combine_libraries "appletvos${suffix}" "appletvsimulator${suffix}" "tvos${suffix}"
     fi
 done
 
@@ -260,10 +258,10 @@ EOF
             add_to_xcframework "$xcf" "$library" "ios" "iphoneos" "$bt"
             add_to_xcframework "$xcf" "$library" "ios" "iphonesimulator" "$bt"
             add_to_xcframework "$xcf" "$library" "ios" "maccatalyst" "$bt"
-            # add_to_xcframework "$xcf" "$library" "watchos" "watchos" "$bt"
-            # add_to_xcframework "$xcf" "$library" "watchos" "watchsimulator" "$bt"
-            # add_to_xcframework "$xcf" "$library" "tvos" "appletvos" "$bt"
-            # add_to_xcframework "$xcf" "$library" "tvos" "appletvsimulator" "$bt"
+            add_to_xcframework "$xcf" "$library" "watchos" "watchos" "$bt"
+            add_to_xcframework "$xcf" "$library" "watchos" "watchsimulator" "$bt"
+            add_to_xcframework "$xcf" "$library" "tvos" "appletvos" "$bt"
+            add_to_xcframework "$xcf" "$library" "tvos" "appletvsimulator" "$bt"
         fi
 
         cat << EOF >> "$xcf/Info.plist"

--- a/tools/build-cocoa.sh
+++ b/tools/build-cocoa.sh
@@ -296,16 +296,23 @@ if [[ -n $COPY ]]; then
     fi
 else
     rm -f "realm-monorepo-cocoa-${VERSION}.tar.xz"
-    rm -f "realm-parser-cocoa-${VERSION}.tar.xz"
     # .tar.gz package is used by realm-js, which uses the parser
     tar -czvf "realm-monorepo-cocoa-${VERSION}.tar.gz" --exclude "realm-monorepo*.xcframework" core
     # .tar.xz package is used by cocoa, which doesn't use the parser
     tar -cJvf "realm-monorepo-cocoa-${VERSION}.tar.xz" --exclude "realm-monorepo*.xcframework" core
-    tar -cJvf "realm-parser-cocoa-${VERSION}.tar.xz" core/realm-parser*.xcframework
 
     if [[ ! -z $BUILD_XCFRAMEWORK ]]; then
+        rm -f "realm-parser-cocoa-${VERSION}.tar.xz"
+        tar -cJvf "realm-parser-cocoa-${VERSION}.tar.xz" core/realm-parser*.xcframework
         rm -f "realm-monorepo-xcframework-${VERSION}.tar.xz"
         # until realmjs requires an xcframework, only package as .xz
         tar -cJvf "realm-monorepo-xcframework-${VERSION}.tar.xz" core/realm-monorepo.xcframework core/realm-monorepo-dbg.xcframework
+
+        # Swift Package Manager only supports a zip containing only the xcframework
+        (
+            cd core
+            cp -R realm-monorepo.xcframework RealmMonorepo.xcframework
+            zip -r "../realm-monorepo-${VERSION}.xcframework.zip" RealmMonorepo.xcframework
+        )
     fi
 fi

--- a/tools/build-cocoa.sh
+++ b/tools/build-cocoa.sh
@@ -45,7 +45,7 @@ function build_macos {
     mkdir -p "${folder_name}"
     (
         cd "${folder_name}" || exit 1
-        rm -f realm-core-*-devel.tar.gz
+        rm -f realm-*-devel.tar.gz
         cmake -D CMAKE_TOOLCHAIN_FILE="../tools/cmake/$platform.toolchain.cmake" \
               -D CMAKE_BUILD_TYPE="${bt}" \
               -D REALM_VERSION="${VERSION}" \
@@ -76,7 +76,7 @@ fi
 rm -rf core
 mkdir core
 
-filename="build-macosx-Release/realm-core-Release-${VERSION}-macosx-devel.tar.gz"
+filename="build-macosx-Release/realm-Release-${VERSION}-macosx-devel.tar.gz"
 tar -C core -zxvf "${filename}" include doc
 
 # Overwrite version.txt
@@ -91,39 +91,98 @@ function combine_libraries {
     # can't have two arm64 slices in the universal library
     lipo "core/librealm-${simulator_suffix}.a" -remove arm64 -output "core/librealm-${simulator_suffix}.a" || true
     lipo "core/librealm-parser-${simulator_suffix}.a" -remove arm64 -output "core/librealm-parser-${simulator_suffix}.a" || true
+    lipo "core/librealm-sync-${simulator_suffix}.a" -remove arm64 -output "core/librealm-sync-${simulator_suffix}.a" || true
+    lipo "core/librealm-object-store-${simulator_suffix}.a" -remove arm64 -output "core/librealm-object-store-${simulator_suffix}.a" || true
 
+    # core
     lipo "core/librealm-${device_suffix}.a" \
          "core/librealm-${simulator_suffix}.a" \
-         -create -output "out/librealm-${output_suffisx}.a"
+         -create -output "core/librealm-${output_suffix}.a"
+    # parser
     lipo "core/librealm-parser-${device_suffix}.a" \
          "core/librealm-parser-${simulator_suffix}.a" \
-         -create -output "out/librealm-parser-${output_suffix}.a"
+         -create -output "core/librealm-parser-${output_suffix}.a"
+    # sync
+    lipo "core/librealm-sync-${device_suffix}.a" \
+         "core/librealm-sync-${simulator_suffix}.a" \
+         -create -output "core/librealm-sync-${output_suffix}.a"
+    # object store
+    lipo "core/librealm-object-store-${device_suffix}.a" \
+         "core/librealm-object-store-${simulator_suffix}.a" \
+         -create -output "core/librealm-object-store-${output_suffix}.a"
+
+    # Merge the core, sync & object store libraries together
+    libtool -static -o core/librealm-monorepo-${device_suffix}.a \
+      core/librealm-${device_suffix}.a \
+      core/librealm-sync-${device_suffix}.a \
+      core/librealm-object-store-${device_suffix}.a
+
+    libtool -static -o core/librealm-monorepo-${simulator_suffix}.a \
+      core/librealm-${simulator_suffix}.a \
+      core/librealm-sync-${simulator_suffix}.a \
+      core/librealm-object-store-${simulator_suffix}.a
+    # remove the now merged libraries, but leave the parser
+    rm -f core/librealm-${simulator_suffix}.a
+    rm -f core/librealm-${device_suffix}.a
+    rm -f core/librealm-${output_suffix}.a
+    rm -f core/librealm-sync-${simulator_suffix}.a
+    rm -f core/librealm-sync-${device_suffix}.a
+    rm -f core/librealm-sync-${output_suffix}.a
+    rm -f core/librealm-object-store-${simulator_suffix}.a
+    rm -f core/librealm-object-store-${device_suffix}.a
+    rm -f core/librealm-object-store-${output_suffix}.a
+}
+
+function combine_libraries_macos {
+    local build_type="$1"
+    # Merge the core, sync & object store libraries together
+    libtool -static -o core/librealm-monorepo-macosx${build_type}.a \
+      core/librealm-macosx${build_type}.a \
+      core/librealm-sync-macosx${build_type}.a \
+      core/librealm-object-store-macosx${build_type}.a
+    # remove the now merged libraries, but leave the parser
+    rm -f core/librealm-macosx${build_type}.a
+    rm -f core/librealm-sync-macosx${build_type}.a
+    rm -f core/librealm-object-store-macosx${build_type}.a
 }
 
 # Assemble the legacy fat libraries
 for bt in "${BUILD_TYPES[@]}"; do
     [[ "$bt" = "Release" ]] && suffix="" || suffix="-dbg"
     for p in "${PLATFORMS[@]}"; do
-        filename="build-${p}-${bt}/realm-core-${bt}-${VERSION}-${p}-devel.tar.gz"
+        filename="build-${p}-${bt}/realm-${bt}-${VERSION}-${p}-devel.tar.gz"
+        # core binary
         tar -C core -zxvf "${filename}" "lib/librealm${suffix}.a"
         mv "core/lib/librealm${suffix}.a" "core/librealm-${p}${suffix}.a"
+        # parser binary
         tar -C core -zxvf "${filename}" "lib/librealm-parser${suffix}.a"
         mv "core/lib/librealm-parser${suffix}.a" "core/librealm-parser-${p}${suffix}.a"
+        # sync binary
+        tar -C core -zxvf "${filename}" "lib/librealm-sync${suffix}.a"
+        mv "core/lib/librealm-sync${suffix}.a" "core/librealm-sync-${p}${suffix}.a"
+        # object store binary
+        tar -C core -zxvf "${filename}" "lib/librealm-object-store${suffix}.a"
+        mv "core/lib/librealm-object-store${suffix}.a" "core/librealm-object-store-${p}${suffix}.a"
+        rm -r "core/lib"
     done
 
-    mkdir -p out
-    mv core/librealm-macosx* out
-    mv core/librealm-parser-macosx* out
+    # merge the libraries for macos
+    combine_libraries_macos ${suffix}
+
     if [[ -z $MACOS_ONLY ]]; then
-        mv core/librealm-maccatalyst* out
-        combine_libraries "iphoneos${suffix}" "iphonesimulator${suffix}" "ios${suffix}"
-        combine_libraries "watchos${suffix}" "watchsimulator${suffix}" "watchos${suffix}"
-        combine_libraries "appletvos${suffix}" "appletvsimulator${suffix}" "tvos${suffix}"
+    # merge the libraries for maccatalyst
+    libtool -static -o core/librealm-monorepo-maccatalyst${suffix}.a \
+      core/librealm-maccatalyst${suffix}.a \
+      core/librealm-sync-maccatalyst${suffix}.a \
+      core/librealm-object-store-maccatalyst${suffix}.a
+    rm -f core/librealm-maccatalyst*.a
+
+    # merge the libraries for other Apple platforms
+    combine_libraries "iphoneos${suffix}" "iphonesimulator${suffix}" "ios${suffix}"
+    combine_libraries "watchos${suffix}" "watchsimulator${suffix}" "watchos${suffix}"
+    combine_libraries "appletvos${suffix}" "appletvsimulator${suffix}" "tvos${suffix}"
     fi
 done
-rm -f core/*.a
-mv out/*.a core
-rmdir out
 
 function add_to_xcframework() {
     local xcf="$1"
@@ -131,9 +190,8 @@ function add_to_xcframework() {
     local os="$3"
     local platform="$4"
     local build_type="$5"
-
-    local suffix
-    [[ "$bt" = "Release" ]] && suffix="" || suffix="-dbg"
+    local suffix 
+    [[ "$build_type" = "Release" ]] && suffix="" || suffix="-dbg"
 
     local variant=""
     if [[ "$platform" = *simulator ]]; then
@@ -142,18 +200,15 @@ function add_to_xcframework() {
         variant="-maccatalyst"
     fi
 
-    # Extract the library from the source tar
-    local source_tar="build-${platform}-${build_type}/realm-core-${build_type}-${VERSION}-${platform}-devel.tar.gz"
-    tar -C "$xcf" -zxvf "${source_tar}" "lib/$library${suffix}.a"
+    local location="core/$library-${platform}${suffix}.a"
 
     # Populate the actual directory structure
-    local archs="$(lipo -archs "$xcf/lib/$library${suffix}.a")"
+    local archs="$(lipo -archs "${location}")"
     local dir="$os-$(echo "$archs" | tr ' ' '_')$variant"
     mkdir -p "$xcf/$dir/Headers"
-    mv "$xcf/lib/$library${suffix}.a" "$xcf/$dir"
-    if [ "$library" = "librealm" ]; then
-        cp -R core/include/* "$xcf/$dir/Headers"
-    fi
+
+    cp ${location} "$xcf/$dir/$library${suffix}.a"
+    cp -R core/include/* "$xcf/$dir/Headers"
 
     # Add this library to the Plist
     cat << EOF >> "$xcf/Info.plist"
@@ -208,7 +263,6 @@ EOF
             add_to_xcframework "$xcf" "$library" "tvos" "appletvos" "$bt"
             add_to_xcframework "$xcf" "$library" "tvos" "appletvsimulator" "$bt"
         fi
-        rmdir "$xcf/lib"
 
         cat << EOF >> "$xcf/Info.plist"
 	</array>
@@ -224,7 +278,7 @@ EOF
 
 # Produce xcframeworks
 if [[ -n $BUILD_XCFRAMEWORK ]]; then
-    create_xcframework realm-core librealm
+    create_xcframework realm-monorepo librealm-monorepo
     create_xcframework realm-parser librealm-parser
 fi
 
@@ -235,23 +289,23 @@ if [[ -n $COPY ]]; then
     cp -R core "${DESTINATION}"
 
     if [[ ! -z $BUILD_XCFRAMEWORK ]]; then
-        rm -rf "${DESTINATION}/realm-sync.xcframework"
-        cp -Rc realm-sync.xcframework "${DESTINATION}"
-        rm -rf "${DESTINATION}/realm-sync-dbg.xcframework"
-        cp -Rc realm-sync-dbg.xcframework "${DESTINATION}"
+        rm -rf "${DESTINATION}/realm-monorepo.xcframework"
+        cp -Rc realm-monorepo.xcframework "${DESTINATION}"
+        rm -rf "${DESTINATION}/realm-monorepo-dbg.xcframework"
+        cp -Rc realm-monorepo-dbg.xcframework "${DESTINATION}"
     fi
 else
-    rm -f "realm-core-cocoa-${VERSION}.tar.xz"
+    rm -f "realm-monorepo-cocoa-${VERSION}.tar.xz"
     rm -f "realm-parser-cocoa-${VERSION}.tar.xz"
     # .tar.gz package is used by realm-js, which uses the parser
-    tar -czvf "realm-core-cocoa-${VERSION}.tar.gz" core
+    tar -czvf "realm-monorepo-cocoa-${VERSION}.tar.gz" --exclude "realm-monorepo*.xcframework" core
     # .tar.xz package is used by cocoa, which doesn't use the parser
-    tar -cJvf "realm-core-cocoa-${VERSION}.tar.xz" --exclude "realm-parser*.xcframework" core
+    tar -cJvf "realm-monorepo-cocoa-${VERSION}.tar.xz" --exclude "realm-monorepo*.xcframework" core
     tar -cJvf "realm-parser-cocoa-${VERSION}.tar.xz" core/realm-parser*.xcframework
 
     if [[ ! -z $BUILD_XCFRAMEWORK ]]; then
-        rm -f "realm-sync-xcframework-${VERSION}.tar.xz"
+        rm -f "realm-monorepo-xcframework-${VERSION}.tar.xz"
         # until realmjs requires an xcframework, only package as .xz
-        tar -cJvf "realm-sync-xcframework-${VERSION}.tar.xz" realm-sync.xcframework realm-sync-dbg.xcframework
+        tar -cJvf "realm-monorepo-xcframework-${VERSION}.tar.xz" core/realm-monorepo.xcframework core/realm-monorepo-dbg.xcframework
     fi
 fi

--- a/tools/build-cocoa.sh
+++ b/tools/build-cocoa.sh
@@ -307,12 +307,5 @@ else
         rm -f "realm-monorepo-xcframework-${VERSION}.tar.xz"
         # until realmjs requires an xcframework, only package as .xz
         tar -cJvf "realm-monorepo-xcframework-${VERSION}.tar.xz" core/realm-monorepo.xcframework core/realm-monorepo-dbg.xcframework
-
-        # Swift Package Manager only supports a zip containing only the xcframework
-        (
-            cd core
-            cp -R realm-monorepo.xcframework RealmMonorepo.xcframework
-            zip -r "../realm-monorepo-${VERSION}.xcframework.zip" RealmMonorepo.xcframework
-        )
     fi
 fi

--- a/tools/cross_compile.sh
+++ b/tools/cross_compile.sh
@@ -100,5 +100,5 @@ else
                -configuration "${BUILD_TYPE}" \
                -target install \
                ONLY_ACTIVE_ARCH=NO
-    tar -cvzf "realm-core-${BUILD_TYPE}-${VERSION}-${OS}-devel.tar.gz" -C install lib include
+    tar -cvzf "realm-${BUILD_TYPE}-${VERSION}-${OS}-devel.tar.gz" -C install lib include
 fi


### PR DESCRIPTION
This PR merges core, sync & object-store libraries, creating a librealm-monorepo.a binary when building with `build-cocoa.sh`. This binary will be packaged as an xcframework. The parser library will also still be packaged as its own xcframework. 