### PR TITLE
Fix some problems in sync manager locking

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 
 ### Fixed
 * SyncManager had some inconsistent locking which could result in data races and/or deadlocks, mostly in ways that would never be hit outside of tests doing very strange things (since v10.0.0).
+* Reduce the peak memory usage of changeset uploading by eliminating an extra copy of each changeset which was held in memory.
 
 ### Breaking changes
 * None.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,9 +4,8 @@
 * None.
 
 ### Fixed
-* <How to hit and notice issue? what was the impact?> ([#????](https://github.com/realm/realm-core/issues/????), since v?.?.?)
-* None.
- 
+* SyncManager had some inconsistent locking which could result in data races and/or deadlocks, mostly in ways that would never be hit outside of tests doing very strange things (since v10.0.0).
+
 ### Breaking changes
 * None.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@
 
 ### Internals
 * ConstTableView and TableView are merged into just TableView. TableView::front(), TableView::back(), TableView::remove() and TableView::remove_last() function are removed as they were not used outside tests.
+* The client file UUID has been removed as it was no longer being used for anything.
 
 ----------------------------------------------
 

--- a/src/realm/object-store/sync/impl/sync_metadata.cpp
+++ b/src/realm/object-store/sync/impl/sync_metadata.cpp
@@ -182,21 +182,6 @@ SyncMetadataManager::SyncMetadataManager(std::string path, bool should_encrypt,
         object_schema->persisted_properties[0].column_key, object_schema->persisted_properties[1].column_key,
         object_schema->persisted_properties[2].column_key, object_schema->persisted_properties[3].column_key,
         object_schema->persisted_properties[4].column_key};
-
-    m_client_uuid = [&]() -> std::string {
-        TableRef table = ObjectStore::table_for_object_type(realm->read_group(), c_sync_clientMetadata);
-        if (table->is_empty()) {
-            realm->begin_transaction();
-            if (table->is_empty()) {
-                auto uuid = util::uuid_string();
-                table->create_object().set(m_client_schema.idx_uuid, uuid);
-                realm->commit_transaction();
-                return uuid;
-            }
-            realm->cancel_transaction();
-        }
-        return table->begin()->get<String>(m_client_schema.idx_uuid);
-    }();
 }
 
 SyncUserMetadataResults SyncMetadataManager::all_unmarked_users() const

--- a/src/realm/object-store/sync/impl/sync_metadata.hpp
+++ b/src/realm/object-store/sync/impl/sync_metadata.hpp
@@ -245,12 +245,6 @@ public:
     void make_file_action_metadata(StringData original_name, StringData partition_key_value, StringData local_uuid,
                                    SyncFileActionMetadata::Action action, StringData new_name = {}) const;
 
-    // Get the unique identifier of this client.
-    const std::string& client_uuid() const
-    {
-        return m_client_uuid;
-    }
-
     util::Optional<std::string> get_current_user_identity() const;
     void set_current_user_identity(const std::string& identity);
 
@@ -274,8 +268,6 @@ private:
     SyncClientMetadata::Schema m_client_schema;
     SyncClientMetadata::Schema m_current_user_identity_schema;
     SyncAppMetadata::Schema m_app_metadata_schema;
-
-    std::string m_client_uuid;
 
     std::shared_ptr<Realm> get_realm() const;
 

--- a/src/realm/object-store/sync/sync_manager.cpp
+++ b/src/realm/object-store/sync/sync_manager.cpp
@@ -44,14 +44,12 @@ SyncClientTimeouts::SyncClientTimeouts()
 void SyncManager::configure(std::shared_ptr<app::App> app, const std::string& sync_route,
                             const SyncClientConfig& config)
 {
-    {
-        std::lock_guard<std::mutex> lock(m_mutex);
-        m_app = app;
-        m_sync_route = sync_route;
-        m_config = std::move(config);
-        if (m_sync_client)
-            return;
-    }
+    util::CheckedLockGuard lock(m_mutex);
+    m_app = app;
+    m_sync_route = sync_route;
+    m_config = std::move(config);
+    if (m_sync_client)
+        return;
 
     struct UserCreationData {
         std::string identity;
@@ -65,7 +63,7 @@ void SyncManager::configure(std::shared_ptr<app::App> app, const std::string& sy
 
     std::vector<UserCreationData> users_to_add;
     {
-        std::lock_guard<std::mutex> lock(m_file_system_mutex);
+        util::CheckedLockGuard lock(m_file_system_mutex);
 
         // Set up the file manager.
         if (m_file_manager) {
@@ -152,7 +150,7 @@ void SyncManager::configure(std::shared_ptr<app::App> app, const std::string& sy
         }
     }
     {
-        std::lock_guard<std::mutex> lock(m_user_mutex);
+        util::CheckedLockGuard lock(m_user_mutex);
         for (auto& user_data : users_to_add) {
             auto& identity = user_data.identity;
             auto& provider_type = user_data.provider_type;
@@ -167,6 +165,7 @@ void SyncManager::configure(std::shared_ptr<app::App> app, const std::string& sy
 
 bool SyncManager::immediately_run_file_actions(const std::string& realm_path)
 {
+    util::CheckedLockGuard lock(m_file_system_mutex);
     if (!m_metadata_manager) {
         return false;
     }
@@ -208,13 +207,15 @@ bool SyncManager::run_file_action(const SyncFileActionMetadata& md)
 
 void SyncManager::reset_for_testing()
 {
-    std::lock_guard<std::mutex> lock(m_file_system_mutex);
-    m_metadata_manager = nullptr;
-    m_client_uuid = util::none;
+    {
+        util::CheckedLockGuard lock(m_file_system_mutex);
+        m_metadata_manager = nullptr;
+        m_client_uuid = util::none;
+    }
 
     {
         // Destroy all the users.
-        std::lock_guard<std::mutex> lock(m_user_mutex);
+        util::CheckedLockGuard lock(m_user_mutex);
         for (auto& user : m_users) {
             user->detach_from_sync_manager();
         }
@@ -222,14 +223,14 @@ void SyncManager::reset_for_testing()
         m_current_user = nullptr;
     }
     {
-        std::lock_guard<std::mutex> lock(m_mutex);
+        util::CheckedLockGuard lock(m_mutex);
 
         // Stop the client. This will abort any uploads that inactive sessions are waiting for.
         if (m_sync_client)
             m_sync_client->stop();
 
         {
-            std::lock_guard<std::mutex> lock(m_session_mutex);
+            util::CheckedLockGuard lock(m_session_mutex);
             // Callers of `SyncManager::reset_for_testing` should ensure there are no existing sessions
             // prior to calling `reset_for_testing`.
             bool no_sessions = !do_has_existing_sessions();
@@ -252,20 +253,23 @@ void SyncManager::reset_for_testing()
         m_sync_route = "";
     }
 
-    if (m_file_manager)
-        util::try_remove_dir_recursive(m_file_manager->base_path());
-    m_file_manager = nullptr;
+    {
+        util::CheckedLockGuard lock(m_file_system_mutex);
+        if (m_file_manager)
+            util::try_remove_dir_recursive(m_file_manager->base_path());
+        m_file_manager = nullptr;
+    }
 }
 
 void SyncManager::set_log_level(util::Logger::Level level) noexcept
 {
-    std::lock_guard<std::mutex> lock(m_mutex);
+    util::CheckedLockGuard lock(m_mutex);
     m_config.log_level = level;
 }
 
 void SyncManager::set_logger_factory(SyncClientConfig::LoggerFactory factory) noexcept
 {
-    std::lock_guard<std::mutex> lock(m_mutex);
+    util::CheckedLockGuard lock(m_mutex);
     m_config.logger_factory = std::move(factory);
 }
 
@@ -282,19 +286,19 @@ std::unique_ptr<util::Logger> SyncManager::make_logger() const
 
 void SyncManager::set_user_agent(std::string user_agent)
 {
-    std::lock_guard<std::mutex> lock(m_mutex);
+    util::CheckedLockGuard lock(m_mutex);
     m_config.user_agent_application_info = std::move(user_agent);
 }
 
 void SyncManager::set_timeouts(SyncClientTimeouts timeouts)
 {
-    std::lock_guard<std::mutex> lock(m_mutex);
+    util::CheckedLockGuard lock(m_mutex);
     m_config.timeouts = timeouts;
 }
 
 void SyncManager::reconnect() const
 {
-    std::lock_guard<std::mutex> lock(m_session_mutex);
+    util::CheckedLockGuard lock(m_session_mutex);
     for (auto& it : m_sessions) {
         it.second->handle_reconnect();
     }
@@ -302,13 +306,13 @@ void SyncManager::reconnect() const
 
 util::Logger::Level SyncManager::log_level() const noexcept
 {
-    std::lock_guard<std::mutex> lock(m_mutex);
+    util::CheckedLockGuard lock(m_mutex);
     return m_config.log_level;
 }
 
 bool SyncManager::perform_metadata_update(std::function<void(const SyncMetadataManager&)> update_function) const
 {
-    std::lock_guard<std::mutex> lock(m_file_system_mutex);
+    util::CheckedLockGuard lock(m_file_system_mutex);
     if (!m_metadata_manager) {
         return false;
     }
@@ -320,7 +324,7 @@ std::shared_ptr<SyncUser> SyncManager::get_user(const std::string& user_id, std:
                                                 std::string access_token, const std::string provider_type,
                                                 std::string device_id)
 {
-    std::lock_guard<std::mutex> lock(m_user_mutex);
+    util::CheckedLockGuard lock(m_user_mutex);
     auto it = std::find_if(m_users.begin(), m_users.end(), [user_id, provider_type](const auto& user) {
         return user->identity() == user_id && user->provider_type() == provider_type &&
                user->state() != SyncUser::State::Removed;
@@ -331,8 +335,12 @@ std::shared_ptr<SyncUser> SyncManager::get_user(const std::string& user_id, std:
             std::make_shared<SyncUser>(std::move(refresh_token), user_id, provider_type, std::move(access_token),
                                        SyncUser::State::LoggedIn, device_id, this);
         m_users.emplace(m_users.begin(), new_user);
-        if (!m_metadata_manager)
-            m_current_user = new_user;
+        {
+            util::CheckedLockGuard lock(m_file_system_mutex);
+            // m_current_user is normally set very indirectly via the metadata manger
+            if (!m_metadata_manager)
+                m_current_user = new_user;
+        }
         return new_user;
     }
     else { // LoggedOut => LoggedIn
@@ -345,7 +353,7 @@ std::shared_ptr<SyncUser> SyncManager::get_user(const std::string& user_id, std:
 
 std::vector<std::shared_ptr<SyncUser>> SyncManager::all_users()
 {
-    std::lock_guard<std::mutex> lock(m_user_mutex);
+    util::CheckedLockGuard lock(m_user_mutex);
     m_users.erase(std::remove_if(m_users.begin(), m_users.end(),
                                  [](auto& user) {
                                      bool should_remove = (user->state() == SyncUser::State::Removed);
@@ -369,11 +377,11 @@ std::shared_ptr<SyncUser> SyncManager::get_user_for_identity(std::string const& 
 
 std::shared_ptr<SyncUser> SyncManager::get_current_user() const
 {
-    std::lock_guard<std::mutex> lock(m_user_mutex);
+    util::CheckedLockGuard lock(m_user_mutex);
 
     if (m_current_user)
         return m_current_user;
-    std::lock_guard<std::mutex> fs_lock(m_file_system_mutex);
+    util::CheckedLockGuard fs_lock(m_file_system_mutex);
     if (!m_metadata_manager)
         return nullptr;
 
@@ -383,7 +391,7 @@ std::shared_ptr<SyncUser> SyncManager::get_current_user() const
 
 void SyncManager::log_out_user(const std::string& user_id)
 {
-    std::lock_guard<std::mutex> lock(m_user_mutex);
+    util::CheckedLockGuard lock(m_user_mutex);
 
     // Move this user to the end of the vector
     if (m_users.size() > 1) {
@@ -395,6 +403,7 @@ void SyncManager::log_out_user(const std::string& user_id)
             std::rotate(it, it + 1, m_users.end());
     }
 
+    util::CheckedLockGuard fs_lock(m_file_system_mutex);
     bool was_active = (m_current_user && m_current_user->identity() == user_id) ||
                       (m_metadata_manager && m_metadata_manager->get_current_user_identity() == user_id);
     if (!was_active)
@@ -410,7 +419,6 @@ void SyncManager::log_out_user(const std::string& user_id)
         }
     }
 
-    std::lock_guard<std::mutex> fs_lock(m_file_system_mutex);
     if (m_metadata_manager)
         m_metadata_manager->set_current_user_identity("");
     m_current_user = nullptr;
@@ -418,23 +426,23 @@ void SyncManager::log_out_user(const std::string& user_id)
 
 void SyncManager::set_current_user(const std::string& user_id)
 {
-    std::lock_guard<std::mutex> lock(m_user_mutex);
+    util::CheckedLockGuard lock(m_user_mutex);
 
     m_current_user = get_user_for_identity(user_id);
-    std::lock_guard<std::mutex> fs_lock(m_file_system_mutex);
+    util::CheckedLockGuard fs_lock(m_file_system_mutex);
     if (m_metadata_manager)
         m_metadata_manager->set_current_user_identity(user_id);
 }
 
 void SyncManager::remove_user(const std::string& user_id)
 {
-    std::lock_guard<std::mutex> lock(m_user_mutex);
+    util::CheckedLockGuard lock(m_user_mutex);
     auto user = get_user_for_identity(user_id);
     if (!user)
         return;
     user->set_state(SyncUser::State::Removed);
 
-    std::lock_guard<std::mutex> fs_lock(m_file_system_mutex);
+    util::CheckedLockGuard fs_lock(m_file_system_mutex);
     if (!m_metadata_manager)
         return;
 
@@ -449,9 +457,9 @@ void SyncManager::remove_user(const std::string& user_id)
 SyncManager::~SyncManager()
 {
     // Grab a vector of the current sessions under a lock so we can shut them down. We have to make a copy because
-    // session->shutdown_and_wait() will modify th m_sessions map.
+    // session->shutdown_and_wait() will modify the m_sessions map.
     auto current_sessions = [&] {
-        std::lock_guard<std::mutex> lk(m_session_mutex);
+        util::CheckedLockGuard lk(m_session_mutex);
         std::vector<std::shared_ptr<SyncSession>> current_sessions;
         std::transform(m_sessions.begin(), m_sessions.end(), std::back_inserter(current_sessions),
                        [](const auto& session_kv) {
@@ -467,7 +475,7 @@ SyncManager::~SyncManager()
     // At this point we should have drained all the sessions.
 #ifdef REALM_DEBUG
     {
-        std::lock_guard<std::mutex> lk(m_session_mutex);
+        util::CheckedLockGuard lk(m_session_mutex);
         REALM_ASSERT(m_sessions.empty());
     }
 #endif
@@ -483,7 +491,7 @@ SyncManager::~SyncManager()
 
 std::shared_ptr<SyncUser> SyncManager::get_existing_logged_in_user(const std::string& user_id) const
 {
-    std::lock_guard<std::mutex> lock(m_user_mutex);
+    util::CheckedLockGuard lock(m_user_mutex);
     auto user = get_user_for_identity(user_id);
     return user && user->state() == SyncUser::State::LoggedIn ? user : nullptr;
 }
@@ -531,14 +539,14 @@ static std::string string_from_partition(const std::string& partition)
 
 std::string SyncManager::path_for_realm(const SyncUser& user, const std::string& realm_file_name) const
 {
-    std::lock_guard<std::mutex> lock(m_file_system_mutex);
+    util::CheckedLockGuard lock(m_file_system_mutex);
     REALM_ASSERT(m_file_manager);
     return m_file_manager->realm_file_path(user.identity(), user.local_identity(), realm_file_name);
 }
 
 std::string SyncManager::path_for_realm(const SyncConfig& config, util::Optional<std::string> custom_file_name) const
 {
-    std::lock_guard<std::mutex> lock(m_file_system_mutex);
+    util::CheckedLockGuard lock(m_file_system_mutex);
     REALM_ASSERT(m_file_manager);
     REALM_ASSERT(config.user);
 
@@ -562,14 +570,14 @@ std::string SyncManager::path_for_realm(const SyncConfig& config, util::Optional
 
 std::string SyncManager::recovery_directory_path(util::Optional<std::string> const& custom_dir_name) const
 {
-    std::lock_guard<std::mutex> lock(m_file_system_mutex);
+    util::CheckedLockGuard lock(m_file_system_mutex);
     REALM_ASSERT(m_file_manager);
     return m_file_manager->recovery_directory_path(custom_dir_name);
 }
 
 std::shared_ptr<SyncSession> SyncManager::get_existing_active_session(const std::string& path) const
 {
-    std::lock_guard<std::mutex> lock(m_session_mutex);
+    util::CheckedLockGuard lock(m_session_mutex);
     if (auto session = get_existing_session_locked(path)) {
         if (auto external_reference = session->existing_external_reference())
             return external_reference;
@@ -579,14 +587,13 @@ std::shared_ptr<SyncSession> SyncManager::get_existing_active_session(const std:
 
 std::shared_ptr<SyncSession> SyncManager::get_existing_session_locked(const std::string& path) const
 {
-    REALM_ASSERT(!m_session_mutex.try_lock());
     auto it = m_sessions.find(path);
     return it == m_sessions.end() ? nullptr : it->second;
 }
 
 std::shared_ptr<SyncSession> SyncManager::get_existing_session(const std::string& path) const
 {
-    std::lock_guard<std::mutex> lock(m_session_mutex);
+    util::CheckedLockGuard lock(m_session_mutex);
     if (auto session = get_existing_session_locked(path))
         return session->external_reference();
 
@@ -598,7 +605,7 @@ std::shared_ptr<SyncSession> SyncManager::get_session(std::shared_ptr<DB> db, co
     auto& client = get_sync_client(); // Throws
     auto path = db->get_path();
 
-    std::unique_lock<std::mutex> lock(m_session_mutex);
+    util::CheckedUniqueLock lock(m_session_mutex);
     if (auto session = get_existing_session_locked(path)) {
         sync_config.user->register_session(session);
         return session->external_reference();
@@ -622,7 +629,7 @@ std::shared_ptr<SyncSession> SyncManager::get_session(std::shared_ptr<DB> db, co
 
 bool SyncManager::has_existing_sessions()
 {
-    std::lock_guard<std::mutex> lock(m_session_mutex);
+    util::CheckedLockGuard lock(m_session_mutex);
     return do_has_existing_sessions();
 }
 
@@ -641,7 +648,7 @@ void SyncManager::wait_for_sessions_to_terminate()
 
 void SyncManager::unregister_session(const std::string& path)
 {
-    std::unique_lock<std::mutex> lock(m_session_mutex);
+    util::CheckedUniqueLock lock(m_session_mutex);
     auto it = m_sessions.find(path);
     if (it == m_sessions.end()) {
         // There was a race to unregister and there's nothing left to do here.
@@ -671,7 +678,7 @@ void SyncManager::unregister_session(const std::string& path)
 
 void SyncManager::enable_session_multiplexing()
 {
-    std::lock_guard<std::mutex> lock(m_mutex);
+    util::CheckedLockGuard lock(m_mutex);
     if (m_config.multiplex_sessions)
         return; // Already enabled, we can ignore
 
@@ -683,7 +690,7 @@ void SyncManager::enable_session_multiplexing()
 
 SyncClient& SyncManager::get_sync_client() const
 {
-    std::lock_guard<std::mutex> lock(m_mutex);
+    util::CheckedLockGuard lock(m_mutex);
     if (!m_sync_client)
         m_sync_client = create_sync_client(); // Throws
     return *m_sync_client;
@@ -691,7 +698,6 @@ SyncClient& SyncManager::get_sync_client() const
 
 std::unique_ptr<SyncClient> SyncManager::create_sync_client() const
 {
-    REALM_ASSERT(!m_mutex.try_lock());
     return std::make_unique<SyncClient>(make_logger(), m_config, weak_from_this());
 }
 
@@ -703,7 +709,7 @@ std::string SyncManager::client_uuid() const
 
 util::Optional<SyncAppMetadata> SyncManager::app_metadata() const
 {
-    std::lock_guard<std::mutex> lock(m_file_system_mutex);
+    util::CheckedLockGuard lock(m_file_system_mutex);
     if (!m_metadata_manager) {
         return util::none;
     }

--- a/src/realm/object-store/sync/sync_manager.cpp
+++ b/src/realm/object-store/sync/sync_manager.cpp
@@ -77,9 +77,6 @@ void SyncManager::configure(std::shared_ptr<app::App> app, const std::string& sy
 
         // Set up the metadata manager, and perform initial loading/purging work.
         if (m_metadata_manager || m_config.metadata_mode == MetadataMode::NoMetadata) {
-            // No metadata means we use a new client uuid each time
-            if (!m_metadata_manager)
-                m_client_uuid = util::uuid_string();
             return;
         }
 
@@ -99,7 +96,6 @@ void SyncManager::configure(std::shared_ptr<app::App> app, const std::string& sy
         }
 
         REALM_ASSERT(m_metadata_manager);
-        m_client_uuid = m_metadata_manager->client_uuid();
 
         // Perform our "on next startup" actions such as deleting Realm files
         // which we couldn't delete immediately due to them being in use
@@ -210,7 +206,6 @@ void SyncManager::reset_for_testing()
     {
         util::CheckedLockGuard lock(m_file_system_mutex);
         m_metadata_manager = nullptr;
-        m_client_uuid = util::none;
     }
 
     {
@@ -699,12 +694,6 @@ SyncClient& SyncManager::get_sync_client() const
 std::unique_ptr<SyncClient> SyncManager::create_sync_client() const
 {
     return std::make_unique<SyncClient>(make_logger(), m_config, weak_from_this());
-}
-
-std::string SyncManager::client_uuid() const
-{
-    REALM_ASSERT(m_client_uuid);
-    return *m_client_uuid;
 }
 
 util::Optional<SyncAppMetadata> SyncManager::app_metadata() const

--- a/src/realm/object-store/sync/sync_manager.hpp
+++ b/src/realm/object-store/sync/sync_manager.hpp
@@ -20,6 +20,7 @@
 #define REALM_OS_SYNC_MANAGER_HPP
 
 #include <realm/object-store/shared_realm.hpp>
+#include <realm/object-store/util/checked_mutex.hpp>
 
 #include <realm/util/logger.hpp>
 #include <realm/util/optional.hpp>
@@ -98,13 +99,13 @@ public:
     // Returns whether or not a file action was successfully executed for the specified Realm.
     // Preconditions: all references to the Realm at the given path must have already been invalidated.
     // The metadata and file management subsystems must also have already been configured.
-    bool immediately_run_file_actions(const std::string& original_name);
+    bool immediately_run_file_actions(const std::string& original_name) REQUIRES(!m_file_system_mutex);
 
     // Use a single connection for all sync sessions for each host/port rather
     // than one per session.
     // This must be called before any sync sessions are created, cannot be
     // disabled afterwards, and currently is incompatible with automatic failover.
-    void enable_session_multiplexing();
+    void enable_session_multiplexing() REQUIRES(!m_mutex);
 
     // Destroys the sync manager, terminates all sessions created by it, and stops its SyncClient.
     ~SyncManager();
@@ -112,19 +113,19 @@ public:
     // Sets the log level for the Sync Client.
     // The log level can only be set up until the point the Sync Client is created. This happens when the first
     // Session is created.
-    void set_log_level(util::Logger::Level) noexcept;
-    void set_logger_factory(SyncClientConfig::LoggerFactory) noexcept;
+    void set_log_level(util::Logger::Level) noexcept REQUIRES(!m_mutex);
+    void set_logger_factory(SyncClientConfig::LoggerFactory) noexcept REQUIRES(!m_mutex);
 
     // Sets the application level user agent string.
     // This should have the format specified here:
     // https://github.com/realm/realm-sync/blob/develop/src/realm/sync/client.hpp#L126 The user agent can only be set
     // up  until the  point the Sync Client is created. This happens when the first Session is created.
-    void set_user_agent(std::string user_agent);
+    void set_user_agent(std::string user_agent) REQUIRES(!m_mutex);
 
     // Sets client timeout settings.
     // The timeout settings can only be set up until the point the Sync Client is created.
     // This happens when the first Session is created.
-    void set_timeouts(SyncClientTimeouts timeouts);
+    void set_timeouts(SyncClientTimeouts timeouts) REQUIRES(!m_mutex);
 
     /// Ask all valid sync sessions to perform whatever tasks might be necessary to
     /// re-establish connectivity with the Realm Object Server. It is presumed that
@@ -132,64 +133,71 @@ public:
     ///
     /// Refer to `SyncSession::handle_reconnect()` to see what sort of work is done
     /// on a per-session basis.
-    void reconnect() const;
+    void reconnect() const REQUIRES(!m_session_mutex);
 
-    util::Logger::Level log_level() const noexcept;
+    util::Logger::Level log_level() const noexcept REQUIRES(!m_mutex);
 
-    std::shared_ptr<SyncSession> get_session(std::shared_ptr<DB> db, const SyncConfig& config);
-    std::shared_ptr<SyncSession> get_existing_session(const std::string& path) const;
-    std::shared_ptr<SyncSession> get_existing_active_session(const std::string& path) const;
+    std::shared_ptr<SyncSession> get_session(std::shared_ptr<DB> db, const SyncConfig& config)
+        REQUIRES(!m_mutex, !m_session_mutex);
+    std::shared_ptr<SyncSession> get_existing_session(const std::string& path) const REQUIRES(!m_session_mutex);
+    std::shared_ptr<SyncSession> get_existing_active_session(const std::string& path) const
+        REQUIRES(!m_session_mutex);
 
     // Returns `true` if the SyncManager still contains any existing sessions not yet fully cleaned up.
     // This will return true as long as there is an external reference to a session object, no matter
     // the state of that session.
-    bool has_existing_sessions();
+    bool has_existing_sessions() REQUIRES(!m_session_mutex);
 
     // Blocking call that only return once all sessions have been terminated.
     // Due to the async nature of the SyncClient, even with `SyncSessionStopPolicy::Immediate`, a
     // session is not guaranteed to stop immediately when a Realm is closed. Using this method
     // makes it possible to guarantee that all sessions have, in fact, been closed.
-    void wait_for_sessions_to_terminate();
+    void wait_for_sessions_to_terminate() REQUIRES(!m_mutex);
 
     // If the metadata manager is configured, perform an update. Returns `true` iff the code was run.
-    bool perform_metadata_update(std::function<void(const SyncMetadataManager&)> update_function) const;
+    bool perform_metadata_update(std::function<void(const SyncMetadataManager&)> update_function) const
+        REQUIRES(!m_file_system_mutex);
 
     // Get a sync user for a given identity, or create one if none exists yet, and set its token.
     // If a logged-out user exists, it will marked as logged back in.
     std::shared_ptr<SyncUser> get_user(const std::string& id, std::string refresh_token, std::string access_token,
-                                       const std::string provider_type, std::string device_id);
+                                       const std::string provider_type, std::string device_id)
+        REQUIRES(!m_user_mutex, !m_file_system_mutex);
 
     // Get an existing user for a given identifier, if one exists and is logged in.
-    std::shared_ptr<SyncUser> get_existing_logged_in_user(const std::string& user_id) const;
+    std::shared_ptr<SyncUser> get_existing_logged_in_user(const std::string& user_id) const REQUIRES(!m_user_mutex);
 
     // Get all the users that are logged in and not errored out.
-    std::vector<std::shared_ptr<SyncUser>> all_users();
+    std::vector<std::shared_ptr<SyncUser>> all_users() REQUIRES(!m_user_mutex);
 
     // Gets the currently active user.
-    std::shared_ptr<SyncUser> get_current_user() const;
+    std::shared_ptr<SyncUser> get_current_user() const REQUIRES(!m_user_mutex, !m_file_system_mutex);
 
     // Log out a given user
-    void log_out_user(const std::string& user_id);
+    void log_out_user(const std::string& user_id) REQUIRES(!m_user_mutex, !m_file_system_mutex);
 
     // Sets the currently active user.
-    void set_current_user(const std::string& user_id);
+    void set_current_user(const std::string& user_id) REQUIRES(!m_user_mutex, !m_file_system_mutex);
 
     // Removes a user
-    void remove_user(const std::string& user_id);
+    void remove_user(const std::string& user_id) REQUIRES(!m_user_mutex, !m_file_system_mutex);
 
     // Get the default path for a Realm for the given user and absolute unresolved URL.
     // If the default path of `<rootDir>/<appId>/<userId>/<realm_file_name>.realm` cannot
     // be created, this function may pass back `<rootDir>/<hashedFileName>.realm`
-    std::string path_for_realm(const SyncUser& user, const std::string& realm_file_name) const;
+    std::string path_for_realm(const SyncUser& user, const std::string& realm_file_name) const
+        REQUIRES(!m_file_system_mutex);
 
     // Get the default path for a Realm for the given configuration.
     // The default value is `<rootDir>/<appId>/<userId>/<partitionValue>.realm`.
     // If the file cannot be created at this location, for example due to path length restrictions,
     // this function may pass back `<rootDir>/<hashedFileName>.realm`
-    std::string path_for_realm(const SyncConfig& config, util::Optional<std::string> custom_file_name = none) const;
+    std::string path_for_realm(const SyncConfig& config, util::Optional<std::string> custom_file_name = none) const
+        REQUIRES(!m_file_system_mutex);
 
     // Get the path of the recovery directory for backed-up or recovered Realms.
-    std::string recovery_directory_path(util::Optional<std::string> const& custom_dir_name = none) const;
+    std::string recovery_directory_path(util::Optional<std::string> const& custom_dir_name = none) const
+        REQUIRES(!m_file_system_mutex);
 
     // Get the unique identifier of this client.
     std::string client_uuid() const;
@@ -197,26 +205,26 @@ public:
     // Reset the singleton state for testing purposes. DO NOT CALL OUTSIDE OF TESTING CODE.
     // Precondition: any synced Realms or `SyncSession`s must be closed or rendered inactive prior to
     // calling this method.
-    void reset_for_testing();
+    void reset_for_testing() REQUIRES(!m_mutex, !m_file_system_mutex, !m_user_mutex, !m_session_mutex);
 
     // Get the app metadata for the active app.
-    util::Optional<SyncAppMetadata> app_metadata() const;
+    util::Optional<SyncAppMetadata> app_metadata() const REQUIRES(!m_file_system_mutex);
 
-    void set_sync_route(std::string sync_route)
+    void set_sync_route(std::string sync_route) REQUIRES(!m_mutex)
     {
-        std::lock_guard<std::mutex> lock(m_mutex);
+        util::CheckedLockGuard lock(m_mutex);
         m_sync_route = std::move(sync_route);
     }
 
-    const std::string sync_route() const
+    const std::string sync_route() const REQUIRES(!m_mutex)
     {
-        std::lock_guard<std::mutex> lock(m_mutex);
+        util::CheckedLockGuard lock(m_mutex);
         return m_sync_route;
     }
 
-    std::weak_ptr<app::App> app() const
+    std::weak_ptr<app::App> app() const REQUIRES(!m_mutex)
     {
-        std::lock_guard<std::mutex> lock(m_mutex);
+        util::CheckedLockGuard lock(m_mutex);
         return m_app;
     }
 
@@ -234,62 +242,64 @@ protected:
 private:
     friend class app::App;
 
-    void configure(std::shared_ptr<app::App> app, const std::string& sync_route, const SyncClientConfig& config);
+    void configure(std::shared_ptr<app::App> app, const std::string& sync_route, const SyncClientConfig& config)
+        REQUIRES(!m_mutex, !m_file_system_mutex, !m_user_mutex, !m_session_mutex);
 
     // Stop tracking the session for the given path if it is inactive.
     // No-op if the session is either still active or in the active sessions list
     // due to someone holding a strong reference to it.
-    void unregister_session(const std::string& path);
+    void unregister_session(const std::string& path) REQUIRES(!m_session_mutex);
 
-    _impl::SyncClient& get_sync_client() const;
-    std::unique_ptr<_impl::SyncClient> create_sync_client() const;
+    _impl::SyncClient& get_sync_client() const REQUIRES(!m_mutex);
+    std::unique_ptr<_impl::SyncClient> create_sync_client() const REQUIRES(m_mutex);
 
-    std::shared_ptr<SyncSession> get_existing_session_locked(const std::string& path) const;
+    std::shared_ptr<SyncSession> get_existing_session_locked(const std::string& path) const REQUIRES(m_session_mutex);
 
-    std::shared_ptr<SyncUser> get_user_for_identity(std::string const& identity) const noexcept;
+    std::shared_ptr<SyncUser> get_user_for_identity(std::string const& identity) const noexcept
+        REQUIRES(m_user_mutex);
 
-    mutable std::mutex m_mutex;
+    mutable util::CheckedMutex m_mutex;
 
-    bool run_file_action(const SyncFileActionMetadata&);
+    bool run_file_action(const SyncFileActionMetadata&) REQUIRES(m_file_system_mutex);
     void init_metadata(SyncClientConfig config, const std::string& app_id);
 
     // Create a new logger of the type which will be used by the sync client
-    std::unique_ptr<util::Logger> make_logger() const;
+    std::unique_ptr<util::Logger> make_logger() const REQUIRES(m_mutex);
 
     // Protects m_users
-    mutable std::mutex m_user_mutex;
+    mutable util::CheckedMutex m_user_mutex;
 
     // A vector of all SyncUser objects.
-    std::vector<std::shared_ptr<SyncUser>> m_users;
-    std::shared_ptr<SyncUser> m_current_user;
+    std::vector<std::shared_ptr<SyncUser>> m_users GUARDED_BY(m_user_mutex);
+    std::shared_ptr<SyncUser> m_current_user GUARDED_BY(m_user_mutex);
 
     mutable std::unique_ptr<_impl::SyncClient> m_sync_client;
 
-    SyncClientConfig m_config;
+    SyncClientConfig m_config GUARDED_BY(m_mutex);
 
     // Protects m_file_manager and m_metadata_manager
-    mutable std::mutex m_file_system_mutex;
-    std::unique_ptr<SyncFileManager> m_file_manager;
-    std::unique_ptr<SyncMetadataManager> m_metadata_manager;
+    mutable util::CheckedMutex m_file_system_mutex;
+    std::unique_ptr<SyncFileManager> m_file_manager GUARDED_BY(m_file_system_mutex);
+    std::unique_ptr<SyncMetadataManager> m_metadata_manager GUARDED_BY(m_file_system_mutex);
 
     // Protects m_sessions
-    mutable std::mutex m_session_mutex;
+    mutable util::CheckedMutex m_session_mutex;
 
     // Map of sessions by path name.
     // Sessions remove themselves from this map by calling `unregister_session` once they're
     // inactive and have performed any necessary cleanup work.
-    std::unordered_map<std::string, std::shared_ptr<SyncSession>> m_sessions;
+    std::unordered_map<std::string, std::shared_ptr<SyncSession>> m_sessions GUARDED_BY(m_session_mutex);
 
     // Internal method returning `true` if the SyncManager still contains sessions not yet fully closed.
     // Callers of this method should hold the `m_session_mutex` themselves.
-    bool do_has_existing_sessions();
+    bool do_has_existing_sessions() REQUIRES(m_session_mutex);
 
     // The unique identifier of this client.
     util::Optional<std::string> m_client_uuid;
 
-    std::string m_sync_route;
+    std::string m_sync_route GUARDED_BY(m_mutex);
 
-    std::weak_ptr<app::App> m_app;
+    std::weak_ptr<app::App> m_app GUARDED_BY(m_mutex);
 };
 
 } // namespace realm

--- a/src/realm/object-store/sync/sync_manager.hpp
+++ b/src/realm/object-store/sync/sync_manager.hpp
@@ -199,9 +199,6 @@ public:
     std::string recovery_directory_path(util::Optional<std::string> const& custom_dir_name = none) const
         REQUIRES(!m_file_system_mutex);
 
-    // Get the unique identifier of this client.
-    std::string client_uuid() const;
-
     // Reset the singleton state for testing purposes. DO NOT CALL OUTSIDE OF TESTING CODE.
     // Precondition: any synced Realms or `SyncSession`s must be closed or rendered inactive prior to
     // calling this method.
@@ -293,9 +290,6 @@ private:
     // Internal method returning `true` if the SyncManager still contains sessions not yet fully closed.
     // Callers of this method should hold the `m_session_mutex` themselves.
     bool do_has_existing_sessions() REQUIRES(m_session_mutex);
-
-    // The unique identifier of this client.
-    util::Optional<std::string> m_client_uuid;
 
     std::string m_sync_route GUARDED_BY(m_mutex);
 

--- a/src/realm/sync/changeset_encoder.hpp
+++ b/src/realm/sync/changeset_encoder.hpp
@@ -14,7 +14,7 @@ struct ChangesetEncoder : InstructionHandler {
 
     Buffer release() noexcept;
     void reset() noexcept;
-    const Buffer& buffer() const noexcept;
+    Buffer& buffer() noexcept;
     InternString intern_string(StringData);
 
     void set_intern_string(uint32_t index, StringBufferRange) override;
@@ -73,13 +73,9 @@ private:
     StringData m_string_range;
 };
 
-template <class Allocator>
-void encode_changeset(const Changeset&, util::AppendBuffer<char, Allocator>& out_buffer);
-
-
 // Implementation
 
-inline auto ChangesetEncoder::buffer() const noexcept -> const Buffer&
+inline auto ChangesetEncoder::buffer() noexcept -> Buffer&
 {
     return m_buffer;
 }
@@ -102,13 +98,12 @@ inline StringData ChangesetEncoder::get_string(StringBufferRange range) const no
     return StringData{data, size};
 }
 
-template <class Allocator>
-void encode_changeset(const Changeset& changeset, util::AppendBuffer<char, Allocator>& out_buffer)
+inline void encode_changeset(const Changeset& changeset, ChangesetEncoder::Buffer& out_buffer)
 {
     ChangesetEncoder encoder;
+    swap(encoder.buffer(), out_buffer);
     encoder.encode_single(changeset); // Throws
-    auto& buffer = encoder.buffer();
-    out_buffer.append(buffer.data(), buffer.size()); // Throws
+    swap(encoder.buffer(), out_buffer);
 }
 
 } // namespace sync

--- a/src/realm/sync/noinst/client_history_impl.cpp
+++ b/src/realm/sync/noinst/client_history_impl.cpp
@@ -345,7 +345,7 @@ bool ClientHistory::integrate_server_changesets(const SyncProgress& progress,
                                                 changesets.size(), reporter, &logger); // Throws
 
         for (std::size_t i = 0; i < num_changesets; ++i) {
-            util::AppendBuffer<char> transformed_changeset;
+            ChangesetEncoder::Buffer transformed_changeset;
             encode_changeset(changesets[i], transformed_changeset);
 
             InstructionApplier applier{*transact};
@@ -924,7 +924,7 @@ void ClientHistory::fix_up_client_file_ident_in_stored_changesets(Transaction& g
         }
 
         if (did_modify) {
-            util::AppendBuffer<char> modified;
+            ChangesetEncoder::Buffer modified;
             encode_changeset(log, modified);
             BinaryData result = BinaryData{modified.data(), modified.size()};
             m_arrays->changesets.set(i, result);

--- a/src/realm/sync/noinst/client_impl_base.cpp
+++ b/src/realm/sync/noinst/client_impl_base.cpp
@@ -2022,6 +2022,7 @@ void Session::send_upload_message()
 #endif
         }
 
+#if 0 // Upload log compaction is currently not implemented
         if (!get_client().m_disable_upload_compaction) {
             ChangesetEncoder::Buffer encode_buffer;
 
@@ -2048,7 +2049,9 @@ void Session::send_upload_message()
                 uc.progress.client_version, uc.progress.last_integrated_server_version, uc.origin_timestamp,
                 uc.origin_file_ident, BinaryData{encode_buffer.data(), encode_buffer.size()}); // Throws
         }
-        else {
+        else
+#endif
+        {
             upload_message_builder.add_changeset(uc.progress.client_version,
                                                  uc.progress.last_integrated_server_version, uc.origin_timestamp,
                                                  uc.origin_file_ident,

--- a/src/realm/sync/noinst/server/server_history.cpp
+++ b/src/realm/sync/noinst/server/server_history.cpp
@@ -980,7 +980,7 @@ bool ServerHistory::fetch_download_info(file_ident_type client_file_ident, Downl
         AllocationMetricNameScope scope{g_log_compaction_metric};
         compact_changesets(changesets.data(), changesets.size());
 
-        util::AppendBuffer<char> encode_buffer;
+        ChangesetEncoder::Buffer encode_buffer;
         for (std::size_t i = 0; i < changesets.size(); ++i) {
             auto& changeset = changesets[i];
             encode_changeset(changeset, encode_buffer); // Throws
@@ -1364,7 +1364,7 @@ bool ServerHistory::do_compact_history(Logger& logger, bool force)
                            compact_bootstrap_changesets.size()); // Throws
 
 
-        util::AppendBuffer<char> buffer;
+        ChangesetEncoder::Buffer buffer;
         for (std::size_t i = 0; i < num_compactable_changesets_this_iteration; ++i) {
             buffer.clear();
             encode_changeset(compact_bootstrap_changesets[i], buffer);
@@ -1652,7 +1652,7 @@ bool ServerHistory::integrate_remote_changesets(file_ident_type remote_file_iden
             entry.origin_file_ident = changeset.origin_file_ident;
             entry.remote_version = changeset.version;
 
-            util::AppendBuffer<char> changeset_buffer;
+            ChangesetEncoder::Buffer changeset_buffer;
 
             TempShortCircuitReplication tdr{*this}; // Short-circuit while integrating changes
             InstructionApplier applier{transaction};
@@ -2634,7 +2634,7 @@ void ServerHistory::fixup_state_and_changesets_for_assigned_file_ident(Transacti
             }
         }
 
-        util::AppendBuffer<char> modified;
+        ChangesetEncoder::Buffer modified;
         encode_changeset(log, modified);
         BinaryData result = BinaryData{modified.data(), modified.size()};
         m_acc->sh_changesets.set(i, result);

--- a/src/realm/sync/transform.hpp
+++ b/src/realm/sync/transform.hpp
@@ -220,8 +220,6 @@ private:
                                         const HistoryEntry&);
     void flush_reciprocal_transform_cache(TransformHistory&);
 
-    static size_t emit_changesets(const Changeset*, size_t num_changesets, util::Buffer<char>& output_buffer);
-
     struct Discriminant;
     struct Transformer;
     struct MergeTracer;

--- a/src/realm/util/buffer.hpp
+++ b/src/realm/util/buffer.hpp
@@ -162,6 +162,13 @@ public:
     /// usable/logical size.
     REALM_NODISCARD Buffer<T, Allocator> release() noexcept;
 
+    friend void swap(AppendBuffer& a, AppendBuffer& b) noexcept
+    {
+        using std::swap;
+        swap(a.m_buffer, b.m_buffer);
+        swap(a.m_size, b.m_size);
+    }
+
 private:
     util::Buffer<T, Allocator> m_buffer;
     size_t m_size;

--- a/test/object-store/sync/metadata.cpp
+++ b/test/object-store/sync/metadata.cpp
@@ -324,7 +324,6 @@ TEST_CASE("sync_metadata: persistence across metadata manager instances", "[sync
         REQUIRE(first->provider_type() == provider_type);
         REQUIRE(first->access_token() == sample_token);
         REQUIRE(first->state() == SyncUser::State::LoggedIn);
-        auto first_client_uuid = first_manager.client_uuid();
         first->set_state(SyncUser::State::LoggedOut);
 
         SyncMetadataManager second_manager(metadata_path, false);
@@ -333,7 +332,6 @@ TEST_CASE("sync_metadata: persistence across metadata manager instances", "[sync
         REQUIRE(second->provider_type() == provider_type);
         REQUIRE(second->access_token() == sample_token);
         REQUIRE(second->state() == SyncUser::State::LoggedOut);
-        REQUIRE(second_manager.client_uuid() == first_client_uuid);
     }
 }
 

--- a/test/peer.hpp
+++ b/test/peer.hpp
@@ -399,7 +399,7 @@ private:
 
     void encode_changesets(Changeset* changesets, std::size_t num_changesets, util::Logger* logger)
     {
-        util::AppendBuffer<char> encode_buffer;
+        sync::ChangesetEncoder::Buffer encode_buffer;
         for (size_t i = 0; i < num_changesets; ++i) {
             encode_changeset(changesets[i], encode_buffer); // Throws
 
@@ -420,7 +420,7 @@ private:
 
     void encode_changesets(Changeset** changesets, std::size_t num_changesets, util::Logger* logger)
     {
-        util::AppendBuffer<char> encode_buffer;
+        sync::ChangesetEncoder::Buffer encode_buffer;
         for (size_t i = 0; i < num_changesets; ++i) {
             encode_changeset(*changesets[i], encode_buffer); // Throws
 
@@ -491,7 +491,7 @@ inline auto ShortCircuitHistory::integrate_remote_changesets(file_ident_type rem
     m_transformer->transform_remote_changesets(transform_hist, m_local_file_ident, local_version, changesets.data(),
                                                changesets.size(), reporter, logger);
 
-    util::AppendBuffer<char> assembled_transformed_changeset;
+    sync::ChangesetEncoder::Buffer assembled_transformed_changeset;
 
     for (size_t i = 0; i < num_changesets; ++i) {
         sync::InstructionApplier applier{*transact};

--- a/test/test_changeset_encoding.cpp
+++ b/test/test_changeset_encoding.cpp
@@ -13,7 +13,7 @@ Changeset encode_then_parse(const Changeset& changeset)
 {
     using realm::_impl::SimpleNoCopyInputStream;
 
-    util::AppendBuffer<char> buffer;
+    sync::ChangesetEncoder::Buffer buffer;
     encode_changeset(changeset, buffer);
     SimpleNoCopyInputStream stream{buffer.data(), buffer.size()};
     Changeset parsed;

--- a/test/test_sync.cpp
+++ b/test/test_sync.cpp
@@ -5904,8 +5904,6 @@ TEST(Sync_ClientErrorHandler)
 }
 
 
-#ifndef REALM_PLATFORM_WIN32
-
 TEST(Sync_VerifyServerHistoryAfterLargeUpload)
 {
     TEST_DIR(server_dir);
@@ -5946,8 +5944,6 @@ TEST(Sync_VerifyServerHistoryAfterLargeUpload)
         }
     }
 }
-
-#endif // REALM_PLATFORM_WIN32
 
 
 TEST(Sync_ServerSideModify_Randomize)


### PR DESCRIPTION
I hit a deadlock due to a lock-order inversion on m_user_mutex and m_filesystem_mutex, found it difficult to determine what the locking should be, and then adding thread-safety annotations revealed a bunch of problems.

While trying to figure out what lock client_uuid should be guarded by I discovered that it's no longer used for anything, as it was a partial sync thing.