### PR TITLE
QUERY messages should be totally ordered with UPLOAD messages

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@
 * Freezing a Realm with a schema that has orphaned embeeded object types threw a "Wrong transactional state" exception (since v11.5.0).
 * SyncManager::path_for_realm now returns a default path when FLX sync is enabled ([#5088](https://github.com/realm/realm-core/pull/5088))
 * Having links in a property of Mixed type would lead to ill-formed JSON output when serializing the database. ([#5125](https://github.com/realm/realm-core/issues/5125), since v11.0.0)
+* FLX sync QUERY messages are now ordered with UPLOAD messages ([#5135](https://github.com/realm/realm-core/pull/5135))
 
 ### Breaking changes
 * FLX SubscriptionSet type split into SubscriptionSet and MutableSubscriptionSet to add type safety ([#5092](https://github.com/realm/realm-core/pull/5092))

--- a/src/realm/object-store/sync/impl/sync_client.hpp
+++ b/src/realm/object-store/sync/impl/sync_client.hpp
@@ -109,9 +109,11 @@ struct SyncClient {
             m_thread.join();
     }
 
-    std::unique_ptr<sync::Session> make_session(std::shared_ptr<DB> db, sync::Session::Config config)
+    std::unique_ptr<sync::Session> make_session(std::shared_ptr<DB> db,
+                                                std::shared_ptr<sync::SubscriptionStore> flx_sub_store,
+                                                sync::Session::Config config)
     {
-        return std::make_unique<sync::Session>(m_client, std::move(db), std::move(config));
+        return std::make_unique<sync::Session>(m_client, std::move(db), std::move(flx_sub_store), std::move(config));
     }
 
     bool decompose_server_url(const std::string& url, sync::ProtocolEnvelope& protocol, std::string& address,

--- a/src/realm/object-store/sync/sync_session.cpp
+++ b/src/realm/object-store/sync/sync_session.cpp
@@ -231,6 +231,7 @@ std::function<void(util::Optional<app::AppError>)> SyncSession::handle_refresh(s
 SyncSession::SyncSession(SyncClient& client, std::shared_ptr<DB> db, SyncConfig config, SyncManager* sync_manager)
     : m_config(std::move(config))
     , m_db(std::move(db))
+    , m_flx_subscription_store(make_flx_subscription_store())
     , m_client(client)
     , m_sync_manager(sync_manager)
 {
@@ -241,6 +242,21 @@ std::shared_ptr<SyncManager> SyncSession::sync_manager() const
     std::lock_guard<std::mutex> lk(m_state_mutex);
     REALM_ASSERT(m_sync_manager);
     return m_sync_manager->shared_from_this();
+}
+
+std::shared_ptr<sync::SubscriptionStore> SyncSession::make_flx_subscription_store()
+{
+    if (!m_config.flx_sync_requested) {
+        return nullptr;
+    }
+
+    return std::make_shared<sync::SubscriptionStore>(m_db, [this](int64_t new_version) {
+        std::lock_guard<std::mutex> lk(m_state_mutex);
+        if (m_state != State::Active) {
+            return;
+        }
+        m_session->on_new_flx_sync_subscription(new_version);
+    });
 }
 
 void SyncSession::detach_from_sync_manager()
@@ -521,7 +537,7 @@ void SyncSession::do_create_sync_session()
     session_config.ssl_trust_certificate_path = m_config.ssl_trust_certificate_path;
     session_config.ssl_verify_callback = m_config.ssl_verify_callback;
     session_config.proxy_config = m_config.proxy_config;
-    session_config.flx_sync_requested = m_config.flx_sync_requested;
+
     {
         std::string sync_route = m_sync_manager->sync_route();
 
@@ -576,7 +592,7 @@ void SyncSession::do_create_sync_session()
         m_force_client_reset = false;
     }
 
-    m_session = m_client.make_session(m_db, std::move(session_config));
+    m_session = m_client.make_session(m_db, m_flx_subscription_store, std::move(session_config));
 
     std::weak_ptr<SyncSession> weak_self = weak_from_this();
 
@@ -875,12 +891,12 @@ std::string const& SyncSession::path() const
 
 sync::SubscriptionStore* SyncSession::get_flx_subscription_store()
 {
-    return m_session->get_flx_subscription_store();
+    return m_flx_subscription_store.get();
 }
 
 bool SyncSession::has_flx_subscription_store() const
 {
-    return m_session->has_flx_subscription_store();
+    return static_cast<bool>(m_flx_subscription_store);
 }
 
 void SyncSession::update_configuration(SyncConfig new_config)

--- a/src/realm/object-store/sync/sync_session.cpp
+++ b/src/realm/object-store/sync/sync_session.cpp
@@ -252,7 +252,7 @@ std::shared_ptr<sync::SubscriptionStore> SyncSession::make_flx_subscription_stor
 
     return std::make_shared<sync::SubscriptionStore>(m_db, [this](int64_t new_version) {
         std::lock_guard<std::mutex> lk(m_state_mutex);
-        if (m_state != State::Active) {
+        if (m_state != State::Active && m_state != State::WaitingForAccessToken) {
             return;
         }
         m_session->on_new_flx_sync_subscription(new_version);

--- a/src/realm/object-store/sync/sync_session.hpp
+++ b/src/realm/object-store/sync/sync_session.hpp
@@ -304,6 +304,7 @@ private:
     // }
 
     std::shared_ptr<SyncManager> sync_manager() const;
+    std::shared_ptr<sync::SubscriptionStore> make_flx_subscription_store();
 
     static std::function<void(util::Optional<app::AppError>)> handle_refresh(std::shared_ptr<SyncSession>);
 
@@ -318,6 +319,7 @@ private:
     void update_error_and_mark_file_for_deletion(SyncError&, ShouldBackup);
     std::string get_recovery_file_path();
     void handle_progress_update(uint64_t, uint64_t, uint64_t, uint64_t, uint64_t, uint64_t);
+    void handle_new_flx_sync_query(int64_t version);
 
     void set_sync_transact_callback(std::function<TransactionCallback>);
     void nonsync_transact_notify(VersionID::version_type);
@@ -351,6 +353,7 @@ private:
 
     SyncConfig m_config;
     std::shared_ptr<DB> m_db;
+    std::shared_ptr<sync::SubscriptionStore> m_flx_subscription_store;
     bool m_force_client_reset = false;
     DBRef m_client_reset_fresh_copy;
     _impl::SyncClient& m_client;

--- a/src/realm/sync/client.cpp
+++ b/src/realm/sync/client.cpp
@@ -167,14 +167,14 @@ ErrorCategoryImpl g_error_category;
 // in ClientImpl::Connection.
 class SessionWrapper final : public util::AtomicRefCountBase, public SyncTransactReporter {
 public:
-    SessionWrapper(ClientImpl&, DBRef db, Session::Config);
+    SessionWrapper(ClientImpl&, DBRef db, std::shared_ptr<SubscriptionStore>, Session::Config);
     ~SessionWrapper() noexcept;
 
     ClientReplication& get_replication() noexcept;
     ClientImpl& get_client() noexcept;
 
     bool has_flx_subscription_store() const;
-    SubscriptionStore* get_or_create_flx_subscription_store();
+    SubscriptionStore* get_flx_subscription_store();
 
     void set_sync_transact_handler(std::function<SyncTransactCallback>);
     void set_progress_handler(std::function<ProgressHandler>);
@@ -203,12 +203,13 @@ public:
     // Overriding member function in SyncTransactReporter
     void report_sync_transact(VersionID, VersionID) override final;
 
+    void on_new_flx_subscription_set(int64_t new_version);
+
 private:
     ClientImpl& m_client;
     DBRef m_db;
     Replication* m_replication;
 
-    const bool m_flx_sync_requested;
     const ProtocolEnvelope m_protocol_envelope;
     const std::string m_server_address;
     const port_type m_server_port;
@@ -236,7 +237,7 @@ private:
     std::function<ProgressHandler> m_progress_handler;
     std::function<ConnectionStateChangeListener> m_connection_state_change_listener;
 
-    std::unique_ptr<SubscriptionStore> m_flx_subscription_store;
+    std::shared_ptr<SubscriptionStore> m_flx_subscription_store;
     int64_t m_flx_active_version = 0;
     int64_t m_flx_last_seen_version = 0;
     int64_t m_flx_latest_version = 0;
@@ -309,10 +310,8 @@ private:
     void on_suspended(std::error_code ec, StringData message, bool is_fatal);
     void on_resumed();
     void on_connection_state_changed(ConnectionState, const SessionErrorInfo*);
-    void on_new_flx_subscription_set(int64_t new_version);
     void on_flx_sync_progress(int64_t new_version, DownloadBatchState batch_state);
     void on_flx_sync_error(int64_t version, std::string_view err_msg);
-    std::unique_ptr<SubscriptionStore> create_flx_subscription_store();
 
     void report_progress();
 
@@ -745,18 +744,18 @@ void SessionImpl::on_flx_sync_progress(int64_t version, DownloadBatchState batch
     m_wrapper.on_flx_sync_progress(version, batch_state);
 }
 
-SubscriptionStore* SessionImpl::get_or_create_flx_subscription_store()
+SubscriptionStore* SessionImpl::get_flx_subscription_store()
 {
-    return m_wrapper.get_or_create_flx_subscription_store();
+    return m_wrapper.get_flx_subscription_store();
 }
 
 // ################ SessionWrapper ################
 
-SessionWrapper::SessionWrapper(ClientImpl& client, DBRef db, Session::Config config)
+SessionWrapper::SessionWrapper(ClientImpl& client, DBRef db, std::shared_ptr<SubscriptionStore> flx_sub_store,
+                               Session::Config config)
     : m_client{client}
     , m_db(std::move(db))
     , m_replication(m_db->get_replication())
-    , m_flx_sync_requested(config.flx_sync_requested)
     , m_protocol_envelope{config.protocol_envelope}
     , m_server_address{std::move(config.server_address)}
     , m_server_port{config.server_port}
@@ -771,11 +770,13 @@ SessionWrapper::SessionWrapper(ClientImpl& client, DBRef db, Session::Config con
     , m_signed_access_token{std::move(config.signed_user_token)}
     , m_client_reset_config{std::move(config.client_reset_config)}
     , m_proxy_config{config.proxy_config} // Throws
-    , m_flx_subscription_store(create_flx_subscription_store())
+    , m_flx_subscription_store(std::move(flx_sub_store))
 {
     REALM_ASSERT(m_db);
     REALM_ASSERT(m_db->get_replication());
     REALM_ASSERT(dynamic_cast<ClientReplication*>(m_db->get_replication()));
+
+    std::tie(m_flx_active_version, m_flx_latest_version) = m_flx_subscription_store->get_active_and_latest_versions();
 }
 
 SessionWrapper::~SessionWrapper() noexcept
@@ -803,31 +804,19 @@ bool SessionWrapper::has_flx_subscription_store() const
 
 void SessionWrapper::on_new_flx_subscription_set(int64_t new_version)
 {
-    if (new_version <= m_flx_latest_version || !m_flx_subscription_store) {
+    if (!m_initiated) {
         return;
     }
-    m_flx_latest_version = new_version;
-    m_sess->on_new_flx_subscription_set(new_version);
-}
 
-std::unique_ptr<SubscriptionStore> SessionWrapper::create_flx_subscription_store()
-{
-    if (!m_flx_sync_requested) {
-        return nullptr;
-    }
-    auto ret = std::make_unique<SubscriptionStore>(m_db, [this](int64_t new_version) {
-        REALM_ASSERT(m_initiated);
+    m_client.get_service().post([new_version, this] {
+        REALM_ASSERT(m_actualized);
+        if (REALM_UNLIKELY(!m_sess)) {
+            return; // Already finalized
+        }
 
-        m_client.get_service().post([new_version, this] {
-            REALM_ASSERT(m_actualized);
-            if (REALM_UNLIKELY(!m_sess))
-                return; // Already finalized
-            on_new_flx_subscription_set(new_version);
-        });
+        m_flx_latest_version = new_version;
+        m_sess->on_new_flx_subscription_set(new_version);
     });
-
-    std::tie(m_flx_active_version, m_flx_latest_version) = ret->get_active_and_latest_versions();
-    return ret;
 }
 
 void SessionWrapper::on_flx_sync_error(int64_t version, std::string_view err_msg)
@@ -835,7 +824,7 @@ void SessionWrapper::on_flx_sync_error(int64_t version, std::string_view err_msg
     REALM_ASSERT(m_flx_latest_version != 0);
     REALM_ASSERT(m_flx_latest_version <= version);
 
-    auto mut_subs = get_or_create_flx_subscription_store()->get_mutable_by_version(version);
+    auto mut_subs = get_flx_subscription_store()->get_mutable_by_version(version);
     mut_subs.update_state(SubscriptionSet::State::Error, err_msg);
     std::move(mut_subs).commit();
 }
@@ -862,13 +851,13 @@ void SessionWrapper::on_flx_sync_progress(int64_t new_version, DownloadBatchStat
     }
 
     if (new_version != 0) {
-        auto mut_subs = get_or_create_flx_subscription_store()->get_mutable_by_version(new_version);
+        auto mut_subs = get_flx_subscription_store()->get_mutable_by_version(new_version);
         mut_subs.update_state(new_state);
         std::move(mut_subs).commit();
     }
 }
 
-SubscriptionStore* SessionWrapper::get_or_create_flx_subscription_store()
+SubscriptionStore* SessionWrapper::get_flx_subscription_store()
 {
     return m_flx_subscription_store.get();
 }
@@ -1106,7 +1095,7 @@ void SessionWrapper::actualize(ServerEndpoint endpoint)
     REALM_ASSERT(!m_sess);
     m_db->claim_sync_agent();
 
-    SyncServerMode sync_mode = m_flx_sync_requested ? SyncServerMode::FLX : SyncServerMode::PBS;
+    SyncServerMode sync_mode = m_flx_subscription_store ? SyncServerMode::FLX : SyncServerMode::PBS;
 
     bool was_created = false;
     ClientImpl::Connection& conn = m_client.get_connection(
@@ -1292,7 +1281,7 @@ void SessionWrapper::on_connection_state_changed(ConnectionState state, const Se
     if (state == ConnectionState::connected && m_sess) {
         ClientImpl::Connection& conn = m_sess->get_connection();
         if (conn.is_flx_sync_connection()) {
-            get_or_create_flx_subscription_store();
+            get_flx_subscription_store();
         }
     }
 
@@ -1482,10 +1471,11 @@ bool Client::decompose_server_url(const std::string& url, ProtocolEnvelope& prot
 }
 
 
-Session::Session(Client& client, DBRef db, Config&& config)
+Session::Session(Client& client, DBRef db, std::shared_ptr<SubscriptionStore> flx_sub_store, Config&& config)
 {
     util::bind_ptr<SessionWrapper> sess;
-    sess.reset(new SessionWrapper{*client.m_impl, std::move(db), std::move(config)}); // Throws
+    sess.reset(
+        new SessionWrapper{*client.m_impl, std::move(db), std::move(flx_sub_store), std::move(config)}); // Throws
     // The reference count passed back to the application is implicitly
     // owned by a naked pointer. This is done to avoid exposing
     // implementation details through the header file (that is, through the
@@ -1584,14 +1574,9 @@ void Session::abandon() noexcept
     SessionWrapper::abandon(std::move(wrapper));
 }
 
-bool Session::has_flx_subscription_store() const
+void Session::on_new_flx_sync_subscription(int64_t new_version)
 {
-    return m_impl->has_flx_subscription_store();
-}
-
-SubscriptionStore* Session::get_flx_subscription_store()
-{
-    return m_impl->get_or_create_flx_subscription_store();
+    m_impl->on_new_flx_subscription_set(new_version);
 }
 
 const std::error_category& client_error_category() noexcept

--- a/src/realm/sync/client.cpp
+++ b/src/realm/sync/client.cpp
@@ -776,7 +776,10 @@ SessionWrapper::SessionWrapper(ClientImpl& client, DBRef db, std::shared_ptr<Sub
     REALM_ASSERT(m_db->get_replication());
     REALM_ASSERT(dynamic_cast<ClientReplication*>(m_db->get_replication()));
 
-    std::tie(m_flx_active_version, m_flx_latest_version) = m_flx_subscription_store->get_active_and_latest_versions();
+    if (m_flx_subscription_store) {
+        std::tie(m_flx_active_version, m_flx_latest_version) =
+            m_flx_subscription_store->get_active_and_latest_versions();
+    }
 }
 
 SessionWrapper::~SessionWrapper() noexcept
@@ -814,6 +817,7 @@ void SessionWrapper::on_new_flx_subscription_set(int64_t new_version)
             return; // Already finalized
         }
 
+        m_sess->recognize_sync_version(m_db->get_version_of_latest_snapshot());
         m_flx_latest_version = new_version;
         m_sess->on_new_flx_subscription_set(new_version);
     });

--- a/src/realm/sync/client.hpp
+++ b/src/realm/sync/client.hpp
@@ -305,8 +305,6 @@ public:
         using ClientReset = sync::ClientReset;
         util::Optional<ClientReset> client_reset_config;
 
-        bool flx_sync_requested = false;
-
         util::Optional<SyncConfig::ProxyConfig> proxy_config;
 
         /// Set to true to cause the integration of the first received changeset
@@ -321,7 +319,7 @@ public:
     /// Note that the session is not fully activated until you call bind().
     /// Also note that if you call set_sync_transact_callback(), it must be
     /// done before calling bind().
-    Session(Client&, std::shared_ptr<DB>, Config&& = {});
+    Session(Client&, std::shared_ptr<DB>, std::shared_ptr<SubscriptionStore>, Config&& = {});
 
     /// This leaves the right-hand side session object detached. See "Thread
     /// safety" section under detach().
@@ -710,11 +708,7 @@ public:
     /// thread, and by multiple threads concurrently.
     void cancel_reconnect_delay();
 
-    /// \brief Gets or creates the subscription store for this session.
-    ///
-    /// Calling this will enable FLX sync for this Session if it has not already been enabled.
-    SubscriptionStore* get_flx_subscription_store();
-    bool has_flx_subscription_store() const;
+    void on_new_flx_sync_subscription(int64_t new_version);
 
 private:
     SessionWrapper* m_impl = nullptr;

--- a/src/realm/sync/noinst/client_impl_base.cpp
+++ b/src/realm/sync/noinst/client_impl_base.cpp
@@ -1617,11 +1617,14 @@ void Session::send_message()
         return send_mark_message(); // Throws
 
     auto check_pending_flx_version = [&]() -> bool {
+        if (!m_is_flx_sync_session) {
+            return false;
+        }
+
         if (!m_allow_upload) {
             return false;
         }
 
-        REALM_ASSERT(m_is_flx_sync_session);
         m_pending_flx_sub_set = get_flx_subscription_store()->get_next_pending_version(
             m_last_sent_flx_query_version, m_upload_progress.client_version);
 

--- a/src/realm/sync/noinst/client_impl_base.cpp
+++ b/src/realm/sync/noinst/client_impl_base.cpp
@@ -1622,7 +1622,7 @@ void Session::send_message()
         }
 
         REALM_ASSERT(m_is_flx_sync_session);
-        m_pending_flx_sub_set = get_or_create_flx_subscription_store()->get_next_pending_version(
+        m_pending_flx_sub_set = get_flx_subscription_store()->get_next_pending_version(
             m_last_sent_flx_query_version, m_upload_progress.client_version);
 
         if (!m_pending_flx_sub_set) {
@@ -1686,7 +1686,7 @@ void Session::send_ident_message()
     session_ident_type session_ident = m_ident;
 
     if (m_is_flx_sync_session) {
-        const auto active_query_set = get_or_create_flx_subscription_store()->get_active();
+        const auto active_query_set = get_flx_subscription_store()->get_active();
         const auto active_query_body = active_query_set.to_ext_json();
         logger.debug("Sending: IDENT(client_file_ident=%1, client_file_ident_salt=%2, "
                      "scan_server_version=%3, scan_client_version=%4, latest_server_version=%5, "
@@ -1727,7 +1727,7 @@ void Session::send_query_change_message()
         return;
     }
 
-    auto sub_store = get_or_create_flx_subscription_store();
+    auto sub_store = get_flx_subscription_store();
     auto latest_sub_set = sub_store->get_by_version(m_pending_flx_sub_set->query_version);
     auto latest_queries = latest_sub_set.to_ext_json();
     logger.debug("Sending: QUERY(query_version=%1, query_size=%2, query=\"%3\"", latest_sub_set.version(),
@@ -1759,12 +1759,12 @@ void Session::send_upload_message()
     auto target_upload_version = m_upload_target_version;
     if (m_is_flx_sync_session) {
         if (!m_pending_flx_sub_set || m_pending_flx_sub_set->snapshot_version < m_upload_progress.client_version) {
-            m_pending_flx_sub_set = get_or_create_flx_subscription_store()->get_next_pending_version(
+            m_pending_flx_sub_set = get_flx_subscription_store()->get_next_pending_version(
                 m_last_sent_flx_query_version, m_upload_progress.client_version);
         }
         if (m_pending_flx_sub_set && m_pending_flx_sub_set->snapshot_version < m_upload_target_version) {
             logger.trace("Limiting UPLOAD message up to version %1 to send QUERY version %2",
-                         m_pending_flx_sub_set->snapshot_version, m_pending_flx_sub_set->snapshot_version);
+                         m_pending_flx_sub_set->snapshot_version, m_pending_flx_sub_set->query_version);
             target_upload_version = m_pending_flx_sub_set->snapshot_version;
         }
     }

--- a/src/realm/sync/noinst/client_impl_base.cpp
+++ b/src/realm/sync/noinst/client_impl_base.cpp
@@ -1616,16 +1616,32 @@ void Session::send_message()
     if (m_target_download_mark > m_last_download_mark_sent)
         return send_mark_message(); // Throws
 
-    if (m_pending_query_message) {
+    auto check_pending_flx_version = [&]() -> bool {
+        if (!m_allow_upload) {
+            return false;
+        }
+
+        REALM_ASSERT(m_is_flx_sync_session);
+        m_pending_flx_sub_set = get_or_create_flx_subscription_store()->get_next_pending_version(
+            m_last_sent_flx_query_version, m_upload_progress.client_version);
+
+        if (!m_pending_flx_sub_set) {
+            return false;
+        }
+
+        return m_upload_progress.client_version >= m_pending_flx_sub_set->snapshot_version;
+    };
+
+    if (check_pending_flx_version()) {
         return send_query_change_message(); // throws
     }
 
     REALM_ASSERT(m_upload_progress.client_version <= m_upload_target_version);
     REALM_ASSERT(m_upload_target_version <= m_last_version_available);
     if (m_allow_upload && m_download_batch_state == DownloadBatchState::LastInBatch &&
-        (m_upload_target_version > m_upload_progress.client_version))
-        send_upload_message(); // Throws
-    return;
+        (m_upload_target_version > m_upload_progress.client_version)) {
+        return send_upload_message(); // Throws
+    }
 }
 
 
@@ -1704,13 +1720,15 @@ void Session::send_query_change_message()
     REALM_ASSERT(m_state == Active);
     REALM_ASSERT(m_ident_message_sent);
     REALM_ASSERT(!m_unbind_message_sent);
-    REALM_ASSERT(m_pending_query_message);
+    REALM_ASSERT(m_pending_flx_sub_set);
+    REALM_ASSERT(m_pending_flx_sub_set->query_version > m_last_sent_flx_query_version);
 
     if (REALM_UNLIKELY(get_client().is_dry_run())) {
         return;
     }
 
-    auto latest_sub_set = get_or_create_flx_subscription_store()->get_latest();
+    auto sub_store = get_or_create_flx_subscription_store();
+    auto latest_sub_set = sub_store->get_by_version(m_pending_flx_sub_set->query_version);
     auto latest_queries = latest_sub_set.to_ext_json();
     logger.debug("Sending: QUERY(query_version=%1, query_size=%2, query=\"%3\"", latest_sub_set.version(),
                  latest_queries.size(), latest_queries);
@@ -1720,7 +1738,10 @@ void Session::send_query_change_message()
     ClientProtocol& protocol = m_conn.get_client_protocol();
     protocol.make_query_change_message(out, session_ident, latest_sub_set.version(), latest_queries);
     m_conn.initiate_write_message(out, this);
-    m_pending_query_message = false;
+
+    m_last_sent_flx_query_version = latest_sub_set.version();
+    m_pending_flx_sub_set =
+        sub_store->get_next_pending_version(m_last_sent_flx_query_version, m_pending_flx_sub_set->snapshot_version);
 
     enlist_to_send(); // throws
 }
@@ -1735,11 +1756,24 @@ void Session::send_upload_message()
     if (REALM_UNLIKELY(get_client().is_dry_run()))
         return;
 
+    auto target_upload_version = m_upload_target_version;
+    if (m_is_flx_sync_session) {
+        if (!m_pending_flx_sub_set || m_pending_flx_sub_set->snapshot_version < m_upload_progress.client_version) {
+            m_pending_flx_sub_set = get_or_create_flx_subscription_store()->get_next_pending_version(
+                m_last_sent_flx_query_version, m_upload_progress.client_version);
+        }
+        if (m_pending_flx_sub_set && m_pending_flx_sub_set->snapshot_version < m_upload_target_version) {
+            logger.trace("Limiting UPLOAD message up to version %1 to send QUERY version %2",
+                         m_pending_flx_sub_set->snapshot_version, m_pending_flx_sub_set->snapshot_version);
+            target_upload_version = m_pending_flx_sub_set->snapshot_version;
+        }
+    }
+
     const ClientReplication& repl = access_realm(); // Throws
 
     std::vector<UploadChangeset> uploadable_changesets;
     version_type locked_server_version = 0;
-    repl.get_history().find_uploadable_changesets(m_upload_progress, m_upload_target_version, uploadable_changesets,
+    repl.get_history().find_uploadable_changesets(m_upload_progress, target_upload_version, uploadable_changesets,
                                                   locked_server_version); // Throws
 
     if (uploadable_changesets.empty()) {
@@ -2087,9 +2121,7 @@ void Session::receive_download_message(const SyncProgress& progress, std::uint_f
     }
 
     initiate_integrate_changesets(downloadable_bytes, batch_state, received_changesets); // Throws
-    if (query_version != 0) {
-        on_flx_sync_progress(query_version, batch_state);
-    }
+    on_flx_sync_progress(query_version, batch_state);
 
     // When we receive a DOWNLOAD message successfully, we can clear the backoff timer value used to reconnect
     // after a retryable session error.

--- a/src/realm/sync/noinst/client_impl_base.hpp
+++ b/src/realm/sync/noinst/client_impl_base.hpp
@@ -704,7 +704,7 @@ public:
     void request_download_completion_notification();
 
     /// \brief Gets or creates the subscription store associated with this Session.
-    SubscriptionStore* get_or_create_flx_subscription_store();
+    SubscriptionStore* get_flx_subscription_store();
 
     /// \brief Callback for when a new subscription set has been created for FLX sync.
     void on_new_flx_subscription_set(int64_t new_version);

--- a/src/realm/sync/noinst/client_impl_base.hpp
+++ b/src/realm/sync/noinst/client_impl_base.hpp
@@ -912,7 +912,7 @@ private:
     //@}
 
     void on_flx_sync_error(int64_t version, std::string_view err_msg);
-    void on_flx_sync_progress(int64_t verison, DownloadBatchState batch_state);
+    void on_flx_sync_progress(int64_t version, DownloadBatchState batch_state);
 
     void begin_resumption_delay();
     void clear_resumption_delay_state();
@@ -961,7 +961,8 @@ private:
     bool m_unbound_message_received;            // UNBOUND message received
 
     // True when there is a new FLX sync query we need to send to the server.
-    bool m_pending_query_message = false;
+    util::Optional<SubscriptionStore::PendingSubscription> m_pending_flx_sub_set;
+    int64_t m_last_sent_flx_query_version = 0;
 
     // `ident == 0` means unassigned.
     SaltedFileIdent m_client_file_ident = {0, 0};

--- a/src/realm/sync/subscriptions.cpp
+++ b/src/realm/sync/subscriptions.cpp
@@ -385,7 +385,7 @@ SubscriptionSet MutableSubscriptionSet::commit() &&
         throw std::logic_error("SubscriptionSet is not in a commitable state");
     }
     if (state() == State::Uncommitted) {
-        m_obj.set(m_mgr->m_sub_set_keys->snapshot_version, static_cast<int64_t>(m_tr->get_version() + 1));
+        m_obj.set(m_mgr->m_sub_set_keys->snapshot_version, static_cast<int64_t>(m_tr->get_version()));
         update_state(State::Pending, util::none);
     }
 

--- a/src/realm/sync/subscriptions.cpp
+++ b/src/realm/sync/subscriptions.cpp
@@ -40,6 +40,7 @@ constexpr static std::string_view c_flx_sub_sets_state_field("state");
 constexpr static std::string_view c_flx_sub_sets_version_field("version");
 constexpr static std::string_view c_flx_sub_sets_error_str_field("error");
 constexpr static std::string_view c_flx_sub_sets_subscriptions_field("subscriptions");
+constexpr static std::string_view c_flx_sub_sets_snapshot_version_field("snapshot_version");
 
 constexpr static std::string_view c_flx_sub_id_field("id");
 constexpr static std::string_view c_flx_sub_created_at_field("created_at");
@@ -384,6 +385,7 @@ SubscriptionSet MutableSubscriptionSet::commit() &&
         throw std::logic_error("SubscriptionSet is not in a commitable state");
     }
     if (state() == State::Uncommitted) {
+        m_obj.set(m_mgr->m_sub_set_keys->snapshot_version, static_cast<int64_t>(m_tr->get_version() + 1));
         update_state(State::Pending, util::none);
     }
 
@@ -473,6 +475,8 @@ SubscriptionStore::SubscriptionStore(DBRef db, util::UniqueFunction<void(int64_t
 
         m_sub_set_keys->table = sub_sets_table->get_key();
         m_sub_set_keys->state = sub_sets_table->add_column(type_Int, c_flx_sub_sets_state_field);
+        m_sub_set_keys->snapshot_version =
+            sub_sets_table->add_column(type_Int, c_flx_sub_sets_snapshot_version_field);
         m_sub_set_keys->error_str = sub_sets_table->add_column(type_String, c_flx_sub_sets_error_str_field, true);
         m_sub_set_keys->subscriptions =
             sub_sets_table->add_column_list(*subs_table, c_flx_sub_sets_subscriptions_field);
@@ -507,6 +511,8 @@ SubscriptionStore::SubscriptionStore(DBRef db, util::UniqueFunction<void(int64_t
         auto sub_sets = tr->get_table(m_sub_set_keys->table);
         m_sub_set_keys->state = lookup_and_validate_column(sub_sets, c_flx_sub_sets_state_field, type_Int);
         m_sub_set_keys->error_str = lookup_and_validate_column(sub_sets, c_flx_sub_sets_error_str_field, type_String);
+        m_sub_set_keys->snapshot_version =
+            lookup_and_validate_column(sub_sets, c_flx_sub_sets_snapshot_version_field, type_Int);
         m_sub_set_keys->subscriptions =
             lookup_and_validate_column(sub_sets, c_flx_sub_sets_subscriptions_field, type_LinkList);
         if (!m_sub_set_keys->subscriptions) {
@@ -583,6 +589,33 @@ std::pair<int64_t, int64_t> SubscriptionStore::get_active_and_latest_versions() 
 
     auto active_id = res.get_object(0).get_primary_key();
     return {active_id.get_int(), latest_id};
+}
+
+util::Optional<SubscriptionStore::PendingSubscription>
+SubscriptionStore::get_next_pending_version(int64_t last_query_version, DB::version_type after_client_version) const
+{
+    auto tr = m_db->start_read();
+    auto sub_sets = tr->get_table(m_sub_set_keys->table);
+    if (sub_sets->is_empty()) {
+        return util::none;
+    }
+
+    DescriptorOrdering descriptor_ordering;
+    descriptor_ordering.append_sort(SortDescriptor{{{sub_sets->get_primary_key_column()}}, {true}});
+    auto res = sub_sets->where()
+                   .greater(sub_sets->get_primary_key_column(), last_query_version)
+                   .equal(m_sub_set_keys->state, static_cast<int64_t>(SubscriptionSet::State::Pending))
+                   .greater_equal(m_sub_set_keys->snapshot_version, static_cast<int64_t>(after_client_version))
+                   .find_all(descriptor_ordering);
+
+    if (res.is_empty()) {
+        return util::none;
+    }
+
+    auto obj = res.get_object(0);
+    auto query_version = obj.get_primary_key().get_int();
+    auto snapshot_version = obj.get<int64_t>(m_sub_set_keys->snapshot_version);
+    return PendingSubscription{query_version, static_cast<DB::version_type>(snapshot_version)};
 }
 
 MutableSubscriptionSet SubscriptionStore::get_mutable_by_version(int64_t version_id)

--- a/test/object-store/sync/flx_sync.cpp
+++ b/test/object-store/sync/flx_sync.cpp
@@ -120,7 +120,6 @@ FLXSyncTestHarness::FLXSyncTestHarness(const std::string& test_name, ServerSchem
 TestSyncManager FLXSyncTestHarness::make_sync_manager()
 {
     TestSyncManager::Config smc(m_app_config);
-    smc.verbose_sync_client_logging = true;
     return TestSyncManager(std::move(smc), {});
 }
 

--- a/test/object-store/sync/flx_sync.cpp
+++ b/test/object-store/sync/flx_sync.cpp
@@ -233,7 +233,7 @@ TEST_CASE("flx: writes work offline", "[sync][flx][app]") {
         auto queryable_int_field = table->get_column_key("queryable_int_field");
         auto new_query = realm->get_latest_subscription_set().make_mutable_copy();
         new_query.insert_or_assign(Query(table));
-        new_query.commit();
+        std::move(new_query).commit();
 
         auto foo_obj_id = ObjectId::gen();
         auto bar_obj_id = ObjectId::gen();
@@ -258,7 +258,7 @@ TEST_CASE("flx: writes work offline", "[sync][flx][app]") {
             auto mut_subs = realm->get_latest_subscription_set().make_mutable_copy();
             mut_subs.clear();
             mut_subs.insert_or_assign(Query(table).equal(queryable_str_field, "foo"));
-            mut_subs.commit();
+            std::move(mut_subs).commit();
         }
 
         {
@@ -273,7 +273,7 @@ TEST_CASE("flx: writes work offline", "[sync][flx][app]") {
             auto mut_subs = realm->get_latest_subscription_set().make_mutable_copy();
             mut_subs.clear();
             mut_subs.insert_or_assign(Query(table).greater_equal(queryable_int_field, static_cast<int64_t>(10)));
-            mut_subs.commit();
+            std::move(mut_subs).commit();
         }
 
         Results results(realm, table);

--- a/test/sync_fixtures.hpp
+++ b/test/sync_fixtures.hpp
@@ -647,7 +647,7 @@ public:
         //  connections, while the MongoDB/Stitch-based Sync server does not.
         config.service_identifier = "/realm-sync";
 
-        Session session{*m_clients[client_index], std::move(db), std::move(config)};
+        Session session{*m_clients[client_index], std::move(db), nullptr, std::move(config)};
         if (m_connection_state_change_listeners[client_index]) {
             session.set_connection_state_change_listener(m_connection_state_change_listeners[client_index]);
         }

--- a/test/test_sync.cpp
+++ b/test/test_sync.cpp
@@ -3950,7 +3950,7 @@ TEST(Sync_UploadDownloadProgress_1)
             client.run();
         });
 
-        Session session(client, db);
+        Session session(client, db, nullptr);
 
         int number_of_handler_calls = 0;
 
@@ -4230,7 +4230,7 @@ TEST(Sync_UploadDownloadProgress_3)
     Session::Config config;
     config.service_identifier = "/realm-sync";
 
-    Session session(client, db, std::move(config));
+    Session session(client, db, nullptr, std::move(config));
 
     // entry is used to count the number of calls to
     // progress_handler. At the first call, the server is
@@ -4538,7 +4538,7 @@ TEST(Sync_UploadDownloadProgress_6)
     session_config.realm_identifier = "/test";
     session_config.signed_user_token = g_signed_test_user_token;
 
-    std::unique_ptr<Session> session{new Session{client, db, std::move(session_config)}};
+    std::unique_ptr<Session> session{new Session{client, db, nullptr, std::move(session_config)}};
 
     util::Mutex mutex;
 
@@ -4586,8 +4586,8 @@ TEST(Sync_MultipleSyncAgentsNotAllowed)
     config.reconnect_mode = ReconnectMode::testing;
     config.tcp_no_delay = true;
     Client client{config};
-    Session session_1{client, db};
-    Session session_2{client, db};
+    Session session_1{client, db, nullptr};
+    Session session_2{client, db, nullptr};
     session_1.bind("realm://foo/bar", "blablabla");
     session_2.bind("realm://foo/bar", "blablabla");
     CHECK_THROW(client.run(), MultipleSyncAgents);
@@ -5855,7 +5855,7 @@ TEST_IF(Sync_SSL_Certificates, false)
         // Invalid token for the cloud.
         session_config.signed_user_token = g_signed_test_user_token;
 
-        Session session{client, db, std::move(session_config)};
+        Session session{client, db, nullptr, std::move(session_config)};
 
         auto listener = [&](ConnectionState state, const Session::ErrorInfo* error_info) {
             if (state == ConnectionState::disconnected) {

--- a/test/test_sync.cpp
+++ b/test/test_sync.cpp
@@ -3811,7 +3811,7 @@ TEST_IF(Sync_SSL_Certificate_Verify_Callback_External, false)
     session_config.ssl_trust_certificate_path = util::none;
     session_config.ssl_verify_callback = ssl_verify_callback;
 
-    Session session(client, db, std::move(session_config));
+    Session session(client, db, nullptr, std::move(session_config));
     session.bind();
     session.wait_for_download_complete_or_client_stopped();
 


### PR DESCRIPTION
## What, How & Why?
This change does a lot of things but shouldn't have any user-visible effects besides FLX sync actually working.

The first big change is that the ownership of the subscription store is moved out from the sync client internals and into the object-store SyncSession type. This was to make sure it's available when the sync session is inactive. But it's mostly just code motion.

The second big change - which is also the title of the PR - is that uploads and query change messages should now be totally ordered with respect to where the transaction that created the query change happened in local history.

Finally there are some new tests to make sure that development mode works and that you can create new subscriptions and mutate data in an FLX sync realm when offline.

## ☑️ ToDos
* [x] 📝 Changelog update
* [x] 🚦 Tests (or not relevant)
