### PR TITLE
Translate IncompatibleHistories

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 ### Fixed
 * <How do the end-user experience this issue? what was the impact?> ([#????](https://github.com/realm/realm-core/issues/????), since v?.?.?)
 * UserIdentity metadata table grows indefinitely. ([#5152](https://github.com/realm/realm-core/issues/5152), since v10.0.0)
+* Add `IncompatibleHistories` case when translating file exceptions (since v6.0.0).
  
 ### Breaking changes
 * None.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,6 @@
 ### Fixed
 * <How do the end-user experience this issue? what was the impact?> ([#????](https://github.com/realm/realm-core/issues/????), since v?.?.?)
 * UserIdentity metadata table grows indefinitely. ([#5152](https://github.com/realm/realm-core/issues/5152), since v10.0.0)
-* Add `IncompatibleHistories` case when translating file exceptions (since v6.0.0).
  
 ### Breaking changes
 * None.
@@ -18,7 +17,7 @@
 -----------
 
 ### Internals
-* None.
+* Add `IncompatibleHistories` case when translating file exceptions (since v6.0.0).
 
 ----------------------------------------------
 

--- a/src/realm/object-store/impl/realm_coordinator.cpp
+++ b/src/realm/object-store/impl/realm_coordinator.cpp
@@ -453,8 +453,7 @@ REALM_NOINLINE void translate_file_exception(StringData path, bool immutable)
     }
     catch (IncompatibleHistories const& ex) {
         RealmFileException::Kind error_kind = RealmFileException::Kind::BadHistoryError;
-        throw RealmFileException(error_kind, ex.get_path(),
-                                 util::format("Unable to open realm: %1.", ex.what()),
+        throw RealmFileException(error_kind, ex.get_path(), util::format("Unable to open realm: %1.", ex.what()),
                                  ex.what());
     }
     catch (util::File::AccessError const& ex) {

--- a/src/realm/object-store/impl/realm_coordinator.cpp
+++ b/src/realm/object-store/impl/realm_coordinator.cpp
@@ -451,15 +451,18 @@ REALM_NOINLINE void translate_file_exception(StringData path, bool immutable)
                                  "in order to proceed.",
                                  ex.what());
     }
+    catch (IncompatibleHistories const& ex) {
+        RealmFileException::Kind error_kind = RealmFileException::Kind::BadHistoryError;
+        throw RealmFileException(error_kind, ex.get_path(),
+                                 util::format("Unable to open realm: %1.", ex.what()),
+                                 ex.what());
+    }
     catch (util::File::AccessError const& ex) {
         // Errors for `open()` include the path, but other errors don't. We
         // don't want two copies of the path in the error, so strip it out if it
         // appears, and then include it in our prefix.
         std::string underlying = ex.what();
         RealmFileException::Kind error_kind = RealmFileException::Kind::AccessError;
-        // FIXME: Replace this with a proper specific exception type once Core adds support for it.
-        if (underlying == "Bad or incompatible history type")
-            error_kind = RealmFileException::Kind::BadHistoryError;
         auto pos = underlying.find(ex.get_path());
         if (pos != std::string::npos && pos > 0) {
             // One extra char at each end for the quotes


### PR DESCRIPTION
## What, How & Why?
```
// FIXME: Replace this with a proper specific exception type once Core adds support for it.
```
The "IncompatibleHistories" error type has been released and can be used to satisfy this fixme.

This PR allows SDKs to more precisely catch incompatible history type errors.

## ☑️ ToDos
* [x] 📝 Changelog update
* [x] 🚦 Tests (or not relevant)