### PR TITLE
Realm2Json can query for objects

### DIFF
--- a/src/realm/exec/CMakeLists.txt
+++ b/src/realm/exec/CMakeLists.txt
@@ -34,7 +34,7 @@ set_target_properties(Realm2JSON PROPERTIES
     OUTPUT_NAME "realm2json-10"
     DEBUG_POSTFIX ${CMAKE_DEBUG_POSTFIX}
 )
-target_link_libraries(Realm2JSON Storage)
+target_link_libraries(Realm2JSON Storage QueryParser)
 list(APPEND ExecTargetsToInstall Realm2JSON)
 
 add_executable(RealmDump EXCLUDE_FROM_ALL realm_dump.c)

--- a/src/realm/table_view.cpp
+++ b/src/realm/table_view.cpp
@@ -402,7 +402,8 @@ size_t TableView::count_mixed(ColKey column_key, Mixed target) const
 }
 
 
-void TableView::to_json(std::ostream& out, size_t link_depth) const
+void TableView::to_json(std::ostream& out, size_t link_depth, const std::map<std::string, std::string>& renames,
+                        JSONOutputMode mode) const
 {
     // Represent table as list of objects
     out << "[";
@@ -417,7 +418,7 @@ void TableView::to_json(std::ostream& out, size_t link_depth) const
             else {
                 out << ",";
             }
-            m_table->get_object(key).to_json(out, link_depth, {}, output_mode_json);
+            m_table->get_object(key).to_json(out, link_depth, renames, mode);
         }
     }
 

--- a/src/realm/table_view.hpp
+++ b/src/realm/table_view.hpp
@@ -301,7 +301,8 @@ public:
     }
 
     // Conversion
-    void to_json(std::ostream&, size_t link_depth = 0) const;
+    void to_json(std::ostream&, size_t link_depth = 0, const std::map<std::string, std::string>& renames = {},
+                 JSONOutputMode mode = output_mode_json) const;
 
     // Determine if the view is 'in sync' with the underlying table
     // as well as other views used to generate the view. Note that updates


### PR DESCRIPTION
Allow for more fine grained inspection of objects when dealing with large Realms by printing only objects which match a query.