### PR TITLE
C API: Add support for getting VersionID for Realm

### DIFF
--- a/src/realm.h
+++ b/src/realm.h
@@ -156,6 +156,10 @@ typedef struct realm_value {
     realm_value_type_e type;
 } realm_value_t;
 
+typedef struct realm_version_id {
+    uint64_t version;
+    uint64_t index;
+} realm_version_id_t;
 
 /* Error types */
 typedef struct realm_async_error realm_async_error_t;
@@ -317,6 +321,11 @@ typedef void (*realm_sync_download_completion_func_t)(void* userdata, realm_asyn
 typedef void (*realm_sync_connection_state_changed_func_t)(void* userdata, int, int);
 typedef void (*realm_sync_session_state_changed_func_t)(void* userdata, int, int);
 typedef void (*realm_sync_progress_func_t)(void* userdata, size_t transferred, size_t total);
+
+/**
+ * Get the VersionID of the current transaction
+ */
+RLM_API bool realm_get_version_id(const realm_t*, realm_version_id_t* out_version);
 
 /**
  * Get a string representing the version number of the Realm library.

--- a/src/realm/object-store/c_api/conversion.hpp
+++ b/src/realm/object-store/c_api/conversion.hpp
@@ -423,6 +423,14 @@ static inline realm_class_info_t to_capi(const ObjectSchema& o)
     return info;
 }
 
+static inline realm_version_id_t to_capi(const VersionID& v)
+{
+    realm_version_id_t version_id;
+    version_id.version = v.version;
+    version_id.index = v.index;
+    return version_id;
+}
+
 } // namespace realm::c_api
 
 

--- a/src/realm/object-store/c_api/realm.cpp
+++ b/src/realm/object-store/c_api/realm.cpp
@@ -3,6 +3,14 @@
 
 namespace realm::c_api {
 
+RLM_API bool realm_get_version_id(const realm_t* realm, realm_version_id_t* out_version)
+{
+    return wrap_err([&]() {
+        *out_version = to_capi((*realm)->read_transaction_version());
+        return true;
+    });
+}
+
 RLM_API const char* realm_get_library_version()
 {
     return REALM_VERSION_STRING;


### PR DESCRIPTION
We need to expose the VersionID for the Kotlin SDK, both for debugging, but also because we use the information to reason about which transaction contains the latest snapshot.