### PR TITLE
Improve handling of Arguments

### DIFF
--- a/src/realm/binary_data.hpp
+++ b/src/realm/binary_data.hpp
@@ -48,6 +48,7 @@ public:
         , m_size(data_size)
     {
     }
+    // Note! This version includes a trailing null character when using in place constant strings
     template <size_t N>
     explicit BinaryData(const char (&external_data)[N])
         : m_data(external_data)
@@ -76,13 +77,6 @@ public:
     size_t size() const noexcept
     {
         return m_size;
-    }
-    void remove_zero_term() noexcept
-    {
-        if (m_size > 0) {
-            REALM_ASSERT(m_data[m_size - 1] == '\0');
-            m_size--;
-        }
     }
 
     /// Is this a null reference?

--- a/src/realm/mixed.hpp
+++ b/src/realm/mixed.hpp
@@ -493,7 +493,7 @@ inline BinaryData Mixed::get<BinaryData>() const noexcept
         return binary_val;
     }
     REALM_ASSERT(get_type() == type_String);
-    return BinaryData(string_val.data(), string_val.size() + 1);
+    return BinaryData(string_val.data(), string_val.size());
 }
 
 inline BinaryData Mixed::get_binary() const

--- a/src/realm/parser/driver.cpp
+++ b/src/realm/parser/driver.cpp
@@ -838,10 +838,7 @@ Subexpr* LinkChain::column(std::string col)
 {
     auto col_key = m_current_table->get_column_key(col);
     if (!col_key) {
-        std::string err = m_current_table->get_name();
-        err += " has no property: ";
-        err += col;
-        throw std::runtime_error(err);
+        throw std::runtime_error(util::format("'%1' has no property: '%2'", m_current_table->get_name(), col));
     }
 
     if (col_key.is_list()) {

--- a/src/realm/parser/query_parser.hpp
+++ b/src/realm/parser/query_parser.hpp
@@ -47,6 +47,44 @@ struct AnyContext {
         }
         return false;
     }
+    DataType get_type_of(const util::Any& wrapper)
+    {
+        const std::type_info& type{wrapper.type()};
+        if (type == typeid(int64_t)) {
+            return type_Int;
+        }
+        if (type == typeid(StringData)) {
+            return type_String;
+        }
+        if (type == typeid(Timestamp)) {
+            return type_Timestamp;
+        }
+        if (type == typeid(double)) {
+            return type_Double;
+        }
+        if (type == typeid(bool)) {
+            return type_Bool;
+        }
+        if (type == typeid(float)) {
+            return type_Float;
+        }
+        if (type == typeid(BinaryData)) {
+            return type_Binary;
+        }
+        if (type == typeid(ObjKey)) {
+            return type_Link;
+        }
+        if (type == typeid(ObjectId)) {
+            return type_ObjectId;
+        }
+        if (type == typeid(Decimal128)) {
+            return type_Decimal;
+        }
+        if (type == typeid(UUID)) {
+            return type_UUID;
+        }
+        return DataType(-1);
+    }
 };
 
 class Arguments {
@@ -64,6 +102,7 @@ public:
     virtual Decimal128 decimal128_for_argument(size_t argument_index) = 0;
     virtual UUID uuid_for_argument(size_t argument_index) = 0;
     virtual bool is_argument_null(size_t argument_index) = 0;
+    virtual DataType type_for_argument(size_t argument_index) = 0;
 
     // dynamic conversion space with lifetime tied to this
     // it is used for storing literal binary/string data
@@ -151,6 +190,11 @@ private:
         return m_arguments[index];
     }
 
+    DataType type_for_argument(size_t i) override
+    {
+        return m_ctx.get_type_of(at(i));
+    }
+
     template <typename T>
     T get(size_t index) const
     {
@@ -213,6 +257,10 @@ public:
         throw NoArgsError();
     }
     bool is_argument_null(size_t)
+    {
+        throw NoArgsError();
+    }
+    DataType type_for_argument(size_t)
     {
         throw NoArgsError();
     }

