### PR TITLE
first pass at mixed type comparison differences

### DIFF
--- a/src/realm/array_mixed.cpp
+++ b/src/realm/array_mixed.cpp
@@ -87,6 +87,13 @@ void ArrayMixed::set_null(size_t ndx)
 
 Mixed ArrayMixed::get(size_t ndx) const
 {
+    Mixed m = do_get(ndx);
+    m.set_source_type(Mixed::SourceType::MixedType);
+    return m;
+}
+
+Mixed ArrayMixed::do_get(size_t ndx) const
+{
     int64_t val = m_composite.get(ndx);
 
     if (val) {

--- a/src/realm/array_mixed.hpp
+++ b/src/realm/array_mixed.hpp
@@ -125,6 +125,7 @@ private:
     {
         return DataType((m_composite.get(ndx) & s_data_type_mask) - 1);
     }
+    Mixed do_get(size_t ndx) const;
     int64_t store(const Mixed&);
     void ensure_array_accessor(Array& arr, size_t ndx_in_parent) const;
     void ensure_int_array() const;

--- a/src/realm/mixed.hpp
+++ b/src/realm/mixed.hpp
@@ -161,6 +161,7 @@ public:
     ~Mixed() noexcept
     {
     }
+    enum class SourceType { StronglyTyped, MixedType };
 
     DataType get_type() const noexcept
     {
@@ -175,7 +176,9 @@ public:
     }
 
     static bool types_are_comparable(const Mixed& l, const Mixed& r);
-    static bool data_types_are_comparable(DataType l_type, DataType r_type);
+    static bool data_types_are_comparable(DataType l_type, DataType r_type,
+                                          SourceType l_source = SourceType::StronglyTyped,
+                                          SourceType r_source = SourceType::StronglyTyped);
 
     template <class T>
     T get() const noexcept;
@@ -227,6 +230,10 @@ public:
     }
     size_t hash() const;
     void use_buffer(std::string& buf);
+    void set_source_type(SourceType type)
+    {
+        m_source_type = type;
+    }
 
 protected:
     friend std::ostream& operator<<(std::ostream& out, const Mixed& m);
@@ -245,6 +252,8 @@ protected:
         ObjLink link_val;
         UUID uuid_val;
     };
+
+    SourceType m_source_type = SourceType::StronglyTyped;
 
 private:
     static bool _is_type() noexcept

--- a/src/realm/query_conditions.hpp
+++ b/src/realm/query_conditions.hpp
@@ -402,7 +402,7 @@ struct NotEqual {
         return true;
     }
 
-    bool operator()(const QueryValue& m1, const Mixed& m2) const
+    bool operator()(const QueryValue& m1, const QueryValue& m2) const
     {
         return !Equal()(m1, m2);
     }

--- a/src/realm/query_engine.hpp
+++ b/src/realm/query_engine.hpp
@@ -1374,7 +1374,12 @@ protected:
                 auto bin = m_value.get_binary();
                 OwnedBinaryData tmp(bin.data(), bin.size());
                 m_buffer = std::move(tmp);
-                m_value = Mixed(m_buffer.get());
+                if (m_value.get_type() == type_String) {
+                    m_value = Mixed(StringData(m_buffer.get().data(), m_buffer.get().size()));
+                }
+                else {
+                    m_value = Mixed(m_buffer.get());
+                }
             }
         }
     }

--- a/test/test_array_mixed.cpp
+++ b/test/test_array_mixed.cpp
@@ -210,7 +210,11 @@ TEST(Mixed_Compare)
     CHECK(Mixed(nan("123")) < 5);
 
     std::string str("Hello");
-    CHECK(Mixed(str) == Mixed(BinaryData(str)));
+    Mixed mixed_str(str);
+    Mixed mixed_bin = Mixed(BinaryData(str));
+    CHECK(mixed_str == mixed_bin);
+    mixed_str.set_source_type(Mixed::SourceType::MixedType);
+    CHECK(mixed_str != mixed_bin);
     CHECK_NOT(Mixed::types_are_comparable(Mixed(), Mixed()));
     CHECK(Mixed() == Mixed());
     CHECK(Mixed(0.f) < Mixed(1));
@@ -221,8 +225,13 @@ TEST(Mixed_Compare)
     CHECK(Mixed(BinaryData("b")) < Mixed("c"));
     CHECK(Mixed("a") < Mixed(Timestamp(1, 2)));
     CHECK(Mixed(Decimal128("25")) < Mixed(Timestamp(1, 2)));
