### PR TITLE
Add Set impls for C-API

### DIFF
--- a/src/realm.h
+++ b/src/realm.h
@@ -1689,11 +1689,13 @@ RLM_API realm_set_t* realm_get_set(const realm_object_t*, realm_property_key_t);
 RLM_API size_t realm_set_size(const realm_set_t*);
 RLM_API bool realm_set_get(const realm_set_t*, size_t index, realm_value_t* out_value);
 RLM_API bool realm_set_find(const realm_set_t*, realm_value_t value, size_t* out_index);
-RLM_API bool realm_set_insert(realm_set_t*, realm_value_t value, size_t out_index);
+RLM_API bool realm_set_insert(realm_set_t*, realm_value_t value, size_t* out_index);
 RLM_API bool realm_set_erase(realm_set_t*, realm_value_t value, bool* out_erased);
 RLM_API bool realm_set_clear(realm_set_t*);
-RLM_API bool realm_set_assign(realm_set_t*, realm_value_t values, size_t num_values);
-RLM_API realm_notification_token_t* realm_set_add_notification_callback(realm_object_t*, void* userdata,
+RLM_API bool realm_set_assign_union(realm_set_t*, realm_value_t* values, size_t num_values);
+RLM_API bool realm_set_assign_difference(realm_set_t*, realm_value_t* values, size_t num_values);
+RLM_API bool realm_set_assign_intersection(realm_set_t*, realm_value_t* values, size_t num_values);
+RLM_API realm_notification_token_t* realm_set_add_notification_callback(realm_set_t*, void* userdata,
                                                                         realm_free_userdata_func_t free,
                                                                         realm_on_collection_change_func_t on_change,
                                                                         realm_callback_error_func_t on_error,

--- a/src/realm/object-store/c_api/notifications.cpp
+++ b/src/realm/object-store/c_api/notifications.cpp
@@ -256,4 +256,20 @@ RLM_API void realm_collection_changes_get_changes(const realm_collection_changes
     }
 }
 
+RLM_API realm_notification_token_t* realm_set_add_notification_callback(realm_set_t* set, void* userdata,
+                                                                        realm_free_userdata_func_t free,
+                                                                        realm_on_collection_change_func_t on_change,
+                                                                        realm_callback_error_func_t on_error,
+                                                                        realm_scheduler_t*)
+{
+    return wrap_err([&]() {
+        CollectionNotificationsCallback cb;
+        cb.m_userdata = UserdataPtr{userdata, free};
+        cb.m_on_change = on_change;
+        cb.m_on_error = on_error;
+        auto token = set->add_notification_callback(std::move(cb));
+        return new realm_notification_token_t{std::move(token)};
+    });
+}
+
 } // namespace realm::c_api

--- a/src/realm/object-store/c_api/object.cpp
+++ b/src/realm/object-store/c_api/object.cpp
@@ -316,6 +316,7 @@ RLM_API bool realm_set_values(realm_object_t* obj, size_t num_values, const real
     });
 }
 
