### PR TITLE
Collection update_if_needed() reform

### DIFF
--- a/src/realm/bplustree.hpp
+++ b/src/realm/bplustree.hpp
@@ -674,6 +674,8 @@ ColumnMinMaxType<T> bptree_maximum(const BPlusTree<T>& tree, size_t* return_ndx 
     using ResultType = typename AggregateResultType<T, act_Max>::result_type;
     ResultType max = std::numeric_limits<ResultType>::lowest();
     if (tree.size() == 0) {
+        if (return_ndx)
+            *return_ndx = not_found;
         return max;
     }
 
@@ -706,6 +708,8 @@ ColumnMinMaxType<T> bptree_minimum(const BPlusTree<T>& tree, size_t* return_ndx 
     using ResultType = typename AggregateResultType<T, act_Max>::result_type;
     ResultType min = std::numeric_limits<ResultType>::max();
     if (tree.size() == 0) {
+        if (return_ndx)
+            *return_ndx = not_found;
         return min;
     }
 

--- a/src/realm/cluster_tree.cpp
+++ b/src/realm/cluster_tree.cpp
@@ -767,6 +767,9 @@ size_t ClusterTree::size_from_ref(ref_type ref, Allocator& alloc)
 std::unique_ptr<ClusterNode> ClusterTree::create_root_from_parent(ArrayParent* parent, size_t ndx_in_parent)
 {
     ref_type ref = parent->get_child_ref(ndx_in_parent);
+    if (!ref)
+        return nullptr;
+
     MemRef mem{m_alloc.translate(ref), ref, m_alloc};
     const char* header = mem.get_addr();
     bool is_leaf = !Array::get_is_inner_bptree_node_from_header(header);
@@ -835,11 +838,15 @@ void ClusterTree::replace_root(std::unique_ptr<ClusterNode> new_root)
     }
 }
 
-void ClusterTree::init_from_parent()
+bool ClusterTree::init_from_parent()
 {
-    auto new_root = get_root_from_parent();
-    m_root = std::move(new_root);
-    m_size = m_root->get_tree_size();
+    m_root = get_root_from_parent();
+    if (m_root) {
+        m_size = m_root->get_tree_size();
+        return true;
+    }
+    m_size = 0;
+    return false;
 }
 
 void ClusterTree::update_from_parent() noexcept

--- a/src/realm/cluster_tree.hpp
+++ b/src/realm/cluster_tree.hpp
@@ -44,14 +44,17 @@ public:
 
     bool is_attached() const
     {
-        return m_root->is_attached();
+        return m_root && m_root->is_attached();
     }
     Allocator& get_alloc() const
     {
         return m_alloc;
     }
 
-    void init_from_parent();
+    /// Initialize the accessor from its slot in the `ArrayParent`. If the ref
+    /// in the parent slot is zero, this returns false and leaves the
+    /// `ClusterTree` in an unusable state.
+    bool init_from_parent();
     void update_from_parent() noexcept;
 
     size_t size() const noexcept
@@ -223,6 +226,6 @@ protected:
     ObjKey load_leaf(ObjKey key) const;
     size_t get_position();
 };
-}
+} // namespace realm
 
 #endif /* REALM_CLUSTER_TREE_HPP */

