### PR TITLE
SizeOfList updates for v6

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,8 +6,9 @@
 ### Fixed
 * <How to hit and notice issue? what was the impact?> ([#????](https://github.com/realm/realm-core/issues/????), since v?.?.?)
 * Fix crash in case insensitive query on indexed string columns when nothing matches ([#6836](https://github.com/realm/realm-cocoa/issues/6836), since v6.0.0)
-* Fix list of primitives for Optional<Float> and Optional<Double> always returning false for `Lst::is_null(ndx)` even on null values, (since v6.0.0).
- 
+* Fix list of primitives for Optional<Float> and Optional<Double> always returning false for `Lst::is_null(ndx)` even on null values, ([#3987](https://github.com/realm/realm-core/pull/3987), since v6.0.0).
+* Fix queries for the size of a list of primitive nullable ints returning size + 1. This applies to the `Query::size_*` methods (SizeListNode) and not query expression syntax (SizeOperator). ([#4016](https://github.com/realm/realm-core/pull/4016), since v6.0.0).
+
 ### Breaking changes
 * None.
 

--- a/src/realm/keys.hpp
+++ b/src/realm/keys.hpp
@@ -108,6 +108,14 @@ struct ColKey {
                  ((tag & 0xFFFFFFFFUL) << 30))
     {
     }
+    bool is_nullable() const
+    {
+        return get_attrs().test(col_attr_Nullable);
+    }
+    bool is_list() const
+    {
+        return get_attrs().test(col_attr_List);
+    }
     ColKey& operator=(int64_t val) noexcept
     {
         value = val;

--- a/src/realm/query.cpp
+++ b/src/realm/query.cpp
@@ -371,34 +371,7 @@ std::unique_ptr<ParentNode> make_size_condition_node(const Table& table, ColKey 
     ColumnAttrMask attr = column_key.get_attrs();
 
     if (attr.test(col_attr_List)) {
-        switch (type) {
-            case type_Int:
-            case type_Bool:
-            case type_OldDateTime: {
-                return std::unique_ptr<ParentNode>{new SizeListNode<int64_t, Cond>(value, column_key)};
-            }
-            case type_Float: {
-                return std::unique_ptr<ParentNode>{new SizeListNode<float, Cond>(value, column_key)};
-            }
-            case type_Double: {
-                return std::unique_ptr<ParentNode>{new SizeListNode<double, Cond>(value, column_key)};
-            }
-            case type_String: {
-                return std::unique_ptr<ParentNode>{new SizeListNode<String, Cond>(value, column_key)};
-            }
-            case type_Binary: {
-                return std::unique_ptr<ParentNode>{new SizeListNode<Binary, Cond>(value, column_key)};
-            }
-            case type_Timestamp: {
-                return std::unique_ptr<ParentNode>{new SizeListNode<Timestamp, Cond>(value, column_key)};
-            }
-            case type_LinkList: {
-                return std::unique_ptr<ParentNode>{new SizeListNode<ObjKey, Cond>(value, column_key)};
-            }
-            default: {
-                throw LogicError{LogicError::type_mismatch};
-            }
-        }
+        return std::unique_ptr<ParentNode>{new SizeListNode<Cond>(value, column_key)};
     }
     switch (type) {
         case type_String: {

--- a/src/realm/query_engine.cpp
+++ b/src/realm/query_engine.cpp
@@ -390,6 +390,68 @@ size_t StringNode<EqualIns>::_find_first_local(size_t start, size_t end)
     return not_found;
 }
 
+size_t size_of_list_from_ref(ref_type ref, Allocator& alloc, ColumnType col_type, bool is_nullable)
+{
+    switch (col_type) {
+        case col_type_Int: {
+            if (is_nullable) {
+                BPlusTree<util::Optional<Int>> list(alloc);
+                list.init_from_ref(ref);
+                return list.size();
+            }
+            else {
+                BPlusTree<Int> list(alloc);
+                list.init_from_ref(ref);
+                return list.size();
+            }
+        }
+        case col_type_Bool: {
+            BPlusTree<Bool> list(alloc);
+            list.init_from_ref(ref);
+            return list.size();
+        }
+        case col_type_String: {
+            BPlusTree<String> list(alloc);
+            list.init_from_ref(ref);
+            return list.size();
+        }
+        case col_type_Binary: {
+            BPlusTree<Binary> list(alloc);
+            list.init_from_ref(ref);
+            return list.size();
+        }
+        case col_type_Timestamp: {
+            BPlusTree<Timestamp> list(alloc);
+            list.init_from_ref(ref);
+            return list.size();
+        }
+        case col_type_Float: {
+            BPlusTree<Float> list(alloc);
+            list.init_from_ref(ref);
+            return list.size();
+        }
+        case col_type_Double: {
+            BPlusTree<Double> list(alloc);
+            list.init_from_ref(ref);
+            return list.size();
+        }
+        case col_type_LinkList: {
+            BPlusTree<ObjKey> list(alloc);
+            list.init_from_ref(ref);
+            return list.size();
+        }
+        case col_type_OldStringEnum:
+        case col_type_Reserved4:
+        case col_type_OldMixed:
+        case col_type_OldTable:
+        case col_type_Link:
+        case col_type_BackLink:
+        case col_type_OldDateTime:
+            REALM_ASSERT(false);
+    }
+    return 0;
+}
+
 } // namespace realm
 
 size_t NotNode::find_first_local(size_t start, size_t end)

--- a/test/benchmark-common-tasks/main.cpp
+++ b/test/benchmark-common-tasks/main.cpp
@@ -835,6 +835,40 @@ struct BenchmarkIntVsDoubleColumns : Benchmark {
 };
 
 
+struct BenchmarkQueryIntListSize : Benchmark {
+    ColKey int_list_col_ndx;
+    constexpr static size_t num_rows = BASE_SIZE * 4;
+    void before_all(DBRef group)
+    {
+        WrtTrans tr(group);
+        TableRef t = tr.add_table(name());
+        int_list_col_ndx = t->add_column_list(type_Int, "ints");
+        for (size_t i = 0; i < num_rows; ++i) {
+            auto obj = t->create_object().set_list_values<Int>(int_list_col_ndx, {0, 1, 2});
+        }
+        tr.commit();
+    }
+    const char* name() const
+    {
+        return "QueryListOfPrimitiveIntsSize";
+    }
+    void operator()(DBRef)
+    {
+        TableRef table = m_table;
+        Query q = table->where().size_equal(int_list_col_ndx, 3);
+        size_t count = q.count();
+        REALM_ASSERT_3(count, ==, (num_rows));
+    }
+
+    void after_all(DBRef group)
+    {
+        WrtTrans tr(group);
+        tr.get_group().remove_table(name());
+        tr.commit();
+    }
+};
+
+
 struct BenchmarkWithIntUIDsRandomOrderSeqAccess : BenchmarkWithIntsTable {
     const char* name() const
     {
@@ -2032,6 +2066,7 @@ int benchmark_common_tasks_main()
     BENCH(BenchmarkQueryTimestampNotEqual);
     BENCH(BenchmarkQueryTimestampNotNull);
     BENCH(BenchmarkQueryTimestampEqualNull);
+    BENCH(BenchmarkQueryIntListSize);
 
     BENCH(BenchmarkWithIntUIDsRandomOrderSeqAccess);
     BENCH(BenchmarkWithIntUIDsRandomOrderRandomAccess);

--- a/test/test_table.cpp
+++ b/test/test_table.cpp
@@ -3125,6 +3125,11 @@ TEST_TYPES(Table_ListOps, Prop<Int>, Prop<Float>, Prop<Double>, Prop<Timestamp>,
     CHECK_EQUAL(list.size(), 3);
     CHECK_EQUAL(list1.size(), 3);
 
+    Query q = table.where().size_equal(col, 3); // SizeListNode
+    CHECK_EQUAL(q.count(), 1);
+    q = table.column<Lst<type>>(col).size() == 3; // SizeOperator expresison
+    CHECK_EQUAL(q.count(), 1);
+
     Lst<type> list2 = list;
     CHECK_EQUAL(list2.size(), 3);
     list2.clear();


### PR DESCRIPTION
Fix a bug when evaluating SizeListNode for `Lst<Optional<Int>>` type which applies to `Query::size_*()` methods. This is because we were instantiating BPTree<Int> where we should be using BPTree<Optional<Int>> because it stores a magic null value in the list and subtracts one from the size.

The change to `SizeListNode` removes one dimension of template instantiation which reduces about 200k from the release library size. The type check is now done at run time, but the benchmark added shows a negligible impact.
```
Req runs:    6  QueryListOfPrimitiveIntsSize (MemOnly, EncryptionOff):     min  70.96ms (-0.06%)            max  75.05ms (-1.02%)            med  72.46ms (+0.77%)            avg  72.70ms (+0.39%)            stddev  1.65ms (-8.56%)
```

Base monorepo branch size report:
```
  ./bloaty -d inputfiles ../realm-core2/build.release/src/realm/CMakeFiles/Storage.dir/*.o
    FILE SIZE        VM SIZE
 --------------  --------------
  26.3%  1.62Mi  26.9%  1.10Mi    ../realm-core2/build.release/src/realm/CMakeFiles/Storage.dir/query.cpp.o
  12.6%   794Ki  15.6%   650Ki    ../realm-core2/build.release/src/realm/CMakeFiles/Storage.dir/array.cpp.o
  11.5%   721Ki  11.4%   473Ki    ../realm-core2/build.release/src/realm/CMakeFiles/Storage.dir/list.cpp.o
   9.1%   569Ki   8.6%   357Ki    ../realm-core2/build.release/src/realm/CMakeFiles/Storage.dir/table.cpp.o
   7.1%   448Ki   5.9%   247Ki    [35 Others]
   6.8%   426Ki   6.2%   259Ki    ../realm-core2/build.release/src/realm/CMakeFiles/Storage.dir/set.cpp.o
   4.8%   299Ki   4.5%   188Ki    ../realm-core2/build.release/src/realm/CMakeFiles/Storage.dir/obj.cpp.o
   4.3%   272Ki   4.4%   183Ki    ../realm-core2/build.release/src/realm/CMakeFiles/Storage.dir/query_expression.cpp.o
   2.6%   165Ki   2.4%   100Ki    ../realm-core2/build.release/src/realm/CMakeFiles/Storage.dir/cluster.cpp.o
   2.2%   141Ki   1.9%  79.3Ki    ../realm-core2/build.release/src/realm/CMakeFiles/Storage.dir/db.cpp.o
   1.8%   112Ki   1.7%  68.9Ki    ../realm-core2/build.release/src/realm/CMakeFiles/Storage.dir/group.cpp.o
   1.7%   107Ki   1.7%  72.9Ki    ../realm-core2/build.release/src/realm/CMakeFiles/Storage.dir/sort_descriptor.cpp.o
   1.4%  90.1Ki   1.3%  54.2Ki    ../realm-core2/build.release/src/realm/CMakeFiles/Storage.dir/table_view.cpp.o
   1.3%  82.2Ki   1.2%  49.3Ki    ../realm-core2/build.release/src/realm/CMakeFiles/Storage.dir/query_engine.cpp.o
   1.2%  72.5Ki   1.2%  49.0Ki    ../realm-core2/build.release/src/realm/CMakeFiles/Storage.dir/index_string.cpp.o
   1.1%  68.6Ki   1.1%  45.6Ki    ../realm-core2/build.release/src/realm/CMakeFiles/Storage.dir/cluster_tree.cpp.o
   1.0%  63.3Ki   1.1%  45.4Ki    ../realm-core2/build.release/src/realm/CMakeFiles/Storage.dir/array_timestamp.cpp.o
   0.9%  56.0Ki   0.8%  33.2Ki    ../realm-core2/build.release/src/realm/CMakeFiles/Storage.dir/dictionary.cpp.o
   0.8%  52.5Ki   0.8%  33.2Ki    ../realm-core2/build.release/src/realm/CMakeFiles/Storage.dir/alloc_slab.cpp.o
   0.8%  50.1Ki   0.8%  34.0Ki    ../realm-core2/build.release/src/realm/CMakeFiles/Storage.dir/group_writer.cpp.o
   0.6%  35.2Ki   0.4%  17.1Ki    ../realm-core2/build.release/src/realm/CMakeFiles/Storage.dir/table_cluster_tree.cpp.o
 100.0%  6.14Mi 100.0%  4.07Mi    TOTAL
````

This PR:
```
 ./bloaty -d inputfiles ../realm-core/build.release/src/realm/CMakeFiles/Storage.dir/*.o
    FILE SIZE        VM SIZE
 --------------  --------------
  22.2%  1.32Mi  23.1%   929Ki    ../realm-core/build.release/src/realm/CMakeFiles/Storage.dir/query.cpp.o
  13.1%   794Ki  16.1%   650Ki    ../realm-core/build.release/src/realm/CMakeFiles/Storage.dir/array.cpp.o
  11.9%   721Ki  11.7%   473Ki    ../realm-core/build.release/src/realm/CMakeFiles/Storage.dir/list.cpp.o
   9.4%   569Ki   8.9%   357Ki    ../realm-core/build.release/src/realm/CMakeFiles/Storage.dir/table.cpp.o
   7.4%   448Ki   6.1%   247Ki    [35 Others]
   7.0%   426Ki   6.4%   259Ki    ../realm-core/build.release/src/realm/CMakeFiles/Storage.dir/set.cpp.o
   4.9%   299Ki   4.7%   188Ki    ../realm-core/build.release/src/realm/CMakeFiles/Storage.dir/obj.cpp.o
   4.5%   272Ki   4.6%   183Ki    ../realm-core/build.release/src/realm/CMakeFiles/Storage.dir/query_expression.cpp.o
   3.1%   186Ki   2.7%   107Ki    ../realm-core/build.release/src/realm/CMakeFiles/Storage.dir/query_engine.cpp.o
   2.7%   165Ki   2.5%   100Ki    ../realm-core/build.release/src/realm/CMakeFiles/Storage.dir/cluster.cpp.o
   2.3%   141Ki   2.0%  79.3Ki    ../realm-core/build.release/src/realm/CMakeFiles/Storage.dir/db.cpp.o
   1.9%   112Ki   1.7%  68.9Ki    ../realm-core/build.release/src/realm/CMakeFiles/Storage.dir/group.cpp.o
   1.8%   107Ki   1.8%  72.9Ki    ../realm-core/build.release/src/realm/CMakeFiles/Storage.dir/sort_descriptor.cpp.o
   1.5%  90.1Ki   1.3%  54.2Ki    ../realm-core/build.release/src/realm/CMakeFiles/Storage.dir/table_view.cpp.o
   1.2%  72.5Ki   1.2%  49.0Ki    ../realm-core/build.release/src/realm/CMakeFiles/Storage.dir/index_string.cpp.o
   1.1%  68.6Ki   1.1%  45.6Ki    ../realm-core/build.release/src/realm/CMakeFiles/Storage.dir/cluster_tree.cpp.o
   1.0%  63.3Ki   1.1%  45.4Ki    ../realm-core/build.release/src/realm/CMakeFiles/Storage.dir/array_timestamp.cpp.o
   0.9%  56.0Ki   0.8%  33.2Ki    ../realm-core/build.release/src/realm/CMakeFiles/Storage.dir/dictionary.cpp.o
   0.9%  52.5Ki   0.8%  33.2Ki    ../realm-core/build.release/src/realm/CMakeFiles/Storage.dir/alloc_slab.cpp.o
   0.8%  50.1Ki   0.8%  34.0Ki    ../realm-core/build.release/src/realm/CMakeFiles/Storage.dir/group_writer.cpp.o
   0.6%  35.1Ki   0.4%  17.0Ki    ../realm-core/build.release/src/realm/CMakeFiles/Storage.dir/table_cluster_tree.cpp.o
 100.0%  5.94Mi 100.0%  3.94Mi    TOTAL
```