### PR TITLE
Collection, Lst<T>, LnkLst interface cleanup / refactor

### DIFF
--- a/src/realm/alloc.hpp
+++ b/src/realm/alloc.hpp
@@ -272,21 +272,25 @@ protected:
         return m_storage_versioning_counter.load(std::memory_order_acquire);
     }
 
+public:
     inline uint_fast64_t get_storage_version()
     {
         return m_storage_versioning_counter.load(std::memory_order_acquire);
     }
 
+protected:
     inline void bump_storage_version() noexcept
     {
         m_storage_versioning_counter.fetch_add(1, std::memory_order_acq_rel);
     }
 
+public:
     REALM_WORKAROUND_MSVC_BUG inline uint_fast64_t get_content_version() noexcept
     {
         return m_content_versioning_counter.load(std::memory_order_acquire);
     }
 
+protected:
     inline uint_fast64_t bump_content_version() noexcept
     {
         return m_content_versioning_counter.fetch_add(1, std::memory_order_acq_rel) + 1;

--- a/src/realm/alloc.hpp
+++ b/src/realm/alloc.hpp
@@ -310,7 +310,8 @@ private:
     friend class Group;
     friend class WrappedAllocator;
     friend class Obj;
-    friend class CollectionBase;
+    template <class>
+    friend class CollectionBaseImpl;
     friend class Dictionary;
 };
 
@@ -325,9 +326,7 @@ public:
         m_ref_translation_ptr.store(m_alloc->m_ref_translation_ptr);
     }
 
-    ~WrappedAllocator()
-    {
-    }
+    ~WrappedAllocator() {}
 
     void switch_underlying_allocator(Allocator& underlying_allocator)
     {
@@ -428,9 +427,7 @@ inline MemRef::MemRef() noexcept
 {
 }
 
-inline MemRef::~MemRef() noexcept
-{
-}
+inline MemRef::~MemRef() noexcept {}
 
 inline MemRef::MemRef(char* addr, ref_type ref, Allocator& alloc) noexcept
     : m_addr(addr)
@@ -543,9 +540,7 @@ inline Allocator::Allocator() noexcept
     m_ref_translation_ptr = nullptr;
 }
 
-inline Allocator::~Allocator() noexcept
-{
-}
+inline Allocator::~Allocator() noexcept {}
 
 // performance critical part of the translation process. Less critical code is in translate_less_critical.
 inline char* Allocator::translate_critical(RefTranslation* ref_translation_ptr, ref_type ref) const noexcept

--- a/src/realm/collection.cpp
+++ b/src/realm/collection.cpp
@@ -1,27 +1,52 @@
 #include <realm/collection.hpp>
