### PR TITLE
Add support for retrieving schema version through the C-API

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 * 'filter', 'sort', 'distinct', and 'limit' functions on Results added to the C-API. ([#5099](https://github.com/realm/realm-core/issues/5099))
 * Set and Dictionary supported in the C-API. ([#5031](https://github.com/realm/realm-core/issues/5031))
 * `Realm::begin_transaction()` no longer spawns a worker thread or asynchronously acquires the write lock on Apple platforms.
+* Added `realm_get_schema_version` to the C-API. ([#5236](https://github.com/realm/realm-core/issues/5236))
 
 ### Fixed
 * <How do the end-user experience this issue? what was the impact?> ([#????](https://github.com/realm/realm-core/issues/????), since v?.?.?)

--- a/src/realm.h
+++ b/src/realm.h
@@ -1031,6 +1031,11 @@ RLM_API realm_schema_t* realm_schema_new(const realm_class_info_t* classes, size
 RLM_API realm_schema_t* realm_get_schema(const realm_t*);
 
 /**
+ * Get the schema version for this realm.
+ */
+RLM_API uint64_t realm_get_schema_version(const realm_t* realm);
+
+/**
  * Update the schema of an open realm.
  *
  * This is equivalent to calling `realm_update_schema_advanced(realm, schema, 0,

--- a/src/realm.h
+++ b/src/realm.h
@@ -1002,6 +1002,8 @@ RLM_API realm_schema_t* realm_get_schema(const realm_t*);
 
 /**
  * Get the schema version for this realm.
+ *
+ * This function cannot fail.
  */
 RLM_API uint64_t realm_get_schema_version(const realm_t* realm);
 

--- a/src/realm/object-store/c_api/schema.cpp
+++ b/src/realm/object-store/c_api/schema.cpp
@@ -49,6 +49,12 @@ RLM_API realm_schema_t* realm_get_schema(const realm_t* realm)
     });
 }
 
+RLM_API uint64_t realm_get_schema_version(const realm_t* realm)
+{
+    auto& rlm = *realm;
+    return rlm->schema_version();
+}
+
 RLM_API bool realm_schema_validate(const realm_schema_t* schema, uint64_t validation_mode)
 {
     return wrap_err([&]() {

--- a/src/realm/object-store/shared_realm.hpp
+++ b/src/realm/object-store/shared_realm.hpp
@@ -228,7 +228,7 @@ public:
     {
         return m_schema;
     }
-    uint64_t schema_version() const
+    uint64_t schema_version() const noexcept
     {
         return m_schema_version;
     }


### PR DESCRIPTION
We need the ability to retrieve schema version of a realm as part of the Kotlin migration API. Just doing the obvious implementation to unblock. 

Closes #5236  

## ☑️ ToDos
* [x] 📝 Changelog update
* [ ] ~~🚦 Tests (or not relevant)~~