### PR TITLE
Enable relational comparison of UUID

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@
 * Fixed the notifiers causing an exception `KeyNotFound("No such object");` if a dictionary or set of links of a single type also had a link column in the linked table. ([#4465](https://github.com/realm/realm-core/issues/4465)).
 * Classes names "class_class_..." was not handled correctly in KeyPathMapping ([#4480](https://github.com/realm/realm-core/issues/4480))
 * Syncing large Decimal128 values will cause "Assertion failed: cx.w[1] == 0" ([#4519](https://github.com/realm/realm-core/issues/4519), since v10.0.0)
+* Fixed the query parser rejecting <,>,<=,>= queries on UUID types. ([#4475](https://github.com/realm/realm-core/issues/4475), since v10.0.0)
  
 ### Breaking changes
 * None.

--- a/src/realm/parser/driver.cpp
+++ b/src/realm/parser/driver.cpp
@@ -448,14 +448,18 @@ Query RelationalNode::visit(ParserDriver* drv)
 
     auto left_type = left->get_type();
     auto right_type = right->get_type();
+    const bool right_type_is_null = right->has_constant_evaluation() && right->get_mixed().is_null();
+    const bool left_type_is_null = left->has_constant_evaluation() && left->get_mixed().is_null();
+    REALM_ASSERT(!(left_type_is_null && right_type_is_null));
 
-    if (left_type == type_UUID || left_type == type_Link || left_type == type_TypeOfValue) {
+    if (left_type == type_Link || left_type == type_TypeOfValue) {
         throw InvalidQueryError(util::format(
             "Unsupported operator %1 in query. Only equal (==) and not equal (!=) are supported for this type.",
             opstr[op]));
     }
 
-    if (!left_type.is_valid() || !right_type.is_valid() || !Mixed::data_types_are_comparable(left_type, right_type)) {
+    if (!(left_type_is_null || right_type_is_null) && (!left_type.is_valid() || !right_type.is_valid() ||
+                                                       !Mixed::data_types_are_comparable(left_type, right_type))) {
         throw InvalidQueryError(util::format("Unsupported comparison between type '%1' and type '%2'",
                                              get_data_type_name(left_type), get_data_type_name(right_type)));
     }

--- a/test/test_parser.cpp
+++ b/test/test_parser.cpp
@@ -1411,7 +1411,7 @@ TEST(Parser_substitution)
     // int
     verify_query_sub(test_context, t, "age > $1", args, num_args, 2);
     CHECK_THROW_ANY(verify_query_sub(test_context, t, "age > $2", args, num_args, 0));
-    CHECK_THROW_ANY(verify_query_sub(test_context, t, "age > $3", args, num_args, 0));
+    verify_query_sub(test_context, t, "age > $3", args, num_args, 0);
     verify_query_sub(test_context, t, "age > $4", args, num_args, 3);
     CHECK_THROW_ANY(verify_query_sub(test_context, t, "age > $5", args, num_args, 0));
     CHECK_THROW_ANY(verify_query_sub(test_context, t, "age > $6", args, num_args, 0));
@@ -1419,7 +1419,7 @@ TEST(Parser_substitution)
     // double
     verify_query_sub(test_context, t, "fees > $0", args, num_args, 4);
     CHECK_THROW_ANY(verify_query_sub(test_context, t, "fees > $2", args, num_args, 0));
-    CHECK_THROW_ANY(verify_query_sub(test_context, t, "fees > $3", args, num_args, 0));
+    verify_query_sub(test_context, t, "fees > $3", args, num_args, 0);
     verify_query_sub(test_context, t, "fees > $4", args, num_args, 5);
     CHECK_THROW_ANY(verify_query_sub(test_context, t, "fees > $5", args, num_args, 0));
     CHECK_THROW_ANY(verify_query_sub(test_context, t, "fees > $6", args, num_args, 0));
@@ -1428,7 +1428,7 @@ TEST(Parser_substitution)
     verify_query_sub(test_context, t, "floats > $0", args, num_args, 2);
     verify_query_sub(test_context, t, "floats > $1", args, num_args, 1);
     CHECK_THROW_ANY(verify_query_sub(test_context, t, "floats > $2", args, num_args, 0));
-    CHECK_THROW_ANY(verify_query_sub(test_context, t, "floats > $3", args, num_args, 0));
+    verify_query_sub(test_context, t, "floats > $3", args, num_args, 0);
     verify_query_sub(test_context, t, "floats > $4", args, num_args, 2);
     CHECK_THROW_ANY(verify_query_sub(test_context, t, "floats > $5", args, num_args, 0));
     CHECK_THROW_ANY(verify_query_sub(test_context, t, "floats > $6", args, num_args, 0));
@@ -4188,14 +4188,30 @@ TEST(Parser_UUID)
         verify_query(test_context, table, "nid == uuid(" + id.to_string() + ")", 1);
         verify_query(test_context, table, "id != uuid(" + id.to_string() + ")", num_rows - 1);
         verify_query(test_context, table, "nid != uuid(" + id.to_string() + ")", num_rows - 1);
-        CHECK_THROW_ANY(verify_query(test_context, table, "nid > uuid(" + id.to_string() + ")", 0));
-        CHECK_THROW_ANY(verify_query(test_context, table, "nid >= uuid(" + id.to_string() + ")", 0));
-        CHECK_THROW_ANY(verify_query(test_context, table, "nid < uuid(" + id.to_string() + ")", 0));
-        CHECK_THROW_ANY(verify_query(test_context, table, "nid <= uuid(" + id.to_string() + ")", 0));
         CHECK_THROW_ANY(verify_query(test_context, table, "nid BEGINSWITH uuid(" + id.to_string() + ")", 0));
         CHECK_THROW_ANY(verify_query(test_context, table, "nid ENDSWITH uuid(" + id.to_string() + ")", 0));
         CHECK_THROW_ANY(verify_query(test_context, table, "nid CONTAINS uuid(" + id.to_string() + ")", 0));
         CHECK_THROW_ANY(verify_query(test_context, table, "nid LIKE uuid(" + id.to_string() + ")", 0));
+    }
+
+    UUID min;
+    UUID max("ffffffff-ffff-ffff-ffff-ffffffffffff");
+    std::vector<std::string> props = {"id", "nid"};
+    for (auto prop_name : props) {
+        // a null value is neither greater nor less than any valid value
+        size_t num_valid_values = (prop_name == "nid" ? num_rows - 1 : num_rows);
+        verify_query(test_context, table, util::format("%1 > uuid(%2)", prop_name, min.to_string()),
+                     num_valid_values);
+        verify_query(test_context, table, util::format("%1 >= uuid(%2)", prop_name, min.to_string()),
+                     num_valid_values);
+        verify_query(test_context, table, util::format("%1 < uuid(%2)", prop_name, min.to_string()), 0);
+        verify_query(test_context, table, util::format("%1 <= uuid(%2)", prop_name, min.to_string()), 0);
+        verify_query(test_context, table, util::format("%1 > uuid(%2)", prop_name, max.to_string()), 0);
+        verify_query(test_context, table, util::format("%1 >= uuid(%2)", prop_name, max.to_string()), 0);
+        verify_query(test_context, table, util::format("%1 < uuid(%2)", prop_name, max.to_string()),
+                     num_valid_values);
+        verify_query(test_context, table, util::format("%1 <= uuid(%2)", prop_name, max.to_string()),
+                     num_valid_values);
     }
 
     // argument substitution checks
@@ -4205,10 +4221,18 @@ TEST(Parser_UUID)
     verify_query_sub(test_context, table, "id == $1", args, num_args, 1);
     verify_query_sub(test_context, table, "id == $2", args, num_args, 1);
     verify_query_sub(test_context, table, "id == $3", args, num_args, 0);
+    verify_query_sub(test_context, table, "id > $3", args, num_args, 0);
+    verify_query_sub(test_context, table, "id < $3", args, num_args, 0);
+    verify_query_sub(test_context, table, "id >= $3", args, num_args, 0);
+    verify_query_sub(test_context, table, "id <= $3", args, num_args, 0);
     verify_query_sub(test_context, table, "nid == $0", args, num_args, 1);
     verify_query_sub(test_context, table, "nid == $1", args, num_args, 1);
     verify_query_sub(test_context, table, "nid == $2", args, num_args, 1);
     verify_query_sub(test_context, table, "nid == $3", args, num_args, 1);
+    verify_query_sub(test_context, table, "nid > $3", args, num_args, 0);
+    verify_query_sub(test_context, table, "nid < $3", args, num_args, 0);
+    verify_query_sub(test_context, table, "nid >= $3", args, num_args, 1);
+    verify_query_sub(test_context, table, "nid <= $3", args, num_args, 1);
 }
 
 


### PR DESCRIPTION
This was originally disabled because the design of UUID said they shouldn't be supported. The underlying comparisons did actually work though because they are needed for sorting and they are already enabled in queries outside of the parser. We enable it for consistency with typed queries as requested by https://github.com/realm/realm-core/issues/4475. Granted there may also be some niche cases where users are building UUIDs manually and want to use these comparisons in their queries.

## ☑️ ToDos
* [x] 📝 Changelog update
* [x] 🚦 Tests (or not relevant)
