### PR TITLE
Remove SyncLoggerFactory

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 
 ### Breaking changes
 * `App::Config::transport_factory` was replaced with `App::Config::transport`. It should now be an instance of `GenericNetworkTransport` rather than a factory for making instances. This allows the SDK to control which thread constructs the transport layer. ([#4903](https://github.com/realm/realm-core/pull/4903))
+* `realm::SyncClientConfig::logger_factory` was replaced with `realm::SyncClientConfig::logger`. It should now be an instance of `util::Logger` rather than a factory for making instances. This allows the SDK to share the logger instance across multiple `App` instances.
 
 -----------
 

--- a/src/realm/object-store/sync/impl/sync_client.hpp
+++ b/src/realm/object-store/sync/impl/sync_client.hpp
@@ -37,7 +37,7 @@ namespace realm {
 namespace _impl {
 
 struct SyncClient {
-    SyncClient(std::unique_ptr<util::Logger> logger, SyncClientConfig const& config,
+    SyncClient(std::shared_ptr<util::Logger> logger, SyncClientConfig const& config,
                std::weak_ptr<const SyncManager> weak_sync_manager)
         : m_client([&] {
             sync::Client::Config c;
@@ -132,7 +132,7 @@ struct SyncClient {
 
 private:
     sync::Client m_client;
-    const std::unique_ptr<util::Logger> m_logger;
+    const std::shared_ptr<util::Logger> m_logger;
     std::thread m_thread;
 #if NETWORK_REACHABILITY_AVAILABLE
     NetworkReachabilityObserver m_reachability_observer;

--- a/src/realm/object-store/sync/sync_manager.hpp
+++ b/src/realm/object-store/sync/sync_manager.hpp
@@ -49,11 +49,6 @@ namespace _impl {
 struct SyncClient;
 }
 
-class SyncLoggerFactory {
-public:
-    virtual std::unique_ptr<util::Logger> make_logger(util::Logger::Level) = 0;
-};
-
 struct SyncClientTimeouts {
     SyncClientTimeouts();
     // See sync::Client::Config for the meaning of these fields.
@@ -76,7 +71,7 @@ struct SyncClientConfig {
     util::Optional<std::vector<char>> custom_encryption_key;
     bool reset_metadata_on_error = false;
 
-    SyncLoggerFactory* logger_factory = nullptr;
+    std::shared_ptr<util::Logger> logger;
     // FIXME: Should probably be util::Logger::Level::error
     util::Logger::Level log_level = util::Logger::Level::info;
     ReconnectMode reconnect_mode = ReconnectMode::normal;
@@ -116,10 +111,10 @@ public:
     // The log level can only be set up until the point the Sync Client is created. This happens when the first
     // Session is created.
     void set_log_level(util::Logger::Level) noexcept;
-    void set_logger_factory(SyncLoggerFactory&) noexcept;
+    void set_logger(std::shared_ptr<util::Logger>) noexcept;
 
-    // Create a new logger of the type which will be used by the sync client
-    std::unique_ptr<util::Logger> make_logger() const;
+    // Get the configured logger instance or make a new default one.
+    std::shared_ptr<util::Logger> get_or_create_logger() const;
 
     // Sets the application level user agent string.
     // This should have the format specified here:


### PR DESCRIPTION
## What, How & Why?
Let's simplify the API somewhat. There's not a good reason that I can see for us to use the factory pattern here.

## ☑️ ToDos
* [x] 📝 Changelog update
* [x] 🚦 Tests (or not relevant)
