### PR TITLE
Added reset function for sync as per Java-Kotlin parity

### DIFF
--- a/src/realm.h
+++ b/src/realm.h
@@ -2802,5 +2802,6 @@ RLM_API void realm_sync_session_wait_for_upload_completion(realm_sync_session_t*
                                                            void* userdata,
                                                            realm_free_userdata_func_t userdata_free) RLM_API_NOEXCEPT;
 
+RLM_API void realm_sync_manager_reset_for_testing(const realm_app_t*);
 
 #endif // REALM_H

--- a/src/realm/object-store/c_api/sync.cpp
+++ b/src/realm/object-store/c_api/sync.cpp
@@ -574,4 +574,10 @@ RLM_API void realm_sync_session_wait_for_upload_completion(realm_sync_session_t*
         };
     (*session)->wait_for_upload_completion(std::move(cb));
 }
+
+RLM_API void realm_sync_manager_reset_for_testing(const realm_app_t* app)
+{
+    (*app)->sync_manager()->reset_for_testing();
+    app::App::clear_cached_apps();
+}
 } // namespace realm::c_api


### PR DESCRIPTION
<!--
 Make sure to assign one and only one Type (`T:`) label.
 Select reviewers if ready for review. Our bot will automatically assign you.
 -->

## What, How & Why?
Added `realm_sync_manager_reset_for_testing` to C-API. This is needed to have parity between Java and Kotlin testing.

## ☑️ ToDos
* [ ] 📝 Changelog update
* [ ] 🚦 Tests (or not relevant)
