### PR TITLE
Fix an incorrect assertion

### DIFF
--- a/src/realm/object-store/impl/realm_coordinator.cpp
+++ b/src/realm/object-store/impl/realm_coordinator.cpp
@@ -1003,7 +1003,7 @@ void RealmCoordinator::run_async_notifiers()
         version = m_db->get_version_id_of_latest_snapshot();
         if (version == m_notifier_sg->get_version_of_current_transaction()) {
             // We were spuriously woken up and there isn't actually anything to do
-            REALM_ASSERT(!m_notifier_skip_version.version);
+            REALM_ASSERT(!skip_version.version);
             m_notifier_cv.notify_all();
             return;
         }


### PR DESCRIPTION
`m_notifier_skip_version` is set to 0 before this point and `skip_version` is the actual value which should be checked.

TSan complained about a data race on the member variable as we've dropped the lock at the point of the assert.
