### PR TITLE
Add hang analyzer

### DIFF
--- a/evergreen/config.yml
+++ b/evergreen/config.yml
@@ -778,6 +778,7 @@ buildvariants:
   expansions:
     cmake_url: "https://s3.amazonaws.com/static.realm.io/evergreen-assets/cmake-3.20.3-linux-aarch64.tar.gz"
     cmake_bindir: "./cmake_binaries/bin"
+    python3: "/opt/mongodbtoolchain/v3/bin/python3"
     use_system_openssl: On
     fetch_missing_dependencies: On
   tasks:

--- a/evergreen/config.yml
+++ b/evergreen/config.yml
@@ -187,6 +187,20 @@ functions:
     params:
       file_location: realm-core/${task_name}_results.json
 
+  "run hang analyzer":
+  - command: shell.exec
+    params:
+      working_dir: realm-core
+      shell: bash
+      script: |-
+        set -o errexit
+        set -o verbose
+
+        python3 evergreen/hang_analyzer
+
+timeout:
+  - func: "run hang analyzer"
+
 tasks:
 - name: compile
   tags: [ "for_pull_requests" ]

--- a/evergreen/config.yml
+++ b/evergreen/config.yml
@@ -224,12 +224,6 @@ functions:
         fi
         python=python
 
-        if [ "Windows_NT" = "$OS" ]; then
-          export PYTHONPATH="$PYTHONPATH;$(cygpath -w ${workdir}/src)"
-        else
-          export PYTHONPATH="$PYTHONPATH:${workdir}/src"
-        fi
-
         echo "python set to $(which $python)"
 
         echo "Upgrading pip to 21.0.1"
@@ -242,11 +236,21 @@ functions:
 
         python -m pip --disable-pip-version-check install "pip==21.0.1" "wheel==0.37.0" || exit 1
 
-        python -m pip install -r $TOP_DIR/evergreen/hang_analyzer/requirements.txt || exit 1
+        REQUIREMENTS_PATH=$TOP_DIR/evergreen/hang_analyzer/requirements.txt
+        if [ "Windows_NT" = "$OS" ]; then
+          REQUIREMENTS_PATH=$(cygpath -w $REQUIREMENTS_PATH)
+        fi
+
+        python -m pip install -r $REQUIREMENTS_PATH || exit 1
 
         echo "Going to run hang analyzer"
 
-        python $TOP_DIR/evergreen/hang_analyzer
+        HANG_ANALYZER_PATH=$TOP_DIR/evergreen/hang_analyzer
+        if [ "Windows_NT" = "$OS" ]; then
+          HANG_ANALYZER_PATH=$(cygpath -w $HANG_ANALYZER_PATH)
+        fi
+
+        python $HANG_ANALYZER_PATH
 
 timeout:
   - func: "run hang analyzer"

--- a/evergreen/config.yml
+++ b/evergreen/config.yml
@@ -766,6 +766,7 @@ buildvariants:
     fetch_missing_dependencies: On
     curl: "/opt/mongodbtoolchain/v3/bin/curl"
     run_tests_against_baas: On
+    python3: "/opt/mongodbtoolchain/v3/bin/python3"
   tasks:
   - name: compile_test_and_package
     distros:

--- a/evergreen/config.yml
+++ b/evergreen/config.yml
@@ -202,7 +202,7 @@ functions:
         TOP_DIR=$(pwd)/realm-core
         mkdir realm-core/hang_analyzer_workdir; cd realm-core/hang_analyzer_workdir
         ${python3|python3} -m venv venv
-  
+
         # venv creates its Scripts/activate file with CLRF endings, which
         # cygwin bash does not like. dos2unix it
         # (See https://bugs.python.org/issue32451)

--- a/evergreen/config.yml
+++ b/evergreen/config.yml
@@ -426,7 +426,7 @@ tasks:
 
 - name: core-tests
   tags: [ "test_suite", "for_pull_requests" ]
-  exec_timeout_secs: 20
+  exec_timeout_secs: 1800
   commands:
   - func: "compile"
   - func: "run tests"

--- a/evergreen/config.yml
+++ b/evergreen/config.yml
@@ -190,13 +190,63 @@ functions:
   "run hang analyzer":
   - command: shell.exec
     params:
-      working_dir: realm-core
       shell: bash
       script: |-
         set -o errexit
         set -o verbose
 
-        python3 evergreen/hang_analyzer
+        if [[ ! -d realm-core ]]; then
+          echo "No source directory exists. Not running hang analyzer"
+        fi
+
+        TOP_DIR=$(pwd)/realm-core
+        mkdir realm-core/hang_analyzer_workdir; cd realm-core/hang_analyzer_workdir
+        ${python3|python3} -m venv venv
+  
+        # venv creates its Scripts/activate file with CLRF endings, which
+        # cygwin bash does not like. dos2unix it
+        # (See https://bugs.python.org/issue32451)
+        if [ "Windows_NT" = "$OS" ]; then
+          dos2unix "venv/Scripts/activate"
+        fi
+
+        export VIRTUAL_ENV_DISABLE_PROMPT=yes
+
+        if [ "Windows_NT" = "$OS" ]; then
+          # Need to quote the path on Windows to preserve the separator.
+          . "venv/Scripts/activate" 2> /tmp/activate_error.log
+        else
+          . venv/bin/activate 2> /tmp/activate_error.log
+        fi
+        if [ $? -ne 0 ]; then
+          echo "Failed to activate virtualenv: $(cat /tmp/activate_error.log)"
+          exit 1
+        fi
+        python=python
+
+        if [ "Windows_NT" = "$OS" ]; then
+          export PYTHONPATH="$PYTHONPATH;$(cygpath -w ${workdir}/src)"
+        else
+          export PYTHONPATH="$PYTHONPATH:${workdir}/src"
+        fi
+
+        echo "python set to $(which $python)"
+
+        echo "Upgrading pip to 21.0.1"
+
+        # ref: https://github.com/grpc/grpc/issues/25082#issuecomment-778392661
+        if [ "$(uname -m)" = "arm64" ] && [ "$(uname)" == "Darwin" ]; then
+          export GRPC_PYTHON_BUILD_SYSTEM_OPENSSL=1
+          export GRPC_PYTHON_BUILD_SYSTEM_ZLIB=1
+        fi
+
+        python -m pip --disable-pip-version-check install "pip==21.0.1" "wheel==0.37.0" || exit 1
+
+        python -m pip install -r $TOP_DIR/evergreen/hang_analyzer/requirements.txt || exit 1
+
+        echo "Going to run hang analyzer"
+
+        python $TOP_DIR/evergreen/hang_analyzer
 
 timeout:
   - func: "run hang analyzer"
