### PR TITLE
Fix running the baas tests on macOS 12

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
 * Sending a QUERY message may fail with `Assertion failed: !m_unbind_message_sent` ([#5149](https://github.com/realm/realm-core/pull/5149), since v11.8.0)
 * Subscription names correctly distinguish an empty string from a nullptr ([#5160](https://github.com/realm/realm-core/pull/5160), since v11.8.0)
 * Converting floats/doubles into Decimal128 would yield imprecise results ([#5184](https://github.com/realm/realm-core/pull/5184), since v6.1.0)
+* Fix some warnings when building with Xcode 13.3.
  
 ### Breaking changes
 * None.

--- a/src/realm/sync/noinst/server/crypto_server_apple.mm
+++ b/src/realm/sync/noinst/server/crypto_server_apple.mm
@@ -94,8 +94,6 @@ bool PKey::verify(BinaryData message, BinaryData signature) const {
     throw CryptoError{"Cannot verify (no public key)."};
   }
 
-#if TARGET_OS_MAC
-
   CFPtr<CFDataRef> signatureCF = adoptCF(CFDataCreateWithBytesNoCopy(
       kCFAllocatorDefault, reinterpret_cast<const UInt8 *>(signature.data()),
       signature.size(), kCFAllocatorNull));
@@ -106,42 +104,33 @@ bool PKey::verify(BinaryData message, BinaryData signature) const {
     throw util::bad_alloc();
   }
 
-  auto translateError = [](CFErrorRef error) -> CryptoError {
-    auto errorCF = adoptCF(error);
-    return CryptoError(std::string("Error verifying message: ") +
-                       [(__bridge NSError *)error description].UTF8String);
-  };
-
   CFErrorRef error = nullptr;
-  CFPtr<SecTransformRef> verifier = adoptCF(SecVerifyTransformCreate(
-      m_impl->public_key.get(), signatureCF.get(), &error));
-  if (!verifier) {
-    throw translateError(error);
+  if (@available(macOS 10.12, *)) {
+    bool result =
+        SecKeyVerifySignature(m_impl->public_key.get(),
+                              kSecKeyAlgorithmRSASignatureMessagePKCS1v15SHA256,
+                              messageCF.get(), signatureCF.get(), &error);
+    if (result) {
+      return true;
+    }
+  } else {
+    // This is now only used in tests, so no need for a fallback for older
+    // macOS versions.
+    REALM_TERMINATE("Sync server requires macOS 10.12 or later");
   }
 
-  if (!SecTransformSetAttribute(verifier.get(), kSecTransformInputAttributeName,
-                                messageCF.get(), &error) ||
-      !SecTransformSetAttribute(verifier.get(), kSecDigestTypeAttribute,
-                                kSecDigestSHA2, &error) ||
-      !SecTransformSetAttribute(verifier.get(), kSecDigestLengthAttribute,
-                                (__bridge CFTypeRef) @256, &error)) {
-    throw translateError(error);
+  auto errorCF = adoptCF(error);
+  auto errorNS = (__bridge NSError *)error;
+  if ([errorNS.domain isEqualToString:NSOSStatusErrorDomain] &&
+      errorNS.code == errSecVerifyFailed) {
+    // Valid input, but the signature doesn't match
+    return false;
   }
 
-  CFPtr<CFTypeRef> result =
-      adoptCF(SecTransformExecute(verifier.get(), &error));
-  if (!result) {
-    throw translateError(error);
+  std::string description;
+  @autoreleasepool {
+    description = util::format("Error verifying message: %1",
+                               errorNS.description.UTF8String);
   }
-  return result.get() == kCFBooleanTrue ? true : false;
-
-#else
-
-  OSStatus status = SecKeyRawVerify(
-      m_impl->public_key.get(), (SecPadding)kSecPaddingPKCS1SHA256,
-      reinterpret_cast<const uint8_t *>(message.data()), message.size(),
-      reinterpret_cast<const uint8_t *>(signature.data()), signature.size());
-  return status == errSecSuccess;
-
-#endif
+  throw CryptoError(description);
 }

--- a/src/realm/sync/transform.cpp
+++ b/src/realm/sync/transform.cpp
@@ -72,12 +72,14 @@ namespace _impl {
 struct TransformerImpl::Discriminant {
     timestamp_type timestamp;
     file_ident_type client_file_ident;
-    Discriminant(const Discriminant&) = default;
     Discriminant(timestamp_type t, file_ident_type p)
         : timestamp(t)
         , client_file_ident(p)
     {
     }
+
+    Discriminant(const Discriminant&) = default;
+    Discriminant& operator=(const Discriminant&) = default;
 
     bool operator<(const Discriminant& other) const
     {

--- a/src/realm/util/allocator.hpp
+++ b/src/realm/util/allocator.hpp
@@ -189,6 +189,7 @@ struct STLAllocator : detail::GetAllocator<Allocator> {
     {
     }
 
+    STLAllocator(const STLAllocator& other) noexcept = default;
     STLAllocator& operator=(const STLAllocator& other) noexcept = default;
 
     T* allocate(std::size_t n)


### PR DESCRIPTION
macOS 12 requires us to set DYLD_LIBRARY_PATH rather than LD_LIBRARY_PATH.

There's also just a pile of warnings when targeting macOS 12 that I fixed.