### PR TITLE
Fix incorrect locking in RealmCoordinator::run_async_notifiers()

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 ### Fixed
 * <How to hit and notice issue? what was the impact?> ([#????](https://github.com/realm/realm-core/issues/????), since v?.?.?)
 * Fixed a bug that prevented an ObjectSchema with incoming links from being marked as embedded during migrations. ([#4414](https://github.com/realm/realm-core/pull/4414))
+* `Results::get_dictionary_element()` on frozen Results was not thread-safe.
  
 ### Breaking changes
 * None.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 * <How to hit and notice issue? what was the impact?> ([#????](https://github.com/realm/realm-core/issues/????), since v?.?.?)
 * Fixed a bug that prevented an ObjectSchema with incoming links from being marked as embedded during migrations. ([#4414](https://github.com/realm/realm-core/pull/4414))
 * `Results::get_dictionary_element()` on frozen Results was not thread-safe.
+* The Realm notification listener thread could sometimes hit the assertion failure "!skip_version.version" if a write transaction was committed at a very specific time (since v10.5.0).
  
 ### Breaking changes
 * None.

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -75,7 +75,7 @@ else()
         add_compile_options(-Wno-uninitialized)
     elseif(${CMAKE_CXX_COMPILER_ID} MATCHES ".*[Cc]lang")
         # FIXME: Re-introduce -Wold-style-cast 
-        add_compile_options(-Wunreachable-code -Wshorten-64-to-32 -Wconditional-uninitialized -Wextra-semi -Wno-nested-anon-types -Wdocumentation)
+        add_compile_options(-Wunreachable-code -Wshorten-64-to-32 -Wconditional-uninitialized -Wextra-semi -Wno-nested-anon-types -Wdocumentation -Wthread-safety -Wthread-safety-negative)
     endif()
 
     # This warning is too agressive. It warns about moves that are not redundant on older

--- a/src/realm/object-store/impl/realm_coordinator.cpp
+++ b/src/realm/object-store/impl/realm_coordinator.cpp
@@ -961,12 +961,12 @@ void RealmCoordinator::run_async_notifiers()
     m_new_notifiers.clear();
     m_notifiers.insert(m_notifiers.end(), new_notifiers.begin(), new_notifiers.end());
 
-    lock.unlock();
-
     // Advance all of the new notifiers to the most recent version, if any
     TransactionRef new_notifier_transaction;
     util::Optional<IncrementalChangeInfo> new_notifier_change_info;
     if (!new_notifiers.empty()) {
+        lock.unlock();
+
         // Starting from the oldest notifier, incrementally advance the notifiers
         // to the latest version, attaching each new notifier as we reach its
         // source version. Suppose three new notifiers have been created:
@@ -1009,6 +1009,8 @@ void RealmCoordinator::run_async_notifiers()
             m_notifier_cv.notify_all();
             return;
         }
+
+        lock.unlock();
     }
 
     if (skip_version.version) {

--- a/src/realm/object-store/impl/realm_coordinator.hpp
+++ b/src/realm/object-store/impl/realm_coordinator.hpp
@@ -221,7 +221,7 @@ private:
     std::vector<WeakRealmNotifier> m_weak_realm_notifiers GUARDED_BY(m_realm_mutex);
 
     util::CheckedMutex m_notifier_mutex;
-    std::condition_variable m_notifier_cv;
+    std::condition_variable m_notifier_cv GUARDED_BY(m_notifier_mutex);
     std::vector<std::shared_ptr<_impl::CollectionNotifier>> m_new_notifiers GUARDED_BY(m_notifier_mutex);
     std::vector<std::shared_ptr<_impl::CollectionNotifier>> m_notifiers GUARDED_BY(m_notifier_mutex);
     VersionID m_notifier_skip_version GUARDED_BY(m_notifier_mutex) = {0, 0};

--- a/src/realm/object-store/results.cpp
+++ b/src/realm/object-store/results.cpp
@@ -381,6 +381,7 @@ Mixed Results::get_any(size_t ndx)
 }
 std::pair<StringData, Mixed> Results::get_dictionary_element(size_t ndx)
 {
+    util::CheckedUniqueLock lock(m_mutex);
     if (m_mode == Mode::Collection && ndx < m_collection->size()) {
         if (auto dict = dynamic_cast<realm::Dictionary*>(m_collection.get())) {
             evaluate_sort_and_distinct_on_collection();

--- a/src/realm/object-store/results.hpp
+++ b/src/realm/object-store/results.hpp
@@ -113,7 +113,7 @@ public:
     // Get an element in a list
     Mixed get_any(size_t index) REQUIRES(!m_mutex);
 
-    std::pair<StringData, Mixed> get_dictionary_element(size_t index);
+    std::pair<StringData, Mixed> get_dictionary_element(size_t index) REQUIRES(!m_mutex);
 
     // Get the boxed row accessor for the given index
     // Throws OutOfBoundsIndexException if index >= size()


### PR DESCRIPTION
The following sequence of events could produce the assertion failure "!skip_version.version":

1. Add a notifier and let the initial run complete
2. Make a commit and let the notifier start running
3. The notifier reads and clears the skip version, releases the lock, and then  calls get_version_id_of_latest_snapshot() with the lock not held. In between  releasing the lock and the call to get_version_id_of_latest_snapshot(),  perform another write.
4. In the next notifier run, the skip version is set but we're already at the  latest version, so the assertion that the skip version is unset for a  spurious wakeup fails.

Pushing the unlock until after the call to get_version_id_of_latest_snapshot() makes this sequencing impossible.

Enabling the static thread safety checks (which were enabled in the objectstore build system but never got ported over here) also revealed a missing lock in Results.