### PR TITLE
Add some additional debug validation to SlabAlloc

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@
 
 ### Internals
 * Android: build with NDK r22. Make `-Wl,-gc-sections` an interface linker flag, which reduces code size because Core is compiled `-fdata-sections` and `-ffunction-sections`. Use `-Oz` even when we enable link-time optimization (previously we used with `-O2`). ([#4407](https://github.com/realm/realm-core/pull/4407))
+* Add additional debug validation to file map management that will hopefully catch cases where we unmap something which is still in use.
 
 ----------------------------------------------
 

--- a/src/realm/alloc_slab.hpp
+++ b/src/realm/alloc_slab.hpp
@@ -392,12 +392,16 @@ private:
         Slab(const Slab&) = delete;
         Slab(Slab&& other) noexcept
             : ref_end(other.ref_end)
+            , addr(other.addr)
             , size(other.size)
         {
-            addr = other.addr;
             other.addr = nullptr;
             other.size = 0;
+            other.ref_end = 0;
         }
+
+        Slab& operator=(const Slab&) = delete;
+        Slab& operator=(Slab&&) = delete;
     };
 
     // free blocks that are in the slab area are managed using the following structures:
@@ -537,11 +541,14 @@ private:
         util::File::Map<char> mapping;
     };
     struct OldRefTranslation {
-        OldRefTranslation(uint64_t v, RefTranslation* m) noexcept
-        : replaced_at_version(v), translations(m)
+        OldRefTranslation(uint64_t v, size_t c, RefTranslation* m) noexcept
+            : replaced_at_version(v)
+            , translation_count(c)
+            , translations(m)
         {
         }
         uint64_t replaced_at_version;
+        size_t translation_count;
         std::unique_ptr<RefTranslation[]> translations;
     };
     static_assert(sizeof(Header) == 24, "Bad header size");
@@ -553,6 +560,8 @@ private:
     static const uint_fast64_t footer_magic_cookie = 0x3034125237E526C8ULL;
 
     util::RaceDetector changes;
+
+    void verify_old_translations(uint64_t verify_old_translations);
 
     // mappings used by newest transactions - additional mappings may be open
     // and in use by older transactions. These translations are in m_old_mappings.

--- a/src/realm/alloc_slab.hpp
+++ b/src/realm/alloc_slab.hpp
@@ -533,33 +533,16 @@ private:
 
     // Description of to-be-deleted memory mapping
     struct OldMapping {
-        OldMapping(uint64_t version, util::File::Map<char>&& map) noexcept
-            : replaced_at_version(version)
-            , mapping(std::move(map))
-        {
-        }
-        OldMapping(OldMapping&& other) noexcept
-            : replaced_at_version(other.replaced_at_version)
-            , mapping()
-        {
-            mapping = std::move(other.mapping);
-        }
-        void operator=(OldMapping&& other) noexcept
-        {
-            replaced_at_version = other.replaced_at_version;
-            mapping = std::move(other.mapping);
-        }
         uint64_t replaced_at_version;
         util::File::Map<char> mapping;
     };
     struct OldRefTranslation {
         OldRefTranslation(uint64_t v, RefTranslation* m) noexcept
+        : replaced_at_version(v), translations(m)
         {
-            replaced_at_version = v;
-            translations = m;
         }
         uint64_t replaced_at_version;
-        RefTranslation* translations;
+        std::unique_ptr<RefTranslation[]> translations;
     };
     static_assert(sizeof(Header) == 24, "Bad header size");
     static_assert(sizeof(StreamingFooter) == 16, "Bad footer size");

--- a/src/realm/group.cpp
+++ b/src/realm/group.cpp
@@ -598,6 +598,9 @@ void Group::open(const std::string& file_path, const char* encryption_key, OpenM
     cfg.no_create = mode == mode_ReadWriteNoCreate;
     cfg.encryption_key = encryption_key;
     ref_type top_ref = m_alloc.attach_file(file_path, cfg); // Throws
+    // Non-Transaction Groups always allow writing and simply don't allow
+    // committing when opened in read-only mode
+    m_alloc.set_read_only(false);
 
     open(top_ref, file_path);
 }

--- a/src/realm/util/file.hpp
+++ b/src/realm/util/file.hpp
@@ -746,6 +746,7 @@ public:
     /// Move the mapping from another Map object to this Map object
     File::Map<T>& operator=(File::Map<T>&& other) noexcept
     {
+        REALM_ASSERT(this != &other);
         if (m_addr)
             unmap();
         m_addr = other.get_addr();

--- a/test/test_transactions.cpp
+++ b/test/test_transactions.cpp
@@ -239,8 +239,7 @@ TEST(Transactions_StateChanges)
     CHECK_THROW(writer->freeze(), realm::LogicError);
     writer->commit_and_continue_as_read();
     // verify that we cannot modify data in a read transaction
-    // FIXME: Checks are not applied at group level yet.
-    // CHECK_THROW(writer->add_table("gylle"), realm::LogicError);
+    CHECK_THROW(writer->add_table("gylle"), realm::LogicError);
     CHECK_THROW(obj.set(col, 100), realm::LogicError);
     // verify that we can freeze a read transaction
     TransactionRef frozen = writer->freeze();


### PR DESCRIPTION
Verify that all of the pointers in old ref translation tables are still pointing to valid things and that we haven't accidentally unmapped something which should still be in use. This was one of my attempts at tracking down https://github.com/realm/realm-cocoa/issues/7175 that unfortunately didn't reveal anything but seems useful nonetheless.