### PR TITLE
Expose bug where current_user is out of sync.

### DIFF
--- a/test/object-store/sync/app.cpp
+++ b/test/object-store/sync/app.cpp
@@ -2086,6 +2086,7 @@ TEST_CASE("app: sync integration", "[sync][app]") {
             });
             // the failed refresh logs out the user
             REQUIRE(!user->is_logged_in());
+            REQUIRE(!app->current_user()->is_logged_in());
         }
 
         SECTION("Requests that receive an error are retried on a backoff") {


### PR DESCRIPTION
Work-in-progress. Exposing, what seems like a problem with user handling in ObjecStore. This surfaces in case of Sync errors where it seems like we have multiple copies of the SyncUser object.