### PR TITLE
Update all involved allocators before performing queries over links

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 ### Fixed
 * <How to hit and notice issue? what was the impact?> ([#????](https://github.com/realm/realm-core/issues/????), since v?.?.?)
 * Fixed property aliases not working in the parsed queries which use the `@links.Class.property` syntax. ([#4398](https://github.com/realm/realm-core/issues/4398), this never previously worked)
+* Fix "Invalid ref translation entry" assertion failure which could occur when querying over a link after creating objects in the destination table.
  
 ### Breaking changes
 * None.

--- a/src/realm/alloc.hpp
+++ b/src/realm/alloc.hpp
@@ -1,4 +1,4 @@
-﻿/*************************************************************************
+/*************************************************************************
  *
  * Copyright 2016 Realm Inc.
  *
@@ -346,13 +346,18 @@ public:
         m_alloc = &underlying_allocator;
         m_baseline.store(m_alloc->m_baseline, std::memory_order_relaxed);
         m_debug_watch = 0;
-        m_ref_translation_ptr.store(m_alloc->m_ref_translation_ptr);
+        refresh_ref_translation();
     }
 
     void update_from_underlying_allocator(bool writable)
     {
         switch_underlying_allocator(*m_alloc);
         set_read_only(!writable);
+    }
+
+    void refresh_ref_translation()
+    {
+        m_ref_translation_ptr.store(m_alloc->m_ref_translation_ptr);
     }
 
 protected:

--- a/src/realm/query_expression.hpp
+++ b/src/realm/query_expression.hpp
@@ -1705,6 +1705,9 @@ public:
 
     void set_cluster(const Cluster* cluster)
     {
+        for (auto& table : m_tables) {
+            table->refresh_allocator_wrapper();
+        }
         Allocator& alloc = get_base_table()->get_alloc();
         m_array_ptr = nullptr;
         switch (m_link_types[0]) {

--- a/src/realm/table.hpp
+++ b/src/realm/table.hpp
@@ -643,6 +643,10 @@ private:
     {
         m_alloc.update_from_underlying_allocator(writable);
     }
+    void refresh_allocator_wrapper() const noexcept
+    {
+        m_alloc.refresh_ref_translation();
+    }
     Spec m_spec;                                    // 1st slot in m_top
     TableClusterTree m_clusters;                    // 3rd slot in m_top
     std::unique_ptr<TableClusterTree> m_tombstones; // 13th slot in m_top


### PR DESCRIPTION
This is an attempt at a more general solution to the same problem as f045da0ac. There are several places where queries are using the allocator from one Table while accessing another Table. Rather than attempting to validate that all of them are correct, instead update each Table's WrappedAllocator before running the query so that it doesn't matter which one is used.

AFAICT this is a perfectly safe thing to do, but it's possible I've misunderstood something. It appears that not updating each WrappedAllocator immediately is a perf optimization and not something required for correctness (or maybe there just isn't an easy way to do it?), and this should be thread-safe for frozen transactions as it's assigning to an atomic variable with proper sequencing.