--- a/src/realm/query_conditions.hpp
+++ b/src/realm/query_conditions.hpp
@@ -120,12 +120,6 @@ struct Contains : public HackClass {
         if (Mixed::types_are_comparable(m1, m2)) {
             BinaryData b1 = m1.get_binary();
             BinaryData b2 = m2.get_binary();
-            if (m1.get_type() == type_String) {
-                b1.remove_zero_term();
-            }
-            if (m2.get_type() == type_String) {
-                b2.remove_zero_term();
-            }
             return operator()(b1, b2, false, false);
         }
         return false;
@@ -187,12 +181,6 @@ struct Like : public HackClass {
         if (Mixed::types_are_comparable(m1, m2)) {
             BinaryData b1 = m1.get_binary();
             BinaryData b2 = m2.get_binary();
-            if (m1.get_type() == type_String) {
-                b1.remove_zero_term();
-            }
-            if (m2.get_type() == type_String) {
-                b2.remove_zero_term();
-            }
             return operator()(b1, b2, false, false);
         }
         return false;
@@ -246,12 +234,6 @@ struct BeginsWith : public HackClass {
         if (Mixed::types_are_comparable(m1, m2)) {
             BinaryData b1 = m1.get_binary();
             BinaryData b2 = m2.get_binary();
-            if (m1.get_type() == type_String) {
-                b1.remove_zero_term();
-            }
-            if (m2.get_type() == type_String) {
-                b2.remove_zero_term();
-            }
             return b2.begins_with(b1);
         }
         return false;
@@ -298,12 +280,6 @@ struct EndsWith : public HackClass {
         if (Mixed::types_are_comparable(m1, m2)) {
             BinaryData b1 = m1.get_binary();
             BinaryData b2 = m2.get_binary();
-            if (m1.get_type() == type_String) {
-                b1.remove_zero_term();
-            }
-            if (m2.get_type() == type_String) {
-                b2.remove_zero_term();
-            }
             return operator()(b1, b2, false, false);
         }
         return false;
@@ -467,12 +443,6 @@ struct ContainsIns : public HackClass {
         if (Mixed::types_are_comparable(m1, m2)) {
             BinaryData b1 = m1.get_binary();
             BinaryData b2 = m2.get_binary();
-            if (m1.get_type() == type_String) {
-                b1.remove_zero_term();
-            }
-            if (m2.get_type() == type_String) {
-                b2.remove_zero_term();
-            }
             return operator()(b1, b2, false, false);
         }
         return false;
@@ -557,12 +527,6 @@ struct LikeIns : public HackClass {
         if (Mixed::types_are_comparable(m1, m2)) {
             BinaryData b1 = m1.get_binary();
             BinaryData b2 = m2.get_binary();
-            if (m1.get_type() == type_String) {
-                b1.remove_zero_term();
-            }
-            if (m2.get_type() == type_String) {
-                b2.remove_zero_term();
-            }
             return operator()(b1, b2, false, false);
         }
         return false;
@@ -628,12 +592,6 @@ struct BeginsWithIns : public HackClass {
         if (Mixed::types_are_comparable(m1, m2)) {
             BinaryData b1 = m1.get_binary();
             BinaryData b2 = m2.get_binary();
-            if (m1.get_type() == type_String) {
-                b1.remove_zero_term();
-            }
-            if (m2.get_type() == type_String) {
-                b2.remove_zero_term();
-            }
             return operator()(b1, b2, false, false);
         }
         return false;
@@ -700,12 +658,6 @@ struct EndsWithIns : public HackClass {
         if (Mixed::types_are_comparable(m1, m2)) {
             BinaryData b1 = m1.get_binary();
             BinaryData b2 = m2.get_binary();
-            if (m1.get_type() == type_String) {
-                b1.remove_zero_term();
-            }
-            if (m2.get_type() == type_String) {
-                b2.remove_zero_term();
-            }
             return operator()(b1, b2, false, false);
         }
         return false;

--- a/src/realm/util/serializer.cpp
+++ b/src/realm/util/serializer.cpp
@@ -41,15 +41,7 @@ std::string print_value<>(BinaryData data)
     if (data.is_null()) {
         return "NULL";
     }
-    std::string out;
-    const char* start = data.data();
-    const size_t len = data.size();
-    util::StringBuffer encode_buffer;
-    encode_buffer.resize(util::base64_encoded_size(len));
-    util::base64_encode(start, len, encode_buffer.data(), encode_buffer.size());
-    out = "B64\"" + encode_buffer.str() + "\"";
-
-    return out;
+    return print_value<StringData>(StringData(data.data(), data.size()));
 }
 
 template <>

--- a/src/realm/util/serializer.cpp
+++ b/src/realm/util/serializer.cpp
@@ -41,7 +41,15 @@ std::string print_value<>(BinaryData data)
     if (data.is_null()) {
         return "NULL";
     }
-    return print_value<StringData>(StringData(data.data(), data.size()));
+    std::string out;
+    const char* start = data.data();
+    const size_t len = data.size();
+    util::StringBuffer encode_buffer;
+    encode_buffer.resize(util::base64_encoded_size(len));
+    util::base64_encode(start, len, encode_buffer.data(), encode_buffer.size());
+    out = "B64\"" + encode_buffer.str() + "\"";
+
+    return out;
 }
 
 template <>

--- a/test/test_array_mixed.cpp
+++ b/test/test_array_mixed.cpp
@@ -209,7 +209,8 @@ TEST(Mixed_Compare)
     CHECK(Mixed(0 - int64_t(0x1234567812345678)) > Mixed(-1.e19));  // double more negative than most negative int
     CHECK(Mixed(nan("123")) < 5);
 
-    CHECK(Mixed("Hello") == Mixed(BinaryData("Hello")));
+    std::string str("Hello");
+    CHECK(Mixed(str) == Mixed(BinaryData(str)));
     CHECK_NOT(Mixed::types_are_comparable(Mixed(), Mixed()));
     CHECK(Mixed() == Mixed());
     CHECK(Mixed(0.f) < Mixed(1));

--- a/test/test_parser.cpp
+++ b/test/test_parser.cpp
@@ -1266,7 +1266,7 @@ TEST(Parser_substitution)
     ColKey link_col = t->add_column(*t, "links");
     ColKey list_col = t->add_column_list(*t, "list");
     std::vector<std::string> names = {"Billy", "Bob", "Joe", "Jane", "Joel"};
-    std::vector<double> fees = {2.0, 2.23, 2.22, 2.25, 3.73};
+    std::vector<double> fees = {2.0, 2.23, 2.25, 2.22, 3.73};
     std::vector<ObjKey> obj_keys;
     t->create_objects(names.size(), obj_keys);
 
@@ -1297,7 +1297,7 @@ TEST(Parser_substitution)
     LnkLst list_1 = t->get_object(obj_keys[1]).get_linklist(list_col);
     list_1.add(obj_keys[0]);
 
-    util::Any args[] = {Int(2), Double(2.22), String("oe"), realm::null{}, Bool(true), Timestamp(1512130073, 505),
+    util::Any args[] = {Int(2), Double(2.25), String("oe"), realm::null{}, Bool(true), Timestamp(1512130073, 505),
                         bd0,    Float(2.33),  Int(1),       Int(3),        Int(4),     Bool(false)};
     size_t num_args = 12;
     verify_query_sub(test_context, t, "age > $0", args, num_args, 2);
@@ -1318,7 +1318,6 @@ TEST(Parser_substitution)
     verify_query_sub(test_context, t, "nuldouble == $3", args, num_args, 3);
     verify_query_sub(test_context, t, "links == $3", args, num_args, 3);
 
-#if 0
     // substitutions through collection aggregates is a different code path
     verify_query_sub(test_context, t, "list.@min.age < $0", args, num_args, 2);
     verify_query_sub(test_context, t, "list.@max.age >= $0", args, num_args, 1);
@@ -1354,29 +1353,29 @@ TEST(Parser_substitution)
     CHECK_THROW_ANY_GET_MESSAGE(verify_query_sub(test_context, t, "age > $2", args, /*num_args*/ 2, 0), message);
     CHECK_EQUAL(message, "Request for argument at index 2 but only 2 arguments are provided");
 
-    // invalid types
+    // Mixed types
     // int
-    CHECK_THROW_ANY(verify_query_sub(test_context, t, "age > $1", args, num_args, 0));
+    verify_query_sub(test_context, t, "age > $1", args, num_args, 2);
     CHECK_THROW_ANY(verify_query_sub(test_context, t, "age > $2", args, num_args, 0));
     CHECK_THROW_ANY(verify_query_sub(test_context, t, "age > $3", args, num_args, 0));
-    CHECK_THROW_ANY(verify_query_sub(test_context, t, "age > $4", args, num_args, 0));
+    verify_query_sub(test_context, t, "age > $4", args, num_args, 3);
     CHECK_THROW_ANY(verify_query_sub(test_context, t, "age > $5", args, num_args, 0));
     CHECK_THROW_ANY(verify_query_sub(test_context, t, "age > $6", args, num_args, 0));
-    CHECK_THROW_ANY(verify_query_sub(test_context, t, "age > $7", args, num_args, 0));
+    verify_query_sub(test_context, t, "age > $7", args, num_args, 2);
     // double
-    CHECK_THROW_ANY(verify_query_sub(test_context, t, "fees > $0", args, num_args, 0));
+    verify_query_sub(test_context, t, "fees > $0", args, num_args, 4);
     CHECK_THROW_ANY(verify_query_sub(test_context, t, "fees > $2", args, num_args, 0));
     CHECK_THROW_ANY(verify_query_sub(test_context, t, "fees > $3", args, num_args, 0));
-    CHECK_THROW_ANY(verify_query_sub(test_context, t, "fees > $4", args, num_args, 0));
+    verify_query_sub(test_context, t, "fees > $4", args, num_args, 5);
     CHECK_THROW_ANY(verify_query_sub(test_context, t, "fees > $5", args, num_args, 0));
     CHECK_THROW_ANY(verify_query_sub(test_context, t, "fees > $6", args, num_args, 0));
-    CHECK_THROW_ANY(verify_query_sub(test_context, t, "fees > $7", args, num_args, 0));
+    verify_query_sub(test_context, t, "fees > $7", args, num_args, 1);
     // float
-    CHECK_THROW_ANY(verify_query_sub(test_context, t, "floats > $0", args, num_args, 0));
-    CHECK_THROW_ANY(verify_query_sub(test_context, t, "floats > $1", args, num_args, 0));
+    verify_query_sub(test_context, t, "floats > $0", args, num_args, 2);
+    verify_query_sub(test_context, t, "floats > $1", args, num_args, 1);
     CHECK_THROW_ANY(verify_query_sub(test_context, t, "floats > $2", args, num_args, 0));
     CHECK_THROW_ANY(verify_query_sub(test_context, t, "floats > $3", args, num_args, 0));
-    CHECK_THROW_ANY(verify_query_sub(test_context, t, "floats > $4", args, num_args, 0));
+    verify_query_sub(test_context, t, "floats > $4", args, num_args, 2);
     CHECK_THROW_ANY(verify_query_sub(test_context, t, "floats > $5", args, num_args, 0));
     CHECK_THROW_ANY(verify_query_sub(test_context, t, "floats > $6", args, num_args, 0));
     // string
@@ -1385,16 +1384,16 @@ TEST(Parser_substitution)
     verify_query_sub(test_context, t, "name == $3", args, num_args, 0);
     CHECK_THROW_ANY(verify_query_sub(test_context, t, "name == $4", args, num_args, 0));
     CHECK_THROW_ANY(verify_query_sub(test_context, t, "name == $5", args, num_args, 0));
-    CHECK_THROW_ANY(verify_query_sub(test_context, t, "name == $6", args, num_args, 0));
+    verify_query_sub(test_context, t, "name == $6", args, num_args, 0);
     CHECK_THROW_ANY(verify_query_sub(test_context, t, "name == $7", args, num_args, 0));
     // bool
-    CHECK_THROW_ANY(verify_query_sub(test_context, t, "paid == $0", args, num_args, 0));
-    CHECK_THROW_ANY(verify_query_sub(test_context, t, "paid == $1", args, num_args, 0));
+    verify_query_sub(test_context, t, "paid == $0", args, num_args, 0);
+    verify_query_sub(test_context, t, "paid == $1", args, num_args, 0);
     CHECK_THROW_ANY(verify_query_sub(test_context, t, "paid == $2", args, num_args, 0));
     verify_query_sub(test_context, t, "paid == $3", args, num_args, 3);
     CHECK_THROW_ANY(verify_query_sub(test_context, t, "paid == $5", args, num_args, 0));
     CHECK_THROW_ANY(verify_query_sub(test_context, t, "paid == $6", args, num_args, 0));
-    CHECK_THROW_ANY(verify_query_sub(test_context, t, "paid == $7", args, num_args, 0));
+    verify_query_sub(test_context, t, "paid == $7", args, num_args, 0);
     // timestamp
     CHECK_THROW_ANY(verify_query_sub(test_context, t, "time == $0", args, num_args, 0));
     CHECK_THROW_ANY(verify_query_sub(test_context, t, "time == $1", args, num_args, 0));
@@ -1406,12 +1405,11 @@ TEST(Parser_substitution)
     // binary
     CHECK_THROW_ANY(verify_query_sub(test_context, t, "binary == $0", args, num_args, 0));
     CHECK_THROW_ANY(verify_query_sub(test_context, t, "binary == $1", args, num_args, 0));
-    CHECK_THROW_ANY(verify_query_sub(test_context, t, "binary == $2", args, num_args, 0));
+    verify_query_sub(test_context, t, "binary == $2", args, num_args, 1);
     verify_query_sub(test_context, t, "binary == $3", args, num_args, 3);
     CHECK_THROW_ANY(verify_query_sub(test_context, t, "binary == $4", args, num_args, 0));
     CHECK_THROW_ANY(verify_query_sub(test_context, t, "binary == $5", args, num_args, 0));
     CHECK_THROW_ANY(verify_query_sub(test_context, t, "binary == $7", args, num_args, 0));
-#endif
 }
 
 TEST(Parser_string_binary_encoding)
@@ -1580,10 +1578,7 @@ TEST(Parser_string_binary_encoding)
                 if (!it->second.should_be_replaced) {
                     bool validate = string_description.find(base64_prefix) == std::string::npos &&
                                     string_description.find(base64_suffix) == std::string::npos &&
-                                    binary_description.find(base64_prefix) == std::string::npos &&
-                                    binary_description.find(base64_suffix) == std::string::npos &&
-                                    string_description.find(it->first) != std::string::npos &&
-                                    binary_description.find(it->first) != std::string::npos;
+                                    string_description.find(it->first) != std::string::npos;
                     CHECK(validate);
                     if (!validate) {
                         std::stringstream ss;
@@ -2046,7 +2041,7 @@ TEST(Parser_list_of_primitive_ints)
         message,
         "Unsupported comparison operator 'endswith' against type 'int', right side must be a string or binary type");
     CHECK_THROW_ANY_GET_MESSAGE(verify_query(test_context, t, "integers == 'string'", 0), message);
-    CHECK_EQUAL(message, "Unsupported comparison between property of type 'int' and constant value ''string''");
+    CHECK_EQUAL(message, "Unsupported comparison between type 'int' and type 'string'");
 }
 #if 0
 

--- a/test/test_parser.cpp
+++ b/test/test_parser.cpp
@@ -1280,8 +1280,10 @@ TEST(Parser_substitution)
     t->get_object(obj_keys[1]).set(bool_col, false);
     t->get_object(obj_keys[1])
         .set(time_col, Timestamp(1512130073, 505)); // 2017/12/02 @ 12:47am (UTC) + 505 nanoseconds
-    BinaryData bd0("oe");
-    BinaryData bd1("eo");
+    std::string str_oe("oe");
+    std::string str_eo("eo");
+    BinaryData bd0(str_oe);
+    BinaryData bd1(str_eo);
     t->get_object(obj_keys[0]).set(binary_col, bd0);
     t->get_object(obj_keys[1]).set(binary_col, bd1);
     t->get_object(obj_keys[0]).set(float_col, 2.33f);
@@ -1327,8 +1329,8 @@ TEST(Parser_substitution)
     verify_query_sub(test_context, t, "list.@size > $0", args, num_args, 1);
     verify_query_sub(test_context, t, "name.@count > $0", args, num_args, 5);
     verify_query_sub(test_context, t, "name.@size > $0", args, num_args, 5);
-    verify_query_sub(test_context, t, "binary.@count > $0", args, num_args, 2);
-    verify_query_sub(test_context, t, "binary.@size > $0", args, num_args, 2);
+    verify_query_sub(test_context, t, "binary.@count >= $0", args, num_args, 2);
+    verify_query_sub(test_context, t, "binary.@size >= $0", args, num_args, 2);
 
     // reusing properties, mixing order
     verify_query_sub(test_context, t, "(age > $0 || fees == $1) && age == $0", args, num_args, 1);
@@ -1611,7 +1613,8 @@ TEST(Parser_string_binary_encoding)
             }
         }
 
-        // std::cerr << "original: " << buff << "\tdescribed: " << string_description << "\n";
+        // std::cerr << "original: " << buff << "\tdescribed: " << string_description << " : " << binary_description
+        // << "\n";
 
         Query qstr2 = t->query(string_description);
         CHECK_EQUAL(qstr2.count(), num_results);

--- a/test/test_query.cpp
+++ b/test/test_query.cpp
@@ -2179,7 +2179,7 @@ TEST(Query_TwoColumnsCrossTypes)
     for (size_t i = 0; i < num_rows; ++i) {
         std::string str = util::format("foo %1", i);
         Timestamp ts{int64_t(i), 0};
-        BinaryData bd(str.c_str(), str.size() + 1); // include the terminal null so comparison against strings work
+        BinaryData bd(str.c_str(), str.size());
         ObjectId oid(ts, int(i), int(i));
         UUID uuid = gen.convert_for_test<UUID>(i);
         table.create_object()
@@ -2310,11 +2310,6 @@ TEST(Query_TwoColumnsCrossTypesNullability)
                 if (are_comparable) {
                     num_expected_matches = 1; // numerics are 0
                 }
-                if ((lhs_type == type_Binary && rhs_type == type_String) ||
-                    (lhs_type == type_String && rhs_type == type_Binary)) {
-                    num_expected_matches =
-                        0; // although comparable, the defaults differ from String: "\0" and Binary: ""
-                }
             }
             {
                 size_t actual_matches = table.where().equal(lhs, rhs).count();
@@ -2367,9 +2362,6 @@ TEST(Query_TwoColumnsCrossTypesNullability)
             }
             {
                 size_t expected_greater = 0;
-                if (both_non_nullable && lhs_type == type_String && rhs_type == type_Binary) {
-                    expected_greater = num_rows;
-                }
                 size_t actual_matches = table.where().greater(lhs, rhs).count();
                 CHECK_EQUAL(expected_greater, actual_matches);
                 if (actual_matches != expected_greater) {
@@ -2379,9 +2371,6 @@ TEST(Query_TwoColumnsCrossTypesNullability)
             }
             {
                 size_t expected_less = 0;
-                if (both_non_nullable && lhs_type == type_Binary && rhs_type == type_String) {
-                    expected_less = num_rows;
-                }
                 size_t actual_matches = table.where().less(lhs, rhs).count();
                 CHECK_EQUAL(expected_less, actual_matches);
                 if (actual_matches != expected_less) {

--- a/test/test_query2.cpp
+++ b/test/test_query2.cpp
@@ -5351,10 +5351,10 @@ TEST(Query_Mixed)
             nb_strings++;
         }
     }
-
+    std::string str2bin("String2Binary");
     table->get_object(15).set(col_any, Mixed());
     table->get_object(75).set(col_any, Mixed(75.));
-    table->get_object(28).set(col_any, Mixed(BinaryData("String2Binary")));
+    table->get_object(28).set(col_any, Mixed(BinaryData(str2bin)));
     table->get_object(25).set(col_any, Mixed(3.));
     table->get_object(35).set(col_any, Mixed(Decimal128("3")));
 


### PR DESCRIPTION
I concluded that it was not possible to guess the type of the argument from the type of the other sub-expression. If we take `.@avg`, the type is `double`, but the argument could be given as `int`. Even if the property we calculate the average of is `int` then it should be possible to compare with `double`.