### PR TITLE
Add 'try_get_object' function to TableView

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,7 +20,7 @@
 -----------
 
 ### Internals
-* None.
+* 'Obj TableView::get(size_t)' removed. Use 'TableView::get_object' instead.
 
 ----------------------------------------------
 

--- a/src/realm/cluster_tree.cpp
+++ b/src/realm/cluster_tree.cpp
@@ -911,7 +911,7 @@ ClusterNode::State ClusterTree::insert(ObjKey k, const FieldValues& values)
     return state;
 }
 
-bool ClusterTree::is_valid(ObjKey k) const
+bool ClusterTree::is_valid(ObjKey k) const noexcept
 {
     if (m_size == 0)
         return false;
@@ -930,7 +930,7 @@ ClusterNode::State ClusterTree::get(ObjKey k) const
 ClusterNode::State ClusterTree::try_get(ObjKey k) const noexcept
 {
     ClusterNode::State state;
-    if (!m_root->try_get(k, state))
+    if (!(k && m_root->try_get(k, state)))
         state.index = realm::npos;
     return state;
 }

--- a/src/realm/cluster_tree.hpp
+++ b/src/realm/cluster_tree.hpp
@@ -135,7 +135,7 @@ public:
     // Delete object with given key
     void erase(ObjKey k, CascadeState& state);
     // Check if an object with given key exists
-    bool is_valid(ObjKey k) const;
+    bool is_valid(ObjKey k) const noexcept;
     // Lookup and return object
     ClusterNode::State get(ObjKey k) const;
     // Lookup and return object

--- a/src/realm/obj_list.hpp
+++ b/src/realm/obj_list.hpp
@@ -64,7 +64,7 @@ public:
     {
         return get_object(ndx);
     }
-    Obj try_get_object(size_t row_ndx) const
+    virtual Obj try_get_object(size_t row_ndx) const noexcept
     {
         REALM_ASSERT(row_ndx < size());
         return is_obj_valid(row_ndx) ? get_object(row_ndx) : Obj();

--- a/src/realm/object-store/results.cpp
+++ b/src/realm/object-store/results.cpp
@@ -384,9 +384,7 @@ util::Optional<Obj> Results::try_get(size_t row_ndx)
         case Mode::TableView:
             if (row_ndx >= m_table_view.size())
                 break;
-            if (m_update_policy == UpdatePolicy::Never && !m_table_view.is_obj_valid(row_ndx))
-                return Obj{};
-            return m_table_view.get(row_ndx);
+            return m_table_view.try_get_object(row_ndx);
     }
     return util::none;
 }

--- a/src/realm/sync/subscriptions.cpp
+++ b/src/realm/sync/subscriptions.cpp
@@ -567,7 +567,7 @@ const SubscriptionSet SubscriptionStore::get_active() const
     if (res.is_empty()) {
         return SubscriptionSet(this, std::move(tr), Obj{});
     }
-    return SubscriptionSet(this, std::move(tr), res.get(0));
+    return SubscriptionSet(this, std::move(tr), res.get_object(0));
 }
 
 std::pair<int64_t, int64_t> SubscriptionStore::get_active_and_latest_versions() const
@@ -590,7 +590,7 @@ std::pair<int64_t, int64_t> SubscriptionStore::get_active_and_latest_versions() 
         return {0, latest_id};
     }
 
-    auto active_id = res.get(0).get_primary_key();
+    auto active_id = res.get_object(0).get_primary_key();
     return {active_id.get_int(), latest_id};
 }
 

