### PR TITLE
Query parser's BETWEEN is a closed interval

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,7 @@
 * Fix an error when compiling a watchOS Simulator target not supporting Thread-local storage ([#7623](https://github.com/realm/realm-swift/issues/7623), since v11.7.0)
 * Check, when opening a realm, that in-memory realms are not encrypted ([#5195](https://github.com/realm/realm-core/issues/5195))
 * Using asynchronous writes from multiple threads had several race conditions and would often crash (since v11.8.0).
+* Changed parsed queries using the `between` operator to be inclusive of the limits, a closed interval instead of an open interval. This is to conform to the published documentation and for parity with NSPredicate's definition. ([#5262](https://github.com/realm/realm-core/issues/5262), since the introduction of this operator in v11.3.0)
  
 ### Breaking changes
 * Renamed SubscriptionSet::State::Superceded -> Superseded to correct typo.

--- a/src/realm/parser/driver.cpp
+++ b/src/realm/parser/driver.cpp
@@ -507,8 +507,8 @@ Query BetweenNode::visit(ParserDriver* drv)
 
     ValueNode min(limits->elements.at(0));
     ValueNode max(limits->elements.at(1));
-    RelationalNode cmp1(prop, CompareNode::GREATER, &min);
-    RelationalNode cmp2(prop, CompareNode::LESS, &max);
+    RelationalNode cmp1(prop, CompareNode::GREATER_EQUAL, &min);
+    RelationalNode cmp2(prop, CompareNode::LESS_EQUAL, &max);
     AndNode and_node(&cmp1, &cmp2);
 
     return and_node.visit(drv);

--- a/test/test_parser.cpp
+++ b/test/test_parser.cpp
@@ -564,8 +564,8 @@ TEST(Parser_basic_serialisation)
     verify_query(test_context, t, "age = 1 || age == 3", 2);
     verify_query(test_context, t, "fees = 1.2 || fees = 2.23", 1);
     verify_query(test_context, t, "fees = 2 || fees = 3", 1);
-    verify_query(test_context, t, "fees BETWEEN {2, 3}", 3);
-    verify_query(test_context, t, "fees BETWEEN {2.20, 2.25}", 2);
+    verify_query(test_context, t, "fees BETWEEN {2, 3}", 4);
+    verify_query(test_context, t, "fees BETWEEN {2.20, 2.25}", 3);
     verify_query(test_context, t, "fees = 2 || fees = 3 || fees = 4", 1);
     verify_query(test_context, t, "fees = 0 || fees = 1", 0);
 
@@ -3871,7 +3871,20 @@ TEST(Parser_Between)
     verify_query(test_context, table, "between > 0", 2);
     verify_query(test_context, table, "between <= 3", 3);
 
-    verify_query(test_context, table, "age between {20, 25}", 1);
+    verify_query(test_context, table, "age between {24, 26}", 3);
+
+    verify_query(test_context, table, "age between {20, 23}", 0);
+    verify_query(test_context, table, "age between {20, 24}", 1);
+    verify_query(test_context, table, "age between {20, 25}", 2);
+    verify_query(test_context, table, "age between {20, 26}", 3);
+    verify_query(test_context, table, "age between {20, 27}", 3);
+
+    verify_query(test_context, table, "age between {23, 30}", 3);
+    verify_query(test_context, table, "age between {24, 30}", 3);
+    verify_query(test_context, table, "age between {25, 30}", 2);
+    verify_query(test_context, table, "age between {26, 30}", 1);
+    verify_query(test_context, table, "age between {27, 30}", 0);
+
     CHECK_THROW_ANY(verify_query(test_context, table, "age between {20}", 1));
     CHECK_THROW_ANY(verify_query(test_context, table, "age between {20, 25, 34}", 1));
 }


### PR DESCRIPTION
This changes the behaviour of what `between` means in parsed queries. There might be some concern that this is a breaking change, but given that we have documented it otherwise I think it we can call it a fix.

The [docs](https://docs.mongodb.com/realm/reference/realm-query-language/#expressions) specify that `BETWEEN` "Evaluates to true if the left-hand numerical or date expression is between or equal to the right-hand range"

This is also the definition according to [NSPredicate](https://developer.apple.com/library/archive/documentation/Cocoa/Conceptual/Predicates/Articles/pSyntax.html#//apple_ref/doc/uid/TP40001795-CJBDBHCB). Which means that this removes a discrepancy between parsed query syntax and cocoa's query syntax.

## ☑️ ToDos
* [x] 📝 Changelog update
* [x] 🚦 Tests (or not relevant)
