### PR TITLE
swap the client reset callback signatures

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 * A client reset in DiscardLocal mode would revert to Manual mode on the next restart of the session. ([#5050](https://github.com/realm/realm-core/issues/5050), since v11.5.0)
 * `@sum` and `@avg` queries on Dictionaries of floats or doubles used too much precision for intermediates, resulting in incorrect rounding (since v10.2.0).
 * Change the exception message for calling refresh on an immutable Realm from "Continuous transaction through DB object without history information." to "Can't refresh a read-only Realm." ([#5061](https://github.com/realm/realm-core/issues/5061), old exception message was since 10.7.2 via https://github.com/realm/realm-core/pull/4688).
+* The client reset callbacks have changed so that the pre and post Realm state are passed to the 'after' callback and thee 'before' callback only has the local state. ([#5066](https://github.com/realm/realm-core/issues/5066), since 11.5.0).
  
 ### Breaking changes
 * None.

--- a/src/realm/sync/client_base.hpp
+++ b/src/realm/sync/client_base.hpp
@@ -60,8 +60,8 @@ class SessionWrapper;
 struct ClientReset {
     bool discard_local = false;
     DBRef fresh_copy;
-    util::UniqueFunction<void(std::string local, std::string remote)> notify_before_client_reset;
-    util::UniqueFunction<void(std::string local)> notify_after_client_reset;
+    util::UniqueFunction<void(std::string path)> notify_before_client_reset;
+    util::UniqueFunction<void(std::string path, VersionID before_version)> notify_after_client_reset;
 };
 
 /// \brief Protocol errors discovered by the client.

--- a/src/realm/sync/config.hpp
+++ b/src/realm/sync/config.hpp
@@ -154,8 +154,8 @@ struct SyncConfig {
     // a client reset in ClientResyncMode::Manual mode
     util::Optional<std::string> recovery_directory;
     ClientResyncMode client_resync_mode = ClientResyncMode::Manual;
-    std::function<void(std::shared_ptr<Realm> local, std::shared_ptr<Realm> remote)> notify_before_client_reset;
-    std::function<void(std::shared_ptr<Realm> local)> notify_after_client_reset;
+    std::function<void(std::shared_ptr<Realm> before_frozen)> notify_before_client_reset;
+    std::function<void(std::shared_ptr<Realm> before_frozen, std::shared_ptr<Realm> after)> notify_after_client_reset;
     std::function<void(const std::string&, std::function<void(DBRef, util::Optional<std::string>)>)>
         get_fresh_realm_for_path;
 

--- a/src/realm/sync/noinst/client_reset_operation.hpp
+++ b/src/realm/sync/noinst/client_reset_operation.hpp
@@ -30,8 +30,8 @@ namespace realm::_impl {
 // state Realm download.
 class ClientResetOperation {
 public:
-    using CallbackBeforeType = util::UniqueFunction<void(std::string, std::string)>;
-    using CallbackAfterType = util::UniqueFunction<void(std::string)>;
+    using CallbackBeforeType = util::UniqueFunction<void(std::string)>;
+    using CallbackAfterType = util::UniqueFunction<void(std::string, VersionID)>;
 
     ClientResetOperation(util::Logger& logger, DB& db, DBRef db_fresh, bool discard_local,
                          CallbackBeforeType notify_before, CallbackAfterType notify_after);

--- a/src/realm/version_id.hpp
+++ b/src/realm/version_id.hpp
@@ -25,6 +25,7 @@
 
 #include <cstdint>
 #include <limits>
+#include <ostream>
 
 namespace realm {
 
@@ -67,6 +68,12 @@ struct VersionID {
         return version >= other.version;
     }
 };
+
+inline std::ostream& operator<<(std::ostream& os, VersionID id)
+{
+    os << "VersionID(" << id.version << ", " << id.index << ")";
+    return os;
+}
 
 } // namespace realm
 

--- a/test/object-store/sync/client_reset.cpp
+++ b/test/object-store/sync/client_reset.cpp
@@ -211,26 +211,25 @@ TEST_CASE("sync: client reset", "[client reset]") {
         const std::string fresh_path = realm::_impl::ClientResetOperation::get_fresh_path_for(local_config.path);
         size_t before_callback_invoctions = 0;
         size_t after_callback_invocations = 0;
-        local_config.sync_config->notify_before_client_reset = [&](SharedRealm local, SharedRealm remote) {
+        local_config.sync_config->notify_before_client_reset = [&](SharedRealm before) {
             ++before_callback_invoctions;
-            REQUIRE(local);
-            REQUIRE(local->is_frozen());
-            REQUIRE(local->read_group().get_table("class_object"));
-            REQUIRE(local->config().path == local_config.path);
-
-            REQUIRE(remote);
-            REQUIRE(remote->is_frozen());
-            REQUIRE(remote->read_group().get_table("class_object"));
-            REQUIRE(remote->config().path == fresh_path);
-
+            REQUIRE(before);
+            REQUIRE(before->is_frozen());
+            REQUIRE(before->read_group().get_table("class_object"));
+            REQUIRE(before->config().path == local_config.path);
             REQUIRE(util::File::exists(local_config.path));
-            REQUIRE(util::File::exists(fresh_path));
         };
-        local_config.sync_config->notify_after_client_reset = [&](SharedRealm local) {
+        local_config.sync_config->notify_after_client_reset = [&](SharedRealm before, SharedRealm after) {
             ++after_callback_invocations;
-            REQUIRE(local);
-            REQUIRE(local->read_group().get_table("class_object"));
-            REQUIRE(local->config().path == local_config.path);
+            REQUIRE(before);
+            REQUIRE(before->is_frozen());
+            REQUIRE(before->read_group().get_table("class_object"));
+            REQUIRE(before->config().path == local_config.path);
+            REQUIRE(after);
+            REQUIRE(!after->is_frozen());
+            REQUIRE(after->read_group().get_table("class_object"));
+            REQUIRE(after->config().path == local_config.path);
+            REQUIRE(after->current_transaction_version() > before->current_transaction_version());
         };
 
         Results results;


### PR DESCRIPTION
Requested via SDK feedback while integrating. (https://github.com/realm/realm-java/pull/7585#discussion_r755034989)

There is not much you could do with the after state in the _before_ callback so it makes more sense to move it to the _after_ callback so that if developers want to do some kind of manual diff themselves they have the opportunity to do it. 

## ☑️ ToDos
* [x] 📝 Changelog update
* [x] 🚦 Tests (or not relevant)
