### PR TITLE
Check for string size when upgrading

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ### Enhancements
 * UUID allowed as partition value ([#4500](https://github.com/realm/realm-core/issues/4500))
 * The error message when the intial steps of opening a Realm file fails is now more descriptive.
+* If a string with invalid size is encountered during file upgrade, the value is just discarded instead of breaking the upgrade completely.
 
 ### Fixed
 * <How to hit and notice issue? what was the impact?> ([#????](https://github.com/realm/realm-core/issues/????), since v?.?.?)

--- a/src/realm/table.cpp
+++ b/src/realm/table.cpp
@@ -1390,9 +1390,9 @@ Mixed get_val_from_column(size_t ndx, ColumnType col_type, bool nullable, BPlusT
             return Mixed{static_cast<BPlusTree<double>*>(accessor)->get(ndx)};
         case col_type_String: {
             auto str = static_cast<LegacyStringColumn*>(accessor)->get_legacy(ndx);
-            // This is a workaround for a bug where the length could be -1
+            // This is a workaround for a bug where the length could be wrong
             // Seen when upgrading very old file.
-            if (str.size() == size_t(-1)) {
+            if (str.size() > Table::max_string_size) {
                 return Mixed("");
             }
             return Mixed{str};


### PR DESCRIPTION
We have seen examples where the size of a string was reported bigger than max size. Perhaps better to just ignore that value instead of breaking the whole upgrade. Currently we don't have a way to signal that the conversion only succeeded partially.

## ☑️ ToDos
* [x] 📝 Changelog update
* [x] 🚦 Tests (or not relevant)
