### PR TITLE
Fixed SPM integration in Xcode 12.1

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -10,6 +10,9 @@ let versionExtra = versionPieces.count > 1 ? versionPieces[1] : ""
 
 let package = Package(
     name: "RealmCore",
+    platforms: [
+        .iOS(.v11)
+    ],
     products: [
         .library(
             name: "RealmCore",


### PR DESCRIPTION
Fixed "Aligned deallocation function of type 'void (void *, std::align_val_t) noexcept' is only available on iOS 11 or newer" when integrating Realm via SPM and running on a arm64 device