### PR TITLE
Parse and print upload changeset similar to download.

### DIFF
--- a/src/realm/sync/noinst/client_impl_base.cpp
+++ b/src/realm/sync/noinst/client_impl_base.cpp
@@ -2271,7 +2271,7 @@ void Session::send_upload_message()
             }
 
 #if REALM_DEBUG
-            ChunkedBinaryInputStream in{ changeset_data };
+            ChunkedBinaryInputStream in{changeset_data};
             sync::Changeset log;
             sync::parse_changeset(in, log);
             std::stringstream ss;

--- a/src/realm/sync/noinst/client_impl_base.cpp
+++ b/src/realm/sync/noinst/client_impl_base.cpp
@@ -2269,6 +2269,15 @@ void Session::send_upload_message()
                 logger.trace("Changeset(comp): %1 % 2", changeset_data.size(),
                              protocol.compressed_hex_dump(changeset_data));
             }
+
+#if REALM_DEBUG
+            ChunkedBinaryInputStream in{ changeset_data };
+            sync::Changeset log;
+            sync::parse_changeset(in, log);
+            std::stringstream ss;
+            log.print(ss);
+            logger.trace("Changeset (parsed):\n%1", ss.str());
+#endif
         }
 
         if (!get_client().m_disable_upload_compaction) {


### PR DESCRIPTION
Add trace logging of the upload changeset similar to what we do for the download one:

https://github.com/realm/realm-core/blob/dae6b8dcd8839e52024007990241bd5a8d2223c2/src/realm/sync/noinst/protocol_codec.hpp#L280-L287

The intention here is to simplify debugging when we need to know precisely what the client attempts to send to the server.