+#include <realm/bplustree.hpp>
+#include <realm/array_key.hpp>
 
 namespace realm {
 
-CollectionBase::CollectionBase(const Obj& owner, ColKey col_key)
-    : m_obj(owner)
-    , m_col_key(col_key)
+namespace _impl {
+
+size_t virtual2real(const std::vector<size_t>& vec, size_t ndx) noexcept
 {
-    if (!col_key.is_collection()) {
-        throw LogicError(LogicError::collection_type_mismatch);
+    for (auto i : vec) {
+        if (i > ndx)
+            break;
+        ndx++;
     }
-    m_nullable = col_key.is_nullable();
+    return ndx;
 }
 
-CollectionBase::~CollectionBase() {}
-
-ref_type CollectionBase::get_child_ref(size_t) const noexcept
+size_t real2virtual(const std::vector<size_t>& vec, size_t ndx) noexcept
 {
-    try {
-        return to_ref(m_obj._get<int64_t>(m_col_key.get_index()));
-    }
-    catch (const KeyNotFound&) {
-        return ref_type(0);
+    // Subtract the number of tombstones below ndx.
+    auto it = std::lower_bound(vec.begin(), vec.end(), ndx);
+    auto n = it - vec.begin();
+    return ndx - n;
+}
+
+void update_unresolved(std::vector<size_t>& vec, const BPlusTree<ObjKey>& tree)
+{
+    vec.clear();
+    if (tree.is_attached()) {
+        // Only do the scan if context flag is set.
+        if (tree.get_context_flag()) {
+            auto func = [&vec](BPlusTreeNode* node, size_t offset) {
+                auto leaf = static_cast<typename BPlusTree<ObjKey>::LeafNode*>(node);
+                size_t sz = leaf->size();
+                for (size_t i = 0; i < sz; i++) {
+                    auto k = leaf->get(i);
+                    if (k.is_unresolved()) {
+                        vec.push_back(i + offset);
+                    }
+                }
+                return false;
+            };
+
+            tree.traverse(func);
+        }
     }
 }
+
+} // namespace _impl
 
 } // namespace realm

--- a/src/realm/collection.cpp
+++ b/src/realm/collection.cpp
@@ -26,23 +26,36 @@ void update_unresolved(std::vector<size_t>& vec, const BPlusTree<ObjKey>& tree)
 {
     vec.clear();
 
-        // Only do the scan if context flag is set.
+    // Only do the scan if context flag is set.
     if (tree.is_attached() && tree.get_context_flag()) {
-            auto func = [&vec](BPlusTreeNode* node, size_t offset) {
+        auto func = [&vec](BPlusTreeNode* node, size_t offset) {
             auto leaf = static_cast<BPlusTree<ObjKey>::LeafNode*>(node);
-                size_t sz = leaf->size();
-                for (size_t i = 0; i < sz; i++) {
-                    auto k = leaf->get(i);
-                    if (k.is_unresolved()) {
-                        vec.push_back(i + offset);
-                    }
+            size_t sz = leaf->size();
+            for (size_t i = 0; i < sz; i++) {
+                auto k = leaf->get(i);
+                if (k.is_unresolved()) {
+                    vec.push_back(i + offset);
                 }
-                return false;
-            };
+            }
+            return false;
+        };
 
-            tree.traverse(func);
+        tree.traverse(func);
+    }
+}
+
+void check_for_last_unresolved(BPlusTree<ObjKey>& tree)
+{
+    bool no_more_unresolved = true;
+    size_t sz = tree.size();
+    for (size_t n = 0; n < sz; n++) {
+        if (tree.get(n).is_unresolved()) {
+            no_more_unresolved = false;
+            break;
         }
     }
+    if (no_more_unresolved)
+        tree.set_context_flag(false);
 }
 
 } // namespace realm::_impl

--- a/src/realm/collection.cpp
+++ b/src/realm/collection.cpp
@@ -2,9 +2,7 @@
 #include <realm/bplustree.hpp>
 #include <realm/array_key.hpp>
 
-namespace realm {
-
-namespace _impl {
+namespace realm::_impl {
 
 size_t virtual2real(const std::vector<size_t>& vec, size_t ndx) noexcept
 {
@@ -27,11 +25,11 @@ size_t real2virtual(const std::vector<size_t>& vec, size_t ndx) noexcept
 void update_unresolved(std::vector<size_t>& vec, const BPlusTree<ObjKey>& tree)
 {
     vec.clear();
-    if (tree.is_attached()) {
+
         // Only do the scan if context flag is set.
-        if (tree.get_context_flag()) {
+    if (tree.is_attached() && tree.get_context_flag()) {
             auto func = [&vec](BPlusTreeNode* node, size_t offset) {
-                auto leaf = static_cast<typename BPlusTree<ObjKey>::LeafNode*>(node);
+            auto leaf = static_cast<BPlusTree<ObjKey>::LeafNode*>(node);
                 size_t sz = leaf->size();
                 for (size_t i = 0; i < sz; i++) {
                     auto k = leaf->get(i);
@@ -47,6 +45,4 @@ void update_unresolved(std::vector<size_t>& vec, const BPlusTree<ObjKey>& tree)
     }
 }
 
-} // namespace _impl
-
-} // namespace realm
+} // namespace realm::_impl

--- a/src/realm/collection.hpp
+++ b/src/realm/collection.hpp
@@ -491,7 +491,7 @@ struct CollectionIterator {
         return *this;
     }
 
-    friend ptrdiff_t operator-(CollectionIterator& lhs, CollectionIterator& rhs) noexcept
+    friend ptrdiff_t operator-(const CollectionIterator& lhs, const CollectionIterator& rhs) noexcept
     {
         return ptrdiff_t(lhs.m_ndx) - ptrdiff_t(rhs.m_ndx);
     }

--- a/src/realm/collection.hpp
+++ b/src/realm/collection.hpp
@@ -217,7 +217,7 @@ public:
         return m_obj;
     }
 
-    bool has_changed() const noexcept final
+    bool has_changed() const final
     {
         update_if_needed();
         if (m_last_content_version != m_content_version) {

--- a/src/realm/collection.hpp
+++ b/src/realm/collection.hpp
@@ -52,13 +52,13 @@ public:
     virtual ObjKey get_key() const = 0;
     virtual bool is_attached() const = 0;
     virtual bool has_changed() const = 0;
-    virtual ConstTableRef get_table() const = 0;
-    virtual ColKey get_col_key() const = 0;
+    virtual ConstTableRef get_table() const noexcept = 0;
+    virtual ColKey get_col_key() const noexcept = 0;
 
 protected:
     friend class Transaction;
-    CollectionBase() = default;
-    CollectionBase(const CollectionBase&) = default;
+    CollectionBase() noexcept = default;
+    CollectionBase(const CollectionBase&) noexcept = default;
 
     virtual bool init_from_parent() const = 0;
     virtual bool update_if_needed() const = 0;
@@ -103,7 +103,7 @@ inline void check_column_type<ObjKey>(ColKey col)
 template <class T, class = void>
 struct MinHelper {
     template <class U>
-    static Mixed eval(U&, size_t*)
+    static Mixed eval(U&, size_t*) noexcept
     {
         return Mixed{};
     }
@@ -121,7 +121,7 @@ struct MinHelper<T, std::void_t<ColumnMinMaxType<T>>> {
 template <class T, class Enable = void>
 struct MaxHelper {
     template <class U>
-    static Mixed eval(U&, size_t*)
+    static Mixed eval(U&, size_t*) noexcept
     {
         return Mixed{};
     }
@@ -140,7 +140,7 @@ template <class T, class Enable = void>
 class SumHelper {
 public:
     template <class U>
-    static Mixed eval(U&, size_t* return_cnt)
+    static Mixed eval(U&, size_t* return_cnt) noexcept
     {
         if (return_cnt)
             *return_cnt = 0;
@@ -161,7 +161,7 @@ public:
 template <class T, class = void>
 struct AverageHelper {
     template <class U>
-    static Mixed eval(U&, size_t* return_cnt)
+    static Mixed eval(U&, size_t* return_cnt) noexcept
     {
         if (return_cnt)
             *return_cnt = 0;
@@ -222,7 +222,7 @@ public:
         return false;
     }
 
-    ConstTableRef get_table() const final
+    ConstTableRef get_table() const noexcept final
     {
         return m_obj.get_table();
     }
@@ -239,7 +239,7 @@ protected:
     CollectionBaseImpl() = default;
     CollectionBaseImpl(const CollectionBaseImpl& other) = default;
 
-    CollectionBaseImpl(const Obj& obj, ColKey col_key)
+    CollectionBaseImpl(const Obj& obj, ColKey col_key) noexcept
         : m_obj(obj)
         , m_col_key(col_key)
         , m_nullable(col_key.is_nullable())
@@ -286,7 +286,7 @@ protected:
         return false;
     }
 
-    void update_content_version() const
+    void update_content_version() const noexcept
     {
         m_content_version = m_obj.get_alloc().get_content_version();
     }
@@ -362,7 +362,7 @@ public:
         }
     }
 
-    bool is_in_sync() const final
+    bool is_in_sync() const noexcept final
     {
         return true;
     }
@@ -401,7 +401,7 @@ protected:
         _impl::check_for_last_unresolved(tree);
     }
 
-    void clear_unresolved()
+    void clear_unresolved() noexcept
     {
         m_unresolved.clear();
     }
@@ -442,37 +442,37 @@ struct CollectionIterator {
     {
     }
 
-    pointer operator->() const noexcept
+    pointer operator->() const
     {
         m_val = m_list->get(m_ndx);
         return &m_val;
     }
 
-    reference operator*() const noexcept
+    reference operator*() const
     {
         return *operator->();
     }
 
-    CollectionIterator& operator++()
+    CollectionIterator& operator++() noexcept
     {
         ++m_ndx;
         return *this;
     }
 
-    CollectionIterator operator++(int)
+    CollectionIterator operator++(int) noexcept
     {
         auto tmp = *this;
         operator++();
         return tmp;
     }
 
-    CollectionIterator& operator--()
+    CollectionIterator& operator--() noexcept
     {
         --m_ndx;
         return *this;
     }
 
-    CollectionIterator operator--(int)
+    CollectionIterator operator--(int) noexcept
     {
         auto tmp = *this;
         operator--();

--- a/src/realm/collection.hpp
+++ b/src/realm/collection.hpp
@@ -246,21 +246,7 @@ protected:
     {
     }
 
-    CollectionBaseImpl& operator=(const CollectionBaseImpl& other)
-    {
-        static_cast<Interface&>(*this) = static_cast<const Interface&>(other);
-
-        if (this != &other) {
-            m_obj = other.m_obj;
-            m_col_key = other.m_col_key;
-            m_nullable = other.m_nullable;
-            m_content_version = other.m_content_version;
-            m_last_content_version = other.m_last_content_version;
-            m_valid = other.m_valid;
-        }
-
-        return *this;
-    }
+    CollectionBaseImpl& operator=(const CollectionBaseImpl& other) = default;
 
     bool operator==(const CollectionBaseImpl& other) const noexcept
     {

--- a/src/realm/collection.hpp
+++ b/src/realm/collection.hpp
@@ -59,6 +59,9 @@ protected:
     friend class Transaction;
     CollectionBase() noexcept = default;
     CollectionBase(const CollectionBase&) noexcept = default;
+    CollectionBase(CollectionBase&&) noexcept = default;
+    CollectionBase& operator=(const CollectionBase&) noexcept = default;
+    CollectionBase& operator=(CollectionBase&&) noexcept = default;
 
     virtual bool init_from_parent() const = 0;
     virtual bool update_if_needed() const = 0;
@@ -238,6 +241,7 @@ protected:
 
     CollectionBaseImpl() = default;
     CollectionBaseImpl(const CollectionBaseImpl& other) = default;
+    CollectionBaseImpl(CollectionBaseImpl&& other) = default;
 
     CollectionBaseImpl(const Obj& obj, ColKey col_key) noexcept
         : m_obj(obj)
@@ -247,6 +251,7 @@ protected:
     }
 
     CollectionBaseImpl& operator=(const CollectionBaseImpl& other) = default;
+    CollectionBaseImpl& operator=(CollectionBaseImpl&& other) = default;
 
     bool operator==(const CollectionBaseImpl& other) const noexcept
     {

--- a/src/realm/collection.hpp
+++ b/src/realm/collection.hpp
@@ -318,7 +318,7 @@ protected:
 
     void update_child_ref(size_t child_ndx, ref_type new_ref) final
     {
-        REALM_ASSERT(child_ndx == 0);
+        static_cast<void>(child_ndx);
         m_obj.set_int(m_col_key, from_ref(new_ref));
     }
 };

--- a/src/realm/dictionary.cpp
+++ b/src/realm/dictionary.cpp
@@ -43,7 +43,8 @@ DictionaryClusterTree::~DictionaryClusterTree() {}
 /******************************** Dictionary *********************************/
 
 Dictionary::Dictionary(const Obj& obj, ColKey col_key)
-    : CollectionBase(obj, col_key)
+    : m_obj(obj)
+    , m_col_key(col_key)
     , m_key_type(m_obj.get_table()->get_dictionary_key_type(m_col_key))
 {
     init_from_parent();
@@ -484,7 +485,7 @@ Mixed Dictionary::do_get(ClusterNode::State&& s) const
 
 /************************* Dictionary::Iterator *************************/
 
-Dictionary::Iterator::Iterator(const Dictionary* dict, size_t pos)
+CollectionIterator<Dictionary>::CollectionIterator(const Dictionary* dict, size_t pos)
     : ClusterTree::Iterator(dict->m_clusters ? *dict->m_clusters : dummy_cluster, pos)
     , m_key_type(dict->get_key_data_type())
 {

--- a/src/realm/dictionary.cpp
+++ b/src/realm/dictionary.cpp
@@ -43,10 +43,12 @@ DictionaryClusterTree::~DictionaryClusterTree() {}
 /******************************** Dictionary *********************************/
 
 Dictionary::Dictionary(const Obj& obj, ColKey col_key)
-    : m_obj(obj)
-    , m_col_key(col_key)
+    : Base(obj, col_key)
     , m_key_type(m_obj.get_table()->get_dictionary_key_type(m_col_key))
 {
+    if (!col_key.is_dictionary()) {
+        throw LogicError(LogicError::collection_type_mismatch);
+    }
     init_from_parent();
 }
 
@@ -57,9 +59,9 @@ Dictionary::~Dictionary()
 
 Dictionary& Dictionary::operator=(const Dictionary& other)
 {
+    Base::operator=(static_cast<const Base&>(other));
+
     if (this != &other) {
-        m_obj = other.m_obj;
-        m_col_key = other.m_col_key;
         init_from_parent();
     }
     return *this;
@@ -299,6 +301,8 @@ std::pair<Dictionary::Iterator, bool> Dictionary::insert(Mixed key, Mixed value)
         throw LogicError(LogicError::collection_type_mismatch);
     }
 
+    update_if_needed();
+
     ObjLink new_link;
     if (value.get_type() == type_TypedLink) {
         new_link = value.get<ObjLink>();
@@ -323,7 +327,7 @@ std::pair<Dictionary::Iterator, bool> Dictionary::insert(Mixed key, Mixed value)
         repl->dictionary_insert(*this, key, value);
     }
 
-    m_obj.bump_content_version();
+    bump_content_version();
     try {
         ClusterNode::State state = m_clusters->insert(k, key, value);
 
@@ -368,7 +372,7 @@ const Mixed Dictionary::operator[](Mixed key)
         create();
         auto hash = key.hash();
         ObjKey k(int64_t(hash & 0x7FFFFFFFFFFFFFFF));
-        m_obj.bump_content_version();
+        bump_content_version();
         m_clusters->insert(k, key, Mixed{});
     }
 
@@ -391,14 +395,17 @@ Dictionary::Iterator Dictionary::find(Mixed key)
 
 void Dictionary::erase(Mixed key)
 {
+    update_if_needed();
+
     if (m_clusters) {
         auto hash = key.hash();
         ObjKey k(int64_t(hash & 0x7FFFFFFFFFFFFFFF));
         CascadeState state;
-        m_clusters->erase(k, state);
         if (Replication* repl = this->m_obj.get_replication()) {
             repl->dictionary_erase(*this, key);
         }
+        m_clusters->erase(k, state);
+        bump_content_version();
     }
 }
 
@@ -412,7 +419,7 @@ void Dictionary::nullify(Mixed key)
     auto hash = key.hash();
     ObjKey k(int64_t(hash & 0x7FFFFFFFFFFFFFFF));
 
-    m_obj.bump_content_version();
+    bump_content_version();
 
     auto state = m_clusters->get(k);
     ArrayMixed values(m_obj.get_alloc());

--- a/src/realm/dictionary.hpp
+++ b/src/realm/dictionary.hpp
@@ -115,7 +115,7 @@ private:
     bool init_from_parent() const final;
     Mixed do_get(ClusterNode::State&&) const;
 
-    friend class CollectionIterator<Dictionary>;
+    friend struct CollectionIterator<Dictionary>;
 };
 
 template <>

--- a/src/realm/dictionary.hpp
+++ b/src/realm/dictionary.hpp
@@ -119,8 +119,7 @@ private:
 };
 
 template <>
-class CollectionIterator<Dictionary> : public ClusterTree::Iterator {
-public:
+struct CollectionIterator<Dictionary> : public ClusterTree::Iterator {
     typedef std::forward_iterator_tag iterator_category;
     typedef std::pair<const Mixed, Mixed> value_type;
     typedef ptrdiff_t difference_type;

--- a/src/realm/impl/transact_log.cpp
+++ b/src/realm/impl/transact_log.cpp
@@ -78,7 +78,7 @@ void TransactLogConvenientEncoder::do_select_collection(const CollectionBase& li
 {
     select_table(list.get_table().unchecked_ptr());
     ColKey col_key = list.get_col_key();
-    ObjKey key = list.CollectionBase::get_key();
+    ObjKey key = list.get_key();
 
     m_encoder.select_collection(col_key, key); // Throws
     m_selected_list = CollectionId(list.get_table()->get_key(), key, col_key);

--- a/src/realm/list.cpp
+++ b/src/realm/list.cpp
@@ -365,13 +365,6 @@ void Lst<Mixed>::do_remove(size_t ndx)
     }
 }
 
-bool LnkLst::init_from_parent() const
-{
-    m_list.init_from_parent();
-    update_unresolved(*m_list.m_tree);
-    return m_list.m_valid;
-}
-
 Obj LnkLst::create_and_insert_linked_object(size_t ndx)
 {
     Table& t = *get_target_table();

--- a/src/realm/list.cpp
+++ b/src/realm/list.cpp
@@ -163,22 +163,6 @@ void Lst<T>::distinct(std::vector<size_t>& indices, util::Optional<bool> sort_or
 
 /********************************* Lst<Key> *********************************/
 
-namespace {
-void check_for_last_unresolved(BPlusTree<ObjKey>& tree)
-{
-    bool no_more_unresolved = true;
-    size_t sz = tree.size();
-    for (size_t n = 0; n < sz; n++) {
-        if (tree.get(n).is_unresolved()) {
-            no_more_unresolved = false;
-            break;
-        }
-    }
-    if (no_more_unresolved)
-        tree.set_context_flag(true);
-}
-} // namespace
-
 template <>
 void Lst<ObjKey>::do_set(size_t ndx, ObjKey target_key)
 {
@@ -200,7 +184,7 @@ void Lst<ObjKey>::do_set(size_t ndx, ObjKey target_key)
     }
     else if (old_key.is_unresolved()) {
         // We might have removed the last unresolved link - check it
-        check_for_last_unresolved(*m_tree);
+        _impl::check_for_last_unresolved(*m_tree);
     }
 }
 
@@ -233,7 +217,7 @@ void Lst<ObjKey>::do_remove(size_t ndx)
     }
     if (old_key.is_unresolved()) {
         // We might have removed the last unresolved link - check it
-        check_for_last_unresolved(*m_tree);
+        _impl::check_for_last_unresolved(*m_tree);
     }
 }
 

--- a/src/realm/list.cpp
+++ b/src/realm/list.cpp
@@ -437,5 +437,21 @@ void LnkLst::remove_all_target_rows()
 template class Lst<ObjKey>;
 template class Lst<Mixed>;
 template class Lst<ObjLink>;
+template class Lst<int64_t>;
+template class Lst<bool>;
+template class Lst<StringData>;
+template class Lst<BinaryData>;
+template class Lst<Timestamp>;
+template class Lst<float>;
+template class Lst<double>;
+template class Lst<Decimal128>;
+template class Lst<ObjectId>;
+template class Lst<UUID>;
+template class Lst<util::Optional<int64_t>>;
+template class Lst<util::Optional<bool>>;
+template class Lst<util::Optional<float>>;
+template class Lst<util::Optional<double>>;
+template class Lst<util::Optional<ObjectId>>;
+template class Lst<util::Optional<UUID>>;
 
 } // namespace realm

--- a/src/realm/list.cpp
+++ b/src/realm/list.cpp
@@ -383,16 +383,16 @@ void Lst<Mixed>::do_remove(size_t ndx)
 
 bool LnkLst::init_from_parent() const
 {
-    m_keys.init_from_parent();
-    update_unresolved(*m_keys.m_tree);
-    return m_keys.m_valid;
+    m_list.init_from_parent();
+    update_unresolved(*m_list.m_tree);
+    return m_list.m_valid;
 }
 
 Obj LnkLst::create_and_insert_linked_object(size_t ndx)
 {
     Table& t = *get_target_table();
     auto o = t.is_embedded() ? t.create_linked_object() : t.create_object();
-    m_keys.insert(ndx, o.get_key());
+    m_list.insert(ndx, o.get_key());
     return o;
 }
 
@@ -400,7 +400,7 @@ Obj LnkLst::create_and_set_linked_object(size_t ndx)
 {
     Table& t = *get_target_table();
     auto o = t.is_embedded() ? t.create_linked_object() : t.create_object();
-    m_keys.set(ndx, o.get_key());
+    m_list.set(ndx, o.get_key());
     return o;
 }
 
@@ -429,7 +429,7 @@ void LnkLst::remove_target_row(size_t link_ndx)
 void LnkLst::remove_all_target_rows()
 {
     if (is_attached()) {
-        _impl::TableFriend::batch_erase_rows(*get_target_table(), *m_keys.m_tree);
+        _impl::TableFriend::batch_erase_rows(*get_target_table(), *m_list.m_tree);
     }
 }
 

--- a/src/realm/list.hpp
+++ b/src/realm/list.hpp
@@ -89,7 +89,6 @@ public:
     Lst(Lst&&) noexcept;
     Lst& operator=(const Lst& other);
     Lst& operator=(Lst&& other) noexcept;
-    Lst& operator=(const BPlusTree<T>& other);
 
     void create();
 
@@ -489,13 +488,6 @@ inline Lst<T>& Lst<T>::operator=(Lst&& other) noexcept
         }
     }
 
-    return *this;
-}
-
-template <class T>
-inline Lst<T>& Lst<T>::operator=(const BPlusTree<T>& other)
-{
-    *m_tree = other;
     return *this;
 }
 

--- a/src/realm/list.hpp
+++ b/src/realm/list.hpp
@@ -109,12 +109,6 @@ public:
     T remove(size_t ndx);
 
     // Overriding members of CollectionBase:
-    using Base::get_col_key;
-    using Base::get_obj;
-    using Base::get_table;
-    using Base::get_target_table;
-    using Base::has_changed;
-    using Base::is_attached;
     size_t size() const final;
     void clear() final;
     Mixed get_any(size_t ndx) const final;
@@ -272,6 +266,7 @@ public:
     }
 
     // Overriding members of CollectionBase:
+    using CollectionBase::get_key;
     size_t size() const final;
     bool is_null(size_t ndx) const final;
     Mixed get_any(size_t ndx) const final;
@@ -281,14 +276,10 @@ public:
     Mixed sum(size_t* return_cnt = nullptr) const final;
     Mixed avg(size_t* return_cnt = nullptr) const final;
     std::unique_ptr<CollectionBase> clone_collection() const final;
-    TableRef get_target_table() const final;
     void sort(std::vector<size_t>& indices, bool ascending = true) const final;
     void distinct(std::vector<size_t>& indices, util::Optional<bool> sort_order = util::none) const final;
     const Obj& get_obj() const noexcept final;
-    ObjKey get_key() const final;
-    bool is_attached() const final;
     bool has_changed() const final;
-    ConstTableRef get_table() const noexcept final;
     ColKey get_col_key() const noexcept final;
 
     // Overriding members of LstBase:
@@ -321,7 +312,6 @@ public:
         ObjKey key = this->get(ndx);
         return get_target_table()->get_object(key);
     }
-
     ObjKey get_key(size_t ndx) const final
     {
         return get(ndx);
@@ -877,11 +867,6 @@ inline std::unique_ptr<CollectionBase> LnkLst::clone_collection() const
     return get_obj().get_linklist_ptr(get_col_key());
 }
 
-inline TableRef LnkLst::get_target_table() const
-{
-    return m_list.get_target_table();
-}
-
 inline void LnkLst::sort(std::vector<size_t>& indices, bool ascending) const
 {
     static_cast<void>(indices);
@@ -901,24 +886,9 @@ inline const Obj& LnkLst::get_obj() const noexcept
     return m_list.get_obj();
 }
 
-inline ObjKey LnkLst::get_key() const
-{
-    return m_list.get_key();
-}
-
-inline bool LnkLst::is_attached() const
-{
-    return m_list.is_attached();
-}
-
 inline bool LnkLst::has_changed() const
 {
     return m_list.has_changed();
-}
-
-inline ConstTableRef LnkLst::get_table() const noexcept
-{
-    return m_list.get_table();
 }
 
 inline ColKey LnkLst::get_col_key() const noexcept

--- a/src/realm/list.hpp
+++ b/src/realm/list.hpp
@@ -216,6 +216,24 @@ template <>
 void Lst<ObjLink>::do_remove(size_t);
 extern template class Lst<ObjLink>;
 
+// Extern template declarations for lists of primitives:
+extern template class Lst<int64_t>;
+extern template class Lst<bool>;
+extern template class Lst<StringData>;
+extern template class Lst<BinaryData>;
+extern template class Lst<Timestamp>;
+extern template class Lst<float>;
+extern template class Lst<double>;
+extern template class Lst<Decimal128>;
+extern template class Lst<ObjectId>;
+extern template class Lst<UUID>;
+extern template class Lst<util::Optional<int64_t>>;
+extern template class Lst<util::Optional<bool>>;
+extern template class Lst<util::Optional<float>>;
+extern template class Lst<util::Optional<double>>;
+extern template class Lst<util::Optional<ObjectId>>;
+extern template class Lst<util::Optional<UUID>>;
+
 class LnkLst final : public ObjCollectionBase<LstBase> {
 public:
     using Base = ObjCollectionBase<LstBase>;
@@ -475,14 +493,14 @@ inline Lst<T>& Lst<T>::operator=(Lst&& other) noexcept
 }
 
 template <class T>
-Lst<T>& Lst<T>::operator=(const BPlusTree<T>& other)
+inline Lst<T>& Lst<T>::operator=(const BPlusTree<T>& other)
 {
     *m_tree = other;
     return *this;
 }
 
 template <class T>
-T Lst<T>::remove(const iterator& it)
+inline T Lst<T>::remove(const iterator& it)
 {
     return remove(it.index());
 }
@@ -539,13 +557,13 @@ inline void Lst<T>::do_remove(size_t ndx)
 
 
 template <typename U>
-Lst<U> Obj::get_list(ColKey col_key) const
+inline Lst<U> Obj::get_list(ColKey col_key) const
 {
     return Lst<U>(*this, col_key);
 }
 
 template <typename U>
-LstPtr<U> Obj::get_list_ptr(ColKey col_key) const
+inline LstPtr<U> Obj::get_list_ptr(ColKey col_key) const
 {
     return std::make_unique<Lst<U>>(*this, col_key);
 }
@@ -582,7 +600,7 @@ void Lst<T>::clear()
 }
 
 template <class T>
-CollectionBasePtr Lst<T>::clone_collection() const
+inline CollectionBasePtr Lst<T>::clone_collection() const
 {
     return std::make_unique<Lst<T>>(m_obj, m_col_key);
 }
@@ -631,13 +649,13 @@ inline Mixed Lst<T>::avg(size_t* return_cnt) const
 }
 
 template <class T>
-LstBasePtr Lst<T>::clone() const
+inline LstBasePtr Lst<T>::clone() const
 {
     return std::make_unique<Lst<T>>(m_obj, m_col_key);
 }
 
 template <class T>
-void Lst<T>::set_null(size_t ndx)
+inline void Lst<T>::set_null(size_t ndx)
 {
     set(ndx, BPlusTree<T>::default_value(m_nullable));
 }
@@ -659,13 +677,13 @@ void Lst<T>::set_any(size_t ndx, Mixed val)
 }
 
 template <class T>
-void Lst<T>::insert_null(size_t ndx)
+inline void Lst<T>::insert_null(size_t ndx)
 {
     insert(ndx, BPlusTree<T>::default_value(m_nullable));
 }
 
 template <class T>
-void Lst<T>::insert_any(size_t ndx, Mixed val)
+inline void Lst<T>::insert_any(size_t ndx, Mixed val)
 {
     if constexpr (std::is_same_v<T, Mixed>) {
         insert(ndx, val);
@@ -693,7 +711,7 @@ void Lst<T>::resize(size_t new_size)
 }
 
 template <class T>
-void Lst<T>::remove(size_t from, size_t to)
+inline void Lst<T>::remove(size_t from, size_t to)
 {
     while (from < to) {
         remove(--to);
@@ -803,6 +821,7 @@ inline bool LnkLst::operator==(const LnkLst& other) const
 {
     return m_keys == other.m_keys;
 }
+
 inline bool LnkLst::operator!=(const LnkLst& other) const
 {
     return m_keys != other.m_keys;
@@ -837,16 +856,19 @@ inline Mixed LnkLst::min(size_t* return_ndx) const
     static_cast<void>(return_ndx);
     REALM_TERMINATE("Not implemented yet");
 }
+
 inline Mixed LnkLst::max(size_t* return_ndx) const
 {
     static_cast<void>(return_ndx);
     REALM_TERMINATE("Not implemented yet");
 }
+
 inline Mixed LnkLst::sum(size_t* return_cnt) const
 {
     static_cast<void>(return_cnt);
     REALM_TERMINATE("Not implemented yet");
 }
+
 inline Mixed LnkLst::avg(size_t* return_cnt) const
 {
     static_cast<void>(return_cnt);

--- a/src/realm/list.hpp
+++ b/src/realm/list.hpp
@@ -86,7 +86,9 @@ public:
     Lst() = default;
     Lst(const Obj& owner, ColKey col_key);
     Lst(const Lst& other);
+    Lst(Lst&&) noexcept;
     Lst& operator=(const Lst& other);
+    Lst& operator=(Lst&& other) noexcept;
     Lst& operator=(const BPlusTree<T>& other);
 
     void create();
@@ -229,7 +231,9 @@ public:
     }
 
     LnkLst(const LnkLst& other) = default;
+    LnkLst(LnkLst&& other) = default;
     LnkLst& operator=(const LnkLst& other) = default;
+    LnkLst& operator=(LnkLst&& other) = default;
     bool operator==(const LnkLst& other) const;
     bool operator!=(const LnkLst& other) const;
 
@@ -419,6 +423,16 @@ inline Lst<T>::Lst(const Lst& other)
 }
 
 template <class T>
+inline Lst<T>::Lst(Lst&& other) noexcept
+    : Base(static_cast<Base&&>(other))
+    , m_tree(std::exchange(other.m_tree, nullptr))
+{
+    if (m_tree) {
+        m_tree->set_parent(this, 0);
+    }
+}
+
+template <class T>
 inline void Lst<T>::create()
 {
     m_tree->create();
@@ -439,6 +453,21 @@ Lst<T>& Lst<T>::operator=(const Lst& other)
             if (m_valid) {
                 m_tree->init_from_ref(other.m_tree->get_ref());
             }
+        }
+    }
+
+    return *this;
+}
+
+template <class T>
+inline Lst<T>& Lst<T>::operator=(Lst&& other) noexcept
+{
+    Base::operator=(static_cast<Base&&>(other));
+
+    if (this != &other) {
+        m_tree = std::exchange(other.m_tree, nullptr);
+        if (m_tree) {
+            m_tree->set_parent(this, 0);
         }
     }
 

--- a/src/realm/list.hpp
+++ b/src/realm/list.hpp
@@ -267,8 +267,8 @@ public:
     ObjKey get_key() const final;
     bool is_attached() const final;
     bool has_changed() const final;
-    ConstTableRef get_table() const final;
-    ColKey get_col_key() const final;
+    ConstTableRef get_table() const noexcept final;
+    ColKey get_col_key() const noexcept final;
 
     // Overriding members of LstBase:
     std::unique_ptr<LstBase> clone() const
@@ -868,12 +868,12 @@ inline bool LnkLst::has_changed() const
     return m_keys.has_changed();
 }
 
-inline ConstTableRef LnkLst::get_table() const
+inline ConstTableRef LnkLst::get_table() const noexcept
 {
     return m_keys.get_table();
 }
 
-inline ColKey LnkLst::get_col_key() const
+inline ColKey LnkLst::get_col_key() const noexcept
 {
     return m_keys.get_col_key();
 }

--- a/src/realm/list.hpp
+++ b/src/realm/list.hpp
@@ -38,10 +38,6 @@
 #include <realm/array_typed_link.hpp>
 #include <realm/replication.hpp>
 
-#ifdef _MSC_VER
-#pragma warning(disable : 4250) // Suppress 'inherits ... via dominance' on MSVC
-#endif
-
 namespace realm {
 
 class TableView;

--- a/src/realm/list.hpp
+++ b/src/realm/list.hpp
@@ -548,30 +548,6 @@ inline LnkLst Obj::get_linklist(StringData col_name) const
 }
 
 template <class T>
-inline ColumnSumType<T> list_sum(const Lst<T>& list, size_t* return_cnt = nullptr)
-{
-    return bptree_sum(list.get_tree(), return_cnt);
-}
-
-template <class T>
-inline ColumnMinMaxType<T> list_maximum(const Lst<T>& list, size_t* return_ndx = nullptr)
-{
-    return bptree_maximum(list.get_tree(), return_ndx);
-}
-
-template <class T>
-inline ColumnMinMaxType<T> list_minimum(const Lst<T>& list, size_t* return_ndx = nullptr)
-{
-    return bptree_minimum(list.get_tree(), return_ndx);
-}
-
-template <class T>
-inline ColumnAverageType<T> list_average(const Lst<T>& list, size_t* return_cnt = nullptr)
-{
-    return bptree_average(list.get_tree(), return_cnt);
-}
-
-template <class T>
 void Lst<T>::clear()
 {
     static_assert(!std::is_same_v<T, ObjKey>);

--- a/src/realm/list.hpp
+++ b/src/realm/list.hpp
@@ -242,9 +242,9 @@ public:
     LnkLst() = default;
 
     LnkLst(const Obj& owner, ColKey col_key)
-        : m_keys(owner, col_key)
+        : m_list(owner, col_key)
     {
-        update_unresolved(*m_keys.m_tree);
+        update_unresolved(*m_list.m_tree);
     }
 
     LnkLst(const LnkLst& other) = default;
@@ -340,7 +340,7 @@ public:
         if (value.is_unresolved())
             return;
 
-        m_keys.find_all(value, [&](size_t ndx) {
+        m_list.find_all(value, [&](size_t ndx) {
             func(real2virtual(ndx));
         });
     }
@@ -374,14 +374,14 @@ public:
 
     const BPlusTree<ObjKey>& get_tree() const
     {
-        return m_keys.get_tree();
+        return m_list.get_tree();
     }
 
 protected:
     bool update_if_needed() const final
     {
-        if (m_keys.update_if_needed()) {
-            update_unresolved(*m_keys.m_tree);
+        if (m_list.update_if_needed()) {
+            update_unresolved(*m_list.m_tree);
             return true;
         }
         return false;
@@ -391,7 +391,7 @@ private:
     friend class ConstTableView;
     friend class Query;
 
-    Lst<ObjKey> m_keys;
+    Lst<ObjKey> m_list;
 
     bool init_from_parent() const final;
 };
@@ -811,35 +811,35 @@ T Lst<T>::remove(size_t ndx)
 
 inline bool LnkLst::operator==(const LnkLst& other) const
 {
-    return m_keys == other.m_keys;
+    return m_list == other.m_list;
 }
 
 inline bool LnkLst::operator!=(const LnkLst& other) const
 {
-    return m_keys != other.m_keys;
+    return m_list != other.m_list;
 }
 
 inline size_t LnkLst::size() const
 {
     update_if_needed();
-    return m_keys.size() - num_unresolved();
+    return m_list.size() - num_unresolved();
 }
 
 inline bool LnkLst::is_null(size_t ndx) const
 {
     update_if_needed();
-    return m_keys.is_null(virtual2real(ndx));
+    return m_list.is_null(virtual2real(ndx));
 }
 
 inline Mixed LnkLst::get_any(size_t ndx) const
 {
     update_if_needed();
-    return m_keys.get_any(virtual2real(ndx));
+    return m_list.get_any(virtual2real(ndx));
 }
 
 inline void LnkLst::clear()
 {
-    m_keys.clear();
+    m_list.clear();
     clear_unresolved();
 }
 
@@ -874,7 +874,7 @@ inline std::unique_ptr<CollectionBase> LnkLst::clone_collection() const
 
 inline TableRef LnkLst::get_target_table() const
 {
-    return m_keys.get_target_table();
+    return m_list.get_target_table();
 }
 
 inline void LnkLst::sort(std::vector<size_t>& indices, bool ascending) const
@@ -893,86 +893,86 @@ inline void LnkLst::distinct(std::vector<size_t>& indices, util::Optional<bool> 
 
 inline const Obj& LnkLst::get_obj() const noexcept
 {
-    return m_keys.get_obj();
+    return m_list.get_obj();
 }
 
 inline ObjKey LnkLst::get_key() const
 {
-    return m_keys.get_key();
+    return m_list.get_key();
 }
 
 inline bool LnkLst::is_attached() const
 {
-    return m_keys.is_attached();
+    return m_list.is_attached();
 }
 
 inline bool LnkLst::has_changed() const
 {
-    return m_keys.has_changed();
+    return m_list.has_changed();
 }
 
 inline ConstTableRef LnkLst::get_table() const noexcept
 {
-    return m_keys.get_table();
+    return m_list.get_table();
 }
 
 inline ColKey LnkLst::get_col_key() const noexcept
 {
-    return m_keys.get_col_key();
+    return m_list.get_col_key();
 }
 
 inline void LnkLst::set_null(size_t ndx)
 {
     update_if_needed();
-    m_keys.set_null(virtual2real(ndx));
+    m_list.set_null(virtual2real(ndx));
 }
 
 inline void LnkLst::set_any(size_t ndx, Mixed val)
 {
     update_if_needed();
-    m_keys.set_any(virtual2real(ndx), val);
+    m_list.set_any(virtual2real(ndx), val);
 }
 
 inline void LnkLst::insert_null(size_t ndx)
 {
     update_if_needed();
-    m_keys.insert_null(virtual2real(ndx));
+    m_list.insert_null(virtual2real(ndx));
 }
 
 inline void LnkLst::insert_any(size_t ndx, Mixed val)
 {
     update_if_needed();
-    m_keys.insert_any(virtual2real(ndx), val);
+    m_list.insert_any(virtual2real(ndx), val);
 }
 
 inline void LnkLst::resize(size_t new_size)
 {
     update_if_needed();
-    m_keys.resize(new_size + num_unresolved());
+    m_list.resize(new_size + num_unresolved());
 }
 
 inline void LnkLst::remove(size_t from, size_t to)
 {
     update_if_needed();
-    m_keys.remove(virtual2real(from), virtual2real(to));
+    m_list.remove(virtual2real(from), virtual2real(to));
 }
 
 inline void LnkLst::move(size_t from, size_t to)
 {
     update_if_needed();
-    m_keys.move(virtual2real(from), virtual2real(to));
+    m_list.move(virtual2real(from), virtual2real(to));
 }
 
 inline void LnkLst::swap(size_t ndx1, size_t ndx2)
 {
     update_if_needed();
-    m_keys.swap(virtual2real(ndx1), virtual2real(ndx2));
+    m_list.swap(virtual2real(ndx1), virtual2real(ndx2));
 }
 
 inline ObjKey LnkLst::get(size_t ndx) const
 {
     update_if_needed();
-    return m_keys.get(virtual2real(ndx));
+    return m_list.get(virtual2real(ndx));
 }
 
 inline size_t LnkLst::find_first(const ObjKey& key) const
@@ -981,7 +981,7 @@ inline size_t LnkLst::find_first(const ObjKey& key) const
         return not_found;
 
     update_if_needed();
-    size_t found = m_keys.find_first(key);
+    size_t found = m_list.find_first(key);
     if (found == not_found)
         return not_found;
     return real2virtual(found);
@@ -993,7 +993,7 @@ inline void LnkLst::insert(size_t ndx, ObjKey value)
     if (get_target_table()->is_embedded() && value != ObjKey())
         throw LogicError(LogicError::wrong_kind_of_table);
     update_if_needed();
-    m_keys.insert(virtual2real(ndx), value);
+    m_list.insert(virtual2real(ndx), value);
 }
 
 inline ObjKey LnkLst::set(size_t ndx, ObjKey value)
@@ -1002,7 +1002,7 @@ inline ObjKey LnkLst::set(size_t ndx, ObjKey value)
     if (get_target_table()->is_embedded() && value != ObjKey())
         throw LogicError(LogicError::wrong_kind_of_table);
     update_if_needed();
-    ObjKey old = m_keys.set(virtual2real(ndx), value);
+    ObjKey old = m_list.set(virtual2real(ndx), value);
     REALM_ASSERT(!old.is_unresolved());
     return old;
 }
@@ -1010,7 +1010,7 @@ inline ObjKey LnkLst::set(size_t ndx, ObjKey value)
 inline ObjKey LnkLst::remove(size_t ndx)
 {
     update_if_needed();
-    ObjKey old = m_keys.remove(virtual2real(ndx));
+    ObjKey old = m_list.remove(virtual2real(ndx));
     REALM_ASSERT(!old.is_unresolved());
     return old;
 }

--- a/src/realm/list.hpp
+++ b/src/realm/list.hpp
@@ -244,7 +244,7 @@ public:
     LnkLst(const Obj& owner, ColKey col_key)
         : m_list(owner, col_key)
     {
-        update_unresolved(*m_list.m_tree);
+        update_unresolved();
     }
 
     LnkLst(const LnkLst& other) = default;
@@ -377,23 +377,28 @@ public:
         return m_list.get_tree();
     }
 
-protected:
-    bool update_if_needed() const final
-    {
-        if (m_list.update_if_needed()) {
-            update_unresolved(*m_list.m_tree);
-            return true;
-        }
-        return false;
-    }
-
 private:
     friend class ConstTableView;
     friend class Query;
 
     Lst<ObjKey> m_list;
 
-    bool init_from_parent() const final;
+    // Overriding members of ObjCollectionBase:
+
+    bool do_update_if_needed() const final
+    {
+        return m_list.update_if_needed();
+    }
+
+    bool do_init_from_parent() const final
+    {
+        return m_list.init_from_parent();
+    }
+
+    BPlusTree<ObjKey>& get_mutable_tree() const final
+    {
+        return *m_list.m_tree;
+    }
 };
 
 

--- a/src/realm/obj.cpp
+++ b/src/realm/obj.cpp
@@ -74,7 +74,7 @@ const TableClusterTree* Obj::get_tree_top() const
     }
 }
 
-Allocator& Obj::get_alloc() const noexcept
+Allocator& Obj::get_alloc() const
 {
     // Do a "checked" deref to table to ensure the instance_version is correct.
     // Even if removed from the public API, this should *not* be optimized away,

--- a/src/realm/obj.cpp
+++ b/src/realm/obj.cpp
@@ -202,6 +202,7 @@ void Obj::remove()
 void Obj::invalidate()
 {
     m_table.cast_away_const()->invalidate_object(m_key);
+    m_key = m_key.get_unresolved();
 }
 
 ColKey Obj::get_column_key(StringData col_name) const

--- a/src/realm/obj.cpp
+++ b/src/realm/obj.cpp
@@ -95,7 +95,7 @@ const Spec& Obj::get_spec() const
     return m_table.unchecked_ptr()->m_spec;
 }
 
-Replication* Obj::get_replication() const noexcept
+Replication* Obj::get_replication() const
 {
     return m_table->get_repl();
 }
@@ -210,7 +210,7 @@ ColKey Obj::get_column_key(StringData col_name) const
     return get_table()->get_column_key(col_name);
 }
 
-TableKey Obj::get_table_key() const noexcept
+TableKey Obj::get_table_key() const
 {
     return get_table()->get_key();
 }

--- a/src/realm/obj.cpp
+++ b/src/realm/obj.cpp
@@ -74,7 +74,7 @@ const TableClusterTree* Obj::get_tree_top() const
     }
 }
 
