### PR TITLE
WIP - Discussion only: Online defragmentation

### DIFF
--- a/src/realm/alloc_slab.cpp
+++ b/src/realm/alloc_slab.cpp
@@ -521,6 +521,7 @@ void SlabAlloc::do_free(ref_type ref, char* addr)
         try {
             REALM_ASSERT_RELEASE_EX(ref != 0, ref, get_file_path_for_assertions());
             REALM_ASSERT_RELEASE_EX(!(ref & 7), ref, get_file_path_for_assertions());
+            std::cout << " * releasing [" << ref << " : " << ref + size << "]" << std::endl;
             auto next = m_free_read_only.lower_bound(ref);
             if (next != m_free_read_only.end()) {
                 REALM_ASSERT_RELEASE_EX(ref + size <= next->first, ref, size, next->first, next->second, get_file_path_for_assertions());

--- a/src/realm/alloc_slab.cpp
+++ b/src/realm/alloc_slab.cpp
@@ -521,7 +521,6 @@ void SlabAlloc::do_free(ref_type ref, char* addr)
         try {
             REALM_ASSERT_RELEASE_EX(ref != 0, ref, get_file_path_for_assertions());
             REALM_ASSERT_RELEASE_EX(!(ref & 7), ref, get_file_path_for_assertions());
-            std::cout << " * releasing [" << ref << " : " << ref + size << "]" << std::endl;
             auto next = m_free_read_only.lower_bound(ref);
             if (next != m_free_read_only.end()) {
                 REALM_ASSERT_RELEASE_EX(ref + size <= next->first, ref, size, next->first, next->second, get_file_path_for_assertions());

--- a/src/realm/alloc_slab.cpp
+++ b/src/realm/alloc_slab.cpp
@@ -215,7 +215,6 @@ MemRef SlabAlloc::do_alloc(size_t size)
     FreeBlock* entry = allocate_block(static_cast<int>(size));
     mark_allocated(entry);
     ref_type ref = entry->ref;
-
 #ifdef REALM_DEBUG
     if (REALM_COVER_NEVER(m_debug_out))
         std::cerr << "Alloc ref: " << ref << " size: " << size << "\n";
@@ -457,7 +456,6 @@ SlabAlloc::FreeBlock* SlabAlloc::grow_slab(int size)
         new_size = already_allocated;
     if (new_size > maximal_alloc)
         new_size = maximal_alloc;
-
     ref_type ref;
     if (m_slabs.empty()) {
         ref = m_baseline.load(std::memory_order_relaxed);

--- a/src/realm/array.cpp
+++ b/src/realm/array.cpp
@@ -306,7 +306,6 @@ ref_type Array::write(ref_type ref, Allocator& alloc, _impl::ArrayWriterBase& ou
         else
             result = array.do_write_deep(out, only_if_modified); // Throws
     }
-    std::cout << "ToDisk-write " << ref << " -> " << result << std::endl;
     return result;
 }
 
@@ -343,7 +342,6 @@ ref_type Array::do_write_deep(_impl::ArrayWriterBase& out, bool only_if_modified
         }
         new_array.add(value); // Throws
     }
-    std::cout << "COPY: " << m_ref << " -> " << new_array.m_ref << std::endl;
     return new_array.do_write_shallow(out); // Throws
 }
 

--- a/src/realm/array.hpp
+++ b/src/realm/array.hpp
@@ -1094,20 +1094,6 @@ inline ref_type Array::write(_impl::ArrayWriterBase& out, bool deep, bool only_i
     return do_write_deep(out, only_if_modified); // Throws
 }
 
-inline ref_type Array::write(ref_type ref, Allocator& alloc, _impl::ArrayWriterBase& out, bool only_if_modified)
-{
-    if (only_if_modified && alloc.is_read_only(ref))
-        return ref;
-
-    Array array(alloc);
-    array.init_from_ref(ref);
-
-    if (!array.m_has_refs)
-        return array.do_write_shallow(out); // Throws
-
-    return array.do_write_deep(out, only_if_modified); // Throws
-}
-
 inline void Array::add(int_fast64_t value)
 {
     insert(m_size, value);

--- a/src/realm/db.cpp
+++ b/src/realm/db.cpp
@@ -2216,6 +2216,7 @@ void DB::low_level_commit(uint_fast64_t new_version, Transaction& transaction)
         std::lock_guard<InterprocessMutex> lock(m_controlmutex); // Throws
         new_top_ref = out.write_group();                         // Throws
     }
+    transaction.m_evacuated = out.evacuated();
     {
         // protect access to shared variables and m_reader_mapping from here
         std::lock_guard<std::recursive_mutex> lock_guard(m_mutex);

--- a/src/realm/db.cpp
+++ b/src/realm/db.cpp
@@ -2245,13 +2245,13 @@ void DB::low_level_commit(uint_fast64_t new_version, Transaction& transaction)
     if (evac_start == 0) {
         size_t logical_file_size = out.get_logical_file_size();
         // 1. We want at least 25% free space. Otherwise it's better to just extend the file to get there
-        if (allocatable > (logical_file_size >> 2)) {
-            std::cout << "<<< Enabling defragmentation >>>" << std::endl;
+        if (logical_file_size > 64 * 1024 && allocatable > (logical_file_size >> 2)) {
             // 2. We'll split the file in 8 equally sized sectors, pick the last.
             // TODO: instead pick the one with most fragmentation - fragmentation is 1 - (largest_free/total_free)
-            evac_start = 7 * logical_file_size / 8;
+            evac_start = round_up_to_page_size(7 * logical_file_size / 8);
             evac_end = logical_file_size;
             progress_vector.resize(0);
+            std::cout << "<<< Enabling defragmentation, zone [ " << evac_start << " : " << evac_end <<  " ] >>>" << std::endl;
         }
     }
     // Save updated defrag parameters as part of commit

--- a/src/realm/db.hpp
+++ b/src/realm/db.hpp
@@ -558,7 +558,7 @@ public:
     /// than what will eventually be needed as we reserve a bit more memory than
     /// what will be needed.
     size_t get_commit_size() const;
-
+    void set_evacuation_zone(size_t evac_start, size_t evac_end);
     DB::version_type commit();
     void rollback();
     void end_read();
@@ -638,6 +638,8 @@ private:
 
     DB::ReadLockInfo m_read_lock;
     DB::TransactStage m_transact_stage = DB::transact_Ready;
+    size_t m_evac_start = 0;
+    size_t m_evac_end = 0;
 
     friend class DB;
     friend class DisableReplication;
@@ -810,6 +812,13 @@ inline DB::TransactStage Transaction::get_transact_stage() const noexcept
 {
     return m_transact_stage;
 }
+
+inline void Transaction::set_evacuation_zone(size_t evac_start, size_t evac_end)
+{
+    m_evac_start = evac_start;
+    m_evac_end = evac_end;
+}
+
 
 class DB::ReadLockGuard {
 public:

--- a/src/realm/db.hpp
+++ b/src/realm/db.hpp
@@ -559,7 +559,6 @@ public:
     /// what will be needed.
     size_t get_commit_size() const;
     void set_evacuation_zone(size_t evac_start, size_t evac_end);
-    bool evacuated();
     DB::version_type commit();
     void rollback();
     void end_read();
@@ -639,9 +638,6 @@ private:
 
     DB::ReadLockInfo m_read_lock;
     DB::TransactStage m_transact_stage = DB::transact_Ready;
-    size_t m_evac_start = 0;
-    size_t m_evac_end = 0;
-    bool m_evacuated = false;
 
     friend class DB;
     friend class DisableReplication;
@@ -815,17 +811,6 @@ inline DB::TransactStage Transaction::get_transact_stage() const noexcept
     return m_transact_stage;
 }
 
-inline void Transaction::set_evacuation_zone(size_t evac_start, size_t evac_end)
-{
-    m_evac_start = evac_start;
-    m_evac_end = evac_end;
-    m_evacuated = false;
-}
-
-inline bool Transaction::evacuated()
-{
-    return m_evacuated;
-}
 
 class DB::ReadLockGuard {
 public:

--- a/src/realm/db.hpp
+++ b/src/realm/db.hpp
@@ -559,6 +559,7 @@ public:
     /// what will be needed.
     size_t get_commit_size() const;
     void set_evacuation_zone(size_t evac_start, size_t evac_end);
+    bool evacuated();
     DB::version_type commit();
     void rollback();
     void end_read();
@@ -640,6 +641,7 @@ private:
     DB::TransactStage m_transact_stage = DB::transact_Ready;
     size_t m_evac_start = 0;
     size_t m_evac_end = 0;
+    bool m_evacuated = false;
 
     friend class DB;
     friend class DisableReplication;
@@ -817,8 +819,13 @@ inline void Transaction::set_evacuation_zone(size_t evac_start, size_t evac_end)
 {
     m_evac_start = evac_start;
     m_evac_end = evac_end;
+    m_evacuated = false;
 }
 
+inline bool Transaction::evacuated()
+{
+    return m_evacuated;
+}
 
 class DB::ReadLockGuard {
 public:

--- a/src/realm/group.cpp
+++ b/src/realm/group.cpp
@@ -1261,7 +1261,11 @@ void Group::recursive_touch(int level, Array& parent, ref_type first, ref_type l
 
 void Group::touch(ref_type first, ref_type last)
 {
+    recursive_touch(1, m_table_names, first, last);
+    recursive_touch(1, m_tables, first, last);
+    // ^ must be done before, so that touching their entries in the top array has no effect.
     recursive_touch(0, m_top, first, last);
+    std::cout << "Touch completed with m_top at " << m_top.m_ref << std::endl << std::endl;
 }
 
 void Group::commit()
@@ -1289,7 +1293,7 @@ void Group::commit()
     size_t old_baseline = m_alloc.get_baseline();
 
     // Update view of the file
-    size_t new_file_size = out.get_file_size();
+    size_t new_file_size = out.get_physical_file_size();
     m_alloc.update_reader_view(new_file_size); // Throws
     update_allocator_wrappers(true);
 

--- a/src/realm/group.cpp
+++ b/src/realm/group.cpp
@@ -1236,9 +1236,11 @@ void Group::write(std::ostream& out, int file_format_version, TableWriter& table
     out_2.write(reinterpret_cast<const char*>(&footer), sizeof footer);
 }
 
-bool Group::recursive_touch(int level, Array& parent, ref_type first, ref_type last, std::vector<int>& progress_vector, size_t& work_limit)
+bool Group::recursive_touch(size_t level, Array& parent, ref_type first, ref_type last, std::vector<unsigned>& progress_vector, size_t& work_limit)
 {
+#ifdef DEBUG_TOUCH
     std::cout << parent.get_ref() << ",  sz = " << parent.size() << std::endl;
+#endif
     if (parent.get_ref() >= first && parent.get_ref() < last)
         parent.copy_on_write();
     if (parent.has_refs()) {
@@ -1256,9 +1258,11 @@ bool Group::recursive_touch(int level, Array& parent, ref_type first, ref_type l
                     ++progress_vector[level];
                     continue;
                 }
+#ifdef DEBUG_TOUCH
                 for (int k = 0; k < level; ++k)
                     std::cout << "    ";
                 std::cout << parent.get_ref() << "[" << i << "] = ";
+#endif
                 arr.init_from_ref(ref);
                 arr.set_parent(&parent, i);
                 auto done = recursive_touch(1 + level, arr, first, last, progress_vector, work_limit);
@@ -1274,7 +1278,7 @@ bool Group::recursive_touch(int level, Array& parent, ref_type first, ref_type l
     return true;
 }
 
-void Group::touch(ref_type first, ref_type last, std::vector<int>& progress_vector, size_t work_limit)
+void Group::touch(ref_type first, ref_type last, std::vector<unsigned>& progress_vector, size_t work_limit)
 {
     size_t early_out_limit = 0;
     bool done = false;
@@ -1306,9 +1310,11 @@ void Group::touch(ref_type first, ref_type last, std::vector<int>& progress_vect
 
     if (done) {
         progress_vector.resize(0);
+#ifdef DEBUG_TOUCH
         std::cout << "Touch completed with m_top at " << m_top.m_ref << std::endl << std::endl;
     } else {
         std::cout << "Incremental Touch with m_top at " << m_top.m_ref << std::endl << std::endl;
+#endif
     }
 }
 

--- a/src/realm/group.hpp
+++ b/src/realm/group.hpp
@@ -1082,6 +1082,7 @@ inline void Group::init_array_parents() noexcept
 
 inline void Group::update_child_ref(size_t child_ndx, ref_type new_ref)
 {
+    std::cout << " *** BONG *** " << std::endl;
     m_tables.set(child_ndx, new_ref);
 }
 

--- a/src/realm/group.hpp
+++ b/src/realm/group.hpp
@@ -542,7 +542,8 @@ public:
     /// size of the last snapshot done in that DB. If the snapshots are
     /// identical, the numbers will of course be equal.
     size_t get_used_space() const noexcept;
-
+    void touch(ref_type first, ref_type end);
+    void recursive_touch(int level, Array& parent, ref_type first, ref_type last);
     void verify() const;
     void validate_primary_columns();
 #ifdef REALM_DEBUG

--- a/src/realm/group.hpp
+++ b/src/realm/group.hpp
@@ -542,6 +542,8 @@ public:
     /// size of the last snapshot done in that DB. If the snapshots are
     /// identical, the numbers will of course be equal.
     size_t get_used_space() const noexcept;
+    void load_defrag_parameters(size_t& evac_start, size_t& evac_end, std::vector<unsigned>& progress_vector);
+    void save_defrag_parameters(size_t& evac_start, size_t& evac_end, std::vector<unsigned>& progress_vector);
     void touch(ref_type first, ref_type end, std::vector<unsigned>& progress_vector, size_t work_limit);
     bool recursive_touch(size_t level, Array& parent, ref_type first, ref_type last, std::vector<unsigned>& progress_vector, size_t& work_limit);
     void verify() const;
@@ -591,6 +593,7 @@ private:
     ///    9th   History ref          (optional)             4
     ///   10th   History version      (optional)             7
     ///   11th   Sync File Id         (optional)            10
+    ///   12th   Defragmenter metadata (optional)
     ///
     /// </pre>
     ///
@@ -653,8 +656,9 @@ private:
     static constexpr size_t s_hist_ref_ndx = 8;
     static constexpr size_t s_hist_version_ndx = 9;
     static constexpr size_t s_sync_file_id_ndx = 10;
+    static constexpr size_t s_defragment_meta_ndx = 11;
 
-    static constexpr size_t s_group_max_size = 11;
+    static constexpr size_t s_group_max_size = 12;
 
     // We use the classic approach to construct a FIFO from two LIFO's,
     // insertion is done into recycler_1, removal is done from recycler_2,
@@ -1079,6 +1083,7 @@ inline void Group::init_array_parents() noexcept
     m_table_names.set_parent(&m_top, 0);
     m_tables.set_parent(&m_top, 1);
 }
+
 
 inline void Group::update_child_ref(size_t child_ndx, ref_type new_ref)
 {

--- a/src/realm/group.hpp
+++ b/src/realm/group.hpp
@@ -542,8 +542,8 @@ public:
     /// size of the last snapshot done in that DB. If the snapshots are
     /// identical, the numbers will of course be equal.
     size_t get_used_space() const noexcept;
-    void load_defrag_parameters(size_t& evac_start, size_t& evac_end, std::vector<unsigned>& progress_vector);
-    void save_defrag_parameters(size_t& evac_start, size_t& evac_end, std::vector<unsigned>& progress_vector);
+    void load_defrag_parameters(size_t& evac_start, size_t& evac_end, size_t& lfs, std::vector<unsigned>& progress_vector);
+    void save_defrag_parameters(size_t& evac_start, size_t& evac_end, size_t& lfs, std::vector<unsigned>& progress_vector);
     void touch(ref_type first, ref_type end, std::vector<unsigned>& progress_vector, size_t work_limit);
     bool recursive_touch(size_t level, Array& parent, ref_type first, ref_type last, std::vector<unsigned>& progress_vector, size_t& work_limit);
     void verify() const;

--- a/src/realm/group.hpp
+++ b/src/realm/group.hpp
@@ -542,8 +542,8 @@ public:
     /// size of the last snapshot done in that DB. If the snapshots are
     /// identical, the numbers will of course be equal.
     size_t get_used_space() const noexcept;
-    void touch(ref_type first, ref_type end, std::vector<int>& progress_vector, size_t work_limit);
-    bool recursive_touch(int level, Array& parent, ref_type first, ref_type last, std::vector<int>& progress_vector, size_t& work_limit);
+    void touch(ref_type first, ref_type end, std::vector<unsigned>& progress_vector, size_t work_limit);
+    bool recursive_touch(size_t level, Array& parent, ref_type first, ref_type last, std::vector<unsigned>& progress_vector, size_t& work_limit);
     void verify() const;
     void validate_primary_columns();
 #ifdef REALM_DEBUG
@@ -1082,7 +1082,6 @@ inline void Group::init_array_parents() noexcept
 
 inline void Group::update_child_ref(size_t child_ndx, ref_type new_ref)
 {
-    std::cout << " *** BONG *** " << std::endl;
     m_tables.set(child_ndx, new_ref);
 }
 

--- a/src/realm/group.hpp
+++ b/src/realm/group.hpp
@@ -542,8 +542,8 @@ public:
     /// size of the last snapshot done in that DB. If the snapshots are
     /// identical, the numbers will of course be equal.
     size_t get_used_space() const noexcept;
-    void touch(ref_type first, ref_type end);
-    void recursive_touch(int level, Array& parent, ref_type first, ref_type last);
+    void touch(ref_type first, ref_type end, std::vector<int>& progress_vector, size_t work_limit);
+    bool recursive_touch(int level, Array& parent, ref_type first, ref_type last, std::vector<int>& progress_vector, size_t& work_limit);
     void verify() const;
     void validate_primary_columns();
 #ifdef REALM_DEBUG

--- a/src/realm/group_writer.cpp
+++ b/src/realm/group_writer.cpp
@@ -614,16 +614,18 @@ void GroupWriter::read_in_freelist(bool& evac_done, bool& zone_freed, size_t& al
         if (e.ref <= m_evac_start && e.ref + e.size >= m_evac_end) {
             zone_freed = true;
             m_evacuated = true;
-/*
+
                 // if the evac zone ends at the logical file size, reset it to
                 // start of free block and discard the free block.
                 size_t logical_file_size = to_size_t(m_group.m_top.get(2) / 2);
                 if (m_evac_end == logical_file_size) {
-                    std::cout << "*** Reducing logical file size to " << e.ref << std::endl;
-                    m_group.m_top.set(2, 1 + 2 * uint64_t(e.ref)); // Throws
-                    continue; // loses this free block
+                    REALM_ASSERT(m_evac_end == e.ref + e.size); 
+                    size_t new_logical_file_size = round_up_to_page_size(m_evac_start);
+                    std::cout << "*** Reducing logical file size to " << new_logical_file_size << std::endl;
+                    m_group.m_top.set(2, 1 + 2 * uint64_t(new_logical_file_size)); // Throws
+                    e.size = new_logical_file_size - e.ref;
                 }
-*/
+
         }
         // prevent use by moving free block to m_not_free_in_file:
         if (e.size) { // (merging may have left entries with size 0 behind. Must be ignored)

--- a/src/realm/group_writer.hpp
+++ b/src/realm/group_writer.hpp
@@ -58,6 +58,7 @@ public:
 
     void set_versions(uint64_t current, uint64_t read_lock) noexcept;
     void set_evacuation_zone(size_t evac_start, size_t evac_end) noexcept;
+    bool evacuated() noexcept;
 
     /// Write all changed array nodes into free space.
     ///
@@ -103,6 +104,7 @@ private:
     size_t m_locked_space_size = 0;
     size_t m_evac_start = 0;
     size_t m_evac_end = 0;
+    bool m_evacuated = false;
     Durability m_durability;
 
     struct FreeSpaceEntry {
@@ -198,6 +200,12 @@ inline void GroupWriter::set_evacuation_zone(size_t evac_start, size_t evac_end)
 {
     m_evac_start = evac_start;
     m_evac_end = evac_end;
+    m_evacuated = false;
+}
+
+inline bool GroupWriter::evacuated() noexcept
+{
+    return m_evacuated;
 }
 
 inline void GroupWriter::set_versions(uint64_t current, uint64_t read_lock) noexcept

--- a/src/realm/group_writer.hpp
+++ b/src/realm/group_writer.hpp
@@ -64,11 +64,17 @@ public:
     // evacuation zone has been evacuated and if it has been freed.
     // (evacuation may complete before everything is freed because
     // older blocks are not fully free until their transaction dies)
-    // The total amount of memory which are ready for allocation is
+    // The total amount of memory which bis ready for allocation is
     // also computed. This excludes free memory inside any evacuation zone.
     //
     // Must be called before write_group()
-    void read_in_freelist(bool& evac_done, bool& zone_freed, size_t& allocatable);
+    struct ZoneStat {
+        size_t ref_end; // end of zone
+        size_t total_free; // includes locked memory
+        size_t largest_free; // includes locked memory
+    };
+    using Zones = std::vector<ZoneStat>;
+    void read_in_freelist(bool& evac_done, bool& zone_freed, size_t& allocatable, Zones& zones);
 
     /// Write all changed array nodes into free space.
     ///

--- a/src/realm/group_writer.hpp
+++ b/src/realm/group_writer.hpp
@@ -57,6 +57,7 @@ public:
     ~GroupWriter();
 
     void set_versions(uint64_t current, uint64_t read_lock) noexcept;
+    void set_evacuation_zone(size_t evac_start, size_t evac_end) noexcept;
 
     /// Write all changed array nodes into free space.
     ///
@@ -69,7 +70,8 @@ public:
     /// returned by write_group().
     void commit(ref_type new_top_ref);
 
-    size_t get_file_size() const noexcept;
+    size_t get_logical_file_size() const noexcept;
+    size_t get_physical_file_size() const noexcept;
 
     ref_type write_array(const char*, size_t, uint32_t) override;
 
@@ -99,6 +101,8 @@ private:
     size_t m_window_alignment;
     size_t m_free_space_size = 0;
     size_t m_locked_space_size = 0;
+    size_t m_evac_start = 0;
+    size_t m_evac_end = 0;
     Durability m_durability;
 
     struct FreeSpaceEntry {
@@ -189,6 +193,12 @@ private:
 
 
 // Implementation:
+
+inline void GroupWriter::set_evacuation_zone(size_t evac_start, size_t evac_end) noexcept
+{
+    m_evac_start = evac_start;
+    m_evac_end = evac_end;
+}
 
 inline void GroupWriter::set_versions(uint64_t current, uint64_t read_lock) noexcept
 {

--- a/src/realm/node.cpp
+++ b/src/realm/node.cpp
@@ -146,7 +146,6 @@ void Node::do_copy_on_write(size_t minimum_size)
     // Update internal data
     m_ref = mref.get_ref();
     m_data = get_data_from_header(new_begin);
-    std::cout << " * COW(" << old_ref << ") -> [" << m_ref << " : ...]" << std::endl;
     // Update capacity in header. Uses m_data to find header, so
     // m_data must be initialized correctly first.
     set_capacity_in_header(new_size, new_begin);

--- a/src/realm/node.cpp
+++ b/src/realm/node.cpp
@@ -127,7 +127,8 @@ void Node::do_copy_on_write(size_t minimum_size)
     const char* header = get_header_from_data(m_data);
 
     // Calculate size in bytes
-    size_t array_size = calc_byte_len(m_size, get_width_from_header(header));
+    //size_t array_size = calc_byte_len(m_size, get_width_from_header(header));
+    size_t array_size = get_byte_size_from_header(header);
     size_t new_size = std::max(array_size, minimum_size);
     new_size = (new_size + 0x7) & ~size_t(0x7); // 64bit blocks
     // Plus a bit of matchcount room for expansion
@@ -145,7 +146,7 @@ void Node::do_copy_on_write(size_t minimum_size)
     // Update internal data
     m_ref = mref.get_ref();
     m_data = get_data_from_header(new_begin);
-
+    std::cout << " * COW(" << old_ref << ") -> [" << m_ref << " : ...]" << std::endl;
     // Update capacity in header. Uses m_data to find header, so
     // m_data must be initialized correctly first.
     set_capacity_in_header(new_size, new_begin);

--- a/src/realm/node.hpp
+++ b/src/realm/node.hpp
@@ -303,6 +303,7 @@ private:
     size_t m_ndx_in_parent = 0; // Ignored if m_parent is null.
 
     void do_copy_on_write(size_t minimum_size = 0);
+    friend class Group;
 };
 
 class Spec;

--- a/test/test_lang_bind_helper.cpp
+++ b/test/test_lang_bind_helper.cpp
@@ -6017,7 +6017,7 @@ TEST(LangBindHelper_FragmentFile)
     for (int i = 0; i < 1000; ++i) {
         w[i] = '0' + (i % 10);
     }
-    size_t num = 10000;
+    size_t num = 100000;
     for (size_t j = 0; j < num; ++j) {
         BinaryData sd(w, 500 + (j % 500));
         t->create_object().set(c, sd);
@@ -6044,12 +6044,13 @@ TEST(LangBindHelper_FragmentFile)
         ++j;
     }
     tr->commit_and_continue_as_read();
+
     db->get_stats(free_space, used_space);
     std::cout << free_space << ", " << used_space << std::endl;
     size_t total = free_space + used_space;
-    std::vector<int> progress_vector;
+    std::vector<unsigned> progress_vector;
     for (int h = 0; h < 10; ++h)  {
-                /* if (free_space * 100 / total > 50) */ 
+                // if (free_space * 100 / total > 50)
         size_t evac_start = h * total / 10;
         if (evac_start < 24) evac_start = 24;
         size_t evac_end = (h+1) * total / 10;
@@ -6065,6 +6066,7 @@ TEST(LangBindHelper_FragmentFile)
         std::cout << free_space << ", " << used_space << std::endl;
         total = free_space + used_space;
     }
+
 }
 
 #endif

--- a/test/test_lang_bind_helper.cpp
+++ b/test/test_lang_bind_helper.cpp
@@ -6017,7 +6017,7 @@ TEST(LangBindHelper_FragmentFile)
     for (int i = 0; i < 1000; ++i) {
         w[i] = '0' + (i % 10);
     }
-    size_t num = 1;
+    size_t num = 1000;
     for (size_t j = 0; j < num; ++j) {
         BinaryData sd(w, 500 + (j % 500));
         t->create_object().set(c, sd);
@@ -6047,15 +6047,18 @@ TEST(LangBindHelper_FragmentFile)
     db->get_stats(free_space, used_space);
     std::cout << free_space << ", " << used_space << std::endl;
     size_t total = free_space + used_space;
+    std::vector<int> progress_vector;
     for (int h = 0; h < 10; ++h)  {
-        tr->promote_to_write();
-        /* if (free_space * 100 / total > 50) */ {
-            size_t evac_start = h * total / 10;
-            size_t evac_end = (h+1) * total / 10;
+                /* if (free_space * 100 / total > 50) */ 
+        size_t evac_start = h * total / 10;
+        if (evac_start < 24) evac_start = 24;
+        size_t evac_end = (h+1) * total / 10;
+        do {
+            tr->promote_to_write();
             tr->touch(evac_start, evac_end);
             tr->set_evacuation_zone(evac_start, evac_end);
-        }
-        tr->commit_and_continue_as_read();
+            tr->commit_and_continue_as_read();
+        } while (!tr->evacuated());
         db->get_stats(free_space, used_space);
         std::cout << free_space << ", " << used_space << std::endl;
         total = free_space + used_space;

--- a/test/test_lang_bind_helper.cpp
+++ b/test/test_lang_bind_helper.cpp
@@ -6049,15 +6049,9 @@ TEST(LangBindHelper_FragmentFile)
     std::cout << free_space << ", " << used_space << std::endl;
     size_t total = free_space + used_space;
     std::vector<unsigned> progress_vector;
-    for (int h = 0; h < 10; ++h)  {
-        int commits = 0;
-        do {
-            tr->promote_to_write();
-            tr->commit_and_continue_as_read();
-            tr->verify();
-            ++commits;
-        } while (!tr->evacuated());
-        std::cout << " *** Evac zone empty after " << commits << " commits" << std::endl;
+    for (int h = 0; h < 1000; ++h)  {
+        tr->promote_to_write();
+        tr->commit_and_continue_as_read();
         db->get_stats(free_space, used_space);
         total = free_space + used_space;
         std::cout << "Total: " << total << ",  Free: " << free_space << ", Used: " << used_space << std::endl;

--- a/test/test_lang_bind_helper.cpp
+++ b/test/test_lang_bind_helper.cpp
@@ -6017,7 +6017,7 @@ TEST(LangBindHelper_FragmentFile)
     for (int i = 0; i < 1000; ++i) {
         w[i] = '0' + (i % 10);
     }
-    size_t num = 4;
+    size_t num = 1;
     for (size_t j = 0; j < num; ++j) {
         BinaryData sd(w, 500 + (j % 500));
         t->create_object().set(c, sd);
@@ -6047,12 +6047,14 @@ TEST(LangBindHelper_FragmentFile)
     db->get_stats(free_space, used_space);
     std::cout << free_space << ", " << used_space << std::endl;
     size_t total = free_space + used_space;
-    while (free_space * 100 / total > 75) {
+    for (int h = 0; h < 10; ++h)  {
         tr->promote_to_write();
-        tr->touch(3 * total / 4, total);
-        tr->commit_and_continue_as_read();
-        tr->promote_to_write();
-        // tr->truncate();
+        /* if (free_space * 100 / total > 50) */ {
+            size_t evac_start = h * total / 10;
+            size_t evac_end = (h+1) * total / 10;
+            tr->touch(evac_start, evac_end);
+            tr->set_evacuation_zone(evac_start, evac_end);
+        }
         tr->commit_and_continue_as_read();
         db->get_stats(free_space, used_space);
         std::cout << free_space << ", " << used_space << std::endl;

--- a/test/test_lang_bind_helper.cpp
+++ b/test/test_lang_bind_helper.cpp
@@ -6050,21 +6050,17 @@ TEST(LangBindHelper_FragmentFile)
     size_t total = free_space + used_space;
     std::vector<unsigned> progress_vector;
     for (int h = 0; h < 10; ++h)  {
-                // if (free_space * 100 / total > 50)
-        size_t evac_start = h * total / 10;
-        if (evac_start < 24) evac_start = 24;
-        size_t evac_end = (h+1) * total / 10;
-        std::cout << " *** Evacuating zone " << evac_start << " : " << evac_end << std::endl;
+        int commits = 0;
         do {
             tr->promote_to_write();
-            tr->touch(evac_start, evac_end, progress_vector, 10);
-            tr->set_evacuation_zone(evac_start, evac_end);
             tr->commit_and_continue_as_read();
+            tr->verify();
+            ++commits;
         } while (!tr->evacuated());
-        std::cout << " *** Evac zone empty" << std::endl;
+        std::cout << " *** Evac zone empty after " << commits << " commits" << std::endl;
         db->get_stats(free_space, used_space);
-        std::cout << free_space << ", " << used_space << std::endl;
         total = free_space + used_space;
+        std::cout << "Total: " << total << ",  Free: " << free_space << ", Used: " << used_space << std::endl;
     }
 
 }

--- a/test/test_lang_bind_helper.cpp
+++ b/test/test_lang_bind_helper.cpp
@@ -6017,7 +6017,7 @@ TEST(LangBindHelper_FragmentFile)
     for (int i = 0; i < 1000; ++i) {
         w[i] = '0' + (i % 10);
     }
-    size_t num = 1000;
+    size_t num = 10000;
     for (size_t j = 0; j < num; ++j) {
         BinaryData sd(w, 500 + (j % 500));
         t->create_object().set(c, sd);
@@ -6053,12 +6053,14 @@ TEST(LangBindHelper_FragmentFile)
         size_t evac_start = h * total / 10;
         if (evac_start < 24) evac_start = 24;
         size_t evac_end = (h+1) * total / 10;
+        std::cout << " *** Evacuating zone " << evac_start << " : " << evac_end << std::endl;
         do {
             tr->promote_to_write();
-            tr->touch(evac_start, evac_end);
+            tr->touch(evac_start, evac_end, progress_vector, 10);
             tr->set_evacuation_zone(evac_start, evac_end);
             tr->commit_and_continue_as_read();
         } while (!tr->evacuated());
+        std::cout << " *** Evac zone empty" << std::endl;
         db->get_stats(free_space, used_space);
         std::cout << free_space << ", " << used_space << std::endl;
         total = free_space + used_space;


### PR DESCRIPTION
This PR is a proof-of-concept of online defragmentation.

Online defragmentation is a prerequisite for online compaction. Online compaction is a possible improvement over offline compaction (aka compact-on-launch).

Defragmentation is done as follows:
 * Heuristics pick an *evacuation zone*.
 * Allocation is always done outside the evacuation zone.
 * As part of commits, live data in the evacuation zone is evacuated using copy-on-write.
 * When the evacuation zone becomes empty, we can pick a new one and start over.

The PR implements *incremental* defragmentation. During each commit, we take a step in the
defragmentation process. The cost of each such step is kept proportional to the associated commit
in order to prevent any surprising stop-the-world moments.

Further notes:
 * The heuristic only enables defragmentation on files with significant free space.
 * If (during defragmentation) it becomes necessary to expand the file, defragmentation is aborted.
 * The heuristic chooses 1/8 of the file as evacuation zone at a time.
 * If there is a lot of free space in the file, it will choose the last 1/8, freeing up the last part of the file
   and reducing "logical file size". We do not actually reduce file size (see below).
 * If there is less free space, but still some, it picks the 1/8 that is most fragmented.

Currently missing
 * API changes to enable/disable
 * Cleanup/Beautification
 * Improved heuristics
 * Experiments with changes to the allocator, now that we can actively combat fragmentation
 * Online compaction

With respect to online compaction this should be a separate PR. It's surprisingly complex because
truncating a memory mapped file must be avoided. We need a coordinating mechanism which will
ensure that all participants have reduced their memory mapping according to logical file size before
actually shrinking the file.