### PR TITLE
Be sure to copy string values when Mixed is used in Query

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
 * Calling Results::snapshot on dictionary values collection containing null returns incorrect results ([#4635](https://github.com/realm/realm-core/issues/4635), Not in any release)
 * Making a aggregate query on Set of Objects would cause a crash in the parser ([#4633](https://github.com/realm/realm-core/issues/4633), since v11.0.0-beta.0)
 * Copying a Query constrained by a Dictionary would crash ([#4640](https://github.com/realm/realm-core/issues/4640), since v11.0.0-beta.0)
+* Some way - used in realm-cocoa - of constructing a Query could result in a use-after-free violation ([#4670](https://github.com/realm/realm-core/pull/4670), since v11.0.0-beta.0)
  
 ### Breaking changes
 * None.

--- a/src/realm/mixed.cpp
+++ b/src/realm/mixed.cpp
@@ -595,6 +595,9 @@ StringData Mixed::get_index_data(std::array<char, 16>& buffer) const
 
 void Mixed::use_buffer(std::string& buf)
 {
+    if (is_null()) {
+        return;
+    }
     switch (get_type()) {
         case type_String:
             buf = std::string(string_val);


### PR DESCRIPTION
## What, How & Why?
Fixes an issue where the string used as argument could have been deleted when the query is run. This could happen if you constructed the Query in a way like this:
```
auto q = foo->colum<Dictionary>(col).equal(str, true).find_all();
```
and `str` would be deleted before the query was run

## ☑️ ToDos
* [x] 📝 Changelog update
* [x] 🚦 Tests (or not relevant)
