### PR TITLE
C API: Simplify key types, rename to high-level concepts

### DIFF
--- a/src/realm/object-store/c_api/conversion.hpp
+++ b/src/realm/object-store/c_api/conversion.hpp
@@ -76,44 +76,14 @@ static inline ObjectId from_capi(realm_object_id_t)
     REALM_TERMINATE("Not implemented yet.");
 }
 
-static inline realm_col_key_t to_capi(ColKey key)
-{
-    return realm_col_key_t{key.value};
-}
-
-static inline ColKey from_capi(realm_col_key_t key)
-{
-    return ColKey{key.col_key};
-}
-
-static inline realm_table_key_t to_capi(TableKey key)
-{
-    return realm_table_key_t{key.value};
-}
-
-static inline TableKey from_capi(realm_table_key_t key)
-{
-    return TableKey{key.table_key};
-}
-
-static inline realm_obj_key_t to_capi(ObjKey key)
-{
-    return realm_obj_key_t{key.value};
-}
-
-static inline ObjKey from_capi(realm_obj_key_t key)
-{
-    return ObjKey{key.obj_key};
-}
-
 static inline ObjLink from_capi(realm_link_t val)
 {
-    return ObjLink{from_capi(val.target_table), from_capi(val.target)};
+    return ObjLink{TableKey(val.target_table), ObjKey(val.target)};
 }
 
 static inline realm_link_t to_capi(ObjLink link)
 {
-    return realm_link_t{to_capi(link.get_table_key()), to_capi(link.get_obj_key())};
+    return realm_link_t{link.get_table_key().value, link.get_obj_key().value};
 }
 
 static inline UUID from_capi(realm_uuid_t val)
@@ -156,7 +126,7 @@ static inline Mixed from_capi(realm_value_t val)
         case RLM_TYPE_OBJECT_ID:
             return Mixed{from_capi(val.object_id)};
         case RLM_TYPE_LINK:
-            return Mixed{ObjLink{from_capi(val.link.target_table), from_capi(val.link.target)}};
+            return Mixed{ObjLink{TableKey(val.link.target_table), ObjKey(val.link.target)}};
         case RLM_TYPE_UUID:
             return Mixed{UUID{from_capi(val.uuid)}};
     }
@@ -222,8 +192,8 @@ static inline realm_value_t to_capi(Mixed value)
             case type_TypedLink: {
                 val.type = RLM_TYPE_LINK;
                 auto link = value.get<ObjLink>();
-                val.link.target_table = to_capi(link.get_table_key());
-                val.link.target = to_capi(link.get_obj_key());
+                val.link.target_table = link.get_table_key().value;
+                val.link.target = link.get_obj_key().value;
                 break;
             }
             case type_UUID: {
@@ -406,7 +376,7 @@ static inline realm_property_info_t to_capi(const Property& prop) noexcept
     if (bool(prop.type & PropertyType::Dictionary))
         p.collection_type = RLM_COLLECTION_TYPE_DICTIONARY;
 
-    p.key = to_capi(prop.column_key);
+    p.key = prop.column_key.value;
 
     return p;
 }
@@ -418,7 +388,7 @@ static inline realm_class_info_t to_capi(const ObjectSchema& o)
     info.primary_key = o.primary_key.c_str();
     info.num_properties = o.persisted_properties.size();
     info.num_computed_properties = o.computed_properties.size();
-    info.key = to_capi(o.table_key);
+    info.key = o.table_key.value;
     if (o.is_embedded) {
         info.flags = RLM_CLASS_EMBEDDED;
     }

