### PR TITLE
prototype for async write/commit

### DIFF
--- a/src/realm/db.cpp
+++ b/src/realm/db.cpp
@@ -1575,6 +1575,12 @@ void DB::release_all_read_locks() noexcept
 // directly.
 void DB::close(bool allow_open_read_transactions)
 {
+    // make helper thread terminate
+    if (m_commit_helper_thread) {
+        m_commit_helper_terminated = true;
+        m_commit_helper_changed.notify_one();
+        m_commit_helper_thread->join();
+    }
     if (m_fake_read_lock_if_immutable) {
         if (!is_attached())
             return;

--- a/src/realm/db.hpp
+++ b/src/realm/db.hpp
@@ -671,9 +671,11 @@ public:
     {
         // TODO make async flush to disk
         m_is_synchronizing = true;
+        // we must release the write mutex before the callback, because the callback
+        // is allowed to re-request it.
+        get_db()->do_end_write();
         when_synchronized();
         m_is_synchronizing = false;
-        get_db()->do_end_write();
     };
     // release the write lock without any sync to disk
     void release_write_lock()

--- a/src/realm/db.hpp
+++ b/src/realm/db.hpp
@@ -673,6 +673,7 @@ public:
         m_is_synchronizing = true;
         when_synchronized();
         m_is_synchronizing = false;
+        get_db()->do_end_write();
     };
     // release the write lock without any sync to disk
     void release_write_lock()

--- a/src/realm/group_writer.hpp
+++ b/src/realm/group_writer.hpp
@@ -139,8 +139,8 @@ private:
     // the least recently used and sync'ing it to disk
     MapWindow* get_window(ref_type start_ref, size_t size);
 
-    // Sync all cached memory mappings
-    void sync_all_mappings();
+    // Flush all cached memory mappings
+    void flush_all_mappings();
 
     /// Allocate a chunk of free space of the specified size. The
     /// specified size must be 8-byte aligned. Extend the file if

--- a/src/realm/object-store/c_api/scheduler.cpp
+++ b/src/realm/object-store/c_api/scheduler.cpp
@@ -138,6 +138,19 @@ struct CAPIScheduler : Scheduler {
             m_set_notify_callback(m_userdata, ptr, free_notify_cpp_callback, invoke_notify_cpp_callback);
         }
     }
+
+    void schedule_writes() override{};
+    void schedule_completions() override{};
+    bool can_schedule_writes() const noexcept override
+    {
+        return false;
+    };
+    bool can_schedule_completions() const noexcept override
+    {
+        return false;
+    };
+    void set_schedule_writes_callback(std::function<void()>) override{};
+    void set_schedule_completions_callback(std::function<void()>) override{};
 };
 
 struct DefaultFactory {

--- a/src/realm/object-store/impl/realm_coordinator.cpp
+++ b/src/realm/object-store/impl/realm_coordinator.cpp
@@ -705,7 +705,7 @@ void RealmCoordinator::wake_up_notifier_worker()
     }
 }
 
-void RealmCoordinator::commit_write(Realm& realm, bool with_lock_held)
+void RealmCoordinator::commit_write(Realm& realm, bool with_lock_held, bool without_sync)
 {
     REALM_ASSERT(!m_config.immutable());
     REALM_ASSERT(realm.is_in_transaction());
@@ -717,7 +717,7 @@ void RealmCoordinator::commit_write(Realm& realm, bool with_lock_held)
         // perform a write and notify us before we get the chance to set the
         // skip version
         util::CheckedLockGuard l(m_notifier_mutex);
-        new_version = tr.commit_and_continue_as_read(with_lock_held);
+        new_version = tr.commit_and_continue_as_read(with_lock_held, without_sync);
 
         // The skip version must always be the notifier transaction's current
         // version plus one, as we can only skip a prefix and not intermediate

--- a/src/realm/object-store/impl/realm_coordinator.hpp
+++ b/src/realm/object-store/impl/realm_coordinator.hpp
@@ -183,11 +183,11 @@ public:
 
     // Deliver notifications for the Realm, blocking if some aren't ready yet
     // The calling Realm must be in a write transaction
-    void promote_to_write(Realm& realm) REQUIRES(!m_notifier_mutex);
+    void promote_to_write(Realm& realm, bool with_lock_held = false) REQUIRES(!m_notifier_mutex);
 
     // Commit a Realm's current write transaction and send notifications to all
     // other Realm instances for that path, including in other processes
-    void commit_write(Realm& realm) REQUIRES(!m_notifier_mutex);
+    void commit_write(Realm& realm, bool with_lock_held = false) REQUIRES(!m_notifier_mutex);
 
     void enable_wait_for_change();
     bool wait_for_change(std::shared_ptr<Transaction> tr);

--- a/src/realm/object-store/impl/realm_coordinator.hpp
+++ b/src/realm/object-store/impl/realm_coordinator.hpp
@@ -187,7 +187,8 @@ public:
 
     // Commit a Realm's current write transaction and send notifications to all
     // other Realm instances for that path, including in other processes
-    void commit_write(Realm& realm, bool with_lock_held = false) REQUIRES(!m_notifier_mutex);
+    void commit_write(Realm& realm, bool with_lock_held = false, bool without_sync = false)
+        REQUIRES(!m_notifier_mutex);
 
     void enable_wait_for_change();
     bool wait_for_change(std::shared_ptr<Transaction> tr);

--- a/src/realm/object-store/impl/transact_log_handler.cpp
+++ b/src/realm/object-store/impl/transact_log_handler.cpp
@@ -641,12 +641,13 @@ void advance(const std::shared_ptr<Transaction>& tr, BindingContext* context, No
         notifiers);
 }
 
