### PR TITLE
Work around compiler bug on MSVC around overloaded{}

### DIFF
--- a/src/realm/sync/changeset.cpp
+++ b/src/realm/sync/changeset.cpp
@@ -60,11 +60,11 @@ InternString Changeset::find_string(StringData string) const noexcept
 
 PrimaryKey Changeset::get_key(const Instruction::PrimaryKey& key) const noexcept
 {
-    auto get = overload{
-        [&](InternString str) -> PrimaryKey {
+    const auto& get = overload{
+        [this](InternString str) -> PrimaryKey {
             return get_string(str);
         },
-        [&](auto&& otherwise) -> PrimaryKey {
+        [](auto otherwise) -> PrimaryKey {
             return otherwise;
         },
     };

--- a/src/realm/sync/transform.cpp
+++ b/src/realm/sync/transform.cpp
@@ -1004,14 +1004,14 @@ struct MergeUtils {
     bool same_path_element(const Instruction::Path::Element& left,
                            const Instruction::Path::Element& right) const noexcept
     {
-        auto pred = util::overload{
+        const auto& pred = util::overload{
             [&](uint32_t lhs, uint32_t rhs) {
                 return lhs == rhs;
             },
             [&](InternString lhs, InternString rhs) {
                 return same_string(lhs, rhs);
             },
-            [&](auto&&, auto&&) {
+            [&](const auto&, const auto&) {
                 // FIXME: Paths contain incompatible element types. Should we raise an
                 // error here?
                 return false;


### PR DESCRIPTION
VS 2019 claims that the stack is corrupted around local variables constructed with `util::overloaded{ ... }`. It might be, but if so it is a miscompilation.

The workaround works for some reason.

Found by @nirinchev in realm-dotnet.