### PR TITLE
Dictionary bugfixes and increased test coverage

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,8 +6,8 @@
 ### Fixed
 * <How to hit and notice issue? what was the impact?> ([#????](https://github.com/realm/realm-core/issues/????), since v?.?.?)
 * Fixed queries of min/max/sum/avg on list of primitive mixed. ([#4472](https://github.com/realm/realm-core/pull/4472), never before working)
-* Fixed sort and distinct on dictionary keys, and distinct on dictionary values.
-* Fixed getting a dictionary value which is null.
+* Fixed sort and distinct on dictionary keys, and distinct on dictionary values. ([#4496](https://github.com/realm/realm-core/pull/4496))
+* Fixed getting a dictionary value which is null via `object_store::Dictionary::get<T>(key)` for any type other than Mixed. ([#4496](https://github.com/realm/realm-core/pull/4496))
 * Fixed notifications tracking modifications across links in a dictionary or set containing Mixed(TypedLink) values. ([#4505](https://github.com/realm/realm-core/pull/4505)).
 * Fixed the notifiers causing an exception `KeyNotFound("No such object");` if a dictionary or set of links of a single type also had a link column in the linked table. ([#4465](https://github.com/realm/realm-core/issues/4465)).
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@
 ### Fixed
 * <How to hit and notice issue? what was the impact?> ([#????](https://github.com/realm/realm-core/issues/????), since v?.?.?)
 * Fixed queries of min/max/sum/avg on list of primitive mixed. ([#4472](https://github.com/realm/realm-core/pull/4472), never before working)
+* Fixed sort and distinct on dictionary keys, and distinct on dictionary values.
+* Fixed getting a dictionary value which is null.
 
 ### Breaking changes
 * None.

--- a/src/realm/dictionary.hpp
+++ b/src/realm/dictionary.hpp
@@ -72,6 +72,8 @@ public:
 
     void sort(std::vector<size_t>& indices, bool ascending = true) const final;
     void distinct(std::vector<size_t>& indices, util::Optional<bool> sort_order = util::none) const final;
+    void sort_keys(std::vector<size_t>& indices, bool ascending = true) const;
+    void distinct_keys(std::vector<size_t>& indices, util::Optional<bool> sort_order = util::none) const;
 
     void create();
 
@@ -163,6 +165,7 @@ private:
     Mixed do_get_key(const ClusterNode::State&) const;
     std::pair<Mixed, Mixed> do_get_pair(const ClusterNode::State&) const;
     bool clear_backlink(Mixed value, CascadeState& state) const;
+    void align_indices(std::vector<size_t>& indices) const;
 
     friend struct CollectionIterator<Dictionary>;
 };

--- a/src/realm/mixed.cpp
+++ b/src/realm/mixed.cpp
@@ -466,7 +466,8 @@ util::Optional<UUID> Mixed::get<util::Optional<UUID>>() const noexcept
 
 size_t Mixed::hash() const
 {
-    REALM_ASSERT(!is_null());
+    if (is_null())
+        return 0;
 
     size_t hash = 0;
     switch (get_type()) {

--- a/src/realm/mixed.hpp
+++ b/src/realm/mixed.hpp
@@ -638,4 +638,15 @@ std::ostream& operator<<(std::ostream& out, const Mixed& m);
 
 } // namespace realm
 
+namespace std {
+template <>
+struct hash<::realm::Mixed> {
+    inline size_t operator()(const ::realm::Mixed& m) const noexcept
+    {
+        return m.hash();
+    }
+};
+} // namespace std
+
+
 #endif // REALM_MIXED_HPP

--- a/src/realm/object-store/dictionary.cpp
+++ b/src/realm/object-store/dictionary.cpp
@@ -71,11 +71,11 @@ public:
     }
     void sort(std::vector<size_t>& indices, bool ascending = true) const override
     {
-        m_dictionary->sort(indices, ascending);
+        m_dictionary->sort_keys(indices, ascending);
     }
     void distinct(std::vector<size_t>& indices, util::Optional<bool> sort_order = util::none) const override
     {
-        m_dictionary->distinct(indices, sort_order);
+        m_dictionary->distinct_keys(indices, sort_order);
     }
     const Obj& get_obj() const noexcept override
     {

--- a/src/realm/object-store/dictionary.hpp
+++ b/src/realm/object-store/dictionary.hpp
@@ -111,7 +111,16 @@ void Dictionary::insert(StringData key, T value)
 template <typename T>
 T Dictionary::get(StringData key) const
 {
-    return dict().get(key).get<T>();
+    auto res = dict().get(key);
+    if (res.is_null()) {
+        if constexpr (std::is_same_v<T, Decimal128>) {
+            return Decimal128{realm::null()};
+        }
+        else {
+            return T{};
+        }
+    }
+    return res.get<T>();
 }
 
 template <>

--- a/src/realm/object-store/list.hpp
+++ b/src/realm/object-store/list.hpp
@@ -32,7 +32,6 @@
 namespace realm {
 class Obj;
 class Query;
-class SortDescriptor;
 class ThreadSafeReference;
 struct ColKey;
 struct ObjKey;

--- a/src/realm/object-store/results.cpp
+++ b/src/realm/object-store/results.cpp
@@ -1135,8 +1135,9 @@ Results Results::snapshot() &&
         case Mode::Table:
         case Mode::Collection:
             m_query = do_get_query();
-            m_mode = Mode::Query;
-
+            if (m_query.get_table()) {
+                m_mode = Mode::Query;
+            }
             REALM_FALLTHROUGH;
         case Mode::Query:
         case Mode::TableView:

--- a/src/realm/object-store/results.cpp
+++ b/src/realm/object-store/results.cpp
@@ -143,7 +143,7 @@ size_t Results::do_size()
         case Mode::Empty:
             return 0;
         case Mode::Table:
-            return m_table->size();
+            return m_table ? m_table->size() : 0;
         case Mode::Collection:
             evaluate_sort_and_distinct_on_collection();
             return m_list_indices ? m_list_indices->size() : m_collection->size();
@@ -287,8 +287,9 @@ util::Optional<Obj> Results::try_get(size_t row_ndx)
     validate_read();
     switch (m_mode) {
         case Mode::Empty:
+            break;
         case Mode::Table:
-            if (row_ndx < m_table->size())
+            if (m_table && row_ndx < m_table->size())
                 return m_table_iterator.get(*m_table, row_ndx);
             break;
         case Mode::Collection:

--- a/test/object-store/collection_fixtures.hpp
+++ b/test/object-store/collection_fixtures.hpp
@@ -32,6 +32,21 @@
 
 namespace realm::collection_fixtures {
 
+struct less {
+    template <class T, class U>
+    auto operator()(T&& a, U&& b) const noexcept
+    {
+        return Mixed(a).compare(Mixed(b)) < 0;
+    }
+};
+struct greater {
+    template <class T, class U>
+    auto operator()(T&& a, U&& b) const noexcept
+    {
+        return Mixed(a).compare(Mixed(b)) > 0;
+    }
+};
+
 template <PropertyType prop_type, typename T>
 struct Base {
     using Type = T;

--- a/test/object-store/collection_fixtures.hpp
+++ b/test/object-store/collection_fixtures.hpp
@@ -1,9 +1,36 @@
-#include "property.hpp"
+////////////////////////////////////////////////////////////////////////////
+//
+// Copyright 2021 Realm Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+////////////////////////////////////////////////////////////////////////////
+
+#ifndef REALM_TEST_COLLECTION_FIXTURES_HPP
+#define REALM_TEST_COLLECTION_FIXTURES_HPP
+
+#include <catch2/catch.hpp>
+
+#include <realm/object-store/list.hpp>
+#include <realm/object-store/property.hpp>
+#include <realm/object-store/results.hpp>
+
+#include <realm/db.hpp>
 #include <realm/util/any.hpp>
 
 #include <type_traits>
 
-namespace realm::primitive_fixtures {
+namespace realm::collection_fixtures {
 
 template <PropertyType prop_type, typename T>
 struct Base {
@@ -11,6 +38,7 @@ struct Base {
     using Wrapped = T;
     using Boxed = T;
     using AvgType = double;
+    enum { is_optional = false };
 
     static PropertyType property_type()
     {
@@ -43,7 +71,10 @@ struct Base {
     {
         abort();
     }
-
+    static T empty_sum_value()
+    {
+        return T{};
+    }
     static bool can_sum()
     {
         return std::is_arithmetic<T>::value;
@@ -160,20 +191,20 @@ struct String : Base<PropertyType::String, StringData> {
 
 struct Binary : Base<PropertyType::Data, BinaryData> {
     using Boxed = std::string;
-    static std::vector<BinaryData> values()
-    {
-        return {BinaryData("a", 1)};
-    }
     static util::Any to_any(BinaryData value)
     {
         return value ? std::string(value) : util::Any();
+    }
+    static std::vector<BinaryData> values()
+    {
+        return {BinaryData("c", 1), BinaryData("a", 1), BinaryData("b", 1)};
     }
 };
 
 struct Date : Base<PropertyType::Date, Timestamp> {
     static std::vector<Timestamp> values()
     {
-        return {Timestamp(1, 1)};
+        return {Timestamp(3, 3), Timestamp(1, 1), Timestamp(2, 2)};
     }
     static bool can_minmax()
     {
@@ -185,14 +216,69 @@ struct Date : Base<PropertyType::Date, Timestamp> {
     }
     static Timestamp max()
     {
-        return Timestamp(1, 1);
+        return Timestamp(3, 3);
+    }
+};
+
+struct MixedVal : Base<PropertyType::Mixed, realm::Mixed> {
+    using AvgType = Decimal128;
+    enum { is_optional = true };
+    static std::vector<realm::Mixed> values()
+    {
+        return {Mixed{realm::UUID()}, Mixed{int64_t(1)},      Mixed{},
+                Mixed{"hello world"}, Mixed{Timestamp(1, 1)}, Mixed{Decimal128("300")},
+                Mixed{double(2.2)},   Mixed{float(3.3)}};
+    }
+    static PropertyType property_type()
+    {
+        return PropertyType::Mixed | PropertyType::Nullable;
+    }
+    static Mixed min()
+    {
+        return Mixed{int64_t(1)};
+    }
+    static Mixed max()
+    {
+        return Mixed{UUID()};
+    }
+    static Decimal128 sum()
+    {
+        return Decimal128("300") + Decimal128(int64_t(1)) + Decimal128(double(2.2)) + Decimal128(float(3.3));
+    }
+    static Decimal128 average()
+    {
+        return (sum() / Decimal128(4));
+    }
+    static Mixed empty_sum_value()
+    {
+        return Mixed{0};
+    }
+    static bool can_sum()
+    {
+        return true;
+    }
+    static bool can_average()
+    {
+        return true;
+    }
+    static bool can_minmax()
+    {
+        return true;
     }
 };
 
 struct OID : Base<PropertyType::ObjectId, ObjectId> {
     static std::vector<ObjectId> values()
     {
-        return {ObjectId("aaaaaaaaaaaaaaaaaaaaaaaa"), ObjectId("bbbbbbbbbbbbbbbbbbbbbbbb")};
+        return {ObjectId("bbbbbbbbbbbbbbbbbbbbbbbb"), ObjectId("aaaaaaaaaaaaaaaaaaaaaaaa")};
+    }
+};
+
+struct UUID : Base<PropertyType::UUID, realm::UUID> {
+    static std::vector<realm::UUID> values()
+    {
+        return {realm::UUID("3b241101-e2bb-4255-8caf-4136c566a962"),
+                realm::UUID("3b241101-a2b3-4255-8caf-4136c566a999")};
     }
 };
 
@@ -200,7 +286,7 @@ struct Decimal : Base<PropertyType::Decimal, Decimal128> {
     using AvgType = Decimal128;
     static std::vector<Decimal128> values()
     {
-        return {Decimal128("123.45e6"), Decimal128("876.54e32")};
+        return {Decimal128("876.54e32"), Decimal128("123.45e6")};
     }
     static Decimal128 min()
     {
@@ -236,6 +322,7 @@ template <typename BaseT>
 struct BoxedOptional : BaseT {
     using Type = util::Optional<typename BaseT::Type>;
     using Boxed = Type;
+    enum { is_optional = true };
     static PropertyType property_type()
     {
         return BaseT::property_type() | PropertyType::Nullable;
@@ -266,6 +353,7 @@ struct BoxedOptional : BaseT {
 
 template <typename BaseT>
 struct UnboxedOptional : BaseT {
+    enum { is_optional = true };
     static PropertyType property_type()
     {
         return BaseT::property_type() | PropertyType::Nullable;
@@ -273,8 +361,46 @@ struct UnboxedOptional : BaseT {
     static auto values() -> decltype(BaseT::values())
     {
         auto ret = BaseT::values();
-        ret.push_back(typename BaseT::Type());
+        if constexpr (std::is_same_v<BaseT, collection_fixtures::Decimal>) {
+            // The default Decimal128 ctr is 0, but we want a null value
+            ret.push_back(Decimal128(realm::null()));
+        }
+        else {
+            ret.push_back(typename BaseT::Type());
+        }
         return ret;
     }
 };
-} // namespace realm::primitive_fixtures
+
+} // namespace realm::collection_fixtures
+
+namespace realm {
+template <typename T>
+bool operator==(List const& list, std::vector<T> const& values)
+{
+    if (list.size() != values.size())
+        return false;
+    for (size_t i = 0; i < values.size(); ++i) {
+        if (list.get<T>(i) != values[i])
+            return false;
+    }
+    return true;
+}
+
+template <typename T>
+bool operator==(Results const& results, std::vector<T> const& values)
+{
+    // FIXME: this is only necessary because Results::size() and ::get() are not const
+    Results copy{results};
+    if (copy.size() != values.size())
+        return false;
+    for (size_t i = 0; i < values.size(); ++i) {
+        if (copy.get<T>(i) != values[i])
+            return false;
+    }
+    return true;
+}
+
+} // namespace realm
+
+#endif // REALM_TEST_COLLECTION_FIXTURES_HPP

--- a/test/object-store/dictionary.cpp
+++ b/test/object-store/dictionary.cpp
@@ -240,7 +240,8 @@ TEMPLATE_TEST_CASE("dictionary types", "[dictionary]", cf::MixedVal, cf::Int, cf
 
     SECTION("values sort and distinct") {
         // make some duplicate values
-        for (size_t i = 0; i < keys.size(); ++i) {
+        size_t num_keys = keys.size();
+        for (size_t i = 0; i < num_keys; ++i) {
             if (i == 0) {
                 dict.insert(keys[i], T(values[0]));
             }
@@ -259,6 +260,31 @@ TEMPLATE_TEST_CASE("dictionary types", "[dictionary]", cf::MixedVal, cf::Int, cf
             REQUIRE(sorted_and_distinct.size() == 2);
             REQUIRE(sorted_and_distinct.get<T>(0) == T(values[0]));
             REQUIRE(sorted_and_distinct.get<T>(1) == T(values[1]));
+        }
+    }
+
+    SECTION("first") {
+        SECTION("key") {
+            REQUIRE(keys_as_results.first<String>() == keys_as_results.get<String>(0));
+            keys_as_results.clear();
+            REQUIRE(!keys_as_results.first<String>());
+        }
+        SECTION("value") {
+            REQUIRE(*values_as_results.first<T>() == values_as_results.get<T>(0));
+            values_as_results.clear();
+            REQUIRE(!values_as_results.first<T>());
+        }
+    }
+    SECTION("last") {
+        SECTION("key") {
+            REQUIRE(keys_as_results.last<String>() == keys_as_results.get<String>(keys_as_results.size() - 1));
+            keys_as_results.clear();
+            REQUIRE(!keys_as_results.last<String>());
+        }
+        SECTION("value") {
+            REQUIRE(*values_as_results.last<T>() == values_as_results.get<T>(values_as_results.size() - 1));
+            values_as_results.clear();
+            REQUIRE(!values_as_results.last<T>());
         }
     }
 

--- a/test/object-store/dictionary.cpp
+++ b/test/object-store/dictionary.cpp
@@ -443,6 +443,14 @@ TEMPLATE_TEST_CASE("dictionary types", "[dictionary]", cf::MixedVal, cf::Int, cf
             REQUIRE(local_change.modifications.count() == 1);
         }
     }
+    SECTION("snapshot") {
+        SECTION("keys") {
+            auto new_keys = keys_as_results.snapshot();
+        }
+        SECTION("values") {
+            auto new_values = values_as_results.snapshot();
+        }
+    }
 }
 
 TEST_CASE("embedded dictionary", "[dictionary]") {

--- a/test/object-store/dictionary.cpp
+++ b/test/object-store/dictionary.cpp
@@ -265,26 +265,39 @@ TEMPLATE_TEST_CASE("dictionary types", "[dictionary]", cf::MixedVal, cf::Int, cf
 
     SECTION("first") {
         SECTION("key") {
-            REQUIRE(keys_as_results.first<String>() == keys_as_results.get<String>(0));
+            auto expected = keys_as_results.get<String>(0);
+            REQUIRE(keys_as_results.first<String>() == expected);
+            REQUIRE(any_cast<std::string>(*keys_as_results.first(ctx)) == expected);
             keys_as_results.clear();
             REQUIRE(!keys_as_results.first<String>());
+            REQUIRE(!keys_as_results.first(ctx));
         }
         SECTION("value") {
-            REQUIRE(*values_as_results.first<T>() == values_as_results.get<T>(0));
+            auto expected = values_as_results.get<T>(0);
+            REQUIRE(*values_as_results.first<T>() == expected);
+            REQUIRE(any_cast<Boxed>(*values_as_results.first(ctx)) == Boxed(expected));
             values_as_results.clear();
             REQUIRE(!values_as_results.first<T>());
+            REQUIRE(!values_as_results.first(ctx));
         }
     }
+
     SECTION("last") {
         SECTION("key") {
-            REQUIRE(keys_as_results.last<String>() == keys_as_results.get<String>(keys_as_results.size() - 1));
+            auto expected = keys_as_results.get<String>(keys_as_results.size() - 1);
+            REQUIRE(keys_as_results.last<String>() == expected);
+            REQUIRE(any_cast<std::string>(*keys_as_results.last(ctx)) == expected);
             keys_as_results.clear();
             REQUIRE(!keys_as_results.last<String>());
+            REQUIRE(!keys_as_results.last(ctx));
         }
         SECTION("value") {
-            REQUIRE(*values_as_results.last<T>() == values_as_results.get<T>(values_as_results.size() - 1));
+            auto expected = values_as_results.get<T>(values_as_results.size() - 1);
+            REQUIRE(*values_as_results.last<T>() == expected);
+            REQUIRE(any_cast<Boxed>(*values_as_results.last(ctx)) == Boxed(expected));
             values_as_results.clear();
             REQUIRE(!values_as_results.last<T>());
+            REQUIRE(!values_as_results.last(ctx));
         }
     }
 
@@ -567,6 +580,7 @@ TEMPLATE_TEST_CASE("dictionary types", "[dictionary]", cf::MixedVal, cf::Int, cf
             }
         }
     }
+
     SECTION("snapshot") {
         SECTION("keys") {
             auto new_keys = keys_as_results.snapshot();

--- a/test/object-store/primitive_list.cpp
+++ b/test/object-store/primitive_list.cpp
@@ -60,41 +60,6 @@ struct StringifyingContext {
     }
 };
 
-struct less {
-    template <class T, class U>
-    auto operator()(T&& a, U&& b) const noexcept
-    {
-        return a < b;
-    }
-};
-struct greater {
-    template <class T, class U>
-    auto operator()(T&& a, U&& b) const noexcept
-    {
-        return a > b;
-    }
-};
-
-template <>
-auto less::operator()<Timestamp&, Timestamp&>(Timestamp& a, Timestamp& b) const noexcept
-{
-    if (b.is_null())
-        return false;
-    if (a.is_null())
-        return true;
-    return a < b;
-}
-
-template <>
-auto greater::operator()<Timestamp&, Timestamp&>(Timestamp& a, Timestamp& b) const noexcept
-{
-    if (a.is_null())
-        return false;
-    if (b.is_null())
-        return true;
-    return a > b;
-}
-
 namespace Catch {
 template <>
 struct StringMaker<List> {
@@ -476,14 +441,14 @@ TEMPLATE_TEST_CASE("primitive list", "[primitives]", cf::MixedVal, cf::Int, cf::
     }
     SECTION("sorted index_of()") {
         auto sorted = list.sort({{"self", true}});
-        std::sort(begin(values), end(values), less());
+        std::sort(begin(values), end(values), cf::less());
         for (size_t i = 0; i < values.size(); ++i) {
             CAPTURE(i);
             REQUIRE(sorted.index_of<T>(values[i]) == i);
         }
 
         sorted = list.sort({{"self", false}});
-        std::sort(begin(values), end(values), greater());
+        std::sort(begin(values), end(values), cf::greater());
         for (size_t i = 0; i < values.size(); ++i) {
             CAPTURE(i);
             REQUIRE(sorted.index_of<T>(values[i]) == i);
@@ -507,13 +472,13 @@ TEMPLATE_TEST_CASE("primitive list", "[primitives]", cf::MixedVal, cf::Int, cf::
 
         auto sorted = list.sort(SortDescriptor({{col}}, {true}));
         auto sorted2 = list.sort({{"self", true}});
-        std::sort(begin(values), end(values), less());
+        std::sort(begin(values), end(values), cf::less());
         REQUIRE(sorted == values);
         REQUIRE(sorted2 == values);
 
         sorted = list.sort(SortDescriptor({{col}}, {false}));
         sorted2 = list.sort({{"self", false}});
-        std::sort(begin(values), end(values), greater());
+        std::sort(begin(values), end(values), cf::greater());
         REQUIRE(sorted == values);
         REQUIRE(sorted2 == values);
 

--- a/test/object-store/primitive_list.cpp
+++ b/test/object-store/primitive_list.cpp
@@ -18,6 +18,7 @@
 
 #include <catch2/catch.hpp>
 
+#include "collection_fixtures.hpp"
 #include "util/event_loop.hpp"
 #include "util/index_helpers.hpp"
 #include "util/test_file.hpp"
@@ -42,414 +43,7 @@
 
 using namespace realm;
 using namespace realm::util;
-
-
-template <PropertyType prop_type, typename T>
-struct Base {
-    using Type = T;
-    using Wrapped = T;
-    using Boxed = T;
-    using AvgType = double;
-    enum { is_optional = false };
-
-    static PropertyType property_type()
-    {
-        return prop_type;
-    }
-    static util::Any to_any(T value)
-    {
-        return value;
-    }
-
-    template <typename Fn>
-    static auto unwrap(T value, Fn&& fn)
-    {
-        return fn(value);
-    }
-
-    static T min()
-    {
-        abort();
-    }
-    static T max()
-    {
-        abort();
-    }
-    static T sum()
-    {
-        abort();
-    }
-    static AvgType average()
-    {
-        abort();
-    }
-    static T empty_sum_value()
-    {
-        return T{};
-    }
-    static bool can_sum()
-    {
-        return std::is_arithmetic<T>::value;
-    }
-    static bool can_average()
-    {
-        return std::is_arithmetic<T>::value;
-    }
-    static bool can_minmax()
-    {
-        return std::is_arithmetic<T>::value;
-    }
-};
-
-struct Int : Base<PropertyType::Int, int64_t> {
-    static std::vector<int64_t> values()
-    {
-        return {3, 1, 2};
-    }
-    static int64_t min()
-    {
-        return 1;
-    }
-    static int64_t max()
-    {
-        return 3;
-    }
-    static int64_t sum()
-    {
-        return 6;
-    }
-    static double average()
-    {
-        return 2.0;
-    }
-};
-
-struct Bool : Base<PropertyType::Bool, bool> {
-    static std::vector<bool> values()
-    {
-        return {true, false};
-    }
-    static bool can_sum()
-    {
-        return false;
-    }
-    static bool can_average()
-    {
-        return false;
-    }
-    static bool can_minmax()
-    {
-        return false;
-    }
-};
-
-struct Float : Base<PropertyType::Float, float> {
-    static std::vector<float> values()
-    {
-        return {3.3f, 1.1f, 2.2f};
-    }
-    static float min()
-    {
-        return 1.1f;
-    }
-    static float max()
-    {
-        return 3.3f;
-    }
-    static auto sum()
-    {
-        return Approx(6.6f);
-    }
-    static auto average()
-    {
-        return Approx(2.2f);
-    }
-};
-
-struct Double : Base<PropertyType::Double, double> {
-    static std::vector<double> values()
-    {
-        return {3.3, 1.1, 2.2};
-    }
-    static double min()
-    {
-        return 1.1;
-    }
-    static double max()
-    {
-        return 3.3;
-    }
-    static auto sum()
-    {
-        return Approx(6.6);
-    }
-    static auto average()
-    {
-        return Approx(2.2);
-    }
-};
-
-struct String : Base<PropertyType::String, StringData> {
-    using Boxed = std::string;
-    static std::vector<StringData> values()
-    {
-        return {"c", "a", "b"};
-    }
-    static util::Any to_any(StringData value)
-    {
-        return value ? std::string(value) : util::Any();
-    }
-};
-
-struct Binary : Base<PropertyType::Data, BinaryData> {
-    using Boxed = std::string;
-    static util::Any to_any(BinaryData value)
-    {
-        return value ? std::string(value) : util::Any();
-    }
-    static std::vector<BinaryData> values()
-    {
-        return {BinaryData("c", 1), BinaryData("a", 1), BinaryData("b", 1)};
-    }
-};
-
-struct Date : Base<PropertyType::Date, Timestamp> {
-    static std::vector<Timestamp> values()
-    {
-        return {Timestamp(3, 3), Timestamp(1, 1), Timestamp(2, 2)};
-    }
-    static bool can_minmax()
-    {
-        return true;
-    }
-    static Timestamp min()
-    {
-        return Timestamp(1, 1);
-    }
-    static Timestamp max()
-    {
-        return Timestamp(3, 3);
-    }
-};
-
-struct MixedVal : Base<PropertyType::Mixed, realm::Mixed> {
-    using AvgType = Decimal128;
-    enum { is_optional = true };
-    static std::vector<realm::Mixed> values()
-    {
-        return {Mixed{realm::UUID()}, Mixed{int64_t(1)},      Mixed{},
-                Mixed{"hello world"}, Mixed{Timestamp(1, 1)}, Mixed{Decimal128("300")},
-                Mixed{double(2.2)},   Mixed{float(3.3)}};
-    }
-    static PropertyType property_type()
-    {
-        return PropertyType::Mixed | PropertyType::Nullable;
-    }
-    static Mixed min()
-    {
-        return Mixed{int64_t(1)};
-    }
-    static Mixed max()
-    {
-        return Mixed{UUID()};
-    }
-    static Decimal128 sum()
-    {
-        return Decimal128("300") + Decimal128(int64_t(1)) + Decimal128(double(2.2)) + Decimal128(float(3.3));
-    }
-    static Decimal128 average()
-    {
-        return (sum() / Decimal128(4));
-    }
-    static Mixed empty_sum_value()
-    {
-        return Mixed{0};
-    }
-    static bool can_sum()
-    {
-        return true;
-    }
-    static bool can_average()
-    {
-        return true;
-    }
-    static bool can_minmax()
-    {
-        return true;
-    }
-};
-
-struct OID : Base<PropertyType::ObjectId, ObjectId> {
-    static std::vector<ObjectId> values()
-    {
-        return {ObjectId("bbbbbbbbbbbbbbbbbbbbbbbb"), ObjectId("aaaaaaaaaaaaaaaaaaaaaaaa")};
-    }
-};
-
-struct UUID : Base<PropertyType::UUID, realm::UUID> {
-    static std::vector<realm::UUID> values()
-    {
-        return {realm::UUID("3b241101-e2bb-4255-8caf-4136c566a962"),
-                realm::UUID("3b241101-a2b3-4255-8caf-4136c566a999")};
-    }
-};
-
-struct Decimal : Base<PropertyType::Decimal, Decimal128> {
-    using AvgType = Decimal128;
-    static std::vector<Decimal128> values()
-    {
-        return {Decimal128("876.54e32"), Decimal128("123.45e6")};
-    }
-    static Decimal128 min()
-    {
-        return Decimal128("123.45e6");
-    }
-    static Decimal128 max()
-    {
-        return Decimal128("876.54e32");
-    }
-    static Decimal128 sum()
-    {
-        return Decimal128("123.45e6") + Decimal128("876.54e32");
-    }
-    static Decimal128 average()
-    {
-        return ((Decimal128("123.45e6") + Decimal128("876.54e32")) / Decimal128(2));
-    }
-    static bool can_sum()
-    {
-        return true;
-    }
-    static bool can_average()
-    {
-        return true;
-    }
-    static bool can_minmax()
-    {
-        return true;
-    }
-};
-
-template <typename BaseT>
-struct BoxedOptional : BaseT {
-    using Type = util::Optional<typename BaseT::Type>;
-    using Boxed = Type;
-    enum { is_optional = true };
-    static PropertyType property_type()
-    {
-        return BaseT::property_type() | PropertyType::Nullable;
-    }
-    static std::vector<Type> values()
-    {
-        std::vector<Type> ret;
-        for (auto v : BaseT::values())
-            ret.push_back(Type(v));
-        ret.push_back(util::none);
-        return ret;
-    }
-    static auto unwrap(Type value)
-    {
-        return *value;
-    }
-    static util::Any to_any(Type value)
-    {
-        return value ? util::Any(*value) : util::Any();
-    }
-
-    template <typename Fn>
-    static auto unwrap(Type value, Fn&& fn)
-    {
-        return value ? fn(*value) : fn(null());
-    }
-};
-
-template <typename BaseT>
-struct UnboxedOptional : BaseT {
-    enum { is_optional = true };
-    static PropertyType property_type()
-    {
-        return BaseT::property_type() | PropertyType::Nullable;
-    }
-    static auto values() -> decltype(BaseT::values())
-    {
-        auto ret = BaseT::values();
-        if constexpr (std::is_same_v<BaseT, ::Decimal>) {
-            // The default Decimal128 ctr is 0, but we want a null value
-            ret.push_back(Decimal128(realm::null()));
-        }
-        else {
-            ret.push_back(typename BaseT::Type());
-        }
-        return ret;
-    }
-};
-
-template <typename T>
-T get(Mixed)
-{
-    abort();
-}
-
-template <>
-Mixed get(Mixed m)
-{
-    return m;
-}
-
-template <>
-int64_t get(Mixed m)
-{
-    return m.get_int();
-}
-template <>
-float get(Mixed m)
-{
-    return m.get_type() == type_Float ? m.get_float() : static_cast<float>(m.get_double());
-}
-template <>
-double get(Mixed m)
-{
-    return m.get_double();
-}
-template <>
-Timestamp get(Mixed m)
-{
-    return m.get_timestamp();
-}
-template <>
-Decimal128 get(Mixed m)
-{
-    return m.get<Decimal128>();
-}
-
-namespace realm {
-template <typename T>
-bool operator==(List const& list, std::vector<T> const& values)
-{
-    if (list.size() != values.size())
-        return false;
-    for (size_t i = 0; i < values.size(); ++i) {
-        if (list.get<T>(i) != values[i])
-            return false;
-    }
-    return true;
-}
-
-template <typename T>
-bool operator==(Results const& results, std::vector<T> const& values)
-{
-    // FIXME: this is only necessary because Results::size() and ::get() are not const
-    Results copy{results};
-    if (copy.size() != values.size())
-        return false;
-    for (size_t i = 0; i < values.size(); ++i) {
-        if (copy.get<T>(i) != values[i])
-            return false;
-    }
-    return true;
-}
-
-} // namespace realm
+namespace cf = realm::collection_fixtures;
 
 struct StringifyingContext {
     template <typename T>
@@ -465,6 +59,41 @@ struct StringifyingContext {
         return util::to_string(obj.get_key().value);
     }
 };
+
+struct less {
+    template <class T, class U>
+    auto operator()(T&& a, U&& b) const noexcept
+    {
+        return a < b;
+    }
+};
+struct greater {
+    template <class T, class U>
+    auto operator()(T&& a, U&& b) const noexcept
+    {
+        return a > b;
+    }
+};
+
+template <>
+auto less::operator()<Timestamp&, Timestamp&>(Timestamp& a, Timestamp& b) const noexcept
+{
+    if (b.is_null())
+        return false;
+    if (a.is_null())
+        return true;
+    return a < b;
+}
+
+template <>
+auto greater::operator()<Timestamp&, Timestamp&>(Timestamp& a, Timestamp& b) const noexcept
+{
+    if (a.is_null())
+        return false;
+    if (b.is_null())
+        return true;
+    return a > b;
+}
 
 namespace Catch {
 template <>
@@ -517,46 +146,49 @@ struct StringMaker<util::None> {
 };
 } // namespace Catch
 
-struct less {
-    template <class T, class U>
-    auto operator()(T&& a, U&& b) const noexcept
-    {
-        return a < b;
-    }
-};
-struct greater {
-    template <class T, class U>
-    auto operator()(T&& a, U&& b) const noexcept
-    {
-        return a > b;
-    }
-};
-
-template <>
-auto less::operator()<Timestamp&, Timestamp&>(Timestamp& a, Timestamp& b) const noexcept
+template <typename T>
+T get(Mixed)
 {
-    if (b.is_null())
-        return false;
-    if (a.is_null())
-        return true;
-    return a < b;
+    abort();
 }
 
 template <>
-auto greater::operator()<Timestamp&, Timestamp&>(Timestamp& a, Timestamp& b) const noexcept
+Mixed get(Mixed m)
 {
-    if (a.is_null())
-        return false;
-    if (b.is_null())
-        return true;
-    return a > b;
+    return m;
 }
 
-TEMPLATE_TEST_CASE("primitive list", "[primitives]", MixedVal, ::Int, ::Bool, ::Float, ::Double, ::String, ::Binary,
-                   ::Date, ::OID, ::Decimal, ::UUID, BoxedOptional<::Int>, BoxedOptional<::Bool>,
-                   BoxedOptional<::Float>, BoxedOptional<::Double>, BoxedOptional<::OID>, BoxedOptional<::UUID>,
-                   UnboxedOptional<::String>, UnboxedOptional<::Binary>, UnboxedOptional<::Date>,
-                   UnboxedOptional<::Decimal>)
+template <>
+int64_t get(Mixed m)
+{
+    return m.get_int();
+}
+template <>
+float get(Mixed m)
+{
+    return m.get_type() == type_Float ? m.get_float() : static_cast<float>(m.get_double());
+}
+template <>
+double get(Mixed m)
+{
+    return m.get_double();
+}
+template <>
+Timestamp get(Mixed m)
+{
+    return m.get_timestamp();
+}
+template <>
+Decimal128 get(Mixed m)
+{
+    return m.get<Decimal128>();
+}
+
+TEMPLATE_TEST_CASE("primitive list", "[primitives]", cf::MixedVal, cf::Int, cf::Bool, cf::Float, cf::Double,
+                   cf::String, cf::Binary, cf::Date, cf::OID, cf::Decimal, cf::UUID, cf::BoxedOptional<cf::Int>,
+                   cf::BoxedOptional<cf::Bool>, cf::BoxedOptional<cf::Float>, cf::BoxedOptional<cf::Double>,
+                   cf::BoxedOptional<cf::OID>, cf::BoxedOptional<cf::UUID>, cf::UnboxedOptional<cf::String>,
+                   cf::UnboxedOptional<cf::Binary>, cf::UnboxedOptional<cf::Date>, cf::UnboxedOptional<cf::Decimal>)
 {
     auto values = TestType::values();
     using T = typename TestType::Type;


### PR DESCRIPTION
I moved the list of primitives templated test types into a shared test file so they can be reused. It looks like this effort was started already previously, but not completed because there was already a stale copy of the code there. Then I transformed and improved the Dictionary tests to use the types. This turned up a few bugs.

## ☑️ ToDos
* [x] 📝 Changelog update
* [x] 🚦 Tests (or not relevant)
