### PR TITLE
Adjust stitch path in .devcontainer settings.

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -13,8 +13,10 @@
         "cmake.configureSettings": {
             "REALM_ENABLE_AUTH_TESTS": "ON",
             "REALM_MONGODB_ENDPOINT": "http://mongodb-realm:9090",
-            "REALM_STITCH_CONFIG": "/realm-core/test/mongodb/config.json",
-        }
+            "REALM_STITCH_CONFIG": "/realm-core/test/object-store/mongodb/config.json",
+        },
+        "cmake.cmakePath": "cmake",
+        "cmake.generator": "Ninja"
     },
 
     // Add the IDs of extensions you want installed when the container is created.


### PR DESCRIPTION
## What, How & Why?
The `mongodb/config.json` was moved to `realm-core/test/object-store` in a prior PR.
This PR fixes the path in `.devcontainer` to point to the correct folder.

Also sets the `cmakePath` and `generator` within the settings.

## ☑️ ToDos
* [ ] 📝 Changelog update
* [X] 🚦 Tests (or not relevant)
