### PR TITLE
Fix stale version tracking in SlabAlloc leading to a use-after-free

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 * Support upgrading from file format 5. ([#7089](https://github.com/realm/realm-cocoa/issues/7089), since v6.0.0)
 * On 32bit devices you may get exception with "No such object" when upgrading to v10.* ([#7314](https://github.com/realm/realm-java/issues/7314), since v10.0.0)
 * The notification worker thread would rerun queries after every commit rather than only commits which modified tables which could effect the query results if the table had any outgoing links to tables not used in the query (since v6.0.0).
+* Fix "Invalid ref translation entry [16045690984833335023, 78187493520]" assertion failure which could occur when using sync or multiple processes writing to a single Realm file. ([Cocoa #7086](https://github.com/realm/realm-cocoa/issues/7086), since v6.0.0.
  
 ### Breaking changes
 * None.

--- a/src/realm/db.cpp
+++ b/src/realm/db.cpp
@@ -2075,6 +2075,7 @@ Replication::version_type DB::do_commit(Transaction& transaction)
         current_version = r_info->get_current_version_unchecked();
     }
     version_type new_version = current_version + 1;
+    m_alloc.init_mapping_management(current_version);
 
     if (Replication* repl = get_replication()) {
         // If Replication::prepare_commit() fails, then the entire transaction

--- a/src/realm/db.hpp
+++ b/src/realm/db.hpp
@@ -880,6 +880,7 @@ inline bool Transaction::promote_to_write(O* observer, bool nonblocking)
 
         REALM_ASSERT(repl); // Presence of `repl` follows from the presence of `hist`
         DB::version_type current_version = m_read_lock.m_version;
+        m_alloc.init_mapping_management(current_version);
         repl->initiate_transact(*this, current_version, history_updated); // Throws
 
         // If the group has no top array (top_ref == 0), create a new node

--- a/test/test_shared.cpp
+++ b/test/test_shared.cpp
@@ -4306,9 +4306,10 @@ TEST(Shared_MultipleDBInstances)
     auto frozen = db2->start_frozen(); // version=3
     auto table = frozen->get_table("foo");
 
+    tr = db2->start_write();
     // creates a new mapping and incorrectly marks the old one as being for
     // version 2 rather than 3
-    tr = db2->start_write();
+    tr->get_table("foo")->create_object();
     // deletes the old mapping even though version 3 still needs it
     tr->commit();
 


### PR DESCRIPTION
SlabAlloc::m_youngest_live_version was only updated when committing a write transaction via that SlabAlloc, which resulted in it having the incorrect value if the write was made via a different DB instance. This lead to old ref translations being marked with the wrong version, and then they'd be deleted while they were still in use.

Fixes https://github.com/realm/realm-cocoa/issues/7086.