### PR TITLE
Trying to intern a string multiple times may lead to duplicates

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@
 * Subscription names correctly distinguish an empty string from a nullptr ([#5160](https://github.com/realm/realm-core/pull/5160), since v11.8.0)
 * Converting floats/doubles into Decimal128 would yield imprecise results ([#5184](https://github.com/realm/realm-core/pull/5184), since v6.1.0)
 * Fix some warnings when building with Xcode 13.3.
+* Using accented characters in class and field names may end the session ([#5196](https://github.com/realm/realm-core/pull/5196), since v10.2.0)
  
 ### Breaking changes
 * None.

--- a/src/realm/string_data.hpp
+++ b/src/realm/string_data.hpp
@@ -166,7 +166,7 @@ public:
     explicit operator bool() const noexcept;
     explicit operator std::string_view() const noexcept
     {
-        return std::string_view(m_data);
+        return std::string_view(m_data, m_size);
     }
 
     /// If the StringData is NULL, the hash is 0. Otherwise, the function

--- a/src/realm/sync/changeset_encoder.cpp
+++ b/src/realm/sync/changeset_encoder.cpp
@@ -229,7 +229,9 @@ InternString ChangesetEncoder::intern_string(StringData str)
         size_t index = m_intern_strings_rev.size();
         // FIXME: Assert might be able to be removed after refactoring of changeset_parser types?
         REALM_ASSERT_RELEASE_EX(index <= std::numeric_limits<uint32_t>::max(), index);
-        it = m_intern_strings_rev.insert({std::string{str}, uint32_t(index)}).first;
+        bool inserted;
+        std::tie(it, inserted) = m_intern_strings_rev.insert({str, uint32_t(index)});
+        REALM_ASSERT_RELEASE_EX(inserted, str);
 
         StringBufferRange range = add_string_range(str);
         set_intern_string(uint32_t(index), range);

--- a/src/realm/sync/changeset_encoder.cpp
+++ b/src/realm/sync/changeset_encoder.cpp
@@ -224,13 +224,13 @@ void ChangesetEncoder::operator()(const Instruction::SetErase& instr)
 
 InternString ChangesetEncoder::intern_string(StringData str)
 {
-    auto it = m_intern_strings_rev.find(str);
+    auto it = m_intern_strings_rev.find(static_cast<std::string_view>(str));
     if (it == m_intern_strings_rev.end()) {
         size_t index = m_intern_strings_rev.size();
         // FIXME: Assert might be able to be removed after refactoring of changeset_parser types?
         REALM_ASSERT_RELEASE_EX(index <= std::numeric_limits<uint32_t>::max(), index);
         bool inserted;
-        std::tie(it, inserted) = m_intern_strings_rev.insert({str, uint32_t(index)});
+        std::tie(it, inserted) = m_intern_strings_rev.insert({std::string{str}, uint32_t(index)});
         REALM_ASSERT_RELEASE_EX(inserted, str);
 
         StringBufferRange range = add_string_range(str);
@@ -250,7 +250,7 @@ void ChangesetEncoder::set_intern_string(uint32_t index, StringBufferRange range
 
 StringBufferRange ChangesetEncoder::add_string_range(StringData data)
 {
-    m_string_range = data;
+    m_string_range = static_cast<std::string_view>(data);
     REALM_ASSERT(data.size() <= std::numeric_limits<uint32_t>::max());
     return StringBufferRange{0, uint32_t(data.size())};
 }

--- a/src/realm/sync/changeset_encoder.hpp
+++ b/src/realm/sync/changeset_encoder.hpp
@@ -69,7 +69,7 @@ private:
     void append_value(UUID);
 
     Buffer m_buffer;
-    util::metered::map<std::string, uint32_t> m_intern_strings_rev;
+    util::metered::map<StringData, uint32_t> m_intern_strings_rev;
     StringData m_string_range;
 };
 

--- a/src/realm/sync/changeset_encoder.hpp
+++ b/src/realm/sync/changeset_encoder.hpp
@@ -69,8 +69,8 @@ private:
     void append_value(UUID);
 
     Buffer m_buffer;
-    util::metered::map<StringData, uint32_t> m_intern_strings_rev;
-    StringData m_string_range;
+    util::metered::map<std::string, uint32_t> m_intern_strings_rev;
+    std::string_view m_string_range;
 };
 
 // Implementation

--- a/src/realm/sync/changeset_parser.cpp
+++ b/src/realm/sync/changeset_parser.cpp
@@ -293,12 +293,10 @@ void ChangesetParser::State::parse_one()
     if (t == InstrTypeInternString) {
         uint32_t index = read_int<uint32_t>();
         StringData str = read_string();
-        auto it1 = m_intern_strings.find(static_cast<std::string_view>(str));
-        if (it1 != m_intern_strings.end()) {
+        if (auto it = m_intern_strings.find(static_cast<std::string_view>(str)); it != m_intern_strings.end()) {
             parser_error("Unexpected intern string");
         }
-        auto it2 = m_valid_interned_strings.find(index);
-        if (it2 != m_valid_interned_strings.end()) {
+        if (auto it = m_valid_interned_strings.find(index); it != m_valid_interned_strings.end()) {
             parser_error("Unexpected intern index");
         }
         StringBufferRange range = m_handler.add_string_range(str);

--- a/src/realm/sync/changeset_parser.cpp
+++ b/src/realm/sync/changeset_parser.cpp
@@ -30,6 +30,9 @@ struct ChangesetParser::State {
 
     StringBuffer m_buffer;
     util::metered::set<uint32_t> m_valid_interned_strings;
+    // Cannot use StringData as key type since m_input_begin may start pointing
+    // to a new chunk of memory.
+    util::metered::set<std::string> m_intern_strings;
 
 
     void parse_one(); // Throws
@@ -290,9 +293,18 @@ void ChangesetParser::State::parse_one()
     if (t == InstrTypeInternString) {
         uint32_t index = read_int<uint32_t>();
         StringData str = read_string();
+        auto it1 = m_intern_strings.find(static_cast<std::string_view>(str));
+        if (it1 != m_intern_strings.end()) {
+            parser_error("Unexpected intern string");
+        }
+        auto it2 = m_valid_interned_strings.find(index);
+        if (it2 != m_valid_interned_strings.end()) {
+            parser_error("Unexpected intern index");
+        }
         StringBufferRange range = m_handler.add_string_range(str);
         m_handler.set_intern_string(index, range);
         m_valid_interned_strings.emplace(index);
+        m_intern_strings.emplace(std::string{str});
         return;
     }
 

--- a/test/test_changeset_encoding.cpp
+++ b/test/test_changeset_encoding.cpp
@@ -22,6 +22,17 @@ Changeset encode_then_parse(const Changeset& changeset)
 }
 } // namespace
 
+TEST(ChangesetEncoding_InternStringsNotDuplicated)
+{
+    sync::ChangesetEncoder encoder;
+
+    encoder.intern_string("Prógram");
+    encoder.intern_string("Program");
+    // Bug #5193 caused "Program" not to be found through the interned strings
+    // although it was just created before.
+    encoder.intern_string("Program");
+}
+
 TEST(ChangesetEncoding_AddTable)
 {
     Changeset changeset;

--- a/test/test_sync.cpp
+++ b/test/test_sync.cpp
@@ -579,8 +579,8 @@ TEST(Sync_TokenWithNullExpirationAllowed)
         TEST_CLIENT_DB(db);
         ClientServerFixture fixture(dir, test_context);
         auto error_handler = [&](std::error_code, bool, const std::string&) {
-            fixture.stop();
             did_fail = true;
+            fixture.stop();
         };
         fixture.set_client_side_error_handler(error_handler);
         fixture.start();
@@ -1601,8 +1601,8 @@ TEST(Sync_ReadFailureSimulation)
             auto error_handler = [&](std::error_code ec, bool is_fatal, const std::string&) {
                 CHECK_EQUAL(_impl::SimulatedFailure::sync_client__read_head, ec);
                 CHECK_NOT(is_fatal);
-                fixture.stop();
                 client_side_read_did_fail = true;
+                fixture.stop();
             };
             fixture.set_client_side_error_handler(error_handler);
             Session session = fixture.make_bound_session(db, "/test");
@@ -5718,8 +5718,8 @@ TEST(Sync_BadChangeset)
             bool is_fatal = error_info->is_fatal;
             CHECK_EQUAL(sync::ProtocolError::bad_changeset, ec);
             CHECK(is_fatal);
-            fixture.stop();
             did_fail = true;
+            fixture.stop();
         };
 
         Session session = fixture.make_session(db);
@@ -5747,7 +5747,6 @@ TEST(Sync_GoodChangeset_AccentCharacterInFieldName)
 
         {
             Session session = fixture.make_bound_session(db);
-            session.wait_for_download_complete_or_client_stopped();
         }
 
         {
@@ -5760,16 +5759,11 @@ TEST(Sync_GoodChangeset_AccentCharacterInFieldName)
             wt.commit();
         }
 
-        auto listener = [&](ConnectionState state, const Session::ErrorInfo* error_info) {
+        auto listener = [&](ConnectionState state, const Session::ErrorInfo*) {
             if (state != ConnectionState::disconnected)
                 return;
-            REALM_ASSERT(error_info);
-            std::error_code ec = error_info->error_code;
-            bool is_fatal = error_info->is_fatal;
-            CHECK_EQUAL(sync::ProtocolError::bad_changeset, ec);
-            CHECK(is_fatal);
-            fixture.stop();
             did_fail = true;
+            fixture.stop();
         };
 
         Session session = fixture.make_session(db);
@@ -5777,7 +5771,6 @@ TEST(Sync_GoodChangeset_AccentCharacterInFieldName)
         fixture.bind_session(session, "/test");
 
         session.wait_for_upload_complete_or_client_stopped();
-        session.wait_for_download_complete_or_client_stopped();
     }
     CHECK_NOT(did_fail);
 }
@@ -6335,8 +6328,8 @@ TEST(Sync_ClientFileBlacklisting)
             bool is_fatal = error_info->is_fatal;
             CHECK_EQUAL(sync::ProtocolError::client_file_blacklisted, ec);
             CHECK(is_fatal);
-            fixture.stop();
             did_fail = true;
+            fixture.stop();
         };
         Session session = fixture.make_session(db);
         session.set_connection_state_change_listener(listener);


### PR DESCRIPTION
## What, How & Why?
Internal strings were stored as **std::string** and looked-up as **StringData**.  As it seems, the **less than** operator of realm::StringData behaves differently than the one of std::string (especially when it comes to UTF-8 strings). Storing the internal strings in a sorted collection led to wrongfully not finding existing intern strings.

This change makes sure we use std::string's to both look-up and insert intern strings.

## ☑️ ToDos
* [x] 📝 Changelog update
* [x] 🚦 Tests (or not relevant)
