### PR TITLE
Use existing sync client backoff on auth errors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 ### Fixed
 * A sync user's Realm was not deleted when the user was removed if the Realm path was too long such that it triggered the fallback hashed name (this is OS dependant but is 300 characters on linux). ([#4187](https://github.com/realm/realm-core/issues/4187), since the introduction of hashed paths in object-store before monorepo, circa early v10 (https://github.com/realm/realm-object-store/pull/1049))
 * Don't keep trying to refresh the access token if the client's clock is more than 30 minutes fast. ([#4941](https://github.com/realm/realm-core/issues/4941))
+* Don't sleep the sync thread artificially if an auth request fails. This could be observed as a UI hang on js applications when sync tries to connect after being offline for more than 30 minutes. ([realm-js#3882](https://github.com/realm/realm-js/issues/3882), since sync to MongoDB was introduced in v10.0.0)
 
 ### Breaking changes
 * None.

--- a/src/realm/sync/noinst/client_impl_base.cpp
+++ b/src/realm/sync/noinst/client_impl_base.cpp
@@ -357,6 +357,7 @@ void Connection::websocket_handshake_error_handler(std::error_code ec, const HTT
     bool is_fatal;
     if (ec == util::websocket::Error::bad_response_3xx_redirection ||
         ec == util::websocket::Error::bad_response_301_moved_permanently ||
+        ec == util::websocket::Error::bad_response_401_unauthorized ||
         ec == util::websocket::Error::bad_response_5xx_server_error ||
         ec == util::websocket::Error::bad_response_500_internal_server_error ||
         ec == util::websocket::Error::bad_response_502_bad_gateway ||


### PR DESCRIPTION
Fixes https://github.com/realm/realm-js/issues/3882 and https://github.com/realm/realm-core/issues/4195

Instead of adding a delay at the sync session level, hook into the sync client's existing retry logic which has built in backoff.

## ☑️ ToDos
* [x] 📝 Changelog update
* [x] 🚦 Tests (or not relevant)