### PR TITLE
Fix dtor-name warnings

### DIFF
--- a/src/realm/util/file.hpp
+++ b/src/realm/util/file.hpp
@@ -1156,7 +1156,7 @@ inline File::Map<T>::Map() noexcept
 }
 
 template <class T>
-inline File::Map<T>::~Map() noexcept
+inline File::Map<T>::~Map<T>() noexcept
 {
 }
 

--- a/src/realm/util/network.hpp
+++ b/src/realm/util/network.hpp
@@ -1783,7 +1783,7 @@ inline Service::OperQueue<Oper>::OperQueue(OperQueue&& q) noexcept
 }
 
 template <class Oper>
-inline Service::OperQueue<Oper>::~OperQueue() noexcept
+inline Service::OperQueue<Oper>::~OperQueue<Oper>() noexcept
 {
     clear();
 }


### PR DESCRIPTION
Upgrading to NDK 22 on Android resulted in a few new warnings. Not sure if they are worth fixing and I can ignore them with `-Wno-dtor-name`, but these changes should fix them.