### PR TITLE
Enable cross type comparisons in a TwoColumnsNode

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ### Enhancements
 * New data types: Mixed, UUID and TypedLink.
 * New collection types: Set and Dictionary 
+* Enable mixed comparison queries between two columns of arbitrary types according to the Mixed::compare rules. ([#4018](https://github.com/realm/realm-core/pull/4018))
 
 ### Fixed
 * <How to hit and notice issue? what was the impact?> ([#????](https://github.com/realm/realm-core/issues/????), since v?.?.?)

--- a/src/realm/array_backlink.hpp
+++ b/src/realm/array_backlink.hpp
@@ -58,7 +58,11 @@ public:
     {
         return Array::get(ndx);
     }
-
+    Mixed get_as_mixed(size_t ndx) const override
+    {
+        REALM_ASSERT(false);
+        return Mixed(get(ndx));
+    }
     void add(int64_t val)
     {
         Array::add(val);

--- a/src/realm/array_backlink.hpp
+++ b/src/realm/array_backlink.hpp
@@ -58,7 +58,7 @@ public:
     {
         return Array::get(ndx);
     }
-    Mixed get_as_mixed(size_t ndx) const override
+    Mixed get_any(size_t ndx) const override
     {
         REALM_ASSERT(false);
         return Mixed(get(ndx));

--- a/src/realm/array_basic.hpp
+++ b/src/realm/array_basic.hpp
@@ -91,7 +91,7 @@ public:
     /// you need to get multiple values, then this method will be
     /// slower.
     static T get(const char* header, size_t ndx) noexcept;
-    Mixed get_as_mixed(size_t ndx) const override
+    Mixed get_any(size_t ndx) const override
     {
         return Mixed(get(ndx));
     }
@@ -178,7 +178,7 @@ public:
         T val = BasicArray<T>::get(ndx);
         return null::is_null_float(val) ? util::none : util::make_optional(val);
     }
-    Mixed get_as_mixed(size_t ndx) const override
+    Mixed get_any(size_t ndx) const override
     {
         return Mixed(get(ndx));
     }

--- a/src/realm/array_basic.hpp
+++ b/src/realm/array_basic.hpp
@@ -91,6 +91,10 @@ public:
     /// you need to get multiple values, then this method will be
     /// slower.
     static T get(const char* header, size_t ndx) noexcept;
+    Mixed get_as_mixed(size_t ndx) const override
+    {
+        return Mixed(get(ndx));
+    }
 
     size_t lower_bound(T value) const noexcept;
     size_t upper_bound(T value) const noexcept;
@@ -173,6 +177,10 @@ public:
     {
         T val = BasicArray<T>::get(ndx);
         return null::is_null_float(val) ? util::none : util::make_optional(val);
+    }
+    Mixed get_as_mixed(size_t ndx) const override
+    {
+        return Mixed(get(ndx));
     }
     size_t find_first(util::Optional<T> value, size_t begin = 0, size_t end = npos) const
     {

--- a/src/realm/array_binary.cpp
+++ b/src/realm/array_binary.cpp
@@ -122,6 +122,11 @@ BinaryData ArrayBinary::get_at(size_t ndx, size_t& pos) const
     }
 }
 
+Mixed ArrayBinary::get_as_mixed(size_t ndx) const
+{
+    return Mixed(get(ndx));
+}
+
 bool ArrayBinary::is_null(size_t ndx) const
 {
     if (!m_is_big) {

--- a/src/realm/array_binary.cpp
+++ b/src/realm/array_binary.cpp
@@ -122,7 +122,7 @@ BinaryData ArrayBinary::get_at(size_t ndx, size_t& pos) const
     }
 }
 
-Mixed ArrayBinary::get_as_mixed(size_t ndx) const
+Mixed ArrayBinary::get_any(size_t ndx) const
 {
     return Mixed(get(ndx));
 }

--- a/src/realm/array_binary.hpp
+++ b/src/realm/array_binary.hpp
@@ -70,7 +70,7 @@ public:
     void insert(size_t ndx, BinaryData value);
     BinaryData get(size_t ndx) const;
     BinaryData get_at(size_t ndx, size_t& pos) const;
-    Mixed get_as_mixed(size_t ndx) const override;
+    Mixed get_any(size_t ndx) const override;
     bool is_null(size_t ndx) const;
     void erase(size_t ndx);
     void move(ArrayBinary& dst, size_t ndx);

--- a/src/realm/array_binary.hpp
+++ b/src/realm/array_binary.hpp
@@ -70,6 +70,7 @@ public:
     void insert(size_t ndx, BinaryData value);
     BinaryData get(size_t ndx) const;
     BinaryData get_at(size_t ndx, size_t& pos) const;
+    Mixed get_as_mixed(size_t ndx) const override;
     bool is_null(size_t ndx) const;
     void erase(size_t ndx);
     void move(ArrayBinary& dst, size_t ndx);

--- a/src/realm/array_bool.hpp
+++ b/src/realm/array_bool.hpp
@@ -69,7 +69,7 @@ public:
     {
         return Array::get(ndx) != 0;
     }
-    Mixed get_as_mixed(size_t ndx) const override
+    Mixed get_any(size_t ndx) const override
     {
         return Mixed(get(ndx));
     }
@@ -133,7 +133,7 @@ public:
             Array::insert(ndx, null_value);
         }
     }
-    Mixed get_as_mixed(size_t ndx) const override
+    Mixed get_any(size_t ndx) const override
     {
         return Mixed(get(ndx));
     }

--- a/src/realm/array_bool.hpp
+++ b/src/realm/array_bool.hpp
@@ -69,6 +69,10 @@ public:
     {
         return Array::get(ndx) != 0;
     }
+    Mixed get_as_mixed(size_t ndx) const override
+    {
+        return Mixed(get(ndx));
+    }
     void add(bool value)
     {
         Array::add(value);
@@ -128,6 +132,10 @@ public:
         else {
             Array::insert(ndx, null_value);
         }
+    }
+    Mixed get_as_mixed(size_t ndx) const override
+    {
+        return Mixed(get(ndx));
     }
     void set_null(size_t ndx)
     {

--- a/src/realm/array_decimal128.hpp
+++ b/src/realm/array_decimal128.hpp
@@ -71,7 +71,7 @@ public:
         return values[ndx];
     }
 
-    Mixed get_as_mixed(size_t ndx) const override
+    Mixed get_any(size_t ndx) const override
     {
         return Mixed(get(ndx));
     }

--- a/src/realm/array_decimal128.hpp
+++ b/src/realm/array_decimal128.hpp
@@ -71,6 +71,11 @@ public:
         return values[ndx];
     }
 
+    Mixed get_as_mixed(size_t ndx) const override
+    {
+        return Mixed(get(ndx));
+    }
+
     void add(Decimal128 value)
     {
         insert(size(), value);

--- a/src/realm/array_fixed_bytes.hpp
+++ b/src/realm/array_fixed_bytes.hpp
@@ -79,7 +79,7 @@ public:
         return get_pos(ndx).get_value(this);
     }
 
-    Mixed get_as_mixed(size_t ndx) const override
+    Mixed get_any(size_t ndx) const override
     {
         return Mixed(get(ndx));
     }
@@ -209,7 +209,7 @@ public:
         }
         return pos.get_value(this);
     }
-    Mixed get_as_mixed(size_t ndx) const override
+    Mixed get_any(size_t ndx) const override
     {
         return Mixed(get(ndx));
     }

--- a/src/realm/array_fixed_bytes.hpp
+++ b/src/realm/array_fixed_bytes.hpp
@@ -79,6 +79,11 @@ public:
         return get_pos(ndx).get_value(this);
     }
 
+    Mixed get_as_mixed(size_t ndx) const override
+    {
+        return Mixed(get(ndx));
+    }
+
     void add(const ObjectType& value)
     {
         insert(size(), value);
@@ -203,6 +208,10 @@ public:
             return util::none;
         }
         return pos.get_value(this);
