### PR TITLE
Unify the string formatting code

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,7 @@
 
 ### Internals
 * DB::write_copy will not use write transaction
+* Refactor the string formatting logic for logging, reducing the compiled size of the library.
 
 ----------------------------------------------
 

--- a/src/realm/cluster_tree.cpp
+++ b/src/realm/cluster_tree.cpp
@@ -25,6 +25,8 @@
 #include "realm/array_string.hpp"
 #include "realm/array_fixed_bytes.hpp"
 
+#include <iostream>
+
 /*
  * Node-splitting is done in the way that if the new element comes after all the
  * current elements, then the new element is added to the new node as the only

--- a/src/realm/sync/apply_to_state_command.cpp
+++ b/src/realm/sync/apply_to_state_command.cpp
@@ -1,9 +1,3 @@
-#include <algorithm>
-#include <string>
-#include <type_traits>
-
-#include <external/mpark/variant.hpp>
-
 #include "realm/db.hpp"
 #include "realm/sync/history.hpp"
 #include "realm/sync/instruction_applier.hpp"
@@ -18,6 +12,14 @@
 #include "realm/util/load_file.hpp"
 #include "realm/util/safe_int_ops.hpp"
 #include "realm/util/string_view.hpp"
+
+#include <external/mpark/variant.hpp>
+
+#include <algorithm>
+#include <iostream>
+#include <string>
+#include <type_traits>
+
 
 using namespace realm::util;
 

--- a/src/realm/sync/instruction_applier.hpp
+++ b/src/realm/sync/instruction_applier.hpp
@@ -64,9 +64,6 @@ protected:
 
     TableRef table_for_class_name(StringData) const; // Throws
 
-    template <class... Params>
-    REALM_NORETURN void bad_transaction_log(const char*, Params&&...) const;
-
     Transaction& m_transaction;
 
     template <class... Args>
@@ -180,19 +177,6 @@ inline void InstructionApplier::apply(A& applier, Changeset& changeset, util::Lo
 inline void InstructionApplier::apply(const Changeset& log, util::Logger* logger)
 {
     apply(*this, log, logger); // Throws
-}
-
-template <class... Params>
-REALM_NORETURN void InstructionApplier::bad_transaction_log(const char* msg, Params&&... params) const
-{
-    // FIXME: Provide a way to format strings without going through a logger implementation.
-    std::stringstream ss;
-    util::StreamLogger logger{ss};
-    logger.error(msg, std::forward<Params>(params)...);
-    // FIXME: Avoid throwing in normal program flow (since changesets can come
-    // in over the network, defective changesets are part of normal program
-    // flow).
-    throw BadChangesetError{ss.str()};
 }
 
 } // namespace sync

--- a/src/realm/sync/noinst/reopening_file_logger.cpp
+++ b/src/realm/sync/noinst/reopening_file_logger.cpp
@@ -18,7 +18,7 @@ ReopeningFileLogger::ReopeningFileLogger(std::string path, volatile std::sig_ato
 }
 
 
-void ReopeningFileLogger::do_log(util::Logger::Level level, std::string message)
+void ReopeningFileLogger::do_log(util::Logger::Level level, const std::string& message)
 {
     if (REALM_UNLIKELY(m_reopen_log_file)) {
         do_log_2(level, "Reopening log file");                // Throws
@@ -30,7 +30,7 @@ void ReopeningFileLogger::do_log(util::Logger::Level level, std::string message)
 }
 
 
-void ReopeningFileLogger::do_log_2(util::Logger::Level level, std::string message)
+void ReopeningFileLogger::do_log_2(util::Logger::Level level, const std::string& message)
 {
     auto now = std::chrono::system_clock::now();
     m_out << m_timestamp_formatter.format(now) << ": " << get_level_prefix(level) << message << '\n'; // Throws

--- a/src/realm/sync/noinst/reopening_file_logger.hpp
+++ b/src/realm/sync/noinst/reopening_file_logger.hpp
@@ -21,7 +21,7 @@ public:
     explicit ReopeningFileLogger(std::string path, volatile std::sig_atomic_t& reopen_log_file, TimestampConfig = {});
 
 protected:
-    void do_log(util::Logger::Level, std::string message) override;
+    void do_log(util::Logger::Level, const std::string& message) override;
 
 private:
     const std::string m_path;
@@ -31,7 +31,7 @@ private:
     volatile std::sig_atomic_t& m_reopen_log_file;
     util::TimestampFormatter m_timestamp_formatter;
 
-    void do_log_2(util::Logger::Level level, std::string message);
+    void do_log_2(util::Logger::Level level, const std::string& message);
 };
 
 } // namespace _impl

--- a/src/realm/sync/server_command.cpp
+++ b/src/realm/sync/server_command.cpp
@@ -1,7 +1,3 @@
-#include <signal.h>
-#include <memory>
-#include <string>
-
 #include <realm/util/features.h>
 #include <realm/util/optional.hpp>
 #include <realm/util/logger.hpp>
@@ -12,6 +8,11 @@
 #include <realm/sync/metrics.hpp>
 #include <realm/sync/server.hpp>
 #include <realm/sync/server_configuration.hpp>
+
+#include <iostream>
+#include <memory>
+#include <signal.h>
+#include <string>
 
 using namespace realm;
 

--- a/src/realm/util/duplicating_logger.cpp
+++ b/src/realm/util/duplicating_logger.cpp
@@ -4,7 +4,7 @@ using namespace realm;
 using util::DuplicatingLogger;
 
 
-void DuplicatingLogger::do_log(Logger::Level level, std::string message)
+void DuplicatingLogger::do_log(Logger::Level level, const std::string& message)
 {
     Logger::do_log(m_base_logger, level, message); // Throws
     Logger::do_log(m_aux_logger, level, message);  // Throws

--- a/src/realm/util/duplicating_logger.hpp
+++ b/src/realm/util/duplicating_logger.hpp
@@ -19,7 +19,7 @@ public:
     explicit DuplicatingLogger(Logger& base_logger, Logger& aux_logger) noexcept;
 
 protected:
-    void do_log(Logger::Level, std::string message) override;
+    void do_log(Logger::Level, const std::string& message) override;
 
 private:
     Logger& m_base_logger;

--- a/src/realm/util/file.hpp
+++ b/src/realm/util/file.hpp
@@ -21,13 +21,12 @@
 
 #include <cstddef>
 #include <cstdint>
-#include <memory>
-#include <functional>
-#include <stdexcept>
-#include <string>
-#include <streambuf>
-#include <iostream>
 #include <ctime>
+#include <functional>
+#include <memory>
+#include <stdexcept>
+#include <streambuf>
+#include <string>
 
 #ifndef _WIN32
 #include <dirent.h> // POSIX.1-2001

--- a/src/realm/util/interprocess_mutex.hpp
+++ b/src/realm/util/interprocess_mutex.hpp
@@ -25,7 +25,6 @@
 #include <realm/utilities.hpp>
 #include <mutex>
 #include <map>
-#include <iostream>
 
 // Enable this only on platforms where it might be needed
 #if REALM_PLATFORM_APPLE || REALM_ANDROID

--- a/src/realm/util/timestamp_logger.cpp
+++ b/src/realm/util/timestamp_logger.cpp
@@ -13,7 +13,7 @@ TimestampStderrLogger::TimestampStderrLogger(Config config)
 }
 
 
-void TimestampStderrLogger::do_log(Logger::Level level, std::string message)
+void TimestampStderrLogger::do_log(Logger::Level level, const std::string& message)
 {
     auto now = std::chrono::system_clock::now();
     std::cerr << m_formatter.format(now) << ": " << get_level_prefix(level) << message << '\n'; // Throws

--- a/src/realm/util/timestamp_logger.hpp
+++ b/src/realm/util/timestamp_logger.hpp
@@ -17,7 +17,7 @@ public:
     explicit TimestampStderrLogger(Config = {});
 
 protected:
-    void do_log(Logger::Level, std::string message) override;
+    void do_log(Logger::Level, const std::string& message) override;
 
 private:
     TimestampFormatter m_formatter;

--- a/src/realm/util/to_string.hpp
+++ b/src/realm/util/to_string.hpp
@@ -20,9 +20,12 @@
 #define REALM_UTIL_TO_STRING_HPP
 
 #include <iosfwd>
+#include <ostream>
 #include <string>
+#include <string_view>
 
 namespace realm {
+class StringData;
 namespace util {
 
 class Printable {
@@ -33,6 +36,11 @@ public:
     {
     }
     constexpr Printable(unsigned char value)
+        : m_type(Type::Uint)
+        , m_uint(value)
+    {
+    }
+    constexpr Printable(unsigned short value)
         : m_type(Type::Uint)
         , m_uint(value)
     {
@@ -53,6 +61,16 @@ public:
     {
     }
     constexpr Printable(char value)
+        : m_type(Type::Int)
+        , m_int(value)
+    {
+    }
+    constexpr Printable(signed char value)
+        : m_type(Type::Int)
+        , m_int(value)
+    {
+    }
+    constexpr Printable(short value)
         : m_type(Type::Int)
         , m_int(value)
     {
@@ -84,7 +102,17 @@ public:
     }
     Printable(std::string const& value)
         : m_type(Type::String)
-        , m_string(value.c_str())
+        , m_string(value)
+    {
+    }
+    Printable(StringData value);
+
+    template <typename T>
+    Printable(T const& value)
+        : m_type(Type::Callback)
+        , m_callback({static_cast<const void*>(&value), [](std::ostream& os, const void* ptr) {
+                          os << *static_cast<const T*>(ptr);
+                      }})
     {
     }
 
@@ -101,13 +129,20 @@ private:
         Uint,
         Double,
         String,
+        Callback,
     } m_type;
+
+    struct Callback {
+        const void* data;
+        void (*fn)(std::ostream&, const void*);
+    };
 
     union {
         uintmax_t m_uint;
         intmax_t m_int;
         double m_double;
-        const char* m_string;
+        std::string_view m_string;
+        Callback m_callback;
     };
 };
 
@@ -118,7 +153,7 @@ std::string to_string(const T& v)
     return Printable(v).str();
 }
 
-
+void format(std::ostream&, const char* fmt, std::initializer_list<Printable>);
 std::string format(const char* fmt, std::initializer_list<Printable>);
 
 // format string format:
@@ -133,6 +168,11 @@ std::string format(const char* fmt, Args&&... args)
     return format(fmt, {Printable(args)...});
 }
 
+template <typename... Args>
+void format(std::ostream& os, const char* fmt, Args&&... args)
+{
+    format(os, fmt, {Printable(args)...});
+}
 
 } // namespace util
 } // namespace realm

--- a/test/object-store/sync/app.cpp
+++ b/test/object-store/sync/app.cpp
@@ -37,8 +37,10 @@
 #include <realm/util/base64.hpp>
 #include <realm/util/uri.hpp>
 #include <realm/util/websocket.hpp>
+
 #include <chrono>
 #include <thread>
+#include <iostream>
 
 using namespace realm;
 using namespace realm::app;

--- a/test/object-store/transaction_log_parsing.cpp
+++ b/test/object-store/transaction_log_parsing.cpp
@@ -33,6 +33,8 @@
 #include <realm.hpp>
 #include <realm/history.hpp>
 
+#include <iostream>
+
 using namespace realm;
 
 class CaptureHelper {

--- a/test/object-store/util/test_file.hpp
+++ b/test/object-store/util/test_file.hpp
@@ -96,7 +96,7 @@ void on_change_but_no_notify(realm::Realm& realm);
 #define TEST_ENABLE_SYNC_LOGGING 0 // change to 1 to enable logging
 
 struct TestLogger : realm::util::Logger::LevelThreshold, realm::util::Logger {
-    void do_log(realm::util::Logger::Level, std::string) override {}
+    void do_log(realm::util::Logger::Level, std::string const&) override {}
     Level get() const noexcept override
     {
         return Level::off;

--- a/test/object-store/util/test_utils.cpp
+++ b/test/object-store/util/test_utils.cpp
@@ -25,6 +25,8 @@
 
 #include <external/json/json.hpp>
 
+#include <iostream>
+
 namespace realm {
 
 bool create_dummy_realm(std::string path)

--- a/test/test_util_logger.cpp
+++ b/test/test_util_logger.cpp
@@ -119,12 +119,8 @@ TEST(Util_Logger_Formatting)
         out_2 << "Foo y bar 3\n";
         logger.info("%3 foo %1 bar %2", 4.1, 4, "z");
         out_2 << "z foo 4.1 bar 4\n";
-        logger.info("Foo %1");
-        out_2 << "Foo %1\n";
-        logger.info("Foo %1 bar %2", "x");
-        out_2 << "Foo x bar %2\n";
-        logger.info("Foo %2 bar %1", "x");
-        out_2 << "Foo %2 bar x\n";
+        logger.info("%1 foo %1 bar %1", "a");
+        out_2 << "a foo a bar a\n";
     }
     CHECK(out_1.str() == out_2.str());
 }
@@ -198,7 +194,7 @@ TEST(Util_Logger_ThreadSafe)
 {
     struct BalloonLogger : public util::RootLogger {
         std::vector<std::string> messages;
-        void do_log(util::Logger::Level, std::string message) override
+        void do_log(util::Logger::Level, std::string const& message) override
         {
             messages.push_back(std::move(message));
         }

--- a/test/test_util_to_string.cpp
+++ b/test/test_util_to_string.cpp
@@ -78,6 +78,13 @@ TEST(ToString_Basic)
 
     {
         std::ostringstream ostr;
+        Printable::print_all(ostr, {0, true, "Hello"}, true);
+        std::string s = ostr.str();
+        CHECK_EQUAL(s, " [0, true, \"Hello\"]");
+    }
+
+    {
+        std::ostringstream ostr;
         Printable::print_all(ostr, {}, false);
         std::string s = ostr.str();
         CHECK_EQUAL(s, "");

--- a/test/util/compare_groups.cpp
+++ b/test/util/compare_groups.cpp
@@ -2,6 +2,7 @@
 #include <vector>
 #include <set>
 #include <sstream>
+#include <iostream>
 
 #include <realm/group.hpp>
 #include <realm/table.hpp>
@@ -19,7 +20,7 @@ namespace {
 
 class MuteLogger : public util::RootLogger {
 public:
-    void do_log(Level, std::string) override final {}
+    void do_log(Level, const std::string&) override final {}
 };
 
 
@@ -31,7 +32,7 @@ public:
         , m_base_logger{base_logger}
     {
     }
-    void do_log(Level level, std::string message) override final
+    void do_log(Level level, const std::string& message) override final
     {
         ensure_prefix();                                          // Throws
         Logger::do_log(m_base_logger, level, m_prefix + message); // Throws
@@ -60,7 +61,7 @@ public:
         , m_base_logger{base_logger}
     {
     }
-    void do_log(Level level, std::string message) override final
+    void do_log(Level level, const std::string& message) override final
     {
         ensure_prefix();                                          // Throws
         Logger::do_log(m_base_logger, level, m_prefix + message); // Throws

--- a/test/util/unit_test.cpp
+++ b/test/util/unit_test.cpp
@@ -428,7 +428,7 @@ public:
     {
     }
 
-    void do_log(Logger::Level level, std::string message) override final
+    void do_log(Logger::Level level, std::string const& message) override final
     {
         Logger::do_log(m_base_logger, level, message); // Throws
     }


### PR DESCRIPTION
We have two different almost-compatible implementations of string formatting, one originally written for sync logging, one for object store. This makes Logger use util::format internally and extends util::format to support arbitrary types rather than just a fixed set. In addition to eliminating some duplicated code, this significantly reduces the compiled size of the library:

| Binary                         | Before (KB) | After (KB) | Change (KB) |
| ------------------------------ | ----------- | ---------- | ----------- |
| macOS static library (debug)   | 296192      | 294467     | 1725        |
| macOS static library (release) | 16174       | 15765      | 409         |
| iOS app archive                | 91648       | 90228      | 1420        |
| sync tests executable          | 9968        | 9796       | 172         |

This has one functional change: the sync logger formatting ignored out-of-bounds format markers, while to_string asserts that they're in bounds. I kept the latter behavior as all format strings should be hardcoded string literals and I've found the assertions to be useful in catching mistakes, but it'd be easy enough to change this if it's a problem.