### PR TITLE
Add support for constraining a query to a dictionary of links.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 # NEXT RELEASE
 
 ### Enhancements
-* None.
+* Added support for creating queries through a dictionary of links, in the same way of LnkLst and LnkSet. ([#4548](https://github.com/realm/realm-core/issues/4593))
 
 ### Fixed
 * <How to hit and notice issue? what was the impact?> ([#????](https://github.com/realm/realm-core/issues/????), since v?.?.?)

--- a/src/realm/collection.cpp
+++ b/src/realm/collection.cpp
@@ -22,12 +22,12 @@ size_t real2virtual(const std::vector<size_t>& vec, size_t ndx) noexcept
     return ndx - n;
 }
 
-void update_unresolved(std::vector<size_t>& vec, const BPlusTree<ObjKey>& tree)
+void update_unresolved(std::vector<size_t>& vec, const BPlusTree<ObjKey>* tree)
 {
     vec.clear();
 
     // Only do the scan if context flag is set.
-    if (tree.is_attached() && tree.get_context_flag()) {
+    if (tree && tree->is_attached() && tree->get_context_flag()) {
         auto func = [&vec](BPlusTreeNode* node, size_t offset) {
             auto leaf = static_cast<BPlusTree<ObjKey>::LeafNode*>(node);
             size_t sz = leaf->size();
@@ -40,22 +40,24 @@ void update_unresolved(std::vector<size_t>& vec, const BPlusTree<ObjKey>& tree)
             return false;
         };
 
-        tree.traverse(func);
+        tree->traverse(func);
     }
 }
 
-void check_for_last_unresolved(BPlusTree<ObjKey>& tree)
+void check_for_last_unresolved(BPlusTree<ObjKey>* tree)
 {
-    bool no_more_unresolved = true;
-    size_t sz = tree.size();
-    for (size_t n = 0; n < sz; n++) {
-        if (tree.get(n).is_unresolved()) {
-            no_more_unresolved = false;
-            break;
+    if (tree) {
+        bool no_more_unresolved = true;
+        size_t sz = tree->size();
+        for (size_t n = 0; n < sz; n++) {
+            if (tree->get(n).is_unresolved()) {
+                no_more_unresolved = false;
+                break;
+            }
         }
+        if (no_more_unresolved)
+            tree->set_context_flag(false);
     }
-    if (no_more_unresolved)
-        tree.set_context_flag(false);
 }
 
 } // namespace realm::_impl

--- a/src/realm/collection.hpp
+++ b/src/realm/collection.hpp
@@ -373,10 +373,10 @@ size_t virtual2real(const std::vector<size_t>& vec, size_t ndx) noexcept;
 size_t real2virtual(const std::vector<size_t>& vec, size_t ndx) noexcept;
 
 /// Rebuild the list of unresolved keys for tombstone handling.
-void update_unresolved(std::vector<size_t>& vec, const BPlusTree<ObjKey>& tree);
+void update_unresolved(std::vector<size_t>& vec, const BPlusTree<ObjKey>* tree);
 
 /// Clear the context flag on the tree if there are no more unresolved links.
-void check_for_last_unresolved(BPlusTree<ObjKey>& tree);
+void check_for_last_unresolved(BPlusTree<ObjKey>* tree);
 
 /// Proxy class needed because the ObjList interface clobbers method names from
 /// CollectionBase.
@@ -448,7 +448,7 @@ protected:
 
     /// Implementations should return a non-const reference to their internal
     /// `BPlusTree<T>`.
-    virtual BPlusTree<ObjKey>& get_mutable_tree() const = 0;
+    virtual BPlusTree<ObjKey>* get_mutable_tree() const = 0;
 
     /// Calls `do_init_from_parent()` and updates the list of unresolved links.
     bool init_from_parent() const final

--- a/src/realm/db.cpp
+++ b/src/realm/db.cpp
@@ -2681,11 +2681,15 @@ SetBasePtr Transaction::import_copy_of(const SetBase& original)
 
 CollectionBasePtr Transaction::import_copy_of(const CollectionBase& original)
 {
+    if (!&original)
+        return nullptr;
     if (Obj obj = import_copy_of(original.get_obj())) {
         ColKey ck = original.get_col_key();
         return obj.get_collection_ptr(ck);
     }
-    return {};
+    // return some empty collection where size() == 0
+    // the type shouldn't matter
+    return std::make_unique<LnkLst>();
 }
 
 LnkLstPtr Transaction::import_copy_of(const LnkLstPtr& original)

--- a/src/realm/db.cpp
+++ b/src/realm/db.cpp
@@ -2681,15 +2681,11 @@ SetBasePtr Transaction::import_copy_of(const SetBase& original)
 
 CollectionBasePtr Transaction::import_copy_of(const CollectionBase& original)
 {
-    if (!&original)
-        return nullptr;
     if (Obj obj = import_copy_of(original.get_obj())) {
         ColKey ck = original.get_col_key();
         return obj.get_collection_ptr(ck);
     }
-    // return some empty collection where size() == 0
-    // the type shouldn't matter
-    return std::make_unique<LnkLst>();
+    return {};
 }
 
 LnkLstPtr Transaction::import_copy_of(const LnkLstPtr& original)
@@ -2712,6 +2708,19 @@ LnkSetPtr Transaction::import_copy_of(const LnkSetPtr& original)
         return obj.get_linkset_ptr(ck);
     }
     return std::make_unique<LnkSet>();
+}
+
+CollectionBasePtr Transaction::import_copy_of(const CollectionBasePtr& original)
+{
+    if (!original)
+        return nullptr;
+    if (Obj obj = import_copy_of(original->get_obj())) {
+        ColKey ck = original->get_col_key();
+        return obj.get_collection_ptr(ck);
+    }
+    // return some empty collection where size() == 0
+    // the type shouldn't matter
+    return std::make_unique<LnkLst>();
 }
 
 std::unique_ptr<Query> Transaction::import_copy_of(Query& query, PayloadPolicy policy)

--- a/src/realm/db.hpp
+++ b/src/realm/db.hpp
@@ -603,7 +603,7 @@ public:
     LstBasePtr import_copy_of(const LstBase& original);
     SetBasePtr import_copy_of(const SetBase& original);
     CollectionBasePtr import_copy_of(const CollectionBase& original);
-    LnkLstPtr import_copy_of(const LnkLstPtr& original);
+    LnkLstPtr import_copy_of(const LnkLstPtr& original); // FIXME: remove these?
     LnkSetPtr import_copy_of(const LnkSetPtr& original);
 
     // handover of the heavier Query and TableView

--- a/src/realm/db.hpp
+++ b/src/realm/db.hpp
@@ -603,8 +603,9 @@ public:
     LstBasePtr import_copy_of(const LstBase& original);
     SetBasePtr import_copy_of(const SetBase& original);
     CollectionBasePtr import_copy_of(const CollectionBase& original);
-    LnkLstPtr import_copy_of(const LnkLstPtr& original); // FIXME: remove these?
+    LnkLstPtr import_copy_of(const LnkLstPtr& original);
     LnkSetPtr import_copy_of(const LnkSetPtr& original);
+    CollectionBasePtr import_copy_of(const CollectionBasePtr& original);
 
     // handover of the heavier Query and TableView
     std::unique_ptr<Query> import_copy_of(Query&, PayloadPolicy);

--- a/src/realm/dictionary.cpp
+++ b/src/realm/dictionary.cpp
@@ -801,4 +801,45 @@ auto Dictionary::Iterator::operator*() const -> value_type
     return std::make_pair(key, values.get(m_state.m_current_index));
 }
 
+
+/************************* DictionaryLinkValues *************************/
+
+DictionaryLinkValues::DictionaryLinkValues(const Obj& obj, ColKey col_key)
+    : m_source(obj, col_key)
+{
+    REALM_ASSERT_EX(col_key.get_type() == col_type_Link, col_key.get_type());
+}
+
+DictionaryLinkValues::DictionaryLinkValues(const Dictionary& source)
+    : m_source(source)
+{
+    REALM_ASSERT_EX(source.get_value_data_type() == type_Link, source.get_value_data_type());
+}
+
+ObjKey DictionaryLinkValues::get_key(size_t ndx) const
+{
+    Mixed val = m_source.get_any(ndx);
+    if (val.is_type(type_Link)) {
+        return val.get<ObjKey>();
+    }
+    return {};
+}
+
+// In contrast to a link list and a link set, a dictionary can contain null links.
+// This is because the corresponding key may contain useful information by itself.
+bool DictionaryLinkValues::is_obj_valid(size_t ndx) const noexcept
+{
+    Mixed val = m_source.get_any(ndx);
+    return val.is_type(type_Link);
+}
+
+Obj DictionaryLinkValues::get_object(size_t row_ndx) const
+{
+    Mixed val = m_source.get_any(row_ndx);
+    if (val.is_type(type_Link)) {
+        return get_target_table()->get_object(val.get<ObjKey>());
+    }
+    return {};
+}
+
 } // namespace realm

--- a/src/realm/dictionary.hpp
+++ b/src/realm/dictionary.hpp
@@ -293,7 +293,12 @@ public:
     }
     BPlusTree<ObjKey>* get_mutable_tree() const
     {
-        // FIXME: check if this is actually needed.
+        // We are faking being an ObjList because the underlying storage is not
+        // actually a BPlusTree<ObjKey> for dictionaries it is all mixed values.
+        // But this is ok, because we don't need to deal with unresolved link
+        // maintenance because they are not hidden from view in dictionaries in
+        // the same way as for LnkSet and LnkLst. This means that the functions
+        // that call get_mutable_tree do not need to do anything for dictionaries.
         return nullptr;
     }
 

