### PR TITLE
RCORE-788 Fix prior_size issues when replacing an embedded object in a list

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@
 
 ### Fixed
 * <How to hit and notice issue? what was the impact?> ([#????](https://github.com/realm/realm-core/issues/????), since v?.?.?)
-* None.
+* Fixes prior_size history corruption when replacing an embedded object in a list ([#4845](https://github.com/realm/realm-core/issues/4845))
  
 ### Breaking changes
 * None.

--- a/src/realm/list.cpp
+++ b/src/realm/list.cpp
@@ -371,16 +371,6 @@ Obj LnkLst::create_and_insert_linked_object(size_t ndx)
 Obj LnkLst::create_and_set_linked_object(size_t ndx)
 {
     Table& t = *get_target_table();
-    if (t.is_embedded() && m_list.get(ndx) != ObjKey{}) {
-        // If this is an embedded object and there was already an embedded object here, then we need to
-        // emit an instruction to set the old embedded object to null to clear the old object on other
-        // sync clients. Without this, you'll only see the Set ObjectValue instruction, which is idempotent,
-        // and then array operations will have a corrupted prior_size.
-        auto o = t.create_linked_object();
-        m_list.remove(ndx);
-        m_list.insert(ndx, o.get_key());
-        return o;
-    }
     auto o = t.is_embedded() ? t.create_linked_object() : t.create_object();
     m_list.set(ndx, o.get_key());
     return o;

--- a/src/realm/sync/instruction_replication.cpp
+++ b/src/realm/sync/instruction_replication.cpp
@@ -424,12 +424,31 @@ void SyncReplication::list_set(const CollectionBase& list, size_t ndx, Mixed val
     }
 
     if (select_collection(list)) {
-        Instruction::Update instr;
-        populate_path_instr(instr, list, uint32_t(ndx));
-        REALM_ASSERT(instr.is_array_update());
-        instr.value = as_payload(list, value);
-        instr.prior_size = uint32_t(list.size());
-        emit(instr);
+        // If this is an embedded object then we need to emit and erase/insert instruction so that the old
+        // object gets cleared, otherwise you'll only see the Update ObjectValue instruction, which is idempotent,
+        // and that will lead to corrupted prior size for array operations inside the embedded object during
+        // changeset application.
+        if (value.is_type(type_Link, type_TypedLink) && list.get_target_table()->is_embedded()) {
+            REALM_ASSERT(!list.is_null(ndx));
+            Instruction::ArrayErase erase_instr;
+            populate_path_instr(erase_instr, list, static_cast<uint32_t>(ndx));
+            erase_instr.prior_size = uint32_t(list.size());
+            emit(erase_instr);
+
+            Instruction::ArrayInsert insert_instr;
+            populate_path_instr(insert_instr, list, static_cast<uint32_t>(ndx));
+            insert_instr.prior_size = erase_instr.prior_size - 1 ;
+            insert_instr.value = as_payload(list, value);
+            emit(insert_instr);
+        }
+        else {
+            Instruction::Update instr;
+            populate_path_instr(instr, list, uint32_t(ndx));
+            REALM_ASSERT(instr.is_array_update());
+            instr.value = as_payload(list, value);
+            instr.prior_size = uint32_t(list.size());
+            emit(instr);
+        }
     }
 }
 

--- a/src/realm/sync/instruction_replication.cpp
+++ b/src/realm/sync/instruction_replication.cpp
@@ -14,8 +14,8 @@ SyncReplication::SyncReplication(const std::string& realm_path)
 
 void SyncReplication::initialize(DB& sg)
 {
-    REALM_ASSERT(!m_sg);
-    m_sg = &sg;
+    REALM_ASSERT(!m_db);
+    m_db = &sg;
 }
 
 void SyncReplication::reset()
@@ -428,7 +428,16 @@ void SyncReplication::list_set(const CollectionBase& list, size_t ndx, Mixed val
         // object gets cleared, otherwise you'll only see the Update ObjectValue instruction, which is idempotent,
         // and that will lead to corrupted prior size for array operations inside the embedded object during
         // changeset application.
-        if (value.is_type(type_Link, type_TypedLink) && list.get_target_table()->is_embedded()) {
+        auto needs_insert_erase_sequence = [&] {
+            if (value.is_type(type_Link)) {
+                return list.get_target_table()->is_embedded();
+            }
+            else if (value.is_type(type_TypedLink)) {
+                return m_transaction->get_table(value.get_link().get_table_key())->is_embedded();
+            }
+            return false;
+        };
+        if (needs_insert_erase_sequence()) {
             REALM_ASSERT(!list.is_null(ndx));
             Instruction::ArrayErase erase_instr;
             populate_path_instr(erase_instr, list, static_cast<uint32_t>(ndx));

--- a/src/realm/sync/instruction_replication.cpp
+++ b/src/realm/sync/instruction_replication.cpp
@@ -437,7 +437,7 @@ void SyncReplication::list_set(const CollectionBase& list, size_t ndx, Mixed val
 
             Instruction::ArrayInsert insert_instr;
             populate_path_instr(insert_instr, list, static_cast<uint32_t>(ndx));
-            insert_instr.prior_size = erase_instr.prior_size - 1 ;
+            insert_instr.prior_size = erase_instr.prior_size - 1;
             insert_instr.value = as_payload(list, value);
             emit(insert_instr);
         }

--- a/src/realm/sync/instruction_replication.hpp
+++ b/src/realm/sync/instruction_replication.hpp
@@ -124,7 +124,7 @@ private:
     bool m_short_circuit = false;
 
     ChangesetEncoder m_encoder;
-    DB* m_sg = nullptr;
+    DB* m_db = nullptr;
     Transaction* m_transaction;
 
     // Consistency checks:

--- a/test/object-store/sync/app.cpp
+++ b/test/object-store/sync/app.cpp
@@ -4063,7 +4063,6 @@ TEST_CASE("app: refresh access token unit tests", "[sync][app]") {
                         completion_block({200, 0, {}, user_json(good_access_token).dump()});
                     }
                     else if (request.url.find("/profile") != std::string::npos) {
-
                         CHECK(login_hit);
 
                         auto access_token = request.headers.at("Authorization");

--- a/test/object-store/sync/app.cpp
+++ b/test/object-store/sync/app.cpp
@@ -1750,7 +1750,6 @@ TEST_CASE("app: set new embedded object", "[sync][app]") {
 
     {
         TestSyncManager::Config tsm_config(app_config);
-        tsm_config.verbose_sync_client_logging = true;
         TestSyncManager sync_manager(tsm_config, {});
         auto app = sync_manager.app();
         app->provider_client<App::UsernamePasswordProviderClient>().register_email(


### PR DESCRIPTION
This is similar to RCORE-734, but with lists. If you have a list of embedded objects `a = {b: [{c: [1, 2]}]}` and update them in the sdk like this `a.b[0] = { c: [ 3, 4 ] }`, you'll end up replacing the object at `a.b[0]` without clearing the old one, so any arrays in the sub-object won't be empty when they get updated on other devices.

In RCORE-734 we fixed this by setting the object to null before doing the replacement. We can't set the array element to null, so instead this transforms the Update into an ArrayErase/ArrayInsert.

## ☑️ ToDos
* [x] 📝 Changelog update
* [X] 🚦 Tests (or not relevant)
