### PR TITLE
finishing read-only thread safe reference

### DIFF
--- a/src/realm/object-store/shared_realm.cpp
+++ b/src/realm/object-store/shared_realm.cpp
@@ -503,13 +503,6 @@ void Realm::notify_schema_changed()
     }
 }
 
-static void check_can_create_any_transaction(const Realm* realm)
-{
-    if (realm->config().immutable()) {
-        throw InvalidTransactionException("Can't perform transactions on read-only Realms.");
-    }
-}
-
 static void check_can_create_write_transaction(const Realm* realm)
 {
     if (realm->config().immutable() || realm->config().read_only_alternative()) {
@@ -571,14 +564,12 @@ VersionID Realm::read_transaction_version() const
 {
     verify_thread();
     verify_open();
-    check_can_create_any_transaction(this);
     return m_transaction->get_version_of_current_transaction();
 }
 
 uint_fast64_t Realm::get_number_of_versions() const
 {
     verify_open();
-    check_can_create_any_transaction(this);
     return m_coordinator->get_number_of_versions();
 }
 
@@ -681,7 +672,6 @@ void Realm::invalidate()
 {
     verify_open();
     verify_thread();
-    check_can_create_any_transaction(this);
 
     if (m_is_sending_notifications) {
         // This was originally because closing the Realm during notification
@@ -812,7 +802,6 @@ void Realm::notify()
 bool Realm::refresh()
 {
     verify_thread();
-    check_can_create_any_transaction(this);
     return do_refresh();
 }
 

--- a/test/object-store/thread_safe_reference.cpp
+++ b/test/object-store/thread_safe_reference.cpp
@@ -274,6 +274,48 @@ TEST_CASE("thread safe reference") {
     }
 
     SECTION("passing over") {
+        SECTION("read-only `ThreadSafeReference`") {
+            // We need to create a new `configuration` for the read-only tests since the `InMemoryTestFile` will be
+            // gone as soon as we `close()` it which we need to do so we can re-open it in read-only after preparing /
+            // writing data to it.
+            TestFile configuration;
+            SharedRealm realm = Realm::get_shared_realm(configuration);
+            realm->update_schema(schema);
+            realm->begin_transaction();
+            create_object(realm, "int object", {{"value", INT64_C(42)}});
+            realm->commit_transaction();
+            realm->close();
+            configuration.schema_mode = SchemaMode::Immutable;
+            SharedRealm read_only_realm = Realm::get_shared_realm(configuration);
+            auto table = read_only_realm->read_group().get_table("class_int object");
+            Results results(read_only_realm, table);
+            REQUIRE(results.size() == 1);
+            REQUIRE(results.get(0).get<int64_t>(int_obj_col) == 42);
+
+            SECTION("read-only `ThreadSafeReference` to `Results`") {
+                auto thread_safe_results = ThreadSafeReference(results);
+                std::thread([thread_safe_results = std::move(thread_safe_results), configuration,
+                             int_obj_col]() mutable {
+                    SharedRealm realm_in_thread = Realm::get_shared_realm(configuration);
+                    Results resolved_results = thread_safe_results.resolve<Results>(realm_in_thread);
+                    REQUIRE(resolved_results.size() == 1);
+                    REQUIRE(resolved_results.get(0).get<int64_t>(int_obj_col) == 42);
+                }).join();
+            }
+
+            SECTION("read-only `ThreadSafeReference` to an `Object`") {
+                Object object(read_only_realm, results.get(0));
+                auto thread_safe_object = ThreadSafeReference(object);
+                std::thread([thread_safe_object = std::move(thread_safe_object), configuration,
+                             int_obj_col]() mutable {
+                    SharedRealm realm_in_thread = Realm::get_shared_realm(configuration);
+                    auto resolved_object = thread_safe_object.resolve<Object>(realm_in_thread);
+                    REQUIRE(resolved_object.is_valid());
+                    REQUIRE(resolved_object.obj().get<int64_t>(int_obj_col) == 42);
+                }).join();
+            }
+        }
+
         SECTION("objects") {
             r->begin_transaction();
             auto str = create_object(r, "string object", {});


### PR DESCRIPTION
Add a test of using thread safe references on an immutable Realm.
Removed the function 'check_can_create_any_transaction()' as it is
non needed anymore, since any open realm, immutable or not, now
supports read transactions.

## ☑️ ToDos
* [ ] 📝 Changelog update
* [x] 🚦 Tests (or not relevant)
