### PR TITLE
Ensure path_for_realm works for FLX sync

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 * The release package was missing several headers (since 11.7.0).
 * The sync client will now drain the receive queue when send fails with ECONNRESET - ensuring that any error message from the server gets received and processed. ([#5078](https://github.com/realm/realm-core/pull/5078))
 * Schema validation was missing for embedded objects in sets, resulting in an unhelpful error being thrown if the user attempted to define one.
+* SyncManager::path_for_realm now returns a default path when FLX sync is enabled ([#5088](https://github.com/realm/realm-core/pull/5088))
 
 ### Breaking changes
 * None.

--- a/src/realm/object-store/sync/sync_manager.cpp
+++ b/src/realm/object-store/sync/sync_manager.cpp
@@ -546,8 +546,16 @@ std::string SyncManager::path_for_realm(const SyncConfig& config, util::Optional
 
         // Attempt to make a nicer filename which will ease debugging when
         // locating files in the filesystem.
-        std::string file_name =
-            (custom_file_name) ? custom_file_name.value() : string_from_partition(config.partition_value);
+        auto file_name = [&]() -> std::string {
+            if (custom_file_name) {
+                return *custom_file_name;
+            }
+            if (config.flx_sync_requested) {
+                REALM_ASSERT_DEBUG(config.partition_value.empty());
+                return "flx_sync_default";
+            }
+            return string_from_partition(config.partition_value);
+        }();
         path = m_file_manager->realm_file_path(user->identity(), user->local_identity(), file_name,
                                                config.partition_value);
     }

--- a/test/object-store/sync/flx_sync.cpp
+++ b/test/object-store/sync/flx_sync.cpp
@@ -252,6 +252,17 @@ TEST_CASE("flx: connect to FLX as PBS returns an error", "[sync][flx][app]") {
     CHECK(sync_error->error_code == make_error_code(sync::ProtocolError::switch_to_flx_sync));
 }
 
+TEST_CASE("flx: connect to FLX with partition value returns an error", "[sync][flx][app]") {
+    FLXSyncTestHarness harness("connect_to_flx_as_pbs");
+
+    auto tsm = harness.make_sync_manager();
+    create_user_and_log_in(tsm.app());
+    SyncTestFile config(tsm.app()->current_user(), harness.schema(), SyncConfig::FLXSyncEnabled{});
+    config.sync_config->partition_value = "\"foobar\"";
+
+    CHECK_THROWS_AS(Realm::get_shared_realm(config), std::logic_error);
+}
+
 TEST_CASE("flx: connect to PBS as FLX returns an error", "[sync][flx][app]") {
     const std::string base_url = get_base_url();
 

--- a/test/object-store/sync/sync_manager.cpp
+++ b/test/object-store/sync/sync_manager.cpp
@@ -182,6 +182,15 @@ TEST_CASE("sync_manager: `path_for_realm` API", "[sync]") {
         // This API should also generate the directory if it doesn't already exist.
         REQUIRE_DIR_EXISTS(base_path + "mongodb-realm/app_id/foobarbaz/");
     }
+
+    SECTION("should produce the FLX sync path when FLX sync is enabled") {
+        TestSyncManager init_sync_manager(Cfg(base_path, SyncManager::MetadataMode::NoMetadata));
+        SyncConfig config(user, SyncConfig::FLXSyncEnabled{});
+        const auto expected = base_path + "mongodb-realm/app_id/foobarbaz/flx_sync_default.realm";
+        REQUIRE(init_sync_manager.app()->sync_manager()->path_for_realm(config) == expected);
+        // This API should also generate the directory if it doesn't already exist.
+        REQUIRE_DIR_EXISTS(base_path + "mongodb-realm/app_id/foobarbaz/");
+    }
 }
 
 TEST_CASE("sync_manager: user state management", "[sync]") {


### PR DESCRIPTION
## What, How & Why?
This just makes sure that if FLX sync is enabled, then we can generate a sane default realm file name in the sync manager.

## ☑️ ToDos
* [x] 📝 Changelog update
* [x] 🚦 Tests (or not relevant)