-void begin(const std::shared_ptr<Transaction>& tr, BindingContext* context, NotifierPackage& notifiers)
+void begin(const std::shared_ptr<Transaction>& tr, BindingContext* context, NotifierPackage& notifiers,
+           bool with_lock_held)
 {
     advance_with_notifications(
         context, tr,
         [&](auto&&... args) {
-            tr->promote_to_write(std::move(args)...);
+            tr->promote_to_write(std::move(args)..., false, with_lock_held);
         },
         notifiers);
 }

--- a/src/realm/object-store/impl/transact_log_handler.hpp
+++ b/src/realm/object-store/impl/transact_log_handler.hpp
@@ -46,7 +46,8 @@ void advance(Transaction& sg, BindingContext* binding_context, VersionID);
 // Begin a write transaction
 // If the read transaction version is not up to date, will first advance to the
 // most recent read transaction and sent notifications to delegate
-void begin(const std::shared_ptr<Transaction>& sg, BindingContext* binding_context, NotifierPackage&);
+void begin(const std::shared_ptr<Transaction>& sg, BindingContext* binding_context, NotifierPackage&,
+           bool with_lock_held);
 
 // Cancel a write transaction and roll back all changes, with change notifications
 // for reverting to the old values sent to delegate

--- a/src/realm/object-store/shared_realm.hpp
+++ b/src/realm/object-store/shared_realm.hpp
@@ -536,7 +536,7 @@ private:
     Transaction& transaction() const;
     std::shared_ptr<Transaction> transaction_ref();
     struct async_write_desc {
-        SharedRealm retained_ref;
+        SharedRealm retained_ref; // needed to keep the Realm object alive
         std::function<void()> writer;
     };
     std::deque<async_write_desc> m_async_write_q;

--- a/src/realm/object-store/shared_realm.hpp
+++ b/src/realm/object-store/shared_realm.hpp
@@ -535,7 +535,11 @@ private:
     Transaction& transaction();
     Transaction& transaction() const;
     std::shared_ptr<Transaction> transaction_ref();
-    std::deque<std::function<void()>> m_async_write_q;
+    struct async_write_desc {
+        SharedRealm retained_ref;
+        std::function<void()> writer;
+    };
+    std::deque<async_write_desc> m_async_write_q;
     struct async_commit_desc {
         DB::ReadLockInfo read_lock;
         std::function<void()> when_completed;

--- a/src/realm/object-store/shared_realm.hpp
+++ b/src/realm/object-store/shared_realm.hpp
@@ -306,6 +306,24 @@ public:
     void cancel_transaction();
     bool is_in_transaction() const noexcept;
 
+    // Asynchronous (write)transaction.
+    // 'the_write_block' is scheduled for execution on the scheduler
+    // associated with the current realm. It will run after the write
+    // mutex has been acquired. it should end by calling commit_transaction(),
+    // cancel_transaction() or schedule_commit(). Returning without one of
+    // these calls will be equivalent to calling cancel_transaction().
+    // The call returns immediately allowing the caller to proceed
+    // while the write mutex is held by someone else.
+    void schedule_transaction(std::function<void()> the_write_block);
+
+    // Asynchronous commit.
+    // 'the_done_block' is scheduled for execution on the scheduler
+    // associated with the current realm. It will run after the commit
+    // has been completed. The call returns immediately allowing
+    // the caller to proceed while the I/O is performed on a dedicated
+    // background thread.
+    void schedule_commit(std::function<void()> the_done_block);
+
     // Returns a frozen copy for the current version of this Realm
     SharedRealm freeze();
 

--- a/src/realm/object-store/util/generic/scheduler.hpp
+++ b/src/realm/object-store/util/generic/scheduler.hpp
@@ -41,6 +41,19 @@ public:
     void set_notify_callback(std::function<void()>) override {}
     void notify() override {}
 
+    void schedule_writes() override{};
+    void schedule_completions() override{};
+    bool can_schedule_writes() const noexcept override
+    {
+        return false;
+    };
+    bool can_schedule_completions() const noexcept override
+    {
+        return false;
+    };
+    void set_schedule_writes_callback(std::function<void()>) override{};
+    void set_schedule_completions_callback(std::function<void()>) override{};
+
 private:
     std::thread::id m_id = std::this_thread::get_id();
 };

