### PR TITLE
Fix OR query and conversion of string constants to numbers

### DIFF
--- a/src/realm/parser/driver.cpp
+++ b/src/realm/parser/driver.cpp
@@ -109,11 +109,6 @@ inline const char* get_type_name<double>()
 {
     return "floating point number";
 }
-template <>
-inline const char* get_type_name<Decimal128>()
-{
-    return "decimal number";
-}
 
 template <typename T>
 inline T string_to(const std::string& s)
@@ -124,7 +119,7 @@ inline T string_to(const std::string& s)
     iss >> value;
     if (iss.fail()) {
         if (!try_parse_specials(s, value)) {
-            throw std::invalid_argument(util::format("Cannot convert '%1'to a %2", s, get_type_name<T>()));
+            throw std::invalid_argument(util::format("Cannot convert '%1' to a %2", s, get_type_name<T>()));
         }
     }
     return value;

--- a/test/object-store/sync/app.cpp
+++ b/test/object-store/sync/app.cpp
@@ -3532,7 +3532,7 @@ TEST_CASE("app: metadata is persisted between sessions", "[sync][app]") {
 TEST_CASE("app: make_streaming_request", "[sync][app]") {
     UnitTestTransport::access_token = good_access_token;
 
-    constexpr auto timeout_ms = 60000;
+    constexpr uint64_t timeout_ms = 60000;
     auto config = get_config([] {
         return std::make_unique<UnitTestTransport>();
     });

--- a/test/test_parser.cpp
+++ b/test/test_parser.cpp
@@ -2041,7 +2041,7 @@ TEST(Parser_list_of_primitive_ints)
         message,
         "Unsupported comparison operator 'endswith' against type 'int', right side must be a string or binary type");
     CHECK_THROW_ANY_GET_MESSAGE(verify_query(test_context, t, "integers == 'string'", 0), message);
-    CHECK_EQUAL(message, "Unsupported comparison between type 'int' and type 'string'");
+    CHECK_EQUAL(message, "Cannot convert 'string'to a number");
 }
 
 TEST(Parser_list_of_primitive_strings)
@@ -3212,7 +3212,7 @@ TEST(Parser_BacklinkCount)
     std::string message;
     // backlink count requires comparison to a numeric type
     CHECK_THROW_ANY_GET_MESSAGE(verify_query(test_context, items, "@links.@count == 'string'", -1), message);
-    CHECK_EQUAL(message, "Unsupported comparison between type 'int' and type 'string'");
+    CHECK_EQUAL(message, "Cannot convert 'string'to a number");
     CHECK_THROW_ANY_GET_MESSAGE(verify_query(test_context, items, "@links.@count == 2018-04-09@14:21:0", -1),
                                 message);
     CHECK_EQUAL(message, "Unsupported comparison between type 'int' and type 'timestamp'");
@@ -3786,6 +3786,7 @@ TEST(Parser_Between)
     CHECK(message.find("Invalid Predicate. The 'between' operator is not supported yet, please rewrite the "
                        "expression using '>' and '<'.") != std::string::npos);
 }
+#endif
 
 TEST(Parser_ChainedStringEqualQueries)
 {
@@ -3891,7 +3892,6 @@ TEST(Parser_ChainedIntEqualQueries)
     default_obj.remove();
     verify_query(test_context, table, query, populated_data.size());
 }
-#endif
 
 TEST(Parser_TimestampNullable)
 {

--- a/test/test_parser.cpp
+++ b/test/test_parser.cpp
@@ -2041,7 +2041,7 @@ TEST(Parser_list_of_primitive_ints)
         message,
         "Unsupported comparison operator 'endswith' against type 'int', right side must be a string or binary type");
     CHECK_THROW_ANY_GET_MESSAGE(verify_query(test_context, t, "integers == 'string'", 0), message);
-    CHECK_EQUAL(message, "Cannot convert 'string'to a number");
+    CHECK_EQUAL(message, "Cannot convert 'string' to a number");
 }
 
 TEST(Parser_list_of_primitive_strings)
@@ -3212,7 +3212,7 @@ TEST(Parser_BacklinkCount)
     std::string message;
     // backlink count requires comparison to a numeric type
     CHECK_THROW_ANY_GET_MESSAGE(verify_query(test_context, items, "@links.@count == 'string'", -1), message);
-    CHECK_EQUAL(message, "Cannot convert 'string'to a number");
+    CHECK_EQUAL(message, "Cannot convert 'string' to a number");
     CHECK_THROW_ANY_GET_MESSAGE(verify_query(test_context, items, "@links.@count == 2018-04-09@14:21:0", -1),
                                 message);
     CHECK_EQUAL(message, "Unsupported comparison between type 'int' and type 'timestamp'");


### PR DESCRIPTION
It came as a total surprise that we accepted `a == "45"` if `a` is an int property.