### PR TITLE
Promote assertions in ClientHistory::update_sync_progress() to relase-mode assertions

### DIFF
--- a/src/realm/sync/noinst/client_history_impl.cpp
+++ b/src/realm/sync/noinst/client_history_impl.cpp
@@ -657,15 +657,18 @@ void ClientHistory::update_sync_progress(const SyncProgress& progress, const std
     // Progress must never decrease
     REALM_ASSERT_RELEASE(progress.latest_server_version.version >=
                          version_type(root.get_as_ref_or_tagged(s_progress_latest_server_version_iip).get_as_int()));
-    REALM_ASSERT_RELEASE(progress.download.server_version >=
-                         version_type(root.get_as_ref_or_tagged(s_progress_download_server_version_iip).get_as_int()));
-    REALM_ASSERT_RELEASE(progress.download.last_integrated_client_version >=
-                         version_type(root.get_as_ref_or_tagged(s_progress_download_client_version_iip).get_as_int()));
+    REALM_ASSERT_RELEASE(
+        progress.download.server_version >=
+        version_type(root.get_as_ref_or_tagged(s_progress_download_server_version_iip).get_as_int()));
+    REALM_ASSERT_RELEASE(
+        progress.download.last_integrated_client_version >=
+        version_type(root.get_as_ref_or_tagged(s_progress_download_client_version_iip).get_as_int()));
     REALM_ASSERT_RELEASE(progress.upload.client_version >=
                          version_type(root.get_as_ref_or_tagged(s_progress_upload_client_version_iip).get_as_int()));
     if (progress.upload.last_integrated_server_version > 0) {
-        REALM_ASSERT_RELEASE(progress.upload.last_integrated_server_version >=
-                             version_type(root.get_as_ref_or_tagged(s_progress_upload_server_version_iip).get_as_int()));
+        REALM_ASSERT_RELEASE(
+            progress.upload.last_integrated_server_version >=
+            version_type(root.get_as_ref_or_tagged(s_progress_upload_server_version_iip).get_as_int()));
     }
 
     auto uploaded_bytes = std::uint_fast64_t(root.get_as_ref_or_tagged(s_progress_uploaded_bytes_iip).get_as_int());

--- a/src/realm/sync/noinst/client_history_impl.cpp
+++ b/src/realm/sync/noinst/client_history_impl.cpp
@@ -655,17 +655,17 @@ void ClientHistory::update_sync_progress(const SyncProgress& progress, const std
     Array& root = m_arrays->root;
 
     // Progress must never decrease
-    REALM_ASSERT(progress.latest_server_version.version >=
-                 version_type(root.get_as_ref_or_tagged(s_progress_latest_server_version_iip).get_as_int()));
-    REALM_ASSERT(progress.download.server_version >=
-                 version_type(root.get_as_ref_or_tagged(s_progress_download_server_version_iip).get_as_int()));
-    REALM_ASSERT(progress.download.last_integrated_client_version >=
-                 version_type(root.get_as_ref_or_tagged(s_progress_download_client_version_iip).get_as_int()));
-    REALM_ASSERT(progress.upload.client_version >=
-                 version_type(root.get_as_ref_or_tagged(s_progress_upload_client_version_iip).get_as_int()));
+    REALM_ASSERT_RELEASE(progress.latest_server_version.version >=
+                         version_type(root.get_as_ref_or_tagged(s_progress_latest_server_version_iip).get_as_int()));
+    REALM_ASSERT_RELEASE(progress.download.server_version >=
+                         version_type(root.get_as_ref_or_tagged(s_progress_download_server_version_iip).get_as_int()));
+    REALM_ASSERT_RELEASE(progress.download.last_integrated_client_version >=
+                         version_type(root.get_as_ref_or_tagged(s_progress_download_client_version_iip).get_as_int()));
+    REALM_ASSERT_RELEASE(progress.upload.client_version >=
+                         version_type(root.get_as_ref_or_tagged(s_progress_upload_client_version_iip).get_as_int()));
     if (progress.upload.last_integrated_server_version > 0) {
-        REALM_ASSERT(progress.upload.last_integrated_server_version >=
-                     version_type(root.get_as_ref_or_tagged(s_progress_upload_server_version_iip).get_as_int()));
+        REALM_ASSERT_RELEASE(progress.upload.last_integrated_server_version >=
+                             version_type(root.get_as_ref_or_tagged(s_progress_upload_server_version_iip).get_as_int()));
     }
 
     auto uploaded_bytes = std::uint_fast64_t(root.get_as_ref_or_tagged(s_progress_uploaded_bytes_iip).get_as_int());


### PR DESCRIPTION
This is in order to help track down the root cause of the issue reported here, https://jira.mongodb.org/browse/RCORE-865.

However, in hindsight, it seems like a generally good thing to make these checks regardless of build mode.