### PR TITLE
Add clang TSE annotations to AsyncOpenTask

### DIFF
--- a/src/realm/object-store/util/checked_mutex.hpp
+++ b/src/realm/object-store/util/checked_mutex.hpp
@@ -19,6 +19,7 @@
 #ifndef REALM_OS_CHECKED_MUTEX_HPP
 #define REALM_OS_CHECKED_MUTEX_HPP
 
+#include <memory>
 #include <mutex>
 
 // Clang's thread safety analysis can be used to statically check that variables


### PR DESCRIPTION
I was curious if this'd have caught the bug fixed by #4956. It didn't, but seems good to have anyway. The unguarded use of `m_coordinator` in the completion callback currently happened to always be safe, but moving the access into the critical section is also just a good idea.