### PR TITLE
Build Android tests on every PR

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -488,7 +488,7 @@ def doAndroidBuildInDocker(String abi, String buildType, boolean runTestsInEmula
                     docker.image('tracer0tong/android-emulator').withRun("-e ARCH=${abi}") { emulator ->
                         buildEnv.inside("--link ${emulator.id}:emulator") {
                             runAndCollectWarnings(
-                                script: "tools/cross_compile.sh -o android -a ${abi} -t ${buildType} -v ${gitDescribeVersion}", 
+                                script: "tools/cross_compile.sh -o android -a ${abi} -t ${buildType} -v ${gitDescribeVersion} -f -DREALM_ENABLE_SYNC=OFF", 
                                 name: "android-armeabi-${abi}-${buildType}",
                                 filters: warningFilters,
                             )

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -13,8 +13,8 @@ repo = tokens[tokens.size()-2]
 branch = tokens[tokens.size()-1]
 
 warningFilters = [
-    excludeFile('external/**/*'), // submodules and external libraries
-    excludeFile('libuv-src/**/*'), // libuv, where it was downloaded and built inside cmake
+    excludeFile('/external/*'), // submodules and external libraries
+    excludeFile('/libuv-src/*'), // libuv, where it was downloaded and built inside cmake
 ]
 
 jobWrapper {

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -126,6 +126,7 @@ jobWrapper {
             checkMacOsRelease_Sync  : doBuildMacOs(buildOptions + [buildType : "Release", enableSync : "ON"]),
             checkWindows_x86_Release: doBuildWindows('Release', false, 'Win32', true),
             checkWindows_x64_Debug  : doBuildWindows('Debug', false, 'x64', true),
+            checkAndroidX86Debug    : doAndroidBuildInDocker('x86', 'Debug', true),
             buildUWP_x86_Release    : doBuildWindows('Release', true, 'Win32', false),
             buildUWP_ARM_Debug      : doBuildWindows('Debug', true, 'ARM', false),
             buildiosDebug           : doBuildAppleDevice('iphoneos', 'MinSizeDebug'),
@@ -141,8 +142,7 @@ jobWrapper {
                 checkRaspberryPiQemuRelease   : doLinuxCrossCompile('armhf', 'Release', armhfQemuTestOptions),
                 checkRaspberryPiNativeRelease : doLinuxCrossCompile('armhf', 'Release', armhfNativeTestOptions),
                 checkMacOsDebug               : doBuildMacOs('Debug', true),
-                buildUWP_x64_Debug            : doBuildWindows('Debug', true, 'x64', false),
-                androidArmeabiRelease         : doAndroidBuildInDocker('armeabi-v7a', 'Release', true),
+                checkArmeabiRelease           : doAndroidBuildInDocker('armeabi-v7a', 'Release', true),
                 coverage                      : doBuildCoverage(),
                 // valgrind                : doCheckValgrind()
             ]
@@ -462,7 +462,7 @@ def doAndroidBuildInDocker(String abi, String buildType, boolean runTestsInEmula
                         }
                     }
                 } else {
-                    docker.image('tracer0tong/android-emulator').withRun('-e ARCH=armeabi-v7a') { emulator ->
+                    docker.image('tracer0tong/android-emulator').withRun("-e ARCH=${abi}") { emulator ->
                         buildEnv.inside("--link ${emulator.id}:emulator") {
                             runAndCollectWarnings(script: "tools/cross_compile.sh -o android -a ${abi} -t ${buildType} -v ${gitDescribeVersion} -f -DREALM_ENABLE_SYNC=0", name: "android-armeabi-${abi}-${buildType}")
                             dir(buildDir) {

--- a/src/external/IntelRDFPMathLib20U2/CMakeLists.txt
+++ b/src/external/IntelRDFPMathLib20U2/CMakeLists.txt
@@ -13,11 +13,4 @@ LIBRARY/src/bid_from_int.c
 LIBRARY/src/bid_round.c
 )
 
-# silence all warnings
-if(MSVC)
-    add_compile_options(/w)
-else()
-    add_compile_options(-w)
-endif()
-
 add_library(Bid OBJECT ${BID_SOURCES})

--- a/test/object-store/CMakeLists.txt
+++ b/test/object-store/CMakeLists.txt
@@ -101,11 +101,29 @@ endif()
 add_custom_command(TARGET ObjectStoreTests POST_BUILD
                    COMMAND ${CMAKE_COMMAND} -E copy_if_different ${CMAKE_CURRENT_SOURCE_DIR}/sync-1.x.realm $<TARGET_FILE_DIR:ObjectStoreTests>)
 
-if(NOT APPLE)
-    find_package(LibUV REQUIRED)
+# on Apple platforms we use the built-in CFRunLoop
+# everywhere else it's libuv, except UWP where it doesn't build
+if(NOT APPLE AND NOT WINDOWS_STORE)
+    find_package(LibUV)
+    if(LibUV_FOUND)
+        set(libuv_target LibUV::LibUV)
+    else()
+        # download and include libuv
+        include(FetchContent)
+        FetchContent_Declare(
+            libuv
+            GIT_REPOSITORY https://github.com/libuv/libuv.git
+            GIT_TAG        v1.35.0
+        )
+        FetchContent_Populate(libuv)
+        add_subdirectory(${libuv_SOURCE_DIR} ${libuv_BINARY_DIR} EXCLUDE_FROM_ALL)
+        set(libuv_target uv_a)
+    endif()
+    target_link_libraries(ObjectStoreTests ${libuv_target})
     # FIXME: ObjectStore itself shouldn't care about this, but we need to refactor scheduler.cpp to make it happen
-    target_link_libraries(ObjectStore PUBLIC LibUV::LibUV)
     target_compile_definitions(ObjectStore PUBLIC REALM_HAVE_UV=1)
+    get_property(libuv_include_dir TARGET ${libuv_target} PROPERTY INCLUDE_DIRECTORIES)
+    target_include_directories(ObjectStore PRIVATE ${libuv_include_dir})
 endif()
 
 add_subdirectory(notifications-fuzzer)

--- a/test/object-store/CMakeLists.txt
+++ b/test/object-store/CMakeLists.txt
@@ -112,7 +112,7 @@ if(NOT APPLE AND NOT WINDOWS_STORE)
     if(LibUV_FOUND)
         set(libuv_target LibUV::LibUV)
     elseif(REALM_FETCH_MISSING_DEPENDENCIES)
-        # download and include libuv
+        message(STATUS "LibUV not found, building from source with FetchContent")
         include(FetchContent)
         FetchContent_Declare(
             libuv

--- a/test/object-store/CMakeLists.txt
+++ b/test/object-store/CMakeLists.txt
@@ -104,10 +104,14 @@ add_custom_command(TARGET ObjectStoreTests POST_BUILD
 # on Apple platforms we use the built-in CFRunLoop
 # everywhere else it's libuv, except UWP where it doesn't build
 if(NOT APPLE AND NOT WINDOWS_STORE)
-    find_package(LibUV)
+    if(REALM_FETCH_MISSING_DEPENDENCIES)
+        find_package(LibUV)
+    else()
+        find_package(LibUV REQUIRED)
+    endif()
     if(LibUV_FOUND)
         set(libuv_target LibUV::LibUV)
-    else()
+    elseif(REALM_FETCH_MISSING_DEPENDENCIES)
         # download and include libuv
         include(FetchContent)
         FetchContent_Declare(


### PR DESCRIPTION
We hadn't built the Android tests for a while on the monorepo branch so they ended up broken. For one thing, Object Store tests need libuv, so we had to fetch that for Android.
I refactored the warnings in the Jenkinsfile so that the issue analyzer always ignores external libraries (libuv produced a number of warnings). I also refactored the `doAndroidBuildInDocker()` function so that it can build just the libraries, build the libraries and tests, and build the libraries and tests and also run them.
Now for each PR we'll build the Android libraries and the tests, and on release builds we'll also run the tests. Previously we only built the libraries on each PR and that didn't alert us to the tests breaking on Android.