### PR TITLE
fix handling of unresolved links when the pk is null

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 ### Fixed
 * <How to hit and notice issue? what was the impact?> ([#????](https://github.com/realm/realm-core/issues/????), since v?.?.?)
 * Failing to refresh the access token due to a 401/403 error will now correctly emit a sync error with `ProtocolError::bad_authentication` rather than `ProtocolError::permission_denied`. ([#4881](https://github.com/realm/realm-core/pull/4881), since 11.0.4)
+* If an object with a null primary key was deleted by another sync client, the exception `KeyNotFound: No such object` could be triggered. ([#4885](https://github.com/realm/realm-core/issues/4885) since unresolved links were introduced in v10.0.0)
 
 ### Breaking changes
 * None.

--- a/src/realm/obj.cpp
+++ b/src/realm/obj.cpp
@@ -1301,8 +1301,10 @@ Obj& Obj::set<Mixed>(ColKey col_key, Mixed value, bool is_default)
         recurse = replace_backlink(col_key, old_link, new_link, state);
     }
 
-
-    if (StringIndex* index = m_table->get_search_index(col_key)) {
+    StringIndex* index = m_table->get_search_index(col_key);
+    // The following check on unresolved is just a precaution as it should not
+    // be possible to hit that while Mixed is not a supported primary key type.
+    if (index && !m_key.is_unresolved()) {
         index->set<Mixed>(m_key, value);
     }
 
@@ -2259,7 +2261,8 @@ Obj& Obj::set_null(ColKey col_key, bool is_default)
         update_if_needed();
         ensure_writeable();
 
-        if (StringIndex* index = m_table->get_search_index(col_key)) {
+        StringIndex* index = m_table->get_search_index(col_key);
+        if (index && !m_key.is_unresolved()) {
             index->set(m_key, null{});
         }
 


### PR DESCRIPTION
Fixes https://github.com/realm/realm-core/issues/4885

There are existing guards against using the index if an object is unresolved. But these were not in place for set_null or set<Mixed>. The handling for set_null is the actual fix. I changed set<Mixed> with the same check, but I think it is currently impossible to trigger it with the restriction that Mixed cannot be a primary key type so I left a comment about that.

## ☑️ ToDos
* [x] 📝 Changelog update
* [x] 🚦 Tests (or not relevant)
