### PR TITLE
enable MongoDB sync tests in Jenkins

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -259,13 +259,10 @@ def doCheckInDocker(Map options = [:]) {
         REALM_ENABLE_SYNC: options.enableSync ? 'ON' : 'OFF',
     ]
     if (options.enableSync) {
-        echo 'FIXME: Skipping stitch tests because of a breaking change in the sync client'
-        /*
         cmakeOptions << [
             REALM_ENABLE_AUTH_TESTS: 'ON',
             REALM_MONGODB_ENDPOINT: 'http://mongodb-realm:9090',
         ]
-        */
     }
     if (longRunningTests) {
         cmakeOptions << [


### PR DESCRIPTION
This was done before, but was probably undone due to a bad merge in https://github.com/realm/realm-core/pull/4153