--- a/src/realm/object-store/util/scheduler.cpp
+++ b/src/realm/object-store/util/scheduler.cpp
@@ -62,6 +62,18 @@ public:
     {
         return false;
     }
+    void schedule_writes() override{};
+    void schedule_completions() override{};
+    bool can_schedule_writes() const noexcept override
+    {
+        return false;
+    };
+    bool can_schedule_completions() const noexcept override
+    {
+        return false;
+    };
+    void set_schedule_writes_callback(std::function<void()>) override{};
+    void set_schedule_completions_callback(std::function<void()>) override{};
 
 private:
     VersionID m_version;

--- a/src/realm/object-store/util/scheduler.hpp
+++ b/src/realm/object-store/util/scheduler.hpp
@@ -56,6 +56,8 @@ public:
     //
     // This function can be called from any thread.
     virtual void notify() = 0;
+    virtual void schedule_writes() = 0;
+    virtual void schedule_completions() = 0;
     // Check if the caller is currently running on the scheduler's thread.
     //
     // This function can be called from any thread.
@@ -73,10 +75,14 @@ public:
     //
     // This function is not thread-safe.
     virtual bool can_deliver_notifications() const noexcept = 0;
+    virtual bool can_schedule_writes() const noexcept = 0;
+    virtual bool can_schedule_completions() const noexcept = 0;
     // Set the callback function which will be called by notify().
     //
     // This function is not thread-safe.
     virtual void set_notify_callback(std::function<void()>) = 0;
+    virtual void set_schedule_writes_callback(std::function<void()>) = 0;
+    virtual void set_schedule_completions_callback(std::function<void()>) = 0;
 
     // virtual int enqueue_write(std::function<void()>& block) = 0;
 

--- a/src/realm/object-store/util/scheduler.hpp
+++ b/src/realm/object-store/util/scheduler.hpp
@@ -78,6 +78,8 @@ public:
     // This function is not thread-safe.
     virtual void set_notify_callback(std::function<void()>) = 0;
 
+    // virtual int enqueue_write(std::function<void()>& block) = 0;
+
     [[deprecated("Use Scheduler::make_frozen() instead")]] static std::shared_ptr<Scheduler>
     get_frozen(VersionID version);
 

--- a/src/realm/object-store/util/uv/scheduler.hpp
+++ b/src/realm/object-store/util/uv/scheduler.hpp
@@ -98,24 +98,6 @@ public:
             // REALM_ASSERT((reinterpret_cast<Data*>(m_notification_handle->data)->callback) == fn);
         }
         m_notification_handle = add_callback(std::move(fn));
-        /*
-        m_handle = new uv_async_t;
-        m_handle->data = new Data{std::move(fn), {false}};
-
-        // This assumes that only one thread matters: the main thread (default loop).
-        uv_async_init(uv_default_loop(), m_handle, [](uv_async_t* handle) {
-            auto& data = *static_cast<Data*>(handle->data);
-            if (data.close_requested) {
-                uv_close(reinterpret_cast<uv_handle_t*>(handle), [](uv_handle_t* handle) {
-                    delete reinterpret_cast<Data*>(handle->data);
-                    delete reinterpret_cast<uv_async_t*>(handle);
-                });
-            }
-            else {
-                data.callback();
-            }
-        });
-        */
     }
 
     void notify() override

