### PR TITLE
Use new format for queryable fields in FLX sync app config

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@
 ### Internals
 * 'Obj TableView::get(size_t)' removed. Use 'TableView::get_object' instead.
 * Fix issue compiling in debug mode for iOS.
+* FLX sync now sends the query version in IDENT messages along with the query body ([#5093](https://github.com/realm/realm-core/pull/5093))
 
 ----------------------------------------------
 

--- a/src/realm/sync/noinst/client_impl_base.cpp
+++ b/src/realm/sync/noinst/client_impl_base.cpp
@@ -1726,15 +1726,17 @@ void Session::send_ident_message()
     session_ident_type session_ident = m_ident;
 
     if (m_is_flx_sync_session) {
-        auto active_query = get_or_create_flx_subscription_store()->get_active().to_ext_json();
+        const auto active_query_set = get_or_create_flx_subscription_store()->get_active();
+        const auto active_query_body = active_query_set.to_ext_json();
         logger.debug("Sending: IDENT(client_file_ident=%1, client_file_ident_salt=%2, "
                      "scan_server_version=%3, scan_client_version=%4, latest_server_version=%5, "
-                     "latest_server_version_salt=%6, query_size: %7 query: \"%8\")",
+                     "latest_server_version_salt=%6, query_version: %7 query_size: %8, query: \"%9\")",
                      m_client_file_ident.ident, m_client_file_ident.salt, m_progress.download.server_version,
                      m_progress.download.last_integrated_client_version, m_progress.latest_server_version.version,
-                     m_progress.latest_server_version.salt, active_query.size(), active_query); // Throws
+                     m_progress.latest_server_version.salt, active_query_set.version(), active_query_body.size(),
+                     active_query_body); // Throws
         protocol.make_flx_ident_message(out, session_ident, m_client_file_ident, m_progress,
-                                        active_query); // Throws
+                                        active_query_set.version(), active_query_body); // Throws
     }
     else {
         logger.debug("Sending: IDENT(client_file_ident=%1, client_file_ident_salt=%2, "

--- a/src/realm/sync/noinst/protocol_codec.cpp
+++ b/src/realm/sync/noinst/protocol_codec.cpp
@@ -43,12 +43,12 @@ void ClientProtocol::make_pbs_ident_message(OutputBuffer& out, session_ident_typ
 
 void ClientProtocol::make_flx_ident_message(OutputBuffer& out, session_ident_type session_ident,
                                             SaltedFileIdent client_file_ident, const SyncProgress& progress,
-                                            std::string_view query_body)
+                                            int64_t query_version, std::string_view query_body)
 {
     out << "ident " << session_ident << " " << client_file_ident.ident << " " << client_file_ident.salt << " "
         << progress.download.server_version << " " << progress.download.last_integrated_client_version << " "
         << progress.latest_server_version.version << " " << progress.latest_server_version.salt << " "
-        << query_body.size() << "\n"
+        << query_version << " " << query_body.size() << "\n"
         << query_body; // Throws
     REALM_ASSERT(!out.fail());
 }

--- a/src/realm/sync/noinst/protocol_codec.hpp
+++ b/src/realm/sync/noinst/protocol_codec.hpp
@@ -173,7 +173,7 @@ public:
                                 const SyncProgress& progress);
 
     void make_flx_ident_message(OutputBuffer&, session_ident_type session_ident, SaltedFileIdent client_file_ident,
-                                const SyncProgress& progress, std::string_view query_body);
+                                const SyncProgress& progress, int64_t query_version, std::string_view query_body);
 
     void make_query_change_message(OutputBuffer&, session_ident_type, int64_t version, std::string_view query_body);
 

--- a/test/object-store/sync/flx_sync.cpp
+++ b/test/object-store/sync/flx_sync.cpp
@@ -100,9 +100,7 @@ AppSession make_app_from_server_schema(const std::string& test_name,
 {
     auto server_app_config = minimal_app_config(get_base_url(), test_name, server_schema.schema);
     AppCreateConfig::FLXSyncConfig flx_config;
-    for (const auto& table : server_schema.schema) {
-        flx_config.queryable_fields[table.name] = server_schema.queryable_fields;
-    }
+    flx_config.queryable_fields = server_schema.queryable_fields;
 
     server_app_config.flx_sync_config = std::move(flx_config);
     return create_app(server_app_config);

--- a/test/object-store/util/baas_admin_api.cpp
+++ b/test/object-store/util/baas_admin_api.cpp
@@ -842,18 +842,13 @@ AppSession create_app(const AppCreateConfig& config)
         {"config", {{"uri", config.mongo_uri}}},
     };
     if (config.flx_sync_config) {
-        auto queryable_fields = nlohmann::json::object();
-        for (const auto& kv : config.flx_sync_config->queryable_fields) {
-            auto table = nlohmann::json::object();
-            for (const auto& field : kv.second) {
-                table[field] = {{"name", field}};
-            }
-            queryable_fields[kv.first] = table;
-        }
+        auto queryable_fields = nlohmann::json::array();
+        const auto& queryable_fields_src = config.flx_sync_config->queryable_fields;
+        std::copy(queryable_fields_src.begin(), queryable_fields_src.end(), std::back_inserter(queryable_fields));
         mongo_service_def["config"]["sync_query"] = nlohmann::json{
             {"state", "enabled"},
             {"database_name", config.mongo_dbname},
-            {"queryable_fields", std::move(queryable_fields)},
+            {"queryable_fields_names", queryable_fields},
             {"permissions",
              {{"rules", nlohmann::json::object()},
               {"defaultRoles",

--- a/test/object-store/util/baas_admin_api.hpp
+++ b/test/object-store/util/baas_admin_api.hpp
@@ -133,7 +133,7 @@ struct AppCreateConfig {
     };
 
     struct FLXSyncConfig {
-        std::map<std::string, std::vector<std::string>> queryable_fields;
+        std::vector<std::string> queryable_fields;
     };
 
     std::string app_name;


### PR DESCRIPTION
## What, How & Why?
The admin API for baas has [changed the format for queryable fields when creating an FLX sync app](https://jira.mongodb.org/browse/REALMC-10837) and this updates the sync client's testing framework to use the new format.

## ☑️ ToDos
* [x] 📝 Changelog update
* ~[ ] 🚦 Tests (or not relevant)~
