### PR TITLE
Fix another notification skipping race condition

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 ### Fixed
 * <How to hit and notice issue? what was the impact?> ([#????](https://github.com/realm/realm-core/issues/????), since v?.?.?)
 * Proactively check the expiry time on the access token and refresh it before attempting to initiate a sync session. This prevents some error logs from appearing on the client such as: "ERROR: Connection[1]: Websocket: Expected HTTP response 101 Switching Protocols, but received: HTTP/1.1 401 Unauthorized" ([RCORE-473](https://jira.mongodb.org/browse/RCORE-473), since v10.0.0)
+* Fix a race condition which could result in a skipping notifications failing to skip if several commits using notification skipping were made in succession (since v6.0.0).
  
 ### Breaking changes
 * None.

--- a/src/realm/object-store/impl/realm_coordinator.cpp
+++ b/src/realm/object-store/impl/realm_coordinator.cpp
@@ -973,9 +973,15 @@ void RealmCoordinator::run_async_notifiers()
         // skipping to work. The skip logic assumes that the notifier can't be
         // running when suppress_next() is called because it can only be called
         // from within a write transaction, and starting the write transaction
-        // would have blocked until the notifier is done running. However,
-        // on_change() can be triggered by things other than writes, so we may
-        // be here even if the notifiers don't need to rerun.
+        // would have blocked until the notifier is done running. However, if we
+        // run the notifiers at a point where the version isn't changing, that
+        // could happen concurrently with a call to suppress_next(), and we
+        // could unset skip_next on a callback from that zero-version run
+        // rather than the intended one.
+        //
+        // Spurious wakeups can happen in a few ways: adding a new notifier,
+        // adding a new notifier in a different process sharing this Realm file,
+        // closing the Realm in a different process, and possibly some other cases.
         notifiers = m_notifiers;
     }
     else {
@@ -1027,7 +1033,14 @@ void RealmCoordinator::run_async_notifiers()
         lock.unlock();
     }
 
-    if (skip_version.version) {
+    // If the skip version is set and we have more than one version to process,
+    // we need to start with just the skip version so that any suppressed
+    // callbacks can ignore the changes from it without missing changes from
+    // later versions. If the skip version is set and there aren't any more
+    // versions after it, we just want to process with normal processing. See
+    // the above note about spurious wakeups for why this is required for
+    // correctness and not just a very minor optimization.
+    if (skip_version.version && skip_version != version) {
         REALM_ASSERT(!notifiers.empty());
         REALM_ASSERT(version >= skip_version);
         IncrementalChangeInfo change_info(*m_notifier_sg, notifiers);


### PR DESCRIPTION
The problematic sequence here was:

1. Main thread commits version X
2. Worker thread begins processing version X makes it through the skip version logic. This updates all of the notifiers to version X.
3. Main thread begins another write transaction. This does not block as the notifiers are up-to-date even though the worker thread is still in run_async_notifiers().
4. Main thread suppresses a notification callback (setting skip_version) and then commits version X+1.
5. Worker thread moves on to the non-skip part of the logic for version X. There wasn't any more versions left after the skip version when this iteration started, so it runs the notifiers on zero changesets.
6. Notifier clears skip_next.
7. Worker thread processes version X+1. The suppressed notification incorrectly produces a notification from this because the no-op run previously cleared skip_next.

The fix for this is once again to ensure that run() is never called when no versions were processed. This is done by skipping the skip version logic when the skip version is the final version, but could also be done by instead skipping the non-skip processing.

This has been making Cocoa CI fail occasionally for a while. I failed to come up with a way to write a deterministic test for it, but I did at least manage to come up with a better test for https://github.com/realm/realm-object-store/pull/1103 which is the same bug hit in a slightly different way.