### PR TITLE
Build with config-aware CMake generators on evergreen

### DIFF
--- a/evergreen/config.yml
+++ b/evergreen/config.yml
@@ -100,10 +100,6 @@ functions:
               set_cmake_var realm_vars REALM_FETCH_MISSING_DEPENDENCIES BOOL On
           fi
 
-          if [[ -n "${cmake_build_type|}" ]]; then
-              set_cmake_var realm_vars CMAKE_BUILD_TYPE STRING "${cmake_build_type}"
-          fi
-
           if [[ -n "${cmake_toolchain_file|}" ]]; then
               set_cmake_var realm_vars CMAKE_TOOLCHAIN_FILE PATH "${cmake_toolchain_file}"
           fi
@@ -119,7 +115,7 @@ functions:
           $CMAKE \
             -B build \
             -C cmake_vars.txt ${extra_flags} \
-            -G "${cmake_generator|Unix Makefiles}"
+            -G "${cmake_generator|Ninja Multi-Config}"
 
           if [[ -n "${target_to_build|}" ]]; then
               target="--target ${target_to_build|}"
@@ -139,12 +135,12 @@ functions:
         script: |-
           set -o errexit
 
-          if [[ -z "${path_to_benchmark}" ]]; then
-              echo "No path to benchmark specified."
+          if [[ -z "${benchmark_name}" ]]; then
+              echo "No benchmark specified."
               exit 1
           fi
 
-          BENCHMARK=$(./evergreen/abspath.sh ${path_to_benchmark})
+          BENCHMARK=$(./evergreen/abspath.sh ./build/test/benchmark-${benchmark_name}/${cmake_build_type|Debug}/realm-benchmark-${benchmark_name})
           echo "Going to run benchmark $BENCHMARK"
 
           [[ -d benchmark_results ]] && rm -rf benchmark_results
@@ -176,7 +172,7 @@ functions:
               export UNITTEST_PROGRESS=${report_test_progress|}
           fi
           cd build
-          $CTEST -V $TEST_FLAGS
+          $CTEST -C ${cmake_build_type|Debug} -V $TEST_FLAGS
 
   "upload test results":
   - command: attach.results
@@ -268,7 +264,7 @@ tasks:
         cpack=$(pwd)/${cmake_bindir}/cpack
 
         cd build
-        $cpack -G TGZ -D "CPACK_PACKAGE_FILE_NAME=realm-core-artifacts" ${package_flags|}
+        $cpack -C ${cmake_build_type|Debug} -G TGZ -D "CPACK_PACKAGE_FILE_NAME=realm-core-artifacts" ${package_flags|}
   - command: s3.put
     params:
       aws_key: '${artifacts_aws_access_key}'
@@ -435,7 +431,7 @@ tasks:
   commands:
   - func: "run benchmark"
     vars:
-      path_to_benchmark: ./build/test/benchmark-common-tasks/realm-benchmark-common-tasks
+      benchmark_name: common-tasks
 
 - name: benchmark-crud
   exec_timeout_secs: 1800
@@ -443,7 +439,7 @@ tasks:
   commands:
   - func: "run benchmark"
     vars:
-      path_to_benchmark: ./build/test/benchmark-crud/realm-benchmark-crud
+      benchmark_name: crud
 
 - name: sync-tests
   tags: [ "test_suite", "for_pull_requests" ]
@@ -745,8 +741,6 @@ buildvariants:
     cmake_bindir: "./cmake_binaries/CMake.app/Contents/bin"
     cmake_toolchain_file: "./tools/cmake/xcode.toolchain.cmake"
     cmake_generator: Xcode
-    test_flags: "-C Debug"
-    package_flags: "-C Debug"
     max_jobs: $(sysctl -n hw.logicalcpu)
     run_tests_against_baas: On
     xcode_developer_dir: /Applications/Xcode12.4.app/Contents/Developer
@@ -763,8 +757,6 @@ buildvariants:
     cmake_bindir: "./cmake_binaries/CMake.app/Contents/bin"
     cmake_toolchain_file: "./tools/cmake/xcode.toolchain.cmake"
     cmake_generator: Xcode
-    test_flags: "-C Release"
-    package_flags: "-C Release"
     max_jobs: $(sysctl -n hw.logicalcpu)
     run_tests_against_baas: On
     cmake_build_type: Release
