### PR TITLE
Set the supported platforms for the Swift package

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,8 +6,8 @@
 ### Fixed
 * <How to hit and notice issue? what was the impact?> ([#????](https://github.com/realm/realm-core/issues/????), since v?.?.?)
 * `Obj::set_list_values` inappropriately resizes list for LinkList causing LogicError to be thrown. ([#4028](https://github.com/realm/realm-core/issues/4028), since v6.0.0)
-* None.
- 
+* Set the supported deployment targets for the Swift package, which fixes errors when archiving an iOS app which depends on it.
+
 ### Breaking changes
 * None.
 

--- a/Package.swift
+++ b/Package.swift
@@ -10,6 +10,12 @@ let versionExtra = versionPieces.count > 1 ? versionPieces[1] : ""
 
 let package = Package(
     name: "RealmCore",
+    platforms: [
+        .macOS(.v10_10),
+        .iOS(.v11),
+        .tvOS(.v9),
+        .watchOS(.v2)
+    ],
     products: [
         .library(
             name: "RealmCore",


### PR DESCRIPTION
Xcode's Archive command has started building packages for all platforms they claim to support even if the app doesn't consume those platforms. In our case, this results in errors when building for 32-bit iOS because that platform does not fully support C++17. Fix this by setting the deployment target for iOS to 11, which dropped support for 32-bit.