### PR TITLE
Remove virtual pointer-based state machine in SyncSession

### DIFF
--- a/src/realm/object-store/c_api/sync.cpp
+++ b/src/realm/object-store/c_api/sync.cpp
@@ -50,10 +50,10 @@ static_assert(realm_sync_session_stop_policy_e(SyncSessionStopPolicy::LiveIndefi
 static_assert(realm_sync_session_stop_policy_e(SyncSessionStopPolicy::AfterChangesUploaded) ==
               RLM_SYNC_SESSION_STOP_POLICY_AFTER_CHANGES_UPLOADED);
 
-static_assert(realm_sync_session_state_e(SyncSession::PublicState::Active) == RLM_SYNC_SESSION_STATE_ACTIVE);
-static_assert(realm_sync_session_state_e(SyncSession::PublicState::Dying) == RLM_SYNC_SESSION_STATE_DYING);
-static_assert(realm_sync_session_state_e(SyncSession::PublicState::Inactive) == RLM_SYNC_SESSION_STATE_INACTIVE);
-static_assert(realm_sync_session_state_e(SyncSession::PublicState::WaitingForAccessToken) ==
+static_assert(realm_sync_session_state_e(SyncSession::State::Active) == RLM_SYNC_SESSION_STATE_ACTIVE);
+static_assert(realm_sync_session_state_e(SyncSession::State::Dying) == RLM_SYNC_SESSION_STATE_DYING);
+static_assert(realm_sync_session_state_e(SyncSession::State::Inactive) == RLM_SYNC_SESSION_STATE_INACTIVE);
+static_assert(realm_sync_session_state_e(SyncSession::State::WaitingForAccessToken) ==
               RLM_SYNC_SESSION_STATE_WAITING_FOR_ACCESS_TOKEN);
 
 static_assert(realm_sync_connection_state_e(SyncSession::ConnectionState::Disconnected) ==

--- a/test/object-store/sync/app.cpp
+++ b/test/object-store/sync/app.cpp
@@ -1937,7 +1937,7 @@ TEST_CASE("app: sync integration", "[sync][app]") {
         SECTION("Expired Access Token is Refreshed") {
             // This assumes that we make an http request for the new token while
             // already in the WaitingForAccessToken state.
-            std::vector<SyncSession::PublicState> seen_states;
+            std::vector<SyncSession::State> seen_states;
             transport->hook = [&](const Request) -> util::Optional<Response> {
                 auto user = app->current_user();
                 REQUIRE(user);
@@ -1948,8 +1948,8 @@ TEST_CASE("app: sync integration", "[sync][app]") {
             };
             SyncTestFile config(app, partition, schema);
             auto r = Realm::get_shared_realm(config);
-            REQUIRE(std::find(begin(seen_states), end(seen_states),
-                              SyncSession::PublicState::WaitingForAccessToken) != end(seen_states));
+            REQUIRE(std::find(begin(seen_states), end(seen_states), SyncSession::State::WaitingForAccessToken) !=
+                    end(seen_states));
             Results dogs = get_dogs(r);
             REQUIRE(dogs.size() == 1);
             REQUIRE(dogs.get(0).get<String>("breed") == "bulldog");

--- a/test/object-store/sync/session/session_util.hpp
+++ b/test/object-store/sync/session/session_util.hpp
@@ -31,12 +31,12 @@ using namespace realm::util;
 
 inline bool sessions_are_active(const SyncSession& session)
 {
-    return session.state() == SyncSession::PublicState::Active;
+    return session.state() == SyncSession::State::Active;
 }
 
 inline bool sessions_are_inactive(const SyncSession& session)
 {
-    return session.state() == SyncSession::PublicState::Inactive;
+    return session.state() == SyncSession::State::Inactive;
 }
 
 inline bool sessions_are_disconnected(const SyncSession& session)


### PR DESCRIPTION
This is mostly just code motion and simplification. The only behavior change
is that shutdown_and_wait() will now transition to Inactive from
WaitingForAccessToken. Previously in was a no-op in WaitingForAccessToken, but
I believe that was a bug that was just easy to miss with how the code used to
be written.

Note to reviewers: The `become_STATE()` methods are easier to review if you hide whitespace changes. With the exception of the above case which seemed like an obvious bug, I tried to keep the behavior the same as before. But if you see other cases that seem to have been handled incorrectly, I'll be happy to change it.

<!--
 Make sure to assign one and only one Type (`T:`) label.
 Select reviewers if ready for review. Our bot will automatically assign you.
 -->

## What, How & Why?
<!-- Describe the changes and give some hints to guide your reviewers if possible. -->
<!-- Link (via zenhub) to relevant issue this fixes -->

## ☑️ ToDos
* ~~[ ] 📝 Changelog update~~
* ~~[ ] 🚦 Tests (or not relevant)~~
