### PR TITLE
Fix a race to deadlock when unregistering a sync session

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 * Using "sort", "distinct", or "limit" as field name in query expression would cause an "Invalid predicate" error ([#7545](https://github.com/realm/realm-java/issues/7545) since v10.1.2)
 * Crash when quering with 'Not()' followed by empty group. ([#4168](https://github.com/realm/realm-core/issues/4168) since v1.0.0)
 * Change Apple/Linux temp dir created with `util::make_temp_dir()` to default to the environment's TMPDIR if available. Make `TestFile` clean up the directories it creates when finished. ([#4921](https://github.com/realm/realm-core/issues/4921))
+* Fixed a rare assertion failure or deadlock when a sync session is racing to close at the same time that external reference to the Realm is being released. ([#4931](https://github.com/realm/realm-core/issues/4931))
 
 ### Breaking changes
 * `App::Config::transport_factory` was replaced with `App::Config::transport`. It should now be an instance of `GenericNetworkTransport` rather than a factory for making instances. This allows the SDK to control which thread constructs the transport layer. ([#4903](https://github.com/realm/realm-core/pull/4903))

--- a/src/realm/object-store/sync/sync_manager.cpp
+++ b/src/realm/object-store/sync/sync_manager.cpp
@@ -637,17 +637,7 @@ void SyncManager::wait_for_sessions_to_terminate()
 
 void SyncManager::unregister_session(const std::string& path)
 {
-    // The order here is intentional, the lock must be released before
-    // `existing_session` is released. This prevents a deadlock in the
-    // scenario where a strong reference to the existing session is acquired
-    // here but other references are cleaned up before this method is finished.
-    // In that case, `existing_session` becomes the last strong external reference
-    // and the session will attempt to close when it goes out of scope. If that
-    // happens while we still hold the lock here, `unregister_session` will be
-    // called again and will block on m_session_mutex which is already held.
-    // Releasing the lock before `existing_session` expires prevents this.
-    std::shared_ptr<SyncSession> existing_session;
-    std::lock_guard<std::mutex> lock(m_session_mutex);
+    std::unique_lock<std::mutex> lock(m_session_mutex);
     auto it = m_sessions.find(path);
     if (it == m_sessions.end()) {
         // There was a race to unregister and there's nothing left to do here.
@@ -659,9 +649,18 @@ void SyncManager::unregister_session(const std::string& path)
     // If the session has an active external reference, leave it be. This will happen if the session
     // moves to an inactive state while still externally reference, for instance, as a result of
     // the session's user being logged out.
-    existing_session = it->second->existing_external_reference();
-    if (existing_session)
+    if (auto existing_session = it->second->existing_external_reference()) {
+        // The lock must be released before `existing_session` is released. This prevents a
+        // deadlock in the scenario where a strong reference to the existing session is
+        // acquired here but other references are cleaned up before this method is
+        // finished. In that case, `existing_session` becomes the last strong external
+        // reference and the session will attempt to close when it goes out of scope. If
+        // that happens while we still hold the lock here, `unregister_session` will be
+        // called again and will block on `m_session_mutex` which is already held.
+        // Releasing the lock before `existing_session` expires prevents this.
+        lock.unlock();
         return;
+    }
 
     m_sessions.erase(path);
 }

--- a/src/realm/object-store/sync/sync_manager.cpp
+++ b/src/realm/object-store/sync/sync_manager.cpp
@@ -637,14 +637,30 @@ void SyncManager::wait_for_sessions_to_terminate()
 
 void SyncManager::unregister_session(const std::string& path)
 {
+    // The order here is intentional, the lock must be released before
+    // `existing_session` is released. This prevents a deadlock in the
+    // scenario where a strong reference to the existing session is acquired
+    // here but other references are cleaned up before this method is finished.
+    // In that case, `existing_session` becomes the last strong external reference
+    // and the session will attempt to close when it goes out of scope. If that
+    // happens while we still hold the lock here, `unregister_session` will be
+    // called again and will block on m_session_mutex which is already held.
+    // Releasing the lock before `existing_session` expires prevents this.
+    std::shared_ptr<SyncSession> existing_session;
     std::lock_guard<std::mutex> lock(m_session_mutex);
     auto it = m_sessions.find(path);
-    REALM_ASSERT(it != m_sessions.end());
+    if (it == m_sessions.end()) {
+        // There was a race to unregister and there's nothing left to do here.
+        // This is known to happen if the sync session is closing down at the
+        // same time that a local Realm reference is being cleaned up.
+        return;
+    }
 
     // If the session has an active external reference, leave it be. This will happen if the session
     // moves to an inactive state while still externally reference, for instance, as a result of
     // the session's user being logged out.
-    if (it->second->existing_external_reference())
+    existing_session = it->second->existing_external_reference();
+    if (existing_session)
         return;
 
     m_sessions.erase(path);


### PR DESCRIPTION
I was running into a deadlock about 1 in 1000 runs in debug builds, in the tests that I added in the client reset branch. It could maybe explain why CI sometimes hangs on the object-store tests, but is unlikely that users would hit this in production.
I'm extracting the fix from the client reset work because it is a change not specifically related to client reset and deserves to get independent reviews.

## ☑️ ToDos
* [x] 📝 Changelog update
* [x] 🚦 Tests (or not relevant)
