### PR TITLE
fix notifications on list of primitive mixed

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 ### Fixed
 * <How to hit and notice issue? what was the impact?> ([#????](https://github.com/realm/realm-core/issues/????), since v?.?.?)
 * Fixed an assertion failure when listening for changes to a list of primitive Mixed which contains links. ([#4767](https://github.com/realm/realm-core/issues/4767), since the beginning of Mixed v11.0.0)
+* Fixed an assertion failure when listening for changes to a dictionary or set which contains an invalidated link. ([#4770](https://github.com/realm/realm-core/pull/4770), since the beginning of v11)
  
 ### Breaking changes
 * None.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@
 
 ### Fixed
 * <How to hit and notice issue? what was the impact?> ([#????](https://github.com/realm/realm-core/issues/????), since v?.?.?)
-* None.
+* Fixed an assertion failure when listening for changes to a list of primitive Mixed which contains links. ([#4767](https://github.com/realm/realm-core/issues/4767), since the beginning of Mixed v11.0.0)
  
 ### Breaking changes
 * None.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,8 @@
 * <How to hit and notice issue? what was the impact?> ([#????](https://github.com/realm/realm-core/issues/????), since v?.?.?)
 * Fixed an assertion failure when listening for changes to a list of primitive Mixed which contains links. ([#4767](https://github.com/realm/realm-core/issues/4767), since the beginning of Mixed v11.0.0)
 * Fixed an assertion failure when listening for changes to a dictionary or set which contains an invalidated link. ([#4770](https://github.com/realm/realm-core/pull/4770), since the beginning of v11)
- 
+* Fixed an endless recursive loop that could cause a stack overflow when computing changes on a set of objects which contained cycles. ([#4770](https://github.com/realm/realm-core/pull/4770), since the beginning of v11)
+
 ### Breaking changes
 * None.
 

--- a/src/realm/obj.cpp
+++ b/src/realm/obj.cpp
@@ -2150,12 +2150,26 @@ void Obj::assign_pk_and_backlinks(const Obj& other)
                 REALM_ASSERT(!linking_obj.get<ObjKey>(c) || linking_obj.get<ObjKey>(c) == other.get_key());
                 linking_obj.set(c, get_key());
             }
+            else if (c.is_list()) {
+                if (c.get_type() == col_type_Mixed) {
+                    auto l = linking_obj.get_list<Mixed>(c);
+                    auto n = l.find_first(ObjLink{m_table->get_key(), other.get_key()});
+                    REALM_ASSERT(n != realm::npos);
+                    l.set(n, ObjLink{m_table->get_key(), get_key()});
+                }
+                else if (c.get_type() == col_type_LinkList) {
+                    // Link list
+                    auto l = linking_obj.get_list<ObjKey>(c);
+                    auto n = l.find_first(other.get_key());
+                    REALM_ASSERT(n != realm::npos);
+                    l.set(n, get_key());
+                }
+                else {
+                    REALM_UNREACHABLE(); // missing type handling
+                }
+            }
             else {
-                // Link list
-                auto l = linking_obj.get_list<ObjKey>(c);
-                auto n = l.find_first(other.get_key());
-                REALM_ASSERT(n != realm::npos);
-                l.set(n, get_key());
+                REALM_UNREACHABLE(); // missing type handling
             }
         }
         return false;

--- a/src/realm/object-store/impl/deep_change_checker.hpp
+++ b/src/realm/object-store/impl/deep_change_checker.hpp
@@ -26,8 +26,10 @@
 
 namespace realm {
 class CollectionBase;
-class Table;
+class Mixed;
 class Realm;
+class Table;
+class TableRef;
 class Transaction;
 
 namespace _impl {
@@ -83,6 +85,8 @@ private:
     bool do_check_for_collection_modifications(std::unique_ptr<CollectionBase> coll, size_t depth);
     template <typename T>
     bool do_check_for_collection_of_mixed(T* coll, size_t depth);
+    template <typename T>
+    bool do_check_mixed_for_link(T* coll, TableRef& cached_linked_table, Mixed value, size_t depth);
 };
 
 } // namespace _impl

--- a/src/realm/object-store/impl/deep_change_checker.hpp
+++ b/src/realm/object-store/impl/deep_change_checker.hpp
@@ -81,6 +81,8 @@ private:
     bool check_row(Table const& table, ObjKeyType obj_key, size_t depth = 0);
     bool check_outgoing_links(TableKey table_key, Table const& table, ObjKey obj_key, size_t depth = 0);
     bool do_check_for_collection_modifications(std::unique_ptr<CollectionBase> coll, size_t depth);
+    template <typename T>
+    bool do_check_for_collection_of_mixed(T* coll, size_t depth);
 };
 
 } // namespace _impl

--- a/test/object-store/transaction_log_parsing.cpp
+++ b/test/object-store/transaction_log_parsing.cpp
@@ -1686,21 +1686,13 @@ struct DictionaryOfObjects {
                                "table"};
     void add_link(Obj from, ColKey col, ObjLink to)
     {
-        from.get_dictionary(col).insert(util::format("key_%1", key_counter++), to);
-        // When adding dynamic links through a mixed value, the relationship map needs to be dynamically updated.
-        // In practice, this is triggered by the addition of backlink columns to any table.
-        if (m_relation_updater) {
-            m_relation_updater();
-        }
+        from.get_dictionary(col).insert(util::format("key_%1", key_counter++), to.get_obj_key());
     }
     size_t size_of_collection(Obj obj, ColKey col)
     {
         return obj.get_dictionary(col).size();
     }
-    void set_relation_updater(std::function<void()> updater)
-    {
-        m_relation_updater = updater;
-    }
+    void set_relation_updater(std::function<void()>) {}
     size_t count_unresolved_links(Obj obj, ColKey col)
     {
         Dictionary dict = obj.get_dictionary(col);
@@ -1796,7 +1788,6 @@ TEMPLATE_TEST_CASE("DeepChangeChecker", "[notifications]", ListOfObjects, ListOf
         _impl::DeepChangeChecker::find_related_tables(tables, *table);
     };
     relation_updater();
-    _impl::DeepChangeChecker::find_related_tables(tables, *table);
     test_type.set_relation_updater(relation_updater);
 
     auto cols = table->get_column_keys();

--- a/test/object-store/transaction_log_parsing.cpp
+++ b/test/object-store/transaction_log_parsing.cpp
@@ -1577,7 +1577,185 @@ TEST_CASE("Transaction log parsing: changeset calcuation") {
     }
 }
 
-TEST_CASE("DeepChangeChecker") {
+struct ListOfObjects {
+    const Property property = {"array", PropertyType::Array | PropertyType::Object, "table"};
+    void add_link(Obj from, ColKey col, ObjLink to)
+    {
+        from.get_linklist(col).add(to.get_obj_key());
+    }
+    size_t size_of_collection(Obj obj, ColKey col)
+    {
+        return obj.get_linklist(col).size();
+    }
+    void set_relation_updater(std::function<void()>) {}
+    size_t count_unresolved_links(Obj, ColKey)
+    {
+        return 0;
+    }
+    constexpr static bool allows_storing_nulls = false;
+};
+
+struct ListOfMixedLinks {
+    const Property property = {"array", PropertyType::Array | PropertyType::Mixed | PropertyType::Nullable};
+    void add_link(Obj from, ColKey col, ObjLink to)
+    {
+        from.get_list<Mixed>(col).add(to);
+        // When adding dynamic links through a mixed value, the relationship map needs to be dynamically updated.
+        // In practice, this is triggered by the addition of backlink columns to any table.
+        if (m_relation_updater) {
+            m_relation_updater();
+        }
+    }
+    size_t size_of_collection(Obj obj, ColKey col)
+    {
+        return obj.get_list<Mixed>(col).size();
+    }
+    void set_relation_updater(std::function<void()> updater)
+    {
+        m_relation_updater = updater;
+    }
+    size_t count_unresolved_links(Obj obj, ColKey col)
+    {
+        Lst<Mixed> list = obj.get_list<Mixed>(col);
+        size_t num_unresolved = 0;
+        for (auto value : list) {
+            if (value.is_unresolved_link()) {
+                ++num_unresolved;
+            }
+        }
+        return num_unresolved;
+    }
+    std::function<void()> m_relation_updater;
+    constexpr static bool allows_storing_nulls = true;
+};
+
+struct SetOfObjects {
+    const Property property = {"array", PropertyType::Set | PropertyType::Object, "table"};
+    void add_link(Obj from, ColKey col, ObjLink to)
+    {
+        from.get_linkset(col).insert(to.get_obj_key());
+    }
+    size_t size_of_collection(Obj obj, ColKey col)
+    {
+        return obj.get_linkset(col).size();
+    }
+    void set_relation_updater(std::function<void()>) {}
+    size_t count_unresolved_links(Obj, ColKey)
+    {
+        return 0;
+    }
+    constexpr static bool allows_storing_nulls = false;
+};
+
+struct SetOfMixedLinks {
+    const Property property = {"array", PropertyType::Set | PropertyType::Mixed | PropertyType::Nullable};
+    void add_link(Obj from, ColKey col, ObjLink to)
+    {
+        from.get_set<Mixed>(col).insert(to);
+        // When adding dynamic links through a mixed value, the relationship map needs to be dynamically updated.
+        // In practice, this is triggered by the addition of backlink columns to any table.
+        if (m_relation_updater) {
+            m_relation_updater();
+        }
+    }
+    size_t size_of_collection(Obj obj, ColKey col)
+    {
+        return obj.get_set<Mixed>(col).size();
+    }
+    void set_relation_updater(std::function<void()> updater)
+    {
+        m_relation_updater = updater;
+    }
+    size_t count_unresolved_links(Obj obj, ColKey col)
+    {
+        Set<Mixed> set = obj.get_set<Mixed>(col);
+        size_t num_unresolved = 0;
+        for (auto value : set) {
+            if (value.is_unresolved_link()) {
+                ++num_unresolved;
+            }
+        }
+        return num_unresolved;
+    }
+    std::function<void()> m_relation_updater;
+    constexpr static bool allows_storing_nulls = true;
+};
+
+struct DictionaryOfObjects {
+    const Property property = {"array", PropertyType::Dictionary | PropertyType::Object | PropertyType::Nullable,
+                               "table"};
+    void add_link(Obj from, ColKey col, ObjLink to)
+    {
+        from.get_dictionary(col).insert(util::format("key_%1", key_counter++), to);
+        // When adding dynamic links through a mixed value, the relationship map needs to be dynamically updated.
+        // In practice, this is triggered by the addition of backlink columns to any table.
+        if (m_relation_updater) {
+            m_relation_updater();
+        }
+    }
+    size_t size_of_collection(Obj obj, ColKey col)
+    {
+        return obj.get_dictionary(col).size();
+    }
+    void set_relation_updater(std::function<void()> updater)
+    {
+        m_relation_updater = updater;
+    }
+    size_t count_unresolved_links(Obj obj, ColKey col)
+    {
+        Dictionary dict = obj.get_dictionary(col);
+        size_t num_unresolved = 0;
+        for (auto value : dict) {
+            if (value.second.is_unresolved_link()) {
+                ++num_unresolved;
+            }
+        }
+        return num_unresolved;
+    }
+    size_t key_counter = 0;
+    std::function<void()> m_relation_updater;
+    constexpr static bool allows_storing_nulls = true;
+};
+
+struct DictionaryOfMixedLinks {
+    const Property property = {"array", PropertyType::Dictionary | PropertyType::Mixed | PropertyType::Nullable};
+    void add_link(Obj from, ColKey col, ObjLink to)
+    {
+        from.get_dictionary(col).insert(util::format("key_%1", key_counter++), to);
+        // When adding dynamic links through a mixed value, the relationship map needs to be dynamically updated.
+        // In practice, this is triggered by the addition of backlink columns to any table.
+        if (m_relation_updater) {
+            m_relation_updater();
+        }
+    }
+    size_t size_of_collection(Obj obj, ColKey col)
+    {
+        return obj.get_dictionary(col).size();
+    }
+    void set_relation_updater(std::function<void()> updater)
+    {
+        m_relation_updater = updater;
+    }
+    size_t count_unresolved_links(Obj obj, ColKey col)
+    {
+        Dictionary dict = obj.get_dictionary(col);
+        size_t num_unresolved = 0;
+        for (auto value : dict) {
+            if (value.second.is_unresolved_link()) {
+                ++num_unresolved;
+            }
+        }
+        return num_unresolved;
+    }
+    size_t key_counter = 0;
+    std::function<void()> m_relation_updater;
+    constexpr static bool allows_storing_nulls = true;
+};
+
+TEMPLATE_TEST_CASE("DeepChangeChecker", "[notifications]", ListOfObjects, ListOfMixedLinks, SetOfObjects,
+                   SetOfMixedLinks, DictionaryOfObjects, DictionaryOfMixedLinks)
+{
+    TestType test_type;
     InMemoryTestFile config;
     config.automatic_change_notifications = false;
     auto r = Realm::get_shared_realm(config);
@@ -1586,9 +1764,10 @@ TEST_CASE("DeepChangeChecker") {
          {{"int", PropertyType::Int},
           {"link1", PropertyType::Object | PropertyType::Nullable, "table"},
           {"link2", PropertyType::Object | PropertyType::Nullable, "table"},
-          {"array", PropertyType::Array | PropertyType::Object, "table"}}},
+          test_type.property}},
     });
     auto table = r->read_group().get_table("class_table");
+    TableKey dst_table_key = table->get_key();
 
     std::vector<Obj> objects;
     r->begin_transaction();
@@ -1613,7 +1792,12 @@ TEST_CASE("DeepChangeChecker") {
     };
 
     _impl::DeepChangeChecker::RelatedTables tables;
+    auto relation_updater = [&]() {
+        _impl::DeepChangeChecker::find_related_tables(tables, *table);
+    };
+    relation_updater();
     _impl::DeepChangeChecker::find_related_tables(tables, *table);
+    test_type.set_relation_updater(relation_updater);
 
     auto cols = table->get_column_keys();
     SECTION("direct changes are tracked") {
@@ -1684,12 +1868,12 @@ TEST_CASE("DeepChangeChecker") {
         });
     }
 
-    SECTION("changes over linklists are tracked") {
+    SECTION("changes over collections are tracked") {
         r->begin_transaction();
         for (int i = 0; i < 3; ++i) {
-            objects[i].get_linklist(cols[3]).add(objects[i].get_key());
-            objects[i].get_linklist(cols[3]).add(objects[i].get_key());
-            objects[i].get_linklist(cols[3]).add(objects[i + 1 + (i == 2)].get_key());
+            test_type.add_link(objects[i], cols[3], {dst_table_key, objects[i].get_key()});
+            test_type.add_link(objects[i], cols[3], {dst_table_key, objects[i].get_key()});
+            test_type.add_link(objects[i], cols[3], {dst_table_key, objects[i + 1 + (i == 2)].get_key()});
         }
         r->commit_transaction();
 
@@ -1705,16 +1889,25 @@ TEST_CASE("DeepChangeChecker") {
         r->begin_transaction();
         size_t obj_ndx_to_invalidate = 6;
         for (int i = 0; i < 3; ++i) {
-            objects[i].get_linklist(cols[3]).add(objects[i].get_key());
-            objects[i].get_linklist(cols[3]).add(objects[obj_ndx_to_invalidate].get_key());
-            objects[i].get_linklist(cols[3]).add(objects[i + 1 + (i == 2)].get_key());
+            test_type.add_link(objects[i], cols[3], {dst_table_key, objects[i].get_key()});
+            test_type.add_link(objects[i], cols[3], {dst_table_key, objects[obj_ndx_to_invalidate].get_key()});
+            test_type.add_link(objects[i], cols[3], {dst_table_key, objects[i + 1 + (i == 2)].get_key()});
         }
         // Object invalidation can only happen if another sync client has deleted the object
         // we simulate this by calling it directly here. The consequence is that links to this
         // object are changed to the invalidated key, but not removed. This tests that the abstraction
         // that core has built to hide invalidated links inside LnkLst is not leaking at this level.
-        objects[6].invalidate();
-        REQUIRE(objects[0].get_linklist(cols[3]).size() == 2); // LnkLst actually has 3 entries but hides one
+        objects[obj_ndx_to_invalidate].invalidate();
+        if (TestType::allows_storing_nulls) {
+            REQUIRE(test_type.size_of_collection(objects[0], cols[3]) == 3);
+            REQUIRE(test_type.count_unresolved_links(objects[0], cols[3]) == 1);
+            REQUIRE(test_type.count_unresolved_links(objects[1], cols[3]) == 1);
+            REQUIRE(test_type.count_unresolved_links(objects[2], cols[3]) == 1);
+        }
+        else {
+            REQUIRE(test_type.size_of_collection(objects[0], cols[3]) ==
+                    2); // LnkLst actually has 3 entries but hides one
+        }
         r->commit_transaction();
 
         auto info = track_changes([&] {
@@ -1767,9 +1960,9 @@ TEST_CASE("DeepChangeChecker") {
         REQUIRE_FALSE(_impl::DeepChangeChecker(info, *table, tables)(0));
     }
 
-    SECTION("cycles over linklists do not loop forever") {
+    SECTION("cycles over collections do not loop forever") {
         r->begin_transaction();
-        objects[0].get_linklist(cols[3]).add(objects[0].get_key());
+        test_type.add_link(objects[0], cols[3], {dst_table_key, objects[0].get_key()});
         r->commit_transaction();
 
         auto info = track_changes([&] {
@@ -1813,9 +2006,9 @@ TEST_CASE("DeepChangeChecker") {
 
     SECTION("changes made in the 3rd elements in the link list") {
         r->begin_transaction();
-        objects[0].get_linklist(cols[3]).add(objects[1].get_key());
-        objects[0].get_linklist(cols[3]).add(objects[2].get_key());
-        objects[0].get_linklist(cols[3]).add(objects[3].get_key());
+        test_type.add_link(objects[0], cols[3], {dst_table_key, objects[1].get_key()});
+        test_type.add_link(objects[0], cols[3], {dst_table_key, objects[2].get_key()});
+        test_type.add_link(objects[0], cols[3], {dst_table_key, objects[3].get_key()});
         objects[1].set(cols[1], objects[0].get_key());
         objects[2].set(cols[1], objects[0].get_key());
         objects[3].set(cols[1], objects[0].get_key());
@@ -1832,7 +2025,7 @@ TEST_CASE("DeepChangeChecker") {
 
     SECTION("changes made to lists mark the containing row as modified") {
         auto info = track_changes([&] {
-            objects[0].get_linklist(cols[3]).add(objects[1].get_key());
+            test_type.add_link(objects[0], cols[3], {dst_table_key, objects[1].get_key()});
         });
         _impl::DeepChangeChecker checker(info, *table, tables);
         REQUIRE(checker(0));


### PR DESCRIPTION
We forgot to handle list of Mixed when checking for deep changes in the notification logic.
It's the same code as Set<Mixed> so I extracted it to a templated method. It couldn't be generalized to work on a CollectionBase pointer because this base class doesn't have an iterator interface at that level, and unfortunately it is not trivial to add.

Reported by https://github.com/realm/realm-core/issues/4767

## ☑️ ToDos
* [x] 📝 Changelog update
* [x] 🚦 Tests (or not relevant)
