### PR TITLE
better error messaging for MixedArguments bounds checking

### DIFF
--- a/src/realm/parser/driver.cpp
+++ b/src/realm/parser/driver.cpp
@@ -158,59 +158,73 @@ inline T string_to(const std::string& s)
 class MixedArguments : public query_parser::Arguments {
 public:
     MixedArguments(const std::vector<Mixed>& args)
-        : m_args(args)
+        : Arguments(args.size())
+        , m_args(args)
     {
     }
     bool bool_for_argument(size_t n) final
     {
+        Arguments::verify_ndx(n);
         return m_args.at(n).get<bool>();
     }
     long long long_for_argument(size_t n) final
     {
+        Arguments::verify_ndx(n);
         return m_args.at(n).get<int64_t>();
     }
     float float_for_argument(size_t n) final
     {
+        Arguments::verify_ndx(n);
         return m_args.at(n).get<float>();
     }
     double double_for_argument(size_t n) final
     {
+        Arguments::verify_ndx(n);
         return m_args.at(n).get<double>();
     }
     StringData string_for_argument(size_t n) final
     {
+        Arguments::verify_ndx(n);
         return m_args.at(n).get<StringData>();
     }
     BinaryData binary_for_argument(size_t n) final
     {
+        Arguments::verify_ndx(n);
         return m_args.at(n).get<BinaryData>();
     }
     Timestamp timestamp_for_argument(size_t n) final
     {
+        Arguments::verify_ndx(n);
         return m_args.at(n).get<Timestamp>();
     }
     ObjectId objectid_for_argument(size_t n) final
     {
+        Arguments::verify_ndx(n);
         return m_args.at(n).get<ObjectId>();
     }
     UUID uuid_for_argument(size_t n) final
     {
+        Arguments::verify_ndx(n);
         return m_args.at(n).get<UUID>();
     }
     Decimal128 decimal128_for_argument(size_t n) final
     {
+        Arguments::verify_ndx(n);
         return m_args.at(n).get<Decimal128>();
     }
     ObjKey object_index_for_argument(size_t n) final
     {
+        Arguments::verify_ndx(n);
         return m_args.at(n).get<ObjKey>();
     }
     bool is_argument_null(size_t n) final
     {
+        Arguments::verify_ndx(n);
         return m_args.at(n).is_null();
     }
     DataType type_for_argument(size_t n)
     {
+        Arguments::verify_ndx(n);
         return m_args.at(n).get_type();
     }
 

--- a/test/test_parser.cpp
+++ b/test/test_parser.cpp
@@ -1358,6 +1358,12 @@ TEST(Parser_substitution)
     CHECK_EQUAL(message, "Request for argument at index 1 but only 1 argument is provided");
     CHECK_THROW_ANY_GET_MESSAGE(verify_query_sub(test_context, t, "age > $2", args, /*num_args*/ 2, 0), message);
     CHECK_EQUAL(message, "Request for argument at index 2 but only 2 arguments are provided");
+    CHECK_THROW_ANY_GET_MESSAGE(t->query("age > $0", std::vector<Mixed>{}), message);
+    CHECK_EQUAL(message, "Request for argument at index 0 but no arguments are provided");
+    CHECK_THROW_ANY_GET_MESSAGE(t->query("age > $1", std::vector<Mixed>{{1}}), message);
+    CHECK_EQUAL(message, "Request for argument at index 1 but only 1 argument is provided");
+    CHECK_THROW_ANY_GET_MESSAGE(t->query("age > $2", std::vector<Mixed>{{1}, {2}}), message);
+    CHECK_EQUAL(message, "Request for argument at index 2 but only 2 arguments are provided");
 
     // Mixed types
     // int


### PR DESCRIPTION
Better error messages for bounds checking when using the MixedArguments, and standard with other argument types.
Requested by @nirinchev 