+    }
+    Mixed get_as_mixed(size_t ndx) const override
+    {
+        return Mixed(get(ndx));
     }
     size_t find_first(const util::Optional<ObjectType>& value, size_t begin = 0, size_t end = npos) const
     {

--- a/src/realm/array_integer.cpp
+++ b/src/realm/array_integer.cpp
@@ -24,12 +24,12 @@
 
 using namespace realm;
 
-Mixed ArrayInteger::get_as_mixed(size_t ndx) const
+Mixed ArrayInteger::get_any(size_t ndx) const
 {
     return Mixed(get(ndx));
 }
 
-Mixed ArrayIntNull::get_as_mixed(size_t ndx) const
+Mixed ArrayIntNull::get_any(size_t ndx) const
 {
     return Mixed(get(ndx));
 }

--- a/src/realm/array_integer.cpp
+++ b/src/realm/array_integer.cpp
@@ -24,6 +24,15 @@
 
 using namespace realm;
 
+Mixed ArrayInteger::get_as_mixed(size_t ndx) const
+{
+    return Mixed(get(ndx));
+}
+
+Mixed ArrayIntNull::get_as_mixed(size_t ndx) const
+{
+    return Mixed(get(ndx));
+}
 
 MemRef ArrayIntNull::create_array(Type type, bool context_flag, size_t size, Allocator& alloc)
 {

--- a/src/realm/array_integer.hpp
+++ b/src/realm/array_integer.hpp
@@ -61,7 +61,7 @@ public:
     {
         Array::create(type_Normal, false, 0, 0);
     }
-    Mixed get_as_mixed(size_t ndx) const override;
+    Mixed get_any(size_t ndx) const override;
 
     bool is_null(size_t) const
     {
@@ -107,7 +107,7 @@ public:
     void add(value_type value);
     void set(size_t ndx, value_type value);
     value_type get(size_t ndx) const noexcept;
-    Mixed get_as_mixed(size_t ndx) const override;
+    Mixed get_any(size_t ndx) const override;
     static value_type get(const char* header, size_t ndx) noexcept;
     void get_chunk(size_t ndx, value_type res[8]) const noexcept;
     void set_null(size_t ndx);

--- a/src/realm/array_integer.hpp
+++ b/src/realm/array_integer.hpp
@@ -61,6 +61,7 @@ public:
     {
         Array::create(type_Normal, false, 0, 0);
     }
+    Mixed get_as_mixed(size_t ndx) const override;
 
     bool is_null(size_t) const
     {
@@ -106,6 +107,7 @@ public:
     void add(value_type value);
     void set(size_t ndx, value_type value);
     value_type get(size_t ndx) const noexcept;
+    Mixed get_as_mixed(size_t ndx) const override;
     static value_type get(const char* header, size_t ndx) noexcept;
     void get_chunk(size_t ndx, value_type res[8]) const noexcept;
     void set_null(size_t ndx);

--- a/src/realm/array_key.hpp
+++ b/src/realm/array_key.hpp
@@ -89,7 +89,7 @@ public:
     {
         return ObjKey{Array::get(ndx) - adj};
     }
-    Mixed get_as_mixed(size_t ndx) const override
+    Mixed get_any(size_t ndx) const override
     {
         return Mixed(get(ndx));
     }

--- a/src/realm/array_key.hpp
+++ b/src/realm/array_key.hpp
@@ -89,6 +89,10 @@ public:
     {
         return ObjKey{Array::get(ndx) - adj};
     }
+    Mixed get_as_mixed(size_t ndx) const override
+    {
+        return Mixed(get(ndx));
+    }
     bool is_null(size_t ndx) const
     {
         return Array::get(ndx) == 0;

--- a/src/realm/array_list.hpp
+++ b/src/realm/array_list.hpp
@@ -75,6 +75,11 @@ public:
     {
         return Array::get_as_ref(ndx);
     }
+    Mixed get_as_mixed(size_t) const override
+    {
+        REALM_ASSERT_DEBUG(false);
+        return {};
+    }
     bool is_null(size_t ndx) const
     {
         return Array::get(ndx) == 0;

--- a/src/realm/array_list.hpp
+++ b/src/realm/array_list.hpp
@@ -75,7 +75,7 @@ public:
     {
         return Array::get_as_ref(ndx);
     }
-    Mixed get_as_mixed(size_t) const override
+    Mixed get_any(size_t) const override
     {
         REALM_ASSERT_DEBUG(false);
         return {};

--- a/src/realm/array_mixed.hpp
+++ b/src/realm/array_mixed.hpp
@@ -79,6 +79,10 @@ public:
     void set_null(size_t ndx);
     void insert(size_t ndx, Mixed value);
     Mixed get(size_t ndx) const;
+    Mixed get_as_mixed(size_t ndx) const override
+    {
+        return get(ndx);
+    }
     bool is_null(size_t ndx) const
     {
         return m_composite.get(ndx) == 0;

--- a/src/realm/array_mixed.hpp
+++ b/src/realm/array_mixed.hpp
@@ -79,7 +79,7 @@ public:
     void set_null(size_t ndx);
     void insert(size_t ndx, Mixed value);
     Mixed get(size_t ndx) const;
-    Mixed get_as_mixed(size_t ndx) const override
+    Mixed get_any(size_t ndx) const override
     {
         return get(ndx);
     }

--- a/src/realm/array_string.cpp
+++ b/src/realm/array_string.cpp
@@ -210,7 +210,7 @@ StringData ArrayString::get_legacy(size_t ndx) const
     return {};
 }
 
-Mixed ArrayString::get_as_mixed(size_t ndx) const
+Mixed ArrayString::get_any(size_t ndx) const
 {
     return Mixed(get(ndx));
 }

--- a/src/realm/array_string.cpp
+++ b/src/realm/array_string.cpp
@@ -210,6 +210,11 @@ StringData ArrayString::get_legacy(size_t ndx) const
     return {};
 }
 
+Mixed ArrayString::get_as_mixed(size_t ndx) const
+{
+    return Mixed(get(ndx));
+}
+
 bool ArrayString::is_null(size_t ndx) const
 {
     switch (m_type) {

--- a/src/realm/array_string.hpp
+++ b/src/realm/array_string.hpp
@@ -105,7 +105,7 @@ public:
     void insert(size_t ndx, StringData value);
     StringData get(size_t ndx) const;
     StringData get_legacy(size_t ndx) const;
-    Mixed get_as_mixed(size_t ndx) const override;
+    Mixed get_any(size_t ndx) const override;
     bool is_null(size_t ndx) const;
     void erase(size_t ndx);
     void move(ArrayString& dst, size_t ndx);

--- a/src/realm/array_string.hpp
+++ b/src/realm/array_string.hpp
@@ -105,6 +105,7 @@ public:
     void insert(size_t ndx, StringData value);
     StringData get(size_t ndx) const;
     StringData get_legacy(size_t ndx) const;
+    Mixed get_as_mixed(size_t ndx) const override;
     bool is_null(size_t ndx) const;
     void erase(size_t ndx);
     void move(ArrayString& dst, size_t ndx);

--- a/src/realm/array_timestamp.hpp
+++ b/src/realm/array_timestamp.hpp
@@ -77,7 +77,7 @@ public:
         util::Optional<int64_t> seconds = m_seconds.get(ndx);
         return seconds ? Timestamp(*seconds, int32_t(m_nanoseconds.get(ndx))) : Timestamp{};
     }
-    Mixed get_as_mixed(size_t ndx) const override
+    Mixed get_any(size_t ndx) const override
     {
         return Mixed(get(ndx));
     }

--- a/src/realm/array_timestamp.hpp
+++ b/src/realm/array_timestamp.hpp
@@ -77,6 +77,10 @@ public:
         util::Optional<int64_t> seconds = m_seconds.get(ndx);
         return seconds ? Timestamp(*seconds, int32_t(m_nanoseconds.get(ndx))) : Timestamp{};
     }
+    Mixed get_as_mixed(size_t ndx) const override
+    {
+        return Mixed(get(ndx));
+    }
     bool is_null(size_t ndx) const
     {
         return m_seconds.is_null(ndx);

--- a/src/realm/array_typed_link.hpp
+++ b/src/realm/array_typed_link.hpp
@@ -112,6 +112,10 @@ public:
         uint32_t tk = uint32_t(Array::get(ndx) - 1) & 0x7FFFFFFF;
         return {TableKey(tk), ObjKey(Array::get(ndx + 1) - 1)};
     }
+    Mixed get_as_mixed(size_t ndx) const override
+    {
+        return Mixed(get(ndx));
+    }
     bool is_null(size_t ndx) const
     {
         return Array::get(ndx << 1) == 0;

--- a/src/realm/array_typed_link.hpp
+++ b/src/realm/array_typed_link.hpp
@@ -112,7 +112,7 @@ public:
         uint32_t tk = uint32_t(Array::get(ndx) - 1) & 0x7FFFFFFF;
         return {TableKey(tk), ObjKey(Array::get(ndx + 1) - 1)};
     }
-    Mixed get_as_mixed(size_t ndx) const override
+    Mixed get_any(size_t ndx) const override
     {
         return Mixed(get(ndx));
     }

--- a/src/realm/mixed.cpp
+++ b/src/realm/mixed.cpp
@@ -166,7 +166,6 @@ Mixed::Mixed(const Obj& obj) noexcept
 {
 }
 
-
 bool Mixed::types_are_comparable(const Mixed& lhs, const Mixed& rhs)
 {
     if (lhs.m_type == rhs.m_type)
@@ -177,6 +176,14 @@ bool Mixed::types_are_comparable(const Mixed& lhs, const Mixed& rhs)
 
     DataType l_type = lhs.get_type();
     DataType r_type = rhs.get_type();
+    return data_types_are_comparable(l_type, r_type);
+}
+
+bool Mixed::data_types_are_comparable(DataType l_type, DataType r_type)
+{
+    if (l_type == r_type)
+        return true;
+
     bool l_is_numeric = l_type == type_Int || l_type == type_Bool || l_type == type_Float || l_type == type_Double ||
                         l_type == type_Decimal;
     bool r_is_numeric = r_type == type_Int || r_type == type_Bool || r_type == type_Float || r_type == type_Double ||
@@ -193,7 +200,6 @@ bool Mixed::types_are_comparable(const Mixed& lhs, const Mixed& rhs)
     }
     return false;
 }
-
 
 int Mixed::compare(const Mixed& b) const
 {

--- a/src/realm/mixed.hpp
+++ b/src/realm/mixed.hpp
@@ -169,6 +169,7 @@ public:
     }
 
     static bool types_are_comparable(const Mixed& l, const Mixed& r);
+    static bool data_types_are_comparable(DataType l_type, DataType r_type);
 
     template <class T>
     T get() const noexcept;

--- a/src/realm/node.hpp
+++ b/src/realm/node.hpp
@@ -352,7 +352,7 @@ public:
     virtual ~ArrayPayload();
     virtual void init_from_ref(ref_type) noexcept = 0;
     virtual void set_parent(ArrayParent* parent, size_t ndx_in_parent) noexcept = 0;
-    virtual Mixed get_as_mixed(size_t ndx) const = 0;
+    virtual Mixed get_any(size_t ndx) const = 0;
     virtual bool need_spec() const
     {
         return false;

--- a/src/realm/node.hpp
+++ b/src/realm/node.hpp
@@ -24,6 +24,8 @@
 
 namespace realm {
 
+class Mixed;
+
 /// Special index value. It has various meanings depending on
 /// context. It is returned by some search functions to indicate 'not
 /// found'. It is similar in function to std::string::npos.
@@ -350,6 +352,7 @@ public:
     virtual ~ArrayPayload();
     virtual void init_from_ref(ref_type) noexcept = 0;
     virtual void set_parent(ArrayParent* parent, size_t ndx_in_parent) noexcept = 0;
+    virtual Mixed get_as_mixed(size_t ndx) const = 0;
     virtual bool need_spec() const
     {
         return false;

--- a/src/realm/query.cpp
+++ b/src/realm/query.cpp
@@ -458,142 +458,42 @@ Query& Query::add_size_condition(ColKey column_key, int64_t value)
     return *this;
 }
 
-
-template <class ColumnType>
+// Two column methods, any type
 Query& Query::equal(ColKey column_key1, ColKey column_key2)
 {
-    auto node = std::unique_ptr<ParentNode>(new TwoColumnsNode<ColumnType, Equal>(column_key1, column_key2));
+    auto node = std::unique_ptr<ParentNode>(new TwoColumnsNode<Equal>(column_key1, column_key2));
     add_node(std::move(node));
     return *this;
 }
-
-// Two column methods, any type
-template <class ColumnType>
 Query& Query::less(ColKey column_key1, ColKey column_key2)
 {
-    auto node = std::unique_ptr<ParentNode>(new TwoColumnsNode<ColumnType, Less>(column_key1, column_key2));
+    auto node = std::unique_ptr<ParentNode>(new TwoColumnsNode<Less>(column_key1, column_key2));
     add_node(std::move(node));
     return *this;
 }
-template <class ColumnType>
 Query& Query::less_equal(ColKey column_key1, ColKey column_key2)
 {
-    auto node = std::unique_ptr<ParentNode>(new TwoColumnsNode<ColumnType, LessEqual>(column_key1, column_key2));
+    auto node = std::unique_ptr<ParentNode>(new TwoColumnsNode<LessEqual>(column_key1, column_key2));
     add_node(std::move(node));
     return *this;
 }
-template <class ColumnType>
 Query& Query::greater(ColKey column_key1, ColKey column_key2)
 {
-    auto node = std::unique_ptr<ParentNode>(new TwoColumnsNode<ColumnType, Greater>(column_key1, column_key2));
+    auto node = std::unique_ptr<ParentNode>(new TwoColumnsNode<Greater>(column_key1, column_key2));
     add_node(std::move(node));
     return *this;
 }
-template <class ColumnType>
 Query& Query::greater_equal(ColKey column_key1, ColKey column_key2)
 {
-    auto node = std::unique_ptr<ParentNode>(new TwoColumnsNode<ColumnType, GreaterEqual>(column_key1, column_key2));
+    auto node = std::unique_ptr<ParentNode>(new TwoColumnsNode<GreaterEqual>(column_key1, column_key2));
     add_node(std::move(node));
     return *this;
 }
-template <class ColumnType>
 Query& Query::not_equal(ColKey column_key1, ColKey column_key2)
 {
-    auto node = std::unique_ptr<ParentNode>(new TwoColumnsNode<ColumnType, NotEqual>(column_key1, column_key2));
+    auto node = std::unique_ptr<ParentNode>(new TwoColumnsNode<NotEqual>(column_key1, column_key2));
     add_node(std::move(node));
     return *this;
-}
-
-// column vs column, integer
-Query& Query::equal_int(ColKey column_key1, ColKey column_key2)
-{
-    return equal<ArrayInteger>(column_key1, column_key2);
-}
-
-Query& Query::not_equal_int(ColKey column_key1, ColKey column_key2)
-{
-    return not_equal<ArrayInteger>(column_key1, column_key2);
-}
-
-Query& Query::less_int(ColKey column_key1, ColKey column_key2)
-{
-    return less<ArrayInteger>(column_key1, column_key2);
-}
-
-Query& Query::greater_equal_int(ColKey column_key1, ColKey column_key2)
-{
-    return greater_equal<ArrayInteger>(column_key1, column_key2);
-}
-
-Query& Query::less_equal_int(ColKey column_key1, ColKey column_key2)
-{
-    return less_equal<ArrayInteger>(column_key1, column_key2);
-}
-
-Query& Query::greater_int(ColKey column_key1, ColKey column_key2)
-{
-    return greater<ArrayInteger>(column_key1, column_key2);
-}
-
-
-// column vs column, float
-Query& Query::not_equal_float(ColKey column_key1, ColKey column_key2)
-{
-    return not_equal<ArrayFloat>(column_key1, column_key2);
-}
-
-Query& Query::less_float(ColKey column_key1, ColKey column_key2)
-{
-    return less<ArrayFloat>(column_key1, column_key2);
-}
-
-Query& Query::greater_float(ColKey column_key1, ColKey column_key2)
-{
-    return greater<ArrayFloat>(column_key1, column_key2);
-}
-
-Query& Query::greater_equal_float(ColKey column_key1, ColKey column_key2)
-{
-    return greater_equal<ArrayFloat>(column_key1, column_key2);
-}
-
-Query& Query::less_equal_float(ColKey column_key1, ColKey column_key2)
-{
-    return less_equal<ArrayFloat>(column_key1, column_key2);
-}
-
-Query& Query::equal_float(ColKey column_key1, ColKey column_key2)
-{
-    return equal<ArrayFloat>(column_key1, column_key2);
-}
-
-// column vs column, double
-Query& Query::equal_double(ColKey column_key1, ColKey column_key2)
-{
-    return equal<ArrayDouble>(column_key1, column_key2);
-}
-
-Query& Query::less_equal_double(ColKey column_key1, ColKey column_key2)
-{
-    return less_equal<ArrayDouble>(column_key1, column_key2);
-}
-
-Query& Query::greater_equal_double(ColKey column_key1, ColKey column_key2)
-{
-    return greater_equal<ArrayDouble>(column_key1, column_key2);
-}
-Query& Query::greater_double(ColKey column_key1, ColKey column_key2)
-{
-    return greater<ArrayDouble>(column_key1, column_key2);
-}
-Query& Query::less_double(ColKey column_key1, ColKey column_key2)
-{
-    return less<ArrayDouble>(column_key1, column_key2);
-}
-
-Query& Query::not_equal_double(ColKey column_key1, ColKey column_key2)
-{
-    return not_equal<ArrayDouble>(column_key1, column_key2);
 }
 
 // null vs column

--- a/src/realm/query.hpp
+++ b/src/realm/query.hpp
@@ -122,14 +122,6 @@ public:
     Query& less_equal(ColKey column_key, int value);
     Query& between(ColKey column_key, int from, int to);
 
-    // Conditions: 2 int columns
-    Query& equal_int(ColKey column_key1, ColKey column_key2);
-    Query& not_equal_int(ColKey column_key1, ColKey column_key2);
-    Query& greater_int(ColKey column_key1, ColKey column_key2);
-    Query& less_int(ColKey column_key1, ColKey column_key2);
-    Query& greater_equal_int(ColKey column_key1, ColKey column_key2);
-    Query& less_equal_int(ColKey column_key1, ColKey column_key2);
-
     // Conditions: float
     Query& equal(ColKey column_key, float value);
     Query& not_equal(ColKey column_key, float value);
@@ -139,14 +131,6 @@ public:
     Query& less_equal(ColKey column_key, float value);
     Query& between(ColKey column_key, float from, float to);
 
-    // Conditions: 2 float columns
-    Query& equal_float(ColKey column_key1, ColKey column_key2);
-    Query& not_equal_float(ColKey column_key1, ColKey column_key2);
-    Query& greater_float(ColKey column_key1, ColKey column_key2);
-    Query& greater_equal_float(ColKey column_key1, ColKey column_key2);
-    Query& less_float(ColKey column_key1, ColKey column_key2);
-    Query& less_equal_float(ColKey column_key1, ColKey column_key2);
-
     // Conditions: double
     Query& equal(ColKey column_key, double value);
     Query& not_equal(ColKey column_key, double value);
@@ -155,14 +139,6 @@ public:
     Query& less(ColKey column_key, double value);
     Query& less_equal(ColKey column_key, double value);
     Query& between(ColKey column_key, double from, double to);
-
-    // Conditions: 2 double columns
-    Query& equal_double(ColKey column_key1, ColKey column_key2);
-    Query& not_equal_double(ColKey column_key1, ColKey column_key2);
-    Query& greater_double(ColKey column_key1, ColKey column_key2);
-    Query& greater_equal_double(ColKey column_key1, ColKey column_key2);
-    Query& less_double(ColKey column_key1, ColKey column_key2);
-    Query& less_equal_double(ColKey column_key1, ColKey column_key2);
 
     // Conditions: timestamp
     Query& equal(ColKey column_key, Timestamp value);
@@ -231,6 +207,15 @@ public:
     Query& ends_with(ColKey column_key, BinaryData value, bool case_sensitive = true);
     Query& contains(ColKey column_key, BinaryData value, bool case_sensitive = true);
     Query& like(ColKey column_key, BinaryData b, bool case_sensitive = true);
+
+    // Conditions: untyped column vs column comparison
+    // if the column types are not comparable, an exception is thrown
+    Query& equal(ColKey column_key1, ColKey column_key2);
+    Query& less(ColKey column_key1, ColKey column_key2);
+    Query& less_equal(ColKey column_key1, ColKey column_key2);
+    Query& greater(ColKey column_key1, ColKey column_key2);
+    Query& greater_equal(ColKey column_key1, ColKey column_key2);
+    Query& not_equal(ColKey column_key1, ColKey column_key2);
 
     // Negation
     Query& Not();
@@ -330,24 +315,6 @@ public:
 
 private:
     void add_expression_node(std::unique_ptr<Expression>);
-
-    template <class ColumnType>
-    Query& equal(ColKey column_key1, ColKey column_key2);
-
-    template <class ColumnType>
-    Query& less(ColKey column_key1, ColKey column_key2);
-
-    template <class ColumnType>
-    Query& less_equal(ColKey column_key1, ColKey column_key2);
-
-    template <class ColumnType>
-    Query& greater(ColKey column_key1, ColKey column_key2);
-
-    template <class ColumnType>
-    Query& greater_equal(ColKey column_key1, ColKey column_key2);
-
-    template <class ColumnType>
-    Query& not_equal(ColKey column_key1, ColKey column_key2);
 
     template <typename TConditionFunction, class T>
     Query& add_condition(ColKey column_key, T value);

--- a/src/realm/query_engine.cpp
+++ b/src/realm/query_engine.cpp
@@ -477,48 +477,6 @@ std::unique_ptr<ArrayPayload> TwoColumnsNodeBase::update_cached_leaf_pointers_fo
     return {};
 }
 
-Mixed TwoColumnsNodeBase::get_value_from_leaf(ArrayPayload* leaf, ColumnType col_type, bool nullable, size_t ndx)
-{
-    switch (col_type) {
-        case col_type_Int:
-            if (nullable) {
-                return (static_cast<ArrayIntNull*>(leaf))->get(ndx);
-            }
-            return (static_cast<ArrayInteger*>(leaf))->get(ndx);
-        case col_type_Bool:
-            return (static_cast<ArrayBoolNull*>(leaf))->get(ndx);
-        case col_type_String:
-            return (static_cast<ArrayString*>(leaf))->get(ndx);
-        case col_type_Binary:
-            return (static_cast<ArrayBinary*>(leaf))->get(ndx);
-        case col_type_Mixed:
-            return (static_cast<ArrayMixed*>(leaf))->get(ndx);
-        case col_type_Timestamp:
-            return (static_cast<ArrayTimestamp*>(leaf))->get(ndx);
-        case col_type_Float:
-            return (static_cast<ArrayFloatNull*>(leaf))->get(ndx);
-        case col_type_Double:
-            return (static_cast<ArrayDoubleNull*>(leaf))->get(ndx);
-        case col_type_Decimal:
-            return (static_cast<ArrayDecimal128*>(leaf))->get(ndx);
-        case col_type_Link:
-            return (static_cast<ArrayKey*>(leaf))->get(ndx);
-        case col_type_ObjectId:
-            return (static_cast<ArrayObjectIdNull*>(leaf))->get(ndx);
-        case col_type_UUID:
-            return (static_cast<ArrayUUIDNull*>(leaf))->get(ndx);
-        case col_type_TypedLink:
-        case col_type_BackLink:
-        case col_type_LinkList:
-        case col_type_OldDateTime:
-        case col_type_OldTable:
-            break;
-    };
-    REALM_UNREACHABLE();
-    return {};
-}
-
-
 } // namespace realm
 
 size_t NotNode::find_first_local(size_t start, size_t end)

--- a/src/realm/query_engine.cpp
+++ b/src/realm/query_engine.cpp
@@ -435,6 +435,90 @@ size_t StringNode<EqualIns>::_find_first_local(size_t start, size_t end)
     return not_found;
 }
 
+std::unique_ptr<ArrayPayload> TwoColumnsNodeBase::update_cached_leaf_pointers_for_column(Allocator& alloc,
+                                                                                         const ColKey& col_key)
+{
+    switch (col_key.get_type()) {
+        case col_type_Int:
+            if (col_key.is_nullable()) {
+                return std::make_unique<ArrayIntNull>(alloc);
+            }
+            return std::make_unique<ArrayInteger>(alloc);
+        case col_type_Bool:
+            return std::make_unique<ArrayBool>(alloc);
+        case col_type_String:
+            return std::make_unique<ArrayString>(alloc);
+        case col_type_Binary:
+            return std::make_unique<ArrayBinary>(alloc);
+        case col_type_Mixed:
+            return std::make_unique<ArrayMixed>(alloc);
+        case col_type_Timestamp:
+            return std::make_unique<ArrayTimestamp>(alloc);
+        case col_type_Float:
+            return std::make_unique<ArrayFloat>(alloc);
+        case col_type_Double:
+            return std::make_unique<ArrayDouble>(alloc);
+        case col_type_Decimal:
+            return std::make_unique<ArrayDecimal128>(alloc);
+        case col_type_Link:
+            return std::make_unique<ArrayKey>(alloc);
+        case col_type_ObjectId:
+            return std::make_unique<ArrayObjectIdNull>(alloc);
+        case col_type_UUID:
+            return std::make_unique<ArrayUUIDNull>(alloc);
+        case col_type_TypedLink:
+        case col_type_BackLink:
+        case col_type_LinkList:
+        case col_type_OldDateTime:
+        case col_type_OldTable:
+            break;
+    };
+    REALM_UNREACHABLE();
+    return {};
+}
+
+Mixed TwoColumnsNodeBase::get_value_from_leaf(ArrayPayload* leaf, ColumnType col_type, bool nullable, size_t ndx)
+{
+    switch (col_type) {
+        case col_type_Int:
+            if (nullable) {
+                return (static_cast<ArrayIntNull*>(leaf))->get(ndx);
+            }
+            return (static_cast<ArrayInteger*>(leaf))->get(ndx);
+        case col_type_Bool:
+            return (static_cast<ArrayBool*>(leaf))->get(ndx);
+        case col_type_String:
+            return (static_cast<ArrayString*>(leaf))->get(ndx);
+        case col_type_Binary:
+            return (static_cast<ArrayBinary*>(leaf))->get(ndx);
+        case col_type_Mixed:
+            return (static_cast<ArrayMixed*>(leaf))->get(ndx);
+        case col_type_Timestamp:
+            return (static_cast<ArrayTimestamp*>(leaf))->get(ndx);
+        case col_type_Float:
+            return (static_cast<ArrayFloat*>(leaf))->get(ndx);
+        case col_type_Double:
+            return (static_cast<ArrayDouble*>(leaf))->get(ndx);
+        case col_type_Decimal:
+            return (static_cast<ArrayDecimal128*>(leaf))->get(ndx);
+        case col_type_Link:
+            return (static_cast<ArrayKey*>(leaf))->get(ndx);
+        case col_type_ObjectId:
+            return (static_cast<ArrayObjectIdNull*>(leaf))->get(ndx);
+        case col_type_UUID:
+            return (static_cast<ArrayUUIDNull*>(leaf))->get(ndx);
+        case col_type_TypedLink:
+        case col_type_BackLink:
+        case col_type_LinkList:
+        case col_type_OldDateTime:
+        case col_type_OldTable:
+            break;
+    };
+    REALM_UNREACHABLE();
+    return {};
+}
+
+
 } // namespace realm
 
 size_t NotNode::find_first_local(size_t start, size_t end)

--- a/src/realm/query_engine.cpp
+++ b/src/realm/query_engine.cpp
@@ -445,7 +445,7 @@ std::unique_ptr<ArrayPayload> TwoColumnsNodeBase::update_cached_leaf_pointers_fo
             }
             return std::make_unique<ArrayInteger>(alloc);
         case col_type_Bool:
-            return std::make_unique<ArrayBool>(alloc);
+            return std::make_unique<ArrayBoolNull>(alloc);
         case col_type_String:
             return std::make_unique<ArrayString>(alloc);
         case col_type_Binary:
@@ -455,9 +455,9 @@ std::unique_ptr<ArrayPayload> TwoColumnsNodeBase::update_cached_leaf_pointers_fo
         case col_type_Timestamp:
             return std::make_unique<ArrayTimestamp>(alloc);
         case col_type_Float:
-            return std::make_unique<ArrayFloat>(alloc);
+            return std::make_unique<ArrayFloatNull>(alloc);
         case col_type_Double:
-            return std::make_unique<ArrayDouble>(alloc);
+            return std::make_unique<ArrayDoubleNull>(alloc);
         case col_type_Decimal:
             return std::make_unique<ArrayDecimal128>(alloc);
         case col_type_Link:
@@ -486,7 +486,7 @@ Mixed TwoColumnsNodeBase::get_value_from_leaf(ArrayPayload* leaf, ColumnType col
             }
             return (static_cast<ArrayInteger*>(leaf))->get(ndx);
         case col_type_Bool:
-            return (static_cast<ArrayBool*>(leaf))->get(ndx);
+            return (static_cast<ArrayBoolNull*>(leaf))->get(ndx);
         case col_type_String:
             return (static_cast<ArrayString*>(leaf))->get(ndx);
         case col_type_Binary:
@@ -496,9 +496,9 @@ Mixed TwoColumnsNodeBase::get_value_from_leaf(ArrayPayload* leaf, ColumnType col
         case col_type_Timestamp:
             return (static_cast<ArrayTimestamp*>(leaf))->get(ndx);
         case col_type_Float:
-            return (static_cast<ArrayFloat*>(leaf))->get(ndx);
+            return (static_cast<ArrayFloatNull*>(leaf))->get(ndx);
         case col_type_Double:
-            return (static_cast<ArrayDouble*>(leaf))->get(ndx);
+            return (static_cast<ArrayDoubleNull*>(leaf))->get(ndx);
         case col_type_Decimal:
             return (static_cast<ArrayDecimal128*>(leaf))->get(ndx);
         case col_type_Link:

--- a/src/realm/query_engine.hpp
+++ b/src/realm/query_engine.hpp
@@ -2559,8 +2559,8 @@ public:
     {
         size_t s = start;
         while (s < end) {
-            Mixed v1 = m_leaf_ptr1->get_as_mixed(s);
-            Mixed v2 = m_leaf_ptr2->get_as_mixed(s);
+            Mixed v1 = m_leaf_ptr1->get_any(s);
+            Mixed v2 = m_leaf_ptr2->get_any(s);
             if (TConditionFunction()(v1, v2, v1.is_null(), v2.is_null()))
                 return s;
             else

--- a/src/realm/query_engine.hpp
+++ b/src/realm/query_engine.hpp
@@ -2550,33 +2550,6 @@ public:
         bool col2_nullable = m_condition_column_key2.is_nullable();
 
         while (s < end) {
-            // FIXME: maybe optimize ints
-            //            if (std::is_same<TConditionValue, int64_t>::value) {
-            //                // For int64_t we've created an array intrinsics named compare_leafs which template
-            //                expands bitwidths
-            //                // of boths arrays to make Get faster.
-            //                QueryState<int64_t> qs(act_ReturnFirst);
-            //                bool resume = m_leaf_ptr1->template compare_leafs<TConditionFunction, act_ReturnFirst>(
-            //                    m_leaf_ptr2, start, end, 0, &qs, CallbackDummy());
-            //
-            //                if (resume)
-            //                    s = end;
-            //                else
-            //                    return to_size_t(qs.m_state);
-            //            }
-            // This is for float and double.
-
-#if 0 && defined(REALM_COMPILER_AVX)
-// AVX has been disabled because of array alignment (see https://app.asana.com/0/search/8836174089724/5763107052506)
-//
-// For AVX you can call things like if (sseavx<1>()) to test for AVX, and then utilize _mm256_movemask_ps (VC)
-// or movemask_cmp_ps (gcc/clang)
-//
-// See https://github.com/rrrlasse/realm/tree/AVX for an example of utilizing AVX for a two-column search which has
-// been benchmarked to: floats: 288 ms vs 552 by using AVX compared to 2-level-unrolled FPU loop. doubles: 415 ms vs
-// 475 (more bandwidth bound). Tests against SSE have not been performed; AVX may not pay off. Please benchmark
-#endif
-
             Mixed v1 = get_value_from_leaf(m_leaf_ptr1.get(), col1_type, col1_nullable, s);
             Mixed v2 = get_value_from_leaf(m_leaf_ptr2.get(), col2_type, col2_nullable, s);
             if (TConditionFunction()(v1, v2))

--- a/src/realm/query_engine.hpp
+++ b/src/realm/query_engine.hpp
@@ -2495,14 +2495,8 @@ public:
                                                       ParentNode::m_table->get_column_name(m_condition_column_key1),
                                                       ParentNode::m_table->get_column_name(m_condition_column_key2)));
             }
-            if (!ParentNode::m_table->valid_column(m_condition_column_key1) ||
-                !ParentNode::m_table->valid_column(m_condition_column_key2)) {
-                throw std::runtime_error(util::format(
-                    "Comparison between two properties must be linked with a relationship or exist on the same "
-                    "Table. For query applied on %1 with properties: %2 and %3)",
-                    ParentNode::m_table->get_name(), ParentNode::m_table->get_column_name(m_condition_column_key1),
-                    ParentNode::m_table->get_column_name(m_condition_column_key2)));
-            }
+            ParentNode::m_table->check_column(m_condition_column_key1);
+            ParentNode::m_table->check_column(m_condition_column_key2);
         }
     }
 

--- a/src/realm/query_expression.hpp
+++ b/src/realm/query_expression.hpp
@@ -977,20 +977,36 @@ public:
         // query_engine supports 'T-column <op> <T-column>' for T = {int64_t, float, double}, op = {<, >, ==, !=, <=,
         // >=},
         // but only if both columns are non-nullable, and aren't in linked tables.
-        if (left_col && right_col && !left_col->links_exist() && !right_col->links_exist()) {
+        if (left_col && right_col) {
             ConstTableRef t = left_col->get_base_table();
-            if (std::is_same_v<Cond, Less>)
-                return Query(t).less(left_col->column_key(), right_col->column_key());
-            if (std::is_same_v<Cond, Greater>)
-                return Query(t).greater(left_col->column_key(), right_col->column_key());
-            if (std::is_same_v<Cond, Equal>)
-                return Query(t).equal(left_col->column_key(), right_col->column_key());
-            if (std::is_same_v<Cond, NotEqual>)
-                return Query(t).not_equal(left_col->column_key(), right_col->column_key());
-            if (std::is_same_v<Cond, LessEqual>)
-                return Query(t).less_equal(left_col->column_key(), right_col->column_key());
-            if (std::is_same_v<Cond, GreaterEqual>)
-                return Query(t).greater_equal(left_col->column_key(), right_col->column_key());
+            ConstTableRef t_right = right_col->get_base_table();
+            REALM_ASSERT_DEBUG(t);
+            REALM_ASSERT_DEBUG(t_right);
+            ColKey left_base_col_key =
+                left_col->links_exist() ? left_col->get_link_map().get_column_at(0) : left_col->column_key();
+            ColKey right_base_col_key =
+                right_col->links_exist() ? right_col->get_link_map().get_column_at(0) : right_col->column_key();
+            // we only support multi column comparisons if they stem from the same table
+            if (!t->valid_column(left_base_col_key) || !t->valid_column(right_base_col_key)) {
+                throw std::runtime_error(util::format(
+                    "Comparison between two properties must be linked with a relationship or exist on the same "
+                    "Table (%1 and %2)",
+                    t->get_name(), right_col->get_base_table()->get_name()));
+            }
+            if (!left_col->links_exist() && !right_col->links_exist()) {
+                if (std::is_same_v<Cond, Less>)
+                    return Query(t).less(left_col->column_key(), right_col->column_key());
+                if (std::is_same_v<Cond, Greater>)
+                    return Query(t).greater(left_col->column_key(), right_col->column_key());
+                if (std::is_same_v<Cond, Equal>)
+                    return Query(t).equal(left_col->column_key(), right_col->column_key());
+                if (std::is_same_v<Cond, NotEqual>)
+                    return Query(t).not_equal(left_col->column_key(), right_col->column_key());
+                if (std::is_same_v<Cond, LessEqual>)
+                    return Query(t).less_equal(left_col->column_key(), right_col->column_key());
+                if (std::is_same_v<Cond, GreaterEqual>)
+                    return Query(t).greater_equal(left_col->column_key(), right_col->column_key());
+            }
         }
 #endif
         // Return query_expression.hpp node
@@ -1774,6 +1790,12 @@ public:
     {
         REALM_ASSERT(!m_tables.empty());
         return m_tables.back();
+    }
+
+    ColKey get_column_at(size_t ndx)
+    {
+        REALM_ASSERT_EX(ndx < m_link_column_keys.size(), ndx, m_link_column_keys.size());
+        return m_link_column_keys[ndx];
     }
 
     bool links_exist() const

--- a/src/realm/query_expression.hpp
+++ b/src/realm/query_expression.hpp
@@ -977,52 +977,20 @@ public:
         // query_engine supports 'T-column <op> <T-column>' for T = {int64_t, float, double}, op = {<, >, ==, !=, <=,
         // >=},
         // but only if both columns are non-nullable, and aren't in linked tables.
-        if (left_col && right_col && std::is_same_v<L, R> && !left_col->is_nullable() && !right_col->is_nullable() &&
-            !left_col->links_exist() && !right_col->links_exist()) {
+        if (left_col && right_col && !left_col->links_exist() && !right_col->links_exist()) {
             ConstTableRef t = left_col->get_base_table();
-
-            if (std::numeric_limits<L>::is_integer) {
-                if (std::is_same_v<Cond, Less>)
-                    return Query(t).less_int(left_col->column_key(), right_col->column_key());
-                if (std::is_same_v<Cond, Greater>)
-                    return Query(t).greater_int(left_col->column_key(), right_col->column_key());
-                if (std::is_same_v<Cond, Equal>)
-                    return Query(t).equal_int(left_col->column_key(), right_col->column_key());
-                if (std::is_same_v<Cond, NotEqual>)
-                    return Query(t).not_equal_int(left_col->column_key(), right_col->column_key());
-                if (std::is_same_v<Cond, LessEqual>)
-                    return Query(t).less_equal_int(left_col->column_key(), right_col->column_key());
-                if (std::is_same_v<Cond, GreaterEqual>)
-                    return Query(t).greater_equal_int(left_col->column_key(), right_col->column_key());
-            }
-            else if (std::is_same_v<L, float>) {
-                if (std::is_same_v<Cond, Less>)
-                    return Query(t).less_float(left_col->column_key(), right_col->column_key());
-                if (std::is_same_v<Cond, Greater>)
-                    return Query(t).greater_float(left_col->column_key(), right_col->column_key());
-                if (std::is_same_v<Cond, Equal>)
-                    return Query(t).equal_float(left_col->column_key(), right_col->column_key());
-                if (std::is_same_v<Cond, NotEqual>)
-                    return Query(t).not_equal_float(left_col->column_key(), right_col->column_key());
-                if (std::is_same_v<Cond, LessEqual>)
-                    return Query(t).less_equal_float(left_col->column_key(), right_col->column_key());
-                if (std::is_same_v<Cond, GreaterEqual>)
-                    return Query(t).greater_equal_float(left_col->column_key(), right_col->column_key());
-            }
-            else if (std::is_same_v<L, double>) {
-                if (std::is_same_v<Cond, Less>)
-                    return Query(t).less_double(left_col->column_key(), right_col->column_key());
-                if (std::is_same_v<Cond, Greater>)
-                    return Query(t).greater_double(left_col->column_key(), right_col->column_key());
-                if (std::is_same_v<Cond, Equal>)
-                    return Query(t).equal_double(left_col->column_key(), right_col->column_key());
-                if (std::is_same_v<Cond, NotEqual>)
-                    return Query(t).not_equal_double(left_col->column_key(), right_col->column_key());
-                if (std::is_same_v<Cond, LessEqual>)
-                    return Query(t).less_equal_double(left_col->column_key(), right_col->column_key());
-                if (std::is_same_v<Cond, GreaterEqual>)
-                    return Query(t).greater_equal_double(left_col->column_key(), right_col->column_key());
-            }
+            if (std::is_same_v<Cond, Less>)
+                return Query(t).less(left_col->column_key(), right_col->column_key());
+            if (std::is_same_v<Cond, Greater>)
+                return Query(t).greater(left_col->column_key(), right_col->column_key());
+            if (std::is_same_v<Cond, Equal>)
+                return Query(t).equal(left_col->column_key(), right_col->column_key());
+            if (std::is_same_v<Cond, NotEqual>)
+                return Query(t).not_equal(left_col->column_key(), right_col->column_key());
+            if (std::is_same_v<Cond, LessEqual>)
+                return Query(t).less_equal(left_col->column_key(), right_col->column_key());
+            if (std::is_same_v<Cond, GreaterEqual>)
+                return Query(t).greater_equal(left_col->column_key(), right_col->column_key());
         }
 #endif
         // Return query_expression.hpp node

--- a/src/realm/query_expression.hpp
+++ b/src/realm/query_expression.hpp
@@ -982,16 +982,12 @@ public:
             ConstTableRef t_right = right_col->get_base_table();
             REALM_ASSERT_DEBUG(t);
             REALM_ASSERT_DEBUG(t_right);
-            ColKey left_base_col_key =
-                left_col->links_exist() ? left_col->get_link_map().get_column_at(0) : left_col->column_key();
-            ColKey right_base_col_key =
-                right_col->links_exist() ? right_col->get_link_map().get_column_at(0) : right_col->column_key();
             // we only support multi column comparisons if they stem from the same table
-            if (!t->valid_column(left_base_col_key) || !t->valid_column(right_base_col_key)) {
+            if (t->get_key() != t_right->get_key()) {
                 throw std::runtime_error(util::format(
                     "Comparison between two properties must be linked with a relationship or exist on the same "
                     "Table (%1 and %2)",
-                    t->get_name(), right_col->get_base_table()->get_name()));
+                    t->get_name(), t_right->get_name()));
             }
             if (!left_col->links_exist() && !right_col->links_exist()) {
                 if (std::is_same_v<Cond, Less>)
@@ -1790,12 +1786,6 @@ public:
     {
         REALM_ASSERT(!m_tables.empty());
         return m_tables.back();
-    }
-
-    ColKey get_column_at(size_t ndx)
-    {
-        REALM_ASSERT_EX(ndx < m_link_column_keys.size(), ndx, m_link_column_keys.size());
-        return m_link_column_keys[ndx];
     }
 
     bool links_exist() const

--- a/test/test_query.cpp
+++ b/test/test_query.cpp
@@ -2437,11 +2437,13 @@ TEST(Query_TwoColumnsDifferentTables)
     auto table_b = g.add_table("table b");
     ColKey col_a = table_a->add_column(type_Float, "float");
     ColKey col_b = table_b->add_column(type_Float, "float");
+    ColKey col_c = table_b->add_column(type_Float, "another float");
     table_a->create_object();
     table_a->create_object();
     table_b->create_object();
 
     CHECK_THROW_ANY(table_a->where().equal(col_a, col_b).count());
+    CHECK_THROW_ANY(table_a->where().equal(col_b, col_c).count());
     CHECK_THROW_ANY((table_a->column<Float>(col_a) == table_b->column<Float>(col_b)).count());
 }
 

--- a/test/test_query.cpp
+++ b/test/test_query.cpp
@@ -2213,6 +2213,15 @@ TEST(Query_TwoColumnsCrossTypes)
                               << " == " << table.get_column_name(rhs) << std::endl;
                 }
             }
