### PR TITLE
invalidate WrappedAllocators earlier

### DIFF
--- a/src/realm/alloc.hpp
+++ b/src/realm/alloc.hpp
@@ -340,6 +340,13 @@ public:
         m_ref_translation_ptr.store(m_alloc->m_ref_translation_ptr);
     }
 
+    void kill()
+    {
+        m_alloc = nullptr;
+        m_baseline.store(0, std::memory_order_relaxed);
+        m_ref_translation_ptr.store(nullptr);
+    }
+
     void update_from_underlying_allocator(bool writable)
     {
         switch_underlying_allocator(*m_alloc);

--- a/src/realm/group.cpp
+++ b/src/realm/group.cpp
@@ -943,7 +943,7 @@ Table* Group::create_table_accessor(size_t table_ndx)
         }
         if (g_table_recycler_2.size() + g_table_recycler_1.size() > g_table_recycling_delay) {
             table = g_table_recycler_2.back();
-            table->fully_detach();
+            //table->fully_detach();
             g_table_recycler_2.pop_back();
         }
     }
@@ -965,6 +965,7 @@ Table* Group::create_table_accessor(size_t table_ndx)
 
 void Group::recycle_table_accessor(Table* to_be_recycled)
 {
+    to_be_recycled->fully_detach();
     std::lock_guard<std::mutex> lg(g_table_recycler_mutex);
     g_table_recycler_1.push_back(to_be_recycled);
 }

--- a/src/realm/group.cpp
+++ b/src/realm/group.cpp
@@ -943,7 +943,7 @@ Table* Group::create_table_accessor(size_t table_ndx)
         }
         if (g_table_recycler_2.size() + g_table_recycler_1.size() > g_table_recycling_delay) {
             table = g_table_recycler_2.back();
-            //table->fully_detach();
+            // table->fully_detach();
             g_table_recycler_2.pop_back();
         }
     }

--- a/src/realm/table.cpp
+++ b/src/realm/table.cpp
@@ -1066,6 +1066,7 @@ void Table::detach(LifeCycleCookie cookie) noexcept
 {
     m_cookie = cookie;
     m_alloc.bump_instance_version();
+    m_alloc.kill();
 }
 
 void Table::fully_detach() noexcept


### PR DESCRIPTION
Fail faster if an attempt is made to use an allocator belonging to a Table that is no longer supposed to be accessible.

This is a change in policy. Earlier, we kept as much of the Table accessor state, so that a data race due to a violation of the thread confinement would not crash, but more often produce an exception (NoSuchTable, typically). However, experience showed that these "late" exceptions are too late to be useful in locating the root cause. This PR tries to fail as early as possible in these cases, by installing nullptrs in the WrappedAllocator for a Table when that table should be logically unreachable. This forces all ref-translations and all alloc/free operations to fail for arrays which refer to the allocator in question.

## ☑️ ToDos
* [ ] 📝 Changelog update
* [ ] 🚦 Tests (or not relevant)
