### PR TITLE
Add some baas config overrides to make integration tests faster

### DIFF
--- a/evergreen/config_overrides.json
+++ b/evergreen/config_overrides.json
@@ -1,0 +1,13 @@
+{
+  "events": {
+    "streams": {
+      "eventSubscriptionPollingPeriodSec": 2,
+      "eventSubscriptionHeartbeatPeriodSec": 2
+    },
+    "mediator": {
+      "eventSubscriptionPollingPeriodSeconds": 4,
+      "unownedEventSubscriptionPollingPeriodSeconds": 2,
+      "staleOwnedJobPollingPeriodSec": 2
+    }
+  }
+}

--- a/evergreen/install_baas.sh
+++ b/evergreen/install_baas.sh
@@ -275,7 +275,7 @@ echo "Starting stitch app server"
 [[ -f $WORK_PATH/baas_server.pid ]] && rm $WORK_PATH/baas_server.pid
 go build -o $WORK_PATH/baas_server cmd/server/main.go
 $WORK_PATH/baas_server \
-    --configFile=etc/configs/test_config.json 2>&1 > $WORK_PATH/baas_server.log &
+    --configFile=etc/configs/test_config.json --configFile=$BASE_PATH/config_overrides.json 2>&1 > $WORK_PATH/baas_server.log &
 echo $! > $WORK_PATH/baas_server.pid
 $BASE_PATH/wait_for_baas.sh $WORK_PATH/baas_server.pid
 


### PR DESCRIPTION
This should hopefully speed up the client reset integration tests which we have seen can take more than 3 minutes to propagate changes from the translator into the backing db.

If this works, I'll update our Docker file to do the same on Jenkins and local development.

## ☑️ ToDos
* [ ] 📝 Changelog update
* [ ] 🚦 Tests (or not relevant)
