### PR TITLE
Unregister all progress_notifiers from an AsyncOpenTask

### DIFF
--- a/src/realm/object-store/sync/async_open_task.hpp
+++ b/src/realm/object-store/sync/async_open_task.hpp
@@ -54,6 +54,7 @@ public:
 private:
     std::shared_ptr<_impl::RealmCoordinator> m_coordinator;
     util::AtomicSharedPtr<SyncSession> m_session;
+    std::vector<uint64_t> m_registered_callbacks;
 };
 
 } // namespace realm


### PR DESCRIPTION
<!--
 Make sure to assign one and only one Type (`T:`) label.
 Select reviewers if ready for review. Our bot will automatically assign you.
 -->

## What, How & Why?
<!-- Describe the changes and give some hints to guide your reviewers if possible. -->
<!-- Link (via zenhub) to relevant issue this fixes -->
It was found that progress_notifiers weren't properly unregistered in an `AsyncOpenTask` because of `m_session` being `null` after the `SyncSession::wait_for_download_completion` executed. So  `AsyncOpenTask::unregister_download_progress_notifier` was effectively doing nothing. More info can be found in the issue [4919](https://github.com/realm/realm-core/issues/4919).

Fixes #4919 

## ☑️ ToDos
* [ ] 📝 Changelog update
* [ ] 🚦 Tests (maybe?)
