### PR TITLE
SizeOfList updates

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 * Fix queries for null on non-nullable indexed integer columns returning results for zero entries. (Since v6)
 * Fix queries for null on a indexed ObjectId column returning results for the zero ObjectId. (Since v10)
 * Fix list of primitives for Optional<Float> and Optional<Double> always returning false for `Lst::is_null(ndx)` even on null values, (since v6.0.0).
+* Fix queries for the size of a list of primitive nullable ints returning size + 1. This applies to the `Query::size_*` methods (SizeListNode) and not query expression syntax (SizeOperator). (since v6.0.0).
 
 ### Breaking changes
 * None.

--- a/src/realm/column_type_traits.hpp
+++ b/src/realm/column_type_traits.hpp
@@ -60,7 +60,6 @@ class BasicArrayNull;
 struct Link;
 template <class>
 class Lst;
-struct SizeOfList;
 
 template <class T>
 struct ColumnTypeTraits;
@@ -255,11 +254,6 @@ struct ColumnTypeTraits<util::Optional<UUID>> {
     using cluster_leaf_type = ArrayFixedBytesNull<UUID, UUID::num_bytes>;
     static const DataType id = type_UUID;
     static const ColumnType column_id = col_type_UUID;
-};
-
-template <>
-struct ColumnTypeTraits<SizeOfList> {
-    static const DataType id = type_Int;
 };
 
 template <>

--- a/src/realm/query.cpp
+++ b/src/realm/query.cpp
@@ -381,50 +381,7 @@ std::unique_ptr<ParentNode> make_size_condition_node(const Table& table, ColKey 
     ColumnAttrMask attr = column_key.get_attrs();
 
     if (attr.test(col_attr_List)) {
-        switch (type) {
-            case type_Int:
-            case type_Bool:
-            case type_OldDateTime: {
-                return std::unique_ptr<ParentNode>{new SizeListNode<int64_t, Cond>(value, column_key)};
-            }
-            case type_Float: {
-                return std::unique_ptr<ParentNode>{new SizeListNode<float, Cond>(value, column_key)};
-            }
-            case type_Double: {
-                return std::unique_ptr<ParentNode>{new SizeListNode<double, Cond>(value, column_key)};
-            }
-            case type_String: {
-                return std::unique_ptr<ParentNode>{new SizeListNode<String, Cond>(value, column_key)};
-            }
-            case type_Binary: {
-                return std::unique_ptr<ParentNode>{new SizeListNode<Binary, Cond>(value, column_key)};
-            }
-            case type_Timestamp: {
-                return std::unique_ptr<ParentNode>{new SizeListNode<Timestamp, Cond>(value, column_key)};
-            }
-            case type_LinkList: {
-                return std::unique_ptr<ParentNode>{new SizeListNode<ObjKey, Cond>(value, column_key)};
-            }
-            case type_ObjectId: {
-                return std::unique_ptr<ParentNode>{new SizeListNode<ObjectId, Cond>(value, column_key)};
-            }
-            case type_Mixed: {
-                return std::unique_ptr<ParentNode>{new SizeListNode<Mixed, Cond>(value, column_key)};
-            }
-            case type_Decimal: {
-                return std::unique_ptr<ParentNode>{new SizeListNode<Decimal128, Cond>(value, column_key)};
-            }
-            case type_UUID: {
-                return std::unique_ptr<ParentNode>{new SizeListNode<UUID, Cond>(value, column_key)};
-            }
-            case type_TypedLink:
-                [[fallthrough]];
-            case type_Link:
-                [[fallthrough]];
-            case type_OldTable: {
-                throw_type_mismatch_error();
-            }
-        }
+        return std::unique_ptr<ParentNode>{new SizeListNode<Cond>(value, column_key)};
     }
     switch (type) {
         case type_String: {

--- a/src/realm/query_engine.cpp
+++ b/src/realm/query_engine.cpp
@@ -435,6 +435,91 @@ size_t StringNode<EqualIns>::_find_first_local(size_t start, size_t end)
     return not_found;
 }
 
+size_t size_of_list_from_ref(ref_type ref, Allocator& alloc, ColumnType col_type, bool is_nullable)
+{
+    switch (col_type) {
+        case col_type_Int: {
+            if (is_nullable) {
+                BPlusTree<util::Optional<Int>> list(alloc);
+                list.init_from_ref(ref);
+                return list.size();
+            }
+            else {
+                BPlusTree<Int> list(alloc);
+                list.init_from_ref(ref);
+                return list.size();
+            }
+        }
+        case col_type_Bool: {
+            BPlusTree<Bool> list(alloc);
+            list.init_from_ref(ref);
+            return list.size();
+        }
+        case col_type_String: {
+            BPlusTree<String> list(alloc);
+            list.init_from_ref(ref);
+            return list.size();
+        }
+        case col_type_Binary: {
+            BPlusTree<Binary> list(alloc);
+            list.init_from_ref(ref);
+            return list.size();
+        }
+        case col_type_Mixed: {
+            BPlusTree<Mixed> list(alloc);
+            list.init_from_ref(ref);
+            return list.size();
+        }
+        case col_type_Timestamp: {
+            BPlusTree<Timestamp> list(alloc);
+            list.init_from_ref(ref);
+            return list.size();
+        }
+        case col_type_Float: {
+            BPlusTree<Float> list(alloc);
+            list.init_from_ref(ref);
+            return list.size();
+        }
+        case col_type_Double: {
+            BPlusTree<Double> list(alloc);
+            list.init_from_ref(ref);
+            return list.size();
+        }
+        case col_type_Decimal: {
+            BPlusTree<Decimal128> list(alloc);
+            list.init_from_ref(ref);
+            return list.size();
+        }
+        case col_type_ObjectId: {
+            BPlusTree<util::Optional<ObjectId>> list(alloc);
+            list.init_from_ref(ref);
+            return list.size();
+        }
+        case col_type_UUID: {
+            BPlusTree<util::Optional<UUID>> list(alloc);
+            list.init_from_ref(ref);
+            return list.size();
+        }
+        case col_type_LinkList: {
+            BPlusTree<ObjKey> list(alloc);
+            list.init_from_ref(ref);
+            return list.size();
+        }
+
+        case col_type_OldTable:
+            [[fallthrough]];
+        case col_type_TypedLink:
+            [[fallthrough]];
+        case col_type_Link:
+            [[fallthrough]];
+        case col_type_BackLink:
+            [[fallthrough]];
+        case col_type_OldDateTime:
+            REALM_ASSERT(false);
+            return 0;
+    }
+}
+
 } // namespace realm
 
 size_t NotNode::find_first_local(size_t start, size_t end)

--- a/src/realm/query_engine.hpp
+++ b/src/realm/query_engine.hpp
@@ -1033,14 +1033,22 @@ private:
     int64_t m_value;
 };
 