+            // select some typed query expressions to test as well
+            if (lhs_type == type_Int && rhs_type == type_Double) {
+                size_t actual_matches = (table.column<Int>(lhs) == table.column<Double>(rhs)).count();
+                CHECK_EQUAL(num_expected_matches, actual_matches);
+            }
+            if (lhs_type == type_String && rhs_type == type_Binary) {
+                size_t actual_matches = (table.column<String>(lhs) == table.column<Binary>(rhs)).count();
+                CHECK_EQUAL(num_expected_matches, actual_matches);
+            }
             {
                 size_t actual_matches = table.where().not_equal(lhs, rhs).count();
                 CHECK_EQUAL(num_rows - num_expected_matches, actual_matches);
@@ -2267,8 +2276,6 @@ TEST(Query_TwoColumnsCrossTypes)
                               << table.get_column_name(rhs) << std::endl;
                 }
             }
-
-            //    Query q_int = table.column<Int>(col_int) == table.column<type>(col_test);
         }
     }
 }

--- a/test/test_query.cpp
+++ b/test/test_query.cpp
@@ -2442,6 +2442,7 @@ TEST(Query_TwoColumnsDifferentTables)
     table_b->create_object();
 
     CHECK_THROW_ANY(table_a->where().equal(col_a, col_b).count());
