### PR TITLE
Do not try to auto refresh a token on a revoked user

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@
 
 ### Fixed
 * <How to hit and notice issue? what was the impact?> ([#????](https://github.com/realm/realm-core/issues/????), since v?.?.?)
-* None.
+* Fixed a recursive loop which would eventually crash trying to refresh a user app token when it had been revoked by an admin. Now this situation logs the user out and reports an error. ([#4745](https://github.com/realm/realm-core/issues/4745), since v10.0.0).
  
 ### Breaking changes
 * None.

--- a/src/realm/object-store/sync/sync_session.cpp
+++ b/src/realm/object-store/sync/sync_session.cpp
@@ -384,6 +384,7 @@ std::function<void(util::Optional<app::AppError>)> SyncSession::handle_refresh(s
             if (error->http_status_code && (*error->http_status_code == 401 || *error->http_status_code == 403)) {
                 // A 401 response on a refresh request means that the token cannot be refreshed and we should not
                 // retry. This can be because an admin has revoked this user's sessions or the user has been disabled.
+                // TODO: ideally this would write to the logs as well in case users didn't set up their error handler.
                 std::unique_lock<std::mutex> lock(session->m_state_mutex);
                 session->cancel_pending_waits(lock, error->error_code);
                 if (session_user && session_user->is_logged_in()) {

--- a/src/realm/object-store/sync/sync_session.cpp
+++ b/src/realm/object-store/sync/sync_session.cpp
@@ -381,20 +381,18 @@ std::function<void(util::Optional<app::AppError>)> SyncSession::handle_refresh(s
             }
         }
         else if (error) {
-            if (error->http_status_code && *error->http_status_code == 401 &&
-                error->error_code == realm::app::make_error_code(realm::app::ServiceErrorCode::invalid_session)) {
-                // a 401 response on a refresh request means that the token cannot be refreshed and we should not
-                // retry. this can be because an admin has revoked this user's sessions
+            if (error->http_status_code && (*error->http_status_code == 401 || *error->http_status_code == 403)) {
+                // A 401 response on a refresh request means that the token cannot be refreshed and we should not
+                // retry. This can be because an admin has revoked this user's sessions or the user has been disabled.
                 std::unique_lock<std::mutex> lock(session->m_state_mutex);
                 session->cancel_pending_waits(lock, error->error_code);
-                if (session->m_config.error_handler) {
-                    auto user_facing_error = SyncError(
-                        realm::sync::ProtocolError::permission_denied,
-                        "Unable to refresh the user access token; has this user been disabled by an admin?", true);
-                    session->m_config.error_handler(session, user_facing_error);
-                }
                 if (session_user && session_user->is_logged_in()) {
                     session_user->log_out();
+                }
+                if (session->m_config.error_handler) {
+                    auto user_facing_error = SyncError(realm::sync::ProtocolError::permission_denied,
+                                                       "Unable to refresh the user access token.", true);
+                    session->m_config.error_handler(session, user_facing_error);
                 }
             }
             else {
@@ -610,9 +608,10 @@ void SyncSession::handle_error(SyncError error)
         }
     }
     else {
-        // The server replies with '401: unauthorized' iff the access token is invalid or expired.
-        // If the access token is valid but was not authorized by the server a '403: forbidden' is sent.
-        // This means that if we did get the 401, the next step is always to request a new access token.
+        // The server replies with '401: unauthorized' if the access token is invalid, expired, revoked, or the user
+        // is disabled. In this scenario we attempt an automatic token refresh and if that succeeds continue as
+        // normal. If the refresh request also fails with 401 then we need to stop retrying and pass along the error;
+        // see handle_refresh().
         if (error_code == util::websocket::make_error_code(util::websocket::Error::bad_response_401_unauthorized)) {
             if (auto u = user()) {
                 u->refresh_custom_data(handle_refresh(shared_from_this()));

--- a/test/object-store/util/baas_admin_api.cpp
+++ b/test/object-store/util/baas_admin_api.cpp
@@ -436,6 +436,24 @@ AdminAPISession AdminAPISession::login(const std::string& base_url, const std::s
     return AdminAPISession(std::move(base_url), std::move(access_token), std::move(group_id));
 }
 
+void AdminAPISession::revoke_user_sessions(const std::string& user_id, const std::string app_id)
+{
+    auto endpoint = AdminAPIEndpoint(
+        util::format("%1/api/admin/v3.0/groups/%2/apps/%3/users/%4/disable", m_base_url, m_group_id, app_id, user_id),
+        m_access_token);
+    auto response = endpoint.put("");
+    REALM_ASSERT(response.http_status_code == 204);
+}
+
+void AdminAPISession::enable_user_sessions(const std::string& user_id, const std::string app_id)
+{
+    auto endpoint = AdminAPIEndpoint(
+        util::format("%1/api/admin/v3.0/groups/%2/apps/%3/users/%4/enable", m_base_url, m_group_id, app_id, user_id),
+        m_access_token);
+    auto response = endpoint.put("");
+    REALM_ASSERT(response.http_status_code == 204);
+}
+
 AdminAPIEndpoint AdminAPISession::apps() const
 {
     return AdminAPIEndpoint(util::format("%1/api/admin/v3.0/groups/%2/apps", m_base_url, m_group_id), m_access_token);

--- a/test/object-store/util/baas_admin_api.hpp
+++ b/test/object-store/util/baas_admin_api.hpp
@@ -63,6 +63,8 @@ public:
                                  const std::string& password);
 
     AdminAPIEndpoint apps() const;
+    void revoke_user_sessions(const std::string& user_id, const std::string app_id);
+    void enable_user_sessions(const std::string& user_id, const std::string app_id);
 
 private:
     AdminAPISession(std::string base_url, std::string access_token, std::string group_id)

--- a/test/object-store/util/baas_admin_api.hpp
+++ b/test/object-store/util/baas_admin_api.hpp
@@ -64,7 +64,9 @@ public:
 
     AdminAPIEndpoint apps() const;
     void revoke_user_sessions(const std::string& user_id, const std::string app_id);
+    void disable_user_sessions(const std::string& user_id, const std::string app_id);
     void enable_user_sessions(const std::string& user_id, const std::string app_id);
+    bool verify_access_token(const std::string& access_token, const std::string app_id);
 
 private:
     AdminAPISession(std::string base_url, std::string access_token, std::string group_id)


### PR DESCRIPTION
Fixes https://github.com/realm/realm-core/issues/4745

The auto refresh would recursively try to refresh the token every 10 seconds which would loop endlessly on a user who had been revoked by an admin. Eventually this would have caused a stack overflow.

## ☑️ ToDos
* [x] 📝 Changelog update
* [x] 🚦 Tests (or not relevant)
