### PR TITLE
Ensure column keys in virgin tables are unique on 32bit devices

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@
 
 ### Fixed
 * <How to hit and notice issue? what was the impact?> ([#????](https://github.com/realm/realm-core/issues/????), since v?.?.?)
-* None.
+* Files upgraded on 32-bit devices could end up being inconsistent resulting in "Key not found" exception to be thown. ([#6992](https://github.com/realm/realm-java/issues/6992), since v6.0.16)
  
 ### Breaking changes
 * None.

--- a/src/realm/keys.hpp
+++ b/src/realm/keys.hpp
@@ -103,7 +103,7 @@ struct ColKey {
         : value(val)
     {
     }
-    explicit ColKey(Idx index, ColumnType type, ColumnAttrMask attrs, unsigned tag) noexcept
+    explicit ColKey(Idx index, ColumnType type, ColumnAttrMask attrs, uint64_t tag) noexcept
         : ColKey((index.val & 0xFFFFUL) | ((type & 0x3FUL) << 16) | ((attrs.m_value & 0xFFUL) << 22) |
                  ((tag & 0xFFFFFFFFUL) << 30))
     {

--- a/test/test_group.cpp
+++ b/test/test_group.cpp
@@ -2216,4 +2216,14 @@ TEST(Group_ChangeStringPrimaryKeyValuesInMigration)
     }
 }
 
+TEST(Group_UniqueColumnKeys)
+{
+    Group g;
+    auto foo = g.add_table("foo");
+    auto bar = g.add_table("bar");
+    auto col_foo = foo->add_column(type_Int, "ints");
+    auto col_bar = bar->add_column(type_Int, "ints");
+    CHECK_NOT_EQUAL(col_foo, col_bar);
+}
+
 #endif // TEST_GROUP

--- a/test/test_group.cpp
+++ b/test/test_group.cpp
@@ -2218,9 +2218,15 @@ TEST(Group_ChangeStringPrimaryKeyValuesInMigration)
 
 TEST(Group_UniqueColumnKeys)
 {
+    // Table key is shifted 30 bits before added to ColKey, so when handled as
+    // 32 bit value, only the two LSB has effect
     Group g;
-    auto foo = g.add_table("foo");
-    auto bar = g.add_table("bar");
+    g.add_table("0");
+    auto foo = g.add_table("foo"); // TableKey == 1
+    g.add_table("2");
+    g.add_table("3");
+    g.add_table("4");
+    auto bar = g.add_table("bar"); // Tablekey == 5. Upper bit stripped off before fix, so equal to 1
     auto col_foo = foo->add_column(type_Int, "ints");
     auto col_bar = bar->add_column(type_Int, "ints");
     CHECK_NOT_EQUAL(col_foo, col_bar);


### PR DESCRIPTION
If column keys are not unique we end up finding the wrong backlink column during upgrade.

Fixes https://github.com/realm/realm-java/issues/6992