### PR TITLE
Add Realm::sync_session() accessor

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ### Enhancements
 * Added methods to freeze and thaw realms, objects, results and lists.
+* Added `Realm::sync_session()` getter as a convenient way to get the sync session for a realm instance.
 
 ### Fixed
 * Fixed forgetting to insert a backlink when inserting a mixed link directly using Table::FieldValues. ([#4899](https://github.com/realm/realm-core/issues/4899) since the introduction of Mixed in v11.0.0)

--- a/src/realm/object-store/impl/realm_coordinator.hpp
+++ b/src/realm/object-store/impl/realm_coordinator.hpp
@@ -73,6 +73,12 @@ public:
     // This is also created as part of opening a Realm, so only use this
     // method if the session needs to exist before the Realm does.
     void create_session(const Realm::Config& config) REQUIRES(!m_realm_mutex, !m_schema_cache_mutex);
+
+    std::shared_ptr<SyncSession> sync_session() REQUIRES(!m_realm_mutex)
+    {
+        util::CheckedLockGuard lock(m_realm_mutex);
+        return m_sync_session;
+    }
 #endif
 
     // Get the existing cached Realm if it exists for the specified scheduler or config.scheduler

--- a/src/realm/object-store/shared_realm.cpp
+++ b/src/realm/object-store/shared_realm.cpp
@@ -175,6 +175,11 @@ std::shared_ptr<AsyncOpenTask> Realm::get_synchronized_realm(Config config)
     auto coordinator = RealmCoordinator::get_coordinator(config.path);
     return coordinator->get_synchronized_realm(std::move(config));
 }
+
+std::shared_ptr<SyncSession> Realm::sync_session() const
+{
+    return m_coordinator->sync_session();
+}
 #endif
 
 void Realm::set_schema(Schema const& reference, Schema schema)

--- a/src/realm/object-store/shared_realm.hpp
+++ b/src/realm/object-store/shared_realm.hpp
@@ -42,6 +42,7 @@ class Table;
 class ThreadSafeReference;
 class Transaction;
 struct SyncConfig;
+class SyncSession;
 typedef std::shared_ptr<Realm> SharedRealm;
 typedef std::weak_ptr<Realm> WeakRealm;
 
@@ -270,6 +271,8 @@ public:
     // using the `AsyncOpenTask` returned. Note that the download doesn't actually
     // start until you call `AsyncOpenTask::start(callback)`
     static std::shared_ptr<AsyncOpenTask> get_synchronized_realm(Config config);
+
+    std::shared_ptr<SyncSession> sync_session() const;
 #endif
     // Returns a frozen Realm for the given Realm. This Realm can be accessed from any thread.
     static SharedRealm get_frozen_realm(Config config, VersionID version);


### PR DESCRIPTION
## What, How & Why?
Add a convenient way to get the sync session for a particular realm instance so that the SDKs don't need to jump through hoops like this: https://github.com/realm/realm-dotnet/blob/db4522869d63f112ee37ae2db5db5755d0438c95/wrappers/src/app_cs.cpp#L277-L282

## ☑️ ToDos
* [x] 📝 Changelog update
* [x] 🚦 Tests (or not relevant)
