### PR TITLE
anticipate access token refresh

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@
 
 ### Fixed
 * <How to hit and notice issue? what was the impact?> ([#????](https://github.com/realm/realm-core/issues/????), since v?.?.?)
-* Proactivly check the expiry time on the access token and refresh it before attempting to initiate a sync session. This prevents some error logs from appearing on the client such as: "ERROR: Connection[1]: Websocket: Expected HTTP response 101 Switching Protocols, but received: HTTP/1.1 401 Unauthorized" ([RCORE-473](https://jira.mongodb.org/browse/RCORE-473), since v10.0.0)
+* Proactively check the expiry time on the access token and refresh it before attempting to initiate a sync session. This prevents some error logs from appearing on the client such as: "ERROR: Connection[1]: Websocket: Expected HTTP response 101 Switching Protocols, but received: HTTP/1.1 401 Unauthorized" ([RCORE-473](https://jira.mongodb.org/browse/RCORE-473), since v10.0.0)
  
 ### Breaking changes
 * None.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@
 
 ### Fixed
 * <How to hit and notice issue? what was the impact?> ([#????](https://github.com/realm/realm-core/issues/????), since v?.?.?)
-* None.
+* Proactivly check the expiry time on the access token and refresh it before attempting to initiate a sync session. This prevents some error logs from appearing on the client such as: "ERROR: Connection[1]: Websocket: Expected HTTP response 101 Switching Protocols, but received: HTTP/1.1 401 Unauthorized" ([RCORE-473](https://jira.mongodb.org/browse/RCORE-473), since v10.0.0)
  
 ### Breaking changes
 * None.

--- a/src/realm/object-store/sync/sync_session.cpp
+++ b/src/realm/object-store/sync/sync_session.cpp
@@ -328,6 +328,14 @@ struct sync_session_states::WaitingForAccessToken : public SyncSession::State {
         session.advance_state(lock, active);
     }
 
+    void nonsync_transact_notify(std::unique_lock<std::mutex>&, SyncSession& session,
+                                 sync::version_type version) const override
+    {
+        if (session.m_session) {
+            session.m_session->nonsync_transact_notify(version);
+        }
+    }
+
     void log_out(std::unique_lock<std::mutex>& lock, SyncSession& session) const override
     {
         session.advance_state(lock, inactive);

--- a/src/realm/object-store/sync/sync_session.cpp
+++ b/src/realm/object-store/sync/sync_session.cpp
@@ -61,7 +61,7 @@ constexpr const char SyncError::c_recovery_file_path_key[];
 ///                is Immediate.
 ///    * DYING: if asked to close and the stop policy is AfterChangesUploaded
 ///    * WAITING_FOR_ACCESS_TOKEN: if the session tried to enter ACTIVE,
-///                              but the token is invalid or expired.
+///                                but the token is invalid or expired.
 ///
 /// DYING: the session is performing clean-up work in preparation to be destroyed.
 /// From: ACTIVE

--- a/src/realm/object-store/sync/sync_session.hpp
+++ b/src/realm/object-store/sync/sync_session.hpp
@@ -342,6 +342,7 @@ private:
     void advance_state(std::unique_lock<std::mutex>& lock, const State&);
 
     void create_sync_session();
+    void do_create_sync_session();
     void unregister(std::unique_lock<std::mutex>& lock);
     void did_drop_external_reference();
 

--- a/src/realm/object-store/sync/sync_session.hpp
+++ b/src/realm/object-store/sync/sync_session.hpp
@@ -44,6 +44,7 @@ namespace sync_session_states {
 struct Active;
 struct Dying;
 struct Inactive;
+struct WaitingForAccessToken;
 } // namespace sync_session_states
 } // namespace _impl
 
@@ -207,13 +208,12 @@ public:
     // longer be open on behalf of it.
     void shutdown_and_wait();
 
-    // Override the address and port of the server that this `SyncSession` is connected to. If the
-    // session is already connected, it will disconnect and then reconnect to the specified address.
-    // If it's not already connected, future connection attempts will be to the specified address.
-    //
-    // NOTE: This is intended for use only in very specific circumstances. Please check with the
-    // object store team before using it.
-    void override_server(std::string address, int port);
+    // The access token needs to periodically be refreshed and this is how to
+    // let the sync session know to update it's internal copy.
+    void update_access_token(std::string signed_token);
+
+    // Request an updated access token from this session's sync user.
+    void initiate_access_token_refresh();
 
     // Update the sync configuration used for this session. The new configuration must have the
     // same user and reference realm url as the old configuration. The session will immediately
@@ -285,6 +285,7 @@ private:
     friend struct _impl::sync_session_states::Active;
     friend struct _impl::sync_session_states::Dying;
     friend struct _impl::sync_session_states::Inactive;
+    friend struct _impl::sync_session_states::WaitingForAccessToken;
 
     class ConnectionChangeNotifier {
     public:

--- a/src/realm/object-store/sync/sync_user.cpp
+++ b/src/realm/object-store/sync/sync_user.cpp
@@ -437,10 +437,7 @@ bool SyncUser::access_token_refresh_required() const
     using namespace std::chrono;
     constexpr size_t buffer_seconds = 5; // arbitrary
     auto threshold = duration_cast<seconds>(system_clock::now().time_since_epoch()).count() - buffer_seconds;
-    if (is_logged_in() && m_access_token.expires_at < static_cast<int64_t>(threshold)) {
-        return true;
-    }
-    return false;
+    return is_logged_in() && m_access_token.expires_at < static_cast<int64_t>(threshold);
 }
 
 } // namespace realm

--- a/src/realm/object-store/sync/sync_user.cpp
+++ b/src/realm/object-store/sync/sync_user.cpp
@@ -432,17 +432,15 @@ void SyncUser::refresh_custom_data(std::function<void(util::Optional<app::AppErr
     }
 }
 
-void SyncUser::refresh_access_token_if_expired(std::function<void(util::Optional<app::AppError>)> completion_block)
+bool SyncUser::access_token_refresh_required() const
 {
     using namespace std::chrono;
     constexpr size_t buffer_seconds = 5; // arbitrary
     auto threshold = duration_cast<seconds>(system_clock::now().time_since_epoch()).count() - buffer_seconds;
     if (is_logged_in() && m_access_token.expires_at < static_cast<int64_t>(threshold)) {
-        refresh_custom_data(std::move(completion_block));
+        return true;
     }
-    else {
-        completion_block({});
-    }
+    return false;
 }
 
 } // namespace realm

--- a/src/realm/object-store/sync/sync_user.hpp
+++ b/src/realm/object-store/sync/sync_user.hpp
@@ -219,9 +219,9 @@ public:
     /// Refreshes the custom data for this user
     void refresh_custom_data(std::function<void(util::Optional<app::AppError>)> completion_block);
 
-    /// Checks the expiry on the access token against the local time and if it expires soon, requests a new one.
-    /// If no refresh is required, the completion block is called immediately.
-    void refresh_access_token_if_expired(std::function<void(util::Optional<app::AppError>)> completion_block);
+    /// Checks the expiry on the access token against the local time and if it is invalid or expires soon, returns
+    /// true.
+    bool access_token_refresh_required() const;
 
     // Optionally set a context factory. If so, must be set before any sessions are created.
     static void set_binding_context_factory(SyncUserContextFactory factory);

--- a/src/realm/object-store/sync/sync_user.hpp
+++ b/src/realm/object-store/sync/sync_user.hpp
@@ -59,9 +59,9 @@ struct RealmJWT {
     std::string token;
 
     // When the token expires.
-    long expires_at;
+    int64_t expires_at;
     // When the token was issued.
-    long issued_at;
+    int64_t issued_at;
     // Custom user data embedded in the encoded token.
     util::Optional<bson::BsonDocument> user_data;
 
@@ -218,6 +218,10 @@ public:
 
     /// Refreshes the custom data for this user
     void refresh_custom_data(std::function<void(util::Optional<app::AppError>)> completion_block);
+
+    /// Checks the expiry on the access token against the local time and if it expires soon, requests a new one.
+    /// If no refresh is required, the completion block is called immediately.
+    void refresh_access_token_if_expired(std::function<void(util::Optional<app::AppError>)> completion_block);
 
     // Optionally set a context factory. If so, must be set before any sessions are created.
     static void set_binding_context_factory(SyncUserContextFactory factory);

--- a/test/object-store/sync/app.cpp
+++ b/test/object-store/sync/app.cpp
@@ -2071,9 +2071,11 @@ TEST_CASE("app: sync integration", "[sync][app]") {
         {
             TestSyncManager reinit(TestSyncManager::Config(app_config), {});
             auto app = get_app_and_login(reinit.app());
+            REQUIRE(!app->current_user()->access_token_refresh_required());
             // Set a bad access token, with an expired time. This will trigger a refresh initiated by the client.
             app->current_user()->update_access_token(
                 encode_fake_jwt("fake_access_token", token.expires, token.timestamp));
+            REQUIRE(app->current_user()->access_token_refresh_required());
 
             auto config = setup_and_get_config(app);
             auto r = realm::Realm::get_shared_realm(config);

--- a/test/object-store/sync/app.cpp
+++ b/test/object-store/sync/app.cpp
@@ -2015,11 +2015,7 @@ TEST_CASE("app: sync integration", "[sync][app]") {
         {
             auto app = get_app_and_login(reinit.app());
             // set a bad access token. this will trigger a refresh when the sync session opens
-            // the expiry is valid so that the pre check doesn't trigger a refresh first
-            std::chrono::system_clock::time_point now = std::chrono::system_clock::now();
-            using namespace std::chrono_literals;
-            int64_t expires = std::chrono::system_clock::to_time_t(now + 30min);
-            app->current_user()->update_access_token(encode_fake_jwt("fake_access_token", expires));
+            app->current_user()->update_access_token(encode_fake_jwt("fake_access_token"));
 
             auto config = setup_and_get_config(app);
             auto r = realm::Realm::get_shared_realm(config);
@@ -2069,7 +2065,7 @@ TEST_CASE("app: sync integration", "[sync][app]") {
             REQUIRE(token.timestamp < token.expires);
             std::chrono::system_clock::time_point now = std::chrono::system_clock::now();
             using namespace std::chrono_literals;
-            token.expires = std::chrono::system_clock::to_time_t(now - 30ms);
+            token.expires = std::chrono::system_clock::to_time_t(now - 30s);
             REQUIRE(token.expired(now));
         }
 

--- a/test/object-store/sync/app.cpp
+++ b/test/object-store/sync/app.cpp
@@ -1930,8 +1930,8 @@ TEST_CASE("app: sync integration", "[sync][app]") {
 
     // MARK: Add Objects -
     SECTION("Add Objects") {
-        TestSyncManager& sync_manager = *new TestSyncManager(TestSyncManager::Config(app_config), {});
         {
+            TestSyncManager sync_manager(TestSyncManager::Config(app_config), {});
             auto app = get_app_and_login(sync_manager.app());
             auto config = setup_and_get_config(app);
             auto r = realm::Realm::get_shared_realm(config);
@@ -1960,11 +1960,10 @@ TEST_CASE("app: sync integration", "[sync][app]") {
         }
 
         // reset sync manager, deleting local data
-        delete &sync_manager;
         util::try_remove_dir_recursive(base_path);
         util::try_make_dir(base_path);
-        TestSyncManager reinit(TestSyncManager::Config(app_config), {});
         {
+            TestSyncManager reinit(TestSyncManager::Config(app_config), {});
             auto app = get_app_and_login(reinit.app());
             auto config = setup_and_get_config(app);
             auto r = realm::Realm::get_shared_realm(config);
@@ -1979,8 +1978,8 @@ TEST_CASE("app: sync integration", "[sync][app]") {
 
     // MARK: Expired Session Refresh -
     SECTION("Invalid Access Token is Refreshed") {
-        TestSyncManager& sync_manager = *new TestSyncManager(TestSyncManager::Config(app_config), {});
         {
+            TestSyncManager sync_manager(TestSyncManager::Config(app_config), {});
             auto app = get_app_and_login(sync_manager.app());
             auto config = setup_and_get_config(app);
             auto r = realm::Realm::get_shared_realm(config);
@@ -2007,12 +2006,10 @@ TEST_CASE("app: sync integration", "[sync][app]") {
 
             REQUIRE(get_dogs(r, session).size() == 1);
         }
-
-        delete &sync_manager;
         util::try_remove_dir_recursive(base_path);
         util::try_make_dir(base_path);
-        TestSyncManager reinit(TestSyncManager::Config(app_config), {});
         {
+            TestSyncManager reinit(TestSyncManager::Config(app_config), {});
             auto app = get_app_and_login(reinit.app());
             // set a bad access token. this will trigger a refresh when the sync session opens
             app->current_user()->update_access_token(encode_fake_jwt("fake_access_token"));
@@ -2029,10 +2026,9 @@ TEST_CASE("app: sync integration", "[sync][app]") {
     }
 
     SECTION("Expired Access Token is Refreshed") {
-        TestSyncManager& sync_manager = *new TestSyncManager(TestSyncManager::Config(app_config), {});
         realm::sync::AccessToken token;
-        realm::sync::AccessToken::ParseError error_state = realm::sync::AccessToken::ParseError::none;
         {
+            TestSyncManager sync_manager(TestSyncManager::Config(app_config), {});
             auto app = get_app_and_login(sync_manager.app());
             auto config = setup_and_get_config(app);
             auto r = realm::Realm::get_shared_realm(config);
@@ -2058,6 +2054,7 @@ TEST_CASE("app: sync integration", "[sync][app]") {
             r->commit_transaction();
 
             REQUIRE(get_dogs(r, session).size() == 1);
+            realm::sync::AccessToken::ParseError error_state = realm::sync::AccessToken::ParseError::none;
             realm::sync::AccessToken::parse(app->current_user()->access_token(), token, error_state, nullptr);
             REQUIRE(error_state == realm::sync::AccessToken::ParseError::none);
             REQUIRE(token.timestamp);
@@ -2069,11 +2066,10 @@ TEST_CASE("app: sync integration", "[sync][app]") {
             REQUIRE(token.expired(now));
         }
 
-        delete &sync_manager;
         util::try_remove_dir_recursive(base_path);
         util::try_make_dir(base_path);
-        TestSyncManager reinit(TestSyncManager::Config(app_config), {});
         {
+            TestSyncManager reinit(TestSyncManager::Config(app_config), {});
             auto app = get_app_and_login(reinit.app());
             // Set a bad access token, with an expired time. This will trigger a refresh initiated by the client.
             app->current_user()->update_access_token(

--- a/test/object-store/util/test_utils.cpp
+++ b/test/object-store/util/test_utils.cpp
@@ -70,7 +70,7 @@ void catch2_ensure_section_run_workaround(bool did_run_a_section, std::string se
     }
 }
 
-std::string encode_fake_jwt(const std::string& in, int64_t exp, int64_t iat)
+std::string encode_fake_jwt(const std::string& in, util::Optional<int64_t> exp, util::Optional<int64_t> iat)
 {
     // by default make a valid expiry time so that the sync session pre check
     // doesn't trigger a token refresh on first open
@@ -87,7 +87,7 @@ std::string encode_fake_jwt(const std::string& in, int64_t exp, int64_t iat)
     std::string unencoded_prefix = nlohmann::json({"alg", "HS256"}).dump();
     std::string unencoded_body =
         nlohmann::json(
-            {{"user_data", {{"token", in}}}, {"exp", exp}, {"iat", iat}, {"access", {"download", "upload"}}})
+            {{"user_data", {{"token", in}}}, {"exp", *exp}, {"iat", *iat}, {"access", {"download", "upload"}}})
             .dump();
     std::string encoded_prefix, encoded_body;
     encoded_prefix.resize(util::base64_encoded_size(unencoded_prefix.size()));

--- a/test/object-store/util/test_utils.cpp
+++ b/test/object-store/util/test_utils.cpp
@@ -70,12 +70,12 @@ void catch2_ensure_section_run_workaround(bool did_run_a_section, std::string se
     }
 }
 
-std::string encode_fake_jwt(const std::string& in)
+std::string encode_fake_jwt(const std::string& in, int64_t exp, int64_t iat)
 {
     std::string unencoded_prefix = nlohmann::json({"alg", "HS256"}).dump();
     std::string unencoded_body =
         nlohmann::json(
-            {{"user_data", {{"token", in}}}, {"exp", 123}, {"iat", 456}, {"access", {"download", "upload"}}})
+            {{"user_data", {{"token", in}}}, {"exp", exp}, {"iat", iat}, {"access", {"download", "upload"}}})
             .dump();
     std::string encoded_prefix, encoded_body;
     encoded_prefix.resize(util::base64_encoded_size(unencoded_prefix.size()));

--- a/test/object-store/util/test_utils.cpp
+++ b/test/object-store/util/test_utils.cpp
@@ -72,6 +72,18 @@ void catch2_ensure_section_run_workaround(bool did_run_a_section, std::string se
 
 std::string encode_fake_jwt(const std::string& in, int64_t exp, int64_t iat)
 {
+    // by default make a valid expiry time so that the sync session pre check
+    // doesn't trigger a token refresh on first open
+    using namespace std::chrono_literals;
+    if (!exp) {
+        std::chrono::system_clock::time_point now = std::chrono::system_clock::now();
+        exp = std::chrono::system_clock::to_time_t(now + 30min);
+    }
+    if (!iat) {
+        std::chrono::system_clock::time_point now = std::chrono::system_clock::now();
+        iat = std::chrono::system_clock::to_time_t(now - 1s);
+    }
+
     std::string unencoded_prefix = nlohmann::json({"alg", "HS256"}).dump();
     std::string unencoded_body =
         nlohmann::json(

--- a/test/object-store/util/test_utils.hpp
+++ b/test/object-store/util/test_utils.hpp
@@ -33,7 +33,7 @@ std::vector<char> make_test_encryption_key(const char start = 0);
 void catch2_ensure_section_run_workaround(bool did_run_a_section, std::string section_name,
                                           std::function<void()> func);
 
-std::string encode_fake_jwt(const std::string& in, int64_t exp = 123, int64_t iat = 456);
+std::string encode_fake_jwt(const std::string& in, int64_t exp = 0, int64_t iat = 0);
 
 static inline std::string random_string(std::string::size_type length)
 {

--- a/test/object-store/util/test_utils.hpp
+++ b/test/object-store/util/test_utils.hpp
@@ -21,6 +21,7 @@
 
 #include <catch2/catch.hpp>
 #include <realm/util/file.hpp>
+#include <realm/util/optional.hpp>
 
 #include <functional>
 
@@ -33,7 +34,8 @@ std::vector<char> make_test_encryption_key(const char start = 0);
 void catch2_ensure_section_run_workaround(bool did_run_a_section, std::string section_name,
                                           std::function<void()> func);
 
-std::string encode_fake_jwt(const std::string& in, int64_t exp = 0, int64_t iat = 0);
+std::string encode_fake_jwt(const std::string& in, util::Optional<int64_t> exp = {},
+                            util::Optional<int64_t> iat = {});
 
 static inline std::string random_string(std::string::size_type length)
 {

--- a/test/object-store/util/test_utils.hpp
+++ b/test/object-store/util/test_utils.hpp
@@ -33,7 +33,8 @@ std::vector<char> make_test_encryption_key(const char start = 0);
 void catch2_ensure_section_run_workaround(bool did_run_a_section, std::string section_name,
                                           std::function<void()> func);
 
-std::string encode_fake_jwt(const std::string& in);
+std::string encode_fake_jwt(const std::string& in, int64_t exp = 123, int64_t iat = 456);
+
 static inline std::string random_string(std::string::size_type length)
 {
     static auto& chrs = "abcdefghijklmnopqrstuvwxyz"


### PR DESCRIPTION
This is to address: https://jira.mongodb.org/browse/RCORE-473
I added back the old WaitingForAccessToken state to the sync session, though the definition of an access token has changed a bit so the flow is much simpler.

Without the changes in this PR, I also did a manual test of logging in a user, then waiting more than 30 minutes to let the access token expire and then using it to start a sync session and the error handling and reconnection all worked for me. So the only thing I can claim to have fixed here for sure is that there are less errors logged (both client side and server side). However, the alarming (though harmless) error logs seems to be what users are concerned about (https://github.com/realm/realm-js/issues/3667).

That being said, the test added does trigger the new code, but will pass without these changes because the 401 response received when initiating a sync session with an expired access token does already get handled correctly (since https://github.com/realm/realm-object-store/pull/1024).

## ☑️ ToDos
* [x] 📝 Changelog update
* [x] 🚦 Tests (or not relevant)
