### PR TITLE
Subscription names should be a default-constructed string_view if empty

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 * <How do the end-user experience this issue? what was the impact?> ([#????](https://github.com/realm/realm-core/issues/????), since v?.?.?)
 * If a list of objects contains links to objects not included in the synchronized partition, the indices contained in CollectionChangeSet for that list may be wrong ([#5164](https://github.com/realm/realm-core/issues/5164), since v10.0.0)
 * Sending a QUERY message may fail with `Assertion failed: !m_unbind_message_sent` ([#5149](https://github.com/realm/realm-core/pull/5149), since v11.8.0)
+* Subscription names correctly distinguish an empty string from a nullptr ([#5160](https://github.com/realm/realm-core/pull/5160), since v11.8.0)
  
 ### Breaking changes
 * None.

--- a/src/realm/sync/subscriptions.cpp
+++ b/src/realm/sync/subscriptions.cpp
@@ -89,6 +89,11 @@ Timestamp Subscription::updated_at() const
     return m_updated_at;
 }
 
+bool Subscription::has_name() const
+{
+    return static_cast<bool>(m_name);
+}
+
 std::string_view Subscription::name() const
 {
     if (!m_name) {
@@ -246,7 +251,7 @@ std::pair<SubscriptionSet::iterator, bool> MutableSubscriptionSet::insert_or_ass
     auto table_name = Group::table_name_to_class_name(query.get_table()->get_name());
     auto query_str = query.get_description();
     auto it = std::find_if(begin(), end(), [&](const Subscription& sub) {
-        return (sub.name() == name);
+        return (sub.has_name() && sub.name() == name);
     });
 
     return insert_or_assign_impl(it, std::string{name}, std::move(table_name), std::move(query_str));

--- a/src/realm/sync/subscriptions.cpp
+++ b/src/realm/sync/subscriptions.cpp
@@ -88,6 +88,9 @@ Timestamp Subscription::updated_at() const
 
 std::string_view Subscription::name() const
 {
+    if (m_name.empty()) {
+        return std::string_view{};
+    }
     return m_name;
 }
 

--- a/src/realm/sync/subscriptions.cpp
+++ b/src/realm/sync/subscriptions.cpp
@@ -49,19 +49,22 @@ constexpr static std::string_view c_flx_sub_name_field("name");
 constexpr static std::string_view c_flx_sub_object_class_field("object_class");
 constexpr static std::string_view c_flx_sub_query_str_field("query");
 
+using OptionalString = util::Optional<std::string>;
+
 } // namespace
 
 Subscription::Subscription(const SubscriptionStore* parent, Obj obj)
     : m_id(obj.get<ObjectId>(parent->m_sub_keys->id))
     , m_created_at(obj.get<Timestamp>(parent->m_sub_keys->created_at))
     , m_updated_at(obj.get<Timestamp>(parent->m_sub_keys->updated_at))
-    , m_name(obj.get<String>(parent->m_sub_keys->name))
+    , m_name(obj.is_null(parent->m_sub_keys->name) ? OptionalString(util::none)
+                                                   : OptionalString{obj.get<String>(parent->m_sub_keys->name)})
     , m_object_class_name(obj.get<String>(parent->m_sub_keys->object_class_name))
     , m_query_string(obj.get<String>(parent->m_sub_keys->query_str))
 {
 }
 
-Subscription::Subscription(std::string name, std::string object_class_name, std::string query_str)
+Subscription::Subscription(util::Optional<std::string> name, std::string object_class_name, std::string query_str)
     : m_id(ObjectId::gen())
     , m_created_at(std::chrono::system_clock::now())
     , m_updated_at(m_created_at)
@@ -88,10 +91,10 @@ Timestamp Subscription::updated_at() const
 
 std::string_view Subscription::name() const
 {
-    if (m_name.empty()) {
+    if (!m_name) {
         return std::string_view{};
     }
-    return m_name;
+    return m_name.value();
 }
 
 std::string_view Subscription::object_class_name() const
@@ -221,8 +224,8 @@ void MutableSubscriptionSet::insert_sub(const Subscription& sub)
 }
 
 std::pair<SubscriptionSet::iterator, bool>
-MutableSubscriptionSet::insert_or_assign_impl(iterator it, std::string name, std::string object_class_name,
-                                              std::string query_str)
+MutableSubscriptionSet::insert_or_assign_impl(iterator it, util::Optional<std::string> name,
+                                              std::string object_class_name, std::string query_str)
 {
     if (it != end()) {
         it->m_object_class_name = std::move(object_class_name);
@@ -257,7 +260,7 @@ std::pair<SubscriptionSet::iterator, bool> MutableSubscriptionSet::insert_or_ass
         return (sub.name().empty() && sub.object_class_name() == table_name && sub.query_string() == query_str);
     });
 
-    return insert_or_assign_impl(it, std::string{}, std::move(table_name), std::move(query_str));
+    return insert_or_assign_impl(it, util::none, std::move(table_name), std::move(query_str));
 }
 
 void MutableSubscriptionSet::update_state(State new_state, util::Optional<std::string_view> error_str)
@@ -424,7 +427,9 @@ SubscriptionSet MutableSubscriptionSet::commit() &&
             new_sub.set(m_mgr->m_sub_keys->id, sub.id());
             new_sub.set(m_mgr->m_sub_keys->created_at, sub.created_at());
             new_sub.set(m_mgr->m_sub_keys->updated_at, sub.updated_at());
-            new_sub.set(m_mgr->m_sub_keys->name, StringData(sub.name()));
+            if (sub.m_name) {
+                new_sub.set(m_mgr->m_sub_keys->name, StringData(sub.name()));
+            }
             new_sub.set(m_mgr->m_sub_keys->object_class_name, StringData(sub.object_class_name()));
             new_sub.set(m_mgr->m_sub_keys->query_str, StringData(sub.query_string()));
         }

--- a/src/realm/sync/subscriptions.hpp
+++ b/src/realm/sync/subscriptions.hpp
@@ -49,6 +49,9 @@ public:
     // Returns the timestamp of the last time this subscription was updated by calling update_query.
     Timestamp updated_at() const;
 
+    // Returns whether the subscription was created as an anonymous subscription or a named subscription.
+    bool has_name() const;
+
     // Returns the name of the subscription that was set when it was created.
     std::string_view name() const;
 

--- a/src/realm/sync/subscriptions.hpp
+++ b/src/realm/sync/subscriptions.hpp
@@ -63,12 +63,12 @@ private:
     friend class MutableSubscriptionSet;
 
     Subscription(const SubscriptionStore* parent, Obj obj);
-    Subscription(std::string name, std::string object_class_name, std::string query_str);
+    Subscription(util::Optional<std::string> name, std::string object_class_name, std::string query_str);
 
     ObjectId m_id;
     Timestamp m_created_at;
     Timestamp m_updated_at;
-    std::string m_name;
+    util::Optional<std::string> m_name;
     std::string m_object_class_name;
     std::string m_query_string;
 };
@@ -258,8 +258,8 @@ private:
     // To refresh a MutableSubscriptionSet, you should call commit() and call refresh() on its return value.
     void refresh() = delete;
 
-    std::pair<iterator, bool> insert_or_assign_impl(iterator it, std::string name, std::string object_class_name,
-                                                    std::string query_str);
+    std::pair<iterator, bool> insert_or_assign_impl(iterator it, util::Optional<std::string> name,
+                                                    std::string object_class_name, std::string query_str);
 
     void insert_sub_impl(ObjectId id, Timestamp created_at, Timestamp updated_at, StringData name,
                          StringData object_class_name, StringData query_str);

--- a/test/test_sync_subscriptions.cpp
+++ b/test/test_sync_subscriptions.cpp
@@ -261,6 +261,7 @@ TEST(Sync_SubscriptionStoreAssignAnonAndNamed)
 
         std::tie(it, inserted) = out.insert_or_assign("", query_b);
         CHECK(inserted);
+        CHECK(it->has_name());
         CHECK_EQUAL(it->name(), "");
         CHECK_NOT_EQUAL(it->id(), named_id);
         CHECK_EQUAL(out.size(), 4);

--- a/test/test_sync_subscriptions.cpp
+++ b/test/test_sync_subscriptions.cpp
@@ -259,8 +259,9 @@ TEST(Sync_SubscriptionStoreAssignAnonAndNamed)
         CHECK(inserted);
         named_id = it->id();
 
-        std::tie(it, inserted) = out.insert_or_assign("b sub", query_b);
+        std::tie(it, inserted) = out.insert_or_assign("", query_b);
         CHECK(inserted);
+        CHECK_EQUAL(it->name(), "");
         CHECK_NOT_EQUAL(it->id(), named_id);
         CHECK_EQUAL(out.size(), 4);
     }

--- a/test/test_sync_subscriptions.cpp
+++ b/test/test_sync_subscriptions.cpp
@@ -30,6 +30,7 @@ struct SubscriptionStoreFixture {
 
 TEST(Sync_SubscriptionStoreBasic)
 {
+    ObjectId anon_sub_id;
     SHARED_GROUP_TEST_PATH(sub_store_path);
     {
         SubscriptionStoreFixture fixture(sub_store_path);
@@ -58,6 +59,17 @@ TEST(Sync_SubscriptionStoreBasic)
         CHECK_EQUAL(it->name(), "a sub");
         CHECK_EQUAL(it->object_class_name(), "a");
         CHECK_EQUAL(it->query_string(), query_a.get_description());
+
+        std::tie(it, inserted) =
+            out.insert_or_assign(Query(read_tr->get_table(fixture.a_table_key)).equal(fixture.foo_col, "bizz"));
+        CHECK_NOT(it == out.end());
+        CHECK(inserted);
+
+        CHECK_EQUAL(it->name(), std::string_view{});
+        StringData name(it->name());
+        CHECK(name.is_null());
+        anon_sub_id = it->id();
+
         std::move(out).commit();
     }
 
@@ -72,7 +84,7 @@ TEST(Sync_SubscriptionStoreBasic)
 
         auto set = store.get_latest();
         CHECK_EQUAL(set.version(), 1);
-        CHECK_EQUAL(set.size(), 1);
+        CHECK_EQUAL(set.size(), 2);
         auto it = set.find(query_a);
         CHECK_NOT(it == set.end());
         CHECK_EQUAL(it->name(), "a sub");
@@ -82,6 +94,12 @@ TEST(Sync_SubscriptionStoreBasic)
         // Make sure we can't get a subscription set that doesn't exist.
         auto it_end = set.find("b subs");
         CHECK(it_end == set.end());
+
+        auto anon_sub_it = std::find_if(set.begin(), set.end(), [&](const Subscription& sub) {
+            return sub.id() == anon_sub_id;
+        });
+        CHECK_NOT(anon_sub_it == set.end());
+        CHECK_EQUAL(anon_sub_it->name(), std::string_view{});
     }
 }
 


### PR DESCRIPTION
## What, How & Why?
Since changing SubscriptionSet's to not hold any database resources, the Subscription object's name hasn't been able to distinguish between a name that's an empty string and an anonymous subscription. This is definitely a very weird and small corner case, but I've fixed it here nonetheless for completeness's sake.

## ☑️ ToDos
* [x] 📝 Changelog update
* [x] 🚦 Tests (or not relevant)
