### PR TITLE
ROBJSTORE-134 do not hardcode temp directory in object-store tests

### DIFF
--- a/test/object-store/realm.cpp
+++ b/test/object-store/realm.cpp
@@ -180,7 +180,7 @@ TEST_CASE("SharedRealm: get_shared_realm()")
 #ifndef _WIN32
     SECTION("should be able to set a FIFO fallback path")
     {
-        std::string fallback_dir = tmp_dir() + "/fallback/";
+        std::string fallback_dir = util::make_temp_dir() + "/fallback/";
         realm::util::try_make_dir(fallback_dir);
         TestFile config;
         config.fifo_files_fallback_path = fallback_dir;
@@ -200,7 +200,7 @@ TEST_CASE("SharedRealm: get_shared_realm()")
 
     SECTION("automatically append dir separator to end of fallback path")
     {
-        std::string fallback_dir = tmp_dir() + "/fallback";
+        std::string fallback_dir = util::make_temp_dir() + "/fallback";
         realm::util::try_make_dir(fallback_dir);
         TestFile config;
         config.fifo_files_fallback_path = fallback_dir;

--- a/test/object-store/sync/app.cpp
+++ b/test/object-store/sync/app.cpp
@@ -1834,7 +1834,7 @@ TEST_CASE("app: sync integration", "[sync][app]")
                                   "Object Store Platform Version Blah",
                                   "An sdk version"};
 
-    auto base_path = tmp_dir() + app_config.app_id;
+    auto base_path = util::make_temp_dir() + app_config.app_id;
     util::try_remove_dir_recursive(base_path);
     util::try_make_dir(base_path);
     // Heap allocate to control lifecycle.
@@ -3372,7 +3372,7 @@ TEST_CASE("app: refresh access token unit tests", "[sync][app]")
 
         auto config = get_config(generic_factory);
         TestSyncManager::Config cfg(config);
-        cfg.base_path = tmp_dir() + config.app_id;
+        cfg.base_path = util::make_temp_dir() + config.app_id;
         cfg.should_teardown_test_directory = false;
         TestSyncManager sync_manager(cfg);
         auto app = sync_manager.app();
@@ -3413,7 +3413,7 @@ TEST_CASE("app: refresh access token unit tests", "[sync][app]")
 
         auto config = get_config(generic_factory);
         TestSyncManager::Config cfg(config);
-        cfg.base_path = tmp_dir() + config.app_id;
+        cfg.base_path = util::make_temp_dir() + config.app_id;
         TestSyncManager sync_manager(cfg);
         auto app = sync_manager.app();
 
@@ -3459,7 +3459,7 @@ TEST_CASE("app: refresh access token unit tests", "[sync][app]")
 
         auto config = get_config(generic_factory);
         TestSyncManager::Config cfg(config);
-        cfg.base_path = tmp_dir() + config.app_id;
+        cfg.base_path = util::make_temp_dir() + config.app_id;
         TestSyncManager sync_manager(cfg);
         auto app = sync_manager.app();
 
@@ -3550,7 +3550,7 @@ TEST_CASE("app: refresh access token unit tests", "[sync][app]")
 
         auto config = get_config(factory);
         TestSyncManager::Config cfg(config);
-        cfg.base_path = tmp_dir() + config.app_id;
+        cfg.base_path = util::make_temp_dir() + config.app_id;
         TestSyncManager sync_manager(cfg);
         auto app = sync_manager.app();
 

--- a/test/object-store/sync/file.cpp
+++ b/test/object-store/sync/file.cpp
@@ -33,7 +33,7 @@ using namespace realm;
 using namespace realm::util;
 using File = realm::util::File;
 
-static const std::string base_path = tmp_dir() + "realm_objectstore_sync_file/";
+static const std::string base_path = util::make_temp_dir() + "realm_objectstore_sync_file/";
 
 static void prepare_sync_manager_test()
 {

--- a/test/object-store/sync/metadata.cpp
+++ b/test/object-store/sync/metadata.cpp
@@ -33,7 +33,7 @@ using namespace realm::util;
 using File = realm::util::File;
 using SyncAction = SyncFileActionMetadata::Action;
 
-static const std::string base_path = tmp_dir() + "realm_objectstore_sync_metadata";
+static const std::string base_path = util::make_temp_dir() + "realm_objectstore_sync_metadata";
 static const std::string metadata_path = base_path + "/metadata.realm";
 
 TEST_CASE("sync_metadata: migration", "[sync]")
@@ -379,7 +379,7 @@ TEST_CASE("sync_metadata: file action metadata", "[sync]")
 
     SECTION("can be properly constructed")
     {
-        const auto original_name = tmp_dir() + "foobar/test1";
+        const auto original_name = util::make_temp_dir() + "foobar/test1";
         manager.make_file_action_metadata(original_name, url_1, local_uuid_1, SyncAction::BackUpThenDeleteRealm);
         auto metadata = *manager.get_file_action_metadata(original_name);
         REQUIRE(metadata.original_name() == original_name);
@@ -391,9 +391,9 @@ TEST_CASE("sync_metadata: file action metadata", "[sync]")
 
     SECTION("properly reflects updating state, across multiple instances")
     {
-        const auto original_name = tmp_dir() + "foobar/test2a";
-        const std::string new_name_1 = tmp_dir() + "foobar/test2b";
-        const std::string new_name_2 = tmp_dir() + "foobar/test2c";
+        const auto original_name = util::make_temp_dir() + "foobar/test2a";
+        const std::string new_name_1 = util::make_temp_dir() + "foobar/test2b";
+        const std::string new_name_2 = util::make_temp_dir() + "foobar/test2c";
 
         manager.make_file_action_metadata(original_name, url_1, local_uuid_1, SyncAction::BackUpThenDeleteRealm,
                                           new_name_1);
@@ -427,9 +427,9 @@ TEST_CASE("sync_metadata: file action metadata APIs", "[sync]")
     SyncMetadataManager manager(metadata_path, false);
     SECTION("properly list all pending actions, reflecting their deletion")
     {
-        const auto filename1 = tmp_dir() + "foobar/file1";
-        const auto filename2 = tmp_dir() + "foobar/file2";
-        const auto filename3 = tmp_dir() + "foobar/file3";
+        const auto filename1 = util::make_temp_dir() + "foobar/file1";
+        const auto filename2 = util::make_temp_dir() + "foobar/file2";
+        const auto filename3 = util::make_temp_dir() + "foobar/file3";
         manager.make_file_action_metadata(filename1, "asdf", "realm://realm.example.com/1",
                                           SyncAction::BackUpThenDeleteRealm);
         manager.make_file_action_metadata(filename2, "asdf", "realm://realm.example.com/2",

--- a/test/object-store/sync/session/connection_change_notifications.cpp
+++ b/test/object-store/sync/session/connection_change_notifications.cpp
@@ -45,7 +45,7 @@ using namespace realm::util;
 static const std::string dummy_auth_url = "https://realm.example.org";
 static const std::string dummy_device_id = "123400000000000000000000";
 
-static const std::string base_path = tmp_dir() + "realm_objectstore_sync_connection_state_changes";
+static const std::string base_path = util::make_temp_dir() + "realm_objectstore_sync_connection_state_changes";
 
 TEST_CASE("sync: Connection state changes", "[sync]")
 {

--- a/test/object-store/sync/sync_manager.cpp
+++ b/test/object-store/sync/sync_manager.cpp
@@ -31,7 +31,7 @@ using namespace realm;
 using namespace realm::util;
 using File = realm::util::File;
 
-static const std::string base_path = tmp_dir() + "realm_objectstore_sync_manager/";
+static const std::string base_path = util::make_temp_dir() + "realm_objectstore_sync_manager/";
 static const std::string dummy_device_id = "123400000000000000000000";
 
 namespace {

--- a/test/object-store/sync/user.cpp
+++ b/test/object-store/sync/user.cpp
@@ -32,7 +32,7 @@ using namespace realm;
 using namespace realm::util;
 using File = realm::util::File;
 
-static const std::string base_path = tmp_dir() + "realm_objectstore_sync_user/";
+static const std::string base_path = util::make_temp_dir() + "realm_objectstore_sync_user/";
 static const std::string dummy_device_id = "123400000000000000000000";
 
 TEST_CASE("sync_user: SyncManager `get_user()` API", "[sync]")

--- a/test/object-store/util/test_utils.cpp
+++ b/test/object-store/util/test_utils.cpp
@@ -54,6 +54,17 @@ std::string tmp_dir()
         return dir;
 #if REALM_ANDROID
     return "/data/local/tmp/";
+#elif _WIN32
+    std::string buf;
+    size_t buf_size_needed = static_cast<size_t>(::GetTempPathA(0, nullptr));
+    buf.resize(buf_size_needed + 1);
+
+    buf_size_needed = static_cast<size_t>(::GetTempPathA(static_cast<DWORD>(buf.size()), buf.data()));
+    if (buf_size_needed == 0) {
+        throw std::system_error(GetLastError(), std::system_category());
+    }
+    buf.resize(buf_size_needed);
+    return buf;
 #else
     return "/tmp/";
 #endif

--- a/test/object-store/util/test_utils.cpp
+++ b/test/object-store/util/test_utils.cpp
@@ -47,29 +47,6 @@ void reset_test_directory(const std::string& base_path)
     util::make_dir(base_path);
 }
 
-std::string tmp_dir()
-{
-    const char* dir = getenv("TMPDIR");
-    if (dir && *dir)
-        return dir;
-#if REALM_ANDROID
-    return "/data/local/tmp/";
-#elif _WIN32
-    std::string buf;
-    size_t buf_size_needed = static_cast<size_t>(::GetTempPathA(0, nullptr));
-    buf.resize(buf_size_needed + 1);
-
-    buf_size_needed = static_cast<size_t>(::GetTempPathA(static_cast<DWORD>(buf.size()), buf.data()));
-    if (buf_size_needed == 0) {
-        throw std::system_error(GetLastError(), std::system_category());
-    }
-    buf.resize(buf_size_needed);
-    return buf;
-#else
-    return "/tmp/";
-#endif
-}
-
 std::vector<char> make_test_encryption_key(const char start)
 {
     std::vector<char> vector;

--- a/test/object-store/util/test_utils.hpp
+++ b/test/object-store/util/test_utils.hpp
@@ -29,7 +29,6 @@ namespace realm {
 /// Open a Realm at a given path, creating its files.
 bool create_dummy_realm(std::string path);
 void reset_test_directory(const std::string& base_path);
-std::string tmp_dir();
 std::vector<char> make_test_encryption_key(const char start = 0);
 void catch2_ensure_section_run_workaround(bool did_run_a_section, std::string section_name,
                                           std::function<void()> func);


### PR DESCRIPTION
this is causing the bulk of the object-store sync tests to fail on windows because they can't find `/tmp`. It looks like https://en.cppreference.com/w/cpp/filesystem/temp_directory_path will give us the correct info on each platform and fall back to `/tmp` if there is no correct info.