### PR TITLE
Anonymous subscription assignment shouldnt replace named subscriptions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,7 @@
 * `SimulatedFailure` mmap handling was not thread-safe.
 * Rename SchemaMode::ReadOnlyAlternative to ReadOnly. ([#5070](https://github.com/realm/realm-core/issues/5070))
 * Subscriptions for FLX sync now have a unique ID ([#5054](https://github.com/realm/realm-core/pull/5054))
+* Assigning an anonymous subscription will no longer overwrite a named subscription ([#5076](https://github.com/realm/realm-core/pull/5076))
 
 ----------------------------------------------
 

--- a/src/realm/sync/subscriptions.cpp
+++ b/src/realm/sync/subscriptions.cpp
@@ -260,7 +260,7 @@ std::pair<SubscriptionSet::iterator, bool> SubscriptionSet::insert_or_assign(con
     auto table_name = Group::table_name_to_class_name(query.get_table()->get_name());
     auto query_str = query.get_description();
     auto it = std::find_if(begin(), end(), [&](const Subscription& sub) {
-        return (sub.object_class_name() == table_name && sub.query_string() == query_str);
+        return (sub.name().empty() && sub.object_class_name() == table_name && sub.query_string() == query_str);
     });
 
     std::string_view name;

--- a/test/test_sync_subscriptions.cpp
+++ b/test/test_sync_subscriptions.cpp
@@ -229,7 +229,7 @@ TEST(Sync_SubscriptionStoreAssignAnonAndNamed)
 
     {
         auto out = store.get_latest().make_mutable_copy();
-        auto [it, inserted ] = out.insert_or_assign("a sub", query_a);
+        auto [it, inserted] = out.insert_or_assign("a sub", query_a);
         CHECK(inserted);
         auto named_id = it->id();
 
@@ -247,7 +247,6 @@ TEST(Sync_SubscriptionStoreAssignAnonAndNamed)
         CHECK_NOT_EQUAL(it->id(), named_id);
         CHECK_EQUAL(out.size(), 4);
     }
-
 }
 
 TEST(Sync_SubscriptionStoreNotifications)

--- a/test/test_sync_subscriptions.cpp
+++ b/test/test_sync_subscriptions.cpp
@@ -215,6 +215,41 @@ TEST(Sync_SubscriptionStoreUpdateExisting)
     }
 }
 
+TEST(Sync_SubscriptionStoreAssignAnonAndNamed)
+{
+    SHARED_GROUP_TEST_PATH(sub_store_path);
+    SubscriptionStoreFixture fixture(sub_store_path);
+    SubscriptionStore store(fixture.db);
+
+    auto read_tr = fixture.db->start_read();
+    Query query_a(read_tr->get_table("class_a"));
+    query_a.equal(fixture.foo_col, StringData("JBR")).greater_equal(fixture.bar_col, int64_t(1));
+    Query query_b(read_tr->get_table(fixture.a_table_key));
+    query_b.equal(fixture.foo_col, "Realm");
+
+    {
+        auto out = store.get_latest().make_mutable_copy();
+        auto [it, inserted ] = out.insert_or_assign("a sub", query_a);
+        CHECK(inserted);
+        auto named_id = it->id();
+
+        std::tie(it, inserted) = out.insert_or_assign(query_a);
+        CHECK(inserted);
+        CHECK_NOT_EQUAL(it->id(), named_id);
+        CHECK_EQUAL(out.size(), 2);
+
+        std::tie(it, inserted) = out.insert_or_assign(query_b);
+        CHECK(inserted);
+        named_id = it->id();
+
+        std::tie(it, inserted) = out.insert_or_assign("b sub", query_b);
+        CHECK(inserted);
+        CHECK_NOT_EQUAL(it->id(), named_id);
+        CHECK_EQUAL(out.size(), 4);
+    }
+
+}
+
 TEST(Sync_SubscriptionStoreNotifications)
 {
     SHARED_GROUP_TEST_PATH(sub_store_path);


### PR DESCRIPTION
## What, How & Why?
This does what it says on the tin.

@nirinchev, is this the behavior you expected?

## ☑️ ToDos
* [x] 📝 Changelog update
* [x] 🚦 Tests (or not relevant)