+    CHECK_THROW_ANY((table_a->column<Float>(col_a) == table_b->column<Float>(col_b)).count());
 }
 
 TEST(Query_DateTest)

--- a/test/test_query.cpp
+++ b/test/test_query.cpp
@@ -2430,6 +2430,20 @@ TEST(Query_TwoColumnsCrossTypesNaN)
     }
 }
 
+TEST(Query_TwoColumnsDifferentTables)
+{
+    Group g;
+    auto table_a = g.add_table("table a");
+    auto table_b = g.add_table("table b");
+    ColKey col_a = table_a->add_column(type_Float, "float");
+    ColKey col_b = table_b->add_column(type_Float, "float");
+    table_a->create_object();
+    table_a->create_object();
+    table_b->create_object();
+
+    CHECK_THROW_ANY(table_a->where().equal(col_a, col_b).count());
+}
+
 TEST(Query_DateTest)
 {
     Table table;

--- a/test/test_query.cpp
+++ b/test/test_query.cpp
@@ -35,6 +35,7 @@ using namespace std::chrono;
 #include <realm/query_expression.hpp>
 #include "test.hpp"
 #include "test_table_helper.hpp"
+#include "test_types_helper.hpp"
 
 using namespace realm;
 using namespace realm::util;
@@ -2012,12 +2013,12 @@ TEST(Query_TwoColsEqualVaryWidthAndValues)
             doubles.push_back(key);
     }
 
