### PR TITLE
Greatly improve performance of sorting dictionaries

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ### Enhancements
 * <New feature description> (PR [#????](https://github.com/realm/realm-core/pull/????))
 * Prioritize integration of local changes over remote changes - shorten the time users may have to wait when committing local changes. Stop storing downloaded changesets in history. ([PR #5844](https://github.com/realm/realm-core/pull/5844)).
+* Greatly improve the performance of sorting or distincting a Dictionary's keys or values. The most expensive operation is now performed O(log N) rather than O(N log N) times, and large Dictionaries can see upwards of 99% reduction in time to sort. ([PR #5166](https://github.com/realm/realm-core/pulls/5166))
 
 ### Fixed
 * <How do the end-user experience this issue? what was the impact?> ([#????](https://github.com/realm/realm-core/issues/????), since v?.?.?)

--- a/src/realm/dictionary.hpp
+++ b/src/realm/dictionary.hpp
@@ -219,6 +219,9 @@ public:
 
     using ClusterTree::Iterator::get_position;
 
+    Mixed key() const;
+    Mixed value() const;
+
 private:
     friend class Dictionary;
 

--- a/test/benchmark-common-tasks/main.cpp
+++ b/test/benchmark-common-tasks/main.cpp
@@ -1224,7 +1224,7 @@ struct BenchmarkSortInt : BenchmarkWithInts {
 struct BenchmarkSortIntList : Benchmark {
     const char* name() const
     {
-        return "BenchmarkSortIntList";
+        return "SortIntList";
     }
 
     void before_all(DBRef group)
@@ -1267,12 +1267,9 @@ struct BenchmarkSortIntList : Benchmark {
 };
 
 struct BenchmarkSortIntDictionary : Benchmark {
-    // Dictionary sorting is sufficiently slow that we want to use a smaller size
-    static const size_t size = BASE_SIZE / 10;
-
     const char* name() const
     {
-        return "BenchmarkSortIntDictionary";
+        return "SortIntDictionary";
     }
 
     void before_all(DBRef group)
@@ -1285,11 +1282,11 @@ struct BenchmarkSortIntDictionary : Benchmark {
 
         Dictionary dict = obj.get_dictionary(m_col);
         Random r;
-        for (size_t i = 0; i < size; ++i) {
+        for (size_t i = 0; i < BASE_SIZE; ++i) {
             dict.insert(util::to_string(i), r.draw_int<int64_t>());
         }
         tr.commit();
-        m_indices.reserve(size);
+        m_indices.reserve(BASE_SIZE);
     }
 
     void after_all(DBRef db)


### PR DESCRIPTION
I noticed in #5163 that dictionary sorting is rather slow and took a stab at improving it.

Dictionary lookup by index is slow, so read all of the keys/values from the dictionary into a vector and sort that instead. Using a dictionary iterator to read the values replaces O(N log N) ClusterTree lookups with O(log N), so this is asymptotically faster. The benchmark is sped up from 3.77 seconds to 21.62 milliseconds, but more reasonably sized Dictionaries will see proportionally smaller benefits.

The downside of this is that the array of Mixed requires 24 bytes of scratch space per element in the dictionary. We already require 8 bytes per element to store the results, so this is just a constant factor increase rather than an asymptotic change in memory use and it's probably not a problem.