### PR TITLE
Fixed min/max queries of Mixed columns.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 ### Fixed
 * <How to hit and notice issue? what was the impact?> ([#????](https://github.com/realm/realm-core/issues/????), since v?.?.?)
 * Dictionary key validation now works on strings without nul termination. ([#4589](https://github.com/realm/realm-core/issues/4589))
+# Fixed queries for min/max of a Mixed column not returning the expected value when using the Query::minimum_mixed(). ([#4571](https://github.com/realm/realm-core/issues/4571), since v11.0.0-beta.2)
  
 ### Breaking changes
 * None.

--- a/src/realm/query.cpp
+++ b/src/realm/query.cpp
@@ -1161,7 +1161,7 @@ int64_t Query::maximum_int(ColKey column_key, ObjKey* return_ndx) const
     else {
         aggregate<int64_t>(st, column_key, nullptr, return_ndx);
     }
-    return st.m_state;
+    return st.get_max();
 }
 
 float Query::maximum_float(ColKey column_key, ObjKey* return_ndx) const
@@ -1172,7 +1172,7 @@ float Query::maximum_float(ColKey column_key, ObjKey* return_ndx) const
 
     QueryStateMax<float> st;
     aggregate<float>(st, column_key, nullptr, return_ndx);
-    return st.m_state;
+    return st.get_max();
 }
 double Query::maximum_double(ColKey column_key, ObjKey* return_ndx) const
 {
@@ -1182,7 +1182,7 @@ double Query::maximum_double(ColKey column_key, ObjKey* return_ndx) const
 
     QueryStateMax<double> st;
     aggregate<double>(st, column_key, nullptr, return_ndx);
-    return st.m_state;
+    return st.get_max();
 }
 
 Decimal128 Query::maximum_decimal128(ColKey column_key, ObjKey* return_ndx) const
@@ -1233,7 +1233,7 @@ int64_t Query::minimum_int(ColKey column_key, ObjKey* return_ndx) const
     else {
         aggregate<int64_t>(st, column_key, nullptr, return_ndx);
     }
-    return st.m_state;
+    return st.get_min();
 }
 float Query::minimum_float(ColKey column_key, ObjKey* return_ndx) const
 {
@@ -1243,7 +1243,7 @@ float Query::minimum_float(ColKey column_key, ObjKey* return_ndx) const
 
     QueryStateMin<float> st;
     aggregate<float>(st, column_key, nullptr, return_ndx);
-    return st.m_state;
+    return st.get_min();
 }
 double Query::minimum_double(ColKey column_key, ObjKey* return_ndx) const
 {
@@ -1253,7 +1253,7 @@ double Query::minimum_double(ColKey column_key, ObjKey* return_ndx) const
 
     QueryStateMin<double> st;
     aggregate<double>(st, column_key, nullptr, return_ndx);
-    return st.m_state;
+    return st.get_min();
 }
 
 Timestamp Query::minimum_timestamp(ColKey column_key, ObjKey* return_ndx)

--- a/src/realm/table.cpp
+++ b/src/realm/table.cpp
@@ -2218,7 +2218,7 @@ int64_t Table::minimum_int(ColKey col_key, ObjKey* return_ndx) const
     if (return_ndx) {
         *return_ndx = st.m_minmax_key;
     }
-    return st.m_state;
+    return st.get_min();
 }
 
 float Table::minimum_float(ColKey col_key, ObjKey* return_ndx) const
@@ -2228,7 +2228,7 @@ float Table::minimum_float(ColKey col_key, ObjKey* return_ndx) const
     if (return_ndx) {
         *return_ndx = st.m_minmax_key;
     }
-    return st.m_state;
+    return st.get_min();
 }
 
 double Table::minimum_double(ColKey col_key, ObjKey* return_ndx) const
@@ -2238,7 +2238,7 @@ double Table::minimum_double(ColKey col_key, ObjKey* return_ndx) const
     if (return_ndx) {
         *return_ndx = st.m_minmax_key;
     }
-    return st.m_state;
+    return st.get_min();
 }
 
 Decimal128 Table::minimum_decimal(ColKey col_key, ObjKey* return_ndx) const
@@ -2286,7 +2286,7 @@ int64_t Table::maximum_int(ColKey col_key, ObjKey* return_ndx) const
     if (return_ndx) {
         *return_ndx = st.m_minmax_key;
     }
-    return st.m_state;
+    return st.get_max();
 }
 
 float Table::maximum_float(ColKey col_key, ObjKey* return_ndx) const
@@ -2296,7 +2296,7 @@ float Table::maximum_float(ColKey col_key, ObjKey* return_ndx) const
     if (return_ndx) {
         *return_ndx = st.m_minmax_key;
     }
-    return st.m_state;
+    return st.get_max();
 }
 
 double Table::maximum_double(ColKey col_key, ObjKey* return_ndx) const
@@ -2306,7 +2306,7 @@ double Table::maximum_double(ColKey col_key, ObjKey* return_ndx) const
     if (return_ndx) {
         *return_ndx = st.m_minmax_key;
     }
-    return st.m_state;
+    return st.get_max();
 }
 
 Decimal128 Table::maximum_decimal(ColKey col_key, ObjKey* return_ndx) const

--- a/test/test_query2.cpp
+++ b/test/test_query2.cpp
@@ -963,7 +963,7 @@ TEST(Query_SumMinMaxAvg)
     CHECK_EQUAL(Decimal128{9.9}, t.where().maximum_decimal128(decimal_col));
     CHECK_EQUAL(Mixed{"foo"}, t.where().maximum_mixed(mixed_col));
     CHECK_EQUAL(Decimal128{1.1}, t.where().minimum_decimal128(decimal_col));
-    CHECK_EQUAL(Mixed{}, t.where().minimum_mixed(mixed_col));
+    CHECK_EQUAL(Mixed{0.1}, t.where().minimum_mixed(mixed_col));
     CHECK_EQUAL(Decimal128{49.5}, t.where().sum_decimal128(decimal_col));
     CHECK_EQUAL(Mixed{48.5}, t.where().sum_mixed(mixed_col));
     CHECK_EQUAL(Decimal128{49.5 / 9}, t.where().average_decimal128(decimal_col));
@@ -971,6 +971,8 @@ TEST(Query_SumMinMaxAvg)
     Decimal128 expected_avg_mixed = Decimal128{48.5 / 6};
     Decimal128 allowed_epsilon{0.001};
     CHECK(avg_mixed <= (expected_avg_mixed + allowed_epsilon) && avg_mixed >= (expected_avg_mixed - allowed_epsilon));
+    t.get_object(keys[6]).set<Mixed>(mixed_col, Mixed{false});
+    CHECK_EQUAL(Mixed{false}, t.where().minimum_mixed(mixed_col));
 
     ObjKey resindex;
 


### PR DESCRIPTION
Fixes https://github.com/realm/realm-core/issues/4571
The min of a mixed column shouldn't be null. Null should be ignored during aggregation in the same way as for other types.

## ☑️ ToDos
* [x] 📝 Changelog update
* [x] 🚦 Tests (or not relevant)
