### PR TITLE
Add unique id to Subscriptions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,7 @@
 * SubscriptionSet::insert_or_assign now returns an iterator pointing to the correct subscription ([#5049](https://github.com/realm/realm-core/pull/5049))
 * `SimulatedFailure` mmap handling was not thread-safe.
 * Rename SchemaMode::ReadOnlyAlternative to ReadOnly. ([#5070](https://github.com/realm/realm-core/issues/5070))
+* Subscriptions for FLX sync now have a unique ID ([#5054](https://github.com/realm/realm-core/pull/5054))
 
 ----------------------------------------------
 

--- a/src/realm/sync/subscriptions.hpp
+++ b/src/realm/sync/subscriptions.hpp
@@ -38,6 +38,9 @@ class SubscriptionStore;
 // send to the server in a QUERY or IDENT message.
 class Subscription {
 public:
+    // Returns the unique ID for this subscription.
+    ObjectId id() const;
+
     // Returns the timestamp of when this subscription was originally created.
     Timestamp created_at() const;
 
@@ -241,8 +244,8 @@ protected:
     std::pair<iterator, bool> insert_or_assign_impl(iterator it, StringData name, StringData object_class_name,
                                                     StringData query_str);
 
-    void insert_sub_impl(Timestamp created_at, Timestamp updated_at, StringData name, StringData object_class_name,
-                         StringData query_str);
+    void insert_sub_impl(ObjectId id, Timestamp created_at, Timestamp updated_at, StringData name,
+                         StringData object_class_name, StringData query_str);
 
     void process_notifications();
 
@@ -283,6 +286,7 @@ private:
 protected:
     struct SubscriptionKeys {
         TableKey table;
+        ColKey id;
         ColKey created_at;
         ColKey updated_at;
         ColKey name;

--- a/test/test_sync_subscriptions.cpp
+++ b/test/test_sync_subscriptions.cpp
@@ -186,18 +186,32 @@ TEST(Sync_SubscriptionStoreUpdateExisting)
     query_a.equal(fixture.foo_col, StringData("JBR")).greater_equal(fixture.bar_col, int64_t(1));
     Query query_b(read_tr->get_table(fixture.a_table_key));
     query_b.equal(fixture.foo_col, "Realm");
+    ObjectId id_of_inserted;
+    auto sub_name = ObjectId::gen().to_string();
     {
         auto out = store.get_latest().make_mutable_copy();
-        auto read_tr = fixture.db->start_read();
-        auto [it, inserted] = out.insert_or_assign("a sub", query_a);
+        auto [it, inserted] = out.insert_or_assign(sub_name, query_a);
         CHECK(inserted);
         CHECK_NOT_EQUAL(it, out.end());
+        id_of_inserted = it->id();
+        CHECK_NOT_EQUAL(id_of_inserted, ObjectId{});
 
-        std::tie(it, inserted) = out.insert_or_assign("a sub", query_b);
+        std::tie(it, inserted) = out.insert_or_assign(sub_name, query_b);
         CHECK(!inserted);
         CHECK_NOT_EQUAL(it, out.end());
         CHECK_EQUAL(it->object_class_name(), "a");
         CHECK_EQUAL(it->query_string(), query_b.get_description());
+        CHECK_EQUAL(it->id(), id_of_inserted);
+        out.commit();
+    }
+    {
+        auto set = store.get_latest().make_mutable_copy();
+        CHECK_EQUAL(set.size(), 1);
+        auto it = std::find_if(set.begin(), set.end(), [&](const Subscription& sub) {
+            return sub.id() == id_of_inserted;
+        });
+        CHECK_NOT_EQUAL(it, set.end());
+        CHECK_EQUAL(it->name(), sub_name);
     }
 }
 


### PR DESCRIPTION
## What, How & Why?
Adds a unique ObjectId to Subscriptions so that you can uniquely identify them without comparing the query or name fields.

## ☑️ ToDos
* [x] 📝 Changelog update
* [x] 🚦 Tests (or not relevant)
