### PR TITLE
Fix issue with Set<Binary>::clear()

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@
 * Equality queries between mixed and object was not supported in query parser ([#4531](https://github.com/realm/realm-core/issues/4531), since v10.0.0)
 * Syncing sets of objects was not supported ([#4538](https://github.com/realm/realm-core/issues/4538), since v10.0.0)
 * Potential/unconfirmed fix for crashes associated with failure to memory map (low on memory, low on virtual address space). For example ([#4514](https://github.com/realm/realm-core/issues/4514)).
+* Invoking Set<Binary>::clear() - directly or indirectly -  could sometimes leave the database in an inconsistent state leading to a crash.
 
 ### Breaking changes
 * None.

--- a/src/realm/set.hpp
+++ b/src/realm/set.hpp
@@ -742,9 +742,11 @@ inline void Set<T>::clear()
         m_tree->clear();
         bump_content_version();
 
-        // For Set<ObjKey>, we are sure that there are no longer any unresolved
-        // links.
-        m_tree->set_context_flag(false);
+        if constexpr (std::is_same_v<T, ObjKey>) {
+            // For Set<ObjKey>, we are sure that there are no longer any unresolved
+            // links.
+            m_tree->set_context_flag(false);
+        }
     }
 }
 

--- a/src/realm/set.hpp
+++ b/src/realm/set.hpp
@@ -742,9 +742,13 @@ inline void Set<T>::clear()
         m_tree->clear();
         bump_content_version();
 
+        // For Set<ObjKey> the context flag is used to indicate if the set
+        // contains unresolved links. As the set is now cleared we can clear
+        // this flag.
+        // If 'T' is not ObjKey we must not clear the flag because it can be
+        // used for other purposes for other types, eg. in ArrayBinary it
+        // is used to indicate a 'big blob' array.
         if constexpr (std::is_same_v<T, ObjKey>) {
-            // For Set<ObjKey>, we are sure that there are no longer any unresolved
-            // links.
             m_tree->set_context_flag(false);
         }
     }


### PR DESCRIPTION
The context flag was wrongfully cleared which meant that information about the current layout of the binary array was lost.
