### PR TITLE
Insert FLX subscription at the correct index

### DIFF
--- a/src/realm/sync/subscriptions.cpp
+++ b/src/realm/sync/subscriptions.cpp
@@ -191,7 +191,7 @@ void SubscriptionSet::clear()
 void SubscriptionSet::insert_sub_impl(Timestamp created_at, Timestamp updated_at, StringData name,
                                       StringData object_class_name, StringData query_str)
 {
-    auto new_sub = m_sub_list.create_and_insert_linked_object(m_sub_list.is_empty() ? 0 : m_sub_list.size() - 1);
+    auto new_sub = m_sub_list.create_and_insert_linked_object(m_sub_list.is_empty() ? 0 : m_sub_list.size());
     new_sub.set(m_mgr->m_sub_keys->created_at, created_at);
     new_sub.set(m_mgr->m_sub_keys->updated_at, updated_at);
     new_sub.set(m_mgr->m_sub_keys->name, name);


### PR DESCRIPTION
This came up while writing .NET tests - the subscription got inserted in the penultimate position, which made the returned iterator incorrect. 