### PR TITLE
Fix availability warnings when building for Apple platforms

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@
 
 ### Fixed
 * <How to hit and notice issue? what was the impact?> ([#????](https://github.com/realm/realm-core/issues/????), since v?.?.?)
-* None.
+* Building for Apple platforms gave availability warnings for clock_gettime(). The code giving the warning is currently used only on Windows, so this could not actually cause crashes at runtime (v10.6.0).
  
 ### Breaking changes
 * None.

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -79,6 +79,8 @@ else()
         add_compile_options(-Wunreachable-code -Wshorten-64-to-32 -Wconditional-uninitialized -Wextra-semi -Wno-nested-anon-types -Wdocumentation -Wthread-safety -Wthread-safety-negative)
     endif()
 
+    add_cxx_flag_if_supported(-Wpartial-availability)
+
     # This warning is too agressive. It warns about moves that are not redundant on older
     # compilers that we still support. It is also harmless, unlike pessimizing moves.
     add_cxx_flag_if_supported(-Wno-redundant-move)

--- a/src/realm/util/interprocess_condvar.hpp
+++ b/src/realm/util/interprocess_condvar.hpp
@@ -28,6 +28,10 @@
 #include <sys/stat.h>
 #include <mutex>
 
+#if REALM_PLATFORM_APPLE
+#include <sys/time.h>
+#endif
+
 // Condvar Emulation is required if RobustMutex emulation is enabled
 #if defined(REALM_ROBUST_MUTEX_EMULATION) || defined(_WIN32)
 #define REALM_CONDVAR_EMULATION
@@ -114,6 +118,16 @@ public:
                 struct timespec now;
 #ifdef _WIN32
                 timespec_get(&now, TIME_UTC);
+#elif REALM_PLATFORM_APPLE
+                if (__builtin_available(iOS 10, macOS 12, tvOS 10, watchOS 3, *)) {
+                    clock_gettime(CLOCK_REALTIME, &now);
+                }
+                else {
+                    timeval tv;
+                    gettimeofday(&tv, 0);
+                    now.tv_sec = tv.tv_sec;
+                    now.tv_nsec = tv.tv_usec * 1000;
+                }
 #else
                 clock_gettime(CLOCK_REALTIME, &now);
 #endif


### PR DESCRIPTION
clock_gettime() requires a newer version of macOS than our minimum deployment target, so we need a fallback for older versions of macOS. This would cause a crash at runtime if it was hit, but the function is currently only used on Windows.