### PR TITLE
Fix the check for if ResultsNotifier needs to rerun queries

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 * <How to hit and notice issue? what was the impact?> ([#????](https://github.com/realm/realm-core/issues/????), since v?.?.?)
 * Support upgrading from file format 5. ([#7089](https://github.com/realm/realm-cocoa/issues/7089), since v6.0.0)
 * On 32bit devices you may get exception with "No such object" when upgrading to v10.* ([#7314](https://github.com/realm/realm-java/issues/7314), since v10.0.0)
+* The notification worker thread would rerun queries after every commit rather than only commits which modified tables which could effect the query results if the table had any outgoing links to tables not used in the query (since v6.0.0).
  
 ### Breaking changes
 * None.

--- a/src/realm/object-store/impl/collection_notifier.hpp
+++ b/src/realm/object-store/impl/collection_notifier.hpp
@@ -205,7 +205,7 @@ protected:
     // but only report this to the notifiers the first time this is reported
     void report_collection_root_is_deleted();
 
-    bool all_related_tables_covered(const TableVersions& versions);
+    bool any_related_table_was_modified(TransactionChangeInfo const&) const noexcept;
     std::function<bool(ObjectChangeSet::ObjectKeyType)> get_modification_checker(TransactionChangeInfo const&,
                                                                                  ConstTableRef);
 

--- a/src/realm/object-store/impl/results_notifier.hpp
+++ b/src/realm/object-store/impl/results_notifier.hpp
@@ -70,7 +70,6 @@ private:
     TransactionChangeInfo* m_info = nullptr;
     bool m_results_were_used = true;
 
-    bool need_to_run();
     void calculate_changes();
 
     void run() override;

--- a/test/object-store/results.cpp
+++ b/test/object-store/results.cpp
@@ -2073,6 +2073,20 @@ TEST_CASE("notifications: results") {
             });
             REQUIRE_FALSE(notifier->get_tableview(tv));
         }
+
+        SECTION("modifying a linked table not used for sorting does not rerun the query") {
+            results = Results(r, table).sort({{"link.value", false}});
+            _impl::CollectionNotifier::Handle<_impl::ResultsNotifierBase> notifier =
+                std::make_shared<_impl::ResultsNotifier>(results);
+            _impl::RealmCoordinator::register_notifier(notifier);
+            advance_and_notify(*r);
+            REQUIRE(notifier->get_tableview(tv));
+
+            write([&] {
+                second_linked_to_table->create_object(ObjKey(53));
+            });
+            REQUIRE_FALSE(notifier->get_tableview(tv));
+        }
     }
 }
 


### PR DESCRIPTION
The previous check would only skip rerunning the query (and sort etc.) if both none of the tables in the query were modified and if the query used every table reachable from the source table, which in many cases meant that it simply reran
after every commit. Instead we want to only rerun if any of the tables used by the query were modified, and only check the objects from the previous run for modification otherwise.