### PR TITLE
Align the result of @sum over a null link to a dictionary with the other collections

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@
 * Change the exception message for calling refresh on an immutable Realm from "Continuous transaction through DB object without history information." to "Can't refresh a read-only Realm." ([#5061](https://github.com/realm/realm-core/issues/5061), old exception message was since 10.7.2 via https://github.com/realm/realm-core/pull/4688).
 * The client reset callbacks have changed so that the pre and post Realm state are passed to the 'after' callback and thee 'before' callback only has the local state. ([#5066](https://github.com/realm/realm-core/issues/5066), since 11.5.0).
 * In the C-API, query `count()` did not apply descriptors such as limit/distinct. ([#5073](https://github.com/realm/realm-core/issues/5073), since the beginning of the C-API in v10.4.0)
+* Queries of the form "link.collection.@sum = 0" where `link` is null matched when `collection` was a List or Set, but not a Dictionary (since the introduction of Dictionary).
  
 ### Breaking changes
 * None.

--- a/src/realm/query_expression.hpp
+++ b/src/realm/query_expression.hpp
@@ -3189,6 +3189,9 @@ public:
                 auto sz = links.size();
 
                 destination.init_for_links(m_columns_collection.m_link_map.only_unary_links(), sz);
+                if (sz == 0 && m_columns_collection.m_link_map.only_unary_links()) {
+                    set_value_for_empty_dictionary(destination, 0);
+                }
                 for (size_t t = 0; t < sz; t++) {
                     const Obj obj = m_columns_collection.m_link_map.get_target_table()->get_object(links[t]);
                     auto dict = obj.get_dictionary(m_columns_collection.m_column_key);


### PR DESCRIPTION
Queries of the form "link.collection.@sum = 0" match when link is null and collection is a List or Set, but didn't when collection was a Dictionary.