### PR TITLE
RCORE-387 Add reporter for core/sync tests to report test results to evergreen

### DIFF
--- a/evergreen/abspath.sh
+++ b/evergreen/abspath.sh
@@ -5,6 +5,9 @@ case $(uname -s) in
     Darwin)
         exec perl -e 'use File::Spec; print File::Spec->rel2abs(shift); print "\n"' $1
         ;;
+    CYGWIN*)
+        exec cygpath -am $1
+        ;;
     *)
         exec realpath -s $1
         ;;

--- a/evergreen/config.yml
+++ b/evergreen/config.yml
@@ -151,8 +151,18 @@ functions:
           fi
           TEST_FLAGS="$TEST_FLAGS ${test_flags|}"
 
+          if [[ -n "${enable_test_result_reporter|}" ]]; then
+              export UNITTEST_EVERGREEN_TEST_RESULTS="./evergreen/abspath.sh ${task_name}_results.json"
+          fi
+
+          if [[ -n "${report_test_progress|}" ]]; then
+              export UNITTEST_PROGRESS=${report_test_progress|}
+          fi
           cd build
           $CTEST -V $TEST_FLAGS
+    - command: attach.results
+      params:
+        file_location: realm-core/${task_name}_results.json
 
 tasks:
 - name: compile
@@ -197,6 +207,7 @@ tasks:
   - func: "run tests"
     vars:
       test_filter: StorageTests
+      enable_test_result_reporter: On
 
 - name: benchmark-common-tasks
   tags: [ "benchmark" ]
@@ -219,6 +230,7 @@ tasks:
   - func: "run tests"
     vars:
       test_filter: SyncTests
+      enable_test_result_reporter: On
 
 - name: object-store-tests
   tags: [ "disabled_on_windows", "test_suite" ]

--- a/evergreen/config.yml
+++ b/evergreen/config.yml
@@ -136,6 +136,32 @@ functions:
       params:
         file: './realm-core/benchmark_results/results.latest.json'
 
+  "run tests with reporter":
+    - command: shell.exec
+      params:
+        working_dir: realm-core
+        shell: bash
+        script: |-
+          set -o errexit
+          set -o verbose
+          CTEST=$(pwd)/${cmake_bindir}/ctest
+
+          if [[ -n "${test_filter}" ]]; then
+              TEST_FLAGS="-R ${test_filter}"
+          fi
+          TEST_FLAGS="$TEST_FLAGS ${test_flags|}"
+
+          export UNITTEST_EVERGREEN_TEST_RESULTS="$(./evergreen/abspath.sh ${task_name}_results.json)"
+
+          if [[ -n "${report_test_progress|}" ]]; then
+              export UNITTEST_PROGRESS=${report_test_progress|}
+          fi
+          cd build
+          $CTEST -V $TEST_FLAGS
+    - command: attach.results
+      params:
+        file_location: realm-core/${task_name}_results.json
+
   "run tests":
     - command: shell.exec
       params:
@@ -151,18 +177,11 @@ functions:
           fi
           TEST_FLAGS="$TEST_FLAGS ${test_flags|}"
 
-          if [[ -n "${enable_test_result_reporter|}" ]]; then
-              export UNITTEST_EVERGREEN_TEST_RESULTS="$(./evergreen/abspath.sh ${task_name}_results.json)"
-          fi
-
           if [[ -n "${report_test_progress|}" ]]; then
               export UNITTEST_PROGRESS=${report_test_progress|}
           fi
           cd build
           $CTEST -V $TEST_FLAGS
-    - command: attach.results
-      params:
-        file_location: realm-core/${task_name}_results.json
 
 tasks:
 - name: compile
@@ -204,10 +223,9 @@ tasks:
   tags: [ "test_suite" ]
   commands:
   - func: "compile"
-  - func: "run tests"
+  - func: "run tests with reporter"
     vars:
       test_filter: StorageTests
-      enable_test_result_reporter: On
 
 - name: benchmark-common-tasks
   tags: [ "benchmark" ]
@@ -227,10 +245,9 @@ tasks:
   tags: [ "test_suite" ]
   commands:
   - func: "compile"
