### PR TITLE
Use same rules for handling numeric values in sets as MongoDB uses

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@
 * Changed the sum of an empty dictionary from null to 0. ([#4678](https://github.com/realm/realm-core/issues/4678), since v11.0.0-beta.0)
 * Some way - used in realm-cocoa - of constructing a Query could result in a use-after-free violation ([#4670](https://github.com/realm/realm-core/pull/4670), since v11.0.0-beta.0)
 * Fix the order of a sorted set of mixed values. ([#4662](https://github.com/realm/realm-core/pull/4662), since v11.0.0-beta.0)
+* Use same rules for handling numeric values in sets as MongoDB uses. All numeric values are compared using the value irregardless of the type.  ([#4686](https://github.com/realm/realm-core/pull/4686), since v11.0.0-beta.0)
  
 ### Breaking changes
 * None.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@
 * Changed the average of an empty set from 0 to null. ([#4678](https://github.com/realm/realm-core/issues/4678), since v11.0.0-beta.0)
 * Changed the sum of an empty dictionary from null to 0. ([#4678](https://github.com/realm/realm-core/issues/4678), since v11.0.0-beta.0)
 * Some way - used in realm-cocoa - of constructing a Query could result in a use-after-free violation ([#4670](https://github.com/realm/realm-core/pull/4670), since v11.0.0-beta.0)
+* Fix the order of a sorted set of mixed values. ([#4662](https://github.com/realm/realm-core/pull/4662), since v11.0.0-beta.0)
  
 ### Breaking changes
 * None.

--- a/src/realm/mixed.cpp
+++ b/src/realm/mixed.cpp
@@ -30,7 +30,7 @@ namespace realm {
 namespace _impl {
 
 static const int sorting_rank[19] = {
-    // OBS. Changing these values breaks the file format for Set<Mixed>
+    // Observe! Changing these values breaks the file format for Set<Mixed>
 
     -1, // null
     1,  // type_Int = 0,
@@ -52,7 +52,7 @@ static const int sorting_rank[19] = {
     6, // type_TypedLink = 16
     5, // type_UUID = 17
 
-    // OBS. Changing these values breaks the file format for Set<Mixed>
+    // Observe! Changing these values breaks the file format for Set<Mixed>
 };
 
 inline int compare_string(StringData a, StringData b)
@@ -238,7 +238,7 @@ bool Mixed::accumulate_numeric_to(Decimal128& destination) const
 
 int Mixed::compare(const Mixed& b) const
 {
-    // OBS. Changing this function breaks the file format for Set<Mixed>
+    // Observe! Changing this function breaks the file format for Set<Mixed>
 
     if (is_null()) {
         return b.is_null() ? 0 : -1;
@@ -359,7 +359,7 @@ int Mixed::compare(const Mixed& b) const
     // Using rank table will ensure that all numeric values are kept together
     return (_impl::sorting_rank[m_type] > _impl::sorting_rank[b.m_type]) ? 1 : -1;
 
-    // OBS. Changing this function breaks the file format for Set<Mixed>
+    // Observe! Changing this function breaks the file format for Set<Mixed>
 }
 
 int Mixed::compare_signed(const Mixed& b) const

--- a/src/realm/mixed.cpp
+++ b/src/realm/mixed.cpp
@@ -30,6 +30,8 @@ namespace realm {
 namespace _impl {
 
 static const int sorting_rank[19] = {
+    // OBS. Changing these values breaks the file format for Set<Mixed>
+
     -1, // null
     1,  // type_Int = 0,
     0,  // type_Bool = 1,
@@ -44,11 +46,13 @@ static const int sorting_rank[19] = {
     1,  // type_Double = 10,
     1,  // type_Decimal = 11,
     7,  // type_Link = 12,
-    8,  // type_LinkList = 13,
+    -1, // type_LinkList = 13,
     -1,
     4, // type_ObjectId = 15,
-    5, // type_TypedLink = 16
-    6, // type_UUID = 17
+    6, // type_TypedLink = 16
+    5, // type_UUID = 17
+
+    // OBS. Changing these values breaks the file format for Set<Mixed>
 };
 
 inline int compare_string(StringData a, StringData b)
@@ -234,6 +238,8 @@ bool Mixed::accumulate_numeric_to(Decimal128& destination) const
 
 int Mixed::compare(const Mixed& b) const
 {
+    // OBS. Changing this function breaks the file format for Set<Mixed>
+
     if (is_null()) {
         return b.is_null() ? 0 : -1;
     }
@@ -348,11 +354,12 @@ int Mixed::compare(const Mixed& b) const
             break;
     }
 
-    // Comparing types as a fallback option makes it possible to make a sort of a list of Mixed
-    // This will also handle the case where null values are considered lower than all other values
+    // Comparing rank of types as a fallback makes it possible to sort of a list of Mixed
     REALM_ASSERT(_impl::sorting_rank[m_type] != _impl::sorting_rank[b.m_type]);
-    // Using rank table will ensure that all numeric values comes first
+    // Using rank table will ensure that all numeric values are kept together
     return (_impl::sorting_rank[m_type] > _impl::sorting_rank[b.m_type]) ? 1 : -1;
+
+    // OBS. Changing this function breaks the file format for Set<Mixed>
 }
 
 int Mixed::compare_signed(const Mixed& b) const

--- a/test/object-store/set.cpp
+++ b/test/object-store/set.cpp
@@ -240,7 +240,6 @@ TEMPLATE_TEST_CASE("set all types", "[set]", cf::MixedVal, cf::Int, cf::Bool, cf
                 REQUIRE(!set.average());
                 REQUIRE(!set_as_results.average());
             }
-            /* FIXME
             SECTION("sort") {
                 SECTION("ascending") {
                     auto sorted = set_as_results.sort({{"self", true}});
@@ -253,7 +252,6 @@ TEMPLATE_TEST_CASE("set all types", "[set]", cf::MixedVal, cf::Int, cf::Bool, cf
                     REQUIRE(sorted == values);
                 }
             }
-            */
         }
     }
 }

--- a/test/test_set.cpp
+++ b/test/test_set.cpp
@@ -120,9 +120,9 @@ TEST(Set_Mixed)
                                   56.f,
                                   88.,
                                   "Hello, World!",
-                                  "æbler",
-                                  "ørken",
-                                  "ådsel",
+                                  "æbler", // Apples
+                                  "ørken", // Dessert
+                                  "ådsel", // Carrion
                                   Timestamp(1, 2),
                                   ObjectId::gen(),
                                   UUID("01234567-9abc-4def-9012-3456789abcde"),

--- a/test/test_sync.cpp
+++ b/test/test_sync.cpp
@@ -8242,8 +8242,8 @@ TEST(Sync_Set)
 
         CHECK_EQUAL(mixeds.size(), 3);
         CHECK_EQUAL(mixeds.find(123), 0);
-        CHECK_EQUAL(mixeds.find("a"), 1);
-        CHECK_EQUAL(mixeds.find(456.0), 2);
+        CHECK_EQUAL(mixeds.find(456.0), 1);
+        CHECK_EQUAL(mixeds.find("a"), 2);
 
         session_1.nonsync_transact_notify(wt.commit());
     }

--- a/test/test_types_helper.hpp
+++ b/test/test_types_helper.hpp
@@ -122,9 +122,9 @@ inline Mixed TestValueGenerator::convert_for_test<Mixed>(int64_t v)
     static std::vector<Mixed> arr = {4, 5.6, Timestamp(5, 6), "Hello", false};
     switch (v & 0x7) {
         case 0:
-            return Mixed(v);
-        case 1:
             return Mixed(true);
+        case 1:
+            return Mixed(v);
         case 2:
             return Mixed(convert_for_test<StringData>(v));
         case 3:


### PR DESCRIPTION
The way we handle sets should be consistent with the way they are handled on the server side.

## ☑️ ToDos
* [ ] 📝 Changelog update
* [x] 🚦 Tests (or not relevant)
