### PR TITLE
Use early return to clean up ClientImplBase::Session::send_message()

### DIFF
--- a/src/realm/sync/noinst/client_impl_base.cpp
+++ b/src/realm/sync/noinst/client_impl_base.cpp
@@ -1937,62 +1937,52 @@ void Session::send_message()
     REALM_ASSERT(m_active_or_deactivating);
     REALM_ASSERT(m_enlisted_to_send);
     m_enlisted_to_send = false;
-    if (REALM_LIKELY(!m_deactivation_initiated)) {
-        // Session life cycle state is Active
-        if (REALM_LIKELY(!m_error_message_received)) {
-            // Session life cycle state is Active and the unbinding process has
-            // not been initiated
-            REALM_ASSERT(!m_unbind_message_sent);
-            if (REALM_LIKELY(m_bind_message_sent)) {
-                if (REALM_LIKELY(m_access_token_sent)) {
-                    if (REALM_LIKELY(m_ident_message_sent)) {
-                        bool send_alloc = (m_num_outstanding_subtier_allocations > 0 && !m_alloc_message_sent);
-                        if (REALM_LIKELY(!send_alloc)) {
-                            bool send_mark = (m_target_download_mark > m_last_download_mark_sent);
-                            if (REALM_LIKELY(!send_mark)) {
-                                REALM_ASSERT(m_upload_progress.client_version <= m_upload_target_version);
-                                REALM_ASSERT(m_upload_target_version <= m_last_version_available);
-                                bool need_upload = (m_upload_target_version > m_upload_progress.client_version);
-                                if (REALM_LIKELY(!need_upload)) {
-                                    return;
-                                }
-                                if (REALM_LIKELY(m_allow_upload))
-                                    send_upload_message(); // Throws
-                                return;
-                            }
-                            send_mark_message(); // Throws
-                            return;
-                        }
-                        send_alloc_message(); // Throws
-                        return;
-                    }
-                    if (have_client_file_ident()) {
-                        send_ident_message(); // Throws
-                    }
-                    return;
-                }
-                send_refresh_message(); // Throws
-                return;
-            }
-            send_bind_message(); // Throws
-            return;
-        }
-    }
-    else {
+    if (REALM_UNLIKELY(m_deactivation_initiated) || REALM_UNLIKELY(m_error_message_received)) {
         // Deactivation has been initiated. If the UNBIND message has not been
         // sent yet, there is no point in sending it. Instead, we can let the
         // deactivation process complete.
         if (!m_bind_message_sent) {
-            complete_deactivation(); // Throws
+            return complete_deactivation(); // Throws
             // Life cycle state is now Deactivated
-            return;
         }
+
+        // Session life cycle state is Deactivating or the unbinding process has
+        // been initiated by a session specific ERROR message
+        if (!m_unbind_message_sent)
+            send_unbind_message(); // Throws
+        return;
     }
-    // Session life cycle state is Deactivating or the unbinding process has
-    // been initiated by a session specific ERROR message
-    REALM_ASSERT(m_bind_message_sent);
-    if (!m_unbind_message_sent)
-        send_unbind_message(); // Throws
+
+    // Session life cycle state is Active and the unbinding process has
+    // not been initiated
+    REALM_ASSERT(!m_unbind_message_sent);
+
+    if (REALM_UNLIKELY(!m_bind_message_sent))
+        return send_bind_message(); // Throws
+
+    if (REALM_UNLIKELY(!m_access_token_sent))
+        return send_refresh_message(); // Throws
+
+    if (REALM_UNLIKELY(!m_ident_message_sent)) {
+        if (have_client_file_ident())
+            send_ident_message(); // Throws
+        return;
+    }
+
+    bool send_alloc = (m_num_outstanding_subtier_allocations > 0 && !m_alloc_message_sent);
+    if (REALM_UNLIKELY(send_alloc))
+        return send_alloc_message(); // Throws
+
+    bool send_mark = (m_target_download_mark > m_last_download_mark_sent);
+    if (REALM_UNLIKELY(send_mark))
+        return send_mark_message(); // Throws
+
+    REALM_ASSERT(m_upload_progress.client_version <= m_upload_target_version);
+    REALM_ASSERT(m_upload_target_version <= m_last_version_available);
+    bool need_upload = (m_upload_target_version > m_upload_progress.client_version);
+    if (REALM_UNLIKELY(need_upload) && REALM_LIKELY(m_allow_upload))
+        send_upload_message(); // Throws
+    return;
 }
 
 


### PR DESCRIPTION
This should be identical to the original version, just easier to read.

<!--
 Make sure to assign one and only one Type (`T:`) label.
 Select reviewers if ready for review. Our bot will automatically assign you.
 -->

## What, How & Why?
<!-- Describe the changes and give some hints to guide your reviewers if possible. -->
<!-- Link (via zenhub) to relevant issue this fixes -->

## ☑️ ToDos
* ~~[ ] 📝 Changelog update~~
* ~~[ ] 🚦 Tests (or not relevant)~~
