### PR TITLE
Rename SchemaMode::ReadOnlyAlternative to ReadOnly

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,7 @@
 * SubscriptionSet::erase now returns the correct itererator for the "next" subscription ([#5053](https://github.com/realm/realm-core/pull/5053))
 * SubscriptionSet::insert_or_assign now returns an iterator pointing to the correct subscription ([#5049](https://github.com/realm/realm-core/pull/5049))
 * `SimulatedFailure` mmap handling was not thread-safe.
+* Rename SchemaMode::ReadOnlyAlternative to ReadOnly. ([#5070](https://github.com/realm/realm-core/issues/5070))
 
 ----------------------------------------------
 

--- a/src/realm.h
+++ b/src/realm.h
@@ -76,7 +76,7 @@ typedef bool (*realm_should_compact_on_launch_func_t)(void* userdata, uint64_t t
 typedef enum realm_schema_mode {
     RLM_SCHEMA_MODE_AUTOMATIC,
     RLM_SCHEMA_MODE_IMMUTABLE,
-    RLM_SCHEMA_MODE_READ_ONLY_ALTERNATIVE,
+    RLM_SCHEMA_MODE_READ_ONLY,
     RLM_SCHEMA_MODE_RESET_FILE,
     RLM_SCHEMA_MODE_ADDITIVE_DISCOVERED,
     RLM_SCHEMA_MODE_ADDITIVE_EXPLICIT,

--- a/src/realm/object-store/c_api/conversion.hpp
+++ b/src/realm/object-store/c_api/conversion.hpp
@@ -225,8 +225,8 @@ static inline SchemaMode from_capi(realm_schema_mode_e mode)
             return SchemaMode::Automatic;
         case RLM_SCHEMA_MODE_IMMUTABLE:
             return SchemaMode::Immutable;
-        case RLM_SCHEMA_MODE_READ_ONLY_ALTERNATIVE:
-            return SchemaMode::ReadOnlyAlternative;
+        case RLM_SCHEMA_MODE_READ_ONLY:
+            return SchemaMode::ReadOnly;
         case RLM_SCHEMA_MODE_RESET_FILE:
             return SchemaMode::ResetFile;
         case RLM_SCHEMA_MODE_ADDITIVE_DISCOVERED:
@@ -246,8 +246,8 @@ static inline realm_schema_mode_e to_capi(SchemaMode mode)
             return RLM_SCHEMA_MODE_AUTOMATIC;
         case SchemaMode::Immutable:
             return RLM_SCHEMA_MODE_IMMUTABLE;
-        case SchemaMode::ReadOnlyAlternative:
-            return RLM_SCHEMA_MODE_READ_ONLY_ALTERNATIVE;
+        case SchemaMode::ReadOnly:
+            return RLM_SCHEMA_MODE_READ_ONLY;
         case SchemaMode::ResetFile:
             return RLM_SCHEMA_MODE_RESET_FILE;
         case SchemaMode::AdditiveDiscovered:

--- a/src/realm/object-store/impl/realm_coordinator.cpp
+++ b/src/realm/object-store/impl/realm_coordinator.cpp
@@ -167,11 +167,11 @@ void RealmCoordinator::set_config(const Realm::Config& config)
         throw std::logic_error("Realms opened in Additive-only schema mode do not use a migration function");
     if (config.schema_mode == SchemaMode::Immutable && config.migration_function)
         throw std::logic_error("Realms opened in immutable mode do not use a migration function");
-    if (config.schema_mode == SchemaMode::ReadOnlyAlternative && config.migration_function)
+    if (config.schema_mode == SchemaMode::ReadOnly && config.migration_function)
         throw std::logic_error("Realms opened in read-only mode do not use a migration function");
     if (config.schema_mode == SchemaMode::Immutable && config.initialization_function)
         throw std::logic_error("Realms opened in immutable mode do not use an initialization function");
-    if (config.schema_mode == SchemaMode::ReadOnlyAlternative && config.initialization_function)
+    if (config.schema_mode == SchemaMode::ReadOnly && config.initialization_function)
         throw std::logic_error("Realms opened in read-only mode do not use an initialization function");
     if (config.schema && config.schema_version == ObjectStore::NotVersioned)
         throw std::logic_error("A schema version must be specified when the schema is specified");

--- a/src/realm/object-store/shared_realm.cpp
+++ b/src/realm/object-store/shared_realm.cpp
@@ -273,7 +273,7 @@ bool Realm::schema_change_needs_write_transaction(Schema& schema, std::vector<Sc
             if (version != m_schema_version)
                 throw InvalidSchemaVersionException(m_schema_version, version);
             REALM_FALLTHROUGH;
-        case SchemaMode::ReadOnlyAlternative:
+        case SchemaMode::ReadOnly:
             ObjectStore::verify_compatible_for_immutable_and_readonly(changes);
             return false;
 
@@ -342,7 +342,7 @@ void Realm::set_schema_subset(Schema schema)
             break;
 
         case SchemaMode::Immutable:
-        case SchemaMode::ReadOnlyAlternative:
+        case SchemaMode::ReadOnly:
             ObjectStore::verify_compatible_for_immutable_and_readonly(changes);
             break;
 
@@ -417,7 +417,7 @@ void Realm::update_schema(Schema schema, uint64_t version, MigrationFunction mig
     if (migration_function && !additive) {
         auto wrapper = [&] {
             auto config = m_config;
-            config.schema_mode = SchemaMode::ReadOnlyAlternative;
+            config.schema_mode = SchemaMode::ReadOnly;
             config.schema = util::none;
             // Don't go through the normal codepath for opening a Realm because
             // we're using a mismatched config
@@ -522,7 +522,7 @@ void Realm::notify_schema_changed()
 
 static void check_can_create_write_transaction(const Realm* realm)
 {
-    if (realm->config().immutable() || realm->config().read_only_alternative()) {
+    if (realm->config().immutable() || realm->config().read_only()) {
         throw InvalidTransactionException("Can't perform transactions on read-only Realms.");
     }
     if (realm->is_frozen()) {
@@ -709,7 +709,7 @@ bool Realm::compact()
     verify_thread();
     verify_open();
 
-    if (m_config.immutable() || m_config.read_only_alternative()) {
+    if (m_config.immutable() || m_config.read_only()) {
         throw InvalidTransactionException("Can't compact a read-only Realm");
     }
     if (is_in_transaction()) {

--- a/src/realm/object-store/shared_realm.hpp
+++ b/src/realm/object-store/shared_realm.hpp
@@ -85,7 +85,6 @@ enum class SchemaMode : uint8_t {
     // version in the file, and all tables present in the file must
     // exactly match the specified schema, except for indexes. Tables
     // are allowed to be missing from the file.
-    // WARNING: This is the original ReadOnly mode.
     Immutable,
 
     // Open the Realm in read-only mode, transactions are not allowed to
@@ -97,10 +96,7 @@ enum class SchemaMode : uint8_t {
     // mode, sync Realm can be opened with ReadOnly mode. Changes
     // can be made to the Realm file through another writable Realm instance.
     // Thus, notifications are also allowed in this mode.
-    // FIXME: Rename this to ReadOnly
-    // WARNING: This is not the original ReadOnly mode. The original ReadOnly
-    // has been renamed to Immutable.
-    ReadOnlyAlternative,
+    ReadOnly,
 
     // If the schema version matches and the only schema changes are new
     // tables and indexes being added or removed, apply the changes to
@@ -213,10 +209,9 @@ public:
         {
             return schema_mode == SchemaMode::Immutable;
         }
-        // FIXME: Rename this to read_only().
-        bool read_only_alternative() const
+        bool read_only() const
         {
-            return schema_mode == SchemaMode::ReadOnlyAlternative;
+            return schema_mode == SchemaMode::ReadOnly;
         }
 
         // The following are intended for internal/testing purposes and

--- a/test/object-store/c_api/c_api.cpp
+++ b/test/object-store/c_api/c_api.cpp
@@ -404,7 +404,7 @@ TEST_CASE("C API (non-database)") {
             };
             check_mode(RLM_SCHEMA_MODE_AUTOMATIC);
             check_mode(RLM_SCHEMA_MODE_IMMUTABLE);
-            check_mode(RLM_SCHEMA_MODE_READ_ONLY_ALTERNATIVE);
+            check_mode(RLM_SCHEMA_MODE_READ_ONLY);
             check_mode(RLM_SCHEMA_MODE_RESET_FILE);
             check_mode(RLM_SCHEMA_MODE_ADDITIVE_EXPLICIT);
             check_mode(RLM_SCHEMA_MODE_ADDITIVE_DISCOVERED);

--- a/test/object-store/migrations.cpp
+++ b/test/object-store/migrations.cpp
@@ -2033,7 +2033,7 @@ TEST_CASE("migration: ReadOnly") {
             auto realm = Realm::get_shared_realm(config);
             realm->update_schema(std::move(schema));
         }
-        config.schema_mode = SchemaMode::ReadOnlyAlternative;
+        config.schema_mode = SchemaMode::ReadOnly;
         return Realm::get_shared_realm(config);
     };
 

--- a/test/object-store/realm.cpp
+++ b/test/object-store/realm.cpp
@@ -101,7 +101,7 @@ TEST_CASE("SharedRealm: get_shared_realm()") {
         }
 
         SECTION("migration function for read-only") {
-            config.schema_mode = SchemaMode::ReadOnlyAlternative;
+            config.schema_mode = SchemaMode::ReadOnly;
             config.migration_function = [](auto, auto, auto) {};
             REQUIRE_THROWS(Realm::get_shared_realm(config));
         }
@@ -125,7 +125,7 @@ TEST_CASE("SharedRealm: get_shared_realm()") {
         }
 
         SECTION("initialization function for read-only") {
-            config.schema_mode = SchemaMode::ReadOnlyAlternative;
+            config.schema_mode = SchemaMode::ReadOnly;
             config.initialization_function = [](auto) {};
             REQUIRE_THROWS(Realm::get_shared_realm(config));
         }


### PR DESCRIPTION
This completes the renaming that should have happened shortly after https://github.com/realm/realm-object-store/pull/511

I also unsuccessfully attempted to reproduce https://github.com/realm/realm-core/issues/4599 and have added a passing test for it. I think the issue lies in the cocoa SDK.

## ☑️ ToDos
* [x] 📝 Changelog update
* [x] 🚦 Tests (or not relevant)
