### PR TITLE
Add missing return in empty-line case of watch() decoder

### DIFF
--- a/src/realm/object-store/sync/mongo_collection.cpp
+++ b/src/realm/object-store/sync/mongo_collection.cpp
@@ -516,6 +516,7 @@ void WatchStream::feed_line(std::string_view line)
         feed_sse({m_data_buffer, m_event_type});
         m_data_buffer.clear();
         m_event_type.clear();
+        return;
     }
 
     if (line[0] == ':')

--- a/test/object-store/sync/remote_mongo_tests.cpp
+++ b/test/object-store/sync/remote_mongo_tests.cpp
@@ -299,6 +299,16 @@ TEST_CASE("WatchStream line processing", "[mongo]") {
         CHECK(Bson(ws.next_event()) == bson::parse(R"({"a": 1})"));
         CHECK(ws.state() == WatchStream::NEED_DATA);
     }
+    SECTION("with null string_view") {
+        ws.feed_line(R"(event: message)");
+        REQ_ND;
+        ws.feed_line(R"(data: {"a": 1})");
+        REQ_ND;
+        ws.feed_line(std::string_view());
+        REQUIRE(ws.state() == WatchStream::HAVE_EVENT);
+        CHECK(Bson(ws.next_event()) == bson::parse(R"({"a": 1})"));
+        CHECK(ws.state() == WatchStream::NEED_DATA);
+    }
     SECTION("no space") {
         ws.feed_line(R"(event:message)");
         REQ_ND;


### PR DESCRIPTION
This was actually mostly harmless because real consumers wouldn't actually
pass in a null string_view, or one where reading from line[0] would trap, and
the later lines of the function are no-ops for an empty line. However, the
read of line[0] triggered an assert in a debug build with MS STL string_view,
which is how this was found.

<!--
 Make sure to assign one and only one Type (`T:`) label.
 Select reviewers if ready for review. Our bot will automatically assign you.
 -->

## What, How & Why?
<!-- Describe the changes and give some hints to guide your reviewers if possible. -->
<!-- Link (via zenhub) to relevant issue this fixes -->

## ☑️ ToDos
* ~[ ] 📝 Changelog update~ (Doesn't have any user-facing impact)
* [x] 🚦 Tests (or not relevant)
