### PR TITLE
Rename FFI target in SPM to RealmFFI

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -80,7 +80,7 @@ let package = Package(
             targets: ["Capi"]),
         .library(
             name: "RealmFFI",
-            targets: ["FFI"]),
+            targets: ["RealmFFI"]),
     ],
     targets: [
         .target(
@@ -202,7 +202,7 @@ let package = Package(
                 .headerSearchPath("external/pegtl/include/tao")
             ] + cxxSettings) as [CXXSetting]),
         .target(
-            name: "FFI",
+            name: "RealmFFI",
             dependencies: ["Capi"],
             path: "src/swift"),
         .target(


### PR DESCRIPTION
Xcode has a built in module called `FFI`, which conflicts with our `FFI` target in the `swift.package`. To solve the conflict I have renamed `FFI` to `RealmFFI`.