### PR TITLE
Client reset updates

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@
 
 ### Fixed
 * <How do the end-user experience this issue? what was the impact?> ([#????](https://github.com/realm/realm-core/issues/????), since v?.?.?)
-* None.
+* The client reset callbacks now pass out SharedRealm objects instead of TransactionRefs. ([#5048](https://github.com/realm/realm-core/issues/5048), since v11.5.0) 
  
 ### Breaking changes
 * None.
@@ -18,6 +18,7 @@
 
 ### Internals
 * The 'power' unary operator template to be used in a query expression is removed
+* Renamed ClientResyncMode::SeamlessLoss -> DiscardLocal.
 
 ----------------------------------------------
 

--- a/src/realm.h
+++ b/src/realm.h
@@ -2479,7 +2479,7 @@ typedef enum realm_sync_client_reconnect_mode {
 
 typedef enum realm_sync_session_resync_mode {
     RLM_SYNC_SESSION_RESYNC_MODE_MANUAL,
-    RLM_SYNC_SESSION_RESYNC_MODE_SEAMLESS_LOSS,
+    RLM_SYNC_SESSION_RESYNC_MODE_DISCARD_LOCAL,
 } realm_sync_session_resync_mode_e;
 
 typedef enum realm_sync_session_stop_policy {

--- a/src/realm/object-store/c_api/sync.cpp
+++ b/src/realm/object-store/c_api/sync.cpp
@@ -40,8 +40,8 @@ static_assert(realm_sync_client_reconnect_mode_e(ReconnectMode::normal) == RLM_S
 static_assert(realm_sync_client_reconnect_mode_e(ReconnectMode::testing) == RLM_SYNC_CLIENT_RECONNECT_MODE_TESTING);
 
 static_assert(realm_sync_session_resync_mode_e(ClientResyncMode::Manual) == RLM_SYNC_SESSION_RESYNC_MODE_MANUAL);
-static_assert(realm_sync_session_resync_mode_e(ClientResyncMode::SeamlessLoss) ==
-              RLM_SYNC_SESSION_RESYNC_MODE_SEAMLESS_LOSS);
+static_assert(realm_sync_session_resync_mode_e(ClientResyncMode::DiscardLocal) ==
+              RLM_SYNC_SESSION_RESYNC_MODE_DISCARD_LOCAL);
 
 static_assert(realm_sync_session_stop_policy_e(SyncSessionStopPolicy::Immediately) ==
               RLM_SYNC_SESSION_STOP_POLICY_IMMEDIATELY);

--- a/src/realm/object-store/impl/realm_coordinator.cpp
+++ b/src/realm/object-store/impl/realm_coordinator.cpp
@@ -108,6 +108,9 @@ void RealmCoordinator::create_sync_session()
                 REALM_ASSERT(path != m_config.path);
                 REALM_ASSERT(m_config.sync_config);
                 auto copy_config = m_config;
+                copy_config.schema = util::none;
+                copy_config.realm_data = BinaryData{};
+                copy_config.audit_factory = {};
                 copy_config.path = path;
                 // Do not use seamless loss mode on the fresh Realm. Use manual mode so that
                 // any error during the download is propagated back to the original session.

--- a/src/realm/object-store/impl/realm_coordinator.cpp
+++ b/src/realm/object-store/impl/realm_coordinator.cpp
@@ -112,7 +112,7 @@ void RealmCoordinator::create_sync_session()
                 copy_config.realm_data = BinaryData{};
                 copy_config.audit_factory = {};
                 copy_config.path = path;
-                // Do not use seamless loss mode on the fresh Realm. Use manual mode so that
+                // Do not use 'discard local' mode on the fresh Realm. Use manual mode so that
                 // any error during the download is propagated back to the original session.
                 // This prevents a cycle if the fresh copy itself experiences a client reset.
                 copy_config.sync_config->client_resync_mode = ClientResyncMode::Manual;

--- a/src/realm/object-store/sync/sync_session.cpp
+++ b/src/realm/object-store/sync/sync_session.cpp
@@ -371,7 +371,7 @@ void SyncSession::handle_error(SyncError error)
                     case ClientResyncMode::Manual:
                         user_handles_client_reset();
                         break;
-                    case ClientResyncMode::SeamlessLoss: {
+                    case ClientResyncMode::DiscardLocal: {
                         REALM_ASSERT(bool(m_config.get_fresh_realm_for_path));
                         std::string fresh_path = _impl::ClientResetOperation::get_fresh_path_for(m_db->get_path());
                         m_config.get_fresh_realm_for_path(fresh_path, [weak_self_ref = weak_from_this()](
@@ -541,7 +541,7 @@ void SyncSession::do_create_sync_session()
 
     if (m_force_client_reset) {
         sync::Session::Config::ClientReset config;
-        config.seamless_loss = (m_config.client_resync_mode == ClientResyncMode::SeamlessLoss);
+        config.discard_local = (m_config.client_resync_mode == ClientResyncMode::DiscardLocal);
         config.notify_after_client_reset = [this](std::string local_path) {
             SharedRealm frozen_local;
             if (!local_path.empty()) {

--- a/src/realm/object-store/sync/sync_session.cpp
+++ b/src/realm/object-store/sync/sync_session.cpp
@@ -542,8 +542,37 @@ void SyncSession::do_create_sync_session()
     if (m_force_client_reset) {
         sync::Session::Config::ClientReset config;
         config.seamless_loss = (m_config.client_resync_mode == ClientResyncMode::SeamlessLoss);
-        config.notify_after_client_reset = m_config.notify_after_client_reset;
-        config.notify_before_client_reset = m_config.notify_before_client_reset;
+        config.notify_after_client_reset = [this](std::string local_path) {
+            SharedRealm frozen_local;
+            if (!local_path.empty()) {
+                if (auto local_coordinator = RealmCoordinator::get_existing_coordinator(local_path)) {
+                    auto local_config = local_coordinator->get_config();
+                    local_config.scheduler = nullptr;
+                    frozen_local = local_coordinator->get_realm(local_config, VersionID());
+                }
+            }
+            m_config.notify_after_client_reset(frozen_local);
+        };
+        config.notify_before_client_reset = [this](std::string local_path, std::string remote_path) {
+            SharedRealm frozen_local, frozen_remote;
+            Realm::Config local_config;
+            if (!local_path.empty()) {
+                if (auto local_coordinator = RealmCoordinator::get_existing_coordinator(local_path)) {
+                    local_config = local_coordinator->get_config();
+                    local_config.scheduler = nullptr;
+                    frozen_local = local_coordinator->get_realm(local_config, VersionID());
+                }
+            }
+            if (!remote_path.empty() && frozen_local) {
+                Realm::Config remote_config;
+                remote_config.path = remote_path;
+                remote_config.force_sync_history = true;
+                remote_config.encryption_key = local_config.encryption_key;
+                auto remote_coordinator = RealmCoordinator::get_coordinator(remote_config);
+                frozen_remote = remote_coordinator->get_realm(remote_config, VersionID());
+            }
+            m_config.notify_before_client_reset(frozen_local, frozen_remote);
+        };
         config.fresh_copy = std::move(m_client_reset_fresh_copy);
         session_config.client_reset_config = std::move(config);
         m_force_client_reset = false;

--- a/src/realm/sync/client_base.hpp
+++ b/src/realm/sync/client_base.hpp
@@ -60,8 +60,8 @@ class SessionWrapper;
 struct ClientReset {
     bool seamless_loss = false;
     DBRef fresh_copy;
-    util::UniqueFunction<void(TransactionRef local, TransactionRef remote)> notify_before_client_reset;
-    util::UniqueFunction<void(TransactionRef local)> notify_after_client_reset;
+    util::UniqueFunction<void(std::string local, std::string remote)> notify_before_client_reset;
+    util::UniqueFunction<void(std::string local)> notify_after_client_reset;
 };
 
 /// \brief Protocol errors discovered by the client.

--- a/src/realm/sync/client_base.hpp
+++ b/src/realm/sync/client_base.hpp
@@ -58,7 +58,7 @@ class SessionWrapper;
 /// either void async_wait_for_download_completion(WaitOperCompletionHandler) or
 /// bool wait_for_download_complete_or_client_stopped().
 struct ClientReset {
-    bool seamless_loss = false;
+    bool discard_local = false;
     DBRef fresh_copy;
     util::UniqueFunction<void(std::string local, std::string remote)> notify_before_client_reset;
     util::UniqueFunction<void(std::string local)> notify_after_client_reset;

--- a/src/realm/sync/config.hpp
+++ b/src/realm/sync/config.hpp
@@ -34,6 +34,7 @@ namespace realm {
 
 class SyncUser;
 class SyncSession;
+class Realm;
 
 namespace bson {
 class Bson;
@@ -153,8 +154,8 @@ struct SyncConfig {
     // a client reset in ClientResyncMode::Manual mode
     util::Optional<std::string> recovery_directory;
     ClientResyncMode client_resync_mode = ClientResyncMode::Manual;
-    std::function<void(TransactionRef local, TransactionRef remote)> notify_before_client_reset;
-    std::function<void(TransactionRef local)> notify_after_client_reset;
+    std::function<void(std::shared_ptr<Realm> local, std::shared_ptr<Realm> remote)> notify_before_client_reset;
+    std::function<void(std::shared_ptr<Realm> local)> notify_after_client_reset;
     std::function<void(const std::string&, std::function<void(DBRef, util::Optional<std::string>)>)>
         get_fresh_realm_for_path;
 

--- a/src/realm/sync/config.hpp
+++ b/src/realm/sync/config.hpp
@@ -96,7 +96,7 @@ enum class ClientResyncMode : unsigned char {
     // Fire a client reset error
     Manual,
     // Discard local changes, without disrupting accessors or closing the Realm
-    SeamlessLoss,
+    DiscardLocal,
 };
 
 enum class ReconnectMode {

--- a/src/realm/sync/noinst/client_impl_base.cpp
+++ b/src/realm/sync/noinst/client_impl_base.cpp
@@ -1509,7 +1509,7 @@ void Session::activate()
                     (client_reset_config && file_exists) ? "true" : "false"); // Throws
         if (client_reset_config && !m_client_reset_operation) {
             m_client_reset_operation = std::make_unique<_impl::ClientResetOperation>(
-                logger, get_db(), std::move(client_reset_config->fresh_copy), client_reset_config->seamless_loss,
+                logger, get_db(), std::move(client_reset_config->fresh_copy), client_reset_config->discard_local,
                 std::move(client_reset_config->notify_before_client_reset),
                 std::move(client_reset_config->notify_after_client_reset)); // Throws
         }

--- a/src/realm/sync/noinst/client_reset.cpp
+++ b/src/realm/sync/noinst/client_reset.cpp
@@ -811,7 +811,7 @@ client_reset::LocalVersionIDs client_reset::perform_client_reset_diff(DB& db_loc
     BinaryData recovered_changeset;
     sync::SaltedVersion fresh_server_version = {0, 0};
 
-    if (db_remote) { // seamless_loss mode
+    if (db_remote) { // 'discard local' mode
         auto wt_remote = db_remote->start_write();
         auto history_remote = dynamic_cast<ClientHistory*>(wt_remote->get_replication()->_get_history_write());
         sync::version_type current_version_remote = wt_remote->get_version();

--- a/src/realm/sync/noinst/client_reset_operation.cpp
+++ b/src/realm/sync/noinst/client_reset_operation.cpp
@@ -67,20 +67,17 @@ bool ClientResetOperation::finalize(sync::SaltedFileIdent salted_file_ident)
             clean_up_state();
         });
 
+        std::string local_path = m_db.get_path();
+        std::string fresh_path = m_db_fresh ? m_db_fresh->get_path() : "";
         if (m_notify_before) {
-            TransactionRef local_frozen, remote_frozen;
-            local_frozen = m_db.start_frozen();
-            if (m_db_fresh) {
-                remote_frozen = m_db_fresh->start_frozen();
-            }
-            m_notify_before(local_frozen, remote_frozen);
+            m_notify_before(local_path, fresh_path);
         }
 
         local_version_ids =
             client_reset::perform_client_reset_diff(m_db, m_db_fresh, m_salted_file_ident, m_logger); // throws
 
         if (m_notify_after) {
-            m_notify_after(m_db.start_frozen());
+            m_notify_after(local_path);
         }
 
         m_client_reset_old_version = local_version_ids.old_version;

--- a/src/realm/sync/noinst/client_reset_operation.cpp
+++ b/src/realm/sync/noinst/client_reset_operation.cpp
@@ -25,16 +25,16 @@
 
 namespace realm::_impl {
 
-ClientResetOperation::ClientResetOperation(util::Logger& logger, DB& db, DBRef db_fresh, bool seamless_loss,
+ClientResetOperation::ClientResetOperation(util::Logger& logger, DB& db, DBRef db_fresh, bool discard_local,
                                            CallbackBeforeType notify_before, CallbackAfterType notify_after)
     : m_logger{logger}
     , m_db{db}
     , m_db_fresh(std::move(db_fresh))
-    , m_seamless_loss(seamless_loss)
+    , m_discard_local(discard_local)
     , m_notify_before(std::move(notify_before))
     , m_notify_after(std::move(notify_after))
 {
-    logger.debug("Create ClientResetOperation, realm_path = %1, seamless_loss = %2", m_db.get_path(), seamless_loss);
+    logger.debug("Create ClientResetOperation, realm_path = %1, discard_local = %2", m_db.get_path(), discard_local);
 }
 
 std::string ClientResetOperation::get_fresh_path_for(const std::string& path)
@@ -49,7 +49,7 @@ std::string ClientResetOperation::get_fresh_path_for(const std::string& path)
 
 bool ClientResetOperation::finalize(sync::SaltedFileIdent salted_file_ident)
 {
-    if (m_seamless_loss) {
+    if (m_discard_local) {
         REALM_ASSERT(m_db_fresh);
     }
 

--- a/src/realm/sync/noinst/client_reset_operation.hpp
+++ b/src/realm/sync/noinst/client_reset_operation.hpp
@@ -30,8 +30,8 @@ namespace realm::_impl {
 // state Realm download.
 class ClientResetOperation {
 public:
-    using CallbackBeforeType = util::UniqueFunction<void(TransactionRef, TransactionRef)>;
-    using CallbackAfterType = util::UniqueFunction<void(TransactionRef)>;
+    using CallbackBeforeType = util::UniqueFunction<void(std::string, std::string)>;
+    using CallbackAfterType = util::UniqueFunction<void(std::string)>;
 
     ClientResetOperation(util::Logger& logger, DB& db, DBRef db_fresh, bool seamless_loss,
                          CallbackBeforeType notify_before, CallbackAfterType notify_after);

--- a/src/realm/sync/noinst/client_reset_operation.hpp
+++ b/src/realm/sync/noinst/client_reset_operation.hpp
@@ -33,7 +33,7 @@ public:
     using CallbackBeforeType = util::UniqueFunction<void(std::string, std::string)>;
     using CallbackAfterType = util::UniqueFunction<void(std::string)>;
 
-    ClientResetOperation(util::Logger& logger, DB& db, DBRef db_fresh, bool seamless_loss,
+    ClientResetOperation(util::Logger& logger, DB& db, DBRef db_fresh, bool discard_local,
                          CallbackBeforeType notify_before, CallbackAfterType notify_after);
 
     // When the client has received the salted file ident from the server, it
@@ -52,7 +52,7 @@ private:
     util::Logger& m_logger;
     DB& m_db;
     DBRef m_db_fresh;
-    bool m_seamless_loss;
+    bool m_discard_local;
     sync::SaltedFileIdent m_salted_file_ident = {0, 0};
     realm::VersionID m_client_reset_old_version;
     realm::VersionID m_client_reset_new_version;

--- a/test/object-store/benchmarks/client_reset.cpp
+++ b/test/object-store/benchmarks/client_reset.cpp
@@ -50,7 +50,7 @@ struct BenchmarkLocalClientReset : public reset_utils::TestClientReset {
         : reset_utils::TestClientReset(local_config, remote_config)
     {
         REALM_ASSERT(m_local_config.sync_config);
-        REALM_ASSERT(m_local_config.sync_config->client_resync_mode == ClientResyncMode::SeamlessLoss);
+        REALM_ASSERT(m_local_config.sync_config->client_resync_mode == ClientResyncMode::DiscardLocal);
         // turn off sync, we only fake it
         m_local_config.sync_config = {};
         m_remote_config.sync_config = {};
@@ -130,7 +130,7 @@ struct BenchmarkLocalClientReset : public reset_utils::TestClientReset {
     SharedRealm m_remote;
 };
 
-TEST_CASE("client reset seamless loss", "[benchmark]") {
+TEST_CASE("client reset: discard local", "[benchmark]") {
     const std::string valid_pk_name = "_id";
     const std::string partition_value = "partition_foo";
     Property partition_prop = {"realm_id", PropertyType::String | PropertyType::Nullable};
@@ -167,7 +167,7 @@ TEST_CASE("client reset seamless loss", "[benchmark]") {
     config.cache = false;
     config.automatic_change_notifications = false;
     config.schema = schema;
-    config.sync_config->client_resync_mode = ClientResyncMode::SeamlessLoss;
+    config.sync_config->client_resync_mode = ClientResyncMode::DiscardLocal;
 
     SyncTestFile config2(init_sync_manager.app(), "default");
 

--- a/test/object-store/sync/client_reset.cpp
+++ b/test/object-store/sync/client_reset.cpp
@@ -204,10 +204,10 @@ TEST_CASE("sync: client reset", "[client reset]") {
         FAIL("Error handler should not have been called");
     };
 
-    SECTION("seamless loss") {
+    SECTION("discard local") {
         local_config.cache = false;
         local_config.automatic_change_notifications = false;
-        local_config.sync_config->client_resync_mode = ClientResyncMode::SeamlessLoss;
+        local_config.sync_config->client_resync_mode = ClientResyncMode::DiscardLocal;
         const std::string fresh_path = realm::_impl::ClientResetOperation::get_fresh_path_for(local_config.path);
         size_t before_callback_invoctions = 0;
         size_t after_callback_invocations = 0;
@@ -937,7 +937,7 @@ TEST_CASE("sync: client reset", "[client reset]") {
 }
 
 namespace cf = realm::collection_fixtures;
-TEMPLATE_TEST_CASE("client reset types", "[client reset][seamless loss]", cf::MixedVal, cf::Int, cf::Bool, cf::Float,
+TEMPLATE_TEST_CASE("client reset types", "[client reset][discard local]", cf::MixedVal, cf::Int, cf::Bool, cf::Float,
                    cf::Double, cf::String, cf::Binary, cf::Date, cf::OID, cf::Decimal, cf::UUID,
                    cf::BoxedOptional<cf::Int>, cf::BoxedOptional<cf::Bool>, cf::BoxedOptional<cf::Float>,
                    cf::BoxedOptional<cf::Double>, cf::BoxedOptional<cf::OID>, cf::BoxedOptional<cf::UUID>,
@@ -954,7 +954,7 @@ TEMPLATE_TEST_CASE("client reset types", "[client reset][seamless loss]", cf::Mi
     SyncTestFile config(init_sync_manager.app(), "default");
     config.cache = false;
     config.automatic_change_notifications = false;
-    config.sync_config->client_resync_mode = ClientResyncMode::SeamlessLoss;
+    config.sync_config->client_resync_mode = ClientResyncMode::DiscardLocal;
     config.schema = Schema{
         {"object",
          {
@@ -1425,7 +1425,7 @@ TEMPLATE_TEST_CASE("client reset types", "[client reset][seamless loss]", cf::Mi
     }
 }
 
-TEMPLATE_TEST_CASE("client reset collections of links", "[client reset][seamless loss][collections]",
+TEMPLATE_TEST_CASE("client reset collections of links", "[client reset][discard local][collections]",
                    cf::ListOfObjects, cf::ListOfMixedLinks, cf::SetOfObjects, cf::SetOfMixedLinks,
                    cf::DictionaryOfObjects, cf::DictionaryOfMixedLinks)
 {
@@ -1459,7 +1459,7 @@ TEMPLATE_TEST_CASE("client reset collections of links", "[client reset][seamless
     config.cache = false;
     config.automatic_change_notifications = false;
     config.schema = schema;
-    config.sync_config->client_resync_mode = ClientResyncMode::SeamlessLoss;
+    config.sync_config->client_resync_mode = ClientResyncMode::DiscardLocal;
 
     SyncTestFile config2(init_sync_manager.app(), "default");
 
@@ -1672,7 +1672,7 @@ TEST_CASE("client reset with embedded object", "[client reset][embedded objects]
     SyncTestFile config(init_sync_manager.app(), "default");
     config.cache = false;
     config.automatic_change_notifications = false;
-    config.sync_config->client_resync_mode = ClientResyncMode::SeamlessLoss;
+    config.sync_config->client_resync_mode = ClientResyncMode::DiscardLocal;
     config.schema = Schema{
         {"object",
          {

--- a/test/object-store/sync/sync_test_utils.cpp
+++ b/test/object-store/sync/sync_test_utils.cpp
@@ -229,13 +229,13 @@ Obj create_object(Realm& realm, StringData object_type, util::Optional<int64_t> 
     return table->create_object_with_primary_key(primary_key ? *primary_key : pk++, std::move(values));
 }
 
-// fake seamless loss by turning off sync and calling transfer group directly
+// fake discard local mode by turning off sync and calling transfer group directly
 struct FakeLocalClientReset : public TestClientReset {
     FakeLocalClientReset(realm::Realm::Config local_config, realm::Realm::Config remote_config)
         : TestClientReset(local_config, remote_config)
     {
         REALM_ASSERT(m_local_config.sync_config);
-        REALM_ASSERT(m_local_config.sync_config->client_resync_mode == ClientResyncMode::SeamlessLoss);
+        REALM_ASSERT(m_local_config.sync_config->client_resync_mode == ClientResyncMode::DiscardLocal);
         // turn off sync, we only fake it
         m_local_config.sync_config = {};
         m_remote_config.sync_config = {};

--- a/test/test_client_reset.cpp
+++ b/test/test_client_reset.cpp
@@ -148,7 +148,7 @@ TEST(ClientReset_NoLocalChanges)
             Session::Config session_config;
             {
                 Session::Config::ClientReset client_reset_config;
-                client_reset_config.seamless_loss = true;
+                client_reset_config.discard_local = true;
                 client_reset_config.fresh_copy = std::move(sg_fresh);
                 session_config.client_reset_config = std::move(client_reset_config);
             }
@@ -221,7 +221,7 @@ TEST(ClientReset_InitialLocalChanges)
     Session::Config session_config_2;
     {
         Session::Config::ClientReset client_reset_config;
-        client_reset_config.seamless_loss = true;
+        client_reset_config.discard_local = true;
         client_reset_config.fresh_copy = std::move(sg_fresh);
         session_config_2.client_reset_config = std::move(client_reset_config);
     }
@@ -573,14 +573,14 @@ TEST(ClientReset_ThreeClients)
             Session::Config session_config_1;
             {
                 Session::Config::ClientReset client_reset_config;
-                client_reset_config.seamless_loss = true;
+                client_reset_config.discard_local = true;
                 client_reset_config.fresh_copy = std::move(sg_fresh1);
                 session_config_1.client_reset_config = std::move(client_reset_config);
             }
             Session::Config session_config_2;
             {
                 Session::Config::ClientReset client_reset_config;
-                client_reset_config.seamless_loss = true;
+                client_reset_config.discard_local = true;
                 client_reset_config.fresh_copy = std::move(sg_fresh2);
                 session_config_2.client_reset_config = std::move(client_reset_config);
             }
@@ -700,7 +700,7 @@ TEST(ClientReset_DoNotRecoverSchema)
         Session::Config session_config;
         {
             Session::Config::ClientReset client_reset_config;
-            client_reset_config.seamless_loss = true;
+            client_reset_config.discard_local = true;
             client_reset_config.fresh_copy = std::move(sg_fresh1);
             session_config.client_reset_config = std::move(client_reset_config);
         }


### PR DESCRIPTION
Several updates based on feedback from SDK integration.

- the notify callbacks now pass a SharedRealm object instead of a TransactionRef
- rename "seamless loss" to "discard local"
- don't download the fresh Realm copy with the local schema because it might be wrong


## ☑️ ToDos
* [x] 📝 Changelog update
* [x] 🚦 Tests (or not relevant)