-    CHECK(Mixed(ObjectId(Timestamp(1, 2), 0, 0)) < Mixed(Timestamp(2, 3)));
+    CHECK(Mixed(Timestamp()) < Mixed(ObjectId()));
+    Mixed oid12 = Mixed(ObjectId(Timestamp(1, 2), 0, 0));
+    Mixed ts23 = Mixed(Timestamp(2, 3));
+    CHECK(oid12 < ts23);
+    oid12.set_source_type(Mixed::SourceType::MixedType);
+    CHECK(oid12 > ts23);
     CHECK(Mixed(Timestamp(1, 2)) < Mixed(ObjectId(Timestamp(2, 3), 0, 0)));
 }
 
-#endif // TEST_ARRAY_VARIANT
+#endif // TEST_ARRAY_MIXED

--- a/test/test_parser.cpp
+++ b/test/test_parser.cpp
@@ -2433,8 +2433,8 @@ TEST(Parser_list_of_primitive_mixed)
     verify_query(test_context, t, "ANY values == 'one'", 1);
     verify_query(test_context, t, "ANY values CONTAINS[c] 'O'", 2);
     verify_query(test_context, t, "values.length == 3", 2);  // string lengths
-    verify_query(test_context, t, "ANY values == false", 2); // 0 also matching
-    verify_query(test_context, t, "ANY values == true", 3);  // 1 also matching
+    verify_query(test_context, t, "ANY values == false", 1); // numeric 0 not matching
+    verify_query(test_context, t, "ANY values == true", 1);  // numeric 1 not matching
     verify_query(test_context, t, "ANY values == false && ANY values.@type == 'bool'", 1);
     verify_query(test_context, t, "ANY values == true && ANY values.@type == 'bool'", 1);
     verify_query(test_context, t, "values.@type == 'string'", 3);
@@ -2446,7 +2446,7 @@ TEST(Parser_list_of_primitive_mixed)
     verify_query(test_context, t, "values.@avg == 1", 1);
     verify_query(test_context, t, "values.@avg == 2.725", 1);
     verify_query(test_context, t, "values.@avg == 2.4", 1);
-    verify_query(test_context, t, "values.@min == 0", 2);
+    verify_query(test_context, t, "values.@min == 0", 1); // does not convert bool(false) to 0
     verify_query(test_context, t, "values.@min == 1", 1);
     verify_query(test_context, t, "values.@max == 2", 1);
     verify_query(test_context, t, "values.@max == 4.4", 1);
@@ -4385,9 +4385,9 @@ TEST(Parser_Mixed)
     verify_query(test_context, table, "mixed != 50", 99);
     verify_query(test_context, table, "mixed == null", 1);
     verify_query(test_context, table, "mixed != null", 99);
-    verify_query(test_context, table, "mixed beginswith 'String2'", 3); // 20, 24, 28
+    verify_query(test_context, table, "mixed beginswith 'String2'", 2); // 20, 24
     verify_query(test_context, table, "mixed beginswith B64\"U3RyaW5nMg==\"",
-                 3); // 20, 24, 28, this string literal is base64 for 'String2'
+                 1); // 28 this string literal is base64 for 'String2'
     verify_query(test_context, table, "mixed contains \"trin\"", 25);
     verify_query(test_context, table, "mixed like \"Strin*\"", 25);
     verify_query(test_context, table, "mixed endswith \"4\"", 5); // 4, 24, 44, 64, 84

--- a/test/test_query.cpp
+++ b/test/test_query.cpp
@@ -2419,9 +2419,8 @@ TEST(Query_TwoColumnsCrossTypes)
                 bool_vs_numeric_comparison = true;
             }
             else if ((lhs_type == type_Mixed || rhs_type == type_Mixed) &&
-                     ((lhs_type == type_String || rhs_type == type_String) ||
-                      (lhs_type == type_Binary || rhs_type == type_Binary))) {
-                num_expected_matches = num_rows; // mixed was set to the same string/binary value
+                     ((lhs_type == type_String || rhs_type == type_String))) {
+                num_expected_matches = num_rows; // mixed was set to the same string value
             }
             {
                 size_t actual_matches = table.where().equal(lhs, rhs).count();


### PR DESCRIPTION
Requested by https://github.com/realm/realm-core/issues/4504

If and only if the comparison is against a mixed type:
- exclude bool from numeric comparison 
- exclude timestamp <-> objectId comparisons 
- exclude string and binary data comparisons

## ☑️ ToDos
* [ ] 📝 Changelog update
* [ ] 🚦 Tests (or not relevant)
