### PR TITLE
Disable supposedly false negative runtime checks for msvc

### DIFF
--- a/src/realm/sync/changeset.cpp
+++ b/src/realm/sync/changeset.cpp
@@ -58,6 +58,8 @@ InternString Changeset::find_string(StringData string) const noexcept
     return InternString{};
 }
 
+// TODO: https://github.com/realm/realm-core/issues/4624 remove the check disabling code once
+// we understand why MSVC reports stack corruption in this method.
 #if _MSC_VER
 #pragma runtime_checks("", off)
 #endif

--- a/src/realm/sync/changeset.cpp
+++ b/src/realm/sync/changeset.cpp
@@ -74,7 +74,7 @@ PrimaryKey Changeset::get_key(const Instruction::PrimaryKey& key) const noexcept
     return mpark::visit(get, key);
 }
 #if _MSC_VER
-#pragma runtime_checks("", off)
+#pragma runtime_checks("", restore)
 #endif
 
 bool Changeset::operator==(const Changeset& that) const noexcept

--- a/src/realm/sync/instruction_applier.cpp
+++ b/src/realm/sync/instruction_applier.cpp
@@ -58,6 +58,11 @@ TableRef InstructionApplier::table_for_class_name(StringData class_name) const
     return m_transaction.get_table(class_name_to_table_name(class_name, buffer));
 }
 
+// TODO: https://github.com/realm/realm-core/issues/4624 remove the check disabling code once
+// we understand why MSVC reports stack corruption in this and the following methods.
+#if _MSC_VER
+#pragma runtime_checks("", off)
+#endif
 void InstructionApplier::operator()(const Instruction::AddTable& instr)
 {
     auto table_name = get_table_name(instr);
@@ -256,9 +261,6 @@ void InstructionApplier::visit_payload(const Instruction::Payload& payload, F&& 
     }
 }
 
-#if _MSC_VER
-#pragma runtime_checks("", off)
-#endif
 void InstructionApplier::operator()(const Instruction::Update& instr)
 {
     auto setter = util::overload{

--- a/src/realm/sync/instruction_applier.cpp
+++ b/src/realm/sync/instruction_applier.cpp
@@ -256,7 +256,9 @@ void InstructionApplier::visit_payload(const Instruction::Payload& payload, F&& 
     }
 }
 
-
+#if _MSC_VER
+#pragma runtime_checks("", off)
+#endif
 void InstructionApplier::operator()(const Instruction::Update& instr)
 {
     auto setter = util::overload{
@@ -893,6 +895,9 @@ void InstructionApplier::operator()(const Instruction::SetErase& instr)
 
     resolve_path(instr, "SetErase", callback);
 }
+#if _MSC_VER
+#pragma runtime_checks("", restore)
+#endif
 
 StringData InstructionApplier::get_table_name(const Instruction::TableInstruction& instr, const char* name)
 {


### PR DESCRIPTION
<!--
 Make sure to assign one and only one Type (`T:`) label.
 Select reviewers if ready for review. Our bot will automatically assign you.
 -->

## What, How & Why?
This disables msvc runtime checks in a few more places because we're seeing stack corrupted assertions similar to the one in https://github.com/realm/realm-core/issues/4624. I am assuming those are again false negatives, although I would appreciate if someone familiar with what's going on there takes a more comprehensive look.
