### PR TITLE
Replace many uses of std::function with util::UniqueFunction

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,9 @@
 ### Internals
 * SubscriptionStore's should be initialized with an implict empty SubscriptionSet so users can wait for query version zero to finish synchronizing. ((#5166)[https://github.com/realm/realm-core/pull/5166])
 * Fixed `Future::on_completion()` and added missing testing for it ((#5181)[https://github.com/realm/realm-core/pull/5181])
+* GenericNetworkTransport::send_request_to_server()'s signature has been changed to `void(Request&& request, util::UniqueFunction<void(const Response&)>&& completion)`. Subclasses implementing it will need to be updated.
+* `MongoClient` had a mixture of functions which took `void(Optional<T>, Optional<AppError>)` callbacks and functions which took `void(Optional<AppError>, Optional<T>)` callbacks. They now all have the error parameter last. Most of the error-first functions other than `call_function()` appear to have been unused.
+* Many functions which previously took `std::function` parameters now take `util::UniqueFunction` parameters. This generally should not require SDK-side changes, but there may be opportunities for binary-size improvements by propagating this change outward in the SDK code.
 
 ----------------------------------------------
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ### Enhancements
 * <New feature description> (PR [#????](https://github.com/realm/realm-core/pull/????))
-* None.
+* Add `util::UniqueFunction::target()`, which does the same thing as `std::function::target()`.
 
 ### Fixed
 * <How do the end-user experience this issue? what was the impact?> ([#????](https://github.com/realm/realm-core/issues/????), since v?.?.?)

--- a/src/realm/db.cpp
+++ b/src/realm/db.cpp
@@ -2423,7 +2423,7 @@ void DB::reserve(size_t size)
 }
 #endif
 
-bool DB::call_with_lock(const std::string& realm_path, CallbackWithLock callback)
+bool DB::call_with_lock(const std::string& realm_path, CallbackWithLock&& callback)
 {
     auto lockfile_path = get_core_file(realm_path, CoreFileType::Lock);
 

--- a/src/realm/db.hpp
+++ b/src/realm/db.hpp
@@ -369,8 +369,8 @@ public:
     // files through a DB.
     // It is safe to delete/replace realm files inside the callback.
     // WARNING: It is not safe to delete the lock file in the callback.
-    using CallbackWithLock = std::function<void(const std::string& realm_path)>;
-    static bool call_with_lock(const std::string& realm_path, CallbackWithLock callback);
+    using CallbackWithLock = util::FunctionRef<void(const std::string& realm_path)>;
+    static bool call_with_lock(const std::string& realm_path, CallbackWithLock&& callback);
 
     enum CoreFileType : uint8_t {
         Lock,

--- a/src/realm/db_options.hpp
+++ b/src/realm/db_options.hpp
@@ -59,7 +59,6 @@ struct DBOptions {
         : durability(Durability::Full)
         , encryption_key(key)
         , allow_file_format_upgrade(true)
-        , upgrade_callback(std::function<void(int, int)>())
         , temp_dir(sys_tmp_dir)
         , enable_metrics(false)
         , metrics_buffer_size(10000)

--- a/src/realm/group.hpp
+++ b/src/realm/group.hpp
@@ -506,7 +506,8 @@ public:
     };
 
     bool has_cascade_notification_handler() const noexcept;
-    void set_cascade_notification_handler(std::function<void(const CascadeNotification&)> new_handler) noexcept;
+    void
+    set_cascade_notification_handler(util::UniqueFunction<void(const CascadeNotification&)> new_handler) noexcept;
 
     //@}
 
@@ -528,7 +529,7 @@ public:
     /// without registering a new one.
 
     bool has_schema_change_notification_handler() const noexcept;
-    void set_schema_change_notification_handler(std::function<void()> new_handler) noexcept;
+    void set_schema_change_notification_handler(util::UniqueFunction<void()> new_handler) noexcept;
 
     //@}
 
@@ -660,8 +661,8 @@ private:
     const bool m_is_shared;
     static std::optional<int> fake_target_file_format;
 
-    std::function<void(const CascadeNotification&)> m_notify_handler;
-    std::function<void()> m_schema_change_handler;
+    util::UniqueFunction<void(const CascadeNotification&)> m_notify_handler;
+    util::UniqueFunction<void()> m_schema_change_handler;
     std::shared_ptr<metrics::Metrics> m_metrics;
     size_t m_total_rows;
 
@@ -1108,7 +1109,7 @@ inline bool Group::has_cascade_notification_handler() const noexcept
 }
 
 inline void
-Group::set_cascade_notification_handler(std::function<void(const CascadeNotification&)> new_handler) noexcept
+Group::set_cascade_notification_handler(util::UniqueFunction<void(const CascadeNotification&)> new_handler) noexcept
 {
     m_notify_handler = std::move(new_handler);
 }
@@ -1124,7 +1125,7 @@ inline bool Group::has_schema_change_notification_handler() const noexcept
     return !!m_schema_change_handler;
 }
 
-inline void Group::set_schema_change_notification_handler(std::function<void()> new_handler) noexcept
+inline void Group::set_schema_change_notification_handler(util::UniqueFunction<void()> new_handler) noexcept
 {
     m_schema_change_handler = std::move(new_handler);
 }

--- a/src/realm/impl/copy_replication.cpp
+++ b/src/realm/impl/copy_replication.cpp
@@ -238,7 +238,7 @@ void CopyReplication::sync(const Table* t, ObjKey obj_key)
                     m_current.table = src_obj.get_table().unchecked_ptr();
                     m_current.obj_key = src_obj.get_key();
                 },
-                nullptr);
+                [](auto) {});
         }
     }
 }

--- a/src/realm/obj.cpp
+++ b/src/realm/obj.cpp
@@ -729,8 +729,7 @@ void Obj::traverse_path(Visitor v, PathSizer ps, size_t path_length) const
         });
     }
     else {
-        if (ps)
-            ps(path_length);
+        ps(path_length);
     }
 }
 

--- a/src/realm/obj.hpp
+++ b/src/realm/obj.hpp
@@ -214,8 +214,8 @@ public:
     // Then there is one call for each object on that path, starting with the top level object
     // The embedded object itself is not considered part of the path.
     // Note: You should never provide the path_index for calls to traverse_path.
-    using Visitor = std::function<void(const Obj&, ColKey, Mixed)>;
-    using PathSizer = std::function<void(size_t)>;
+    using Visitor = util::FunctionRef<void(const Obj&, ColKey, Mixed)>;
+    using PathSizer = util::FunctionRef<void(size_t)>;
     void traverse_path(Visitor v, PathSizer ps, size_t path_index = 0) const;
 
     template <typename U>

