### PR TITLE
Revert Mixed::compare to use utf8 compare for strings

### DIFF
--- a/src/realm/index_string.cpp
+++ b/src/realm/index_string.cpp
@@ -1013,7 +1013,7 @@ bool StringIndex::leaf_insert(ObjKey obj_key, key_type key, size_t offset, Strin
             if (index_data == index_data_2 || suboffset > s_max_offset) {
                 // These strings have the same prefix up to this point but we
                 // don't want to recurse further, create a list in sorted order.
-                bool row_ndx_first = value < v2;
+                bool row_ndx_first = value.compare_signed(v2) < 0;
                 Array row_list(alloc);
                 row_list.create(Array::type_Normal); // Throws
                 row_list.add(row_ndx_first ? obj_key.value : obj_key2.value);
@@ -1335,11 +1335,11 @@ bool SortedListComparator::operator()(int64_t key_value, Mixed needle) // used i
     if (a == needle)
         return false;
 
-    // The StringData::operator< uses a lexicograpical comparison, therefore we
+    // The Mixed::operator< uses a lexicograpical comparison, therefore we
     // cannot use our utf8_compare here because we need to be consistent with
     // using the same compare method as how these strings were they were put
     // into this ordered column in the first place.
-    return a < needle;
+    return a.compare_signed(needle) < 0;
 }
 
 
@@ -1403,7 +1403,7 @@ void StringIndex::verify() const
                     while (it != it_end) {
                         Mixed it_data = get(ObjKey(*it));
                         size_t it_row = to_size_t(*it);
-                        REALM_ASSERT(previous <= it_data);
+                        REALM_ASSERT(previous.compare_signed(it_data) <= 0);
                         if (it != sub.cbegin() && previous == it_data) {
                             REALM_ASSERT_EX(it_row > last_row, it_row, last_row);
                         }

--- a/src/realm/mixed.cpp
+++ b/src/realm/mixed.cpp
@@ -55,7 +55,7 @@ inline int compare_string(StringData a, StringData b)
 {
     if (a == b)
         return 0;
-    return a < b ? -1 : 1;
+    return utf8_compare(a, b) ? -1 : 1;
 }
 
 inline int compare_binary(BinaryData a, BinaryData b)
@@ -355,12 +355,12 @@ int Mixed::compare(const Mixed& b) const
     return (_impl::sorting_rank[m_type] > _impl::sorting_rank[b.m_type]) ? 1 : -1;
 }
 
-int Mixed::compare_utf8(const Mixed& b) const
+int Mixed::compare_signed(const Mixed& b) const
 {
     if (is_type(type_String) && b.is_type(type_String)) {
         auto a_val = get_string();
         auto b_val = b.get_string();
-        return a_val == b_val ? 0 : utf8_compare(a_val, b_val) ? -1 : 1;
+        return a_val == b_val ? 0 : a_val < b_val ? -1 : 1;
     }
     return compare(b);
 }

--- a/src/realm/mixed.hpp
+++ b/src/realm/mixed.hpp
@@ -200,8 +200,10 @@ public:
     bool accumulate_numeric_to(Decimal128& destination) const;
     bool is_unresolved_link() const;
     bool is_same_type(const Mixed& b) const;
+    // Will use utf8_compare for strings
     int compare(const Mixed& b) const;
-    int compare_utf8(const Mixed& b) const;
+    // Will compare strings as arrays of signed chars
+    int compare_signed(const Mixed& b) const;
     bool operator==(const Mixed& other) const
     {
         return compare(other) == 0;

--- a/src/realm/sort_descriptor.cpp
+++ b/src/realm/sort_descriptor.cpp
@@ -309,7 +309,7 @@ bool BaseDescriptor::Sorter::operator()(IndexPair i, IndexPair j, bool total_ord
         int c;
 
         if (t == 0) {
-            c = i.cached_value.compare_utf8(j.cached_value);
+            c = i.cached_value.compare(j.cached_value);
         }
         else {
             if (m_cache[t - 1].empty()) {
@@ -336,7 +336,7 @@ bool BaseDescriptor::Sorter::operator()(IndexPair i, IndexPair j, bool total_ord
                 cache_j.key = key_j;
             }
 
-            c = val_i.compare_utf8(cache_j.value);
+            c = val_i.compare(cache_j.value);
         }
         // if c is negative i comes before j
         if (c) {


### PR DESCRIPTION
Reverts some functionality introduced by feaa559e538b59. 
Values should be sorted consistently. We use utf8_compare in SortDescriptor.

Add new function that can be used by string index. String index requires
that strings are compared as signed bytes. It should match the way the
keys are compared.
