### PR TITLE
Fix a segfault in code produced by Visual Studio 2019

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@
 
 ### Fixed
 * <How to hit and notice issue? what was the impact?> ([#????](https://github.com/realm/realm-core/issues/????), since v?.?.?)
-* None.
+* Fixed a segfault in sync compiled by MSVC 2019. ([#4624](https://github.com/realm/realm-core/issues/4624), since v10.4.0)
  
 ### Breaking changes
 * None.

--- a/src/realm/sync/changeset.cpp
+++ b/src/realm/sync/changeset.cpp
@@ -58,26 +58,33 @@ InternString Changeset::find_string(StringData string) const noexcept
     return InternString{};
 }
 
-// TODO: https://github.com/realm/realm-core/issues/4624 remove the check disabling code once
-// we understand why MSVC reports stack corruption in this method.
-#if _MSC_VER
-#pragma runtime_checks("", off)
-#endif
 PrimaryKey Changeset::get_key(const Instruction::PrimaryKey& key) const noexcept
 {
-    const auto& get = overload{
-        [this](InternString str) -> PrimaryKey {
-            return get_string(str);
-        },
-        [](auto otherwise) -> PrimaryKey {
-            return otherwise;
-        },
-    };
-    return mpark::visit(get, key);
+    // we do not use the expected `mpark::visit(overload...` because in MSVC 2019 this
+    // code produces a segfault for something that works on other compilers.
+    // See https://github.com/realm/realm-core/issues/4624
+    if (const auto int64_ptr = mpark::get_if<int64_t>(&key)) {
+        return *int64_ptr;
+    }
+    else if (const auto intern_string_ptr = mpark::get_if<InternString>(&key)) {
+        return this->get_string(*intern_string_ptr);
+    }
+    else if (const auto monostate_ptr = mpark::get_if<mpark::monostate>(&key)) {
+        return *monostate_ptr;
+    }
+    else if (const auto global_key_ptr = mpark::get_if<GlobalKey>(&key)) {
+        return *global_key_ptr;
+    }
+    else if (const auto oid_ptr = mpark::get_if<ObjectId>(&key)) {
+        return *oid_ptr;
+    }
+    else if (const auto uuid_ptr = mpark::get_if<UUID>(&key)) {
+        return *uuid_ptr;
+    }
+    else {
+        REALM_UNREACHABLE(); // unhandled primary key type
+    }
 }
-#if _MSC_VER
-#pragma runtime_checks("", restore)
-#endif
 
 bool Changeset::operator==(const Changeset& that) const noexcept
 {

--- a/src/realm/sync/instruction_applier.cpp
+++ b/src/realm/sync/instruction_applier.cpp
@@ -702,7 +702,7 @@ void InstructionApplier::operator()(const Instruction::ArrayInsert& instr)
             bad_transaction_log("Invalid path for ArrayInsert (obj, col)");
         }};
 
-    resolve_path(instr, "ArrayInsert", callback);
+    resolve_path(instr, "ArrayInsert", std::move(callback));
 }
 
 void InstructionApplier::operator()(const Instruction::ArrayMove& instr)
@@ -873,19 +873,19 @@ void InstructionApplier::operator()(const Instruction::SetInsert& instr)
 
             visit_payload(instr.value, inserter);
         },
