### PR TITLE
Adding Mixed to the dictionary type dispatch function.

### DIFF
--- a/src/realm/object-store/dictionary.hpp
+++ b/src/realm/object-store/dictionary.hpp
@@ -148,6 +148,8 @@ auto Dictionary::dispatch(Fn&& fn) const
             return fn((Decimal128*)0);
         case PT::UUID:
             return fn((UUID*)0);
+        case PT::Mixed:
+            return fn((Mixed*)0);
         default:
             REALM_COMPILER_HINT_UNREACHABLE();
     }


### PR DESCRIPTION
 Adding Mixed to the dictionary type dispatch function for dictionaries, this way can handle key/Mixed values in the Javascript SDK.