### PR TITLE
Ensure receive queue is drained after socket error

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@
 ### Fixed
 * <How do the end-user experience this issue? what was the impact?> ([#????](https://github.com/realm/realm-core/issues/????), since v?.?.?)
 * The release package was missing several headers (since 11.7.0).
- * The sync client will now drain the receive queue when send fails with ECONNRESET - ensuring that any error message from the server gets received and processed. ([#5047](https://github.com/realm/realm-core/pull/5047)) 
+* The sync client will now drain the receive queue when send fails with ECONNRESET - ensuring that any error message from the server gets received and processed. ([#5078](https://github.com/realm/realm-core/pull/5078))
 
 ### Breaking changes
 * None.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,8 @@
 ### Fixed
 * <How do the end-user experience this issue? what was the impact?> ([#????](https://github.com/realm/realm-core/issues/????), since v?.?.?)
 * The release package was missing several headers (since 11.7.0).
- 
+ * The sync client will now drain the receive queue when send fails with ECONNRESET - ensuring that any error message from the server gets received and processed. ([#5047](https://github.com/realm/realm-core/pull/5047)) 
+
 ### Breaking changes
 * None.
 

--- a/test/object-store/sync/app.cpp
+++ b/test/object-store/sync/app.cpp
@@ -2337,10 +2337,7 @@ TEST_CASE("app: sync integration", "[sync][app]") {
     }
 
     SECTION("too large sync message error handling") {
-        TestSyncManager::Config test_config = app_config;
-        // Too much log output seems to create problems on Evergreen CI
-        test_config.verbose_sync_client_logging = false;
-
+        TestSyncManager::Config test_config(app_config);
         TestSyncManager sync_manager(test_config, {});
         auto app = sync_manager.app();
         auto creds = create_user_and_log_in(sync_manager.app());


### PR DESCRIPTION
## What, How & Why?
I think what's going on with this test being flakey is a subtle bug in our websocket implementation.

When the test is failing, this is the order of operations:
At T0, the client sends a message to the server that is too large for the server to receive.
At T1, the server sends a websocket close message with an error message
At T2, the client begins to send another message and the server closes the TCP underlying TCP socket.
At T3, the client's call to send fails with ECONNRESET and the client begins its reconnect loop. Go back to T0.

When the test is succeeding, this is the order of operations:
At T0, the client sends a message to the server that is too large for the server to receive.
At T1, the server sends a websocket close message with an error message
At T2, the client receives the close message and reports it as a sync error.

I think, surprisingly, the answer here is to ignore ECONNRESET errors for calls to send. That way the read side of the websocket can drain the receive queue and process any error messages that may have been sent. If the send side of the TCP connection has gotten ECONNRESET, then the recv side should also be receiving it soon, so if the connection was aborted for an actual error condition, we should get that error on the recv side shortly after ignoring the error on the send side.
## ☑️ ToDos
* [x] 📝 Changelog update
* [x] 🚦 Tests (or not relevant)
