### PR TITLE
Nc/debugging around

### DIFF
--- a/test/object-store/object.cpp
+++ b/test/object-store/object.cpp
@@ -152,27 +152,25 @@ public:
     mutable CreatePolicy last_create_policy;
 };
 
-TEST_CASE("test_object_nico")
-{
+TEST_CASE("test_object_nico") {
     using namespace std::string_literals;
     _impl::RealmCoordinator::assert_no_open_realms();
 
     TestFile config;
-    //realm::Realm::Config config;
+    // realm::Realm::Config config;
     config.cache = false;
     config.automatic_change_notifications = true;
-    config.schema = Schema{{"test",{
-        //{"val1",PropertyType::Int},
-        {"val2",PropertyType::Set}
-    }}};
-    
+    config.schema = Schema{{"test",
+                            {//{"val1",PropertyType::Int},
+                             {"val2", PropertyType::Set}}}};
+
     config.schema_version = 0;
     auto realm = Realm::get_shared_realm(config);
-    REQUIRE(realm!=nullptr);
+    REQUIRE(realm != nullptr);
     auto table = realm->read_group().get_table("class_test");
-    REQUIRE(table!=nullptr);
-    auto col_key_set  = table->get_column_key("val2");
-    
+    REQUIRE(table != nullptr);
+    auto col_key_set = table->get_column_key("val2");
+
     realm->begin_transaction();
     Obj objAccessor = table->create_object();
     object_store::Set set(realm, objAccessor, col_key_set);
@@ -180,30 +178,30 @@ TEST_CASE("test_object_nico")
     set.insert(5);
     set.insert(2);
     realm->commit_transaction();
-    
-    //register listener to table changes
+
+    // register listener to table changes
     Object obj{realm, *table->begin()};
     CollectionChangeSet c;
-    obj.add_notification_callback([&](CollectionChangeSet change, std::exception_ptr ex){
+    obj.add_notification_callback([&](CollectionChangeSet change, std::exception_ptr ex) {
         static_cast<void>(ex);
         auto c = change;
     });
-//
-    //write into the set
+    //
+    // write into the set
     realm->begin_transaction();
-    //interesting this kills compilation
-    //auto elem =  table->begin()->get_set<int>(col_key_set).size();
+    // interesting this kills compilation
+    // auto elem =  table->begin()->get_set<int>(col_key_set).size();
     table->begin()->get_set<int64_t>(col_key_set).insert(6);
-    //objAccessor.get_set<int>(col_key_set).insert(3);
+    // objAccessor.get_set<int>(col_key_set).insert(3);
     realm->commit_transaction();
-//
-//
+    //
+    //
     advance_and_notify(*realm);
-//
-//
-//    //end close file
+    //
+    //
+    //    //end close file
     REQUIRE(!c.empty());
-//    realm->close();
+    //    realm->close();
 }
 
 TEST_CASE("object") {


### PR DESCRIPTION
## What, How & Why?
This simple test seems to be triggering some race condition that is resulting into crashes due to memory corruption (SIGSEV). 
There are 2 things that could affect this behaviour. 
1) If I put the callback on the set itself there are not crashes and obviously the listener may or may not run. Putting the listener on the Object seems to be a problem. 
2) The order of execution between the thread that is committing the transaction and the listener who is listening to the event matters.

I only tested this on MacOs.

Stack trace: 

/Users/nilk/Documents/GitHub/realm-core/src/realm/object-store/index_set.cpp:178: [realm-core-11.10.0] Assertion failed: prev_end == size_t(-1) || range.first > prev_end
0   realm-object-store-tests            0x0000000102a1e12c _ZN5realm4utilL18terminate_internalERNSt3__118basic_stringstreamIcNS1_11char_traitsIcEENS1_9allocatorIcEEEE + 28
1   realm-object-store-tests            0x0000000102a1e3ef _ZN5realm4util9terminateEPKcS2_lOSt16initializer_listINS0_9PrintableEE + 287
2   realm-object-store-tests            0x0000000101ea1371 _ZNK5realm5_impl18ChunkedRangeVector6verifyEv + 305
3   realm-object-store-tests            0x0000000101ea109e _ZN5realm5_impl18ChunkedRangeVector9push_backENSt3__14pairImmEE + 414
4   realm-object-store-tests            0x0000000101ea1734 _ZN5realm5_impl18ChunkedRangeVector6insertENS0_33MutableChunkedRangeVectorIteratorINSt3__111__wrap_iterIPNS1_5ChunkEEEEENS3_4pairImmEE + 148
5   realm-object-store-tests            0x0000000101ea3fb5 _ZN5realm8IndexSet6do_addENS_5_impl33MutableChunkedRangeVectorIteratorINSt3__111__wrap_iterIPNS1_18ChunkedRangeVector5ChunkEEEEEm + 1317
6   realm-object-store-tests            0x0000000101ea3003 _ZN5realm8IndexSet3addEm + 83
7   realm-object-store-tests            0x0000000101e2437f _ZN5realm5_impl14ObjectNotifier3runEv + 1183
8   realm-object-store-tests            0x0000000101e35fe2 _ZN5realm5_impl16RealmCoordinator19run_async_notifiersEv + 4450
9   realm-object-store-tests            0x0000000101e34d49 _ZN5realm5_impl16RealmCoordinator9on_changeEv + 25
10  realm-object-store-tests            0x0000000101d7be17 _Z23on_change_but_no_notifyRN5realm5RealmE + 71
11  realm-object-store-tests            0x0000000101d7be85 _Z18advance_and_notifyRN5realm5RealmE + 21
12  realm-object-store-tests            0x000000010097f9f8 _ZL29____C_A_T_C_H____T_E_S_T____0v + 3432
13  realm-object-store-tests            0x0000000100760163 _ZNK5Catch21TestInvokerAsFunction6invokeEv + 19
14  realm-object-store-tests            0x0000000100758764 _ZNK5Catch8TestCase6invokeEv + 36
15  realm-object-store-tests            0x000000010075869a _ZN5Catch10RunContext20invokeActiveTestCaseEv + 42
16  realm-object-store-tests            0x00000001007568b5 _ZN5Catch10RunContext14runCurrentTestERNSt3__112basic_stringIcNS1_11char_traitsIcEENS1_9allocatorIcEEEES8_ + 1061
17  realm-object-store-tests            0x0000000100755cd6 _ZN5Catch10RunContext7runTestERKNS_8TestCaseE + 614
18  realm-object-store-tests            0x000000010075b533 _ZN5Catch12_GLOBAL__N_19TestGroup7executeEv + 307
19  realm-object-store-tests            0x000000010075adb2 _ZN5Catch7Session11runInternalEv + 498
20  realm-object-store-tests            0x000000010075ab67 _ZN5Catch7Session3runEv + 87
21  realm-object-store-tests            0x00000001007747ba _ZN5Catch7Session3runIcEEiiPKPKT_ + 90
22  realm-object-store-tests            0x0000000100774684 main + 596
23  dyld                                0x000000010895d4fe start + 462!!! IMPORTANT: Please report this at https://github.com/realm/realm-core/issues/new/choose2022-03-02 11:43:53.747779+0100 realm-object-store-tests[61934:2972017] /Users/nilk/Documents/GitHub/realm-core/src/realm/object-store/index_set.cpp:178: [realm-core-11.10.0] Assertion failed: prev_end == size_t(-1) || range.first > prev_end
0   realm-object-store-tests            0x0000000102a1e12c _ZN5realm4utilL18terminate_internalERNSt3__118basic_stringstreamIcNS1_11char_traitsIcEENS1_9allocatorIcEEEE + 28
1   realm-object-store-tests            0x0000000102a1e3ef _ZN5realm4util9terminateEPKcS2_lOSt16initializer_listINS0_9PrintableEE + 287
2   realm-object-store-tests            0x0000000101ea1371 _ZNK5realm5_impl18ChunkedRangeVector6verifyEv + 305
3   realm-object-store-tests            0x0000000101ea109e _ZN5realm5_impl18ChunkedRangeVector9push_backENSt3__14pairImmEE + 414
4   realm-object-store-tests            0x0000000101ea1734 _ZN5realm5_impl18ChunkedRangeVector6insertENS0_33MutableChunkedRangeVectorIteratorINSt3__111__wrap_iterIPNS1_5ChunkEEEEENS3_4pairImmEE + 148
5   realm-object-store-tests            0x0000000101ea3fb5 _ZN5realm8IndexSet6do_addENS_5_impl33MutableChunkedRangeVectorIteratorINSt3__111__wrap_iterIPNS1_18ChunkedRangeVector5ChunkEEEEEm + 1317
6   realm-object-store-tests            0x0000000101ea3003 _ZN5realm8IndexSet3addEm + 83
7   realm-object-store-tests            0x0000000101e2437f _ZN5realm5_impl14ObjectNotifier3runEv + 1183
8   realm-object-store-tests            0x0000000101e35fe2 _ZN5realm5_impl16RealmCoordinator19run_async_notifiersEv + 4450
9   realm-object-store-tests            0x0000000101e34d49 _ZN5realm5_impl16RealmCoordinator9on_changeEv + 25
10  realm-object-store-tests            0x0000000101d7be17 _Z23on_change_but_no_notifyRN5realm5RealmE + 71
11  realm-object-store-tests            0x0000000101d7be85 _Z18advance_and_notifyRN5realm5RealmE + 21
12  realm-object-store-tests            0x000000010097f9f8 _ZL29____C_A_T_C_H____T_E_S_T____0v + 3432
13  realm-object-store-tests            0x0000000100760163 _ZNK5Catch21TestInvokerAsFunction6invokeEv + 19
14  realm-object-store-tests            0x0000000100758764 _ZNK5Catch8TestCase6invokeEv + 36
15  realm-object-store-tests            0x000000010075869a _ZN5Catch10RunContext20invokeActiveTestCaseEv + 42
16  realm-object-store-tests            0x00000001007568b5 _ZN5Catch10RunContext14runCurrentTestERNSt3__112basic_stringIcNS1_11char_traitsIcEENS1_9allocatorIcEEEES8_ + 1061
17  realm-object-store-tests            0x0000000100755cd6 _ZN5Catch10RunContext7runTestERKNS_8TestCaseE + 614
18  realm-object-store-tests            0x000000010075b533 _ZN5Catch12_GLOBAL__N_19TestGroup7executeEv + 307
19  realm-object-store-tests            0x000000010075adb2 _ZN5Catch7Session11runInternalEv + 498
20  realm-object-store-tests            0x000000010075ab67 _ZN5Catch7Session3runEv + 87
21  realm-object-store-tests            0x00000001007747ba _ZN5Catch7Session3runIcEEiiPKPKT_ + 90
22  realm-object-store-tests            0x0000000100774684 main + 596
23  dyld                                0x000000010895d4fe start + 462!!! IMPORTANT: Please report this at 


## ☑️ ToDos
* [ ] 📝 Changelog update
* [ ] 🚦 Tests (or not relevant)