--- a/src/realm/dictionary.hpp
+++ b/src/realm/dictionary.hpp
@@ -157,6 +157,7 @@ public:
 
 private:
     friend class DictionaryAggregate;
+    friend class DictionaryLinkValues;
     mutable DictionaryClusterTree* m_clusters = nullptr;
     DataType m_key_type = type_String;
 
@@ -203,6 +204,103 @@ private:
 
     Iterator(const Dictionary* dict, size_t pos);
 };
+
+// An interface used when the value type of the dictionary consists of
+// links to a single table. Implementation of the ObjList interface on
+// top of a Dictionary of objects. This is the dictionary equivilent of
+// LnkLst and LnkSet.
+class DictionaryLinkValues final : public ObjCollectionBase<CollectionBase> {
+public:
+    DictionaryLinkValues() = default;
+    DictionaryLinkValues(const Obj& obj, ColKey col_key);
+    DictionaryLinkValues(const Dictionary& source);
+
+    // Overrides of ObjList:
+    ObjKey get_key(size_t ndx) const final;
+    bool is_obj_valid(size_t ndx) const noexcept final;
+    Obj get_object(size_t row_ndx) const final;
+
+    // Overrides of CollectionBase, these simply forward to the underlying dictionary.
+    size_t size() const final
+    {
+        return m_source.size();
+    }
+    bool is_null(size_t ndx) const final
+    {
+        return m_source.is_null(ndx);
+    }
+    Mixed get_any(size_t ndx) const final
+    {
+        return m_source.get_any(ndx);
+    }
+    void clear() final
+    {
+        m_source.clear();
+    }
+    util::Optional<Mixed> min(size_t* return_ndx = nullptr) const final
+    {
+        return m_source.min(return_ndx);
+    }
+    util::Optional<Mixed> max(size_t* return_ndx = nullptr) const final
+    {
+        return m_source.max(return_ndx);
+    }
+    util::Optional<Mixed> sum(size_t* return_cnt = nullptr) const final
+    {
+        return m_source.sum(return_cnt);
+    }
+    util::Optional<Mixed> avg(size_t* return_cnt = nullptr) const final
+    {
+        return m_source.avg(return_cnt);
+    }
+    std::unique_ptr<CollectionBase> clone_collection() const final
+    {
+        return std::make_unique<DictionaryLinkValues>(m_source);
+    }
+    void sort(std::vector<size_t>& indices, bool ascending = true) const final
+    {
+        m_source.sort(indices, ascending);
+    }
+    void distinct(std::vector<size_t>& indices, util::Optional<bool> sort_order = util::none) const final
+    {
+        m_source.distinct(indices, sort_order);
+    }
+    size_t find_any(Mixed value) const final
+    {
+        return m_source.find_any(value);
+    }
+    const Obj& get_obj() const noexcept final
+    {
+        return m_source.get_obj();
+    }
+    ColKey get_col_key() const noexcept final
+    {
+        return m_source.get_col_key();
+    }
+    bool has_changed() const final
+    {
+        return m_source.has_changed();
+    }
+
+    // Overrides of ObjCollectionBase:
+    bool do_update_if_needed() const final
+    {
+        return m_source.update_if_needed();
+    }
+    bool do_init_from_parent() const final
+    {
+        return m_source.init_from_parent();
+    }
+    BPlusTree<ObjKey>* get_mutable_tree() const
+    {
+        // FIXME: check if this is actually needed.
+        return nullptr;
+    }
+
+private:
+    Dictionary m_source;
+};
+
 
 inline std::pair<Dictionary::Iterator, bool> Dictionary::insert(Mixed key, const Obj& obj)
 {

--- a/src/realm/list.cpp
+++ b/src/realm/list.cpp
@@ -181,7 +181,7 @@ void Lst<ObjKey>::do_set(size_t ndx, ObjKey target_key)
     }
     else if (old_key.is_unresolved()) {
         // We might have removed the last unresolved link - check it
-        _impl::check_for_last_unresolved(*m_tree);
+        _impl::check_for_last_unresolved(m_tree.get());
     }
 }
 
@@ -214,7 +214,7 @@ void Lst<ObjKey>::do_remove(size_t ndx)
     }
     if (old_key.is_unresolved()) {
         // We might have removed the last unresolved link - check it
-        _impl::check_for_last_unresolved(*m_tree);
+        _impl::check_for_last_unresolved(m_tree.get());
     }
 }
 

--- a/src/realm/list.hpp
+++ b/src/realm/list.hpp
@@ -387,9 +387,9 @@ private:
         return m_list.init_from_parent();
     }
 
-    BPlusTree<ObjKey>& get_mutable_tree() const final
+    BPlusTree<ObjKey>* get_mutable_tree() const final
     {
-        return *m_list.m_tree;
+        return m_list.m_tree.get();
     }
 };
 
@@ -897,7 +897,7 @@ inline util::Optional<Mixed> LnkLst::avg(size_t* return_cnt) const
 
 inline std::unique_ptr<CollectionBase> LnkLst::clone_collection() const
 {
-    return get_obj().get_linklist_ptr(get_col_key());
+    return clone_linklist();
 }
 
 inline void LnkLst::sort(std::vector<size_t>& indices, bool ascending) const

--- a/src/realm/obj.hpp
+++ b/src/realm/obj.hpp
@@ -58,6 +58,7 @@ using LnkSetPtr = std::unique_ptr<LnkSet>;
 template <class>
 class Set;
 class Dictionary;
+class DictionaryLinkValues;
 using DictionaryPtr = std::unique_ptr<Dictionary>;
 
 enum JSONOutputMode {

--- a/src/realm/object-store/results.cpp
+++ b/src/realm/object-store/results.cpp
@@ -961,6 +961,11 @@ Query Results::do_get_query() const
                 return m_table->where(*list);
             if (auto set = dynamic_cast<LnkSet*>(m_collection.get()))
                 return m_table->where(*set);
+            if (auto dict = dynamic_cast<Dictionary*>(m_collection.get())) {
+                if (dict->get_value_data_type() == type_Link) {
+                    return m_table->where(*dict);
+                }
+            }
             return m_query;
         case Mode::Table:
             return m_table->where();

--- a/src/realm/query.cpp
+++ b/src/realm/query.cpp
@@ -59,9 +59,9 @@ Query::Query(ConstTableRef table, const LnkSet& set)
     create();
 }
 
-Query::Query(ConstTableRef table, const Dictionary& dict_of_links)
+Query::Query(ConstTableRef table, const DictionaryLinkValues& dict_of_links)
     : m_table(table.cast_away_const())
