### PR TITLE
Change listeners not triggered on certain Mixed attribute changes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@
 * Mixed: crash when removing/setting a null-valued position of a Mixed list or set ([#4304](https://github.com/realm/realm-core/issues/4304))
 * Results based on dictionary keys will return wrong value from 'get_type'. ([#4365](https://github.com/realm/realm-core/issues/4365))
 * If a Dictionary contains Objects, those can not be returned by Results::get<Obj> ([#4374](https://github.com/realm/realm-core/issues/4374))
+* Change listeners not triggered on certain Mixed attribute changes ([#4404](https://github.com/realm/realm-core/issues/4404))
 
 ### Breaking changes
 * None.

--- a/src/realm/mixed.hpp
+++ b/src/realm/mixed.hpp
@@ -198,6 +198,7 @@ public:
 
     bool is_null() const;
     bool is_unresolved_link() const;
+    bool is_same_type(const Mixed& b) const;
     int compare(const Mixed& b) const;
     bool operator==(const Mixed& other) const
     {
@@ -598,6 +599,11 @@ inline ObjLink Mixed::get_link() const
 inline bool Mixed::is_null() const
 {
     return (m_type == 0);
+}
+
+inline bool Mixed::is_same_type(const Mixed& b) const
+{
+    return (m_type == b.m_type);
 }
 
 inline bool Mixed::is_unresolved_link() const

--- a/src/realm/object-store/object_accessor.hpp
+++ b/src/realm/object-store/object_accessor.hpp
@@ -99,8 +99,8 @@ struct ValueUpdater {
         if (!attr_changed) {
             auto old_val = obj.get<T>(col);
 
-            if (!attr_changed || std::is_same<T, realm::Mixed>::value) {
-                attr_changed = !Mixed(new_val).is_same_type(old_val);
+            if constexpr (std::is_same<T, realm::Mixed>::value) {
+                attr_changed = !new_val.is_same_type(old_val);
             }
 
             attr_changed = attr_changed || new_val != old_val;

--- a/src/realm/object-store/object_accessor.hpp
+++ b/src/realm/object-store/object_accessor.hpp
@@ -93,10 +93,21 @@ struct ValueUpdater {
     template <typename T>
     void operator()(T*)
     {
+        bool attr_changed = !policy.diff;
         auto new_val = ctx.template unbox<T>(value);
-        if (!policy.diff || obj.get<T>(col) != new_val) {
-            obj.set(col, new_val, is_default);
+
+        if (!attr_changed) {
+            auto old_val = obj.get<T>(col);
+
+            if (!attr_changed || std::is_same<T, realm::Mixed>::value) {
+                attr_changed = !Mixed(new_val).is_same_type(old_val);
+            }
+
+            attr_changed = attr_changed || new_val != old_val;
         }
+
+        if (attr_changed)
+            obj.set(col, new_val, is_default);
     }
 };
 } // namespace

--- a/test/object-store/object.cpp
+++ b/test/object-store/object.cpp
@@ -1255,7 +1255,8 @@ TEST_CASE("object") {
     SECTION("Mixed emit notification on type change") {
         auto validate_change = [&](util::Any&& obj_dict, util::Any&& value) {
             r->begin_transaction();
-            auto obj = Object::create(d, r, *r->schema().find("all optional types"), obj_dict, CreatePolicy::UpdateModified);
+            auto obj =
+                Object::create(d, r, *r->schema().find("all optional types"), obj_dict, CreatePolicy::UpdateModified);
             r->commit_transaction();
 
             CollectionChangeSet change;
@@ -1273,22 +1274,13 @@ TEST_CASE("object") {
             REQUIRE_INDICES(change.modifications, 0);
         };
 
-        validate_change(AnyDict{
-            {"_id", util::Any()},
-            {"mixed", true}
-        }, util::Any(1));
+        validate_change(AnyDict{{"_id", util::Any()}, {"mixed", true}}, util::Any(1));
 
-        validate_change(AnyDict{
-            {"_id", util::Any()},
-            {"mixed", false}
-        }, util::Any(0));
+        validate_change(AnyDict{{"_id", util::Any()}, {"mixed", false}}, util::Any(0));
 
         auto object_id = ObjectId::gen();
 
-        validate_change(AnyDict{
-            {"_id", util::Any()},
-            {"mixed", object_id}
-        }, util::Any(object_id.get_timestamp()));
+        validate_change(AnyDict{{"_id", util::Any()}, {"mixed", object_id}}, util::Any(object_id.get_timestamp()));
     }
 
 #if REALM_ENABLE_SYNC

--- a/test/object-store/object.cpp
+++ b/test/object-store/object.cpp
@@ -142,6 +142,8 @@ TEST_CASE("object") {
              {"object id", PropertyType::ObjectId | PropertyType::Nullable},
              {"decimal", PropertyType::Decimal | PropertyType::Nullable},
              {"uuid", PropertyType::UUID | PropertyType::Nullable},
+             {"mixed", PropertyType::Mixed | PropertyType::Nullable, Property::IsPrimary{false},
+              Property::IsIndexed{true}},
 
              {"bool array", PropertyType::Array | PropertyType::Bool | PropertyType::Nullable},
              {"int array", PropertyType::Array | PropertyType::Int | PropertyType::Nullable},
@@ -1248,6 +1250,45 @@ TEST_CASE("object") {
 
         REQUIRE(any_cast<List&&>(obj.get_property_value<util::Any>(d, "bool array")).size() == 2);
         REQUIRE(any_cast<List&&>(obj.get_property_value<util::Any>(d, "object array")).size() == 1);
+    }
+
+    SECTION("Mixed emit notification on type change") {
+        auto validate_change = [&](util::Any&& obj_dict, util::Any&& value) {
+            r->begin_transaction();
+            auto obj = Object::create(d, r, *r->schema().find("all optional types"), obj_dict, CreatePolicy::UpdateModified);
+            r->commit_transaction();
+
+            CollectionChangeSet change;
+            auto token = obj.add_notification_callback([&](CollectionChangeSet c, std::exception_ptr) {
+                change = c;
+            });
+            advance_and_notify(*r);
+
+            r->begin_transaction();
+            obj.set_property_value(d, "mixed", value, CreatePolicy::UpdateModified);
+            r->commit_transaction();
+
+            advance_and_notify(*r);
+
+            REQUIRE_INDICES(change.modifications, 0);
+        };
+
+        validate_change(AnyDict{
+            {"_id", util::Any()},
+            {"mixed", true}
+        }, util::Any(1));
+
+        validate_change(AnyDict{
+            {"_id", util::Any()},
+            {"mixed", false}
+        }, util::Any(0));
+
+        auto object_id = ObjectId::gen();
+
+        validate_change(AnyDict{
+            {"_id", util::Any()},
+            {"mixed", object_id}
+        }, util::Any(object_id.get_timestamp()));
     }
 
 #if REALM_ENABLE_SYNC


### PR DESCRIPTION
## What, How & Why?

The `objectaccessor` object update logic doesn't emit change notifications when changing the Mixed types. It results in a confusing behavior where the final user might be expecting a notification. For example, changing from Mixed(true) to Mixed(1) won't emit a notification.

This PR adds a logic in the object store to trigger changing mixed attributes on Mixed type changes.

Fixes #4404 

## ☑️ ToDos
* [x] 📝 Changelog update
* [x] 🚦 Tests (or not relevant)