### PR TITLE
Support sorting based on values from a dictionary.

### DIFF
--- a/src/realm/keys.hpp
+++ b/src/realm/keys.hpp
@@ -182,7 +182,7 @@ inline std::ostream& operator<<(std::ostream& os, ColKey ck)
 struct DictionaryKey {
     ColKey parent_key;
     // FIXME: This should probably be a Mixed instead of hardcoding the string key type.
-    const char* child_key;
+    std::string child_key;
 };
 
 inline std::ostream& operator<<(std::ostream& os, DictionaryKey ck)

--- a/src/realm/keys.hpp
+++ b/src/realm/keys.hpp
@@ -175,6 +175,22 @@ inline std::ostream& operator<<(std::ostream& os, ColKey ck)
     return os;
 }
 
+// Keys inside a dictionary are not directly representable by ColKey,
+// a DictionaryKey represents a key within a dictionary column of some table.
+// For example, consider a table with a dictionary column "dict" with string keys,
+// dict["foo"] can be referenced by a DictionaryKey{get_column_key("dict"), "foo"}.
+struct DictionaryKey {
+    ColKey parent_key;
+    // FIXME: This should probably be a Mixed instead of hardcoding the string key type.
+    const char* child_key;
+};
+
+inline std::ostream& operator<<(std::ostream& os, DictionaryKey ck)
+{
+    os << "DictionaryKey(" << ck.parent_key.value << ", " << ck.child_key << ")";
+    return os;
+}
+
 struct ObjKey {
     constexpr ObjKey() noexcept
         : value(-1)

--- a/src/realm/object-store/results.cpp
+++ b/src/realm/object-store/results.cpp
@@ -1007,7 +1007,7 @@ TableView Results::get_tableview()
     REALM_COMPILER_HINT_UNREACHABLE();
 }
 
