### PR TITLE
eliminate use of 'baseline' in filtering accessor updates

### DIFF
--- a/src/realm/array.cpp
+++ b/src/realm/array.cpp
@@ -229,25 +229,13 @@ void Array::init_from_mem(MemRef mem) noexcept
     set_width(m_width);
 }
 
-bool Array::update_from_parent(size_t old_baseline) noexcept
+void Array::update_from_parent() noexcept
 {
     REALM_ASSERT_DEBUG(is_attached());
     ArrayParent* parent = get_parent();
     REALM_ASSERT_DEBUG(parent);
-
-    // Array nodes that are part of the previous version of the
-    // database will not be overwritten by Group::commit(). This is
-    // necessary for robustness in the face of abrupt termination of
-    // the process. It also means that we can be sure that an array
-    // remains unchanged across a commit if the new ref is equal to
-    // the old ref and the ref is below the previous baseline.
-
     ref_type new_ref = get_ref_from_parent();
-    if (new_ref == m_ref && new_ref < old_baseline)
-        return false; // Has not changed
-
     init_from_ref(new_ref);
-    return true; // Might have changed
 }
 
 void Array::set_type(Type type)

--- a/src/realm/array.hpp
+++ b/src/realm/array.hpp
@@ -184,10 +184,7 @@ public:
     /// accessors stay valid across a commit. Please note that this works only
     /// for non-transactional commits. Accessors obtained during a transaction
     /// are always detached when the transaction ends.
-    ///
-    /// Returns true if, and only if the array has changed. If the array has not
-    /// changed, then its children are guaranteed to also not have changed.
-    bool update_from_parent(size_t old_baseline) noexcept;
+    void update_from_parent() noexcept;
 
     /// Change the type of an already attached array node.
     ///

--- a/src/realm/array_blobs_small.hpp
+++ b/src/realm/array_blobs_small.hpp
@@ -118,7 +118,7 @@ public:
 #ifdef REALM_DEBUG
     void to_dot(std::ostream&, bool is_strings, StringData title = StringData()) const;
 #endif
-    bool update_from_parent(size_t old_baseline) noexcept;
+    void update_from_parent() noexcept;
 
 private:
     friend class ArrayString;
@@ -265,15 +265,12 @@ inline size_t ArraySmallBlobs::get_size_from_header(const char* header, Allocato
     return Array::get_size_from_header(offsets_header);
 }
 
-inline bool ArraySmallBlobs::update_from_parent(size_t old_baseline) noexcept
+inline void ArraySmallBlobs::update_from_parent() noexcept
 {
-    bool res = Array::update_from_parent(old_baseline);
-    if (res) {
-        m_blob.update_from_parent(old_baseline);
-        m_offsets.update_from_parent(old_baseline);
-        m_nulls.update_from_parent(old_baseline);
-    }
-    return res;
+    Array::update_from_parent();
+    m_blob.update_from_parent();
+    m_offsets.update_from_parent();
+    m_nulls.update_from_parent();
 }
 
 } // namespace realm

--- a/src/realm/array_unsigned.cpp
+++ b/src/realm/array_unsigned.cpp
@@ -80,25 +80,13 @@ void ArrayUnsigned::create(size_t initial_size, uint64_t ubound_value)
     init_from_mem(mem);
 }
 
-bool ArrayUnsigned::update_from_parent(size_t old_baseline) noexcept
+void ArrayUnsigned::update_from_parent() noexcept
 {
     REALM_ASSERT_DEBUG(is_attached());
     ArrayParent* parent = get_parent();
     REALM_ASSERT_DEBUG(parent);
-
-    // Array nodes that are part of the previous version of the
-    // database will not be overwritten by Group::commit(). This is
-    // necessary for robustness in the face of abrupt termination of
-    // the process. It also means that we can be sure that an array
-    // remains unchanged across a commit if the new ref is equal to
-    // the old ref and the ref is below the previous baseline.
-
     ref_type new_ref = get_ref_from_parent();
-    if (new_ref == m_ref && new_ref < old_baseline)
-        return false; // Has not changed
-
     init_from_ref(new_ref);
-    return true; // Might have changed
 }
 
 size_t ArrayUnsigned::lower_bound(uint64_t value) const noexcept

--- a/src/realm/array_unsigned.hpp
+++ b/src/realm/array_unsigned.hpp
@@ -43,7 +43,7 @@ public:
         init_from_mem(MemRef(header, ref, m_alloc));
     }
 
