### PR TITLE
remove count arg from evergreen benchmarks

### DIFF
--- a/test/util/benchmark_results.cpp
+++ b/test/util/benchmark_results.cpp
@@ -375,9 +375,11 @@ void BenchmarkResults::save_results()
                 metric_objs.push_back(make_result_obj("stddev", result.stddev));
             }
 
-            test_results.push_back(json{{"info", json{{"test_name", measurement.first},
-                                                      {"parent", m_suite_name},
-                                                      {"args", json{{"count", result.rep}}}}},
+            test_results.push_back(json{{"info",
+                                         json{
+                                             {"test_name", measurement.first},
+                                             {"parent", m_suite_name},
+                                         }},
                                         {"metrics", std::move(metric_objs)}});
         }
 


### PR DESCRIPTION
The measurement `result.rep` is the total number of samples obtained for a benchmark. This can vary between runs because the benchmark suite dynamically determines the number of runs based on how long they take. It is informational only and used to compute the min/max/avg/med results, but should not distinguish benchmarks from one another. The way evergreen interprets arguments is to use each "arg" as part of the unique id for the timeseries reporting. This causes the graphs to incorrectly interpret different count runs as distinct benchmarks (see below image). This change removes the count argument which will cause all runs of different counts to be combined, going forward.
![Screen Shot 2021-04-15 at 2 53 21 PM](https://user-images.githubusercontent.com/2826060/114943674-3666f000-9dfb-11eb-9bf6-5911a4db8ab1.png)

