### PR TITLE
Check if the Realm folder exists before using the lock file.

### DIFF
--- a/src/realm/object-store/shared_realm.cpp
+++ b/src/realm/object-store/shared_realm.cpp
@@ -906,20 +906,17 @@ void Realm::close()
 
 void Realm::delete_files(const std::string& realm_file_path, bool* did_delete_realm)
 {
-    try {
-        auto lock_successful = DB::call_with_lock(realm_file_path, [=](auto const& path) {
-            DB::delete_files(path, did_delete_realm);
-        });
-        if (!lock_successful) {
-            throw DeleteOnOpenRealmException(realm_file_path);
-        }
-    }
-    catch (const util::File::NotFound&) {
-        // Thrown only if the parent directory of the lock file does not exist,
-        // which obviously indicates that we didn't need to delete anything
+    if (!util::File::exists(realm_file_path)) {
         if (did_delete_realm) {
             *did_delete_realm = false;
         }
+        return;
+    }
+    auto lock_successful = DB::call_with_lock(realm_file_path, [=](auto const& path) {
+        DB::delete_files(path, did_delete_realm);
+    });
+    if (!lock_successful) {
+        throw DeleteOnOpenRealmException(realm_file_path);
     }
 }
 

--- a/test/object-store/realm.cpp
+++ b/test/object-store/realm.cpp
@@ -1062,7 +1062,9 @@ TEST_CASE("Realm::delete_files()") {
 
     SECTION("Calling delete on a folder that does not exist.") {
         auto fake_path = "/tmp/doesNotExist/realm.424242";
-        Realm::delete_files(fake_path);
+        bool did_delete = false;
+        Realm::delete_files(fake_path, &did_delete);
+        REQUIRE_FALSE(did_delete);
     }
 
     SECTION("passing did_delete is optional") {


### PR DESCRIPTION
When deleting a Realm we catch a `File::NotFound` exception in case the folder does not exist, see https://github.com/realm/realm-core/blob/master/src/realm/object-store/shared_realm.cpp#L917-L923 (added with https://github.com/realm/realm-core/pull/4771).

Unfortunately this check is not sufficient on Windows and crashes when trying to access the lock file (see https://ci.realm.io/blue/organizations/jenkins/realm%2Frealm-dotnet/detail/PR-2558/1/tests for example).

It couldn't have been caught earlier since the OS tests are *not* run on Windows. It only surfaced when run through the .NET CI with a similar check on the SDK level (see https://github.com/realm/realm-dotnet/blob/master/Tests/Realm.Tests/Database/InstanceTests.cs#L96-L105).

## ☑️ ToDos
* [ ] 📝 Changelog update
* [X] 🚦 Tests (or not relevant) -> There are no relevant test changes for my code changes in Core because of above mentioned reasons (it failed already, but only on Windows). The above mentioned .NET test serves as the relevant test for this change until the Core CI runs on Windows as well.
I did, however, add a check for the `did_delete` flag to the non-existing folder test (which is unrelated to the code changes though).
