### PR TITLE
Enable TSAN of object store tests

### DIFF
--- a/test/object-store/CMakeLists.txt
+++ b/test/object-store/CMakeLists.txt
@@ -68,9 +68,7 @@ target_link_libraries(ObjectStoreTests ObjectStore RealmFFIStatic)
 
 create_coverage_target(generate-coverage ObjectStoreTests)
 
-if (NOT REALM_TSAN)
-    add_test(NAME ObjectStoreTests COMMAND realm-object-store-tests)
-endif()
+add_test(NAME ObjectStoreTests COMMAND realm-object-store-tests)
 
 if(REALM_ENABLE_SYNC)
     target_link_libraries(ObjectStoreTests SyncServer)


### PR DESCRIPTION
This was previously disabled because there were false positives which have been since resolved.
Previously, in the Jenkins TSAN step, only the core and sync tests were run.