### PR TITLE
Spread query performance statistics over more than one cluster

### DIFF
--- a/src/realm/array_string.hpp
+++ b/src/realm/array_string.hpp
@@ -30,6 +30,7 @@ class Spec;
 class ArrayString : public ArrayPayload {
 public:
     using value_type = StringData;
+    enum class Type { small_strings, medium_strings, big_strings, enum_strings };
 
     explicit ArrayString(Allocator&);
 
@@ -38,6 +39,10 @@ public:
         return nullable ? StringData{} : StringData{""};
     }
 
+    Type get_type() const noexcept
+    {
+        return m_type;
+    }
     // This is only used in the upgrade process
     void set_nullability(bool n)
     {
@@ -128,7 +133,6 @@ private:
         std::aligned_storage<sizeof(ArrayBigBlobs), alignof(ArrayBigBlobs)>::type m_big_blobs;
         std::aligned_storage<sizeof(Array), alignof(Array)>::type m_enum;
     };
-    enum class Type { small_strings, medium_strings, big_strings, enum_strings };
 
     Type m_type = Type::small_strings;
 

--- a/src/realm/query.cpp
+++ b/src/realm/query.cpp
@@ -956,13 +956,13 @@ void Query::aggregate(QueryStateBase& st, ColKey column_key, size_t* resultcount
 
         if (!m_view) {
             auto pn = root_node();
-            auto best = find_best_node(pn);
-            auto node = pn->m_children[best];
+            st.m_best_node = find_best_node(pn);
+            auto node = pn->m_children[st.m_best_node];
             if (node->has_search_index()) {
                 auto keys = node->index_based_keys();
                 // The node having the search index can be removed from the query as we know that
                 // all the objects will match this condition
-                pn->m_children[best] = pn->m_children.back();
+                pn->m_children[st.m_best_node] = pn->m_children.back();
                 pn->m_children.pop_back();
                 for (auto key : keys) {
                     auto obj = m_table->get_object(key);
@@ -1031,29 +1031,53 @@ size_t Query::find_best_node(ParentNode* pn) const
 void Query::aggregate_internal(ParentNode* pn, QueryStateBase* st, size_t start, size_t end,
                                ArrayPayload* source_column) const
 {
+    auto current_node = pn->m_children[st->m_best_node];
     while (start < end) {
+        if (st->m_local_match_count >= findlocals) {
+            // Time to evaluate other nodes
+            // Update m_dD
+            current_node->m_dD = double(st->m_number_checked) / st->m_local_match_count;
+            double current_cost = current_node->cost();
+            bool re_evaluate = false;
+
+            // Make remaining conditions compute their m_dD (statistics)
+            for (size_t c = 0; c < pn->m_children.size() && start < end; c++) {
+                if (c == st->m_best_node)
+                    continue;
+
+                // Skip test if there is no way its cost can ever be better than best node's
+                if (pn->m_children[c]->m_dT > current_cost)
+                    continue;
+
+                // Limit to bestdist in order not to skip too large parts of index nodes
+                size_t td = end;
+                if (pn->m_children[c]->m_dT != 0.0 && start + bestdist < end) {
+                    td = start + bestdist;
+                }
+                size_t prev_pos = start;
+                st->m_local_match_count = 0;
+                start = pn->m_children[c]->aggregate_local(st, start, td, probe_matches, source_column);
+
+                // Calculate new m_dD - and handle the case where st->m_local_match_count is zero
+                pn->m_children[c]->m_dD = double(start - prev_pos) / (st->m_local_match_count + 1);
+                re_evaluate = true;
+            }
+            if (re_evaluate) {
+                st->m_local_match_count = 0;
+                st->m_number_checked = 0;
+                st->m_best_node = find_best_node(pn);
+                current_node = pn->m_children[st->m_best_node];
+                if (start >= end)
+                    return;
+            }
+        }
+        size_t prev_pos = start;
         // Executes start...end range of a query and will stay inside the condition loop of the node it was called
         // on. Can be called on any node; yields same result, but different performance. Returns prematurely if
         // condition of called node has evaluated to true local_matches number of times.
         // Return value is the next row for resuming aggregating (next row that caller must call aggregate_local on)
-        size_t best = find_best_node(pn);
-        start = pn->m_children[best]->aggregate_local(st, start, end, findlocals, source_column);
-        double current_cost = pn->m_children[best]->cost();
-
-        // Make remaining conditions compute their m_dD (statistics)
-        for (size_t c = 0; c < pn->m_children.size() && start < end; c++) {
-            if (c == best)
-                continue;
-
-            // Skip test if there is no way its cost can ever be better than best node's
-            if (pn->m_children[c]->m_dT < current_cost) {
-
-                // Limit to bestdist in order not to skip too large parts of index nodes
-                size_t maxD = pn->m_children[c]->m_dT == 0.0 ? end - start : bestdist;
-                size_t td = pn->m_children[c]->m_dT == 0.0 ? end : (start + maxD > end ? end : start + maxD);
-                start = pn->m_children[c]->aggregate_local(st, start, td, probe_matches, source_column);
-            }
-        }
+        start = current_node->aggregate_local(st, start, end, findlocals, source_column);
+        st->m_number_checked += (start - prev_pos);
     }
 }
 
@@ -1480,9 +1504,10 @@ void Query::find_all(ConstTableView& ret, size_t begin, size_t end, size_t limit
         }
         else {
             auto pn = root_node();
-            auto best = find_best_node(pn);
-            auto node = pn->m_children[best];
-            if (node->has_search_index()) {
+            QueryStateFindAll<KeyColumn> st(ret.m_key_values, limit);
+            st.m_best_node = find_best_node(pn);
+            auto best_node = pn->m_children[st.m_best_node];
+            if (best_node->has_search_index()) {
                 // translate begin/end limiters into corresponding keys
                 auto begin_key = (begin >= m_table->size()) ? ObjKey() : m_table->get_object(begin).get_key();
                 auto end_key = (end >= m_table->size()) ? ObjKey() : m_table->get_object(end).get_key();
@@ -1490,10 +1515,10 @@ void Query::find_all(ConstTableView& ret, size_t begin, size_t end, size_t limit
 
                 // The node having the search index can be removed from the query as we know that
                 // all the objects will match this condition
-                pn->m_children[best] = pn->m_children.back();
+                pn->m_children[st.m_best_node] = pn->m_children.back();
                 pn->m_children.pop_back();
 
-                auto keys = node->index_based_keys();
+                auto keys = best_node->index_based_keys();
                 for (auto key : keys) {
                     if (limit == 0)
                         break;
@@ -1517,19 +1542,16 @@ void Query::find_all(ConstTableView& ret, size_t begin, size_t end, size_t limit
                 return;
             }
             // no index on best node (and likely no index at all), descend B+-tree
-            node = pn;
-            QueryStateFindAll<KeyColumn> st(ret.m_key_values, limit);
-
-            auto f = [&begin, &end, &node, &st, this](const Cluster* cluster) {
+            auto f = [&begin, &end, &pn, &st, this](const Cluster* cluster) {
                 size_t e = cluster->node_size();
                 if (begin < e) {
                     if (e > end) {
                         e = end;
                     }
-                    node->set_cluster(cluster);
+                    pn->set_cluster(cluster);
                     st.m_key_offset = cluster->get_offset();
                     st.m_key_values = cluster->get_key_array();
-                    aggregate_internal(node, &st, begin, e, nullptr);
+                    aggregate_internal(pn, &st, begin, e, nullptr);
                     begin = 0;
                 }
                 else {
@@ -1589,14 +1611,16 @@ size_t Query::do_count(size_t limit) const
     else {
         size_t counter = 0;
         auto pn = root_node();
-        auto best = find_best_node(pn);
-        auto node = pn->m_children[best];
+        QueryStateCount st(limit);
+        st.m_best_node = find_best_node(pn);
+
+        auto node = pn->m_children[st.m_best_node];
         if (node->has_search_index()) {
             auto keys = node->index_based_keys();
             if (pn->m_children.size() > 1) {
                 // The node having the search index can be removed from the query as we know that
                 // all the objects will match this condition
-                pn->m_children[best] = pn->m_children.back();
+                pn->m_children[st.m_best_node] = pn->m_children.back();
                 pn->m_children.pop_back();
                 for (auto key : keys) {
                     auto obj = m_table->get_object(key);
@@ -1615,15 +1639,13 @@ size_t Query::do_count(size_t limit) const
             return counter;
         }
         // no index, descend down the B+-tree instead
-        node = pn;
-        QueryStateCount st(limit);
 
-        auto f = [&node, &st, this](const Cluster* cluster) {
+        auto f = [&pn, &st, this](const Cluster* cluster) {
             size_t e = cluster->node_size();
-            node->set_cluster(cluster);
+            pn->set_cluster(cluster);
             st.m_key_offset = cluster->get_offset();
             st.m_key_values = cluster->get_key_array();
-            aggregate_internal(node, &st, 0, e, nullptr);
+            aggregate_internal(pn, &st, 0, e, nullptr);
             // Stop if limit or end is reached
             return st.match_count() == st.limit();
         };

--- a/src/realm/query_conditions.hpp
+++ b/src/realm/query_conditions.hpp
@@ -45,11 +45,18 @@ class ClusterKeyArray;
 
 class QueryStateBase {
 public:
+    size_t m_best_node;
+    size_t m_number_checked;
+    size_t m_local_match_count;
     int64_t m_minmax_key; // used only for min/max, to save index of current min/max value
     uint64_t m_key_offset;
     const ClusterKeyArray* m_key_values;
+
     QueryStateBase(size_t limit)
-        : m_minmax_key(-1)
+        : m_best_node(-1)
+        , m_number_checked(0)
+        , m_local_match_count(0)
+        , m_minmax_key(-1)
         , m_key_offset(0)
         , m_key_values(nullptr)
         , m_match_count(0)

--- a/src/realm/query_engine.cpp
+++ b/src/realm/query_engine.cpp
@@ -109,7 +109,7 @@ size_t ParentNode::aggregate_local(QueryStateBase* st, size_t start, size_t end,
     size_t r = start - 1;
     for (;;) {
         if (local_matches == local_limit) {
-            m_dD = double(r - start) / (local_matches + 1.1);
+            st->m_local_match_count += local_matches;
             return r + 1;
         }
 
@@ -117,7 +117,7 @@ size_t ParentNode::aggregate_local(QueryStateBase* st, size_t start, size_t end,
         auto pos = r + 1;
         r = find_first_local(pos, end);
         if (r == not_found) {
-            m_dD = double(pos - start) / (local_matches + 1.1);
+            st->m_local_match_count += local_matches;
             return end;
         }
 
@@ -172,13 +172,6 @@ void MixedNode<Equal>::init(bool will_query_ranges)
     MixedNodeBase::init(will_query_ranges);
 
     if (m_has_search_index) {
-        m_dT = 0.0;
-    }
-    else {
-        m_dT = 10.0;
-    }
-
-    if (m_has_search_index) {
         // Will set m_index_matches, m_index_matches_destroy, m_results_start and m_results_end
         auto index = ParentNode::m_table->get_search_index(ParentNode::m_condition_column_key);
         m_index_matches.clear();
@@ -189,6 +182,7 @@ void MixedNode<Equal>::init(bool will_query_ranges)
         if (m_results_start != m_results_end) {
             m_actual_key = m_index_matches[0];
         }
+        m_dT = 0.0;
     }
 }
 

--- a/src/realm/query_engine.hpp
+++ b/src/realm/query_engine.hpp
@@ -130,7 +130,7 @@ const size_t findlocals = 64;
 
 // Average match distance in linear searches where further increase in distance no longer increases query speed
 // (because time spent on handling each match becomes insignificant compared to time spent on the search).
-const size_t bestdist = 512;
+const size_t bestdist = 128;
 
 // Minimum number of matches required in a certain condition before it can be used to compute statistics. Too high
 // value can spent too much time in a bad node (with high match frequency). Too low value gives inaccurate statistics.
@@ -862,7 +862,7 @@ public:
         : m_value(v)
     {
         m_condition_column_key = column;
-        m_dT = 100.0;
+        m_dT = 15.0;
     }
 
     BinaryNode(null, ColKey column)
@@ -982,7 +982,6 @@ public:
         : m_value(v)
     {
         m_condition_column_key = column;
-        m_dT = 2.0;
     }
 
     TimestampNodeBase(null, ColKey column)
@@ -1051,6 +1050,7 @@ public:
         : m_value(v)
     {
         m_condition_column_key = column;
+        m_dT = 15.;
     }
 
     DecimalNodeBase(null, ColKey column)
@@ -1064,13 +1064,6 @@ public:
         m_array_ptr = LeafPtr(new (&m_leaf_cache_storage) ArrayDecimal128(m_table.unchecked_ptr()->get_alloc()));
         m_cluster->init_leaf(this->m_condition_column_key, m_array_ptr.get());
         m_leaf_ptr = m_array_ptr.get();
-    }
-
-    void init(bool will_query_ranges) override
-    {
-        ParentNode::init(will_query_ranges);
-
-        m_dD = 100.0;
     }
 
 protected:
@@ -1156,8 +1149,7 @@ public:
     void init(bool will_query_ranges) override
     {
         ParentNode::init(will_query_ranges);
-
-        m_dD = 100.0;
+        m_dT = double(sizeof(ObjectType)) / 4;
     }
 
 protected:
@@ -1321,6 +1313,7 @@ public:
         REALM_ASSERT(column.get_type() == col_type_Mixed);
         get_ownership();
         m_condition_column_key = column;
+        m_dT = 15.0;
     }
 
     MixedNodeBase(null, ColKey column)
@@ -1337,12 +1330,6 @@ public:
         m_leaf_ptr = m_array_ptr.get();
     }
 
-    void init(bool will_query_ranges) override
-    {
-        ParentNode::init(will_query_ranges);
-
-        m_dD = 100.0;
-    }
 
     std::string describe(util::serializer::SerialisationState& state) const override
     {
@@ -1516,6 +1503,19 @@ public:
         m_array_ptr = LeafPtr(new (&m_leaf_cache_storage) ArrayString(m_table.unchecked_ptr()->get_alloc()));
         m_cluster->init_leaf(this->m_condition_column_key, m_array_ptr.get());
         m_leaf_ptr = m_array_ptr.get();
+        switch (m_leaf_ptr->get_type()) {
+            case ArrayString::Type::small_strings:
+                m_dT = 5.;
+                break;
+            case ArrayString::Type::medium_strings:
+                m_dT = 10.;
+                break;
+            case ArrayString::Type::big_strings:
+                m_dT = 15.;
+                break;
+            case ArrayString::Type::enum_strings:
+                break;
+        }
     }
 
     void init(bool will_query_ranges) override


### PR DESCRIPTION
The idea is that the index of the best node is stored in the QueryState
object along with the number of matches found by that node. When that
number reached 64, the other nodes will be probed and the distance
between hits will be calculated. Based on this the new best node will
be found.

<!--
 Make sure to assign one and only one Type (`T:`) label.
 Select reviewers if ready for review. Our bot will automatically assign you.
 -->

## What, How & Why?
<!-- Describe the changes and give some hints to guide your reviewers if possible. -->
<!-- Link (via zenhub) to relevant issue this fixes -->

## ☑️ ToDos
* [ ] 📝 Changelog update
* [ ] 🚦 Tests (or not relevant)
