### PR TITLE
Enable Multiprocess Sync

### DIFF
--- a/src/realm/db.cpp
+++ b/src/realm/db.cpp
@@ -1326,9 +1326,10 @@ void DB::do_open(const std::string& path, bool no_create_file, bool is_backend, 
 
     m_alloc.set_read_only(true);
     auto fs_path = path.substr(0, path.find_last_of("/"));
-    auto process_lock_path = util::file_path_by_appending_component(fs_path,
-                                                                    "process.lock");
+    const auto process_lock_path = util::file_path_by_appending_component(fs_path,
+                                                                          "process.lock");
     m_sync_agent_lock = util::File(process_lock_path, util::File::Mode::mode_Write);
+    m_sync_agent_lock.set_fifo_path(fs_path, "process.fifo");
 }
 
 void DB::open(BinaryData buffer, bool take_ownership)

--- a/src/realm/db.hpp
+++ b/src/realm/db.hpp
@@ -393,14 +393,15 @@ public:
                              bool delete_lockfile = false);
 
     /// Mark this DB as the sync agent for the file.
-    /// \throw MultipleSyncAgents if another DB is already the sync agent.
     void claim_sync_agent();
-    void release_sync_agent();
+    void release_sync_agent(bool with_lock = true);
 
+    bool can_claim_sync_agent();
 protected:
     explicit DB(const DBOptions& options); // Is this ever used?
 
 private:
+    util::File m_sync_agent_lock;
     std::recursive_mutex m_mutex;
     int m_transaction_count = 0;
     SlabAlloc m_alloc;

--- a/src/realm/object-store/impl/realm_coordinator.cpp
+++ b/src/realm/object-store/impl/realm_coordinator.cpp
@@ -810,9 +810,12 @@ void RealmCoordinator::on_change()
 
 #if REALM_ENABLE_SYNC
     // Invoke realm sync if another process has notified for a change
-    if (m_sync_session) {
+    if (const auto session = m_sync_session.get()) {
+        if (session->state() == SyncSession::PublicState::Dying) {
+            return;
+        }
         auto version = m_db->get_version_of_latest_snapshot();
-        SyncSession::Internal::nonsync_transact_notify(*m_sync_session, version);
+        SyncSession::Internal::nonsync_transact_notify(*session, version);
     }
 #endif
 }

--- a/src/realm/object-store/impl/realm_coordinator.cpp
+++ b/src/realm/object-store/impl/realm_coordinator.cpp
@@ -49,7 +49,6 @@
 
 using namespace realm;
 using namespace realm::_impl;
-
 static auto& s_coordinator_mutex = *new std::mutex;
 static auto& s_coordinators_per_path = *new std::unordered_map<std::string, std::weak_ptr<RealmCoordinator>>;
 
@@ -91,11 +90,13 @@ std::shared_ptr<RealmCoordinator> RealmCoordinator::get_existing_coordinator(Str
 void RealmCoordinator::create_sync_session()
 {
 #if REALM_ENABLE_SYNC
-    if (m_sync_session)
+    if (m_sync_session || m_is_suspended)
         return;
 
     open_db();
     if (m_sync_session)
+        return;
+    if (!m_db->can_claim_sync_agent())
         return;
     m_sync_session = m_config.sync_config->user->sync_manager()->get_session(m_db, *m_config.sync_config);
 

--- a/src/realm/object-store/impl/realm_coordinator.hpp
+++ b/src/realm/object-store/impl/realm_coordinator.hpp
@@ -215,10 +215,10 @@ public:
         m_sync_session = nullptr;
 #endif
     }
-    void resume(const Realm::Config& config) noexcept
+    void resume() noexcept
     {
         m_is_suspended = false;
-        create_session(config);
+        create_session(m_config);
     }
 private:
     friend class realm::SyncManager;

--- a/src/realm/object-store/impl/realm_coordinator.hpp
+++ b/src/realm/object-store/impl/realm_coordinator.hpp
@@ -269,7 +269,7 @@ private:
     void clean_up_dead_notifiers() REQUIRES(m_notifier_mutex);
 
     std::vector<std::shared_ptr<_impl::CollectionNotifier>> notifiers_for_realm(Realm&) REQUIRES(m_notifier_mutex);
-    bool m_is_suspended;
+    bool m_is_suspended = false;
 };
 
 void translate_file_exception(StringData path, bool immutable = false);

--- a/src/realm/object-store/sync/app.hpp
+++ b/src/realm/object-store/sync/app.hpp
@@ -64,6 +64,10 @@ public:
         std::string platform;
         std::string platform_version;
         std::string sdk_version;
+        // The path for a Synced Realm that will be shared
+        // by multiple processes.
+        // TODO: Probably could use a better name.
+        util::Optional<std::string> shared_path;
     };
 
     // `enable_shared_from_this` is unsafe with public constructors; use `get_shared_app` instead

