### PR TITLE
Make sync client more compatible with simple websocket libs

### DIFF
--- a/src/realm/sync/client.cpp
+++ b/src/realm/sync/client.cpp
@@ -1397,7 +1397,15 @@ void ClientImpl::Connection::on_idle()
 
 std::string ClientImpl::Connection::get_http_request_path() const
 {
-    std::string path = m_http_request_path_prefix; // Throws (copy)
+    using namespace std::string_view_literals;
+    const auto param = m_http_request_path_prefix.find('?') == std::string::npos ? "?baas_at="sv : "&baas_at="sv;
+
+    std::string path;
+    path.reserve(m_http_request_path_prefix.size() + param.size() + m_signed_access_token.size());
+    path += m_http_request_path_prefix;
+    path += param;
+    path += m_signed_access_token;
+
     return path;
 }
 

--- a/src/realm/sync/client.cpp
+++ b/src/realm/sync/client.cpp
@@ -1337,7 +1337,6 @@ ClientImpl::Connection::Connection(ClientImpl& client, connection_ident_type ide
     , m_protocol_envelope{std::get<0>(endpoint)}
     , m_address{std::get<1>(endpoint)}
     , m_port{std::get<2>(endpoint)}
-    , m_http_host{util::make_http_host(is_ssl(m_protocol_envelope), m_address, m_port)} // Throws
     , m_verify_servers_ssl_certificate{verify_servers_ssl_certificate}
     , m_ssl_trust_certificate_path{std::move(ssl_trust_certificate_path)}
     , m_ssl_verify_callback{std::move(ssl_verify_callback)}

--- a/src/realm/sync/client_base.hpp
+++ b/src/realm/sync/client_base.hpp
@@ -277,12 +277,6 @@ struct ClientConfig {
     /// consumption.
     bool disable_upload_compaction = false;
 
-    /// Set the `TCP_NODELAY` option on all TCP/IP sockets. This disables
-    /// the Nagle algorithm. Disabling it, can in some cases be used to
-    /// decrease latencies, but possibly at the expense of scalability. Be
-    /// sure to research the subject before you enable this option.
-    bool tcp_no_delay = false;
-
     /// The specified function will be called whenever a PONG message is
     /// received on any connection. The round-trip time in milliseconds will
     /// be pased to the function. The specified function will always be

--- a/src/realm/sync/noinst/client_impl_base.cpp
+++ b/src/realm/sync/noinst/client_impl_base.cpp
@@ -652,7 +652,6 @@ void Connection::initiate_reconnect()
         m_client.m_socket_factory.connect(this, util::websocket::EZEndpoint{
                                                     m_address,
                                                     m_port,
-                                                    m_http_host,
                                                     get_http_request_path(),
                                                     std::move(sec_websocket_protocol),
                                                     is_ssl(m_protocol_envelope),

--- a/src/realm/sync/noinst/client_impl_base.cpp
+++ b/src/realm/sync/noinst/client_impl_base.cpp
@@ -648,25 +648,20 @@ void Connection::initiate_reconnect()
         sec_websocket_protocol = std::move(out).str();
     }
 
-    util::HTTPHeaders headers;
-    headers[m_authorization_header_name] = _impl::make_authorization_header(m_signed_access_token); // Throws
-
-    for (auto const& header : m_custom_http_headers)
-        headers[header.first] = header.second;
-
-    m_websocket = m_client.m_socket_factory.connect(this, util::websocket::EZEndpoint{
-                                                              m_address,
-                                                              m_port,
-                                                              m_http_host,
-                                                              get_http_request_path(),
-                                                              std::move(sec_websocket_protocol),
-                                                              is_ssl(m_protocol_envelope),
-                                                              std::move(headers),
-                                                              m_verify_servers_ssl_certificate,
-                                                              m_ssl_trust_certificate_path,
-                                                              m_ssl_verify_callback,
-                                                              m_proxy_config,
-                                                          });
+    m_websocket =
+        m_client.m_socket_factory.connect(this, util::websocket::EZEndpoint{
+                                                    m_address,
+                                                    m_port,
+                                                    m_http_host,
+                                                    get_http_request_path(),
+                                                    std::move(sec_websocket_protocol),
+                                                    is_ssl(m_protocol_envelope),
+                                                    {m_custom_http_headers.begin(), m_custom_http_headers.end()},
+                                                    m_verify_servers_ssl_certificate,
+                                                    m_ssl_trust_certificate_path,
+                                                    m_ssl_verify_callback,
+                                                    m_proxy_config,
+                                                });
 }
 
 

--- a/src/realm/sync/noinst/client_impl_base.cpp
+++ b/src/realm/sync/noinst/client_impl_base.cpp
@@ -111,7 +111,6 @@ ClientImpl::ClientImpl(ClientConfig config)
     , m_fast_reconnect_limit{config.fast_reconnect_limit}
     , m_disable_upload_activation_delay{config.disable_upload_activation_delay}
     , m_dry_run{config.dry_run}
-    , m_tcp_no_delay{config.tcp_no_delay}
     , m_enable_default_port_hack{config.enable_default_port_hack}
     , m_disable_upload_compaction{config.disable_upload_compaction}
     , m_roundtrip_time_handler{std::move(config.roundtrip_time_handler)}
@@ -122,7 +121,6 @@ ClientImpl::ClientImpl(ClientConfig config)
           m_random,
           m_service,
           get_user_agent_string(),
-          get_tcp_no_delay(),
       })
     , m_client_protocol{} // Throws
     , m_one_connection_per_session{config.one_connection_per_session}
