### PR TITLE
Fix crashes when sync trace logging is enabled

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@
 
 ### Fixed
 * <How to hit and notice issue? what was the impact?> ([#????](https://github.com/realm/realm-core/issues/????), since v?.?.?)
-* None.
+* Fix crashes when sync logging is set to trace or higher (since 11.0.2).
  
 ### Breaking changes
 * None.

--- a/evergreen/config.yml
+++ b/evergreen/config.yml
@@ -105,6 +105,10 @@ functions:
               set_cmake_var realm_vars CMAKE_BUILD_TYPE STRING "${cmake_build_type}"
           fi
 
+          if [ -n "${enable_logging|}" ]; then
+              set_cmake_var realm_vars REALM_TEST_SYNC_LOGGING BOOL On
+          fi
+
           echo "Running cmake with these vars:"
           cat cmake_vars/*.txt | tee cmake_vars.txt
           echo
@@ -370,6 +374,8 @@ tasks:
   tags: [ "disabled_on_windows", "test_suite", "for_pull_requests" ]
   commands:
   - func: "compile"
+    vars:
+      enable_logging: true
   # If we need to start a local copy of baas, do it in the background here in a separate script.
   # Evergreen should take care of the lifetime of the processes we start here automatically.
   - command: shell.exec

--- a/src/realm/sync/server.cpp
+++ b/src/realm/sync/server.cpp
@@ -3927,7 +3927,7 @@ private:
             if (!disable_download_compaction) {
                 std::size_t saved = accum_original_size - accum_compacted_size;
                 double saved_2 = (accum_original_size == 0 ? 0 : std::round(saved * 100.0 / accum_original_size));
-                logger.detail("Download compaction: Saved %1 bytes (%2%)", saved, saved_2); // Throws
+                logger.detail("Download compaction: Saved %1 bytes (%2%%)", saved, saved_2); // Throws
             }
 
             m_download_progress = download_progress;

--- a/src/realm/util/to_string.hpp
+++ b/src/realm/util/to_string.hpp
@@ -107,7 +107,7 @@ public:
     }
     Printable(StringData value);
 
-    template <typename T>
+    template <typename T, typename = std::enable_if_t<!std::is_constructible_v<Printable, T>>>
     Printable(T const& value)
         : m_type(Type::Callback)
         , m_callback({static_cast<const void*>(&value), [](std::ostream& os, const void* ptr) {

--- a/test/object-store/CMakeLists.txt
+++ b/test/object-store/CMakeLists.txt
@@ -91,6 +91,12 @@ if(REALM_ENABLE_SYNC)
     endif()
 endif()
 
+if(REALM_TEST_SYNC_LOGGING)
+    target_compile_definitions(ObjectStoreTests PRIVATE
+        TEST_ENABLE_SYNC_LOGGING=1
+    )
+endif()
+
 target_include_directories(ObjectStoreTests PRIVATE ${CATCH_INCLUDE_DIR} ${JSON_INCLUDE_DIR} ${CMAKE_CURRENT_SOURCE_DIR})
 
 if(VSCODE_TEST_RUNNER)

--- a/test/object-store/util/test_file.hpp
+++ b/test/object-store/util/test_file.hpp
@@ -93,7 +93,9 @@ void on_change_but_no_notify(realm::Realm& realm);
 
 #if REALM_ENABLE_SYNC
 
+#ifndef TEST_ENABLE_SYNC_LOGGING
 #define TEST_ENABLE_SYNC_LOGGING 0 // change to 1 to enable logging
+#endif
 
 struct TestLogger : realm::util::Logger::LevelThreshold, realm::util::Logger {
     void do_log(realm::util::Logger::Level, std::string const&) override {}

--- a/test/test_all.cpp
+++ b/test/test_all.cpp
@@ -126,7 +126,7 @@ const char* file_order[] = {
 
     "test_lang_bind_helper.cpp",
 
-    "large_tests*.cpp"
+    "large_tests*.cpp",
     "test_crypto.cpp",
     "test_transform.cpp",
     "test_array.cpp",


### PR DESCRIPTION
Logging a DataType formed an infinite loop (until stack overflow) due to the wrong conversion being picked. This was not caught on CI because we didn't actually run any tests with sync logging enabled, so enable it for the object store tests.

Ideally the *sync* tests would test the logging, but I couldn't find a convenient way to enable logging for all of them.