### PR TITLE
ignore snapshot on a collection of primitives

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 * <How to hit and notice issue? what was the impact?> ([#????](https://github.com/realm/realm-core/issues/????), since v?.?.?)
 * Calling `remove_all_target_rows()` on a newly constructed `LnkSet` dereferenced a null pointer (since v11.5.0).
 * Mutating a Set via one accessor and then calling `remove_all_target_rows()` on a different accessor for the same Set could potentially result in a stale version of the Set being used (since v11.0.0).
+* A snapshot on a collection of primitives would assert on the next operation. ([#4971](https://github.com/realm/realm-core/issues/4971), since v11.5.0)
  
 ### Breaking changes
 * None.

--- a/src/realm/object-store/results.cpp
+++ b/src/realm/object-store/results.cpp
@@ -1174,6 +1174,10 @@ Results Results::snapshot() &&
         case Mode::Query:
         case Mode::TableView:
             ensure_up_to_date(EvaluateMode::Snapshot);
+            if (do_get_type() != PropertyType::Object) {
+                // Snapshot of a collection of primitive values is meaningless and ignored.
+                return std::move(*this);
+            }
             m_notifier.reset();
             m_update_policy = UpdatePolicy::Never;
             return std::move(*this);

--- a/test/object-store/dictionary.cpp
+++ b/test/object-store/dictionary.cpp
@@ -824,9 +824,11 @@ TEMPLATE_TEST_CASE("dictionary types", "[dictionary]", cf::MixedVal, cf::Int, cf
     SECTION("snapshot") {
         SECTION("keys") {
             auto new_keys = keys_as_results.snapshot();
+            REQUIRE(new_keys.size() == keys.size());
         }
         SECTION("values") {
             auto new_values = values_as_results.snapshot();
+            REQUIRE(new_values.size() == values.size());
         }
     }
 }


### PR DESCRIPTION
Fixes https://github.com/realm/realm-core/issues/4971

I considered making snapshot of a collection of primitives throw an exception, but I think it will be easier for SDK's to not have to worry about what the underlying types are and according to our [public facing comments](https://github.com/realm/realm-core/blob/master/src/realm/object-store/results.hpp#L164-L165), this case should be ignored.

## ☑️ ToDos
* [x] 📝 Changelog update
* [x] 🚦 Tests (or not relevant)