-    bool update_from_parent(size_t old_baseline) noexcept;
+    void update_from_parent() noexcept;
 
     void init_from_mem(MemRef mem) noexcept
     {

--- a/src/realm/cluster.cpp
+++ b/src/realm/cluster.cpp
@@ -71,7 +71,7 @@ public:
 
     void create(int sub_tree_depth);
     void init(MemRef mem) override;
-    bool update_from_parent(size_t old_baseline) noexcept override;
+    void update_from_parent() noexcept override;
     MemRef ensure_writeable(ObjKey k) override;
 
     bool is_leaf() const override
@@ -262,17 +262,14 @@ void ClusterNodeInner::init(MemRef mem)
     m_shift_factor = m_sub_tree_depth * node_shift_factor;
 }
 
-bool ClusterNodeInner::update_from_parent(size_t old_baseline) noexcept
+void ClusterNodeInner::update_from_parent() noexcept
 {
-    if (Array::update_from_parent(old_baseline)) {
-        ref_type ref = Array::get_as_ref(s_key_ref_index);
-        if (ref) {
-            m_keys.update_from_parent(old_baseline);
-        }
-        m_sub_tree_depth = int(Array::get(s_sub_tree_depth_index)) >> 1;
-        return true;
+    Array::update_from_parent();
+    ref_type ref = Array::get_as_ref(s_key_ref_index);
+    if (ref) {
+        m_keys.update_from_parent();
     }
-    return false;
+    m_sub_tree_depth = int(Array::get(s_sub_tree_depth_index)) >> 1;
 }
 
 template <class T, class F>
@@ -859,16 +856,13 @@ void Cluster::init(MemRef mem)
     }
 }
 
-bool Cluster::update_from_parent(size_t old_baseline) noexcept
+void Cluster::update_from_parent() noexcept
 {
-    if (Array::update_from_parent(old_baseline)) {
-        auto rot = Array::get_as_ref_or_tagged(0);
-        if (!rot.is_tagged()) {
-            m_keys.update_from_parent(old_baseline);
-        }
-        return true;
+    Array::update_from_parent();
+    auto rot = Array::get_as_ref_or_tagged(0);
+    if (!rot.is_tagged()) {
+        m_keys.update_from_parent();
     }
-    return false;
 }
 
 MemRef Cluster::ensure_writeable(ObjKey)
@@ -1827,13 +1821,10 @@ void ClusterTree::init_from_parent()
     init_from_ref(ref);
 }
 
-bool ClusterTree::update_from_parent(size_t old_baseline) noexcept
+void ClusterTree::update_from_parent() noexcept
 {
-    bool was_updated = m_root->update_from_parent(old_baseline);
-    if (was_updated) {
-        m_size = m_root->get_tree_size();
-    }
-    return was_updated;
+    m_root->update_from_parent();
+    m_size = m_root->get_tree_size();
 }
 
 void ClusterTree::clear(CascadeState& state)

--- a/src/realm/cluster.hpp
+++ b/src/realm/cluster.hpp
@@ -96,7 +96,7 @@ public:
         return m_keys.get(ndx);
     }
 
-    virtual bool update_from_parent(size_t old_baseline) noexcept = 0;
+    virtual void update_from_parent() noexcept = 0;
     virtual bool is_leaf() const = 0;
     virtual int get_sub_tree_depth() const = 0;
     virtual size_t node_size() const = 0;
@@ -180,7 +180,7 @@ public:
 
     void create(size_t nb_leaf_columns); // Note: leaf columns - may include holes
     void init(MemRef mem) override;
-    bool update_from_parent(size_t old_baseline) noexcept override;
+    void update_from_parent() noexcept override;
     bool is_writeable() const
     {
         return !Array::is_read_only();

--- a/src/realm/cluster_tree.hpp
+++ b/src/realm/cluster_tree.hpp
@@ -57,7 +57,7 @@ public:
 
     void init_from_ref(ref_type ref);
     void init_from_parent();
-    bool update_from_parent(size_t old_baseline) noexcept;
+    void update_from_parent() noexcept;
 
     size_t size() const noexcept
     {

--- a/src/realm/group.hpp
+++ b/src/realm/group.hpp
@@ -710,7 +710,7 @@ private:
     /// that exists across Group::commit() will remain valid. This
     /// function is not appropriate for use in conjunction with
     /// commits via shared group.
-    void update_refs(ref_type top_ref, size_t old_baseline) noexcept;
+    void update_refs(ref_type top_ref) noexcept;
 
     // Overriding method in ArrayParent
     void update_child_ref(size_t, ref_type) override;

--- a/src/realm/index_string.hpp
+++ b/src/realm/index_string.hpp
@@ -182,7 +182,7 @@ public:
     void set_parent(ArrayParent* parent, size_t ndx_in_parent) noexcept;
     size_t get_ndx_in_parent() const noexcept;
     void set_ndx_in_parent(size_t ndx_in_parent) noexcept;
-    void update_from_parent(size_t old_baseline) noexcept;
+    void update_from_parent() noexcept;
     void refresh_accessor_tree(const ClusterColumn& target_column);
     ref_type get_ref() const noexcept;
 
@@ -638,9 +638,9 @@ inline void StringIndex::set_ndx_in_parent(size_t ndx_in_parent) noexcept
     m_array->set_ndx_in_parent(ndx_in_parent);
 }
 
-inline void StringIndex::update_from_parent(size_t old_baseline) noexcept
+inline void StringIndex::update_from_parent() noexcept
 {
-    m_array->update_from_parent(old_baseline);
+    m_array->update_from_parent();
 }
 
 } // namespace realm

