### PR TITLE
SubscriptionStores should contain an implicit SubscriptionSet with version zero

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,7 +17,7 @@
 -----------
 
 ### Internals
-* None.
+* SubscriptionStore's should be initialized with an implict empty SubscriptionSet so users can wait for query version zero to finish synchronizing. ((#5166)[https://github.com/realm/realm-core/pull/5166])
 
 ----------------------------------------------
 

--- a/src/realm/sync/client.cpp
+++ b/src/realm/sync/client.cpp
@@ -831,6 +831,9 @@ void SessionWrapper::on_flx_sync_error(int64_t version, std::string_view err_msg
 
 void SessionWrapper::on_flx_sync_progress(int64_t new_version, DownloadBatchState batch_state)
 {
+    if (!has_flx_subscription_store()) {
+        return;
+    }
     REALM_ASSERT(new_version >= m_flx_last_seen_version);
     REALM_ASSERT(new_version >= m_flx_active_version);
     SubscriptionSet::State new_state;

--- a/src/realm/sync/client.cpp
+++ b/src/realm/sync/client.cpp
@@ -850,11 +850,9 @@ void SessionWrapper::on_flx_sync_progress(int64_t new_version, DownloadBatchStat
             break;
     }
 
-    if (new_version != 0) {
-        auto mut_subs = get_flx_subscription_store()->get_mutable_by_version(new_version);
-        mut_subs.update_state(new_state);
-        std::move(mut_subs).commit();
-    }
+    auto mut_subs = get_flx_subscription_store()->get_mutable_by_version(new_version);
+    mut_subs.update_state(new_state);
+    std::move(mut_subs).commit();
 }
 
 SubscriptionStore* SessionWrapper::get_flx_subscription_store()

--- a/src/realm/sync/subscriptions.cpp
+++ b/src/realm/sync/subscriptions.cpp
@@ -526,6 +526,10 @@ SubscriptionStore::SubscriptionStore(DBRef db, util::UniqueFunction<void(int64_t
         m_sub_set_keys->error_str = sub_sets_table->add_column(type_String, c_flx_sub_sets_error_str_field, true);
         m_sub_set_keys->subscriptions =
             sub_sets_table->add_column_list(*subs_table, c_flx_sub_sets_subscriptions_field);
+
+        auto zero_sub = sub_sets_table->create_object_with_primary_key(Mixed{int64_t(0)});
+        zero_sub.set(m_sub_set_keys->state, static_cast<int64_t>(SubscriptionSet::State::Pending));
+        zero_sub.set(m_sub_set_keys->snapshot_version, tr->get_version());
         tr->commit();
         return true;
     };

--- a/src/realm/sync/subscriptions.cpp
+++ b/src/realm/sync/subscriptions.cpp
@@ -30,7 +30,10 @@
 
 namespace realm::sync {
 namespace {
+// Schema version history:
+//   v2: Initial public beta.
 
+constexpr static int c_flx_schema_version = 2;
 constexpr static std::string_view c_flx_metadata_table("flx_metadata");
 constexpr static std::string_view c_flx_subscription_sets_table("flx_subscription_sets");
 constexpr static std::string_view c_flx_subscriptions_table("flx_subscriptions");
@@ -506,7 +509,7 @@ SubscriptionStore::SubscriptionStore(DBRef db, util::UniqueFunction<void(int64_t
 
         auto schema_metadata = tr->add_table(c_flx_metadata_table);
         auto version_col = schema_metadata->add_column(type_Int, c_flx_meta_schema_version_field);
-        schema_metadata->create_object().set(version_col, int64_t(2));
+        schema_metadata->create_object().set(version_col, int64_t(c_flx_schema_version));
 
         auto sub_sets_table =
             tr->add_table_with_primary_key(c_flx_subscription_sets_table, type_Int, c_flx_sub_sets_version_field);
@@ -526,11 +529,7 @@ SubscriptionStore::SubscriptionStore(DBRef db, util::UniqueFunction<void(int64_t
         m_sub_set_keys->error_str = sub_sets_table->add_column(type_String, c_flx_sub_sets_error_str_field, true);
         m_sub_set_keys->subscriptions =
             sub_sets_table->add_column_list(*subs_table, c_flx_sub_sets_subscriptions_field);
-
-        auto zero_sub = sub_sets_table->create_object_with_primary_key(Mixed{int64_t(0)});
-        zero_sub.set(m_sub_set_keys->state, static_cast<int64_t>(SubscriptionSet::State::Pending));
-        zero_sub.set(m_sub_set_keys->snapshot_version, tr->get_version());
-        tr->commit();
+        tr->commit_and_continue_as_read();
         return true;
     };
 
@@ -553,7 +552,7 @@ SubscriptionStore::SubscriptionStore(DBRef db, util::UniqueFunction<void(int64_t
         auto version_obj = schema_metadata->get_object(0);
         auto version = version_obj.get<int64_t>(
             lookup_and_validate_column(schema_metadata, c_flx_meta_schema_version_field, type_Int));
-        if (version != 2) {
+        if (version != c_flx_schema_version) {
             throw std::runtime_error("Invalid schema version for flexible sync metadata");
         }
 
@@ -580,6 +579,16 @@ SubscriptionStore::SubscriptionStore(DBRef db, util::UniqueFunction<void(int64_t
         m_sub_keys->query_str = lookup_and_validate_column(subs, c_flx_sub_query_str_field, type_String);
         m_sub_keys->object_class_name = lookup_and_validate_column(subs, c_flx_sub_object_class_field, type_String);
         m_sub_keys->name = lookup_and_validate_column(subs, c_flx_sub_name_field, type_String);
+    }
+
+    // There should always be at least one subscription set so that the user can always wait for synchronizationon
+    // on the result of get_latest().
+    if (auto sub_sets = tr->get_table(m_sub_set_keys->table); sub_sets->is_empty()) {
+        tr->promote_to_write();
+        auto zero_sub = sub_sets->create_object_with_primary_key(Mixed{int64_t(0)});
+        zero_sub.set(m_sub_set_keys->state, static_cast<int64_t>(SubscriptionSet::State::Pending));
+        zero_sub.set(m_sub_set_keys->snapshot_version, tr->get_version());
+        tr->commit();
     }
 }
 

--- a/test/object-store/sync/flx_sync.cpp
+++ b/test/object-store/sync/flx_sync.cpp
@@ -155,6 +155,14 @@ TEST_CASE("flx: connect to FLX-enabled app", "[sync][flx][app]") {
     });
 
     harness.do_with_new_realm([&](SharedRealm realm) {
+        wait_for_download(*realm);
+        {
+            auto empty_subs = realm->get_latest_subscription_set();
+            CHECK(empty_subs.size() == 0);
+            CHECK(empty_subs.version() == 0);
+            empty_subs.get_state_change_notification(sync::SubscriptionSet::State::Complete).get();
+        }
+
         auto table = realm->read_group().get_table("class_TopLevel");
         auto col_key = table->get_column_key("queryable_str_field");
         Query query_foo(table);
@@ -166,6 +174,7 @@ TEST_CASE("flx: connect to FLX-enabled app", "[sync][flx][app]") {
             subs.get_state_change_notification(sync::SubscriptionSet::State::Complete).get();
         }
 
+        wait_for_download(*realm);
         {
             realm->refresh();
             Results results(realm, table);

--- a/test/test_sync_subscriptions.cpp
+++ b/test/test_sync_subscriptions.cpp
@@ -34,15 +34,16 @@ TEST(Sync_SubscriptionStoreBasic)
     {
         SubscriptionStoreFixture fixture(sub_store_path);
         SubscriptionStore store(fixture.db, [](int64_t) {});
-        // Because there are no subscription sets yet, get_latest should point to an invalid object
-        // and all the property accessors should return dummy values.
+        // Because there are no subscription sets yet, get_latest should point to an empty object
         auto latest = store.get_latest();
         CHECK(latest.begin() == latest.end());
         CHECK_EQUAL(latest.size(), 0);
         CHECK(latest.find("a sub") == latest.end());
         CHECK_EQUAL(latest.version(), 0);
         CHECK(latest.error_str().is_null());
-        CHECK_EQUAL(latest.state(), SubscriptionSet::State::Uncommitted);
+        // The "0" query is "Pending" from beginning since it gets created in the initial constructor
+        // of SubscriptionStore
+        CHECK_EQUAL(latest.state(), SubscriptionSet::State::Pending);
 
         // By making a mutable copy of `latest` we should create an actual object that we can modify.
         auto out = latest.make_mutable_copy();


### PR DESCRIPTION
## What, How & Why?
This changes the SubscriptionStore so it's initialized with a an empty "version zero" SubscriptionSet so that users can call `get_state_change_notification()` on the result of `get_latest()` before actually creating any subscriptions.

## ☑️ ToDos
* [x] 📝 Changelog update
* [x] 🚦 Tests (or not relevant)
