### PR TITLE
Use Schema::find(TableKey) in C API functions

### DIFF
--- a/src/realm/object-store/c_api/util.hpp
+++ b/src/realm/object-store/c_api/util.hpp
@@ -25,11 +25,9 @@ inline const ObjectSchema& schema_for_table(const std::shared_ptr<Realm>& realm,
     realm->read_group().get_table(table_key);
     const auto& schema = realm->schema();
 
-    // FIXME: Faster lookup than linear search.
-    for (auto& os : schema) {
-        if (os.table_key == table_key) {
-            return os;
-        }
+    auto it = schema.find(table_key);
+    if (it != schema.end()) {
+        return *it;
     }
 
     throw NoSuchTable{};

--- a/src/realm/object-store/schema.cpp
+++ b/src/realm/object-store/schema.cpp
@@ -87,6 +87,7 @@ Schema::iterator Schema::find(TableKey table_key) noexcept
     if (!table_key) {
         return end();
     }
+    // FIXME: Faster lookup than linear search.
     return std::find_if(begin(), end(), [table_key](const ObjectSchema& os) {
         return os.table_key == table_key;
     });


### PR DESCRIPTION
Quick adoption of #4413 in the C API.