@@ -156,8 +154,6 @@ ClientImpl::ClientImpl(ClientConfig config)
                  config.fast_reconnect_limit); // Throws
     logger.debug("Config param: disable_upload_compaction = %1",
                  config.disable_upload_compaction); // Throws
-    logger.debug("Config param: tcp_no_delay = %1",
-                 config.tcp_no_delay); // Throws
     logger.debug("Config param: disable_sync_to_disk = %1",
                  config.disable_sync_to_disk); // Throws
     logger.debug("User agent string: '%1'", get_user_agent_string());

--- a/src/realm/sync/noinst/client_impl_base.hpp
+++ b/src/realm/sync/noinst/client_impl_base.hpp
@@ -129,7 +129,6 @@ public:
     const std::string& get_user_agent_string() const noexcept;
     ReconnectMode get_reconnect_mode() const noexcept;
     bool is_dry_run() const noexcept;
-    bool get_tcp_no_delay() const noexcept;
     util::network::Service& get_service() noexcept;
     std::mt19937_64& get_random() noexcept;
 
@@ -151,7 +150,6 @@ private:
     const milliseconds_type m_fast_reconnect_limit;
     const bool m_disable_upload_activation_delay;
     const bool m_dry_run; // For testing purposes only
-    const bool m_tcp_no_delay;
     const bool m_enable_default_port_hack;
     const bool m_disable_upload_compaction;
     const std::function<RoundtripTimeHandler> m_roundtrip_time_handler;
@@ -1080,11 +1078,6 @@ inline auto ClientImpl::get_reconnect_mode() const noexcept -> ReconnectMode
 inline bool ClientImpl::is_dry_run() const noexcept
 {
     return m_dry_run;
-}
-
-inline bool ClientImpl::get_tcp_no_delay() const noexcept
-{
-    return m_tcp_no_delay;
 }
 
 inline util::network::Service& ClientImpl::get_service() noexcept

--- a/src/realm/sync/noinst/client_impl_base.hpp
+++ b/src/realm/sync/noinst/client_impl_base.hpp
@@ -490,7 +490,6 @@ private:
     const ProtocolEnvelope m_protocol_envelope;
     const std::string m_address;
     const port_type m_port;
-    const std::string m_http_host; // Contents of `Host:` request header
     const bool m_verify_servers_ssl_certificate;
     const util::Optional<std::string> m_ssl_trust_certificate_path;
     const std::function<SSLVerifyCallback> m_ssl_verify_callback;

--- a/src/realm/sync/noinst/server/server.cpp
+++ b/src/realm/sync/noinst/server/server.cpp
@@ -1981,7 +1981,7 @@ private:
         // supposed to be mandatory, then that check ought to be delegated to
         // handle_request_for_sync(), as that will yield a sharper separation of
         // concerns.
