### PR TITLE
RCORE-444 Add test for dangling links being included in prior_size

### DIFF
--- a/test/test_sync.cpp
+++ b/test/test_sync.cpp
@@ -8336,7 +8336,7 @@ TEST(Sync_DanglingLinksCountInPriorSize)
         auto wt = local_db->start_write();
         auto source_table = sync::create_table_with_primary_key(*wt, "class_source", type_String, "_id");
         auto target_table = sync::create_table_with_primary_key(*wt, "class_target", type_String, "_id");
-        source_table->add_column_link(type_LinkList, "links", *target_table);
+        source_table->add_column_list(*target_table, "links");
 
         source_table_key = source_table->get_key();
         target_table_key = target_table->get_key();

--- a/test/test_sync.cpp
+++ b/test/test_sync.cpp
@@ -8305,4 +8305,89 @@ TEST(Sync_Set)
     }
 }
 
+TEST(Sync_DanglingLinksCountInPriorSize)
+{
+    SHARED_GROUP_TEST_PATH(path);
+    realm::DBOptions db_opts;
+    realm::_impl::ClientHistoryImpl history{path};
+    auto local_db = realm::DB::create(history, db_opts);
+    auto& logger = test_context.logger;
+
+    history.set_client_file_ident(sync::SaltedFileIdent{1, 123456}, true);
+
+    version_type last_version, last_version_observed = 0;
+    auto dump_uploadable = [&] {
+        UploadCursor upload_cursor{last_version_observed, 0};
+        std::vector<sync::ClientReplicationBase::UploadChangeset> changesets_to_upload;
+        version_type locked_server_version = 0;
+        history.find_uploadable_changesets(upload_cursor, last_version, changesets_to_upload, locked_server_version);
+        CHECK_EQUAL(changesets_to_upload.size(), static_cast<size_t>(1));
+        realm::sync::Changeset parsed_changeset;
+        auto unparsed_changeset = changesets_to_upload[0].changeset.get_first_chunk();
+        realm::_impl::SimpleNoCopyInputStream changeset_stream(unparsed_changeset.data(), unparsed_changeset.size());
+        realm::sync::parse_changeset(changeset_stream, parsed_changeset);
+        logger.info("changeset at version %1: %2", last_version, parsed_changeset);
+        last_version_observed = last_version;
+        return parsed_changeset;
+    };
+
+    TableKey source_table_key, target_table_key;
+    {
+        auto wt = local_db->start_write();
+        auto source_table = sync::create_table_with_primary_key(*wt, "class_source", type_String, "_id");
+        auto target_table = sync::create_table_with_primary_key(*wt, "class_target", type_String, "_id");
+        source_table->add_column_link(type_LinkList, "links", *target_table);
+
+        source_table_key = source_table->get_key();
+        target_table_key = target_table->get_key();
+
+        auto obj_to_keep = target_table->create_object_with_primary_key(std::string{"target1"});
+        auto obj_to_delete = target_table->create_object_with_primary_key(std::string{"target2"});
+        auto source_obj = source_table->create_object_with_primary_key(std::string{"source"});
+
+        auto links_list = source_obj.get_linklist("links");
+        links_list.add(obj_to_keep.get_key());
+        links_list.add(obj_to_delete.get_key());
+        last_version = wt->commit();
+    }
+
+    dump_uploadable();
+
+    {
+        // Simulate removing the object via the sync client so we get a dangling link
+        TempShortCircuitReplication disable_repl(history);
+        auto wt = local_db->start_write();
+        auto target_table = wt->get_table(target_table_key);
+        auto obj = target_table->get_object_with_primary_key(std::string{"target2"});
+        obj.invalidate();
+        last_version = wt->commit();
+    }
+
+    {
+        auto wt = local_db->start_write();
+        auto source_table = wt->get_table(source_table_key);
+        auto target_table = wt->get_table(target_table_key);
+
+        auto obj_to_add = target_table->create_object_with_primary_key(std::string{"target3"});
+
+        auto source_obj = source_table->get_object_with_primary_key(std::string{"source"});
+        auto links_list = source_obj.get_linklist("links");
+        links_list.add(obj_to_add.get_key());
+        last_version = wt->commit();
+    }
+
+    auto changeset = dump_uploadable();
+    CHECK_EQUAL(changeset.size(), static_cast<size_t>(2));
+    auto changeset_it = changeset.end();
+    --changeset_it;
+    auto last_instr = *changeset_it;
+    CHECK_EQUAL(last_instr->type(), Instruction::Type::ArrayInsert);
+    auto arr_insert_instr = last_instr->get_as<Instruction::ArrayInsert>();
+    CHECK_EQUAL(changeset.get_string(arr_insert_instr.table), StringData("source"));
+    CHECK(arr_insert_instr.value.type == sync::instr::Payload::Type::Link);
+    CHECK_EQUAL(changeset.get_string(mpark::get<InternString>(arr_insert_instr.value.data.link.target)),
+                StringData("target3"));
+    CHECK_EQUAL(arr_insert_instr.prior_size, 2);
+}
+
 } // unnamed namespace


### PR DESCRIPTION
In the realm-sync repo, dangling links in lists of links weren't included in the prior_size field of array mutation instructions which would cause the server to reject operations on those lists with an error. This behavior was fixed in the monorepo (now merged into the master branch) - this PR only copies the test that was added to the v10 branch of the realm-sync repo to realm-core so that we have a test case for this issue going forward.