### PR TITLE
Make sure sync client receives error message when TCP socket is closed

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 * A client reset in DiscardLocal mode would revert to Manual mode on the next restart of the session. ([#5050](https://github.com/realm/realm-core/issues/5050), since v11.5.0)
 * `@sum` and `@avg` queries on Dictionaries of floats or doubles used too much precision for intermediates, resulting in incorrect rounding (since v10.2.0).
 * Change the exception message for calling refresh on an immutable Realm from "Continuous transaction through DB object without history information." to "Can't refresh a read-only Realm." ([#5061](https://github.com/realm/realm-core/issues/5061), old exception message was since 10.7.2 via https://github.com/realm/realm-core/pull/4688).
+* The sync client will now drain the receive queue when send fails with ECONNRESET - ensuring that any error message from the server gets received and processed. ([#5047](https://github.com/realm/realm-core/pull/5047)) 
  
 ### Breaking changes
 * None.

--- a/src/realm/util/websocket.cpp
+++ b/src/realm/util/websocket.cpp
@@ -681,12 +681,13 @@ public:
             // If the socket has been closed then we should continue to read from it until we've drained
             // the receive buffer. Eventually we will either receive an in-band error message from the
             // server about why we got disconnected or we'll receive ECONNRESET on the receive side as well.
-            if (ec == util::error::operation_aborted ||
-                ec == util::error::make_error_code(util::error::connection_reset) ||
-                ec == util::make_error_code(util::MiscExtErrors::end_of_input)) {
+            bool closed = (ec == util::error::operation_aborted ||
+                           ec == util::error::make_error_code(util::error::connection_reset) ||
+                           ec == util::make_error_code(util::MiscExtErrors::end_of_input));
+            if (closed) {
                 return;
             }
-            else if (ec) {
+            if (ec) {
                 stop();
                 return m_config.websocket_write_error_handler(ec);
             }

--- a/src/realm/util/websocket.cpp
+++ b/src/realm/util/websocket.cpp
@@ -678,14 +678,20 @@ public:
 
         auto handler = [this](std::error_code ec, size_t) {
             // If the operation is aborted, the socket object may have been destroyed.
-            if (ec != util::error::operation_aborted) {
-                if (ec) {
-                    stop();
-                    m_config.websocket_write_error_handler(ec);
-                    return;
-                }
-                handle_write_message(); // Throws
+            // If the socket has been closed then we should continue to read from it until we've drained
+            // the receive buffer. Eventually we will either receive an in-band error message from the
+            // server about why we got disconnected or we'll receive ECONNRESET on the receive side as well.
+            if (ec == util::error::operation_aborted ||
+                ec == util::error::make_error_code(util::error::connection_reset) ||
+                ec == util::make_error_code(util::MiscExtErrors::end_of_input)) {
+                return;
             }
+            else if (ec) {
+                stop();
+                return m_config.websocket_write_error_handler(ec);
+            }
+
+            handle_write_message();
         };
 
         m_config.async_write(m_write_buffer.data(), message_size, handler);

--- a/test/object-store/sync/app.cpp
+++ b/test/object-store/sync/app.cpp
@@ -2332,10 +2332,7 @@ TEST_CASE("app: sync integration", "[sync][app]") {
     }
 
     SECTION("too large sync message error handling") {
-        TestSyncManager::Config test_config = app_config;
-        // Too much log output seems to create problems on Evergreen CI
-        test_config.verbose_sync_client_logging = false;
-
+        TestSyncManager::Config test_config(app_config);
         TestSyncManager sync_manager(test_config, {});
         auto app = sync_manager.app();
         auto creds = create_user_and_log_in(sync_manager.app());


### PR DESCRIPTION
## What, How & Why?
I think what's going on with this test being flakey is a subtle bug in our websocket implementation.

When the test is failing, this is the order of operations:
At T0, the client sends a message to the server that is too large for the server to receive.
At T1, the server sends a websocket close message with an error message
At T2, the client begins to send another message and the server closes the TCP underlying TCP socket.
At T3, the client's call to `send` fails with `ECONNRESET` and the client begins its reconnect loop. Go back to T0.

When the test is succeeding, this is the order of operations:
At T0, the client sends a message to the server that is too large for the server to receive.
At T1, the server sends a websocket close message with an error message
At T2, the client receives the close message and reports it as a sync error.

I think, surprisingly, the answer here is to ignore `ECONNRESET` errors for calls to `send`. That way the read side of the websocket can drain the receive queue and process any error messages that may have been sent. If the send side of the TCP connection has gotten `ECONNRESET`, then the recv side should also be receiving it soon, so if the connection was aborted for an actual error condition, we should get that error on the `recv` side shortly after ignoring the error on the `send` side.

## ☑️ ToDos
* [x] 📝 Changelog update
* [x] 🚦 Tests (or not relevant)
