### PR TITLE
changelog entry for fix of thread-safe references on immutable Realms

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
   TableRecycler at the top of the stack ([#4600](https://github.com/realm/realm-core/issues/4600), since v6)
 * Calling Realm::get_synchronized_realm() while the session was waiting for an access token would crash ([PR #4677](https://github.com/realm/realm-core/pull/4677), since v10.6.1).
 * Opening a metadata realm with the wrong encryption key or different encryption configuration will remove that metadata realm and create a new metadata realm using the new key or configuration. [#4285](https://github.com/realm/realm-core/pull/4285)
+* A read-only Realm does not support `ThreadSafeReference` ([Cocoa #5475](https://github.com/realm/realm-cocoa/issues/5475)).
 
 ### Breaking changes
 * None.


### PR DESCRIPTION
Add the missed changelog update for #4688 

* [x] 📝 Changelog update
