### PR TITLE
Restore original behavior of Realm::write_copy

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,14 +6,14 @@
 ### Fixed
 * <How to hit and notice issue? what was the impact?> ([#????](https://github.com/realm/realm-core/issues/????), since v?.?.?)
 * Writing a copy of a copy would fail on a non-synced realm ([#4672](https://github.com/realm/realm-core/pull/4672), since v10.7.0)
- 
+
 ### Breaking changes
 * None.
 
 -----------
 
 ### Internals
-* None.
+* Restored original behavior of Realm::write_copy(). New behavior now in Realm::write_copy_without_client_file_id.
 
 ----------------------------------------------
 

--- a/src/realm/object-store/shared_realm.cpp
+++ b/src/realm/object-store/shared_realm.cpp
@@ -714,7 +714,21 @@ bool Realm::compact()
     return m_coordinator->compact();
 }
 
-void Realm::write_copy(StringData path, BinaryData key, bool allow_overwrite)
+void Realm::write_copy(StringData path, BinaryData key)
+{
+    if (key.data() && key.size() != 64) {
+        throw InvalidEncryptionKeyException();
+    }
+    verify_thread();
+    try {
+        read_group().write(path, key.data());
+    }
+    catch (...) {
+        _impl::translate_file_exception(path);
+    }
+}
+
+void Realm::write_copy_without_client_file_id(StringData path, BinaryData key, bool allow_overwrite)
 {
     if (key.data() && key.size() != 64) {
         throw InvalidEncryptionKeyException();

--- a/src/realm/object-store/shared_realm.hpp
+++ b/src/realm/object-store/shared_realm.hpp
@@ -356,7 +356,8 @@ public:
     // because it's not crash safe! It may corrupt your database if something fails
     bool compact();
     // For synchronized realms, the file written will have the client file ident removed.
-    void write_copy(StringData path, BinaryData encryption_key, bool allow_overwrite = false);
+    void write_copy(StringData path, BinaryData encryption_key);
+    void write_copy_without_client_file_id(StringData path, BinaryData encryption_key, bool allow_overwrite = false);
     OwnedBinaryData write_copy();
 
     void verify_thread() const;

--- a/test/object-store/realm.cpp
+++ b/test/object-store/realm.cpp
@@ -563,7 +563,7 @@ TEST_CASE("Get Realm using Async Open", "[asyncOpen]") {
                 return bool(realm_ref);
             });
             SharedRealm realm = Realm::get_shared_realm(std::move(realm_ref));
-            realm->write_copy(config3.path, BinaryData());
+            realm->write_copy_without_client_file_id(config3.path, BinaryData());
         }
 
         // Create some more content on the server


### PR DESCRIPTION
## What, How & Why?
New behavior was seen as breaking.

## ☑️ ToDos
* [x] 📝 Changelog update
* [x] 🚦 Tests (or not relevant)
