### PR TITLE
fix a loop when the client clock is incorrect

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,8 +5,8 @@
 
 ### Fixed
 * <How to hit and notice issue? what was the impact?> ([#????](https://github.com/realm/realm-core/issues/????), since v?.?.?)
-* None.
- 
+* Fixed an infinite loop when the client device time is incorrect by more than 30 minutes as compared to the server time. ([#4941](https://github.com/realm/realm-core/issues/4941), since v10)
+
 ### Breaking changes
 * None.
 

--- a/src/realm/object-store/sync/sync_session.cpp
+++ b/src/realm/object-store/sync/sync_session.cpp
@@ -321,7 +321,7 @@ struct sync_session_states::WaitingForAccessToken : public SyncSession::State {
     void access_token_updated(std::unique_lock<std::mutex>& lock, SyncSession& session,
                               std::string signed_access_token) const override
     {
-        // We don't expect there to be a session at this point, but if there is refresh the token there.
+        // We don't expect there to be a session at this point, but if there is, refresh it's token.
         // If not, the latest token will be seeded from SyncUser::access_token() on session creation.
         if (session.m_session) {
             session.m_session->refresh(signed_access_token);

--- a/test/object-store/util/test_file.hpp
+++ b/test/object-store/util/test_file.hpp
@@ -212,19 +212,21 @@ struct TestSyncManager {
 
     // Capture the token refresh callback so that we can invoke it later with
     // the desired result
-    std::function<void(realm::app::Response)> network_callback;
+    std::function<realm::app::Response(realm::app::Request)> network_callback;
     struct Transport : realm::app::GenericNetworkTransport {
-        Transport(std::function<void(realm::app::Response)>* network_callback)
+        Transport(std::function<realm::app::Response(realm::app::Request)>* network_callback)
             : network_callback(network_callback)
         {
         }
 
-        void send_request_to_server(realm::app::Request, std::function<void(realm::app::Response)> completion_block)
+        void send_request_to_server(realm::app::Request request,
+                                    std::function<void(realm::app::Response)> completion_block)
         {
-            *network_callback = completion_block;
+            auto response = (*network_callback)(request);
+            completion_block(response);
         }
 
-        std::function<void(realm::app::Response)>* network_callback;
+        std::function<realm::app::Response(realm::app::Request)>* network_callback;
     };
     std::shared_ptr<realm::app::GenericNetworkTransport> transport = std::make_shared<Transport>(&network_callback);
 


### PR DESCRIPTION
Fixes https://github.com/realm/realm-core/issues/4941

The idea here is that we should only do a client side check on the token expiry according to the client's clock in the following cases:
- the user was just created using a stored access token from disk
- the user hasn't had any updates to the access token for the last x (15) minutes

This maintains the behaviour that a preemptive access token refresh is triggered when starting sync for the first time to avoid unnecessary errors in the logs (requested by https://jira.mongodb.org/browse/RCORE-473)

This is a replacement to https://github.com/realm/realm-core/pull/4943 which has a problem if the client clock changes again after the access token is received.

## ☑️ ToDos
* [x] 📝 Changelog update - blocked on https://github.com/realm/realm-core/pull/4984 for the next release notes section.
* [x] 🚦 Tests (or not relevant)