-    realm::TableView t1 = table.where().equal_int(col_int0, col_int1).find_all();
-    realm::TableView t2 = table.where().equal_int(col_int2, col_int3).find_all();
-    realm::TableView t3 = table.where().equal_int(col_int4, col_int5).find_all();
+    realm::TableView t1 = table.where().equal(col_int0, col_int1).find_all();
+    realm::TableView t2 = table.where().equal(col_int2, col_int3).find_all();
+    realm::TableView t3 = table.where().equal(col_int4, col_int5).find_all();
 
-    realm::TableView t4 = table.where().equal_float(col_float6, col_float7).find_all();
-    realm::TableView t5 = table.where().equal_double(col_double8, col_double9).find_all();
+    realm::TableView t4 = table.where().equal(col_float6, col_float7).find_all();
+    realm::TableView t5 = table.where().equal(col_double8, col_double9).find_all();
 
 
     CHECK_EQUAL(ints1.size(), t1.size());
@@ -2060,26 +2061,26 @@ TEST(Query_TwoColsVaryOperators)
     Obj obj1 = table.create_object().set_all(10, 5, 10.0f, 5.0f, 10.0, 5.0);
     Obj obj2 = table.create_object().set_all(-10, -5, -10.0f, -5.0f, -10.0, -5.0);
 
