### PR TITLE
fix SharedMemory on win32

### DIFF
--- a/src/realm/object-store/impl/windows/external_commit_helper.hpp
+++ b/src/realm/object-store/impl/windows/external_commit_helper.hpp
@@ -29,7 +29,7 @@ namespace win32 {
 template <class T, void (*Initializer)(T&)>
 class SharedMemory {
 public:
-    SharedMemory(LPCWSTR name) 
+    SharedMemory(LPCWSTR name)
     {
         // assume another process have already initialzied the shared memory
         bool shouldInit = false;
@@ -67,12 +67,12 @@ public:
         }
     }
 
-    T& get() const noexcept 
-    { 
-        return *m_memory; 
+    T& get() const noexcept
+    {
+        return *m_memory;
     }
 
-    ~SharedMemory() 
+    ~SharedMemory()
     {
         if (m_memory) {
             UnmapViewOfFile(m_memory);

--- a/src/realm/object-store/impl/windows/external_commit_helper.hpp
+++ b/src/realm/object-store/impl/windows/external_commit_helper.hpp
@@ -29,8 +29,9 @@ namespace win32 {
 template <class T, void (*Initializer)(T&)>
 class SharedMemory {
 public:
-    SharedMemory(LPCWSTR name) {
-        //assume another process have already initialzied the shared memory
+    SharedMemory(LPCWSTR name) 
+    {
+        // assume another process have already initialzied the shared memory
         bool shouldInit = false;
 
         m_mapped_file = OpenFileMappingW(FILE_MAP_ALL_ACCESS, FALSE, name);
@@ -40,7 +41,7 @@ public:
             m_mapped_file = CreateFileMappingW(INVALID_HANDLE_VALUE, nullptr, PAGE_READWRITE, 0, sizeof(T), name);
             error = GetLastError();
 
-            //init since this is the first process creating the shared memory
+            // init since this is the first process creating the shared memory
             shouldInit = true;
         }
 
@@ -66,9 +67,13 @@ public:
         }
     }
 
-    T& get() const noexcept { return *m_memory; }
+    T& get() const noexcept 
+    { 
+        return *m_memory; 
+    }
 
-    ~SharedMemory() {
+    ~SharedMemory() 
+    {
         if (m_memory) {
             UnmapViewOfFile(m_memory);
             m_memory = nullptr;
@@ -84,7 +89,7 @@ private:
     T* m_memory = nullptr;
     HANDLE m_mapped_file = nullptr;
 };
-}
+} // namespace win32
 
 class ExternalCommitHelper {
 public:

--- a/src/realm/object-store/impl/windows/external_commit_helper.hpp
+++ b/src/realm/object-store/impl/windows/external_commit_helper.hpp
@@ -29,53 +29,62 @@ namespace win32 {
 template <class T, void (*Initializer)(T&)>
 class SharedMemory {
 public:
-    SharedMemory(LPCWSTR name)
-    {
-#if REALM_WINDOWS
-        HANDLE mapping = CreateFileMappingW(INVALID_HANDLE_VALUE, nullptr, PAGE_READWRITE, 0, sizeof(T), name);
-        auto error = GetLastError();
-        if (mapping != NULL)
-            m_memory = reinterpret_cast<T*>(MapViewOfFile(mapping, FILE_MAP_ALL_ACCESS, 0, 0, sizeof(T)));
-#elif REALM_UWP
-        HANDLE mapping = CreateFileMappingFromApp(INVALID_HANDLE_VALUE, nullptr, PAGE_READWRITE, sizeof(T), name);
-        auto error = GetLastError();
-        if (mapping != NULL)
-            m_memory = reinterpret_cast<T*>(MapViewOfFileFromApp(mapping, FILE_MAP_ALL_ACCESS, 0, sizeof(T)));
-#endif
+    SharedMemory(LPCWSTR name) {
+        //assume another process have already initialzied the shared memory
+        bool shouldInit = false;
 
-        if (mapping) {
-            // we can close the handle we own because the view has now referenced it
-            CloseHandle(mapping);
+        m_mapped_file = OpenFileMappingW(FILE_MAP_ALL_ACCESS, FALSE, name);
+        auto error = GetLastError();
+
+        if (m_mapped_file == NULL) {
+            m_mapped_file = CreateFileMappingW(INVALID_HANDLE_VALUE, nullptr, PAGE_READWRITE, 0, sizeof(T), name);
+            error = GetLastError();
+
+            //init since this is the first process creating the shared memory
+            shouldInit = true;
         }
 
-        try {
-            if (error == 0) {
+        if (m_mapped_file == NULL) {
+            throw std::system_error(error, std::system_category());
+        }
+
+        LPVOID view = MapViewOfFile(m_mapped_file, FILE_MAP_ALL_ACCESS, 0, 0, sizeof(T));
+        error = GetLastError();
+        if (view == NULL) {
+            throw std::system_error(error, std::system_category());
+        }
+        m_memory = reinterpret_cast<T*>(view);
+
+        if (shouldInit) {
+            try {
                 Initializer(get());
             }
-            else if (error != ERROR_ALREADY_EXISTS) {
-                throw std::system_error(error, std::system_category());
+            catch (...) {
+                UnmapViewOfFile(m_memory);
+                throw;
             }
         }
-        catch (...) {
+    }
+
+    T& get() const noexcept { return *m_memory; }
+
+    ~SharedMemory() {
+        if (m_memory) {
             UnmapViewOfFile(m_memory);
-            throw;
+            m_memory = nullptr;
         }
-    }
 
-    T& get() const noexcept
-    {
-        return *m_memory;
-    }
-
-    ~SharedMemory()
-    {
-        UnmapViewOfFile(m_memory);
+        if (m_mapped_file) {
+            CloseHandle(m_mapped_file);
+            m_mapped_file = nullptr;
+        }
     }
 
 private:
     T* m_memory = nullptr;
+    HANDLE m_mapped_file = nullptr;
 };
-} // namespace win32
+}
 
 class ExternalCommitHelper {
 public:


### PR DESCRIPTION
fix SharedMemory on Win32 targets
https://github.com/realm/realm-object-store/pull/1129/files into core-6

don't close the mapped file handle cause the mapped file can not be opened from another process. This fixes the sharing of memory needed to synchronize realm file access between windows processes
Contained in branches:
core-6-fix-sharedmemory-win32
Contained in no tag

Derives from no tag