--- a/src/realm/object-store/sync/async_open_task.cpp
+++ b/src/realm/object-store/sync/async_open_task.cpp
@@ -35,9 +35,10 @@ AsyncOpenTask::AsyncOpenTask(std::shared_ptr<_impl::RealmCoordinator> coordinato
 void AsyncOpenTask::start(std::function<void(ThreadSafeReference, std::exception_ptr)> callback)
 {
     std::lock_guard<std::mutex> lock(m_mutex);
-    if (!m_session)
+    if (!m_session) {
+        callback(m_coordinator->get_unbound_realm(), nullptr);
         return;
-
+    }
     std::shared_ptr<AsyncOpenTask> self(shared_from_this());
     m_session->wait_for_download_completion([callback, self, this](std::error_code ec) {
         {

--- a/src/realm/object-store/sync/impl/sync_file.cpp
+++ b/src/realm/object-store/sync/impl/sync_file.cpp
@@ -231,10 +231,12 @@ static std::string validate_and_clean_path(const std::string& path)
 
 } // namespace util
 
-SyncFileManager::SyncFileManager(const std::string& base_path, const std::string& app_id)
+SyncFileManager::SyncFileManager(const std::string& base_path, const std::string& app_id,
+                                 std::string&& metadata_ext)
     : m_base_path(util::file_path_by_appending_component(base_path, c_sync_directory, util::FilePathType::Directory))
     , m_app_path(util::file_path_by_appending_component(m_base_path, util::validate_and_clean_path(app_id),
                                                         util::FilePathType::Directory))
+    , m_metadata_ext(std::move(metadata_ext))
 {
     util::try_make_dir(m_base_path);
     util::try_make_dir(m_app_path);
@@ -404,7 +406,6 @@ std::string SyncFileManager::realm_file_path(const std::string& user_identity, c
             }
         }
     }
-
     return preferred_path;
 }
 
@@ -412,6 +413,13 @@ std::string SyncFileManager::metadata_path() const
 {
     auto dir_path = file_path_by_appending_component(get_utility_directory(), c_metadata_directory,
                                                      util::FilePathType::Directory);
+    util::try_make_dir(dir_path);
+    // if we have a path extension (likely due to a shared app group).
+    // append it to the base metadata path
+    if (!m_metadata_ext.empty()) {
+        dir_path = file_path_by_appending_component(dir_path, m_metadata_ext,
+                                                    util::FilePathType::Directory);
+    }
     util::try_make_dir(dir_path);
     return util::file_path_by_appending_component(dir_path, c_metadata_realm);
 }

--- a/src/realm/object-store/sync/impl/sync_file.hpp
+++ b/src/realm/object-store/sync/impl/sync_file.hpp
@@ -58,7 +58,7 @@ std::string reserve_unique_file_name(const std::string& path, const std::string&
 // This class manages how Synced Realms are stored on the filesystem.
 class SyncFileManager {
 public:
-    SyncFileManager(const std::string& base_path, const std::string& app_id);
+    SyncFileManager(const std::string& base_path, const std::string& app_id, std::string&& metadata_ext);
 
     /// Return the user directory for a given user, creating it if it does not already exist.
     std::string user_directory(const std::string& identity) const;
@@ -111,6 +111,7 @@ public:
     }
 
 private:
+    const std::string m_metadata_ext;
     // Denotes the base path for the mongodb-realm app associated with this sync manager.
     // Expected to be `base_path` + "mongodb-realm/" + `app_id` + "/".
     const std::string m_base_path;

--- a/src/realm/object-store/sync/sync_manager.cpp
+++ b/src/realm/object-store/sync/sync_manager.cpp
@@ -683,12 +683,11 @@ void SyncManager::enable_session_multiplexing()
 
 void SyncManager::resume()
 {
-    for (auto& [k,v] : m_suspended_sessions) {
-        auto coordinator = RealmCoordinator::get_coordinator(k);
-        coordinator->resume(std::move(v));
+    for (auto& v : m_suspended_paths) {
+        RealmCoordinator::get_coordinator(v)->resume();
     }
 
-    m_suspended_sessions.clear();
+    m_suspended_paths.clear();
 }
 
 void SyncManager::suspend()
@@ -700,7 +699,7 @@ void SyncManager::suspend()
     m_sessions.begin()->second->m_db->release_sync_agent();
     for (auto& [k,v] : m_sessions) {
         auto coordinator = RealmCoordinator::get_coordinator(v->m_db->get_path());
-        m_suspended_sessions.insert({v->m_db->get_path(), std::move(coordinator->get_config())});
+        m_suspended_paths.push_back(v->m_db->get_path());
         v->close();
         coordinator->suspend();
     }

--- a/src/realm/object-store/sync/sync_manager.cpp
+++ b/src/realm/object-store/sync/sync_manager.cpp
@@ -701,12 +701,12 @@ void SyncManager::resume()
 }
 
 bool SyncManager::can_claim_sync_agent() {
-    if (!has_existing_sessions()) {
+    if (has_existing_sessions() || m_suspended_paths.empty()) {
         return false;
     }
 
-    for (auto& [k,v] : m_sessions) {
-        auto coordinator = RealmCoordinator::get_coordinator(v->m_db->get_path());
+    for (auto& v: m_suspended_paths) {
+        auto coordinator = RealmCoordinator::get_coordinator(v);
         return coordinator->m_db->can_claim_sync_agent();
     }
 }

--- a/src/realm/object-store/sync/sync_manager.hpp
+++ b/src/realm/object-store/sync/sync_manager.hpp
@@ -144,6 +144,13 @@ public:
     // the state of that session.
     bool has_existing_sessions();
 
+    // Resume sync. This will recreate all sync sessions that were suspended.
+    // It will also attempt to claim ownership of the sync agent.
+    void resume();
+    // Suspend sync. This will terminate all sync sessions and store their metadata to
+    // be reconstructed on resumption. It will also release ownership of the sync agent.
+    void suspend();
+
     // Blocking call that only return once all sessions have been terminated.
     // Due to the async nature of the SyncClient, even with `SyncSessionStopPolicy::Immediate`, a
     // session is not guaranteed to stop immediately when a Realm is closed. Using this method
@@ -278,6 +285,10 @@ private:
     // Sessions remove themselves from this map by calling `unregister_session` once they're
     // inactive and have performed any necessary cleanup work.
     std::unordered_map<std::string, std::shared_ptr<SyncSession>> m_sessions;
+    // Map of suspended sessions by path name.
+    // The path and config are used to create new `SyncSessions`
+    // upon resumption via the `RealmCoordinator`.
+    std::unordered_map<std::string, Realm::Config> m_suspended_sessions;
 
     // Internal method returning `true` if the SyncManager still contains sessions not yet fully closed.
     // Callers of this method should hold the `m_session_mutex` themselves.

--- a/src/realm/object-store/sync/sync_manager.hpp
+++ b/src/realm/object-store/sync/sync_manager.hpp
@@ -285,10 +285,10 @@ private:
     // Sessions remove themselves from this map by calling `unregister_session` once they're
     // inactive and have performed any necessary cleanup work.
     std::unordered_map<std::string, std::shared_ptr<SyncSession>> m_sessions;
-    // Map of suspended sessions by path name.
-    // The path and config are used to create new `SyncSessions`
+    // Vector of suspended session realm paths.
+    // The paths used to create new `SyncSessions`
     // upon resumption via the `RealmCoordinator`.
-    std::unordered_map<std::string, Realm::Config> m_suspended_sessions;
+    std::vector<std::string> m_suspended_paths;
 
     // Internal method returning `true` if the SyncManager still contains sessions not yet fully closed.
     // Callers of this method should hold the `m_session_mutex` themselves.

--- a/src/realm/object-store/sync/sync_manager.hpp
+++ b/src/realm/object-store/sync/sync_manager.hpp
@@ -225,6 +225,7 @@ public:
         std::lock_guard<std::mutex> lock(m_mutex);
         return m_app;
     }
+    bool can_claim_sync_agent();
 
     SyncManager() = default;
     SyncManager(const SyncManager&) = delete;

--- a/src/realm/object-store/sync/sync_session.cpp
+++ b/src/realm/object-store/sync/sync_session.cpp
@@ -810,6 +810,9 @@ void SyncSession::advance_state(std::unique_lock<std::mutex>& lock, const State&
 
 void SyncSession::nonsync_transact_notify(sync::version_type version)
 {
+    if (m_state == &State::dying) {
+        return;
+    }
     m_progress_notifier.set_local_version(version);
 
     std::unique_lock<std::mutex> lock(m_state_mutex);


### PR DESCRIPTION
Enable Multiprocess Sync. This is predominately motivated by App Groups for Cocoa needing their own synced realms per app that have to re download changes from other apps in the group.

Methodology:
The first process that creates a SyncManager holds the file lock on the sync agent, claiming it.
The second process that opens sees that the lock is held and does not create any sync sessions, "piggy backing" off the initial process.
If the first process is suspended or terminated, it suspends the SyncManager, releasing ownership of the lock/sync agent. The next process to resume then reclaims the lock/sync agent, and recreates its sync sessions.

This is a draft and obviously needs to be tested beyond the manual testing I have done. Could use some sanity/general checks though.

See https://github.com/realm/realm-cocoa/pull/7482 for Cocoa integration.

https://user-images.githubusercontent.com/4356928/137394303-6a99c930-3c6f-4f8d-bcde-4e07d65a8747.mov


