### PR TITLE
Add Obj::get_any(StringData) for convenience

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 * ThreadSafeReference no longer pins the source transaction version for anything other than a Results backed by a Query.
 * A ThreadSafeReference to a Results backed by a collection can now be created inside a write transaction as long as the collection was not created in the current write transaction.
 * Synchronized Realms are no longer opened twice, cutting the address space and file descriptors used in half. ([#4839](https://github.com/realm/realm-core/pull/4839))
+* A method Obj::get_any(StringData) has been added.
 
 ### Fixed
 * <How to hit and notice issue? what was the impact?> ([#????](https://github.com/realm/realm-core/issues/????), since v?.?.?)

--- a/src/realm/obj.hpp
+++ b/src/realm/obj.hpp
@@ -126,6 +126,10 @@ public:
     U get(ColKey col_key) const;
 
     Mixed get_any(ColKey col_key) const;
+    Mixed get_any(StringData col_name) const
+    {
+        return get_any(get_column_key(col_name));
+    }
     Mixed get_any(std::vector<std::string>::iterator path_start, std::vector<std::string>::iterator path_end) const;
     Mixed get_primary_key() const;
 

--- a/test/test_array_mixed.cpp
+++ b/test/test_array_mixed.cpp
@@ -158,6 +158,8 @@ TEST(Mixed_Table)
     auto obj1 = t.create_object().set(col_data, Mixed("Hello"));
     CHECK_EQUAL(obj0.get_any(col_data), Mixed(5));
     CHECK_EQUAL(obj1.get_any(col_data), Mixed("Hello"));
+    CHECK_EQUAL(obj0.get_any("data"), Mixed(5));
+    CHECK_EQUAL(obj1.get_any("data"), Mixed("Hello"));
 }
 
 


### PR DESCRIPTION
<!--
 Make sure to assign one and only one Type (`T:`) label.
 Select reviewers if ready for review. Our bot will automatically assign you.
 -->

## What, How & Why?
It can be a bit cumbersome to use `get_any(ColKey)` when you only have the name of the property/column.

## ☑️ ToDos
* [x] 📝 Changelog update
* [x] 🚦 Tests (or not relevant)