--- a/src/realm/object-store/util/uv/scheduler.hpp
+++ b/src/realm/object-store/util/uv/scheduler.hpp
@@ -20,14 +20,31 @@
 #include <thread>
 #include <uv.h>
 #include <realm/object-store/util/scheduler.hpp>
+#include <realm/util/assert.hpp>
 
 namespace realm::util {
 
 class UvMainLoopScheduler : public util::Scheduler {
 public:
     UvMainLoopScheduler() = default;
+    void remove_handle(uv_async_t*& handle)
+    {
+        if (handle && handle->data) {
+            static_cast<Data*>(handle->data)->close_requested = true;
+            uv_async_send(handle);
+            // Don't delete anything here as we need to delete it from within the event loop instead
+        }
+        else {
+            delete handle;
+        }
+        handle = nullptr;
+    }
     ~UvMainLoopScheduler()
     {
+        remove_handle(m_notification_handle);
+        remove_handle(m_write_handle);
+        remove_handle(m_completion_handle);
+        /*
         if (m_handle && m_handle->data) {
             static_cast<Data*>(m_handle->data)->close_requested = true;
             uv_async_send(m_handle);
@@ -36,6 +53,7 @@ public:
         else {
             delete m_handle;
         }
+        */
     }
 
     bool is_on_thread() const noexcept override
@@ -52,8 +70,35 @@ public:
         return true;
     }
 
+    uv_async_t* add_callback(std::function<void()> fn)
+    {
+        auto the_handle = new uv_async_t;
+        the_handle->data = new Data{std::move(fn), {false}};
+
+        // This assumes that only one thread matters: the main thread (default loop).
+        uv_async_init(uv_default_loop(), the_handle, [](uv_async_t* handle) {
+            auto& data = *static_cast<Data*>(handle->data);
+            if (data.close_requested) {
+                uv_close(reinterpret_cast<uv_handle_t*>(handle), [](uv_handle_t* handle) {
+                    delete reinterpret_cast<Data*>(handle->data);
+                    delete reinterpret_cast<uv_async_t*>(handle);
+                });
+            }
+            else {
+                data.callback();
+            }
+        });
+        return the_handle;
+    }
     void set_notify_callback(std::function<void()> fn) override
     {
+        if (m_notification_handle && m_notification_handle->data) {
+            return; // danger!
+            // We would like to, but cant do this check:
+            // REALM_ASSERT((reinterpret_cast<Data*>(m_notification_handle->data)->callback) == fn);
+        }
+        m_notification_handle = add_callback(std::move(fn));
+        /*
         m_handle = new uv_async_t;
         m_handle->data = new Data{std::move(fn), {false}};
 
@@ -70,19 +115,56 @@ public:
                 data.callback();
             }
         });
+        */
     }
 
     void notify() override
     {
-        uv_async_send(m_handle);
+        uv_async_send(m_notification_handle);
     }
+    void schedule_writes() override
+    {
+        uv_async_send(m_write_handle);
+    };
+    void schedule_completions() override
+    {
+        uv_async_send(m_completion_handle);
+    };
+    bool can_schedule_writes() const noexcept override
+    {
+        return true;
+    };
+    bool can_schedule_completions() const noexcept override
+    {
+        return false;
+    };
+    void set_schedule_writes_callback(std::function<void()> fn) override
+    {
+        if (m_write_handle && m_write_handle->data) {
+            return; // danger!
+            // We would like to, but cant do this check:
+            // REALM_ASSERT((reinterpret_cast<Data*>(m_notification_handle->data)->callback) == fn);
+        }
+        m_write_handle = add_callback(std::move(fn));
+    };
+    void set_schedule_completions_callback(std::function<void()> fn) override
+    {
+        if (m_completion_handle && m_completion_handle->data) {
+            return; // danger!
+            // We would like to, but cant do this check:
+            // REALM_ASSERT((reinterpret_cast<Data*>(m_notification_handle->data)->callback) == fn);
+        }
+        m_completion_handle = add_callback(std::move(fn));
+    };
 
 private:
     struct Data {
         std::function<void()> callback;
         std::atomic<bool> close_requested;
     };
-    uv_async_t* m_handle = nullptr;
+    uv_async_t* m_notification_handle = nullptr;
+    uv_async_t* m_write_handle = nullptr;
+    uv_async_t* m_completion_handle = nullptr;
     std::thread::id m_id = std::this_thread::get_id();
 };
 