-        [&](LstBase&, size_t) {
+        [](LstBase&, size_t) {
             bad_transaction_log("Invalid path for SetInsert (list, index)");
         },
-        [&](LstBase&) {
+        [](LstBase&) {
             bad_transaction_log("Invalid path for SetInsert (list)");
         },
-        [&](Dictionary&, Mixed) {
+        [](Dictionary&, Mixed) {
             bad_transaction_log("Invalid path for SetInsert (dictionary, key)");
         },
-        [&](Dictionary&) {
+        [](Dictionary&) {
             bad_transaction_log("Invalid path for SetInsert (dictionary, key)");
         },
-        [&](Obj&, ColKey) {
+        [](Obj&, ColKey) {
             bad_transaction_log("Invalid path for SetInsert (object, column)");
         }};
 
@@ -956,19 +956,19 @@ void InstructionApplier::operator()(const Instruction::SetErase& instr)
 
             visit_payload(instr.value, inserter);
         },
-        [&](LstBase&, size_t) {
+        [](LstBase&, size_t) {
             bad_transaction_log("Invalid path for SetErase (list, index)");
         },
-        [&](LstBase&) {
+        [](LstBase&) {
             bad_transaction_log("Invalid path for SetErase (list)");
         },
-        [&](Dictionary&, Mixed) {
+        [](Dictionary&, Mixed) {
             bad_transaction_log("Invalid path for SetErase (dictionary, key)");
         },
-        [&](Dictionary&) {
+        [](Dictionary&) {
             bad_transaction_log("Invalid path for SetErase (dictionary, key)");
         },
-        [&](Obj&, ColKey) {
+        [](Obj&, ColKey) {
             bad_transaction_log("Invalid path for SetErase (object, column)");
         }};
 

--- a/test/test_sync.cpp
+++ b/test/test_sync.cpp
@@ -8422,4 +8422,73 @@ TEST(Sync_BundledRealmFile)
     db->write_copy(path_1.c_str());
 }
 
+// This test is extracted from ClientReset_ThreeClients
+// because it uncovers a bug in how MSVC 2019 compiles
+// things in Changeset::get_key()
+TEST(Sync_MergeStringPrimaryKey)
+{
+    TEST_DIR(dir_1); // The server.
+    SHARED_GROUP_TEST_PATH(path_1);
+    SHARED_GROUP_TEST_PATH(path_2);
+    TEST_DIR(metadata_dir_1);
+    TEST_DIR(metadata_dir_2);
+
+    const std::string server_path = "/data";
+
+    std::string real_path_1, real_path_2;
+
+    auto create_schema = [&](Transaction& group) {
+        TableRef table_0 = create_table(group, "class_table_0");
+        table_0->add_column(type_Int, "int");
+        table_0->add_column(type_Bool, "bool");
+        table_0->add_column(type_Float, "float");
+        table_0->add_column(type_Double, "double");
+        table_0->add_column(type_Timestamp, "timestamp");
+
+        TableRef table_1 = create_table_with_primary_key(group, "class_table_1", type_Int, "pk_int");
+        table_1->add_column(type_String, "String");
+
+        TableRef table_2 = create_table_with_primary_key(group, "class_table_2", type_String, "pk_string");
+        table_2->add_column_list(type_String, "array_string");
+    };
+
+    // First we make changesets. Then we upload them.
+    {
+        ClientServerFixture fixture(dir_1, test_context);
+        fixture.start();
+        real_path_1 = fixture.map_virtual_to_real_path(server_path);
+
+        {
+            std::unique_ptr<ClientReplication> history = make_client_replication(path_1);
+            DBRef sg = DB::create(*history);
+            WriteTransaction wt{sg};
+            create_schema(wt);
+            wt.commit();
+        }
+        {
+            std::unique_ptr<ClientReplication> history = make_client_replication(path_2);
+            DBRef sg = DB::create(*history);
+            WriteTransaction wt{sg};
+            create_schema(wt);
+
+            TableRef table_2 = wt.get_table("class_table_2");
+            auto col = table_2->get_column_key("array_string");
+            auto list_string = table_2->create_object_with_primary_key("aaa").get_list<String>(col);
+            list_string.add("a");
+            list_string.add("b");
+
+            wt.commit();
+        }
+
+        Session session_1 = fixture.make_session(path_1);
+        fixture.bind_session(session_1, server_path);
+        Session session_2 = fixture.make_session(path_2);
+        fixture.bind_session(session_2, server_path);
+
+        session_1.wait_for_upload_complete_or_client_stopped();
+        session_2.wait_for_upload_complete_or_client_stopped();
+        // Download completion is not important.
+    }
+}
+
 } // unnamed namespace


### PR DESCRIPTION
The segfault was discovered by additional tests enabled in https://github.com/realm/realm-core/pull/4706.

It looks to have been introduced by https://github.com/realm/realm-core/pull/4178 to fix another MSVC issue in debug mode. Instead of reverting that change which would bring up the old debug mode issue, this changes the code to not rely on the `mpark::visit(overload` pattern with an auto case as this seems to be a combination of code that shows a bug in MSVC 2019 and/or mpark.

I have observed that there are other ways to "fix" the issue, such as removing the lifetime extension idea and adding an explicit case for GlobalKey:
```
    auto get = overload{
        [this](InternString str) -> PrimaryKey {
            return get_string(str);
        },
        [](const GlobalKey& key) -> PrimaryKey {
            return key;
        },
        [](auto otherwise) -> PrimaryKey {
            return otherwise;
        },
    };
    return mpark::visit(get, key);
```

But the changes in this PR seem less magical and less prone to similar issues in the future.
This should also fix https://github.com/realm/realm-core/issues/4624

## ☑️ ToDos
* [x] 📝 Changelog update
* [x] 🚦 Tests (or not relevant)
