### PR TITLE
Consolidate the code for Collection, LinkList and LinkSet in Results

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,7 @@
 * If a Dictionary contains Objects, those can not be returned by Results::get<Obj> ([#4374](https://github.com/realm/realm-core/issues/4374))
 * Change listeners not triggered on certain Mixed attribute changes ([#4404](https://github.com/realm/realm-core/issues/4404))
 * Calling Dictionary::find_any() on a virgin dictionary will crash (([#4438](https://github.com/realm/realm-core/issues/4438))
+* `Dictionary::as_results()` on a dictionary of links gave a Results which did not support most object operations.
 
 ### Breaking changes
 * Sync protocol version increased to 3. This version adds support for the new data types introduced in file format version 21.

--- a/src/realm/dictionary.hpp
+++ b/src/realm/dictionary.hpp
@@ -54,13 +54,14 @@ public:
     DataType get_key_data_type() const;
     DataType get_value_data_type() const;
 
+    std::pair<Mixed, Mixed> get_pair(size_t ndx) const;
+    Mixed get_key(size_t ndx) const;
+
     // Overriding members of CollectionBase:
-    std::unique_ptr<CollectionBase> clone_collection() const;
+    std::unique_ptr<CollectionBase> clone_collection() const final;
     size_t size() const final;
     bool is_null(size_t ndx) const final;
     Mixed get_any(size_t ndx) const final;
-    std::pair<Mixed, Mixed> get_pair(size_t ndx) const;
-    Mixed get_key(size_t ndx) const;
     size_t find_any(Mixed value) const final;
     size_t find_any_key(Mixed value) const;
 

--- a/src/realm/list.hpp
+++ b/src/realm/list.hpp
@@ -854,7 +854,8 @@ inline bool LnkLst::is_null(size_t ndx) const
 inline Mixed LnkLst::get_any(size_t ndx) const
 {
     update_if_needed();
-    return m_list.get_any(virtual2real(ndx));
+    auto obj_key = m_list.get(virtual2real(ndx));
+    return ObjLink{get_target_table()->get_key(), obj_key};
 }
 
 inline void LnkLst::clear()

--- a/src/realm/mixed.hpp
+++ b/src/realm/mixed.hpp
@@ -584,6 +584,8 @@ inline UUID Mixed::get_uuid() const
 template <>
 inline ObjKey Mixed::get<ObjKey>() const noexcept
 {
+    if (get_type() == type_TypedLink)
+        return link_val.get_obj_key();
     REALM_ASSERT(get_type() == type_Link);
     return ObjKey(int_val);
 }

--- a/src/realm/object-store/collection.hpp
+++ b/src/realm/object-store/collection.hpp
@@ -38,6 +38,10 @@ class ListNotifier;
 namespace object_store {
 class Collection {
 public:
+    Collection() noexcept;
+    Collection(std::shared_ptr<Realm> r, const Obj& parent_obj, ColKey col);
+    Collection(std::shared_ptr<Realm> r, const CollectionBase& coll);
+
     // The Collection object has been invalidated (due to the Realm being invalidated,
     // or the containing object being deleted)
     // All non-noexcept functions can throw this
@@ -89,6 +93,12 @@ public:
     // Return a Results representing a live view of this Collection.
     Results as_results() const;
 
+    // Return a Results representing a snapshot of this Collection.
+    Results snapshot() const;
+
+    Results sort(SortDescriptor order) const;
+    Results sort(std::vector<std::pair<std::string, bool>> const& keypaths) const;
+
     NotificationToken add_notification_callback(CollectionChangeCallback cb) &;
 
     // The object being added to the collection is already a managed embedded object
@@ -107,11 +117,6 @@ protected:
     _impl::CollectionNotifier::Handle<_impl::ListNotifier> m_notifier;
     bool m_is_embedded = false;
 
-    Collection() noexcept;
-    Collection(std::shared_ptr<Realm> r, const Obj& parent_obj, ColKey col);
-
-    Collection(std::shared_ptr<Realm> r, const CollectionBase& coll);
-
     Collection(const Collection&);
     Collection& operator=(const Collection&);
     Collection(Collection&&);
@@ -122,6 +127,8 @@ protected:
 
     template <typename T, typename Context>
     void validate_embedded(Context& ctx, T&& value, CreatePolicy policy) const;
+
+    size_t hash() const noexcept;
 };
 
 template <typename T, typename Context>

--- a/src/realm/object-store/impl/results_notifier.cpp
+++ b/src/realm/object-store/impl/results_notifier.cpp
@@ -234,6 +234,7 @@ ListResultsNotifier::ListResultsNotifier(Results& target)
     : ResultsNotifierBase(target.get_realm())
     , m_list(target.get_collection())
 {
+    REALM_ASSERT(target.get_type() != PropertyType::Object);
     auto& ordering = target.get_descriptor_ordering();
     for (size_t i = 0, sz = ordering.size(); i < sz; i++) {
         auto descr = ordering[i];

--- a/src/realm/object-store/list.cpp
+++ b/src/realm/object-store/list.cpp
@@ -42,25 +42,10 @@ struct ListType<Obj> {
 namespace realm {
 using namespace _impl;
 
-List::List() noexcept = default;
-List::~List() = default;
-
 List::List(const List&) = default;
 List& List::operator=(const List&) = default;
 List::List(List&&) = default;
 List& List::operator=(List&&) = default;
-
-List::List(std::shared_ptr<Realm> r, const Obj& parent_obj, ColKey col)
-    : Collection(std::move(r), parent_obj, col)
-    , m_list_base(std::dynamic_pointer_cast<LstBase>(m_coll_base))
-{
-}
-
-List::List(std::shared_ptr<Realm> r, const LstBase& list)
-    : Collection(std::move(r), list)
-    , m_list_base(std::dynamic_pointer_cast<LstBase>(m_coll_base))
-{
-}
 
 Query List::get_query() const
 {
@@ -71,7 +56,7 @@ ConstTableRef List::get_table() const
 {
     verify_attached();
     if (m_type == PropertyType::Object)
-        return m_list_base->get_target_table();
+        return list_base().get_target_table();
     throw std::runtime_error("not implemented");
 }
 
@@ -162,20 +147,20 @@ void List::move(size_t source_ndx, size_t dest_ndx)
     if (source_ndx == dest_ndx)
         return;
 
-    m_list_base->move(source_ndx, dest_ndx);
+    list_base().move(source_ndx, dest_ndx);
 }
 
 void List::remove(size_t row_ndx)
 {
     verify_in_transaction();
     verify_valid_row(row_ndx);
-    m_list_base->remove(row_ndx, row_ndx + 1);
+    list_base().remove(row_ndx, row_ndx + 1);
 }
 
 void List::remove_all()
 {
     verify_in_transaction();
-    m_list_base->clear();
+    list_base().clear();
 }
 
 template <typename T>
@@ -191,25 +176,25 @@ void List::insert_any(size_t row_ndx, Mixed value)
 {
     verify_in_transaction();
     verify_valid_row(row_ndx, true);
-    m_list_base->insert_any(row_ndx, value);
+    list_base().insert_any(row_ndx, value);
 }
 
 void List::set_any(size_t row_ndx, Mixed value)
 {
     verify_in_transaction();
     verify_valid_row(row_ndx);
-    m_list_base->set_any(row_ndx, value);
+    list_base().set_any(row_ndx, value);
 }
 
 Mixed List::get_any(size_t row_ndx) const
 {
     verify_valid_row(row_ndx);
-    return m_list_base->get_any(row_ndx);
+    return list_base().get_any(row_ndx);
 }
 
 size_t List::find_any(Mixed value) const
 {
-    return m_list_base->find_any(value);
+    return list_base().find_any(value);
 }
 
 template <>
@@ -261,7 +246,7 @@ void List::swap(size_t ndx1, size_t ndx2)
     verify_in_transaction();
     verify_valid_row(ndx1);
     verify_valid_row(ndx2);
-    m_list_base->swap(ndx1, ndx2);
+    list_base().swap(ndx1, ndx2);
 }
 
 void List::delete_at(size_t row_ndx)
@@ -271,7 +256,7 @@ void List::delete_at(size_t row_ndx)
     if (m_type == PropertyType::Object)
         as<Obj>().remove_target_row(row_ndx);
     else
-        m_list_base->remove(row_ndx, row_ndx + 1);
+        list_base().remove(row_ndx, row_ndx + 1);
 }
 
 void List::delete_all()
@@ -280,36 +265,13 @@ void List::delete_all()
     if (m_type == PropertyType::Object)
         as<Obj>().remove_all_target_rows();
     else
-        m_list_base->clear();
-}
-
-Results List::sort(SortDescriptor order) const
-{
-    verify_attached();
-    if ((m_type == PropertyType::Object)) {
-        return Results(m_realm, std::dynamic_pointer_cast<LnkLst>(m_list_base), util::none, std::move(order));
-    }
-    else {
-        DescriptorOrdering o;
-        o.append_sort(order);
-        return Results(m_realm, m_list_base, std::move(o));
-    }
-}
-
-Results List::sort(std::vector<std::pair<std::string, bool>> const& keypaths) const
-{
-    return as_results().sort(keypaths);
+        list_base().clear();
 }
 
 Results List::filter(Query q) const
 {
     verify_attached();
-    return Results(m_realm, std::dynamic_pointer_cast<LnkLst>(m_list_base), get_query().and_query(std::move(q)));
-}
-
-Results List::snapshot() const
-{
-    return as_results().snapshot();
+    return Results(m_realm, std::dynamic_pointer_cast<LnkLst>(m_coll_base), get_query().and_query(std::move(q)));
 }
 
 // The simpler definition of void_t below does not work in gcc 4.9 due to a bug
@@ -364,10 +326,9 @@ util::Optional<Mixed> List::max(ColKey col) const
     if (get_type() == PropertyType::Object)
         return as_results().max(col);
     size_t out_ndx = not_found;
-    auto result = m_list_base->max(&out_ndx);
+    auto result = list_base().max(&out_ndx);
     if (result.is_null()) {
-        throw realm::Results::UnsupportedColumnTypeException(m_list_base->get_col_key(), m_list_base->get_table(),
-                                                             "max");
+        throw Results::UnsupportedColumnTypeException(list_base().get_col_key(), list_base().get_table(), "max");
     }
     return out_ndx == not_found ? none : util::make_optional(result);
 }
@@ -378,10 +339,9 @@ util::Optional<Mixed> List::min(ColKey col) const
         return as_results().min(col);
 
     size_t out_ndx = not_found;
-    auto result = m_list_base->min(&out_ndx);
+    auto result = list_base().min(&out_ndx);
     if (result.is_null()) {
-        throw realm::Results::UnsupportedColumnTypeException(m_list_base->get_col_key(), m_list_base->get_table(),
-                                                             "min");
+        throw Results::UnsupportedColumnTypeException(list_base().get_col_key(), list_base().get_table(), "min");
     }
     return out_ndx == not_found ? none : util::make_optional(result);
 }
@@ -391,10 +351,9 @@ Mixed List::sum(ColKey col) const
     if (get_type() == PropertyType::Object)
         return *as_results().sum(col);
 
-    auto result = m_list_base->sum();
+    auto result = list_base().sum();
     if (result.is_null()) {
-        throw realm::Results::UnsupportedColumnTypeException(m_list_base->get_col_key(), m_list_base->get_table(),
-                                                             "sum");
+        throw Results::UnsupportedColumnTypeException(list_base().get_col_key(), list_base().get_table(), "sum");
     }
     return result;
 }
@@ -404,24 +363,23 @@ util::Optional<Mixed> List::average(ColKey col) const
     if (get_type() == PropertyType::Object)
         return as_results().average(col);
     size_t count = 0;
-    auto result = m_list_base->avg(&count);
+    auto result = list_base().avg(&count);
     if (result.is_null()) {
-        throw realm::Results::UnsupportedColumnTypeException(m_list_base->get_col_key(), m_list_base->get_table(),
-                                                             "average");
+        throw Results::UnsupportedColumnTypeException(list_base().get_col_key(), list_base().get_table(), "average");
     }
     return count == 0 ? none : util::make_optional(result);
 }
 
 bool List::operator==(List const& rgt) const noexcept
 {
-    return m_list_base->get_table() == rgt.m_list_base->get_table() &&
-           m_list_base->get_owner_key() == rgt.m_list_base->get_owner_key() &&
-           m_list_base->get_col_key() == rgt.m_list_base->get_col_key();
+    return list_base().get_table() == rgt.list_base().get_table() &&
+           list_base().get_owner_key() == rgt.list_base().get_owner_key() &&
+           list_base().get_col_key() == rgt.list_base().get_col_key();
 }
 
 List List::freeze(std::shared_ptr<Realm> const& frozen_realm) const
 {
-    return List(frozen_realm, *frozen_realm->import_copy_of(*m_list_base));
+    return List(frozen_realm, *frozen_realm->import_copy_of(*m_coll_base));
 }
 
 #define REALM_PRIMITIVE_LIST_TYPE(T)                                                                                 \
@@ -453,24 +411,9 @@ REALM_PRIMITIVE_LIST_TYPE(util::Optional<UUID>)
 #undef REALM_PRIMITIVE_LIST_TYPE
 } // namespace realm
 
-namespace {
-size_t hash_combine()
-{
-    return 0;
-}
-template <typename T, typename... Rest>
-size_t hash_combine(const T& v, Rest... rest)
-{
-    size_t h = hash_combine(rest...);
-    h ^= std::hash<T>()(v) + 0x9e3779b9 + (h << 6) + (h >> 2);
-    return h;
-}
-} // namespace
-
 namespace std {
 size_t hash<List>::operator()(List const& list) const
 {
-    auto& impl = *list.m_list_base;
-    return hash_combine(impl.get_owner_key().value, impl.get_table()->get_key().value, impl.get_col_key().value);
+    return list.hash();
 }
 } // namespace std

--- a/src/realm/object-store/object_schema.cpp
+++ b/src/realm/object-store/object_schema.cpp
@@ -92,6 +92,7 @@ PropertyType ObjectSchema::from_core_type(ColumnType type)
         case col_type_UUID:
             return PropertyType::UUID;
         case col_type_Link:
+        case col_type_TypedLink:
             return PropertyType::Object;
         case col_type_LinkList:
             return PropertyType::Object | PropertyType::Array;
@@ -103,20 +104,19 @@ PropertyType ObjectSchema::from_core_type(ColumnType type)
 
 PropertyType ObjectSchema::from_core_type(ColKey col)
 {
-    auto flags = PropertyType::Required;
-    auto attr = col.get_attrs();
-
-    if (attr.test(col_attr_Nullable))
-        flags |= PropertyType::Nullable;
-    if (attr.test(col_attr_List))
-        flags |= PropertyType::Array;
-    else if (attr.test(col_attr_Set))
-        flags |= PropertyType::Set;
-    else if (attr.test(col_attr_Dictionary))
-        flags |= PropertyType::Dictionary;
-
     PropertyType prop_type = from_core_type(col.get_type());
-    return prop_type | flags;
+
+    auto attr = col.get_attrs();
+    if (attr.test(col_attr_Nullable))
+        prop_type |= PropertyType::Nullable;
+    if (attr.test(col_attr_List))
+        prop_type |= PropertyType::Array;
+    else if (attr.test(col_attr_Set))
+        prop_type |= PropertyType::Set;
+    else if (attr.test(col_attr_Dictionary))
+        prop_type |= PropertyType::Dictionary;
+
+    return prop_type;
 }
 
 ObjectSchema::ObjectSchema(Group const& group, StringData name, TableKey key)

--- a/src/realm/object-store/results.cpp
+++ b/src/realm/object-store/results.cpp
@@ -52,13 +52,19 @@ Results::Results(SharedRealm r, ConstTableRef table)
 {
 }
 
-Results::Results(std::shared_ptr<Realm> r, std::shared_ptr<CollectionBase> coll)
+Results::Results(std::shared_ptr<Realm> r, std::shared_ptr<CollectionBase> coll, util::Optional<Query> q,
+                 SortDescriptor s)
     : m_realm(std::move(r))
     , m_table(coll->get_target_table())
     , m_collection(std::move(coll))
     , m_mode(Mode::Collection)
     , m_mutex(m_realm && m_realm->is_frozen())
 {
+    if (q) {
+        m_query = std::move(*q);
+        m_mode = Mode::Query;
+    }
+    m_descriptor_ordering.append_sort(std::move(s));
 }
 
 Results::Results(std::shared_ptr<Realm> r, std::shared_ptr<CollectionBase> coll, DescriptorOrdering o)
@@ -79,34 +85,6 @@ Results::Results(std::shared_ptr<Realm> r, TableView tv, DescriptorOrdering o)
     , m_mutex(m_realm && m_realm->is_frozen())
 {
     m_table = m_table_view.get_parent();
-}
-
-Results::Results(std::shared_ptr<Realm> r, std::shared_ptr<LnkLst> lv, util::Optional<Query> q, SortDescriptor s)
-    : m_realm(std::move(r))
-    , m_link_list(std::move(lv))
-    , m_mode(Mode::LinkList)
-    , m_mutex(m_realm && m_realm->is_frozen())
-{
-    m_table = m_link_list->get_target_table();
-    if (q) {
-        m_query = std::move(*q);
-        m_mode = Mode::Query;
-    }
-    m_descriptor_ordering.append_sort(std::move(s));
-}
-
-Results::Results(std::shared_ptr<Realm> r, std::shared_ptr<LnkSet> ls, util::Optional<Query> q, SortDescriptor s)
-    : m_realm(std::move(r))
-    , m_link_set(std::move(ls))
-    , m_mode(Mode::LinkSet)
-    , m_mutex(m_realm && m_realm->is_frozen())
-{
-    m_table = m_link_set->get_target_table();
-    if (q) {
-        m_query = std::move(*q);
-        m_mode = Mode::Query;
-    }
-    m_descriptor_ordering.append_sort(std::move(s));
 }
 
 Results::Results(const Results&) = default;
@@ -166,10 +144,6 @@ size_t Results::do_size()
             return 0;
         case Mode::Table:
             return m_table->size();
-        case Mode::LinkList:
-            return m_link_list->size();
-        case Mode::LinkSet:
-            return m_link_set->size();
         case Mode::Collection:
             evaluate_sort_and_distinct_on_collection();
             return m_list_indices ? m_list_indices->size() : m_collection->size();
@@ -214,6 +188,13 @@ void Results::evaluate_sort_and_distinct_on_collection()
     if (m_descriptor_ordering.is_empty())
         return;
 
+    if (do_get_type() == PropertyType::Object) {
+        m_query = do_get_query();
+        m_mode = Mode::Query;
+        do_evaluate_query_if_needed();
+        return;
+    }
+
     // We can't use the sorted list from the notifier if we're in a write
     // transaction as we only check the transaction version to see if the data matches
     if (m_notifier && m_notifier->get_list_indices(m_list_indices) && !m_realm->is_in_transaction())
@@ -248,6 +229,15 @@ void Results::evaluate_sort_and_distinct_on_collection()
         m_collection->sort(*m_list_indices, *sort_order);
 }
 
+template <typename T>
+static T get_unwraped(CollectionBase& collection, size_t ndx)
+{
+    using U = typename util::RemoveOptional<T>::type;
+    Mixed mixed = collection.get_any(ndx);
+    if (!mixed.is_null())
+        return mixed.get<U>();
+    return BPlusTree<T>::default_value(collection.get_col_key().is_nullable());
+}
 
 template <typename T>
 util::Optional<T> Results::try_get(size_t ndx)
@@ -259,21 +249,7 @@ util::Optional<T> Results::try_get(size_t ndx)
             ndx = (ndx < m_list_indices->size()) ? (*m_list_indices)[ndx] : realm::npos;
         }
         if (ndx < m_collection->size()) {
-            using U = typename util::RemoveOptional<T>::type;
-            Mixed mixed;
-            if (m_dictionary_keys) {
-                if (auto dict = dynamic_cast<realm::Dictionary*>(m_collection.get())) {
-                    mixed = dict->get_key(ndx);
-                }
-            }
-            else {
-                mixed = m_collection->get_any(ndx);
-            }
-            T val = BPlusTree<T>::default_value(m_collection->get_col_key().is_nullable());
-            if (!mixed.is_null()) {
-                val = mixed.get<U>();
-            }
-            return util::Optional<T>(val);
+            return get_unwraped<T>(*m_collection, ndx);
         }
     }
     return util::none;
@@ -311,38 +287,25 @@ util::Optional<Obj> Results::try_get(size_t row_ndx)
     validate_read();
     switch (m_mode) {
         case Mode::Empty:
-            break;
-        case Mode::Collection: {
-            Mixed m = get_from_collection(row_ndx);
-            if (m.is_type(type_Link) && m_table) {
-                return m_table->get_object(m.get<ObjKey>());
-            }
-            else if (m.is_type(type_TypedLink)) {
-                return m_realm->read_group().get_object(m.get_link());
-            }
-            else if (m.is_null()) {
-                return Obj();
-            }
-            break;
-        }
         case Mode::Table:
             if (row_ndx < m_table->size())
                 return m_table_iterator.get(*m_table, row_ndx);
             break;
-        case Mode::LinkList:
-            if (update_link_collection()) {
-                if (row_ndx < m_link_list->size())
-                    return m_link_list->get_object(row_ndx);
+        case Mode::Collection:
+            evaluate_sort_and_distinct_on_collection();
+            if (m_mode == Mode::Collection) {
+                if (row_ndx < m_collection->size()) {
+                    auto m = m_collection->get_any(row_ndx);
+                    if (m.is_null())
+                        return Obj();
+                    if (m.get_type() == type_Link)
+                        return m_table->get_object(m.get<ObjKey>());
+                    if (m.get_type() == type_TypedLink)
+                        return m_table->get_parent_group()->get_object(m.get_link());
+                }
                 break;
             }
             [[fallthrough]];
-        case Mode::LinkSet:
-            if (update_link_collection()) {
-                if (row_ndx < m_link_set->size())
-                    return m_link_set->get_object(row_ndx);
-                break;
-            }
-            REALM_FALLTHROUGH;
         case Mode::Query:
         case Mode::TableView:
             do_evaluate_query_if_needed();
@@ -355,36 +318,6 @@ util::Optional<Obj> Results::try_get(size_t row_ndx)
     return util::none;
 }
 
-Mixed Results::get_from_collection(size_t ndx)
-{
-    REALM_ASSERT_RELEASE(m_mode == Mode::Collection);
-    evaluate_sort_and_distinct_on_collection();
-    if (m_list_indices) {
-        if (ndx < m_list_indices->size()) {
-            ndx = (*m_list_indices)[ndx];
-        }
-        else {
-            throw OutOfBoundsIndexException{ndx, m_list_indices->size()};
-        }
-    }
-    if (ndx < m_collection->size()) {
-        Mixed mixed;
-        if (m_dictionary_keys) {
-            if (auto dict = dynamic_cast<realm::Dictionary*>(m_collection.get())) {
-                mixed = dict->get_key(ndx);
-            }
-        }
-        else {
-            mixed = m_collection->get_any(ndx);
-        }
-        return mixed;
-    }
-    else {
-        throw OutOfBoundsIndexException{ndx, m_collection->size()};
-    }
-    return {};
-}
-
 Mixed Results::get_any(size_t ndx)
 {
     util::CheckedUniqueLock lock(m_mutex);
@@ -392,20 +325,20 @@ Mixed Results::get_any(size_t ndx)
     switch (m_mode) {
         case Mode::Empty:
             break;
-        case Mode::Collection:
-            return get_from_collection(ndx);
         case Mode::Table:
             if (ndx < m_table->size())
                 return m_table_iterator.get(*m_table, ndx);
             break;
-        case Mode::LinkSet:
-        case Mode::LinkList:
-            if (update_link_collection()) {
-                if (ndx < m_link_list->size()) {
-                    auto obj_key = m_link_list->get(ndx);
-                    auto table_key = m_link_list->get_target_table()->get_key();
-                    return Mixed(ObjLink(table_key, obj_key));
-                }
+        case Mode::Collection:
+            evaluate_sort_and_distinct_on_collection();
+            if (m_list_indices) {
+                if (ndx < m_list_indices->size())
+                    return m_collection->get_any((*m_list_indices)[ndx]);
+                break;
+            }
+            if (m_mode == Mode::Collection) {
+                if (ndx < m_collection->size())
+                    return m_collection->get_any(ndx);
                 break;
             }
             REALM_FALLTHROUGH;
@@ -420,30 +353,26 @@ Mixed Results::get_any(size_t ndx)
             return Mixed(ObjLink(m_table->get_key(), obj_key));
         }
     }
-    return {};
+    throw OutOfBoundsIndexException{ndx, do_size()};
 }
+
 std::pair<StringData, Mixed> Results::get_dictionary_element(size_t ndx)
 {
     util::CheckedUniqueLock lock(m_mutex);
-    if (m_mode == Mode::Collection && ndx < m_collection->size()) {
-        if (auto dict = dynamic_cast<realm::Dictionary*>(m_collection.get())) {
-            evaluate_sort_and_distinct_on_collection();
-            if (m_list_indices) {
-                if (ndx < m_list_indices->size()) {
-                    ndx = (*m_list_indices)[ndx];
-                }
-                else {
-                    throw OutOfBoundsIndexException{ndx, m_list_indices->size()};
-                }
-            }
-            if (ndx < dict->size()) {
-                auto val = dict->get_pair(ndx);
-                return {val.first.get_string(), val.second};
-            }
-            throw OutOfBoundsIndexException{ndx, dict->size()};
-        }
+    REALM_ASSERT(m_mode == Mode::Collection);
+    auto& dict = static_cast<Dictionary&>(*m_collection);
+    REALM_ASSERT(typeid(dict) == typeid(Dictionary));
+
+    evaluate_sort_and_distinct_on_collection();
+    size_t actual = ndx;
+    if (m_list_indices)
+        actual = ndx < m_list_indices->size() ? (*m_list_indices)[ndx] : npos;
+
+    if (actual < dict.size()) {
+        auto val = dict.get_pair(ndx);
+        return {val.first.get_string(), val.second};
     }
-    return {"", {}};
+    throw OutOfBoundsIndexException{ndx, dict.size()};
 }
 
 template <typename T>
@@ -473,19 +402,6 @@ util::Optional<T> Results::last()
     return try_get<T>(do_size() - 1);
 }
 
-bool Results::update_link_collection()
-{
-    REALM_ASSERT(m_update_policy == UpdatePolicy::Auto);
-
-    if (!m_descriptor_ordering.is_empty()) {
-        m_query = do_get_query();
-        m_mode = Mode::Query;
-        do_evaluate_query_if_needed();
-        return false;
-    }
-    return true;
-}
-
 void Results::evaluate_query_if_needed(bool wants_notifications)
 {
     util::CheckedUniqueLock lock(m_mutex);
@@ -504,8 +420,6 @@ void Results::do_evaluate_query_if_needed(bool wants_notifications)
         case Mode::Empty:
         case Mode::Table:
         case Mode::Collection:
-        case Mode::LinkList:
-        case Mode::LinkSet:
             return;
         case Mode::Query:
             if (m_notifier && m_notifier->get_tableview(m_table_view)) {
@@ -545,18 +459,13 @@ size_t Results::index_of(Obj const& row)
 
     switch (m_mode) {
         case Mode::Empty:
-        case Mode::Collection:
-            return not_found;
         case Mode::Table:
             return m_table->get_object_ndx(row.get_key());
-        case Mode::LinkList:
-            if (update_link_collection())
-                return m_link_list->find_first(row.get_key());
+        case Mode::Collection:
+            evaluate_sort_and_distinct_on_collection();
+            if (m_mode == Mode::Collection)
+                return m_collection->find_any(row.get_key());
             [[fallthrough]];
-        case Mode::LinkSet:
-            if (update_link_collection())
-                return m_link_set->find_first(row.get_key());
-            REALM_FALLTHROUGH;
         case Mode::Query:
         case Mode::TableView:
             do_evaluate_query_if_needed();
@@ -571,27 +480,15 @@ size_t Results::index_of(T const& value)
     util::CheckedUniqueLock lock(m_mutex);
     validate_read();
     if (m_mode != Mode::Collection)
-        return not_found; // Non-List results can only ever contain Objects
+        return not_found; // Non-Collection results can only ever contain Objects
     evaluate_sort_and_distinct_on_collection();
     if (m_list_indices) {
         for (size_t i = 0; i < m_list_indices->size(); ++i) {
-            using U = typename util::RemoveOptional<T>::type;
-            auto mixed = m_collection->get_any((*m_list_indices)[i]);
-            T val = BPlusTree<T>::default_value(m_collection->get_col_key().is_nullable());
-            if (!mixed.is_null()) {
-                val = mixed.get<U>();
-            }
-            if (val == value)
+            if (value == get_unwraped<T>(*m_collection, (*m_list_indices)[i]))
                 return i;
         }
         return not_found;
     }
-    if (m_dictionary_keys) {
-        if (auto dict = dynamic_cast<realm::Dictionary*>(m_collection.get())) {
-            return dict->find_any_key(value);
-        }
-    }
-
     return m_collection->find_any(value);
 }
 
@@ -619,9 +516,8 @@ DataType Results::prepare_for_aggregate(ColKey column, const char* name)
             break;
         case Mode::Collection:
             type = m_collection->get_table()->get_column_type(m_collection->get_col_key());
-            break;
-        case Mode::LinkList:
-        case Mode::LinkSet:
+            if (type != type_LinkList && type != type_Link)
+                break;
             m_query = do_get_query();
             m_mode = Mode::Query;
             REALM_FALLTHROUGH;
@@ -942,15 +838,12 @@ void Results::clear()
             break;
         case Mode::Collection:
             validate_write();
-            m_collection->clear();
-            break;
-        case Mode::LinkList:
-            validate_write();
-            m_link_list->remove_all_target_rows();
-            break;
-        case Mode::LinkSet:
-            validate_write();
-            m_link_set->remove_all_target_rows();
+            if (auto list = dynamic_cast<LnkLst*>(m_collection.get()))
+                list->remove_all_target_rows();
+            else if (auto set = dynamic_cast<LnkSet*>(m_collection.get()))
+                set->remove_all_target_rows();
+            else
+                m_collection->clear();
             break;
     }
 }
@@ -958,30 +851,20 @@ void Results::clear()
 PropertyType Results::get_type() const
 {
     util::CheckedUniqueLock lock(m_mutex);
+    validate_read();
     return do_get_type();
 }
 
 PropertyType Results::do_get_type() const
 {
-    validate_read();
     switch (m_mode) {
         case Mode::Empty:
-        case Mode::LinkList:
-        case Mode::LinkSet:
-            return PropertyType::Object;
         case Mode::Query:
         case Mode::TableView:
         case Mode::Table:
             return PropertyType::Object;
         case Mode::Collection:
-            if (m_dictionary_keys) {
-                if (auto dict = dynamic_cast<realm::Dictionary*>(m_collection.get())) {
-                    return ObjectSchema::from_core_type(ColumnType(dict->get_key_data_type()));
-                }
-            }
-            else {
-                return ObjectSchema::from_core_type(m_collection->get_col_key());
-            }
+            return ObjectSchema::from_core_type(m_collection->get_col_key());
     }
     REALM_COMPILER_HINT_UNREACHABLE();
 }
@@ -1003,8 +886,6 @@ ConstTableRef Results::get_table() const
         case Mode::TableView:
             return m_table_view.get_target_table();
         case Mode::Collection:
-        case Mode::LinkList:
-        case Mode::LinkSet:
             return m_collection->get_target_table();
         case Mode::Table:
             return m_table;
@@ -1018,8 +899,6 @@ Query Results::do_get_query() const
     switch (m_mode) {
         case Mode::Empty:
         case Mode::Query:
-        case Mode::Collection:
-            return m_query;
         case Mode::TableView: {
             if (const_cast<Query&>(m_query).get_table())
                 return m_query;
@@ -1038,10 +917,12 @@ Query Results::do_get_query() const
             }
             return Query(m_table, std::unique_ptr<ConstTableView>(new TableView(m_table_view)));
         }
-        case Mode::LinkList:
-            return m_table->where(*m_link_list);
-        case Mode::LinkSet:
-            return m_table->where(*m_link_set);
+        case Mode::Collection:
+            if (auto list = dynamic_cast<LnkLst*>(m_collection.get()))
+                return m_table->where(*list);
+            if (auto set = dynamic_cast<LnkSet*>(m_collection.get()))
+                return m_table->where(*set);
+            return m_query;
         case Mode::Table:
             return m_table->where();
     }
@@ -1055,15 +936,10 @@ TableView Results::get_tableview()
     switch (m_mode) {
         case Mode::Empty:
         case Mode::Collection:
-            return {};
-        case Mode::LinkList:
-            if (update_link_collection())
-                return m_table->where(*m_link_list).find_all();
-            [[fallthrough]];
-        case Mode::LinkSet:
-            if (update_link_collection())
-                return m_table->where(*m_link_set).find_all();
-            REALM_FALLTHROUGH;
+            evaluate_sort_and_distinct_on_collection();
+            if (m_mode == Mode::Collection)
+                return do_get_query().find_all();
+            return m_table_view;
         case Mode::Query:
         case Mode::TableView:
             do_evaluate_query_if_needed();
@@ -1148,14 +1024,8 @@ Results Results::sort(SortDescriptor&& sort) const
     util::CheckedUniqueLock lock(m_mutex);
     DescriptorOrdering new_order = m_descriptor_ordering;
     new_order.append_sort(std::move(sort));
-    if (m_mode == Mode::LinkList) {
-        return Results(m_realm, m_link_list, util::none, std::move(sort));
-    }
-    else if (m_mode == Mode::Collection) {
-        Results ret(m_realm, m_collection, std::move(new_order));
-        ret.as_keys(m_dictionary_keys);
-        return ret;
-    }
+    if (m_mode == Mode::Collection)
+        return Results(m_realm, m_collection, std::move(new_order));
     return Results(m_realm, do_get_query(), std::move(new_order));
 }
 
@@ -1176,25 +1046,7 @@ Results Results::limit(size_t max_count) const
 Results Results::apply_ordering(DescriptorOrdering&& ordering)
 {
     DescriptorOrdering new_order = m_descriptor_ordering;
-    for (size_t i = 0; i < ordering.size(); ++i) {
-        switch (ordering.get_type(i)) {
-            case DescriptorType::Sort: {
-                auto sort = dynamic_cast<const SortDescriptor*>(ordering[i]);
-                new_order.append_sort(std::move(*sort));
-                break;
-            }
-            case DescriptorType::Distinct: {
-                auto distinct = dynamic_cast<const DistinctDescriptor*>(ordering[i]);
-                new_order.append_distinct(std::move(*distinct));
-                break;
-            }
-            case DescriptorType::Limit: {
-                auto limit = dynamic_cast<const LimitDescriptor*>(ordering[i]);
-                new_order.append_limit(std::move(*limit));
-                break;
-            }
-        }
-    }
+    new_order.append(std::move(ordering));
     return Results(m_realm, get_query(), std::move(new_order));
 }
 
@@ -1248,15 +1100,13 @@ Results Results::snapshot() &&
             return Results();
 
         case Mode::Table:
-        case Mode::LinkList:
-        case Mode::LinkSet:
+        case Mode::Collection:
             m_query = do_get_query();
             m_mode = Mode::Query;
 
             REALM_FALLTHROUGH;
         case Mode::Query:
         case Mode::TableView:
-        case Mode::Collection: // FIXME Correct?
             do_evaluate_query_if_needed(false);
             m_notifier.reset();
             m_update_policy = UpdatePolicy::Never;
@@ -1290,7 +1140,7 @@ void Results::prepare_async(ForCallback force) NO_THREAD_SAFETY_ANALYSIS
             return;
     }
 
