### PR TITLE
Replace the SyncLoggerFactory class with a closure

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@
   * `realm::SyncSessionTransactCallback` -> `realm::SyncSession::TransactionCallback`
   * `realm::SyncProgressNotifierCallback` -> `realm::SyncSession::ProgressNotifierCallback`
   * `realm::SyncSession::NotifierType` -> `realm::SyncSession::ProgressDirection`
+* `realm::SyncClientConfig::logger_factory` was changed to a `std::function` that returns logger instances. The abstract class `SyncLoggerFactory` was removed.
 
 -----------
 

--- a/src/realm/object-store/sync/sync_manager.cpp
+++ b/src/realm/object-store/sync/sync_manager.cpp
@@ -263,16 +263,16 @@ void SyncManager::set_log_level(util::Logger::Level level) noexcept
     m_config.log_level = level;
 }
 
-void SyncManager::set_logger_factory(SyncLoggerFactory& factory) noexcept
+void SyncManager::set_logger_factory(std::function<SyncLoggerFactory> factory) noexcept
 {
     std::lock_guard<std::mutex> lock(m_mutex);
-    m_config.logger_factory = &factory;
+    m_config.logger_factory = std::move(factory);
 }
 
 std::unique_ptr<util::Logger> SyncManager::make_logger() const
 {
     if (m_config.logger_factory) {
-        return m_config.logger_factory->make_logger(m_config.log_level); // Throws
+        return m_config.logger_factory(m_config.log_level); // Throws
     }
 
     auto stderr_logger = std::make_unique<util::StderrLogger>(); // Throws

--- a/src/realm/object-store/sync/sync_manager.cpp
+++ b/src/realm/object-store/sync/sync_manager.cpp
@@ -263,7 +263,7 @@ void SyncManager::set_log_level(util::Logger::Level level) noexcept
     m_config.log_level = level;
 }
 
-void SyncManager::set_logger_factory(std::function<SyncLoggerFactory> factory) noexcept
+void SyncManager::set_logger_factory(SyncClientConfig::LoggerFactory factory) noexcept
 {
     std::lock_guard<std::mutex> lock(m_mutex);
     m_config.logger_factory = std::move(factory);

--- a/src/realm/object-store/sync/sync_manager.hpp
+++ b/src/realm/object-store/sync/sync_manager.hpp
@@ -49,8 +49,6 @@ namespace _impl {
 struct SyncClient;
 }
 
-using SyncLoggerFactory = std::unique_ptr<util::Logger>(util::Logger::Level);
-
 struct SyncClientTimeouts {
     SyncClientTimeouts();
     // See sync::Client::Config for the meaning of these fields.
@@ -73,7 +71,8 @@ struct SyncClientConfig {
     util::Optional<std::vector<char>> custom_encryption_key;
     bool reset_metadata_on_error = false;
 
-    std::function<SyncLoggerFactory> logger_factory;
+    using LoggerFactory = std::function<std::unique_ptr<util::Logger>(util::Logger::Level)>;
+    LoggerFactory logger_factory;
     // FIXME: Should probably be util::Logger::Level::error
     util::Logger::Level log_level = util::Logger::Level::info;
     ReconnectMode reconnect_mode = ReconnectMode::normal;
@@ -113,7 +112,7 @@ public:
     // The log level can only be set up until the point the Sync Client is created. This happens when the first
     // Session is created.
     void set_log_level(util::Logger::Level) noexcept;
-    void set_logger_factory(std::function<SyncLoggerFactory>) noexcept;
+    void set_logger_factory(SyncClientConfig::LoggerFactory) noexcept;
 
     // Sets the application level user agent string.
     // This should have the format specified here:

--- a/src/realm/object-store/sync/sync_manager.hpp
+++ b/src/realm/object-store/sync/sync_manager.hpp
@@ -49,10 +49,7 @@ namespace _impl {
 struct SyncClient;
 }
 
-class SyncLoggerFactory {
-public:
-    virtual std::unique_ptr<util::Logger> make_logger(util::Logger::Level) = 0;
-};
+using SyncLoggerFactory = std::unique_ptr<util::Logger>(util::Logger::Level);
 
 struct SyncClientTimeouts {
     SyncClientTimeouts();
@@ -76,7 +73,7 @@ struct SyncClientConfig {
     util::Optional<std::vector<char>> custom_encryption_key;
     bool reset_metadata_on_error = false;
 
-    SyncLoggerFactory* logger_factory = nullptr;
+    std::function<SyncLoggerFactory> logger_factory;
     // FIXME: Should probably be util::Logger::Level::error
     util::Logger::Level log_level = util::Logger::Level::info;
     ReconnectMode reconnect_mode = ReconnectMode::normal;
@@ -116,10 +113,7 @@ public:
     // The log level can only be set up until the point the Sync Client is created. This happens when the first
     // Session is created.
     void set_log_level(util::Logger::Level) noexcept;
-    void set_logger_factory(SyncLoggerFactory&) noexcept;
-
-    // Create a new logger of the type which will be used by the sync client
-    std::unique_ptr<util::Logger> make_logger() const;
+    void set_logger_factory(std::function<SyncLoggerFactory>) noexcept;
 
     // Sets the application level user agent string.
     // This should have the format specified here:
@@ -258,6 +252,9 @@ private:
 
     bool run_file_action(const SyncFileActionMetadata&);
     void init_metadata(SyncClientConfig config, const std::string& app_id);
+
+    // Create a new logger of the type which will be used by the sync client
+    std::unique_ptr<util::Logger> make_logger() const;
 
     // Protects m_users
     mutable std::mutex m_user_mutex;


### PR DESCRIPTION
## What, How & Why?
The abstract factory class only ever had one method so a `std::function` is a better fit. Making it a `std::function` and not a raw pointer also makes life easier for some SDKs.

## ☑️ ToDos
* [x] 📝 Changelog update
* [x] 🚦 Tests (or not relevant)
