### PR TITLE
Fix a dangling reference in SyncUser::refresh_custom_data()

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,8 @@
 
 ### Fixed
 * Fix an assertion failure when querying for null on a non-nullable string primary key property. ([#4060](https://github.com/realm/realm-core/issues/4060), since v10.0.0-alpha.2)
- 
+* Fix a use of a dangling reference when refreshing a user's custom data that could lead to a crash (since v10.0.0).
+
 ### Breaking changes
 * None.
 

--- a/src/realm/object-store/sync/sync_user.cpp
+++ b/src/realm/object-store/sync/sync_user.cpp
@@ -421,7 +421,7 @@ void SyncUser::set_binding_context_factory(SyncUserContextFactory factory)
 void SyncUser::refresh_custom_data(std::function<void(util::Optional<app::AppError>)> completion_block)
 {
     if (auto app = m_sync_manager->app().lock()) {
-        app->refresh_custom_data(shared_from_this(), [&](auto error) {
+        app->refresh_custom_data(shared_from_this(), [=](auto error) {
             emit_change_to_subscribers(*this);
             completion_block(error);
         });


### PR DESCRIPTION
refresh_custom_data() is async and so the lambda needs to capture by value rather than capturing a reference to the stack variable.