-Allocator& Obj::get_alloc() const
+Allocator& Obj::get_alloc() const noexcept
 {
     // Do a "checked" deref to table to ensure the instance_version is correct.
     // Even if removed from the public API, this should *not* be optimized away,
@@ -83,7 +83,7 @@ Allocator& Obj::get_alloc() const
     return m_table->m_alloc;
 }
 
-Allocator& Obj::_get_alloc() const
+Allocator& Obj::_get_alloc() const noexcept
 {
     // Bypass check of table instance version. To be used only in contexts,
     // where instance version match has already been established (e.g _get<>)
@@ -95,7 +95,7 @@ const Spec& Obj::get_spec() const
     return m_table.unchecked_ptr()->m_spec;
 }
 
-Replication* Obj::get_replication() const
+Replication* Obj::get_replication() const noexcept
 {
     return m_table->get_repl();
 }
@@ -178,7 +178,7 @@ bool Obj::operator==(const Obj& other) const
     return true;
 }
 
-bool Obj::is_valid() const
+bool Obj::is_valid() const noexcept
 {
     // Cache valid state. If once invalid, it can never become valid again
     if (m_valid)
@@ -210,7 +210,7 @@ ColKey Obj::get_column_key(StringData col_name) const
     return get_table()->get_column_key(col_name);
 }
 
