### PR TITLE
Use correct tests when determining whether to send a QUERY message

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@
 
 ### Fixed
 * <How do the end-user experience this issue? what was the impact?> ([#????](https://github.com/realm/realm-core/issues/????), since v?.?.?)
-* None.
+* Sending a QUERY message may fail with `Assertion failed: !m_unbind_message_sent` ([#5149](https://github.com/realm/realm-core/pull/5149), since v11.8.0)
  
 ### Breaking changes
 * None.

--- a/src/realm/sync/client.cpp
+++ b/src/realm/sync/client.cpp
@@ -724,6 +724,9 @@ void SessionImpl::on_resumed()
 
 void SessionImpl::on_new_flx_subscription_set(int64_t new_version)
 {
+    // If m_state == State::Active then we know that we haven't sent an UNBIND message and all we need to
+    // check is that we have completed the IDENT message handshake and have not yet received an ERROR
+    // message to call ensure_enlisted_to_send().
     if (m_state == State::Active && m_ident_message_sent && !m_error_message_received) {
         logger.trace("Requesting QUERY change message for new subscription set version %1", new_version);
         ensure_enlisted_to_send();

--- a/src/realm/sync/client.cpp
+++ b/src/realm/sync/client.cpp
@@ -724,7 +724,7 @@ void SessionImpl::on_resumed()
 
 void SessionImpl::on_new_flx_subscription_set(int64_t new_version)
 {
-    if (m_conn.get_state() == ConnectionState::connected) {
+    if (m_state == State::Active && m_ident_message_sent && !m_error_message_received) {
         logger.trace("Requesting QUERY change message for new subscription set version %1", new_version);
         ensure_enlisted_to_send();
     }


### PR DESCRIPTION
## What, How & Why?
This fixes a pretty narrow race that happens if the callback to send a new QUERY message gets ordered on the sync thread's run loop after the session is torn down, so I haven't try to reproduce it in a test, but it's happened more than once for @tomduncalf. So I think we should get this change in that at least brings the behavior of checking whether its safe to send messages in line with how the rest of the sync client checks for that condition.

## ☑️ ToDos
* [x] 📝 Changelog update
* [ ] 🚦 Tests (or not relevant)
