### PR TITLE
Guard against unresolved links in the change checker

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
   TableRecycler at the top of the stack ([#4600](https://github.com/realm/realm-core/issues/4600), since v6)
 * Calling Realm::get_synchronized_realm() while the session was waiting for an access token would crash ([PR #4677](https://github.com/realm/realm-core/pull/4677), since v10.6.1).
 * Fixed errors related to "uncaught exception in notifier thread: N5realm11KeyNotFoundE: No such object". This could happen in a sync'd app when a linked object was deleted by another client. ([realm-js#3611](https://github.com/realm/realm-js/issues/3611), since v6.1.0-alpha.5)
+* Changed the behaviour of `Object::get_property_value(Context)` when fetching an unresolved link from returning an empty Object, to returning null which is consistent with how this method behaves on a null link. ([#4687](https://github.com/realm/realm-core/pull/4687), since v6.1.0-alpha.5)
 
 ### Breaking changes
 * None.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 * Destruction of the TableRecycler at exit  was unordered compared to other threads running. This could lead to crashes, some with the
   TableRecycler at the top of the stack ([#4600](https://github.com/realm/realm-core/issues/4600), since v6)
 * Calling Realm::get_synchronized_realm() while the session was waiting for an access token would crash ([PR #4677](https://github.com/realm/realm-core/pull/4677), since v10.6.1).
+* Fixed errors related to "uncaught exception in notifier thread: N5realm11KeyNotFoundE: No such object". This could happen in a sync'd app when a linked object was deleted by another client. ([realm-js#3611](https://github.com/realm/realm-js/issues/3611), since v6.1.0-alpha.5)
 
 ### Breaking changes
 * None.

--- a/src/realm/array_key.hpp
+++ b/src/realm/array_key.hpp
@@ -95,7 +95,8 @@ public:
     }
     bool is_null(size_t ndx) const
     {
-        return Array::get(ndx) == 0;
+        ObjKey key = get(ndx);
+        return !key || key.is_unresolved();
     }
     void move(ArrayKeyBase& dst, size_t ndx)
     {

--- a/src/realm/object-store/impl/collection_notifier.cpp
+++ b/src/realm/object-store/impl/collection_notifier.cpp
@@ -129,7 +129,7 @@ bool DeepChangeChecker::check_outgoing_links(TableKey table_key, Table const& ta
         if (already_checking(link.col_key))
             return false;
         if (!link.is_list) {
-            if (obj.is_null(ColKey(link.col_key)))
+            if (obj.is_null(ColKey(link.col_key)) || obj.is_unresolved(ColKey(link.col_key)))
                 return false;
             auto dst = obj.get<ObjKey>(ColKey(link.col_key)).value;
             return check_row(*table.get_link_target(ColKey(link.col_key)), dst, depth + 1);

--- a/src/realm/object-store/impl/collection_notifier.cpp
+++ b/src/realm/object-store/impl/collection_notifier.cpp
@@ -129,10 +129,10 @@ bool DeepChangeChecker::check_outgoing_links(TableKey table_key, Table const& ta
         if (already_checking(link.col_key))
             return false;
         if (!link.is_list) {
-            if (obj.is_null(ColKey(link.col_key)) || obj.is_unresolved(ColKey(link.col_key)))
+            ObjKey dst_key = obj.get<ObjKey>(ColKey(link.col_key));
+            if (!dst_key) // do not descend into a null or unresolved link
                 return false;
-            auto dst = obj.get<ObjKey>(ColKey(link.col_key)).value;
-            return check_row(*table.get_link_target(ColKey(link.col_key)), dst, depth + 1);
+            return check_row(*table.get_link_target(ColKey(link.col_key)), dst_key.value, depth + 1);
         }
 
         auto& target = *table.get_link_target(ColKey(link.col_key));

--- a/src/realm/object-store/object_accessor.hpp
+++ b/src/realm/object-store/object_accessor.hpp
@@ -112,7 +112,7 @@ void Object::set_property_value_impl(ContextType& ctx, const Property& property,
         if (!policy.diff || !m_obj.is_null(col)) {
             if (property.type == PropertyType::Object) {
                 if (!is_default)
-                    m_obj.set_null(col); // FIXME: setting null on an unresolved link causes some bug
+                    m_obj.set_null(col);
             }
             else {
                 m_obj.set_null(col, is_default);

--- a/src/realm/object-store/object_accessor.hpp
+++ b/src/realm/object-store/object_accessor.hpp
@@ -112,7 +112,7 @@ void Object::set_property_value_impl(ContextType& ctx, const Property& property,
         if (!policy.diff || !m_obj.is_null(col)) {
             if (property.type == PropertyType::Object) {
                 if (!is_default)
-                    m_obj.set_null(col);
+                    m_obj.set_null(col); // FIXME: setting null on an unresolved link causes some bug
             }
             else {
                 m_obj.set_null(col, is_default);

--- a/test/object-store/object.cpp
+++ b/test/object-store/object.cpp
@@ -1272,8 +1272,9 @@ TEST_CASE("object") {
 
         CHECK_FALSE(obj.get_property_value<util::Any>(d, "object").has_value());
 
-        // setting a null on an unresolved link corrupts the memory in a way which causes an assertion on rollback
         obj.set_property_value(d, "object", util::Any());
+        // Cancelling a transaction in which the first tombstone was created, caused the program to crash
+        // because we tried to update m_tombstones on a null ref. Now fixed
         r->cancel_transaction();
     }
 

--- a/test/object-store/transaction_log_parsing.cpp
+++ b/test/object-store/transaction_log_parsing.cpp
@@ -1725,6 +1725,35 @@ TEST_CASE("DeepChangeChecker") {
         REQUIRE_FALSE(_impl::DeepChangeChecker(info, *table, tables)(3));
     }
 
+    SECTION("changes from an object with an unresolved link") {
+        r->begin_transaction();
+        size_t obj_ndx_to_invalidate = 6;
+        ColKey col_link1 = cols[1];
+        objects[0].set(col_link1, objects[obj_ndx_to_invalidate].get_key());
+        ObjKey link = objects[0].get<ObjKey>(col_link1);
+        REQUIRE(!link.is_unresolved());
+        REQUIRE(link);
+
+        // Object invalidation can only happen if another sync client has deleted the object
+        // we simulate this by calling it directly here. The consequence is that links to this
+        // object are changed to the invalidated key, but not removed. This tests that the
+        // change checker doesn't try to descend down invalidated link paths.
+        objects[obj_ndx_to_invalidate].invalidate();
+
+        // the link is actually unresolved, but that is hidden by a null at this level of abstraction
+        link = objects[0].get<ObjKey>(col_link1);
+        REQUIRE(!link.is_unresolved());
+        REQUIRE(!link);
+        r->commit_transaction();
+
+        auto info = track_changes([&] {
+            objects[1].set(cols[0], 10);
+        });
+        // if the change checker iterates over an invalid link, it'll throw an exception
+        REQUIRE_FALSE(_impl::DeepChangeChecker(info, *table, tables)(0));
+        REQUIRE(_impl::DeepChangeChecker(info, *table, tables)(1));
+    }
+
     SECTION("cycles over links do not loop forever") {
         r->begin_transaction();
         objects[0].set(cols[1], objects[0].get_key());


### PR DESCRIPTION
`obj.is_null(ColKey(link.col_key)` returns false for an unresolved link, but `obj.get<ObjKey>(ColKey(link.col_key))` returns a null ObjKey for an unresolved link. This mismatch caused the change checker to try to descend down an unresolved link.

It is essentially the single link version of the same error we fixed for link lists earlier: https://github.com/realm/realm-core/pull/4175

I believe it should fix this report https://github.com/realm/realm-js/issues/3611#issuecomment-823014128 as well as https://jira.mongodb.org/browse/HELP-24406 and https://jira.mongodb.org/browse/HELP-23982

## ☑️ ToDos
* [x] 📝 Changelog update
* [x] 🚦 Tests (or not relevant)
