### PR TITLE
Discard token from bind and refresh messages

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -73,7 +73,7 @@
 * Future::get_async() no longer requires its callback to be marked noexcept. ([#5130](https://github.com/realm/realm-core/pull/5130))
 * SubscriptionSet no longer holds any database resources. ([#5150](https://github.com/realm/realm-core/pull/5150))
 * ClientHistoryImpl::integrate_server_changesets now throws instead of returning a boolean to indicate success ([#5118](https://github.com/realm/realm-core/pull/5118))
-* Send empty token in bind and refresh messages. ([#5151](https://github.com/realm/realm-core/pull/5151))
+* Send empty access token in bind messages. Remove refresh message from sync protocol. ([#5151](https://github.com/realm/realm-core/pull/5151))
 
 ----------------------------------------------
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -73,6 +73,7 @@
 * Future::get_async() no longer requires its callback to be marked noexcept. ([#5130](https://github.com/realm/realm-core/pull/5130))
 * SubscriptionSet no longer holds any database resources. ([#5150](https://github.com/realm/realm-core/pull/5150))
 * ClientHistoryImpl::integrate_server_changesets now throws instead of returning a boolean to indicate success ([#5118](https://github.com/realm/realm-core/pull/5118))
+* Send empty token in bind and refresh messages. ([#5151](https://github.com/realm/realm-core/pull/5151))
 
 ----------------------------------------------
 

--- a/doc/protocol/protocol_1.md
+++ b/doc/protocol/protocol_1.md
@@ -461,35 +461,6 @@ abrupt disconnections.
 All ALLOC messages must be sent after the [IDENT](#ident) message has been sent.
 
 
-### REFRESH
-
-    head  =  'refresh'  <session ident>  <signed user token size>
-    body  =  <signed user token>
-
-The client sends a REFRESH message when it has procured a new user token for
-authorization purposes. When the server receives a REFRESH message, and the new
-user token passes verification, the server will consider the session
-authenticated with the new token. If the new token grants fewer access rights in
-the current session or is expired, the server will still install it for this
-session and behave accordingly (i.e., terminate the session with an error code
-indicating lack of privileges).
-
-The client will be interested in sending this message when it is able to
-ascertain that its token is about to expire, so as to avoid receiving any
-"Access token expired" (202) error codes, causing the session to be terminated
-and requiring reestablishment of the session with a fresh token.
-
-Param: `<signed user token>` is the new user token. See the [BIND](#bind) message
-for a description of the contents of the user token.
-
-The client is allowed to send the REFRESH message any number of times during a
-session.
-
-The client is not allowed to send a REFRESH message whose token specifies a
-different user identity than the token in the [BIND](#bind) message that initiated
-the session.
-
-
 ### STATE_REQUEST
 
     head  =  'state_request'  <session ident>  <partial transfer server version>
@@ -1044,17 +1015,17 @@ The list of errors passed in [ERROR](#error) messages.
 | 200  | Session closed (no error)
 | 201  | Other session level error
 | 202  | Access token expired
-| 203  | Bad user authentication (BIND, REFRESH)
+| 203  | Bad user authentication (BIND)
 | 204  | Illegal Realm path (BIND)
 | 205  | No such Realm (BIND)
-| 206  | Permission denied (BIND, REFRESH)
+| 206  | Permission denied (BIND)
 | 207  | Bad server file identifier (IDENT) (obsolete)
 | 208  | Bad client file identifier (IDENT)
 | 209  | Bad server version (IDENT, UPLOAD)
 | 210  | Bad client version (IDENT, UPLOAD)
 | 211  | Diverging histories (IDENT)
 | 212  | Bad changeset (UPLOAD)
-| 213  | Disabled session (BIND, REFRESH, IDENT, UPLOAD, MARK)
+| 213  | Disabled session (BIND, IDENT, UPLOAD, MARK)
 | 214  | Partial sync disabled (BIND)
 | 215  | Unsupported session-level feature
 | 216  | Bad origin file identifier (UPLOAD)

--- a/src/realm/sync/client.cpp
+++ b/src/realm/sync/client.cpp
@@ -638,12 +638,6 @@ const std::string& SessionImpl::get_virt_path() const noexcept
     return m_wrapper.m_virt_path;
 }
 
-
-const std::string& SessionImpl::get_signed_access_token() const noexcept
-{
-    return m_wrapper.m_signed_access_token;
-}
-
 const std::string& SessionImpl::get_realm_path() const noexcept
 {
     return m_wrapper.m_db->get_path();
@@ -1075,7 +1069,6 @@ void SessionWrapper::refresh(std::string signed_access_token)
         ClientImpl::Connection& conn = sess.get_connection();
         // FIXME: This only makes sense when each session uses a separate connection.
         conn.update_connect_info(self->m_http_request_path_prefix, self->m_signed_access_token); // Throws
-        sess.new_access_token_available();                                                       // Throws
         sess.cancel_resumption_delay();                                                          // Throws
         conn.cancel_reconnect_delay();                                                           // Throws
     });

--- a/src/realm/sync/noinst/client_impl_base.cpp
+++ b/src/realm/sync/noinst/client_impl_base.cpp
@@ -1595,9 +1595,6 @@ void Session::send_message()
     if (!m_bind_message_sent)
         return send_bind_message(); // Throws
 
-    if (!m_access_token_sent)
-        return send_refresh_message(); // Throws
-
     if (!m_ident_message_sent) {
         if (have_client_file_ident())
             send_ident_message(); // Throws
@@ -1659,7 +1656,6 @@ void Session::send_bind_message()
     m_conn.initiate_write_message(out, this);                           // Throws
 
     m_bind_message_sent = true;
-    m_access_token_sent = true;
 
     // Ready to send the IDENT message if the file identifier pair is already
     // available.
@@ -1891,37 +1887,6 @@ void Session::send_mark_message()
 }
 
 
-void Session::send_refresh_message()
-{
-    REALM_ASSERT(m_state == Active);
-    REALM_ASSERT(m_bind_message_sent);
-    REALM_ASSERT(!m_unbind_message_sent);
-    REALM_ASSERT(!m_access_token_sent);
-
-    // Discard the token since it's ignored by the server.
-    std::string empty_access_token{};
-    std::size_t signed_access_token_size = empty_access_token.size();
-
-    logger.debug("Sending: REFRESH(signed_user_token_size=%1)",
-                 signed_access_token_size); // Throws
-
-    ClientProtocol& protocol = m_conn.get_client_protocol();
-    OutputBuffer& out = m_conn.get_output_buffer();
-    session_ident_type session_ident = get_ident();
-    protocol.make_refresh_message(out, session_ident, empty_access_token); // Throws
-    m_conn.initiate_write_message(out, this);                              // Throws
-
-    m_access_token_sent = true;
-
-    // If the IDENT message has not yet been sent, is now ready to be sent if the
-    // file identifier pair has become available. If IDENT message has been
-    // sent, various other messages may be waiting to be sent, but in that case,
-    // we also have the file identifier pair.
-    if (have_client_file_ident())
-        enlist_to_send(); // Throws
-}
-
-
 void Session::send_unbind_message()
 {
     REALM_ASSERT(m_state == Deactivating || m_error_message_received);
@@ -1969,7 +1934,7 @@ std::error_code Session::receive_ident_message(SaltedFileIdent client_file_ident
     m_client_file_ident = client_file_ident;
 
     if (REALM_UNLIKELY(get_client().is_dry_run())) {
-        // Ready to send the IDENT (or REFRESH) message
+        // Ready to send the IDENT message
         ensure_enlisted_to_send(); // Throws
         return std::error_code{};  // Success
     }
@@ -2036,7 +2001,7 @@ std::error_code Session::receive_ident_message(SaltedFileIdent client_file_ident
         this->m_progress.upload.client_version = 0;
     }
 
-    // Ready to send the IDENT (or REFRESH) message
+    // Ready to send the IDENT message
     ensure_enlisted_to_send(); // Throws
     return std::error_code{};  // Success
 }

--- a/src/realm/sync/noinst/client_impl_base.cpp
+++ b/src/realm/sync/noinst/client_impl_base.cpp
@@ -1645,7 +1645,6 @@ void Session::send_bind_message()
 
     session_ident_type session_ident = m_ident;
     const std::string& path = get_virt_path();
-    const std::string& signed_access_token = get_signed_access_token();
     bool need_client_file_ident = !have_client_file_ident();
     const bool is_subserver = false;
 
@@ -1653,8 +1652,10 @@ void Session::send_bind_message()
     ClientProtocol& protocol = m_conn.get_client_protocol();
     int protocol_version = m_conn.get_negotiated_protocol_version();
     OutputBuffer& out = m_conn.get_output_buffer();
-    protocol.make_bind_message(protocol_version, out, session_ident, path, signed_access_token,
-                               need_client_file_ident, is_subserver);   // Throws
+    // Discard the token since it's ignored by the server.
+    std::string empty_access_token{};
+    protocol.make_bind_message(protocol_version, out, session_ident, path, empty_access_token, need_client_file_ident,
+                               is_subserver);                           // Throws
     m_conn.initiate_write_message(out, this);                           // Throws
 
     m_bind_message_sent = true;
@@ -1897,8 +1898,9 @@ void Session::send_refresh_message()
     REALM_ASSERT(!m_unbind_message_sent);
     REALM_ASSERT(!m_access_token_sent);
 
-    const std::string& signed_access_token = get_signed_access_token();
-    std::size_t signed_access_token_size = signed_access_token.size();
+    // Discard the token since it's ignored by the server.
+    std::string empty_access_token{};
+    std::size_t signed_access_token_size = empty_access_token.size();
 
     logger.debug("Sending: REFRESH(signed_user_token_size=%1)",
                  signed_access_token_size); // Throws
@@ -1906,8 +1908,8 @@ void Session::send_refresh_message()
     ClientProtocol& protocol = m_conn.get_client_protocol();
     OutputBuffer& out = m_conn.get_output_buffer();
     session_ident_type session_ident = get_ident();
-    protocol.make_refresh_message(out, session_ident, signed_access_token); // Throws
-    m_conn.initiate_write_message(out, this);                               // Throws
+    protocol.make_refresh_message(out, session_ident, empty_access_token); // Throws
+    m_conn.initiate_write_message(out, this);                              // Throws
 
     m_access_token_sent = true;
 

--- a/src/realm/sync/noinst/server/server.cpp
+++ b/src/realm/sync/noinst/server/server.cpp
@@ -2797,7 +2797,7 @@ public:
         return true;
     }
 
-    bool receive_refresh_message(std::string signed_user_token, ProtocolError&)
+    bool receive_refresh_message(std::string signed_user_token)
     {
         // Protocol state must be AllocatingIdent, SendIdent, WaitForIdent, or WaitForUnbind.
         REALM_ASSERT(!unbind_message_received());
@@ -5609,10 +5609,7 @@ void SyncConnection::receive_refresh_message(session_ident_type session_ident, s
         return;
     }
 
-    ProtocolError error;
-    bool success = sess.receive_refresh_message(std::move(signed_user_token), error); // Throws
-    if (REALM_UNLIKELY(!success))                                                     // Throws
-        protocol_error(error, &sess);                                                 // Throws
+    sess.receive_refresh_message(std::move(signed_user_token)); // Throws
 }
 
 

--- a/src/realm/sync/noinst/server/server.cpp
+++ b/src/realm/sync/noinst/server/server.cpp
@@ -2620,7 +2620,6 @@ public:
     void terminate()
     {
         logger.detail("Session terminated", m_session_ident);         // Throws
-        modify_user_sessions_metric(-1);                              // Throws
         metrics().increment("session.terminated");                    // Throws
         metrics().gauge("session.online", --gauges().session_online); // Throws
     }
@@ -2652,12 +2651,6 @@ public:
             return;
         }
         // Protocol state was SendUnbound, and remains unchanged
-    }
-
-    bool expired()
-    {
-        const ServerImpl& server = m_connection.get_server();
-        return (m_access_token && m_access_token->expired(server.token_expiration_clock_now()));
     }
 
     bool is_enlisted_to_send() const noexcept
@@ -2740,96 +2733,6 @@ public:
         // This session is now destroyed!
     }
 
-    bool authenticate_user(const std::string& signed_user_token, bool is_refresh, ProtocolError& perror)
-    {
-        AccessToken::ParseError error;
-        Optional<AccessToken> access_token =
-            m_connection.get_server().get_access_control().verify_access_token(signed_user_token, &error);
-        switch (error) {
-            case AccessToken::ParseError::invalid_base64: {
-                logger.error("Invalid Base64 (signed_user_token='%1', is_refresh=%2)",
-                             short_token_fmt(signed_user_token), is_refresh); // Throws
-                metrics().increment("authentication.failed");                 // Throws
-                perror = ProtocolError::bad_authentication;
-                return false;
-            }
-            case AccessToken::ParseError::invalid_json: {
-                logger.error("Invalid JSON (signed_user_token='%1', is_refresh=%2)",
-                             short_token_fmt(signed_user_token), is_refresh); // Throws
-                metrics().increment("authentication.failed");                 // Throws
-                perror = ProtocolError::bad_authentication;
-                return false;
-            }
-            case AccessToken::ParseError::invalid_signature: {
-                if (access_token) {
-                    if (is_refresh && access_token->identity != m_access_token->identity)
-                        goto wrong_identity;
-                    // Invalid signature, but still got a token; this indicates
-                    // that we're running without token verification, so
-                    // issue a warning and proceed.
-                    logger.warn("Accepting client without authentication!"); // Throws
-                    metrics().increment("authentication.failed");            // Throws
-                    m_access_token = std::move(access_token);
-                    return true;
-                }
-                else {
-                    logger.error("Signature does not match user token (signed_user_token='%1', "
-                                 "is_refresh=%2)",
-                                 short_token_fmt(signed_user_token),
-                                 is_refresh);                     // Throws
-                    metrics().increment("authentication.failed"); // Throws
-                    perror = ProtocolError::bad_authentication;
-                    return false;
-                }
-            }
-            case AccessToken::ParseError::invalid_jwt: {
-                logger.error("Invalid JWT format (signed_user_token='%1', is_refresh=%2)",
-                             short_token_fmt(signed_user_token), is_refresh); // Throws
-                metrics().increment("authentication.failed");                 // Throws
-                perror = ProtocolError::bad_authentication;
-                return false;
-            }
-            case AccessToken::ParseError::none:
-                REALM_ASSERT(access_token);
-
-                if (is_refresh && access_token->identity != m_access_token->identity) {
-                wrong_identity:
-                    logger.error("Change of user identity during session (signed_user_token='%1')",
-                                 short_token_fmt(signed_user_token)); // Throws
-                    metrics().increment("authentication.failed");     // Throws
-                    perror = ProtocolError::bad_authentication;
-                    return false;
-                }
-
-                const ServerImpl& server = m_connection.get_server();
-                if (access_token->expired(server.token_expiration_clock_now())) {
-                    logger.detail("Token expired (signed_user_token='%1', is_refresh=%2)",
-                                  short_token_fmt(signed_user_token), is_refresh); // Throws
-                    metrics().increment("authentication.failed");                  // Throws
-                    perror = ProtocolError::token_expired;
-                    return false;
-                }
-
-                if (access_token->sync_label) {
-                    if (*access_token->sync_label != "default") {
-                        const ServerImpl& server = m_connection.get_server();
-                        if (!server.is_load_balancing_allowed()) {
-                            logger.error("Load balancing is not allowed by the feature token "
-                                         "(signed_user_token='%1', is_refresh=%2)",
-                                         short_token_fmt(signed_user_token), is_refresh); // Throws
-                            metrics().increment("authentication.failed");                 // Throws
-                            perror = ProtocolError::bad_authentication;
-                            return false;
-                        }
-                    }
-                }
-
-                m_access_token = std::move(access_token);
-                return true;
-        }
-        REALM_UNREACHABLE();
-    }
-
     bool receive_bind_message(std::string path, std::string signed_user_token, bool need_client_file_ident,
                               bool is_subserver, ProtocolError& error)
     {
@@ -2839,12 +2742,6 @@ public:
                           path, short_token_fmt(signed_user_token), int(need_client_file_ident),
                           int(is_subserver)); // Throws
         }
-
-        bool is_refresh = false;
-        if (!authenticate_user(signed_user_token, is_refresh, error)) // Throws
-            return false;
-
-        modify_user_sessions_metric(+1); // Throws
 
         ServerImpl& server = m_connection.get_server();
         _impl::VirtualPathComponents virt_path_components =
@@ -2858,35 +2755,6 @@ public:
             metrics().increment("protocol.violated");         // Throws
             error = ProtocolError::illegal_realm_path;
             return false;
-        }
-
-        const AccessControl& access_control = server.get_access_control();
-        bool is_admin = access_control.is_admin(*m_access_token);
-
-        // For now, clients can only declare themselves as subservers if they
-        // have admin rights.
-        if (REALM_UNLIKELY(is_subserver && !is_admin)) {
-            logger.error("Permission denied: Client without admin rights cannot declare itself as "
-                         "subserver");                // Throws
-            metrics().increment("permission.denied"); // Throws
-            error = ProtocolError::permission_denied;
-            return false;
-        }
-
-        // We need to check that the user has permission to work with the Realm corresponding to path.
-        // Admin users have full access.
-
-        if (!is_admin) {
-            // Full sync for a non-admin user.
-            if (REALM_UNLIKELY(!access_control.can(*m_access_token, Privilege::Download, path))) {
-                logger.error("Permission denied for full sync "
-                             "(message_type='bind', permission='download', path='%1', "
-                             "signed_user_token='%2')",
-                             path, short_token_fmt(signed_user_token)); // Throws
-                metrics().increment("permission.denied");               // Throws
-                error = ProtocolError::permission_denied;
-                return false;
-            }
         }
 
         // The user has proper permissions at this stage.
@@ -2908,8 +2776,8 @@ public:
 
         m_server_file->add_unidentified_session(this); // Throws
 
-        logger.info("Client info: (path='%1', user='%2', from=%3, protocol=%4) %5", path, m_access_token->identity,
-                    m_connection.get_remote_endpoint(), m_connection.get_client_protocol_version(),
+        logger.info("Client info: (path='%1', from=%2, protocol=%3) %4", path, m_connection.get_remote_endpoint(),
+                    m_connection.get_client_protocol_version(),
                     m_connection.get_client_user_agent()); // Throws
 
         m_is_subserver = is_subserver;
@@ -2929,7 +2797,7 @@ public:
         return true;
     }
 
-    bool receive_refresh_message(std::string signed_user_token, ProtocolError& error)
+    bool receive_refresh_message(std::string signed_user_token, ProtocolError&)
     {
         // Protocol state must be AllocatingIdent, SendIdent, WaitForIdent, or WaitForUnbind.
         REALM_ASSERT(!unbind_message_received());
@@ -2937,22 +2805,6 @@ public:
 
         logger.detail("Received: REFRESH(signed_user_token='%1')",
                       short_token_fmt(signed_user_token)); // Throws
-
-        bool is_refresh = true;
-        if (!authenticate_user(signed_user_token, is_refresh, error)) // Throws
-            return false;
-
-        const std::string& virt_path = m_server_file->get_virt_path();
-        const AccessControl& access_control = m_connection.get_server().get_access_control();
-        if (!access_control.can(*m_access_token, Privilege::Download, virt_path)) {
-            logger.error("Permission denied "
-                         "(message_type='bind', permission='download', path='%1', "
-                         "signed_user_token='%2').",
-                         virt_path, short_token_fmt(signed_user_token)); // Throws
-            metrics().increment("permission.denied");                    // Throws
-            error = ProtocolError::permission_denied;
-            return false;
-        }
 
         return true;
     }
@@ -2976,30 +2828,6 @@ public:
                      "latest_server_version_salt=%6)",
                      client_file_ident, client_file_ident_salt, scan_server_version, scan_client_version,
                      latest_server_version, latest_server_version_salt); // Throws
-
-        if (!m_access_token) {
-            logger.error("Permission denied (message_type='ident', reason='not logged in')"); // Throws
-            metrics().increment("permission.denied");                                         // Throws
-            error = ProtocolError::permission_denied;
-            return false;
-        }
-
-        if (expired()) {
-            logger.detail("Received IDENT message while session token had expired"); // Throws
-            metrics().increment("authentication.failed");                            // Throws
-            error = ProtocolError::token_expired;
-            return false;
-        }
-
-        ServerImpl& server = m_connection.get_server();
-        const std::string& virt_path = m_server_file->get_virt_path();
-        const AccessControl& access_control = server.get_access_control();
-        if (!access_control.can(*m_access_token, Privilege::Download, virt_path)) {
-            logger.error("Permission denied (message_type='ident', permission='download')"); // Throws
-            metrics().increment("permission.denied");                                        // Throws
-            error = ProtocolError::permission_denied;
-            return false;
-        }
 
         {
             const ClientFileBlacklist& list = m_server_file->get_client_file_blacklist();
@@ -3107,6 +2935,7 @@ public:
         m_upload_threshold = upload_threshold;
         m_locked_server_version = locked_server_version;
 
+        ServerImpl& server = m_connection.get_server();
         const Server::Config& config = server.get_config();
         m_disable_download = (config.disable_download_for.count(client_file_ident) != 0);
 
@@ -3135,39 +2964,6 @@ public:
                       "locked_server_version=%3, num_changesets=%4)",
                       progress_client_version, progress_server_version, locked_server_version,
                       upload_changesets.size()); // Throws
-
-        // UPLOAD permission is only checked if there are actually changesets in
-        // the UPLOAD message. If the UPLOAD message is empty, it means only
-        // that the client is reporting its download progress to the server, so
-        // we actually want to react to that when we can, such that history can
-        // be compacted, even for read-only clients.
-        if (!upload_changesets.empty()) {
-            if (REALM_UNLIKELY(!m_access_token)) {
-                logger.error("Permission denied (message_type='upload', "
-                             "reason='not logged in')");  // Throws
-                metrics().increment("permission.denied"); // Throws
-                error = ProtocolError::permission_denied;
-                return false;
-            }
-
-            if (REALM_UNLIKELY(expired())) {
-                logger.detail("Received non-empty UPLOAD message while session token had "
-                              "expired");                     // Throws
-                metrics().increment("authentication.failed"); // Throws
-                error = ProtocolError::token_expired;
-                return false;
-            }
-
-            const AccessControl& access_control = m_connection.get_server().get_access_control();
-            const std::string& virt_path = m_server_file->get_virt_path();
-            if (REALM_UNLIKELY(!access_control.can(*m_access_token, Privilege::Upload, virt_path))) {
-                logger.error("Permission denied (message_type='upload', path='%1')",
-                             virt_path);                  // Throws
-                metrics().increment("permission.denied"); // Throws
-                error = ProtocolError::permission_denied;
-                return false;
-            }
-        }
 
         // We are unable to reproduce the cursor object for the upload progress
         // when the protocol version is less than 29, because the client does
@@ -3424,7 +3220,7 @@ public:
         return true;
     }
 
-    bool receive_mark_message(request_ident_type request_ident, ProtocolError& error)
+    bool receive_mark_message(request_ident_type request_ident, ProtocolError&)
     {
         // Protocol state must be WaitForUnbind
         REALM_ASSERT(!m_send_ident_message);
@@ -3434,13 +3230,6 @@ public:
         REALM_ASSERT(!m_error_message_sent);
 
         logger.debug("Received: MARK(request_ident=%1)", request_ident); // Throws
-
-        if (expired()) {
-            logger.detail("Received MARK message while session token had expired"); // Throws
-            metrics().increment("authentication.failed");                           // Throws
-            error = ProtocolError::token_expired;
-            return false;
-        }
 
         m_download_completion_request = request_ident;
 
@@ -3489,10 +3278,6 @@ private:
     // reset to null when the deactivation process is initiated, either when the
     // UNBIND message is recieved, or when initiate_deactivation() is called.
     util::bind_ptr<ServerFile> m_server_file;
-
-    // The current access token, if any, for this session. This is populated
-    // by authenticate_user() after receiving a BIND message.
-    Optional<AccessToken> m_access_token;
 
     bool m_disable_download = false;
     bool m_is_subserver = false;
@@ -3869,16 +3654,6 @@ private:
         if (m_file_ident_request != 0)
             file.cancel_file_ident_request(m_file_ident_request);
         m_server_file.reset();
-    }
-
-    void modify_user_sessions_metric(double diff)
-    {
-        if (m_access_token) {
-            std::string key =
-                ("user_sessions,identity=" + Metrics::percent_encode(m_access_token->identity)); // Throws
-            double val = (gauges().user_sessions[m_access_token->identity] += diff);             // Throws
-            metrics().gauge(key.c_str(), val);                                                   // Throws
-        }
     }
 
     friend class SessionQueue;

--- a/test/test_sync.cpp
+++ b/test/test_sync.cpp
@@ -3255,9 +3255,6 @@ TEST(Sync_Permissions)
 
     TEST_DIR(server_dir);
 
-    // FIXME: This could use a single client, but the fixture doesn't really
-    // make it easier to deal with session-level errors without disrupting other
-    // sessions.
     ClientServerFixture fixture{server_dir, test_context};
     fixture.set_client_side_error_handler([&](std::error_code, bool, const std::string& message) {
         CHECK_EQUAL("", message);


### PR DESCRIPTION
## What, How & Why?
Token is ignored on the server so we send an empty one. Related to #4047.

## ☑️ ToDos
* [x] 📝 Changelog update
* [x] 🚦 Tests (or not relevant)
