### PR TITLE
add missing WaitForAccessToken state handling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 ### Fixed
 * <How to hit and notice issue? what was the impact?> ([#????](https://github.com/realm/realm-core/issues/????), since v?.?.?)
 * Building for Apple platforms gave availability warnings for clock_gettime(). The code giving the warning is currently used only on Windows, so this could not actually cause crashes at runtime (v10.6.0).
+* Fixed a crash that could happen adding a upload/download notification for a sync session. ([#4638](https://github.com/realm/realm-core/pull/4638#issuecomment-832227309) since v10.6.1).
  
 ### Breaking changes
 * None.

--- a/src/realm/object-store/sync/sync_session.cpp
+++ b/src/realm/object-store/sync/sync_session.cpp
@@ -928,6 +928,9 @@ SyncSession::PublicState SyncSession::get_public_state() const
     else if (m_state == &State::inactive) {
         return PublicState::Inactive;
     }
+    else if (m_state == &State::waiting_for_access_token) {
+        return PublicState::WaitingForAccessToken;
+    }
     REALM_UNREACHABLE();
 }
 

--- a/src/realm/object-store/sync/sync_session.hpp
+++ b/src/realm/object-store/sync/sync_session.hpp
@@ -116,6 +116,7 @@ public:
         Active,
         Dying,
         Inactive,
+        WaitingForAccessToken,
     };
 
     enum class ConnectionState {


### PR DESCRIPTION
This was caught by the cocoa tests (https://github.com/realm/realm-core/pull/4638#issuecomment-832227309)
The fix is straightforward; the hardest part was coming up with a test case to trigger it.

## ☑️ ToDos
* [x] 📝 Changelog update
* [x] 🚦 Tests (or not relevant)
