### PR TITLE
Improve exception safety in SlabAlloc::update_reader_view()

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,8 +5,8 @@
 
 ### Fixed
 * <How to hit and notice issue? what was the impact?> ([#????](https://github.com/realm/realm-core/issues/????), since v?.?.?)
-* None.
- 
+* Potential/unconfirmed fix for crashes associated with failure to memory map (low on memory, low on virtual address space). For example ([#4514](https://github.com/realm/realm-core/issues/4514)).
+
 ### Breaking changes
 * None.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 # NEXT RELEASE
 
 ### Enhancements
-* None.
+* The error message when the intial steps of opening a Realm file fails is now more descriptive.
 
 ### Fixed
 * <How to hit and notice issue? what was the impact?> ([#????](https://github.com/realm/realm-core/issues/????), since v?.?.?)

--- a/src/realm/alloc.hpp
+++ b/src/realm/alloc.hpp
@@ -153,6 +153,11 @@ public:
 
     struct MappedFile;
 
+    static constexpr size_t section_size() noexcept
+    {
+        return 1 << section_shift;
+    }
+
 protected:
     constexpr static int section_shift = 26;
 

--- a/src/realm/alloc_slab.cpp
+++ b/src/realm/alloc_slab.cpp
@@ -818,10 +818,14 @@ ref_type SlabAlloc::attach_file(const std::string& file_path, Config& cfg)
         note_reader_end(this);
         throw InvalidDatabase("Realm file decryption failed", path);
     }
-    catch (...) {
+    catch (const std::exception& e) {
         note_reader_end(this);
         // we end up here if any of the file or mapping operations fail.
-        throw InvalidDatabase("Realm file initial open failed", path);
+        throw InvalidDatabase(util::format("Realm file initial open failed: %1", e.what()), path);
+    }
+    catch (...) {
+        note_reader_end(this);
+        throw InvalidDatabase("Realm file initial open failed: unknown error", path);
     }
     m_baseline = 0;
     auto handler = [this]() noexcept { note_reader_end(this); };

--- a/src/realm/alloc_slab.cpp
+++ b/src/realm/alloc_slab.cpp
@@ -1115,83 +1115,61 @@ void SlabAlloc::update_reader_view(size_t file_size)
         return;
     }
     REALM_ASSERT_EX(file_size % 8 == 0, file_size, get_file_path_for_assertions()); // 8-byte alignment required
-    REALM_ASSERT_EX(m_attach_mode == attach_SharedFile || m_attach_mode == attach_UnsharedFile, m_attach_mode, get_file_path_for_assertions());
+    REALM_ASSERT_EX(m_attach_mode == attach_SharedFile || m_attach_mode == attach_UnsharedFile, m_attach_mode,
+                    get_file_path_for_assertions());
     REALM_ASSERT_DEBUG(is_free_space_clean());
-    bool requires_new_translation = false;
 
-    // Extend mapping by adding sections, potentially replacing older sections
+    // Create the new mappings we needed to cover the new size. We don't mutate
+    // any of the member variables until we've successfully created all of the
+    // mappings so that we leave things in a consistent state if one of them
+    // hits an allocation failure.
+    bool replace_last_mapping = false;
+    std::vector<MapEntry> new_mappings;
     const auto old_slab_base = align_size_to_section_boundary(old_baseline);
-    const size_t old_num_mappings = get_section_index(old_slab_base);
+    size_t old_num_mappings = get_section_index(old_slab_base);
     REALM_ASSERT(m_mappings.size() == old_num_mappings);
-    m_baseline.store(file_size, std::memory_order_relaxed);
+
     {
-        // 0. Special case: figure out if extension is to be done entirely within a single
-        // existing mapping. This is the case if the new baseline (which must be larger
-        // then the old baseline) is still below the old base of the slab area.
-        if (file_size < old_slab_base) {
+        // If the old slab base was greater than the old baseline then the final
+        // mapping was a partial section and we need to replace it with a larger
+        // mapping.
+        if (old_baseline < old_slab_base) {
+            // old_slab_base should be 0 if we had no mappings previously
             REALM_ASSERT(old_num_mappings > 0);
-            const auto earlier_last_index = old_num_mappings - 1;
-            MapEntry& cur_entry = m_mappings[earlier_last_index];
-            const size_t section_start_offset = get_section_base(earlier_last_index);
-            const size_t section_size = file_size - section_start_offset;
-            requires_new_translation = true;
-            // save the old mapping/keep it open
-            m_old_mappings.emplace_back(m_youngest_live_version, std::move(cur_entry.primary_mapping));
-            // extension cannot possibly happen if we alread have a xover mapping established
-            REALM_ASSERT(!cur_entry.xover_mapping.is_attached());
-            cur_entry.primary_mapping =
-                util::File::Map<char>(m_file, section_start_offset, File::access_ReadOnly, section_size);
-            m_mapping_version++;
+            replace_last_mapping = true;
+            --old_num_mappings;
         }
-        else { // extension stretches over multiple sections:
 
-            // 1. figure out if there is a partially completed mapping, that we need to extend
-            // to cover a full mapping section
-            if (old_baseline < old_slab_base) {
-                REALM_ASSERT(old_num_mappings > 0);
-                const auto earlier_last_index = old_num_mappings - 1;
-                MapEntry& cur_entry = m_mappings[earlier_last_index];
-                const size_t section_start_offset = get_section_base(earlier_last_index);
-                const size_t section_size = old_slab_base - section_start_offset;
-                // we could not extend the old mapping, so replace it with a full, new one
-                requires_new_translation = true;
-                const size_t section_reservation = get_section_base(old_num_mappings) - section_start_offset;
-                REALM_ASSERT(section_size == section_reservation);
-                // save the old mapping/keep it open
-                m_old_mappings.emplace_back(m_youngest_live_version, std::move(cur_entry.primary_mapping));
-                // A xover mapping cannot be present in this case:
-                REALM_ASSERT(!cur_entry.xover_mapping.is_attached());
-                cur_entry.primary_mapping =
-                    util::File::Map<char>(m_file, section_start_offset, File::access_ReadOnly, section_size);
-                m_mapping_version++;
-            }
-
-            // 2. add any full mappings
-            //  - figure out how many full mappings we need to match the requested size
-            const auto new_slab_base = align_size_to_section_boundary(file_size);
-            const size_t num_full_mappings = get_section_index(file_size);
-            const size_t num_mappings = get_section_index(new_slab_base);
-            if (num_mappings > old_num_mappings) {
-                m_mappings.resize(num_mappings);
-            }
-
-            for (size_t k = old_num_mappings; k < num_full_mappings; ++k) {
-                const size_t section_start_offset = get_section_base(k);
-                const size_t section_size = 1 << section_shift;
-                m_mappings[k].primary_mapping =
-                    util::File::Map<char>(m_file, section_start_offset, File::access_ReadOnly, section_size);
-            }
-
-            // 3. add a final partial mapping if needed
-            if (file_size < new_slab_base) {
-                REALM_ASSERT(num_mappings == num_full_mappings + 1);
-                const size_t section_start_offset = get_section_base(num_full_mappings);
-                const size_t section_size = file_size - section_start_offset;
-                m_mappings[num_full_mappings].primary_mapping =
-                    util::File::Map<char>(m_file, section_start_offset, File::access_ReadOnly, section_size);
-            }
+        // Create new mappings covering from the end of the last complete
+        // section to the end of the new file size.
+        const auto new_slab_base = align_size_to_section_boundary(file_size);
+        const size_t num_mappings = get_section_index(new_slab_base);
+        new_mappings.reserve(num_mappings - old_num_mappings);
+        for (size_t k = old_num_mappings; k < num_mappings; ++k) {
+            const size_t section_start_offset = get_section_base(k);
+            const size_t section_size = std::min<size_t>(1 << section_shift, file_size - section_start_offset);
+            new_mappings.push_back(
+                {util::File::Map<char>(m_file, section_start_offset, File::access_ReadOnly, section_size)});
         }
     }
+
+    // Now that we've successfully created our mappings, update our member
+    // variables (and assume that resizing a simple vector won't produce memory
+    // allocation failures, unlike 64 MB mmaps).
+    if (replace_last_mapping) {
+        MapEntry& cur_entry = m_mappings.back();
+        // We should not have a xover mapping here because that would mean
+        // that there was already something mapped after the last section
+        REALM_ASSERT(!cur_entry.xover_mapping.is_attached());
+        // save the old mapping/keep it open
+        m_old_mappings.emplace_back(m_youngest_live_version, std::move(cur_entry.primary_mapping));
+        m_mappings.pop_back();
+        m_mapping_version++;
+    }
+
+    std::move(new_mappings.begin(), new_mappings.end(), std::back_inserter(m_mappings));
+    m_baseline.store(file_size, std::memory_order_relaxed);
+
     const size_t ref_start = align_size_to_section_boundary(file_size);
     const size_t ref_displacement = ref_start - old_slab_base;
     if (ref_displacement > 0) {
@@ -1218,7 +1196,7 @@ void SlabAlloc::update_reader_view(size_t file_size)
     // that is achieved by being single threaded, interlocked or run from a sequential
     // scheduling queue.
     //
-    rebuild_translations(requires_new_translation, old_num_mappings);
+    rebuild_translations(replace_last_mapping, old_num_mappings);
 }
 
 size_t SlabAlloc::get_allocated_size() const noexcept

--- a/src/realm/alloc_slab.hpp
+++ b/src/realm/alloc_slab.hpp
@@ -285,12 +285,6 @@ public:
     /// or one that was not attached using attach_file(). Doing so
     /// will result in undefined behavior.
     ///
-    /// The file_size argument must be aligned to a *section* boundary:
-    /// The database file is logically split into sections, each section
-    /// guaranteed to be mapped as a contiguous address range. The allocation
-    /// of memory in the file must ensure that no allocation crosses the
-    /// boundary between two sections.
-    ///
     /// Updates the memory mappings to reflect a new size for the file.
     /// Stale mappings are retained so that they remain valid for other threads,
     /// which haven't yet seen the file size change. The stale mappings are
@@ -305,8 +299,8 @@ public:
 
     /// Get an ID for the current mapping version. This ID changes whenever any part
     /// of an existing mapping is changed. Such a change requires all refs to be
-    /// retranslated to new pointers. The allocator tries to avoid this, and we
-    /// believe it will only ever occur on Windows based platforms.
+    /// retranslated to new pointers. This will happen whenever the reader view
+    /// is extended unless the old size was aligned to a section boundary.
     uint64_t get_mapping_version()
     {
         return m_mapping_version;

--- a/src/realm/impl/simulated_failure.cpp
+++ b/src/realm/impl/simulated_failure.cpp
@@ -170,6 +170,19 @@ bool SimulatedFailure::do_check_trigger(FailureType failure_type) noexcept
     return false;
 }
 
+static bool (*s_mmap_predicate)(size_t);
+
+void SimulatedFailure::do_prime_mmap(bool (*predicate)(size_t))
+{
+    s_mmap_predicate = predicate;
+}
+
+void SimulatedFailure::do_trigger_mmap(size_t size)
+{
+    if (s_mmap_predicate && s_mmap_predicate(size))
+        throw std::bad_alloc();
+}
+
 #endif // REALM_ENABLE_SIMULATED_FAILURE
 
 

--- a/src/realm/util/file.cpp
+++ b/src/realm/util/file.cpp
@@ -1227,7 +1227,7 @@ void* File::map_reserve(AccessMode a, size_t size, size_t offset, EncryptedFileM
 #endif
 }
 
-#endif
+#endif // REALM_ENABLE_ENCRYPTION
 
 void File::unmap(void* addr, size_t size) noexcept
 {

--- a/src/realm/util/file_mapper.cpp
+++ b/src/realm/util/file_mapper.cpp
@@ -28,9 +28,10 @@
 #include <unistd.h>
 #endif
 
+#include <realm/exceptions.hpp>
+#include <realm/impl/simulated_failure.hpp>
 #include <realm/util/errno.hpp>
 #include <realm/util/to_string.hpp>
-#include <realm/exceptions.hpp>
 #include <system_error>
 
 #if REALM_ENABLE_ENCRYPTION
@@ -44,7 +45,6 @@
 #include <sys/stat.h>
 #include <cstring>
 #include <atomic>
-#include <iostream>
 #include <fstream>
 #include <sstream>
 #include <regex>
@@ -629,6 +629,7 @@ void remove_mapping(void* addr, size_t size)
 void* mmap(FileDesc fd, size_t size, File::AccessMode access, size_t offset, const char* encryption_key,
            EncryptedFileMapping*& mapping)
 {
+    _impl::SimulatedFailure::trigger_mmap(size);
     if (encryption_key) {
         size = round_up_to_page_size(size);
         void* addr = mmap_anon(size);
@@ -757,6 +758,7 @@ void* mmap_reserve(FileDesc fd, size_t reservation_size, size_t offset_in_file)
 
 void* mmap(FileDesc fd, size_t size, File::AccessMode access, size_t offset, const char* encryption_key)
 {
+    _impl::SimulatedFailure::trigger_mmap(size);
 #if REALM_ENABLE_ENCRYPTION
     if (encryption_key) {
         size = round_up_to_page_size(size);

--- a/test/test_alloc.cpp
+++ b/test/test_alloc.cpp
@@ -367,6 +367,7 @@ TEST_IF(Alloc_MapFailureRecovery, _impl::SimulatedFailure::is_enabled())
         CHECK_EQUAL(initial_translated, alloc.translate(1000));
 
         _impl::SimulatedFailure::prime_mmap(nullptr);
+        alloc.get_file().resize(page_size * 2);
         alloc.update_reader_view(page_size * 2);
         CHECK_EQUAL(alloc.get_baseline(), page_size * 2);
         CHECK_EQUAL(initial_version + 1, alloc.get_mapping_version());
@@ -440,8 +441,7 @@ TEST_IF(Alloc_MapFailureRecovery, _impl::SimulatedFailure::is_enabled())
 
 namespace {
 
-class TestSlabAlloc : public SlabAlloc
-{
+class TestSlabAlloc : public SlabAlloc {
 
 public:
     size_t test_get_upper_section_boundary(size_t start_pos)
@@ -456,7 +456,8 @@ public:
     {
         return get_section_base(index);
     }
-    size_t test_get_section_index(size_t ref) {
+    size_t test_get_section_index(size_t ref)
+    {
         return get_section_index(ref);
     }
 };

--- a/test/test_alloc.cpp
+++ b/test/test_alloc.cpp
@@ -19,15 +19,16 @@
 #include "testsettings.hpp"
 #ifdef TEST_ALLOC
 
-#include <string>
-#include <map>
-#include <unordered_map>
 #include <list>
+#include <map>
+#include <string>
+#include <unordered_map>
 #include <vector>
 
-#include <realm/util/file.hpp>
 #include <realm/alloc_slab.hpp>
+#include <realm/impl/simulated_failure.hpp>
 #include <realm/util/allocator.hpp>
+#include <realm/util/file.hpp>
 
 #include "test.hpp"
 
@@ -311,6 +312,129 @@ TEST(Alloc_Fuzzy)
                 refs.erase(refs.begin());
             }
         }
+    }
+}
+
+TEST_IF(Alloc_MapFailureRecovery, _impl::SimulatedFailure::is_enabled())
+{
+    GROUP_TEST_PATH(path);
+
+    SlabAlloc::Config cfg;
+    SlabAlloc alloc;
+
+    { // Initial Header mapping fails
+        _impl::SimulatedFailure::prime_mmap([](size_t) {
+            return true;
+        });
+        CHECK_THROW(alloc.attach_file(path, cfg), InvalidDatabase);
+        CHECK(!alloc.is_attached());
+    }
+
+    { // Initial Footer mapping fails
+        _impl::SimulatedFailure::prime_mmap([](size_t) {
+            static int c = 0;
+            return ++c > 1;
+        });
+        CHECK_THROW(alloc.attach_file(path, cfg), InvalidDatabase);
+        CHECK(!alloc.is_attached());
+    }
+
+    const size_t page_size = util::page_size();
+
+    { // Verify we can still open the file with the same allocator
+        _impl::SimulatedFailure::prime_mmap(nullptr);
+        alloc.attach_file(path, cfg);
+        CHECK(alloc.is_attached());
+        CHECK(alloc.get_baseline() == page_size);
+
+        alloc.init_mapping_management(1);
+    }
+
+    { // Extendind the first mapping
+        const auto initial_baseline = alloc.get_baseline();
+        const auto initial_version = alloc.get_mapping_version();
+        const char* initial_translated = alloc.translate(1000);
+
+        _impl::SimulatedFailure::prime_mmap([](size_t) {
+            return true;
+        });
+        // Does not expand so it succeeds
+        alloc.update_reader_view(page_size);
+
+        CHECK_THROW(alloc.update_reader_view(page_size * 2), std::bad_alloc);
+        CHECK_EQUAL(initial_baseline, alloc.get_baseline());
+        CHECK_EQUAL(initial_version, alloc.get_mapping_version());
+        CHECK_EQUAL(initial_translated, alloc.translate(1000));
+
+        _impl::SimulatedFailure::prime_mmap(nullptr);
+        alloc.update_reader_view(page_size * 2);
+        CHECK_EQUAL(alloc.get_baseline(), page_size * 2);
+        CHECK_EQUAL(initial_version + 1, alloc.get_mapping_version());
+        CHECK_NOT_EQUAL(initial_translated, alloc.translate(1000));
+
+        // Delete the old mapping. Will double-delete it if we incorrectly added
+        // the mapping in the call that failed.
+        alloc.purge_old_mappings(2, 2);
+    }
+
+    // Expand the first mapping to a full section
+    static constexpr auto section_size = Allocator::section_size();
+    alloc.get_file().resize(section_size * 2);
+    alloc.update_reader_view(Allocator::section_size());
+    alloc.purge_old_mappings(3, 3);
+
+    { // Add a new complete section after a complete section
+        const auto initial_baseline = alloc.get_baseline();
+        const auto initial_version = alloc.get_mapping_version();
+        const char* initial_translated = alloc.translate(1000);
+
+        _impl::SimulatedFailure::prime_mmap([](size_t) {
+            return true;
+        });
+
+        CHECK_THROW(alloc.update_reader_view(section_size * 2), std::bad_alloc);
+        CHECK_EQUAL(initial_baseline, alloc.get_baseline());
+        CHECK_EQUAL(initial_version, alloc.get_mapping_version());
+        CHECK_EQUAL(initial_translated, alloc.translate(1000));
+
+        _impl::SimulatedFailure::prime_mmap(nullptr);
+        alloc.update_reader_view(section_size * 2);
+        CHECK_EQUAL(alloc.get_baseline(), section_size * 2);
+        CHECK_EQUAL(initial_version, alloc.get_mapping_version()); // did not alter an existing mapping
+        CHECK_EQUAL(initial_translated, alloc.translate(1000));    // first section was not remapped
+        CHECK_EQUAL(0, *alloc.translate(section_size * 2 - page_size));
+
+        alloc.purge_old_mappings(4, 4);
+    }
+
+    alloc.get_file().resize(section_size * 4);
+
+    { // Add complete section and a a partial section after that
+        const auto initial_baseline = alloc.get_baseline();
+        const auto initial_version = alloc.get_mapping_version();
+        const char* initial_translated_1 = alloc.translate(1000);
+        const char* initial_translated_2 = alloc.translate(section_size + 1000);
+
+        _impl::SimulatedFailure::prime_mmap([](size_t size) {
+            // Let the first allocation succeed and only the second one fail
+            return size < section_size;
+        });
+
+        CHECK_THROW(alloc.update_reader_view(section_size * 3 + page_size), std::bad_alloc);
+        CHECK_EQUAL(initial_baseline, alloc.get_baseline());
+        CHECK_EQUAL(initial_version, alloc.get_mapping_version());
+        CHECK_EQUAL(initial_translated_1, alloc.translate(1000));
+        CHECK_EQUAL(initial_translated_2, alloc.translate(section_size + 1000));
+
+        _impl::SimulatedFailure::prime_mmap(nullptr);
+        alloc.update_reader_view(section_size * 3 + page_size);
+        CHECK_EQUAL(alloc.get_baseline(), section_size * 3 + page_size);
+        CHECK_EQUAL(initial_version, alloc.get_mapping_version()); // did not alter an existing mapping
+        CHECK_EQUAL(initial_translated_1, alloc.translate(1000));
+        CHECK_EQUAL(initial_translated_2, alloc.translate(section_size + 1000));
+        CHECK_EQUAL(0, *alloc.translate(section_size * 2 + 1000));
+
+        alloc.purge_old_mappings(5, 5);
     }
 }
 


### PR DESCRIPTION
Shuffle things around so that we don't mutate any member variables until after we've created all the new mappings, which ensures that everything is left in a valid state if creating a mapping fails. Allocation failures other than creating a new mapping can still make things be invalid, though. While shuffling the code around I noticed that the special cases were actually just doing the same thing as the normal case, so it ended up being a net reduction in code assuming I didn't misunderstand anything.

This makes the following particularly stupid test successfully run to completion rather than crashing shortly after the first thread gets an alloc failure:

```
ONLY(ManyWriters)
{
    SHARED_GROUP_TEST_PATH(path);
    std::unique_ptr<Replication> hist_w(make_in_realm_history(path));
    DBRef db = DB::create(*hist_w);
    const int num_threads = 100;
    std::thread workers[num_threads];
    std::vector<Obj> objects;
    for (int j = 0; j < num_threads; ++j)
        workers[j] = std::thread([&] {
            try {
                auto tr = db->start_read();
                for (int i = 0; i < 1000; ++i) {
                    tr->promote_to_write();
                    auto table = tr->get_or_add_table("table");
                    if (table->get_column_count() == 0) {
                        table->add_column(type_Double, "col1");
                        table->add_column(type_Double, "col2");
                        table->add_column(type_Double, "col3");
                        table->add_column(type_Double, "col4");
                    }
                    for (auto& obj : *table) {
                        obj.set("col4", obj.get<double>("col1"));
                        obj.set("col1", obj.get<double>("col2") + obj.get<double>("col3"));
                    }
                    for (int k = 0; k < 1000; ++k)
                        objects.push_back(table->create_object().set_all<double, double, double, double>(k, k, k, k));
                    tr->commit_and_continue_as_read();
                }
            }
            catch (std::exception& e) {
                std::cout << "Exception: " << e.what() << "\n";
            }
        });
    for (int j = 0; j < num_threads; ++j)
        workers[j].join();
}
```

I have no idea if this has anything to do with any of the problems any actual users have hit, but it was the first thing I ran into while trying to reproduce the assertion failure.