### PR TITLE
Allow calling snapshot() on non-Object Results

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 * <How to hit and notice issue? what was the impact?> ([#????](https://github.com/realm/realm-core/issues/????), since v?.?.?)
 * Calling `remove_all_target_rows()` on a newly constructed `LnkSet` dereferenced a null pointer (since v11.5.0).
 * Mutating a Set via one accessor and then calling `remove_all_target_rows()` on a different accessor for the same Set could potentially result in a stale version of the Set being used (since v11.0.0).
+* Restore support for calling snapshot() on non-Object collections ([#4971](https://github.com/realm/realm-core/issues/4971), since 11.5.0)
  
 ### Breaking changes
 * None.

--- a/src/realm/object-store/results.cpp
+++ b/src/realm/object-store/results.cpp
@@ -1175,7 +1175,9 @@ Results Results::snapshot() &&
         case Mode::TableView:
             ensure_up_to_date(EvaluateMode::Snapshot);
             m_notifier.reset();
-            m_update_policy = UpdatePolicy::Never;
+            if (do_get_type() == PropertyType::Object) {
+                m_update_policy = UpdatePolicy::Never;
+            }
             return std::move(*this);
     }
     REALM_COMPILER_HINT_UNREACHABLE();

--- a/test/object-store/dictionary.cpp
+++ b/test/object-store/dictionary.cpp
@@ -824,9 +824,15 @@ TEMPLATE_TEST_CASE("dictionary types", "[dictionary]", cf::MixedVal, cf::Int, cf
     SECTION("snapshot") {
         SECTION("keys") {
             auto new_keys = keys_as_results.snapshot();
+            REQUIRE(new_keys.size() == keys.size());
+            dict.remove_all();
+            REQUIRE(new_keys.size() == 0);
         }
         SECTION("values") {
             auto new_values = values_as_results.snapshot();
+            REQUIRE(new_values.size() == values.size());
+            dict.remove_all();
+            REQUIRE(new_values.size() == 0);
         }
     }
 }

--- a/test/object-store/primitive_list.cpp
+++ b/test/object-store/primitive_list.cpp
@@ -568,6 +568,15 @@ TEMPLATE_TEST_CASE("primitive list", "[primitives]", cf::MixedVal, cf::Int, cf::
         REQUIRE(results2 == values);
     }
 
+    SECTION("snapshot") {
+        auto snapshot = results.snapshot();
+        REQUIRE(snapshot.size() == results.size());
+        REQUIRE(snapshot.get<T>(0) == results.get<T>(0));
+        list.remove_all();
+        // Snapshotting only actually works for collections of objects
+        REQUIRE(snapshot.size() == 0);
+    }
+
     SECTION("notifications") {
         r->commit_transaction();
 


### PR DESCRIPTION
This is sort of incorrect and maybe should just be forbidding this, but in practice it's what the SDKs actually want for where we use snapshot().

Fixes #4971.