-    , m_source_collection(std::make_unique<DictionaryLinkValues>(dict_of_links))
+    , m_source_collection(dict_of_links.clone_collection())
 {
     m_view = dynamic_cast<ObjList*>(m_source_collection.get());
     REALM_ASSERT_DEBUG(m_view);
@@ -188,8 +188,8 @@ Query::Query(const Query* source, Transaction* tr, PayloadPolicy policy)
     else {
         // nothing?
     }
-    if (source->m_source_collection.get()) {
-        m_source_collection = tr->import_copy_of(*source->m_source_collection);
+    if (source->m_source_collection) {
+        m_source_collection = tr->import_copy_of(source->m_source_collection);
         m_view = dynamic_cast<ObjList*>(m_source_collection.get());
         REALM_ASSERT_DEBUG(m_view);
     }

--- a/src/realm/query.hpp
+++ b/src/realm/query.hpp
@@ -87,6 +87,7 @@ public:
     Query(ConstTableRef table, std::unique_ptr<ConstTableView>);
     Query(ConstTableRef table, const LnkLst& list);
     Query(ConstTableRef table, const LnkSet& set);
+    Query(ConstTableRef table, const Dictionary& dict_of_links);
     Query(ConstTableRef table, LnkLstPtr&& list);
     Query(ConstTableRef table, LnkSetPtr&& set);
     Query();
@@ -395,8 +396,7 @@ private:
     ObjList* m_view = nullptr;
 
     // At most one of these can be non-zero, and if so the non-zero one indicates the restricting view.
-    LnkLstPtr m_source_link_list;                  // link lists are owned by the query.
-    LnkSetPtr m_source_link_set;                   // link sets are owned by the query.
+    std::unique_ptr<CollectionBase> m_source_collection; // collections are owned by the query.
     ConstTableView* m_source_table_view = nullptr; // table views are not refcounted, and not owned by the query.
     std::unique_ptr<ConstTableView> m_owned_source_table_view; // <--- except when indicated here
     std::shared_ptr<DescriptorOrdering> m_ordering;

--- a/src/realm/query.hpp
+++ b/src/realm/query.hpp
@@ -87,7 +87,7 @@ public:
     Query(ConstTableRef table, std::unique_ptr<ConstTableView>);
     Query(ConstTableRef table, const LnkLst& list);
     Query(ConstTableRef table, const LnkSet& set);
-    Query(ConstTableRef table, const Dictionary& dict_of_links);
+    Query(ConstTableRef table, const DictionaryLinkValues& dict_of_links);
     Query(ConstTableRef table, LnkLstPtr&& list);
     Query(ConstTableRef table, LnkSetPtr&& set);
     Query();
@@ -391,11 +391,15 @@ private:
     TableRef m_table;
 
     // points to the base class of the restricting view. If the restricting
-    // view is a link view, m_source_link_list is non-zero. If it is a table view,
+    // view is a link view, m_source_collection is non-zero. If it is a table view,
     // m_source_table_view is non-zero.
     ObjList* m_view = nullptr;
 
     // At most one of these can be non-zero, and if so the non-zero one indicates the restricting view.
+    //
+    // m_source_collection is a pointer to a collection which must also be a ObjList*
+    // this includes: LnkLst, LnkSet, and DictionaryLinkValues. It cannot be a list of primitives because
+    // it is used to populate a query through a collection of objects and there are asserts for this.
     std::unique_ptr<CollectionBase> m_source_collection; // collections are owned by the query.
     ConstTableView* m_source_table_view = nullptr; // table views are not refcounted, and not owned by the query.
     std::unique_ptr<ConstTableView> m_owned_source_table_view; // <--- except when indicated here

--- a/src/realm/query_engine.cpp
+++ b/src/realm/query_engine.cpp
@@ -69,6 +69,7 @@ size_t ParentNode::find_first(size_t start, size_t end)
 template <class T>
 inline bool Obj::evaluate(T func) const
 {
+    REALM_ASSERT(is_valid());
     Cluster cluster(0, get_alloc(), m_table->m_clusters);
     cluster.init(m_mem);
     cluster.set_offset(m_key.value - cluster.get_key_value(m_row_ndx));

--- a/src/realm/set.cpp
+++ b/src/realm/set.cpp
@@ -150,7 +150,7 @@ void Set<ObjKey>::do_erase(size_t ndx)
 
         // FIXME: Exploit the fact that the values are sorted and unresolved
         // keys have a negative value.
-        _impl::check_for_last_unresolved(*m_tree);
+        _impl::check_for_last_unresolved(m_tree.get());
     }
 }
 

--- a/src/realm/set.hpp
+++ b/src/realm/set.hpp
@@ -328,9 +328,9 @@ private:
         return m_set.init_from_parent();
     }
 
-    BPlusTree<ObjKey>& get_mutable_tree() const final
+    BPlusTree<ObjKey>* get_mutable_tree() const final
     {
-        return *m_set.m_tree;
+        return m_set.m_tree.get();
     }
 };
 

--- a/src/realm/table.hpp
+++ b/src/realm/table.hpp
@@ -543,6 +543,12 @@ public:
         return Query(m_own_ref, set);
     }
 
+    // Perform queries on a Dictionary containing values of links to a single table.
+    Query where(const Dictionary& dictionary_of_links) const
+    {
+        return Query(m_own_ref, dictionary_of_links);
+    }
+
     Query query(const std::string& query_string, const std::vector<Mixed>& arguments = {}) const;
     Query query(const std::string& query_string, const std::vector<Mixed>& arguments,
                 const query_parser::KeyPathMapping& mapping) const;

--- a/src/realm/table.hpp
+++ b/src/realm/table.hpp
@@ -544,7 +544,7 @@ public:
     }
 
     // Perform queries on a Dictionary containing values of links to a single table.
-    Query where(const Dictionary& dictionary_of_links) const
+    Query where(const DictionaryLinkValues& dictionary_of_links) const
     {
         return Query(m_own_ref, dictionary_of_links);
     }

--- a/test/object-store/dictionary.cpp
+++ b/test/object-store/dictionary.cpp
@@ -772,7 +772,6 @@ TEMPLATE_TEST_CASE("dictionary of objects", "[dictionary][links]", cf::MixedVal,
                    cf::UnboxedOptional<cf::Decimal>)
 {
     using T = typename TestType::Type;
-    using Boxed = typename TestType::Boxed;
     using W = typename TestType::Wrapped;
     InMemoryTestFile config;
     config.cache = false;

--- a/test/object-store/dictionary.cpp
+++ b/test/object-store/dictionary.cpp
@@ -764,6 +764,92 @@ TEST_CASE("embedded dictionary", "[dictionary]") {
     }
 }
 
+TEMPLATE_TEST_CASE("dictionary of objects", "[dictionary][links]", cf::MixedVal, cf::Int, cf::Bool, cf::Float,
+                   cf::Double, cf::String, cf::Binary, cf::Date, cf::OID, cf::Decimal, cf::UUID,
+                   cf::BoxedOptional<cf::Int>, cf::BoxedOptional<cf::Bool>, cf::BoxedOptional<cf::Float>,
+                   cf::BoxedOptional<cf::Double>, cf::BoxedOptional<cf::OID>, cf::BoxedOptional<cf::UUID>,
+                   cf::UnboxedOptional<cf::String>, cf::UnboxedOptional<cf::Binary>, cf::UnboxedOptional<cf::Date>,
+                   cf::UnboxedOptional<cf::Decimal>)
+{
+    using T = typename TestType::Type;
+    using Boxed = typename TestType::Boxed;
+    using W = typename TestType::Wrapped;
+    InMemoryTestFile config;
+    config.cache = false;
+    config.automatic_change_notifications = false;
+    config.schema = Schema{
+        {"object", {{"links", PropertyType::Dictionary | PropertyType::Object | PropertyType::Nullable, "target"}}},
+        {"target", {{"value", TestType::property_type()}}},
+    };
+
+    auto r = Realm::get_shared_realm(config);
+    auto table = r->read_group().get_table("class_object");
+    auto target = r->read_group().get_table("class_target");
+    r->begin_transaction();
+    Obj obj = table->create_object();
+    Obj obj1 = table->create_object(); // empty dictionary
+    Obj empty_target = target->create_object();
+    ColKey col_links = table->get_column_key("links");
+    ColKey col_target_value = target->get_column_key("value");
+
+    object_store::Dictionary dict(r, obj, col_links);
+    auto keys_as_results = dict.get_keys();
+    auto values_as_results = dict.get_values();
+
+    auto values = TestType::values();
+    std::vector<std::string> keys;
+    for (size_t i = 0; i < values.size(); ++i) {
+        keys.push_back(util::format("key_%1", i));
+    }
+
+    for (size_t i = 0; i < values.size(); ++i) {
+        Obj target_obj = target->create_object().set(col_target_value, T(values[i]));
+        dict.insert(keys[i], target_obj);
+    }
+
+    SECTION("min()") {
+        if (!TestType::can_minmax()) {
+            REQUIRE_THROWS_AS(values_as_results.min(col_target_value), Results::UnsupportedColumnTypeException);
+            return;
+        }
+        REQUIRE(Mixed(TestType::min()) == values_as_results.min(col_target_value));
+        dict.remove_all();
+        REQUIRE(!values_as_results.min(col_target_value));
+    }
+
+    SECTION("max()") {
+        if (!TestType::can_minmax()) {
+            REQUIRE_THROWS_AS(values_as_results.max(col_target_value), Results::UnsupportedColumnTypeException);
+            return;
+        }
+        REQUIRE(Mixed(TestType::max()) == values_as_results.max(col_target_value));
+        dict.remove_all();
+        REQUIRE(!values_as_results.max(col_target_value));
+    }
+
+    SECTION("sum()") {
+        if (!TestType::can_sum()) {
+            REQUIRE_THROWS_AS(values_as_results.sum(col_target_value), Results::UnsupportedColumnTypeException);
+            return;
+        }
+        REQUIRE(cf::get<W>(*values_as_results.sum(col_target_value)) == TestType::sum());
+        dict.remove_all();
+        REQUIRE(values_as_results.sum(col_target_value) == 0);
+    }
+
+    SECTION("average()") {
+        if (!TestType::can_average()) {
+            REQUIRE_THROWS_AS(values_as_results.average(col_target_value), Results::UnsupportedColumnTypeException);
+            return;
+        }
+        REQUIRE(cf::get<typename TestType::AvgType>(*values_as_results.average(col_target_value)) ==
+                TestType::average());
+        dict.remove_all();
+        REQUIRE(!values_as_results.average(col_target_value));
+    }
+}
+
+
 TEST_CASE("dictionary with mixed links", "[dictionary]") {
     InMemoryTestFile config;
     config.cache = false;

--- a/test/test_dictionary.cpp
+++ b/test/test_dictionary.cpp
@@ -418,15 +418,19 @@ TEST(Dictionary_Tombstones)
     Group g;
     auto foos = g.add_table_with_primary_key("class_Foo", type_Int, "id");
     auto bars = g.add_table_with_primary_key("class_Bar", type_String, "id");
-    ColKey col_dict = foos->add_column_dictionary(type_Mixed, "dict");
+    auto col_int = bars->add_column(type_Int, "value");
+    ColKey col_dict = foos->add_column_dictionary(*bars, "dict");
 
     auto foo = foos->create_object_with_primary_key(123);
-    auto a = bars->create_object_with_primary_key("a");
-    auto b = bars->create_object_with_primary_key("b");
+    auto a = bars->create_object_with_primary_key("a").set(col_int, 1);
+    auto b = bars->create_object_with_primary_key("b").set(col_int, 2);
 
     auto dict = foo.get_dictionary(col_dict);
     dict.insert("a", a);
     dict.insert("b", b);
+
+    auto q = bars->where(dict).equal(col_int, 1);
+    CHECK_EQUAL(q.count(), 1);
 
     a.invalidate();
 
@@ -434,4 +438,6 @@ TEST(Dictionary_Tombstones)
     CHECK((*dict.find("a")).second.is_unresolved_link());
 
     CHECK(dict.find("b") != dict.end());
+
+    CHECK_EQUAL(q.count(), 0);
 }

