### PR TITLE
Reduce number of places to update file format version

### DIFF
--- a/src/realm/group.cpp
+++ b/src/realm/group.cpp
@@ -413,15 +413,13 @@ void Transaction::upgrade_file_format(int target_file_format_version)
     // forget it.
     REALM_ASSERT_EX(target_file_format_version == 22, target_file_format_version);
 
+    // DB::do_open() must ensure that only supported version are allowed.
+    // It does that by asking backup if the current file format version is
+    // included in the accepted versions, so be sure to align the list of
+    // versions with the logic below
+
     int current_file_format_version = get_file_format_version();
     REALM_ASSERT(current_file_format_version < target_file_format_version);
-
-    // DB::do_open() must ensure this. Be sure to revisit the
-    // following upgrade logic when DB::do_open() is changed (or
-    // vice versa).
-    REALM_ASSERT_EX(current_file_format_version >= 5 && current_file_format_version <= 21,
-                    current_file_format_version);
-
 
     // Upgrade from version prior to 7 (new history schema version in top array)
     if (current_file_format_version <= 6 && target_file_format_version >= 7) {

--- a/src/realm/group.hpp
+++ b/src/realm/group.hpp
@@ -229,6 +229,11 @@ public:
 
     size_t size() const noexcept;
 
+    static int get_current_file_format_version()
+    {
+        return g_current_file_format_version;
+    }
+
     int get_history_schema_version() noexcept;
 
     Replication* get_replication() const

--- a/test/test_transactions.cpp
+++ b/test/test_transactions.cpp
@@ -165,9 +165,9 @@ TEST_IF(Transactions_LargeUpgrade, TEST_DURATION > 0)
         util::File f(path, util::File::mode_Update);
         util::File::Map<Header> headerMap(f, util::File::access_ReadWrite);
         auto* header = headerMap.get_addr();
-        // at least one of the versions in the header must be 22.
-        // this is hard coded to current file format version, bump accordingly
-        CHECK(header->m_file_format[1] == 22 || header->m_file_format[0] == 22);
+        auto file_format_version = Group::get_current_file_format_version();
+        // at least one of the versions in the header must be the current version.
+        CHECK(header->m_file_format[1] == file_format_version || header->m_file_format[0] == file_format_version);
         header->m_file_format[1] = header->m_file_format[0] = 11; // downgrade (both) to previous version
         headerMap.sync();
     }


### PR DESCRIPTION
Fixes #4798.

A constant was already used. There is one place where the constant is not used and this is because we want increase the probability that the upgrade logic is updated appropriately to be able to upgrade to the new version. Unit tests will ensure that this is done. The assertion that was able to slip untouched through unit test is removed as it is not that relevant any longer because of the new backup logic.
