### PR TITLE
Object store - Allow optional object fields on Object Builder

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,7 @@
 * Classes names "class_class_..." was not handled correctly in KeyPathMapping ([#4480](https://github.com/realm/realm-core/issues/4480))
 * Syncing large Decimal128 values will cause "Assertion failed: cx.w[1] == 0" ([#4519](https://github.com/realm/realm-core/issues/4519), since v10.0.0)
 * Fixed the query parser rejecting <,>,<=,>= queries on UUID types. ([#4475](https://github.com/realm/realm-core/issues/4475), since v10.0.0)
-* Fixed the object builder to dictionaries of objects with null values. ([#4537](https://github.com/realm/realm-core/issues/4537))
+* Creating dictionaries with null links through SDK context would crash. ([#4537](https://github.com/realm/realm-core/issues/4537))
 
 ### Breaking changes
 * None.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,8 @@
 * Classes names "class_class_..." was not handled correctly in KeyPathMapping ([#4480](https://github.com/realm/realm-core/issues/4480))
 * Syncing large Decimal128 values will cause "Assertion failed: cx.w[1] == 0" ([#4519](https://github.com/realm/realm-core/issues/4519), since v10.0.0)
 * Fixed the query parser rejecting <,>,<=,>= queries on UUID types. ([#4475](https://github.com/realm/realm-core/issues/4475), since v10.0.0)
- 
+* Fixed the object builder to dictionaries of objects with null values. ([#4537](https://github.com/realm/realm-core/issues/4537))
+
 ### Breaking changes
 * None.
 

--- a/src/realm/object-store/dictionary.hpp
+++ b/src/realm/object-store/dictionary.hpp
@@ -132,6 +132,10 @@ inline Obj Dictionary::get<Obj>(StringData key) const
 template <typename T, typename Context>
 void Dictionary::insert(Context& ctx, StringData key, T&& value, CreatePolicy policy)
 {
+    if (ctx.is_null(value)) {
+        this->insert(key, Mixed());
+        return;
+    }
     if (m_is_embedded) {
         validate_embedded(ctx, value, policy);
         auto obj_key = dict().create_and_insert_linked_object(key).get_key();

--- a/src/realm/object-store/property.hpp
+++ b/src/realm/object-store/property.hpp
@@ -238,7 +238,7 @@ static auto switch_on_type(PropertyType type, Fn&& fn)
         case PT::Date:
             return fn((Timestamp*)0);
         case PT::Object:
-            return is_optional ? fn((Mixed *) 0) : fn((ObjType *) 0);
+            return fn((ObjType*)0);
         case PT::ObjectId:
             return is_optional ? fn((util::Optional<ObjectId>*)0) : fn((ObjectId*)0);
         case PT::Decimal:

--- a/src/realm/object-store/property.hpp
+++ b/src/realm/object-store/property.hpp
@@ -238,7 +238,7 @@ static auto switch_on_type(PropertyType type, Fn&& fn)
         case PT::Date:
             return fn((Timestamp*)0);
         case PT::Object:
-            return fn((ObjType*)0);
+            return is_optional ? fn((Mixed *) 0) : fn((ObjType *) 0);
         case PT::ObjectId:
             return is_optional ? fn((util::Optional<ObjectId>*)0) : fn((ObjectId*)0);
         case PT::Decimal:

--- a/test/object-store/dictionary.cpp
+++ b/test/object-store/dictionary.cpp
@@ -103,7 +103,7 @@ TEMPLATE_TEST_CASE("dictionary types", "[dictionary]", cf::MixedVal, cf::Int, cf
     object_store::Dictionary links(r, obj, col_links);
     auto keys_as_results = dict.get_keys();
     auto values_as_results = dict.get_values();
-    CppContext ctx(r);
+    CppContext ctx(r, &links.get_object_schema());
 
     auto values = TestType::values();
     std::vector<std::string> keys;
@@ -169,6 +169,11 @@ TEMPLATE_TEST_CASE("dictionary types", "[dictionary]", cf::MixedVal, cf::Int, cf
             dict.insert(ctx, keys[i], TestType::to_any(values[i]));
             REQUIRE(dict.get<T>(keys[i]) == values[i]);
         }
+    }
+
+    SECTION("links") {
+        links.insert(ctx, "foo", util::Any(another));
+        links.insert(ctx, "m", util::Any());
     }
 
     SECTION("iteration") {


### PR DESCRIPTION
## What, How & Why?
This PR allows passing null entries on RealmDictionaries of RealmModels when constructing an object through the ObjectBuilder. 

The issue causes a crash when it tries to unbox an empty JavaValue to then pass it to a Dictionary of RealmModels.

Fixes #4537
## ☑️ ToDos
* [x] 📝 Changelog update
