### PR TITLE
Revert "Reimplement Windows version of InterprocessCondVar (#4224)"

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@
 
 ### Fixed
 * <How to hit and notice issue? what was the impact?> ([#????](https://github.com/realm/realm-core/issues/????), since v?.?.?)
-* None.
+* Windows `InterprocessCondVar` changes reverted.
  
 ### Breaking changes
 * None.

--- a/src/realm/db.cpp
+++ b/src/realm/db.cpp
@@ -79,12 +79,7 @@ const uint16_t relaxed_sync_threshold = 50;
 //  9      Fair write transactions requires an additional condition variable,
 //         `write_fairness`
 // 10      Introducing SharedInfo::history_schema_version.
-// 11      New impl of InterprocessCondVar on windows.
-#ifdef _WIN32
-const uint_fast16_t g_shared_info_version = 11;
-#else
-const uint_fast16_t g_shared_info_version = 10; // version 11 didn't change anything on non-windows platforms
-#endif
+const uint_fast16_t g_shared_info_version = 10;
 
 // The following functions are carefully designed for minimal overhead
 // in case of contention among read transactions. In case of contention,
@@ -2039,7 +2034,7 @@ void DB::finish_begin_write()
 
         // if we are running low on write slots, kick the sync daemon
         if (info->free_write_slots < relaxed_sync_threshold)
-            m_work_to_do.notify_all();
+            m_work_to_do.notify();
         // if we are out of write slots, wait for the sync daemon to catch up
         while (info->free_write_slots <= 0) {
             m_room_to_write.wait(m_balancemutex, 0);

--- a/src/realm/object-store/impl/windows/external_commit_helper.cpp
+++ b/src/realm/object-store/impl/windows/external_commit_helper.cpp
@@ -50,14 +50,14 @@ static std::string create_condvar_sharedmemory_name(std::string realm_path)
 
 ExternalCommitHelper::ExternalCommitHelper(RealmCoordinator& parent)
     : m_parent(parent)
-    , m_shared_part(create_condvar_sharedmemory_name(parent.get_path()))
+    , m_condvar_shared(create_condvar_sharedmemory_name(parent.get_path()))
 {
     m_mutex.set_shared_part(InterprocessMutex::SharedPart(),
                             normalize_realm_path_for_windows_kernel_object_name(parent.get_path()),
                             "ExternalCommitHelper_ControlMutex");
 
     m_commit_available.set_shared_part(
-        m_shared_part->cv, normalize_realm_path_for_windows_kernel_object_name(parent.get_path()),
+        m_condvar_shared.get(), normalize_realm_path_for_windows_kernel_object_name(parent.get_path()),
         "ExternalCommitHelper_CommitCondVar",
         normalize_realm_path_for_windows_kernel_object_name(std::filesystem::temp_directory_path().u8string()));
 
@@ -81,25 +81,18 @@ ExternalCommitHelper::~ExternalCommitHelper()
 void ExternalCommitHelper::notify_others()
 {
     std::lock_guard<InterprocessMutex> lock(m_mutex);
-    m_shared_part->num_signals++;
     m_commit_available.notify_all();
 }
 
 void ExternalCommitHelper::listen()
 {
-    auto lock = std::unique_lock(m_mutex);
-    auto last_count = m_shared_part->num_signals;
-    while (true) {
-        m_commit_available.wait(m_mutex, nullptr, [&] {
-            return !m_keep_listening || m_shared_part->num_signals != last_count;
-        });
-        last_count = m_shared_part->num_signals;
-
-        if (!m_keep_listening)
-            return;
-
-        lock.unlock();
-        m_parent.on_change();
-        lock.lock();
+    std::lock_guard<InterprocessMutex> lock(m_mutex);
+    while (m_keep_listening) {
+        m_commit_available.wait(m_mutex, nullptr);
+        if (m_keep_listening) {
+            m_mutex.unlock();
+            m_parent.on_change();
+            m_mutex.lock();
+        }
     }
 }

--- a/src/realm/object-store/impl/windows/external_commit_helper.hpp
+++ b/src/realm/object-store/impl/windows/external_commit_helper.hpp
@@ -70,11 +70,6 @@ public:
         }
     }
 
-    T* operator->() const noexcept
-    {
-        return m_memory;
-    }
-
     T& get() const noexcept
     {
         return *m_memory;
@@ -114,18 +109,8 @@ private:
     // The listener thread
     std::future<void> m_thread;
 
-    struct SharedPart {
-        util::InterprocessCondVar::SharedPart cv;
-        int64_t num_signals;
-
-        static void init(SharedPart& sp)
-        {
-            util::InterprocessCondVar::init_shared_part(sp.cv);
-            sp.num_signals = 0;
-        }
-    };
-
-    win32::SharedMemory<SharedPart, SharedPart::init> m_shared_part;
+    win32::SharedMemory<util::InterprocessCondVar::SharedPart, util::InterprocessCondVar::init_shared_part>
+        m_condvar_shared;
 
     util::InterprocessCondVar m_commit_available;
     util::InterprocessMutex m_mutex;

--- a/src/realm/util/interprocess_condvar.cpp
+++ b/src/realm/util/interprocess_condvar.cpp
@@ -36,56 +36,8 @@
 
 #ifdef _WIN32
 #include <Windows.h>
-#include <set>
 #endif
 
-// Theory of operation for windows implementation:
-// The core idea is that each process[1] owns a uniquely numbered Event object that is uses for
-// waiting. Prior to waiting it ensures that the event is cleared then waits for it to be signaled.
-// The notifier signals all events from 0 to the maximum to wake everyone who is interested in this
-// CV. The complexity comes from three sources, 1) acquiring a unique id for your process, 2)
-// determining the maximum Event to notify, 3) supporting more than one waiting thread per process.
-// And this all must be done in a way that is robust to both processes joining, or being arbitrarily
-// killed at any time. This is simplified somewhat by the additional requirement on ICV that you
-// must hold the associated InterprocessMutex while notifying, and not just while waiting as in
-// std::condition_variable, and this implementation relies on that for correctness.
-//
-// 1) Unique ids are assigned by acquiring a named mutex that will be held for the lifetime of the
-// process. This ensures that nobody else will be able to use this id. Windows will automatically
-// release this mutex if the process dies or is killed, so we will not be leaking the id. We try
-// to lock each number starting at 0 and going up until we are able to lock one, then use that as
-// our id. This ensures we get the lowest possible id that isn't currently in use to avoid raising
-// m_max_process_num unnecessarily.
-//
-// 2) The maximum process id is adjusted each time a new process joins and claims an id. If the
-// current value of m_max_process_num equals our id, nothing needs to be done. If our id is higher,
-// raise it directly to our id. If our id is lower, try to acquire the mutex for the maximum num. If
-// we fail to lock, assume the process is still running and stop. If we succeed at locking it, that
-// process must no longer be running, so we can safely lower the maximum process number and repeat
-// this process until we either fail to lock the mutex for that process or hit our own mutex, since
-// we know *we* are still alive at least (also windows mutexes are reentrant, so we would otherwise
-// get the signal that we are dead when we most certainly are not).
-//
-// 3) Because we reset the Event each time we wait, this only supports a single waiter per process.
-// To overcome this, we also keep some per-process state to ensure that we only have one waiter at a
-// time. Each potential waiter increments m_highest_waiter claiming the new value, then checks if
-// there is already a designated waiter at the moment. If there is, wait on the private CV until
-// m_signaled_waiters >= my waiter number. Otherwise, wait on the shared Event, and once it is
-// ready, set m_signaled_waiters to m_highest waiters and notify the CV so that anyone who started
-// waiting while we were waiting is also notified.
-//
-// [1] I'm using "process" in this description for simplicity, but it is really per
-// InterprocessCondVar instance per process. So if a process opens two ICVs to the same underlying
-// shared condvar, it counts as two processes in this description. Equivalently, if the process
-// destroys and recreates an ICV, it counts as the process dieing and restarting. Because windows
-// mutexes are reentrant, we also keep a set of the ids we have in use within each OS process to
-// ensure that don't use the same id for two ICVs even if we are able to lock the mutex for that id.
-//
-// Mutex order: Associated InterprocessMutex
-//            > g_process_nums_in_use_mutex
-//            > Mutex[i] (all of them at same level)
-//            > Mutex["max_process_num"]
-// This is briefly violated, but using try_lock() which avoids deadlock.
 
 using namespace realm;
 using namespace realm::util;
@@ -100,12 +52,8 @@ int64_t timediff(const timeval& tv1, const timespec& ts2)
     return int64_t(ts2.tv_sec - tv1.tv_sec) * 1000 + (ts2.tv_nsec / 1000000) - (tv1.tv_usec / 1000);
 }
 
-#ifdef _WIN32
-// CV name+path -> process num
-// Ensures we don't use the same process num twice for two ICVs within the same process.
-std::mutex g_process_nums_in_use_mutex;
-std::map<std::string, std::set<int32_t>> g_process_nums_in_use;
-#else
+#ifndef _WIN32
+
 // Write a byte to a pipe to notify anyone waiting for data on the pipe
 void notify_fd(int fd)
 {
@@ -131,6 +79,7 @@ void notify_fd(int fd)
 } // anonymous namespace
 #endif // REALM_CONDVAR_EMULATION
 
+
 InterprocessCondVar::InterprocessCondVar() {}
 
 
@@ -147,17 +96,18 @@ void InterprocessCondVar::close() noexcept
         m_fd_write = -1;
     }
 #else
-    if (m_my_mutex.handle)
-        m_my_mutex.unlock();
-
-    if (m_my_id != -1) {
-        auto lk = std::lock_guard(g_process_nums_in_use_mutex);
-        g_process_nums_in_use[m_name_with_path].erase(m_my_id);
-        m_my_id = -1;
+    if (m_sema) {
+        bool b = CloseHandle(m_sema);
+        REALM_ASSERT_RELEASE(b);
+        REALM_ASSERT_RELEASE(m_waiters_done);
     }
-
-    m_events.clear();
-    m_my_mutex = {};
+    if (m_waiters_done) {
+        bool b = CloseHandle(m_waiters_done);
+        REALM_ASSERT_RELEASE(b);
+        REALM_ASSERT_RELEASE(m_sema);
+    }
+    m_waiters_done = 0;
+    m_sema = 0;
 #endif
 #endif
     // we don't do anything to the shared part, other CondVars may share it
@@ -247,55 +197,32 @@ void InterprocessCondVar::set_shared_part(SharedPart& shared_part, std::string b
     std::string base_path_escaped = base_path;
     std::replace(base_path_escaped.begin(), base_path_escaped.end(), '\\', '/');
 
-    m_name_with_path = base_path_escaped + condvar_name;
+    std::string sem = "Local\\realm_sema_" + base_path_escaped + condvar_name;
+    std::string eve = "Local\\realm_event_" + base_path_escaped + condvar_name;
 
-    {
-        // Claim our mutex (lowest available id)
-        auto lk = std::unique_lock(g_process_nums_in_use_mutex);
-        auto& nums_in_use = g_process_nums_in_use[m_name_with_path];
-        for (int32_t i = 0; true; i++) {
-            if (nums_in_use.count(i))
-                continue; // There is another ICV instance in this process for this CV.
+    // UWP only has W versions of API.
+    std::wstring se = std::wstring(sem.begin(), sem.end());
+    std::wstring ev = std::wstring(eve.begin(), eve.end());
 
-            auto mutex = open_mutex(i);
-            if (mutex.try_lock()) {
-                m_my_mutex = std::move(mutex);
-                m_my_id = i;
-                nums_in_use.insert(i);
-                break;
-            }
-        }
+    m_sema = CreateSemaphoreW(nullptr,    // no security
+                              0,          // initially 0
+                              0x7fffffff, // max count
+                              LPWSTR(se.c_str()));
+    if (!m_sema) {
+        throw std::system_error(GetLastError(), std::system_category(), "Error opening semaphore");
     }
 
-    {
-        // Update m_shared_part->m_max_process_num.
-        auto max_process_num_mutex = open_mutex("max_process_num");
-        auto lk = std::unique_lock(max_process_num_mutex);
-        if (m_my_id > m_shared_part->m_max_process_num) {
-            // I am the new max process.
-            m_shared_part->m_max_process_num = m_my_id;
-        }
-        else if (m_my_id < m_shared_part->m_max_process_num) {
-            // Walk backwards lowering m_max_process_num to eliminate any dead processes.
-            for (int32_t i = m_shared_part->m_max_process_num; i > m_my_id; i--) {
-                auto mutex = open_mutex(i);
-                // This *is* a cycle in the lock order since the holder of mutex[i] may be waiting
-                // to acquire mutex["max_process_num"]. However, because we are using try_lock()
-                // here, it will not result in a deadlock.
-                if (!mutex.try_lock())
-                    break; // found a process that is still alive, so can't lower num any more.
-                mutex.unlock();
-
-                // Process `i` must no longer be running if we were able to grab the mutex.
-                // If a new process `i` starts up, it will raise it back after acquiring the
-                // max_process_num_mutex. So this is safe even if that process starts concurrently,
-                // since we hold that mutex.
-                m_shared_part->m_max_process_num = i - 1;
-            }
-        } // Nothing to do if they are already equal.
+    m_waiters_done = CreateEventW(nullptr, // no security
+                                  false,   // auto-reset
+                                  false,   // non-signaled initially
+                                  LPWSTR(ev.c_str()));
+    if (!m_waiters_done) {
+        throw std::system_error(GetLastError(), std::system_category(), "Error opening event");
     }
 
-    update_event_handles();
+    // InterprocessMutex::SharedPart() is an unused dummy object
+    m_waiters_lockcount.set_shared_part(InterprocessMutex::SharedPart(), base_path, condvar_name);
+
 #endif // _WIN32
 #endif // REALM_CONDVAR_EMULATION
 }
@@ -305,8 +232,8 @@ void InterprocessCondVar::init_shared_part(SharedPart& shared_part)
 {
 #ifdef REALM_CONDVAR_EMULATION
 #ifdef _WIN32
-    shared_part.m_max_process_num = 0;
-    shared_part.m_any_waiters = false;
+    shared_part.m_waiters_count = 0;
+    shared_part.m_was_broadcast = 0;
 #else
     shared_part.wait_counter = 0;
     shared_part.signal_counter = 0;
@@ -344,54 +271,49 @@ void InterprocessCondVar::wait(InterprocessMutex& m, const struct timespec* tp)
 #ifdef REALM_CONDVAR_EMULATION
 
 #ifdef _WIN32
-    const auto my_waiter = ++m_highest_waiter;
+    int64_t wait_milliseconds = INFINITE;
 
-    if (m_have_waiter) {
-        // Someone else is waiting, so just wait for their signal.
-        auto waiter_lock = std::unique_lock(m, std::adopt_lock);
-        if (tp) {
-            m_waiter_cv.wait_until(
-                waiter_lock,
-                std::chrono::system_clock::from_time_t(tp->tv_sec) + std::chrono::nanoseconds(tp->tv_nsec), [&] {
-                    return m_signaled_waiters >= my_waiter;
-                });
-        }
-        else {
-            m_waiter_cv.wait(waiter_lock, [&] {
-                return m_signaled_waiters >= my_waiter;
-            });
-        }
-        waiter_lock.release(); // not unlock(). Prevents unlock() when returning.
-        return;
-    }
-
-    // I am the waiter.
-    m_have_waiter = true;
-
-    DWORD wait_milliseconds = INFINITE;
     if (tp) {
         timeval tp2;
         gettimeofday(&tp2, nullptr);
-        auto milliseconds = timediff(tp2, *tp);
-        if (milliseconds < 0) // need to check before converting to unsigned DWORD
-            milliseconds = 0;
-        wait_milliseconds = DWORD(milliseconds);
+        wait_milliseconds = timediff(tp2, *tp);
+        if (wait_milliseconds < 0)
+            wait_milliseconds = 0;
     }
 
-    m_shared_part->m_any_waiters = true;
-    my_event().reset(); // Ignore any notifications from before we were waiting.
+    m_waiters_lockcount.lock();
+    m_shared_part->m_waiters_count++;
+    m_waiters_lockcount.unlock();
+
     m.unlock();
-    static_assert(noexcept(my_event().wait(wait_milliseconds)));
-    my_event().wait(wait_milliseconds);
-    m.lock();
 
-    if (my_waiter != m_highest_waiter) {
-        // Signal everyone that tried to wait while I was waiting. Do this even if I timed out, since
-        // spurious wakeups are legal and they might miss a notification otherwise.
-        m_signaled_waiters = m_highest_waiter;
-        m_waiter_cv.notify_all();
+    DWORD d = WaitForSingleObject(m_sema, DWORD(wait_milliseconds));
+    REALM_ASSERT_RELEASE(d != WAIT_FAILED);
+
+    // Reacquire lock to avoid race conditions.
+    m_waiters_lockcount.lock();
+
+    // We're no longer waiting...
+    m_shared_part->m_waiters_count--;
+
+    // Check to see if we're the last waiter after notify_all().
+    bool last_waiter = m_shared_part->m_was_broadcast && m_shared_part->m_waiters_count == 0;
+
+    // m_shared_part->m_waiters_countlock.unlock();
+    m_waiters_lockcount.unlock();
+
+    // If we're the last waiter thread during this particular broadcast then let all the other threads proceed.
+    if (last_waiter) {
+        // This call atomically signals the <m_waiters_done> event and waits until it can acquire the
+        // external mutex. This is required to ensure fairness. This need to signal an event back means
+        // that we cannot take m.lock earlier and this in turn forces us to add an additional mutex,
+        // m_waiters_countlock.
+        SetEvent(m_waiters_done);
     }
-    m_have_waiter = false;
+
+    // Always regain the external mutex since that's the guarantee we give to our callers.
+    m.lock();
+    return;
 #else
     // indicate arrival of a new waiter (me) and get our own number in the
     // line of waiters. We later use this number to determine if a wakeup
@@ -497,6 +419,38 @@ void InterprocessCondVar::wait(InterprocessMutex& m, const struct timespec* tp)
 }
 
 
+// Notify:
+// precondition: The caller holds the mutex guarding the condition variable.
+// operation: If a waiter is present, we wake her up by writing a single
+// byte to the fifo.
+
+void InterprocessCondVar::notify() noexcept
+{
+    REALM_ASSERT(m_shared_part);
+#ifdef REALM_CONDVAR_EMULATION
+#ifdef _WIN32
+    m_waiters_lockcount.lock();
+
+    bool have_waiters = m_shared_part->m_waiters_count > 0;
+
+    m_waiters_lockcount.unlock();
+
+    // If there aren't any waiters, then this is a no-op.
+    if (have_waiters) {
+        ReleaseSemaphore(m_sema, 1, 0);
+    }
+#else
+    if (m_shared_part->wait_counter > m_shared_part->signal_counter) {
+        m_shared_part->signal_counter++;
+        notify_fd(m_fd_write != -1 ? m_fd_write : m_fd_read);
+    }
+#endif
+#else
+    m_shared_part->notify();
+#endif
+}
+
+
 // Notify_all:
 // precondition: The caller holds the mutex guarding the condition variable.
 // operation: If waiters are present, we wake them up by writing a single
@@ -507,20 +461,36 @@ void InterprocessCondVar::notify_all() noexcept
     REALM_ASSERT(m_shared_part);
 #ifdef REALM_CONDVAR_EMULATION
 #ifdef _WIN32
-    if (!m_shared_part->m_any_waiters)
-        return;
+    // This is needed to ensure that <m_waiters_count> and <m_was_broadcast> are
+    // consistent relative to each other.
+    m_waiters_lockcount.lock();
 
-    m_shared_part->m_any_waiters = false;
+    bool have_waiters = false;
 
-    // Note that this could change while notifying but that is ok. Because the caller must hold the
-    // associated mutex when notifying (unlike with std::condition_variable), the new process cannot
-    // enter a wait since that also requires holding the mutex.
-    if (m_events.size() != size_t(m_shared_part->m_max_process_num) + 1)
-        update_event_handles();
+    if (m_shared_part->m_waiters_count > 0) {
+        // We are broadcasting, even if there is just one waiter...
+        // Record that we are broadcasting, which helps optimize
+        // wait() for the non-broadcast case.
+        m_shared_part->m_was_broadcast = 1;
+        have_waiters = true;
+    }
 
-    for (auto&& ev : m_events) {
-        // Can't skip ourself because we could have other threads waiting.
-        ev.set();
+    if (have_waiters) {
+        // Wake up all the waiters atomically.
+        ReleaseSemaphore(m_sema, m_shared_part->m_waiters_count, 0);
+        m_waiters_lockcount.unlock();
+
+        // Wait for all the awakened threads to acquire the counting
+        // semaphore.
+        DWORD d = WaitForSingleObject(m_waiters_done, INFINITE);
+        REALM_ASSERT_RELEASE(d != WAIT_FAILED);
+
+        // This assignment is okay, even without the <m_waiters_countlock> held
+        // because no other waiter threads can wake up to access it.
+        m_shared_part->m_was_broadcast = 0;
+    }
+    else {
+        m_waiters_lockcount.unlock();
     }
 #else
     while (m_shared_part->wait_counter > m_shared_part->signal_counter) {
@@ -532,81 +502,3 @@ void InterprocessCondVar::notify_all() noexcept
     m_shared_part->notify_all();
 #endif
 }
-
-#ifdef _WIN32
-void InterprocessCondVar::Event::wait(DWORD millis) noexcept
-{
-    auto ret = WaitForSingleObject(handle, millis);
-    REALM_ASSERT_RELEASE(ret != WAIT_FAILED);
-    REALM_ASSERT_RELEASE(ret == WAIT_OBJECT_0 || ret == WAIT_TIMEOUT);
-}
-void InterprocessCondVar::Event::set() noexcept
-{
-    REALM_ASSERT_RELEASE(SetEvent(handle));
-}
-void InterprocessCondVar::Event::reset() noexcept
-{
-    REALM_ASSERT_RELEASE(ResetEvent(handle));
-}
-
-void InterprocessCondVar::Mutex::lock() noexcept
-{
-    auto ret = WaitForSingleObject(handle, INFINITE);
-    REALM_ASSERT_RELEASE(ret != WAIT_FAILED);
-    REALM_ASSERT_RELEASE(ret == WAIT_OBJECT_0 || ret == WAIT_ABANDONED_0);
-}
-bool InterprocessCondVar::Mutex::try_lock() noexcept
-{
-    auto ret = WaitForSingleObject(handle, 0);
-    REALM_ASSERT_RELEASE(ret != WAIT_FAILED);
-    return ret != WAIT_TIMEOUT;
-}
-void InterprocessCondVar::Mutex::unlock() noexcept
-{
-    REALM_ASSERT_RELEASE(ReleaseMutex(handle));
-}
-
-void InterprocessCondVar::update_event_handles()
-{
-    const int32_t max_process_num = m_shared_part->m_max_process_num;
-    REALM_ASSERT_RELEASE(max_process_num >= 0);
-    REALM_ASSERT_RELEASE(max_process_num < 1'000'000); // Sanity check.
-
-    const size_t old_size = m_events.size();
-    m_events.resize(size_t(max_process_num) + 1);
-    for (size_t i = old_size; i < m_events.size(); i++) { // skipped if not growing.
-        m_events[i] = open_event(int32_t(i));
-    }
-}
-
-InterprocessCondVar::Mutex InterprocessCondVar::open_mutex(int32_t n)
-{
-    REALM_ASSERT_RELEASE(n >= 0);
-    REALM_ASSERT_RELEASE(n < 1'000'000); // Sanity check.
-    return open_mutex(std::to_string(n));
-}
-InterprocessCondVar::Mutex InterprocessCondVar::open_mutex(std::string name)
-{
-    const std::string uri = "Local\\realm_cv_mutex_" + m_name_with_path + '_' + name;
-    const auto wuri = std::wstring(uri.begin(), uri.end());
-    HandleHolder handle = CreateMutexW(nullptr, // no security
-                                       false,   // initial owner
-                                       wuri.c_str());
-    REALM_ASSERT_RELEASE(handle);
-    return Mutex{std::move(handle)};
-}
-InterprocessCondVar::Event InterprocessCondVar::open_event(int32_t n)
-{
-    REALM_ASSERT_RELEASE(n >= 0);
-    REALM_ASSERT_RELEASE(n < 1'000'000); // Sanity check.
-    const std::string uri = "Local\\realm_cv_event_" + m_name_with_path + '_' + std::to_string(n);
-    const auto wuri = std::wstring(uri.begin(), uri.end());
-
-    HandleHolder handle = CreateEventW(nullptr, // no security
-                                       false,   // auto-reset
-                                       false,   // non-signaled initially
-                                       wuri.c_str());
-    REALM_ASSERT_RELEASE(handle);
-    return Event{std::move(handle)};
-}
-#endif

--- a/src/realm/util/interprocess_condvar.hpp
+++ b/src/realm/util/interprocess_condvar.hpp
@@ -66,11 +66,9 @@ public:
 #ifdef REALM_CONDVAR_EMULATION
     struct SharedPart {
 #ifdef _WIN32
-        // See top of .cpp for description of how windows implementation works.
-        std::atomic_int32_t m_max_process_num;
-        bool m_any_waiters; // guarded by mutex associated with this CondVar.
-
-        static_assert(std::atomic_int32_t::is_always_lock_free);
+        // Number of waiting threads.
+        int32_t m_waiters_count;
+        size_t m_was_broadcast;
 #else
         uint64_t signal_counter;
         uint64_t wait_counter;
@@ -95,30 +93,20 @@ public:
     /// be used *only* when you are certain, that nobody is using it.
     void release_shared_part();
 
-    /// Wait for someone to call notify_all() on this condition
+    /// Wait for someone to call notify() or notify_all() on this condition
     /// variable. The call to wait() may return spuriously, so the caller should
     /// always re-evaluate the condition on which to wait and loop on wait()
     /// if necessary.
     void wait(InterprocessMutex& m, const struct timespec* tp);
 
-    /// While cond() returns false, waits for a call to notify_all(). This is
-    /// the preferred overload to use because it correctly handles spurious
-    /// wakeups, and avoids some condvar anti-patterns, by pushing callers into
-    /// the correct pattern.
-    template <typename Cond>
-    void wait(InterprocessMutex& m, const struct timespec* tp, Cond&& cond)
-    {
-        while (!cond()) {
-            wait(m, tp);
-        }
-    }
+    /// If any threads are waiting for this condition, wake up at least one.
+    /// (Current implementation may actually wake all :-O ). The caller must
+    /// hold the lock associated with the condvar at the time of calling notify()
+    void notify() noexcept;
 
     /// Wake up every thread that is currently waiting on this condition.
     /// The caller must hold the lock associated with the condvar at the time
     /// of calling notify_all().
-    /// In order to avoid missed wakeups in the case of sudden process termination, it is important
-    /// to notify the CV *prior* to changing the state that the condition variable is protecting,
-    /// within the same mutex hold.
     void notify_all() noexcept;
 
     /// Cleanup and release system resources if possible.
@@ -127,7 +115,6 @@ public:
 private:
     // non-zero if a shared part has been registered (always 0 on process local instances)
     SharedPart* m_shared_part = nullptr;
-
 #ifdef REALM_CONDVAR_EMULATION
     // keep the path to allocated system resource so we can remove them again
     std::string m_resource_path;
@@ -135,85 +122,21 @@ private:
     // When using an anonymous pipe (currently only for tvOS) m_fd_read is read-only and m_fd_write is write-only.
     int m_fd_read = -1;
     int m_fd_write = -1;
-#endif
 
 #ifdef _WIN32
-    // A wrapper around HANDLE that auto-closes.
-    struct HandleHolder {
-        HandleHolder() = default;
-        /*implicit*/ HandleHolder(HANDLE h)
-            : handle(h)
-        {
-        }
-        ~HandleHolder()
-        {
-            if (handle)
-                REALM_ASSERT_RELEASE(CloseHandle(handle));
-        }
-        HandleHolder(HandleHolder&& other) noexcept
-            : handle(std::exchange(other.handle, {}))
-        {
-        }
-        HandleHolder& operator=(HandleHolder&& other) noexcept
-        {
-            if (handle)
-                REALM_ASSERT_RELEASE(CloseHandle(handle));
-            handle = std::exchange(other.handle, {});
-            return *this;
-        }
+    // Semaphore used to queue up threads waiting for the condition to
+    // become signaled.
+    HANDLE m_sema = 0;
+    // An auto-reset event used by the broadcast/signal thread to wait
+    // for all the waiting thread(s) to wake up and be released from the
+    // semaphore.
+    HANDLE m_waiters_done = 0;
+    std::string m_name;
 
-        /*implicit*/ operator HANDLE() const
-        {
-            return handle;
-        }
+    // Serialize access to m_waiters_count
+    InterprocessMutex m_waiters_lockcount;
+#endif
 
-        explicit operator bool() const
-        {
-            return bool(handle);
-        }
-
-        HANDLE handle = {};
-    };
-
-    struct Event {
-        void wait(DWORD millis = INFINITE) noexcept;
-        void set() noexcept;
-        void reset() noexcept;
-        HandleHolder handle;
-    };
-
-    struct Mutex {
-        void lock() noexcept;
-        bool try_lock() noexcept;
-        void unlock() noexcept;
-        HandleHolder handle;
-    };
-
-    void update_event_handles();
-    Event open_event(int32_t n);
-    Mutex open_mutex(int32_t n);
-    Mutex open_mutex(std::string name);
-
-    Event& my_event() noexcept
-    {
-        return m_events[m_my_id];
-    }
-
-    int32_t m_my_id = -1;
-    std::vector<Event> m_events;
-
-    // Held whole time this condvar object lives.
-    Mutex m_my_mutex;
-
-    // The main algorithm only supports one waiter per process.
-    // These members exist to extend that to support N waiters per process.
-    // They are guarded by the mutex associated with this cv.
-    std::condition_variable_any m_waiter_cv;
-    int64_t m_highest_waiter = 0;
-    int64_t m_signaled_waiters = 0;
-    bool m_have_waiter = false;
-
-    std::string m_name_with_path;
 #endif
 };
 


### PR DESCRIPTION
This reverts commit 7be1f6aabc07e28f95f5c5625c14ad18fa1a4cf8.

<!--
 Make sure to assign one and only one Type (`T:`) label.
 Select reviewers if ready for review. Our bot will automatically assign you.
 -->

## What, How & Why?
<!-- Describe the changes and give some hints to guide your reviewers if possible. -->
<!-- Link (via zenhub) to relevant issue this fixes -->

## ☑️ ToDos
* [ ] 📝 Changelog update
* [ ] 🚦 Tests (or not relevant)