-    if (m_collection)
+    if (do_get_type() != PropertyType::Object)
         m_notifier = std::make_shared<_impl::ListResultsNotifier>(*this);
     else
         m_notifier = std::make_shared<_impl::ResultsNotifier>(*this);
@@ -1310,10 +1160,8 @@ bool Results::is_in_table_order() const NO_THREAD_SAFETY_ANALYSIS
     switch (m_mode) {
         case Mode::Empty:
         case Mode::Table:
-        case Mode::Collection:
             return true;
-        case Mode::LinkList:
-        case Mode::LinkSet:
+        case Mode::Collection:
             return false;
         case Mode::Query:
             return m_query.produces_results_in_table_order() && !m_descriptor_ordering.will_apply_sort();
@@ -1367,21 +1215,6 @@ Results Results::freeze(std::shared_ptr<Realm> const& frozen_realm)
             return Results(frozen_realm, frozen_realm->import_copy_of(m_table));
         case Mode::Collection:
             return Results(frozen_realm, frozen_realm->import_copy_of(*m_collection), m_descriptor_ordering);
-        case Mode::LinkList: {
-            std::shared_ptr<LnkLst> frozen_ll(
-                frozen_realm->import_copy_of(std::make_unique<LnkLst>(*m_link_list)).release());
-
-            // If query/sort was provided for the original Results, mode would have changed to Query, so no need
-            // include them here.
-            return Results(frozen_realm, std::move(frozen_ll));
-        }
-        case Mode::LinkSet: {
-            std::shared_ptr<LnkSet> frozen_ls(
-                frozen_realm->import_copy_of(std::make_unique<LnkSet>(*m_link_set)).release());
-            // If query/sort was provided for the original Results, mode would have changed to Query, so no need
-            // include them here.
-            return Results(frozen_realm, std::move(frozen_ls));
-        }
         case Mode::Query:
             return Results(frozen_realm, *frozen_realm->import_copy_of(m_query, PayloadPolicy::Copy),
                            m_descriptor_ordering);

--- a/src/realm/object-store/set.cpp
+++ b/src/realm/object-store/set.cpp
@@ -27,43 +27,23 @@
 #include <realm/object-store/shared_realm.hpp>
 
 namespace realm::object_store {
-using namespace _impl;
 
-Set::Set() noexcept = default;
-Set::~Set() = default;
 Set::Set(const Set&) = default;
 Set::Set(Set&&) = default;
 Set& Set::operator=(const Set&) = default;
 Set& Set::operator=(Set&&) = default;
 
-Set::Set(std::shared_ptr<Realm> r, const Obj& parent_obj, ColKey col)
-    : Collection(std::move(r), parent_obj, col)
-    , m_set_base(std::dynamic_pointer_cast<SetBase>(m_coll_base))
-{
-}
-
-Set::Set(std::shared_ptr<Realm> r, const SetBase& set)
-    : Collection(std::move(r), set)
-    , m_set_base(std::dynamic_pointer_cast<SetBase>(m_coll_base))
-{
-}
-
 Query Set::get_query() const
 {
-    verify_attached();
-    if (m_type == PropertyType::Object) {
-        return static_cast<LnkSet&>(*m_set_base).get_target_table()->where(as<Obj>());
-    }
-    throw std::runtime_error("not implemented");
+    return get_table()->where(as<Obj>());
 }
 
-ConstTableRef Set::get_target_table() const
+ConstTableRef Set::get_table() const
 {
-    auto table = m_set_base->get_table();
-    auto col = m_set_base->get_col_key();
-    if (col.get_type() != col_type_Link)
-        return nullptr;
-    return table->get_link_target(col);
+    verify_attached();
+    if (m_type == PropertyType::Object)
+        return set_base().get_target_table();
+    throw std::runtime_error("not implemented");
 }
 
 template <class T>
@@ -109,10 +89,9 @@ util::Optional<Mixed> Set::max(ColKey col) const
     if (get_type() == PropertyType::Object)
         return as_results().max(col);
     size_t out_ndx = not_found;
-    auto result = m_set_base->max(&out_ndx);
+    auto result = set_base().max(&out_ndx);
     if (result.is_null()) {
-        throw realm::Results::UnsupportedColumnTypeException(m_set_base->get_col_key(), m_set_base->get_table(),
-                                                             "max");
+        throw Results::UnsupportedColumnTypeException(set_base().get_col_key(), set_base().get_table(), "max");
     }
     return out_ndx == not_found ? none : util::make_optional(result);
 }
@@ -123,10 +102,9 @@ util::Optional<Mixed> Set::min(ColKey col) const
         return as_results().min(col);
 
     size_t out_ndx = not_found;
-    auto result = m_set_base->min(&out_ndx);
+    auto result = set_base().min(&out_ndx);
     if (result.is_null()) {
-        throw realm::Results::UnsupportedColumnTypeException(m_set_base->get_col_key(), m_set_base->get_table(),
-                                                             "min");
+        throw Results::UnsupportedColumnTypeException(set_base().get_col_key(), set_base().get_table(), "min");
     }
     return out_ndx == not_found ? none : util::make_optional(result);
 }
