### PR TITLE
Fsa/fix race on index accessors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 
 ### Fixed
 * <How to hit and notice issue? what was the impact?> ([#????](https://github.com/realm/realm-core/issues/????), since v?.?.?)
+* Fix race potentially allowing frozen transactions to access incomplete search index accessors. (Since v6)
 * Fix queries for null on non-nullable indexed integer columns returning results for zero entries. (Since v6)
 * Fix queries for null on a indexed ObjectId column returning results for the zero ObjectId. (Since v10)
 * Fix list of primitives for Optional<Float> and Optional<Double> always returning false for `Lst::is_null(ndx)` even on null values, (since v6.0.0).

--- a/src/realm/group.cpp
+++ b/src/realm/group.cpp
@@ -956,9 +956,9 @@ Table* Group::create_table_accessor(size_t table_ndx)
         new_table->init(ref, this, table_ndx, m_is_writable, is_frozen()); // Throws
         table = new_table.release();
     }
+    table->refresh_index_accessors();
     // must be atomic to allow concurrent probing of the m_table_accessors vector.
     store_atomic(m_table_accessors[table_ndx], table, std::memory_order_release);
-    table->refresh_index_accessors();
     return table;
 }
 


### PR DESCRIPTION
When initializing a table accessor, the pointer to the accessor was made public before init was complete.
In a multithreaded setting one thread might obtain access to this accessor while another one was working
on completing the initialization. Multithreaded access may occur on frozen transactions, but could also
occur on live transactions in case of violation of the thread confinement.

The fix just delays publication of the accessor until initialization is complete.

It is currently being investigated if this can explain some of the errors linked from https://github.com/realm/realm-core/issues/4032
