### PR TITLE
Fix ObjKey generation after file format upgrade

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 * Windows `InterprocessCondVar` no longer crashes if destroyed on a different thread than created  ([#4174](https://github.com/realm/realm-core/issues/4174), since v10.3.3)
 * Fix an issue when using `Results::freeze` across threads with different transaction versions. Previously, copying the `Results`'s tableview could result in a stale state or objects from a future version. Now there is a comparison for the source and desitnation transaction version when constructing `ConstTableView`, which will cause the tableview to reflect the correct state if needed ([#4254](https://github.com/realm/realm-core/pull/4254)).
 * `@min` and `@max` queries on a list of float, double or Decimal128 values could match the incorrect value if NaN or null was present in the list (since 5.0.0).
+* Creating an object after file format upgrade may fail with assertion "Assertion failed: lo() <= std::numeric_limits<uint32_t>::max()" ([#4295](https://github.com/realm/realm-core/issues/4295), since v6.0.0)
  
 ### Breaking changes
 * None.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@
 * Windows `InterprocessCondVar` no longer crashes if destroyed on a different thread than created  ([#4174](https://github.com/realm/realm-core/issues/4174), since v10.3.3)
 * Fix an issue when using `Results::freeze` across threads with different transaction versions. Previously, copying the `Results`'s tableview could result in a stale state or objects from a future version. Now there is a comparison for the source and desitnation transaction version when constructing `ConstTableView`, which will cause the tableview to reflect the correct state if needed ([#4254](https://github.com/realm/realm-core/pull/4254)).
 * `@min` and `@max` queries on a list of float, double or Decimal128 values could match the incorrect value if NaN or null was present in the list (since 5.0.0).
-* Creating an object after file format upgrade may fail with assertion "Assertion failed: lo() <= std::numeric_limits<uint32_t>::max()" ([#4295](https://github.com/realm/realm-core/issues/4295), since v6.0.0)
+* Fixed an issue where creating an object after file format upgrade may fail with assertion "Assertion failed: lo() <= std::numeric_limits<uint32_t>::max()" ([#4295](https://github.com/realm/realm-core/issues/4295), since v6.0.0)
  
 ### Breaking changes
 * None.

--- a/src/realm/global_key.hpp
+++ b/src/realm/global_key.hpp
@@ -123,7 +123,6 @@ struct GlobalKey {
     ObjKey get_local_key(uint64_t sync_file_id)
     {
         REALM_ASSERT(m_hi <= 0x3fffffff);
-        REALM_ASSERT(lo() <= std::numeric_limits<uint32_t>::max());
 
         auto high = m_hi;
         if (high == sync_file_id)

--- a/src/realm/table.cpp
+++ b/src/realm/table.cpp
@@ -1612,7 +1612,6 @@ bool Table::migrate_objects(ColKey pk_col_key)
 
     /*************************** Create objects ******************************/
 
-    int64_t max_key_value = -1;
     // Store old row ndx in a temporary column. Use this in next steps to find
     // the right target for links
     ColKey orig_row_ndx_col;
@@ -1645,13 +1644,16 @@ bool Table::migrate_objects(ColKey pk_col_key)
             // Generate key from pk value
             GlobalKey object_id{pk_val};
             obj_key = global_to_local_object_id_hashed(object_id);
+            // Check for collision
+            if (is_valid(obj_key)) {
+                Obj existing_obj = m_clusters.get(obj_key);
+                auto existing_pk_value = existing_obj.get_any(pk_col_key);
+                GlobalKey existing_id{existing_pk_value};
+                obj_key = allocate_local_id_after_hash_collision(object_id, existing_id, obj_key);
+            }
         }
         else {
             obj_key = ObjKey(row_ndx);
-        }
-
-        if (obj_key.value > max_key_value) {
-            max_key_value = obj_key.value;
         }
 
         // Create object with the initial values
@@ -1706,13 +1708,15 @@ bool Table::migrate_objects(ColKey pk_col_key)
         col_refs.set(ndx, 0);
     }
 
-    // We need to be sure that the stored 'next sequence number' is bigger than
-    // the biggest ObjKey currently used.
-    RefOrTagged rot = m_top.get_as_ref_or_tagged(top_position_for_sequence_number);
-    uint64_t sn = rot.is_tagged() ? rot.get_as_int() : 0;
-    if (uint64_t(max_key_value) >= sn) {
-        rot = RefOrTagged::make_tagged(max_key_value + 1);
-        m_top.set(top_position_for_sequence_number, rot);
+    if (pk_col_key) {
+        // If we have a primary key column, the sequence number is used to generate unique
+        // keys after collision and must not be updated here.
+    }
+    else {
+        // We need to be sure that the stored 'next sequence number' is bigger than
+        // the biggest ObjKey currently used.
+        auto max_key_value = m_clusters.get_last_key_value();
+        this->set_sequence_number(uint64_t(max_key_value + 1));
     }
 
 #if 0
@@ -2014,14 +2018,14 @@ size_t Table::get_index_in_group() const noexcept
     return m_top.get_ndx_in_parent();
 }
 
-uint64_t Table::allocate_sequence_number()
+uint32_t Table::allocate_sequence_number()
 {
     RefOrTagged rot = m_top.get_as_ref_or_tagged(top_position_for_sequence_number);
     uint64_t sn = rot.is_tagged() ? rot.get_as_int() : 0;
     rot = RefOrTagged::make_tagged(sn + 1);
     m_top.set(top_position_for_sequence_number, rot);
 
-    return sn;
+    return uint32_t(sn);
 }
 
 void Table::set_sequence_number(uint64_t seq)
@@ -3240,7 +3244,7 @@ ObjKey Table::allocate_local_id_after_hash_collision(GlobalKey incoming_id, Glob
         ++num_entries;
     };
 
-    uint64_t sequence_number_for_local_id = allocate_sequence_number();
+    auto sequence_number_for_local_id = allocate_sequence_number();
     ObjKey new_local_id = make_tagged_local_id_after_hash_collision(sequence_number_for_local_id);
     insert_collision(incoming_id, new_local_id);
     insert_collision(colliding_id, colliding_local_id);
@@ -3546,7 +3550,7 @@ void Table::rebuild_table_with_pk_column()
             // new PK column.
             // Create temporary object to hold the values of the current object,
             // and then we'll move the object to its final key in a second pass.
-            uint64_t sequence_number_for_local_id = allocate_sequence_number();
+            auto sequence_number_for_local_id = allocate_sequence_number();
             ObjKey temp_key = make_tagged_local_id_after_hash_collision(sequence_number_for_local_id);
             auto tmp_obj = m_clusters.insert(temp_key, {});
             tmp_obj.assign(old_obj);

--- a/src/realm/table.hpp
+++ b/src/realm/table.hpp
@@ -339,7 +339,7 @@ public:
     size_t get_index_in_group() const noexcept;
     TableKey get_key() const noexcept;
 
-    uint64_t allocate_sequence_number();
+    uint32_t allocate_sequence_number();
     // Used by upgrade
     void set_sequence_number(uint64_t seq);
     void set_collision_map(ref_type ref);


### PR DESCRIPTION
For some yet unknown reason, the stored sequence_number could have the value 0x400000000000000. This would break the assertion in GlobalKey::get_local_key().

The implementation is now changed so that the generated sequence number is only 32 bit. So even if we find this stray number, the assertion will not be broken.

We also ensure that the sequence number is not updated if the table has a primary  key column. If we set the sequence number to be one bigger than the biggest ColKey, then it will in many cases be out of range.

Fixes #4295 
