### PR TITLE
ROBJSTORE-135 Fix type deduction for arguments to corpus_check lambdas

### DIFF
--- a/test/object-store/bson.cpp
+++ b/test/object-store/bson.cpp
@@ -42,12 +42,9 @@ static inline std::string remove_whitespace(const char* c)
  ======== BSON CORPUS ========
  */
 template <typename T>
-using CorpusCheck = void (*)(T);
-
-template <typename T>
 struct CorpusEntry {
     const char* canonical_extjson;
-    CorpusCheck<T> check;
+    std::function<void(T)> check;
     bool lossy;
 };
 

--- a/test/object-store/bson.cpp
+++ b/test/object-store/bson.cpp
@@ -41,6 +41,8 @@ static inline std::string remove_whitespace(const char* c)
 /**
  ======== BSON CORPUS ========
  */
+// FIXME(BUILD-12151) the argument to the corpus check function is an r-value reference to work around
+// a bug in the version of gcc in the v3 mongodb toolchain.
 template <typename T>
 using CorpusCheck = void (*)(T&&);
 

--- a/test/object-store/bson.cpp
+++ b/test/object-store/bson.cpp
@@ -42,9 +42,12 @@ static inline std::string remove_whitespace(const char* c)
  ======== BSON CORPUS ========
  */
 template <typename T>
+using CorpusCheck = void (*)(T&&);
+
+template <typename T>
 struct CorpusEntry {
     const char* canonical_extjson;
-    std::function<void(T)> check;
+    CorpusCheck<T> check;
     bool lossy;
 };
 


### PR DESCRIPTION
The bson corpus tests capture the cheir check function as a function pointer. On some compilers this means that when the function is being called during the check, the lifetime of the lambda representing the check has already expired.