### PR TITLE
Fixed parsing queries comparing links/lists to TypedLink args

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,10 +4,10 @@
 * None.
 
 ### Fixed
-* <How to hit and notice issue? what was the impact?> ([#????](https://github.com/realm/realm-core/issues/????), since v?.?.?)
 * Fixed a bug that prevented an ObjectSchema with incoming links from being marked as embedded during migrations. ([#4414](https://github.com/realm/realm-core/pull/4414))
 * `Results::get_dictionary_element()` on frozen Results was not thread-safe.
 * The Realm notification listener thread could sometimes hit the assertion failure "!skip_version.version" if a write transaction was committed at a very specific time (since v10.5.0).
+* Fixed parsing queries comparing a link or list to an arguments of TypedLink. ([#4429](https://github.com/realm/realm-core/issues/4429), this never previously worked)]
  
 ### Breaking changes
 * None.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,8 +7,9 @@
 * Fixed a bug that prevented an ObjectSchema with incoming links from being marked as embedded during migrations. ([#4414](https://github.com/realm/realm-core/pull/4414))
 * `Results::get_dictionary_element()` on frozen Results was not thread-safe.
 * The Realm notification listener thread could sometimes hit the assertion failure "!skip_version.version" if a write transaction was committed at a very specific time (since v10.5.0).
-* Fixed parsing queries comparing a link or list to an arguments of TypedLink. ([#4429](https://github.com/realm/realm-core/issues/4429), this never previously worked)]
- 
+* Fixed parsing queries comparing a link or list to an arguments of TypedLink. ([#4429](https://github.com/realm/realm-core/issues/4429), this never previously worked)
+* Fixed `links_to` queries that searched for an object key in a list or set of objects that contained more than 1000 objects where sometimes an object might not be found. ([#4429](https://github.com/realm/realm-core/pull/4429), since v6.0.0)
+
 ### Breaking changes
 * None.
 

--- a/src/realm/query_engine.hpp
+++ b/src/realm/query_engine.hpp
@@ -2390,13 +2390,13 @@ public:
     size_t find_first_local(size_t start, size_t end) override
     {
         if (m_column_type == type_LinkList || m_condition_column_key.is_set()) {
-            ArrayKeyNonNullable arr(m_table.unchecked_ptr()->get_alloc());
+            BPlusTree<ObjKey> links(m_table.unchecked_ptr()->get_alloc());
             for (size_t i = start; i < end; i++) {
                 if (ref_type ref = static_cast<const ArrayList*>(m_leaf_ptr)->get(i)) {
-                    arr.init_from_ref(ref);
+                    links.init_from_ref(ref);
                     for (auto& key : m_target_keys) {
                         if (key) {
-                            if (arr.find_first(key, 0, arr.size()) != not_found)
+                            if (links.find_first(key) != not_found)
                                 return i;
                         }
                     }

--- a/test/test_query2.cpp
+++ b/test/test_query2.cpp
@@ -6126,4 +6126,37 @@ TEST(Query_TypeOfValue)
     CHECK_EQUAL(tv.size(), 1);
 }
 
+TEST(Query_links_to_with_bpnode_split)
+{
+    // The bug here is that LinksToNode would read a LinkList as a simple Array
+    // instead of a BPTree. So this only worked when the number of items < REALM_MAX_BPNODE_SIZE
+    Group g;
+    auto table = g.add_table("Foo");
+    auto origin = g.add_table("Origin");
+    auto col_int = table->add_column(type_Int, "int");
+    auto col_link = origin->add_column(*table, "link");
+    auto col_links = origin->add_column_list(*table, "links");
+    constexpr size_t num_items = REALM_MAX_BPNODE_SIZE + 1;
+    for (size_t i = 0; i < num_items; ++i) {
+        table->create_object().set(col_int, int64_t(i));
+    }
+    for (size_t i = 0; i < num_items; ++i) {
+        auto obj = origin->create_object();
+        auto it_i = table->begin();
+        it_i.go(i);
+        obj.set(col_link, it_i->get_key());
+        auto list = obj.get_linklist(col_links);
+        for (auto it = table->begin(); it != table->end(); ++it) {
+            list.add(it->get_key());
+        }
+    }
+
+    for (auto it = table->begin(); it != table->end(); ++it) {
+        Query q = origin->where().links_to(col_links, it->get_key());
+        CHECK_EQUAL(q.count(), num_items);
+        Query q2 = origin->where().links_to(col_link, it->get_key());
+        CHECK_EQUAL(q2.count(), 1);
+    }
+}
+
 #endif // TEST_QUERY


### PR DESCRIPTION
This was requested by .NET in relation to https://jira.mongodb.org/browse/RCORE-316 and https://github.com/realm/realm-core/pull/4395

Users might query an argument of TypedLink, and if they do, we can check that the link table matches and do the object key comparison or else throw a more informative message.