### PR TITLE
Bump file format if new data types are used

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@
 * None.
  
 ### Breaking changes
-* None.
+* File format version is bumped to 21 if the new data types are used.
 
 -----------
 

--- a/src/realm/db.cpp
+++ b/src/realm/db.cpp
@@ -2249,6 +2249,7 @@ void DB::low_level_commit(uint_fast64_t new_version, Transaction& transaction)
                 // mode the file on disk may very likely be in an invalid state.
                 break;
         }
+        this->m_file_format_version = transaction.get_file_format_version();
         size_t new_file_size = out.get_file_size();
         // We must reset the allocators free space tracking before communicating the new
         // version through the ring buffer. If not, a reader may start updating the allocators

--- a/src/realm/db.cpp
+++ b/src/realm/db.cpp
@@ -1066,6 +1066,7 @@ void DB::do_open(const std::string& path, bool no_create_file, bool is_backend, 
                 case 10:
                 case 11:
                 case 20:
+                case 21:
                     file_format_ok = true;
                     break;
             }
@@ -1219,7 +1220,7 @@ void DB::do_open(const std::string& path, bool no_create_file, bool is_backend, 
                 // with a bumped SharedInfo file format version, if there isn't.
                 if (info->file_format_version != target_file_format_version) {
                     std::stringstream ss;
-                    ss << "File format version deosn't match: " << info->file_format_version << " "
+                    ss << "File format version doesn't match: " << int(info->file_format_version) << " "
                        << target_file_format_version << ".";
                     throw IncompatibleLockFile(ss.str());
                 }
@@ -2249,7 +2250,7 @@ void DB::low_level_commit(uint_fast64_t new_version, Transaction& transaction)
                 // mode the file on disk may very likely be in an invalid state.
                 break;
         }
-        this->m_file_format_version = transaction.get_file_format_version();
+        m_file_format_version = transaction.get_file_format_version();
         size_t new_file_size = out.get_file_size();
         // We must reset the allocators free space tracking before communicating the new
         // version through the ring buffer. If not, a reader may start updating the allocators

--- a/src/realm/db.hpp
+++ b/src/realm/db.hpp
@@ -214,6 +214,8 @@ public:
     /// Returns the version of the latest snapshot.
     version_type get_version_of_latest_snapshot();
 
+    int get_file_format_version() const noexcept;
+
     /// Thrown by start_read() if the specified version does not correspond to a
     /// bound (AKA tethered) snapshot.
     struct BadVersion;
@@ -508,8 +510,6 @@ private:
     /// Upgrade file format and/or history schema
     void upgrade_file_format(bool allow_file_format_upgrade, int target_file_format_version,
                              int current_hist_schema_version, int target_hist_schema_version);
-
-    int get_file_format_version() const noexcept;
 
     /// finish up the process of starting a write transaction. Internal use only.
     void finish_begin_write();

--- a/src/realm/group.cpp
+++ b/src/realm/group.cpp
@@ -321,6 +321,11 @@ int Group::get_target_file_format_version_for_session(int current_file_format_ve
         return 11;
     }
 
+    if (current_file_format_version > 20) {
+        return current_file_format_version;
+    }
+
+    // The default file format version is 20.
     return 20;
 }
 

--- a/src/realm/group.cpp
+++ b/src/realm/group.cpp
@@ -552,6 +552,7 @@ void Group::open(ref_type top_ref, const std::string& file_path)
             break;
         case 11:
         case 20:
+        case 21:
             file_format_ok = true;
             break;
     }

--- a/src/realm/group.hpp
+++ b/src/realm/group.hpp
@@ -825,6 +825,8 @@ private:
     ///
     ///  20 New data types: Decimal128 and ObjectId. Embedded tables.
     ///
+    ///  21 New data types: UUID, Mixed, Set and Dictionary.
+    ///
     /// IMPORTANT: When introducing a new file format version, be sure to review
     /// the file validity checks in Group::open() and DB::do_open, the file
     /// format selection logic in

--- a/src/realm/table.cpp
+++ b/src/realm/table.cpp
@@ -927,6 +927,12 @@ ColKey Table::do_insert_root_column(ColKey col_key, ColumnType type, StringData 
     // locate insertion point: ordinary columns must come before backlink columns
     size_t spec_ndx = (type == col_type_BackLink) ? m_spec.get_column_count() : m_spec.get_public_column_count();
 
+    if (col_key.is_dictionary() || col_key.is_set() || col_key.get_type() == col_type_Mixed ||
+        col_key.get_type() == col_type_UUID) {
+        if (auto g = get_parent_group()) {
+            g->set_file_format_version(21);
+        }
+    }
     if (!col_key) {
         col_key = generate_col_key(type, {});
     }

--- a/test/test_shared.cpp
+++ b/test/test_shared.cpp
@@ -4283,4 +4283,28 @@ TEST(Shared_ManyColumns)
     foo->create_object().set("Prop0", 500);
 }
 
+TEST(Shared_BumpFileFormat)
+{
+    // We had a bug where cluster array has to expand, but the new ref
+    // was not updated in the parent.
+
+    SHARED_GROUP_TEST_PATH(path);
+    auto hist = make_in_realm_history(path);
+    DBRef db = DB::create(*hist);
+
+    auto tr = db->start_write();
+    auto t = tr->add_table("Foo");
+    t->add_column(type_Int, "ints");
+    tr->commit();
+
+    CHECK_EQUAL(db->get_file_format_version(), 20);
+
+    tr = db->start_write();
+    t = tr->get_table("Foo");
+    t->add_column_set(type_Int, "intset");
+    tr->commit();
+
+    CHECK_EQUAL(db->get_file_format_version(), 21);
+}
+
 #endif // TEST_SHARED

--- a/test/test_shared.cpp
+++ b/test/test_shared.cpp
@@ -4290,21 +4290,30 @@ TEST(Shared_BumpFileFormat)
 
     SHARED_GROUP_TEST_PATH(path);
     auto hist = make_in_realm_history(path);
-    DBRef db = DB::create(*hist);
+    {
+        DBRef db = DB::create(*hist);
 
-    auto tr = db->start_write();
-    auto t = tr->add_table("Foo");
-    t->add_column(type_Int, "ints");
-    tr->commit();
+        auto tr = db->start_write();
+        auto t = tr->add_table("Foo");
+        t->add_column(type_Int, "ints");
+        tr->commit();
 
-    CHECK_EQUAL(db->get_file_format_version(), 20);
+        CHECK_EQUAL(db->get_file_format_version(), 20);
 
-    tr = db->start_write();
-    t = tr->get_table("Foo");
-    t->add_column_set(type_Int, "intset");
-    tr->commit();
+        tr = db->start_write();
+        t = tr->get_table("Foo");
+        t->add_column_set(type_Int, "intset");
+        tr->commit();
 
-    CHECK_EQUAL(db->get_file_format_version(), 21);
+        CHECK_EQUAL(db->get_file_format_version(), 21);
+    }
+    {
+        DBRef db = DB::create(*hist);
+
+        CHECK_EQUAL(db->get_file_format_version(), 21);
+        auto tr = db->start_read();
+        tr->verify();
+    }
 }
 
 #endif // TEST_SHARED


### PR DESCRIPTION
I propose that the file format is only updated if the new data types are used. In this way it will still be possible for customers to roll back to previous version if they are not using the new capapilities.