### PR TITLE
RCORE-369 Add initial benchmark tasks to evergreen

### DIFF
--- a/evergreen/config.yml
+++ b/evergreen/config.yml
@@ -173,12 +173,12 @@ tasks:
       script: |-
         set -o errexit
 
-        mkdir bench_results
-        cd bench_results
+        mkdir ${task_name|benchmark}_results
+        cd ${task_name|benchmark}_results
         ../build/test/benchmark-common-tasks/realm-benchmark-common-tasks
   - command: perf.send
     params:
-      file: ./realm-core/bench_results/results.latest.json
+      file: ./realm-core/${task_name|benchmark}_results/results.latest.json
 
 - name: benchmark-crud
   commands:
@@ -189,12 +189,12 @@ tasks:
       script: |-
         set -o errexit
 
-        mkdir bench_results
-        cd bench_results
+        mkdir ${task_name|benchmark}_results
+        cd ${task_name|benchmark}_results
         ../build/test/benchmark-crud/realm-benchmark-crud
   - command: perf.send
     params:
-      file: ./realm-core/bench_results/results.latest.json
+      file: ./realm-core/${task_name|benchmark}_results/results.latest.json
 
 - name: sync-tests
   commands:

--- a/evergreen/config.yml
+++ b/evergreen/config.yml
@@ -86,10 +86,6 @@ functions:
               set_cmake_var realm_vars REALM_USE_SYSTEM_OPENSSL BOOL On
           fi
 
-          if [[ -n "${enable_long_running_tests|}" ]]; then
-              set_cmake_var realm_vars REALM_TEST_DURATION STRING "${enable_long_running_tests}"
-          fi
-
           set_cmake_var realm_vars REALM_BUILD_COMMANDLINE_TOOLS BOOL On
           set_cmake_var realm_vars REALM_ENABLE_ENCRYPTION BOOL On
 

--- a/evergreen/config.yml
+++ b/evergreen/config.yml
@@ -33,83 +33,96 @@ functions:
           set -o errexit
           git submodule update --init --recursive
 
