### PR TITLE
Fix DB::write_copy() of realms without history

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@
 
 ### Fixed
 * <How to hit and notice issue? what was the impact?> ([#????](https://github.com/realm/realm-core/issues/????), since v?.?.?)
-* None.
+* Writing a copy of a copy would fail on a non-synced realm ([#4672](https://github.com/realm/realm-core/pull/4672))
  
 ### Breaking changes
 * None.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@
 
 ### Fixed
 * <How to hit and notice issue? what was the impact?> ([#????](https://github.com/realm/realm-core/issues/????), since v?.?.?)
-* Writing a copy of a copy would fail on a non-synced realm ([#4672](https://github.com/realm/realm-core/pull/4672))
+* Writing a copy of a copy would fail on a non-synced realm ([#4672](https://github.com/realm/realm-core/pull/4672), since v10.7.0)
  
 ### Breaking changes
 * None.

--- a/src/realm/db.cpp
+++ b/src/realm/db.cpp
@@ -1510,10 +1510,12 @@ void DB::write_copy(StringData path, util::Optional<const char*> output_encrypti
     const char* write_key = bool(output_encryption_key) ? *output_encryption_key : m_key;
 
     auto tr = start_write();
-    if (!tr->get_history()->no_pending_local_changes(tr->get_version())) {
-        throw std::runtime_error("Could not write file as not all client changes are integrated in server");
+    if (auto hist = tr->get_history()) {
+        if (!hist->no_pending_local_changes(tr->get_version())) {
+            throw std::runtime_error("Could not write file as not all client changes are integrated in server");
+        }
+        tr->remove_sync_file_id();
     }
-    tr->remove_sync_file_id();
     tr->write(path, write_key, info->latest_version_number, true);
     tr->rollback();
 }

--- a/src/realm/group.cpp
+++ b/src/realm/group.cpp
@@ -382,8 +382,9 @@ uint64_t Group::get_sync_file_id() const noexcept
 
 void Group::remove_sync_file_id()
 {
-    REALM_ASSERT(m_top.is_attached() && m_top.size() > s_sync_file_id_ndx);
-    m_top.set(s_sync_file_id_ndx, RefOrTagged::make_tagged(0));
+    if (m_top.is_attached() && m_top.size() > s_sync_file_id_ndx) {
+        m_top.set(s_sync_file_id_ndx, RefOrTagged::make_tagged(0));
+    }
 }
 
 void Transaction::upgrade_file_format(int target_file_format_version)


### PR DESCRIPTION
## What, How & Why?
DB::write_copy would break if the realm did not have a history. When we write the copy, we will only write a history if it is a Client Sync history. So if we start with a file with InRealm history, then the copy will not have a history and cannot subsequently be used to copy from.

## ☑️ ToDos
* [x] 📝 Changelog update
* [x] 🚦 Tests (or not relevant)
