### PR TITLE
App cannot be deallocated while api calls are in progress

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -72,6 +72,7 @@
 * Check, when opening a realm, that in-memory realms are not encrypted ([#5195](https://github.com/realm/realm-core/issues/5195))
 * Changed parsed queries using the `between` operator to be inclusive of the limits, a closed interval instead of an open interval. This is to conform to the published documentation and for parity with NSPredicate's definition. ([#5262](https://github.com/realm/realm-core/issues/5262), since the introduction of this operator in v11.3.0)
 * Using a SubscriptionSet after closing the realm could result in a use-after-free violation ([#5208](https://github.com/realm/realm-core/issues/5208), since v11.6.1)
+* Refreshing the user profile after the app has been destroyed leads to assertion failure ([#5238](https://github.com/realm/realm-core/issues/5238))
  
 ### Breaking changes
 * Renamed SubscriptionSet::State::Superceded -> Superseded to correct typo.

--- a/src/realm/object-store/sync/sync_manager.cpp
+++ b/src/realm/object-store/sync/sync_manager.cpp
@@ -521,13 +521,19 @@ SyncManager::~SyncManager()
     }
 #endif
 
-    for (auto& user : m_users) {
-        user->detach_from_sync_manager();
+    {
+        util::CheckedLockGuard lk(m_user_mutex);
+        for (auto& user : m_users) {
+            user->detach_from_sync_manager();
+        }
     }
 
-    // Stop the client. This will abort any uploads that inactive sessions are waiting for.
-    if (m_sync_client)
-        m_sync_client->stop();
+    {
+        util::CheckedLockGuard lk(m_mutex);
+        // Stop the client. This will abort any uploads that inactive sessions are waiting for.
+        if (m_sync_client)
+            m_sync_client->stop();
+    }
 }
 
 std::shared_ptr<SyncUser> SyncManager::get_existing_logged_in_user(const std::string& user_id) const

--- a/test/object-store/sync/app.cpp
+++ b/test/object-store/sync/app.cpp
@@ -4178,7 +4178,6 @@ TEST_CASE("app: app destroyed during token refresh", "[sync][app]") {
                                          promise.emplace_value(std::move(user));
                                      });
 
-        state.wait_for(TestState::profile_2);
         auto cur_user = std::move(cur_user_future).get();
         CHECK(cur_user);
 
@@ -4459,7 +4458,6 @@ TEST_CASE("app: app cannot get deallocated during log in", "[sync][app]") {
     }
 
     // At this point the test does not hold any reference to `app`.
-    state.wait_for(TestState::login);
     state.advance_to(TestState::app_deallocated);
     auto cur_user = std::move(cur_user_future).get();
     CHECK(cur_user);

--- a/test/object-store/sync/app.cpp
+++ b/test/object-store/sync/app.cpp
@@ -4170,7 +4170,6 @@ TEST_CASE("app: app destroyed during token refresh", "[sync][app]") {
     auto app = sync_manager.app();
 
     {
-        std::mutex mutex;
         auto [cur_user_promise, cur_user_future] = util::make_promise_future<std::shared_ptr<SyncUser>>();
         app->log_in_with_credentials(AppCredentials::anonymous(),
                                      [promise = std::move(cur_user_promise)](std::shared_ptr<SyncUser> user,
@@ -4445,7 +4444,6 @@ TEST_CASE("app: app cannot get deallocated during log in", "[sync][app]") {
     };
 
     auto [cur_user_promise, cur_user_future] = util::make_promise_future<std::shared_ptr<SyncUser>>();
-    std::mutex mutex;
     auto transporter = std::make_shared<transport>(mock_transport_worker, state);
 
     {

--- a/test/object-store/sync/app.cpp
+++ b/test/object-store/sync/app.cpp
@@ -4400,7 +4400,7 @@ TEST_CASE("app: app cannot get deallocated during log in", "[sync][app]") {
         {
             std::unique_lock<std::mutex> lk(mutex);
             cond.wait(lk, [&] {
-                return state == new_state;
+                return state >= new_state;
             });
         }
 


### PR DESCRIPTION
## What, How & Why?
Refreshing the user profile after the app has been destroyed leads to assertion failure and use-after-free violation. 

This is fixed by making it impossible that callbacks are executed after the app is deallocated. All user callbacks hold a reference to the app until they are executed. Fixes #5238, [#2800](https://github.com/realm/realm-dotnet/issues/2800)

## ☑️ ToDos
* [x] 📝 Changelog update
* [x] 🚦 Tests (or not relevant)