### PR TITLE
Rework integration error handling with exceptions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,7 @@
 * The JSON output is slightly changed in the event of link cycles. Nobody is expected to rely on that.
 * Future::get_async() no longer requires its callback to be marked noexcept. ([#5130](https://github.com/realm/realm-core/pull/5130))
 * SubscriptionSet no longer holds any database resources. ([#5150](https://github.com/realm/realm-core/pull/5150))
+* ClientHistoryImpl::integrate_server_changesets now throws instead of returning a boolean to indicate success ([#5118](https://github.com/realm/realm-core/pull/5118))
 
 ----------------------------------------------
 

--- a/src/realm/sync/client.cpp
+++ b/src/realm/sync/client.cpp
@@ -675,7 +675,7 @@ void SessionImpl::initiate_integrate_changesets(std::uint_fast64_t downloadable_
     try {
         bool simulate_integration_error = (m_wrapper.m_simulate_integration_error && !changesets.empty());
         if (simulate_integration_error) {
-            throw IntegrationException(IntegrationException::bad_changeset, "simulated failure");
+            throw IntegrationException(ClientError::bad_changeset, "simulated failure");
         }
         version_type client_version;
         if (REALM_LIKELY(!get_client().is_dry_run())) {

--- a/src/realm/sync/noinst/client_history_impl.cpp
+++ b/src/realm/sync/noinst/client_history_impl.cpp
@@ -368,11 +368,11 @@ void ClientHistory::integrate_server_changesets(const SyncProgress& progress,
         }
     }
     catch (BadChangesetError& e) {
-        throw IntegrationException(IntegrationException::bad_changeset,
+        throw IntegrationException(ClientError::bad_changeset,
                                    util::format("Failed to parse, or apply received changeset: %1", e.what()));
     }
     catch (TransformError& e) {
-        throw IntegrationException(IntegrationException::bad_changeset,
+        throw IntegrationException(ClientError::bad_changeset,
                                    util::format("Failed to transform received changeset: %1", e.what()));
     }
 
@@ -653,29 +653,26 @@ void ClientHistory::update_sync_progress(const SyncProgress& progress, const std
     // Progress must never decrease
     if (progress.latest_server_version.version <
         version_type(root.get_as_ref_or_tagged(s_progress_latest_server_version_iip).get_as_int())) {
-        throw IntegrationException(IntegrationException::decreasing_progress,
-                                   "latest server version cannot decrease");
+        throw IntegrationException(ClientError::bad_progress, "latest server version cannot decrease");
     }
     if (progress.download.server_version <
         version_type(root.get_as_ref_or_tagged(s_progress_download_server_version_iip).get_as_int())) {
-        throw IntegrationException(IntegrationException::decreasing_progress,
-                                   "server version of download cursor cannot decrease");
+        throw IntegrationException(ClientError::bad_progress, "server version of download cursor cannot decrease");
     }
     if (progress.download.last_integrated_client_version <
         version_type(root.get_as_ref_or_tagged(s_progress_download_client_version_iip).get_as_int())) {
-        throw IntegrationException(IntegrationException::decreasing_progress,
+        throw IntegrationException(ClientError::bad_progress,
                                    "last integrated client version of download cursor cannot decrease");
     }
     if (progress.upload.client_version <
         version_type(root.get_as_ref_or_tagged(s_progress_upload_client_version_iip).get_as_int())) {
-        throw IntegrationException(IntegrationException::decreasing_progress,
-                                   "client version of upload cursor cannot decrease");
+        throw IntegrationException(ClientError::bad_progress, "client version of upload cursor cannot decrease");
     }
     const auto last_integrated_server_version = progress.upload.last_integrated_server_version;
     if (last_integrated_server_version > 0 &&
         last_integrated_server_version <
             version_type(root.get_as_ref_or_tagged(s_progress_upload_server_version_iip).get_as_int())) {
-        throw IntegrationException(IntegrationException::decreasing_progress,
+        throw IntegrationException(ClientError::bad_progress,
                                    "last integrated server version of upload cursor cannot decrease");
     }
 

--- a/src/realm/sync/noinst/client_history_impl.hpp
+++ b/src/realm/sync/noinst/client_history_impl.hpp
@@ -50,8 +50,6 @@ constexpr int get_client_history_schema_version() noexcept
 
 class IntegrationException : public std::runtime_error {
 public:
-    enum IntegrationError { bad_origin_file_ident, bad_changeset, decreasing_progress, invalid_batch_state };
-
     IntegrationException(ClientError code, const std::string& msg)
         : std::runtime_error(msg)
         , m_error(code)

--- a/src/realm/sync/noinst/client_history_impl.hpp
+++ b/src/realm/sync/noinst/client_history_impl.hpp
@@ -3,11 +3,11 @@
 #define REALM_NOINST_CLIENT_HISTORY_IMPL_HPP
 
 #include <realm/util/optional.hpp>
+#include <realm/sync/client_base.hpp>
 #include <realm/sync/history.hpp>
 #include <realm/array_integer.hpp>
 
-namespace realm {
-namespace sync {
+namespace realm::sync {
 
 class ClientReplication;
 // As new schema versions come into existence, describe them here.
@@ -52,19 +52,19 @@ class IntegrationException : public std::runtime_error {
 public:
     enum IntegrationError { bad_origin_file_ident, bad_changeset, decreasing_progress, invalid_batch_state };
 
-    IntegrationException(IntegrationError code, const std::string& msg)
+    IntegrationException(ClientError code, const std::string& msg)
         : std::runtime_error(msg)
         , m_error(code)
     {
     }
 
-    IntegrationError code() const noexcept
+    ClientError code() const noexcept
     {
         return m_error;
     }
 
 private:
-    IntegrationError m_error;
+    ClientError m_error;
 };
 
 class ClientHistory final : public _impl::History, public TransformHistory {
@@ -510,7 +510,6 @@ inline auto ClientHistory::get_transformer() -> Transformer&
 /// realm::DB objects.
 std::unique_ptr<ClientReplication> make_client_replication();
 
-} // namespace sync
-} // namespace realm
+} // namespace realm::sync
 
 #endif // REALM_NOINST_CLIENT_HISTORY_IMPL_HPP

--- a/src/realm/sync/noinst/client_impl_base.hpp
+++ b/src/realm/sync/noinst/client_impl_base.hpp
@@ -598,7 +598,6 @@ private:
 class ClientImpl::Session {
 public:
     using ReceivedChangesets = ClientProtocol::ReceivedChangesets;
-    using IntegrationError = ClientHistory::IntegrationError;
 
     util::PrefixLogger logger;
 
@@ -759,9 +758,8 @@ public:
     /// This function is thread-safe, but if called from a thread other than the
     /// event loop thread of the associated client object, the specified history
     /// accessor must **not** be the one made available by access_realm().
-    bool integrate_changesets(ClientReplication&, const SyncProgress&, std::uint_fast64_t downloadable_bytes,
-                              const ReceivedChangesets&, VersionInfo&, IntegrationError&,
-                              DownloadBatchState last_in_batch);
+    void integrate_changesets(ClientReplication&, const SyncProgress&, std::uint_fast64_t downloadable_bytes,
+                              const ReceivedChangesets&, VersionInfo&, DownloadBatchState last_in_batch);
 
     /// To be used in connection with implementations of
     /// initiate_integrate_changesets().
@@ -773,8 +771,10 @@ public:
     /// It is an error to call this function before activation of the session
     /// (Connection::activate_session()), or after initiation of deactivation
     /// (Connection::initiate_session_deactivation()).
-    void on_changesets_integrated(bool success, version_type client_version, DownloadCursor download_progress,
-                                  IntegrationError error, DownloadBatchState batch_state);
+    void on_changesets_integrated(version_type client_version, DownloadCursor download_progress,
+                                  DownloadBatchState batch_state);
+
+    void on_integration_failure(const IntegrationException& e, DownloadBatchState batch_state);
 
     void on_connection_state_changed(ConnectionState, const SessionErrorInfo*);
 

--- a/src/realm/sync/tools/apply_to_state_command.cpp
+++ b/src/realm/sync/tools/apply_to_state_command.cpp
@@ -284,19 +284,13 @@ int main(int argc, const char** argv)
             return EXIT_FAILURE;
         }
 
-        bool download_integration_failed = false;
         mpark::visit(realm::util::overload{
                          [&](const DownloadMessage& download_message) {
                              realm::sync::VersionInfo version_info;
-                             realm::sync::ClientHistory::IntegrationError integration_error;
-                             if (!history.integrate_server_changesets(
-                                     download_message.progress, &download_message.downloadable_bytes,
-                                     download_message.changesets.data(), download_message.changesets.size(),
-                                     version_info, integration_error, sync::DownloadBatchState::LastInBatch, *logger,
-                                     nullptr)) {
-                                 logger->error("Error applying download message to realm");
-                                 download_integration_failed = true;
-                             }
+                             history.integrate_server_changesets(
+                                 download_message.progress, &download_message.downloadable_bytes,
+                                 download_message.changesets.data(), download_message.changesets.size(), version_info,
+                                 sync::DownloadBatchState::LastInBatch, *logger, nullptr);
                          },
                          [&](const UploadMessage& upload_message) {
                              for (const auto& changeset : upload_message.changesets) {
@@ -315,9 +309,6 @@ int main(int argc, const char** argv)
                              history.set_client_file_ident(ident_message.file_ident, true);
                          }},
                      message);
-        if (download_integration_failed) {
-            return EXIT_FAILURE;
-        }
     }
 
     return EXIT_SUCCESS;


### PR DESCRIPTION
## What, How & Why?
This reworks integrating downloaded changesets so that errors are handled by throwing an exception rather than setting a mutable reference parameter to an error code an returning false.

It also adds some validation to the code that updates sync progress information so that it throws an error rather than aborting the process in debug builds.

## ☑️ ToDos
* [x] 📝 Changelog update
* ~[ ] 🚦 Tests (or not relevant)~ there should be no user-facing changes from this.
