### PR TITLE
list set mixed link exposing bad link fix

### DIFF
--- a/src/realm/collection.hpp
+++ b/src/realm/collection.hpp
@@ -652,6 +652,10 @@ struct CollectionIterator {
 
     pointer operator->() const
     {
+        if constexpr (std::is_same_v<L, Set<Mixed>>) {
+            m_val = m_list->get_internal(m_ndx);
+            return &m_val;
+        }
         m_val = m_list->get(m_ndx);
         return &m_val;
     }

--- a/src/realm/list.cpp
+++ b/src/realm/list.cpp
@@ -135,15 +135,14 @@ template <class T>
 void Lst<T>::sort(std::vector<size_t>& indices, bool ascending) const
 {
     update_if_needed();
-    auto tree = m_tree.get();
     if (ascending) {
-        do_sort(indices, size(), [tree](size_t i1, size_t i2) noexcept {
-            return tree->get(i1) < tree->get(i2);
+        do_sort(indices, size(), [this](size_t i1, size_t i2) noexcept {
+            return get(i1) < get(i2);
         });
     }
     else {
-        do_sort(indices, size(), [tree](size_t i1, size_t i2) noexcept {
-            return tree->get(i1) > tree->get(i2);
+        do_sort(indices, size(), [this](size_t i1, size_t i2) noexcept {
+            return get(i1) > get(i2);
         });
     }
 }
@@ -153,9 +152,8 @@ void Lst<T>::distinct(std::vector<size_t>& indices, util::Optional<bool> sort_or
 {
     indices.clear();
     sort(indices, sort_order.value_or(true));
-    auto tree = m_tree.get();
-    auto duplicates = std::unique(indices.begin(), indices.end(), [tree](size_t i1, size_t i2) noexcept {
-        return tree->get(i1) == tree->get(i2);
+    auto duplicates = std::unique(indices.begin(), indices.end(), [this](size_t i1, size_t i2) noexcept {
+        return get(i1) == get(i2);
     });
     // Erase the duplicates
     indices.erase(duplicates, indices.end());

--- a/src/realm/list.cpp
+++ b/src/realm/list.cpp
@@ -135,18 +135,31 @@ template <class T>
 void Lst<T>::sort(std::vector<size_t>& indices, bool ascending) const
 {
     update_if_needed();
-    auto comparator = [this, &ascending](size_t i1, size_t i2) {
-        if constexpr (std::is_same_v<T, Mixed>) {
-            return ascending ? get(i1) < get(i2) : get(i1) > get(i2);
+
+    if constexpr (std::is_same_v<T, Mixed>) {
+        if (ascending) {
+            do_sort(indices, size(), [this](size_t i1, size_t i2) {
+                return get(i1) < get(i2);
+            });
         }
         else {
-            return ascending ? m_tree->get(i1) < m_tree->get(i2) : m_tree->get(i1) > m_tree->get(i2);
+            do_sort(indices, size(), [this](size_t i1, size_t i2) {
+                return get(i1) > get(i2);
+            });
         }
-    };
-
-    do_sort(indices, size(), [&comparator](size_t i1, size_t i2) {
-        return comparator(i1, i2);
-    });
+    }
+    else {
+        if (ascending) {
+            do_sort(indices, size(), [this](size_t i1, size_t i2) {
+                return m_tree->get(i1) < m_tree->get(i2);
+            });
+        }
+        else {
+            do_sort(indices, size(), [this](size_t i1, size_t i2) {
+                return m_tree->get(i1) > m_tree->get(i2);
+            });
+        }
+    }
 }
 
 template <class T>

--- a/src/realm/list.cpp
+++ b/src/realm/list.cpp
@@ -135,16 +135,18 @@ template <class T>
 void Lst<T>::sort(std::vector<size_t>& indices, bool ascending) const
 {
     update_if_needed();
-    if (ascending) {
-        do_sort(indices, size(), [this](size_t i1, size_t i2) noexcept {
-            return get(i1) < get(i2);
-        });
-    }
-    else {
-        do_sort(indices, size(), [this](size_t i1, size_t i2) noexcept {
-            return get(i1) > get(i2);
-        });
-    }
+    auto comparator = [this, &ascending](size_t i1, size_t i2) {
+        if constexpr (std::is_same_v<T, Mixed>) {
+            return ascending ? get(i1) < get(i2) : get(i1) > get(i2);
+        }
+        else {
+            return ascending ? m_tree->get(i1) < m_tree->get(i2) : m_tree->get(i1) > m_tree->get(i2);
+        }
+    };
+
+    do_sort(indices, size(), [&comparator](size_t i1, size_t i2) {
+        return comparator(i1, i2);
+    });
 }
 
 template <class T>
@@ -152,9 +154,19 @@ void Lst<T>::distinct(std::vector<size_t>& indices, util::Optional<bool> sort_or
 {
     indices.clear();
     sort(indices, sort_order.value_or(true));
-    auto duplicates = std::unique(indices.begin(), indices.end(), [this](size_t i1, size_t i2) noexcept {
-        return get(i1) == get(i2);
-    });
+    auto duplicates = indices.end();
+
+    if constexpr (std::is_same_v<T, Mixed>) {
+        duplicates = std::unique(indices.begin(), indices.end(), [this](size_t i1, size_t i2) noexcept {
+            return get(i1) == get(i2);
+        });
+    }
+    else {
+        duplicates = std::unique(indices.begin(), indices.end(), [this](size_t i1, size_t i2) noexcept {
+            return m_tree->get(i1) == m_tree->get(i2);
+        });
+    }
+
     // Erase the duplicates
     indices.erase(duplicates, indices.end());
 
@@ -163,7 +175,6 @@ void Lst<T>::distinct(std::vector<size_t>& indices, util::Optional<bool> sort_or
         std::sort(indices.begin(), indices.end(), std::less<size_t>());
     }
 }
-
 
 /********************************* Lst<Key> *********************************/
 
@@ -307,7 +318,7 @@ void Lst<Mixed>::do_set(size_t ndx, Mixed value)
 {
     ObjLink old_link;
     ObjLink target_link;
-    Mixed old_value = get(ndx);
+    Mixed old_value = m_tree->get(ndx);
 
     if (old_value.is_type(type_TypedLink)) {
         old_link = old_value.get<ObjLink>();
@@ -339,7 +350,7 @@ void Lst<Mixed>::do_insert(size_t ndx, Mixed value)
 template <>
 void Lst<Mixed>::do_remove(size_t ndx)
 {
-    if (Mixed old_value = get(ndx); old_value.is_type(type_TypedLink)) {
+    if (Mixed old_value = m_tree->get(ndx); old_value.is_type(type_TypedLink)) {
         auto old_link = old_value.get<ObjLink>();
 
         CascadeState state(old_link.get_obj_key().is_unresolved() ? CascadeState::Mode::All

--- a/src/realm/list.hpp
+++ b/src/realm/list.hpp
@@ -147,7 +147,7 @@ public:
         if (update()) {
             if constexpr (std::is_same_v<T, Mixed>) {
                 if (value.is_null()) {
-                    // if value is null then we find all the unresolved links with a linear scan
+                    // if value is null then we find also all the unresolved links with a O(n lg n) scan
                     find_all_mixed_unresolved_links(std::forward<Func>(func));
                 }
             }

--- a/src/realm/list.hpp
+++ b/src/realm/list.hpp
@@ -145,13 +145,6 @@ public:
     void find_all(value_type value, Func&& func) const
     {
         if (update()) {
-            if constexpr (std::is_same_v<T, Mixed>) {
-                if (value.is_null() || (value.is_type(type_TypedLink) && value.get_link().is_null())) {
-                    auto unresolved_link = m_obj.get_table()->create_object();
-                    unresolved_link.invalidate();
-                    m_tree->find_all(unresolved_link, std::forward<Func>(func));
-                }
-            }
             m_tree->find_all(value, std::forward<Func>(func));
         }
     }
@@ -692,14 +685,6 @@ inline size_t Lst<T>::find_first(const T& value) const
 {
     if (!update())
         return not_found;
-
-    if constexpr (std::is_same_v<T, Mixed>) {
-        if (value.is_null() || (value.is_type(type_TypedLink) && value.get_link().is_null())) {
-            auto unresolved_link = m_obj.get_table()->create_object();
-            unresolved_link.invalidate();
-            return m_tree->find_first(unresolved_link);
-        }
-    }
     return m_tree->find_first(value);
 }
 
@@ -901,14 +886,6 @@ void Lst<T>::insert(size_t ndx, T value)
         throw std::out_of_range("Index out of range");
 
     ensure_created();
-
-    if constexpr (std::is_same_v<T, Mixed>) {
-        if (value.is_null() || (value.is_type(type_TypedLink) && value.get_link().is_null())) {
-            auto unresolved_link = m_obj.get_table()->create_object();
-            unresolved_link.invalidate();
-            value = Mixed{unresolved_link};
-        }
-    }
 
     if (Replication* repl = this->m_obj.get_replication()) {
         repl->list_insert(*this, ndx, value, sz);

--- a/src/realm/list.hpp
+++ b/src/realm/list.hpp
@@ -655,12 +655,13 @@ inline T Lst<T>::get(size_t ndx) const
     if (ndx >= current_size) {
         throw std::out_of_range("Index out of range");
     }
-    
-    //proxy out the mixed value for links, we need to know if the link is valid or not (not necesseraly must it be null)
-    if constexpr(std::is_same<T, Mixed>::value)
-    {
+
+    // proxy out the mixed value for links, we need to know if the link is valid or not (not necesseraly must it be
+    // null)
+    if constexpr (std::is_same<T, Mixed>::value) {
         Mixed mixed_link_value = m_tree->get(ndx);
-        if(mixed_link_value.is_null()) return Mixed{};
+        if (mixed_link_value.is_null())
+            return Mixed{};
         return mixed_link_value;
     }
     return m_tree->get(ndx);

--- a/src/realm/list.hpp
+++ b/src/realm/list.hpp
@@ -145,17 +145,13 @@ public:
     void find_all(value_type value, Func&& func) const
     {
         if (update()) {
-            m_tree->find_all(value, std::forward<Func>(func));
             if constexpr (std::is_same_v<T, Mixed>) {
-                if (value.is_unresolved_link()) {
-                    // if value is a mixed which contains an unresolved link, find all the nulls
-                    m_tree->find_all(realm::null(), std::forward<Func>(func));
-                }
-                else if (value.is_null()) {
+                if (value.is_null()) {
                     // if value is null then we find all the unresolved links with a linear scan
                     find_all_mixed_unresolved_links(std::forward<Func>(func));
                 }
             }
+            m_tree->find_all(value, std::forward<Func>(func));
         }
     }
 

--- a/src/realm/list.hpp
+++ b/src/realm/list.hpp
@@ -660,7 +660,7 @@ inline T Lst<T>::get(size_t ndx) const
     // null)
     if constexpr (std::is_same<T, Mixed>::value) {
         Mixed mixed_link_value = m_tree->get(ndx);
-        if (mixed_link_value.is_null())
+        if (mixed_link_value.is_unresolved_link())
             return Mixed{};
         return mixed_link_value;
     }

--- a/src/realm/list.hpp
+++ b/src/realm/list.hpp
@@ -229,9 +229,6 @@ protected:
     void do_remove(size_t ndx);
     void do_clear();
 
-    // internal getter for mixed
-    T get_mixed_value(size_t ndx) const;
-
     // BPlusTree must be wrapped in an `std::unique_ptr` because it is not
     // default-constructible, due to its `Allocator&` member.
     mutable std::unique_ptr<BPlusTree<T>> m_tree;
@@ -666,16 +663,6 @@ inline T Lst<T>::get(size_t ndx) const
         if (mixed_value.is_type(type_TypedLink) && mixed_value.is_unresolved_link())
             return Mixed{};
         return mixed_value;
-    }
-    return m_tree->get(ndx);
-}
-
-template <class T>
-inline T Lst<T>::get_mixed_value(size_t ndx) const
-{
-    const auto current_size = size();
-    if (ndx >= current_size) {
-        throw std::out_of_range("Index out of range");
     }
     return m_tree->get(ndx);
 }

--- a/src/realm/list.hpp
+++ b/src/realm/list.hpp
@@ -677,15 +677,13 @@ inline T Lst<T>::get(size_t ndx) const
         throw std::out_of_range("Index out of range");
     }
 
-    // proxy out the mixed value for links, we need to know if the link is valid or not (not necesseraly must it be
-    // null)
+    auto value = m_tree->get(ndx);
     if constexpr (std::is_same_v<T, Mixed>) {
-        Mixed mixed_value = m_tree->get(ndx);
-        if (mixed_value.is_type(type_TypedLink) && mixed_value.is_unresolved_link())
+        // return a null for mixed unresolved link
+        if (value.is_type(type_TypedLink) && value.is_unresolved_link())
             return Mixed{};
-        return mixed_value;
     }
-    return m_tree->get(ndx);
+    return value;
 }
 
 template <class T>

--- a/src/realm/list.hpp
+++ b/src/realm/list.hpp
@@ -560,10 +560,42 @@ inline T Lst<T>::remove(const iterator& it)
     return remove(it.index());
 }
 
+//template<typename Tree>
+//inline size_t mixed_links_size(Tree& m_tree)
+//{
+//
+//    size_t null_links = 0;
+//    size_t size_mixed = m_tree->size();
+//
+//    for(size_t ndx = 0; ndx<size_mixed; ++ndx) {
+//
+//        Mixed mixed= m_tree->get(ndx);
+//        if(mixed.is_unresolved_link())
+//        auto link = mixed.get_link();
+//        if(link.is_null() || link.is_unresolved())
+//            null_links += 1;
+//
+//    }
+//    return size_mixed - null_links;
+//}
+
 template <class T>
 inline size_t Lst<T>::size() const
 {
     return update() ? m_tree->size() : 0;
+    
+//    if constexpr (std::is_same<T, Mixed>::value) {
+//        
+//        if(size > 0) {
+//            Mixed mixed = get_any(0);
+//            if(mixed.
+//        } && get_any(0).)
+//        //mixed logic
+//        update();
+//        return mixed_links_size(m_tree);
+//    }
+//    
+//    return ;
 }
 
 template <class T>
@@ -654,6 +686,14 @@ inline T Lst<T>::get(size_t ndx) const
     const auto current_size = size();
     if (ndx >= current_size) {
         throw std::out_of_range("Index out of range");
+    }
+    
+    //proxy out the mixed value for links, we need to know if the link is valid or not (not necesseraly must it be null)
+    if constexpr(std::is_same<T, Mixed>::value)
+    {
+        Mixed mixed_link_value = m_tree->get(ndx);
+        if(mixed_link_value.is_null()) return Mixed{};
+        return mixed_link_value;
     }
     return m_tree->get(ndx);
 }

--- a/src/realm/list.hpp
+++ b/src/realm/list.hpp
@@ -144,19 +144,15 @@ public:
     template <typename Func>
     void find_all(value_type value, Func&& func) const
     {
-        if (update())
-        {
+        if (update()) {
             m_tree->find_all(value, std::forward<Func>(func));
-            if constexpr (std::is_same_v<T, Mixed>)
-            {
-                if (value.is_unresolved_link())
-                {
-                    //if value is a mixed which contains an unresolved link, find all the nulls
+            if constexpr (std::is_same_v<T, Mixed>) {
+                if (value.is_unresolved_link()) {
+                    // if value is a mixed which contains an unresolved link, find all the nulls
                     m_tree->find_all(realm::null(), std::forward<Func>(func));
                 }
-                else if (value.is_null())
-                {
-                    //if value is null then we find all the unresolved links with a linear scan
+                else if (value.is_null()) {
+                    // if value is null then we find all the unresolved links with a linear scan
                     find_all_mixed_unresolved_links(std::forward<Func>(func));
                 }
             }
@@ -274,15 +270,13 @@ protected:
         REALM_ASSERT(m_tree->is_attached());
         return true;
     }
-    
-    template<class Func>
+
+    template <class Func>
     void find_all_mixed_unresolved_links(Func&& func) const
     {
-        for(size_t i=0; i<m_tree->size(); ++i)
-        {
+        for (size_t i = 0; i < m_tree->size(); ++i) {
             auto mixed = m_tree->get(i);
-            if(mixed.is_unresolved_link())
-            {
+            if (mixed.is_unresolved_link()) {
                 func(i);
             }
         }

--- a/src/realm/list.hpp
+++ b/src/realm/list.hpp
@@ -560,42 +560,10 @@ inline T Lst<T>::remove(const iterator& it)
     return remove(it.index());
 }
 
-//template<typename Tree>
-//inline size_t mixed_links_size(Tree& m_tree)
-//{
-//
-//    size_t null_links = 0;
-//    size_t size_mixed = m_tree->size();
-//
-//    for(size_t ndx = 0; ndx<size_mixed; ++ndx) {
-//
-//        Mixed mixed= m_tree->get(ndx);
-//        if(mixed.is_unresolved_link())
-//        auto link = mixed.get_link();
-//        if(link.is_null() || link.is_unresolved())
-//            null_links += 1;
-//
-//    }
-//    return size_mixed - null_links;
-//}
-
 template <class T>
 inline size_t Lst<T>::size() const
 {
     return update() ? m_tree->size() : 0;
-    
-//    if constexpr (std::is_same<T, Mixed>::value) {
-//        
-//        if(size > 0) {
-//            Mixed mixed = get_any(0);
-//            if(mixed.
-//        } && get_any(0).)
-//        //mixed logic
-//        update();
-//        return mixed_links_size(m_tree);
-//    }
-//    
-//    return ;
 }
 
 template <class T>

--- a/src/realm/object-store/property.hpp
+++ b/src/realm/object-store/property.hpp
@@ -204,6 +204,11 @@ inline constexpr bool is_nullable(PropertyType a)
     return to_underlying(a & PropertyType::Nullable) == to_underlying(PropertyType::Nullable);
 }
 
+inline constexpr bool is_mixed(PropertyType a)
+{
+    return to_underlying(a & PropertyType::Mixed) == to_underlying(PropertyType::Mixed);
+}
+
 // Some of the places we use switch_on_type() the Obj version isn't instantiatable
 // or reachable, so we want to map it to a valid type to let the unreachable code compile
 template <typename T>

--- a/src/realm/set.cpp
+++ b/src/realm/set.cpp
@@ -212,7 +212,7 @@ void Set<Mixed>::do_insert(size_t ndx, Mixed value)
 template <>
 void Set<Mixed>::do_erase(size_t ndx)
 {
-    if (Mixed old_value = get_internal(ndx); old_value.is_type(type_TypedLink)) {
+    if (Mixed old_value = m_tree->get(ndx); old_value.is_type(type_TypedLink)) {
         auto old_link = old_value.get<ObjLink>();
 
         CascadeState state(old_link.get_obj_key().is_unresolved() ? CascadeState::Mode::All

--- a/src/realm/set.cpp
+++ b/src/realm/set.cpp
@@ -212,7 +212,7 @@ void Set<Mixed>::do_insert(size_t ndx, Mixed value)
 template <>
 void Set<Mixed>::do_erase(size_t ndx)
 {
-    if (Mixed old_value = get(ndx); old_value.is_type(type_TypedLink)) {
+    if (Mixed old_value = get_internal(ndx); old_value.is_type(type_TypedLink)) {
         auto old_link = old_value.get<ObjLink>();
 
         CascadeState state(old_link.get_obj_key().is_unresolved() ? CascadeState::Mode::All

--- a/src/realm/set.hpp
+++ b/src/realm/set.hpp
@@ -72,12 +72,13 @@ public:
         if (ndx >= current_size) {
             throw std::out_of_range("Index out of range");
         }
-        
-        //proxy out the mixed value for links, we need to know if the link is valid or not (not necesseraly must it be null)
-        if constexpr(std::is_same<T, Mixed>::value)
-        {
+
+        // proxy out the mixed value for links, we need to know if the link is valid or not (not necesseraly must it
+        // be null)
+        if constexpr (std::is_same<T, Mixed>::value) {
             Mixed mixed_link_value = m_tree->get(ndx);
-            if(mixed_link_value.is_null()) return Mixed{};
+            if (mixed_link_value.is_null())
+                return Mixed{};
             return mixed_link_value;
         }
         return m_tree->get(ndx);

--- a/src/realm/set.hpp
+++ b/src/realm/set.hpp
@@ -68,10 +68,14 @@ public:
 
     T get(size_t ndx) const
     {
-        auto value = get_internal(ndx);
-        // proxy out the mixed value for links, we need to know if the link is valid or not (not necesseraly must it
-        // be null)
+        const auto current_size = size();
+        if (ndx >= current_size) {
+            throw std::out_of_range("Index out of range");
+        }
+
+        auto value = m_tree->get(ndx);
         if constexpr (std::is_same_v<T, Mixed>) {
+            // return a null for mixed unresolved link
             if (value.is_type(type_TypedLink) && value.is_unresolved_link())
                 return Mixed{};
         }
@@ -272,8 +276,6 @@ private:
     void assign_symmetric_difference(It1, It2);
 
     static std::vector<T> convert_to_set(const CollectionBase& rhs, bool nullable);
-
-    T get_internal(std::size_t) const;
 
     std::pair<size_t, bool> erase_all_nulls(T value);
 };
@@ -581,16 +583,6 @@ inline LnkSet Obj::get_linkset(ColKey col_key) const
 inline LnkSetPtr Obj::get_linkset_ptr(ColKey col_key) const
 {
     return std::make_unique<LnkSet>(*this, col_key);
-}
-
-template <class T>
-T Set<T>::get_internal(std::size_t ndx) const
-{
-    const auto current_size = size();
-    if (ndx >= current_size) {
-        throw std::out_of_range("Index out of range");
-    }
-    return m_tree->get(ndx);
 }
 
 template <class T>

--- a/src/realm/set.hpp
+++ b/src/realm/set.hpp
@@ -77,7 +77,7 @@ public:
         // be null)
         if constexpr (std::is_same<T, Mixed>::value) {
             Mixed mixed_link_value = m_tree->get(ndx);
-            if (mixed_link_value.is_null())
+            if (mixed_link_value.is_unresolved_link())
                 return Mixed{};
             return mixed_link_value;
         }

--- a/src/realm/set.hpp
+++ b/src/realm/set.hpp
@@ -596,13 +596,6 @@ T Set<T>::get_internal(std::size_t ndx) const
 template <class T>
 size_t Set<T>::find(T value) const
 {
-    if constexpr (std::is_same_v<T, Mixed>) {
-        if (value.is_null() || (value.is_type(type_TypedLink) && value.get_link().is_null())) {
-            auto unresolved_link = m_obj.get_table()->create_object();
-            unresolved_link.invalidate();
-            value = Mixed{unresolved_link};
-        }
-    }
     auto it = find_impl(value);
     if (it != end() && SetElementEquals<T>{}(*it, value)) {
         return it.index();
@@ -646,14 +639,6 @@ std::pair<size_t, bool> Set<T>::insert(T value)
         throw LogicError(LogicError::column_not_nullable);
 
     ensure_created();
-    // if value is null, then convert it to unresolved link
-    if constexpr (std::is_same_v<T, Mixed>) {
-        if (value.is_null() || (value.is_type(type_TypedLink) && value.get_link().is_null())) {
-            auto unresolved_link = m_obj.get_table()->create_object();
-            unresolved_link.invalidate();
-            value = Mixed{unresolved_link};
-        }
-    }
     auto it = find_impl(value);
 
     if (it != this->end() && SetElementEquals<T>{}(*it, value)) {
@@ -691,15 +676,6 @@ std::pair<size_t, bool> Set<T>::insert_any(Mixed value)
 template <class T>
 std::pair<size_t, bool> Set<T>::erase(T value)
 {
-    // Null Mixed must be treated as unresolved link
-    if constexpr (std::is_same_v<T, Mixed>) {
-        if (value.is_null() || (value.is_type(type_TypedLink) && value.get_link().is_null())) {
-            auto unresolved_link = m_obj.get_table()->create_object();
-            unresolved_link.invalidate();
-            value = Mixed{unresolved_link};
-        }
-    }
-
     auto it = find_impl(value); // Note: This ends up calling `update_if_needed()`.
 
     if (it == end() || !SetElementEquals<T>{}(*it, value)) {

--- a/src/realm/set.hpp
+++ b/src/realm/set.hpp
@@ -116,10 +116,7 @@ public:
 
     /// Erase an element from the set, returning true if the set contained the element.
     /// In case of null mixed links by default all the nulls will be deleted
-    enum class MixedNullLink {
-        EraseAll = 0,
-        EraseOne = 1
-    };
+    enum class MixedNullLink { EraseAll = 0, EraseOne = 1 };
     template <MixedNullLink e = MixedNullLink::EraseAll>
     std::pair<size_t, bool> erase(T value);
 

--- a/src/realm/set.hpp
+++ b/src/realm/set.hpp
@@ -95,7 +95,7 @@ public:
 
     template <class Func>
     void find_all(const T& value, Func&& func) const;
-    
+
     bool is_subset_of(const CollectionBase&) const;
     bool is_strict_subset_of(const CollectionBase& rhs) const;
     bool is_superset_of(const CollectionBase& rhs) const;
@@ -115,9 +115,9 @@ public:
     size_t find(T value) const;
 
     /// Erase an element from the set, returning true if the set contained the element.
-    template<bool AllNull = true>
+    template <bool AllNull = true>
     std::pair<size_t, bool> erase(T value);
-    
+
     // Overriding members of CollectionBase:
     size_t size() const final;
     bool is_null(size_t ndx) const final;
@@ -272,7 +272,7 @@ private:
     static std::vector<T> convert_to_set(const CollectionBase& rhs, bool nullable);
 
     T get_internal(std::size_t) const;
-    
+
     std::pair<size_t, bool> erase_all_nulls(T value);
 };
 
@@ -641,13 +641,12 @@ template <class Func>
 void Set<T>::find_all(const T& value, Func&& func) const
 {
     auto it = find_impl(value);
-    
-    if(it == end())
-    {
+
+    if (it == end()) {
         func(not_found);
         return;
     }
-        
+
     while (it != end() && SetElementEquals<T>{}(*it, value)) {
         func(it.index());
         it += 1;
@@ -702,11 +701,11 @@ template <class T>
 template <bool AllNull>
 std::pair<size_t, bool> Set<T>::erase(T value)
 {
-    if constexpr(std::is_same_v<Mixed, T> && AllNull) {
-        if(value.is_null())
+    if constexpr (std::is_same_v<Mixed, T> && AllNull) {
+        if (value.is_null())
             return erase_null();
     }
-    
+
     auto it = find_impl(value); // Note: This ends up calling `update_if_needed()`.
     if (it == end() || !SetElementEquals<T>{}(*it, value)) {
         return {npos, false};
@@ -746,7 +745,7 @@ template <class T>
 std::pair<size_t, bool> Set<T>::erase_null()
 {
     const auto& res = erase<false>(BPlusTree<T>::default_value(this->m_nullable));
-    if(res.second)
+    if (res.second)
         return erase_null();
     return res;
 }

--- a/src/realm/set.hpp
+++ b/src/realm/set.hpp
@@ -72,6 +72,14 @@ public:
         if (ndx >= current_size) {
             throw std::out_of_range("Index out of range");
         }
+        
+        //proxy out the mixed value for links, we need to know if the link is valid or not (not necesseraly must it be null)
+        if constexpr(std::is_same<T, Mixed>::value)
+        {
+            Mixed mixed_link_value = m_tree->get(ndx);
+            if(mixed_link_value.is_null()) return Mixed{};
+            return mixed_link_value;
+        }
         return m_tree->get(ndx);
     }
 

--- a/src/realm/set.hpp
+++ b/src/realm/set.hpp
@@ -745,7 +745,7 @@ template <class T>
 std::pair<size_t, bool> Set<T>::erase_null()
 {
     auto res = erase<false>(BPlusTree<T>::default_value(this->m_nullable));
-    if(res.second)
+    if (res.second)
         erase_null();
     return res;
 }

--- a/src/realm/set.hpp
+++ b/src/realm/set.hpp
@@ -115,7 +115,12 @@ public:
     size_t find(T value) const;
 
     /// Erase an element from the set, returning true if the set contained the element.
-    template <bool AllNull = true>
+    /// In case of null mixed links by default all the nulls will be deleted
+    enum class MixedNullLink {
+        EraseAll = 0,
+        EraseOne = 1
+    };
+    template <MixedNullLink e = MixedNullLink::EraseAll>
     std::pair<size_t, bool> erase(T value);
 
     // Overriding members of CollectionBase:
@@ -698,10 +703,10 @@ std::pair<size_t, bool> Set<T>::insert_any(Mixed value)
 }
 
 template <class T>
-template <bool AllNull>
+template <typename Set<T>::MixedNullLink e>
 std::pair<size_t, bool> Set<T>::erase(T value)
 {
-    if constexpr (std::is_same_v<Mixed, T> && AllNull) {
+    if constexpr (std::is_same_v<Mixed, T> && e == MixedNullLink::EraseAll) {
         if (value.is_null())
             return erase_null();
     }
@@ -744,7 +749,7 @@ inline std::pair<size_t, bool> Set<T>::insert_null()
 template <class T>
 std::pair<size_t, bool> Set<T>::erase_null()
 {
-    auto res = erase<false>(BPlusTree<T>::default_value(this->m_nullable));
+    auto res = erase<MixedNullLink::EraseOne>(BPlusTree<T>::default_value(this->m_nullable));
     if (res.second)
         erase_null();
     return res;

--- a/src/realm/set.hpp
+++ b/src/realm/set.hpp
@@ -744,9 +744,9 @@ inline std::pair<size_t, bool> Set<T>::insert_null()
 template <class T>
 std::pair<size_t, bool> Set<T>::erase_null()
 {
-    const auto& res = erase<false>(BPlusTree<T>::default_value(this->m_nullable));
-    if (res.second)
-        return erase_null();
+    auto res = erase<false>(BPlusTree<T>::default_value(this->m_nullable));
+    if(res.second)
+        erase_null();
     return res;
 }
 

--- a/test/object-store/collection_fixtures.hpp
+++ b/test/object-store/collection_fixtures.hpp
@@ -629,7 +629,8 @@ struct ListOfMixedLinks : public LinkedCollectionBase {
         Lst<Mixed> list = obj.get_list<Mixed>(col);
         size_t num_unresolved = 0;
         for (auto value : list) {
-            if (value.is_unresolved_link()) {
+            // mixed link can never be invalid only null
+            if (value.is_null()) {
                 ++num_unresolved;
             }
         }
@@ -736,7 +737,8 @@ struct SetOfMixedLinks : public LinkedCollectionBase {
         Set<Mixed> set = obj.get_set<Mixed>(col);
         size_t num_unresolved = 0;
         for (auto value : set) {
-            if (value.is_unresolved_link()) {
+            // mixed link can never be invalid only null
+            if (value.is_null()) {
                 ++num_unresolved;
             }
         }

--- a/test/object-store/collection_fixtures.hpp
+++ b/test/object-store/collection_fixtures.hpp
@@ -629,8 +629,7 @@ struct ListOfMixedLinks : public LinkedCollectionBase {
         Lst<Mixed> list = obj.get_list<Mixed>(col);
         size_t num_unresolved = 0;
         for (auto value : list) {
-            // mixed link can never be invalid only null
-            if (value.is_null()) {
+            if (value.is_unresolved_link()) {
                 ++num_unresolved;
             }
         }
@@ -737,8 +736,7 @@ struct SetOfMixedLinks : public LinkedCollectionBase {
         Set<Mixed> set = obj.get_set<Mixed>(col);
         size_t num_unresolved = 0;
         for (auto value : set) {
-            // mixed link can never be invalid only null
-            if (value.is_null()) {
+            if (value.is_unresolved_link()) {
                 ++num_unresolved;
             }
         }

--- a/test/object-store/transaction_log_parsing.cpp
+++ b/test/object-store/transaction_log_parsing.cpp
@@ -1692,7 +1692,7 @@ TEMPLATE_TEST_CASE("DeepChangeChecker collections", "[notifications]", cf::ListO
         if (TestType::allows_storing_nulls) {
             REQUIRE(test_type.size_of_collection(objects[0]) == 3);
             const auto type = test_type.property().type;
-            size_t unresolved_links_counter = (is_mixed(type) && (is_set(type) || is_array(type))) ? 0 : 1;
+            size_t unresolved_links_counter = (is_mixed(type) && is_array(type)) ? 0 : 1;
             REQUIRE(test_type.count_unresolved_links(objects[0]) == unresolved_links_counter);
             REQUIRE(test_type.count_unresolved_links(objects[1]) == unresolved_links_counter);
             REQUIRE(test_type.count_unresolved_links(objects[2]) == unresolved_links_counter);

--- a/test/object-store/transaction_log_parsing.cpp
+++ b/test/object-store/transaction_log_parsing.cpp
@@ -1691,9 +1691,11 @@ TEMPLATE_TEST_CASE("DeepChangeChecker collections", "[notifications]", cf::ListO
         objects[obj_ndx_to_invalidate].invalidate();
         if (TestType::allows_storing_nulls) {
             REQUIRE(test_type.size_of_collection(objects[0]) == 3);
-            REQUIRE(test_type.count_unresolved_links(objects[0]) == 1);
-            REQUIRE(test_type.count_unresolved_links(objects[1]) == 1);
-            REQUIRE(test_type.count_unresolved_links(objects[2]) == 1);
+            const auto type = test_type.property().type;
+            size_t unresolved_links_counter = (is_mixed(type) && (is_set(type) || is_array(type))) ? 0 : 1;
+            REQUIRE(test_type.count_unresolved_links(objects[0]) == unresolved_links_counter);
+            REQUIRE(test_type.count_unresolved_links(objects[1]) == unresolved_links_counter);
+            REQUIRE(test_type.count_unresolved_links(objects[2]) == unresolved_links_counter);
         }
         else {
             // LnkLst actually has 3 entries but hides one

--- a/test/test_links.cpp
+++ b/test/test_links.cpp
@@ -1632,21 +1632,16 @@ TEST(Unresolved_Mixed_links)
     // difference between list/set of links and lst/set of Mixed, size returns the whole list of links also the
     // null/unresolved ones
     expected_size = 1;
-    CHECK_EQUAL(list_mixed.size(), expected_size); // fails
-    CHECK_EQUAL(set_mixed.size(), expected_size);  // fails
+    CHECK_EQUAL(list_mixed.size(), expected_size);
+    CHECK_EQUAL(set_mixed.size(), expected_size);
 
-    auto check_mixed_link = [&](Mixed link) {
-        auto is_null = link.is_null();
-        auto is_unresolved = link.is_unresolved_link();
-        CHECK(is_null || is_unresolved);
-    };
     if (list_mixed.size()) {
         auto link = list_mixed.get(0);
-        check_mixed_link(link);
+        CHECK(link.is_null());
     }
     if (set_mixed.size()) {
         auto link = set_mixed.get(0);
-        check_mixed_link(link);
+        CHECK(link.is_null());
     }
 }
 

--- a/test/test_links.cpp
+++ b/test/test_links.cpp
@@ -1605,4 +1605,48 @@ TEST(Links_DetachedAccessor)
     CHECK_NOT(link_list.is_attached());
 }
 
+TEST(Unresolved_Mixed_links)
+{
+    Group g;
+    
+    auto source_table = g.add_table_with_primary_key("source", type_Int, "source_id");
+    auto dest_table = g.add_table_with_primary_key("dest", type_Int, "dest_id");
+    auto list_mixed_col = source_table->add_column_list(type_Mixed, "list of mixed");
+    auto set_of_mixed_col = source_table->add_column_set(type_Mixed, "set of mixed");
+    
+    auto source_obj = source_table->create_object_with_primary_key(0);
+    auto dest_obj = dest_table->create_object_with_primary_key(1);
+    
+    Lst<Mixed> list_mixed = source_obj.get_list<Mixed>(list_mixed_col);
+    Set<Mixed> set_mixed = source_obj.get_set<Mixed>(set_of_mixed_col);
+    
+    list_mixed.add(ObjLink{dest_table->get_key(), dest_obj.get_key()});
+    set_mixed.insert(ObjLink{dest_table->get_key(), dest_obj.get_key()});
+    
+    size_t expected_size = 1;
+    CHECK_EQUAL(list_mixed.size(), expected_size);
+    CHECK_EQUAL(set_mixed.size(), expected_size);
+    
+    dest_obj.invalidate(); // send to graveyard, and transform all incoming links to be unresolved
+    
+    //difference between list/set of links and lst/set of Mixed, size returns the whole list of links also the null/unresolved ones
+    expected_size = 1;
+    CHECK_EQUAL(list_mixed.size(), expected_size); // fails
+    CHECK_EQUAL(set_mixed.size(), expected_size);  // fails
+    
+    auto check_mixed_link = [&](Mixed link) {
+        auto is_null = link.is_null();
+        auto is_unresolved = link.is_unresolved_link();
+        CHECK(is_null || is_unresolved);
+    };
+    if(list_mixed.size()) {
+        auto link = list_mixed.get(0);
+        check_mixed_link(link);
+    }
+    if(set_mixed.size()) {
+        auto link = set_mixed.get(0);
+        check_mixed_link(link);
+    }
+}
+
 #endif // TEST_LINKS

--- a/test/test_links.cpp
+++ b/test/test_links.cpp
@@ -1608,42 +1608,43 @@ TEST(Links_DetachedAccessor)
 TEST(Unresolved_Mixed_links)
 {
     Group g;
-    
+
     auto source_table = g.add_table_with_primary_key("source", type_Int, "source_id");
     auto dest_table = g.add_table_with_primary_key("dest", type_Int, "dest_id");
     auto list_mixed_col = source_table->add_column_list(type_Mixed, "list of mixed");
     auto set_of_mixed_col = source_table->add_column_set(type_Mixed, "set of mixed");
-    
+
     auto source_obj = source_table->create_object_with_primary_key(0);
     auto dest_obj = dest_table->create_object_with_primary_key(1);
-    
+
     Lst<Mixed> list_mixed = source_obj.get_list<Mixed>(list_mixed_col);
     Set<Mixed> set_mixed = source_obj.get_set<Mixed>(set_of_mixed_col);
-    
+
     list_mixed.add(ObjLink{dest_table->get_key(), dest_obj.get_key()});
     set_mixed.insert(ObjLink{dest_table->get_key(), dest_obj.get_key()});
-    
+
     size_t expected_size = 1;
     CHECK_EQUAL(list_mixed.size(), expected_size);
     CHECK_EQUAL(set_mixed.size(), expected_size);
-    
+
     dest_obj.invalidate(); // send to graveyard, and transform all incoming links to be unresolved
-    
-    //difference between list/set of links and lst/set of Mixed, size returns the whole list of links also the null/unresolved ones
+
+    // difference between list/set of links and lst/set of Mixed, size returns the whole list of links also the
+    // null/unresolved ones
     expected_size = 1;
     CHECK_EQUAL(list_mixed.size(), expected_size); // fails
     CHECK_EQUAL(set_mixed.size(), expected_size);  // fails
-    
+
     auto check_mixed_link = [&](Mixed link) {
         auto is_null = link.is_null();
         auto is_unresolved = link.is_unresolved_link();
         CHECK(is_null || is_unresolved);
     };
-    if(list_mixed.size()) {
+    if (list_mixed.size()) {
         auto link = list_mixed.get(0);
         check_mixed_link(link);
     }
-    if(set_mixed.size()) {
+    if (set_mixed.size()) {
         auto link = set_mixed.get(0);
         check_mixed_link(link);
     }

--- a/test/test_mixed_null_assertions.cpp
+++ b/test/test_mixed_null_assertions.cpp
@@ -120,19 +120,16 @@ TEST(Mixed_List_unresolved_as_null)
     }
 
     {
-        // find null or unresolved link must work the same way
+        // find null or find unresolved link diverge, different objects should be returned
         auto index = list.find_any(realm::null());
         CHECK(index == 0);
         index = list.find_first(obj1);
-        CHECK(index == 0);
-    }
-
-    {
-        // is null for unresolved links and null must behave the same way
+        CHECK(index == 2);
+        //but both should look like nulls
         CHECK(list.is_null(0));
         CHECK(list.is_null(2));
     }
-
+    
     {
         std::vector<size_t> indices{0, 1, 2};
         list.sort(indices);
@@ -158,7 +155,7 @@ TEST(Mixed_List_unresolved_as_null)
 
     {
         list.remove(0);
-        CHECK(list.find_any(realm::null()) == 1);
+        CHECK(list.find_any(obj1) == 1);
         list.remove(1);
         CHECK(list.find_any(realm::null()) == npos);
         CHECK(list.size() == 1);
@@ -276,8 +273,7 @@ TEST(Mixed_Set_unresolved_as_null)
         CHECK(set.size() == 3);
         obj6.invalidate();
         // remove only the first null
-        using erase_one = Set<Mixed>::MixedNullLink::One;
-        set.erase<erase_one>(Mixed{});
+        set.erase<Set<Mixed>::MixedNullLink::EraseOne>(Mixed{});
         CHECK(set.size() == 2);
     }
 }

--- a/test/test_mixed_null_assertions.cpp
+++ b/test/test_mixed_null_assertions.cpp
@@ -91,29 +91,32 @@ TEST(Mixed_List_unresolved_as_null)
 
     list.insert_null(0);
     list.insert(1, Mixed{"test"});
-    obj1.invalidate();
     list.insert(2, obj1);
+    obj1.invalidate();
 
     CHECK(list.size() == 3);
 
     {
         // find all mixed nulls or unresolved link should work the same way
-        int cnt = 0;
-        list.find_all(realm::null(), [this, &cnt](size_t pos) {
-            if (cnt == 0)
-                CHECK(pos == 0);
-            else if (cnt == 1)
-                CHECK(pos == 2);
-            cnt += 1;
+        std::vector<size_t> found;
+        std::vector<size_t> expected = {0, 2};
+        auto check_results = [&]() {
+            CHECK_EQUAL(found.size(), expected.size());
+            std::sort(found.begin(), found.end());
+            std::sort(expected.begin(), expected.end());
+            for (size_t i = 0; i < found.size(); ++i) {
+                CHECK_EQUAL(found[i], expected[i]);
+            }
+        };
+        list.find_all(realm::null(), [&](size_t pos) {
+            found.push_back(pos);
         });
-        cnt = 0;
-        list.find_all(obj1, [this, &cnt](size_t pos) {
-            if (cnt == 0)
-                CHECK(pos == 0);
-            else if (cnt == 1)
-                CHECK(pos == 2);
-            cnt += 1;
+        check_results();
+        found = {};
+        list.find_all(obj1, [&](size_t pos) {
+            found.push_back(pos);
         });
+        check_results();
     }
 
     {

--- a/test/test_mixed_null_assertions.cpp
+++ b/test/test_mixed_null_assertions.cpp
@@ -125,11 +125,11 @@ TEST(Mixed_List_unresolved_as_null)
         CHECK(index == 0);
         index = list.find_first(obj1);
         CHECK(index == 2);
-        //but both should look like nulls
+        // but both should look like nulls
         CHECK(list.is_null(0));
         CHECK(list.is_null(2));
     }
-    
+
     {
         std::vector<size_t> indices{0, 1, 2};
         list.sort(indices);

--- a/test/test_mixed_null_assertions.cpp
+++ b/test/test_mixed_null_assertions.cpp
@@ -100,17 +100,17 @@ TEST(Mixed_List_unresolved_as_null)
         // find all mixed nulls or unresolved link should work the same way
         int cnt = 0;
         list.find_all(realm::null(), [this, &cnt](size_t pos) {
-            if(cnt == 0)
+            if (cnt == 0)
                 CHECK(pos == 0);
-            else if(cnt == 1)
+            else if (cnt == 1)
                 CHECK(pos == 2);
             cnt += 1;
         });
         cnt = 0;
         list.find_all(obj1, [this, &cnt](size_t pos) {
-            if(cnt == 0)
+            if (cnt == 0)
                 CHECK(pos == 0);
-            else if(cnt == 1)
+            else if (cnt == 1)
                 CHECK(pos == 2);
             cnt += 1;
         });
@@ -181,7 +181,7 @@ TEST(Mixed_Set_unresolved_as_null)
     CHECK(success1);
 
     {
-        //null treated as invalalid link
+        // null treated as invalalid link
         CHECK(set.size() == 2);
         auto [it, success] = set.insert(Mixed{});
         CHECK(!success);
@@ -218,9 +218,9 @@ TEST(Mixed_Set_unresolved_as_null)
         CHECK(indices[0] == 0);
         CHECK(indices[1] == 1);
     }
-    
+
     {
-        //trigger interface exception, we ended up with multiple nulls
+        // trigger interface exception, we ended up with multiple nulls
         Group g;
         auto t = g.add_table("foo");
         t->add_column_set(type_Mixed, "mixeds");
@@ -239,21 +239,21 @@ TEST(Mixed_Set_unresolved_as_null)
         CHECK(set.is_null(0));
         CHECK(!set.is_null(1));
         obj2.invalidate();
-        //this is the only violation we allow right now, we have ended up with 2 nulls
+        // this is the only violation we allow right now, we have ended up with 2 nulls
         CHECK(set.is_null(0));
         CHECK(set.is_null(1));
         auto obj3 = t->create_object();
         set.insert(obj3);
         CHECK(set.size() == 3);
         int cnt = 0;
-        //we can now do find_all for nulls
+        // we can now do find_all for nulls
         set.find_all(Mixed{}, [this, &set, &cnt](size_t index) {
             CHECK(index == 0 || index == 1);
             CHECK(set.is_null(index));
             cnt += 1;
         });
         CHECK(cnt == 2);
-        //erase null will erase all the nulls
+        // erase null will erase all the nulls
         set.erase_null();
         CHECK(set.size() == 1);
         auto obj4 = t->create_object();
@@ -261,7 +261,7 @@ TEST(Mixed_Set_unresolved_as_null)
         set.insert(obj4);
         set.insert(obj5);
         CHECK(set.size() == 3);
-        //erase all the nulls by default
+        // erase all the nulls by default
         obj4.invalidate();
         obj5.invalidate();
         set.erase(Mixed{});
@@ -272,7 +272,7 @@ TEST(Mixed_Set_unresolved_as_null)
         set.insert(obj7);
         CHECK(set.size() == 3);
         obj6.invalidate();
-        //remove only the first null
+        // remove only the first null
         set.erase<false>(Mixed{});
         CHECK(set.size() == 2);
     }

--- a/test/test_mixed_null_assertions.cpp
+++ b/test/test_mixed_null_assertions.cpp
@@ -232,23 +232,24 @@ TEST(Mixed_Set_unresolved_as_null)
         auto obj1 = t->create_object();
         auto obj2 = t->create_object();
         auto set = obj.get_set<Mixed>("mixeds");
+        set.insert(Mixed(1));
         auto [it, success] = set.insert(obj1);
         auto [it1, success1] = set.insert(obj2);
         CHECK(success);
         CHECK(success1);
-        CHECK(set.size() == 2);
-        CHECK(!set.is_null(0));
+        CHECK_EQUAL(set.size(), 3);
         CHECK(!set.is_null(1));
+        CHECK(!set.is_null(2));
         obj1.invalidate();
-        CHECK(set.is_null(0));
-        CHECK(!set.is_null(1));
+        CHECK(set.is_null(1));
+        CHECK(!set.is_null(2));
         obj2.invalidate();
         // this is the only violation we allow right now, we have ended up with 2 nulls
-        CHECK(set.is_null(0));
         CHECK(set.is_null(1));
+        CHECK(set.is_null(2));
         auto obj3 = t->create_object();
         set.insert(obj3);
-        CHECK(set.size() == 3);
+        CHECK_EQUAL(set.size(), 4);
         // we can now do find_all for nulls (only actual null values will be returned, no unresolved links)
         set.find_all(Mixed{}, [this, &set](size_t index) {
             CHECK(index == 0);
@@ -256,28 +257,28 @@ TEST(Mixed_Set_unresolved_as_null)
         });
         // erase null will erase only nulls (no unresolved)
         set.erase_null();
-        CHECK(set.size() == 1);
+        CHECK_EQUAL(set.size(), 1);
         auto obj4 = t->create_object();
         auto obj5 = t->create_object();
         set.insert(obj4);
         set.insert(obj5);
-        CHECK(set.size() == 3);
+        CHECK_EQUAL(set.size(), 3);
         // erase all the nulls by default
         obj4.invalidate();
         obj5.invalidate();
         set.erase_null();
-        CHECK(set.size() == 1);
+        CHECK_EQUAL(set.size(), 1);
         auto obj6 = t->create_object();
         auto obj7 = t->create_object();
         set.insert(obj6);
         set.insert(obj7);
-        CHECK(set.size() == 3);
+        CHECK_EQUAL(set.size(), 3);
         obj6.invalidate();
         // remove only obj6 (no allowed)
         set.erase(obj6);
-        CHECK(set.size() == 3);
+        CHECK_EQUAL(set.size(), 3);
         obj7.invalidate();
         set.erase(Mixed{});
-        CHECK(set.size() == 1);
+        CHECK_EQUAL(set.size(), 1);
     }
 }

--- a/test/test_mixed_null_assertions.cpp
+++ b/test/test_mixed_null_assertions.cpp
@@ -100,23 +100,27 @@ TEST(Mixed_List_unresolved_as_null)
         // find all mixed nulls or unresolved link should work the same way
         std::vector<size_t> found;
         std::vector<size_t> expected = {0, 2};
-        auto check_results = [&]() {
-            CHECK_EQUAL(found.size(), expected.size());
+        auto check_results = [&]() -> bool {
+            if (found.size() != expected.size())
+                return false;
+
             std::sort(found.begin(), found.end());
             std::sort(expected.begin(), expected.end());
             for (size_t i = 0; i < found.size(); ++i) {
-                CHECK_EQUAL(found[i], expected[i]);
+                if (found[i] != expected[i])
+                    return false;
             }
+            return true;
         };
         list.find_all(realm::null(), [&](size_t pos) {
             found.push_back(pos);
         });
-        check_results();
+        CHECK(check_results());
         found = {};
         list.find_all(obj1, [&](size_t pos) {
             found.push_back(pos);
         });
-        check_results();
+        CHECK(!check_results());
     }
 
     {

--- a/test/test_mixed_null_assertions.cpp
+++ b/test/test_mixed_null_assertions.cpp
@@ -273,7 +273,8 @@ TEST(Mixed_Set_unresolved_as_null)
         CHECK(set.size() == 3);
         obj6.invalidate();
         // remove only the first null
-        set.erase<false>(Mixed{});
+        using erase_one = Set<Mixed>::MixedNullLink::One;
+        set.erase<erase_one>(Mixed{});
         CHECK(set.size() == 2);
     }
 }

--- a/test/test_mixed_null_assertions.cpp
+++ b/test/test_mixed_null_assertions.cpp
@@ -171,11 +171,10 @@ TEST(Mixed_Set_unresolved_as_null)
     auto obj = t->create_object();
     auto obj1 = t->create_object();
     auto obj2 = t->create_object();
-    obj1.invalidate();
-    obj2.invalidate();
-
     auto set = obj.get_set<Mixed>("mixeds");
     auto [it, success] = set.insert(Mixed{obj1});
+    obj1.invalidate();
+
     CHECK(success);
     auto [it1, success1] = set.insert(Mixed{"test"});
     CHECK(success1);
@@ -210,13 +209,15 @@ TEST(Mixed_Set_unresolved_as_null)
 
     {
         auto [it, success] = set.insert(Mixed{obj2});
-        CHECK(!success);
-        CHECK(set.size() == 2);
-        std::vector<size_t> indices{0, 1};
+        obj2.invalidate();
+        CHECK(success);
+        CHECK(set.size() == 3);
+        std::vector<size_t> indices{1, 0, 2};
         set.sort(indices);
-        CHECK(indices.size() == 2);
+        CHECK(indices.size() == 3);
         CHECK(indices[0] == 0);
         CHECK(indices[1] == 1);
+        CHECK(indices[2] == 2);
     }
 
     {

--- a/test/test_mixed_null_assertions.cpp
+++ b/test/test_mixed_null_assertions.cpp
@@ -152,7 +152,7 @@ TEST(Mixed_List_unresolved_as_null)
     }
 }
 
-ONLY(Mixed_Set_unresolved_as_null)
+TEST(Mixed_Set_unresolved_as_null)
 {
     Group g;
 


### PR DESCRIPTION
## What, How & Why?
This PR attempts to fix the issue we have in the way we represent Mixed Links for Lists and Sets.
As per the current implementation, we are leaking a mixed link that is unresolved and not signalling it. 
Although, the method ```size``` both for ```Lst<Mixed>``` and ```Set<Mixed>``` that contains an unresolved ```Mixed``` link could be easily fixable, adding a O(n) check only for these data structures and only for ```T == Mixed```, this would have 2 implications:

1. Adding O(n) computation in a function that should behave in O(lg n) for ```Mixed``` that contain links. 
2. Breaking Links representation for Sync code. It seems to me that altering the size of ```List<Mixed>``` and ```Set<Mixed>``` might have implication in regard to how sync behaves, and it might also have implication in the way SDKs are using these containers. 

Although I am not 100% sure, we can really invalidate these DS and avoid to break SDKs (changing the size or even removing the links altogether), 
It seems to me that the less impactful solution to this problem is to keep a bit of discrepancy in the interface between ```LnkLst``` and ```Lst<Mixed>``` for the ```size()``` method and return for the former case all the links - tombstone, whereas for the latter all the links (invalidating the Mixed links, thus avoiding exposing an unreferenced link as it a resolved one)

Besides, I have a doubt about ```Lst<T>::size()``` and ```LnkLst::size()```. In the current implementation, ```LnkList::size()``` returns the tree size - tombstone links.
So for example if we have 

```1 -> 2 -> 3``` 

And I invalidate the link number 2, the total size will be 2.
Assuming the list is going to be accessed sequentially using a for loop, I expect this code to be legit.
for(size_t i=0; i<list.size(); ++i) 
     list.get(i)
I am not sure whether ```LnkLst``` erases the link in the middle (I guess it does, otherwise we might have lost link 3 forever) but surely we can't do that for ```Lst<Mixed>``` without otherwise triggering a sync refresh. 
It seems like the same does not happen, returning an unresolved link (at least I haven't found a test that failed)


Fixes https://github.com/realm/realm-core/issues/5215

## ☑️ ToDos
* [ ] 📝 Changelog update
* [ ] 🚦 Tests (or not relevant)