--- a/test/test_query2.cpp
+++ b/test/test_query2.cpp
@@ -2680,7 +2680,75 @@ TEST(Query_LinkCounts)
     CHECK_EQUAL(k1, match);
 }
 
-TEST(Query_Link_Minimum)
+struct TestLinkList {
+    ColKey add_link_column(TableRef source, TableRef dest)
+    {
+        return source->add_column_list(*dest, "linklist");
+    }
+    void create_object_with_links(TableRef table, ColKey col, std::vector<ObjKey> links)
+    {
+        LnkLst ll = table->create_object().get_linklist(col);
+        for (auto link : links) {
+            ll.add(link);
+        }
+    }
+    void add_links_to(TableRef table, ColKey col, ObjKey obj, std::vector<ObjKey> links)
+    {
+        LnkLst ll = table->get_object(obj).get_linklist(col);
+        for (auto link : links) {
+            ll.add(link);
+        }
+    }
+};
+
+
+struct TestLinkSet {
+    ColKey add_link_column(TableRef source, TableRef dest)
+    {
+        return source->add_column_set(*dest, "linkset");
+    }
+    void create_object_with_links(TableRef table, ColKey col, std::vector<ObjKey> links)
+    {
+        LnkSet ls = table->create_object().get_linkset(col);
+        for (auto link : links) {
+            ls.insert(link);
+        }
+    }
+    void add_links_to(TableRef table, ColKey col, ObjKey obj, std::vector<ObjKey> links)
+    {
+        LnkSet ls = table->get_object(obj).get_linkset(col);
+        for (auto link : links) {
+            ls.insert(link);
+        }
+    }
+};
+
+struct TestDictionaryLinkValues {
+    ColKey add_link_column(TableRef source, TableRef dest)
+    {
+        return source->add_column_dictionary(*dest, "linkdictionary");
+    }
+    void create_object_with_links(TableRef table, ColKey col, std::vector<ObjKey> links)
+    {
+        Dictionary dict = table->create_object().get_dictionary(col);
+        for (auto link : links) {
+            std::string key = util::format("key_%1", keys_added++);
+            dict.insert(Mixed(StringData(key)), Mixed(link));
+        }
+    }
+    void add_links_to(TableRef table, ColKey col, ObjKey obj, std::vector<ObjKey> links)
+    {
+        Dictionary dict = table->get_object(obj).get_dictionary(col);
+        for (auto link : links) {
+            std::string key = util::format("key_%1", keys_added++);
+            dict.insert(Mixed(StringData(key)), Mixed(link));
+        }
+    }
+
+    size_t keys_added = 0;
+};
+
+TEST_TYPES(Query_Link_Container_Minimum, TestLinkList, TestLinkSet, TestDictionaryLinkValues)
 {
     Group group;
     TableRef table1 = group.add_table("table1");
@@ -2699,8 +2767,9 @@ TEST(Query_Link_Minimum)
     auto k2 = table1->create_object().set_all(123, 123.f, 123.).get_key();
     auto k3 = table1->create_object().get_key();
 
+    TEST_TYPE test_container;
     TableRef table2 = group.add_table("table2");
-    auto col_linklist = table2->add_column_list(*table1, "linklist");
+    ColKey col_linktest = test_container.add_link_column(table2, table1);
 
     // table2
     // 0: { }
@@ -2708,143 +2777,54 @@ TEST(Query_Link_Minimum)
     // 2: { 1, 2 }
     // 3: { 1, 2, 3 }
 
-    LnkLst ll;
-    table2->create_object();
-    ll = table2->create_object().get_linklist(col_linklist);
-    ll.add(k1);
-    ll = table2->create_object().get_linklist(col_linklist);
-    ll.add(k1);
-    ll.add(k2);
-    ll = table2->create_object().get_linklist(col_linklist);
-    ll.add(k1);
-    ll.add(k2);
-    ll.add(k3);
+    test_container.create_object_with_links(table2, col_linktest, {});
+    test_container.create_object_with_links(table2, col_linktest, {k1});
+    test_container.create_object_with_links(table2, col_linktest, {k1, k2});
+    test_container.create_object_with_links(table2, col_linktest, {k1, k2, k3});
 
     Query q;
     TableView tv;
 
-    q = table2->column<Link>(col_linklist).column<Int>(col_int).min() == 123;
+    q = table2->column<Link>(col_linktest).column<Int>(col_int).min() == 123;
     tv = q.find_all();
     CHECK_EQUAL(tv.size(), 2);
     CHECK_EQUAL(k2, tv.get_key(0));
     CHECK_EQUAL(k3, tv.get_key(1));
 
-    q = table2->column<Link>(col_linklist).column<Int>(col_int).min() == 456;
+    q = table2->column<Link>(col_linktest).column<Int>(col_int).min() == 456;
     tv = q.find_all();
     CHECK_EQUAL(tv.size(), 1);
     CHECK_EQUAL(k1, tv.get_key(0));
 
-    q = table2->column<Link>(col_linklist).column<Int>(col_int).min() == null();
+    q = table2->column<Link>(col_linktest).column<Int>(col_int).min() == null();
     tv = q.find_all();
     CHECK_EQUAL(tv.size(), 1);
     CHECK_EQUAL(k0, tv.get_key(0));
 
-    q = table2->column<Link>(col_linklist).column<Float>(col_float).min() == 123.0f;
+    q = table2->column<Link>(col_linktest).column<Float>(col_float).min() == 123.0f;
     tv = q.find_all();
     CHECK_EQUAL(tv.size(), 2);
     CHECK_EQUAL(k2, tv.get_key(0));
     CHECK_EQUAL(k3, tv.get_key(1));
 
-    q = table2->column<Link>(col_linklist).column<Float>(col_float).min() == 456.0f;
+    q = table2->column<Link>(col_linktest).column<Float>(col_float).min() == 456.0f;
     tv = q.find_all();
     CHECK_EQUAL(tv.size(), 1);
     CHECK_EQUAL(k1, tv.get_key(0));
 
-    q = table2->column<Link>(col_linklist).column<Double>(col_double).min() == 123.0;
+    q = table2->column<Link>(col_linktest).column<Double>(col_double).min() == 123.0;
     tv = q.find_all();
     CHECK_EQUAL(tv.size(), 2);
     CHECK_EQUAL(k2, tv.get_key(0));
     CHECK_EQUAL(k3, tv.get_key(1));
 
-    q = table2->column<Link>(col_linklist).column<Double>(col_double).min() == 456.0;
+    q = table2->column<Link>(col_linktest).column<Double>(col_double).min() == 456.0;
     tv = q.find_all();
     CHECK_EQUAL(tv.size(), 1);
     CHECK_EQUAL(k1, tv.get_key(0));
 }
 
