### PR TITLE
Add util/uri.hpp to the release package

### DIFF
--- a/src/realm/CMakeLists.txt
+++ b/src/realm/CMakeLists.txt
@@ -247,6 +247,7 @@ set(REALM_INSTALL_HEADERS
     util/to_string.hpp
     util/type_list.hpp
     util/type_traits.hpp
+    util/uri.hpp
     util/utf8.hpp
 
     util/metered/unordered_map.hpp


### PR DESCRIPTION
It was part of the realm-sync release bundle, but the monorepo move didn't include it and now realm-js needs it.
