### PR TITLE
Fix Windows 8.1 targeting when building with the Windows 10 SDK

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,6 +40,7 @@
 * Many functions which previously took `std::function` parameters now take `util::UniqueFunction` parameters. This generally should not require SDK-side changes, but there may be opportunities for binary-size improvements by propagating this change outward in the SDK code.
 * realm_results_snapshot actually implemented. ([#5154](https://github.com/realm/realm-core/issues/5154))
 * Updated apply_to_state_command tool to support query based sync download messages. ([#5226](https://github.com/realm/realm-core/pull/5226))
+* Fixed an issue that made it necessary to always compile with the Windows 8.1 SDK to produce binaries able to run on Windows 8.1. ([#5247](https://github.com/realm/realm-core/pull/5247))
 
 ----------------------------------------------
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -214,6 +214,7 @@ endif()
 if(REALM_NEEDS_OPENSSL)
     if(REALM_USE_SYSTEM_OPENSSL)
         # Use system OpenSSL
+        set(OPENSSL_USE_STATIC_LIBS ON)
         find_package(OpenSSL REQUIRED)
     else()
         # Use our OpenSSL

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -126,11 +126,20 @@ set(CMAKE_MINSIZEDEBUG_POSTFIX "-dbg")
 set(CMAKE_POSITION_INDEPENDENT_CODE ON)
 
 if(CMAKE_SYSTEM_NAME MATCHES "^Windows")
-    add_definitions(
-        /DWIN32_LEAN_AND_MEAN
-        /DUNICODE
-        /D_UNICODE
+    add_compile_definitions(
+        WIN32_LEAN_AND_MEAN # include minimal Windows.h for faster builds
+        UNICODE # prefer Unicode variants of Windows APIs over ANSI variants
+        _UNICODE # prefer Unicode variants of C runtime APIs over ANSI variants
     )
+    if(NOT WINDOWS_STORE)
+        # for regular Windows target Windows 8.1 as the minimum version
+        # see https://docs.microsoft.com/en-us/windows/win32/WinProg/using-the-windows-headers
+        add_compile_definitions(
+            _WIN32_WINNT=0x0603
+            WINVER=0x603
+            NTDDI_VERSION=0x06030000
+        )
+    endif()
 endif()
 
 if(MSVC)

--- a/src/realm/sync/CMakeLists.txt
+++ b/src/realm/sync/CMakeLists.txt
@@ -92,7 +92,7 @@ else()
 endif()
 
 if(WIN32 AND NOT WINDOWS_STORE)
-    target_link_libraries(Sync INTERFACE Mincore.lib)
+    target_link_libraries(Sync INTERFACE Version.lib)
 endif()
 
 install(TARGETS Sync EXPORT realm

--- a/src/realm/sync/CMakeLists.txt
+++ b/src/realm/sync/CMakeLists.txt
@@ -93,6 +93,11 @@ endif()
 
 if(WIN32 AND NOT WINDOWS_STORE)
     target_link_libraries(Sync INTERFACE Version.lib)
+    if(CMAKE_VERSION VERSION_LESS "3.21")
+        # This is needed for OpenSSL, but CMake's FindOpenSSL didn't declare it
+        # on the OpenSSL::Crypto target until CMake 3.21.0. 
+        target_link_libraries(Sync INTERFACE Crypt32.lib)
+    endif()
 endif()
 
 install(TARGETS Sync EXPORT realm


### PR DESCRIPTION
## What, How & Why?
Long ago, in https://github.com/realm/realm-sync/pull/2506, I had made the mistake of linking against the wrong Windows library to pull in a simple function to get the operating system version.

Instead of linking against `Version.lib` as I should have, instead I linked against the `MinCore` [umbrella library](https://docs.microsoft.com/en-us/windows/win32/apiindex/windows-umbrella-libraries), which actually describes a [Windows API set](https://docs.microsoft.com/en-us/windows/win32/apiindex/windows-apisets). API sets are useful, because they allow a binary to target different Windows platforms (PCs, tablets, HoloLens, etc.), but at the cost of additional runtime stub libraries the application needs to distribute which facilitate backwards compatibility on older versions of Windows.

Realm on Windows had gotten away with not distributing extra runtime libraries by linking everything statically, and by building with the Windows 8.1 SDK, which is the oldest Windows version we support. `Mincore.lib` from the Windows 8.1 SDK adds a runtime dependency to stub libraries that are already present in Windows 8.1 installations. Building with the Windows 10 SDK however adds additional dependencies that aren't there on Windows 8.1 and are meant to be distributed alongside the native Realm libraries.

By linking against `Version.lib` instead we incur a runtime dependency only on `Version.dll`, which is a "classical" Win32 library found in the Desktop flavor of Windows dating back many versions now. That is fine for us, because we don't distribute a single binary across several Windows variants, so we don't actually need to use API sets and umbrella libraries.

We don't test Core on Windows 8.1 machines, but https://github.com/realm/realm-dotnet/pull/2809 tests this change on realm-dotnet's Windows 8.1 test environment to make sure that not building with the Windows 8.1 SDK produces binaries capable of running on Windows 8.1.

## ☑️ ToDos
* [x] 📝 Changelog update
* [x] 🚦 Tests (or not relevant)
