### PR TITLE
Set evergreen test tasks to time out after 30 minutes

### DIFF
--- a/evergreen/config.yml
+++ b/evergreen/config.yml
@@ -354,6 +354,7 @@ tasks:
 
 - name: core-tests
   tags: [ "test_suite", "for_pull_requests" ]
+  exec_timeout_secs: 1800
   commands:
   - func: "compile"
   - func: "run tests"
@@ -361,6 +362,7 @@ tasks:
       test_filter: StorageTests
 
 - name: benchmark-common-tasks
+  exec_timeout_secs: 1800
   tags: [ "benchmark" ]
   commands:
   - func: "run benchmark"
@@ -368,6 +370,7 @@ tasks:
       path_to_benchmark: ./build/test/benchmark-common-tasks/realm-benchmark-common-tasks
 
 - name: benchmark-crud
+  exec_timeout_secs: 1800
   tags: [ "benchmark" ]
   commands:
   - func: "run benchmark"
@@ -376,6 +379,7 @@ tasks:
 
 - name: sync-tests
   tags: [ "test_suite", "for_pull_requests" ]
+  exec_timeout_secs: 1800
   commands:
   - func: "compile"
   - func: "run tests"
@@ -384,6 +388,7 @@ tasks:
 
 - name: object-store-tests
   tags: [ "disabled_on_windows", "test_suite", "for_pull_requests" ]
+  exec_timeout_secs: 1800
   commands:
   - func: "compile"
     vars:


### PR DESCRIPTION
To be a good evergreen citizen, this sets the timeout for most of our tests to 30 minutes to make sure we don't accidentally hog machines for hours and hours.
