### PR TITLE
Optimize using search index in Equal queries

### DIFF
--- a/src/realm/query.cpp
+++ b/src/realm/query.cpp
@@ -956,18 +956,21 @@ void Query::aggregate(QueryStateBase& st, ColKey column_key, size_t* resultcount
 
         if (!m_view) {
             auto pn = root_node();
-            auto node = pn->m_children[find_best_node(pn)];
+            auto best = find_best_node(pn);
+            auto node = pn->m_children[best];
             if (node->has_search_index()) {
-                node->index_based_aggregate(size_t(-1), [&](const Obj& obj) -> bool {
-                    if (eval_object(obj)) {
+                auto keys = node->index_based_keys();
+                // The node having the search index can be removed from the query as we know that
+                // all the objects will match this condition
+                pn->m_children[best] = pn->m_children.back();
+                pn->m_children.pop_back();
+                for (auto key : keys) {
+                    auto obj = m_table->get_object(key);
+                    if (pn->m_children.empty() || eval_object(obj)) {
                         st.m_key_offset = obj.get_key().value;
                         st.match(realm::npos, obj.get<T>(column_key));
-                        return true;
                     }
-                    else {
-                        return false;
-                    }
-                });
+                }
             }
             else {
                 // no index, traverse cluster tree
@@ -1477,26 +1480,36 @@ void Query::find_all(ConstTableView& ret, size_t begin, size_t end, size_t limit
         }
         else {
             auto pn = root_node();
-            auto node = pn->m_children[find_best_node(pn)];
+            auto best = find_best_node(pn);
+            auto node = pn->m_children[best];
             if (node->has_search_index()) {
                 // translate begin/end limiters into corresponding keys
                 auto begin_key = (begin >= m_table->size()) ? ObjKey() : m_table->get_object(begin).get_key();
                 auto end_key = (end >= m_table->size()) ? ObjKey() : m_table->get_object(end).get_key();
                 KeyColumn& refs = ret.m_key_values;
-                node->index_based_aggregate(limit, [&](const Obj& obj) -> bool {
-                    auto key = obj.get_key();
+
+                // The node having the search index can be removed from the query as we know that
+                // all the objects will match this condition
+                pn->m_children[best] = pn->m_children.back();
+                pn->m_children.pop_back();
+
+                auto keys = node->index_based_keys();
+                for (auto key : keys) {
                     if (begin_key && key < begin_key)
-                        return false;
+                        continue;
                     if (end_key && !(key < end_key))
-                        return false;
-                    if (eval_object(obj)) {
+                        continue;
+                    if (pn->m_children.empty()) {
+                        // No more conditions - just add key
                         refs.add(key);
-                        return true;
                     }
                     else {
-                        return false;
+                        auto obj = m_table->get_object(key);
+                        if (eval_object(obj)) {
+                            refs.add(key);
+                        }
                     }
-                });
+                }
                 return;
             }
             // no index on best node (and likely no index at all), descend B+-tree
@@ -1572,17 +1585,29 @@ size_t Query::do_count(size_t limit) const
     else {
         size_t counter = 0;
         auto pn = root_node();
-        auto node = pn->m_children[find_best_node(pn)];
+        auto best = find_best_node(pn);
+        auto node = pn->m_children[best];
         if (node->has_search_index()) {
-            node->index_based_aggregate(limit, [&](const Obj& obj) -> bool {
-                if (eval_object(obj)) {
-                    ++counter;
-                    return true;
+            auto keys = node->index_based_keys();
+            if (pn->m_children.size() > 1) {
+                // The node having the search index can be removed from the query as we know that
+                // all the objects will match this condition
+                pn->m_children[best] = pn->m_children.back();
+                pn->m_children.pop_back();
+                for (auto key : keys) {
+                    auto obj = m_table->get_object(key);
+                    if (eval_object(obj)) {
+                        ++counter;
+                        if (counter == limit)
+                            break;
+                    }
                 }
-                else {
-                    return false;
-                }
-            });
+            }
+            else {
+                // The node having the search index is the only node
+                auto sz = keys.size();
+                counter = std::min(limit, sz);
+            }
             return counter;
         }
         // no index, descend down the B+-tree instead

--- a/src/realm/query_engine.cpp
+++ b/src/realm/query_engine.cpp
@@ -25,6 +25,8 @@
 
 namespace realm {
 
+std::vector<ObjKey> ParentNode::s_dummy_keys;
+
 ParentNode::ParentNode(const ParentNode& from)
     : m_child(from.m_child ? from.m_child->clone() : nullptr)
     , m_condition_column_key(from.m_condition_column_key)
@@ -236,16 +238,6 @@ size_t MixedNode<Equal>::find_first_local(size_t start, size_t end)
     }
 
     return not_found;
-}
-
-void MixedNode<Equal>::index_based_aggregate(size_t limit, Evaluator evaluator)
-{
-    for (size_t t = 0; t < m_index_matches.size() && limit > 0; ++t) {
-        auto obj = m_table->get_object(m_index_matches[t]);
-        if (evaluator(obj)) {
-            --limit;
-        }
-    }
 }
 
 void StringNodeEqualBase::init(bool will_query_ranges)

--- a/src/realm/query_engine.hpp
+++ b/src/realm/query_engine.hpp
@@ -152,7 +152,10 @@ public:
     {
         return false;
     }
-    virtual void index_based_aggregate(size_t, Evaluator) {}
+    virtual const std::vector<ObjKey>& index_based_keys()
+    {
+        return s_dummy_keys;
+    }
 
     void gather_children(std::vector<ParentNode*>& v)
     {
@@ -319,6 +322,7 @@ protected:
     const Cluster* m_cluster = nullptr;
     QueryStateBase* m_state = nullptr;
     std::string error_code;
+    static std::vector<ObjKey> s_dummy_keys;
 
     ColumnType get_real_column_type(ColKey key)
     {
@@ -546,14 +550,9 @@ public:
         return this->m_table->has_search_index(IntegerNodeBase<LeafType>::m_condition_column_key);
     }
 
-    void index_based_aggregate(size_t limit, Evaluator evaluator) override
+    const std::vector<ObjKey>& index_based_keys() override
     {
-        for (size_t t = 0; t < m_result.size() && limit > 0; ++t) {
-            auto obj = this->m_table->get_object(m_result[t]);
-            if (evaluator(obj)) {
-                --limit;
-            }
-        }
+        return m_result;
     }
 
     size_t find_first_local(size_t start, size_t end) override
@@ -1246,14 +1245,9 @@ public:
         }
     }
 
-    void index_based_aggregate(size_t limit, Evaluator evaluator) override
+    const std::vector<ObjKey>& index_based_keys() override
     {
-        for (size_t t = 0; t < m_result.size() && limit > 0; ++t) {
-            auto obj = this->m_table->get_object(m_result[t]);
-            if (evaluator(obj)) {
-                --limit;
-            }
-        }
+        return m_result;
     }
 
     bool has_search_index() const override
@@ -1488,7 +1482,10 @@ protected:
     size_t m_results_end;
     bool m_has_search_index = false;
 
-    void index_based_aggregate(size_t limit, Evaluator evaluator) override;
+    const std::vector<ObjKey>& index_based_keys() override
+    {
+        return m_index_matches;
+    }
 };
 
 class StringNodeBase : public ParentNode {
@@ -1877,24 +1874,20 @@ public:
             }
         }
     }
-    void index_based_aggregate(size_t limit, Evaluator evaluator) override
+    const std::vector<ObjKey>& index_based_keys() override
     {
-        if (limit == 0)
-            return;
+        m_obj_key_buffer.clear();
         if (m_index_matches == nullptr) {
             if (m_results_end) { // 1 result
-                auto obj = m_table->get_object(m_actual_key);
-                evaluator(obj);
+                m_obj_key_buffer.push_back(m_actual_key);
             }
         }
         else { // multiple results
-            for (size_t t = m_results_start; t < m_results_end && limit > 0; ++t) {
-                auto obj = m_table->get_object(ObjKey(m_index_matches->get(t)));
-                if (evaluator(obj)) {
-                    --limit;
-                }
+            for (size_t t = m_results_start; t < m_results_end; ++t) {
+                m_obj_key_buffer.push_back(ObjKey(m_index_matches->get(t)));
             }
         }
+        return m_obj_key_buffer;
     }
 
 private:
@@ -1914,6 +1907,7 @@ private:
     size_t _find_first_local(size_t start, size_t end) override;
     std::unordered_set<StringData> m_needles;
     std::vector<std::unique_ptr<char[]>> m_needle_storage;
+    std::vector<ObjKey> m_obj_key_buffer;
 };
 
 
@@ -1966,14 +1960,9 @@ public:
     {
     }
 
-    void index_based_aggregate(size_t limit, Evaluator evaluator) override
+    const std::vector<ObjKey>& index_based_keys() override
     {
-        for (size_t t = 0; t < m_index_matches.size() && limit > 0; ++t) {
-            auto obj = m_table->get_object(m_index_matches[t]);
-            if (evaluator(obj)) {
-                --limit;
-            }
-        }
+        return m_index_matches;
     }
 
 private:


### PR DESCRIPTION
When a search index is used to find potential matching objects, then the objects were also tested with respect to the property for which the index was used. This is redundant as they should all match this test. This is especially significant when this is the only test..
This was triggered by https://github.com/realm/realm-java/issues/7570. It only improves performance for that use case slightly as  most of the time is used to find the objects and to to execute the test.