### PR TITLE
Maybe fix a hang in the core tests

### DIFF
--- a/test/test_lang_bind_helper.cpp
+++ b/test/test_lang_bind_helper.cpp
@@ -3090,6 +3090,11 @@ TEST(LangBindHelper_ImplicitTransactions_MultipleTrackers)
 
 TEST(LangBindHelper_ImplicitTransactions_InterProcess)
 {
+    // to communicate effectively across processes we need to be ACID
+    if (get_disable_sync_to_disk()) {
+        return;
+    }
+
     const int write_process_count = 7;
     const int read_process_count = 3;
 


### PR DESCRIPTION
Occasionally, CI will time out while running the core test suite ([example](https://ci.realm.io/blue/organizations/jenkins/realm%2Frealm-core/detail/PR-5084/5/pipeline)). From added logging, I found it was hanging in `LangBindHelper_ImplicitTransactions_InterProcess`. There is an [old history](https://github.com/realm/realm-core/pull/818/commits/af5ebff4c4b3de4266aa92ea84f0c451d6561eb6#diff-9215d027423d090703d5f1f443d70bc4b6d22b65600fbaf8b9b4dd5a6db9600eL3037-L3039) of this test hanging. 

I am not 100% sure that this will fix the issue, but it seems to me from reading the test that reading and writing to a shared Realm from different processes relies on sync to disk being enabled. By default, all our tests have this flag disabled, so this effectively removes the test from our CI testing until we decide to test with sync to disk enabled.