### PR TITLE
Handle Set and Dictionary in CollectionNotifier

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 ### Fixed
 * <How to hit and notice issue? what was the impact?> ([#????](https://github.com/realm/realm-core/issues/????), since v?.?.?)
 * Fixed queries of min/max/sum/avg on list of primitive mixed. ([#4472](https://github.com/realm/realm-core/pull/4472), never before working)
+* Fixed the notifiers causing an exception `KeyNotFound("No such object");` if a dictionary or set of links of a single type also had a link column in the linked table. ([#4465](https://github.com/realm/realm-core/issues/4465)).
 
 ### Breaking changes
 * None.

--- a/src/realm/keys.hpp
+++ b/src/realm/keys.hpp
@@ -321,6 +321,9 @@ private:
     TableKey m_table_key;
 };
 
+using TableKeyType = decltype(TableKey::value);
+using ObjKeyType = decltype(ObjKey::value);
+
 inline std::ostream& operator<<(std::ostream& os, ObjLink link)
 {
     os << '{' << link.get_table_key() << ',' << link.get_obj_key() << '}';
@@ -347,6 +350,14 @@ struct hash<realm::ObjKey> {
     size_t operator()(realm::ObjKey key) const
     {
         return std::hash<uint64_t>{}(key.value);
+    }
+};
+
+template <>
+struct hash<realm::TableKey> {
+    size_t operator()(realm::TableKey key) const
+    {
+        return std::hash<uint32_t>{}(key.value);
     }
 };
 

--- a/src/realm/object-store/impl/collection_notifier.hpp
+++ b/src/realm/object-store/impl/collection_notifier.hpp
@@ -50,10 +50,6 @@ struct ListChangeInfo {
     CollectionChangeBuilder* changes;
 };
 
-// FIXME: this should be in core
-using TableKeyType = decltype(TableKey::value);
-using ObjKeyType = decltype(ObjKey::value);
-
 struct TransactionChangeInfo {
     std::vector<ListChangeInfo> lists;
     std::unordered_map<TableKeyType, ObjectChangeSet> tables;
@@ -63,23 +59,15 @@ struct TransactionChangeInfo {
 
 class DeepChangeChecker {
 public:
-    struct OutgoingLink {
-        int64_t col_key;
-        bool is_list;
-    };
-    struct RelatedTable {
-        TableKey table_key;
-        std::vector<OutgoingLink> links;
-    };
-
+    typedef std::unordered_map<TableKey, std::vector<ColKey>> RelatedTables;
     DeepChangeChecker(TransactionChangeInfo const& info, Table const& root_table,
-                      std::vector<RelatedTable> const& related_tables);
+                      RelatedTables const& related_tables);
 
-    bool operator()(int64_t obj_key);
+    bool operator()(ObjKeyType obj_key);
 
     // Recursively add `table` and all tables it links to to `out`, along with
     // information about the links from them
-    static void find_related_tables(std::vector<RelatedTable>& out, Table const& table);
+    static void find_related_tables(RelatedTables& out, Table const& table);
 
 private:
     TransactionChangeInfo const& m_info;
@@ -87,17 +75,17 @@ private:
     const TableKey m_root_table_key;
     ObjectChangeSet const* const m_root_object_changes;
     std::unordered_map<TableKeyType, std::unordered_set<ObjKeyType>> m_not_modified;
-    std::vector<RelatedTable> const& m_related_tables;
+    RelatedTables const& m_related_tables;
 
     struct Path {
-        int64_t obj_key;
-        int64_t col_key;
+        ObjKey obj_key;
+        ColKey col_key;
         bool depth_exceeded;
     };
     std::array<Path, 4> m_current_path;
 
     bool check_row(Table const& table, ObjKeyType obj_key, size_t depth = 0);
-    bool check_outgoing_links(TableKey table_key, Table const& table, int64_t obj_key, size_t depth = 0);
+    bool check_outgoing_links(TableKey table_key, Table const& table, ObjKey obj_key, size_t depth = 0);
 };
 
 // A base class for a notifier that keeps a collection up to date and/or
@@ -230,7 +218,7 @@ private:
     bool m_has_run = false;
     bool m_error = false;
     bool m_has_delivered_root_deletion_event = false;
-    std::vector<DeepChangeChecker::RelatedTable> m_related_tables;
+    DeepChangeChecker::RelatedTables m_related_tables;
 
     struct Callback {
         CollectionChangeCallback fn;

--- a/src/realm/table.cpp
+++ b/src/realm/table.cpp
@@ -3555,6 +3555,21 @@ Table::BacklinkOrigin Table::find_backlink_origin(ColKey backlink_col) const noe
     return {};
 }
 
+std::vector<std::pair<ColKey, TableKey>> Table::get_outgoing_links() const noexcept
+{
+    std::vector<std::pair<ColKey, TableKey>> ret;
+
+    for_each_public_column([&](ColKey col_key) {
+        if (auto k = get_opposite_table_key(col_key)) {
+            ret.emplace_back(col_key, k);
+        }
+        return false;
+    });
+
+    return ret;
+}
+
+
 ColKey Table::get_primary_key_column() const
 {
     return m_primary_key_col;

--- a/src/realm/table.hpp
+++ b/src/realm/table.hpp
@@ -130,6 +130,7 @@ public:
     typedef util::Optional<std::pair<ConstTableRef, ColKey>> BacklinkOrigin;
     BacklinkOrigin find_backlink_origin(StringData origin_table_name, StringData origin_col_name) const noexcept;
     BacklinkOrigin find_backlink_origin(ColKey backlink_col) const noexcept;
+    std::vector<std::pair<ColKey, TableKey>> get_outgoing_links() const noexcept;
     //@}
 
     // Primary key columns

--- a/test/object-store/set.cpp
+++ b/test/object-store/set.cpp
@@ -19,7 +19,7 @@
 
 using namespace realm;
 
-TEST_CASE("set") {
+TEST_CASE("set", "[set]") {
     InMemoryTestFile config;
     config.automatic_change_notifications = false;
     auto r = Realm::get_shared_realm(config);

--- a/test/object-store/transaction_log_parsing.cpp
+++ b/test/object-store/transaction_log_parsing.cpp
@@ -1610,7 +1610,7 @@ TEST_CASE("DeepChangeChecker") {
         return info;
     };
 
-    std::vector<_impl::DeepChangeChecker::RelatedTable> tables;
+    _impl::DeepChangeChecker::RelatedTables tables;
     _impl::DeepChangeChecker::find_related_tables(tables, *table);
 
     auto cols = table->get_column_keys();


### PR DESCRIPTION
Co-authored-by: James Stone <james.stone@mongodb.com>

The change checker was handling dictionaries and sets as if they were lists. This could lead to an exception KeyNotFound("No such object"); as described in #4465

## ☑️ ToDos
* [x] 📝 Changelog update
* [x] 🚦 Tests (or not relevant)
