### PR TITLE
Handle out-of-view client resets in FLX sync

### DIFF
--- a/src/realm/object-store/impl/realm_coordinator.cpp
+++ b/src/realm/object-store/impl/realm_coordinator.cpp
@@ -190,6 +190,12 @@ void RealmCoordinator::set_config(const Realm::Config& config)
         if (config.sync_config->flx_sync_requested && !config.sync_config->partition_value.empty()) {
             throw std::logic_error("Cannot specify a partition value when flexible sync is enabled");
         }
+        // TODO(RCORE-912) we definitely do want to support this, but until its implemented we should prevent users
+        // from using something that is currently broken.
+        if (config.sync_config->flx_sync_requested &&
+            config.sync_config->client_resync_mode != ClientResyncMode::Manual) {
+            throw std::logic_error("Only manual client resets are supported with flexible sync");
+        }
     }
 #endif
 

--- a/src/realm/sync/config.cpp
+++ b/src/realm/sync/config.cpp
@@ -148,6 +148,7 @@ SimplifiedProtocolError get_simplified_error(sync::ProtocolError err)
         case ProtocolError::user_blacklisted:
         case ProtocolError::object_already_exists:
         case ProtocolError::server_permissions_changed:
+        case ProtocolError::write_not_allowed:
             return SimplifiedProtocolError::ClientResetRequested;
     }
     return SimplifiedProtocolError::UnexpectedInternalIssue; // always return a value to appease MSVC.

--- a/src/realm/sync/protocol.cpp
+++ b/src/realm/sync/protocol.cpp
@@ -136,6 +136,9 @@ const char* get_protocol_error_message(int error_code) noexcept
             return "Server permissions for this file ident have changed since the last time it was used (IDENT)";
         case ProtocolError::initial_sync_not_completed:
             return "Client tried to open a session before initial sync is complete (BIND)";
+        case ProtocolError::write_not_allowed:
+            return "Client attempted a write that is disallowed by permissions, or modifies an object outside the "
+                   "current query - requires client reset";
     }
     return nullptr;
 }

--- a/src/realm/sync/protocol.hpp
+++ b/src/realm/sync/protocol.hpp
@@ -248,6 +248,8 @@ enum class ProtocolError {
     server_permissions_changed   = 228, // Server permissions for this file ident have changed since the last time it
                                         // was used (IDENT)
     initial_sync_not_completed   = 229, // Client tried to open a session before initial sync is complete (BIND)
+    write_not_allowed            = 230, // Client attempted a write that is disallowed by permissions, or modifies an
+                                        // object outside the current query - requires client reset (UPLOAD)
 
     // clang-format on
 };


### PR DESCRIPTION
## What, How & Why?
This adds the error code the server will send back if the client upload something that is "out-of-view" to the server as described in REALMC-11271. I'm not tackling supporting the DiscardLocal client resync mode here since I think that will be kinda involved, for now I think we should just make sure the error codes get exposed correctly.

## ☑️ ToDos
* [ ] 📝 Changelog update
* [x] 🚦 Tests (or not relevant)
