### PR TITLE
Fix crashes when sync trace logging is enabled

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 * <How to hit and notice issue? what was the impact?> ([#????](https://github.com/realm/realm-core/issues/????), since v?.?.?)
 * Fixed the string based query parser not supporting integer constants above 32 bits on a 32 bit platform. ([realm-js #3773](https://github.com/realm/realm-js/issues/3773), since v10.4.0 with the introduction of the new query parser)
 * When replacing an embedded object, we must emit a sync instruction that sets the link to the embedded object to null so that it is properly cleared. ([#4740](https://github.com/realm/realm-core/issues/4740)
+* Fix crashes when sync logging is set to trace or higher (since 11.0.2).
  
 ### Breaking changes
 * None.

--- a/evergreen/config.yml
+++ b/evergreen/config.yml
@@ -109,6 +109,10 @@ functions:
               set_cmake_var realm_vars CMAKE_TOOLCHAIN_FILE PATH "${cmake_toolchain_file}"
           fi
 
+          if [ -n "${enable_logging|}" ]; then
+              set_cmake_var realm_vars REALM_TEST_SYNC_LOGGING BOOL On
+          fi
+
           echo "Running cmake with these vars:"
           cat cmake_vars/*.txt | tee cmake_vars.txt
           echo
@@ -378,6 +382,8 @@ tasks:
   tags: [ "disabled_on_windows", "test_suite", "for_pull_requests" ]
   commands:
   - func: "compile"
+    vars:
+      enable_logging: true
   # If we need to start a local copy of baas, do it in the background here in a separate script.
   # Evergreen should take care of the lifetime of the processes we start here automatically.
   - command: shell.exec

--- a/how-to-build.md
+++ b/how-to-build.md
@@ -162,7 +162,7 @@ has a mapped volume to the `tests/mongodb` directory.
 To run the [app] tests against the local image, you need to configure a build with some cmake options to tell the tests where to point to.
 ```
 mkdir build.sync.ninja
-cmake -B build.sync.ninja -G Ninja -DREALM_ENABLE_AUTH_TESTS=1 -DREALM_MONGODB_ENDPOINT=http://localhost:9090 -DREALM_STITCH_CONFIG=$(pwd)/test/object-store/mongodb/config.json
+cmake -B build.sync.ninja -G Ninja -DREALM_ENABLE_AUTH_TESTS=1 -DREALM_MONGODB_ENDPOINT=http://localhost:9090
 cmake --build build.sync.ninja --target tests
 ./build.sync.ninja/test/object-store/realm-object-store-tests -d=1
 ```

--- a/src/realm/sync/server.cpp
+++ b/src/realm/sync/server.cpp
@@ -3927,7 +3927,7 @@ private:
             if (!disable_download_compaction) {
                 std::size_t saved = accum_original_size - accum_compacted_size;
                 double saved_2 = (accum_original_size == 0 ? 0 : std::round(saved * 100.0 / accum_original_size));
-                logger.detail("Download compaction: Saved %1 bytes (%2%)", saved, saved_2); // Throws
+                logger.detail("Download compaction: Saved %1 bytes (%2%%)", saved, saved_2); // Throws
             }
 
             m_download_progress = download_progress;

--- a/src/realm/util/to_string.hpp
+++ b/src/realm/util/to_string.hpp
@@ -107,7 +107,7 @@ public:
     }
     Printable(StringData value);
 
-    template <typename T>
+    template <typename T, typename = std::enable_if_t<!std::is_constructible_v<Printable, T>>>
     Printable(T const& value)
         : m_type(Type::Callback)
         , m_callback({static_cast<const void*>(&value), [](std::ostream& os, const void* ptr) {

--- a/test/object-store/CMakeLists.txt
+++ b/test/object-store/CMakeLists.txt
@@ -91,6 +91,12 @@ if(REALM_ENABLE_SYNC)
     endif()
 endif()
 
+if(REALM_TEST_SYNC_LOGGING)
+    target_compile_definitions(ObjectStoreTests PRIVATE
+        TEST_ENABLE_SYNC_LOGGING=1
+    )
+endif()
+
 target_include_directories(ObjectStoreTests PRIVATE ${CATCH_INCLUDE_DIR} ${JSON_INCLUDE_DIR} ${CMAKE_CURRENT_SOURCE_DIR})
 
 if(VSCODE_TEST_RUNNER)

--- a/test/object-store/mongodb/auth_providers/anon-user.json
+++ b/test/object-store/mongodb/auth_providers/anon-user.json
@@ -1,5 +1,5 @@
 {
-    "id": "5f92b2ebe246d032a4404963",
+    "id": "60c337a1cd492490c66d2852",
     "name": "anon-user",
     "type": "anon-user",
     "disabled": false

--- a/test/object-store/mongodb/auth_providers/api-key.json
+++ b/test/object-store/mongodb/auth_providers/api-key.json
@@ -1,5 +1,5 @@
 {
-    "id": "5f92b2ebe246d032a4404964",
+    "id": "60c337a1cd492490c66d2853",
     "name": "api-key",
     "type": "api-key",
     "disabled": false

--- a/test/object-store/mongodb/auth_providers/custom-function.json
+++ b/test/object-store/mongodb/auth_providers/custom-function.json
@@ -1,5 +1,5 @@
 {
-    "id": "5f92b2ebe246d032a4404965",
+    "id": "60c337a1cd492490c66d2854",
     "name": "custom-function",
     "type": "custom-function",
     "config": {

--- a/test/object-store/mongodb/auth_providers/local-userpass.json
+++ b/test/object-store/mongodb/auth_providers/local-userpass.json
@@ -1,5 +1,5 @@
 {
-    "id": "5f92b2ebe246d032a4404966",
+    "id": "60c337a1cd492490c66d2855",
     "name": "local-userpass",
     "type": "local-userpass",
     "config": {

--- a/test/object-store/mongodb/config.json
+++ b/test/object-store/mongodb/config.json
@@ -1,5 +1,5 @@
 {
-    "app_id": "auth-integration-tests-jlloa",
+    "app_id": "auth-integration-tests-ytaxg",
     "config_version": 20200603,
     "name": "auth-integration-tests",
     "location": "US-VA",

--- a/test/object-store/mongodb/functions/authFunc/config.json
+++ b/test/object-store/mongodb/functions/authFunc/config.json
@@ -1,6 +1,6 @@
 {
     "can_evaluate": {},
-    "id": "5f92b2ebe246d032a440495f",
+    "id": "60c337a1cd492490c66d284e",
     "name": "authFunc",
     "private": false
 }

--- a/test/object-store/mongodb/functions/confirmFunc/config.json
+++ b/test/object-store/mongodb/functions/confirmFunc/config.json
@@ -1,6 +1,6 @@
 {
     "can_evaluate": {},
-    "id": "5f92b2ebe246d032a4404960",
+    "id": "60c337a1cd492490c66d284f",
     "name": "confirmFunc",
     "private": false
 }

--- a/test/object-store/mongodb/functions/resetFunc/config.json
+++ b/test/object-store/mongodb/functions/resetFunc/config.json
@@ -1,6 +1,6 @@
 {
     "can_evaluate": {},
-    "id": "5f92b2ebe246d032a4404961",
+    "id": "60c337a1cd492490c66d2850",
     "name": "resetFunc",
     "private": false
 }

--- a/test/object-store/mongodb/functions/sumFunc/config.json
+++ b/test/object-store/mongodb/functions/sumFunc/config.json
@@ -1,6 +1,6 @@
 {
     "can_evaluate": {},
-    "id": "5f92b2ebe246d032a4404962",
+    "id": "60c337a1cd492490c66d2851",
     "name": "sumFunc",
     "private": false
 }

--- a/test/object-store/mongodb/graphql/config.json
+++ b/test/object-store/mongodb/graphql/config.json
@@ -1,0 +1,3 @@
+{
+    "use_natural_pluralization": true
+}

--- a/test/object-store/mongodb/services/BackingDB/config.json
+++ b/test/object-store/mongodb/services/BackingDB/config.json
@@ -1,5 +1,5 @@
 {
-    "id": "5f92b2ebe246d032a440495a",
+    "id": "60c337a1cd492490c66d2849",
     "name": "BackingDB",
     "type": "mongodb",
     "config": {

--- a/test/object-store/mongodb/services/BackingDB/rules/test_data.Dog.json
+++ b/test/object-store/mongodb/services/BackingDB/rules/test_data.Dog.json
@@ -1,7 +1,7 @@
 {
     "collection": "Dog",
     "database": "test_data",
-    "id": "5f92b2ebe246d032a440495b",
+    "id": "60c337a1cd492490c66d284a",
     "roles": [
         {
             "name": "default",

--- a/test/object-store/mongodb/services/BackingDB/rules/test_data.Person.json
+++ b/test/object-store/mongodb/services/BackingDB/rules/test_data.Person.json
@@ -1,7 +1,7 @@
 {
     "collection": "Person",
     "database": "test_data",
-    "id": "5f92b2ebe246d032a440495c",
+    "id": "60c337a1cd492490c66d284b",
     "relationships": {
         "dogs": {
             "ref": "#/relationship/BackingDB/test_data/Dog",

--- a/test/object-store/mongodb/services/BackingDB/rules/test_data.testRemoteMongoClient.json
+++ b/test/object-store/mongodb/services/BackingDB/rules/test_data.testRemoteMongoClient.json
@@ -1,7 +1,7 @@
 {
     "collection": "testRemoteMongoClient",
     "database": "test_data",
-    "id": "5f92b2ebe246d032a440495d",
+    "id": "60c337a1cd492490c66d284c",
     "roles": [
         {
             "name": "default",

--- a/test/object-store/mongodb/services/gcm/config.json
+++ b/test/object-store/mongodb/services/gcm/config.json
@@ -1,5 +1,5 @@
 {
-    "id": "5f92b2ebe246d032a440495e",
+    "id": "60c337a1cd492490c66d284d",
     "name": "gcm",
     "type": "gcm",
     "config": {

--- a/test/object-store/sync/app.cpp
+++ b/test/object-store/sync/app.cpp
@@ -2163,7 +2163,10 @@ TEST_CASE("app: sync integration", "[sync][app]") {
 
     SECTION("too large sync message error handling") {
         TestSyncManager::Config test_config(app_config);
+
+        // Too much log output seems to create problems on Evergreen CI
         test_config.verbose_sync_client_logging = false;
+
         TestSyncManager sync_manager(test_config, {});
         auto app = get_app_and_login(sync_manager.app());
         auto config = setup_and_get_config(app);

--- a/test/object-store/sync/app.cpp
+++ b/test/object-store/sync/app.cpp
@@ -2162,7 +2162,9 @@ TEST_CASE("app: sync integration", "[sync][app]") {
     }
 
     SECTION("too large sync message error handling") {
-        TestSyncManager sync_manager(TestSyncManager::Config(app_config), {});
+        TestSyncManager::Config test_config(app_config);
+        test_config.verbose_sync_client_logging = false;
+        TestSyncManager sync_manager(test_config, {});
         auto app = get_app_and_login(sync_manager.app());
         auto config = setup_and_get_config(app);
 

--- a/test/object-store/util/test_file.cpp
+++ b/test/object-store/util/test_file.cpp
@@ -248,9 +248,6 @@ TestSyncManager::TestSyncManager(const Config& config, const SyncServer::Config&
     util::try_make_dir(m_base_file_path);
     sc_config.base_file_path = m_base_file_path;
     sc_config.metadata_mode = config.metadata_mode;
-#if TEST_ENABLE_SYNC_LOGGING
-    config.verbose_sync_client_logging = true;
-#endif
     sc_config.log_level = config.verbose_sync_client_logging ? util::Logger::Level::all : util::Logger::Level::off;
 
     m_app = app::App::get_shared_app(app_config, sc_config);

--- a/test/object-store/util/test_file.hpp
+++ b/test/object-store/util/test_file.hpp
@@ -93,7 +93,9 @@ void on_change_but_no_notify(realm::Realm& realm);
 
 #if REALM_ENABLE_SYNC
 
+#ifndef TEST_ENABLE_SYNC_LOGGING
 #define TEST_ENABLE_SYNC_LOGGING 0 // change to 1 to enable logging
+#endif
 
 struct TestLogger : realm::util::Logger::LevelThreshold, realm::util::Logger {
     void do_log(realm::util::Logger::Level, std::string const&) override {}
@@ -171,6 +173,11 @@ struct SyncTestFile : TestFile {
 
 struct TestSyncManager {
     struct Config {
+#if TEST_ENABLE_SYNC_LOGGING
+        static constexpr bool default_logging = true;
+#else
+        static constexpr bool default_logging = false;
+#endif
         Config();
         Config(std::string, realm::SyncManager::MetadataMode = realm::SyncManager::MetadataMode::NoEncryption);
         Config(std::string, std::string,
@@ -181,7 +188,7 @@ struct TestSyncManager {
         std::string base_url;
         realm::SyncManager::MetadataMode metadata_mode;
         bool should_teardown_test_directory;
-        bool verbose_sync_client_logging = false;
+        bool verbose_sync_client_logging = default_logging;
     };
 
     TestSyncManager(const Config& = Config(), const SyncServer::Config& = {});

--- a/test/test_all.cpp
+++ b/test/test_all.cpp
@@ -127,7 +127,7 @@ const char* file_order[] = {
 
     "test_lang_bind_helper.cpp",
 
-    "large_tests*.cpp"
+    "large_tests*.cpp",
     "test_crypto.cpp",
     "test_transform.cpp",
     "test_array.cpp",


### PR DESCRIPTION
Logging a DataType formed an infinite loop (until stack overflow) due to the wrong conversion being picked. This was not caught on CI because we didn't actually run any tests with sync logging enabled, so enable it for the object store tests.

Ideally the sync tests would test the logging, but I couldn't find a convenient way to enable logging for all of them.

Copy of #4752 made by @tgoyne. Too late I realized that the original PR was based on `v11`. The error was released on that branch, but if we decide that we must make a release from `master` we should have the fix there as well.