-TableKey Obj::get_table_key() const
+TableKey Obj::get_table_key() const noexcept
 {
     return get_table()->get_key();
 }

--- a/src/realm/obj.cpp
+++ b/src/realm/obj.cpp
@@ -235,7 +235,7 @@ TableRef Obj::get_target_table(ObjLink link) const
     }
 }
 
-inline bool Obj::update() const
+bool Obj::update() const
 {
     // Get a new object from key
     Obj new_obj = get_tree_top()->get(m_key);
@@ -254,15 +254,6 @@ inline bool Obj::update() const
 inline bool Obj::_update_if_needed() const
 {
     auto current_version = _get_alloc().get_storage_version();
-    if (current_version != m_storage_version) {
-        return update();
-    }
-    return false;
-}
-
-bool Obj::update_if_needed() const
-{
-    auto current_version = get_alloc().get_storage_version();
     if (current_version != m_storage_version) {
         return update();
     }
@@ -1191,19 +1182,6 @@ bool Obj::ensure_writeable()
         return true;
     }
     return false;
-}
-
-void Obj::bump_content_version()
-{
-    Allocator& alloc = get_alloc();
-    alloc.bump_content_version();
-}
-
-void Obj::bump_both_versions()
-{
-    Allocator& alloc = get_alloc();
-    alloc.bump_content_version();
-    alloc.bump_storage_version();
 }
 
 template <>

