### PR TITLE
Throw exception when operating on a SubscriptionSet after the SubscriptionStore is deallocated

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -52,6 +52,7 @@
 * Fix an error when compiling a watchOS Simulator target not supporting Thread-local storage ([#7623](https://github.com/realm/realm-swift/issues/7623), since v11.7.0)
 * Check, when opening a realm, that in-memory realms are not encrypted ([#5195](https://github.com/realm/realm-core/issues/5195))
 * Changed parsed queries using the `between` operator to be inclusive of the limits, a closed interval instead of an open interval. This is to conform to the published documentation and for parity with NSPredicate's definition. ([#5262](https://github.com/realm/realm-core/issues/5262), since the introduction of this operator in v11.3.0)
+* Using a SubscriptionSet after closing the realm could result in a use-after-free violation ([#5208](https://github.com/realm/realm-core/issues/5208), since v11.6.1)
  
 ### Breaking changes
 * Renamed SubscriptionSet::State::Superceded -> Superseded to correct typo.

--- a/src/realm/object-store/sync/sync_session.cpp
+++ b/src/realm/object-store/sync/sync_session.cpp
@@ -251,7 +251,7 @@ std::shared_ptr<sync::SubscriptionStore> SyncSession::make_flx_subscription_stor
         return nullptr;
     }
 
-    return std::make_shared<sync::SubscriptionStore>(m_db, [this](int64_t new_version) {
+    return sync::SubscriptionStore::create(m_db, [this](int64_t new_version) {
         std::lock_guard<std::mutex> lk(m_state_mutex);
         if (m_state != State::Active && m_state != State::WaitingForAccessToken) {
             return;

--- a/src/realm/sync/subscriptions.cpp
+++ b/src/realm/sync/subscriptions.cpp
@@ -533,7 +533,7 @@ public:
 };
 } // namespace
 
-SubscriptionStoreRef SubscriptionStore::create(DBRef db, util::UniqueFunction<void(int64_t)> on_new_subscription_set) 
+SubscriptionStoreRef SubscriptionStore::create(DBRef db, util::UniqueFunction<void(int64_t)> on_new_subscription_set)
 {
     return std::make_shared<SubscriptionStoreInit>(std::move(db), std::move(on_new_subscription_set));
 }
@@ -728,7 +728,8 @@ MutableSubscriptionSet SubscriptionStore::get_mutable_by_version(int64_t version
 {
     auto tr = m_db->start_write();
     auto sub_sets = tr->get_table(m_sub_set_keys->table);
-    return MutableSubscriptionSet(weak_from_this(), std::move(tr), sub_sets->get_object_with_primary_key(Mixed{version_id}));
+    return MutableSubscriptionSet(weak_from_this(), std::move(tr),
+                                  sub_sets->get_object_with_primary_key(Mixed{version_id}));
 }
 
 SubscriptionSet SubscriptionStore::get_by_version(int64_t version_id) const
@@ -742,7 +743,8 @@ SubscriptionSet SubscriptionStore::get_by_version_impl(int64_t version_id,
     auto tr = m_db->start_frozen(db_version.value_or(VersionID{}));
     auto sub_sets = tr->get_table(m_sub_set_keys->table);
     try {
-        return SubscriptionSet(weak_from_this(), std::move(tr), sub_sets->get_object_with_primary_key(Mixed{version_id}));
+        return SubscriptionSet(weak_from_this(), std::move(tr),
+                               sub_sets->get_object_with_primary_key(Mixed{version_id}));
     }
     catch (const KeyNotFound&) {
         std::lock_guard<std::mutex> lk(m_pending_notifications_mutex);

--- a/src/realm/sync/subscriptions.cpp
+++ b/src/realm/sync/subscriptions.cpp
@@ -115,7 +115,7 @@ std::string_view Subscription::query_string() const
     return m_query_string;
 }
 
-SubscriptionSet::SubscriptionSet(const SubscriptionStore* mgr, TransactionRef tr, Obj obj)
+SubscriptionSet::SubscriptionSet(std::weak_ptr<const SubscriptionStore> mgr, TransactionRef tr, Obj obj)
     : m_mgr(mgr)
 {
     if (obj.is_valid()) {
@@ -123,7 +123,7 @@ SubscriptionSet::SubscriptionSet(const SubscriptionStore* mgr, TransactionRef tr
     }
 }
 
-SubscriptionSet::SubscriptionSet(const SubscriptionStore* mgr, int64_t version, SupersededTag)
+SubscriptionSet::SubscriptionSet(std::weak_ptr<const SubscriptionStore> mgr, int64_t version, SupersededTag)
     : m_mgr(mgr)
     , m_version(version)
     , m_state(State::Superseded)
@@ -132,16 +132,26 @@ SubscriptionSet::SubscriptionSet(const SubscriptionStore* mgr, int64_t version, 
 
 void SubscriptionSet::load_from_database(TransactionRef tr, Obj obj)
 {
+    auto mgr = get_flx_subscription_store(); // Throws
+
     m_cur_version = tr->get_version();
     m_version = obj.get_primary_key().get_int();
-    m_state = static_cast<State>(obj.get<int64_t>(m_mgr->m_sub_set_keys->state));
-    m_error_str = obj.get<String>(m_mgr->m_sub_set_keys->error_str);
-    m_snapshot_version = static_cast<DB::version_type>(obj.get<int64_t>(m_mgr->m_sub_set_keys->snapshot_version));
-    auto sub_list = obj.get_linklist(m_mgr->m_sub_set_keys->subscriptions);
+    m_state = static_cast<State>(obj.get<int64_t>(mgr->m_sub_set_keys->state));
+    m_error_str = obj.get<String>(mgr->m_sub_set_keys->error_str);
+    m_snapshot_version = static_cast<DB::version_type>(obj.get<int64_t>(mgr->m_sub_set_keys->snapshot_version));
+    auto sub_list = obj.get_linklist(mgr->m_sub_set_keys->subscriptions);
     m_subs.clear();
     for (size_t idx = 0; idx < sub_list.size(); ++idx) {
-        m_subs.push_back(Subscription(m_mgr, sub_list.get_object(idx)));
+        m_subs.push_back(Subscription(mgr.get(), sub_list.get_object(idx)));
     }
+}
+
+std::shared_ptr<const SubscriptionStore> SubscriptionSet::get_flx_subscription_store() const
+{
+    if (auto mgr = m_mgr.lock()) {
+        return mgr;
+    }
+    throw std::logic_error("Active SubscriptionSet without a SubscriptionStore");
 }
 
 int64_t SubscriptionSet::version() const
@@ -198,7 +208,7 @@ SubscriptionSet::const_iterator SubscriptionSet::find(const Query& query) const
     });
 }
 
-MutableSubscriptionSet::MutableSubscriptionSet(const SubscriptionStore* mgr, TransactionRef tr, Obj obj)
+MutableSubscriptionSet::MutableSubscriptionSet(std::weak_ptr<const SubscriptionStore> mgr, TransactionRef tr, Obj obj)
     : SubscriptionSet(mgr, tr, obj)
     , m_tr(std::move(tr))
     , m_obj(std::move(obj))
@@ -297,14 +307,16 @@ void MutableSubscriptionSet::update_state(State new_state, util::Optional<std::s
             }
             m_state = new_state;
             break;
-        case State::Complete:
+        case State::Complete: {
             if (error_str) {
                 throw std::logic_error(
                     "Cannot supply an error message for a subscription set when state is not Error");
             }
+            auto mgr = get_flx_subscription_store(); // Throws
             m_state = new_state;
-            m_mgr->supercede_prior_to(m_tr, version());
+            mgr->supercede_prior_to(m_tr, version());
             break;
+        }
         case State::Superseded:
             throw std::logic_error("Cannot set a subscription to the superseded state");
             break;
@@ -316,36 +328,40 @@ void MutableSubscriptionSet::update_state(State new_state, util::Optional<std::s
 
 MutableSubscriptionSet SubscriptionSet::make_mutable_copy() const
 {
-    return m_mgr->make_mutable_copy(*this);
+    auto mgr = get_flx_subscription_store(); // Throws
+    return mgr->make_mutable_copy(*this);
 }
 
 void SubscriptionSet::refresh()
 {
-    auto refreshed_self = m_mgr->get_by_version(version());
+    auto mgr = get_flx_subscription_store(); // Throws
+    auto refreshed_self = mgr->get_by_version(version());
     m_state = refreshed_self.m_state;
     m_error_str = refreshed_self.m_error_str;
     m_cur_version = refreshed_self.m_cur_version;
-    *this = m_mgr->get_by_version(version());
+    *this = mgr->get_by_version(version());
 }
 
 util::Future<SubscriptionSet::State> SubscriptionSet::get_state_change_notification(State notify_when) const
 {
-    std::unique_lock<std::mutex> lk(m_mgr->m_pending_notifications_mutex);
+    auto mgr = get_flx_subscription_store(); // Throws
+
+    std::unique_lock<std::mutex> lk(mgr->m_pending_notifications_mutex);
     // If we've already been superceded by another version getting completed, then we should skip registering
     // a notification because it may never fire.
-    if (m_mgr->m_min_outstanding_version > version()) {
+    if (mgr->m_min_outstanding_version > version()) {
         return util::Future<State>::make_ready(State::Superseded);
     }
 
     // Begin by blocking process_notifications from starting to fill futures. No matter the outcome, we'll
     // unblock process_notifications() at the end of this function via the guard we construct below.
-    m_mgr->m_outstanding_requests++;
+    mgr->m_outstanding_requests++;
     auto guard = util::make_scope_exit([&]() noexcept {
         if (!lk.owns_lock()) {
             lk.lock();
         }
-        --m_mgr->m_outstanding_requests;
-        m_mgr->m_pending_notifications_cv.notify_one();
+        --mgr->m_outstanding_requests;
+        mgr->m_pending_notifications_cv.notify_one();
     });
     lk.unlock();
 
@@ -354,8 +370,8 @@ util::Future<SubscriptionSet::State> SubscriptionSet::get_state_change_notificat
 
     // If there have been writes to the database since this SubscriptionSet was created, we need to fetch
     // the updated version from the DB to know the true current state and maybe return a ready future.
-    if (m_cur_version < m_mgr->m_db->get_version_of_latest_snapshot()) {
-        auto refreshed_self = m_mgr->get_by_version(version());
+    if (m_cur_version < mgr->m_db->get_version_of_latest_snapshot()) {
+        auto refreshed_self = mgr->get_by_version(version());
         cur_state = refreshed_self.state();
         err_str = refreshed_self.error_str();
     }
@@ -373,24 +389,25 @@ util::Future<SubscriptionSet::State> SubscriptionSet::get_state_change_notificat
 
     // Otherwise, make a promise/future pair and add it to the list of pending notifications.
     auto [promise, future] = util::make_promise_future<State>();
-    m_mgr->m_pending_notifications.emplace_back(version(), std::move(promise), notify_when);
+    mgr->m_pending_notifications.emplace_back(version(), std::move(promise), notify_when);
     return std::move(future);
 }
 
 void MutableSubscriptionSet::process_notifications()
 {
+    auto mgr = get_flx_subscription_store(); // Throws
     auto new_state = state();
     auto my_version = version();
 
     std::list<SubscriptionStore::NotificationRequest> to_finish;
-    std::unique_lock<std::mutex> lk(m_mgr->m_pending_notifications_mutex);
-    m_mgr->m_pending_notifications_cv.wait(lk, [&] {
-        return m_mgr->m_outstanding_requests == 0;
+    std::unique_lock<std::mutex> lk(mgr->m_pending_notifications_mutex);
+    mgr->m_pending_notifications_cv.wait(lk, [&] {
+        return mgr->m_outstanding_requests == 0;
     });
-    for (auto it = m_mgr->m_pending_notifications.begin(); it != m_mgr->m_pending_notifications.end();) {
+    for (auto it = mgr->m_pending_notifications.begin(); it != mgr->m_pending_notifications.end();) {
         if ((it->version == my_version && (new_state == State::Error || new_state >= it->notify_when)) ||
             (new_state == State::Complete && it->version < my_version)) {
-            to_finish.splice(to_finish.end(), m_mgr->m_pending_notifications, it++);
+            to_finish.splice(to_finish.end(), mgr->m_pending_notifications, it++);
         }
         else {
             ++it;
@@ -398,7 +415,7 @@ void MutableSubscriptionSet::process_notifications()
     }
 
     if (new_state == State::Complete) {
-        m_mgr->m_min_outstanding_version = my_version;
+        mgr->m_min_outstanding_version = my_version;
     }
 
     lk.unlock();
@@ -421,30 +438,32 @@ SubscriptionSet MutableSubscriptionSet::commit() &&
     if (m_tr->get_transact_stage() != DB::transact_Writing) {
         throw std::logic_error("SubscriptionSet is not in a commitable state");
     }
+    auto mgr = get_flx_subscription_store(); // Throws
+
     if (m_old_state == State::Uncommitted) {
         if (m_state == State::Uncommitted) {
             m_state = State::Pending;
         }
-        m_obj.set(m_mgr->m_sub_set_keys->snapshot_version, static_cast<int64_t>(m_tr->get_version()));
+        m_obj.set(mgr->m_sub_set_keys->snapshot_version, static_cast<int64_t>(m_tr->get_version()));
 
-        auto obj_sub_list = m_obj.get_linklist(m_mgr->m_sub_set_keys->subscriptions);
+        auto obj_sub_list = m_obj.get_linklist(mgr->m_sub_set_keys->subscriptions);
         obj_sub_list.clear();
         for (const auto& sub : m_subs) {
             auto new_sub =
                 obj_sub_list.create_and_insert_linked_object(obj_sub_list.is_empty() ? 0 : obj_sub_list.size());
-            new_sub.set(m_mgr->m_sub_keys->id, sub.id());
-            new_sub.set(m_mgr->m_sub_keys->created_at, sub.created_at());
-            new_sub.set(m_mgr->m_sub_keys->updated_at, sub.updated_at());
+            new_sub.set(mgr->m_sub_keys->id, sub.id());
+            new_sub.set(mgr->m_sub_keys->created_at, sub.created_at());
+            new_sub.set(mgr->m_sub_keys->updated_at, sub.updated_at());
             if (sub.m_name) {
-                new_sub.set(m_mgr->m_sub_keys->name, StringData(sub.name()));
+                new_sub.set(mgr->m_sub_keys->name, StringData(sub.name()));
             }
-            new_sub.set(m_mgr->m_sub_keys->object_class_name, StringData(sub.object_class_name()));
-            new_sub.set(m_mgr->m_sub_keys->query_str, StringData(sub.query_string()));
+            new_sub.set(mgr->m_sub_keys->object_class_name, StringData(sub.object_class_name()));
+            new_sub.set(mgr->m_sub_keys->query_str, StringData(sub.query_string()));
         }
     }
-    m_obj.set(m_mgr->m_sub_set_keys->state, static_cast<int64_t>(m_state));
+    m_obj.set(mgr->m_sub_set_keys->state, static_cast<int64_t>(m_state));
     if (!m_error_str.empty()) {
-        m_obj.set(m_mgr->m_sub_set_keys->error_str, StringData(m_error_str));
+        m_obj.set(mgr->m_sub_set_keys->error_str, StringData(m_error_str));
     }
 
     const auto flx_version = version();
@@ -453,10 +472,10 @@ SubscriptionSet MutableSubscriptionSet::commit() &&
     process_notifications();
 
     if (state() == State::Pending) {
-        m_mgr->m_on_new_subscription_set(flx_version);
+        mgr->m_on_new_subscription_set(flx_version);
     }
 
-    return m_mgr->get_by_version_impl(flx_version, m_tr->get_version_of_current_transaction());
+    return mgr->get_by_version_impl(flx_version, m_tr->get_version_of_current_transaction());
 }
 
 std::string SubscriptionSet::to_ext_json() const
@@ -502,6 +521,21 @@ std::string SubscriptionSet::to_ext_json() const
     }
 
     return output_json.dump();
+}
+
+namespace {
+class SubscriptionStoreInit : public SubscriptionStore {
+public:
+    explicit SubscriptionStoreInit(DBRef db, util::UniqueFunction<void(int64_t)> on_new_subscription_set)
+        : SubscriptionStore(std::move(db), std::move(on_new_subscription_set))
+    {
+    }
+};
+} // namespace
+
+SubscriptionStoreRef SubscriptionStore::create(DBRef db, util::UniqueFunction<void(int64_t)> on_new_subscription_set) 
+{
+    return std::make_shared<SubscriptionStoreInit>(std::move(db), std::move(on_new_subscription_set));
 }
 
 SubscriptionStore::SubscriptionStore(DBRef db, util::UniqueFunction<void(int64_t)> on_new_subscription_set)
@@ -610,12 +644,12 @@ SubscriptionSet SubscriptionStore::get_latest() const
     auto tr = m_db->start_frozen();
     auto sub_sets = tr->get_table(m_sub_set_keys->table);
     if (sub_sets->is_empty()) {
-        return SubscriptionSet(this, std::move(tr), Obj{});
+        return SubscriptionSet(weak_from_this(), std::move(tr), Obj{});
     }
     auto latest_id = sub_sets->maximum_int(sub_sets->get_primary_key_column());
     auto latest_obj = sub_sets->get_object_with_primary_key(Mixed{latest_id});
 
-    return SubscriptionSet(this, std::move(tr), std::move(latest_obj));
+    return SubscriptionSet(weak_from_this(), std::move(tr), std::move(latest_obj));
 }
 
 SubscriptionSet SubscriptionStore::get_active() const
@@ -623,7 +657,7 @@ SubscriptionSet SubscriptionStore::get_active() const
     auto tr = m_db->start_frozen();
     auto sub_sets = tr->get_table(m_sub_set_keys->table);
     if (sub_sets->is_empty()) {
-        return SubscriptionSet(this, std::move(tr), Obj{});
+        return SubscriptionSet(weak_from_this(), std::move(tr), Obj{});
     }
 
     DescriptorOrdering descriptor_ordering;
@@ -634,9 +668,9 @@ SubscriptionSet SubscriptionStore::get_active() const
                    .find_all(descriptor_ordering);
 
     if (res.is_empty()) {
-        return SubscriptionSet(this, std::move(tr), Obj{});
+        return SubscriptionSet(weak_from_this(), std::move(tr), Obj{});
     }
-    return SubscriptionSet(this, std::move(tr), res.get_object(0));
+    return SubscriptionSet(weak_from_this(), std::move(tr), res.get_object(0));
 }
 
 std::pair<int64_t, int64_t> SubscriptionStore::get_active_and_latest_versions() const
@@ -694,7 +728,7 @@ MutableSubscriptionSet SubscriptionStore::get_mutable_by_version(int64_t version
 {
     auto tr = m_db->start_write();
     auto sub_sets = tr->get_table(m_sub_set_keys->table);
-    return MutableSubscriptionSet(this, std::move(tr), sub_sets->get_object_with_primary_key(Mixed{version_id}));
+    return MutableSubscriptionSet(weak_from_this(), std::move(tr), sub_sets->get_object_with_primary_key(Mixed{version_id}));
 }
 
 SubscriptionSet SubscriptionStore::get_by_version(int64_t version_id) const
@@ -708,12 +742,12 @@ SubscriptionSet SubscriptionStore::get_by_version_impl(int64_t version_id,
     auto tr = m_db->start_frozen(db_version.value_or(VersionID{}));
     auto sub_sets = tr->get_table(m_sub_set_keys->table);
     try {
-        return SubscriptionSet(this, std::move(tr), sub_sets->get_object_with_primary_key(Mixed{version_id}));
+        return SubscriptionSet(weak_from_this(), std::move(tr), sub_sets->get_object_with_primary_key(Mixed{version_id}));
     }
     catch (const KeyNotFound&) {
         std::lock_guard<std::mutex> lk(m_pending_notifications_mutex);
         if (version_id < m_min_outstanding_version) {
-            return SubscriptionSet(this, version_id, SubscriptionSet::SupersededTag{});
+            return SubscriptionSet(weak_from_this(), version_id, SubscriptionSet::SupersededTag{});
         }
         throw;
     }
@@ -734,7 +768,7 @@ MutableSubscriptionSet SubscriptionStore::make_mutable_copy(const SubscriptionSe
     auto sub_sets = new_tr->get_table(m_sub_set_keys->table);
     auto new_pk = sub_sets->maximum_int(sub_sets->get_primary_key_column()) + 1;
 
-    MutableSubscriptionSet new_set_obj(this, std::move(new_tr),
+    MutableSubscriptionSet new_set_obj(weak_from_this(), std::move(new_tr),
                                        sub_sets->create_object_with_primary_key(Mixed{new_pk}));
     for (const auto& sub : set) {
         new_set_obj.insert_sub(sub);

--- a/test/test_sync_subscriptions.cpp
+++ b/test/test_sync_subscriptions.cpp
@@ -401,7 +401,7 @@ TEST(Sync_RefreshSubscriptionSetInvalidSubscriptionStore)
     store.reset();
 
     // Throws since the SubscriptionStore is gone.
-    CHECK_THROW_ANY(latest->refresh());
+    CHECK_THROW(latest->refresh(), std::logic_error);
 }
 
 } // namespace realm::sync

--- a/test/test_sync_subscriptions.cpp
+++ b/test/test_sync_subscriptions.cpp
@@ -398,9 +398,11 @@ TEST(Sync_EmptySubscriptionSetRefresh)
     auto latest = store.get_latest();
     CHECK(latest.begin() == latest.end());
     CHECK_EQUAL(latest.size(), 0);
-    auto out = latest.make_mutable_copy();
-    std::move(out).commit();
-    latest.refresh();
+    auto new_set = std::move(latest.make_mutable_copy()).commit();
+    new_set.get_state_change_notification(SubscriptionSet::State::Complete)
+        .get_async([new_set](StatusWith<SubscriptionSet::State>) mutable noexcept {
+            new_set.refresh();
+        });
 }
 
 } // namespace realm::sync

--- a/test/test_sync_subscriptions.cpp
+++ b/test/test_sync_subscriptions.cpp
@@ -34,9 +34,9 @@ TEST(Sync_SubscriptionStoreBasic)
     SHARED_GROUP_TEST_PATH(sub_store_path);
     {
         SubscriptionStoreFixture fixture(sub_store_path);
-        SubscriptionStore store(fixture.db, [](int64_t) {});
+        auto store = SubscriptionStore::create(fixture.db, [](int64_t) {});
         // Because there are no subscription sets yet, get_latest should point to an empty object
-        auto latest = store.get_latest();
+        auto latest = store->get_latest();
         CHECK(latest.begin() == latest.end());
         CHECK_EQUAL(latest.size(), 0);
         CHECK(latest.find("a sub") == latest.end());
@@ -77,13 +77,13 @@ TEST(Sync_SubscriptionStoreBasic)
     // Destroy the DB and reload it and make sure we can get the subscriptions we set in the previous block.
     {
         SubscriptionStoreFixture fixture(sub_store_path);
-        SubscriptionStore store(fixture.db, [](int64_t) {});
+        auto store = SubscriptionStore::create(fixture.db, [](int64_t) {});
 
         auto read_tr = fixture.db->start_read();
         Query query_a(read_tr->get_table(fixture.a_table_key));
         query_a.equal(fixture.foo_col, StringData("JBR")).greater_equal(fixture.bar_col, int64_t(1));
 
-        auto set = store.get_latest();
+        auto set = store->get_latest();
         CHECK_EQUAL(set.version(), 1);
         CHECK_EQUAL(set.size(), 2);
         auto it = set.find(query_a);
@@ -108,7 +108,7 @@ TEST(Sync_SubscriptionStoreStateUpdates)
 {
     SHARED_GROUP_TEST_PATH(sub_store_path);
     SubscriptionStoreFixture fixture(sub_store_path);
-    SubscriptionStore store(fixture.db, [](int64_t) {});
+    auto store = SubscriptionStore::create(fixture.db, [](int64_t) {});
 
     auto read_tr = fixture.db->start_read();
     Query query_a(read_tr->get_table("class_a"));
@@ -118,7 +118,7 @@ TEST(Sync_SubscriptionStoreStateUpdates)
 
     // Create a new subscription set, insert a subscription into it, and mark it as complete.
     {
-        auto out = store.get_latest().make_mutable_copy();
+        auto out = store->get_latest().make_mutable_copy();
         auto&& [it, inserted] = out.insert_or_assign("a sub", query_a);
         CHECK(inserted);
         CHECK_NOT(it == out.end());
@@ -129,7 +129,7 @@ TEST(Sync_SubscriptionStoreStateUpdates)
 
     // Clone the completed set and update it to have a new query.
     {
-        auto new_set = store.get_latest().make_mutable_copy();
+        auto new_set = store->get_latest().make_mutable_copy();
         CHECK_EQUAL(new_set.version(), 2);
         new_set.clear();
         new_set.insert_or_assign("b sub", query_b);
@@ -139,8 +139,8 @@ TEST(Sync_SubscriptionStoreStateUpdates)
     // There should now be two subscription sets, version 1 is complete with query a and version 2 is pending with
     // query b.
     {
-        auto active = store.get_active();
-        auto latest = store.get_latest();
+        auto active = store->get_active();
+        auto latest = store->get_latest();
         CHECK_NOT_EQUAL(active.version(), latest.version());
         CHECK_EQUAL(active.state(), SubscriptionSet::State::Complete);
         CHECK_EQUAL(latest.state(), SubscriptionSet::State::Pending);
@@ -155,24 +155,24 @@ TEST(Sync_SubscriptionStoreStateUpdates)
 
     // Mark the version 2 set as complete.
     {
-        auto latest_mutable = store.get_mutable_by_version(2);
+        auto latest_mutable = store->get_mutable_by_version(2);
         latest_mutable.update_state(SubscriptionSet::State::Complete);
         std::move(latest_mutable).commit();
     }
 
     // There should now only be one set, version 2, that is complete. Trying to get version 1 should throw an error.
     {
-        auto active = store.get_active();
-        auto latest = store.get_latest();
+        auto active = store->get_active();
+        auto latest = store->get_latest();
         CHECK(active.version() == latest.version());
         CHECK(active.state() == SubscriptionSet::State::Complete);
 
         // By marking version 2 as complete version 1 will get superceded and removed.
-        CHECK_THROW(store.get_mutable_by_version(1), KeyNotFound);
+        CHECK_THROW(store->get_mutable_by_version(1), KeyNotFound);
     }
 
     {
-        auto set = store.get_latest().make_mutable_copy();
+        auto set = store->get_latest().make_mutable_copy();
         CHECK_EQUAL(set.size(), 1);
         // This is just to create a unique name for this sub so we can verify that the iterator returned by
         // insert_or_assign is pointing to the subscription that was just created.
@@ -197,7 +197,7 @@ TEST(Sync_SubscriptionStoreUpdateExisting)
 {
     SHARED_GROUP_TEST_PATH(sub_store_path);
     SubscriptionStoreFixture fixture(sub_store_path);
-    SubscriptionStore store(fixture.db, [](int64_t) {});
+    auto store = SubscriptionStore::create(fixture.db, [](int64_t) {});
 
     auto read_tr = fixture.db->start_read();
     Query query_a(read_tr->get_table("class_a"));
@@ -207,7 +207,7 @@ TEST(Sync_SubscriptionStoreUpdateExisting)
     ObjectId id_of_inserted;
     auto sub_name = ObjectId::gen().to_string();
     {
-        auto out = store.get_latest().make_mutable_copy();
+        auto out = store->get_latest().make_mutable_copy();
         auto [it, inserted] = out.insert_or_assign(sub_name, query_a);
         CHECK(inserted);
         CHECK_NOT(it == out.end());
@@ -223,7 +223,7 @@ TEST(Sync_SubscriptionStoreUpdateExisting)
         std::move(out).commit();
     }
     {
-        auto set = store.get_latest().make_mutable_copy();
+        auto set = store->get_latest().make_mutable_copy();
         CHECK_EQUAL(set.size(), 1);
         auto it = std::find_if(set.begin(), set.end(), [&](const Subscription& sub) {
             return sub.id() == id_of_inserted;
@@ -237,7 +237,7 @@ TEST(Sync_SubscriptionStoreAssignAnonAndNamed)
 {
     SHARED_GROUP_TEST_PATH(sub_store_path);
     SubscriptionStoreFixture fixture(sub_store_path);
-    SubscriptionStore store(fixture.db, [](int64_t) {});
+    auto store = SubscriptionStore::create(fixture.db, [](int64_t) {});
 
     auto read_tr = fixture.db->start_read();
     Query query_a(read_tr->get_table("class_a"));
@@ -246,7 +246,7 @@ TEST(Sync_SubscriptionStoreAssignAnonAndNamed)
     query_b.equal(fixture.foo_col, "Realm");
 
     {
-        auto out = store.get_latest().make_mutable_copy();
+        auto out = store->get_latest().make_mutable_copy();
         auto [it, inserted] = out.insert_or_assign("a sub", query_a);
         CHECK(inserted);
         auto named_id = it->id();
@@ -273,10 +273,10 @@ TEST(Sync_SubscriptionStoreNotifications)
 {
     SHARED_GROUP_TEST_PATH(sub_store_path);
     SubscriptionStoreFixture fixture(sub_store_path);
-    SubscriptionStore store(fixture.db, [](int64_t) {});
+    auto store = SubscriptionStore::create(fixture.db, [](int64_t) {});
 
     std::vector<util::Future<SubscriptionSet::State>> notification_futures;
-    auto sub_set = store.get_latest().make_mutable_copy();
+    auto sub_set = store->get_latest().make_mutable_copy();
     notification_futures.push_back(sub_set.get_state_change_notification(SubscriptionSet::State::Pending));
     sub_set = std::move(sub_set).commit().make_mutable_copy();
     notification_futures.push_back(sub_set.get_state_change_notification(SubscriptionSet::State::Bootstrapping));
@@ -294,13 +294,13 @@ TEST(Sync_SubscriptionStoreNotifications)
     CHECK_EQUAL(notification_futures[0].get(), SubscriptionSet::State::Pending);
 
     // This should also return immediately with a ready future because the subset is in the correct state.
-    CHECK_EQUAL(store.get_mutable_by_version(1).get_state_change_notification(SubscriptionSet::State::Pending).get(),
+    CHECK_EQUAL(store->get_mutable_by_version(1).get_state_change_notification(SubscriptionSet::State::Pending).get(),
                 SubscriptionSet::State::Pending);
 
     // This should not be ready yet because we haven't updated its state.
     CHECK_NOT(notification_futures[1].is_ready());
 
-    sub_set = store.get_mutable_by_version(2);
+    sub_set = store->get_mutable_by_version(2);
     sub_set.update_state(SubscriptionSet::State::Bootstrapping);
     std::move(sub_set).commit();
 
@@ -311,7 +311,7 @@ TEST(Sync_SubscriptionStoreNotifications)
     CHECK_NOT(notification_futures[2].is_ready());
 
     // Update the state to complete - skipping the bootstrapping phase entirely.
-    sub_set = store.get_mutable_by_version(3);
+    sub_set = store->get_mutable_by_version(3);
     sub_set.update_state(SubscriptionSet::State::Complete);
     std::move(sub_set).commit();
 
@@ -322,8 +322,8 @@ TEST(Sync_SubscriptionStoreNotifications)
     // Update one of the subscription sets to have an error state along with an error message.
     std::string error_msg = "foo bar bizz buzz. i'm an error string for this test!";
     CHECK_NOT(notification_futures[3].is_ready());
-    auto old_sub_set = store.get_by_version(4);
-    sub_set = store.get_mutable_by_version(4);
+    auto old_sub_set = store->get_by_version(4);
+    sub_set = store->get_mutable_by_version(4);
     sub_set.update_state(SubscriptionSet::State::Bootstrapping);
     sub_set.update_state(SubscriptionSet::State::Error, std::string_view(error_msg));
     std::move(sub_set).commit();
@@ -341,7 +341,7 @@ TEST(Sync_SubscriptionStoreNotifications)
     CHECK_EQUAL(err_res.get_status().reason(), error_msg);
 
     // Getting a ready future on a set that's already in the error state should also return immediately with an error.
-    err_res = store.get_by_version(4).get_state_change_notification(SubscriptionSet::State::Complete).get_no_throw();
+    err_res = store->get_by_version(4).get_state_change_notification(SubscriptionSet::State::Complete).get_no_throw();
     CHECK_NOT(err_res.is_ok());
     CHECK_EQUAL(err_res.get_status().code(), ErrorCodes::RuntimeError);
     CHECK_EQUAL(err_res.get_status().reason(), error_msg);
@@ -352,9 +352,9 @@ TEST(Sync_SubscriptionStoreNotifications)
     CHECK_NOT(notification_futures[4].is_ready());
     CHECK_NOT(notification_futures[5].is_ready());
 
-    old_sub_set = store.get_by_version(5);
+    old_sub_set = store->get_by_version(5);
 
-    sub_set = store.get_mutable_by_version(6);
+    sub_set = store->get_mutable_by_version(6);
     sub_set.update_state(SubscriptionSet::State::Complete);
     std::move(sub_set).commit();
 
@@ -375,11 +375,11 @@ TEST(Sync_SubscriptionStoreNotifications)
     // Check that if a subscription set gets updated to a new state and the SubscriptionSet returned by commit() is
     // not explicitly refreshed (i.e. is reading from a snapshot from before the state change), that it can still
     // return a ready future.
-    auto mut_set = store.get_latest().make_mutable_copy();
+    auto mut_set = store->get_latest().make_mutable_copy();
     auto waitable_set = std::move(mut_set).commit();
 
     {
-        mut_set = store.get_mutable_by_version(waitable_set.version());
+        mut_set = store->get_mutable_by_version(waitable_set.version());
         mut_set.update_state(SubscriptionSet::State::Complete);
         std::move(mut_set).commit();
     }
@@ -389,20 +389,19 @@ TEST(Sync_SubscriptionStoreNotifications)
     CHECK_EQUAL(std::move(fut).get(), SubscriptionSet::State::Complete);
 }
 
-TEST(Sync_EmptySubscriptionSetRefresh)
+TEST(Sync_RefreshSubscriptionSetInvalidSubscriptionStore)
 {
-    SHARED_GROUP_TEST_PATH(sub_store_path);
+    SHARED_GROUP_TEST_PATH(sub_store_path)
     SubscriptionStoreFixture fixture(sub_store_path);
-    SubscriptionStore store(fixture.db, [](int64_t) {});
+    auto store = SubscriptionStore::create(fixture.db, [](int64_t) {});
     // Because there are no subscription sets yet, get_latest should point to an empty object
-    auto latest = store.get_latest();
-    CHECK(latest.begin() == latest.end());
-    CHECK_EQUAL(latest.size(), 0);
-    auto new_set = std::move(latest.make_mutable_copy()).commit();
-    new_set.get_state_change_notification(SubscriptionSet::State::Complete)
-        .get_async([new_set](StatusWith<SubscriptionSet::State>) mutable noexcept {
-            new_set.refresh();
-        });
+    auto latest = std::make_unique<SubscriptionSet>(store->get_latest());
+    CHECK(latest->begin() == latest->end());
+    // The SubscriptionStore gets destroyed.
+    store.reset();
+
+    // Throws since the SubscriptionStore is gone.
+    CHECK_THROW_ANY(latest->refresh());
 }
 
 } // namespace realm::sync

--- a/test/test_sync_subscriptions.cpp
+++ b/test/test_sync_subscriptions.cpp
@@ -389,4 +389,18 @@ TEST(Sync_SubscriptionStoreNotifications)
     CHECK_EQUAL(std::move(fut).get(), SubscriptionSet::State::Complete);
 }
 
+TEST(Sync_EmptySubscriptionSetRefresh)
+{
+    SHARED_GROUP_TEST_PATH(sub_store_path);
+    SubscriptionStoreFixture fixture(sub_store_path);
+    SubscriptionStore store(fixture.db, [](int64_t) {});
+    // Because there are no subscription sets yet, get_latest should point to an empty object
+    auto latest = store.get_latest();
+    CHECK(latest.begin() == latest.end());
+    CHECK_EQUAL(latest.size(), 0);
+    auto out = latest.make_mutable_copy();
+    std::move(out).commit();
+    latest.refresh();
+}
+
 } // namespace realm::sync


### PR DESCRIPTION
## What, How & Why?
Core may crash If a SubscriptionSet is used after the SubscriptionStore referenced by it is deallocated.

If an SDK user closes the realm but still operates on a SubscriptionSet, a use-after-free violation may occur. This only happens if QBS is used.

This pull request identifies when the SubscriptionStore is not available anymore and throws an exception if a SubscriptionSet is used.

Fixes #5208.

## ☑️ ToDos
* [x] 📝 Changelog update
* [x] 🚦 Tests (or not relevant)
