### PR TITLE
Improve error messages when accessing an invalidated collection object

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 * <How to hit and notice issue? what was the impact?> ([#????](https://github.com/realm/realm-core/issues/????), since v?.?.?)
 * Removing a change callback from a Results would sometimes block the calling thread while the query for that Results was running on the background worker thread (since v11.1.0).
 * Object observers did not handle the object being deleted properly, which could result in assertion failures mentioning "m_table" in ObjectNotifier ([#4824](https://github.com/realm/realm-core/issues/4824), since v11.1.0).
+* Accessing an invalidated dictionary will throw a confusing error message ([#4805](https://github.com/realm/realm-core/issues/4805), since v11.0.0).
  
 ### Breaking changes
 * None.

--- a/src/realm/object-store/collection.cpp
+++ b/src/realm/object-store/collection.cpp
@@ -33,7 +33,10 @@ Collection::OutOfBoundsIndexException::OutOfBoundsIndexException(size_t r, size_
 {
 }
 
-Collection::Collection() noexcept {}
+Collection::Collection(PropertyType type) noexcept
+    : m_type(type)
+{
+}
 
 Collection::Collection(const Object& parent_obj, const Property* prop)
     : m_realm(parent_obj.get_realm())
@@ -121,7 +124,14 @@ void Collection::validate(const Obj& obj) const
 void Collection::verify_attached() const
 {
     if (!is_valid()) {
-        throw InvalidatedException();
+        std::string coll_type = "Collection";
+        if (is_array(m_type))
+            coll_type = "List";
+        else if (is_dictionary(m_type))
+            coll_type = "Dictionary";
+        else if (is_set(m_type))
+            coll_type = "Set";
+        throw InvalidatedException(util::format("Access to invalidated %1 object", coll_type));
     }
 }
 

--- a/src/realm/object-store/collection.hpp
+++ b/src/realm/object-store/collection.hpp
@@ -38,7 +38,7 @@ class ListNotifier;
 namespace object_store {
 class Collection {
 public:
-    Collection() noexcept;
+    Collection(PropertyType type) noexcept;
     Collection(const Object& parent_obj, const Property* prop);
     Collection(std::shared_ptr<Realm> r, const Obj& parent_obj, ColKey col);
     Collection(std::shared_ptr<Realm> r, const CollectionBase& coll);
@@ -48,8 +48,8 @@ public:
     // or the containing object being deleted)
     // All non-noexcept functions can throw this
     struct InvalidatedException : public std::logic_error {
-        InvalidatedException()
-            : std::logic_error("Access to invalidated List object")
+        InvalidatedException(const std::string& msg)
+            : std::logic_error(msg)
         {
         }
     };

--- a/src/realm/object-store/dictionary.hpp
+++ b/src/realm/object-store/dictionary.hpp
@@ -76,6 +76,10 @@ class Dictionary : public object_store::Collection {
 public:
     using Iterator = realm::Dictionary::Iterator;
     using Collection::Collection;
+    Dictionary()
+        : Collection(PropertyType::Dictionary)
+    {
+    }
 
     bool operator==(const Dictionary& rgt) const noexcept;
     bool operator!=(const Dictionary& rgt) const noexcept;

--- a/src/realm/object-store/list.hpp
+++ b/src/realm/object-store/list.hpp
@@ -39,6 +39,10 @@ struct ObjKey;
 class List : public object_store::Collection {
 public:
     using object_store::Collection::Collection;
+    List()
+        : Collection(PropertyType::Array)
+    {
+    }
 
     List(const List&);
     List& operator=(const List&);

--- a/src/realm/object-store/set.hpp
+++ b/src/realm/object-store/set.hpp
@@ -39,6 +39,10 @@ namespace object_store {
 class Set : public Collection {
 public:
     using Collection::Collection;
+    Set()
+        : Collection(PropertyType::Set)
+    {
+    }
 
     Set(const Set&);
     Set& operator=(const Set&);

--- a/test/object-store/dictionary.cpp
+++ b/test/object-store/dictionary.cpp
@@ -160,7 +160,7 @@ TEMPLATE_TEST_CASE("dictionary types", "[dictionary]", cf::MixedVal, cf::Int, cf
     SECTION("verify_attached()") {
         object_store::Dictionary unattached;
         REQUIRE_NOTHROW(dict.verify_attached());
-        REQUIRE_THROWS_AS(unattached.verify_attached(), realm::List::InvalidatedException);
+        REQUIRE_THROWS_WITH(unattached.verify_attached(), "Access to invalidated Dictionary object");
     }
 
     SECTION("verify_in_transaction()") {


### PR DESCRIPTION
The relevant collection type (List, Set, Dictionary) should be included in the
error message.

Fixes #4805 

## ☑️ ToDos
* [x] 📝 Changelog update
* [x] 🚦 Tests (or not relevant)