@@ -784,8 +776,6 @@ buildvariants:
     cmake_bindir: "./cmake_binaries/CMake.app/Contents/bin"
     cmake_toolchain_file: "./tools/cmake/xcode.toolchain.cmake"
     cmake_generator: Xcode
-    test_flags: "-C Debug"
-    package_flags: "-C Debug"
     max_jobs: $(sysctl -n hw.logicalcpu)
     run_tests_against_baas: On
     xcode_developer_dir: /Applications/Xcode12.4.app/Contents/Developer
@@ -804,8 +794,6 @@ buildvariants:
     cmake_bindir: "./cmake_binaries/CMake.app/Contents/bin"
     cmake_toolchain_file: "./tools/cmake/xcode.toolchain.cmake"
     cmake_generator: Xcode
-    test_flags: "-C Release"
-    package_flags: "-C Release"
     max_jobs: $(sysctl -n hw.logicalcpu)
     cmake_build_type: Release
     run_tests_against_baas: On
@@ -825,8 +813,6 @@ buildvariants:
     cmake_bindir: "./cmake-3.20.3-windows-x86_64/bin"
     cmake_generator: "Visual Studio 16 2019"
     extra_flags: "-A x64"
-    test_flags: "-C Debug"
-    package_flags: "-C Debug"
     max_jobs: $(($(grep -c proc /proc/cpuinfo) / 2))
     fetch_missing_dependencies: On
     build_zlib: On
@@ -846,8 +832,6 @@ buildvariants:
     cmake_generator: "Visual Studio 16 2019"
     extra_flags: "-A x64"
     cmake_build_type: "Release"
-    test_flags: "-C Release"
-    package_flags: "-C Release"
     max_jobs: $(($(grep -c proc /proc/cpuinfo) / 2))
     fetch_missing_dependencies: On
     build_zlib: On

--- a/evergreen/config.yml
+++ b/evergreen/config.yml
@@ -108,6 +108,12 @@ functions:
               set_cmake_var realm_vars REALM_TEST_SYNC_LOGGING BOOL On
           fi
 
+          GENERATOR="${cmake_generator}"
+          if [ -z "${cmake_generator|}" ]; then
+              GENERATOR="Ninja Multi-Config"
+              set_cmake_var generator_vars CMAKE_MAKE_PROGRAM PATH "${ninja|ninja}"
+          fi
+
           echo "Running cmake with these vars:"
           cat cmake_vars/*.txt | tee cmake_vars.txt
           echo
@@ -115,7 +121,7 @@ functions:
           $CMAKE \
             -B build \
             -C cmake_vars.txt ${extra_flags} \
-            -G "${cmake_generator|Ninja Multi-Config}"
+            -G "$GENERATOR"
 
           if [[ -n "${target_to_build|}" ]]; then
               target="--target ${target_to_build|}"
@@ -599,7 +605,6 @@ task_groups:
   - func: "fetch binaries"
   - func: "compile"
     vars:
-      cmake_build_type: "Release"
       target_to_build: "benchmarks"
   timeout:
   - func: "run hang analyzer"
@@ -711,6 +716,7 @@ buildvariants:
     curl: "/opt/mongodbtoolchain/v3/bin/curl"
     run_tests_against_baas: On
     python3: "/opt/mongodbtoolchain/v3/bin/python3"
+    ninja: "/opt/mongodbtoolchain/v4/bin/ninja"
   tasks:
   - name: compile_test_and_package
     distros:


### PR DESCRIPTION
#5271 broke running benchmarks on macOS on Evergreen because it started using Xcode as a generator instead of the default Unix Makefiles. This is a problem because Xcode and other config-aware generators place products in a configuration-specific folder in the build tree (e.g. `${CMAKE_BINARY_DIR}/$<CONFIG>/$<TARGET_OUTPUT_NAME>`), and our benchmark tasks hardcode the paths to the benchmark executables.

The fix this PR proposes is to bite the bullet and always use configuration-aware generators (Xcode and Visual Studio already are, Ninja Multi-Config becomes the default everywhere else). This allows us to always assume build product paths contain the configuration everywhere, not just on some generators, and makes fixing the actual benchmark task simpler.