@@ -372,7 +422,7 @@ tasks:
 
 - name: core-tests
   tags: [ "test_suite", "for_pull_requests" ]
-  exec_timeout_secs: 1800
+  exec_timeout_secs: 20
   commands:
   - func: "compile"
   - func: "run tests"
@@ -513,6 +563,8 @@ task_groups:
   - func: "fetch binaries"
   teardown_task:
   - func: "upload test results"
+  timeout:
+  - func: "run hang analyzer"
   tasks:
   - compile
   - .test_suite
@@ -528,6 +580,8 @@ task_groups:
   - func: "fetch binaries"
   teardown_task:
   - func: "upload test results"
+  timeout:
+  - func: "run hang analyzer"
   tasks:
   - compile
   - "!.disabled_on_windows .test_suite"
@@ -541,6 +595,8 @@ task_groups:
   - func: "fetch binaries"
   teardown_task:
   - func: "upload test results"
+  timeout:
+  - func: "run hang analyzer"
   tasks:
   - compile
   - "!.disabled_on_windows .test_suite"
@@ -553,6 +609,8 @@ task_groups:
   - func: "fetch binaries"
   teardown_task:
   - func: "upload test results"
+  timeout:
+  - func: "run hang analyzer"
   tasks:
   - compile
   - .test_suite
@@ -565,6 +623,8 @@ task_groups:
   - func: "fetch binaries"
   teardown_task:
   - func: "upload test results"
+  timeout:
+  - func: "run hang analyzer"
   tasks:
   - compile
   - object-store-tests
@@ -578,6 +638,8 @@ task_groups:
     vars:
       cmake_build_type: "Release"
       target_to_build: "benchmarks"
+  timeout:
+  - func: "run hang analyzer"
   tasks:
   - .benchmark
 
@@ -592,6 +654,8 @@ task_groups:
       target_to_build: CoreTests
   teardown_task:
   - func: "upload test results"
+  timeout:
+  - func: "run hang analyzer"
   tasks:
   - long-running-core-tests
 
@@ -810,6 +874,7 @@ buildvariants:
     max_jobs: $(($(grep -c proc /proc/cpuinfo) / 2))
     fetch_missing_dependencies: On
     build_zlib: On
+    python3: "/cygdrive/c/python/python37/python.exe"
   tasks:
   - name: compile_test_and_package_windows
     distros:
@@ -830,6 +895,7 @@ buildvariants:
     max_jobs: $(($(grep -c proc /proc/cpuinfo) / 2))
     fetch_missing_dependencies: On
     build_zlib: On
+    python3: "/cygdrive/c/python/python37/python.exe"
   tasks:
   - name: compile_test_windows
     distros:

