### PR TITLE
Fix a crash when calling Realm::get_synchronized_realm() while waiting for an access token

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,8 +5,8 @@
 
 ### Fixed
 * <How to hit and notice issue? what was the impact?> ([#????](https://github.com/realm/realm-core/issues/????), since v?.?.?)
-* None.
- 
+* Calling Realm::get_synchronized_realm() while the session was waiting for an access token would crash ([PR #4677](https://github.com/realm/realm-core/pull/4677), since v10.6.1).
+
 ### Breaking changes
 * None.
 

--- a/src/realm/object-store/sync/sync_session.cpp
+++ b/src/realm/object-store/sync/sync_session.cpp
@@ -857,7 +857,7 @@ void SyncSession::add_completion_callback(const std::unique_lock<std::mutex>&,
                                         std::make_pair(direction, std::move(callback)));
     // If the state is inactive then just store the callback and return. The callback will get
     // re-registered with the underlying session if/when the session ever becomes active again.
-    if (get_public_state() == PublicState::Inactive) {
+    if (!m_session) {
         return;
     }
 

--- a/test/object-store/util/test_file.cpp
+++ b/test/object-store/util/test_file.cpp
@@ -222,8 +222,8 @@ TestSyncManager::TestSyncManager(const Config& config, const SyncServer::Config&
 {
     app::App::Config app_config = config.app_config;
     if (!app_config.transport_generator) {
-        app_config.transport_generator = []() -> std::unique_ptr<app::GenericNetworkTransport> {
-            REALM_ASSERT_RELEASE(false);
+        app_config.transport_generator = [this] {
+            return transport_generator();
         };
     }
 

--- a/test/object-store/util/test_file.hpp
+++ b/test/object-store/util/test_file.hpp
@@ -192,6 +192,8 @@ struct TestSyncManager {
         return m_sync_server;
     }
 
+    std::function<std::unique_ptr<realm::app::GenericNetworkTransport>()> transport_generator;
+
 private:
     std::shared_ptr<realm::app::App> m_app;
     SyncServer m_sync_server;


### PR DESCRIPTION
We need to defer adding the completion handler if the session doesn't exist for any reason, and not just if it doesn't exist because the state is currently Inactive.

A trivial fix that turned out to be fairly involved to test.