### PR TITLE
RCORE-734 Emit set(null) instruction before replacing embedded object

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 ### Fixed
 * <How to hit and notice issue? what was the impact?> ([#????](https://github.com/realm/realm-core/issues/????), since v?.?.?)
 * Fixed the string based query parser not supporting integer constants above 32 bits on a 32 bit platform. ([realm-js #3773](https://github.com/realm/realm-js/issues/3773), since v10.4.0 with the introduction of the new query parser)
+* When replacing an embedded object, we must emit a sync instruction that sets the link to the embedded object to null so that it is properly cleared. ([#4740](https://github.com/realm/realm-core/issues/4740)
  
 ### Breaking changes
 * None.

--- a/src/realm/obj.cpp
+++ b/src/realm/obj.cpp
@@ -1547,9 +1547,21 @@ Obj Obj::create_and_set_linked_object(ColKey col_key, bool is_default)
     auto result = t.is_embedded() ? t.create_linked_object() : t.create_object();
     auto target_key = result.get_key();
     ObjKey old_key = get<ObjKey>(col_key); // Will update if needed
-    if (!t.is_embedded() && old_key != ObjKey()) {
-        throw LogicError(LogicError::wrong_kind_of_table);
+    if (old_key != ObjKey()) {
+        if (!t.is_embedded()) {
+            throw LogicError(LogicError::wrong_kind_of_table);
+        }
+
+        // If this is an embedded object and there was already an embedded object here, then we need to
+        // emit an instruction to set the old embedded object to null to clear the old object on other
+        // sync clients. Without this, you'll only see the Set ObjectValue instruction, which is idempotent,
+        // and then array operations will have a corrupted prior_size.
+        if (Replication* repl = get_replication()) {
+            repl->set(m_table.unchecked_ptr(), col_key, m_key, util::none,
+                      is_default ? _impl::instr_SetDefault : _impl::instr_Set); // Throws
+        }
     }
+
     if (target_key != old_key) {
         CascadeState state;
 

--- a/test/object-store/util/test_file.cpp
+++ b/test/object-store/util/test_file.cpp
@@ -249,10 +249,9 @@ TestSyncManager::TestSyncManager(const Config& config, const SyncServer::Config&
     sc_config.base_file_path = m_base_file_path;
     sc_config.metadata_mode = config.metadata_mode;
 #if TEST_ENABLE_SYNC_LOGGING
-    sc_config.log_level = util::Logger::Level::all;
-#else
-    sc_config.log_level = util::Logger::Level::off;
+    config.verbose_sync_client_logging = true;
 #endif
+    sc_config.log_level = config.verbose_sync_client_logging ? util::Logger::Level::all : util::Logger::Level::off;
 
     m_app = app::App::get_shared_app(app_config, sc_config);
     m_app->sync_manager()->set_sync_route((config.base_url.empty() ? m_sync_server.base_url() : config.base_url) +

--- a/test/object-store/util/test_file.hpp
+++ b/test/object-store/util/test_file.hpp
@@ -181,6 +181,7 @@ struct TestSyncManager {
         std::string base_url;
         realm::SyncManager::MetadataMode metadata_mode;
         bool should_teardown_test_directory;
+        bool verbose_sync_client_logging = false;
     };
 
     TestSyncManager(const Config& = Config(), const SyncServer::Config& = {});


### PR DESCRIPTION
## What, How & Why?
If you are replacing an embedded object with a new one, rather than simply updating all its fields, we need to emit a sync instruction to set the old embedded object to null so that its fields get cleared before setting the new object's fields. Without doing this, any array instructions on the new object could have a corrupted prior_size because from the sync protocol's perspective, they'll be operating on a non-empty array.

## ☑️ ToDos
* [x] 📝 Changelog update
* [X] 🚦 Tests (or not relevant)
