### PR TITLE
Relax noexcept requirement in util::Future::get_async

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,7 @@
 * Fix issue compiling in debug mode for iOS.
 * FLX sync now sends the query version in IDENT messages along with the query body ([#5093](https://github.com/realm/realm-core/pull/5093))
 * Errors in C API no longer store or expose a std::exception_ptr. The comparison of realm_async_error_t now compares error code vs object identity. ([#5064](https://github.com/realm/realm-core/pull/5064))
+* Future::get_async() no longer requires its callback to be marked noexcept. ([#5130](https://github.com/realm/realm-core/pull/5130))
 
 ----------------------------------------------
 

--- a/src/realm/util/future.hpp
+++ b/src/realm/util/future.hpp
@@ -666,12 +666,12 @@ public:
     /**
      * This ends the Future continuation chain by calling a callback on completion. Use this to
      * escape back into a callback-based API.
+     *
+     * The callback must not throw since it is called from a noexcept context.
      */
     template <typename Func> // StatusOrStatusWith<T> -> void
     void get_async(Func&& func) && noexcept
     {
-        static_assert(std::is_nothrow_invocable_r_v<void, Func, StatusOrStatusWith<FakeVoidToVoid<T>>>);
-
         return general_impl(
             // on ready success:
             [&](T&& val) {

--- a/src/realm/util/future.hpp
+++ b/src/realm/util/future.hpp
@@ -667,11 +667,14 @@ public:
      * This ends the Future continuation chain by calling a callback on completion. Use this to
      * escape back into a callback-based API.
      *
-     * The callback must not throw since it is called from a noexcept context.
+     * The callback must not throw since it is called from a noexcept context. The callback must take a
+     * StatusOrStatusWith as its argument and have a return type of void.
      */
     template <typename Func> // StatusOrStatusWith<T> -> void
     void get_async(Func&& func) && noexcept
     {
+        static_assert(std::is_void_v<std::invoke_result_t<Func, StatusOrStatusWith<FakeVoidToVoid<T>>>>);
+
         return general_impl(
             // on ready success:
             [&](T&& val) {


### PR DESCRIPTION
## What, How & Why?
This relaxes the requirement that callbacks to Future::get_async must be marked as noexcept. They will always be called from a noexcept context so if the callback does throw it will get noexcept behavior immediately from its caller. This also means you can pass in `UniqueFunction`'s without having to mark them noexcept in the function signature (something that is not currently supported).

## ☑️ ToDos
* [ ] 📝 Changelog update
* [ ] 🚦 Tests (or not relevant)
