### PR TITLE
Allow commit_transaction to be called recurcively

### DIFF
--- a/src/realm/db.cpp
+++ b/src/realm/db.cpp
@@ -2759,41 +2759,47 @@ void DB::release_sync_agent()
     m_is_sync_agent = false;
 }
 
-void Transaction::async_request_sync_to_storage(util::UniqueFunction<void()> when_synchronized)
+void Transaction::async_end(util::UniqueFunction<void()> when_synchronized)
 {
     std::unique_lock<std::mutex> lck(mtx);
-    REALM_ASSERT(m_async_stage == AsyncState::HasCommits);
-    m_async_stage = AsyncState::Syncing;
-    m_commit_exception = std::exception_ptr();
-    // get a callback on the helper thread, in which to sync to disk
-    get_db()->async_sync_to_disk([&, cb = std::move(when_synchronized)]() noexcept {
-        // sync to disk:
-        try {
-            DB::ReadLockInfo read_lock;
-            db->grab_read_lock(read_lock, VersionID());
-            GroupWriter out(*this);
-            out.commit(read_lock.m_top_ref); // Throws
-            // we must release the write mutex before the callback, because the callback
-            // is allowed to re-request it.
-            db->release_read_lock(read_lock);
-            if (m_oldest_version_not_persisted) {
-                db->release_read_lock(*m_oldest_version_not_persisted);
-                m_oldest_version_not_persisted.reset();
-            }
-            db->do_end_write();
-        }
-        catch (...) {
-            m_commit_exception = std::current_exception();
-        }
-
-        std::unique_lock<std::mutex> lck(mtx);
+    if (m_async_stage == AsyncState::HasLock) {
+        // Nothing to commit to disk - just release write lock
         m_async_stage = AsyncState::Idle;
-        if (waiting_for_sync) {
-            waiting_for_sync = false;
-            cv.notify_one();
-        }
-        else if (cb) {
-            cb();
-        }
-    });
+        get_db()->async_end_write();
+    }
+    else if (m_async_stage == AsyncState::HasCommits) {
+        m_async_stage = AsyncState::Syncing;
+        m_commit_exception = std::exception_ptr();
+        // get a callback on the helper thread, in which to sync to disk
+        get_db()->async_sync_to_disk([&, cb = std::move(when_synchronized)]() noexcept {
+            // sync to disk:
+            try {
+                DB::ReadLockInfo read_lock;
+                db->grab_read_lock(read_lock, VersionID());
+                GroupWriter out(*this);
+                out.commit(read_lock.m_top_ref); // Throws
+                // we must release the write mutex before the callback, because the callback
+                // is allowed to re-request it.
+                db->release_read_lock(read_lock);
+                if (m_oldest_version_not_persisted) {
+                    db->release_read_lock(*m_oldest_version_not_persisted);
+                    m_oldest_version_not_persisted.reset();
+                }
+                db->do_end_write();
+            }
+            catch (...) {
+                m_commit_exception = std::current_exception();
+            }
+
+            std::unique_lock<std::mutex> lck(mtx);
+            m_async_stage = AsyncState::Idle;
+            if (waiting_for_sync) {
+                waiting_for_sync = false;
+                cv.notify_one();
+            }
+            else if (cb) {
+                cb();
+            }
+        });
+    }
 }

--- a/src/realm/db.hpp
+++ b/src/realm/db.hpp
@@ -688,18 +688,11 @@ public:
     {
         return m_async_stage == AsyncState::HasLock || m_async_stage == AsyncState::HasCommits;
     }
+
     // request full synchronization to stable storage for all writes done since
