### PR TITLE
Fix some sporadically failing tests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 ### Fixed
 * <How do the end-user experience this issue? what was the impact?> ([#????](https://github.com/realm/realm-core/issues/????), since v?.?.?)
 * The client reset callbacks now pass out SharedRealm objects instead of TransactionRefs. ([#5048](https://github.com/realm/realm-core/issues/5048), since v11.5.0) 
+* A client reset in DiscardLocal mode would revert to Manual mode on the next restart of the session. ([#5050](https://github.com/realm/realm-core/issues/5050), since v11.5.0)
  
 ### Breaking changes
 * None.

--- a/src/realm/object-store/impl/realm_coordinator.cpp
+++ b/src/realm/object-store/impl/realm_coordinator.cpp
@@ -115,6 +115,9 @@ void RealmCoordinator::create_sync_session()
                 // Do not use 'discard local' mode on the fresh Realm. Use manual mode so that
                 // any error during the download is propagated back to the original session.
                 // This prevents a cycle if the fresh copy itself experiences a client reset.
+                // To make this change and not have it affect the actual sync session, an explicit
+                // copy must be made of the sync config because it is a shared pointer.
+                copy_config.sync_config = std::make_shared<SyncConfig>(*m_config.sync_config);
                 copy_config.sync_config->client_resync_mode = ClientResyncMode::Manual;
                 std::shared_ptr<RealmCoordinator> rc = get_coordinator(copy_config);
                 REALM_ASSERT(rc);

--- a/test/object-store/sync/app.cpp
+++ b/test/object-store/sync/app.cpp
@@ -1847,7 +1847,8 @@ TEST_CASE("app: make distributable client file", "[sync][app]") {
 
 constexpr size_t minus_25_percent(size_t val)
 {
-    return val * .75 - 1;
+    REALM_ASSERT(val * .75 > 10);
+    return val * .75 - 10;
 }
 
 TEST_CASE("app: sync integration", "[sync][app]") {
@@ -2114,7 +2115,7 @@ TEST_CASE("app: sync integration", "[sync][app]") {
             REQUIRE(!user->is_logged_in());
         }
 
-        SECTION("Requests that receive an error are retried on an backoff") {
+        SECTION("Requests that receive an error are retried on a backoff") {
             using namespace std::chrono;
             std::vector<time_point<steady_clock>> response_times;
             std::atomic<bool> did_receive_valid_token{false};

--- a/test/object-store/sync/sync_test_utils.cpp
+++ b/test/object-store/sync/sync_test_utils.cpp
@@ -469,7 +469,7 @@ struct BaasClientReset : public TestClientReset {
                     }
                     return count_external > 0;
                 },
-                std::chrono::minutes(3));
+                std::chrono::minutes(5));
             session->log_out();
 
             realm->begin_transaction();


### PR DESCRIPTION
Several sporadic failures were actually pointing to a real problem which was an oversight that copying a config object would not copy the sync config. This meant that a subsequent client reset would use manual mode. (ex [report](https://ci.realm.io/blue/organizations/jenkins/realm%2Frealm-core/detail/PR-5009/15/pipeline/)) 

Increasing the wait time for baas to pull changes into the backing db from 3 to 5 minutes because sometimes this is timing out on CI (ex [report](https://spruce.mongodb.com/task/realm_core_stable_macos_1015_release_object_store_tests_patch_9878e696b6df99c65d99eaa31cae08908fbad5df_6193fcec3e8e8628da63a80b_21_11_16_18_48_13/logs?execution=0&sortBy=STATUS&sortDir=ASC))

The backoff times are relaxed a bit because there was a [failure reported](https://spruce.mongodb.com/task/realm_core_stable_ubuntu2004_object_store_tests_patch_9878e696b6df99c65d99eaa31cae08908fbad5df_61952a0f3066157127be83ce_21_11_17_16_13_04/logs?execution=0&sortBy=STATUS&sortDir=ASC) with `from expresion: 'delay_times[i] > expected_min_delays[i]' with expansion: '748 (0x2ec) > 749 (0x2ed)'`

## ☑️ ToDos
* [x] 📝 Changelog update
* [x] 🚦 Tests (or not relevant)