--- a/src/realm/object-store/c_api/notifications.cpp
+++ b/src/realm/object-store/c_api/notifications.cpp
@@ -92,7 +92,7 @@ RLM_API size_t realm_object_changes_get_num_modified_properties(const realm_obje
 }
 
 RLM_API size_t realm_object_changes_get_modified_properties(const realm_object_changes_t* changes,
-                                                            realm_col_key_t* out_properties, size_t max)
+                                                            realm_property_key_t* out_properties, size_t max)
 {
     if (!out_properties)
         return changes->columns.size();
@@ -102,7 +102,7 @@ RLM_API size_t realm_object_changes_get_modified_properties(const realm_object_c
         if (i >= max) {
             break;
         }
-        out_properties[i].col_key = col_key_val;
+        out_properties[i] = col_key_val;
         ++i;
     }
     return i;

--- a/src/realm/object-store/c_api/query.cpp
+++ b/src/realm/object-store/c_api/query.cpp
@@ -141,11 +141,11 @@ static void parse_and_apply_query(const std::shared_ptr<Realm>& realm, Query& q,
     query_builder::apply_ordering(ordering, q.get_table(), parser_result.ordering, mapping);
 }
 
-RLM_API realm_query_t* realm_query_parse(const realm_t* realm, realm_table_key_t target_table_key,
+RLM_API realm_query_t* realm_query_parse(const realm_t* realm, realm_class_key_t target_table_key,
                                          const char* query_string, size_t num_args, const realm_value_t* args)
 {
     return wrap_err([&]() {
-        auto table = (*realm)->read_group().get_table(from_capi(target_table_key));
+        auto table = (*realm)->read_group().get_table(TableKey(target_table_key));
         auto query = table->where();
         DescriptorOrdering ordering;
         parse_and_apply_query(*realm, query, ordering, query_string, num_args, args);
@@ -229,8 +229,8 @@ RLM_API bool realm_results_get(realm_results_t* results, size_t index, realm_val
         auto obj_key = obj.get_key();
         if (out_value) {
             out_value->type = RLM_TYPE_LINK;
-            out_value->link.target_table = to_capi(table_key);
-            out_value->link.target = to_capi(obj_key);
+            out_value->link.target_table = table_key.value;
+            out_value->link.target = obj_key.value;
         }
         return true;
     });
@@ -255,11 +255,11 @@ RLM_API bool realm_results_delete_all(realm_results_t* results)
     });
 }
 
-RLM_API bool realm_results_min(realm_results_t* results, realm_col_key_t col, realm_value_t* out_value,
+RLM_API bool realm_results_min(realm_results_t* results, realm_property_key_t col, realm_value_t* out_value,
                                bool* out_found)
 {
     return wrap_err([&]() {
-        if (auto x = results->min(from_capi(col))) {
+        if (auto x = results->min(ColKey(col))) {
             if (out_found) {
                 *out_found = true;
             }
@@ -279,11 +279,11 @@ RLM_API bool realm_results_min(realm_results_t* results, realm_col_key_t col, re
     });
 }
 
-RLM_API bool realm_results_max(realm_results_t* results, realm_col_key_t col, realm_value_t* out_value,
+RLM_API bool realm_results_max(realm_results_t* results, realm_property_key_t col, realm_value_t* out_value,
                                bool* out_found)
 {
     return wrap_err([&]() {
-        if (auto x = results->max(from_capi(col))) {
+        if (auto x = results->max(ColKey(col))) {
             if (out_found) {
                 *out_found = true;
             }
@@ -303,11 +303,11 @@ RLM_API bool realm_results_max(realm_results_t* results, realm_col_key_t col, re
     });
 }
 
-RLM_API bool realm_results_sum(realm_results_t* results, realm_col_key_t col, realm_value_t* out_value,
+RLM_API bool realm_results_sum(realm_results_t* results, realm_property_key_t col, realm_value_t* out_value,
                                bool* out_found)
 {
     return wrap_err([&]() {
-        if (auto x = results->sum(from_capi(col))) {
+        if (auto x = results->sum(ColKey(col))) {
             if (out_found) {
                 *out_found = true;
             }
@@ -327,11 +327,11 @@ RLM_API bool realm_results_sum(realm_results_t* results, realm_col_key_t col, re
     });
 }
 
-RLM_API bool realm_results_average(realm_results_t* results, realm_col_key_t col, realm_value_t* out_value,
+RLM_API bool realm_results_average(realm_results_t* results, realm_property_key_t col, realm_value_t* out_value,
                                    bool* out_found)
 {
     return wrap_err([&]() {
-        if (auto x = results->average(from_capi(col))) {
+        if (auto x = results->average(ColKey(col))) {
             if (out_found) {
                 *out_found = true;
             }

--- a/src/realm/object-store/c_api/schema.cpp
+++ b/src/realm/object-store/c_api/schema.cpp
@@ -63,7 +63,7 @@ RLM_API size_t realm_get_num_classes(const realm_t* realm)
     return n;
 }
 
-RLM_API bool realm_get_class_keys(const realm_t* realm, realm_table_key_t* out_keys, size_t max, size_t* out_n)
+RLM_API bool realm_get_class_keys(const realm_t* realm, realm_class_key_t* out_keys, size_t max, size_t* out_n)
 {
     return wrap_err([&]() {
         const auto& shared_realm = **realm;
@@ -73,7 +73,7 @@ RLM_API bool realm_get_class_keys(const realm_t* realm, realm_table_key_t* out_k
             for (auto& os : schema) {
                 if (i >= max)
                     break;
-                out_keys[i++] = to_capi(os.table_key);
+                out_keys[i++] = os.table_key.value;
             }
             if (out_n)
                 *out_n = i;
@@ -107,7 +107,7 @@ RLM_API bool realm_find_class(const realm_t* realm, const char* name, bool* out_
     });
 }
 
-RLM_API bool realm_get_class(const realm_t* realm, realm_table_key_t key, realm_class_info_t* out_class_info)
+RLM_API bool realm_get_class(const realm_t* realm, realm_class_key_t key, realm_class_info_t* out_class_info)
 {
     return wrap_err([&]() {
         auto& os = schema_for_table(realm, key);
@@ -116,7 +116,7 @@ RLM_API bool realm_get_class(const realm_t* realm, realm_table_key_t key, realm_
     });
 }
 
-RLM_API bool realm_get_class_properties(const realm_t* realm, realm_table_key_t key,
+RLM_API bool realm_get_class_properties(const realm_t* realm, realm_class_key_t key,
                                         realm_property_info_t* out_properties, size_t max, size_t* out_n)
 {
     return wrap_err([&]() {
@@ -150,7 +150,7 @@ RLM_API bool realm_get_class_properties(const realm_t* realm, realm_table_key_t 
     });
 }
 
-RLM_API bool realm_get_property_keys(const realm_t* realm, realm_table_key_t key, realm_col_key_t* out_keys,
+RLM_API bool realm_get_property_keys(const realm_t* realm, realm_class_key_t key, realm_property_key_t* out_keys,
                                      size_t max, size_t* out_n)
 {
     return wrap_err([&]() {
@@ -162,13 +162,13 @@ RLM_API bool realm_get_property_keys(const realm_t* realm, realm_table_key_t key
             for (auto& prop : os.persisted_properties) {
                 if (i >= max)
                     break;
-                out_keys[i++] = to_capi(prop.column_key);
+                out_keys[i++] = prop.column_key.value;
             }
 
             for (auto& prop : os.computed_properties) {
                 if (i >= max)
                     break;
-                out_keys[i++] = to_capi(prop.column_key);
+                out_keys[i++] = prop.column_key.value;
             }
 
             if (out_n) {
@@ -184,12 +184,12 @@ RLM_API bool realm_get_property_keys(const realm_t* realm, realm_table_key_t key
     });
 }
 
-RLM_API bool realm_get_property(const realm_t* realm, realm_table_key_t class_key, realm_col_key_t key,
+RLM_API bool realm_get_property(const realm_t* realm, realm_class_key_t class_key, realm_property_key_t key,
                                 realm_property_info_t* out_property_info)
 {
     return wrap_err([&]() {
         auto& os = schema_for_table(realm, class_key);
-        auto col_key = from_capi(key);
+        auto col_key = ColKey(key);
 
         // FIXME: We can do better than linear search.
 
@@ -212,7 +212,7 @@ RLM_API bool realm_get_property(const realm_t* realm, realm_table_key_t class_ke
     });
 }
 
-RLM_API bool realm_find_property(const realm_t* realm, realm_table_key_t class_key, const char* name, bool* out_found,
+RLM_API bool realm_find_property(const realm_t* realm, realm_class_key_t class_key, const char* name, bool* out_found,
                                  realm_property_info_t* out_property_info)
 {
     return wrap_err([&]() {
@@ -234,7 +234,7 @@ RLM_API bool realm_find_property(const realm_t* realm, realm_table_key_t class_k
     });
 }
 
-RLM_API bool realm_find_property_by_public_name(const realm_t* realm, realm_table_key_t class_key,
+RLM_API bool realm_find_property_by_public_name(const realm_t* realm, realm_class_key_t class_key,
                                                 const char* public_name, bool* out_found,
                                                 realm_property_info_t* out_property_info)
 {

--- a/src/realm/object-store/c_api/util.hpp
+++ b/src/realm/object-store/c_api/util.hpp
@@ -45,9 +45,9 @@ static inline const T& cast_ref(const void* ptr)
     return *cast_ptr<T>(ptr);
 }
 
-static inline const ObjectSchema& schema_for_table(const std::shared_ptr<Realm>& realm, realm_table_key_t key)
+static inline const ObjectSchema& schema_for_table(const std::shared_ptr<Realm>& realm, realm_class_key_t key)
 {
-    auto table_key = from_capi(key);
+    auto table_key = TableKey(key);
 
     // Validate the table key.
     realm->read_group().get_table(table_key);
@@ -64,7 +64,7 @@ static inline const ObjectSchema& schema_for_table(const std::shared_ptr<Realm>&
     throw std::logic_error{"Class not in schema"};
 }
 
-static inline const ObjectSchema& schema_for_table(const realm_t* realm, realm_table_key_t key)
+static inline const ObjectSchema& schema_for_table(const realm_t* realm, realm_class_key_t key)
 {
     auto& shared_realm = *realm;
     return schema_for_table(shared_realm, key);

--- a/src/realm/realm.h
+++ b/src/realm/realm.h
@@ -71,22 +71,14 @@ typedef enum realm_schema_mode {
 } realm_schema_mode_e;
 
 /* Key types */
-typedef struct realm_table_key {
-    uint32_t table_key;
-} realm_table_key_t;
+typedef uint32_t realm_class_key_t;
+typedef int64_t realm_property_key_t;
+typedef int64_t realm_object_key_t;
+typedef uint64_t realm_version_t;
 
-typedef struct realm_col_key {
-    int64_t col_key;
-} realm_col_key_t;
-
-typedef struct realm_obj_key {
-    int64_t obj_key;
-} realm_obj_key_t;
-
-typedef struct realm_version {
-    uint64_t version;
-} realm_version_t;
-
+static const realm_class_key_t RLM_INVALID_CLASS_KEY = ((uint32_t)-1) >> 1;
+static const realm_property_key_t RLM_INVALID_PROPERTY_KEY = -1;
+static const realm_object_key_t RLM_INVALID_OBJECT_KEY = -1;
 
 /* Value types */
 
@@ -125,8 +117,8 @@ typedef struct realm_decimal128 {
 } realm_decimal128_t;
 
 typedef struct realm_link {
-    realm_table_key_t target_table;
-    realm_obj_key_t target;
+    realm_class_key_t target_table;
+    realm_object_key_t target;
 } realm_link_t;
 
 typedef struct realm_object_id {
@@ -265,7 +257,7 @@ typedef struct realm_property_info {
 
     const char* link_target;
     const char* link_origin_property_name;
-    realm_col_key_t key;
+    realm_property_key_t key;
     int flags;
 } realm_property_info_t;
 
@@ -274,7 +266,7 @@ typedef struct realm_class_info {
     const char* primary_key;
     size_t num_properties;
     size_t num_computed_properties;
-    realm_table_key_t key;
+    realm_class_key_t key;
     int flags;
 } realm_class_info_t;
 
@@ -815,7 +807,7 @@ RLM_API bool realm_compact(realm_t*, bool* did_compact);
  *
  * Note: This function does not validate the schema.
  *
- * Note: `realm_table_key_t` and `realm_col_key_t` values inside
+ * Note: `realm_class_key_t` and `realm_property_key_t` values inside
  *       `realm_class_info_t` and `realm_property_info_t` are unused when
  *       defining the schema. Call `realm_get_schema()` to obtain the values for
  *       these fields in an open realm.
@@ -868,7 +860,7 @@ RLM_API size_t realm_get_num_classes(const realm_t*);
  * @param out_n The actual number of classes. May be NULL.
  * @return True if no exception occurred.
  */
-RLM_API bool realm_get_class_keys(const realm_t*, realm_table_key_t* out_keys, size_t max, size_t* out_n);
+RLM_API bool realm_get_class_keys(const realm_t*, realm_class_key_t* out_keys, size_t max, size_t* out_n);
 
 /**
  * Find a by the name of @a name.
@@ -894,7 +886,7 @@ RLM_API bool realm_find_class(const realm_t*, const char* name, bool* out_found,
  *                       NULL, though that's kind of pointless.
  * @return True if no exception occurred.
  */
-RLM_API bool realm_get_class(const realm_t*, realm_table_key_t key, realm_class_info_t* out_class_info);
+RLM_API bool realm_get_class(const realm_t*, realm_class_key_t key, realm_class_info_t* out_class_info);
 
 /**
  * Get the list of properties for the class with this @a key.
@@ -911,7 +903,7 @@ RLM_API bool realm_get_class(const realm_t*, realm_table_key_t key, realm_class_
  * @param out_n The actual number of properties written to `out_properties`.
  * @return True if no exception occurred.
  */
-RLM_API bool realm_get_class_properties(const realm_t*, realm_table_key_t key, realm_property_info_t* out_properties,
+RLM_API bool realm_get_class_properties(const realm_t*, realm_class_key_t key, realm_property_info_t* out_properties,
                                         size_t max, size_t* out_n);
 
 /**
@@ -926,8 +918,8 @@ RLM_API bool realm_get_class_properties(const realm_t*, realm_table_key_t key, r
  * @param out_n The actual number of properties written to `out_col_keys` (if
  *              non-NULL), or number of properties in the class.
  **/
-RLM_API bool realm_get_property_keys(const realm_t*, realm_table_key_t key, realm_col_key_t* out_col_keys, size_t max,
-                                     size_t* out_n);
+RLM_API bool realm_get_property_keys(const realm_t*, realm_class_key_t key, realm_property_key_t* out_col_keys,
+                                     size_t max, size_t* out_n);
 
 
 /**
@@ -941,7 +933,7 @@ RLM_API bool realm_get_property_keys(const realm_t*, realm_table_key_t key, real
  *                          populated with information about the property.
  * @return True if no exception occurred.
  */
-RLM_API bool realm_get_property(const realm_t*, realm_table_key_t class_key, realm_col_key_t key,
+RLM_API bool realm_get_property(const realm_t*, realm_class_key_t class_key, realm_property_key_t key,
                                 realm_property_info_t* out_property_info);
 
 /**
@@ -956,7 +948,7 @@ RLM_API bool realm_get_property(const realm_t*, realm_table_key_t class_key, rea
  *                          be NULL.
  * @return True if no exception occurred.
  */
-RLM_API bool realm_find_property(const realm_t*, realm_table_key_t class_key, const char* name, bool* out_found,
+RLM_API bool realm_find_property(const realm_t*, realm_class_key_t class_key, const char* name, bool* out_found,
                                  realm_property_info_t* out_property_info);
 
 /**
@@ -971,7 +963,7 @@ RLM_API bool realm_find_property(const realm_t*, realm_table_key_t class_key, co
  *                          be NULL.
  * @return True if no exception occurred.
  */
-RLM_API bool realm_find_property_by_public_name(const realm_t*, realm_table_key_t class_key, const char* public_name,
+RLM_API bool realm_find_property_by_public_name(const realm_t*, realm_class_key_t class_key, const char* public_name,
                                                 bool* out_found, realm_property_info_t* out_property_info);
 
 /**
@@ -985,7 +977,7 @@ RLM_API bool realm_find_property_by_public_name(const realm_t*, realm_table_key_
  *                          was found. May be NULL.
  * @return True if no exception occurred.
  */
-RLM_API bool realm_find_primary_key_property(const realm_t*, realm_table_key_t class_key, bool* out_found,
+RLM_API bool realm_find_primary_key_property(const realm_t*, realm_class_key_t class_key, bool* out_found,
                                              realm_property_info_t* out_property_info);
 
 /**
@@ -995,7 +987,7 @@ RLM_API bool realm_find_primary_key_property(const realm_t*, realm_table_key_t c
  *                  objects, if successful.
  * @return True if the table key was valid for this realm.
  */
-RLM_API bool realm_get_num_objects(const realm_t*, realm_table_key_t, size_t* out_count);
+RLM_API bool realm_get_num_objects(const realm_t*, realm_class_key_t, size_t* out_count);
 
 /**
  * Get an object with a particular object key.
@@ -1005,7 +997,7 @@ RLM_API bool realm_get_num_objects(const realm_t*, realm_table_key_t, size_t* ou
  *                considered an error.
  * @return A non-NULL pointer if no exception occurred.
  */
-RLM_API realm_object_t* realm_get_object(const realm_t*, realm_table_key_t class_key, realm_obj_key_t obj_key);
+RLM_API realm_object_t* realm_get_object(const realm_t*, realm_class_key_t class_key, realm_object_key_t obj_key);
 
 /**
  * Find an object with a particular primary key value.
@@ -1014,7 +1006,7 @@ RLM_API realm_object_t* realm_get_object(const realm_t*, realm_table_key_t class
  *                  no error occurred.
  * @return A non-NULL pointer if the object was found and no exception occurred.
  */
-RLM_API realm_object_t* realm_object_find_with_primary_key(const realm_t*, realm_table_key_t, realm_value_t pk,
+RLM_API realm_object_t* realm_object_find_with_primary_key(const realm_t*, realm_class_key_t, realm_value_t pk,
                                                            bool* out_found);
 
 /**
@@ -1022,14 +1014,14 @@ RLM_API realm_object_t* realm_object_find_with_primary_key(const realm_t*, realm
  *
  * @return A non-NULL pointer if the object was created successfully.
  */
-RLM_API realm_object_t* realm_object_create(realm_t*, realm_table_key_t);
+RLM_API realm_object_t* realm_object_create(realm_t*, realm_class_key_t);
 
 /**
  * Create an object in a class with a primary key.
  *
  * @return A non-NULL pointer if the object was created successfully.
  */
-RLM_API realm_object_t* realm_object_create_with_primary_key(realm_t*, realm_table_key_t, realm_value_t pk);
+RLM_API realm_object_t* realm_object_create_with_primary_key(realm_t*, realm_class_key_t, realm_value_t pk);
 
 /**
  * Delete a realm object.
@@ -1056,14 +1048,14 @@ RLM_API bool realm_object_is_valid(const realm_object_t*);
  *
  * This function cannot fail.
  */
-RLM_API realm_obj_key_t realm_object_get_key(const realm_object_t* object);
+RLM_API realm_object_key_t realm_object_get_key(const realm_object_t* object);
 
 /**
  * Get the table for this object.
  *
  * This function cannot fail.
  */
-RLM_API realm_table_key_t realm_object_get_table(const realm_object_t* object);
+RLM_API realm_class_key_t realm_object_get_table(const realm_object_t* object);
 
 /**
  * Get a `realm_link_t` representing a link to @a object.
@@ -1094,7 +1086,7 @@ RLM_API realm_object_t* realm_object_from_thread_safe_reference(const realm_t*, 
  *
  * @return True if no exception occurred.
  */
-RLM_API bool realm_get_value(const realm_object_t*, realm_col_key_t, realm_value_t* out_value);
+RLM_API bool realm_get_value(const realm_object_t*, realm_property_key_t, realm_value_t* out_value);
 
 /**
  * Get the values for several properties.
@@ -1117,7 +1109,7 @@ RLM_API bool realm_get_value(const realm_object_t*, realm_col_key_t, realm_value
  *                   NULL.
  * @return True if no exception occurs.
  */
-RLM_API bool realm_get_values(const realm_object_t*, size_t num_values, const realm_col_key_t* properties,
+RLM_API bool realm_get_values(const realm_object_t*, size_t num_values, const realm_property_key_t* properties,
                               realm_value_t* out_values);
 
 /**
@@ -1129,7 +1121,7 @@ RLM_API bool realm_get_values(const realm_object_t*, size_t num_values, const re
  *                   non-sync'ed realms.
  * @return True if no exception occurred.
  */
-RLM_API bool realm_set_value(realm_object_t*, realm_col_key_t, realm_value_t new_value, bool is_default);
+RLM_API bool realm_set_value(realm_object_t*, realm_property_key_t, realm_value_t new_value, bool is_default);
 
 /**
  * Set the values for several properties.
@@ -1157,7 +1149,7 @@ RLM_API bool realm_set_value(realm_object_t*, realm_col_key_t, realm_value_t new
  *                   non-sync'ed realms.
  * @return True if no exception occurred.
  */
-RLM_API bool realm_set_values(realm_object_t*, size_t num_values, const realm_col_key_t* properties,
+RLM_API bool realm_set_values(realm_object_t*, size_t num_values, const realm_property_key_t* properties,
                               const realm_value_t* values, bool is_default);
 
 /**
@@ -1167,7 +1159,7 @@ RLM_API bool realm_set_values(realm_object_t*, size_t num_values, const realm_co
  *
  * @return A non-null pointer if no exception occurred.
  */
-RLM_API realm_list_t* realm_get_list(realm_object_t*, realm_col_key_t);
+RLM_API realm_list_t* realm_get_list(realm_object_t*, realm_property_key_t);
 
 /**
  * Create a `realm_list_t` from a pointer to a `realm::List`, copy-constructing
@@ -1298,7 +1290,7 @@ RLM_API size_t realm_object_changes_get_num_modified_properties(const realm_obje
  *         of modified properties if @a out_modified is NULL.
  */
 RLM_API size_t realm_object_changes_get_modified_properties(const realm_object_changes_t*,
-                                                            realm_col_key_t* out_modified, size_t max);
+                                                            realm_property_key_t* out_modified, size_t max);
 
 /**
  * Get the number of various types of changes in a collection notification.
@@ -1386,7 +1378,7 @@ RLM_API void realm_collection_changes_get_ranges(
 
 RLM_API realm_set_t* _realm_set_from_native_copy(const void* pset, size_t n);
 RLM_API realm_set_t* _realm_set_from_native_move(void* pset, size_t n);
-RLM_API realm_set_t* realm_get_set(const realm_object_t*, realm_col_key_t);
+RLM_API realm_set_t* realm_get_set(const realm_object_t*, realm_property_key_t);
 RLM_API size_t realm_set_size(const realm_set_t*);
 RLM_API bool realm_set_get(const realm_set_t*, size_t index, realm_value_t* out_value);
 RLM_API bool realm_set_find(const realm_set_t*, realm_value_t value, size_t* out_index);
@@ -1403,7 +1395,7 @@ RLM_API realm_notification_token_t* realm_set_add_notification_callback(realm_ob
 
 RLM_API realm_dictionary_t* _realm_dictionary_from_native_copy(const void* pdict, size_t n);
 RLM_API realm_dictionary_t* _realm_dictionary_from_native_move(void* pdict, size_t n);
-RLM_API realm_dictionary_t* realm_get_dictionary(const realm_object_t*, realm_col_key_t);
+RLM_API realm_dictionary_t* realm_get_dictionary(const realm_object_t*, realm_property_key_t);
 RLM_API size_t realm_dictionary_size(const realm_dictionary_t*);
 RLM_API bool realm_dictionary_get(const realm_dictionary_t*, realm_value_t key, realm_value_t* out_value,
                                   bool* out_found);
@@ -1433,7 +1425,7 @@ realm_dictionary_add_notification_callback(realm_object_t*, void* userdata, real
  * @return A non-null pointer if the query was successfully parsed and no
  *         exception occurred.
  */
-RLM_API realm_query_t* realm_query_parse(const realm_t*, realm_table_key_t target_table, const char* query_string,
+RLM_API realm_query_t* realm_query_parse(const realm_t*, realm_class_key_t target_table, const char* query_string,
                                          size_t num_args, const realm_value_t* args);
 
 /**
@@ -1562,7 +1554,7 @@ RLM_API realm_results_t* realm_results_freeze(const realm_results_t*, const real
  * @param out_found Set to true if there are matching rows.
  * @return True if no exception occurred.
  */
-RLM_API bool realm_results_min(realm_results_t*, realm_col_key_t, realm_value_t* out_min, bool* out_found);
+RLM_API bool realm_results_min(realm_results_t*, realm_property_key_t, realm_value_t* out_min, bool* out_found);
 
 /**
  * Compute the maximum value of a property in the results.
@@ -1571,7 +1563,7 @@ RLM_API bool realm_results_min(realm_results_t*, realm_col_key_t, realm_value_t*
  * @param out_found Set to true if there are matching rows.
  * @return True if no exception occurred.
  */
-RLM_API bool realm_results_max(realm_results_t*, realm_col_key_t, realm_value_t* out_max, bool* out_found);
+RLM_API bool realm_results_max(realm_results_t*, realm_property_key_t, realm_value_t* out_max, bool* out_found);
 
 /**
  * Compute the sum value of a property in the results.
@@ -1580,7 +1572,7 @@ RLM_API bool realm_results_max(realm_results_t*, realm_col_key_t, realm_value_t*
  * @param out_found Set to true if there are matching rows.
  * @return True if no exception occurred.
  */
-RLM_API bool realm_results_sum(realm_results_t*, realm_col_key_t, realm_value_t* out_sum, bool* out_found);
+RLM_API bool realm_results_sum(realm_results_t*, realm_property_key_t, realm_value_t* out_sum, bool* out_found);
 
 /**
  * Compute the average value of a property in the results.
@@ -1591,7 +1583,8 @@ RLM_API bool realm_results_sum(realm_results_t*, realm_col_key_t, realm_value_t*
  * @param out_found Set to true if there are matching rows.
  * @return True if no exception occurred.
  */
-RLM_API bool realm_results_average(realm_results_t*, realm_col_key_t, realm_value_t* out_average, bool* out_found);
+RLM_API bool realm_results_average(realm_results_t*, realm_property_key_t, realm_value_t* out_average,
+                                   bool* out_found);
 
 RLM_API realm_notification_token_t* realm_results_add_notification_callback(realm_results_t*, void* userdata,
                                                                             realm_free_userdata_func_t,

--- a/test/object-store/c_api.cpp
+++ b/test/object-store/c_api.cpp
@@ -110,7 +110,7 @@ TEST_CASE("C API") {
                 "", // primary key
                 3,  // properties
                 0,  // computed_properties
-                realm_table_key_t{},
+                RLM_INVALID_CLASS_KEY,
                 RLM_CLASS_NORMAL,
             },
             {
@@ -118,7 +118,7 @@ TEST_CASE("C API") {
                 "int", // primary key
                 2,     // properties
                 0,     // computed properties,
-                realm_table_key{},
+                RLM_INVALID_CLASS_KEY,
                 RLM_CLASS_NORMAL,
             },
         };
@@ -131,7 +131,7 @@ TEST_CASE("C API") {
                 RLM_COLLECTION_TYPE_NONE,
                 "",
                 "",
-                realm_col_key_t{},
+                RLM_INVALID_PROPERTY_KEY,
                 RLM_PROPERTY_NORMAL,
             },
             {
@@ -141,7 +141,7 @@ TEST_CASE("C API") {
                 RLM_COLLECTION_TYPE_NONE,
                 "",
                 "",
-                realm_col_key_t{},
+                RLM_INVALID_PROPERTY_KEY,
                 RLM_PROPERTY_NORMAL,
             },
             {
@@ -151,7 +151,7 @@ TEST_CASE("C API") {
                 RLM_COLLECTION_TYPE_LIST,
                 "bar",
                 "",
-                realm_col_key_t{},
+                RLM_INVALID_PROPERTY_KEY,
                 RLM_PROPERTY_NORMAL,
             },
         };
@@ -164,7 +164,7 @@ TEST_CASE("C API") {
                 RLM_COLLECTION_TYPE_NONE,
                 "",
                 "",
-                realm_col_key_t{},
+                RLM_INVALID_PROPERTY_KEY,
                 RLM_PROPERTY_INDEXED | RLM_PROPERTY_PRIMARY_KEY,
             },
             {
@@ -174,7 +174,7 @@ TEST_CASE("C API") {
                 RLM_COLLECTION_TYPE_LIST,
                 "",
                 "",
-                realm_col_key_t{},
+                RLM_INVALID_PROPERTY_KEY,
                 RLM_PROPERTY_NORMAL | RLM_PROPERTY_NULLABLE,
             },
         };
@@ -280,7 +280,7 @@ TEST_CASE("C API") {
             CHECK(found);
             auto p_key = realm_object_get_key(p.get());
             auto obj2_key = realm_object_get_key(obj2.get());
-            CHECK(p_key.obj_key == obj2_key.obj_key);
+            CHECK(p_key == obj2_key);
 
             // Check that finding by type-mismatched values just find nothing.
             CHECK(!realm_object_find_with_primary_key(realm, bar_info.key, rlm_null(), &found));
@@ -302,8 +302,8 @@ TEST_CASE("C API") {
             CHECK(checked(realm_query_find_first(q.get(), &found_value, &found)));
             CHECK(found);
             CHECK(found_value.type == RLM_TYPE_LINK);
-            CHECK(found_value.link.target_table.table_key == foo_info.key.table_key);
-            CHECK(found_value.link.target.obj_key == realm_object_get_key(obj1.get()).obj_key);
+            CHECK(found_value.link.target_table == foo_info.key);
+            CHECK(found_value.link.target == realm_object_get_key(obj1.get()));
 
             auto r = make_cptr(checked(realm_query_find_all(q.get())));
 
@@ -422,13 +422,13 @@ TEST_CASE("C API") {
                     realm_value_t val;
                     CHECK(checked(realm_list_get(bars.get(), 0, &val)));
                     CHECK(val.type == RLM_TYPE_LINK);
-                    CHECK(val.link.target_table.table_key == bar_info.key.table_key);
-                    CHECK(val.link.target.obj_key == realm_object_get_key(obj2.get()).obj_key);
+                    CHECK(val.link.target_table == bar_info.key);
+                    CHECK(val.link.target == realm_object_get_key(obj2.get()));
 
                     CHECK(checked(realm_list_get(bars.get(), 1, &val)));
                     CHECK(val.type == RLM_TYPE_LINK);
-                    CHECK(val.link.target_table.table_key == bar_info.key.table_key);
-                    CHECK(val.link.target.obj_key == realm_object_get_key(obj2.get()).obj_key);
+                    CHECK(val.link.target_table == bar_info.key);
+                    CHECK(val.link.target == realm_object_get_key(obj2.get()));
 
                     auto result = realm_list_get(bars.get(), 2, &val);
                     CHECK(!result);
@@ -601,11 +601,11 @@ TEST_CASE("C API") {
                 CHECK(!deleted);
                 size_t num_modified = realm_object_changes_get_num_modified_properties(state.changes.get());
                 CHECK(num_modified == 2);
-                realm_col_key_t modified_keys[2];
+                realm_property_key_t modified_keys[2];
                 size_t n = realm_object_changes_get_modified_properties(state.changes.get(), modified_keys, 2);
                 CHECK(n == 2);
-                CHECK(modified_keys[0].col_key == foo_int_property.key.col_key);
-                CHECK(modified_keys[1].col_key == foo_str_property.key.col_key);
+                CHECK(modified_keys[0] == foo_int_property.key);
+                CHECK(modified_keys[1] == foo_str_property.key);
             }
         }
     }


### PR DESCRIPTION
The following are renamed:

* `realm_table_key_t` -> `realm_class_key_t`
* `realm_col_key_t` -> `realm_property_key_t`
* `realm_obj_key_t` -> `realm_object_key_t`

Furthermore, they are all changed from being structs containing an integer value to become plain typedefs on the integer type. This allows the introduction of the global constants `RLM_INVALID_CLASS_KEY`, `RLM_INVALID_PROPERTY_KEY`, and `RLM_INVALID_OBJECT_KEY`.