-    // last sync. The write mutex is released after full synchronization.
-    void async_request_sync_to_storage(util::UniqueFunction<void()> when_synchronized = nullptr);
-    // release the write lock without any sync to disk
-    void async_release_write_lock()
-    {
-        std::unique_lock<std::mutex> lck(mtx);
-        if (m_async_stage == AsyncState::HasLock) {
-            m_async_stage = AsyncState::Idle;
-            get_db()->async_end_write();
-        }
-    }
+    // last sync - or just release write mutex.
+    // The write mutex is released after full synchronization.
+    void async_end(util::UniqueFunction<void()> when_synchronized = nullptr);
 
     // true if sync to disk has been requested
     bool is_synchronizing() noexcept

--- a/src/realm/db.hpp
+++ b/src/realm/db.hpp
@@ -701,31 +701,26 @@ public:
         return m_async_stage == AsyncState::Syncing;
     }
 
-    void wait_for_write_lock()
+    // Wait for any async operation to complete.
+    // Returns TRUE if async stage is Idle
+    bool wait_for_async_completion()
     {
-        std::unique_lock<std::mutex> lck(mtx);
-        if (m_async_stage == Transaction::AsyncState::Requesting) {
-            waiting_for_write_lock = true;
-            do {
-                cv.wait(lck);
-            } while (waiting_for_write_lock);
-        }
-    }
-
-    bool wait_for_sync()
-    {
-        bool did_wait = false;
         std::unique_lock<std::mutex> lck(mtx);
         if (m_async_stage == Transaction::AsyncState::Syncing) {
             waiting_for_sync = true;
             do {
                 cv.wait(lck);
             } while (waiting_for_sync);
-            did_wait = true;
+        }
+        else if (m_async_stage == Transaction::AsyncState::Requesting) {
+            waiting_for_write_lock = true;
+            do {
+                cv.wait(lck);
+            } while (waiting_for_write_lock);
         }
         if (m_commit_exception)
             throw m_commit_exception;
-        return did_wait;
+        return m_async_stage == Transaction::AsyncState::Idle;
     }
 
     std::exception_ptr get_commit_exception()

--- a/test/object-store/realm.cpp
+++ b/test/object-store/realm.cpp
@@ -1197,6 +1197,58 @@ TEST_CASE("SharedRealm: async_writes") {
         REQUIRE(observer.array_change(0, col) == IndexSet{0, 1, 2});
         realm->m_binding_context.release();
     }
+    SECTION("begin_transaction() from within did_change()") {
+        struct Context : public BindingContext {
+            Context(SharedRealm r)
+                : m_realm(r)
+            {
+            }
+            void did_change(std::vector<ObserverState> const&, std::vector<void*> const&, bool) override
+            {
+                m_realm->begin_transaction();
+                auto table = m_realm->read_group().get_table("class_object");
+                auto obj = table->create_object();
+                if (++change_count == 1) {
+                    m_realm->commit_transaction();
+                }
+                else {
+                    m_realm->cancel_transaction();
+                }
+            }
+            SharedRealm m_realm;
+            int change_count = 0;
+        };
+
+        realm->m_binding_context.reset(new Context(realm));
+
+        realm->begin_transaction();
+        auto table = realm->read_group().get_table("class_object");
+        auto obj = table->create_object();
+        realm->commit_transaction();
+        REQUIRE(table->size() == 2);
+    }
+
+    SECTION("close realm from within did_change()") {
+        struct Context : public BindingContext {
+            Context(SharedRealm r)
+                : m_realm(r)
+            {
+            }
+            void did_change(std::vector<ObserverState> const&, std::vector<void*> const&, bool) override
+            {
+                m_realm->close();
+            }
+            SharedRealm m_realm;
+        };
+
+        auto r2 = Realm::get_shared_realm(config);
+        r2->m_binding_context.reset(new Context(r2));
+
+        r2->begin_transaction();
+        auto table = r2->read_group().get_table("class_object");
+        auto obj = table->create_object();
+        r2->commit_transaction();
+    }
 }
 
 class LooperDelegate {


### PR DESCRIPTION
As part of commit_transaction, a callback on an a binding context can happen. During this callback, it should be possible to make new transactions or possibly close the Realm.
