### PR TITLE
Include context about what object/changeset caused the exception in InstructionApplier logs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 # NEXT RELEASE
 
 ### Enhancements
-* None.
+* InstructionApplier exceptions now contain information about what object/changeset was being applied when the exception was thrown. ([#4836](https://github.com/realm/realm-core/issues/4836))
 
 ### Fixed
 * <How to hit and notice issue? what was the impact?> ([#????](https://github.com/realm/realm-core/issues/????), since v?.?.?)

--- a/src/realm/sync/instruction_applier.cpp
+++ b/src/realm/sync/instruction_applier.cpp
@@ -18,12 +18,28 @@ REALM_NORETURN void InstructionApplier::bad_transaction_log(const std::string& m
         if (m_last_field_name) {
             field_name = m_last_field_name;
         }
-        m_log->print_path(ss, m_last_table_name, *m_last_object_key, field_name, &(*m_current_path));
+        const instr::Path* cur_path = m_current_path ? &(*m_current_path) : nullptr;
+        m_log->print_path(ss, m_last_table_name, *m_last_object_key, field_name, cur_path);
         throw BadChangesetError{
             util::format("%1 (instruction target: %2, version: %3, last_integrated_remote_version: %4, "
                          "origin_file_ident: %5, timestamp: %6)",
                          msg, ss.str(), m_log->version, m_log->last_integrated_remote_version,
                          m_log->origin_file_ident, m_log->origin_timestamp)};
+    }
+    else if (m_last_table_name) {
+        // We should have a changeset if we have a table name defined.
+        REALM_ASSERT(m_log);
+        throw BadChangesetError{
+            util::format("%1 (instruction table: %2, version: %3, last_integrated_remote_version: %4, "
+                         "origin_file_ident: %5, timestamp: %6)",
+                         msg, m_log->get_string(m_last_table_name), m_log->version,
+                         m_log->last_integrated_remote_version, m_log->origin_file_ident, m_log->origin_timestamp)};
+    } else if (m_log) {
+        // If all we have is a changeset, then we should log whatever we can about it.
+        throw BadChangesetError{util::format("%1 (version: %2, last_integrated_remote_version: %3, "
+                                             "origin_file_ident: %4, timestamp: %5)",
+                                             msg, m_log->version, m_log->last_integrated_remote_version,
+                                             m_log->origin_file_ident, m_log->origin_timestamp)};
     }
     throw BadChangesetError{msg};
 }

--- a/src/realm/sync/instruction_applier.cpp
+++ b/src/realm/sync/instruction_applier.cpp
@@ -8,7 +8,7 @@
 namespace realm::sync {
 namespace {
 
-void throw_bad_transaction_log(std::string msg)
+REALM_NORETURN void throw_bad_transaction_log(std::string msg)
 {
     throw BadChangesetError{std::move(msg)};
 }

--- a/src/realm/sync/instruction_applier.cpp
+++ b/src/realm/sync/instruction_applier.cpp
@@ -34,7 +34,8 @@ REALM_NORETURN void InstructionApplier::bad_transaction_log(const std::string& m
                          "origin_file_ident: %5, timestamp: %6)",
                          msg, m_log->get_string(m_last_table_name), m_log->version,
                          m_log->last_integrated_remote_version, m_log->origin_file_ident, m_log->origin_timestamp)};
-    } else if (m_log) {
+    }
+    else if (m_log) {
         // If all we have is a changeset, then we should log whatever we can about it.
         throw BadChangesetError{util::format("%1 (version: %2, last_integrated_remote_version: %3, "
                                              "origin_file_ident: %4, timestamp: %5)",

--- a/src/realm/sync/instruction_applier.hpp
+++ b/src/realm/sync/instruction_applier.hpp
@@ -149,6 +149,7 @@ inline void InstructionApplier::end_apply() noexcept
     m_last_table = TableRef{};
     m_last_field = ColKey{};
     m_last_object.reset();
+    m_last_object_key.reset();
     m_last_list.reset();
 }
 

--- a/src/realm/sync/instruction_applier.hpp
+++ b/src/realm/sync/instruction_applier.hpp
@@ -84,6 +84,7 @@ private:
     TableRef m_last_table;
     ColKey m_last_field;
     util::Optional<Instruction::PrimaryKey> m_last_object_key;
+    util::Optional<Instruction::Path> m_current_path;
     util::Optional<Obj> m_last_object;
     std::unique_ptr<LstBase> m_last_list;
 
@@ -119,6 +120,10 @@ private:
 
     template <class F>
     void visit_payload(const Instruction::Payload&, F&& visitor);
+
+    REALM_NORETURN void bad_transaction_log(const std::string& msg) const;
+    template <class... Params>
+    REALM_NORETURN void bad_transaction_log(const char* msg, Params&&... params) const;
 };
 
 


### PR DESCRIPTION
This adds information about what table/object/path the current instruction was mutating along with the changeset header information when the InstructionApplier throws an exception.

With this change, errors during download integration will look like:
```
ERROR: Failed to parse, or apply received changeset: ArrayInsert: Invalid prior_size (list size = 1, prior_size = 0) (instruction target: table_name[ObjectId{...}].field_name.path[0].to[0].embedded_field, version: server_verison, last_integrated_remote_version: client_version, origin_file_ident: file_ident, timestamp: changeset timestamp)
```
Instead of
```
ERROR: Failed to parse, or apply received changeset: ArrayInsert: Invalid prior_size (list size = 1, prior_size = 0)
```

## ☑️ ToDos
* [X] 📝 Changelog update
* [N/A] 🚦 Tests (or not relevant)
