### PR TITLE
Add missing constructor definitions for Dictionary

### DIFF
--- a/src/realm/object-store/dictionary.cpp
+++ b/src/realm/object-store/dictionary.cpp
@@ -22,6 +22,11 @@
 
 namespace realm::object_store {
 
+Dictionary::Dictionary(const Dictionary&) = default;
+Dictionary::Dictionary(Dictionary&&) = default;
+Dictionary& Dictionary::operator=(const Dictionary&) = default;
+Dictionary& Dictionary::operator=(Dictionary&&) = default;
+
 Dictionary::Dictionary() noexcept
     : m_dict(nullptr)
 {

--- a/src/realm/object-store/dictionary.hpp
+++ b/src/realm/object-store/dictionary.hpp
@@ -26,13 +26,18 @@
 namespace realm {
 namespace object_store {
 
-class Dictionary : public object_store::Collection {
+class Dictionary : public Collection {
 public:
     using Iterator = realm::Dictionary::Iterator;
     Dictionary() noexcept;
     Dictionary(std::shared_ptr<Realm> r, const Obj& parent_obj, ColKey col);
     Dictionary(std::shared_ptr<Realm> r, const realm::Dictionary& dict);
     ~Dictionary() override;
+
+    Dictionary(const Dictionary&);
+    Dictionary& operator=(const Dictionary&);
+    Dictionary(Dictionary&&);
+    Dictionary& operator=(Dictionary&&);
 
     bool operator==(const Dictionary& rgt) const noexcept
     {


### PR DESCRIPTION
## What, How & Why?
Cocoa will not compile without explicitly declaring the constructor definitions, so this PR just adds them.

## ☑️ ToDos
* [ ] 📝 Changelog update
* [ ] 🚦 Tests (or not relevant)