--- a/src/realm/spec.cpp
+++ b/src/realm/spec.cpp
@@ -111,34 +111,30 @@ void Spec::update_internals() noexcept
     }
 }
 
-bool Spec::update_from_parent(size_t old_baseline) noexcept
+void Spec::update_from_parent() noexcept
 {
-    if (!m_top.update_from_parent(old_baseline))
-        return false;
-
-    m_types.update_from_parent(old_baseline);
-    m_names.update_from_parent(old_baseline);
-    m_attr.update_from_parent(old_baseline);
+    m_top.update_from_parent();
+    m_types.update_from_parent();
+    m_names.update_from_parent();
+    m_attr.update_from_parent();
 
     if (m_top.get_as_ref(3) != 0) {
-        m_oldsubspecs.update_from_parent(old_baseline);
+        m_oldsubspecs.update_from_parent();
     }
     else {
         m_oldsubspecs.detach();
     }
 
     if (m_top.get_as_ref(4) != 0) {
-        m_enumkeys.update_from_parent(old_baseline);
+        m_enumkeys.update_from_parent();
     }
     else {
         m_enumkeys.detach();
     }
 
-    m_keys.update_from_parent(old_baseline);
+    m_keys.update_from_parent();
 
     update_internals();
-
-    return true;
 }
 
 

--- a/src/realm/spec.hpp
+++ b/src/realm/spec.hpp
@@ -127,7 +127,7 @@ private:
     /// note that this works only for non-transactional commits. Table
     /// accessors obtained during a transaction are always detached
     /// when the transaction ends.
-    bool update_from_parent(size_t old_baseline) noexcept;
+    void update_from_parent() noexcept;
 
     void set_parent(ArrayParent*, size_t ndx_in_parent) noexcept;
 

--- a/src/realm/table.cpp
+++ b/src/realm/table.cpp
@@ -2192,30 +2192,24 @@ const Table* Table::get_link_chain_target(const std::vector<ColKey>& link_chain)
 }
 
 
-void Table::update_from_parent(size_t old_baseline) noexcept
+void Table::update_from_parent() noexcept
 {
     // There is no top for sub-tables sharing spec
     if (m_top.is_attached()) {
-        if (!m_top.update_from_parent(old_baseline))
-            return;
-
-        m_spec.update_from_parent(old_baseline);
-        if (m_top.size() > top_position_for_cluster_tree) {
-            m_clusters.update_from_parent(old_baseline);
-        }
-        if (m_top.size() > top_position_for_search_indexes) {
-            if (m_index_refs.update_from_parent(old_baseline)) {
-                for (auto index : m_index_accessors) {
-                    if (index != nullptr) {
-                        index->update_from_parent(old_baseline);
-                    }
-                }
+        m_top.update_from_parent();
+        m_spec.update_from_parent();
+        m_clusters.update_from_parent();
+        m_index_refs.update_from_parent();
+        for (auto index : m_index_accessors) {
+            if (index != nullptr) {
+                index->update_from_parent();
             }
         }
+        // FIXME: REMOVE CONDITIONAL CHECKS?
         if (m_top.size() > top_position_for_opposite_table)
-            m_opposite_table.update_from_parent(old_baseline);
+            m_opposite_table.update_from_parent();
         if (m_top.size() > top_position_for_opposite_column)
-            m_opposite_column.update_from_parent(old_baseline);
+            m_opposite_column.update_from_parent();
         refresh_content_version();
     }
     m_alloc.bump_storage_version();

--- a/src/realm/table.hpp
+++ b/src/realm/table.hpp
@@ -779,7 +779,7 @@ private:
     /// note that this works only for non-transactional commits. Table
     /// accessors obtained during a transaction are always detached
     /// when the transaction ends.
-    void update_from_parent(size_t old_baseline) noexcept;
+    void update_from_parent() noexcept;
 
     // Detach accessor. This recycles the Table accessor and all subordinate
     // accessors become invalid.


### PR DESCRIPTION
Since core 6, we do not actually filter accessor updates based on the "baseline" argument provided to update_from_parent(), because the argument provided "at the top" when initiating accessor update is always forced to 0.

This PR simply removes all the redundant parameter passing and filtering code that is now trivially true.
