### PR TITLE
Reduce instantiations of std::sort and std::set

### DIFF
--- a/src/realm/dictionary.cpp
+++ b/src/realm/dictionary.cpp
@@ -456,16 +456,11 @@ void Dictionary::sort(std::vector<size_t>& indices, bool ascending) const
     align_indices(indices);
     auto b = indices.begin();
     auto e = indices.end();
-    if (ascending) {
-        std::sort(b, e, [this](size_t i1, size_t i2) {
-            return get_any(i1) < get_any(i2);
-        });
-    }
-    else {
-        std::sort(b, e, [this](size_t i1, size_t i2) {
-            return get_any(i1) > get_any(i2);
-        });
-    }
+    std::sort(b, e, [this](size_t i1, size_t i2) {
+        return get_any(i1) < get_any(i2);
+    });
+    if (!ascending)
+        std::reverse(b, e);
 }
 
 void Dictionary::distinct(std::vector<size_t>& indices, util::Optional<bool> ascending) const
@@ -491,16 +486,11 @@ void Dictionary::sort_keys(std::vector<size_t>& indices, bool ascending) const
     align_indices(indices);
     auto b = indices.begin();
     auto e = indices.end();
-    if (ascending) {
-        std::sort(b, e, [this](size_t i1, size_t i2) {
-            return get_key(i1) < get_key(i2);
-        });
-    }
-    else {
-        std::sort(b, e, [this](size_t i1, size_t i2) {
-            return get_key(i1) > get_key(i2);
-        });
-    }
+    std::sort(b, e, [this](size_t i1, size_t i2) {
+        return get_key(i1) < get_key(i2);
+    });
+    if (!ascending)
+        std::reverse(b, e);
 }
 
 void Dictionary::distinct_keys(std::vector<size_t>& indices, util::Optional<bool>) const

--- a/src/realm/dictionary.cpp
+++ b/src/realm/dictionary.cpp
@@ -456,11 +456,11 @@ void Dictionary::sort(std::vector<size_t>& indices, bool ascending) const
     align_indices(indices);
     auto b = indices.begin();
     auto e = indices.end();
