### PR TITLE
Fix more version skipping logic errors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@
 ### Fixed
 * <How to hit and notice issue? what was the impact?> ([#????](https://github.com/realm/realm-core/issues/????), since v?.?.?)
 * Fixed a conflict resolution bug related to the ArrayMove instruction, which could sometimes cause an "Invalid prior_size" exception to prevent synchronization (since v10.3.0).
+* Fix another bug which could lead to the assertion failures "!skip_version.version" if a write transaction was committed while the first run of a notifier with no registered observers was happening (since v10.5.0).
+* Skipping a change notification in the first write transaction after the observer was added could potentially fail to skip the notification (since v10.3.3).
  
 ### Breaking changes
 * None.

--- a/src/realm/db.cpp
+++ b/src/realm/db.cpp
@@ -2097,7 +2097,7 @@ Replication::version_type DB::do_commit(Transaction& transaction)
 }
 
 
-DB::version_type Transaction::commit_and_continue_as_read()
+VersionID Transaction::commit_and_continue_as_read()
 {
     if (!is_attached())
         throw LogicError(LogicError::wrong_transact_state);
@@ -2129,7 +2129,7 @@ DB::version_type Transaction::commit_and_continue_as_read()
     m_history = nullptr;
     set_transact_stage(DB::transact_Reading);
 
-    return version;
+    return VersionID{version, new_read_lock.m_reader_idx};
 }
 
 // Caller must lock m_mutex.

--- a/src/realm/db.hpp
+++ b/src/realm/db.hpp
@@ -565,7 +565,7 @@ public:
     void end_read();
 
     // Live transactions state changes, often taking an observer functor:
-    DB::version_type commit_and_continue_as_read();
+    VersionID commit_and_continue_as_read();
     template <class O>
     void rollback_and_continue_as_read(O* observer);
     void rollback_and_continue_as_read()

--- a/src/realm/object-store/impl/realm_coordinator.cpp
+++ b/src/realm/object-store/impl/realm_coordinator.cpp
@@ -711,28 +711,45 @@ void RealmCoordinator::commit_write(Realm& realm)
     REALM_ASSERT(realm.is_in_transaction());
 
     Transaction& tr = Realm::Internal::get_transaction(realm);
+    VersionID new_version;
     {
         // Need to acquire this lock before committing or another process could
         // perform a write and notify us before we get the chance to set the
         // skip version
         util::CheckedLockGuard l(m_notifier_mutex);
+        new_version = tr.commit_and_continue_as_read();
 
-        tr.commit_and_continue_as_read();
-
-        // Don't need to check m_new_notifiers because those don't skip versions
+        // The skip version must always be the notifier transaction's current
+        // version plus one, as we can only skip a prefix and not intermediate
+        // transactions. If we have a notifier for the current Realm, then we
+        // waited until it finished running in begin_transaction() and this
+        // invarient holds. If we don't have any notifiers then we don't need
+        // to set the skip version, but more importantly *can't* because we
+        // didn't block when starting the write and the notifier transaction
+        // may still be on an older version.
+        //
+        // Note that this relies on the fact that callbacks cannot be added from
+        // within write transactions. If they could be, we could hit this point
+        // with an implicit-created notifier which ran (and so is in m_notifiers
+        // and not m_new_notifiers) but didn't have a callback at the start of
+        // the write so we didn't block for it then, but does now have a callback.
+        // If we add support for that, we'll need to update this logic.
         bool have_notifiers = std::any_of(m_notifiers.begin(), m_notifiers.end(), [&](auto&& notifier) {
-            return notifier->is_for_realm(realm);
+            return notifier->is_for_realm(realm) && notifier->have_callbacks();
         });
         if (have_notifiers) {
-            m_notifier_skip_version = Realm::Internal::get_transaction(realm).get_version_of_current_transaction();
+            REALM_ASSERT(!m_notifier_skip_version.version);
+            REALM_ASSERT(m_notifier_sg);
+            REALM_ASSERT_3(m_notifier_sg->get_transact_stage(), ==, DB::transact_Reading);
+            REALM_ASSERT_3(m_notifier_sg->get_version() + 1, ==, new_version.version);
+            m_notifier_skip_version = new_version;
         }
     }
 
 #if REALM_ENABLE_SYNC
     // Realm could be closed in did_change. So send sync notification first before did_change.
     if (m_sync_session) {
-        auto version = tr.get_version();
-        SyncSession::Internal::nonsync_transact_notify(*m_sync_session, version);
+        SyncSession::Internal::nonsync_transact_notify(*m_sync_session, new_version.version);
     }
 #endif
     if (realm.m_binding_context) {
@@ -923,11 +940,13 @@ void RealmCoordinator::run_async_notifiers()
     clean_up_dead_notifiers();
 
     if (m_notifiers.empty() && m_new_notifiers.empty()) {
+        REALM_ASSERT(!m_notifier_skip_version.version);
         m_notifier_cv.notify_all();
         return;
     }
 
     if (!m_notifier_sg) {
+        REALM_ASSERT(!m_notifier_skip_version.version);
         m_notifier_sg = m_db->start_read();
     }
 
@@ -938,7 +957,10 @@ void RealmCoordinator::run_async_notifiers()
         return;
     }
 
-    VersionID version;
+    // We need to pick the final version to advance to while the lock is held
+    // as otherwise if a commit is made while new notifiers are being advanced
+    // we could end up advancing over the skip version.
+    VersionID version = m_db->get_version_id_of_latest_snapshot();
     auto skip_version = m_notifier_skip_version;
     m_notifier_skip_version = {0, 0};
 
@@ -989,20 +1011,9 @@ void RealmCoordinator::run_async_notifiers()
             notifier->attach_to(new_notifier_transaction);
             notifier->add_required_change_info(new_notifier_change_info->current());
         }
