### PR TITLE
Disallow opening a realm as in-memory and encrypted

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@
 * Releasing all references to a Realm while an asynchronous write was in progress would sometimes result in use-after-frees (since v11.8.0).
 * Throwing exceptions from asynchronous write callbacks would result in crashes or the Realm being in an invalid state (since v11.8.0).
 * Fix an error when compiling a watchOS Simulator target not supporting Thread-local storage ([#7623](https://github.com/realm/realm-swift/issues/7623), since v11.7.0)
+* Check, when opening a realm, that in-memory realms are not encrypted ([#5195](https://github.com/realm/realm-core/issues/5195))
  
 ### Breaking changes
 * Renamed SubscriptionSet::State::Superceded -> Superseded to correct typo.

--- a/src/realm/object-store/impl/realm_coordinator.cpp
+++ b/src/realm/object-store/impl/realm_coordinator.cpp
@@ -182,8 +182,9 @@ void RealmCoordinator::set_config(const Realm::Config& config)
         throw std::logic_error("Specifying both memory buffer and path is invalid");
     if (!config.realm_data.is_null() && !config.encryption_key.empty())
         throw std::logic_error("Memory buffers do not support encryption");
-    if (config.in_memory && !config.encryption_key.empty())
+    if (config.in_memory && !config.encryption_key.empty()) {
         throw std::logic_error("Encryption is not supported for in-memory realms");
+    }
     // ResetFile also won't use the migration function, but specifying one is
     // allowed to simplify temporarily switching modes during development
 

--- a/src/realm/object-store/impl/realm_coordinator.cpp
+++ b/src/realm/object-store/impl/realm_coordinator.cpp
@@ -182,6 +182,8 @@ void RealmCoordinator::set_config(const Realm::Config& config)
         throw std::logic_error("Specifying both memory buffer and path is invalid");
     if (!config.realm_data.is_null() && !config.encryption_key.empty())
         throw std::logic_error("Memory buffers do not support encryption");
+    if (config.in_memory && !config.encryption_key.empty())
+        throw std::logic_error("Encryption is not supported for in-memory realms");
     // ResetFile also won't use the migration function, but specifying one is
     // allowed to simplify temporarily switching modes during development
 

--- a/test/object-store/realm.cpp
+++ b/test/object-store/realm.cpp
@@ -167,6 +167,11 @@ TEST_CASE("SharedRealm: get_shared_realm()") {
             config.initialization_function = [](auto) {};
             REQUIRE_THROWS(Realm::get_shared_realm(config));
         }
+        SECTION("in-memory encrypted realms are rejected") {
+            config.in_memory = true;
+            config.encryption_key = make_test_encryption_key();
+            REQUIRE_THROWS(Realm::get_shared_realm(config));
+        }
     }
 
     SECTION("should reject mismatched config") {


### PR DESCRIPTION
## What, How & Why?
Adds some checking when opening a realm to make sure you can't open an in-memory realm that's encrypted, which is not something we support.

## ☑️ ToDos
* [x] 📝 Changelog update
* [x] 🚦 Tests (or not relevant)