--- a/src/realm/collection.hpp
+++ b/src/realm/collection.hpp
@@ -14,6 +14,13 @@ namespace realm {
 template <class L>
 struct CollectionIterator;
 
+/// Base class for all collection accessors.
+///
+/// Collections are bound to particular properties of an object. In a
+/// collection's public interface, the implementation must take care to keep the
+/// object consistent with the persisted state, mindful of the fact that the
+/// state may have changed as a consquence of modifications from other instances
+/// referencing the same persisted state.
 class CollectionBase {
 public:
     virtual ~CollectionBase() {}
@@ -112,15 +119,6 @@ protected:
     CollectionBase(CollectionBase&&) noexcept = default;
     CollectionBase& operator=(const CollectionBase&) noexcept = default;
     CollectionBase& operator=(CollectionBase&&) noexcept = default;
-
-    /// Unconditionally (re)initialize this accessor from its parent (the owner
-    /// object). May leave the collection detached if the object is no longer
-    /// valid. Return true if the accessor is attached.
-    virtual bool init_from_parent() const = 0;
-
-    /// If the underlying memory has changed, update this accessor to reflect
-    /// the new state. Returns true if the accessor was actually updated.
-    virtual bool update_if_needed() const = 0;
 };
 
 
@@ -166,6 +164,11 @@ struct MinHelper {
     {
         return Mixed{};
     }
+
+    static Mixed not_found(size_t*) noexcept
+    {
+        return Mixed{};
+    }
 };
 
 template <class T>
@@ -175,12 +178,25 @@ struct MinHelper<T, std::void_t<ColumnMinMaxType<T>>> {
     {
         return Mixed(bptree_minimum<T>(tree, return_ndx));
     }
+
+    static Mixed not_found(size_t* return_ndx) noexcept
+    {
+        if (return_ndx)
+            *return_ndx = realm::not_found;
+        using ResultType = typename AggregateResultType<T, act_Max>::result_type;
+        return std::numeric_limits<ResultType>::max();
+    }
 };
 
 template <class T, class Enable = void>
 struct MaxHelper {
     template <class U>
     static Mixed eval(U&, size_t*) noexcept
+    {
+        return Mixed{};
+    }
+
+    static Mixed not_found(size_t*) noexcept
     {
         return Mixed{};
     }
@@ -193,6 +209,14 @@ struct MaxHelper<T, std::void_t<ColumnMinMaxType<T>>> {
     {
         return Mixed(bptree_maximum<T>(tree, return_ndx));
     }
+
+    static Mixed not_found(size_t* return_ndx) noexcept
+    {
+        if (return_ndx)
+            *return_ndx = realm::not_found;
+        using ResultType = typename AggregateResultType<T, act_Max>::result_type;
+        return std::numeric_limits<ResultType>::lowest();
+    }
 };
 
 template <class T, class Enable = void>
@@ -200,6 +224,13 @@ class SumHelper {
 public:
     template <class U>
     static Mixed eval(U&, size_t* return_cnt) noexcept
+    {
+        if (return_cnt)
+            *return_cnt = 0;
+        return Mixed{};
+    }
+
+    static Mixed not_found(size_t* return_cnt) noexcept
     {
         if (return_cnt)
             *return_cnt = 0;
@@ -215,12 +246,28 @@ public:
     {
         return Mixed(bptree_sum<T>(tree, return_cnt));
     }
+
+    static Mixed not_found(size_t* return_cnt)
+    {
+        if (return_cnt) {
+            *return_cnt = 0;
+        }
+        using ResultType = typename AggregateResultType<T, act_Sum>::result_type;
+        return ResultType{};
+    }
 };
 
 template <class T, class = void>
 struct AverageHelper {
     template <class U>
     static Mixed eval(U&, size_t* return_cnt) noexcept
+    {
+        if (return_cnt)
+            *return_cnt = 0;
+        return Mixed{};
+    }
+
+    static Mixed not_found(size_t* return_cnt) noexcept
     {
         if (return_cnt)
             *return_cnt = 0;
@@ -234,6 +281,15 @@ struct AverageHelper<T, std::void_t<ColumnSumType<T>>> {
     static Mixed eval(U& tree, size_t* return_cnt)
     {
         return Mixed(bptree_average<T>(tree, return_cnt));
+    }
+
+    static Mixed not_found(size_t* return_cnt)
+    {
+        if (return_cnt) {
+            *return_cnt = 0;
+        }
+        using ResultType = typename AggregateResultType<T, act_Sum>::result_type;
+        return ResultType{};
     }
 };
 
@@ -256,8 +312,19 @@ public:
         return m_obj;
     }
 
+    /// Returns true if the accessor has changed since the last time
+    /// `has_changed()` was called.
+    ///
+    /// Note: This method is not idempotent.
+    ///
+    /// Note: This involves a call to `update_if_needed()`.
+    ///
+    /// Note: This function does not return true for an accessor that became
+    /// detached since the last call, even though it may look to the caller as
+    /// if the size of the collection suddenly became zero.
     bool has_changed() const final
     {
+        // FIXME: `has_changed()` sneakily modifies internal state.
         update_if_needed();
         if (m_last_content_version != m_content_version) {
             m_last_content_version = m_content_version;
@@ -275,8 +342,9 @@ protected:
     bool m_nullable = false;
 
     mutable uint_fast64_t m_content_version = 0;
+
+    // Content version used by `has_changed()`.
     mutable uint_fast64_t m_last_content_version = 0;
-    mutable bool m_valid = false;
 
     CollectionBaseImpl() = default;
     CollectionBaseImpl(const CollectionBaseImpl& other) = default;
@@ -302,38 +370,85 @@ protected:
         return !(*this == other);
     }
 
-    // Overriding members of CollectionBase:
-    REALM_NOINLINE bool update_if_needed() const final
+    /// Refresh the associated `Obj` (if needed), and update the internal
+    /// content version number. This is meant to be called from a derived class
+    /// before accessing its data.
+    ///
+    /// If the `Obj` changed since the last call, or the content version was
+    /// bumped, this returns `UpdateStatus::Updated`. In response, the caller
+    /// must invoke `init_from_parent()` or similar on its internal state
+    /// accessors to refresh its view of the data.
+    ///
+    /// If the owning object (or parent container) was deleted, this returns
+    /// `UpdateStatus::Detached`, and the caller is allowed to enter a
+    /// degenerate state.
+    ///
+    /// If no change has happened to the data, this function returns
+    /// `UpdateStatus::NoChange`, and the caller is allowed to not do anything.
+    virtual UpdateStatus update_if_needed() const
     {
-        if (!m_obj.is_valid())
-            return false;
+        UpdateStatus status = m_obj.update_if_needed_with_status();
 
-        auto content_version = m_obj.get_alloc().get_content_version();
-        if (m_obj.update_if_needed() || content_version != m_content_version) {
-            this->init_from_parent();
-            return true;
+        if (status != UpdateStatus::Detached) {
+            auto content_version = m_obj.get_alloc().get_content_version();
+            if (content_version != m_content_version) {
+                m_content_version = content_version;
+                return UpdateStatus::Updated;
+            }
+            return status;
         }
-        return false;
+        return UpdateStatus::Detached;
     }
 
-    void update_content_version() const noexcept
+    /// Refresh the associated `Obj` (if needed) and ensure that it is in a
+    /// writable state.
+    ///
+    /// The caller must react to the `UpdateStatus` in the same way as with
+    /// `update_if_needed()`, i.e., eventually end up calling
+    /// `init_from_parent()` or similar.
+    ///
+    /// The parameter `allow_create` is unused by this method, but may be used
+    /// by overriding implementations in derived classes to lazily initialize
+    /// the in-file data structures.
+    ///
+    /// Throws if the owning object no longer exists. Note: This means that this
+    /// method will never return `UpdateStatus::Detached`.
+    ///
+    /// Throws if we are not in a write transaction.
+    virtual UpdateStatus ensure_writable(bool allow_create)
     {
-        m_content_version = m_obj.get_alloc().get_content_version();
+        static_cast<void>(allow_create);
+
+        bool changed = m_obj.update_if_needed();         // Throws if the object does not exist.
+        bool became_writable = m_obj.ensure_writeable(); // Throws if we are not in a write transaction.
+        auto content_version = m_obj.get_alloc().get_content_version();
+
+        if (changed || became_writable || content_version != m_content_version) {
+            m_content_version = content_version;
+            return UpdateStatus::Updated;
+        }
+
+        return UpdateStatus::NoChange;
     }
 
+    /// Signal the owning object that the collection has changed. This allows
+    /// other accessors referring to the same data to detect the update the next
+    /// time their `update_if_needed()` is called.
     void bump_content_version()
     {
         m_content_version = m_obj.bump_content_version();
     }
 
-    void ensure_writeable()
+    /// Reset the accessor's tracking of the content version. Derived classes
+    /// may choose to call this to force the accessor to become out of date,
+    /// such that `update_if_needed()` returns `UpdateStatus::Updated` the next
+    /// time it is called (or `UpdateStatus::Detached` if the data vanished in
+    /// the meantime).
+    void reset_content_version()
     {
-        if (m_obj.ensure_writeable()) {
-            this->init_from_parent();
-        }
+        m_content_version = 0;
     }
 
-protected:
     // Overriding ArrayParent interface:
     ref_type get_child_ref(size_t child_ndx) const noexcept final
     {
@@ -404,18 +519,18 @@ public:
 
     void sync_if_needed() const final
     {
-        if (is_attached()) {
-            update_if_needed();
-        }
+        update_if_needed();
     }
 
     bool is_in_sync() const noexcept final
     {
+        // FIXME: Document why this is OK.
         return true;
     }
 
     bool has_unresolved() const noexcept
     {
+        update_if_needed();
         return m_unresolved.size() != 0;
     }
 
@@ -430,35 +545,34 @@ protected:
 
     /// Implementations should call `update_if_needed()` on their inner accessor
     /// (without `update_unresolved()`).
-    virtual bool do_update_if_needed() const = 0;
+    virtual UpdateStatus do_update_if_needed() const = 0;
 
-    /// Implementations should call `init_from_parent()` on their inner accessor
-    /// (without `update_unresolved()`).
-    virtual bool do_init_from_parent() const = 0;
+    /// Implementations should call `Obj::ensure_writable()` and
+    /// `update_if_needed()` on their inner accessor (without
+    /// `update_unresolved()`).
+    virtual UpdateStatus do_ensure_writable(bool allow_create) = 0;
 
     /// Implementations should return a non-const reference to their internal
     /// `BPlusTree<T>`.
     virtual BPlusTree<ObjKey>& get_mutable_tree() const = 0;
 
-    /// Calls `do_init_from_parent()` and updates the list of unresolved links.
-    bool init_from_parent() const final
-    {
-        clear_unresolved();
-        bool valid = do_init_from_parent();
-        if (valid) {
-            update_unresolved();
-        }
-        return valid;
-    }
-
     /// Implements update_if_needed() in a way that ensures the consistency of
     /// the unresolved list. Derived classes should call this instead of calling
     /// `update_if_needed()` on their inner accessor.
-    bool update_if_needed() const final
+    UpdateStatus update_if_needed() const
     {
-        bool updated = do_update_if_needed();
-        update_unresolved();
-        return updated;
+        auto status = do_update_if_needed();
+        update_unresolved(status);
+        return status;
+    }
+
+    /// Ensure that the collection is writable, maintain the unresolved list if
+    /// the collection was updated, and return true if it is not detached.
+    UpdateStatus ensure_writable(bool allow_create)
+    {
+        auto status = do_ensure_writable(allow_create);
+        update_unresolved(status);
+        return status;
     }
 
     /// Translate from condensed index to uncondensed.
@@ -473,22 +587,28 @@ protected:
         return _impl::real2virtual(m_unresolved, ndx);
     }
 
-    /// Rebuild the list of tombstones if there is a chance that it has changed.
-    void update_unresolved() const
+    /// Rebuild the list of tombstones if there is a possibility that it has
+    /// changed.
+    ///
+    /// If the accessor became detached, this clears the unresolved list.
+    void update_unresolved(UpdateStatus status) const
     {
-        const auto& obj = this->get_obj();
-        if (obj.is_valid()) {
-            auto content_version = this->get_obj().get_alloc().get_content_version();
-            if (content_version != m_content_version) {
-                _impl::update_unresolved(m_unresolved, get_mutable_tree());
-                m_content_version = content_version;
+        switch (status) {
+            case UpdateStatus::Detached: {
+                clear_unresolved();
+                break;
             }
-        }
-        else {
-            clear_unresolved();
+            case UpdateStatus::Updated: {
+                _impl::update_unresolved(m_unresolved, get_mutable_tree());
+                break;
+            }
+            case UpdateStatus::NoChange:
+                break;
         }
     }
 
+    /// When a tombstone is removed from a list, call this to update internal
+    /// flags that indicate the presence of tombstones.
     void check_for_last_unresolved()
     {
         _impl::check_for_last_unresolved(get_mutable_tree());
@@ -499,7 +619,6 @@ protected:
     void clear_unresolved() const noexcept
     {
         m_unresolved.clear();
-        m_content_version = uint_fast64_t(-1);
     }
 
     /// Return the number of tombstones.
@@ -511,12 +630,6 @@ protected:
 private:
     // Sorted set of indices containing unresolved links.
     mutable std::vector<size_t> m_unresolved;
-
-    // We need to track the content version separately to keep the list of
-    // unresolved indices up to date, and can't rely on the return value of
-    // `do_update_if_needed()`, because the inner accessor may have been
-    // refreshed without our knowledge.
-    mutable uint_fast64_t m_content_version = uint_fast64_t(-1);
 
     TableRef proxy_get_target_table() const final
     {

--- a/src/realm/list.cpp
+++ b/src/realm/list.cpp
@@ -221,10 +221,11 @@ void Lst<ObjKey>::do_remove(size_t ndx)
 template <>
 void Lst<ObjKey>::clear()
 {
-    update_if_needed();
     auto sz = Lst<ObjKey>::size();
 
     if (sz > 0) {
+        ensure_writable(false);
+
         auto origin_table = m_obj.get_table();
         TableRef target_table = m_obj.get_target_table(m_col_key);
 
@@ -402,8 +403,7 @@ void LnkLst::remove_target_row(size_t link_ndx)
 
 void LnkLst::remove_all_target_rows()
 {
-    if (is_attached()) {
-        update_if_needed();
+    if (update_if_needed() != UpdateStatus::Detached) {
         _impl::TableFriend::batch_erase_rows(*get_target_table(), *m_list.m_tree);
     }
 }

--- a/src/realm/list.hpp
+++ b/src/realm/list.hpp
@@ -145,7 +145,7 @@ public:
     template <typename Func>
     void find_all(value_type value, Func&& func) const
     {
-        if (m_valid && init_from_parent())
+        if (update())
             m_tree->find_all(value, std::forward<Func>(func));
     }
 
@@ -154,26 +154,100 @@ public:
         return *m_tree;
     }
 
+    UpdateStatus update_if_needed() const final
+    {
+        auto status = Base::update_if_needed();
+        switch (status) {
+            case UpdateStatus::Detached: {
+                m_tree.reset();
+                return UpdateStatus::Detached;
+            }
+            case UpdateStatus::NoChange:
+                if (m_tree && m_tree->is_attached()) {
+                    return UpdateStatus::NoChange;
+                }
+                // The tree has not been initialized yet for this accessor, so
+                // perform lazy initialization by treating it as an update.
+                [[fallthrough]];
+            case UpdateStatus::Updated: {
+                bool attached = init_from_parent(false);
+                return attached ? UpdateStatus::Updated : UpdateStatus::Detached;
+            }
+        }
+        REALM_UNREACHABLE();
+    }
+
+    UpdateStatus ensure_writable(bool allow_create) final
+    {
+        auto status = Base::ensure_writable(allow_create);
+        switch (status) {
+            case UpdateStatus::Detached:
+                break; // Not possible (would have thrown earlier).
+            case UpdateStatus::NoChange: {
+                if (m_tree && m_tree->is_attached()) {
+                    return UpdateStatus::NoChange;
+                }
+                // The tree has not been initialized yet for this accessor, so
+                // perform lazy initialization by treating it as an update.
+                [[fallthrough]];
+            }
+            case UpdateStatus::Updated: {
+                bool attached = init_from_parent(allow_create);
+                REALM_ASSERT(attached || !allow_create);
+                return attached ? UpdateStatus::Updated : UpdateStatus::Detached;
+            }
+        }
+
+        REALM_UNREACHABLE();
+    }
+
 protected:
-    void ensure_created();
+    // `do_` methods here perform the action after preconditions have been
+    // checked (bounds check, writability, etc.).
     void do_set(size_t ndx, T value);
     void do_insert(size_t ndx, T value);
     void do_remove(size_t ndx);
 
-    friend class LnkLst;
-
+    // FIXME: BPlusTree must be wrapped in an `std::unique_ptr` for the
+    // following reasons:
+    // - It is not default-constructible, due to its `Allocator&` member.
+    // - Its move/copy assignment operators write to the database! (they call
+    //   `destroy()`).
     mutable std::unique_ptr<BPlusTree<T>> m_tree;
+
+    using Base::bump_content_version;
     using Base::m_col_key;
     using Base::m_nullable;
     using Base::m_obj;
-    using Base::m_valid;
-    using Base::update_if_needed;
 
-    bool init_from_parent() const final
+    // Friend because it needs access to `m_tree` in the implementation of
+    // `ObjCollectionBase::get_mutable_tree()`.
+    friend class LnkLst;
+
+    bool init_from_parent(bool allow_create) const
     {
-        m_valid = m_tree->init_from_parent();
-        update_content_version();
-        return m_valid;
+        if (!m_tree) {
+            m_tree.reset(new BPlusTree<T>(m_obj.get_alloc()));
+            const ArrayParent* parent = this;
+            m_tree->set_parent(const_cast<ArrayParent*>(parent), 0);
+        }
+
+        bool attached = m_tree->init_from_parent();
+
+        if (!attached && allow_create) {
+            // The ref in the column was NULL, create the tree in place.
+            m_tree->create();
+            REALM_ASSERT(m_tree->is_attached());
+            return true;
+        }
+
+        return attached;
+    }
+
+    /// Update the accessor and return true if it is attached after the update.
+    inline bool update() const
+    {
+        return update_if_needed() != UpdateStatus::Detached;
     }
 };
 
@@ -235,7 +309,6 @@ public:
     LnkLst(const Obj& owner, ColKey col_key)
         : m_list(owner, col_key)
     {
-        update_unresolved();
     }
 
     LnkLst(const LnkLst& other) = default;
@@ -319,8 +392,6 @@ public:
 
     std::unique_ptr<LnkLst> clone_linklist() const
     {
-        // FIXME: The copy constructor requires this.
-        update_if_needed();
         return std::make_unique<LnkLst>(*this);
     }
 
@@ -367,6 +438,9 @@ public:
         return m_list.get_tree();
     }
 
+    using Base::ensure_writable;
+    using Base::update_if_needed;
+
 private:
     friend class ConstTableView;
     friend class Query;
@@ -375,14 +449,18 @@ private:
 
     // Overriding members of ObjCollectionBase:
 
-    bool do_update_if_needed() const final
+    UpdateStatus do_update_if_needed() const final
     {
+        // Note: Caller (`ObjCollectionBase::update_if_needed()`) takes care of
+        // maintaining the unresolved list.
         return m_list.update_if_needed();
     }
 
-    bool do_init_from_parent() const final
+    UpdateStatus do_ensure_writable(bool allow_create) final
     {
-        return m_list.init_from_parent();
+        // Note: Caller (`ObjCollectionBase::ensure_writable()`) takes care of
+        // maintaining the unresolved list.
+        return m_list.ensure_writable(allow_create);
     }
 
     BPlusTree<ObjKey>& get_mutable_tree() const final
@@ -406,36 +484,21 @@ inline void LstBase::swap_repl(Replication* repl, size_t ndx1, size_t ndx2) cons
 template <class T>
 inline Lst<T>::Lst(const Obj& obj, ColKey col_key)
     : Base(obj, col_key)
-    , m_tree(new BPlusTree<T>(obj.get_alloc()))
 {
     if (!col_key.is_list()) {
         throw LogicError(LogicError::collection_type_mismatch);
     }
 
     check_column_type<T>(m_col_key);
-
-    m_tree->set_parent(this, 0); // ndx not used, implicit in m_owner
-    if (m_obj) {
-        // Fine because init_from_parent() is final.
-        init_from_parent();
-    }
 }
 
 template <class T>
 inline Lst<T>::Lst(const Lst& other)
     : Base(static_cast<const Base&>(other))
 {
-    // FIXME: If the other side needed an update, we could be using a stale ref
-    // below.
-    REALM_ASSERT(!other.update_if_needed());
-
-    if (other.m_tree) {
-        Allocator& alloc = other.m_tree->get_alloc();
-        m_tree = std::make_unique<BPlusTree<T>>(alloc);
-        m_tree->set_parent(this, 0);
-        if (m_valid)
-            m_tree->init_from_ref(other.m_tree->get_ref());
-    }
+    // Reset the content version so we can rely on init_from_parent() being
+    // called lazily when the accessor is used.
+    reset_content_version();
 }
 
 template <class T>
@@ -449,27 +512,19 @@ inline Lst<T>::Lst(Lst&& other) noexcept
 }
 
 template <class T>
-inline void Lst<T>::create()
-{
-    m_tree->create();
-    m_valid = true;
-}
-
-template <class T>
 Lst<T>& Lst<T>::operator=(const Lst& other)
 {
     Base::operator=(static_cast<const Base&>(other));
 
     if (this != &other) {
+        // FIXME: Can't do copy-assignment because:
+        // - BPlusTree's assignment operator calls destroy().
+        // - BPlusTree has an `Allocator&` member.
+        //
+        // Just reset the pointer and rely on init_from_parent() being called
+        // when the accessor is actually used.
         m_tree.reset();
-        if (other.m_tree) {
-            Allocator& alloc = other.m_tree->get_alloc();
-            m_tree = std::make_unique<BPlusTree<T>>(alloc);
-            m_tree->set_parent(this, 0);
-            if (m_valid) {
-                m_tree->init_from_ref(other.m_tree->get_ref());
-            }
-        }
+        reset_content_version();
     }
 
     return *this;
@@ -484,6 +539,9 @@ inline Lst<T>& Lst<T>::operator=(Lst&& other) noexcept
         m_tree = std::exchange(other.m_tree, nullptr);
         if (m_tree) {
             m_tree->set_parent(this, 0);
+
+            // Note: We do not need to call reset_content_version(), because we
+            // took both `m_tree` and `m_content_version` from `other`.
         }
     }
 
@@ -499,12 +557,9 @@ inline T Lst<T>::remove(const iterator& it)
 template <class T>
 inline size_t Lst<T>::size() const
 {
-    if (!is_attached())
+    if (!update())
         return 0;
-    update_if_needed();
-    if (!m_valid) {
-        return 0;
-    }
+
     return m_tree->size();
 }
 
@@ -518,14 +573,6 @@ template <class T>
 inline Mixed Lst<T>::get_any(size_t ndx) const
 {
     return get(ndx);
-}
-
-template <class T>
-inline void Lst<T>::ensure_created()
-{
-    if (!m_valid && m_obj.is_valid()) {
-        create();
-    }
 }
 
 template <class T>
@@ -578,10 +625,10 @@ template <class T>
 void Lst<T>::clear()
 {
     static_assert(!std::is_same_v<T, ObjKey>);
-    ensure_created();
-    update_if_needed();
-    this->ensure_writeable();
-    if (size() > 0) {
+
+    ensure_writable(false);
+
+    if (m_tree->size() > 0) {
         if (Replication* repl = this->m_obj.get_replication()) {
             repl->list_clear(*this);
         }
@@ -599,6 +646,7 @@ inline CollectionBasePtr Lst<T>::clone_collection() const
 template <class T>
 inline T Lst<T>::get(size_t ndx) const
 {
+    // Note: `size()` returns 0 if we are detached, so the bounds check will fail.
     const auto current_size = size();
     if (ndx >= current_size) {
         throw std::out_of_range("Index out of range");
@@ -609,37 +657,44 @@ inline T Lst<T>::get(size_t ndx) const
 template <class T>
 inline size_t Lst<T>::find_first(const T& value) const
 {
-    if (!m_valid && !init_from_parent())
+    if (!update())
         return not_found;
-    update_if_needed();
     return m_tree->find_first(value);
 }
 
 template <class T>
 inline Mixed Lst<T>::min(size_t* return_ndx) const
 {
-    update_if_needed();
+    if (!update()) {
+        return MinHelper<T>::not_found(return_ndx);
+    }
     return MinHelper<T>::eval(*m_tree, return_ndx);
 }
 
 template <class T>
 inline Mixed Lst<T>::max(size_t* return_ndx) const
 {
-    update_if_needed();
+    if (!update()) {
+        return MaxHelper<T>::not_found(return_ndx);
+    }
     return MaxHelper<T>::eval(*m_tree, return_ndx);
 }
 
 template <class T>
 inline Mixed Lst<T>::sum(size_t* return_cnt) const
 {
-    update_if_needed();
+    if (!update()) {
+        return SumHelper<T>::not_found(return_cnt);
+    }
     return SumHelper<T>::eval(*m_tree, return_cnt);
 }
 
 template <class T>
 inline Mixed Lst<T>::avg(size_t* return_cnt) const
 {
-    update_if_needed();
+    if (!update()) {
+        return AverageHelper<T>::not_found(return_cnt);
+    }
     return AverageHelper<T>::eval(*m_tree, return_cnt);
 }
 
@@ -713,8 +768,7 @@ size_t Lst<T>::find_any(Mixed val) const
 template <class T>
 void Lst<T>::resize(size_t new_size)
 {
-    update_if_needed();
-    size_t current_size = m_tree->size();
+    size_t current_size = size();
     while (new_size > current_size) {
         insert_null(current_size++);
     }
@@ -733,12 +787,18 @@ inline void Lst<T>::remove(size_t from, size_t to)
 template <class T>
 void Lst<T>::move(size_t from, size_t to)
 {
-    update_if_needed();
+    // `size()` will return 0 if we are detached, so the bounds check will fail.
+    auto sz = size();
+    if (from >= sz || to >= sz) {
+        throw std::out_of_range{"index out of bounds"};
+    }
+
     if (from != to) {
-        this->ensure_writeable();
         if (Replication* repl = this->m_obj.get_replication()) {
             repl->list_move(*this, from, to);
         }
+        ensure_writable(false);
+
         if (to > from) {
             to++;
         }
@@ -760,11 +820,18 @@ void Lst<T>::move(size_t from, size_t to)
 template <class T>
 void Lst<T>::swap(size_t ndx1, size_t ndx2)
 {
-    update_if_needed();
     if (ndx1 != ndx2) {
+        ensure_writable(false);
+
+        auto sz = m_tree->size();
+        if (ndx1 >= sz || ndx2 >= sz) {
+            throw std::out_of_range{"index out of bounds"};
+        }
+
         if (Replication* repl = this->m_obj.get_replication()) {
             LstBase::swap_repl(repl, ndx1, ndx2);
         }
+
         m_tree->swap(ndx1, ndx2);
         bump_content_version();
     }
@@ -773,15 +840,15 @@ void Lst<T>::swap(size_t ndx1, size_t ndx2)
 template <class T>
 T Lst<T>::set(size_t ndx, T value)
 {
-    update_if_needed();
-
     if (value_is_null(value) && !m_nullable)
         throw LogicError(LogicError::column_not_nullable);
 
-    // get will check for ndx out of bounds
+    ensure_writable(false);
+
+    // `get()` will check for ndx out of bounds.
     T old = get(ndx);
+
     if (old != value) {
-        this->ensure_writeable();
         do_set(ndx, value);
         bump_content_version();
     }
@@ -794,16 +861,15 @@ T Lst<T>::set(size_t ndx, T value)
 template <class T>
 void Lst<T>::insert(size_t ndx, T value)
 {
-    update_if_needed();
-
     if (value_is_null(value) && !m_nullable)
         throw LogicError(LogicError::column_not_nullable);
 
-    ensure_created();
+    ensure_writable(true);
+
     if (ndx > m_tree->size()) {
         throw std::out_of_range("Index out of range");
     }
-    this->ensure_writeable();
+
     if (Replication* repl = this->m_obj.get_replication()) {
         repl->list_insert(*this, ndx, value);
     }
@@ -814,12 +880,11 @@ void Lst<T>::insert(size_t ndx, T value)
 template <class T>
 T Lst<T>::remove(size_t ndx)
 {
-    update_if_needed();
+    ensure_writable(false);
 
-    this->ensure_writeable();
-
-    // get will check for ndx out of bounds
+    // `get()` will check bounds.
     T old = get(ndx);
+
     if (Replication* repl = this->m_obj.get_replication()) {
         repl->list_erase(*this, ndx);
     }
@@ -859,6 +924,8 @@ inline Mixed LnkLst::get_any(size_t ndx) const
 
 inline void LnkLst::clear()
 {
+    // Note: Explicit call to `ensure_writable()` not needed, because we
+    // explicitly call `clear_unresolved()`.
     m_list.clear();
     clear_unresolved();
 }
@@ -923,25 +990,25 @@ inline ColKey LnkLst::get_col_key() const noexcept
 
 inline void LnkLst::set_null(size_t ndx)
 {
-    update_if_needed();
+    ensure_writable(false);
     m_list.set_null(virtual2real(ndx));
 }
 
 inline void LnkLst::set_any(size_t ndx, Mixed val)
 {
-    update_if_needed();
+    ensure_writable(false);
     m_list.set_any(virtual2real(ndx), val);
 }
 
 inline void LnkLst::insert_null(size_t ndx)
 {
-    update_if_needed();
+    ensure_writable(true);
     m_list.insert_null(virtual2real(ndx));
 }
 
 inline void LnkLst::insert_any(size_t ndx, Mixed val)
 {
-    update_if_needed();
+    ensure_writable(true);
     m_list.insert_any(virtual2real(ndx), val);
 }
 
@@ -958,25 +1025,28 @@ inline size_t LnkLst::find_any(Mixed value) const
 
 inline void LnkLst::resize(size_t new_size)
 {
-    update_if_needed();
+    ensure_writable(true);
+
+    // FIXME: This operation doesn't make much sense, because the inserted
+    // values at the end will be tombstones.
     m_list.resize(new_size + num_unresolved());
 }
 
 inline void LnkLst::remove(size_t from, size_t to)
 {
-    update_if_needed();
+    ensure_writable(false);
     m_list.remove(virtual2real(from), virtual2real(to));
 }
 
 inline void LnkLst::move(size_t from, size_t to)
 {
-    update_if_needed();
+    ensure_writable(false);
     m_list.move(virtual2real(from), virtual2real(to));
 }
 
 inline void LnkLst::swap(size_t ndx1, size_t ndx2)
 {
-    update_if_needed();
+    ensure_writable(false);
     m_list.swap(virtual2real(ndx1), virtual2real(ndx2));
 }
 
@@ -992,6 +1062,7 @@ inline size_t LnkLst::find_first(const ObjKey& key) const
         return not_found;
 
     update_if_needed();
+
     size_t found = m_list.find_first(key);
     if (found == not_found)
         return not_found;
@@ -1003,8 +1074,10 @@ inline void LnkLst::insert(size_t ndx, ObjKey value)
     REALM_ASSERT(!value.is_unresolved());
     if (get_target_table()->is_embedded() && value != ObjKey())
         throw LogicError(LogicError::wrong_kind_of_table);
-    update_if_needed();
+
+    ensure_writable(true);
     m_list.insert(virtual2real(ndx), value);
+    update_unresolved(UpdateStatus::Updated);
 }
 
 inline ObjKey LnkLst::set(size_t ndx, ObjKey value)
@@ -1012,7 +1085,8 @@ inline ObjKey LnkLst::set(size_t ndx, ObjKey value)
     REALM_ASSERT(!value.is_unresolved());
     if (get_target_table()->is_embedded() && value != ObjKey())
         throw LogicError(LogicError::wrong_kind_of_table);
-    update_if_needed();
+
+    ensure_writable(false);
     ObjKey old = m_list.set(virtual2real(ndx), value);
     REALM_ASSERT(!old.is_unresolved());
     return old;
@@ -1020,9 +1094,10 @@ inline ObjKey LnkLst::set(size_t ndx, ObjKey value)
 
 inline ObjKey LnkLst::remove(size_t ndx)
 {
-    update_if_needed();
+    ensure_writable(false);
     ObjKey old = m_list.remove(virtual2real(ndx));
     REALM_ASSERT(!old.is_unresolved());
+    update_unresolved(UpdateStatus::Updated);
     return old;
 }
 

--- a/src/realm/set.hpp
+++ b/src/realm/set.hpp
@@ -1159,7 +1159,7 @@ inline std::pair<size_t, bool> LnkSet::insert(ObjKey value)
 
     auto [ndx, inserted] = m_set.insert(value);
     if (inserted) {
-        update_unresolved();
+        update_unresolved(UpdateStatus::Updated);
     }
     return {real2virtual(ndx), inserted};
 }
@@ -1171,7 +1171,7 @@ inline std::pair<size_t, bool> LnkSet::erase(ObjKey value)
 
     auto [ndx, removed] = m_set.erase(value);
     if (removed) {
-        update_unresolved(UpdateStatus::Update);
+        update_unresolved(UpdateStatus::Updated);
         ndx = real2virtual(ndx);
     }
     return {ndx, removed};
@@ -1194,7 +1194,7 @@ inline std::pair<size_t, bool> LnkSet::insert_null()
     update_if_needed();
     auto [ndx, inserted] = m_set.insert_null();
     if (inserted) {
-        update_unresolved(UpdateStatus::Update);
+        update_unresolved(UpdateStatus::Updated);
     }
     return {real2virtual(ndx), inserted};
 }
@@ -1204,7 +1204,7 @@ inline std::pair<size_t, bool> LnkSet::erase_null()
     update_if_needed();
     auto [ndx, erased] = m_set.erase_null();
     if (erased) {
-        update_unresolved(UpdateStatus::Update);
+        update_unresolved(UpdateStatus::Updated);
         ndx = real2virtual(ndx);
     }
     return {ndx, erased};
@@ -1215,7 +1215,7 @@ inline std::pair<size_t, bool> LnkSet::insert_any(Mixed value)
     update_if_needed();
     auto [ndx, inserted] = m_set.insert_any(value);
     if (inserted) {
-        update_unresolved(UpdateStatus::Update);
+        update_unresolved(UpdateStatus::Updated);
     }
     return {real2virtual(ndx), inserted};
 }
@@ -1224,7 +1224,7 @@ inline std::pair<size_t, bool> LnkSet::erase_any(Mixed value)
 {
     auto [ndx, erased] = m_set.erase_any(value);
     if (erased) {
-        update_unresolved(UpdateStatus::Update);
+        update_unresolved(UpdateStatus::Updated);
         ndx = real2virtual(ndx);
     }
     return {ndx, erased};

--- a/test/test_table.cpp
+++ b/test/test_table.cpp
@@ -2855,13 +2855,14 @@ TEST(Table_list_basic)
         CHECK_NOT(obj.is_null(list_col));
         CHECK(list.is_empty());
 
-        size_t return_cnt = 0;
+        size_t return_cnt = 0, return_ndx = 0;
         list.sum(&return_cnt);
         CHECK_EQUAL(return_cnt, 0);
-        list.max(&return_cnt);
-        CHECK_EQUAL(return_cnt, 0);
-        list.min(&return_cnt);
-        CHECK_EQUAL(return_cnt, 0);
+        list.max(&return_ndx);
+        CHECK_EQUAL(return_ndx, not_found);
+        return_ndx = 0;
+        list.min(&return_ndx);
+        CHECK_EQUAL(return_ndx, not_found);
         list.avg(&return_cnt);
         CHECK_EQUAL(return_cnt, 0);
 


### PR DESCRIPTION
## What, How & Why?

This PR shifts around the responsibility of updating internal state of collection accessors.

Accessors are now initialized lazily when they are first used. This makes certain things simpler, especially copy-construction of collection accessors, which previously required the source to be updated (or it would throw an exception). With this change, the new copy can be in an uninitialized state until it is first used.

Information about how to respond to an update to the underlying storage now flows upwards (through `UpdateStatus`). This isolates the responsibility of detecting an update to the accessor that actually manages that data.

The "detached" state is now explicitly called out during accessor updates (`UpdateStatus::Detached`).

The flow of accessor update is now:

- The user calls a method on the collection accessor (such as `insert()` etc.)
- The accessor calls `update_if_needed()` on its inner accessor (in the case of `LnkLst`) or its parent `Obj`.
- The parent object tells the accessor via the return value whether it updated itself.
    - If the parent object was updated, the accessor must always update itself and return `UpdateStatus::Updated`.
    - If the parent object was not updated, and was not detached, the accessor has the opportunity to update itself based on other criteria (e.g. whether `storage_version` changed in the case of most collections). If it decided to update itself, it should return `UpdateStatus::Updated` to instruct potential users of the class to update themselves in turn (this is currently only relevant for `Lst<ObjKey>` and `Set<ObjKey>`, which are used by `LnkLst` and `LnkSet`, respectively).
    - If the parent object was detached, the accessor may choose to de-initialize itself and return to a detached state, freeing up resources associated with the accessor.
- The accessor then performs the operation requested by the user, or throws an exception if it cannot be carried out.

One drawback of this design is that accessor updates cannot be initiated by the bottom-most accessor (unless it is a base class of the topmost accessor, and the topmost accessor calls `Base::update_if_needed()` in its implementation of `update_if_needed()`). In practice, it means that `LnkLst` must call its own `update_if_needed()` before carrying out any operations on its internal `Lst<ObjKey>`, or risk that its list of unresolved links becomes out of date.

The upside is that the accessor update flow becomes significantly easier to reason about, with fewer details leaking between different accessor types and a clearer flow of information.

## ☑️ ToDos
* [ ] 📝 Changelog update
* [x] 🚦 Tests (or not relevant)