@@ -136,10 +114,9 @@ Mixed Set::sum(ColKey col) const
     if (get_type() == PropertyType::Object)
         return *as_results().sum(col);
 
-    auto result = m_set_base->sum();
+    auto result = set_base().sum();
     if (result.is_null()) {
-        throw realm::Results::UnsupportedColumnTypeException(m_set_base->get_col_key(), m_set_base->get_table(),
-                                                             "sum");
+        throw Results::UnsupportedColumnTypeException(set_base().get_col_key(), set_base().get_table(), "sum");
     }
     return result;
 }
@@ -149,64 +126,29 @@ util::Optional<Mixed> Set::average(ColKey col) const
     if (get_type() == PropertyType::Object)
         return as_results().average(col);
     size_t count = 0;
-    auto result = m_set_base->avg(&count);
+    auto result = set_base().avg(&count);
     if (result.is_null()) {
-        throw realm::Results::UnsupportedColumnTypeException(m_set_base->get_col_key(), m_set_base->get_table(),
-                                                             "average");
+        throw Results::UnsupportedColumnTypeException(set_base().get_col_key(), set_base().get_table(), "average");
     }
     return count == 0 ? none : util::make_optional(result);
 }
 
 bool Set::operator==(const Set& rgt) const noexcept
 {
-    return m_set_base->get_table() == rgt.m_set_base->get_table() &&
-           m_set_base->get_owner_key() == rgt.m_set_base->get_owner_key() &&
-           m_set_base->get_col_key() == rgt.m_set_base->get_col_key();
-}
-
-Results Set::snapshot() const
-{
-    return as_results().snapshot();
-}
-
-Results Set::sort(SortDescriptor order) const
-{
-    verify_attached();
-    if ((m_type == PropertyType::Object)) {
-        return Results(m_realm, std::dynamic_pointer_cast<LnkSet>(m_set_base), util::none, std::move(order));
-    }
-    else {
-        DescriptorOrdering o;
-        o.append_sort(order);
-        return Results(m_realm, m_set_base, std::move(o));
-    }
-}
-
-Results Set::sort(const std::vector<std::pair<std::string, bool>>& keypaths) const
-{
-    return as_results().sort(keypaths);
+    return set_base().get_table() == rgt.set_base().get_table() &&
+           set_base().get_owner_key() == rgt.set_base().get_owner_key() &&
+           set_base().get_col_key() == rgt.set_base().get_col_key();
 }
 
 Results Set::filter(Query q) const
 {
     verify_attached();
-    return Results(m_realm, std::dynamic_pointer_cast<LnkSet>(m_set_base), get_query().and_query(std::move(q)));
+    return Results(m_realm, std::dynamic_pointer_cast<LnkSet>(m_coll_base), get_query().and_query(std::move(q)));
 }
 
 Set Set::freeze(const std::shared_ptr<Realm>& frozen_realm) const
 {
-    return Set(frozen_realm, *frozen_realm->import_copy_of(*m_set_base));
-}
-
-NotificationToken Set::add_notification_callback(CollectionChangeCallback cb) &
-{
-    if (m_notifier && !m_notifier->have_callbacks())
-        m_notifier.reset();
-    if (!m_notifier) {
-        m_notifier = std::make_shared<ListNotifier>(m_realm, *m_set_base, m_type);
-        RealmCoordinator::register_notifier(m_notifier);
-    }
-    return {m_notifier, m_notifier->add_callback(std::move(cb))};
+    return Set(frozen_realm, *frozen_realm->import_copy_of(*m_coll_base));
 }
 
 #define REALM_PRIMITIVE_SET_TYPE(T)                                                                                  \