-        if (path == "/realm-sync" || path.begins_with("/realm-sync/%2F")) {
+        if (path == "/realm-sync" || path.begins_with("/realm-sync?") || path.begins_with("/realm-sync/%2F")) {
             handle_request_for_sync(request); // Throws
         }
         else if (path.begins_with("/api/")) {

--- a/src/realm/util/ez_websocket.cpp
+++ b/src/realm/util/ez_websocket.cpp
@@ -334,7 +334,7 @@ void EZSocketImpl::handle_ssl_handshake(std::error_code ec)
 
 void EZSocketImpl::initiate_websocket_handshake()
 {
-    HTTPHeaders headers = m_endpoint.headers;
+    auto headers = util::HTTPHeaders(m_endpoint.headers.begin(), m_endpoint.headers.end());
     headers["User-Agent"] = m_config.user_agent;
 
     m_websocket.initiate_client_handshake(m_endpoint.path, m_endpoint.http_host, m_endpoint.protocols,

--- a/src/realm/util/ez_websocket.cpp
+++ b/src/realm/util/ez_websocket.cpp
@@ -218,8 +218,6 @@ void EZSocketImpl::handle_tcp_connect(std::error_code ec, util::network::Endpoin
     }
 
     REALM_ASSERT(m_socket);
-    if (m_config.tcp_no_delay)
-        m_socket->set_option(util::network::SocketBase::no_delay(true)); // Throws
     util::network::Endpoint ep_2 = m_socket->local_endpoint();
     logger().info("Connected to endpoint '%1:%2' (from '%3:%4')", ep.address(), ep.port(), ep_2.address(),
                   ep_2.port()); // Throws

--- a/src/realm/util/ez_websocket.cpp
+++ b/src/realm/util/ez_websocket.cpp
@@ -337,7 +337,12 @@ void EZSocketImpl::initiate_websocket_handshake()
     auto headers = util::HTTPHeaders(m_endpoint.headers.begin(), m_endpoint.headers.end());
     headers["User-Agent"] = m_config.user_agent;
 
-    m_websocket.initiate_client_handshake(m_endpoint.path, m_endpoint.http_host, m_endpoint.protocols,
+    // Compute the value of the "Host" header.
+    const std::uint_fast16_t default_port = (m_endpoint.is_ssl ? 443 : 80);
+    auto host = m_endpoint.port == default_port ? m_endpoint.address
+                                                : util::format("%1:%2", m_endpoint.address, m_endpoint.port);
+
+    m_websocket.initiate_client_handshake(m_endpoint.path, std::move(host), m_endpoint.protocols,
                                           std::move(headers)); // Throws
 }
 } // namespace

--- a/src/realm/util/ez_websocket.hpp
+++ b/src/realm/util/ez_websocket.hpp
@@ -21,7 +21,6 @@ struct EZConfig {
     std::mt19937_64& random;
     util::network::Service& service;
     std::string user_agent;
-    bool tcp_no_delay;
 };
 
 struct EZEndpoint {

--- a/src/realm/util/ez_websocket.hpp
+++ b/src/realm/util/ez_websocket.hpp
@@ -27,7 +27,6 @@ struct EZConfig {
 struct EZEndpoint {
     std::string address;
     port_type port;
-    std::string http_host; // Contents of `Host:` request header
     std::string path;      // Includes auth token in query.
     std::string protocols; // separated with ", "
     bool is_ssl;

--- a/src/realm/util/ez_websocket.hpp
+++ b/src/realm/util/ez_websocket.hpp
@@ -28,10 +28,14 @@ struct EZEndpoint {
     std::string address;
     port_type port;
     std::string http_host; // Contents of `Host:` request header
-    std::string path;
+    std::string path;      // Includes auth token in query.
     std::string protocols; // separated with ", "
     bool is_ssl;
-    util::HTTPHeaders headers; // Includes both auth and "custom" headers
+
+    // The remaining fields are just passing through values from the SyncConfig. They can be ignored if SDK chooses
+    // not to support the related config options. This may be necessary when using websocket libraries without
+    // low-level control.
+    std::map<std::string, std::string> headers; // Only includes "custom" headers.
     bool verify_servers_ssl_certificate;
     util::Optional<std::string> ssl_trust_certificate_path;
     std::function<SyncConfig::SSLVerifyCallback> ssl_verify_callback;

--- a/src/realm/util/http.cpp
+++ b/src/realm/util/http.cpp
@@ -482,16 +482,5 @@ std::error_code make_error_code(HTTPParserError error)
     return std::error_code(static_cast<int>(error), g_http_parser_error_category);
 }
 
-
-std::string make_http_host(bool is_ssl, std::string_view address, std::uint_fast16_t port)
-{
-    std::ostringstream out;
-    out << address; // Throws
-    std::uint_fast16_t default_port = (is_ssl ? 443 : 80);
-    if (port != default_port)
-        out << ":" << port; // Throws
-    return std::move(out).str();
-}
-
 } // namespace util
 } // namespace realm

--- a/src/realm/util/http.hpp
+++ b/src/realm/util/http.hpp
@@ -515,9 +515,6 @@ private:
     }
 };
 
-
-std::string make_http_host(bool is_ssl, std::string_view address, std::uint_fast16_t port);
-
 } // namespace util
 } // namespace realm
 

