### PR TITLE
Fix distro used for MacOS release builds

### DIFF
--- a/evergreen/config.yml
+++ b/evergreen/config.yml
@@ -538,7 +538,7 @@ buildvariants:
 
 - name: macos-1014-release
   display_name: "MacOS 10.14 x86_64 (Release build)"
-  run_on: macos-1014-test
+  run_on: macos-1014
   expansions:
     cmake_url: "https://s3.amazonaws.com/static.realm.io/evergreen-assets/cmake-3.19.1-Darwin-x86_64.tar.gz"
     cmake_bindir: "./cmake_binaries/CMake.app/Contents/bin"


### PR DESCRIPTION
This is just a small tweak to the distro we use to build the release builds on MacOS. It turns out the macos-1014-test distro doesn't actually have any hosts defined in it right now.
