### PR TITLE
Update set operations to work for String sets

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 * Calling Table::clear() will in many cases not work for the data types introduced in v10.2.0. ([#4198](https://github.com/realm/realm-core/issues/4198), since v10.2.0)
 * Fix `links_to()` queries on sets of objects. ([#4264](https://github.com/realm/realm-core/pull/4264)
 * Windows `InterprocessCondVar` changes reverted.
+* Operations like Set::assign_union() can fail on StringData sets, ([#4288](https://github.com/realm/realm-core/issues/4288)
  
 ### Breaking changes
 * Support for IncludeDescriptor has been removed.

--- a/src/realm/set.hpp
+++ b/src/realm/set.hpp
@@ -905,10 +905,11 @@ template <class T>
 template <class It1, class It2>
 void Set<T>::assign_union(It1 first, It2 last)
 {
-    std::vector<T> the_union;
-    std::set_union(begin(), end(), first, last, std::back_inserter(the_union), SetElementLessThan<T>{});
-    clear();
-    for (auto value : the_union) {
+    std::vector<T> the_diff;
+    std::set_difference(first, last, begin(), end(), std::back_inserter(the_diff), SetElementLessThan<T>{});
+    // 'the_diff' now contains all the elements that are in foreign set, but not in 'this'
+    // Now insert those elements
+    for (auto value : the_diff) {
         insert(value);
     }
 }
@@ -925,8 +926,9 @@ template <class It1, class It2>
 void Set<T>::assign_intersection(It1 first, It2 last)
 {
     std::vector<T> intersection;
-    std::set_intersection(begin(), end(), first, last, std::back_inserter(intersection), SetElementLessThan<T>{});
+    std::set_intersection(first, last, begin(), end(), std::back_inserter(intersection), SetElementLessThan<T>{});
     clear();
+    // Elements in intersection comes from foreign set, so ok to use here
     for (auto value : intersection) {
         insert(value);
     }
@@ -943,11 +945,12 @@ template <class T>
 template <class It1, class It2>
 void Set<T>::assign_difference(It1 first, It2 last)
 {
-    std::vector<T> difference;
-    std::set_difference(begin(), end(), first, last, std::back_inserter(difference), SetElementLessThan<T>{});
-    clear();
-    for (auto value : difference) {
-        insert(value);
+    std::vector<T> intersection;
+    std::set_intersection(first, last, begin(), end(), std::back_inserter(intersection), SetElementLessThan<T>{});
+    // 'intersection' now contains all the elements that are in both foreign set and 'this'.
+    // Remove those elements. The elements comes from the foreign set, so ok to refer to.
+    for (auto value : intersection) {
+        erase(value);
     }
 }
 
@@ -963,9 +966,13 @@ template <class It1, class It2>
 void Set<T>::assign_symmetric_difference(It1 first, It2 last)
 {
     std::vector<T> difference;
-    std::set_symmetric_difference(begin(), end(), first, last, std::back_inserter(difference),
-                                  SetElementLessThan<T>{});
-    clear();
+    std::set_difference(first, last, begin(), end(), std::back_inserter(difference), SetElementLessThan<T>{});
+    std::vector<T> intersection;
+    std::set_intersection(first, last, begin(), end(), std::back_inserter(intersection), SetElementLessThan<T>{});
+    // Now remove the common elements and add the differences
+    for (auto value : intersection) {
+        erase(value);
+    }
     for (auto value : difference) {
         insert(value);
     }

--- a/test/test_set.cpp
+++ b/test/test_set.cpp
@@ -377,6 +377,35 @@ TEST(Set_Union)
     CHECK_EQUAL(set1.get(4), 5);
 }
 
+TEST(Set_UnionString)
+{
+    Group g;
+    auto foos = g.add_table("class_Foo");
+    ColKey col_strings = foos->add_column_set(type_String, "strings");
+
+    auto obj1 = foos->create_object();
+    auto obj2 = foos->create_object();
+
+    auto set1 = obj1.get_set<String>(col_strings);
+    auto set2 = obj2.get_set<String>(col_strings);
+
+    set1.insert("FooBar");
+    set1.insert("A");
+    set1.insert("The fox jumps over the lazy dog");
+
+    set2.insert("FooBar");
+    set2.insert("World");
+    set2.insert("Atomic");
+
+    set1.assign_union(set2);
+    CHECK_EQUAL(set1.size(), 5);
+    CHECK_EQUAL(set1.get(0), "A");
+    CHECK_EQUAL(set1.get(1), "Atomic");
+    CHECK_EQUAL(set1.get(2), "FooBar");
+    CHECK_EQUAL(set1.get(3), "The fox jumps over the lazy dog");
+    CHECK_EQUAL(set1.get(4), "World");
+}
+
 TEST(Set_Intersection)
 {
     Group g;
@@ -412,6 +441,40 @@ TEST(Set_Intersection)
     CHECK_EQUAL(set1.size(), 2);
     CHECK_EQUAL(set1.get(0), 4);
     CHECK_EQUAL(set1.get(1), 5);
+}
+
+TEST(Set_IntersectionString)
+{
+    Group g;
+    auto foos = g.add_table("class_Foo");
+    ColKey col_strings = foos->add_column_set(type_String, "strings");
+
+    auto obj1 = foos->create_object();
+    auto obj2 = foos->create_object();
+
+    auto set1 = obj1.get_set<String>(col_strings);
+    auto set2 = obj2.get_set<String>(col_strings);
+
+    set1.insert("FooBar");
+    set1.insert("A");
+    set1.insert("Hello");
+    set1.insert("The fox jumps over the lazy dog");
+
+    set2.insert("FooBar");
+    set2.insert("World");
+    set2.insert("The fox jumps over the lazy dog");
+
+    CHECK(set1.intersects(set2));
+    CHECK(set2.intersects(set1));
+    CHECK(!set1.is_subset_of(set2));
+    CHECK(!set2.is_subset_of(set1));
+    CHECK(!set1.is_superset_of(set2));
+    CHECK(!set2.is_superset_of(set1));
+
+    set1.assign_intersection(set2);
+    CHECK_EQUAL(set1.size(), 2);
+    CHECK_EQUAL(set1.get(0), "FooBar");
+    CHECK_EQUAL(set1.get(1), "The fox jumps over the lazy dog");
 }
 
 TEST(Set_Difference)
@@ -465,4 +528,32 @@ TEST(Set_SymmetricDifference)
     CHECK_EQUAL(set1.get(0), 1);
     CHECK_EQUAL(set1.get(1), 2);
     CHECK_EQUAL(set1.get(2), 3);
+}
+
+TEST(Set_SymmetricDifferenceString)
+{
+    Group g;
+    auto foos = g.add_table("class_Foo");
+    ColKey col_strings = foos->add_column_set(type_String, "strings");
+
+    auto obj1 = foos->create_object();
+    auto obj2 = foos->create_object();
+
+    auto set1 = obj1.get_set<String>(col_strings);
+    auto set2 = obj2.get_set<String>(col_strings);
+
+    set1.insert("FooBar");
+    set1.insert("A");
+    set1.insert("The fox jumps over the lazy dog");
+
+    set2.insert("FooBar");
+    set2.insert("World");
+    set2.insert("Cosmic love");
+
+    set1.assign_symmetric_difference(set2);
+    CHECK_EQUAL(set1.size(), 4);
+    CHECK_EQUAL(set1.get(0), "A");
+    CHECK_EQUAL(set1.get(1), "Cosmic love");
+    CHECK_EQUAL(set1.get(2), "The fox jumps over the lazy dog");
+    CHECK_EQUAL(set1.get(3), "World");
 }


### PR DESCRIPTION
It is not legal to use a StringData object belonging in an ArrayString that is modified. The string data will move around.

## What, How & Why?
Fixes https://github.com/realm/realm-core/issues/4288

## ☑️ ToDos
* [x] 📝 Changelog update
* [x] 🚦 Tests (or not relevant)
