### PR TITLE
Add Status/StatusWith/ExceptionForStatus types to represent errors and exceptions for Promise/Future callbacks/results

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,7 +15,7 @@
 -----------
 
 ### Internals
-* None.
+* Added Status/StatusWith types for representing errors/exceptions as values ([#4859](https://github.com/realm/realm-core/issues/4859))
 
 ----------------------------------------------
 

--- a/Package.swift
+++ b/Package.swift
@@ -90,6 +90,7 @@ let notSyncServerSources: [String] = [
     "realm/decimal128.cpp",
     "realm/dictionary.cpp",
     "realm/disable_sync_to_disk.cpp",
+    "relam/error_codes.cpp",
     "realm/exceptions.cpp",
     "realm/global_key.cpp",
     "realm/group.cpp",
@@ -111,6 +112,7 @@ let notSyncServerSources: [String] = [
     "realm/set.cpp",
     "realm/sort_descriptor.cpp",
     "realm/spec.cpp",
+    "realm/status.cpp"
     "realm/string_data.cpp",
     "realm/sync/auth.cpp",
     "realm/sync/changeset.cpp",
@@ -412,6 +414,7 @@ let headers: [String] = [
     "realm/dictionary.hpp",
     "realm/dictionary_cluster_tree.hpp",
     "realm/disable_sync_to_disk.hpp",
+    "realm/error_codes.hpp",
     "realm/exceptions.hpp",
     "realm/exec/importer.hpp",
     "realm/global_key.hpp",
@@ -537,6 +540,8 @@ let headers: [String] = [
     "realm/set.hpp",
     "realm/sort_descriptor.hpp",
     "realm/spec.hpp",
+    "realm/status.hpp",
+    "relam/status_with.hpp"
     "realm/string_data.hpp",
     "realm/sync/access_control.hpp",
     "realm/sync/access_token.hpp",

--- a/Package.swift
+++ b/Package.swift
@@ -90,7 +90,7 @@ let notSyncServerSources: [String] = [
     "realm/decimal128.cpp",
     "realm/dictionary.cpp",
     "realm/disable_sync_to_disk.cpp",
-    "relam/error_codes.cpp",
+    "realm/error_codes.cpp",
     "realm/exceptions.cpp",
     "realm/global_key.cpp",
     "realm/group.cpp",
@@ -112,7 +112,7 @@ let notSyncServerSources: [String] = [
     "realm/set.cpp",
     "realm/sort_descriptor.cpp",
     "realm/spec.cpp",
-    "realm/status.cpp"
+    "realm/status.cpp",
     "realm/string_data.cpp",
     "realm/sync/auth.cpp",
     "realm/sync/changeset.cpp",
@@ -541,7 +541,7 @@ let headers: [String] = [
     "realm/sort_descriptor.hpp",
     "realm/spec.hpp",
     "realm/status.hpp",
-    "relam/status_with.hpp"
+    "relam/status_with.hpp",
     "realm/string_data.hpp",
     "realm/sync/access_control.hpp",
     "realm/sync/access_token.hpp",

--- a/src/realm/CMakeLists.txt
+++ b/src/realm/CMakeLists.txt
@@ -24,6 +24,7 @@ set(REALM_SOURCES
     cluster.cpp
     collection.cpp
     cluster_tree.cpp
+    error_codes.cpp
     table_cluster_tree.cpp
     column_binary.cpp
     decimal128.cpp
@@ -56,6 +57,7 @@ set(REALM_SOURCES
     object_id.cpp
     table_view.cpp
     sort_descriptor.cpp
+    status.cpp
     unicode.cpp
     utilities.cpp
     uuid.cpp
@@ -148,6 +150,7 @@ set(REALM_INSTALL_HEADERS
     dictionary.hpp
     dictionary_cluster_tree.hpp
     disable_sync_to_disk.hpp
+    error_codes.hpp
     exceptions.hpp
     global_key.hpp
     group.hpp
@@ -175,6 +178,7 @@ set(REALM_INSTALL_HEADERS
     set.hpp
     sort_descriptor.hpp
     spec.hpp
+    status.hpp
     string_data.hpp
     table.hpp
     table_cluster_tree.hpp

--- a/src/realm/error_codes.cpp
+++ b/src/realm/error_codes.cpp
@@ -1,0 +1,40 @@
+/*************************************************************************
+ *
+ * Copyright 2021 Realm Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ **************************************************************************/
+
+#include "realm/error_codes.hpp"
+
+namespace realm {
+
+StringData ErrorCodes::error_string(Error code)
+{
+    switch (code) {
+        case ErrorCodes::OK:
+            return "OK";
+        case ErrorCodes::RuntimeError:
+            return "RuntimeError";
+        case ErrorCodes::LogicErorr:
+            return "LogicError";
+        case ErrorCodes::BrokenPromise:
+            return "BrokenPromise";
+        case ErrorCodes::UnknownError:
+        default:
+            return "UnknownError";
+    }
+}
+
+} // namespace realm

--- a/src/realm/error_codes.cpp
+++ b/src/realm/error_codes.cpp
@@ -27,7 +27,7 @@ StringData ErrorCodes::error_string(Error code)
             return "OK";
         case ErrorCodes::RuntimeError:
             return "RuntimeError";
-        case ErrorCodes::LogicErorr:
+        case ErrorCodes::LogicError:
             return "LogicError";
         case ErrorCodes::BrokenPromise:
             return "BrokenPromise";

--- a/src/realm/error_codes.hpp
+++ b/src/realm/error_codes.hpp
@@ -33,7 +33,7 @@ public:
         OK = 0,
         UnknownError = 1,
         RuntimeError = 2,
-        LogicErorr = 3,
+        LogicError = 3,
         BrokenPromise = 4,
     };
 

--- a/src/realm/error_codes.hpp
+++ b/src/realm/error_codes.hpp
@@ -1,0 +1,43 @@
+/*************************************************************************
+ *
+ * Copyright 2021 Realm Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ **************************************************************************/
+
+#pragma once
+
+#include <realm/string_data.hpp>
+
+namespace realm {
+
+/*
+ * TODO As part of RCORE-720, we'll move all the exception types and error codes we want to expose in the
+ * public API here so that each one has a unique error code. For now though, this is here to complete the
+ * API of Status/StatusWith.
+ */
+class ErrorCodes {
+public:
+    enum Error : int32_t {
+        OK = 0,
+        UnknownError = 1,
+        RuntimeError = 2,
+        LogicErorr = 3,
+        BrokenPromise = 4,
+    };
+
+    static StringData error_string(Error code);
+};
+
+} // namespace realm

--- a/src/realm/status.cpp
+++ b/src/realm/status.cpp
@@ -43,17 +43,10 @@ Status::Status(ErrorCodes::Error code, const char* reason)
 }
 
 Status::ErrorInfo::ErrorInfo(ErrorCodes::Error code, StringData reason)
-    : m_code(code)
+    : m_refs(0)
+    , m_code(code)
     , m_reason(reason)
 {
-}
-
-uint32_t Status::ref_count_for_testing() const noexcept
-{
-    if (!m_error) {
-        return 0;
-    }
-    return m_error->m_refs.load(std::memory_order_relaxed);
 }
 
 util::bind_ptr<Status::ErrorInfo> Status::ErrorInfo::create(ErrorCodes::Error code, StringData reason)

--- a/src/realm/status.cpp
+++ b/src/realm/status.cpp
@@ -1,0 +1,87 @@
+/*************************************************************************
+ *
+ * Copyright 2021 Realm Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ **************************************************************************/
+
+#include "realm/status.hpp"
+
+#include "realm/util/demangle.hpp"
+
+#include <iostream>
+
+namespace realm {
+
+Status::Status(ErrorCodes::Error code, StringData reason)
+    : m_error(ErrorInfo::create(code, reason))
+{
+    // OK status should be created by calling Status::OK() - which is a special case that doesn't allocate
+    // anything.
+    REALM_ASSERT(code != ErrorCodes::OK);
+}
+
+Status::Status(ErrorCodes::Error code, const std::string& reason)
+    : Status(code, StringData(reason))
+{
+}
+
+Status::Status(ErrorCodes::Error code, const char* reason)
+    : Status(code, StringData(reason, std::char_traits<char>::length(reason)))
+{
+}
+
+Status::ErrorInfo::ErrorInfo(ErrorCodes::Error code, StringData reason)
+    : m_code(code)
+    , m_reason(reason)
+{
+}
+
+uint32_t Status::ref_count_for_testing() const noexcept
+{
+    if (!m_error) {
+        return 0;
+    }
+    return m_error->m_refs.load(std::memory_order_relaxed);
+}
+
+util::bind_ptr<Status::ErrorInfo> Status::ErrorInfo::create(ErrorCodes::Error code, StringData reason)
+{
+    return util::bind_ptr<Status::ErrorInfo>(new ErrorInfo(code, reason));
+}
+
+std::ostream& operator<<(std::ostream& out, const Status& val)
+{
+    out << val.code_string() << ": " << val.reason();
+    return out;
+}
+
+Status exception_to_status() noexcept
+{
+    try {
+        throw;
+    }
+    catch (const ExceptionForStatus& e) {
+        return e.to_status();
+    }
+    catch (const std::exception& e) {
+        return Status(ErrorCodes::UnknownError,
+                      util::format("Caught std::exception of type %1: %2", util::get_type_name(e), e.what()));
+    }
+    catch (...) {
+        REALM_UNREACHABLE();
+    }
+}
+
+} // namespace realm

--- a/src/realm/status.hpp
+++ b/src/realm/status.hpp
@@ -64,8 +64,6 @@ public:
      */
     void ignore() const noexcept {}
 
-    uint32_t ref_count_for_testing() const noexcept;
-
 private:
     Status() = default;
 
@@ -80,14 +78,14 @@ private:
         template <typename>
         friend class ::realm::util::bind_ptr;
 
-        void bind_ptr() const noexcept
+        inline void bind_ptr() const noexcept
         {
             m_refs.fetch_add(1, std::memory_order_relaxed);
         }
 
-        void unbind_ptr() const noexcept
+        inline void unbind_ptr() const noexcept
         {
-            if (m_refs.fetch_sub(1, std::memory_order_acq_rel) == 0) {
+            if (m_refs.fetch_sub(1, std::memory_order_acq_rel) == 1) {
                 delete this;
             }
         }

--- a/src/realm/status.hpp
+++ b/src/realm/status.hpp
@@ -30,7 +30,7 @@
 
 namespace realm {
 
-class REALM_NODISCARD Status {
+class [[nodiscard]] Status {
 public:
     /*
      * This is the best way to construct a Status that represents a non-error condition.

--- a/src/realm/status.hpp
+++ b/src/realm/status.hpp
@@ -1,0 +1,223 @@
+/*************************************************************************
+ *
+ * Copyright 2021 Realm Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ **************************************************************************/
+
+#pragma once
+
+#include <atomic>
+#include <cstdint>
+#include <iosfwd>
+#include <string>
+
+#include "realm/error_codes.hpp"
+#include "realm/string_data.hpp"
+#include "realm/util/bind_ptr.hpp"
+#include "realm/util/features.h"
+
+namespace realm {
+
+class REALM_NODISCARD Status {
+public:
+    /*
+     * This is the best way to construct a Status that represents a non-error condition.
+     */
+    static inline Status OK();
+
+    /*
+     * You can construct a Status from a strings, C strings, and StringData's.
+     */
+    Status(ErrorCodes::Error code, StringData reason);
+    Status(ErrorCodes::Error code, const std::string& reason);
+    Status(ErrorCodes::Error code, const char* reason);
+
+    /*
+     * Copying a Status is just copying an intrusive pointer - i.e. very cheap. Moving them is similarly cheap.
+     */
+    inline Status(const Status& other);
+    inline Status& operator=(const Status& other);
+
+    inline Status(Status&& other) noexcept;
+    inline Status& operator=(Status&& other) noexcept;
+
+    inline bool is_ok() const noexcept;
+    inline const std::string& reason() const noexcept;
+    inline ErrorCodes::Error code() const noexcept;
+    inline StringData code_string() const noexcept;
+
+    /*
+     * This class is marked nodiscard so that we always handle errors. If there is a place where we need
+     * to explicitly ignore an error, you can call this function, which does nothing, to satisfy the compiler.
+     */
+    void ignore() const noexcept {}
+
+    uint32_t ref_count_for_testing() const noexcept;
+
+private:
+    Status() = default;
+
+    struct ErrorInfo {
+        mutable std::atomic<uint32_t> m_refs;
+        const ErrorCodes::Error m_code;
+        const std::string m_reason;
+
+        static util::bind_ptr<ErrorInfo> create(ErrorCodes::Error code, StringData reason);
+
+    protected:
+        template <typename>
+        friend class ::realm::util::bind_ptr;
+
+        void bind_ptr() const noexcept
+        {
+            m_refs.fetch_add(1, std::memory_order_relaxed);
+        }
+
+        void unbind_ptr() const noexcept
+        {
+            if (m_refs.fetch_sub(1, std::memory_order_acq_rel) == 0) {
+                delete this;
+            }
+        }
+
+    private:
+        ErrorInfo(ErrorCodes::Error code, StringData reason);
+    };
+
+    util::bind_ptr<ErrorInfo> m_error = {};
+};
+
+class ExceptionForStatus : public std::exception {
+public:
+    const char* what() const noexcept final
+    {
+        return reason().c_str();
+    }
+
+    const Status& to_status() const
+    {
+        return m_status;
+    }
+
+    const std::string& reason() const noexcept
+    {
+        return m_status.reason();
+    }
+
+    ErrorCodes::Error code() const noexcept
+    {
+        return m_status.code();
+    }
+
+    StringData code_string() const noexcept
+    {
+        return m_status.code_string();
+    }
+
+    ExceptionForStatus(ErrorCodes::Error err, StringData str)
+        : m_status(err, str)
+    {
+    }
+
+    explicit ExceptionForStatus(Status status)
+        : m_status(std::move(status))
+    {
+    }
+
+private:
+    Status m_status;
+};
+
+/*
+ * This will convert an exception in a catch(...) block into a Status. For ExceptionForStatus's, it returns the
+ * status held in the exception directly. Otherwise it returns a status with an UnknownError error code and a
+ * reason string holding the exception type and message.
+ *
+ * Currently this works for exceptions that derive from std::exception or ExceptionForStatus only.
+ */
+Status exception_to_status() noexcept;
+
+std::ostream& operator<<(std::ostream& out, const Status& val);
+
+inline bool operator==(const Status& lhs, const Status& rhs) noexcept
+{
+    return lhs.code() == rhs.code();
+}
+
+inline bool operator!=(const Status& lhs, const Status& rhs) noexcept
+{
+    return lhs.code() != rhs.code();
+}
+
+inline bool operator==(const Status& lhs, ErrorCodes::Error rhs) noexcept
+{
+    return lhs.code() == rhs;
+}
+
+inline bool operator!=(const Status& lhs, ErrorCodes::Error rhs) noexcept
+{
+    return lhs.code() != rhs;
+}
+
+inline Status Status::OK()
+{
+    // Returns a status with m_error set to nullptr.
+    return Status{};
+}
+
+inline Status::Status(const Status& other)
+    : m_error(other.m_error)
+{
+}
+
+inline Status& Status::operator=(const Status& other)
+{
+    m_error = other.m_error;
+    return *this;
+}
+
+inline Status::Status(Status&& other) noexcept
+    : m_error(std::move(other.m_error))
+{
+}
+
+inline Status& Status::operator=(Status&& other) noexcept
+{
+    m_error = std::move(other.m_error);
+    return *this;
+}
+
+inline bool Status::is_ok() const noexcept
+{
+    return !m_error;
+}
+
+inline const std::string& Status::reason() const noexcept
+{
+    static const std::string empty;
+    return m_error ? m_error->m_reason : empty;
+}
+
+inline ErrorCodes::Error Status::code() const noexcept
+{
+    return m_error ? m_error->m_code : ErrorCodes::OK;
+}
+
+inline StringData Status::code_string() const noexcept
+{
+    return ErrorCodes::error_string(code());
+}
+
+} // namespace realm

--- a/src/realm/status.hpp
+++ b/src/realm/status.hpp
@@ -38,7 +38,7 @@ public:
     static inline Status OK();
 
     /*
-     * You can construct a Status from a strings, C strings, and StringData's.
+     * You can construct a Status from strings, C strings, and StringData's.
      */
     Status(ErrorCodes::Error code, StringData reason);
     Status(ErrorCodes::Error code, const std::string& reason);

--- a/src/realm/status_with.hpp
+++ b/src/realm/status_with.hpp
@@ -1,0 +1,220 @@
+/*************************************************************************
+ *
+ * Copyright 2021 Realm Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ **************************************************************************/
+
+#pragma once
+
+#include <type_traits>
+
+#include "realm/status.hpp"
+#include "realm/util/assert.hpp"
+#include "realm/util/features.h"
+#include "realm/util/optional.hpp"
+
+namespace realm {
+
+template <typename T>
+class StatusWith;
+
+template <typename T>
+constexpr bool is_status_with = false;
+template <typename T>
+constexpr bool is_status_with<StatusWith<T>> = true;
+
+template <typename T>
+constexpr bool is_status_or_status_with = std::is_same_v<T, ::realm::Status> || is_status_with<T>;
+
+template <typename T>
+using StatusOrStatusWith = std::conditional_t<std::is_void_v<T>, Status, StatusWith<T>>;
+
+/**
+ * StatusWith is used to return an error or a value.
+ * This class is designed to make exception-free code cleaner by not needing as many out
+ * parameters.
+ *
+ * Example:
+ * StatusWith<int> fib( int n ) {
+ *   if ( n < 0 )
+ *       return StatusWith<int>( ErrorCodes::BadValue, "parameter to fib has to be >= 0" );
+ *   if ( n <= 1 ) return StatusWith<int>( 1 );
+ *   StatusWith<int> a = fib( n - 1 );
+ *   StatusWith<int> b = fib( n - 2 );
+ *   if ( !a.isOK() ) return a;
+ *   if ( !b.isOK() ) return b;
+ *   return StatusWith<int>( a.getValue() + b.getValue() );
+ * }
+ */
+template <typename T>
+class REALM_NODISCARD StatusWith {
+    static_assert(!is_status_or_status_with<T>, "StatusWith<Status> and StatusWith<StatusWith<T>> are banned.");
+
+public:
+    using value_type = T;
+
+    StatusWith(ErrorCodes::Error code, StringData reason)
+        : m_status(code, reason)
+    {
+    }
+
+    StatusWith(ErrorCodes::Error code, const std::string& reason)
+        : m_status(code, reason)
+    {
+    }
+
+    StatusWith(ErrorCodes::Error code, const char* reason)
+        : m_status(code, reason)
+    {
+    }
+
+    StatusWith(Status status)
+        : m_status(std::move(status))
+    {
+    }
+
+    StatusWith(T value)
+        : m_status(Status::OK())
+        , m_value(std::move(value))
+    {
+    }
+
+    bool is_ok() const
+    {
+        return m_status.is_ok();
+    }
+
+    const T& get_value() const
+    {
+        REALM_ASSERT_DEBUG(is_ok());
+        return *m_value;
+    }
+
+    T& get_value()
+    {
+        REALM_ASSERT_DEBUG(is_ok());
+        return *m_value;
+    }
+
+    const Status& get_status() const
+    {
+        return m_status;
+    }
+
+private:
+    Status m_status;
+    util::Optional<T> m_value;
+};
+
+template <typename T, typename... Args>
+StatusWith<T> make_status_with(Args&&... args)
+{
+    return StatusWith<T>{T(std::forward<Args>(args)...)};
+}
+
+template <typename T>
+auto operator<<(std::ostream& stream, const StatusWith<T>& sw)
+    -> decltype(stream << sw.get_value()) // SFINAE on T streamability.
+{
+    if (sw.is_ok())
+        return stream << sw.get_value();
+    return stream << sw.get_status();
+}
+
+//
+// EqualityComparable(StatusWith<T>, T). Intentionally not providing an ordering relation.
+//
+
+template <typename T>
+bool operator==(const StatusWith<T>& sw, const T& val)
+{
+    return sw.is_ok() && sw.get_value() == val;
+}
+
+template <typename T>
+bool operator==(const T& val, const StatusWith<T>& sw)
+{
+    return sw.is_ok() && val == sw.get_value();
+}
+
+template <typename T>
+bool operator!=(const StatusWith<T>& sw, const T& val)
+{
+    return !(sw == val);
+}
+
+template <typename T>
+bool operator!=(const T& val, const StatusWith<T>& sw)
+{
+    return !(val == sw);
+}
+
+//
+// EqualityComparable(StatusWith<T>, Status)
+//
+
+template <typename T>
+bool operator==(const StatusWith<T>& sw, const Status& status)
+{
+    return sw.get_status() == status;
+}
+
+template <typename T>
+bool operator==(const Status& status, const StatusWith<T>& sw)
+{
+    return status == sw.get_status();
+}
+
+template <typename T>
+bool operator!=(const StatusWith<T>& sw, const Status& status)
+{
+    return !(sw == status);
+}
+
+template <typename T>
+bool operator!=(const Status& status, const StatusWith<T>& sw)
+{
+    return !(status == sw);
+}
+
+//
+// EqualityComparable(StatusWith<T>, ErrorCode)
+//
+
+template <typename T>
+bool operator==(const StatusWith<T>& sw, const ErrorCodes::Error code)
+{
+    return sw.get_status() == code;
+}
+
+template <typename T>
+bool operator==(const ErrorCodes::Error code, const StatusWith<T>& sw)
+{
+    return code == sw.get_status();
+}
+
+template <typename T>
+bool operator!=(const StatusWith<T>& sw, const ErrorCodes::Error code)
+{
+    return !(sw == code);
+}
+
+template <typename T>
+bool operator!=(const ErrorCodes::Error code, const StatusWith<T>& sw)
+{
+    return !(code == sw);
+}
+
+} // namespace realm

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -63,6 +63,7 @@ set(CORE_TEST_SOURCES
     test_safe_int_ops.cpp
     test_self.cpp
     test_shared.cpp
+    test_status.cpp
     test_string_data.cpp
     test_table_view.cpp
     test_thread.cpp

--- a/test/test_status.cpp
+++ b/test/test_status.cpp
@@ -40,7 +40,7 @@ TEST(Status)
 
     CHECK_NOT_EQUAL(ok_status, err_status);
     CHECK_EQUAL(err_status, Status(ErrorCodes::RuntimeError, "runtime error 2"));
-    CHECK_NOT_EQUAL(err_status, Status(ErrorCodes::LogicErorr, "logic error"));
+    CHECK_NOT_EQUAL(err_status, Status(ErrorCodes::LogicError, "logic error"));
 
     auto caught_status = Status::OK();
     try {

--- a/test/test_status.cpp
+++ b/test/test_status.cpp
@@ -1,0 +1,71 @@
+/*************************************************************************
+ *
+ * Copyright 2021 Realm Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ **************************************************************************/
+
+#include "test.hpp"
+
+#include "realm/status.hpp"
+
+namespace realm {
+namespace {
+
+TEST(Status)
+{
+    auto ok_status = Status::OK();
+    CHECK_EQUAL(ok_status.code(), ErrorCodes::OK);
+    CHECK(ok_status.is_ok());
+    CHECK_EQUAL(ok_status.code_string(), ErrorCodes::error_string(ok_status.code()));
+    CHECK(ok_status.reason().empty());
+
+    const auto err_status_reason = "runtime error 1";
+    auto err_status = Status(ErrorCodes::RuntimeError, err_status_reason);
+    CHECK_EQUAL(err_status.code(), ErrorCodes::RuntimeError);
+    CHECK(!err_status.is_ok());
+    CHECK_EQUAL(err_status.code_string(), ErrorCodes::error_string(err_status.code()));
+    CHECK_EQUAL(err_status.reason(), err_status_reason);
+
+    CHECK_NOT_EQUAL(ok_status, err_status);
+    CHECK_EQUAL(err_status, Status(ErrorCodes::RuntimeError, "runtime error 2"));
+    CHECK_NOT_EQUAL(err_status, Status(ErrorCodes::LogicErorr, "logic error"));
+
+    auto caught_status = Status::OK();
+    try {
+        throw ExceptionForStatus(err_status);
+    }
+    catch (...) {
+        caught_status = exception_to_status();
+    }
+
+    CHECK_EQUAL(caught_status, err_status);
+
+    struct ExoticError : public std::runtime_error {
+        using std::runtime_error::runtime_error;
+    };
+
+    const auto exotic_error_reason = "serious error";
+    try {
+        throw ExoticError(exotic_error_reason);
+    }
+    catch (...) {
+        caught_status = exception_to_status();
+    }
+    CHECK_EQUAL(caught_status, ErrorCodes::UnknownError);
+    CHECK_NOT_EQUAL(caught_status.reason().find(exotic_error_reason), std::string::npos);
+}
+
+} // namespace
+} // namespace realm


### PR DESCRIPTION
This ports the Status/StatusWith types from the MongoDB server codebase into realm. Status is a type that represents an error - or the lack-thereof - with an error code and an error message. This is just the initial implementation. There are some features that I are missing and I've kept the error codes both manually defined (in Mongo they're generated from a YAML file) and minimal until we can tackle the "Unify Error Handling" project. For now, this is enough for porting the Promise/Future libraries.

If you want to see what these look like in the Mongo codebase, they're in https://github.com/mongodb/mongo/blob/master/src/mongo/base/status.h and https://github.com/mongodb/mongo/blob/master/src/mongo/base/status_with.h.

## ☑️ ToDos
* [x] 📝 Changelog update
* [x] 🚦 Tests (or not relevant)
