### PR TITLE
Fix a race in the client reset tests

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -12,6 +12,7 @@ org = tokens[tokens.size()-3]
 repo = tokens[tokens.size()-2]
 branch = tokens[tokens.size()-1]
 
+ctest_cmd = "ctest -VV"
 warningFilters = [
     excludeFile('/external/*'), // submodules and external libraries
     excludeFile('/libuv-src/*'), // libuv, where it was downloaded and built inside cmake
@@ -275,7 +276,7 @@ def doCheckInDocker(Map options = [:]) {
                                     name: "linux-${options.buildType}-encrypt${options.enableEncryption}-BPNODESIZE_${options.maxBpNodeSize}",
                                     filters: warningFilters,
                                 )
-                                sh 'ctest --output-on-failure'
+                                sh "${ctest_cmd}"
                             }
                         } finally {
                             recordTests("Linux-${options.buildType}")
@@ -361,7 +362,7 @@ def doCheckSanity(Map options = [:]) {
                                 name: "linux-clang-${options.buildType}-${options.sanitizeMode}",
                                 filters: warningFilters,
                             )
-                            sh 'ctest --output-on-failure'
+                            sh "${ctest_cmd}"
                         }
 
                     } finally {
@@ -766,7 +767,7 @@ def doBuildMacOs(Map options = [:]) {
                     environment << 'CTEST_OUTPUT_ON_FAILURE=1'
                     dir("build-macosx-${buildType}") {
                         withEnv(environment) {
-                            sh 'ctest'
+                            sh "${ctest_cmd}"
                         }
                     }
                 } finally {

--- a/test/object-store/sync/sync_test_utils.cpp
+++ b/test/object-store/sync/sync_test_utils.cpp
@@ -394,7 +394,7 @@ struct TestServerClientReset : public TestClientReset {
         if (m_on_post_local) {
             m_on_post_local(realm);
         }
-        wait_for_download(*realm);
+        wait_for_upload(*realm);
         if (m_on_post_reset) {
             m_on_post_reset(realm);
         }


### PR DESCRIPTION
This should hopefully fix the failures we have occasionally been seeing. 
The issue is that the test harness creates several commits on the remote Realm and if the timing is just right, `wait_for_download` will only pick up the first one. Instead, `wait_for_upload` should block until the local changes are acknowledged by the server which causes the reset to take place.
This is only affecting the tests which are configured to run against the local sync test server, but I haven't seen any failures on the tests running against baas recently.
Recent reported failures that this may fix:

https://ci.realm.io/blue/organizations/jenkins/realm%2Frealm-core/detail/PR-5000/18/pipeline/
https://ci.realm.io/blue/organizations/jenkins/realm%2Frealm-core/detail/PR-5076/2/pipeline/
https://ci.realm.io/blue/organizations/jenkins/realm%2Frealm-core/detail/PR-5081/2/pipeline
https://ci.realm.io/blue/organizations/jenkins/realm%2Frealm-core/detail/PR-5075/13/pipeline/86/
