### PR TITLE
Fix a race in the TestServer client reset tests

### DIFF
--- a/test/object-store/sync/sync_test_utils.cpp
+++ b/test/object-store/sync/sync_test_utils.cpp
@@ -377,20 +377,17 @@ struct TestServerClientReset : public TestClientReset {
             auto realm2 = Realm::get_shared_realm(m_remote_config);
             auto session2 = sync_manager->get_existing_session(realm2->config().path);
 
-            for (int i = 0; i < 2; ++i) {
-                wait_for_download(*realm2);
-                realm2->begin_transaction();
-                auto table = get_table(*realm2, "object");
-                auto col = table->get_column_key("value");
-                table->begin()->set(col, i + 5);
-                if (i == 1 && m_make_remote_changes) {
-                    m_make_remote_changes(realm2);
-                }
-                realm2->commit_transaction();
-                wait_for_upload(*realm2);
-                server.advance_clock(10s);
+            wait_for_download(*realm2);
+            realm2->begin_transaction();
+            auto table = get_table(*realm2, "object");
+            auto col = table->get_column_key("value");
+            table->begin()->set(col, 6);
+            if (m_make_remote_changes) {
+                m_make_remote_changes(realm2);
             }
-            server.advance_clock(10s);
+            realm2->commit_transaction();
+            wait_for_upload(*realm2);
+            server.advance_clock(60s);
             realm2->close();
         }
 


### PR DESCRIPTION
[Occasionally](https://ci.realm.io/blue/organizations/jenkins/realm%2Frealm-core/detail/PR-5244/45/pipeline/88), client reset tests running against the old SyncTestServer (ie without baas), will fail with the following:
```
3:   discard local
3:   modify
3: -------------------------------------------------------------------------------
3: /mnt/jenkins/workspace/realm_realm-core_PR-5244@3/test/object-store/sync/client_reset.cpp:291
3: ...............................................................................
3: 
3: /mnt/jenkins/workspace/realm_realm-core_PR-5244@3/test/object-store/sync/client_reset.cpp:305: FAILED:
3:   CHECK( results.get<Obj>(0).get<Int>("value") == 6 )
3: with expansion:
3:   5 == 6
3: 
3: /mnt/jenkins/workspace/realm_realm-core_PR-5244@3/test/object-store/sync/client_reset.cpp:306: FAILED:
3:   CHECK( object.obj().get<Int>("value") == 6 )
3: with expansion:
3:   5 == 6
3: 
3: -------------------------------------------------------------------------------
3: sync: client reset
3:   discard local
3:   modify
3:   a Realm can be reset twice
3: -------------------------------------------------------------------------------
3: /mnt/jenkins/workspace/realm_realm-core_PR-5244@3/test/object-store/sync/client_reset.cpp:319
3: ...............................................................................
3: 
3: /mnt/jenkins/workspace/realm_realm-core_PR-5244@3/test/object-store/sync/client_reset.cpp:329: FAILED:
3:   REQUIRE( table->begin()->get<Int>("value") == 6 )
3: with expansion:
3:   5 == 6
```

This seems to be because after making the remote changes, the call to `wait_for_upload` did not guarantee that the second change made had been integrated. This changes avoids that scenario by only making the final change immediately instead of across a couple transactions.