### PR TITLE
RCORE-440 Add basic bloaty integration to evergreen

### DIFF
--- a/evergreen/bloaty_to_json.py
+++ b/evergreen/bloaty_to_json.py
@@ -1,0 +1,155 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import argparse
+import json
+import re
+from csv import DictReader
+from pathlib import Path
+
+parser = argparse.ArgumentParser(description='Checks how bloated realm has become')
+parser.add_argument(
+    '--short-symbols-input',
+    type=Path,
+    help='Path to CSV output of short symbols input file',
+)
+parser.add_argument(
+    '--sections-input',
+    type=Path,
+    help='Path to CSV output of sections input file',
+)
+
+parser.add_argument(
+    '--analyzed-file',
+    type=str,
+    help='Name of file being analyzed by bloaty',
+)
+
+evgOpts = parser.add_argument_group('Evergreen Metadata')
+evgOpts.add_argument('--output', type=Path, help='The evergreen json output filename')
+evgOpts.add_argument('--project', type=str, help='Evergreen project this script is running in')
+evgOpts.add_argument('--execution', type=int, help='Execution # of this evergreen task')
+evgOpts.add_argument(
+    '--is-patch',
+    type=bool,
+    dest='is_patch',
+    help='Specify if this is not a patch build',
+)
+evgOpts.add_argument(
+    '--build-variant',
+    type=str,
+    dest='build_variant',
+    help='Build variant of the evergreen task',
+)
+evgOpts.add_argument('--branch', type=str, help='Git branch that was being tested')
+evgOpts.add_argument('--revision', type=str, help='Git sha being tested')
+evgOpts.add_argument('--task-id', type=str, dest='task_id', help='Evergreen task ID of this task')
+evgOpts.add_argument('--task-name', type=str, dest='task_name', help='Name of this evergreen task')
+evgOpts.add_argument(
+    '--revision-order-id',
+    type=str,
+    dest='revision_order_id',
+    help='Evergreen revision order id',
+)
+evgOpts.add_argument('--version-id', type=str, dest='version_id', help='Name of this evergreen version')
+
+args = parser.parse_args()
+patch_username : str = ''
+
+def parse_patch_order():
+    global patch_username
+    patch_order_re = re.compile(r"(?P<patch_username>[\w\@\.]+)_(?P<patch_order>\d+)")
+    match_obj = patch_order_re.match(args.revision_order_id)
+    patch_username = match_obj.group('patch_username')
+    return int(match_obj.group('patch_order'))
+evg_order = int(args.revision_order_id) if not args.is_patch else parse_patch_order()
+
+cxx_method_re = re.compile(
+        # namespaces/parent class name
+        r"(?P<ns>(?:(?:[_a-zA-Z][\w]*)(?:<.*>)?(?:::)|(?:\(anonymous namespace\)::))+)" +
+        r"(?P<name>[\~a-zA-Z_][\w]*)(?:<.*>)?" + # function/class name
+        r"(?P<is_function>\(\))?" + # if this is function, this will capture "()"
+        # will be a number if this is a lambda
+        r"(?:::\{lambda\(\)\#(?P<lambda_number>\d+)\}::)?")
+
+elf_section_re = re.compile(r"\[section \.(?P<section_name>[\w\.\-]+)\]")
+
+items : list[dict] = []
+sections_seen = set()
+if args.short_symbols_input:
+    with open(args.short_symbols_input, 'r') as csv_file:
+        input_csv_reader = DictReader(csv_file)
+        for row in input_csv_reader:
+            raw_name = row['shortsymbols']
+            if match := cxx_method_re.search(raw_name):
+                ns = match.group('ns').rstrip(':')
+
+                node_name = match.group('name')
+                if match.group('lambda_number'):
+                    node_name = "{} lambda #{}".format(node_name, match.group('lambda_number'))
+
+                type_str: str = 'symbol'
+                if match.group('lambda_number'):
+                   type_str = 'lambda'
+                elif match.group('is_function'):
+                   type_str = 'function'
+
+                items.append({
+                    'type': type_str,
+                    'name': raw_name,
+                    'ns': ns,
+                    'file_size': int(row['filesize']),
+                    'vm_size': int(row['vmsize']),
+                })
+
+            elif match := elf_section_re.search(raw_name):
+                section_name = match.group('section_name')
+                type_str: str = 'section' if not section_name.startswith('.debug') else 'debug_section'
+                if section_name not in sections_seen:
+                    items.append({
+                        'type': type_str,
+                        'name': section_name,
+                        'file_size': int(row['filesize']),
+                        'vm_size': int(row['vmsize'])
+                    })
+            else:
+                items.append({
+                    'type': 'symbol',
+                    'name': raw_name,
+                    'file_size': int(row['filesize']),
+                    'vm_size': int(row['vmsize']),
+                })
+
+if args.sections_input:
+    with open(args.sections_input, 'r') as csv_file:
+        input_csv_reader = DictReader(csv_file)
+
+        for row in input_csv_reader:
+            section_name = row['sections']
+            type_str: str = 'section' if not section_name.startswith('.debug') else 'debug_section'
+            if section_name not in sections_seen:
+                items.append({
+                    'name': section_name,
+                    'type': type_str,
+                    'file_size': int(row['filesize']),
+                    'vm_size': int(row['vmsize'])
+                })
+
+output_obj = {
+    'items': items,
+    'execution': args.execution,
+    'is_mainline': (args.is_patch is not True),
+    'analyzed_file': args.analyzed_file,
+    'order': evg_order,
+    'project': args.project,
+    'branch': args.branch,
+    'build_variant': args.build_variant,
+    'revision': args.revision,
+    'task_id': args.task_id,
+    'task_name': args.task_name,
+    'version_id': args.version_id,
+    'patch_username': patch_username
+}
+
+with open(args.output, 'w') as out_fp:
+    json.dump(output_obj, out_fp)

