### PR TITLE
Fix building the Swift package with Xcode 12.5

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,8 +5,8 @@
 
 ### Fixed
 * <How to hit and notice issue? what was the impact?> ([#????](https://github.com/realm/realm-core/issues/????), since v?.?.?)
-* None.
- 
+* The Swift package could not be imported in Xcode 12.5 (since v11.5.0).
+
 ### Breaking changes
 * None.
 

--- a/Package.swift
+++ b/Package.swift
@@ -24,7 +24,7 @@ var cxxSettings: [CXXSetting] = [
     .define("REALM_VERSION_STRING", to: "\"\(versionStr)\"")
 ]
 
-#if swift(>=5.4)
+#if swift(>=5.5)
 cxxSettings.append(.define("REALM_HAVE_SECURE_TRANSPORT", to: "1", .when(platforms: [.macOS, .macCatalyst, .iOS, .tvOS, .watchOS])))
 #else
 cxxSettings.append(.define("REALM_HAVE_SECURE_TRANSPORT", to: "1", .when(platforms: [.macOS, .iOS, .tvOS, .watchOS])))


### PR DESCRIPTION
`.macCatalyst` was added in swift 5.5, not 5.4.