--- a/src/realm/obj.hpp
+++ b/src/realm/obj.hpp
@@ -77,7 +77,7 @@ public:
         return m_table.cast_away_const();
     }
 
-    Allocator& get_alloc() const noexcept;
+    Allocator& get_alloc() const;
 
     bool operator==(const Obj& other) const;
 

--- a/src/realm/obj.hpp
+++ b/src/realm/obj.hpp
@@ -245,6 +245,11 @@ public:
     LnkLstPtr get_linklist_ptr(ColKey col_key) const;
     LnkLst get_linklist(StringData col_name) const;
 
+    /// Get a type-erased list instance for the given list column.
+    ///
+    /// Note: For lists of links, this always returns a `LnkLst`, rather than a
+    /// `Lst<ObjKey>`. Use `get_list_ptr<ObjKey>(col_key)` to get a list of
+    /// links with uncondensed indices.
     LstBasePtr get_listbase_ptr(ColKey col_key) const;
 
     template <typename U>

--- a/src/realm/obj.hpp
+++ b/src/realm/obj.hpp
@@ -273,6 +273,8 @@ private:
     template <class, class>
     friend class Collection;
     template <class>
+    friend class CollectionBaseImpl;
+    template <class>
     friend class Lst;
     friend class LnkLst;
     friend class Dictionary;
@@ -351,6 +353,9 @@ private:
 };
 
 std::ostream& operator<<(std::ostream&, const Obj& obj);
+
+template <>
+int64_t Obj::_get(ColKey::Idx col_ndx) const;
 
 struct Obj::FatPathElement {
     Obj obj;        // Object which embeds...

--- a/src/realm/obj.hpp
+++ b/src/realm/obj.hpp
@@ -72,16 +72,16 @@ public:
     }
     Obj(TableRef table, MemRef mem, ObjKey key, size_t row_ndx);
 
-    TableRef get_table() const
+    TableRef get_table() const noexcept
     {
         return m_table.cast_away_const();
     }
 
-    Allocator& get_alloc() const;
+    Allocator& get_alloc() const noexcept;
 
     bool operator==(const Obj& other) const;
 
-    ObjKey get_key() const
+    ObjKey get_key() const noexcept
     {
         return m_key;
     }
@@ -89,16 +89,16 @@ public:
     GlobalKey get_object_id() const;
     ObjLink get_link() const;
 
-    Replication* get_replication() const;
+    Replication* get_replication() const noexcept;
 
     // Check if this object is default constructed
-    explicit operator bool() const
+    explicit operator bool() const noexcept
     {
         return m_table != nullptr;
     }
 
     // Check if the object is still alive
-    bool is_valid() const;
+    bool is_valid() const noexcept;
     // Will throw if object is not valid
     void check_valid() const;
     // Delete object from table. Object is invalid afterwards.
@@ -296,7 +296,7 @@ private:
     mutable uint64_t m_storage_version;
     mutable bool m_valid;
 
-    Allocator& _get_alloc() const;
+    Allocator& _get_alloc() const noexcept;
     bool update() const;
     // update if needed - with and without check of table instance version:
     bool update_if_needed() const;
@@ -307,7 +307,7 @@ private:
     const TableClusterTree* get_tree_top() const;
     ColKey get_column_key(StringData col_name) const;
     ColKey get_primary_key_column() const;
-    TableKey get_table_key() const;
+    TableKey get_table_key() const noexcept;
     TableRef get_target_table(ColKey col_key) const;
     TableRef get_target_table(ObjLink link) const;
     const Spec& get_spec() const;

--- a/src/realm/obj.hpp
+++ b/src/realm/obj.hpp
@@ -327,7 +327,7 @@ private:
     ColKey spec_ndx2colkey(size_t col_ndx);
     size_t colkey2spec_ndx(ColKey);
     bool ensure_writeable();
-    void bump_content_version();
+    int_fast64_t bump_content_version();
     void bump_both_versions();
     template <class T>
     void do_set_null(ColKey col_key);
@@ -509,6 +509,29 @@ inline Obj& Obj::set_all(Head v, Tail... tail)
 
     return _set(start_index, v, tail...);
 }
+
+inline bool Obj::update_if_needed() const
+{
+    auto current_version = get_alloc().get_storage_version();
+    if (current_version != m_storage_version) {
+        return update();
+    }
+    return false;
+}
+
+inline int_fast64_t Obj::bump_content_version()
+{
+    Allocator& alloc = get_alloc();
+    return alloc.bump_content_version();
+}
+
+inline void Obj::bump_both_versions()
+{
+    Allocator& alloc = get_alloc();
+    alloc.bump_content_version();
+    alloc.bump_storage_version();
+}
+
 } // namespace realm
 
 #endif // REALM_OBJ_HPP

--- a/src/realm/obj.hpp
+++ b/src/realm/obj.hpp
@@ -89,7 +89,7 @@ public:
     GlobalKey get_object_id() const;
     ObjLink get_link() const;
 
-    Replication* get_replication() const noexcept;
+    Replication* get_replication() const;
 
     // Check if this object is default constructed
     explicit operator bool() const noexcept
@@ -307,7 +307,7 @@ private:
     const TableClusterTree* get_tree_top() const;
     ColKey get_column_key(StringData col_name) const;
     ColKey get_primary_key_column() const;
-    TableKey get_table_key() const noexcept;
+    TableKey get_table_key() const;
     TableRef get_target_table(ColKey col_key) const;
     TableRef get_target_table(ObjLink link) const;
     const Spec& get_spec() const;

