### PR TITLE
Filter out unresolved links in replication of list changes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@
 
 ### Fixed
 * <How do the end-user experience this issue? what was the impact?> ([#????](https://github.com/realm/realm-core/issues/????), since v?.?.?)
-* None.
+* If a list of objects contains links to objects not included in the synchronized partition, the indices contained in CollectionChangeSet for that list may be wrong ([#5164](https://github.com/realm/realm-core/issues/5164), since v10.0.0)
  
 ### Breaking changes
 * None.

--- a/src/realm/collection.hpp
+++ b/src/realm/collection.hpp
@@ -114,6 +114,11 @@ public:
         return get_obj().get_target_table(get_col_key());
     }
 
+    virtual size_t translate_index(size_t ndx) const noexcept
+    {
+        return ndx;
+    }
+
 protected:
     friend class Transaction;
     CollectionBase() noexcept = default;
@@ -461,6 +466,7 @@ namespace _impl {
 /// Translate from condensed index to uncondensed index in collections that hide
 /// tombstones.
 size_t virtual2real(const std::vector<size_t>& vec, size_t ndx) noexcept;
+size_t virtual2real(const BPlusTree<ObjKey>* tree, size_t ndx) noexcept;
 
 /// Translate from uncondensed index to condensed into in collections that hide
 /// tombstones.

--- a/src/realm/list.hpp
+++ b/src/realm/list.hpp
@@ -207,6 +207,16 @@ public:
         return update_if_needed() != UpdateStatus::Detached;
     }
 
+    size_t translate_index(size_t ndx) const noexcept override
+    {
+        if constexpr (std::is_same_v<T, ObjKey>) {
+            return _impl::virtual2real(m_tree.get(), ndx);
+        }
+        else {
+            return ndx;
+        }
+    }
+
 protected:
     // Friend because it needs access to `m_tree` in the implementation of
     // `ObjCollectionBase::get_mutable_tree()`.
@@ -834,12 +844,12 @@ T Lst<T>::set(size_t ndx, T value)
 
     // get will check for ndx out of bounds
     T old = get(ndx);
+    if (Replication* repl = this->m_obj.get_replication()) {
+        repl->list_set(*this, ndx, value);
+    }
     if (old != value) {
         do_set(ndx, value);
         bump_content_version();
-    }
-    if (Replication* repl = this->m_obj.get_replication()) {
-        repl->list_set(*this, ndx, value);
     }
     return old;
 }

--- a/src/realm/replication.hpp
+++ b/src/realm/replication.hpp
@@ -542,13 +542,13 @@ inline void Replication::nullify_link(const Table* t, ColKey col_key, ObjKey key
 inline void Replication::list_set(const CollectionBase& list, size_t list_ndx, Mixed)
 {
     select_collection(list);      // Throws
-    m_encoder.list_set(list_ndx); // Throws
+    m_encoder.list_set(list.translate_index(list_ndx)); // Throws
 }
 
 inline void Replication::list_insert(const CollectionBase& list, size_t list_ndx, Mixed, size_t)
 {
     select_collection(list);         // Throws
-    m_encoder.list_insert(list_ndx); // Throws
+    m_encoder.list_insert(list.translate_index(list_ndx)); // Throws
 }
 
 inline void Replication::set_insert(const CollectionBase& set, size_t set_ndx, Mixed)
@@ -578,13 +578,13 @@ inline void Replication::remove_object(const Table* t, ObjKey key)
 inline void Replication::list_move(const CollectionBase& list, size_t from_link_ndx, size_t to_link_ndx)
 {
     select_collection(list);                         // Throws
-    m_encoder.list_move(from_link_ndx, to_link_ndx); // Throws
+    m_encoder.list_move(list.translate_index(from_link_ndx), list.translate_index(to_link_ndx)); // Throws
 }
 
 inline void Replication::list_erase(const CollectionBase& list, size_t link_ndx)
 {
     select_collection(list);        // Throws
-    m_encoder.list_erase(link_ndx); // Throws
+    m_encoder.list_erase(list.translate_index(link_ndx)); // Throws
 }
 
 inline void Replication::typed_link_change(const Table* source_table, ColKey col, TableKey dest_table)


### PR DESCRIPTION
The notification system in ObjectStore should work reflect the changes as seen by the user, so we need to adjust the indices according to the presence of unresolved links in the list.

## What, How & Why?
Fixes #5164 

## ☑️ ToDos
* [x] 📝 Changelog update
* [x] 🚦 Tests (or not relevant)
