### PR TITLE
Use the correct data type for aggregate queries on Dictionaries

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 * <How do the end-user experience this issue? what was the impact?> ([#????](https://github.com/realm/realm-core/issues/????), since v?.?.?)
 * The client reset callbacks now pass out SharedRealm objects instead of TransactionRefs. ([#5048](https://github.com/realm/realm-core/issues/5048), since v11.5.0) 
 * A client reset in DiscardLocal mode would revert to Manual mode on the next restart of the session. ([#5050](https://github.com/realm/realm-core/issues/5050), since v11.5.0)
+* `@sum` and `@avg` queries on Dictionaries of floats or doubles used too much precision for intermediates, resulting in incorrect rounding (since v10.2.0).
  
 ### Breaking changes
 * None.

--- a/src/realm/query.cpp
+++ b/src/realm/query.cpp
@@ -1863,13 +1863,13 @@ std::string Query::get_description(util::serializer::SerialisationState& state) 
     std::string description;
     if (root_node()) {
         if (m_view) {
-            throw SerialisationError("Serialisation of a query constrianed by a view is not currently supported");
+            throw SerialisationError("Serialisation of a query constrained by a view is not currently supported");
         }
         description = root_node()->describe_expression(state);
     }
     else {
         // An empty query returns all results and one way to indicate this
-        // is to serialise TRUEPREDICATE which is functionally equivilent
+        // is to serialise TRUEPREDICATE which is functionally equivalent
         description = "TRUEPREDICATE";
     }
     if (this->m_ordering) {

--- a/src/realm/query_expression.hpp
+++ b/src/realm/query_expression.hpp
@@ -972,9 +972,7 @@ class Subexpr2 : public Subexpr,
                  public Overloads<T, Mixed>,
                  public Overloads<T, null> {
 public:
-    virtual ~Subexpr2() {}
-
-    DataType get_type() const final
+    DataType get_type() const override
     {
         return ColumnTypeTraits<T>::id;
     }
@@ -1107,7 +1105,7 @@ public:
     Query contains(const Subexpr2<Mixed>& col, bool case_sensitive = true);
     Query like(Mixed sd, bool case_sensitive = true);
     Query like(const Subexpr2<Mixed>& col, bool case_sensitive = true);
-    DataType get_type() const final
+    DataType get_type() const override
     {
         return type_Mixed;
     }
@@ -3153,6 +3151,11 @@ public:
     {
     }
 
+    DataType get_type() const override
+    {
+        return DataType(m_columns_collection.m_column_key.get_type());
+    }
+
     std::unique_ptr<Subexpr> clone() const override
     {
         return make_subexpr<CollectionColumnAggregate>(*this);
@@ -3278,10 +3281,10 @@ private:
             return dict_cluster.min();
         }
         else if constexpr (std::is_same_v<Operation, aggregate_operations::Average<Mixed>>) {
-            return dict_cluster.avg();
+            return dict_cluster.avg(nullptr, get_type());
         }
         else if constexpr (std::is_same_v<Operation, aggregate_operations::Sum<Mixed>>) {
-            return dict_cluster.sum();
+            return dict_cluster.sum(nullptr, get_type());
         }
         REALM_UNREACHABLE();
     }

--- a/src/realm/util/serializer.cpp
+++ b/src/realm/util/serializer.cpp
@@ -66,7 +66,7 @@ inline std::string print_with_nan_check(T val)
         return "nan";
     }
     std::stringstream ss;
-    ss << val;
+    ss << std::setprecision(std::numeric_limits<T>::max_digits10) << val;
     return ss.str();
 }
 

--- a/test/test_parser.cpp
+++ b/test/test_parser.cpp
@@ -4704,6 +4704,31 @@ TEST(Parser_DictionaryObjects)
     verify_query(test_context, persons, "pets.@values.age > 4", 1);
 }
 
+TEST_TYPES(Parser_DictionaryAggregates, Prop<float>, Prop<double>, Prop<Decimal128>)
+{
+    using type = typename TEST_TYPE::type;
+
+    std::array<type, 3> values = {type(5.55444333), type(6.55444333), type(7.55444333)};
+
+    Group g;
+    auto table = g.add_table("table");
+    auto col = table->add_column_dictionary(TEST_TYPE::data_type, "dict");
+    auto obj = table->create_object();
+    Dictionary dict = obj.get_dictionary(col);
+    dict.insert("1", values[0]);
+    dict.insert("2", values[1]);
+    dict.insert("3", values[2]);
+
+    Any arg = values[0];
+    verify_query_sub(test_context, table, "dict.@min == $0", &arg, 1, 1);
+    arg = values[2];
+    verify_query_sub(test_context, table, "dict.@max == $0", &arg, 1, 1);
+    arg = values[0] + values[1] + values[2];
+    verify_query_sub(test_context, table, "dict.@sum == $0", &arg, 1, 1);
+    arg = (values[0] + values[1] + values[2]) / 3;
+    verify_query_sub(test_context, table, "dict.@avg == $0", &arg, 1, 1);
+}
+
 TEST_TYPES(Parser_Set, Prop<int64_t>, Prop<float>, Prop<double>, Prop<Decimal128>, Prop<ObjectId>, Prop<Timestamp>,
            Prop<String>, Prop<BinaryData>, Prop<UUID>, Nullable<int64_t>, Nullable<float>, Nullable<double>,
            Nullable<Decimal128>, Nullable<ObjectId>, Nullable<Timestamp>, Nullable<String>, Nullable<BinaryData>,


### PR DESCRIPTION
The impetus for all this is that queries of the sort `realm.objects(DictionaryContainingObject.self).filter("dictionary.@avg = %@", dictionary.average())` would sometimes fail to match the object containing that dictionary. There turned out to be a few problems.

1. Aggregate operations on Dictionaries always did the aggregate using Decimal128 temporaries, which produces incorrect rounding; summing a sequence of Decimal128s and then converting to float isn't identical to summing a sequences of floats. Fortunately the relevant code already supports aggregating the specific types and just had to be passed the data type. I don't know if the specific change here is ideal. I know we're trying to move away from converting ColumnTypes to DataTypes, but I don't see a good way to get the DataType.
2. Serializing queries used insufficient precision for writing floating-point values. This meant that in some cases the serialize-and-then-reparse tests failed even when the initial query worked. This was a simple fix and doesn't get a changelog entry because we aren't currently using query serialization (but will start using it again soon for flexible sync).
3. Parsing queries always parsed numbers being compared to dictionary fields as as Decimal128. This some failures in the serialize-then-parse case even with the above fixes, and I'm not entirely sure why. Overriding get_type() in CollectionColumnAggregate makes it use the correct type for non-Mixed.

While trying to figure out why the above was an issue, I noticed that Decimal128(double) wasn't serializing the double with maximum precision and so the conversion was lossy. Fixing this resulted in a lot of test failures, [which I started trying to address](https://github.com/realm/realm-core/commit/db39e0cc275f4b766e39c53938284f436b3398fa) but gave up on. Many of the problems were simply due to the tests being incorrect; they relied on the lossy rounding making `3.3f + 4.4 == 7.7`, which isn't actually correct. Other ones were due to constructing `Decimal128` objects with a double literal rather than a string, resulting in them not actually having the intended value.

The part that wasn't just something to be fixed in tests is comparisons on Mixed columns in the query parser, where there's a lot of cases that look like they should work but happen to only work because of the rounding. Currently numbers in a query string which are compared to a Mixed value are parsed as a double, then converted to a Decimal128. This obviously is lossy even with correct double -> Decimal128 conversions. Doing the obvious thing of changing it to parse numbers for Mixed as Decimal128 instead adds a new problem: `mixedProp == 7.6` no longer matches `Mixed(7.6)`, because `Decimal128(7.6) != Decimal128("7.6")`. Trying to find a solution to that was a rabbit hole of its own, so I gave up on trying to fix the double -> Decimal128 conversion.