--- a/evergreen/hang_analyzer/__main__.py
+++ b/evergreen/hang_analyzer/__main__.py
@@ -23,7 +23,7 @@ parser.add_option('-s', '--max-core-dumps-size', dest='max_core_dumps_size', def
                   help='Maximum total size of core dumps to keep in megabytes')
 parser.add_option(
     '-o', '--debugger-output', dest='debugger_output', action="append",
-    choices=['file', 'stdout'], default='stdout',
+    choices=['file', 'stdout'], default=['stdout'],
     help="If 'stdout', then the debugger's output is written to the Python"
     " process's stdout. If 'file', then the debugger's output is written"
     " to a file named debugger_<process>_<pid>.log for each process it"

--- a/evergreen/hang_analyzer/__main__.py
+++ b/evergreen/hang_analyzer/__main__.py
@@ -1,0 +1,39 @@
+from src.hang_analyzer import HangAnalyzer
+
+from optparse import OptionParser
+
+parser = OptionParser(description=__doc__)
+parser.add_option(
+    '-m', '--process-match', dest='process_match', choices=['contains', 'exact'],
+    default='contains', help="Type of match for process names (-p & -g), specify 'contains', or"
+    " 'exact'. Note that the process name match performs the following"
+    " conversions: change all process names to lowecase, strip off the file"
+    " extension, like '.exe' on Windows. Default is 'contains'.")
+parser.add_option('-p', '--process-names', dest='process_names',
+                  help='Comma separated list of process names to analyze')
+parser.add_option('-g', '--go-process-names', dest='go_process_names',
+                  help='Comma separated list of go process names to analyze')
+parser.add_option(
+    '-d', '--process-ids', dest='process_ids', default=None,
+    help='Comma separated list of process ids (PID) to analyze, overrides -p &'
+    ' -g')
+parser.add_option('-c', '--dump-core', dest='dump_core', action="store_true", default=False,
+                  help='Dump core file for each analyzed process')
+parser.add_option('-s', '--max-core-dumps-size', dest='max_core_dumps_size', default=10000,
+                  help='Maximum total size of core dumps to keep in megabytes')
+parser.add_option(
+    '-o', '--debugger-output', dest='debugger_output', action="append",
+    choices=['file', 'stdout'], default='stdout',
+    help="If 'stdout', then the debugger's output is written to the Python"
+    " process's stdout. If 'file', then the debugger's output is written"
+    " to a file named debugger_<process>_<pid>.log for each process it"
+    " attaches to. This option can be specified multiple times on the"
+    " command line to have the debugger's output written to multiple"
+    " locations. By default, the debugger's output is written only to the"
+    " Python process's stdout.")
+
+(options, _) = parser.parse_args()
+
+print("going to analyze")
+analyzer = HangAnalyzer(options)
+analyzer.execute()

--- a/evergreen/hang_analyzer/requirements.txt
+++ b/evergreen/hang_analyzer/requirements.txt
@@ -1,0 +1,3 @@
+pypiwin32==223; sys_platform == "win32" and python_version > "3"
+pywin32==225; sys_platform == "win32" and python_version > "3"
+distro == 1.5.0

--- a/evergreen/hang_analyzer/src/dumper.py
+++ b/evergreen/hang_analyzer/src/dumper.py
@@ -229,24 +229,6 @@ class GDBDumper(Dumper):
 
         process.call([dbg, "--version"], logger)
 
-        script_dir = "buildscripts"
-        root_logger.info("dir %s", script_dir)
-
-        if not logger.mongo_process_filename:
-            raw_stacks_commands = []
-        else:
-            base, ext = os.path.splitext(logger.mongo_process_filename)
-            raw_stacks_filename = base + '_raw_stacks' + ext
-            raw_stacks_commands = [
-                'echo \\nWriting raw stacks to %s.\\n' % raw_stacks_filename,
-                # This sends output to log file rather than stdout until we turn logging off.
-                'set logging redirect on',
-                'set logging file ' + raw_stacks_filename,
-                'set logging on',
-                'thread apply all bt',
-                'set logging off',
-            ]
-
         cmds = [
             "set interactive-mode off",
             "set print thread-events off",  # Suppress GDB messages of threads starting/finishing.
@@ -254,7 +236,7 @@ class GDBDumper(Dumper):
             "info sharedlibrary",
             "info threads",  # Dump a simple list of commands to get the thread name
             "set python print-stack full",
-        ] + raw_stacks_commands + [
+            "thread apply all bt",
             # Lock the scheduler, before running commands, which execute code in the attached process.
             "set scheduler-locking on",
             dump_command,

--- a/evergreen/hang_analyzer/src/dumper.py
+++ b/evergreen/hang_analyzer/src/dumper.py
@@ -1,0 +1,283 @@
+"""Tools to dump debug info for each OS."""
+
+import os
+import sys
+import tempfile
+import itertools
+from distutils import spawn  # pylint: disable=no-name-in-module
+from collections import namedtuple
+
+from . import process
+
+Dumpers = namedtuple('Dumpers', ['dbg'])
+
+
+def get_dumpers():
+    """Return OS-appropriate dumpers."""
+
+    dbg = None
+    jstack = None
+    if sys.platform.startswith("linux"):
+        dbg = GDBDumper()
+    elif sys.platform == "win32" or sys.platform == "cygwin":
+        dbg = WindowsDumper()
+    elif sys.platform == "darwin":
+        dbg = LLDBDumper()
+
+    return Dumpers(dbg=dbg)
+
+
+class Dumper(object):
+    """Abstract base class for OS-specific dumpers."""
+
+    def dump_info(  # pylint: disable=too-many-arguments,too-many-locals
+            self, root_logger, logger, pinfo, take_dump):
+        """
+        Perform dump for a process.
+        :param root_logger: Top-level logger
+        :param logger: Logger to output dump info to
+        :param pinfo: A Pinfo describing the process
+        :param take_dump: Whether to take a core dump
+        """
+        raise NotImplementedError("dump_info must be implemented in OS-specific subclasses")
+
+    @staticmethod
+    def get_dump_ext():
+        """Return the dump file extension."""
+        raise NotImplementedError("get_dump_ext must be implemented in OS-specific subclasses")
+
+
+class WindowsDumper(Dumper):
+    """WindowsDumper class."""
+
+    @staticmethod
+    def __find_debugger(logger, debugger):
+        """Find the installed debugger."""
+        # We are looking for c:\Program Files (x86)\Windows Kits\8.1\Debuggers\x64
+        cdb = spawn.find_executable(debugger)
+        if cdb is not None:
+            return cdb
+        from win32com.shell import shell, shellcon
+
+        # Cygwin via sshd does not expose the normal environment variables
+        # Use the shell api to get the variable instead
+        root_dir = shell.SHGetFolderPath(0, shellcon.CSIDL_PROGRAM_FILESX86, None, 0)
+
+        # Construct the debugger search paths in most-recent order
+        debugger_paths = [os.path.join(root_dir, "Windows Kits", "10", "Debuggers", "x64")]
+        for idx in reversed(range(0, 2)):
+            debugger_paths.append(
+                os.path.join(root_dir, "Windows Kits", "8." + str(idx), "Debuggers", "x64"))
+
+        for dbg_path in debugger_paths:
+            logger.info("Checking for debugger in %s", dbg_path)
+            if os.path.exists(dbg_path):
+                return os.path.join(dbg_path, debugger)
+
+        return None
+
+    def dump_info(  # pylint: disable=too-many-arguments
+            self, root_logger, logger, pinfo, take_dump):
+        """Dump useful information to the console."""
+        debugger = "cdb.exe"
+        dbg = self.__find_debugger(root_logger, debugger)
+
+        if dbg is None:
+            root_logger.warning("Debugger %s not found, skipping dumping of %d", debugger,
+                                pinfo.pid)
+            return
+
+        root_logger.info("Debugger %s, analyzing %s process with PID %d", dbg, pinfo.name,
+                         pinfo.pid)
+
+        dump_command = ""
+        if take_dump:
+            # Dump to file, dump_<process name>.<pid>.mdmp
+            dump_file = "dump_%s.%d.%s" % (os.path.splitext(pinfo.name)[0], pinfo.pid,
+                                           self.get_dump_ext())
+            dump_command = ".dump /ma %s" % dump_file
+            root_logger.info("Dumping core to %s", dump_file)
+
+        cmds = [
+            ".symfix",  # Fixup symbol path
+            ".symopt +0x10",  # Enable line loading (off by default in CDB, on by default in WinDBG)
+            ".reload",  # Reload symbols
+            "!peb",  # Dump current exe, & environment variables
+            "lm",  # Dump loaded modules
+            dump_command,
+            "!uniqstack -pn",  # Dump All unique Threads with function arguments
+            "!cs -l",  # Dump all locked critical sections
+            ".detach",  # Detach
+            "q"  # Quit
+        ]
+
+        process.call([dbg, '-c', ";".join(cmds), '-p', str(pinfo.pid)], logger)
+
+        root_logger.info("Done analyzing %s process with PID %d", pinfo.name, pinfo.pid)
+
+    @staticmethod
+    def get_dump_ext():
+        """Return the dump file extension."""
+        return "mdmp"
+
+
+# LLDB dumper is for MacOS X
+class LLDBDumper(Dumper):
+    """LLDBDumper class."""
+
+    @staticmethod
+    def __find_debugger(debugger):
+        """Find the installed debugger."""
+        return process.find_program(debugger, ['/usr/bin'])
+
+    def dump_info(  # pylint: disable=too-many-arguments,too-many-locals
+            self, root_logger, logger, pinfo, take_dump):
+        """Dump info."""
+        debugger = "lldb"
+        dbg = self.__find_debugger(debugger)
+
+        if dbg is None:
+            root_logger.warning("Debugger %s not found, skipping dumping of %d", debugger,
+                                pinfo.pid)
+            return
+
+        root_logger.info("Debugger %s, analyzing %s process with PID %d", dbg, pinfo.name,
+                         pinfo.pid)
+
+        lldb_version = process.callo([dbg, "--version"], logger)
+
+        logger.info(lldb_version)
+
+        # Do we have the XCode or LLVM version of lldb?
+        # Old versions of lldb do not work well when taking commands via a file
+        # XCode (7.2): lldb-340.4.119
+        # LLVM - lldb version 3.7.0 ( revision )
+
+        if 'version' not in lldb_version:
+            # We have XCode's lldb
+            lldb_version = lldb_version[lldb_version.index("lldb-"):]
+            lldb_version = lldb_version.replace('lldb-', '')
+            lldb_major_version = int(lldb_version[:lldb_version.index('.')])
+            if lldb_major_version < 340:
+                logger.warning("Debugger lldb is too old, please upgrade to XCode 7.2")
+                return
+
+        dump_command = ""
+        if take_dump:
+            # Dump to file, dump_<process name>.<pid>.core
+            dump_file = "dump_%s.%d.%s" % (pinfo.name, pinfo.pid, self.get_dump_ext())
+            dump_command = "process save-core %s" % dump_file
+            root_logger.info("Dumping core to %s", dump_file)
+
+        cmds = [
+            "attach -p %d" % pinfo.pid,
+            "target modules list",
+            "thread backtrace all",
+            dump_command,
+            "settings set interpreter.prompt-on-quit false",
+            "quit",
+        ]
+
+        tf = tempfile.NamedTemporaryFile(mode='w', encoding='utf-8')
+
+        for cmd in cmds:
+            tf.write(cmd + "\n")
+
+        tf.flush()
+
+        # Works on in MacOS 10.9 & later
+        #call([dbg] +  list( itertools.chain.from_iterable([['-o', b] for b in cmds])), logger)
+        process.call(['cat', tf.name], logger)
+        process.call([dbg, '--source', tf.name], logger)
+
+        root_logger.info("Done analyzing %s process with PID %d", pinfo.name, pinfo.pid)
+
+    @staticmethod
+    def get_dump_ext():
+        """Return the dump file extension."""
+        return "core"
+
+
+# GDB dumper is for Linux
+class GDBDumper(Dumper):
+    """GDBDumper class."""
+
+    @staticmethod
+    def __find_debugger(debugger):
+        """Find the installed debugger."""
+        return process.find_program(debugger, ['/opt/mongodbtoolchain/gdb/bin', '/usr/bin'])
+
+    def dump_info(  # pylint: disable=too-many-arguments,too-many-locals
+            self, root_logger, logger, pinfo, take_dump):
+        """Dump info."""
+        debugger = "gdb"
+        dbg = self.__find_debugger(debugger)
+
+        if dbg is None:
+            logger.warning("Debugger %s not found, skipping dumping of %d", debugger, pinfo.pid)
+            return
+
+        root_logger.info("Debugger %s, analyzing %s process with PID %d", dbg, pinfo.name,
+                         pinfo.pid)
+
+        dump_command = ""
+        if take_dump:
+            # Dump to file, dump_<process name>.<pid>.core
+            dump_file = "dump_%s.%d.%s" % (pinfo.name, pinfo.pid, self.get_dump_ext())
+            dump_command = "gcore %s" % dump_file
+            root_logger.info("Dumping core to %s", dump_file)
+
+        process.call([dbg, "--version"], logger)
+
+        script_dir = "buildscripts"
+        root_logger.info("dir %s", script_dir)
+
+        if not logger.mongo_process_filename:
+            raw_stacks_commands = []
+        else:
+            base, ext = os.path.splitext(logger.mongo_process_filename)
+            raw_stacks_filename = base + '_raw_stacks' + ext
+            raw_stacks_commands = [
+                'echo \\nWriting raw stacks to %s.\\n' % raw_stacks_filename,
+                # This sends output to log file rather than stdout until we turn logging off.
+                'set logging redirect on',
+                'set logging file ' + raw_stacks_filename,
+                'set logging on',
+                'thread apply all bt',
+                'set logging off',
+            ]
+
+        cmds = [
+            "set interactive-mode off",
+            "set print thread-events off",  # Suppress GDB messages of threads starting/finishing.
+            "attach %d" % pinfo.pid,
+            "info sharedlibrary",
+            "info threads",  # Dump a simple list of commands to get the thread name
+            "set python print-stack full",
+        ] + raw_stacks_commands + [
+            # Lock the scheduler, before running commands, which execute code in the attached process.
+            "set scheduler-locking on",
+            dump_command,
+            "set confirm off",
+            "quit",
+        ]
+
+        process.call([dbg, "--quiet", "--nx"] + list(
+            itertools.chain.from_iterable([['-ex', b] for b in cmds])), logger)
+
+        root_logger.info("Done analyzing %s process with PID %d", pinfo.name, pinfo.pid)
+
+    @staticmethod
+    def get_dump_ext():
+        """Return the dump file extension."""
+        return "core"
+
+    @staticmethod
+    def _find_gcore():
+        """Find the installed gcore."""
+        dbg = "/usr/bin/gcore"
+        if os.path.exists(dbg):
+            return dbg
+
+        return None
+

--- a/evergreen/hang_analyzer/src/hang_analyzer.py
+++ b/evergreen/hang_analyzer/src/hang_analyzer.py
@@ -31,7 +31,7 @@ class HangAnalyzer(object):
         self.options = options
         self.root_logger = None
         self.interesting_processes = [
-            "mongod", "-tests", 
+            "mongod", "-tests",
         ]
         self.go_processes = []
         self.process_ids = []

--- a/evergreen/hang_analyzer/src/hang_analyzer.py
+++ b/evergreen/hang_analyzer/src/hang_analyzer.py
@@ -15,7 +15,6 @@ import signal
 import logging
 import platform
 import traceback
-from distro import linux_distribution
 
 from . import dumper
 from . import process_list
@@ -64,7 +63,6 @@ class HangAnalyzer(object):
 
         # Dump all processes, except python & java.
         for pinfo in [pinfo for pinfo in processes if not re.match("^(java|python)", pinfo.name)]:
-            print("going to dump {}", pinfo.name)
             process_logger = self._get_process_logger(pinfo)
             try:
                 dumpers.dbg.dump_info(
@@ -121,12 +119,15 @@ class HangAnalyzer(object):
             if sys.platform == "win32" or sys.platform == "cygwin":
                 distro = platform.win32_ver()
                 self.root_logger.info("Windows Distribution: %s", distro)
-            else:
+            elif sys.platform == "linux":
+                from distro import linux_distribution
                 distro = linux_distribution()
                 self.root_logger.info("Linux Distribution: %s", distro)
-
-        except AttributeError:
-            self.root_logger.warning("Cannot determine Linux distro since Python is too old")
+            elif sys.platform == "darwin":
+                mac_ver, _, mac_arch = platform.mac_ver()
+                self.root_logger.info("MacOS version: %s Architecture: %s", mac_ver, mac_arch)
+        except ImportError:
+            self.root_logger.warning("Cannot determine Linux distro without distro pip package")
 
         try:
             uid = os.getuid()

--- a/evergreen/hang_analyzer/src/hang_analyzer.py
+++ b/evergreen/hang_analyzer/src/hang_analyzer.py
@@ -1,0 +1,172 @@
+"""Hang Analyzer module.
+A prototype hang analyzer for Evergreen integration to help investigate test timeouts
+1. Script supports taking dumps, and/or dumping a summary of useful information about a process
+2. Script will iterate through a list of interesting processes,
+    and run the tools from step 1. The list of processes can be provided as an option.
+3. Java processes will be dumped using jstack, if available.
+Supports Linux, MacOS X, and Windows.
+"""
+
+import re
+import os
+import sys
+import glob
+import signal
+import logging
+import platform
+import traceback
+from distro import linux_distribution
+
+from . import dumper
+from . import process_list
+from . import process
+
+class HangAnalyzer(object):
+    """Main class for the hang analyzer subcommand."""
+
+    def __init__(self, options):
+        """
+        Configure processe lists based on options.
+        :param options: Options as parsed by parser.py
+        """
+        self.options = options
+        self.root_logger = None
+        self.interesting_processes = [
+            "mongod", "-tests", 
+        ]
+        self.go_processes = []
+        self.process_ids = []
+
+        self._configure_processes()
+
+    def execute(self):  # pylint: disable=too-many-branches,too-many-locals,too-many-statements
+        """
+        Execute hang analysis.
+        1. Get a list of interesting processes
+        2. Dump useful information or take core dumps
+        """
+        self._setup_logging()
+        self._log_system_info()
+
+        dumpers = dumper.get_dumpers()
+
+        processes = process_list.get_processes(self.process_ids, self.interesting_processes,
+                                               self.options.process_match, self.root_logger)
+
+        max_dump_size_bytes = int(self.options.max_core_dumps_size) * 1024 * 1024
+
+        # Dump python processes by signalling them. The resmoke.py process will generate
+        # the report.json, when signalled, so we do this before attaching to other processes.
+        for pinfo in [pinfo for pinfo in processes if pinfo.name.startswith("python")]:
+            process.signal_python(self.root_logger, pinfo)
+
+        trapped_exceptions = []
+
+        # Dump all processes, except python & java.
+        for pinfo in [pinfo for pinfo in processes if not re.match("^(java|python)", pinfo.name)]:
+            print("going to dump {}", pinfo.name)
+            process_logger = self._get_process_logger(pinfo)
+            try:
+                dumpers.dbg.dump_info(
+                    self.root_logger, process_logger, pinfo, self.options.dump_core
+                    and _check_dump_quota(max_dump_size_bytes, dumpers.dbg.get_dump_ext()))
+            except Exception as err:  # pylint: disable=broad-except
+                self.root_logger.info("Error encountered when invoking debugger %s", err)
+                trapped_exceptions.append(traceback.format_exc())
+
+        # Signal go processes to ensure they print out stack traces, and die on POSIX OSes.
+        # On Windows, this will simply kill the process since python emulates SIGABRT as
+        # TerminateProcess.
+        # Note: The stacktrace output may be captured elsewhere (i.e. resmoke).
+        for pinfo in [pinfo for pinfo in processes if pinfo.name in self.go_processes]:
+            self.root_logger.info("Sending signal SIGABRT to go process %s with PID %d", pinfo.name,
+                                  pinfo.pid)
+            process.signal_process(self.root_logger, pinfo.pid, signal.SIGABRT)
+
+        self.root_logger.info("Done analyzing all processes for hangs")
+
+        for exception in trapped_exceptions:
+            self.root_logger.info(exception)
+        if trapped_exceptions:
+            raise RuntimeError(
+                "Exceptions were thrown while dumping. There may still be some valid dumps.")
+
+    def _configure_processes(self):
+        if self.options.debugger_output is None:
+            self.options.debugger_output = ['stdout']
+
+        if self.options.process_ids is not None:
+            # self.process_ids is an int list of PIDs
+            self.process_ids = [int(pid) for pid in self.options.process_ids.split(',')]
+
+        if self.options.process_names is not None:
+            self.interesting_processes = self.options.process_names.split(',')
+
+        if self.options.go_process_names is not None:
+            self.go_processes = self.options.go_process_names.split(',')
+            self.interesting_processes += self.go_processes
+
+    def _setup_logging(self):
+        self.root_logger = logging.Logger("hang_analyzer", level=logging.DEBUG)
+
+        handler = logging.StreamHandler(sys.stdout)
+        handler.setFormatter(logging.Formatter(fmt="%(message)s"))
+        self.root_logger.addHandler(handler)
+
+        self.root_logger.info("Python Version: %s", sys.version)
+        self.root_logger.info("OS: %s", platform.platform())
+
+    def _log_system_info(self):
+        try:
+            if sys.platform == "win32" or sys.platform == "cygwin":
+                distro = platform.win32_ver()
+                self.root_logger.info("Windows Distribution: %s", distro)
+            else:
+                distro = linux_distribution()
+                self.root_logger.info("Linux Distribution: %s", distro)
+
+        except AttributeError:
+            self.root_logger.warning("Cannot determine Linux distro since Python is too old")
+
+        try:
+            uid = os.getuid()
+            self.root_logger.info("Current User: %s", uid)
+            current_login = os.getlogin()
+            self.root_logger.info("Current Login: %s", current_login)
+        except OSError:
+            self.root_logger.warning("Cannot determine Unix Current Login")
+        except AttributeError:
+            self.root_logger.warning(
+                "Cannot determine Unix Current Login, not supported on Windows")
+
+    def _get_process_logger(self, pinfo):
+        """Return the process logger from options specified."""
+        process_logger = logging.Logger("process", level=logging.DEBUG)
+        #process_logger.mongo_process_filename = None
+
+        if 'stdout' in self.options.debugger_output:
+            s_handler = logging.StreamHandler(sys.stdout)
+            s_handler.setFormatter(logging.Formatter(fmt="%(message)s"))
+            process_logger.addHandler(s_handler)
+
+        if 'file' in self.options.debugger_output:
+            filename = "debugger_%s_%d.log" % (os.path.splitext(pinfo.name)[0], pinfo.pid)
+            #process_logger.mongo_process_filename = filename
+            f_handler = logging.FileHandler(filename=filename, mode="w")
+            f_handler.setFormatter(logging.Formatter(fmt="%(message)s"))
+            process_logger.addHandler(f_handler)
+
+        return process_logger
+
+
+def _check_dump_quota(quota, ext):
+    """Check if sum of the files with ext is within the specified quota in megabytes."""
+
+    files = glob.glob("*." + ext)
+
+    size_sum = 0
+    for file_name in files:
+        size_sum += os.path.getsize(file_name)
+
+    return size_sum <= quota
+

--- a/evergreen/hang_analyzer/src/pipe.py
+++ b/evergreen/hang_analyzer/src/pipe.py
@@ -1,0 +1,86 @@
+"""
+Helper class to read output of a subprocess.
+Used to avoid deadlocks from the pipe buffer filling up and blocking the subprocess while it's
+being waited on.
+"""
+
+import threading
+
+
+class LoggerPipe(threading.Thread):  # pylint: disable=too-many-instance-attributes
+    """Asynchronously reads the output of a subprocess and sends it to a logger."""
+
+    # The start() and join() methods are not intended to be called directly on the LoggerPipe
+    # instance. Since we override them for that effect, the super's version are preserved here.
+    __start = threading.Thread.start
+    __join = threading.Thread.join
+
+    def __init__(self, logger, level, pipe_out):
+        """Initialize the LoggerPipe with the specified arguments."""
+
+        threading.Thread.__init__(self)
+        # Main thread should not call join() when exiting
+        self.daemon = True
+
+        self.__logger = logger
+        self.__level = level
+        self.__pipe_out = pipe_out
+
+        self.__lock = threading.Lock()
+        self.__condition = threading.Condition(self.__lock)
+
+        self.__started = False
+        self.__finished = False
+
+        LoggerPipe.__start(self)
+
+    def start(self):
+        """Start not implemented."""
+        raise NotImplementedError("start should not be called directly")
+
+    def run(self):
+        """Read the output from 'pipe_out' and logs each line to 'logger'."""
+
+        with self.__lock:
+            self.__started = True
+            self.__condition.notify_all()
+
+        # Close the pipe when finished reading all of the output.
+        with self.__pipe_out:
+            # Avoid buffering the output from the pipe.
+            for line in iter(self.__pipe_out.readline, b""):
+                # Replace null bytes in the output of the subprocess with a literal backslash ('\')
+                # followed by a literal zero ('0') so tools like grep don't treat resmoke.py's
+                # output as binary data.
+                line = line.replace(b"\0", b"\\0")
+
+                # Convert the output of the process from a bytestring to a UTF-8 string, and replace
+                # any characters that cannot be decoded with the official Unicode replacement
+                # character, U+FFFD. The log messages of MongoDB processes are not always valid
+                # UTF-8 sequences. See SERVER-7506.
+                line = line.decode("utf-8", "replace")
+                self.__logger.log(self.__level, line.rstrip())
+
+        with self.__lock:
+            self.__finished = True
+            self.__condition.notify_all()
+
+    def join(self, timeout=None):
+        """Join not implemented."""
+        raise NotImplementedError("join should not be called directly")
+
+    def wait_until_started(self):
+        """Wait until started."""
+        with self.__lock:
+            while not self.__started:
+                self.__condition.wait()
+
+    def wait_until_finished(self):
+        """Wait until finished."""
+        with self.__lock:
+            while not self.__finished:
+                self.__condition.wait()
+
+        # No need to pass a timeout to join() because the thread should already be done after
+        # notifying us it has finished reading output from the pipe.
+        LoggerPipe.__join(self)  # Tidy up the started thread.

--- a/evergreen/hang_analyzer/src/process.py
+++ b/evergreen/hang_analyzer/src/process.py
@@ -1,0 +1,109 @@
+"""Miscellaneous utility functions used by the hang analyzer."""
+
+import os
+import sys
+import time
+import signal
+import logging
+import subprocess
+from distutils import spawn  # pylint: disable=no-name-in-module
+
+from . import pipe
+
+_IS_WINDOWS = (sys.platform == "win32")
+
+if _IS_WINDOWS:
+    import win32event
+    import win32api
+
+
+def call(args, logger):
+    """Call subprocess on args list."""
+    logger.info(str(args))
+
+    # Use a common pipe for stdout & stderr for logging.
+    process = subprocess.Popen(args, stdout=subprocess.PIPE, stderr=subprocess.STDOUT)
+    logger_pipe = pipe.LoggerPipe(logger, logging.INFO, process.stdout)
+    logger_pipe.wait_until_started()
+
+    ret = process.wait()
+    logger_pipe.wait_until_finished()
+
+    if ret != 0:
+        logger.error("Bad exit code %d", ret)
+        raise Exception("Bad exit code %d from %s" % (ret, " ".join(args)))
+
+
+def find_program(prog, paths):
+    """Find the specified program in env PATH, or tries a set of paths."""
+    loc = spawn.find_executable(prog)
+
+    if loc is not None:
+        return loc
+
+    for loc in paths:
+        full_prog = os.path.join(loc, prog)
+        if os.path.exists(full_prog):
+            return full_prog
+
+    return None
+
+
+def callo(args, logger):
+    """Call subprocess on args string."""
+    logger.info("%s", str(args))
+    return subprocess.check_output(args).decode('utf-8', 'replace')
+
+
+def signal_python(logger, pinfo):
+    """Send appropriate dumping signal to python processes."""
+
+    # On Windows, we set up an event object to wait on a signal. For Cygwin, we register
+    # a signal handler to wait for the signal since it supports POSIX signals.
+    if _IS_WINDOWS:
+        logger.info("Calling SetEvent to signal python process %s with PID %d", pinfo.name,
+                    pinfo.pid)
+        signal_event_object(logger, pinfo.pid)
+    else:
+        logger.info("Sending signal SIGUSR1 to python process %s with PID %d", pinfo.name,
+                    pinfo.pid)
+        signal_process(logger, pinfo.pid, signal.SIGUSR1)
+
+
+def signal_event_object(logger, pid):
+    """Signal the Windows event object."""
+
+    # Use unique event_name created.
+    event_name = "Global\\Mongo_Python_" + str(pid)
+
+    try:
+        desired_access = win32event.EVENT_MODIFY_STATE
+        inherit_handle = False
+        task_timeout_handle = win32event.OpenEvent(desired_access, inherit_handle, event_name)
+    except win32event.error as err:
+        logger.info("Exception from win32event.OpenEvent with error: %s", err)
+        return
+
+    try:
+        win32event.SetEvent(task_timeout_handle)
+    except win32event.error as err:
+        logger.info("Exception from win32event.SetEvent with error: %s", err)
+    finally:
+        win32api.CloseHandle(task_timeout_handle)
+
+    logger.info("Waiting for process to report")
+    time.sleep(5)
+
+
+def signal_process(logger, pid, signalnum):
+    """Signal process with signal, N/A on Windows."""
+    try:
+        os.kill(pid, signalnum)
+
+        logger.info("Waiting for process to report")
+        time.sleep(5)
+    except OSError as err:
+        logger.error("Hit OS error trying to signal process: %s", err)
+
+    except AttributeError:
+        logger.error("Cannot send signal to a process on Windows")

--- a/evergreen/hang_analyzer/src/process_list.py
+++ b/evergreen/hang_analyzer/src/process_list.py
@@ -1,0 +1,154 @@
+"""Functions to list processes in each OS and search for interesting processes."""
+
+import os
+import io
+import sys
+import csv
+from collections import namedtuple
+
+from . process import call, callo, find_program
+
+Pinfo = namedtuple('Pinfo', ['pid', 'name'])
+
+
+def get_processes(process_ids, interesting_processes, process_match, logger):
+    """
+    Find all running interesting processes.
+    If a list of process_ids is supplied, match on that.
+    Otherwise, do a substring match on interesting_processes.
+    :param process_ids: List of PIDs to match on.
+    :param interesting_processes: List of process names to match on.
+    :param process_match: String describing the process match to use.
+    :param logger: Where to log output.
+    :return: A list Pinfo objects for matched processes.
+    """
+    ps = _get_lister()
+
+    all_processes = ps.dump_processes(logger)
+
+    # Canonicalize the process names to lowercase to handle cases where the name of the Python
+    # process is /System/Library/.../Python on OS X and -p python is specified to the hang analyzer.
+    all_processes = [(pid, process_name.lower()) for (pid, process_name) in all_processes]
+
+    if process_ids:
+        processes = [
+            Pinfo(pid=pid, name=pname) for (pid, pname) in all_processes
+            if pid in process_ids and pid != os.getpid()
+        ]
+
+        running_pids = {pid for (pid, pname) in all_processes}
+        missing_pids = set(process_ids) - running_pids
+        if missing_pids:
+            logger.warning("The following requested process ids are not running %s",
+                           list(missing_pids))
+    else:
+        processes = [
+            Pinfo(pid=pid, name=pname) for (pid, pname) in all_processes
+            if _pname_match(process_match, pname, interesting_processes) and pid != os.getpid()
+        ]
+
+    logger.info("Found %d interesting processes %s", len(processes), processes)
+    return processes
+
+
+def _get_lister():
+    """Return _ProcessList object for OS."""
+    if sys.platform.startswith("linux"):
+        ps = _LinuxProcessList()
+    elif sys.platform == "win32" or sys.platform == "cygwin":
+        ps = _WindowsProcessList()
+    elif sys.platform == "darwin":
+        ps = _DarwinProcessList()
+    else:
+        raise OSError("Hang analyzer: Unsupported platform: {}".format(sys.platform))
+
+    return ps
+
+
+class _ProcessList(object):
+    """Abstract base class for all process listers."""
+
+    def dump_processes(self, logger):
+        """
+        Find all processes.
+        :param logger: Where to log output.
+        :return: A list of process names.
+        """
+        raise NotImplementedError("dump_process must be implemented in OS-specific subclasses")
+
+
+class _WindowsProcessList(_ProcessList):
+    """_WindowsProcessList class."""
+
+    @staticmethod
+    def __find_ps():
+        """Find tasklist."""
+        return os.path.join(os.environ["WINDIR"], "system32", "tasklist.exe")
+
+    def dump_processes(self, logger):
+        """Get list of [Pid, Process Name]."""
+        ps = self.__find_ps()
+
+        logger.info("Getting list of processes using %s", ps)
+
+        ret = callo([ps, "/FO", "CSV"], logger)
+
+        buff = io.StringIO(ret)
+        csv_reader = csv.reader(buff)
+
+        return [[int(row[1]), row[0]] for row in csv_reader if row[1] != "PID"]
+
+
+class _DarwinProcessList(_ProcessList):
+    """_DarwinProcessList class."""
+
+    @staticmethod
+    def __find_ps():
+        """Find ps."""
+        return find_program('ps', ['/bin'])
+
+    def dump_processes(self, logger):
+        """Get list of [Pid, Process Name]."""
+        ps = self.__find_ps()
+
+        logger.info("Getting list of processes using %s", ps)
+
+        ret = callo([ps, "-axco", "pid,comm"], logger)
+
+        buff = io.StringIO(ret)
+        csv_reader = csv.reader(buff, delimiter=' ', quoting=csv.QUOTE_NONE, skipinitialspace=True)
+
+        return [[int(row[0]), row[1]] for row in csv_reader if row[0] != "PID"]
+
+
+class _LinuxProcessList(_ProcessList):
+    """_LinuxProcessList class."""
+
+    @staticmethod
+    def __find_ps():
+        """Find ps."""
+        return find_program('ps', ['/bin', '/usr/bin'])
+
+    def dump_processes(self, logger):
+        """Get list of [Pid, Process Name]."""
+        ps = self.__find_ps()
+
+        logger.info("Getting list of processes using %s", ps)
+
+        call([ps, "--version"], logger)
+
+        ret = callo([ps, "-eo", "pid,args"], logger)
+
+        buff = io.StringIO(ret)
+        csv_reader = csv.reader(buff, delimiter=' ', quoting=csv.QUOTE_NONE, skipinitialspace=True)
+
+        return [[int(row[0]), os.path.split(row[1])[1]] for row in csv_reader if row[0] != "PID"]
+
+
+def _pname_match(match_type, pname, interesting_processes):
+    """Return True if the pname matches an interesting_processes."""
+    pname = os.path.splitext(pname)[0]
+    for ip in interesting_processes:
+        if match_type == 'exact' and pname == ip or match_type == 'contains' and ip in pname:
+            return True
+    return False


### PR DESCRIPTION
## What, How & Why?
This ports over the hang analyzer from the mongodb server's codebase and evergreen config. If a test times out in evergreen, the hang analyzer will attach to it via the local debugger (gdb, lldb, or windbg) and print a stacktrace for all the threads as well as other helpful info like what shared libraries were loaded and what critical sections were locked.

Most of this change is porting over the python code from https://github.com/mongodb/mongo/tree/master/buildscripts/resmokelib/hang_analyzer so that it works without all the resmoke infrastructure used in the server.

This is not an urgent PR, but I think it would be a nice quality of life improvement for timed out tests.

For an example of the output, can you check out this evergreen patch that forces the core tests to time out after only 20 seconds: https://spruce.mongodb.com/version/61bcea74c9ec443c5b7e641b/tasks

The hang analyzer also knows to to generate a core dump for the processes it attaches to that we can store in s3 for later analysis if that would be helpful for folks. For now though, I'm just having it drop its output into the evergreen logs.

## ☑️ ToDos
* ~[ ] 📝 Changelog update~ this change is entirely internal to the CI configuration
* ~[ ] 🚦 Tests (or not relevant)~
