### PR TITLE
Link dynamically against libz on Android

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@
 
 ### Internals
 * On Android, the CMake build no longer sets -Oz explicitly for Release builds if `CMAKE_INTERPROCEDURAL_OPTIMIZATION` is enabled. Additionally, Android unit tests are built with LTO.
+* On Android, fixed the build to link against the dynamic `libz.so`. CMake was choosing the static library, which is both undesirable and has issues on newer NDKs.
 * ThreadSafeReference for Dictionary added
 
 ----------------------------------------------

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,7 +19,7 @@
 
 ### Internals
 * On Android, the CMake build no longer sets -Oz explicitly for Release builds if `CMAKE_INTERPROCEDURAL_OPTIMIZATION` is enabled. Additionally, Android unit tests are built with LTO.
-* On Android, fixed the build to link against the dynamic `libz.so`. CMake was choosing the static library, which is both undesirable and has issues on newer NDKs.
+* On Android, fixed the build to link against the dynamic `libz.so`. CMake was choosing the static library, which is both undesirable and has issues on newer NDKs. ([#4376](https://github.com/realm/realm-core/pull/4376))
 * ThreadSafeReference for Dictionary added
 
 ----------------------------------------------

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -246,7 +246,18 @@ endif()
 # so for an iOS build it'll use the path from the Device plaform, which is an error on Simulator.
 # Just use -lz and let Xcode figure it out
 if(REALM_ENABLE_SYNC AND NOT APPLE AND NOT TARGET ZLIB::ZLIB)
+    if(ANDROID)
+        # On Android FindZLIB chooses the static libz over the dynamic one, but this leads to issues
+        # (see https://github.com/android/ndk/issues/1179)
+        # We want to link against the stub library instead of statically linking anyway,
+        # so we hack find_library to only consider shared object libraries when looking for libz
+        set(_CMAKE_FIND_LIBRARY_SUFFIXES_orig ${CMAKE_FIND_LIBRARY_SUFFIXES})
+        set(CMAKE_FIND_LIBRARY_SUFFIXES .so)
+    endif()
     find_package(ZLIB REQUIRED)
+    if(ANDROID)
+        set(CMAKE_FIND_LIBRARY_SUFFIXES ${_CMAKE_FIND_LIBRARY_SUFFIXES_orig})
+    endif()
 endif()
 
 # Store configuration in header file


### PR DESCRIPTION
## What, How & Why?
Turns out we were statically linking against `libz` on Android all this time. We only noticed this when we attempted upgrading to NDK r22 and it turned out the `libz.a` there is broken. This PR forces CMake to only consider the dynamic `libz.so` when running the `FindZLIB` module.

## ☑️ ToDos
* [x] 📝 Changelog update
* [x] 🚦 Tests (or not relevant)
