### PR TITLE
Expose SubscriptionSet::at

### DIFF
--- a/src/realm/sync/subscriptions.cpp
+++ b/src/realm/sync/subscriptions.cpp
@@ -151,10 +151,10 @@ size_t SubscriptionSet::size() const
     return m_sub_list.size();
 }
 
-Subscription SubscriptionSet::get_at_index(size_t index) const
+Subscription SubscriptionSet::at(size_t index) const
 {
     if (index >= m_sub_list.size()) {
-        return Subscription(this, Obj{});
+        throw std::out_of_range("index");
     }
 
     return Subscription(this, m_sub_list.get_object(index));

--- a/src/realm/sync/subscriptions.cpp
+++ b/src/realm/sync/subscriptions.cpp
@@ -151,6 +151,15 @@ size_t SubscriptionSet::size() const
     return m_sub_list.size();
 }
 
+Subscription SubscriptionSet::get_at_index(size_t index) const
+{
+    if (index >= m_sub_list.size()) {
+        return Subscription(this, Obj{});
+    }
+
+    return Subscription(this, m_sub_list.get_object(index));
+}
+
 SubscriptionSet::const_iterator SubscriptionSet::begin() const
 {
     return iterator(this, m_sub_list.begin());

--- a/src/realm/sync/subscriptions.hpp
+++ b/src/realm/sync/subscriptions.hpp
@@ -184,6 +184,8 @@ public:
     const_iterator begin() const;
     const_iterator end() const;
 
+    Subscription get_at_index(size_t index) const;
+
     // Returns a const_iterator to the query matching either the name or Query object, or end() if no such
     // subscription exists.
     const_iterator find(StringData name) const;

--- a/src/realm/sync/subscriptions.hpp
+++ b/src/realm/sync/subscriptions.hpp
@@ -184,7 +184,7 @@ public:
     const_iterator begin() const;
     const_iterator end() const;
 
-    Subscription get_at_index(size_t index) const;
+    Subscription at(size_t index) const;
 
     // Returns a const_iterator to the query matching either the name or Query object, or end() if no such
     // subscription exists.


### PR DESCRIPTION
I was implementing the C API for .NET and noticed we're missing a get_at_index for the subscription set. This is needed to support C# enumerators (equivalent to C++ iterators) without building a lot of complex machinery around the already exposed subscription set iterator. Feel free to also discard this PR if there's a better way to go about it.