### PR TITLE
Avoid race when starting ExternalCommitHelper on windows

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 ### Fixed
 * <How to hit and notice issue? what was the impact?> ([#????](https://github.com/realm/realm-core/issues/????), since v?.?.?)
 * Classes names "class_class_..." was not handled correctly in KeyPathMapping ([#4480](https://github.com/realm/realm-core/issues/4480))
+* Avoid race condition leading to possible hangs on windows. ([realm-dotnet#2245](https://github.com/realm/realm-dotnet/issues/2245))
  
 ### Breaking changes
 * None.

--- a/src/realm/object-store/impl/windows/external_commit_helper.hpp
+++ b/src/realm/object-store/impl/windows/external_commit_helper.hpp
@@ -112,7 +112,7 @@ private:
     RealmCoordinator& m_parent;
 
     // The listener thread
-    std::future<void> m_thread;
+    std::thread m_thread;
 
     struct SharedPart {
         util::InterprocessCondVar::SharedPart cv;
@@ -130,6 +130,7 @@ private:
     util::InterprocessCondVar m_commit_available;
     util::InterprocessMutex m_mutex;
     bool m_keep_listening = true;
+    int64_t m_last_count;
 };
 
 } // namespace _impl

--- a/src/realm/util/interprocess_condvar.hpp
+++ b/src/realm/util/interprocess_condvar.hpp
@@ -112,7 +112,11 @@ public:
             wait(m, tp);
             if (tp) {
                 struct timespec now;
+#ifdef _WIN32
                 timespec_get(&now, TIME_UTC);
+#else
+                clock_gettime(CLOCK_REAL, &now);
+#endif
                 if (std::tie(now.tv_sec, now.tv_nsec) >= std::tie(tp->tv_sec, tp->tv_nsec))
                     return;
             }

--- a/src/realm/util/interprocess_condvar.hpp
+++ b/src/realm/util/interprocess_condvar.hpp
@@ -108,14 +108,14 @@ public:
     template <typename Cond>
     void wait(InterprocessMutex& m, const struct timespec* tp, Cond&& cond)
     {
-        using clock = std::chrono::system_clock;
-        const auto deadline =
-            tp ? clock::time_point::ceil(clock::from_time_t(tp->tv_sec) + std::chrono::nanoseconds(tp->tv_nsec))
-               : clock::time_point();
         while (!cond()) {
             wait(m, tp);
-            if (tp && clock::now() >= deadline)
-                return;
+            if (tp) {
+                struct timespec now;
+                timespec_get(&now, TIME_UTC);
+                if (std::tie(now.tv_sec, now.tv_nsec) >= std::tie(tp->tv_sec, tp->tv_nsec))
+                    return;
+            }
         }
     }
 

--- a/src/realm/util/interprocess_condvar.hpp
+++ b/src/realm/util/interprocess_condvar.hpp
@@ -110,7 +110,7 @@ public:
     {
         using clock = std::chrono::system_clock;
         const auto deadline =
-            tp ? clock::time_point(std::chrono::seconds(tp->tv_sec) + std::chrono::nanoseconds(tp->tv_nsec))
+            tp ? clock::time_point::ceil(clock::from_time_t(tp->tv_sec) + std::chrono::nanoseconds(tp->tv_nsec))
                : clock::time_point();
         while (!cond()) {
             wait(m, tp);

--- a/src/realm/util/interprocess_condvar.hpp
+++ b/src/realm/util/interprocess_condvar.hpp
@@ -115,7 +115,7 @@ public:
 #ifdef _WIN32
                 timespec_get(&now, TIME_UTC);
 #else
-                clock_gettime(CLOCK_REAL, &now);
+                clock_gettime(CLOCK_REALTIME, &now);
 #endif
                 if (std::tie(now.tv_sec, now.tv_nsec) >= std::tie(tp->tv_sec, tp->tv_nsec))
                     return;

--- a/src/realm/util/interprocess_condvar.hpp
+++ b/src/realm/util/interprocess_condvar.hpp
@@ -106,10 +106,11 @@ public:
     /// wakeups, and avoids some condvar anti-patterns, by pushing callers into
     /// the correct pattern.
     template <typename Cond>
-    void wait(InterprocessMutex& m, const struct timespec* tp, Cond&& cond)
+    void wait(InterprocessMutex& m, Cond&& cond)
     {
+
         while (!cond()) {
-            wait(m, tp);
+            wait(m, nullptr);
         }
     }
 


### PR DESCRIPTION
Previously if a notification came in between the time when the ECH was
contructed and when the background listener thread acquired the lock,
that notification would be missed. Now, the ECH looks at the
notification count on the constructing thread prior to launching the
background thread. If a notification comes in, the listener thread will
see a different notification count and will not wait on the condvar
prior to calling on_change().

<!--
 Make sure to assign one and only one Type (`T:`) label.
 Select reviewers if ready for review. Our bot will automatically assign you.
 -->

## What, How & Why?
<!-- Describe the changes and give some hints to guide your reviewers if possible. -->
<!-- Link (via zenhub) to relevant issue this fixes -->

## ☑️ ToDos
* [x] 📝 Changelog update
* [ ] 🚦 Tests (or not relevant)
