### PR TITLE
RCORE-422 surface errors from WebSocket close messages to user

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ### Enhancements
 * Sync client now logs error messages received from server rather than just the size of the error message ([RCORE-425](https://jira.mongodb.org/browse/RCORE-425)).
+* Errors returned from the server when sync WebSockets get closed are now captured and surfaced as a SyncError ([RCORE-422](https://jira.mongodb.org/browse/RCORE-422))
 
 ### Fixed
 * <How to hit and notice issue? what was the impact?> ([#????](https://github.com/realm/realm-core/issues/????), since v?.?.?)

--- a/src/realm/sync/noinst/client_impl_base.cpp
+++ b/src/realm/sync/noinst/client_impl_base.cpp
@@ -463,6 +463,17 @@ bool Connection::websocket_pong_message_received(const char* data, std::size_t s
 }
 
 
+bool Connection::websocket_close_message_received(std::error_code error_code, StringData message)
+{
+    if (error_code.category() == websocket::websocket_close_status_category() && error_code.value() != 1005 &&
+        error_code.value() != 1000) {
+        m_reconnect_info.m_reason = ConnectionTerminationReason::websocket_protocol_violation;
+        involuntary_disconnect(error_code, false, &message);
+    }
+
+    return true;
+}
+
 // Guarantees that handle_reconnect_wait() is never called from within the
 // execution of initiate_reconnect_wait() (no callback reentrance).
 void Connection::initiate_reconnect_wait()

--- a/src/realm/sync/noinst/client_impl_base.hpp
+++ b/src/realm/sync/noinst/client_impl_base.hpp
@@ -299,6 +299,7 @@ public:
     void websocket_handshake_error_handler(std::error_code, const util::HTTPHeaders*,
                                            const util::StringView*) override;
     void websocket_protocol_error_handler(std::error_code) override;
+    bool websocket_close_message_received(std::error_code error_code, StringData message) override;
     bool websocket_binary_message_received(const char*, std::size_t) override;
     bool websocket_pong_message_received(const char*, std::size_t) override;
 

--- a/src/realm/util/websocket.cpp
+++ b/src/realm/util/websocket.cpp
@@ -912,7 +912,7 @@ private:
     {
         uint16_t error_code;
         StringData error_message;
-        if (m_frame_reader.delivery_size < 2) {
+        if (size < 2) {
             // Error code 1005 is defined as
             //     1005 is a reserved value and MUST NOT be set as a status code in a
             //     Close control frame by an endpoint.  It is designated for use in
@@ -925,8 +925,8 @@ private:
             // Otherwise, the error code is the first two bytes of the body as a uint16_t in
             // network byte order. See https://tools.ietf.org/html/rfc6455#section-5.5.1 for more
             // details.
-            error_code = ntohs((m_frame_reader.delivery_buffer[1] << 8) | m_frame_reader.delivery_buffer[0]);
-            error_message = StringData(m_frame_reader.delivery_buffer + 2, m_frame_reader.delivery_size - 2);
+            error_code = ntohs((data[1] << 8) | data[0]);
+            error_message = StringData(data + 2, size - 2);
         }
 
         std::error_code error_code_with_category{error_code, websocket::websocket_close_status_category()};

--- a/src/realm/util/websocket.hpp
+++ b/src/realm/util/websocket.hpp
@@ -81,7 +81,7 @@ public:
     /// websocket object is destroyed during execution of the function.
     virtual bool websocket_text_message_received(const char* data, size_t size);
     virtual bool websocket_binary_message_received(const char* data, size_t size);
-    virtual bool websocket_close_message_received(const char* data, size_t size);
+    virtual bool websocket_close_message_received(std::error_code error_code, StringData message);
     virtual bool websocket_ping_message_received(const char* data, size_t size);
     virtual bool websocket_pong_message_received(const char* data, size_t size);
     //@}
@@ -215,6 +215,8 @@ enum class Error {
     bad_response_header_protocol_violation,
     bad_message
 };
+
+const std::error_category& websocket_close_status_category() noexcept;
 
 const std::error_category& error_category() noexcept;
 

--- a/test/test_util_websocket.cpp
+++ b/test/test_util_websocket.cpp
@@ -173,7 +173,7 @@ public:
 
     std::vector<std::string> text_messages;
     std::vector<std::string> binary_messages;
-    std::vector<std::string> close_messages;
+    std::vector<std::pair<std::error_code, std::string>> close_messages;
     std::vector<std::string> ping_messages;
     std::vector<std::string> pong_messages;
 
@@ -246,9 +246,9 @@ public:
         return true;
     }
 
-    bool websocket_close_message_received(const char* data, size_t size) override
+    bool websocket_close_message_received(std::error_code error_code, StringData error_message) override
     {
-        close_messages.push_back(std::string{data, size});
+        close_messages.push_back(std::make_pair(error_code, std::string{error_message}));
         return true;
     }
 
@@ -387,9 +387,12 @@ TEST(WebSocket_Messages)
     CHECK_EQUAL(config_2.binary_messages.size(), 1);
     CHECK_EQUAL(config_2.binary_messages[0], "short binary example");
 
-    socket_2.async_write_close("close message", 13, handler_no_op);
+    socket_2.async_write_close("\x03\xe8"
+                               "close message",
+                               15, handler_no_op);
     CHECK_EQUAL(config_1.close_messages.size(), 1);
-    CHECK_EQUAL(config_1.close_messages[0], "close message");
+    CHECK_EQUAL(config_1.close_messages[0].first.value(), 1000);
+    CHECK_EQUAL(config_1.close_messages[0].second, "close message");
 
     std::vector<size_t> message_sizes{1, 2, 100, 125, 126, 127, 128, 200, 1000, 65000, 65535, 65536, 100000, 1000000};
     for (size_t i = 0; i < message_sizes.size(); ++i) {


### PR DESCRIPTION
This changes our WebSocket implementation so that it captures the error code and error message from the server and surfaces it to the user as a SyncError. This fixes the case where a very large changeset (16MB) would cause the sync client to get disconnected with just a connection reset.
