### PR TITLE
fix a crash during discardLocal reset if the session dies

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 ### Fixed
 * <How do the end-user experience this issue? what was the impact?> ([#????](https://github.com/realm/realm-core/issues/????), since v?.?.?)
 * Query parser would not accept "in" as a property name ([#5312](https://github.com/realm/realm-core/issues/5312))
+* Fixed a potential crash if a sync session is stopped in the middle of a `DiscardLocal` client reset. ([#5295](https://github.com/realm/realm-core/issues/5295), since v11.5.0) 
  
 ### Breaking changes
 * SchemaMode::ResetFile renamed to SchemaMode::SoftResetFile.

--- a/src/realm/object-store/sync/sync_session.cpp
+++ b/src/realm/object-store/sync/sync_session.cpp
@@ -533,24 +533,25 @@ sync::Session::Config::ClientReset make_client_reset_config(SyncConfig& session_
 {
     sync::Session::Config::ClientReset config;
     config.discard_local = (session_config.client_resync_mode == ClientResyncMode::DiscardLocal);
-    config.notify_after_client_reset = [&session_config](std::string local_path, VersionID previous_version) {
-        REALM_ASSERT(!local_path.empty());
-        SharedRealm frozen_before, active_after;
-        if (auto local_coordinator = RealmCoordinator::get_existing_coordinator(local_path)) {
-            auto local_config = local_coordinator->get_config();
-            active_after = local_coordinator->get_realm(local_config, util::none);
-            local_config.scheduler = nullptr;
-            frozen_before = local_coordinator->get_realm(local_config, previous_version);
-            REALM_ASSERT(active_after);
-            REALM_ASSERT(!active_after->is_frozen());
-            REALM_ASSERT(frozen_before);
-            REALM_ASSERT(frozen_before->is_frozen());
-        }
-        if (session_config.notify_after_client_reset) {
-            session_config.notify_after_client_reset(frozen_before, active_after);
-        }
-    };
-    config.notify_before_client_reset = [&session_config](std::string local_path) {
+    config.notify_after_client_reset =
+        [notify = session_config.notify_after_client_reset](std::string local_path, VersionID previous_version) {
+            REALM_ASSERT(!local_path.empty());
+            SharedRealm frozen_before, active_after;
+            if (auto local_coordinator = RealmCoordinator::get_existing_coordinator(local_path)) {
+                auto local_config = local_coordinator->get_config();
+                active_after = local_coordinator->get_realm(local_config, util::none);
+                local_config.scheduler = nullptr;
+                frozen_before = local_coordinator->get_realm(local_config, previous_version);
+                REALM_ASSERT(active_after);
+                REALM_ASSERT(!active_after->is_frozen());
+                REALM_ASSERT(frozen_before);
+                REALM_ASSERT(frozen_before->is_frozen());
+            }
+            if (notify) {
+                notify(frozen_before, active_after);
+            }
+        };
+    config.notify_before_client_reset = [notify = session_config.notify_before_client_reset](std::string local_path) {
         REALM_ASSERT(!local_path.empty());
         SharedRealm frozen_local;
         Realm::Config local_config;
@@ -561,8 +562,8 @@ sync::Session::Config::ClientReset make_client_reset_config(SyncConfig& session_
             REALM_ASSERT(frozen_local);
             REALM_ASSERT(frozen_local->is_frozen());
         }
-        if (session_config.notify_before_client_reset) {
-            session_config.notify_before_client_reset(frozen_local);
+        if (notify) {
+            notify(frozen_local);
         }
     };
     config.fresh_copy = std::move(fresh_copy);


### PR DESCRIPTION
Fixes https://github.com/realm/realm-core/issues/5295

I couldn't find a way to directly trigger the same crash reported by @nirinchev. But the test I added fails when run with the address sanitizer and the checks ensure that the after callback is not invoked. 

## ☑️ ToDos
* [x] 📝 Changelog update
* [x] 🚦 Tests (or not relevant)
