### PR TITLE
Improve performance of some notifier things

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -73,6 +73,7 @@ ForEachMacros:
   - SECTION
   - TEST_CASE
   - DYNAMIC_SECTION
+  - BENCHMARK
 IncludeBlocks:   Preserve
 IncludeCategories:
   - Regex:           '^"(llvm|llvm-c|clang|clang-c)/'

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 # NEXT RELEASE
 
 ### Enhancements
-* None.
+* Improve performance of creating collection notifiers for Realms with a complex schema. In the SDKs this means that the first run of a synchronous query, first call to observe() on a collection, or any call to find_async() will do significantly less work on the calling thread.
 
 ### Fixed
 * <How to hit and notice issue? what was the impact?> ([#????](https://github.com/realm/realm-core/issues/????), since v?.?.?)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ### Enhancements
 * Improve performance of creating collection notifiers for Realms with a complex schema. In the SDKs this means that the first run of a synchronous query, first call to observe() on a collection, or any call to find_async() will do significantly less work on the calling thread.
+* Improve performance of calculating changesets for notifications, particularly for deeply nested object graphs and objects which have List or Set properties with small numbers of objects in the collection.
 
 ### Fixed
 * <How to hit and notice issue? what was the impact?> ([#????](https://github.com/realm/realm-core/issues/????), since v?.?.?)

--- a/src/realm/obj.cpp
+++ b/src/realm/obj.cpp
@@ -2309,4 +2309,9 @@ ColKey Obj::get_primary_key_column() const
     return m_table->get_primary_key_column();
 }
 
+ref_type Obj::Internal::get_ref(const Obj& obj, ColKey col_key)
+{
+    return to_ref(obj._get<int64_t>(col_key.get_index()));
+}
+
 } // namespace realm

--- a/src/realm/obj.cpp
+++ b/src/realm/obj.cpp
@@ -209,7 +209,7 @@ T Obj::_get(ColKey::Idx col_ndx) const
 {
     _update_if_needed();
 
-    typename ColumnTypeTraits<T>::cluster_leaf_type values(get_alloc());
+    typename ColumnTypeTraits<T>::cluster_leaf_type values(_get_alloc());
     ref_type ref = to_ref(Array::get(m_mem.get_addr(), col_ndx.val + 1));
     values.init_from_ref(ref);
 
@@ -221,7 +221,7 @@ ObjKey Obj::_get<ObjKey>(ColKey::Idx col_ndx) const
 {
     _update_if_needed();
 
-    ArrayKey values(get_alloc());
+    ArrayKey values(_get_alloc());
     ref_type ref = to_ref(Array::get(m_mem.get_addr(), col_ndx.val + 1));
     values.init_from_ref(ref);
 

--- a/src/realm/obj.hpp
+++ b/src/realm/obj.hpp
@@ -63,6 +63,10 @@ class Dictionary;
 class DictionaryLinkValues;
 using DictionaryPtr = std::unique_ptr<Dictionary>;
 
+namespace _impl {
+class DeepChangeChecker;
+}
+
 enum JSONOutputMode {
     output_mode_json,       // default / existing implementation for outputting realm to json
     output_mode_xjson,      // extended json as described in the spec
@@ -281,6 +285,12 @@ public:
     LinkCollectionPtr get_linkcollection_ptr(ColKey col_key) const;
 
     void assign_pk_and_backlinks(const Obj& other);
+
+    class Internal {
+        friend class _impl::DeepChangeChecker;
+
+        static ref_type get_ref(const Obj& obj, ColKey col_key);
+    };
 
 private:
     friend class ArrayBacklink;

--- a/src/realm/object-store/impl/collection_notifier.cpp
+++ b/src/realm/object-store/impl/collection_notifier.cpp
@@ -94,7 +94,7 @@ CollectionNotifier::get_object_modification_checker(TransactionChangeInfo const&
 
 void CollectionNotifier::recalculate_key_path_array()
 {
-    m_key_path_array = {};
+    m_key_path_array.clear();
     m_all_callbacks_filtered = true;
     for (const auto& callback : m_callbacks) {
         const auto& key_path_array = callback.key_path_array;

--- a/src/realm/object-store/impl/deep_change_checker.hpp
+++ b/src/realm/object-store/impl/deep_change_checker.hpp
@@ -26,6 +26,7 @@
 
 namespace realm {
 class CollectionBase;
+class Group;
 class Mixed;
 class Realm;
 class Table;
@@ -34,6 +35,7 @@ class Transaction;
 
 using KeyPath = std::vector<std::pair<TableKey, ColKey>>;
 using KeyPathArray = std::vector<KeyPath>;
+using ref_type = size_t;
 
 namespace _impl {
 class RealmCoordinator;
@@ -182,12 +184,12 @@ private:
     bool check_outgoing_links(Table const& table, ObjKey object_key, const std::vector<ColKey>& filtered_columns,
                               size_t depth = 0);
 
-    bool do_check_for_collection_modifications(std::unique_ptr<CollectionBase> coll,
+    bool do_check_for_collection_modifications(const Obj& obj, ColKey col,
                                                const std::vector<ColKey>& filtered_columns, size_t depth);
     template <typename T>
-    bool do_check_for_collection_of_mixed(T* coll, const std::vector<ColKey>& filtered_columns, size_t depth);
-    template <typename T>
-    bool do_check_mixed_for_link(T* coll, TableRef& cached_linked_table, Mixed value,
+    bool check_collection(ref_type ref, const Obj& obj, ColKey col, const std::vector<ColKey>& filtered_columns,
+                          size_t depth);
+    bool do_check_mixed_for_link(Group&, TableRef& cached_linked_table, Mixed value,
                                  const std::vector<ColKey>& filtered_columns, size_t depth);
 };
 

--- a/src/realm/object-store/results.hpp
+++ b/src/realm/object-store/results.hpp
@@ -206,7 +206,7 @@ public:
         Query,      // Backed by a query that has not yet been turned into a TableView
         TableView,  // Backed by a TableView created from a Query
     };
-    // Get the currrent mode of the Results
+    // Get the current mode of the Results
     // Ideally this would not be public but it's needed for some KVO stuff
     Mode get_mode() const noexcept REQUIRES(!m_mutex);
 

--- a/test/object-store/benchmarks/main.cpp
+++ b/test/object-store/benchmarks/main.cpp
@@ -35,7 +35,7 @@ int main(int argc, char** argv)
 #ifdef _MSC_VER
     char path[MAX_PATH];
     if (GetModuleFileNameA(NULL, path, sizeof(path)) == 0) {
-        fprintf(stderr, "Failed to retrieve path to exectuable.\n");
+        fprintf(stderr, "Failed to retrieve path to executable.\n");
         return 1;
     }
     PathRemoveFileSpecA(path);

--- a/test/object-store/benchmarks/results.cpp
+++ b/test/object-store/benchmarks/results.cpp
@@ -21,11 +21,11 @@
 #include "util/test_file.hpp"
 #include "util/test_utils.hpp"
 
-#include <realm/object-store/binding_context.hpp>
 #include <realm/object-store/object_schema.hpp>
 #include <realm/object-store/property.hpp>
 #include <realm/object-store/results.hpp>
 #include <realm/object-store/schema.hpp>
+#include <realm/object-store/impl/realm_coordinator.hpp>
 
 #include <realm/db.hpp>
 #include <realm/query_engine.hpp>
@@ -89,44 +89,37 @@ TEST_CASE("Benchmark results", "[benchmark]") {
 
     SECTION("basics") {
         REQUIRE(r.filter(Query(table->where().less(col_value, 2))).size() == 2);
-        BENCHMARK("basic filter")
-        {
+        BENCHMARK("basic filter") {
             return r.filter(Query(table->where().less(col_value, 2))).size();
         };
 
         REQUIRE_ORDER((r.sort({{"value", true}})), 2, 3, 0, 1);
-        BENCHMARK("sort simple ints")
-        {
+        BENCHMARK("sort simple ints") {
             return r.sort({{"value", true}});
         };
 
         REQUIRE_ORDER((r.sort({{"bool", true}, {"value", true}})), 2, 0, 3, 1);
-        BENCHMARK("sort over two properties")
-        {
+        BENCHMARK("sort over two properties") {
             return r.sort({{"bool", true}, {"value", true}});
         };
 
         REQUIRE_ORDER((r.sort({{"link.value", true}})), 0, 3, 2, 1);
-        BENCHMARK("sort over link")
-        {
+        BENCHMARK("sort over link") {
             return r.sort({{"link.value", true}});
         };
 
         REQUIRE_ORDER((r.sort({{"link.link.value", true}})), 1, 0, 3, 2);
-        BENCHMARK("sort over two links")
-        {
+        BENCHMARK("sort over two links") {
             return r.sort({{"link.link.value", true}});
         };
 
         REQUIRE(r.distinct({{"value"}}).size() == 4);
-        BENCHMARK("distinct ints")
-        {
+        BENCHMARK("distinct ints") {
             return r.distinct({{"value"}});
         };
 
         REQUIRE(r.distinct({{"bool"}}).size() == 2);
-        BENCHMARK("distinct bool")
-        {
+        BENCHMARK("distinct bool") {
             return r.distinct({{"bool"}});
         };
     }
@@ -139,33 +132,205 @@ TEST_CASE("Benchmark results", "[benchmark]") {
             table->get_object(table_keys[i]).set_all((i + 2) % 4, bool(i % 2));
         realm->commit_transaction();
 
-        BENCHMARK("Table forwards")
-        {
+        BENCHMARK("Table forwards") {
             for (size_t i = 0, size = r.size(); i < size; ++i) {
                 Obj o = r.get<Obj>(i);
             }
         };
 
-        BENCHMARK("Table reverse")
-        {
+        BENCHMARK("Table reverse") {
             for (size_t i = 0, size = r.size(); i < size; ++i) {
                 Obj o = r.get<Obj>(size - i - 1);
             }
         };
 
         auto tv = r.snapshot();
-        BENCHMARK("TableView forwards")
-        {
+        BENCHMARK("TableView forwards") {
             for (size_t i = 0, size = r.size(); i < size; ++i) {
                 Obj o = tv.get<Obj>(i);
             }
         };
 
-        BENCHMARK("TableView reverse")
-        {
+        BENCHMARK("TableView reverse") {
             for (size_t i = 0, size = r.size(); i < size; ++i) {
                 Obj o = tv.get<Obj>(size - i - 1);
             }
+        };
+    }
+}
+
+TEST_CASE("Benchmark results notifier", "[benchmark]") {
+    InMemoryTestFile config;
+
+    SECTION("100 strongly connected tables") {
+        std::vector<ObjectSchema> schema;
+        for (int i = 0; i < 100; ++i) {
+            ObjectSchema os;
+            os.name = util::format("table %1", i);
+            os.persisted_properties = {{"value", PropertyType::Int}};
+            for (int j = 0; j < 100; ++j) {
+                os.persisted_properties.push_back({util::format("column %1", j),
+                                                   PropertyType::Object | PropertyType::Nullable,
+                                                   util::format("table %1", j)});
+            }
+            schema.push_back(std::move(os));
+        }
+        config.schema = Schema{schema};
+        auto realm = Realm::get_shared_realm(config);
+        auto table_0 = realm->read_group().get_table("class_table 0");
+
+        BENCHMARK("create notifier") {
+            Results r(realm, table_0->where());
+            r.evaluate_query_if_needed(true);
+        };
+    }
+
+    config.automatic_change_notifications = false;
+    static const int table_count = 6;
+    static const int column_count = 50;
+    static const int object_count = 50;
+
+    auto make_schema = [](PropertyType link_type) {
+        std::vector<ObjectSchema> schema;
+        for (int i = 0; i < table_count; ++i) {
+            ObjectSchema os;
+            os.name = util::format("table %1", i);
+            os.persisted_properties = {{"value", PropertyType::Int}};
+            for (int j = 0; j < column_count; ++j) {
+                os.persisted_properties.push_back(
+                    {util::format("column %1", j), link_type, util::format("table %1", (i + 1) % table_count)});
+            }
+            schema.push_back(std::move(os));
+        }
+        return schema;
+    };
+
+    SECTION("chained tables using links") {
+        std::vector<ObjectSchema> schema = make_schema(PropertyType::Object | PropertyType::Nullable);
+        config.schema = Schema{schema};
+        auto realm = Realm::get_shared_realm(config);
+
+        auto& group = realm->read_group();
+        std::vector<TableRef> tables;
+        for (int i = 0; i < table_count; ++i) {
+            tables.push_back(group.get_table(util::format("class_table %1", i)));
+        }
+
+        realm->begin_transaction();
+        for (int i = 0; i < table_count; ++i) {
+            for (int j = 0; j < object_count; ++j) {
+                tables[i]->create_object();
+            }
+        }
+        for (int i = 0; i < table_count; ++i) {
+            auto target_table = tables[(i + 1) % table_count];
+            for (int j = 0; j < object_count; ++j) {
+                auto obj = tables[i]->get_object(j);
+                for (int k = 0; k < column_count; ++k) {
+                    obj.set(util::format("column %1", k), target_table->get_object((j + k) % object_count).get_key());
+                }
+            }
+        }
+        realm->commit_transaction();
+
+        Results r(realm, tables[0]->where());
+        auto token = r.add_notification_callback([](CollectionChangeSet, std::exception_ptr) {});
+        auto& coordinator = *_impl::RealmCoordinator::get_coordinator(config.path);
+        coordinator.on_change();
+
+        BENCHMARK("modify at depth 0", iteration) {
+            realm->begin_transaction();
+            for (int i = 0; i < object_count; ++i) {
+                tables[0]->get_object(i).set_all(iteration);
+            }
+            realm->commit_transaction();
+            coordinator.on_change();
+        };
+
+        BENCHMARK("modify at depth 1", iteration) {
+            realm->begin_transaction();
+            tables[1]->get_object(0).set_all(iteration);
+            realm->commit_transaction();
+            coordinator.on_change();
+        };
+
+        BENCHMARK("modify at depth 2", iteration) {
+            realm->begin_transaction();
+            tables[2]->get_object(0).set_all(iteration);
+            realm->commit_transaction();
+            coordinator.on_change();
+        };
+
+        BENCHMARK("modify at depth 3", iteration) {
+            realm->begin_transaction();
+            tables[3]->get_object(0).set_all(iteration);
+            realm->commit_transaction();
+            coordinator.on_change();
+        };
+    }
+
+    SECTION("chained tables using lists") {
+        std::vector<ObjectSchema> schema = make_schema(PropertyType::Object | PropertyType::Array);
+        config.schema = Schema{schema};
+        auto realm = Realm::get_shared_realm(config);
+
+        auto& group = realm->read_group();
+        std::vector<TableRef> tables;
+        for (int i = 0; i < table_count; ++i) {
+            tables.push_back(group.get_table(util::format("class_table %1", i)));
+        }
+
+        realm->begin_transaction();
+        for (int i = 0; i < table_count; ++i) {
+            for (int j = 0; j < object_count; ++j) {
+                tables[i]->create_object();
+            }
+        }
+        for (int i = 0; i < table_count; ++i) {
+            auto target_table = tables[(i + 1) % table_count];
+            for (int j = 0; j < object_count; ++j) {
+                auto obj = tables[i]->get_object(j);
+                for (int k = 0; k < column_count; ++k) {
+                    obj.get_linklist(util::format("column %1", k))
+                        .add(target_table->get_object((j + k) % object_count).get_key());
+                }
+            }
+        }
+        realm->commit_transaction();
+
+        Results r(realm, tables[0]->where());
+        auto token = r.add_notification_callback([](CollectionChangeSet, std::exception_ptr) {});
+        auto& coordinator = *_impl::RealmCoordinator::get_coordinator(config.path);
+        coordinator.on_change();
+
+        BENCHMARK("modify at depth 0", iteration) {
+            realm->begin_transaction();
+            for (int i = 0; i < object_count; ++i) {
+                tables[0]->get_object(i).set_all(iteration);
+            }
+            realm->commit_transaction();
+            coordinator.on_change();
+        };
+
+        BENCHMARK("modify at depth 1", iteration) {
+            realm->begin_transaction();
+            tables[1]->get_object(0).set_all(iteration);
+            realm->commit_transaction();
+            coordinator.on_change();
+        };
+
+        BENCHMARK("modify at depth 2", iteration) {
+            realm->begin_transaction();
+            tables[2]->get_object(0).set_all(iteration);
+            realm->commit_transaction();
+            coordinator.on_change();
+        };
+
+        BENCHMARK("modify at depth 3", iteration) {
+            realm->begin_transaction();
+            tables[3]->get_object(0).set_all(iteration);
+            realm->commit_transaction();
+            coordinator.on_change();
         };
     }
 }

--- a/test/object-store/transaction_log_parsing.cpp
+++ b/test/object-store/transaction_log_parsing.cpp
@@ -1795,6 +1795,7 @@ TEMPLATE_TEST_CASE("DeepChangeChecker", "[notifications]", ListOfObjects, ListOf
     KeyPathArray key_path_array_test_type = {key_path_test_type};
     KeyPathArray key_path_array_empty = {};
     auto relation_updater = [&]() {
+        related_tables.clear();
         _impl::DeepChangeChecker::find_related_tables(related_tables, *table, key_path_array_empty);
     };
     relation_updater();
@@ -1982,8 +1983,8 @@ TEMPLATE_TEST_CASE("DeepChangeChecker", "[notifications]", ListOfObjects, ListOf
             REQUIRE(test_type.count_unresolved_links(objects[2], cols[3]) == 1);
         }
         else {
-            REQUIRE(test_type.size_of_collection(objects[0], cols[3]) ==
-                    2); // LnkLst actually has 3 entries but hides one
+            // LnkLst actually has 3 entries but hides one
+            REQUIRE(test_type.size_of_collection(objects[0], cols[3]) == 2);
         }
         r->commit_transaction();
 


### PR DESCRIPTION
Prompted by [a report of a performance regression in notifier performance in v11](https://github.com/realm/realm-cocoa/issues/7316), I wrote a few new benchmarks and optimized some stuff. I haven't yet reproduced the regression the user reported, but I did find a regression in notifier creation perf (which is moderately important as it happens on the main thread) and found some room to optimize things which might be similar to what the user was hitting.

It may be easiest to review this by looking at the commits individually as they're each doing fairly distinct things.

Test | v10.8.1 | master | This PR
 -|-|-|-
Create notifier | 409 us | 12.5 ms | 333 us
Chained object links (depth 0) | 25 us | 22 us | 24 us
Chained object links (depth 1) | 314 ms | 337 ms | 10 ms
Chained object links (depth 2) | 10 ms | 11 ms | 380 us
Chained object links (depth 3) | 375 us | 400 us | 25 us
Chained object lists (depth 0) | 24 us | 22 us | 23 us
Chained object lists (depth 1) | 2.4 s | 3.5 s | 30 ms
Chained object lists (depth 2) | 80 ms | 116 ms | 1 ms
Chained object lists (depth 3) | 2.74 ms |3.9 ms | 64 us

The 100x speedup there is not particularly representative of anything realistic, but it should provide a meaningful speedup even without 99 empty lists in each object.