### PR TITLE
Make it possible to block until all sessions are terminated

### DIFF
--- a/src/realm/object-store/sync/sync_manager.cpp
+++ b/src/realm/object-store/sync/sync_manager.cpp
@@ -636,6 +636,11 @@ bool SyncManager::do_has_existing_sessions()
     });
 }
 
+void SyncManager::wait_for_sessions_to_terminate() {
+    auto& client = get_sync_client(); // Throws
+    client.wait_for_session_terminations();
+}
+
 void SyncManager::unregister_session(const std::string& path)
 {
     std::lock_guard<std::mutex> lock(m_session_mutex);

--- a/src/realm/object-store/sync/sync_manager.hpp
+++ b/src/realm/object-store/sync/sync_manager.hpp
@@ -151,6 +151,12 @@ public:
     // the state of that session.
     bool has_existing_sessions();
 
+    // Blocking call that only return once all sessions have been terminated.
+    // Due to the async nature of the SyncClient, even with `SyncSessionStopPolicy::Immediate`, a
+    // session is not guaranteed to stop immediately when a Realm is closed. Using this method
+    // makes it possible to guarantee that all sessions have, in fact, been closed.
+    void wait_for_sessions_to_terminate();
+
     // If the metadata manager is configured, perform an update. Returns `true` iff the code was run.
     bool perform_metadata_update(std::function<void(const SyncMetadataManager&)> update_function) const;
 


### PR DESCRIPTION
Java is still seeing sporadic test failures when using `SyncManager::reset_for_testing()`.

The most likely cause is that even with `SyncSessionStopPolicy::Immediate` set, we are not guaranteed the session to be actually gone when calling the reset method.

This PR exposes a method that is currently only visible on the SyncClient that allows us to wait until all sessions are _really_ gone.