### PR TITLE
RCORE-498 Allow overriding changeset timestamps for testing

### DIFF
--- a/src/realm/sync/apply_to_state_command.cpp
+++ b/src/realm/sync/apply_to_state_command.cpp
@@ -369,11 +369,15 @@ int main(int argc, const char** argv)
                          },
                          [&](const UploadMessage& upload_message) {
                              for (const auto& changeset : upload_message.changesets) {
+                                 history.set_local_origin_timestamp_source([&]() {
+                                     return changeset.origin_timestamp;
+                                 });
                                  auto transaction = local_db->start_write();
                                  realm::sync::InstructionApplier applier(*transaction);
                                  applier.apply(changeset, logger.get());
                                  auto generated_version = transaction->commit();
                                  logger->debug("integrated local changesets as version %1", generated_version);
+                                 history.set_local_origin_timestamp_source(realm::sync::generate_changeset_timestamp);
                              }
                          },
                          [&](const ServerIdentMessage& ident_message) {

--- a/src/realm/sync/noinst/client_history_impl.cpp
+++ b/src/realm/sync/noinst/client_history_impl.cpp
@@ -248,7 +248,6 @@ void ClientHistoryImpl::do_initiate_transact(Group& group, version_type version,
     SyncReplication::do_initiate_transact(group, version, history_updated);
 }
 
-
 // Overriding member function in realm::TrivialReplication
 auto ClientHistoryImpl::prepare_changeset(const char* data, size_t size, version_type orig_version) -> version_type
 {
@@ -280,7 +279,7 @@ auto ClientHistoryImpl::prepare_changeset(const char* data, size_t size, version
             changeset = BinaryData(buffer.data(), buffer.size());
         }
 
-        entry.origin_timestamp = sync::generate_changeset_timestamp();
+        entry.origin_timestamp = m_local_origin_timestamp_source();
         entry.origin_file_ident = 0; // Of local origin
         entry.remote_version = m_progress_download.server_version;
         entry.changeset = changeset;

--- a/src/realm/sync/noinst/client_history_impl.cpp
+++ b/src/realm/sync/noinst/client_history_impl.cpp
@@ -153,6 +153,11 @@ void ClientHistoryImpl::set_client_reset_adjustments(version_type current_versio
 }
 
 
+void ClientHistoryImpl::set_local_origin_timestamp_source(std::function<sync::timestamp_type()> source_fn)
+{
+    m_local_origin_timestamp_source = std::move(source_fn);
+}
+
 // Overriding member function in realm::Replication
 void ClientHistoryImpl::initialize(DB& sg)
 {

--- a/src/realm/sync/noinst/client_history_impl.hpp
+++ b/src/realm/sync/noinst/client_history_impl.hpp
@@ -106,6 +106,11 @@ public:
                                       sync::SaltedVersion server_version, uint_fast64_t downloaded_bytes,
                                       BinaryData uploadable_changeset);
 
+    /// set_local_origin_timestamp_override() allows you to override the origin timestamp of new changesets
+    /// of local origin. This should only be used for testing and defaults to calling
+    /// sync::generate_changeset_timestamp().
+    void set_local_origin_timestamp_source(std::function<sync::timestamp_type()> source_fn);
+
     // Overriding member functions in realm::Replication
     void initialize(DB& sg) override final;
     void initiate_session(version_type) override final;
@@ -304,6 +309,8 @@ private:
 
     mutable std::unique_ptr<BinaryColumn> m_ch_changesets; // Not nullable
     mutable std::unique_ptr<IntegerBpTree> m_ch_server_versions;
+
+    std::function<sync::timestamp_type()> m_local_origin_timestamp_source = sync::generate_changeset_timestamp;
 
     version_type find_sync_history_entry(version_type begin_version, version_type end_version, HistoryEntry& entry,
                                          version_type& last_integrated_server_version) const noexcept;


### PR DESCRIPTION
This fixes the apply2state command for the cloud team by letting it override the timestamps on changesets generated by local transactions.