### PR TITLE
Add support for min/max queries on Timestamp lists

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 # NEXT RELEASE
 
 ### Enhancements
-* None.
+* Add support for @min and @max queries on Timestamp lists.
 
 ### Fixed
 * <How to hit and notice issue? what was the impact?> ([#????](https://github.com/realm/realm-core/issues/????), since v?.?.?)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@
 * <How to hit and notice issue? what was the impact?> ([#????](https://github.com/realm/realm-core/issues/????), since v?.?.?)
 * Windows `InterprocessCondVar` changes reverted.
 * Fix an issue when using `Results::freeze` across threads with different transaction versions. Previously, copying the `Results`'s tableview could result in a stale state or objects from a future version. Now there is a comparison for the source and desitnation transaction version when constructing `ConstTableView`, which will cause the tableview to reflect the correct state if needed ([#4254](https://github.com/realm/realm-core/pull/4254)).
-* `@min` and `@max` queries on a list of optional float, double or Decimal128 values could match NaN or Inf instead of the correct value if null was present in the list (since 5.0.0).
+* `@min` and `@max` queries on a list of float, double or Decimal128 values could match the incorrect value if NaN or null was present in the list (since 5.0.0).
  
 ### Breaking changes
 * None.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 * <How to hit and notice issue? what was the impact?> ([#????](https://github.com/realm/realm-core/issues/????), since v?.?.?)
 * Windows `InterprocessCondVar` changes reverted.
 * Fix an issue when using `Results::freeze` across threads with different transaction versions. Previously, copying the `Results`'s tableview could result in a stale state or objects from a future version. Now there is a comparison for the source and desitnation transaction version when constructing `ConstTableView`, which will cause the tableview to reflect the correct state if needed ([#4254](https://github.com/realm/realm-core/pull/4254)).
+* `@min` and `@max` queries on a list of optional float, double or Decimal128 values could match NaN or Inf instead of the correct value if null was present in the list (since 5.0.0).
  
 ### Breaking changes
 * None.

--- a/src/realm/null.hpp
+++ b/src/realm/null.hpp
@@ -57,9 +57,7 @@ The `S` bit is at position 22 (float) or 51 (double).
 */
 
 struct null {
-    null()
-    {
-    }
+    constexpr null() = default;
     operator int64_t()
     {
         throw(LogicError::type_mismatch);

--- a/src/realm/parser/collection_operator_expression.hpp
+++ b/src/realm/parser/collection_operator_expression.hpp
@@ -84,7 +84,7 @@ struct CollectionOperatorGetter {
 template <typename RetType>
 struct CollectionOperatorGetter<
     RetType, parser::Expression::KeyPathOp::Min, PropertyExpression,
-    typename std::enable_if_t<realm::is_any<RetType, Int, Float, Double, Decimal128>::value>> {
+    typename std::enable_if_t<realm::is_any<RetType, Int, Float, Double, Decimal128, Timestamp>::value>> {
     static SubColumnAggregate<RetType, aggregate_operations::Minimum<RetType>>
     convert(const CollectionOperatorExpression<parser::Expression::KeyPathOp::Min, PropertyExpression>& expr)
     {
@@ -106,7 +106,7 @@ struct CollectionOperatorGetter<
 template <typename RetType>
 struct CollectionOperatorGetter<
     RetType, parser::Expression::KeyPathOp::Min, PrimitiveListExpression,
-    typename std::enable_if_t<realm::is_any<RetType, Int, Float, Double, Decimal128>::value>> {
+    typename std::enable_if_t<realm::is_any<RetType, Int, Float, Double, Decimal128, Timestamp>::value>> {
     static ListColumnAggregate<RetType, aggregate_operations::Minimum<RetType>>
     convert(const CollectionOperatorExpression<parser::Expression::KeyPathOp::Min, PrimitiveListExpression>& expr)
     {
@@ -117,7 +117,7 @@ struct CollectionOperatorGetter<
 template <typename RetType>
 struct CollectionOperatorGetter<
     RetType, parser::Expression::KeyPathOp::Max, PropertyExpression,
-    typename std::enable_if_t<realm::is_any<RetType, Int, Float, Double, Decimal128>::value>> {
+    typename std::enable_if_t<realm::is_any<RetType, Int, Float, Double, Decimal128, Timestamp>::value>> {
     static SubColumnAggregate<RetType, aggregate_operations::Maximum<RetType>>
     convert(const CollectionOperatorExpression<parser::Expression::KeyPathOp::Max, PropertyExpression>& expr)
     {
@@ -139,7 +139,7 @@ struct CollectionOperatorGetter<
 template <typename RetType>
 struct CollectionOperatorGetter<
     RetType, parser::Expression::KeyPathOp::Max, PrimitiveListExpression,
-    typename std::enable_if_t<realm::is_any<RetType, Int, Float, Double, Decimal128>::value>> {
+    typename std::enable_if_t<realm::is_any<RetType, Int, Float, Double, Decimal128, Timestamp>::value>> {
     static ListColumnAggregate<RetType, aggregate_operations::Maximum<RetType>>
     convert(const CollectionOperatorExpression<parser::Expression::KeyPathOp::Max, PrimitiveListExpression>& expr)
     {

--- a/src/realm/query_expression.hpp
+++ b/src/realm/query_expression.hpp
@@ -3132,13 +3132,13 @@ private:
         size_t s = list.size();
         for (unsigned j = 0; j < s; j++) {
             auto v = list.get(j);
-            if constexpr (std::is_same_v<StorageType, util::Optional<T>>) {
-                if (v) {
+            if (!value_is_null(v)) {
+                if constexpr (std::is_same_v<StorageType, util::Optional<T>>) {
                     op.accumulate(*v);
                 }
-            }
-            else {
-                op.accumulate(v);
+                else {
+                    op.accumulate(v);
+                }
             }
         }
     }

--- a/src/realm/query_expression.hpp
+++ b/src/realm/query_expression.hpp
@@ -3730,7 +3730,11 @@ static bool is_nan(T value)
     if constexpr (std::is_floating_point_v<T>) {
         return std::isnan(value);
     }
-    return false;
+    else {
+        // gcc considers the argument unused if it's only used in one branch of if constexpr
+        static_cast<void>(value);
+        return false;
+    }
 }
 
 template <>

--- a/src/realm/query_expression.hpp
+++ b/src/realm/query_expression.hpp
@@ -3045,10 +3045,8 @@ SizeOperator<int64_t> Columns<Lst<T>>::size()
 }
 
 template <typename T, typename Operation>
-class ListColumnAggregate : public Subexpr2<typename Operation::ResultType> {
+class ListColumnAggregate : public Subexpr2<decltype(Operation().result())> {
 public:
-    using R = typename Operation::ResultType;
-
     ListColumnAggregate(ColKey column_key, Columns<Lst<T>> column)
         : m_column_key(column_key)
         , m_list(std::move(column))
@@ -3088,24 +3086,6 @@ public:
 
     void evaluate(size_t index, ValueBase& destination) override
     {
-        if constexpr (realm::is_any_v<T, ObjectId, Int, Bool, UUID>) {
-            if (m_list.m_is_nullable_storage) {
-                evaluate<util::Optional<T>>(index, destination);
-                return;
-            }
-        }
-        evaluate<T>(index, destination);
-    }
-
-    virtual std::string description(util::serializer::SerialisationState& state) const override
-    {
-        return m_list.description(state) + util::serializer::value_separator + Operation::description();
-    }
-
-private:
-    template <typename StorageType>
-    void evaluate(size_t index, ValueBase& destination)
-    {
         Allocator& alloc = get_base_table()->get_alloc();
         Value<int64_t> list_refs;
         m_list.get_lists(index, list_refs, 1);
@@ -3117,11 +3097,16 @@ private:
             auto list_ref = to_ref(list_refs[i].get_int());
             Operation op;
             if (list_ref) {
-                BPlusTree<StorageType> list(alloc);
-                list.init_from_ref(list_ref);
-                size_t s = list.size();
-                for (unsigned j = 0; j < s; j++) {
-                    op.accumulate(list.get(j));
+                if constexpr (realm::is_any_v<T, ObjectId, Int, Bool, UUID>) {
+                    if (m_list.m_is_nullable_storage) {
+                        accumulate<util::Optional<T>>(op, alloc, list_ref);
+                    }
+                    else {
+                        accumulate<T>(op, alloc, list_ref);
+                    }
+                }
+                else {
+                    accumulate<T>(op, alloc, list_ref);
                 }
             }
             if (op.is_null()) {
@@ -3129,6 +3114,31 @@ private:
             }
             else {
                 destination.set(i, op.result());
+            }
+        }
+    }
+
+    virtual std::string description(util::serializer::SerialisationState& state) const override
+    {
+        return m_list.description(state) + util::serializer::value_separator + Operation::description();
+    }
+
+private:
+    template <typename StorageType>
+    void accumulate(Operation& op, Allocator& alloc, ref_type list_ref)
+    {
+        BPlusTree<StorageType> list(alloc);
+        list.init_from_ref(list_ref);
+        size_t s = list.size();
+        for (unsigned j = 0; j < s; j++) {
+            auto v = list.get(j);
+            if constexpr (std::is_same_v<StorageType, util::Optional<T>>) {
+                if (v) {
+                    op.accumulate(*v);
+                }
+            }
+            else {
+                op.accumulate(v);
             }
         }
     }
@@ -3552,7 +3562,7 @@ private:
 };
 
 template <typename T, typename Operation>
-class SubColumnAggregate : public Subexpr2<typename Operation::ResultType> {
+class SubColumnAggregate : public Subexpr2<decltype(Operation().result())> {
 public:
     SubColumnAggregate(const Columns<T>& column, const LinkMap& link_map)
         : m_column(column)
@@ -3714,26 +3724,80 @@ private:
 };
 
 namespace aggregate_operations {
-template <typename T, typename Derived, typename R = T>
-class BaseAggregateOperation {
-    static_assert(realm::is_any<T, Int, Float, Double, Decimal128>::value,
-                  "Numeric aggregates can only be used with subcolumns of numeric types");
-
+template <typename T, typename Compare>
+class MinMaxAggregateOperator {
 public:
-    using ResultType = R;
+    void accumulate(T value)
+    {
+        if (!m_result || Compare()(value, *m_result)) {
+            m_result = value;
+        }
+    }
 
+    bool is_null() const
+    {
+        return !m_result;
+    }
+    T result() const
+    {
+        return *m_result;
+    }
+
+private:
+    util::Optional<T> m_result;
+};
+
+template <typename T>
+class Minimum : public MinMaxAggregateOperator<T, std::less<>> {
+public:
+    static const char* description()
+    {
+        return "@min";
+    }
+};
+
+template <typename T>
+class Maximum : public MinMaxAggregateOperator<T, std::greater<>> {
+public:
+    static const char* description()
+    {
+        return "@max";
+    }
+};
+
+template <typename T>
+class Sum {
+public:
+    void accumulate(T value)
+    {
+        m_result += value;
+    }
+
+    bool is_null() const
+    {
+        return false;
+    }
+    T result() const
+    {
+        return m_result;
+    }
+    static const char* description()
+    {
+        return "@sum";
+    }
+
+private:
+    T m_result = {};
+};
+
+template <typename T>
+class Average {
+public:
+    using ResultType = typename std::conditional<std::is_same_v<T, Decimal128>, Decimal128, double>::type;
     void accumulate(T value)
     {
         m_count++;
-        m_result = Derived::apply(m_result, value);
-    }
-
-    void accumulate(util::Optional<T> value)
-    {
-        if (value) {
-            m_count++;
-            m_result = Derived::apply(m_result, *value);
-        }
+        m_result += value;
     }
 
     bool is_null() const
@@ -3742,147 +3806,16 @@ public:
     }
     ResultType result() const
     {
-        return m_result;
+        return m_result / m_count;
+    }
+    static const char* description()
+    {
+        return "@avg";
     }
 
-protected:
+private:
     size_t m_count = 0;
-    ResultType m_result = Derived::initial_value();
-};
-
-template <typename T>
-class Minimum : public BaseAggregateOperation<T, Minimum<T>> {
-public:
-    static T initial_value()
-    {
-        return std::numeric_limits<T>::max();
-    }
-    static T apply(T a, T b)
-    {
-        return std::min(a, b);
-    }
-    static std::string description()
-    {
-        return "@min";
-    }
-};
-
-template <>
-class Minimum<Decimal128> : public BaseAggregateOperation<Decimal128, Minimum<Decimal128>> {
-public:
-    static Decimal128 initial_value()
-    {
-        return Decimal128("+inf");
-    }
-    static Decimal128 apply(Decimal128 a, Decimal128 b)
-    {
-        return std::min(a, b);
-    }
-    static std::string description()
-    {
-        return "@min";
-    }
-};
-
-template <typename T>
-class Maximum : public BaseAggregateOperation<T, Maximum<T>> {
-public:
-    static T initial_value()
-    {
-        return std::numeric_limits<T>::lowest();
-    }
-    static T apply(T a, T b)
-    {
-        return std::max(a, b);
-    }
-    static std::string description()
-    {
-        return "@max";
-    }
-};
-
-template <>
-class Maximum<Decimal128> : public BaseAggregateOperation<Decimal128, Maximum<Decimal128>> {
-public:
-    static Decimal128 initial_value()
-    {
-        return Decimal128("-inf");
-    }
-    static Decimal128 apply(Decimal128 a, Decimal128 b)
-    {
-        return std::max(a, b);
-    }
-    static std::string description()
-    {
-        return "@max";
-    }
-};
-
-template <typename T>
-class Sum : public BaseAggregateOperation<T, Sum<T>> {
-public:
-    static T initial_value()
-    {
-        return T();
-    }
-    static T apply(T a, T b)
-    {
-        return a + b;
-    }
-    bool is_null() const
-    {
-        return false;
-    }
-    static std::string description()
-    {
-        return "@sum";
-    }
-};
-
-template <typename T>
-class Average : public BaseAggregateOperation<T, Average<T>, double> {
-    using Base = BaseAggregateOperation<T, Average<T>, double>;
-
-public:
-    static double initial_value()
-    {
-        return 0;
-    }
-    static double apply(double a, T b)
-    {
-        return a + b;
-    }
-    double result() const
-    {
-        return Base::m_result / Base::m_count;
-    }
-    static std::string description()
-    {
-        return "@avg";
-    }
-};
-
-template <>
-class Average<Decimal128> : public BaseAggregateOperation<Decimal128, Average<Decimal128>, Decimal128> {
-    using Base = BaseAggregateOperation<Decimal128, Average<Decimal128>, Decimal128>;
-
-public:
-    static Decimal128 initial_value()
-    {
-        return Decimal128(0);
-    }
-    static Decimal128 apply(Decimal128 a, Decimal128 b)
-    {
-        return a + b;
-    }
-    Decimal128 result() const
-    {
-        return Decimal128(Base::m_result) / Base::m_count;
-    }
-    static std::string description()
-    {
-        return "@avg";
-    }
+    ResultType m_result = {};
 };
 } // namespace aggregate_operations
 

--- a/test/test_parser.cpp
+++ b/test/test_parser.cpp
@@ -1118,7 +1118,7 @@ TEST(Parser_TwoColumnAggregates)
         obj.set(item_price_col, item_info[i].second);
         obj.set(item_price_float_col, float(item_info[i].second));
         obj.set(item_price_decimal_col, Decimal128(item_info[i].second));
-        obj.set(item_creation_date, Timestamp(item_info[i].second * 10, 0));
+        obj.set(item_creation_date, Timestamp(static_cast<int64_t>(item_info[i].second * 10), 0));
     }
     items->get_object(item_keys[0]).set(item_discount_col, discount_keys[2]); // milk -0.50
     items->get_object(item_keys[2]).set(item_discount_col, discount_keys[1]); // pizza -2.5

--- a/test/test_parser.cpp
+++ b/test/test_parser.cpp
@@ -1107,6 +1107,7 @@ TEST(Parser_TwoColumnAggregates)
     ColKey item_price_float_col = items->add_column(type_Float, "price_float");
     ColKey item_price_decimal_col = items->add_column(type_Decimal, "price_decimal");
     ColKey item_discount_col = items->add_column(*discounts, "discount");
+    ColKey item_creation_date = items->add_column(type_Timestamp, "creation_date");
     using item_t = std::pair<std::string, double>;
     std::vector<item_t> item_info = {{"milk", 5.5}, {"oranges", 4.0}, {"pizza", 9.5}, {"cereal", 6.5}};
     std::vector<ObjKey> item_keys;
@@ -1117,6 +1118,7 @@ TEST(Parser_TwoColumnAggregates)
         obj.set(item_price_col, item_info[i].second);
         obj.set(item_price_float_col, float(item_info[i].second));
         obj.set(item_price_decimal_col, Decimal128(item_info[i].second));
+        obj.set(item_creation_date, Timestamp(item_info[i].second * 10, 0));
     }
     items->get_object(item_keys[0]).set(item_discount_col, discount_keys[2]); // milk -0.50
     items->get_object(item_keys[2]).set(item_discount_col, discount_keys[1]); // pizza -2.5
@@ -1128,6 +1130,7 @@ TEST(Parser_TwoColumnAggregates)
     ColKey items_col = t->add_column_list(*items, "items");
     ColKey account_float_col = t->add_column(type_Float, "account_balance_float");
     ColKey account_decimal_col = t->add_column(type_Decimal, "account_balance_decimal");
+    ColKey account_creation_date_col = t->add_column(type_Timestamp, "account_creation_date");
 
     Obj person0 = t->create_object();
     Obj person1 = t->create_object();
@@ -1137,14 +1140,17 @@ TEST(Parser_TwoColumnAggregates)
     person0.set(account_col, double(10.0));
     person0.set(account_float_col, float(10.0));
     person0.set(account_decimal_col, Decimal128(10.0));
+    person0.set(account_creation_date_col, Timestamp(30, 0));
     person1.set(id_col, int64_t(1));
     person1.set(account_col, double(20.0));
     person1.set(account_float_col, float(20.0));
     person1.set(account_decimal_col, Decimal128(20.0));
+    person1.set(account_creation_date_col, Timestamp(50, 0));
     person2.set(id_col, int64_t(2));
     person2.set(account_col, double(30.0));
     person2.set(account_float_col, float(30.0));
     person2.set(account_decimal_col, Decimal128(30.0));
+    person2.set(account_creation_date_col, Timestamp(70, 0));
 
     LnkLst list_0 = person0.get_linklist(items_col);
     list_0.add(item_keys[0]);
@@ -1201,6 +1207,11 @@ TEST(Parser_TwoColumnAggregates)
     verify_query(test_context, t, "items.@min.price_decimal > account_balance_decimal", 0);
     verify_query(test_context, t, "items.@max.price_decimal > account_balance_decimal", 0);
     verify_query(test_context, t, "items.@avg.price_decimal > account_balance_decimal", 0);
+    // Timestamp vs Timestamp
+    verify_query(test_context, t, "items.@min.creation_date == T40:0", 1); // person0
+    verify_query(test_context, t, "items.@max.creation_date == T95:0", 2); // person0, person2
+    verify_query(test_context, t, "items.@min.creation_date > account_creation_date", 2);
+    verify_query(test_context, t, "items.@max.creation_date > account_creation_date", 3);
 
     // cannot aggregate string
     CHECK_THROW_ANY(verify_query(test_context, t, "items.@min.name > account_balance", 0));
@@ -1663,6 +1674,7 @@ TEST(Parser_collection_aggregates)
     auto credits_col = courses->add_column(type_Double, "credits");
     auto hours_col = courses->add_column(type_Int, "hours_required");
     auto fail_col = courses->add_column(type_Float, "failure_percentage");
+    auto start_date_col = courses->add_column(type_Timestamp, "start_date");
     auto int_col = people->add_column(type_Int, "age");
     auto str_col = people->add_column(type_String, "name");
     auto courses_col = people->add_column_list(*courses, "courses_taken");
@@ -1678,10 +1690,11 @@ TEST(Parser_collection_aggregates)
         BinaryData payload(hash);
         obj.set(binary_col, payload);
     }
-    using cinfo = std::tuple<std::string, double, int64_t, float>;
-    std::vector<cinfo> course_info = {cinfo{"Math", 5.0, 42, 0.36f}, cinfo{"Comp Sci", 4.5, 45, 0.25f},
-                                      cinfo{"Chemistry", 4.0, 41, 0.40f}, cinfo{"English", 3.5, 40, 0.07f},
-                                      cinfo{"Physics", 4.5, 42, 0.42f}};
+    using cinfo = std::tuple<std::string, double, int64_t, float, Timestamp>;
+    std::vector<cinfo> course_info = {
+        cinfo{"Math", 5.0, 42, 0.36f, {10, 0}}, cinfo{"Comp Sci", 4.5, 45, 0.25f, {11, 0}},
+        cinfo{"Chemistry", 4.0, 41, 0.40f, {12, 0}}, cinfo{"English", 3.5, 40, 0.07f, {13, 0}},
+        cinfo{"Physics", 4.5, 42, 0.42f, {14, 0}}};
     std::vector<ObjKey> course_keys;
     for (cinfo course : course_info) {
         Obj obj = courses->create_object();
@@ -1690,6 +1703,7 @@ TEST(Parser_collection_aggregates)
         obj.set(credits_col, std::get<1>(course));
         obj.set(hours_col, std::get<2>(course));
         obj.set(fail_col, std::get<3>(course));
+        obj.set(start_date_col, std::get<4>(course));
     }
     auto it = people->begin();
     LnkLstPtr billy_courses = it->get_linklist_ptr(courses_col);
@@ -1728,6 +1742,10 @@ TEST(Parser_collection_aggregates)
     verify_query(test_context, people, "courses_taken.@max.failure_percentage > 0.40", 2);
     verify_query(test_context, people, "courses_taken.@sum.failure_percentage > 0.5", 3);
     verify_query(test_context, people, "courses_taken.@avg.failure_percentage > 0.40", 1);
+
+    // timestamp
+    verify_query(test_context, people, "courses_taken.@min.start_date < T12:0", 2);
+    verify_query(test_context, people, "courses_taken.@max.start_date > T12:0", 3);
 
     // count and size are interchangeable but only operate on certain types
     // count of lists


### PR DESCRIPTION
This actually makes the query expressions work for any comparable column type, but I only added it to the parser for Timestamp and that's probably all that Cocoa will expose (querying for the minimum string has well-defined results but is pretty weird). Should be a trivial merge over to the bison branch since the only parser change was adding Timestamp to the list of supported types.

I shuffled some code around in ListColumnAggregate to detemplate some of the code in evaluate that didn't need to be templated and to eliminate the need for accumulate(Optional<T>) in each operation. BaseAggregateOperation turned out to not simplify the subclasses, and removing it was a net reduction in code.

The new tests are pretty minimal because there isn't actually any Timestamp-specific code to test.