### PR TITLE
Fix CMake files for external consumption

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -334,7 +334,7 @@ install(EXPORT realm
         COMPONENT devel
 )
 
-install(FILES ${CMAKE_CURRENT_BINARY_DIR}/RealmConfig.cmake 
+install(FILES ${CMAKE_CURRENT_BINARY_DIR}/RealmConfig.cmake
         DESTINATION lib/cmake/Realm
         COMPONENT devel
 )

--- a/src/realm/CMakeLists.txt
+++ b/src/realm/CMakeLists.txt
@@ -181,6 +181,7 @@ set(REALM_INSTALL_HEADERS
     sort_descriptor.hpp
     spec.hpp
     status.hpp
+    status_with.hpp
     string_data.hpp
     table.hpp
     table_cluster_tree.hpp
@@ -224,6 +225,7 @@ set(REALM_INSTALL_HEADERS
     util/fixed_size_buffer.hpp
     util/function_ref.hpp
     util/functional.hpp
+    util/future.hpp
     util/hex_dump.hpp
     util/inspect.hpp
     util/interprocess_condvar.hpp

--- a/src/realm/CMakeLists.txt
+++ b/src/realm/CMakeLists.txt
@@ -173,6 +173,7 @@ set(REALM_INSTALL_HEADERS
     query_conditions.hpp
     query_engine.hpp
     query_expression.hpp
+    query_state.hpp
     query_value.hpp
     realm_nmmintrin.h
     replication.hpp

--- a/src/realm/object-store/CMakeLists.txt
+++ b/src/realm/object-store/CMakeLists.txt
@@ -108,6 +108,7 @@ if(REALM_ENABLE_SYNC)
         sync/impl/sync_client.hpp
         sync/impl/sync_file.hpp
         sync/impl/sync_metadata.hpp
+        sync/impl/network_reachability.hpp
 
         util/bson/bson.hpp
         util/bson/min_key.hpp
@@ -134,6 +135,11 @@ if(REALM_ENABLE_SYNC)
         util/bson/bson.cpp
         util/bson/regular_expression.cpp)
     if(APPLE)
+
+        list(APPEND HEADERS
+            sync/impl/apple/network_reachability_observer.hpp
+            sync/impl/apple/system_configuration.hpp)
+
         list(APPEND SOURCES
             sync/impl/apple/network_reachability_observer.cpp
             sync/impl/apple/system_configuration.cpp)

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -336,11 +336,11 @@ if(REALM_ENABLE_SYNC)
 
 	add_custom_command(TARGET SyncTests POST_BUILD
 	                   COMMAND ${CMAKE_COMMAND} -E copy_directory
-	                           ${CMAKE_SOURCE_DIR}/certificate-authority
+	                           ${PROJECT_SOURCE_DIR}/certificate-authority
 	                           $<TARGET_FILE_DIR:SyncTests>/../certificate-authority)
 
 	add_custom_command(TARGET SyncTests POST_BUILD
 	                   COMMAND ${CMAKE_COMMAND} -E copy_directory
-	                           ${CMAKE_SOURCE_DIR}/test/resources
+	                           ${PROJECT_SOURCE_DIR}/test/resources
 	                           $<TARGET_FILE_DIR:SyncTests>/resources)
 endif()


### PR DESCRIPTION
`query_state.hpp` simply appears to be missing, and the copying of certs would fail for external projects considering where the cmake source directory would be pointing.