-    CHECK_EQUAL(null_key, table.where().equal_int(col_int0, col_int1).find());
-    CHECK_EQUAL(obj0.get_key(), table.where().not_equal_int(col_int0, col_int1).find());
-    CHECK_EQUAL(obj0.get_key(), table.where().less_int(col_int0, col_int1).find());
-    CHECK_EQUAL(obj1.get_key(), table.where().greater_int(col_int0, col_int1).find());
-    CHECK_EQUAL(obj1.get_key(), table.where().greater_equal_int(col_int0, col_int1).find());
-    CHECK_EQUAL(obj0.get_key(), table.where().less_equal_int(col_int0, col_int1).find());
+    CHECK_EQUAL(null_key, table.where().equal(col_int0, col_int1).find());
+    CHECK_EQUAL(obj0.get_key(), table.where().not_equal(col_int0, col_int1).find());
+    CHECK_EQUAL(obj0.get_key(), table.where().less(col_int0, col_int1).find());
+    CHECK_EQUAL(obj1.get_key(), table.where().greater(col_int0, col_int1).find());
+    CHECK_EQUAL(obj1.get_key(), table.where().greater_equal(col_int0, col_int1).find());
+    CHECK_EQUAL(obj0.get_key(), table.where().less_equal(col_int0, col_int1).find());
 