-  - func: "run tests"
+  - func: "run tests with reporter"
     vars:
       test_filter: SyncTests
-      enable_test_result_reporter: On
 
 - name: object-store-tests
   tags: [ "disabled_on_windows", "test_suite" ]

--- a/evergreen/config.yml
+++ b/evergreen/config.yml
@@ -152,7 +152,7 @@ functions:
           TEST_FLAGS="$TEST_FLAGS ${test_flags|}"
 
           if [[ -n "${enable_test_result_reporter|}" ]]; then
-              export UNITTEST_EVERGREEN_TEST_RESULTS="./evergreen/abspath.sh ${task_name}_results.json"
+              export UNITTEST_EVERGREEN_TEST_RESULTS="$(./evergreen/abspath.sh ${task_name}_results.json)"
           fi
 
           if [[ -n "${report_test_progress|}" ]]; then

--- a/test/test_all.cpp
+++ b/test/test_all.cpp
@@ -500,6 +500,7 @@ bool run_tests(util::Logger* logger)
         reporters.push_back(std::move(reporter_2));
     }
     else if (const char* str = getenv("UNITTEST_EVERGREEN_TEST_RESULTS"); str && strlen(str) != 0) {
+        std::cout << "Configuring evergreen reporter to store test results in " << str << std::endl;
         auto evergreen_reporter = create_evergreen_reporter(str);
         auto combined_reporter = create_twofold_reporter(*reporters.back(), *evergreen_reporter);
         reporters.push_back(std::move(evergreen_reporter));

--- a/test/test_all.cpp
+++ b/test/test_all.cpp
@@ -499,6 +499,12 @@ bool run_tests(util::Logger* logger)
         reporters.push_back(std::move(reporter_1));
         reporters.push_back(std::move(reporter_2));
     }
+    else if (const char* str = getenv("UNITTEST_EVERGREEN_TEST_RESULTS"); str && strlen(str) != 0) {
+        auto evergreen_reporter = create_evergreen_reporter(str);
+        auto combined_reporter = create_twofold_reporter(*reporters.back(), *evergreen_reporter);
+        reporters.push_back(std::move(evergreen_reporter));
+        reporters.push_back(std::move(combined_reporter));
+    }
     config.reporter = reporters.back().get();
 
     // Set up filter

