### PR TITLE
Filter out embedded orphan types earlier in the schema update process

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@
 * The release package was missing several headers (since 11.7.0).
 * The sync client will now drain the receive queue when send fails with ECONNRESET - ensuring that any error message from the server gets received and processed. ([#5078](https://github.com/realm/realm-core/pull/5078))
 * Schema validation was missing for embedded objects in sets, resulting in an unhelpful error being thrown if the user attempted to define one.
+* Opening a Realm with a schema that has an orphaned embedded object type performed an extra empty write transaction (since v11.0.0).
+* Freezing a Realm with a schema that has orphaned embeeded object types threw a "Wrong transactional state" exception (since v11.5.0).
 
 ### Breaking changes
 * None.

--- a/src/realm/object-store/object_store.cpp
+++ b/src/realm/object-store/object_store.cpp
@@ -643,55 +643,42 @@ static void create_initial_tables(Group& group, std::vector<SchemaChange> const&
     }
 }
 
-void ObjectStore::apply_additive_changes(Group& group, std::vector<SchemaChange> const& changes, bool update_indexes,
-                                         std::unordered_set<std::string>&& ignore_types)
+void ObjectStore::apply_additive_changes(Group& group, std::vector<SchemaChange> const& changes, bool update_indexes)
 {
     using namespace schema_change;
     struct Applier {
-        Applier(Group& group, bool update_indexes, std::unordered_set<std::string>&& ignore_types)
+        Applier(Group& group, bool update_indexes)
             : group{group}
             , table{group}
             , update_indexes{update_indexes}
-            , ignored_types{std::move(ignore_types)}
         {
         }
         Group& group;
         TableHelper table;
         bool update_indexes;
-        std::unordered_set<std::string> ignored_types;
 
         void operator()(AddTable op)
         {
-            if (!ignored_types.count(op.object->name)) {
-                create_table(group, *op.object);
-            }
+            create_table(group, *op.object);
         }
         void operator()(RemoveTable) {}
         void operator()(AddInitialProperties op)
         {
-            if (!ignored_types.count(op.object->name)) {
-                add_initial_columns(group, *op.object);
-            }
+            add_initial_columns(group, *op.object);
         }
         void operator()(AddProperty op)
         {
-            if (!ignored_types.count(op.object->name)) {
-                add_column(group, table(op.object), *op.property);
-            }
+            add_column(group, table(op.object), *op.property);
         }
         void operator()(AddIndex op)
         {
-            if (!ignored_types.count(op.object->name)) {
-                if (update_indexes)
-                    table(op.object).add_search_index(op.property->column_key);
-            }
+            if (update_indexes)
+                table(op.object).add_search_index(op.property->column_key);
         }
         void operator()(RemoveIndex op)
         {
-            if (!ignored_types.count(op.object->name)) {
-                if (update_indexes)
-                    table(op.object).remove_search_index(op.property->column_key);
-            }
+            if (update_indexes)
+                table(op.object).remove_search_index(op.property->column_key);
         }
         void operator()(RemoveProperty) {}
 
@@ -701,7 +688,7 @@ void ObjectStore::apply_additive_changes(Group& group, std::vector<SchemaChange>
         void operator()(ChangePropertyType) {}
         void operator()(MakePropertyNullable) {}
         void operator()(MakePropertyRequired) {}
-    } applier{group, update_indexes, std::move(ignore_types)};
+    } applier{group, update_indexes};
 
     for (auto& change : changes) {
         change.visit(applier);
@@ -856,14 +843,9 @@ void ObjectStore::apply_schema_changes(Transaction& group, uint64_t schema_versi
         bool target_schema_is_newer =
             (schema_version < target_schema_version || schema_version == ObjectStore::NotVersioned);
 
-        std::unordered_set<std::string> embedded_orphan_types;
-        if (mode == SchemaMode::AdditiveDiscovered) {
-            // we choose not to create backing tables for embedded orphan types when in discovered schema mode
-            embedded_orphan_types = target_schema.get_embedded_object_orphans();
-        }
         // With sync v2.x, indexes are no longer synced, so there's no reason to avoid creating them.
         bool update_indexes = true;
-        apply_additive_changes(group, changes, update_indexes, std::move(embedded_orphan_types));
+        apply_additive_changes(group, changes, update_indexes);
 
         if (target_schema_is_newer)
             set_schema_version(group, target_schema_version);
@@ -906,7 +888,7 @@ void ObjectStore::apply_schema_changes(Transaction& group, uint64_t schema_versi
 
         // Migration function may have changed the schema, so we need to re-read it
         auto schema = schema_from_group(group);
-        apply_post_migration_changes(group, schema.compare(target_schema), old_schema, DidRereadSchema::Yes);
+        apply_post_migration_changes(group, schema.compare(target_schema, mode), old_schema, DidRereadSchema::Yes);
         group.validate_primary_columns();
     }
     else {

--- a/src/realm/object-store/object_store.hpp
+++ b/src/realm/object-store/object_store.hpp
@@ -87,8 +87,7 @@ public:
                                      std::vector<SchemaChange> const& changes,
                                      std::function<void()> migration_function = {});
 
-    static void apply_additive_changes(Group&, std::vector<SchemaChange> const&, bool update_indexes,
-                                       std::unordered_set<std::string>&& ignore_types);
+    static void apply_additive_changes(Group&, std::vector<SchemaChange> const&, bool update_indexes);
 
     // get a table for an object type
     static realm::TableRef table_for_object_type(Group& group, StringData object_type);

--- a/src/realm/object-store/schema.hpp
+++ b/src/realm/object-store/schema.hpp
@@ -20,7 +20,6 @@
 #define REALM_SCHEMA_HPP
 
 #include <string>
-#include <unordered_set>
 #include <vector>
 
 #include <realm/util/features.h>
@@ -33,6 +32,86 @@ struct TableKey;
 struct Property;
 
 enum SchemaValidationMode : uint64_t { Basic = 0, Sync = 1, RejectEmbeddedOrphans = 2 };
+
+// How to handle update_schema() being called on a file which has
+// already been initialized with a different schema
+enum class SchemaMode : uint8_t {
+    // If the schema version has increased, automatically apply all
+    // changes, then call the migration function.
+    //
+    // If the schema version has not changed, verify that the only
+    // changes are to add new tables and add or remove indexes, and then
+    // apply them if so. Does not call the migration function.
+    //
+    // This mode does not automatically remove tables which are not
+    // present in the schema that must be manually done in the migration
+    // function, to support sharing a Realm file between processes using
+    // different class subsets.
+    //
+    // This mode allows using schemata with different subsets of tables
+    // on different threads, but the tables which are shared must be
+    // identical.
+    Automatic,
+
+    // Open the file in immutable mode. Schema version must match the
+    // version in the file, and all tables present in the file must
+    // exactly match the specified schema, except for indexes. Tables
+    // are allowed to be missing from the file.
+    Immutable,
+
+    // Open the Realm in read-only mode, transactions are not allowed to
+    // be performed on the Realm instance. The schema of the existing Realm
+    // file won't be changed through this Realm instance. Extra tables and
+    // extra properties are allowed in the existing Realm schema. The
+    // difference of indexes is allowed as well. Other schema differences
+    // than those will cause an exception. This is different from Immutable
+    // mode, sync Realm can be opened with ReadOnly mode. Changes
+    // can be made to the Realm file through another writable Realm instance.
+    // Thus, notifications are also allowed in this mode.
+    ReadOnly,
+
+    // If the schema version matches and the only schema changes are new
+    // tables and indexes being added or removed, apply the changes to
+    // the existing file.
+    // Otherwise delete the file and recreate it from scratch.
+    // The migration function is not used.
+    //
+    // This mode allows using schemata with different subsets of tables
+    // on different threads, but the tables which are shared must be
+    // identical.
+    ResetFile,
+
+    // The only changes allowed are to add new tables, add columns to
+    // existing tables, and to add or remove indexes from existing
+    // columns. Extra tables not present in the schema are ignored.
+    // Indexes are only added to or removed from existing columns if the
+    // schema version is greater than the existing one (and unlike other
+    // modes, the schema version is allowed to be less than the existing
+    // one).
+    // The migration function is not used.
+    // This should be used when including discovered user classes.
+    // Previously called Additive.
+    //
+    // This mode allows updating the schema with additive changes even
+    // if the Realm is already open on another thread.
+    AdditiveDiscovered,
+
+    // The same additive properties as AdditiveDiscovered, except
+    // in this mode, all classes in the schema have been explicitly
+    // included by the user. This means that stricter schema checks are
+    // run such as throwing an error when an embedded object type which
+    // is not linked from any top level object types is included.
+    AdditiveExplicit,
+
+    // Verify that the schema version has increased, call the migraiton
+    // function, and then verify that the schema now matches.
+    // The migration function is mandatory for this mode.
+    //
+    // This mode requires that all threads and processes which open a
+    // file use identical schemata.
+    Manual
+};
+
 
 class Schema : private std::vector<ObjectSchema> {
 private:
@@ -65,10 +144,10 @@ public:
     // Verify that this schema is internally consistent (i.e. all properties are
     // valid, links link to types that actually exist, etc.)
     void validate(uint64_t validation_mode = SchemaValidationMode::Basic) const;
-    std::unordered_set<std::string> get_embedded_object_orphans() const;
 
     // Get the changes which must be applied to this schema to produce the passed-in schema
-    std::vector<SchemaChange> compare(Schema const&, bool include_removals = false) const;
+    std::vector<SchemaChange> compare(Schema const&, SchemaMode = SchemaMode::Automatic,
+                                      bool include_removals = false) const;
 
     void copy_keys_from(Schema const&) noexcept;
 

--- a/src/realm/object-store/shared_realm.cpp
+++ b/src/realm/object-store/shared_realm.cpp
@@ -189,12 +189,12 @@ std::shared_ptr<SyncSession> Realm::sync_session() const
     return m_coordinator->sync_session();
 }
 
-sync::SubscriptionSet Realm::get_latest_subscription_set()
+const sync::SubscriptionSet Realm::get_latest_subscription_set()
 {
     return m_coordinator->sync_session()->get_flx_subscription_store()->get_latest();
 }
 
-sync::SubscriptionSet Realm::get_active_subscription_set()
+const sync::SubscriptionSet Realm::get_active_subscription_set()
 {
     return m_coordinator->sync_session()->get_flx_subscription_store()->get_active();
 }

--- a/src/realm/object-store/shared_realm.hpp
+++ b/src/realm/object-store/shared_realm.hpp
@@ -199,8 +199,8 @@ public:
     // Returns the latest/active subscription set for a FLX-sync enabled realm. If FLX sync is not currently
     // enabled for this realm, calling this will cause future connections to the server to be opened in FLX
     // sync mode if they aren't already.
-    sync::SubscriptionSet get_latest_subscription_set();
-    sync::SubscriptionSet get_active_subscription_set();
+    const sync::SubscriptionSet get_latest_subscription_set();
+    const sync::SubscriptionSet get_active_subscription_set();
 #endif
 
     // Returns a frozen Realm for the given Realm. This Realm can be accessed from any thread.

--- a/test/object-store/realm.cpp
+++ b/test/object-store/realm.cpp
@@ -570,6 +570,19 @@ TEST_CASE("SharedRealm: get_shared_realm()") {
         REQUIRE(realm->schema() == subset_schema);
         REQUIRE(frozen_schema == subset_schema);
     }
+
+    SECTION("freeze with orphaned embedded tables") {
+        auto schema = Schema{
+            {"object1", {{"value", PropertyType::Int}}},
+            {"object2", ObjectSchema::IsEmbedded{true}, {{"value", PropertyType::Int}}},
+        };
+        config.schema = schema;
+        config.schema_mode = SchemaMode::AdditiveDiscovered;
+        auto realm = Realm::get_shared_realm(config);
+        realm->read_group();
+        auto frozen_realm = realm->freeze();
+        REQUIRE(frozen_realm->schema() == schema);
+    }
 }
 
 #if REALM_ENABLE_SYNC


### PR DESCRIPTION
In AdditiveDiscovered mode we don't create tables for embedded object types which are never actually used. However, because of where we did this logic we would think that we had schema changes to apply every time we opened a Realm and so would commit an empty write transaction. https://github.com/realm/realm-core/pull/4965 changed this from a silent performance problem to a crash because starting the pointless write transaction would fail.

To fix this, filter out table additions for orphaned types in compare() rather than when applying the result of compare().