-    CHECK_EQUAL(null_key, table.where().equal_float(col_float2, col_float3).find());
-    CHECK_EQUAL(obj0.get_key(), table.where().not_equal_float(col_float2, col_float3).find());
-    CHECK_EQUAL(obj0.get_key(), table.where().less_float(col_float2, col_float3).find());
-    CHECK_EQUAL(obj1.get_key(), table.where().greater_float(col_float2, col_float3).find());
-    CHECK_EQUAL(obj1.get_key(), table.where().greater_equal_float(col_float2, col_float3).find());
-    CHECK_EQUAL(obj0.get_key(), table.where().less_equal_float(col_float2, col_float3).find());
+    CHECK_EQUAL(null_key, table.where().equal(col_float2, col_float3).find());
+    CHECK_EQUAL(obj0.get_key(), table.where().not_equal(col_float2, col_float3).find());
+    CHECK_EQUAL(obj0.get_key(), table.where().less(col_float2, col_float3).find());
+    CHECK_EQUAL(obj1.get_key(), table.where().greater(col_float2, col_float3).find());
+    CHECK_EQUAL(obj1.get_key(), table.where().greater_equal(col_float2, col_float3).find());
+    CHECK_EQUAL(obj0.get_key(), table.where().less_equal(col_float2, col_float3).find());
 
-    CHECK_EQUAL(null_key, table.where().equal_double(col_double4, col_double5).find());
-    CHECK_EQUAL(obj0.get_key(), table.where().not_equal_double(col_double4, col_double5).find());
-    CHECK_EQUAL(obj0.get_key(), table.where().less_double(col_double4, col_double5).find());
-    CHECK_EQUAL(obj1.get_key(), table.where().greater_double(col_double4, col_double5).find());
-    CHECK_EQUAL(obj1.get_key(), table.where().greater_equal_double(col_double4, col_double5).find());
-    CHECK_EQUAL(obj0.get_key(), table.where().less_equal_double(col_double4, col_double5).find());
+    CHECK_EQUAL(null_key, table.where().equal(col_double4, col_double5).find());
+    CHECK_EQUAL(obj0.get_key(), table.where().not_equal(col_double4, col_double5).find());
+    CHECK_EQUAL(obj0.get_key(), table.where().less(col_double4, col_double5).find());
+    CHECK_EQUAL(obj1.get_key(), table.where().greater(col_double4, col_double5).find());
+    CHECK_EQUAL(obj1.get_key(), table.where().greater_equal(col_double4, col_double5).find());
+    CHECK_EQUAL(obj0.get_key(), table.where().less_equal(col_double4, col_double5).find());
 }
 
 
@@ -2094,10 +2095,10 @@ TEST(Query_TwoCols0)
         table.create_object();
     }
 
-    realm::TableView t1 = table.where().equal_int(col0, col1).find_all();
+    realm::TableView t1 = table.where().equal(col0, col1).find_all();
     CHECK_EQUAL(50, t1.size());
 
-    realm::TableView t2 = table.where().less_int(col0, col1).find_all();
+    realm::TableView t2 = table.where().less(col0, col1).find_all();
     CHECK_EQUAL(0, t2.size());
 }
 
@@ -2141,6 +2142,136 @@ TEST(Query_TwoSameCols)
     CHECK_EQUAL(2, q6.count());
 }
 