--- a/test/util/unit_test.cpp
+++ b/test/util/unit_test.cpp
@@ -100,7 +100,7 @@ public:
         auto results_arr = nlohmann::json::array();
         for (const auto& [test_name, cur_result] : m_results) {
             auto to_millis = [](const auto& tp) -> double {
-                return std::chrono::duration_cast<std::chrono::milliseconds>(tp.time_since_epoch()).count();
+                return static_cast<double>(std::chrono::duration_cast<std::chrono::milliseconds>(tp.time_since_epoch()).count());
             };
             double start_secs = to_millis(cur_result.start_time) / 1000;
             double end_secs = to_millis(cur_result.end_time) / 1000;

--- a/test/util/unit_test.cpp
+++ b/test/util/unit_test.cpp
@@ -100,7 +100,8 @@ public:
         auto results_arr = nlohmann::json::array();
         for (const auto& [test_name, cur_result] : m_results) {
             auto to_millis = [](const auto& tp) -> double {
-                return static_cast<double>(std::chrono::duration_cast<std::chrono::milliseconds>(tp.time_since_epoch()).count());
+                return static_cast<double>(
+                    std::chrono::duration_cast<std::chrono::milliseconds>(tp.time_since_epoch()).count());
             };
             double start_secs = to_millis(cur_result.start_time) / 1000;
             double end_secs = to_millis(cur_result.end_time) / 1000;

--- a/test/util/unit_test.cpp
+++ b/test/util/unit_test.cpp
@@ -24,9 +24,12 @@
 #include <locale>
 #include <iostream>
 #include <iomanip>
+#include <fstream>
 
 #include <realm/util/thread.hpp>
 #include <realm/util/timestamp_logger.hpp>
+
+#include <external/json/json.hpp>
 
 #include "demangle.hpp"
 #include "timer.hpp"
@@ -62,6 +65,74 @@ std::string xml_escape(const std::string& value)
     replace_char(value_2, '\"', "&quot;");
     return value_2;
 }
+
+class EvergreenReporter final : public Reporter {
+public:
+    explicit EvergreenReporter(const std::string& output_path)
+        : m_output(output_path)
+    {
+    }
+
+    void begin(const TestContext& context) override
+    {
+        m_results.emplace(std::make_pair(context.get_test_name(), TestResult{}));
+    }
+
+    void fail(const TestContext& context, const char*, long, const std::string&) override
+    {
+        auto it = m_results.find(context.get_test_name());
+        REALM_ASSERT(it != m_results.end());
+        it->second.status = "fail";
+    }
+
+    void end(const TestContext& context, double) override
+    {
+        auto it = m_results.find(context.get_test_name());
+        REALM_ASSERT(it != m_results.end());
+        if (it->second.status == "unknown") {
+            it->second.status = "pass";
+        }
+        it->second.end_time = std::chrono::system_clock::now();
+    }
+
+    void summary(const SharedContext&, const Summary&) override
+    {
+        auto results_arr = nlohmann::json::array();
+        for (const auto& [test_name, cur_result] : m_results) {
+            auto to_millis = [](const auto& tp) -> double {
+                return std::chrono::duration_cast<std::chrono::milliseconds>(tp.time_since_epoch()).count();
+            };
+            double start_secs = to_millis(cur_result.start_time) / 1000;
+            double end_secs = to_millis(cur_result.end_time) / 1000;
+            int exit_code = 0;
+            if (cur_result.status != "pass") {
+                exit_code = 1;
+            }
+
+            nlohmann::json cur_result_obj = {{"test_file", test_name}, {"status", cur_result.status},
+                                             {"exit_code", exit_code}, {"start", start_secs},
+                                             {"end", end_secs},        {"elapsed", end_secs - start_secs}};
+            results_arr.push_back(std::move(cur_result_obj));
+        }
+        auto result_file_obj = nlohmann::json{{"results", std::move(results_arr)}};
+        m_output << result_file_obj << std::endl;
+    }
+
+private:
+    struct TestResult {
+        TestResult()
+            : start_time{std::chrono::system_clock::now()}
+            , end_time{}
+            , status{"unknown"}
+        {
+        }
+        std::chrono::time_point<std::chrono::system_clock> start_time;
+        std::chrono::time_point<std::chrono::system_clock> end_time;
+        std::string status;
+    };
+    std::map<std::string, TestResult> m_results;
+    std::ofstream m_output;
+};
 
 
 class XmlReporter : public Reporter {
@@ -1027,6 +1098,11 @@ std::unique_ptr<Reporter> create_junit_reporter(std::ostream& out)
 std::unique_ptr<Reporter> create_xml_reporter(std::ostream& out)
 {
     return std::make_unique<XmlReporter>(out);
+}
+
+std::unique_ptr<Reporter> create_evergreen_reporter(const std::string& path)
+{
+    return std::make_unique<EvergreenReporter>(path);
 }
 
 std::unique_ptr<Reporter> create_twofold_reporter(Reporter& subreporter_1, Reporter& subreporter_2)

--- a/test/util/unit_test.hpp
+++ b/test/util/unit_test.hpp
@@ -418,6 +418,9 @@ std::unique_ptr<Reporter> create_xml_reporter(std::ostream&);
 /// http://llg.cubic.org/docs/junit/
 std::unique_ptr<Reporter> create_junit_reporter(std::ostream&);
 
+/// Generates output that is compatible with the evergreen test results api.
+std::unique_ptr<Reporter> create_evergreen_reporter(const std::string&);
+
 std::unique_ptr<Reporter> create_twofold_reporter(Reporter& subreporter_1, Reporter& subreporter_2);
 
 /// Run only those tests whose name is both included and not


### PR DESCRIPTION
This adds a reporter to the core/sync unittest framework so that individual test results get reported to evergreen rather than just the whole suite passing or failing.
