### PR TITLE
Add flag for disabling building FFI support

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -173,6 +173,7 @@ endif()
 
 # Options (passed to CMake)
 option(REALM_ENABLE_SYNC "Enable synchronized realms." ON)
+option(REALM_ENABLE_FFI "Build FFI support library." ON)
 option(REALM_BUILD_TEST_CLIENT "Build the test client" OFF)
 option(REALM_BUILD_DOGLESS "Build server with support for emitting statsd" OFF)
 option(REALM_BUILD_INSPECTOR "Build inspector" OFF)
@@ -297,9 +298,10 @@ set(REALM_EXPORTED_TARGETS
     Storage
     QueryParser
     ObjectStore
-    RealmFFI
-    RealmFFIStatic
 )
+if (REALM_ENABLE_FFI)
+    list(APPEND REALM_EXPORTED_TARGETS RealmFFI RealmFFIStatic)
+endif()
 if(REALM_ENABLE_SYNC)
     list(APPEND REALM_EXPORTED_TARGETS Sync)
 endif()

--- a/src/realm/object-store/CMakeLists.txt
+++ b/src/realm/object-store/CMakeLists.txt
@@ -1,4 +1,6 @@
-add_subdirectory(c_api)
+if (REALM_ENABLE_FFI)
+    add_subdirectory(c_api)
+endif()
 
 set(SOURCES
     binding_callback_thread_observer.cpp


### PR DESCRIPTION
Java building from source does not require FFI, so would rather avoid spending resources building it to then discard it.