### PR TITLE
Fix notifications on dict/set of links

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@
 ### Fixed
 * <How to hit and notice issue? what was the impact?> ([#????](https://github.com/realm/realm-core/issues/????), since v?.?.?)
 * Fixed queries of min/max/sum/avg on list of primitive mixed. ([#4472](https://github.com/realm/realm-core/pull/4472), never before working)
+* Fixed notifications tracking modifications across links in a dictionary or set containing Mixed(TypedLink) values. ([#4505](https://github.com/realm/realm-core/pull/4505)).
+* Fixed the notifiers causing an exception `KeyNotFound("No such object");` if a dictionary or set of links of a single type also had a link column in the linked table. ([#4465](https://github.com/realm/realm-core/issues/4465)).
 
 ### Breaking changes
 * None.

--- a/src/realm/group.cpp
+++ b/src/realm/group.cpp
@@ -1680,6 +1680,10 @@ public:
     {
         return true; // No-op
     }
+    bool typed_link_initialize(ColKey, TableKey)
+    {
+        return true; // No-op
+    }
 
 private:
     bool& m_schema_changed;

--- a/src/realm/group.cpp
+++ b/src/realm/group.cpp
@@ -1680,7 +1680,7 @@ public:
     {
         return true; // No-op
     }
-    bool typed_link_initialize(ColKey, TableKey)
+    bool typed_link_change(ColKey, TableKey)
     {
         return true; // No-op
     }

--- a/src/realm/keys.hpp
+++ b/src/realm/keys.hpp
@@ -321,6 +321,9 @@ private:
     TableKey m_table_key;
 };
 
+using TableKeyType = decltype(TableKey::value);
+using ObjKeyType = decltype(ObjKey::value);
+
 inline std::ostream& operator<<(std::ostream& os, ObjLink link)
 {
     os << '{' << link.get_table_key() << ',' << link.get_obj_key() << '}';
@@ -347,6 +350,14 @@ struct hash<realm::ObjKey> {
     size_t operator()(realm::ObjKey key) const
     {
         return std::hash<uint64_t>{}(key.value);
+    }
+};
+
+template <>
+struct hash<realm::TableKey> {
+    size_t operator()(realm::TableKey key) const
+    {
+        return std::hash<uint32_t>{}(key.value);
     }
 };
 

--- a/src/realm/object-store/impl/collection_notifier.hpp
+++ b/src/realm/object-store/impl/collection_notifier.hpp
@@ -59,7 +59,11 @@ struct TransactionChangeInfo {
 
 class DeepChangeChecker {
 public:
-    typedef std::unordered_map<TableKey, std::vector<ColKey>> RelatedTables;
+    struct RelatedTable {
+        TableKey table_key;
+        std::vector<ColKey> links;
+    };
+    typedef std::vector<RelatedTable> RelatedTables;
     DeepChangeChecker(TransactionChangeInfo const& info, Table const& root_table,
                       RelatedTables const& related_tables);
 

--- a/src/realm/object-store/impl/collection_notifier.hpp
+++ b/src/realm/object-store/impl/collection_notifier.hpp
@@ -37,6 +37,7 @@
 #include <unordered_set>
 
 namespace realm {
+class CollectionBase;
 class Realm;
 class Transaction;
 
@@ -90,6 +91,7 @@ private:
 
     bool check_row(Table const& table, ObjKeyType obj_key, size_t depth = 0);
     bool check_outgoing_links(TableKey table_key, Table const& table, ObjKey obj_key, size_t depth = 0);
+    bool do_check_for_collection_modifications(std::unique_ptr<CollectionBase> coll, size_t depth);
 };
 
 // A base class for a notifier that keeps a collection up to date and/or

--- a/src/realm/object-store/impl/collection_notifier.hpp
+++ b/src/realm/object-store/impl/collection_notifier.hpp
@@ -50,10 +50,6 @@ struct ListChangeInfo {
     CollectionChangeBuilder* changes;
 };
 
-// FIXME: this should be in core
-using TableKeyType = decltype(TableKey::value);
-using ObjKeyType = decltype(ObjKey::value);
-
 struct TransactionChangeInfo {
     std::vector<ListChangeInfo> lists;
     std::unordered_map<TableKeyType, ObjectChangeSet> tables;
@@ -61,16 +57,9 @@ struct TransactionChangeInfo {
     bool schema_changed;
 };
 
-struct TableKeyHasher {
-    std::size_t operator()(const TableKey& key) const
-    {
-        return std::hash<TableKeyType>{}(key.value);
-    }
-};
-
 class DeepChangeChecker {
 public:
-    typedef std::unordered_map<TableKey, std::vector<ColKey>, TableKeyHasher> RelatedTables;
+    typedef std::unordered_map<TableKey, std::vector<ColKey>> RelatedTables;
     DeepChangeChecker(TransactionChangeInfo const& info, Table const& root_table,
                       RelatedTables const& related_tables);
 

--- a/src/realm/object-store/impl/collection_notifier.hpp
+++ b/src/realm/object-store/impl/collection_notifier.hpp
@@ -63,19 +63,15 @@ struct TransactionChangeInfo {
 
 class DeepChangeChecker {
 public:
-    struct OutgoingLink {
-        int64_t col_key;
-        bool is_list;
-    };
     struct RelatedTable {
         TableKey table_key;
-        std::vector<OutgoingLink> links;
+        std::vector<ColKey> outgoing_links;
     };
 
     DeepChangeChecker(TransactionChangeInfo const& info, Table const& root_table,
                       std::vector<RelatedTable> const& related_tables);
 
-    bool operator()(int64_t obj_key);
+    bool operator()(ObjKeyType obj_key);
 
     // Recursively add `table` and all tables it links to to `out`, along with
     // information about the links from them
@@ -90,14 +86,14 @@ private:
     std::vector<RelatedTable> const& m_related_tables;
 
     struct Path {
-        int64_t obj_key;
-        int64_t col_key;
+        ObjKey obj_key;
+        ColKey col_key;
         bool depth_exceeded;
     };
     std::array<Path, 4> m_current_path;
 
     bool check_row(Table const& table, ObjKeyType obj_key, size_t depth = 0);
-    bool check_outgoing_links(TableKey table_key, Table const& table, int64_t obj_key, size_t depth = 0);
+    bool check_outgoing_links(TableKey table_key, Table const& table, ObjKey obj_key, size_t depth = 0);
 };
 
 // A base class for a notifier that keeps a collection up to date and/or

--- a/src/realm/object-store/impl/transact_log_handler.cpp
+++ b/src/realm/object-store/impl/transact_log_handler.cpp
@@ -311,7 +311,7 @@ public:
     {
         return true;
     }
-    bool typed_link_initialize(ColKey, TableKey)
+    bool typed_link_change(ColKey, TableKey)
     {
         return true;
     }
@@ -527,7 +527,7 @@ public:
         return true;
     }
 
-    bool typed_link_initialize(ColKey, TableKey)
+    bool typed_link_change(ColKey, TableKey)
     {
         m_info.schema_changed = true;
         return true;

--- a/src/realm/object-store/impl/transact_log_handler.cpp
+++ b/src/realm/object-store/impl/transact_log_handler.cpp
@@ -311,6 +311,10 @@ public:
     {
         return true;
     }
+    bool typed_link_initialize(ColKey, TableKey)
+    {
+        return true;
+    }
 };
 
 
@@ -518,6 +522,12 @@ public:
     }
 
     bool insert_group_level_table(TableKey)
+    {
+        m_info.schema_changed = true;
+        return true;
+    }
+
+    bool typed_link_initialize(ColKey, TableKey)
     {
         m_info.schema_changed = true;
         return true;

--- a/src/realm/table.cpp
+++ b/src/realm/table.cpp
@@ -3555,13 +3555,13 @@ Table::BacklinkOrigin Table::find_backlink_origin(ColKey backlink_col) const noe
     return {};
 }
 
-std::vector<Table::BacklinkOrigin> Table::get_incoming_link_columns() const noexcept
+std::vector<std::pair<TableKey, ColKey>> Table::get_incoming_link_columns() const noexcept
 {
-    std::vector<BacklinkOrigin> origins;
+    std::vector<std::pair<TableKey, ColKey>> origins;
     auto f = [&](ColKey backlink_col_key) {
-        auto origin_table = get_opposite_table(backlink_col_key);
+        auto origin_table_key = get_opposite_table_key(backlink_col_key);
         auto origin_link_col = get_opposite_column(backlink_col_key);
-        origins.push_back({{origin_table, origin_link_col}});
+        origins.emplace_back(origin_table_key, origin_link_col);
         return false;
     };
     this->for_each_backlink_column(f);

--- a/src/realm/table.cpp
+++ b/src/realm/table.cpp
@@ -4015,8 +4015,8 @@ ColKey Table::find_or_add_backlink_column(ColKey origin_col_key, TableKey origin
         set_opposite_column(backlink_col_key, origin_table, origin_col_key);
 
         if (Replication* repl = get_repl())
-            repl->typed_link_initialize(get_parent_group()->get_table(origin_table).unchecked_ptr(), origin_col_key,
-                                        m_key); // Throws
+            repl->typed_link_change(get_parent_group()->get_table(origin_table).unchecked_ptr(), origin_col_key,
+                                    m_key); // Throws
     }
 
     return backlink_col_key;

--- a/src/realm/table.cpp
+++ b/src/realm/table.cpp
@@ -4013,6 +4013,10 @@ ColKey Table::find_or_add_backlink_column(ColKey origin_col_key, TableKey origin
     if (!backlink_col_key) {
         backlink_col_key = do_insert_root_column(ColKey{}, col_type_BackLink, "");
         set_opposite_column(backlink_col_key, origin_table, origin_col_key);
+
+        if (Replication* repl = get_repl())
+            repl->typed_link_initialize(get_parent_group()->get_table(origin_table).unchecked_ptr(), origin_col_key,
+                                        m_key); // Throws
     }
 
     return backlink_col_key;

--- a/src/realm/table.cpp
+++ b/src/realm/table.cpp
@@ -3555,6 +3555,19 @@ Table::BacklinkOrigin Table::find_backlink_origin(ColKey backlink_col) const noe
     return {};
 }
 
+std::vector<Table::BacklinkOrigin> Table::get_incoming_link_columns() const noexcept
+{
+    std::vector<BacklinkOrigin> origins;
+    auto f = [&](ColKey backlink_col_key) {
+        auto origin_table = get_opposite_table(backlink_col_key);
+        auto origin_link_col = get_opposite_column(backlink_col_key);
+        origins.push_back({{origin_table, origin_link_col}});
+        return false;
+    };
+    this->for_each_backlink_column(f);
+    return origins;
+}
+
 ColKey Table::get_primary_key_column() const
 {
     return m_primary_key_col;

--- a/src/realm/table.hpp
+++ b/src/realm/table.hpp
@@ -130,7 +130,7 @@ public:
     typedef util::Optional<std::pair<ConstTableRef, ColKey>> BacklinkOrigin;
     BacklinkOrigin find_backlink_origin(StringData origin_table_name, StringData origin_col_name) const noexcept;
     BacklinkOrigin find_backlink_origin(ColKey backlink_col) const noexcept;
-    std::vector<BacklinkOrigin> get_incoming_link_columns() const noexcept;
+    std::vector<std::pair<TableKey, ColKey>> get_incoming_link_columns() const noexcept;
     //@}
 
     // Primary key columns

--- a/src/realm/table.hpp
+++ b/src/realm/table.hpp
@@ -130,6 +130,7 @@ public:
     typedef util::Optional<std::pair<ConstTableRef, ColKey>> BacklinkOrigin;
     BacklinkOrigin find_backlink_origin(StringData origin_table_name, StringData origin_col_name) const noexcept;
     BacklinkOrigin find_backlink_origin(ColKey backlink_col) const noexcept;
+    std::vector<BacklinkOrigin> get_incoming_link_columns() const noexcept;
     //@}
 
     // Primary key columns

--- a/test/object-store/dictionary.cpp
+++ b/test/object-store/dictionary.cpp
@@ -55,27 +55,38 @@ struct StringMaker<object_store::Dictionary> {
 };
 } // namespace Catch
 
-TEST_CASE("dictionary") {
+TEST_CASE("dictionary", "[dictionary]") {
     InMemoryTestFile config;
     config.cache = false;
     config.automatic_change_notifications = false;
-    config.schema =
-        Schema{{"object",
-                {{"value", PropertyType::Dictionary | PropertyType::String},
-                 {"links", PropertyType::Dictionary | PropertyType::Object | PropertyType::Nullable, "target"}}},
-               {"target", {{"value", PropertyType::Int}}}};
+    config.schema = Schema{
+        {"object",
+         {{"value", PropertyType::Dictionary | PropertyType::String},
+          {"links", PropertyType::Dictionary | PropertyType::Object | PropertyType::Nullable, "target"}}},
+        {"target",
+         {{"value", PropertyType::Int}, {"self_link", PropertyType::Object | PropertyType::Nullable, "target"}}},
+        {"source", {{"link", PropertyType::Object | PropertyType::Nullable, "object"}}}};
 
     auto r = Realm::get_shared_realm(config);
     auto r2 = Realm::get_shared_realm(config);
 
     auto table = r->read_group().get_table("class_object");
     auto target = r->read_group().get_table("class_target");
+    auto source = r->read_group().get_table("class_source");
     auto table2 = r2->read_group().get_table("class_object");
     r->begin_transaction();
     Obj obj = table->create_object();
+    Obj obj1 = table->create_object(); // empty dictionary
     Obj another = target->create_object();
+    Obj source_obj0 = source->create_object();
+    Obj source_obj1 = source->create_object();
     ColKey col = table->get_column_key("value");
     ColKey col_links = table->get_column_key("links");
+    ColKey col_source_link = source->get_column_key("link");
+    ColKey col_target_value = target->get_column_key("value");
+
+    source_obj0.set(col_source_link, obj.get_key());
+    source_obj1.set(col_source_link, obj1.get_key());
 
     object_store::Dictionary dict(r, obj, col);
     object_store::Dictionary links(r, obj, col_links);
@@ -358,6 +369,64 @@ TEST_CASE("dictionary") {
             advance_and_notify(*r);
             REQUIRE(local_change.modifications.count() == 1);
         }
+
+        SECTION("source links") {
+            Results all_sources(r, source->where());
+            REQUIRE(all_sources.size() == 2);
+            CollectionChangeSet local_changes;
+            auto x =
+                all_sources.add_notification_callback([&local_changes](CollectionChangeSet c, std::exception_ptr) {
+                    local_changes = c;
+                });
+            advance_and_notify(*r);
+
+            SECTION("direct insertion") {
+                r->begin_transaction();
+                source->create_object();
+                r->commit_transaction();
+                advance_and_notify(*r);
+                REQUIRE(local_changes.insertions.count() == 1);
+                REQUIRE(local_changes.modifications.count() == 0);
+                REQUIRE(local_changes.deletions.count() == 0);
+            }
+            SECTION("indirect insertion to dictionary link") {
+                r->begin_transaction();
+                links.insert("new key", ObjKey());
+                r->commit_transaction();
+                advance_and_notify(*r);
+                REQUIRE(local_changes.insertions.count() == 0);
+                REQUIRE(local_changes.modifications.count() == 1);
+                REQUIRE(local_changes.deletions.count() == 0);
+            }
+            SECTION("no change for non linked insertion") {
+                r->begin_transaction();
+                table->create_object();
+                r->commit_transaction();
+                advance_and_notify(*r);
+                REQUIRE(local_changes.insertions.count() == 0);
+                REQUIRE(local_changes.modifications.count() == 0);
+                REQUIRE(local_changes.deletions.count() == 0);
+            }
+            SECTION("modification marked for change to linked object through dictionary") {
+                r->begin_transaction();
+                links.insert("l", another.get_key());
+                links.insert("m", ObjKey());
+                r->commit_transaction();
+                advance_and_notify(*r);
+                REQUIRE(local_changes.insertions.count() == 0);
+                REQUIRE(local_changes.modifications.count() == 1);
+                REQUIRE(local_changes.deletions.count() == 0);
+                local_changes = {};
+
+                r->begin_transaction();
+                another.set_any(col_target_value, {42});
+                r->commit_transaction();
+                advance_and_notify(*r);
+                REQUIRE(local_changes.insertions.count() == 0);
+                REQUIRE(local_changes.modifications.count() == 1);
+                REQUIRE(local_changes.deletions.count() == 0);
+            }
+        }
     }
 }
 
@@ -407,5 +476,97 @@ TEST_CASE("embedded dictionary") {
         }
 
         r->cancel_transaction();
+    }
+}
+
+TEST_CASE("dictionary with mixed links", "[dictionary]") {
+    InMemoryTestFile config;
+    config.cache = false;
+    config.automatic_change_notifications = false;
+    config.schema = Schema{
+        {"object", {{"value", PropertyType::Dictionary | PropertyType::Mixed | PropertyType::Nullable}}},
+        {"target1",
+         {{"value1", PropertyType::Int}, {"self_link1", PropertyType::Object | PropertyType::Nullable, "target1"}}},
+        {"target2",
+         {{"value2", PropertyType::Int}, {"self_link2", PropertyType::Object | PropertyType::Nullable, "target2"}}}};
+
+    auto r = Realm::get_shared_realm(config);
+
+    auto table = r->read_group().get_table("class_object");
+    auto target1 = r->read_group().get_table("class_target1");
+    auto target2 = r->read_group().get_table("class_target2");
+    ColKey col_value1 = target1->get_column_key("value1");
+    ColKey col_value2 = target2->get_column_key("value2");
+    r->begin_transaction();
+    Obj obj = table->create_object();
+    Obj obj1 = table->create_object(); // empty dictionary
+    Obj target1_obj = target1->create_object().set(col_value1, 100);
+    Obj target2_obj = target2->create_object().set(col_value2, 200);
+    ColKey col = table->get_column_key("value");
+
+    object_store::Dictionary dict(r, obj, col);
+    auto keys_as_results = dict.get_keys();
+    auto values_as_results = dict.get_values();
+    CppContext ctx(r);
+
+    SECTION("get_realm()") {
+        REQUIRE(dict.get_realm() == r);
+        REQUIRE(values_as_results.get_realm() == r);
+    }
+
+    std::vector<std::string> keys = {"a", "b", "c"};
+    std::vector<std::string> values = {"apple", "banana", "clementine"};
+
+    dict.insert("key_a", Mixed{ObjLink(target1->get_key(), target1_obj.get_key())});
+    dict.insert("key_b", Mixed{ObjLink(target2->get_key(), target2_obj.get_key())});
+    dict.insert("key_c", Mixed{});
+    dict.insert("key_d", Mixed{int64_t{42}});
+    r->commit_transaction();
+
+    Results all_objects(r, table->where());
+    REQUIRE(all_objects.size() == 2);
+    CollectionChangeSet local_changes;
+    auto x = all_objects.add_notification_callback([&local_changes](CollectionChangeSet c, std::exception_ptr) {
+        local_changes = c;
+    });
+    advance_and_notify(*r);
+
+    SECTION("insertion") {
+        r->begin_transaction();
+        table->create_object();
+        r->commit_transaction();
+        advance_and_notify(*r);
+        REQUIRE(local_changes.insertions.count() == 1);
+        REQUIRE(local_changes.modifications.count() == 0);
+        REQUIRE(local_changes.deletions.count() == 0);
+    }
+    SECTION("insert to dictionary is a modification") {
+        r->begin_transaction();
+        dict.insert("key_e", Mixed{"hello"});
+        r->commit_transaction();
+        advance_and_notify(*r);
+        REQUIRE(local_changes.insertions.count() == 0);
+        REQUIRE(local_changes.modifications.count() == 1);
+        REQUIRE(local_changes.deletions.count() == 0);
+    }
+    SECTION("modify an existing key is a modification") {
+        r->begin_transaction();
+        dict.insert("key_a", Mixed{});
+        r->commit_transaction();
+        advance_and_notify(*r);
+        REQUIRE(local_changes.insertions.count() == 0);
+        REQUIRE(local_changes.modifications.count() == 1);
+        REQUIRE(local_changes.deletions.count() == 0);
+    }
+    // FIXME: no change is detected because the m_related_tables of the notifier
+    // does not account for Mixed{TypedLink} which can point to any table.
+    SECTION("modify a linked object is a modification") {
+        r->begin_transaction();
+        target1_obj.set(col_value1, 1000);
+        r->commit_transaction();
+        advance_and_notify(*r);
+        REQUIRE(local_changes.insertions.count() == 0);
+        REQUIRE(local_changes.modifications.count() == 1);
+        REQUIRE(local_changes.deletions.count() == 0);
     }
 }

--- a/test/object-store/set.cpp
+++ b/test/object-store/set.cpp
@@ -223,14 +223,15 @@ TEST_CASE("set", "[set]") {
                 CHECK(!link_set.insert(target1).second);
                 CHECK(link_set.insert(target2).second);
                 CHECK(link_set.insert(target3).second);
+                CHECK(link_set.insert(ObjKey{}).second);
             });
 
             write([&] {
-                CHECK(link_set.size() == 3);
+                CHECK(link_set.size() == 4);
                 REQUIRE(link_set.remove(target2).second);
             });
-            CHECK(link_set.size() == 2);
-            REQUIRE_INDICES(change.deletions, 1);
+            CHECK(link_set.size() == 3);
+            REQUIRE_INDICES(change.deletions, 2);
         }
 
         SECTION("modifying a different set doesn't send a change notification") {

--- a/test/object-store/set.cpp
+++ b/test/object-store/set.cpp
@@ -19,7 +19,7 @@
 
 using namespace realm;
 
-TEST_CASE("set") {
+TEST_CASE("set", "[set]") {
     InMemoryTestFile config;
     config.automatic_change_notifications = false;
     auto r = Realm::get_shared_realm(config);
@@ -543,5 +543,93 @@ TEST_CASE("set") {
             });
             CHECK(set2.size() == 3);
         }
+    }
+}
+
+
+TEST_CASE("set with mixed links", "[set]") {
+    InMemoryTestFile config;
+    config.cache = false;
+    config.automatic_change_notifications = false;
+    config.schema = Schema{
+        {"object", {{"value", PropertyType::Set | PropertyType::Mixed | PropertyType::Nullable}}},
+        {"target1",
+         {{"value1", PropertyType::Int}, {"link1", PropertyType::Object | PropertyType::Nullable, "target1"}}},
+        {"target2",
+         {{"value2", PropertyType::Int}, {"link2", PropertyType::Object | PropertyType::Nullable, "target2"}}}};
+
+    auto r = Realm::get_shared_realm(config);
+
+    auto table = r->read_group().get_table("class_object");
+    auto target1 = r->read_group().get_table("class_target1");
+    auto target2 = r->read_group().get_table("class_target2");
+    ColKey col_value1 = target1->get_column_key("value1");
+    ColKey col_value2 = target2->get_column_key("value2");
+    ColKey col_link1 = target1->get_column_key("link1");
+    r->begin_transaction();
+    Obj obj = table->create_object();
+    Obj obj1 = table->create_object(); // empty set
+    Obj target1_obj = target1->create_object().set(col_value1, 100);
+    Obj target2_obj = target2->create_object().set(col_value2, 200);
+    ColKey col = table->get_column_key("value");
+
+    object_store::Set set(r, obj, col);
+    CppContext ctx(r);
+
+    set.insert(Mixed{ObjLink(target1->get_key(), target1_obj.get_key())});
+    set.insert(Mixed{ObjLink(target2->get_key(), target2_obj.get_key())});
+    set.insert(Mixed{});
+    set.insert(Mixed{int64_t{42}});
+    r->commit_transaction();
+
+    Results all_objects(r, table->where());
+    REQUIRE(all_objects.size() == 2);
+    CollectionChangeSet local_changes;
+    auto x = all_objects.add_notification_callback([&local_changes](CollectionChangeSet c, std::exception_ptr) {
+        local_changes = c;
+    });
+    advance_and_notify(*r);
+
+    SECTION("insertion") {
+        r->begin_transaction();
+        table->create_object();
+        r->commit_transaction();
+        advance_and_notify(*r);
+        REQUIRE(local_changes.insertions.count() == 1);
+        REQUIRE(local_changes.modifications.count() == 0);
+        REQUIRE(local_changes.deletions.count() == 0);
+    }
+    SECTION("insert to set is a modification") {
+        r->begin_transaction();
+        set.insert(Mixed{"hello"});
+        r->commit_transaction();
+        advance_and_notify(*r);
+        REQUIRE(local_changes.insertions.count() == 0);
+        REQUIRE(local_changes.modifications.count() == 1);
+        REQUIRE(local_changes.deletions.count() == 0);
+    }
+    SECTION("modify a linked object is a modification") {
+        r->begin_transaction();
+        target1_obj.set(col_value1, 1000);
+        r->commit_transaction();
+        advance_and_notify(*r);
+        REQUIRE(local_changes.insertions.count() == 0);
+        REQUIRE(local_changes.modifications.count() == 1);
+        REQUIRE(local_changes.deletions.count() == 0);
+    }
+    SECTION("modify a linked object once removed is a modification") {
+        r->begin_transaction();
+        auto target1_obj2 = target1->create_object().set(col_value1, 1000);
+        target1_obj.set(col_link1, target1_obj2.get_key());
+        r->commit_transaction();
+        advance_and_notify(*r);
+        local_changes = {};
+        r->begin_transaction();
+        target1_obj2.set(col_value1, 2000);
+        r->commit_transaction();
+        advance_and_notify(*r);
+        REQUIRE(local_changes.insertions.count() == 0);
+        REQUIRE(local_changes.modifications.count() == 1);
+        REQUIRE(local_changes.deletions.count() == 0);
     }
 }

--- a/test/object-store/transaction_log_parsing.cpp
+++ b/test/object-store/transaction_log_parsing.cpp
@@ -1610,7 +1610,7 @@ TEST_CASE("DeepChangeChecker") {
         return info;
     };
 
-    std::vector<_impl::DeepChangeChecker::RelatedTable> tables;
+    _impl::DeepChangeChecker::RelatedTables tables;
     _impl::DeepChangeChecker::find_related_tables(tables, *table);
 
     auto cols = table->get_column_keys();

--- a/test/test_lang_bind_helper.cpp
+++ b/test/test_lang_bind_helper.cpp
@@ -2000,7 +2000,7 @@ public:
     {
         return false;
     }
-    bool typed_link_initialize(ColKey, TableKey)
+    bool typed_link_change(ColKey, TableKey)
     {
         return true;
     }

--- a/test/test_lang_bind_helper.cpp
+++ b/test/test_lang_bind_helper.cpp
@@ -2000,6 +2000,10 @@ public:
     {
         return false;
     }
+    bool typed_link_initialize(ColKey, TableKey)
+    {
+        return true;
+    }
 };
 
 struct AdvanceReadTransact {


### PR DESCRIPTION
The change checker was handling dictionaries and sets as if they were lists. This could lead to an exception `KeyNotFound("No such object");` as described in https://github.com/realm/realm-core/issues/4465

This also turned up the case that the notifiers did not account for links through `Mixed(TypedLink)` values which can link to any table. This is because we build up the links to check by traversing the forward link columns in each table, but these do not have the information about TypedLinks. The way I found to fix this is to rely on backlink columns being present at the destination table for each kind of TypedLink because those are added dynamically as needed. This means we don't actually add the Mixed column to check in the case that there are no outgoing links because the backlink column won't exist. 

## ☑️ ToDos
* [x] 📝 Changelog update
* [x] 🚦 Tests (or not relevant)