@@ -251,24 +193,24 @@ std::pair<size_t, bool> Set::remove<int>(const int& value)
 std::pair<size_t, bool> Set::insert_any(Mixed value)
 {
     verify_in_transaction();
-    return m_set_base->insert_any(value);
+    return set_base().insert_any(value);
 }
 
 Mixed Set::get_any(size_t ndx) const
 {
     verify_valid_row(ndx);
-    return m_set_base->get_any(ndx);
+    return set_base().get_any(ndx);
 }
 
 std::pair<size_t, bool> Set::remove_any(Mixed value)
 {
     verify_in_transaction();
-    return m_set_base->erase_any(value);
+    return set_base().erase_any(value);
 }
 
 size_t Set::find_any(Mixed value) const
 {
-    return m_set_base->find_any(value);
+    return set_base().find_any(value);
 }
 
 void Set::delete_all()
@@ -277,13 +219,13 @@ void Set::delete_all()
     if (m_type == PropertyType::Object)
         as<Obj>().remove_all_target_rows();
     else
-        m_set_base->clear();
+        set_base().clear();
 }
 
 void Set::remove_all()
 {
     verify_in_transaction();
-    m_set_base->clear();
+    set_base().clear();
 }
 
 template <>
@@ -400,24 +342,9 @@ void Set::assign_symmetric_difference(const Set& rhs)
 
 } // namespace realm::object_store
 
