### PR TITLE
Split SubscriptionSet into MutableSubscriptionSet and SubscriptionSet for type safety

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,7 +15,7 @@
 * SyncManager::path_for_realm now returns a default path when FLX sync is enabled ([#5088](https://github.com/realm/realm-core/pull/5088))
 
 ### Breaking changes
-* None.
+* FLX SubscriptionSet type split into SubscriptionSet and MutableSubscriptionSet to add type safety ([#5092](https://github.com/realm/realm-core/pull/5092))
 
 ### Compatibility
 * Fileformat: Generates files with format v22. Reads and automatically upgrade from fileformat v5.

--- a/src/realm/object-store/shared_realm.cpp
+++ b/src/realm/object-store/shared_realm.cpp
@@ -189,12 +189,12 @@ std::shared_ptr<SyncSession> Realm::sync_session() const
     return m_coordinator->sync_session();
 }
 
-const sync::SubscriptionSet Realm::get_latest_subscription_set()
+sync::SubscriptionSet Realm::get_latest_subscription_set()
 {
     return m_coordinator->sync_session()->get_flx_subscription_store()->get_latest();
 }
 
-const sync::SubscriptionSet Realm::get_active_subscription_set()
+sync::SubscriptionSet Realm::get_active_subscription_set()
 {
     return m_coordinator->sync_session()->get_flx_subscription_store()->get_active();
 }

--- a/src/realm/object-store/shared_realm.hpp
+++ b/src/realm/object-store/shared_realm.hpp
@@ -199,8 +199,8 @@ public:
     // Returns the latest/active subscription set for a FLX-sync enabled realm. If FLX sync is not currently
     // enabled for this realm, calling this will cause future connections to the server to be opened in FLX
     // sync mode if they aren't already.
-    const sync::SubscriptionSet get_latest_subscription_set();
-    const sync::SubscriptionSet get_active_subscription_set();
+    sync::SubscriptionSet get_latest_subscription_set();
+    sync::SubscriptionSet get_active_subscription_set();
 #endif
 
     // Returns a frozen Realm for the given Realm. This Realm can be accessed from any thread.

--- a/src/realm/sync/client.cpp
+++ b/src/realm/sync/client.cpp
@@ -834,7 +834,7 @@ void SessionWrapper::on_flx_sync_error(int64_t version, std::string_view err_msg
 
     auto mut_subs = get_or_create_flx_subscription_store()->get_mutable_by_version(version);
     mut_subs.update_state(SubscriptionSet::State::Error, err_msg);
-    mut_subs.commit();
+    std::move(mut_subs).commit();
 }
 
 void SessionWrapper::on_flx_sync_progress(int64_t new_version, DownloadBatchState batch_state)
@@ -869,7 +869,7 @@ void SessionWrapper::on_flx_sync_progress(int64_t new_version, DownloadBatchStat
 
     auto mut_subs = get_or_create_flx_subscription_store()->get_mutable_by_version(new_version);
     mut_subs.update_state(new_state);
-    mut_subs.commit();
+    std::move(mut_subs).commit();
 }
 
 SubscriptionStore* SessionWrapper::get_or_create_flx_subscription_store()

--- a/src/realm/sync/subscriptions.cpp
+++ b/src/realm/sync/subscriptions.cpp
@@ -389,9 +389,6 @@ SubscriptionSet MutableSubscriptionSet::commit() &&
 
     const auto flx_version = version();
     m_tr->commit_and_continue_as_read();
-    auto old_tr = std::move(m_tr);
-    m_tr = old_tr->freeze();
-    m_obj = m_tr->import_copy_of(m_obj);
 
     process_notifications();
 

--- a/src/realm/sync/subscriptions.hpp
+++ b/src/realm/sync/subscriptions.hpp
@@ -58,17 +58,13 @@ public:
     // Returns a stringified version of the query associated with this subscription.
     std::string_view query_string() const;
 
-protected:
+private:
     friend class SubscriptionSet;
     friend class MutableSubscriptionSet;
 
-    Subscription() = default;
-    Subscription(const SubscriptionSet* parent, Obj obj);
+    Subscription(const SubscriptionStore* parent, Obj obj);
 
-private:
-    const SubscriptionStore* store() const;
-
-    const SubscriptionSet* m_parent = nullptr;
+    const SubscriptionStore* m_store = nullptr;
     Obj m_obj;
 };
 
@@ -202,7 +198,6 @@ public:
 
 protected:
     friend class SubscriptionStore;
-    friend class Subscription;
 
     void insert_sub_impl(ObjectId id, Timestamp created_at, Timestamp updated_at, StringData name,
                          StringData object_class_name, StringData query_str);
@@ -263,7 +258,6 @@ public:
     void commit();
 
 protected:
-    friend class SubscriptionSet;
     friend class SubscriptionStore;
 
     using SubscriptionSet::SubscriptionSet;
@@ -338,6 +332,8 @@ protected:
     };
 
     void supercede_prior_to(TransactionRef tr, int64_t version_id) const;
+
+    MutableSubscriptionSet make_mutable_copy(const SubscriptionSet& set) const;
 
     friend class MutableSubscriptionSet;
     friend class Subscription;

--- a/src/realm/sync/subscriptions.hpp
+++ b/src/realm/sync/subscriptions.hpp
@@ -32,6 +32,7 @@
 
 namespace realm::sync {
 
+class MutableSubscriptionSet;
 class SubscriptionSet;
 class SubscriptionStore;
 
@@ -59,6 +60,7 @@ public:
 
 protected:
     friend class SubscriptionSet;
+    friend class MutableSubscriptionSet;
 
     Subscription() = default;
     Subscription(const SubscriptionSet* parent, Obj obj);
@@ -148,12 +150,12 @@ public:
         iterator& operator++();
         iterator operator++(int);
 
-    protected:
+    private:
         friend class SubscriptionSet;
+        friend class MutableSubscriptionSet;
 
         iterator(const SubscriptionSet* parent, LnkLst::iterator it);
 
-    private:
         const SubscriptionSet* m_parent;
         LnkLst::iterator m_sub_it;
         mutable Subscription m_cur_sub;
@@ -164,7 +166,7 @@ public:
     // This will make a copy of this subscription set with the next available version number and return it as
     // a mutable SubscriptionSet to be updated. The new SubscriptionSet's state will be Uncommitted. This
     // subscription set will be unchanged.
-    SubscriptionSet make_mutable_copy() const;
+    MutableSubscriptionSet make_mutable_copy() const;
 
     // Returns a future that will resolve either with an error status if this subscription set encounters an
     // error, or resolves when the subscription set reaches at least that state. It's possible for a subscription
@@ -195,11 +197,28 @@ public:
     const_iterator find(StringData name) const;
     const_iterator find(const Query& query) const;
 
-    // Erases a subscription pointed to by an iterator. Returns the "next" iterator in the set - to provide
-    // STL compatibility. The SubscriptionSet must be in the Uncommitted state to call this - otherwise
-    // this will throw.
-    const_iterator erase(const_iterator it);
+    // Returns this query set as extended JSON in a form suitable for transmitting to the server.
+    std::string to_ext_json() const;
 
+protected:
+    friend class SubscriptionStore;
+    friend class Subscription;
+
+    void insert_sub_impl(ObjectId id, Timestamp created_at, Timestamp updated_at, StringData name,
+                         StringData object_class_name, StringData query_str);
+
+    explicit SubscriptionSet(const SubscriptionStore* mgr, TransactionRef tr, Obj obj);
+
+    Subscription subscription_from_iterator(LnkLst::iterator it) const;
+
+    const SubscriptionStore* m_mgr;
+    TransactionRef m_tr;
+    Obj m_obj;
+    LnkLst m_sub_list;
+};
+
+class MutableSubscriptionSet : public SubscriptionSet {
+public:
     // Erases all subscriptions in the subscription set.
     void clear();
 
@@ -225,6 +244,11 @@ public:
     // will have
     std::pair<iterator, bool> insert_or_assign(const Query& query);
 
+    // Erases a subscription pointed to by an iterator. Returns the "next" iterator in the set - to provide
+    // STL compatibility. The SubscriptionSet must be in the Uncommitted state to call this - otherwise
+    // this will throw.
+    const_iterator erase(const_iterator it);
+
     // Updates the state of the transaction and optionally updates its error information.
     //
     // You may only set an error_str when the State is State::Error.
@@ -238,29 +262,17 @@ public:
     // continues the set's lifetime in a read-only transaction. Otherwise, this will throw.
     void commit();
 
-    // Returns this query set as extended JSON in a form suitable for transmitting to the server.
-    std::string to_ext_json() const;
-
 protected:
+    friend class SubscriptionSet;
     friend class SubscriptionStore;
-    friend class Subscription;
 
+    using SubscriptionSet::SubscriptionSet;
+
+private:
     std::pair<iterator, bool> insert_or_assign_impl(iterator it, StringData name, StringData object_class_name,
                                                     StringData query_str);
 
-    void insert_sub_impl(ObjectId id, Timestamp created_at, Timestamp updated_at, StringData name,
-                         StringData object_class_name, StringData query_str);
-
     void process_notifications();
-
-    explicit SubscriptionSet(const SubscriptionStore* mgr, TransactionRef tr, Obj obj);
-
-    Subscription subscription_from_iterator(LnkLst::iterator it) const;
-
-    const SubscriptionStore* m_mgr;
-    TransactionRef m_tr;
-    Obj m_obj;
-    LnkLst m_sub_list;
 };
 
 // A SubscriptionStore manages the FLX metadata tables and the lifecycles of SubscriptionSets and Subscriptions.
@@ -284,7 +296,7 @@ public:
 
     // To be used internally by the sync client. This returns a mutable view of a subscription set by its
     // version ID. If there is no SubscriptionSet with that version ID, this throws KeyNotFound.
-    SubscriptionSet get_mutable_by_version(int64_t version_id);
+    MutableSubscriptionSet get_mutable_by_version(int64_t version_id);
 
     // To be used internally by the sync client. This returns a read-only view of a subscription set by its
     // version ID. If there is no SubscriptionSet with that version ID, this throws KeyNotFound.
@@ -327,6 +339,7 @@ protected:
 
     void supercede_prior_to(TransactionRef tr, int64_t version_id) const;
 
+    friend class MutableSubscriptionSet;
     friend class Subscription;
     friend class SubscriptionSet;
 


### PR DESCRIPTION
## What, How & Why?
This splits `SubscriptionSet` into `MutableSubscriptionSet` and `SubscriptionSet` to add some more type safety around what you can do with what gets returned from `SubscriptionStore::get_latest()`.

This also adds a method to the `SubscriptionSet` that lets you reload any state changes from disk and makes it clearer that `MutableSubscriptionSet`s should only exist until you commit them (i.e. `commit()` now returns a regular `SubscriptionSet` that reflects the set after it was committed.
 
## ☑️ ToDos
* [x] 📝 Changelog update
* [x] 🚦 Tests (or not relevant)
