### PR TITLE
Fix a crash when calling LnkSet::remove_all_target_rows()

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,8 @@
 
 ### Fixed
 * <How to hit and notice issue? what was the impact?> ([#????](https://github.com/realm/realm-core/issues/????), since v?.?.?)
-* None.
+* Calling `remove_all_target_rows()` on a newly constructed `LnkSet` dereferenced a null pointer (since v11.5.0).
+* Mutating a Set via one accessor and then calling `remove_all_target_rows()` on a different accessor for the same Set could potentially result in a stale version of the Set being used (since v11.0.0).
  
 ### Breaking changes
 * None.

--- a/src/realm/set.cpp
+++ b/src/realm/set.cpp
@@ -238,7 +238,7 @@ void LnkSet::remove_target_row(size_t link_ndx)
 
 void LnkSet::remove_all_target_rows()
 {
-    if (is_attached()) {
+    if (m_set.update()) {
         _impl::TableFriend::batch_erase_rows(*get_target_table(), *m_set.m_tree);
     }
 }

--- a/test/object-store/collection_fixtures.hpp
+++ b/test/object-store/collection_fixtures.hpp
@@ -142,6 +142,10 @@ struct Base {
     {
         return std::is_arithmetic<T>::value;
     }
+    static bool can_sort()
+    {
+        return true;
+    }
 };
 
 struct Int : Base<PropertyType::Int, int64_t> {
@@ -253,6 +257,10 @@ struct Binary : Base<PropertyType::Data, BinaryData> {
     static std::vector<BinaryData> values()
     {
         return {BinaryData("c", 1), BinaryData("a", 1), BinaryData("b", 1)};
+    }
+    static bool can_sort()
+    {
+        return false;
     }
 };
 

--- a/test/object-store/set.cpp
+++ b/test/object-store/set.cpp
@@ -23,22 +23,64 @@ using namespace realm;
 using namespace realm::util;
 namespace cf = realm::collection_fixtures;
 
-TEMPLATE_TEST_CASE("set all types", "[set]", cf::MixedVal, cf::Int, cf::Bool, cf::Float, cf::Double, cf::String,
-                   cf::Binary, cf::Date, cf::OID, cf::Decimal, cf::UUID, cf::BoxedOptional<cf::Int>,
-                   cf::BoxedOptional<cf::Bool>, cf::BoxedOptional<cf::Float>, cf::BoxedOptional<cf::Double>,
-                   cf::BoxedOptional<cf::OID>, cf::BoxedOptional<cf::UUID>, cf::UnboxedOptional<cf::String>,
-                   cf::UnboxedOptional<cf::Binary>, cf::UnboxedOptional<cf::Date>, cf::UnboxedOptional<cf::Decimal>)
+// Create a new Set for each operation to validate that every Set function
+// initializes things correctly
+template <typename T>
+struct CreateNewSet {
+    using Test = T;
+    static auto get_set(const std::shared_ptr<Realm>& r, Obj& obj, ColKey col)
+    {
+        return [&, col] {
+            return object_store::Set{r, obj, col};
+        };
+    }
+    static auto get_results(const std::shared_ptr<Realm>& r, Obj& obj, ColKey col)
+    {
+        return [&, col] {
+            return object_store::Set{r, obj, col}.as_results();
+        };
+    }
+};
+// Use a single Set for an entire test to validate that the Set is left in a
+// valid state after operations
+template <typename T>
+struct ReuseSet {
+    using Test = T;
+    static auto get_set(const std::shared_ptr<Realm>& r, Obj& obj, ColKey col)
+    {
+        object_store::Set set{r, obj, col};
+        return [set]() mutable -> object_store::Set& {
+            return set;
+        };
+    }
+    static auto get_results(const std::shared_ptr<Realm>& r, Obj& obj, ColKey col)
+    {
+        Results results = object_store::Set{r, obj, col}.as_results();
+        return [results]() mutable -> Results& {
+            return results;
+        };
+    }
+};
+
+TEMPLATE_PRODUCT_TEST_CASE("set all types", "[set]", (CreateNewSet, ReuseSet),
+                           (cf::MixedVal, cf::Int, cf::Bool, cf::Float, cf::Double, cf::String, cf::Binary, cf::Date,
+                            cf::OID, cf::Decimal, cf::UUID, cf::BoxedOptional<cf::Int>, cf::BoxedOptional<cf::Bool>,
+                            cf::BoxedOptional<cf::Float>, cf::BoxedOptional<cf::Double>, cf::BoxedOptional<cf::OID>,
+                            cf::BoxedOptional<cf::UUID>, cf::UnboxedOptional<cf::String>,
+                            cf::UnboxedOptional<cf::Binary>, cf::UnboxedOptional<cf::Date>,
+                            cf::UnboxedOptional<cf::Decimal>))
 {
-    using T = typename TestType::Type;
-    using Boxed = typename TestType::Boxed;
-    using W = typename TestType::Wrapped;
+    using Test = typename TestType::Test;
+    using T = typename Test::Type;
+    using Boxed = typename Test::Boxed;
+    using W = typename Test::Wrapped;
 
     InMemoryTestFile config;
     config.automatic_change_notifications = false;
     auto r = Realm::get_shared_realm(config);
     r->update_schema({
         {"table",
-         {{"value_set", PropertyType::Set | TestType::property_type()},
+         {{"value_set", PropertyType::Set | Test::property_type()},
           {"link_set", PropertyType::Set | PropertyType::Object, "table2"}}},
         {"table2", {{"id", PropertyType::Int, Property::IsPrimary{true}}}},
     });
@@ -64,199 +106,405 @@ TEMPLATE_TEST_CASE("set all types", "[set]", cf::MixedVal, cf::Int, cf::Bool, cf
         return table->create_object();
     });
 
-    auto values = TestType::values();
+    auto values = Test::values();
+    auto set = TestType::get_set(r, obj, col_set);
+    auto set_as_results = TestType::get_results(r, obj, col_set);
+    CppContext ctx(r);
 
-    SECTION("basics") {
-        object_store::Set set{r, obj, col_set};
-        Results set_as_results = set.as_results();
-        CppContext ctx(r);
+    SECTION("valid") {
+        REQUIRE(set().is_valid());
+        REQUIRE_NOTHROW(set().verify_attached());
+        object_store::Set unattached;
+        REQUIRE_THROWS(unattached.verify_attached());
+        REQUIRE(!unattached.is_valid());
+    }
 
-        SECTION("valid") {
-            REQUIRE(set.is_valid());
-            REQUIRE_NOTHROW(set.verify_attached());
-            object_store::Set unattached;
-            REQUIRE_THROWS(unattached.verify_attached());
-            REQUIRE(!unattached.is_valid());
+    SECTION("basic value operations") {
+        REQUIRE(set().size() == 0);
+        REQUIRE(set().get_type() == Test::property_type());
+        REQUIRE(set_as_results().get_type() == Test::property_type());
+        write([&]() {
+            for (size_t i = 0; i < values.size(); ++i) {
+                auto result = set().insert(T(values[i]));
+                REQUIRE(result.first < values.size());
+                REQUIRE(result.second);
+                auto result2 = set().insert(T(values[i]));
+                REQUIRE(!result2.second);
+            }
+        });
+
+        REQUIRE(set().is_valid());
+        REQUIRE(set().size() == values.size());
+        REQUIRE(set_as_results().size() == values.size());
+
+        SECTION("get()") {
+            std::vector<size_t> found_indices;
+            for (auto val : values) {
+                size_t ndx = set().find(T(val));
+                REQUIRE(ndx < set().size());
+                found_indices.push_back(ndx);
+                size_t ndx_any = set().find_any(Mixed{T(val)});
+                REQUIRE(ndx_any == ndx);
+                REQUIRE(set().template get<T>(ndx) == T(val));
+                REQUIRE(set().get_any(ndx) == Mixed{T(val)});
+                auto ctx_val = set().get(ctx, ndx);
+                REQUIRE(any_cast<Boxed>(ctx_val) == Boxed(T(val)));
+                // and through results
+                auto res_ndx = set_as_results().index_of(T(val));
+                REQUIRE(res_ndx == ndx);
+                REQUIRE(set_as_results().template get<T>(res_ndx) == T(val));
+                auto res_ctx_val = set_as_results().get(ctx, res_ndx);
+                REQUIRE(any_cast<Boxed>(res_ctx_val) == Boxed(T(val)));
+                REQUIRE(set_as_results().get_any(res_ndx) == Mixed{T(val)});
+            }
+            // we do not require any particular ordering
+            std::sort(begin(found_indices), end(found_indices), std::less<size_t>());
+            std::vector<size_t> expected_indices(values.size());
+            std::iota(begin(expected_indices), end(expected_indices), 0);
+            REQUIRE(found_indices == expected_indices);
         }
 
-        SECTION("basic value operations") {
-            REQUIRE(set.size() == 0);
-            REQUIRE(set.get_type() == TestType::property_type());
-            REQUIRE(set_as_results.get_type() == TestType::property_type());
+        auto check_empty = [&]() {
+            REQUIRE(set().size() == 0);
+            for (size_t i = 0; i < values.size(); ++i) {
+                REQUIRE(set().find(T(values[i])) == realm::not_found);
+            }
+        };
+        SECTION("remove()") {
             write([&]() {
                 for (size_t i = 0; i < values.size(); ++i) {
-                    auto result = set.insert(T(values[i]));
+                    auto result = set().remove(T(values[i]));
                     REQUIRE(result.first < values.size());
                     REQUIRE(result.second);
-                    auto result2 = set.insert(T(values[i]));
+                    auto result2 = set().remove(T(values[i]));
                     REQUIRE(!result2.second);
                 }
             });
-
-            REQUIRE(set.is_valid());
-            REQUIRE(set.size() == values.size());
-            REQUIRE(set_as_results.size() == values.size());
-
-            SECTION("get()") {
-                std::vector<size_t> found_indices;
-                for (auto val : values) {
-                    size_t ndx = set.find(T(val));
-                    REQUIRE(ndx < set.size());
-                    found_indices.push_back(ndx);
-                    size_t ndx_any = set.find_any(Mixed{T(val)});
-                    REQUIRE(ndx_any == ndx);
-                    REQUIRE(set.get<T>(ndx) == T(val));
-                    REQUIRE(set.get_any(ndx) == Mixed{T(val)});
-                    auto ctx_val = set.get(ctx, ndx);
-                    REQUIRE(any_cast<Boxed>(ctx_val) == Boxed(T(val)));
-                    // and through results
-                    auto res_ndx = set_as_results.index_of(T(val));
-                    REQUIRE(res_ndx == ndx);
-                    REQUIRE(set_as_results.get<T>(res_ndx) == T(val));
-                    auto res_ctx_val = set_as_results.get(ctx, res_ndx);
-                    REQUIRE(any_cast<Boxed>(res_ctx_val) == Boxed(T(val)));
-                    REQUIRE(set_as_results.get_any(res_ndx) == Mixed{T(val)});
-                }
-                // we do not require any particular ordering
-                std::sort(begin(found_indices), end(found_indices), std::less<size_t>());
-                std::vector<size_t> expected_indices(values.size());
-                std::iota(begin(expected_indices), end(expected_indices), 0);
-                REQUIRE(found_indices == expected_indices);
-            }
-
-            auto check_empty = [&]() {
-                REQUIRE(set.size() == 0);
+            check_empty();
+        }
+        SECTION("remove_any()") {
+            write([&]() {
                 for (size_t i = 0; i < values.size(); ++i) {
-                    REQUIRE(set.find(T(values[i])) == realm::not_found);
+                    auto result = set().remove_any(Mixed(T(values[i])));
+                    REQUIRE(result.first < values.size());
+                    REQUIRE(result.second);
+                    auto result2 = set().remove_any(Mixed(T(values[i])));
+                    REQUIRE(!result2.second);
                 }
-            };
-            SECTION("remove()") {
-                write([&]() {
-                    for (size_t i = 0; i < values.size(); ++i) {
-                        auto result = set.remove(T(values[i]));
-                        REQUIRE(result.first < values.size());
-                        REQUIRE(result.second);
-                        auto result2 = set.remove(T(values[i]));
-                        REQUIRE(!result2.second);
-                    }
-                });
-                check_empty();
-            }
-            SECTION("remove_any()") {
-                write([&]() {
-                    for (size_t i = 0; i < values.size(); ++i) {
-                        auto result = set.remove_any(Mixed(T(values[i])));
-                        REQUIRE(result.first < values.size());
-                        REQUIRE(result.second);
-                        auto result2 = set.remove_any(Mixed(T(values[i])));
-                        REQUIRE(!result2.second);
-                    }
-                });
-                check_empty();
-            }
-            SECTION("remove(ctx)") {
-                write([&]() {
-                    for (size_t i = 0; i < values.size(); ++i) {
-                        auto result = set.remove(ctx, TestType::to_any(T(values[i])));
-                        REQUIRE(result.first < values.size());
-                        REQUIRE(result.second);
-                        auto result2 = set.remove(ctx, TestType::to_any(T(values[i])));
-                        REQUIRE(!result2.second);
-                    }
-                });
-                check_empty();
-            }
-            SECTION("remove_all()") {
-                write([&]() {
-                    set.remove_all();
-                });
-                check_empty();
-            }
-            SECTION("delete_all()") {
-                write([&]() {
-                    set.delete_all();
-                });
-                check_empty();
-            }
-            SECTION("Results::clear()") {
-                write([&]() {
-                    set_as_results.clear();
-                });
-                check_empty();
-            }
-            SECTION("min()") {
-                if (!TestType::can_minmax()) {
-                    REQUIRE_THROWS_AS(set.min(), Results::UnsupportedColumnTypeException);
-                    REQUIRE_THROWS_AS(set_as_results.min(), Results::UnsupportedColumnTypeException);
-                    return;
+            });
+            check_empty();
+        }
+        SECTION("remove(ctx)") {
+            write([&]() {
+                for (size_t i = 0; i < values.size(); ++i) {
+                    auto result = set().remove(ctx, Test::to_any(T(values[i])));
+                    REQUIRE(result.first < values.size());
+                    REQUIRE(result.second);
+                    auto result2 = set().remove(ctx, Test::to_any(T(values[i])));
+                    REQUIRE(!result2.second);
                 }
-                REQUIRE(Mixed(TestType::min()) == set.min());
-                REQUIRE(Mixed(TestType::min()) == set_as_results.min());
-                write([&]() {
-                    set.remove_all();
-                });
-                REQUIRE(!set.min());
-                REQUIRE(!set_as_results.min());
+            });
+            check_empty();
+        }
+        SECTION("remove_all()") {
+            write([&]() {
+                set().remove_all();
+            });
+            check_empty();
+        }
+        SECTION("delete_all()") {
+            write([&]() {
+                set().delete_all();
+            });
+            check_empty();
+        }
+        SECTION("Results::clear()") {
+            write([&]() {
+                set_as_results().clear();
+            });
+            check_empty();
+        }
+        SECTION("min()") {
+            if (!Test::can_minmax()) {
+                REQUIRE_THROWS_AS(set().min(), Results::UnsupportedColumnTypeException);
+                REQUIRE_THROWS_AS(set_as_results().min(), Results::UnsupportedColumnTypeException);
+                return;
             }
-            SECTION("max()") {
-                if (!TestType::can_minmax()) {
-                    REQUIRE_THROWS_AS(set.max(), Results::UnsupportedColumnTypeException);
-                    REQUIRE_THROWS_AS(set_as_results.max(), Results::UnsupportedColumnTypeException);
-                    return;
-                }
-                REQUIRE(Mixed(TestType::max()) == set.max());
-                REQUIRE(Mixed(TestType::max()) == set_as_results.max());
-                write([&]() {
-                    set.remove_all();
-                });
-                REQUIRE(!set.max());
-                REQUIRE(!set_as_results.max());
+            REQUIRE(Mixed(Test::min()) == set().min());
+            REQUIRE(Mixed(Test::min()) == set_as_results().min());
+            write([&]() {
+                set().remove_all();
+            });
+            REQUIRE(!set().min());
+            REQUIRE(!set_as_results().min());
+        }
+        SECTION("max()") {
+            if (!Test::can_minmax()) {
+                REQUIRE_THROWS_AS(set().max(), Results::UnsupportedColumnTypeException);
+                REQUIRE_THROWS_AS(set_as_results().max(), Results::UnsupportedColumnTypeException);
+                return;
             }
-            SECTION("sum()") {
-                if (!TestType::can_sum()) {
-                    REQUIRE_THROWS_AS(set.sum(), Results::UnsupportedColumnTypeException);
-                    REQUIRE_THROWS_AS(set_as_results.sum(), Results::UnsupportedColumnTypeException);
-                    return;
-                }
-                REQUIRE(cf::get<W>(set.sum()) == TestType::sum());
-                REQUIRE(cf::get<W>(*set_as_results.sum()) == TestType::sum());
-                write([&]() {
-                    set.remove_all();
-                });
-                REQUIRE(set.sum() == 0);
-                REQUIRE(set_as_results.sum() == 0);
+            REQUIRE(Mixed(Test::max()) == set().max());
+            REQUIRE(Mixed(Test::max()) == set_as_results().max());
+            write([&]() {
+                set().remove_all();
+            });
+            REQUIRE(!set().max());
+            REQUIRE(!set_as_results().max());
+        }
+        SECTION("sum()") {
+            if (!Test::can_sum()) {
+                REQUIRE_THROWS_AS(set().sum(), Results::UnsupportedColumnTypeException);
+                REQUIRE_THROWS_AS(set_as_results().sum(), Results::UnsupportedColumnTypeException);
+                return;
             }
-            SECTION("average()") {
-                if (!TestType::can_average()) {
-                    REQUIRE_THROWS_AS(set.average(), Results::UnsupportedColumnTypeException);
-                    REQUIRE_THROWS_AS(set_as_results.average(), Results::UnsupportedColumnTypeException);
-                    return;
-                }
-                REQUIRE(cf::get<typename TestType::AvgType>(*set.average()) == TestType::average());
-                REQUIRE(cf::get<typename TestType::AvgType>(*set_as_results.average()) == TestType::average());
-                write([&]() {
-                    set.remove_all();
-                });
-                REQUIRE(!set.average());
-                REQUIRE(!set_as_results.average());
+            REQUIRE(cf::get<W>(set().sum()) == Test::sum());
+            REQUIRE(cf::get<W>(*set_as_results().sum()) == Test::sum());
+            write([&]() {
+                set().remove_all();
+            });
+            REQUIRE(set().sum() == 0);
+            REQUIRE(set_as_results().sum() == 0);
+        }
+        SECTION("average()") {
+            if (!Test::can_average()) {
+                REQUIRE_THROWS_AS(set().average(), Results::UnsupportedColumnTypeException);
+                REQUIRE_THROWS_AS(set_as_results().average(), Results::UnsupportedColumnTypeException);
+                return;
             }
-            SECTION("sort") {
-                SECTION("ascending") {
-                    auto sorted = set_as_results.sort({{"self", true}});
-                    std::sort(begin(values), end(values), cf::less());
-                    REQUIRE(sorted == values);
+            REQUIRE(cf::get<typename Test::AvgType>(*set().average()) == Test::average());
+            REQUIRE(cf::get<typename Test::AvgType>(*set_as_results().average()) == Test::average());
+            write([&]() {
+                set().remove_all();
+            });
+            REQUIRE(!set().average());
+            REQUIRE(!set_as_results().average());
+        }
+        SECTION("sort") {
+            SECTION("ascending") {
+                auto sorted = set_as_results().sort({{"self", true}});
+                std::sort(begin(values), end(values), cf::less());
+                REQUIRE(sorted == values);
+            }
+            SECTION("descending") {
+                auto sorted = set_as_results().sort({{"self", false}});
+                std::sort(begin(values), end(values), cf::greater());
+                REQUIRE(sorted == values);
+            }
+        }
+    }
+}
+
+TEMPLATE_PRODUCT_TEST_CASE("set of links to all types", "[set]", (CreateNewSet, ReuseSet),
+                           (cf::MixedVal, cf::Int, cf::Bool, cf::Float, cf::Double, cf::String, cf::Binary, cf::Date,
+                            cf::OID, cf::Decimal, cf::UUID, cf::BoxedOptional<cf::Int>, cf::BoxedOptional<cf::Bool>,
+                            cf::BoxedOptional<cf::Float>, cf::BoxedOptional<cf::Double>, cf::BoxedOptional<cf::OID>,
+                            cf::BoxedOptional<cf::UUID>, cf::UnboxedOptional<cf::String>,
+                            cf::UnboxedOptional<cf::Binary>, cf::UnboxedOptional<cf::Date>,
+                            cf::UnboxedOptional<cf::Decimal>))
+{
+    using Test = typename TestType::Test;
+    using T = typename Test::Type;
+    using W = typename Test::Wrapped;
+
+    InMemoryTestFile config;
+    config.automatic_change_notifications = false;
+    auto r = Realm::get_shared_realm(config);
+    r->update_schema({{"table", {{"link_set", PropertyType::Set | PropertyType::Object, "table2"}}},
+                      {"table2", {{"value", Test::property_type()}}}});
+    auto table = r->read_group().get_table("class_table");
+    ColKey col_set = table->get_column_key("link_set");
+    auto target = r->read_group().get_table("class_table2");
+    ColKey target_col = target->get_column_key("value");
+
+    auto write = [&](auto&& f) {
+        r->begin_transaction();
+        if constexpr (std::is_void_v<decltype(f())>) {
+            f();
+            r->commit_transaction();
+            advance_and_notify(*r);
+        }
+        else {
+            auto result = f();
+            r->commit_transaction();
+            advance_and_notify(*r);
+            return result;
+        }
+    };
+
+    auto values = Test::values();
+    std::vector<ObjKey> keys;
+    auto obj = write([&] {
+        for (T value : values) {
+            auto obj = target->create_object();
+            obj.set_all(value);
+            keys.push_back(obj.get_key());
+        }
+        return table->create_object();
+    });
+
+
+    auto set = TestType::get_set(r, obj, col_set);
+    auto set_as_results = TestType::get_results(r, obj, col_set);
+    CppContext ctx(r);
+
+    SECTION("valid") {
+        REQUIRE(set().is_valid());
+        REQUIRE_NOTHROW(set().verify_attached());
+        object_store::Set unattached;
+        REQUIRE_THROWS(unattached.verify_attached());
+        REQUIRE(!unattached.is_valid());
+    }
+
+    SECTION("basic value operations") {
+        REQUIRE(set().size() == 0);
+        REQUIRE(set().get_type() == PropertyType::Object);
+        REQUIRE(set_as_results().get_type() == PropertyType::Object);
+        write([&]() {
+            for (auto key : keys) {
+                auto result = set().insert(key);
+                REQUIRE(result.first < values.size());
+                REQUIRE(result.second);
+                auto result2 = set().insert(key);
+                REQUIRE(!result2.second);
+            }
+        });
+
+        REQUIRE(set().is_valid());
+        REQUIRE(set().size() == keys.size());
+        REQUIRE(set_as_results().size() == keys.size());
+
+        SECTION("get()") {
+            std::vector<size_t> found_indices;
+            for (ObjKey key : keys) {
+                size_t ndx = set().find(key);
+                REQUIRE(ndx < set().size());
+                REQUIRE(set().get(ndx).get_key() == key);
+                REQUIRE(set_as_results().get(ndx).get_key() == key);
+            }
+        }
+
+        auto check_empty = [&]() {
+            REQUIRE(set().size() == 0);
+            for (auto key : keys) {
+                REQUIRE(set().find(key) == realm::not_found);
+            }
+        };
+        SECTION("remove()") {
+            write([&]() {
+                for (auto key : keys) {
+                    auto result = set().remove(key);
+                    REQUIRE(result.first < keys.size());
+                    REQUIRE(result.second);
+                    auto result2 = set().remove(key);
+                    REQUIRE(!result2.second);
                 }
-                SECTION("descending") {
-                    auto sorted = set_as_results.sort({{"self", false}});
-                    std::sort(begin(values), end(values), cf::greater());
-                    REQUIRE(sorted == values);
+            });
+            check_empty();
+        }
+        SECTION("remove_all()") {
+            write([&]() {
+                set().remove_all();
+            });
+            check_empty();
+            REQUIRE(target->size() != 0);
+        }
+        SECTION("delete_all()") {
+            write([&]() {
+                set().delete_all();
+            });
+            check_empty();
+            REQUIRE(target->size() == 0);
+        }
+        SECTION("Results::clear()") {
+            write([&]() {
+                set_as_results().clear();
+            });
+            check_empty();
+            REQUIRE(target->size() == 0);
+        }
+        SECTION("min()") {
+            if (!Test::can_minmax()) {
+                REQUIRE_THROWS_AS(set().min(target_col), Results::UnsupportedColumnTypeException);
+                REQUIRE_THROWS_AS(set_as_results().min(target_col), Results::UnsupportedColumnTypeException);
+                return;
+            }
+            REQUIRE(Mixed(Test::min()) == set().min(target_col));
+            REQUIRE(Mixed(Test::min()) == set_as_results().min(target_col));
+            write([&]() {
+                set().remove_all();
+            });
+            REQUIRE(!set().min(target_col));
+            REQUIRE(!set_as_results().min(target_col));
+        }
+        SECTION("max()") {
+            if (!Test::can_minmax()) {
+                REQUIRE_THROWS_AS(set().max(target_col), Results::UnsupportedColumnTypeException);
+                REQUIRE_THROWS_AS(set_as_results().max(target_col), Results::UnsupportedColumnTypeException);
+                return;
+            }
+            REQUIRE(Mixed(Test::max()) == set().max(target_col));
+            REQUIRE(Mixed(Test::max()) == set_as_results().max(target_col));
+            write([&]() {
+                set().remove_all();
+            });
+            REQUIRE(!set().max(target_col));
+            REQUIRE(!set_as_results().max(target_col));
+        }
+        SECTION("sum()") {
+            if (!Test::can_sum()) {
+                REQUIRE_THROWS_AS(set().sum(target_col), Results::UnsupportedColumnTypeException);
+                REQUIRE_THROWS_AS(set_as_results().sum(target_col), Results::UnsupportedColumnTypeException);
+                return;
+            }
+            REQUIRE(cf::get<W>(set().sum(target_col)) == Test::sum());
+            REQUIRE(cf::get<W>(*set_as_results().sum(target_col)) == Test::sum());
+            write([&]() {
+                set().remove_all();
+            });
+            REQUIRE(set().sum(target_col) == 0);
+            REQUIRE(set_as_results().sum(target_col) == 0);
+        }
+        SECTION("average()") {
+            if (!Test::can_average()) {
+                REQUIRE_THROWS_AS(set().average(target_col), Results::UnsupportedColumnTypeException);
+                REQUIRE_THROWS_AS(set_as_results().average(target_col), Results::UnsupportedColumnTypeException);
+                return;
+            }
+            REQUIRE(cf::get<typename Test::AvgType>(*set().average(target_col)) == Test::average());
+            REQUIRE(cf::get<typename Test::AvgType>(*set_as_results().average(target_col)) == Test::average());
+            write([&]() {
+                set().remove_all();
+            });
+            REQUIRE(!set().average(target_col));
+            REQUIRE(!set_as_results().average(target_col));
+        }
+        SECTION("sort") {
+            if (!Test::can_sort()) {
+                REQUIRE_THROWS_WITH(set_as_results().sort({{"value", true}}),
+                                    Catch::Matchers::Contains("is of unsupported type"));
+                return;
+            }
+            SECTION("ascending") {
+                auto sorted = set_as_results().sort({{"value", true}});
+                std::sort(begin(values), end(values), cf::less());
+                for (size_t i = 0; i < values.size(); ++i) {
+                    REQUIRE(sorted.get(i).template get<T>(target_col) == values[i]);
+                }
+            }
+            SECTION("descending") {
+                auto sorted = set_as_results().sort({{"value", false}});
+                std::sort(begin(values), end(values), cf::greater());
+                for (size_t i = 0; i < values.size(); ++i) {
+                    REQUIRE(sorted.get(i).template get<T>(target_col) == values[i]);
                 }
             }
         }
     }
 }
 
-TEST_CASE("set", "[set]") {
+TEMPLATE_TEST_CASE("set", "[set]", CreateNewSet<void>, ReuseSet<void>)
+{
     InMemoryTestFile config;
     config.automatic_change_notifications = false;
     auto r = Realm::get_shared_realm(config);
@@ -276,9 +524,6 @@ TEST_CASE("set", "[set]") {
           {"link_set", PropertyType::Set | PropertyType::Object, "other_table2"}}},
         {"other_table2", {{"id", PropertyType::Int, Property::IsPrimary{true}}}},
     });
-
-    auto& coordinator = *_impl::RealmCoordinator::get_coordinator(config.path);
-    static_cast<void>(coordinator);
 
     auto table = r->read_group().get_table("class_table");
     auto table2 = r->read_group().get_table("class_table2");
@@ -317,57 +562,57 @@ TEST_CASE("set", "[set]") {
     });
 
     SECTION("basics") {
-        object_store::Set set{r, obj, col_int_set};
+        auto set = TestType::get_set(r, obj, col_int_set);
 
         write([&]() {
-            CHECK(set.insert(123).second);
-            CHECK(set.insert(456).second);
-            CHECK(set.insert(0).second);
-            CHECK(set.insert_any(-1).second);
-            CHECK(!set.insert(456).second);
+            CHECK(set().insert(123).second);
+            CHECK(set().insert(456).second);
+            CHECK(set().insert(0).second);
+            CHECK(set().insert_any(-1).second);
+            CHECK(!set().insert(456).second);
         });
 
-        REQUIRE(set.is_valid());
-        CHECK(set.size() == 4);
-        CHECK(set.find(-1) == 0);
-        CHECK(set.find(0) == 1);
-        CHECK(set.get_any(2) == Mixed(123));
-        CHECK(set.find_any(456) == 3);
-        CHECK(set.find(999) == size_t(-1));
+        REQUIRE(set().is_valid());
+        CHECK(set().size() == 4);
+        CHECK(set().find(-1) == 0);
+        CHECK(set().find(0) == 1);
+        CHECK(set().get_any(2) == Mixed(123));
+        CHECK(set().find_any(456) == 3);
+        CHECK(set().find(999) == size_t(-1));
 
         write([&]() {
-            CHECK(set.remove(123).second);
-            CHECK(!set.remove(123).second);
-            CHECK(set.remove_any(-1).second);
+            CHECK(set().remove(123).second);
+            CHECK(!set().remove(123).second);
+            CHECK(set().remove_any(-1).second);
         });
 
-        CHECK(set.size() == 2);
+        CHECK(set().size() == 2);
 
         write([&]() {
             obj.remove();
         });
-        CHECK(!set.is_valid());
+        CHECK(!set().is_valid());
     }
 
     SECTION("nullable decimal") {
-        object_store::Set set{r, obj, col_decimal_set};
-        auto results = set.as_results();
+        auto set = TestType::get_set(r, obj, col_decimal_set);
+        auto results = set().as_results();
 
         write([&]() {
-            CHECK(set.insert(Decimal128(5)).second);
-            CHECK(set.insert(Decimal128(realm::null())).second);
-            CHECK(set.insert(Decimal128(7)).second);
+            CHECK(set().insert(Decimal128(5)).second);
+            CHECK(set().insert(Decimal128(realm::null())).second);
+            CHECK(set().insert(Decimal128(7)).second);
         });
 
-        REQUIRE(set.is_valid());
-        CHECK(set.size() == 3);
+        REQUIRE(set().is_valid());
+        CHECK(set().size() == 3);
         CHECK(results.index_of(Decimal128(realm::null())) == 0);
         auto sorted = results.sort({{"self", false}});
         CHECK(sorted.index_of(Decimal128(realm::null())) == 2);
     }
 
     SECTION("objects / links") {
-        object_store::Set set{r, obj, col_link_set};
+        auto set = TestType::get_set(r, obj, col_link_set);
 
         Obj target1, target2, target3;
         write([&]() {
@@ -377,53 +622,53 @@ TEST_CASE("set", "[set]") {
         });
 
         write([&]() {
-            CHECK(set.insert(target1).second);
-            CHECK(!set.insert(target1).second);
-            CHECK(set.insert(target2).second);
-            CHECK(set.insert(target3).second);
+            CHECK(set().insert(target1).second);
+            CHECK(!set().insert(target1).second);
+            CHECK(set().insert(target2).second);
+            CHECK(set().insert(target3).second);
         });
 
-        REQUIRE(set.is_valid());
-        CHECK(set.size() == 3);
+        REQUIRE(set().is_valid());
+        CHECK(set().size() == 3);
 
-        CHECK(set.find(target1) != size_t(-1));
-        CHECK(set.find(target2) != size_t(-1));
-        CHECK(set.find(target3) != size_t(-1));
+        CHECK(set().find(target1) != size_t(-1));
+        CHECK(set().find(target2) != size_t(-1));
+        CHECK(set().find(target3) != size_t(-1));
 
         write([&]() {
             target2.invalidate();
         });
 
-        // Invalidating the object changes the reported size of the set.
-        CHECK(set.size() == 2);
+        // Invalidating the object changes the reported size of the set().
+        CHECK(set().size() == 2);
 
-        CHECK_THROWS(set.find(target2));
+        CHECK_THROWS(set().find(target2));
 
         // Resurrect the tombstone of target2.
         write([&]() {
             target2 = table2->create_object_with_primary_key(456);
         });
-        CHECK(set.find(target2));
-        CHECK(set.size() == 3);
+        CHECK(set().find(target2));
+        CHECK(set().size() == 3);
     }
 
     SECTION("max / min / sum / avg") {
-        object_store::Set set{r, obj, col_int_set};
+        auto set = TestType::get_set(r, obj, col_int_set);
 
         write([&]() {
-            CHECK(set.insert(123).second);
-            CHECK(set.insert(456).second);
-            CHECK(set.insert(0).second);
-            CHECK(set.insert(-1).second);
+            CHECK(set().insert(123).second);
+            CHECK(set().insert(456).second);
+            CHECK(set().insert(0).second);
+            CHECK(set().insert(-1).second);
         });
 
-        auto x = set.min();
+        auto x = set().min();
 
-        REQUIRE(set.is_valid());
-        CHECK(set.sum(col_int_set) == 578);
-        CHECK(set.min(col_int_set) == -1);
-        CHECK(set.max(col_int_set) == 456);
-        CHECK(set.average(col_int_set) == 144.5);
+        REQUIRE(set().is_valid());
+        CHECK(set().sum(col_int_set) == 578);
+        CHECK(set().min(col_int_set) == -1);
+        CHECK(set().max(col_int_set) == 456);
+        CHECK(set().average(col_int_set) == 144.5);
     }
 
     SECTION("add_notification_block()") {
@@ -668,7 +913,7 @@ TEST_CASE("set", "[set]") {
     }
 
     SECTION("find(Query)") {
-        object_store::Set set{r, obj, col_link_set};
+        auto set = TestType::get_set(r, obj, col_link_set);
 
         Obj target1, target2, target3;
         write([&]() {
@@ -678,25 +923,25 @@ TEST_CASE("set", "[set]") {
         });
 
         write([&]() {
-            CHECK(set.insert(target1).second);
-            CHECK(!set.insert(target1).second);
-            CHECK(set.insert(target2).second);
-            CHECK(set.insert(target3).second);
+            CHECK(set().insert(target1).second);
+            CHECK(!set().insert(target1).second);
+            CHECK(set().insert(target2).second);
+            CHECK(set().insert(target3).second);
         });
 
-        REQUIRE(set.is_valid());
-        CHECK(set.size() == 3);
+        REQUIRE(set().is_valid());
+        CHECK(set().size() == 3);
 
         SECTION("returns index in set for boxed Object") {
-            REQUIRE(set.find(std::move(table2->where().equal(col_link_obj_id, 123))) == 0);
-            REQUIRE(set.find(std::move(table2->where().equal(col_link_obj_id, 456))) == 1);
-            REQUIRE(set.find(std::move(table2->where().equal(col_link_obj_id, 789))) == 2);
+            REQUIRE(set().find(std::move(table2->where().equal(col_link_obj_id, 123))) == 0);
+            REQUIRE(set().find(std::move(table2->where().equal(col_link_obj_id, 456))) == 1);
+            REQUIRE(set().find(std::move(table2->where().equal(col_link_obj_id, 789))) == 2);
         }
     }
 
     SECTION("is_superset_of") {
-        object_store::Set set{r, obj, col_link_set};
-        object_store::Set set2{r, other_obj, other_col_link_set};
+        auto set = TestType::get_set(r, obj, col_link_set);
+        auto set2 = TestType::get_set(r, other_obj, other_col_link_set);
 
         std::vector<Obj> targets;
         write([&]() {
@@ -710,27 +955,27 @@ TEST_CASE("set", "[set]") {
 
         write([&]() {
             for (auto& obj : targets) {
-                CHECK(set.insert(obj).second);
+                CHECK(set().insert(obj).second);
             }
-            CHECK(set2.insert(targets[0]).second);
-            CHECK(set2.insert(targets[1]).second);
-            CHECK(set2.insert(targets[2]).second);
+            CHECK(set2().insert(targets[0]).second);
+            CHECK(set2().insert(targets[1]).second);
+            CHECK(set2().insert(targets[2]).second);
         });
 
-        REQUIRE(set.is_valid());
-        CHECK(set.size() == 6);
-        REQUIRE(set2.is_valid());
-        CHECK(set2.size() == 3);
+        REQUIRE(set().is_valid());
+        CHECK(set().size() == 6);
+        REQUIRE(set2().is_valid());
+        CHECK(set2().size() == 3);
 
         SECTION("set2 is a subset of set") {
-            REQUIRE(set2.is_subset_of(set));
-            REQUIRE_FALSE(set.is_subset_of(set2));
+            REQUIRE(set2().is_subset_of(set()));
+            REQUIRE_FALSE(set().is_subset_of(set2()));
         }
     }
 
     SECTION("intersects") {
-        object_store::Set set{r, obj, col_link_set};
-        object_store::Set set2{r, other_obj, other_col_link_set};
+        auto set = TestType::get_set(r, obj, col_link_set);
+        auto set2 = TestType::get_set(r, other_obj, other_col_link_set);
 
         std::vector<Obj> targets;
         write([&]() {
@@ -751,39 +996,39 @@ TEST_CASE("set", "[set]") {
 
         write([&]() {
             for (auto& obj : targets) {
-                CHECK(set.insert(obj).second);
+                CHECK(set().insert(obj).second);
             }
             for (auto& obj : other_targets) {
-                CHECK(set2.insert(obj).second);
+                CHECK(set2().insert(obj).second);
             }
-            CHECK(set2.insert(targets[0]).second);
-            CHECK(set2.insert(targets[1]).second);
-            CHECK(set2.insert(targets[2]).second);
+            CHECK(set2().insert(targets[0]).second);
+            CHECK(set2().insert(targets[1]).second);
+            CHECK(set2().insert(targets[2]).second);
         });
 
-        REQUIRE(set.is_valid());
-        CHECK(set.size() == 6);
-        REQUIRE(set2.is_valid());
-        CHECK(set2.size() == 6);
+        REQUIRE(set().is_valid());
+        CHECK(set().size() == 6);
+        REQUIRE(set2().is_valid());
+        CHECK(set2().size() == 6);
 
 
         SECTION("set2 intersects set") {
             // (123, 456, 789, (321, 654, 987), 111, 222, 333)
-            REQUIRE(set2.intersects(set));
-            REQUIRE(set.intersects(set2));
+            REQUIRE(set2().intersects(set()));
+            REQUIRE(set().intersects(set2()));
             write([&]() {
-                set2.remove(targets[0]);
-                set2.remove(targets[1]);
-                set2.remove(targets[2]);
+                set2().remove(targets[0]);
+                set2().remove(targets[1]);
+                set2().remove(targets[2]);
             });
             // (123, 456, 789, (), 111, 222, 333)
-            REQUIRE_FALSE(set2.intersects(set));
+            REQUIRE_FALSE(set2().intersects(set()));
         }
     }
 
     SECTION("assign intersection") {
-        object_store::Set set{r, obj, col_link_set};
-        object_store::Set set2{r, other_obj, other_col_link_set};
+        auto set = TestType::get_set(r, obj, col_link_set);
+        auto set2 = TestType::get_set(r, other_obj, other_col_link_set);
 
         std::vector<Obj> targets;
         write([&]() {
@@ -804,33 +1049,33 @@ TEST_CASE("set", "[set]") {
 
         write([&]() {
             for (auto& obj : targets) {
-                CHECK(set.insert(obj).second);
+                CHECK(set().insert(obj).second);
             }
             for (auto& obj : other_targets) {
-                CHECK(set2.insert(obj).second);
+                CHECK(set2().insert(obj).second);
             }
-            CHECK(set2.insert(targets[0]).second);
-            CHECK(set2.insert(targets[1]).second);
-            CHECK(set2.insert(targets[2]).second);
+            CHECK(set2().insert(targets[0]).second);
+            CHECK(set2().insert(targets[1]).second);
+            CHECK(set2().insert(targets[2]).second);
         });
 
-        REQUIRE(set.is_valid());
-        CHECK(set.size() == 6);
-        REQUIRE(set2.is_valid());
-        CHECK(set2.size() == 6);
+        REQUIRE(set().is_valid());
+        CHECK(set().size() == 6);
+        REQUIRE(set2().is_valid());
+        CHECK(set2().size() == 6);
 
         SECTION("set2 intersects set") {
             // (123, 456, 789, (321, 654, 987), 111, 222, 333)
             write([&] {
-                set2.assign_intersection(set);
+                set2().assign_intersection(set());
             });
-            CHECK(set2.size() == 3);
+            CHECK(set2().size() == 3);
         }
     }
 
     SECTION("assign union") {
-        object_store::Set set{r, obj, col_link_set};
-        object_store::Set set2{r, other_obj, other_col_link_set};
+        auto set = TestType::get_set(r, obj, col_link_set);
+        auto set2 = TestType::get_set(r, other_obj, other_col_link_set);
 
         std::vector<Obj> targets;
         write([&]() {
@@ -851,33 +1096,33 @@ TEST_CASE("set", "[set]") {
 
         write([&]() {
             for (auto& obj : targets) {
-                CHECK(set.insert(obj).second);
+                CHECK(set().insert(obj).second);
             }
             for (auto& obj : other_targets) {
-                CHECK(set2.insert(obj).second);
+                CHECK(set2().insert(obj).second);
             }
-            CHECK(set2.insert(targets[0]).second);
-            CHECK(set2.insert(targets[1]).second);
-            CHECK(set2.insert(targets[2]).second);
+            CHECK(set2().insert(targets[0]).second);
+            CHECK(set2().insert(targets[1]).second);
+            CHECK(set2().insert(targets[2]).second);
         });
 
-        REQUIRE(set.is_valid());
-        CHECK(set.size() == 6);
-        REQUIRE(set2.is_valid());
-        CHECK(set2.size() == 6);
+        REQUIRE(set().is_valid());
+        CHECK(set().size() == 6);
+        REQUIRE(set2().is_valid());
+        CHECK(set2().size() == 6);
 
         SECTION("set2 intersects set") {
             // (123, 456, 789, (321, 654, 987), 111, 222, 333)
             write([&] {
-                set2.assign_union(set);
+                set2().assign_union(set());
             });
-            CHECK(set2.size() == 9);
+            CHECK(set2().size() == 9);
         }
     }
 
     SECTION("assign difference") {
-        object_store::Set set{r, obj, col_link_set};
-        object_store::Set set2{r, other_obj, other_col_link_set};
+        auto set = TestType::get_set(r, obj, col_link_set);
+        auto set2 = TestType::get_set(r, other_obj, other_col_link_set);
 
         std::vector<Obj> targets;
         write([&]() {
@@ -898,38 +1143,38 @@ TEST_CASE("set", "[set]") {
 
         write([&]() {
             for (auto& obj : targets) {
-                CHECK(set.insert(obj).second);
+                CHECK(set().insert(obj).second);
             }
             for (auto& obj : other_targets) {
-                CHECK(set2.insert(obj).second);
+                CHECK(set2().insert(obj).second);
             }
-            CHECK(set2.insert(targets[0]).second);
-            CHECK(set2.insert(targets[1]).second);
-            CHECK(set2.insert(targets[2]).second);
+            CHECK(set2().insert(targets[0]).second);
+            CHECK(set2().insert(targets[1]).second);
+            CHECK(set2().insert(targets[2]).second);
         });
 
-        REQUIRE(set.is_valid());
-        CHECK(set.size() == 6);
-        REQUIRE(set2.is_valid());
-        CHECK(set2.size() == 6);
+        REQUIRE(set().is_valid());
+        CHECK(set().size() == 6);
+        REQUIRE(set2().is_valid());
+        CHECK(set2().size() == 6);
 
         SECTION("set2 intersects set") {
             // (123, 456, 789, (321, 654, 987), 111, 222, 333)
             write([&] {
-                set2.assign_difference(set);
+                set2().assign_difference(set());
             });
-            CHECK(set2.size() == 3);
+            CHECK(set2().size() == 3);
         }
     }
 
     SECTION("set operations against list") {
-        object_store::Set set{r, obj, col_decimal_set};
+        auto set = TestType::get_set(r, obj, col_decimal_set);
         List list{r, obj, col_decimal_list};
 
         write([&]() {
-            CHECK(set.insert(Decimal128(5)).second);
-            CHECK(set.insert(Decimal128(realm::null())).second);
-            CHECK(set.insert(Decimal128(7)).second);
+            CHECK(set().insert(Decimal128(5)).second);
+            CHECK(set().insert(Decimal128(realm::null())).second);
+            CHECK(set().insert(Decimal128(7)).second);
         });
 
         write([&]() {
@@ -938,30 +1183,30 @@ TEST_CASE("set", "[set]") {
             list.add(Decimal128(7));
             list.add(Decimal128(4));
         });
-        REQUIRE(set.intersects(list));
+        REQUIRE(set().intersects(list));
         write([&]() {
-            set.assign_union(list); // set == { null, 4, 5, 7 }
+            set().assign_union(list); // set == { null, 4, 5, 7 }
         });
-        REQUIRE(set.size() == 4);
-        REQUIRE(set.is_strict_superset_of(list));
+        REQUIRE(set().size() == 4);
+        REQUIRE(set().is_strict_superset_of(list));
         write([&]() {
-            set.assign_difference(list); // set == { 5 }
+            set().assign_difference(list); // set == { 5 }
         });
-        REQUIRE(set.size() == 1);
+        REQUIRE(set().size() == 1);
         write([&]() {
-            CHECK(set.insert(Decimal128(4)).second); // set == { 4, 5 }
-            set.assign_symmetric_difference(list);   // set == { null, 5, 7 }
+            CHECK(set().insert(Decimal128(4)).second); // set == { 4, 5 }
+            set().assign_symmetric_difference(list);   // set == { null, 5, 7 }
         });
-        REQUIRE(set.size() == 3);
+        REQUIRE(set().size() == 3);
         write([&]() {
-            set.assign_intersection(list); // set == { null, 7 }
+            set().assign_intersection(list); // set == { null, 7 }
         });
-        REQUIRE(set.size() == 2);
-        REQUIRE(set.is_strict_subset_of(list));
+        REQUIRE(set().size() == 2);
+        REQUIRE(set().is_strict_subset_of(list));
         write([&]() {
-            CHECK(set.insert(Decimal128(4)).second); // set == { null, 4, 7 }
+            CHECK(set().insert(Decimal128(4)).second); // set == { null, 4, 7 }
         });
-        REQUIRE(set.set_equals(list));
+        REQUIRE(set().set_equals(list));
     }
 }
 


### PR DESCRIPTION
https://github.com/realm/realm-core/pull/4891 made it so that any functions in Set which fail to call update() will crash when called on a newly-constructed Set as m_tree is no longer initialized at construction time. This revealed that LnkSet::remove_all_target_rows() was failing to do so (and not doing so was always a problem; it just had a less obvious symptom previously).

This function was doubly untested: there weren't any tests which called this function at all, and even if there had been they wouldn't have called it on a newly-constructed instance and so wouldn't have caught the bug. I fixed both parts of this by adding some more LnkSet tests and making it so that many of the object store Set tests validate both that reusing a Set instance works and that constructing a new Set instance every time works.
