### PR TITLE
RCORE-719 create baas app dynamically

### DIFF
--- a/evergreen/config.yml
+++ b/evergreen/config.yml
@@ -267,7 +267,7 @@ tasks:
         export CURL=${curl|curl}
 
         if [[ -n "${run_tests_against_baas|}" ]]; then
-            ./evergreen/install_baas.sh ./baas-work-dir ./test/object-store/mongodb
+            ./evergreen/install_baas.sh -w ./baas-work-dir
         fi
 
   - command: shell.exec

--- a/evergreen/install_baas.sh
+++ b/evergreen/install_baas.sh
@@ -82,10 +82,7 @@ usage()
     exit 0
 }
 
-PASSED_ARGUMENTS=$(getopt w:s:b: "$*")
-if [[ $? != 0 ]]; then
-    usage
-fi
+PASSED_ARGUMENTS=$(getopt w:s:b: "$*") || usage
 
 WORK_PATH=""
 STITCH_APP=""

--- a/test/object-store/CMakeLists.txt
+++ b/test/object-store/CMakeLists.txt
@@ -29,6 +29,7 @@ set(SOURCES
     c_api/c_api.c
 
     util/event_loop.cpp
+    util/baas_admin_api.cpp
     util/test_file.cpp
     util/test_utils.cpp
 )

--- a/test/object-store/CMakeLists.txt
+++ b/test/object-store/CMakeLists.txt
@@ -29,11 +29,13 @@ set(SOURCES
     c_api/c_api.c
 
     util/event_loop.cpp
-    util/baas_admin_api.cpp
     util/test_file.cpp
     util/test_utils.cpp
 )
 
