### PR TITLE
SubscriptionSet should not hold any database resources

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,7 @@
 * Errors in C API no longer store or expose a std::exception_ptr. The comparison of realm_async_error_t now compares error code vs object identity. ([#5064](https://github.com/realm/realm-core/pull/5064))
 * The JSON output is slightly changed in the event of link cycles. Nobody is expected to rely on that.
 * Future::get_async() no longer requires its callback to be marked noexcept. ([#5130](https://github.com/realm/realm-core/pull/5130))
+* SubscriptionSet no longer holds any database resources. ([#5150](https://github.com/realm/realm-core/pull/5150))
 
 ----------------------------------------------
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 * <New feature description> (PR [#????](https://github.com/realm/realm-core/pull/????))
 * Support arithmetric operations (+, -, *, /) in query parser. Operands can be properties and/or constants of numeric types (integer, float, double or Decimal128). You can now say something like "(age + 5) * 2 > child.age".
 * Support for asynchronous transactions added. (PR [#5035](https://github.com/realm/realm-core/pull/5035))
+* FLX sync now properly handles write_not_allowed client reset errors ([#5147](https://github.com/realm/realm-core/pull/5147))
 
 ### Fixed
 * <How do the end-user experience this issue? what was the impact?> ([#????](https://github.com/realm/realm-core/issues/????), since v?.?.?)

--- a/src/realm/sync/subscriptions.cpp
+++ b/src/realm/sync/subscriptions.cpp
@@ -310,6 +310,7 @@ void SubscriptionSet::refresh()
     auto refreshed_self = m_mgr->get_by_version(version());
     m_state = refreshed_self.m_state;
     m_error_str = refreshed_self.m_error_str;
+    m_cur_version = refreshed_self.m_cur_version;
     *this = m_mgr->get_by_version(version());
 }
 

--- a/src/realm/sync/subscriptions.cpp
+++ b/src/realm/sync/subscriptions.cpp
@@ -55,9 +55,9 @@ Subscription::Subscription(const SubscriptionStore* parent, Obj obj)
     : m_id(obj.get<ObjectId>(parent->m_sub_keys->id))
     , m_created_at(obj.get<Timestamp>(parent->m_sub_keys->created_at))
     , m_updated_at(obj.get<Timestamp>(parent->m_sub_keys->updated_at))
-    , m_name(static_cast<std::string_view>(obj.get<StringData>(parent->m_sub_keys->name)))
-    , m_object_class_name(static_cast<std::string_view>(obj.get<StringData>(parent->m_sub_keys->object_class_name)))
-    , m_query_string(static_cast<std::string_view>(obj.get<StringData>(parent->m_sub_keys->query_str)))
+    , m_name(obj.get<String>(parent->m_sub_keys->name))
+    , m_object_class_name(obj.get<String>(parent->m_sub_keys->object_class_name))
+    , m_query_string(obj.get<String>(parent->m_sub_keys->query_str))
 {
 }
 
@@ -445,7 +445,7 @@ SubscriptionSet MutableSubscriptionSet::commit() &&
 
 std::string SubscriptionSet::to_ext_json() const
 {
-    if (!m_subs.empty()) {
+    if (m_subs.empty()) {
         return "{}";
     }
 

--- a/src/realm/sync/subscriptions.cpp
+++ b/src/realm/sync/subscriptions.cpp
@@ -49,130 +49,116 @@ constexpr static std::string_view c_flx_sub_name_field("name");
 constexpr static std::string_view c_flx_sub_object_class_field("object_class");
 constexpr static std::string_view c_flx_sub_query_str_field("query");
 
-inline std::string_view to_string_view(StringData in) noexcept
-{
-    return std::string_view(in.data(), in.size());
-}
-
 } // namespace
 
 Subscription::Subscription(const SubscriptionStore* parent, Obj obj)
-    : m_store(parent)
-    , m_obj(std::move(obj))
+    : m_id(obj.get<ObjectId>(parent->m_sub_keys->id))
+    , m_created_at(obj.get<Timestamp>(parent->m_sub_keys->created_at))
+    , m_updated_at(obj.get<Timestamp>(parent->m_sub_keys->updated_at))
+    , m_name(static_cast<std::string_view>(obj.get<StringData>(parent->m_sub_keys->name)))
+    , m_object_class_name(static_cast<std::string_view>(obj.get<StringData>(parent->m_sub_keys->object_class_name)))
+    , m_query_string(static_cast<std::string_view>(obj.get<StringData>(parent->m_sub_keys->query_str)))
+{
+}
+
+Subscription::Subscription(std::string name, std::string object_class_name, std::string query_str)
+    : m_id(ObjectId::gen())
+    , m_created_at(std::chrono::system_clock::now())
+    , m_updated_at(m_created_at)
+    , m_name(std::move(name))
+    , m_object_class_name(std::move(object_class_name))
+    , m_query_string(std::move(query_str))
 {
 }
 
 ObjectId Subscription::id() const
 {
-    return m_obj.get<ObjectId>(m_store->m_sub_keys->id);
+    return m_id;
 }
 
 Timestamp Subscription::created_at() const
 {
-    return m_obj.get<Timestamp>(m_store->m_sub_keys->created_at);
+    return m_created_at;
 }
 
 Timestamp Subscription::updated_at() const
 {
-    return m_obj.get<Timestamp>(m_store->m_sub_keys->updated_at);
+    return m_updated_at;
 }
 
 std::string_view Subscription::name() const
 {
-    return to_string_view(m_obj.get<StringData>(m_store->m_sub_keys->name));
+    return m_name;
 }
 
 std::string_view Subscription::object_class_name() const
 {
-    return to_string_view(m_obj.get<StringData>(m_store->m_sub_keys->object_class_name));
+    return m_object_class_name;
 }
 
 std::string_view Subscription::query_string() const
 {
-    return to_string_view(m_obj.get<StringData>(m_store->m_sub_keys->query_str));
-}
-
-SubscriptionSet::iterator::iterator(const SubscriptionSet* parent, LnkLst::iterator it)
-    : m_parent(parent)
-    , m_sub_it(std::move(it))
-    , m_cur_sub(m_parent->subscription_from_iterator(m_sub_it))
-{
-}
-
-SubscriptionSet::iterator& SubscriptionSet::iterator::operator++()
-{
-    ++m_sub_it;
-    m_cur_sub = m_parent->subscription_from_iterator(m_sub_it);
-    return *this;
-}
-
-SubscriptionSet::iterator SubscriptionSet::iterator::operator++(int)
-{
-    auto ret = *this;
-    ++(*this);
-    return ret;
+    return m_query_string;
 }
 
 SubscriptionSet::SubscriptionSet(const SubscriptionStore* mgr, TransactionRef tr, Obj obj)
     : m_mgr(mgr)
-    , m_tr(std::move(tr))
-    , m_obj(std::move(obj))
-    , m_sub_list{}
 {
-    if (m_obj.is_valid()) {
-        m_sub_list = LnkLst(m_obj, m_mgr->m_sub_set_keys->subscriptions);
+    if (obj.is_valid()) {
+        load_from_database(std::move(tr), std::move(obj));
+    }
+}
+
+void SubscriptionSet::load_from_database(TransactionRef tr, Obj obj)
+{
+    m_cur_version = tr->get_version();
+    m_version = obj.get_primary_key().get_int();
+    m_state = static_cast<State>(obj.get<int64_t>(m_mgr->m_sub_set_keys->state));
+    m_error_str = obj.get<String>(m_mgr->m_sub_set_keys->error_str);
+    m_snapshot_version = static_cast<DB::version_type>(obj.get<int64_t>(m_mgr->m_sub_set_keys->snapshot_version));
+    auto sub_list = obj.get_linklist(m_mgr->m_sub_set_keys->subscriptions);
+    m_subs.clear();
+    for (size_t idx = 0; idx < sub_list.size(); ++idx) {
+        m_subs.push_back(Subscription(m_mgr, sub_list.get_object(idx)));
     }
 }
 
 int64_t SubscriptionSet::version() const
 {
-    if (!m_obj.is_valid()) {
-        return 0;
-    }
-    return m_obj.get_primary_key().get_int();
+    return m_version;
 }
 
 SubscriptionSet::State SubscriptionSet::state() const
 {
-    if (!m_obj.is_valid()) {
-        return State::Uncommitted;
-    }
-    return static_cast<State>(m_obj.get<int64_t>(m_mgr->m_sub_set_keys->state));
+    return m_state;
 }
 
 StringData SubscriptionSet::error_str() const
 {
-    if (!m_obj.is_valid()) {
+    if (m_error_str.empty()) {
         return StringData{};
     }
-    return m_obj.get<StringData>(m_mgr->m_sub_set_keys->error_str);
+    return m_error_str;
 }
 
 size_t SubscriptionSet::size() const
 {
-    if (!m_obj.is_valid()) {
-        return 0;
-    }
-    return m_sub_list.size();
+    return m_subs.size();
 }
 
 Subscription SubscriptionSet::at(size_t index) const
 {
-    if (index >= m_sub_list.size()) {
-        throw std::out_of_range("index");
-    }
-
-    return Subscription(m_mgr, m_sub_list.get_object(index));
+    return m_subs.at(index);
 }
 
 SubscriptionSet::const_iterator SubscriptionSet::begin() const
 {
-    return iterator(this, m_sub_list.begin());
+    return m_subs.begin();
 }
 
 SubscriptionSet::const_iterator SubscriptionSet::end() const
 {
-    return iterator(this, m_sub_list.end());
+    return m_subs.end();
 }
 
 SubscriptionSet::const_iterator SubscriptionSet::find(StringData name) const
@@ -191,55 +177,54 @@ SubscriptionSet::const_iterator SubscriptionSet::find(const Query& query) const
     });
 }
 
-SubscriptionSet::const_iterator MutableSubscriptionSet::erase(const_iterator it)
+MutableSubscriptionSet::MutableSubscriptionSet(const SubscriptionStore* mgr, TransactionRef tr, Obj obj)
+    : SubscriptionSet(mgr, tr, obj)
+    , m_tr(std::move(tr))
+    , m_obj(std::move(obj))
+    , m_old_state(state())
 {
-    m_sub_list.remove_target_row(it.m_sub_it.index());
-    auto at_end = (it.m_sub_it.index() == m_sub_list.size());
-    return at_end ? const_iterator(this, m_sub_list.end())
-                  : const_iterator(this, LnkLst::iterator(&m_sub_list, it.m_sub_it.index()));
+}
+
+MutableSubscriptionSet::iterator MutableSubscriptionSet::begin()
+{
+    return m_subs.begin();
+}
+
+MutableSubscriptionSet::iterator MutableSubscriptionSet::end()
+{
+    return m_subs.end();
+}
+
+SubscriptionSet::iterator MutableSubscriptionSet::erase(iterator it)
+{
+    return m_subs.erase(it);
 }
 
 void MutableSubscriptionSet::clear()
 {
-    m_sub_list.remove_all_target_rows();
+    m_subs.clear();
 }
 
-void SubscriptionSet::insert_sub_impl(ObjectId id, Timestamp created_at, Timestamp updated_at, StringData name,
-                                      StringData object_class_name, StringData query_str)
+void MutableSubscriptionSet::insert_sub(const Subscription& sub)
 {
-    auto new_sub = m_sub_list.create_and_insert_linked_object(m_sub_list.is_empty() ? 0 : m_sub_list.size());
-    new_sub.set(m_mgr->m_sub_keys->id, id);
-    new_sub.set(m_mgr->m_sub_keys->created_at, created_at);
-    new_sub.set(m_mgr->m_sub_keys->updated_at, updated_at);
-    new_sub.set(m_mgr->m_sub_keys->name, name);
-    new_sub.set(m_mgr->m_sub_keys->object_class_name, object_class_name);
-    new_sub.set(m_mgr->m_sub_keys->query_str, query_str);
+    m_subs.push_back(sub);
 }
 
-Subscription SubscriptionSet::subscription_from_iterator(LnkLst::iterator it) const
+std::pair<SubscriptionSet::iterator, bool>
+MutableSubscriptionSet::insert_or_assign_impl(iterator it, std::string name, std::string object_class_name,
+                                              std::string query_str)
 {
-    if (it == m_sub_list.end()) {
-        return Subscription(m_mgr, Obj{});
-    }
-    return Subscription(m_mgr, m_sub_list.get_object(it.index()));
-}
-
-std::pair<SubscriptionSet::iterator, bool> MutableSubscriptionSet::insert_or_assign_impl(iterator it, StringData name,
-                                                                                         StringData object_class_name,
-                                                                                         StringData query_str)
-{
-    auto now = Timestamp{std::chrono::system_clock::now()};
     if (it != end()) {
-        it->m_obj.set(m_mgr->m_sub_keys->object_class_name, object_class_name);
-        it->m_obj.set(m_mgr->m_sub_keys->query_str, query_str);
-        it->m_obj.set(m_mgr->m_sub_keys->updated_at, now);
+        it->m_object_class_name = std::move(object_class_name);
+        it->m_query_string = std::move(query_str);
+        it->m_updated_at = Timestamp{std::chrono::system_clock::now()};
 
         return {it, false};
     }
+    it = m_subs.insert(m_subs.end(),
+                       Subscription(std::move(name), std::move(object_class_name), std::move(query_str)));
 
-    insert_sub_impl(ObjectId::gen(), now, now, name, object_class_name, query_str);
-
-    return {iterator(this, LnkLst::iterator(&m_sub_list, m_sub_list.size() - 1)), true};
+    return {it, true};
 }
 
 std::pair<SubscriptionSet::iterator, bool> MutableSubscriptionSet::insert_or_assign(std::string_view name,
@@ -251,7 +236,7 @@ std::pair<SubscriptionSet::iterator, bool> MutableSubscriptionSet::insert_or_ass
         return (sub.name() == name);
     });
 
-    return insert_or_assign_impl(it, name, table_name, query_str);
+    return insert_or_assign_impl(it, std::string{name}, std::move(table_name), std::move(query_str));
 }
 
 std::pair<SubscriptionSet::iterator, bool> MutableSubscriptionSet::insert_or_assign(const Query& query)
@@ -262,8 +247,7 @@ std::pair<SubscriptionSet::iterator, bool> MutableSubscriptionSet::insert_or_ass
         return (sub.name().empty() && sub.object_class_name() == table_name && sub.query_string() == query_str);
     });
 
-    std::string_view name;
-    return insert_or_assign_impl(it, name, table_name, query_str);
+    return insert_or_assign_impl(it, std::string{}, std::move(table_name), std::move(query_str));
 }
 
 void MutableSubscriptionSet::update_state(State new_state, util::Optional<std::string_view> error_str)
@@ -282,27 +266,29 @@ void MutableSubscriptionSet::update_state(State new_state, util::Optional<std::s
                 throw std::logic_error("Must supply an error message when setting a subscription to the error state");
             }
 
-            m_obj.set(m_mgr->m_sub_set_keys->state, static_cast<int64_t>(new_state));
-            m_obj.set(m_mgr->m_sub_set_keys->error_str, StringData(error_str->data(), error_str->size()));
+            m_state = new_state;
+            m_error_str = std::string{*error_str};
             break;
         case State::Bootstrapping:
-        case State::Pending:
             if (error_str) {
                 throw std::logic_error(
                     "Cannot supply an error message for a subscription set when state is not Error");
             }
-            m_obj.set(m_mgr->m_sub_set_keys->state, static_cast<int64_t>(new_state));
+            m_state = new_state;
             break;
         case State::Complete:
             if (error_str) {
                 throw std::logic_error(
                     "Cannot supply an error message for a subscription set when state is not Error");
             }
-            m_obj.set(m_mgr->m_sub_set_keys->state, static_cast<int64_t>(new_state));
+            m_state = new_state;
             m_mgr->supercede_prior_to(m_tr, version());
             break;
         case State::Superceded:
             throw std::logic_error("Cannot set a subscription to the superceded state");
+            break;
+        case State::Pending:
+            throw std::logic_error("Cannot set subscription set to the pending state");
             break;
     }
 }
@@ -343,7 +329,7 @@ util::Future<SubscriptionSet::State> SubscriptionSet::get_state_change_notificat
 
     // If there have been writes to the database since this SubscriptionSet was created, we need to fetch
     // the updated version from the DB to know the true current state and maybe return a ready future.
-    if (m_tr->get_version() < m_mgr->m_db->get_version_of_latest_snapshot()) {
+    if (m_cur_version < m_mgr->m_db->get_version_of_latest_snapshot()) {
         auto refreshed_self = m_mgr->get_by_version(version());
         cur_state = refreshed_self.state();
         err_str = refreshed_self.error_str();
@@ -410,9 +396,28 @@ SubscriptionSet MutableSubscriptionSet::commit() &&
     if (m_tr->get_transact_stage() != DB::transact_Writing) {
         throw std::logic_error("SubscriptionSet is not in a commitable state");
     }
-    if (state() == State::Uncommitted) {
+    if (m_old_state == State::Uncommitted) {
+        if (m_state == State::Uncommitted) {
+            m_state = State::Pending;
+        }
         m_obj.set(m_mgr->m_sub_set_keys->snapshot_version, static_cast<int64_t>(m_tr->get_version()));
-        update_state(State::Pending, util::none);
+
+        auto obj_sub_list = m_obj.get_linklist(m_mgr->m_sub_set_keys->subscriptions);
+        obj_sub_list.clear();
+        for (const auto& sub : m_subs) {
+            auto new_sub =
+                obj_sub_list.create_and_insert_linked_object(obj_sub_list.is_empty() ? 0 : obj_sub_list.size());
+            new_sub.set(m_mgr->m_sub_keys->id, sub.id());
+            new_sub.set(m_mgr->m_sub_keys->created_at, sub.created_at());
+            new_sub.set(m_mgr->m_sub_keys->updated_at, sub.updated_at());
+            new_sub.set(m_mgr->m_sub_keys->name, StringData(sub.name()));
+            new_sub.set(m_mgr->m_sub_keys->object_class_name, StringData(sub.object_class_name()));
+            new_sub.set(m_mgr->m_sub_keys->query_str, StringData(sub.query_string()));
+        }
+    }
+    m_obj.set(m_mgr->m_sub_set_keys->state, static_cast<int64_t>(m_state));
+    if (!m_error_str.empty()) {
+        m_obj.set(m_mgr->m_sub_set_keys->error_str, StringData(m_error_str));
     }
 
     const auto flx_version = version();
@@ -429,7 +434,7 @@ SubscriptionSet MutableSubscriptionSet::commit() &&
 
 std::string SubscriptionSet::to_ext_json() const
 {
-    if (!m_obj.is_valid()) {
+    if (!m_subs.empty()) {
         return "{}";
     }
 
@@ -682,8 +687,7 @@ MutableSubscriptionSet SubscriptionStore::make_mutable_copy(const SubscriptionSe
     MutableSubscriptionSet new_set_obj(this, std::move(new_tr),
                                        sub_sets->create_object_with_primary_key(Mixed{new_pk}));
     for (const auto& sub : set) {
-        new_set_obj.insert_sub_impl(sub.id(), sub.created_at(), sub.updated_at(), sub.name(), sub.object_class_name(),
-                                    sub.query_string());
+        new_set_obj.insert_sub(sub);
     }
 
     return new_set_obj;

--- a/src/realm/sync/subscriptions.hpp
+++ b/src/realm/sync/subscriptions.hpp
@@ -178,7 +178,10 @@ public:
 
 protected:
     friend class SubscriptionStore;
+    struct SupercededTag {
+    };
 
+    explicit SubscriptionSet(const SubscriptionStore* mgr, int64_t version, SupercededTag);
     explicit SubscriptionSet(const SubscriptionStore* mgr, TransactionRef tr, Obj obj);
 
     void load_from_database(TransactionRef tr, Obj obj);

--- a/test/test_sync_subscriptions.cpp
+++ b/test/test_sync_subscriptions.cpp
@@ -343,6 +343,8 @@ TEST(Sync_SubscriptionStoreNotifications)
     // Also check that new requests for the superceded sub set get filled immediately.
     CHECK_EQUAL(old_sub_set.get_state_change_notification(SubscriptionSet::State::Complete).get(),
                 SubscriptionSet::State::Superceded);
+    old_sub_set.refresh();
+    CHECK_EQUAL(old_sub_set.state(), SubscriptionSet::State::Superceded);
 
     // Check that asking for a state change that is less than the current state of the sub set gets filled
     // immediately.

--- a/test/test_sync_subscriptions.cpp
+++ b/test/test_sync_subscriptions.cpp
@@ -37,9 +37,9 @@ TEST(Sync_SubscriptionStoreBasic)
         // Because there are no subscription sets yet, get_latest should point to an invalid object
         // and all the property accessors should return dummy values.
         auto latest = store.get_latest();
-        CHECK_EQUAL(latest.begin(), latest.end());
+        CHECK(latest.begin() == latest.end());
         CHECK_EQUAL(latest.size(), 0);
-        CHECK_EQUAL(latest.find("a sub"), latest.end());
+        CHECK(latest.find("a sub") == latest.end());
         CHECK_EQUAL(latest.version(), 0);
         CHECK(latest.error_str().is_null());
         CHECK_EQUAL(latest.state(), SubscriptionSet::State::Uncommitted);
@@ -54,7 +54,7 @@ TEST(Sync_SubscriptionStoreBasic)
         query_a.equal(fixture.foo_col, StringData("JBR")).greater_equal(fixture.bar_col, int64_t(1));
         auto&& [it, inserted] = out.insert_or_assign("a sub", query_a);
         CHECK(inserted);
-        CHECK_NOT_EQUAL(it, out.end());
+        CHECK_NOT(it == out.end());
         CHECK_EQUAL(it->name(), "a sub");
         CHECK_EQUAL(it->object_class_name(), "a");
         CHECK_EQUAL(it->query_string(), query_a.get_description());
@@ -74,14 +74,14 @@ TEST(Sync_SubscriptionStoreBasic)
         CHECK_EQUAL(set.version(), 1);
         CHECK_EQUAL(set.size(), 1);
         auto it = set.find(query_a);
-        CHECK_NOT_EQUAL(it, set.end());
+        CHECK_NOT(it == set.end());
         CHECK_EQUAL(it->name(), "a sub");
         CHECK_EQUAL(it->object_class_name(), "a");
         CHECK_EQUAL(it->query_string(), query_a.get_description());
 
         // Make sure we can't get a subscription set that doesn't exist.
         auto it_end = set.find("b subs");
-        CHECK_EQUAL(it_end, set.end());
+        CHECK(it_end == set.end());
     }
 }
 
@@ -100,10 +100,9 @@ TEST(Sync_SubscriptionStoreStateUpdates)
     // Create a new subscription set, insert a subscription into it, and mark it as complete.
     {
         auto out = store.get_latest().make_mutable_copy();
-        auto read_tr = fixture.db->start_read();
         auto&& [it, inserted] = out.insert_or_assign("a sub", query_a);
         CHECK(inserted);
-        CHECK_NOT_EQUAL(it, out.end());
+        CHECK_NOT(it == out.end());
 
         out.update_state(SubscriptionSet::State::Complete);
         std::move(out).commit();
@@ -166,11 +165,11 @@ TEST(Sync_SubscriptionStoreStateUpdates)
         auto it = set.begin();
         CHECK_EQUAL(it->name(), "b sub");
         it = set.erase(it);
-        CHECK_NOT_EQUAL(it, set.end());
+        CHECK_NOT(it == set.end());
         CHECK_EQUAL(set.size(), 1);
         CHECK_EQUAL(it->name(), new_sub_name);
         it = set.erase(it);
-        CHECK_EQUAL(it, set.end());
+        CHECK(it == set.end());
         CHECK_EQUAL(set.size(), 0);
     }
 }
@@ -192,13 +191,13 @@ TEST(Sync_SubscriptionStoreUpdateExisting)
         auto out = store.get_latest().make_mutable_copy();
         auto [it, inserted] = out.insert_or_assign(sub_name, query_a);
         CHECK(inserted);
-        CHECK_NOT_EQUAL(it, out.end());
+        CHECK_NOT(it == out.end());
         id_of_inserted = it->id();
         CHECK_NOT_EQUAL(id_of_inserted, ObjectId{});
 
         std::tie(it, inserted) = out.insert_or_assign(sub_name, query_b);
         CHECK(!inserted);
-        CHECK_NOT_EQUAL(it, out.end());
+        CHECK_NOT(it == out.end());
         CHECK_EQUAL(it->object_class_name(), "a");
         CHECK_EQUAL(it->query_string(), query_b.get_description());
         CHECK_EQUAL(it->id(), id_of_inserted);
@@ -210,7 +209,7 @@ TEST(Sync_SubscriptionStoreUpdateExisting)
         auto it = std::find_if(set.begin(), set.end(), [&](const Subscription& sub) {
             return sub.id() == id_of_inserted;
         });
-        CHECK_NOT_EQUAL(it, set.end());
+        CHECK_NOT(it == set.end());
         CHECK_EQUAL(it->name(), sub_name);
     }
 }


### PR DESCRIPTION
## What, How & Why?
This reworks the implementation of `SubscriptionSet`/`MutableSubscriptionSet` so that `SubscriptionSet` does not actually hold on to any database resources and we can avoid pinning old versions of the database if a user holds on to a `SubscriptionSet` for a long time.

This simplified a bunch of things - like we don't need to maintain our own iterator implementation anymore, we can just re-use `std::vector`'s iterators. But it also made the commit method do actual serialization work in addition to just committing.

This also lets us handle the `Superceded` state a little more gracefully. Before, if you called `refresh()` on a `Superceded` `SubscriptonSet` it would throw a `KeyNotFound` error, and now it will properly update the state info.

## ☑️ ToDos
* [x] 📝 Changelog update
* [x] 🚦 Tests (or not relevant)
