### PR TITLE
Fix object store test formatting

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -70,6 +70,8 @@ ForEachMacros:
   - foreach
   - Q_FOREACH
   - BOOST_FOREACH
+  - SECTION
+  - TEST_CASE
 IncludeBlocks:   Preserve
 IncludeCategories:
   - Regex:           '^"(llvm|llvm-c|clang|clang-c)/'
@@ -113,7 +115,7 @@ SpaceBeforeAssignmentOperators: true
 SpaceBeforeCpp11BracedList: false
 SpaceBeforeCtorInitializerColon: true
 SpaceBeforeInheritanceColon: true
-SpaceBeforeParens: ControlStatements
+SpaceBeforeParens: ControlStatementsExceptForEachMacros
 SpaceBeforeRangeBasedForLoopColon: true
 SpaceInEmptyParentheses: false
 SpacesBeforeTrailingComments: 1

--- a/test/object-store/benchmarks/results.cpp
+++ b/test/object-store/benchmarks/results.cpp
@@ -33,8 +33,7 @@
 
 using namespace realm;
 
-TEST_CASE("Benchmark results", "[benchmark]")
-{
+TEST_CASE("Benchmark results", "[benchmark]") {
     InMemoryTestFile config;
     config.schema = Schema{
         {"object",
@@ -88,8 +87,7 @@ TEST_CASE("Benchmark results", "[benchmark]")
             REQUIRE(results.get(i).get_key() == expected[i]);                                                        \
     } while (0)
 
-    SECTION("basics")
-    {
+    SECTION("basics") {
         REQUIRE(r.filter(Query(table->where().less(col_value, 2))).size() == 2);
         BENCHMARK("basic filter")
         {
@@ -133,8 +131,7 @@ TEST_CASE("Benchmark results", "[benchmark]")
         };
     }
 
-    SECTION("iteration")
-    {
+    SECTION("iteration") {
         const int additional_row_count = 10000;
         realm->begin_transaction();
         table->create_objects(additional_row_count, table_keys);

--- a/test/object-store/bson.cpp
+++ b/test/object-store/bson.cpp
@@ -68,17 +68,14 @@ static inline void run_corpus(const char* test_key, const CorpusEntry<T>& entry)
     }
 }
 
-TEST_CASE("canonical_extjson_fragments", "[bson]")
-{
-    SECTION("Array")
-    {
+TEST_CASE("canonical_extjson_fragments", "[bson]") {
+    SECTION("Array") {
         auto const b = bson::parse("[]");
         auto const array = static_cast<BsonArray>(b);
         CHECK(array.empty());
     }
 
-    SECTION("Array with Object")
-    {
+    SECTION("Array with Object") {
         auto const b = bson::parse("[{\"a\": \"foo\"}]");
         auto const array = static_cast<BsonArray>(b);
         CHECK(array.size() == 1);
@@ -86,21 +83,18 @@ TEST_CASE("canonical_extjson_fragments", "[bson]")
         CHECK(static_cast<std::string>(doc["a"]) == "foo");
     }
 
-    SECTION("Null")
-    {
+    SECTION("Null") {
         auto const b = bson::parse("null");
         CHECK(bson::holds_alternative<util::None>(b));
     }
 
-    SECTION("String")
-    {
+    SECTION("String") {
         auto const b = bson::parse("\"foo\"");
         auto const str = static_cast<std::string>(b);
         CHECK(str == "foo");
     }
 
-    SECTION("Boolean")
-    {
+    SECTION("Boolean") {
         auto b = bson::parse("true");
         auto boolean = static_cast<bool>(b);
         CHECK(boolean);
@@ -111,30 +105,24 @@ TEST_CASE("canonical_extjson_fragments", "[bson]")
     }
 }
 
-TEST_CASE("canonical_extjson_corpus", "[bson]")
-{
-    SECTION("Array")
-    {
-        SECTION("Empty")
-        {
+TEST_CASE("canonical_extjson_corpus", "[bson]") {
+    SECTION("Array") {
+        SECTION("Empty") {
             run_corpus<BsonArray>("a", {"{\"a\" : []}", [](auto val) {
                                             CHECK(val.empty());
                                         }});
         }
-        SECTION("Single Element Array")
-        {
+        SECTION("Single Element Array") {
             run_corpus<BsonArray>("a", {"{\"a\" : [{\"$numberInt\": \"10\"}]}", [](auto val) {
                                             CHECK((int32_t)val[0] == 10);
                                         }});
         }
-        SECTION("Single Element Boolean Array")
-        {
+        SECTION("Single Element Boolean Array") {
             run_corpus<BsonArray>("a", {"{\"a\" : [true]}", [](auto val) {
                                             CHECK((bool)val[0]);
                                         }});
         }
-        SECTION("Multi Element Array")
-        {
+        SECTION("Multi Element Array") {
             run_corpus<BsonArray>("a",
                                   {"{\"a\" : [{\"$numberInt\": \"10\"}, {\"$numberInt\": \"20\"}]}", [](auto val) {
                                        CHECK((int32_t)val[0] == 10);
@@ -143,17 +131,14 @@ TEST_CASE("canonical_extjson_corpus", "[bson]")
         }
     }
 
-    SECTION("Binary")
-    {
-        SECTION("subtype 0x00 (Zero-length)")
-        {
+    SECTION("Binary") {
+        SECTION("subtype 0x00 (Zero-length)") {
             run_corpus<std::vector<char>>(
                 "x", {"{\"x\" : { \"$binary\" : {\"base64\" : \"\", \"subType\" : \"00\"}}}", [](auto val) {
                           CHECK(val == std::vector<char>());
                       }});
         }
-        SECTION("subtype 0x00 (Zero-length, keys reversed)")
-        {
+        SECTION("subtype 0x00 (Zero-length, keys reversed)") {
             run_corpus<std::vector<char>>(
                 "x", {
 
@@ -162,8 +147,7 @@ TEST_CASE("canonical_extjson_corpus", "[bson]")
                          }});
         }
 
-        SECTION("subtype 0x00")
-        {
+        SECTION("subtype 0x00") {
             run_corpus<std::vector<char>>(
                 "x", {"{\"x\" : { \"$binary\" : {\"base64\" : \"//8=\", \"subType\" : \"00\"}}}", [](auto val) {
                           std::string bin = "//8=";
@@ -172,50 +156,42 @@ TEST_CASE("canonical_extjson_corpus", "[bson]")
         }
     }
 
-    SECTION("Boolean")
-    {
-        SECTION("True")
-        {
+    SECTION("Boolean") {
+        SECTION("True") {
             run_corpus<bool>("b", {"{\"b\" : true}", [](auto val) {
                                        CHECK(val);
                                    }});
         }
 
-        SECTION("False")
-        {
+        SECTION("False") {
             run_corpus<bool>("b", {"{\"b\" : false}", [](auto val) {
                                        CHECK(!val);
                                    }});
         }
     }
 
-    SECTION("DateTime")
-    {
-        SECTION("epoch")
-        {
+    SECTION("DateTime") {
+        SECTION("epoch") {
             run_corpus<realm::Timestamp>("a", {"{\"a\" : {\"$date\" : {\"$numberLong\" : \"0\"}}}", [](auto val) {
                                                    CHECK(val.get_seconds() == 0);
                                                    CHECK(val.get_nanoseconds() == 0);
                                                }});
         }
-        SECTION("positive ms")
-        {
+        SECTION("positive ms") {
             run_corpus<realm::Timestamp>(
                 "a", {"{\"a\" : {\"$date\" : {\"$numberLong\" : \"1356351330501\"}}}", [](auto val) {
                           CHECK(val.get_seconds() == 1356351330501 / 1000);
                           CHECK(val.get_nanoseconds() == 501000000);
                       }});
         }
-        SECTION("negative")
-        {
+        SECTION("negative") {
             run_corpus<realm::Timestamp>(
                 "a", {"{\"a\" : {\"$date\" : {\"$numberLong\" : \"-284643869501\"}}}", [](auto val) {
                           CHECK(val.get_seconds() == -284643869501 / 1000);
                           CHECK(val.get_nanoseconds() == -501000000);
                       }});
         }
-        SECTION("Y10K")
-        {
+        SECTION("Y10K") {
             run_corpus<realm::Timestamp>("a",
                                          {"{\"a\":{\"$date\":{\"$numberLong\":\"253402300800000\"}}}", [](auto val) {
                                               CHECK(val.get_seconds() == 253402300800000 / 1000);
@@ -224,70 +200,58 @@ TEST_CASE("canonical_extjson_corpus", "[bson]")
         };
     }
 
-    SECTION("Decimal")
-    {
-        SECTION("Special - Canonical NaN")
-        {
+    SECTION("Decimal") {
+        SECTION("Special - Canonical NaN") {
             run_corpus<Decimal128>("d", {"{\"d\" : {\"$numberDecimal\" : \"NaN\"}}", [](auto val) {
                                              CHECK(val.is_nan());
                                          }});
         }
 
-        SECTION("Special - Canonical Positive Infinity")
-        {
+        SECTION("Special - Canonical Positive Infinity") {
             run_corpus<Decimal128>("d", {"{\"d\" : {\"$numberDecimal\" : \"Infinity\"}}", [](auto val) {
                                              CHECK(val == Decimal128("Infinity"));
                                          }});
         }
-        SECTION("Special - Canonical Negative Infinity")
-        {
+        SECTION("Special - Canonical Negative Infinity") {
             run_corpus<Decimal128>("d", {"{\"d\" : {\"$numberDecimal\" : \"-Infinity\"}}", [](auto val) {
                                              CHECK(val == Decimal128("-Infinity"));
                                          }});
         }
-        SECTION("Regular - Smallest")
-        {
+        SECTION("Regular - Smallest") {
             run_corpus<Decimal128>("d", {"{\"d\" : {\"$numberDecimal\" : \"1.234E-3\"}}", [](auto val) {
                                              CHECK(val == Decimal128("0.001234"));
                                          }});
         }
 
-        SECTION("Regular - 0.1")
-        {
+        SECTION("Regular - 0.1") {
             run_corpus<Decimal128>("d", {"{\"d\" : {\"$numberDecimal\" : \"1E-1\"}}", [](auto val) {
                                              CHECK(val == Decimal128("0.1"));
                                          }});
         };
     }
 
-    SECTION("Document")
-    {
-        SECTION("Empty subdoc")
-        {
+    SECTION("Document") {
+        SECTION("Empty subdoc") {
             run_corpus<BsonDocument>("x", {"{\"x\" : {}}", [](auto val) {
                                                CHECK(val.empty());
                                            }});
         }
-        SECTION("Empty-string key subdoc")
-        {
+        SECTION("Empty-string key subdoc") {
             run_corpus<BsonDocument>("x", {"{\"x\" : {\"\" : \"b\"}}", [](auto val) {
                                                CHECK((std::string)val[""] == "b");
                                            }});
         }
-        SECTION("Single-character key subdoc")
-        {
+        SECTION("Single-character key subdoc") {
             run_corpus<BsonDocument>("x", {"{\"x\" : {\"a\" : \"b\"}}", [](auto val) {
                                                CHECK((std::string)val["a"] == "b");
                                            }});
         }
-        SECTION("Special characters in field name")
-        {
+        SECTION("Special characters in field name") {
             run_corpus<BsonDocument>("x", {R"({"x" : {">\n\t\u0002\\\"<" : "b"}})", [](auto val) {
                                                CHECK((std::string)val[">\n\t\x02\\\"<"] == "b");
                                            }});
         }
-        SECTION("Nested Objects")
-        {
+        SECTION("Nested Objects") {
             run_corpus<BsonDocument>(
                 "x", {R"({"x": {"value": {"hello": "world", "_id": {"$oid": "5ec38e1e693f9e61e968f701"}}}})",
                       [](auto val) {
@@ -298,8 +262,7 @@ TEST_CASE("canonical_extjson_corpus", "[bson]")
                           CHECK(inner["_id"].operator ObjectId() == ObjectId("5ec38e1e693f9e61e968f701"));
                       }});
         }
-        SECTION("Nested Objects 2")
-        {
+        SECTION("Nested Objects 2") {
             run_corpus<BsonDocument>("x", {R"({"x": {"value": {"hello": {"$numberInt": "42"}}}})", [](auto val) {
                                                CHECK(val.size() == 1);
                                                auto inner = val["value"].operator const BsonDocument&();
@@ -307,8 +270,7 @@ TEST_CASE("canonical_extjson_corpus", "[bson]")
                                                CHECK(inner["hello"].operator int32_t() == 42);
                                            }});
         }
-        SECTION("Nested Objects 3")
-        {
+        SECTION("Nested Objects 3") {
             run_corpus<BsonDocument>("x", {R"({"x": {"value": {"hello": "world"}}})", [](auto val) {
                                                CHECK(val.size() == 1);
                                                auto inner = val["value"].operator const BsonDocument&();
@@ -316,8 +278,7 @@ TEST_CASE("canonical_extjson_corpus", "[bson]")
                                                CHECK(inner["hello"].operator const std::string&() == "world");
                                            }});
         }
-        SECTION("Nested Objects 3")
-        {
+        SECTION("Nested Objects 3") {
             run_corpus<BsonDocument>("x",
                                      {R"({"x": {"value": {"hello": "world", "hello_2": "world_2"}}})", [](auto val) {
                                           CHECK(val.size() == 1);
@@ -327,16 +288,14 @@ TEST_CASE("canonical_extjson_corpus", "[bson]")
                                           CHECK(inner["hello_2"].operator const std::string&() == "world_2");
                                       }});
         }
-        SECTION("Nested Array Empty Objects")
-        {
+        SECTION("Nested Array Empty Objects") {
             run_corpus<BsonArray>("value", {"{\"value\": [ {}, {} ] }", [](auto val) {
                                                 ;
                                                 CHECK(static_cast<BsonDocument>(val[0]).size() == 0);
                                                 CHECK(static_cast<BsonDocument>(val[1]).size() == 0);
                                             }});
         }
-        SECTION("Doubly Nested Array")
-        {
+        SECTION("Doubly Nested Array") {
             run_corpus<BsonArray>(
                 "value",
                 {"{\"value\": [ [ {\"$numberInt\": \"1\"}, true, {\"$numberInt\": \"3\"} ] ] }", [](auto val) {
@@ -348,8 +307,7 @@ TEST_CASE("canonical_extjson_corpus", "[bson]")
                      CHECK(sub_array[2] == 3);
                  }});
         }
-        SECTION("Doubly Nested Array 2")
-        {
+        SECTION("Doubly Nested Array 2") {
             run_corpus<BsonArray>(
                 "value",
                 {"{\"value\": [ [ {\"$numberInt\": \"1\"}, \"Realm\", {\"$numberInt\": \"3\"} ] ] }", [](auto val) {
@@ -361,8 +319,7 @@ TEST_CASE("canonical_extjson_corpus", "[bson]")
                      CHECK(sub_array[2] == 3);
                  }});
         }
-        SECTION("Doubly Nested Array 3")
-        {
+        SECTION("Doubly Nested Array 3") {
             run_corpus<BsonArray>("value",
                                   {"{\"value\": [ {\"KEY\": \"666\"}, {\"KEY\": \"666\"}, {}] }", [](auto val) {
                                        ;
@@ -374,24 +331,20 @@ TEST_CASE("canonical_extjson_corpus", "[bson]")
         }
     }
 
-    SECTION("Double type")
-    {
+    SECTION("Double type") {
         static double epsilon = 0.000000001;
 
-        SECTION("+1.0")
-        {
+        SECTION("+1.0") {
             run_corpus<double>("d", {"{\"d\" : {\"$numberDouble\": \"1\"}}", [](auto val) {
                                          CHECK(abs(val - 1.0) < epsilon);
                                      }});
         }
-        SECTION("-1.0")
-        {
+        SECTION("-1.0") {
             run_corpus<double>("d", {"{\"d\" : {\"$numberDouble\": \"-1\"}}", [](auto val) {
                                          CHECK(abs(val - -1.0) < epsilon);
                                      }});
         }
-        SECTION("+1.0001220703125")
-        {
+        SECTION("+1.0001220703125") {
             run_corpus<double>("d", {
                                         "{\"d\" : {\"$numberDouble\": \"1.0001220703125\"}}",
                                         [](auto val) {
@@ -399,8 +352,7 @@ TEST_CASE("canonical_extjson_corpus", "[bson]")
                                         },
                                     });
         }
-        SECTION("-1.0001220703125")
-        {
+        SECTION("-1.0001220703125") {
             run_corpus<double>("d", {
                                         "{\"d\" : {\"$numberDouble\": \"-1.0001220703125\"}}",
                                         [](auto val) {
@@ -408,8 +360,7 @@ TEST_CASE("canonical_extjson_corpus", "[bson]")
                                         },
                                     });
         }
-        SECTION("1.2345678921232E+18")
-        {
+        SECTION("1.2345678921232E+18") {
             run_corpus<double>("d", {
                                         "{\"d\" : {\"$numberDouble\": \"1.2345678921232e+18\"}}",
                                         [](auto val) {
@@ -417,8 +368,7 @@ TEST_CASE("canonical_extjson_corpus", "[bson]")
                                         },
                                     });
         }
-        SECTION("-1.2345678921232E+18")
-        {
+        SECTION("-1.2345678921232E+18") {
             run_corpus<double>("d", {
                                         "{\"d\" : {\"$numberDouble\": \"-1.2345678921232e+18\"}}",
                                         [](auto val) {
@@ -426,8 +376,7 @@ TEST_CASE("canonical_extjson_corpus", "[bson]")
                                         },
                                     });
         }
-        SECTION("1.7976931348623157E+308")
-        {
+        SECTION("1.7976931348623157E+308") {
             run_corpus<double>("d", {
                                         "{\"d\" : {\"$numberDouble\": \"1.7976931348623157e+308\"}}",
                                         [](auto val) {
@@ -435,8 +384,7 @@ TEST_CASE("canonical_extjson_corpus", "[bson]")
                                         },
                                     });
         }
-        SECTION("0.0")
-        {
+        SECTION("0.0") {
             run_corpus<double>("d", {"{\"d\" : {\"$numberDouble\": \"0\"}}",
                                      [](auto val) {
                                          CHECK(abs(val - 0.0) < epsilon);
@@ -444,116 +392,97 @@ TEST_CASE("canonical_extjson_corpus", "[bson]")
 
                                     });
         }
-        SECTION("-0.0")
-        {
+        SECTION("-0.0") {
             run_corpus<double>("d", {"{\"d\" : {\"$numberDouble\": \"-0\"}}", [](auto val) {
                                          CHECK(abs(val - -0.0) < epsilon);
                                      }});
         }
-        SECTION("NaN")
-        {
+        SECTION("NaN") {
             run_corpus<double>("d", {"{\"d\": {\"$numberDouble\": \"NaN\"}}", [](auto val) {
                                          CHECK(std::isnan(val));
                                      }});
         }
-        SECTION("Inf")
-        {
+        SECTION("Inf") {
             run_corpus<double>("d", {"{\"d\": {\"$numberDouble\": \"Infinity\"}}", [](auto val) {
                                          CHECK(val == std::numeric_limits<double>::infinity());
                                      }});
         }
-        SECTION("-Inf")
-        {
+        SECTION("-Inf") {
             run_corpus<double>("d", {"{\"d\": {\"$numberDouble\": \"-Infinity\"}}", [](auto val) {
                                          CHECK(val == (-1 * std::numeric_limits<double>::infinity()));
                                      }});
         }
     }
 
-    SECTION("Int32 type")
-    {
-        SECTION("MinValue")
-        {
+    SECTION("Int32 type") {
+        SECTION("MinValue") {
             run_corpus<int32_t>("i", {"{\"i\" : {\"$numberInt\": \"-2147483648\"}}", [](auto val) {
                                           CHECK(val == -2147483648);
                                       }});
         }
-        SECTION("MaxValue")
-        {
+        SECTION("MaxValue") {
             run_corpus<int32_t>("i", {"{\"i\" : {\"$numberInt\": \"2147483647\"}}", [](auto val) {
                                           CHECK(val == 2147483647);
                                       }});
         }
-        SECTION("-1")
-        {
+        SECTION("-1") {
             run_corpus<int32_t>("i", {"{\"i\" : {\"$numberInt\": \"-1\"}}", [](auto val) {
                                           CHECK(val == -1);
                                       }});
         }
-        SECTION("0")
-        {
+        SECTION("0") {
             run_corpus<int32_t>("i", {"{\"i\" : {\"$numberInt\": \"0\"}}", [](auto val) {
                                           CHECK(val == 0);
                                       }});
         }
-        SECTION("1")
-        {
+        SECTION("1") {
             run_corpus<int32_t>("i", {"{\"i\" : {\"$numberInt\": \"1\"}}", [](auto val) {
                                           CHECK(val == 1);
                                       }});
         }
     }
 
-    SECTION("Int64 type")
-    {
-        SECTION("MinValue")
-        {
+    SECTION("Int64 type") {
+        SECTION("MinValue") {
             run_corpus<int64_t>("a", {"{\"a\" : {\"$numberLong\" : \"-9223372036854775808\"}}", [](auto val) {
                                           CHECK(val == LLONG_MIN);
                                       }});
         }
-        SECTION("MaxValue")
-        {
+        SECTION("MaxValue") {
             run_corpus<int64_t>("a", {"{\"a\" : {\"$numberLong\" : \"9223372036854775807\"}}", [](auto val) {
                                           CHECK(val == LLONG_MAX);
                                       }});
         }
-        SECTION("-1")
-        {
+        SECTION("-1") {
             run_corpus<int64_t>("a", {"{\"a\" : {\"$numberLong\" : \"-1\"}}", [](auto val) {
                                           CHECK(val == -1);
                                       }});
         }
-        SECTION("0")
-        {
+        SECTION("0") {
             run_corpus<int64_t>("a", {"{\"a\" : {\"$numberLong\" : \"0\"}}", [](auto val) {
                                           CHECK(val == 0);
                                       }});
         }
-        SECTION("1")
-        {
+        SECTION("1") {
             run_corpus<int64_t>("a", {"{\"a\" : {\"$numberLong\" : \"1\"}}", [](auto val) {
                                           CHECK(val == 1);
                                       }});
         }
     }
 
-    SECTION("Maxkey type")
-    {
+    SECTION("Maxkey type") {
         run_corpus<MaxKey>("a", {"{\"a\" : {\"$maxKey\" : 1}}", [](auto val) {
                                      CHECK(val == max_key);
                                  }});
     }
 
-    SECTION("Minkey type")
-    {
+    SECTION("Minkey type") {
         run_corpus<MinKey>("a", {"{\"a\" : {\"$minKey\" : 1}}", [](auto val) {
                                      CHECK(val == min_key);
                                  }});
     }
 
-    SECTION("Multiple types within the same documment")
-    {
+    SECTION("Multiple types within the same documment") {
         auto canonical_extjson = remove_whitespace(
             "{\"_id\": {\"$oid\": \"57e193d7a9cc81b4027498b5\"}, \"String\": \"string\", \"Int32\": {\"$numberInt\": "
             "\"42\"}, \"Int64\": {\"$numberLong\": \"42\"}, \"Double\": {\"$numberDouble\": \"-1\"}, \"Binary\": { "
@@ -596,54 +525,45 @@ TEST_CASE("canonical_extjson_corpus", "[bson]")
         CHECK(canonical_extjson == s.str());
     }
 
-    SECTION("Null type")
-    {
+    SECTION("Null type") {
         run_corpus<realm::util::None>("a", {"{\"a\" : null}", [](auto) {
                                                 CHECK(true);
                                             }});
     }
 
-    SECTION("ObjectId")
-    {
-        SECTION("All zeroes")
-        {
+    SECTION("ObjectId") {
+        SECTION("All zeroes") {
             run_corpus<ObjectId>("a", {"{\"a\" : {\"$oid\" : \"000000000000000000000000\"}}", [](auto val) {
                                            CHECK(val == ObjectId("000000000000000000000000"));
                                        }});
         }
-        SECTION("All ones")
-        {
+        SECTION("All ones") {
             run_corpus<ObjectId>("a", {"{\"a\" : {\"$oid\" : \"ffffffffffffffffffffffff\"}}", [](auto val) {
                                            CHECK(val == ObjectId("ffffffffffffffffffffffff"));
                                        }});
         }
-        SECTION("Random")
-        {
+        SECTION("Random") {
             run_corpus<ObjectId>("a", {"{\"a\" : {\"$oid\" : \"56e1fc72e0c917e9c4714161\"}}", [](auto val) {
                                            CHECK(val == ObjectId("56e1fc72e0c917e9c4714161"));
                                        }});
         }
     }
 
-    SECTION("Regular Expression type")
-    {
-        SECTION("empty regex with no options")
-        {
+    SECTION("Regular Expression type") {
+        SECTION("empty regex with no options") {
             run_corpus<RegularExpression>(
                 "a", {"{\"a\" : {\"$regularExpression\" : { \"pattern\": \"\", \"options\" : \"\"}}}", [](auto val) {
                           CHECK(val == RegularExpression());
                       }});
         }
-        SECTION("regex without options")
-        {
+        SECTION("regex without options") {
             run_corpus<RegularExpression>(
                 "a",
                 {"{\"a\" : {\"$regularExpression\" : { \"pattern\": \"abc\", \"options\" : \"\"}}}", [](auto val) {
                      CHECK(val == RegularExpression("abc", ""));
                  }});
         }
-        SECTION("regex with options")
-        {
+        SECTION("regex with options") {
             run_corpus<RegularExpression>(
                 "a",
                 {"{\"a\" : {\"$regularExpression\" : { \"pattern\": \"abc\", \"options\" : \"im\"}}}", [](auto val) {
@@ -654,8 +574,7 @@ TEST_CASE("canonical_extjson_corpus", "[bson]")
                          ((val.options() & RegularExpression::Option::Multiline) != RegularExpression::Option::None));
                  }});
         }
-        SECTION("regex with options (keys reversed)")
-        {
+        SECTION("regex with options (keys reversed)") {
             run_corpus<RegularExpression>(
                 "a", {"{\"a\" : {\"$regularExpression\" : {\"options\" : \"im\", \"pattern\": \"abc\"}}}",
                       [](auto val) {
@@ -667,8 +586,7 @@ TEST_CASE("canonical_extjson_corpus", "[bson]")
                       },
                       true});
         }
-        SECTION("regex with slash")
-        {
+        SECTION("regex with slash") {
             run_corpus<RegularExpression>(
                 "a", {"{\"a\" : {\"$regularExpression\" : { \"pattern\": \"ab/cd\", \"options\" : \"im\"}}}",
                       [](auto val) {
@@ -679,8 +597,7 @@ TEST_CASE("canonical_extjson_corpus", "[bson]")
                                  RegularExpression::Option::None));
                       }});
         }
-        SECTION("flags not alphabetized")
-        {
+        SECTION("flags not alphabetized") {
             run_corpus<RegularExpression>(
                 "a", {"{\"a\" : {\"$regularExpression\" : { \"pattern\": \"abc\", \"options\" : \"mix\"}}}",
                       [](auto val) {
@@ -694,8 +611,7 @@ TEST_CASE("canonical_extjson_corpus", "[bson]")
                       },
                       true});
         }
-        SECTION("Regular expression as value of $regex query operator")
-        {
+        SECTION("Regular expression as value of $regex query operator") {
             run_corpus<RegularExpression>(
                 "$regex",
                 {"{\"$regex\" : {\"$regularExpression\" : { \"pattern\": \"pattern\", \"options\" : \"ix\"}}}",
@@ -709,38 +625,31 @@ TEST_CASE("canonical_extjson_corpus", "[bson]")
         }
     }
 
-    SECTION("String")
-    {
-        SECTION("Empty string")
-        {
+    SECTION("String") {
+        SECTION("Empty string") {
             run_corpus<std::string>("a", {"{\"a\" : \"\"}", [](auto val) {
                                               CHECK(val.empty());
                                           }});
         }
-        SECTION("Single character")
-        {
+        SECTION("Single character") {
             run_corpus<std::string>("a", {"{\"a\" : \"b\"}", [](auto val) {
                                               CHECK(val == "b");
                                           }});
         }
-        SECTION("Multi-character")
-        {
+        SECTION("Multi-character") {
             run_corpus<std::string>("a", {"{\"a\" : \"abababababab\"}", [](auto val) {
                                               CHECK(val == "abababababab");
                                           }});
         }
-        SECTION("Special characters in string")
-        {
+        SECTION("Special characters in string") {
             run_corpus<std::string>("x", {R"({"x" : ">\n\t\u0000\\\"<"})", [](auto val) {
                                               CHECK(val == ">\n\t\x00\\\"<"sv);
                                           }});
         }
     }
 
-    SECTION("Timestamp")
-    {
-        SECTION("Timestamp: (123456789, 42)")
-        {
+    SECTION("Timestamp") {
+        SECTION("Timestamp: (123456789, 42)") {
             run_corpus<MongoTimestamp>("a", {
                                                 "{\"a\" : {\"$timestamp\" : {\"t\" : 123456789, \"i\" : 42} } }",
                                                 [](auto val) {
@@ -749,8 +658,7 @@ TEST_CASE("canonical_extjson_corpus", "[bson]")
                                                 },
                                             });
         }
-        SECTION("Timestamp: (123456789, 42) (keys reversed)")
-        {
+        SECTION("Timestamp: (123456789, 42) (keys reversed)") {
             run_corpus<MongoTimestamp>("a", {
                                                 "{\"a\" : {\"$timestamp\" : {\"t\" : 123456789, \"i\" : 42 } } }",
                                                 [](auto val) {
@@ -759,8 +667,7 @@ TEST_CASE("canonical_extjson_corpus", "[bson]")
                                                 },
                                             });
         }
-        SECTION("Timestamp with high-order bit set on both seconds and increment")
-        {
+        SECTION("Timestamp with high-order bit set on both seconds and increment") {
             run_corpus<MongoTimestamp>("a",
                                        {
                                            "{\"a\" : {\"$timestamp\" : {\"t\" : 4294967295, \"i\" :  4294967295} } }",
@@ -773,11 +680,9 @@ TEST_CASE("canonical_extjson_corpus", "[bson]")
     }
 }
 
-TEST_CASE("nested types parsing", "[bson]")
-{
+TEST_CASE("nested types parsing", "[bson]") {
 
-    SECTION("Nested types")
-    {
+    SECTION("Nested types") {
         auto d1 = bson::BsonDocument({{"aNest", bson::BsonArray({1, 2, 3})}, {"anotherKey", "hey"}});
         auto d2 = bson::BsonDocument({{"numberArray", bson::BsonArray({1, 2, 3})}});
         auto d3 = bson::BsonDocument(

--- a/test/object-store/dictionary.cpp
+++ b/test/object-store/dictionary.cpp
@@ -39,8 +39,7 @@ using namespace realm;
 using namespace realm::util;
 
 
-TEST_CASE("dictionary")
-{
+TEST_CASE("dictionary") {
     InMemoryTestFile config;
     config.cache = false;
     config.automatic_change_notifications = false;
@@ -58,8 +57,7 @@ TEST_CASE("dictionary")
     auto results = dict.as_results();
     CppContext ctx(r);
 
-    SECTION("get_realm()")
-    {
+    SECTION("get_realm()") {
         REQUIRE(dict.get_realm() == r);
         REQUIRE(results.get_realm() == r);
     }
@@ -72,16 +70,14 @@ TEST_CASE("dictionary")
     }
 
 
-    SECTION("clear()")
-    {
+    SECTION("clear()") {
         REQUIRE(dict.size() == 3);
         results.clear();
         REQUIRE(dict.size() == 0);
         REQUIRE(results.size() == 0);
     }
 
-    SECTION("get()")
-    {
+    SECTION("get()") {
         for (size_t i = 0; i < values.size(); ++i) {
             REQUIRE(dict.get<String>(keys[i]) == values[i]);
             auto val = dict.get(ctx, util::Any(keys[i]));
@@ -89,8 +85,7 @@ TEST_CASE("dictionary")
         }
     }
 
-    SECTION("insert()")
-    {
+    SECTION("insert()") {
         for (size_t i = 0; i < values.size(); ++i) {
             auto rev = values.size() - i - 1;
             dict.insert(keys[i], values[rev]);

--- a/test/object-store/index_set.cpp
+++ b/test/object-store/index_set.cpp
@@ -22,28 +22,23 @@
 
 #include "util/index_helpers.hpp"
 
-TEST_CASE("index_set: contains()")
-{
-    SECTION("returns false if the index is before the first entry in the set")
-    {
+TEST_CASE("index_set: contains()") {
+    SECTION("returns false if the index is before the first entry in the set") {
         realm::IndexSet set = {1, 2, 5};
         REQUIRE_FALSE(set.contains(0));
     }
 
-    SECTION("returns false if the index is after the last entry in the set")
-    {
+    SECTION("returns false if the index is after the last entry in the set") {
         realm::IndexSet set = {1, 2, 5};
         REQUIRE_FALSE(set.contains(6));
     }
 
-    SECTION("returns false if the index is between ranges in the set")
-    {
+    SECTION("returns false if the index is between ranges in the set") {
         realm::IndexSet set = {1, 2, 5};
         REQUIRE_FALSE(set.contains(4));
     }
 
-    SECTION("returns true if the index is in the set")
-    {
+    SECTION("returns true if the index is in the set") {
         realm::IndexSet set = {1, 2, 5};
         REQUIRE(set.contains(1));
         REQUIRE(set.contains(2));
@@ -51,10 +46,8 @@ TEST_CASE("index_set: contains()")
     }
 }
 
-TEST_CASE("index_set: count()")
-{
-    SECTION("returns the number of indices in the set in the given range")
-    {
+TEST_CASE("index_set: count()") {
+    SECTION("returns the number of indices in the set in the given range") {
         realm::IndexSet set = {1, 2, 3, 5};
         REQUIRE(set.count(0, 6) == 4);
         REQUIRE(set.count(0, 5) == 3);
@@ -73,20 +66,17 @@ TEST_CASE("index_set: count()")
         REQUIRE(set.count(6, 6) == 0);
     }
 
-    SECTION("includes full ranges in the middle")
-    {
+    SECTION("includes full ranges in the middle") {
         realm::IndexSet set = {1, 3, 4, 5, 10};
         REQUIRE(set.count(0, 11) == 5);
     }
 
-    SECTION("truncates ranges at the beginning and end")
-    {
+    SECTION("truncates ranges at the beginning and end") {
         realm::IndexSet set = {1, 2, 3, 5, 6, 7, 8, 9};
         REQUIRE(set.count(3, 9) == 5);
     }
 
-    SECTION("handles full chunks well")
-    {
+    SECTION("handles full chunks well") {
         size_t count = realm::_impl::ChunkedRangeVector::max_size * 4;
         realm::IndexSet set;
         for (size_t i = 0; i < count; ++i) {
@@ -101,12 +91,10 @@ TEST_CASE("index_set: count()")
     }
 }
 
-TEST_CASE("index_set: add()")
-{
+TEST_CASE("index_set: add()") {
     realm::IndexSet set;
 
-    SECTION("extends existing ranges when next to an edge")
-    {
+    SECTION("extends existing ranges when next to an edge") {
         set.add(1);
         REQUIRE_INDICES(set, 1);
 
@@ -117,8 +105,7 @@ TEST_CASE("index_set: add()")
         REQUIRE_INDICES(set, 0, 1, 2);
     }
 
-    SECTION("does not extend ranges over gaps")
-    {
+    SECTION("does not extend ranges over gaps") {
         set.add(0);
         REQUIRE_INDICES(set, 0);
 
@@ -126,38 +113,33 @@ TEST_CASE("index_set: add()")
         REQUIRE_INDICES(set, 0, 2);
     }
 
-    SECTION("does nothing when the index is already in the set")
-    {
+    SECTION("does nothing when the index is already in the set") {
         set.add(0);
         set.add(0);
         REQUIRE_INDICES(set, 0);
     }
 
-    SECTION("merges existing ranges when adding the index between them")
-    {
+    SECTION("merges existing ranges when adding the index between them") {
         set = {0, 2, 4};
 
         set.add(1);
         REQUIRE_INDICES(set, 0, 1, 2, 4);
     }
 
-    SECTION("combines multiple index sets without any shifting")
-    {
+    SECTION("combines multiple index sets without any shifting") {
         set = {0, 2, 6};
 
         set.add({1, 4, 5});
         REQUIRE_INDICES(set, 0, 1, 2, 4, 5, 6);
     }
 
-    SECTION("handles front additions of ranges")
-    {
+    SECTION("handles front additions of ranges") {
         for (size_t i = 20; i > 0; i -= 2)
             set.add(i);
         REQUIRE_INDICES(set, 2, 4, 6, 8, 10, 12, 14, 16, 18, 20);
     }
 
-    SECTION("merges ranges even when they are in different chunks")
-    {
+    SECTION("merges ranges even when they are in different chunks") {
         realm::IndexSet set2;
         for (int i = 0; i < 20; ++i) {
             set.add(i * 2);
@@ -169,25 +151,21 @@ TEST_CASE("index_set: add()")
     }
 }
 
-TEST_CASE("index_set: add_shifted()")
-{
+TEST_CASE("index_set: add_shifted()") {
     realm::IndexSet set;
 
-    SECTION("on an empty set is just add()")
-    {
+    SECTION("on an empty set is just add()") {
         set.add_shifted(5);
         REQUIRE_INDICES(set, 5);
     }
 
-    SECTION("before the first range is just add()")
-    {
+    SECTION("before the first range is just add()") {
         set = {10};
         set.add_shifted(5);
         REQUIRE_INDICES(set, 5, 10);
     }
 
-    SECTION("on first index of a range extends the range")
-    {
+    SECTION("on first index of a range extends the range") {
         set = {5};
 
         set.add_shifted(5);
@@ -197,15 +175,13 @@ TEST_CASE("index_set: add_shifted()")
         REQUIRE_INDICES(set, 5, 6, 7);
     }
 
-    SECTION("in the middle of a range is shifted by that range")
-    {
+    SECTION("in the middle of a range is shifted by that range") {
         set = {5, 6, 7};
         set.add_shifted(6);
         REQUIRE_INDICES(set, 5, 6, 7, 9);
     }
 
-    SECTION("after the last range adds the total count to the index to be added")
-    {
+    SECTION("after the last range adds the total count to the index to be added") {
         set = {5};
 
         set.add_shifted(6);
@@ -215,56 +191,48 @@ TEST_CASE("index_set: add_shifted()")
         REQUIRE_INDICES(set, 5, 7, 12);
     }
 
-    SECTION("in between ranges can be bumped into the next range")
-    {
+    SECTION("in between ranges can be bumped into the next range") {
         set = {5, 7};
         set.add_shifted(6);
         REQUIRE_INDICES(set, 5, 7, 8);
     }
 }
 
-TEST_CASE("index_set: add_shifted_by()")
-{
+TEST_CASE("index_set: add_shifted_by()") {
     realm::IndexSet set;
 
-    SECTION("does nothing given an empty set to add")
-    {
+    SECTION("does nothing given an empty set to add") {
         set = {5, 6, 7};
         set.add_shifted_by({5, 6}, {});
         REQUIRE_INDICES(set, 5, 6, 7);
     }
 
-    SECTION("does nothing if values is a subset of shifted_by")
-    {
+    SECTION("does nothing if values is a subset of shifted_by") {
         set = {5, 6, 7};
         set.add_shifted_by({3, 4}, {3, 4});
         REQUIRE_INDICES(set, 5, 6, 7);
     }
 
-    SECTION("just adds the indices when they are all before the old indices and the shifted-by set is empty")
-    {
+    SECTION("just adds the indices when they are all before the old indices and the shifted-by set is empty") {
         set = {5, 6};
         set.add_shifted_by({}, {3, 4});
         REQUIRE_INDICES(set, 3, 4, 5, 6);
     }
 
     SECTION("adds the indices shifted by the old count when they are all after the old indices and the shifted-by "
-            "set is empty")
-    {
+            "set is empty") {
         set = {5, 6};
         set.add_shifted_by({}, {7, 9, 11, 13});
         REQUIRE_INDICES(set, 5, 6, 9, 11, 13, 15);
     }
 
-    SECTION("acts like bulk add_shifted() when shifted_by is empty")
-    {
+    SECTION("acts like bulk add_shifted() when shifted_by is empty") {
         set = {5, 10, 15, 20, 25};
         set.add_shifted_by({}, {4, 5, 11});
         REQUIRE_INDICES(set, 4, 5, 6, 10, 13, 15, 20, 25);
     }
 
-    SECTION("shifts indices in values back by the number of indices in shifted_by before them")
-    {
+    SECTION("shifts indices in values back by the number of indices in shifted_by before them") {
         set = {5};
         set.add_shifted_by({0, 2, 3}, {6});
         REQUIRE_INDICES(set, 3, 5);
@@ -274,32 +242,27 @@ TEST_CASE("index_set: add_shifted_by()")
         REQUIRE_INDICES(set, 2, 5);
     }
 
-    SECTION("discards indices in both shifted_by and values")
-    {
+    SECTION("discards indices in both shifted_by and values") {
         set = {5};
         set.add_shifted_by({2}, {2, 4});
         REQUIRE_INDICES(set, 3, 5);
     }
 }
 
-TEST_CASE("index_set: set()")
-{
+TEST_CASE("index_set: set()") {
     realm::IndexSet set;
 
-    SECTION("clears the existing indices and replaces with the range [0, value)")
-    {
+    SECTION("clears the existing indices and replaces with the range [0, value)") {
         set = {8, 9};
         set.set(5);
         REQUIRE_INDICES(set, 0, 1, 2, 3, 4);
     }
 }
 
-TEST_CASE("index_set: insert_at()")
-{
+TEST_CASE("index_set: insert_at()") {
     realm::IndexSet set;
 
-    SECTION("on an empty set is add()")
-    {
+    SECTION("on an empty set is add()") {
         set.insert_at(5);
         REQUIRE_INDICES(set, 5);
 
@@ -308,15 +271,13 @@ TEST_CASE("index_set: insert_at()")
         REQUIRE_INDICES(set, 1, 3, 5);
     }
 
-    SECTION("with an empty set is a no-op")
-    {
+    SECTION("with an empty set is a no-op") {
         set = {5, 6};
         set.insert_at(realm::IndexSet{});
         REQUIRE_INDICES(set, 5, 6);
     }
 
-    SECTION("extends ranges containing the target range")
-    {
+    SECTION("extends ranges containing the target range") {
         set = {5, 6};
 
         set.insert_at(5);
@@ -329,8 +290,7 @@ TEST_CASE("index_set: insert_at()")
         REQUIRE_INDICES(set, 5, 6, 7, 8, 9, 10, 11, 12);
     }
 
-    SECTION("shifts ranges after the insertion point")
-    {
+    SECTION("shifts ranges after the insertion point") {
         set = {5, 6};
 
         set.insert_at(3);
@@ -340,8 +300,7 @@ TEST_CASE("index_set: insert_at()")
         REQUIRE_INDICES(set, 0, 1, 5, 8, 9);
     }
 
-    SECTION("does not shift ranges before the insertion point")
-    {
+    SECTION("does not shift ranges before the insertion point") {
         set = {5, 6};
 
         set.insert_at(10);
@@ -351,55 +310,47 @@ TEST_CASE("index_set: insert_at()")
         REQUIRE_INDICES(set, 5, 6, 10, 15, 16);
     }
 
-    SECTION("can not join ranges")
-    {
+    SECTION("can not join ranges") {
         set = {5, 7};
         set.insert_at(6);
         REQUIRE_INDICES(set, 5, 6, 8);
     }
 
-    SECTION("adds later ranges after shifting for previous insertions")
-    {
+    SECTION("adds later ranges after shifting for previous insertions") {
         set = {5, 10};
         set.insert_at({5, 10});
         REQUIRE_INDICES(set, 5, 6, 10, 12);
     }
 }
 
-TEST_CASE("index_set: shift_for_insert_at()")
-{
+TEST_CASE("index_set: shift_for_insert_at()") {
     realm::IndexSet set;
 
-    SECTION("does nothing given an empty set of insertion points")
-    {
+    SECTION("does nothing given an empty set of insertion points") {
         set = {5, 8};
         set.shift_for_insert_at(realm::IndexSet{});
         REQUIRE_INDICES(set, 5, 8);
     }
 
-    SECTION("does nothing when called on an empty set")
-    {
+    SECTION("does nothing when called on an empty set") {
         set = {};
         set.shift_for_insert_at({5, 8});
         REQUIRE(set.empty());
     }
 
-    SECTION("does nothing when the insertion points are all after the current indices")
-    {
+    SECTION("does nothing when the insertion points are all after the current indices") {
         set = {10, 20};
         set.shift_for_insert_at({30, 40});
         REQUIRE_INDICES(set, 10, 20);
     }
 
-    SECTION("does shift when the insertion points are all before the current indices")
-    {
+    SECTION("does shift when the insertion points are all before the current indices") {
         set = {10, 20};
         set.shift_for_insert_at({2, 4});
         REQUIRE_INDICES(set, 12, 22);
     }
 
-    SECTION("shifts indices at or after the insertion points")
-    {
+    SECTION("shifts indices at or after the insertion points") {
         set = {5};
 
         set.shift_for_insert_at(4);
@@ -412,15 +363,13 @@ TEST_CASE("index_set: shift_for_insert_at()")
         REQUIRE_INDICES(set, 9);
     }
 
-    SECTION("shifts indices by the count specified")
-    {
+    SECTION("shifts indices by the count specified") {
         set = {5};
         set.shift_for_insert_at(3, 10);
         REQUIRE_INDICES(set, 15);
     }
 
-    SECTION("does not shift indices before the insertion points")
-    {
+    SECTION("does not shift indices before the insertion points") {
         set = {5};
 
         set.shift_for_insert_at(6);
@@ -430,8 +379,7 @@ TEST_CASE("index_set: shift_for_insert_at()")
         REQUIRE_INDICES(set, 6);
     }
 
-    SECTION("splits ranges containing the insertion points")
-    {
+    SECTION("splits ranges containing the insertion points") {
         set = {5, 6, 7, 8};
 
         set.shift_for_insert_at(6);
@@ -442,12 +390,10 @@ TEST_CASE("index_set: shift_for_insert_at()")
     }
 }
 
-TEST_CASE("index_set: erase_at()")
-{
+TEST_CASE("index_set: erase_at()") {
     realm::IndexSet set;
 
-    SECTION("is a no-op on an empty set")
-    {
+    SECTION("is a no-op on an empty set") {
         set.erase_at(10);
         REQUIRE(set.empty());
 
@@ -455,15 +401,13 @@ TEST_CASE("index_set: erase_at()")
         REQUIRE(set.empty());
     }
 
-    SECTION("does nothing when given an empty set")
-    {
+    SECTION("does nothing when given an empty set") {
         set = {5};
         set.erase_at(realm::IndexSet{});
         REQUIRE_INDICES(set, 5);
     }
 
-    SECTION("removes the specified indices")
-    {
+    SECTION("removes the specified indices") {
         set = {5};
         set.erase_at(5);
         REQUIRE(set.empty());
@@ -473,8 +417,7 @@ TEST_CASE("index_set: erase_at()")
         REQUIRE(set.empty());
     }
 
-    SECTION("does not modify indices before the removed one")
-    {
+    SECTION("does not modify indices before the removed one") {
         set = {5, 8};
         set.erase_at(8);
         REQUIRE_INDICES(set, 5);
@@ -484,8 +427,7 @@ TEST_CASE("index_set: erase_at()")
         REQUIRE_INDICES(set, 5);
     }
 
-    SECTION("shifts indices after the removed one")
-    {
+    SECTION("shifts indices after the removed one") {
         set = {5, 8};
         set.erase_at(5);
         REQUIRE_INDICES(set, 7);
@@ -495,8 +437,7 @@ TEST_CASE("index_set: erase_at()")
         REQUIRE_INDICES(set, 13, 18);
     }
 
-    SECTION("shrinks ranges when used on one of the edges of them")
-    {
+    SECTION("shrinks ranges when used on one of the edges of them") {
         set = {5, 6, 7, 8};
         set.erase_at(8);
         REQUIRE_INDICES(set, 5, 6, 7);
@@ -508,8 +449,7 @@ TEST_CASE("index_set: erase_at()")
         REQUIRE_INDICES(set, 5, 6);
     }
 
-    SECTION("shrinks ranges when used in the middle of them")
-    {
+    SECTION("shrinks ranges when used in the middle of them") {
         set = {5, 6, 7, 8};
         set.erase_at(7);
         REQUIRE_INDICES(set, 5, 6, 7);
@@ -519,8 +459,7 @@ TEST_CASE("index_set: erase_at()")
         REQUIRE_INDICES(set, 5, 6);
     }
 
-    SECTION("merges ranges when the gap between them is deleted")
-    {
+    SECTION("merges ranges when the gap between them is deleted") {
         set = {3, 5};
         set.erase_at(4);
         REQUIRE_INDICES(set, 3, 4);
@@ -531,34 +470,29 @@ TEST_CASE("index_set: erase_at()")
     }
 }
 
-TEST_CASE("index_set: erase_or_unshift()")
-{
+TEST_CASE("index_set: erase_or_unshift()") {
     realm::IndexSet set;
 
-    SECTION("removes the given index")
-    {
+    SECTION("removes the given index") {
         set = {1, 2};
         set.erase_or_unshift(2);
         REQUIRE_INDICES(set, 1);
     }
 
-    SECTION("shifts indexes after the given index")
-    {
+    SECTION("shifts indexes after the given index") {
         set = {1, 5};
         set.erase_or_unshift(2);
         REQUIRE_INDICES(set, 1, 4);
     }
 
-    SECTION("returns npos for indices in the set")
-    {
+    SECTION("returns npos for indices in the set") {
         set = {1, 3, 5};
         REQUIRE(realm::IndexSet(set).erase_or_unshift(1) == realm::IndexSet::npos);
         REQUIRE(realm::IndexSet(set).erase_or_unshift(3) == realm::IndexSet::npos);
         REQUIRE(realm::IndexSet(set).erase_or_unshift(5) == realm::IndexSet::npos);
     }
 
-    SECTION("returns the number of indices in the set before the index for ones not in the set")
-    {
+    SECTION("returns the number of indices in the set before the index for ones not in the set") {
         set = {1, 3, 5, 6};
         REQUIRE(realm::IndexSet(set).erase_or_unshift(0) == 0);
         REQUIRE(realm::IndexSet(set).erase_or_unshift(2) == 1);
@@ -567,12 +501,10 @@ TEST_CASE("index_set: erase_or_unshift()")
     }
 }
 
-TEST_CASE("index_set: remove()")
-{
+TEST_CASE("index_set: remove()") {
     realm::IndexSet set;
 
-    SECTION("is a no-op if the set is empty")
-    {
+    SECTION("is a no-op if the set is empty") {
         set.remove(4);
         REQUIRE(set.empty());
 
@@ -580,15 +512,13 @@ TEST_CASE("index_set: remove()")
         REQUIRE(set.empty());
     }
 
-    SECTION("is a no-op if the set to remove is empty")
-    {
+    SECTION("is a no-op if the set to remove is empty") {
         set = {5};
         set.remove(realm::IndexSet{});
         REQUIRE_INDICES(set, 5);
     }
 
-    SECTION("is a no-op if the index to remove is not in the set")
-    {
+    SECTION("is a no-op if the index to remove is not in the set") {
         set = {5};
         set.remove(4);
         set.remove(6);
@@ -596,8 +526,7 @@ TEST_CASE("index_set: remove()")
         REQUIRE_INDICES(set, 5);
     }
 
-    SECTION("removes one-element ranges")
-    {
+    SECTION("removes one-element ranges") {
         set = {5};
         set.remove(5);
         REQUIRE(set.empty());
@@ -607,8 +536,7 @@ TEST_CASE("index_set: remove()")
         REQUIRE(set.empty());
     }
 
-    SECTION("shrinks ranges beginning with the index")
-    {
+    SECTION("shrinks ranges beginning with the index") {
         set = {5, 6, 7};
         set.remove(5);
         REQUIRE_INDICES(set, 6, 7);
@@ -618,8 +546,7 @@ TEST_CASE("index_set: remove()")
         REQUIRE_INDICES(set, 6, 7);
     }
 
-    SECTION("shrinks ranges ending with the index")
-    {
+    SECTION("shrinks ranges ending with the index") {
         set = {5, 6, 7};
         set.remove(7);
         REQUIRE_INDICES(set, 5, 6);
@@ -629,8 +556,7 @@ TEST_CASE("index_set: remove()")
         REQUIRE_INDICES(set, 5, 6);
     }
 
-    SECTION("splits ranges containing the index")
-    {
+    SECTION("splits ranges containing the index") {
         set = {5, 6, 7};
         set.remove(6);
         REQUIRE_INDICES(set, 5, 7);
@@ -640,20 +566,17 @@ TEST_CASE("index_set: remove()")
         REQUIRE_INDICES(set, 5, 7);
     }
 
-    SECTION("does not shift other indices and uses unshifted positions")
-    {
+    SECTION("does not shift other indices and uses unshifted positions") {
         set = {5, 6, 7, 10, 11, 12, 13, 15};
         set.remove({6, 11, 13});
         REQUIRE_INDICES(set, 5, 7, 10, 12, 15);
     }
 }
 
-TEST_CASE("index_set: shift()")
-{
+TEST_CASE("index_set: shift()") {
     realm::IndexSet set;
 
-    SECTION("is ind + count(0, ind), but adds the count-so-far to the stop index")
-    {
+    SECTION("is ind + count(0, ind), but adds the count-so-far to the stop index") {
         set = {1, 3, 5, 6};
         REQUIRE(set.shift(0) == 0);
         REQUIRE(set.shift(1) == 2);
@@ -663,12 +586,10 @@ TEST_CASE("index_set: shift()")
     }
 }
 
-TEST_CASE("index_set: unshift()")
-{
+TEST_CASE("index_set: unshift()") {
     realm::IndexSet set;
 
-    SECTION("is index - count(0, index)")
-    {
+    SECTION("is index - count(0, index)") {
         set = {1, 3, 5, 6};
         REQUIRE(set.unshift(0) == 0);
         REQUIRE(set.unshift(2) == 1);
@@ -678,12 +599,10 @@ TEST_CASE("index_set: unshift()")
     }
 }
 
-TEST_CASE("index_set: clear()")
-{
+TEST_CASE("index_set: clear()") {
     realm::IndexSet set;
 
-    SECTION("removes all indices from the set")
-    {
+    SECTION("removes all indices from the set") {
         set = {1, 2, 3};
         set.clear();
         REQUIRE(set.empty());

--- a/test/object-store/migrations.cpp
+++ b/test/object-store/migrations.cpp
@@ -109,8 +109,9 @@ Schema add_table(Schema const& schema, ObjectSchema object_schema)
 Schema remove_table(Schema const& schema, StringData object_name)
 {
     std::vector<ObjectSchema> new_schema;
-    std::remove_copy_if(schema.begin(), schema.end(), std::back_inserter(new_schema),
-                        [&](auto&& object_schema) { return object_schema.name == object_name; });
+    std::remove_copy_if(schema.begin(), schema.end(), std::back_inserter(new_schema), [&](auto&& object_schema) {
+        return object_schema.name == object_name;
+    });
     return new_schema;
 }
 
@@ -123,8 +124,9 @@ Schema add_property(Schema schema, StringData object_name, Property property)
 Schema remove_property(Schema schema, StringData object_name, StringData property_name)
 {
     auto& properties = schema.find(object_name)->persisted_properties;
-    properties.erase(
-        find_if(begin(properties), end(properties), [&](auto&& prop) { return prop.name == property_name; }));
+    properties.erase(find_if(begin(properties), end(properties), [&](auto&& prop) {
+        return prop.name == property_name;
+    }));
     return schema;
 }
 
@@ -183,15 +185,12 @@ auto create_objects(Table& table, size_t count)
 }
 } // anonymous namespace
 
-TEST_CASE("migration: Automatic")
-{
+TEST_CASE("migration: Automatic") {
     InMemoryTestFile config;
     config.automatic_change_notifications = false;
 
-    SECTION("no migration required")
-    {
-        SECTION("add object schema")
-        {
+    SECTION("no migration required") {
+        SECTION("add object schema") {
             auto realm = Realm::get_shared_realm(config);
 
             Schema schema1 = {};
@@ -202,8 +201,7 @@ TEST_CASE("migration: Automatic")
             REQUIRE_UPDATE_SUCCEEDS(*realm, schema3, 0);
         }
 
-        SECTION("add embedded object schema")
-        {
+        SECTION("add embedded object schema") {
             auto realm = Realm::get_shared_realm(config);
 
             Schema schema1 = {};
@@ -214,8 +212,7 @@ TEST_CASE("migration: Automatic")
             REQUIRE_UPDATE_SUCCEEDS(*realm, schema3, 0);
         }
 
-        SECTION("remove object schema")
-        {
+        SECTION("remove object schema") {
             auto realm = Realm::get_shared_realm(config);
 
             Schema schema1 = {
@@ -229,8 +226,7 @@ TEST_CASE("migration: Automatic")
             REQUIRE_UPDATE_SUCCEEDS(*realm, schema1, 0);
         }
 
-        SECTION("add index")
-        {
+        SECTION("add index") {
             auto realm = Realm::get_shared_realm(config);
             Schema schema = {
                 {"object", {{"value", PropertyType::Int}}},
@@ -238,8 +234,7 @@ TEST_CASE("migration: Automatic")
             REQUIRE_NO_MIGRATION_NEEDED(*realm, schema, set_indexed(schema, "object", "value", true));
         }
 
-        SECTION("remove index")
-        {
+        SECTION("remove index") {
             auto realm = Realm::get_shared_realm(config);
             Schema schema = {
                 {"object", {{"value", PropertyType::Int, Property::IsPrimary{false}, Property::IsIndexed{true}}}},
@@ -247,8 +242,7 @@ TEST_CASE("migration: Automatic")
             REQUIRE_NO_MIGRATION_NEEDED(*realm, schema, set_indexed(schema, "object", "value", false));
         }
 
-        SECTION("reordering properties")
-        {
+        SECTION("reordering properties") {
             auto realm = Realm::get_shared_realm(config);
 
             Schema schema1 = {
@@ -269,10 +263,8 @@ TEST_CASE("migration: Automatic")
         }
     }
 
-    SECTION("migration required")
-    {
-        SECTION("add property to existing object schema")
-        {
+    SECTION("migration required") {
+        SECTION("add property to existing object schema") {
             auto realm = Realm::get_shared_realm(config);
 
             Schema schema1 = {
@@ -285,8 +277,7 @@ TEST_CASE("migration: Automatic")
             REQUIRE_MIGRATION_NEEDED(*realm, schema1, schema2);
         }
 
-        SECTION("remove property from existing object schema")
-        {
+        SECTION("remove property from existing object schema") {
             auto realm = Realm::get_shared_realm(config);
             Schema schema = {
                 {"object",
@@ -298,8 +289,7 @@ TEST_CASE("migration: Automatic")
             REQUIRE_MIGRATION_NEEDED(*realm, schema, remove_property(schema, "object", "col2"));
         }
 
-        SECTION("migratation which replaces a persisted property with a computed one")
-        {
+        SECTION("migratation which replaces a persisted property with a computed one") {
             auto realm = Realm::get_shared_realm(config);
             Schema schema1 = {
                 {"object",
@@ -326,8 +316,7 @@ TEST_CASE("migration: Automatic")
             REQUIRE((*realm).schema() == schema2);
         }
 
-        SECTION("change property type")
-        {
+        SECTION("change property type") {
             auto realm = Realm::get_shared_realm(config);
             Schema schema = {
                 {"object",
@@ -338,8 +327,7 @@ TEST_CASE("migration: Automatic")
             REQUIRE_MIGRATION_NEEDED(*realm, schema, set_type(schema, "object", "value", PropertyType::Float));
         }
 
-        SECTION("make property nullable")
-        {
+        SECTION("make property nullable") {
             auto realm = Realm::get_shared_realm(config);
 
             Schema schema = {
@@ -351,8 +339,7 @@ TEST_CASE("migration: Automatic")
             REQUIRE_MIGRATION_NEEDED(*realm, schema, set_optional(schema, "object", "value", true));
         }
 
-        SECTION("make property required")
-        {
+        SECTION("make property required") {
             auto realm = Realm::get_shared_realm(config);
 
             Schema schema = {
@@ -364,8 +351,7 @@ TEST_CASE("migration: Automatic")
             REQUIRE_MIGRATION_NEEDED(*realm, schema, set_optional(schema, "object", "value", false));
         }
 
-        SECTION("change link target")
-        {
+        SECTION("change link target") {
             auto realm = Realm::get_shared_realm(config);
 
             Schema schema = {
@@ -385,8 +371,7 @@ TEST_CASE("migration: Automatic")
             REQUIRE_MIGRATION_NEEDED(*realm, schema, set_target(schema, "origin", "value", "target 2"));
         }
 
-        SECTION("add pk")
-        {
+        SECTION("add pk") {
             auto realm = Realm::get_shared_realm(config);
 
             Schema schema = {
@@ -398,8 +383,7 @@ TEST_CASE("migration: Automatic")
             REQUIRE_MIGRATION_NEEDED(*realm, schema, set_primary_key(schema, "object", "value"));
         }
 
-        SECTION("remove pk")
-        {
+        SECTION("remove pk") {
             auto realm = Realm::get_shared_realm(config);
 
             Schema schema = {
@@ -411,8 +395,7 @@ TEST_CASE("migration: Automatic")
             REQUIRE_MIGRATION_NEEDED(*realm, schema, set_primary_key(schema, "object", ""));
         }
 
-        SECTION("adding column and table in same migration doesn't add duplicate columns")
-        {
+        SECTION("adding column and table in same migration doesn't add duplicate columns") {
             auto realm = Realm::get_shared_realm(config);
 
             Schema schema1 = {
@@ -430,8 +413,7 @@ TEST_CASE("migration: Automatic")
             REQUIRE(table.get_column_count() == 1);
         }
 
-        SECTION("adding column and embedded table in same migration")
-        {
+        SECTION("adding column and embedded table in same migration") {
             auto realm = Realm::get_shared_realm(config);
 
             Schema schema1 = {
@@ -446,8 +428,7 @@ TEST_CASE("migration: Automatic")
             REQUIRE_UPDATE_SUCCEEDS(*realm, schema2, 1);
         }
 
-        SECTION("change table from embedded to top-level")
-        {
+        SECTION("change table from embedded to top-level") {
             auto realm = Realm::get_shared_realm(config);
 
             Schema schema = {
@@ -460,8 +441,7 @@ TEST_CASE("migration: Automatic")
             REQUIRE_MIGRATION_NEEDED(*realm, schema, set_embedded(schema, "object", false));
         }
 
-        SECTION("change table from top-level to embedded")
-        {
+        SECTION("change table from top-level to embedded") {
             auto realm = Realm::get_shared_realm(config);
 
             Schema schema = {
@@ -474,10 +454,8 @@ TEST_CASE("migration: Automatic")
         }
     }
 
-    SECTION("migration block invocations")
-    {
-        SECTION("not called for initial creation of schema")
-        {
+    SECTION("migration block invocations") {
+        SECTION("not called for initial creation of schema") {
             Schema schema = {
                 {"object",
                  {
@@ -485,11 +463,12 @@ TEST_CASE("migration: Automatic")
                  }},
             };
             auto realm = Realm::get_shared_realm(config);
-            realm->update_schema(schema, 5, [](SharedRealm, SharedRealm, Schema&) { REQUIRE(false); });
+            realm->update_schema(schema, 5, [](SharedRealm, SharedRealm, Schema&) {
+                REQUIRE(false);
+            });
         }
 
-        SECTION("not called when schema version is unchanged even if there are schema changes")
-        {
+        SECTION("not called when schema version is unchanged even if there are schema changes") {
             Schema schema1 = {
                 {"object",
                  {
@@ -502,11 +481,12 @@ TEST_CASE("migration: Automatic")
                                                  }});
             auto realm = Realm::get_shared_realm(config);
             realm->update_schema(schema1, 1);
-            realm->update_schema(schema2, 1, [](SharedRealm, SharedRealm, Schema&) { REQUIRE(false); });
+            realm->update_schema(schema2, 1, [](SharedRealm, SharedRealm, Schema&) {
+                REQUIRE(false);
+            });
         }
 
-        SECTION("called when schema version is bumped even if there are no schema changes")
-        {
+        SECTION("called when schema version is bumped even if there are no schema changes") {
             Schema schema = {
                 {"object",
                  {
@@ -516,23 +496,22 @@ TEST_CASE("migration: Automatic")
             auto realm = Realm::get_shared_realm(config);
             realm->update_schema(schema);
             bool called = false;
-            realm->update_schema(schema, 5, [&](SharedRealm, SharedRealm, Schema&) { called = true; });
+            realm->update_schema(schema, 5, [&](SharedRealm, SharedRealm, Schema&) {
+                called = true;
+            });
             REQUIRE(called);
         }
     }
 
-    SECTION("migration errors")
-    {
-        SECTION("schema version cannot go down")
-        {
+    SECTION("migration errors") {
+        SECTION("schema version cannot go down") {
             auto realm = Realm::get_shared_realm(config);
             realm->update_schema({}, 1);
             realm->update_schema({}, 2);
             REQUIRE_THROWS(realm->update_schema({}, 0));
         }
 
-        SECTION("insert duplicate keys for existing PK during migration")
-        {
+        SECTION("insert duplicate keys for existing PK during migration") {
             Schema schema = {
                 {"object",
                  {
@@ -548,8 +527,7 @@ TEST_CASE("migration: Automatic")
             }));
         }
 
-        SECTION("add pk to existing table with duplicate keys")
-        {
+        SECTION("add pk to existing table with duplicate keys") {
             Schema schema = {
                 {"object",
                  {
@@ -568,8 +546,7 @@ TEST_CASE("migration: Automatic")
             REQUIRE_THROWS(realm->update_schema(schema, 2, nullptr));
         }
 
-        SECTION("throwing an exception from migration function rolls back all changes")
-        {
+        SECTION("throwing an exception from migration function rolls back all changes") {
             Schema schema1 = {
                 {"object",
                  {
@@ -592,8 +569,7 @@ TEST_CASE("migration: Automatic")
             REQUIRE(realm->schema() == schema1);
         }
 
-        SECTION("make object with multiple pre-existing incoming links embedded")
-        {
+        SECTION("make object with multiple pre-existing incoming links embedded") {
             Schema schema = {
                 {"target",
                  {
@@ -619,10 +595,8 @@ TEST_CASE("migration: Automatic")
         }
     }
 
-    SECTION("valid migrations")
-    {
-        SECTION("changing all columns does not lose row count")
-        {
+    SECTION("valid migrations") {
+        SECTION("changing all columns does not lose row count") {
             Schema schema = {
                 {"object",
                  {
@@ -642,8 +616,7 @@ TEST_CASE("migration: Automatic")
             REQUIRE(table->size() == 10);
         }
 
-        SECTION("values for required properties are copied when converitng to nullable")
-        {
+        SECTION("values for required properties are copied when converitng to nullable") {
             Schema schema = {
                 {"object",
                  {
@@ -667,8 +640,7 @@ TEST_CASE("migration: Automatic")
                 REQUIRE(table->get_object(i).get<util::Optional<int64_t>>(key) == i);
         }
 
-        SECTION("values for nullable properties are discarded when converting to required")
-        {
+        SECTION("values for nullable properties are discarded when converting to required") {
             Schema schema = {
                 {"object",
                  {
@@ -692,8 +664,7 @@ TEST_CASE("migration: Automatic")
                 REQUIRE(table->get_object(i).get<int64_t>(key) == 0);
         }
 
-        SECTION("deleting table removed from the schema deletes it")
-        {
+        SECTION("deleting table removed from the schema deletes it") {
             Schema schema = {
                 {"object",
                  {
@@ -709,8 +680,7 @@ TEST_CASE("migration: Automatic")
             REQUIRE_FALSE(ObjectStore::table_for_object_type(realm->read_group(), "object"));
         }
 
-        SECTION("deleting table still in the schema recreates it with no rows")
-        {
+        SECTION("deleting table still in the schema recreates it with no rows") {
             Schema schema = {
                 {"object",
                  {
@@ -732,8 +702,7 @@ TEST_CASE("migration: Automatic")
             REQUIRE(table->size() == 0);
         }
 
-        SECTION("deleting table which doesn't exist does nothing")
-        {
+        SECTION("deleting table which doesn't exist does nothing") {
             Schema schema = {
                 {"object",
                  {
@@ -749,8 +718,7 @@ TEST_CASE("migration: Automatic")
         }
     }
 
-    SECTION("schema correctness during migration")
-    {
+    SECTION("schema correctness during migration") {
         InMemoryTestFile config;
         config.schema_mode = SchemaMode::Automatic;
         auto realm = Realm::get_shared_realm(config);
@@ -793,87 +761,69 @@ TEST_CASE("migration: Automatic")
         VERIFY_SCHEMA(*realm, false);                                                                                \
     } while (false)
 
-        SECTION("add new table")
-        {
+        SECTION("add new table") {
             VERIFY_SCHEMA_IN_MIGRATION(add_table(schema, {"new table",
                                                           {
                                                               {"value", PropertyType::Int},
                                                           }}));
         }
-        SECTION("add embedded table")
-        {
+        SECTION("add embedded table") {
             VERIFY_SCHEMA_IN_MIGRATION(add_table(schema, {"new table",
                                                           IsEmbedded{true},
                                                           {
                                                               {"value", PropertyType::Int},
                                                           }}));
         }
-        SECTION("change table type")
-        {
+        SECTION("change table type") {
             VERIFY_SCHEMA_IN_MIGRATION(set_embedded(schema, "no pk object", true));
         }
-        SECTION("add property to table")
-        {
+        SECTION("add property to table") {
             VERIFY_SCHEMA_IN_MIGRATION(add_property(schema, "object", {"new", PropertyType::Int}));
         }
-        SECTION("remove property from table")
-        {
+        SECTION("remove property from table") {
             VERIFY_SCHEMA_IN_MIGRATION(remove_property(schema, "object", "value"));
         }
-        SECTION("remove multiple properties from table")
-        {
+        SECTION("remove multiple properties from table") {
             VERIFY_SCHEMA_IN_MIGRATION(
                 remove_property(remove_property(schema, "object", "value"), "object", "optional"));
         }
-        SECTION("add primary key to table")
-        {
+        SECTION("add primary key to table") {
             VERIFY_SCHEMA_IN_MIGRATION(set_primary_key(schema, "link origin", "not a pk"));
         }
-        SECTION("remove primary key from table")
-        {
+        SECTION("remove primary key from table") {
             VERIFY_SCHEMA_IN_MIGRATION(set_primary_key(schema, "object", ""));
         }
-        SECTION("change primary key")
-        {
+        SECTION("change primary key") {
             VERIFY_SCHEMA_IN_MIGRATION(set_primary_key(schema, "object", "value"));
         }
-        SECTION("change property type")
-        {
+        SECTION("change property type") {
             VERIFY_SCHEMA_IN_MIGRATION(set_type(schema, "object", "value", PropertyType::Date));
         }
-        SECTION("change link target")
-        {
+        SECTION("change link target") {
             VERIFY_SCHEMA_IN_MIGRATION(set_target(schema, "link origin", "object", "link origin"));
         }
-        SECTION("change linklist target")
-        {
+        SECTION("change linklist target") {
             VERIFY_SCHEMA_IN_MIGRATION(set_target(schema, "link origin", "array", "link origin"));
         }
-        SECTION("make property optional")
-        {
+        SECTION("make property optional") {
             VERIFY_SCHEMA_IN_MIGRATION(set_optional(schema, "object", "value", true));
         }
-        SECTION("make property required")
-        {
+        SECTION("make property required") {
             VERIFY_SCHEMA_IN_MIGRATION(set_optional(schema, "object", "optional", false));
         }
-        SECTION("add index")
-        {
+        SECTION("add index") {
             VERIFY_SCHEMA_IN_MIGRATION(set_indexed(schema, "object", "optional", true));
         }
-        SECTION("remove index")
-        {
+        SECTION("remove index") {
             VERIFY_SCHEMA_IN_MIGRATION(set_indexed(schema, "object", "value", false));
         }
-        SECTION("reorder properties")
-        {
+        SECTION("reorder properties") {
             auto schema2 = schema;
             auto& properties = schema2.find("object")->persisted_properties;
             std::swap(properties[0], properties[1]);
             VERIFY_SCHEMA_IN_MIGRATION(schema2);
         }
-        SECTION("change linklist to set")
-        {
+        SECTION("change linklist to set") {
             auto schema2 = schema;
             auto prop = schema2.find("link origin")->property_for_name("array");
             prop->type = PropertyType::Set | PropertyType::Object;
@@ -881,8 +831,7 @@ TEST_CASE("migration: Automatic")
         }
     }
 
-    SECTION("change nullability and primary key")
-    {
+    SECTION("change nullability and primary key") {
         using namespace std::string_literals;
         Schema schema{{"EmpDetails",
                        {
@@ -923,8 +872,7 @@ TEST_CASE("migration: Automatic")
         });
     }
 
-    SECTION("object accessors inside migrations")
-    {
+    SECTION("object accessors inside migrations") {
         using namespace std::string_literals;
 
         Schema schema{
@@ -990,8 +938,7 @@ TEST_CASE("migration: Automatic")
         Object::create(ctx, realm, *realm->schema().find("all types"), values);
         realm->commit_transaction();
 
-        SECTION("read values from old realm")
-        {
+        SECTION("read values from old realm") {
             Schema schema{
                 {"all types",
                  {
@@ -1034,8 +981,7 @@ TEST_CASE("migration: Automatic")
             });
         }
 
-        SECTION("cannot mutate old realm")
-        {
+        SECTION("cannot mutate old realm") {
             realm->update_schema(schema, 2, [](auto old_realm, auto, Schema&) {
                 CppContext ctx(old_realm);
                 Object obj = Object::get_for_primary_key(ctx, old_realm, "all types", util::Any(INT64_C(1)));
@@ -1045,8 +991,7 @@ TEST_CASE("migration: Automatic")
             });
         }
 
-        SECTION("cannot read values for removed properties from new realm")
-        {
+        SECTION("cannot read values for removed properties from new realm") {
             Schema schema{
                 {"all types",
                  {
@@ -1063,8 +1008,7 @@ TEST_CASE("migration: Automatic")
             });
         }
 
-        SECTION("read values from new object")
-        {
+        SECTION("read values from new object") {
             realm->update_schema(schema, 2, [](auto, auto new_realm, Schema&) {
                 CppContext ctx(new_realm);
                 Object obj = Object::get_for_primary_key(ctx, new_realm, "all types", util::Any(INT64_C(1)));
@@ -1085,8 +1029,7 @@ TEST_CASE("migration: Automatic")
             });
         }
 
-        SECTION("read and write values in new object")
-        {
+        SECTION("read and write values in new object") {
             realm->update_schema(schema, 2, [](auto, auto new_realm, Schema&) {
                 CppContext ctx(new_realm);
                 Object obj = Object::get_for_primary_key(ctx, new_realm, "all types", util::Any(INT64_C(1)));
@@ -1148,8 +1091,7 @@ TEST_CASE("migration: Automatic")
             });
         }
 
-        SECTION("create object in new realm")
-        {
+        SECTION("create object in new realm") {
             realm->update_schema(schema, 2, [&values](auto, auto new_realm, Schema&) {
                 REQUIRE(new_realm->is_in_transaction());
 
@@ -1164,8 +1106,7 @@ TEST_CASE("migration: Automatic")
             });
         }
 
-        SECTION("upsert in new realm")
-        {
+        SECTION("upsert in new realm") {
             realm->update_schema(schema, 2, [&values](auto, auto new_realm, Schema&) {
                 REQUIRE(new_realm->is_in_transaction());
                 CppContext ctx(new_realm);
@@ -1178,8 +1119,7 @@ TEST_CASE("migration: Automatic")
             });
         }
 
-        SECTION("upsert in new realm after modifying primary key")
-        {
+        SECTION("upsert in new realm after modifying primary key") {
             realm->update_schema(schema, 2, [&values](auto, auto new_realm, Schema&) {
                 get_table(new_realm, "all types")->set_primary_key_column(ColKey());
                 REQUIRE(new_realm->is_in_transaction());
@@ -1193,8 +1133,7 @@ TEST_CASE("migration: Automatic")
             });
         }
 
-        SECTION("change primary key property type")
-        {
+        SECTION("change primary key property type") {
             schema = set_type(schema, "all types", "pk", PropertyType::String);
             realm->update_schema(schema, 2, [](auto, auto new_realm, auto&) {
                 Object obj(new_realm, "all types", 0);
@@ -1204,8 +1143,7 @@ TEST_CASE("migration: Automatic")
             });
         }
 
-        SECTION("set primary key to duplicate values in migration")
-        {
+        SECTION("set primary key to duplicate values in migration") {
             auto bad_migration = [&](auto, auto new_realm, Schema&) {
                 // shoud not be able to create a new object with the same PK
                 Object::create(ctx, new_realm, "all types", values);
@@ -1225,8 +1163,7 @@ TEST_CASE("migration: Automatic")
             REQUIRE(get_table(realm, "all types")->size() == 2);
         }
 
-        SECTION("modify existing int primary key values in migration")
-        {
+        SECTION("modify existing int primary key values in migration") {
             // Create several more objects to increase the chance of things
             // actually breaking if we're doing invalid things
             CppContext ctx(realm);
@@ -1269,8 +1206,7 @@ TEST_CASE("migration: Automatic")
             }
         }
 
-        SECTION("modify existing string primary key values in migration")
-        {
+        SECTION("modify existing string primary key values in migration") {
             // Create several objects to increase the chance of things
             // actually breaking if we're doing invalid things
             CppContext ctx(realm);
@@ -1315,16 +1251,15 @@ TEST_CASE("migration: Automatic")
             }
         }
 
-        SECTION("create and modify int primary key inside migration")
-        {
-            SECTION("with index")
-            {
+        SECTION("create and modify int primary key inside migration") {
+            SECTION("with index") {
                 realm->begin_transaction();
                 auto table = get_table(realm, "int pk");
                 table->add_search_index(table->get_column_key("pk"));
                 realm->commit_transaction();
             }
-            SECTION("no index") {}
+            SECTION("no index") {
+            }
 
             realm->update_schema(schema, 2, [](auto, auto new_realm, Schema&) {
                 CppContext ctx(new_realm);
@@ -1345,16 +1280,15 @@ TEST_CASE("migration: Automatic")
             }
         }
 
-        SECTION("create and modify string primary key inside migration")
-        {
-            SECTION("with index")
-            {
+        SECTION("create and modify string primary key inside migration") {
+            SECTION("with index") {
                 realm->begin_transaction();
                 auto table = get_table(realm, "string pk");
                 table->add_search_index(table->get_column_key("pk"));
                 realm->commit_transaction();
             }
-            SECTION("no index") {}
+            SECTION("no index") {
+            }
 
             realm->update_schema(schema, 2, [](auto, auto new_realm, Schema&) {
                 CppContext ctx(new_realm);
@@ -1372,8 +1306,7 @@ TEST_CASE("migration: Automatic")
                 REQUIRE(obj.get<StringData>("pk") == util::to_string(obj.get<int64_t>("value")).c_str());
         }
 
-        SECTION("create object after adding primary key")
-        {
+        SECTION("create object after adding primary key") {
             schema = set_primary_key(schema, "all types", "");
             realm->update_schema(schema, 2);
             schema = set_primary_key(schema, "all types", "pk");
@@ -1385,8 +1318,7 @@ TEST_CASE("migration: Automatic")
         }
     }
 
-    SECTION("property renaming")
-    {
+    SECTION("property renaming") {
         InMemoryTestFile config;
         config.schema_mode = SchemaMode::Automatic;
         auto realm = Realm::get_shared_realm(config);
@@ -1419,8 +1351,7 @@ TEST_CASE("migration: Automatic")
              }},
         };
 
-        SECTION("table does not exist in old schema")
-        {
+        SECTION("table does not exist in old schema") {
             auto schema2 = add_table(schema, {"object 2",
                                               {
                                                   {"value 2", PropertyType::Int},
@@ -1429,15 +1360,13 @@ TEST_CASE("migration: Automatic")
                           {"object 2", "value", "value 2"});
         }
 
-        SECTION("table does not exist in new schema")
-        {
+        SECTION("table does not exist in new schema") {
             FAILED_RENAME(schema, {},
                           "Cannot rename properties for type 'object' because it has been removed from the Realm.",
                           {"object", "value", "value 2"});
         }
 
-        SECTION("property does not exist in old schema")
-        {
+        SECTION("property does not exist in old schema") {
             auto schema2 = add_property(schema, "object", {"new", PropertyType::Int});
             FAILED_RENAME(schema, schema2, "Cannot rename property 'object.nonexistent' because it does not exist.",
                           {"object", "nonexistent", "new"});
@@ -1448,22 +1377,19 @@ TEST_CASE("migration: Automatic")
             return schema;
         };
 
-        SECTION("property does not exist in new schema")
-        {
+        SECTION("property does not exist in new schema") {
             FAILED_RENAME(schema, rename_value(schema), "Renamed property 'object.nonexistent' does not exist.",
                           {"object", "value", "nonexistent"});
         }
 
-        SECTION("source propety still exists in the new schema")
-        {
+        SECTION("source propety still exists in the new schema") {
             auto schema2 = add_property(schema, "object", {"new", PropertyType::Int});
             FAILED_RENAME(schema, schema2,
                           "Cannot rename property 'object.value' to 'new' because the source property still exists.",
                           {"object", "value", "new"});
         }
 
-        SECTION("different type")
-        {
+        SECTION("different type") {
             auto schema2 = rename_value(set_type(schema, "object", "value", PropertyType::Date));
             FAILED_RENAME(
                 schema, schema2,
@@ -1471,8 +1397,7 @@ TEST_CASE("migration: Automatic")
                 {"object", "value", "new"});
         }
 
-        SECTION("different link targets")
-        {
+        SECTION("different link targets") {
             Schema schema = {
                 {"target",
                  {
@@ -1491,8 +1416,7 @@ TEST_CASE("migration: Automatic")
                           {"origin", "link", "new"});
         }
 
-        SECTION("different linklist targets")
-        {
+        SECTION("different linklist targets") {
             Schema schema = {
                 {"target",
                  {
@@ -1511,8 +1435,7 @@ TEST_CASE("migration: Automatic")
                           {"origin", "link", "new"});
         }
 
-        SECTION("different object set targets")
-        {
+        SECTION("different object set targets") {
             Schema schema = {
                 {"target",
                  {
@@ -1531,8 +1454,7 @@ TEST_CASE("migration: Automatic")
                           {"origin", "link", "new"});
         }
 
-        SECTION("make required")
-        {
+        SECTION("make required") {
             schema = set_optional(schema, "object", "value", true);
             auto schema2 = rename_value(set_optional(schema, "object", "value", false));
             FAILED_RENAME(
@@ -1568,60 +1490,51 @@ TEST_CASE("migration: Automatic")
             REQUIRE(table->begin()->get<int64_t>(key) == 10);                                                        \
     } while (false)
 
-        SECTION("basic valid rename")
-        {
+        SECTION("basic valid rename") {
             auto schema2 = rename_value(schema);
             SUCCESSFUL_RENAME(schema, schema2, {"object", "value", "new"});
         }
 
-        SECTION("chained rename")
-        {
+        SECTION("chained rename") {
             auto schema2 = rename_value(schema);
             SUCCESSFUL_RENAME(schema, schema2, {"object", "value", "a"}, {"object", "a", "b"},
                               {"object", "b", "new"});
         }
 
-        SECTION("old is pk, new is not")
-        {
+        SECTION("old is pk, new is not") {
             auto schema2 = rename_value(schema);
             schema = set_primary_key(schema, "object", "value");
             SUCCESSFUL_RENAME(schema, schema2, {"object", "value", "new"});
         }
 
-        SECTION("new is pk, old is not")
-        {
+        SECTION("new is pk, old is not") {
             auto schema2 = set_primary_key(rename_value(schema), "object", "new");
             SUCCESSFUL_RENAME(schema, schema2, {"object", "value", "new"});
         }
 
-        SECTION("both are pk")
-        {
+        SECTION("both are pk") {
             schema = set_primary_key(schema, "object", "value");
             auto schema2 = set_primary_key(rename_value(schema), "object", "new");
             SUCCESSFUL_RENAME(schema, schema2, {"object", "value", "new"});
         }
 
-        SECTION("make optional")
-        {
+        SECTION("make optional") {
             auto schema2 = rename_value(set_optional(schema, "object", "value", true));
             SUCCESSFUL_RENAME(schema, schema2, {"object", "value", "new"});
         }
 
-        SECTION("add index")
-        {
+        SECTION("add index") {
             auto schema2 = rename_value(set_indexed(schema, "object", "value", true));
             SUCCESSFUL_RENAME(schema, schema2, {"object", "value", "new"});
         }
 
-        SECTION("remove index")
-        {
+        SECTION("remove index") {
             auto schema2 = rename_value(schema);
             schema = set_indexed(schema, "object", "value", true);
             SUCCESSFUL_RENAME(schema, schema2, {"object", "value", "new"});
         }
 
-        SECTION("create object inside migration after renaming pk")
-        {
+        SECTION("create object inside migration after renaming pk") {
             schema = set_primary_key(schema, "object", "value");
             auto new_schema = set_primary_key(rename_value(schema), "object", "new");
             init(schema);
@@ -1643,8 +1556,7 @@ TEST_CASE("migration: Automatic")
     }
 }
 
-TEST_CASE("migration: Immutable")
-{
+TEST_CASE("migration: Immutable") {
     TestFile config;
 
     auto realm_with_schema = [&](Schema schema) {
@@ -1656,10 +1568,8 @@ TEST_CASE("migration: Immutable")
         return Realm::get_shared_realm(config);
     };
 
-    SECTION("allowed schema mismatches")
-    {
-        SECTION("index")
-        {
+    SECTION("allowed schema mismatches") {
+        SECTION("index") {
             auto realm = realm_with_schema({
                 {"object",
                  {
@@ -1678,8 +1588,7 @@ TEST_CASE("migration: Immutable")
             REQUIRE(realm->schema() == schema);
         }
 
-        SECTION("extra tables")
-        {
+        SECTION("extra tables") {
             auto realm = realm_with_schema({
                 {"object",
                  {
@@ -1699,8 +1608,7 @@ TEST_CASE("migration: Immutable")
             REQUIRE_NOTHROW(realm->update_schema(schema));
         }
 
-        SECTION("missing tables")
-        {
+        SECTION("missing tables") {
             auto realm = realm_with_schema({
                 {"object",
                  {
@@ -1729,8 +1637,7 @@ TEST_CASE("migration: Immutable")
             REQUIRE(!object_schema->persisted_properties[0].column_key);
         }
 
-        SECTION("extra columns in table")
-        {
+        SECTION("extra columns in table") {
             auto realm = realm_with_schema({
                 {"object",
                  {
@@ -1747,8 +1654,7 @@ TEST_CASE("migration: Immutable")
             REQUIRE_NOTHROW(realm->update_schema(schema));
         }
 
-        SECTION("differing embeddedness")
-        {
+        SECTION("differing embeddedness") {
             auto realm = realm_with_schema({
                 {"object",
                  {
@@ -1760,10 +1666,8 @@ TEST_CASE("migration: Immutable")
         }
     }
 
-    SECTION("disallowed mismatches")
-    {
-        SECTION("missing columns in table")
-        {
+    SECTION("disallowed mismatches") {
+        SECTION("missing columns in table") {
             auto realm = realm_with_schema({
                 {"object",
                  {
@@ -1780,8 +1684,7 @@ TEST_CASE("migration: Immutable")
             REQUIRE_THROWS(realm->update_schema(schema));
         }
 
-        SECTION("bump schema version")
-        {
+        SECTION("bump schema version") {
             Schema schema = {
                 {"object",
                  {
@@ -1794,8 +1697,7 @@ TEST_CASE("migration: Immutable")
     }
 }
 
-TEST_CASE("migration: ReadOnly")
-{
+TEST_CASE("migration: ReadOnly") {
     TestFile config;
 
     auto realm_with_schema = [&](Schema schema) {
@@ -1807,10 +1709,8 @@ TEST_CASE("migration: ReadOnly")
         return Realm::get_shared_realm(config);
     };
 
-    SECTION("allowed schema mismatches")
-    {
-        SECTION("index")
-        {
+    SECTION("allowed schema mismatches") {
+        SECTION("index") {
             auto realm = realm_with_schema({
                 {"object",
                  {
@@ -1829,8 +1729,7 @@ TEST_CASE("migration: ReadOnly")
             REQUIRE(realm->schema() == schema);
         }
 
-        SECTION("extra tables")
-        {
+        SECTION("extra tables") {
             auto realm = realm_with_schema({
                 {"object",
                  {
@@ -1850,8 +1749,7 @@ TEST_CASE("migration: ReadOnly")
             REQUIRE_NOTHROW(realm->update_schema(schema));
         }
 
-        SECTION("extra columns in table")
-        {
+        SECTION("extra columns in table") {
             auto realm = realm_with_schema({
                 {"object",
                  {
@@ -1868,8 +1766,7 @@ TEST_CASE("migration: ReadOnly")
             REQUIRE_NOTHROW(realm->update_schema(schema));
         }
 
-        SECTION("missing tables")
-        {
+        SECTION("missing tables") {
             auto realm = realm_with_schema({
                 {"object",
                  {
@@ -1889,8 +1786,7 @@ TEST_CASE("migration: ReadOnly")
             REQUIRE_NOTHROW(realm->update_schema(schema));
         }
 
-        SECTION("bump schema version")
-        {
+        SECTION("bump schema version") {
             Schema schema = {
                 {"object",
                  {
@@ -1901,8 +1797,7 @@ TEST_CASE("migration: ReadOnly")
             REQUIRE_NOTHROW(realm->update_schema(schema, 1));
         }
 
-        SECTION("differing embeddedness")
-        {
+        SECTION("differing embeddedness") {
             Schema schema = {
                 {"object",
                  {
@@ -1914,11 +1809,9 @@ TEST_CASE("migration: ReadOnly")
         }
     }
 
-    SECTION("disallowed mismatches")
-    {
+    SECTION("disallowed mismatches") {
 
-        SECTION("missing columns in table")
-        {
+        SECTION("missing columns in table") {
             auto realm = realm_with_schema({
                 {"object",
                  {
@@ -1937,8 +1830,7 @@ TEST_CASE("migration: ReadOnly")
     }
 }
 
-TEST_CASE("migration: ResetFile")
-{
+TEST_CASE("migration: ResetFile") {
     TestFile config;
     config.schema_mode = SchemaMode::ResetFile;
 
@@ -1963,7 +1855,9 @@ TEST_CASE("migration: ResetFile")
         HANDLE handle =
             CreateFile2(ws.c_str(), GENERIC_READ, FILE_SHARE_READ | FILE_SHARE_WRITE, OPEN_EXISTING, nullptr);
         REQUIRE(handle != INVALID_HANDLE_VALUE);
-        auto close = util::make_scope_exit([=]() noexcept { CloseHandle(handle); });
+        auto close = util::make_scope_exit([=]() noexcept {
+            CloseHandle(handle);
+        });
 
         BY_HANDLE_FILE_INFORMATION info{};
         REQUIRE(GetFileInformationByHandle(handle, &info));
@@ -1990,22 +1884,19 @@ TEST_CASE("migration: ResetFile")
     auto realm = Realm::get_shared_realm(config);
     auto ino = get_fileid();
 
-    SECTION("file is reset when schema version increases")
-    {
+    SECTION("file is reset when schema version increases") {
         realm->update_schema(schema, 1);
         REQUIRE(ObjectStore::table_for_object_type(realm->read_group(), "object")->size() == 0);
         REQUIRE(ino != get_fileid());
     }
 
-    SECTION("file is reset when an existing table is modified")
-    {
+    SECTION("file is reset when an existing table is modified") {
         realm->update_schema(add_property(schema, "object", {"value 2", PropertyType::Int}));
         REQUIRE(ObjectStore::table_for_object_type(realm->read_group(), "object")->size() == 0);
         REQUIRE(ino != get_fileid());
     }
 
-    SECTION("file is not reset when adding a new table")
-    {
+    SECTION("file is not reset when adding a new table") {
         realm->update_schema(add_table(schema, {"object 3",
                                                 {
                                                     {"value", PropertyType::Int},
@@ -2015,8 +1906,7 @@ TEST_CASE("migration: ResetFile")
         REQUIRE(ino == get_fileid());
     }
 
-    SECTION("file is not reset when removing a table")
-    {
+    SECTION("file is not reset when removing a table") {
         realm->update_schema(remove_table(schema, "object 2"));
         REQUIRE(ObjectStore::table_for_object_type(realm->read_group(), "object")->size() == 1);
         REQUIRE(ObjectStore::table_for_object_type(realm->read_group(), "object 2"));
@@ -2024,15 +1914,13 @@ TEST_CASE("migration: ResetFile")
         REQUIRE(ino == get_fileid());
     }
 
-    SECTION("file is not reset when adding an index")
-    {
+    SECTION("file is not reset when adding an index") {
         realm->update_schema(set_indexed(schema, "object", "value", true));
         REQUIRE(ObjectStore::table_for_object_type(realm->read_group(), "object")->size() == 1);
         REQUIRE(ino == get_fileid());
     }
 
-    SECTION("file is not reset when removing an index")
-    {
+    SECTION("file is not reset when removing an index") {
         realm->update_schema(set_indexed(schema, "object", "value", true));
         realm->update_schema(schema);
         REQUIRE(ObjectStore::table_for_object_type(realm->read_group(), "object")->size() == 1);
@@ -2040,8 +1928,7 @@ TEST_CASE("migration: ResetFile")
     }
 }
 
-TEST_CASE("migration: Additive")
-{
+TEST_CASE("migration: Additive") {
     Schema schema = {
         {"object",
          {
@@ -2057,14 +1944,12 @@ TEST_CASE("migration: Additive")
     auto realm = Realm::get_shared_realm(config);
     realm->update_schema(schema);
 
-    SECTION("can add new properties to existing tables")
-    {
+    SECTION("can add new properties to existing tables") {
         REQUIRE_NOTHROW(realm->update_schema(add_property(schema, "object", {"value 3", PropertyType::Int})));
         REQUIRE(ObjectStore::table_for_object_type(realm->read_group(), "object")->get_column_count() == 3);
     }
 
-    SECTION("can add new tables")
-    {
+    SECTION("can add new tables") {
         REQUIRE_NOTHROW(realm->update_schema(add_table(schema, {"object 2",
                                                                 {
                                                                     {"value", PropertyType::Int},
@@ -2073,13 +1958,11 @@ TEST_CASE("migration: Additive")
         REQUIRE(ObjectStore::table_for_object_type(realm->read_group(), "object 2"));
     }
 
-    SECTION("cannot change existing table type")
-    {
+    SECTION("cannot change existing table type") {
         REQUIRE_THROWS(realm->update_schema(set_embedded(schema, "object", true)));
     }
 
-    SECTION("indexes are updated when schema version is bumped")
-    {
+    SECTION("indexes are updated when schema version is bumped") {
         auto table = ObjectStore::table_for_object_type(realm->read_group(), "object");
         auto col_keys = table->get_column_keys();
         REQUIRE(table->has_search_index(col_keys[0]));
@@ -2092,8 +1975,7 @@ TEST_CASE("migration: Additive")
         REQUIRE(table->has_search_index(col_keys[1]));
     }
 
-    SECTION("indexes are not updated when schema version is not bumped")
-    {
+    SECTION("indexes are not updated when schema version is not bumped") {
         auto table = ObjectStore::table_for_object_type(realm->read_group(), "object");
         auto col_keys = table->get_column_keys();
         REQUIRE(table->has_search_index(col_keys[0]));
@@ -2106,8 +1988,7 @@ TEST_CASE("migration: Additive")
         REQUIRE(!table->has_search_index(col_keys[1]));
     }
 
-    SECTION("can remove properties from existing tables, but column is not removed")
-    {
+    SECTION("can remove properties from existing tables, but column is not removed") {
         auto table = ObjectStore::table_for_object_type(realm->read_group(), "object");
         REQUIRE_NOTHROW(realm->update_schema(remove_property(schema, "object", "value")));
         REQUIRE(ObjectStore::table_for_object_type(realm->read_group(), "object")->get_column_count() == 2);
@@ -2118,19 +1999,16 @@ TEST_CASE("migration: Additive")
         REQUIRE(properties[0].column_key == col_keys[1]);
     }
 
-    SECTION("cannot change existing property types")
-    {
+    SECTION("cannot change existing property types") {
         REQUIRE_THROWS(realm->update_schema(set_type(schema, "object", "value", PropertyType::Float)));
     }
 
-    SECTION("cannot change existing property nullability")
-    {
+    SECTION("cannot change existing property nullability") {
         REQUIRE_THROWS(realm->update_schema(set_optional(schema, "object", "value", true)));
         REQUIRE_THROWS(realm->update_schema(set_optional(schema, "object", "value 2", false)));
     }
 
-    SECTION("cannot change existing link targets")
-    {
+    SECTION("cannot change existing link targets") {
         REQUIRE_NOTHROW(realm->update_schema(
             add_table(schema, {"object 2",
                                {
@@ -2139,8 +2017,7 @@ TEST_CASE("migration: Additive")
         REQUIRE_THROWS(realm->update_schema(set_target(realm->schema(), "object 2", "link", "object 2")));
     }
 
-    SECTION("cannot change primary keys")
-    {
+    SECTION("cannot change primary keys") {
         REQUIRE_THROWS(realm->update_schema(set_primary_key(schema, "object", "value")));
 
         REQUIRE_NOTHROW(
@@ -2152,21 +2029,20 @@ TEST_CASE("migration: Additive")
         REQUIRE_THROWS(realm->update_schema(set_primary_key(realm->schema(), "object 2", "")));
     }
 
-    SECTION("schema version is allowed to go down")
-    {
+    SECTION("schema version is allowed to go down") {
         REQUIRE_NOTHROW(realm->update_schema(schema, 1));
         REQUIRE(realm->schema_version() == 1);
         REQUIRE_NOTHROW(realm->update_schema(schema, 0));
         REQUIRE(realm->schema_version() == 1);
     }
 
-    SECTION("migration function is not used")
-    {
-        REQUIRE_NOTHROW(realm->update_schema(schema, 1, [&](SharedRealm, SharedRealm, Schema&) { REQUIRE(false); }));
+    SECTION("migration function is not used") {
+        REQUIRE_NOTHROW(realm->update_schema(schema, 1, [&](SharedRealm, SharedRealm, Schema&) {
+            REQUIRE(false);
+        }));
     }
 
-    SECTION("add new columns from different SG")
-    {
+    SECTION("add new columns from different SG") {
         auto realm2 = Realm::get_shared_realm(config);
         auto& group = realm2->read_group();
         realm2->begin_transaction();
@@ -2181,8 +2057,7 @@ TEST_CASE("migration: Additive")
         REQUIRE(realm->schema().find("object")->persisted_properties[1].column_key == col_keys[1]);
     }
 
-    SECTION("opening new Realms uses the correct schema after an external change")
-    {
+    SECTION("opening new Realms uses the correct schema after an external change") {
         auto realm2 = Realm::get_shared_realm(config);
         auto& group = realm2->read_group();
         realm2->begin_transaction();
@@ -2212,8 +2087,7 @@ TEST_CASE("migration: Additive")
         REQUIRE(realm->schema().find("object")->persisted_properties[1].column_key == col_keys[1]);
     }
 
-    SECTION("can have different subsets of columns in different Realm instances")
-    {
+    SECTION("can have different subsets of columns in different Realm instances") {
         auto config2 = config;
         config2.schema = add_property(schema, "object", {"value 3", PropertyType::Int});
         auto config3 = config;
@@ -2238,8 +2112,7 @@ TEST_CASE("migration: Additive")
         REQUIRE(realm4->schema().find("object")->persisted_properties.size() == 3);
     }
 
-    SECTION("updating a schema to include already-present column")
-    {
+    SECTION("updating a schema to include already-present column") {
         auto config2 = config;
         config2.schema = add_property(schema, "object", {"value 3", PropertyType::Int});
         auto realm2 = Realm::get_shared_realm(config2);
@@ -2253,8 +2126,7 @@ TEST_CASE("migration: Additive")
         REQUIRE(properties[2].column_key == properties2[2].column_key);
     }
 
-    SECTION("increasing schema version without modifying schema properly leaves the schema untouched")
-    {
+    SECTION("increasing schema version without modifying schema properly leaves the schema untouched") {
         TestFile config1;
         config1.schema = schema;
         config1.schema_mode = SchemaMode::Additive;
@@ -2271,8 +2143,7 @@ TEST_CASE("migration: Additive")
         REQUIRE(realm2->schema() == schema1);
     }
 
-    SECTION("invalid schema update leaves the schema untouched")
-    {
+    SECTION("invalid schema update leaves the schema untouched") {
         auto config2 = config;
         config2.schema = add_property(schema, "object", {"value 3", PropertyType::Int});
         auto realm2 = Realm::get_shared_realm(config2);
@@ -2281,8 +2152,7 @@ TEST_CASE("migration: Additive")
         REQUIRE(realm->schema().find("object")->persisted_properties.size() == 2);
     }
 
-    SECTION("update_schema() does not begin a write transaction when extra columns are present")
-    {
+    SECTION("update_schema() does not begin a write transaction when extra columns are present") {
         realm->begin_transaction();
 
         auto realm2 = Realm::get_shared_realm(config);
@@ -2290,9 +2160,8 @@ TEST_CASE("migration: Additive")
         realm2->update_schema(remove_property(schema, "object", "value"));
     }
 
-    SECTION(
-        "update_schema() does not begin a write transaction when indexes are changed without bumping schema version")
-    {
+    SECTION("update_schema() does not begin a write transaction when indexes are changed without bumping schema "
+            "version") {
         realm->begin_transaction();
 
         auto realm2 = Realm::get_shared_realm(config);
@@ -2300,8 +2169,7 @@ TEST_CASE("migration: Additive")
         realm->update_schema(set_indexed(schema, "object", "value 2", true));
     }
 
-    SECTION("update_schema() does not begin a write transaction for invalid schema changes")
-    {
+    SECTION("update_schema() does not begin a write transaction for invalid schema changes") {
         realm->begin_transaction();
 
         auto realm2 = Realm::get_shared_realm(config);
@@ -2312,8 +2180,7 @@ TEST_CASE("migration: Additive")
     }
 }
 
-TEST_CASE("migration: Manual")
-{
+TEST_CASE("migration: Manual") {
     TestFile config;
     config.schema_mode = SchemaMode::Manual;
     auto realm = Realm::get_shared_realm(config);
@@ -2344,8 +2211,7 @@ TEST_CASE("migration: Manual")
         REQUIRE(realm->schema_version() == 1);                                                                       \
     } while (false)
 
-    SECTION("add new table")
-    {
+    SECTION("add new table") {
         REQUIRE_MIGRATION(add_table(schema, {"new table",
                                              {
                                                  {"value", PropertyType::Int},
@@ -2354,21 +2220,18 @@ TEST_CASE("migration: Manual")
                               realm->read_group().add_table("class_new table")->add_column(type_Int, "value");
                           });
     }
-    SECTION("add property to table")
-    {
+    SECTION("add property to table") {
         REQUIRE_MIGRATION(add_property(schema, "object", {"new", PropertyType::Int}),
                           [&](SharedRealm, SharedRealm realm, Schema&) {
                               get_table(realm, "object")->add_column(type_Int, "new");
                           });
     }
-    SECTION("remove property from table")
-    {
+    SECTION("remove property from table") {
         REQUIRE_MIGRATION(remove_property(schema, "object", "value"), [&](SharedRealm, SharedRealm realm, Schema&) {
             get_table(realm, "object")->remove_column(col_keys[1]);
         });
     }
-    SECTION("add primary key to table")
-    {
+    SECTION("add primary key to table") {
         REQUIRE_MIGRATION(set_primary_key(schema, "link origin", "not a pk"),
                           [&](SharedRealm, SharedRealm realm, Schema&) {
                               ObjectStore::set_primary_key_for_object(realm->read_group(), "link origin", "not a pk");
@@ -2376,15 +2239,13 @@ TEST_CASE("migration: Manual")
                               table->add_search_index(table->get_column_key("not a pk"));
                           });
     }
-    SECTION("remove primary key from table")
-    {
+    SECTION("remove primary key from table") {
         REQUIRE_MIGRATION(set_primary_key(schema, "object", ""), [&](SharedRealm, SharedRealm realm, Schema&) {
             ObjectStore::set_primary_key_for_object(realm->read_group(), "object", "");
             get_table(realm, "object")->remove_search_index(col_keys[0]);
         });
     }
-    SECTION("change primary key")
-    {
+    SECTION("change primary key") {
         REQUIRE_MIGRATION(set_primary_key(schema, "object", "value"), [&](SharedRealm, SharedRealm realm, Schema&) {
             ObjectStore::set_primary_key_for_object(realm->read_group(), "object", "value");
             auto table = get_table(realm, "object");
@@ -2392,8 +2253,7 @@ TEST_CASE("migration: Manual")
             table->add_search_index(col_keys[1]);
         });
     }
-    SECTION("change property type")
-    {
+    SECTION("change property type") {
         REQUIRE_MIGRATION(set_type(schema, "object", "value", PropertyType::Date),
                           [&](SharedRealm, SharedRealm realm, Schema&) {
                               auto table = get_table(realm, "object");
@@ -2402,8 +2262,7 @@ TEST_CASE("migration: Manual")
                               table->add_search_index(col);
                           });
     }
-    SECTION("change link target")
-    {
+    SECTION("change link target") {
         REQUIRE_MIGRATION(set_target(schema, "link origin", "object", "link origin"),
                           [&](SharedRealm, SharedRealm realm, Schema&) {
                               auto table = get_table(realm, "link origin");
@@ -2411,8 +2270,7 @@ TEST_CASE("migration: Manual")
                               table->add_column(*table, "object");
                           });
     }
-    SECTION("change linklist target")
-    {
+    SECTION("change linklist target") {
         REQUIRE_MIGRATION(set_target(schema, "link origin", "array", "link origin"),
                           [&](SharedRealm, SharedRealm realm, Schema&) {
                               auto table = get_table(realm, "link origin");
@@ -2420,8 +2278,7 @@ TEST_CASE("migration: Manual")
                               table->add_column_list(*table, "array");
                           });
     }
-    SECTION("make property optional")
-    {
+    SECTION("make property optional") {
         REQUIRE_MIGRATION(set_optional(schema, "object", "value", true),
                           [&](SharedRealm, SharedRealm realm, Schema&) {
                               auto table = get_table(realm, "object");
@@ -2430,8 +2287,7 @@ TEST_CASE("migration: Manual")
                               table->add_search_index(col);
                           });
     }
-    SECTION("make property required")
-    {
+    SECTION("make property required") {
         REQUIRE_MIGRATION(set_optional(schema, "object", "optional", false),
                           [&](SharedRealm, SharedRealm realm, Schema&) {
                               auto table = get_table(realm, "object");
@@ -2439,38 +2295,33 @@ TEST_CASE("migration: Manual")
                               table->add_column(type_Int, "optional", false);
                           });
     }
-    SECTION("add index")
-    {
+    SECTION("add index") {
         REQUIRE_MIGRATION(set_indexed(schema, "object", "optional", true),
                           [&](SharedRealm, SharedRealm realm, Schema&) {
                               get_table(realm, "object")->add_search_index(col_keys[2]);
                           });
     }
-    SECTION("remove index")
-    {
+    SECTION("remove index") {
         REQUIRE_MIGRATION(set_indexed(schema, "object", "value", false),
                           [&](SharedRealm, SharedRealm realm, Schema&) {
                               get_table(realm, "object")->remove_search_index(col_keys[1]);
                           });
     }
-    SECTION("reorder properties")
-    {
+    SECTION("reorder properties") {
         auto schema2 = schema;
         auto& properties = schema2.find("object")->persisted_properties;
         std::swap(properties[0], properties[1]);
         REQUIRE_NOTHROW(realm->update_schema(schema2));
     }
 
-    SECTION("cannot lower schema version")
-    {
+    SECTION("cannot lower schema version") {
         REQUIRE_NOTHROW(realm->update_schema(schema, 1, [](SharedRealm, SharedRealm, Schema&) {}));
         REQUIRE(realm->schema_version() == 1);
         REQUIRE_THROWS(realm->update_schema(schema, 0, [](SharedRealm, SharedRealm, Schema&) {}));
         REQUIRE(realm->schema_version() == 1);
     }
 
-    SECTION("update_schema() does not begin a write transaction when schema version is unchanged")
-    {
+    SECTION("update_schema() does not begin a write transaction when schema version is unchanged") {
         realm->begin_transaction();
 
         auto realm2 = Realm::get_shared_realm(config);
@@ -2479,8 +2330,7 @@ TEST_CASE("migration: Manual")
         REQUIRE_THROWS(realm2->update_schema(remove_property(schema, "object", "value")));
     }
 
-    SECTION("null migration callback should throw SchemaMismatchException")
-    {
+    SECTION("null migration callback should throw SchemaMismatchException") {
         Schema new_schema = remove_property(schema, "object", "value");
         REQUIRE_THROWS_AS(realm->update_schema(new_schema, 1, nullptr), SchemaMismatchException);
     }

--- a/test/object-store/notifications-fuzzer/command_file.cpp
+++ b/test/object-store/notifications-fuzzer/command_file.cpp
@@ -46,7 +46,9 @@ static T read_value(std::istream& input)
 template <typename... Args>
 static auto make_reader(void (*fn)(RealmState&, Args...))
 {
-    return [=](std::istream& input) { return std::bind(fn, std::placeholders::_1, read_value<Args>(input)...); };
+    return [=](std::istream& input) {
+        return std::bind(fn, std::placeholders::_1, read_value<Args>(input)...);
+    };
 }
 
 static void run_add(RealmState& state, int64_t value)

--- a/test/object-store/object.cpp
+++ b/test/object-store/object.cpp
@@ -82,8 +82,7 @@ struct TestContext : CppContext {
     }
 };
 
-TEST_CASE("object")
-{
+TEST_CASE("object") {
     using namespace std::string_literals;
     _impl::RealmCoordinator::assert_no_open_realms();
 
@@ -199,8 +198,7 @@ TEST_CASE("object")
     auto r = Realm::get_shared_realm(config);
     auto& coordinator = *_impl::RealmCoordinator::get_coordinator(config.path);
 
-    SECTION("add_notification_callback()")
-    {
+    SECTION("add_notification_callback()") {
         auto table = r->read_group().get_table("class_table");
         auto col_keys = table->get_column_keys();
         std::vector<int64_t> pks = {3, 4, 7, 9, 10, 21, 24, 34, 42, 50};
@@ -224,8 +222,9 @@ TEST_CASE("object")
         };
 
         auto require_change = [&] {
-            auto token =
-                object.add_notification_callback([&](CollectionChangeSet c, std::exception_ptr) { change = c; });
+            auto token = object.add_notification_callback([&](CollectionChangeSet c, std::exception_ptr) {
+                change = c;
+            });
             advance_and_notify(*r);
             return token;
         };
@@ -240,53 +239,59 @@ TEST_CASE("object")
             return token;
         };
 
-        SECTION("deleting the object sends a change notification")
-        {
+        SECTION("deleting the object sends a change notification") {
             auto token = require_change();
-            write([&] { obj.remove(); });
+            write([&] {
+                obj.remove();
+            });
             REQUIRE_INDICES(change.deletions, 0);
         }
 
-        SECTION("clearing the table sends a change notification")
-        {
+        SECTION("clearing the table sends a change notification") {
             auto token = require_change();
-            write([&] { table->clear(); });
+            write([&] {
+                table->clear();
+            });
             REQUIRE_INDICES(change.deletions, 0);
         }
 
-        SECTION("clearing the table sends a change notification to the last object")
-        {
+        SECTION("clearing the table sends a change notification to the last object") {
             obj = table->get_object(table->size() - 1);
             object = Object(r, obj);
 
             auto token = require_change();
-            write([&] { table->clear(); });
+            write([&] {
+                table->clear();
+            });
             REQUIRE_INDICES(change.deletions, 0);
         }
 
-        SECTION("modifying the object sends a change notification")
-        {
+        SECTION("modifying the object sends a change notification") {
             auto token = require_change();
 
-            write([&] { obj.set(col_keys[0], 10); });
+            write([&] {
+                obj.set(col_keys[0], 10);
+            });
             REQUIRE_INDICES(change.modifications, 0);
             REQUIRE(change.columns.size() == 1);
             REQUIRE_INDICES(change.columns[col_keys[0].value], 0);
 
-            write([&] { obj.set(col_keys[1], 10); });
+            write([&] {
+                obj.set(col_keys[1], 10);
+            });
             REQUIRE_INDICES(change.modifications, 0);
             REQUIRE(change.columns.size() == 1);
             REQUIRE_INDICES(change.columns[col_keys[1].value], 0);
         }
 
-        SECTION("modifying a different object")
-        {
+        SECTION("modifying a different object") {
             auto token = require_no_change();
-            write([&] { table->get_object(1).set(col_keys[0], 10); });
+            write([&] {
+                table->get_object(1).set(col_keys[0], 10);
+            });
         }
 
-        SECTION("multiple write transactions")
-        {
+        SECTION("multiple write transactions") {
             auto token = require_change();
 
             auto r2row = r2->read_group().get_table("class_table")->get_object(0);
@@ -303,8 +308,7 @@ TEST_CASE("object")
             REQUIRE_INDICES(change.columns[col_keys[1].value], 0);
         }
 
-        SECTION("skipping a notification")
-        {
+        SECTION("skipping a notification") {
             auto token = require_no_change();
             write([&] {
                 obj.set(col_keys[0], 1);
@@ -312,33 +316,39 @@ TEST_CASE("object")
             });
         }
 
-        SECTION("skipping only effects the current transaction even if no notification would occur anyway")
-        {
+        SECTION("skipping only effects the current transaction even if no notification would occur anyway") {
             auto token = require_change();
 
             // would not produce a notification even if it wasn't skipped because no changes were made
-            write([&] { token.suppress_next(); });
+            write([&] {
+                token.suppress_next();
+            });
             REQUIRE(change.empty());
 
             // should now produce a notification
-            write([&] { obj.set(col_keys[0], 1); });
+            write([&] {
+                obj.set(col_keys[0], 1);
+            });
             REQUIRE_INDICES(change.modifications, 0);
         }
 
-        SECTION("add notification callback, remove it, then add another notification callback")
-        {
+        SECTION("add notification callback, remove it, then add another notification callback") {
             {
-                auto token = object.add_notification_callback(
-                    [&](CollectionChangeSet, std::exception_ptr) { FAIL("This should never happen"); });
+                auto token = object.add_notification_callback([&](CollectionChangeSet, std::exception_ptr) {
+                    FAIL("This should never happen");
+                });
             }
             auto token = require_change();
-            write([&] { obj.remove(); });
+            write([&] {
+                obj.remove();
+            });
             REQUIRE_INDICES(change.deletions, 0);
         }
 
-        SECTION("observing deleted object throws")
-        {
-            write([&] { obj.remove(); });
+        SECTION("observing deleted object throws") {
+            write([&] {
+                obj.remove();
+            });
             REQUIRE_THROWS(require_change());
         }
     }
@@ -363,8 +373,7 @@ TEST_CASE("object")
         return obj;
     };
 
-    SECTION("create object")
-    {
+    SECTION("create object") {
         auto obj = create(AnyDict{
             {"_id", INT64_C(1)},
             {"bool", true},
@@ -441,8 +450,7 @@ TEST_CASE("object")
         REQUIRE(list->get_object(0).get<Int>(array_target_table->get_column_key("value")) == 20);
     }
 
-    SECTION("create uses defaults for missing values")
-    {
+    SECTION("create uses defaults for missing values") {
         d.defaults["all types"] = {
             {"bool", true},
             {"int", INT64_C(5)},
@@ -501,8 +509,7 @@ TEST_CASE("object")
         REQUIRE(row.get_listbase_ptr(table->get_column_key("uuid array"))->size() == 2);
     }
 
-    SECTION("create can use defaults for primary key")
-    {
+    SECTION("create can use defaults for primary key") {
         d.defaults["all types"] = {
             {"_id", INT64_C(10)},
         };
@@ -525,8 +532,7 @@ TEST_CASE("object")
         REQUIRE(row.get<Int>(row.get_table()->get_column_key("_id")) == 10);
     }
 
-    SECTION("create does not complain about missing values for nullable fields")
-    {
+    SECTION("create does not complain about missing values for nullable fields") {
         r->begin_transaction();
         realm::Object obj;
         REQUIRE_NOTHROW(obj = Object::create(d, r, *r->schema().find("all optional types"), util::Any(AnyDict{})));
@@ -554,16 +560,14 @@ TEST_CASE("object")
         REQUIRE(any_cast<List&&>(obj.get_property_value<util::Any>(d, "uuid array")).size() == 0);
     }
 
-    SECTION("create throws for missing values if there is no default")
-    {
+    SECTION("create throws for missing values if there is no default") {
         REQUIRE_THROWS(create(AnyDict{
             {"_id", INT64_C(1)},
             {"float", 6.6f},
         }));
     }
 
-    SECTION("create always sets the PK first")
-    {
+    SECTION("create always sets the PK first") {
         AnyDict value{
             {"array 1", AnyVector{AnyDict{{"_id", INT64_C(1)}, {"value", INT64_C(1)}}}},
             {"array 2", AnyVector{AnyDict{{"_id", INT64_C(2)}, {"value", INT64_C(2)}}}},
@@ -576,8 +580,7 @@ TEST_CASE("object")
         REQUIRE_NOTHROW(Object::create(d, r, *r->schema().find("pk after list"), util::Any(value)));
     }
 
-    SECTION("create with update")
-    {
+    SECTION("create with update") {
         CollectionChangeSet change;
         bool callback_called;
         Object obj = create(AnyDict{
@@ -640,8 +643,7 @@ TEST_CASE("object")
         REQUIRE(row.get<UUID>(table->get_column_key("uuid")) == UUID("3b241101-9999-9999-9999-4136c566a962"));
     }
 
-    SECTION("create with update - only with diffs")
-    {
+    SECTION("create with update - only with diffs") {
         CollectionChangeSet change;
         bool callback_called;
         AnyDict adam{
@@ -718,8 +720,7 @@ TEST_CASE("object")
         REQUIRE_INDICES(change.modifications, 1);
     }
 
-    SECTION("create with update - identical sub-object")
-    {
+    SECTION("create with update - identical sub-object") {
         Object sub_obj = create_sub(AnyDict{{"value", INT64_C(10)}, {"_id", INT64_C(10)}});
         Object obj = create(AnyDict{
             {"_id", INT64_C(1)},
@@ -741,12 +742,15 @@ TEST_CASE("object")
         bool callback_called;
         bool results_callback_called;
         bool sub_callback_called;
-        auto token1 =
-            obj.add_notification_callback([&](CollectionChangeSet, std::exception_ptr) { callback_called = true; });
-        auto token2 = result.add_notification_callback(
-            [&](CollectionChangeSet, std::exception_ptr) { results_callback_called = true; });
-        auto token3 = sub_obj.add_notification_callback(
-            [&](CollectionChangeSet, std::exception_ptr) { sub_callback_called = true; });
+        auto token1 = obj.add_notification_callback([&](CollectionChangeSet, std::exception_ptr) {
+            callback_called = true;
+        });
+        auto token2 = result.add_notification_callback([&](CollectionChangeSet, std::exception_ptr) {
+            results_callback_called = true;
+        });
+        auto token3 = sub_obj.add_notification_callback([&](CollectionChangeSet, std::exception_ptr) {
+            sub_callback_called = true;
+        });
         advance_and_notify(*r);
 
         auto table = r->read_group().get_table("class_link target");
@@ -805,8 +809,7 @@ TEST_CASE("object")
         REQUIRE(sub_callback_called);
     }
 
-    SECTION("create with update - identical array of sub-objects")
-    {
+    SECTION("create with update - identical array of sub-objects") {
         bool callback_called;
         auto dict = AnyDict{
             {"_id", INT64_C(1)},
@@ -827,8 +830,9 @@ TEST_CASE("object")
 
         auto obj_table = r->read_group().get_table("class_all types");
         Results result(r, obj_table);
-        auto token1 = result.add_notification_callback(
-            [&](CollectionChangeSet, std::exception_ptr) { callback_called = true; });
+        auto token1 = result.add_notification_callback([&](CollectionChangeSet, std::exception_ptr) {
+            callback_called = true;
+        });
         advance_and_notify(*r);
 
         create(dict, CreatePolicy::UpdateModified);
@@ -847,8 +851,7 @@ TEST_CASE("object")
     }
 
     for (auto policy : {CreatePolicy::UpdateAll, CreatePolicy::UpdateModified}) {
-        SECTION("set existing fields to null with update "s + (policy.diff ? "(diffed)" : "(all)"))
-        {
+        SECTION("set existing fields to null with update "s + (policy.diff ? "(diffed)" : "(all)")) {
             AnyDict initial_values{
                 {"_id", INT64_C(1)},
                 {"bool", true},
@@ -1014,8 +1017,7 @@ TEST_CASE("object")
         }
     }
 
-    SECTION("create throws for duplicate pk if update is not specified")
-    {
+    SECTION("create throws for duplicate pk if update is not specified") {
         create(AnyDict{
             {"_id", INT64_C(1)},
             {"bool", true},
@@ -1048,8 +1050,7 @@ TEST_CASE("object")
         }));
     }
 
-    SECTION("create with explicit null pk does not fall back to default")
-    {
+    SECTION("create with explicit null pk does not fall back to default") {
         d.defaults["nullable int pk"] = {
             {"_id", INT64_C(10)},
         };
@@ -1076,8 +1077,7 @@ TEST_CASE("object")
         REQUIRE(obj.obj().get<String>(col_pk_str) == "value");
     }
 
-    SECTION("create null and 0 primary keys for Int types")
-    {
+    SECTION("create null and 0 primary keys for Int types") {
         auto create = [&](util::Any&& value, StringData type) {
             r->begin_transaction();
             auto obj = Object::create(d, r, *r->schema().find(type), value);
@@ -1089,8 +1089,7 @@ TEST_CASE("object")
         REQUIRE(Results(r, r->read_group().get_table("class_all optional types")).size() == 2);
     }
 
-    SECTION("create null and default primary keys for ObjectId types")
-    {
+    SECTION("create null and default primary keys for ObjectId types") {
         auto create = [&](util::Any&& value, StringData type) {
             r->begin_transaction();
             auto obj = Object::create(d, r, *r->schema().find(type), value);
@@ -1102,8 +1101,7 @@ TEST_CASE("object")
         REQUIRE(Results(r, r->read_group().get_table("class_nullable object id pk")).size() == 2);
     }
 
-    SECTION("getters and setters")
-    {
+    SECTION("getters and setters") {
         r->begin_transaction();
 
         auto table = r->read_group().get_table("class_all types");
@@ -1163,8 +1161,7 @@ TEST_CASE("object")
         REQUIRE_THROWS(obj.set_property_value(d, "int", util::Any(INT64_C(5))));
     }
 
-    SECTION("list property self-assign is a no-op")
-    {
+    SECTION("list property self-assign is a no-op") {
         auto obj = create(AnyDict{
             {"_id", INT64_C(1)},
             {"bool", true},
@@ -1197,8 +1194,7 @@ TEST_CASE("object")
 #if REALM_ENABLE_SYNC
     if (!util::EventLoop::has_implementation())
         return;
-    SECTION("defaults do not override values explicitly passed to create()")
-    {
+    SECTION("defaults do not override values explicitly passed to create()") {
         TestSyncManager init_sync_manager({}, {false});
         auto& server = init_sync_manager.sync_server();
         SyncTestFile config1(init_sync_manager.app(), "shared");
@@ -1237,8 +1233,9 @@ TEST_CASE("object")
         r1->commit_transaction();
 
         server.start();
-        util::EventLoop::main().run_until(
-            [&] { return r1->read_group().get_table("class_array target")->size() == 4; });
+        util::EventLoop::main().run_until([&] {
+            return r1->read_group().get_table("class_array target")->size() == 4;
+        });
 
         Obj obj = object1.obj();
         REQUIRE(obj.get<Int>("_id") == 7); // pk
@@ -1250,8 +1247,7 @@ TEST_CASE("object")
 #endif
 }
 
-TEST_CASE("Embedded Object")
-{
+TEST_CASE("Embedded Object") {
     Schema schema{
         {"all types",
          {
@@ -1291,8 +1287,7 @@ TEST_CASE("Embedded Object")
         return obj;
     };
 
-    SECTION("Basic object creation")
-    {
+    SECTION("Basic object creation") {
         auto obj = create(AnyDict{
             {"_id", INT64_C(1)},
             {"object", AnyDict{{"value", INT64_C(10)}}},
@@ -1309,16 +1304,14 @@ TEST_CASE("Embedded Object")
         REQUIRE(list.get(1).get<int64_t>("value") == 30);
     }
 
-    SECTION("set_property_value() on link to embedded object")
-    {
+    SECTION("set_property_value() on link to embedded object") {
         auto obj = create(AnyDict{
             {"_id", INT64_C(1)},
             {"object", AnyDict{{"value", INT64_C(10)}}},
             {"array", AnyVector{AnyDict{{"value", INT64_C(20)}}, AnyDict{{"value", INT64_C(30)}}}},
         });
 
-        SECTION("throws when given a managed object")
-        {
+        SECTION("throws when given a managed object") {
             realm->begin_transaction();
             REQUIRE_THROWS_WITH(
                 obj.set_property_value(ctx, "object", obj.get_property_value<util::Any>(ctx, "object")),
@@ -1326,8 +1319,7 @@ TEST_CASE("Embedded Object")
             realm->cancel_transaction();
         }
 
-        SECTION("replaces object when given a dictionary and CreatePolicy::UpdateAll")
-        {
+        SECTION("replaces object when given a dictionary and CreatePolicy::UpdateAll") {
             realm->begin_transaction();
             auto old_linked = any_cast<Object>(obj.get_property_value<util::Any>(ctx, "object"));
             obj.set_property_value(ctx, "object", util::Any(AnyDict{{"value", INT64_C(40)}}));
@@ -1337,8 +1329,7 @@ TEST_CASE("Embedded Object")
             realm->cancel_transaction();
         }
 
-        SECTION("mutates existing object when given a dictionary and CreatePolicy::UpdateModified")
-        {
+        SECTION("mutates existing object when given a dictionary and CreatePolicy::UpdateModified") {
             realm->begin_transaction();
             auto old_linked = any_cast<Object>(obj.get_property_value<util::Any>(ctx, "object"));
             obj.set_property_value(ctx, "object", util::Any(AnyDict{{"value", INT64_C(40)}}),
@@ -1350,8 +1341,7 @@ TEST_CASE("Embedded Object")
             realm->cancel_transaction();
         }
 
-        SECTION("can set embedded link to null")
-        {
+        SECTION("can set embedded link to null") {
             realm->begin_transaction();
             auto old_linked = any_cast<Object>(obj.get_property_value<util::Any>(ctx, "object"));
             obj.set_property_value(ctx, "object", util::Any());
@@ -1362,8 +1352,7 @@ TEST_CASE("Embedded Object")
         }
     }
 
-    SECTION("set_property_value() on list of embedded objects")
-    {
+    SECTION("set_property_value() on list of embedded objects") {
         auto obj = create(AnyDict{
             {"_id", INT64_C(1)},
             {"array", AnyVector{AnyDict{{"value", INT64_C(1)}}, AnyDict{{"value", INT64_C(2)}}}},
@@ -1375,16 +1364,14 @@ TEST_CASE("Embedded Object")
         });
         List list2(realm, obj2.obj().get_linklist("array"));
 
-        SECTION("throws when given a managed object")
-        {
+        SECTION("throws when given a managed object") {
             realm->begin_transaction();
             REQUIRE_THROWS_WITH(obj.set_property_value(ctx, "array", util::Any{AnyVector{list2.get(0)}}),
                                 "Cannot add an existing managed embedded object to a List.");
             realm->cancel_transaction();
         }
 
-        SECTION("replaces objects when given a dictionary and CreatePolicy::UpdateAll")
-        {
+        SECTION("replaces objects when given a dictionary and CreatePolicy::UpdateAll") {
             realm->begin_transaction();
             auto old_obj_1 = list.get(0);
             auto old_obj_2 = list.get(1);
@@ -1401,8 +1388,7 @@ TEST_CASE("Embedded Object")
             realm->cancel_transaction();
         }
 
-        SECTION("mutates existing objects when given a dictionary and CreatePolicy::UpdateModified")
-        {
+        SECTION("mutates existing objects when given a dictionary and CreatePolicy::UpdateModified") {
             realm->begin_transaction();
             auto old_obj_1 = list.get(0);
             auto old_obj_2 = list.get(1);
@@ -1419,8 +1405,7 @@ TEST_CASE("Embedded Object")
             realm->cancel_transaction();
         }
 
-        SECTION("clears list when given null")
-        {
+        SECTION("clears list when given null") {
             realm->begin_transaction();
             obj.set_property_value(ctx, "array", util::Any());
             REQUIRE(list.size() == 0);
@@ -1428,8 +1413,7 @@ TEST_CASE("Embedded Object")
         }
     }
 
-    SECTION("create with UpdateModified diffs child objects")
-    {
+    SECTION("create with UpdateModified diffs child objects") {
         auto obj = create(AnyDict{
             {"_id", INT64_C(1)},
             {"object", AnyDict{{"value", INT64_C(10)}}},
@@ -1440,11 +1424,13 @@ TEST_CASE("Embedded Object")
         Results result(realm, array_table);
 
         bool obj_callback_called = false;
-        auto token = obj.add_notification_callback(
-            [&](CollectionChangeSet, std::exception_ptr) { obj_callback_called = true; });
+        auto token = obj.add_notification_callback([&](CollectionChangeSet, std::exception_ptr) {
+            obj_callback_called = true;
+        });
         bool list_callback_called = false;
-        auto token1 = result.add_notification_callback(
-            [&](CollectionChangeSet, std::exception_ptr) { list_callback_called = true; });
+        auto token1 = result.add_notification_callback([&](CollectionChangeSet, std::exception_ptr) {
+            list_callback_called = true;
+        });
         advance_and_notify(*realm);
 
         // Update with identical value
@@ -1476,8 +1462,7 @@ TEST_CASE("Embedded Object")
         REQUIRE(list_callback_called);
     }
 
-    SECTION("deleting parent object sends change notification")
-    {
+    SECTION("deleting parent object sends change notification") {
         auto parent = create(AnyDict{
             {"_id", INT64_C(1)},
             {"object", AnyDict{{"value", INT64_C(10)}}},

--- a/test/object-store/object_store.cpp
+++ b/test/object-store/object_store.cpp
@@ -30,20 +30,16 @@
 
 using namespace realm;
 
-TEST_CASE("ObjectStore: table_name_for_object_type()")
-{
-    SECTION("should work with strings that aren't null-terminated")
-    {
+TEST_CASE("ObjectStore: table_name_for_object_type()") {
+    SECTION("should work with strings that aren't null-terminated") {
         auto input = StringData("good_no_bad", 4);
         auto result = ObjectStore::table_name_for_object_type(input);
         REQUIRE(result == "class_good");
     }
 }
 
-TEST_CASE("ObjectStore:: property_for_column_key()")
-{
-    SECTION("Property should match the schema")
-    {
+TEST_CASE("ObjectStore:: property_for_column_key()") {
+    SECTION("Property should match the schema") {
         Schema schema = {
             {"object",
              {

--- a/test/object-store/primitive_list.cpp
+++ b/test/object-store/primitive_list.cpp
@@ -519,8 +519,7 @@ TEMPLATE_TEST_CASE("primitive list", "[primitives]", ::Int, ::Bool, ::Float, ::D
     auto results = list.as_results();
     CppContext ctx(r);
 
-    SECTION("get_realm()")
-    {
+    SECTION("get_realm()") {
         REQUIRE(list.get_realm() == r);
         REQUIRE(results.get_realm() == r);
     }
@@ -533,111 +532,93 @@ TEMPLATE_TEST_CASE("primitive list", "[primitives]", ::Int, ::Bool, ::Float, ::D
         REQUIRE(results.get_query().count() == 1);
     }
 #endif
-    SECTION("get_origin_row_index()")
-    {
+    SECTION("get_origin_row_index()") {
         REQUIRE(list.get_parent_object_key() == obj.get_key());
         table->create_object();
         REQUIRE(list.get_parent_object_key() == obj.get_key());
     }
 
-    SECTION("get_type()")
-    {
+    SECTION("get_type()") {
         REQUIRE(list.get_type() == TestType::property_type());
         REQUIRE(results.get_type() == TestType::property_type());
     }
 
-    SECTION("get_object_type()")
-    {
+    SECTION("get_object_type()") {
         REQUIRE(results.get_object_type() == StringData());
     }
 
-    SECTION("is_valid()")
-    {
+    SECTION("is_valid()") {
         REQUIRE(list.is_valid());
         REQUIRE(results.is_valid());
 
-        SECTION("invalidate")
-        {
+        SECTION("invalidate") {
             r->invalidate();
             REQUIRE_FALSE(list.is_valid());
             REQUIRE_FALSE(results.is_valid());
         }
 
-        SECTION("close")
-        {
+        SECTION("close") {
             r->close();
             REQUIRE_FALSE(list.is_valid());
             REQUIRE_FALSE(results.is_valid());
         }
 
-        SECTION("delete row")
-        {
+        SECTION("delete row") {
             obj.remove();
             REQUIRE_FALSE(list.is_valid());
             REQUIRE_FALSE(results.is_valid());
         }
 
-        SECTION("rollback transaction creating list")
-        {
+        SECTION("rollback transaction creating list") {
             r->cancel_transaction();
             REQUIRE_FALSE(list.is_valid());
             REQUIRE_FALSE(results.is_valid());
         }
     }
 
-    SECTION("verify_attached()")
-    {
+    SECTION("verify_attached()") {
         REQUIRE_NOTHROW(list.verify_attached());
 
-        SECTION("invalidate")
-        {
+        SECTION("invalidate") {
             r->invalidate();
             REQUIRE_THROWS(list.verify_attached());
         }
 
-        SECTION("close")
-        {
+        SECTION("close") {
             r->close();
             REQUIRE_THROWS(list.verify_attached());
         }
 
-        SECTION("delete row")
-        {
+        SECTION("delete row") {
             obj.remove();
             REQUIRE_THROWS(list.verify_attached());
         }
 
-        SECTION("rollback transaction creating list")
-        {
+        SECTION("rollback transaction creating list") {
             r->cancel_transaction();
             REQUIRE_THROWS(list.verify_attached());
         }
     }
 
-    SECTION("verify_in_transaction()")
-    {
+    SECTION("verify_in_transaction()") {
         REQUIRE_NOTHROW(list.verify_in_transaction());
 
-        SECTION("invalidate")
-        {
+        SECTION("invalidate") {
             r->invalidate();
             REQUIRE_THROWS(list.verify_in_transaction());
         }
 
-        SECTION("close")
-        {
+        SECTION("close") {
             r->close();
             REQUIRE_THROWS(list.verify_in_transaction());
         }
 
-        SECTION("delete row")
-        {
+        SECTION("delete row") {
             obj.remove();
             REQUIRE_THROWS(list.verify_in_transaction());
         }
 
-        SECTION("end write")
-        {
+        SECTION("end write") {
             r->commit_transaction();
             REQUIRE_THROWS(list.verify_in_transaction());
         }
@@ -649,8 +630,7 @@ TEMPLATE_TEST_CASE("primitive list", "[primitives]", ::Int, ::Bool, ::Float, ::D
     for (T value : values)
         list.add(value);
 
-    SECTION("move()")
-    {
+    SECTION("move()") {
         if (list.size() < 3)
             return;
 
@@ -675,8 +655,7 @@ TEMPLATE_TEST_CASE("primitive list", "[primitives]", ::Int, ::Bool, ::Float, ::D
         REQUIRE(results == values);
     }
 
-    SECTION("remove()")
-    {
+    SECTION("remove()") {
         if (list.size() < 3)
             return;
 
@@ -686,15 +665,13 @@ TEMPLATE_TEST_CASE("primitive list", "[primitives]", ::Int, ::Bool, ::Float, ::D
         REQUIRE(results == values);
     }
 
-    SECTION("remove_all()")
-    {
+    SECTION("remove_all()") {
         list.remove_all();
         REQUIRE(list.size() == 0);
         REQUIRE(results.size() == 0);
     }
 
-    SECTION("swap()")
-    {
+    SECTION("swap()") {
         if (list.size() < 3)
             return;
 
@@ -704,22 +681,19 @@ TEMPLATE_TEST_CASE("primitive list", "[primitives]", ::Int, ::Bool, ::Float, ::D
         REQUIRE(results == values);
     }
 
-    SECTION("delete_all()")
-    {
+    SECTION("delete_all()") {
         list.delete_all();
         REQUIRE(list.size() == 0);
         REQUIRE(results.size() == 0);
     }
 
-    SECTION("clear()")
-    {
+    SECTION("clear()") {
         results.clear();
         REQUIRE(list.size() == 0);
         REQUIRE(results.size() == 0);
     }
 
-    SECTION("get()")
-    {
+    SECTION("get()") {
         for (size_t i = 0; i < values.size(); ++i) {
             CAPTURE(i);
             REQUIRE(list.get<T>(i) == values[i]);
@@ -733,23 +707,20 @@ TEMPLATE_TEST_CASE("primitive list", "[primitives]", ::Int, ::Bool, ::Float, ::D
         REQUIRE_THROWS(results.get(ctx, values.size()));
     }
 
-    SECTION("first()")
-    {
+    SECTION("first()") {
         REQUIRE(*results.first<T>() == values.front());
         REQUIRE(any_cast<Boxed>(*results.first(ctx)) == Boxed(values.front()));
         list.remove_all();
         REQUIRE(results.first<T>() == util::none);
     }
 
-    SECTION("last()")
-    {
+    SECTION("last()") {
         REQUIRE(*results.last<T>() == values.back());
         list.remove_all();
         REQUIRE(results.last<T>() == util::none);
     }
 
-    SECTION("set()")
-    {
+    SECTION("set()") {
         for (size_t i = 0; i < values.size(); ++i) {
             CAPTURE(i);
             auto rev = values.size() - i - 1;
@@ -767,8 +738,7 @@ TEMPLATE_TEST_CASE("primitive list", "[primitives]", ::Int, ::Bool, ::Float, ::D
         REQUIRE_THROWS(list.set(list.size(), static_cast<T>(values[0])));
     }
 
-    SECTION("find()")
-    {
+    SECTION("find()") {
         for (size_t i = 0; i < values.size(); ++i) {
             CAPTURE(i);
             REQUIRE(list.find<T>(values[i]) == i);
@@ -790,8 +760,7 @@ TEMPLATE_TEST_CASE("primitive list", "[primitives]", ::Int, ::Bool, ::Float, ::D
         REQUIRE(list.find(ctx, TestType::to_any(values[0])) == npos);
         REQUIRE(results.index_of(ctx, TestType::to_any(values[0])) == npos);
     }
-    SECTION("sorted index_of()")
-    {
+    SECTION("sorted index_of()") {
         auto sorted = list.sort({{"self", true}});
         std::sort(begin(values), end(values), less());
         for (size_t i = 0; i < values.size(); ++i) {
@@ -818,8 +787,7 @@ TEMPLATE_TEST_CASE("primitive list", "[primitives]", ::Int, ::Bool, ::Float, ::D
         }
     }
 #endif
-    SECTION("sort()")
-    {
+    SECTION("sort()") {
         auto unsorted = list.sort(std::vector<std::pair<std::string, bool>>{});
         REQUIRE(unsorted == values);
 
@@ -844,8 +812,7 @@ TEMPLATE_TEST_CASE("primitive list", "[primitives]", ::Int, ::Bool, ::Float, ::D
                                          string_for_property_type(TestType::property_type() & ~PropertyType::Flags)));
     }
 
-    SECTION("distinct()")
-    {
+    SECTION("distinct()") {
         for (T value : values)
             list.add(value);
         auto values2 = values;
@@ -884,8 +851,7 @@ TEMPLATE_TEST_CASE("primitive list", "[primitives]", ::Int, ::Bool, ::Float, ::D
     }
 #endif
 
-    SECTION("min()")
-    {
+    SECTION("min()") {
         if (!TestType::can_minmax()) {
             REQUIRE_THROWS(list.min());
             REQUIRE_THROWS(results.min());
@@ -899,8 +865,7 @@ TEMPLATE_TEST_CASE("primitive list", "[primitives]", ::Int, ::Bool, ::Float, ::D
         REQUIRE(results.min() == util::none);
     }
 
-    SECTION("max()")
-    {
+    SECTION("max()") {
         if (!TestType::can_minmax()) {
             REQUIRE_THROWS(list.max());
             REQUIRE_THROWS(results.max());
@@ -914,8 +879,7 @@ TEMPLATE_TEST_CASE("primitive list", "[primitives]", ::Int, ::Bool, ::Float, ::D
         REQUIRE(results.max() == util::none);
     }
 
-    SECTION("sum()")
-    {
+    SECTION("sum()") {
         if (!TestType::can_sum()) {
             REQUIRE_THROWS(list.sum());
             return;
@@ -928,8 +892,7 @@ TEMPLATE_TEST_CASE("primitive list", "[primitives]", ::Int, ::Bool, ::Float, ::D
         REQUIRE(get<W>(*results.sum()) == W{});
     }
 
-    SECTION("average()")
-    {
+    SECTION("average()") {
         if (!TestType::can_average()) {
             REQUIRE_THROWS(list.average());
             return;
@@ -942,23 +905,20 @@ TEMPLATE_TEST_CASE("primitive list", "[primitives]", ::Int, ::Bool, ::Float, ::D
         REQUIRE(results.average() == util::none);
     }
 
-    SECTION("operator==()")
-    {
+    SECTION("operator==()") {
         Obj obj1 = table->create_object();
         REQUIRE(list == List(r, obj, col));
         REQUIRE_FALSE(list == List(r, obj1, col));
     }
 
-    SECTION("hash")
-    {
+    SECTION("hash") {
         Obj obj1 = table->create_object();
         std::hash<List> h;
         REQUIRE(h(list) == h(List(r, obj, col)));
         REQUIRE_FALSE(h(list) == h(List(r, obj1, col)));
     }
 
-    SECTION("handover")
-    {
+    SECTION("handover") {
         r->commit_transaction();
 
         auto list2 = ThreadSafeReference(list).resolve<List>(r);
@@ -967,8 +927,7 @@ TEMPLATE_TEST_CASE("primitive list", "[primitives]", ::Int, ::Bool, ::Float, ::D
         REQUIRE(results2 == values);
     }
 
-    SECTION("notifications")
-    {
+    SECTION("notifications") {
         r->commit_transaction();
 
         auto sorted = results.sort({{"self", true}});
@@ -988,8 +947,7 @@ TEMPLATE_TEST_CASE("primitive list", "[primitives]", ::Int, ::Bool, ::Float, ::D
             ++calls;
         });
 
-        SECTION("add value to list")
-        {
+        SECTION("add value to list") {
             // Remove the existing copy of this value so that the sorted list
             // doesn't have dupes resulting in an unstable order
             advance_and_notify(*r);
@@ -1009,8 +967,7 @@ TEMPLATE_TEST_CASE("primitive list", "[primitives]", ::Int, ::Bool, ::Float, ::D
             REQUIRE_INDICES(srchange.insertions, values.size() - 1);
         }
 
-        SECTION("remove value from list")
-        {
+        SECTION("remove value from list") {
             advance_and_notify(*r);
             r->begin_transaction();
             list.remove(1);
@@ -1024,8 +981,7 @@ TEMPLATE_TEST_CASE("primitive list", "[primitives]", ::Int, ::Bool, ::Float, ::D
             REQUIRE_INDICES(srchange.deletions, TestType::is_optional);
         }
 
-        SECTION("clear list")
-        {
+        SECTION("clear list") {
             advance_and_notify(*r);
 
             r->begin_transaction();
@@ -1037,8 +993,7 @@ TEMPLATE_TEST_CASE("primitive list", "[primitives]", ::Int, ::Bool, ::Float, ::D
             REQUIRE(srchange.deletions.count() == values.size());
         }
 
-        SECTION("delete containing row")
-        {
+        SECTION("delete containing row") {
             advance_and_notify(*r);
             REQUIRE(calls == 3);
 
@@ -1058,8 +1013,7 @@ TEMPLATE_TEST_CASE("primitive list", "[primitives]", ::Int, ::Bool, ::Float, ::D
             REQUIRE(calls == 6);
         }
 
-        SECTION("deleting containing row before first run of notifier")
-        {
+        SECTION("deleting containing row before first run of notifier") {
             r2->begin_transaction();
             table2->begin()->remove();
             r2->commit_transaction();
@@ -1069,8 +1023,7 @@ TEMPLATE_TEST_CASE("primitive list", "[primitives]", ::Int, ::Bool, ::Float, ::D
     }
 
 #if REALM_ENABLE_SYNC && REALM_HAVE_SYNC_STABLE_IDS
-    SECTION("sync compatibility")
-    {
+    SECTION("sync compatibility") {
         if (!util::EventLoop::has_implementation())
             return;
 

--- a/test/object-store/realm.cpp
+++ b/test/object-store/realm.cpp
@@ -58,8 +58,7 @@ public:
 
 using namespace realm;
 
-TEST_CASE("SharedRealm: get_shared_realm()")
-{
+TEST_CASE("SharedRealm: get_shared_realm()") {
     TestFile config;
     config.cache = true;
     config.schema_version = 1;
@@ -67,81 +66,69 @@ TEST_CASE("SharedRealm: get_shared_realm()")
         {"object", {{"value", PropertyType::Int}}},
     };
 
-    SECTION("should return the same instance when caching is enabled")
-    {
+    SECTION("should return the same instance when caching is enabled") {
         auto realm1 = Realm::get_shared_realm(config);
         auto realm2 = Realm::get_shared_realm(config);
         REQUIRE(realm1.get() == realm2.get());
     }
 
-    SECTION("should return different instances when caching is disabled")
-    {
+    SECTION("should return different instances when caching is disabled") {
         config.cache = false;
         auto realm1 = Realm::get_shared_realm(config);
         auto realm2 = Realm::get_shared_realm(config);
         REQUIRE(realm1.get() != realm2.get());
     }
 
-    SECTION("should validate that the config is sensible")
-    {
-        SECTION("bad encryption key")
-        {
+    SECTION("should validate that the config is sensible") {
+        SECTION("bad encryption key") {
             config.encryption_key = std::vector<char>(2, 0);
             REQUIRE_THROWS(Realm::get_shared_realm(config));
         }
 
-        SECTION("schema without schema version")
-        {
+        SECTION("schema without schema version") {
             config.schema_version = ObjectStore::NotVersioned;
             REQUIRE_THROWS(Realm::get_shared_realm(config));
         }
 
-        SECTION("migration function for immutable")
-        {
+        SECTION("migration function for immutable") {
             config.schema_mode = SchemaMode::Immutable;
             config.migration_function = [](auto, auto, auto) {};
             REQUIRE_THROWS(Realm::get_shared_realm(config));
         }
 
-        SECTION("migration function for read-only")
-        {
+        SECTION("migration function for read-only") {
             config.schema_mode = SchemaMode::ReadOnlyAlternative;
             config.migration_function = [](auto, auto, auto) {};
             REQUIRE_THROWS(Realm::get_shared_realm(config));
         }
 
-        SECTION("migration function for additive-only")
-        {
+        SECTION("migration function for additive-only") {
             config.schema_mode = SchemaMode::Additive;
             config.migration_function = [](auto, auto, auto) {};
             REQUIRE_THROWS(Realm::get_shared_realm(config));
         }
 
-        SECTION("initialization function for immutable")
-        {
+        SECTION("initialization function for immutable") {
             config.schema_mode = SchemaMode::Immutable;
             config.initialization_function = [](auto) {};
             REQUIRE_THROWS(Realm::get_shared_realm(config));
         }
 
-        SECTION("initialization function for read-only")
-        {
+        SECTION("initialization function for read-only") {
             config.schema_mode = SchemaMode::ReadOnlyAlternative;
             config.initialization_function = [](auto) {};
             REQUIRE_THROWS(Realm::get_shared_realm(config));
         }
     }
 
-    SECTION("should reject mismatched config")
-    {
-        SECTION("cached") {}
-        SECTION("uncached")
-        {
+    SECTION("should reject mismatched config") {
+        SECTION("cached") {
+        }
+        SECTION("uncached") {
             config.cache = false;
         }
 
-        SECTION("schema version")
-        {
+        SECTION("schema version") {
             auto realm = Realm::get_shared_realm(config);
             config.schema_version = 2;
             REQUIRE_THROWS(Realm::get_shared_realm(config));
@@ -151,22 +138,19 @@ TEST_CASE("SharedRealm: get_shared_realm()")
             REQUIRE_NOTHROW(Realm::get_shared_realm(config));
         }
 
-        SECTION("schema mode")
-        {
+        SECTION("schema mode") {
             auto realm = Realm::get_shared_realm(config);
             config.schema_mode = SchemaMode::Manual;
             REQUIRE_THROWS(Realm::get_shared_realm(config));
         }
 
-        SECTION("durability")
-        {
+        SECTION("durability") {
             auto realm = Realm::get_shared_realm(config);
             config.in_memory = true;
             REQUIRE_THROWS(Realm::get_shared_realm(config));
         }
 
-        SECTION("schema")
-        {
+        SECTION("schema") {
             auto realm = Realm::get_shared_realm(config);
             config.schema = Schema{
                 {"object", {{"value", PropertyType::Int}, {"value2", PropertyType::Int}}},
@@ -178,8 +162,7 @@ TEST_CASE("SharedRealm: get_shared_realm()")
 
 // Windows doesn't use fifos
 #ifndef _WIN32
-    SECTION("should be able to set a FIFO fallback path")
-    {
+    SECTION("should be able to set a FIFO fallback path") {
         std::string fallback_dir = util::make_temp_dir() + "/fallback/";
         realm::util::try_make_dir(fallback_dir);
         TestFile config;
@@ -198,8 +181,7 @@ TEST_CASE("SharedRealm: get_shared_realm()")
         realm::util::remove_dir_recursive(fallback_dir);
     }
 
-    SECTION("automatically append dir separator to end of fallback path")
-    {
+    SECTION("automatically append dir separator to end of fallback path") {
         std::string fallback_dir = util::make_temp_dir() + "/fallback";
         realm::util::try_make_dir(fallback_dir);
         TestFile config;
@@ -219,8 +201,7 @@ TEST_CASE("SharedRealm: get_shared_realm()")
     }
 #endif
 
-    SECTION("should verify that the schema is valid")
-    {
+    SECTION("should verify that the schema is valid") {
         config.schema =
             Schema{{"object",
                     {{"value", PropertyType::Int}},
@@ -229,8 +210,7 @@ TEST_CASE("SharedRealm: get_shared_realm()")
                             Catch::Matchers::Contains("origin of linking objects property"));
     }
 
-    SECTION("should apply the schema if one is supplied")
-    {
+    SECTION("should apply the schema if one is supplied") {
         Realm::get_shared_realm(config);
 
         {
@@ -255,8 +235,7 @@ TEST_CASE("SharedRealm: get_shared_realm()")
         REQUIRE(migration_called);
     }
 
-    SECTION("should properly roll back from migration errors")
-    {
+    SECTION("should properly roll back from migration errors") {
         Realm::get_shared_realm(config);
 
         config.schema_version = 2;
@@ -277,8 +256,7 @@ TEST_CASE("SharedRealm: get_shared_realm()")
         REQUIRE_NOTHROW(Realm::get_shared_realm(config));
     }
 
-    SECTION("should read the schema from the file if none is supplied")
-    {
+    SECTION("should read the schema from the file if none is supplied") {
         Realm::get_shared_realm(config);
 
         config.schema = util::none;
@@ -293,8 +271,7 @@ TEST_CASE("SharedRealm: get_shared_realm()")
         REQUIRE(it->persisted_properties[0].column_key == table->get_column_key("value"));
     }
 
-    SECTION("should read the proper schema from the file if a custom version is supplied")
-    {
+    SECTION("should read the proper schema from the file if a custom version is supplied") {
         Realm::get_shared_realm(config);
 
         config.schema = util::none;
@@ -325,11 +302,10 @@ TEST_CASE("SharedRealm: get_shared_realm()")
         REQUIRE(old_realm->schema().size() == 1);
     }
 
-    SECTION("should sensibly handle opening an uninitialized file without a schema specified")
-    {
-        SECTION("cached") {}
-        SECTION("uncached")
-        {
+    SECTION("should sensibly handle opening an uninitialized file without a schema specified") {
+        SECTION("cached") {
+        }
+        SECTION("uncached") {
             config.cache = false;
         }
 
@@ -352,8 +328,7 @@ TEST_CASE("SharedRealm: get_shared_realm()")
         REQUIRE(realm2->schema_version() == 1);
     }
 
-    SECTION("should populate the table columns in the schema when opening as immutable")
-    {
+    SECTION("should populate the table columns in the schema when opening as immutable") {
         Realm::get_shared_realm(config);
 
         config.schema_mode = SchemaMode::Immutable;
@@ -367,8 +342,7 @@ TEST_CASE("SharedRealm: get_shared_realm()")
         REQUIRE(it->persisted_properties[0].column_key == table->get_column_key("value"));
     }
 
-    SECTION("should support using different table subsets on different threads")
-    {
+    SECTION("should support using different table subsets on different threads") {
         config.cache = false;
         auto realm1 = Realm::get_shared_realm(config);
 
@@ -401,8 +375,7 @@ TEST_CASE("SharedRealm: get_shared_realm()")
 
 // The ExternalCommitHelper implementation on Windows doesn't rely on files
 #ifndef _WIN32
-    SECTION("should throw when creating the notification pipe fails")
-    {
+    SECTION("should throw when creating the notification pipe fails") {
         REQUIRE(util::try_make_dir(config.path + ".note"));
         auto sys_fallback_file =
             util::format("%1realm_%2.note", util::normalize_dir(DBOptions::get_sys_tmp_dir()),
@@ -414,8 +387,7 @@ TEST_CASE("SharedRealm: get_shared_realm()")
     }
 #endif
 
-    SECTION("should get different instances on different threads")
-    {
+    SECTION("should get different instances on different threads") {
         auto realm1 = Realm::get_shared_realm(config);
         std::thread([&] {
             auto realm2 = Realm::get_shared_realm(config);
@@ -423,10 +395,11 @@ TEST_CASE("SharedRealm: get_shared_realm()")
         }).join();
     }
 
-    SECTION("should detect use of Realm on incorrect thread")
-    {
+    SECTION("should detect use of Realm on incorrect thread") {
         auto realm = Realm::get_shared_realm(config);
-        std::thread([&] { REQUIRE_THROWS_AS(realm->verify_thread(), IncorrectThreadException); }).join();
+        std::thread([&] {
+            REQUIRE_THROWS_AS(realm->verify_thread(), IncorrectThreadException);
+        }).join();
     }
 
     // Our test scheduler uses a simple integer identifier to allow cross thread scheduling
@@ -458,8 +431,7 @@ TEST_CASE("SharedRealm: get_shared_realm()")
         size_t m_id;
     };
 
-    SECTION("should get different instances for different explicitly different schedulers")
-    {
+    SECTION("should get different instances for different explicitly different schedulers") {
         config.scheduler = std::make_shared<SimpleScheduler>(1);
         auto realm1 = Realm::get_shared_realm(config);
         config.scheduler = std::make_shared<SimpleScheduler>(2);
@@ -472,8 +444,7 @@ TEST_CASE("SharedRealm: get_shared_realm()")
         REQUIRE(realm2 != realm3);
     }
 
-    SECTION("can use Realm with explicit scheduler on different thread")
-    {
+    SECTION("can use Realm with explicit scheduler on different thread") {
         config.scheduler = std::make_shared<SimpleScheduler>(1);
         auto realm = Realm::get_shared_realm(config);
         std::thread([&] {
@@ -481,8 +452,7 @@ TEST_CASE("SharedRealm: get_shared_realm()")
         }).join();
     }
 
-    SECTION("should get same instance for same explicit execution context on different thread")
-    {
+    SECTION("should get same instance for same explicit execution context on different thread") {
         config.scheduler = std::make_shared<SimpleScheduler>(1);
         auto realm1 = Realm::get_shared_realm(config);
         std::thread([&] {
@@ -491,16 +461,14 @@ TEST_CASE("SharedRealm: get_shared_realm()")
         }).join();
     }
 
-    SECTION("should not modify the schema when fetching from the cache")
-    {
+    SECTION("should not modify the schema when fetching from the cache") {
         auto realm = Realm::get_shared_realm(config);
         auto object_schema = &*realm->schema().find("object");
         Realm::get_shared_realm(config);
         REQUIRE(object_schema == &*realm->schema().find("object"));
     }
 
-    SECTION("should not use cached frozen Realm if versions don't match")
-    {
+    SECTION("should not use cached frozen Realm if versions don't match") {
         auto realm = Realm::get_shared_realm(config);
         realm->read_group();
         auto frozen1 = realm->freeze();
@@ -527,8 +495,7 @@ TEST_CASE("SharedRealm: get_shared_realm()")
 }
 
 #if REALM_ENABLE_SYNC
-TEST_CASE("Get Realm using Async Open", "[asyncOpen]")
-{
+TEST_CASE("Get Realm using Async Open", "[asyncOpen]") {
     TestFile local_config;
     local_config.schema_version = 1;
     local_config.schema = Schema{
@@ -557,8 +524,7 @@ TEST_CASE("Get Realm using Async Open", "[asyncOpen]")
     config2.cache = false;
 
     std::mutex mutex;
-    SECTION("can open synced Realms that don't already exist")
-    {
+    SECTION("can open synced Realms that don't already exist") {
         std::atomic<bool> called{false};
         auto task = Realm::get_synchronized_realm(config);
         task->start([&](auto ref, auto error) {
@@ -568,13 +534,14 @@ TEST_CASE("Get Realm using Async Open", "[asyncOpen]")
 
             REQUIRE(Realm::get_shared_realm(std::move(ref))->read_group().get_table("class_object"));
         });
-        util::EventLoop::main().run_until([&] { return called.load(); });
+        util::EventLoop::main().run_until([&] {
+            return called.load();
+        });
         std::lock_guard<std::mutex> lock(mutex);
         REQUIRE(called);
     }
 
-    SECTION("downloads Realms which exist on the server")
-    {
+    SECTION("downloads Realms which exist on the server") {
         {
             auto realm = Realm::get_shared_realm(config2);
             realm->begin_transaction();
@@ -592,13 +559,14 @@ TEST_CASE("Get Realm using Async Open", "[asyncOpen]")
 
             REQUIRE(Realm::get_shared_realm(std::move(ref))->read_group().get_table("class_object"));
         });
-        util::EventLoop::main().run_until([&] { return called.load(); });
+        util::EventLoop::main().run_until([&] {
+            return called.load();
+        });
         std::lock_guard<std::mutex> lock(mutex);
         REQUIRE(called);
     }
 
-    SECTION("downloads latest state for Realms which already exist locally")
-    {
+    SECTION("downloads latest state for Realms which already exist locally") {
         wait_for_upload(*Realm::get_shared_realm(config));
 
         {
@@ -618,13 +586,14 @@ TEST_CASE("Get Realm using Async Open", "[asyncOpen]")
 
             REQUIRE(Realm::get_shared_realm(std::move(ref))->read_group().get_table("class_object")->size() == 1);
         });
-        util::EventLoop::main().run_until([&] { return called.load(); });
+        util::EventLoop::main().run_until([&] {
+            return called.load();
+        });
         std::lock_guard<std::mutex> lock(mutex);
         REQUIRE(called);
     }
 
-    SECTION("can download multiple Realms at a time")
-    {
+    SECTION("can download multiple Realms at a time") {
         SyncTestFile config1(init_sync_manager.app(), "realm1");
         SyncTestFile config2(init_sync_manager.app(), "realm2");
         SyncTestFile config3(init_sync_manager.app(), "realm3");
@@ -639,15 +608,18 @@ TEST_CASE("Get Realm using Async Open", "[asyncOpen]")
 
         std::atomic<int> completed{0};
         for (auto& task : tasks) {
-            task->start([&](auto, auto) { ++completed; });
+            task->start([&](auto, auto) {
+                ++completed;
+            });
         }
-        util::EventLoop::main().run_until([&] { return completed == 4; });
+        util::EventLoop::main().run_until([&] {
+            return completed == 4;
+        });
     }
 }
 #endif
 
-TEST_CASE("SharedRealm: notifications")
-{
+TEST_CASE("SharedRealm: notifications") {
     if (!util::EventLoop::has_implementation())
         return;
 
@@ -677,26 +649,25 @@ TEST_CASE("SharedRealm: notifications")
     realm->m_binding_context.reset(new Context{&change_count});
     realm->m_binding_context->realm = realm;
 
-    SECTION("local notifications are sent synchronously")
-    {
+    SECTION("local notifications are sent synchronously") {
         realm->begin_transaction();
         REQUIRE(change_count == 0);
         realm->commit_transaction();
         REQUIRE(change_count == 1);
     }
 
-    SECTION("remote notifications are sent asynchronously")
-    {
+    SECTION("remote notifications are sent asynchronously") {
         auto r2 = Realm::get_shared_realm(config);
         r2->begin_transaction();
         r2->commit_transaction();
         REQUIRE(change_count == 0);
-        util::EventLoop::main().run_until([&] { return change_count > 0; });
+        util::EventLoop::main().run_until([&] {
+            return change_count > 0;
+        });
         REQUIRE(change_count == 1);
     }
 
-    SECTION("refresh() from within changes_available() refreshes")
-    {
+    SECTION("refresh() from within changes_available() refreshes") {
         struct Context : BindingContext {
             Realm& realm;
             Context(Realm& realm)
@@ -720,8 +691,7 @@ TEST_CASE("SharedRealm: notifications")
         REQUIRE_FALSE(realm->refresh());
     }
 
-    SECTION("refresh() from within did_change() is a no-op")
-    {
+    SECTION("refresh() from within did_change() is a no-op") {
         struct Context : BindingContext {
             Realm& realm;
             Context(Realm& realm)
@@ -757,8 +727,7 @@ TEST_CASE("SharedRealm: notifications")
         REQUIRE_FALSE(realm->refresh());
     }
 
-    SECTION("begin_write() from within did_change() produces recursive notifications")
-    {
+    SECTION("begin_write() from within did_change() produces recursive notifications") {
         struct Context : BindingContext {
             Realm& realm;
             size_t calls = 0;
@@ -797,8 +766,7 @@ TEST_CASE("SharedRealm: notifications")
     }
 }
 
-TEST_CASE("SharedRealm: schema updating from external changes")
-{
+TEST_CASE("SharedRealm: schema updating from external changes") {
     TestFile config;
     config.schema_version = 0;
     config.schema_mode = SchemaMode::Additive;
@@ -810,8 +778,7 @@ TEST_CASE("SharedRealm: schema updating from external changes")
          }},
     };
 
-    SECTION("newly added columns update table columns but are not added to properties")
-    {
+    SECTION("newly added columns update table columns but are not added to properties") {
         // Does this test add any value when column keys are stable?
         auto r1 = Realm::get_shared_realm(config);
         auto r2 = Realm::get_shared_realm(config);
@@ -826,20 +793,17 @@ TEST_CASE("SharedRealm: schema updating from external changes")
             r1->refresh();
             REQUIRE(object_schema.persisted_properties[0].column_key == col);
         };
-        SECTION("with an active read transaction")
-        {
+        SECTION("with an active read transaction") {
             r1->read_group();
             test();
         }
-        SECTION("without an active read transaction")
-        {
+        SECTION("without an active read transaction") {
             r1->invalidate();
             test();
         }
     }
 
-    SECTION("beginning a read transaction checks for incompatible changes")
-    {
+    SECTION("beginning a read transaction checks for incompatible changes") {
         auto r = Realm::get_shared_realm(config);
         r->invalidate();
 
@@ -847,15 +811,13 @@ TEST_CASE("SharedRealm: schema updating from external changes")
         WriteTransaction wt(db);
         auto& table = *wt.get_table("class_object");
 
-        SECTION("removing a property")
-        {
+        SECTION("removing a property") {
             table.remove_column(table.get_column_key("value"));
             wt.commit();
             REQUIRE_THROWS_WITH(r->refresh(), Catch::Matchers::Contains("Property 'object.value' has been removed."));
         }
 
-        SECTION("change property type")
-        {
+        SECTION("change property type") {
             table.remove_column(table.get_column_key("value 2"));
             table.add_column(type_Float, "value 2");
             wt.commit();
@@ -864,8 +826,7 @@ TEST_CASE("SharedRealm: schema updating from external changes")
                 Catch::Matchers::Contains("Property 'object.value 2' has been changed from 'int' to 'float'"));
         }
 
-        SECTION("make property optional")
-        {
+        SECTION("make property optional") {
             table.remove_column(table.get_column_key("value 2"));
             table.add_column(type_Int, "value 2", true);
             wt.commit();
@@ -873,16 +834,14 @@ TEST_CASE("SharedRealm: schema updating from external changes")
                                 Catch::Matchers::Contains("Property 'object.value 2' has been made optional"));
         }
 
-        SECTION("recreate column with no changes")
-        {
+        SECTION("recreate column with no changes") {
             table.remove_column(table.get_column_key("value 2"));
             table.add_column(type_Int, "value 2");
             wt.commit();
             REQUIRE_NOTHROW(r->refresh());
         }
 
-        SECTION("remove index from non-PK")
-        {
+        SECTION("remove index from non-PK") {
             table.remove_search_index(table.get_column_key("value 2"));
             wt.commit();
             REQUIRE_NOTHROW(r->refresh());
@@ -890,8 +849,7 @@ TEST_CASE("SharedRealm: schema updating from external changes")
     }
 }
 
-TEST_CASE("SharedRealm: close()")
-{
+TEST_CASE("SharedRealm: close()") {
     TestFile config;
     config.schema_version = 1;
     config.schema = Schema{
@@ -901,8 +859,7 @@ TEST_CASE("SharedRealm: close()")
 
     auto realm = Realm::get_shared_realm(config);
 
-    SECTION("all functions throw ClosedRealmException after close")
-    {
+    SECTION("all functions throw ClosedRealmException after close") {
         realm->close();
 
         REQUIRE(realm->is_closed());
@@ -918,8 +875,7 @@ TEST_CASE("SharedRealm: close()")
         REQUIRE_THROWS_AS(realm->compact(), ClosedRealmException);
     }
 
-    SECTION("fully closes database file even with live notifiers")
-    {
+    SECTION("fully closes database file even with live notifiers") {
         auto& group = realm->read_group();
         realm->begin_transaction();
         auto obj = ObjectStore::table_for_object_type(group, "list")->create_object();
@@ -945,16 +901,14 @@ TEST_CASE("SharedRealm: close()")
     }
 }
 
-TEST_CASE("ShareRealm: in-memory mode from buffer")
-{
+TEST_CASE("ShareRealm: in-memory mode from buffer") {
     TestFile config;
     config.schema_version = 1;
     config.schema = Schema{
         {"object", {{"value", PropertyType::Int}}},
     };
 
-    SECTION("Save and open Realm from in-memory buffer")
-    {
+    SECTION("Save and open Realm from in-memory buffer") {
         // Write in-memory copy of Realm to a buffer
         auto realm = Realm::get_shared_realm(config);
         OwnedBinaryData realm_buffer = realm->write_copy();
@@ -993,8 +947,7 @@ TEST_CASE("ShareRealm: in-memory mode from buffer")
     }
 }
 
-TEST_CASE("ShareRealm: realm closed in did_change callback")
-{
+TEST_CASE("ShareRealm: realm closed in did_change callback") {
     TestFile config;
     config.schema_version = 1;
     config.cache = false;
@@ -1020,8 +973,7 @@ TEST_CASE("ShareRealm: realm closed in did_change callback")
         }
     };
 
-    SECTION("did_change")
-    {
+    SECTION("did_change") {
         r1->m_binding_context.reset(new Context());
         r1->invalidate();
 
@@ -1034,8 +986,7 @@ TEST_CASE("ShareRealm: realm closed in did_change callback")
         r1->notify();
     }
 
-    SECTION("did_change with async results")
-    {
+    SECTION("did_change with async results") {
         r1->m_binding_context.reset(new Context());
         Results results(r1, table->where());
         auto token = results.add_notification_callback([&](CollectionChangeSet, std::exception_ptr) {
@@ -1055,8 +1006,7 @@ TEST_CASE("ShareRealm: realm closed in did_change callback")
         r1->notify();
     }
 
-    SECTION("refresh")
-    {
+    SECTION("refresh") {
         r1->m_binding_context.reset(new Context());
 
         auto r2 = Realm::get_shared_realm(config);
@@ -1071,8 +1021,7 @@ TEST_CASE("ShareRealm: realm closed in did_change callback")
     shared_realm = nullptr;
 }
 
-TEST_CASE("RealmCoordinator: schema cache")
-{
+TEST_CASE("RealmCoordinator: schema cache") {
     TestFile config;
     auto coordinator = _impl::RealmCoordinator::get_coordinator(config.path);
 
@@ -1093,8 +1042,7 @@ TEST_CASE("RealmCoordinator: schema cache")
          }},
     };
 
-    SECTION("valid initial schema sets cache")
-    {
+    SECTION("valid initial schema sets cache") {
         coordinator->cache_schema(schema, 5, 10);
         REQUIRE(coordinator->get_cached_schema(cache_schema, cache_sv, cache_tv));
         REQUIRE(cache_schema == schema);
@@ -1102,8 +1050,7 @@ TEST_CASE("RealmCoordinator: schema cache")
         REQUIRE(cache_tv == 10);
     }
 
-    SECTION("cache can be updated with newer schema")
-    {
+    SECTION("cache can be updated with newer schema") {
         coordinator->cache_schema(schema, 5, 10);
         coordinator->cache_schema(schema2, 6, 11);
         REQUIRE(coordinator->get_cached_schema(cache_schema, cache_sv, cache_tv));
@@ -1112,8 +1059,7 @@ TEST_CASE("RealmCoordinator: schema cache")
         REQUIRE(cache_tv == 11);
     }
 
-    SECTION("empty schema is ignored")
-    {
+    SECTION("empty schema is ignored") {
         coordinator->cache_schema(Schema{}, 5, 10);
         REQUIRE_FALSE(coordinator->get_cached_schema(cache_schema, cache_sv, cache_tv));
 
@@ -1125,8 +1071,7 @@ TEST_CASE("RealmCoordinator: schema cache")
         REQUIRE(cache_tv == 10);
     }
 
-    SECTION("schema for older transaction is ignored")
-    {
+    SECTION("schema for older transaction is ignored") {
         coordinator->cache_schema(schema, 5, 10);
         coordinator->cache_schema(schema2, 4, 8);
 
@@ -1141,8 +1086,7 @@ TEST_CASE("RealmCoordinator: schema cache")
         REQUIRE(cache_tv == 20); // should not have dropped to 15
     }
 
-    SECTION("advance_schema() from transaction version bumps transaction version")
-    {
+    SECTION("advance_schema() from transaction version bumps transaction version") {
         coordinator->cache_schema(schema, 5, 10);
         coordinator->advance_schema_cache(10, 12);
         REQUIRE(coordinator->get_cached_schema(cache_schema, cache_sv, cache_tv));
@@ -1151,8 +1095,7 @@ TEST_CASE("RealmCoordinator: schema cache")
         REQUIRE(cache_tv == 12);
     }
 
-    SECTION("advance_schema() ending before transaction version does nothing")
-    {
+    SECTION("advance_schema() ending before transaction version does nothing") {
         coordinator->cache_schema(schema, 5, 10);
         coordinator->advance_schema_cache(8, 9);
         REQUIRE(coordinator->get_cached_schema(cache_schema, cache_sv, cache_tv));
@@ -1161,8 +1104,7 @@ TEST_CASE("RealmCoordinator: schema cache")
         REQUIRE(cache_tv == 10);
     }
 
-    SECTION("advance_schema() extending over transaction version bumps version")
-    {
+    SECTION("advance_schema() extending over transaction version bumps version") {
         coordinator->cache_schema(schema, 5, 10);
         coordinator->advance_schema_cache(3, 15);
         REQUIRE(coordinator->get_cached_schema(cache_schema, cache_sv, cache_tv));
@@ -1171,15 +1113,13 @@ TEST_CASE("RealmCoordinator: schema cache")
         REQUIRE(cache_tv == 15);
     }
 
-    SECTION("advance_schema() with no cahced schema does nothing")
-    {
+    SECTION("advance_schema() with no cahced schema does nothing") {
         coordinator->advance_schema_cache(3, 15);
         REQUIRE_FALSE(coordinator->get_cached_schema(cache_schema, cache_sv, cache_tv));
     }
 }
 
-TEST_CASE("SharedRealm: coordinator schema cache")
-{
+TEST_CASE("SharedRealm: coordinator schema cache") {
     TestFile config;
     auto r = Realm::get_shared_realm(config);
     auto coordinator = _impl::RealmCoordinator::get_coordinator(config.path);
@@ -1224,14 +1164,12 @@ TEST_CASE("SharedRealm: coordinator schema cache")
         wt.wt.commit();
     };
 
-    SECTION("is initially empty for uninitialized file")
-    {
+    SECTION("is initially empty for uninitialized file") {
         REQUIRE_FALSE(coordinator->get_cached_schema(cache_schema, cache_sv, cache_tv));
     }
     r->update_schema(schema);
 
-    SECTION("is populated after calling update_schema()")
-    {
+    SECTION("is populated after calling update_schema()") {
         REQUIRE(coordinator->get_cached_schema(cache_schema, cache_sv, cache_tv));
         REQUIRE(cache_sv == 0);
         REQUIRE(cache_schema == schema);
@@ -1244,16 +1182,14 @@ TEST_CASE("SharedRealm: coordinator schema cache")
     coordinator = _impl::RealmCoordinator::get_coordinator(config.path);
     REQUIRE(coordinator->get_cached_schema(cache_schema, cache_sv, cache_tv));
 
-    SECTION("is populated after opening an initialized file")
-    {
+    SECTION("is populated after opening an initialized file") {
         REQUIRE(cache_sv == 0);
         REQUIRE(cache_tv == 2); // with in-realm history the version doesn't reset
         REQUIRE(cache_schema == schema);
         REQUIRE(cache_schema.begin()->persisted_properties[0].column_key != ColKey{});
     }
 
-    SECTION("transaction version is bumped after a local write")
-    {
+    SECTION("transaction version is bumped after a local write") {
         auto tv = cache_tv;
         r->begin_transaction();
         r->commit_transaction();
@@ -1261,17 +1197,18 @@ TEST_CASE("SharedRealm: coordinator schema cache")
         REQUIRE(cache_tv == tv + 1);
     }
 
-    SECTION("notify() without a read transaction does not bump transaction version")
-    {
+    SECTION("notify() without a read transaction does not bump transaction version") {
         auto tv = cache_tv;
 
-        SECTION("non-schema change")
-        {
-            external_write(config, [](auto& wt) { wt.get_table("class_object")->create_object(); });
+        SECTION("non-schema change") {
+            external_write(config, [](auto& wt) {
+                wt.get_table("class_object")->create_object();
+            });
         }
-        SECTION("schema change")
-        {
-            external_write(config, [](auto& wt) { wt.add_table("class_object 2"); });
+        SECTION("schema change") {
+            external_write(config, [](auto& wt) {
+                wt.add_table("class_object 2");
+            });
         }
 
         r->notify();
@@ -1280,10 +1217,11 @@ TEST_CASE("SharedRealm: coordinator schema cache")
         REQUIRE(cache_schema == schema);
     }
 
-    SECTION("notify() with a read transaction bumps transaction version")
-    {
+    SECTION("notify() with a read transaction bumps transaction version") {
         r->read_group();
-        external_write(config, [](auto& wt) { wt.get_table("class_object")->create_object(); });
+        external_write(config, [](auto& wt) {
+            wt.get_table("class_object")->create_object();
+        });
 
         r->notify();
         auto tv = cache_tv;
@@ -1291,10 +1229,11 @@ TEST_CASE("SharedRealm: coordinator schema cache")
         REQUIRE(cache_tv == tv + 1);
     }
 
-    SECTION("notify() with a read transaction updates schema folloing external schema change")
-    {
+    SECTION("notify() with a read transaction updates schema folloing external schema change") {
         r->read_group();
-        external_write(config, [](auto& wt) { wt.add_table("class_object 2"); });
+        external_write(config, [](auto& wt) {
+            wt.add_table("class_object 2");
+        });
 
         r->notify();
         auto tv = cache_tv;
@@ -1304,9 +1243,10 @@ TEST_CASE("SharedRealm: coordinator schema cache")
         REQUIRE(cache_schema.find("object 2") != cache_schema.end());
     }
 
-    SECTION("transaction version is bumped after refresh() following external non-schema write")
-    {
-        external_write(config, [](auto& wt) { wt.get_table("class_object")->create_object(); });
+    SECTION("transaction version is bumped after refresh() following external non-schema write") {
+        external_write(config, [](auto& wt) {
+            wt.get_table("class_object")->create_object();
+        });
 
         r->refresh();
         auto tv = cache_tv;
@@ -1314,9 +1254,10 @@ TEST_CASE("SharedRealm: coordinator schema cache")
         REQUIRE(cache_tv == tv + 1);
     }
 
-    SECTION("schema is reread following refresh() over external schema change")
-    {
-        external_write(config, [](auto& wt) { wt.add_table("class_object 2"); });
+    SECTION("schema is reread following refresh() over external schema change") {
+        external_write(config, [](auto& wt) {
+            wt.add_table("class_object 2");
+        });
 
         r->refresh();
         auto tv = cache_tv;
@@ -1326,8 +1267,7 @@ TEST_CASE("SharedRealm: coordinator schema cache")
         REQUIRE(cache_schema.find("object 2") != cache_schema.end());
     }
 
-    SECTION("update_schema() to version already on disk updates cache")
-    {
+    SECTION("update_schema() to version already on disk updates cache") {
         r->read_group();
         external_write(config, [](auto& wt) {
             auto table = wt.add_table("class_object 2");
@@ -1343,8 +1283,7 @@ TEST_CASE("SharedRealm: coordinator schema cache")
         REQUIRE(cache_schema.find("object 2") != cache_schema.end());
     }
 
-    SECTION("update_schema() to version already on disk updates cache")
-    {
+    SECTION("update_schema() to version already on disk updates cache") {
         r->read_group();
         external_write(config, [](auto& wt) {
             auto table = wt.add_table("class_object 2");
@@ -1360,8 +1299,7 @@ TEST_CASE("SharedRealm: coordinator schema cache")
         REQUIRE(cache_schema.find("object 2") != cache_schema.end());
     }
 
-    SECTION("update_schema() to version populated on disk while waiting for the write lock updates cache")
-    {
+    SECTION("update_schema() to version populated on disk while waiting for the write lock updates cache") {
         r->read_group();
 
         // We want to commit the write while we're waiting on the write lock on
@@ -1404,8 +1342,7 @@ TEST_CASE("SharedRealm: coordinator schema cache")
     }
 }
 
-TEST_CASE("SharedRealm: dynamic schema mode doesn't invalidate object schema pointers when schema hasn't changed")
-{
+TEST_CASE("SharedRealm: dynamic schema mode doesn't invalidate object schema pointers when schema hasn't changed") {
     TestFile config;
 
     // Prepopulate the Realm with the schema.
@@ -1433,8 +1370,7 @@ TEST_CASE("SharedRealm: dynamic schema mode doesn't invalidate object schema poi
     REQUIRE(object_schema == &*r2->schema().find("object"));
 }
 
-TEST_CASE("SharedRealm: declaring an object as embedded results in creating an embedded table")
-{
+TEST_CASE("SharedRealm: declaring an object as embedded results in creating an embedded table") {
     TestFile config;
 
     // Prepopulate the Realm with the schema.
@@ -1454,8 +1390,7 @@ TEST_CASE("SharedRealm: declaring an object as embedded results in creating an e
     REQUIRE(t->is_embedded());
 }
 
-TEST_CASE("SharedRealm: SchemaChangedFunction")
-{
+TEST_CASE("SharedRealm: SchemaChangedFunction") {
     struct Context : BindingContext {
         size_t* change_count;
         Schema* schema;
@@ -1491,10 +1426,8 @@ TEST_CASE("SharedRealm: SchemaChangedFunction")
     r1->read_group();
     r1->m_binding_context.reset(new Context(&schema_changed_called, &changed_fixed_schema));
 
-    SECTION("Fixed schema")
-    {
-        SECTION("update_schema")
-        {
+    SECTION("Fixed schema") {
+        SECTION("update_schema") {
             auto new_schema = Schema{{"object3",
                                       {
                                           {"value", PropertyType::Int},
@@ -1504,14 +1437,12 @@ TEST_CASE("SharedRealm: SchemaChangedFunction")
             REQUIRE(changed_fixed_schema.find("object3")->property_for_name("value")->column_key != ColKey{});
         }
 
-        SECTION("Open a new Realm instance with same config won't trigger")
-        {
+        SECTION("Open a new Realm instance with same config won't trigger") {
             auto r2 = Realm::get_shared_realm(config);
             REQUIRE(schema_changed_called == 0);
         }
 
-        SECTION("Non schema related transaction doesn't trigger")
-        {
+        SECTION("Non schema related transaction doesn't trigger") {
             auto r2 = Realm::get_shared_realm(config);
             r2->begin_transaction();
             r2->commit_transaction();
@@ -1519,8 +1450,7 @@ TEST_CASE("SharedRealm: SchemaChangedFunction")
             REQUIRE(schema_changed_called == 0);
         }
 
-        SECTION("Schema is changed by another Realm")
-        {
+        SECTION("Schema is changed by another Realm") {
             auto r2 = Realm::get_shared_realm(config);
             r2->begin_transaction();
             r2->read_group().get_table("class_object1")->add_column(type_String, "new col");
@@ -1531,8 +1461,7 @@ TEST_CASE("SharedRealm: SchemaChangedFunction")
         }
 
         // This is not a valid use case. m_schema won't be refreshed.
-        SECTION("Schema is changed by this Realm won't trigger")
-        {
+        SECTION("Schema is changed by this Realm won't trigger") {
             r1->begin_transaction();
             r1->read_group().get_table("class_object1")->add_column(type_String, "new col");
             r1->commit_transaction();
@@ -1540,15 +1469,13 @@ TEST_CASE("SharedRealm: SchemaChangedFunction")
         }
     }
 
-    SECTION("Dynamic schema")
-    {
+    SECTION("Dynamic schema") {
         size_t dynamic_schema_changed_called = 0;
         Schema changed_dynamic_schema;
         auto r2 = Realm::get_shared_realm(dynamic_config);
         r2->m_binding_context.reset(new Context(&dynamic_schema_changed_called, &changed_dynamic_schema));
 
-        SECTION("set_schema_subset")
-        {
+        SECTION("set_schema_subset") {
             auto new_schema = Schema{{"object1",
                                       {
                                           {"value", PropertyType::Int},
@@ -1559,8 +1486,7 @@ TEST_CASE("SharedRealm: SchemaChangedFunction")
             REQUIRE(changed_dynamic_schema.find("object1")->property_for_name("value")->column_key != ColKey{});
         }
 
-        SECTION("Non schema related transaction will always trigger in dynamic mode")
-        {
+        SECTION("Non schema related transaction will always trigger in dynamic mode") {
             auto r1 = Realm::get_shared_realm(config);
             // An empty transaction will trigger the schema changes always in dynamic mode.
             r1->begin_transaction();
@@ -1570,8 +1496,7 @@ TEST_CASE("SharedRealm: SchemaChangedFunction")
             REQUIRE(changed_dynamic_schema.find("object1")->property_for_name("value")->column_key != ColKey{});
         }
 
-        SECTION("Schema is changed by another Realm")
-        {
+        SECTION("Schema is changed by another Realm") {
             r1->begin_transaction();
             r1->read_group().get_table("class_object1")->add_column(type_String, "new col");
             r1->commit_transaction();
@@ -1583,8 +1508,7 @@ TEST_CASE("SharedRealm: SchemaChangedFunction")
 }
 
 #ifndef _WIN32
-TEST_CASE("SharedRealm: compact on launch")
-{
+TEST_CASE("SharedRealm: compact on launch") {
     // Make compactable Realm
     TestFile config;
     config.automatic_change_notifications = false;
@@ -1609,8 +1533,7 @@ TEST_CASE("SharedRealm: compact on launch")
     REQUIRE(table->size() == count);
     r->close();
 
-    SECTION("compact reduces the file size")
-    {
+    SECTION("compact reduces the file size") {
         // Confirm expected sizes before and after opening the Realm
         size_t size_before = size_t(util::File(config.path).get_size());
         r = Realm::get_shared_realm(config);
@@ -1630,8 +1553,7 @@ TEST_CASE("SharedRealm: compact on launch")
         r->close();
     }
 
-    SECTION("compact function does not get invoked if realm is open on another thread")
-    {
+    SECTION("compact function does not get invoked if realm is open on another thread") {
         config.scheduler = util::Scheduler::get_frozen(VersionID());
         r = Realm::get_shared_realm(config);
         REQUIRE(num_opens == 2);
@@ -1709,8 +1631,7 @@ TEMPLATE_TEST_CASE("SharedRealm: update_schema with initialization_function", "[
         {"object", {{"value", PropertyType::String}}},
     };
 
-    SECTION("call initialization function directly by update_schema")
-    {
+    SECTION("call initialization function directly by update_schema") {
         // Open in dynamic mode with no schema specified
         auto realm = Realm::get_shared_realm(config);
         REQUIRE_FALSE(initialization_function_called);
@@ -1724,8 +1645,7 @@ TEMPLATE_TEST_CASE("SharedRealm: update_schema with initialization_function", "[
     config.schema_version = 0;
     config.schema = schema;
 
-    SECTION("initialization function should be called for unversioned realm")
-    {
+    SECTION("initialization function should be called for unversioned realm") {
         config.initialization_function = initialization_function;
         Realm::get_shared_realm(config);
         REQUIRE(initialization_function_called);
@@ -1733,8 +1653,7 @@ TEMPLATE_TEST_CASE("SharedRealm: update_schema with initialization_function", "[
         REQUIRE(schema_in_callback.compare(schema).size() == 0);
     }
 
-    SECTION("initialization function for versioned realm")
-    {
+    SECTION("initialization function for versioned realm") {
         // Initialize v0
         Realm::get_shared_realm(config);
 
@@ -1749,8 +1668,7 @@ TEMPLATE_TEST_CASE("SharedRealm: update_schema with initialization_function", "[
     }
 }
 
-TEST_CASE("BindingContext is notified about delivery of change notifications")
-{
+TEST_CASE("BindingContext is notified about delivery of change notifications") {
     _impl::RealmCoordinator::assert_no_open_realms();
 
     InMemoryTestFile config;
@@ -1764,8 +1682,7 @@ TEST_CASE("BindingContext is notified about delivery of change notifications")
     auto coordinator = _impl::RealmCoordinator::get_coordinator(config.path);
     auto table = r->read_group().get_table("class_object");
 
-    SECTION("BindingContext notified even if no callbacks are registered")
-    {
+    SECTION("BindingContext notified even if no callbacks are registered") {
         static int binding_context_start_notify_calls = 0;
         static int binding_context_end_notify_calls = 0;
         struct Context : BindingContext {
@@ -1781,8 +1698,7 @@ TEST_CASE("BindingContext is notified about delivery of change notifications")
         };
         r->m_binding_context.reset(new Context());
 
-        SECTION("local commit")
-        {
+        SECTION("local commit") {
             binding_context_start_notify_calls = 0;
             binding_context_end_notify_calls = 0;
             coordinator->on_change();
@@ -1792,8 +1708,7 @@ TEST_CASE("BindingContext is notified about delivery of change notifications")
             r->cancel_transaction();
         }
 
-        SECTION("remote commit")
-        {
+        SECTION("remote commit") {
             binding_context_start_notify_calls = 0;
             binding_context_end_notify_calls = 0;
             JoiningThread([&] {
@@ -1809,8 +1724,7 @@ TEST_CASE("BindingContext is notified about delivery of change notifications")
         }
     }
 
-    SECTION("notify BindingContext before and after sending notifications")
-    {
+    SECTION("notify BindingContext before and after sending notifications") {
         static int binding_context_start_notify_calls = 0;
         static int binding_context_end_notify_calls = 0;
         static int notification_calls = 0;
@@ -1846,8 +1760,7 @@ TEST_CASE("BindingContext is notified about delivery of change notifications")
         };
         r->m_binding_context.reset(new Context());
 
-        SECTION("local commit")
-        {
+        SECTION("local commit") {
             binding_context_start_notify_calls = 0;
             binding_context_end_notify_calls = 0;
             notification_calls = 0;
@@ -1859,8 +1772,7 @@ TEST_CASE("BindingContext is notified about delivery of change notifications")
             REQUIRE(binding_context_end_notify_calls == 1);
         }
 
-        SECTION("remote commit")
-        {
+        SECTION("remote commit") {
             binding_context_start_notify_calls = 0;
             binding_context_end_notify_calls = 0;
             notification_calls = 0;
@@ -1877,8 +1789,7 @@ TEST_CASE("BindingContext is notified about delivery of change notifications")
         }
     }
 
-    SECTION("did_send() is skipped if the Realm is closed first")
-    {
+    SECTION("did_send() is skipped if the Realm is closed first") {
         Results results(r, table->where());
         bool do_close = true;
         auto token = results.add_notification_callback([&](CollectionChangeSet, std::exception_ptr) {
@@ -1905,15 +1816,13 @@ TEST_CASE("BindingContext is notified about delivery of change notifications")
             }
         };
 
-        SECTION("closed in notification callback for notify()")
-        {
+        SECTION("closed in notification callback for notify()") {
             r->m_binding_context.reset(new FailOnDidSend);
             coordinator->on_change();
             r->notify();
         }
 
-        SECTION("closed in notification callback for refresh()")
-        {
+        SECTION("closed in notification callback for refresh()") {
             do_close = false;
             coordinator->on_change();
             r->notify();
@@ -1931,15 +1840,13 @@ TEST_CASE("BindingContext is notified about delivery of change notifications")
             r->refresh();
         }
 
-        SECTION("closed in will_send() for notify()")
-        {
+        SECTION("closed in will_send() for notify()") {
             r->m_binding_context.reset(new CloseOnWillChange(*r));
             coordinator->on_change();
             r->notify();
         }
 
-        SECTION("closed in will_send() for refresh()")
-        {
+        SECTION("closed in will_send() for refresh()") {
             do_close = false;
             coordinator->on_change();
             r->notify();
@@ -1959,8 +1866,7 @@ TEST_CASE("BindingContext is notified about delivery of change notifications")
     }
 }
 
-TEST_CASE("Statistics on Realms")
-{
+TEST_CASE("Statistics on Realms") {
     _impl::RealmCoordinator::assert_no_open_realms();
 
     InMemoryTestFile config;
@@ -1972,16 +1878,14 @@ TEST_CASE("Statistics on Realms")
         {"object", {{"value", PropertyType::Int}}},
     });
 
-    SECTION("compute_size")
-    {
+    SECTION("compute_size") {
         auto s = r->read_group().compute_aggregated_byte_size();
         REQUIRE(s > 0);
     }
 }
 
 #if REALM_PLATFORM_APPLE && NOTIFIER_BACKGROUND_ERRORS
-TEST_CASE("BindingContext is notified in case of notifier errors")
-{
+TEST_CASE("BindingContext is notified in case of notifier errors") {
     _impl::RealmCoordinator::assert_no_open_realms();
 
     class OpenFileLimiter {
@@ -2033,8 +1937,7 @@ TEST_CASE("BindingContext is notified in case of notifier errors")
     };
     r->m_binding_context.reset(new Context());
 
-    SECTION("realm on background thread could not be opened")
-    {
+    SECTION("realm on background thread could not be opened") {
         OpenFileLimiter limiter;
 
         auto token = results.add_notification_callback([&](CollectionChangeSet, std::exception_ptr err) {
@@ -2050,8 +1953,7 @@ TEST_CASE("BindingContext is notified in case of notifier errors")
 }
 #endif
 
-TEST_CASE("RealmCoordinator: get_unbound_realm()")
-{
+TEST_CASE("RealmCoordinator: get_unbound_realm()") {
     TestFile config;
     config.cache = true;
     config.schema = Schema{
@@ -2059,43 +1961,48 @@ TEST_CASE("RealmCoordinator: get_unbound_realm()")
     };
 
     ThreadSafeReference ref;
-    std::thread([&] { ref = _impl::RealmCoordinator::get_coordinator(config)->get_unbound_realm(); }).join();
+    std::thread([&] {
+        ref = _impl::RealmCoordinator::get_coordinator(config)->get_unbound_realm();
+    }).join();
 
-    SECTION("checks thread after being resolved")
-    {
+    SECTION("checks thread after being resolved") {
         auto realm = Realm::get_shared_realm(std::move(ref));
         REQUIRE_NOTHROW(realm->verify_thread());
-        std::thread([&] { REQUIRE_THROWS(realm->verify_thread()); }).join();
+        std::thread([&] {
+            REQUIRE_THROWS(realm->verify_thread());
+        }).join();
     }
 
-    SECTION("delivers notifications to the thread it is resolved on")
-    {
+    SECTION("delivers notifications to the thread it is resolved on") {
         if (!util::EventLoop::has_implementation())
             return;
         auto realm = Realm::get_shared_realm(std::move(ref));
         Results results(realm, ObjectStore::table_for_object_type(realm->read_group(), "object")->where());
         bool called = false;
-        auto token =
-            results.add_notification_callback([&](CollectionChangeSet, std::exception_ptr) { called = true; });
-        util::EventLoop::main().run_until([&] { return called; });
+        auto token = results.add_notification_callback([&](CollectionChangeSet, std::exception_ptr) {
+            called = true;
+        });
+        util::EventLoop::main().run_until([&] {
+            return called;
+        });
     }
 
-    SECTION("resolves to existing cached Realm for the thread if caching is enabled")
-    {
+    SECTION("resolves to existing cached Realm for the thread if caching is enabled") {
         auto r1 = Realm::get_shared_realm(config);
         auto r2 = Realm::get_shared_realm(std::move(ref));
         REQUIRE(r1 == r2);
     }
 
-    SECTION("resolves to a new Realm if caching is disabled")
-    {
+    SECTION("resolves to a new Realm if caching is disabled") {
         config.cache = false;
         auto r1 = Realm::get_shared_realm(config);
         auto r2 = Realm::get_shared_realm(std::move(ref));
         REQUIRE(r1 != r2);
 
         // New unbound with cache disabled
-        std::thread([&] { ref = _impl::RealmCoordinator::get_coordinator(config)->get_unbound_realm(); }).join();
+        std::thread([&] {
+            ref = _impl::RealmCoordinator::get_coordinator(config)->get_unbound_realm();
+        }).join();
         auto r3 = Realm::get_shared_realm(std::move(ref));
         REQUIRE(r1 != r3);
         REQUIRE(r2 != r3);

--- a/test/object-store/results.cpp
+++ b/test/object-store/results.cpp
@@ -101,8 +101,7 @@ struct TestContext : CppContext {
 };
 
 
-TEST_CASE("notifications: async delivery")
-{
+TEST_CASE("notifications: async delivery") {
     _impl::RealmCoordinator::assert_no_open_realms();
 
     InMemoryTestFile config;
@@ -143,25 +142,21 @@ TEST_CASE("notifications: async delivery")
         r2->commit_transaction();
     };
 
-    SECTION("initial notification")
-    {
-        SECTION("is delivered on notify()")
-        {
+    SECTION("initial notification") {
+        SECTION("is delivered on notify()") {
             REQUIRE(notification_calls == 0);
             advance_and_notify(*r);
             REQUIRE(notification_calls == 1);
         }
 
-        SECTION("is delivered on refresh()")
-        {
+        SECTION("is delivered on refresh()") {
             coordinator->on_change();
             REQUIRE(notification_calls == 0);
             r->refresh();
             REQUIRE(notification_calls == 1);
         }
 
-        SECTION("is delivered on begin_transaction()")
-        {
+        SECTION("is delivered on begin_transaction()") {
             coordinator->on_change();
             REQUIRE(notification_calls == 0);
             r->begin_transaction();
@@ -169,16 +164,14 @@ TEST_CASE("notifications: async delivery")
             r->cancel_transaction();
         }
 
-        SECTION("is delivered on notify() even with autorefresh disabled")
-        {
+        SECTION("is delivered on notify() even with autorefresh disabled") {
             r->set_auto_refresh(false);
             REQUIRE(notification_calls == 0);
             advance_and_notify(*r);
             REQUIRE(notification_calls == 1);
         }
 
-        SECTION("refresh() blocks due to initial results not being ready")
-        {
+        SECTION("refresh() blocks due to initial results not being ready") {
             REQUIRE(notification_calls == 0);
             JoiningThread thread([&] {
                 std::this_thread::sleep_for(std::chrono::microseconds(5000));
@@ -188,8 +181,7 @@ TEST_CASE("notifications: async delivery")
             REQUIRE(notification_calls == 1);
         }
 
-        SECTION("begin_transaction() blocks due to initial results not being ready")
-        {
+        SECTION("begin_transaction() blocks due to initial results not being ready") {
             REQUIRE(notification_calls == 0);
             JoiningThread thread([&] {
                 std::this_thread::sleep_for(std::chrono::microseconds(5000));
@@ -200,27 +192,23 @@ TEST_CASE("notifications: async delivery")
             r->cancel_transaction();
         }
 
-        SECTION("notify() does not block due to initial results not being ready")
-        {
+        SECTION("notify() does not block due to initial results not being ready") {
             REQUIRE(notification_calls == 0);
             r->notify();
             REQUIRE(notification_calls == 0);
         }
 
-        SECTION("is delivered after invalidate()")
-        {
+        SECTION("is delivered after invalidate()") {
             r->invalidate();
 
-            SECTION("notify()")
-            {
+            SECTION("notify()") {
                 coordinator->on_change();
                 REQUIRE_FALSE(r->is_in_read_transaction());
                 r->notify();
                 REQUIRE(notification_calls == 1);
             }
 
-            SECTION("notify() without autorefresh")
-            {
+            SECTION("notify() without autorefresh") {
                 r->set_auto_refresh(false);
                 coordinator->on_change();
                 REQUIRE_FALSE(r->is_in_read_transaction());
@@ -228,16 +216,14 @@ TEST_CASE("notifications: async delivery")
                 REQUIRE(notification_calls == 1);
             }
 
-            SECTION("refresh()")
-            {
+            SECTION("refresh()") {
                 coordinator->on_change();
                 REQUIRE_FALSE(r->is_in_read_transaction());
                 r->refresh();
                 REQUIRE(notification_calls == 1);
             }
 
-            SECTION("begin_transaction()")
-            {
+            SECTION("begin_transaction()") {
                 coordinator->on_change();
                 REQUIRE_FALSE(r->is_in_read_transaction());
                 r->begin_transaction();
@@ -246,8 +232,7 @@ TEST_CASE("notifications: async delivery")
             }
         }
 
-        SECTION("is delivered by notify() even if there are later versions")
-        {
+        SECTION("is delivered by notify() even if there are later versions") {
             REQUIRE(notification_calls == 0);
             coordinator->on_change();
             make_remote_change();
@@ -258,53 +243,45 @@ TEST_CASE("notifications: async delivery")
 
     advance_and_notify(*r);
 
-    SECTION("notifications for local changes")
-    {
+    SECTION("notifications for local changes") {
         make_local_change();
         coordinator->on_change();
         REQUIRE(notification_calls == 1);
 
-        SECTION("notify()")
-        {
+        SECTION("notify()") {
             r->notify();
             REQUIRE(notification_calls == 2);
         }
 
-        SECTION("notify() without autorefresh")
-        {
+        SECTION("notify() without autorefresh") {
             r->set_auto_refresh(false);
             r->notify();
             REQUIRE(notification_calls == 2);
         }
 
-        SECTION("refresh()")
-        {
+        SECTION("refresh()") {
             r->refresh();
             REQUIRE(notification_calls == 2);
         }
 
-        SECTION("begin_transaction()")
-        {
+        SECTION("begin_transaction()") {
             r->begin_transaction();
             REQUIRE(notification_calls == 2);
             r->cancel_transaction();
         }
     }
 
-    SECTION("notifications for remote changes")
-    {
+    SECTION("notifications for remote changes") {
         make_remote_change();
         coordinator->on_change();
         REQUIRE(notification_calls == 1);
 
-        SECTION("notify()")
-        {
+        SECTION("notify()") {
             r->notify();
             REQUIRE(notification_calls == 2);
         }
 
-        SECTION("notify() without autorefresh")
-        {
+        SECTION("notify() without autorefresh") {
             r->set_auto_refresh(false);
             r->notify();
             REQUIRE(notification_calls == 1);
@@ -312,22 +289,19 @@ TEST_CASE("notifications: async delivery")
             REQUIRE(notification_calls == 2);
         }
 
-        SECTION("refresh()")
-        {
+        SECTION("refresh()") {
             r->refresh();
             REQUIRE(notification_calls == 2);
         }
 
-        SECTION("begin_transaction()")
-        {
+        SECTION("begin_transaction()") {
             r->begin_transaction();
             REQUIRE(notification_calls == 2);
             r->cancel_transaction();
         }
     }
 
-    SECTION("notifications are not delivered when the token is destroyed before they are calculated")
-    {
+    SECTION("notifications are not delivered when the token is destroyed before they are calculated") {
         make_remote_change();
         REQUIRE(notification_calls == 1);
         token = {};
@@ -335,8 +309,7 @@ TEST_CASE("notifications: async delivery")
         REQUIRE(notification_calls == 1);
     }
 
-    SECTION("notifications are not delivered when the token is destroyed before they are delivered")
-    {
+    SECTION("notifications are not delivered when the token is destroyed before they are delivered") {
         make_remote_change();
         REQUIRE(notification_calls == 1);
         coordinator->on_change();
@@ -345,14 +318,14 @@ TEST_CASE("notifications: async delivery")
         REQUIRE(notification_calls == 1);
     }
 
-    SECTION("notifications are delivered on the next cycle when a new callback is added from within a callback")
-    {
+    SECTION("notifications are delivered on the next cycle when a new callback is added from within a callback") {
         NotificationToken token2, token3;
         bool called = false;
         token2 = results.add_notification_callback([&](CollectionChangeSet, std::exception_ptr) {
             token2 = {};
-            token3 =
-                results.add_notification_callback([&](CollectionChangeSet, std::exception_ptr) { called = true; });
+            token3 = results.add_notification_callback([&](CollectionChangeSet, std::exception_ptr) {
+                called = true;
+            });
         });
 
         advance_and_notify(*r);
@@ -361,8 +334,7 @@ TEST_CASE("notifications: async delivery")
         REQUIRE(called);
     }
 
-    SECTION("notifications are delivered on the next cycle when a new callback is added from within a callback")
-    {
+    SECTION("notifications are delivered on the next cycle when a new callback is added from within a callback") {
         auto results2 = results;
         auto results3 = results;
         NotificationToken token2, token3, token4;
@@ -371,8 +343,9 @@ TEST_CASE("notifications: async delivery")
         auto check = [&](Results& outer, Results& inner) {
             token2 = outer.add_notification_callback([&](CollectionChangeSet, std::exception_ptr) {
                 token2 = {};
-                token3 =
-                    inner.add_notification_callback([&](CollectionChangeSet, std::exception_ptr) { called = true; });
+                token3 = inner.add_notification_callback([&](CollectionChangeSet, std::exception_ptr) {
+                    called = true;
+                });
             });
 
             advance_and_notify(*r);
@@ -381,49 +354,42 @@ TEST_CASE("notifications: async delivery")
             REQUIRE(called);
         };
 
-        SECTION("same Results")
-        {
+        SECTION("same Results") {
             check(results, results);
         }
 
-        SECTION("Results which has never had a notifier")
-        {
+        SECTION("Results which has never had a notifier") {
             check(results, results2);
         }
 
-        SECTION("Results which used to have callbacks but no longer does")
-        {
-            SECTION("notifier before active")
-            {
-                token3 =
-                    results2.add_notification_callback([&](CollectionChangeSet, std::exception_ptr) { token3 = {}; });
+        SECTION("Results which used to have callbacks but no longer does") {
+            SECTION("notifier before active") {
+                token3 = results2.add_notification_callback([&](CollectionChangeSet, std::exception_ptr) {
+                    token3 = {};
+                });
                 check(results3, results2);
             }
-            SECTION("notifier after active")
-            {
-                token3 =
-                    results2.add_notification_callback([&](CollectionChangeSet, std::exception_ptr) { token3 = {}; });
+            SECTION("notifier after active") {
+                token3 = results2.add_notification_callback([&](CollectionChangeSet, std::exception_ptr) {
+                    token3 = {};
+                });
                 check(results, results2);
             }
         }
 
-        SECTION("Results which already has callbacks")
-        {
-            SECTION("notifier before active")
-            {
+        SECTION("Results which already has callbacks") {
+            SECTION("notifier before active") {
                 token4 = results2.add_notification_callback([&](CollectionChangeSet, std::exception_ptr) {});
                 check(results3, results2);
             }
-            SECTION("notifier after active")
-            {
+            SECTION("notifier after active") {
                 token4 = results2.add_notification_callback([&](CollectionChangeSet, std::exception_ptr) {});
                 check(results, results2);
             }
         }
     }
 
-    SECTION("remote changes made before adding a callback from within a callback are not reported")
-    {
+    SECTION("remote changes made before adding a callback from within a callback are not reported") {
         NotificationToken token2, token3;
         bool called = false;
         token2 = results.add_notification_callback([&](CollectionChangeSet, std::exception_ptr) {
@@ -443,44 +409,48 @@ TEST_CASE("notifications: async delivery")
         REQUIRE(called);
     }
 
-    SECTION("notifications are not delivered when a callback is removed from within a callback")
-    {
+    SECTION("notifications are not delivered when a callback is removed from within a callback") {
         NotificationToken token2, token3;
-        token2 = results.add_notification_callback([&](CollectionChangeSet, std::exception_ptr) { token3 = {}; });
-        token3 = results.add_notification_callback([&](CollectionChangeSet, std::exception_ptr) { REQUIRE(false); });
+        token2 = results.add_notification_callback([&](CollectionChangeSet, std::exception_ptr) {
+            token3 = {};
+        });
+        token3 = results.add_notification_callback([&](CollectionChangeSet, std::exception_ptr) {
+            REQUIRE(false);
+        });
 
         advance_and_notify(*r);
     }
 
-    SECTION("removing the current callback does not stop later ones from being called")
-    {
+    SECTION("removing the current callback does not stop later ones from being called") {
         NotificationToken token2, token3;
         bool called = false;
-        token2 = results.add_notification_callback([&](CollectionChangeSet, std::exception_ptr) { token2 = {}; });
-        token3 = results.add_notification_callback([&](CollectionChangeSet, std::exception_ptr) { called = true; });
+        token2 = results.add_notification_callback([&](CollectionChangeSet, std::exception_ptr) {
+            token2 = {};
+        });
+        token3 = results.add_notification_callback([&](CollectionChangeSet, std::exception_ptr) {
+            called = true;
+        });
 
         advance_and_notify(*r);
 
         REQUIRE(called);
     }
 
-    SECTION("the first call of a notification can include changes if it previously ran for a different callback")
-    {
+    SECTION("the first call of a notification can include changes if it previously ran for a different callback") {
         r->begin_transaction();
-        auto token2 = results.add_notification_callback(
-            [&](CollectionChangeSet c, std::exception_ptr) { REQUIRE(!c.empty()); });
+        auto token2 = results.add_notification_callback([&](CollectionChangeSet c, std::exception_ptr) {
+            REQUIRE(!c.empty());
+        });
 
         table->create_object().set(col, 5);
         r->commit_transaction();
         advance_and_notify(*r);
     }
 
-    SECTION("handling of results not ready")
-    {
+    SECTION("handling of results not ready") {
         make_remote_change();
 
-        SECTION("notify() does nothing")
-        {
+        SECTION("notify() does nothing") {
             r->notify();
             REQUIRE(notification_calls == 1);
             coordinator->on_change();
@@ -488,8 +458,7 @@ TEST_CASE("notifications: async delivery")
             REQUIRE(notification_calls == 2);
         }
 
-        SECTION("refresh() blocks")
-        {
+        SECTION("refresh() blocks") {
             REQUIRE(notification_calls == 1);
             JoiningThread thread([&] {
                 std::this_thread::sleep_for(std::chrono::microseconds(5000));
@@ -500,8 +469,7 @@ TEST_CASE("notifications: async delivery")
         }
 
         SECTION("refresh() advances to the first version with notifiers ready that is at least a recent as the "
-                "newest at the time it is called")
-        {
+                "newest at the time it is called") {
             JoiningThread thread([&] {
                 std::this_thread::sleep_for(std::chrono::microseconds(5000));
                 make_remote_change();
@@ -522,8 +490,7 @@ TEST_CASE("notifications: async delivery")
             REQUIRE(notification_calls == 3);
         }
 
-        SECTION("begin_transaction() blocks")
-        {
+        SECTION("begin_transaction() blocks") {
             REQUIRE(notification_calls == 1);
             JoiningThread thread([&] {
                 std::this_thread::sleep_for(std::chrono::microseconds(5000));
@@ -534,23 +501,20 @@ TEST_CASE("notifications: async delivery")
             r->cancel_transaction();
         }
 
-        SECTION("refresh() does not block for results without callbacks")
-        {
+        SECTION("refresh() does not block for results without callbacks") {
             token = {};
             // this would deadlock if it waits for the notifier to be ready
             r->refresh();
         }
 
-        SECTION("begin_transaction() does not block for results without callbacks")
-        {
+        SECTION("begin_transaction() does not block for results without callbacks") {
             token = {};
             // this would deadlock if it waits for the notifier to be ready
             r->begin_transaction();
             r->cancel_transaction();
         }
 
-        SECTION("begin_transaction() does not block for Results for different Realms")
-        {
+        SECTION("begin_transaction() does not block for Results for different Realms") {
             // this would deadlock if beginning the write on the secondary Realm
             // waited for the primary Realm to be ready
             make_remote_change();
@@ -561,14 +525,12 @@ TEST_CASE("notifications: async delivery")
         }
     }
 
-    SECTION("handling of stale results")
-    {
+    SECTION("handling of stale results") {
         make_remote_change();
         coordinator->on_change();
         make_remote_change();
 
-        SECTION("notify() uses the older version")
-        {
+        SECTION("notify() uses the older version") {
             r->notify();
             REQUIRE(notification_calls == 2);
             coordinator->on_change();
@@ -578,8 +540,7 @@ TEST_CASE("notifications: async delivery")
             REQUIRE(notification_calls == 3);
         }
 
-        SECTION("refresh() blocks")
-        {
+        SECTION("refresh() blocks") {
             REQUIRE(notification_calls == 1);
             JoiningThread thread([&] {
                 std::this_thread::sleep_for(std::chrono::microseconds(5000));
@@ -589,8 +550,7 @@ TEST_CASE("notifications: async delivery")
             REQUIRE(notification_calls == 2);
         }
 
-        SECTION("begin_transaction() blocks")
-        {
+        SECTION("begin_transaction() blocks") {
             REQUIRE(notification_calls == 1);
             JoiningThread thread([&] {
                 std::this_thread::sleep_for(std::chrono::microseconds(5000));
@@ -602,21 +562,18 @@ TEST_CASE("notifications: async delivery")
         }
     }
 
-    SECTION("updates are delivered after invalidate()")
-    {
+    SECTION("updates are delivered after invalidate()") {
         r->invalidate();
         make_remote_change();
 
-        SECTION("notify()")
-        {
+        SECTION("notify()") {
             coordinator->on_change();
             REQUIRE_FALSE(r->is_in_read_transaction());
             r->notify();
             REQUIRE(notification_calls == 2);
         }
 
-        SECTION("notify() without autorefresh")
-        {
+        SECTION("notify() without autorefresh") {
             r->set_auto_refresh(false);
             coordinator->on_change();
             REQUIRE_FALSE(r->is_in_read_transaction());
@@ -626,16 +583,14 @@ TEST_CASE("notifications: async delivery")
             REQUIRE(notification_calls == 2);
         }
 
-        SECTION("refresh()")
-        {
+        SECTION("refresh()") {
             coordinator->on_change();
             REQUIRE_FALSE(r->is_in_read_transaction());
             r->refresh();
             REQUIRE(notification_calls == 2);
         }
 
-        SECTION("begin_transaction()")
-        {
+        SECTION("begin_transaction()") {
             coordinator->on_change();
             REQUIRE_FALSE(r->is_in_read_transaction());
             r->begin_transaction();
@@ -644,8 +599,7 @@ TEST_CASE("notifications: async delivery")
         }
     }
 
-    SECTION("refresh() from within changes_available() do not interfere with notification delivery")
-    {
+    SECTION("refresh() from within changes_available() do not interfere with notification delivery") {
         struct Context : BindingContext {
             Realm& realm;
             Context(Realm& realm)
@@ -673,8 +627,7 @@ TEST_CASE("notifications: async delivery")
         REQUIRE(notification_calls == 2);
     }
 
-    SECTION("refresh() from within a notification is a no-op")
-    {
+    SECTION("refresh() from within a notification is a no-op") {
         token = results.add_notification_callback([&](CollectionChangeSet, std::exception_ptr err) {
             REQUIRE_FALSE(err);
             REQUIRE_FALSE(r->refresh()); // would deadlock if it actually tried to refresh
@@ -689,8 +642,7 @@ TEST_CASE("notifications: async delivery")
         REQUIRE_FALSE(r->refresh()); // does not advance since it's now up-to-date
     }
 
-    SECTION("begin_transaction() from within a notification does not send notifications immediately")
-    {
+    SECTION("begin_transaction() from within a notification does not send notifications immediately") {
         bool first = true;
         auto token2 = results.add_notification_callback([&](CollectionChangeSet, std::exception_ptr err) {
             REQUIRE_FALSE(err);
@@ -714,8 +666,7 @@ TEST_CASE("notifications: async delivery")
         REQUIRE(notification_calls == 3);
     }
 
-    SECTION("begin_transaction() from within a notification does not break delivering additional notifications")
-    {
+    SECTION("begin_transaction() from within a notification does not break delivering additional notifications") {
         size_t calls = 0;
         token = results.add_notification_callback([&](CollectionChangeSet, std::exception_ptr err) {
             REQUIRE_FALSE(err);
@@ -748,8 +699,7 @@ TEST_CASE("notifications: async delivery")
         REQUIRE(calls2 == 2);
     }
 
-    SECTION("begin_transaction() from within did_change() does not break delivering collection notification")
-    {
+    SECTION("begin_transaction() from within did_change() does not break delivering collection notification") {
         struct Context : BindingContext {
             Realm& realm;
             Context(Realm& realm)
@@ -775,8 +725,7 @@ TEST_CASE("notifications: async delivery")
     }
 
     SECTION("is_in_transaction() is reported correctly within a notification from begin_transaction() and changes "
-            "can be made")
-    {
+            "can be made") {
         bool first = true;
         token = results.add_notification_callback([&](CollectionChangeSet, std::exception_ptr err) {
             REQUIRE_FALSE(err);
@@ -798,8 +747,7 @@ TEST_CASE("notifications: async delivery")
         REQUIRE(table->begin()->get<int64_t>(col) != 100);
     }
 
-    SECTION("invalidate() from within notification is a no-op")
-    {
+    SECTION("invalidate() from within notification is a no-op") {
         token = results.add_notification_callback([&](CollectionChangeSet, std::exception_ptr err) {
             REQUIRE_FALSE(err);
             r->invalidate();
@@ -814,8 +762,8 @@ TEST_CASE("notifications: async delivery")
         r->cancel_transaction();
     }
 
-    SECTION("cancel_transaction() from within notification ends the write transaction started by begin_transaction()")
-    {
+    SECTION(
+        "cancel_transaction() from within notification ends the write transaction started by begin_transaction()") {
         token = results.add_notification_callback([&](CollectionChangeSet, std::exception_ptr err) {
             REQUIRE_FALSE(err);
             if (r->is_in_transaction())
@@ -829,8 +777,7 @@ TEST_CASE("notifications: async delivery")
     }
 }
 
-TEST_CASE("notifications: skip")
-{
+TEST_CASE("notifications: skip") {
     _impl::RealmCoordinator::assert_no_open_realms();
 
     InMemoryTestFile config;
@@ -879,8 +826,7 @@ TEST_CASE("notifications: skip")
     CollectionChangeSet changes1;
     auto token1 = add_callback(results, calls1, changes1);
 
-    SECTION("no notification is sent when only callback is skipped")
-    {
+    SECTION("no notification is sent when only callback is skipped") {
         advance_and_notify(*r);
         REQUIRE(calls1 == 1);
 
@@ -891,8 +837,7 @@ TEST_CASE("notifications: skip")
         REQUIRE(changes1.empty());
     }
 
-    SECTION("unskipped tokens for the same Results are still delivered")
-    {
+    SECTION("unskipped tokens for the same Results are still delivered") {
         int calls2 = 0;
         CollectionChangeSet changes2;
         auto token2 = add_callback(results, calls2, changes2);
@@ -910,8 +855,7 @@ TEST_CASE("notifications: skip")
         REQUIRE_INDICES(changes2.insertions, 10);
     }
 
-    SECTION("unskipped tokens for different Results are still delivered")
-    {
+    SECTION("unskipped tokens for different Results are still delivered") {
         Results results2(r, table->where());
         int calls2 = 0;
         CollectionChangeSet changes2;
@@ -930,8 +874,7 @@ TEST_CASE("notifications: skip")
         REQUIRE_INDICES(changes2.insertions, 10);
     }
 
-    SECTION("additional commits which occur before calculation are merged in")
-    {
+    SECTION("additional commits which occur before calculation are merged in") {
         int calls2 = 0;
         CollectionChangeSet changes2;
         auto token2 = add_callback(results, calls2, changes2);
@@ -950,8 +893,7 @@ TEST_CASE("notifications: skip")
         REQUIRE_INDICES(changes2.insertions, 10, 11);
     }
 
-    SECTION("additional commits which occur before delivery are merged in")
-    {
+    SECTION("additional commits which occur before delivery are merged in") {
         int calls2 = 0;
         CollectionChangeSet changes2;
         auto token2 = add_callback(results, calls2, changes2);
@@ -971,21 +913,20 @@ TEST_CASE("notifications: skip")
         REQUIRE_INDICES(changes2.insertions, 10, 11);
     }
 
-    SECTION("skipping must be done from within a write transaction")
-    {
+    SECTION("skipping must be done from within a write transaction") {
         REQUIRE_THROWS(token1.suppress_next());
     }
 
-    SECTION("skipping must be done from the Realm's thread")
-    {
+    SECTION("skipping must be done from the Realm's thread") {
         advance_and_notify(*r);
         r->begin_transaction();
-        std::thread([&] { REQUIRE_THROWS(token1.suppress_next()); }).join();
+        std::thread([&] {
+            REQUIRE_THROWS(token1.suppress_next());
+        }).join();
         r->cancel_transaction();
     }
 
-    SECTION("new notifiers do not interfere with skipping")
-    {
+    SECTION("new notifiers do not interfere with skipping") {
         advance_and_notify(*r);
         REQUIRE(calls1 == 1);
 
@@ -1025,8 +966,7 @@ TEST_CASE("notifications: skip")
         REQUIRE(calls4 == 1);
     }
 
-    SECTION("skipping only effects the current transaction even if no notification would occur anyway")
-    {
+    SECTION("skipping only effects the current transaction even if no notification would occur anyway") {
         advance_and_notify(*r);
         REQUIRE(calls1 == 1);
 
@@ -1045,8 +985,7 @@ TEST_CASE("notifications: skip")
         REQUIRE(calls1 == 2);
     }
 
-    SECTION("removing skipped notifier before it gets the chance to run")
-    {
+    SECTION("removing skipped notifier before it gets the chance to run") {
         advance_and_notify(*r);
         REQUIRE(calls1 == 1);
 
@@ -1067,8 +1006,7 @@ TEST_CASE("notifications: skip")
         REQUIRE(calls1 == 2);
     }
 
-    SECTION("skipping every write in a loop with spurious background runs works")
-    {
+    SECTION("skipping every write in a loop with spurious background runs works") {
         advance_and_notify(*r);
         REQUIRE(calls1 == 1);
 
@@ -1090,8 +1028,7 @@ TEST_CASE("notifications: skip")
     }
 }
 
-TEST_CASE("notifications: TableView delivery")
-{
+TEST_CASE("notifications: TableView delivery") {
     _impl::RealmCoordinator::assert_no_open_realms();
 
     InMemoryTestFile config;
@@ -1115,8 +1052,7 @@ TEST_CASE("notifications: TableView delivery")
     Results results(r, table->where());
     results.set_update_policy(Results::UpdatePolicy::AsyncOnly);
 
-    SECTION("Initial run never happens with no callbacks")
-    {
+    SECTION("Initial run never happens with no callbacks") {
         advance_and_notify(*r);
         REQUIRE(results.get_mode() == Results::Mode::Query);
     }
@@ -1141,35 +1077,30 @@ TEST_CASE("notifications: TableView delivery")
         r2->commit_transaction();
     };
 
-    SECTION("does not update after local change with no on_change")
-    {
+    SECTION("does not update after local change with no on_change") {
         make_local_change();
         REQUIRE(results.size() == 0);
     }
 
-    SECTION("TV is delivered when no commit is made")
-    {
+    SECTION("TV is delivered when no commit is made") {
         advance_and_notify(*r);
         REQUIRE(results.get_mode() == Results::Mode::TableView);
         REQUIRE(results.size() == 10);
     }
 
-    SECTION("TV is not delivered when notifier version > local version")
-    {
+    SECTION("TV is not delivered when notifier version > local version") {
         make_remote_change();
         r->refresh();
         REQUIRE(results.size() == 0);
     }
 
-    SECTION("TV is delivered when notifier version = local version")
-    {
+    SECTION("TV is delivered when notifier version = local version") {
         make_remote_change();
         advance_and_notify(*r);
         REQUIRE(results.size() == 11);
     }
 
-    SECTION("TV is delivered when previous TV wasn't used due to never refreshing")
-    {
+    SECTION("TV is delivered when previous TV wasn't used due to never refreshing") {
         // These two generate TVs that never get used
         make_remote_change();
         on_change_but_no_notify(*r);
@@ -1184,8 +1115,7 @@ TEST_CASE("notifications: TableView delivery")
         REQUIRE(results.size() == 13);
     }
 
-    SECTION("TV is not delivered when main thread refreshed but previous TV was not used")
-    {
+    SECTION("TV is not delivered when main thread refreshed but previous TV was not used") {
         // First run generates a TV that's unused
         make_remote_change();
         advance_and_notify(*r);
@@ -1207,10 +1137,8 @@ TEST_CASE("notifications: TableView delivery")
         REQUIRE(results.size() == 0);
     }
 
-    SECTION("TV can't be delivered in a write transaction")
-    {
-        SECTION("no changes")
-        {
+    SECTION("TV can't be delivered in a write transaction") {
+        SECTION("no changes") {
             make_remote_change();
             advance_and_notify(*r);
             r->begin_transaction();
@@ -1218,8 +1146,7 @@ TEST_CASE("notifications: TableView delivery")
             r->cancel_transaction();
         }
 
-        SECTION("local change with automatic updates disabled")
-        {
+        SECTION("local change with automatic updates disabled") {
             advance_and_notify(*r);
             REQUIRE(results.size() == 10);
             make_remote_change();
@@ -1231,8 +1158,7 @@ TEST_CASE("notifications: TableView delivery")
             r->cancel_transaction();
         }
 
-        SECTION("local change with automatic updates enabled")
-        {
+        SECTION("local change with automatic updates enabled") {
             // Use a new Results because AsyncOnly leaves the Results in a
             // weird state and switching back to Auto doesn't work.
             Results results(r, table->where());
@@ -1250,8 +1176,7 @@ TEST_CASE("notifications: TableView delivery")
         }
     }
 
-    SECTION("unused background TVs do not pin old versions forever")
-    {
+    SECTION("unused background TVs do not pin old versions forever") {
         // This will exceed the maximum active version count (5) if any
         // transactions are being pinned, resulting in make_remote_change() throwing
         for (int i = 0; i < 10; ++i) {
@@ -1263,8 +1188,7 @@ TEST_CASE("notifications: TableView delivery")
 
 
 #if REALM_PLATFORM_APPLE && NOTIFIER_BACKGROUND_ERRORS
-TEST_CASE("notifications: async error handling")
-{
+TEST_CASE("notifications: async error handling") {
     _impl::RealmCoordinator::assert_no_open_realms();
 
     InMemoryTestFile config;
@@ -1304,8 +1228,7 @@ TEST_CASE("notifications: async error handling")
         rlimit m_old;
     };
 
-    SECTION("error when opening the advancer SG")
-    {
+    SECTION("error when opening the advancer SG") {
         OpenFileLimiter limiter;
 
         bool called = false;
@@ -1316,16 +1239,14 @@ TEST_CASE("notifications: async error handling")
         });
         REQUIRE(!called);
 
-        SECTION("error is delivered on notify() without changes")
-        {
+        SECTION("error is delivered on notify() without changes") {
             coordinator->on_change();
             REQUIRE(!called);
             r->notify();
             REQUIRE(called);
         }
 
-        SECTION("error is delivered on notify() with changes")
-        {
+        SECTION("error is delivered on notify() with changes") {
             r2->begin_transaction();
             r2->commit_transaction();
             REQUIRE(!called);
@@ -1335,16 +1256,14 @@ TEST_CASE("notifications: async error handling")
             REQUIRE(called);
         }
 
-        SECTION("error is delivered on refresh() without changes")
-        {
+        SECTION("error is delivered on refresh() without changes") {
             coordinator->on_change();
             REQUIRE(!called);
             r->refresh();
             REQUIRE(called);
         }
 
-        SECTION("error is delivered on refresh() with changes")
-        {
+        SECTION("error is delivered on refresh() with changes") {
             r2->begin_transaction();
             r2->commit_transaction();
             REQUIRE(!called);
@@ -1354,8 +1273,7 @@ TEST_CASE("notifications: async error handling")
             REQUIRE(called);
         }
 
-        SECTION("error is delivered on begin_transaction() without changes")
-        {
+        SECTION("error is delivered on begin_transaction() without changes") {
             coordinator->on_change();
             REQUIRE(!called);
             r->begin_transaction();
@@ -1363,8 +1281,7 @@ TEST_CASE("notifications: async error handling")
             r->cancel_transaction();
         }
 
-        SECTION("error is delivered on begin_transaction() with changes")
-        {
+        SECTION("error is delivered on begin_transaction() with changes") {
             r2->begin_transaction();
             r2->commit_transaction();
             REQUIRE(!called);
@@ -1375,8 +1292,7 @@ TEST_CASE("notifications: async error handling")
             r->cancel_transaction();
         }
 
-        SECTION("adding another callback sends the error to only the newly added one")
-        {
+        SECTION("adding another callback sends the error to only the newly added one") {
             advance_and_notify(*r);
             REQUIRE(called);
 
@@ -1391,8 +1307,7 @@ TEST_CASE("notifications: async error handling")
             REQUIRE(called2);
         }
 
-        SECTION("destroying a token from before the error does not remove newly added callbacks")
-        {
+        SECTION("destroying a token from before the error does not remove newly added callbacks") {
             advance_and_notify(*r);
 
             bool called = false;
@@ -1407,8 +1322,7 @@ TEST_CASE("notifications: async error handling")
             REQUIRE(called);
         }
 
-        SECTION("adding another callback from within an error callback defers delivery")
-        {
+        SECTION("adding another callback from within an error callback defers delivery") {
             NotificationToken token2;
             token = results.add_notification_callback([&](CollectionChangeSet, std::exception_ptr) {
                 token2 = results.add_notification_callback([&](CollectionChangeSet, std::exception_ptr err) {
@@ -1423,8 +1337,7 @@ TEST_CASE("notifications: async error handling")
             REQUIRE(called);
         }
 
-        SECTION("adding a callback to a different collection from within the error callback defers delivery")
-        {
+        SECTION("adding a callback to a different collection from within the error callback defers delivery") {
             auto results2 = results;
             NotificationToken token2;
             token = results.add_notification_callback([&](CollectionChangeSet, std::exception_ptr) {
@@ -1441,10 +1354,8 @@ TEST_CASE("notifications: async error handling")
         }
     }
 
-    SECTION("error when opening the executor SG")
-    {
-        SECTION("error is delivered asynchronously")
-        {
+    SECTION("error when opening the executor SG") {
+        SECTION("error is delivered asynchronously") {
             bool called = false;
             auto token = results.add_notification_callback([&](CollectionChangeSet, std::exception_ptr err) {
                 REQUIRE(err);
@@ -1459,8 +1370,7 @@ TEST_CASE("notifications: async error handling")
             REQUIRE(called);
         }
 
-        SECTION("adding another callback only sends the error to the new one")
-        {
+        SECTION("adding another callback only sends the error to the new one") {
             bool called = false;
             auto token = results.add_notification_callback([&](CollectionChangeSet, std::exception_ptr err) {
                 REQUIRE(err);
@@ -1487,8 +1397,7 @@ TEST_CASE("notifications: async error handling")
 #endif
 
 #if REALM_ENABLE_SYNC
-TEST_CASE("notifications: sync")
-{
+TEST_CASE("notifications: sync") {
     _impl::RealmCoordinator::assert_no_open_realms();
 
     TestSyncManager init_sync_manager({}, {false});
@@ -1504,8 +1413,7 @@ TEST_CASE("notifications: sync")
          }},
     };
 
-    SECTION("sync progress commits do not distrupt notifications")
-    {
+    SECTION("sync progress commits do not distrupt notifications") {
         auto r = Realm::get_shared_realm(config);
         auto wait_realm = Realm::get_shared_realm(config);
 
@@ -1538,8 +1446,7 @@ TEST_CASE("notifications: sync")
 }
 #endif
 
-TEST_CASE("notifications: results")
-{
+TEST_CASE("notifications: results") {
     _impl::RealmCoordinator::assert_no_open_realms();
 
     InMemoryTestFile config;
@@ -1574,8 +1481,7 @@ TEST_CASE("notifications: results")
 
     Results results(r, table->where().greater(col_value, 0).less(col_value, 10));
 
-    SECTION("unsorted notifications")
-    {
+    SECTION("unsorted notifications") {
         int notification_calls = 0;
         CollectionChangeSet change;
         auto token = results.add_notification_callback([&](CollectionChangeSet c, std::exception_ptr err) {
@@ -1593,32 +1499,35 @@ TEST_CASE("notifications: results")
             advance_and_notify(*r);
         };
 
-        SECTION("modifications to unrelated tables do not send notifications")
-        {
-            write([&] { r->read_group().get_table("class_other object")->create_object(); });
+        SECTION("modifications to unrelated tables do not send notifications") {
+            write([&] {
+                r->read_group().get_table("class_other object")->create_object();
+            });
             REQUIRE(notification_calls == 1);
         }
 
-        SECTION("irrelevant modifications to linked tables do not send notifications")
-        {
-            write([&] { r->read_group().get_table("class_linked to object")->create_object(); });
+        SECTION("irrelevant modifications to linked tables do not send notifications") {
+            write([&] {
+                r->read_group().get_table("class_linked to object")->create_object();
+            });
             REQUIRE(notification_calls == 1);
         }
 
-        SECTION("irrelevant modifications to linking tables do not send notifications")
-        {
-            write([&] { r->read_group().get_table("class_linking object")->create_object(); });
+        SECTION("irrelevant modifications to linking tables do not send notifications") {
+            write([&] {
+                r->read_group().get_table("class_linking object")->create_object();
+            });
             REQUIRE(notification_calls == 1);
         }
 
-        SECTION("modifications that leave a non-matching row non-matching do not send notifications")
-        {
-            write([&] { table->get_object(object_keys[6]).set(col_value, 13); });
+        SECTION("modifications that leave a non-matching row non-matching do not send notifications") {
+            write([&] {
+                table->get_object(object_keys[6]).set(col_value, 13);
+            });
             REQUIRE(notification_calls == 1);
         }
 
-        SECTION("deleting non-matching rows does not send a notification")
-        {
+        SECTION("deleting non-matching rows does not send a notification") {
             write([&] {
                 table->remove_object(object_keys[0]);
                 table->remove_object(object_keys[6]);
@@ -1626,39 +1535,42 @@ TEST_CASE("notifications: results")
             REQUIRE(notification_calls == 1);
         }
 
-        SECTION("modifying a matching row and leaving it matching marks that row as modified")
-        {
-            write([&] { table->get_object(object_keys[1]).set(col_value, 3); });
+        SECTION("modifying a matching row and leaving it matching marks that row as modified") {
+            write([&] {
+                table->get_object(object_keys[1]).set(col_value, 3);
+            });
             REQUIRE(notification_calls == 2);
             REQUIRE_INDICES(change.modifications, 0);
             REQUIRE_INDICES(change.modifications_new, 0);
         }
 
-        SECTION("modifying a matching row to no longer match marks that row as deleted")
-        {
-            write([&] { table->get_object(object_keys[2]).set(col_value, 0); });
+        SECTION("modifying a matching row to no longer match marks that row as deleted") {
+            write([&] {
+                table->get_object(object_keys[2]).set(col_value, 0);
+            });
             REQUIRE(notification_calls == 2);
             REQUIRE_INDICES(change.deletions, 1);
         }
 
-        SECTION("modifying a non-matching row to match marks that row as inserted, but not modified")
-        {
-            write([&] { table->get_object(object_keys[7]).set(col_value, 3); });
+        SECTION("modifying a non-matching row to match marks that row as inserted, but not modified") {
+            write([&] {
+                table->get_object(object_keys[7]).set(col_value, 3);
+            });
             REQUIRE(notification_calls == 2);
             REQUIRE_INDICES(change.insertions, 4);
             REQUIRE(change.modifications.empty());
             REQUIRE(change.modifications_new.empty());
         }
 
-        SECTION("deleting a matching row marks that row as deleted")
-        {
-            write([&] { table->remove_object(object_keys[3]); });
+        SECTION("deleting a matching row marks that row as deleted") {
+            write([&] {
+                table->remove_object(object_keys[3]);
+            });
             REQUIRE(notification_calls == 2);
             REQUIRE_INDICES(change.deletions, 2);
         }
 
-        SECTION("modifications from multiple transactions are collapsed")
-        {
+        SECTION("modifications from multiple transactions are collapsed") {
             r2->begin_transaction();
             r2_table->get_object(object_keys[0]).set(col_value, 6);
             r2->commit_transaction();
@@ -1675,8 +1587,7 @@ TEST_CASE("notifications: results")
             REQUIRE(notification_calls == 2);
         }
 
-        SECTION("inserting a row then modifying it in a second transaction does not report it as modified")
-        {
+        SECTION("inserting a row then modifying it in a second transaction does not report it as modified") {
             r2->begin_transaction();
             ObjKey k = r2_table->create_object(ObjKey(53)).set(col_value, 6).get_key();
             r2->commit_transaction();
@@ -1695,8 +1606,7 @@ TEST_CASE("notifications: results")
             REQUIRE(change.modifications_new.empty());
         }
 
-        SECTION("modification indices are pre-insert/delete")
-        {
+        SECTION("modification indices are pre-insert/delete") {
             r->begin_transaction();
             table->get_object(object_keys[2]).set(col_value, 0);
             table->get_object(object_keys[3]).set(col_value, 6);
@@ -1709,8 +1619,7 @@ TEST_CASE("notifications: results")
             REQUIRE_INDICES(change.modifications_new, 1);
         }
 
-        SECTION("notifications are not delivered when collapsing transactions results in no net change")
-        {
+        SECTION("notifications are not delivered when collapsing transactions results in no net change") {
             r2->begin_transaction();
             ObjKey k = r2_table->create_object().set(col_value, 5).get_key();
             r2->commit_transaction();
@@ -1727,21 +1636,22 @@ TEST_CASE("notifications: results")
             REQUIRE(notification_calls == 1);
         }
 
-        SECTION("inserting a non-matching row at the beginning does not produce a notification")
-        {
-            write([&] { table->create_object(ObjKey(1)); });
+        SECTION("inserting a non-matching row at the beginning does not produce a notification") {
+            write([&] {
+                table->create_object(ObjKey(1));
+            });
             REQUIRE(notification_calls == 1);
         }
 
-        SECTION("inserting a matching row at the beginning marks just it as inserted")
-        {
-            write([&] { table->create_object(ObjKey(0)).set(col_value, 5); });
+        SECTION("inserting a matching row at the beginning marks just it as inserted") {
+            write([&] {
+                table->create_object(ObjKey(0)).set(col_value, 5);
+            });
             REQUIRE(notification_calls == 2);
             REQUIRE_INDICES(change.insertions, 0);
         }
 
-        SECTION("modification to related table not included in query")
-        {
+        SECTION("modification to related table not included in query") {
             write([&] {
                 auto table = r->read_group().get_table("class_linked to object");
                 auto col = table->get_column_key("value");
@@ -1753,8 +1663,7 @@ TEST_CASE("notifications: results")
         }
     }
 
-    SECTION("before/after change callback")
-    {
+    SECTION("before/after change callback") {
         struct Callback {
             size_t before_calls = 0;
             size_t after_calls = 0;
@@ -1783,8 +1692,7 @@ TEST_CASE("notifications: results")
         auto token = results.add_notification_callback(&callback);
         advance_and_notify(*r);
 
-        SECTION("only after() is called for initial results")
-        {
+        SECTION("only after() is called for initial results") {
             REQUIRE(callback.before_calls == 0);
             REQUIRE(callback.after_calls == 1);
             REQUIRE(callback.after_change.empty());
@@ -1797,43 +1705,45 @@ TEST_CASE("notifications: results")
             advance_and_notify(*r);
         };
 
-        SECTION("both are called after a write")
-        {
-            write([&](auto&& t) { t.create_object(ObjKey(53)).set(col_value, 5); });
+        SECTION("both are called after a write") {
+            write([&](auto&& t) {
+                t.create_object(ObjKey(53)).set(col_value, 5);
+            });
             REQUIRE(callback.before_calls == 1);
             REQUIRE(callback.after_calls == 2);
             REQUIRE_INDICES(callback.before_change.insertions, 4);
             REQUIRE_INDICES(callback.after_change.insertions, 4);
         }
 
-        SECTION("deleted objects are usable in before()")
-        {
+        SECTION("deleted objects are usable in before()") {
             callback.on_before = [&] {
                 REQUIRE(results.size() == 4);
                 REQUIRE_INDICES(callback.before_change.deletions, 0);
                 REQUIRE(results.get(0).is_valid());
                 REQUIRE(results.get(0).get<int64_t>(col_value) == 2);
             };
-            write([&](auto&& t) { t.remove_object(results.get(0).get_key()); });
+            write([&](auto&& t) {
+                t.remove_object(results.get(0).get_key());
+            });
             REQUIRE(callback.before_calls == 1);
             REQUIRE(callback.after_calls == 2);
         }
 
-        SECTION("inserted objects are usable in after()")
-        {
+        SECTION("inserted objects are usable in after()") {
             callback.on_after = [&] {
                 REQUIRE(results.size() == 5);
                 REQUIRE_INDICES(callback.after_change.insertions, 4);
                 REQUIRE(results.last()->get<int64_t>(col_value) == 5);
             };
-            write([&](auto&& t) { t.create_object(ObjKey(53)).set(col_value, 5); });
+            write([&](auto&& t) {
+                t.create_object(ObjKey(53)).set(col_value, 5);
+            });
             REQUIRE(callback.before_calls == 1);
             REQUIRE(callback.after_calls == 2);
         }
     }
 
-    SECTION("sorted notifications")
-    {
+    SECTION("sorted notifications") {
         // Sort in descending order
         results = results.sort({{{col_value}}, {false}});
 
@@ -1854,14 +1764,14 @@ TEST_CASE("notifications: results")
             advance_and_notify(*r);
         };
 
-        SECTION("modifications that leave a non-matching row non-matching do not send notifications")
-        {
-            write([&] { table->get_object(object_keys[6]).set(col_value, 13); });
+        SECTION("modifications that leave a non-matching row non-matching do not send notifications") {
+            write([&] {
+                table->get_object(object_keys[6]).set(col_value, 13);
+            });
             REQUIRE(notification_calls == 1);
         }
 
-        SECTION("deleting non-matching rows does not send a notification")
-        {
+        SECTION("deleting non-matching rows does not send a notification") {
             write([&] {
                 table->remove_object(object_keys[0]);
                 table->remove_object(object_keys[6]);
@@ -1869,47 +1779,53 @@ TEST_CASE("notifications: results")
             REQUIRE(notification_calls == 1);
         }
 
-        SECTION("modifying a matching row and leaving it matching marks that row as modified")
-        {
-            write([&] { table->get_object(object_keys[1]).set(col_value, 3); });
+        SECTION("modifying a matching row and leaving it matching marks that row as modified") {
+            write([&] {
+                table->get_object(object_keys[1]).set(col_value, 3);
+            });
             REQUIRE(notification_calls == 2);
             REQUIRE_INDICES(change.modifications, 3);
             REQUIRE_INDICES(change.modifications_new, 3);
         }
 
-        SECTION("modifying a matching row to no longer match marks that row as deleted")
-        {
-            write([&] { table->get_object(object_keys[2]).set(col_value, 0); });
+        SECTION("modifying a matching row to no longer match marks that row as deleted") {
+            write([&] {
+                table->get_object(object_keys[2]).set(col_value, 0);
+            });
             REQUIRE(notification_calls == 2);
             REQUIRE_INDICES(change.deletions, 2);
         }
 
-        SECTION("modifying a non-matching row to match marks that row as inserted")
-        {
-            write([&] { table->get_object(object_keys[7]).set(col_value, 3); });
+        SECTION("modifying a non-matching row to match marks that row as inserted") {
+            write([&] {
+                table->get_object(object_keys[7]).set(col_value, 3);
+            });
             REQUIRE(notification_calls == 2);
             REQUIRE_INDICES(change.insertions, 3);
         }
 
-        SECTION("deleting a matching row marks that row as deleted")
-        {
-            write([&] { table->remove_object(object_keys[3]); });
+        SECTION("deleting a matching row marks that row as deleted") {
+            write([&] {
+                table->remove_object(object_keys[3]);
+            });
             REQUIRE(notification_calls == 2);
             REQUIRE_INDICES(change.deletions, 1);
         }
 
-        SECTION("clearing the table marks all rows as deleted")
-        {
+        SECTION("clearing the table marks all rows as deleted") {
             size_t num_expected_deletes = results.size();
-            write([&] { table->clear(); });
+            write([&] {
+                table->clear();
+            });
             REQUIRE(notification_calls == 2);
             REQUIRE(change.deletions.count() == num_expected_deletes);
         }
 
-        SECTION("clear insert clear marks the correct rows as deleted")
-        {
+        SECTION("clear insert clear marks the correct rows as deleted") {
             size_t num_expected_deletes = results.size();
-            write([&] { table->clear(); });
+            write([&] {
+                table->clear();
+            });
             REQUIRE(notification_calls == 2);
             REQUIRE(change.deletions.count() == num_expected_deletes);
             write([&] {
@@ -1920,15 +1836,16 @@ TEST_CASE("notifications: results")
             REQUIRE(notification_calls == 3);
             REQUIRE_INDICES(change.insertions, 0, 1, 2);
             REQUIRE(change.deletions.empty());
-            write([&] { table->clear(); });
+            write([&] {
+                table->clear();
+            });
             REQUIRE(notification_calls == 4);
             REQUIRE_INDICES(change.deletions, 0, 1, 2);
             REQUIRE(change.insertions.empty());
             REQUIRE(change.modifications.empty());
         }
 
-        SECTION("delete insert clear marks the correct rows as deleted")
-        {
+        SECTION("delete insert clear marks the correct rows as deleted") {
             size_t num_expected_deletes = results.size();
             write([&] {
                 results.clear(); // delete all 4 matches
@@ -1943,23 +1860,25 @@ TEST_CASE("notifications: results")
             REQUIRE(notification_calls == 3);
             REQUIRE_INDICES(change.insertions, 0, 1, 2);
             REQUIRE(change.deletions.empty());
-            write([&] { table->clear(); });
+            write([&] {
+                table->clear();
+            });
             REQUIRE(notification_calls == 4);
             REQUIRE_INDICES(change.deletions, 0, 1, 2);
             REQUIRE(change.insertions.empty());
             REQUIRE(change.modifications.empty());
         }
 
-        SECTION("modifying a matching row to change its position sends insert+delete")
-        {
-            write([&] { table->get_object(object_keys[2]).set(col_value, 9); });
+        SECTION("modifying a matching row to change its position sends insert+delete") {
+            write([&] {
+                table->get_object(object_keys[2]).set(col_value, 9);
+            });
             REQUIRE(notification_calls == 2);
             REQUIRE_INDICES(change.deletions, 2);
             REQUIRE_INDICES(change.insertions, 0);
         }
 
-        SECTION("modifications from multiple transactions are collapsed")
-        {
+        SECTION("modifications from multiple transactions are collapsed") {
             r2->begin_transaction();
             r2_table->get_object(object_keys[0]).set(col_value, 5);
             r2->commit_transaction();
@@ -1973,8 +1892,7 @@ TEST_CASE("notifications: results")
             REQUIRE(notification_calls == 2);
         }
 
-        SECTION("moving a matching row by deleting all other rows")
-        {
+        SECTION("moving a matching row by deleting all other rows") {
             r->begin_transaction();
             table->clear();
             ObjKey k0 = table->create_object().set(col_value, 15).get_key();
@@ -1993,8 +1911,7 @@ TEST_CASE("notifications: results")
         }
     }
 
-    SECTION("distinct notifications")
-    {
+    SECTION("distinct notifications") {
         results = results.distinct(DistinctDescriptor({{col_value}}));
 
         int notification_calls = 0;
@@ -2014,14 +1931,14 @@ TEST_CASE("notifications: results")
             advance_and_notify(*r);
         };
 
-        SECTION("modifications that leave a non-matching row non-matching do not send notifications")
-        {
-            write([&] { table->get_object(object_keys[6]).set(col_value, 13); });
+        SECTION("modifications that leave a non-matching row non-matching do not send notifications") {
+            write([&] {
+                table->get_object(object_keys[6]).set(col_value, 13);
+            });
             REQUIRE(notification_calls == 1);
         }
 
-        SECTION("deleting non-matching rows does not send a notification")
-        {
+        SECTION("deleting non-matching rows does not send a notification") {
             write([&] {
                 table->remove_object(object_keys[0]);
                 table->remove_object(object_keys[6]);
@@ -2029,47 +1946,51 @@ TEST_CASE("notifications: results")
             REQUIRE(notification_calls == 1);
         }
 
-        SECTION("modifying a matching row and leaving it matching marks that row as modified")
-        {
-            write([&] { table->get_object(object_keys[1]).set(col_value, 3); });
+        SECTION("modifying a matching row and leaving it matching marks that row as modified") {
+            write([&] {
+                table->get_object(object_keys[1]).set(col_value, 3);
+            });
             REQUIRE(notification_calls == 2);
             REQUIRE_INDICES(change.modifications, 0);
             REQUIRE_INDICES(change.modifications_new, 0);
         }
 
         SECTION("modifying a non-matching row which is after the distinct results in the table to be a same value \
-                in the distinct results doesn't send notification.")
-        {
-            write([&] { table->get_object(object_keys[6]).set(col_value, 2); });
+                in the distinct results doesn't send notification.") {
+            write([&] {
+                table->get_object(object_keys[6]).set(col_value, 2);
+            });
             REQUIRE(notification_calls == 1);
         }
 
         SECTION("modifying a non-matching row which is before the distinct results in the table to be a same value \
-                in the distinct results send insert + delete.")
-        {
-            write([&] { table->get_object(object_keys[0]).set(col_value, 2); });
+                in the distinct results send insert + delete.") {
+            write([&] {
+                table->get_object(object_keys[0]).set(col_value, 2);
+            });
             REQUIRE(notification_calls == 2);
             REQUIRE_INDICES(change.deletions, 0);
             REQUIRE_INDICES(change.insertions, 0);
         }
 
-        SECTION("modifying a matching row to duplicated value in distinct results marks that row as deleted")
-        {
-            write([&] { table->get_object(object_keys[2]).set(col_value, 2); });
+        SECTION("modifying a matching row to duplicated value in distinct results marks that row as deleted") {
+            write([&] {
+                table->get_object(object_keys[2]).set(col_value, 2);
+            });
             REQUIRE(notification_calls == 2);
             REQUIRE_INDICES(change.deletions, 1);
         }
 
-        SECTION("modifying a non-matching row to match and different value marks that row as inserted")
-        {
-            write([&] { table->get_object(object_keys[0]).set(col_value, 1); });
+        SECTION("modifying a non-matching row to match and different value marks that row as inserted") {
+            write([&] {
+                table->get_object(object_keys[0]).set(col_value, 1);
+            });
             REQUIRE(notification_calls == 2);
             REQUIRE_INDICES(change.insertions, 0);
         }
     }
 
-    SECTION("schema changes")
-    {
+    SECTION("schema changes") {
         CollectionChangeSet change;
         auto token = results.add_notification_callback([&](CollectionChangeSet c, std::exception_ptr err) {
             REQUIRE_FALSE(err);
@@ -2084,8 +2005,7 @@ TEST_CASE("notifications: results")
             advance_and_notify(*r);
         };
 
-        SECTION("insert table before observed table")
-        {
+        SECTION("insert table before observed table") {
             write([&] {
                 table->create_object(ObjKey(53)).set(col_value, 5);
                 r->read_group().add_table("new table");
@@ -2096,8 +2016,7 @@ TEST_CASE("notifications: results")
 
         auto linked_table = table->get_link_target(col_link);
         auto col = linked_table->get_column_key("value");
-        SECTION("insert new column before link column")
-        {
+        SECTION("insert new column before link column") {
             write([&] {
                 linked_table->get_object(target_keys[1]).set(col, 5);
                 table->add_column(type_Int, "new col");
@@ -2106,8 +2025,7 @@ TEST_CASE("notifications: results")
             REQUIRE_INDICES(change.modifications, 0, 1);
         }
 #ifdef UNITTESTS_NOT_PARSING
-        SECTION("insert table before link target")
-        {
+        SECTION("insert table before link target") {
             write([&] {
                 linked_table->get_object(target_keys[1]).set(col, 5);
                 r->read_group().add_table("new table");
@@ -2119,8 +2037,7 @@ TEST_CASE("notifications: results")
     }
 }
 
-TEST_CASE("results: notifications after move")
-{
+TEST_CASE("results: notifications after move") {
     InMemoryTestFile config;
     config.automatic_change_notifications = false;
 
@@ -2150,28 +2067,29 @@ TEST_CASE("results: notifications after move")
         advance_and_notify(*r);
     };
 
-    SECTION("notifications continue to work after Results is moved (move-constructor)")
-    {
+    SECTION("notifications continue to work after Results is moved (move-constructor)") {
         Results r(std::move(*results));
         results.reset();
 
-        write([&] { table->create_object().set_all(1); });
+        write([&] {
+            table->create_object().set_all(1);
+        });
         REQUIRE(notification_calls == 2);
     }
 
-    SECTION("notifications continue to work after Results is moved (move-assignment)")
-    {
+    SECTION("notifications continue to work after Results is moved (move-assignment)") {
         Results r;
         r = std::move(*results);
         results.reset();
 
-        write([&] { table->create_object().set_all(1); });
+        write([&] {
+            table->create_object().set_all(1);
+        });
         REQUIRE(notification_calls == 2);
     }
 }
 
-TEST_CASE("results: notifier with no callbacks")
-{
+TEST_CASE("results: notifier with no callbacks") {
     _impl::RealmCoordinator::assert_no_open_realms();
 
     InMemoryTestFile config;
@@ -2191,8 +2109,7 @@ TEST_CASE("results: notifier with no callbacks")
     Results results(r, table->where());
     results.last(); // force evaluation and creation of TableView
 
-    SECTION("refresh() does not block due to implicit notifier")
-    {
+    SECTION("refresh() does not block due to implicit notifier") {
         // Create and then immediately remove a callback because
         // `automatic_change_notifications = false` makes Results not implicitly
         // create a notifier
@@ -2206,8 +2123,7 @@ TEST_CASE("results: notifier with no callbacks")
         r->refresh(); // would deadlock if there was a callback
     }
 
-    SECTION("refresh() does not attempt to deliver stale results")
-    {
+    SECTION("refresh() does not attempt to deliver stale results") {
         results.add_notification_callback([](CollectionChangeSet const&, std::exception_ptr) {});
 
         // Create version 1
@@ -2227,8 +2143,7 @@ TEST_CASE("results: notifier with no callbacks")
         r->refresh();
     }
 
-    SECTION("should not pin the source version even after the Realm has been closed")
-    {
+    SECTION("should not pin the source version even after the Realm has been closed") {
         auto r2 = coordinator->get_realm();
         REQUIRE(r != r2);
         r->close();
@@ -2252,8 +2167,7 @@ TEST_CASE("results: notifier with no callbacks")
     }
 }
 
-TEST_CASE("results: error messages")
-{
+TEST_CASE("results: error messages") {
     InMemoryTestFile config;
     config.schema = Schema{
         {"object",
@@ -2270,20 +2184,17 @@ TEST_CASE("results: error messages")
     table->create_object();
     r->commit_transaction();
 
-    SECTION("out of bounds access")
-    {
+    SECTION("out of bounds access") {
         REQUIRE_THROWS_WITH(results.get(5), "Requested index 5 greater than max 0");
     }
 
-    SECTION("unsupported aggregate operation")
-    {
+    SECTION("unsupported aggregate operation") {
         REQUIRE_THROWS_WITH(results.sum("value"),
                             "Cannot sum property 'value': operation not supported for 'string' properties");
     }
 }
 
-TEST_CASE("results: snapshots")
-{
+TEST_CASE("results: snapshots") {
     InMemoryTestFile config;
     config.cache = false;
     config.automatic_change_notifications = false;
@@ -2294,8 +2205,7 @@ TEST_CASE("results: snapshots")
 
     auto r = Realm::get_shared_realm(config);
 
-    SECTION("snapshot of empty Results")
-    {
+    SECTION("snapshot of empty Results") {
         Results results;
         auto snapshot = results.snapshot();
         REQUIRE(snapshot.size() == 0);
@@ -2308,8 +2218,7 @@ TEST_CASE("results: snapshots")
         advance_and_notify(*r);
     };
 
-    SECTION("snapshot of Results based on Table")
-    {
+    SECTION("snapshot of Results based on Table") {
         auto table = r->read_group().get_table("class_object");
         Results results(r, table);
 
@@ -2318,7 +2227,9 @@ TEST_CASE("results: snapshots")
             auto snapshot = results.snapshot();
             REQUIRE(results.size() == 0);
             REQUIRE(snapshot.size() == 0);
-            write([=] { table->create_object(); });
+            write([=] {
+                table->create_object();
+            });
             REQUIRE(results.size() == 1);
             REQUIRE(snapshot.size() == 0);
         }
@@ -2329,26 +2240,31 @@ TEST_CASE("results: snapshots")
             auto snapshot = results.snapshot();
             REQUIRE(results.size() == 1);
             REQUIRE(snapshot.size() == 1);
-            write([=] { table->begin()->remove(); });
+            write([=] {
+                table->begin()->remove();
+            });
             REQUIRE(results.size() == 0);
             REQUIRE(snapshot.size() == 1);
             REQUIRE(!snapshot.get(0).is_valid());
 
             // Adding a row at the same index that was formerly present in the snapshot shouldn't
             // affect the state of the snapshot.
-            write([=] { table->create_object(); });
+            write([=] {
+                table->create_object();
+            });
             REQUIRE(snapshot.size() == 1);
             REQUIRE(!snapshot.get(0).is_valid());
         }
     }
 
-    SECTION("snapshot of Results based on LinkView")
-    {
+    SECTION("snapshot of Results based on LinkView") {
         auto object = r->read_group().get_table("class_object");
         auto col_link = object->get_column_key("array");
         auto linked_to = r->read_group().get_table("class_linked to object");
 
-        write([=] { object->create_object(); });
+        write([=] {
+            object->create_object();
+        });
 
         std::shared_ptr<LnkLst> lv = object->begin()->get_linklist_ptr(col_link);
         Results results(r, lv);
@@ -2358,7 +2274,9 @@ TEST_CASE("results: snapshots")
             auto snapshot = results.snapshot();
             REQUIRE(results.size() == 0);
             REQUIRE(snapshot.size() == 0);
-            write([&] { lv->add(linked_to->create_object().get_key()); });
+            write([&] {
+                lv->add(linked_to->create_object().get_key());
+            });
             REQUIRE(results.size() == 1);
             REQUIRE(snapshot.size() == 0);
         }
@@ -2368,26 +2286,31 @@ TEST_CASE("results: snapshots")
             auto snapshot = results.snapshot();
             REQUIRE(results.size() == 1);
             REQUIRE(snapshot.size() == 1);
-            write([&] { lv->remove(0); });
+            write([&] {
+                lv->remove(0);
+            });
             REQUIRE(results.size() == 0);
             REQUIRE(snapshot.size() == 1);
             REQUIRE(snapshot.get(0).is_valid());
 
             // Removing a row present in the snapshot from its table should result in the snapshot
             // returning a detached row accessor.
-            write([&] { linked_to->begin()->remove(); });
+            write([&] {
+                linked_to->begin()->remove();
+            });
             REQUIRE(snapshot.size() == 1);
             REQUIRE(!snapshot.get(0).is_valid());
 
             // Adding a new row to the link list shouldn't affect the state of the snapshot.
-            write([&] { lv->add(linked_to->create_object().get_key()); });
+            write([&] {
+                lv->add(linked_to->create_object().get_key());
+            });
             REQUIRE(snapshot.size() == 1);
             REQUIRE(!snapshot.get(0).is_valid());
         }
     }
 
-    SECTION("snapshot of Results based on Query")
-    {
+    SECTION("snapshot of Results based on Query") {
         auto table = r->read_group().get_table("class_object");
         auto col_value = table->get_column_key("value");
         Query q = table->column<Int>(col_value) > 0;
@@ -2398,7 +2321,9 @@ TEST_CASE("results: snapshots")
             auto snapshot = results.snapshot();
             REQUIRE(results.size() == 0);
             REQUIRE(snapshot.size() == 0);
-            write([=] { table->create_object().set(col_value, 1); });
+            write([=] {
+                table->create_object().set(col_value, 1);
+            });
             REQUIRE(results.size() == 1);
             REQUIRE(snapshot.size() == 0);
         }
@@ -2408,26 +2333,31 @@ TEST_CASE("results: snapshots")
             auto snapshot = results.snapshot();
             REQUIRE(results.size() == 1);
             REQUIRE(snapshot.size() == 1);
-            write([=] { table->begin()->set(col_value, 0); });
+            write([=] {
+                table->begin()->set(col_value, 0);
+            });
             REQUIRE(results.size() == 0);
             REQUIRE(snapshot.size() == 1);
             REQUIRE(snapshot.get(0).is_valid());
 
             // Removing a row present in the snapshot from its table should result in the snapshot
             // returning a detached row accessor.
-            write([=] { table->begin()->remove(); });
+            write([=] {
+                table->begin()->remove();
+            });
             REQUIRE(snapshot.size() == 1);
             REQUIRE(!snapshot.get(0).is_valid());
 
             // Adding a new row that matches the query criteria shouldn't affect the state of the snapshot.
-            write([=] { table->create_object().set(col_value, 1); });
+            write([=] {
+                table->create_object().set(col_value, 1);
+            });
             REQUIRE(snapshot.size() == 1);
             REQUIRE(!snapshot.get(0).is_valid());
         }
     }
 
-    SECTION("snapshot of Results based on TableView from query")
-    {
+    SECTION("snapshot of Results based on TableView from query") {
         auto table = r->read_group().get_table("class_object");
         auto col_value = table->get_column_key("value");
         Query q = table->column<Int>(col_value) > 0;
@@ -2438,7 +2368,9 @@ TEST_CASE("results: snapshots")
             auto snapshot = results.snapshot();
             REQUIRE(results.size() == 0);
             REQUIRE(snapshot.size() == 0);
-            write([=] { table->create_object().set(col_value, 1); });
+            write([=] {
+                table->create_object().set(col_value, 1);
+            });
             REQUIRE(results.size() == 1);
             REQUIRE(snapshot.size() == 0);
         }
@@ -2448,26 +2380,31 @@ TEST_CASE("results: snapshots")
             auto snapshot = results.snapshot();
             REQUIRE(results.size() == 1);
             REQUIRE(snapshot.size() == 1);
-            write([=] { table->begin()->set(col_value, 0); });
+            write([=] {
+                table->begin()->set(col_value, 0);
+            });
             REQUIRE(results.size() == 0);
             REQUIRE(snapshot.size() == 1);
             REQUIRE(snapshot.get(0).is_valid());
 
             // Removing a row present in the snapshot from its table should result in the snapshot
             // returning a detached row accessor.
-            write([=] { table->begin()->remove(); });
+            write([=] {
+                table->begin()->remove();
+            });
             REQUIRE(snapshot.size() == 1);
             REQUIRE(!snapshot.get(0).is_valid());
 
             // Adding a new row that matches the query criteria shouldn't affect the state of the snapshot.
-            write([=] { table->create_object().set(col_value, 1); });
+            write([=] {
+                table->create_object().set(col_value, 1);
+            });
             REQUIRE(snapshot.size() == 1);
             REQUIRE(!snapshot.get(0).is_valid());
         }
     }
 
-    SECTION("snapshot of Results based on TableView from backlinks")
-    {
+    SECTION("snapshot of Results based on TableView from backlinks") {
         auto object = r->read_group().get_table("class_object");
         auto col_link = object->get_column_key("array");
         auto linked_to = r->read_group().get_table("class_linked to object");
@@ -2488,7 +2425,9 @@ TEST_CASE("results: snapshots")
             auto snapshot = results.snapshot();
             REQUIRE(results.size() == 0);
             REQUIRE(snapshot.size() == 0);
-            write([&] { lv->add(linked_to_obj.get_key()); });
+            write([&] {
+                lv->add(linked_to_obj.get_key());
+            });
             REQUIRE(results.size() == 1);
             REQUIRE(snapshot.size() == 0);
         }
@@ -2508,45 +2447,50 @@ TEST_CASE("results: snapshots")
 
             // Removing a row present in the snapshot from its table should result in the snapshot
             // returning a detached row accessor.
-            write([=] { object->begin()->remove(); });
+            write([=] {
+                object->begin()->remove();
+            });
             REQUIRE(snapshot.size() == 1);
             REQUIRE(!snapshot.get(0).is_valid());
 
             // Adding a new link shouldn't affect the state of the snapshot.
-            write([=] { object->create_object().get_linklist(col_link).add(linked_to_obj.get_key()); });
+            write([=] {
+                object->create_object().get_linklist(col_link).add(linked_to_obj.get_key());
+            });
             REQUIRE(snapshot.size() == 1);
             REQUIRE(!snapshot.get(0).is_valid());
         }
     }
 
-    SECTION("snapshot of Results with notification callback registered")
-    {
+    SECTION("snapshot of Results with notification callback registered") {
         auto table = r->read_group().get_table("class_object");
         auto col_value = table->get_column_key("value");
         Query q = table->column<Int>(col_value) > 0;
         Results results(r, q.find_all());
 
-        auto token = results.add_notification_callback(
-            [&](CollectionChangeSet, std::exception_ptr err) { REQUIRE_FALSE(err); });
+        auto token = results.add_notification_callback([&](CollectionChangeSet, std::exception_ptr err) {
+            REQUIRE_FALSE(err);
+        });
         advance_and_notify(*r);
 
-        SECTION("snapshot of lvalue")
-        {
+        SECTION("snapshot of lvalue") {
             auto snapshot = results.snapshot();
-            write([=] { table->create_object().set(col_value, 1); });
+            write([=] {
+                table->create_object().set(col_value, 1);
+            });
             REQUIRE(snapshot.size() == 0);
         }
 
-        SECTION("snapshot of rvalue")
-        {
+        SECTION("snapshot of rvalue") {
             auto snapshot = std::move(results).snapshot();
-            write([=] { table->create_object().set(col_value, 1); });
+            write([=] {
+                table->create_object().set(col_value, 1);
+            });
             REQUIRE(snapshot.size() == 0);
         }
     }
 
-    SECTION("adding notification callback to snapshot throws")
-    {
+    SECTION("adding notification callback to snapshot throws") {
         auto table = r->read_group().get_table("class_object");
         auto col_value = table->get_column_key("value");
         Query q = table->column<Int>(col_value) > 0;
@@ -2555,10 +2499,11 @@ TEST_CASE("results: snapshots")
         CHECK_THROWS(snapshot.add_notification_callback([](CollectionChangeSet, std::exception_ptr) {}));
     }
 
-    SECTION("accessors should return none for detached row")
-    {
+    SECTION("accessors should return none for detached row") {
         auto table = r->read_group().get_table("class_object");
-        write([=] { table->create_object(); });
+        write([=] {
+            table->create_object();
+        });
         Results results(r, table);
         auto snapshot = results.snapshot();
         write([=] {
@@ -2572,8 +2517,7 @@ TEST_CASE("results: snapshots")
     }
 }
 
-TEST_CASE("results: distinct")
-{
+TEST_CASE("results: distinct") {
     const int N = 10;
     InMemoryTestFile config;
     config.cache = false;
@@ -2613,8 +2557,7 @@ TEST_CASE("results: distinct")
     ColKey col_num2 = table->get_column_key("num2");
     ColKey col_num3 = table->get_column_key("num3");
 
-    SECTION("Single integer property")
-    {
+    SECTION("Single integer property") {
         Results unique = results.distinct(DistinctDescriptor({{col_num1}}));
         // unique:
         //  0, Foo_0, 10
@@ -2626,8 +2569,7 @@ TEST_CASE("results: distinct")
         REQUIRE(unique.get(2).get<Int>(col_num2) == 8);
     }
 
-    SECTION("Single integer via apply_ordering")
-    {
+    SECTION("Single integer via apply_ordering") {
         DescriptorOrdering ordering;
         ordering.append_sort(SortDescriptor({{col_num1}}));
         ordering.append_distinct(DistinctDescriptor({{col_num1}}));
@@ -2642,8 +2584,7 @@ TEST_CASE("results: distinct")
         REQUIRE(unique.get(2).get<Int>(col_num2) == 8);
     }
 
-    SECTION("Single string property")
-    {
+    SECTION("Single string property") {
         Results unique = results.distinct(DistinctDescriptor({{col_string}}));
         // unique:
         //  0, Foo_0, 10
@@ -2655,8 +2596,7 @@ TEST_CASE("results: distinct")
         REQUIRE(unique.get(2).get<Int>(col_num2) == 8);
     }
 
-    SECTION("Two integer properties combined")
-    {
+    SECTION("Two integer properties combined") {
         Results unique = results.distinct(DistinctDescriptor({{col_num1}, {col_num2}}));
         // unique is the same as the table
         REQUIRE(unique.size() == N);
@@ -2665,8 +2605,7 @@ TEST_CASE("results: distinct")
         }
     }
 
-    SECTION("String and integer combined")
-    {
+    SECTION("String and integer combined") {
         Results unique = results.distinct(DistinctDescriptor({{col_num2}, {col_string}}));
         // unique is the same as the table
         REQUIRE(unique.size() == N);
@@ -2676,8 +2615,7 @@ TEST_CASE("results: distinct")
     }
 
     // This section and next section demonstrate that sort().distinct() != distinct().sort()
-    SECTION("Order after sort and distinct")
-    {
+    SECTION("Order after sort and distinct") {
         Results reverse = results.sort(SortDescriptor({{col_num2}}, {true}));
         // reverse:
         //   0, Foo_0,  1
@@ -2698,8 +2636,7 @@ TEST_CASE("results: distinct")
         REQUIRE(unique.get(2).get<Int>(col_num2) == 3);
     }
 
-    SECTION("Order after distinct and sort")
-    {
+    SECTION("Order after distinct and sort") {
         Results unique = results.distinct(DistinctDescriptor({{col_num1}}));
         // unique:
         //  0, Foo_0, 10
@@ -2721,8 +2658,7 @@ TEST_CASE("results: distinct")
         REQUIRE(reverse.get(2).get<Int>(col_num2) == 10);
     }
 
-    SECTION("Chaining distinct")
-    {
+    SECTION("Chaining distinct") {
         Results first = results.distinct(DistinctDescriptor({{col_num1}}));
         REQUIRE(first.size() == 3);
 
@@ -2731,8 +2667,7 @@ TEST_CASE("results: distinct")
         REQUIRE(second.size() == 2);
     }
 
-    SECTION("Chaining sort")
-    {
+    SECTION("Chaining sort") {
         using cols_0_3 = std::pair<int, int>;
         Results first = results.sort(SortDescriptor({{col_num1}}));
         Results second = first.sort(SortDescriptor({{col_num3}}));
@@ -2749,8 +2684,7 @@ TEST_CASE("results: distinct")
         }
     }
 
-    SECTION("Distinct is carried over to new queries")
-    {
+    SECTION("Distinct is carried over to new queries") {
         Results unique = results.distinct(DistinctDescriptor({{col_num1}}));
         // unique:
         //  0, Foo_0, 10
@@ -2767,8 +2701,7 @@ TEST_CASE("results: distinct")
         REQUIRE(filtered.get(1).get<Int>(col_num2) == 9);
     }
 
-    SECTION("Distinct will not forget previous query")
-    {
+    SECTION("Distinct will not forget previous query") {
         Results filtered = results.filter(Query(table->where().greater(col_num2, 5)));
         // filtered:
         //   0, Foo_0, 10
@@ -2796,8 +2729,7 @@ TEST_CASE("results: distinct")
     }
 }
 
-TEST_CASE("results: sort")
-{
+TEST_CASE("results: sort") {
     InMemoryTestFile config;
     config.cache = false;
     config.schema = Schema{
@@ -2821,10 +2753,8 @@ TEST_CASE("results: sort")
     auto table2 = realm->read_group().get_table("class_object 2");
     Results r(realm, table);
 
-    SECTION("invalid keypaths")
-    {
-        SECTION("empty property name")
-        {
+    SECTION("invalid keypaths") {
+        SECTION("empty property name") {
             REQUIRE_THROWS_WITH(r.sort({{"", true}}), "Cannot sort on key path '': missing property name.");
             REQUIRE_THROWS_WITH(r.sort({{".", true}}), "Cannot sort on key path '.': missing property name.");
             REQUIRE_THROWS_WITH(r.sort({{"link.", true}}), "Cannot sort on key path 'link.': missing property name.");
@@ -2833,8 +2763,7 @@ TEST_CASE("results: sort")
             REQUIRE_THROWS_WITH(r.sort({{"link..value", true}}),
                                 "Cannot sort on key path 'link..value': missing property name.");
         }
-        SECTION("bad property name")
-        {
+        SECTION("bad property name") {
             REQUIRE_THROWS_WITH(
                 r.sort({{"not a property", true}}),
                 "Cannot sort on key path 'not a property': property 'object.not a property' does not exist.");
@@ -2842,14 +2771,12 @@ TEST_CASE("results: sort")
                 r.sort({{"link.not a property", true}}),
                 "Cannot sort on key path 'link.not a property': property 'object 2.not a property' does not exist.");
         }
-        SECTION("subscript primitive")
-        {
+        SECTION("subscript primitive") {
             REQUIRE_THROWS_WITH(r.sort({{"value.link", true}}),
                                 "Cannot sort on key path 'value.link': property 'object.value' of type 'int' may "
                                 "only be the final property in the key path.");
         }
-        SECTION("end in link")
-        {
+        SECTION("end in link") {
             REQUIRE_THROWS_WITH(r.sort({{"link", true}}),
                                 "Cannot sort on key path 'link': property 'object.link' of type 'object' cannot be "
                                 "the final property in the key path.");
@@ -2857,8 +2784,7 @@ TEST_CASE("results: sort")
                                 "Cannot sort on key path 'link.link': property 'object 2.link' of type 'object' "
                                 "cannot be the final property in the key path.");
         }
-        SECTION("sort involving bad property types")
-        {
+        SECTION("sort involving bad property types") {
             REQUIRE_THROWS_WITH(
                 r.sort({{"array", true}}),
                 "Cannot sort on key path 'array': property 'object.array' is of unsupported type 'array'.");
@@ -2904,26 +2830,22 @@ TEST_CASE("results: sort")
             REQUIRE(results.get(i).get_key() == expected[i]);                                                        \
     } while (0)
 
-    SECTION("sort on single property")
-    {
+    SECTION("sort on single property") {
         REQUIRE_ORDER((r.sort({{"value", true}})), 2, 3, 0, 1);
         REQUIRE_ORDER((r.sort({{"value", false}})), 1, 0, 3, 2);
     }
 
-    SECTION("sort on two properties")
-    {
+    SECTION("sort on two properties") {
         REQUIRE_ORDER((r.sort({{"bool", true}, {"value", true}})), 2, 0, 3, 1);
         REQUIRE_ORDER((r.sort({{"bool", false}, {"value", true}})), 3, 1, 2, 0);
         REQUIRE_ORDER((r.sort({{"bool", true}, {"value", false}})), 0, 2, 1, 3);
         REQUIRE_ORDER((r.sort({{"bool", false}, {"value", false}})), 1, 3, 0, 2);
     }
-    SECTION("sort over link")
-    {
+    SECTION("sort over link") {
         REQUIRE_ORDER((r.sort({{"link.value", true}})), 0, 3, 2, 1);
         REQUIRE_ORDER((r.sort({{"link.value", false}})), 1, 2, 3, 0);
     }
-    SECTION("sort over two links")
-    {
+    SECTION("sort over two links") {
         REQUIRE_ORDER((r.sort({{"link.link.value", true}})), 1, 0, 3, 2);
         REQUIRE_ORDER((r.sort({{"link.link.value", false}})), 2, 3, 0, 1);
     }
@@ -2986,23 +2908,20 @@ TEMPLATE_TEST_CASE("results: get<Obj>()", "", ResultsFromTable, ResultsFromQuery
 
     Results results = TestType::call(r, table);
 
-    SECTION("sequential in increasing order")
-    {
+    SECTION("sequential in increasing order") {
         for (int i = 0; i < 10; ++i)
             CHECK(results.get<Obj>(i).get<int64_t>(col_value) == i);
         for (int i = 0; i < 10; ++i)
             CHECK(results.get<Obj>(i).get<int64_t>(col_value) == i);
         CHECK_THROWS(results.get(11));
     }
-    SECTION("sequential in decreasing order")
-    {
+    SECTION("sequential in decreasing order") {
         for (int i = 9; i >= 0; --i)
             CHECK(results.get<Obj>(i).get<int64_t>(col_value) == i);
         for (int i = 9; i >= 0; --i)
             CHECK(results.get<Obj>(i).get<int64_t>(col_value) == i);
     }
-    SECTION("random order")
-    {
+    SECTION("random order") {
         int indexes[10];
         std::iota(std::begin(indexes), std::end(indexes), 0);
         std::random_device rd;
@@ -3037,18 +2956,14 @@ TEMPLATE_TEST_CASE("results: accessor interface", "", ResultsFromTable, ResultsF
     Results empty_results = TestType::call(r, table);
     CppContext ctx(r, &empty_results.get_object_schema());
 
-    SECTION("no objects")
-    {
-        SECTION("get()")
-        {
+    SECTION("no objects") {
+        SECTION("get()") {
             CHECK_THROWS_WITH(empty_results.get(ctx, 0), "Requested index 0 in empty Results");
         }
-        SECTION("first()")
-        {
+        SECTION("first()") {
             CHECK_FALSE(empty_results.first(ctx));
         }
-        SECTION("last()")
-        {
+        SECTION("last()") {
             CHECK_FALSE(empty_results.last(ctx));
         }
     }
@@ -3062,43 +2977,35 @@ TEMPLATE_TEST_CASE("results: accessor interface", "", ResultsFromTable, ResultsF
     Results results = TestType::call(r, table);
     auto r2 = Realm::get_shared_realm(config);
 
-    SECTION("get()")
-    {
+    SECTION("get()") {
         for (int i = 0; i < 10; ++i)
             CHECK(any_cast<Object>(results.get(ctx, i)).get_column_value<int64_t>("value") == i);
         CHECK_THROWS_WITH(results.get(ctx, 10), "Requested index 10 greater than max 9");
     }
 
-    SECTION("first()")
-    {
+    SECTION("first()") {
         CHECK(any_cast<Object>(*results.first(ctx)).get_column_value<int64_t>("value") == 0);
     }
 
-    SECTION("last()")
-    {
+    SECTION("last()") {
         CHECK(any_cast<Object>(*results.last(ctx)).get_column_value<int64_t>("value") == 9);
     }
 
-    SECTION("index_of()")
-    {
-        SECTION("valid")
-        {
+    SECTION("index_of()") {
+        SECTION("valid") {
             for (size_t i = 0; i < 10; ++i)
                 REQUIRE(results.index_of(ctx, util::Any(results.get<Obj>(i))) == i);
         }
-        SECTION("wrong object type")
-        {
+        SECTION("wrong object type") {
             CHECK_THROWS_WITH(results.index_of(ctx, util::Any(other_obj)),
                               "Object of type 'different type' does not match Results type 'object'");
         }
-        SECTION("wrong realm")
-        {
+        SECTION("wrong realm") {
             auto obj = r2->read_group().get_table("class_object")->get_object(0);
             CHECK_THROWS_WITH(results.index_of(ctx, util::Any(obj)),
                               "Object of type 'object' does not match Results type 'object'");
         }
-        SECTION("detached object")
-        {
+        SECTION("detached object") {
             Obj detached_obj;
             CHECK_THROWS_WITH(results.index_of(ctx, util::Any(detached_obj)),
                               "Attempting to access an invalid object");
@@ -3130,8 +3037,7 @@ TEMPLATE_TEST_CASE("results: aggregate", "[query][aggregate]", ResultsFromTable,
     ColKey col_double = table->get_column_key("double");
     ColKey col_date = table->get_column_key("date");
 
-    SECTION("one row with null values")
-    {
+    SECTION("one row with null values") {
         r->begin_transaction();
         table->create_object();
         table->create_object().set_all(0, 0.f, 0.0, Timestamp(0, 0));
@@ -3144,32 +3050,28 @@ TEMPLATE_TEST_CASE("results: aggregate", "[query][aggregate]", ResultsFromTable,
 
         Results results = TestType::call(r, table);
 
-        SECTION("max")
-        {
+        SECTION("max") {
             REQUIRE(results.max(col_int)->get_int() == 2);
             REQUIRE(results.max(col_float)->get_float() == 2.f);
             REQUIRE(results.max(col_double)->get_double() == 2.0);
             REQUIRE(results.max(col_date)->get_timestamp() == Timestamp(2, 0));
         }
 
-        SECTION("min")
-        {
+        SECTION("min") {
             REQUIRE(results.min(col_int)->get_int() == 0);
             REQUIRE(results.min(col_float)->get_float() == 0.f);
             REQUIRE(results.min(col_double)->get_double() == 0.0);
             REQUIRE(results.min(col_date)->get_timestamp() == Timestamp(0, 0));
         }
 
-        SECTION("average")
-        {
+        SECTION("average") {
             REQUIRE(results.average(col_int) == 1.0);
             REQUIRE(results.average(col_float) == 1.0);
             REQUIRE(results.average(col_double) == 1.0);
             REQUIRE_THROWS_AS(results.average(col_date), Results::UnsupportedColumnTypeException);
         }
 
-        SECTION("sum")
-        {
+        SECTION("sum") {
             REQUIRE(results.sum(col_int)->get_int() == 2);
             REQUIRE(results.sum(col_float)->get_double() == 2.0);
             REQUIRE(results.sum(col_double)->get_double() == 2.0);
@@ -3177,8 +3079,7 @@ TEMPLATE_TEST_CASE("results: aggregate", "[query][aggregate]", ResultsFromTable,
         }
     }
 
-    SECTION("rows with all null values")
-    {
+    SECTION("rows with all null values") {
         r->begin_transaction();
         table->create_object();
         table->create_object();
@@ -3191,32 +3092,28 @@ TEMPLATE_TEST_CASE("results: aggregate", "[query][aggregate]", ResultsFromTable,
 
         Results results = TestType::call(r, table);
 
-        SECTION("max")
-        {
+        SECTION("max") {
             REQUIRE(!results.max(col_int));
             REQUIRE(!results.max(col_float));
             REQUIRE(!results.max(col_double));
             REQUIRE(!results.max(col_date));
         }
 
-        SECTION("min")
-        {
+        SECTION("min") {
             REQUIRE(!results.min(col_int));
             REQUIRE(!results.min(col_float));
             REQUIRE(!results.min(col_double));
             REQUIRE(!results.min(col_date));
         }
 
-        SECTION("average")
-        {
+        SECTION("average") {
             REQUIRE(!results.average(col_int));
             REQUIRE(!results.average(col_float));
             REQUIRE(!results.average(col_double));
             REQUIRE_THROWS_AS(results.average(col_date), Results::UnsupportedColumnTypeException);
         }
 
-        SECTION("sum")
-        {
+        SECTION("sum") {
             REQUIRE(results.sum(col_int)->get_int() == 0);
             REQUIRE(results.sum(col_float)->get_double() == 0.0);
             REQUIRE(results.sum(col_double)->get_double() == 0.0);
@@ -3224,36 +3121,31 @@ TEMPLATE_TEST_CASE("results: aggregate", "[query][aggregate]", ResultsFromTable,
         }
     }
 
-    SECTION("empty")
-    {
+    SECTION("empty") {
         Results results = TestType::call(r, table);
 
-        SECTION("max")
-        {
+        SECTION("max") {
             REQUIRE(!results.max(col_int));
             REQUIRE(!results.max(col_float));
             REQUIRE(!results.max(col_double));
             REQUIRE(!results.max(col_date));
         }
 
-        SECTION("min")
-        {
+        SECTION("min") {
             REQUIRE(!results.min(col_int));
             REQUIRE(!results.min(col_float));
             REQUIRE(!results.min(col_double));
             REQUIRE(!results.min(col_date));
         }
 
-        SECTION("average")
-        {
+        SECTION("average") {
             REQUIRE(!results.average(col_int));
             REQUIRE(!results.average(col_float));
             REQUIRE(!results.average(col_double));
             REQUIRE_THROWS_AS(results.average(col_date), Results::UnsupportedColumnTypeException);
         }
 
-        SECTION("sum")
-        {
+        SECTION("sum") {
             REQUIRE(results.sum(col_int)->get_int() == 0);
             REQUIRE(results.sum(col_float)->get_double() == 0.0);
             REQUIRE(results.sum(col_double)->get_double() == 0.0);
@@ -3262,8 +3154,7 @@ TEMPLATE_TEST_CASE("results: aggregate", "[query][aggregate]", ResultsFromTable,
     }
 }
 
-TEST_CASE("results: set property value on all objects", "[batch_updates]")
-{
+TEST_CASE("results: set property value on all objects", "[batch_updates]") {
     InMemoryTestFile config;
     config.automatic_change_notifications = false;
     config.schema = Schema{{"AllTypes",
@@ -3308,30 +3199,26 @@ TEST_CASE("results: set property value on all objects", "[batch_updates]")
 
     TestContext ctx(realm);
 
-    SECTION("non-existing property name")
-    {
+    SECTION("non-existing property name") {
         realm->begin_transaction();
         REQUIRE_THROWS_AS(r.set_property_value(ctx, "i dont exist", util::Any(false)),
                           Results::InvalidPropertyException);
         realm->cancel_transaction();
     }
 
-    SECTION("readonly property")
-    {
+    SECTION("readonly property") {
         realm->begin_transaction();
         REQUIRE_THROWS_AS(r.set_property_value(ctx, "parents", util::Any(false)), ReadOnlyPropertyException);
         realm->cancel_transaction();
     }
 
-    SECTION("primarykey property")
-    {
+    SECTION("primarykey property") {
         realm->begin_transaction();
         REQUIRE_THROWS_AS(r.set_property_value(ctx, "pk", util::Any(1)), std::logic_error);
         realm->cancel_transaction();
     }
 
-    SECTION("set property values removes object from Results")
-    {
+    SECTION("set property values removes object from Results") {
         realm->begin_transaction();
         Results results(realm, table->where().equal(table->get_column_key("int"), 0));
         CHECK(results.size() == 2);
@@ -3340,8 +3227,7 @@ TEST_CASE("results: set property value on all objects", "[batch_updates]")
         realm->cancel_transaction();
     }
 
-    SECTION("set property value")
-    {
+    SECTION("set property value") {
         realm->begin_transaction();
 
         r.set_property_value<util::Any>(ctx, "bool", util::Any(true));
@@ -3472,8 +3358,7 @@ TEST_CASE("results: set property value on all objects", "[batch_updates]")
     }
 }
 
-TEST_CASE("results: limit", "[limit]")
-{
+TEST_CASE("results: limit", "[limit]") {
     InMemoryTestFile config;
     // config.cache = false;
     config.automatic_change_notifications = false;
@@ -3495,8 +3380,7 @@ TEST_CASE("results: limit", "[limit]")
     realm->commit_transaction();
     Results r(realm, table);
 
-    SECTION("unsorted")
-    {
+    SECTION("unsorted") {
         REQUIRE(r.limit(0).size() == 0);
         REQUIRE_ORDER(r.limit(1), 0);
         REQUIRE_ORDER(r.limit(2), 0, 1);
@@ -3504,8 +3388,7 @@ TEST_CASE("results: limit", "[limit]")
         REQUIRE_ORDER(r.limit(100), 0, 1, 2, 3, 4, 5, 6, 7);
     }
 
-    SECTION("sorted")
-    {
+    SECTION("sorted") {
         auto sorted = r.sort({{"value", true}});
         REQUIRE(sorted.limit(0).size() == 0);
         REQUIRE_ORDER(sorted.limit(1), 2);
@@ -3514,8 +3397,7 @@ TEST_CASE("results: limit", "[limit]")
         REQUIRE_ORDER(sorted.limit(100), 2, 6, 3, 7, 0, 4, 1, 5);
     }
 
-    SECTION("sort after limit")
-    {
+    SECTION("sort after limit") {
         REQUIRE(r.limit(0).sort({{"value", true}}).size() == 0);
         REQUIRE_ORDER(r.limit(1).sort({{"value", true}}), 0);
         REQUIRE_ORDER(r.limit(3).sort({{"value", true}}), 2, 0, 1);
@@ -3523,8 +3405,7 @@ TEST_CASE("results: limit", "[limit]")
         REQUIRE_ORDER(r.limit(100).sort({{"value", true}}), 2, 6, 3, 7, 0, 4, 1, 5);
     }
 
-    SECTION("distinct")
-    {
+    SECTION("distinct") {
         auto sorted = r.distinct({"value"});
         REQUIRE(sorted.limit(0).size() == 0);
         REQUIRE_ORDER(sorted.limit(1), 0);
@@ -3538,8 +3419,7 @@ TEST_CASE("results: limit", "[limit]")
         REQUIRE_ORDER(sorted.limit(8), 2, 3, 0, 1);
     }
 
-    SECTION("notifications on results using all descriptor types")
-    {
+    SECTION("notifications on results using all descriptor types") {
         r = r.distinct({"value"}).sort({{"value", false}}).limit(2);
         int notification_calls = 0;
         auto token = r.add_notification_callback([&](CollectionChangeSet c, std::exception_ptr err) {
@@ -3571,8 +3451,7 @@ TEST_CASE("results: limit", "[limit]")
         REQUIRE(notification_calls == 2);
     }
 
-    SECTION("notifications on only limited results")
-    {
+    SECTION("notifications on only limited results") {
         r = r.limit(2);
         int notification_calls = 0;
         auto token = r.add_notification_callback([&](CollectionChangeSet c, std::exception_ptr err) {
@@ -3600,15 +3479,13 @@ TEST_CASE("results: limit", "[limit]")
         REQUIRE(notification_calls == 2);
     }
 
-    SECTION("does not support further filtering")
-    {
+    SECTION("does not support further filtering") {
         auto limited = r.limit(0);
         REQUIRE_THROWS_AS(limited.filter(table->where()), Results::UnimplementedOperationException);
     }
 }
 
-TEST_CASE("results: query helpers", "[include]")
-{
+TEST_CASE("results: query helpers", "[include]") {
     InMemoryTestFile config;
     config.automatic_change_notifications = false;
     config.schema = Schema{
@@ -3631,16 +3508,14 @@ TEST_CASE("results: query helpers", "[include]")
 
     Results r(realm, table);
 
-    SECTION("not valid")
-    {
+    SECTION("not valid") {
         std::vector<StringData> paths;
         parser::KeyPathMapping mapping;
         ObjectSchema schema = *realm->schema().find("object");
         IncludeDescriptor includes = realm::generate_include_from_keypaths(paths, *realm, schema, mapping);
         CHECK(!includes.is_valid());
     }
-    SECTION("valid")
-    {
+    SECTION("valid") {
         std::vector<StringData> paths = {"@links.linking_object.link"};
         parser::KeyPathMapping mapping;
         realm::populate_keypath_mapping(mapping, *realm);

--- a/test/object-store/schema.cpp
+++ b/test/object-store/schema.cpp
@@ -82,10 +82,8 @@ struct StringMaker<SchemaChange> {
 };
 } // namespace Catch
 
-TEST_CASE("ObjectSchema")
-{
-    SECTION("Aliases are still present in schema returned from the Realm")
-    {
+TEST_CASE("ObjectSchema") {
+    SECTION("Aliases are still present in schema returned from the Realm") {
         TestFile config;
         config.schema_version = 1;
         config.schema = Schema{
@@ -97,8 +95,7 @@ TEST_CASE("ObjectSchema")
         REQUIRE(realm->schema().find("object")->property_for_name("value")->public_name == "alias");
     }
 
-    SECTION("looking up properties by alias matches name if alias is not set")
-    {
+    SECTION("looking up properties by alias matches name if alias is not set") {
         auto schema = Schema{
             {"object",
              {{"value", PropertyType::Int, Property::IsPrimary{false}, Property::IsIndexed{false}, "alias"},
@@ -110,8 +107,7 @@ TEST_CASE("ObjectSchema")
         REQUIRE(schema.find("object")->property_for_public_name("other_value")->name == "other_value");
     }
 
-    SECTION("from a Group")
-    {
+    SECTION("from a Group") {
         Group g;
 
         TableRef table = g.add_table_with_primary_key("class_table", type_Int, "pk");
@@ -350,12 +346,9 @@ TEST_CASE("ObjectSchema")
     }
 }
 
-TEST_CASE("Schema")
-{
-    SECTION("validate()")
-    {
-        SECTION("rejects link properties with no target object")
-        {
+TEST_CASE("Schema") {
+    SECTION("validate()") {
+        SECTION("rejects link properties with no target object") {
             Schema schema = {
                 {"object", {{"link", PropertyType::Object | PropertyType::Nullable}}},
             };
@@ -363,8 +356,7 @@ TEST_CASE("Schema")
                                       "Property 'object.link' of type 'object' has unknown object type ''");
         }
 
-        SECTION("rejects array properties with no target object")
-        {
+        SECTION("rejects array properties with no target object") {
             Schema schema = {
                 {"object", {{"array", PropertyType::Array | PropertyType::Object}}},
             };
@@ -372,24 +364,21 @@ TEST_CASE("Schema")
                                       "Property 'object.array' of type 'array' has unknown object type ''");
         }
 
-        SECTION("rejects link properties with a target not in the schema")
-        {
+        SECTION("rejects link properties with a target not in the schema") {
             Schema schema = {{"object", {{"link", PropertyType::Object | PropertyType::Nullable, "invalid target"}}}};
             REQUIRE_THROWS_CONTAINING(
                 schema.validate(),
                 "Property 'object.link' of type 'object' has unknown object type 'invalid target'");
         }
 
-        SECTION("rejects array properties with a target not in the schema")
-        {
+        SECTION("rejects array properties with a target not in the schema") {
             Schema schema = {{"object", {{"array", PropertyType::Array | PropertyType::Object, "invalid target"}}}};
             REQUIRE_THROWS_CONTAINING(
                 schema.validate(),
                 "Property 'object.array' of type 'array' has unknown object type 'invalid target'");
         }
 
-        SECTION("allows link properties from embedded to top-level")
-        {
+        SECTION("allows link properties from embedded to top-level") {
             Schema schema = {{"target", {{"value", PropertyType::Int}}},
                              {"origin",
                               ObjectSchema::IsEmbedded{true},
@@ -397,8 +386,7 @@ TEST_CASE("Schema")
             REQUIRE_NOTHROW(schema.validate());
         }
 
-        SECTION("allows array properties from embedded to top-level")
-        {
+        SECTION("allows array properties from embedded to top-level") {
             Schema schema = {{"target", {{"value", PropertyType::Int}}},
                              {"origin",
                               ObjectSchema::IsEmbedded{true},
@@ -406,8 +394,7 @@ TEST_CASE("Schema")
             REQUIRE_NOTHROW(schema.validate());
         }
 
-        SECTION("allows linking objects from embedded to top-level")
-        {
+        SECTION("allows linking objects from embedded to top-level") {
             Schema schema = {{"target",
                               ObjectSchema::IsEmbedded{true},
                               {{"value", PropertyType::Int}},
@@ -416,8 +403,7 @@ TEST_CASE("Schema")
             REQUIRE_NOTHROW(schema.validate());
         }
 
-        SECTION("rejects embedded objects self loop via top level object")
-        {
+        SECTION("rejects embedded objects self loop via top level object") {
             Schema schema = {
                 {"TopLevelObject",
                  {{"link_to_embedded_object", PropertyType::Object | PropertyType::Nullable, "EmbeddedObject"}}},
@@ -429,8 +415,7 @@ TEST_CASE("Schema")
                                       "'EmbeddedObject.link_to_top_level_object.link_to_embedded_object'");
         }
 
-        SECTION("rejects embedded objects loop to itself")
-        {
+        SECTION("rejects embedded objects loop to itself") {
             Schema schema = {
                 {"TopLevelObject",
                  {{"link_to_embedded_object", PropertyType::Object | PropertyType::Nullable, "EmbeddedObject"}}},
@@ -442,8 +427,7 @@ TEST_CASE("Schema")
                 "Cycles containing embedded objects are not currently supported: 'EmbeddedObject.link_to_self'");
         }
 
-        SECTION("rejects embedded objects self loop via different embedded object")
-        {
+        SECTION("rejects embedded objects self loop via different embedded object") {
             Schema schema = {
                 {"TopLevelObject",
                  {{"link_to_embedded_object", PropertyType::Object | PropertyType::Nullable, "EmbeddedObjectA"}}},
@@ -457,8 +441,7 @@ TEST_CASE("Schema")
                                                          "supported: 'EmbeddedObjectA.link_to_b.link_to_a'");
         }
 
-        SECTION("rejects with descriptions of all embedded object loops")
-        {
+        SECTION("rejects with descriptions of all embedded object loops") {
             Schema schema = {
                 {"TopLevelObject",
                  {{"link_to_embedded_object", PropertyType::Object | PropertyType::Nullable, "EmbeddedObjectA"}}},
@@ -490,8 +473,7 @@ TEST_CASE("Schema")
                                  "'EmbeddedObjectC.link_to_a.link_to_c'") != std::string::npos);
         }
 
-        SECTION("allows top level loops")
-        {
+        SECTION("allows top level loops") {
             Schema schema = {{"TopLevelObjectA",
                               {{"link_to_top_b", PropertyType::Object | PropertyType::Nullable, "TopLevelObjectB"}}},
                              {"TopLevelObjectB",
@@ -505,8 +487,7 @@ TEST_CASE("Schema")
             REQUIRE_NOTHROW(schema.validate());
         }
 
-        SECTION("rejects linking objects without a source object")
-        {
+        SECTION("rejects linking objects without a source object") {
             Schema schema = {{"object",
                               {
                                   {"value", PropertyType::Int},
@@ -516,8 +497,7 @@ TEST_CASE("Schema")
                 schema.validate(), "Property 'object.incoming' of type 'linking objects' has unknown object type ''");
         }
 
-        SECTION("rejects linking objects without a source property")
-        {
+        SECTION("rejects linking objects without a source property") {
             Schema schema = {{"object",
                               {
                                   {"value", PropertyType::Int},
@@ -528,8 +508,7 @@ TEST_CASE("Schema")
                 "Property 'object.incoming' of type 'linking objects' must have an origin property name.");
         }
 
-        SECTION("rejects linking objects with invalid source object")
-        {
+        SECTION("rejects linking objects with invalid source object") {
             Schema schema = {
                 {"object",
                  {
@@ -541,8 +520,7 @@ TEST_CASE("Schema")
                 "Property 'object.incoming' of type 'linking objects' has unknown object type 'not an object type'");
         }
 
-        SECTION("rejects linking objects with invalid source property")
-        {
+        SECTION("rejects linking objects with invalid source property") {
             Schema schema = {{"object",
                               {
                                   {"value", PropertyType::Int},
@@ -566,8 +544,7 @@ TEST_CASE("Schema")
                                       "'object.incoming' links to type 'object 2'");
         }
 
-        SECTION("rejects non-array linking objects")
-        {
+        SECTION("rejects non-array linking objects") {
             Schema schema = {{"object",
                               {
                                   {"link", PropertyType::Object | PropertyType::Nullable, "object"},
@@ -577,8 +554,7 @@ TEST_CASE("Schema")
                                       "Linking Objects property 'object.incoming' must be an array.");
         }
 
-        SECTION("rejects target object types for non-link properties")
-        {
+        SECTION("rejects target object types for non-link properties") {
             Schema schema = {{"object",
                               {
                                   {"int", PropertyType::Int},
@@ -599,8 +575,7 @@ TEST_CASE("Schema")
             }
         }
 
-        SECTION("rejects source property name for non-linking objects properties")
-        {
+        SECTION("rejects source property name for non-linking objects properties") {
             Schema schema = {{"object",
                               {
                                   {"int", PropertyType::Int},
@@ -626,15 +601,13 @@ TEST_CASE("Schema")
             }
         }
 
-        SECTION("rejects non-nullable link properties")
-        {
+        SECTION("rejects non-nullable link properties") {
             Schema schema = {{"object", {{"link", PropertyType::Object, "target"}}},
                              {"target", {{"value", PropertyType::Int}}}};
             REQUIRE_THROWS_CONTAINING(schema.validate(), "Property 'object.link' of type 'object' must be nullable.");
         }
 
-        SECTION("rejects nullable array properties")
-        {
+        SECTION("rejects nullable array properties") {
             Schema schema = {
                 {"object",
                  {{"array", PropertyType::Array | PropertyType::Object | PropertyType::Nullable, "target"}}},
@@ -643,8 +616,7 @@ TEST_CASE("Schema")
                                       "Property 'object.array' of type 'array' cannot be nullable.");
         }
 
-        SECTION("rejects nullable linking objects")
-        {
+        SECTION("rejects nullable linking objects") {
             Schema schema = {
                 {"object",
                  {
@@ -656,8 +628,7 @@ TEST_CASE("Schema")
                                       "Property 'object.incoming' of type 'linking objects' cannot be nullable.");
         }
 
-        SECTION("rejects duplicate primary keys")
-        {
+        SECTION("rejects duplicate primary keys") {
             Schema schema = {{"object",
                               {
                                   {"pk1", PropertyType::Int, Property::IsPrimary{true}},
@@ -667,8 +638,7 @@ TEST_CASE("Schema")
                                       "Properties 'pk2' and 'pk1' are both marked as the primary key of 'object'.");
         }
 
-        SECTION("rejects primary key on embedded table")
-        {
+        SECTION("rejects primary key on embedded table") {
             Schema schema = {{"object",
                               ObjectSchema::IsEmbedded{true},
                               {
@@ -678,8 +648,7 @@ TEST_CASE("Schema")
             REQUIRE_THROWS_CONTAINING(schema.validate(), "Embedded object type 'object' cannot have a primary key.");
         }
 
-        SECTION("rejects invalid primary key types")
-        {
+        SECTION("rejects invalid primary key types") {
             Schema schema = {{"object",
                               {
                                   {"pk", PropertyType::Float, Property::IsPrimary{true}},
@@ -722,8 +691,7 @@ TEST_CASE("Schema")
                                       "Property 'object.pk' of type 'decimal' cannot be made the primary key.");
         }
 
-        SECTION("allows valid primary key types")
-        {
+        SECTION("allows valid primary key types") {
             Schema schema = {{"object",
                               {
                                   {"pk", PropertyType::Int, Property::IsPrimary{true}},
@@ -747,8 +715,7 @@ TEST_CASE("Schema")
             REQUIRE_NOTHROW(schema.validate());
         }
 
-        SECTION("rejects nonexistent primary key")
-        {
+        SECTION("rejects nonexistent primary key") {
             Schema schema = {{"object",
                               {
                                   {"value", PropertyType::Int},
@@ -758,8 +725,7 @@ TEST_CASE("Schema")
                                       "Specified primary key 'object.nonexistent' does not exist.");
         }
 
-        SECTION("rejects indexes for types that cannot be indexed")
-        {
+        SECTION("rejects indexes for types that cannot be indexed") {
             Schema schema = {{"object",
                               {
                                   {"float", PropertyType::Float},
@@ -779,8 +745,7 @@ TEST_CASE("Schema")
             }
         }
 
-        SECTION("allows indexing types that can be indexed")
-        {
+        SECTION("allows indexing types that can be indexed") {
             Schema schema = {
                 {"object",
                  {
@@ -794,8 +759,7 @@ TEST_CASE("Schema")
             REQUIRE_NOTHROW(schema.validate());
         }
 
-        SECTION("rejects duplicate types with the same name")
-        {
+        SECTION("rejects duplicate types with the same name") {
             Schema schema = {{"object1",
                               {
                                   {"int", PropertyType::Int},
@@ -821,8 +785,7 @@ TEST_CASE("Schema")
                                                          "- Type 'object2' appears more than once in the schema.");
         }
 
-        SECTION("rejects properties with the same name")
-        {
+        SECTION("rejects properties with the same name") {
             Schema schema = {{"object",
                               {
                                   {"child", PropertyType::Object | PropertyType::Nullable, "object"},
@@ -841,8 +804,7 @@ TEST_CASE("Schema")
                                       "- Property 'parent' appears more than once in the schema for type 'object'.");
         }
 
-        SECTION("rejects schema if all properties have the same name")
-        {
+        SECTION("rejects schema if all properties have the same name") {
             Schema schema = {{"object",
                               {
                                   {"field", PropertyType::Int},
@@ -862,8 +824,7 @@ TEST_CASE("Schema")
                                    "- Property 'otherField' appears more than once in the schema for type 'object'.");
         }
 
-        SECTION("rejects properties with the same alias")
-        {
+        SECTION("rejects properties with the same alias") {
             Schema schema = {
                 {"object",
                  {
@@ -895,8 +856,7 @@ TEST_CASE("Schema")
                                       "- Alias '_parent' appears more than once in the schema for type 'object'.");
         }
 
-        SECTION("rejects properties whose name conflicts with an alias for another property")
-        {
+        SECTION("rejects properties whose name conflicts with an alias for another property") {
             Schema schema = {
                 {"object",
                  {
@@ -914,12 +874,10 @@ TEST_CASE("Schema")
         }
     }
 
-    SECTION("compare()")
-    {
+    SECTION("compare()") {
         using namespace schema_change;
         using vec = std::vector<SchemaChange>;
-        SECTION("add table")
-        {
+        SECTION("add table") {
             Schema schema1 = {{"object 1",
                                {
                                    {"int", PropertyType::Int},
@@ -937,8 +895,7 @@ TEST_CASE("Schema")
             REQUIRE(schema1.compare(schema2) == expected);
         }
 
-        SECTION("add property")
-        {
+        SECTION("add property") {
             Schema schema1 = {{"object",
                                {
                                    {"int 1", PropertyType::Int},
@@ -952,8 +909,7 @@ TEST_CASE("Schema")
                     vec{(AddProperty{&*schema1.find("object"), &schema2.find("object")->persisted_properties[1]})});
         }
 
-        SECTION("remove property")
-        {
+        SECTION("remove property") {
             Schema schema1 = {{"object",
                                {
                                    {"int 1", PropertyType::Int},
@@ -968,8 +924,7 @@ TEST_CASE("Schema")
                 vec{(RemoveProperty{&*schema1.find("object"), &schema1.find("object")->persisted_properties[1]})});
         }
 
-        SECTION("change property type")
-        {
+        SECTION("change property type") {
             Schema schema1 = {{"object",
                                {
                                    {"value", PropertyType::Int},
@@ -984,8 +939,7 @@ TEST_CASE("Schema")
                                         &schema2.find("object")->persisted_properties[0]})});
         };
 
-        SECTION("change link target")
-        {
+        SECTION("change link target") {
             Schema schema1 = {
                 {"object",
                  {
@@ -1020,8 +974,7 @@ TEST_CASE("Schema")
                                         &schema2.find("object")->persisted_properties[0]})});
         }
 
-        SECTION("add index")
-        {
+        SECTION("add index") {
             Schema schema1 = {{"object",
                                {
                                    {"int", PropertyType::Int},
@@ -1035,8 +988,7 @@ TEST_CASE("Schema")
                     vec{(AddIndex{object_schema, &object_schema->persisted_properties[0]})});
         }
 
-        SECTION("remove index")
-        {
+        SECTION("remove index") {
             Schema schema1 = {{"object",
                                {
                                    {"int", PropertyType::Int, Property::IsPrimary{false}, Property::IsIndexed{true}},
@@ -1050,8 +1002,7 @@ TEST_CASE("Schema")
                     vec{(RemoveIndex{object_schema, &object_schema->persisted_properties[0]})});
         }
 
-        SECTION("add index and make nullable")
-        {
+        SECTION("add index and make nullable") {
             Schema schema1 = {{"object",
                                {
                                    {"int", PropertyType::Int},
@@ -1067,8 +1018,7 @@ TEST_CASE("Schema")
                          AddIndex{object_schema, &object_schema->persisted_properties[0]}}));
         }
 
-        SECTION("add index and change type")
-        {
+        SECTION("add index and change type") {
             Schema schema1 = {{"object",
                                {
                                    {"value", PropertyType::Int},
@@ -1084,8 +1034,7 @@ TEST_CASE("Schema")
                                         &schema2.find("object")->persisted_properties[0]})});
         }
 
-        SECTION("make nullable and change type")
-        {
+        SECTION("make nullable and change type") {
             Schema schema1 = {{"object",
                                {
                                    {"value", PropertyType::Int},

--- a/test/object-store/sync/app.cpp
+++ b/test/object-store/sync/app.cpp
@@ -211,11 +211,9 @@ static std::string get_config_path()
 
 // MARK: - Login with Credentials Tests
 
-TEST_CASE("app: login_with_credentials integration", "[sync][app]")
-{
+TEST_CASE("app: login_with_credentials integration", "[sync][app]") {
 
-    SECTION("login")
-    {
+    SECTION("login") {
         std::unique_ptr<GenericNetworkTransport> (*factory)() = [] {
             return std::unique_ptr<GenericNetworkTransport>(new IntTestTransport);
         };
@@ -265,8 +263,7 @@ TEST_CASE("app: login_with_credentials integration", "[sync][app]")
 
 // MARK: - UsernamePasswordProviderClient Tests
 
-TEST_CASE("app: UsernamePasswordProviderClient integration", "[sync][app]")
-{
+TEST_CASE("app: UsernamePasswordProviderClient integration", "[sync][app]") {
     auto email = util::format("realm_tests_do_autoverify%1@%2.com", random_string(10), random_string(10));
 
     auto password = random_string(10);
@@ -302,8 +299,7 @@ TEST_CASE("app: UsernamePasswordProviderClient integration", "[sync][app]")
             }
         });
 
-    SECTION("double registration should fail")
-    {
+    SECTION("double registration should fail") {
         app->provider_client<App::UsernamePasswordProviderClient>().register_email(
             email, password, [&](Optional<app::AppError> error) {
                 // Error returned states the account has already been created
@@ -317,8 +313,7 @@ TEST_CASE("app: UsernamePasswordProviderClient integration", "[sync][app]")
         CHECK(processed);
     }
 
-    SECTION("double registration should fail")
-    {
+    SECTION("double registration should fail") {
         // the server registration function will reject emails that do not contain "realm_tests_do_autoverify"
         std::string email_to_reject = util::format("%1@%2.com", random_string(10), random_string(10));
         app->provider_client<App::UsernamePasswordProviderClient>().register_email(
@@ -331,8 +326,7 @@ TEST_CASE("app: UsernamePasswordProviderClient integration", "[sync][app]")
         CHECK(processed);
     }
 
-    SECTION("can login with registered account")
-    {
+    SECTION("can login with registered account") {
         app->log_in_with_credentials(realm::app::AppCredentials::username_password(email, password),
                                      [&](std::shared_ptr<realm::SyncUser> user, Optional<app::AppError> error) {
                                          REQUIRE(user);
@@ -346,8 +340,7 @@ TEST_CASE("app: UsernamePasswordProviderClient integration", "[sync][app]")
         CHECK(user->user_profile().email == email);
     }
 
-    SECTION("confirm user")
-    {
+    SECTION("confirm user") {
         app->provider_client<App::UsernamePasswordProviderClient>().confirm_user(
             "a_token", "a_token_id", [&](Optional<app::AppError> error) {
                 REQUIRE(error);
@@ -357,8 +350,7 @@ TEST_CASE("app: UsernamePasswordProviderClient integration", "[sync][app]")
         CHECK(processed);
     }
 
-    SECTION("resend confirmation email")
-    {
+    SECTION("resend confirmation email") {
         app->provider_client<App::UsernamePasswordProviderClient>().resend_confirmation_email(
             email, [&](Optional<app::AppError> error) {
                 REQUIRE(error);
@@ -368,8 +360,7 @@ TEST_CASE("app: UsernamePasswordProviderClient integration", "[sync][app]")
         CHECK(processed);
     }
 
-    SECTION("reset password invalid tokens")
-    {
+    SECTION("reset password invalid tokens") {
         app->provider_client<App::UsernamePasswordProviderClient>().reset_password(
             password, "token_sample", "token_id_sample", [&](Optional<app::AppError> error) {
                 REQUIRE(error);
@@ -381,8 +372,7 @@ TEST_CASE("app: UsernamePasswordProviderClient integration", "[sync][app]")
         CHECK(processed);
     }
 
-    SECTION("reset password function success")
-    {
+    SECTION("reset password function success") {
         // the imported test app will accept password reset if the password contains "realm_tests_do_reset" via a
         // function
         std::string accepted_new_password = util::format("realm_tests_do_reset%1", random_string(10));
@@ -394,8 +384,7 @@ TEST_CASE("app: UsernamePasswordProviderClient integration", "[sync][app]")
         CHECK(processed);
     }
 
-    SECTION("reset password function failure")
-    {
+    SECTION("reset password function failure") {
         std::string rejected_password = util::format("%1", random_string(10));
         app->provider_client<App::UsernamePasswordProviderClient>().call_reset_password_function(
             email, rejected_password, {"foo", "bar"}, [&](Optional<app::AppError> error) {
@@ -407,8 +396,7 @@ TEST_CASE("app: UsernamePasswordProviderClient integration", "[sync][app]")
         CHECK(processed);
     }
 
-    SECTION("reset password function for invalid user fails")
-    {
+    SECTION("reset password function for invalid user fails") {
         app->provider_client<App::UsernamePasswordProviderClient>().call_reset_password_function(
             util::format("%1@%2.com", random_string(5), random_string(5)), password, {"foo", "bar"},
             [&](Optional<app::AppError> error) {
@@ -421,8 +409,7 @@ TEST_CASE("app: UsernamePasswordProviderClient integration", "[sync][app]")
         CHECK(processed);
     }
 
-    SECTION("retry custom confirmation")
-    {
+    SECTION("retry custom confirmation") {
         app->provider_client<App::UsernamePasswordProviderClient>().retry_custom_confirmation(
             email, [&](Optional<app::AppError> error) {
                 REQUIRE(error);
@@ -432,8 +419,7 @@ TEST_CASE("app: UsernamePasswordProviderClient integration", "[sync][app]")
         CHECK(processed);
     }
 
-    SECTION("retry custom confirmation for invalid user fails")
-    {
+    SECTION("retry custom confirmation for invalid user fails") {
         app->provider_client<App::UsernamePasswordProviderClient>().retry_custom_confirmation(
             util::format("%1@%2.com", random_string(5), random_string(5)), [&](Optional<app::AppError> error) {
                 REQUIRE(error);
@@ -448,8 +434,7 @@ TEST_CASE("app: UsernamePasswordProviderClient integration", "[sync][app]")
 
 // MARK: - UserAPIKeyProviderClient Tests
 
-TEST_CASE("app: UserAPIKeyProviderClient integration", "[sync][app]")
-{
+TEST_CASE("app: UserAPIKeyProviderClient integration", "[sync][app]") {
 
     std::unique_ptr<GenericNetworkTransport> (*factory)() = [] {
         return std::unique_ptr<GenericNetworkTransport>(new IntTestTransport);
@@ -499,8 +484,7 @@ TEST_CASE("app: UserAPIKeyProviderClient integration", "[sync][app]")
 
     App::UserAPIKey api_key;
 
-    SECTION("api-key")
-    {
+    SECTION("api-key") {
         std::shared_ptr<SyncUser> logged_in_user = register_and_log_in_user();
         auto api_key_name = util::format("%1", random_string(15));
         app->provider_client<App::UserAPIKeyProviderClient>().create_api_key(
@@ -568,8 +552,7 @@ TEST_CASE("app: UserAPIKeyProviderClient integration", "[sync][app]")
         CHECK(processed);
     }
 
-    SECTION("api-key without a user")
-    {
+    SECTION("api-key without a user") {
         std::shared_ptr<SyncUser> no_user = nullptr;
         auto api_key_name = util::format("%1", random_string(15));
         app->provider_client<App::UserAPIKeyProviderClient>().create_api_key(
@@ -644,8 +627,7 @@ TEST_CASE("app: UserAPIKeyProviderClient integration", "[sync][app]")
         CHECK(processed);
     }
 
-    SECTION("api-key against the wrong user")
-    {
+    SECTION("api-key against the wrong user") {
         std::shared_ptr<SyncUser> first_user = register_and_log_in_user();
         std::shared_ptr<SyncUser> second_user = register_and_log_in_user();
         auto api_key_name = util::format("%1", random_string(15));
@@ -779,8 +761,7 @@ TEST_CASE("app: UserAPIKeyProviderClient integration", "[sync][app]")
 
 // MARK: - Auth Providers Function Tests
 
-TEST_CASE("app: auth providers function integration", "[sync][app]")
-{
+TEST_CASE("app: auth providers function integration", "[sync][app]") {
 
     std::unique_ptr<GenericNetworkTransport> (*factory)() = [] {
         return std::unique_ptr<GenericNetworkTransport>(new IntTestTransport);
@@ -804,8 +785,7 @@ TEST_CASE("app: auth providers function integration", "[sync][app]")
 
     bool processed = false;
 
-    SECTION("auth providers function integration")
-    {
+    SECTION("auth providers function integration") {
         bson::BsonDocument function_params{{"realmCustomAuthFuncUserId", "123456"}};
         auto credentials = realm::app::AppCredentials::function(function_params);
 
@@ -823,10 +803,8 @@ TEST_CASE("app: auth providers function integration", "[sync][app]")
 
 // MARK: - Link User Tests
 
-TEST_CASE("app: link_user integration", "[sync][app]")
-{
-    SECTION("link_user intergration")
-    {
+TEST_CASE("app: link_user integration", "[sync][app]") {
+    SECTION("link_user intergration") {
 
         auto email = util::format("realm_tests_do_autoverify%1@%2.com", random_string(10), random_string(10));
 
@@ -891,8 +869,7 @@ TEST_CASE("app: link_user integration", "[sync][app]")
 
 // MARK: - Call Function Tests
 
-TEST_CASE("app: call function", "[sync][app]")
-{
+TEST_CASE("app: call function", "[sync][app]") {
     std::unique_ptr<GenericNetworkTransport> (*factory)() = [] {
         return std::unique_ptr<GenericNetworkTransport>(new IntTestTransport);
     };
@@ -942,8 +919,7 @@ TEST_CASE("app: call function", "[sync][app]")
 
 // MARK: - Remote Mongo Client Tests
 
-TEST_CASE("app: remote mongo client", "[sync][app]")
-{
+TEST_CASE("app: remote mongo client", "[sync][app]") {
 
     std::unique_ptr<GenericNetworkTransport> (*factory)() = [] {
         return std::unique_ptr<GenericNetworkTransport>(new IntTestTransport);
@@ -1028,8 +1004,7 @@ TEST_CASE("app: remote mongo client", "[sync][app]")
         CHECK(!error);
     });
 
-    SECTION("insert")
-    {
+    SECTION("insert") {
         bool processed = false;
         ObjectId dog_object_id;
         ObjectId dog2_object_id;
@@ -1113,8 +1088,7 @@ TEST_CASE("app: remote mongo client", "[sync][app]")
         CHECK(processed);
     }
 
-    SECTION("find")
-    {
+    SECTION("find") {
         bool processed = false;
 
         dog_collection.find(dog_document,
@@ -1256,8 +1230,7 @@ TEST_CASE("app: remote mongo client", "[sync][app]")
         CHECK(processed);
     }
 
-    SECTION("count and aggregate")
-    {
+    SECTION("count and aggregate") {
         bool processed = false;
 
         ObjectId dog_object_id;
@@ -1335,8 +1308,7 @@ TEST_CASE("app: remote mongo client", "[sync][app]")
         CHECK(processed);
     }
 
-    SECTION("find and update")
-    {
+    SECTION("find and update") {
 
         bool processed = false;
 
@@ -1407,8 +1379,7 @@ TEST_CASE("app: remote mongo client", "[sync][app]")
         CHECK(processed);
     }
 
-    SECTION("update")
-    {
+    SECTION("update") {
         bool processed = false;
         ObjectId dog_object_id;
 
@@ -1458,8 +1429,7 @@ TEST_CASE("app: remote mongo client", "[sync][app]")
         CHECK(processed);
     }
 
-    SECTION("update many")
-    {
+    SECTION("update many") {
         bool processed = false;
 
         dog_collection.insert_one(dog_document, [&](Optional<bson::Bson> object_id, Optional<app::AppError> error) {
@@ -1485,8 +1455,7 @@ TEST_CASE("app: remote mongo client", "[sync][app]")
         CHECK(processed);
     }
 
-    SECTION("find and replace")
-    {
+    SECTION("find and replace") {
         bool processed = false;
         ObjectId dog_object_id;
         ObjectId person_object_id;
@@ -1579,8 +1548,7 @@ TEST_CASE("app: remote mongo client", "[sync][app]")
         CHECK(processed);
     }
 
-    SECTION("delete")
-    {
+    SECTION("delete") {
 
         bool processed = false;
 
@@ -1624,8 +1592,7 @@ TEST_CASE("app: remote mongo client", "[sync][app]")
 
 // MARK: - Push Notifications Tests
 
-TEST_CASE("app: push notifications", "[sync][app]")
-{
+TEST_CASE("app: push notifications", "[sync][app]") {
 
     std::unique_ptr<GenericNetworkTransport> (*factory)() = [] {
         return std::unique_ptr<GenericNetworkTransport>(new IntTestTransport);
@@ -1664,8 +1631,7 @@ TEST_CASE("app: push notifications", "[sync][app]")
                                      sync_user = user;
                                  });
 
-    SECTION("register")
-    {
+    SECTION("register") {
         bool processed;
 
         app->push_notification_client("gcm").register_device("hello", sync_user, [&](Optional<app::AppError> error) {
@@ -1698,8 +1664,7 @@ TEST_CASE("app: push notifications", "[sync][app]")
             CHECK(processed);
         }
     */
-    SECTION("deregister")
-    {
+    SECTION("deregister") {
         bool processed;
 
         app->push_notification_client("gcm").deregister_device(sync_user, [&](Optional<app::AppError> error) {
@@ -1709,8 +1674,7 @@ TEST_CASE("app: push notifications", "[sync][app]")
         CHECK(processed);
     }
 
-    SECTION("register with unavailable service")
-    {
+    SECTION("register with unavailable service") {
         bool processed;
 
         app->push_notification_client("gcm_blah")
@@ -1722,8 +1686,7 @@ TEST_CASE("app: push notifications", "[sync][app]")
         CHECK(processed);
     }
 
-    SECTION("register with logged out user")
-    {
+    SECTION("register with logged out user") {
         bool processed;
 
         app->log_out([=](util::Optional<AppError> error) {
@@ -1746,8 +1709,7 @@ TEST_CASE("app: push notifications", "[sync][app]")
 
 // MARK: - Token refresh
 
-TEST_CASE("app: token refresh", "[sync][app]")
-{
+TEST_CASE("app: token refresh", "[sync][app]") {
 
     std::unique_ptr<GenericNetworkTransport> (*factory)() = [] {
         return std::unique_ptr<GenericNetworkTransport>(new IntTestTransport);
@@ -1792,8 +1754,7 @@ TEST_CASE("app: token refresh", "[sync][app]")
     auto dog_collection = db["Dog"];
     bson::BsonDocument dog_document{{"name", "fido"}, {"breed", "king charles"}};
 
-    SECTION("access token should refresh")
-    {
+    SECTION("access token should refresh") {
         /*
          Expected sequence of events:
          - `find_one` tries to hit the server with a bad access token
@@ -1814,8 +1775,7 @@ TEST_CASE("app: token refresh", "[sync][app]")
 
 // MARK: - Sync Tests
 
-TEST_CASE("app: sync integration", "[sync][app]")
-{
+TEST_CASE("app: sync integration", "[sync][app]") {
     std::unique_ptr<GenericNetworkTransport> (*factory)() = [] {
         return std::unique_ptr<GenericNetworkTransport>(new IntTestTransport);
     };
@@ -1903,8 +1863,7 @@ TEST_CASE("app: sync integration", "[sync][app]")
     };
 
     // MARK: Add Objects -
-    SECTION("Add Objects")
-    {
+    SECTION("Add Objects") {
         TestSyncManager& sync_manager = *new TestSyncManager(TestSyncManager::Config(app_config), {});
         {
             auto app = get_app_and_login(sync_manager.app());
@@ -1953,8 +1912,7 @@ TEST_CASE("app: sync integration", "[sync][app]")
     }
 
     // MARK: Expired Session Refresh -
-    SECTION("Expired Session Refresh")
-    {
+    SECTION("Expired Session Refresh") {
         TestSyncManager& sync_manager = *new TestSyncManager(TestSyncManager::Config(app_config), {});
         {
             auto app = get_app_and_login(sync_manager.app());
@@ -2004,8 +1962,7 @@ TEST_CASE("app: sync integration", "[sync][app]")
         }
     }
 
-    SECTION("invalid partition error handling")
-    {
+    SECTION("invalid partition error handling") {
         TestSyncManager sync_manager(TestSyncManager::Config(app_config), {});
         auto app = get_app_and_login(sync_manager.app());
         auto config = setup_and_get_config(app);
@@ -2024,8 +1981,7 @@ TEST_CASE("app: sync integration", "[sync][app]")
         REQUIRE(error_did_occur.load());
     }
 
-    SECTION("invalid pk schema error handling")
-    {
+    SECTION("invalid pk schema error handling") {
         const std::string invalid_pk_name = "my_primary_key";
         TestSyncManager sync_manager(TestSyncManager::Config(app_config), {});
         auto app = get_app_and_login(sync_manager.app());
@@ -2043,8 +1999,7 @@ TEST_CASE("app: sync integration", "[sync][app]")
                 valid_pk_name, invalid_pk_name));
     }
 
-    SECTION("missing pk schema error handling")
-    {
+    SECTION("missing pk schema error handling") {
         TestSyncManager sync_manager(TestSyncManager::Config(app_config), {});
         auto app = get_app_and_login(sync_manager.app());
         auto config = setup_and_get_config(app);
@@ -2081,10 +2036,8 @@ private:
     std::string m_message;
 };
 
-TEST_CASE("app: custom error handling", "[sync][app][custom_errors]")
-{
-    SECTION("custom code and message is sent back")
-    {
+TEST_CASE("app: custom error handling", "[sync][app][custom_errors]") {
+    SECTION("custom code and message is sent back") {
         std::unique_ptr<GenericNetworkTransport> (*factory)() = [] {
             return std::unique_ptr<GenericNetworkTransport>(new CustomErrorTransport(1001, "Boom!"));
         };
@@ -2352,10 +2305,8 @@ const std::string UnitTestTransport::user_id = "Ailuropoda melanoleuca";
 const std::string UnitTestTransport::identity_0_id = "Ursus arctos isabellinus";
 const std::string UnitTestTransport::identity_1_id = "Ursus arctos horribilis";
 
-TEST_CASE("app: login_with_credentials unit_tests", "[sync][app]")
-{
-    SECTION("login_anonymous good")
-    {
+TEST_CASE("app: login_with_credentials unit_tests", "[sync][app]") {
+    SECTION("login_anonymous good") {
         UnitTestTransport::access_token = good_access_token;
 
         bool processed = false;
@@ -2403,8 +2354,7 @@ TEST_CASE("app: login_with_credentials unit_tests", "[sync][app]")
         CHECK(processed);
     }
 
-    SECTION("login_anonymous bad")
-    {
+    SECTION("login_anonymous bad") {
         std::unique_ptr<GenericNetworkTransport> (*factory)() = [] {
             struct transport : GenericNetworkTransport {
                 void send_request_to_server(const Request request,
@@ -2462,8 +2412,7 @@ TEST_CASE("app: login_with_credentials unit_tests", "[sync][app]")
     }
 }
 
-TEST_CASE("app: UserAPIKeyProviderClient unit_tests", "[sync][app]")
-{
+TEST_CASE("app: UserAPIKeyProviderClient unit_tests", "[sync][app]") {
     std::unique_ptr<GenericNetworkTransport> (*factory)() = [] {
         return std::unique_ptr<GenericNetworkTransport>(new UnitTestTransport);
     };
@@ -2486,8 +2435,7 @@ TEST_CASE("app: UserAPIKeyProviderClient unit_tests", "[sync][app]")
     bool processed = false;
     ObjectId obj_id(UnitTestTransport::api_key_id.c_str());
 
-    SECTION("create api key")
-    {
+    SECTION("create api key") {
         app->provider_client<App::UserAPIKeyProviderClient>().create_api_key(
             UnitTestTransport::api_key_name, logged_in_user,
             [&](App::UserAPIKey user_api_key, util::Optional<AppError> error) {
@@ -2499,8 +2447,7 @@ TEST_CASE("app: UserAPIKeyProviderClient unit_tests", "[sync][app]")
             });
     }
 
-    SECTION("fetch api key")
-    {
+    SECTION("fetch api key") {
         app->provider_client<App::UserAPIKeyProviderClient>().fetch_api_key(
             obj_id, logged_in_user, [&](App::UserAPIKey user_api_key, util::Optional<AppError> error) {
                 CHECK(!error);
@@ -2510,8 +2457,7 @@ TEST_CASE("app: UserAPIKeyProviderClient unit_tests", "[sync][app]")
             });
     }
 
-    SECTION("fetch api keys")
-    {
+    SECTION("fetch api keys") {
         app->provider_client<App::UserAPIKeyProviderClient>().fetch_api_keys(
             logged_in_user, [&](std::vector<App::UserAPIKey> user_api_keys, util::Optional<AppError> error) {
                 CHECK(!error);
@@ -2528,8 +2474,7 @@ TEST_CASE("app: UserAPIKeyProviderClient unit_tests", "[sync][app]")
 }
 
 
-TEST_CASE("app: user_semantics", "[app]")
-{
+TEST_CASE("app: user_semantics", "[app]") {
     std::unique_ptr<GenericNetworkTransport> (*factory)() = [] {
         struct transport : GenericNetworkTransport {
             void send_request_to_server(const Request request, std::function<void(const Response)> completion_block)
@@ -2593,14 +2538,12 @@ TEST_CASE("app: user_semantics", "[app]")
 
     CHECK(!app->current_user());
 
-    SECTION("current user is populated")
-    {
+    SECTION("current user is populated") {
         const auto user1 = login_user_anonymous();
         CHECK(app->current_user()->identity() == user1->identity());
     }
 
-    SECTION("current user is updated on login")
-    {
+    SECTION("current user is updated on login") {
         const auto user1 = login_user_anonymous();
         CHECK(app->current_user()->identity() == user1->identity());
         const auto user2 = login_user_email_pass();
@@ -2608,8 +2551,7 @@ TEST_CASE("app: user_semantics", "[app]")
         CHECK(user1->identity() != user2->identity());
     }
 
-    SECTION("current user is updated to last used user on logout")
-    {
+    SECTION("current user is updated to last used user on logout") {
         const auto user1 = login_user_anonymous();
         CHECK(app->current_user()->identity() == user1->identity());
         CHECK(app->all_users()[0]->state() == SyncUser::State::LoggedIn);
@@ -2632,8 +2574,7 @@ TEST_CASE("app: user_semantics", "[app]")
         CHECK(app->all_users()[0]->state() == SyncUser::State::LoggedIn);
     }
 
-    SECTION("anon users are removed on logout")
-    {
+    SECTION("anon users are removed on logout") {
         const auto user1 = login_user_anonymous();
         CHECK(app->current_user()->identity() == user1->identity());
         CHECK(app->all_users()[0]->state() == SyncUser::State::LoggedIn);
@@ -2648,8 +2589,7 @@ TEST_CASE("app: user_semantics", "[app]")
         CHECK(app->all_users().size() == 0);
     }
 
-    SECTION("logout user")
-    {
+    SECTION("logout user") {
         auto user1 = login_user_email_pass();
         auto user2 = login_user_anonymous();
 
@@ -2692,8 +2632,7 @@ private:
     Response m_response;
 };
 
-TEST_CASE("app: response error handling", "[sync][app]")
-{
+TEST_CASE("app: response error handling", "[sync][app]") {
     std::string response_body = nlohmann::json({{"access_token", good_access_token},
                                                 {"refresh_token", good_access_token},
                                                 {"user_id", "Brown Bear"},
@@ -2721,8 +2660,7 @@ TEST_CASE("app: response error handling", "[sync][app]")
 
     bool processed = false;
 
-    SECTION("http 404")
-    {
+    SECTION("http 404") {
         response.http_status_code = 404;
         app->log_in_with_credentials(realm::app::AppCredentials::anonymous(),
                                      [&](std::shared_ptr<realm::SyncUser> user, Optional<app::AppError> error) {
@@ -2740,8 +2678,7 @@ TEST_CASE("app: response error handling", "[sync][app]")
                                      });
         CHECK(processed);
     }
-    SECTION("http 500")
-    {
+    SECTION("http 500") {
         response.http_status_code = 500;
         app->log_in_with_credentials(realm::app::AppCredentials::anonymous(),
                                      [&](std::shared_ptr<realm::SyncUser> user, Optional<app::AppError> error) {
@@ -2759,8 +2696,7 @@ TEST_CASE("app: response error handling", "[sync][app]")
                                      });
         CHECK(processed);
     }
-    SECTION("custom error code")
-    {
+    SECTION("custom error code") {
         response.custom_status_code = 42;
         response.body = "Custom error message";
         app->log_in_with_credentials(realm::app::AppCredentials::anonymous(),
@@ -2780,8 +2716,7 @@ TEST_CASE("app: response error handling", "[sync][app]")
         CHECK(processed);
     }
 
-    SECTION("session error code")
-    {
+    SECTION("session error code") {
         response.http_status_code = 400;
         response.body = nlohmann::json({{"error_code", "MongoDBError"},
                                         {"error", "a fake MongoDB error message!"},
@@ -2791,27 +2726,25 @@ TEST_CASE("app: response error handling", "[sync][app]")
                                         {"device_id", "Panda Bear"},
                                         {"link", "http://...whatever the server passes us"}})
                             .dump();
-        app->log_in_with_credentials(realm::app::AppCredentials::anonymous(),
-                                     [&](std::shared_ptr<realm::SyncUser> user, Optional<app::AppError> error) {
-                                         CHECK(!user);
-                                         CHECK(error);
-                                         CHECK(!error->is_http_error());
-                                         CHECK(!error->is_json_error());
-                                         CHECK(!error->is_custom_error());
-                                         CHECK(error->is_service_error());
-                                         CHECK(app::ServiceErrorCode(error->error_code.value()) ==
-                                               app::ServiceErrorCode::mongodb_error);
-                                         CHECK(error->message == std::string("a fake MongoDB error message!"));
-                                         CHECK(error->error_code.message() == "MongoDBError");
-                                         CHECK(error->link_to_server_logs ==
-                                               std::string("http://...whatever the server passes us"));
-                                         processed = true;
-                                     });
+        app->log_in_with_credentials(
+            realm::app::AppCredentials::anonymous(),
+            [&](std::shared_ptr<realm::SyncUser> user, Optional<app::AppError> error) {
+                CHECK(!user);
+                CHECK(error);
+                CHECK(!error->is_http_error());
+                CHECK(!error->is_json_error());
+                CHECK(!error->is_custom_error());
+                CHECK(error->is_service_error());
+                CHECK(app::ServiceErrorCode(error->error_code.value()) == app::ServiceErrorCode::mongodb_error);
+                CHECK(error->message == std::string("a fake MongoDB error message!"));
+                CHECK(error->error_code.message() == "MongoDBError");
+                CHECK(error->link_to_server_logs == std::string("http://...whatever the server passes us"));
+                processed = true;
+            });
         CHECK(processed);
     }
 
-    SECTION("json error code")
-    {
+    SECTION("json error code") {
         response.body = "this: is not{} a valid json body!";
         app->log_in_with_credentials(
             realm::app::AppCredentials::anonymous(),
@@ -2833,8 +2766,7 @@ TEST_CASE("app: response error handling", "[sync][app]")
     }
 }
 
-TEST_CASE("app: switch user", "[sync][app]")
-{
+TEST_CASE("app: switch user", "[sync][app]") {
     std::function<std::unique_ptr<GenericNetworkTransport>()> transport_generator = [&] {
         return std::unique_ptr<GenericNetworkTransport>(new UnitTestTransport("local-userpass"));
     };
@@ -2857,8 +2789,7 @@ TEST_CASE("app: switch user", "[sync][app]")
     std::shared_ptr<SyncUser> user_a;
     std::shared_ptr<SyncUser> user_b;
 
-    SECTION("switch user expect success")
-    {
+    SECTION("switch user expect success") {
 
         CHECK(app->sync_manager()->all_users().size() == 0);
 
@@ -2893,8 +2824,7 @@ TEST_CASE("app: switch user", "[sync][app]")
         CHECK(processed);
     }
 
-    SECTION("switch user expect fail")
-    {
+    SECTION("switch user expect fail") {
         CHECK(app->sync_manager()->all_users().size() == 0);
 
         // Log in user 1
@@ -2938,8 +2868,7 @@ TEST_CASE("app: switch user", "[sync][app]")
     }
 }
 
-TEST_CASE("app: remove anonymous user", "[sync][app]")
-{
+TEST_CASE("app: remove anonymous user", "[sync][app]") {
 
     std::function<std::unique_ptr<GenericNetworkTransport>()> transport_generator = [&] {
         return std::unique_ptr<GenericNetworkTransport>(new UnitTestTransport());
@@ -2962,8 +2891,7 @@ TEST_CASE("app: remove anonymous user", "[sync][app]")
     std::shared_ptr<SyncUser> user_a;
     std::shared_ptr<SyncUser> user_b;
 
-    SECTION("remove user expect success")
-    {
+    SECTION("remove user expect success") {
         CHECK(app->sync_manager()->all_users().size() == 0);
 
         // Log in user 1
@@ -3014,8 +2942,7 @@ TEST_CASE("app: remove anonymous user", "[sync][app]")
     }
 }
 
-TEST_CASE("app: remove user with credentials", "[sync][app]")
-{
+TEST_CASE("app: remove user with credentials", "[sync][app]") {
 
     std::unique_ptr<GenericNetworkTransport> (*transport_generator)() = [] {
         struct transport : GenericNetworkTransport {
@@ -3061,8 +2988,7 @@ TEST_CASE("app: remove user with credentials", "[sync][app]")
     bool processed = false;
     std::shared_ptr<SyncUser> test_user;
 
-    SECTION("log in, log out and remove")
-    {
+    SECTION("log in, log out and remove") {
 
         CHECK(app->sync_manager()->all_users().size() == 0);
         CHECK(app->sync_manager()->get_current_user() == nullptr);
@@ -3097,11 +3023,9 @@ TEST_CASE("app: remove user with credentials", "[sync][app]")
     }
 }
 
-TEST_CASE("app: link_user", "[sync][app]")
-{
+TEST_CASE("app: link_user", "[sync][app]") {
 
-    SECTION("link_user")
-    {
+    SECTION("link_user") {
         std::unique_ptr<GenericNetworkTransport> (*transport_generator)() = [] {
             struct transport : GenericNetworkTransport {
                 void send_request_to_server(const Request request,
@@ -3176,8 +3100,7 @@ TEST_CASE("app: link_user", "[sync][app]")
         CHECK(processed);
     }
 
-    SECTION("link_user should fail")
-    {
+    SECTION("link_user should fail") {
         std::unique_ptr<GenericNetworkTransport> (*transport_generator)() = [] {
             struct transport : GenericNetworkTransport {
                 void send_request_to_server(const Request request,
@@ -3253,51 +3176,44 @@ TEST_CASE("app: link_user", "[sync][app]")
     }
 }
 
-TEST_CASE("app: auth providers", "[sync][app]")
-{
+TEST_CASE("app: auth providers", "[sync][app]") {
 
-    SECTION("auth providers facebook")
-    {
+    SECTION("auth providers facebook") {
         auto credentials = realm::app::AppCredentials::facebook("a_token");
         CHECK(credentials.provider() == AuthProvider::FACEBOOK);
         CHECK(credentials.provider_as_string() == IdentityProviderFacebook);
         CHECK(credentials.serialize_as_json() == "{\"accessToken\":\"a_token\",\"provider\":\"oauth2-facebook\"}");
     }
 
-    SECTION("auth providers anonymous")
-    {
+    SECTION("auth providers anonymous") {
         auto credentials = realm::app::AppCredentials::anonymous();
         CHECK(credentials.provider() == AuthProvider::ANONYMOUS);
         CHECK(credentials.provider_as_string() == IdentityProviderAnonymous);
         CHECK(credentials.serialize_as_json() == "{\"provider\":\"anon-user\"}");
     }
 
-    SECTION("auth providers google")
-    {
+    SECTION("auth providers google") {
         auto credentials = realm::app::AppCredentials::google("a_token");
         CHECK(credentials.provider() == AuthProvider::GOOGLE);
         CHECK(credentials.provider_as_string() == IdentityProviderGoogle);
         CHECK(credentials.serialize_as_json() == "{\"authCode\":\"a_token\",\"provider\":\"oauth2-google\"}");
     }
 
-    SECTION("auth providers apple")
-    {
+    SECTION("auth providers apple") {
         auto credentials = realm::app::AppCredentials::apple("a_token");
         CHECK(credentials.provider() == AuthProvider::APPLE);
         CHECK(credentials.provider_as_string() == IdentityProviderApple);
         CHECK(credentials.serialize_as_json() == "{\"id_token\":\"a_token\",\"provider\":\"oauth2-apple\"}");
     }
 
-    SECTION("auth providers custom")
-    {
+    SECTION("auth providers custom") {
         auto credentials = realm::app::AppCredentials::custom("a_token");
         CHECK(credentials.provider() == AuthProvider::CUSTOM);
         CHECK(credentials.provider_as_string() == IdentityProviderCustom);
         CHECK(credentials.serialize_as_json() == "{\"provider\":\"custom-token\",\"token\":\"a_token\"}");
     }
 
-    SECTION("auth providers username password")
-    {
+    SECTION("auth providers username password") {
         auto credentials = realm::app::AppCredentials::username_password("user", "pass");
         CHECK(credentials.provider() == AuthProvider::USERNAME_PASSWORD);
         CHECK(credentials.provider_as_string() == IdentityProviderUsernamePassword);
@@ -3305,8 +3221,7 @@ TEST_CASE("app: auth providers", "[sync][app]")
               "{\"password\":\"pass\",\"provider\":\"local-userpass\",\"username\":\"user\"}");
     }
 
-    SECTION("auth providers function")
-    {
+    SECTION("auth providers function") {
         bson::BsonDocument function_params{{"name", "mongo"}};
         auto credentials = realm::app::AppCredentials::function(function_params);
         CHECK(credentials.provider() == AuthProvider::FUNCTION);
@@ -3314,16 +3229,14 @@ TEST_CASE("app: auth providers", "[sync][app]")
         CHECK(credentials.serialize_as_json() == "{\"name\":\"mongo\"}");
     }
 
-    SECTION("auth providers user api key")
-    {
+    SECTION("auth providers user api key") {
         auto credentials = realm::app::AppCredentials::user_api_key("a key");
         CHECK(credentials.provider() == AuthProvider::USER_API_KEY);
         CHECK(credentials.provider_as_string() == IdentityProviderUserAPIKey);
         CHECK(credentials.serialize_as_json() == "{\"key\":\"a key\",\"provider\":\"api-key\"}");
     }
 
-    SECTION("auth providers server api key")
-    {
+    SECTION("auth providers server api key") {
         auto credentials = realm::app::AppCredentials::server_api_key("a key");
         CHECK(credentials.provider() == AuthProvider::SERVER_API_KEY);
         CHECK(credentials.provider_as_string() == IdentityProviderServerAPIKey);
@@ -3345,8 +3258,7 @@ static App::Config get_config(Factory factory)
             "An sdk version"};
 }
 
-TEST_CASE("app: refresh access token unit tests", "[sync][app]")
-{
+TEST_CASE("app: refresh access token unit tests", "[sync][app]") {
     auto setup_user = []() {
         std::unique_ptr<GenericNetworkTransport> (*generic_factory)() = [] {
             struct transport : GenericNetworkTransport {
@@ -3384,8 +3296,7 @@ TEST_CASE("app: refresh access token unit tests", "[sync][app]")
                                       dummy_device_id);
     };
 
-    SECTION("refresh custom data happy path")
-    {
+    SECTION("refresh custom data happy path") {
         static bool session_route_hit = false;
 
         std::unique_ptr<GenericNetworkTransport> (*generic_factory)() = [] {
@@ -3430,8 +3341,7 @@ TEST_CASE("app: refresh access token unit tests", "[sync][app]")
         CHECK(processed);
     }
 
-    SECTION("refresh custom data sad path")
-    {
+    SECTION("refresh custom data sad path") {
         static bool session_route_hit = false;
 
         std::unique_ptr<GenericNetworkTransport> (*generic_factory)() = [] {
@@ -3477,8 +3387,7 @@ TEST_CASE("app: refresh access token unit tests", "[sync][app]")
         CHECK(processed);
     }
 
-    SECTION("refresh token ensure flow is correct")
-    {
+    SECTION("refresh token ensure flow is correct") {
         /*
          Expected flow:
          Login - this gets access and refresh tokens
@@ -3569,8 +3478,7 @@ TEST_CASE("app: refresh access token unit tests", "[sync][app]")
     }
 }
 
-TEST_CASE("app: metadata is persisted between sessions", "[sync][app]")
-{
+TEST_CASE("app: metadata is persisted between sessions", "[sync][app]") {
     static const auto test_hostname = "proto://host:1234";
     static const auto test_ws_hostname = "wsproto://host:1234";
 
@@ -3621,8 +3529,7 @@ TEST_CASE("app: metadata is persisted between sessions", "[sync][app]")
     }
 }
 
-TEST_CASE("app: make_streaming_request", "[sync][app]")
-{
+TEST_CASE("app: make_streaming_request", "[sync][app]") {
     UnitTestTransport::access_token = good_access_token;
 
     constexpr auto timeout_ms = 60000;
@@ -3669,8 +3576,7 @@ TEST_CASE("app: make_streaming_request", "[sync][app]")
         CHECK(req.uses_refresh_token == false);
     };
 
-    SECTION("no args")
-    {
+    SECTION("no args") {
         auto args = bson::BsonArray{};
         auto req = app->make_streaming_request(nullptr, "func", args, {"svc"});
         common_checks(req);
@@ -3681,8 +3587,7 @@ TEST_CASE("app: make_streaming_request", "[sync][app]")
 
         CHECK(req.url.find('&') == std::string::npos);
     }
-    SECTION("args")
-    {
+    SECTION("args") {
         auto args = bson::BsonArray{"arg1", "arg2"};
         auto req = app->make_streaming_request(nullptr, "func", args, {"svc"});
         common_checks(req);
@@ -3693,8 +3598,7 @@ TEST_CASE("app: make_streaming_request", "[sync][app]")
 
         CHECK(req.url.find('&') == std::string::npos);
     }
-    SECTION("percent encoding")
-    {
+    SECTION("percent encoding") {
         // These force the base64 encoding to have + and / bytes and = padding, all of which are uri encoded.
         auto args = bson::BsonArray{">>>>>?????"};
         auto req = app->make_streaming_request(nullptr, "func", args, {"svc"});
@@ -3711,8 +3615,7 @@ TEST_CASE("app: make_streaming_request", "[sync][app]")
         CHECK(req.url.find("%3D") != std::string::npos);   // = (tail padding)
         CHECK(req.url.rfind("%3D") == req.url.size() - 3); // = (tail padding)
     }
-    SECTION("with user")
-    {
+    SECTION("with user") {
         auto args = bson::BsonArray{"arg1", "arg2"};
         auto req = app->make_streaming_request(user, "func", args, {"svc"});
         common_checks(req);

--- a/test/object-store/sync/file.cpp
+++ b/test/object-store/sync/file.cpp
@@ -44,41 +44,35 @@ static void prepare_sync_manager_test()
     util::make_dir(manager_path);
 }
 
-TEST_CASE("sync_file: percent-encoding APIs", "[sync]")
-{
-    SECTION("does not encode a string that has no restricted characters")
-    {
+TEST_CASE("sync_file: percent-encoding APIs", "[sync]") {
+    SECTION("does not encode a string that has no restricted characters") {
         const std::string expected = "abcdefghijklmnopqrstuvwxyz0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZ_-";
         auto actual = make_percent_encoded_string(expected);
         REQUIRE(actual == expected);
     }
 
-    SECTION("properly encodes a sample Realm URL")
-    {
+    SECTION("properly encodes a sample Realm URL") {
         const std::string expected = "realms%3A%2F%2Fexample.com%2F%7E%2Ffoo_bar%2Fuser-realm";
         const std::string raw_string = "realms://example.com/~/foo_bar/user-realm";
         auto actual = make_percent_encoded_string(raw_string);
         REQUIRE(actual == expected);
     }
 
-    SECTION("properly decodes a sample Realm URL")
-    {
+    SECTION("properly decodes a sample Realm URL") {
         const std::string expected = "realms://example.com/~/foo_bar/user-realm";
         const std::string encoded_string = "realms%3A%2F%2Fexample.com%2F%7E%2Ffoo_bar%2Fuser-realm";
         auto actual = make_raw_string(encoded_string);
         REQUIRE(actual == expected);
     }
 
-    SECTION("properly encodes non-latin characters")
-    {
+    SECTION("properly encodes non-latin characters") {
         const std::string expected = "%D0%BF%D1%80%D0%B8%D0%B2%D0%B5%D1%82";
         const std::string raw_string = "\xd0\xbf\xd1\x80\xd0\xb8\xd0\xb2\xd0\xb5\xd1\x82";
         auto actual = make_percent_encoded_string(raw_string);
         REQUIRE(actual == expected);
     }
 
-    SECTION("properly decodes non-latin characters")
-    {
+    SECTION("properly decodes non-latin characters") {
         const std::string expected = "\xd0\xbf\xd1\x80\xd0\xb8\xd0\xb2\xd0\xb5\xd1\x82";
         const std::string encoded_string = "%D0%BF%D1%80%D0%B8%D0%B2%D0%B5%D1%82";
         auto actual = make_raw_string(encoded_string);
@@ -86,10 +80,8 @@ TEST_CASE("sync_file: percent-encoding APIs", "[sync]")
     }
 }
 
-TEST_CASE("sync_file: URL manipulation APIs", "[sync]")
-{
-    SECTION("properly concatenates a path when the path has a trailing slash")
-    {
+TEST_CASE("sync_file: URL manipulation APIs", "[sync]") {
+    SECTION("properly concatenates a path when the path has a trailing slash") {
         const std::string expected = "/foo/bar";
         const std::string path = "/foo/";
         const std::string component = "bar";
@@ -97,8 +89,7 @@ TEST_CASE("sync_file: URL manipulation APIs", "[sync]")
         REQUIRE(actual == expected);
     }
 
-    SECTION("properly concatenates a path when the component has a leading slash")
-    {
+    SECTION("properly concatenates a path when the component has a leading slash") {
         const std::string expected = "/foo/bar";
         const std::string path = "/foo";
         const std::string component = "/bar";
@@ -106,8 +97,7 @@ TEST_CASE("sync_file: URL manipulation APIs", "[sync]")
         REQUIRE(actual == expected);
     }
 
-    SECTION("properly concatenates a path when both arguments have slashes")
-    {
+    SECTION("properly concatenates a path when both arguments have slashes") {
         const std::string expected = "/foo/bar";
         const std::string path = "/foo/";
         const std::string component = "/bar";
@@ -115,8 +105,7 @@ TEST_CASE("sync_file: URL manipulation APIs", "[sync]")
         REQUIRE(actual == expected);
     }
 
-    SECTION("properly concatenates a directory path when the component doesn't have a trailing slash")
-    {
+    SECTION("properly concatenates a directory path when the component doesn't have a trailing slash") {
         const std::string expected = "/foo/bar/";
         const std::string path = "/foo/";
         const std::string component = "/bar";
@@ -124,8 +113,7 @@ TEST_CASE("sync_file: URL manipulation APIs", "[sync]")
         REQUIRE(actual == expected);
     }
 
-    SECTION("properly concatenates a directory path when the component has a trailing slash")
-    {
+    SECTION("properly concatenates a directory path when the component has a trailing slash") {
         const std::string expected = "/foo/bar/";
         const std::string path = "/foo/";
         const std::string component = "/bar/";
@@ -133,8 +121,7 @@ TEST_CASE("sync_file: URL manipulation APIs", "[sync]")
         REQUIRE(actual == expected);
     }
 
-    SECTION("properly concatenates an extension when the path has a trailing dot")
-    {
+    SECTION("properly concatenates an extension when the path has a trailing dot") {
         const std::string expected = "/foo.management";
         const std::string path = "/foo.";
         const std::string component = "management";
@@ -142,8 +129,7 @@ TEST_CASE("sync_file: URL manipulation APIs", "[sync]")
         REQUIRE(actual == expected);
     }
 
-    SECTION("properly concatenates a path when the extension has a leading dot")
-    {
+    SECTION("properly concatenates a path when the extension has a leading dot") {
         const std::string expected = "/foo.management";
         const std::string path = "/foo";
         const std::string component = ".management";
@@ -151,8 +137,7 @@ TEST_CASE("sync_file: URL manipulation APIs", "[sync]")
         REQUIRE(actual == expected);
     }
 
-    SECTION("properly concatenates a path when both arguments have dots")
-    {
+    SECTION("properly concatenates a path when both arguments have dots") {
         const std::string expected = "/foo.management";
         const std::string path = "/foo.";
         const std::string component = ".management";
@@ -161,8 +146,7 @@ TEST_CASE("sync_file: URL manipulation APIs", "[sync]")
     }
 }
 
-TEST_CASE("sync_file: SyncFileManager APIs", "[sync]")
-{
+TEST_CASE("sync_file: SyncFileManager APIs", "[sync]") {
     const std::string identity = "abcdefghi";
     const std::string local_identity = "123456789";
     const std::string app_id = "test_app_id*$#@!%1";
@@ -174,36 +158,29 @@ TEST_CASE("sync_file: SyncFileManager APIs", "[sync]")
     });
     auto manager = SyncFileManager(base_path + "syncmanager/", app_id);
 
-    SECTION("user directory APIs")
-    {
+    SECTION("user directory APIs") {
         const std::string expected = manager_path + identity + "/";
-        SECTION("getting a user directory")
-        {
-            SECTION("that didn't exist before succeeds")
-            {
+        SECTION("getting a user directory") {
+            SECTION("that didn't exist before succeeds") {
                 auto actual = manager.user_directory(identity);
                 REQUIRE(actual == expected);
                 REQUIRE_DIR_EXISTS(expected);
             }
-            SECTION("that already existed succeeds")
-            {
+            SECTION("that already existed succeeds") {
                 auto actual = manager.user_directory(identity);
                 REQUIRE(actual == expected);
                 REQUIRE_DIR_EXISTS(expected);
             }
         }
 
-        SECTION("deleting a user directory")
-        {
+        SECTION("deleting a user directory") {
             manager.user_directory(identity);
             REQUIRE_DIR_EXISTS(expected);
-            SECTION("that wasn't yet deleted succeeds")
-            {
+            SECTION("that wasn't yet deleted succeeds") {
                 manager.remove_user_directory(identity);
                 REQUIRE_DIR_DOES_NOT_EXIST(expected);
             }
-            SECTION("that was already deleted succeeds")
-            {
+            SECTION("that was already deleted succeeds") {
                 manager.remove_user_directory(identity);
                 // REQUIRE(opendir(expected.c_str()) == NULL); // FIXME: Does not work on Windows
                 REQUIRE_DIR_DOES_NOT_EXIST(expected);
@@ -211,8 +188,7 @@ TEST_CASE("sync_file: SyncFileManager APIs", "[sync]")
         }
     }
 
-    SECTION("Realm path APIs")
-    {
+    SECTION("Realm path APIs") {
         auto relative_path = "realms://r.example.com/~/my/realm/path";
         auto expected_name = manager_path + "abcdefghi/realms%3A%2F%2Fr.example.com%2F%7E%2Fmy%2Frealm%2Fpath";
         auto expected_name_with_suffix = expected_name + ".realm";
@@ -223,14 +199,12 @@ TEST_CASE("sync_file: SyncFileManager APIs", "[sync]")
             return util::hex_dump(hash.data(), hash.size(), "");
         };
 
-        SECTION("getting a Realm path")
-        {
+        SECTION("getting a Realm path") {
             auto actual = manager.realm_file_path(identity, local_identity, relative_path);
             REQUIRE(expected_name_with_suffix == actual);
         }
 
-        SECTION("deleting a Realm for a valid user")
-        {
+        SECTION("deleting a Realm for a valid user") {
             manager.realm_file_path(identity, local_identity, relative_path);
             // Create the required files
             REQUIRE(create_dummy_realm(expected_name));
@@ -245,13 +219,11 @@ TEST_CASE("sync_file: SyncFileManager APIs", "[sync]")
             REQUIRE_DIR_DOES_NOT_EXIST(expected_name + ".management");
         }
 
-        SECTION("deleting a Realm for an invalid user")
-        {
+        SECTION("deleting a Realm for an invalid user") {
             REQUIRE(!manager.remove_realm("invalid_user", relative_path));
         }
 
-        SECTION("hashed path is used if it already exists")
-        {
+        SECTION("hashed path is used if it already exists") {
             const std::string traditional_path = expected_name_with_suffix;
 
             const std::string hashed_path = manager_path + hashed_file_name(expected_name) + ".realm";
@@ -268,8 +240,7 @@ TEST_CASE("sync_file: SyncFileManager APIs", "[sync]")
             REQUIRE(!File::exists(traditional_path));
         }
 
-        SECTION("legacy local identity path is detected and used")
-        {
+        SECTION("legacy local identity path is detected and used") {
             const std::string traditional_path = expected_name_with_suffix;
 
             const std::string local_id_expected_name =
@@ -290,8 +261,7 @@ TEST_CASE("sync_file: SyncFileManager APIs", "[sync]")
             REQUIRE(!File::exists(traditional_path));
         }
 
-        SECTION("legacy sync paths are detected and used")
-        {
+        SECTION("legacy sync paths are detected and used") {
             const std::string legacy_dir = "realm-object-server/";
             const std::string old_path = manager_path + legacy_dir + local_identity +
                                          "/realms%3A%2F%2Fr.example.com%2F%7E%2Fmy%2Frealm%2Fpath";
@@ -309,8 +279,7 @@ TEST_CASE("sync_file: SyncFileManager APIs", "[sync]")
             REQUIRE(!File::exists(expected_name_with_suffix));
         }
 
-        SECTION("paths have a fallback hashed location if the preferred path is too long")
-        {
+        SECTION("paths have a fallback hashed location if the preferred path is too long") {
             const std::string long_path_name = std::string(300, 'a');
             REQUIRE(long_path_name.length() > 255); // linux name length limit
             auto actual = manager.realm_file_path(identity, local_identity, long_path_name);
@@ -320,18 +289,15 @@ TEST_CASE("sync_file: SyncFileManager APIs", "[sync]")
         }
     }
 
-    SECTION("Utility path APIs")
-    {
+    SECTION("Utility path APIs") {
         auto metadata_dir = manager_path + "server-utility/metadata/";
 
-        SECTION("getting the metadata path")
-        {
+        SECTION("getting the metadata path") {
             auto path = manager.metadata_path();
             REQUIRE(path == (metadata_dir + "sync_metadata.realm"));
         }
 
-        SECTION("removing the metadata Realm")
-        {
+        SECTION("removing the metadata Realm") {
             manager.metadata_path();
             REQUIRE_DIR_EXISTS(metadata_dir);
             manager.remove_metadata_realm();

--- a/test/object-store/sync/metadata.cpp
+++ b/test/object-store/sync/metadata.cpp
@@ -36,8 +36,7 @@ using SyncAction = SyncFileActionMetadata::Action;
 static const std::string base_path = util::make_temp_dir() + "realm_objectstore_sync_metadata";
 static const std::string metadata_path = base_path + "/metadata.realm";
 
-TEST_CASE("sync_metadata: migration", "[sync]")
-{
+TEST_CASE("sync_metadata: migration", "[sync]") {
     util::try_make_dir(base_path);
     auto close = util::make_scope_exit([=]() noexcept {
         util::try_remove_dir_recursive(base_path);
@@ -88,8 +87,7 @@ TEST_CASE("sync_metadata: migration", "[sync]")
          }},
     };
 
-    SECTION("properly upgrades from v0 to v2")
-    {
+    SECTION("properly upgrades from v0 to v2") {
         // Open v0 metadata (create a Realm directly)
         {
             Realm::Config config;
@@ -119,8 +117,7 @@ TEST_CASE("sync_metadata: migration", "[sync]")
         // Open v2 metadata
         {
             SyncMetadataManager manager(metadata_path, false, none);
-            SECTION("for existing entries")
-            {
+            SECTION("for existing entries") {
                 auto md_1 = manager.get_or_make_user_metadata(identity_1, "", false);
                 REQUIRE(bool(md_1));
                 CHECK(md_1->identity() == identity_1);
@@ -137,8 +134,7 @@ TEST_CASE("sync_metadata: migration", "[sync]")
                 CHECK(md_2->is_valid());
             }
 
-            SECTION("and creates new entries properly")
-            {
+            SECTION("and creates new entries properly") {
                 auto user_metadata = manager.get_or_make_user_metadata(identity_3, provider_type);
                 REQUIRE(user_metadata->is_valid());
                 CHECK(user_metadata->identity() == identity_3);
@@ -149,8 +145,7 @@ TEST_CASE("sync_metadata: migration", "[sync]")
         }
     }
 
-    SECTION("properly upgrades from v1 to v2")
-    {
+    SECTION("properly upgrades from v1 to v2") {
         // Open v1 metadata (create a Realm directly)
         {
             Realm::Config config;
@@ -180,8 +175,7 @@ TEST_CASE("sync_metadata: migration", "[sync]")
         // Open v2 metadata
         {
             SyncMetadataManager manager(metadata_path, false, none);
-            SECTION("for existing entries")
-            {
+            SECTION("for existing entries") {
                 auto md_1 = manager.get_or_make_user_metadata(identity_1, "", false);
                 REQUIRE(bool(md_1));
                 CHECK(md_1->identity() == identity_1);
@@ -198,8 +192,7 @@ TEST_CASE("sync_metadata: migration", "[sync]")
                 CHECK(md_2->is_valid());
             }
 
-            SECTION("and creates new entries properly")
-            {
+            SECTION("and creates new entries properly") {
                 auto user_metadata = manager.get_or_make_user_metadata(identity_3, provider_type);
                 REQUIRE(user_metadata->is_valid());
                 CHECK(user_metadata->identity() == identity_3);
@@ -213,8 +206,7 @@ TEST_CASE("sync_metadata: migration", "[sync]")
     }
 }
 
-TEST_CASE("sync_metadata: user metadata", "[sync]")
-{
+TEST_CASE("sync_metadata: user metadata", "[sync]") {
     util::try_make_dir(base_path);
     auto close = util::make_scope_exit([=]() noexcept {
         util::try_remove_dir_recursive(base_path);
@@ -223,8 +215,7 @@ TEST_CASE("sync_metadata: user metadata", "[sync]")
     SyncMetadataManager manager(metadata_path, false);
     const std::string provider_type = "https://realm.example.org";
 
-    SECTION("can be properly constructed")
-    {
+    SECTION("can be properly constructed") {
         const auto identity = "testcase1a";
         auto user_metadata = manager.get_or_make_user_metadata(identity, provider_type);
         REQUIRE(user_metadata->identity() == identity);
@@ -232,8 +223,7 @@ TEST_CASE("sync_metadata: user metadata", "[sync]")
         REQUIRE(user_metadata->access_token().empty());
     }
 
-    SECTION("properly reflects updating state")
-    {
+    SECTION("properly reflects updating state") {
         const auto identity = "testcase1b";
         const std::string sample_token = "this_is_a_user_token";
         auto user_metadata = manager.get_or_make_user_metadata(identity, provider_type);
@@ -243,8 +233,7 @@ TEST_CASE("sync_metadata: user metadata", "[sync]")
         REQUIRE(user_metadata->access_token() == sample_token);
     }
 
-    SECTION("can be properly re-retrieved from the same manager")
-    {
+    SECTION("can be properly re-retrieved from the same manager") {
         const auto identity = "testcase1c";
         const std::string sample_token = "this_is_a_user_token";
         auto first = manager.get_or_make_user_metadata(identity, provider_type);
@@ -256,8 +245,7 @@ TEST_CASE("sync_metadata: user metadata", "[sync]")
         REQUIRE(second->access_token() == sample_token);
     }
 
-    SECTION("properly reflects changes across different instances")
-    {
+    SECTION("properly reflects changes across different instances") {
         const auto identity = "testcase1d";
         const std::string sample_token_1 = "this_is_a_user_token";
         auto first = manager.get_or_make_user_metadata(identity, provider_type);
@@ -280,8 +268,7 @@ TEST_CASE("sync_metadata: user metadata", "[sync]")
         REQUIRE(second->access_token() == sample_token_2);
     }
 
-    SECTION("can be removed")
-    {
+    SECTION("can be removed") {
         const auto identity = "testcase1e";
         auto user_metadata = manager.get_or_make_user_metadata(identity, provider_type);
         REQUIRE(user_metadata->is_valid());
@@ -289,18 +276,15 @@ TEST_CASE("sync_metadata: user metadata", "[sync]")
         REQUIRE(!user_metadata->is_valid());
     }
 
-    SECTION("respects make_if_absent flag set to false in constructor")
-    {
+    SECTION("respects make_if_absent flag set to false in constructor") {
         const std::string sample_token = "this_is_a_user_token";
 
-        SECTION("with no prior metadata for the identifier")
-        {
+        SECTION("with no prior metadata for the identifier") {
             const auto identity = "testcase1g1";
             auto user_metadata = manager.get_or_make_user_metadata(identity, provider_type, false);
             REQUIRE(!user_metadata);
         }
-        SECTION("with valid prior metadata for the identifier")
-        {
+        SECTION("with valid prior metadata for the identifier") {
             const auto identity = "testcase1g2";
             auto first = manager.get_or_make_user_metadata(identity, provider_type);
             first->set_access_token(sample_token);
@@ -310,8 +294,7 @@ TEST_CASE("sync_metadata: user metadata", "[sync]")
             REQUIRE(second->provider_type() == provider_type);
             REQUIRE(second->access_token() == sample_token);
         }
-        SECTION("with invalid prior metadata for the identifier")
-        {
+        SECTION("with invalid prior metadata for the identifier") {
             const auto identity = "testcase1g3";
             auto first = manager.get_or_make_user_metadata(identity, provider_type);
             first->set_access_token(sample_token);
@@ -322,8 +305,7 @@ TEST_CASE("sync_metadata: user metadata", "[sync]")
     }
 }
 
-TEST_CASE("sync_metadata: user metadata APIs", "[sync]")
-{
+TEST_CASE("sync_metadata: user metadata APIs", "[sync]") {
     util::try_make_dir(base_path);
     auto close = util::make_scope_exit([=]() noexcept {
         util::try_remove_dir_recursive(base_path);
@@ -332,8 +314,7 @@ TEST_CASE("sync_metadata: user metadata APIs", "[sync]")
     SyncMetadataManager manager(metadata_path, false);
     const std::string provider_type = "https://realm.example.org";
 
-    SECTION("properly list all marked and unmarked users")
-    {
+    SECTION("properly list all marked and unmarked users") {
         const auto identity1 = "testcase2a1";
         const auto identity2 = "testcase2a1"; // same as identity 1
         const auto identity3 = "testcase2a3";
@@ -363,8 +344,7 @@ TEST_CASE("sync_metadata: user metadata APIs", "[sync]")
     }
 }
 
-TEST_CASE("sync_metadata: file action metadata", "[sync]")
-{
+TEST_CASE("sync_metadata: file action metadata", "[sync]") {
     util::try_make_dir(base_path);
     auto close = util::make_scope_exit([=]() noexcept {
         util::try_remove_dir_recursive(base_path);
@@ -377,8 +357,7 @@ TEST_CASE("sync_metadata: file action metadata", "[sync]")
     const std::string url_1 = "realm://realm.example.com/1";
     const std::string url_2 = "realm://realm.example.com/2";
 
-    SECTION("can be properly constructed")
-    {
+    SECTION("can be properly constructed") {
         const auto original_name = util::make_temp_dir() + "foobar/test1";
         manager.make_file_action_metadata(original_name, url_1, local_uuid_1, SyncAction::BackUpThenDeleteRealm);
         auto metadata = *manager.get_file_action_metadata(original_name);
@@ -389,8 +368,7 @@ TEST_CASE("sync_metadata: file action metadata", "[sync]")
         REQUIRE(metadata.user_local_uuid() == local_uuid_1);
     }
 
-    SECTION("properly reflects updating state, across multiple instances")
-    {
+    SECTION("properly reflects updating state, across multiple instances") {
         const auto original_name = util::make_temp_dir() + "foobar/test2a";
         const std::string new_name_1 = util::make_temp_dir() + "foobar/test2b";
         const std::string new_name_2 = util::make_temp_dir() + "foobar/test2c";
@@ -417,16 +395,14 @@ TEST_CASE("sync_metadata: file action metadata", "[sync]")
     }
 }
 
-TEST_CASE("sync_metadata: file action metadata APIs", "[sync]")
-{
+TEST_CASE("sync_metadata: file action metadata APIs", "[sync]") {
     util::try_make_dir(base_path);
     auto close = util::make_scope_exit([=]() noexcept {
         util::try_remove_dir_recursive(base_path);
     });
 
     SyncMetadataManager manager(metadata_path, false);
-    SECTION("properly list all pending actions, reflecting their deletion")
-    {
+    SECTION("properly list all pending actions, reflecting their deletion") {
         const auto filename1 = util::make_temp_dir() + "foobar/file1";
         const auto filename2 = util::make_temp_dir() + "foobar/file2";
         const auto filename3 = util::make_temp_dir() + "foobar/file3";
@@ -448,8 +424,7 @@ TEST_CASE("sync_metadata: file action metadata APIs", "[sync]")
     }
 }
 
-TEST_CASE("sync_metadata: results", "[sync]")
-{
+TEST_CASE("sync_metadata: results", "[sync]") {
     util::try_make_dir(base_path);
     auto close = util::make_scope_exit([=]() noexcept {
         util::try_remove_dir_recursive(base_path);
@@ -464,8 +439,7 @@ TEST_CASE("sync_metadata: results", "[sync]")
     const std::string provider_type_3 = "https://realm.example.org";
 
 
-    SECTION("properly update as underlying items are added")
-    {
+    SECTION("properly update as underlying items are added") {
         auto results = manager.all_unmarked_users();
         REQUIRE(results.size() == 0);
         // Add users, one at a time.
@@ -480,8 +454,7 @@ TEST_CASE("sync_metadata: results", "[sync]")
         REQUIRE(results_contains_user(results, identity3, provider_type_3));
     }
 
-    SECTION("properly update as underlying items are removed")
-    {
+    SECTION("properly update as underlying items are removed") {
         auto results = manager.all_unmarked_users();
         auto first = manager.get_or_make_user_metadata(identity1, provider_type_1);
         auto second = manager.get_or_make_user_metadata(identity2, provider_type_2);
@@ -502,15 +475,13 @@ TEST_CASE("sync_metadata: results", "[sync]")
     }
 }
 
-TEST_CASE("sync_metadata: persistence across metadata manager instances", "[sync]")
-{
+TEST_CASE("sync_metadata: persistence across metadata manager instances", "[sync]") {
     util::try_make_dir(base_path);
     auto close = util::make_scope_exit([=]() noexcept {
         util::try_remove_dir_recursive(base_path);
     });
 
-    SECTION("works for the basic case")
-    {
+    SECTION("works for the basic case") {
         const auto identity = "testcase4a";
         const std::string provider_type = "any-type";
         const std::string sample_token = "this_is_a_user_token";
@@ -534,29 +505,24 @@ TEST_CASE("sync_metadata: persistence across metadata manager instances", "[sync
     }
 }
 
-TEST_CASE("sync_metadata: encryption", "[sync]")
-{
+TEST_CASE("sync_metadata: encryption", "[sync]") {
     util::try_make_dir(base_path);
     auto close = util::make_scope_exit([=]() noexcept {
         util::try_remove_dir_recursive(base_path);
     });
 
-    SECTION("prohibits opening the metadata Realm with different keys")
-    {
-        SECTION("different keys")
-        {
+    SECTION("prohibits opening the metadata Realm with different keys") {
+        SECTION("different keys") {
             SyncMetadataManager first_manager(metadata_path, true, make_test_encryption_key(10));
             REQUIRE_THROWS(SyncMetadataManager(metadata_path, true, make_test_encryption_key(11)));
         }
-        SECTION("different encryption settings")
-        {
+        SECTION("different encryption settings") {
             SyncMetadataManager first_manager(metadata_path, true, make_test_encryption_key(10));
             REQUIRE_THROWS(SyncMetadataManager(metadata_path, false));
         }
     }
 
-    SECTION("works when enabled")
-    {
+    SECTION("works when enabled") {
         std::vector<char> key = make_test_encryption_key(10);
         const auto identity = "testcase5a";
         const auto auth_url = "https://realm.example.org";

--- a/test/object-store/sync/session/connection_change_notifications.cpp
+++ b/test/object-store/sync/session/connection_change_notifications.cpp
@@ -47,8 +47,7 @@ static const std::string dummy_device_id = "123400000000000000000000";
 
 static const std::string base_path = util::make_temp_dir() + "realm_objectstore_sync_connection_state_changes";
 
-TEST_CASE("sync: Connection state changes", "[sync]")
-{
+TEST_CASE("sync: Connection state changes", "[sync]") {
     if (!EventLoop::has_implementation())
         return;
 
@@ -60,38 +59,50 @@ TEST_CASE("sync: Connection state changes", "[sync]")
         app->sync_manager()->get_user("user", ENCODE_FAKE_JWT("not_a_real_token"),
                                       ENCODE_FAKE_JWT("also_not_a_real_token"), dummy_auth_url, dummy_device_id);
 
-    SECTION("register connection change listener")
-    {
+    SECTION("register connection change listener") {
         auto session = sync_session(
             user, "/connection-state-changes-1", [](auto, auto) {}, SyncSessionStopPolicy::AfterChangesUploaded);
 
-        EventLoop::main().run_until([&] { return sessions_are_active(*session); });
-        EventLoop::main().run_until([&] { return sessions_are_connected(*session); });
+        EventLoop::main().run_until([&] {
+            return sessions_are_active(*session);
+        });
+        EventLoop::main().run_until([&] {
+            return sessions_are_connected(*session);
+        });
 
         std::atomic<bool> listener_called(false);
-        session->register_connection_change_callback(
-            [&](SyncSession::ConnectionState, SyncSession::ConnectionState) { listener_called = true; });
+        session->register_connection_change_callback([&](SyncSession::ConnectionState, SyncSession::ConnectionState) {
+            listener_called = true;
+        });
 
         user->log_out();
-        EventLoop::main().run_until([&] { return sessions_are_disconnected(*session); });
+        EventLoop::main().run_until([&] {
+            return sessions_are_disconnected(*session);
+        });
         REQUIRE(listener_called == true);
     }
 
-    SECTION("unregister connection change listener")
-    {
+    SECTION("unregister connection change listener") {
         auto session = sync_session(
             user, "/connection-state-changes-2", [](auto, auto) {}, SyncSessionStopPolicy::AfterChangesUploaded);
 
-        EventLoop::main().run_until([&] { return sessions_are_active(*session); });
-        EventLoop::main().run_until([&] { return sessions_are_connected(*session); });
+        EventLoop::main().run_until([&] {
+            return sessions_are_active(*session);
+        });
+        EventLoop::main().run_until([&] {
+            return sessions_are_connected(*session);
+        });
 
         std::atomic<bool> listener1_called(false);
         std::atomic<bool> listener2_called(false);
         auto token1 = session->register_connection_change_callback(
-            [&](SyncSession::ConnectionState, SyncSession::ConnectionState) { listener1_called = true; });
+            [&](SyncSession::ConnectionState, SyncSession::ConnectionState) {
+                listener1_called = true;
+            });
         session->unregister_connection_change_callback(token1);
-        session->register_connection_change_callback(
-            [&](SyncSession::ConnectionState, SyncSession::ConnectionState) { listener2_called = true; });
+        session->register_connection_change_callback([&](SyncSession::ConnectionState, SyncSession::ConnectionState) {
+            listener2_called = true;
+        });
 
         user->log_out();
         REQUIRE(sessions_are_disconnected(*session));

--- a/test/object-store/sync/session/wait_for_completion.cpp
+++ b/test/object-store/sync/session/wait_for_completion.cpp
@@ -26,8 +26,7 @@
 using namespace realm;
 using namespace realm::util;
 
-TEST_CASE("SyncSession: wait_for_download_completion() API", "[sync]")
-{
+TEST_CASE("SyncSession: wait_for_download_completion() API", "[sync]") {
     if (!EventLoop::has_implementation())
         return;
 
@@ -42,49 +41,63 @@ TEST_CASE("SyncSession: wait_for_download_completion() API", "[sync]")
     auto sync_manager = init_sync_manager.app()->sync_manager();
     std::atomic<bool> handler_called(false);
 
-    SECTION("works properly when called after the session is bound")
-    {
+    SECTION("works properly when called after the session is bound") {
         server.start();
         auto user = sync_manager->get_user("user-async-wait-download-1", ENCODE_FAKE_JWT("not_a_real_token"),
                                            ENCODE_FAKE_JWT("not_a_real_token"), dummy_auth_url, dummy_device_id);
         auto session = sync_session(user, "/async-wait-download-1", [](auto, auto) {});
-        EventLoop::main().run_until([&] { return sessions_are_active(*session); });
+        EventLoop::main().run_until([&] {
+            return sessions_are_active(*session);
+        });
         // Register the download-completion notification
-        session->wait_for_download_completion([&](auto) { handler_called = true; });
-        EventLoop::main().run_until([&] { return handler_called == true; });
+        session->wait_for_download_completion([&](auto) {
+            handler_called = true;
+        });
+        EventLoop::main().run_until([&] {
+            return handler_called == true;
+        });
     }
 
-    SECTION("works properly when called on a logged-out session")
-    {
+    SECTION("works properly when called on a logged-out session") {
         server.start();
         const auto user_id = "user-async-wait-download-3";
         auto user = sync_manager->get_user(user_id, ENCODE_FAKE_JWT("not_a_real_token"),
                                            ENCODE_FAKE_JWT("not_a_real_token"), dummy_auth_url, dummy_device_id);
         auto session = sync_session(user, "/user-async-wait-download-3", [](auto, auto) {});
-        EventLoop::main().run_until([&] { return sessions_are_active(*session); });
+        EventLoop::main().run_until([&] {
+            return sessions_are_active(*session);
+        });
         // Log the user out, and wait for the sessions to log out.
         user->log_out();
-        EventLoop::main().run_until([&] { return sessions_are_inactive(*session); });
+        EventLoop::main().run_until([&] {
+            return sessions_are_inactive(*session);
+        });
         // Register the download-completion notification
-        session->wait_for_download_completion([&](auto) { handler_called = true; });
+        session->wait_for_download_completion([&](auto) {
+            handler_called = true;
+        });
         spin_runloop();
         REQUIRE(handler_called == false);
         // Log the user back in
         user = sync_manager->get_user(user_id, ENCODE_FAKE_JWT("not_a_real_token"),
                                       ENCODE_FAKE_JWT("not_a_real_token"), dummy_auth_url, dummy_device_id);
-        EventLoop::main().run_until([&] { return sessions_are_active(*session); });
+        EventLoop::main().run_until([&] {
+            return sessions_are_active(*session);
+        });
         // Now, wait for the completion handler to be called.
-        EventLoop::main().run_until([&] { return handler_called == true; });
+        EventLoop::main().run_until([&] {
+            return handler_called == true;
+        });
     }
 
-    SECTION("aborts properly when queued and the session errors out")
-    {
+    SECTION("aborts properly when queued and the session errors out") {
         using ProtocolError = realm::sync::ProtocolError;
         auto user = sync_manager->get_user("user-async-wait-download-4", ENCODE_FAKE_JWT("not_a_real_token"),
                                            ENCODE_FAKE_JWT("not_a_real_token"), dummy_auth_url, dummy_device_id);
         std::atomic<int> error_count(0);
-        std::shared_ptr<SyncSession> session =
-            sync_session(user, "/async-wait-download-4", [&](auto, auto) { ++error_count; });
+        std::shared_ptr<SyncSession> session = sync_session(user, "/async-wait-download-4", [&](auto, auto) {
+            ++error_count;
+        });
         std::error_code code =
             std::error_code{static_cast<int>(ProtocolError::bad_syntax), realm::sync::protocol_error_category()};
         // Register the download-completion notification
@@ -95,13 +108,14 @@ TEST_CASE("SyncSession: wait_for_download_completion() API", "[sync]")
         REQUIRE(handler_called == false);
         // Now trigger an error
         SyncSession::OnlyForTesting::handle_error(*session, {code, "Not a real error message", true});
-        EventLoop::main().run_until([&] { return error_count > 0; });
+        EventLoop::main().run_until([&] {
+            return error_count > 0;
+        });
         REQUIRE(handler_called == true);
     }
 }
 
-TEST_CASE("SyncSession: wait_for_upload_completion() API", "[sync]")
-{
+TEST_CASE("SyncSession: wait_for_upload_completion() API", "[sync]") {
     if (!EventLoop::has_implementation())
         return;
 
@@ -119,39 +133,53 @@ TEST_CASE("SyncSession: wait_for_upload_completion() API", "[sync]")
     auto sync_manager = init_sync_manager.app()->sync_manager();
     std::atomic<bool> handler_called(false);
 
-    SECTION("works properly when called after the session is bound")
-    {
+    SECTION("works properly when called after the session is bound") {
         server.start();
         auto user = sync_manager->get_user("user-async-wait-upload-1", ENCODE_FAKE_JWT("not_a_real_token"),
                                            ENCODE_FAKE_JWT("not_a_real_token"), dummy_auth_url, dummy_device_id);
         auto session = sync_session(user, "/async-wait-upload-1", [](auto, auto) {});
-        EventLoop::main().run_until([&] { return sessions_are_active(*session); });
+        EventLoop::main().run_until([&] {
+            return sessions_are_active(*session);
+        });
         // Register the upload-completion notification
-        session->wait_for_upload_completion([&](auto) { handler_called = true; });
-        EventLoop::main().run_until([&] { return handler_called == true; });
+        session->wait_for_upload_completion([&](auto) {
+            handler_called = true;
+        });
+        EventLoop::main().run_until([&] {
+            return handler_called == true;
+        });
     }
 
-    SECTION("works properly when called on a logged-out session")
-    {
+    SECTION("works properly when called on a logged-out session") {
         server.start();
         const auto user_id = "user-async-wait-upload-3";
         auto user = sync_manager->get_user(user_id, ENCODE_FAKE_JWT("not_a_real_token"),
                                            ENCODE_FAKE_JWT("not_a_real_token"), dummy_auth_url, dummy_device_id);
         auto session = sync_session(user, "/user-async-wait-upload-3", [](auto, auto) {});
-        EventLoop::main().run_until([&] { return sessions_are_active(*session); });
+        EventLoop::main().run_until([&] {
+            return sessions_are_active(*session);
+        });
         // Log the user out, and wait for the sessions to log out.
         user->log_out();
-        EventLoop::main().run_until([&] { return sessions_are_inactive(*session); });
+        EventLoop::main().run_until([&] {
+            return sessions_are_inactive(*session);
+        });
         // Register the upload-completion notification
-        session->wait_for_upload_completion([&](auto) { handler_called = true; });
+        session->wait_for_upload_completion([&](auto) {
+            handler_called = true;
+        });
         spin_runloop();
         REQUIRE(handler_called == false);
         // Log the user back in
         user = sync_manager->get_user(user_id, ENCODE_FAKE_JWT("not_a_real_token"),
                                       ENCODE_FAKE_JWT("not_a_real_token"), dummy_auth_url, dummy_device_id);
-        EventLoop::main().run_until([&] { return sessions_are_active(*session); });
+        EventLoop::main().run_until([&] {
+            return sessions_are_active(*session);
+        });
         // Now, wait for the completion handler to be called.
-        EventLoop::main().run_until([&] { return handler_called == true; });
+        EventLoop::main().run_until([&] {
+            return handler_called == true;
+        });
     }
 
     // FIXME: There seems to be a race condition here where the upload completion handler

--- a/test/object-store/sync/sync_manager.cpp
+++ b/test/object-store/sync/sync_manager.cpp
@@ -50,27 +50,23 @@ bool validate_user_in_vector(std::vector<std::shared_ptr<SyncUser>> vector, cons
 }
 } // anonymous namespace
 
-TEST_CASE("sync_manager: basic properties and APIs", "[sync]")
-{
+TEST_CASE("sync_manager: basic properties and APIs", "[sync]") {
     TestSyncManager init_sync_manager;
     auto app = init_sync_manager.app();
 
-    SECTION("should work for log level")
-    {
+    SECTION("should work for log level") {
         app->sync_manager()->set_log_level(util::Logger::Level::info);
         REQUIRE(app->sync_manager()->log_level() == util::Logger::Level::info);
         app->sync_manager()->set_log_level(util::Logger::Level::error);
         REQUIRE(app->sync_manager()->log_level() == util::Logger::Level::error);
     }
 
-    SECTION("should not crash on 'reconnect()'")
-    {
+    SECTION("should not crash on 'reconnect()'") {
         app->sync_manager()->reconnect();
     }
 }
 
-TEST_CASE("sync_manager: `path_for_realm` API", "[sync]")
-{
+TEST_CASE("sync_manager: `path_for_realm` API", "[sync]") {
     const std::string auth_server_url = "https://realm.example.org";
     const std::string raw_url = "realms://realm.example.org/a/b/~/123456/xyz";
     using Cfg = TestSyncManager::Config;
@@ -84,8 +80,7 @@ TEST_CASE("sync_manager: `path_for_realm` API", "[sync]")
     auto server_identity = user->identity();
     REQUIRE(server_identity == identity);
 
-    SECTION("should work properly without metadata")
-    {
+    SECTION("should work properly without metadata") {
         TestSyncManager init_sync_manager(Cfg(base_path, SyncManager::MetadataMode::NoMetadata));
         const auto expected =
             base_path +
@@ -98,8 +93,7 @@ TEST_CASE("sync_manager: `path_for_realm` API", "[sync]")
         REQUIRE_DIR_EXISTS(base_path + "mongodb-realm/app_id/foobarbaz/");
     }
 
-    SECTION("should work properly with metadata")
-    {
+    SECTION("should work properly with metadata") {
         TestSyncManager init_sync_manager(Cfg(base_path, SyncManager::MetadataMode::NoEncryption));
         const auto expected = base_path + "mongodb-realm/app_id/" + server_identity +
                               "/realms%3A%2F%2Frealm.example.org%2Fa%2Fb%2F%7E%2F123456%2Fxyz.realm";
@@ -109,8 +103,7 @@ TEST_CASE("sync_manager: `path_for_realm` API", "[sync]")
         REQUIRE_DIR_EXISTS(base_path + "mongodb-realm/app_id/" + server_identity + "/");
     }
 
-    SECTION("should produce the expected path for a string partition")
-    {
+    SECTION("should produce the expected path for a string partition") {
         TestSyncManager init_sync_manager(Cfg(base_path, SyncManager::MetadataMode::NoMetadata));
         const bson::Bson partition("string-partition-value&^#");
         SyncConfig config(user, partition);
@@ -120,8 +113,7 @@ TEST_CASE("sync_manager: `path_for_realm` API", "[sync]")
         REQUIRE_DIR_EXISTS(base_path + "mongodb-realm/app_id/foobarbaz/");
     }
 
-    SECTION("should produce a hashed path for string partitions which exceed file system path length limits")
-    {
+    SECTION("should produce a hashed path for string partitions which exceed file system path length limits") {
         TestSyncManager init_sync_manager(Cfg(base_path, SyncManager::MetadataMode::NoMetadata));
         const std::string name_too_long(500, 'b');
         REQUIRE(name_too_long.length() == 500);
@@ -136,8 +128,7 @@ TEST_CASE("sync_manager: `path_for_realm` API", "[sync]")
         REQUIRE(actual.find(expected_suffix) != std::string::npos);
     }
 
-    SECTION("should produce the expected path for a int32 partition")
-    {
+    SECTION("should produce the expected path for a int32 partition") {
         TestSyncManager init_sync_manager(Cfg(base_path, SyncManager::MetadataMode::NoMetadata));
         const bson::Bson partition(int32_t(-25));
         SyncConfig config(user, partition);
@@ -147,8 +138,7 @@ TEST_CASE("sync_manager: `path_for_realm` API", "[sync]")
         REQUIRE_DIR_EXISTS(base_path + "mongodb-realm/app_id/foobarbaz/");
     }
 
-    SECTION("should produce the expected path for a int64 partition")
-    {
+    SECTION("should produce the expected path for a int64 partition") {
         TestSyncManager init_sync_manager(Cfg(base_path, SyncManager::MetadataMode::NoMetadata));
         const bson::Bson partition(int64_t(1.15e18)); // > 32 bits
         SyncConfig config(user, partition);
@@ -158,8 +148,7 @@ TEST_CASE("sync_manager: `path_for_realm` API", "[sync]")
         REQUIRE_DIR_EXISTS(base_path + "mongodb-realm/app_id/foobarbaz/");
     }
 
-    SECTION("should produce the expected path for a ObjectId partition")
-    {
+    SECTION("should produce the expected path for a ObjectId partition") {
         TestSyncManager init_sync_manager(Cfg(base_path, SyncManager::MetadataMode::NoMetadata));
         const bson::Bson partition(ObjectId("0123456789abcdefffffffff"));
         SyncConfig config(user, partition);
@@ -169,8 +158,7 @@ TEST_CASE("sync_manager: `path_for_realm` API", "[sync]")
         REQUIRE_DIR_EXISTS(base_path + "mongodb-realm/app_id/foobarbaz/");
     }
 
-    SECTION("should produce the expected path for a Null partition")
-    {
+    SECTION("should produce the expected path for a Null partition") {
         TestSyncManager init_sync_manager(Cfg(base_path, SyncManager::MetadataMode::NoMetadata));
         const bson::Bson partition;
         REQUIRE(partition.type() == bson::Bson::Type::Null);
@@ -182,8 +170,7 @@ TEST_CASE("sync_manager: `path_for_realm` API", "[sync]")
     }
 }
 
-TEST_CASE("sync_manager: user state management", "[sync]")
-{
+TEST_CASE("sync_manager: user state management", "[sync]") {
     TestSyncManager init_sync_manager(TestSyncManager::Config(base_path, SyncManager::MetadataMode::NoEncryption));
     auto sync_manager = init_sync_manager.app()->sync_manager();
 
@@ -203,8 +190,7 @@ TEST_CASE("sync_manager: user state management", "[sync]")
     const std::string identity_2 = "user-bar";
     const std::string identity_3 = "user-baz";
 
-    SECTION("should get all users that are created during run time")
-    {
+    SECTION("should get all users that are created during run time") {
         sync_manager->get_user(identity_1, r_token_1, a_token_1, url_1, dummy_device_id);
         sync_manager->get_user(identity_2, r_token_2, a_token_2, url_2, dummy_device_id);
         auto users = sync_manager->all_users();
@@ -213,8 +199,7 @@ TEST_CASE("sync_manager: user state management", "[sync]")
         CHECK(validate_user_in_vector(users, identity_2, url_2, r_token_2, a_token_2, dummy_device_id));
     }
 
-    SECTION("should be able to distinguish users based solely on URL")
-    {
+    SECTION("should be able to distinguish users based solely on URL") {
         sync_manager->get_user(identity_1, r_token_1, a_token_1, url_1, dummy_device_id);
         sync_manager->get_user(identity_1, r_token_1, a_token_1, url_2, dummy_device_id);
         sync_manager->get_user(identity_1, r_token_1, a_token_1, url_3, dummy_device_id);
@@ -226,8 +211,7 @@ TEST_CASE("sync_manager: user state management", "[sync]")
         CHECK(validate_user_in_vector(users, identity_1, url_2, r_token_1, a_token_1, dummy_device_id));
     }
 
-    SECTION("should be able to distinguish users based solely on user ID")
-    {
+    SECTION("should be able to distinguish users based solely on user ID") {
         sync_manager->get_user(identity_1, r_token_1, a_token_1, url_1, dummy_device_id);
         sync_manager->get_user(identity_2, r_token_1, a_token_1, url_1, dummy_device_id);
         sync_manager->get_user(identity_3, r_token_1, a_token_1, url_1, dummy_device_id);
@@ -239,8 +223,7 @@ TEST_CASE("sync_manager: user state management", "[sync]")
         CHECK(validate_user_in_vector(users, identity_3, url_1, r_token_1, a_token_1, dummy_device_id));
     }
 
-    SECTION("should properly update state in response to users logging in and out")
-    {
+    SECTION("should properly update state in response to users logging in and out") {
         auto r_token_3a = ENCODE_FAKE_JWT("qwerty");
         auto a_token_3a = ENCODE_FAKE_JWT("ytrewq");
 
@@ -271,8 +254,7 @@ TEST_CASE("sync_manager: user state management", "[sync]")
         CHECK(validate_user_in_vector(users, identity_3, url_3, r_token_3a, a_token_3a, dummy_device_id));
     }
 
-    SECTION("should return current user that was created during run time")
-    {
+    SECTION("should return current user that was created during run time") {
         auto u_null = sync_manager->get_current_user();
         REQUIRE(u_null == nullptr);
 
@@ -287,8 +269,7 @@ TEST_CASE("sync_manager: user state management", "[sync]")
     }
 }
 
-TEST_CASE("sync_manager: persistent user state management", "[sync]")
-{
+TEST_CASE("sync_manager: persistent user state management", "[sync]") {
 
     reset_test_directory(base_path);
     auto file_manager = SyncFileManager(base_path, "app_id");
@@ -306,8 +287,7 @@ TEST_CASE("sync_manager: persistent user state management", "[sync]")
     const std::string a_token_2 = ENCODE_FAKE_JWT("wobble");
     const std::string a_token_3 = ENCODE_FAKE_JWT("wubble");
 
-    SECTION("when users are persisted")
-    {
+    SECTION("when users are persisted") {
         const std::string identity_1 = "foo-1";
         const std::string identity_2 = "bar-1";
         const std::string identity_3 = "baz-1";
@@ -328,8 +308,7 @@ TEST_CASE("sync_manager: persistent user state management", "[sync]")
         auto u_invalid = manager.get_or_make_user_metadata("invalid_user", url_1);
         REQUIRE(manager.all_unmarked_users().size() == 4);
 
-        SECTION("they should be added to the active users list when metadata is enabled")
-        {
+        SECTION("they should be added to the active users list when metadata is enabled") {
             TestSyncManager tsm(Cfg(base_path, SyncManager::MetadataMode::NoEncryption));
             auto users = tsm.app()->sync_manager()->all_users();
             REQUIRE(users.size() == 3);
@@ -338,16 +317,14 @@ TEST_CASE("sync_manager: persistent user state management", "[sync]")
             REQUIRE(validate_user_in_vector(users, identity_3, url_3, r_token_3, a_token_3, dummy_device_id));
         }
 
-        SECTION("they should not be added to the active users list when metadata is disabled")
-        {
+        SECTION("they should not be added to the active users list when metadata is disabled") {
             TestSyncManager tsm(Cfg(base_path, SyncManager::MetadataMode::NoMetadata));
             auto users = tsm.app()->sync_manager()->all_users();
             REQUIRE(users.size() == 0);
         }
     }
 
-    SECTION("when users are marked")
-    {
+    SECTION("when users are marked") {
         const std::string auth_url = "https://example.realm.org";
         const std::string identity_1 = "foo-2";
         const std::string identity_2 = "bar-2";
@@ -374,8 +351,7 @@ TEST_CASE("sync_manager: persistent user state management", "[sync]")
         create_dummy_realm(user_dir_3 + "bar");
         create_dummy_realm(user_dir_3 + "baz");
 
-        SECTION("they should be cleaned up if metadata is enabled")
-        {
+        SECTION("they should be cleaned up if metadata is enabled") {
             TestSyncManager tsm(Cfg(base_path, SyncManager::MetadataMode::NoEncryption));
             auto users = tsm.app()->sync_manager()->all_users();
             REQUIRE(users.size() == 1);
@@ -384,8 +360,7 @@ TEST_CASE("sync_manager: persistent user state management", "[sync]")
             REQUIRE_DIR_DOES_NOT_EXIST(user_dir_2);
             REQUIRE_DIR_EXISTS(user_dir_3);
         }
-        SECTION("they should be left alone if metadata is disabled")
-        {
+        SECTION("they should be left alone if metadata is disabled") {
             TestSyncManager tsm(Cfg(base_path, SyncManager::MetadataMode::NoMetadata));
             auto users = tsm.app()->sync_manager()->all_users();
             REQUIRE_DIR_EXISTS(user_dir_1);
@@ -395,8 +370,7 @@ TEST_CASE("sync_manager: persistent user state management", "[sync]")
     }
 }
 
-TEST_CASE("sync_manager: file actions", "[sync]")
-{
+TEST_CASE("sync_manager: file actions", "[sync]") {
     using Action = SyncFileActionMetadata::Action;
     using Cfg = TestSyncManager::Config;
     reset_test_directory(base_path);
@@ -422,15 +396,13 @@ TEST_CASE("sync_manager: file actions", "[sync]")
     const std::string realm_path_3 = file_manager.realm_file_path(uuid_3, local_uuid_3, realm_url);
     const std::string realm_path_4 = file_manager.realm_file_path(uuid_4, local_uuid_4, realm_url);
 
-    SECTION("Action::DeleteRealm")
-    {
+    SECTION("Action::DeleteRealm") {
         // Create some file actions
         manager.make_file_action_metadata(realm_path_1, realm_url, "user1", Action::DeleteRealm);
         manager.make_file_action_metadata(realm_path_2, realm_url, "user2", Action::DeleteRealm);
         manager.make_file_action_metadata(realm_path_3, realm_url, "user3", Action::DeleteRealm);
 
-        SECTION("should properly delete the Realm")
-        {
+        SECTION("should properly delete the Realm") {
             // Create some Realms
             create_dummy_realm(realm_path_1);
             create_dummy_realm(realm_path_2);
@@ -445,8 +417,7 @@ TEST_CASE("sync_manager: file actions", "[sync]")
             REQUIRE_REALM_DOES_NOT_EXIST(realm_path_3);
         }
 
-        SECTION("should fail gracefully if the Realm is missing")
-        {
+        SECTION("should fail gracefully if the Realm is missing") {
             // Don't actually create the Realm files
             REQUIRE_REALM_DOES_NOT_EXIST(realm_path_1);
             REQUIRE_REALM_DOES_NOT_EXIST(realm_path_2);
@@ -456,8 +427,7 @@ TEST_CASE("sync_manager: file actions", "[sync]")
             CHECK(pending_actions.size() == 0);
         }
 
-        SECTION("should do nothing if metadata is disabled")
-        {
+        SECTION("should do nothing if metadata is disabled") {
             // Create some Realms
             create_dummy_realm(realm_path_1);
             create_dummy_realm(realm_path_2);
@@ -473,8 +443,7 @@ TEST_CASE("sync_manager: file actions", "[sync]")
         }
     }
 
-    SECTION("Action::BackUpThenDeleteRealm")
-    {
+    SECTION("Action::BackUpThenDeleteRealm") {
         const auto recovery_dir = file_manager.recovery_directory_path();
         // Create some file actions
         const std::string recovery_1 = util::file_path_by_appending_component(recovery_dir, "recovery-1");
@@ -487,8 +456,7 @@ TEST_CASE("sync_manager: file actions", "[sync]")
         manager.make_file_action_metadata(realm_path_3, realm_url, "user3", Action::BackUpThenDeleteRealm,
                                           recovery_3);
 
-        SECTION("should properly copy the Realm file and delete the Realm")
-        {
+        SECTION("should properly copy the Realm file and delete the Realm") {
             // Create some Realms
             create_dummy_realm(realm_path_1);
             create_dummy_realm(realm_path_2);
@@ -507,8 +475,7 @@ TEST_CASE("sync_manager: file actions", "[sync]")
             CHECK(File::exists(recovery_3));
         }
 
-        SECTION("should copy the Realm to the recovery_directory_path")
-        {
+        SECTION("should copy the Realm to the recovery_directory_path") {
             const std::string identity = "b241922032489d4836ecd0c82d0445f0";
             const auto realm_base_path = file_manager.user_directory(identity) + "realmtasks";
             std::string recovery_path = util::reserve_unique_file_name(
@@ -530,8 +497,7 @@ TEST_CASE("sync_manager: file actions", "[sync]")
             REQUIRE_REALM_DOES_NOT_EXIST(realm_base_path);
         }
 
-        SECTION("should fail gracefully if the Realm is missing")
-        {
+        SECTION("should fail gracefully if the Realm is missing") {
             // Don't actually create the Realm files
             REQUIRE_REALM_DOES_NOT_EXIST(realm_path_1);
             REQUIRE_REALM_DOES_NOT_EXIST(realm_path_2);
@@ -546,8 +512,7 @@ TEST_CASE("sync_manager: file actions", "[sync]")
             CHECK(!File::exists(util::file_path_by_appending_component(recovery_dir, recovery_3)));
         }
 
-        SECTION("should work properly when manually driven")
-        {
+        SECTION("should work properly when manually driven") {
             REQUIRE(!File::exists(recovery_1));
             // Create a Realm file
             create_dummy_realm(realm_path_4);
@@ -568,8 +533,7 @@ TEST_CASE("sync_manager: file actions", "[sync]")
             REQUIRE(manager.all_pending_actions().size() == 0);
         }
 
-        SECTION("should fail gracefully if there is already a file at the destination")
-        {
+        SECTION("should fail gracefully if there is already a file at the destination") {
             // Create some Realms
             create_dummy_realm(realm_path_1);
             create_dummy_realm(realm_path_2);
@@ -588,8 +552,7 @@ TEST_CASE("sync_manager: file actions", "[sync]")
             CHECK(File::exists(recovery_3));
         }
 
-        SECTION("should do nothing if metadata is disabled")
-        {
+        SECTION("should do nothing if metadata is disabled") {
             // Create some Realms
             create_dummy_realm(realm_path_1);
             create_dummy_realm(realm_path_2);
@@ -610,8 +573,7 @@ TEST_CASE("sync_manager: file actions", "[sync]")
     }
 }
 
-TEST_CASE("sync_manager: metadata")
-{
+TEST_CASE("sync_manager: metadata") {
     TestSyncManager init_sync_manager(
         TestSyncManager::Config(base_path, realm::SyncManager::MetadataMode::NoEncryption));
     auto sync_manager = init_sync_manager.app()->sync_manager();
@@ -631,8 +593,7 @@ TEST_CASE("sync_manager: metadata")
     app_config.platform_version = "OS Test Platform Version";
     app_config.sdk_version = "SDK Version";
 
-    SECTION("should be reset in case of decryption error")
-    {
+    SECTION("should be reset in case of decryption error") {
         SyncClientConfig config;
         config.base_file_path = base_path;
         config.metadata_mode = SyncManager::MetadataMode::Encryption;
@@ -645,16 +606,14 @@ TEST_CASE("sync_manager: metadata")
     }
 }
 
-TEST_CASE("sync_manager: has_active_sessions", "[active_sessions]")
-{
+TEST_CASE("sync_manager: has_active_sessions", "[active_sessions]") {
     reset_test_directory(base_path);
 
     TestSyncManager init_sync_manager(TestSyncManager::Config(base_path, SyncManager::MetadataMode::NoEncryption),
                                       {false});
     auto sync_manager = init_sync_manager.app()->sync_manager();
 
-    SECTION("no active sessions")
-    {
+    SECTION("no active sessions") {
         REQUIRE(!sync_manager->has_existing_sessions());
     }
 
@@ -672,14 +631,18 @@ TEST_CASE("sync_manager: has_active_sessions", "[active_sessions]")
                                        "https://realm.example.org", dummy_device_id);
     auto create_session = [&](SyncSessionStopPolicy stop_policy) {
         std::shared_ptr<SyncSession> session = sync_session(
-            user, "/test-dying-state", [&](auto, auto) { error_handler_invoked = true; }, stop_policy, nullptr,
-            schema, &config);
-        EventLoop::main().run_until([&] { return sessions_are_active(*session); });
+            user, "/test-dying-state",
+            [&](auto, auto) {
+                error_handler_invoked = true;
+            },
+            stop_policy, nullptr, schema, &config);
+        EventLoop::main().run_until([&] {
+            return sessions_are_active(*session);
+        });
         return session;
     };
 
-    SECTION("active sessions")
-    {
+    SECTION("active sessions") {
         {
             auto session = create_session(SyncSessionStopPolicy::Immediately);
             REQUIRE(sync_manager->has_existing_sessions());

--- a/test/object-store/sync/user.cpp
+++ b/test/object-store/sync/user.cpp
@@ -35,8 +35,7 @@ using File = realm::util::File;
 static const std::string base_path = util::make_temp_dir() + "realm_objectstore_sync_user/";
 static const std::string dummy_device_id = "123400000000000000000000";
 
-TEST_CASE("sync_user: SyncManager `get_user()` API", "[sync]")
-{
+TEST_CASE("sync_user: SyncManager `get_user()` API", "[sync]") {
     TestSyncManager init_sync_manager(TestSyncManager::Config(base_path), {});
     auto sync_manager = init_sync_manager.app()->sync_manager();
     const std::string identity = "sync_test_identity";
@@ -44,8 +43,7 @@ TEST_CASE("sync_user: SyncManager `get_user()` API", "[sync]")
     const std::string access_token = ENCODE_FAKE_JWT("1234567890-fake-access-token");
     const std::string server_url = "https://realm.example.org";
 
-    SECTION("properly creates a new normal user")
-    {
+    SECTION("properly creates a new normal user") {
         auto user = sync_manager->get_user(identity, refresh_token, access_token, server_url, dummy_device_id);
         REQUIRE(user);
         // The expected state for a newly created user:
@@ -56,8 +54,7 @@ TEST_CASE("sync_user: SyncManager `get_user()` API", "[sync]")
         REQUIRE(user->state() == SyncUser::State::LoggedIn);
     }
 
-    SECTION("properly retrieves a previously created user, updating fields as necessary")
-    {
+    SECTION("properly retrieves a previously created user, updating fields as necessary") {
         const std::string second_refresh_token = ENCODE_FAKE_JWT("0987654321-fake-refresh-token");
         const std::string second_access_token = ENCODE_FAKE_JWT("0987654321-fake-access-token");
 
@@ -74,8 +71,7 @@ TEST_CASE("sync_user: SyncManager `get_user()` API", "[sync]")
         REQUIRE(second->refresh_token() == second_refresh_token);
     }
 
-    SECTION("properly resurrects a logged-out user")
-    {
+    SECTION("properly resurrects a logged-out user") {
         const std::string second_refresh_token = ENCODE_FAKE_JWT("0987654321-fake-refresh-token");
         const std::string second_access_token = ENCODE_FAKE_JWT("0987654321-fake-access-token");
 
@@ -93,8 +89,7 @@ TEST_CASE("sync_user: SyncManager `get_user()` API", "[sync]")
     }
 }
 
-TEST_CASE("sync_user: SyncManager `get_existing_logged_in_user()` API", "[sync]")
-{
+TEST_CASE("sync_user: SyncManager `get_existing_logged_in_user()` API", "[sync]") {
     TestSyncManager init_sync_manager(TestSyncManager::Config(base_path, SyncManager::MetadataMode::NoMetadata));
     auto sync_manager = init_sync_manager.app()->sync_manager();
     const std::string identity = "sync_test_identity";
@@ -102,14 +97,12 @@ TEST_CASE("sync_user: SyncManager `get_existing_logged_in_user()` API", "[sync]"
     const std::string access_token = ENCODE_FAKE_JWT("1234567890-fake-access-token");
     const std::string server_url = "https://realm.example.org";
 
-    SECTION("properly returns a null pointer when called for a non-existent user")
-    {
+    SECTION("properly returns a null pointer when called for a non-existent user") {
         std::shared_ptr<SyncUser> user = sync_manager->get_existing_logged_in_user(identity);
         REQUIRE(!user);
     }
 
-    SECTION("properly returns an existing logged-in user")
-    {
+    SECTION("properly returns an existing logged-in user") {
         auto first = sync_manager->get_user(identity, refresh_token, access_token, server_url, dummy_device_id);
         REQUIRE(first->identity() == identity);
         REQUIRE(first->state() == SyncUser::State::LoggedIn);
@@ -120,8 +113,7 @@ TEST_CASE("sync_user: SyncManager `get_existing_logged_in_user()` API", "[sync]"
         REQUIRE(second->refresh_token() == refresh_token);
     }
 
-    SECTION("properly returns a null pointer for a logged-out user")
-    {
+    SECTION("properly returns a null pointer for a logged-out user") {
         auto first = sync_manager->get_user(identity, refresh_token, access_token, server_url, dummy_device_id);
         first->log_out();
         REQUIRE(first->identity() == identity);
@@ -132,8 +124,7 @@ TEST_CASE("sync_user: SyncManager `get_existing_logged_in_user()` API", "[sync]"
     }
 }
 
-TEST_CASE("sync_user: logout", "[sync]")
-{
+TEST_CASE("sync_user: logout", "[sync]") {
     TestSyncManager init_sync_manager(TestSyncManager::Config(base_path, SyncManager::MetadataMode::NoMetadata));
     auto sync_manager = init_sync_manager.app()->sync_manager();
     const std::string identity = "sync_test_identity";
@@ -141,8 +132,7 @@ TEST_CASE("sync_user: logout", "[sync]")
     const std::string access_token = ENCODE_FAKE_JWT("1234567890-fake-access-token");
     const std::string server_url = "https://realm.example.org";
 
-    SECTION("properly changes the state of the user object")
-    {
+    SECTION("properly changes the state of the user object") {
         auto user = sync_manager->get_user(identity, refresh_token, access_token, server_url, dummy_device_id);
         REQUIRE(user->state() == SyncUser::State::LoggedIn);
         user->log_out();
@@ -150,8 +140,7 @@ TEST_CASE("sync_user: logout", "[sync]")
     }
 }
 
-TEST_CASE("sync_user: user persistence", "[sync]")
-{
+TEST_CASE("sync_user: user persistence", "[sync]") {
     TestSyncManager init_sync_manager(
         TestSyncManager::Config("baz_app_id", base_path, SyncManager::MetadataMode::NoEncryption));
     auto sync_manager = init_sync_manager.app()->sync_manager();
@@ -159,8 +148,7 @@ TEST_CASE("sync_user: user persistence", "[sync]")
     // Open the metadata separately, so we can investigate it ourselves.
     SyncMetadataManager manager(file_manager.metadata_path(), false);
 
-    SECTION("properly persists a user's information upon creation")
-    {
+    SECTION("properly persists a user's information upon creation") {
         const std::string identity = "test_identity_1";
         const std::string refresh_token = ENCODE_FAKE_JWT("r-token-1");
         const std::string access_token = ENCODE_FAKE_JWT("a-token-1");
@@ -179,8 +167,7 @@ TEST_CASE("sync_user: user persistence", "[sync]")
         REQUIRE(metadata->identities() == identities);
     }
 
-    SECTION("properly removes a user's access/refresh token upon log out")
-    {
+    SECTION("properly removes a user's access/refresh token upon log out") {
         const std::string identity = "test_identity_1";
         const std::string refresh_token = ENCODE_FAKE_JWT("r-token-1");
         const std::string access_token = ENCODE_FAKE_JWT("a-token-1");
@@ -202,8 +189,7 @@ TEST_CASE("sync_user: user persistence", "[sync]")
         REQUIRE(user->is_logged_in() == false);
     }
 
-    SECTION("properly persists a user's information when the user is updated")
-    {
+    SECTION("properly persists a user's information when the user is updated") {
         const std::string identity = "test_identity_2";
         const std::string refresh_token = ENCODE_FAKE_JWT("r_token-2a");
         const std::string access_token = ENCODE_FAKE_JWT("a_token-1a");
@@ -221,8 +207,7 @@ TEST_CASE("sync_user: user persistence", "[sync]")
         REQUIRE(second_metadata->access_token() == token_2);
     }
 
-    SECTION("properly does not mark a user when the user is logged out and not anon")
-    {
+    SECTION("properly does not mark a user when the user is logged out and not anon") {
         const std::string identity = "test_identity_3";
         const std::string refresh_token = ENCODE_FAKE_JWT("r-token-3");
         const std::string access_token = ENCODE_FAKE_JWT("a-token-3");
@@ -237,8 +222,7 @@ TEST_CASE("sync_user: user persistence", "[sync]")
         REQUIRE(marked_users.size() == 0);
     }
 
-    SECTION("properly removes a user when the user is logged out and is anon")
-    {
+    SECTION("properly removes a user when the user is logged out and is anon") {
         const std::string identity = "test_identity_3";
         const std::string refresh_token = ENCODE_FAKE_JWT("r-token-3");
         const std::string access_token = ENCODE_FAKE_JWT("a-token-3");
@@ -252,8 +236,7 @@ TEST_CASE("sync_user: user persistence", "[sync]")
         REQUIRE(sync_manager->all_users().size() == 0);
     }
 
-    SECTION("properly revives a logged-out user when it's requested again")
-    {
+    SECTION("properly revives a logged-out user when it's requested again") {
         const std::string identity = "test_identity_3";
         const std::string refresh_token = ENCODE_FAKE_JWT("r-token-4a");
         const std::string access_token = ENCODE_FAKE_JWT("a-token-4a");

--- a/test/object-store/util/event_loop.cpp
+++ b/test/object-store/util/event_loop.cpp
@@ -165,8 +165,9 @@ struct IdleHandler {
     }
     ~IdleHandler()
     {
-        uv_close(reinterpret_cast<uv_handle_t*>(idle),
-                 [](uv_handle_t* handle) { delete reinterpret_cast<uv_idle_t*>(handle); });
+        uv_close(reinterpret_cast<uv_handle_t*>(idle), [](uv_handle_t* handle) {
+            delete reinterpret_cast<uv_idle_t*>(handle);
+        });
     }
 };
 

--- a/test/object-store/util/test_file.cpp
+++ b/test/object-store/util/test_file.cpp
@@ -120,7 +120,9 @@ SyncTestFile::SyncTestFile(std::shared_ptr<app::App> app, std::string name, std:
                                                                    app->base_url(), fake_device_id),
                                      name);
     sync_config->stop_policy = SyncSessionStopPolicy::Immediately;
-    sync_config->error_handler = [](auto, auto) { abort(); };
+    sync_config->error_handler = [](auto, auto) {
+        abort();
+    };
     schema_mode = SchemaMode::Additive;
 }
 
@@ -164,7 +166,9 @@ SyncServer::~SyncServer()
 void SyncServer::start()
 {
     REALM_ASSERT(!m_thread.joinable());
-    m_thread = std::thread([this] { m_server.run(); });
+    m_thread = std::thread([this] {
+        m_server.run();
+    });
 }
 
 void SyncServer::stop()
@@ -194,7 +198,9 @@ static std::error_code wait_for_session(Realm& realm, void (SyncSession::*fn)(st
         cv.notify_one();
     });
     std::unique_lock<std::mutex> lock(wait_mutex);
-    cv.wait(lock, [&]() { return wait_flag == true; });
+    cv.wait(lock, [&]() {
+        return wait_flag == true;
+    });
     return ec;
 }
 
@@ -281,7 +287,9 @@ static class TsanNotifyWorker {
 public:
     TsanNotifyWorker()
     {
-        m_thread = std::thread([&] { work(); });
+        m_thread = std::thread([&] {
+            work();
+        });
     }
 
     void work()

--- a/test/object-store/uuid.cpp
+++ b/test/object-store/uuid.cpp
@@ -25,9 +25,10 @@
 
 using namespace realm;
 
-TEST_CASE("uuid")
-{
-    auto isxdigit = [](char c) { return std::isxdigit(c); };
+TEST_CASE("uuid") {
+    auto isxdigit = [](char c) {
+        return std::isxdigit(c);
+    };
 
     auto uuid = util::uuid_string();
     INFO("uuid: " << uuid);


### PR DESCRIPTION
By default clang-format incorrectly inserts a newline after SECTION because it doesn't know that SECTION and TEST_CASE are control statements.

All of the changes here to files other than .clang-format and clang.Dockerfile are just the result of rerunning clang-format on the test files.