### PR TITLE
Do not use std::exception_ptr for C error API

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@
 * 'Obj TableView::get(size_t)' removed. Use 'TableView::get_object' instead.
 * Fix issue compiling in debug mode for iOS.
 * FLX sync now sends the query version in IDENT messages along with the query body ([#5093](https://github.com/realm/realm-core/pull/5093))
+* Errors in C API no longer store or expose a std::exception_ptr. The comparison of realm_async_error_t now compares error code vs object identity. ([#5064](https://github.com/realm/realm-core/pull/5064))
 
 ----------------------------------------------
 

--- a/src/realm.h
+++ b/src/realm.h
@@ -414,16 +414,6 @@ RLM_API realm_async_error_t* realm_get_last_error_as_async_error(void);
 
 #if defined(__cplusplus)
 /**
- * Rethrow the last exception.
- *
- * Note: This function does not have C linkage, because throwing across language
- * boundaries is undefined behavior. When called from C code, this should result
- * in a linker error. When called from C++, `std::rethrow_exception` will be
- * called to propagate the exception unchanged.
- */
-RLM_EXPORT void realm_rethrow_last_error(void);
-
-/**
  * Invoke a function that may throw an exception, and report that exception as
  * part of the C API error handling mechanism.
  *

--- a/src/realm/object-store/c_api/error.cpp
+++ b/src/realm/object-store/c_api/error.cpp
@@ -76,7 +76,6 @@ void ErrorStorage::assign(std::exception_ptr eptr) noexcept
         clear();
         return;
     }
-    m_err->kind.code = 0;
 
     auto populate_error = [&](const std::exception& ex, realm_errno_e error_number) {
         m_err.emplace();
@@ -192,6 +191,8 @@ void ErrorStorage::assign(std::exception_ptr eptr) noexcept
         m_message_buf = "Unknown error";
         m_err->message = m_message_buf.c_str();
     }
+
+    m_err->kind.code = 0;
 }
 
 bool ErrorStorage::has_error() const noexcept

--- a/src/realm/object-store/c_api/error.cpp
+++ b/src/realm/object-store/c_api/error.cpp
@@ -61,7 +61,7 @@ ErrorStorage& ErrorStorage::operator=(ErrorStorage&& other)
 
 bool ErrorStorage::operator==(const ErrorStorage& other) const noexcept
 {
-    if ((m_err && !other.m_err) || (!m_err && other.m_err)) {
+    if (bool(m_err) != bool(other.m_err)) {
         return false;
     }
     else if (!m_err && !other.m_err) {
@@ -77,16 +77,19 @@ void ErrorStorage::assign(std::exception_ptr eptr) noexcept
         return;
     }
 
+    m_err.emplace();
+    m_err->kind.code = 0;
     auto populate_error = [&](const std::exception& ex, realm_errno_e error_number) {
-        m_err.emplace();
         m_err->error = error_number;
         try {
             m_message_buf = ex.what();
             m_err->message = m_message_buf.c_str();
         }
         catch (const std::bad_alloc&) {
-            m_message_buf = std::string{};
-            m_err->message = "Bad alloc while building error";
+            // If we are unable to build the new error because we ran out of memory we should propagate the OOM condition
+            // and leaf the m_message_buf as it was.
+            m_err->error = RLM_ERR_OUT_OF_MEMORY;
+            m_err->message = "Out of memory while creating realm_error_t";
         }
     };
 
@@ -186,13 +189,10 @@ void ErrorStorage::assign(std::exception_ptr eptr) noexcept
     }
     // FIXME: Handle more exception types.
     catch (...) {
-        m_err.emplace();
         m_err->error = RLM_ERR_UNKNOWN;
         m_message_buf = "Unknown error";
         m_err->message = m_message_buf.c_str();
     }
-
-    m_err->kind.code = 0;
 }
 
 bool ErrorStorage::has_error() const noexcept

--- a/src/realm/object-store/c_api/error.cpp
+++ b/src/realm/object-store/c_api/error.cpp
@@ -1,3 +1,4 @@
+#include <realm/object-store/c_api/error.hpp>
 #include <realm/object-store/c_api/util.hpp>
 #include <realm/parser/query_parser.hpp>
 
@@ -11,220 +12,265 @@
 
 namespace realm::c_api {
 
-#if !defined(RLM_NO_THREAD_LOCAL)
-
-thread_local std::exception_ptr g_last_exception;
-
-void set_last_exception(std::exception_ptr eptr)
+ErrorStorage::ErrorStorage(std::exception_ptr ptr) noexcept
+    : m_err(none)
+    , m_message_buf()
 {
-    g_last_exception = eptr;
+    assign(std::move(ptr));
 }
 
-static std::exception_ptr* get_last_exception()
+ErrorStorage::ErrorStorage(const ErrorStorage& other)
+    : m_err(other.m_err)
+    , m_message_buf(other.m_message_buf)
 {
-    return &g_last_exception;
-}
-
-#else // RLM_NO_THREAD_LOCAL
-
-static pthread_key_t g_last_exception_key;
-static pthread_once_t g_last_exception_key_init_once = PTHREAD_ONCE_INIT;
-
-static void destroy_last_exception(void* ptr)
-{
-    auto p = static_cast<std::exception_ptr*>(ptr);
-    delete p;
-}
-
-static void init_last_exception_key()
-{
-    pthread_key_create(&g_last_exception_key, destroy_last_exception);
-}
-
-void set_last_exception(std::exception_ptr eptr)
-{
-    pthread_once(&g_last_exception_key_init_once, init_last_exception_key);
-    void* ptr = pthread_getspecific(g_last_exception_key);
-    std::exception_ptr* p;
-    if (!ptr) {
-        p = new std::exception_ptr;
-        pthread_setspecific(g_last_exception_key, p);
+    if (m_err) {
+        m_err->message = m_message_buf.c_str();
     }
-    else {
-        p = static_cast<std::exception_ptr*>(ptr);
+}
+
+ErrorStorage& ErrorStorage::operator=(const ErrorStorage& other)
+{
+    m_err = other.m_err;
+    m_message_buf = other.m_message_buf;
+    if (m_err) {
+        m_err->message = m_message_buf.c_str();
     }
-    *p = eptr;
+    return *this;
 }
 
-static std::exception_ptr* get_last_exception()
+ErrorStorage::ErrorStorage(ErrorStorage&& other)
+    : m_err(std::move(other.m_err))
+    , m_message_buf(std::move(other.m_message_buf))
 {
-    pthread_once(&g_last_exception_key_init_once, init_last_exception_key);
-    void* ptr = pthread_getspecific(g_last_exception_key);
-    return static_cast<std::exception_ptr*>(ptr);
+    if (m_err) {
+        m_err->message = m_message_buf.c_str();
+    }
+    other.m_err.reset();
 }
 
-#endif // RLM_NO_THREAD_LOCAL
-
-static bool convert_error(std::exception_ptr* ptr, realm_error_t* err)
+ErrorStorage& ErrorStorage::operator=(ErrorStorage&& other)
 {
-    if (ptr && *ptr) {
-        err->kind.code = 0;
+    m_err = std::move(other.m_err);
+    m_message_buf = std::move(other.m_message_buf);
+    if (m_err) {
+        m_err->message = m_message_buf.c_str();
+    }
+    other.m_err.reset();
+    return *this;
+}
 
-        auto populate_error = [&](const std::exception& ex, realm_errno_e error_number) {
-            if (err) {
-                err->error = error_number;
-                err->message = ex.what();
-            }
-            *ptr = std::current_exception();
-        };
-
-        try {
-            std::rethrow_exception(*ptr);
-        }
-
-        // C API exceptions:
-        catch (const NotClonableException& ex) {
-            populate_error(ex, RLM_ERR_NOT_CLONABLE);
-        }
-        catch (const InvalidatedObjectException& ex) {
-            populate_error(ex, RLM_ERR_INVALIDATED_OBJECT);
-        }
-        catch (const UnexpectedPrimaryKeyException& ex) {
-            populate_error(ex, RLM_ERR_UNEXPECTED_PRIMARY_KEY);
-        }
-        catch (const DuplicatePrimaryKeyException& ex) {
-            populate_error(ex, RLM_ERR_DUPLICATE_PRIMARY_KEY_VALUE);
-        }
-        catch (const InvalidPropertyKeyException& ex) {
-            populate_error(ex, RLM_ERR_INVALID_PROPERTY);
-        }
-        catch (const CallbackFailed& ex) {
-            populate_error(ex, RLM_ERR_CALLBACK);
-        }
-
-        // Core exceptions:
-        catch (const NoSuchTable& ex) {
-            populate_error(ex, RLM_ERR_NO_SUCH_TABLE);
-        }
-        catch (const KeyNotFound& ex) {
-            populate_error(ex, RLM_ERR_NO_SUCH_OBJECT);
-        }
-        catch (const LogicError& ex) {
-            using Kind = LogicError::ErrorKind;
-            switch (ex.kind()) {
-                case Kind::column_does_not_exist:
-                case Kind::column_index_out_of_range:
-                    populate_error(ex, RLM_ERR_INVALID_PROPERTY);
-                    break;
-                case Kind::wrong_transact_state:
-                    populate_error(ex, RLM_ERR_NOT_IN_A_TRANSACTION);
-                    break;
-                default:
-                    populate_error(ex, RLM_ERR_LOGIC);
-            }
-        }
-
-        // Object Store exceptions:
-        catch (const InvalidTransactionException& ex) {
-            populate_error(ex, RLM_ERR_NOT_IN_A_TRANSACTION);
-        }
-        catch (const IncorrectThreadException& ex) {
-            populate_error(ex, RLM_ERR_WRONG_THREAD);
-        }
-        catch (const List::InvalidatedException& ex) {
-            populate_error(ex, RLM_ERR_INVALIDATED_OBJECT);
-        }
-        catch (const MissingPrimaryKeyException& ex) {
-            populate_error(ex, RLM_ERR_MISSING_PRIMARY_KEY);
-        }
-        catch (const WrongPrimaryKeyTypeException& ex) {
-            populate_error(ex, RLM_ERR_WRONG_PRIMARY_KEY_TYPE);
-        }
-        catch (const PropertyTypeMismatch& ex) {
-            populate_error(ex, RLM_ERR_PROPERTY_TYPE_MISMATCH);
-        }
-        catch (const NotNullableException& ex) {
-            populate_error(ex, RLM_ERR_PROPERTY_NOT_NULLABLE);
-        }
-        catch (const List::OutOfBoundsIndexException& ex) {
-            populate_error(ex, RLM_ERR_INDEX_OUT_OF_BOUNDS);
-        }
-        catch (const query_parser::InvalidQueryError& ex) {
-            populate_error(ex, RLM_ERR_INVALID_QUERY);
-        }
-        catch (const query_parser::SyntaxError& ex) {
-            populate_error(ex, RLM_ERR_INVALID_QUERY_STRING);
-        }
-
-        // Generic exceptions:
-        catch (const std::invalid_argument& ex) {
-            populate_error(ex, RLM_ERR_INVALID_ARGUMENT);
-        }
-        catch (const std::out_of_range& ex) {
-            populate_error(ex, RLM_ERR_INDEX_OUT_OF_BOUNDS);
-        }
-        catch (const std::logic_error& ex) {
-            populate_error(ex, RLM_ERR_LOGIC);
-        }
-        catch (const std::bad_alloc& ex) {
-            populate_error(ex, RLM_ERR_OUT_OF_MEMORY);
-        }
-        catch (const std::exception& ex) {
-            populate_error(ex, RLM_ERR_OTHER_EXCEPTION);
-        }
-        // FIXME: Handle more exception types.
-        catch (...) {
-            err->error = RLM_ERR_UNKNOWN;
-            err->message = "Unknown error";
-            *ptr = std::current_exception();
-        }
+bool ErrorStorage::operator==(const ErrorStorage& other) const noexcept
+{
+    if ((m_err && !other.m_err) || (!m_err && other.m_err)) {
+        return false;
+    }
+    else if (!m_err && !other.m_err) {
         return true;
     }
-    return false;
+    return m_err->error == other.m_err->error && m_message_buf == other.m_message_buf;
+}
+
+void ErrorStorage::assign(std::exception_ptr eptr) noexcept
+{
+    if (!eptr) {
+        clear();
+        return;
+    }
+    m_err->kind.code = 0;
+
+    auto populate_error = [&](const std::exception& ex, realm_errno_e error_number) {
+        m_err.emplace();
+        m_err->error = error_number;
+        try {
+            m_message_buf = ex.what();
+            m_err->message = m_message_buf.c_str();
+        }
+        catch (const std::bad_alloc&) {
+            m_message_buf = std::string{};
+            m_err->message = "Bad alloc while building error";
+        }
+    };
+
+    try {
+        std::rethrow_exception(eptr);
+    }
+
+    // C API exceptions:
+    catch (const NotClonableException& ex) {
+        populate_error(ex, RLM_ERR_NOT_CLONABLE);
+    }
+    catch (const InvalidatedObjectException& ex) {
+        populate_error(ex, RLM_ERR_INVALIDATED_OBJECT);
+    }
+    catch (const UnexpectedPrimaryKeyException& ex) {
+        populate_error(ex, RLM_ERR_UNEXPECTED_PRIMARY_KEY);
+    }
+    catch (const DuplicatePrimaryKeyException& ex) {
+        populate_error(ex, RLM_ERR_DUPLICATE_PRIMARY_KEY_VALUE);
+    }
+    catch (const InvalidPropertyKeyException& ex) {
+        populate_error(ex, RLM_ERR_INVALID_PROPERTY);
+    }
+    catch (const CallbackFailed& ex) {
+        populate_error(ex, RLM_ERR_CALLBACK);
+    }
+
+    // Core exceptions:
+    catch (const NoSuchTable& ex) {
+        populate_error(ex, RLM_ERR_NO_SUCH_TABLE);
+    }
+    catch (const KeyNotFound& ex) {
+        populate_error(ex, RLM_ERR_NO_SUCH_OBJECT);
+    }
+    catch (const LogicError& ex) {
+        using Kind = LogicError::ErrorKind;
+        switch (ex.kind()) {
+            case Kind::column_does_not_exist:
+            case Kind::column_index_out_of_range:
+                populate_error(ex, RLM_ERR_INVALID_PROPERTY);
+                break;
+            case Kind::wrong_transact_state:
+                populate_error(ex, RLM_ERR_NOT_IN_A_TRANSACTION);
+                break;
+            default:
+                populate_error(ex, RLM_ERR_LOGIC);
+        }
+    }
+
+    // Object Store exceptions:
+    catch (const InvalidTransactionException& ex) {
+        populate_error(ex, RLM_ERR_NOT_IN_A_TRANSACTION);
+    }
+    catch (const IncorrectThreadException& ex) {
+        populate_error(ex, RLM_ERR_WRONG_THREAD);
+    }
+    catch (const List::InvalidatedException& ex) {
+        populate_error(ex, RLM_ERR_INVALIDATED_OBJECT);
+    }
+    catch (const MissingPrimaryKeyException& ex) {
+        populate_error(ex, RLM_ERR_MISSING_PRIMARY_KEY);
+    }
+    catch (const WrongPrimaryKeyTypeException& ex) {
+        populate_error(ex, RLM_ERR_WRONG_PRIMARY_KEY_TYPE);
+    }
+    catch (const PropertyTypeMismatch& ex) {
+        populate_error(ex, RLM_ERR_PROPERTY_TYPE_MISMATCH);
+    }
+    catch (const NotNullableException& ex) {
+        populate_error(ex, RLM_ERR_PROPERTY_NOT_NULLABLE);
+    }
+    catch (const List::OutOfBoundsIndexException& ex) {
+        populate_error(ex, RLM_ERR_INDEX_OUT_OF_BOUNDS);
+    }
+    catch (const query_parser::InvalidQueryError& ex) {
+        populate_error(ex, RLM_ERR_INVALID_QUERY);
+    }
+    catch (const query_parser::SyntaxError& ex) {
+        populate_error(ex, RLM_ERR_INVALID_QUERY_STRING);
+    }
+
+    // Generic exceptions:
+    catch (const std::invalid_argument& ex) {
+        populate_error(ex, RLM_ERR_INVALID_ARGUMENT);
+    }
+    catch (const std::out_of_range& ex) {
+        populate_error(ex, RLM_ERR_INDEX_OUT_OF_BOUNDS);
+    }
+    catch (const std::logic_error& ex) {
+        populate_error(ex, RLM_ERR_LOGIC);
+    }
+    catch (const std::bad_alloc& ex) {
+        populate_error(ex, RLM_ERR_OUT_OF_MEMORY);
+    }
+    catch (const std::exception& ex) {
+        populate_error(ex, RLM_ERR_OTHER_EXCEPTION);
+    }
+    // FIXME: Handle more exception types.
+    catch (...) {
+        m_err.emplace();
+        m_err->error = RLM_ERR_UNKNOWN;
+        m_message_buf = "Unknown error";
+        m_err->message = m_message_buf.c_str();
+    }
+}
+
+bool ErrorStorage::has_error() const noexcept
+{
+    return static_cast<bool>(m_err);
+}
+
+bool ErrorStorage::get_as_realm_error_t(realm_error_t* out) const noexcept
+{
+    if (!m_err) {
+        return false;
+    }
+
+    *out = *m_err;
+    return true;
+}
+
+bool ErrorStorage::clear() noexcept
+{
+    auto ret = static_cast<bool>(m_err);
+    m_err.reset();
+    return ret;
+}
+
+ErrorStorage* ErrorStorage::get_thread_local()
+{
+#if !defined(RLM_NO_THREAD_LOCAL)
+    static thread_local ErrorStorage g_error_storage;
+    return &g_error_storage;
+#else
+    static pthread_key_t g_last_exception_key;
+    static pthread_once_t g_last_exception_key_init_once = PTHREAD_ONCE_INIT;
+
+    pthread_once(&g_last_exception_key_init_once, [] {
+        pthread_key_create(&g_last_exception_key, [](void* ptr) {
+            delete reinterpret_cast<ErrorStorage*>(ptr);
+        });
+    });
+
+    if (auto ptr = reinterpret_cast<ErrorStorage*>(pthread_getspecific(g_last_exception_key)); ptr != nullptr) {
+        return ptr;
+    }
+
+    auto ptr = new ErrorStorage{};
+    pthread_setspecific(g_last_exception_key, ptr);
+    return ptr;
+#endif
+}
+
+void set_last_exception(std::exception_ptr eptr)
+{
+    ErrorStorage::get_thread_local()->assign(std::move(eptr));
 }
 
 RLM_API bool realm_get_last_error(realm_error_t* err)
 {
-    std::exception_ptr* ptr = get_last_exception();
-    if (ptr) {
-        return convert_error(ptr, err);
-    }
-    return false;
+    return ErrorStorage::get_thread_local()->get_as_realm_error_t(err);
 }
 
 RLM_API bool realm_clear_last_error()
 {
-    std::exception_ptr* ptr = get_last_exception();
-    if (ptr && *ptr) {
-        *ptr = std::exception_ptr{};
-        return true;
-    }
-    return false;
+    return ErrorStorage::get_thread_local()->clear();
 }
 
 RLM_API realm_async_error_t* realm_get_last_error_as_async_error(void)
 {
-    auto p = get_last_exception();
-    if (p && *p) {
-        return new realm_async_error_t{*p};
+    if (!ErrorStorage::get_thread_local()->has_error()) {
+        return nullptr;
     }
-    return nullptr;
+
+    return new realm_async_error_t{*ErrorStorage::get_thread_local()};
 }
 
 RLM_API void realm_get_async_error(const realm_async_error_t* async_err, realm_error_t* out_err)
 {
-    convert_error(&const_cast<realm_async_error_t*>(async_err)->ep, out_err);
+    async_err->error_storage.get_as_realm_error_t(out_err);
 }
 
 } // namespace realm::c_api
-
-RLM_EXPORT void realm_rethrow_last_error()
-{
-    std::exception_ptr* ptr = realm::c_api::get_last_exception();
-    if (ptr && *ptr) {
-        std::rethrow_exception(*ptr);
-    }
-}
 
 RLM_EXPORT bool realm_wrap_exceptions(void (*func)()) noexcept
 {

--- a/src/realm/object-store/c_api/error.cpp
+++ b/src/realm/object-store/c_api/error.cpp
@@ -86,8 +86,8 @@ void ErrorStorage::assign(std::exception_ptr eptr) noexcept
             m_err->message = m_message_buf.c_str();
         }
         catch (const std::bad_alloc&) {
-            // If we are unable to build the new error because we ran out of memory we should propagate the OOM condition
-            // and leaf the m_message_buf as it was.
+            // If we are unable to build the new error because we ran out of memory we should propagate the OOM
+            // condition and leaf the m_message_buf as it was.
             m_err->error = RLM_ERR_OUT_OF_MEMORY;
             m_err->message = "Out of memory while creating realm_error_t";
         }

--- a/src/realm/object-store/c_api/error.hpp
+++ b/src/realm/object-store/c_api/error.hpp
@@ -1,0 +1,54 @@
+/*************************************************************************
+ *
+ * Copyright 2021 Realm Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ **************************************************************************/
+
+#pragma once
+
+#include <string>
+
+#include <realm.h>
+#include <realm/util/optional.hpp>
+
+namespace realm::c_api {
+
+void set_last_exception(std::exception_ptr eptr);
+
+class ErrorStorage {
+public:
+    static ErrorStorage* get_thread_local();
+
+    ErrorStorage() = default;
+    explicit ErrorStorage(std::exception_ptr eptr) noexcept;
+    ErrorStorage(const ErrorStorage& other);
+    ErrorStorage& operator=(const ErrorStorage& other);
+
+    ErrorStorage(ErrorStorage&& other);
+    ErrorStorage& operator=(ErrorStorage&& other);
+
+    bool operator==(const ErrorStorage& other) const noexcept;
+
+    void assign(std::exception_ptr eptr) noexcept;
+    bool has_error() const noexcept;
+    bool get_as_realm_error_t(realm_error_t* out) const noexcept;
+    bool clear() noexcept;
+
+private:
+    util::Optional<realm_error_t> m_err;
+    std::string m_message_buf;
+};
+
+} // namespace realm::c_api

--- a/src/realm/object-store/c_api/util.hpp
+++ b/src/realm/object-store/c_api/util.hpp
@@ -1,12 +1,11 @@
 #ifndef REALM_OBJECT_STORE_C_API_UTIL_HPP
 #define REALM_OBJECT_STORE_C_API_UTIL_HPP
 
+#include <realm/object-store/c_api/error.hpp>
 #include <realm/object-store/c_api/types.hpp>
 #include <realm/util/functional.hpp>
 
 namespace realm::c_api {
-
-void set_last_exception(std::exception_ptr eptr);
 
 template <class F>
 inline auto wrap_err(F&& f) noexcept -> decltype(f())

--- a/test/object-store/c_api/c_api.cpp
+++ b/test/object-store/c_api/c_api.cpp
@@ -16,7 +16,10 @@ template <class T>
 T checked(T x)
 {
     if (!x) {
-        realm_rethrow_last_error();
+        realm_error_t err_info;
+        if (realm_get_last_error(&err_info)) {
+            FAIL(err_info.message);
+        }
     }
     return x;
 }
@@ -269,22 +272,6 @@ TEST_CASE("C API (non-database)") {
         CHECK(realm_get_last_error(&err));
         CHECK(err.error == RLM_ERR_OTHER_EXCEPTION);
         CHECK(std::string{err.message} == "Synthetic error");
-        realm_clear_last_error();
-    }
-
-    SECTION("realm_rethrow_last_error() lossless") {
-        struct SyntheticException {
-        };
-
-        auto synthetic = []() {
-            throw SyntheticException{};
-        };
-
-        CHECK(!realm_wrap_exceptions(synthetic));
-        realm_error_t err;
-        CHECK(realm_get_last_error(&err));
-        CHECK(err.error == RLM_ERR_UNKNOWN);
-        CHECK_THROWS_AS(realm_rethrow_last_error(), SyntheticException);
         realm_clear_last_error();
     }
 


### PR DESCRIPTION
## What, How & Why?
This changes the C api so that it doesn't use std::exception_ptr to store error information internally and just allocates a string to store the result of `what()` instead. It also changes the async_error type to capture the new `ErrorStorage` type. I've removed some helper functions that let you treat the C api realm error types a C++ exceptions since the philosophical change in this PR is that the error types we expose from the C API are not C++ exceptions, they're realm errors.

## ☑️ ToDos
* [x] 📝 Changelog update
* [x] 🚦 Tests (or not relevant)
