### PR TITLE
Catch metadata realm decryption.

### DIFF
--- a/src/realm/object-store/sync/impl/sync_metadata.cpp
+++ b/src/realm/object-store/sync/impl/sync_metadata.cpp
@@ -435,7 +435,7 @@ util::Optional<SyncFileActionMetadata> SyncMetadataManager::get_file_action_meta
 
 std::shared_ptr<Realm> SyncMetadataManager::get_realm() const
 {
-    SharedRealm realm = Realm::get_shared_realm(m_metadata_config);
+    auto realm = Realm::get_shared_realm(m_metadata_config);
     realm->refresh();
     return realm;
 }

--- a/src/realm/object-store/sync/impl/sync_metadata.hpp
+++ b/src/realm/object-store/sync/impl/sync_metadata.hpp
@@ -33,6 +33,7 @@ template <typename T>
 class BasicRowExpr;
 using RowExpr = BasicRowExpr<Table>;
 class SyncMetadataManager;
+class SyncFileManager;
 
 // A facade for a metadata Realm object representing app metadata
 class SyncAppMetadata {
@@ -260,7 +261,7 @@ public:
     /// If the platform supports it, setting `should_encrypt` to `true` and not specifying an encryption key will make
     /// the object store handle generating and persisting an encryption key for the metadata database. Otherwise, an
     /// exception will be thrown.
-    SyncMetadataManager(std::string path, bool should_encrypt,
+    SyncMetadataManager(const SyncFileManager& file_manager, std::string path, bool should_encrypt,
                         util::Optional<std::vector<char>> encryption_key = none);
 
 private:

--- a/src/realm/object-store/sync/sync_manager.cpp
+++ b/src/realm/object-store/sync/sync_manager.cpp
@@ -87,7 +87,6 @@ void SyncManager::configure(std::shared_ptr<app::App> app, const std::string& sy
 
         bool encrypt = m_config.metadata_mode == MetadataMode::Encryption;
         try {
-            // *m_file_manager,
             m_metadata_manager = std::make_unique<SyncMetadataManager>(*m_file_manager, m_file_manager->metadata_path(), encrypt,
                                                                        m_config.custom_encryption_key);
         }

--- a/src/realm/object-store/sync/sync_manager.cpp
+++ b/src/realm/object-store/sync/sync_manager.cpp
@@ -87,12 +87,13 @@ void SyncManager::configure(std::shared_ptr<app::App> app, const std::string& sy
 
         bool encrypt = m_config.metadata_mode == MetadataMode::Encryption;
         try {
-            m_metadata_manager = std::make_unique<SyncMetadataManager>(m_file_manager->metadata_path(), encrypt,
+            // *m_file_manager,
+            m_metadata_manager = std::make_unique<SyncMetadataManager>(*m_file_manager, m_file_manager->metadata_path(), encrypt,
                                                                        m_config.custom_encryption_key);
         }
         catch (RealmFileException const&) {
             if (m_config.reset_metadata_on_error && m_file_manager->remove_metadata_realm()) {
-                m_metadata_manager = std::make_unique<SyncMetadataManager>(m_file_manager->metadata_path(), encrypt,
+                m_metadata_manager = std::make_unique<SyncMetadataManager>(*m_file_manager, m_file_manager->metadata_path(), encrypt,
                                                                            std::move(m_config.custom_encryption_key));
             }
             else {

--- a/test/object-store/sync/metadata.cpp
+++ b/test/object-store/sync/metadata.cpp
@@ -504,22 +504,50 @@ TEST_CASE("sync_metadata: persistence across metadata manager instances", "[sync
         REQUIRE(second_manager.client_uuid() == first_client_uuid);
     }
 }
-
+#include "sync_test_utils.hpp"
 TEST_CASE("sync_metadata: encryption", "[sync]") {
     util::try_make_dir(base_path);
     auto close = util::make_scope_exit([=]() noexcept {
         util::try_remove_dir_recursive(base_path);
     });
 
+    
     SECTION("prohibits opening the metadata Realm with different keys") {
         SECTION("different keys") {
-            SyncMetadataManager first_manager(metadata_path, true, make_test_encryption_key(10));
-            REQUIRE_THROWS(SyncMetadataManager(metadata_path, true, make_test_encryption_key(11)));
+            const auto identity0 = "identity0";
+            const auto auth_url = "https://realm.example.org";
+
+            // Open metadata realm, make metadata
+            std::vector<char> key0 = make_test_encryption_key(10);
+            SyncMetadataManager manager0(metadata_path, true, key0);
+            auto user_metadata = manager0.get_or_make_user_metadata(identity0, auth_url);
+            REQUIRE(bool(user_metadata));
+            CHECK(user_metadata->identity() == identity0);
+            CHECK(user_metadata->provider_type() == auth_url);
+            CHECK(user_metadata->access_token().empty());
+            CHECK(user_metadata->is_valid());
+            
+            // close metadatarealm?? ---
+            
+            // Open metadata realm with different key
+            std::vector<char> key1 = make_test_encryption_key(11);
+            SyncMetadataManager manager1(metadata_path, true, key1);
+            auto user_metadata1 = manager1.get_or_make_user_metadata(identity0, auth_url, false);
+            // Expect previous metadata to no longer be stored
+            CHECK_FALSE(bool(user_metadata1));
+
+            // But new metadata can still be created
+            const auto identity1 = "identity1";
+            auto user_metadata2 = manager1.get_or_make_user_metadata(identity1, auth_url);
+            CHECK(user_metadata2->identity() == identity1);
+            CHECK(user_metadata2->provider_type() == auth_url);
+            CHECK(user_metadata2->access_token().empty());
+            CHECK(user_metadata2->is_valid());
         }
-        SECTION("different encryption settings") {
-            SyncMetadataManager first_manager(metadata_path, true, make_test_encryption_key(10));
-            REQUIRE_THROWS(SyncMetadataManager(metadata_path, false));
-        }
+//        SECTION("different encryption settings") {
+//            SyncMetadataManager first_manager(metadata_path, true, make_test_encryption_key(10));
+//            REQUIRE_THROWS(SyncMetadataManager(metadata_path, false));
+//        }
     }
 
     SECTION("works when enabled") {

--- a/test/object-store/sync/metadata.cpp
+++ b/test/object-store/sync/metadata.cpp
@@ -513,7 +513,7 @@ TEST_CASE("sync_metadata: persistence across metadata manager instances", "[sync
         REQUIRE(second_manager.client_uuid() == first_client_uuid);
     }
 }
-#include "sync_test_utils.hpp"
+
 TEST_CASE("sync_metadata: encryption", "[sync]") {
     util::try_make_dir(base_path);
     auto close = util::make_scope_exit([=]() noexcept {

--- a/test/object-store/sync/metadata.cpp
+++ b/test/object-store/sync/metadata.cpp
@@ -23,6 +23,7 @@
 #include <realm/object-store/schema.hpp>
 
 #include <realm/object-store/impl/object_accessor_impl.hpp>
+#include "util/test_file.hpp"
 #include "util/test_utils.hpp"
 
 #include <realm/util/file.hpp>
@@ -116,7 +117,8 @@ TEST_CASE("sync_metadata: migration", "[sync]") {
         }
         // Open v2 metadata
         {
-            SyncMetadataManager manager(metadata_path, false, none);
+            auto file_manager = SyncFileManager(base_path, "app_id");
+            SyncMetadataManager manager(file_manager, metadata_path, false, none);
             SECTION("for existing entries") {
                 auto md_1 = manager.get_or_make_user_metadata(identity_1, "", false);
                 REQUIRE(bool(md_1));
@@ -174,7 +176,8 @@ TEST_CASE("sync_metadata: migration", "[sync]") {
         }
         // Open v2 metadata
         {
-            SyncMetadataManager manager(metadata_path, false, none);
+            auto file_manager = SyncFileManager(base_path, "app_id");
+            SyncMetadataManager manager(file_manager, metadata_path, false, none);
             SECTION("for existing entries") {
                 auto md_1 = manager.get_or_make_user_metadata(identity_1, "", false);
                 REQUIRE(bool(md_1));
@@ -212,7 +215,8 @@ TEST_CASE("sync_metadata: user metadata", "[sync]") {
         util::try_remove_dir_recursive(base_path);
     });
 
-    SyncMetadataManager manager(metadata_path, false);
+    auto file_manager = SyncFileManager(base_path, "app_id");
+    SyncMetadataManager manager(file_manager, file_manager.metadata_path(), false);
     const std::string provider_type = "https://realm.example.org";
 
     SECTION("can be properly constructed") {
@@ -311,7 +315,8 @@ TEST_CASE("sync_metadata: user metadata APIs", "[sync]") {
         util::try_remove_dir_recursive(base_path);
     });
 
-    SyncMetadataManager manager(metadata_path, false);
+    auto file_manager = SyncFileManager(base_path, "app_id");
+    SyncMetadataManager manager(file_manager, file_manager.metadata_path(), false);
     const std::string provider_type = "https://realm.example.org";
 
     SECTION("properly list all marked and unmarked users") {
@@ -350,7 +355,8 @@ TEST_CASE("sync_metadata: file action metadata", "[sync]") {
         util::try_remove_dir_recursive(base_path);
     });
 
-    SyncMetadataManager manager(metadata_path, false);
+    auto file_manager = SyncFileManager(base_path, "app_id");
+    SyncMetadataManager manager(file_manager, file_manager.metadata_path(), false);
 
     const std::string local_uuid_1 = "asdfg";
     const std::string local_uuid_2 = "qwerty";
@@ -401,7 +407,8 @@ TEST_CASE("sync_metadata: file action metadata APIs", "[sync]") {
         util::try_remove_dir_recursive(base_path);
     });
 
-    SyncMetadataManager manager(metadata_path, false);
+    auto file_manager = SyncFileManager(base_path, "app_id");
+    SyncMetadataManager manager(file_manager, file_manager.metadata_path(), false);
     SECTION("properly list all pending actions, reflecting their deletion") {
         const auto filename1 = util::make_temp_dir() + "foobar/file1";
         const auto filename2 = util::make_temp_dir() + "foobar/file2";
@@ -430,7 +437,8 @@ TEST_CASE("sync_metadata: results", "[sync]") {
         util::try_remove_dir_recursive(base_path);
     });
 
-    SyncMetadataManager manager(metadata_path, false);
+    auto file_manager = SyncFileManager(base_path, "app_id");
+    SyncMetadataManager manager(file_manager, file_manager.metadata_path(), false);
     const auto identity1 = "testcase3a1";
     const auto identity2 = "testcase3a1"; // same as identity 1
     const auto identity3 = "testcase3a3";
@@ -482,10 +490,11 @@ TEST_CASE("sync_metadata: persistence across metadata manager instances", "[sync
     });
 
     SECTION("works for the basic case") {
+        auto file_manager = SyncFileManager(base_path, "app_id");
         const auto identity = "testcase4a";
         const std::string provider_type = "any-type";
         const std::string sample_token = "this_is_a_user_token";
-        SyncMetadataManager first_manager(metadata_path, false);
+        SyncMetadataManager first_manager(file_manager, file_manager.metadata_path(), false);
         auto first = first_manager.get_or_make_user_metadata(identity, provider_type);
         first->set_access_token(sample_token);
         REQUIRE(first->identity() == identity);
@@ -495,7 +504,7 @@ TEST_CASE("sync_metadata: persistence across metadata manager instances", "[sync
         auto first_client_uuid = first_manager.client_uuid();
         first->set_state(SyncUser::State::LoggedOut);
 
-        SyncMetadataManager second_manager(metadata_path, false);
+        SyncMetadataManager second_manager(file_manager, file_manager.metadata_path(), false);
         auto second = second_manager.get_or_make_user_metadata(identity, provider_type, false);
         REQUIRE(second->identity() == identity);
         REQUIRE(second->provider_type() == provider_type);
@@ -514,24 +523,23 @@ TEST_CASE("sync_metadata: encryption", "[sync]") {
     
     SECTION("prohibits opening the metadata Realm with different keys") {
         SECTION("different keys") {
+            auto file_manager = SyncFileManager(base_path, "app_id");
             const auto identity0 = "identity0";
             const auto auth_url = "https://realm.example.org";
 
             // Open metadata realm, make metadata
             std::vector<char> key0 = make_test_encryption_key(10);
-            SyncMetadataManager manager0(metadata_path, true, key0);
+            SyncMetadataManager manager0(file_manager, file_manager.metadata_path(), true, key0);
             auto user_metadata = manager0.get_or_make_user_metadata(identity0, auth_url);
             REQUIRE(bool(user_metadata));
             CHECK(user_metadata->identity() == identity0);
             CHECK(user_metadata->provider_type() == auth_url);
             CHECK(user_metadata->access_token().empty());
             CHECK(user_metadata->is_valid());
-            
-            // close metadatarealm?? ---
-            
+                        
             // Open metadata realm with different key
             std::vector<char> key1 = make_test_encryption_key(11);
-            SyncMetadataManager manager1(metadata_path, true, key1);
+            SyncMetadataManager manager1(file_manager, file_manager.metadata_path(), true, key1);
             auto user_metadata1 = manager1.get_or_make_user_metadata(identity0, auth_url, false);
             // Expect previous metadata to no longer be stored
             CHECK_FALSE(bool(user_metadata1));
@@ -544,17 +552,19 @@ TEST_CASE("sync_metadata: encryption", "[sync]") {
             CHECK(user_metadata2->access_token().empty());
             CHECK(user_metadata2->is_valid());
         }
-//        SECTION("different encryption settings") {
-//            SyncMetadataManager first_manager(metadata_path, true, make_test_encryption_key(10));
-//            REQUIRE_THROWS(SyncMetadataManager(metadata_path, false));
-//        }
+        SECTION("different encryption settings") {
+            auto file_manager = SyncFileManager(base_path, "app_id");
+            SyncMetadataManager first_manager(file_manager, file_manager.metadata_path(), true, make_test_encryption_key(10));
+            REQUIRE_THROWS(SyncMetadataManager(file_manager, file_manager.metadata_path(), false));
+        }
     }
 
     SECTION("works when enabled") {
+        auto file_manager = SyncFileManager(base_path, "app_id");
         std::vector<char> key = make_test_encryption_key(10);
         const auto identity = "testcase5a";
         const auto auth_url = "https://realm.example.org";
-        SyncMetadataManager manager(metadata_path, true, key);
+        SyncMetadataManager manager(file_manager, file_manager.metadata_path(), true, key);
         auto user_metadata = manager.get_or_make_user_metadata(identity, auth_url);
         REQUIRE(bool(user_metadata));
         CHECK(user_metadata->identity() == identity);
@@ -562,7 +572,7 @@ TEST_CASE("sync_metadata: encryption", "[sync]") {
         CHECK(user_metadata->access_token().empty());
         CHECK(user_metadata->is_valid());
         // Reopen the metadata file with the same key.
-        SyncMetadataManager manager_2(metadata_path, true, key);
+        SyncMetadataManager manager_2(file_manager, file_manager.metadata_path(), true, key);
         auto user_metadata_2 = manager_2.get_or_make_user_metadata(identity, auth_url, false);
         REQUIRE(bool(user_metadata_2));
         CHECK(user_metadata_2->identity() == identity);

--- a/test/object-store/sync/sync_manager.cpp
+++ b/test/object-store/sync/sync_manager.cpp
@@ -274,7 +274,7 @@ TEST_CASE("sync_manager: persistent user state management", "[sync]") {
     reset_test_directory(base_path);
     auto file_manager = SyncFileManager(base_path, "app_id");
     // Open the metadata separately, so we can investigate it ourselves.
-    SyncMetadataManager manager(file_manager.metadata_path(), false);
+    SyncMetadataManager manager(file_manager, file_manager.metadata_path(), false);
     using Cfg = TestSyncManager::Config;
 
     const std::string url_1 = "https://realm.example.org/1/";
@@ -377,7 +377,7 @@ TEST_CASE("sync_manager: file actions", "[sync]") {
 
     auto file_manager = SyncFileManager(base_path, "bar_app_id");
     // Open the metadata separately, so we can investigate it ourselves.
-    SyncMetadataManager manager(file_manager.metadata_path(), false);
+    SyncMetadataManager manager(file_manager, file_manager.metadata_path(), false);
 
     const std::string realm_url = "https://example.realm.com/~/1";
     const std::string uuid_1 = "uuid-foo-1";

--- a/test/object-store/sync/user.cpp
+++ b/test/object-store/sync/user.cpp
@@ -146,7 +146,7 @@ TEST_CASE("sync_user: user persistence", "[sync]") {
     auto sync_manager = init_sync_manager.app()->sync_manager();
     auto file_manager = SyncFileManager(base_path, "baz_app_id");
     // Open the metadata separately, so we can investigate it ourselves.
-    SyncMetadataManager manager(file_manager.metadata_path(), false);
+    SyncMetadataManager manager(file_manager, file_manager.metadata_path(), false);
 
     SECTION("properly persists a user's information upon creation") {
         const std::string identity = "test_identity_1";


### PR DESCRIPTION
Related to [RCOCOA-1035](https://jira.mongodb.org/browse/RCOCOA-1035)



## What, How & Why?
**What:** Opening a metadata realm with the wrong encryption key will remove that metadata realm and create a new realm using the new key.

**How:** Catch opening the metadata realm when the SyncMetadataManager is being constructed. If caught exception, remove metadata realm, open a new one in its place.

**Why:** Realm-core creates an encryption key for devices if one does not exist. It's possible for a device to lose its encryption key, but retain the sync metadata realm (for example, via a backup). Previously, the newly created key couldn't open the realm and an exception could be thrown each time the app is started.

## ☑️ ToDos
* [ ] 📝 Changelog update
* [ ] 🚦 Tests (or not relevant)
