### PR TITLE
Fix a deadlock in AsyncOpenTask::cancel

### DIFF
--- a/src/realm/object-store/sync/async_open_task.cpp
+++ b/src/realm/object-store/sync/async_open_task.cpp
@@ -38,6 +38,8 @@ void AsyncOpenTask::start(std::function<void(ThreadSafeReference, std::exception
     if (!m_session)
         return;
 
+    m_session->revive_if_needed();
+
     std::shared_ptr<AsyncOpenTask> self(shared_from_this());
     m_session->wait_for_download_completion([callback, self, this](std::error_code ec) {
         {


### PR DESCRIPTION
<!--
 Make sure to assign one and only one Type (`T:`) label.
 Select reviewers if ready for review. Our bot will automatically assign you.
 -->

## What, How & Why?
Fixes https://github.com/realm/realm-core/issues/4955. I couldn't find tests for AsyncOpenTask::cancel which would explain why it wasn't caught when https://github.com/realm/realm-core/pull/4935 changed the behavior.


## ☑️ ToDos
* [ ] ~📝 Changelog update~ the bug hasn't been released.
* [x] 🚦 Tests (or not relevant): Thanks @ironage for adding the tests.