### PR TITLE
Ensure proper move operation is used for PayloadPolicy::Move

### DIFF
--- a/src/realm/table_view.cpp
+++ b/src/realm/table_view.cpp
@@ -25,14 +25,7 @@
 
 using namespace realm;
 
-ConstTableView::ConstTableView(ConstTableView& src, Transaction*, PayloadPolicy)
-    : m_source_column_key(src.m_source_column_key)
-    , m_key_values(Allocator::get_default())
-{
-    REALM_ASSERT(false); // unimplemented
-}
-
-ConstTableView::ConstTableView(const ConstTableView& src, Transaction* tr, PayloadPolicy mode)
+ConstTableView::ConstTableView(ConstTableView& src, Transaction* tr, PayloadPolicy mode)
     : m_source_column_key(src.m_source_column_key)
     , m_linked_obj_key(src.m_linked_obj_key)
     , m_key_values(Allocator::get_default())
@@ -64,6 +57,7 @@ ConstTableView::ConstTableView(const ConstTableView& src, Transaction* tr, Paylo
         m_key_values = src.m_key_values;
     }
     else if (mode == PayloadPolicy::Move && src.m_key_values.is_attached())
+        // Requires that 'src' is a writable object
         m_key_values = std::move(src.m_key_values);
     else {
         m_key_values.create();

--- a/src/realm/table_view.hpp
+++ b/src/realm/table_view.hpp
@@ -183,7 +183,6 @@ public:
     ConstTableView& operator=(const ConstTableView&);
     ConstTableView& operator=(ConstTableView&&) noexcept;
 
-    ConstTableView(const ConstTableView& source, Transaction* tr, PayloadPolicy mode);
     ConstTableView(ConstTableView& source, Transaction* tr, PayloadPolicy mode);
 
     ~ConstTableView()
@@ -246,7 +245,7 @@ public:
     // import_copy_of() machinery entry points based on dynamic type. These methods:
     // a) forward their calls to the static type entry points.
     // b) new/delete patch data structures.
-    std::unique_ptr<ConstTableView> clone_for_handover(Transaction* tr, PayloadPolicy mode) const
+    std::unique_ptr<ConstTableView> clone_for_handover(Transaction* tr, PayloadPolicy mode)
     {
         std::unique_ptr<ConstTableView> retval(new ConstTableView(*this, tr, mode));
         return retval;
@@ -474,7 +473,7 @@ public:
         return std::unique_ptr<TableView>(new TableView(*this));
     }
 
-    std::unique_ptr<TableView> clone_for_handover(Transaction* tr, PayloadPolicy policy) const
+    std::unique_ptr<TableView> clone_for_handover(Transaction* tr, PayloadPolicy policy)
     {
         std::unique_ptr<TableView> retval(new TableView(*this, tr, policy));
         return retval;

--- a/test/test_bplus_tree.cpp
+++ b/test/test_bplus_tree.cpp
@@ -349,6 +349,22 @@ TEST(BPlusTree_Copy)
     another_tree.destroy();
 }
 
+TEST(BPlusTree_Move)
+{
+    BPlusTree<Int> tree(Allocator::get_default());
+
+    auto another_tree = create_bplustree_int();
+    CHECK_EQUAL(tree.size(), 0);
+    CHECK_EQUAL(another_tree.size(), 10);
+
+    tree = std::move(another_tree);
+    CHECK_EQUAL(tree.size(), 10);
+    CHECK_EQUAL(another_tree.size(), 0);
+
+    tree.destroy();
+    another_tree.destroy();
+}
+
 TEST(BPlusTree_Performance)
 {
     // We try to optimize for add and sequential lookup

--- a/test/test_lang_bind_helper.cpp
+++ b/test/test_lang_bind_helper.cpp
@@ -3561,14 +3561,14 @@ TEST(LangBindHelper_HandoverNestedTableViews)
             writer->commit_and_continue_as_read();
             // Create a TableView tv2 that is backed by a Query that is restricted to rows from TableView tv1.
             TableView tv1 = table->where().less_equal(col, 50).find_all();
-            TableView tv2 = tv1.get_parent()->where(&tv1).find_all();
+            TableView tv2 = tv1.get_parent()->where(&tv1).greater(col, 25).find_all();
             CHECK(tv2.is_in_sync());
             reader = writer->duplicate();
             tv = reader->import_copy_of(tv2, PayloadPolicy::Move);
         }
         CHECK(tv->is_in_sync());
         CHECK(tv->is_attached());
-        CHECK_EQUAL(51, tv->size());
+        CHECK_EQUAL(25, tv->size());
     }
 }
 

--- a/test/test_table_view.cpp
+++ b/test/test_table_view.cpp
@@ -1369,7 +1369,7 @@ TEST(TableView_IsInSync)
     VersionID initial_v = initial_tr->get_version_of_current_transaction();
     CHECK_NOT_EQUAL(src_v.version, initial_v.version);
 
-    const TableView tv = table.where().find_all();
+    TableView tv = table.where().find_all();
     ConstTableView ctv0 = ConstTableView(tv, initial_tr.get(), PayloadPolicy::Copy);
     ConstTableView ctv1 = ConstTableView(tv, tr.get(), PayloadPolicy::Copy);
 


### PR DESCRIPTION
In ConstTableView constructor taking a const ConstTableView as src parameter
the copy assignment function was called in both the "Copy" and the "Move" case.
If the move assignment functions should be used, the src parameter should refer
to a writeable object as the content of m_key_values would be moved out of it.