+// MARK: List
 RLM_API realm_list_t* realm_get_list(realm_object_t* object, realm_property_key_t key)
 {
     return wrap_err([&]() {
@@ -483,6 +484,97 @@ RLM_API bool realm_list_is_valid(const realm_list_t* list)
     if (!list)
         return false;
     return list->is_valid();
+}
+
+// MARK: Set
+RLM_API size_t realm_set_size(const realm_set_t* set)
+{
+    return wrap_err([&]() {
+        return set->size();
+    });
+}
+
+RLM_API bool realm_set_get(const realm_set_t* set, size_t index, realm_value_t* out_value)
+{
+  return wrap_err([&]() {
+      return set->size();
+  });
+}
+
+RLM_API bool realm_set_find(const realm_set_t* set, realm_value_t value, size_t* out_index)
+{
+    return wrap_err([&]() {
+        auto val = from_capi(value);
+        if (out_index)
+            *out_index = set->find_any(val);
+        return true;
+    });
+}
+
+RLM_API bool realm_set_insert(realm_set_t* set, realm_value_t value, size_t* out_index)
+{
+    return wrap_err([&]() {
+        auto val = from_capi(value);
+        auto ret_val = set->insert_any(val);
+        if (out_index)
+            *out_index = ret_val.first;
+        return ret_val.second;
+    });
+}
+
+RLM_API bool realm_set_erase(realm_set_t* set, realm_value_t value, bool* out_erased)
+{
+    return wrap_err([&]() {
+        auto val = from_capi(value);
+        auto ret_val = set->remove(val);
+        if (out_erased)
+            *out_erased = ret_val.first;
+        return true;
+    });
+}
+
+RLM_API bool realm_set_clear(realm_set_t* set)
+{
+    return wrap_err([&]() {
+        set->remove_all();
+        return true;
+    });
+}
+
+RLM_API bool realm_set_assign_union(realm_set_t* set, realm_value_t* values, size_t num_values)
+{
+    return wrap_err([&]() {
+        auto collection = realm::object_store::Set();
+        for (size_t i = 0; i < num_values; i++) {
+            collection.insert(values[i]);
+        }
+        set->assign_union(collection);
+        return true;
+    });
+}
+
+RLM_API bool realm_set_assign_intersection(realm_set_t* set, realm_value_t* values, size_t num_values)
+{
+    return wrap_err([&]() {
+        auto collection = realm::object_store::Set();
+        for (size_t i = 0; i < num_values; i++) {
+            collection.insert(values[i]);
+        }
+        set->assign_intersection(collection);
+        return true;
+    });
+}
+
+RLM_API bool realm_set_assign_difference(realm_set_t* set, realm_value_t* values, size_t num_values)
+{
+    return wrap_err([&]() {
+        auto collection = realm::object_store::Set();
+        for (size_t i = 0; i < num_values; i++) {
+            collection.insert(values[i]);
+        }
+        set->assign_difference(collection);
+        return true;
+    });
 }
 
 } // namespace realm::c_api

--- a/src/realm/object-store/c_api/types.hpp
+++ b/src/realm/object-store/c_api/types.hpp
@@ -9,6 +9,7 @@
 #include <realm/object-store/shared_realm.hpp>
 #include <realm/object-store/object_schema.hpp>
 #include <realm/object-store/object.hpp>
+#include <realm/object-store/set.hpp>
 #include <realm/object-store/object_accessor.hpp>
 #include <realm/object-store/util/scheduler.hpp>
 #include <realm/object-store/thread_safe_reference.hpp>
@@ -399,6 +400,45 @@ struct realm_results : realm::c_api::WrapC, realm::Results {
     struct thread_safe_reference : realm_thread_safe_reference_t, realm::ThreadSafeReference {
         thread_safe_reference(const realm::Results& results)
             : realm::ThreadSafeReference(results)
+        {
+        }
+    };
+
+    realm_thread_safe_reference_t* get_thread_safe_reference() const final
+    {
+        return new thread_safe_reference{*this};
+    }
+};
+
+struct realm_set : realm::c_api::WrapC, realm::object_store::Set {
+    explicit realm_set(realm::object_store::Set set)
+        : realm::object_store::Set(std::move(set))
+    {
+    }
+
+    realm_set* clone() const override
+    {
+        return new realm_set{*this};
+    }
+
+    bool is_frozen() const override
+    {
+        return realm::object_store::Set::is_frozen();
+    }
+
+    bool equals(const WrapC& other) const noexcept final
+    {
+        if (auto ptr = dynamic_cast<const realm_set_t*>(&other)) {
+            return get_realm() == ptr->get_realm() && get_parent_table_key() == ptr->get_parent_table_key() &&
+                   get_parent_column_key() == ptr->get_parent_column_key() &&
+                   get_parent_object_key() == ptr->get_parent_object_key();
+        }
+        return false;
+    }
+
+    struct thread_safe_reference : realm_thread_safe_reference, realm::ThreadSafeReference {
+        thread_safe_reference(const Set& set)
+            : realm::ThreadSafeReference(set)
         {
         }
     };


### PR DESCRIPTION
Add implementation for Set methods for C-API.

This includes missing methods/methods with seemingly incorrect signatures.

Still needs testing, but @cmelchior hopefully this unblocks Kotlin in the interim.