### PR TITLE
Fix an assertion if the server adds an embedded table during client reset

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 * <How do the end-user experience this issue? what was the impact?> ([#????](https://github.com/realm/realm-core/issues/????), since v?.?.?)
 * The client reset callbacks now pass out SharedRealm objects instead of TransactionRefs. ([#5048](https://github.com/realm/realm-core/issues/5048), since v11.5.0) 
 * A client reset in DiscardLocal mode would revert to Manual mode on the next restart of the session. ([#5050](https://github.com/realm/realm-core/issues/5050), since v11.5.0)
+* A client reset in DiscardLocal mode would assert if the server added embedded object tables. ([#5069](https://github.com/realm/realm-core/issues/5069), since v11.5.0)
 * `@sum` and `@avg` queries on Dictionaries of floats or doubles used too much precision for intermediates, resulting in incorrect rounding (since v10.2.0).
 * Change the exception message for calling refresh on an immutable Realm from "Continuous transaction through DB object without history information." to "Can't refresh a read-only Realm." ([#5061](https://github.com/realm/realm-core/issues/5061), old exception message was since 10.7.2 via https://github.com/realm/realm-core/pull/4688).
  

--- a/src/realm/sync/noinst/client_reset.cpp
+++ b/src/realm/sync/noinst/client_reset.cpp
@@ -571,11 +571,15 @@ void client_reset::transfer_group(const Transaction& group_src, Transaction& gro
     if (!tables_to_remove.empty()) {
         std::string names_list;
         for (const std::string& table_name : tables_to_remove) {
-            names_list += table_name;
+            names_list += Group::table_name_to_class_name(table_name);
             names_list += ", ";
         }
+        if (names_list.size() > 2) {
+            // remove the final ", "
+            names_list = names_list.substr(0, names_list.size() - 2);
+        }
         throw ClientResetFailed(
-            util::format("Client reset cannot recover when tables have been removed: {%1}", names_list));
+            util::format("Client reset cannot recover when classes have been removed: {%1}", names_list));
     }
 
     // Create new tables in dst if needed.
@@ -588,11 +592,17 @@ void client_reset::transfer_group(const Transaction& group_src, Transaction& gro
         TableRef table_dst = group_dst.get_table(table_name);
         if (!table_dst) {
             // Create the table.
-            REALM_ASSERT(pk_col_src); // a sync table will have a pk
-            auto pk_col_src = table_src->get_primary_key_column();
-            DataType pk_type = DataType(pk_col_src.get_type());
-            StringData pk_col_name = table_src->get_column_name(pk_col_src);
-            group_dst.add_table_with_primary_key(table_name, pk_type, pk_col_name, pk_col_src.is_nullable());
+            if (table_src->is_embedded()) {
+                REALM_ASSERT(!pk_col_src);
+                group_dst.add_embedded_table(table_name);
+            }
+            else {
+                REALM_ASSERT(pk_col_src); // a sync table will have a pk
+                auto pk_col_src = table_src->get_primary_key_column();
+                DataType pk_type = DataType(pk_col_src.get_type());
+                StringData pk_col_name = table_src->get_column_name(pk_col_src);
+                group_dst.add_table_with_primary_key(table_name, pk_type, pk_col_name, pk_col_src.is_nullable());
+            }
         }
     }
 

--- a/test/object-store/sync/client_reset.cpp
+++ b/test/object-store/sync/client_reset.cpp
@@ -977,6 +977,7 @@ TEMPLATE_TEST_CASE("client reset types", "[client reset][discard local]", cf::Mi
     };
 
     SyncTestFile config2(init_sync_manager.app(), "default");
+    config2.schema = config.schema;
 
     Results results;
     Object object;
@@ -1469,6 +1470,7 @@ TEMPLATE_TEST_CASE("client reset collections of links", "[client reset][discard 
     config.sync_config->client_resync_mode = ClientResyncMode::DiscardLocal;
 
     SyncTestFile config2(init_sync_manager.app(), "default");
+    config2.schema = schema;
 
     // The following can be used to perform the client reset proper, but these tests
     // are only intended to check the transfer_group logic for different types,
@@ -1671,7 +1673,7 @@ TEMPLATE_TEST_CASE("client reset collections of links", "[client reset][discard 
     }
 }
 
-TEST_CASE("client reset with embedded object", "[client reset][embedded objects]") {
+TEST_CASE("client reset with embedded object", "[client reset][discard local][embedded objects]") {
     if (!util::EventLoop::has_implementation())
         return;
 
@@ -1680,12 +1682,15 @@ TEST_CASE("client reset with embedded object", "[client reset][embedded objects]
     config.cache = false;
     config.automatic_change_notifications = false;
     config.sync_config->client_resync_mode = ClientResyncMode::DiscardLocal;
+
+    ObjectSchema shared_class = {"object",
+                                 {
+                                     {"_id", PropertyType::Int, Property::IsPrimary{true}},
+                                     {"value", PropertyType::Int},
+                                 }};
+
     config.schema = Schema{
-        {"object",
-         {
-             {"_id", PropertyType::Int, Property::IsPrimary{true}},
-             {"value", PropertyType::Int},
-         }},
+        shared_class,
         {"TopLevel",
          {
              {"_id", PropertyType::ObjectId, Property::IsPrimary{true}},
@@ -1728,6 +1733,7 @@ TEST_CASE("client reset with embedded object", "[client reset][embedded objects]
     };
 
     SyncTestFile config2(init_sync_manager.app(), "default");
+    config2.schema = config.schema;
 
     std::unique_ptr<reset_utils::TestClientReset> test_reset =
         reset_utils::make_fake_local_client_reset(config, config2);
@@ -1966,6 +1972,42 @@ TEST_CASE("client reset with embedded object", "[client reset][embedded objects]
         TopLevelContent remote = local;
         local.link_value->second_level->pk_of_linked_object = Mixed{pk_val};
         reset_embedded_object(local, remote);
+    }
+    SECTION("server adds embedded object classes") {
+        SyncTestFile config2(init_sync_manager.app(), "default");
+        config2.schema = config.schema;
+        config.schema = Schema{shared_class};
+        test_reset = reset_utils::make_fake_local_client_reset(config, config2);
+        TopLevelContent remote_content;
+
+        test_reset
+            ->make_remote_changes([&](SharedRealm remote) {
+                TableRef table = get_table(*remote, "TopLevel");
+                auto obj = table->create_object_with_primary_key(pk_val);
+                REQUIRE(table->size() == 1);
+                set_content(obj, remote_content);
+            })
+            ->on_post_reset([&](SharedRealm local) {
+                TableRef table = get_table(*local, "TopLevel");
+                REQUIRE(table->size() == 1);
+                Obj obj = *table->begin();
+                check_content(obj, remote_content);
+            })
+            ->run();
+    }
+    SECTION("client adds embedded object classes") {
+        SyncTestFile config2(init_sync_manager.app(), "default");
+        config2.schema = Schema{shared_class};
+        test_reset = reset_utils::make_fake_local_client_reset(config, config2);
+        TopLevelContent local_content;
+        test_reset->make_local_changes([&](SharedRealm local) {
+            TableRef table = get_table(*local, "TopLevel");
+            auto obj = table->create_object_with_primary_key(pk_val);
+            REQUIRE(table->size() == 1);
+            set_content(obj, local_content);
+        });
+        REQUIRE_THROWS_WITH(test_reset->run(), "Client reset cannot recover when classes have been removed: "
+                                               "{EmbeddedObject, EmbeddedObject2, TopLevel}");
     }
 }
 

--- a/test/object-store/sync/sync_test_utils.cpp
+++ b/test/object-store/sync/sync_test_utils.cpp
@@ -285,7 +285,6 @@ struct FakeLocalClientReset : public TestClientReset {
         }
 
         {
-            m_remote_config.schema = m_local_config.schema;
             auto realm2 = Realm::get_shared_realm(m_remote_config);
             realm2->begin_transaction();
             if (m_on_setup) {


### PR DESCRIPTION
Reported by @clementetb  during SDK integration tests.

## ☑️ ToDos
* [x] 📝 Changelog update
* [x] 🚦 Tests (or not relevant)