### PR TITLE
fix sum of empty dictionary and avg of empty set

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@
 * Calling Results::snapshot on dictionary values collection containing null returns incorrect results ([#4635](https://github.com/realm/realm-core/issues/4635), Not in any release)
 * Making a aggregate query on Set of Objects would cause a crash in the parser ([#4633](https://github.com/realm/realm-core/issues/4633), since v11.0.0-beta.0)
 * Copying a Query constrained by a Dictionary would crash ([#4640](https://github.com/realm/realm-core/issues/4640), since v11.0.0-beta.0)
+* Changed the average of an empty set from 0 to null. ([#4678](https://github.com/realm/realm-core/issues/4678), since v11.0.0-beta.0)
+* Changed the sum of an empty dictionary from null to 0. ([#4678](https://github.com/realm/realm-core/issues/4678), since v11.0.0-beta.0)
  
 ### Breaking changes
 * None.

--- a/src/realm/collection.hpp
+++ b/src/realm/collection.hpp
@@ -243,7 +243,12 @@ struct AverageHelper<T, std::void_t<ColumnSumType<T>>> {
     template <class U>
     static util::Optional<Mixed> eval(U& tree, size_t* return_cnt)
     {
-        return Mixed{bptree_average<T>(tree, return_cnt)};
+        size_t count = 0;
+        auto result = Mixed{bptree_average<T>(tree, &count)};
+        if (return_cnt) {
+            *return_cnt = count;
+        }
+        return count == 0 ? util::none : result;
     }
 };
 

--- a/src/realm/dictionary.cpp
+++ b/src/realm/dictionary.cpp
@@ -293,7 +293,7 @@ util::Optional<Mixed> Dictionary::min(size_t* return_ndx) const
     }
     if (return_ndx)
         *return_ndx = realm::npos;
-    return {};
+    return Mixed{};
 }
 
 util::Optional<Mixed> Dictionary::max(size_t* return_ndx) const
@@ -304,7 +304,7 @@ util::Optional<Mixed> Dictionary::max(size_t* return_ndx) const
     }
     if (return_ndx)
         *return_ndx = realm::npos;
-    return {};
+    return Mixed{};
 }
 
 util::Optional<Mixed> Dictionary::sum(size_t* return_cnt) const
@@ -315,7 +315,7 @@ util::Optional<Mixed> Dictionary::sum(size_t* return_cnt) const
     }
     if (return_cnt)
         *return_cnt = 0;
-    return {};
+    return Mixed{0};
 }
 
 util::Optional<Mixed> Dictionary::avg(size_t* return_cnt) const
@@ -326,7 +326,7 @@ util::Optional<Mixed> Dictionary::avg(size_t* return_cnt) const
     }
     if (return_cnt)
         *return_cnt = 0;
-    return {};
+    return Mixed{};
 }
 
 void Dictionary::align_indices(std::vector<size_t>& indices) const

--- a/src/realm/query_expression.hpp
+++ b/src/realm/query_expression.hpp
@@ -3463,7 +3463,7 @@ public:
                         destination.set(t, do_dictionary_agg(*dict.m_clusters));
                     }
                     else {
-                        destination.set_null(t);
+                        set_value_for_empty_dictionary(destination, t);
                     }
                 }
             }
@@ -3476,7 +3476,7 @@ public:
                     destination.set(0, do_dictionary_agg(dict_cluster));
                 }
                 else {
-                    destination.set_null(0);
+                    set_value_for_empty_dictionary(destination, 0);
                 }
             }
         }
@@ -3554,6 +3554,16 @@ private:
             return dict_cluster.sum();
         }
         REALM_UNREACHABLE();
+    }
+
+    inline void set_value_for_empty_dictionary(ValueBase& destination, size_t ndx)
+    {
+        if constexpr (std::is_same_v<Operation, aggregate_operations::Sum<Mixed>>) {
+            destination.set(ndx, 0); // the sum of nothing is zero
+        }
+        else {
+            destination.set_null(ndx);
+        }
     }
 
     ColumnsCollection<T> m_columns_collection;

--- a/test/object-store/dictionary.cpp
+++ b/test/object-store/dictionary.cpp
@@ -494,7 +494,7 @@ TEMPLATE_TEST_CASE("dictionary types", "[dictionary]", cf::MixedVal, cf::Int, cf
         }
         REQUIRE(cf::get<W>(*values_as_results.sum()) == TestType::sum());
         dict.remove_all();
-        REQUIRE(!values_as_results.sum());
+        REQUIRE(values_as_results.sum() == 0);
     }
 
     SECTION("average()") {


### PR DESCRIPTION
@leemaguire reported that the sum of an empty dictionary should be zero and not null.
I added a test to check that we are being consistent across lists/sets/dictionaries containing the same values and fixed another inconsistency with sets as well.

## ☑️ ToDos
* [x] 📝 Changelog update
* [x] 🚦 Tests (or not relevant)
