### PR TITLE
Trigger collection notifications when the source object is deleted

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 * Sync client now logs error messages received from server rather than just the size of the error message.
 * Added class name substitution to KeyPathMapping for the query parser. ([#4326](https://github.com/realm/realm-core/issues/4326)).
 * Errors returned from the server when sync WebSockets get closed are now captured and surfaced as a SyncError.
+* Notifications will now be triggered for empty collections whose source object has been deleted. ([#4228](https://github.com/realm/realm-core/issues/4228)).
 
 ### Fixed
 * <How to hit and notice issue? what was the impact?> ([#????](https://github.com/realm/realm-core/issues/????), since v?.?.?)

--- a/src/realm/object-store/collection_notifications.hpp
+++ b/src/realm/object-store/collection_notifications.hpp
@@ -89,13 +89,18 @@ struct CollectionChangeSet {
     // unreported moves which show up only as a delete/insert pair.
     std::vector<Move> moves;
 
+    // This flag indicates whether the underlying object which is the source of this
+    // collection was deleted. This applies to lists, dictionaries and sets.
+    // This enables notifiers to report a change on empty collections that have been deleted.
+    bool collection_root_was_deleted = false;
+
     // Per-column version of `modifications`
     std::unordered_map<int64_t, IndexSet> columns;
 
     bool empty() const noexcept
     {
         return deletions.empty() && insertions.empty() && modifications.empty() && modifications_new.empty() &&
-               moves.empty();
+               moves.empty() && !collection_root_was_deleted;
     }
 };
 

--- a/src/realm/object-store/impl/collection_change_builder.cpp
+++ b/src/realm/object-store/impl/collection_change_builder.cpp
@@ -25,38 +25,6 @@
 using namespace realm;
 using namespace realm::_impl;
 
-CollectionChangeBuilder::CollectionChangeBuilder(CollectionChangeBuilder&& other)
-{
-    if (&other == this) {
-        return;
-    }
-    deletions = std::move(other.deletions);
-    insertions = std::move(other.insertions);
-    modifications = std::move(other.modifications);
-    moves = std::move(other.moves);
-    collection_root_was_deleted = other.collection_root_was_deleted;
-    columns = std::move(other.columns);
-    m_track_columns = other.m_track_columns;
-
-    other.collection_root_was_deleted = false;
-}
-
-CollectionChangeBuilder& CollectionChangeBuilder::operator=(CollectionChangeBuilder&& other)
-{
-    if (&other == this) {
-        return *this;
-    }
-    deletions = std::move(other.deletions);
-    insertions = std::move(other.insertions);
-    modifications = std::move(other.modifications);
-    moves = std::move(other.moves);
-    collection_root_was_deleted = other.collection_root_was_deleted;
-    columns = std::move(other.columns);
-    m_track_columns = other.m_track_columns;
-    other.collection_root_was_deleted = false;
-    return *this;
-}
-
 CollectionChangeBuilder::CollectionChangeBuilder(IndexSet deletions, IndexSet insertions, IndexSet modifications,
                                                  std::vector<Move> moves, bool root_was_deleted)
     : CollectionChangeSet({std::move(deletions),
@@ -714,12 +682,7 @@ CollectionChangeSet CollectionChangeBuilder::finalize() &&
     // but we don't want inserts in the final modification set
     modifications.remove(insertions);
 
-    // moving a bool will not reset it's value, so to get the move out behaviour
-    // that this method requires, manually reset the state
-    bool was_deleted = collection_root_was_deleted;
-    collection_root_was_deleted = false;
-
     return {std::move(deletions),     std::move(insertions), std::move(modifications_in_old),
-            std::move(modifications), std::move(moves),      was_deleted,
+            std::move(modifications), std::move(moves),      collection_root_was_deleted,
             std::move(columns)};
 }

--- a/src/realm/object-store/impl/collection_change_builder.hpp
+++ b/src/realm/object-store/impl/collection_change_builder.hpp
@@ -33,12 +33,12 @@ namespace _impl {
 class CollectionChangeBuilder : public CollectionChangeSet {
 public:
     CollectionChangeBuilder(CollectionChangeBuilder const&) = default;
-    CollectionChangeBuilder(CollectionChangeBuilder&&) = default;
+    CollectionChangeBuilder(CollectionChangeBuilder&&);
     CollectionChangeBuilder& operator=(CollectionChangeBuilder const&) = default;
-    CollectionChangeBuilder& operator=(CollectionChangeBuilder&&) = default;
+    CollectionChangeBuilder& operator=(CollectionChangeBuilder&&);
 
     CollectionChangeBuilder(IndexSet deletions = {}, IndexSet insertions = {}, IndexSet modification = {},
-                            std::vector<Move> moves = {});
+                            std::vector<Move> moves = {}, bool root_was_deleted = false);
 
     // Calculate where rows need to be inserted or deleted from old_rows to turn
     // it into new_rows, and check all matching rows for modifications

--- a/src/realm/object-store/impl/collection_change_builder.hpp
+++ b/src/realm/object-store/impl/collection_change_builder.hpp
@@ -33,9 +33,9 @@ namespace _impl {
 class CollectionChangeBuilder : public CollectionChangeSet {
 public:
     CollectionChangeBuilder(CollectionChangeBuilder const&) = default;
-    CollectionChangeBuilder(CollectionChangeBuilder&&);
+    CollectionChangeBuilder(CollectionChangeBuilder&&) = default;
     CollectionChangeBuilder& operator=(CollectionChangeBuilder const&) = default;
-    CollectionChangeBuilder& operator=(CollectionChangeBuilder&&);
+    CollectionChangeBuilder& operator=(CollectionChangeBuilder&&) = default;
 
     CollectionChangeBuilder(IndexSet deletions = {}, IndexSet insertions = {}, IndexSet modification = {},
                             std::vector<Move> moves = {}, bool root_was_deleted = false);

--- a/src/realm/object-store/impl/collection_notifier.cpp
+++ b/src/realm/object-store/impl/collection_notifier.cpp
@@ -320,6 +320,7 @@ void CollectionNotifier::prepare_handover()
     m_sg_version = m_sg->get_version_of_current_transaction();
     do_prepare_handover(*m_sg);
     add_changes(std::move(m_change));
+    m_change = {};
     REALM_ASSERT(m_change.empty());
     m_has_run = true;
 
@@ -393,8 +394,10 @@ bool CollectionNotifier::package_for_delivery()
     if (!prepare_to_deliver())
         return false;
     util::CheckedLockGuard lock(m_callback_mutex);
-    for (auto& callback : m_callbacks)
+    for (auto& callback : m_callbacks) {
         callback.changes_to_deliver = std::move(callback.accumulated_changes).finalize();
+        callback.accumulated_changes = {};
+    }
     m_callback_count = m_callbacks.size();
     return true;
 }

--- a/src/realm/object-store/impl/collection_notifier.cpp
+++ b/src/realm/object-store/impl/collection_notifier.cpp
@@ -424,6 +424,14 @@ Transaction& CollectionNotifier::source_shared_group()
     return Realm::Internal::get_transaction(*m_realm);
 }
 
+void CollectionNotifier::report_collection_root_is_deleted()
+{
+    if (!m_has_delivered_root_deletion_event) {
+        m_change.collection_root_was_deleted = true;
+        m_has_delivered_root_deletion_event = true;
+    }
+}
+
 void CollectionNotifier::add_changes(CollectionChangeBuilder change)
 {
     util::CheckedLockGuard lock(m_callback_mutex);

--- a/src/realm/object-store/impl/collection_notifier.hpp
+++ b/src/realm/object-store/impl/collection_notifier.hpp
@@ -201,6 +201,9 @@ protected:
     void set_table(ConstTableRef table);
     std::unique_lock<std::mutex> lock_target();
     Transaction& source_shared_group();
+    // signal that the underlying source object of the collection has been deleted
+    // but only report this to the notifiers the first time this is reported
+    void report_collection_root_is_deleted();
 
     bool all_related_tables_covered(const TableVersions& versions);
     std::function<bool(ObjectChangeSet::ObjectKeyType)> get_modification_checker(TransactionChangeInfo const&,
@@ -226,6 +229,7 @@ private:
 
     bool m_has_run = false;
     bool m_error = false;
+    bool m_has_delivered_root_deletion_event = false;
     std::vector<DeepChangeChecker::RelatedTable> m_related_tables;
 
     struct Callback {

--- a/src/realm/object-store/impl/list_notifier.cpp
+++ b/src/realm/object-store/impl/list_notifier.cpp
@@ -79,6 +79,7 @@ void ListNotifier::run()
         else {
             m_change = {};
         }
+        report_collection_root_is_deleted();
         return;
     }
 

--- a/src/realm/object-store/impl/results_notifier.cpp
+++ b/src/realm/object-store/impl/results_notifier.cpp
@@ -320,6 +320,7 @@ void ListResultsNotifier::run()
         m_change = {};
         m_change.deletions.set(m_previous_indices.size());
         m_previous_indices.clear();
+        report_collection_root_is_deleted();
         return;
     }
 

--- a/src/realm/object-store/impl/set_notifier.cpp
+++ b/src/realm/object-store/impl/set_notifier.cpp
@@ -78,6 +78,7 @@ void SetNotifier::run()
         else {
             m_change = {};
         }
+        report_collection_root_is_deleted();
         return;
     }
 

--- a/test/object-store/dictionary.cpp
+++ b/test/object-store/dictionary.cpp
@@ -227,6 +227,7 @@ TEST_CASE("dictionary") {
         SECTION("delete containing row") {
             advance_and_notify(*r);
             REQUIRE(calls == 3);
+            REQUIRE(!change.collection_root_was_deleted);
 
             r->begin_transaction();
             obj.remove();
@@ -236,6 +237,7 @@ TEST_CASE("dictionary") {
             REQUIRE(change.deletions.count() == values.size());
             REQUIRE(rchange.deletions.count() == values.size());
             REQUIRE(srchange.deletions.count() == values.size());
+            REQUIRE(change.collection_root_was_deleted);
 
             r->begin_transaction();
             table->create_object();
@@ -250,6 +252,30 @@ TEST_CASE("dictionary") {
             r2->commit_transaction();
             advance_and_notify(*r);
             REQUIRE(change.deletions.count() == values.size());
+            REQUIRE(change.collection_root_was_deleted);
+        }
+
+        SECTION("deleting a row with an empty dictionary triggers notifications") {
+            advance_and_notify(*r);
+            REQUIRE(calls == 3);
+            r->begin_transaction();
+            REQUIRE(dict.size() == values.size());
+            results.clear();
+            REQUIRE(dict.size() == 0);
+            REQUIRE(results.size() == 0);
+            r->commit_transaction();
+            advance_and_notify(*r);
+            REQUIRE(change.deletions.count() == values.size());
+            REQUIRE(!change.collection_root_was_deleted);
+            REQUIRE(calls == 6);
+
+            r->begin_transaction();
+            obj.remove();
+            r->commit_transaction();
+            advance_and_notify(*r);
+            REQUIRE(change.deletions.count() == 0);
+            REQUIRE(change.collection_root_was_deleted);
+            REQUIRE(calls == 9);
         }
     }
 }

--- a/test/object-store/set.cpp
+++ b/test/object-store/set.cpp
@@ -269,6 +269,25 @@ TEST_CASE("set") {
             });
             REQUIRE(change.empty());
         }
+
+        SECTION("deleting an empty set sends a change notification") {
+            auto token = require_change();
+            REQUIRE(link_set.size() == 0);
+            REQUIRE(!change.collection_root_was_deleted);
+
+            write([&]() {
+                obj.remove();
+            });
+            REQUIRE(change.deletions.empty());
+            REQUIRE(change.collection_root_was_deleted);
+
+            // Should not resend delete all notification after another commit
+            change = {};
+            write([&] {
+                table->create_object();
+            });
+            REQUIRE(change.empty());
+        }
     }
 
     SECTION("find(Query)") {


### PR DESCRIPTION
This is an enhancement to fire notifications when an empty collection has been deleted because the underlying object was deleted. This was already working for the case where there were items in the collection, so this is just an enhancement to for people who would expect to be notified when the object itself is deleted. Even though it is a behavioural change, I don't think it is breaking because there are no changes reported in the notifier. It is up to the SDK's if they would like to somehow expose the new `collection_root_was_deleted` flag somehow if that is appropriate. Fixes #4228. 