-        new_notifier_change_info->advance_to_final(VersionID{});
-
-        // We want to advance the non-new notifiers to the same version as the
-        // new notifiers to avoid having to merge changes from any new
-        // transaction that happen immediately after this into the new notifier
-        // changes
-        version = new_notifier_transaction->get_version_of_current_transaction();
+        new_notifier_change_info->advance_to_final(version);
     }
     else {
-        // If we have no new notifiers we want to just advance to the latest
-        // version, but we have to pick a "latest" version while holding the
-        // notifier lock to avoid advancing over a transaction which should be
-        // skipped
-        version = m_db->get_version_id_of_latest_snapshot();
         if (version == m_notifier_sg->get_version_of_current_transaction()) {
             // We were spuriously woken up and there isn't actually anything to do
             REALM_ASSERT(!skip_version.version);

--- a/src/realm/sync/noinst/client_history_impl.cpp
+++ b/src/realm/sync/noinst/client_history_impl.cpp
@@ -633,7 +633,7 @@ bool ClientHistoryImpl::integrate_server_changesets(const SyncProgress& progress
 
     update_sync_progress(progress, downloadable_bytes); // Throws
 
-    version_type new_version = transact->commit_and_continue_as_read(); // Throws
+    version_type new_version = transact->commit_and_continue_as_read().version; // Throws
 #if REALM_DEBUG
     ensure_updated(new_version); // Throws
     REALM_ASSERT(m_ct_history->size() == m_ct_history_size);


### PR DESCRIPTION
There were two bugs here:

1. The logic for whether we block until notifiers are ready when beginning a write transaction and whether we set `m_notifier_skip_version` in `commit_write()` (which depends on us having blocked when starting the write) were mismatched. We don't block for notifiers without callbacks as the only purpose of those notifiers is to rerun the query on a background thread to avoid spending time on the main thread, so waiting would be counterproductive. This means that we also need to not set the skip version if we only have notifiers without callbacks. This probably did not cause any functional
problems, but violated some of the invariants of notification skipping and so assertions checking those invariants failed.

2. The latest snapshot version needs to be acquired while the notifier lock is held to ensure that we don't get mismatched values for it and the skip version. 368f0c7e5 fixed this in one of the code paths, but another code path implicitly obtained the latest snapshot version via `advance_read(VersionID{})` without holding the lock. The fix for this is to just always obtain the "final" version before releasing the lock, which ends up simplifying the code a little as well.

I still don't have any ideas for how to write tests for this. The Cocoa test suite hit the assertion failure occasionally so I've had that running in a loop for a few hours and it hasn't broken.