### PR TITLE
Fix iterator handling in SubscriptionSet erase

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@
 * The 'power' unary operator template to be used in a query expression is removed
 * Renamed ClientResyncMode::SeamlessLoss -> DiscardLocal.
 * Updated sync client to be able to open connections to FLX sync-enabled apps in baas ([#5009](https://github.com/realm/realm-core/pull/5009))
+* SubscriptionSet::erase now returns the correct itererator for the "next" subscription ([#5053](https://github.com/realm/realm-core/pull/5053))
 
 ----------------------------------------------
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@
 * Renamed ClientResyncMode::SeamlessLoss -> DiscardLocal.
 * Updated sync client to be able to open connections to FLX sync-enabled apps in baas ([#5009](https://github.com/realm/realm-core/pull/5009))
 * SubscriptionSet::erase now returns the correct itererator for the "next" subscription ([#5053](https://github.com/realm/realm-core/pull/5053))
+* SubscriptionSet::insert_or_assign now returns an iterator pointing to the correct subscription ([#5049](https://github.com/realm/realm-core/pull/5049))
 
 ----------------------------------------------
 

--- a/src/realm/sync/subscriptions.cpp
+++ b/src/realm/sync/subscriptions.cpp
@@ -180,7 +180,9 @@ SubscriptionSet::const_iterator SubscriptionSet::find(const Query& query) const
 SubscriptionSet::const_iterator SubscriptionSet::erase(const_iterator it)
 {
     m_sub_list.remove_target_row(it.m_sub_it.index());
-    return it;
+    auto at_end = (it.m_sub_it.index() == m_sub_list.size());
+    return at_end ? const_iterator(this, m_sub_list.end())
+                  : const_iterator(this, LnkLst::iterator(&m_sub_list, it.m_sub_it.index()));
 }
 
 void SubscriptionSet::clear()

--- a/test/test_sync_subscriptions.cpp
+++ b/test/test_sync_subscriptions.cpp
@@ -156,13 +156,19 @@ TEST(Sync_SubscriptionStoreStateUpdates)
     {
         auto set = store.get_latest().make_mutable_copy();
         CHECK_EQUAL(set.size(), 1);
-        set.insert_or_assign(query_a);
+        // This is just to create a unique name for this sub so we can verify that the iterator returned by
+        // insert_or_assign is pointing to the subscription that was just created.
+        std::string new_sub_name = ObjectId::gen().to_string();
+        auto&& [inserted_it, inserted] = set.insert_or_assign(new_sub_name, query_a);
+        CHECK(inserted);
+        CHECK_EQUAL(inserted_it->name(), new_sub_name);
         CHECK_EQUAL(set.size(), 2);
         auto it = set.begin();
+        CHECK_EQUAL(it->name(), "b sub");
         it = set.erase(it);
         CHECK_NOT_EQUAL(it, set.end());
         CHECK_EQUAL(set.size(), 1);
-        CHECK_EQUAL(it->name(), "b sub");
+        CHECK_EQUAL(it->name(), new_sub_name);
         it = set.erase(it);
         CHECK_EQUAL(it, set.end());
         CHECK_EQUAL(set.size(), 0);

--- a/test/test_sync_subscriptions.cpp
+++ b/test/test_sync_subscriptions.cpp
@@ -152,6 +152,21 @@ TEST(Sync_SubscriptionStoreStateUpdates)
         // By marking version 2 as complete version 1 will get superceded and removed.
         CHECK_THROW(store.get_mutable_by_version(1), KeyNotFound);
     }
+
+    {
+        auto set = store.get_latest().make_mutable_copy();
+        CHECK_EQUAL(set.size(), 1);
+        set.insert_or_assign(query_a);
+        CHECK_EQUAL(set.size(), 2);
+        auto it = set.begin();
+        it = set.erase(it);
+        CHECK_NOT_EQUAL(it, set.end());
+        CHECK_EQUAL(set.size(), 1);
+        CHECK_EQUAL(it->name(), "b sub");
+        it = set.erase(it);
+        CHECK_EQUAL(it, set.end());
+        CHECK_EQUAL(set.size(), 0);
+    }
 }
 
 TEST(Sync_SubscriptionStoreUpdateExisting)


### PR DESCRIPTION
## What, How & Why?
Fixes the erase() method if SubscriptionSet so that it returns the correct iterator. Also adds a test case for the iterator returned by the insert method.

Fixes https://github.com/realm/realm-core/issues/5052

## ☑️ ToDos
* [x] 📝 Changelog update
* [x] 🚦 Tests (or not relevant)
