### PR TITLE
Fix crash on empty or unexpected response

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@
 * Fix an issue when using `Results::freeze` across threads with different transaction versions. Previously, copying the `Results`'s tableview could result in a stale state or objects from a future version. Now there is a comparison for the source and desitnation transaction version when constructing `ConstTableView`, which will cause the tableview to reflect the correct state if needed ([#4254](https://github.com/realm/realm-core/pull/4254)).
 * `@min` and `@max` queries on a list of float, double or Decimal128 values could match the incorrect value if NaN or null was present in the list (since 5.0.0).
 * Fixed an issue where creating an object after file format upgrade may fail with assertion "Assertion failed: lo() <= std::numeric_limits<uint32_t>::max()" ([#4295](https://github.com/realm/realm-core/issues/4295), since v6.0.0)
+* Fixed crash on empty or unexpected Response ([#6965](https://github.com/realm/realm-cocoa/issues/6965))
  
 ### Breaking changes
 * Support for IncludeDescriptor has been removed.

--- a/src/realm/object-store/sync/app_utils.cpp
+++ b/src/realm/object-store/sync/app_utils.cpp
@@ -77,7 +77,7 @@ util::Optional<AppError> AppUtils::check_for_errors(const Response& response)
                         response.http_status_code);
     }
 
-    return {};
+    return AppError(make_error_code(ServiceErrorCode::unknown), (!response.body.empty()) ? response.body : "unexpected error");
 }
 
 } // namespace app

--- a/src/realm/object-store/sync/app_utils.cpp
+++ b/src/realm/object-store/sync/app_utils.cpp
@@ -77,7 +77,7 @@ util::Optional<AppError> AppUtils::check_for_errors(const Response& response)
                         response.http_status_code);
     }
 
-    return AppError(make_error_code(ServiceErrorCode::unknown), (!response.body.empty()) ? response.body : "unexpected error");
+    return AppError(make_error_code(ServiceErrorCode::unknown), response.body.value_or("unexpected error"));
 }
 
 } // namespace app

--- a/src/realm/object-store/sync/generic_network_transport.hpp
+++ b/src/realm/object-store/sync/generic_network_transport.hpp
@@ -205,6 +205,10 @@ struct Request {
     bool uses_refresh_token = false;
 };
 
+/**
+ * The content of Response.status can be Success of Failure. In case of successful Request the response should have a body (optional) and status = Success.
+ * In case of error please provide Response.error and ResponseResult::Failure is a flag for Response.status
+ */
 enum class ResponseResult { Success, Failure };
 
 /**
@@ -212,7 +216,9 @@ enum class ResponseResult { Success, Failure };
  */
 struct Response {
     /**
-     * Response result - success or failure
+     * Response result - Success or Failure
+     * In case of successful request the Response should have a value for body and Success for status.
+     * With Failure a value for error property should be set.
      */
     ResponseResult status;
 


### PR DESCRIPTION
## What, How & Why?
AppUtils::check_for_errors could return {}. In this case realm-cocoa will crash on attempt to convert AppError to NSError.

## ☑️ ToDos
* [X] 📝 Changelog update
* [X] 🚦 Tests - will be added in the followup pull request in realm-cocoa.
