### PR TITLE
Improve handling of write transactions inside notification callbacks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 * <How to hit and notice issue? what was the impact?> ([#????](https://github.com/realm/realm-core/issues/????), since v?.?.?)
 * Potential/unconfirmed fix for crashes associated with failure to memory map (low on memory, low on virtual address space). For example ([#4514](https://github.com/realm/realm-core/issues/4514)).
 * Fixed name aliasing not working in sort/distinct clauses of the query parser. ([#4550](https://github.com/realm/realm-core/issues/4550), never before working).
+* Fix assertion failures such as "!m_notifier_skip_version.version" when performing writes inside change notification callbacks. Previously refreshing the Realm by beginning a write transaction would skip delivering notifications, leaving things in an inconsistent state. Notifications are now delivered recursively when needed instead. ([Cocoa #7165](https://github.com/realm/realm-cocoa/issues/7165)).
 
 ### Breaking changes
 * None.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@
 * <How to hit and notice issue? what was the impact?> ([#????](https://github.com/realm/realm-core/issues/????), since v?.?.?)
 * Potential/unconfirmed fix for crashes associated with failure to memory map (low on memory, low on virtual address space). For example ([#4514](https://github.com/realm/realm-core/issues/4514)).
 * Fixed name aliasing not working in sort/distinct clauses of the query parser. ([#4550](https://github.com/realm/realm-core/issues/4550), never before working).
-* Fix assertion failures such as "!m_notifier_skip_version.version" when performing writes inside change notification callbacks. Previously refreshing the Realm by beginning a write transaction would skip delivering notifications, leaving things in an inconsistent state. Notifications are now delivered recursively when needed instead. ([Cocoa #7165](https://github.com/realm/realm-cocoa/issues/7165)).
+* Fix assertion failures such as "!m_notifier_skip_version.version" or "m_notifier_sg->get_version() + 1 == new_version.version" when performing writes inside change notification callbacks. Previously refreshing the Realm by beginning a write transaction would skip delivering notifications, leaving things in an inconsistent state. Notifications are now delivered recursively when needed instead. ([Cocoa #7165](https://github.com/realm/realm-cocoa/issues/7165)).
 
 ### Breaking changes
 * None.

--- a/src/realm/object-store/impl/collection_notifier.cpp
+++ b/src/realm/object-store/impl/collection_notifier.cpp
@@ -250,6 +250,11 @@ void CollectionNotifier::suppress_next_notification(uint64_t token)
     util::CheckedLockGuard lock(m_callback_mutex);
     auto it = find_callback(token);
     if (it != end(m_callbacks)) {
+        // We're inside a write on this collection's Realm, so the callback
+        // should have already been called and there are no versions after
+        // this one yet
+        REALM_ASSERT(it->changes_to_deliver.empty());
+        REALM_ASSERT(it->accumulated_changes.empty());
         it->skip_next = true;
     }
 }

--- a/src/realm/object-store/impl/collection_notifier.cpp
+++ b/src/realm/object-store/impl/collection_notifier.cpp
@@ -341,7 +341,8 @@ void CollectionNotifier::after_advance()
         }
         callback.initial_delivered = true;
 
-        auto changes = std::move(callback.changes_to_deliver);
+        auto changes = std::move(callback.changes_to_deliver).finalize();
+        callback.changes_to_deliver = {};
         // acquire a local reference to the callback so that removing the
         // callback from within it can't result in a dangling pointer
         auto cb = callback.fn;
@@ -352,7 +353,8 @@ void CollectionNotifier::after_advance()
 
 void CollectionNotifier::deliver_error(std::exception_ptr error)
 {
-    // Don't complain about double-unregistering callbacks
+    // Don't complain about double-unregistering callbacks if we sent an error
+    // because we're going to remove all the callbacks immediately.
     m_error = true;
 
     m_callback_count = m_callbacks.size();
@@ -381,7 +383,11 @@ bool CollectionNotifier::package_for_delivery()
         return false;
     util::CheckedLockGuard lock(m_callback_mutex);
     for (auto& callback : m_callbacks) {
-        callback.changes_to_deliver = std::move(callback.accumulated_changes).finalize();
+        // changes_to_deliver will normally be empty here. If it's non-empty
+        // then that means package_for_delivery() was called multiple times
+        // without the notification actually being delivered, which can happen
+        // if the Realm was refreshed from within a notification callback.
+        callback.changes_to_deliver.merge(std::move(callback.accumulated_changes));
         callback.accumulated_changes = {};
     }
     m_callback_count = m_callbacks.size();
@@ -393,7 +399,7 @@ void CollectionNotifier::for_each_callback(Fn&& fn)
 {
     util::CheckedUniqueLock callback_lock(m_callback_mutex);
     REALM_ASSERT_DEBUG(m_callback_count <= m_callbacks.size());
-    for (++m_callback_index; m_callback_index < m_callback_count; ++m_callback_index) {
+    for (m_callback_index = 0; m_callback_index < m_callback_count; ++m_callback_index) {
         fn(callback_lock, m_callbacks[m_callback_index]);
         if (!callback_lock.owns_lock())
             callback_lock.lock_unchecked();
@@ -426,10 +432,13 @@ void CollectionNotifier::add_changes(CollectionChangeBuilder change)
     util::CheckedLockGuard lock(m_callback_mutex);
     for (auto& callback : m_callbacks) {
         if (callback.skip_next) {
+            // Only the first commit in a batched set of transactions can be
+            // skipped, so if we already have some changes something went wrong.
             REALM_ASSERT_DEBUG(callback.accumulated_changes.empty());
             callback.skip_next = false;
         }
         else {
+            // Only copy the changeset if there's more callbacks that need it
             if (&callback == &m_callbacks.back())
                 callback.accumulated_changes.merge(std::move(change));
             else
@@ -496,10 +505,4 @@ void NotifierPackage::after_advance()
     }
     for (auto& notifier : m_notifiers)
         notifier->after_advance();
-}
-
-void NotifierPackage::add_notifier(std::shared_ptr<CollectionNotifier> notifier)
-{
-    m_notifiers.push_back(notifier);
-    m_coordinator->register_notifier(notifier);
 }

--- a/src/realm/object-store/impl/realm_coordinator.cpp
+++ b/src/realm/object-store/impl/realm_coordinator.cpp
@@ -978,6 +978,9 @@ void RealmCoordinator::run_async_notifiers()
         // be here even if the notifiers don't need to rerun.
         notifiers = m_notifiers;
     }
+    else {
+        REALM_ASSERT(!skip_version.version);
+    }
 
     auto new_notifiers = std::move(m_new_notifiers);
     m_new_notifiers.clear();

--- a/src/realm/object-store/results.hpp
+++ b/src/realm/object-store/results.hpp
@@ -20,13 +20,13 @@
 #define REALM_RESULTS_HPP
 
 #include <realm/object-store/collection_notifications.hpp>
+#include <realm/object-store/dictionary.hpp>
 #include <realm/object-store/impl/collection_notifier.hpp>
 #include <realm/object-store/list.hpp>
-#include <realm/object-store/set.hpp>
-#include <realm/object-store/dictionary.hpp>
 #include <realm/object-store/object.hpp>
 #include <realm/object-store/object_schema.hpp>
 #include <realm/object-store/property.hpp>
+#include <realm/object-store/set.hpp>
 #include <realm/object-store/shared_realm.hpp>
 #include <realm/object-store/util/checked_mutex.hpp>
 #include <realm/object-store/util/copyable_atomic.hpp>
@@ -36,7 +36,6 @@
 
 namespace realm {
 class Mixed;
-class ObjectSchema;
 
 namespace _impl {
 class ResultsNotifierBase;

--- a/src/realm/object-store/shared_realm.cpp
+++ b/src/realm/object-store/shared_realm.cpp
@@ -35,8 +35,8 @@
 #include <realm/object-store/util/scheduler.hpp>
 
 #include <realm/db.hpp>
-#include <realm/util/scope_exit.hpp>
 #include <realm/util/fifo_helper.hpp>
+#include <realm/util/scope_exit.hpp>
 
 #if REALM_ENABLE_SYNC
 #include <realm/object-store/sync/impl/sync_file.hpp>
@@ -49,6 +49,24 @@
 
 using namespace realm;
 using namespace realm::_impl;
+
+namespace {
+class CountGuard {
+public:
+    CountGuard(size_t& count)
+        : m_count(count)
+    {
+        ++m_count;
+    }
+    ~CountGuard()
+    {
+        --m_count;
+    }
+
+private:
+    size_t& m_count;
+};
+} // namespace
 
 Realm::Realm(Config config, util::Optional<VersionID> version, std::shared_ptr<_impl::RealmCoordinator> coordinator,
              MakeSharedTag)
@@ -615,24 +633,10 @@ void Realm::begin_transaction()
     // strong reference to `this`
     auto retain_self = shared_from_this();
 
-    // If we're already in the middle of sending notifications, just begin the
-    // write transaction without sending more notifications. If this actually
-    // advances the read version this could leave the user in an inconsistent
-    // state, but that's unavoidable.
-    if (m_is_sending_notifications) {
-        _impl::NotifierPackage notifiers;
-        transaction::begin(transaction_ref(), m_binding_context.get(), notifiers);
-        return;
-    }
-
     // make sure we have a read transaction
     read_group();
 
-    m_is_sending_notifications = true;
-    auto cleanup = util::make_scope_exit([this]() noexcept {
-        m_is_sending_notifications = false;
-    });
-
+    CountGuard sending_notifications(m_is_sending_notifications);
     try {
         m_coordinator->promote_to_write(*this);
     }
@@ -682,6 +686,9 @@ void Realm::invalidate()
     check_can_create_any_transaction(this);
 
     if (m_is_sending_notifications) {
+        // This was originally because closing the Realm during notification
+        // sending would break things, but we now support that. However, it's a
+        // breaking change so we keep the old behavior for now.
         return;
     }
 
@@ -752,11 +759,8 @@ void Realm::notify()
         }
     }
 
-    auto cleanup = util::make_scope_exit([this]() noexcept {
-        m_is_sending_notifications = false;
-    });
     if (!m_coordinator->can_advance(*this)) {
-        m_is_sending_notifications = true;
+        CountGuard sending_notifications(m_is_sending_notifications);
         m_coordinator->process_available_async(*this);
         return;
     }
@@ -770,7 +774,7 @@ void Realm::notify()
             return;
     }
 
-    m_is_sending_notifications = true;
+    CountGuard sending_notifications(m_is_sending_notifications);
     if (m_auto_refresh) {
         if (m_group) {
             try {
@@ -821,11 +825,7 @@ bool Realm::do_refresh()
     // strong reference to `this`
     auto retain_self = shared_from_this();
 
-    m_is_sending_notifications = true;
-    auto cleanup = util::make_scope_exit([this]() noexcept {
-        m_is_sending_notifications = false;
-    });
-
+    CountGuard sending_notifications(m_is_sending_notifications);
     if (m_binding_context) {
         m_binding_context->before_notify();
     }

--- a/src/realm/object-store/shared_realm.hpp
+++ b/src/realm/object-store/shared_realm.hpp
@@ -448,9 +448,9 @@ private:
     // that's actually fully working
     bool m_dynamic_schema = true;
 
-    // True while sending the notifications caused by advancing the read
+    // Non-zero while sending the notifications caused by advancing the read
     // transaction version, to avoid recursive notifications where possible
-    bool m_is_sending_notifications = false;
+    size_t m_is_sending_notifications = 0;
 
     // True while we're performing a schema migration via this Realm instance
     // to allow for different behavior (such as allowing modifications to

--- a/test/object-store/realm.cpp
+++ b/test/object-store/realm.cpp
@@ -639,6 +639,9 @@ TEST_CASE("SharedRealm: notifications") {
 
     struct Context : BindingContext {
         size_t* change_count;
+        std::function<void()> did_change_fn;
+        std::function<void()> changes_available_fn;
+
         Context(size_t* out)
             : change_count(out)
         {
@@ -647,13 +650,22 @@ TEST_CASE("SharedRealm: notifications") {
         void did_change(std::vector<ObserverState> const&, std::vector<void*> const&, bool) override
         {
             ++*change_count;
+            if (did_change_fn)
+                did_change_fn();
+        }
+
+        void changes_available() override
+        {
+            if (changes_available_fn)
+                changes_available_fn();
         }
     };
 
     size_t change_count = 0;
     auto realm = Realm::get_shared_realm(config);
     realm->read_group();
-    realm->m_binding_context.reset(new Context{&change_count});
+    auto context = new Context{&change_count};
+    realm->m_binding_context.reset(context);
     realm->m_binding_context->realm = realm;
 
     SECTION("local notifications are sent synchronously") {
@@ -675,19 +687,9 @@ TEST_CASE("SharedRealm: notifications") {
     }
 
     SECTION("refresh() from within changes_available() refreshes") {
-        struct Context : BindingContext {
-            Realm& realm;
-            Context(Realm& realm)
-                : realm(realm)
-            {
-            }
-
-            void changes_available() override
-            {
-                REQUIRE(realm.refresh());
-            }
+        context->changes_available_fn = [&] {
+            REQUIRE(realm->refresh());
         };
-        realm->m_binding_context.reset(new Context{*realm});
         realm->set_auto_refresh(false);
 
         auto r2 = Realm::get_shared_realm(config);
@@ -699,76 +701,51 @@ TEST_CASE("SharedRealm: notifications") {
     }
 
     SECTION("refresh() from within did_change() is a no-op") {
-        struct Context : BindingContext {
-            Realm& realm;
-            Context(Realm& realm)
-                : realm(realm)
-            {
-            }
+        context->did_change_fn = [&] {
+            if (change_count > 1)
+                return;
 
-            void did_change(std::vector<ObserverState> const&, std::vector<void*> const&, bool) override
-            {
-                // Create another version so that refresh() could do something
-                auto r2 = Realm::get_shared_realm(realm.config());
-                r2->begin_transaction();
-                r2->commit_transaction();
+            // Create another version so that refresh() advances the version
+            auto r2 = Realm::get_shared_realm(realm->config());
+            r2->begin_transaction();
+            r2->commit_transaction();
 
-                // Should be a no-op
-                REQUIRE_FALSE(realm.refresh());
-            }
+            REQUIRE_FALSE(realm->refresh());
         };
-        realm->m_binding_context.reset(new Context{*realm});
 
         auto r2 = Realm::get_shared_realm(config);
         r2->begin_transaction();
         r2->commit_transaction();
-        REQUIRE(realm->refresh());
 
-        auto ver = realm->current_transaction_version();
-        realm->m_binding_context.reset();
-        // Should advance to the version created in the previous did_change()
         REQUIRE(realm->refresh());
-        auto new_ver = realm->current_transaction_version();
-        REQUIRE(*new_ver > *ver);
-        // No more versions, so returns false
+        REQUIRE(change_count == 1);
+
+        REQUIRE(realm->refresh());
+        REQUIRE(change_count == 2);
         REQUIRE_FALSE(realm->refresh());
     }
 
     SECTION("begin_write() from within did_change() produces recursive notifications") {
-        struct Context : BindingContext {
-            Realm& realm;
-            size_t calls = 0;
-            Context(Realm& realm)
-                : realm(realm)
-            {
-            }
+        context->did_change_fn = [&] {
+            if (realm->is_in_transaction())
+                realm->cancel_transaction();
+            if (change_count > 3)
+                return;
 
-            void did_change(std::vector<ObserverState> const&, std::vector<void*> const&, bool) override
-            {
-                ++calls;
-                if (realm.is_in_transaction())
-                    return;
+            // Create another version so that begin_write() advances the version
+            auto r2 = Realm::get_shared_realm(realm->config());
+            r2->begin_transaction();
+            r2->commit_transaction();
 
-                // Create another version so that begin_write() advances the version
-                auto r2 = Realm::get_shared_realm(realm.config());
-                r2->begin_transaction();
-                r2->commit_transaction();
-
-                realm.begin_transaction();
-                realm.cancel_transaction();
-            }
+            realm->begin_transaction();
+            REQUIRE(change_count == 4);
         };
-        auto context = new Context{*realm};
-        realm->m_binding_context.reset(context);
 
         auto r2 = Realm::get_shared_realm(config);
         r2->begin_transaction();
         r2->commit_transaction();
         REQUIRE(realm->refresh());
-        REQUIRE(context->calls == 2);
-
-        // Despite not sending a new notification we did advance the version, so
-        // no more versions to refresh to
+        REQUIRE(change_count == 4);
         REQUIRE_FALSE(realm->refresh());
     }
 }


### PR DESCRIPTION
When I first implemented notifications I wasn't sure how to handle writes refreshing the Realm while inside notification callbacks and eventually settled on just not handling it and accepting that doing that would result in incorrect notifications. This resulted in some things being in an invalid state when it happened, which makes the asserts added in #4449 failing. Fortunately, it turns out that the refactoring to enable notification skipping also gave a pretty straightforward route to deliver correctish notifications. The new behavior is that when a Realm is refreshed in the middle of sending notifications, we recursively send notifications from within that notification block, and merge the new changes into the existing changes to be delivered for any callbacks we didn't reach.

Fixes https://github.com/realm/realm-cocoa/issues/7165. Fixes https://github.com/realm/realm-core/issues/4511. Fixes https://github.com/realm/realm-core/issues/4510. Fixes https://github.com/realm/realm-core/issues/4512.