+extern size_t size_of_list_from_ref(ref_type ref, Allocator& alloc, ColumnType col_type, bool nullable);
 
-template <class T, class TConditionFunction>
+template <class TConditionFunction>
 class SizeListNode : public ParentNode {
 public:
     SizeListNode(int64_t v, ColKey column)
         : m_value(v)
     {
         m_condition_column_key = column;
+    }
+
+    void reset_cache()
+    {
+        m_cached_col_type = m_condition_column_key.get_type();
+        m_cached_nullable = m_condition_column_key.is_nullable();
+        REALM_ASSERT_DEBUG(m_condition_column_key.is_list());
     }
 
     void cluster_changed() override
@@ -1053,22 +1061,23 @@ public:
         m_array_ptr = LeafPtr(new (&m_leaf_cache_storage) ArrayList(m_table.unchecked_ptr()->get_alloc()));
         m_cluster->init_leaf(this->m_condition_column_key, m_array_ptr.get());
         m_leaf_ptr = m_array_ptr.get();
+        reset_cache();
     }
 
     void init(bool will_query_ranges) override
     {
         ParentNode::init(will_query_ranges);
         m_dD = 50.0;
+        reset_cache();
     }
 
     size_t find_first_local(size_t start, size_t end) override
     {
+        Allocator& alloc = m_table.unchecked_ptr()->get_alloc();
         for (size_t s = start; s < end; ++s) {
             ref_type ref = m_leaf_ptr->get(s);
             if (ref) {
-                ListType list(m_table.unchecked_ptr()->get_alloc());
-                list.init_from_ref(ref);
-                int64_t sz = list.size();
+                int64_t sz = size_of_list_from_ref(ref, alloc, m_cached_col_type, m_cached_nullable);
                 if (TConditionFunction()(sz, m_value))
                     return s;
             }
@@ -1089,7 +1098,6 @@ public:
 
 private:
     // Leaf cache
-    using ListType = BPlusTree<T>;
     using LeafCacheStorage = typename std::aligned_storage<sizeof(ArrayList), alignof(ArrayList)>::type;
     using LeafPtr = std::unique_ptr<ArrayList, PlacementDelete>;
     LeafCacheStorage m_leaf_cache_storage;
@@ -1097,6 +1105,9 @@ private:
     const ArrayList* m_leaf_ptr = nullptr;
 
     int64_t m_value;
+
+    ColumnType m_cached_col_type;
+    bool m_cached_nullable;
 };
 
 

--- a/test/test_table.cpp
+++ b/test/test_table.cpp
@@ -3044,6 +3044,11 @@ TEST_TYPES(Table_ListOps, Prop<Int>, Prop<Float>, Prop<Double>, Prop<Decimal128>
     CHECK_EQUAL(list.size(), 3);
     CHECK_EQUAL(list1.size(), 3);
 
+    Query q = table.where().size_equal(col, 3); // SizeListNode
+    CHECK_EQUAL(q.count(), 1);
+    q = table.column<Lst<type>>(col).size() == 3; // SizeOperator expresison
+    CHECK_EQUAL(q.count(), 1);
+
     Lst<type> list2 = list;
     CHECK_EQUAL(list2.size(), 3);
     list2.clear();


### PR DESCRIPTION
Fix a bug when evaluating SizeListNode for `Lst<Optional<Int>>` type which applies to `Query::size_*()` methods. This is because we were instantiating BPTree<Int> where we should be using BPTree<Optional<Int>> because it stores a magic null value in the list and subtracts one from the size.

The change to `SizeListNode` removes one dimension of template instantiation which reduces about 200k from the release library size. The type check is now done at run time, but the benchmark added shows a negligible impact.
```
Req runs:    6  QueryListOfPrimitiveIntsSize (MemOnly, EncryptionOff):     min  70.96ms (-0.06%)            max  75.05ms (-1.02%)            med  72.46ms (+0.77%)            avg  72.70ms (+0.39%)            stddev  1.65ms (-8.56%)
```

Base monorepo branch size report:
```
  ./bloaty -d inputfiles ../realm-core2/build.release/src/realm/CMakeFiles/Storage.dir/*.o
    FILE SIZE        VM SIZE
 --------------  --------------
  26.3%  1.62Mi  26.9%  1.10Mi    ../realm-core2/build.release/src/realm/CMakeFiles/Storage.dir/query.cpp.o
  12.6%   794Ki  15.6%   650Ki    ../realm-core2/build.release/src/realm/CMakeFiles/Storage.dir/array.cpp.o
  11.5%   721Ki  11.4%   473Ki    ../realm-core2/build.release/src/realm/CMakeFiles/Storage.dir/list.cpp.o
   9.1%   569Ki   8.6%   357Ki    ../realm-core2/build.release/src/realm/CMakeFiles/Storage.dir/table.cpp.o
   7.1%   448Ki   5.9%   247Ki    [35 Others]
   6.8%   426Ki   6.2%   259Ki    ../realm-core2/build.release/src/realm/CMakeFiles/Storage.dir/set.cpp.o
   4.8%   299Ki   4.5%   188Ki    ../realm-core2/build.release/src/realm/CMakeFiles/Storage.dir/obj.cpp.o
   4.3%   272Ki   4.4%   183Ki    ../realm-core2/build.release/src/realm/CMakeFiles/Storage.dir/query_expression.cpp.o
   2.6%   165Ki   2.4%   100Ki    ../realm-core2/build.release/src/realm/CMakeFiles/Storage.dir/cluster.cpp.o
   2.2%   141Ki   1.9%  79.3Ki    ../realm-core2/build.release/src/realm/CMakeFiles/Storage.dir/db.cpp.o
   1.8%   112Ki   1.7%  68.9Ki    ../realm-core2/build.release/src/realm/CMakeFiles/Storage.dir/group.cpp.o
   1.7%   107Ki   1.7%  72.9Ki    ../realm-core2/build.release/src/realm/CMakeFiles/Storage.dir/sort_descriptor.cpp.o
   1.4%  90.1Ki   1.3%  54.2Ki    ../realm-core2/build.release/src/realm/CMakeFiles/Storage.dir/table_view.cpp.o
   1.3%  82.2Ki   1.2%  49.3Ki    ../realm-core2/build.release/src/realm/CMakeFiles/Storage.dir/query_engine.cpp.o
   1.2%  72.5Ki   1.2%  49.0Ki    ../realm-core2/build.release/src/realm/CMakeFiles/Storage.dir/index_string.cpp.o
   1.1%  68.6Ki   1.1%  45.6Ki    ../realm-core2/build.release/src/realm/CMakeFiles/Storage.dir/cluster_tree.cpp.o
   1.0%  63.3Ki   1.1%  45.4Ki    ../realm-core2/build.release/src/realm/CMakeFiles/Storage.dir/array_timestamp.cpp.o
   0.9%  56.0Ki   0.8%  33.2Ki    ../realm-core2/build.release/src/realm/CMakeFiles/Storage.dir/dictionary.cpp.o
   0.8%  52.5Ki   0.8%  33.2Ki    ../realm-core2/build.release/src/realm/CMakeFiles/Storage.dir/alloc_slab.cpp.o
   0.8%  50.1Ki   0.8%  34.0Ki    ../realm-core2/build.release/src/realm/CMakeFiles/Storage.dir/group_writer.cpp.o
   0.6%  35.2Ki   0.4%  17.1Ki    ../realm-core2/build.release/src/realm/CMakeFiles/Storage.dir/table_cluster_tree.cpp.o
 100.0%  6.14Mi 100.0%  4.07Mi    TOTAL
````

This PR:
```
 ./bloaty -d inputfiles ../realm-core/build.release/src/realm/CMakeFiles/Storage.dir/*.o
    FILE SIZE        VM SIZE
 --------------  --------------
  22.2%  1.32Mi  23.1%   929Ki    ../realm-core/build.release/src/realm/CMakeFiles/Storage.dir/query.cpp.o
  13.1%   794Ki  16.1%   650Ki    ../realm-core/build.release/src/realm/CMakeFiles/Storage.dir/array.cpp.o
  11.9%   721Ki  11.7%   473Ki    ../realm-core/build.release/src/realm/CMakeFiles/Storage.dir/list.cpp.o
   9.4%   569Ki   8.9%   357Ki    ../realm-core/build.release/src/realm/CMakeFiles/Storage.dir/table.cpp.o
   7.4%   448Ki   6.1%   247Ki    [35 Others]
   7.0%   426Ki   6.4%   259Ki    ../realm-core/build.release/src/realm/CMakeFiles/Storage.dir/set.cpp.o
   4.9%   299Ki   4.7%   188Ki    ../realm-core/build.release/src/realm/CMakeFiles/Storage.dir/obj.cpp.o
   4.5%   272Ki   4.6%   183Ki    ../realm-core/build.release/src/realm/CMakeFiles/Storage.dir/query_expression.cpp.o
   3.1%   186Ki   2.7%   107Ki    ../realm-core/build.release/src/realm/CMakeFiles/Storage.dir/query_engine.cpp.o
   2.7%   165Ki   2.5%   100Ki    ../realm-core/build.release/src/realm/CMakeFiles/Storage.dir/cluster.cpp.o
   2.3%   141Ki   2.0%  79.3Ki    ../realm-core/build.release/src/realm/CMakeFiles/Storage.dir/db.cpp.o
   1.9%   112Ki   1.7%  68.9Ki    ../realm-core/build.release/src/realm/CMakeFiles/Storage.dir/group.cpp.o
   1.8%   107Ki   1.8%  72.9Ki    ../realm-core/build.release/src/realm/CMakeFiles/Storage.dir/sort_descriptor.cpp.o
   1.5%  90.1Ki   1.3%  54.2Ki    ../realm-core/build.release/src/realm/CMakeFiles/Storage.dir/table_view.cpp.o
   1.2%  72.5Ki   1.2%  49.0Ki    ../realm-core/build.release/src/realm/CMakeFiles/Storage.dir/index_string.cpp.o
   1.1%  68.6Ki   1.1%  45.6Ki    ../realm-core/build.release/src/realm/CMakeFiles/Storage.dir/cluster_tree.cpp.o
   1.0%  63.3Ki   1.1%  45.4Ki    ../realm-core/build.release/src/realm/CMakeFiles/Storage.dir/array_timestamp.cpp.o
   0.9%  56.0Ki   0.8%  33.2Ki    ../realm-core/build.release/src/realm/CMakeFiles/Storage.dir/dictionary.cpp.o
   0.9%  52.5Ki   0.8%  33.2Ki    ../realm-core/build.release/src/realm/CMakeFiles/Storage.dir/alloc_slab.cpp.o
   0.8%  50.1Ki   0.8%  34.0Ki    ../realm-core/build.release/src/realm/CMakeFiles/Storage.dir/group_writer.cpp.o
   0.6%  35.1Ki   0.4%  17.0Ki    ../realm-core/build.release/src/realm/CMakeFiles/Storage.dir/table_cluster_tree.cpp.o
 100.0%  5.94Mi 100.0%  3.94Mi    TOTAL
```