### PR TITLE
Add missing set methods

### DIFF
--- a/src/realm/object-store/set.cpp
+++ b/src/realm/object-store/set.cpp
@@ -361,6 +361,13 @@ bool Set::intersects(const Set& rhs) const
     });
 }
 
+bool Set::set_equals(const Set& rhs) const
+{
+    return dispatch([&](auto t) {
+        return this->as<std::decay_t<decltype(*t)>>().set_equals(rhs.as<std::decay_t<decltype(*t)>>());
+    });
+}
+
 void Set::assign_intersection(const Set& rhs)
 {
     return dispatch([&](auto t) {
@@ -379,6 +386,13 @@ void Set::assign_difference(const Set& rhs)
 {
     return dispatch([&](auto t) {
         return this->as<std::decay_t<decltype(*t)>>().assign_difference(rhs.as<std::decay_t<decltype(*t)>>());
+    });
+}
+
+void Set::assign_symmetric_difference(const Set& rhs)
+{
+    return dispatch([&](auto t) {
+        return this->as<std::decay_t<decltype(*t)>>().assign_symmetric_difference(rhs.as<std::decay_t<decltype(*t)>>());
     });
 }
 

--- a/src/realm/object-store/set.cpp
+++ b/src/realm/object-store/set.cpp
@@ -392,7 +392,8 @@ void Set::assign_difference(const Set& rhs)
 void Set::assign_symmetric_difference(const Set& rhs)
 {
     return dispatch([&](auto t) {
-        return this->as<std::decay_t<decltype(*t)>>().assign_symmetric_difference(rhs.as<std::decay_t<decltype(*t)>>());
+        return this->as<std::decay_t<decltype(*t)>>().assign_symmetric_difference(
+            rhs.as<std::decay_t<decltype(*t)>>());
     });
 }
 

--- a/src/realm/object-store/set.hpp
+++ b/src/realm/object-store/set.hpp
@@ -113,6 +113,7 @@ public:
     void assign_intersection(const Set& rhs);
     void assign_union(const Set& rhs);
     void assign_difference(const Set& rhs);
+    void assign_symmetric_difference(const Set& rhs);
 
     bool operator==(const Set& rhs) const noexcept;
 

--- a/src/realm/set.cpp
+++ b/src/realm/set.cpp
@@ -248,6 +248,11 @@ bool LnkSet::intersects(const LnkSet& rhs) const
     return this->m_set.intersects(rhs.m_set);
 }
 
+bool LnkSet::set_equals(const LnkSet& rhs) const
+{
+    return this->m_set.set_equals(rhs.m_set);
+}
+
 void set_sorted_indices(size_t sz, std::vector<size_t>& indices, bool ascending)
 {
     indices.resize(sz);

--- a/src/realm/set.hpp
+++ b/src/realm/set.hpp
@@ -287,6 +287,7 @@ public:
     bool is_superset_of(const LnkSet& rhs) const;
     bool is_strict_superset_of(const LnkSet& rhs) const;
     bool intersects(const LnkSet& rhs) const;
+    bool set_equals(const LnkSet& rhs) const;
 
     // Overriding members of CollectionBase:
     using CollectionBase::get_key;


### PR DESCRIPTION
<!--
 Make sure to assign one and only one Type (`T:`) label.
 Select reviewers if ready for review. Our bot will automatically assign you.
 -->

## What, How & Why?
This exposes set_equals and assign_symmetric_difference on the OS Set and adds set_equals to LnkSet.
