### PR TITLE
Fix the exception message for refreshing an immutable Realm

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 * The client reset callbacks now pass out SharedRealm objects instead of TransactionRefs. ([#5048](https://github.com/realm/realm-core/issues/5048), since v11.5.0) 
 * A client reset in DiscardLocal mode would revert to Manual mode on the next restart of the session. ([#5050](https://github.com/realm/realm-core/issues/5050), since v11.5.0)
 * `@sum` and `@avg` queries on Dictionaries of floats or doubles used too much precision for intermediates, resulting in incorrect rounding (since v10.2.0).
+* Change the exception message for calling refresh on an immutable Realm from "Continuous transaction through DB object without history information." to "Can't refresh a read-only Realm." ([#5061](https://github.com/realm/realm-core/issues/5061), old exception message was since 10.7.2 via https://github.com/realm/realm-core/pull/4688).
  
 ### Breaking changes
 * None.

--- a/src/realm/object-store/shared_realm.cpp
+++ b/src/realm/object-store/shared_realm.cpp
@@ -822,6 +822,10 @@ bool Realm::do_refresh()
         return false;
     }
 
+    if (m_config.immutable()) {
+        throw std::logic_error("Can't refresh a read-only Realm.");
+    }
+
     // can't be any new changes if we're in a write transaction
     if (is_in_transaction()) {
         return false;

--- a/test/object-store/realm.cpp
+++ b/test/object-store/realm.cpp
@@ -350,6 +350,10 @@ TEST_CASE("SharedRealm: get_shared_realm()") {
         REQUIRE(it->persisted_properties.size() == 1);
         REQUIRE(it->persisted_properties[0].name == "value");
         REQUIRE(it->persisted_properties[0].column_key == table->get_column_key("value"));
+
+        SECTION("refreshing an immutable Realm throws") {
+            REQUIRE_THROWS_WITH(realm->refresh(), "Can't refresh a read-only Realm.");
+        }
     }
 
     SECTION("should support using different table subsets on different threads") {


### PR DESCRIPTION
Fixes https://github.com/realm/realm-core/issues/5061

It may be debatable if calling refresh on an immutable Realm should throw or silently do nothing. We could easily make it a no-op, but it seems that the historical behaviour has been to throw an exception so I'll bring that back to not break other SDKs who may be relying on this.

Tracking down the history led to https://github.com/realm/realm-core/pull/4688 being where the first refresh was allowed and did nothing. This was because the first refresh of an immutable Realm had no associated transaction and so populated one there. The second call to refresh, now having a transaction actually tried to advance the version and the DB object throws because it has been configured without history.

## ☑️ ToDos
* [x] 📝 Changelog update
* [x] 🚦 Tests (or not relevant)
