### PR TITLE
Add a non-throwing version of Dictionary::erase()

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 # NEXT RELEASE
 
 ### Enhancements
-* None.
+* Add Dictionary::try_erase(), which returns false if the key is not found rather than throwing.
 
 ### Fixed
 * <How to hit and notice issue? what was the impact?> ([#????](https://github.com/realm/realm-core/issues/????), since v?.?.?)

--- a/src/realm/dictionary.hpp
+++ b/src/realm/dictionary.hpp
@@ -106,6 +106,7 @@ public:
 
     void erase(Mixed key);
     void erase(Iterator it);
+    bool try_erase(Mixed key);
 
     void nullify(Mixed);
     void remove_backlinks(CascadeState& state) const;
@@ -178,7 +179,7 @@ private:
     template <typename T, typename Op>
     friend class CollectionColumnAggregate;
     friend class DictionaryLinkValues;
-    mutable DictionaryClusterTree* m_clusters = nullptr;
+    mutable std::unique_ptr<DictionaryClusterTree> m_clusters;
     DataType m_key_type = type_String;
 
 #ifdef REALM_DEBUG

--- a/src/realm/object-store/dictionary.cpp
+++ b/src/realm/object-store/dictionary.cpp
@@ -196,6 +196,12 @@ void Dictionary::erase(StringData key)
     dict().erase(key);
 }
 
+bool Dictionary::try_erase(StringData key)
+{
+    verify_in_transaction();
+    return dict().try_erase(key);
+}
+
 void Dictionary::remove_all()
 {
     verify_in_transaction();

--- a/src/realm/object-store/dictionary.hpp
+++ b/src/realm/object-store/dictionary.hpp
@@ -87,6 +87,7 @@ public:
 
     Obj insert_embedded(StringData key);
     void erase(StringData key);
+    bool try_erase(StringData key);
     void remove_all();
     Obj get_object(StringData key);
     Mixed get_any(StringData key);

--- a/test/object-store/dictionary.cpp
+++ b/test/object-store/dictionary.cpp
@@ -229,8 +229,21 @@ TEMPLATE_TEST_CASE("dictionary types", "[dictionary]", cf::MixedVal, cf::Int, cf
             REQUIRE(dict.contains(key));
             dict.erase(key);
             REQUIRE(!dict.contains(key));
+            REQUIRE_THROWS(dict.erase(key));
         }
         REQUIRE(dict.size() == 0);
+        REQUIRE_THROWS(dict.erase(keys[0]));
+    }
+
+    SECTION("try_erase()") {
+        for (auto key : keys) {
+            REQUIRE(dict.contains(key));
+            REQUIRE(dict.try_erase(key));
+            REQUIRE(!dict.contains(key));
+            REQUIRE_FALSE(dict.try_erase(key));
+        }
+        REQUIRE(dict.size() == 0);
+        REQUIRE_FALSE(dict.try_erase(keys[0]));
     }
 
     SECTION("contains()") {


### PR DESCRIPTION
Cocoa doesn't consider a missing dictionary key to be an error and throwing spurious exceptions on non-error codepaths is obnoxious for debugging. This also eliminates some exceptions which were thrown and caught entirely within the dictionary code for the same reason, and fixes a bug where empty dictionaries didn't complain about missing keys.