--- a/src/realm/object-store/binding_context.hpp
+++ b/src/realm/object-store/binding_context.hpp
@@ -41,12 +41,13 @@ namespace realm {
 // public:
 //     // A token returned from add_notification that can be used to remove the
 //     // notification later
-//     struct token : private std::list<std::function<void ()>>::iterator {
-//         token(std::list<std::function<void ()>>::iterator it) : std::list<std::function<void ()>>::iterator(it) { }
+//     struct token : private std::list<util::UniqueFunction<void ()>>::iterator {
+//         token(std::list<util::UniqueFunction<void ()>>::iterator it)
+//         : std::list<util::UniqueFunction<void ()>>::iterator(it) { }
 //         friend class DelegateImplementation;
 //     };
 //
-//     token add_notification(std::function<void ()> func)
+//     token add_notification(util::UniqueFunction<void ()> func)
 //     {
 //         m_registered_notifications.push_back(std::move(func));
 //         return token(std::prev(m_registered_notifications.end()));
@@ -68,7 +69,7 @@ namespace realm {
 //     }
 //
 // private:
-//     std::list<std::function<void ()>> m_registered_notifications;
+//     std::list<util::UniqueFunction<void ()>> m_registered_notifications;
 // };
 class Realm;
 class Schema;

--- a/src/realm/object-store/c_api/app.cpp
+++ b/src/realm/object-store/c_api/app.cpp
@@ -667,7 +667,7 @@ RLM_API bool realm_app_call_function(const realm_app_t* app, const realm_user_t*
 {
     return wrap_err([&] {
         auto cb = [callback, userdata = SharedUserdata{userdata, FreeUserdata(userdata_free)}](
-                      util::Optional<AppError> error, util::Optional<bson::Bson> bson) {
+                      util::Optional<bson::Bson>&& bson, util::Optional<AppError> error) {
             if (error) {
                 realm_app_error_t c_error(to_capi(*error));
                 callback(userdata.get(), nullptr, &c_error);

--- a/src/realm/object-store/c_api/http.cpp
+++ b/src/realm/object-store/c_api/http.cpp
@@ -30,7 +30,7 @@ static_assert(realm_http_request_method_e(HttpMethod::put) == RLM_HTTP_REQUEST_M
 static_assert(realm_http_request_method_e(HttpMethod::del) == RLM_HTTP_REQUEST_METHOD_DELETE);
 
 class CNetworkTransport final : public GenericNetworkTransport {
-    using Completion = std::function<void(const Response)>;
+    using Completion = realm::util::UniqueFunction<void(const Response&)>;
 
 public:
     CNetworkTransport(UserdataPtr userdata, realm_http_request_func_t request_executor)
@@ -53,7 +53,7 @@ public:
     }
 
 private:
-    void send_request_to_server(const Request request, Completion completion_block) final
+    void send_request_to_server(Request&& request, Completion&& completion_block) final
     {
         auto completion_data = std::make_unique<Completion>(std::move(completion_block));
 
@@ -69,7 +69,7 @@ private:
                                        c_headers.size(),
                                        request.body.data(),
                                        request.body.size()};
-        m_request_executor(m_userdata.get(), std::move(c_request), completion_data.release());
+        m_request_executor(m_userdata.get(), c_request, completion_data.release());
     }
 
     UserdataPtr m_userdata;

--- a/src/realm/object-store/c_api/sync.cpp
+++ b/src/realm/object-store/c_api/sync.cpp
@@ -545,7 +545,7 @@ RLM_API void realm_sync_session_wait_for_download_completion(realm_sync_session_
                                                              void* userdata,
                                                              realm_free_userdata_func_t userdata_free) noexcept
 {
-    std::function<void(std::error_code)> cb =
+    util::UniqueFunction<void(std::error_code)> cb =
         [done, userdata = SharedUserdata(userdata, FreeUserdata(userdata_free))](std::error_code e) {
             if (e) {
                 std::string error_code_message;
@@ -563,7 +563,7 @@ RLM_API void realm_sync_session_wait_for_upload_completion(realm_sync_session_t*
                                                            realm_sync_upload_completion_func_t done, void* userdata,
                                                            realm_free_userdata_func_t userdata_free) noexcept
 {
-    std::function<void(std::error_code)> cb =
+    util::UniqueFunction<void(std::error_code)> cb =
         [done, userdata = SharedUserdata(userdata, FreeUserdata(userdata_free))](std::error_code e) {
             if (e) {
                 std::string error_code_message;

--- a/src/realm/object-store/dictionary.cpp
+++ b/src/realm/object-store/dictionary.cpp
@@ -276,7 +276,7 @@ public:
         : m_dict(dict)
         , m_prev_rt(static_cast<Transaction*>(dict.get_table()->get_parent_group())->duplicate())
         , m_prev_dict(static_cast<realm::Dictionary*>(m_prev_rt->import_copy_of(dict).release()))
-        , m_cb(cb)
+        , m_cb(std::move(cb))
     {
     }
 
@@ -327,7 +327,7 @@ private:
 
 NotificationToken Dictionary::add_key_based_notification_callback(CBFunc cb, KeyPathArray key_path_array) &
 {
-    return add_notification_callback(NotificationHandler(dict(), cb), key_path_array);
+    return add_notification_callback(NotificationHandler(dict(), std::move(cb)), key_path_array);
 }
 
 Dictionary Dictionary::freeze(const std::shared_ptr<Realm>& frozen_realm) const

--- a/src/realm/object-store/dictionary.hpp
+++ b/src/realm/object-store/dictionary.hpp
@@ -115,7 +115,7 @@ public:
     Results get_keys() const;
     Results get_values() const;
 
-    using CBFunc = std::function<void(DictionaryChangeSet, std::exception_ptr)>;
+    using CBFunc = util::UniqueFunction<void(DictionaryChangeSet, std::exception_ptr)>;
     NotificationToken add_key_based_notification_callback(CBFunc cb, KeyPathArray key_path_array = {}) &;
 
     Iterator begin() const;

--- a/src/realm/object-store/impl/collection_notifier.cpp
+++ b/src/realm/object-store/impl/collection_notifier.cpp
@@ -41,8 +41,8 @@ bool CollectionNotifier::any_related_table_was_modified(TransactionChangeInfo co
     return any_of(begin(m_related_tables), end(m_related_tables), check_related_table);
 }
 
-std::function<bool(ObjKey)> CollectionNotifier::get_modification_checker(TransactionChangeInfo const& info,
-                                                                         ConstTableRef root_table)
+util::UniqueFunction<bool(ObjKey)> CollectionNotifier::get_modification_checker(TransactionChangeInfo const& info,
+                                                                                ConstTableRef root_table)
 {
     // If new links were added to existing tables we need to recalculate our
     // related tables info. This'll also happen for schema changes that don't
@@ -90,7 +90,7 @@ std::function<bool(ObjKey)> CollectionNotifier::get_modification_checker(Transac
     return DeepChangeChecker(info, *root_table, m_related_tables, m_key_path_array, m_all_callbacks_filtered);
 }
 
-std::function<std::vector<ColKey>(ObjKey)>
+util::UniqueFunction<std::vector<ColKey>(ObjKey)>
 CollectionNotifier::get_object_modification_checker(TransactionChangeInfo const& info, ConstTableRef root_table)
 {
     return ObjectKeyPathChangeChecker(info, *root_table, m_related_tables, m_key_path_array,

--- a/src/realm/object-store/impl/collection_notifier.hpp
+++ b/src/realm/object-store/impl/collection_notifier.hpp
@@ -23,6 +23,7 @@
 #include <realm/object-store/util/checked_mutex.hpp>
 
 #include <realm/util/assert.hpp>
+#include <realm/util/functional.hpp>
 #include <realm/version_id.hpp>
 #include <realm/table_ref.hpp>
 
@@ -187,13 +188,13 @@ protected:
     bool any_related_table_was_modified(TransactionChangeInfo const&) const noexcept;
 
     // Creates and returns a `DeepChangeChecker` or `KeyPathChecker` depending on the given KeyPathArray.
-    std::function<bool(ObjKey)> get_modification_checker(TransactionChangeInfo const&, ConstTableRef)
+    util::UniqueFunction<bool(ObjKey)> get_modification_checker(TransactionChangeInfo const&, ConstTableRef)
         REQUIRES(!m_callback_mutex);
 
     // Creates and returns a `ObjectKeyPathChangeChecker` which behaves slightly different that `DeepChangeChecker`
     // and `KeyPathChecker` which are used for `Collection`s.
-    std::function<std::vector<ColKey>(ObjKey)> get_object_modification_checker(TransactionChangeInfo const&,
-                                                                               ConstTableRef)
+    util::UniqueFunction<std::vector<ColKey>(ObjKey)> get_object_modification_checker(TransactionChangeInfo const&,
+                                                                                      ConstTableRef)
         REQUIRES(!m_callback_mutex);
 
     // Returns a vector containing all `KeyPathArray`s from all `NotificationCallback`s attached to this notifier.

--- a/src/realm/object-store/impl/realm_coordinator.cpp
+++ b/src/realm/object-store/impl/realm_coordinator.cpp
@@ -100,7 +100,7 @@ void RealmCoordinator::create_sync_session()
     if (m_sync_session)
         return;
     m_config.sync_config->get_fresh_realm_for_path =
-        [&](const std::string& path, std::function<void(DBRef, util::Optional<std::string>)> callback) {
+        [&](const std::string& path, util::UniqueFunction<void(DBRef, util::Optional<std::string>)> callback) {
             try {
                 // Get a fully downloaded Realm using the current configuration but changing the
                 // on disk path to the one provided. The current sync session is not affected.
@@ -122,7 +122,7 @@ void RealmCoordinator::create_sync_session()
                 std::shared_ptr<RealmCoordinator> rc = get_coordinator(copy_config);
                 REALM_ASSERT(rc);
                 auto task = rc->get_synchronized_realm(copy_config);
-                task->start([callback, path](ThreadSafeReference, std::exception_ptr err) {
+                task->start([callback = std::move(callback), path](ThreadSafeReference, std::exception_ptr err) {
                     try {
                         if (err) {
                             std::rethrow_exception(err);

--- a/src/realm/object-store/sync/app.cpp
+++ b/src/realm/object-store/sync/app.cpp
@@ -20,47 +20,121 @@
 
 #include <realm/util/base64.hpp>
 #include <realm/util/uri.hpp>
-#include <realm/object-store/sync/app_credentials.hpp>
 #include <realm/object-store/sync/app_utils.hpp>
-#include <realm/object-store/sync/generic_network_transport.hpp>
-#include <realm/object-store/sync/impl/sync_client.hpp>
-#include <realm/object-store/sync/impl/sync_file.hpp>
 #include <realm/object-store/sync/impl/sync_metadata.hpp>
 #include <realm/object-store/sync/sync_manager.hpp>
 #include <realm/object-store/sync/sync_user.hpp>
 
-#include <external/json/json.hpp>
 #include <string>
 
-namespace realm {
-namespace app {
-
+using namespace realm;
+using namespace realm::app;
+using namespace bson;
 using util::Optional;
+using util::UniqueFunction;
 
+namespace {
 // MARK: - Helpers
-// wrap an optional json key into the Optional type
-template <typename T>
-Optional<T> get_optional(const nlohmann::json& json, const std::string& key)
+
+REALM_COLD
+REALM_NOINLINE
+REALM_NORETURN
+void throw_json_error(JSONErrorCode ec, std::string_view message)
 {
-    auto it = json.find(key);
-    return it != json.end() ? Optional<T>(it->get<T>()) : realm::util::none;
+    throw AppError(make_error_code(ec), std::string(message));
 }
 
 template <typename T>
-T value_from_json(const nlohmann::json& data, const std::string& key)
+T as(const Bson& bson)
 {
-    if (auto it = data.find(key); it != data.end()) {
-        return it->get<T>();
+    if (holds_alternative<T>(bson)) {
+        return static_cast<T>(bson);
     }
-    throw AppError(make_error_code(JSONErrorCode::missing_json_key), key);
+    throw_json_error(JSONErrorCode::malformed_json, "?");
 }
+
+template <typename T>
+T get(const BsonDocument& doc, const std::string& key)
+{
+    auto& raw = doc.entries();
+    if (auto it = raw.find(key); it != raw.end()) {
+        return as<T>(it->second);
+    }
+    throw_json_error(JSONErrorCode::missing_json_key, key);
+}
+
+template <typename T>
+void read_field(const BsonDocument& data, const std::string& key, T& value)
+{
+    auto& raw = data.entries();
+    if (auto it = raw.find(key); it != raw.end()) {
+        value = as<T>(it->second);
+    }
+    else {
+        throw_json_error(JSONErrorCode::missing_json_key, key);
+    }
+}
+
+template <>
+void read_field(const BsonDocument& data, const std::string& key, ObjectId& value)
+{
+    value = ObjectId(get<std::string>(data, key).c_str());
+}
+
+template <typename T>
+void read_field(const BsonDocument& data, const std::string& key, Optional<T>& value)
+{
+    auto& raw = data.entries();
+    if (auto it = raw.find(key); it != raw.end()) {
+        value = as<T>(it->second);
+    }
+}
+
+template <typename T>
+T parse(std::string_view str)
+{
+    try {
+        return as<T>(bson::parse(str));
+    }
+    catch (const std::exception& e) {
+        throw_json_error(JSONErrorCode::malformed_json, e.what());
+    }
+}
+
+struct UserAPIKeyResponseHandler {
+    UniqueFunction<void(App::UserAPIKey&&, Optional<AppError>)> completion;
+    void operator()(const Response& response)
+    {
+        if (auto error = AppUtils::check_for_errors(response)) {
+            return completion({}, std::move(error));
+        }
+
+        try {
+            auto json = parse<BsonDocument>(response.body);
+            completion(read_user_api_key(json), {});
+        }
+        catch (AppError& e) {
+            completion({}, std::move(e));
+        }
+    }
+
+    static App::UserAPIKey read_user_api_key(const BsonDocument& doc)
+    {
+        App::UserAPIKey user_api_key;
+        read_field(doc, "_id", user_api_key.id);
+        read_field(doc, "key", user_api_key.key);
+        read_field(doc, "name", user_api_key.name);
+        read_field(doc, "disabled", user_api_key.disabled);
+        return user_api_key;
+    }
+};
 
 enum class RequestTokenType { NoAuth, AccessToken, RefreshToken };
 
 // generate the request headers for a HTTP call, by default it will generate headers with a refresh token if a user is
 // passed
-static std::map<std::string, std::string>
-get_request_headers(std::shared_ptr<SyncUser> with_user_authorization = nullptr,
+std::map<std::string, std::string>
+get_request_headers(const std::shared_ptr<SyncUser>& with_user_authorization = nullptr,
                     RequestTokenType token_type = RequestTokenType::RefreshToken)
 {
     std::map<std::string, std::string> headers{{"Content-Type", "application/json;charset=utf-8"},
@@ -82,6 +156,13 @@ get_request_headers(std::shared_ptr<SyncUser> with_user_authorization = nullptr,
     return headers;
 }
 
+UniqueFunction<void(const Response&)> handle_default_response(UniqueFunction<void(Optional<AppError>)>&& completion)
+{
+    return [completion = std::move(completion)](const Response& response) {
+        completion(AppUtils::check_for_errors(response));
+    };
+}
+
 const static std::string default_base_url = "https://realm.mongodb.com";
 const static std::string base_path = "/api/client/v2.0";
 const static std::string app_path = "/app";
@@ -92,6 +173,11 @@ const static std::string username_password_provider_key = "local-userpass";
 const static std::string user_api_key_provider_key_path = "api_keys";
 static std::unordered_map<std::string, std::shared_ptr<App>> s_apps_cache;
 std::mutex s_apps_mutex;
+
+} // anonymous namespace
+
+namespace realm {
+namespace app {
 
 SharedApp App::get_shared_app(const Config& config, const SyncClientConfig& sync_client_config)
 {
@@ -172,17 +258,6 @@ void App::configure(const SyncClientConfig& sync_client_config)
     }
 }
 
-static void handle_default_response(const Response& response,
-                                    std::function<void(Optional<AppError>)> completion_block)
-{
-    if (auto error = AppUtils::check_for_errors(response)) {
-        return completion_block(error);
-    }
-    else {
-        return completion_block({});
-    }
-}
-
 // MARK: - Template specializations
 
 template <>
@@ -200,132 +275,56 @@ App::UserAPIKeyProviderClient App::provider_client<App::UserAPIKeyProviderClient
 // MARK: - UsernamePasswordProviderClient
 
 void App::UsernamePasswordProviderClient::register_email(const std::string& email, const std::string& password,
-                                                         std::function<void(Optional<AppError>)> completion_block)
+                                                         UniqueFunction<void(Optional<AppError>)>&& completion)
 {
-    REALM_ASSERT(m_parent);
-    std::string route =
-        util::format("%1/providers/%2/register", m_parent->m_auth_route, username_password_provider_key);
-
-    auto handler = [completion_block](const Response& response) {
-        handle_default_response(response, completion_block);
-    };
-
-    nlohmann::json body = {{"email", email}, {"password", password}};
-
-    m_parent->do_request(
-        Request{HttpMethod::post, route, m_parent->m_request_timeout_ms, get_request_headers(), body.dump()},
-        handler);
+    m_parent->post(util::format("%1/providers/%2/register", m_parent->m_auth_route, username_password_provider_key),
+                   std::move(completion), {{"email", email}, {"password", password}});
 }
 
 void App::UsernamePasswordProviderClient::confirm_user(const std::string& token, const std::string& token_id,
-                                                       std::function<void(Optional<AppError>)> completion_block)
+                                                       UniqueFunction<void(Optional<AppError>)>&& completion)
 {
-    REALM_ASSERT(m_parent);
-    std::string route =
-        util::format("%1/providers/%2/confirm", m_parent->m_auth_route, username_password_provider_key);
-
-    auto handler = [completion_block](const Response& response) {
-        handle_default_response(response, completion_block);
-    };
-
-    nlohmann::json body = {{"token", token}, {"tokenId", token_id}};
-
-    m_parent->do_request(
-        Request{HttpMethod::post, route, m_parent->m_request_timeout_ms, get_request_headers(), body.dump()},
-        handler);
+    m_parent->post(util::format("%1/providers/%2/confirm", m_parent->m_auth_route, username_password_provider_key),
+                   std::move(completion), {{"token", token}, {"tokenId", token_id}});
 }
 
 void App::UsernamePasswordProviderClient::resend_confirmation_email(
-    const std::string& email, std::function<void(Optional<AppError>)> completion_block)
+    const std::string& email, UniqueFunction<void(Optional<AppError>)>&& completion)
 {
-    REALM_ASSERT(m_parent);
-    std::string route =
-        util::format("%1/providers/%2/confirm/send", m_parent->m_auth_route, username_password_provider_key);
-
-    auto handler = [completion_block](const Response& response) {
-        handle_default_response(response, completion_block);
-    };
-
-    nlohmann::json body{{"email", email}};
-
-    m_parent->do_request(
-        Request{HttpMethod::post, route, m_parent->m_request_timeout_ms, get_request_headers(), body.dump()},
-        handler);
+    m_parent->post(
+        util::format("%1/providers/%2/confirm/send", m_parent->m_auth_route, username_password_provider_key),
+        std::move(completion), {{"email", email}});
 }
 
 void App::UsernamePasswordProviderClient::retry_custom_confirmation(
-    const std::string& email, std::function<void(Optional<AppError>)> completion_block)
+    const std::string& email, UniqueFunction<void(Optional<AppError>)>&& completion)
 {
-    REALM_ASSERT(m_parent);
-    std::string route =
-        util::format("%1/providers/%2/confirm/call", m_parent->m_auth_route, username_password_provider_key);
-
-    auto handler = [completion_block](const Response& response) {
-        handle_default_response(response, completion_block);
-    };
-
-    nlohmann::json body{{"email", email}};
-
-    m_parent->do_request(
-        Request{HttpMethod::post, route, m_parent->m_request_timeout_ms, get_request_headers(), body.dump()},
-        handler);
+    m_parent->post(
+        util::format("%1/providers/%2/confirm/call", m_parent->m_auth_route, username_password_provider_key),
+        std::move(completion), {{"email", email}});
 }
 
 void App::UsernamePasswordProviderClient::send_reset_password_email(
-    const std::string& email, std::function<void(Optional<AppError>)> completion_block)
+    const std::string& email, UniqueFunction<void(Optional<AppError>)>&& completion)
 {
-    REALM_ASSERT(m_parent);
-    std::string route =
-        util::format("%1/providers/%2/reset/send", m_parent->m_auth_route, username_password_provider_key);
-
-    auto handler = [completion_block](const Response& response) {
-        handle_default_response(response, completion_block);
-    };
-
-    nlohmann::json body = {{"email", email}};
-
-    m_parent->do_request(
-        Request{HttpMethod::post, route, m_parent->m_request_timeout_ms, get_request_headers(), body.dump()},
-        handler);
+    m_parent->post(util::format("%1/providers/%2/reset/send", m_parent->m_auth_route, username_password_provider_key),
+                   std::move(completion), {{"email", email}});
 }
 
 void App::UsernamePasswordProviderClient::reset_password(const std::string& password, const std::string& token,
                                                          const std::string& token_id,
-                                                         std::function<void(Optional<AppError>)> completion_block)
+                                                         UniqueFunction<void(Optional<AppError>)>&& completion)
 {
-    REALM_ASSERT(m_parent);
-    std::string route = util::format("%1/providers/%2/reset", m_parent->m_auth_route, username_password_provider_key);
-
-    auto handler = [completion_block](const Response& response) {
-        handle_default_response(response, completion_block);
-    };
-
-    nlohmann::json body = {{"password", password}, {"token", token}, {"tokenId", token_id}};
-
-    m_parent->do_request(
-        Request{HttpMethod::post, route, m_parent->m_request_timeout_ms, get_request_headers(), body.dump()},
-        handler);
+    m_parent->post(util::format("%1/providers/%2/reset", m_parent->m_auth_route, username_password_provider_key),
+                   std::move(completion), {{"password", password}, {"token", token}, {"tokenId", token_id}});
 }
 
 void App::UsernamePasswordProviderClient::call_reset_password_function(
-    const std::string& email, const std::string& password, const bson::BsonArray& args,
-    std::function<void(Optional<AppError>)> completion_block)
+    const std::string& email, const std::string& password, const BsonArray& args,
+    UniqueFunction<void(Optional<AppError>)>&& completion)
 {
-    REALM_ASSERT(m_parent);
-    std::string route =
-        util::format("%1/providers/%2/reset/call", m_parent->m_auth_route, username_password_provider_key);
-
-    auto handler = [completion_block](const Response& response) {
-        handle_default_response(response, completion_block);
-    };
-
-    bson::BsonDocument arg = {{"email", email}, {"password", password}, {"arguments", args}};
-
-    std::stringstream body;
-    body << bson::Bson(arg);
-
-    m_parent->do_request(
-        Request{HttpMethod::post, route, m_parent->m_request_timeout_ms, get_request_headers(), body.str()}, handler);
+    m_parent->post(util::format("%1/providers/%2/reset/call", m_parent->m_auth_route, username_password_provider_key),
+                   std::move(completion), {{"email", email}, {"password", password}, {"arguments", args}});
 }
 
 // MARK: - UserAPIKeyProviderClient
@@ -341,193 +340,91 @@ std::string App::UserAPIKeyProviderClient::url_for_path(const std::string& path 
 }
 
 void App::UserAPIKeyProviderClient::create_api_key(
-    const std::string& name, std::shared_ptr<SyncUser> user,
-    std::function<void(UserAPIKey, Optional<AppError>)> completion_block)
+    const std::string& name, const std::shared_ptr<SyncUser>& user,
+    UniqueFunction<void(UserAPIKey&&, Optional<AppError>)>&& completion)
 {
-    std::string route = url_for_path();
-
-    auto handler = [completion_block](const Response& response) {
-        if (auto error = AppUtils::check_for_errors(response)) {
-            return completion_block({}, error);
-        }
-
-        nlohmann::json json;
-        try {
-            json = nlohmann::json::parse(response.body);
-        }
-        catch (const std::exception& e) {
-            return completion_block({}, AppError(make_error_code(JSONErrorCode::malformed_json), e.what()));
-        }
-
-        try {
-            auto user_api_key = App::UserAPIKey{
-                ObjectId(value_from_json<std::string>(json, "_id").c_str()), get_optional<std::string>(json, "key"),
-                value_from_json<std::string>(json, "name"), value_from_json<bool>(json, "disabled")};
-            return completion_block(user_api_key, {});
-        }
-        catch (const std::exception& e) {
-            return completion_block({}, AppError(make_error_code(JSONErrorCode::malformed_json), e.what()));
-        }
-    };
-
-    nlohmann::json body = {{"name", name}};
     Request req;
     req.method = HttpMethod::post;
-    req.url = route;
-    req.body = body.dump();
+    req.url = url_for_path();
+    req.body = Bson(BsonDocument{{"name", name}}).to_string();
     req.uses_refresh_token = true;
-
-    m_auth_request_client.do_authenticated_request(req, user, handler);
+    m_auth_request_client.do_authenticated_request(std::move(req), user,
+                                                   UserAPIKeyResponseHandler{std::move(completion)});
 }
 
-void App::UserAPIKeyProviderClient::fetch_api_key(
-    const realm::ObjectId& id, std::shared_ptr<SyncUser> user,
-    std::function<void(UserAPIKey, Optional<AppError>)> completion_block)
+void App::UserAPIKeyProviderClient::fetch_api_key(const realm::ObjectId& id, const std::shared_ptr<SyncUser>& user,
+                                                  UniqueFunction<void(UserAPIKey&&, Optional<AppError>)>&& completion)
 {
-    std::string route = url_for_path(id.to_string());
-
-    auto handler = [completion_block](const Response& response) {
-        if (auto error = AppUtils::check_for_errors(response)) {
-            return completion_block({}, error);
-        }
-
-        nlohmann::json json;
-        try {
-            json = nlohmann::json::parse(response.body);
-        }
-        catch (const std::exception& e) {
-            return completion_block({}, AppError(make_error_code(JSONErrorCode::malformed_json), e.what()));
-        }
-
-        try {
-            auto user_api_key = App::UserAPIKey{
-                ObjectId(value_from_json<std::string>(json, "_id").c_str()), get_optional<std::string>(json, "key"),
-                value_from_json<std::string>(json, "name"), value_from_json<bool>(json, "disabled")};
-            return completion_block(user_api_key, {});
-        }
-        catch (const std::exception& e) {
-            return completion_block({}, AppError(make_error_code(JSONErrorCode::malformed_json), e.what()));
-        }
-    };
-
     Request req;
     req.method = HttpMethod::get;
-    req.url = route;
+    req.url = url_for_path(id.to_string());
     req.uses_refresh_token = true;
-
-    m_auth_request_client.do_authenticated_request(req, user, handler);
+    m_auth_request_client.do_authenticated_request(std::move(req), user,
+                                                   UserAPIKeyResponseHandler{std::move(completion)});
 }
 
 void App::UserAPIKeyProviderClient::fetch_api_keys(
-    std::shared_ptr<SyncUser> user, std::function<void(std::vector<UserAPIKey>, Optional<AppError>)> completion_block)
+    const std::shared_ptr<SyncUser>& user,
+    UniqueFunction<void(std::vector<UserAPIKey>&&, Optional<AppError>)>&& completion)
 {
-    std::string route = url_for_path();
-
-    auto handler = [completion_block](const Response& response) {
-        if (auto error = AppUtils::check_for_errors(response)) {
-            return completion_block(std::vector<UserAPIKey>(), error);
-        }
-
-        nlohmann::json json;
-        try {
-            json = nlohmann::json::parse(response.body);
-        }
-        catch (const std::exception& e) {
-            return completion_block(std::vector<UserAPIKey>(),
-                                    AppError(make_error_code(JSONErrorCode::malformed_json), e.what()));
-        }
-
-        try {
-            auto api_key_array = std::vector<UserAPIKey>();
-            auto json_array = json.get<std::vector<nlohmann::json>>();
-            for (nlohmann::json& api_key_json : json_array) {
-                api_key_array.push_back(
-                    App::UserAPIKey{ObjectId(value_from_json<std::string>(api_key_json, "_id").c_str()),
-                                    get_optional<std::string>(api_key_json, "key"),
-                                    value_from_json<std::string>(api_key_json, "name"),
-                                    value_from_json<bool>(api_key_json, "disabled")});
-            }
-            return completion_block(api_key_array, {});
-        }
-        catch (const std::exception& e) {
-            return completion_block(std::vector<UserAPIKey>(),
-                                    AppError(make_error_code(JSONErrorCode::malformed_json), e.what()));
-        }
-    };
-
     Request req;
     req.method = HttpMethod::get;
-    req.url = route;
+    req.url = url_for_path();
     req.uses_refresh_token = true;
 
-    m_auth_request_client.do_authenticated_request(req, user, handler);
+    m_auth_request_client.do_authenticated_request(
+        std::move(req), user, [completion = std::move(completion)](const Response& response) {
+            if (auto error = AppUtils::check_for_errors(response)) {
+                return completion({}, std::move(error));
+            }
+
+            try {
+                auto json = parse<BsonArray>(response.body);
+                std::vector<UserAPIKey> keys;
+                keys.reserve(json.size());
+                for (auto&& api_key_json : json) {
+                    keys.push_back(UserAPIKeyResponseHandler::read_user_api_key(as<BsonDocument>(api_key_json)));
+                }
+                return completion(std::move(keys), {});
+            }
+            catch (AppError& e) {
+                completion({}, std::move(e));
+            }
+        });
 }
 
 
-void App::UserAPIKeyProviderClient::delete_api_key(const realm::ObjectId& id, std::shared_ptr<SyncUser> user,
-                                                   std::function<void(util::Optional<AppError>)> completion_block)
+void App::UserAPIKeyProviderClient::delete_api_key(const realm::ObjectId& id, const std::shared_ptr<SyncUser>& user,
+                                                   UniqueFunction<void(Optional<AppError>)>&& completion)
 {
-    std::string route = url_for_path(id.to_string());
-
-    auto handler = [completion_block](const Response& response) {
-        if (auto error = AppUtils::check_for_errors(response)) {
-            return completion_block(error);
-        }
-        else {
-            return completion_block({});
-        }
-    };
-
     Request req;
     req.method = HttpMethod::del;
-    req.url = route;
+    req.url = url_for_path(id.to_string());
     req.uses_refresh_token = true;
-
-    m_auth_request_client.do_authenticated_request(req, user, handler);
+    m_auth_request_client.do_authenticated_request(std::move(req), user,
+                                                   handle_default_response(std::move(completion)));
 }
 
-void App::UserAPIKeyProviderClient::enable_api_key(const realm::ObjectId& id, std::shared_ptr<SyncUser> user,
-                                                   std::function<void(Optional<AppError> error)> completion_block)
+void App::UserAPIKeyProviderClient::enable_api_key(const realm::ObjectId& id, const std::shared_ptr<SyncUser>& user,
+                                                   UniqueFunction<void(Optional<AppError>)>&& completion)
 {
-    std::string route = url_for_path(util::format("%1/enable", id.to_string()));
-
-    auto handler = [completion_block](const Response& response) {
-        if (auto error = AppUtils::check_for_errors(response)) {
-            return completion_block(error);
-        }
-        else {
-            return completion_block({});
-        }
-    };
-
     Request req;
     req.method = HttpMethod::put;
-    req.url = route;
+    req.url = url_for_path(util::format("%1/enable", id.to_string()));
     req.uses_refresh_token = true;
-
-    m_auth_request_client.do_authenticated_request(req, user, handler);
+    m_auth_request_client.do_authenticated_request(std::move(req), user,
+                                                   handle_default_response(std::move(completion)));
 }
 
-void App::UserAPIKeyProviderClient::disable_api_key(const realm::ObjectId& id, std::shared_ptr<SyncUser> user,
-                                                    std::function<void(Optional<AppError> error)> completion_block)
+void App::UserAPIKeyProviderClient::disable_api_key(const realm::ObjectId& id, const std::shared_ptr<SyncUser>& user,
+                                                    UniqueFunction<void(Optional<AppError>)>&& completion)
 {
-    std::string route = url_for_path(util::format("%1/disable", id.to_string()));
-
-    auto handler = [completion_block](const Response& response) {
-        if (auto error = AppUtils::check_for_errors(response)) {
-            return completion_block(error);
-        }
-        else {
-            return completion_block({});
-        }
-    };
-
     Request req;
     req.method = HttpMethod::put;
-    req.url = route;
+    req.url = url_for_path(util::format("%1/disable", id.to_string()));
     req.uses_refresh_token = true;
-
-    m_auth_request_client.do_authenticated_request(req, user, handler);
+    m_auth_request_client.do_authenticated_request(std::move(req), user,
+                                                   handle_default_response(std::move(completion)));
 }
 // MARK: - App
 
@@ -541,51 +438,9 @@ std::vector<std::shared_ptr<SyncUser>> App::all_users() const
     return m_sync_manager->all_users();
 }
 
-void App::get_profile(std::shared_ptr<SyncUser> sync_user,
-                      std::function<void(std::shared_ptr<SyncUser>, util::Optional<AppError>)> completion_block)
+void App::get_profile(const std::shared_ptr<SyncUser>& sync_user,
+                      UniqueFunction<void(const std::shared_ptr<SyncUser>&, Optional<AppError>)>&& completion)
 {
-    auto profile_handler = [completion_block, this, sync_user](const Response& profile_response) {
-        if (auto error = AppUtils::check_for_errors(profile_response)) {
-            return completion_block(nullptr, error);
-        }
-
-        nlohmann::json profile_json;
-        try {
-            profile_json = nlohmann::json::parse(profile_response.body);
-        }
-        catch (const std::domain_error& e) {
-            return completion_block(nullptr, AppError(make_error_code(JSONErrorCode::malformed_json), e.what()));
-        }
-
-        try {
-            std::vector<SyncUserIdentity> identities;
-            nlohmann::json identities_json = value_from_json<nlohmann::json>(profile_json, "identities");
-
-            for (size_t i = 0; i < identities_json.size(); i++) {
-                auto identity_json = identities_json[i];
-                identities.push_back(SyncUserIdentity(value_from_json<std::string>(identity_json, "id"),
-                                                      value_from_json<std::string>(identity_json, "provider_type")));
-            }
-
-            sync_user->update_identities(identities);
-
-            auto profile_data = value_from_json<nlohmann::json>(profile_json, "data");
-
-            sync_user->update_user_profile(
-                SyncUserProfile(static_cast<bson::BsonDocument>(bson::parse(profile_data.dump()))));
-
-            sync_user->set_state(SyncUser::State::LoggedIn);
-            m_sync_manager->set_current_user(sync_user->identity());
-            emit_change_to_subscribers(*this);
-        }
-        catch (const AppError& err) {
-            return completion_block(nullptr, err);
-        }
-
-        return completion_block(sync_user, {});
-    };
-
-
     Request req;
     req.method = HttpMethod::get;
     req.timeout_ms = m_request_timeout_ms;
@@ -595,12 +450,42 @@ void App::get_profile(std::shared_ptr<SyncUser> sync_user,
         req.url = util::format("%1/auth/profile", m_base_route);
     }
 
-    do_authenticated_request(req, sync_user, profile_handler);
+    do_authenticated_request(
+        std::move(req), sync_user,
+        [completion = std::move(completion), this, sync_user](const Response& profile_response) {
+            if (auto error = AppUtils::check_for_errors(profile_response)) {
+                return completion(nullptr, std::move(error));
+            }
+
+            try {
+                auto profile_json = parse<BsonDocument>(profile_response.body);
+                auto identities_json = get<BsonArray>(profile_json, "identities");
+
+                std::vector<SyncUserIdentity> identities;
+                identities.reserve(profile_json.size());
+                for (auto& identity_json : identities_json) {
+                    auto doc = as<BsonDocument>(identity_json);
+                    identities.push_back(
+                        SyncUserIdentity(get<std::string>(doc, "id"), get<std::string>(doc, "provider_type")));
+                }
+
+                sync_user->update_identities(identities);
+                sync_user->update_user_profile(SyncUserProfile(get<BsonDocument>(profile_json, "data")));
+                sync_user->set_state(SyncUser::State::LoggedIn);
+                m_sync_manager->set_current_user(sync_user->identity());
+                emit_change_to_subscribers(*this);
+            }
+            catch (const AppError& err) {
+                return completion(nullptr, err);
+            }
+
+            return completion(sync_user, {});
+        });
 }
 
-void App::attach_auth_options(bson::BsonDocument& body)
+void App::attach_auth_options(BsonDocument& body)
 {
-    bson::BsonDocument options;
+    BsonDocument options;
 
     if (m_config.local_app_version) {
         options["appVersion"] = *m_config.local_app_version;
@@ -611,90 +496,72 @@ void App::attach_auth_options(bson::BsonDocument& body)
     options["platformVersion"] = m_config.platform_version;
     options["sdkVersion"] = m_config.sdk_version;
 
-    body["options"] = bson::BsonDocument({{"device", options}});
+    body["options"] = BsonDocument({{"device", options}});
 }
 
-void App::log_in_with_credentials(const AppCredentials& credentials, const std::shared_ptr<SyncUser> linking_user,
-                                  std::function<void(std::shared_ptr<SyncUser>, Optional<AppError>)> completion_block)
+void App::log_in_with_credentials(
+    const AppCredentials& credentials, const std::shared_ptr<SyncUser>& linking_user,
+    UniqueFunction<void(const std::shared_ptr<SyncUser>&, Optional<AppError>)>&& completion)
 {
-    // construct the route
-    std::string route = util::format("%1/providers/%2/login%3", m_auth_route, credentials.provider_as_string(),
-                                     linking_user ? "?link=true" : "");
-
-    auto handler = [completion_block, credentials, linking_user, this](const Response& response) {
-        if (auto error = AppUtils::check_for_errors(response)) {
-            return completion_block(nullptr, error);
-        }
-
-        nlohmann::json json;
-        try {
-            json = nlohmann::json::parse(response.body);
-        }
-        catch (const std::exception& e) {
-            return completion_block(nullptr, AppError(make_error_code(JSONErrorCode::malformed_json), e.what()));
-        }
-
-        std::shared_ptr<realm::SyncUser> sync_user;
-        try {
-            if (linking_user) {
-                linking_user->update_access_token(value_from_json<std::string>(json, "access_token"));
-            }
-            else {
-                sync_user = m_sync_manager->get_user(value_from_json<std::string>(json, "user_id"),
-                                                     value_from_json<std::string>(json, "refresh_token"),
-                                                     value_from_json<std::string>(json, "access_token"),
-                                                     credentials.provider_as_string(),
-                                                     value_from_json<std::string>(json, "device_id"));
-            }
-        }
-        catch (const AppError& err) {
-            return completion_block(nullptr, err);
-        }
-
-        App::get_profile(linking_user ? linking_user : sync_user, completion_block);
-    };
-
-    bson::Bson credentials_as_bson = bson::parse(credentials.serialize_as_json());
-    bson::BsonDocument body = static_cast<bson::BsonDocument>(credentials_as_bson);
-    attach_auth_options(body);
-
-    std::stringstream s;
-    s << bson::Bson(body);
-
     // if we try logging in with an anonymous user while there
     // is already an anonymous session active, reuse it
     if (credentials.provider() == AuthProvider::ANONYMOUS) {
-        for (auto user : m_sync_manager->all_users()) {
+        for (auto&& user : m_sync_manager->all_users()) {
             if (user->provider_type() == credentials.provider_as_string() && user->is_logged_in()) {
-                completion_block(switch_user(user), util::none);
+                completion(switch_user(user), util::none);
                 return;
             }
         }
     }
 
-    do_request({HttpMethod::post, route, m_request_timeout_ms,
-                get_request_headers(linking_user, RequestTokenType::AccessToken), s.str()},
-               handler);
+    // construct the route
+    std::string route = util::format("%1/providers/%2/login%3", m_auth_route, credentials.provider_as_string(),
+                                     linking_user ? "?link=true" : "");
+
+    BsonDocument body = credentials.serialize_as_bson();
+    attach_auth_options(body);
+
+    do_request(
+        {HttpMethod::post, route, m_request_timeout_ms,
+         get_request_headers(linking_user, RequestTokenType::AccessToken), Bson(body).to_string()},
+        [completion = std::move(completion), credentials, linking_user, this](const Response& response) mutable {
+            if (auto error = AppUtils::check_for_errors(response)) {
+                return completion(nullptr, std::move(error));
+            }
+
+            std::shared_ptr<realm::SyncUser> sync_user = linking_user;
+            try {
+                auto json = parse<BsonDocument>(response.body);
+                if (linking_user) {
+                    linking_user->update_access_token(get<std::string>(json, "access_token"));
+                }
+                else {
+                    sync_user = m_sync_manager->get_user(
+                        get<std::string>(json, "user_id"), get<std::string>(json, "refresh_token"),
+                        get<std::string>(json, "access_token"), credentials.provider_as_string(),
+                        get<std::string>(json, "device_id"));
+                }
+            }
+            catch (const AppError& e) {
+                return completion(nullptr, e);
+            }
+
+            App::get_profile(sync_user, std::move(completion));
+        });
 }
 
-void App::log_in_with_credentials(const AppCredentials& credentials,
-                                  std::function<void(std::shared_ptr<SyncUser>, Optional<AppError>)> completion_block)
+void App::log_in_with_credentials(
+    const AppCredentials& credentials,
+    util::UniqueFunction<void(const std::shared_ptr<SyncUser>&, Optional<AppError>)>&& completion)
 {
-    App::log_in_with_credentials(credentials, nullptr, completion_block);
+    App::log_in_with_credentials(credentials, nullptr, std::move(completion));
 }
 
-void App::log_out(std::shared_ptr<SyncUser> user, std::function<void(Optional<AppError>)> completion_block)
+void App::log_out(const std::shared_ptr<SyncUser>& user, UniqueFunction<void(Optional<AppError>)>&& completion)
 {
     if (!user || user->state() != SyncUser::State::LoggedIn) {
-        return completion_block(util::none);
+        return completion(util::none);
     }
-
-    auto handler = [completion_block, user](const Response& response) {
-        if (auto error = AppUtils::check_for_errors(response)) {
-            return completion_block(error);
-        }
-        return completion_block(util::none);
-    };
 
     auto refresh_token = user->refresh_token();
     user->log_out();
@@ -713,24 +580,30 @@ void App::log_out(std::shared_ptr<SyncUser> user, std::function<void(Optional<Ap
         req.url = util::format("%1/auth/session", m_base_route);
     }
 
-    do_request(req, [anchor = shared_from_this(), completion_block = std::move(completion_block)](Response response) {
-        if (auto error = AppUtils::check_for_errors(response)) {
-            // We do not care about handling auth errors on log out
-            completion_block(error);
-        }
-        else {
-            anchor->emit_change_to_subscribers(*anchor);
-            completion_block(util::none);
-        }
+    do_request(std::move(req),
+               [anchor = shared_from_this(), completion = std::move(completion)](const Response& response) {
+                   auto error = AppUtils::check_for_errors(response);
+                   if (!error) {
+                       anchor->emit_change_to_subscribers(*anchor);
+                   }
+                   completion(error);
+               });
+}
+
+void App::log_out(UniqueFunction<void(Optional<AppError>)>&& completion)
+{
+    log_out(current_user(), std::move(completion));
+}
+
+bool App::verify_user_present(const std::shared_ptr<SyncUser>& user) const
+{
+    auto users = m_sync_manager->all_users();
+    return std::any_of(users.begin(), users.end(), [&](auto&& u) {
+        return u == user;
     });
 }
 
-void App::log_out(std::function<void(Optional<AppError>)> completion_block)
-{
-    log_out(current_user(), completion_block);
-}
-
-std::shared_ptr<SyncUser> App::switch_user(std::shared_ptr<SyncUser> user) const
+std::shared_ptr<SyncUser> App::switch_user(const std::shared_ptr<SyncUser>& user) const
 {
     if (!user || user->state() != SyncUser::State::LoggedIn) {
         throw AppError(make_client_error_code(ClientErrorCode::user_not_logged_in),
@@ -749,99 +622,76 @@ std::shared_ptr<SyncUser> App::switch_user(std::shared_ptr<SyncUser> user) const
     return current_user();
 }
 
-void App::remove_user(std::shared_ptr<SyncUser> user, std::function<void(Optional<AppError>)> completion_block)
+void App::remove_user(const std::shared_ptr<SyncUser>& user, UniqueFunction<void(Optional<AppError>)>&& completion)
 {
     if (!user || user->state() == SyncUser::State::Removed) {
-        return completion_block(
+        return completion(
             AppError(make_client_error_code(ClientErrorCode::user_not_found), "User has already been removed"));
     }
-
-    auto users = m_sync_manager->all_users();
-
-    auto it = std::find(users.begin(), users.end(), user);
-
-    if (it == users.end()) {
-        return completion_block(
+    if (!verify_user_present(user)) {
+        return completion(
             AppError(make_client_error_code(ClientErrorCode::user_not_found), "No user has been found"));
     }
 
     if (user->is_logged_in()) {
-        log_out(user, [user, completion_block, this](const Optional<AppError>& error) {
+        log_out(user, [user, completion = std::move(completion), this](const Optional<AppError>& error) {
             m_sync_manager->remove_user(user->identity());
-            return completion_block(error);
+            return completion(error);
         });
     }
     else {
         m_sync_manager->remove_user(user->identity());
-        return completion_block({});
+        return completion({});
     }
 }
 
-void App::delete_user(std::shared_ptr<SyncUser> user, std::function<void(Optional<AppError>)> completion_block)
+void App::delete_user(const std::shared_ptr<SyncUser>& user, UniqueFunction<void(Optional<AppError>)>&& completion)
 {
     if (!user || user->state() != SyncUser::State::LoggedIn) {
-        return completion_block(AppError(make_client_error_code(ClientErrorCode::user_not_found),
-                                         "User must be logged in to be deleted."));
+        return completion(AppError(make_client_error_code(ClientErrorCode::user_not_found),
+                                   "User must be logged in to be deleted."));
     }
 
-    auto users = m_sync_manager->all_users();
-
-    auto it = std::find(users.begin(), users.end(), user);
-
-    if (it == users.end()) {
-        return completion_block(
+    if (!verify_user_present(user)) {
+        return completion(
             AppError(make_client_error_code(ClientErrorCode::user_not_found), "No user has been found"));
     }
 
-    std::string route = util::format("%1/auth/session", m_base_route);
-
     Request req;
     req.method = HttpMethod::del;
-    req.url = route;
     req.timeout_ms = m_request_timeout_ms;
-    {
-        std::lock_guard<std::mutex> lock(*m_route_mutex);
-        req.url = util::format("%1/auth/delete", m_base_route);
-    }
-
-    do_authenticated_request(req, user,
-                             [anchor = shared_from_this(), completion_block = std::move(completion_block), this,
-                              identitiy = user->identity()](Response response) {
-                                 if (auto error = AppUtils::check_for_errors(response)) {
-                                     completion_block(error);
-                                 }
-                                 else {
+    req.url = url_for_path("/auth/delete");
+    do_authenticated_request(std::move(req), user,
+                             [anchor = shared_from_this(), completion = std::move(completion), this,
+                              identitiy = user->identity()](const Response& response) {
+                                 auto error = AppUtils::check_for_errors(response);
+                                 if (!error) {
                                      anchor->emit_change_to_subscribers(*anchor);
                                      m_sync_manager->delete_user(identitiy);
-                                     completion_block(error);
                                  }
+                                 completion(error);
                              });
 }
 
-void App::link_user(std::shared_ptr<SyncUser> user, const AppCredentials& credentials,
-                    std::function<void(std::shared_ptr<SyncUser>, Optional<AppError>)> completion_block)
+void App::link_user(const std::shared_ptr<SyncUser>& user, const AppCredentials& credentials,
+                    UniqueFunction<void(const std::shared_ptr<SyncUser>&, Optional<AppError>)>&& completion)
 {
     if (!user || user->state() != SyncUser::State::LoggedIn) {
-        return completion_block(nullptr, AppError(make_client_error_code(ClientErrorCode::user_not_found),
-                                                  "The specified user is not logged in"));
+        return completion(nullptr, AppError(make_client_error_code(ClientErrorCode::user_not_found),
+                                            "The specified user is not logged in"));
+    }
+    if (!verify_user_present(user)) {
+        return completion(nullptr, AppError(make_client_error_code(ClientErrorCode::user_not_found),
+                                            "The specified user was not found"));
     }
 
-    auto users = m_sync_manager->all_users();
-
-    auto it = std::find(users.begin(), users.end(), user);
-
-    if (it == users.end()) {
-        return completion_block(nullptr, AppError(make_client_error_code(ClientErrorCode::user_not_found),
-                                                  "The specified user was not found"));
-    }
-
-    App::log_in_with_credentials(credentials, user, completion_block);
+    App::log_in_with_credentials(credentials, user, std::move(completion));
 }
 
-void App::refresh_custom_data(std::shared_ptr<SyncUser> sync_user,
-                              std::function<void(Optional<AppError>)> completion_block)
+void App::refresh_custom_data(const std::shared_ptr<SyncUser>& user,
+                              UniqueFunction<void(Optional<AppError>)>&& completion)
 {
-    refresh_access_token(sync_user, completion_block);
+    refresh_access_token(user, std::move(completion));
 }
 
 std::string App::url_for_path(const std::string& path = "") const
@@ -851,10 +701,10 @@ std::string App::url_for_path(const std::string& path = "") const
 }
 
 // FIXME: This passes back the response to bubble up any potential errors, making this somewhat leaky
-void App::init_app_metadata(std::function<void(util::Optional<AppError>, util::Optional<Response>)> completion_block)
+void App::init_app_metadata(UniqueFunction<void(const Optional<Response>&)>&& completion)
 {
     if (m_sync_manager->app_metadata()) {
-        return completion_block(util::none, util::none);
+        return completion(util::none);
     }
 
     std::string route = util::format("%1/location", m_app_route);
@@ -864,150 +714,140 @@ void App::init_app_metadata(std::function<void(util::Optional<AppError>, util::O
     req.url = route;
     req.timeout_ms = m_request_timeout_ms;
 
-    m_config.transport->send_request_to_server(req, [this, completion_block](const Response& response) {
-        nlohmann::json json;
-        try {
-            json = nlohmann::json::parse(response.body);
-        }
-        catch (const std::exception& e) {
-            return completion_block(AppError(make_error_code(JSONErrorCode::malformed_json), e.what()), response);
-        }
+    m_config.transport->send_request_to_server(
+        std::move(req), [this, completion = std::move(completion)](const Response& response) {
+            try {
+                auto json = parse<BsonDocument>(response.body);
+                auto hostname = get<std::string>(json, "hostname");
+                auto ws_hostname = get<std::string>(json, "ws_hostname");
+                auto deployment_model = get<std::string>(json, "deployment_model");
+                auto location = get<std::string>(json, "location");
+                m_sync_manager->perform_metadata_update([&](const SyncMetadataManager& manager) {
+                    manager.set_app_metadata(deployment_model, location, hostname, ws_hostname);
+                });
 
-        try {
-            auto hostname = value_from_json<std::string>(json, "hostname");
-            auto ws_hostname = value_from_json<std::string>(json, "ws_hostname");
-            m_sync_manager->perform_metadata_update([&](const SyncMetadataManager& manager) {
-                manager.set_app_metadata(value_from_json<std::string>(json, "deployment_model"),
-                                         value_from_json<std::string>(json, "location"), hostname, ws_hostname);
-            });
+                auto metadata = m_sync_manager->app_metadata();
 
-            auto metadata = m_sync_manager->app_metadata();
+                std::lock_guard<std::mutex> lock(*m_route_mutex);
+                m_base_route = hostname + base_path;
+                std::string this_app_path = app_path + "/" + m_config.app_id;
+                m_app_route = m_base_route + this_app_path;
+                m_auth_route = m_app_route + auth_path;
+                m_sync_manager->set_sync_route(ws_hostname + base_path + this_app_path + sync_path);
+            }
+            catch (const AppError&) {
+                return completion(std::move(response));
+            }
 
-            std::lock_guard<std::mutex> lock(*m_route_mutex);
-            m_base_route = hostname + base_path;
-            std::string this_app_path = app_path + "/" + m_config.app_id;
-            m_app_route = m_base_route + this_app_path;
-            m_auth_route = m_app_route + auth_path;
-            m_sync_manager->set_sync_route(ws_hostname + base_path + this_app_path + sync_path);
-        }
-        catch (const AppError& err) {
-            return completion_block(err, response);
-        }
-
-        completion_block(util::none, util::none);
-    });
+            completion(util::none);
+        });
 }
 
-void App::do_request(Request request, std::function<void(Response)> completion_block)
+void App::post(std::string&& route, util::UniqueFunction<void(util::Optional<AppError>)>&& completion,
+               const BsonDocument& body)
+{
+    do_request(Request{HttpMethod::post, std::move(route), m_request_timeout_ms, get_request_headers(),
+                       Bson(body).to_string()},
+               handle_default_response(std::move(completion)));
+}
+
+void App::do_request(Request&& request, UniqueFunction<void(const Response&)>&& completion)
 {
     request.timeout_ms = default_timeout_ms;
 
-    // if we do not have metadata yet, we need to initialize it
-    if (!m_sync_manager->app_metadata()) {
-        init_app_metadata([completion_block, request, this](const util::Optional<AppError> error,
-                                                            const util::Optional<Response> response) mutable {
-            if (error) {
-                return completion_block(*response);
-            }
-
-            // if this is the first time we have received app metadata, the
-            // original request will not have the correct URL hostname for
-            // non global deployments.
-            auto app_metadata = m_sync_manager->app_metadata();
-            if (app_metadata && app_metadata->deployment_model != "GLOBAL" &&
-                request.url.rfind(m_base_url, 0) != std::string::npos) {
-                request.url.replace(0, m_base_url.size(), app_metadata->hostname);
-            }
-
-            m_config.transport->send_request_to_server(request, completion_block);
-        });
+    if (m_sync_manager->app_metadata()) {
+        m_config.transport->send_request_to_server(std::move(request), std::move(completion));
+        return;
     }
-    else {
-        m_config.transport->send_request_to_server(request, completion_block);
-    }
+
+    // if we do not have metadata yet, we need to initialize it and send the
+    // request once that's complete
+    init_app_metadata([completion = std::move(completion), request = std::move(request),
+                       this](const util::Optional<Response>& error) mutable {
+        if (error) {
+            return completion(std::move(*error));
+        }
+
+        // if this is the first time we have received app metadata, the
+        // original request will not have the correct URL hostname for
+        // non global deployments.
+        auto app_metadata = m_sync_manager->app_metadata();
+        if (app_metadata && app_metadata->deployment_model != "GLOBAL" &&
+            request.url.rfind(m_base_url, 0) != std::string::npos) {
+            request.url.replace(0, m_base_url.size(), app_metadata->hostname);
+        }
+
+        m_config.transport->send_request_to_server(std::move(request), std::move(completion));
+    });
 }
 
-void App::do_authenticated_request(Request request, std::shared_ptr<SyncUser> sync_user,
-                                   std::function<void(Response)> completion_block)
+void App::do_authenticated_request(Request&& request, const std::shared_ptr<SyncUser>& sync_user,
+                                   util::UniqueFunction<void(const Response&)>&& completion)
 {
     request.headers = get_request_headers(sync_user, request.uses_refresh_token ? RequestTokenType::RefreshToken
                                                                                 : RequestTokenType::AccessToken);
 
-    do_request(request, [completion_block, request, sync_user, this](Response response) {
+    auto completion_2 = [completion = std::move(completion), request, sync_user,
+                         this](const Response& response) mutable {
         if (auto error = AppUtils::check_for_errors(response)) {
-            App::handle_auth_failure(error.value(), response, request, sync_user, completion_block);
+            App::handle_auth_failure(std::move(*error), std::move(response), std::move(request), sync_user,
+                                     std::move(completion));
         }
         else {
-            completion_block(response);
-        }
-    });
-}
-
-void App::handle_auth_failure(const AppError& error, const Response& response, Request request,
-                              std::shared_ptr<SyncUser> sync_user, std::function<void(Response)> completion_block)
-{
-    auto access_token_handler = [this, request, completion_block, response,
-                                 sync_user](const Optional<AppError>& error) {
-        if (!error) {
-            // assign the new access_token to the auth header
-            Request newRequest = request;
-            newRequest.headers = get_request_headers(sync_user, RequestTokenType::AccessToken);
-            m_config.transport->send_request_to_server(newRequest, completion_block);
-        }
-        else {
-            // pass the error back up the chain
-            completion_block(response);
+            completion(std::move(response));
         }
     };
+    do_request(std::move(request), std::move(completion_2));
+}
 
+void App::handle_auth_failure(const AppError& error, const Response& response, Request&& request,
+                              const std::shared_ptr<SyncUser>& sync_user,
+                              util::UniqueFunction<void(const Response&)>&& completion)
+{
     // Only handle auth failures
-    if (*error.http_status_code && *error.http_status_code == 401) {
+    if (*error.http_status_code == 401) {
         if (request.uses_refresh_token) {
             if (sync_user && sync_user->is_logged_in()) {
                 sync_user->log_out();
             }
-            completion_block(response);
+            completion(std::move(response));
             return;
         }
-
-        App::refresh_access_token(sync_user, access_token_handler);
     }
     else {
-        completion_block(response);
+        completion(std::move(response));
+        return;
     }
+
+    App::refresh_access_token(sync_user, [this, request = std::move(request), completion = std::move(completion),
+                                          response = std::move(response),
+                                          sync_user](Optional<AppError>&& error) mutable {
+        if (!error) {
+            // assign the new access_token to the auth header
+            request.headers = get_request_headers(sync_user, RequestTokenType::AccessToken);
+            m_config.transport->send_request_to_server(std::move(request), std::move(completion));
+        }
+        else {
+            // pass the error back up the chain
+            completion(std::move(response));
+        }
+    });
 }
 
 /// MARK: - refresh access token
-void App::refresh_access_token(std::shared_ptr<SyncUser> sync_user,
-                               std::function<void(Optional<AppError>)> completion_block)
+void App::refresh_access_token(const std::shared_ptr<SyncUser>& sync_user,
+                               util::UniqueFunction<void(Optional<AppError>)>&& completion)
 {
     if (!sync_user) {
-        completion_block(AppError(make_client_error_code(ClientErrorCode::user_not_found), "No current user exists"));
+        completion(AppError(make_client_error_code(ClientErrorCode::user_not_found), "No current user exists"));
         return;
     }
 
     if (!sync_user->is_logged_in()) {
-        completion_block(
+        completion(
             AppError(make_client_error_code(ClientErrorCode::user_not_logged_in), "The user is not logged in"));
         return;
     }
-
-    auto handler = [completion_block, sync_user](const Response& response) {
-        if (auto error = AppUtils::check_for_errors(response)) {
-            return completion_block(error);
-        }
-
-        try {
-            nlohmann::json json = nlohmann::json::parse(response.body);
-            auto access_token = value_from_json<std::string>(json, "access_token");
-            sync_user->update_access_token(std::move(access_token));
-        }
-        catch (const AppError& err) {
-            return completion_block(err);
-        }
-
-        return completion_block(util::none);
-    };
 
     std::string route;
     {
@@ -1015,9 +855,23 @@ void App::refresh_access_token(std::shared_ptr<SyncUser> sync_user,
         route = util::format("%1/auth/session", m_base_route);
     }
 
-    do_request(Request{HttpMethod::post, route, m_request_timeout_ms,
+    do_request(Request{HttpMethod::post, std::move(route), m_request_timeout_ms,
                        get_request_headers(sync_user, RequestTokenType::RefreshToken)},
-               handler);
+               [completion = std::move(completion), sync_user](const Response& response) {
+                   if (auto error = AppUtils::check_for_errors(response)) {
+                       return completion(std::move(error));
+                   }
+
+                   try {
+                       auto json = parse<BsonDocument>(response.body);
+                       sync_user->update_access_token(get<std::string>(json, "access_token"));
+                   }
+                   catch (AppError& err) {
+                       return completion(std::move(err));
+                   }
+
+                   return completion(util::none);
+               });
 }
 
 std::string App::function_call_url_path() const
@@ -1026,67 +880,65 @@ std::string App::function_call_url_path() const
     return util::format("%1/app/%2/functions/call", m_base_route, m_config.app_id);
 }
 
-void App::call_function(std::shared_ptr<SyncUser> user, const std::string& name, const bson::BsonArray& args_bson,
-                        const util::Optional<std::string>& service_name,
-                        std::function<void(util::Optional<AppError>, util::Optional<bson::Bson>)> completion_block)
+void App::call_function(const std::shared_ptr<SyncUser>& user, const std::string& name, const BsonArray& args_bson,
+                        const Optional<std::string>& service_name,
+                        UniqueFunction<void(Optional<Bson>&&, Optional<AppError>)>&& completion)
 {
-    auto handler = [completion_block](const Response& response) {
+    auto handler = [completion = std::move(completion)](const Response& response) {
         if (auto error = AppUtils::check_for_errors(response)) {
-            return completion_block(error, util::none);
+            return completion(util::none, error);
         }
-        util::Optional<bson::Bson> body_as_bson;
+        util::Optional<Bson> body_as_bson;
         try {
             body_as_bson = bson::parse(response.body);
         }
         catch (const std::exception& e) {
-            return completion_block(AppError(make_error_code(JSONErrorCode::bad_bson_parse), e.what()), util::none);
+            return completion(util::none, AppError(make_error_code(JSONErrorCode::bad_bson_parse), e.what()));
         };
-        completion_block(util::none, body_as_bson);
+        completion(std::move(body_as_bson), util::none);
     };
 
-    bson::BsonDocument args{{"arguments", args_bson}, {"name", name}};
+    BsonDocument args{{"arguments", args_bson}, {"name", name}};
 
     if (service_name) {
         args["service"] = *service_name;
     }
 
     do_authenticated_request(
-        Request{
-            HttpMethod::post, function_call_url_path(), m_request_timeout_ms, {}, bson::Bson(args).toJson(), false},
-        user, handler);
+        Request{HttpMethod::post, function_call_url_path(), m_request_timeout_ms, {}, Bson(args).toJson(), false},
+        user, std::move(handler));
 }
 
-void App::call_function(std::shared_ptr<SyncUser> user, const std::string& name, const bson::BsonArray& args_bson,
-                        std::function<void(util::Optional<AppError>, util::Optional<bson::Bson>)> completion_block)
+void App::call_function(const std::shared_ptr<SyncUser>& user, const std::string& name, const BsonArray& args_bson,
+                        UniqueFunction<void(Optional<bson::Bson>&&, Optional<AppError>)>&& completion)
 {
-    call_function(user, name, args_bson, util::none, completion_block);
+    call_function(user, name, args_bson, util::none, std::move(completion));
 }
 
-void App::call_function(const std::string& name, const bson::BsonArray& args_bson,
-                        const util::Optional<std::string>& service_name,
-                        std::function<void(util::Optional<AppError>, util::Optional<bson::Bson>)> completion_block)
+void App::call_function(const std::string& name, const BsonArray& args_bson,
+                        const Optional<std::string>& service_name,
+                        UniqueFunction<void(Optional<bson::Bson>&&, Optional<AppError>)>&& completion)
 {
-    call_function(m_sync_manager->get_current_user(), name, args_bson, service_name, completion_block);
+    call_function(m_sync_manager->get_current_user(), name, args_bson, service_name, std::move(completion));
 }
 
-void App::call_function(const std::string& name, const bson::BsonArray& args_bson,
-                        std::function<void(util::Optional<AppError>, util::Optional<bson::Bson>)> completion_block)
+void App::call_function(const std::string& name, const BsonArray& args_bson,
+                        UniqueFunction<void(Optional<bson::Bson>&&, Optional<AppError>)>&& completion)
 {
-    call_function(m_sync_manager->get_current_user(), name, args_bson, completion_block);
+    call_function(m_sync_manager->get_current_user(), name, args_bson, std::move(completion));
 }
 
-Request App::make_streaming_request(std::shared_ptr<SyncUser> user, const std::string& name,
-                                    const bson::BsonArray& args_bson,
-                                    const util::Optional<std::string>& service_name) const
+Request App::make_streaming_request(const std::shared_ptr<SyncUser>& user, const std::string& name,
+                                    const BsonArray& args_bson, const Optional<std::string>& service_name) const
 {
-    auto args = bson::BsonDocument{
+    auto args = BsonDocument{
         {"arguments", args_bson},
         {"name", name},
     };
     if (service_name) {
         args["service"] = *service_name;
     }
-    const auto args_json = bson::Bson(args).toJson();
+    const auto args_json = Bson(args).to_string();
 
     auto args_base64 = std::string(util::base64_encoded_size(args_json.size()), '\0');
     util::base64_encode(args_json.data(), args_json.size(), args_base64.data(), args_base64.size());

--- a/src/realm/object-store/sync/app.hpp
+++ b/src/realm/object-store/sync/app.hpp
@@ -28,6 +28,7 @@
 
 #include <realm/object_id.hpp>
 #include <realm/util/optional.hpp>
+#include <realm/util/functional.hpp>
 
 #include <mutex>
 
@@ -87,7 +88,7 @@ public:
     /// Get all users.
     std::vector<std::shared_ptr<SyncUser>> all_users() const;
 
-    std::shared_ptr<SyncManager> sync_manager() const
+    std::shared_ptr<SyncManager> const& sync_manager() const
     {
         return m_sync_manager;
     }
@@ -115,41 +116,42 @@ public:
     public:
         /// Creates a user API key that can be used to authenticate as the current user.
         /// @param name The name of the API key to be created.
-        /// @param completion_block A callback to be invoked once the call is complete.
-        void create_api_key(const std::string& name, std::shared_ptr<SyncUser> user,
-                            std::function<void(UserAPIKey, util::Optional<AppError>)> completion_block);
+        /// @param completion A callback to be invoked once the call is complete.
+        void create_api_key(const std::string& name, const std::shared_ptr<SyncUser>& user,
+                            util::UniqueFunction<void(UserAPIKey&&, util::Optional<AppError>)>&& completion);
 
         /// Fetches a user API key associated with the current user.
         /// @param id The id of the API key to fetch.
-        /// @param completion_block A callback to be invoked once the call is complete.
-        void fetch_api_key(const realm::ObjectId& id, std::shared_ptr<SyncUser> user,
-                           std::function<void(UserAPIKey, util::Optional<AppError>)> completion_block);
+        /// @param completion A callback to be invoked once the call is complete.
+        void fetch_api_key(const realm::ObjectId& id, const std::shared_ptr<SyncUser>& user,
+                           util::UniqueFunction<void(UserAPIKey&&, util::Optional<AppError>)>&& completion);
 
         /// Fetches the user API keys associated with the current user.
-        /// @param completion_block A callback to be invoked once the call is complete.
-        void fetch_api_keys(std::shared_ptr<SyncUser> user,
-                            std::function<void(std::vector<UserAPIKey>, util::Optional<AppError>)> completion_block);
+        /// @param completion A callback to be invoked once the call is complete.
+        void
+        fetch_api_keys(const std::shared_ptr<SyncUser>& user,
+                       util::UniqueFunction<void(std::vector<UserAPIKey>&&, util::Optional<AppError>)>&& completion);
 
         /// Deletes a user API key associated with the current user.
         /// @param id The id of the API key to delete.
         /// @param user The user to perform this operation.
-        /// @param completion_block A callback to be invoked once the call is complete.
-        void delete_api_key(const realm::ObjectId& id, std::shared_ptr<SyncUser> user,
-                            std::function<void(util::Optional<AppError>)> completion_block);
+        /// @param completion A callback to be invoked once the call is complete.
+        void delete_api_key(const realm::ObjectId& id, const std::shared_ptr<SyncUser>& user,
+                            util::UniqueFunction<void(util::Optional<AppError>)>&& completion);
 
         /// Enables a user API key associated with the current user.
         /// @param id The id of the API key to enable.
         /// @param user The user to perform this operation.
-        /// @param completion_block A callback to be invoked once the call is complete.
-        void enable_api_key(const realm::ObjectId& id, std::shared_ptr<SyncUser> user,
-                            std::function<void(util::Optional<AppError>)> completion_block);
+        /// @param completion A callback to be invoked once the call is complete.
+        void enable_api_key(const realm::ObjectId& id, const std::shared_ptr<SyncUser>& user,
+                            util::UniqueFunction<void(util::Optional<AppError>)>&& completion);
 
         /// Disables a user API key associated with the current user.
         /// @param id The id of the API key to disable.
         /// @param user The user to perform this operation.
-        /// @param completion_block A callback to be invoked once the call is complete.
-        void disable_api_key(const realm::ObjectId& id, std::shared_ptr<SyncUser> user,
-                             std::function<void(util::Optional<AppError>)> completion_block);
+        /// @param completion A callback to be invoked once the call is complete.
+        void disable_api_key(const realm::ObjectId& id, const std::shared_ptr<SyncUser>& user,
+                             util::UniqueFunction<void(util::Optional<AppError>)>&& completion);
 
     private:
         friend class App;
@@ -172,51 +174,51 @@ public:
         /// and sends a confirmation email to the provided address.
         /// @param email The email address of the user to register.
         /// @param password The password that the user created for the new username/password identity.
-        /// @param completion_block A callback to be invoked once the call is complete.
+        /// @param completion A callback to be invoked once the call is complete.
         void register_email(const std::string& email, const std::string& password,
-                            std::function<void(util::Optional<AppError>)> completion_block);
+                            util::UniqueFunction<void(util::Optional<AppError>)>&& completion);
 
         /// Confirms an email identity with the username/password provider.
         /// @param token The confirmation token that was emailed to the user.
         /// @param token_id The confirmation token id that was emailed to the user.
-        /// @param completion_block A callback to be invoked once the call is complete.
+        /// @param completion A callback to be invoked once the call is complete.
         void confirm_user(const std::string& token, const std::string& token_id,
-                          std::function<void(util::Optional<AppError>)> completion_block);
+                          util::UniqueFunction<void(util::Optional<AppError>)>&& completion);
 
         /// Re-sends a confirmation email to a user that has registered but
         /// not yet confirmed their email address.
         /// @param email The email address of the user to re-send a confirmation for.
-        /// @param completion_block A callback to be invoked once the call is complete.
+        /// @param completion A callback to be invoked once the call is complete.
         void resend_confirmation_email(const std::string& email,
-                                       std::function<void(util::Optional<AppError>)> completion_block);
+                                       util::UniqueFunction<void(util::Optional<AppError>)>&& completion);
 
         void send_reset_password_email(const std::string& email,
-                                       std::function<void(util::Optional<AppError>)> completion_block);
+                                       util::UniqueFunction<void(util::Optional<AppError>)>&& completion);
 
         /// Retries the custom confirmation function on a user for a given email.
         /// @param email The email address of the user to retry the custom confirmation for.
-        /// @param completion_block A callback to be invoked once the retry is complete.
+        /// @param completion A callback to be invoked once the retry is complete.
         void retry_custom_confirmation(const std::string& email,
-                                       std::function<void(util::Optional<AppError>)> completion_block);
+                                       util::UniqueFunction<void(util::Optional<AppError>)>&& completion);
 
         /// Resets the password of an email identity using the
         /// password reset token emailed to a user.
         /// @param password The desired new password.
         /// @param token The password reset token that was emailed to the user.
         /// @param token_id The password reset token id that was emailed to the user.
-        /// @param completion_block A callback to be invoked once the call is complete.
+        /// @param completion A callback to be invoked once the call is complete.
         void reset_password(const std::string& password, const std::string& token, const std::string& token_id,
-                            std::function<void(util::Optional<AppError>)> completion_block);
+                            util::UniqueFunction<void(util::Optional<AppError>)>&& completion);
 
         /// Resets the password of an email identity using the
         /// password reset function set up in the application.
         /// @param email The email address of the user.
         /// @param password The desired new password.
         /// @param args A bson array of arguments.
-        /// @param completion_block A callback to be invoked once the call is complete.
+        /// @param completion A callback to be invoked once the call is complete.
         void call_reset_password_function(const std::string& email, const std::string& password,
                                           const bson::BsonArray& args,
-                                          std::function<void(util::Optional<AppError>)> completion_block);
+                                          util::UniqueFunction<void(util::Optional<AppError>)>&& completion);
 
     private:
         friend class App;
@@ -238,20 +240,22 @@ public:
     /// completion block will be called with an error.
     ///
     /// @param credentials A `SyncCredentials` object representing the user to log in.
-    /// @param completion_block A callback block to be invoked once the log in completes.
+    /// @param completion A callback block to be invoked once the log in completes.
     void log_in_with_credentials(
         const AppCredentials& credentials,
-        std::function<void(std::shared_ptr<SyncUser>, util::Optional<AppError>)> completion_block);
+        util::UniqueFunction<void(const std::shared_ptr<SyncUser>&, util::Optional<AppError>)>&& completion);
 
     /// Logout the current user.
-    void log_out(std::function<void(util::Optional<AppError>)>);
+    void log_out(util::UniqueFunction<void(util::Optional<AppError>)>&&);
 
     /// Refreshes the custom data for a specified user
-    /// @param sync_user The user you want to refresh
-    void refresh_custom_data(std::shared_ptr<SyncUser> sync_user, std::function<void(util::Optional<AppError>)>);
+    /// @param user The user you want to refresh
+    void refresh_custom_data(const std::shared_ptr<SyncUser>& user,
+                             util::UniqueFunction<void(util::Optional<AppError>)>&&);
 
     /// Log out the given user if they are not already logged out.
-    void log_out(std::shared_ptr<SyncUser> user, std::function<void(util::Optional<AppError>)> completion_block);
+    void log_out(const std::shared_ptr<SyncUser>& user,
+                 util::UniqueFunction<void(util::Optional<AppError>)>&& completion);
 
     /// Links the currently authenticated user with a new identity, where the identity is defined by the credential
     /// specified as a parameter. This will only be successful if this `SyncUser` is the currently authenticated
@@ -259,11 +263,12 @@ public:
     ///
     /// @param user The user which will have the credentials linked to, the user must be logged in
     /// @param credentials The `AppCredentials` used to link the user to a new identity.
-    /// @param completion_block The completion handler to call when the linking is complete.
+    /// @param completion The completion handler to call when the linking is complete.
     ///                         If the operation is  successful, the result will contain the original
     ///                         `SyncUser` object representing the user.
-    void link_user(std::shared_ptr<SyncUser> user, const AppCredentials& credentials,
-                   std::function<void(std::shared_ptr<SyncUser>, util::Optional<AppError>)> completion_block);
+    void
+    link_user(const std::shared_ptr<SyncUser>& user, const AppCredentials& credentials,
+              util::UniqueFunction<void(const std::shared_ptr<SyncUser>&, util::Optional<AppError>)>&& completion);
 
     /// Switches the active user with the specified one. The user must
     /// exist in the list of all users who have logged into this application, and
@@ -272,18 +277,20 @@ public:
     ///
     /// @param user The user to switch to
     /// @returns A shared pointer to the new current user
-    std::shared_ptr<SyncUser> switch_user(std::shared_ptr<SyncUser> user) const;
+    std::shared_ptr<SyncUser> switch_user(const std::shared_ptr<SyncUser>& user) const;
 
     /// Logs out and removes the provided user.
     /// This invokes logout on the server.
     /// @param user the user to remove
-    /// @param completion_block Will return an error if the user is not found or the http request failed.
-    void remove_user(std::shared_ptr<SyncUser> user, std::function<void(util::Optional<AppError>)> completion_block);
+    /// @param completion Will return an error if the user is not found or the http request failed.
+    void remove_user(const std::shared_ptr<SyncUser>& user,
+                     util::UniqueFunction<void(util::Optional<AppError>)>&& completion);
 
     /// Deletes a user and all its data from the server.
     /// @param user The user to delete
-    /// @param completion_block Will return an error if the user is not found or the http request failed.
-    void delete_user(std::shared_ptr<SyncUser> user, std::function<void(util::Optional<AppError>)> completion_block);
+    /// @param completion Will return an error if the user is not found or the http request failed.
+    void delete_user(const std::shared_ptr<SyncUser>& user,
+                     util::UniqueFunction<void(util::Optional<AppError>)>&& completion);
 
     // Get a provider client for the given class type.
     template <class T>
@@ -293,46 +300,48 @@ public:
     }
 
     void call_function(
-        std::shared_ptr<SyncUser> user, const std::string& name, const bson::BsonArray& args_bson,
+        const std::shared_ptr<SyncUser>& user, const std::string& name, const bson::BsonArray& args_bson,
         const util::Optional<std::string>& service_name,
-        std::function<void(util::Optional<AppError>, util::Optional<bson::Bson>)> completion_block) override;
+        util::UniqueFunction<void(util::Optional<bson::Bson>&&, util::Optional<AppError>)>&& completion) override;
 
     void call_function(
-        std::shared_ptr<SyncUser> user, const std::string&, const bson::BsonArray& args_bson,
-        std::function<void(util::Optional<AppError>, util::Optional<bson::Bson>)> completion_block) override;
+        const std::shared_ptr<SyncUser>& user, const std::string&, const bson::BsonArray& args_bson,
+        util::UniqueFunction<void(util::Optional<bson::Bson>&&, util::Optional<AppError>)>&& completion) override;
 
     void call_function(
         const std::string& name, const bson::BsonArray& args_bson, const util::Optional<std::string>& service_name,
-        std::function<void(util::Optional<AppError>, util::Optional<bson::Bson>)> completion_block) override;
+        util::UniqueFunction<void(util::Optional<bson::Bson>&&, util::Optional<AppError>)>&& completion) override;
 
     void call_function(
         const std::string&, const bson::BsonArray& args_bson,
-        std::function<void(util::Optional<AppError>, util::Optional<bson::Bson>)> completion_block) override;
+        util::UniqueFunction<void(util::Optional<bson::Bson>&&, util::Optional<AppError>)>&& completion) override;
 
     template <typename T>
-    void call_function(std::shared_ptr<SyncUser> user, const std::string& name, const bson::BsonArray& args_bson,
-                       std::function<void(util::Optional<AppError>, util::Optional<T>)> completion_block)
+    void call_function(const std::shared_ptr<SyncUser>& user, const std::string& name,
+                       const bson::BsonArray& args_bson,
+                       util::UniqueFunction<void(util::Optional<T>&&, util::Optional<AppError>)>&& completion)
     {
-        call_function(user, name, args_bson, util::none,
-                      [completion_block](util::Optional<AppError> error, util::Optional<bson::Bson> value) {
-                          if (value) {
-                              return completion_block(error, util::some<T>(static_cast<T>(*value)));
-                          }
+        call_function(
+            user, name, args_bson, util::none,
+            [completion = std::move(completion)](util::Optional<bson::Bson>&& value, util::Optional<AppError> error) {
+                if (value) {
+                    return completion(util::some<T>(static_cast<T>(*value)), std::move(error));
+                }
 
-                          return completion_block(error, util::none);
-                      });
+                return completion(util::none, std::move(error));
+            });
     }
 
     template <typename T>
     void call_function(const std::string& name, const bson::BsonArray& args_bson,
-                       std::function<void(util::Optional<AppError>, util::Optional<T>)> completion_block)
+                       util::UniqueFunction<void(util::Optional<T>&&, util::Optional<AppError>)>&& completion)
     {
-        call_function(current_user(), name, args_bson, completion_block);
+        call_function(current_user(), name, args_bson, std::move(completion));
     }
 
     // NOTE: only sets "Accept: text/event-stream" header. If you use an API that sets that but doesn't support
     // setting other headers (eg. EventSource() in JS), you can ignore the headers field on the request.
-    Request make_streaming_request(std::shared_ptr<SyncUser> user, const std::string& name,
+    Request make_streaming_request(const std::shared_ptr<SyncUser>& user, const std::string& name,
                                    const bson::BsonArray& args_bson,
                                    const util::Optional<std::string>& service_name) const;
 
@@ -355,41 +364,47 @@ private:
     std::shared_ptr<SyncManager> m_sync_manager;
 
     /// Refreshes the access token for a specified `SyncUser`
-    /// @param completion_block Passes an error should one occur.
-    void refresh_access_token(std::shared_ptr<SyncUser> sync_user,
-                              std::function<void(util::Optional<AppError>)> completion_block);
-
+    /// @param completion Passes an error should one occur.
+    void refresh_access_token(const std::shared_ptr<SyncUser>& user,
+                              util::UniqueFunction<void(util::Optional<AppError>)>&& completion);
 
     /// Checks if an auth failure has taken place and if so it will attempt to refresh the
     /// access token and then perform the orginal request again with the new access token
     /// @param error The error to check for auth failures
     /// @param response The original response to pass back should this not be an auth error
     /// @param request The request to perform
-    /// @param completion_block returns the original response in the case it is not an auth error, or if a failure
+    /// @param completion returns the original response in the case it is not an auth error, or if a failure
     /// occurs, if the refresh was a success the newly attempted response will be passed back
-    void handle_auth_failure(const AppError& error, const Response& response, Request request,
-                             std::shared_ptr<SyncUser> sync_user, std::function<void(Response)> completion_block);
+    void handle_auth_failure(const AppError& error, const Response& response, Request&& request,
+                             const std::shared_ptr<SyncUser>& user,
+                             util::UniqueFunction<void(const Response&)>&& completion);
 
     std::string url_for_path(const std::string& path) const override;
 
-    void init_app_metadata(std::function<void(util::Optional<AppError>, util::Optional<Response>)> completion_block);
+    void init_app_metadata(util::UniqueFunction<void(const util::Optional<Response>&)>&& completion);
+
+    void basic_request(std::string&& route, std::string&& body,
+                       util::UniqueFunction<void(util::Optional<AppError>)>&& completion);
+    void post(std::string&& route, util::UniqueFunction<void(util::Optional<AppError>)>&& completion,
+              const bson::BsonDocument& body);
 
     /// Performs a request to the Stitch server. This request does not contain authentication state.
     /// @param request The request to be performed
-    /// @param completion_block Returns the response from the server
-    void do_request(Request request, std::function<void(Response)> completion_block);
+    /// @param completion Returns the response from the server
+    void do_request(Request&& request, util::UniqueFunction<void(const Response&)>&& completion);
 
     /// Performs an authenticated request to the Stitch server, using the current authentication state
     /// @param request The request to be performed
-    /// @param completion_block Returns the response from the server
-    void do_authenticated_request(Request request, std::shared_ptr<SyncUser> sync_user,
-                                  std::function<void(Response)> completion_block) override;
+    /// @param completion Returns the response from the server
+    void do_authenticated_request(Request&& request, const std::shared_ptr<SyncUser>& user,
+                                  util::UniqueFunction<void(const Response&)>&& completion) override;
 
 
     /// Gets the social profile for a `SyncUser`
-    /// @param completion_block Callback will pass the `SyncUser` with the social profile details
-    void get_profile(std::shared_ptr<SyncUser> sync_user,
-                     std::function<void(std::shared_ptr<SyncUser>, util::Optional<AppError>)> completion_block);
+    /// @param completion Callback will pass the `SyncUser` with the social profile details
+    void
+    get_profile(const std::shared_ptr<SyncUser>& user,
+                util::UniqueFunction<void(const std::shared_ptr<SyncUser>&, util::Optional<AppError>)>&& completion);
 
     /// Log in a user and asynchronously retrieve a user object.
     /// If the log in completes successfully, the completion block will be called, and a
@@ -399,10 +414,10 @@ private:
     ///
     /// @param credentials A `SyncCredentials` object representing the user to log in.
     /// @param linking_user A `SyncUser` you want to link these credentials too
-    /// @param completion_block A callback block to be invoked once the log in completes.
+    /// @param completion A callback block to be invoked once the log in completes.
     void log_in_with_credentials(
-        const AppCredentials& credentials, const std::shared_ptr<SyncUser> linking_user,
-        std::function<void(std::shared_ptr<SyncUser>, util::Optional<AppError>)> completion_block);
+        const AppCredentials& credentials, const std::shared_ptr<SyncUser>& linking_user,
+        util::UniqueFunction<void(const std::shared_ptr<SyncUser>&, util::Optional<AppError>)>&& completion);
 
     /// Provides MongoDB Realm Cloud with metadata related to the users session
     void attach_auth_options(bson::BsonDocument& body);
@@ -410,6 +425,8 @@ private:
     std::string function_call_url_path() const;
 
     void configure(const SyncClientConfig& sync_client_config);
+
+    bool verify_user_present(const std::shared_ptr<SyncUser>& user) const;
 };
 
 // MARK: Provider client templates

--- a/src/realm/object-store/sync/app_credentials.hpp
+++ b/src/realm/object-store/sync/app_credentials.hpp
@@ -21,7 +21,7 @@
 
 #include <realm/object-store/util/tagged_string.hpp>
 
-#include <functional>
+#include <memory>
 #include <string>
 
 namespace realm {
@@ -129,19 +129,21 @@ struct AppCredentials {
     std::string provider_as_string() const;
 
     // The serialized payload
+    bson::BsonDocument serialize_as_bson() const;
     std::string serialize_as_json() const;
 
     AppCredentials() = default;
-    AppCredentials(const AppCredentials&) = default;
+    AppCredentials(const AppCredentials&);
     AppCredentials(AppCredentials&&) = default;
-    AppCredentials& operator=(AppCredentials const&) = default;
+    AppCredentials& operator=(AppCredentials const&);
     AppCredentials& operator=(AppCredentials&&) = default;
 
 private:
-    AppCredentials(AuthProvider provider, std::function<std::string()> factory);
+    AppCredentials(AuthProvider provider, std::unique_ptr<bson::BsonDocument> payload);
+    AppCredentials(AuthProvider provider, std::initializer_list<std::pair<const char*, bson::Bson>>);
     // The name of the identity provider which generated the credentials token.
     AuthProvider m_provider;
-    std::function<std::string()> m_payload_factory;
+    std::unique_ptr<bson::BsonDocument> m_payload;
 };
 
 } // namespace app

--- a/src/realm/object-store/sync/app_service_client.hpp
+++ b/src/realm/object-store/sync/app_service_client.hpp
@@ -20,6 +20,7 @@
 #define APP_SERVICE_CLIENT_HPP
 
 #include <realm/object-store/util/bson/bson.hpp>
+#include <realm/util/functional.hpp>
 #include <realm/util/optional.hpp>
 
 #include <string>
@@ -29,8 +30,8 @@ class SyncUser;
 namespace app {
 struct AppError;
 
-/// A class providing the core functionality necessary to make authenticated function call requests for a particular
-/// Stitch service.
+/// A class providing the core functionality necessary to make authenticated
+/// function call requests for a particular Stitch service.
 class AppServiceClient {
 public:
     virtual ~AppServiceClient() = default;
@@ -40,44 +41,43 @@ public:
     /// @param name The name of the Realm Cloud function to be called.
     /// @param args_bson The `BSONArray` of arguments to be provided to the function.
     /// @param service_name The name of the service, this is optional.
-    /// @param completion_block Returns the result from the intended call, will return an Optional AppError is an
+    /// @param completion Returns the result from the intended call, will return an Optional AppError is an
     /// error is thrown and bson if successful
-    virtual void
-    call_function(std::shared_ptr<SyncUser> user, const std::string& name, const bson::BsonArray& args_bson,
-                  const util::Optional<std::string>& service_name,
-                  std::function<void(util::Optional<AppError>, util::Optional<bson::Bson>)> completion_block) = 0;
+    virtual void call_function(
+        const std::shared_ptr<SyncUser>& user, const std::string& name, const bson::BsonArray& args_bson,
+        const util::Optional<std::string>& service_name,
+        util::UniqueFunction<void(util::Optional<bson::Bson>&&, util::Optional<AppError>)>&& completion) = 0;
 
     /// Calls the Realm Cloud function with the provided name and arguments.
     /// @param user The sync user to perform this request.
     /// @param name The name of the Realm Cloud function to be called.
     /// @param args_bson The `BSONArray` of arguments to be provided to the function.
-    /// @param completion_block Returns the result from the intended call, will return an Optional AppError is an
+    /// @param completion Returns the result from the intended call, will return an Optional AppError is an
     /// error is thrown and bson if successful
-    virtual void
-    call_function(std::shared_ptr<SyncUser> user, const std::string& name, const bson::BsonArray& args_bson,
-                  std::function<void(util::Optional<AppError>, util::Optional<bson::Bson>)> completion_block) = 0;
+    virtual void call_function(
+        const std::shared_ptr<SyncUser>& user, const std::string& name, const bson::BsonArray& args_bson,
+        util::UniqueFunction<void(util::Optional<bson::Bson>&&, util::Optional<AppError>)>&& completion) = 0;
 
     /// Calls the Realm Cloud function with the provided name and arguments.
     /// This will use the current logged in user to perform the request
     /// @param name The name of the Realm Cloud function to be called.
     /// @param args_bson The `BSONArray` of arguments to be provided to the function.
     /// @param service_name The name of the service, this is optional.
-    /// @param completion_block Returns the result from the intended call, will return an Optional AppError is an
+    /// @param completion Returns the result from the intended call, will return an Optional AppError is an
     /// error is thrown and bson if successful
-    virtual void
-    call_function(const std::string& name, const bson::BsonArray& args_bson,
-                  const util::Optional<std::string>& service_name,
-                  std::function<void(util::Optional<AppError>, util::Optional<bson::Bson>)> completion_block) = 0;
+    virtual void call_function(
+        const std::string& name, const bson::BsonArray& args_bson, const util::Optional<std::string>& service_name,
+        util::UniqueFunction<void(util::Optional<bson::Bson>&&, util::Optional<AppError>)>&& completion) = 0;
 
     /// Calls the Realm Cloud function with the provided name and arguments.
     /// This will use the current logged in user to perform the request
     /// @param name The name of the Realm Cloud function to be called.
     /// @param args_bson The `BSONArray` of arguments to be provided to the function.
-    /// @param completion_block Returns the result from the intended call, will return an Optional AppError is an
+    /// @param completion Returns the result from the intended call, will return an Optional AppError is an
     /// error is thrown and bson if successful
-    virtual void
-    call_function(const std::string& name, const bson::BsonArray& args_bson,
-                  std::function<void(util::Optional<AppError>, util::Optional<bson::Bson>)> completion_block) = 0;
+    virtual void call_function(
+        const std::string& name, const bson::BsonArray& args_bson,
+        util::UniqueFunction<void(util::Optional<bson::Bson>&&, util::Optional<AppError>)>&& completion) = 0;
 };
 
 } // namespace app

--- a/src/realm/object-store/sync/async_open_task.hpp
+++ b/src/realm/object-store/sync/async_open_task.hpp
@@ -20,8 +20,8 @@
 #define ASYNC_OPEN_TASK_HPP
 
 #include <realm/object-store/util/checked_mutex.hpp>
+#include <realm/util/functional.hpp>
 
-#include <functional>
 #include <memory>
 #include <vector>
 
@@ -43,13 +43,13 @@ public:
     //
     // If multiple AsyncOpenTasks all attempt to download the same Realm and one of them is canceled,
     // the other tasks will receive a "Cancelled" exception.
-    void start(std::function<void(ThreadSafeReference, std::exception_ptr)> callback) REQUIRES(!m_mutex);
+    void start(util::UniqueFunction<void(ThreadSafeReference, std::exception_ptr)> callback) REQUIRES(!m_mutex);
 
     // Cancels the download and stops the session. No further functions should be called on this class.
     void cancel() REQUIRES(!m_mutex);
 
     uint64_t register_download_progress_notifier(
-        std::function<void(uint64_t transferred_bytes, uint64_t transferrable_bytes)> callback) REQUIRES(!m_mutex);
+        std::function<void(uint64_t transferred_bytes, uint64_t transferrable_bytes)>&& callback) REQUIRES(!m_mutex);
     void unregister_download_progress_notifier(uint64_t token) REQUIRES(!m_mutex);
 
 private:

--- a/src/realm/object-store/sync/auth_request_client.hpp
+++ b/src/realm/object-store/sync/auth_request_client.hpp
@@ -19,7 +19,8 @@
 #ifndef AUTH_REQUEST_CLIENT_HPP
 #define AUTH_REQUEST_CLIENT_HPP
 
-#include <functional>
+#include <realm/util/functional.hpp>
+#include <memory>
 #include <string>
 
 namespace realm {
@@ -34,8 +35,8 @@ public:
 
     virtual std::string url_for_path(const std::string& path) const = 0;
 
-    virtual void do_authenticated_request(Request, std::shared_ptr<SyncUser> sync_user,
-                                          std::function<void(Response)>) = 0;
+    virtual void do_authenticated_request(Request&&, const std::shared_ptr<SyncUser>& sync_user,
+                                          util::UniqueFunction<void(const Response&)>&&) = 0;
 };
 
 } // namespace app

--- a/src/realm/object-store/sync/generic_network_transport.cpp
+++ b/src/realm/object-store/sync/generic_network_transport.cpp
@@ -18,10 +18,7 @@
 
 #include <realm/object-store/sync/generic_network_transport.hpp>
 
-#include <string>
-
-namespace realm {
-namespace app {
+namespace realm::app {
 
 namespace {
 
@@ -255,5 +252,4 @@ std::error_code make_client_error_code(ClientErrorCode error) noexcept
     return std::error_code{int(error), g_client_error_category};
 }
 
-} // namespace app
-} // namespace realm
+} // namespace realm::app

--- a/src/realm/object-store/sync/generic_network_transport.hpp
+++ b/src/realm/object-store/sync/generic_network_transport.hpp
@@ -19,10 +19,9 @@
 #ifndef REALM_GENERIC_NETWORK_TRANSPORT_HPP
 #define REALM_GENERIC_NETWORK_TRANSPORT_HPP
 
-#include <realm/util/to_string.hpp>
+#include <realm/util/functional.hpp>
 #include <realm/util/optional.hpp>
 
-#include <functional>
 #include <iosfwd>
 #include <map>
 #include <memory>
@@ -30,8 +29,7 @@
 #include <system_error>
 #include <vector>
 
-namespace realm {
-namespace app {
+namespace realm::app {
 
 enum class ClientErrorCode { user_not_found = 1, user_not_logged_in = 2, app_deallocated = 3 };
 
@@ -220,12 +218,11 @@ struct Response {
 
 /// Generic network transport for foreign interfaces.
 struct GenericNetworkTransport {
-    virtual void send_request_to_server(const Request request,
-                                        std::function<void(const Response)> completionBlock) = 0;
+    virtual void send_request_to_server(Request&& request,
+                                        util::UniqueFunction<void(const Response&)>&& completionBlock) = 0;
     virtual ~GenericNetworkTransport() = default;
 };
 
-} // namespace app
-} // namespace realm
+} // namespace realm::app
 
 #endif /* REALM_GENERIC_NETWORK_TRANSPORT_HPP */

--- a/src/realm/object-store/sync/impl/apple/network_reachability_observer.cpp
+++ b/src/realm/object-store/sync/impl/apple/network_reachability_observer.cpp
@@ -48,8 +48,8 @@ NetworkReachabilityStatus reachability_status_for_flags(SCNetworkReachabilityFla
 
 } // namespace
 
-NetworkReachabilityObserver::NetworkReachabilityObserver(util::Optional<std::string> hostname,
-                                                         std::function<void(const NetworkReachabilityStatus)> handler)
+NetworkReachabilityObserver::NetworkReachabilityObserver(
+    util::Optional<std::string> hostname, util::UniqueFunction<void(const NetworkReachabilityStatus)> handler)
     : m_callback_queue(dispatch_queue_create("io.realm.sync.reachability", DISPATCH_QUEUE_SERIAL))
     , m_change_handler(std::move(handler))
 {

--- a/src/realm/object-store/sync/impl/apple/network_reachability_observer.hpp
+++ b/src/realm/object-store/sync/impl/apple/network_reachability_observer.hpp
@@ -19,10 +19,10 @@
 #ifndef REALM_OS_NETWORK_REACHABILITY_OBSERVER_HPP
 #define REALM_OS_NETWORK_REACHABILITY_OBSERVER_HPP
 
-#include <functional>
 #include <string>
 
 #include <realm/util/cf_ptr.hpp>
+#include <realm/util/functional.hpp>
 #include <realm/util/optional.hpp>
 
 #include <realm/object-store/sync/impl/network_reachability.hpp>
@@ -39,7 +39,7 @@ enum NetworkReachabilityStatus { NotReachable, ReachableViaWiFi, ReachableViaWWA
 class NetworkReachabilityObserver {
 public:
     NetworkReachabilityObserver(util::Optional<std::string> hostname,
-                                std::function<void(const NetworkReachabilityStatus)> handler);
+                                util::UniqueFunction<void(const NetworkReachabilityStatus)> handler);
 
     ~NetworkReachabilityObserver();
 
@@ -54,7 +54,7 @@ private:
     util::CFPtr<SCNetworkReachabilityRef> m_reachability_ref;
     NetworkReachabilityStatus m_previous_status;
     dispatch_queue_t m_callback_queue;
-    std::function<void(const NetworkReachabilityStatus)> m_change_handler;
+    util::UniqueFunction<void(const NetworkReachabilityStatus)> m_change_handler;
 };
 
 } // namespace _impl

--- a/src/realm/object-store/sync/push_client.hpp
+++ b/src/realm/object-store/sync/push_client.hpp
@@ -19,6 +19,7 @@
 #ifndef PUSH_CLIENT_HPP
 #define PUSH_CLIENT_HPP
 
+#include <realm/util/functional.hpp>
 #include <realm/util/optional.hpp>
 
 #include <memory>
@@ -32,8 +33,8 @@ struct AppError;
 
 class PushClient {
 public:
-    PushClient(const std::string& service_name, const std::string& app_id, const uint64_t timeout_ms,
-               std::shared_ptr<AuthRequestClient> auth_request_client)
+    PushClient(const std::string& service_name, const std::string& app_id, uint64_t timeout_ms,
+               std::shared_ptr<AuthRequestClient>&& auth_request_client)
         : m_service_name(service_name)
         , m_app_id(app_id)
         , m_timeout_ms(timeout_ms)
@@ -51,17 +52,17 @@ public:
     /// Register a device for push notifications.
     /// @param registration_token GCM registration token for the device.
     /// @param sync_user The sync user requesting push registration.
-    /// @param completion_block An error will be returned should something go wrong.
-    void register_device(const std::string& registration_token, std::shared_ptr<SyncUser> sync_user,
-                         std::function<void(util::Optional<AppError>)> completion_block);
+    /// @param completion An error will be returned should something go wrong.
+    void register_device(const std::string& registration_token, const std::shared_ptr<SyncUser>& sync_user,
+                         util::UniqueFunction<void(util::Optional<AppError>)>&& completion);
 
 
     /// Deregister a device for push notificatons, no token or device id needs to be passed
     /// as it is linked to the user in MongoDB Realm Cloud.
     /// @param sync_user The sync user requesting push degistration.
-    /// @param completion_block An error will be returned should something go wrong.
-    void deregister_device(std::shared_ptr<SyncUser> sync_user,
-                           std::function<void(util::Optional<AppError>)> completion_block);
+    /// @param completion An error will be returned should something go wrong.
+    void deregister_device(const std::shared_ptr<SyncUser>& sync_user,
+                           util::UniqueFunction<void(util::Optional<AppError>)>&& completion);
 
 private:
     std::string m_service_name;

--- a/src/realm/object-store/sync/sync_manager.cpp
+++ b/src/realm/object-store/sync/sync_manager.cpp
@@ -41,6 +41,8 @@ SyncClientTimeouts::SyncClientTimeouts()
 {
 }
 
+SyncManager::SyncManager() = default;
+
 void SyncManager::configure(std::shared_ptr<app::App> app, const std::string& sync_route,
                             const SyncClientConfig& config)
 {
@@ -308,7 +310,7 @@ util::Logger::Level SyncManager::log_level() const noexcept
     return m_config.log_level;
 }
 
-bool SyncManager::perform_metadata_update(std::function<void(const SyncMetadataManager&)> update_function) const
+bool SyncManager::perform_metadata_update(util::FunctionRef<void(const SyncMetadataManager&)> update_function) const
 {
     util::CheckedLockGuard lock(m_file_system_mutex);
     if (!m_metadata_manager) {

--- a/src/realm/object-store/sync/sync_manager.hpp
+++ b/src/realm/object-store/sync/sync_manager.hpp
@@ -155,7 +155,7 @@ public:
     void wait_for_sessions_to_terminate() REQUIRES(!m_mutex);
 
     // If the metadata manager is configured, perform an update. Returns `true` iff the code was run.
-    bool perform_metadata_update(std::function<void(const SyncMetadataManager&)> update_function) const
+    bool perform_metadata_update(util::FunctionRef<void(const SyncMetadataManager&)> update_function) const
         REQUIRES(!m_file_system_mutex);
 
     // Get a sync user for a given identity, or create one if none exists yet, and set its token.
@@ -222,7 +222,7 @@ public:
         return m_app;
     }
 
-    SyncManager() = default;
+    SyncManager();
     SyncManager(const SyncManager&) = delete;
     SyncManager& operator=(const SyncManager&) = delete;
 

--- a/src/realm/object-store/sync/sync_user.cpp
+++ b/src/realm/object-store/sync/sync_user.cpp
@@ -485,7 +485,7 @@ void SyncUser::set_binding_context_factory(SyncUserContextFactory factory)
     s_binding_context_factory = std::move(factory);
 }
 
-void SyncUser::refresh_custom_data(std::function<void(util::Optional<app::AppError>)> completion_block)
+void SyncUser::refresh_custom_data(util::UniqueFunction<void(util::Optional<app::AppError>)> completion_block)
 {
     std::shared_ptr<app::App> app;
     std::shared_ptr<SyncUser> user;
@@ -510,7 +510,7 @@ void SyncUser::refresh_custom_data(std::function<void(util::Optional<app::AppErr
     }
     else {
         std::weak_ptr<SyncUser> weak_user = user->weak_from_this();
-        app->refresh_custom_data(user, [completion_block, weak_user](auto error) {
+        app->refresh_custom_data(user, [completion_block = std::move(completion_block), weak_user](auto error) {
             if (auto strong = weak_user.lock()) {
                 strong->emit_change_to_subscribers(*strong);
             }

--- a/src/realm/object-store/sync/sync_user.hpp
+++ b/src/realm/object-store/sync/sync_user.hpp
@@ -48,7 +48,7 @@ public:
     virtual ~SyncUserContext() = default;
 };
 
-using SyncUserContextFactory = std::function<std::shared_ptr<SyncUserContext>()>;
+using SyncUserContextFactory = util::UniqueFunction<std::shared_ptr<SyncUserContext>()>;
 
 // A struct that decodes a given JWT.
 struct RealmJWT {
@@ -285,7 +285,8 @@ public:
     void register_session(std::shared_ptr<SyncSession>) REQUIRES(!m_mutex);
 
     /// Refreshes the custom data for this user
-    void refresh_custom_data(std::function<void(util::Optional<app::AppError>)> completion_block) REQUIRES(!m_mutex);
+    void refresh_custom_data(util::UniqueFunction<void(util::Optional<app::AppError>)> completion_block)
+        REQUIRES(!m_mutex);
 
     /// Checks the expiry on the access token against the local time and if it is invalid or expires soon, returns
     /// true.

--- a/src/realm/object-store/util/android/scheduler.hpp
+++ b/src/realm/object-store/util/android/scheduler.hpp
@@ -127,7 +127,7 @@ public:
     }
 
 private:
-    std::function<void()> m_callback;
+    util::UniqueFunction<void()> m_callback;
     ALooper* m_looper = ALooper_forThread();
     pthread_t m_thread = pthread_self();
     bool m_initialized = false;

--- a/src/realm/object-store/util/apple/scheduler.hpp
+++ b/src/realm/object-store/util/apple/scheduler.hpp
@@ -37,19 +37,19 @@ public:
 
     void set_notify_callback(std::function<void()> fn) override
     {
-        set_callback(m_notify_signal, fn);
+        set_callback(m_notify_signal, std::move(fn));
     }
-    void set_schedule_writes_callback(std::function<void()> fn) override
+    void set_schedule_writes_callback(util::UniqueFunction<void()> fn) override
     {
         if (m_write_signal)
             return; // danger!
-        set_callback(m_write_signal, fn);
+        set_callback(m_write_signal, std::move(fn));
     }
-    void set_schedule_completions_callback(std::function<void()> fn) override
+    void set_schedule_completions_callback(util::UniqueFunction<void()> fn) override
     {
         if (m_completion_signal)
             return; // danger!
-        set_callback(m_completion_signal, fn);
+        set_callback(m_completion_signal, std::move(fn));
     }
 
     bool is_on_thread() const noexcept override;
@@ -71,7 +71,7 @@ private:
     CFRunLoopSourceRef m_completion_signal = nullptr;
 
     void release(CFRunLoopSourceRef&);
-    void set_callback(CFRunLoopSourceRef&, std::function<void()>);
+    void set_callback(CFRunLoopSourceRef&, util::UniqueFunction<void()>);
 };
 
 RunLoopScheduler::RunLoopScheduler(CFRunLoopRef run_loop)
@@ -97,12 +97,12 @@ void RunLoopScheduler::release(CFRunLoopSourceRef& source)
     }
 }
 
-void RunLoopScheduler::set_callback(CFRunLoopSourceRef& source, std::function<void()> callback)
+void RunLoopScheduler::set_callback(CFRunLoopSourceRef& source, util::UniqueFunction<void()> callback)
 {
     release(source);
 
     struct RefCountedRunloopCallback {
-        std::function<void()> callback;
+        util::UniqueFunction<void()> callback;
         std::atomic<size_t> ref_count;
     };
 

--- a/src/realm/object-store/util/bson/bson.hpp
+++ b/src/realm/object-store/util/bson/bson.hpp
@@ -136,10 +136,22 @@ public:
         return double_val;
     }
 
+    explicit operator std::string&()
+    {
+        REALM_ASSERT(m_type == Bson::Type::String);
+        return string_val;
+    }
+
     explicit operator const std::string&() const
     {
         REALM_ASSERT(m_type == Bson::Type::String);
         return string_val;
+    }
+
+    explicit operator std::vector<char>&()
+    {
+        REALM_ASSERT(m_type == Bson::Type::Binary);
+        return binary_val;
     }
 
     explicit operator const std::vector<char>&() const
@@ -190,10 +202,22 @@ public:
         return max_key_val;
     }
 
+    explicit operator IndexedMap<Bson>&() noexcept
+    {
+        REALM_ASSERT(m_type == Bson::Type::Document);
+        return *document_val;
+    }
+
     explicit operator const IndexedMap<Bson>&() const noexcept
     {
         REALM_ASSERT(m_type == Bson::Type::Document);
         return *document_val;
+    }
+
+    explicit operator std::vector<Bson>&() noexcept
+    {
+        REALM_ASSERT(m_type == Bson::Type::Array);
+        return *array_val;
     }
 
     explicit operator const std::vector<Bson>&() const noexcept

--- a/src/realm/object-store/util/bson/indexed_map.hpp
+++ b/src/realm/object-store/util/bson/indexed_map.hpp
@@ -102,7 +102,14 @@ public:
     /// Pop the last entry of the map
     void pop_back();
 
-    const std::vector<std::string> keys() const;
+    const std::vector<std::string>& keys() const noexcept
+    {
+        return m_keys;
+    }
+    const std::unordered_map<std::string, T>& entries() const noexcept
+    {
+        return m_map;
+    }
 
 private:
     template <typename V>
@@ -256,12 +263,6 @@ void IndexedMap<T>::pop_back()
     auto last_key = m_keys.back();
     m_keys.pop_back();
     m_map.erase(last_key);
-}
-
-template <typename T>
-const std::vector<std::string> IndexedMap<T>::keys() const
-{
-    return m_keys;
 }
 
 } // namespace bson

--- a/src/realm/object-store/util/event_loop_dispatcher.hpp
+++ b/src/realm/object-store/util/event_loop_dispatcher.hpp
@@ -38,12 +38,12 @@ class EventLoopDispatcher<void(Args...)> {
 
 private:
     struct State {
-        State(std::function<void(Args...)> func)
+        State(util::UniqueFunction<void(Args...)> func)
             : func(std::move(func))
         {
         }
 
-        const std::function<void(Args...)> func;
+        const util::UniqueFunction<void(Args...)> func;
         std::queue<Tuple> invocations;
         std::mutex mutex;
         std::shared_ptr<util::Scheduler> scheduler;
@@ -52,7 +52,7 @@ private:
     const std::shared_ptr<util::Scheduler> m_scheduler = util::Scheduler::make_default();
 
 public:
-    EventLoopDispatcher(std::function<void(Args...)> func)
+    EventLoopDispatcher(util::UniqueFunction<void(Args...)> func)
         : m_state(std::make_shared<State>(std::move(func)))
     {
         m_scheduler->set_notify_callback([state = m_state] {
@@ -69,7 +69,7 @@ public:
         });
     }
 
-    const std::function<void(Args...)>& func() const
+    const util::UniqueFunction<void(Args...)>& func() const
     {
         return m_state->func;
     }
@@ -126,8 +126,8 @@ template <typename T, typename... Args>
 struct ExtractSignatureImpl<void (T::*)(Args...) const& noexcept> {
     using signature = void(Args...);
 };
-// Note: no && specializations since std::function doesn't support them, so you can't construct an EventLoopDispatcher
-// from something with that anyway.
+// Note: no && specializations since util::UniqueFunction doesn't support them, so you can't construct an
+// EventLoopDispatcher from something with that anyway.
 
 template <typename T>
 using ExtractSignature = typename ExtractSignatureImpl<T>::signature;

--- a/src/realm/object-store/util/generic/scheduler.hpp
+++ b/src/realm/object-store/util/generic/scheduler.hpp
@@ -51,8 +51,8 @@ public:
     {
         return false;
     }
-    void set_schedule_writes_callback(std::function<void()>) override {}
-    void set_schedule_completions_callback(std::function<void()>) override {}
+    void set_schedule_writes_callback(util::UniqueFunction<void()>) override {}
+    void set_schedule_completions_callback(util::UniqueFunction<void()>) override {}
 
 private:
     std::thread::id m_id = std::this_thread::get_id();

--- a/src/realm/object-store/util/scheduler.cpp
+++ b/src/realm/object-store/util/scheduler.cpp
@@ -38,7 +38,7 @@ namespace realm {
 namespace util {
 namespace {
 
-std::function<std::shared_ptr<Scheduler>()> s_factory = &Scheduler::make_platform_default;
+util::UniqueFunction<std::shared_ptr<Scheduler>()> s_factory = &Scheduler::make_platform_default;
 
 class FrozenScheduler : public util::Scheduler {
 public:
@@ -72,8 +72,8 @@ public:
     {
         return false;
     }
-    void set_schedule_writes_callback(std::function<void()>) override {}
-    void set_schedule_completions_callback(std::function<void()>) override {}
+    void set_schedule_writes_callback(util::UniqueFunction<void()>) override {}
+    void set_schedule_completions_callback(util::UniqueFunction<void()>) override {}
 
 private:
     VersionID m_version;
@@ -82,7 +82,7 @@ private:
 
 Scheduler::~Scheduler() = default;
 
-void Scheduler::set_default_factory(std::function<std::shared_ptr<Scheduler>()> factory)
+void Scheduler::set_default_factory(util::UniqueFunction<std::shared_ptr<Scheduler>()> factory)
 {
     s_factory = std::move(factory);
 }

--- a/src/realm/object-store/util/scheduler.hpp
+++ b/src/realm/object-store/util/scheduler.hpp
@@ -20,9 +20,9 @@
 #define REALM_OS_UTIL_SCHEDULER
 
 #include <realm/util/features.h>
+#include <realm/util/functional.hpp>
 #include <realm/version_id.hpp>
 
-#include <functional>
 #include <memory>
 
 #if REALM_PLATFORM_APPLE
@@ -87,15 +87,15 @@ public:
     //
     // This function is not thread-safe.
     virtual void set_notify_callback(std::function<void()>) = 0;
-    virtual void set_schedule_writes_callback(std::function<void()>) {}
-    virtual void set_schedule_completions_callback(std::function<void()>) {}
+    virtual void set_schedule_writes_callback(util::UniqueFunction<void()>) {}
+    virtual void set_schedule_completions_callback(util::UniqueFunction<void()>) {}
 
-    virtual bool set_timeout_callback(uint64_t, std::function<void()>)
+    virtual bool set_timeout_callback(uint64_t, util::UniqueFunction<void()>)
     {
         return false;
     }
 
-    // virtual int enqueue_write(std::function<void()>& block) = 0;
+    // virtual int enqueue_write(util::UniqueFunction<void()>& block) = 0;
 
     [[deprecated("Use Scheduler::make_frozen() instead")]] static std::shared_ptr<Scheduler>
     get_frozen(VersionID version);
@@ -145,7 +145,7 @@ public:
 
     /// Register a factory function which can produce custom schedulers when
     /// `Scheduler::make_default()` is called.
-    static void set_default_factory(std::function<std::shared_ptr<Scheduler>()>);
+    static void set_default_factory(util::UniqueFunction<std::shared_ptr<Scheduler>()>);
 };
 
 

--- a/src/realm/object-store/util/uv/scheduler.hpp
+++ b/src/realm/object-store/util/uv/scheduler.hpp
@@ -60,7 +60,7 @@ public:
         return true;
     }
 
-    uv_async_t* add_callback(std::function<void()> fn)
+    uv_async_t* add_callback(util::UniqueFunction<void()> fn)
     {
         auto the_handle = new uv_async_t;
         the_handle->data = new Data{std::move(fn), {false}};
@@ -110,7 +110,7 @@ public:
     {
         return true;
     }
-    void set_schedule_writes_callback(std::function<void()> fn) override
+    void set_schedule_writes_callback(util::UniqueFunction<void()> fn) override
     {
         if (m_write_handle && m_write_handle->data) {
             return; // danger!
@@ -119,7 +119,7 @@ public:
         }
         m_write_handle = add_callback(std::move(fn));
     }
-    void set_schedule_completions_callback(std::function<void()> fn) override
+    void set_schedule_completions_callback(util::UniqueFunction<void()> fn) override
     {
         if (m_completion_handle && m_completion_handle->data) {
             return; // danger!
@@ -129,7 +129,7 @@ public:
         m_completion_handle = add_callback(std::move(fn));
     }
 
-    bool set_timeout_callback(uint64_t timeout, std::function<void()> fn) override
+    bool set_timeout_callback(uint64_t timeout, util::UniqueFunction<void()> fn) override
     {
         if (!m_timer || !m_timer->data) {
             auto m_timer = new uv_timer_t;
@@ -150,7 +150,7 @@ public:
 
 private:
     struct Data {
-        std::function<void()> callback;
+        util::UniqueFunction<void()> callback;
         std::atomic<bool> close_requested;
     };
     uv_async_t* m_notification_handle = nullptr;

--- a/src/realm/sync/CMakeLists.txt
+++ b/src/realm/sync/CMakeLists.txt
@@ -49,6 +49,8 @@ set(SYNC_INSTALL_HEADERS
 )
 
 set(NOINST_HEADERS
+    ../util/http.hpp
+    ../util/websocket.hpp
     noinst/changeset_index.hpp
     noinst/client_history_impl.hpp
     noinst/client_impl_base.hpp

--- a/src/realm/sync/client.cpp
+++ b/src/realm/sync/client.cpp
@@ -176,9 +176,9 @@ public:
     bool has_flx_subscription_store() const;
     SubscriptionStore* get_flx_subscription_store();
 
-    void set_sync_transact_handler(std::function<SyncTransactCallback>);
-    void set_progress_handler(std::function<ProgressHandler>);
-    void set_connection_state_change_listener(std::function<ConnectionStateChangeListener>);
+    void set_sync_transact_handler(util::UniqueFunction<SyncTransactCallback>);
+    void set_progress_handler(util::UniqueFunction<ProgressHandler>);
+    void set_connection_state_change_listener(util::UniqueFunction<ConnectionStateChangeListener>);
 
     void initiate();
     void initiate(ProtocolEnvelope, std::string server_address, port_type server_port, std::string virt_path,
@@ -233,9 +233,9 @@ private:
 
     util::Optional<ProxyConfig> m_proxy_config;
 
-    std::function<SyncTransactCallback> m_sync_transact_handler;
-    std::function<ProgressHandler> m_progress_handler;
-    std::function<ConnectionStateChangeListener> m_connection_state_change_listener;
+    util::UniqueFunction<SyncTransactCallback> m_sync_transact_handler;
+    util::UniqueFunction<ProgressHandler> m_progress_handler;
+    util::UniqueFunction<ConnectionStateChangeListener> m_connection_state_change_listener;
 
     std::shared_ptr<SubscriptionStore> m_flx_subscription_store;
     int64_t m_flx_active_version = 0;
@@ -485,7 +485,7 @@ void ClientImpl::start_keep_running_timer()
         if (ec != util::error::operation_aborted)
             start_keep_running_timer();
     };
-    m_keep_running_timer.async_wait(std::chrono::hours(1000), handler); // Throws
+    m_keep_running_timer.async_wait(std::chrono::hours(1000), std::move(handler)); // Throws
 }
 
 
@@ -861,14 +861,14 @@ SubscriptionStore* SessionWrapper::get_flx_subscription_store()
 }
 
 
-inline void SessionWrapper::set_sync_transact_handler(std::function<SyncTransactCallback> handler)
+inline void SessionWrapper::set_sync_transact_handler(util::UniqueFunction<SyncTransactCallback> handler)
 {
     REALM_ASSERT(!m_initiated);
     m_sync_transact_handler = std::move(handler); // Throws
 }
 
 
-inline void SessionWrapper::set_progress_handler(std::function<ProgressHandler> handler)
+inline void SessionWrapper::set_progress_handler(util::UniqueFunction<ProgressHandler> handler)
 {
     REALM_ASSERT(!m_initiated);
     m_progress_handler = std::move(handler);
@@ -876,7 +876,7 @@ inline void SessionWrapper::set_progress_handler(std::function<ProgressHandler> 
 
 
 inline void
-SessionWrapper::set_connection_state_change_listener(std::function<ConnectionStateChangeListener> listener)
+SessionWrapper::set_connection_state_change_listener(util::UniqueFunction<ConnectionStateChangeListener> listener)
 {
     REALM_ASSERT(!m_initiated);
     m_connection_state_change_listener = std::move(listener);
@@ -947,7 +947,8 @@ void SessionWrapper::async_wait_for(bool upload_completion, bool download_comple
     REALM_ASSERT(m_initiated);
 
     util::bind_ptr<SessionWrapper> self{this};
-    auto handler_2 = [self = std::move(self), handler = std::move(handler), upload_completion, download_completion] {
+    auto handler_2 = [self = std::move(self), handler = std::move(handler), upload_completion,
+                      download_completion]() mutable {
         REALM_ASSERT(self->m_actualized);
         if (REALM_UNLIKELY(!self->m_sess)) {
             // Already finalized
@@ -1481,19 +1482,19 @@ Session::Session(Client& client, DBRef db, std::shared_ptr<SubscriptionStore> fl
 }
 
 
-void Session::set_sync_transact_callback(std::function<SyncTransactCallback> handler)
+void Session::set_sync_transact_callback(util::UniqueFunction<SyncTransactCallback> handler)
 {
     m_impl->set_sync_transact_handler(std::move(handler)); // Throws
 }
 
 
-void Session::set_progress_handler(std::function<ProgressHandler> handler)
+void Session::set_progress_handler(util::UniqueFunction<ProgressHandler> handler)
 {
     m_impl->set_progress_handler(std::move(handler)); // Throws
 }
 
 
-void Session::set_connection_state_change_listener(std::function<ConnectionStateChangeListener> listener)
+void Session::set_connection_state_change_listener(util::UniqueFunction<ConnectionStateChangeListener> listener)
 {
     m_impl->set_connection_state_change_listener(std::move(listener)); // Throws
 }

--- a/src/realm/sync/client.hpp
+++ b/src/realm/sync/client.hpp
@@ -168,7 +168,7 @@ public:
     using ProgressHandler = void(std::uint_fast64_t downloaded_bytes, std::uint_fast64_t downloadable_bytes,
                                  std::uint_fast64_t uploaded_bytes, std::uint_fast64_t uploadable_bytes,
                                  std::uint_fast64_t progress_version, std::uint_fast64_t snapshot_version);
-    using WaitOperCompletionHandler = std::function<void(std::error_code)>;
+    using WaitOperCompletionHandler = util::UniqueFunction<void(std::error_code)>;
     using SSLVerifyCallback = bool(const std::string& server_address, port_type server_port, const char* pem_data,
                                    size_t pem_size, int preverify_ok, int depth);
 
@@ -381,7 +381,7 @@ public:
     /// to bind() returns, and it may get called (or continue to execute) after
     /// the session object is destroyed. Please see "Callback semantics" section
     /// under Session for more on this.
-    void set_sync_transact_callback(std::function<SyncTransactCallback>);
+    void set_sync_transact_callback(util::UniqueFunction<SyncTransactCallback>);
 
     /// \brief Set a handler to monitor the state of download and upload
     /// progress.
@@ -456,7 +456,7 @@ public:
     /// to bind() returns, and it may get called (or continue to execute) after
     /// the session object is destroyed. Please see "Callback semantics" section
     /// under Session for more on this.
-    void set_progress_handler(std::function<ProgressHandler>);
+    void set_progress_handler(util::UniqueFunction<ProgressHandler>);
 
 
     using ConnectionStateChangeListener = void(ConnectionState, const SessionErrorInfo*);
@@ -494,12 +494,12 @@ public:
     /// to bind() returns, and it may get called (or continue to execute) after
     /// the session object is destroyed. Please see "Callback semantics" section
     /// under Session for more on this.
-    void set_connection_state_change_listener(std::function<ConnectionStateChangeListener>);
+    void set_connection_state_change_listener(util::UniqueFunction<ConnectionStateChangeListener>);
 
     //@{
     /// Deprecated! Use set_connection_state_change_listener() instead.
     using ErrorHandler = void(std::error_code, bool is_fatal, const std::string& detailed_message);
-    void set_error_handler(std::function<ErrorHandler>);
+    void set_error_handler(util::UniqueFunction<ErrorHandler>);
     //@}
 
     /// @{ \brief Bind this session to the specified server side Realm.
@@ -759,7 +759,7 @@ inline void Session::detach() noexcept
     m_impl = nullptr;
 }
 
-inline void Session::set_error_handler(std::function<ErrorHandler> handler)
+inline void Session::set_error_handler(util::UniqueFunction<ErrorHandler> handler)
 {
     auto handler_2 = [handler = std::move(handler)](ConnectionState state, const SessionErrorInfo* error_info) {
         if (state != ConnectionState::disconnected)

--- a/src/realm/sync/config.hpp
+++ b/src/realm/sync/config.hpp
@@ -160,7 +160,7 @@ struct SyncConfig {
     ClientResyncMode client_resync_mode = ClientResyncMode::Manual;
     std::function<void(std::shared_ptr<Realm> before_frozen)> notify_before_client_reset;
     std::function<void(std::shared_ptr<Realm> before_frozen, std::shared_ptr<Realm> after)> notify_after_client_reset;
-    std::function<void(const std::string&, std::function<void(DBRef, util::Optional<std::string>)>)>
+    std::function<void(const std::string&, util::UniqueFunction<void(DBRef, util::Optional<std::string>)>)>
         get_fresh_realm_for_path;
 
     explicit SyncConfig(std::shared_ptr<SyncUser> user, bson::Bson partition);

--- a/src/realm/sync/noinst/client_history_impl.cpp
+++ b/src/realm/sync/noinst/client_history_impl.cpp
@@ -69,7 +69,7 @@ void ClientHistory::set_client_reset_adjustments(version_type current_version, S
 }
 
 
-void ClientHistory::set_local_origin_timestamp_source(std::function<timestamp_type()> source_fn)
+void ClientHistory::set_local_origin_timestamp_source(util::UniqueFunction<timestamp_type()> source_fn)
 {
     m_local_origin_timestamp_source = std::move(source_fn);
 }

--- a/src/realm/sync/noinst/client_history_impl.hpp
+++ b/src/realm/sync/noinst/client_history_impl.hpp
@@ -241,7 +241,7 @@ public: // Stuff in this section is only used by CLI tools.
     /// set_local_origin_timestamp_override() allows you to override the origin timestamp of new changesets
     /// of local origin. This should only be used for testing and defaults to calling
     /// generate_changeset_timestamp().
-    void set_local_origin_timestamp_source(std::function<timestamp_type()> source_fn);
+    void set_local_origin_timestamp_source(util::UniqueFunction<timestamp_type()> source_fn);
 
 public: // Stuff in this section is only used by tests.
     // virtual void set_client_file_ident_in_wt() sets the client file ident.
@@ -365,7 +365,7 @@ private:
 
     version_type m_version_of_oldest_bound_snapshot = 0;
 
-    std::function<timestamp_type()> m_local_origin_timestamp_source = generate_changeset_timestamp;
+    util::UniqueFunction<timestamp_type()> m_local_origin_timestamp_source = generate_changeset_timestamp;
 
     void initialize(DB& db) noexcept
     {

--- a/src/realm/sync/noinst/server/server.cpp
+++ b/src/realm/sync/noinst/server/server.cpp
@@ -1,63 +1,62 @@
-#include <cstdint>
-#include <cmath>
-#include <cstring>
-#include <cstdio>
-#include <algorithm>
-#include <stdexcept>
-#include <locale>
-#include <vector>
-#include <queue>
-#include <map>
-#include <memory>
-#include <sstream>
-#include <chrono>
-#include <cctype>
-#include <condition_variable>
-#include <functional>
-#include <algorithm>
-#include <atomic>
-#include <thread>
+#include <realm/sync/noinst/server/server.hpp>
 
-#include <realm/sync/noinst/server/encrypt_fingerprint.hpp>
-#include <realm/util/value_reset_guard.hpp>
-#include <realm/util/scope_exit.hpp>
-#include <realm/util/safe_int_ops.hpp>
-#include <realm/util/memory_stream.hpp>
-#include <realm/util/random.hpp>
-#include <realm/util/bind_ptr.hpp>
-#include <realm/util/circular_buffer.hpp>
-#include <realm/util/optional.hpp>
-#include <realm/util/file.hpp>
-#include <realm/util/load_file.hpp>
-#include <realm/util/parent_dir.hpp>
-#include <realm/util/platform_info.hpp>
-#include <realm/util/scratch_allocator.hpp>
-#include <realm/util/base64.hpp>
-#include <realm/util/buffer_stream.hpp>
-#include <realm/util/json_parser.hpp>
-#include <realm/util/thread.hpp>
-#include <realm/util/thread_exec_guard.hpp>
-#include <realm/util/network_ssl.hpp>
-#include <realm/util/http.hpp>
-#include <realm/util/websocket.hpp>
-#include <realm/version.hpp>
-#include <realm/string_data.hpp>
 #include <realm/binary_data.hpp>
-#include <realm/sync/noinst/compression.hpp>
-#include <realm/sync/noinst/server/server_dir.hpp>
+#include <realm/impl/simulated_failure.hpp>
+#include <realm/string_data.hpp>
+#include <realm/sync/changeset.hpp>
+#include <realm/sync/impl/clamped_hex_dump.hpp>
+#include <realm/sync/impl/clock.hpp>
 #include <realm/sync/noinst/client_history_impl.hpp>
-#include <realm/sync/noinst/server/server_file_access_cache.hpp>
+#include <realm/sync/noinst/compression.hpp>
 #include <realm/sync/noinst/protocol_codec.hpp>
+#include <realm/sync/noinst/server/access_control.hpp>
+#include <realm/sync/noinst/server/encrypt_fingerprint.hpp>
+#include <realm/sync/noinst/server/server_dir.hpp>
+#include <realm/sync/noinst/server/server_file_access_cache.hpp>
 #include <realm/sync/noinst/server/server_impl_base.hpp>
 #include <realm/sync/noinst/server/vacuum.hpp>
-#include <realm/sync/impl/clock.hpp>
-#include <realm/sync/impl/clamped_hex_dump.hpp>
-#include <realm/impl/simulated_failure.hpp>
-#include <realm/version.hpp>
 #include <realm/sync/transform.hpp>
-#include <realm/sync/noinst/server/access_control.hpp>
-#include <realm/sync/noinst/server/server.hpp>
-#include <realm/sync/changeset.hpp>
+#include <realm/util/base64.hpp>
+#include <realm/util/bind_ptr.hpp>
+#include <realm/util/buffer_stream.hpp>
+#include <realm/util/circular_buffer.hpp>
+#include <realm/util/file.hpp>
+#include <realm/util/http.hpp>
+#include <realm/util/json_parser.hpp>
+#include <realm/util/load_file.hpp>
+#include <realm/util/memory_stream.hpp>
+#include <realm/util/network_ssl.hpp>
+#include <realm/util/optional.hpp>
+#include <realm/util/parent_dir.hpp>
+#include <realm/util/platform_info.hpp>
+#include <realm/util/random.hpp>
+#include <realm/util/safe_int_ops.hpp>
+#include <realm/util/scope_exit.hpp>
+#include <realm/util/scratch_allocator.hpp>
+#include <realm/util/thread.hpp>
+#include <realm/util/thread_exec_guard.hpp>
+#include <realm/util/value_reset_guard.hpp>
+#include <realm/util/websocket.hpp>
+#include <realm/version.hpp>
+
+#include <algorithm>
+#include <atomic>
+#include <cctype>
+#include <chrono>
+#include <cmath>
+#include <condition_variable>
+#include <cstdint>
+#include <cstdio>
+#include <cstring>
+#include <functional>
+#include <locale>
+#include <map>
+#include <memory>
+#include <queue>
+#include <sstream>
+#include <stdexcept>
+#include <thread>
+#include <vector>
 
 // NOTE: The protocol specification is in `/doc/protocol.md`
 
@@ -401,7 +400,7 @@ protected:
 
 class WorkerBox {
 public:
-    using JobType = std::function<void(WorkerState&)>;
+    using JobType = util::UniqueFunction<void(WorkerState&)>;
     void add_work(WorkerState& state, JobType job)
     {
         std::unique_lock<std::mutex> lock(m_mutex);
@@ -1052,7 +1051,7 @@ public:
     void run();
     void stop() noexcept;
 
-    void report_event_loop_metrics(std::function<EventLoopMetricsHandler>);
+    void report_event_loop_metrics(util::UniqueFunction<EventLoopMetricsHandler>);
 
     HTTPConnection* get_http_connection(std::int_fast64_t conn_id) noexcept;
 
@@ -1144,7 +1143,7 @@ public:
 
     void recognize_external_change(const std::string& virt_path);
 
-    void stop_sync_and_wait_for_backup_completion(std::function<void(bool did_backup)> completion_handler,
+    void stop_sync_and_wait_for_backup_completion(util::UniqueFunction<void(bool did_backup)> completion_handler,
                                                   milliseconds_type timeout);
 
     void initiate_compact_realm(std::int_fast64_t conn_id, StringData virt_path);
@@ -1291,7 +1290,7 @@ private:
     void initiate_allocation_metrics_wait();
     void handle_allocation_metrics_wait();
 
-    void do_stop_sync_and_wait_for_backup_completion(std::function<void(bool did_complete)> completion_handler,
+    void do_stop_sync_and_wait_for_backup_completion(util::UniqueFunction<void(bool did_complete)> completion_handler,
                                                      milliseconds_type timeout);
 };
 
@@ -1485,37 +1484,34 @@ public:
 
     void async_write(const char* data, size_t size, util::websocket::WriteCompletionHandler handler) final override
     {
-        // FIXME: Use std::move() on type-erased handlers, or avoid type erasure altogether
         if (m_ssl_stream) {
-            m_ssl_stream->async_write(data, size, handler); // Throws
+            m_ssl_stream->async_write(data, size, std::move(handler)); // Throws
         }
         else {
-            m_socket->async_write(data, size, handler); // Throws
+            m_socket->async_write(data, size, std::move(handler)); // Throws
         }
     }
 
     void async_read(char* buffer, size_t size, util::websocket::ReadCompletionHandler handler) final override
     {
-        // FIXME: Use std::move() on type-erased handlers, or avoid type erasure altogether
         if (m_ssl_stream) {
-            m_ssl_stream->async_read(buffer, size, *m_read_ahead_buffer, handler); // Throws
+            m_ssl_stream->async_read(buffer, size, *m_read_ahead_buffer, std::move(handler)); // Throws
         }
         else {
-            m_socket->async_read(buffer, size, *m_read_ahead_buffer, handler); // Throws
+            m_socket->async_read(buffer, size, *m_read_ahead_buffer, std::move(handler)); // Throws
         }
     }
 
     void async_read_until(char* buffer, size_t size, char delim,
                           util::websocket::ReadCompletionHandler handler) final override
     {
-        // FIXME: Use std::move() on type-erased handlers, or avoid type erasure altogether
         if (m_ssl_stream) {
             m_ssl_stream->async_read_until(buffer, size, delim, *m_read_ahead_buffer,
-                                           handler); // Throws
+                                           std::move(handler)); // Throws
         }
         else {
             m_socket->async_read_until(buffer, size, delim, *m_read_ahead_buffer,
-                                       handler); // Throws
+                                       std::move(handler)); // Throws
         }
     }
 
@@ -4955,7 +4951,7 @@ void ServerImpl::stop() noexcept
     m_service.stop();
 }
 
-void ServerImpl::report_event_loop_metrics(std::function<EventLoopMetricsHandler> handler)
+void ServerImpl::report_event_loop_metrics(util::UniqueFunction<EventLoopMetricsHandler> handler)
 {
     m_service.report_event_loop_metrics(std::move(handler)); // Throws
 }
@@ -5096,7 +5092,7 @@ void ServerImpl::initiate_accept()
     };
     bool is_ssl = bool(m_ssl_context);
     m_next_http_conn.reset(new HTTPConnection(*this, ++m_next_conn_id, is_ssl));                 // Throws
-    m_acceptor.async_accept(m_next_http_conn->get_socket(), m_next_http_conn_endpoint, handler); // Throws
+    m_acceptor.async_accept(m_next_http_conn->get_socket(), m_next_http_conn_endpoint, std::move(handler)); // Throws
 }
 
 
@@ -5210,14 +5206,14 @@ void ServerImpl::recognize_external_change(const std::string& virt_path)
 }
 
 
-void ServerImpl::stop_sync_and_wait_for_backup_completion(std::function<void(bool did_backup)> completion_handler,
-                                                          milliseconds_type timeout)
+void ServerImpl::stop_sync_and_wait_for_backup_completion(
+    util::UniqueFunction<void(bool did_backup)> completion_handler, milliseconds_type timeout)
 {
     logger.info("stop_sync_and_wait_for_backup_completion() called with "
                 "timeout = %1",
                 timeout); // Throws
 
-    auto handler = [this, completion_handler = std::move(completion_handler), timeout] {
+    auto handler = [this, completion_handler = std::move(completion_handler), timeout]() mutable {
         do_stop_sync_and_wait_for_backup_completion(std::move(completion_handler),
                                                     timeout); // Throws
     };
@@ -5326,7 +5322,7 @@ void ServerImpl::initiate_allocation_metrics_wait()
             handle_allocation_metrics_wait();
         }
     };
-    m_allocation_metrics_timer.async_wait(std::chrono::seconds(1), handler); // Throws
+    m_allocation_metrics_timer.async_wait(std::chrono::seconds(1), std::move(handler)); // Throws
 }
 
 
@@ -5349,7 +5345,7 @@ void ServerImpl::handle_allocation_metrics_wait()
 }
 
 void ServerImpl::do_stop_sync_and_wait_for_backup_completion(
-    std::function<void(bool did_complete)> completion_handler, milliseconds_type timeout)
+    util::UniqueFunction<void(bool did_complete)> completion_handler, milliseconds_type timeout)
 {
     static_cast<void>(timeout);
     if (m_sync_stopped)
@@ -5999,7 +5995,7 @@ uint_fast64_t Server::errors_seen() const noexcept
 }
 
 
-void Server::stop_sync_and_wait_for_backup_completion(std::function<void(bool did_backup)> completion_handler,
+void Server::stop_sync_and_wait_for_backup_completion(util::UniqueFunction<void(bool did_backup)> completion_handler,
                                                       milliseconds_type timeout)
 {
     m_impl->stop_sync_and_wait_for_backup_completion(std::move(completion_handler), timeout); // Throws

--- a/src/realm/sync/noinst/server/server.hpp
+++ b/src/realm/sync/noinst/server/server.hpp
@@ -376,7 +376,7 @@ public:
     ///
     /// CAUTION: The completion handler may be called before
     /// stop_sync_and_wait_for_backup_completion() returns.
-    void stop_sync_and_wait_for_backup_completion(std::function<void(bool did_complete)> completion_handler,
+    void stop_sync_and_wait_for_backup_completion(util::UniqueFunction<void(bool did_complete)> completion_handler,
                                                   milliseconds_type timeout);
 
     /// See Config::connection_reaper_timeout..

--- a/src/realm/sync/noinst/server/server_dir.hpp
+++ b/src/realm/sync/noinst/server/server_dir.hpp
@@ -6,9 +6,10 @@
 #include <random>
 #include <stdexcept>
 
-#include <realm/util/optional.hpp>
-#include <realm/util/file.hpp>
 #include <realm/util/backtrace.hpp>
+#include <realm/util/file.hpp>
+#include <realm/util/functional.hpp>
+#include <realm/util/optional.hpp>
 #include <realm/string_data.hpp>
 #include <realm/binary_data.hpp>
 
@@ -106,7 +107,7 @@ template <class H>
 void find_realm_files(const std::string& root_dir, H handler)
 {
     StringData realm_suffix = ".realm";
-    std::function<void(const std::string&, const std::string&)> scan_dir;
+    util::UniqueFunction<void(const std::string&, const std::string&)> scan_dir;
     scan_dir = [&](const std::string& real_path, const std::string& virt_path) {
         util::DirScanner ds{real_path}; // Throws
         std::string name;

--- a/src/realm/unicode.cpp
+++ b/src/realm/unicode.cpp
@@ -88,7 +88,7 @@ bool set_string_compare_method(string_compare_method_t method, StringCompareCall
 #endif
     }
     else if (method == STRING_COMPARE_CALLBACK) {
-        string_compare_callback = callback;
+        string_compare_callback = std::move(callback);
     }
 
     // other success actions

--- a/src/realm/util/ez_websocket.cpp
+++ b/src/realm/util/ez_websocket.cpp
@@ -18,7 +18,7 @@ public:
         initiate_resolve();
     }
 
-    void async_write_binary(const char* data, size_t size, std::function<void()>&& handler) override
+    void async_write_binary(const char* data, size_t size, util::UniqueFunction<void()>&& handler) override
     {
         m_websocket.async_write_binary(data, size, std::move(handler));
     }
@@ -115,10 +115,10 @@ void EZSocketImpl::async_read(char* buffer, std::size_t size, ReadCompletionHand
 {
     REALM_ASSERT(m_socket);
     if (m_ssl_stream) {
-        m_ssl_stream->async_read(buffer, size, m_read_ahead_buffer, handler); // Throws
+        m_ssl_stream->async_read(buffer, size, m_read_ahead_buffer, std::move(handler)); // Throws
     }
     else {
-        m_socket->async_read(buffer, size, m_read_ahead_buffer, handler); // Throws
+        m_socket->async_read(buffer, size, m_read_ahead_buffer, std::move(handler)); // Throws
     }
 }
 
@@ -127,10 +127,10 @@ void EZSocketImpl::async_read_until(char* buffer, std::size_t size, char delim, 
 {
     REALM_ASSERT(m_socket);
     if (m_ssl_stream) {
-        m_ssl_stream->async_read_until(buffer, size, delim, m_read_ahead_buffer, handler); // Throws
+        m_ssl_stream->async_read_until(buffer, size, delim, m_read_ahead_buffer, std::move(handler)); // Throws
     }
     else {
-        m_socket->async_read_until(buffer, size, delim, m_read_ahead_buffer, handler); // Throws
+        m_socket->async_read_until(buffer, size, delim, m_read_ahead_buffer, std::move(handler)); // Throws
     }
 }
 
@@ -139,10 +139,10 @@ void EZSocketImpl::async_write(const char* data, std::size_t size, WriteCompleti
 {
     REALM_ASSERT(m_socket);
     if (m_ssl_stream) {
-        m_ssl_stream->async_write(data, size, handler); // Throws
+        m_ssl_stream->async_write(data, size, std::move(handler)); // Throws
     }
     else {
-        m_socket->async_write(data, size, handler); // Throws
+        m_socket->async_write(data, size, std::move(handler)); // Throws
     }
 }
 

--- a/src/realm/util/ez_websocket.hpp
+++ b/src/realm/util/ez_websocket.hpp
@@ -87,7 +87,7 @@ class EZSocket {
 public:
     virtual ~EZSocket();
 
-    virtual void async_write_binary(const char* data, size_t size, std::function<void()>&& handler) = 0;
+    virtual void async_write_binary(const char* data, size_t size, util::UniqueFunction<void()>&& handler) = 0;
 };
 
 class EZSocketFactory {

--- a/src/realm/util/file_mapper.hpp
+++ b/src/realm/util/file_mapper.hpp
@@ -23,8 +23,7 @@
 #include <realm/utilities.hpp>
 #include <realm/util/thread.hpp>
 #include <realm/util/encrypted_file_mapping.hpp>
-
-#include <functional>
+#include <realm/util/functional.hpp>
 
 namespace realm {
 namespace util {
@@ -52,7 +51,7 @@ public:
     // must return the target load (also in bytes). Returns no_match if no
     // target can be set
     static constexpr int64_t no_match = -1;
-    virtual std::function<int64_t()> current_target_getter(size_t load) = 0;
+    virtual util::UniqueFunction<int64_t()> current_target_getter(size_t load) = 0;
     virtual void report_target_result(int64_t) = 0;
 };
 

--- a/src/realm/util/functional.hpp
+++ b/src/realm/util/functional.hpp
@@ -16,14 +16,15 @@
  *
  **************************************************************************/
 
-#pragma once
+#ifndef REALM_UTIL_FUNCTIONAL
+#define REALM_UTIL_FUNCTIONAL
+
+#include <realm/util/assert.hpp>
+#include <realm/util/type_traits.hpp>
 
 #include <functional>
 #include <memory>
 #include <type_traits>
-
-#include "realm/util/assert.hpp"
-#include "realm/util/type_traits.hpp"
 
 namespace realm::util {
 
@@ -40,18 +41,11 @@ class UniqueFunction;
 template <typename RetType, typename... Args>
 class UniqueFunction<RetType(Args...)> {
 private:
-    // `TagTypeBase` is used as a base for the `TagType` type, to prevent it from being an
-    // aggregate.
-    struct TagTypeBase {
-    protected:
-        TagTypeBase() = default;
-    };
-    // `TagType` is used as a placeholder type in parameter lists for `enable_if` clauses.  They
-    // have to be real parameters, not template parameters, due to MSVC limitations.
-    class TagType : TagTypeBase {
-        TagType() = default;
-        friend UniqueFunction;
-    };
+    template <typename Functor>
+    using EnableIfCallable =
+        std::enable_if_t<std::conjunction_v<std::is_invocable_r<RetType, Functor, Args...>,
+                                            std::negation<std::is_same<std::decay_t<Functor>, UniqueFunction>>>,
+                         int>;
 
 public:
     using result_type = RetType;
@@ -76,18 +70,14 @@ public:
         a.swap(b);
     }
 
-    template <typename Functor>
+    template <typename Functor, EnableIfCallable<Functor> = 0>
     /* implicit */
-    UniqueFunction(
-        Functor&& functor,
-        // The remaining arguments here are only for SFINAE purposes to enable this ctor when our
-        // requirements are met.  They must be concrete parameters not template parameters to work
-        // around bugs in some compilers that we presently use.  We may be able to revisit this
-        // design after toolchain upgrades for C++17.
-        std::enable_if_t<std::is_invocable_r<RetType, Functor, Args...>::value, TagType> = make_tag(),
-        std::enable_if_t<std::is_move_constructible<Functor>::value, TagType> = make_tag(),
-        std::enable_if_t<!std::is_same<std::decay_t<Functor>, UniqueFunction>::value, TagType> = make_tag())
-        : impl(make_impl(std::forward<Functor>(functor)))
+    UniqueFunction(Functor&& functor)
+        // This does not use make_unique() because
+        // std::unique_ptr<Base>(std::make_unique<Derived>()) results in
+        // std::unique_ptr<Derived> being instantiated, which can have
+        // surprisingly negative effects on debug build performance.
+        : impl(new SpecificImpl<Functor>(std::forward<Functor>(functor)))
     {
     }
 
@@ -104,26 +94,18 @@ public:
         return static_cast<bool>(this->impl);
     }
 
-    // Needed to make `std::is_convertible<mongo::UniqueFunction<...>, std::function<...>>` be
-    // `std::false_type`.  `mongo::UniqueFunction` objects are not convertible to any kind of
+    // Needed to make `std::is_convertible<util::UniqueFunction<...>, std::function<...>>` be
+    // `std::false_type`.  `UniqueFunction` objects are not convertible to any kind of
     // `std::function` object, since the latter requires a copy constructor, which the former does
     // not provide.  If you see a compiler error which references this line, you have tried to
     // assign a `UniqueFunction` object to a `std::function` object which is impossible -- please
     // check your variables and function signatures.
-    //
-    // NOTE: This is not quite able to disable all `std::function` conversions on MSVC, at this
-    // time.
+    template <typename Signature>
+    operator std::function<Signature>() = delete;
     template <typename Signature>
     operator std::function<Signature>() const = delete;
 
 private:
-    // The `TagType` type cannot be constructed as a default function-parameter in Clang.  So we use
-    // a static member function that initializes that default parameter.
-    static TagType make_tag()
-    {
-        return {};
-    }
-
     struct Impl {
         virtual ~Impl() noexcept = default;
         virtual RetType call(Args&&... args) = 0;
@@ -147,24 +129,19 @@ private:
     }
 
     template <typename Functor>
-    static auto make_impl(Functor&& functor)
-    {
-        struct SpecificImpl : Impl {
-            explicit SpecificImpl(Functor&& func)
-                : f(std::forward<Functor>(func))
-            {
-            }
+    struct SpecificImpl : Impl {
+        explicit SpecificImpl(Functor&& func)
+            : f(std::forward<Functor>(func))
+        {
+        }
 
-            RetType call(Args&&... args) override
-            {
-                return call_regular_void(std::is_void<RetType>(), f, std::forward<Args>(args)...);
-            }
+        RetType call(Args&&... args) override
+        {
+            return call_regular_void(std::is_void<RetType>(), f, std::forward<Args>(args)...);
+        }
 
-            std::decay_t<Functor> f;
-        };
-
-        return std::make_unique<SpecificImpl>(std::forward<Functor>(functor));
-    }
+        std::decay_t<Functor> f;
+    };
 
     std::unique_ptr<Impl> impl;
 };
@@ -223,3 +200,5 @@ bool operator!=(std::nullptr_t, const UniqueFunction<Signature>& rhs) noexcept
 }
 
 } // namespace realm::util
+
+#endif // REALM_UTIL_FUNCTIONAL

--- a/src/realm/util/http.hpp
+++ b/src/realm/util/http.hpp
@@ -318,7 +318,7 @@ struct HTTPParser : protected HTTPParserBase {
         }
     }
 
-    void write_buffer(std::function<void(std::error_code, size_t)> handler)
+    void write_buffer(util::UniqueFunction<void(std::error_code, size_t)> handler)
     {
         m_socket.async_write(m_write_buffer.data(), m_write_buffer.size(), std::move(handler));
     }
@@ -352,7 +352,7 @@ struct HTTPClient : protected HTTPParser<Socket> {
     /// If a request is already in progress, an exception will be thrown.
     ///
     /// This method is *NOT* thread-safe.
-    void async_request(const HTTPRequest& request, std::function<Handler> handler)
+    void async_request(const HTTPRequest& request, util::UniqueFunction<Handler> handler)
     {
         if (REALM_UNLIKELY(m_handler)) {
             throw util::runtime_error("Request already in progress.");
@@ -373,7 +373,7 @@ struct HTTPClient : protected HTTPParser<Socket> {
     }
 
 private:
-    std::function<Handler> m_handler;
+    util::UniqueFunction<Handler> m_handler;
     HTTPResponse m_response;
 
     std::error_code on_first_line(StringData line) override final
@@ -436,7 +436,7 @@ struct HTTPServer : protected HTTPParser<Socket> {
     /// receive the next request.
     ///
     /// This function is *NOT* thread-safe.
-    void async_receive_request(std::function<RequestHandler> handler)
+    void async_receive_request(util::UniqueFunction<RequestHandler> handler)
     {
         if (REALM_UNLIKELY(m_request_handler)) {
             throw util::runtime_error("Response already in progress.");
@@ -456,7 +456,7 @@ struct HTTPServer : protected HTTPParser<Socket> {
     /// before the \a handler of a previous invocation has been invoked.
     ///
     /// This function is *NOT* thread-safe.
-    void async_send_response(const HTTPResponse& response, std::function<RespondHandler> handler)
+    void async_send_response(const HTTPResponse& response, util::UniqueFunction<RespondHandler> handler)
     {
         if (REALM_UNLIKELY(!m_request_handler)) {
             throw util::runtime_error("No request in progress.");
@@ -479,8 +479,8 @@ struct HTTPServer : protected HTTPParser<Socket> {
     }
 
 private:
-    std::function<RequestHandler> m_request_handler;
-    std::function<RespondHandler> m_respond_handler;
+    util::UniqueFunction<RequestHandler> m_request_handler;
+    util::UniqueFunction<RespondHandler> m_respond_handler;
     HTTPRequest m_request;
 
     std::error_code on_first_line(StringData line) override final

--- a/src/realm/util/network.cpp
+++ b/src/realm/util/network.cpp
@@ -1341,7 +1341,7 @@ public:
         m_completed_operations.clear();
     }
 
-    void report_event_loop_metrics(std::function<EventLoopMetricsHandler> handler)
+    void report_event_loop_metrics(util::UniqueFunction<EventLoopMetricsHandler> handler)
     {
 #ifdef REALM_UTIL_NETWORK_EVENT_LOOP_METRICS
         m_event_loop_metrics_timer.emplace(service);
@@ -1768,7 +1768,7 @@ void Service::reset() noexcept
 }
 
 
-void Service::report_event_loop_metrics(std::function<EventLoopMetricsHandler> handler)
+void Service::report_event_loop_metrics(util::UniqueFunction<EventLoopMetricsHandler> handler)
 {
     m_impl->report_event_loop_metrics(std::move(handler)); // Throws
 }

--- a/src/realm/util/websocket.cpp
+++ b/src/realm/util/websocket.cpp
@@ -660,7 +660,7 @@ public:
     }
 
     void async_write_frame(bool fin, int opcode, const char* data, size_t size,
-                           std::function<void()> write_completion_handler)
+                           util::UniqueFunction<void()> write_completion_handler)
     {
         REALM_ASSERT(!m_stopped);
 
@@ -710,8 +710,8 @@ public:
             m_write_buffer.shrink_to_fit();
         }
 
-        auto handler = m_write_completion_handler;
-        m_write_completion_handler = std::function<void()>{};
+        auto handler = std::move(m_write_completion_handler);
+        m_write_completion_handler = nullptr;
         handler();
     }
 
@@ -739,7 +739,7 @@ private:
     std::vector<char> m_write_buffer;
     static const size_t s_write_buffer_stable_size = 2048;
 
-    std::function<void()> m_write_completion_handler;
+    util::UniqueFunction<void()> m_write_completion_handler;
 
     void error_client_malformed_response()
     {
@@ -1200,34 +1200,34 @@ void websocket::Socket::initiate_server_websocket_after_handshake()
 }
 
 void websocket::Socket::async_write_frame(bool fin, Opcode opcode, const char* data, size_t size,
-                                          std::function<void()> handler)
+                                          util::UniqueFunction<void()> handler)
 {
-    m_impl->async_write_frame(fin, int(opcode), data, size, handler);
+    m_impl->async_write_frame(fin, int(opcode), data, size, std::move(handler));
 }
 
-void websocket::Socket::async_write_text(const char* data, size_t size, std::function<void()> handler)
+void websocket::Socket::async_write_text(const char* data, size_t size, util::UniqueFunction<void()> handler)
 {
-    async_write_frame(true, Opcode::text, data, size, handler);
+    async_write_frame(true, Opcode::text, data, size, std::move(handler));
 }
 
-void websocket::Socket::async_write_binary(const char* data, size_t size, std::function<void()> handler)
+void websocket::Socket::async_write_binary(const char* data, size_t size, util::UniqueFunction<void()> handler)
 {
-    async_write_frame(true, Opcode::binary, data, size, handler);
+    async_write_frame(true, Opcode::binary, data, size, std::move(handler));
 }
 
-void websocket::Socket::async_write_close(const char* data, size_t size, std::function<void()> handler)
+void websocket::Socket::async_write_close(const char* data, size_t size, util::UniqueFunction<void()> handler)
 {
-    async_write_frame(true, Opcode::close, data, size, handler);
+    async_write_frame(true, Opcode::close, data, size, std::move(handler));
 }
 
-void websocket::Socket::async_write_ping(const char* data, size_t size, std::function<void()> handler)
+void websocket::Socket::async_write_ping(const char* data, size_t size, util::UniqueFunction<void()> handler)
 {
-    async_write_frame(true, Opcode::ping, data, size, handler);
+    async_write_frame(true, Opcode::ping, data, size, std::move(handler));
 }
 
-void websocket::Socket::async_write_pong(const char* data, size_t size, std::function<void()> handler)
+void websocket::Socket::async_write_pong(const char* data, size_t size, util::UniqueFunction<void()> handler)
 {
-    async_write_frame(true, Opcode::pong, data, size, handler);
+    async_write_frame(true, Opcode::pong, data, size, std::move(handler));
 }
 
 void websocket::Socket::stop() noexcept

--- a/src/realm/utilities.hpp
+++ b/src/realm/utilities.hpp
@@ -43,6 +43,7 @@ typedef SSIZE_T ssize_t;
 
 #include <realm/util/features.h>
 #include <realm/util/assert.hpp>
+#include <realm/util/functional.hpp>
 #include <realm/util/safe_int_ops.hpp>
 
 // GCC defines __i386__ and __x86_64__
@@ -74,7 +75,7 @@ typedef SSIZE_T ssize_t;
 
 namespace realm {
 
-using StringCompareCallback = std::function<bool(const char* string1, const char* string2)>;
+using StringCompareCallback = util::UniqueFunction<bool(const char* string1, const char* string2)>;
 
 extern signed char sse_support;
 extern signed char avx_support;

--- a/test/object-store/benchmarks/object.cpp
+++ b/test/object-store/benchmarks/object.cpp
@@ -85,8 +85,8 @@ TEST_CASE("Benchmark index change calculations", "[benchmark]") {
 
     SECTION("reports inserts/deletes for simple reorderings") {
         auto calc = [&](std::vector<int64_t> old_rows, std::vector<int64_t> new_rows,
-                        std::function<bool(size_t)> modifications) {
-            return _impl::CollectionChangeBuilder::calculate(old_rows, new_rows, modifications, false);
+                        util::UniqueFunction<bool(size_t)> modifications) {
+            return _impl::CollectionChangeBuilder::calculate(old_rows, new_rows, std::move(modifications), false);
         };
         std::vector<int64_t> indices = {};
         constexpr size_t indices_size = 10000;

--- a/test/object-store/collection_fixtures.hpp
+++ b/test/object-store/collection_fixtures.hpp
@@ -472,7 +472,7 @@ struct LinkedCollectionBase {
     {
     }
 
-    void set_relation_updater(std::function<void()> updater)
+    void set_relation_updater(util::UniqueFunction<void()> updater)
     {
         m_relation_updater = std::move(updater);
     }

--- a/test/object-store/results.cpp
+++ b/test/object-store/results.cpp
@@ -1927,8 +1927,8 @@ TEST_CASE("notifications: results") {
             size_t after_calls = 0;
             CollectionChangeSet before_change;
             CollectionChangeSet after_change;
-            std::function<void(void)> on_before = [] {};
-            std::function<void(void)> on_after = [] {};
+            util::UniqueFunction<void(void)> on_before = [] {};
+            util::UniqueFunction<void(void)> on_after = [] {};
 
             void before(CollectionChangeSet c)
             {

--- a/test/object-store/sync/app.cpp
+++ b/test/object-store/sync/app.cpp
@@ -69,30 +69,26 @@ using util::Optional;
 using namespace std::string_view_literals;
 
 namespace {
-std::shared_ptr<SyncUser> log_in(std::shared_ptr<App> app,
-                                 app::AppCredentials credentials = app::AppCredentials::anonymous())
+std::shared_ptr<SyncUser> log_in(std::shared_ptr<App> app, AppCredentials credentials = AppCredentials::anonymous())
 {
     std::shared_ptr<SyncUser> user;
-    app->log_in_with_credentials(credentials,
-                                 [&](std::shared_ptr<SyncUser> user_arg, util::Optional<app::AppError> error) {
-                                     REQUIRE_FALSE(error);
-                                     REQUIRE(user_arg);
-                                     user = std::move(user_arg);
-                                 });
+    app->log_in_with_credentials(credentials, [&](std::shared_ptr<SyncUser> user_arg, Optional<AppError> error) {
+        REQUIRE_FALSE(error);
+        REQUIRE(user_arg);
+        user = std::move(user_arg);
+    });
     REQUIRE(user);
     return user;
 }
 
-app::AppError failed_log_in(std::shared_ptr<App> app,
-                            app::AppCredentials credentials = app::AppCredentials::anonymous())
+AppError failed_log_in(std::shared_ptr<App> app, AppCredentials credentials = AppCredentials::anonymous())
 {
-    util::Optional<app::AppError> err;
-    app->log_in_with_credentials(credentials,
-                                 [&](std::shared_ptr<SyncUser> user, util::Optional<app::AppError> error) {
-                                     REQUIRE(error);
-                                     REQUIRE_FALSE(user);
-                                     err = error;
-                                 });
+    Optional<AppError> err;
+    app->log_in_with_credentials(credentials, [&](std::shared_ptr<SyncUser> user, Optional<AppError> error) {
+        REQUIRE(error);
+        REQUIRE_FALSE(user);
+        err = error;
+    });
     REQUIRE(err);
     return *err;
 }
@@ -218,18 +214,18 @@ TEST_CASE("app: UsernamePasswordProviderClient integration", "[sync][app]") {
 
     bool processed = false;
 
-    client.register_email(email, password, [&](Optional<app::AppError> error) {
+    client.register_email(email, password, [&](Optional<AppError> error) {
         CAPTURE(email);
         CAPTURE(password);
         REQUIRE_FALSE(error); // first registration success
     });
 
     SECTION("double registration should fail") {
-        client.register_email(email, password, [&](Optional<app::AppError> error) {
+        client.register_email(email, password, [&](Optional<AppError> error) {
             // Error returned states the account has already been created
             REQUIRE(error);
             CHECK(error->message == "name already in use");
-            CHECK(app::ServiceErrorCode(error->error_code.value()) == app::ServiceErrorCode::account_name_in_use);
+            CHECK(ServiceErrorCode(error->error_code.value()) == ServiceErrorCode::account_name_in_use);
             CHECK(!error->link_to_server_logs.empty());
             CHECK(error->link_to_server_logs.find(base_url) != std::string::npos);
             processed = true;
@@ -240,10 +236,10 @@ TEST_CASE("app: UsernamePasswordProviderClient integration", "[sync][app]") {
     SECTION("double registration should fail") {
         // the server registration function will reject emails that do not contain "realm_tests_do_autoverify"
         std::string email_to_reject = util::format("%1@%2.com", random_string(10), random_string(10));
-        client.register_email(email_to_reject, password, [&](Optional<app::AppError> error) {
+        client.register_email(email_to_reject, password, [&](Optional<AppError> error) {
             REQUIRE(error);
             CHECK(error->message == util::format("failed to confirm user %1", email_to_reject));
-            CHECK(app::ServiceErrorCode(error->error_code.value()) == app::ServiceErrorCode::bad_request);
+            CHECK(ServiceErrorCode(error->error_code.value()) == ServiceErrorCode::bad_request);
             processed = true;
         });
         CHECK(processed);
@@ -255,8 +251,8 @@ TEST_CASE("app: UsernamePasswordProviderClient integration", "[sync][app]") {
     }
 
     SECTION("cannot login with wrong password") {
-        app->log_in_with_credentials(realm::app::AppCredentials::username_password(email, "boogeyman"),
-                                     [&](std::shared_ptr<realm::SyncUser> user, Optional<app::AppError> error) {
+        app->log_in_with_credentials(AppCredentials::username_password(email, "boogeyman"),
+                                     [&](std::shared_ptr<realm::SyncUser> user, Optional<AppError> error) {
                                          CHECK(!user);
                                          REQUIRE(error);
                                          REQUIRE(error->error_code.value() ==
@@ -267,7 +263,7 @@ TEST_CASE("app: UsernamePasswordProviderClient integration", "[sync][app]") {
     }
 
     SECTION("confirm user") {
-        client.confirm_user("a_token", "a_token_id", [&](Optional<app::AppError> error) {
+        client.confirm_user("a_token", "a_token_id", [&](Optional<AppError> error) {
             REQUIRE(error);
             CHECK(error->message == "invalid token data");
             processed = true;
@@ -276,7 +272,7 @@ TEST_CASE("app: UsernamePasswordProviderClient integration", "[sync][app]") {
     }
 
     SECTION("resend confirmation email") {
-        client.resend_confirmation_email(email, [&](Optional<app::AppError> error) {
+        client.resend_confirmation_email(email, [&](Optional<AppError> error) {
             REQUIRE(error);
             CHECK(error->message == "already confirmed");
             processed = true;
@@ -285,7 +281,7 @@ TEST_CASE("app: UsernamePasswordProviderClient integration", "[sync][app]") {
     }
 
     SECTION("reset password invalid tokens") {
-        client.reset_password(password, "token_sample", "token_id_sample", [&](Optional<app::AppError> error) {
+        client.reset_password(password, "token_sample", "token_id_sample", [&](Optional<AppError> error) {
             REQUIRE(error);
             CHECK(error->message == "invalid token data");
             CHECK(!error->link_to_server_logs.empty());
@@ -299,7 +295,7 @@ TEST_CASE("app: UsernamePasswordProviderClient integration", "[sync][app]") {
         // the imported test app will accept password reset if the password contains "realm_tests_do_reset" via a
         // function
         std::string accepted_new_password = util::format("realm_tests_do_reset%1", random_string(10));
-        client.call_reset_password_function(email, accepted_new_password, {}, [&](Optional<app::AppError> error) {
+        client.call_reset_password_function(email, accepted_new_password, {}, [&](Optional<AppError> error) {
             REQUIRE_FALSE(error);
             processed = true;
         });
@@ -308,31 +304,30 @@ TEST_CASE("app: UsernamePasswordProviderClient integration", "[sync][app]") {
 
     SECTION("reset password function failure") {
         std::string rejected_password = util::format("%1", random_string(10));
-        client.call_reset_password_function(
-            email, rejected_password, {"foo", "bar"}, [&](Optional<app::AppError> error) {
-                REQUIRE(error);
-                CHECK(error->message == util::format("failed to reset password for user %1", email));
-                CHECK(error->is_service_error());
-                processed = true;
-            });
+        client.call_reset_password_function(email, rejected_password, {"foo", "bar"}, [&](Optional<AppError> error) {
+            REQUIRE(error);
+            CHECK(error->message == util::format("failed to reset password for user %1", email));
+            CHECK(error->is_service_error());
+            processed = true;
+        });
         CHECK(processed);
     }
 
     SECTION("reset password function for invalid user fails") {
         client.call_reset_password_function(util::format("%1@%2.com", random_string(5), random_string(5)), password,
-                                            {"foo", "bar"}, [&](Optional<app::AppError> error) {
+                                            {"foo", "bar"}, [&](Optional<AppError> error) {
                                                 REQUIRE(error);
                                                 CHECK(error->message == "user not found");
                                                 CHECK(error->is_service_error());
-                                                CHECK(app::ServiceErrorCode(error->error_code.value()) ==
-                                                      app::ServiceErrorCode::user_not_found);
+                                                CHECK(ServiceErrorCode(error->error_code.value()) ==
+                                                      ServiceErrorCode::user_not_found);
                                                 processed = true;
                                             });
         CHECK(processed);
     }
 
     SECTION("retry custom confirmation") {
-        client.retry_custom_confirmation(email, [&](Optional<app::AppError> error) {
+        client.retry_custom_confirmation(email, [&](Optional<AppError> error) {
             REQUIRE(error);
             CHECK(error->message == "already confirmed");
             processed = true;
@@ -342,11 +337,11 @@ TEST_CASE("app: UsernamePasswordProviderClient integration", "[sync][app]") {
 
     SECTION("retry custom confirmation for invalid user fails") {
         client.retry_custom_confirmation(
-            util::format("%1@%2.com", random_string(5), random_string(5)), [&](Optional<app::AppError> error) {
+            util::format("%1@%2.com", random_string(5), random_string(5)), [&](Optional<AppError> error) {
                 REQUIRE(error);
                 CHECK(error->message == "user not found");
                 CHECK(error->is_service_error());
-                CHECK(app::ServiceErrorCode(error->error_code.value()) == app::ServiceErrorCode::user_not_found);
+                CHECK(ServiceErrorCode(error->error_code.value()) == ServiceErrorCode::user_not_found);
                 processed = true;
             });
         CHECK(processed);
@@ -356,23 +351,23 @@ TEST_CASE("app: UsernamePasswordProviderClient integration", "[sync][app]") {
         CHECK(app->sync_manager()->all_users().size() == 0);
         CHECK(app->sync_manager()->get_current_user() == nullptr);
 
-        auto user = log_in(app, app::AppCredentials::username_password(email, password));
+        auto user = log_in(app, AppCredentials::username_password(email, password));
         CHECK(user->user_profile().email() == email);
         CHECK(user->state() == SyncUser::State::LoggedIn);
 
-        app->remove_user(user, [&](Optional<app::AppError> error) {
+        app->remove_user(user, [&](Optional<AppError> error) {
             REQUIRE_FALSE(error);
         });
         CHECK(user->state() == SyncUser::State::Removed);
 
-        log_in(app, app::AppCredentials::username_password(email, password));
+        log_in(app, AppCredentials::username_password(email, password));
         CHECK(user->state() == SyncUser::State::Removed);
         CHECK(app->current_user() != user);
         user = app->current_user();
         CHECK(user->user_profile().email() == email);
         CHECK(user->state() == SyncUser::State::LoggedIn);
 
-        app->remove_user(user, [&](Optional<app::AppError> error) {
+        app->remove_user(user, [&](Optional<AppError> error) {
             REQUIRE(!error);
             CHECK(app->sync_manager()->all_users().size() == 0);
             processed = true;
@@ -399,18 +394,17 @@ TEST_CASE("app: UserAPIKeyProviderClient integration", "[sync][app]") {
         std::shared_ptr<SyncUser> logged_in_user = app->current_user();
         auto api_key_name = util::format("%1", random_string(15));
         client.create_api_key(api_key_name, logged_in_user,
-                              [&](App::UserAPIKey user_api_key, Optional<app::AppError> error) {
+                              [&](App::UserAPIKey user_api_key, Optional<AppError> error) {
                                   REQUIRE_FALSE(error);
                                   CHECK(user_api_key.name == api_key_name);
                                   api_key = user_api_key;
                               });
 
-        client.fetch_api_key(api_key.id, logged_in_user,
-                             [&](App::UserAPIKey user_api_key, Optional<app::AppError> error) {
-                                 REQUIRE_FALSE(error);
-                                 CHECK(user_api_key.name == api_key_name);
-                                 CHECK(user_api_key.id == api_key.id);
-                             });
+        client.fetch_api_key(api_key.id, logged_in_user, [&](App::UserAPIKey user_api_key, Optional<AppError> error) {
+            REQUIRE_FALSE(error);
+            CHECK(user_api_key.name == api_key_name);
+            CHECK(user_api_key.id == api_key.id);
+        });
 
         client.fetch_api_keys(logged_in_user, [&](std::vector<App::UserAPIKey> api_keys, Optional<AppError> error) {
             CHECK(api_keys.size() == 1);
@@ -426,35 +420,32 @@ TEST_CASE("app: UserAPIKeyProviderClient integration", "[sync][app]") {
             REQUIRE_FALSE(error);
         });
 
-        client.fetch_api_key(api_key.id, logged_in_user,
-                             [&](App::UserAPIKey user_api_key, Optional<app::AppError> error) {
-                                 REQUIRE_FALSE(error);
-                                 CHECK(user_api_key.disabled == false);
-                                 CHECK(user_api_key.name == api_key_name);
-                                 CHECK(user_api_key.id == api_key.id);
-                             });
+        client.fetch_api_key(api_key.id, logged_in_user, [&](App::UserAPIKey user_api_key, Optional<AppError> error) {
+            REQUIRE_FALSE(error);
+            CHECK(user_api_key.disabled == false);
+            CHECK(user_api_key.name == api_key_name);
+            CHECK(user_api_key.id == api_key.id);
+        });
 
         client.disable_api_key(api_key.id, logged_in_user, [&](Optional<AppError> error) {
             REQUIRE_FALSE(error);
         });
 
-        client.fetch_api_key(api_key.id, logged_in_user,
-                             [&](App::UserAPIKey user_api_key, Optional<app::AppError> error) {
-                                 REQUIRE_FALSE(error);
-                                 CHECK(user_api_key.disabled == true);
-                                 CHECK(user_api_key.name == api_key_name);
-                             });
+        client.fetch_api_key(api_key.id, logged_in_user, [&](App::UserAPIKey user_api_key, Optional<AppError> error) {
+            REQUIRE_FALSE(error);
+            CHECK(user_api_key.disabled == true);
+            CHECK(user_api_key.name == api_key_name);
+        });
 
         client.delete_api_key(api_key.id, logged_in_user, [&](Optional<AppError> error) {
             REQUIRE_FALSE(error);
         });
 
-        client.fetch_api_key(api_key.id, logged_in_user,
-                             [&](App::UserAPIKey user_api_key, Optional<app::AppError> error) {
-                                 CHECK(user_api_key.name == "");
-                                 CHECK(error);
-                                 processed = true;
-                             });
+        client.fetch_api_key(api_key.id, logged_in_user, [&](App::UserAPIKey user_api_key, Optional<AppError> error) {
+            CHECK(user_api_key.name == "");
+            CHECK(error);
+            processed = true;
+        });
 
         CHECK(processed);
     }
@@ -462,15 +453,14 @@ TEST_CASE("app: UserAPIKeyProviderClient integration", "[sync][app]") {
     SECTION("api-key without a user") {
         std::shared_ptr<SyncUser> no_user = nullptr;
         auto api_key_name = util::format("%1", random_string(15));
-        client.create_api_key(api_key_name, no_user,
-                              [&](App::UserAPIKey user_api_key, Optional<app::AppError> error) {
-                                  REQUIRE(error);
-                                  CHECK(error->is_service_error());
-                                  CHECK(error->message == "must authenticate first");
-                                  CHECK(user_api_key.name == "");
-                              });
+        client.create_api_key(api_key_name, no_user, [&](App::UserAPIKey user_api_key, Optional<AppError> error) {
+            REQUIRE(error);
+            CHECK(error->is_service_error());
+            CHECK(error->message == "must authenticate first");
+            CHECK(user_api_key.name == "");
+        });
 
-        client.fetch_api_key(api_key.id, no_user, [&](App::UserAPIKey user_api_key, Optional<app::AppError> error) {
+        client.fetch_api_key(api_key.id, no_user, [&](App::UserAPIKey user_api_key, Optional<AppError> error) {
             REQUIRE(error);
             CHECK(error->is_service_error());
             CHECK(error->message == "must authenticate first");
@@ -490,7 +480,7 @@ TEST_CASE("app: UserAPIKeyProviderClient integration", "[sync][app]") {
             CHECK(error->message == "must authenticate first");
         });
 
-        client.fetch_api_key(api_key.id, no_user, [&](App::UserAPIKey user_api_key, Optional<app::AppError> error) {
+        client.fetch_api_key(api_key.id, no_user, [&](App::UserAPIKey user_api_key, Optional<AppError> error) {
             REQUIRE(error);
             CHECK(error->is_service_error());
             CHECK(error->message == "must authenticate first");
@@ -503,7 +493,7 @@ TEST_CASE("app: UserAPIKeyProviderClient integration", "[sync][app]") {
             CHECK(error->message == "must authenticate first");
         });
 
-        client.fetch_api_key(api_key.id, no_user, [&](App::UserAPIKey user_api_key, Optional<app::AppError> error) {
+        client.fetch_api_key(api_key.id, no_user, [&](App::UserAPIKey user_api_key, Optional<AppError> error) {
             REQUIRE(error);
             CHECK(error->is_service_error());
             CHECK(error->message == "must authenticate first");
@@ -516,7 +506,7 @@ TEST_CASE("app: UserAPIKeyProviderClient integration", "[sync][app]") {
             CHECK(error->message == "must authenticate first");
         });
 
-        client.fetch_api_key(api_key.id, no_user, [&](App::UserAPIKey user_api_key, Optional<app::AppError> error) {
+        client.fetch_api_key(api_key.id, no_user, [&](App::UserAPIKey user_api_key, Optional<AppError> error) {
             CHECK(user_api_key.name == "");
             REQUIRE(error);
             CHECK(error->is_service_error());
@@ -537,27 +527,25 @@ TEST_CASE("app: UserAPIKeyProviderClient integration", "[sync][app]") {
         App::UserAPIKeyProviderClient provider = app->provider_client<App::UserAPIKeyProviderClient>();
 
         provider.create_api_key(api_key_name, first_user,
-                                [&](App::UserAPIKey user_api_key, Optional<app::AppError> error) {
+                                [&](App::UserAPIKey user_api_key, Optional<AppError> error) {
                                     REQUIRE_FALSE(error);
                                     CHECK(user_api_key.name == api_key_name);
                                     api_key = user_api_key;
                                 });
 
-        provider.fetch_api_key(api_key.id, first_user,
-                               [&](App::UserAPIKey user_api_key, Optional<app::AppError> error) {
-                                   REQUIRE_FALSE(error);
-                                   CHECK(user_api_key.name == api_key_name);
-                                   CHECK(user_api_key.id.to_string() == user_api_key.id.to_string());
-                               });
+        provider.fetch_api_key(api_key.id, first_user, [&](App::UserAPIKey user_api_key, Optional<AppError> error) {
+            REQUIRE_FALSE(error);
+            CHECK(user_api_key.name == api_key_name);
+            CHECK(user_api_key.id.to_string() == user_api_key.id.to_string());
+        });
 
-        provider.fetch_api_key(
-            api_key.id, second_user, [&](App::UserAPIKey user_api_key, Optional<app::AppError> error) {
-                REQUIRE(error);
-                CHECK(error->message == "API key not found");
-                CHECK(error->is_service_error());
-                CHECK(app::ServiceErrorCode(error->error_code.value()) == app::ServiceErrorCode::api_key_not_found);
-                CHECK(user_api_key.name == "");
-            });
+        provider.fetch_api_key(api_key.id, second_user, [&](App::UserAPIKey user_api_key, Optional<AppError> error) {
+            REQUIRE(error);
+            CHECK(error->message == "API key not found");
+            CHECK(error->is_service_error());
+            CHECK(ServiceErrorCode(error->error_code.value()) == ServiceErrorCode::api_key_not_found);
+            CHECK(user_api_key.name == "");
+        });
 
         provider.fetch_api_keys(first_user, [&](std::vector<App::UserAPIKey> api_keys, Optional<AppError> error) {
             CHECK(api_keys.size() == 1);
@@ -580,24 +568,22 @@ TEST_CASE("app: UserAPIKeyProviderClient integration", "[sync][app]") {
             REQUIRE(error);
             CHECK(error->message == "API key not found");
             CHECK(error->is_service_error());
-            CHECK(app::ServiceErrorCode(error->error_code.value()) == app::ServiceErrorCode::api_key_not_found);
+            CHECK(ServiceErrorCode(error->error_code.value()) == ServiceErrorCode::api_key_not_found);
         });
 
-        provider.fetch_api_key(api_key.id, first_user,
-                               [&](App::UserAPIKey user_api_key, Optional<app::AppError> error) {
-                                   REQUIRE_FALSE(error);
-                                   CHECK(user_api_key.disabled == false);
-                                   CHECK(user_api_key.name == api_key_name);
-                               });
+        provider.fetch_api_key(api_key.id, first_user, [&](App::UserAPIKey user_api_key, Optional<AppError> error) {
+            REQUIRE_FALSE(error);
+            CHECK(user_api_key.disabled == false);
+            CHECK(user_api_key.name == api_key_name);
+        });
 
-        provider.fetch_api_key(
-            api_key.id, second_user, [&](App::UserAPIKey user_api_key, Optional<app::AppError> error) {
-                REQUIRE(error);
-                CHECK(user_api_key.name == "");
-                CHECK(error->message == "API key not found");
-                CHECK(error->is_service_error());
-                CHECK(app::ServiceErrorCode(error->error_code.value()) == app::ServiceErrorCode::api_key_not_found);
-            });
+        provider.fetch_api_key(api_key.id, second_user, [&](App::UserAPIKey user_api_key, Optional<AppError> error) {
+            REQUIRE(error);
+            CHECK(user_api_key.name == "");
+            CHECK(error->message == "API key not found");
+            CHECK(error->is_service_error());
+            CHECK(ServiceErrorCode(error->error_code.value()) == ServiceErrorCode::api_key_not_found);
+        });
 
         provider.disable_api_key(api_key.id, first_user, [&](Optional<AppError> error) {
             REQUIRE_FALSE(error);
@@ -607,55 +593,51 @@ TEST_CASE("app: UserAPIKeyProviderClient integration", "[sync][app]") {
             REQUIRE(error);
             CHECK(error->message == "API key not found");
             CHECK(error->is_service_error());
-            CHECK(app::ServiceErrorCode(error->error_code.value()) == app::ServiceErrorCode::api_key_not_found);
+            CHECK(ServiceErrorCode(error->error_code.value()) == ServiceErrorCode::api_key_not_found);
         });
 
-        provider.fetch_api_key(api_key.id, first_user,
-                               [&](App::UserAPIKey user_api_key, Optional<app::AppError> error) {
-                                   REQUIRE_FALSE(error);
-                                   CHECK(user_api_key.disabled == true);
-                                   CHECK(user_api_key.name == api_key_name);
-                               });
+        provider.fetch_api_key(api_key.id, first_user, [&](App::UserAPIKey user_api_key, Optional<AppError> error) {
+            REQUIRE_FALSE(error);
+            CHECK(user_api_key.disabled == true);
+            CHECK(user_api_key.name == api_key_name);
+        });
 
-        provider.fetch_api_key(
-            api_key.id, second_user, [&](App::UserAPIKey user_api_key, Optional<app::AppError> error) {
-                REQUIRE(error);
-                CHECK(user_api_key.name == "");
-                CHECK(error->message == "API key not found");
-                CHECK(error->is_service_error());
-                CHECK(app::ServiceErrorCode(error->error_code.value()) == app::ServiceErrorCode::api_key_not_found);
-            });
+        provider.fetch_api_key(api_key.id, second_user, [&](App::UserAPIKey user_api_key, Optional<AppError> error) {
+            REQUIRE(error);
+            CHECK(user_api_key.name == "");
+            CHECK(error->message == "API key not found");
+            CHECK(error->is_service_error());
+            CHECK(ServiceErrorCode(error->error_code.value()) == ServiceErrorCode::api_key_not_found);
+        });
 
         provider.delete_api_key(api_key.id, second_user, [&](Optional<AppError> error) {
             REQUIRE(error);
             CHECK(error->message == "API key not found");
             CHECK(error->is_service_error());
-            CHECK(app::ServiceErrorCode(error->error_code.value()) == app::ServiceErrorCode::api_key_not_found);
+            CHECK(ServiceErrorCode(error->error_code.value()) == ServiceErrorCode::api_key_not_found);
         });
 
         provider.delete_api_key(api_key.id, first_user, [&](Optional<AppError> error) {
             REQUIRE_FALSE(error);
         });
 
-        provider.fetch_api_key(
-            api_key.id, first_user, [&](App::UserAPIKey user_api_key, Optional<app::AppError> error) {
-                CHECK(user_api_key.name == "");
-                REQUIRE(error);
-                CHECK(error->message == "API key not found");
-                CHECK(error->is_service_error());
-                CHECK(app::ServiceErrorCode(error->error_code.value()) == app::ServiceErrorCode::api_key_not_found);
-                processed = true;
-            });
+        provider.fetch_api_key(api_key.id, first_user, [&](App::UserAPIKey user_api_key, Optional<AppError> error) {
+            CHECK(user_api_key.name == "");
+            REQUIRE(error);
+            CHECK(error->message == "API key not found");
+            CHECK(error->is_service_error());
+            CHECK(ServiceErrorCode(error->error_code.value()) == ServiceErrorCode::api_key_not_found);
+            processed = true;
+        });
 
-        provider.fetch_api_key(
-            api_key.id, second_user, [&](App::UserAPIKey user_api_key, Optional<app::AppError> error) {
-                CHECK(user_api_key.name == "");
-                REQUIRE(error);
-                CHECK(error->message == "API key not found");
-                CHECK(error->is_service_error());
-                CHECK(app::ServiceErrorCode(error->error_code.value()) == app::ServiceErrorCode::api_key_not_found);
-                processed = true;
-            });
+        provider.fetch_api_key(api_key.id, second_user, [&](App::UserAPIKey user_api_key, Optional<AppError> error) {
+            CHECK(user_api_key.name == "");
+            REQUIRE(error);
+            CHECK(error->message == "API key not found");
+            CHECK(error->is_service_error());
+            CHECK(ServiceErrorCode(error->error_code.value()) == ServiceErrorCode::api_key_not_found);
+            processed = true;
+        });
 
         CHECK(processed);
     }
@@ -669,7 +651,7 @@ TEST_CASE("app: auth providers function integration", "[sync][app]") {
 
     SECTION("auth providers function integration") {
         bson::BsonDocument function_params{{"realmCustomAuthFuncUserId", "123456"}};
-        auto credentials = app::AppCredentials::function(function_params);
+        auto credentials = AppCredentials::function(function_params);
         auto user = log_in(app, credentials);
         REQUIRE(user->provider_type() == IdentityProviderFunction);
     }
@@ -687,7 +669,7 @@ TEST_CASE("app: link_user integration", "[sync][app]") {
         std::shared_ptr<SyncUser> sync_user;
 
         app->provider_client<App::UsernamePasswordProviderClient>().register_email(
-            creds.email, creds.password, [&](Optional<app::AppError> error) {
+            creds.email, creds.password, [&](Optional<AppError> error) {
                 CAPTURE(creds.email);
                 CAPTURE(creds.password);
                 REQUIRE_FALSE(error); // first registration success
@@ -696,7 +678,7 @@ TEST_CASE("app: link_user integration", "[sync][app]") {
         sync_user = log_in(app);
         CHECK(sync_user->provider_type() == IdentityProviderAnonymous);
 
-        app->link_user(sync_user, creds, [&](std::shared_ptr<SyncUser> user, Optional<app::AppError> error) {
+        app->link_user(sync_user, creds, [&](std::shared_ptr<SyncUser> user, Optional<AppError> error) {
             REQUIRE_FALSE(error);
             REQUIRE(user);
             CHECK(user->identity() == sync_user->identity());
@@ -800,7 +782,7 @@ TEST_CASE("app: call function", "[sync][app]") {
 
     bson::BsonArray toSum(5);
     std::iota(toSum.begin(), toSum.end(), static_cast<int64_t>(1));
-    const auto checkFn = [](Optional<app::AppError> error, Optional<int64_t> sum) {
+    const auto checkFn = [](Optional<int64_t>&& sum, Optional<AppError>&& error) {
         REQUIRE(!error);
         CHECK(*sum == 15);
     };
@@ -846,23 +828,23 @@ TEST_CASE("app: remote mongo client", "[sync][app]") {
 
     bson::BsonDocument bad_document{{"bad", "value"}};
 
-    dog_collection.delete_many(dog_document, [&](uint64_t, Optional<app::AppError> error) {
+    dog_collection.delete_many(dog_document, [&](uint64_t, Optional<AppError> error) {
         REQUIRE_FALSE(error);
     });
 
-    dog_collection.delete_many(dog_document2, [&](uint64_t, Optional<app::AppError> error) {
+    dog_collection.delete_many(dog_document2, [&](uint64_t, Optional<AppError> error) {
         REQUIRE_FALSE(error);
     });
 
-    dog_collection.delete_many({}, [&](uint64_t, Optional<app::AppError> error) {
+    dog_collection.delete_many({}, [&](uint64_t, Optional<AppError> error) {
         REQUIRE_FALSE(error);
     });
 
-    dog_collection.delete_many(person_document, [&](uint64_t, Optional<app::AppError> error) {
+    dog_collection.delete_many(person_document, [&](uint64_t, Optional<AppError> error) {
         REQUIRE_FALSE(error);
     });
 
-    dog_collection.delete_many(person_document2, [&](uint64_t, Optional<app::AppError> error) {
+    dog_collection.delete_many(person_document2, [&](uint64_t, Optional<AppError> error) {
         REQUIRE_FALSE(error);
     });
 
@@ -871,52 +853,51 @@ TEST_CASE("app: remote mongo client", "[sync][app]") {
         ObjectId dog_object_id;
         ObjectId dog2_object_id;
 
-        dog_collection.insert_one_bson(bad_document, [&](Optional<app::AppError> error, Optional<bson::Bson> bson) {
+        dog_collection.insert_one_bson(bad_document, [&](Optional<bson::Bson> bson, Optional<AppError> error) {
             CHECK(error);
             CHECK(!bson);
         });
 
-        dog_collection.insert_one_bson(dog_document3, [&](Optional<app::AppError> error, Optional<bson::Bson> value) {
+        dog_collection.insert_one_bson(dog_document3, [&](Optional<bson::Bson> value, Optional<AppError> error) {
             REQUIRE_FALSE(error);
             auto bson = static_cast<bson::BsonDocument>(*value);
             CHECK(static_cast<ObjectId>(bson["insertedId"]) == dog3_object_id);
         });
 
-        dog_collection.delete_many({}, [&](uint64_t, Optional<app::AppError> error) {
+        dog_collection.delete_many({}, [&](uint64_t, Optional<AppError> error) {
             REQUIRE_FALSE(error);
         });
 
-        dog_collection.insert_one(bad_document, [&](Optional<bson::Bson> object_id, Optional<app::AppError> error) {
+        dog_collection.insert_one(bad_document, [&](Optional<bson::Bson> object_id, Optional<AppError> error) {
             CHECK(error);
             CHECK(!object_id);
         });
 
-        dog_collection.insert_one(dog_document, [&](Optional<bson::Bson> object_id, Optional<app::AppError> error) {
+        dog_collection.insert_one(dog_document, [&](Optional<bson::Bson> object_id, Optional<AppError> error) {
             REQUIRE_FALSE(error);
             CHECK((*object_id).to_string() != "");
             dog_object_id = static_cast<ObjectId>(*object_id);
         });
 
-        dog_collection.insert_one(dog_document2, [&](Optional<bson::Bson> object_id, Optional<app::AppError> error) {
+        dog_collection.insert_one(dog_document2, [&](Optional<bson::Bson> object_id, Optional<AppError> error) {
             REQUIRE_FALSE(error);
             CHECK((*object_id).to_string() != "");
             dog2_object_id = static_cast<ObjectId>(*object_id);
         });
 
-        dog_collection.insert_one(dog_document3, [&](Optional<bson::Bson> object_id, Optional<app::AppError> error) {
+        dog_collection.insert_one(dog_document3, [&](Optional<bson::Bson> object_id, Optional<AppError> error) {
             REQUIRE_FALSE(error);
             CHECK(object_id->type() == bson::Bson::Type::ObjectId);
             CHECK(static_cast<ObjectId>(*object_id) == dog3_object_id);
         });
 
         person_document["dogs"] = bson::BsonArray({dog_object_id, dog2_object_id, dog3_object_id});
-        person_collection.insert_one(person_document,
-                                     [&](Optional<bson::Bson> object_id, Optional<app::AppError> error) {
-                                         REQUIRE_FALSE(error);
-                                         CHECK((*object_id).to_string() != "");
-                                     });
+        person_collection.insert_one(person_document, [&](Optional<bson::Bson> object_id, Optional<AppError> error) {
+            REQUIRE_FALSE(error);
+            CHECK((*object_id).to_string() != "");
+        });
 
-        dog_collection.delete_many({}, [&](uint64_t, Optional<app::AppError> error) {
+        dog_collection.delete_many({}, [&](uint64_t, Optional<AppError> error) {
             REQUIRE_FALSE(error);
         });
 
@@ -926,26 +907,25 @@ TEST_CASE("app: remote mongo client", "[sync][app]") {
             dog_document3,
         };
 
-        dog_collection.insert_many_bson(documents, [&](Optional<app::AppError> error, Optional<bson::Bson> value) {
+        dog_collection.insert_many_bson(documents, [&](Optional<bson::Bson> value, Optional<AppError> error) {
             REQUIRE_FALSE(error);
             auto bson = static_cast<bson::BsonDocument>(*value);
             auto insertedIds = static_cast<bson::BsonArray>(bson["insertedIds"]);
         });
 
-        dog_collection.delete_many({}, [&](uint64_t, Optional<app::AppError> error) {
+        dog_collection.delete_many({}, [&](uint64_t, Optional<AppError> error) {
             REQUIRE_FALSE(error);
         });
 
-        dog_collection.insert_many(documents,
-                                   [&](std::vector<bson::Bson> inserted_docs, Optional<app::AppError> error) {
-                                       REQUIRE_FALSE(error);
-                                       CHECK(inserted_docs.size() == 3);
-                                       CHECK(inserted_docs[0].type() == bson::Bson::Type::ObjectId);
-                                       CHECK(inserted_docs[1].type() == bson::Bson::Type::ObjectId);
-                                       CHECK(inserted_docs[2].type() == bson::Bson::Type::ObjectId);
-                                       CHECK(static_cast<ObjectId>(inserted_docs[2]) == dog3_object_id);
-                                       processed = true;
-                                   });
+        dog_collection.insert_many(documents, [&](std::vector<bson::Bson> inserted_docs, Optional<AppError> error) {
+            REQUIRE_FALSE(error);
+            CHECK(inserted_docs.size() == 3);
+            CHECK(inserted_docs[0].type() == bson::Bson::Type::ObjectId);
+            CHECK(inserted_docs[1].type() == bson::Bson::Type::ObjectId);
+            CHECK(inserted_docs[2].type() == bson::Bson::Type::ObjectId);
+            CHECK(static_cast<ObjectId>(inserted_docs[2]) == dog3_object_id);
+            processed = true;
+        });
 
         CHECK(processed);
     }
@@ -953,24 +933,22 @@ TEST_CASE("app: remote mongo client", "[sync][app]") {
     SECTION("find") {
         bool processed = false;
 
-        dog_collection.find(dog_document,
-                            [&](Optional<bson::BsonArray> document_array, Optional<app::AppError> error) {
-                                REQUIRE_FALSE(error);
-                                CHECK((*document_array).size() == 0);
-                            });
+        dog_collection.find(dog_document, [&](Optional<bson::BsonArray> document_array, Optional<AppError> error) {
+            REQUIRE_FALSE(error);
+            CHECK((*document_array).size() == 0);
+        });
 
-        dog_collection.find_bson(dog_document, {}, [&](Optional<app::AppError> error, Optional<bson::Bson> bson) {
+        dog_collection.find_bson(dog_document, {}, [&](Optional<bson::Bson> bson, Optional<AppError> error) {
             REQUIRE_FALSE(error);
             CHECK(static_cast<bson::BsonArray>(*bson).size() == 0);
         });
 
-        dog_collection.find_one(dog_document,
-                                [&](Optional<bson::BsonDocument> document, Optional<app::AppError> error) {
-                                    REQUIRE_FALSE(error);
-                                    CHECK(!document);
-                                });
+        dog_collection.find_one(dog_document, [&](Optional<bson::BsonDocument> document, Optional<AppError> error) {
+            REQUIRE_FALSE(error);
+            CHECK(!document);
+        });
 
-        dog_collection.find_one_bson(dog_document, {}, [&](Optional<app::AppError> error, Optional<bson::Bson> bson) {
+        dog_collection.find_one_bson(dog_document, {}, [&](Optional<bson::Bson> bson, Optional<AppError> error) {
             REQUIRE_FALSE(error);
             CHECK((!bson || bson::holds_alternative<util::None>(*bson)));
         });
@@ -978,112 +956,108 @@ TEST_CASE("app: remote mongo client", "[sync][app]") {
         ObjectId dog_object_id;
         ObjectId dog2_object_id;
 
-        dog_collection.insert_one(dog_document, [&](Optional<bson::Bson> object_id, Optional<app::AppError> error) {
+        dog_collection.insert_one(dog_document, [&](Optional<bson::Bson> object_id, Optional<AppError> error) {
             REQUIRE_FALSE(error);
             CHECK((*object_id).to_string() != "");
             dog_object_id = static_cast<ObjectId>(*object_id);
         });
 
-        dog_collection.insert_one(dog_document2, [&](Optional<bson::Bson> object_id, Optional<app::AppError> error) {
+        dog_collection.insert_one(dog_document2, [&](Optional<bson::Bson> object_id, Optional<AppError> error) {
             REQUIRE_FALSE(error);
             CHECK((*object_id).to_string() != "");
             dog2_object_id = static_cast<ObjectId>(*object_id);
         });
 
         person_document["dogs"] = bson::BsonArray({dog_object_id, dog2_object_id});
-        person_collection.insert_one(person_document,
-                                     [&](Optional<bson::Bson> object_id, Optional<app::AppError> error) {
-                                         REQUIRE_FALSE(error);
-                                         CHECK((*object_id).to_string() != "");
-                                     });
+        person_collection.insert_one(person_document, [&](Optional<bson::Bson> object_id, Optional<AppError> error) {
+            REQUIRE_FALSE(error);
+            CHECK((*object_id).to_string() != "");
+        });
 
-        dog_collection.find(dog_document, [&](Optional<bson::BsonArray> documents, Optional<app::AppError> error) {
+        dog_collection.find(dog_document, [&](Optional<bson::BsonArray> documents, Optional<AppError> error) {
             REQUIRE_FALSE(error);
             CHECK((*documents).size() == 1);
         });
 
-        dog_collection.find_bson(dog_document, {}, [&](Optional<app::AppError> error, Optional<bson::Bson> bson) {
+        dog_collection.find_bson(dog_document, {}, [&](Optional<bson::Bson> bson, Optional<AppError> error) {
             REQUIRE_FALSE(error);
             CHECK(static_cast<bson::BsonArray>(*bson).size() == 1);
         });
 
-        person_collection.find(person_document,
-                               [&](Optional<bson::BsonArray> documents, Optional<app::AppError> error) {
-                                   REQUIRE_FALSE(error);
-                                   CHECK((*documents).size() == 1);
-                               });
+        person_collection.find(person_document, [&](Optional<bson::BsonArray> documents, Optional<AppError> error) {
+            REQUIRE_FALSE(error);
+            CHECK((*documents).size() == 1);
+        });
 
-        app::MongoCollection::FindOptions options{
-            2,                                                               // document limit
-            util::Optional<bson::BsonDocument>({{"name", 1}, {"breed", 1}}), // project
-            util::Optional<bson::BsonDocument>({{"breed", 1}})               // sort
+        MongoCollection::FindOptions options{
+            2,                                                         // document limit
+            Optional<bson::BsonDocument>({{"name", 1}, {"breed", 1}}), // project
+            Optional<bson::BsonDocument>({{"breed", 1}})               // sort
         };
 
         dog_collection.find(dog_document, options,
-                            [&](Optional<bson::BsonArray> document_array, Optional<app::AppError> error) {
+                            [&](Optional<bson::BsonArray> document_array, Optional<AppError> error) {
                                 REQUIRE_FALSE(error);
                                 CHECK((*document_array).size() == 1);
                             });
 
         dog_collection.find({{"name", "fido"}}, options,
-                            [&](Optional<bson::BsonArray> document_array, Optional<app::AppError> error) {
+                            [&](Optional<bson::BsonArray> document_array, Optional<AppError> error) {
                                 REQUIRE_FALSE(error);
                                 CHECK((*document_array).size() == 1);
                                 auto king_charles = static_cast<bson::BsonDocument>((*document_array)[0]);
                                 CHECK(king_charles["breed"] == "king charles");
                             });
 
-        dog_collection.find_one(dog_document,
-                                [&](Optional<bson::BsonDocument> document, Optional<app::AppError> error) {
-                                    REQUIRE_FALSE(error);
-                                    auto name = (*document)["name"];
-                                    CHECK(name == "fido");
-                                });
+        dog_collection.find_one(dog_document, [&](Optional<bson::BsonDocument> document, Optional<AppError> error) {
+            REQUIRE_FALSE(error);
+            auto name = (*document)["name"];
+            CHECK(name == "fido");
+        });
 
         dog_collection.find_one(dog_document, options,
-                                [&](Optional<bson::BsonDocument> document, Optional<app::AppError> error) {
+                                [&](Optional<bson::BsonDocument> document, Optional<AppError> error) {
                                     REQUIRE_FALSE(error);
                                     auto name = (*document)["name"];
                                     CHECK(name == "fido");
                                 });
 
-        dog_collection.find_one_bson(dog_document, options,
-                                     [&](Optional<app::AppError> error, Optional<bson::Bson> bson) {
-                                         REQUIRE_FALSE(error);
-                                         auto name = (static_cast<bson::BsonDocument>(*bson))["name"];
-                                         CHECK(name == "fido");
-                                     });
+        dog_collection.find_one_bson(dog_document, options, [&](Optional<bson::Bson> bson, Optional<AppError> error) {
+            REQUIRE_FALSE(error);
+            auto name = (static_cast<bson::BsonDocument>(*bson))["name"];
+            CHECK(name == "fido");
+        });
 
-        dog_collection.find(dog_document, [&](Optional<bson::BsonArray> documents, Optional<app::AppError> error) {
+        dog_collection.find(dog_document, [&](Optional<bson::BsonArray> documents, Optional<AppError> error) {
             REQUIRE_FALSE(error);
             CHECK((*documents).size() == 1);
         });
 
         dog_collection.find_one_and_delete(dog_document,
-                                           [&](Optional<bson::BsonDocument> document, Optional<app::AppError> error) {
+                                           [&](Optional<bson::BsonDocument> document, Optional<AppError> error) {
                                                REQUIRE_FALSE(error);
                                                REQUIRE(document);
                                            });
 
         dog_collection.find_one_and_delete({{}},
-                                           [&](Optional<bson::BsonDocument> document, Optional<app::AppError> error) {
+                                           [&](Optional<bson::BsonDocument> document, Optional<AppError> error) {
                                                REQUIRE_FALSE(error);
                                                REQUIRE(document);
                                            });
 
         dog_collection.find_one_and_delete({{"invalid", "key"}},
-                                           [&](Optional<bson::BsonDocument> document, Optional<app::AppError> error) {
+                                           [&](Optional<bson::BsonDocument> document, Optional<AppError> error) {
                                                REQUIRE_FALSE(error);
                                                CHECK(!document);
                                            });
 
         dog_collection.find_one_and_delete_bson({{"invalid", "key"}}, {},
-                                                [&](Optional<app::AppError> error, Optional<bson::Bson> bson) {
+                                                [&](Optional<bson::Bson> bson, Optional<AppError> error) {
                                                     REQUIRE_FALSE(error);
                                                     CHECK((!bson || bson::holds_alternative<util::None>(*bson)));
                                                 });
 
-        dog_collection.find(dog_document, [&](Optional<bson::BsonArray> documents, Optional<app::AppError> error) {
+        dog_collection.find(dog_document, [&](Optional<bson::BsonArray> documents, Optional<AppError> error) {
             REQUIRE_FALSE(error);
             CHECK((*documents).size() == 0);
             processed = true;
@@ -1098,29 +1072,28 @@ TEST_CASE("app: remote mongo client", "[sync][app]") {
         ObjectId dog_object_id;
         ObjectId dog2_object_id;
 
-        dog_collection.insert_one(dog_document, [&](Optional<bson::Bson> object_id, Optional<app::AppError> error) {
+        dog_collection.insert_one(dog_document, [&](Optional<bson::Bson> object_id, Optional<AppError> error) {
             REQUIRE_FALSE(error);
             CHECK((*object_id).to_string() != "");
         });
 
-        dog_collection.insert_one(dog_document, [&](Optional<bson::Bson> object_id, Optional<app::AppError> error) {
+        dog_collection.insert_one(dog_document, [&](Optional<bson::Bson> object_id, Optional<AppError> error) {
             REQUIRE_FALSE(error);
             CHECK((*object_id).to_string() != "");
             dog_object_id = static_cast<ObjectId>(*object_id);
         });
 
-        dog_collection.insert_one(dog_document2, [&](Optional<bson::Bson> object_id, Optional<app::AppError> error) {
+        dog_collection.insert_one(dog_document2, [&](Optional<bson::Bson> object_id, Optional<AppError> error) {
             REQUIRE_FALSE(error);
             CHECK((*object_id).to_string() != "");
             dog2_object_id = static_cast<ObjectId>(*object_id);
         });
 
         person_document["dogs"] = bson::BsonArray({dog_object_id, dog2_object_id});
-        person_collection.insert_one(person_document,
-                                     [&](Optional<bson::Bson> object_id, Optional<app::AppError> error) {
-                                         REQUIRE_FALSE(error);
-                                         CHECK((*object_id).to_string() != "");
-                                     });
+        person_collection.insert_one(person_document, [&](Optional<bson::Bson> object_id, Optional<AppError> error) {
+            REQUIRE_FALSE(error);
+            CHECK((*object_id).to_string() != "");
+        });
 
         bson::BsonDocument match{{"$match", bson::BsonDocument({{"name", "fido"}})}};
 
@@ -1128,40 +1101,40 @@ TEST_CASE("app: remote mongo client", "[sync][app]") {
 
         bson::BsonArray pipeline{match, group};
 
-        dog_collection.aggregate(pipeline, [&](Optional<bson::BsonArray> documents, Optional<app::AppError> error) {
+        dog_collection.aggregate(pipeline, [&](Optional<bson::BsonArray> documents, Optional<AppError> error) {
             REQUIRE_FALSE(error);
             CHECK((*documents).size() == 1);
         });
 
-        dog_collection.aggregate_bson(pipeline, [&](Optional<app::AppError> error, Optional<bson::Bson> bson) {
+        dog_collection.aggregate_bson(pipeline, [&](Optional<bson::Bson> bson, Optional<AppError> error) {
             REQUIRE_FALSE(error);
             CHECK(static_cast<bson::BsonArray>(*bson).size() == 1);
         });
 
-        dog_collection.count({{"breed", "king charles"}}, [&](uint64_t count, Optional<app::AppError> error) {
+        dog_collection.count({{"breed", "king charles"}}, [&](uint64_t count, Optional<AppError> error) {
             REQUIRE_FALSE(error);
             CHECK(count == 2);
         });
 
         dog_collection.count_bson({{"breed", "king charles"}}, 0,
-                                  [&](Optional<app::AppError> error, Optional<bson::Bson> bson) {
+                                  [&](Optional<bson::Bson> bson, Optional<AppError> error) {
                                       REQUIRE_FALSE(error);
                                       CHECK(static_cast<int64_t>(*bson) == 2);
                                   });
 
-        dog_collection.count({{"breed", "french bulldog"}}, [&](uint64_t count, Optional<app::AppError> error) {
+        dog_collection.count({{"breed", "french bulldog"}}, [&](uint64_t count, Optional<AppError> error) {
             REQUIRE_FALSE(error);
             CHECK(count == 1);
         });
 
-        dog_collection.count({{"breed", "king charles"}}, 1, [&](uint64_t count, Optional<app::AppError> error) {
+        dog_collection.count({{"breed", "king charles"}}, 1, [&](uint64_t count, Optional<AppError> error) {
             REQUIRE_FALSE(error);
             CHECK(count == 1);
         });
 
         person_collection.count(
             {{"firstName", "John"}, {"lastName", "Johnson"}, {"age", bson::BsonDocument({{"$gt", 25}})}}, 1,
-            [&](uint64_t count, Optional<app::AppError> error) {
+            [&](uint64_t count, Optional<AppError> error) {
                 REQUIRE_FALSE(error);
                 CHECK(count == 1);
                 processed = true;
@@ -1173,40 +1146,40 @@ TEST_CASE("app: remote mongo client", "[sync][app]") {
     SECTION("find and update") {
         bool processed = false;
 
-        app::MongoCollection::FindOneAndModifyOptions find_and_modify_options{
-            util::Optional<bson::BsonDocument>({{"name", 1}, {"breed", 1}}), // project
-            util::Optional<bson::BsonDocument>({{"name", 1}}),               // sort,
-            true,                                                            // upsert
-            true                                                             // return new doc
+        MongoCollection::FindOneAndModifyOptions find_and_modify_options{
+            Optional<bson::BsonDocument>({{"name", 1}, {"breed", 1}}), // project
+            Optional<bson::BsonDocument>({{"name", 1}}),               // sort,
+            true,                                                      // upsert
+            true                                                       // return new doc
         };
 
         dog_collection.find_one_and_update(dog_document, dog_document2,
-                                           [&](Optional<bson::BsonDocument> document, Optional<app::AppError> error) {
+                                           [&](Optional<bson::BsonDocument> document, Optional<AppError> error) {
                                                REQUIRE_FALSE(error);
                                                CHECK(!document);
                                            });
 
-        dog_collection.insert_one(dog_document, [&](Optional<bson::Bson> object_id, Optional<app::AppError> error) {
+        dog_collection.insert_one(dog_document, [&](Optional<bson::Bson> object_id, Optional<AppError> error) {
             REQUIRE_FALSE(error);
             CHECK((*object_id).to_string() != "");
         });
 
         dog_collection.find_one_and_update(dog_document, dog_document2, find_and_modify_options,
-                                           [&](Optional<bson::BsonDocument> document, Optional<app::AppError> error) {
+                                           [&](Optional<bson::BsonDocument> document, Optional<AppError> error) {
                                                REQUIRE_FALSE(error);
                                                auto breed = static_cast<std::string>((*document)["breed"]);
                                                CHECK(breed == "french bulldog");
                                            });
 
         dog_collection.find_one_and_update(dog_document2, dog_document, find_and_modify_options,
-                                           [&](Optional<bson::BsonDocument> document, Optional<app::AppError> error) {
+                                           [&](Optional<bson::BsonDocument> document, Optional<AppError> error) {
                                                REQUIRE_FALSE(error);
                                                auto breed = static_cast<std::string>((*document)["breed"]);
                                                CHECK(breed == "king charles");
                                            });
 
         dog_collection.find_one_and_update_bson(dog_document, dog_document2, find_and_modify_options,
-                                                [&](Optional<app::AppError> error, Optional<bson::Bson> bson) {
+                                                [&](Optional<bson::Bson> bson, Optional<AppError> error) {
                                                     REQUIRE_FALSE(error);
                                                     auto breed = static_cast<std::string>(
                                                         static_cast<bson::BsonDocument>(*bson)["breed"]);
@@ -1214,7 +1187,7 @@ TEST_CASE("app: remote mongo client", "[sync][app]") {
                                                 });
 
         dog_collection.find_one_and_update_bson(dog_document2, dog_document, find_and_modify_options,
-                                                [&](Optional<app::AppError> error, Optional<bson::Bson> bson) {
+                                                [&](Optional<bson::Bson> bson, Optional<AppError> error) {
                                                     REQUIRE_FALSE(error);
                                                     auto breed = static_cast<std::string>(
                                                         static_cast<bson::BsonDocument>(*bson)["breed"]);
@@ -1222,7 +1195,7 @@ TEST_CASE("app: remote mongo client", "[sync][app]") {
                                                 });
 
         dog_collection.find_one_and_update({{"name", "invalid name"}}, {{"name", "some name"}},
-                                           [&](Optional<bson::BsonDocument> document, Optional<app::AppError> error) {
+                                           [&](Optional<bson::BsonDocument> document, Optional<AppError> error) {
                                                REQUIRE_FALSE(error);
                                                CHECK(!document);
                                                processed = true;
@@ -1231,7 +1204,7 @@ TEST_CASE("app: remote mongo client", "[sync][app]") {
         processed = false;
 
         dog_collection.find_one_and_update({{"name", "invalid name"}}, {{}}, find_and_modify_options,
-                                           [&](Optional<bson::BsonDocument> document, Optional<app::AppError> error) {
+                                           [&](Optional<bson::BsonDocument> document, Optional<AppError> error) {
                                                REQUIRE(error);
                                                CHECK(error->message == "insert not permitted");
                                                CHECK(!document);
@@ -1245,23 +1218,23 @@ TEST_CASE("app: remote mongo client", "[sync][app]") {
         ObjectId dog_object_id;
 
         dog_collection.update_one(dog_document, dog_document2, true,
-                                  [&](app::MongoCollection::UpdateResult result, Optional<app::AppError> error) {
+                                  [&](MongoCollection::UpdateResult result, Optional<AppError> error) {
                                       REQUIRE_FALSE(error);
                                       CHECK((*result.upserted_id).to_string() != "");
                                   });
 
         dog_collection.update_one(dog_document2, dog_document,
-                                  [&](app::MongoCollection::UpdateResult result, Optional<app::AppError> error) {
+                                  [&](MongoCollection::UpdateResult result, Optional<AppError> error) {
                                       REQUIRE_FALSE(error);
                                       CHECK(!result.upserted_id);
                                   });
 
-        dog_collection.delete_many({}, [&](uint64_t, Optional<app::AppError> error) {
+        dog_collection.delete_many({}, [&](uint64_t, Optional<AppError> error) {
             REQUIRE_FALSE(error);
         });
 
         dog_collection.update_one_bson(dog_document, dog_document2, true,
-                                       [&](Optional<app::AppError> error, Optional<bson::Bson> bson) {
+                                       [&](Optional<bson::Bson> bson, Optional<AppError> error) {
                                            REQUIRE_FALSE(error);
                                            auto upserted_id = static_cast<bson::BsonDocument>(*bson)["upsertedId"];
 
@@ -1269,7 +1242,7 @@ TEST_CASE("app: remote mongo client", "[sync][app]") {
                                        });
 
         dog_collection.update_one_bson(dog_document2, dog_document, true,
-                                       [&](Optional<app::AppError> error, Optional<bson::Bson> bson) {
+                                       [&](Optional<bson::Bson> bson, Optional<AppError> error) {
                                            REQUIRE_FALSE(error);
                                            auto document = static_cast<bson::BsonDocument>(*bson);
                                            auto foundUpsertedId = document.find("upsertedId") != document.end();
@@ -1280,7 +1253,7 @@ TEST_CASE("app: remote mongo client", "[sync][app]") {
         bson::BsonDocument person_document_copy = bson::BsonDocument(person_document);
         person_document_copy["dogs"] = bson::BsonArray({dog_object_id});
         person_collection.update_one(person_document, person_document, true,
-                                     [&](app::MongoCollection::UpdateResult, Optional<app::AppError> error) {
+                                     [&](MongoCollection::UpdateResult, Optional<AppError> error) {
                                          REQUIRE_FALSE(error);
                                          processed = true;
                                      });
@@ -1291,19 +1264,19 @@ TEST_CASE("app: remote mongo client", "[sync][app]") {
     SECTION("update many") {
         bool processed = false;
 
-        dog_collection.insert_one(dog_document, [&](Optional<bson::Bson> object_id, Optional<app::AppError> error) {
+        dog_collection.insert_one(dog_document, [&](Optional<bson::Bson> object_id, Optional<AppError> error) {
             REQUIRE_FALSE(error);
             CHECK((*object_id).to_string() != "");
         });
 
         dog_collection.update_many(dog_document2, dog_document, true,
-                                   [&](app::MongoCollection::UpdateResult result, Optional<app::AppError> error) {
+                                   [&](MongoCollection::UpdateResult result, Optional<AppError> error) {
                                        REQUIRE_FALSE(error);
                                        CHECK((*result.upserted_id).to_string() != "");
                                    });
 
         dog_collection.update_many(dog_document2, dog_document,
-                                   [&](app::MongoCollection::UpdateResult result, Optional<app::AppError> error) {
+                                   [&](MongoCollection::UpdateResult result, Optional<AppError> error) {
                                        REQUIRE_FALSE(error);
                                        CHECK(!result.upserted_id);
                                        processed = true;
@@ -1317,90 +1290,85 @@ TEST_CASE("app: remote mongo client", "[sync][app]") {
         ObjectId dog_object_id;
         ObjectId person_object_id;
 
-        app::MongoCollection::FindOneAndModifyOptions find_and_modify_options{
-            util::Optional<bson::BsonDocument>({{"name", "fido"}}), // project
-            util::Optional<bson::BsonDocument>({{"name", 1}}),      // sort,
-            true,                                                   // upsert
-            true                                                    // return new doc
+        MongoCollection::FindOneAndModifyOptions find_and_modify_options{
+            Optional<bson::BsonDocument>({{"name", "fido"}}), // project
+            Optional<bson::BsonDocument>({{"name", 1}}),      // sort,
+            true,                                             // upsert
+            true                                              // return new doc
         };
 
-        dog_collection.find_one_and_replace(
-            dog_document, dog_document2, [&](Optional<bson::BsonDocument> document, Optional<app::AppError> error) {
-                REQUIRE_FALSE(error);
-                CHECK(!document);
-            });
+        dog_collection.find_one_and_replace(dog_document, dog_document2,
+                                            [&](Optional<bson::BsonDocument> document, Optional<AppError> error) {
+                                                REQUIRE_FALSE(error);
+                                                CHECK(!document);
+                                            });
 
-        dog_collection.insert_one(dog_document, [&](Optional<bson::Bson> object_id, Optional<app::AppError> error) {
+        dog_collection.insert_one(dog_document, [&](Optional<bson::Bson> object_id, Optional<AppError> error) {
             REQUIRE_FALSE(error);
             CHECK((*object_id).to_string() != "");
             dog_object_id = static_cast<ObjectId>(*object_id);
         });
 
-        dog_collection.find_one_and_replace(
-            dog_document, dog_document2, [&](Optional<bson::BsonDocument> document, Optional<app::AppError> error) {
-                REQUIRE_FALSE(error);
-                auto name = static_cast<std::string>((*document)["name"]);
-                CHECK(name == "fido");
-            });
+        dog_collection.find_one_and_replace(dog_document, dog_document2,
+                                            [&](Optional<bson::BsonDocument> document, Optional<AppError> error) {
+                                                REQUIRE_FALSE(error);
+                                                auto name = static_cast<std::string>((*document)["name"]);
+                                                CHECK(name == "fido");
+                                            });
 
-        dog_collection.find_one_and_replace(
-            dog_document2, dog_document, find_and_modify_options,
-            [&](Optional<bson::BsonDocument> document, Optional<app::AppError> error) {
-                REQUIRE_FALSE(error);
-                auto name = static_cast<std::string>((*document)["name"]);
-                CHECK(static_cast<std::string>(name) == "fido");
-            });
+        dog_collection.find_one_and_replace(dog_document2, dog_document, find_and_modify_options,
+                                            [&](Optional<bson::BsonDocument> document, Optional<AppError> error) {
+                                                REQUIRE_FALSE(error);
+                                                auto name = static_cast<std::string>((*document)["name"]);
+                                                CHECK(static_cast<std::string>(name) == "fido");
+                                            });
 
         person_document["dogs"] = bson::BsonArray({dog_object_id});
         person_document2["dogs"] = bson::BsonArray({dog_object_id});
-        person_collection.insert_one(person_document,
-                                     [&](Optional<bson::Bson> object_id, Optional<app::AppError> error) {
-                                         REQUIRE_FALSE(error);
-                                         CHECK((*object_id).to_string() != "");
-                                         person_object_id = static_cast<ObjectId>(*object_id);
-                                     });
+        person_collection.insert_one(person_document, [&](Optional<bson::Bson> object_id, Optional<AppError> error) {
+            REQUIRE_FALSE(error);
+            CHECK((*object_id).to_string() != "");
+            person_object_id = static_cast<ObjectId>(*object_id);
+        });
 
-        app::MongoCollection::FindOneAndModifyOptions person_find_and_modify_options{
-            util::Optional<bson::BsonDocument>({{"firstName", 1}}), // project
-            util::Optional<bson::BsonDocument>({{"firstName", 1}}), // sort,
-            false,                                                  // upsert
-            true                                                    // return new doc
+        MongoCollection::FindOneAndModifyOptions person_find_and_modify_options{
+            Optional<bson::BsonDocument>({{"firstName", 1}}), // project
+            Optional<bson::BsonDocument>({{"firstName", 1}}), // sort,
+            false,                                            // upsert
+            true                                              // return new doc
         };
 
-        person_collection.find_one_and_replace(
-            person_document, person_document2,
-            [&](Optional<bson::BsonDocument> document, Optional<app::AppError> error) {
-                REQUIRE_FALSE(error);
-                auto name = static_cast<std::string>((*document)["firstName"]);
-                // Should return the old document
-                CHECK(name == "John");
-                processed = true;
-            });
+        person_collection.find_one_and_replace(person_document, person_document2,
+                                               [&](Optional<bson::BsonDocument> document, Optional<AppError> error) {
+                                                   REQUIRE_FALSE(error);
+                                                   auto name = static_cast<std::string>((*document)["firstName"]);
+                                                   // Should return the old document
+                                                   CHECK(name == "John");
+                                                   processed = true;
+                                               });
 
-        person_collection.find_one_and_replace(
-            person_document2, person_document, person_find_and_modify_options,
-            [&](Optional<bson::BsonDocument> document, Optional<app::AppError> error) {
-                REQUIRE_FALSE(error);
-                auto name = static_cast<std::string>((*document)["firstName"]);
-                // Should return new document, Bob -> John
-                CHECK(name == "John");
-            });
+        person_collection.find_one_and_replace(person_document2, person_document, person_find_and_modify_options,
+                                               [&](Optional<bson::BsonDocument> document, Optional<AppError> error) {
+                                                   REQUIRE_FALSE(error);
+                                                   auto name = static_cast<std::string>((*document)["firstName"]);
+                                                   // Should return new document, Bob -> John
+                                                   CHECK(name == "John");
+                                               });
 
-        person_collection.find_one_and_replace(
-            {{"invalid", "item"}}, {{}}, [&](Optional<bson::BsonDocument> document, Optional<app::AppError> error) {
-                // If a document is not found then null will be returned for the document and no error will be
-                // returned
-                REQUIRE_FALSE(error);
-                CHECK(!document);
-            });
+        person_collection.find_one_and_replace({{"invalid", "item"}}, {{}},
+                                               [&](Optional<bson::BsonDocument> document, Optional<AppError> error) {
+                                                   // If a document is not found then null will be returned for the
+                                                   // document and no error will be returned
+                                                   REQUIRE_FALSE(error);
+                                                   CHECK(!document);
+                                               });
 
-        person_collection.find_one_and_replace(
-            {{"invalid", "item"}}, {{}}, person_find_and_modify_options,
-            [&](Optional<bson::BsonDocument> document, Optional<app::AppError> error) {
-                REQUIRE_FALSE(error);
-                CHECK(!document);
-                processed = true;
-            });
+        person_collection.find_one_and_replace({{"invalid", "item"}}, {{}}, person_find_and_modify_options,
+                                               [&](Optional<bson::BsonDocument> document, Optional<AppError> error) {
+                                                   REQUIRE_FALSE(error);
+                                                   CHECK(!document);
+                                                   processed = true;
+                                               });
 
         CHECK(processed);
     }
@@ -1412,36 +1380,34 @@ TEST_CASE("app: remote mongo client", "[sync][app]") {
         bson::BsonArray documents;
         documents.assign(3, dog_document);
 
-        dog_collection.insert_many(documents,
-                                   [&](std::vector<bson::Bson> inserted_docs, Optional<app::AppError> error) {
-                                       REQUIRE_FALSE(error);
-                                       CHECK(inserted_docs.size() == 3);
-                                   });
+        dog_collection.insert_many(documents, [&](std::vector<bson::Bson> inserted_docs, Optional<AppError> error) {
+            REQUIRE_FALSE(error);
+            CHECK(inserted_docs.size() == 3);
+        });
 
-        app::MongoCollection::FindOneAndModifyOptions find_and_modify_options{
-            util::Optional<bson::BsonDocument>({{"name", "fido"}}), // project
-            util::Optional<bson::BsonDocument>({{"name", 1}}),      // sort,
-            true,                                                   // upsert
-            true                                                    // return new doc
+        MongoCollection::FindOneAndModifyOptions find_and_modify_options{
+            Optional<bson::BsonDocument>({{"name", "fido"}}), // project
+            Optional<bson::BsonDocument>({{"name", 1}}),      // sort,
+            true,                                             // upsert
+            true                                              // return new doc
         };
 
-        dog_collection.delete_one(dog_document, [&](uint64_t deleted_count, Optional<app::AppError> error) {
+        dog_collection.delete_one(dog_document, [&](uint64_t deleted_count, Optional<AppError> error) {
             REQUIRE_FALSE(error);
             CHECK(deleted_count >= 1);
         });
 
-        dog_collection.delete_many(dog_document, [&](uint64_t deleted_count, Optional<app::AppError> error) {
+        dog_collection.delete_many(dog_document, [&](uint64_t deleted_count, Optional<AppError> error) {
             REQUIRE_FALSE(error);
             CHECK(deleted_count >= 1);
             processed = true;
         });
 
-        person_collection.delete_many_bson(
-            person_document, [&](Optional<app::AppError> error, Optional<bson::Bson> bson) {
-                REQUIRE_FALSE(error);
-                CHECK(static_cast<int32_t>(static_cast<bson::BsonDocument>(*bson)["deletedCount"]) >= 1);
-                processed = true;
-            });
+        person_collection.delete_many_bson(person_document, [&](Optional<bson::Bson> bson, Optional<AppError> error) {
+            REQUIRE_FALSE(error);
+            CHECK(static_cast<int32_t>(static_cast<bson::BsonDocument>(*bson)["deletedCount"]) >= 1);
+            processed = true;
+        });
 
         CHECK(processed);
     }
@@ -1459,7 +1425,7 @@ TEST_CASE("app: push notifications", "[sync][app]") {
     SECTION("register") {
         bool processed;
 
-        app->push_notification_client("gcm").register_device("hello", sync_user, [&](Optional<app::AppError> error) {
+        app->push_notification_client("gcm").register_device("hello", sync_user, [&](Optional<AppError> error) {
             REQUIRE_FALSE(error);
             processed = true;
         });
@@ -1475,13 +1441,13 @@ TEST_CASE("app: push notifications", "[sync][app]") {
 
             app->push_notification_client("gcm").register_device("hello",
                                                                  sync_user,
-                                                                 [&](Optional<app::AppError> error) {
+                                                                 [&](Optional<AppError> error) {
                 REQUIRE_FALSE(error);
             });
 
             app->push_notification_client("gcm").register_device("hello",
                                                                  sync_user,
-                                                                 [&](Optional<app::AppError> error) {
+                                                                 [&](Optional<AppError> error) {
                 REQUIRE_FALSE(error);
                 processed = true;
             });
@@ -1492,7 +1458,7 @@ TEST_CASE("app: push notifications", "[sync][app]") {
     SECTION("deregister") {
         bool processed;
 
-        app->push_notification_client("gcm").deregister_device(sync_user, [&](Optional<app::AppError> error) {
+        app->push_notification_client("gcm").deregister_device(sync_user, [&](Optional<AppError> error) {
             REQUIRE_FALSE(error);
             processed = true;
         });
@@ -1502,28 +1468,27 @@ TEST_CASE("app: push notifications", "[sync][app]") {
     SECTION("register with unavailable service") {
         bool processed;
 
-        app->push_notification_client("gcm_blah")
-            .register_device("hello", sync_user, [&](Optional<app::AppError> error) {
-                REQUIRE(error);
-                CHECK(error->message == "service not found: 'gcm_blah'");
-                processed = true;
-            });
+        app->push_notification_client("gcm_blah").register_device("hello", sync_user, [&](Optional<AppError> error) {
+            REQUIRE(error);
+            CHECK(error->message == "service not found: 'gcm_blah'");
+            processed = true;
+        });
         CHECK(processed);
     }
 
     SECTION("register with logged out user") {
         bool processed;
 
-        app->log_out([=](util::Optional<AppError> error) {
+        app->log_out([=](Optional<AppError> error) {
             REQUIRE_FALSE(error);
         });
 
-        app->push_notification_client("gcm").register_device("hello", sync_user, [&](Optional<app::AppError> error) {
+        app->push_notification_client("gcm").register_device("hello", sync_user, [&](Optional<AppError> error) {
             REQUIRE(error);
             processed = true;
         });
 
-        app->push_notification_client("gcm").register_device("hello", nullptr, [&](Optional<app::AppError> error) {
+        app->push_notification_client("gcm").register_device("hello", nullptr, [&](Optional<AppError> error) {
             REQUIRE(error);
             processed = true;
         });
@@ -1560,7 +1525,7 @@ TEST_CASE("app: token refresh", "[sync][app][token]") {
          - If the token refresh was successful, the original request will retry and we should expect no error in the
          callback of `find_one`
          */
-        dog_collection.find_one(dog_document, [&](Optional<bson::BsonDocument>, Optional<app::AppError> error) {
+        dog_collection.find_one(dog_document, [&](Optional<bson::BsonDocument>, Optional<AppError> error) {
             REQUIRE_FALSE(error);
         });
     }
@@ -1593,7 +1558,7 @@ TEST_CASE("app: mixed lists with object links", "[sync][app]") {
 
     auto email = std::string("realm_tests_do_autoverify-test@example.com");
     auto password = std::string{"password"};
-    auto creds = app::AppCredentials::username_password(email, password);
+    auto creds = AppCredentials::username_password(email, password);
     auto obj_id = ObjectId::gen();
     auto target_id = ObjectId::gen();
     auto mixed_list_values = AnyVector{
@@ -1604,10 +1569,10 @@ TEST_CASE("app: mixed lists with object links", "[sync][app]") {
     {
         TestSyncManager sync_manager(app_config, {});
         auto app = sync_manager.app();
-        app->provider_client<App::UsernamePasswordProviderClient>().register_email(
-            email, password, [&](Optional<app::AppError> error) {
-                REQUIRE_FALSE(error);
-            });
+        app->provider_client<App::UsernamePasswordProviderClient>().register_email(email, password,
+                                                                                   [&](Optional<AppError> error) {
+                                                                                       REQUIRE_FALSE(error);
+                                                                                   });
         log_in(app, creds);
         SyncTestFile config(app, partition, schema);
         auto realm = Realm::get_shared_realm(config);
@@ -1791,17 +1756,17 @@ TEST_CASE("app: set new embedded object", "[sync][app]") {
     auto dict_obj_id = ObjectId::gen();
     auto email = std::string("realm_tests_do_autoverify-test@example.com");
     auto password = std::string{"password"};
-    auto creds = app::AppCredentials::username_password(email, password);
+    auto creds = AppCredentials::username_password(email, password);
 
     {
         TestSyncManager sync_manager(app_config, {});
         auto app = sync_manager.app();
-        app->provider_client<App::UsernamePasswordProviderClient>().register_email(
-            email, password, [&](Optional<app::AppError> error) {
-                REQUIRE_FALSE(error);
-            });
-        app->log_in_with_credentials(app::AppCredentials::username_password(email, password),
-                                     [&](std::shared_ptr<SyncUser> user, Optional<app::AppError> error) {
+        app->provider_client<App::UsernamePasswordProviderClient>().register_email(email, password,
+                                                                                   [&](Optional<AppError> error) {
+                                                                                       REQUIRE_FALSE(error);
+                                                                                   });
+        app->log_in_with_credentials(AppCredentials::username_password(email, password),
+                                     [&](std::shared_ptr<SyncUser> user, Optional<AppError> error) {
                                          REQUIRE(user);
                                          REQUIRE_FALSE(error);
                                      });
@@ -1920,7 +1885,7 @@ TEST_CASE("app: make distributable client file", "[sync][app]") {
         TestSyncManager sync_manager(TestSyncManager::Config(config), {});
         auto app = sync_manager.app();
         app->log_in_with_credentials(AppCredentials::anonymous(),
-                                     [&](std::shared_ptr<SyncUser> user, Optional<app::AppError> error) {
+                                     [&](std::shared_ptr<SyncUser> user, Optional<AppError> error) {
                                          REQUIRE(!error);
                                          REQUIRE(user);
                                      });
@@ -1974,7 +1939,7 @@ TEST_CASE("app: make distributable client file", "[sync][app]") {
         TestSyncManager sync_manager(TestSyncManager::Config(config), {});
         auto app = sync_manager.app();
         app->log_in_with_credentials(AppCredentials::anonymous(),
-                                     [&](std::shared_ptr<SyncUser> user, Optional<app::AppError> error) {
+                                     [&](std::shared_ptr<SyncUser> user, Optional<AppError> error) {
                                          REQUIRE(!error);
                                          REQUIRE(user);
                                      });
@@ -2116,20 +2081,21 @@ TEST_CASE("app: sync integration", "[sync][app]") {
 
     class HookedTransport : public SynchronousTestTransport {
     public:
-        void send_request_to_server(const Request request, std::function<void(Response)> completion_block) override
+        void send_request_to_server(Request&& request,
+                                    util::UniqueFunction<void(const Response&)>&& completion_block) override
         {
             if (request_hook) {
                 request_hook(request);
             }
-            SynchronousTestTransport::send_request_to_server(request, [&](Response response) {
+            SynchronousTestTransport::send_request_to_server(std::move(request), [&](const Response& response) {
                 if (response_hook) {
-                    response_hook(request, response);
+                    response_hook(request, const_cast<Response&>(response));
                 }
                 completion_block(response);
             });
         }
-        std::function<void(const Request&, Response&)> response_hook;
-        std::function<void(const Request&)> request_hook;
+        util::UniqueFunction<void(Request&, Response&)> response_hook;
+        util::UniqueFunction<void(Request&)> request_hook;
     };
 
     SECTION("Fast clock on client") {
@@ -2163,10 +2129,10 @@ TEST_CASE("app: sync integration", "[sync][app]") {
         // This assumes that we make an http request for the new token while
         // already in the WaitingForAccessToken state.
         bool seen_waiting_for_access_token = false;
-        transport->request_hook = [&](const Request) {
+        transport->request_hook = [&](Request&) {
             auto user = app->current_user();
             REQUIRE(user);
-            for (auto session : user->all_sessions()) {
+            for (auto& session : user->all_sessions()) {
                 // Prior to the fix for #4941, this callback would be called from an infinite loop, always in the
                 // WaitingForAccessToken state.
                 if (session->state() == SyncSession::State::WaitingForAccessToken) {
@@ -2227,10 +2193,10 @@ TEST_CASE("app: sync integration", "[sync][app]") {
             // This assumes that we make an http request for the new token while
             // already in the WaitingForAccessToken state.
             bool seen_waiting_for_access_token = false;
-            transport->request_hook = [&](const Request) {
+            transport->request_hook = [&](Request&) {
                 auto user = app->current_user();
                 REQUIRE(user);
-                for (auto session : user->all_sessions()) {
+                for (auto& session : user->all_sessions()) {
                     if (session->state() == SyncSession::State::WaitingForAccessToken) {
                         REQUIRE(!seen_waiting_for_access_token);
                         seen_waiting_for_access_token = true;
@@ -2248,7 +2214,7 @@ TEST_CASE("app: sync integration", "[sync][app]") {
 
         SECTION("User is logged out if the refresh request is denied") {
             REQUIRE(user->is_logged_in());
-            transport->response_hook = [&](const Request request, Response& response) {
+            transport->response_hook = [&](Request& request, Response& response) {
                 auto user = app->current_user();
                 REQUIRE(user);
                 // simulate the server denying the refresh
@@ -2278,7 +2244,7 @@ TEST_CASE("app: sync integration", "[sync][app]") {
             std::atomic<bool> did_receive_valid_token{false};
             constexpr size_t num_error_responses = 6;
 
-            transport->response_hook = [&](const Request& request, Response& response) {
+            transport->response_hook = [&](Request& request, Response& response) {
                 // simulate the server experiencing an internal server error
                 if (request.url.find("/session") != std::string::npos) {
                     if (response_times.size() >= num_error_responses) {
@@ -2330,10 +2296,10 @@ TEST_CASE("app: sync integration", "[sync][app]") {
             REQUIRE(app_session.admin_api.verify_access_token(user->access_token(), app_session.server_app_id));
 
             // requesting a new access token fails because the refresh token used for this request is revoked
-            user->refresh_custom_data([&](util::Optional<AppError> error) {
+            user->refresh_custom_data([&](Optional<AppError> error) {
                 REQUIRE(error);
                 REQUIRE(error->http_status_code == 401);
-                REQUIRE(error->error_code == app::make_error_code(realm::app::ServiceErrorCode::invalid_session));
+                REQUIRE(error->error_code == make_error_code(ServiceErrorCode::invalid_session));
             });
 
             // Set a bad access token. This will force a request for a new access token when the sync session opens
@@ -2361,7 +2327,7 @@ TEST_CASE("app: sync integration", "[sync][app]") {
                 session->wait_for_upload_completion([&](std::error_code err) {
                     std::lock_guard<std::mutex> lock(mtx);
                     called.store(true);
-                    REQUIRE(err == app::make_error_code(realm::app::ServiceErrorCode::invalid_session));
+                    REQUIRE(err == make_error_code(ServiceErrorCode::invalid_session));
                 });
                 timed_wait_for([&] {
                     return called.load();
@@ -2392,7 +2358,7 @@ TEST_CASE("app: sync integration", "[sync][app]") {
 
             // logging in again doesn't fix things while the account is disabled
             auto error = failed_log_in(app, creds);
-            REQUIRE(error.error_code == app::make_error_code(realm::app::ServiceErrorCode::user_disabled));
+            REQUIRE(error.error_code == make_error_code(ServiceErrorCode::user_disabled));
 
             // admin enables user sessions again which should allow the session to continue
             app_session.admin_api.enable_user_sessions(user->identity(), app_session.server_app_id);
@@ -2433,7 +2399,7 @@ TEST_CASE("app: sync integration", "[sync][app]") {
             REQUIRE(user->is_logged_in());
 
             // new requests for an access token succeed again
-            user->refresh_custom_data([&](util::Optional<AppError> error) {
+            user->refresh_custom_data([&](Optional<AppError> error) {
                 REQUIRE_FALSE(error);
             });
 
@@ -2465,7 +2431,7 @@ TEST_CASE("app: sync integration", "[sync][app]") {
             REQUIRE(anon_user->state() == SyncUser::State::Removed);
 
             // new requests for an access token do not work for anon users
-            anon_user->refresh_custom_data([&](util::Optional<AppError> error) {
+            anon_user->refresh_custom_data([&](Optional<AppError> error) {
                 REQUIRE(error);
                 REQUIRE(error->message ==
                         util::format("Cannot initiate a refresh on user '%1' because the user has been removed",
@@ -2632,7 +2598,7 @@ TEST_CASE("app: custom user data integration tests", "[sync][app]") {
 
         std::shared_ptr<SyncUser> user = log_in(app);
         app->call_function(user, "updateUserData", {bson::BsonDocument({{"favorite_color", "green"}})},
-                           [&](auto error, auto response) {
+                           [&](auto response, auto error) {
                                CHECK(error == none);
                                CHECK(response);
                                CHECK(*response == true);
@@ -2659,10 +2625,10 @@ TEST_CASE("app: jwt login and metadata tests", "[sync][app]") {
 
         bool processed = false;
 
-        std::shared_ptr<SyncUser> user = log_in(app, app::AppCredentials::custom(jwt));
+        std::shared_ptr<SyncUser> user = log_in(app, AppCredentials::custom(jwt));
 
         app->call_function(user, "updateUserData", {bson::BsonDocument({{"name", "Not Foo Bar"}})},
-                           [&](auto error, auto response) {
+                           [&](auto response, auto error) {
                                CHECK(error == none);
                                CHECK(response);
                                CHECK(*response == true);
@@ -2937,7 +2903,8 @@ TEST_CASE("app: custom error handling", "[sync][app][custom_errors]") {
         {
         }
 
-        void send_request_to_server(const Request, std::function<void(const Response)> completion_block) override
+        void send_request_to_server(Request&&,
+                                    util::UniqueFunction<void(const Response&)>&& completion_block) override
         {
             completion_block(Response{0, m_code, std::map<std::string, std::string>(), m_message});
         }
@@ -3020,7 +2987,7 @@ public:
     }
 
 private:
-    void handle_profile(const Request request, std::function<void(Response)> completion_block)
+    void handle_profile(Request& request, util::UniqueFunction<void(const Response&)>& completion_block)
     {
         CHECK(request.method == HttpMethod::get);
         CHECK(request.headers.at("Content-Type") == "application/json;charset=utf-8");
@@ -3039,7 +3006,7 @@ private:
         completion_block(Response{200, 0, {}, response});
     }
 
-    void handle_login(const Request request, std::function<void(Response)> completion_block)
+    void handle_login(Request& request, util::UniqueFunction<void(const Response&)>& completion_block)
     {
         CHECK(request.method == HttpMethod::post);
         CHECK(request.headers.at("Content-Type") == "application/json;charset=utf-8");
@@ -3062,7 +3029,7 @@ private:
         completion_block(Response{200, 0, {}, response});
     }
 
-    void handle_location(const Request request, std::function<void(Response)> completion_block)
+    void handle_location(Request& request, util::UniqueFunction<void(const Response&)>& completion_block)
     {
         CHECK(request.method == HttpMethod::get);
         CHECK(request.timeout_ms == 60000);
@@ -3076,7 +3043,7 @@ private:
         completion_block(Response{200, 0, {}, response});
     }
 
-    void handle_create_api_key(const Request request, std::function<void(Response)> completion_block)
+    void handle_create_api_key(Request& request, util::UniqueFunction<void(const Response&)>& completion_block)
     {
         CHECK(request.method == HttpMethod::post);
         CHECK(request.headers.at("Content-Type") == "application/json;charset=utf-8");
@@ -3090,7 +3057,7 @@ private:
         completion_block(Response{200, 0, {}, response});
     }
 
-    void handle_fetch_api_key(const Request request, std::function<void(Response)> completion_block)
+    void handle_fetch_api_key(Request& request, util::UniqueFunction<void(const Response&)>& completion_block)
     {
         CHECK(request.method == HttpMethod::get);
         CHECK(request.headers.at("Content-Type") == "application/json;charset=utf-8");
@@ -3104,7 +3071,7 @@ private:
         completion_block(Response{200, 0, {}, response});
     }
 
-    void handle_fetch_api_keys(const Request request, std::function<void(Response)> completion_block)
+    void handle_fetch_api_keys(Request& request, util::UniqueFunction<void(const Response&)>& completion_block)
     {
         CHECK(request.method == HttpMethod::get);
         CHECK(request.headers.at("Content-Type") == "application/json;charset=utf-8");
@@ -3120,7 +3087,7 @@ private:
         completion_block(Response{200, 0, {}, nlohmann::json(elements).dump()});
     }
 
-    void handle_token_refresh(const Request request, std::function<void(Response)> completion_block)
+    void handle_token_refresh(Request& request, util::UniqueFunction<void(const Response&)>& completion_block)
     {
         CHECK(request.method == HttpMethod::post);
         CHECK(request.headers.at("Content-Type") == "application/json;charset=utf-8");
@@ -3135,7 +3102,8 @@ private:
     }
 
 public:
-    void send_request_to_server(const Request request, std::function<void(const Response)> completion_block) override
+    void send_request_to_server(Request&& request,
+                                util::UniqueFunction<void(const Response&)>&& completion_block) override
     {
         if (request.url.find("/login") != std::string::npos) {
             handle_login(request, completion_block);
@@ -3325,13 +3293,14 @@ TEST_CASE("app: login_with_credentials unit_tests", "[sync][app]") {
 
     SECTION("login_anonymous bad") {
         struct transport : UnitTestTransport {
-            void send_request_to_server(const Request request, std::function<void(const Response)> completion_block)
+            void send_request_to_server(Request&& request,
+                                        util::UniqueFunction<void(const Response&)>&& completion_block) override
             {
                 if (request.url.find("/login") != std::string::npos) {
                     completion_block({200, 0, {}, user_json(bad_access_token).dump()});
                 }
                 else {
-                    UnitTestTransport::send_request_to_server(request, completion_block);
+                    UnitTestTransport::send_request_to_server(std::move(request), std::move(completion_block));
                 }
             }
         };
@@ -3342,9 +3311,9 @@ TEST_CASE("app: login_with_credentials unit_tests", "[sync][app]") {
         auto error = failed_log_in(app);
         CHECK(error.message == std::string("jwt missing parts"));
         CHECK(error.error_code.message() == "bad token");
-        CHECK(error.error_code.category() == app::json_error_category());
+        CHECK(error.error_code.category() == json_error_category());
         CHECK(error.is_json_error());
-        CHECK(app::JSONErrorCode(error.error_code.value()) == app::JSONErrorCode::bad_token);
+        CHECK(JSONErrorCode(error.error_code.value()) == JSONErrorCode::bad_token);
     }
 }
 
@@ -3360,7 +3329,7 @@ TEST_CASE("app: UserAPIKeyProviderClient unit_tests", "[sync][app]") {
 
     SECTION("create api key") {
         client.create_api_key(UnitTestTransport::api_key_name, logged_in_user,
-                              [&](App::UserAPIKey user_api_key, util::Optional<AppError> error) {
+                              [&](App::UserAPIKey user_api_key, Optional<AppError> error) {
                                   REQUIRE_FALSE(error);
                                   CHECK(user_api_key.disabled == false);
                                   CHECK(user_api_key.id.to_string() == UnitTestTransport::api_key_id);
@@ -3370,18 +3339,17 @@ TEST_CASE("app: UserAPIKeyProviderClient unit_tests", "[sync][app]") {
     }
 
     SECTION("fetch api key") {
-        client.fetch_api_key(obj_id, logged_in_user,
-                             [&](App::UserAPIKey user_api_key, util::Optional<AppError> error) {
-                                 REQUIRE_FALSE(error);
-                                 CHECK(user_api_key.disabled == false);
-                                 CHECK(user_api_key.id.to_string() == UnitTestTransport::api_key_id);
-                                 CHECK(user_api_key.name == UnitTestTransport::api_key_name);
-                             });
+        client.fetch_api_key(obj_id, logged_in_user, [&](App::UserAPIKey user_api_key, Optional<AppError> error) {
+            REQUIRE_FALSE(error);
+            CHECK(user_api_key.disabled == false);
+            CHECK(user_api_key.id.to_string() == UnitTestTransport::api_key_id);
+            CHECK(user_api_key.name == UnitTestTransport::api_key_name);
+        });
     }
 
     SECTION("fetch api keys") {
         client.fetch_api_keys(logged_in_user,
-                              [&](std::vector<App::UserAPIKey> user_api_keys, util::Optional<AppError> error) {
+                              [&](std::vector<App::UserAPIKey> user_api_keys, Optional<AppError> error) {
                                   REQUIRE_FALSE(error);
                                   CHECK(user_api_keys.size() == 2);
                                   for (auto user_api_key : user_api_keys) {
@@ -3401,10 +3369,10 @@ TEST_CASE("app: user_semantics", "[app]") {
     auto app = tsm.app();
 
     const auto login_user_email_pass = [=] {
-        return log_in(app, app::AppCredentials::username_password("bob", "thompson"));
+        return log_in(app, AppCredentials::username_password("bob", "thompson"));
     };
     const auto login_user_anonymous = [=] {
-        return log_in(app, app::AppCredentials::anonymous());
+        return log_in(app, AppCredentials::anonymous());
     };
 
     CHECK(!app->current_user());
@@ -3449,7 +3417,7 @@ TEST_CASE("app: user_semantics", "[app]") {
             user_events_processed++;
         });
 
-        app->log_out([&](auto) {});
+        app->log_out([](auto) {});
         CHECK(user_events_processed == 1);
 
         CHECK(app->current_user()->identity() == user2->identity());
@@ -3471,7 +3439,7 @@ TEST_CASE("app: user_semantics", "[app]") {
         CHECK(app->current_user()->identity() == user2->identity());
         CHECK(user1->identity() == user2->identity());
 
-        app->log_out([&](auto) {});
+        app->log_out([](auto) {});
         CHECK(app->all_users().size() == 0);
 
         CHECK(event_processed == 3);
@@ -3520,7 +3488,7 @@ TEST_CASE("app: user_semantics", "[app]") {
         CHECK(app->current_user()->identity() == user2->identity());
         CHECK(user1->identity() == user2->identity());
 
-        app->log_out([&](auto) {});
+        app->log_out([](auto) {});
         CHECK(app->all_users().size() == 0);
 
         CHECK(event_processed == 0);
@@ -3532,9 +3500,9 @@ struct ErrorCheckingTransport : public GenericNetworkTransport {
         : m_response(r)
     {
     }
-    void send_request_to_server(const Request, std::function<void(const Response)> completion_block) override
+    void send_request_to_server(Request&&, util::UniqueFunction<void(const Response&)>&& completion_block) override
     {
-        completion_block(*m_response);
+        completion_block(Response(*m_response));
     }
 
 private:
@@ -3606,7 +3574,7 @@ TEST_CASE("app: response error handling", "[sync][app]") {
         CHECK(!error.is_json_error());
         CHECK(!error.is_custom_error());
         CHECK(error.is_service_error());
-        CHECK(app::ServiceErrorCode(error.error_code.value()) == app::ServiceErrorCode::mongodb_error);
+        CHECK(ServiceErrorCode(error.error_code.value()) == ServiceErrorCode::mongodb_error);
         CHECK(error.message == std::string("a fake MongoDB error message!"));
         CHECK(error.error_code.message() == "MongoDBError");
         CHECK(error.link_to_server_logs == std::string("http://...whatever the server passes us"));
@@ -3619,7 +3587,7 @@ TEST_CASE("app: response error handling", "[sync][app]") {
         CHECK(error.is_json_error());
         CHECK(!error.is_custom_error());
         CHECK(!error.is_service_error());
-        CHECK(app::JSONErrorCode(error.error_code.value()) == app::JSONErrorCode::malformed_json);
+        CHECK(JSONErrorCode(error.error_code.value()) == JSONErrorCode::malformed_json);
         CHECK(error.message ==
               std::string("[json.exception.parse_error.101] parse error at line 1, column 2: syntax error "
                           "while parsing value - invalid literal; last read: 'th'"));
@@ -3637,11 +3605,11 @@ TEST_CASE("app: switch user", "[sync][app]") {
         CHECK(app->sync_manager()->all_users().size() == 0);
 
         // Log in user 1
-        auto user_a = log_in(app, app::AppCredentials::username_password("test@10gen.com", "password"));
+        auto user_a = log_in(app, AppCredentials::username_password("test@10gen.com", "password"));
         CHECK(app->sync_manager()->get_current_user() == user_a);
 
         // Log in user 2
-        auto user_b = log_in(app, app::AppCredentials::username_password("test2@10gen.com", "password"));
+        auto user_b = log_in(app, AppCredentials::username_password("test2@10gen.com", "password"));
         CHECK(app->sync_manager()->get_current_user() == user_b);
 
         CHECK(app->sync_manager()->all_users().size() == 2);
@@ -3663,10 +3631,10 @@ TEST_CASE("app: switch user", "[sync][app]") {
         CHECK(app->sync_manager()->all_users().size() == 0);
 
         // Log in user 1
-        auto user_a = log_in(app, app::AppCredentials::username_password("test@10gen.com", "password"));
+        auto user_a = log_in(app, AppCredentials::username_password("test@10gen.com", "password"));
         CHECK(app->sync_manager()->get_current_user() == user_a);
 
-        app->log_out([&](Optional<app::AppError> error) {
+        app->log_out([&](Optional<AppError> error) {
             REQUIRE_FALSE(error);
         });
 
@@ -3674,7 +3642,7 @@ TEST_CASE("app: switch user", "[sync][app]") {
         CHECK(user_a->state() == SyncUser::State::LoggedOut);
 
         // Log in user 2
-        auto user_b = log_in(app, app::AppCredentials::username_password("test2@10gen.com", "password"));
+        auto user_b = log_in(app, AppCredentials::username_password("test2@10gen.com", "password"));
         CHECK(app->sync_manager()->get_current_user() == user_b);
         CHECK(app->sync_manager()->all_users().size() == 2);
 
@@ -3694,14 +3662,14 @@ TEST_CASE("app: remove anonymous user", "[sync][app]") {
         auto user_a = log_in(app);
         CHECK(user_a->state() == SyncUser::State::LoggedIn);
 
-        app->log_out(user_a, [&](Optional<app::AppError> error) {
+        app->log_out(user_a, [&](Optional<AppError> error) {
             REQUIRE_FALSE(error);
             // a logged out anon user will be marked as Removed, not LoggedOut
             CHECK(user_a->state() == SyncUser::State::Removed);
         });
         CHECK(app->sync_manager()->all_users().empty());
 
-        app->remove_user(user_a, [&](Optional<app::AppError> error) {
+        app->remove_user(user_a, [&](Optional<AppError> error) {
             CHECK(error->message == "User has already been removed");
             CHECK(app->sync_manager()->all_users().size() == 0);
         });
@@ -3712,7 +3680,7 @@ TEST_CASE("app: remove anonymous user", "[sync][app]") {
         CHECK(user_b->state() == SyncUser::State::LoggedIn);
         CHECK(app->sync_manager()->all_users().size() == 1);
 
-        app->remove_user(user_b, [&](Optional<app::AppError> error) {
+        app->remove_user(user_b, [&](Optional<AppError> error) {
             REQUIRE_FALSE(error);
             CHECK(app->sync_manager()->all_users().size() == 0);
         });
@@ -3733,23 +3701,23 @@ TEST_CASE("app: remove user with credentials", "[sync][app]") {
         CHECK(app->sync_manager()->all_users().size() == 0);
         CHECK(app->sync_manager()->get_current_user() == nullptr);
 
-        auto user = log_in(app, app::AppCredentials::username_password("email", "pass"));
+        auto user = log_in(app, AppCredentials::username_password("email", "pass"));
 
         CHECK(user->state() == SyncUser::State::LoggedIn);
 
-        app->log_out(user, [&](Optional<app::AppError> error) {
+        app->log_out(user, [&](Optional<AppError> error) {
             REQUIRE_FALSE(error);
         });
 
         CHECK(user->state() == SyncUser::State::LoggedOut);
 
-        app->remove_user(user, [&](Optional<app::AppError> error) {
+        app->remove_user(user, [&](Optional<AppError> error) {
             REQUIRE_FALSE(error);
         });
         CHECK(app->sync_manager()->all_users().size() == 0);
 
-        util::Optional<app::AppError> error;
-        app->remove_user(user, [&](Optional<app::AppError> err) {
+        Optional<AppError> error;
+        app->remove_user(user, [&](Optional<AppError> err) {
             error = err;
         });
         CHECK(error->error_code.value() > 0);
@@ -3765,111 +3733,114 @@ TEST_CASE("app: link_user", "[sync][app]") {
     auto email = util::format("realm_tests_do_autoverify%1@%2.com", random_string(10), random_string(10));
     auto password = random_string(10);
 
-    auto custom_credentials = app::AppCredentials::facebook("a_token");
-    auto email_pass_credentials = app::AppCredentials::username_password(email, password);
+    auto custom_credentials = AppCredentials::facebook("a_token");
+    auto email_pass_credentials = AppCredentials::username_password(email, password);
 
     auto sync_user = log_in(app, email_pass_credentials);
     CHECK(sync_user->provider_type() == IdentityProviderUsernamePassword);
 
     SECTION("successful link") {
         bool processed = false;
-        app->link_user(sync_user, custom_credentials,
-                       [&](std::shared_ptr<SyncUser> user, Optional<app::AppError> error) {
-                           REQUIRE_FALSE(error);
-                           REQUIRE(user);
-                           CHECK(user->identity() == sync_user->identity());
-                           processed = true;
-                       });
+        app->link_user(sync_user, custom_credentials, [&](std::shared_ptr<SyncUser> user, Optional<AppError> error) {
+            REQUIRE_FALSE(error);
+            REQUIRE(user);
+            CHECK(user->identity() == sync_user->identity());
+            processed = true;
+        });
         CHECK(processed);
     }
 
     SECTION("link_user should fail when logged out") {
-        app->log_out([&](Optional<app::AppError> error) {
+        app->log_out([&](Optional<AppError> error) {
             REQUIRE_FALSE(error);
         });
 
         bool processed = false;
-        app->link_user(sync_user, custom_credentials,
-                       [&](std::shared_ptr<SyncUser> user, Optional<app::AppError> error) {
-                           CHECK(error->message == "The specified user is not logged in");
-                           CHECK(!user);
-                           processed = true;
-                       });
+        app->link_user(sync_user, custom_credentials, [&](std::shared_ptr<SyncUser> user, Optional<AppError> error) {
+            CHECK(error->message == "The specified user is not logged in");
+            CHECK(!user);
+            processed = true;
+        });
         CHECK(processed);
     }
 }
 
 TEST_CASE("app: auth providers", "[sync][app]") {
     SECTION("auth providers facebook") {
-        auto credentials = app::AppCredentials::facebook("a_token");
+        auto credentials = AppCredentials::facebook("a_token");
         CHECK(credentials.provider() == AuthProvider::FACEBOOK);
         CHECK(credentials.provider_as_string() == IdentityProviderFacebook);
-        CHECK(credentials.serialize_as_json() == "{\"accessToken\":\"a_token\",\"provider\":\"oauth2-facebook\"}");
+        CHECK(credentials.serialize_as_bson() ==
+              bson::BsonDocument{{"provider", "oauth2-facebook"}, {"accessToken", "a_token"}});
     }
 
     SECTION("auth providers anonymous") {
-        auto credentials = app::AppCredentials::anonymous();
+        auto credentials = AppCredentials::anonymous();
         CHECK(credentials.provider() == AuthProvider::ANONYMOUS);
         CHECK(credentials.provider_as_string() == IdentityProviderAnonymous);
-        CHECK(credentials.serialize_as_json() == "{\"provider\":\"anon-user\"}");
+        CHECK(credentials.serialize_as_bson() == bson::BsonDocument{{"provider", "anon-user"}});
     }
 
     SECTION("auth providers google authCode") {
-        auto credentials = app::AppCredentials::google(AuthCode("a_token"));
+        auto credentials = AppCredentials::google(AuthCode("a_token"));
         CHECK(credentials.provider() == AuthProvider::GOOGLE);
         CHECK(credentials.provider_as_string() == IdentityProviderGoogle);
-        CHECK(credentials.serialize_as_json() == "{\"authCode\":\"a_token\",\"provider\":\"oauth2-google\"}");
+        CHECK(credentials.serialize_as_bson() ==
+              bson::BsonDocument{{"provider", "oauth2-google"}, {"authCode", "a_token"}});
     }
 
     SECTION("auth providers google idToken") {
-        auto credentials = app::AppCredentials::google(IdToken("a_token"));
+        auto credentials = AppCredentials::google(IdToken("a_token"));
         CHECK(credentials.provider() == AuthProvider::GOOGLE);
         CHECK(credentials.provider_as_string() == IdentityProviderGoogle);
-        CHECK(credentials.serialize_as_json() == "{\"id_token\":\"a_token\",\"provider\":\"oauth2-google\"}");
+        CHECK(credentials.serialize_as_bson() ==
+              bson::BsonDocument{{"provider", "oauth2-google"}, {"id_token", "a_token"}});
     }
 
     SECTION("auth providers apple") {
-        auto credentials = app::AppCredentials::apple("a_token");
+        auto credentials = AppCredentials::apple("a_token");
         CHECK(credentials.provider() == AuthProvider::APPLE);
         CHECK(credentials.provider_as_string() == IdentityProviderApple);
-        CHECK(credentials.serialize_as_json() == "{\"id_token\":\"a_token\",\"provider\":\"oauth2-apple\"}");
+        CHECK(credentials.serialize_as_bson() ==
+              bson::BsonDocument{{"provider", "oauth2-apple"}, {"id_token", "a_token"}});
     }
 
     SECTION("auth providers custom") {
-        auto credentials = app::AppCredentials::custom("a_token");
+        auto credentials = AppCredentials::custom("a_token");
         CHECK(credentials.provider() == AuthProvider::CUSTOM);
         CHECK(credentials.provider_as_string() == IdentityProviderCustom);
-        CHECK(credentials.serialize_as_json() == "{\"provider\":\"custom-token\",\"token\":\"a_token\"}");
+        CHECK(credentials.serialize_as_bson() ==
+              bson::BsonDocument{{"provider", "custom-token"}, {"token", "a_token"}});
     }
 
     SECTION("auth providers username password") {
-        auto credentials = app::AppCredentials::username_password("user", "pass");
+        auto credentials = AppCredentials::username_password("user", "pass");
         CHECK(credentials.provider() == AuthProvider::USERNAME_PASSWORD);
         CHECK(credentials.provider_as_string() == IdentityProviderUsernamePassword);
-        CHECK(credentials.serialize_as_json() ==
-              "{\"password\":\"pass\",\"provider\":\"local-userpass\",\"username\":\"user\"}");
+        CHECK(credentials.serialize_as_bson() ==
+              bson::BsonDocument{{"provider", "local-userpass"}, {"username", "user"}, {"password", "pass"}});
     }
 
     SECTION("auth providers function") {
         bson::BsonDocument function_params{{"name", "mongo"}};
-        auto credentials = app::AppCredentials::function(function_params);
+        auto credentials = AppCredentials::function(function_params);
         CHECK(credentials.provider() == AuthProvider::FUNCTION);
         CHECK(credentials.provider_as_string() == IdentityProviderFunction);
-        CHECK(credentials.serialize_as_json() == "{\"name\":\"mongo\"}");
+        CHECK(credentials.serialize_as_bson() == bson::BsonDocument{{"name", "mongo"}});
     }
 
     SECTION("auth providers user api key") {
-        auto credentials = app::AppCredentials::user_api_key("a key");
+        auto credentials = AppCredentials::user_api_key("a key");
         CHECK(credentials.provider() == AuthProvider::USER_API_KEY);
         CHECK(credentials.provider_as_string() == IdentityProviderUserAPIKey);
-        CHECK(credentials.serialize_as_json() == "{\"key\":\"a key\",\"provider\":\"api-key\"}");
+        CHECK(credentials.serialize_as_bson() == bson::BsonDocument{{"provider", "api-key"}, {"key", "a key"}});
     }
 
     SECTION("auth providers server api key") {
-        auto credentials = app::AppCredentials::server_api_key("a key");
+        auto credentials = AppCredentials::server_api_key("a key");
         CHECK(credentials.provider() == AuthProvider::SERVER_API_KEY);
         CHECK(credentials.provider_as_string() == IdentityProviderServerAPIKey);
-        CHECK(credentials.serialize_as_json() == "{\"key\":\"a key\",\"provider\":\"api-key\"}");
+        CHECK(credentials.serialize_as_bson() == bson::BsonDocument{{"provider", "api-key"}, {"key", "a key"}});
     }
 }
 
@@ -3886,7 +3857,8 @@ TEST_CASE("app: refresh access token unit tests", "[sync][app]") {
         static bool session_route_hit = false;
 
         struct transport : UnitTestTransport {
-            void send_request_to_server(const Request request, std::function<void(const Response)> completion_block)
+            void send_request_to_server(Request&& request,
+                                        util::UniqueFunction<void(const Response&)>&& completion_block) override
             {
                 if (request.url.find("/session") != std::string::npos) {
                     session_route_hit = true;
@@ -3894,7 +3866,7 @@ TEST_CASE("app: refresh access token unit tests", "[sync][app]") {
                     completion_block({200, 0, {}, json.dump()});
                 }
                 else {
-                    UnitTestTransport::send_request_to_server(request, completion_block);
+                    UnitTestTransport::send_request_to_server(std::move(request), std::move(completion_block));
                 }
             }
         };
@@ -3916,7 +3888,8 @@ TEST_CASE("app: refresh access token unit tests", "[sync][app]") {
         static bool session_route_hit = false;
 
         struct transport : UnitTestTransport {
-            void send_request_to_server(const Request request, std::function<void(const Response)> completion_block)
+            void send_request_to_server(Request&& request,
+                                        util::UniqueFunction<void(const Response&)>&& completion_block) override
             {
                 if (request.url.find("/session") != std::string::npos) {
                     session_route_hit = true;
@@ -3924,7 +3897,7 @@ TEST_CASE("app: refresh access token unit tests", "[sync][app]") {
                     completion_block({200, 0, {}, json.dump()});
                 }
                 else {
-                    UnitTestTransport::send_request_to_server(request, completion_block);
+                    UnitTestTransport::send_request_to_server(std::move(request), std::move(completion_block));
                 }
             }
         };
@@ -3958,8 +3931,8 @@ TEST_CASE("app: refresh access token unit tests", "[sync][app]") {
                 bool get_profile_2_hit = false;
                 bool refresh_hit = false;
 
-                void send_request_to_server(const Request request,
-                                            std::function<void(const Response)> completion_block)
+                void send_request_to_server(Request&& request,
+                                            util::UniqueFunction<void(const Response&)>&& completion_block) override
                 {
                     if (request.url.find("/login") != std::string::npos) {
                         login_hit = true;
@@ -4022,14 +3995,14 @@ public:
     {
     }
 
-    void add_work_item(Response response, std::function<void(const Response)> completion_block)
+    void add_work_item(Response response, util::UniqueFunction<void(const Response&)> completion_block)
     {
         std::lock_guard<std::mutex> lk(transport_work_mutex);
         transport_work.push_front(ResponseWorkItem{std::move(response), std::move(completion_block)});
         transport_work_cond.notify_one();
     }
 
-    void add_work_item(std::function<void()> cb)
+    void add_work_item(util::UniqueFunction<void()> cb)
     {
         std::lock_guard<std::mutex> lk(transport_work_mutex);
         transport_work.push_front(std::move(cb));
@@ -4048,7 +4021,7 @@ public:
 private:
     struct ResponseWorkItem {
         Response response;
-        std::function<void(const Response)> completion_block;
+        util::UniqueFunction<void(const Response&)> completion_block;
     };
 
     void worker_routine()
@@ -4067,7 +4040,7 @@ private:
                 mpark::visit(util::overload{[](ResponseWorkItem& work_item) {
                                                 work_item.completion_block(std::move(work_item.response));
                                             },
-                                            [](std::function<void()>& cb) {
+                                            [](util::UniqueFunction<void()>& cb) {
                                                 cb();
                                             }},
                              work_item);
@@ -4085,7 +4058,7 @@ private:
     std::mutex transport_work_mutex;
     std::condition_variable transport_work_cond;
     bool test_complete = false;
-    std::list<mpark::variant<ResponseWorkItem, std::function<void()>>> transport_work;
+    std::list<mpark::variant<ResponseWorkItem, util::UniqueFunction<void()>>> transport_work;
     JoiningThread transport_thread;
 };
 
@@ -4128,8 +4101,8 @@ TEST_CASE("app: app destroyed during token refresh", "[sync][app]") {
         {
         }
 
-        void send_request_to_server(const Request request,
-                                    std::function<void(const Response)> completion_block) override
+        void send_request_to_server(Request&& request,
+                                    util::UniqueFunction<void(const Response&)>&& completion_block) override
 
         {
             std::cerr << request.url << std::endl;
@@ -4198,7 +4171,7 @@ TEST_CASE("app: app destroyed during token refresh", "[sync][app]") {
         std::mutex mutex;
         std::shared_ptr<SyncUser> cur_user;
         app->log_in_with_credentials(AppCredentials::anonymous(),
-                                     [&](std::shared_ptr<SyncUser> user, Optional<app::AppError> error) {
+                                     [&](std::shared_ptr<SyncUser> user, Optional<AppError> error) {
                                          std::lock_guard lock(mutex);
                                          CHECK(user);
                                          REQUIRE_FALSE(error);
@@ -4244,8 +4217,8 @@ TEST_CASE("app: metadata is persisted between sessions", "[sync][app]") {
     static const auto test_ws_hostname = "wsproto://host:1234";
 
     struct transport : UnitTestTransport {
-        void send_request_to_server(const Request request,
-                                    std::function<void(const Response)> completion_block) override
+        void send_request_to_server(Request&& request,
+                                    util::UniqueFunction<void(const Response&)>&& completion_block) override
         {
             if (request.url.find("/location") != std::string::npos) {
                 CHECK(request.method == HttpMethod::get);
@@ -4262,7 +4235,7 @@ TEST_CASE("app: metadata is persisted between sessions", "[sync][app]") {
                 REQUIRE(request.url.rfind(test_hostname, 0) != std::string::npos);
             }
             else {
-                UnitTestTransport::send_request_to_server(request, completion_block);
+                UnitTestTransport::send_request_to_server(std::move(request), std::move(completion_block));
             }
         }
     };

--- a/test/object-store/sync/client_reset.cpp
+++ b/test/object-store/sync/client_reset.cpp
@@ -169,8 +169,8 @@ TEST_CASE("sync: client reset", "[client reset]") {
         // There is a race in the test code of the sync test server where somehow the
         // remote Realm is also reset sometimes. We ignore it as it shouldn't affect the result.
     };
-    auto make_reset = [&](Realm::Config config_local,
-                          Realm::Config config_remote) -> std::unique_ptr<reset_utils::TestClientReset> {
+    auto make_reset = [&](const Realm::Config& config_local,
+                          const Realm::Config& config_remote) -> std::unique_ptr<reset_utils::TestClientReset> {
         return reset_utils::make_test_server_client_reset(config_local, config_remote, sync_manager);
     };
 #endif

--- a/test/object-store/transaction_log_parsing.cpp
+++ b/test/object-store/transaction_log_parsing.cpp
@@ -2102,7 +2102,7 @@ TEST_CASE("DeepChangeChecker singular links", "[notifications]") {
         }
 
         SECTION("link chains are tracked for column: " + column_name) {
-            auto verify_changes_for = [&](auto& checker, std::function<bool(size_t)> pred) {
+            auto verify_changes_for = [&](auto& checker, util::FunctionRef<bool(size_t)> pred) {
                 // Check in random orders to make sure that the caching doesn't affect
                 // the results
                 std::vector<size_t> indices(20);

--- a/test/object-store/util/baas_admin_api.cpp
+++ b/test/object-store/util/baas_admin_api.cpp
@@ -68,7 +68,7 @@ std::string property_type_to_bson_type_str(PropertyType type)
 
 class BaasRuleBuilder {
 public:
-    using IncludePropCond = std::function<bool(const Property&)>;
+    using IncludePropCond = util::UniqueFunction<bool(const Property&)>;
     BaasRuleBuilder(const Schema& schema, const Property& partition_key, const std::string& service_name,
                     const std::string& db_name, IncludePropCond include_prop)
         : m_schema(schema)
@@ -88,7 +88,7 @@ private:
     const Property& m_partition_key;
     const std::string& m_mongo_service_name;
     const std::string& m_mongo_db_name;
-    std::function<bool(const Property&)> m_include_prop;
+    util::UniqueFunction<bool(const Property&)> m_include_prop;
     nlohmann::json m_relationships;
     std::vector<std::string> m_current_path;
 };
@@ -264,7 +264,7 @@ size_t curl_header_cb(char* buffer, size_t size, size_t nitems, std::map<std::st
 
 } // namespace
 
-app::Response do_http_request(const app::Request& request)
+app::Response do_http_request(app::Request&& request)
 {
     CurlGlobalGuard curl_global_guard;
     auto curl = curl_easy_init();
@@ -346,8 +346,7 @@ app::Response AdminAPIEndpoint::do_request(app::Request request) const
     request.headers["Content-Type"] = "application/json;charset=utf-8";
     request.headers["Accept"] = "application/json";
     request.headers["Authorization"] = util::format("Bearer %1", m_access_token);
-    auto resp = do_http_request(request);
-    return resp;
+    return do_http_request(std::move(request));
 }
 
 app::Response AdminAPIEndpoint::get() const
@@ -439,7 +438,7 @@ AdminAPISession AdminAPISession::login(const std::string& base_url, const std::s
         },
         login_req_body.dump(),
     };
-    auto login_resp = do_http_request(auth_req);
+    auto login_resp = do_http_request(std::move(auth_req));
     REALM_ASSERT(login_resp.http_status_code == 200);
     auto login_resp_body = nlohmann::json::parse(login_resp.body);
 

--- a/test/object-store/util/baas_admin_api.hpp
+++ b/test/object-store/util/baas_admin_api.hpp
@@ -29,7 +29,7 @@
 
 #if REALM_ENABLE_AUTH_TESTS
 namespace realm {
-app::Response do_http_request(const app::Request& request);
+app::Response do_http_request(app::Request&& request);
 
 class AdminAPIEndpoint {
 public:
@@ -171,10 +171,10 @@ AppSession create_app(const AppCreateConfig& config);
 
 class SynchronousTestTransport : public app::GenericNetworkTransport {
 public:
-    void send_request_to_server(const app::Request request,
-                                std::function<void(const app::Response)> completion_block) override
+    void send_request_to_server(app::Request&& request,
+                                util::UniqueFunction<void(const app::Response&)>&& completion) override
     {
-        completion_block(do_http_request(request));
+        completion(do_http_request(std::move(request)));
     }
 };
 

--- a/test/object-store/util/event_loop.cpp
+++ b/test/object-store/util/event_loop.cpp
@@ -73,10 +73,10 @@ struct EventLoop::Impl {
     static std::unique_ptr<Impl> main();
 
     // Run the event loop until the given return predicate returns true
-    void run_until(std::function<bool()> predicate);
+    void run_until(util::FunctionRef<bool()> predicate);
 
     // Schedule execution of the given function on the event loop.
-    void perform(std::function<void()>);
+    void perform(util::UniqueFunction<void()>);
 
     ~Impl();
 
@@ -84,7 +84,7 @@ private:
 #if REALM_USE_UV
     Impl(uv_loop_t* loop);
 
-    std::vector<std::function<void()>> m_pending_work;
+    std::vector<util::UniqueFunction<void()>> m_pending_work;
     std::mutex m_mutex;
     uv_loop_t* m_loop;
     uv_async_t m_perform_work;
@@ -111,12 +111,12 @@ EventLoop::EventLoop(std::unique_ptr<Impl> impl)
 
 EventLoop::~EventLoop() = default;
 
-void EventLoop::run_until(std::function<bool()> predicate)
+void EventLoop::run_until(util::FunctionRef<bool()> predicate)
 {
     return m_impl->run_until(std::move(predicate));
 }
 
-void EventLoop::perform(std::function<void()> function)
+void EventLoop::perform(util::UniqueFunction<void()> function)
 {
     return m_impl->perform(std::move(function));
 }
@@ -138,7 +138,7 @@ EventLoop::Impl::Impl(uv_loop_t* loop)
 {
     m_perform_work.data = this;
     uv_async_init(uv_default_loop(), &m_perform_work, [](uv_async_t* handle) {
-        std::vector<std::function<void()>> pending_work;
+        std::vector<util::UniqueFunction<void()>> pending_work;
         {
             Impl& self = *static_cast<Impl*>(handle->data);
             std::lock_guard<std::mutex> lock(self.m_mutex);
@@ -171,7 +171,7 @@ struct IdleHandler {
     }
 };
 
-void EventLoop::Impl::run_until(std::function<bool()> predicate)
+void EventLoop::Impl::run_until(util::FunctionRef<bool()> predicate)
 {
     if (predicate())
         return;
@@ -180,7 +180,7 @@ void EventLoop::Impl::run_until(std::function<bool()> predicate)
     observer.idle->data = &predicate;
 
     uv_idle_start(observer.idle, [](uv_idle_t* handle) {
-        auto& predicate = *static_cast<std::function<bool()>*>(handle->data);
+        auto& predicate = *static_cast<util::FunctionRef<bool()>*>(handle->data);
         if (predicate()) {
             uv_stop(handle->loop);
         }
@@ -190,7 +190,7 @@ void EventLoop::Impl::run_until(std::function<bool()> predicate)
     uv_idle_stop(observer.idle);
 }
 
-void EventLoop::Impl::perform(std::function<void()> f)
+void EventLoop::Impl::perform(util::UniqueFunction<void()> f)
 {
     {
         std::lock_guard<std::mutex> lock(m_mutex);
@@ -213,12 +213,12 @@ std::unique_ptr<EventLoop::Impl> EventLoop::Impl::main()
 
 EventLoop::Impl::~Impl() = default;
 
-void EventLoop::Impl::run_until(std::function<bool()> predicate)
+void EventLoop::Impl::run_until(util::FunctionRef<bool()> predicate)
 {
     REALM_ASSERT(m_loop.get() == CFRunLoopGetCurrent());
 
     auto callback = [](CFRunLoopObserverRef, CFRunLoopActivity, void* info) {
-        if ((*static_cast<std::function<bool()>*>(info))()) {
+        if ((*static_cast<util::FunctionRef<bool()>*>(info))()) {
             CFRunLoopStop(CFRunLoopGetCurrent());
         }
     };
@@ -238,8 +238,9 @@ void EventLoop::Impl::run_until(std::function<bool()> predicate)
     CFRunLoopRemoveObserver(CFRunLoopGetCurrent(), observer.get(), kCFRunLoopCommonModes);
 }
 
-void EventLoop::Impl::perform(std::function<void()> f)
+void EventLoop::Impl::perform(util::UniqueFunction<void()> func)
 {
+    __block auto f = std::move(func);
     CFRunLoopPerformBlock(m_loop.get(), kCFRunLoopDefaultMode, ^{
       f();
     });
@@ -257,11 +258,11 @@ std::unique_ptr<EventLoop::Impl> EventLoop::Impl::main()
     return nullptr;
 }
 EventLoop::Impl::~Impl() = default;
-void EventLoop::Impl::run_until(std::function<bool()>)
+void EventLoop::Impl::run_until(util::FunctionRef<bool()>)
 {
     printf("WARNING: there is no event loop implementation and nothing is happening.\n");
 }
-void EventLoop::Impl::perform(std::function<void()>)
+void EventLoop::Impl::perform(util::UniqueFunction<void()>)
 {
     printf("WARNING: there is no event loop implementation and nothing is happening.\n");
 }

--- a/test/object-store/util/event_loop.hpp
+++ b/test/object-store/util/event_loop.hpp
@@ -19,6 +19,8 @@
 #ifndef REALM_OS_TESTS_UTIL_EVENT_LOOP_HPP
 #define REALM_OS_TESTS_UTIL_EVENT_LOOP_HPP
 
+#include <realm/util/function_ref.hpp>
+
 #include <functional>
 #include <memory>
 
@@ -33,10 +35,10 @@ struct EventLoop {
     static EventLoop& main();
 
     // Run the event loop until the given return predicate returns true
-    void run_until(std::function<bool()> predicate);
+    void run_until(util::FunctionRef<bool()> predicate);
 
     // Schedule execution of the given function on the event loop.
-    void perform(std::function<void()>);
+    void perform(util::UniqueFunction<void()>);
 
     EventLoop(EventLoop&&) = default;
     EventLoop& operator=(EventLoop&&) = default;

--- a/test/object-store/util/test_file.cpp
+++ b/test/object-store/util/test_file.cpp
@@ -245,7 +245,8 @@ std::string SyncServer::url_for_realm(StringData realm_name) const
     return util::format("%1/%2", m_url, realm_name);
 }
 
-static std::error_code wait_for_session(Realm& realm, void (SyncSession::*fn)(std::function<void(std::error_code)>))
+static std::error_code wait_for_session(Realm& realm,
+                                        void (SyncSession::*fn)(util::UniqueFunction<void(std::error_code)>&&))
 {
     std::condition_variable cv;
     std::mutex wait_mutex;

--- a/test/object-store/util/test_file.hpp
+++ b/test/object-store/util/test_file.hpp
@@ -213,19 +213,21 @@ struct TestSyncManager {
 
     // Capture the token refresh callback so that we can invoke it later with
     // the desired result
-    std::function<void(realm::app::Response)> network_callback;
+    realm::util::UniqueFunction<void(const realm::app::Response&)> network_callback;
     struct Transport : realm::app::GenericNetworkTransport {
-        Transport(std::function<void(realm::app::Response)>* network_callback)
+        Transport(realm::util::UniqueFunction<void(const realm::app::Response&)>* network_callback)
             : network_callback(network_callback)
         {
         }
 
-        void send_request_to_server(realm::app::Request, std::function<void(realm::app::Response)> completion_block)
+        void send_request_to_server(
+            realm::app::Request&&,
+            realm::util::UniqueFunction<void(const realm::app::Response&)>&& completion_block) override
         {
-            *network_callback = completion_block;
+            *network_callback = std::move(completion_block);
         }
 
-        std::function<void(realm::app::Response)>* network_callback;
+        realm::util::UniqueFunction<void(const realm::app::Response&)>* network_callback;
     };
     std::shared_ptr<realm::app::GenericNetworkTransport> transport = std::make_shared<Transport>(&network_callback);
 

--- a/test/object-store/util/test_utils.cpp
+++ b/test/object-store/util/test_utils.cpp
@@ -62,7 +62,7 @@ std::vector<char> make_test_encryption_key(const char start)
 // FIXME: Catch2 limitation on old compilers (currently our android CI)
 // https://github.com/catchorg/Catch2/blob/master/docs/limitations.md#clangg----skipping-leaf-sections-after-an-exception
 void catch2_ensure_section_run_workaround(bool did_run_a_section, std::string section_name,
-                                          std::function<void()> func)
+                                          util::FunctionRef<void()> func)
 {
     if (did_run_a_section) {
         func();

--- a/test/object-store/util/test_utils.hpp
+++ b/test/object-store/util/test_utils.hpp
@@ -32,7 +32,7 @@ bool create_dummy_realm(std::string path);
 void reset_test_directory(const std::string& base_path);
 std::vector<char> make_test_encryption_key(const char start = 0);
 void catch2_ensure_section_run_workaround(bool did_run_a_section, std::string section_name,
-                                          std::function<void()> func);
+                                          util::FunctionRef<void()> func);
 
 std::string encode_fake_jwt(const std::string& in, util::Optional<int64_t> exp = {},
                             util::Optional<int64_t> iat = {});

--- a/test/test_all.cpp
+++ b/test/test_all.cpp
@@ -219,7 +219,7 @@ void set_random_seed()
 
 class AggressiveGovernor : public util::PageReclaimGovernor {
 public:
-    std::function<int64_t()> current_target_getter(size_t) override
+    util::UniqueFunction<int64_t()> current_target_getter(size_t) override
     {
         return []() { return 4096; };
     }

--- a/test/test_dictionary.cpp
+++ b/test/test_dictionary.cpp
@@ -649,7 +649,7 @@ public:
     }
 
     std::map<std::string, Mixed> the_map;
-    std::function<int64_t(void)> rnd = std::mt19937(unit_test_random_seed);
+    util::UniqueFunction<int64_t(void)> rnd = std::mt19937(unit_test_random_seed);
 };
 
 NONCONCURRENT_TEST(Dictionary_HashRandomOpsTransaction)

--- a/test/test_encrypt_transform.cpp
+++ b/test/test_encrypt_transform.cpp
@@ -141,7 +141,7 @@ TEST_IF(EncryptTransform_ServerHistory, false)
 
         ClientServerFixture::Config server_config;
         server_config.server_encryption_key = encryption_key1;
-        ClientServerFixture fixture{dir, test_context, server_config};
+        ClientServerFixture fixture{dir, test_context, std::move(server_config)};
         fixture.start();
 
         Session reference_session = fixture.make_session(reference_sg);

--- a/test/test_lang_bind_helper.cpp
+++ b/test/test_lang_bind_helper.cpp
@@ -5830,11 +5830,11 @@ TEST(LangBindHelper_RemoveObject)
 TEST(LangBindHelper_callWithLock)
 {
     SHARED_GROUP_TEST_PATH(path);
-    DB::CallbackWithLock callback = [&](const std::string& realm_path) {
+    auto callback = [&](const std::string& realm_path) {
         CHECK(realm_path.compare(path) == 0);
     };
 
-    DB::CallbackWithLock callback_not_called = [&](const std::string&) {
+    auto callback_not_called = [&](const std::string&) {
         CHECK(false);
     };
 

--- a/test/test_metrics.cpp
+++ b/test/test_metrics.cpp
@@ -983,7 +983,7 @@ public:
         has_run_twice = will_run.get_future();
     }
 
-    std::function<int64_t()> current_target_getter(size_t) override
+    util::UniqueFunction<int64_t()> current_target_getter(size_t) override
     {
         return []() { return realm::util::PageReclaimGovernor::no_match; };
     }

--- a/test/test_shared.cpp
+++ b/test/test_shared.cpp
@@ -3086,7 +3086,7 @@ NONCONCURRENT_TEST(SharedGroupOptions_tmp_dir)
 
     // Should use the specified temp dir.
     const std::string test_dir2 = "/test2-temp";
-    DBOptions options2(DBOptions::Durability::Full, nullptr, true, std::function<void(int, int)>(), test_dir2);
+    DBOptions options2(DBOptions::Durability::Full, nullptr, true, nullptr, test_dir2);
     CHECK(options2.temp_dir.compare(test_dir2) == 0);
 
     DBOptions::set_sys_tmp_dir(initial_system_dir);

--- a/test/test_sync.cpp
+++ b/test/test_sync.cpp
@@ -2258,7 +2258,7 @@ void test_realm_deletion(unit_test::TestContext& test_context, bool disable_stat
     }
 
     ClientServerFixture::Config config;
-    ClientServerFixture fixture(server_dir, test_context, config);
+    ClientServerFixture fixture(server_dir, test_context, std::move(config));
 
     std::string server_path = "/test";
     std::string server_realm_file = fixture.map_virtual_to_real_path(server_path);
@@ -3288,7 +3288,7 @@ TEST(Sync_SSL_Certificate_1)
     config.server_ssl_certificate_path = ca_dir + "/certs/localhost-chain.crt.pem";
     config.server_ssl_certificate_key_path = ca_dir + "/certs/localhost-server.key.pem";
 
-    ClientServerFixture fixture{server_dir, test_context, config};
+    ClientServerFixture fixture{server_dir, test_context, std::move(config)};
 
     Session::Config session_config;
     session_config.protocol_envelope = ProtocolEnvelope::realms;
@@ -3318,7 +3318,7 @@ TEST(Sync_SSL_Certificate_2)
     config.server_ssl_certificate_path = ca_dir + "/certs/localhost-chain.crt.pem";
     config.server_ssl_certificate_key_path = ca_dir + "/certs/localhost-server.key.pem";
 
-    ClientServerFixture fixture{server_dir, test_context, config};
+    ClientServerFixture fixture{server_dir, test_context, std::move(config)};
 
     Session::Config session_config;
     session_config.protocol_envelope = ProtocolEnvelope::realms;
@@ -3356,7 +3356,7 @@ TEST(Sync_SSL_Certificate_3)
     config.server_ssl_certificate_path = ca_dir + "/certs/localhost-chain.crt.pem";
     config.server_ssl_certificate_key_path = ca_dir + "/certs/localhost-server.key.pem";
 
-    ClientServerFixture fixture{server_dir, test_context, config};
+    ClientServerFixture fixture{server_dir, test_context, std::move(config)};
 
     Session::Config session_config;
     session_config.protocol_envelope = ProtocolEnvelope::realms;
@@ -3383,7 +3383,7 @@ TEST(Sync_SSL_Certificate_DER)
     config.server_ssl_certificate_path = ca_dir + "/certs/localhost-chain.crt.pem";
     config.server_ssl_certificate_key_path = ca_dir + "/certs/localhost-server.key.pem";
 
-    ClientServerFixture fixture{server_dir, test_context, config};
+    ClientServerFixture fixture{server_dir, test_context, std::move(config)};
 
     Session::Config session_config;
     session_config.protocol_envelope = ProtocolEnvelope::realms;
@@ -4149,7 +4149,7 @@ TEST(Sync_UploadDownloadProgress_4)
 
     ClientServerFixture::Config config;
     config.max_download_size = size_t(1e5);
-    ClientServerFixture fixture(server_dir, test_context, config);
+    ClientServerFixture fixture(server_dir, test_context, std::move(config));
     fixture.start();
 
     Session session_1 = fixture.make_session(db_1);
@@ -4384,7 +4384,7 @@ TEST(Sync_CancelReconnectDelay)
 
     // After connection-level error, and at session-level.
     {
-        ClientServerFixture fixture{server_dir, test_context, fixture_config};
+        ClientServerFixture fixture{server_dir, test_context, std::move(fixture_config)};
         fixture.start();
 
         BowlOfStonesSemaphore bowl;
@@ -4406,7 +4406,7 @@ TEST(Sync_CancelReconnectDelay)
     // After connection-level error, and at client-level while connection
     // object exists (ConnectionImpl in clinet.cpp).
     {
-        ClientServerFixture fixture{server_dir, test_context, fixture_config};
+        ClientServerFixture fixture{server_dir, test_context, std::move(fixture_config)};
         fixture.start();
 
         BowlOfStonesSemaphore bowl;
@@ -4428,7 +4428,7 @@ TEST(Sync_CancelReconnectDelay)
     // After connection-level error, and at client-level while connection object
     // does not exist (ConnectionImpl in clinet.cpp).
     {
-        ClientServerFixture fixture{server_dir, test_context, fixture_config};
+        ClientServerFixture fixture{server_dir, test_context, std::move(fixture_config)};
         fixture.start();
 
         {
@@ -4461,7 +4461,7 @@ TEST(Sync_CancelReconnectDelay)
 
     // After session-level error, and at session-level.
     {
-        ClientServerFixture fixture{server_dir, test_context, fixture_config};
+        ClientServerFixture fixture{server_dir, test_context, std::move(fixture_config)};
         fixture.start();
 
         // Add a session for the purpose of keeping the connection open
@@ -4484,7 +4484,7 @@ TEST(Sync_CancelReconnectDelay)
 
     // After session-level error, and at client-level.
     {
-        ClientServerFixture fixture{server_dir, test_context, fixture_config};
+        ClientServerFixture fixture{server_dir, test_context, std::move(fixture_config)};
         fixture.start();
 
         // Add a session for the purpose of keeping the connection open
@@ -4910,7 +4910,7 @@ TEST(Sync_PingTimesOut)
         ClientServerFixture::Config config;
         config.client_ping_period = 0;  // send ping immediately
         config.client_pong_timeout = 0; // time out immediately
-        ClientServerFixture fixture(dir, test_context, config);
+        ClientServerFixture fixture(dir, test_context, std::move(config));
 
         auto error_handler = [&](std::error_code ec, bool, const std::string&) {
             CHECK_EQUAL(Client::Error::pong_timeout, ec);
@@ -4937,7 +4937,7 @@ TEST(Sync_ReconnectAfterPingTimeout)
     config.client_ping_period = 0;  // send ping immediately
     config.client_pong_timeout = 0; // time out immediately
 
-    ClientServerFixture fixture(dir, test_context, config);
+    ClientServerFixture fixture(dir, test_context, std::move(config));
 
     BowlOfStonesSemaphore bowl;
     auto error_handler = [&](std::error_code ec, bool, const std::string&) {
@@ -4962,7 +4962,7 @@ TEST(Sync_UrgentPingIsSent)
         ClientServerFixture::Config config;
         config.client_pong_timeout = 0; // urgent pings time out immediately
 
-        ClientServerFixture fixture(dir, test_context, config);
+        ClientServerFixture fixture(dir, test_context, std::move(config));
 
         auto error_handler = [&](std::error_code ec, bool, const std::string&) {
             CHECK_EQUAL(Client::Error::pong_timeout, ec);
@@ -4990,7 +4990,7 @@ TEST(Sync_ServerDiscardDeadConnections)
     ClientServerFixture::Config config;
     config.server_connection_reaper_interval = 1; // discard dead connections quickly, FIXME: 0 will not work here :(
 
-    ClientServerFixture fixture(dir, test_context, config);
+    ClientServerFixture fixture(dir, test_context, std::move(config));
 
     BowlOfStonesSemaphore bowl;
     auto error_handler = [&](std::error_code ec, bool, const std::string&) {
@@ -5115,7 +5115,7 @@ TEST(Sync_UploadLogCompactionEnabled)
 
     ClientServerFixture::Config config;
     config.disable_upload_compaction = false;
-    ClientServerFixture fixture(server_dir, test_context, config);
+    ClientServerFixture fixture(server_dir, test_context, std::move(config));
     fixture.start();
 
     Session session_1 = fixture.make_session(db_1);
@@ -5177,7 +5177,7 @@ TEST(Sync_UploadLogCompactionDisabled)
     ClientServerFixture::Config config;
     config.disable_upload_compaction = true;
     config.disable_history_compaction = true;
-    ClientServerFixture fixture{server_dir, test_context, config};
+    ClientServerFixture fixture{server_dir, test_context, std::move(config)};
     fixture.start();
 
     // Create a changeset with lots of overwrites of the
@@ -5667,13 +5667,14 @@ TEST(Sync_AuthorizationHeaderName)
     TEST_DIR(dir);
     TEST_CLIENT_DB(db);
 
+    const char* authorization_header_name = "X-Alternative-Name";
     ClientServerFixture::Config config;
-    config.authorization_header_name = "X-Alternative-Name";
-    ClientServerFixture fixture(dir, test_context, config);
+    config.authorization_header_name = authorization_header_name;
+    ClientServerFixture fixture(dir, test_context, std::move(config));
     fixture.start();
 
     Session::Config session_config;
-    session_config.authorization_header_name = config.authorization_header_name;
+    session_config.authorization_header_name = authorization_header_name;
 
     std::map<std::string, std::string> custom_http_headers;
     custom_http_headers["Header-Name-1"] = "Header-Value-1";
@@ -5695,7 +5696,7 @@ TEST(Sync_BadChangeset)
     {
         ClientServerFixture::Config config;
         config.disable_upload_compaction = true;
-        ClientServerFixture fixture(dir, test_context, config);
+        ClientServerFixture fixture(dir, test_context, std::move(config));
         fixture.start();
 
         {
@@ -5991,7 +5992,7 @@ TEST(Sync_ConcurrentHttpDeleteAndHttpCompact)
 {
     TEST_DIR(server_dir);
     ClientServerFixture::Config config;
-    ClientServerFixture fixture(server_dir, test_context, config);
+    ClientServerFixture fixture(server_dir, test_context, std::move(config));
     fixture.start();
 
     for (int i = 0; i < 64; ++i) {
@@ -6025,7 +6026,7 @@ TEST(Sync_RunServerWithoutPublicKey)
     TEST_DIR(server_dir);
     ClientServerFixture::Config config;
     config.server_public_key_path = {};
-    ClientServerFixture fixture(server_dir, test_context, config);
+    ClientServerFixture fixture(server_dir, test_context, std::move(config));
     fixture.start();
 
     // Server must accept an unsigned token when a public key is not passed to
@@ -6059,7 +6060,7 @@ TEST(Sync_ServerSideEncryption)
     {
         ClientServerFixture::Config config;
         config.server_encryption_key = crypt_key_2(always_encrypt);
-        ClientServerFixture fixture(server_dir, test_context, config);
+        ClientServerFixture fixture(server_dir, test_context, std::move(config));
         fixture.start();
 
         Session session = fixture.make_bound_session(db, "/test");
@@ -6089,7 +6090,7 @@ TEST(Sync_ServerSideEncryptionPlusCompact)
     ClientServerFixture::Config config;
     bool always_encrypt = true;
     config.server_encryption_key = crypt_key_2(always_encrypt);
-    ClientServerFixture fixture(server_dir, test_context, config);
+    ClientServerFixture fixture(server_dir, test_context, std::move(config));
     fixture.start();
 
     {
@@ -6165,7 +6166,7 @@ TEST(Sync_LogCompaction_EraseObject_LinkList)
     config.disable_upload_compaction = false;
     config.disable_download_compaction = false;
 
-    ClientServerFixture fixture(dir, test_context, config);
+    ClientServerFixture fixture(dir, test_context, std::move(config));
     fixture.start();
 
     {
@@ -6277,7 +6278,7 @@ TEST(Sync_ClientFileBlacklisting)
         ClientServerFixture::Config config;
         config.server_metrics = &metrics;
         config.client_file_blacklists["/test"].push_back(client_file_ident);
-        ClientServerFixture fixture(server_dir, test_context, config);
+        ClientServerFixture fixture(server_dir, test_context, std::move(config));
         fixture.start();
         using ConnectionState = ConnectionState;
         using ErrorInfo = Session::ErrorInfo;

--- a/test/test_transactions.cpp
+++ b/test/test_transactions.cpp
@@ -670,7 +670,7 @@ void preparations(SharedGroup& sg_w)
 // illustration of possible governor function which takes total system load into account
 class ExampleGovernor : public util::PageReclaimGovernor {
 public:
-    std::function<int64_t()> current_target_getter(size_t load) override
+    util::UniqueFunction<int64_t()> current_target_getter(size_t load) override
     {
         return std::bind(file_control_governor, load);
     }

--- a/test/test_util_functional.cpp
+++ b/test/test_util_functional.cpp
@@ -56,6 +56,33 @@ TEST(Util_UniqueFunction)
     CHECK(func_moved);
 }
 
+TEST(Util_UniqueFunction_Target)
+{
+    struct Value1 {
+        int value;
+        void operator()() {}
+    };
+    struct Value2 {
+        int value;
+        void operator()() {}
+    };
+
+    Value1 v1 = {1};
+    Value2 v2 = {2};
+
+    UniqueFunction<void()> func;
+    CHECK_NOT(func.target<Value1>());
+    CHECK_NOT(func.target<Value2>());
+
+    func = v1;
+    CHECK_EQUAL(func.target<Value1>()->value, 1);
+    CHECK_NOT(func.target<Value2>());
+
+    func = v2;
+    CHECK_NOT(func.target<Value1>());
+    CHECK_EQUAL(func.target<Value2>()->value, 2);
+}
+
 } // namespace
 } // namespace realm::util
 

--- a/test/test_util_websocket.cpp
+++ b/test/test_util_websocket.cpp
@@ -196,17 +196,17 @@ public:
 
     void async_write(const char* data, size_t size, WriteCompletionHandler handler) override
     {
-        m_pipe_out.async_write(data, size, handler);
+        m_pipe_out.async_write(data, size, std::move(handler));
     }
 
     void async_read(char* buffer, size_t size, ReadCompletionHandler handler) override
     {
-        m_pipe_in.async_read(buffer, size, handler);
+        m_pipe_in.async_read(buffer, size, std::move(handler));
     }
 
     void async_read_until(char* buffer, size_t size, char delim, ReadCompletionHandler handler) override
     {
-        m_pipe_in.async_read_until(buffer, size, delim, handler);
+        m_pipe_in.async_read_until(buffer, size, delim, std::move(handler));
     }
 
     void websocket_handshake_completion_handler(const HTTPHeaders&) override

--- a/test/util/compare_groups.cpp
+++ b/test/util/compare_groups.cpp
@@ -1054,7 +1054,7 @@ bool compare_groups(const Transaction& group_1, const Transaction& group_2)
 
 
 bool compare_groups(const Transaction& group_1, const Transaction& group_2,
-                    std::function<bool(StringData)> filter_func, util::Logger& logger)
+                    util::FunctionRef<bool(StringData)> filter_func, util::Logger& logger)
 {
     auto filter = [&](const Group& group, std::vector<StringData>& tables) {
         auto table_keys = group.get_table_keys();

--- a/test/util/compare_groups.hpp
+++ b/test/util/compare_groups.hpp
@@ -1,8 +1,7 @@
 #ifndef REALM_TEST_UTIL_COMPARE_GROUPS_HPP
 #define REALM_TEST_UTIL_COMPARE_GROUPS_HPP
 
-#include <functional>
-
+#include <realm/util/functional.hpp>
 #include <realm/util/logger.hpp>
 #include <realm/group.hpp>
 #include <realm/table.hpp>
@@ -22,7 +21,7 @@ bool compare_groups(const Transaction& group_1, const Transaction& group_2);
 bool compare_groups(const Transaction& group_1, const Transaction& group_2, util::Logger&);
 
 bool compare_groups(const Transaction& group_1, const Transaction& group_2,
-                    std::function<bool(StringData table_name)> filter_func, util::Logger&);
+                    util::FunctionRef<bool(StringData table_name)> filter_func, util::Logger&);
 
 
 // Implementation


### PR DESCRIPTION
(And occasionally util::FunctionRef)

This gives the SDKs more flexiblity in what functions they pass in and greatly improves codegen. In total this cuts the Cocoa SPM-built Release dylib from 7104688 bytes to 6891776 bytes, a savings of 212912 bytes. There's some API breaking changes, but the updates required for [Cocoa](https://github.com/realm/realm-swift/commit/9336283cc7591d564479f0fba2a4b822dbef4c25) and [JS](https://github.com/realm/realm-js/commit/32bc9073cc27a52fbfdc8c2f56a02e82df5f5211) were trivial.

AppCredential did not particularly need to be using std::function at all, as generating the payload lazily wasn't a meaningful optimization. I also made it expose the Bson payload directly rather than converting it to a string as the thing using this was just parsing it as Bson immediately. `serialize_as_json()` remains as a wrapper as realm-js calls it.

UniqueFunction did some SFINAE checks in an awkward way to work around MSVC bugs in an unspecified version of VS. The comment dates back to 2018 so it is presumably 2017 or earlier. We currently target VS 2019, where whatever bug was present has presumably been fixed as [their standard library implementation of std::function does the simpler thing](https://github.com/microsoft/STL/blob/main/stl/inc/functional#L1048).  This doesn't meaningfully change the compiled result but it makes stepping through UniqueFunction construction in a debug build less annoying.

Realm-js uses std::function::target(), so I added that to UniqueFunction.

In the third commit which actually adopts UniqueFunction, every file except for app.cpp, mongo_collection.cpp, and push_client.cpp are just find/replace, adding std::move(), and other minor changes required to make things compile.  Those three files have a separate set of refactoring to reduce duplication and compiled size which was too annoying to detangle from this.

The notable changes in those files which aren't just extracting code to helper functions are:

1. MongoClient had some callbacks which took (Optional\<Error\>, Optional\<T\>) and some which took (Optional\<T\>, Optional\<Error\>). I normalized this to all pass the error last. Most of the error-first functions seemingly aren't actually used by any SDKs or the C API.
2. IndexedMap now exposes (const) access to the underlying map. This enables unexcitingly better performance but mostly just means that we don't need to wrap all of the various lookup functions.
3. app.cpp was using nlohmann::json directly to parse and serialize ejson. This was _probably_ fine because it looked like the functions would never get types which need ejson serialization, but there might have been some lurking bugs. Always using the Bson types instead eliminates the possiblity of this, cuts down on the amount of code, and improves the compiled size a bit as the json library we use is not exactly svelte.

