### PR TITLE
Release Scheduler on Realm Closure

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@
 ### Fixed
 * <How to hit and notice issue? what was the impact?> ([#????](https://github.com/realm/realm-core/issues/????), since v?.?.?)
 * Fixed race between updating user tokens and state in persisted metadata when logging in/out. ([#4875](https://github.com/realm/realm-core/issues/4875))
-* Immediately free shared pointers to scheduler on realm closure ([realm-js/#3620](https://github.com/realm/realm-js/issues/3620), [realm-js/#2993](https://github.com/realm/realm-js/issues/2993))
+* Immediately free shared pointers to scheduler on realm closure ([realm/realm-js#3620](https://github.com/realm/realm-js/issues/3620), [realm/realm-js#2993](https://github.com/realm/realm-js/issues/2993))
  
 ### Breaking changes
 * None.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 ### Fixed
 * <How to hit and notice issue? what was the impact?> ([#????](https://github.com/realm/realm-core/issues/????), since v?.?.?)
 * Fixed race between updating user tokens and state in persisted metadata when logging in/out. ([#4875](https://github.com/realm/realm-core/issues/4875))
+* Immediately free shared pointers to scheduler on realm closure ([realm-js/#3620](https://github.com/realm/realm-js/issues/3620), [realm-js/#2993](https://github.com/realm/realm-js/issues/2993))
  
 ### Breaking changes
 * None.

--- a/src/realm/object-store/shared_realm.cpp
+++ b/src/realm/object-store/shared_realm.cpp
@@ -902,6 +902,8 @@ void Realm::close()
     m_transaction = nullptr;
     m_binding_context = nullptr;
     m_coordinator = nullptr;
+    m_scheduler = nullptr;
+    m_config.scheduler = nullptr
 }
 
 void Realm::delete_files(const std::string& realm_file_path, bool* did_delete_realm)

--- a/src/realm/object-store/shared_realm.cpp
+++ b/src/realm/object-store/shared_realm.cpp
@@ -903,7 +903,7 @@ void Realm::close()
     m_binding_context = nullptr;
     m_coordinator = nullptr;
     m_scheduler = nullptr;
-    m_config.scheduler = nullptr;
+    m_config = {};
 }
 
 void Realm::delete_files(const std::string& realm_file_path, bool* did_delete_realm)

--- a/src/realm/object-store/shared_realm.cpp
+++ b/src/realm/object-store/shared_realm.cpp
@@ -903,7 +903,7 @@ void Realm::close()
     m_binding_context = nullptr;
     m_coordinator = nullptr;
     m_scheduler = nullptr;
-    m_config.scheduler = nullptr
+    m_config.scheduler = nullptr;
 }
 
 void Realm::delete_files(const std::string& realm_file_path, bool* did_delete_realm)

--- a/src/realm/object-store/shared_realm.hpp
+++ b/src/realm/object-store/shared_realm.hpp
@@ -187,7 +187,7 @@ public:
         // called with the supplied schema, version and migration function when
         // the Realm is actually opened and not just retrieved from the cache
         util::Optional<Schema> schema;
-        uint64_t schema_version = -1;
+        uint64_t schema_version = uint64_t(-1);
         MigrationFunction migration_function;
 
         DataInitializationFunction initialization_function;


### PR DESCRIPTION
In realm-js, we were witnessing a large delay when the process was killed.
It seems this was due to the cleanup being left to the garbage collector,
which would take anywhere between 5 to 10 seconds to release everything.

This change will release the resources immediately on realm closure and
fixes the issue we were having.

This fixes the following issues: 
https://github.com/realm/realm-js/issues/3620
https://github.com/realm/realm-js/issues/2993

## ☑️ ToDos
* [x] 📝 Changelog update
* [ ] 🚦 Tests (or not relevant)
