### PR TITLE
Make SimulatedFailure mmap() handling thread-safe

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,7 @@
 * Updated sync client to be able to open connections to FLX sync-enabled apps in baas ([#5009](https://github.com/realm/realm-core/pull/5009))
 * SubscriptionSet::erase now returns the correct itererator for the "next" subscription ([#5053](https://github.com/realm/realm-core/pull/5053))
 * SubscriptionSet::insert_or_assign now returns an iterator pointing to the correct subscription ([#5049](https://github.com/realm/realm-core/pull/5049))
+* `SimulatedFailure` mmap handling was not thread-safe.
 
 ----------------------------------------------
 

--- a/src/realm/impl/simulated_failure.cpp
+++ b/src/realm/impl/simulated_failure.cpp
@@ -48,9 +48,7 @@ const int num_failure_types = SimulatedFailure::_num_failure_types;
 
 struct PrimeMode {
     virtual bool check_trigger() noexcept = 0;
-    virtual ~PrimeMode() noexcept
-    {
-    }
+    virtual ~PrimeMode() noexcept {}
 };
 
 struct PrimeState {
@@ -170,7 +168,7 @@ bool SimulatedFailure::do_check_trigger(FailureType failure_type) noexcept
     return false;
 }
 
-static bool (*s_mmap_predicate)(size_t);
+thread_local bool (*s_mmap_predicate)(size_t);
 
 void SimulatedFailure::do_prime_mmap(bool (*predicate)(size_t))
 {


### PR DESCRIPTION
## What, How & Why?

`SimulatedFailure` has support for intercepting calls to `mmap()` by installing a function pointer in a global variable. However, when running unit tests with `UNITTEST_THREADS=30`, the simulated failure would impact other threads.

This changes the mmap interception mechanism to be thread-local.

## ☑️ ToDos
* [x] 📝 Changelog update
* [x] 🚦 Tests (or not relevant)