+  "compile":
+    - command: shell.exec
+      params:
+        working_dir: realm-core
+        shell: bash
+        script: |-
+          set -o errexit
+          set -o verbose
+
+          if [ -d cmake_vars ]; then
+              rm cmake_vars/*.txt
+          fi
+          export CMAKE_VARS_DIR=$(./evergreen/abspath.sh cmake_vars)
+          source evergreen/cmake_vars_utils.sh
+          export CMAKE=$(./evergreen/abspath.sh ${cmake_bindir}/cmake)
+
+          if [ -n "${c_compiler}" ]; then
+              [ -n "${cxx_compiler}" ] || (echo "C compiler defined as  but C++ compiler is undefined"; exit 1)
+              set_cmake_var compiler_vars CMAKE_C_COMPILER PATH $(./evergreen/abspath.sh ${c_compiler})
+              set_cmake_var compiler_vars CMAKE_CXX_COMPILER PATH $(./evergreen/abspath.sh ${cxx_compiler})
+          fi
+
+          if [ -n "${build_zlib|}" ]; then
+              CC="${c_compiler|}" GENERATOR="${cmake_generator|}" \
+                  ./evergreen/build_zlib.sh \
+                      -p zlib_prefix \
+                      -b v1.2.11 \
+                      -e "${extra_flags}" \
+                      -j ${max_jobs|$(grep -c proc /proc/cpuinfo)}
+          fi
+
+          if [ -n "${run_tests_against_baas|}" ]; then
+              set_cmake_var baas_vars REALM_ENABLE_AUTH_TESTS BOOL On
+              set_cmake_var baas_vars REALM_MONGODB_ENDPOINT STRING "http://localhost:9090"
+              set_cmake_var baas_vars REALM_STITCH_CONFIG PATH $(pwd)/test/object-store/mongodb/stitch.json
+          fi
+
+          if [ -n "${enable_asan|}" ]; then
+              set_cmake_var realm_vars REALM_ASAN BOOL On
+          fi
+
+          if [ -n "${enable_tsan|}" ]; then
+              set_cmake_var realm_vars REALM_TSAN BOOL On
+          fi
+
+          if [ -z "${disable_sync|}" ]; then
+              set_cmake_var realm_vars REALM_ENABLE_SYNC BOOL On
+          fi
+
+          if [ -n "${use_system_openssl|}" ]; then
+              set_cmake_var realm_vars REALM_USE_SYSTEM_OPENSSL BOOL On
+          fi
+
+          if [[ -n "${enable_long_running_tests|}" ]]; then
+              set_cmake_var realm_vars REALM_TEST_DURATION STRING "${enable_long_running_tests}"
+          fi
+
+          set_cmake_var realm_vars REALM_BUILD_COMMANDLINE_TOOLS BOOL On
+          set_cmake_var realm_vars REALM_ENABLE_ENCRYPTION BOOL On
+
+          if [[ -n "${fetch_missing_dependencies|}" ]]; then
+              set_cmake_var realm_vars REALM_FETCH_MISSING_DEPENDENCIES BOOL On
+          fi
+
+          if [[ -n "${cmake_build_type|}" ]]; then
+              set_cmake_var realm_vars CMAKE_BUILD_TYPE STRING "${cmake_build_type}"
+          fi
+
+          echo "Running cmake with these vars:"
+          cat cmake_vars/*.txt | tee cmake_vars.txt
+          echo
+
+          $CMAKE \
+            -B build \
+            -C cmake_vars.txt ${extra_flags} \
+            -G "${cmake_generator|Unix Makefiles}"
+
+          ${cmake_bindir}/cmake \
+              --build build \
+              -j ${max_jobs|$(grep -c proc /proc/cpuinfo)} \
+              --target ${target_to_build|}
+
 tasks:
 - name: compile
   commands:
-  - command: shell.exec
-    params:
-      working_dir: realm-core
-      shell: bash
-      script: |-
-        set -o errexit
-        set -o verbose
+  - func: "compile"
 
-        if [ -d cmake_vars ]; then
-            rm cmake_vars/*.txt
-        fi
-        export CMAKE_VARS_DIR=$(./evergreen/abspath.sh cmake_vars)
-        source evergreen/cmake_vars_utils.sh
-        export CMAKE=$(./evergreen/abspath.sh ${cmake_bindir}/cmake)
-        
-        if [ -n "${c_compiler}" ]; then
-            [ -n "${cxx_compiler}" ] || (echo "C compiler defined as  but C++ compiler is undefined"; exit 1)
-            set_cmake_var compiler_vars CMAKE_C_COMPILER PATH $(./evergreen/abspath.sh ${c_compiler})
-            set_cmake_var compiler_vars CMAKE_CXX_COMPILER PATH $(./evergreen/abspath.sh ${cxx_compiler})
-        fi
-       
-        if [ -n "${build_zlib|}" ]; then
-            CC="${c_compiler|}" GENERATOR="${cmake_generator|}" \
-                ./evergreen/build_zlib.sh \
-                    -p zlib_prefix \
-                    -b v1.2.11 \
-                    -e "${extra_flags}" \
-                    -j ${max_jobs|$(grep -c proc /proc/cpuinfo)}
-        fi
-
-        if [ -n "${run_tests_against_baas|}" ]; then
-            set_cmake_var baas_vars REALM_ENABLE_AUTH_TESTS BOOL On
-            set_cmake_var baas_vars REALM_MONGODB_ENDPOINT STRING "http://localhost:9090"
-            set_cmake_var baas_vars REALM_STITCH_CONFIG PATH $(pwd)/test/object-store/mongodb/stitch.json
-        fi
-
-        if [ -n "${enable_asan|}" ]; then
-            set_cmake_var realm_vars REALM_ASAN BOOL On
-        fi
-
-        if [ -n "${enable_tsan|}" ]; then
-            set_cmake_var realm_vars REALM_TSAN BOOL On
-        fi
-
-        if [ -z "${disable_sync|}" ]; then
-            set_cmake_var realm_vars REALM_ENABLE_SYNC BOOL On
-        fi
-
-        if [ -n "${use_system_openssl|}" ]; then
-            set_cmake_var realm_vars REALM_USE_SYSTEM_OPENSSL BOOL On
-        fi
-
-        set_cmake_var realm_vars REALM_BUILD_COMMANDLINE_TOOLS BOOL On
-        set_cmake_var realm_vars REALM_ENABLE_ENCRYPTION BOOL On
-
-        if [[ -n "${fetch_missing_dependencies|}" ]]; then
-            set_cmake_var realm_vars REALM_FETCH_MISSING_DEPENDENCIES BOOL On
-        fi
-
-        echo "Running cmake with these vars:"
-        cat cmake_vars/*.txt | tee cmake_vars.txt
-        echo
-        
-        mkdir build
-        $CMAKE \
-          -B build \
-          -C cmake_vars.txt ${extra_flags} \
-          -G "${cmake_generator|Unix Makefiles}"
-
-        ${cmake_bindir}/cmake --build build -j ${max_jobs|$(grep -c proc /proc/cpuinfo)}
 - name: package
-  depends_on:
-  - "compile"
   commands:
+  - func: "compile"
   - command: shell.exec
     params:
       working_dir: realm-core
@@ -139,9 +152,8 @@ tasks:
       content_type: '${content_type|application/x-gzip}'
 
 - name: core-tests
-  depends_on:
-  - "compile"
   commands:
+  - func: "compile"
   - command: shell.exec
     params:
       working_dir: realm-core
@@ -152,10 +164,41 @@ tasks:
         cd build
         $CTEST -V -R StorageTests ${test_flags|}
 
-- name: sync-tests
-  depends_on:
-  - "compile"
+- name: benchmark-common-tasks
   commands:
+  - command: shell.exec
+    params:
+      working_dir: realm-core
+      shell: bash
+      script: |-
+        set -o errexit
+
+        mkdir bench_results
+        cd bench_results
+        ../build/test/benchmark-common-tasks/realm-benchmark-common-tasks
+  - command: perf.send
+    params:
+      file: ./realm-core/bench_results/results.latest.json
+
+- name: benchmark-crud
+  commands:
+  - command: shell.exec
+    params:
+      working_dir: realm-core
+      shell: bash
+      script: |-
+        set -o errexit
+
+        mkdir bench_results
+        cd bench_results
+        ../build/test/benchmark-crud/realm-benchmark-crud
+  - command: perf.send
+    params:
+      file: ./realm-core/bench_results/results.latest.json
+
+- name: sync-tests
+  commands:
+  - func: "compile"
   - command: shell.exec
     params:
       working_dir: realm-core
@@ -167,9 +210,8 @@ tasks:
         $CTEST -V -R SyncTests ${test_flags|}
 
 - name: object-store-tests
-  depends_on:
-  - "compile"
   commands:
+  - func: "compile"
   # If we need to start a local copy of baas, do it in the background here in a separate script.
   # Evergreen should take care of the lifetime of the processes we start here automatically.
   - command: shell.exec
@@ -269,7 +311,20 @@ task_groups:
   - core-tests
   - sync-tests
   - object-store-tests
- 
+
+- name: benchmarks
+  setup_group_can_fail_task: true
+  setup_group:
+  - func: "fetch source"
+  - func: "fetch binaries"
+  - func: "compile"
+    vars:
+      cmake_build_type: "Release"
+      target_to_build: "benchmarks"
+  tasks:
+  - benchmark-common-tasks
+  - benchmark-crud
+
 buildvariants:
 - name: ubuntu2004
   display_name: "Ubuntu 20.04 x86_64 (Clang 11)"

--- a/evergreen/config.yml
+++ b/evergreen/config.yml
@@ -111,6 +111,48 @@ functions:
               -j ${max_jobs|$(grep -c proc /proc/cpuinfo)} \
               --target ${target_to_build|}
 
+  "run benchmark":
+    - command: shell.exec
+      params:
+        working_dir: realm-core
+        shell: bash
+        script: |-
+          set -o errexit
+
+          if [[ -z "${path_to_benchmark}" ]]; then
+              echo "No path to benchmark specified."
+              exit 1
+          fi
+
+          BENCHMARK=$(./evergreen/abspath.sh ${path_to_benchmark})
+          echo "Going to run benchmark $BENCHMARK"
+
+          [[ -d benchmark_results ]] && rm -rf benchmark_results
+          mkdir benchmark_results
+          cd benchmark_results
+
+          $BENCHMARK
+    - command: perf.send
+      params:
+        file: './realm-core/benchmark_results/results.latest.json'
+
+  "run tests":
+    - command: shell.exec
+      params:
+        working_dir: realm-core
+        shell: bash
+        script: |-
+          set -o errexit
+          CTEST=$(pwd)/${cmake_bindir}/ctest
+
+          if [[ -n "${test_filter}" ]]; then
+              TEST_FLAGS="-R ${test_filter}"
+          fi
+          TETS_FLAGS="$TEST_FLAGS ${test_flags|}"
+
+          cd build
+          $CTEST -V $TEST_FLAGS
+
 tasks:
 - name: compile
   commands:
@@ -150,60 +192,30 @@ tasks:
 - name: core-tests
   commands:
   - func: "compile"
-  - command: shell.exec
-    params:
-      working_dir: realm-core
-      script: |-
-        set -o errexit
-        CTEST=$(pwd)/${cmake_bindir}/ctest
-
-        cd build
-        $CTEST -V -R StorageTests ${test_flags|}
+  - func: "run tests"
+    vars:
+      test_filter: StorageTests
 
 - name: benchmark-common-tasks
+  tags: [ "benchmark" ]
   commands:
-  - command: shell.exec
-    params:
-      working_dir: realm-core
-      shell: bash
-      script: |-
-        set -o errexit
-
-        mkdir ${task_name|benchmark}_results
-        cd ${task_name|benchmark}_results
-        ../build/test/benchmark-common-tasks/realm-benchmark-common-tasks
-  - command: perf.send
-    params:
-      file: ./realm-core/${task_name|benchmark}_results/results.latest.json
+  - func: "run benchmark"
+    vars:
+      path_to_benchmark: ./build/test/benchmark-common-tasks/realm-benchmark-common-tasks
 
 - name: benchmark-crud
+  tags: [ "benchmark" ]
   commands:
-  - command: shell.exec
-    params:
-      working_dir: realm-core
-      shell: bash
-      script: |-
-        set -o errexit
-
-        mkdir ${task_name|benchmark}_results
-        cd ${task_name|benchmark}_results
-        ../build/test/benchmark-crud/realm-benchmark-crud
-  - command: perf.send
-    params:
-      file: ./realm-core/${task_name|benchmark}_results/results.latest.json
+  - func: "run benchmark"
+    vars:
+      path_to_benchmark: ./build/test/benchmark-crud/realm-benchmark-crud
 
 - name: sync-tests
   commands:
   - func: "compile"
-  - command: shell.exec
-    params:
-      working_dir: realm-core
-      script: |-
-        set -o errexit
-        CTEST=$(pwd)/${cmake_bindir}/ctest
-
-        cd build
-        $CTEST -V -R SyncTests ${test_flags|}
+  - func: "run tests"
+    vars:
+      test_filter: SyncTests
 
 - name: object-store-tests
   commands:
@@ -249,11 +261,9 @@ tasks:
                 sleep 5
             done
         fi
-
-        CTEST=$(pwd)/${cmake_bindir}/ctest
-
-        cd build
-        $CTEST -V -R ObjectStoreTests ${test_flags|}
+  - func: "run tests"
+    vars:
+      test_filter: ObjectStoreTests
 
 - name: lint
   commands:
@@ -274,7 +284,7 @@ tasks:
         if [[ "$out" == *"no modified files to format"* ]]; then
             exit 0
         fi
-        if [[ "$out" == *"clang-format did not modify any files"* ]];
+        if [[ "$out" == *"clang-format did not modify any files"* ]]; then
             exit 0
         fi
 
@@ -318,8 +328,7 @@ task_groups:
       cmake_build_type: "Release"
       target_to_build: "benchmarks"
   tasks:
-  - benchmark-common-tasks
-  - benchmark-crud
+  - .benchmark
 
 buildvariants:
 - name: ubuntu2004
@@ -426,7 +435,7 @@ buildvariants:
 
 - name: windows-64-vs2019
   display_name: "Windows x86_64 (VS 2019)"
-  run_on: windows-64-vs2019-test 
+  run_on: windows-64-vs2019-test
   expansions:
     cmake_url: "https://s3.amazonaws.com/static.realm.io/evergreen-assets/cmake-3.19.1-win64-x64.zip"
     cmake_bindir: "./cmake-3.19.1-win64-x64/bin"

--- a/evergreen/config.yml
+++ b/evergreen/config.yml
@@ -338,6 +338,9 @@ buildvariants:
   - name: compile_test_and_package
     distros:
     - ubuntu2004-large
+  - name: benchmarks
+    distros:
+    - ubuntu2004-large
 
 - name: ubuntu2004-asan
   display_name: "Ubuntu 20.04 x86_64 (Clang 11 ASAN)"
@@ -401,6 +404,9 @@ buildvariants:
   - name: compile_test_and_package
     distros:
     - ubuntu2004-arm64-large
+  - name: benchmarks
+    distros:
+    - ubuntu2004-arm64-large
 
 - name: macos-1014
   display_name: "MacOS 10.14 x86_64"
@@ -412,6 +418,9 @@ buildvariants:
     run_tests_against_baas: On
   tasks:
   - name: compile_test_and_package
+    distros:
+    - macos-1014
+  - name: benchmarks
     distros:
     - macos-1014
 

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -6,6 +6,8 @@ if(NOT CMAKE_SYSTEM_NAME MATCHES "^Windows")
     add_subdirectory(fuzzy)
 endif()
 
+add_custom_target(benchmarks)
+
 add_subdirectory(benchmark-common-tasks)
 add_subdirectory(benchmark-crud)
 # FIXME: Add other benchmarks
@@ -129,6 +131,10 @@ file(GLOB REQUIRED_TEST_FILES
 
 add_executable(CoreTests ${CORE_TESTS} ${MAIN_FILE} ${REQUIRED_TEST_FILES} ${REALM_TEST_HEADERS})
 set_target_properties(CoreTests PROPERTIES OUTPUT_NAME "realm-tests")
+
+if (REALM_TEST_DURATION)
+  add_compile_definitions("TEST_DURATION=${REALM_TEST_DURATION}")
+endif()
 
 # Resources required for running the tests copied to the target directory
 if(CMAKE_GENERATOR STREQUAL Xcode)

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -132,10 +132,6 @@ file(GLOB REQUIRED_TEST_FILES
 add_executable(CoreTests ${CORE_TESTS} ${MAIN_FILE} ${REQUIRED_TEST_FILES} ${REALM_TEST_HEADERS})
 set_target_properties(CoreTests PROPERTIES OUTPUT_NAME "realm-tests")
 
-if (REALM_TEST_DURATION)
-  add_compile_definitions("TEST_DURATION=${REALM_TEST_DURATION}")
-endif()
-
 # Resources required for running the tests copied to the target directory
 if(CMAKE_GENERATOR STREQUAL Xcode)
     # a simple copy doesn't work for an Xcode build because Xcode also needs to sign them

--- a/test/benchmark-common-tasks/CMakeLists.txt
+++ b/test/benchmark-common-tasks/CMakeLists.txt
@@ -1,5 +1,6 @@
 add_executable(realm-benchmark-common-tasks main.cpp compatibility.cpp)
 target_link_libraries(realm-benchmark-common-tasks TestUtil)
+add_dependencies(benchmarks realm-benchmark-common-tasks)
 
 add_executable(realm-stats stats.cpp compatibility.cpp)
 target_link_libraries(realm-stats Storage)

--- a/test/benchmark-common-tasks/main.cpp
+++ b/test/benchmark-common-tasks/main.cpp
@@ -1889,7 +1889,7 @@ void run_benchmark(BenchmarkResults& results, bool force_full = false)
 
         benchmark.after_all(group);
 
-        results.finish(ident, lead_text_ss.str());
+        results.finish(ident, lead_text_ss.str(), "runtime_secs");
     }
     std::cout << std::endl;
 }
@@ -1901,7 +1901,7 @@ extern "C" int benchmark_common_tasks_main();
 int benchmark_common_tasks_main()
 {
     std::string results_file_stem = realm::test_util::get_test_path_prefix() + "results";
-    BenchmarkResults results(40, results_file_stem.c_str());
+    BenchmarkResults results(40, "benchmark-common-tasks", results_file_stem.c_str());
 
 #define BENCH(B) run_benchmark<B>(results)
 #define BENCH2(B, mode) run_benchmark<B>(results, mode)

--- a/test/benchmark-crud/CMakeLists.txt
+++ b/test/benchmark-crud/CMakeLists.txt
@@ -1,2 +1,3 @@
 add_executable(realm-benchmark-crud main.cpp)
+add_dependencies(benchmarks realm-benchmark-crud)
 target_link_libraries(realm-benchmark-crud TestUtil)

--- a/test/benchmark-crud/main.cpp
+++ b/test/benchmark-crud/main.cpp
@@ -148,7 +148,7 @@ int main()
     int_fast64_t dummy = 0;
 
     int max_lead_text_size = 26;
-    BenchmarkResults results(max_lead_text_size);
+    BenchmarkResults results(max_lead_text_size, "benchmark-crud");
 
     Timer timer_total(Timer::type_UserTime);
     Timer timer(Timer::type_UserTime);
@@ -161,7 +161,7 @@ int main()
             insert(tables_1[i], rising_order);
             results.submit(id, timer);
         }
-        results.finish(id, desc);
+        results.finish(id, desc, "runtime_secs");
 
         id = "read_sequential_compact";
         desc = "Sequential read (compact)";
@@ -170,7 +170,7 @@ int main()
             dummy += read(tables_1[i], rising_order);
             results.submit(id, timer);
         }
-        results.finish(id, desc);
+        results.finish(id, desc, "runtime_secs");
 
         id = "read_random_compact";
         desc = "Random read (compact)";
@@ -179,7 +179,7 @@ int main()
             dummy += read(tables_1[i], random_order);
             results.submit(id, timer);
         }
-        results.finish(id, desc);
+        results.finish(id, desc, "runtime_secs");
 
         id = "write_sequential_compact";
         desc = "Sequential write (compact)";
@@ -188,7 +188,7 @@ int main()
             write(tables_1[i], rising_order);
             results.submit(id, timer);
         }
-        results.finish(id, desc);
+        results.finish(id, desc, "runtime_secs");
 
         id = "write_random_compact";
         desc = "Random write (compact)";
@@ -197,7 +197,7 @@ int main()
             write(tables_1[i], random_order);
             results.submit(id, timer);
         }
-        results.finish(id, desc);
+        results.finish(id, desc, "runtime_secs");
 
         id = "erase_end_compact";
         desc = "Erase from end (compact)";
@@ -206,7 +206,7 @@ int main()
             erase(tables_1[i], falling_order);
             results.submit(id, timer);
         }
-        results.finish(id, desc);
+        results.finish(id, desc, "runtime_secs");
     }
 
     // Start again using a random order (generalized).
@@ -218,45 +218,45 @@ int main()
             insert(tables_2[i], random_insert_order);
             results.submit(id, timer);
         }
-        results.finish(id, desc);
+        results.finish(id, desc, "runtime_secs");
         id = "read_sequential_general";
         desc = "Sequential read (general)";
         for (int i = 0; i != num_tables; ++i) {
             dummy += read(tables_2[0], rising_order);
             results.submit(id, timer);
         }
-        results.finish(id, desc);
+        results.finish(id, desc, "runtime_secs");
         id = "read_random_general";
         desc = "Random read (general)";
         for (int i = 0; i != num_tables; ++i) {
             dummy += read(tables_2[0], random_order);
             results.submit(id, timer);
         }
-        results.finish(id, desc);
+        results.finish(id, desc, "runtime_secs");
         id = "write_sequential_general";
         desc = "Sequential write (general)";
         for (int i = 0; i != num_tables; ++i) {
             write(tables_2[i], rising_order);
             results.submit(id, timer);
         }
-        results.finish(id, desc);
+        results.finish(id, desc, "runtime_secs");
         id = "write_random_general";
         desc = "Random write (general)";
         for (int i = 0; i != num_tables; ++i) {
             write(tables_2[i], random_order);
             results.submit(id, timer);
         }
-        results.finish(id, desc);
+        results.finish(id, desc, "runtime_secs");
         id = "erase_random_general";
         desc = "Random erase (general)";
         for (int i = 0; i != num_tables; ++i) {
             erase(tables_2[i], random_erase_order);
             results.submit(id, timer);
         }
-        results.finish(id, desc);
+        results.finish(id, desc, "runtime_secs");
     }
 
-    results.submit_single("crud_total_time", "Total time", timer_total);
+    results.submit_single("crud_total_time", "Total time", "runtime_secs", timer_total);
 
     std::cout << "dummy = " << dummy << " (to avoid over-optimization)\n";
 }

--- a/test/object-store/benchmarks/CMakeLists.txt
+++ b/test/object-store/benchmarks/CMakeLists.txt
@@ -26,18 +26,18 @@ if(REALM_ENABLE_SYNC)
     )
 endif()
 
-add_executable(benchmarks ${SOURCES} ${HEADERS})
+add_executable(object-store-benchmarks ${SOURCES} ${HEADERS})
 
-target_include_directories(benchmarks PRIVATE 
+target_include_directories(object-store-benchmarks PRIVATE 
     ${CATCH_INCLUDE_DIR}
     ../util
 )
 
 if(REALM_ENABLE_SYNC)
-    target_link_libraries(benchmarks SyncServer)
+    target_link_libraries(object-store-benchmarks SyncServer)
 endif()
 
-target_link_libraries(benchmarks ObjectStore)
-set_target_properties(benchmarks PROPERTIES
+target_link_libraries(object-store-benchmarks ObjectStore)
+set_target_properties(object-store-benchmarks PROPERTIES
       EXCLUDE_FROM_ALL 1
       EXCLUDE_FROM_DEFAULT_BUILD 1)

--- a/test/test_query.cpp
+++ b/test/test_query.cpp
@@ -2521,8 +2521,10 @@ TEST(Query_Huge)
     for (int N = 0; N < 100; N++) {
 #elif TEST_DURATION == 2
     for (int N = 0; N < 1000; N++) {
-#elif TEST_DURATION == 3
+#elif TEST_DURATION >= 3
     for (int N = 0; N < 10000; N++) {
+#else
+#error("TEST_DURATION must be 0 >= TEST_DURATION <= 3")
 #endif
 
         // Makes you reproduce a bug in a certain run, without having

--- a/test/test_query.cpp
+++ b/test/test_query.cpp
@@ -2521,10 +2521,8 @@ TEST(Query_Huge)
     for (int N = 0; N < 100; N++) {
 #elif TEST_DURATION == 2
     for (int N = 0; N < 1000; N++) {
-#elif TEST_DURATION >= 3
+#elif TEST_DURATION == 3
     for (int N = 0; N < 10000; N++) {
-#else
-#error("TEST_DURATION must be 0 >= TEST_DURATION <= 3")
 #endif
 
         // Makes you reproduce a bug in a certain run, without having

--- a/test/util/benchmark_results.hpp
+++ b/test/util/benchmark_results.hpp
@@ -75,7 +75,8 @@ private:
 
 // Implementation:
 
-inline BenchmarkResults::BenchmarkResults(int max_lead_text_width, std::string suite_name, const char* results_file_stem)
+inline BenchmarkResults::BenchmarkResults(int max_lead_text_width, std::string suite_name,
+                                          const char* results_file_stem)
     : m_max_lead_text_width(max_lead_text_width)
     , m_results_file_stem(results_file_stem)
     , m_suite_name(std::move(suite_name))

--- a/test/util/benchmark_results.hpp
+++ b/test/util/benchmark_results.hpp
@@ -29,25 +29,20 @@ namespace test_util {
 
 class BenchmarkResults {
 public:
-    BenchmarkResults(int max_lead_text_width, const char* results_file_stem = "results");
+    BenchmarkResults(int max_lead_text_width, std::string suite_name, const char* results_file_stem = "results");
     ~BenchmarkResults();
 
-    enum ChangeType {
-        change_Percent,
-        change_DropFactor,
-        change_RiseFactor,
-    };
-
     /// Use submit_single() when you know there is only going to be a single datapoint.
-    void submit_single(const char* ident, const char* lead_text, double seconds, ChangeType = change_Percent);
+    void submit_single(const char* ident, const char* lead_text, std::string measurement_type, double seconds);
 
     /// Use submit() when there are multiple data points, and call finish() when you are done.
     void submit(const char* ident, double seconds);
-    void finish(const std::string& ident, const std::string& lead_text, ChangeType = change_Percent);
+    void finish(const std::string& ident, const std::string& lead_text, std::string measurement_type);
 
 private:
     int m_max_lead_text_width;
     std::string m_results_file_stem;
+    std::string m_suite_name;
 
     struct Result {
         Result();
@@ -63,6 +58,7 @@ private:
 
     struct Measurement {
         std::vector<double> samples;
+        std::string type;
 
         Result finish() const;
     };
@@ -79,9 +75,10 @@ private:
 
 // Implementation:
 
-inline BenchmarkResults::BenchmarkResults(int max_lead_text_width, const char* results_file_stem)
+inline BenchmarkResults::BenchmarkResults(int max_lead_text_width, std::string suite_name, const char* results_file_stem)
     : m_max_lead_text_width(max_lead_text_width)
     , m_results_file_stem(results_file_stem)
+    , m_suite_name(std::move(suite_name))
 {
     try_load_baseline_results();
 }


### PR DESCRIPTION
This refactors the evergreen config a bit and adds tasks that run a few of the benchmarks and uploads their results to evergreen. I also updated the benchmark_results infrastructure to output results in a format evergreen understands.