### PR TITLE
Rename "Superceded" to "Superseded"

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,8 @@
 * Converting floats/doubles into Decimal128 would yield imprecise results ([#5184](https://github.com/realm/realm-core/pull/5184), since v6.1.0)
  
 ### Breaking changes
-* None.
+* Renamed SubscriptionSet::State::Superceded -> Superseded to correct typo.
+* Renamed SubscriptionSet::SupercededTag -> SupersededTag to correct typo.
 
 ### Compatibility
 * Fileformat: Generates files with format v22. Reads and automatically upgrade from fileformat v5.

--- a/src/realm/sync/subscriptions.hpp
+++ b/src/realm/sync/subscriptions.hpp
@@ -86,7 +86,7 @@ public:
      *                    ┌───────────┬─────────►Error─────────┐
      *                    │           │                        │
      *                    │           │                        ▼
-     *   Uncommitted──►Pending──►Bootstrapping──►Complete───►Superceded
+     *   Uncommitted──►Pending──►Bootstrapping──►Complete───►Superseded
      *                    │                                    ▲
      *                    │                                    │
      *                    └────────────────────────────────────┘
@@ -106,7 +106,7 @@ public:
         Error,
         // The server responded to a later subscription set to this one and this one has been trimmed from the
         // local storage of subscription sets.
-        Superceded,
+        Superseded,
     };
 
     // Used in tests.
@@ -128,8 +128,8 @@ public:
             case State::Error:
                 o << "Error";
                 break;
-            case State::Superceded:
-                o << "Superceded";
+            case State::Superseded:
+                o << "Superseded";
                 break;
         }
         return o;
@@ -145,7 +145,7 @@ public:
 
     // Returns a future that will resolve either with an error status if this subscription set encounters an
     // error, or resolves when the subscription set reaches at least that state. It's possible for a subscription
-    // set to skip a state (i.e. go from Pending to Complete or Pending to Superceded), and the future value
+    // set to skip a state (i.e. go from Pending to Complete or Pending to Superseded), and the future value
     // will the the state it actually reached.
     util::Future<State> get_state_change_notification(State notify_when) const;
 
@@ -181,10 +181,10 @@ public:
 
 protected:
     friend class SubscriptionStore;
-    struct SupercededTag {
+    struct SupersededTag {
     };
 
-    explicit SubscriptionSet(const SubscriptionStore* mgr, int64_t version, SupercededTag);
+    explicit SubscriptionSet(const SubscriptionStore* mgr, int64_t version, SupersededTag);
     explicit SubscriptionSet(const SubscriptionStore* mgr, TransactionRef tr, Obj obj);
 
     void load_from_database(TransactionRef tr, Obj obj);

--- a/test/test_sync_subscriptions.cpp
+++ b/test/test_sync_subscriptions.cpp
@@ -358,14 +358,14 @@ TEST(Sync_SubscriptionStoreNotifications)
     sub_set.update_state(SubscriptionSet::State::Complete);
     std::move(sub_set).commit();
 
-    CHECK_EQUAL(notification_futures[4].get(), SubscriptionSet::State::Superceded);
+    CHECK_EQUAL(notification_futures[4].get(), SubscriptionSet::State::Superseded);
     CHECK_EQUAL(notification_futures[5].get(), SubscriptionSet::State::Complete);
 
     // Also check that new requests for the superceded sub set get filled immediately.
     CHECK_EQUAL(old_sub_set.get_state_change_notification(SubscriptionSet::State::Complete).get(),
-                SubscriptionSet::State::Superceded);
+                SubscriptionSet::State::Superseded);
     old_sub_set.refresh();
-    CHECK_EQUAL(old_sub_set.state(), SubscriptionSet::State::Superceded);
+    CHECK_EQUAL(old_sub_set.state(), SubscriptionSet::State::Superseded);
 
     // Check that asking for a state change that is less than the current state of the sub set gets filled
     // immediately.


### PR DESCRIPTION
## What, How & Why?

Renaming to avoid SDKs propagating this typo to end-users.

## ☑️ ToDos
* [x] 📝 Changelog update
* [x] 🚦 Tests (or not relevant)
