### PR TITLE
fix inserting a mixed link

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,8 +4,7 @@
 * None.
 
 ### Fixed
-* <How to hit and notice issue? what was the impact?> ([#????](https://github.com/realm/realm-core/issues/????), since v?.?.?)
-* None.
+* Fixed forgetting to insert a backlink when inserting a mixed link directly using Table::FieldValues. ([#4899](https://github.com/realm/realm-core/issues/4899) since the introduction of Mixed in v11.0.0)
  
 ### Breaking changes
 * None.

--- a/src/realm/cluster.cpp
+++ b/src/realm/cluster.cpp
@@ -281,12 +281,15 @@ inline void Cluster::do_insert_mixed(size_t ndx, ColKey col_key, Mixed init_valu
 
     // Insert backlink if needed
     if (init_value.is_type(type_TypedLink)) {
-        ObjLink link = init_value.get<ObjLink>();
-        Table* origin_table = const_cast<Table*>(m_tree_top.get_owning_table());
-        auto target_table = origin_table->get_parent_group()->get_table(link.get_table_key());
+        // In case we are inserting in a Dictionary cluster, the backlink will
+        // be handled in Dictionary::insert function
+        if (Table* origin_table = const_cast<Table*>(m_tree_top.get_owning_table())) {
+            ObjLink link = init_value.get<ObjLink>();
+            auto target_table = origin_table->get_parent_group()->get_table(link.get_table_key());
 
-        ColKey backlink_col_key = target_table->find_or_add_backlink_column(col_key, origin_table->get_key());
-        target_table->get_object(link.get_obj_key()).add_backlink(backlink_col_key, origin_key);
+            ColKey backlink_col_key = target_table->find_or_add_backlink_column(col_key, origin_table->get_key());
+            target_table->get_object(link.get_obj_key()).add_backlink(backlink_col_key, origin_key);
+        }
     }
 }
 

--- a/src/realm/cluster.hpp
+++ b/src/realm/cluster.hpp
@@ -307,6 +307,7 @@ private:
     void do_erase_key(size_t ndx, ColKey col, CascadeState& state);
     void do_insert_key(size_t ndx, ColKey col, Mixed init_val, ObjKey origin_key);
     void do_insert_link(size_t ndx, ColKey col, Mixed init_val, ObjKey origin_key);
+    void do_insert_mixed(size_t ndx, ColKey col_key, Mixed init_value, ObjKey origin_key);
     template <class T>
     void set_spec(T&, ColKey::Idx) const;
     template <class ArrayType>

--- a/test/test_table.cpp
+++ b/test/test_table.cpp
@@ -5766,6 +5766,25 @@ TEST(Table_MixedNull)
     list.remove(0);
 }
 
+TEST(Table_InsertWithMixedLink)
+{
+    Group g;
+    TableRef dest = g.add_table_with_primary_key("dest", type_Int, "value");
+    TableRef source = g.add_table_with_primary_key("source", type_Int, "value");
+    ColKey mixed_col = source->add_column(type_Mixed, "mixed");
+
+    Obj dest_obj = dest->create_object_with_primary_key(0);
+
+    Mixed mixed_link = ObjLink{dest->get_key(), dest_obj.get_key()};
+    FieldValues values = {
+        {mixed_col, mixed_link},
+    };
+    source->create_object_with_primary_key(0, std::move(values));
+
+    source->clear();
+    dest->clear();
+}
+
 TEST(Table_SortEncrypted)
 {
     SHARED_GROUP_TEST_PATH(path);


### PR DESCRIPTION
I ran into this while writing benchmarks for something unrelated. This affects `Table::create(... FieldValues)` when one of the values is a Mixed link. SDKs may be unaffected if they are not using this way of creating objects.

## ☑️ ToDos
* [x] 📝 Changelog update
* [x] 🚦 Tests (or not relevant)
