### PR TITLE
Change baas admin API in tests to use new names

### DIFF
--- a/evergreen/install_baas.sh
+++ b/evergreen/install_baas.sh
@@ -223,17 +223,27 @@ fi
 mkdir mongodb-dbpath
 
 function cleanup() {
+    BAAS_PID=""
+    MONGOD_PID=""
     if [[ -f $WORK_PATH/baas_server.pid ]]; then
-        PIDS_TO_KILL="$(< $WORK_PATH/baas_server.pid)"
+        BAAS_PID="$(< $WORK_PATH/baas_server.pid)"
     fi
 
     if [[ -f $WORK_PATH/mongod.pid ]]; then
-        PIDS_TO_KILL="$(< $WORK_PATH/mongod.pid) $PIDS_TO_KILL"
+        MONGOD_PID="$(< $WORK_PATH/mongod.pid)"
     fi
 
-    if [[ -n "$PIDS_TO_KILL" ]]; then
-        echo "Killing $PIDS_TO_KILL"
-        kill $PIDS_TO_KILL
+    if [[ -n "$BAAS_PID" ]]; then
+        echo "Stopping baas $BAAS_PID"
+        kill $BAAS_PID
+        echo "Waiting for baas to stop"
+        wait $BAAS_PID
+    fi
+
+
+    if [[ -n "$MONGOD_PID" ]]; then
+        echo "Killing mongod $MONGOD_PID"
+        kill $MONGOD_PID
         echo "Waiting for processes to exit"
         wait
     fi

--- a/test/object-store/util/baas_admin_api.cpp
+++ b/test/object-store/util/baas_admin_api.cpp
@@ -845,7 +845,7 @@ AppSession create_app(const AppCreateConfig& config)
         auto queryable_fields = nlohmann::json::array();
         const auto& queryable_fields_src = config.flx_sync_config->queryable_fields;
         std::copy(queryable_fields_src.begin(), queryable_fields_src.end(), std::back_inserter(queryable_fields));
-        mongo_service_def["config"]["sync_query"] = nlohmann::json{
+        mongo_service_def["config"]["flexible_sync"] = nlohmann::json{
             {"state", "enabled"},
             {"database_name", config.mongo_dbname},
             {"queryable_fields_names", queryable_fields},


### PR DESCRIPTION
## What, How & Why?
This changes the baas admin api in our tests to use the new naming in REALMC-11259.

There's also a drive-by fix to the `install_baas.sh` script so it safely shuts down the baas server.

## ☑️ ToDos
* [ ] 📝 Changelog update
* ~[ ] 🚦 Tests (or not relevant)~ 
