### PR TITLE
Fix an assertion failure when starting an async transaction from within a synchronous transaction

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 * The Swift package set the linker flags on the wrong target, resulting in linker errors when SPM decides to build the core library as a dynamic library ([Swift #7266](https://github.com/realm/realm-swift/issues/7266)).
 * Wrong error code returned from C-API on MacOS ([#5233](https://github.com/realm/realm-core/issues/5233), since v10.0.0)
 * Mixed::compare() used inconsistent rounding for comparing a Decimal128 to a float, giving different results from comparing those values directly ([#5270](https://github.com/realm/realm-core/pull/5270)).
+* Calling Realm::async_begin_transaction() from within a write transaction while the async state was idle would hit an assertion failure (since v11.10.0).
  
 ### Breaking changes
 * None.


### PR DESCRIPTION
Starting an async write transaction from within a write transaction while the async state was idle would result in the background thread waiting on the write lock while the Transaction already held it on the current thread. This isn't an
inherently invalid thing to do, but it's something that can't happen in any other way and had a pile of race conditions. Rather than try to get this to work correctly, it's easier to just schedule the async write to be kicked off when the synchronous write is committed, which makes this scenario work much more like other scenarios.