### PR TITLE
Be sure to dump entire changeset when log level is trace

### DIFF
--- a/src/realm/sync/noinst/client_impl_base.cpp
+++ b/src/realm/sync/noinst/client_impl_base.cpp
@@ -2251,8 +2251,15 @@ void Session::send_upload_message()
                      uc.progress.client_version, uc.progress.last_integrated_server_version, uc.changeset.size(),
                      uc.origin_timestamp, uc.origin_file_ident); // Throws
         if (logger.would_log(util::Logger::Level::trace)) {
-            logger.trace("Changeset: %1",
-                         _impl::clamped_hex_dump(uc.changeset.get_first_chunk())); // Throws
+            BinaryData changeset_data = uc.changeset.get_first_chunk();
+            if (changeset_data.size() < 1024) {
+                logger.trace("Changeset: %1",
+                             _impl::clamped_hex_dump(changeset_data)); // Throws
+            }
+            else {
+                logger.trace("Changeset(comp): %1 % 2", changeset_data.size(),
+                             protocol.compressed_hex_dump(changeset_data));
+            }
         }
 
         if (!get_client().m_disable_upload_compaction) {

--- a/src/realm/sync/noinst/protocol_codec.cpp
+++ b/src/realm/sync/noinst/protocol_codec.cpp
@@ -1,4 +1,5 @@
 #include <realm/util/assert.hpp>
+#include <realm/util/base64.hpp>
 #include <realm/sync/noinst/protocol_codec.hpp>
 #include <realm/sync/noinst/server_impl_base.hpp>
 
@@ -158,6 +159,20 @@ void ClientProtocol::make_ping(OutputBuffer& out, milliseconds_type timestamp, m
     out << "ping " << timestamp << " " << rtt << "\n"; // Throws
 }
 
+
+std::string ClientProtocol::compressed_hex_dump(BinaryData blob)
+{
+    std::vector<char> buf;
+    size_t sz = _impl::compression::allocate_and_compress(m_compress_memory_arena, blob,
+                                                          buf); // Throws
+
+    util::StringBuffer encode_buffer;
+    auto encoded_size = util::base64_encoded_size(sz);
+    encode_buffer.resize(encoded_size);
+    util::base64_encode(buf.data(), sz, encode_buffer.data(), encode_buffer.size());
+
+    return encode_buffer.str();
+}
 
 // Server protocol
 

--- a/src/realm/sync/noinst/protocol_codec.hpp
+++ b/src/realm/sync/noinst/protocol_codec.hpp
@@ -114,6 +114,8 @@ public:
 
     void make_ping(OutputBuffer&, milliseconds_type timestamp, milliseconds_type rtt);
 
+    std::string compressed_hex_dump(BinaryData blob);
+
     // Messages received by the client.
 
     // parse_pong_received takes a (WebSocket) pong and parses it.
@@ -267,8 +269,14 @@ public:
                                  server_version, client_version, origin_timestamp, origin_file_ident,
                                  original_changeset_size,
                                  changeset_size); // Throws
-                    logger.trace("Changeset: %1",
-                                 clamped_hex_dump(changeset_data)); // Throws
+                    if (changeset_data.size() < 1056) {
+                        logger.trace("Changeset: %1",
+                                     clamped_hex_dump(changeset_data)); // Throws
+                    }
+                    else {
+                        logger.trace("Changeset(comp): %1 %2", changeset_data.size(),
+                                     compressed_hex_dump(changeset_data)); // Throws
+                    }
 #if REALM_DEBUG
                     ChunkedBinaryInputStream in{changeset_data};
                     sync::Changeset log;


### PR DESCRIPTION
If changeset is bigger than 1024 it will be compressed and BASE64 encoded

We have received some trace output from customers that ends out being useless as the dump of changeset is clamped to only output the first 1024 bytes. 