### PR TITLE
Merge Realm::write_copy_without_client_file_id and Realm::write_copy

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,7 @@
 -----------
 
 ### Internals
-* None.
+* Realm::write_copy_without_client_file_id and Realm::write_copy are merged.
 
 ----------------------------------------------
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,7 @@
 -----------
 
 ### Internals
-* Realm::write_copy_without_client_file_id and Realm::write_copy are merged.
+* Realm::write_copy_without_client_file_id and Realm::write_copy are merged. For synchronized realms, the file written will have the client file ident removed. Furthermore it is required that all local changes are synchronized with the server before the copy can. The function will throw if there are pending uploads.
 
 ----------------------------------------------
 

--- a/src/realm/object-store/shared_realm.hpp
+++ b/src/realm/object-store/shared_realm.hpp
@@ -355,7 +355,10 @@ public:
     // WARNING / FIXME: compact() should NOT be exposed publicly on Windows
     // because it's not crash safe! It may corrupt your database if something fails
     bool compact();
-    // For synchronized realms, the file written will have the client file ident removed.
+    // For synchronized realms, the file written will have the client file ident removed. Furthermore
+    // it is required that all local changes are synchronized with the server before the copy can
+    // be written. This is to be sure that the file can be used as a stating point for a newly
+    // installed application. The function will throw if there are pending uploads.
     void write_copy(StringData path, BinaryData encryption_key);
     OwnedBinaryData write_copy();
 

--- a/src/realm/object-store/shared_realm.hpp
+++ b/src/realm/object-store/shared_realm.hpp
@@ -357,7 +357,6 @@ public:
     bool compact();
     // For synchronized realms, the file written will have the client file ident removed.
     void write_copy(StringData path, BinaryData encryption_key);
-    void write_copy_without_client_file_id(StringData path, BinaryData encryption_key, bool allow_overwrite = false);
     OwnedBinaryData write_copy();
 
     void verify_thread() const;

--- a/test/object-store/realm.cpp
+++ b/test/object-store/realm.cpp
@@ -565,7 +565,7 @@ TEST_CASE("Get Realm using Async Open", "[asyncOpen]") {
                 return bool(realm_ref);
             });
             SharedRealm realm = Realm::get_shared_realm(std::move(realm_ref));
-            realm->write_copy_without_client_file_id(config3.path, BinaryData());
+            realm->write_copy(config3.path, BinaryData());
         }
 
         // Create some more content on the server

--- a/test/object-store/realm.cpp
+++ b/test/object-store/realm.cpp
@@ -545,6 +545,7 @@ TEST_CASE("Get Realm using Async Open", "[asyncOpen]") {
         SyncTestFile config3(init_sync_manager.app(), "default");
         config3.schema = config.schema;
         config3.cache = false;
+        uint64_t client_file_id;
 
         // Create some content
         auto origin = Realm::get_shared_realm(config);
@@ -565,6 +566,7 @@ TEST_CASE("Get Realm using Async Open", "[asyncOpen]") {
                 return bool(realm_ref);
             });
             SharedRealm realm = Realm::get_shared_realm(std::move(realm_ref));
+            client_file_id = realm->read_group().get_sync_file_id();
             realm->write_copy(config3.path, BinaryData());
         }
 
@@ -577,6 +579,8 @@ TEST_CASE("Get Realm using Async Open", "[asyncOpen]") {
         // Now open a realm based on the realm file created above
         auto realm = Realm::get_shared_realm(config3);
         wait_for_download(*realm);
+        // Make sure we have got a new client file id
+        REQUIRE(realm->read_group().get_sync_file_id() != client_file_id);
         REQUIRE(realm->read_group().get_table("class_object")->size() == 2);
 
         // Check that we can continue committing to this realm


### PR DESCRIPTION
Ensure we have only one `write_copy` method.
Fixes #4801 

## ☑️ ToDos
* [x] 📝 Changelog update
* [x] 🚦 Tests (or not relevant)
