### PR TITLE
fix dictionary of mixed aggregates

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@
 * Classes names "class_class_..." was not handled correctly in KeyPathMapping ([#4480](https://github.com/realm/realm-core/issues/4480))
 * Syncing large Decimal128 values will cause "Assertion failed: cx.w[1] == 0" ([#4519](https://github.com/realm/realm-core/issues/4519), since v10.0.0)
 * Fixed the query parser rejecting <,>,<=,>= queries on UUID types. ([#4475](https://github.com/realm/realm-core/issues/4475), since v10.0.0)
+* Fixed min/max/sum/avg not working on dictionaries of Mixed types when more than one type existed as values. ([#4546](https://github.com/realm/realm-core/issues/4546), since v11.0.0-beta.0)
  
 ### Breaking changes
 * None.

--- a/src/realm/aggregate_ops.hpp
+++ b/src/realm/aggregate_ops.hpp
@@ -92,6 +92,15 @@ public:
         return false;
     }
 
+    template <typename Type = T>
+    std::enable_if_t<!std::is_same_v<Type, Mixed>, bool> accumulate(const Mixed& value)
+    {
+        if (!value.is_null()) {
+            return accumulate(value.get<T>());
+        }
+        return false;
+    }
+
     bool is_null() const
     {
         return !m_result;
@@ -155,6 +164,14 @@ public:
         }
         return false;
     }
+    template <typename Type = T>
+    std::enable_if_t<!std::is_same_v<Type, Mixed>, bool> accumulate(const Mixed& value)
+    {
+        if (!value.is_null()) {
+            return accumulate(value.get<Type>());
+        }
+        return false;
+    }
 
     bool is_null() const
     {
@@ -182,6 +199,7 @@ template <typename T>
 class Average {
 public:
     using ResultType = typename std::conditional<realm::is_any_v<T, Decimal128, Mixed>, Decimal128, double>::type;
+
     bool accumulate(T value)
     {
         if constexpr (std::is_same_v<T, Mixed>) {
@@ -207,6 +225,15 @@ public:
         return false;
     }
 
+    template <typename Type = T>
+    std::enable_if_t<!std::is_same_v<Type, Mixed>, bool> accumulate(const Mixed& value)
+    {
+        if (!value.is_null()) {
+            return accumulate(value.get<Type>());
+        }
+        return false;
+    }
+
     bool is_null() const
     {
         return m_count == 0;
@@ -219,6 +246,10 @@ public:
     static const char* description()
     {
         return "@avg";
+    }
+    size_t items_counted() const
+    {
+        return m_count;
     }
 
 private:

--- a/src/realm/dictionary_cluster_tree.hpp
+++ b/src/realm/dictionary_cluster_tree.hpp
@@ -82,10 +82,13 @@ public:
     }
     Mixed min(size_t* return_ndx = nullptr) const;
     Mixed max(size_t* return_ndx = nullptr) const;
-    Mixed sum(size_t* return_cnt = nullptr) const;
-    Mixed avg(size_t* return_cnt = nullptr) const;
+    Mixed sum(size_t* return_cnt = nullptr, DataType type = type_Mixed) const;
+    Mixed avg(size_t* return_cnt = nullptr, DataType type = type_Mixed) const;
 
 private:
+    template <typename AggregateType>
+    void do_accumulate(size_t* return_ndx, AggregateType& agg) const;
+
     ArrayParent* m_owner;
     size_t m_ndx_in_cluster;
     ColKey m_keys_col;

--- a/src/realm/object-store/dictionary.cpp
+++ b/src/realm/object-store/dictionary.cpp
@@ -129,6 +129,11 @@ bool Dictionary::operator==(const Dictionary& rgt) const noexcept
     return dict() == rgt.dict();
 }
 
+bool Dictionary::operator!=(const Dictionary& rgt) const noexcept
+{
+    return !(*this == rgt);
+}
+
 Obj Dictionary::insert_embedded(StringData key)
 {
     return dict().create_and_insert_linked_object(key);

--- a/src/realm/object-store/dictionary.hpp
+++ b/src/realm/object-store/dictionary.hpp
@@ -44,6 +44,7 @@ public:
     using Collection::Collection;
 
     bool operator==(const Dictionary& rgt) const noexcept;
+    bool operator!=(const Dictionary& rgt) const noexcept;
 
     template <typename T>
     void insert(StringData key, T value);

--- a/src/realm/object-store/results.cpp
+++ b/src/realm/object-store/results.cpp
@@ -539,7 +539,12 @@ DataType Results::prepare_for_aggregate(ColKey column, const char* name)
         case type_Mixed:
             break;
         default:
-            throw UnsupportedColumnTypeException{column, *m_table, name};
+            if (m_mode == Mode::Collection) {
+                throw UnsupportedColumnTypeException(m_collection->get_col_key(), m_collection->get_table(), name);
+            }
+            else {
+                throw UnsupportedColumnTypeException{column, *m_table, name};
+            }
     }
     return type;
 }

--- a/test/object-store/collection_fixtures.hpp
+++ b/test/object-store/collection_fixtures.hpp
@@ -47,6 +47,44 @@ struct greater {
     }
 };
 
+template <typename T>
+inline T get(Mixed)
+{
+    abort();
+}
+
+template <>
+inline Mixed get(Mixed m)
+{
+    return m;
+}
+
+template <>
+inline int64_t get(Mixed m)
+{
+    return m.get_int();
+}
+template <>
+inline float get(Mixed m)
+{
+    return m.get_type() == type_Float ? m.get_float() : static_cast<float>(m.get_double());
+}
+template <>
+inline double get(Mixed m)
+{
+    return m.get_double();
+}
+template <>
+inline Timestamp get(Mixed m)
+{
+    return m.get_timestamp();
+}
+template <>
+inline Decimal128 get(Mixed m)
+{
+    return m.get<Decimal128>();
+}
+
 template <PropertyType prop_type, typename T>
 struct Base {
     using Type = T;

--- a/test/object-store/primitive_list.cpp
+++ b/test/object-store/primitive_list.cpp
@@ -111,44 +111,6 @@ struct StringMaker<util::None> {
 };
 } // namespace Catch
 
-template <typename T>
-T get(Mixed)
-{
-    abort();
-}
-
-template <>
-Mixed get(Mixed m)
-{
-    return m;
-}
-
-template <>
-int64_t get(Mixed m)
-{
-    return m.get_int();
-}
-template <>
-float get(Mixed m)
-{
-    return m.get_type() == type_Float ? m.get_float() : static_cast<float>(m.get_double());
-}
-template <>
-double get(Mixed m)
-{
-    return m.get_double();
-}
-template <>
-Timestamp get(Mixed m)
-{
-    return m.get_timestamp();
-}
-template <>
-Decimal128 get(Mixed m)
-{
-    return m.get<Decimal128>();
-}
-
 TEMPLATE_TEST_CASE("primitive list", "[primitives]", cf::MixedVal, cf::Int, cf::Bool, cf::Float, cf::Double,
                    cf::String, cf::Binary, cf::Date, cf::OID, cf::Decimal, cf::UUID, cf::BoxedOptional<cf::Int>,
                    cf::BoxedOptional<cf::Bool>, cf::BoxedOptional<cf::Float>, cf::BoxedOptional<cf::Double>,
@@ -531,13 +493,13 @@ TEMPLATE_TEST_CASE("primitive list", "[primitives]", cf::MixedVal, cf::Int, cf::
 
     SECTION("min()") {
         if (!TestType::can_minmax()) {
-            REQUIRE_THROWS(list.min());
-            REQUIRE_THROWS(results.min());
+            REQUIRE_THROWS_AS(list.min(), Results::UnsupportedColumnTypeException);
+            REQUIRE_THROWS_AS(results.min(), Results::UnsupportedColumnTypeException);
             return;
         }
 
-        REQUIRE(get<W>(*list.min()) == TestType::min());
-        REQUIRE(get<W>(*results.min()) == TestType::min());
+        REQUIRE(cf::get<W>(*list.min()) == TestType::min());
+        REQUIRE(cf::get<W>(*results.min()) == TestType::min());
         list.remove_all();
         REQUIRE(list.min() == util::none);
         REQUIRE(results.min() == util::none);
@@ -545,13 +507,13 @@ TEMPLATE_TEST_CASE("primitive list", "[primitives]", cf::MixedVal, cf::Int, cf::
 
     SECTION("max()") {
         if (!TestType::can_minmax()) {
-            REQUIRE_THROWS(list.max());
-            REQUIRE_THROWS(results.max());
+            REQUIRE_THROWS_AS(list.max(), Results::UnsupportedColumnTypeException);
+            REQUIRE_THROWS_AS(results.max(), Results::UnsupportedColumnTypeException);
             return;
         }
 
-        REQUIRE(get<W>(*list.max()) == TestType::max());
-        REQUIRE(get<W>(*results.max()) == TestType::max());
+        REQUIRE(cf::get<W>(*list.max()) == TestType::max());
+        REQUIRE(cf::get<W>(*results.max()) == TestType::max());
         list.remove_all();
         REQUIRE(list.max() == util::none);
         REQUIRE(results.max() == util::none);
@@ -559,25 +521,25 @@ TEMPLATE_TEST_CASE("primitive list", "[primitives]", cf::MixedVal, cf::Int, cf::
 
     SECTION("sum()") {
         if (!TestType::can_sum()) {
-            REQUIRE_THROWS(list.sum());
+            REQUIRE_THROWS_AS(list.sum(), Results::UnsupportedColumnTypeException);
             return;
         }
 
-        REQUIRE(get<W>(list.sum()) == TestType::sum());
-        REQUIRE(get<W>(*results.sum()) == TestType::sum());
+        REQUIRE(cf::get<W>(list.sum()) == TestType::sum());
+        REQUIRE(cf::get<W>(*results.sum()) == TestType::sum());
         list.remove_all();
-        REQUIRE(get<W>(list.sum()) == TestType::empty_sum_value());
-        REQUIRE(get<W>(*results.sum()) == TestType::empty_sum_value());
+        REQUIRE(cf::get<W>(list.sum()) == TestType::empty_sum_value());
+        REQUIRE(cf::get<W>(*results.sum()) == TestType::empty_sum_value());
     }
 
     SECTION("average()") {
         if (!TestType::can_average()) {
-            REQUIRE_THROWS(list.average());
+            REQUIRE_THROWS_AS(list.average(), Results::UnsupportedColumnTypeException);
             return;
         }
 
-        REQUIRE(get<typename TestType::AvgType>(*list.average()) == TestType::average());
-        REQUIRE(get<typename TestType::AvgType>(*results.average()) == TestType::average());
+        REQUIRE(cf::get<typename TestType::AvgType>(*list.average()) == TestType::average());
+        REQUIRE(cf::get<typename TestType::AvgType>(*results.average()) == TestType::average());
         list.remove_all();
         REQUIRE(list.average() == util::none);
         REQUIRE(results.average() == util::none);

--- a/test/test_parser.cpp
+++ b/test/test_parser.cpp
@@ -4664,13 +4664,16 @@ TEST(Parser_Dictionary)
     CHECK_THROW_ANY_GET_MESSAGE(verify_query(test_context, origin, "link.dict.Value > 50", 3), message);
     CHECK_EQUAL(message, "Property 'dict' in 'foo' is not an Object");
 
-    CHECK_THROW_ANY_GET_MESSAGE(verify_query(test_context, foo, "dict.@sum >= 100", 9), message);
-    CHECK_EQUAL(message, "Cannot add int and double");
-
+    // aggregates still work with mixed types
+    verify_query(test_context, foo, "dict.@max == 100", 2);
+    verify_query(test_context, foo, "dict.@min < 2", 2);
+    verify_query(test_context, foo, "dict.@sum >= 100", 9);
+    verify_query(test_context, foo, "dict.@avg < 10", 15);
     dict.insert("Bar", Timestamp(1234, 5678));
-    // g.to_json(std::cout);
-    CHECK_THROW_ANY_GET_MESSAGE(verify_query(test_context, foo, "dict.@sum >= 100", 9), message);
-    CHECK_EQUAL(message, "Sum not defined for timestamps");
+    verify_query(test_context, foo, "dict.@max == 100", 2);
+    verify_query(test_context, foo, "dict.@min < 2", 1);
+    verify_query(test_context, foo, "dict.@sum >= 100", 9);
+    verify_query(test_context, foo, "dict.@avg < 10", 15);
 }
 
 TEST(Parser_DictionaryObjects)


### PR DESCRIPTION
Adding more tests for object-store dictionary. Fixed a few small issues, with the main thing being aligning the aggregate implementation of Dictionary values to use `aggregate_ops` which produces consistent results with aggregates on a mixed column. Notably, this changes the previous behaviour of throwing when encountering different numeric types, into accumulating them into a Decimal128.

## ☑️ ToDos
* [x] 📝 Changelog update
* [x] 🚦 Tests (or not relevant)
