### PR TITLE
Add SubscriptionSet::get_subscription_store() accessor

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,7 @@
 * Fix issue compiling in debug mode for iOS.
 * FLX sync now sends the query version in IDENT messages along with the query body ([#5093](https://github.com/realm/realm-core/pull/5093))
 * Errors in C API no longer store or expose a std::exception_ptr. The comparison of realm_async_error_t now compares error code vs object identity. ([#5064](https://github.com/realm/realm-core/pull/5064))
+* `get_subscription_store()` accessor added to FLX `SubscriptionSet` ([#5122](https://github.com/realm/realm-core/pull/5122/))
 
 ----------------------------------------------
 

--- a/src/realm/sync/subscriptions.cpp
+++ b/src/realm/sync/subscriptions.cpp
@@ -450,6 +450,11 @@ std::string SubscriptionSet::to_ext_json() const
     return output_json.dump();
 }
 
+const SubscriptionStore* SubscriptionSet::get_subscription_store() const noexcept
+{
+    return m_mgr;
+}
+
 SubscriptionStore::SubscriptionStore(DBRef db, util::UniqueFunction<void(int64_t)> on_new_subscription_set)
     : m_db(std::move(db))
     , m_on_new_subscription_set(std::move(on_new_subscription_set))

--- a/src/realm/sync/subscriptions.hpp
+++ b/src/realm/sync/subscriptions.hpp
@@ -241,6 +241,9 @@ public:
     // Returns this query set as extended JSON in a form suitable for transmitting to the server.
     std::string to_ext_json() const;
 
+    // Get the SubscriptionStore this SubscriptionSet belongs to.
+    const SubscriptionStore* get_subscription_store() const noexcept;
+
 protected:
     friend class SubscriptionStore;
     friend class Subscription;


### PR DESCRIPTION
## What, How & Why?
Allows SDKs to access the `SubscriptionStore` that a given `SubscriptionSet` belongs to, for example so they can call `subs->get_subscription_store()->get_by_version(subs->version());` to get an updated version when the state changes.

## ☑️ ToDos
* [ ] 📝 Changelog update
* [ ] 🚦 Tests (or not relevant)
