### PR TITLE
Refactor check on valid column keys

### DIFF
--- a/src/realm/cluster.cpp
+++ b/src/realm/cluster.cpp
@@ -962,14 +962,9 @@ void Cluster::upgrade_string_to_enum(ColKey col_key, ArrayString& keys)
     Array::destroy_deep(ref, m_alloc);
 }
 
-void Cluster::init_leaf(ColKey col_key, ArrayPayload* leaf) const
+void Cluster::init_leaf(ColKey col_key, ArrayPayload* leaf) const noexcept
 {
     auto col_ndx = col_key.get_index();
-    // FIXME: Move this validation into callers.
-    // Currently, the query subsystem may call with an unvalidated key.
-    // once fixed, reintroduce the noexcept declaration :-D
-    if (auto t = m_tree_top.get_owning_table())
-        t->report_invalid_key(col_key);
     ref_type ref = to_ref(Array::get(col_ndx.val + 1));
     if (leaf->need_spec()) {
         m_tree_top.set_spec(*leaf, col_ndx);

--- a/src/realm/cluster.hpp
+++ b/src/realm/cluster.hpp
@@ -261,7 +261,7 @@ public:
     void nullify_incoming_links(ObjKey key, CascadeState& state) override;
     void upgrade_string_to_enum(ColKey col, ArrayString& keys);
 
-    void init_leaf(ColKey col, ArrayPayload* leaf) const;
+    void init_leaf(ColKey col, ArrayPayload* leaf) const noexcept;
     void add_leaf(ColKey col, ref_type ref);
 
     void verify() const;

--- a/src/realm/exceptions.cpp
+++ b/src/realm/exceptions.cpp
@@ -100,8 +100,6 @@ const char* LogicError::message() const noexcept
                    "to the DB constructor) was not consistent across the session";
         case table_has_no_columns:
             return "Table has no columns";
-        case column_does_not_exist:
-            return "Column does not exist";
         case subtable_of_subtable_index:
             return "Search index on a subtable of a subtable is not yet supported";
         case collection_type_mismatch:

--- a/src/realm/exceptions.hpp
+++ b/src/realm/exceptions.hpp
@@ -310,9 +310,6 @@ public:
         /// Adding rows to a table with no columns is not supported.
         table_has_no_columns,
 
-        /// Referring to a column that has been deleted.
-        column_does_not_exist,
-
         /// You can not add index on a subtable of a subtable
         subtable_of_subtable_index,
 

--- a/src/realm/obj.cpp
+++ b/src/realm/obj.cpp
@@ -261,7 +261,7 @@ inline bool Obj::_update_if_needed() const
 template <class T>
 T Obj::get(ColKey col_key) const
 {
-    m_table->report_invalid_key(col_key);
+    m_table->check_column(col_key);
     ColumnType type = col_key.get_type();
     REALM_ASSERT(type == ColumnTypeTraits<T>::column_id);
 
@@ -295,7 +295,7 @@ ObjKey Obj::_get<ObjKey>(ColKey::Idx col_ndx) const
 
 bool Obj::is_unresolved(ColKey col_key) const
 {
-    m_table->report_invalid_key(col_key);
+    m_table->check_column(col_key);
     ColumnType type = col_key.get_type();
     REALM_ASSERT(type == col_type_Link);
 
@@ -333,7 +333,7 @@ int64_t Obj::_get<int64_t>(ColKey::Idx col_ndx) const
 template <>
 int64_t Obj::get<int64_t>(ColKey col_key) const
 {
-    m_table->report_invalid_key(col_key);
+    m_table->check_column(col_key);
     ColumnType type = col_key.get_type();
     REALM_ASSERT(type == col_type_Int);
 
@@ -352,7 +352,7 @@ int64_t Obj::get<int64_t>(ColKey col_key) const
 template <>
 bool Obj::get<bool>(ColKey col_key) const
 {
-    m_table->report_invalid_key(col_key);
+    m_table->check_column(col_key);
     ColumnType type = col_key.get_type();
     REALM_ASSERT(type == col_type_Bool);
 
@@ -409,7 +409,7 @@ BinaryData Obj::_get<BinaryData>(ColKey::Idx col_ndx) const
 
 Mixed Obj::get_any(ColKey col_key) const
 {
-    m_table->report_invalid_key(col_key);
+    m_table->check_column(col_key);
     auto col_ndx = col_key.get_index();
     switch (col_key.get_type()) {
         case col_type_Int:
@@ -635,7 +635,7 @@ TableView Obj::get_backlink_view(TableRef src_table, ColKey src_col_key)
 
 ObjKey Obj::get_backlink(ColKey backlink_col, size_t backlink_ndx) const
 {
-    get_table()->report_invalid_key(backlink_col);
+    get_table()->check_column(backlink_col);
     Allocator& alloc = get_alloc();
     Array fields(alloc);
     fields.init_from_mem(m_mem);
@@ -648,7 +648,7 @@ ObjKey Obj::get_backlink(ColKey backlink_col, size_t backlink_ndx) const
 
 std::vector<ObjKey> Obj::get_all_backlinks(ColKey backlink_col) const
 {
-    get_table()->report_invalid_key(backlink_col);
+    get_table()->check_column(backlink_col);
     Allocator& alloc = get_alloc();
     Array fields(alloc);
     fields.init_from_mem(m_mem);
@@ -1188,7 +1188,7 @@ template <>
 Obj& Obj::set<Mixed>(ColKey col_key, Mixed value, bool is_default)
 {
     update_if_needed();
-    get_table()->report_invalid_key(col_key);
+    get_table()->check_column(col_key);
     auto type = col_key.get_type();
     auto attrs = col_key.get_attrs();
     auto col_ndx = col_key.get_index();
@@ -1309,7 +1309,7 @@ template <>
 Obj& Obj::set<int64_t>(ColKey col_key, int64_t value, bool is_default)
 {
     update_if_needed();
-    get_table()->report_invalid_key(col_key);
+    get_table()->check_column(col_key);
     auto col_ndx = col_key.get_index();
 
     if (col_key.get_type() != ColumnTypeTraits<int64_t>::column_id)
@@ -1353,7 +1353,7 @@ Obj& Obj::set<int64_t>(ColKey col_key, int64_t value, bool is_default)
 Obj& Obj::add_int(ColKey col_key, int64_t value)
 {
     update_if_needed();
-    get_table()->report_invalid_key(col_key);
+    get_table()->check_column(col_key);
     auto col_ndx = col_key.get_index();
 
     ensure_writeable();
@@ -1411,7 +1411,7 @@ template <>
 Obj& Obj::set<ObjKey>(ColKey col_key, ObjKey target_key, bool is_default)
 {
     update_if_needed();
-    get_table()->report_invalid_key(col_key);
+    get_table()->check_column(col_key);
     ColKey::Idx col_ndx = col_key.get_index();
     ColumnType type = col_key.get_type();
     if (type != ColumnTypeTraits<ObjKey>::column_id)
@@ -1462,7 +1462,7 @@ template <>
 Obj& Obj::set<ObjLink>(ColKey col_key, ObjLink target_link, bool is_default)
 {
     update_if_needed();
-    get_table()->report_invalid_key(col_key);
+    get_table()->check_column(col_key);
     ColKey::Idx col_ndx = col_key.get_index();
     ColumnType type = col_key.get_type();
     if (type != ColumnTypeTraits<ObjLink>::column_id)
@@ -1504,7 +1504,7 @@ Obj& Obj::set<ObjLink>(ColKey col_key, ObjLink target_link, bool is_default)
 Obj Obj::create_and_set_linked_object(ColKey col_key, bool is_default)
 {
     update_if_needed();
-    get_table()->report_invalid_key(col_key);
+    get_table()->check_column(col_key);
     ColKey::Idx col_ndx = col_key.get_index();
     ColumnType type = col_key.get_type();
     if (type != col_type_Link)
@@ -1585,7 +1585,7 @@ template <class T>
 Obj& Obj::set(ColKey col_key, T value, bool is_default)
 {
     update_if_needed();
-    get_table()->report_invalid_key(col_key);
+    get_table()->check_column(col_key);
     auto type = col_key.get_type();
     auto attrs = col_key.get_attrs();
     auto col_ndx = col_key.get_index();

--- a/src/realm/object-store/c_api/object.cpp
+++ b/src/realm/object-store/c_api/object.cpp
@@ -283,7 +283,7 @@ RLM_API realm_list_t* realm_get_list(realm_object_t* object, realm_property_key_
         auto table = obj.get_table();
 
         auto col_key = ColKey(key);
-        table->report_invalid_key(col_key);
+        table->check_column(col_key);
 
         if (!col_key.is_list()) {
             // FIXME: Proper exception type.

--- a/src/realm/query_engine.hpp
+++ b/src/realm/query_engine.hpp
@@ -183,7 +183,7 @@ public:
         m_dD = 100.0;
 
         if (m_condition_column_key)
-            m_table->report_invalid_key(m_condition_column_key);
+            m_table->check_column(m_condition_column_key);
         if (m_child)
             m_child->init(will_query_ranges);
 
@@ -278,18 +278,6 @@ public:
     }
 
     virtual std::unique_ptr<ParentNode> clone() const = 0;
-
-    ColKey get_column_key(StringData column_name) const
-    {
-        ColKey column_key;
-        if (column_name.size() > 0) {
-            column_key = m_table.unchecked_ptr()->get_column_key(column_name);
-            if (column_key == ColKey()) {
-                throw LogicError(LogicError::column_does_not_exist);
-            }
-        }
-        return column_key;
-    }
 
     virtual std::string describe(util::serializer::SerialisationState&) const
     {
@@ -2455,8 +2443,8 @@ public:
     void init(bool will_query_ranges)
     {
         ParentNode::init(will_query_ranges);
-        ParentNode::m_table->report_invalid_key(m_condition_column_key1);
-        ParentNode::m_table->report_invalid_key(m_condition_column_key2);
+        ParentNode::m_table->check_column(m_condition_column_key1);
+        ParentNode::m_table->check_column(m_condition_column_key2);
     }
 
     static std::unique_ptr<ArrayPayload> update_cached_leaf_pointers_for_column(Allocator& alloc,

--- a/src/realm/query_engine.hpp
+++ b/src/realm/query_engine.hpp
@@ -182,6 +182,8 @@ public:
     {
         m_dD = 100.0;
 
+        if (m_condition_column_key)
+            m_table->report_invalid_key(m_condition_column_key);
         if (m_child)
             m_child->init(will_query_ranges);
 
@@ -2447,9 +2449,14 @@ public:
                                                       ParentNode::m_table->get_column_name(m_condition_column_key1),
                                                       ParentNode::m_table->get_column_name(m_condition_column_key2)));
             }
-            ParentNode::m_table->check_column(m_condition_column_key1);
-            ParentNode::m_table->check_column(m_condition_column_key2);
         }
+    }
+
+    void init(bool will_query_ranges)
+    {
+        ParentNode::init(will_query_ranges);
+        ParentNode::m_table->report_invalid_key(m_condition_column_key1);
+        ParentNode::m_table->report_invalid_key(m_condition_column_key2);
     }
 
     static std::unique_ptr<ArrayPayload> update_cached_leaf_pointers_for_column(Allocator& alloc,

--- a/src/realm/query_expression.cpp
+++ b/src/realm/query_expression.cpp
@@ -34,7 +34,7 @@ void LinkMap::set_base_table(ConstTableRef table)
 
     for (size_t i = 0; i < m_link_column_keys.size(); i++) {
         ColKey link_column_key = m_link_column_keys[i];
-        table->report_invalid_key(link_column_key);
+        table->check_column(link_column_key);
         // Link column can be either LinkList or single Link
         ColumnType type = link_column_key.get_type();
         REALM_ASSERT(Table::is_link_type(type) || type == col_type_BackLink);
@@ -52,10 +52,10 @@ void LinkMap::set_base_table(ConstTableRef table)
 void LinkMap::check_columns(ColKey target_col) const
 {
     for (size_t i = 0; i < m_link_column_keys.size(); ++i) {
-        m_tables[i]->report_invalid_key(m_link_column_keys[i]);
+        m_tables[i]->check_column(m_link_column_keys[i]);
     }
     if (target_col)
-        m_tables.back()->report_invalid_key(target_col);
+        m_tables.back()->check_column(target_col);
 }
 
 void LinkMap::collect_dependencies(std::vector<TableKey>& tables) const

--- a/src/realm/query_expression.hpp
+++ b/src/realm/query_expression.hpp
@@ -1725,7 +1725,7 @@ public:
             default:
                 break;
         }
-        // m_tables[0]->report_invalid_key(m_link_column_keys[0]);
+        // m_tables[0]->check_column(m_link_column_keys[0]);
         cluster->init_leaf(m_link_column_keys[0], m_array_ptr.get());
         m_leaf_ptr = m_array_ptr.get();
     }

--- a/src/realm/sort_descriptor.cpp
+++ b/src/realm/sort_descriptor.cpp
@@ -170,7 +170,7 @@ BaseDescriptor::Sorter::Sorter(std::vector<std::vector<ColKey>> const& column_li
         std::vector<const Table*> tables = {&root_table};
         tables.resize(sz);
         for (size_t j = 0; j + 1 < sz; ++j) {
-            tables[j]->report_invalid_key(columns[j]);
+            tables[j]->check_column(columns[j]);
             if (columns[j].get_type() != col_type_Link) {
                 // Only last column in link chain is allowed to be non-link
                 throw LogicError(LogicError::type_mismatch);

--- a/src/realm/table.cpp
+++ b/src/realm/table.cpp
@@ -660,7 +660,7 @@ ColKey Table::do_insert_column(ColKey col_key, DataType type, StringData name, T
 
     if (target_table) {
         auto backlink_col_key = target_table->do_insert_root_column(ColKey{}, col_type_BackLink, ""); // Throws
-        target_table->report_invalid_key(backlink_col_key);
+        target_table->check_column(backlink_col_key);
 
         set_opposite_column(col_key, target_table->get_key(), backlink_col_key);
         target_table->set_opposite_column(backlink_col_key, get_key(), col_key);

--- a/src/realm/table.hpp
+++ b/src/realm/table.hpp
@@ -383,7 +383,7 @@ public:
     // Will return pointer to search index accessor. Will return nullptr if no index
     StringIndex* get_search_index(ColKey col) const noexcept
     {
-        report_invalid_key(col);
+        check_column(col);
         if (!has_search_index(col))
             return nullptr;
         return m_index_accessors[col.get_index().val];
@@ -513,7 +513,6 @@ public:
     ColKey::Idx spec_ndx2leaf_ndx(size_t idx) const;
     ColKey leaf_ndx2colkey(ColKey::Idx idx) const;
     ColKey spec_ndx2colkey(size_t ndx) const;
-    void report_invalid_key(ColKey col_key) const;
 
     // Queries
     // Using where(tv) is the new method to perform queries on TableView. The 'tv' can have any order; it does not
@@ -969,7 +968,7 @@ public:
     template <class T>
     inline Columns<T> column(ColKey col_key)
     {
-        m_current_table->report_invalid_key(col_key);
+        m_current_table->check_column(col_key);
 
         // Check if user-given template type equals Realm type.
         auto ct = col_key.get_type();
@@ -1302,15 +1301,6 @@ inline ColKey Table::spec_ndx2colkey(size_t spec_ndx) const
 {
     REALM_ASSERT(spec_ndx < m_spec_ndx2leaf_ndx.size());
     return m_leaf_ndx2colkey[m_spec_ndx2leaf_ndx[spec_ndx].val];
-}
-
-inline void Table::report_invalid_key(ColKey col_key) const
-{
-    if (col_key == ColKey())
-        throw LogicError(LogicError::column_does_not_exist);
-    auto idx = col_key.get_index();
-    if (idx.val >= m_leaf_ndx2colkey.size() || m_leaf_ndx2colkey[idx.val] != col_key)
-        throw LogicError(LogicError::column_does_not_exist);
 }
 
 inline size_t Table::leaf_ndx2spec_ndx(ColKey::Idx leaf_ndx) const

--- a/src/realm/table_view.cpp
+++ b/src/realm/table_view.cpp
@@ -598,7 +598,7 @@ void ConstTableView::do_sync()
             if (m_table->valid_column(m_source_column_key)) { // return empty result, if column has been removed
                 ColKey backlink_col = m_table->get_opposite_column(m_source_column_key);
                 REALM_ASSERT(backlink_col);
-                m_linked_table->report_invalid_key(backlink_col);
+                m_linked_table->check_column(backlink_col);
                 auto backlinks = m_linked_obj.get_all_backlinks(backlink_col);
                 for (auto k : backlinks) {
                     m_key_values.add(k);

--- a/test/test_query.cpp
+++ b/test/test_query.cpp
@@ -4208,8 +4208,7 @@ TEST(Query_LinkChainSortErrors)
     ColKey backlink_ndx(2);
     CHECK_LOGIC_ERROR(t1->get_sorted_view(SortDescriptor({{t1_linklist_col, t2_string_col}})),
                       LogicError::type_mismatch);
-    CHECK_LOGIC_ERROR(t1->get_sorted_view(SortDescriptor({{backlink_ndx, t2_string_col}})),
-                      LogicError::column_does_not_exist);
+    CHECK_THROW(t1->get_sorted_view(SortDescriptor({{backlink_ndx, t2_string_col}})), ColumnNotFound);
     CHECK_LOGIC_ERROR(t1->get_sorted_view(SortDescriptor({{t1_int_col, t2_string_col}})), LogicError::type_mismatch);
 }
 

--- a/test/test_query2.cpp
+++ b/test/test_query2.cpp
@@ -4849,8 +4849,8 @@ TEST(Query_ColumnDeletionSimple)
     foo.remove_column(col_int0);
 
     size_t x = 0;
-    CHECK_LOGIC_ERROR(x = q1.count(), LogicError::column_does_not_exist);
-    CHECK_LOGIC_ERROR(tv1.sync_if_needed(), LogicError::column_does_not_exist);
+    CHECK_THROW(x = q1.count(), ColumnNotFound);
+    CHECK_THROW(tv1.sync_if_needed(), ColumnNotFound);
     CHECK_EQUAL(x, 0);
     CHECK_EQUAL(tv1.size(), 0);
 
@@ -4861,8 +4861,8 @@ TEST(Query_ColumnDeletionSimple)
     CHECK_EQUAL(tv2.size(), 2);
 
     x = 0;
-    CHECK_LOGIC_ERROR(x = q3.count(), LogicError::column_does_not_exist);
-    CHECK_LOGIC_ERROR(tv3.sync_if_needed(), LogicError::column_does_not_exist);
+    CHECK_THROW(x = q3.count(), ColumnNotFound);
+    CHECK_THROW(tv3.sync_if_needed(), ColumnNotFound);
     CHECK_EQUAL(x, 0);
     CHECK_EQUAL(tv3.size(), 0);
 }
@@ -4912,9 +4912,9 @@ TEST(Query_ColumnDeletionExpression)
 
     foo.remove_column(col_int0);
     size_t x = 0;
-    CHECK_LOGIC_ERROR(x = q.count(), LogicError::column_does_not_exist);
-    CHECK_LOGIC_ERROR(tv.sync_if_needed(), LogicError::column_does_not_exist);
-    CHECK_LOGIC_ERROR(tv1.sync_if_needed(), LogicError::column_does_not_exist);
+    CHECK_THROW(x = q.count(), ColumnNotFound);
+    CHECK_THROW(tv.sync_if_needed(), ColumnNotFound);
+    CHECK_THROW(tv1.sync_if_needed(), ColumnNotFound);
     CHECK_EQUAL(x, 0);
     CHECK_EQUAL(tv.size(), 0);
 
@@ -4926,8 +4926,8 @@ TEST(Query_ColumnDeletionExpression)
     CHECK_EQUAL(tv.size(), 1);
     CHECK_EQUAL(tv1.size(), 1);
     foo.remove_column(col_date3);
-    CHECK_LOGIC_ERROR(tv.sync_if_needed(), LogicError::column_does_not_exist);
-    CHECK_LOGIC_ERROR(tv1.sync_if_needed(), LogicError::column_does_not_exist);
+    CHECK_THROW(tv.sync_if_needed(), ColumnNotFound);
+    CHECK_THROW(tv1.sync_if_needed(), ColumnNotFound);
 
     // StringNodeBase
     q = foo.column<String>(col_str4) == StringData("Hello, world");
@@ -4937,22 +4937,22 @@ TEST(Query_ColumnDeletionExpression)
     CHECK_EQUAL(tv.size(), 1);
     CHECK_EQUAL(tv1.size(), 4);
     foo.remove_column(col_str4);
-    CHECK_LOGIC_ERROR(tv.sync_if_needed(), LogicError::column_does_not_exist);
-    CHECK_LOGIC_ERROR(tv1.sync_if_needed(), LogicError::column_does_not_exist);
+    CHECK_THROW(tv.sync_if_needed(), ColumnNotFound);
+    CHECK_THROW(tv1.sync_if_needed(), ColumnNotFound);
 
     // FloatDoubleNode
     q = foo.column<Float>(col_float5) > 0.0f;
     tv = q.find_all();
     CHECK_EQUAL(tv.size(), 2);
     foo.remove_column(col_float5);
-    CHECK_LOGIC_ERROR(tv.sync_if_needed(), LogicError::column_does_not_exist);
+    CHECK_THROW(tv.sync_if_needed(), ColumnNotFound);
 
     // BinaryNode
     q = foo.column<Binary>(col_bin6) != BinaryData("Binary", 6);
     tv = q.find_all();
     CHECK_EQUAL(tv.size(), 4);
     foo.remove_column(col_bin6);
-    CHECK_LOGIC_ERROR(tv.sync_if_needed(), LogicError::column_does_not_exist);
+    CHECK_THROW(tv.sync_if_needed(), ColumnNotFound);
 }
 
 
@@ -5000,12 +5000,12 @@ TEST(Query_ColumnDeletionLinks)
     CHECK_EQUAL(tv.size(), 1);
     // remove link column, disaster
     bar->remove_column(col_link0);
-    CHECK_LOGIC_ERROR(bar->report_invalid_key(col_link0), LogicError::column_does_not_exist);
-    CHECK_LOGIC_ERROR(tv.sync_if_needed(), LogicError::column_does_not_exist);
+    CHECK_THROW(bar->check_column(col_link0), ColumnNotFound);
+    CHECK_THROW(tv.sync_if_needed(), ColumnNotFound);
     foo->remove_column(col_link1);
-    CHECK_LOGIC_ERROR(foo->report_invalid_key(col_link1), LogicError::column_does_not_exist);
-    CHECK_LOGIC_ERROR(q1.count(), LogicError::column_does_not_exist);
-    CHECK_LOGIC_ERROR(q2.count(), LogicError::column_does_not_exist);
+    CHECK_THROW(foo->check_column(col_link1), ColumnNotFound);
+    CHECK_THROW(q1.count(), ColumnNotFound);
+    CHECK_THROW(q2.count(), ColumnNotFound);
 }
 
 


### PR DESCRIPTION
- Move check on valid column to init phase of query
- Replace Table::report_invalid_key with Table::check_column
- The exception thrown is now ColumnNotFound instead of LogicError::column_does_not_exist.