--- a/test/sync_fixtures.hpp
+++ b/test/sync_fixtures.hpp
@@ -545,7 +545,6 @@ public:
             config_2.ping_keepalive_period = config.client_ping_period;
             config_2.pong_keepalive_timeout = config.client_pong_timeout;
             config_2.disable_upload_compaction = config.disable_upload_compaction;
-            config_2.tcp_no_delay = true;
             config_2.one_connection_per_session = config.one_connection_per_session;
             config_2.disable_upload_activation_delay = config.disable_upload_activation_delay;
             m_clients[i] = std::make_unique<Client>(std::move(config_2));

--- a/test/test_sync.cpp
+++ b/test/test_sync.cpp
@@ -3563,7 +3563,6 @@ TEST_IF(Sync_SSL_Certificate_Verify_Callback_External, false)
     Client::Config config;
     config.logger = &client_logger;
     config.reconnect_mode = ReconnectMode::testing;
-    config.tcp_no_delay = true;
     Client client(config);
 
     ThreadWrapper client_thread;
@@ -3721,7 +3720,6 @@ TEST(Sync_UploadDownloadProgress_1)
         Client::Config config;
         config.logger = &client_logger;
         config.reconnect_mode = ReconnectMode::testing;
-        config.tcp_no_delay = true;
         Client client(config);
 
         ThreadWrapper client_thread;
@@ -3997,7 +3995,6 @@ TEST(Sync_UploadDownloadProgress_3)
     Client::Config client_config;
     client_config.logger = &client_logger;
     client_config.reconnect_mode = ReconnectMode::testing;
-    client_config.tcp_no_delay = true;
     Client client(client_config);
 
     ThreadWrapper client_thread;
@@ -4303,7 +4300,6 @@ TEST(Sync_UploadDownloadProgress_6)
     client_config.logger = &client_logger;
     client_config.reconnect_mode = ReconnectMode::testing;
     client_config.one_connection_per_session = false;
-    client_config.tcp_no_delay = true;
     Client client(client_config);
 
     ThreadWrapper client_thread;
@@ -4363,7 +4359,6 @@ TEST(Sync_MultipleSyncAgentsNotAllowed)
     Client::Config config;
     config.logger = &test_context.logger;
     config.reconnect_mode = ReconnectMode::testing;
-    config.tcp_no_delay = true;
     Client client{config};
     Session session_1{client, db, nullptr};
     Session session_2{client, db, nullptr};


### PR DESCRIPTION
## What, How & Why?
<!-- Describe the changes and give some hints to guide your reviewers if possible. -->
<!-- Link to relevant issue this fixes -->

This stack of 3 commits are all about making the sync client business logic not need to set low-level options (such as HTTP headers) when making websocket requests.

## ☑️ ToDos
* ~~[ ] 📝 Changelog update~~
* ~~[ ] 🚦 Tests (or not relevant)~~
