### PR TITLE
Fix race in SubscriptionSet::get_state_change_nofication()

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@
 * SyncManager::path_for_realm now returns a default path when FLX sync is enabled ([#5088](https://github.com/realm/realm-core/pull/5088))
 * Having links in a property of Mixed type would lead to ill-formed JSON output when serializing the database. ([#5125](https://github.com/realm/realm-core/issues/5125), since v11.0.0)
 * FLX sync QUERY messages are now ordered with UPLOAD messages ([#5135](https://github.com/realm/realm-core/pull/5135))
+* Fixed race condition when waiting for state change notifications on FLX subscription sets that may have caused a hang ([#5146](https://github.com/realm/realm-core/pull/5146))
 
 ### Breaking changes
 * FLX SubscriptionSet type split into SubscriptionSet and MutableSubscriptionSet to add type safety ([#5092](https://github.com/realm/realm-core/pull/5092))

--- a/src/realm/sync/subscriptions.hpp
+++ b/src/realm/sync/subscriptions.hpp
@@ -384,6 +384,8 @@ protected:
     std::unique_ptr<SubscriptionKeys> m_sub_keys;
 
     mutable std::mutex m_pending_notifications_mutex;
+    mutable std::condition_variable m_pending_notifications_cv;
+    mutable int64_t m_outstanding_requests = 0;
     mutable int64_t m_min_outstanding_version = 0;
     mutable std::list<NotificationRequest> m_pending_notifications;
 };

--- a/test/test_sync_subscriptions.cpp
+++ b/test/test_sync_subscriptions.cpp
@@ -349,6 +349,18 @@ TEST(Sync_SubscriptionStoreNotifications)
     // immediately.
     CHECK_EQUAL(sub_set.get_state_change_notification(SubscriptionSet::State::Bootstrapping).get(),
                 SubscriptionSet::State::Complete);
+
+    auto mut_set = store.get_latest().make_mutable_copy();
+    auto waitable_set = std::move(mut_set).commit();
+
+    {
+        mut_set = store.get_mutable_by_version(waitable_set.version());
+        mut_set.update_state(SubscriptionSet::State::Complete);
+        std::move(mut_set).commit();
+    }
+
+    waitable_set.get_state_change_notification(SubscriptionSet::State::Complete).get();
+    waitable_set.get_state_change_notification(SubscriptionSet::State::Complete).get();
 }
 
 } // namespace realm::sync


### PR DESCRIPTION
If there have been writes to the database since SubscriptionSet was
created we need to refresh our state before maybe returning a ready
future. We also need to block process_notifications while determining
whether to return a ready future because otherwise the state may change
between deciding not to add a ready future and acquiring the lock to add
the pending future.

## What, How & Why?
<!-- Describe the changes and give some hints to guide your reviewers if possible. -->
<!-- Link to relevant issue this fixes -->

## ☑️ ToDos
* [x] 📝 Changelog update
* [x] 🚦 Tests (or not relevant)
