### PR TITLE
Query::find_all should disregard null links when no conditions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 * Added the names requested by .NET to match mixed type based querying. ([#4353](https://github.com/realm/realm-core/issues/4353))
 * <How to hit and notice issue? what was the impact?> ([#????](https://github.com/realm/realm-core/issues/????), since v?.?.?)
 * Comparing dictionaries from different realms could sometimes return equality ([#4629](https://github.com/realm/realm-core/issues/4629), since v11.0.0-beta.0)
+* Calling Results::snapshot on dictionary values collection containing null returns incorrect results ([#4635](https://github.com/realm/realm-core/issues/4635), Not in any release)
  
 ### Breaking changes
 * None.

--- a/src/realm/query.cpp
+++ b/src/realm/query.cpp
@@ -970,7 +970,7 @@ Query& Query::like(ColKey column_key, StringData value, bool case_sensitive)
 bool Query::eval_object(const Obj& obj) const
 {
     if (has_conditions())
-        return root_node()->match(obj);
+        return obj && root_node()->match(obj);
 
     // Query has no conditions, so all rows match, also the user given argument
     return true;
@@ -1433,7 +1433,7 @@ ObjKey Query::find()
         size_t sz = m_view->size();
         for (size_t i = 0; i < sz; i++) {
             const Obj obj = m_view->try_get_object(i);
-            if (obj && eval_object(obj)) {
+            if (eval_object(obj)) {
                 return obj.get_key();
             }
         }
@@ -1476,7 +1476,7 @@ void Query::find_all(ConstTableView& ret, size_t begin, size_t end, size_t limit
             end = m_view->size();
         for (size_t t = begin; t < end && ret.size() < limit; t++) {
             const Obj obj = m_view->try_get_object(t);
-            if (!has_cond || (obj && eval_object(obj))) {
+            if (eval_object(obj)) {
                 ret.m_key_values.add(obj.get_key());
             }
         }

--- a/src/realm/query.cpp
+++ b/src/realm/query.cpp
@@ -1469,12 +1469,14 @@ void Query::find_all(ConstTableView& ret, size_t begin, size_t end, size_t limit
 
     init();
 
+    bool has_cond = has_conditions();
+
     if (m_view) {
         if (end == size_t(-1))
             end = m_view->size();
         for (size_t t = begin; t < end && ret.size() < limit; t++) {
             const Obj obj = m_view->try_get_object(t);
-            if (obj && eval_object(obj)) {
+            if (!has_cond || (obj && eval_object(obj))) {
                 ret.m_key_values.add(obj.get_key());
             }
         }
@@ -1482,7 +1484,7 @@ void Query::find_all(ConstTableView& ret, size_t begin, size_t end, size_t limit
     else {
         if (end == size_t(-1))
             end = m_table->size();
-        if (!has_conditions()) {
+        if (!has_cond) {
             KeyColumn& refs = ret.m_key_values;
 
             auto f = [&begin, &end, &limit, &refs](const Cluster* cluster) {

--- a/test/object-store/dictionary.cpp
+++ b/test/object-store/dictionary.cpp
@@ -1032,7 +1032,7 @@ TEST_CASE("dictionary snapshot null", "[dictionary]") {
     auto prop = r->schema().find("object")->property_for_name("value");
     r->commit_transaction();
 
-    r->read_group().to_json(std::cout);
+    // r->read_group().to_json(std::cout);
 
     object_store::Dictionary dict(obj, prop);
     auto values = dict.get_values();


### PR DESCRIPTION
## What, How & Why?
Fixes #4635 

## ☑️ ToDos
* [x] 📝 Changelog update
* [x] 🚦 Tests (or not relevant)
