### PR TITLE
de-factory GenericNetworkTransport::NetworkFactory

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@
 * Fixed forgetting to insert a backlink when inserting a mixed link directly using Table::FieldValues. ([#4899](https://github.com/realm/realm-core/issues/4899) since the introduction of Mixed in v11.0.0)
  
 ### Breaking changes
-* None.
+* `App::Config::transport_factory` was replaced with `App::Config::transport`. It should now be an instance of `GenericNetworkTransport` rather than a factory for making instances. This allows the SDK to control which thread constructs the transport layer. ([#4903](https://github.com/realm/realm-core/pull/4903))
 
 -----------
 

--- a/src/realm/object-store/sync/app.hpp
+++ b/src/realm/object-store/sync/app.hpp
@@ -56,7 +56,7 @@ class App : public std::enable_shared_from_this<App>,
 public:
     struct Config {
         std::string app_id;
-        GenericNetworkTransport::NetworkTransportFactory transport_generator;
+        std::shared_ptr<GenericNetworkTransport> transport;
         util::Optional<std::string> base_url;
         util::Optional<std::string> local_app_name;
         util::Optional<std::string> local_app_version;

--- a/src/realm/object-store/sync/generic_network_transport.hpp
+++ b/src/realm/object-store/sync/generic_network_transport.hpp
@@ -232,7 +232,6 @@ struct Response {
 
 /// Generic network transport for foreign interfaces.
 struct GenericNetworkTransport {
-    using NetworkTransportFactory = std::function<std::unique_ptr<GenericNetworkTransport>()>;
     virtual void send_request_to_server(const Request request,
                                         std::function<void(const Response)> completionBlock) = 0;
     virtual ~GenericNetworkTransport() = default;

--- a/test/object-store/realm.cpp
+++ b/test/object-store/realm.cpp
@@ -679,19 +679,6 @@ TEST_CASE("Get Realm using Async Open", "[asyncOpen]") {
     util::base64_encode(unencoded_body.data(), unencoded_body.size(), &encoded_body[0], encoded_body.size());
     auto invalid_token = "." + encoded_body + ".";
 
-    // Capture the token refresh callback so that we can invoke it later with
-    // the desired result
-    static std::function<void(app::Response)> refresh_completion;
-    init_sync_manager.transport_generator = [] {
-        struct transport : app::GenericNetworkTransport {
-            void send_request_to_server(app::Request, std::function<void(app::Response)> completion_block)
-            {
-                refresh_completion = completion_block;
-            }
-        };
-        return std::unique_ptr<app::GenericNetworkTransport>(new transport);
-    };
-
     // Token refreshing requires that we have app metadata and we can't fetch
     // it normally, so just stick some fake values in
     init_sync_manager.app()->sync_manager()->perform_metadata_update([&](const SyncMetadataManager& manager) {
@@ -713,11 +700,10 @@ TEST_CASE("Get Realm using Async Open", "[asyncOpen]") {
         });
 
         auto body = nlohmann::json({{"access_token", valid_token}}).dump();
-        refresh_completion(app::Response{200, 0, {}, body});
+        init_sync_manager.network_callback(app::Response{200, 0, {}, body});
         util::EventLoop::main().run_until([&] {
             return called.load();
         });
-        refresh_completion = nullptr;
         std::lock_guard<std::mutex> lock(mutex);
         REQUIRE(called);
     }
@@ -739,11 +725,10 @@ TEST_CASE("Get Realm using Async Open", "[asyncOpen]") {
             REQUIRE(!ref);
             called = true;
         });
-        refresh_completion(app::Response{403});
+        init_sync_manager.network_callback(app::Response{403});
         util::EventLoop::main().run_until([&] {
             return called.load();
         });
-        refresh_completion = nullptr;
         std::lock_guard<std::mutex> lock(mutex);
         REQUIRE(called);
         REQUIRE(got_error);

--- a/test/object-store/sync/app.cpp
+++ b/test/object-store/sync/app.cpp
@@ -112,10 +112,7 @@ app::AppError failed_log_in(std::shared_ptr<App> app,
 }
 
 template <typename Transport>
-std::unique_ptr<GenericNetworkTransport> factory()
-{
-    return std::unique_ptr<GenericNetworkTransport>(new Transport);
-}
+const std::shared_ptr<GenericNetworkTransport> instance_of = std::make_shared<Transport>();
 } // namespace
 
 
@@ -216,7 +213,7 @@ App::Config get_integration_config()
     std::string base_url = get_base_url();
     REQUIRE(!base_url.empty());
     auto app_session = get_runtime_app_session(base_url);
-    return get_config(factory<SynchronousTestTransport>, app_session);
+    return get_config(instance_of<SynchronousTestTransport>, app_session);
 }
 } // namespace
 
@@ -1560,7 +1557,7 @@ TEST_CASE("app: mixed lists with object links", "[sync][app]") {
 
     auto server_app_config = minimal_app_config(base_url, "set_new_embedded_object", schema);
     auto app_session = create_app(server_app_config);
-    auto app_config = get_config(factory<SynchronousTestTransport>, app_session);
+    auto app_config = get_config(instance_of<SynchronousTestTransport>, app_session);
     auto partition = random_string(100);
 
     auto email = std::string("realm_tests_do_autoverify-test@example.com");
@@ -1653,7 +1650,7 @@ TEST_CASE("app: set new embedded object", "[sync][app]") {
 
     auto server_app_config = minimal_app_config(base_url, "set_new_embedded_object", schema);
     auto app_session = create_app(server_app_config);
-    auto app_config = get_config(factory<SynchronousTestTransport>, app_session);
+    auto app_config = get_config(instance_of<SynchronousTestTransport>, app_session);
     auto partition = random_string(100);
 
     auto array_of_objs_id = ObjectId::gen();
@@ -1910,13 +1907,26 @@ TEST_CASE("app: sync integration", "[sync][app]") {
 
         {
             std::function<void()> hook;
-            std::function<std::unique_ptr<GenericNetworkTransport>()> hooked_factory = [&hook] {
-                if (hook) {
-                    hook();
+            class MyTestTransport : public SynchronousTestTransport {
+            public:
+                MyTestTransport(std::function<void()>* hook)
+                    : hook(hook)
+                {
                 }
-                return std::unique_ptr<GenericNetworkTransport>(new SynchronousTestTransport);
+
+                void send_request_to_server(const Request request,
+                                            std::function<void(const Response)> completion_block) override
+                {
+                    if (*hook) {
+                        (*hook)();
+                    }
+                    SynchronousTestTransport::send_request_to_server(request, std::move(completion_block));
+                }
+
+            private:
+                std::function<void()>* hook;
             };
-            app_config.transport_generator = hooked_factory;
+            app_config.transport = std::make_shared<MyTestTransport>(&hook);
 
             TestSyncManager sync_manager(app_config, {});
             auto app = sync_manager.app();
@@ -2233,7 +2243,7 @@ TEMPLATE_TEST_CASE("app: collections of links integration", "[sync][app][collect
                       }}};
     auto server_app_config = minimal_app_config(base_url, "collections_of_links", schema);
     auto app_session = create_app(server_app_config);
-    auto app_config = get_config(factory<SynchronousTestTransport>, app_session);
+    auto app_config = get_config(instance_of<SynchronousTestTransport>, app_session);
     TestSyncManager sync_manager(app_config);
     auto app = sync_manager.app();
 
@@ -2389,11 +2399,7 @@ TEST_CASE("app: custom error handling", "[sync][app][custom_errors]") {
     };
 
     SECTION("custom code and message is sent back") {
-        std::unique_ptr<GenericNetworkTransport> (*factory)() = [] {
-            return std::unique_ptr<GenericNetworkTransport>(new CustomErrorTransport(1001, "Boom!"));
-        };
-
-        TestSyncManager tsm(get_config(factory), {});
+        TestSyncManager tsm(get_config(std::make_shared<CustomErrorTransport>(1001, "Boom!")), {});
         auto app = tsm.app();
         auto error = failed_log_in(app);
         CHECK(error.is_custom_error());
@@ -2615,7 +2621,7 @@ public:
 
 App::Config get_config()
 {
-    return get_config(factory<UnitTestTransport>);
+    return get_config(instance_of<UnitTestTransport>);
 }
 
 static const std::string good_access_token =
@@ -2781,7 +2787,7 @@ TEST_CASE("app: login_with_credentials unit_tests", "[sync][app]") {
             }
         };
 
-        TestSyncManager tsm(get_config(factory<transport>), {});
+        TestSyncManager tsm(get_config(instance_of<transport>), {});
         auto app = tsm.app();
 
         auto error = failed_log_in(app);
@@ -2973,17 +2979,17 @@ TEST_CASE("app: user_semantics", "[app]") {
 }
 
 struct ErrorCheckingTransport : public GenericNetworkTransport {
-    ErrorCheckingTransport(Response r)
+    ErrorCheckingTransport(Response* r)
         : m_response(r)
     {
     }
     void send_request_to_server(const Request, std::function<void(const Response)> completion_block) override
     {
-        completion_block(m_response);
+        completion_block(*m_response);
     }
 
 private:
-    Response m_response;
+    Response* m_response;
 };
 
 TEST_CASE("app: response error handling", "[sync][app]") {
@@ -2995,11 +3001,7 @@ TEST_CASE("app: response error handling", "[sync][app]") {
 
     Response response{200, 0, {{"Content-Type", "application/json"}}, response_body};
 
-    std::function<std::unique_ptr<GenericNetworkTransport>()> transport_generator = [&response] {
-        return std::unique_ptr<GenericNetworkTransport>(new ErrorCheckingTransport(response));
-    };
-
-    TestSyncManager tsm(get_config(transport_generator), {});
+    TestSyncManager tsm(get_config(std::make_shared<ErrorCheckingTransport>(&response)), {});
     auto app = tsm.app();
 
     SECTION("http 404") {
@@ -3348,7 +3350,7 @@ TEST_CASE("app: refresh access token unit tests", "[sync][app]") {
             }
         };
 
-        TestSyncManager sync_manager(get_config(factory<transport>));
+        TestSyncManager sync_manager(get_config(instance_of<transport>));
         auto app = sync_manager.app();
         setup_user(app);
 
@@ -3378,7 +3380,7 @@ TEST_CASE("app: refresh access token unit tests", "[sync][app]") {
             }
         };
 
-        TestSyncManager sync_manager(get_config(factory<transport>));
+        TestSyncManager sync_manager(get_config(instance_of<transport>));
         auto app = sync_manager.app();
         setup_user(app);
 
@@ -3456,7 +3458,7 @@ TEST_CASE("app: refresh access token unit tests", "[sync][app]") {
                 }
             };
 
-            TestSyncManager sync_manager(get_config(factory<transport>));
+            TestSyncManager sync_manager(get_config(instance_of<transport>));
             auto app = sync_manager.app();
             setup_user(app);
             REQUIRE(log_in(app));
@@ -3570,81 +3572,77 @@ TEST_CASE("app: app destroyed during token refresh", "[sync][app]") {
 
         TestState state = TestState::unknown;
     } state;
-    std::function<std::unique_ptr<GenericNetworkTransport>()> generic_factory = [&] {
-        struct transport : public GenericNetworkTransport {
-            transport(AsyncMockNetworkTransport& worker, TestStateBundle& state)
-                : mock_transport_worker(worker)
-                , state(state)
-            {
+    struct transport : public GenericNetworkTransport {
+        transport(AsyncMockNetworkTransport& worker, TestStateBundle& state)
+            : mock_transport_worker(worker)
+            , state(state)
+        {
+        }
+
+        void send_request_to_server(const Request request,
+                                    std::function<void(const Response)> completion_block) override
+
+        {
+            std::cerr << request.url << std::endl;
+            if (request.url.find("/login") != std::string::npos) {
+                CHECK(state.get() == TestState::location);
+                state.advance_to(TestState::login);
+                mock_transport_worker.add_work_item(
+                    Response{200, 0, {}, user_json(encode_fake_jwt("access token 1")).dump()},
+                    std::move(completion_block));
             }
-
-            void send_request_to_server(const Request request,
-                                        std::function<void(const Response)> completion_block) override
-
-            {
-                std::cerr << request.url << std::endl;
-                if (request.url.find("/login") != std::string::npos) {
-                    CHECK(state.get() == TestState::location);
-                    state.advance_to(TestState::login);
-                    mock_transport_worker.add_work_item(
-                        Response{200, 0, {}, user_json(encode_fake_jwt("access token 1")).dump()},
-                        std::move(completion_block));
+            else if (request.url.find("/profile") != std::string::npos) {
+                // simulated bad token request
+                auto cur_state = state.get();
+                CHECK((cur_state == TestState::refresh_1 || cur_state == TestState::login));
+                if (cur_state == TestState::refresh_1) {
+                    state.advance_to(TestState::profile_2);
+                    mock_transport_worker.add_work_item(Response{200, 0, {}, user_profile_json().dump()},
+                                                        std::move(completion_block));
                 }
-                else if (request.url.find("/profile") != std::string::npos) {
-                    // simulated bad token request
-                    auto cur_state = state.get();
-                    CHECK((cur_state == TestState::refresh_1 || cur_state == TestState::login));
-                    if (cur_state == TestState::refresh_1) {
-                        state.advance_to(TestState::profile_2);
-                        mock_transport_worker.add_work_item(Response{200, 0, {}, user_profile_json().dump()},
-                                                            std::move(completion_block));
-                    }
-                    else if (cur_state == TestState::login) {
-                        state.advance_to(TestState::profile_1);
-                        mock_transport_worker.add_work_item(Response{401, 0, {}}, std::move(completion_block));
-                    }
-                }
-                else if (request.url.find("/session") != std::string::npos && request.method == HttpMethod::post) {
-                    if (state.get() == TestState::profile_1) {
-                        state.advance_to(TestState::refresh_1);
-                        nlohmann::json json{{"access_token", encode_fake_jwt("access token 1")}};
-                        mock_transport_worker.add_work_item(Response{200, 0, {}, json.dump()},
-                                                            std::move(completion_block));
-                    }
-                    else if (state.get() == TestState::profile_2) {
-                        state.advance_to(TestState::refresh_2);
-                        mock_transport_worker.add_work_item(Response{200, 0, {}, "{\"error\":\"too bad, buddy!\"}"},
-                                                            std::move(completion_block));
-                    }
-                    else {
-                        CHECK(state.get() == TestState::refresh_2);
-                        state.advance_to(TestState::refresh_3);
-                        nlohmann::json json{{"access_token", encode_fake_jwt("access token 2")}};
-                        mock_transport_worker.add_work_item(Response{200, 0, {}, json.dump()},
-                                                            std::move(completion_block));
-                    }
-                }
-                else if (request.url.find("/location") != std::string::npos) {
-                    CHECK(request.method == HttpMethod::get);
-                    CHECK(state.get() == TestState::unknown);
-                    state.advance_to(TestState::location);
-                    mock_transport_worker.add_work_item(
-                        Response{200,
-                                 0,
-                                 {},
-                                 "{\"deployment_model\":\"GLOBAL\",\"location\":\"US-VA\",\"hostname\":"
-                                 "\"http://localhost:9090\",\"ws_hostname\":\"ws://localhost:9090\"}"},
-                        std::move(completion_block));
+                else if (cur_state == TestState::login) {
+                    state.advance_to(TestState::profile_1);
+                    mock_transport_worker.add_work_item(Response{401, 0, {}}, std::move(completion_block));
                 }
             }
+            else if (request.url.find("/session") != std::string::npos && request.method == HttpMethod::post) {
+                if (state.get() == TestState::profile_1) {
+                    state.advance_to(TestState::refresh_1);
+                    nlohmann::json json{{"access_token", encode_fake_jwt("access token 1")}};
+                    mock_transport_worker.add_work_item(Response{200, 0, {}, json.dump()},
+                                                        std::move(completion_block));
+                }
+                else if (state.get() == TestState::profile_2) {
+                    state.advance_to(TestState::refresh_2);
+                    mock_transport_worker.add_work_item(Response{200, 0, {}, "{\"error\":\"too bad, buddy!\"}"},
+                                                        std::move(completion_block));
+                }
+                else {
+                    CHECK(state.get() == TestState::refresh_2);
+                    state.advance_to(TestState::refresh_3);
+                    nlohmann::json json{{"access_token", encode_fake_jwt("access token 2")}};
+                    mock_transport_worker.add_work_item(Response{200, 0, {}, json.dump()},
+                                                        std::move(completion_block));
+                }
+            }
+            else if (request.url.find("/location") != std::string::npos) {
+                CHECK(request.method == HttpMethod::get);
+                CHECK(state.get() == TestState::unknown);
+                state.advance_to(TestState::location);
+                mock_transport_worker.add_work_item(
+                    Response{200,
+                             0,
+                             {},
+                             "{\"deployment_model\":\"GLOBAL\",\"location\":\"US-VA\",\"hostname\":"
+                             "\"http://localhost:9090\",\"ws_hostname\":\"ws://localhost:9090\"}"},
+                    std::move(completion_block));
+            }
+        }
 
-            AsyncMockNetworkTransport& mock_transport_worker;
-            TestStateBundle& state;
-        };
-        return std::make_unique<transport>(mock_transport_worker, state);
+        AsyncMockNetworkTransport& mock_transport_worker;
+        TestStateBundle& state;
     };
-
-    TestSyncManager sync_manager(get_config(generic_factory));
+    TestSyncManager sync_manager(get_config(std::make_shared<transport>(mock_transport_worker, state)));
     auto app = sync_manager.app();
 
     {
@@ -3719,7 +3717,7 @@ TEST_CASE("app: metadata is persisted between sessions", "[sync][app]") {
         }
     };
 
-    TestSyncManager::Config config = get_config(factory<transport>);
+    TestSyncManager::Config config = get_config(instance_of<transport>);
     config.base_path = util::make_temp_dir();
     config.should_teardown_test_directory = false;
 

--- a/test/object-store/sync/sync_manager.cpp
+++ b/test/object-store/sync/sync_manager.cpp
@@ -596,9 +596,6 @@ TEST_CASE("sync_manager: metadata") {
 
     app::App::Config app_config;
     app_config.app_id = "foo_app_id";
-    app_config.transport_generator = []() -> std::unique_ptr<app::GenericNetworkTransport> {
-        REALM_ASSERT_RELEASE(false);
-    };
     app_config.base_url = base_path;
     app_config.platform = "OS Test Platform";
     app_config.platform_version = "OS Test Platform Version";

--- a/test/object-store/util/test_file.cpp
+++ b/test/object-store/util/test_file.cpp
@@ -234,10 +234,8 @@ TestSyncManager::TestSyncManager(const Config& config, const SyncServer::Config&
     , m_should_teardown_test_directory(config.should_teardown_test_directory)
 {
     app::App::Config app_config = config.app_config;
-    if (!app_config.transport_generator) {
-        app_config.transport_generator = [this] {
-            return transport_generator();
-        };
+    if (!app_config.transport) {
+        app_config.transport = transport;
     }
 
     if (app_config.platform.empty()) {

--- a/test/object-store/util/test_file.hpp
+++ b/test/object-store/util/test_file.hpp
@@ -202,7 +202,23 @@ struct TestSyncManager {
         return m_sync_server;
     }
 
-    std::function<std::unique_ptr<realm::app::GenericNetworkTransport>()> transport_generator;
+    // Capture the token refresh callback so that we can invoke it later with
+    // the desired result
+    std::function<void(realm::app::Response)> network_callback;
+    struct Transport : realm::app::GenericNetworkTransport {
+        Transport(std::function<void(realm::app::Response)>* network_callback)
+            : network_callback(network_callback)
+        {
+        }
+
+        void send_request_to_server(realm::app::Request, std::function<void(realm::app::Response)> completion_block)
+        {
+            *network_callback = completion_block;
+        }
+
+        std::function<void(realm::app::Response)>* network_callback;
+    };
+    std::shared_ptr<realm::app::GenericNetworkTransport> transport = std::make_shared<Transport>(&network_callback);
 
 private:
     std::shared_ptr<realm::app::App> m_app;


### PR DESCRIPTION
Now we just have `App::Config::transport` which is a
`shared_ptr<GenericNetworkTransport>`.

<!--
 Make sure to assign one and only one Type (`T:`) label.
 Select reviewers if ready for review. Our bot will automatically assign you.
 -->

## What, How & Why?
<!-- Describe the changes and give some hints to guide your reviewers if possible. -->
<!-- Link (via zenhub) to relevant issue this fixes -->

## ☑️ ToDos
* [x] 📝 Changelog update
* ~~[ ] 🚦 Tests (or not relevant)~~