-TEST(Query_Link_Minimum_Set)
-{
-    Group group;
-    TableRef table1 = group.add_table("table1");
-    auto col_int = table1->add_column(type_Int, "int", /* nullable */ true);
-    auto col_float = table1->add_column(type_Float, "float", /* nullable */ true);
-    auto col_double = table1->add_column(type_Double, "double", /* nullable */ true);
-
-    // table1
-    // 0: 789 789.0f 789.0
-    // 1: 456 456.0f 456.0
-    // 2: 123 123.0f 123.0
-    // 3: null null null
-
-    auto k0 = table1->create_object().set_all(789, 789.f, 789.).get_key();
-    auto k1 = table1->create_object().set_all(456, 456.f, 456.).get_key();
-    auto k2 = table1->create_object().set_all(123, 123.f, 123.).get_key();
-    auto k3 = table1->create_object().get_key();
-
-    TableRef table2 = group.add_table("table2");
-    auto col_linkset = table2->add_column_set(*table1, "linkset");
-
-    // table2
-    // 0: { }
-    // 1: { 1 }
-    // 2: { 1, 2 }
-    // 3: { 1, 2, 3 }
-
-    LnkSet ll;
-    table2->create_object();
-    ll = table2->create_object().get_linkset(col_linkset);
-    ll.insert(k1);
-    ll = table2->create_object().get_linkset(col_linkset);
-    ll.insert(k1);
-    ll.insert(k2);
-    ll = table2->create_object().get_linkset(col_linkset);
-    ll.insert(k1);
-    ll.insert(k2);
-    ll.insert(k3);
-
-    Query q;
-    TableView tv;
-
-    q = table2->column<Link>(col_linkset).column<Int>(col_int).min() == 123;
-    tv = q.find_all();
-    CHECK_EQUAL(tv.size(), 2);
-    CHECK_EQUAL(k2, tv.get_key(0));
-    CHECK_EQUAL(k3, tv.get_key(1));
-
-    q = table2->column<Link>(col_linkset).column<Int>(col_int).min() == 456;
-    tv = q.find_all();
-    CHECK_EQUAL(tv.size(), 1);
-    CHECK_EQUAL(k1, tv.get_key(0));
-
-    q = table2->column<Link>(col_linkset).column<Int>(col_int).min() == null();
-    tv = q.find_all();
-    CHECK_EQUAL(tv.size(), 1);
-    CHECK_EQUAL(k0, tv.get_key(0));
-
-    q = table2->column<Link>(col_linkset).column<Float>(col_float).min() == 123.0f;
-    tv = q.find_all();
-    CHECK_EQUAL(tv.size(), 2);
-    CHECK_EQUAL(k2, tv.get_key(0));
-    CHECK_EQUAL(k3, tv.get_key(1));
-
-    q = table2->column<Link>(col_linkset).column<Float>(col_float).min() == 456.0f;
-    tv = q.find_all();
-    CHECK_EQUAL(tv.size(), 1);
-    CHECK_EQUAL(k1, tv.get_key(0));
-
-    q = table2->column<Link>(col_linkset).column<Double>(col_double).min() == 123.0;
-    tv = q.find_all();
-    CHECK_EQUAL(tv.size(), 2);
-    CHECK_EQUAL(k2, tv.get_key(0));
-    CHECK_EQUAL(k3, tv.get_key(1));
-
-    q = table2->column<Link>(col_linkset).column<Double>(col_double).min() == 456.0;
-    tv = q.find_all();
-    CHECK_EQUAL(tv.size(), 1);
-    CHECK_EQUAL(k1, tv.get_key(0));
-}
-
-TEST(Query_Link_MaximumSumAverage)
+TEST_TYPES(Query_Link_MaximumSumAverage, TestLinkList, TestLinkSet, TestDictionaryLinkValues)
 {
     Group group;
     TableRef table1 = group.add_table("table1");
@@ -2865,10 +2845,11 @@ TEST(Query_Link_MaximumSumAverage)
     (++it)->set_all(456, 456.f, 456.);
     (++it)->set_all(789, 789.f, 789.);
 
+    TEST_TYPE test_container;
     TableRef table2 = group.add_table("table2");
     auto col_double = table2->add_column(type_Double, "double");
     auto col_link = table2->add_column(*table1, "link");
-    auto col_linklist = table2->add_column_list(*table1, "linklist");
+    ColKey col_linktest = test_container.add_link_column(table2, table1);
 
     // table2
     // 0: 456.0 ->0 { }
@@ -2876,73 +2857,68 @@ TEST(Query_Link_MaximumSumAverage)
     // 2: 456.0 ->2 { 1, 2 }
     // 3: 456.0 ->3 { 1, 2, 3 }
 
-    LnkLst ll;
     auto k0 = table2->create_object().set_all(456.0, keys[0]).get_key();
     auto k1 = table2->create_object().set_all(456.0, keys[1]).get_key();
     auto k2 = table2->create_object().set_all(456.0, keys[2]).get_key();
     auto k3 = table2->create_object().set_all(456.0, keys[3]).get_key();
-    ll = table2->get_object(k1).get_linklist(col_linklist);
-    ll.add(keys[1]);
-    ll = table2->get_object(k2).get_linklist(col_linklist);
-    ll.add(keys[1]);
-    ll.add(keys[2]);
-    ll = table2->get_object(k3).get_linklist(col_linklist);
-    ll.add(keys[1]);
-    ll.add(keys[2]);
-    ll.add(keys[3]);
+
+    test_container.add_links_to(table2, col_linktest, k0, {});
+    test_container.add_links_to(table2, col_linktest, k1, {keys[1]});
+    test_container.add_links_to(table2, col_linktest, k2, {keys[1], keys[2]});
+    test_container.add_links_to(table2, col_linktest, k3, {keys[1], keys[2], keys[3]});
 
     Query q;
     TableView tv;
 
     // Maximum.
 
-    q = table2->column<Link>(col_linklist).column<Int>(col_int).max() == 789;
+    q = table2->column<Link>(col_linktest).column<Int>(col_int).max() == 789;
     tv = q.find_all();
     CHECK_EQUAL(tv.size(), 2);
     CHECK_EQUAL(k2, tv.get_key(0));
     CHECK_EQUAL(k3, tv.get_key(1));
 
-    q = table2->column<Link>(col_linklist).column<Int>(col_int).max() == 456;
+    q = table2->column<Link>(col_linktest).column<Int>(col_int).max() == 456;
     tv = q.find_all();
     CHECK_EQUAL(tv.size(), 1);
     CHECK_EQUAL(k1, tv.get_key(0));
 
-    q = table2->column<Link>(col_linklist).column<Int>(col_int).max() == null();
+    q = table2->column<Link>(col_linktest).column<Int>(col_int).max() == null();
     tv = q.find_all();
     CHECK_EQUAL(tv.size(), 1);
     CHECK_EQUAL(k0, tv.get_key(0));
 
-    q = table2->column<Link>(col_linklist).column<Int>(col_int).max() == table2->link(col_link).column<Int>(col_int);
+    q = table2->column<Link>(col_linktest).column<Int>(col_int).max() == table2->link(col_link).column<Int>(col_int);
     tv = q.find_all();
     CHECK_EQUAL(tv.size(), 2);
     CHECK_EQUAL(k1, tv.get_key(0));
     CHECK_EQUAL(k2, tv.get_key(1));
 
-    q = table2->column<Link>(col_linklist).column<Int>(col_int).max() == table2->column<Double>(col_double);
+    q = table2->column<Link>(col_linktest).column<Int>(col_int).max() == table2->column<Double>(col_double);
     tv = q.find_all();
     CHECK_EQUAL(tv.size(), 1);
     CHECK_EQUAL(k1, tv.get_key(0));
 
 
-    q = table2->column<Link>(col_linklist).column<Float>(col_flt).max() == 789.0f;
+    q = table2->column<Link>(col_linktest).column<Float>(col_flt).max() == 789.0f;
     tv = q.find_all();
     CHECK_EQUAL(tv.size(), 2);
     CHECK_EQUAL(k2, tv.get_key(0));
     CHECK_EQUAL(k3, tv.get_key(1));
 
-    q = table2->column<Link>(col_linklist).column<Float>(col_flt).max() == 456.0f;
+    q = table2->column<Link>(col_linktest).column<Float>(col_flt).max() == 456.0f;
     tv = q.find_all();
     CHECK_EQUAL(tv.size(), 1);
     CHECK_EQUAL(k1, tv.get_key(0));
 
 
-    q = table2->column<Link>(col_linklist).column<Double>(col_dbl).max() == 789.0;
+    q = table2->column<Link>(col_linktest).column<Double>(col_dbl).max() == 789.0;
     tv = q.find_all();
     CHECK_EQUAL(tv.size(), 2);
     CHECK_EQUAL(k2, tv.get_key(0));
     CHECK_EQUAL(k3, tv.get_key(1));
 
-    q = table2->column<Link>(col_linklist).column<Double>(col_dbl).max() == 456.0;
+    q = table2->column<Link>(col_linktest).column<Double>(col_dbl).max() == 456.0;
     tv = q.find_all();
     CHECK_EQUAL(tv.size(), 1);
     CHECK_EQUAL(k1, tv.get_key(0));
@@ -2952,47 +2928,47 @@ TEST(Query_Link_MaximumSumAverage)
     // Floating point results below may be inexact for some combination of architectures, compilers, and compiler
     // flags.
 
-    q = table2->column<Link>(col_linklist).column<Int>(col_int).sum() == 1245;
+    q = table2->column<Link>(col_linktest).column<Int>(col_int).sum() == 1245;
     tv = q.find_all();
     CHECK_EQUAL(tv.size(), 2);
     CHECK_EQUAL(k2, tv.get_key(0));
     CHECK_EQUAL(k3, tv.get_key(1));
 
-    q = table2->column<Link>(col_linklist).column<Int>(col_int).sum() == 456;
+    q = table2->column<Link>(col_linktest).column<Int>(col_int).sum() == 456;
     tv = q.find_all();
     CHECK_EQUAL(tv.size(), 1);
     CHECK_EQUAL(k1, tv.get_key(0));
 
-    q = table2->column<Link>(col_linklist).column<Int>(col_int).sum() == table2->link(col_link).column<Int>(col_int);
+    q = table2->column<Link>(col_linktest).column<Int>(col_int).sum() == table2->link(col_link).column<Int>(col_int);
     tv = q.find_all();
     CHECK_EQUAL(tv.size(), 1);
     CHECK_EQUAL(k1, tv.get_key(0));
 
-    q = table2->column<Link>(col_linklist).column<Int>(col_int).sum() == table2->column<Double>(col_double);
+    q = table2->column<Link>(col_linktest).column<Int>(col_int).sum() == table2->column<Double>(col_double);
     tv = q.find_all();
     CHECK_EQUAL(tv.size(), 1);
     CHECK_EQUAL(k1, tv.get_key(0));
 
 
-    q = table2->column<Link>(col_linklist).column<Float>(col_flt).sum() == 1245.0f;
+    q = table2->column<Link>(col_linktest).column<Float>(col_flt).sum() == 1245.0f;
     tv = q.find_all();
     CHECK_EQUAL(tv.size(), 2);
     CHECK_EQUAL(k2, tv.get_key(0));
     CHECK_EQUAL(k3, tv.get_key(1));
 
-    q = table2->column<Link>(col_linklist).column<Float>(col_flt).sum() == 456.0f;
+    q = table2->column<Link>(col_linktest).column<Float>(col_flt).sum() == 456.0f;
     tv = q.find_all();
     CHECK_EQUAL(tv.size(), 1);
     CHECK_EQUAL(k1, tv.get_key(0));
 
 
-    q = table2->column<Link>(col_linklist).column<Double>(col_dbl).sum() == 1245.0;
+    q = table2->column<Link>(col_linktest).column<Double>(col_dbl).sum() == 1245.0;
     tv = q.find_all();
     CHECK_EQUAL(tv.size(), 2);
     CHECK_EQUAL(k2, tv.get_key(0));
     CHECK_EQUAL(k3, tv.get_key(1));
 
-    q = table2->column<Link>(col_linklist).column<Double>(col_dbl).sum() == 456.0;
+    q = table2->column<Link>(col_linktest).column<Double>(col_dbl).sum() == 456.0;
     tv = q.find_all();
     CHECK_EQUAL(tv.size(), 1);
     CHECK_EQUAL(k1, tv.get_key(0));
@@ -3002,269 +2978,59 @@ TEST(Query_Link_MaximumSumAverage)
     // Floating point results below may be inexact for some combination of architectures, compilers, and compiler
     // flags.
 
-    q = table2->column<Link>(col_linklist).column<Int>(col_int).average() == 622.5;
+    q = table2->column<Link>(col_linktest).column<Int>(col_int).average() == 622.5;
     tv = q.find_all();
     CHECK_EQUAL(tv.size(), 2);
     CHECK_EQUAL(k2, tv.get_key(0));
     CHECK_EQUAL(k3, tv.get_key(1));
 
-    q = table2->column<Link>(col_linklist).column<Int>(col_int).average() == 456;
+    q = table2->column<Link>(col_linktest).column<Int>(col_int).average() == 456;
     tv = q.find_all();
     CHECK_EQUAL(tv.size(), 1);
     CHECK_EQUAL(k1, tv.get_key(0));
 
-    q = table2->column<Link>(col_linklist).column<Int>(col_int).average() == null();
+    q = table2->column<Link>(col_linktest).column<Int>(col_int).average() == null();
     tv = q.find_all();
     CHECK_EQUAL(tv.size(), 1);
     CHECK_EQUAL(k0, tv.get_key(0));
 
-    q = table2->column<Link>(col_linklist).column<Int>(col_int).average() <
+    q = table2->column<Link>(col_linktest).column<Int>(col_int).average() <
         table2->link(col_link).column<Int>(col_int);
     tv = q.find_all();
     CHECK_EQUAL(tv.size(), 1);
     CHECK_EQUAL(k2, tv.get_key(0));
 
-    q = table2->column<Link>(col_linklist).column<Int>(col_int).average() == table2->column<Double>(col_double);
+    q = table2->column<Link>(col_linktest).column<Int>(col_int).average() == table2->column<Double>(col_double);
     tv = q.find_all();
     CHECK_EQUAL(tv.size(), 1);
     CHECK_EQUAL(k1, tv.get_key(0));
 
 
-    q = table2->column<Link>(col_linklist).column<Float>(col_flt).average() == 622.5;
+    q = table2->column<Link>(col_linktest).column<Float>(col_flt).average() == 622.5;
     tv = q.find_all();
     CHECK_EQUAL(tv.size(), 2);
     CHECK_EQUAL(k2, tv.get_key(0));
     CHECK_EQUAL(k3, tv.get_key(1));
 
-    q = table2->column<Link>(col_linklist).column<Float>(col_flt).average() == 456.0f;
+    q = table2->column<Link>(col_linktest).column<Float>(col_flt).average() == 456.0f;
     tv = q.find_all();
     CHECK_EQUAL(tv.size(), 1);
     CHECK_EQUAL(k1, tv.get_key(0));
 
 
-    q = table2->column<Link>(col_linklist).column<Double>(col_dbl).average() == 622.5;
+    q = table2->column<Link>(col_linktest).column<Double>(col_dbl).average() == 622.5;
     tv = q.find_all();
     CHECK_EQUAL(tv.size(), 2);
     CHECK_EQUAL(k2, tv.get_key(0));
     CHECK_EQUAL(k3, tv.get_key(1));
 
-    q = table2->column<Link>(col_linklist).column<Double>(col_dbl).average() == 456.0;
+    q = table2->column<Link>(col_linktest).column<Double>(col_dbl).average() == 456.0;
     tv = q.find_all();
     CHECK_EQUAL(tv.size(), 1);
     CHECK_EQUAL(k1, tv.get_key(0));
 }
 
