### PR TITLE
Fix setting the cmake target for evg tasks

### DIFF
--- a/evergreen/config.yml
+++ b/evergreen/config.yml
@@ -119,14 +119,14 @@ functions:
             -G "${cmake_generator|Unix Makefiles}"
 
           if [[ -n "${target_to_build|}" ]]; then
-              target=(--target "${target_to_build|}")
+              target="--target ${target_to_build|}"
           fi
 
           ${cmake_bindir}/cmake \
               --build build \
               --config ${cmake_build_type|Debug} \
               -j ${max_jobs|$(grep -c proc /proc/cpuinfo)} \
-              ${target[@]}
+              $target
 
   "run benchmark":
     - command: shell.exec


### PR DESCRIPTION
Evergreen's expansions syntax means we can't use bash arrays as it eats anything using ${. Using a simple variable expansion will result in things breaking if a target name has a space in it, but the rest of the script isn't space-safe anyway.

https://evergreen.mongodb.com/task/realm_core_stable_ubuntu2004_asan_long_running_core_tests_patch_ed9fbb907e0b5e97e0e2d5b8efdc0951b2eb980c_60bffbb461837d355b954238_21_06_08_23_23_03 is a patch run with these changes which is building the right thing.