### PR TITLE
Remove extraneous quotes from an error message

### DIFF
--- a/src/realm/object-store/impl/realm_coordinator.cpp
+++ b/src/realm/object-store/impl/realm_coordinator.cpp
@@ -457,7 +457,7 @@ REALM_NOINLINE void translate_file_exception(StringData path, bool immutable)
     catch (util::File::NotFound const& ex) {
         throw RealmFileException(
             RealmFileException::Kind::NotFound, ex.get_path(),
-            util::format("'%1' at path '%2' does not exist.", immutable ? "File" : "Directory", ex.get_path()),
+            util::format("%1 at path '%2' does not exist.", immutable ? "File" : "Directory", ex.get_path()),
             ex.what());
     }
     catch (FileFormatUpgradeRequired const& ex) {


### PR DESCRIPTION
Putting quotes around File and Directory in this error just makes it awkward.