-TEST(Query_Link_MaximumSumAverage_Set)
-{
-    Group group;
-    TableRef table1 = group.add_table("table1");
-    auto col_int = table1->add_column(type_Int, "int", /* nullable */ true);
-    auto col_flt = table1->add_column(type_Float, "float", /* nullable */ true);
-    auto col_dbl = table1->add_column(type_Double, "double", /* nullable */ true);
-
-    // table1
-    // 0: 123 123.0f 123.0
-    // 1: 456 456.0f 456.0
-    // 2: 789 789.0f 789.0
-    // 3: null null null
-
-    ObjKeys keys({3, 5, 7, 9});
-    table1->create_objects(keys);
-    auto it = table1->begin();
-    it->set_all(123, 123.f, 123.);
-    (++it)->set_all(456, 456.f, 456.);
-    (++it)->set_all(789, 789.f, 789.);
-
-    TableRef table2 = group.add_table("table2");
-    auto col_double = table2->add_column(type_Double, "double");
-    auto col_link = table2->add_column(*table1, "link");
-    auto col_linkset = table2->add_column_set(*table1, "linkset");
-
-    // table2
-    // 0: 456.0 ->0 { }
-    // 1: 456.0 ->1 { 1 }
-    // 2: 456.0 ->2 { 1, 2 }
-    // 3: 456.0 ->3 { 1, 2, 3 }
-
-    LnkSet ll;
-    auto k0 = table2->create_object().set_all(456.0, keys[0]).get_key();
-    auto k1 = table2->create_object().set_all(456.0, keys[1]).get_key();
-    auto k2 = table2->create_object().set_all(456.0, keys[2]).get_key();
-    auto k3 = table2->create_object().set_all(456.0, keys[3]).get_key();
-    ll = table2->get_object(k1).get_linkset(col_linkset);
-    ll.insert(keys[1]);
-    ll = table2->get_object(k2).get_linkset(col_linkset);
-    ll.insert(keys[1]);
-    ll.insert(keys[2]);
-    ll = table2->get_object(k3).get_linkset(col_linkset);
-    ll.insert(keys[1]);
-    ll.insert(keys[2]);
-    ll.insert(keys[3]);
-
-    Query q;
-    TableView tv;
-
-    // Maximum.
-
-    q = table2->column<Link>(col_linkset).column<Int>(col_int).max() == 789;
-    tv = q.find_all();
-    CHECK_EQUAL(tv.size(), 2);
-    CHECK_EQUAL(k2, tv.get_key(0));
-    CHECK_EQUAL(k3, tv.get_key(1));
-
-    q = table2->column<Link>(col_linkset).column<Int>(col_int).max() == 456;
-    tv = q.find_all();
-    CHECK_EQUAL(tv.size(), 1);
-    CHECK_EQUAL(k1, tv.get_key(0));
-
-    q = table2->column<Link>(col_linkset).column<Int>(col_int).max() == null();
-    tv = q.find_all();
-    CHECK_EQUAL(tv.size(), 1);
-    CHECK_EQUAL(k0, tv.get_key(0));
-
-    q = table2->column<Link>(col_linkset).column<Int>(col_int).max() == table2->link(col_link).column<Int>(col_int);
-    tv = q.find_all();
-    CHECK_EQUAL(tv.size(), 2);
-    CHECK_EQUAL(k1, tv.get_key(0));
-    CHECK_EQUAL(k2, tv.get_key(1));
-
-    q = table2->column<Link>(col_linkset).column<Int>(col_int).max() == table2->column<Double>(col_double);
-    tv = q.find_all();
-    CHECK_EQUAL(tv.size(), 1);
-    CHECK_EQUAL(k1, tv.get_key(0));
-
-
-    q = table2->column<Link>(col_linkset).column<Float>(col_flt).max() == 789.0f;
-    tv = q.find_all();
-    CHECK_EQUAL(tv.size(), 2);
-    CHECK_EQUAL(k2, tv.get_key(0));
-    CHECK_EQUAL(k3, tv.get_key(1));
-
-    q = table2->column<Link>(col_linkset).column<Float>(col_flt).max() == 456.0f;
-    tv = q.find_all();
-    CHECK_EQUAL(tv.size(), 1);
-    CHECK_EQUAL(k1, tv.get_key(0));
-
-
-    q = table2->column<Link>(col_linkset).column<Double>(col_dbl).max() == 789.0;
-    tv = q.find_all();
-    CHECK_EQUAL(tv.size(), 2);
-    CHECK_EQUAL(k2, tv.get_key(0));
-    CHECK_EQUAL(k3, tv.get_key(1));
-
-    q = table2->column<Link>(col_linkset).column<Double>(col_dbl).max() == 456.0;
-    tv = q.find_all();
-    CHECK_EQUAL(tv.size(), 1);
-    CHECK_EQUAL(k1, tv.get_key(0));
-
-
-    // Sum.
-    // Floating point results below may be inexact for some combination of architectures, compilers, and compiler
-    // flags.
-
-    q = table2->column<Link>(col_linkset).column<Int>(col_int).sum() == 1245;
-    tv = q.find_all();
-    CHECK_EQUAL(tv.size(), 2);
-    CHECK_EQUAL(k2, tv.get_key(0));
-    CHECK_EQUAL(k3, tv.get_key(1));
-
-    q = table2->column<Link>(col_linkset).column<Int>(col_int).sum() == 456;
-    tv = q.find_all();
-    CHECK_EQUAL(tv.size(), 1);
-    CHECK_EQUAL(k1, tv.get_key(0));
-
-    q = table2->column<Link>(col_linkset).column<Int>(col_int).sum() == table2->link(col_link).column<Int>(col_int);
-    tv = q.find_all();
-    CHECK_EQUAL(tv.size(), 1);
-    CHECK_EQUAL(k1, tv.get_key(0));
-
-    q = table2->column<Link>(col_linkset).column<Int>(col_int).sum() == table2->column<Double>(col_double);
-    tv = q.find_all();
-    CHECK_EQUAL(tv.size(), 1);
-    CHECK_EQUAL(k1, tv.get_key(0));
-
-
-    q = table2->column<Link>(col_linkset).column<Float>(col_flt).sum() == 1245.0f;
-    tv = q.find_all();
-    CHECK_EQUAL(tv.size(), 2);
-    CHECK_EQUAL(k2, tv.get_key(0));
-    CHECK_EQUAL(k3, tv.get_key(1));
-
-    q = table2->column<Link>(col_linkset).column<Float>(col_flt).sum() == 456.0f;
-    tv = q.find_all();
-    CHECK_EQUAL(tv.size(), 1);
-    CHECK_EQUAL(k1, tv.get_key(0));
-
-
-    q = table2->column<Link>(col_linkset).column<Double>(col_dbl).sum() == 1245.0;
-    tv = q.find_all();
-    CHECK_EQUAL(tv.size(), 2);
-    CHECK_EQUAL(k2, tv.get_key(0));
-    CHECK_EQUAL(k3, tv.get_key(1));
-
-    q = table2->column<Link>(col_linkset).column<Double>(col_dbl).sum() == 456.0;
-    tv = q.find_all();
-    CHECK_EQUAL(tv.size(), 1);
-    CHECK_EQUAL(k1, tv.get_key(0));
-
-
-    // Average.
-    // Floating point results below may be inexact for some combination of architectures, compilers, and compiler
-    // flags.
-
-    q = table2->column<Link>(col_linkset).column<Int>(col_int).average() == 622.5;
-    tv = q.find_all();
-    CHECK_EQUAL(tv.size(), 2);
-    CHECK_EQUAL(k2, tv.get_key(0));
-    CHECK_EQUAL(k3, tv.get_key(1));
-
-    q = table2->column<Link>(col_linkset).column<Int>(col_int).average() == 456;
-    tv = q.find_all();
-    CHECK_EQUAL(tv.size(), 1);
-    CHECK_EQUAL(k1, tv.get_key(0));
-
-    q = table2->column<Link>(col_linkset).column<Int>(col_int).average() == null();
-    tv = q.find_all();
-    CHECK_EQUAL(tv.size(), 1);
-    CHECK_EQUAL(k0, tv.get_key(0));
-
-    q = table2->column<Link>(col_linkset).column<Int>(col_int).average() <
-        table2->link(col_link).column<Int>(col_int);
-    tv = q.find_all();
-    CHECK_EQUAL(tv.size(), 1);
-    CHECK_EQUAL(k2, tv.get_key(0));
-
-    q = table2->column<Link>(col_linkset).column<Int>(col_int).average() == table2->column<Double>(col_double);
-    tv = q.find_all();
-    CHECK_EQUAL(tv.size(), 1);
-    CHECK_EQUAL(k1, tv.get_key(0));
-
-
-    q = table2->column<Link>(col_linkset).column<Float>(col_flt).average() == 622.5;
-    tv = q.find_all();
-    CHECK_EQUAL(tv.size(), 2);
-    CHECK_EQUAL(k2, tv.get_key(0));
-    CHECK_EQUAL(k3, tv.get_key(1));
-
-    q = table2->column<Link>(col_linkset).column<Float>(col_flt).average() == 456.0f;
-    tv = q.find_all();
-    CHECK_EQUAL(tv.size(), 1);
-    CHECK_EQUAL(k1, tv.get_key(0));
-
-
-    q = table2->column<Link>(col_linkset).column<Double>(col_dbl).average() == 622.5;
-    tv = q.find_all();
-    CHECK_EQUAL(tv.size(), 2);
-    CHECK_EQUAL(k2, tv.get_key(0));
-    CHECK_EQUAL(k3, tv.get_key(1));
-
-    q = table2->column<Link>(col_linkset).column<Double>(col_dbl).average() == 456.0;
-    tv = q.find_all();
-    CHECK_EQUAL(tv.size(), 1);
-    CHECK_EQUAL(k1, tv.get_key(0));
-}
-
-TEST(Query_OperatorsOverLink)
+TEST_TYPES(Query_OperatorsOverLink, TestLinkList, TestLinkSet, TestDictionaryLinkValues)
 {
     Group group;
     TableRef table1 = group.add_table("table1");
@@ -3280,9 +3046,10 @@ TEST(Query_OperatorsOverLink)
     table1->get_object(keys[0]).set_all(2, 2.0);
     table1->get_object(keys[1]).set_all(3, 3.0);
 
+    TEST_TYPE test_container;
     TableRef table2 = group.add_table("table2");
     auto col_int2 = table2->add_column(type_Int, "int");
-    auto col_linklist = table2->add_column_list(*table1, "linklist");
+    ColKey col_linktest = test_container.add_link_column(table2, table1);
 
     // table2
     // 0:  0 { }
@@ -3293,12 +3060,8 @@ TEST(Query_OperatorsOverLink)
     auto k1 = table2->create_object().set_all(4).get_key();
     auto k2 = table2->create_object().set_all(4).get_key();
 
-    auto ll = table2->get_object(k1).get_linklist(col_linklist);
-    ll.add(keys[0]);
-
-    ll = table2->get_object(k2).get_linklist(col_linklist);
-    ll.add(keys[1]);
-    ll.add(keys[0]);
+    test_container.add_links_to(table2, col_linktest, k1, {keys[0]});
+    test_container.add_links_to(table2, col_linktest, k2, {keys[1], keys[0]});
 
     Query q;
     TableView tv;
@@ -3307,7 +3070,7 @@ TEST(Query_OperatorsOverLink)
 
     // Rows 1 and 2 should match this query as 2 * 2 == 4.
     // Row 0 should not as the power subexpression will not produce any results.
-    q = power(table2->link(col_linklist).column<Int>(col_int)) == table2->column<Int>(col_int2);
+    q = power(table2->link(col_linktest).column<Int>(col_int)) == table2->column<Int>(col_int2);
     tv = q.find_all();
     CHECK_EQUAL(tv.size(), 2);
     CHECK_EQUAL(k1, tv.get_key(0));
@@ -3315,7 +3078,7 @@ TEST(Query_OperatorsOverLink)
 
     // Rows 1 and 2 should match this query as 2 * 2 == 4.
     // Row 0 should not as the power subexpression will not produce any results.
-    q = table2->column<Int>(col_int2) == power(table2->link(col_linklist).column<Int>(col_int));
+    q = table2->column<Int>(col_int2) == power(table2->link(col_linktest).column<Int>(col_int));
     tv = q.find_all();
     CHECK_EQUAL(tv.size(), 2);
     CHECK_EQUAL(k1, tv.get_key(0));
@@ -3324,7 +3087,7 @@ TEST(Query_OperatorsOverLink)
 
     // Rows 1 and 2 should match this query as 2.0 * 2.0 == 4.0.
     // Row 0 should not as the power subexpression will not produce any results.
-    q = power(table2->link(col_linklist).column<Double>(col_dbl)) == table2->column<Int>(col_int2);
+    q = power(table2->link(col_linktest).column<Double>(col_dbl)) == table2->column<Int>(col_int2);
     tv = q.find_all();
     CHECK_EQUAL(tv.size(), 2);
     CHECK_EQUAL(k1, tv.get_key(0));
@@ -3332,7 +3095,7 @@ TEST(Query_OperatorsOverLink)
 
     // Rows 1 and 2 should match this query as 2.0 * 2.0 == 4.0.
     // Row 0 should not as the power subexpression will not produce any results.
-    q = table2->column<Int>(col_int2) == power(table2->link(col_linklist).column<Double>(col_dbl));
+    q = table2->column<Int>(col_int2) == power(table2->link(col_linktest).column<Double>(col_dbl));
     tv = q.find_all();
     CHECK_EQUAL(tv.size(), 2);
     CHECK_EQUAL(k1, tv.get_key(0));
@@ -3343,7 +3106,7 @@ TEST(Query_OperatorsOverLink)
 
     // Rows 1 and 2 should match this query as 2 * 2 == 4.
     // Row 0 should not as the multiplication will not produce any results.
-    q = table2->link(col_linklist).column<Int>(col_int) * 2 == table2->column<Int>(col_int2);
+    q = table2->link(col_linktest).column<Int>(col_int) * 2 == table2->column<Int>(col_int2);
     tv = q.find_all();
     CHECK_EQUAL(tv.size(), 2);
     CHECK_EQUAL(k1, tv.get_key(0));
@@ -3351,7 +3114,7 @@ TEST(Query_OperatorsOverLink)
 
     // Rows 1 and 2 should match this query as 2 * 2 == 4.
     // Row 0 should not as the multiplication will not produce any results.
-    q = table2->column<Int>(col_int2) == 2 * table2->link(col_linklist).column<Int>(col_int);
+    q = table2->column<Int>(col_int2) == 2 * table2->link(col_linktest).column<Int>(col_int);
     tv = q.find_all();
     CHECK_EQUAL(tv.size(), 2);
     CHECK_EQUAL(k1, tv.get_key(0));
@@ -3359,7 +3122,7 @@ TEST(Query_OperatorsOverLink)
 
     // Rows 1 and 2 should match this query as 2.0 * 2.0 == 4.0.
     // Row 0 should not as the multiplication will not produce any results.
-    q = table2->link(col_linklist).column<Double>(col_dbl) * 2 == table2->column<Int>(col_int2);
+    q = table2->link(col_linktest).column<Double>(col_dbl) * 2 == table2->column<Int>(col_int2);
     tv = q.find_all();
     CHECK_EQUAL(tv.size(), 2);
     CHECK_EQUAL(k1, tv.get_key(0));
@@ -3367,117 +3130,7 @@ TEST(Query_OperatorsOverLink)
 
     // Rows 1 and 2 should match this query as 2.0 * 2.0 == 4.0.
     // Row 0 should not as the multiplication will not produce any results.
-    q = table2->column<Int>(col_int2) == 2 * table2->link(col_linklist).column<Double>(col_dbl);
-    tv = q.find_all();
-    CHECK_EQUAL(tv.size(), 2);
-    CHECK_EQUAL(k1, tv.get_key(0));
-    CHECK_EQUAL(k2, tv.get_key(1));
-}
-
-TEST(Query_OperatorsOverLink_Set)
-{
-    Group group;
-    TableRef table1 = group.add_table("table1");
-    auto col_int = table1->add_column(type_Int, "int");
-    auto col_dbl = table1->add_column(type_Double, "double");
-
-    // table1
-    // 0: 2 2.0
-    // 1: 3 3.0
-
-    ObjKeys keys({5, 6});
-    table1->create_objects(keys);
-    table1->get_object(keys[0]).set_all(2, 2.0);
-    table1->get_object(keys[1]).set_all(3, 3.0);
-
-    TableRef table2 = group.add_table("table2");
-    auto col_int2 = table2->add_column(type_Int, "int");
-    auto col_linkset = table2->add_column_set(*table1, "linkset");
-
-    // table2
-    // 0:  0 { }
-    // 1:  4 { 0 }
-    // 2:  4 { 1, 0 }
-
-    table2->create_object();
-    auto k1 = table2->create_object().set_all(4).get_key();
-    auto k2 = table2->create_object().set_all(4).get_key();
-
-    auto ll = table2->get_object(k1).get_linkset(col_linkset);
-    ll.insert(keys[0]);
-
-    ll = table2->get_object(k2).get_linkset(col_linkset);
-    ll.insert(keys[1]);
-    ll.insert(keys[0]);
-
-    Query q;
-    TableView tv;
-
-    // Unary operators.
-
-    // Rows 1 and 2 should match this query as 2 * 2 == 4.
-    // Row 0 should not as the power subexpression will not produce any results.
-    q = power(table2->link(col_linkset).column<Int>(col_int)) == table2->column<Int>(col_int2);
-    tv = q.find_all();
-    CHECK_EQUAL(tv.size(), 2);
-    CHECK_EQUAL(k1, tv.get_key(0));
-    CHECK_EQUAL(k2, tv.get_key(1));
-
-    // Rows 1 and 2 should match this query as 2 * 2 == 4.
-    // Row 0 should not as the power subexpression will not produce any results.
-    q = table2->column<Int>(col_int2) == power(table2->link(col_linkset).column<Int>(col_int));
-    tv = q.find_all();
-    CHECK_EQUAL(tv.size(), 2);
-    CHECK_EQUAL(k1, tv.get_key(0));
-    CHECK_EQUAL(k2, tv.get_key(1));
-
-
-    // Rows 1 and 2 should match this query as 2.0 * 2.0 == 4.0.
-    // Row 0 should not as the power subexpression will not produce any results.
-    q = power(table2->link(col_linkset).column<Double>(col_dbl)) == table2->column<Int>(col_int2);
-    tv = q.find_all();
-    CHECK_EQUAL(tv.size(), 2);
-    CHECK_EQUAL(k1, tv.get_key(0));
-    CHECK_EQUAL(k2, tv.get_key(1));
-
-    // Rows 1 and 2 should match this query as 2.0 * 2.0 == 4.0.
-    // Row 0 should not as the power subexpression will not produce any results.
-    q = table2->column<Int>(col_int2) == power(table2->link(col_linkset).column<Double>(col_dbl));
-    tv = q.find_all();
-    CHECK_EQUAL(tv.size(), 2);
-    CHECK_EQUAL(k1, tv.get_key(0));
-    CHECK_EQUAL(k2, tv.get_key(1));
-
-
-    // Binary operators.
-
-    // Rows 1 and 2 should match this query as 2 * 2 == 4.
-    // Row 0 should not as the multiplication will not produce any results.
-    q = table2->link(col_linkset).column<Int>(col_int) * 2 == table2->column<Int>(col_int2);
-    tv = q.find_all();
-    CHECK_EQUAL(tv.size(), 2);
-    CHECK_EQUAL(k1, tv.get_key(0));
-    CHECK_EQUAL(k2, tv.get_key(1));
-
-    // Rows 1 and 2 should match this query as 2 * 2 == 4.
-    // Row 0 should not as the multiplication will not produce any results.
-    q = table2->column<Int>(col_int2) == 2 * table2->link(col_linkset).column<Int>(col_int);
-    tv = q.find_all();
-    CHECK_EQUAL(tv.size(), 2);
-    CHECK_EQUAL(k1, tv.get_key(0));
-    CHECK_EQUAL(k2, tv.get_key(1));
-
-    // Rows 1 and 2 should match this query as 2.0 * 2.0 == 4.0.
-    // Row 0 should not as the multiplication will not produce any results.
-    q = table2->link(col_linkset).column<Double>(col_dbl) * 2 == table2->column<Int>(col_int2);
-    tv = q.find_all();
-    CHECK_EQUAL(tv.size(), 2);
-    CHECK_EQUAL(k1, tv.get_key(0));
-    CHECK_EQUAL(k2, tv.get_key(1));
-
-    // Rows 1 and 2 should match this query as 2.0 * 2.0 == 4.0.
-    // Row 0 should not as the multiplication will not produce any results.
-    q = table2->column<Int>(col_int2) == 2 * table2->link(col_linkset).column<Double>(col_dbl);
+    q = table2->column<Int>(col_int2) == 2 * table2->link(col_linktest).column<Double>(col_dbl);
     tv = q.find_all();
     CHECK_EQUAL(tv.size(), 2);
     CHECK_EQUAL(k1, tv.get_key(0));


### PR DESCRIPTION
Instead of adding more duplicated code, the query code was changed from handling a LnkLst and a LnkSet to handling a CollectionBase which does the same things and allows adding in the dictionary too. The assumption here is that the constraining collection can also be cast to a ObjList and this is covered by assertions. 

Since dictionaries do not implement the ObjList interface, an adapter class is created `DictionaryLinkValues` which is the functional equivalent to `LnkSet` and `LnkLst`. This abstraction almost works, except that it cannot provide a `BPlusTree<ObjKey>* get_mutable_tree()` because links are stored in a mixed. This has consequences for unresolved link maintenance that I am unsure about and needs to be resolved before merging. 

@jedelbo do you know if it is necessary to apply `collection.cpp:update_unresolved` and `collection.cpp:check_for_last_unresolved` to dictionaries?

## ☑️ ToDos
* [x] 📝 Changelog update
* [x] 🚦 Tests (or not relevant)