--- a/src/realm/object-store/collection.cpp
+++ b/src/realm/object-store/collection.cpp
@@ -43,7 +43,7 @@ Collection::Collection(std::shared_ptr<Realm> r, const Obj& parent_obj, ColKey c
 Collection::Collection(std::shared_ptr<Realm> r, const CollectionBase& coll)
     : m_realm(std::move(r))
     , m_type(ObjectSchema::from_core_type(coll.get_col_key()) & ~PropertyType::Collection)
-    , m_coll_base(coll.clone())
+    , m_coll_base(coll.clone_collection())
 {
 }
 

--- a/src/realm/object-store/list.hpp
+++ b/src/realm/object-store/list.hpp
@@ -154,12 +154,21 @@ private:
 template <typename T>
 auto& List::as() const
 {
+    REALM_ASSERT(dynamic_cast<Lst<T>*>(&*m_list_base));
     return static_cast<Lst<T>&>(*m_list_base);
 }
 
 template <>
 inline auto& List::as<Obj>() const
 {
+    REALM_ASSERT(dynamic_cast<LnkLst*>(&*m_list_base));
+    return static_cast<LnkLst&>(*m_list_base);
+}
+
+template <>
+inline auto& List::as<ObjKey>() const
+{
+    REALM_ASSERT(dynamic_cast<LnkLst*>(&*m_list_base));
     return static_cast<LnkLst&>(*m_list_base);
 }
 

--- a/src/realm/object-store/results.cpp
+++ b/src/realm/object-store/results.cpp
@@ -420,7 +420,7 @@ size_t Results::index_of(Obj const& row)
             return m_table->get_object_ndx(row.get_key());
         case Mode::LinkList:
             if (update_linklist())
-                return m_link_list->Lst<ObjKey>::find_first(row.get_key());
+                return m_link_list->find_first(row.get_key());
             REALM_FALLTHROUGH;
         case Mode::Query:
         case Mode::TableView:
@@ -731,26 +731,34 @@ util::Optional<Mixed> Results::aggregate(ColKey column, const char* name, Aggreg
 util::Optional<Mixed> Results::max(ColKey column)
 {
     ReturnIndexHelper return_ndx;
-    auto results = aggregate(column, "max", [&](auto&& helper) { return helper.max(column, return_ndx); });
+    auto results = aggregate(column, "max", [&](auto&& helper) {
+        return helper.max(column, return_ndx);
+    });
     return return_ndx ? results : none;
 }
 
 util::Optional<Mixed> Results::min(ColKey column)
 {
     ReturnIndexHelper return_ndx;
-    auto results = aggregate(column, "min", [&](auto&& helper) { return helper.min(column, return_ndx); });
+    auto results = aggregate(column, "min", [&](auto&& helper) {
+        return helper.min(column, return_ndx);
+    });
     return return_ndx ? results : none;
 }
 
 util::Optional<Mixed> Results::sum(ColKey column)
 {
-    return aggregate(column, "sum", [&](auto&& helper) { return helper.sum(column); });
+    return aggregate(column, "sum", [&](auto&& helper) {
+        return helper.sum(column);
+    });
 }
 
 util::Optional<Mixed> Results::average(ColKey column)
 {
     size_t value_count = 0;
-    auto results = aggregate(column, "avg", [&](auto&& helper) { return helper.avg(column, &value_count); });
+    auto results = aggregate(column, "avg", [&](auto&& helper) {
+        return helper.avg(column, &value_count);
+    });
     return value_count == 0 ? none : results;
 }
 

--- a/src/realm/query.cpp
+++ b/src/realm/query.cpp
@@ -39,7 +39,7 @@ Query::Query()
 
 Query::Query(ConstTableRef table, const LnkLst& list)
     : m_table(table.cast_away_const())
-    , m_source_link_list(list.clone())
+    , m_source_link_list(list.clone_linklist())
 {
     m_view = m_source_link_list.get();
     REALM_ASSERT_DEBUG(list.get_target_table() == m_table);
@@ -90,7 +90,7 @@ Query::Query(const Query& source)
         // FIXME: The lifetime of `m_source_table_view` may be tied to that of `source`, which can easily
         // turn `m_source_table_view` into a dangling reference.
         m_source_table_view = source.m_source_table_view;
-        m_source_link_list = source.m_source_link_list ? source.m_source_link_list->clone() : LnkLstPtr{};
+        m_source_link_list = source.m_source_link_list ? source.m_source_link_list->clone_linklist() : LnkLstPtr{};
     }
     if (m_source_table_view) {
         m_view = m_source_table_view;
@@ -118,7 +118,8 @@ Query& Query::operator=(const Query& source)
             m_source_table_view = source.m_source_table_view;
             m_owned_source_table_view = nullptr;
 
-            m_source_link_list = source.m_source_link_list ? source.m_source_link_list->clone() : LnkLstPtr{};
+            m_source_link_list =
+                source.m_source_link_list ? source.m_source_link_list->clone_linklist() : LnkLstPtr{};
         }
         if (m_source_table_view) {
             m_view = m_source_table_view;
@@ -1063,18 +1064,20 @@ R Query::aggregate(ColKey column_key, size_t* resultcount, ObjKey* return_ndx) c
 
 size_t Query::find_best_node(ParentNode* pn) const
 {
-    auto score_compare = [](const ParentNode* a, const ParentNode* b) { return a->cost() < b->cost(); };
+    auto score_compare = [](const ParentNode* a, const ParentNode* b) {
+        return a->cost() < b->cost();
+    };
     size_t best = std::distance(pn->m_children.begin(),
                                 std::min_element(pn->m_children.begin(), pn->m_children.end(), score_compare));
     return best;
 }
 
 /**************************************************************************************************************
-*                                                                                                             *
-* Main entry point of a query. Schedules calls to aggregate_local                                             *
-* Return value is the result of the query, or Array pointer for FindAll.                                      *
-*                                                                                                             *
-**************************************************************************************************************/
+ *                                                                                                             *
+ * Main entry point of a query. Schedules calls to aggregate_local                                             *
+ * Return value is the result of the query, or Array pointer for FindAll.                                      *
+ *                                                                                                             *
+ **************************************************************************************************************/
 
 void Query::aggregate_internal(ParentNode* pn, QueryStateBase* st, size_t start, size_t end,
                                ArrayPayload* source_column) const
@@ -1907,11 +1910,11 @@ void Query::add_node(std::unique_ptr<ParentNode> node)
 }
 
 /* ********************************************************************************************************************
-*
-*  Stuff related to next-generation query syntax
-*
-********************************************************************************************************************
-*/
+ *
+ *  Stuff related to next-generation query syntax
+ *
+ ********************************************************************************************************************
+ */
 
 Query& Query::and_query(const Query& q)
 {
@@ -2023,4 +2026,3 @@ QueryGroup& QueryGroup::operator=(const QueryGroup& other)
     }
     return *this;
 }
-

--- a/src/realm/query_expression.hpp
+++ b/src/realm/query_expression.hpp
@@ -683,12 +683,8 @@ private:
 
 class Expression {
 public:
-    Expression()
-    {
-    }
-    virtual ~Expression()
-    {
-    }
+    Expression() {}
+    virtual ~Expression() {}
 
     virtual double init()
     {
@@ -698,9 +694,7 @@ public:
     virtual size_t find_first(size_t start, size_t end) const = 0;
     virtual void set_base_table(ConstTableRef table) = 0;
     virtual void set_cluster(const Cluster*) = 0;
-    virtual void collect_dependencies(std::vector<TableKey>&) const
-    {
-    }
+    virtual void collect_dependencies(std::vector<TableKey>&) const {}
     virtual ConstTableRef get_base_table() const = 0;
     virtual std::string description(util::serializer::SerialisationState& state) const = 0;
 
@@ -715,9 +709,7 @@ std::unique_ptr<Expression> make_expression(Args&&... args)
 
 class Subexpr {
 public:
-    virtual ~Subexpr()
-    {
-    }
+    virtual ~Subexpr() {}
 
     virtual std::unique_ptr<Subexpr> clone() const = 0;
 
@@ -732,9 +724,7 @@ public:
 
     virtual std::string description(util::serializer::SerialisationState& state) const = 0;
 
-    virtual void set_cluster(const Cluster*)
-    {
-    }
+    virtual void set_cluster(const Cluster*) {}
 
     // Recursively fetch tables of columns in expression tree. Used when user first builds a stand-alone expression
     // and
@@ -744,9 +734,7 @@ public:
         return nullptr;
     }
 
-    virtual void collect_dependencies(std::vector<TableKey>&) const
-    {
-    }
+    virtual void collect_dependencies(std::vector<TableKey>&) const {}
 
     virtual bool has_constant_evaluation() const
     {
@@ -1074,9 +1062,7 @@ class Subexpr2 : public Subexpr,
                  public Overloads<T, UUID>,
                  public Overloads<T, null> {
 public:
-    virtual ~Subexpr2()
-    {
-    }
+    virtual ~Subexpr2() {}
 
     DataType get_type() const final
     {
@@ -2771,7 +2757,7 @@ template <typename T>
 class Sum;
 template <typename T>
 class Average;
-}
+} // namespace aggregate_operations
 
 class ColumnListBase {
 public:
@@ -2938,6 +2924,17 @@ private:
         : ColumnListBase(column_key, table, links, type)
         , m_is_nullable_storage(this->m_column_key.get_attrs().test(col_attr_Nullable))
     {
+    }
+};
+
+template <>
+class Columns<LnkLst> : public Columns<Lst<ObjKey>> {
+public:
+    using Columns<Lst<ObjKey>>::Columns;
+
+    std::unique_ptr<Subexpr> clone() const override
+    {
+        return make_subexpr<Columns<LnkLst>>(*this);
     }
 };
 
@@ -3904,7 +3901,7 @@ public:
         return "@avg";
     }
 };
-}
+} // namespace aggregate_operations
 
 template <class oper, class TLeft>
 class UnaryOperator : public Subexpr2<typename oper::type> {
@@ -4266,5 +4263,5 @@ private:
     mutable size_t m_index_get = 0;
     size_t m_index_end = 0;
 };
-}
+} // namespace realm
 #endif // REALM_QUERY_EXPRESSION_HPP

--- a/src/realm/set.hpp
+++ b/src/realm/set.hpp
@@ -48,7 +48,7 @@ protected:
 };
 
 template <class T>
-class Set : public CollectionBaseImpl<SetBase> {
+class Set final : public CollectionBaseImpl<SetBase> {
 public:
     using Base = CollectionBaseImpl<SetBase>;
     using value_type = T;
@@ -159,14 +159,6 @@ private:
         m_valid = m_tree->init_from_parent();
         update_content_version();
         return m_valid;
-    }
-
-    bool update_if_needed() const final
-    {
-        if (m_obj.update_if_needed()) {
-            return this->init_from_parent();
-        }
-        return false;
     }
 
     void ensure_created()
@@ -373,7 +365,7 @@ size_t Set<T>::find(T value) const
 template <class T>
 std::pair<size_t, bool> Set<T>::insert(T value)
 {
-    REALM_ASSERT_DEBUG(!update_if_needed());
+    update_if_needed();
 
     ensure_created();
     this->ensure_writeable();
@@ -393,7 +385,7 @@ std::pair<size_t, bool> Set<T>::insert(T value)
     }
 
     do_insert(it.index(), value);
-    m_obj.bump_content_version();
+    bump_content_version();
     return {it.index(), true};
 }
 
