### PR TITLE
Query now holds a LinkCollectionPtr in m_source_collection

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 * Comparing dictionaries from different realms could sometimes return equality ([#4629](https://github.com/realm/realm-core/issues/4629), since v11.0.0-beta.0)
 * Calling Results::snapshot on dictionary values collection containing null returns incorrect results ([#4635](https://github.com/realm/realm-core/issues/4635), Not in any release)
 * Making a aggregate query on Set of Objects would cause a crash in the parser ([#4633](https://github.com/realm/realm-core/issues/4633), since v11.0.0-beta.0)
+* Copying a Query constrained by a Dictionary would crash ([#4640](https://github.com/realm/realm-core/issues/4640), since v11.0.0-beta.0)
  
 ### Breaking changes
 * None.

--- a/src/realm/collection.hpp
+++ b/src/realm/collection.hpp
@@ -400,6 +400,8 @@ class ObjCollectionBase : public Interface, public _impl::ObjListProxy {
 public:
     static_assert(std::is_base_of_v<CollectionBase, Interface>);
 
+    using Interface::get_col_key;
+    using Interface::get_obj;
     using Interface::get_table;
     using Interface::is_attached;
     using Interface::size;
@@ -533,6 +535,19 @@ private:
     TableRef proxy_get_target_table() const final
     {
         return Interface::get_target_table();
+    }
+    bool matches(const ObjList& other) const final
+    {
+        return get_owning_obj().get_key() == other.get_owning_obj().get_key() &&
+               get_owning_col_key() == other.get_owning_col_key();
+    }
+    Obj get_owning_obj() const final
+    {
+        return get_obj();
+    }
+    ColKey get_owning_col_key() const final
+    {
+        return get_col_key();
     }
 };
 

--- a/src/realm/db.cpp
+++ b/src/realm/db.cpp
@@ -2710,13 +2710,13 @@ LnkSetPtr Transaction::import_copy_of(const LnkSetPtr& original)
     return std::make_unique<LnkSet>();
 }
 
-CollectionBasePtr Transaction::import_copy_of(const CollectionBasePtr& original)
+LinkCollectionPtr Transaction::import_copy_of(const LinkCollectionPtr& original)
 {
     if (!original)
         return nullptr;
-    if (Obj obj = import_copy_of(original->get_obj())) {
-        ColKey ck = original->get_col_key();
-        return obj.get_collection_ptr(ck);
+    if (Obj obj = import_copy_of(original->get_owning_obj())) {
+        ColKey ck = original->get_owning_col_key();
+        return obj.get_linkcollection_ptr(ck);
     }
     // return some empty collection where size() == 0
     // the type shouldn't matter

--- a/src/realm/db.hpp
+++ b/src/realm/db.hpp
@@ -605,7 +605,7 @@ public:
     CollectionBasePtr import_copy_of(const CollectionBase& original);
     LnkLstPtr import_copy_of(const LnkLstPtr& original);
     LnkSetPtr import_copy_of(const LnkSetPtr& original);
-    CollectionBasePtr import_copy_of(const CollectionBasePtr& original);
+    LinkCollectionPtr import_copy_of(const LinkCollectionPtr& original);
 
     // handover of the heavier Query and TableView
     std::unique_ptr<Query> import_copy_of(Query&, PayloadPolicy);

--- a/src/realm/dictionary.hpp
+++ b/src/realm/dictionary.hpp
@@ -257,6 +257,10 @@ public:
     {
         return std::make_unique<DictionaryLinkValues>(m_source);
     }
+    LinkCollectionPtr clone_obj_list() const final
+    {
+        return std::make_unique<DictionaryLinkValues>(m_source);
+    }
     void sort(std::vector<size_t>& indices, bool ascending = true) const final
     {
         m_source.sort(indices, ascending);

--- a/src/realm/list.hpp
+++ b/src/realm/list.hpp
@@ -291,6 +291,16 @@ public:
             return std::make_unique<LnkLst>();
         }
     }
+    // Overriding members of ObjList:
+    LinkCollectionPtr clone_obj_list() const
+    {
+        if (get_obj().is_valid()) {
+            return std::make_unique<LnkLst>(get_obj(), get_col_key());
+        }
+        else {
+            return std::make_unique<LnkLst>();
+        }
+    }
     void set_null(size_t ndx) final;
     void set_any(size_t ndx, Mixed val) final;
     void insert_null(size_t ndx) final;

--- a/src/realm/obj_list.hpp
+++ b/src/realm/obj_list.hpp
@@ -39,6 +39,19 @@ public:
     virtual void sync_if_needed() const = 0;
     virtual void get_dependencies(TableVersions&) const = 0;
     virtual bool is_in_sync() const = 0;
+    virtual LinkCollectionPtr clone_obj_list() const = 0;
+    virtual bool matches(const ObjList&) const
+    {
+        return true;
+    }
+    virtual Obj get_owning_obj() const
+    {
+        return {};
+    }
+    virtual ColKey get_owning_col_key() const
+    {
+        return {};
+    }
 
     // Get the versions of all tables which this list depends on
     TableVersions get_dependency_versions() const

--- a/src/realm/query.hpp
+++ b/src/realm/query.hpp
@@ -400,7 +400,7 @@ private:
     // m_source_collection is a pointer to a collection which must also be a ObjList*
     // this includes: LnkLst, LnkSet, and DictionaryLinkValues. It cannot be a list of primitives because
     // it is used to populate a query through a collection of objects and there are asserts for this.
-    std::unique_ptr<CollectionBase> m_source_collection; // collections are owned by the query.
+    LinkCollectionPtr m_source_collection;         // collections are owned by the query.
     ConstTableView* m_source_table_view = nullptr; // table views are not refcounted, and not owned by the query.
     std::unique_ptr<ConstTableView> m_owned_source_table_view; // <--- except when indicated here
     std::shared_ptr<DescriptorOrdering> m_ordering;

--- a/src/realm/set.hpp
+++ b/src/realm/set.hpp
@@ -268,6 +268,11 @@ public:
     {
         return clone_linkset();
     }
+    // Overriding members of ObjList:
+    LinkCollectionPtr clone_obj_list() const final
+    {
+        return clone_linkset();
+    }
     size_t find_any(Mixed) const final;
     std::pair<size_t, bool> insert_null() final;
     std::pair<size_t, bool> erase_null() final;

--- a/src/realm/table_view.hpp
+++ b/src/realm/table_view.hpp
@@ -243,6 +243,11 @@ public:
         return std::unique_ptr<ConstTableView>(new ConstTableView(*this));
     }
 
+    LinkCollectionPtr clone_obj_list() const
+    {
+        return std::unique_ptr<ConstTableView>(new ConstTableView(*this));
+    }
+
     // import_copy_of() machinery entry points based on dynamic type. These methods:
     // a) forward their calls to the static type entry points.
     // b) new/delete patch data structures.

--- a/src/realm/table_view.hpp
+++ b/src/realm/table_view.hpp
@@ -243,7 +243,7 @@ public:
         return std::unique_ptr<ConstTableView>(new ConstTableView(*this));
     }
 
-    LinkCollectionPtr clone_obj_list() const
+    LinkCollectionPtr clone_obj_list() const final
     {
         return std::unique_ptr<ConstTableView>(new ConstTableView(*this));
     }


### PR DESCRIPTION
LinkCollectionPtr is a std::unique_ptr<ObjList> which more precisely captures that it is a collection of links.

## What, How & Why?
Fixes #4640 

## ☑️ ToDos
* [x] 📝 Changelog update
* [x] 🚦 Tests (or not relevant)
