### PR TITLE
RCORE-341 Run long-running core tests in evergreen

### DIFF
--- a/evergreen/config.yml
+++ b/evergreen/config.yml
@@ -433,7 +433,6 @@ buildvariants:
   - name: compile_test
     distros:
     - ubuntu2004-large
-  - name: long-running-tests
 
 - name: rhel70
   display_name: "RHEL 7 x86_64"

--- a/evergreen/config.yml
+++ b/evergreen/config.yml
@@ -468,7 +468,7 @@ buildvariants:
 
 - name: macos-1014
   display_name: "MacOS 10.14 x86_64"
-  run_on: macos-1014-test
+  run_on: macos-1014
   expansions:
     cmake_url: "https://s3.amazonaws.com/static.realm.io/evergreen-assets/cmake-3.19.1-Darwin-x86_64.tar.gz"
     cmake_bindir: "./cmake_binaries/CMake.app/Contents/bin"
@@ -476,11 +476,7 @@ buildvariants:
     run_tests_against_baas: On
   tasks:
   - name: compile_test_and_package
-    distros:
-    - macos-1014
   - name: benchmarks
-    distros:
-    - macos-1014
   - name: long-running-tests
 
 - name: windows-64-vs2019

--- a/evergreen/config.yml
+++ b/evergreen/config.yml
@@ -86,6 +86,10 @@ functions:
               set_cmake_var realm_vars REALM_USE_SYSTEM_OPENSSL BOOL On
           fi
 
+          if [ -n "${long_running_test_duration|}" ]; then
+              set_cmake_var realm_vars REALM_TEST_DURATION STRING "${long_running_test_duration}"
+          fi
+
           set_cmake_var realm_vars REALM_BUILD_COMMANDLINE_TOOLS BOOL On
           set_cmake_var realm_vars REALM_ENABLE_ENCRYPTION BOOL On
 
@@ -151,11 +155,15 @@ functions:
           fi
           TEST_FLAGS="$TEST_FLAGS ${test_flags|}"
 
+          if [[ -n "${report_test_progress|}" ]]; then
+              export UNITTEST_PROGRESS=${report_test_progress|}
+          fi
           cd build
           $CTEST -V $TEST_FLAGS
 
 tasks:
 - name: compile
+  tags: [ "for_pull_requests" ]
   commands:
   - func: "compile"
 
@@ -190,8 +198,15 @@ tasks:
       local_file: 'realm-core/build/realm-core-artifacts-runtime.tar.gz'
       content_type: '${content_type|application/x-gzip}'
 
+- name: long-running-core-tests
+  commands:
+  - func: "run tests"
+    vars:
+      test_filter: StorageTests
+      report_test_progress: On
+
 - name: core-tests
-  tags: [ "test_suite" ]
+  tags: [ "test_suite", "for_pull_requests" ]
   commands:
   - func: "compile"
   - func: "run tests"
@@ -213,7 +228,7 @@ tasks:
       path_to_benchmark: ./build/test/benchmark-crud/realm-benchmark-crud
 
 - name: sync-tests
-  tags: [ "test_suite" ]
+  tags: [ "test_suite", "for_pull_requests" ]
   commands:
   - func: "compile"
   - func: "run tests"
@@ -221,7 +236,7 @@ tasks:
       test_filter: SyncTests
 
 - name: object-store-tests
-  tags: [ "disabled_on_windows", "test_suite" ]
+  tags: [ "disabled_on_windows", "test_suite", "for_pull_requests" ]
   commands:
   - func: "compile"
   # If we need to start a local copy of baas, do it in the background here in a separate script.
@@ -270,6 +285,7 @@ tasks:
       test_filter: ObjectStoreTests
 
 - name: lint
+  tags: [ "for_pull_requests" ]
   commands:
   - func: "fetch source"
   - func: "fetch binaries"
@@ -349,6 +365,18 @@ task_groups:
   tasks:
   - .benchmark
 
+- name: long-running-tests
+  setup_group_can_fail_task: true
+  setup_group:
+  - func: "fetch source"
+  - func: "fetch binaries"
+  - func: "compile"
+    vars:
+      long_running_test_duration: 2
+      target_to_build: CoreTests
+  tasks:
+  - long-running-core-tests
+
 buildvariants:
 - name: ubuntu2004
   display_name: "Ubuntu 20.04 x86_64 (Clang 11)"
@@ -369,6 +397,7 @@ buildvariants:
   - name: benchmarks
     distros:
     - ubuntu2004-large
+  - name: long-running-tests
 
 - name: ubuntu2004-asan
   display_name: "Ubuntu 20.04 x86_64 (Clang 11 ASAN)"
@@ -386,6 +415,7 @@ buildvariants:
   - name: compile_test
     distros:
     - ubuntu2004-large
+  - name: long-running-tests
 
 - name: ubuntu2004-tsan
   display_name: "Ubuntu 20.04 x86_64 (Clang 11 TSAN)"
@@ -403,6 +433,7 @@ buildvariants:
   - name: compile_test
     distros:
     - ubuntu2004-large
+  - name: long-running-tests
 
 - name: rhel70
   display_name: "RHEL 7 x86_64"
@@ -451,6 +482,7 @@ buildvariants:
   - name: benchmarks
     distros:
     - macos-1014
+  - name: long-running-tests
 
 - name: windows-64-vs2019
   display_name: "Windows x86_64 (VS 2019)"
@@ -469,4 +501,5 @@ buildvariants:
   - name: compile_test_and_package_windows
     distros:
     - windows-64-vs2019-large
+  - name: long-running-tests
 

--- a/evergreen/config.yml
+++ b/evergreen/config.yml
@@ -201,6 +201,9 @@ tasks:
 - name: long-running-core-tests
   commands:
   - func: "run tests"
+    # The long-running tests can take a really long time on Windows, so we give the test up to 4
+    # hours to complete
+    timeout_secs: 14400
     vars:
       test_filter: StorageTests
       report_test_progress: On

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -132,6 +132,10 @@ file(GLOB REQUIRED_TEST_FILES
 add_executable(CoreTests ${CORE_TESTS} ${MAIN_FILE} ${REQUIRED_TEST_FILES} ${REALM_TEST_HEADERS})
 set_target_properties(CoreTests PROPERTIES OUTPUT_NAME "realm-tests")
 
+if (REALM_TEST_DURATION)
+    add_compile_definitions(TEST_DURATION=${REALM_TEST_DURATION})
+endif()
+
 # Resources required for running the tests copied to the target directory
 if(CMAKE_GENERATOR STREQUAL Xcode)
     # a simple copy doesn't work for an Xcode build because Xcode also needs to sign them


### PR DESCRIPTION
This adds running the long-running tests (TEST_DURATION=2) to evergreen. If this gets approved, I will change the evergreen project config so that pull requests only run tasks with the `for_pull_requests` tag, which will exclude the long-running tasks. The long-running tasks will run on waterfall builds (after merge). I'll work with @fealebenpae to make sure we get notifications if they fail.