-    std::sort(b, e, [this](size_t i1, size_t i2) {
-        return get_any(i1) < get_any(i2);
+    std::sort(b, e, [this, ascending](size_t i1, size_t i2) {
+        auto v1 = get_any(i1);
+        auto v2 = get_any(i2);
+        return ascending ? v1 < v2 : v2 < v1;
     });
-    if (!ascending)
-        std::reverse(b, e);
 }
 
 void Dictionary::distinct(std::vector<size_t>& indices, util::Optional<bool> ascending) const
@@ -486,11 +486,11 @@ void Dictionary::sort_keys(std::vector<size_t>& indices, bool ascending) const
     align_indices(indices);
     auto b = indices.begin();
     auto e = indices.end();
-    std::sort(b, e, [this](size_t i1, size_t i2) {
-        return get_key(i1) < get_key(i2);
+    std::sort(b, e, [this, ascending](size_t i1, size_t i2) {
+        auto k1 = get_key(i1);
+        auto k2 = get_key(i2);
+        return ascending ? k1 < k2 : k2 < k1;
     });
-    if (!ascending)
-        std::reverse(b, e);
 }
 
 void Dictionary::distinct_keys(std::vector<size_t>& indices, util::Optional<bool>) const

--- a/src/realm/group.cpp
+++ b/src/realm/group.cpp
@@ -18,7 +18,6 @@
 
 #include <new>
 #include <algorithm>
-#include <set>
 #include <fstream>
 
 #ifdef REALM_DEBUG

--- a/src/realm/list.cpp
+++ b/src/realm/list.cpp
@@ -110,32 +110,40 @@ LstBasePtr Obj::get_listbase_ptr(ColKey col_key) const
 
 /****************************** Lst aggregates *******************************/
 
-template <class T>
-void Lst<T>::sort(std::vector<size_t>& indices, bool ascending) const
+namespace {
+void do_sort(std::vector<size_t>& indices, size_t size, util::FunctionRef<bool(size_t, size_t)> comp)
 {
-    auto sz = size();
-    auto sz2 = indices.size();
-
-    indices.reserve(sz);
-    if (sz < sz2) {
+    auto old_size = indices.size();
+    indices.reserve(size);
+    if (size < old_size) {
         // If list size has decreased, we have to start all over
         indices.clear();
-        sz2 = 0;
+        old_size = 0;
     }
-    for (size_t i = sz2; i < sz; i++) {
+    for (size_t i = old_size; i < size; i++) {
         // If list size has increased, just add the missing indices
         indices.push_back(i);
     }
+
     auto b = indices.begin();
     auto e = indices.end();
+    std::sort(b, e, comp);
+}
+} // anonymous namespace
+
+template <class T>
+void Lst<T>::sort(std::vector<size_t>& indices, bool ascending) const
+{
+    update_if_needed();
+    auto tree = m_tree.get();
     if (ascending) {
-        std::sort(b, e, [this](size_t i1, size_t i2) {
-            return m_tree->get(i1) < m_tree->get(i2);
+        do_sort(indices, size(), [tree](size_t i1, size_t i2) noexcept {
+            return tree->get(i1) < tree->get(i2);
         });
     }
     else {
-        std::sort(b, e, [this](size_t i1, size_t i2) {
-            return m_tree->get(i1) > m_tree->get(i2);
+        do_sort(indices, size(), [tree](size_t i1, size_t i2) noexcept {
+            return tree->get(i1) > tree->get(i2);
         });
     }
 }
@@ -144,9 +152,10 @@ template <class T>
 void Lst<T>::distinct(std::vector<size_t>& indices, util::Optional<bool> sort_order) const
 {
     indices.clear();
-    sort(indices, sort_order ? *sort_order : true);
-    auto duplicates = std::unique(indices.begin(), indices.end(), [this](size_t i1, size_t i2) {
-        return m_tree->get(i1) == m_tree->get(i2);
+    sort(indices, sort_order.value_or(true));
+    auto tree = m_tree.get();
+    auto duplicates = std::unique(indices.begin(), indices.end(), [tree](size_t i1, size_t i2) noexcept {
+        return tree->get(i1) == tree->get(i2);
     });
     // Erase the duplicates
     indices.erase(duplicates, indices.end());

--- a/src/realm/object-store/impl/collection_change_builder.cpp
+++ b/src/realm/object-store/impl/collection_change_builder.cpp
@@ -633,6 +633,13 @@ int64_t to_int64_t<ObjKey>(ObjKey val)
     return val.value;
 }
 
+void sort_row_info(std::vector<RowInfo>& info)
+{
+    std::sort(begin(info), end(info), [](auto& lft, auto& rgt) {
+        return lft.key < rgt.key;
+    });
+}
+
 template <typename T>
 std::vector<RowInfo> build_row_info(const std::vector<T>& rows)
 {
@@ -640,9 +647,7 @@ std::vector<RowInfo> build_row_info(const std::vector<T>& rows)
     info.reserve(rows.size());
     for (size_t i = 0; i < rows.size(); ++i)
         info.push_back({to_int64_t(rows[i]), IndexSet::npos, i});
-    std::sort(begin(info), end(info), [](auto& lft, auto& rgt) {
-        return lft.key < rgt.key;
-    });
+    sort_row_info(info);
     return info;
 }
 

--- a/src/realm/set.cpp
+++ b/src/realm/set.cpp
@@ -118,6 +118,18 @@ void SetBase::clear_repl(Replication* repl) const
     repl->set_clear(*this);
 }
 
+std::vector<Mixed> SetBase::convert_to_mixed_set(const CollectionBase& rhs)
+{
+    std::vector<Mixed> mixed;
+    mixed.reserve(rhs.size());
+    for (size_t i = 0; i < rhs.size(); i++) {
+        mixed.push_back(rhs.get_any(i));
+    }
+    std::sort(mixed.begin(), mixed.end(), SetElementLessThan<Mixed>());
+    mixed.erase(std::unique(mixed.begin(), mixed.end()), mixed.end());
+    return mixed;
+}
+
 template <>
 void Set<ObjKey>::do_insert(size_t ndx, ObjKey target_key)
 {

--- a/src/realm/set.hpp
+++ b/src/realm/set.hpp
@@ -24,7 +24,6 @@
 #include <realm/array_key.hpp>
 
 #include <numeric> // std::iota
-#include <set>
 
 namespace realm {
 
@@ -43,6 +42,7 @@ protected:
     void insert_repl(Replication* repl, size_t index, Mixed value) const;
     void erase_repl(Replication* repl, size_t index, Mixed value) const;
     void clear_repl(Replication* repl) const;
+    static std::vector<Mixed> convert_to_mixed_set(const CollectionBase& rhs);
 };
 
 template <class T>
@@ -269,6 +269,8 @@ private:
 
     template <class It1, class It2>
     void assign_symmetric_difference(It1, It2);
+
+    static std::vector<T> convert_to_set(const CollectionBase& rhs, bool nullable);
 };
 
 class LnkSet final : public ObjCollectionBase<SetBase> {
@@ -795,28 +797,26 @@ inline void Set<T>::do_clear()
     m_tree->clear();
 }
 
-namespace {
 template <class T>
-auto convert_to_set(const CollectionBase& rhs, bool nullable)
+std::vector<T> Set<T>::convert_to_set(const CollectionBase& rhs, bool nullable)
 {
-    std::set<T, SetElementLessThan<T>> ret;
-    for (size_t i = 0; i < rhs.size(); i++) {
-        auto val = rhs.get_any(i);
-        if constexpr (std::is_same_v<T, Mixed>) {
-            ret.emplace(val);
+    if constexpr (std::is_same_v<T, Mixed>) {
+        return SetBase::convert_to_mixed_set(rhs);
+    }
+
+    std::vector<Mixed> mixed = SetBase::convert_to_mixed_set(rhs);
+    std::vector<T> ret;
+    ret.reserve(mixed.size());
+    for (auto&& val : mixed) {
+        if (val.is_type(ColumnTypeTraits<T>::id)) {
+            ret.push_back(val.get<T>());
         }
-        else {
-            if (val.is_type(ColumnTypeTraits<T>::id)) {
-                ret.emplace(val.get<T>());
-            }
-            else if (val.is_null() && nullable) {
-                ret.emplace(BPlusTree<T>::default_value(true));
-            }
+        else if (val.is_null() && nullable) {
+            ret.push_back(BPlusTree<T>::default_value(true));
         }
     }
     return ret;
 }
-} // namespace
 
 template <class T>
 bool Set<T>::is_subset_of(const CollectionBase& rhs) const
@@ -824,7 +824,7 @@ bool Set<T>::is_subset_of(const CollectionBase& rhs) const
     if (auto other_set = dynamic_cast<const Set<T>*>(&rhs)) {
         return is_subset_of(other_set->begin(), other_set->end());
     }
-    auto other_set = convert_to_set<T>(rhs, m_nullable);
+    auto other_set = convert_to_set(rhs, m_nullable);
     return is_subset_of(other_set.begin(), other_set.end());
 }
 
@@ -841,7 +841,7 @@ bool Set<T>::is_strict_subset_of(const CollectionBase& rhs) const
     if (auto other_set = dynamic_cast<const Set<T>*>(&rhs)) {
         return size() != rhs.size() && is_subset_of(other_set->begin(), other_set->end());
     }
-    auto other_set = convert_to_set<T>(rhs, m_nullable);
+    auto other_set = convert_to_set(rhs, m_nullable);
     return size() != other_set.size() && is_subset_of(other_set.begin(), other_set.end());
 }
 
@@ -851,7 +851,7 @@ bool Set<T>::is_superset_of(const CollectionBase& rhs) const
     if (auto other_set = dynamic_cast<const Set<T>*>(&rhs)) {
         return is_superset_of(other_set->begin(), other_set->end());
     }
-    auto other_set = convert_to_set<T>(rhs, m_nullable);
+    auto other_set = convert_to_set(rhs, m_nullable);
     return is_superset_of(other_set.begin(), other_set.end());
 }
 
@@ -868,7 +868,7 @@ bool Set<T>::is_strict_superset_of(const CollectionBase& rhs) const
     if (auto other_set = dynamic_cast<const Set<T>*>(&rhs)) {
         return size() != rhs.size() && is_superset_of(other_set->begin(), other_set->end());
     }
-    auto other_set = convert_to_set<T>(rhs, m_nullable);
+    auto other_set = convert_to_set(rhs, m_nullable);
     return size() != other_set.size() && is_superset_of(other_set.begin(), other_set.end());
 }
 
@@ -878,7 +878,7 @@ bool Set<T>::intersects(const CollectionBase& rhs) const
     if (auto other_set = dynamic_cast<const Set<T>*>(&rhs)) {
         return intersects(other_set->begin(), other_set->end());
     }
-    auto other_set = convert_to_set<T>(rhs, m_nullable);
+    auto other_set = convert_to_set(rhs, m_nullable);
     return intersects(other_set.begin(), other_set.end());
 }
 
@@ -908,7 +908,7 @@ bool Set<T>::set_equals(const CollectionBase& rhs) const
     if (auto other_set = dynamic_cast<const Set<T>*>(&rhs)) {
         return size() == rhs.size() && is_subset_of(other_set->begin(), other_set->end());
     }
-    auto other_set = convert_to_set<T>(rhs, m_nullable);
+    auto other_set = convert_to_set(rhs, m_nullable);
     return size() == other_set.size() && is_subset_of(other_set.begin(), other_set.end());
 }
 
@@ -918,7 +918,7 @@ inline void Set<T>::assign_union(const CollectionBase& rhs)
     if (auto other_set = dynamic_cast<const Set<T>*>(&rhs)) {
         return assign_union(other_set->begin(), other_set->end());
     }
-    auto other_set = convert_to_set<T>(rhs, m_nullable);
+    auto other_set = convert_to_set(rhs, m_nullable);
     return assign_union(other_set.begin(), other_set.end());
 }
 
@@ -930,7 +930,7 @@ void Set<T>::assign_union(It1 first, It2 last)
     std::set_difference(first, last, begin(), end(), std::back_inserter(the_diff), SetElementLessThan<T>{});
     // 'the_diff' now contains all the elements that are in foreign set, but not in 'this'
     // Now insert those elements
-    for (auto value : the_diff) {
+    for (auto&& value : the_diff) {
         insert(value);
     }
 }
@@ -941,7 +941,7 @@ inline void Set<T>::assign_intersection(const CollectionBase& rhs)
     if (auto other_set = dynamic_cast<const Set<T>*>(&rhs)) {
         return assign_intersection(other_set->begin(), other_set->end());
     }
-    auto other_set = convert_to_set<T>(rhs, m_nullable);
+    auto other_set = convert_to_set(rhs, m_nullable);
     return assign_intersection(other_set.begin(), other_set.end());
 }
 
@@ -953,7 +953,7 @@ void Set<T>::assign_intersection(It1 first, It2 last)
     std::set_intersection(first, last, begin(), end(), std::back_inserter(intersection), SetElementLessThan<T>{});
     clear();
     // Elements in intersection comes from foreign set, so ok to use here
-    for (auto value : intersection) {
+    for (auto&& value : intersection) {
         insert(value);
     }
 }
@@ -964,7 +964,7 @@ inline void Set<T>::assign_difference(const CollectionBase& rhs)
     if (auto other_set = dynamic_cast<const Set<T>*>(&rhs)) {
         return assign_difference(other_set->begin(), other_set->end());
     }
-    auto other_set = convert_to_set<T>(rhs, m_nullable);
+    auto other_set = convert_to_set(rhs, m_nullable);
     return assign_difference(other_set.begin(), other_set.end());
 }
 
@@ -976,7 +976,7 @@ void Set<T>::assign_difference(It1 first, It2 last)
     std::set_intersection(first, last, begin(), end(), std::back_inserter(intersection), SetElementLessThan<T>{});
     // 'intersection' now contains all the elements that are in both foreign set and 'this'.
     // Remove those elements. The elements comes from the foreign set, so ok to refer to.
-    for (auto value : intersection) {
+    for (auto&& value : intersection) {
         erase(value);
     }
 }
@@ -987,7 +987,7 @@ inline void Set<T>::assign_symmetric_difference(const CollectionBase& rhs)
     if (auto other_set = dynamic_cast<const Set<T>*>(&rhs)) {
         return assign_symmetric_difference(other_set->begin(), other_set->end());
     }
-    auto other_set = convert_to_set<T>(rhs, m_nullable);
+    auto other_set = convert_to_set(rhs, m_nullable);
     return assign_symmetric_difference(other_set.begin(), other_set.end());
 }
 
@@ -1000,10 +1000,10 @@ void Set<T>::assign_symmetric_difference(It1 first, It2 last)
     std::vector<T> intersection;
     std::set_intersection(first, last, begin(), end(), std::back_inserter(intersection), SetElementLessThan<T>{});
     // Now remove the common elements and add the differences
-    for (auto value : intersection) {
+    for (auto&& value : intersection) {
         erase(value);
     }
-    for (auto value : difference) {
+    for (auto&& value : difference) {
         insert(value);
     }
 }

--- a/src/realm/sync/changeset_parser.cpp
+++ b/src/realm/sync/changeset_parser.cpp
@@ -4,8 +4,6 @@
 #include <realm/table.hpp>
 #include <realm/sync/changeset_parser.hpp>
 
-#include <set>
-
 using namespace realm;
 using namespace realm::sync;
 

--- a/src/realm/sync/instructions.cpp
+++ b/src/realm/sync/instructions.cpp
@@ -1,10 +1,6 @@
 #include <realm/impl/transact_log.hpp>
 #include <realm/sync/instructions.hpp>
 
-#include <algorithm>
-#include <ostream>
-#include <set>
-
 using namespace realm;
 using namespace realm::_impl;
 

--- a/src/realm/sync/noinst/changeset_index.hpp
+++ b/src/realm/sync/noinst/changeset_index.hpp
@@ -5,7 +5,6 @@
 #include <deque>
 #include <list>
 #include <map>
-#include <set>
 
 #include <realm/sync/changeset.hpp>
 #include <realm/util/metered/map.hpp>

--- a/src/realm/sync/noinst/server/server.cpp
+++ b/src/realm/sync/noinst/server/server.cpp
@@ -7,7 +7,6 @@
 #include <locale>
 #include <vector>
 #include <queue>
-#include <set>
 #include <map>
 #include <memory>
 #include <sstream>

--- a/src/realm/sync/noinst/server/server_history.hpp
+++ b/src/realm/sync/noinst/server/server_history.hpp
@@ -7,7 +7,6 @@
 #include <random>
 #include <string>
 #include <unordered_map>
-#include <set>
 
 #include <realm/util/buffer.hpp>
 #include <realm/util/logger.hpp>

--- a/src/realm/sync/object_id.hpp
+++ b/src/realm/sync/object_id.hpp
@@ -23,7 +23,6 @@
 #include <string>
 #include <iosfwd> // operator<<
 #include <map>
-#include <set>
 
 #include <external/mpark/variant.hpp>
 #include <realm/global_key.hpp>

--- a/test/benchmark-common-tasks/main.cpp
+++ b/test/benchmark-common-tasks/main.cpp
@@ -1221,6 +1221,51 @@ struct BenchmarkSortInt : BenchmarkWithInts {
     }
 };
 
+struct BenchmarkSortIntList : Benchmark {
+    const char* name() const
+    {
+        return "BenchmarkSortIntList";
+    }
+
+    void before_all(DBRef group)
+    {
+        WrtTrans tr(group);
+        TableRef t = tr.add_table(name());
+        m_col = t->add_column_list(type_Int, "ints");
+        auto obj = t->create_object();
+        m_obj = obj.get_key();
+
+        auto list = obj.get_list<int64_t>(m_col);
+        Random r;
+        for (size_t i = 0; i < BASE_SIZE; ++i) {
+            list.add(r.draw_int<int64_t>());
+        }
+        tr.commit();
+        m_indices.reserve(BASE_SIZE);
+    }
+
+    void after_all(DBRef db)
+    {
+        WrtTrans tr(db);
+        tr.get_group().remove_table(name());
+        tr.commit();
+    }
+
+    void operator()(DBRef db)
+    {
+        RdTrans tr(db);
+        auto table = tr.get_group().get_table(name());
+        auto list = table->get_object(m_obj).get_list<int64_t>(m_col);
+        list.sort(m_indices, true);
+        list.sort(m_indices, false);
+        m_indices.clear();
+    }
+
+    ColKey m_col;
+    ObjKey m_obj;
+    std::vector<size_t> m_indices;
+};
+
 struct BenchmarkInsert : BenchmarkWithStringsTable {
     const char* name() const
     {
@@ -2000,6 +2045,7 @@ int benchmark_common_tasks_main()
 
     BENCH(BenchmarkSort);
     BENCH(BenchmarkSortInt);
+    BENCH(BenchmarkSortIntList);
 
     BENCH(BenchmarkUnorderedTableViewClear);
     BENCH(BenchmarkUnorderedTableViewClearIndexed);

--- a/test/benchmark-common-tasks/main.cpp
+++ b/test/benchmark-common-tasks/main.cpp
@@ -1266,6 +1266,54 @@ struct BenchmarkSortIntList : Benchmark {
     std::vector<size_t> m_indices;
 };
 
+struct BenchmarkSortIntDictionary : Benchmark {
+    // Dictionary sorting is sufficiently slow that we want to use a smaller size
+    static const size_t size = BASE_SIZE / 10;
+
+    const char* name() const
+    {
+        return "BenchmarkSortIntDictionary";
+    }
+
+    void before_all(DBRef group)
+    {
+        WrtTrans tr(group);
+        TableRef t = tr.add_table(name());
+        m_col = t->add_column_dictionary(type_Int, "ints");
+        auto obj = t->create_object();
+        m_obj = obj.get_key();
+
+        Dictionary dict = obj.get_dictionary(m_col);
+        Random r;
+        for (size_t i = 0; i < size; ++i) {
+            dict.insert(util::to_string(i), r.draw_int<int64_t>());
+        }
+        tr.commit();
+        m_indices.reserve(size);
+    }
+
+    void after_all(DBRef db)
+    {
+        WrtTrans tr(db);
+        tr.get_group().remove_table(name());
+        tr.commit();
+    }
+
+    void operator()(DBRef db)
+    {
+        RdTrans tr(db);
+        auto table = tr.get_group().get_table(name());
+        auto dict = table->get_object(m_obj).get_dictionary(m_col);
+        dict.sort(m_indices, true);
+        dict.sort(m_indices, false);
+        m_indices.clear();
+    }
+
+    ColKey m_col;
+    ObjKey m_obj;
+    std::vector<size_t> m_indices;
+};
+
 struct BenchmarkInsert : BenchmarkWithStringsTable {
     const char* name() const
     {
@@ -2046,6 +2094,7 @@ int benchmark_common_tasks_main()
     BENCH(BenchmarkSort);
     BENCH(BenchmarkSortInt);
     BENCH(BenchmarkSortIntList);
+    BENCH(BenchmarkSortIntDictionary);
 
     BENCH(BenchmarkUnorderedTableViewClear);
     BENCH(BenchmarkUnorderedTableViewClearIndexed);

--- a/test/client/auth.hpp
+++ b/test/client/auth.hpp
@@ -22,7 +22,6 @@
 #include <cstdint>
 #include <limits>
 #include <functional>
-#include <set>
 #include <deque>
 #include <random>
 


### PR DESCRIPTION
Each instantiation of std::sort() is about 3 KB, which isn't a ton, but Lst was instantiating around 50 of them. We can reduce this to one at the cost of introducing a single virtual call per comparison. Based on the single benchmark of this, hoisting the load of `m_tree` out of the loop entirely cancels out the perf hit from this.

There were also a handful of other places where we were pointlessly instantiating std::sort() with different lambdas. ICF would make this not a problem, but ld64 doesn't support ICF.

File | Before | After | Change
----|-------|------|--
Stripped Realm.framework (SPM macOS) | 7,234,848 | 7,067,760 | 167,088
Stripped Realm.framework (Other iOS) | 7,152,304 | 6,971,216 | 181,088
Unstripped Realm.framework (SPM macOS) | 12,812,139 | 12,562,779 | 249,360
Unstripped Realm.framework (Other iOS) | 47,876,032 | 47,167,048 | 708,984
librealm-monorepo.a | 122,767,728 | 120,408,024 | 2,359,704

The stripped framework sizes are the actual size added to an app install. The size is slightly different for SPM and non-SPM installations because different compiler flags are used. The unstripped SPM size includes debugging symbols and
the unstripped Other size includes bitcode. This size isn't particularly meaningful, but is the easiest to measure so it's what people complain about on Twitter. The size of librealm-monorepo.a matters because currently it's over Github's file size limit (100 MB), which causes problems for people who want to commit their Pods directory to git.