### PR TITLE
Add state-change notifications for FLX subscription sets

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@
 
 ### Internals
 * Added type to manage flexible sync subscriptions. [#5005](https://github.com/realm/realm-core/pull/5005)
+* Added support for notifications on flexible sync subscription state changes [#5027](https://github.com/realm/realm-core/pull/5027)
 
 ----------------------------------------------
 

--- a/src/realm/sync/subscriptions.cpp
+++ b/src/realm/sync/subscriptions.cpp
@@ -310,7 +310,7 @@ util::Future<void> SubscriptionSet::get_state_change_notification(State notify_w
 {
     // If we've already reached the desired state, or if the subscription is in an error state,
     // we can return a ready future immediately.
-    if (state() == notify_when) {
+    if (state() >= notify_when) {
         return util::Future<void>::make_ready();
     }
     else if (state() == State::Error) {
@@ -500,6 +500,13 @@ const SubscriptionSet SubscriptionStore::get_active() const
 SubscriptionSet SubscriptionStore::get_mutable_by_version(int64_t version_id)
 {
     auto tr = m_db->start_write();
+    auto sub_sets = tr->get_table(m_sub_set_keys->table);
+    return SubscriptionSet(this, std::move(tr), sub_sets->get_object_with_primary_key(Mixed{version_id}));
+}
+
+const SubscriptionSet SubscriptionStore::get_by_version(int64_t version_id) const
+{
+    auto tr = m_db->start_read();
     auto sub_sets = tr->get_table(m_sub_set_keys->table);
     return SubscriptionSet(this, std::move(tr), sub_sets->get_object_with_primary_key(Mixed{version_id}));
 }

--- a/src/realm/sync/subscriptions.hpp
+++ b/src/realm/sync/subscriptions.hpp
@@ -244,8 +244,6 @@ protected:
     TransactionRef m_tr;
     Obj m_obj;
     LnkLst m_sub_list;
-
-    bool m_state_changed = false;
 };
 
 // A SubscriptionStore manages the FLX metadata tables and the lifecycles of SubscriptionSets and Subscriptions.

--- a/src/realm/sync/subscriptions.hpp
+++ b/src/realm/sync/subscriptions.hpp
@@ -265,6 +265,10 @@ public:
     // version ID. If there is no SubscriptionSet with that version ID, this throws KeyNotFound.
     SubscriptionSet get_mutable_by_version(int64_t version_id);
 
+    // To be used internally by the sync client. This returns a read-only view of a subscription set by its
+    // version ID. If there is no SubscriptionSet with that version ID, this throws KeyNotFound.
+    const SubscriptionSet get_by_version(int64_t version_id) const;
+
 private:
     DBRef m_db;
 

--- a/test/test_sync_subscriptions.cpp
+++ b/test/test_sync_subscriptions.cpp
@@ -180,4 +180,85 @@ TEST(Sync_SubscriptionStoreUpdateExisting)
     }
 }
 
+TEST(Sync_SubscriptionStoreNotifications)
+{
+    SHARED_GROUP_TEST_PATH(sub_store_path);
+    SubscriptionStoreFixture fixture(sub_store_path);
+    SubscriptionStore store(fixture.db);
+
+    std::vector<util::Future<void>> notification_futures;
+    auto sub_set = store.get_latest().make_mutable_copy();
+    notification_futures.push_back(sub_set.get_state_change_notification(SubscriptionSet::State::Pending));
+    sub_set.commit();
+    sub_set = store.get_latest().make_mutable_copy();
+    notification_futures.push_back(sub_set.get_state_change_notification(SubscriptionSet::State::Bootstrapping));
+    sub_set.commit();
+    sub_set = store.get_latest().make_mutable_copy();
+    notification_futures.push_back(sub_set.get_state_change_notification(SubscriptionSet::State::Bootstrapping));
+    sub_set.commit();
+    sub_set = store.get_latest().make_mutable_copy();
+    notification_futures.push_back(sub_set.get_state_change_notification(SubscriptionSet::State::Complete));
+    sub_set.commit();
+    sub_set = store.get_latest().make_mutable_copy();
+    notification_futures.push_back(sub_set.get_state_change_notification(SubscriptionSet::State::Complete));
+    sub_set.commit();
+    sub_set = store.get_latest().make_mutable_copy();
+    notification_futures.push_back(sub_set.get_state_change_notification(SubscriptionSet::State::Complete));
+    sub_set.commit();
+
+    // This should complete immediately because transitioning to the Pending state happens when you commit.
+    notification_futures[0].get();
+
+    // This should also return immediately with a ready future because the subset is in the correct state.
+    store.get_mutable_by_version(1).get_state_change_notification(SubscriptionSet::State::Pending).get();
+
+    // This should not be ready yet because we haven't updated its state.
+    CHECK_NOT(notification_futures[1].is_ready());
+
+    sub_set = store.get_mutable_by_version(2);
+    sub_set.update_state(SubscriptionSet::State::Bootstrapping);
+    sub_set.commit();
+
+    // Now we should be able to get the future result because we updated the state.
+    notification_futures[1].get();
+
+    // This should not be ready yet because we haven't updated its state.
+    CHECK_NOT(notification_futures[2].is_ready());
+
+    // Update the state to complete - skipping the bootstrapping phase entirely.
+    sub_set = store.get_mutable_by_version(3);
+    sub_set.update_state(SubscriptionSet::State::Complete);
+    sub_set.commit();
+
+    // Now we should be able to get the future result because we updated the state and skipped the bootstrapping
+    // phase.
+    notification_futures[2].get();
+
+    // Update one of the subscription sets to have an error state along with an error message.
+    std::string error_msg = "foo bar bizz buzz. i'm an error string for this test!";
+    CHECK_NOT(notification_futures[3].is_ready());
+    sub_set = store.get_mutable_by_version(4);
+    sub_set.update_state(SubscriptionSet::State::Error, error_msg);
+    sub_set.commit();
+
+    // This should return a non-OK Status with the error message we set on the subscription set.
+    auto err_res = notification_futures[3].get_no_throw();
+    CHECK_NOT(err_res.is_ok());
+    CHECK_EQUAL(err_res.code(), ErrorCodes::RuntimeError);
+    CHECK_EQUAL(err_res.reason(), error_msg);
+
+    // When a higher version supercedes an older one - i.e. you send query sets for versions 5/6 and the server starts
+    // bootstrapping version 6 - we expect the notifications for both versions to be fulfilled when the latest one
+    // completes bootstrapping.
+    CHECK_NOT(notification_futures[4].is_ready());
+    CHECK_NOT(notification_futures[5].is_ready());
+
+    sub_set = store.get_mutable_by_version(6);
+    sub_set.update_state(SubscriptionSet::State::Complete);
+    sub_set.commit();
+
+    notification_futures[4].get();
+    notification_futures[5].get();
+}
+
 } // namespace realm::sync

--- a/test/test_sync_subscriptions.cpp
+++ b/test/test_sync_subscriptions.cpp
@@ -248,6 +248,12 @@ TEST(Sync_SubscriptionStoreNotifications)
     CHECK_EQUAL(err_res.code(), ErrorCodes::RuntimeError);
     CHECK_EQUAL(err_res.reason(), error_msg);
 
+    // Getting a ready future on a set that's already in the error state should also return immediately with an error.
+    err_res = store.get_by_version(4).get_state_change_notification(SubscriptionSet::State::Complete).get_no_throw();
+    CHECK_NOT(err_res.is_ok());
+    CHECK_EQUAL(err_res.code(), ErrorCodes::RuntimeError);
+    CHECK_EQUAL(err_res.reason(), error_msg);
+
     // When a higher version supercedes an older one - i.e. you send query sets for versions 5/6 and the server starts
     // bootstrapping version 6 - we expect the notifications for both versions to be fulfilled when the latest one
     // completes bootstrapping.

--- a/test/test_sync_subscriptions.cpp
+++ b/test/test_sync_subscriptions.cpp
@@ -266,7 +266,8 @@ TEST(Sync_SubscriptionStoreNotifications)
     // Also check that new requests for the superceded sub set get filled immediately.
     old_sub_set.get_state_change_notification(SubscriptionSet::State::Complete).get();
 
-    // Check that asking for a state change that is less than the current state of the sub set gets filled immediately.
+    // Check that asking for a state change that is less than the current state of the sub set gets filled
+    // immediately.
     sub_set.get_state_change_notification(SubscriptionSet::State::Bootstrapping).get();
 }
 

--- a/test/test_sync_subscriptions.cpp
+++ b/test/test_sync_subscriptions.cpp
@@ -238,6 +238,7 @@ TEST(Sync_SubscriptionStoreNotifications)
     std::string error_msg = "foo bar bizz buzz. i'm an error string for this test!";
     CHECK_NOT(notification_futures[3].is_ready());
     sub_set = store.get_mutable_by_version(4);
+    sub_set.update_state(SubscriptionSet::State::Bootstrapping);
     sub_set.update_state(SubscriptionSet::State::Error, error_msg);
     sub_set.commit();
 

--- a/test/test_sync_subscriptions.cpp
+++ b/test/test_sync_subscriptions.cpp
@@ -254,12 +254,20 @@ TEST(Sync_SubscriptionStoreNotifications)
     CHECK_NOT(notification_futures[4].is_ready());
     CHECK_NOT(notification_futures[5].is_ready());
 
+    auto old_sub_set = store.get_by_version(5);
+
     sub_set = store.get_mutable_by_version(6);
     sub_set.update_state(SubscriptionSet::State::Complete);
     sub_set.commit();
 
     notification_futures[4].get();
     notification_futures[5].get();
+
+    // Also check that new requests for the superceded sub set get filled immediately.
+    old_sub_set.get_state_change_notification(SubscriptionSet::State::Complete).get();
+
+    // Check that asking for a state change that is less than the current state of the sub set gets filled immediately.
+    sub_set.get_state_change_notification(SubscriptionSet::State::Bootstrapping).get();
 }
 
 } // namespace realm::sync


### PR DESCRIPTION
## What, How & Why?
This adds the ability to request notifications (in the form of a Future resolving) for changes to the state of FLX sync subscription sets.

## ☑️ ToDos
* [ ] 📝 Changelog update
* [x] 🚦 Tests (or not relevant)
