### PR TITLE
fix a race allowing access to incomplete init of table accessor

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,7 @@
 
 ### Fixed
 * <How to hit and notice issue? what was the impact?> ([#????](https://github.com/realm/realm-core/issues/????), since v?.?.?)
+* Fix race potentially allowing frozen transactions to access incomplete search index accessors. (Since v6)
 * Fix queries for null on non-nullable indexed integer columns returning results for zero entries. (Since v6)
 * Fix queries for null on a indexed ObjectId column returning results for the zero ObjectId. (Since v10)
 * Fix list of primitives for Optional<Float> and Optional<Double> always returning false for `Lst::is_null(ndx)` even on null values, (since v6.0.0).

--- a/src/realm/group.cpp
+++ b/src/realm/group.cpp
@@ -956,9 +956,9 @@ Table* Group::create_table_accessor(size_t table_ndx)
         new_table->init(ref, this, table_ndx, m_is_writable, is_frozen()); // Throws
         table = new_table.release();
     }
+    table->refresh_index_accessors();
     // must be atomic to allow concurrent probing of the m_table_accessors vector.
     store_atomic(m_table_accessors[table_ndx], table, std::memory_order_release);
-    table->refresh_index_accessors();
     return table;
 }
 


### PR DESCRIPTION
Cherry-picking https://github.com/realm/realm-core/pull/4098