### PR TITLE
Collections: Handle copy-construction of stale accessor

### DIFF
--- a/src/realm/list.hpp
+++ b/src/realm/list.hpp
@@ -317,6 +317,8 @@ public:
 
     std::unique_ptr<LnkLst> clone_linklist() const
     {
+        // FIXME: The copy constructor requires this.
+        update_if_needed();
         return std::make_unique<LnkLst>(*this);
     }
 

--- a/src/realm/list.hpp
+++ b/src/realm/list.hpp
@@ -421,6 +421,10 @@ template <class T>
 inline Lst<T>::Lst(const Lst& other)
     : Base(static_cast<const Base&>(other))
 {
+    // FIXME: If the other side needed an update, we could be using a stale ref
+    // below.
+    REALM_ASSERT(!other.update_if_needed());
+
     if (other.m_tree) {
         Allocator& alloc = other.m_tree->get_alloc();
         m_tree = std::make_unique<BPlusTree<T>>(alloc);

--- a/src/realm/set.hpp
+++ b/src/realm/set.hpp
@@ -526,6 +526,10 @@ template <class T>
 inline Set<T>::Set(const Set& other)
     : Base(static_cast<const Base&>(other))
 {
+    // FIXME: If the other side needed an update, we could be using a stale ref
+    // below.
+    REALM_ASSERT(!other.update_if_needed());
+
     if (other.m_tree) {
         Allocator& alloc = other.m_tree->get_alloc();
         m_tree = std::make_unique<BPlusTree<T>>(alloc);

--- a/src/realm/set.hpp
+++ b/src/realm/set.hpp
@@ -300,6 +300,8 @@ public:
 
     std::unique_ptr<LnkSet> clone_linkset() const
     {
+        // FIXME: The copy constructor requires this.
+        update_if_needed();
         return std::make_unique<LnkSet>(*this);
     }
 

--- a/test/object-store/list.cpp
+++ b/test/object-store/list.cpp
@@ -716,6 +716,23 @@ TEST_CASE("list") {
         REQUIRE(snapshot.size() == 10);
     }
 
+    SECTION("snapshot() after deletion") {
+        List list(r, *lv);
+
+        auto snapshot = list.snapshot();
+
+        for (size_t i = 0; i < snapshot.size(); ++i) {
+            r->begin_transaction();
+            Obj obj = snapshot.get<Obj>(i);
+            obj.remove();
+            r->commit_transaction();
+        }
+
+        auto snapshot2 = list.snapshot();
+        CHECK(snapshot2.size() == 0);
+        CHECK(list.size() == 0);
+    }
+
     SECTION("get_object_schema()") {
         List list(r, *lv);
         auto objectschema = &*r->schema().find("target");

--- a/test/test_links.cpp
+++ b/test/test_links.cpp
@@ -491,6 +491,7 @@ TEST(Links_LinkList_Construction)
     list0.add(target_keys[0]); // Ensure usability
     list0.clear();             // Make it empty again
 
+    links1.size();        // call update_if_needed()
     LnkLst list1(links1); // Constructed from not empty list
     CHECK_EQUAL(3, list1.size());
     list1.clear();


### PR DESCRIPTION
Copy-constructing a stale collection accessor would cause init_from_ref to be called with a stale ref.

This asserts that the source accessor is not stale when copy-constructing.

It's hard to see what the right approach should be here. The internal `BPlusTree<T>` in the copied `Lst<T>` cannot be initialized if the source instance is stale, so the "staleness" should probably be copied over instead and then update_if_needed when needed. This requires wrestling a bit more with the internals of collections.

Problem since #4057.

Fixes #4114 