@@ -416,7 +408,7 @@ std::pair<size_t, bool> Set<T>::insert_any(Mixed value)
 template <class T>
 std::pair<size_t, bool> Set<T>::erase(T value)
 {
-    REALM_ASSERT_DEBUG(!update_if_needed());
+    update_if_needed();
     this->ensure_writeable();
 
     auto b = this->begin();
@@ -431,7 +423,7 @@ std::pair<size_t, bool> Set<T>::erase(T value)
         this->erase_repl(repl, it.index(), value);
     }
     do_erase(it.index());
-    m_obj.bump_content_version();
+    bump_content_version();
     return {it.index(), true};
 }
 
@@ -474,7 +466,7 @@ inline void Set<T>::clear()
             this->clear_repl(repl);
         }
         m_tree->clear();
-        m_obj.bump_content_version();
+        bump_content_version();
     }
 }
 

--- a/src/realm/sync/instruction_applier.cpp
+++ b/src/realm/sync/instruction_applier.cpp
@@ -309,14 +309,17 @@ void InstructionApplier::operator()(const Instruction::Update& instr)
             auto visitor = util::overload{
                 [&](const ObjLink& link) {
                     if (data_type == type_TypedLink) {
+                        REALM_ASSERT(dynamic_cast<Lst<ObjLink>*>(&list));
                         auto& link_list = static_cast<Lst<ObjLink>&>(list);
                         link_list.set(index, link);
                     }
                     else if (data_type == type_Mixed) {
+                        REALM_ASSERT(dynamic_cast<Lst<Mixed>*>(&list));
                         auto& mixed_list = static_cast<Lst<Mixed>&>(list);
                         mixed_list.set(index, link);
                     }
                     else if (data_type == type_LinkList || data_type == type_Link) {
+                        REALM_ASSERT(dynamic_cast<Lst<ObjKey>*>(&list));
                         auto& link_list = static_cast<Lst<ObjKey>&>(list);
                         // Validate the target.
                         auto target_table = table->get_link_target(col);
@@ -560,14 +563,17 @@ void InstructionApplier::operator()(const Instruction::ArrayInsert& instr)
             auto inserter = util::overload{
                 [&](const ObjLink& link) {
                     if (data_type == type_TypedLink) {
+                        REALM_ASSERT(dynamic_cast<Lst<ObjLink>*>(&list));
                         auto& link_list = static_cast<Lst<ObjLink>&>(list);
                         link_list.insert(index, link);
                     }
                     else if (data_type == type_Mixed) {
+                        REALM_ASSERT(dynamic_cast<Lst<Mixed>*>(&list));
                         auto& mixed_list = static_cast<Lst<Mixed>&>(list);
                         mixed_list.insert(index, link);
                     }
                     else if (data_type == type_LinkList || data_type == type_Link) {
+                        REALM_ASSERT(dynamic_cast<Lst<ObjKey>*>(&list));
                         auto& link_list = static_cast<Lst<ObjKey>&>(list);
                         // Validate the target.
                         auto target_table = table->get_link_target(col);
@@ -613,6 +619,7 @@ void InstructionApplier::operator()(const Instruction::ArrayInsert& instr)
                                                 target_table->get_name());
                         }
 
+                        REALM_ASSERT(dynamic_cast<LnkLst*>(&list));
                         auto& link_list = static_cast<LnkLst&>(list);
                         link_list.create_and_insert_linked_object(index);
                     }
@@ -722,14 +729,17 @@ void InstructionApplier::operator()(const Instruction::SetInsert& instr)
             auto inserter = util::overload{
                 [&](const ObjLink& link) {
                     if (data_type == type_TypedLink) {
+                        REALM_ASSERT(dynamic_cast<Set<ObjLink>*>(&set));
                         auto& link_set = static_cast<Set<ObjLink>&>(set);
                         link_set.insert(link);
                     }
                     else if (data_type == type_Mixed) {
+                        REALM_ASSERT(dynamic_cast<Set<Mixed>*>(&set));
                         auto& mixed_set = static_cast<Set<Mixed>&>(set);
                         mixed_set.insert(link);
                     }
                     else if (data_type == type_Link) {
+                        REALM_ASSERT(dynamic_cast<Set<ObjKey>*>(&set));
                         auto& link_set = static_cast<Set<ObjKey>&>(set);
                         // Validate the target.
                         auto target_table = table->get_link_target(col);
@@ -791,14 +801,17 @@ void InstructionApplier::operator()(const Instruction::SetErase& instr)
             auto inserter = util::overload{
                 [&](const ObjLink& link) {
                     if (data_type == type_TypedLink) {
+                        REALM_ASSERT(dynamic_cast<Set<ObjLink>*>(&set));
                         auto& link_set = static_cast<Set<ObjLink>&>(set);
                         link_set.erase(link);
                     }
                     else if (data_type == type_Mixed) {
+                        REALM_ASSERT(dynamic_cast<Set<Mixed>*>(&set));
                         auto& mixed_set = static_cast<Set<Mixed>&>(set);
                         mixed_set.erase(link);
                     }
                     else if (data_type == type_Link) {
+                        REALM_ASSERT(dynamic_cast<Set<ObjKey>*>(&set));
                         auto& link_set = static_cast<Set<ObjKey>&>(set);
                         // Validate the target.
                         auto target_table = table->get_link_target(col);
@@ -969,7 +982,7 @@ void InstructionApplier::resolve_field(Obj& obj, InternString field, Instruction
             if (col.get_type() == col_type_Link || col.get_type() == col_type_LinkList) {
                 auto table = obj.get_table();
                 if (!table->get_link_target(col)->is_embedded()) {
-                    list = std::make_unique<Lst<ObjKey>>(obj, col);
+                    list = obj.get_list_ptr<ObjKey>(col);
                 }
                 else {
                     list = obj.get_listbase_ptr(col);
@@ -1043,6 +1056,7 @@ void InstructionApplier::resolve_list_element(LstBase& list, size_t index, Instr
                                 list.get_table()->get_name(), index);
         }
 
+        REALM_ASSERT(dynamic_cast<LnkLst*>(&list));
         auto& link_list = static_cast<LnkLst&>(list);
         if (index >= link_list.size()) {
             bad_transaction_log("%1: Out-of-bounds index through list at '%3.%2[%4]'", instr_name, field_name,

--- a/src/realm/table_view.hpp
+++ b/src/realm/table_view.hpp
@@ -159,7 +159,6 @@ namespace realm {
 /// for more on this.
 class ConstTableView : public ObjList {
 public:
-
     /// Construct null view (no memory allocated).
     ConstTableView()
         : m_key_values(Allocator::get_default())
@@ -299,7 +298,10 @@ public:
 
     // A TableView is frozen if it is a) obtained from a query against a frozen table
     // and b) is synchronized (is_in_sync())
-    bool is_frozen() { return m_table->is_frozen() && is_in_sync(); }
+    bool is_frozen()
+    {
+        return m_table->is_frozen() && is_in_sync();
+    }
     // Tells if this TableView depends on a LinkList or row that has been deleted.
     bool depends_on_deleted_object() const;
 
@@ -483,8 +485,6 @@ private:
 };
 
 
-
-
 // ================================================================================================
 // ConstTableView Implementation:
 
@@ -540,7 +540,7 @@ inline ConstTableView::ConstTableView(const ConstTableView& tv)
     , m_source_column_key(tv.m_source_column_key)
     , m_linked_obj_key(tv.m_linked_obj_key)
     , m_linked_table(tv.m_linked_table)
-    , m_linklist_source(tv.m_linklist_source ? tv.m_linklist_source->clone() : LnkLstPtr{})
+    , m_linklist_source(tv.m_linklist_source ? tv.m_linklist_source->clone_linklist() : LnkLstPtr{})
     , m_descriptor_ordering(tv.m_descriptor_ordering)
     , m_query(tv.m_query)
     , m_start(tv.m_start)
@@ -607,7 +607,7 @@ inline ConstTableView& ConstTableView::operator=(const ConstTableView& tv)
     m_source_column_key = tv.m_source_column_key;
     m_linked_obj_key = tv.m_linked_obj_key;
     m_linked_table = tv.m_linked_table;
-    m_linklist_source = tv.m_linklist_source ? tv.m_linklist_source->clone() : LnkLstPtr{};
+    m_linklist_source = tv.m_linklist_source ? tv.m_linklist_source->clone_linklist() : LnkLstPtr{};
     m_descriptor_ordering = tv.m_descriptor_ordering;
 
     return *this;

--- a/test/object-store/transaction_log_parsing.cpp
+++ b/test/object-store/transaction_log_parsing.cpp
@@ -57,7 +57,7 @@ public:
         _impl::CollectionChangeBuilder c;
         _impl::TransactionChangeInfo info{};
         info.tables[m_table_key.value];
-        info.lists.push_back({m_table_key, m_list.CollectionBase::get_key().value, m_list.get_col_key().value, &c});
+        info.lists.push_back({m_table_key, m_list.get_key().value, m_list.get_col_key().value, &c});
         _impl::transaction::advance(*m_group, info);
 
         if (info.lists.empty()) {

--- a/test/test_links.cpp
+++ b/test/test_links.cpp
@@ -781,7 +781,7 @@ TEST(Links_LinkList_Inserts)
     auto obj = origin->create_object();
     auto links = obj.get_linklist_ptr(col_link);
     auto links2 = obj.get_linklist_ptr(col_link);
-    auto k0 = links->CollectionBase::get_key();
+    auto k0 = links->get_key();
 
     CHECK_EQUAL(0, links->size());
     CHECK_EQUAL(0, links2->size());
@@ -832,7 +832,7 @@ TEST(Links_LinkList_Backlinks)
 
     Obj origin_obj = origin->create_object();
     auto links = origin_obj.get_linklist_ptr(col_link);
-    auto k0 = links->CollectionBase::get_key();
+    auto k0 = links->get_key();
 
     // add several links to a single linklist
     links->add(key2);
@@ -866,8 +866,8 @@ TEST(Links_LinkList_Backlinks)
     auto links2 = origin->create_object().get_linklist_ptr(col_link);
     links1->add(obj1.get_key());
     links2->add(obj0.get_key());
-    auto k1 = links1->CollectionBase::get_key();
-    auto k2 = links2->CollectionBase::get_key();
+    auto k1 = links1->get_key();
+    auto k2 = links2->get_key();
 
     // Verify backlinks
     CHECK_EQUAL(1, obj0.get_backlink_count(*origin, col_link));
@@ -924,8 +924,12 @@ TEST(Links_LinkList_FindByOrigin)
     CHECK_EQUAL(not_found, links->find_first(key2));
     CHECK_EQUAL(not_found, links2->find_first(key2));
 
-    links->find_all(key2, [&](size_t) { CHECK(false); });
-    links2->find_all(key2, [&](size_t) { CHECK(false); });
+    links->find_all(key2, [&](size_t) {
+        CHECK(false);
+    });
+    links2->find_all(key2, [&](size_t) {
+        CHECK(false);
+    });
 
     links->add(key2);
     links->add(key1);
@@ -939,10 +943,16 @@ TEST(Links_LinkList_FindByOrigin)
     CHECK_EQUAL(2, links2->find_first(key0));
 
     int calls = 0;
-    links->find_all(key2, [&](size_t i) { CHECK_EQUAL(i, 0); ++calls; });
+    links->find_all(key2, [&](size_t i) {
+        CHECK_EQUAL(i, 0);
+        ++calls;
+    });
     CHECK_EQUAL(calls, 1);
     calls = 0;
-    links2->find_all(key0, [&](size_t i) { CHECK_EQUAL(i, 2); ++calls; });
+    links2->find_all(key0, [&](size_t i) {
+        CHECK_EQUAL(i, 2);
+        ++calls;
+    });
     CHECK_EQUAL(calls, 1);
 
     links->remove(0);
@@ -954,7 +964,10 @@ TEST(Links_LinkList_FindByOrigin)
     links->add(key0);
 
     calls = 0;
-    links->find_all(key0, [&](size_t i) { CHECK(i >= 1); ++calls; });
+    links->find_all(key0, [&](size_t i) {
+        CHECK(i >= 1);
+        ++calls;
+    });
     CHECK_EQUAL(calls, 3);
 }
 

--- a/test/test_table.cpp
+++ b/test/test_table.cpp
@@ -2978,39 +2978,6 @@ TEST_TYPES(Table_list_nullable, int64_t, float, double, Decimal128)
     table.remove_object(ObjKey(5));
 }
 
-TEST(Table_StableIteration)
-{
-    Table table;
-    auto list_col = table.add_column_list(type_Int, "int_list");
-    std::vector<int64_t> values = {1, 7, 3, 5, 5, 2, 4};
-    Obj obj = table.create_object(ObjKey(5)).set_list_values(list_col, values);
-
-    auto list = obj.get_list<int64_t>(list_col);
-    auto x = list.begin();
-    CHECK_EQUAL(*x, 1);
-    ++x; // == 7
-    ++x; // == 3
-    CHECK_EQUAL(*x, 3);
-    auto end = list.end();
-    for (auto it = list.begin(); it != end; it++) {
-        if (*it > 3) {
-            list.remove(it);
-            // When an element is removed, the iterator should be invalid
-            CHECK_THROW_ANY(*it);
-        }
-        // This iterator should keep pointing to the same element
-        CHECK_EQUAL(*x, 3);
-    }
-    // Advancing the iterator should skip the two deleted elements
-    ++x; // == 2
-    CHECK_EQUAL(*x, 2);
-    ++x; // Past end of list
-    CHECK_THROW_ANY(*x);
-    CHECK_EQUAL(list.size(), 3);
-    CHECK_EQUAL(list[0], 1);
-    CHECK_EQUAL(list[1], 3);
-    CHECK_EQUAL(list[2], 2);
-}
 
 TEST_TYPES(Table_ListOps, Prop<Int>, Prop<Float>, Prop<Double>, Prop<Decimal128>, Prop<ObjectId>, Prop<UUID>,
            Prop<Timestamp>, Prop<String>, Prop<Binary>, Prop<Bool>, Nullable<Int>, Nullable<Float>, Nullable<Double>,

--- a/test/test_unresolved_links.cpp
+++ b/test/test_unresolved_links.cpp
@@ -452,6 +452,8 @@ TEST(Unresolved_CondensedIndices)
     list2 = list1;
     CHECK_EQUAL(list2.size(), 1);
 
+    auto key_list = obj789.get_list<ObjKey>("t2s");
+    CHECK_EQUAL(key_list.size(), 2);
 
     // Check that find methods return condensed indices.
 
@@ -469,6 +471,23 @@ TEST(Unresolved_CondensedIndices)
     });
     CHECK_EQUAL(found_indices.size(), 1);
     CHECK_EQUAL(found_indices[0], 0);
+
+    // Check that the list of unresolved indices remains consistent over
+    // insertion to the middle. list1 currently considers index 0 to be
+    // unresolved, because obj123 was invalidated above. Insertion to index 0
+    // should bump the unresolved index to 1.
+    CHECK_EQUAL(key_list.get(0), obj123.get_key());
+    CHECK_EQUAL(key_list.get(1), obj456.get_key());
+    key_list.insert(2, obj123.get_key());
+    key_list.insert(3, obj456.get_key());
+    // Uncondensed list is now: (obj123, obj456, obj123, obj456)
+    // Condensed list is now: (obj456, obj456)
+    list1.insert(0, obj456.get_key());
+    // Uncondensed list is now: (obj123, obj456, obj456, obj123, obj456)
+    // Condensed list should now be: (obj456, obj456, obj456)
+    CHECK_EQUAL(list1.get(0), obj456.get_key());
+    CHECK_EQUAL(list1.get(1), obj456.get_key());
+    CHECK_EQUAL(list1.get(2), obj456.get_key());
 }
 
 #endif

--- a/test/test_unresolved_links.cpp
+++ b/test/test_unresolved_links.cpp
@@ -451,6 +451,24 @@ TEST(Unresolved_CondensedIndices)
     CHECK_EQUAL(list1.get_object(0).get_key(), obj456.get_key());
     list2 = list1;
     CHECK_EQUAL(list2.size(), 1);
+
+
+    // Check that find methods return condensed indices.
+
+    CHECK_EQUAL(list1.find_first(obj123.get_key()), not_found);
+    CHECK_EQUAL(list1.find_first(obj456.get_key()), 0);
+
+    std::vector<size_t> found_indices;
+    list1.find_all(obj123.get_key(), [&](size_t index) {
+        found_indices.push_back(index);
+    });
+    CHECK_EQUAL(found_indices.size(), 0);
+    found_indices.clear();
+    list1.find_all(obj456.get_key(), [&](size_t index) {
+        found_indices.push_back(index);
+    });
+    CHECK_EQUAL(found_indices.size(), 1);
+    CHECK_EQUAL(found_indices[0], 0);
 }
 
 #endif

--- a/test/test_unresolved_links.cpp
+++ b/test/test_unresolved_links.cpp
@@ -302,7 +302,7 @@ TEST(Unresolved_QueryOverLinks)
     CHECK_EQUAL(q.count(), 1);
 
     auto new_tesla = cars->get_objkey_from_primary_key("Tesla 10");
-    bilmekka.get_linklist(col_has).insert(0, new_tesla);
+    bilmekka.get_list<ObjKey>(col_has).insert(0, new_tesla);
     CHECK_EQUAL(q.count(), 1);
 
     q = persons->link(col_owns).column<Decimal128>(col_price) < Decimal128("1000000");


### PR DESCRIPTION
There were some issues with the current interface hierarchy surrounding collections:

- `LnkLst` derived publicly from `Lst<ObjKey>`, but uses a different "index space", because `LnkLst` hides tombstone links (unresolved links), while `Lst<ObjKey>` doesn't. This meant that it was easy to accidentally call a method on `LnkLst` and get or use indices that don't make sense or are out of bounds. `LnkLst::find_first` and `LnkLst::find_all` had this problem.
- `Lst<T>` could not be marked `final` due to the inheritance, which prevents devirtualization (inlining, direct method call, etc.).
- Several methods were statically overridden, rather than dynamically, resulting in dispatch based on the type of pointer you had, rather than the actual type of the instance. This could lead to similar bugs.
- Members on `CollectionBase` and friends made it difficult / ugly to compose a collection implementation from other collections (say, implementing `LnkLst` in terms of `Lst<ObjKey>` without deriving).
- Handling of tombstones / unresolved links was isolated to `LnkLst`, and could not be reused in other collections.
- `Lst<T>` had a weird and poorly justified precondition that all calls must be preceded by a call to `size()`, in order to get the accessor properly refreshed. Failure to do so was only detected in debug mode, and could result in corruption. The motivation behind it was to avoid a bounds check in some methods, but at high risk.

This refactor makes the following changes:

- All member variables move to the bottom-most class in the class hierarchy.
- Methods on base classes are marked as `virtual`.
- ... but concrete collection types are marked as `final`, so stuff can be inlined.
- Several interfaces have been cleaned up, such that more things are private and fewer things can leak through layers.
- All methods on `Lst<T>` and other collections call `update_if_needed()`. Will measure performance impact; none expected.
- The `bump_content_version()` / `update_if_needed()` flow is updated such that a collection accessor never has a precondition of calling some methods before others just to refresh the accessor.
    - Some appropriate inlining is added to ensure that the overhead is minimal in the common case.
- It is impossible to get a `Lst<ObjKey>&` that is actually a `LnkLst` (avoiding the mix of dynamic and static overrides). In other words, it is impossible to access the contents of a `LnkLst` without accounting for tombstones.
     - Use `Obj::get_linklist()` to get a `LnkLst` (condensed indices).
     - Use `Obj::get_list<ObjKey>()` get a `Lst<ObjKey>` (uncondensed indices).
     - `Obj::get_listbase_ptr()` returns a `LnkLst` instance.
- Stable iteration over `Lst<T>` is removed (the `m_deleted` member of `CollectionBase`). This is unused by SDKs and added complexity.
- `Collection<T, Interface>` is gone, its responsibilities divided between `CollectionImplBase<Interface>` and concrete collection implementations (`Lst<T>`, `Set<T>`, `Dictionary`).
- `CollectionBase` no longer derives from `ArrayParent`.
- `LnkLst` no longer derives from `Lst<ObjKey>`, removing the risk of mixing condensed/uncondensed indices. The choice between access by condensed or uncondensed indices is made at instantiation time, rather than at method dispatch time.
- `real2virtual()` is added as a companion to `virtual2real()`, which is needed for find() functions. Opposed to `virtual2real()`, it is implemented using binary search.
- Collection iterators are now `random_access_iterator`s, rather than `bidirectional_iterator`s. This is important for utility functions such as `std::lower_bound`.

The new class hierarchy looks like this for `LnkLst` (from the bottom up):

- `LnkLst` (final, internally has a `Lst<ObjKey>` as a member)
    - `ObjCollectionBase<LstBase>` (tombstone handling, `virtual2real` etc.)
        - `LstBase` (base class for all lists)
           - `CollectionBase` (base class for all collections)
        - `ObjList` (generic interface for lists of objects)

The new class hierarchy looks like this for `Lst<T>` (from the bottom up):

- `Lst<T>` (final, internally has `BPlusTree<T>`)
    - `CollectionBaseImpl<LstBase>` (convenience implementation of things shared by all containers (`m_obj`, `m_col_key`, etc.)).
        - `ArrayParent` (protected base class, used to attach the collection accessor to the object)
        - `LstBase` (base class for all lists)
            - `CollectionBase` (base class for all collections)

The new class hierarchy for `Dictionary` (from the bottom up):

- `Dictionary`
    - `CollectionBaseImpl<CollectionBase>`
        - `ArrayParent`
        - `CollectionBase`

The new class hierarchy for `Set<T>` (from the bottom up):

- `Set<T>`
    - `CollectionBaseImpl<SetBase>`
        - `ArrayParent`
        - `SetBase`
            - `CollectionBase`

Goals achieved:

- Protection against nonsensical list indices due to tombstone handling.
- Centralized implementation of tombstone handling.
- Classes are `final`, enabling devirtualization.
- Implementation details are hidden where possible.
- The `ArrayParent` interface is out of sight.