### PR TITLE
RCORE-807 ApplyToState tool should fail if download integration fails

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@
 
 ### Internals
 * Added Status/StatusWith types for representing errors/exceptions as values ([#4859](https://github.com/realm/realm-core/issues/4859))
+* ApplyToState tool now exits with a non-zero exit code if download message application fails.
 
 ----------------------------------------------
 

--- a/src/realm/sync/apply_to_state_command.cpp
+++ b/src/realm/sync/apply_to_state_command.cpp
@@ -364,10 +364,13 @@ int main(int argc, const char** argv)
                          [&](const DownloadMessage& download_message) {
                              realm::sync::VersionInfo version_info;
                              realm::sync::ClientReplication::IntegrationError integration_error;
-                             history.integrate_server_changesets(
-                                 download_message.progress, &download_message.downloadable_bytes,
-                                 download_message.changesets.data(), download_message.changesets.size(), version_info,
-                                 integration_error, *logger, nullptr);
+                             if (!history.integrate_server_changesets(
+                                     download_message.progress, &download_message.downloadable_bytes,
+                                     download_message.changesets.data(), download_message.changesets.size(),
+                                     version_info, integration_error, *logger, nullptr)) {
+                                 logger->error("Error applying download message to realm");
+                                 return EXIT_FAILURE;
+                             }
                          },
                          [&](const UploadMessage& upload_message) {
                              for (const auto& changeset : upload_message.changesets) {

--- a/src/realm/sync/apply_to_state_command.cpp
+++ b/src/realm/sync/apply_to_state_command.cpp
@@ -360,6 +360,7 @@ int main(int argc, const char** argv)
         }
 
         input_view = message.second;
+        bool download_integration_failed = false;
         mpark::visit(realm::util::overload{
                          [&](const DownloadMessage& download_message) {
                              realm::sync::VersionInfo version_info;
@@ -369,7 +370,7 @@ int main(int argc, const char** argv)
                                      download_message.changesets.data(), download_message.changesets.size(),
                                      version_info, integration_error, *logger, nullptr)) {
                                  logger->error("Error applying download message to realm");
-                                 return EXIT_FAILURE;
+                                 download_integration_failed = true;
                              }
                          },
                          [&](const UploadMessage& upload_message) {
@@ -389,6 +390,9 @@ int main(int argc, const char** argv)
                              history.set_client_file_ident(ident_message.file_ident, true);
                          }},
                      message.first);
+        if (download_integration_failed) {
+            return EXIT_FAILURE;
+        }
     }
 
     return EXIT_SUCCESS;


### PR DESCRIPTION
This fixes an internal command-line tool that applies wire protocol messages to a local realm so that it fails with a bad exit code if download message integration fails

## ☑️ ToDos
* [x] 📝 Changelog update
* [ ] 🚦 Tests (or not relevant)
