### PR TITLE
WIP

### DIFF
--- a/src/realm/error_codes.cpp
+++ b/src/realm/error_codes.cpp
@@ -20,7 +20,7 @@
 
 namespace realm {
 
-StringData ErrorCodes::error_string(Error code)
+std::string_view ErrorCodes::error_string(Error code)
 {
     switch (code) {
         case ErrorCodes::OK:
@@ -31,6 +31,20 @@ StringData ErrorCodes::error_string(Error code)
             return "LogicError";
         case ErrorCodes::BrokenPromise:
             return "BrokenPromise";
+        case ErrorCodes::NoSuchTable:
+            return "NoSuchTable";
+        case ErrorCodes::MaximumFileSizeExceeded:
+            return "MaximumFileSizeExceeded";
+        case ErrorCodes::ColumnNotFound:
+            return "ColumnNotFound";
+        case ErrorCodes::KeyNotFound:
+            return "KeyNotFound";
+        case ErrorCodes::KeyAlreadyUsed:
+            return "KeyAlreadyUsed";
+        case ErrorCodes::DuplicatePrimaryKeyValue:
+            return "DuplicatePrimaryKeyValue";
+        case ErrorCodes::InvalidPath:
+            return "InvalidPath";
         case ErrorCodes::UnknownError:
         default:
             return "UnknownError";

--- a/src/realm/error_codes.hpp
+++ b/src/realm/error_codes.hpp
@@ -18,7 +18,7 @@
 
 #pragma once
 
-#include <realm/string_data.hpp>
+#include <string>
 
 namespace realm {
 
@@ -35,9 +35,16 @@ public:
         RuntimeError = 2,
         LogicError = 3,
         BrokenPromise = 4,
+        NoSuchTable = 5,
+        MaximumFileSizeExceeded = 6,
+        ColumnNotFound = 7,
+        KeyNotFound = 9,
+        KeyAlreadyUsed = 10,
+        DuplicatePrimaryKeyValue = 11,
+        InvalidPath = 12,
     };
 
-    static StringData error_string(Error code);
+    static std::string_view error_string(Error code);
 };
 
 } // namespace realm

--- a/src/realm/exceptions.cpp
+++ b/src/realm/exceptions.cpp
@@ -22,19 +22,11 @@
 
 using namespace realm;
 
-DuplicatePrimaryKeyValueException::DuplicatePrimaryKeyValueException(std::string obj_type, std::string prop)
-    : logic_error(util::format("Primary key property '%1.%2' has duplicate values after migration.", obj_type, prop))
-    , m_object_type(obj_type)
-    , m_property(prop)
-{
-}
-
-
 // LCOV_EXCL_START (LogicError is not a part of the public API, so code may never
 // rely on the contents of these strings, as they are deliberately unspecified.)
-const char* LogicError::message() const noexcept
+const char* LogicError::message(ErrorKind kind) noexcept
 {
-    switch (m_kind) {
+    switch (kind) {
         case string_too_big:
             return "String too big";
         case binary_too_big:

--- a/src/realm/status.cpp
+++ b/src/realm/status.cpp
@@ -24,7 +24,7 @@
 
 namespace realm {
 
-Status::Status(ErrorCodes::Error code, StringData reason)
+Status::Status(ErrorCodes::Error code, std::string_view reason)
     : m_error(ErrorInfo::create(code, reason))
 {
     // OK status should be created by calling Status::OK() - which is a special case that doesn't allocate
@@ -32,24 +32,19 @@ Status::Status(ErrorCodes::Error code, StringData reason)
     REALM_ASSERT(code != ErrorCodes::OK);
 }
 
-Status::Status(ErrorCodes::Error code, const std::string& reason)
-    : Status(code, StringData(reason))
-{
-}
-
 Status::Status(ErrorCodes::Error code, const char* reason)
-    : Status(code, StringData(reason, std::char_traits<char>::length(reason)))
+    : Status(code, std::string_view(reason, std::char_traits<char>::length(reason)))
 {
 }
 
-Status::ErrorInfo::ErrorInfo(ErrorCodes::Error code, StringData reason)
+Status::ErrorInfo::ErrorInfo(ErrorCodes::Error code, std::string_view reason)
     : m_refs(0)
     , m_code(code)
     , m_reason(reason)
 {
 }
 
-util::bind_ptr<Status::ErrorInfo> Status::ErrorInfo::create(ErrorCodes::Error code, StringData reason)
+util::bind_ptr<Status::ErrorInfo> Status::ErrorInfo::create(ErrorCodes::Error code, std::string_view reason)
 {
     return util::bind_ptr<Status::ErrorInfo>(new ErrorInfo(code, reason));
 }

--- a/src/realm/status.hpp
+++ b/src/realm/status.hpp
@@ -24,7 +24,6 @@
 #include <string>
 
 #include "realm/error_codes.hpp"
-#include "realm/string_data.hpp"
 #include "realm/util/bind_ptr.hpp"
 #include "realm/util/features.h"
 
@@ -38,10 +37,9 @@ public:
     static inline Status OK();
 
     /*
-     * You can construct a Status from strings, C strings, and StringData's.
+     * You can construct a Status from strings, C strings
      */
-    Status(ErrorCodes::Error code, StringData reason);
-    Status(ErrorCodes::Error code, const std::string& reason);
+    Status(ErrorCodes::Error code, std::string_view reason);
     Status(ErrorCodes::Error code, const char* reason);
 
     /*
@@ -56,7 +54,7 @@ public:
     inline bool is_ok() const noexcept;
     inline const std::string& reason() const noexcept;
     inline ErrorCodes::Error code() const noexcept;
-    inline StringData code_string() const noexcept;
+    inline std::string_view code_string() const noexcept;
 
     /*
      * This class is marked nodiscard so that we always handle errors. If there is a place where we need
@@ -72,7 +70,7 @@ private:
         const ErrorCodes::Error m_code;
         const std::string m_reason;
 
-        static util::bind_ptr<ErrorInfo> create(ErrorCodes::Error code, StringData reason);
+        static util::bind_ptr<ErrorInfo> create(ErrorCodes::Error code, std::string_view reason);
 
     protected:
         template <typename>
@@ -91,7 +89,7 @@ private:
         }
 
     private:
-        ErrorInfo(ErrorCodes::Error code, StringData reason);
+        ErrorInfo(ErrorCodes::Error code, std::string_view reason);
     };
 
     util::bind_ptr<ErrorInfo> m_error = {};
@@ -119,12 +117,12 @@ public:
         return m_status.code();
     }
 
-    StringData code_string() const noexcept
+    std::string_view code_string() const noexcept
     {
         return m_status.code_string();
     }
 
-    ExceptionForStatus(ErrorCodes::Error err, StringData str)
+    ExceptionForStatus(ErrorCodes::Error err, std::string_view str)
         : m_status(err, str)
     {
     }
@@ -213,7 +211,7 @@ inline ErrorCodes::Error Status::code() const noexcept
     return m_error ? m_error->m_code : ErrorCodes::OK;
 }
 
-inline StringData Status::code_string() const noexcept
+inline std::string_view Status::code_string() const noexcept
 {
     return ErrorCodes::error_string(code());
 }

--- a/src/realm/status_with.hpp
+++ b/src/realm/status_with.hpp
@@ -65,12 +65,7 @@ class REALM_NODISCARD StatusWith {
 public:
     using value_type = T;
 
-    StatusWith(ErrorCodes::Error code, StringData reason)
-        : m_status(code, reason)
-    {
-    }
-
-    StatusWith(ErrorCodes::Error code, const std::string& reason)
+    StatusWith(ErrorCodes::Error code, std::string_view reason)
         : m_status(code, reason)
     {
     }

--- a/src/realm/sync/subscriptions.cpp
+++ b/src/realm/sync/subscriptions.cpp
@@ -322,7 +322,7 @@ util::Future<SubscriptionSet::State> SubscriptionSet::get_state_change_notificat
     // we can return a ready future immediately.
     auto cur_state = state();
     if (cur_state == State::Error) {
-        return util::Future<State>::make_ready(Status{ErrorCodes::RuntimeError, error_str()});
+        return util::Future<State>::make_ready(Status{ErrorCodes::RuntimeError, std::string_view(error_str())});
     }
     else if (cur_state >= notify_when) {
         return util::Future<State>::make_ready(cur_state);
@@ -367,7 +367,7 @@ void MutableSubscriptionSet::process_notifications()
 
     for (auto& req : to_finish) {
         if (new_state == State::Error && req.version == my_version) {
-            req.promise.set_error({ErrorCodes::RuntimeError, error_str()});
+            req.promise.set_error({ErrorCodes::RuntimeError, std::string_view(error_str())});
         }
         else if (req.version < my_version) {
             req.promise.emplace_value(State::Superceded);

--- a/src/realm/table.cpp
+++ b/src/realm/table.cpp
@@ -327,7 +327,8 @@ void LinkChain::add(ColKey ck)
     }
     else {
         // Only last column in link chain is allowed to be non-link
-        throw std::runtime_error(util::format("%1.%2 is not an object reference property",
+        throw ExceptionForStatus(ErrorCodes::LogicError,
+                                 util::format("%1.%2 is not an object reference property",
                                               m_current_table->get_name(), m_current_table->get_column_name(ck)));
     }
     m_link_cols.push_back(ck);
@@ -1559,7 +1560,8 @@ bool Table::migrate_objects()
         std::unique_ptr<BPlusTree<int64_t>> list_acc;
 
         if (!(col_ndx < col_refs.size())) {
-            throw std::runtime_error(
+            throw ExceptionForStatus(
+                ErrorCodes::LogicError,
                 util::format("Objects in '%1' corrupted by previous upgrade attempt", get_name()));
         }
 
@@ -3589,7 +3591,8 @@ bool Table::contains_unique_values(ColKey col) const
 void Table::validate_column_is_unique(ColKey col) const
 {
     if (!contains_unique_values(col)) {
-        throw DuplicatePrimaryKeyValueException(get_name(), get_column_name(col));
+        throw DuplicatePrimaryKeyValueException(util::format(
+            "Primary key property '%1.%2' has duplicate values after migration.", get_name(), get_column_name(col)));
     }
 }
 
@@ -3654,7 +3657,8 @@ void Table::change_nullability(ColKey key_from, ColKey key_to, bool throw_on_nul
         for (size_t i = 0; i < sz; i++) {
             if (from_nullability && from_arr.is_null(i)) {
                 if (throw_on_null) {
-                    throw std::runtime_error(util::format("Objects in '%1' has null value(s) in property '%2'",
+                    throw ExceptionForStatus(ErrorCodes::LogicError,
+                                             util::format("Objects in '%1' has null value(s) in property '%2'",
                                                           get_name(), get_column_name(key_from)));
                 }
                 else {
@@ -3702,7 +3706,8 @@ void Table::change_nullability_list(ColKey key_from, ColKey key_to, bool throw_o
                     }
                     else {
                         if (throw_on_null) {
-                            throw std::runtime_error(
+                            throw ExceptionForStatus(
+                                ErrorCodes::LogicError,
                                 util::format("Objects in '%1' has null value(s) in list property '%2'", get_name(),
                                              get_column_name(key_from)));
                         }


### PR DESCRIPTION
## What, How & Why?
Probe on "Unify Core error handling"

The reason I substituted `StringData` with `std::string_view` in various places was to avoid some circular header dependency.

## ☑️ ToDos
* [ ] 📝 Changelog update
* [ ] 🚦 Tests (or not relevant)