--- a/src/realm/table.cpp
+++ b/src/realm/table.cpp
@@ -2974,8 +2974,8 @@ Obj Table::create_object_with_primary_key(const Mixed& primary_key, FieldValues&
         ObjKey object_key = global_to_local_object_id_hashed(object_id);
 
         ObjKey key = object_key.get_unresolved();
-        if (m_tombstones->is_valid(key)) {
-            auto existing_pk_value = m_tombstones->get(key).get_any(primary_key_col);
+        if (auto obj = m_tombstones->try_get_obj(key)) {
+            auto existing_pk_value = obj.get_any(primary_key_col);
 
             // If the primary key is the same, the object should be resurrected below
             if (existing_pk_value == primary_key) {
@@ -3027,8 +3027,8 @@ ObjKey Table::find_primary_key(Mixed primary_key) const
     ObjKey object_key = global_to_local_object_id_hashed(object_id);
 
     // Check if existing
-    if (m_clusters.is_valid(object_key)) {
-        auto existing_pk_value = m_clusters.get(object_key).get_any(primary_key_col);
+    if (auto obj = m_clusters.try_get_obj(object_key)) {
+        auto existing_pk_value = obj.get_any(primary_key_col);
 
         if (existing_pk_value == primary_key) {
             return object_key;

--- a/src/realm/table.hpp
+++ b/src/realm/table.hpp
@@ -263,7 +263,7 @@ public:
     /// Create a number of objects with keys supplied
     void create_objects(const std::vector<ObjKey>& keys);
     /// Does the key refer to an object within the table?
-    bool is_valid(ObjKey key) const
+    bool is_valid(ObjKey key) const noexcept
     {
         return m_clusters.is_valid(key);
     }
@@ -272,6 +272,10 @@ public:
     {
         REALM_ASSERT(!key.is_unresolved());
         return m_clusters.get(key);
+    }
+    Obj try_get_object(ObjKey key) const noexcept
+    {
+        return m_clusters.try_get_obj(key);
     }
     Obj get_object(size_t ndx) const
     {

--- a/src/realm/table_cluster_tree.hpp
+++ b/src/realm/table_cluster_tree.hpp
@@ -38,6 +38,13 @@ public:
         auto state = ClusterTree::get(k);
         return Obj(get_table_ref(), state.mem, k, state.index);
     }
+    Obj try_get_obj(ObjKey k) const noexcept
+    {
+        if (auto state = ClusterTree::try_get(k)) {
+            return Obj(get_table_ref(), state.mem, k, state.index);
+        }
+        return {};
+    }
     Obj get(size_t ndx) const
     {
         ObjKey k;

--- a/src/realm/table_view.hpp
+++ b/src/realm/table_view.hpp
@@ -206,17 +206,19 @@ public:
         return m_table->is_valid(get_key(ndx));
     }
 
-    Obj get(size_t row_ndx) const
+    Obj get_object(size_t ndx) const final
     {
-        REALM_ASSERT(row_ndx < size());
-        ObjKey key(m_key_values.get(row_ndx));
+        REALM_ASSERT(ndx < size());
+        ObjKey key(m_key_values.get(ndx));
         REALM_ASSERT(key);
         return m_table->get_object(key);
     }
 
-    Obj get_object(size_t ndx) const final
+    Obj try_get_object(size_t ndx) const noexcept override
     {
-        return get(ndx);
+        REALM_ASSERT(ndx < size());
+        ObjKey key(m_key_values.get(ndx));
+        return m_table->try_get_object(key);
     }
 
     // Get the query used to create this TableView

--- a/test/test_array_mixed.cpp
+++ b/test/test_array_mixed.cpp
@@ -196,7 +196,7 @@ TEST(Mixed_SortNumeric)
                            "5\n7.5\n34.8\n42\n42.125\n100\n"
                            "129.85\n256.25\n500\n10000\n\"Hello\"\n";
     for (size_t i = 0; i < sz; i++) {
-        Mixed val = tv.get(i).get<Mixed>(col_data);
+        Mixed val = tv.get_object(i).get<Mixed>(col_data);
         out << val << std::endl;
     }
     std::string actual = out.str();

--- a/test/test_group.cpp
+++ b/test/test_group.cpp
@@ -2022,7 +2022,7 @@ TEST(Group_ChangeIntPrimaryKeyValuesInMigration)
 
     TableView tv = table->where().find_all();
     for (size_t i = 0; i < tv.size(); ++i) {
-        Obj obj = tv.get(i);
+        Obj obj = tv.get_object(i);
         obj.set(pk_col, obj.get<int64_t>(value_col));
     }
     table->validate_primary_column();
@@ -2049,7 +2049,7 @@ TEST(Group_ChangeStringPrimaryKeyValuesInMigration)
 
     TableView tv = table->where().find_all();
     for (size_t i = 0; i < tv.size(); ++i) {
-        Obj obj = tv.get(i);
+        Obj obj = tv.get_object(i);
         obj.set(pk_col, obj.get<StringData>(value_col));
     }
     table->validate_primary_column();

--- a/test/test_lang_bind_helper.cpp
+++ b/test/test_lang_bind_helper.cpp
@@ -1699,7 +1699,7 @@ TEST(LangBindHelper_AdvanceReadTransact_TableClear)
     // key is still there...
     CHECK(tv.get_key(0));
     // but no obj for that key...
-    CHECK_THROW(tv.get(0), realm::KeyNotFound);
+    CHECK_THROW(tv.get_object(0), realm::KeyNotFound);
 
     tv.sync_if_needed();
     CHECK_EQUAL(tv.size(), 0);
@@ -3521,9 +3521,9 @@ TEST(LangBindHelper_HandoverPartialQuery)
             TableView tv = qq2->greater(col0, 48).find_all();
             CHECK(tv.is_attached());
             CHECK_EQUAL(2, tv.size());
-            auto obj = tv.get(0);
+            auto obj = tv.get_object(0);
             CHECK_EQUAL(49, obj.get<int64_t>(col0));
-            obj = tv.get(1);
+            obj = tv.get_object(1);
             CHECK_EQUAL(50, obj.get<int64_t>(col0));
         }
     }
@@ -3589,7 +3589,7 @@ TEST(LangBindHelper_HandoverAccessors)
         CHECK(tv.is_attached());
         CHECK_EQUAL(100, tv.size());
         for (int i = 0; i < 100; ++i)
-            CHECK_EQUAL(i, tv.get(i).get<Int>(col));
+            CHECK_EQUAL(i, tv.get_object(i).get<Int>(col));
 
         reader = writer->duplicate();
         tv2 = reader->import_copy_of(tv, PayloadPolicy::Copy);
@@ -3854,8 +3854,8 @@ void handover_verifier(HandoverControl<Work>* control, TestContext& test_context
         CHECK(tv2->is_in_sync());
         CHECK_EQUAL(tv.size(), tv2->size());
         for (size_t k = 0; k < tv.size(); ++k) {
-            auto o = tv.get(k);
-            auto o2 = tv2->get(k);
+            auto o = tv.get_object(k);
+            auto o2 = tv2->get_object(k);
             CHECK_EQUAL(o.get<int64_t>(cols[0]), o2.get<int64_t>(cols[0]));
         }
         if (table->where().equal(cols[0], 0).count() >= 1)
@@ -3973,12 +3973,12 @@ TEST(LangBindHelper_HandoverDependentViews)
             CHECK(tv2.is_attached());
             CHECK_EQUAL(100, tv1.size());
             for (int i = 0; i < 100; ++i) {
-                auto o = tv1.get(i);
+                auto o = tv1.get_object(i);
                 CHECK_EQUAL(i, o.get<int64_t>(col));
             }
             CHECK_EQUAL(100, tv2.size());
             for (int i = 0; i < 100; ++i) {
-                auto o = tv2.get(i);
+                auto o = tv2.get_object(i);
                 CHECK_EQUAL(i, o.get<int64_t>(col));
             }
             tr = group_w->duplicate();
@@ -3992,7 +3992,7 @@ TEST(LangBindHelper_HandoverDependentViews)
             CHECK(tv_ov->is_attached());
             CHECK_EQUAL(100, tv_ov->size());
             for (int i = 0; i < 100; ++i) {
-                auto o = tv_ov->get(i);
+                auto o = tv_ov->get_object(i);
                 CHECK_EQUAL(i, o.get<int64_t>(col));
             }
         }

--- a/test/test_link_query_view.cpp
+++ b/test/test_link_query_view.cpp
@@ -676,46 +676,46 @@ TEST(LinkList_SortLinkView)
     list_ptr->add(key0);
 
     tv = list_ptr->get_sorted_view(col_int);
-    CHECK_EQUAL(tv.get(0).get_key(), key0);
-    CHECK_EQUAL(tv.get(1).get_key(), key1);
-    CHECK_EQUAL(tv.get(2).get_key(), key2);
+    CHECK_EQUAL(tv.get_object(0).get_key(), key0);
+    CHECK_EQUAL(tv.get_object(1).get_key(), key1);
+    CHECK_EQUAL(tv.get_object(2).get_key(), key2);
 
     // String
     tv = list_ptr->get_sorted_view(col_str1);
-    CHECK_EQUAL(tv.get(0).get_key(), key0);
-    CHECK_EQUAL(tv.get(1).get_key(), key2);
-    CHECK_EQUAL(tv.get(2).get_key(), key1);
+    CHECK_EQUAL(tv.get_object(0).get_key(), key0);
+    CHECK_EQUAL(tv.get_object(1).get_key(), key2);
+    CHECK_EQUAL(tv.get_object(2).get_key(), key1);
 
     // Sort Timestamp column
     tv = list_ptr->get_sorted_view(col_date);
-    CHECK_EQUAL(tv.get(0).get_key(), key1);
-    CHECK_EQUAL(tv.get(1).get_key(), key0);
-    CHECK_EQUAL(tv.get(2).get_key(), key2);
+    CHECK_EQUAL(tv.get_object(0).get_key(), key1);
+    CHECK_EQUAL(tv.get_object(1).get_key(), key0);
+    CHECK_EQUAL(tv.get_object(2).get_key(), key2);
 
     // Sort floats
     tv = list_ptr->get_sorted_view(col_float);
-    CHECK_EQUAL(tv.get(0).get_key(), key2);
-    CHECK_EQUAL(tv.get(1).get_key(), key1);
-    CHECK_EQUAL(tv.get(2).get_key(), key0);
+    CHECK_EQUAL(tv.get_object(0).get_key(), key2);
+    CHECK_EQUAL(tv.get_object(1).get_key(), key1);
+    CHECK_EQUAL(tv.get_object(2).get_key(), key0);
 
 
     // Sort descending
     tv = list_ptr->get_sorted_view(col_int, false);
-    CHECK_EQUAL(tv.get(0).get_key(), key2);
-    CHECK_EQUAL(tv.get(1).get_key(), key1);
-    CHECK_EQUAL(tv.get(2).get_key(), key0);
+    CHECK_EQUAL(tv.get_object(0).get_key(), key2);
+    CHECK_EQUAL(tv.get_object(1).get_key(), key1);
+    CHECK_EQUAL(tv.get_object(2).get_key(), key0);
 
     // Floats
     tv = list_ptr->get_sorted_view(col_float, false);
-    CHECK_EQUAL(tv.get(0).get_key(), key0);
-    CHECK_EQUAL(tv.get(1).get_key(), key2);
-    CHECK_EQUAL(tv.get(2).get_key(), key1);
+    CHECK_EQUAL(tv.get_object(0).get_key(), key0);
+    CHECK_EQUAL(tv.get_object(1).get_key(), key2);
+    CHECK_EQUAL(tv.get_object(2).get_key(), key1);
 
     // Doubles
     tv = list_ptr->get_sorted_view(col_double, false);
-    CHECK_EQUAL(tv.get(0).get_key(), key1);
-    CHECK_EQUAL(tv.get(1).get_key(), key0);
-    CHECK_EQUAL(tv.get(2).get_key(), key2);
+    CHECK_EQUAL(tv.get_object(0).get_key(), key1);
+    CHECK_EQUAL(tv.get_object(1).get_key(), key0);
+    CHECK_EQUAL(tv.get_object(2).get_key(), key2);
 
     // Test multi-column sorting
     std::vector<std::vector<ColKey>> v;
@@ -725,29 +725,29 @@ TEST(LinkList_SortLinkView)
     v.push_back({col_str2});
     v.push_back({col_str1});
     tv = list_ptr->get_sorted_view(SortDescriptor{v, a_false});
-    CHECK_EQUAL(tv.get(0).get_key(), key1);
-    CHECK_EQUAL(tv.get(1).get_key(), key2);
-    CHECK_EQUAL(tv.get(2).get_key(), key0);
+    CHECK_EQUAL(tv.get_object(0).get_key(), key1);
+    CHECK_EQUAL(tv.get_object(1).get_key(), key2);
+    CHECK_EQUAL(tv.get_object(2).get_key(), key0);
 
     tv = list_ptr->get_sorted_view(SortDescriptor{v, a});
-    CHECK_EQUAL(tv.get(0).get_key(), key0);
-    CHECK_EQUAL(tv.get(1).get_key(), key2);
-    CHECK_EQUAL(tv.get(2).get_key(), key1);
+    CHECK_EQUAL(tv.get_object(0).get_key(), key0);
+    CHECK_EQUAL(tv.get_object(1).get_key(), key2);
+    CHECK_EQUAL(tv.get_object(2).get_key(), key1);
 
     v.push_back({col_float});
     a.push_back(true);
 
     // The last added column should have no influence
     tv = list_ptr->get_sorted_view(SortDescriptor{v, a});
-    CHECK_EQUAL(tv.get(0).get_key(), key0);
-    CHECK_EQUAL(tv.get(1).get_key(), key2);
-    CHECK_EQUAL(tv.get(2).get_key(), key1);
+    CHECK_EQUAL(tv.get_object(0).get_key(), key0);
+    CHECK_EQUAL(tv.get_object(1).get_key(), key2);
+    CHECK_EQUAL(tv.get_object(2).get_key(), key1);
 
     table1->remove_object(key0);
     tv.sync_if_needed();
     CHECK_EQUAL(tv.size(), 2);
-    CHECK_EQUAL(tv.get(0).get_key(), key2);
-    CHECK_EQUAL(tv.get(1).get_key(), key1);
+    CHECK_EQUAL(tv.get_object(0).get_key(), key2);
+    CHECK_EQUAL(tv.get_object(1).get_key(), key1);
 }
 
 TEST(Link_EmptySortedView)

--- a/test/test_object_id.cpp
+++ b/test/test_object_id.cpp
@@ -375,7 +375,7 @@ TEST_TYPES(ObjectId_Query, WithIndex, WithoutIndex)
         auto tv = q1.find_all();
         tv.sort(col, true);
         for (int i = 0; i < 25; i++) {
-            CHECK_EQUAL(tv.get(i).get<int64_t>(col_int), i);
+            CHECK_EQUAL(tv.get_object(i).get<int64_t>(col_int), i);
         }
         Query q2 = table->column<ObjectId>(col_id) == alternative_id;
         // std::cout << q2.get_description() << std::endl;

--- a/test/test_parser.cpp
+++ b/test/test_parser.cpp
@@ -2654,7 +2654,7 @@ TEST(Parser_SortAndDistinct)
     {
         auto check_tv = [&](TableView tv) {
             for (size_t row_ndx = 1; row_ndx < tv.size(); ++row_ndx) {
-                CHECK(tv.get(row_ndx - 1).get<Int>(age_col) <= tv.get(row_ndx).get<Int>(age_col));
+                CHECK(tv.get_object(row_ndx - 1).get<Int>(age_col) <= tv.get_object(row_ndx).get<Int>(age_col));
             }
         };
         check_tv(get_sorted_view(people, "age > 0 SORT(age ASC)"));
@@ -2664,7 +2664,7 @@ TEST(Parser_SortAndDistinct)
     {
         auto check_tv = [&](TableView tv) {
             for (size_t row_ndx = 1; row_ndx < tv.size(); ++row_ndx) {
-                CHECK(tv.get(row_ndx - 1).get<Int>(age_col) >= tv.get(row_ndx).get<Int>(age_col));
+                CHECK(tv.get_object(row_ndx - 1).get<Int>(age_col) >= tv.get_object(row_ndx).get<Int>(age_col));
             }
         };
         check_tv(get_sorted_view(people, "age > 0 SORT(age DESC)"));
@@ -2674,9 +2674,9 @@ TEST(Parser_SortAndDistinct)
     {
         auto check_tv = [&](TableView tv) {
             CHECK_EQUAL(tv.size(), 3);
-            CHECK_EQUAL(tv.get(0).get<String>(name_col), "Ben");
-            CHECK_EQUAL(tv.get(1).get<String>(name_col), "Adam");
-            CHECK_EQUAL(tv.get(2).get<String>(name_col), "Frank");
+            CHECK_EQUAL(tv.get_object(0).get<String>(name_col), "Ben");
+            CHECK_EQUAL(tv.get_object(1).get<String>(name_col), "Adam");
+            CHECK_EQUAL(tv.get_object(2).get<String>(name_col), "Frank");
         };
         check_tv(get_sorted_view(people, "age > 0 SORT(age ASC, name DESC)"));
         check_tv(
@@ -2686,8 +2686,8 @@ TEST(Parser_SortAndDistinct)
     {
         auto check_tv = [&](TableView tv) {
             for (size_t row_ndx = 1; row_ndx < tv.size(); ++row_ndx) {
-                ObjKey link_ndx1 = tv.get(row_ndx - 1).get<ObjKey>(account_col);
-                ObjKey link_ndx2 = tv.get(row_ndx).get<ObjKey>(account_col);
+                ObjKey link_ndx1 = tv.get_object(row_ndx - 1).get<ObjKey>(account_col);
+                ObjKey link_ndx2 = tv.get_object(row_ndx).get<ObjKey>(account_col);
                 CHECK(accounts->get_object(link_ndx1).get<double>(balance_col) <=
                       accounts->get_object(link_ndx2).get<double>(balance_col));
             }
@@ -2701,8 +2701,8 @@ TEST(Parser_SortAndDistinct)
     {
         auto check_tv = [&](TableView tv) {
             for (size_t row_ndx = 1; row_ndx < tv.size(); ++row_ndx) {
-                ObjKey link_ndx1 = tv.get(row_ndx - 1).get<ObjKey>(account_col);
-                ObjKey link_ndx2 = tv.get(row_ndx).get<ObjKey>(account_col);
+                ObjKey link_ndx1 = tv.get_object(row_ndx - 1).get<ObjKey>(account_col);
+                ObjKey link_ndx2 = tv.get_object(row_ndx).get<ObjKey>(account_col);
                 CHECK(accounts->get_object(link_ndx1).get<double>(balance_col) >=
                       accounts->get_object(link_ndx2).get<double>(balance_col));
             }
@@ -2715,7 +2715,7 @@ TEST(Parser_SortAndDistinct)
         auto check_tv = [&](TableView tv) {
             CHECK_EQUAL(tv.size(), 2);
             for (size_t row_ndx = 1; row_ndx < tv.size(); ++row_ndx) {
-                CHECK(tv.get(row_ndx - 1).get<Int>(age_col) != tv.get(row_ndx).get<Int>(age_col));
+                CHECK(tv.get_object(row_ndx - 1).get<Int>(age_col) != tv.get_object(row_ndx).get<Int>(age_col));
             }
         };
         check_tv(get_sorted_view(people, "TRUEPREDICATE DISTINCT(age)"));
@@ -2725,9 +2725,9 @@ TEST(Parser_SortAndDistinct)
     {
         auto check_tv = [&](TableView tv) {
             CHECK_EQUAL(tv.size(), 3);
-            CHECK_EQUAL(tv.get(0).get<String>(name_col), "Adam");
-            CHECK_EQUAL(tv.get(1).get<String>(name_col), "Frank");
-            CHECK_EQUAL(tv.get(2).get<String>(name_col), "Ben");
+            CHECK_EQUAL(tv.get_object(0).get<String>(name_col), "Adam");
+            CHECK_EQUAL(tv.get_object(1).get<String>(name_col), "Frank");
+            CHECK_EQUAL(tv.get_object(2).get<String>(name_col), "Ben");
         };
         check_tv(get_sorted_view(people, "TRUEPREDICATE DISTINCT(age, account.balance)", mapping));
         check_tv(get_sorted_view(people, "TRUEPREDICATE DISTINCT(sol_rotations, holdings.funds)", mapping));
@@ -2736,7 +2736,7 @@ TEST(Parser_SortAndDistinct)
     {
         auto check_tv = [&](TableView tv) {
             CHECK_EQUAL(tv.size(), 1);
-            CHECK_EQUAL(tv.get(0).get<String>(name_col), "Adam");
+            CHECK_EQUAL(tv.get_object(0).get<String>(name_col), "Adam");
         };
         check_tv(get_sorted_view(people, "TRUEPREDICATE DISTINCT(age) DISTINCT(account.balance)"));
         check_tv(get_sorted_view(people, "TRUEPREDICATE DISTINCT(sol_rotations) DISTINCT(holdings.funds)", mapping));
@@ -2745,8 +2745,8 @@ TEST(Parser_SortAndDistinct)
     {
         auto check_tv = [&](TableView tv) {
             CHECK_EQUAL(tv.size(), 2);
-            CHECK_EQUAL(tv.get(0).get<Int>(age_col), 28);
-            CHECK_EQUAL(tv.get(1).get<Int>(age_col), 30);
+            CHECK_EQUAL(tv.get_object(0).get<Int>(age_col), 28);
+            CHECK_EQUAL(tv.get_object(1).get<Int>(age_col), 30);
         };
         check_tv(get_sorted_view(people, "TRUEPREDICATE SORT(age ASC) DISTINCT(age)"));
         check_tv(get_sorted_view(people, "TRUEPREDICATE SORT(sol_rotations ASC) DISTINCT(sol_rotations)", mapping));
@@ -2755,8 +2755,8 @@ TEST(Parser_SortAndDistinct)
     {
         auto check_tv = [&](TableView tv) {
             CHECK_EQUAL(tv.size(), 2);
-            CHECK_EQUAL(tv.get(0).get<String>(name_col), "Ben");
-            CHECK_EQUAL(tv.get(1).get<String>(name_col), "Frank");
+            CHECK_EQUAL(tv.get_object(0).get<String>(name_col), "Ben");
+            CHECK_EQUAL(tv.get_object(1).get<String>(name_col), "Frank");
         };
         check_tv(
             get_sorted_view(people, "TRUEPREDICATE SORT(name DESC) DISTINCT(age) SORT(name ASC) DISTINCT(name)"));
@@ -2769,8 +2769,8 @@ TEST(Parser_SortAndDistinct)
     {
         auto check_tv = [&](TableView tv) {
             CHECK_EQUAL(tv.size(), 2);
-            CHECK_EQUAL(tv.get(0).get<String>(name_col), "Ben");
-            CHECK_EQUAL(tv.get(1).get<String>(name_col), "Frank");
+            CHECK_EQUAL(tv.get_object(0).get<String>(name_col), "Ben");
+            CHECK_EQUAL(tv.get_object(1).get<String>(name_col), "Frank");
         };
         check_tv(get_sorted_view(people, "account.num_transactions > 10 SORT(name ASC)"));
         check_tv(get_sorted_view(people, "holdings.sum_of_actions > 10 SORT(nominal_identifier ASC)", mapping));
@@ -3843,7 +3843,7 @@ TEST(Parser_Object)
     verify_query(test_context, table, "link == NULL", 1); // vanilla base check
     verify_query(test_context, table, "link == O1", 2);
 
-    Query q0 = table->where().and_query(table->column<Link>(link_col) == tv.get(0));
+    Query q0 = table->where().and_query(table->column<Link>(link_col) == tv.get_object(0));
     std::string description = q0.get_description(); // shouldn't throw
     CHECK(description.find("O0") != std::string::npos);
 

--- a/test/test_query.cpp
+++ b/test/test_query.cpp
@@ -2092,21 +2092,21 @@ TEST_TYPES(Query_StringIndexCommonPrefix, std::true_type, std::false_type)
 
         TableView v = table->where().equal(col_str, spb).find_all();
         CHECK_EQUAL(v.size(), 1);
-        CHECK_EQUAL(v.get(0).get_key(), keys[0]);
+        CHECK_EQUAL(v.get_object(0).get_key(), keys[0]);
 
         v = table->where().equal(col_str, spc).find_all();
         CHECK_EQUAL(v.size(), 2);
-        CHECK_EQUAL(v.get(0).get_key(), keys[1]);
-        CHECK_EQUAL(v.get(1).get_key(), keys[2]);
+        CHECK_EQUAL(v.get_object(0).get_key(), keys[1]);
+        CHECK_EQUAL(v.get_object(1).get_key(), keys[2]);
 
         v = table->where().equal(col_str, spd).find_all();
         CHECK_EQUAL(v.size(), 0);
 
         v = table->where().equal(col_str, spe).find_all();
         CHECK_EQUAL(v.size(), 3);
-        CHECK_EQUAL(v.get(0).get_key(), keys[3]);
-        CHECK_EQUAL(v.get(1).get_key(), keys[4]);
-        CHECK_EQUAL(v.get(2).get_key(), keys[5]);
+        CHECK_EQUAL(v.get_object(0).get_key(), keys[3]);
+        CHECK_EQUAL(v.get_object(1).get_key(), keys[4]);
+        CHECK_EQUAL(v.get_object(2).get_key(), keys[5]);
     };
 
     std::string std_max(StringIndex::s_max_offset, 'a');
@@ -3572,18 +3572,18 @@ TEST(Query_FindAllContains2_2)
     Query q1 = ttt.where().contains(col_str, StringData("foO"), false);
     TableView tv1 = q1.find_all();
     CHECK_EQUAL(6, tv1.size());
-    CHECK_EQUAL(0, tv1.get(0).get<Int>(col_int));
-    CHECK_EQUAL(1, tv1.get(1).get<Int>(col_int));
-    CHECK_EQUAL(2, tv1.get(2).get<Int>(col_int));
-    CHECK_EQUAL(3, tv1.get(3).get<Int>(col_int));
-    CHECK_EQUAL(4, tv1.get(4).get<Int>(col_int));
-    CHECK_EQUAL(5, tv1.get(5).get<Int>(col_int));
+    CHECK_EQUAL(0, tv1.get_object(0).get<Int>(col_int));
+    CHECK_EQUAL(1, tv1.get_object(1).get<Int>(col_int));
+    CHECK_EQUAL(2, tv1.get_object(2).get<Int>(col_int));
+    CHECK_EQUAL(3, tv1.get_object(3).get<Int>(col_int));
+    CHECK_EQUAL(4, tv1.get_object(4).get<Int>(col_int));
+    CHECK_EQUAL(5, tv1.get_object(5).get<Int>(col_int));
     Query q2 = ttt.where().contains(col_str, StringData("foO"), true);
     TableView tv2 = q2.find_all();
     CHECK_EQUAL(3, tv2.size());
-    CHECK_EQUAL(3, tv2.get(0).get<Int>(col_int));
-    CHECK_EQUAL(4, tv2.get(1).get<Int>(col_int));
-    CHECK_EQUAL(5, tv2.get(2).get<Int>(col_int));
+    CHECK_EQUAL(3, tv2.get_object(0).get<Int>(col_int));
+    CHECK_EQUAL(4, tv2.get_object(1).get<Int>(col_int));
+    CHECK_EQUAL(5, tv2.get_object(2).get<Int>(col_int));
 }
 
 TEST(Query_SumNewAggregates)
@@ -4744,7 +4744,7 @@ TEST(Query_SortDistinctOrderThroughHandover)
         CHECK(tv->is_in_sync());
         CHECK_EQUAL(tv->size(), results.size());
         for (size_t i = 0; i < tv->size(); ++i) {
-            CHECK_EQUAL(tv->get(i).get<String>(t1_str_col), results[i].first);
+            CHECK_EQUAL(tv->get_object(i).get<String>(t1_str_col), results[i].first);
             CHECK_EQUAL(tv->get_key(i), results[i].second);
         }
     };
@@ -4766,7 +4766,7 @@ TEST(Query_SortDistinctOrderThroughHandover)
 
         CHECK_EQUAL(tv.size(), results.size());
         for (size_t i = 0; i < tv.size(); ++i) {
-            CHECK_EQUAL(tv.get(i).get<String>(t1_str_col), results[i].first);
+            CHECK_EQUAL(tv.get_object(i).get<String>(t1_str_col), results[i].first);
             CHECK_EQUAL(tv.get_key(i), results[i].second);
         }
         auto tr = g->duplicate();
@@ -4802,7 +4802,7 @@ TEST(Query_SortDistinctOrderThroughHandover)
         tv.sort(SortDescriptor({{t1_int_col}}, {false}));
         CHECK_EQUAL(tv.size(), results.size());
         for (size_t i = 0; i < tv.size(); ++i) {
-            CHECK_EQUAL(tv.get(i).get<String>(t1_str_col), results[i].first);
+            CHECK_EQUAL(tv.get_object(i).get<String>(t1_str_col), results[i].first);
             CHECK_EQUAL(tv.get_key(i), results[i].second);
         }
         auto tr = g->duplicate();
@@ -4816,7 +4816,7 @@ TEST(Query_SortDistinctOrderThroughHandover)
         tv.distinct(DistinctDescriptor({{t1_str_col}, {t1_int_col}}));
         CHECK_EQUAL(tv.size(), results.size());
         for (size_t i = 0; i < tv.size(); ++i) {
-            CHECK_EQUAL(tv.get(i).get<String>(t1_str_col), results[i].first);
+            CHECK_EQUAL(tv.get_object(i).get<String>(t1_str_col), results[i].first);
             CHECK_EQUAL(tv.get_key(i), results[i].second);
         }
         auto tr = g->duplicate();
@@ -4830,7 +4830,7 @@ TEST(Query_SortDistinctOrderThroughHandover)
         tv.sort(SortDescriptor({{t1_int_col}}, {false}));
         CHECK_EQUAL(tv.size(), results.size());
         for (size_t i = 0; i < tv.size(); ++i) {
-            CHECK_EQUAL(tv.get(i).get<String>(t1_str_col), results[i].first);
+            CHECK_EQUAL(tv.get_object(i).get<String>(t1_str_col), results[i].first);
             CHECK_EQUAL(tv.get_key(i), results[i].second);
         }
         auto tr = g->duplicate();
@@ -4864,7 +4864,7 @@ TEST(Query_CompoundDescriptors) {
         CHECK(tv->is_in_sync());
         CHECK_EQUAL(tv->size(), results.size());
         for (size_t i = 0; i < tv->size(); ++i) {
-            CHECK_EQUAL(tv->get(i).get<Int>(t1_int_col), results[i].first);
+            CHECK_EQUAL(tv->get_object(i).get<Int>(t1_int_col), results[i].first);
             CHECK_EQUAL(tv->get_key(i), results[i].second);
         }
     };
@@ -5265,7 +5265,7 @@ TEST(Query_Sort_And_Requery)
     CHECK_EQUAL(9, tv3[3].get<Int>(col_int));
 
     // Test that remove() maintains order
-    tv3.get(0).remove();
+    tv3.get_object(0).remove();
     tv3.sync_if_needed();
     // q5 and q3 should behave the same.
     Query q5 = table.where(&tv2).not_equal(col_str, "X");

--- a/test/test_query2.cpp
+++ b/test/test_query2.cpp
@@ -3274,13 +3274,13 @@ TEST(Query_LinksToDeletedOrMovedRow)
     TableView tvB = qB.find_all();
     CHECK_EQUAL(1, tvB.size());
     CHECK_EQUAL(keys[1], tvB[0].get<ObjKey>(col_link));
-    CHECK_EQUAL("B", tvB.get(0).get_linked_object(col_link).get<String>(col_name));
+    CHECK_EQUAL("B", tvB.get_object(0).get_linked_object(col_link).get<String>(col_name));
 
     // Row C should still be found
     TableView tvC = qC.find_all();
     CHECK_EQUAL(1, tvC.size());
     CHECK_EQUAL(keys[2], tvC[0].get<ObjKey>(col_link));
-    CHECK_EQUAL("C", tvC.get(0).get_linked_object(col_link).get<String>(col_name));
+    CHECK_EQUAL("C", tvC.get_object(0).get_linked_object(col_link).get<String>(col_name));
 }
 
 // Triggers bug in compare_relation()
@@ -3423,10 +3423,10 @@ TEST(Query_NegativeNumbers)
         id = -1;
         for (size_t i = 0; i < view.size(); ++i) {
             if (nullable == 0) {
-                CHECK_EQUAL(id, view.get(i).get<Optional<Int>>(c0));
+                CHECK_EQUAL(id, view.get_object(i).get<Optional<Int>>(c0));
             }
             else {
-                CHECK_EQUAL(id, view.get(i).get<Int>(c0));
+                CHECK_EQUAL(id, view.get_object(i).get<Int>(c0));
             }
             id--;
         }
@@ -4744,18 +4744,18 @@ TEST(Query_IntOnly)
 
     TableView tv = q.find_all();
     CHECK_EQUAL(tv.size(), 2);
-    CHECK_EQUAL(tv.get(0).get_key(), ObjKey(7));
-    CHECK_EQUAL(tv.get(1).get_key(), ObjKey(21));
+    CHECK_EQUAL(tv.get_object(0).get_key(), ObjKey(7));
+    CHECK_EQUAL(tv.get_object(1).get_key(), ObjKey(21));
 
     auto q1 = table.where(&tv).equal(c0, 2);
     TableView tv1 = q1.find_all();
     CHECK_EQUAL(tv1.size(), 1);
-    CHECK_EQUAL(tv1.get(0).get_key(), ObjKey(21));
+    CHECK_EQUAL(tv1.get_object(0).get_key(), ObjKey(21));
 
     q1 = table.where(&tv).greater(c0, 5);
     tv1 = q1.find_all();
     CHECK_EQUAL(tv1.size(), 1);
-    CHECK_EQUAL(tv1.get(0).get_key(), ObjKey(7));
+    CHECK_EQUAL(tv1.get_object(0).get_key(), ObjKey(7));
 
     q = table.column<Int>(c0) == 19 && table.column<Int>(c1) == 9;
     key = q.find();
@@ -4763,14 +4763,14 @@ TEST(Query_IntOnly)
 
     tv = q.find_all();
     CHECK_EQUAL(tv.size(), 1);
-    CHECK_EQUAL(tv.get(0).get_key(), ObjKey(19));
+    CHECK_EQUAL(tv.get_object(0).get_key(), ObjKey(19));
 
     // Two column expression
     q = table.column<Int>(c0) < table.column<Int>(c1);
     tv = q.find_all();
     CHECK_EQUAL(tv.size(), 2);
-    CHECK_EQUAL(tv.get(0).get_key(), ObjKey(5));
-    CHECK_EQUAL(tv.get(1).get_key(), ObjKey(21));
+    CHECK_EQUAL(tv.get_object(0).get_key(), ObjKey(5));
+    CHECK_EQUAL(tv.get_object(1).get_key(), ObjKey(21));
 }
 
 TEST(Query_LinksTo)

--- a/test/test_table.cpp
+++ b/test/test_table.cpp
@@ -1340,13 +1340,13 @@ TEST_TYPES(Table_SortFloat, float, double, Decimal128)
     // nulls should appear first,
     // followed by nans, folllowed by the rest of the values in ascending order
     for (size_t i = 0; i < 300; ++i) {
-        CHECK(sorted.get(i).is_null(col));
+        CHECK(sorted.get_object(i).is_null(col));
     }
     for (size_t i = 300; i < 600; ++i) {
-        CHECK(realm::isnan(sorted.get(i).get<TEST_TYPE>(col)));
+        CHECK(realm::isnan(sorted.get_object(i).get<TEST_TYPE>(col)));
     }
     for (size_t i = 600; i + 1 < 900; ++i) {
-        CHECK_GREATER(sorted.get(i + 1).get<TEST_TYPE>(col), sorted.get(i).get<TEST_TYPE>(col));
+        CHECK_GREATER(sorted.get_object(i + 1).get<TEST_TYPE>(col), sorted.get_object(i).get<TEST_TYPE>(col));
     }
 }
 
@@ -1687,11 +1687,11 @@ TEST(Table_AutoEnumeration)
 
     auto tv = table.find_all_string(col_str, "eftg");
     CHECK_EQUAL(5, tv.size());
-    CHECK_EQUAL("eftg", tv.get(0).get<String>(col_str));
-    CHECK_EQUAL("eftg", tv.get(1).get<String>(col_str));
-    CHECK_EQUAL("eftg", tv.get(2).get<String>(col_str));
-    CHECK_EQUAL("eftg", tv.get(3).get<String>(col_str));
-    CHECK_EQUAL("eftg", tv.get(4).get<String>(col_str));
+    CHECK_EQUAL("eftg", tv.get_object(0).get<String>(col_str));
+    CHECK_EQUAL("eftg", tv.get_object(1).get<String>(col_str));
+    CHECK_EQUAL("eftg", tv.get_object(2).get<String>(col_str));
+    CHECK_EQUAL("eftg", tv.get_object(3).get<String>(col_str));
+    CHECK_EQUAL("eftg", tv.get_object(4).get<String>(col_str));
 
     Obj obj = table.create_object();
     CHECK_EQUAL(0, obj.get<Int>(col_int));

--- a/test/test_table_view.cpp
+++ b/test/test_table_view.cpp
@@ -1468,8 +1468,8 @@ TEST(TableView_DistinctOverNullLink)
     auto tv = origin->where().find_all();
     tv.distinct(DistinctDescriptor({{col_link, col_int}}));
     CHECK_EQUAL(tv.size(), 2);
-    CHECK_EQUAL(tv.get(0).get_linked_object(col_link).get<Int>(col_int), 0);
-    CHECK_EQUAL(tv.get(1).get_linked_object(col_link).get<Int>(col_int), 1);
+    CHECK_EQUAL(tv.get_object(0).get_linked_object(col_link).get<Int>(col_int), 0);
+    CHECK_EQUAL(tv.get_object(1).get_linked_object(col_link).get<Int>(col_int), 1);
 }
 
 TEST(TableView_IsRowAttachedAfterClear)
@@ -2789,14 +2789,14 @@ TEST(TableView_RemoveColumnsAfterSort)
     table.create_object();
     table.remove_column(col_str0);
     auto tv = table.get_sorted_view(desc);
-    CHECK_EQUAL(tv.get(0).get<Int>(col_int), 9);
-    CHECK_EQUAL(tv.get(9).get<Int>(col_int), 0);
+    CHECK_EQUAL(tv.get_object(0).get<Int>(col_int), 9);
+    CHECK_EQUAL(tv.get_object(9).get<Int>(col_int), 0);
 
     table.remove_column(col_str1);
     table.create_object();
     tv.sync_if_needed();
-    CHECK_EQUAL(tv.get(0).get<Int>(col_int), 9);
-    CHECK_EQUAL(tv.get(10).get<Int>(col_int), 0);
+    CHECK_EQUAL(tv.get_object(0).get<Int>(col_int), 9);
+    CHECK_EQUAL(tv.get_object(10).get<Int>(col_int), 0);
 }
 
 TEST(TableView_TimestampMaxRemoveRow)

--- a/test/test_uuid.cpp
+++ b/test/test_uuid.cpp
@@ -578,7 +578,7 @@ TEST_TYPES(UUID_Query, WithIndex, WithoutIndex)
         CHECK_EQUAL(tv.size(), tv2.size());
         // check that sorting ascending vs descending is stable
         for (size_t i = 0; i < tv.size(); i++) {
-            CHECK_EQUAL(tv.get(i).get<UUID>(col), tv2.get(tv2.size() - i - 1).get<UUID>(col));
+            CHECK_EQUAL(tv.get_object(i).get<UUID>(col), tv2.get_object(tv2.size() - i - 1).get<UUID>(col));
         }
 
         Query q2 = table->column<UUID>(col_id) == uuid3;


### PR DESCRIPTION
The original implementation in ObjList uses two virtual methods to first find out if the key was valid and  - if it was - subsequently
find the object using that key. For tables, this can be done more efficiently by just trying to look up the object.

At the same time TableView::get() is removed. It is silly to have two names for the same function.