-static std::vector<ColKey> parse_keypath(StringData keypath, Schema const& schema, const ObjectSchema* object_schema)
+static std::vector<SortableColumnKey> parse_keypath(StringData keypath, Schema const& schema, const ObjectSchema* object_schema)
 {
     auto check = [&](bool condition, const char* fmt, auto... args) {
         if (!condition) {
@@ -1023,7 +1023,7 @@ static std::vector<ColKey> parse_keypath(StringData keypath, Schema const& schem
     const char* end = keypath.data() + keypath.size();
     check(begin != end, "missing property name");
 
-    std::vector<ColKey> indices;
+    std::vector<SortableColumnKey> indices;
     while (begin != end) {
         auto sep = std::find(begin, end, '.');
         check(sep != begin && sep + 1 != end, "missing property name");
@@ -1064,7 +1064,7 @@ Results Results::sort(std::vector<std::pair<std::string, bool>> const& keypaths)
         return sort({{{}}, {keypaths[0].second}});
     }
 
-    std::vector<std::vector<ColKey>> column_keys;
+    std::vector<std::vector<SortableColumnKey>> column_keys;
     std::vector<bool> ascending;
     column_keys.reserve(keypaths.size());
     ascending.reserve(keypaths.size());
@@ -1139,7 +1139,7 @@ Results Results::distinct(std::vector<std::string> const& keypaths) const
         return distinct(DistinctDescriptor({{ColKey()}}));
     }
 
-    std::vector<std::vector<ColKey>> column_keys;
+    std::vector<std::vector<SortableColumnKey>> column_keys;
     column_keys.reserve(keypaths.size());
     for (auto& keypath : keypaths)
         column_keys.push_back(parse_keypath(keypath, m_realm->schema(), &get_object_schema()));

--- a/src/realm/parser/driver.cpp
+++ b/src/realm/parser/driver.cpp
@@ -1252,9 +1252,9 @@ std::unique_ptr<DescriptorOrdering> DescriptorOrderingNode::visit(ParserDriver* 
         }
         else {
             bool is_distinct = cur_ordering->get_type() == DescriptorNode::DISTINCT;
-            std::vector<std::vector<ColKey>> property_columns;
+            std::vector<std::vector<SortableColumnKey>> property_columns;
             for (auto& col_names : cur_ordering->columns) {
-                std::vector<ColKey> columns;
+                std::vector<SortableColumnKey> columns;
                 LinkChain link_chain(target);
                 for (size_t ndx_in_path = 0; ndx_in_path < col_names.size(); ++ndx_in_path) {
                     std::string path_elem = drv->translate(link_chain, col_names[ndx_in_path]);

--- a/src/realm/sort_descriptor.cpp
+++ b/src/realm/sort_descriptor.cpp
@@ -155,7 +155,7 @@ util::Optional<Mixed> SortableColumnKey::try_get_value(const Obj& obj) const {
             return obj.get_any(col_key);
         },
         [&obj, this](DictionaryKey dict_key) {
-            REALM_ASSERT(dict_key.child_key);
+            REALM_ASSERT(!dict_key.child_key.empty());
             // Not all objects need have this specific sort key in their dictionary.
             const auto dictionary = obj.get_dictionary(dict_key.parent_key);
             return dictionary.try_get(dict_key.child_key);

--- a/src/realm/sort_descriptor.hpp
+++ b/src/realm/sort_descriptor.hpp
@@ -20,8 +20,8 @@
 #define REALM_SORT_DESCRIPTOR_HPP
 
 #include <vector>
-#include <variant>
 #include <unordered_set>
+#include <external/mpark/variant.hpp>
 #include <realm/cluster.hpp>
 #include <realm/mixed.hpp>
 
@@ -33,7 +33,7 @@ class Group;
 
 enum class DescriptorType { Sort, Distinct, Limit };
 
-using SortableColumnKeyVariant = std::variant<ColKey, DictionaryKey>;
+using SortableColumnKeyVariant = mpark::variant<ColKey, DictionaryKey>;
 
 // A key wrapper to be used for sorting,
 // it supports normal column keys as well as dictionary keys.

--- a/test/object-store/dictionary.cpp
+++ b/test/object-store/dictionary.cpp
@@ -1347,14 +1347,6 @@ TEST_CASE("dictionary sort by keyPath value", "[dictionary]") {
     auto col_s1 = table->get_column_key("s1");
     auto col_dict = table->get_column_key("intDictionary");
 
-    /*SECTION("sort by dict field '0'") {
-        // FIXME: Implement sorting by dict field keyPath
-        auto sorted = all_values.sort({{"intDictionary['0']", false}});
-        REQUIRE(sorted.size() == 2);
-        REQUIRE(sorted.get(0).get<Int>(col_id) == 0);
-        REQUIRE(sorted.get(1).get<Int>(col_id) == 1);
-    }*/
-
     SECTION("sort by dict field 'a' using ColKey ascending") {
         Object::create(
             ctx, r, *r->schema().find("DictionaryObject"),

--- a/test/test_link_query_view.cpp
+++ b/test/test_link_query_view.cpp
@@ -718,7 +718,7 @@ TEST(LinkList_SortLinkView)
     CHECK_EQUAL(tv.get_object(2).get_key(), key2);
 
     // Test multi-column sorting
-    std::vector<std::vector<ColKey>> v;
+    std::vector<std::vector<SortableColumnKey>> v;
     std::vector<bool> a = {true, true};
     std::vector<bool> a_false = {false, false};
 

--- a/test/test_table.cpp
+++ b/test/test_table.cpp
@@ -1362,7 +1362,7 @@ TEST_TYPES(Table_Multi_Sort, int64_t, float, double, Decimal128)
     table.create_object(ObjKey(3)).set_all(TEST_TYPE(2), TEST_TYPE(14));
     table.create_object(ObjKey(4)).set_all(TEST_TYPE(1), TEST_TYPE(14));
 
-    std::vector<std::vector<ColKey>> col_ndx1 = {{col_0}, {col_1}};
+    std::vector<std::vector<SortableColumnKey>> col_ndx1 = {{col_0}, {col_1}};
     std::vector<bool> asc = {true, true};
 
     // (0, 10); (1, 10); (1, 14); (2, 10); (2; 14)
@@ -1374,7 +1374,7 @@ TEST_TYPES(Table_Multi_Sort, int64_t, float, double, Decimal128)
     CHECK_EQUAL(ObjKey(1), v_sorted1.get_key(3));
     CHECK_EQUAL(ObjKey(3), v_sorted1.get_key(4));
 
-    std::vector<std::vector<ColKey>> col_ndx2 = {{col_1}, {col_0}};
+    std::vector<std::vector<SortableColumnKey>> col_ndx2 = {{col_1}, {col_0}};
 
     // (0, 10); (1, 10); (2, 10); (1, 14); (2, 14)
     TableView v_sorted2 = table.get_sorted_view(SortDescriptor{col_ndx2, asc});

--- a/test/test_table_view.cpp
+++ b/test/test_table_view.cpp
@@ -837,7 +837,7 @@ TEST(TableView_MultiColSort)
 
     TableView tv = table.where().find_all();
 
-    std::vector<std::vector<ColKey>> v = {{col_int}, {col_float}};
+    std::vector<std::vector<SortableColumnKey>> v = {{col_int}, {col_float}};
     std::vector<bool> a = {true, true};
 
     tv.sort(SortDescriptor{v, a});
@@ -1083,7 +1083,7 @@ TEST(TableView_SortOverLink)
     CHECK_EQUAL(tv.size(), 2);
     CHECK_EQUAL(tv[0].get<Int>(col_int), 2);
     CHECK_EQUAL(tv[1].get<Int>(col_int), 3);
-    std::vector<std::vector<ColKey>> v = {{col_link, col_str}};
+    std::vector<std::vector<SortableColumnKey>> v = {{col_link, col_str}};
     std::vector<bool> a = {true};
     tv.sort(SortDescriptor{v, a});
     CHECK_EQUAL(tv[0].get<Int>(col_int), 3);
@@ -1141,7 +1141,7 @@ TEST(TableView_SortOverMultiLink)
     CHECK_EQUAL(tv[2].get<Int>(col_int), 29);
     CHECK_EQUAL(tv[3].get<Int>(col_int), 30);
 
-    std::vector<std::vector<ColKey>> v = {{col_link1, col_link2, col_str}};
+    std::vector<std::vector<SortableColumnKey>> v = {{col_link1, col_link2, col_str}};
     std::vector<bool> a = {true};
     tv.sort(SortDescriptor{v, a});
     CHECK_EQUAL(tv.size(), 4);
@@ -1203,7 +1203,7 @@ struct DistinctDirect {
 
     SortDescriptor get_sort(std::initializer_list<ColKey> columns, std::vector<bool> ascending = {}) const
     {
-        std::vector<std::vector<ColKey>> column_indices;
+        std::vector<std::vector<SortableColumnKey>> column_indices;
         for (ColKey col : columns)
             column_indices.push_back({col});
         return SortDescriptor(column_indices, ascending);
@@ -1211,7 +1211,7 @@ struct DistinctDirect {
 
     DistinctDescriptor get_distinct(std::initializer_list<ColKey> columns) const
     {
-        std::vector<std::vector<ColKey>> column_indices;
+        std::vector<std::vector<SortableColumnKey>> column_indices;
         for (ColKey col : columns)
             column_indices.push_back({col});
         return DistinctDescriptor(column_indices);
@@ -1244,7 +1244,7 @@ struct DistinctOverLink {
 
     SortDescriptor get_sort(std::initializer_list<ColKey> columns, std::vector<bool> ascending = {}) const
     {
-        std::vector<std::vector<ColKey>> column_indices;
+        std::vector<std::vector<SortableColumnKey>> column_indices;
         for (ColKey col : columns)
             column_indices.push_back({m_col_link, col});
         return SortDescriptor(column_indices, ascending);
@@ -1252,7 +1252,7 @@ struct DistinctOverLink {
 
     DistinctDescriptor get_distinct(std::initializer_list<ColKey> columns) const
     {
-        std::vector<std::vector<ColKey>> column_indices;
+        std::vector<std::vector<SortableColumnKey>> column_indices;
         for (ColKey col : columns)
             column_indices.push_back({m_col_link, col});
         return DistinctDescriptor(column_indices);


### PR DESCRIPTION
## What, How & Why?
This is a draft and a request for comments about the feature and its implementation, I figured the best way to ask for help was to open a PR.

Note that it is currently possible to *filter* by a value stored under a specific dictionary key (using the `dictionary['key']` syntax) but is impossible to *sort* by that same key, this PR aims to change that.

I added some tests and FIXME comments about what I'm unsure about. This is my first time actually touching Realm's core code :)

Sorting is implemented by storing the parent dictionary's ColKey and the specific dictionary key we want to sort by.

This is a work-in-progress, the performance characteristics of searching the dictionary for the desired key on every iteration of the sort predicate are unknown.

The dictionary ColKey and the desired sort key are currently stored inside the ColKey structure to avoid changing too much of the SortDescriptor interface.

Sorting by dictionary keys using keyPath is currently not implemented (but desired).

In the future this could be extended to support sorting on specific indexes of a collection, ie. sort('array[0]').

## Pain points
- ~Changing the ColKey structure to store the extra fields needed feels like a hack, and makes it way bigger than a single 64 bit integer, this probably affects the cost of copying it all throughout the codebase. Maybe it would be better to store this data directly inside the SortDescriptor?~ This data is now stored in DictionaryKey and SortableColumnKey.
- The sort currently gets the parent dictionary and queries it for the sort key on _every_ iteration of the Sorter predicate, I'm not sure how fast that is, but the answer is probably "not at all".
- ~Currently only dictionaries of integers/strings are supported, this could probably be extended to arbitrary-length paths.~ Following links through the dictionary keys is now supported, it was nice low-hanging fruit after the SortableColumnKey implementation.
- There is very little error-checking in this patch, I wanted to get it out there and see what reaction I get about the feature.

## Example scenario
When you have data in the Entity-Attribute-Value pattern with dynamic attributes and want to allow the users of your application to sort by any of the fields, it's more convenient to have a dictionary of attributes keyed by attribute id in your table and be able to filter and sort by that directly.
Currently the way to solve that is to extract your Attributes into another table, filter that table by AttributeId, and then sort it based on the AttributeValue, after that you can grab the parent objects by looping through the attribute objects and grabbing a backlink to the parent Entity. But this seems convoluted when all you want is a simple sort.

## Update 1
Following feedback I reworked this patch so that the ColKey structure is unchanged. A new DictionaryKey structure was added to hold the required information to reference the specific dictionary keys, and the SortDescriptor and Sorter now deal with a derived type of std::variant<ColKey, DictionaryKey> called SortableColumnKey that deals with dispatching the proper key-specific behavior depending on the key type.

<!-- Describe the changes and give some hints to guide your reviewers if possible. -->
<!-- Link to relevant issue this fixes -->

## ☑️ ToDos
* [ ] 📝 Changelog update
* [X] 🚦 Tests (or not relevant)
