### PR TITLE
RCORE-538 Fix flakey websocket error handling test

### DIFF
--- a/test/object-store/sync/app.cpp
+++ b/test/object-store/sync/app.cpp
@@ -2112,7 +2112,7 @@ TEST_CASE("app: sync integration", "[sync][app]") {
 
         const auto wait_start = std::chrono::steady_clock::now();
         auto pred = [](const SyncError& error) {
-                return error.error_code.category() == util::websocket::websocket_close_status_category();
+            return error.error_code.category() == util::websocket::websocket_close_status_category();
         };
         util::EventLoop::main().run_until([&]() -> bool {
             std::lock_guard<std::mutex> lk(sync_error_mutex);


### PR DESCRIPTION
I noticed the test I changed in this PR was failing pretty reliably in https://evergreen.mongodb.com/task/realm_core_stable_ubuntu2004_asan_object_store_tests_022161f01fa8cfb085287a0c3d4998f562ed28e2_21_01_26_14_51_15. This just changes the test to ignore other transient errors that aren't related to the error category the test is exercising.