### PR TITLE
Hook up FLX subscriptions to wire protocol state machine

### DIFF
--- a/src/realm/object-store/sync/sync_session.cpp
+++ b/src/realm/object-store/sync/sync_session.cpp
@@ -521,6 +521,7 @@ void SyncSession::do_create_sync_session()
     session_config.ssl_trust_certificate_path = m_config.ssl_trust_certificate_path;
     session_config.ssl_verify_callback = m_config.ssl_verify_callback;
     session_config.proxy_config = m_config.proxy_config;
+    session_config.flx_sync_requested = m_config.flx_sync_requested;
     {
         std::string sync_route = m_sync_manager->sync_route();
 

--- a/src/realm/sync/client.cpp
+++ b/src/realm/sync/client.cpp
@@ -866,6 +866,10 @@ SubscriptionStore* SessionWrapper::get_or_create_flx_subscription_store()
         });
 
         m_client.get_service().post([self = util::bind_ptr<SessionWrapper>(this)] {
+            REALM_ASSERT(self->m_actualized);
+            if (REALM_UNLIKELY(!self->m_sess))
+                return; // Already finalized
+
             const auto& sub_store = self->m_flx_subscription_store;
             self->m_flx_latest_version = sub_store->get_latest().version();
             self->m_flx_active_version = sub_store->get_active().version();
@@ -1304,7 +1308,7 @@ void SessionWrapper::on_connection_state_changed(ConnectionState state, const Se
     if (state == ConnectionState::connected && m_sess) {
         ClientImpl::Connection& conn = m_sess->get_connection();
         if (conn.is_flx_sync_connection()) {
-            m_sess->get_or_create_flx_subscription_store();
+            get_or_create_flx_subscription_store();
         }
     }
 

--- a/src/realm/sync/client.cpp
+++ b/src/realm/sync/client.cpp
@@ -847,7 +847,7 @@ void SessionWrapper::on_flx_sync_progress(int64_t new_version, DownloadBatchStat
 
 SubscriptionStore* SessionWrapper::get_or_create_flx_subscription_store()
 {
-    std::call_once(m_flx_subscription_store_init_flag, [&] {
+    std::call_once(m_flx_subscription_store_init_flag, [this] {
         std::lock_guard<std::mutex> lk(m_flx_subscription_store_mutex);
         m_flx_subscription_store = std::make_unique<SubscriptionStore>(m_db, [this](int64_t new_version) {
             REALM_ASSERT(m_initiated);

--- a/src/realm/sync/client.cpp
+++ b/src/realm/sync/client.cpp
@@ -748,7 +748,6 @@ void SessionImpl::on_flx_sync_progress(int64_t version, DownloadBatchState batch
 
 SubscriptionStore* SessionImpl::get_or_create_flx_subscription_store()
 {
-    m_is_flx_sync_session = true;
     return m_wrapper.get_or_create_flx_subscription_store();
 }
 
@@ -871,7 +870,7 @@ SubscriptionStore* SessionWrapper::get_or_create_flx_subscription_store()
             self->m_flx_latest_version = sub_store->get_latest().version();
             self->m_flx_active_version = sub_store->get_active().version();
 
-            self->m_sess->get_connection().force_flx_sync_mode();
+            self->m_sess->force_flx_sync_mode();
 
             if (self->m_flx_latest_version > self->m_flx_active_version) {
                 self->m_sess->on_new_flx_subscription_set(self->m_flx_latest_version);

--- a/src/realm/sync/client.cpp
+++ b/src/realm/sync/client.cpp
@@ -731,6 +731,7 @@ void SessionImpl::on_new_flx_subscription_set(int64_t new_version)
 {
     logger.trace("Requesting QUERY change message for new subscription set version %1", new_version);
     m_pending_query_message = true;
+    ensure_enlisted_to_send();
 }
 
 void SessionImpl::on_flx_sync_error(int64_t version, std::string_view err_msg)

--- a/src/realm/sync/client.cpp
+++ b/src/realm/sync/client.cpp
@@ -873,8 +873,8 @@ SubscriptionStore* SessionWrapper::get_or_create_flx_subscription_store()
                 return; // Already finalized
 
             const auto& sub_store = self->m_flx_subscription_store;
-            self->m_flx_latest_version = sub_store->get_latest().version();
-            self->m_flx_active_version = sub_store->get_active().version();
+            std::tie(self->m_flx_active_version, self->m_flx_latest_version) =
+                sub_store->get_active_and_latest_versions();
 
             if (self->m_flx_latest_version > self->m_flx_active_version) {
                 self->m_sess->on_new_flx_subscription_set(self->m_flx_latest_version);

--- a/src/realm/sync/client.cpp
+++ b/src/realm/sync/client.cpp
@@ -745,6 +745,7 @@ void SessionImpl::on_flx_sync_progress(int64_t version, DownloadBatchState batch
 
 SubscriptionStore* SessionImpl::get_or_create_flx_subscription_store()
 {
+    m_is_flx_sync_session = true;
     return m_wrapper.get_or_create_flx_subscription_store();
 }
 
@@ -1292,7 +1293,7 @@ void SessionWrapper::on_connection_state_changed(ConnectionState state, const Se
     if (state == ConnectionState::connected && m_sess) {
         ClientImpl::Connection& conn = m_sess->get_connection();
         if (conn.is_flx_sync_connection()) {
-            get_or_create_flx_subscription_store();
+            m_sess->get_or_create_flx_subscription_store();
         }
     }
 

--- a/src/realm/sync/client.cpp
+++ b/src/realm/sync/client.cpp
@@ -811,15 +811,15 @@ std::unique_ptr<SubscriptionStore> SessionWrapper::create_flx_subscription_store
     auto ret = std::make_unique<SubscriptionStore>(m_db, [this](int64_t new_version) {
         REALM_ASSERT(m_initiated);
 
-        m_client.get_service().post([new_version, self = util::bind_ptr<SessionWrapper>(this)] {
-            REALM_ASSERT(self->m_actualized);
-            if (REALM_UNLIKELY(!self->m_sess))
+        m_client.get_service().post([new_version, this] {
+            REALM_ASSERT(m_actualized);
+            if (REALM_UNLIKELY(!m_sess))
                 return; // Already finalized
-            if (new_version <= self->m_flx_latest_version || !self->m_flx_subscription_store) {
+            if (new_version <= m_flx_latest_version || !m_flx_subscription_store) {
                 return;
             }
-            self->m_flx_latest_version = new_version;
-            self->m_sess->on_new_flx_subscription_set(new_version);
+            m_flx_latest_version = new_version;
+            m_sess->on_new_flx_subscription_set(new_version);
         });
     });
 

--- a/src/realm/sync/client.cpp
+++ b/src/realm/sync/client.cpp
@@ -208,13 +208,6 @@ private:
     DBRef m_db;
     Replication* m_replication;
 
-    std::once_flag m_flx_subscription_store_init_flag;
-    mutable std::mutex m_flx_subscription_store_mutex;
-    std::unique_ptr<SubscriptionStore> m_flx_subscription_store;
-    int64_t m_flx_active_version = 0;
-    int64_t m_flx_last_seen_version = 0;
-    int64_t m_flx_latest_version = 0;
-
     const bool m_flx_sync_requested;
     const ProtocolEnvelope m_protocol_envelope;
     const std::string m_server_address;
@@ -242,6 +235,12 @@ private:
     std::function<SyncTransactCallback> m_sync_transact_handler;
     std::function<ProgressHandler> m_progress_handler;
     std::function<ConnectionStateChangeListener> m_connection_state_change_listener;
+
+    std::unique_ptr<SubscriptionStore> m_flx_subscription_store;
+    int64_t m_flx_active_version = 0;
+    int64_t m_flx_last_seen_version = 0;
+    int64_t m_flx_latest_version = 0;
+
 
     bool m_initiated = false;
 
@@ -314,6 +313,7 @@ private:
     void on_new_flx_subscription_set(int64_t new_version);
     void on_flx_sync_progress(int64_t new_version, DownloadBatchState batch_state);
     void on_flx_sync_error(int64_t version, std::string_view err_msg);
+    std::unique_ptr<SubscriptionStore> create_flx_subscription_store();
 
     void report_progress();
 
@@ -773,6 +773,7 @@ SessionWrapper::SessionWrapper(ClientImpl& client, DBRef db, Session::Config con
     , m_signed_access_token{std::move(config.signed_user_token)}
     , m_client_reset_config{std::move(config.client_reset_config)}
     , m_proxy_config{config.proxy_config} // Throws
+    , m_flx_subscription_store(create_flx_subscription_store())
 {
     REALM_ASSERT(m_db);
     REALM_ASSERT(m_db->get_replication());
@@ -799,8 +800,31 @@ inline ClientImpl& SessionWrapper::get_client() noexcept
 
 bool SessionWrapper::has_flx_subscription_store() const
 {
-    std::lock_guard<std::mutex> lk(m_flx_subscription_store_mutex);
     return static_cast<bool>(m_flx_subscription_store);
+}
+
+std::unique_ptr<SubscriptionStore> SessionWrapper::create_flx_subscription_store()
+{
+    if (!m_flx_sync_requested) {
+        return nullptr;
+    }
+    auto ret = std::make_unique<SubscriptionStore>(m_db, [this](int64_t new_version) {
+        REALM_ASSERT(m_initiated);
+
+        m_client.get_service().post([new_version, self = util::bind_ptr<SessionWrapper>(this)] {
+            REALM_ASSERT(self->m_actualized);
+            if (REALM_UNLIKELY(!self->m_sess))
+                return; // Already finalized
+            if (new_version <= self->m_flx_latest_version || !self->m_flx_subscription_store) {
+                return;
+            }
+            self->m_flx_latest_version = new_version;
+            self->m_sess->on_new_flx_subscription_set(new_version);
+        });
+    });
+
+    std::tie(m_flx_active_version, m_flx_latest_version) = ret->get_active_and_latest_versions();
+    return ret;
 }
 
 void SessionWrapper::on_flx_sync_error(int64_t version, std::string_view err_msg)
@@ -850,38 +874,6 @@ void SessionWrapper::on_flx_sync_progress(int64_t new_version, DownloadBatchStat
 
 SubscriptionStore* SessionWrapper::get_or_create_flx_subscription_store()
 {
-    std::call_once(m_flx_subscription_store_init_flag, [this] {
-        std::lock_guard<std::mutex> lk(m_flx_subscription_store_mutex);
-        m_flx_subscription_store = std::make_unique<SubscriptionStore>(m_db, [this](int64_t new_version) {
-            REALM_ASSERT(m_initiated);
-
-            m_client.get_service().post([new_version, self = util::bind_ptr<SessionWrapper>(this)] {
-                REALM_ASSERT(self->m_actualized);
-                if (REALM_UNLIKELY(!self->m_sess))
-                    return; // Already finalized
-                if (new_version <= self->m_flx_latest_version || !self->m_flx_subscription_store) {
-                    return;
-                }
-                self->m_flx_latest_version = new_version;
-                self->m_sess->on_new_flx_subscription_set(new_version);
-            });
-        });
-
-        m_client.get_service().post([self = util::bind_ptr<SessionWrapper>(this)] {
-            REALM_ASSERT(self->m_actualized);
-            if (REALM_UNLIKELY(!self->m_sess))
-                return; // Already finalized
-
-            const auto& sub_store = self->m_flx_subscription_store;
-            std::tie(self->m_flx_active_version, self->m_flx_latest_version) =
-                sub_store->get_active_and_latest_versions();
-
-            if (self->m_flx_latest_version > self->m_flx_active_version) {
-                self->m_sess->on_new_flx_subscription_set(self->m_flx_latest_version);
-            }
-        });
-    });
-
     return m_flx_subscription_store.get();
 }
 

--- a/src/realm/sync/client.hpp
+++ b/src/realm/sync/client.hpp
@@ -305,6 +305,8 @@ public:
         using ClientReset = sync::ClientReset;
         util::Optional<ClientReset> client_reset_config;
 
+        bool flx_sync_requested = false;
+
         util::Optional<SyncConfig::ProxyConfig> proxy_config;
 
         /// Set to true to cause the integration of the first received changeset

--- a/src/realm/sync/config.cpp
+++ b/src/realm/sync/config.cpp
@@ -94,7 +94,6 @@ SimplifiedProtocolError get_simplified_error(sync::ProtocolError err)
         // Connection level errors
         case ProtocolError::connection_closed:
         case ProtocolError::other_error:
-        case ProtocolError::switch_to_flx_sync:
             // Not real errors, don't need to be reported to the binding.
             return SimplifiedProtocolError::ConnectionIssue;
         case ProtocolError::unknown_message:
@@ -119,6 +118,7 @@ SimplifiedProtocolError get_simplified_error(sync::ProtocolError err)
         case ProtocolError::too_many_sessions:
         case ProtocolError::bad_query:
         case ProtocolError::switch_to_pbs:
+        case ProtocolError::switch_to_flx_sync:
             return SimplifiedProtocolError::UnexpectedInternalIssue;
         // Session errors
         case ProtocolError::session_closed:

--- a/src/realm/sync/config.cpp
+++ b/src/realm/sync/config.cpp
@@ -111,11 +111,13 @@ SimplifiedProtocolError get_simplified_error(sync::ProtocolError err)
         case ProtocolError::partial_sync_disabled:
         case ProtocolError::user_mismatch:
         case ProtocolError::too_many_sessions:
+        case ProtocolError::bad_query:
             return SimplifiedProtocolError::UnexpectedInternalIssue;
         // Session errors
         case ProtocolError::session_closed:
         case ProtocolError::other_session_error:
         case ProtocolError::disabled_session:
+        case ProtocolError::initial_sync_not_completed:
             // The binding doesn't need to be aware of these because they are strictly informational, and do not
             // represent actual errors.
             return SimplifiedProtocolError::SessionIssue;
@@ -137,6 +139,8 @@ SimplifiedProtocolError get_simplified_error(sync::ProtocolError err)
         case ProtocolError::invalid_schema_change:
         case ProtocolError::server_file_deleted:
         case ProtocolError::user_blacklisted:
+        case ProtocolError::object_already_exists:
+        case ProtocolError::server_permissions_changed:
             return SimplifiedProtocolError::ClientResetRequested;
     }
     return SimplifiedProtocolError::UnexpectedInternalIssue; // always return a value to appease MSVC.

--- a/src/realm/sync/config.cpp
+++ b/src/realm/sync/config.cpp
@@ -88,7 +88,6 @@ SimplifiedProtocolError get_simplified_error(sync::ProtocolError err)
         case ProtocolError::connection_closed:
         case ProtocolError::other_error:
         case ProtocolError::switch_to_flx_sync:
-        case ProtocolError::switch_to_pbs:
             // Not real errors, don't need to be reported to the binding.
             return SimplifiedProtocolError::ConnectionIssue;
         case ProtocolError::unknown_message:
@@ -112,6 +111,7 @@ SimplifiedProtocolError get_simplified_error(sync::ProtocolError err)
         case ProtocolError::user_mismatch:
         case ProtocolError::too_many_sessions:
         case ProtocolError::bad_query:
+        case ProtocolError::switch_to_pbs:
             return SimplifiedProtocolError::UnexpectedInternalIssue;
         // Session errors
         case ProtocolError::session_closed:

--- a/src/realm/sync/config.cpp
+++ b/src/realm/sync/config.cpp
@@ -81,6 +81,13 @@ SyncConfig::SyncConfig(std::shared_ptr<SyncUser> user, const char* partition)
 {
 }
 
+SyncConfig::SyncConfig(std::shared_ptr<SyncUser> user, FLXSyncEnabled)
+    : user(std::move(user))
+    , partition_value()
+    , flx_sync_requested(true)
+{
+}
+
 SimplifiedProtocolError get_simplified_error(sync::ProtocolError err)
 {
     switch (err) {

--- a/src/realm/sync/config.hpp
+++ b/src/realm/sync/config.hpp
@@ -126,6 +126,9 @@ enum class SyncSessionStopPolicy {
 };
 
 struct SyncConfig {
+    struct FLXSyncEnabled {
+    };
+
     struct ProxyConfig {
         using port_type = sync::port_type;
         enum class Type { HTTP, HTTPS } type;
@@ -137,6 +140,7 @@ struct SyncConfig {
 
     std::shared_ptr<SyncUser> user;
     std::string partition_value;
+    bool flx_sync_requested = false;
     SyncSessionStopPolicy stop_policy = SyncSessionStopPolicy::AfterChangesUploaded;
     std::function<SyncSessionErrorHandler> error_handler;
     bool client_validate_ssl = true;
@@ -162,6 +166,7 @@ struct SyncConfig {
     explicit SyncConfig(std::shared_ptr<SyncUser> user, bson::Bson partition);
     explicit SyncConfig(std::shared_ptr<SyncUser> user, std::string partition);
     explicit SyncConfig(std::shared_ptr<SyncUser> user, const char* partition);
+    explicit SyncConfig(std::shared_ptr<SyncUser> user, FLXSyncEnabled);
 };
 
 } // namespace realm

--- a/src/realm/sync/noinst/client_impl_base.cpp
+++ b/src/realm/sync/noinst/client_impl_base.cpp
@@ -1784,7 +1784,7 @@ void Session::send_query_change_message()
 
     auto latest_sub_set = get_or_create_flx_subscription_store()->get_latest();
     auto latest_queries = latest_sub_set.to_ext_json();
-    logger.debug("Sending: QUERY(query_verison=%1, query_size=%2, query=\"%3\"", latest_sub_set.version(),
+    logger.debug("Sending: QUERY(query_version=%1, query_size=%2, query=\"%3\"", latest_sub_set.version(),
                  latest_queries.size(), latest_queries);
 
     OutputBuffer& out = m_conn.get_output_buffer();
@@ -2118,11 +2118,10 @@ void Session::receive_download_message(const SyncProgress& progress, std::uint_f
     version_type server_version = m_progress.download.server_version;
     version_type last_integrated_client_version = m_progress.download.last_integrated_client_version;
     for (const Transformer::RemoteChangeset& changeset : received_changesets) {
-        // Check that per-changeset server version is strictly increasing.
-        bool good_server_version =
-            ((changeset.remote_version > server_version ||
-              (changeset.remote_version >= server_version && batch_state == DownloadBatchState::MoreToCome)) &&
-             changeset.remote_version <= progress.download.server_version);
+        // Check that per-changeset server version is strictly increasing, except in FLX sync where the server version
+        // must be increasing, but can stay the same during bootstraps.
+        bool good_server_version = m_is_flx_sync_session ? (changeset.remote_version >= server_version)
+                                                         : (changeset.remote_version > server_version);
         if (!good_server_version) {
             logger.error("Bad server version in changeset header (DOWNLOAD) (%1, %2, %3)", changeset.remote_version,
                          server_version, progress.download.server_version);

--- a/src/realm/sync/noinst/client_impl_base.cpp
+++ b/src/realm/sync/noinst/client_impl_base.cpp
@@ -1203,6 +1203,9 @@ void Connection::force_flx_sync_mode()
     if (old_sync_mode != SyncServerMode::PBS) {
         return;
     }
+    if (get_state() != ConnectionState::connected) {
+        return;
+    }
     logger.debug("Forcing sync connection into FLX sync mode");
     m_reconnect_info.m_reason = ConnectionTerminationReason::switch_wire_protocols;
     involuntary_disconnect(make_error_code(ProtocolError::switch_to_flx_sync), false, nullptr);

--- a/src/realm/sync/noinst/client_impl_base.cpp
+++ b/src/realm/sync/noinst/client_impl_base.cpp
@@ -1196,6 +1196,18 @@ bool Connection::is_flx_sync_connection() const noexcept
     return m_sync_mode != SyncServerMode::PBS;
 }
 
+void Connection::force_flx_sync_mode()
+{
+    auto old_sync_mode = SyncServerMode::FLXRequested;
+    std::swap(m_sync_mode, old_sync_mode);
+    if (old_sync_mode != SyncServerMode::PBS) {
+        return;
+    }
+    logger.debug("Forcing sync connection into FLX sync mode");
+    m_reconnect_info.m_reason = ConnectionTerminationReason::switch_wire_protocols;
+    involuntary_disconnect(make_error_code(ProtocolError::switch_to_flx_sync), false, nullptr);
+}
+
 void Connection::receive_pong(milliseconds_type timestamp)
 {
     logger.debug("Received: PONG(timestamp=%1)", timestamp);

--- a/src/realm/sync/noinst/client_impl_base.cpp
+++ b/src/realm/sync/noinst/client_impl_base.cpp
@@ -1743,7 +1743,7 @@ void Session::send_ident_message()
     OutputBuffer& out = m_conn.get_output_buffer();
     session_ident_type session_ident = m_ident;
 
-    if (m_conn.is_flx_sync_connection()) {
+    if (m_is_flx_sync_session) {
         auto active_query = get_or_create_flx_subscription_store()->get_active().to_ext_json();
         logger.debug("Sending: IDENT(client_file_ident=%1, client_file_ident_salt=%2, "
                      "scan_server_version=%3, scan_client_version=%4, latest_server_version=%5, "

--- a/src/realm/sync/noinst/client_impl_base.cpp
+++ b/src/realm/sync/noinst/client_impl_base.cpp
@@ -1656,7 +1656,11 @@ void Session::complete_deactivation()
     logger.debug("Deactivation completed"); // Throws
 }
 
-
+void Session::force_flx_sync_mode()
+{
+    m_is_flx_sync_session = true;
+    m_conn.force_flx_sync_mode();
+}
 // Called by the associated Connection object when this session is granted an
 // opportunity to send a message.
 //

--- a/src/realm/sync/noinst/client_impl_base.cpp
+++ b/src/realm/sync/noinst/client_impl_base.cpp
@@ -1285,7 +1285,7 @@ void Connection::receive_query_error_message(int raw_error_code, std::string_vie
         return close_due_to_protocol_error(ClientError::bad_session_ident);                              // throws
     }
 
-    if (auto ec = session->receive_query_error_message(raw_error_code, message, query_version); ec) {
+    if (auto ec = session->receive_query_error_message(raw_error_code, message, query_version)) {
         close_due_to_protocol_error(ec);
     }
 }
@@ -2214,7 +2214,7 @@ std::error_code Session::receive_unbound_message()
 
 std::error_code Session::receive_query_error_message(int error_code, std::string_view message, int64_t query_version)
 {
-    logger.info("Received QUERY_ERROR \"%1\" (error_code=%2, query_verison=%3)", message, error_code, query_version);
+    logger.info("Received QUERY_ERROR \"%1\" (error_code=%2, query_version=%3)", message, error_code, query_version);
     on_flx_sync_error(query_version, std::string_view(message.data(), message.size())); // throws
     return {};
 }

--- a/src/realm/sync/noinst/client_impl_base.cpp
+++ b/src/realm/sync/noinst/client_impl_base.cpp
@@ -2290,18 +2290,17 @@ void Session::begin_resumption_delay()
     REALM_ASSERT(!m_try_again_activation_timer);
     m_try_again_activation_timer.emplace(m_conn.get_client().get_service());
     logger.debug("Will attempt to resume session after %1 milliseconds", m_try_again_activation_delay.count());
-    m_try_again_activation_timer->async_wait(m_try_again_activation_delay,
-                                             [this](std::error_code ec) {
-                                                 if (ec == util::error::operation_aborted) {
-                                                     return;
-                                                 }
+    m_try_again_activation_timer->async_wait(m_try_again_activation_delay, [this](std::error_code ec) {
+        if (ec == util::error::operation_aborted) {
+            return;
+        }
 
-                                                 m_try_again_activation_timer.reset();
-                                                 if (m_try_again_activation_delay < std::chrono::minutes{5}) {
-                                                    m_try_again_activation_delay *= 2;
-                                                 }
-                                                 cancel_resumption_delay();
-                                             });
+        m_try_again_activation_timer.reset();
+        if (m_try_again_activation_delay < std::chrono::minutes{5}) {
+            m_try_again_activation_delay *= 2;
+        }
+        cancel_resumption_delay();
+    });
 }
 
 void Session::clear_resumption_delay_state()

--- a/src/realm/sync/noinst/client_impl_base.hpp
+++ b/src/realm/sync/noinst/client_impl_base.hpp
@@ -725,6 +725,8 @@ public:
     /// \brief Callback for when a new subscription set has been created for FLX sync.
     void on_new_flx_subscription_set(int64_t new_version);
 
+    void force_flx_sync_mode();
+
     /// \brief Announce that a new access token is available.
     ///
     /// By calling this function, the application announces to the session

--- a/src/realm/sync/noinst/client_impl_base.hpp
+++ b/src/realm/sync/noinst/client_impl_base.hpp
@@ -395,7 +395,9 @@ public:
     connection_ident_type get_ident() const noexcept;
     const ServerEndpoint& get_server_endpoint() const noexcept;
     ConnectionState get_state() const noexcept;
+    SyncServerMode get_sync_server_mode() const noexcept;
     bool is_flx_sync_connection() const noexcept;
+    void force_flx_sync_mode();
 
     void update_connect_info(const std::string& http_request_path_prefix, const std::string& realm_virt_path,
                              const std::string& signed_access_token);
@@ -1193,6 +1195,11 @@ inline ClientImpl& ClientImpl::Connection::get_client() noexcept
 inline ConnectionState ClientImpl::Connection::get_state() const noexcept
 {
     return m_state;
+}
+
+inline SyncServerMode ClientImpl::Connection::get_sync_server_mode() const noexcept
+{
+    return m_sync_mode;
 }
 
 inline auto ClientImpl::Connection::get_reconnect_info() const noexcept -> ReconnectInfo

--- a/src/realm/sync/noinst/client_impl_base.hpp
+++ b/src/realm/sync/noinst/client_impl_base.hpp
@@ -962,6 +962,8 @@ private:
 
     bool m_upload_completion_notification_requested = false;
 
+    bool m_is_flx_sync_session = false;
+
     // These are reset when the session is activated, and again whenever the
     // connection is lost or the rebinding process is initiated.
     bool m_enlisted_to_send;

--- a/src/realm/sync/noinst/protocol_codec.cpp
+++ b/src/realm/sync/noinst/protocol_codec.cpp
@@ -53,6 +53,13 @@ void ClientProtocol::make_flx_ident_message(OutputBuffer& out, session_ident_typ
     REALM_ASSERT(!out.fail());
 }
 
+void ClientProtocol::make_query_change_message(OutputBuffer& out, session_ident_type session, int64_t version,
+                                               std::string_view query_body)
+{
+    out << "query " << session << " " << version << " " << query_body.size() << "\n" << query_body; // throws
+    REALM_ASSERT(!out.fail());
+}
+
 ClientProtocol::UploadMessageBuilder::UploadMessageBuilder(
     util::Logger& logger, OutputBuffer& body_buffer, std::vector<char>& compression_buffer,
     _impl::compression::CompressMemoryArena& compress_memory_arena)

--- a/src/realm/sync/protocol.cpp
+++ b/src/realm/sync/protocol.cpp
@@ -128,6 +128,14 @@ const char* get_protocol_error_message(int error_code) noexcept
             return "Too many sessions in connection (BIND)";
         case ProtocolError::invalid_schema_change:
             return "Invalid schema change (UPLOAD)";
+        case ProtocolError::bad_query:
+            return "Client query is invalid/malformed (IDENT, QUERY)";
+        case ProtocolError::object_already_exists:
+            return "Client tried to create an object that already exists outside their view (UPLOAD)";
+        case ProtocolError::server_permissions_changed:
+            return "Server permissions for this file ident have changed since the last time it was used (IDENT)";
+        case ProtocolError::initial_sync_not_completed:
+            return "Client tried to open a session before initial sync is complete (BIND)";
     }
     return nullptr;
 }

--- a/src/realm/sync/protocol.hpp
+++ b/src/realm/sync/protocol.hpp
@@ -40,7 +40,7 @@ constexpr std::string_view get_flx_websocket_protocol_prefix() noexcept
     return "com.mongodb.realm-query-sync/";
 }
 
-enum class SyncServerMode { PBS, FLXDiscovered, FLXRequested };
+enum class SyncServerMode { PBS, FLX };
 
 /// Supported protocol envelopes:
 ///

--- a/src/realm/sync/protocol.hpp
+++ b/src/realm/sync/protocol.hpp
@@ -242,6 +242,12 @@ enum class ProtocolError {
     user_mismatch                = 223, // User mismatch for client file identifier (IDENT)
     too_many_sessions            = 224, // Too many sessions in connection (BIND)
     invalid_schema_change        = 225, // Invalid schema change (UPLOAD)
+    bad_query                    = 226, // Client query is invalid/malformed (IDENT, QUERY)
+    object_already_exists        = 227, // Client tried to create an object that already exists outside their
+                                        // view (UPLOAD)
+    server_permissions_changed   = 228, // Server permissions for this file ident have changed since the last time it
+                                        // was used (IDENT)
+    initial_sync_not_completed   = 229, // Client tried to open a session before initial sync is complete (BIND)
 
     // clang-format on
 };

--- a/src/realm/sync/subscriptions.cpp
+++ b/src/realm/sync/subscriptions.cpp
@@ -271,8 +271,9 @@ void SubscriptionSet::update_state(State new_state, util::Optional<std::string_v
             throw std::logic_error("cannot set subscription set state to uncommitted");
 
         case State::Error:
-            if (old_state != State::Bootstrapping) {
-                throw std::logic_error("subscription set must be in Bootstrapping to update state to error");
+            if (old_state != State::Bootstrapping && old_state != State::Pending) {
+                throw std::logic_error(
+                    "subscription set must be in Bootstrapping or Pending to update state to error");
             }
             if (!error_str) {
                 throw std::logic_error("Must supply an error message when setting a subscription to the error state");
@@ -555,7 +556,6 @@ const SubscriptionSet SubscriptionStore::get_active() const
                    .find_all(descriptor_ordering);
 
     if (res.is_empty()) {
-        tr->close();
         return SubscriptionSet(this, std::move(tr), Obj{});
     }
     return SubscriptionSet(this, std::move(tr), res.get(0));

--- a/src/realm/sync/subscriptions.hpp
+++ b/src/realm/sync/subscriptions.hpp
@@ -24,6 +24,7 @@
 #include "realm/query.hpp"
 #include "realm/timestamp.hpp"
 #include "realm/util/future.hpp"
+#include "realm/util/functional.hpp"
 #include "realm/util/optional.hpp"
 
 #include <list>
@@ -228,11 +229,14 @@ public:
     // If set to State::Complete, this will erase all subscription sets with a version less than this one's.
     //
     // This should be called internally within the sync client.
-    void update_state(State state, util::Optional<std::string> error_str = util::none);
+    void update_state(State state, util::Optional<std::string_view> error_str = util::none);
 
     // If this is a mutable subscription set that has not had its changes committed, this commits them and
     // continues the set's lifetime in a read-only transaction. Otherwise, this will throw.
     void commit();
+
+    // Returns this query set as extended JSON in a form suitable for transmitting to the server.
+    std::string to_ext_json() const;
 
 protected:
     friend class SubscriptionStore;
@@ -259,7 +263,7 @@ protected:
 // A SubscriptionStore manages the FLX metadata tables and the lifecycles of SubscriptionSets and Subscriptions.
 class SubscriptionStore {
 public:
-    explicit SubscriptionStore(DBRef db);
+    explicit SubscriptionStore(DBRef db, util::UniqueFunction<void(int64_t)> on_new_subscription_set);
 
     // Get the latest subscription created by calling update_latest(). Once bootstrapping is complete,
     // this and get_active() will return the same thing. If no SubscriptionSet has been set, then
@@ -267,6 +271,8 @@ public:
     const SubscriptionSet get_latest() const;
 
     // Gets the subscription set that has been acknowledged by the server as having finished bootstrapping.
+    // If no subscriptions have reached the complete stage, this returns an empty subscription with version
+    // zero.
     const SubscriptionSet get_active() const;
 
     // To be used internally by the sync client. This returns a mutable view of a subscription set by its
@@ -316,6 +322,7 @@ protected:
     friend class Subscription;
     friend class SubscriptionSet;
 
+    util::UniqueFunction<void(int64_t)> m_on_new_subscription_set;
     std::unique_ptr<SubscriptionSetKeys> m_sub_set_keys;
     std::unique_ptr<SubscriptionKeys> m_sub_keys;
 

--- a/src/realm/sync/subscriptions.hpp
+++ b/src/realm/sync/subscriptions.hpp
@@ -275,6 +275,10 @@ public:
     // zero.
     const SubscriptionSet get_active() const;
 
+    // Returns the version number of the current active and latest subscription sets. This function guarantees
+    // that the versions will be read from the same underlying transaction and will thus be consistent.
+    std::pair<int64_t, int64_t> get_active_and_latest_versions() const;
+
     // To be used internally by the sync client. This returns a mutable view of a subscription set by its
     // version ID. If there is no SubscriptionSet with that version ID, this throws KeyNotFound.
     SubscriptionSet get_mutable_by_version(int64_t version_id);

--- a/test/object-store/sync/flx_sync.cpp
+++ b/test/object-store/sync/flx_sync.cpp
@@ -44,6 +44,7 @@ TEST_CASE("flx: connect to FLX-enabled app", "[sync][flx][app]") {
     auto app_config = get_config(instance_of<SynchronousTestTransport>, app_session);
 
     TestSyncManager::Config smc(app_config);
+    smc.verbose_sync_client_logging = true;
     TestSyncManager sync_manager(std::move(smc), {});
     auto app = sync_manager.app();
 

--- a/test/object-store/sync/flx_sync.cpp
+++ b/test/object-store/sync/flx_sync.cpp
@@ -200,7 +200,7 @@ TEST_CASE("flx: query on non-queryable field results in query error message", "[
         std::move(new_subs).get_state_change_notification(sync::SubscriptionSet::State::Complete).get();
 
         CHECK(realm->get_active_subscription_set().version() == 2);
-        CHECK(realm->get_latest_subscription_set().version() == 2); 
+        CHECK(realm->get_latest_subscription_set().version() == 2);
     });
 }
 

--- a/test/object-store/sync/flx_sync.cpp
+++ b/test/object-store/sync/flx_sync.cpp
@@ -39,7 +39,9 @@ TEST_CASE("flx: connect to FLX-enabled app", "[sync][flx][app]") {
     };
 
     auto server_app_config = minimal_app_config(base_url, "flx_connect", schema);
-    server_app_config.sync_mode = AppCreateConfig::SyncMode::FLX;
+    AppCreateConfig::FLXSyncConfig flx_config;
+    flx_config.queryable_fields["TopLevel"] = {"queryable_int_field", "queryable_str_field"};
+    server_app_config.flx_sync_config = std::move(flx_config);
     auto app_session = create_app(server_app_config);
     auto app_config = get_config(instance_of<SynchronousTestTransport>, app_session);
 

--- a/test/object-store/util/baas_admin_api.cpp
+++ b/test/object-store/util/baas_admin_api.cpp
@@ -379,7 +379,6 @@ app::Response AdminAPIEndpoint::post(std::string body) const
     req.method = app::HttpMethod::post;
     req.url = m_url;
     req.body = std::move(body);
-    std::cerr << req.body << std::endl;
     return do_request(std::move(req));
 }
 

--- a/test/object-store/util/baas_admin_api.cpp
+++ b/test/object-store/util/baas_admin_api.cpp
@@ -859,7 +859,6 @@ AppSession create_app(const AppCreateConfig& config)
               {"defaultRoles",
                nlohmann::json::array(
                    {{{"name", "all"}, {"applyWhen", nlohmann::json::object()}, {"read", true}, {"write", true}}})}
-
              }}};
     }
     else {

--- a/test/object-store/util/baas_admin_api.cpp
+++ b/test/object-store/util/baas_admin_api.cpp
@@ -858,8 +858,7 @@ AppSession create_app(const AppCreateConfig& config)
              {{"rules", nlohmann::json::object()},
               {"defaultRoles",
                nlohmann::json::array(
-                   {{{"name", "all"}, {"applyWhen", nlohmann::json::object()}, {"read", true}, {"write", true}}})}
-             }}};
+                   {{{"name", "all"}, {"applyWhen", nlohmann::json::object()}, {"read", true}, {"write", true}}})}}}};
     }
     else {
         mongo_service_def["config"]["sync"] = nlohmann::json{

--- a/test/object-store/util/baas_admin_api.hpp
+++ b/test/object-store/util/baas_admin_api.hpp
@@ -132,6 +132,10 @@ struct AppCreateConfig {
         bool run_reset_function;
     };
 
+    struct FLXSyncConfig {
+        std::map<std::string, std::vector<std::string>> queryable_fields;
+    };
+
     std::string app_name;
     std::string base_url;
     std::string admin_username;
@@ -143,8 +147,7 @@ struct AppCreateConfig {
     Schema schema;
     Property partition_key;
     bool dev_mode_enabled;
-    enum class SyncMode { FLX, PBS };
-    SyncMode sync_mode = SyncMode::PBS;
+    util::Optional<FLXSyncConfig> flx_sync_config;
 
     std::vector<FunctionDef> functions;
 

--- a/test/object-store/util/test_file.cpp
+++ b/test/object-store/util/test_file.cpp
@@ -156,6 +156,24 @@ SyncTestFile::SyncTestFile(std::shared_ptr<realm::SyncUser> user, bson::Bson par
     schema_mode = SchemaMode::AdditiveExplicit;
 }
 
+SyncTestFile::SyncTestFile(std::shared_ptr<realm::SyncUser> user, realm::Schema _schema, SyncConfig::FLXSyncEnabled)
+{
+    if (!user)
+        throw std::runtime_error("Must provide `user` for SyncTestFile");
+
+    sync_config = std::make_shared<realm::SyncConfig>(user, SyncConfig::FLXSyncEnabled{});
+    sync_config->stop_policy = SyncSessionStopPolicy::Immediately;
+    sync_config->error_handler = [](std::shared_ptr<SyncSession>, SyncError error) {
+        std::cerr << util::format("An unexpected sync error was caught by the default SyncTestFile handler: '%1'",
+                                  error.message)
+                  << std::endl;
+        abort();
+    };
+    schema_version = 1;
+    schema = _schema;
+    schema_mode = SchemaMode::AdditiveExplicit;
+}
+
 SyncTestFile::SyncTestFile(std::shared_ptr<app::App> app, bson::Bson partition, Schema schema)
 {
     REALM_ASSERT(app);

--- a/test/object-store/util/test_file.hpp
+++ b/test/object-store/util/test_file.hpp
@@ -173,6 +173,7 @@ struct SyncTestFile : TestFile {
                  std::string user_name = "test");
     SyncTestFile(std::shared_ptr<realm::SyncUser> user, realm::bson::Bson partition, realm::Schema schema);
     SyncTestFile(std::shared_ptr<realm::app::App> app, realm::bson::Bson partition, realm::Schema schema);
+    SyncTestFile(std::shared_ptr<realm::SyncUser> user, realm::Schema schema, realm::SyncConfig::FLXSyncEnabled);
 };
 
 struct TestSyncManager {

--- a/test/test_sync_subscriptions.cpp
+++ b/test/test_sync_subscriptions.cpp
@@ -33,7 +33,7 @@ TEST(Sync_SubscriptionStoreBasic)
     SHARED_GROUP_TEST_PATH(sub_store_path);
     {
         SubscriptionStoreFixture fixture(sub_store_path);
-        SubscriptionStore store(fixture.db);
+        SubscriptionStore store(fixture.db, [](int64_t) {});
         // Because there are no subscription sets yet, get_latest should point to an invalid object
         // and all the property accessors should return dummy values.
         auto latest = store.get_latest();
@@ -64,7 +64,7 @@ TEST(Sync_SubscriptionStoreBasic)
     // Destroy the DB and reload it and make sure we can get the subscriptions we set in the previous block.
     {
         SubscriptionStoreFixture fixture(sub_store_path);
-        SubscriptionStore store(fixture.db);
+        SubscriptionStore store(fixture.db, [](int64_t) {});
 
         auto read_tr = fixture.db->start_read();
         Query query_a(read_tr->get_table(fixture.a_table_key));
@@ -89,7 +89,7 @@ TEST(Sync_SubscriptionStoreStateUpdates)
 {
     SHARED_GROUP_TEST_PATH(sub_store_path);
     SubscriptionStoreFixture fixture(sub_store_path);
-    SubscriptionStore store(fixture.db);
+    SubscriptionStore store(fixture.db, [](int64_t) {});
 
     auto read_tr = fixture.db->start_read();
     Query query_a(read_tr->get_table("class_a"));
@@ -179,7 +179,7 @@ TEST(Sync_SubscriptionStoreUpdateExisting)
 {
     SHARED_GROUP_TEST_PATH(sub_store_path);
     SubscriptionStoreFixture fixture(sub_store_path);
-    SubscriptionStore store(fixture.db);
+    SubscriptionStore store(fixture.db, [](int64_t) {});
 
     auto read_tr = fixture.db->start_read();
     Query query_a(read_tr->get_table("class_a"));
@@ -205,7 +205,7 @@ TEST(Sync_SubscriptionStoreNotifications)
 {
     SHARED_GROUP_TEST_PATH(sub_store_path);
     SubscriptionStoreFixture fixture(sub_store_path);
-    SubscriptionStore store(fixture.db);
+    SubscriptionStore store(fixture.db, [](int64_t) {});
 
     std::vector<util::Future<SubscriptionSet::State>> notification_futures;
     auto sub_set = store.get_latest().make_mutable_copy();
@@ -261,7 +261,7 @@ TEST(Sync_SubscriptionStoreNotifications)
     CHECK_NOT(notification_futures[3].is_ready());
     sub_set = store.get_mutable_by_version(4);
     sub_set.update_state(SubscriptionSet::State::Bootstrapping);
-    sub_set.update_state(SubscriptionSet::State::Error, error_msg);
+    sub_set.update_state(SubscriptionSet::State::Error, std::string_view(error_msg));
     sub_set.commit();
 
     // This should return a non-OK Status with the error message we set on the subscription set.


### PR DESCRIPTION
## What, How & Why?
This is the MVP of flexible sync. This does a bunch of things, it:
- Adds some basic serialization of `SubscriptionSet`'s to json so they can be sent to the server 
- Connects the `SubscriptionStore` and the `SubscriptionSet` lifecycle up to the sync client, so that new subscription sets get sent to the server as QUERY messages and QUERY_ERROR messages get propogated to `SubscriptionSet`'s as errors.
- Adds an option for constructing the `SyncConfig` struct specifically for FLX sync, and uses that to decide whether to open an FLX sync connection/sync session or not.
- Implements retries on session-level ERROR messages where try_again is true. This lets the server send back a session level error message that causes just that session to unbind and attempt to re-bind after a delay with some backoff.
- Adds some integration tests for FLX sync.

## ☑️ ToDos
* [ ] 📝 Changelog update
* [x] 🚦 Tests (or not relevant)
