### PR TITLE
Fix Future::on_completion

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@
 
 ### Internals
 * SubscriptionStore's should be initialized with an implict empty SubscriptionSet so users can wait for query version zero to finish synchronizing. ((#5166)[https://github.com/realm/realm-core/pull/5166])
+* Fixed `Future::on_completion()` and added missing testing for it ((#5181)[https://github.com/realm/realm-core/pull/5181])
 
 ----------------------------------------------
 


### PR DESCRIPTION
## What, How & Why?
I noticed while working on something that Future::on_completion() was not working. I don't know how I missed this when I was doing this work earlier in the year, but it looks like I missed some test coverage here. I've fixed on_completion and added a bunch of tests for it.

There were also two other minor bugs in the future header that get fixed as well.
## ☑️ ToDos
* [ ] 📝 Changelog update
* [x] 🚦 Tests (or not relevant)