-namespace {
-size_t hash_combine()
-{
-    return 0;
-}
-template <typename T, typename... Rest>
-size_t hash_combine(const T& v, Rest... rest)
-{
-    size_t h = hash_combine(rest...);
-    h ^= std::hash<T>()(v) + 0x9e3779b9 + (h << 6) + (h >> 2);
-    return h;
-}
-} // namespace
-
 namespace std {
 size_t hash<realm::object_store::Set>::operator()(realm::object_store::Set const& set) const
 {
-    auto& impl = *set.m_set_base;
-    return hash_combine(impl.get_owner_key().value, impl.get_table()->get_key().value, impl.get_col_key().value);
+    return set.hash();
 }
 } // namespace std

--- a/src/realm/object-store/thread_safe_reference.cpp
+++ b/src/realm/object-store/thread_safe_reference.cpp
@@ -167,7 +167,9 @@ public:
         : Payload(*r.get_realm())
         , m_ordering(r.get_descriptor_ordering())
     {
-        if (auto list = r.get_collection()) {
+        if (r.get_type() != PropertyType::Object) {
+            auto list = r.get_collection();
+            REALM_ASSERT(list);
             m_key = list->get_owner_key();
             m_table_key = list->get_table()->get_key();
             m_col_key = list->get_col_key();

--- a/src/realm/sort_descriptor.cpp
+++ b/src/realm/sort_descriptor.cpp
@@ -421,6 +421,12 @@ void DescriptorOrdering::append(const DescriptorOrdering& other)
     }
 }
 
+void DescriptorOrdering::append(DescriptorOrdering&& other)
+{
+    std::move(other.m_descriptors.begin(), other.m_descriptors.end(), std::back_inserter(m_descriptors));
+    other.m_descriptors.clear();
+}
+
 DescriptorType DescriptorOrdering::get_type(size_t index) const
 {
     REALM_ASSERT(index < m_descriptors.size());

--- a/src/realm/sort_descriptor.hpp
+++ b/src/realm/sort_descriptor.hpp
@@ -280,6 +280,7 @@ public:
     void append_distinct(DistinctDescriptor distinct);
     void append_limit(LimitDescriptor limit);
     void append(const DescriptorOrdering& other);
+    void append(DescriptorOrdering&& other);
     realm::util::Optional<size_t> get_min_limit() const;
     /// Remove all LIMIT statements from this descriptor ordering, returning the
     /// minimum LIMIT value that existed. If there was no LIMIT statement,

--- a/test/object-store/frozen_objects.cpp
+++ b/test/object-store/frozen_objects.cpp
@@ -189,7 +189,7 @@ TEST_CASE("Freeze Results", "[freeze_results]") {
         JoiningThread thread([&] {
             REQUIRE(frozen_res.is_frozen());
             REQUIRE(frozen_res.size() == 0);
-            REQUIRE(frozen_res.get_any(0).is_null());
+            REQUIRE_THROWS(frozen_res.get_any(0));
         });
     }
 

--- a/test/object-store/list.cpp
+++ b/test/object-store/list.cpp
@@ -679,7 +679,7 @@ TEST_CASE("list") {
         auto results = list.sort({{{col_value}}, {false}});
 
         REQUIRE(&results.get_object_schema() == objectschema);
-        REQUIRE(results.get_mode() == Results::Mode::LinkList);
+        REQUIRE(results.get_mode() == Results::Mode::Collection);
         REQUIRE(results.size() == 10);
 
         // Aggregates don't inherently have to convert to TableView, but do
@@ -699,7 +699,7 @@ TEST_CASE("list") {
         for (size_t i = 0; i < 10; ++i)
             REQUIRE(results.get(i).get_key() == target_keys[i]);
         REQUIRE_THROWS_WITH(results.get(10), "Requested index 10 greater than max 9");
-        REQUIRE(results.get_mode() == Results::Mode::LinkList);
+        REQUIRE(results.get_mode() == Results::Mode::Collection);
     }
 
     SECTION("filter()") {


### PR DESCRIPTION
In addition to eliminating some duplicated code and mostly simplifying things, this also fixes a pile of bugs with Results wrapping a Dictionary of links and makes the API less error-prone. It was possible to construct a Results from a CollectionBase with a type of Object (as Dictionaries did) and some things worked, but many functions did not work properly as the Collection mode was only intended for non-objects.