+TEST(Query_TwoColumnsCrossTypes)
+{
+    Table table;
+    table.add_column(type_Int, "int");
+    table.add_column(type_Bool, "bool");
+    table.add_column(type_String, "string");
+    table.add_column(type_Binary, "binary");
+    table.add_column(type_Mixed, "mixed");
+    table.add_column(type_Timestamp, "timestamp");
+    table.add_column(type_Float, "float");
+    table.add_column(type_Double, "double");
+    table.add_column(type_Decimal, "decimal128");
+    table.add_column(type_ObjectId, "objectId");
+    table.add_column(type_UUID, "uuid");
+
+    table.add_column(type_Int, "int?", true);
+    table.add_column(type_Bool, "bool?", true);
+    table.add_column(type_String, "string?", true);
+    table.add_column(type_Binary, "binary?", true);
+    table.add_column(type_Mixed, "mixed?", true);
+    table.add_column(type_Timestamp, "timestamp?", true);
+    table.add_column(type_Float, "float?", true);
+    table.add_column(type_Double, "double?", true);
+    table.add_column(type_Decimal, "decimal128?", true);
+    table.add_column(type_ObjectId, "objectId?", true);
+    table.add_column(type_UUID, "uuid?", true);
+
+    TestValueGenerator gen;
+
+    constexpr size_t num_rows = 10;
+    for (size_t i = 0; i < num_rows; ++i) {
+        std::string str = util::format("foo %1", i);
+        Timestamp ts{int64_t(i), 0};
+        BinaryData bd(str.c_str(), str.size() + 1); // include the terminal null so comparison against strings work
+        ObjectId oid(ts, int(i), int(i));
+        UUID uuid = gen.convert_for_test<UUID>(i);
+        table.create_object()
+            .set_all(int64_t(i), i % 2 == 1, StringData(str), bd, Mixed(str), ts, float(i), double(i),
+                     Decimal128(int64_t(i)), oid, uuid, int64_t(i), i % 2 == 1, StringData(str), bd, Mixed(str), ts,
+                     float(i), double(i), Decimal128(int64_t(i)), oid, uuid)
+            .get_key();
+    }
+
+    ColKeys columns = table.get_column_keys();
+    for (size_t i = 0; i < columns.size(); ++i) {
+        for (size_t j = 0; j < columns.size(); ++j) {
+            ColKey lhs = columns[i];
+            ColKey rhs = columns[j];
+            DataType lhs_type = DataType(lhs.get_type());
+            DataType rhs_type = DataType(rhs.get_type());
+            bool are_comparable = Mixed::data_types_are_comparable(lhs_type, rhs_type);
+            size_t num_expected_matches = are_comparable ? num_rows : 0;
+            bool bool_vs_numeric_comparison = false;
+            if (are_comparable && ((lhs_type == type_Bool && rhs_type != type_Bool) ||
+                                   (lhs_type != type_Bool && rhs_type == type_Bool))) {
+                num_expected_matches = 2; // bool only stores two values so only matches the first two numerics
+                bool_vs_numeric_comparison = true;
+            }
+            else if ((lhs_type == type_Mixed || rhs_type == type_Mixed) &&
+                     ((lhs_type == type_String || rhs_type == type_String) ||
+                      (lhs_type == type_Binary || rhs_type == type_Binary))) {
+                num_expected_matches = num_rows; // mixed was set to the same string/binary value
+            }
+            {
+                size_t actual_matches = table.where().equal(lhs, rhs).count();
+                CHECK_EQUAL(num_expected_matches, actual_matches);
+                if (actual_matches != num_expected_matches) {
+                    std::cout << "failure comparing columns: " << table.get_column_name(lhs)
+                              << " == " << table.get_column_name(rhs) << std::endl;
+                }
+            }
+            {
+                size_t actual_matches = table.where().not_equal(lhs, rhs).count();
+                CHECK_EQUAL(num_rows - num_expected_matches, actual_matches);
+                if (actual_matches != num_rows - num_expected_matches) {
+                    std::cout << "failure comparing columns: " << table.get_column_name(lhs)
+                              << " != " << table.get_column_name(rhs) << std::endl;
+                }
+            }
+            {
+                if (bool_vs_numeric_comparison && rhs_type == type_Bool) {
+                    num_expected_matches = num_rows;
+                }
+                size_t actual_matches = table.where().greater_equal(lhs, rhs).count();
+                CHECK_EQUAL(num_expected_matches, actual_matches);
+                if (actual_matches != num_expected_matches) {
+                    std::cout << "failure comparing columns: " << table.get_column_name(lhs)
+                              << " >= " << table.get_column_name(rhs) << std::endl;
+                }
+            }
+            {
+                if (bool_vs_numeric_comparison) {
+                    num_expected_matches = (rhs_type == type_Bool) ? 2 : num_rows;
+                }
+                size_t actual_matches = table.where().less_equal(lhs, rhs).count();
+                CHECK_EQUAL(num_expected_matches, actual_matches);
+                if (actual_matches != num_expected_matches) {
+                    std::cout << "failure comparing columns: " << table.get_column_name(lhs)
+                              << " <= " << table.get_column_name(rhs) << std::endl;
+                }
+            }
+            {
+                num_expected_matches = 0;
+                if (bool_vs_numeric_comparison && rhs_type == type_Bool) {
+                    num_expected_matches = num_rows - 2;
+                }
+                size_t actual_matches = table.where().greater(lhs, rhs).count();
+                CHECK_EQUAL(num_expected_matches, actual_matches);
+                if (actual_matches != num_expected_matches) {
+                    std::cout << "failure comparing columns: " << table.get_column_name(lhs) << " > "
+                              << table.get_column_name(rhs) << std::endl;
+                }
+            }
+            {
+                num_expected_matches = 0;
+                if (bool_vs_numeric_comparison) {
+                    num_expected_matches = (lhs_type == type_Bool) ? num_rows - 2 : 0;
+                }
+                size_t actual_matches = table.where().less(lhs, rhs).count();
+                CHECK_EQUAL(num_expected_matches, actual_matches);
+                if (actual_matches != num_expected_matches) {
+                    std::cout << "failure comparing columns: " << table.get_column_name(lhs) << " < "
+                              << table.get_column_name(rhs) << std::endl;
+                }
+            }
+
+            //    Query q_int = table.column<Int>(col_int) == table.column<type>(col_test);
+        }
+    }
+}
 
 TEST(Query_DateTest)
 {
@@ -2163,8 +2294,8 @@ TEST(Query_TwoColsNoRows)
     auto col0 = table.add_column(type_Int, "first1");
     auto col1 = table.add_column(type_Int, "second1");
 
-    CHECK_EQUAL(null_key, table.where().equal_int(col0, col1).find());
-    CHECK_EQUAL(null_key, table.where().not_equal_int(col0, col1).find());
+    CHECK_EQUAL(null_key, table.where().equal(col0, col1).find());
+    CHECK_EQUAL(null_key, table.where().not_equal(col0, col1).find());
 }
 
 

--- a/test/test_query_big.cpp
+++ b/test/test_query_big.cpp
@@ -364,12 +364,24 @@ TEST(Query_TableInitialization)
     helper([&](Query& q, auto&& test) { test(q.between(col_int, int{}, {})); });
 
     // Conditions: 2 int columns
-    helper([&](Query& q, auto&& test) { test(q.equal_int(col_int, col_int)); });
-    helper([&](Query& q, auto&& test) { test(q.not_equal_int(col_int, col_int)); });
-    helper([&](Query& q, auto&& test) { test(q.greater_int(col_int, col_int)); });
-    helper([&](Query& q, auto&& test) { test(q.less_int(col_int, col_int)); });
-    helper([&](Query& q, auto&& test) { test(q.greater_equal_int(col_int, col_int)); });
-    helper([&](Query& q, auto&& test) { test(q.less_equal_int(col_int, col_int)); });
+    helper([&](Query& q, auto&& test) {
+        test(q.equal(col_int, col_int));
+    });
+    helper([&](Query& q, auto&& test) {
+        test(q.not_equal(col_int, col_int));
+    });
+    helper([&](Query& q, auto&& test) {
+        test(q.greater(col_int, col_int));
+    });
+    helper([&](Query& q, auto&& test) {
+        test(q.less(col_int, col_int));
+    });
+    helper([&](Query& q, auto&& test) {
+        test(q.greater_equal(col_int, col_int));
+    });
+    helper([&](Query& q, auto&& test) {
+        test(q.less_equal(col_int, col_int));
+    });
 
     // Conditions: float
     helper([&](Query& q, auto&& test) { test(q.equal(col_float, float{})); });
@@ -381,12 +393,24 @@ TEST(Query_TableInitialization)
     helper([&](Query& q, auto&& test) { test(q.between(col_float, float{}, {})); });
 
     // Conditions: 2 float columns
-    helper([&](Query& q, auto&& test) { test(q.equal_float(col_float, col_float)); });
-    helper([&](Query& q, auto&& test) { test(q.not_equal_float(col_float, col_float)); });
-    helper([&](Query& q, auto&& test) { test(q.greater_float(col_float, col_float)); });
-    helper([&](Query& q, auto&& test) { test(q.greater_equal_float(col_float, col_float)); });
-    helper([&](Query& q, auto&& test) { test(q.less_float(col_float, col_float)); });
-    helper([&](Query& q, auto&& test) { test(q.less_equal_float(col_float, col_float)); });
+    helper([&](Query& q, auto&& test) {
+        test(q.equal(col_float, col_float));
+    });
+    helper([&](Query& q, auto&& test) {
+        test(q.not_equal(col_float, col_float));
+    });
+    helper([&](Query& q, auto&& test) {
+        test(q.greater(col_float, col_float));
+    });
+    helper([&](Query& q, auto&& test) {
+        test(q.greater_equal(col_float, col_float));
+    });
+    helper([&](Query& q, auto&& test) {
+        test(q.less(col_float, col_float));
+    });
+    helper([&](Query& q, auto&& test) {
+        test(q.less_equal(col_float, col_float));
+    });
 
     // Conditions: double
     helper([&](Query& q, auto&& test) { test(q.equal(col_double, double{})); });
@@ -398,12 +422,24 @@ TEST(Query_TableInitialization)
     helper([&](Query& q, auto&& test) { test(q.between(col_double, double{}, {})); });
 
     // Conditions: 2 double columns
-    helper([&](Query& q, auto&& test) { test(q.equal_double(col_double, col_double)); });
-    helper([&](Query& q, auto&& test) { test(q.not_equal_double(col_double, col_double)); });
-    helper([&](Query& q, auto&& test) { test(q.greater_double(col_double, col_double)); });
-    helper([&](Query& q, auto&& test) { test(q.greater_equal_double(col_double, col_double)); });
-    helper([&](Query& q, auto&& test) { test(q.less_double(col_double, col_double)); });
-    helper([&](Query& q, auto&& test) { test(q.less_equal_double(col_double, col_double)); });
+    helper([&](Query& q, auto&& test) {
+        test(q.equal(col_double, col_double));
+    });
+    helper([&](Query& q, auto&& test) {
+        test(q.not_equal(col_double, col_double));
+    });
+    helper([&](Query& q, auto&& test) {
+        test(q.greater(col_double, col_double));
+    });
+    helper([&](Query& q, auto&& test) {
+        test(q.greater_equal(col_double, col_double));
+    });
+    helper([&](Query& q, auto&& test) {
+        test(q.less(col_double, col_double));
+    });
+    helper([&](Query& q, auto&& test) {
+        test(q.less_equal(col_double, col_double));
+    });
 
     // Conditions: timestamp
     helper([&](Query& q, auto&& test) { test(q.equal(col_timestamp, Timestamp{5, 5})); });


### PR DESCRIPTION
- Optimized column comparisons of different types as TwoColumnsNode can be used instead of the generic Compare expression for more cases
- Removed the column type template dimension from TwoColumnsNode which reduces the library size by ~120k
- Simplified the column vs column Query interface so that instead of `Query::equal_<int/double/float...>(ColKey, ColKey)` there is just `Query::equal(ColKey, ColKey)`

The cost of all this is performing an extra type check at runtime when evaluating the query, but it doesn't seem to have a noticeable performance impact.