### PR TITLE
get_last_error returns memory allocated copy of the error

### DIFF
--- a/src/realm.h
+++ b/src/realm.h
@@ -378,7 +378,8 @@ RLM_API void realm_get_library_version_numbers(int* out_major, int* out_minor, i
  * Note: Calling this function does not clear the current last error.
  *
  * This function does allocate memory. It should be released with a call to `realm_release_last_error`.
- * 
+ *
+ *
  * Note: As a best practice always check the function result for success before calling realm_get_last_error since it
  * copies the error message everytime and needs a subsequent `realm_release_last_error() call`
  *
@@ -389,8 +390,8 @@ RLM_API realm_error_t* realm_get_last_error();
 
 /**
  * Releases the `realm_error_t` allocated by `realm_get_last_error()` and `realm_get_async_error()`
- * 
- * 
+ *
+ *
  * @see realm_get_last_error()
  */
 RLM_API void realm_release_last_error(realm_error_t* err);
@@ -399,6 +400,7 @@ RLM_API void realm_release_last_error(realm_error_t* err);
  * Get information about an async error, potentially coming from another thread.
  *
  * This function does allocate memory. It should be released with a call to `realm_release_last_error`.
+ * 
  * 
  * @see realm_get_last_error()
  * @return A pointer to a `realm_error_t` struct that will be populated with

--- a/src/realm.h
+++ b/src/realm.h
@@ -379,8 +379,8 @@ RLM_API void realm_get_library_version_numbers(int* out_major, int* out_minor, i
  *
  * This function does allocate memory. It should be released with a call to `realm_release_last_error`.
  * 
- * Note: As a best practice always check the function result for success before calling realm_get_last_error since it copies the error message everytime 
- * and needs a subsequent `realm_release_last_error() call`
+ * Note: As a best practice always check the function result for success before calling realm_get_last_error since it
+ * copies the error message everytime and needs a subsequent `realm_release_last_error() call`
  *
  * @return A pointer to a `realm_error_t` struct that will be populated with
  *         information about the last error, if there is one. Or NULL if no error occured.
@@ -388,7 +388,8 @@ RLM_API void realm_get_library_version_numbers(int* out_major, int* out_minor, i
 RLM_API realm_error_t* realm_get_last_error();
 
 /**
- * Releases the `realm_error_t` allocated by `realm_get_last_error()`
+ * Releases the `realm_error_t` allocated by `realm_get_last_error()` and `realm_get_async_error()`
+ * 
  * 
  * @see realm_get_last_error()
  */
@@ -397,9 +398,11 @@ RLM_API void realm_release_last_error(realm_error_t* err);
 /**
  * Get information about an async error, potentially coming from another thread.
  *
+ * This function does allocate memory. It should be released with a call to `realm_release_last_error`.
+ * 
  * @see realm_get_last_error()
  * @return A pointer to a `realm_error_t` struct that will be populated with
- *         information about the error. 
+ *         information about the error.
  */
 RLM_API realm_error_t* realm_get_async_error(const realm_async_error_t* err);
 

--- a/src/realm.h
+++ b/src/realm.h
@@ -400,8 +400,8 @@ RLM_API void realm_release_last_error(realm_error_t* err);
  * Get information about an async error, potentially coming from another thread.
  *
  * This function does allocate memory. It should be released with a call to `realm_release_last_error`.
- * 
- * 
+ *
+ *
  * @see realm_get_last_error()
  * @return A pointer to a `realm_error_t` struct that will be populated with
  *         information about the error.

--- a/src/realm.h
+++ b/src/realm.h
@@ -371,33 +371,37 @@ RLM_API void realm_get_library_version_numbers(int* out_major, int* out_minor, i
  * the call that caused the error to occur. The error is specific to the current
  * thread, and not the Realm instance for which the error occurred.
  *
- * Note: The error message in @a err will only be safe to use until the next API
- *       call is made on the current thread.
- *
  * Note: The error is not cleared by subsequent successful calls to this
  *       function, but it will be overwritten by subsequent failing calls to
  *       other library functions.
  *
  * Note: Calling this function does not clear the current last error.
  *
- * This function does not allocate any memory.
+ * This function does allocate memory. It should be released with a call to `realm_release_last_error`.
+ * 
+ * Note: As a best practice always check the function result for success before calling realm_get_last_error since it copies the error message everytime 
+ * and needs a subsequent `realm_release_last_error() call`
  *
- * @param err A pointer to a `realm_error_t` struct that will be populated with
- *            information about the last error, if there is one. May be NULL.
- * @return True if an error occurred.
+ * @return A pointer to a `realm_error_t` struct that will be populated with
+ *         information about the last error, if there is one. Or NULL if no error occured.
  */
-RLM_API bool realm_get_last_error(realm_error_t* err);
+RLM_API realm_error_t* realm_get_last_error();
+
+/**
+ * Releases the `realm_error_t` allocated by `realm_get_last_error()`
+ * 
+ * @see realm_get_last_error()
+ */
+RLM_API void realm_release_last_error(realm_error_t* err);
 
 /**
  * Get information about an async error, potentially coming from another thread.
  *
- * This function does not allocate any memory.
- *
- * @param err A pointer to a `realm_error_t` struct that will be populated with
- *            information about the error. May not be NULL.
  * @see realm_get_last_error()
+ * @return A pointer to a `realm_error_t` struct that will be populated with
+ *         information about the error. 
  */
-RLM_API void realm_get_async_error(const realm_async_error_t* err, realm_error_t* out_err);
+RLM_API realm_error_t* realm_get_async_error(const realm_async_error_t* err);
 
 /**
  * Convert the last error to `realm_async_error_t`, which can safely be passed

--- a/src/realm/object-store/c_api/error.cpp
+++ b/src/realm/object-store/c_api/error.cpp
@@ -75,7 +75,8 @@ static realm_error_t* create_error(std::exception_ptr* ptr)
             if (err) {
                 err->error = error_number;
 
-                //copy the message. rethrow_exception copies the exception object on some platforms (Windows) hence the ex.what() ptr will get invalidated
+                // copy the message. rethrow_exception copies the exception object on some platforms (Windows) hence
+                // the ex.what() ptr will get invalidated
                 std::string message(ex.what());
                 char* messagePtr = static_cast<char*>(std::calloc(message.size() + 1u, sizeof(char*)));
                 std::copy(message.data(), message.data() + message.size() + 1u, messagePtr);

--- a/src/realm/object-store/c_api/error.cpp
+++ b/src/realm/object-store/c_api/error.cpp
@@ -208,7 +208,7 @@ RLM_API void realm_release_last_error(realm_error_t* err)
     if (err) {
         if (err->message) {
             void* ptr = static_cast<void*>(const_cast<char*>(err->message));
-            delete [] ptr;
+            delete[] ptr;
         }
         delete err;
     }

--- a/src/realm/object-store/c_api/error.cpp
+++ b/src/realm/object-store/c_api/error.cpp
@@ -65,12 +65,12 @@ static std::exception_ptr* get_last_exception()
 
 #endif // RLM_NO_THREAD_LOCAL
 
-static const char* copy_message(const char* msg) {
-    std::string message(msg);
-    char* messagePtr = static_cast<char*>(std::malloc(message.size() + 1u));
-    std::copy(message.data(), message.data() + message.size() + 1u, messagePtr);
-    messagePtr[message.size()] = '\0';
-    return static_cast<const char*>(messagePtr);
+static const char* copy_message(const char* msg)
+{
+    std::string_view message_contents(msg);
+    auto message = std::make_unique<char[]>(message_contents.size() + 1);
+    std::strcpy(message.get(), msg);
+    return const_cast<const char*>(message.release());
 }
 
 static realm_error_t* create_error(std::exception_ptr* ptr)
@@ -209,7 +209,7 @@ RLM_API void realm_release_last_error(realm_error_t* err)
     if (err) {
         if (err->message) {
             void* ptr = static_cast<void*>(const_cast<char*>(err->message));
-            std::free(ptr);
+            delete ptr;
         }
         delete err;
     }

--- a/src/realm/object-store/c_api/error.cpp
+++ b/src/realm/object-store/c_api/error.cpp
@@ -82,12 +82,11 @@ static realm_error_t* create_error(std::exception_ptr* ptr)
         err->message = nullptr;
 
         auto populate_error = [&](const std::exception& ex, realm_errno_e error_number) {
-            if (err) {
-                err->error = error_number;
-                // copy the message. rethrow_exception copies the exception object on some platforms (Windows) hence
-                // the ex.what() ptr will get invalidated when create_error completes
-                err->message = copy_message(ex.what());
-            }
+            err->error = error_number;
+            // copy the message. rethrow_exception copies the exception object on some platforms (Windows) hence
+            // the ex.what() ptr will get invalidated when create_error completes
+            err->message = copy_message(ex.what());
+        
             *ptr = std::current_exception();
         };
 

--- a/src/realm/object-store/c_api/error.cpp
+++ b/src/realm/object-store/c_api/error.cpp
@@ -70,6 +70,7 @@ static realm_error_t* create_error(std::exception_ptr* ptr)
     if (ptr && *ptr) {
         realm_error_t* err = new realm_error_t;
         err->kind.code = 0;
+        err->message = nullptr;
 
         auto populate_error = [&](const std::exception& ex, realm_errno_e error_number) {
             if (err) {
@@ -78,7 +79,7 @@ static realm_error_t* create_error(std::exception_ptr* ptr)
                 // copy the message. rethrow_exception copies the exception object on some platforms (Windows) hence
                 // the ex.what() ptr will get invalidated
                 std::string message(ex.what());
-                char* messagePtr = static_cast<char*>(std::calloc(message.size() + 1u, sizeof(char*)));
+                char* messagePtr = static_cast<char*>(std::malloc(message.size() + 1u));
                 std::copy(message.data(), message.data() + message.size() + 1u, messagePtr);
                 messagePtr[message.size()] = '\0';
                 err->message = static_cast<const char*>(messagePtr);

--- a/src/realm/object-store/c_api/error.cpp
+++ b/src/realm/object-store/c_api/error.cpp
@@ -67,11 +67,10 @@ static std::exception_ptr* get_last_exception()
 
 static const char* copy_message(const char* msg)
 {
-    std::string message(msg);
-    char* messagePtr = static_cast<char*>(std::malloc(message.size() + 1u));
-    std::copy(message.data(), message.data() + message.size() + 1u, messagePtr);
-    messagePtr[message.size()] = '\0';
-    return static_cast<const char*>(messagePtr);
+    std::string_view message_contents(msg);
+    auto message = std::make_unique<char[]>(message_contents.size() + 1);
+    std::strcpy(message.get(), msg);
+    return const_cast<const char*>(message.release());
 }
 
 static realm_error_t* create_error(std::exception_ptr* ptr)
@@ -209,7 +208,7 @@ RLM_API void realm_release_last_error(realm_error_t* err)
     if (err) {
         if (err->message) {
             void* ptr = static_cast<void*>(const_cast<char*>(err->message));
-            std::free(ptr);
+            delete [] ptr;
         }
         delete err;
     }

--- a/src/realm/object-store/c_api/error.cpp
+++ b/src/realm/object-store/c_api/error.cpp
@@ -67,10 +67,11 @@ static std::exception_ptr* get_last_exception()
 
 static const char* copy_message(const char* msg)
 {
-    std::string_view message_contents(msg);
-    auto message = std::make_unique<char[]>(message_contents.size() + 1);
-    std::strcpy(message.get(), msg);
-    return const_cast<const char*>(message.release());
+    std::string message(msg);
+    char* messagePtr = static_cast<char*>(std::malloc(message.size() + 1u));
+    std::copy(message.data(), message.data() + message.size() + 1u, messagePtr);
+    messagePtr[message.size()] = '\0';
+    return static_cast<const char*>(messagePtr);
 }
 
 static realm_error_t* create_error(std::exception_ptr* ptr)
@@ -209,7 +210,7 @@ RLM_API void realm_release_last_error(realm_error_t* err)
     if (err) {
         if (err->message) {
             void* ptr = static_cast<void*>(const_cast<char*>(err->message));
-            delete ptr;
+            std::free(ptr);
         }
         delete err;
     }

--- a/src/realm/object-store/c_api/error.cpp
+++ b/src/realm/object-store/c_api/error.cpp
@@ -86,7 +86,7 @@ static realm_error_t* create_error(std::exception_ptr* ptr)
             // copy the message. rethrow_exception copies the exception object on some platforms (Windows) hence
             // the ex.what() ptr will get invalidated when create_error completes
             err->message = copy_message(ex.what());
-        
+
             *ptr = std::current_exception();
         };
 

--- a/test/object-store/c_api/c_api.c
+++ b/test/object-store/c_api/c_api.c
@@ -11,7 +11,7 @@
 #define CHECK_ERROR()                                                                                                \
     do {                                                                                                             \
         realm_error_t* err = realm_get_last_error();                                                                 \
-        if (err) {                                                                                                  \
+        if (err) {                                                                                                   \
             fprintf(stderr, "ERROR: %s\n", err->message);                                                            \
             realm_release_last_error(err);                                                                           \
             return 1;                                                                                                \

--- a/test/object-store/c_api/c_api.c
+++ b/test/object-store/c_api/c_api.c
@@ -10,9 +10,10 @@
 
 #define CHECK_ERROR()                                                                                                \
     do {                                                                                                             \
-        realm_error_t err;                                                                                           \
-        if (realm_get_last_error(&err)) {                                                                            \
-            fprintf(stderr, "ERROR: %s\n", err.message);                                                             \
+        realm_error_t* err = realm_get_last_error();                                                                 \
+        if (err) {                                                                                                  \
+            fprintf(stderr, "ERROR: %s\n", err->message);                                                            \
+            realm_release_last_error(err);                                                                           \
             return 1;                                                                                                \
         }                                                                                                            \
     } while (0)
@@ -236,9 +237,10 @@ int realm_c_api_tests(const char* file)
     CHECK_ERROR();
 
     realm_object_create(realm, foo_info.key);
-    realm_error_t err;
-    assert(realm_get_last_error(&err));
-    assert(err.error == RLM_ERR_NOT_IN_A_TRANSACTION);
+    realm_error_t* err = realm_get_last_error();
+    assert(err);
+    assert(err->error == RLM_ERR_NOT_IN_A_TRANSACTION);
+    realm_release_last_error(err);
     realm_clear_last_error();
 
     realm_object_t* foo_1;

--- a/test/object-store/c_api/c_api.cpp
+++ b/test/object-store/c_api/c_api.cpp
@@ -210,7 +210,7 @@ CPtr<T> clone_cptr(const T* ptr)
 
 #define CHECK_ERR(err)                                                                                               \
     do {                                                                                                             \
-        realm_error_t* _err = realm_get_last_error();                                                                 \
+        realm_error_t* _err = realm_get_last_error();                                                                \
         _err.message = "";                                                                                           \
         _err.error = RLM_ERR_NONE;                                                                                   \
         CHECK(_err != nullptr);                                                                                      \

--- a/test/object-store/c_api/c_api.cpp
+++ b/test/object-store/c_api/c_api.cpp
@@ -266,7 +266,7 @@ TEST_CASE("C API (non-database)") {
         };
         CHECK(!realm_wrap_exceptions(synthetic));
 
-        realm_error_t* err = realm_get_last_error(&err);
+        realm_error_t* err = realm_get_last_error();
         CHECK(err);
         CHECK(err->error == RLM_ERR_OTHER_EXCEPTION);
         CHECK(std::string{err->message} == "Synthetic error");

--- a/test/object-store/c_api/c_api.cpp
+++ b/test/object-store/c_api/c_api.cpp
@@ -267,7 +267,7 @@ TEST_CASE("C API (non-database)") {
         CHECK(!realm_wrap_exceptions(synthetic));
 
         realm_error_t* err = realm_get_last_error();
-        CHECK(err);
+        CHECK(err != nullptr);
         CHECK(err->error == RLM_ERR_OTHER_EXCEPTION);
         CHECK(std::string{err->message} == "Synthetic error");
         realm_release_last_error(err);
@@ -284,7 +284,7 @@ TEST_CASE("C API (non-database)") {
 
         CHECK(!realm_wrap_exceptions(synthetic));
         realm_error_t* err = realm_get_last_error();
-        CHECK(err);
+        CHECK(err != nullptr);
         CHECK(err->error == RLM_ERR_UNKNOWN);
         realm_release_last_error(err);
         CHECK_THROWS_AS(realm_rethrow_last_error(), SyntheticException);

--- a/test/object-store/c_api/c_api.cpp
+++ b/test/object-store/c_api/c_api.cpp
@@ -221,7 +221,7 @@ CPtr<T> clone_cptr(const T* ptr)
         else {                                                                                                       \
             realm_clear_last_error();                                                                                \
         }                                                                                                            \
-        realm_release_last_error(_err);                                                                           \
+        realm_release_last_error(_err);                                                                              \
     } while (false);
 
 TEST_CASE("C API (C)") {
@@ -269,7 +269,7 @@ TEST_CASE("C API (non-database)") {
         realm_error_t* err = realm_get_last_error(&err);
         CHECK(err);
         CHECK(err->error == RLM_ERR_OTHER_EXCEPTION);
-        CHECK(std::string{err=>message} == "Synthetic error");
+        CHECK(std::string{err->message} == "Synthetic error");
         realm_release_last_error(err);
         realm_clear_last_error();
     }

--- a/test/object-store/c_api/c_api.cpp
+++ b/test/object-store/c_api/c_api.cpp
@@ -211,12 +211,9 @@ CPtr<T> clone_cptr(const T* ptr)
 #define CHECK_ERR(err)                                                                                               \
     do {                                                                                                             \
         realm_error_t* _err = realm_get_last_error();                                                                \
-        _err->message = "";                                                                                          \
-        _err->error = RLM_ERR_NONE;                                                                                  \
         CHECK(_err != nullptr);                                                                                      \
         if (_err->error != err) {                                                                                    \
             CHECK(_err->error == err);                                                                               \
-            CHECK(std::string{_err->message} == "");                                                                 \
         }                                                                                                            \
         else {                                                                                                       \
             realm_clear_last_error();                                                                                \

--- a/test/object-store/c_api/c_api.cpp
+++ b/test/object-store/c_api/c_api.cpp
@@ -211,12 +211,12 @@ CPtr<T> clone_cptr(const T* ptr)
 #define CHECK_ERR(err)                                                                                               \
     do {                                                                                                             \
         realm_error_t* _err = realm_get_last_error();                                                                \
-        _err->message = "";                                                                                           \
-        _err->error = RLM_ERR_NONE;                                                                                   \
+        _err->message = "";                                                                                          \
+        _err->error = RLM_ERR_NONE;                                                                                  \
         CHECK(_err != nullptr);                                                                                      \
-        if (_err->error != err) {                                                                                     \
-            CHECK(_err->error == err);                                                                                \
-            CHECK(std::string{_err->message} == "");                                                                  \
+        if (_err->error != err) {                                                                                    \
+            CHECK(_err->error == err);                                                                               \
+            CHECK(std::string{_err->message} == "");                                                                 \
         }                                                                                                            \
         else {                                                                                                       \
             realm_clear_last_error();                                                                                \

--- a/test/object-store/c_api/c_api.cpp
+++ b/test/object-store/c_api/c_api.cpp
@@ -211,12 +211,12 @@ CPtr<T> clone_cptr(const T* ptr)
 #define CHECK_ERR(err)                                                                                               \
     do {                                                                                                             \
         realm_error_t* _err = realm_get_last_error();                                                                \
-        _err.message = "";                                                                                           \
-        _err.error = RLM_ERR_NONE;                                                                                   \
+        _err->message = "";                                                                                           \
+        _err->error = RLM_ERR_NONE;                                                                                   \
         CHECK(_err != nullptr);                                                                                      \
-        if (_err.error != err) {                                                                                     \
-            CHECK(_err.error == err);                                                                                \
-            CHECK(std::string{_err.message} == "");                                                                  \
+        if (_err->error != err) {                                                                                     \
+            CHECK(_err->error == err);                                                                                \
+            CHECK(std::string{_err->message} == "");                                                                  \
         }                                                                                                            \
         else {                                                                                                       \
             realm_clear_last_error();                                                                                \

--- a/test/object-store/c_api/c_api.cpp
+++ b/test/object-store/c_api/c_api.cpp
@@ -210,7 +210,7 @@ CPtr<T> clone_cptr(const T* ptr)
 
 #define CHECK_ERR(err)                                                                                               \
     do {                                                                                                             \
-        realm_error_t _err = realm_get_last_error();                                                                 \
+        realm_error_t* _err = realm_get_last_error();                                                                 \
         _err.message = "";                                                                                           \
         _err.error = RLM_ERR_NONE;                                                                                   \
         CHECK(_err != nullptr);                                                                                      \


### PR DESCRIPTION
This fixes use after free where exception objects maybe copied accross `rethrow_exception` calls. This happens on Windows but is possible everywhere since the `rethrow_exception` behaviour is unspecified. 

introduces realm_release_last_error
fixes tests