+if(REALM_ENABLE_AUTH_TESTS)
+    list(APPEND SOURCES util/baas_admin_api.cpp)
+endif()
 
 if(REALM_ENABLE_SYNC)
     list(APPEND HEADERS
@@ -79,14 +81,9 @@ if(REALM_ENABLE_SYNC)
             message(FATAL_ERROR "REALM_MONGODB_ENDPOINT must be set when specifying REALM_ENABLE_AUTH_TESTS.")
         endif()
 
-        if(NOT REALM_STITCH_CONFIG)
-            message(FATAL_ERROR "REALM_STITCH_CONFIG must be set when specifying REALM_ENABLE_AUTH_TESTS.")
-        endif()
-
         target_compile_definitions(ObjectStoreTests PRIVATE
             REALM_ENABLE_AUTH_TESTS=1
             REALM_MONGODB_ENDPOINT="${REALM_MONGODB_ENDPOINT}"
-            REALM_STITCH_CONFIG="${REALM_STITCH_CONFIG}"
         )
 
         find_package(CURL REQUIRED)

--- a/test/object-store/object.cpp
+++ b/test/object-store/object.cpp
@@ -1334,33 +1334,6 @@ TEST_CASE("object") {
 #endif
 }
 
-TEST_CASE("HELP-24751") {
-    Schema schema{
-        {"top", {{"location", PropertyType::Object | PropertyType::Nullable, "location"}}},
-        {"location", ObjectSchema::IsEmbedded{true}, {{"coordinates", PropertyType::Double | PropertyType::Array}}}};
-
-    InMemoryTestFile config;
-    config.automatic_change_notifications = false;
-    config.schema_mode = SchemaMode::Automatic;
-    config.schema = schema;
-
-    auto realm = Realm::get_shared_realm(config);
-    CppContext ctx(realm);
-
-    auto create = [&](util::Any&& value, CreatePolicy policy = CreatePolicy::UpdateAll) {
-        realm->begin_transaction();
-        auto obj = Object::create(ctx, realm, *realm->schema().find("top"), value, policy);
-        realm->commit_transaction();
-        return obj;
-    };
-
-    auto obj = create(AnyDict{{"location", AnyDict{{"coordinates", AnyVector{double(1.0), double(2.0)}}}}});
-
-    realm->begin_transaction();
-    obj.set_property_value(ctx, "location", util::Any(AnyDict{{"coordinates", AnyVector{double(5.0), double(6.0)}}}));
-    realm->commit_transaction();
-}
-
 TEST_CASE("Embedded Object") {
     Schema schema{
         {"all types",

--- a/test/object-store/sync/app.cpp
+++ b/test/object-store/sync/app.cpp
@@ -2010,8 +2010,9 @@ TEST_CASE("app: sync integration", "[sync][app]") {
         config.sync_config->partition_value = "not a bson serialized string";
         std::atomic<bool> error_did_occur = false;
         config.sync_config->error_handler = [&error_did_occur](std::shared_ptr<SyncSession>, SyncError error) {
-            CHECK(error.message ==
-                  "Illegal Realm path (BIND): serialized partition 'not a bson serialized string' is invalid");
+            CHECK(error.message.find(
+                      "Illegal Realm path (BIND): serialized partition 'not a bson serialized string' is invalid") !=
+                  std::string::npos);
             error_did_occur.store(true);
         };
         auto r = realm::Realm::get_shared_realm(config);

--- a/test/object-store/util/baas_admin_api.cpp
+++ b/test/object-store/util/baas_admin_api.cpp
@@ -642,8 +642,10 @@ std::string create_app(const AppCreateConfig& config)
     secrets.post_json({{"name", "gcm"}, {"value", "gcm"}});
 
     auto services = app["services"];
+    static const std::string mongo_service_name = "BackingDB";
+
     auto create_mongo_service_resp = services.post_json({
-        {"name", "BackingDB"},
+        {"name", mongo_service_name},
         {"type", "mongodb"},
         {"config",
          {
@@ -676,7 +678,7 @@ std::string create_app(const AppCreateConfig& config)
             continue;
         }
 
-        BaasRuleBuilder rule_builder(config.schema, config.partition_key, "BackingDB", config.mongo_dbname,
+        BaasRuleBuilder rule_builder(config.schema, config.partition_key, mongo_service_name, config.mongo_dbname,
                                      [&](const Property& prop) {
                                          return prop.name == "_id" || prop.name == config.partition_key.name;
                                      });
@@ -693,7 +695,7 @@ std::string create_app(const AppCreateConfig& config)
 
         auto rule_id = obj_schema_name_to_id.find(obj_schema.name);
         REALM_ASSERT(rule_id != obj_schema_name_to_id.end());
-        BaasRuleBuilder rule_builder(config.schema, config.partition_key, "BackingDB", config.mongo_dbname,
+        BaasRuleBuilder rule_builder(config.schema, config.partition_key, mongo_service_name, config.mongo_dbname,
                                      include_all_props);
         auto schema_to_create = rule_builder.object_schema_to_baas_rule(obj_schema);
         schema_to_create["_id"] = rule_id->second;

--- a/test/object-store/util/baas_admin_api.cpp
+++ b/test/object-store/util/baas_admin_api.cpp
@@ -18,6 +18,8 @@
 
 #include "baas_admin_api.hpp"
 
+#ifdef REALM_ENABLE_AUTH_TESTS
+
 #include <iostream>
 #include <mutex>
 
@@ -794,3 +796,5 @@ TEST_CASE("app: baas admin api", "[sync][app]") {
 #endif
 
 } // namespace realm
+
+#endif

--- a/test/object-store/util/baas_admin_api.cpp
+++ b/test/object-store/util/baas_admin_api.cpp
@@ -67,7 +67,7 @@ class BaasRuleBuilder {
 public:
     using IncludePropCond = std::function<bool(const Property&)>;
     BaasRuleBuilder(const Schema& schema, const Property& partition_key, const std::string& service_name,
-                      const std::string& db_name, IncludePropCond include_prop)
+                    const std::string& db_name, IncludePropCond include_prop)
         : m_schema(schema)
         , m_partition_key(partition_key)
         , m_mongo_service_name(service_name)
@@ -134,16 +134,18 @@ nlohmann::json BaasRuleBuilder::property_to_jsonschema(const Property& prop)
 
             type_output = object_schema_to_jsonschema(*target_obj);
             type_output.emplace("bsonType", "object");
-        } else {
+        }
+        else {
             REALM_ASSERT(target_obj->primary_key_property());
             util::StringBuffer rel_name_buf;
-            for (const auto& path_elem: m_current_path) {
+            for (const auto& path_elem : m_current_path) {
                 rel_name_buf.append(path_elem);
                 rel_name_buf.append(".", 1);
             }
             rel_name_buf.append(prop.name);
             m_relationships[rel_name_buf.c_str()] = {
-                {"ref", util::format("#/relationship/%1/%2/%3", m_mongo_service_name, m_mongo_db_name, target_obj->name)},
+                {"ref",
+                 util::format("#/relationship/%1/%2/%3", m_mongo_service_name, m_mongo_db_name, target_obj->name)},
                 {"foreign_key", target_obj->primary_key_property()->name},
                 {"is_list", is_array(prop.type)},
             };
@@ -545,15 +547,8 @@ AppCreateConfig minimal_app_config(const std::string& base_url, const std::strin
     Property partition_key("partition", PropertyType::String | PropertyType::Nullable);
 
     AppCreateConfig::UserPassAuthConfig user_pass_config{
-        true,
-        "Confirm",
-        "",
-        "http://example.com/confirmEmail",
-        "",
-        "Reset",
-        "http://exmaple.com/resetPassword",
-        false,
-        false,
+        true,  "Confirm", "", "http://example.com/confirmEmail", "", "Reset", "http://exmaple.com/resetPassword",
+        false, false,
     };
 
     return AppCreateConfig{
@@ -565,12 +560,12 @@ AppCreateConfig minimal_app_config(const std::string& base_url, const std::strin
         util::format("test_data_%1", name),
         schema,
         std::move(partition_key),
-        true, // dev_mode_enabled
-        {}, // no functions
+        true,                        // dev_mode_enabled
+        {},                          // no functions
         std::move(user_pass_config), // enable basic user/pass auth
-        util::none, // disable custom auth
-        true, // enable api key auth
-        true, // enable anonymous auth
+        util::none,                  // disable custom auth
+        true,                        // enable api key auth
+        true,                        // enable anonymous auth
     };
 }
 
@@ -619,8 +614,7 @@ std::string create_app(const AppCreateConfig& config)
             user_pass_config_obj.emplace("resetFunctionId", function_name_to_id[reset_func_name]);
             user_pass_config_obj.emplace("runResetFunction", config.user_pass_auth->run_reset_function);
         }
-        auth_providers.post_json({{"type", "local-userpass"},
-                                  {"config", std::move(user_pass_config_obj)}});
+        auth_providers.post_json({{"type", "local-userpass"}, {"config", std::move(user_pass_config_obj)}});
     }
     if (config.custom_function_auth) {
         auth_providers.post_json({{"type", "custom-function"},
@@ -683,9 +677,9 @@ std::string create_app(const AppCreateConfig& config)
         }
 
         BaasRuleBuilder rule_builder(config.schema, config.partition_key, "BackingDB", config.mongo_dbname,
-                                       [&](const Property& prop) {
-                                           return prop.name == "_id" || prop.name == config.partition_key.name;
-                                       });
+                                     [&](const Property& prop) {
+                                         return prop.name == "_id" || prop.name == config.partition_key.name;
+                                     });
         auto schema_to_create = rule_builder.object_schema_to_baas_rule(obj_schema);
 
         auto rule_create_resp = rules.post_json(schema_to_create);
@@ -700,7 +694,7 @@ std::string create_app(const AppCreateConfig& config)
         auto rule_id = obj_schema_name_to_id.find(obj_schema.name);
         REALM_ASSERT(rule_id != obj_schema_name_to_id.end());
         BaasRuleBuilder rule_builder(config.schema, config.partition_key, "BackingDB", config.mongo_dbname,
-                                       include_all_props);
+                                     include_all_props);
         auto schema_to_create = rule_builder.object_schema_to_baas_rule(obj_schema);
         schema_to_create["_id"] = rule_id->second;
 

--- a/test/object-store/util/baas_admin_api.cpp
+++ b/test/object-store/util/baas_admin_api.cpp
@@ -1,0 +1,608 @@
+////////////////////////////////////////////////////////////////////////////
+//
+// Copyright 2021 Realm Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+////////////////////////////////////////////////////////////////////////////
+
+#include "baas_admin_api.hpp"
+
+#include <iostream>
+
+#include <curl/curl.h>
+
+#include "realm/util/scope_exit.hpp"
+
+namespace realm {
+namespace {
+std::string property_type_to_bson_type_str(PropertyType type)
+{
+    switch (type & ~PropertyType::Flags) {
+        case PropertyType::UUID:
+            return "uuid";
+        case PropertyType::Mixed:
+            return "mixed";
+        case PropertyType::Bool:
+            return "bool";
+        case PropertyType::Data:
+            return "binData";
+        case PropertyType::Date:
+            return "date";
+        case PropertyType::Decimal:
+            return "decimal";
+        case PropertyType::Double:
+            return "double";
+        case PropertyType::Float:
+            return "float";
+        case PropertyType::Int:
+            return "long";
+        case PropertyType::Object:
+            return "object";
+        case PropertyType::ObjectId:
+            return "objectId";
+        case PropertyType::String:
+            return "string";
+        case PropertyType::LinkingObjects:
+            return "linkingObjects";
+        default:
+            REALM_COMPILER_HINT_UNREACHABLE();
+    }
+}
+
+template <typename Cond>
+nlohmann::json property_to_jsonschema(const Property& prop, const Schema& schema, nlohmann::json* relationships,
+                                      Cond&& include_prop);
+
+static const auto include_all_props = [](const Property&) -> bool {
+    return true;
+};
+
+template <typename Cond>
+nlohmann::json objectschema_to_jsonschema(const ObjectSchema& obj_schema, const Schema& schema,
+                                          nlohmann::json* relationships, Cond&& include_prop)
+{
+    nlohmann::json required = nlohmann::json::array();
+    nlohmann::json properties;
+    for (const auto& prop : obj_schema.persisted_properties) {
+        if (!include_prop(prop)) {
+            continue;
+        }
+        properties.emplace(prop.name, property_to_jsonschema(prop, schema, relationships, include_prop));
+        if (!is_nullable(prop.type) && !is_collection(prop.type)) {
+            required.push_back(prop.name);
+        }
+    }
+
+    return {
+        {"properties", properties},
+        {"required", required},
+    };
+}
+
+template <typename Cond>
+nlohmann::json property_to_jsonschema(const Property& prop, const Schema& schema, nlohmann::json* relationships,
+                                      Cond&& include_prop)
+{
+    std::string type_str;
+    if ((prop.type & ~PropertyType::Flags) == PropertyType::Object) {
+        auto target_obj = schema.find(prop.object_type);
+        REALM_ASSERT(target_obj != schema.end());
+
+        if (target_obj->is_embedded) {
+            auto target_obj_jsonschema = objectschema_to_jsonschema(*target_obj, schema, relationships, include_prop);
+            target_obj_jsonschema["bsonType"] = "object";
+            if (is_array(prop.type)) {
+                return {
+                    {"bsonType", "array"},
+                    {"items", target_obj_jsonschema},
+                };
+            }
+            return target_obj_jsonschema;
+        }
+
+        (*relationships)[prop.name] = {
+            {"ref", util::format("#/relationship/mongodb1/test_data/%1", target_obj->name)},
+            {"foreign_key", target_obj->primary_key_property()->name},
+            {"is_list", is_array(prop.type)},
+        };
+        type_str = property_type_to_bson_type_str(target_obj->primary_key_property()->type);
+    }
+    else {
+        type_str = property_type_to_bson_type_str(prop.type);
+    }
+
+    if (is_array(prop.type)) {
+        return nlohmann::json{{"bsonType", "array"}, {"items", nlohmann::json{{"bsonType", type_str}}}};
+    }
+    if (is_set(prop.type)) {
+        return nlohmann::json{
+            {"bsonType", "array"}, {"uniqueItems", true}, {"items", nlohmann::json{{"bsonType", type_str}}}};
+    }
+    if (is_dictionary(prop.type)) {
+        return nlohmann::json{{"bsonType", "object"},
+                              {"properties", nlohmann::json{}},
+                              {"additionalProperties", nlohmann::json{{"bsonType", type_str}}}};
+    }
+    return nlohmann::json{{"bsonType", type_str}};
+}
+
+template <typename Cond>
+nlohmann::json schema_to_baas_rule(const ObjectSchema& obj_schema, const Schema& schema,
+                                   const Property& partition_key, Cond&& include_prop)
+{
+    nlohmann::json relationships;
+    auto schema_json = objectschema_to_jsonschema(obj_schema, schema, &relationships, include_prop);
+    schema_json.emplace("title", obj_schema.name);
+    auto& prop_sub_obj = schema_json["properties"];
+    if (include_prop(partition_key) && prop_sub_obj.find(partition_key.name) == prop_sub_obj.end()) {
+        prop_sub_obj.emplace(partition_key.name,
+                             property_to_jsonschema(partition_key, schema, &relationships, include_prop));
+        if (!partition_key.type_is_nullable()) {
+            schema_json["required"].push_back(partition_key.name);
+        }
+    }
+    return {
+        {"database", "test_data"},
+        {"collection", obj_schema.name},
+        {"relationships", relationships},
+        {"schema", schema_json},
+        {"roles", nlohmann::json::array({{{"name", "default"},
+                                          {"apply_when", nlohmann::json::object()},
+                                          {"insert", true},
+                                          {"delete", true},
+                                          {"additional_fields", nlohmann::json::object()}}})},
+    };
+}
+
+class CurlGlobalGuard {
+public:
+    CurlGlobalGuard()
+    {
+        std::lock_guard<std::mutex> lk(m_mutex);
+        if (++m_users == 1) {
+            curl_global_init(CURL_GLOBAL_ALL);
+        }
+    }
+
+    ~CurlGlobalGuard()
+    {
+        std::lock_guard<std::mutex> lk(m_mutex);
+        if (--m_users == 0) {
+            curl_global_cleanup();
+        }
+    }
+
+    CurlGlobalGuard(const CurlGlobalGuard&) = delete;
+    CurlGlobalGuard(CurlGlobalGuard&&) = delete;
+    CurlGlobalGuard& operator=(const CurlGlobalGuard&) = delete;
+    CurlGlobalGuard& operator=(CurlGlobalGuard&&) = delete;
+
+private:
+    static std::mutex m_mutex;
+    static int m_users;
+};
+
+std::mutex CurlGlobalGuard::m_mutex = {};
+int CurlGlobalGuard::m_users = 0;
+
+size_t curl_write_cb(char* ptr, size_t size, size_t nmemb, std::string* response)
+{
+    REALM_ASSERT(response);
+    size_t realsize = size * nmemb;
+    response->append(ptr, realsize);
+    return realsize;
+}
+
+size_t curl_header_cb(char* buffer, size_t size, size_t nitems, std::map<std::string, std::string>* response_headers)
+{
+    REALM_ASSERT(response_headers);
+    std::string combined(buffer, size * nitems);
+    if (auto pos = combined.find(':'); pos != std::string::npos) {
+        std::string key = combined.substr(0, pos);
+        std::string value = combined.substr(pos + 1);
+        while (value.size() > 0 && value[0] == ' ') {
+            value = value.substr(1);
+        }
+        while (value.size() > 0 && (value[value.size() - 1] == '\r' || value[value.size() - 1] == '\n')) {
+            value = value.substr(0, value.size() - 1);
+        }
+        response_headers->insert({key, value});
+    }
+    else {
+        if (combined.size() > 5 && combined.substr(0, 5) != "HTTP/") { // ignore for now HTTP/1.1 ...
+            std::cerr << "test transport skipping header: " << combined << std::endl;
+        }
+    }
+    return nitems * size;
+}
+
+} // namespace
+
+app::Response do_http_request(const app::Request& request)
+{
+    CurlGlobalGuard curl_global_guard;
+    auto curl = curl_easy_init();
+    if (!curl) {
+        return app::Response{500, -1};
+    }
+
+    struct curl_slist* list = nullptr;
+    auto curl_cleanup = util::ScopeExit([&]() noexcept {
+        curl_easy_cleanup(curl);
+        curl_slist_free_all(list);
+    });
+
+    std::string response;
+    std::map<std::string, std::string> response_headers;
+
+    /* First set the URL that is about to receive our POST. This URL can
+     just as well be a https:// URL if that is what should receive the
+     data. */
+    curl_easy_setopt(curl, CURLOPT_URL, request.url.c_str());
+
+    /* Now specify the POST data */
+    if (request.method == app::HttpMethod::post) {
+        curl_easy_setopt(curl, CURLOPT_POSTFIELDS, request.body.c_str());
+    }
+    else if (request.method == app::HttpMethod::put) {
+        curl_easy_setopt(curl, CURLOPT_CUSTOMREQUEST, "PUT");
+        curl_easy_setopt(curl, CURLOPT_POSTFIELDS, request.body.c_str());
+    }
+    else if (request.method == app::HttpMethod::del) {
+        curl_easy_setopt(curl, CURLOPT_CUSTOMREQUEST, "DELETE");
+        curl_easy_setopt(curl, CURLOPT_POSTFIELDS, request.body.c_str());
+    }
+
+    curl_easy_setopt(curl, CURLOPT_TIMEOUT, request.timeout_ms);
+
+    for (auto header : request.headers) {
+        auto header_str = util::format("%1: %2", header.first, header.second);
+        list = curl_slist_append(list, header_str.c_str());
+    }
+
+    curl_easy_setopt(curl, CURLOPT_HTTPHEADER, list);
+    curl_easy_setopt(curl, CURLOPT_WRITEFUNCTION, curl_write_cb);
+    curl_easy_setopt(curl, CURLOPT_WRITEDATA, &response);
+    curl_easy_setopt(curl, CURLOPT_HEADERFUNCTION, curl_header_cb);
+    curl_easy_setopt(curl, CURLOPT_HEADERDATA, &response_headers);
+
+    auto response_code = curl_easy_perform(curl);
+    if (response_code != CURLE_OK) {
+        fprintf(stderr, "curl_easy_perform() failed when sending request to '%s' with body '%s': %s\n",
+                request.url.c_str(), request.body.c_str(), curl_easy_strerror(response_code));
+    }
+    int http_code = 0;
+    curl_easy_getinfo(curl, CURLINFO_RESPONSE_CODE, &http_code);
+    return {
+        http_code,
+        0, // binding_response_code
+        std::move(response_headers),
+        std::move(response),
+    };
+}
+
+AdminAPIEndpoint AdminAPIEndpoint::operator[](StringData name) const
+{
+    return AdminAPIEndpoint(util::format("%1/%2", m_url, name), m_access_token);
+}
+
+app::Response AdminAPIEndpoint::do_request(app::Request request) const
+{
+    request.url = util::format("%1?bypass_service_change=SyncProtocolVersionIncrease", request.url);
+    request.headers["Content-Type"] = "application/json;charset=utf-8";
+    request.headers["Accept"] = "application/json";
+    request.headers["Authorization"] = util::format("Bearer %1", m_access_token);
+    auto resp = do_http_request(request);
+    std::cerr << "sent " << request.body << " to " << request.url << " and got " << resp.body << std::endl;
+    return resp;
+}
+
+app::Response AdminAPIEndpoint::get() const
+{
+    app::Request req;
+    req.method = app::HttpMethod::get;
+    req.url = m_url;
+    return do_request(std::move(req));
+}
+
+nlohmann::json AdminAPIEndpoint::get_json() const
+{
+    auto resp = get();
+    REALM_ASSERT(resp.http_status_code >= 200 && resp.http_status_code < 300);
+    return nlohmann::json::parse(resp.body.empty() ? "{}" : resp.body);
+}
+
+app::Response AdminAPIEndpoint::post(std::string body) const
+{
+    app::Request req;
+    req.method = app::HttpMethod::post;
+    req.url = m_url;
+    req.body = std::move(body);
+    return do_request(std::move(req));
+}
+
+nlohmann::json AdminAPIEndpoint::post_json(nlohmann::json body) const
+{
+    auto resp = post(body.dump());
+    REALM_ASSERT(resp.http_status_code >= 200 && resp.http_status_code < 300);
+    return nlohmann::json::parse(resp.body.empty() ? "{}" : resp.body);
+}
+
+app::Response AdminAPIEndpoint::put(std::string body) const
+{
+    app::Request req;
+    req.method = app::HttpMethod::put;
+    req.url = m_url;
+    req.body = std::move(body);
+    return do_request(std::move(req));
+}
+
+nlohmann::json AdminAPIEndpoint::put_json(nlohmann::json body) const
+{
+    auto resp = put(body.dump());
+    REALM_ASSERT(resp.http_status_code >= 200 && resp.http_status_code < 300);
+    return nlohmann::json::parse(resp.body.empty() ? "{}" : resp.body);
+}
+
+app::Response AdminAPIEndpoint::patch(std::string body) const
+{
+    app::Request req;
+    req.method = app::HttpMethod::patch;
+    req.url = m_url;
+    req.body = std::move(body);
+    return do_request(std::move(req));
+}
+
+nlohmann::json AdminAPIEndpoint::patch_json(nlohmann::json body) const
+{
+    auto resp = patch(body.dump());
+    REALM_ASSERT(resp.http_status_code >= 200 && resp.http_status_code < 300);
+    return nlohmann::json::parse(resp.body.empty() ? "{}" : resp.body);
+}
+
+AdminAPISession AdminAPISession::login(const std::string& base_url, const std::string& username,
+                                       const std::string& password)
+{
+    nlohmann::json login_req_body{
+        {"provider", "userpass"},
+        {"username", username},
+        {"password", password},
+    };
+    app::Request auth_req{
+        app::HttpMethod::post,
+        util::format("%1/api/admin/v3.0/auth/providers/local-userpass/login", base_url),
+        60000, // 1 minute timeout
+        {
+            {"Content-Type", "application/json;charset=utf-8"},
+            {"Accept", "application/json"},
+        },
+        login_req_body.dump(),
+    };
+    auto login_resp = do_http_request(auth_req);
+    REALM_ASSERT(login_resp.http_status_code == 200);
+    auto login_resp_body = nlohmann::json::parse(login_resp.body);
+
+    std::string access_token = login_resp_body["access_token"];
+
+    AdminAPIEndpoint user_profile(util::format("%1/api/admin/v3.0/auth/profile", base_url), access_token);
+    auto profile_resp = user_profile.get_json();
+
+    std::string group_id = profile_resp["roles"][0]["group_id"];
+
+    return AdminAPISession(std::move(base_url), std::move(access_token), std::move(group_id));
+}
+
+AdminAPIEndpoint AdminAPISession::apps() const
+{
+    return AdminAPIEndpoint(util::format("%1/api/admin/v3.0/groups/%2/apps", m_base_url, m_group_id), m_access_token);
+}
+
+const AppCreateConfig& default_app_config()
+{
+    static const AppCreateConfig default_config = [] {
+        constexpr const char* update_user_data_func = R"(
+            exports = async function(data) {
+                const user = context.user;
+                const mongodb = context.services.get("mongodb1");
+                const userDataCollection = mongodb.db("test_data").collection("UserData");
+                await userDataCollection.updateOne(
+                                                   { "user_id": user.id },
+                                                   { "$set": data },
+                                                   { "upsert": true }
+                                                   );
+                return true;
+            };
+        )";
+
+        constexpr const char* sum_func = R"(
+            exports = function(...args) {
+                return parseInt(args.reduce((a,b) => a + b, 0));
+            };
+        )";
+        std::vector<AppCreateConfig::FunctionDef> funcs = {
+            {"updateUserData", update_user_data_func, false},
+            {"sum", sum_func, false},
+        };
+
+        const auto dog_schema =
+            ObjectSchema("Dog", {realm::Property("_id", PropertyType::ObjectId | PropertyType::Nullable, true),
+                                 realm::Property("breed", PropertyType::String | PropertyType::Nullable),
+                                 realm::Property("name", PropertyType::String),
+                                 realm::Property("realm_id", PropertyType::String | PropertyType::Nullable)});
+        const auto person_schema =
+            ObjectSchema("Person", {realm::Property("_id", PropertyType::ObjectId | PropertyType::Nullable, true),
+                                    realm::Property("age", PropertyType::Int),
+                                    realm::Property("dogs", PropertyType::Object | PropertyType::Array, "Dog"),
+                                    realm::Property("firstName", PropertyType::String),
+                                    realm::Property("lastName", PropertyType::String),
+                                    realm::Property("realm_id", PropertyType::String | PropertyType::Nullable)});
+        realm::Schema default_schema({dog_schema, person_schema});
+
+        Property partition_key("realm_id", PropertyType::String | PropertyType::Nullable);
+
+        return AppCreateConfig{
+            "test",      "http://localhost:9090",   "unique_user@domain.com", "password", "mongodb://localhost:26000",
+            "test_data", std::move(default_schema), std::move(partition_key), true,       std::move(funcs),
+        };
+    }();
+    return default_config;
+}
+
+std::string create_app(const AppCreateConfig& config)
+{
+    auto session = AdminAPISession::login(config.base_url, config.admin_username, config.admin_password);
+    auto create_app_resp = session.apps().post_json(nlohmann::json{{"name", config.app_name}});
+    std::string app_id = create_app_resp["_id"];
+    std::string client_app_id = create_app_resp["client_app_id"];
+
+    auto app = session.apps()[app_id];
+
+    auto auth_providers = app["auth_providers"];
+    auth_providers.post_json({{"type", "anon-user"}});
+    auth_providers.post_json({{"type", "local-userpass"},
+                              {"config",
+                               {
+                                   {"emailConfirmationUrl", "http://example.com/confirm_email"},
+                                   {"resetPasswordUrl", "http://example.com/reset_password"},
+                                   {"confirmEmailSubject", "Hi"},
+                                   {"resetPasswordSubject", "Bye"},
+                                   {"autoConfirm", true},
+                               }}});
+
+    auto all_auth_providers = auth_providers.get_json();
+    auto api_key_provider =
+        std::find_if(all_auth_providers.begin(), all_auth_providers.end(), [](const nlohmann::json& provider) {
+            return provider["type"] == "api-key";
+        });
+    REALM_ASSERT(api_key_provider != all_auth_providers.end());
+    std::string api_key_provider_id = (*api_key_provider)["_id"];
+    auto api_key_enable_resp = auth_providers[api_key_provider_id]["enable"].put("");
+    REALM_ASSERT(api_key_enable_resp.http_status_code >= 200 && api_key_enable_resp.http_status_code < 300);
+
+    auto secrets = app["secrets"];
+    secrets.post_json({{"name", "BackingDB_uri"}, {"value", config.mongo_uri}});
+    secrets.post_json({{"name", "gcm"}, {"value", "gcm"}});
+
+    auto services = app["services"];
+    auto create_mongo_service_resp = services.post_json({
+        {"name", "mongodb1"},
+        {"type", "mongodb"},
+        {"config",
+         {
+             {"uri", config.mongo_uri},
+             {"sync",
+              {
+                  {"state", "enabled"},
+                  {"database_name", config.mongo_dbname},
+                  {"partition",
+                   {
+                       {"key", config.partition_key.name},
+                       {"type", property_type_to_bson_type_str(config.partition_key.type)},
+                       {"required", false},
+                       {"permissions",
+                        {
+                            {"read", true},
+                            {"write", true},
+                        }},
+                   }},
+              }},
+         }},
+    });
+
+    std::string mongo_service_id = create_mongo_service_resp["_id"];
+    auto rules = services[mongo_service_id]["rules"];
+
+    std::unordered_map<std::string, std::string> obj_schema_name_to_id;
+    for (const auto& obj_schema : config.schema) {
+        if (auto pk_prop = obj_schema.primary_key_property(); pk_prop == nullptr || pk_prop->name != "_id") {
+            continue;
+        }
+
+        auto schema_to_create =
+            schema_to_baas_rule(obj_schema, config.schema, config.partition_key, [&](const Property& prop) {
+                return prop.name == "_id" || prop.name == config.partition_key.name;
+            });
+
+        auto rule_create_resp = rules.post_json(schema_to_create);
+        obj_schema_name_to_id.insert({obj_schema.name, rule_create_resp["_id"]});
+    }
+
+    for (const auto& obj_schema : config.schema) {
+        if (auto pk_prop = obj_schema.primary_key_property(); pk_prop == nullptr || pk_prop->name != "_id") {
+            continue;
+        }
+
+        auto rule_id = obj_schema_name_to_id.find(obj_schema.name);
+        REALM_ASSERT(rule_id != obj_schema_name_to_id.end());
+
+        auto schema_to_create =
+            schema_to_baas_rule(obj_schema, config.schema, config.partition_key, include_all_props);
+        schema_to_create["_id"] = rule_id->second;
+
+        rules[rule_id->second].put_json(schema_to_create);
+    }
+
+    app["sync"]["config"].put_json({{"development_mode_enabled", config.dev_mode_enabled}});
+
+    auto functions = app["functions"];
+    for (const auto& func : config.functions) {
+        functions.post_json({
+            {"name", func.name},
+            {"private", func.is_private},
+            {"can_evaluate", nlohmann::json::object()},
+            {"source", func.source},
+        });
+    }
+
+    rules.post_json({
+        {"database", config.mongo_dbname},
+        {"collection", "UserData"},
+        {"roles",
+         {{
+             {"name", "default"},
+             {"apply_when", nlohmann::json::object()},
+             {"insert", true},
+             {"delete", true},
+             {"additional_fields", nlohmann::json::object()},
+         }}},
+        {"schema", nlohmann::json::object()},
+        {"relationships", nlohmann::json::object()},
+    });
+
+    app["custom_user_data"].patch_json({
+        {"mongo_service_id", mongo_service_id},
+        {"enabled", true},
+        {"database_name", config.mongo_dbname},
+        {"collection_name", "UserData"},
+        {"user_id_field", "user_id"},
+    });
+
+    services.post_json({
+        {"name", "gcm"},
+        {"type", "gcm"},
+        {"config",
+         {
+             {"senderId", "gcm"},
+         }},
+        {"secret_config",
+         {
+             {"apiKey", "gcm"},
+         }},
+        {"version", 1},
+    });
+
+    return client_app_id;
+}
+
+} // namespace realm

--- a/test/object-store/util/baas_admin_api.hpp
+++ b/test/object-store/util/baas_admin_api.hpp
@@ -117,6 +117,7 @@ struct AppCreateConfig {
 };
 
 AppCreateConfig default_app_config(const std::string& base_url);
+AppCreateConfig minimal_app_config(const std::string& base_url, const std::string& name);
 
 std::string create_app(const AppCreateConfig& config);
 

--- a/test/object-store/util/baas_admin_api.hpp
+++ b/test/object-store/util/baas_admin_api.hpp
@@ -78,11 +78,22 @@ private:
 };
 
 struct AppCreateConfig {
-
     struct FunctionDef {
         std::string name;
         std::string source;
         bool is_private;
+    };
+
+    struct UserPassAuthConfig {
+        bool auto_confirm;
+        std::string confirm_email_subject;
+        std::string confirmation_function_name;
+        std::string email_confirmation_url;
+        std::string reset_function_name;
+        std::string reset_password_subject;
+        std::string reset_password_url;
+        bool run_confirmation_function;
+        bool run_reset_function;
     };
 
     std::string app_name;
@@ -98,6 +109,11 @@ struct AppCreateConfig {
     bool dev_mode_enabled;
 
     std::vector<FunctionDef> functions;
+
+    util::Optional<UserPassAuthConfig> user_pass_auth;
+    util::Optional<std::string> custom_function_auth;
+    bool enable_api_key_auth = false;
+    bool enable_anonymous_auth = false;
 };
 
 const AppCreateConfig& default_app_config();

--- a/test/object-store/util/baas_admin_api.hpp
+++ b/test/object-store/util/baas_admin_api.hpp
@@ -117,7 +117,7 @@ struct AppCreateConfig {
 };
 
 AppCreateConfig default_app_config(const std::string& base_url);
-AppCreateConfig minimal_app_config(const std::string& base_url, const std::string& name);
+AppCreateConfig minimal_app_config(const std::string& base_url, const std::string& name, const Schema& schema);
 
 std::string create_app(const AppCreateConfig& config);
 

--- a/test/object-store/util/baas_admin_api.hpp
+++ b/test/object-store/util/baas_admin_api.hpp
@@ -1,0 +1,107 @@
+////////////////////////////////////////////////////////////////////////////
+//
+// Copyright 2021 Realm Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+////////////////////////////////////////////////////////////////////////////
+
+#pragma once
+
+#include "realm/object-store/property.hpp"
+#include "realm/object-store/object_schema.hpp"
+#include "realm/object-store/schema.hpp"
+#include "realm/object-store/sync/generic_network_transport.hpp"
+
+#include "external/json/json.hpp"
+
+namespace realm {
+
+app::Response do_http_request(const app::Request& request);
+
+class AdminAPIEndpoint {
+public:
+    app::Response get() const;
+    app::Response patch(std::string body) const;
+    app::Response post(std::string body) const;
+    app::Response put(std::string body) const;
+    nlohmann::json get_json() const;
+    nlohmann::json patch_json(nlohmann::json body) const;
+    nlohmann::json post_json(nlohmann::json body) const;
+    nlohmann::json put_json(nlohmann::json body) const;
+
+    AdminAPIEndpoint operator[](StringData name) const;
+
+protected:
+    friend class AdminAPISession;
+    AdminAPIEndpoint(std::string url, std::string access_token)
+        : m_url(std::move(url))
+        , m_access_token(std::move(access_token))
+    {
+    }
+
+    app::Response do_request(app::Request request) const;
+
+private:
+    std::string m_url;
+    std::string m_access_token;
+};
+
+class AdminAPISession {
+public:
+    static AdminAPISession login(const std::string& base_url, const std::string& username,
+                                 const std::string& password);
+
+    AdminAPIEndpoint apps() const;
+
+private:
+    AdminAPISession(std::string base_url, std::string access_token, std::string group_id)
+        : m_base_url(std::move(base_url))
+        , m_access_token(std::move(access_token))
+        , m_group_id(std::move(group_id))
+    {
+    }
+
+    std::string m_base_url;
+    std::string m_access_token;
+    std::string m_group_id;
+};
+
+struct AppCreateConfig {
+
+    struct FunctionDef {
+        std::string name;
+        std::string source;
+        bool is_private;
+    };
+
+    std::string app_name;
+    std::string base_url;
+    std::string admin_username;
+    std::string admin_password;
+
+    std::string mongo_uri;
+    std::string mongo_dbname;
+
+    Schema schema;
+    Property partition_key;
+    bool dev_mode_enabled;
+
+    std::vector<FunctionDef> functions;
+};
+
+const AppCreateConfig& default_app_config();
+
+std::string create_app(const AppCreateConfig& config);
+
+} // namespace realm

--- a/test/object-store/util/baas_admin_api.hpp
+++ b/test/object-store/util/baas_admin_api.hpp
@@ -25,8 +25,8 @@
 
 #include "external/json/json.hpp"
 
+#ifdef REALM_ENABLE_AUTH_TESTS
 namespace realm {
-
 app::Response do_http_request(const app::Request& request);
 
 class AdminAPIEndpoint {
@@ -116,8 +116,10 @@ struct AppCreateConfig {
     bool enable_anonymous_auth = false;
 };
 
-const AppCreateConfig& default_app_config();
+AppCreateConfig default_app_config(const std::string& base_url);
 
 std::string create_app(const AppCreateConfig& config);
 
 } // namespace realm
+
+#endif // REALM_ENABLE_AUTH_TESTS


### PR DESCRIPTION
This changes the object-store tests to create their apps in baas dynamically via a C++ admin api rather than importing static apps prior to running the tests. This will let us more easily write tests with arbitrary schemas, functions, and features enabled.