--- a/src/realm/util/file.cpp
+++ b/src/realm/util/file.cpp
@@ -115,11 +115,11 @@ bool for_each_helper(const std::string& path, const std::string& dir, File::ForE
 {
     DirScanner ds{path}; // Throws
     std::string name;
-    while (ds.next(name)) { // Throws
+    while (ds.next(name)) {                              // Throws
         std::string subpath = File::resolve(name, path); // Throws
         bool go_on;
-        if (File::is_dir(subpath)) { // Throws
-            std::string subdir = File::resolve(name, dir); // Throws
+        if (File::is_dir(subpath)) {                           // Throws
+            std::string subdir = File::resolve(name, dir);     // Throws
             go_on = for_each_helper(subpath, subdir, handler); // Throws
         }
         else {
@@ -276,10 +276,10 @@ bool try_remove_dir_recursive(const std::string& path)
         bool allow_missing = true;
         DirScanner ds{path, allow_missing}; // Throws
         std::string name;
-        while (ds.next(name)) { // Throws
+        while (ds.next(name)) {                              // Throws
             std::string subpath = File::resolve(name, path); // Throws
-            if (File::is_dir(subpath)) { // Throws
-                try_remove_dir_recursive(subpath); // Throws
+            if (File::is_dir(subpath)) {                     // Throws
+                try_remove_dir_recursive(subpath);           // Throws
             }
             else {
                 File::remove(subpath); // Throws
@@ -382,8 +382,7 @@ void File::open_internal(const std::string& path, AccessMode a, CreateMode c, in
     }
     DWORD flags_and_attributes = 0;
     std::wstring ws = string_to_wstring(path);
-    HANDLE handle =
-        CreateFile2(ws.c_str(), desired_access, share_mode, creation_disposition, nullptr);
+    HANDLE handle = CreateFile2(ws.c_str(), desired_access, share_mode, creation_disposition, nullptr);
     if (handle != INVALID_HANDLE_VALUE) {
         m_fd = handle;
         m_have_lock = false;
@@ -613,7 +612,7 @@ error:
         throw OutOfDiskSpace(msg);
     }
     throw std::system_error(err, std::system_category(), "write() failed");
-// LCOV_EXCL_STOP
+    // LCOV_EXCL_STOP
 
 #endif
 }
@@ -920,13 +919,13 @@ bool File::prealloc_if_supported(SizeType offset, size_t size)
     }
     throw std::system_error(status, std::system_category(), "posix_fallocate() failed");
 
-// FIXME: OS X does not have any version of fallocate, but see
-// http://stackoverflow.com/questions/11497567/fallocate-command-equivalent-in-os-x
+    // FIXME: OS X does not have any version of fallocate, but see
+    // http://stackoverflow.com/questions/11497567/fallocate-command-equivalent-in-os-x
 
-// FIXME: On Windows one could use a call to CreateFileMapping()
-// since it will grow the file if necessary, but never shrink it,
-// just like posix_fallocate(). The advantage would be that it
-// then becomes an atomic operation (probably).
+    // FIXME: On Windows one could use a call to CreateFileMapping()
+    // since it will grow the file if necessary, but never shrink it,
+    // just like posix_fallocate(). The advantage would be that it
+    // then becomes an atomic operation (probably).
 
 #else
 
@@ -1667,6 +1666,16 @@ void File::MapBase::sync()
     File::sync_map(m_fd, m_addr, m_size);
 }
 
+void File::MapBase::flush()
+{
+    REALM_ASSERT(m_addr);
+#if REALM_ENABLE_ENCRYPTION
+    if (m_encrypted_mapping) {
+        m_encrypted_mapping->flush();
+    }
+#endif
+}
+
 std::time_t File::last_write_time(const std::string& path)
 {
 #ifdef _WIN32
@@ -1826,9 +1835,7 @@ DirScanner::DirScanner(const std::string&, bool)
     throw util::runtime_error("Not yet supported");
 }
 
-DirScanner::~DirScanner() noexcept
-{
-}
+DirScanner::~DirScanner() noexcept {}
 
 bool DirScanner::next(std::string&)
 {

--- a/src/realm/util/file.hpp
+++ b/src/realm/util/file.hpp
@@ -651,6 +651,12 @@ private:
         void map(const File&, AccessMode, size_t size, int map_flags, size_t offset = 0);
         void remap(const File&, AccessMode, size_t size, int map_flags);
         void unmap() noexcept;
+        // fully update any process shared representation (e.g. buffer cache).
+        // other processes will be able to see changes, but a full platform crash
+        // may loose data
+        void flush();
+        // fully synchronize any underlying storage. After completion, a full platform
+        // crash will *not* have lost data.
         void sync();
 #if REALM_ENABLE_ENCRYPTION
         mutable util::EncryptedFileMapping* m_encrypted_mapping = nullptr;
@@ -793,6 +799,7 @@ public:
     /// attached to a memory mapped file, has undefined behavior.
     void sync();
 
+    void flush();
     /// Check whether this Map instance is currently attached to a
     /// memory mapped file.
     bool is_attached() const noexcept;
@@ -1184,7 +1191,7 @@ inline void File::Map<T>::unmap() noexcept
 template <class T>
 inline T* File::Map<T>::remap(const File& f, AccessMode a, size_t size, int map_flags)
 {
-    //MapBase::remap(f, a, size, map_flags);
+    // MapBase::remap(f, a, size, map_flags);
     // missing sync() here?
     unmap();
     map(f, a, size, map_flags);
@@ -1196,6 +1203,12 @@ template <class T>
 inline void File::Map<T>::sync()
 {
     MapBase::sync();
+}
+
+template <class T>
+inline void File::Map<T>::flush()
+{
+    MapBase::flush();
 }
 
 template <class T>

--- a/test/object-store/realm.cpp
+++ b/test/object-store/realm.cpp
@@ -784,19 +784,22 @@ TEST_CASE("SharedRealm: async_writes") {
             ++commit_nr;
         });
     });
-    realm->async_transaction([&]() {
-        REQUIRE(write_nr == 1);
-        ++write_nr;
-        auto table = realm->read_group().get_table("class_object");
-        auto col = table->get_column_key("value");
-        auto o = table->get_object(0);
-        o.set(col, o.get<int64_t>(col) + 37);
-        realm->async_commit([&]() {
-            REQUIRE(commit_nr == 1);
-            ++commit_nr;
-            done = true;
+    for (int expected = 1; expected < 100000; ++expected) {
+        realm->async_transaction([&, expected]() {
+            REQUIRE(write_nr == expected);
+            ++write_nr;
+            auto table = realm->read_group().get_table("class_object");
+            auto col = table->get_column_key("value");
+            auto o = table->get_object(0);
+            o.set(col, o.get<int64_t>(col) + 37);
+            realm->async_commit(
+                [&]() {
+                    ++commit_nr;
+                    done = commit_nr == 100000;
+                },
+                true);
         });
-    });
+    }
     util::EventLoop::main().run_until([&] {
         return done;
     });

--- a/test/object-store/realm.cpp
+++ b/test/object-store/realm.cpp
@@ -436,6 +436,19 @@ TEST_CASE("SharedRealm: get_shared_realm()") {
         void set_notify_callback(std::function<void()>) override {}
         void notify() override {}
 
+        void schedule_writes() override{};
+        void schedule_completions() override{};
+        bool can_schedule_writes() const noexcept override
+        {
+            return false;
+        };
+        bool can_schedule_completions() const noexcept override
+        {
+            return false;
+        };
+        void set_schedule_writes_callback(std::function<void()>) override{};
+        void set_schedule_completions_callback(std::function<void()>) override{};
+
     protected:
         size_t m_id;
     };


### PR DESCRIPTION
Prototype for async write/commit

This PR is a prototype:

* Integrated with libuv only
* The write mutex can now be acquired asynchronously by the main thread (no blocking).
* Async writes on the main thread are done in program order, each write transaction sees the effect of previous ones.
* The sync-to-disk part of each commit is done on a helper thread, so the main thread is free to run other tasks.
* Grouped Commits: Multiple back-to-back commits can be grouped and written with a single shared sync-to-disk.
* Each individual commit can be marked as allowing grouping or not (default is not).
* In case of a crash all commits grouped together are either fully done or not at all.
* Grouped commits can provide a large performance boost: more than 10x write performance gain has been observed for small commits.

This is complex stuff and careful hardening and testing is required.

## ☑️ ToDos
* [ ] 📝 Changelog update
* [ ] integrate with the other runloops we support
* [ ] integration with our old synchronous commit (currently sync operations will not mix with async operations)
* [ ] check/fix possible assumptions in Sync related to when a commit has reached stable storage
* [ ] check/limit usage we don't want to support (like doing a synchronous commit inside an async write)
* [ ] fully implement cancel/rollback of transactions
* [ ] implement cancellation of callbacks
* [ ] 🚦 Tests
