### PR TITLE
Fix an assertion failure in ObjectNotifier

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 # NEXT RELEASE
 
 ### Enhancements
-* None.
+* Shift more of the work done when first initializing a collection notifier to the background worker thread rather than doing it on the main thread.
 
 ### Fixed
 * <How to hit and notice issue? what was the impact?> ([#????](https://github.com/realm/realm-core/issues/????), since v?.?.?)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 ### Fixed
 * <How to hit and notice issue? what was the impact?> ([#????](https://github.com/realm/realm-core/issues/????), since v?.?.?)
 * Removing a change callback from a Results would sometimes block the calling thread while the query for that Results was running on the background worker thread (since v11.1.0).
+* Object observers did not handle the object being deleted properly, which could result in assertion failures mentioning "m_table" in ObjectNotifier ([#4824](https://github.com/realm/realm-core/issues/4824), since v11.1.0).
  
 ### Breaking changes
 * None.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@
 
 ### Fixed
 * <How to hit and notice issue? what was the impact?> ([#????](https://github.com/realm/realm-core/issues/????), since v?.?.?)
-* None.
+* Removing a change callback from a Results would sometimes block the calling thread while the query for that Results was running on the background worker thread (since v11.1.0).
  
 ### Breaking changes
 * None.

--- a/src/realm/keys.hpp
+++ b/src/realm/keys.hpp
@@ -128,11 +128,6 @@ struct ColKey {
     {
         return get_attrs().test(col_attr_Collection);
     }
-    ColKey& operator=(int64_t val) noexcept
-    {
-        value = val;
-        return *this;
-    }
     bool operator==(const ColKey& rhs) const noexcept
     {
         return value == rhs.value;
@@ -196,11 +191,6 @@ struct ObjKey {
     ObjKey get_unresolved() const
     {
         return ObjKey(-2 - value);
-    }
-    ObjKey& operator=(int64_t val) noexcept
-    {
-        value = val;
-        return *this;
     }
     bool operator==(const ObjKey& rhs) const noexcept
     {

--- a/src/realm/keys.hpp
+++ b/src/realm/keys.hpp
@@ -35,33 +35,28 @@ struct TableKey {
         : value(null_value)
     {
     }
-    explicit TableKey(uint32_t val) noexcept
+    constexpr explicit TableKey(uint32_t val) noexcept
         : value(val)
     {
     }
-    TableKey& operator=(uint32_t val) noexcept
-    {
-        value = val;
-        return *this;
-    }
-    bool operator==(const TableKey& rhs) const noexcept
+    constexpr bool operator==(const TableKey& rhs) const noexcept
     {
         return value == rhs.value;
     }
-    bool operator!=(const TableKey& rhs) const noexcept
+    constexpr bool operator!=(const TableKey& rhs) const noexcept
     {
         return value != rhs.value;
     }
-    bool operator<(const TableKey& rhs) const noexcept
+    constexpr bool operator<(const TableKey& rhs) const noexcept
     {
         return value < rhs.value;
     }
-    bool operator>(const TableKey& rhs) const noexcept
+    constexpr bool operator>(const TableKey& rhs) const noexcept
     {
         return value > rhs.value;
     }
 
-    explicit operator bool() const noexcept
+    constexpr explicit operator bool() const noexcept
     {
         return value != null_value;
     }

--- a/src/realm/object-store/impl/collection_notifier.cpp
+++ b/src/realm/object-store/impl/collection_notifier.cpp
@@ -56,7 +56,6 @@ CollectionNotifier::get_modification_checker(TransactionChangeInfo const& info, 
     // If the table in question has no outgoing links it will be the only entry in `m_related_tables`.
     // In this case we do not need a `DeepChangeChecker` and check the modifications using the
     // `ObjectChangeSet` within the `TransactionChangeInfo` for this table directly.
-    util::CheckedLockGuard lock(m_callback_mutex);
     if (m_related_tables.size() == 1 && !all_callbacks_filtered()) {
         auto root_table_key = m_related_tables[0].table_key;
         auto& object_change_set = info.tables.find(root_table_key.value)->second;
@@ -94,14 +93,17 @@ CollectionNotifier::get_object_modification_checker(TransactionChangeInfo const&
 
 void CollectionNotifier::recalculate_key_path_array()
 {
-    m_key_path_array.clear();
     m_all_callbacks_filtered = true;
+    m_any_callbacks_filtered = false;
+    m_key_path_array.clear();
     for (const auto& callback : m_callbacks) {
-        const auto& key_path_array = callback.key_path_array;
-        if (key_path_array.size() == 0) {
+        if (callback.key_path_array.empty()) {
             m_all_callbacks_filtered = false;
         }
-        for (const auto& key_path : key_path_array) {
+        else {
+            m_any_callbacks_filtered = true;
+        }
+        for (const auto& key_path : callback.key_path_array) {
             m_key_path_array.push_back(key_path);
         }
     }
@@ -109,17 +111,12 @@ void CollectionNotifier::recalculate_key_path_array()
 
 bool CollectionNotifier::any_callbacks_filtered() const noexcept
 {
-    return any_of(begin(m_callbacks), end(m_callbacks), [](const auto& callback) {
-        return callback.key_path_array.size() > 0;
-    });
+    return m_any_callbacks_filtered;
 }
-
 
 bool CollectionNotifier::all_callbacks_filtered() const noexcept
 {
-    return all_of(begin(m_callbacks), end(m_callbacks), [](const auto& callback) {
-        return callback.key_path_array.size() > 0;
-    });
+    return m_all_callbacks_filtered;
 }
 
 CollectionNotifier::CollectionNotifier(std::shared_ptr<Realm> realm)
@@ -140,14 +137,28 @@ void CollectionNotifier::release_data() noexcept
     m_sg = nullptr;
 }
 
+static bool all_have_filters(std::vector<NotificationCallback> const& callbacks) noexcept
+{
+    return std::all_of(callbacks.begin(), callbacks.end(), [](auto& cb) {
+        return !cb.key_path_array.empty();
+    });
+}
+
 uint64_t CollectionNotifier::add_callback(CollectionChangeCallback callback, KeyPathArray key_path_array)
 {
     m_realm->verify_thread();
 
     util::CheckedLockGuard lock(m_callback_mutex);
+    // If we're adding a callback with a keypath filter or if previously all
+    // callbacks had filters but this one doesn't we will need to recalculate
+    // the related tables on the background thread.
+    if (!key_path_array.empty() || all_have_filters(m_callbacks)) {
+        m_did_modify_callbacks = true;
+    }
+
     auto token = m_next_token++;
     m_callbacks.push_back({std::move(callback), {}, {}, std::move(key_path_array), token, false, false});
-    m_did_modify_callbacks = true;
+
     if (m_callback_index == npos) { // Don't need to wake up if we're already sending notifications
         Realm::Internal::get_coordinator(*m_realm).wake_up_notifier_worker();
         m_have_callbacks = true;
@@ -176,7 +187,13 @@ void CollectionNotifier::remove_callback(uint64_t token)
 
         old = std::move(*it);
         m_callbacks.erase(it);
-        m_did_modify_callbacks = true;
+
+        // If we're removing a callback with a keypath filter or the last callback
+        // without a keypath filter we will need to recalcuate the related tables
+        // on next run.
+        if (!old.key_path_array.empty() || all_have_filters(m_callbacks)) {
+            m_did_modify_callbacks = true;
+        }
 
         m_have_callbacks = !m_callbacks.empty();
     }
@@ -276,7 +293,6 @@ void CollectionNotifier::prepare_handover()
     util::CheckedLockGuard lock(m_callback_mutex);
     for (auto& callback : m_callbacks)
         REALM_ASSERT(!callback.skip_next);
-    m_did_modify_callbacks = true;
 #endif
 }
 
@@ -320,7 +336,12 @@ void CollectionNotifier::deliver_error(std::exception_ptr error)
     // because we're going to remove all the callbacks immediately.
     m_error = true;
 
-    m_callback_count = m_callbacks.size();
+    {
+        // In the non-error codepath this is done as part of package_for_delivery()
+        // but that's skipped for errors
+        util::CheckedLockGuard lock(m_callback_mutex);
+        m_callback_count = m_callbacks.size();
+    }
     for_each_callback([this, &error](auto& lock, auto& callback) {
         // acquire a local reference to the callback so that removing the
         // callback from within it can't result in a dangling pointer
@@ -373,6 +394,7 @@ void CollectionNotifier::for_each_callback(Fn&& fn)
 
 void CollectionNotifier::attach_to(std::shared_ptr<Transaction> sg)
 {
+    REALM_ASSERT(!m_has_run);
     do_attach_to(*sg);
     m_sg = std::move(sg);
 }

--- a/src/realm/object-store/impl/collection_notifier.hpp
+++ b/src/realm/object-store/impl/collection_notifier.hpp
@@ -178,7 +178,6 @@ public:
 
 protected:
     void add_changes(CollectionChangeBuilder change) REQUIRES(!m_callback_mutex);
-    void set_table(ConstTableRef table) REQUIRES(!m_callback_mutex);
     std::unique_lock<std::mutex> lock_target();
     Transaction& source_shared_group();
     // signal that the underlying source object of the collection has been deleted

--- a/src/realm/object-store/impl/collection_notifier.hpp
+++ b/src/realm/object-store/impl/collection_notifier.hpp
@@ -192,28 +192,24 @@ protected:
                                                                                  ConstTableRef)
         REQUIRES(!m_callback_mutex);
 
-    // Creates and returns a `ObjectKeyPathChangeChecker` which behaves slighty different that `DeepChangeChecker`
+    // Creates and returns a `ObjectKeyPathChangeChecker` which behaves slightly different that `DeepChangeChecker`
     // and `KeyPathChecker` which are used for `Collection`s.
     std::function<std::vector<int64_t>(ObjectChangeSet::ObjectKeyType)>
-    get_object_modification_checker(TransactionChangeInfo const&, ConstTableRef) REQUIRES(m_callback_mutex);
+    get_object_modification_checker(TransactionChangeInfo const&, ConstTableRef) REQUIRES(!m_callback_mutex);
 
     // Returns a vector containing all `KeyPathArray`s from all `NotificationCallback`s attached to this notifier.
     void recalculate_key_path_array() REQUIRES(m_callback_mutex);
     // Checks `KeyPathArray` filters on all `m_callbacks` and returns true if at least one key path
     // filter is attached to each of them.
-    bool any_callbacks_filtered() const noexcept REQUIRES(m_callback_mutex);
+    bool any_callbacks_filtered() const noexcept;
     // Checks `KeyPathArray` filters on all `m_callbacks` and returns true if at least one key path
     // filter is attached to all of them.
-    bool all_callbacks_filtered() const noexcept REQUIRES(m_callback_mutex);
+    bool all_callbacks_filtered() const noexcept;
 
     void update_related_tables(Table const& table) REQUIRES(m_callback_mutex);
 
     // A summary of all `KeyPath`s attached to the `m_callbacks`.
     KeyPathArray m_key_path_array;
-
-    // When updating `m_key_path_array` we need to also check if all callbacks have a filter.
-    // This information is later used in `DeepChangeChecker`.
-    bool m_all_callbacks_filtered = false;
 
     // The actual change, calculated in run() and delivered in prepare_handover()
     CollectionChangeBuilder m_change;
@@ -222,7 +218,7 @@ protected:
     std::vector<DeepChangeChecker::RelatedTable> m_related_tables;
 
     // Due to the keypath filtered notifications we need to update the related tables every time the callbacks do see
-    // a change since the list of related tables is filtered by the key paths used for the notifcations.
+    // a change since the list of related tables is filtered by the key paths used for the notifications.
     bool m_did_modify_callbacks = true;
 
     // Currently registered callbacks and a mutex which must always be held
@@ -255,6 +251,11 @@ private:
     bool m_error = false;
     bool m_has_delivered_root_deletion_event = false;
 
+    // Cached check for if callbacks have keypath filters which can be used
+    // only on the worker thread, but without acquiring the callback mutex
+    bool m_all_callbacks_filtered = false;
+    bool m_any_callbacks_filtered = false;
+
     // All `NotificationCallback`s added to this `CollectionNotifier` via `add_callback()`.
     std::vector<NotificationCallback> m_callbacks;
 
@@ -267,14 +268,14 @@ private:
     // Iteration variable for looping over callbacks. remove_callback() will
     // sometimes update this to ensure that removing a callback while iterating
     // over the callbacks will not skip an unrelated callback.
-    size_t m_callback_index = -1;
+    size_t m_callback_index GUARDED_BY(m_callback_mutex) = -1;
     // The number of callbacks which were present when the notifier was packaged
     // for delivery which are still present.
     // Updated by packaged_for_delivery and remove_callback(), and used in
     // for_each_callback() to avoid calling callbacks registered during delivery.
-    size_t m_callback_count = -1;
+    size_t m_callback_count GUARDED_BY(m_callback_mutex) = -1;
 
-    uint64_t m_next_token = 0;
+    uint64_t m_next_token GUARDED_BY(m_callback_mutex) = 0;
 };
 
 // A smart pointer to a CollectionNotifier that unregisters the notifier when

--- a/src/realm/object-store/impl/list_notifier.cpp
+++ b/src/realm/object-store/impl/list_notifier.cpp
@@ -34,9 +34,6 @@ ListNotifier::ListNotifier(std::shared_ptr<Realm> realm, CollectionBase const& l
     , m_obj(list.get_owner_key())
     , m_prev_size(list.size())
 {
-    if (m_type == PropertyType::Object) {
-        set_table(list.get_target_table());
-    }
 }
 
 void ListNotifier::release_data() noexcept
@@ -71,8 +68,7 @@ bool ListNotifier::do_add_required_change_info(TransactionChangeInfo& info)
     util::CheckedLockGuard lock(m_callback_mutex);
     if (m_did_modify_callbacks && m_type == PropertyType::Object) {
         auto& list = static_cast<LnkLst&>(*m_list);
-        const Table& table = *(list.get_table());
-        update_related_tables(table);
+        update_related_tables(*list.get_table());
     }
 
     return true;

--- a/src/realm/object-store/impl/object_notifier.cpp
+++ b/src/realm/object-store/impl/object_notifier.cpp
@@ -32,12 +32,8 @@ ObjectNotifier::ObjectNotifier(std::shared_ptr<Realm> realm, TableKey table_key,
 
 void ObjectNotifier::do_attach_to(Transaction& sg)
 {
-    try {
-        m_table = sg.get_table(m_table_key);
-    }
-    catch (const NoSuchTable&) {
-        m_table = {};
-    }
+    REALM_ASSERT(m_table_key);
+    m_table = sg.get_table(m_table_key);
 }
 
 bool ObjectNotifier::do_add_required_change_info(TransactionChangeInfo& info)
@@ -64,7 +60,6 @@ void ObjectNotifier::run()
     if (!m_table_key)
         return;
 
-    util::CheckedLockGuard lock(m_callback_mutex);
     if (!m_change.modifications.contains(0) && any_callbacks_filtered()) {
         // If any callback has a key path filter we will check all related tables and if any of them was changed we
         // mark the this object as changed.

--- a/src/realm/object-store/impl/object_notifier.cpp
+++ b/src/realm/object-store/impl/object_notifier.cpp
@@ -40,6 +40,7 @@ bool ObjectNotifier::do_add_required_change_info(TransactionChangeInfo& info)
 {
     if (!m_table_key)
         return false;
+    REALM_ASSERT(m_table);
 
     m_info = &info;
     info.tables[m_table_key.value];
@@ -48,7 +49,6 @@ bool ObjectNotifier::do_add_required_change_info(TransactionChangeInfo& info)
     // when key path filters are set hence we need to recalculate every time the callbacks are changed.
     util::CheckedLockGuard lock(m_callback_mutex);
     if (m_did_modify_callbacks) {
-        REALM_ASSERT(m_table);
         update_related_tables(*m_table);
     }
 
@@ -59,20 +59,24 @@ void ObjectNotifier::run()
 {
     if (!m_table_key)
         return;
+    REALM_ASSERT(m_table);
+
+    auto it = m_info->tables.find(m_table_key.value);
+    if (it != m_info->tables.end() && it->second.deletions_contains(m_obj_key.value)) {
+        // The object was deleted in this set of changes, so report that and
+        // release all of our resources so that we don't do anything further.
+        m_change.deletions.add(0);
+        m_table = {};
+        m_table_key = {};
+        m_obj_key = {};
+        return;
+    }
 
     if (!m_change.modifications.contains(0) && any_callbacks_filtered()) {
         // If any callback has a key path filter we will check all related tables and if any of them was changed we
         // mark the this object as changed.
-        REALM_ASSERT(m_table);
         auto object_change_checker = get_object_modification_checker(*m_info, m_table);
         std::vector<int64_t> changed_columns = object_change_checker(m_obj_key.value);
-
-        if (auto it = m_info->tables.find(m_table_key.value); it != m_info->tables.end()) {
-            const auto& change = it->second;
-            if (object_was_deleted(change)) {
-                return;
-            }
-        }
 
         if (changed_columns.size() > 0) {
             m_change.modifications.add(0);
@@ -85,16 +89,12 @@ void ObjectNotifier::run()
         }
     }
 
-    auto it = m_info->tables.find(m_table_key.value);
     if (it == m_info->tables.end())
         // This object's table is not in the map of changed tables held by `m_info`
         // hence no further details have to be checked.
         return;
 
     const auto& change = it->second;
-    if (object_was_deleted(change)) {
-        return;
-    }
 
     auto column_modifications = change.get_columns_modified(m_obj_key.value);
     if (!column_modifications)
@@ -105,17 +105,4 @@ void ObjectNotifier::run()
     for (auto col : *column_modifications) {
         m_change.columns[col].add(0);
     }
-}
-
-bool ObjectNotifier::object_was_deleted(const ObjectChangeSet& object_change_set)
-{
-    if (object_change_set.deletions_contains(m_obj_key.value)) {
-        // The object was deleted after adding the notifier.
-        m_change.deletions.add(0);
-        m_table = {};
-        m_table_key = {};
-        m_obj_key = {};
-        return true;
-    }
-    return false;
 }

--- a/src/realm/object-store/impl/object_notifier.hpp
+++ b/src/realm/object-store/impl/object_notifier.hpp
@@ -24,9 +24,7 @@
 #include <realm/keys.hpp>
 #include <realm/table.hpp>
 
-namespace realm {
-
-namespace _impl {
+namespace realm::_impl {
 class ObjectNotifier : public CollectionNotifier {
 public:
     ObjectNotifier(std::shared_ptr<Realm> realm, TableKey table_key, ObjKey obj_key);
@@ -42,10 +40,7 @@ private:
     void do_attach_to(Transaction& sg) override;
 
     bool do_add_required_change_info(TransactionChangeInfo& info) override;
-
-    bool object_was_deleted(const ObjectChangeSet& object_change_set);
 };
-} // namespace _impl
-} // namespace realm
+} // namespace realm::_impl
 
 #endif // REALM_OS_OBJECT_NOTIFIER_HPP

--- a/src/realm/object-store/impl/realm_coordinator.cpp
+++ b/src/realm/object-store/impl/realm_coordinator.cpp
@@ -772,7 +772,7 @@ void RealmCoordinator::wait_for_change_release()
     m_db->wait_for_change_release();
 }
 
-// Thread-safety analsys doesn't reasonably handle calling functions on different
+// Thread-safety analysis doesn't reasonably handle calling functions on different
 // instances of this type
 void RealmCoordinator::register_notifier(std::shared_ptr<CollectionNotifier> notifier) NO_THREAD_SAFETY_ANALYSIS
 {
@@ -942,6 +942,7 @@ void RealmCoordinator::run_async_notifiers()
     }
 
     if (!m_notifier_sg) {
+        REALM_ASSERT(m_notifiers.empty());
         REALM_ASSERT(!m_notifier_skip_version.version);
         m_notifier_sg = m_db->start_read();
     }
@@ -1060,7 +1061,10 @@ void RealmCoordinator::run_async_notifiers()
     }
     change_info.advance_to_final(version);
 
-    // Attach the new notifiers to the main SG and move them to the main list
+    // Now that they're at the same version, switch the new notifiers over to
+    // the main Transaction used for background work rather than the temporary one
+    REALM_ASSERT(new_notifiers.empty() || m_notifier_sg->get_version_of_current_transaction() ==
+                                              new_notifier_transaction->get_version_of_current_transaction());
     for (auto& notifier : new_notifiers) {
         notifier->attach_to(m_notifier_sg);
         notifier->run();

--- a/src/realm/object-store/impl/results_notifier.cpp
+++ b/src/realm/object-store/impl/results_notifier.cpp
@@ -63,10 +63,6 @@ ResultsNotifier::ResultsNotifier(Results& target)
     , m_descriptor_ordering(target.get_descriptor_ordering())
     , m_target_is_in_table_order(target.is_in_table_order())
 {
-    auto table = m_query->get_table();
-    if (table) {
-        set_table(table);
-    }
 }
 
 void ResultsNotifier::release_data() noexcept

--- a/src/realm/object-store/impl/results_notifier.hpp
+++ b/src/realm/object-store/impl/results_notifier.hpp
@@ -31,10 +31,16 @@ public:
     using ListIndices = util::Optional<std::vector<size_t>>;
     using CollectionNotifier::CollectionNotifier;
 
+    // If this notifier has up-to-date results, populate the TableView with
+    // those results. Results calls this to avoid rerunning the Query on the
+    // source thread when possible. Returns true if it was able to populate the
+    // TableView, and false if the Results will need to update itself instead.
     virtual bool get_tableview(TableView&)
     {
         return false;
     }
+    // Same as get_tableview(), but for a sorted/distinct list of primitives
+    // instead of a Results of objects.
     virtual bool get_list_indices(ListIndices&)
     {
         return false;

--- a/src/realm/object-store/object_store.cpp
+++ b/src/realm/object-store/object_store.cpp
@@ -204,7 +204,7 @@ void make_property_required(Group& group, Table& table, Property property)
 {
     property.type &= ~PropertyType::Nullable;
     table.remove_column(property.column_key);
-    property.column_key = add_column(group, table, property).value;
+    property.column_key = add_column(group, table, property);
 }
 
 void add_search_index(Table& table, Property property)

--- a/src/realm/query.cpp
+++ b/src/realm/query.cpp
@@ -1004,7 +1004,7 @@ void Query::aggregate(QueryStateBase& st, ColKey column_key, size_t* resultcount
     }
 
     if (return_ndx) {
-        *return_ndx = st.m_minmax_key;
+        *return_ndx = ObjKey(st.m_minmax_key);
     }
 }
 

--- a/src/realm/table.cpp
+++ b/src/realm/table.cpp
@@ -2197,7 +2197,7 @@ int64_t Table::minimum_int(ColKey col_key, ObjKey* return_ndx) const
         aggregate<int64_t>(st, col_key);
     }
     if (return_ndx) {
-        *return_ndx = st.m_minmax_key;
+        *return_ndx = ObjKey(st.m_minmax_key);
     }
     return st.get_min();
 }
@@ -2207,7 +2207,7 @@ float Table::minimum_float(ColKey col_key, ObjKey* return_ndx) const
     QueryStateMin<float> st;
     aggregate<float>(st, col_key);
     if (return_ndx) {
-        *return_ndx = st.m_minmax_key;
+        *return_ndx = ObjKey(st.m_minmax_key);
     }
     return st.get_min();
 }
@@ -2217,7 +2217,7 @@ double Table::minimum_double(ColKey col_key, ObjKey* return_ndx) const
     QueryStateMin<double> st;
     aggregate<double>(st, col_key);
     if (return_ndx) {
-        *return_ndx = st.m_minmax_key;
+        *return_ndx = ObjKey(st.m_minmax_key);
     }
     return st.get_min();
 }
@@ -2227,7 +2227,7 @@ Decimal128 Table::minimum_decimal(ColKey col_key, ObjKey* return_ndx) const
     QueryStateMin<Decimal128> st;
     aggregate<Decimal128>(st, col_key);
     if (return_ndx) {
-        *return_ndx = st.m_minmax_key;
+        *return_ndx = ObjKey(st.m_minmax_key);
     }
     return st.get_min();
 }
@@ -2237,7 +2237,7 @@ Timestamp Table::minimum_timestamp(ColKey col_key, ObjKey* return_ndx) const
     QueryStateMin<Timestamp> st;
     aggregate<Timestamp>(st, col_key);
     if (return_ndx) {
-        *return_ndx = st.m_minmax_key;
+        *return_ndx = ObjKey(st.m_minmax_key);
     }
     return st.get_min();
 }
@@ -2247,7 +2247,7 @@ Mixed Table::minimum_mixed(ColKey col_key, ObjKey* return_ndx) const
     QueryStateMin<Mixed> st;
     aggregate<Mixed>(st, col_key);
     if (return_ndx) {
-        *return_ndx = st.m_minmax_key;
+        *return_ndx = ObjKey(st.m_minmax_key);
     }
     return st.get_min();
 }
@@ -2265,7 +2265,7 @@ int64_t Table::maximum_int(ColKey col_key, ObjKey* return_ndx) const
         aggregate<int64_t>(st, col_key);
     }
     if (return_ndx) {
-        *return_ndx = st.m_minmax_key;
+        *return_ndx = ObjKey(st.m_minmax_key);
     }
     return st.get_max();
 }
@@ -2275,7 +2275,7 @@ float Table::maximum_float(ColKey col_key, ObjKey* return_ndx) const
     QueryStateMax<float> st;
     aggregate<float>(st, col_key);
     if (return_ndx) {
-        *return_ndx = st.m_minmax_key;
+        *return_ndx = ObjKey(st.m_minmax_key);
     }
     return st.get_max();
 }
@@ -2285,7 +2285,7 @@ double Table::maximum_double(ColKey col_key, ObjKey* return_ndx) const
     QueryStateMax<double> st;
     aggregate<double>(st, col_key);
     if (return_ndx) {
-        *return_ndx = st.m_minmax_key;
+        *return_ndx = ObjKey(st.m_minmax_key);
     }
     return st.get_max();
 }
@@ -2311,7 +2311,7 @@ Decimal128 Table::maximum_decimal(ColKey col_key, ObjKey* return_ndx) const
 
     traverse_clusters(f);
     if (return_ndx) {
-        *return_ndx = ret_key;
+        *return_ndx = ObjKey(ret_key);
     }
     return max;
 }
@@ -2321,7 +2321,7 @@ Timestamp Table::maximum_timestamp(ColKey col_key, ObjKey* return_ndx) const
     QueryStateMax<Timestamp> st;
     aggregate<Timestamp>(st, col_key);
     if (return_ndx) {
-        *return_ndx = st.m_minmax_key;
+        *return_ndx = ObjKey(st.m_minmax_key);
     }
     return st.get_max();
 }
@@ -2331,7 +2331,7 @@ Mixed Table::maximum_mixed(ColKey col_key, ObjKey* return_ndx) const
     QueryStateMax<Mixed> st;
     aggregate<Mixed>(st, col_key);
     if (return_ndx) {
-        *return_ndx = st.m_minmax_key;
+        *return_ndx = ObjKey(st.m_minmax_key);
     }
     return st.get_max();
 }

--- a/test/object-store/frozen_objects.cpp
+++ b/test/object-store/frozen_objects.cpp
@@ -211,19 +211,23 @@ TEST_CASE("Freeze Results", "[freeze_results]") {
         const List list = List(frozen_realm, table->get_object(0), int_list_col);
         auto list_results = list.as_results();
 
-        Results frozen_res = list_results.freeze(frozen_realm);
-        JoiningThread thread1([&] {
-            REQUIRE(frozen_res.is_frozen());
-            REQUIRE(frozen_res.size() == 5);
-            REQUIRE(frozen_res.get<Int>(0) == 42);
-        });
+        SECTION("unsorted") {
+            Results frozen_res = list_results.freeze(frozen_realm);
+            JoiningThread thread1([&] {
+                REQUIRE(frozen_res.is_frozen());
+                REQUIRE(frozen_res.size() == 5);
+                REQUIRE(frozen_res.get<Int>(0) == 42);
+            });
+        }
 
-        Results sorted_frozen_res = list.sort({{"self", false}}).freeze(frozen_realm);
-        JoiningThread thread2([&] {
-            REQUIRE(sorted_frozen_res.is_frozen());
-            REQUIRE(sorted_frozen_res.size() == 5);
-            REQUIRE(sorted_frozen_res.get<Int>(0) == 46);
-        });
+        SECTION("sorted") {
+            Results sorted_frozen_res = list.sort({{"self", false}}).freeze(frozen_realm);
+            JoiningThread thread2([&] {
+                REQUIRE(sorted_frozen_res.is_frozen());
+                REQUIRE(sorted_frozen_res.size() == 5);
+                REQUIRE(sorted_frozen_res.get<Int>(0) == 46);
+            });
+        }
     }
 
     SECTION("Result constructor - Dictionary") {

--- a/test/object-store/realm.cpp
+++ b/test/object-store/realm.cpp
@@ -562,6 +562,7 @@ TEST_CASE("Get Realm using Async Open", "[asyncOpen]") {
                 realm_ref = std::move(ref);
             });
             util::EventLoop::main().run_until([&] {
+                std::lock_guard<std::mutex> lock(mutex);
                 return bool(realm_ref);
             });
             SharedRealm realm = Realm::get_shared_realm(std::move(realm_ref));

--- a/test/test_query2.cpp
+++ b/test/test_query2.cpp
@@ -2411,11 +2411,11 @@ TEST(Query_Null_BetweenMinMax_Nullable)
     // becuase 0 rows exist.
     auto test_tv = [&]() {
         // int
-        match = 123;
+        match = ObjKey(123);
         tv.maximum_int(col_price, &match);
         CHECK_EQUAL(match, realm::null_key);
 
-        match = 123;
+        match = ObjKey(123);
         tv.minimum_int(col_price, &match);
         CHECK_EQUAL(match, realm::null_key);
 
@@ -2425,11 +2425,11 @@ TEST(Query_Null_BetweenMinMax_Nullable)
         CHECK_EQUAL(count, 0);
 
         // float
-        match = 123;
+        match = ObjKey(123);
         tv.maximum_float(col_shipping, &match);
         CHECK_EQUAL(match, realm::null_key);
 
-        match = 123;
+        match = ObjKey(123);
         tv.minimum_float(col_shipping, &match);
         CHECK_EQUAL(match, realm::null_key);
 
@@ -2439,11 +2439,11 @@ TEST(Query_Null_BetweenMinMax_Nullable)
         CHECK_EQUAL(count, 0);
 
         // double
-        match = 123;
+        match = ObjKey(123);
         tv.maximum_double(col_rating, &match);
         CHECK_EQUAL(match, realm::null_key);
 
-        match = 123;
+        match = ObjKey(123);
         tv.minimum_double(col_rating, &match);
         CHECK_EQUAL(match, realm::null_key);
 
@@ -2453,11 +2453,11 @@ TEST(Query_Null_BetweenMinMax_Nullable)
         CHECK_EQUAL(count, 0);
 
         // date
-        match = 123;
+        match = ObjKey(123);
         tv.maximum_timestamp(col_date, &match);
         CHECK_EQUAL(match, realm::null_key);
 
-        match = 123;
+        match = ObjKey(123);
         tv.minimum_timestamp(col_date, &match);
         CHECK_EQUAL(match, realm::null_key);
     };

--- a/test/test_table.cpp
+++ b/test/test_table.cpp
@@ -703,38 +703,38 @@ TEST(Table_AggregateFuzz)
         // Test methods on Table
         {
             // Table::max
-            key = 123;
+            key = ObjKey(123);
             f = table->maximum_float(float_col, &key);
             CHECK_EQUAL(key, largest_pos);
             if (largest_pos != null_key)
                 CHECK_EQUAL(f, table->get_object(largest_pos).get<float>(float_col));
 
-            key = 123;
+            key = ObjKey(123);
             i = table->maximum_int(int_col, &key);
             CHECK_EQUAL(key, largest_pos);
             if (largest_pos != null_key)
                 CHECK_EQUAL(i, table->get_object(largest_pos).get<util::Optional<Int>>(int_col));
 
-            key = 123;
+            key = ObjKey(123);
             ts = table->maximum_timestamp(date_col, &key);
             CHECK_EQUAL(key, largest_pos);
             if (largest_pos != null_key)
                 CHECK_EQUAL(ts, table->get_object(largest_pos).get<Timestamp>(date_col));
 
             // Table::min
-            key = 123;
+            key = ObjKey(123);
             f = table->minimum_float(float_col, &key);
             CHECK_EQUAL(key, smallest_pos);
             if (smallest_pos != null_key)
                 CHECK_EQUAL(f, table->get_object(smallest_pos).get<float>(float_col));
 
-            key = 123;
+            key = ObjKey(123);
             i = table->minimum_int(int_col, &key);
             CHECK_EQUAL(key, smallest_pos);
             if (smallest_pos != null_key)
                 CHECK_EQUAL(i, table->get_object(smallest_pos).get<util::Optional<Int>>(int_col));
 
-            key = 123;
+            key = ObjKey(123);
             ts = table->minimum_timestamp(date_col, &key);
             CHECK_EQUAL(key, smallest_pos);
             if (smallest_pos != null_key)
@@ -769,38 +769,38 @@ TEST(Table_AggregateFuzz)
         // Test methods on TableView
         {
             // TableView::max
-            key = 123;
+            key = ObjKey(123);
             f = table->where().find_all().maximum_float(float_col, &key);
             CHECK_EQUAL(key, largest_pos);
             if (largest_pos != null_key)
                 CHECK_EQUAL(f, table->get_object(largest_pos).get<float>(float_col));
 
-            key = 123;
+            key = ObjKey(123);
             i = table->where().find_all().maximum_int(int_col, &key);
             CHECK_EQUAL(key, largest_pos);
             if (largest_pos != null_key)
                 CHECK_EQUAL(i, table->get_object(largest_pos).get<util::Optional<Int>>(int_col));
 
-            key = 123;
+            key = ObjKey(123);
             ts = table->where().find_all().maximum_timestamp(date_col, &key);
             CHECK_EQUAL(key, largest_pos);
             if (largest_pos != null_key)
                 CHECK_EQUAL(ts, table->get_object(largest_pos).get<Timestamp>(date_col));
 
             // TableView::min
-            key = 123;
+            key = ObjKey(123);
             f = table->where().find_all().minimum_float(float_col, &key);
             CHECK_EQUAL(key, smallest_pos);
             if (smallest_pos != null_key)
                 CHECK_EQUAL(f, table->get_object(smallest_pos).get<float>(float_col));
 
-            key = 123;
+            key = ObjKey(123);
             i = table->where().find_all().minimum_int(int_col, &key);
             CHECK_EQUAL(key, smallest_pos);
             if (smallest_pos != null_key)
                 CHECK_EQUAL(i, table->get_object(smallest_pos).get<util::Optional<Int>>(int_col));
 
-            key = 123;
+            key = ObjKey(123);
             ts = table->where().find_all().minimum_timestamp(date_col, &key);
             CHECK_EQUAL(key, smallest_pos);
             if (smallest_pos != null_key)
@@ -810,7 +810,7 @@ TEST(Table_AggregateFuzz)
             double d;
 
             // number of non-null values used in computing the avg or sum
-            key = 123;
+            key = ObjKey(123);
 
             // TableView::avg
             d = table->where().find_all().average_float(float_col, &cnt);
@@ -836,19 +836,19 @@ TEST(Table_AggregateFuzz)
         // Test methods on Query
         {
             // TableView::max
-            key = 123;
+            key = ObjKey(123);
             f = table->where().maximum_float(float_col, &key);
             CHECK_EQUAL(key, largest_pos);
             if (largest_pos != null_key)
                 CHECK_EQUAL(f, table->get_object(largest_pos).get<float>(float_col));
 
-            key = 123;
+            key = ObjKey(123);
             i = table->where().maximum_int(int_col, &key);
             CHECK_EQUAL(key, largest_pos);
             if (largest_pos != null_key)
                 CHECK_EQUAL(i, table->get_object(largest_pos).get<util::Optional<Int>>(int_col));
 
-            key = 123;
+            key = ObjKey(123);
             // Note: Method arguments different from metholds on other column types
             ts = table->where().maximum_timestamp(date_col, &key);
             CHECK_EQUAL(key, largest_pos);
@@ -856,19 +856,19 @@ TEST(Table_AggregateFuzz)
                 CHECK_EQUAL(ts, table->get_object(largest_pos).get<Timestamp>(date_col));
 
             // TableView::min
-            key = 123;
+            key = ObjKey(123);
             f = table->where().minimum_float(float_col, &key);
             CHECK_EQUAL(key, smallest_pos);
             if (smallest_pos != null_key)
                 CHECK_EQUAL(f, table->get_object(smallest_pos).get<float>(float_col));
 
-            key = 123;
+            key = ObjKey(123);
             i = table->where().minimum_int(int_col, &key);
             CHECK_EQUAL(key, smallest_pos);
             if (smallest_pos != null_key)
                 CHECK_EQUAL(i, table->get_object(smallest_pos).get<util::Optional<Int>>(int_col));
 
-            key = 123;
+            key = ObjKey(123);
             // Note: Method arguments different from metholds on other column types
             ts = table->where().minimum_timestamp(date_col, &key);
             CHECK_EQUAL(key, smallest_pos);
@@ -2040,43 +2040,43 @@ TEST(Table_Aggregates3)
         ObjKey pos;
         if (nullable) {
             // max
-            pos = 123;
+            pos = ObjKey(123);
             CHECK_EQUAL(table->maximum_int(col_price), 3);
             CHECK_EQUAL(table->maximum_int(col_price, &pos), 3);
             CHECK_EQUAL(pos, ObjKey(2));
 
-            pos = 123;
+            pos = ObjKey(123);
             CHECK_EQUAL(table->maximum_float(col_shipping), 30.f);
             CHECK_EQUAL(table->maximum_float(col_shipping, &pos), 30.f);
             CHECK_EQUAL(pos, ObjKey(2));
 
-            pos = 123;
+            pos = ObjKey(123);
             CHECK_EQUAL(table->maximum_double(col_rating), 2.2);
             CHECK_EQUAL(table->maximum_double(col_rating, &pos), 2.2);
             CHECK_EQUAL(pos, ObjKey(1));
 
-            pos = 123;
+            pos = ObjKey(123);
             CHECK_EQUAL(table->maximum_timestamp(col_date), Timestamp(6, 6));
             CHECK_EQUAL(table->maximum_timestamp(col_date, &pos), Timestamp(6, 6));
             CHECK_EQUAL(pos, ObjKey(2));
 
             // min
-            pos = 123;
+            pos = ObjKey(123);
             CHECK_EQUAL(table->minimum_int(col_price), 1);
             CHECK_EQUAL(table->minimum_int(col_price, &pos), 1);
             CHECK_EQUAL(pos, ObjKey(0));
 
-            pos = 123;
+            pos = ObjKey(123);
             CHECK_EQUAL(table->minimum_float(col_shipping), 30.f);
             CHECK_EQUAL(table->minimum_float(col_shipping, &pos), 30.f);
             CHECK_EQUAL(pos, ObjKey(2));
 
-            pos = 123;
+            pos = ObjKey(123);
             CHECK_EQUAL(table->minimum_double(col_rating), 1.1);
             CHECK_EQUAL(table->minimum_double(col_rating, &pos), 1.1);
             CHECK_EQUAL(pos, ObjKey(0));
 
-            pos = 123;
+            pos = ObjKey(123);
             CHECK_EQUAL(table->minimum_timestamp(col_date), Timestamp(2, 2));
             CHECK_EQUAL(table->minimum_timestamp(col_date, &pos), Timestamp(2, 2));
             CHECK_EQUAL(pos, ObjKey(0));
@@ -2104,36 +2104,36 @@ TEST(Table_Aggregates3)
         }
         else { // not nullable
             // max
-            pos = 123;
+            pos = ObjKey(123);
             CHECK_EQUAL(table->maximum_int(col_price, &pos), 3);
             CHECK_EQUAL(pos, ObjKey(2));
 
-            pos = 123;
+            pos = ObjKey(123);
             CHECK_EQUAL(table->maximum_float(col_shipping, &pos), 30.f);
             CHECK_EQUAL(pos, ObjKey(2));
 
-            pos = 123;
+            pos = ObjKey(123);
             CHECK_EQUAL(table->maximum_double(col_rating, &pos), 2.2);
             CHECK_EQUAL(pos, ObjKey(1));
 
-            pos = 123;
+            pos = ObjKey(123);
             CHECK_EQUAL(table->maximum_timestamp(col_date, &pos), Timestamp(6, 6));
             CHECK_EQUAL(pos, ObjKey(2));
 
             // min
-            pos = 123;
+            pos = ObjKey(123);
             CHECK_EQUAL(table->minimum_int(col_price, &pos), 0);
             CHECK_EQUAL(pos, ObjKey(1));
 
-            pos = 123;
+            pos = ObjKey(123);
             CHECK_EQUAL(table->minimum_float(col_shipping, &pos), 0.f);
             CHECK_EQUAL(pos, ObjKey(0));
 
-            pos = 123;
+            pos = ObjKey(123);
             CHECK_EQUAL(table->minimum_double(col_rating, &pos), 0.);
             CHECK_EQUAL(pos, ObjKey(2));
 
-            pos = 123;
+            pos = ObjKey(123);
             // Timestamp(0, 0) is default value for non-nullable column
             CHECK_EQUAL(table->minimum_timestamp(col_date, &pos), Timestamp(0, 0));
             CHECK_EQUAL(pos, ObjKey(1));


### PR DESCRIPTION
`m_table_key = {}` calls `TableKey::operator=(uint32_t)` instead of the intended `TableKey::operator=(TableKey)`, which results in it setting `m_table_key` to zero instead of the null value. This then breaks the subsequent checks for `(bool)m_table_key`, as `TableKey(0)` is true. As this is extremely error-prone and that `operator=` appears to never be intentionally used, I fixed this by removing it.

While trying to track this down I also found and fixed a few other things. We were holding the callback lock while doing a significant amount of work on the background thread, which is bad as it can block the main thread. Fixing this just required shuffling around where exactly we access the data from the callbacks a bit. `CollectionNotifier::set_table()` is now kinda redundant and could be removed with some minor tweaks.

Fixes https://github.com/realm/realm-core/issues/4824.