### PR TITLE
Clean-up after removal of refresh message from sync protocol

### DIFF
--- a/src/realm/sync/noinst/protocol_codec.cpp
+++ b/src/realm/sync/noinst/protocol_codec.cpp
@@ -24,14 +24,6 @@ void ClientProtocol::make_bind_message(int protocol_version, OutputBuffer& out, 
     out.write(signed_user_token.data(), signed_user_token.size()); // Throws
 }
 
-void ClientProtocol::make_refresh_message(OutputBuffer& out, session_ident_type session_ident,
-                                          const std::string& signed_user_token)
-{
-    out << "refresh " << session_ident << " " << signed_user_token.size() << "\n"; // Throws
-    out.write(signed_user_token.data(), signed_user_token.size());                 // Throws
-    REALM_ASSERT(!out.fail());
-}
-
 void ClientProtocol::make_pbs_ident_message(OutputBuffer& out, session_ident_type session_ident,
                                             SaltedFileIdent client_file_ident, const SyncProgress& progress)
 {

--- a/src/realm/sync/noinst/protocol_codec.hpp
+++ b/src/realm/sync/noinst/protocol_codec.hpp
@@ -167,8 +167,6 @@ public:
                            const std::string& server_path, const std::string& signed_user_token,
                            bool need_client_file_ident, bool is_subserver);
 
-    void make_refresh_message(OutputBuffer&, session_ident_type session_ident, const std::string& signed_user_token);
-
     void make_pbs_ident_message(OutputBuffer&, session_ident_type session_ident, SaltedFileIdent client_file_ident,
                                 const SyncProgress& progress);
 
@@ -647,16 +645,6 @@ public:
 
                 connection.receive_bind_message(session_ident, std::move(path), std::move(signed_user_token),
                                                 need_client_file_ident, is_subserver); // Throws
-            }
-            else if (message_type == "refresh") {
-                auto session_ident = msg.read_next<session_ident_type>();
-                auto signed_user_token_size = msg.read_next<size_t>('\n');
-                if (signed_user_token_size > s_max_signed_user_token_size)
-                    return report_error(Error::limits_exceeded, "Signed user token in REFRESH message is too large");
-
-                auto signed_user_token = msg.read_sized_data<std::string>(signed_user_token_size);
-
-                connection.receive_refresh_message(session_ident, std::move(signed_user_token)); // Throws
             }
             else if (message_type == "ident") {
                 auto session_ident = msg.read_next<session_ident_type>();

--- a/src/realm/sync/protocol.cpp
+++ b/src/realm/sync/protocol.cpp
@@ -74,13 +74,13 @@ const char* get_protocol_error_message(int error_code) noexcept
         case ProtocolError::token_expired:
             return "Access token expired";
         case ProtocolError::bad_authentication:
-            return "Bad user authentication (BIND, REFRESH)";
+            return "Bad user authentication (BIND)";
         case ProtocolError::illegal_realm_path:
             return "Illegal Realm path (BIND)";
         case ProtocolError::no_such_realm:
             return "No such Realm (BIND)";
         case ProtocolError::permission_denied:
-            return "Permission denied (BIND, REFRESH)";
+            return "Permission denied (BIND)";
         case ProtocolError::bad_server_file_ident:
             return "The server sent an obsolete error code (Bad server file identifier (IDENT))";
         case ProtocolError::bad_client_file_ident:

--- a/src/realm/sync/protocol.hpp
+++ b/src/realm/sync/protocol.hpp
@@ -218,10 +218,10 @@ enum class ProtocolError {
     session_closed               = 200, // Session closed (no error)
     other_session_error          = 201, // Other session level error
     token_expired                = 202, // Access token expired
-    bad_authentication           = 203, // Bad user authentication (BIND, REFRESH)
+    bad_authentication           = 203, // Bad user authentication (BIND)
     illegal_realm_path           = 204, // Illegal Realm path (BIND)
     no_such_realm                = 205, // No such Realm (BIND)
-    permission_denied            = 206, // Permission denied (BIND, REFRESH)
+    permission_denied            = 206, // Permission denied (BIND)
     bad_server_file_ident        = 207, // Bad server file identifier (IDENT) (obsolete!)
     bad_client_file_ident        = 208, // Bad client file identifier (IDENT)
     bad_server_version           = 209, // Bad server version (IDENT, UPLOAD, TRANSACT)


### PR DESCRIPTION
## What, How & Why?
After the removal of the REFRESH message from sync protocol there were still some references to it and some unused test code. This pull request addresses that.

