### PR TITLE
Use correct protocol error code for 401/403 on token refresh

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,8 +7,8 @@
 
 ### Fixed
 * <How to hit and notice issue? what was the impact?> ([#????](https://github.com/realm/realm-core/issues/????), since v?.?.?)
-* None.
- 
+* Failing to refresh the access token due to a 401/403 error will now correctly emit a sync error with `ProtocolError::bad_authentication` rather than `ProtocolError::permission_denied`. ([#4881](https://github.com/realm/realm-core/pull/4881), since 11.0.4)
+
 ### Breaking changes
 * None.
 

--- a/src/realm/object-store/sync/sync_session.cpp
+++ b/src/realm/object-store/sync/sync_session.cpp
@@ -395,7 +395,7 @@ std::function<void(util::Optional<app::AppError>)> SyncSession::handle_refresh(s
                     session_user->log_out();
                 }
                 if (session->m_config.error_handler) {
-                    auto user_facing_error = SyncError(realm::sync::ProtocolError::permission_denied,
+                    auto user_facing_error = SyncError(realm::sync::ProtocolError::bad_authentication,
                                                        "Unable to refresh the user access token.", true);
                     session->m_config.error_handler(session, user_facing_error);
                 }

--- a/test/object-store/sync/app.cpp
+++ b/test/object-store/sync/app.cpp
@@ -1972,7 +1972,7 @@ TEST_CASE("app: sync integration", "[sync][app]") {
             std::atomic<bool> sync_error_handler_called{false};
             config.sync_config->error_handler = [&](std::shared_ptr<SyncSession>, SyncError error) {
                 sync_error_handler_called.store(true);
-                REQUIRE(error.error_code == sync::make_error_code(realm::sync::ProtocolError::permission_denied));
+                REQUIRE(error.error_code == sync::make_error_code(realm::sync::ProtocolError::bad_authentication));
                 REQUIRE(error.message == "Unable to refresh the user access token.");
             };
 


### PR DESCRIPTION
<!--
 Make sure to assign one and only one Type (`T:`) label.
 Select reviewers if ready for review. Our bot will automatically assign you.
 -->

## What, How & Why?
When receiving a 401/403 response on token refresh, we would create a fake `SyncError` with protocol error: `permission_denied`. This was incorrect as the SDKs would then expect the `user_info` dictionary to contain the path to the original file - see: https://github.com/realm/realm-core/blob/62527a1296a283f2b5ca6c7fde3454297acbedd6/src/realm/object-store/sync/sync_session.cpp#L446-L451

There would also be an expectation that a file where permissions have been denied would be deleted, which is neither the case, nor the intention of our code handling the 401 response. I've replaced the protocol error with `bad_authentication` because it better reflects reality and there's no special handling for this particular error code by SDKs.

@ironage I have updated the only test I could find that was verifying the error code, but if you think we can/should write more tests, let me know. 

## ☑️ ToDos
* [x] 📝 Changelog update
* [x] 🚦 Tests (or not relevant)
