### PR TITLE
Fix DiscardLocal client reset failure with unset callbacks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@
 * Calling `Realm::close()` or `Realm::invalidate()` from the async write callbacks could result in crashes (since v11.8.0).
 * Asynchronous writes did not work with queue-confined Realms (since v11.8.0).
 * Releasing all references to a Realm while an asynchronous write was in progress would sometimes result in use-after-frees (since v11.8.0).
+* Fixed a fatal sync error "Automatic recovery failed" during DiscardLocal client reset if the reset notifier callbacks were not set to something. ([#5223](https://github.com/realm/realm-core/issues/5223), since v11.5.0)
 * Throwing exceptions from asynchronous write callbacks would result in crashes or the Realm being in an invalid state (since v11.8.0).
  
 ### Breaking changes

--- a/src/realm/object-store/sync/sync_session.cpp
+++ b/src/realm/object-store/sync/sync_session.cpp
@@ -573,7 +573,9 @@ void SyncSession::do_create_sync_session()
                 REALM_ASSERT(frozen_before);
                 REALM_ASSERT(frozen_before->is_frozen());
             }
-            m_config.notify_after_client_reset(frozen_before, active_after);
+            if (m_config.notify_after_client_reset) {
+                m_config.notify_after_client_reset(frozen_before, active_after);
+            }
         };
         config.notify_before_client_reset = [this](std::string local_path) {
             REALM_ASSERT(!local_path.empty());
@@ -586,7 +588,9 @@ void SyncSession::do_create_sync_session()
                 REALM_ASSERT(frozen_local);
                 REALM_ASSERT(frozen_local->is_frozen());
             }
-            m_config.notify_before_client_reset(frozen_local);
+            if (m_config.notify_before_client_reset) {
+                m_config.notify_before_client_reset(frozen_local);
+            }
         };
         config.fresh_copy = std::move(m_client_reset_fresh_copy);
         session_config.client_reset_config = std::move(config);

--- a/test/object-store/sync/client_reset.cpp
+++ b/test/object-store/sync/client_reset.cpp
@@ -341,6 +341,14 @@ TEST_CASE("sync: client reset", "[client reset]") {
             }
         }
 
+        SECTION("can be reset without notifiers") {
+            local_config.sync_config->notify_before_client_reset = nullptr;
+            local_config.sync_config->notify_after_client_reset = nullptr;
+            make_reset(local_config, remote_config)->run();
+            REQUIRE(before_callback_invoctions == 0);
+            REQUIRE(after_callback_invocations == 0);
+        }
+
         SECTION("an interrupted reset can recover on the next session") {
             struct SessionInterruption : public std::runtime_error {
                 using std::runtime_error::runtime_error;


### PR DESCRIPTION
Fixes https://github.com/realm/realm-core/issues/5223
I forgot to check a function before calling it. I think SDKs other than cocoa have these always set because they wrap them up in a SDK layer callback so are likely not affected.

## ☑️ ToDos
* [x] 📝 Changelog update
* [x] 🚦 Tests (or not relevant)