### PR TITLE
RCORE-440 Track compileunits output from bloaty

### DIFF
--- a/evergreen/bloaty_to_json.py
+++ b/evergreen/bloaty_to_json.py
@@ -20,6 +20,12 @@ parser.add_argument(
 )
 
 parser.add_argument(
+    '--compileunits-input',
+    type=Path,
+    help='Path to CSV output of compileunits input file',
+)
+
+parser.add_argument(
     '--analyzed-file',
     type=str,
     help='Name of file being analyzed by bloaty',
@@ -131,6 +137,20 @@ if args.sections_input:
                 items.append({
                     'name': section_name,
                     'type': type_str,
+                    'file_size': int(row['filesize']),
+                    'vm_size': int(row['vmsize'])
+                })
+
+if args.sections_input:
+    with open(args.compileunits_input, 'r') as csv_file:
+        input_csv_reader = DictReader(csv_file)
+
+        for row in input_csv_reader:
+            compileunit_name = row['compileunits']
+            if not elf_section_re.search(compileunit_name):
+                items.append({
+                    'name': compileunit_name,
+                    'type': 'compileunit',
                     'file_size': int(row['filesize']),
                     'vm_size': int(row['vmsize'])
                 })

--- a/evergreen/config.yml
+++ b/evergreen/config.yml
@@ -256,7 +256,6 @@ tasks:
         #!/bin/bash
         set -o errexit
         set -o pipefail
-        set -o verbose
 
         mkdir bloaty-binaries && cd bloaty-binaries
         curl --silent -L ${bloaty_url} | tar -xz --strip-components=1

--- a/evergreen/config.yml
+++ b/evergreen/config.yml
@@ -272,9 +272,14 @@ tasks:
             $BLOATY -d sections $input_path -n 0 --csv > "bloaty-results/$input_file-sections.csv"
             $BLOATY -d shortsymbols $input_path -n 0 > "bloaty-results/$input_file-shortsymbols.txt"
             $BLOATY -d sections $input_path -n 0 > "bloaty-results/$input_file-sections.txt"
+            $BLOATY -d compileunits $input_path -n 0 > "bloaty-results/$input_file-compileunits.txt"
+            $BLOATY -d compileunits $input_path -n 0 --csv > "bloaty-results/$input_file-compileunits.csv"
 
             echo "Bloaty sections output for $input_file"
             head -n 100 "bloaty-results/$input_file-sections.txt"
+            echo
+            echo "Bloaty compile units output for $input_file"
+            head -n 100 "bloaty-results/$input_file-compileunits.txt"
             echo
             echo "Bloaty short symbols output for $input_file"
             head -n 100 "bloaty-results/$input_file-shortsymbols.txt"
@@ -282,6 +287,7 @@ tasks:
             ${python3|} ./evergreen/bloaty_to_json.py \
                 --short-symbols-input="bloaty-results/$input_file-shortsymbols.csv" \
                 --sections-input="bloaty-results/$input_file-sections.csv" \
+                --compileunits-input="bloaty-results/$input_file-compileunits.csv" \
                 --analyzed-file=$input_file \
                 --output "bloaty-results/$input_file-results.json" \
                 --project=${project} \
@@ -579,7 +585,7 @@ buildvariants:
     cmake_url: "https://s3.amazonaws.com/static.realm.io/evergreen-assets/cmake-3.20.3-linux-x86_64.tar.gz"
     bloaty_url: "https://s3.amazonaws.com/static.realm.io/evergreen-assets/bloaty-v1.1-39-gefc1c61-ubuntu2004-x86_64.tar.gz"
     cmake_bindir: "./cmake_binaries/bin"
-    cmake_build_type: Release
+    cmake_build_type: RelWithDebInfo
     fetch_missing_dependencies: On
     run_tests_against_baas: On
     c_compiler: "./clang_binaries/bin/clang"


### PR DESCRIPTION
This is a small internal change to the evergreen config/bloaty processing script that adds compile units to the info we collect/store/track from bloaty. It was sitting in a branch for weeks and weeks since I last looked at bloaty stuff and figured I'd get it committed so I don't just forget about it permanently.
