### PR TITLE
Define destructors in class body to work around compiler disagreement on correct syntax

### DIFF
--- a/src/realm/util/file.hpp
+++ b/src/realm/util/file.hpp
@@ -736,8 +736,6 @@ public:
     /// mapped file.
     Map() noexcept;
 
-    ~Map() noexcept;
-
     // Disable copying. Copying an opened Map will create a scenario
     // where the same memory will be mapped once but unmapped twice.
     Map(const Map&) = delete;
@@ -1161,11 +1159,6 @@ inline File::Map<T>::Map(const File& f, size_t offset, AccessMode a, size_t size
 
 template <class T>
 inline File::Map<T>::Map() noexcept
-{
-}
-
-template <class T>
-inline File::Map<T>::~Map() noexcept
 {
 }
 

--- a/src/realm/util/network.hpp
+++ b/src/realm/util/network.hpp
@@ -439,7 +439,9 @@ public:
     void clear() noexcept;
     OperQueue() noexcept = default;
     OperQueue(OperQueue&&) noexcept;
-    ~OperQueue() noexcept;
+    ~OperQueue() noexcept {
+        clear();
+    }
 
 private:
     Oper* m_back = nullptr;
@@ -1780,12 +1782,6 @@ inline Service::OperQueue<Oper>::OperQueue(OperQueue&& q) noexcept
     : m_back{q.m_back}
 {
     q.m_back = nullptr;
-}
-
-template <class Oper>
-inline Service::OperQueue<Oper>::~OperQueue() noexcept
-{
-    clear();
 }
 
 // ---------------- Service::Descriptor ----------------


### PR DESCRIPTION
Fixes #4732

<!--
 Make sure to assign one and only one Type (`T:`) label.
 Select reviewers if ready for review. Our bot will automatically assign you.
 -->

## What, How & Why?
<!-- Describe the changes and give some hints to guide your reviewers if possible. -->
<!-- Link (via zenhub) to relevant issue this fixes -->

## ☑️ ToDos
* ~~[ ] 📝 Changelog update~~
* ~~[ ] 🚦 Tests (or not relevant)~~