--- a/evergreen/config.yml
+++ b/evergreen/config.yml
@@ -209,6 +209,102 @@ tasks:
       local_file: 'realm-core/build/realm-core-artifacts-runtime.tar.gz'
       content_type: '${content_type|application/x-gzip}'
 
+- name: bloaty
+  commands:
+  - func: "fetch source"
+  - func: "fetch binaries"
+  - func: "compile"
+    vars:
+      target_to_build: RealmFFI
+  - command: shell.exec
+    params:
+      working_dir: realm-core
+      shell: /bin/bash
+      script: |-
+        #!/bin/bash
+        set -o errexit
+        set -o pipefail
+        set -o verbose
+
+        mkdir bloaty-binaries && cd bloaty-binaries
+        curl --silent -L ${bloaty_url} | tar -xz --strip-components=1
+        BLOATY=$(pwd)/bin/bloaty
+        cd ..
+
+        FILES_TO_ANALYZE="./build/src/realm/object-store/c_api/librealm-ffi.so"
+
+        mkdir bloaty-results
+        for input_path in $FILES_TO_ANALYZE; do
+            input_file=$(basename $input_path)
+            $BLOATY -d shortsymbols $input_path -n 0 --csv > "bloaty-results/$input_file-shortsymbols.csv"
+            $BLOATY -d sections $input_path -n 0 --csv > "bloaty-results/$input_file-sections.csv"
+            $BLOATY -d shortsymbols $input_path -n 0 > "bloaty-results/$input_file-shortsymbols.txt"
+            $BLOATY -d sections $input_path -n 0 > "bloaty-results/$input_file-sections.txt"
+
+            echo "Bloaty sections output for $input_file"
+            head -n 100 "bloaty-results/$input_file-sections.txt"
+            echo
+            echo "Bloaty short symbols output for $input_file"
+            head -n 100 "bloaty-results/$input_file-shortsymbols.txt"
+
+            ${python3|} ./evergreen/bloaty_to_json.py \
+                --short-symbols-input="bloaty-results/$input_file-shortsymbols.csv" \
+                --sections-input="bloaty-results/$input_file-sections.csv" \
+                --analyzed-file=$input_file \
+                --output "bloaty-results/$input_file-results.json" \
+                --project=${project} \
+                --execution=${execution} \
+                --is-patch=${is_patch} \
+                --build-variant=${build_variant} \
+                --branch=${branch_name} \
+                --revision=${revision} \
+                --task-id=${task_id} \
+                --task-name=${task_name} \
+                --revision-order-id=${revision_order_id} \
+                --version-id=${version_id}
+
+            # TODO(JBR) This is pointing to a test application for now. When we have charts configured we can create
+            # a real realm app to house them and this URL will change.
+            curl \
+                -H "Content-Type: application/json" \
+                -d "@bloaty-results/$input_file-results.json" \
+                https://us-east-1.aws.webhooks.mongodb-realm.com/api/client/v2.0/app/application-0-htnkr/service/http1/incoming_webhook/upload_bloaty_results?secret=${bloaty_secret}
+        done
+
+  - command: s3.put
+    params:
+      aws_key: '${artifacts_aws_access_key}'
+      aws_secret: '${artifacts_aws_secret_key}'
+      local_files_include_filter:
+        - realm-core/bloaty-results/*.csv
+      remote_file: '${project}/${branch_name}/${task_id}/${execution}/bloaty-results-'
+      bucket: mciuploads
+      permissions: public-read
+      content_type: text/csv
+      display_name: bloaty-results
+  - command: s3.put
+    params:
+      aws_key: '${artifacts_aws_access_key}'
+      aws_secret: '${artifacts_aws_secret_key}'
+      local_files_include_filter:
+        - realm-core/bloaty-results/*.txt
+      remote_file: '${project}/${branch_name}/${task_id}/${execution}/bloaty-results-'
+      bucket: mciuploads
+      permissions: public-read
+      content_type: text/text
+      display_name: bloaty-results
+  - command: s3.put
+    params:
+      aws_key: '${artifacts_aws_access_key}'
+      aws_secret: '${artifacts_aws_secret_key}'
+      local_files_include_filter:
+        - realm-core/bloaty-results/*.json
+      remote_file: '${project}/${branch_name}/${task_id}/${execution}/bloaty-results-'
+      bucket: mciuploads
+      permissions: public-read
+      content_type: application/json
+      display_name: bloaty-results
+
 - name: long-running-core-tests
   commands:
   - func: "run tests"
@@ -435,12 +531,14 @@ buildvariants:
   expansions:
     clang_url: "https://s3.amazonaws.com/static.realm.io/evergreen-assets/clang%2Bllvm-11.0.0-x86_64-linux-gnu-ubuntu-20.04.tar.xz"
     cmake_url: "https://s3.amazonaws.com/static.realm.io/evergreen-assets/cmake-3.19.1-Linux-x86_64.tar.gz"
+    bloaty_url: "https://s3.amazonaws.com/static.realm.io/evergreen-assets/bloaty-v1.1-39-gefc1c61-ubuntu2004-x86_64.tar.gz"
     cmake_bindir: "./cmake_binaries/bin"
     cmake_build_type: Release
     fetch_missing_dependencies: On
     run_tests_against_baas: On
     c_compiler: "./clang_binaries/bin/clang"
     cxx_compiler: "./clang_binaries/bin/clang++"
+    python3: /opt/mongodbtoolchain/v3/bin/python3
   tasks:
   - name: compile_test_and_package
     distros:
@@ -449,6 +547,7 @@ buildvariants:
     distros:
     - ubuntu2004-large
   - name: long-running-tests
+  - name: bloaty
 
 - name: ubuntu2004-asan
   display_name: "Ubuntu 20.04 x86_64 (Clang 11 ASAN)"


### PR DESCRIPTION
This adds some very basic bloaty integration to evergreen. On the Ubuntu release builder, we'll run bloaty against librealm-ffi.so, collecting the `sections` and `shortsymbols` outputs in both CSV/text file format. There's also a new python script that will transform the CSV files into json format with metadata about where/how it was generated in evergreen that gets uploaded to MongoDB so we can visualize this data later on with charts and graphs. All the generated files also get uploaded to S3 and attached to the task in evergreen so we can go look at them later.