### PR TITLE
Fix coverage tools

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,6 +12,8 @@ GTAGS
 /gcovr.xml
 /tmp
 doc/html
+/html
+coverage-*
 
 # CMake artifacts
 CMakeFiles

--- a/tools/coverage.sh
+++ b/tools/coverage.sh
@@ -9,13 +9,13 @@ mkdir -p build.cov
 cd build.cov/
 echo cmake -G Ninja -D REALM_COVERAGE=ON -D CMAKE_CXX_FLAGS=-g -DREALM_MAX_BPNODE_SIZE=${MAX_NODE_SIZE} ..
 cmake -G Ninja -D REALM_COVERAGE=ON -D CMAKE_CXX_FLAGS=-g -DREALM_MAX_BPNODE_SIZE=${MAX_NODE_SIZE} ..
-ninja realm-tests
+ninja
 cd ${PROJECT_DIR}
 if [ ! -f coverage-base.info ]; then
   lcov --no-external --capture --initial --directory . --output-file ./coverage-base.info
 fi
 cd build.cov/test/
-./realm-tests 
+ctest 
 cd ${PROJECT_DIR}
 lcov --no-external --directory . --capture --output-file ./coverage-test.info
 lcov --add-tracefile coverage-base.info --add-tracefile coverage-test.info --output-file ${PROJECT_DIR}/coverage-total.info


### PR DESCRIPTION
Updates `tools/coverage.sh` to do something useful with the monorepo.