### PR TITLE
Fix several data races in object store sync code

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 * Fix queries for null on non-nullable indexed integer columns returning results for zero entries. (Since v6)
 * Fix queries for null on a indexed ObjectId column returning results for the zero ObjectId. (Since v10)
 * Fix list of primitives for Optional<Float> and Optional<Double> always returning false for `Lst::is_null(ndx)` even on null values, (since v6.0.0).
+* Fix several data races in App and SyncSession initialization. These could possibly have caused strange errors the first time a synchronized Realm was opened (sinrce v10.0.0).
 
 ### Breaking changes
 * None.

--- a/src/realm/object-store/sync/app.hpp
+++ b/src/realm/object-store/sync/app.hpp
@@ -19,14 +19,16 @@
 #ifndef REALM_APP_HPP
 #define REALM_APP_HPP
 
-#include <realm/object-store/sync/auth_request_client.hpp>
-#include <realm/object-store/sync/app_service_client.hpp>
 #include <realm/object-store/sync/app_credentials.hpp>
-#include <realm/object-store/sync/push_client.hpp>
+#include <realm/object-store/sync/app_service_client.hpp>
+#include <realm/object-store/sync/auth_request_client.hpp>
 #include <realm/object-store/sync/generic_network_transport.hpp>
+#include <realm/object-store/sync/push_client.hpp>
 
 #include <realm/object_id.hpp>
 #include <realm/util/optional.hpp>
+
+#include <mutex>
 
 namespace realm {
 
@@ -62,10 +64,8 @@ public:
 
     // `enable_shared_from_this` is unsafe with public constructors; use `get_shared_app` instead
     App(const Config& config);
-    App(const App&) = default;
     App(App&&) noexcept = default;
-    App& operator=(App const&) = default;
-    App& operator=(App&&) = default;
+    App& operator=(App&&) noexcept = default;
 
     const Config& config() const
     {
@@ -337,6 +337,7 @@ private:
     friend class OnlyForTesting;
 
     Config m_config;
+    mutable std::unique_ptr<std::mutex> m_route_mutex = std::make_unique<std::mutex>();
     std::string m_base_url;
     std::string m_base_route;
     std::string m_app_route;

--- a/src/realm/object-store/sync/sync_manager.cpp
+++ b/src/realm/object-store/sync/sync_manager.cpp
@@ -44,10 +44,10 @@ SyncClientTimeouts::SyncClientTimeouts()
 void SyncManager::configure(std::shared_ptr<app::App> app, const std::string& sync_route,
                             const SyncClientConfig& config)
 {
-    m_app = app;
-    m_sync_route = sync_route;
     {
         std::lock_guard<std::mutex> lock(m_mutex);
+        m_app = app;
+        m_sync_route = sync_route;
         m_config = std::move(config);
         if (m_sync_client)
             return;
@@ -377,6 +377,7 @@ std::shared_ptr<SyncUser> SyncManager::get_current_user() const
 
     if (m_current_user)
         return m_current_user;
+    std::lock_guard<std::mutex> fs_lock(m_file_system_mutex);
     if (!m_metadata_manager)
         return nullptr;
 
@@ -413,6 +414,7 @@ void SyncManager::log_out_user(const std::string& user_id)
         }
     }
 
+    std::lock_guard<std::mutex> fs_lock(m_file_system_mutex);
     if (m_metadata_manager)
         m_metadata_manager->set_current_user_identity("");
     m_current_user = nullptr;
@@ -423,6 +425,7 @@ void SyncManager::set_current_user(const std::string& user_id)
     std::lock_guard<std::mutex> lock(m_user_mutex);
 
     m_current_user = get_user_for_identity(user_id);
+    std::lock_guard<std::mutex> fs_lock(m_file_system_mutex);
     if (m_metadata_manager)
         m_metadata_manager->set_current_user_identity(user_id);
 }
@@ -435,6 +438,7 @@ void SyncManager::remove_user(const std::string& user_id)
         return;
     user->set_state(SyncUser::State::Removed);
 
+    std::lock_guard<std::mutex> fs_lock(m_file_system_mutex);
     if (!m_metadata_manager)
         return;
 
@@ -642,6 +646,7 @@ std::string SyncManager::client_uuid() const
 
 util::Optional<SyncAppMetadata> SyncManager::app_metadata() const
 {
+    std::lock_guard<std::mutex> lock(m_file_system_mutex);
     if (!m_metadata_manager) {
         return util::none;
     }

--- a/src/realm/object-store/sync/sync_manager.hpp
+++ b/src/realm/object-store/sync/sync_manager.hpp
@@ -201,16 +201,19 @@ public:
 
     void set_sync_route(std::string sync_route)
     {
+        std::lock_guard<std::mutex> lock(m_mutex);
         m_sync_route = std::move(sync_route);
     }
 
     const std::string sync_route() const
     {
+        std::lock_guard<std::mutex> lock(m_mutex);
         return m_sync_route;
     }
 
     std::weak_ptr<app::App> app() const
     {
+        std::lock_guard<std::mutex> lock(m_mutex);
         return m_app;
     }
 

--- a/src/realm/object-store/sync/sync_session.cpp
+++ b/src/realm/object-store/sync/sync_session.cpp
@@ -621,6 +621,7 @@ void SyncSession::create_sync_session()
     // Configure the sync transaction callback.
     auto wrapped_callback = [this, weak_self](VersionID old_version, VersionID new_version) {
         if (auto self = weak_self.lock()) {
+            std::lock_guard l(m_state_mutex);
             if (m_sync_transact_callback) {
                 m_sync_transact_callback(old_version, new_version);
             }
@@ -673,6 +674,7 @@ void SyncSession::create_sync_session()
 
 void SyncSession::set_sync_transact_callback(std::function<sync::Session::SyncTransactCallback> callback)
 {
+    std::lock_guard l(m_state_mutex);
     m_sync_transact_callback = std::move(callback);
 }
 


### PR DESCRIPTION
We now can run the Cocoa sync tests with thread sanitizer enabled, which unsurprisingly revealed a few bugs.

If a SyncSession is created before the corresponding RealmCoordinator there was a data race on the transaction callback.

App's route members are set on a background thread after fetching them from the server and so need synchronization.