### PR TITLE
Fix Set::erase_null() for float/double

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ### Enhancements
 * New data types: Mixed, UUID and TypedLink.
+* New collection types: Set and Dictionary 
 
 ### Fixed
 * <How to hit and notice issue? what was the impact?> ([#????](https://github.com/realm/realm-core/issues/????), since v?.?.?)
@@ -15,7 +16,7 @@
 -----------
 
 ### Internals
-* None.
+* Set::erase_null() would not properly erase a potential null value ([#4001](https://github.com/realm/realm-core/issues/4001), (not in any release))
 
 ----------------------------------------------
 

--- a/src/realm/array_basic.hpp
+++ b/src/realm/array_basic.hpp
@@ -131,9 +131,9 @@ class BasicArrayNull : public BasicArray<T> {
 public:
     using BasicArray<T>::BasicArray;
 
-    static T default_value(bool nullable)
+    static util::Optional<T> default_value(bool nullable)
     {
-        return nullable ? null::get_null_float<T>() : T(0.0);
+        return nullable ? util::Optional<T>() : util::Optional<T>(0.0);
     }
     void set(size_t ndx, util::Optional<T> value)
     {

--- a/test/test_set.cpp
+++ b/test/test_set.cpp
@@ -233,7 +233,6 @@ TEST(Set_Links)
     CHECK_EQUAL(set_mixeds.find(bar2_link), realm::npos);
 }
 
-// FIXME: Set::erase_null() doesn't work for nullable float/double
 TEST_TYPES(Set_Types, Prop<Int>, Prop<String>, Prop<Float>, Prop<Double>, Prop<Timestamp>, Prop<UUID>, Prop<ObjectId>,
            Prop<Decimal128>, Prop<BinaryData>, Nullable<Int>, Nullable<String>, Nullable<Float>, Nullable<Double>,
            Nullable<Timestamp>, Nullable<UUID>, Nullable<ObjectId>, Nullable<Decimal128>, Nullable<BinaryData>)

--- a/test/test_set.cpp
+++ b/test/test_set.cpp
@@ -235,9 +235,8 @@ TEST(Set_Links)
 
 // FIXME: Set::erase_null() doesn't work for nullable float/double
 TEST_TYPES(Set_Types, Prop<Int>, Prop<String>, Prop<Float>, Prop<Double>, Prop<Timestamp>, Prop<UUID>, Prop<ObjectId>,
-           Prop<Decimal128>, Prop<BinaryData>, Nullable<Int>, Nullable<String>,
-           /*Nullable<Float>, Nullable<Double>,*/ Nullable<Timestamp>, Nullable<UUID>, Nullable<ObjectId>,
-           Nullable<Decimal128>, Nullable<BinaryData>)
+           Prop<Decimal128>, Prop<BinaryData>, Nullable<Int>, Nullable<String>, Nullable<Float>, Nullable<Double>,
+           Nullable<Timestamp>, Nullable<UUID>, Nullable<ObjectId>, Nullable<Decimal128>, Nullable<BinaryData>)
 {
     using type = typename TEST_TYPE::type;
     TestValueGenerator gen;

--- a/test/test_types_helper.hpp
+++ b/test/test_types_helper.hpp
@@ -151,9 +151,6 @@ struct Prop<T, state,
     using underlying_type = T;
     static type default_value()
     {
-        if constexpr (realm::is_any_v<type, util::Optional<float>, util::Optional<double>>) {
-            return type(); // optional float/double would return NaN and for consistency we want to operate on null
-        }
         return ColumnTypeTraits<type>::cluster_leaf_type::default_value(is_nullable);
     }
     static underlying_type default_non_nullable_value()


### PR DESCRIPTION
Fixes #4001 