### PR TITLE
Expose missing symbols to realm-cocoa.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 * Sending a QUERY message may fail with `Assertion failed: !m_unbind_message_sent` ([#5149](https://github.com/realm/realm-core/pull/5149), since v11.8.0)
 * Subscription names correctly distinguish an empty string from a nullptr ([#5160](https://github.com/realm/realm-core/pull/5160), since v11.8.0)
 * Converting floats/doubles into Decimal128 would yield imprecise results ([#5184](https://github.com/realm/realm-core/pull/5184), since v6.1.0)
+* Fixed an issue where having realm-cocoa as SPM sub-target dependency leads to missing symbols error during iOS archiving. ([#7645](https://github.com/realm/realm-swift/issues/7645))
  
 ### Breaking changes
 * None.

--- a/src/realm/table.cpp
+++ b/src/realm/table.cpp
@@ -2403,6 +2403,7 @@ template ObjKey Table::find_first(ColKey col_key, ObjectId) const;
 template ObjKey Table::find_first(ColKey col_key, ObjKey) const;
 template ObjKey Table::find_first(ColKey col_key, util::Optional<bool>) const;
 template ObjKey Table::find_first(ColKey col_key, util::Optional<int64_t>) const;
+template ObjKey Table::find_first(ColKey col_key, StringData) const;
 template ObjKey Table::find_first(ColKey col_key, BinaryData) const;
 template ObjKey Table::find_first(ColKey col_key, Mixed) const;
 template ObjKey Table::find_first(ColKey col_key, UUID) const;
@@ -2452,7 +2453,7 @@ ObjKey Table::find_first_decimal(ColKey col_key, Decimal128 value) const
 
 ObjKey Table::find_first_string(ColKey col_key, StringData value) const
 {
-    return find_first(col_key, value);
+    return find_first<StringData>(col_key, value);
 }
 
 ObjKey Table::find_first_binary(ColKey col_key, BinaryData value) const


### PR DESCRIPTION
Fixed an issue where having realm-cocoa as SPM sub-target dependency leads to missing symbols error during iOS archiving. ([#7645](https://github.com/realm/realm-swift/issues/7645))

## What, How & Why?
<!-- Describe the changes and give some hints to guide your reviewers if possible. -->
<!-- Link to relevant issue this fixes -->

## ☑️ ToDos
* [x] 📝 Changelog update
* [x] 🚦 Tests (or not relevant)
