### PR TITLE
Fix a race condition in notifier initialization

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@
 
 ### Fixed
 * <How to hit and notice issue? what was the impact?> ([#????](https://github.com/realm/realm-core/issues/????), since v?.?.?)
-* None.
+* Fix a race condition which would lead to "uncaught exception in notifier thread: N5realm15InvalidTableRefE: transaction_ended" and a crash when the source Realm was closed or invalidated at a very specific time during the first run of a collection notifier ([#3761](https://github.com/realm/realm-core/issues/3761), since v6.0.0).
  
 ### Breaking changes
 * None.

--- a/src/realm/db.hpp
+++ b/src/realm/db.hpp
@@ -213,6 +213,7 @@ public:
 
     /// Returns the version of the latest snapshot.
     version_type get_version_of_latest_snapshot();
+    VersionID get_version_id_of_latest_snapshot();
 
     /// Thrown by start_read() if the specified version does not correspond to a
     /// bound (AKA tethered) snapshot.

--- a/src/realm/object-store/impl/list_notifier.cpp
+++ b/src/realm/object-store/impl/list_notifier.cpp
@@ -52,12 +52,13 @@ void ListNotifier::do_attach_to(Transaction& sg)
         m_list = obj.get_listbase_ptr(m_col);
     }
     catch (const KeyNotFound&) {
+        m_list = nullptr;
     }
 }
 
 bool ListNotifier::do_add_required_change_info(TransactionChangeInfo& info)
 {
-    if (!m_list->is_attached())
+    if (!m_list || !m_list->is_attached())
         return false; // origin row was deleted after the notification was added
 
     info.lists.push_back({m_table, m_obj.value, m_col.value, &m_change});
@@ -68,7 +69,7 @@ bool ListNotifier::do_add_required_change_info(TransactionChangeInfo& info)
 
 void ListNotifier::run()
 {
-    if (!m_list->is_attached()) {
+    if (!m_list || !m_list->is_attached()) {
         // List was deleted, so report all of the rows being removed if this is
         // the first run after that
         if (m_prev_size) {

--- a/src/realm/object-store/impl/realm_coordinator.hpp
+++ b/src/realm/object-store/impl/realm_coordinator.hpp
@@ -230,10 +230,6 @@ private:
     // Will have a read transaction iff m_notifiers is non-empty
     std::shared_ptr<Transaction> m_notifier_sg;
 
-    // Transaction used to advance notifiers in m_new_notifiers to the main shared
-    // group's transaction version
-    // Will have a read transaction iff m_new_notifiers is non-empty
-    std::shared_ptr<Transaction> m_advancer_sg;
     std::exception_ptr m_async_error;
 
     std::unique_ptr<_impl::ExternalCommitHelper> m_notifier;
@@ -247,8 +243,6 @@ private:
     std::shared_ptr<AuditInterface> m_audit_context;
 
     void open_db();
-
-    void pin_version(VersionID version) REQUIRES(m_notifier_mutex);
 
     void set_config(const Realm::Config&) REQUIRES(m_realm_mutex, !m_schema_cache_mutex);
     void create_sync_session(bool force_client_resync);


### PR DESCRIPTION
Newly created notifiers copied their Query from the source Realm on the worker thread without locking the source Realm, which could race with things that invalidated the source Realm.

To fix this, switch to copying the required data to a temporary Transaction owned by the notifier while still on the source thread. This increases the amount of work done on the source thread to create a notifier (as it has to create a new Transaction each time), but eliminates the need to hold the lock while parsing the transaction logs for new notifiers, so it may turn out to be a net reduction in main-thread blockage.

Fixes https://github.com/realm/realm-core/issues/3761.