### PR TITLE
fix Results::index_of() for dictionary keys

### DIFF
--- a/src/realm/dictionary.cpp
+++ b/src/realm/dictionary.cpp
@@ -295,6 +295,23 @@ size_t Dictionary::find_any(Mixed value) const
     return ret;
 }
 
+size_t Dictionary::find_any_key(Mixed key) const
+{
+    size_t ret = realm::not_found;
+    if (size()) {
+        update_if_needed();
+        try {
+            auto hash = key.hash();
+            ObjKey k(int64_t(hash & 0x7FFFFFFFFFFFFFFF));
+            ret = m_clusters->get_ndx(k);
+        }
+        catch (...) {
+            // ignored
+        }
+    }
+    return ret;
+}
+
 Mixed Dictionary::min(size_t* return_ndx) const
 {
     update_if_needed();

--- a/src/realm/dictionary.hpp
+++ b/src/realm/dictionary.hpp
@@ -61,6 +61,7 @@ public:
     Mixed get_any(size_t ndx) const final;
     std::pair<Mixed, Mixed> get_pair(size_t ndx) const;
     size_t find_any(Mixed value) const final;
+    size_t find_any_key(Mixed value) const;
 
     Mixed min(size_t* return_ndx = nullptr) const final;
     Mixed max(size_t* return_ndx = nullptr) const final;

--- a/src/realm/object-store/dictionary.hpp
+++ b/src/realm/object-store/dictionary.hpp
@@ -88,6 +88,12 @@ public:
     {
         return m_dict->find_any(value);
     }
+
+    size_t find_any_key(Mixed key) const
+    {
+        return m_dict->find_any_key(key);
+    }
+
     bool contains(StringData key)
     {
         return m_dict->contains(key);

--- a/src/realm/object-store/results.cpp
+++ b/src/realm/object-store/results.cpp
@@ -588,6 +588,12 @@ size_t Results::index_of(T const& value)
         }
         return not_found;
     }
+    if (m_dictionary_keys) {
+        if (auto dict = dynamic_cast<realm::Dictionary*>(m_collection.get())) {
+            return dict->find_any_key(value);
+        }
+    }
+
     return m_collection->find_any(value);
 }
 


### PR DESCRIPTION
Results::index_of() was reported (on slack) broken for results produced by `object_store::Dictionary::get_keys()`