### PR TITLE
translate property aliases in backlinks queries

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@
 
 ### Fixed
 * <How to hit and notice issue? what was the impact?> ([#????](https://github.com/realm/realm-core/issues/????), since v?.?.?)
-* None.
+* Fixed property aliases not working in the parsed queries which use the `@links.Class.property` syntax. ([#4398](https://github.com/realm/realm-core/issues/4398), this never previously worked)
  
 ### Breaking changes
 * None.

--- a/src/realm/parser/driver.cpp
+++ b/src/realm/parser/driver.cpp
@@ -1183,10 +1183,11 @@ void ParserDriver::backlink(LinkChain& link_chain, const std::string& identifier
 
     auto table_name = table_column_pair.substr(0, dot_pos);
     table_name = m_mapping.translate_table_name(table_name);
-    auto column_name = table_column_pair.substr(dot_pos + 1);
     auto origin_table = m_base_table->get_parent_group()->get_table(table_name);
+    auto column_name = table_column_pair.substr(dot_pos + 1);
     ColKey origin_column;
     if (origin_table) {
+        column_name = m_mapping.translate(origin_table, column_name);
         origin_column = origin_table->get_column_key(column_name);
     }
     if (!origin_column) {

--- a/src/realm/parser/keypath_mapping.cpp
+++ b/src/realm/parser/keypath_mapping.cpp
@@ -111,10 +111,9 @@ std::string KeyPathMapping::translate_table_name(const std::string& identifier)
     return alias;
 }
 
-std::string KeyPathMapping::translate(LinkChain& link_chain, const std::string& identifier)
+std::string KeyPathMapping::translate(ConstTableRef table, const std::string& identifier)
 {
     size_t substitutions = 0;
-    auto table = link_chain.get_current_table();
     auto tk = table->get_key();
     std::string alias = identifier;
     while (auto mapped = get_mapping(tk, alias)) {
@@ -127,6 +126,12 @@ std::string KeyPathMapping::translate(LinkChain& link_chain, const std::string& 
         substitutions++;
     }
     return alias;
+}
+
+std::string KeyPathMapping::translate(LinkChain& link_chain, const std::string& identifier)
+{
+    auto table = link_chain.get_current_table();
+    return translate(table, identifier);
 }
 
 

--- a/src/realm/parser/keypath_mapping.hpp
+++ b/src/realm/parser/keypath_mapping.hpp
@@ -78,6 +78,7 @@ public:
         return m_backlink_class_prefix;
     }
     std::string translate(LinkChain&, const std::string& identifier);
+    std::string translate(ConstTableRef table, const std::string& identifier);
     std::string translate_table_name(const std::string& identifier);
 
 protected:

--- a/test/test_parser.cpp
+++ b/test/test_parser.cpp
@@ -2835,6 +2835,7 @@ TEST(Parser_Backlinks)
     query_parser::KeyPathMapping mapping_with_prefix;
     mapping_with_prefix.set_backlink_class_prefix("class_");
     mapping_with_prefix.add_mapping(items, "purchasers", "@links.Person.items");
+    mapping_with_prefix.add_mapping(t, "things", "items");
     mapping_with_prefix.add_mapping(t, "money", "account_balance");
     mapping_with_prefix.add_mapping(t, "funds", "money");     // double indirection
     mapping_with_prefix.add_mapping(t, "capital", "capital"); // self loop
@@ -2855,6 +2856,10 @@ TEST(Parser_Backlinks)
     verify_query(test_context, items, "@links.class_Person.items.@count > 2", 2, mapping_with_prefix);
     // class name substitution
     verify_query(test_context, items, "@links.CustomPersonClassName.items.@count > 2", 2, mapping_with_prefix);
+    // property translation
+    verify_query(test_context, items, "@links.class_Person.things.@count > 2", 2, mapping_with_prefix);
+    // class and property translation
+    verify_query(test_context, items, "@links.CustomPersonClassName.things.@count > 2", 2, mapping_with_prefix);
 
     // infinite loops are detected
     CHECK_THROW_ANY_GET_MESSAGE(


### PR DESCRIPTION
As discovered by Christian in https://github.com/realm/realm-core/issues/4398 the properties in the backlink syntax `@links.Class.property` were not being translated by the mapping so aliasing didn't work in that case.