### PR TITLE
Key based notifications on Dictionary

### DIFF
--- a/src/realm/dictionary.cpp
+++ b/src/realm/dictionary.cpp
@@ -269,6 +269,16 @@ std::pair<Mixed, Mixed> Dictionary::get_pair(size_t ndx) const
     return do_get_pair(m_clusters->get(ndx, k));
 }
 
+Mixed Dictionary::get_key(size_t ndx) const
+{
+    update_if_needed();
+    if (ndx >= size()) {
+        throw std::out_of_range("ndx out of range");
+    }
+    ObjKey k;
+    return do_get_key(m_clusters->get(ndx, k));
+}
+
 size_t Dictionary::find_any(Mixed value) const
 {
     size_t ret = realm::not_found;
@@ -686,7 +696,7 @@ Mixed Dictionary::do_get(const ClusterNode::State& s) const
     return val;
 }
 
-std::pair<Mixed, Mixed> Dictionary::do_get_pair(const ClusterNode::State& s) const
+Mixed Dictionary::do_get_key(const ClusterNode::State& s) const
 {
     Mixed key;
     switch (m_key_type) {
@@ -708,9 +718,12 @@ std::pair<Mixed, Mixed> Dictionary::do_get_pair(const ClusterNode::State& s) con
             throw std::runtime_error("Not implemented");
             break;
     }
-    Mixed val = do_get(std::move(s));
+    return key;
+}
 
-    return std::make_pair(key, val);
+std::pair<Mixed, Mixed> Dictionary::do_get_pair(const ClusterNode::State& s) const
+{
+    return {do_get_key(s), do_get(s)};
 }
 
 bool Dictionary::clear_backlink(Mixed value, CascadeState& state) const

--- a/src/realm/dictionary.hpp
+++ b/src/realm/dictionary.hpp
@@ -60,6 +60,7 @@ public:
     bool is_null(size_t ndx) const final;
     Mixed get_any(size_t ndx) const final;
     std::pair<Mixed, Mixed> get_pair(size_t ndx) const;
+    Mixed get_key(size_t ndx) const;
     size_t find_any(Mixed value) const final;
 
     Mixed min(size_t* return_ndx = nullptr) const final;
@@ -157,6 +158,7 @@ private:
 
     bool init_from_parent() const final;
     Mixed do_get(const ClusterNode::State&) const;
+    Mixed do_get_key(const ClusterNode::State&) const;
     std::pair<Mixed, Mixed> do_get_pair(const ClusterNode::State&) const;
     bool clear_backlink(Mixed value, CascadeState& state) const;
 

--- a/src/realm/object-store/dictionary.hpp
+++ b/src/realm/object-store/dictionary.hpp
@@ -24,6 +24,18 @@
 #include <realm/dictionary.hpp>
 
 namespace realm {
+
+struct DictionaryChangeSet {
+    // Indexes which were removed from the _old_ dictionary
+    std::vector<size_t> deletions;
+
+    // Keys in the _new_ dictionary which are new insertions
+    std::vector<Mixed> insertions;
+
+    // Keys of objects/values which were modified
+    std::vector<Mixed> modifications;
+};
+
 namespace object_store {
 
 class Dictionary : public object_store::Collection {
@@ -106,6 +118,9 @@ public:
     Dictionary freeze(const std::shared_ptr<Realm>& realm) const;
     Results get_keys() const;
     Results get_values() const;
+
+    using CBFunc = std::function<void(DictionaryChangeSet, std::exception_ptr)>;
+    NotificationToken add_key_based_notification_callback(CBFunc cb) &;
 
     Iterator begin() const
     {

--- a/src/realm/object-store/results.cpp
+++ b/src/realm/object-store/results.cpp
@@ -263,8 +263,7 @@ util::Optional<T> Results::try_get(size_t ndx)
             Mixed mixed;
             if (m_dictionary_keys) {
                 if (auto dict = dynamic_cast<realm::Dictionary*>(m_collection.get())) {
-                    auto key_value = dict->get_pair(ndx);
-                    mixed = key_value.first;
+                    mixed = dict->get_key(ndx);
                 }
             }
             else {
@@ -372,8 +371,7 @@ Mixed Results::get_from_collection(size_t ndx)
         Mixed mixed;
         if (m_dictionary_keys) {
             if (auto dict = dynamic_cast<realm::Dictionary*>(m_collection.get())) {
-                auto key_value = dict->get_pair(ndx);
-                mixed = key_value.first;
+                mixed = dict->get_key(ndx);
             }
         }
         else {

--- a/test/object-store/dictionary.cpp
+++ b/test/object-store/dictionary.cpp
@@ -233,6 +233,22 @@ TEST_CASE("dictionary") {
             REQUIRE_INDICES(srchange.deletions, 0);
         }
 
+        SECTION("key based notification") {
+            DictionaryChangeSet key_change;
+            auto token =
+                dict.add_key_based_notification_callback([&key_change](DictionaryChangeSet c, std::exception_ptr) {
+                    key_change = c;
+                });
+            advance_and_notify(*r);
+
+            r->begin_transaction();
+            dict.insert("a", "apricot");
+            r->commit_transaction();
+
+            advance_and_notify(*r);
+            REQUIRE(key_change.modifications[0].get_string() == "a");
+        }
+
         SECTION("clear list") {
             advance_and_notify(*r);
 


### PR DESCRIPTION
This is a preliminary implementation of #4232. It is currently not possible to deliver key based notifications on deleted entries as the kay values are not available when the basic notifications are sent out. Instead the indices are delivered.