### PR TITLE
Fix inconsistent float/decimal128 comparisons in Mixed

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 * <How do the end-user experience this issue? what was the impact?> ([#????](https://github.com/realm/realm-core/issues/????), since v?.?.?)
 * The Swift package set the linker flags on the wrong target, resulting in linker errors when SPM decides to build the core library as a dynamic library ([Swift #7266](https://github.com/realm/realm-swift/issues/7266)).
 * Wrong error code returned from C-API on MacOS ([#5233](https://github.com/realm/realm-core/issues/5233), since v10.0.0)
+* Mixed::compare() used inconsistent rounding for comparing a Decimal128 to a float, giving different results from comparing those values directly ([#5270](https://github.com/realm/realm-core/pull/5270)).
  
 ### Breaking changes
 * None.


### PR DESCRIPTION
Mixed::compare() promoted floats to double before converting to Decimal128, which as of #5191 results in different rounding than converting a float to Decimal128 directly. The comparison was also invalid before #5191, but in the opposite direction (comparing double to Decimal128 used too little precision), and fixing that revealed this.

This is sort of a file-format break as it changes the result of Mixed::compare(), which matters for Set<Mixed>. However, it's just partially walking back #5191's change to comparison, so if this is actually a problem then we're in trouble regardless.

The other changes to mixed.cpp are just making the helper functions not be exported as they don't need to be.