### PR TITLE
Use the env TEMPDIR if available instead of P_tmpdir.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 * Fixed forgetting to insert a backlink when inserting a mixed link directly using Table::FieldValues. ([#4899](https://github.com/realm/realm-core/issues/4899) since the introduction of Mixed in v11.0.0)
 * Using "sort", "distinct", or "limit" as field name in query expression would cause an "Invalid predicate" error ([#7545](https://github.com/realm/realm-java/issues/7545) since v10.1.2)
 * Crash when quering with 'Not()' followed by empty group. ([#4168](https://github.com/realm/realm-core/issues/4168) since v1.0.0)
+* Change Apple/Linux temp dir created with `util::make_temp_dir()` to default to the environment's TMPDIR if available. Make `TestFile` clean up the directories it creates when finished. ([#4921](https://github.com/realm/realm-core/issues/4921))
 
 ### Breaking changes
 * `App::Config::transport_factory` was replaced with `App::Config::transport`. It should now be an instance of `GenericNetworkTransport` rather than a factory for making instances. This allows the SDK to control which thread constructs the transport layer. ([#4903](https://github.com/realm/realm-core/pull/4903))

--- a/src/realm/util/file.cpp
+++ b/src/realm/util/file.cpp
@@ -322,7 +322,12 @@ std::string make_temp_dir()
     }
     return std::string(buffer);
 #else
-    std::string tmp = std::string(P_tmpdir) + std::string("/realm_XXXXXX") + std::string("\0", 1);
+    char* tmp_dir_env = getenv("TMPDIR");
+    std::string base_dir = tmp_dir_env ? tmp_dir_env : std::string(P_tmpdir);
+    if (!base_dir.empty() && base_dir[base_dir.length() - 1] != '/') {
+        base_dir = base_dir + "/";
+    }
+    std::string tmp = base_dir + std::string("realm_XXXXXX") + std::string("\0", 1);
     std::unique_ptr<char[]> buffer = std::make_unique<char[]>(tmp.size()); // Throws
     memcpy(buffer.get(), tmp.c_str(), tmp.size());
     if (mkdtemp(buffer.get()) == 0) {

--- a/test/object-store/migrations.cpp
+++ b/test/object-store/migrations.cpp
@@ -2266,13 +2266,12 @@ TEST_CASE("migration: AdditiveDiscovered") {
          }},
     };
 
-    TestFile config;
-    config.cache = false;
-    config.schema = schema;
-
     std::vector<SchemaMode> additive_modes = {SchemaMode::AdditiveDiscovered, SchemaMode::AdditiveExplicit};
 
     for (auto mode : additive_modes) {
+        TestFile config;
+        config.cache = false;
+        config.schema = schema;
         config.schema_mode = mode;
         auto realm = Realm::get_shared_realm(config);
         realm->update_schema(schema);

--- a/test/object-store/util/test_file.cpp
+++ b/test/object-store/util/test_file.cpp
@@ -85,8 +85,13 @@ TestFile::TestFile()
 TestFile::~TestFile()
 {
     if (!m_persist) {
-        util::File::try_remove(path);
-        util::try_remove_dir_recursive(m_temp_dir);
+        try {
+            util::File::try_remove(path);
+            util::try_remove_dir_recursive(m_temp_dir);
+        }
+        catch (...) {
+            // clean up is best effort, ignored.
+        }
     }
 }
 

--- a/test/object-store/util/test_file.hpp
+++ b/test/object-store/util/test_file.hpp
@@ -82,6 +82,7 @@ struct TestFile : realm::Realm::Config {
 
 private:
     bool m_persist = false;
+    std::string m_temp_dir;
 };
 
 struct InMemoryTestFile : TestFile {


### PR DESCRIPTION
On Mac this changes the directory that test files are written from "/var/tmp/" to "/var/folders/1y/_7..." which allows the OS to clean them up on a reboot.

Additionally, `TestFile` will clean up the temp directory it creates when finished, if not instructed to persist it.

This should mitigate part of https://jira.mongodb.org/browse/BUILD-13876 going forward.

My dev machine had 2 million mostly empty directories in `/var/tmp/realm_*` totalling 12 GB. Every run of the object-store tests created around 4000 directories there. Since at this scale, most attempts to do anything at that path from the terminal didn't work I had to use a script to clean it out: 

```
            util::DirScanner dir("/var/tmp/");
            size_t count = 0;
            size_t did_delete = 0;
            std::string name;
            while (dir.next(name)) {
                if (name.size() > 6 && name.substr(0, 6) == "realm_") {
                    bool deleted = util::try_remove_dir_recursive("/var/tmp/" + name);
                    did_delete = did_delete + size_t(deleted);
                }
                ++count;
                if (count % 10000 == 0) {
                    std::cout << util::format("deleted %1 out of %2", did_delete, count) << std::endl;
                }
            }
            std::cout << "end of file listings" << std::endl;
```

## ☑️ ToDos
* [x] 📝 Changelog update
* [x] 🚦 Tests (or not relevant)
