### PR TITLE
Improve handling of keychain errors on macOS

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 ### Fixed
 * <How do the end-user experience this issue? what was the impact?> ([#????](https://github.com/realm/realm-core/issues/????), since v?.?.?)
 * Fixed a potential crash if a sync session is stopped in the middle of a `DiscardLocal` client reset. ([#5295](https://github.com/realm/realm-core/issues/5295), since v11.5.0) 
+* Opening an encrypted Realm while the keychain is locked on macOS would crash ([Swift #7438](https://github.com/realm/realm-swift/issues/7438)).
  
 ### Breaking changes
 * None.

--- a/src/realm.h
+++ b/src/realm.h
@@ -3050,7 +3050,6 @@ RLM_API void realm_sync_client_config_set_metadata_mode(realm_sync_client_config
                                                         realm_sync_client_metadata_mode_e) RLM_API_NOEXCEPT;
 RLM_API void realm_sync_client_config_set_metadata_encryption_key(realm_sync_client_config_t*,
                                                                   const uint8_t[64]) RLM_API_NOEXCEPT;
-RLM_API void realm_sync_client_config_set_reset_metadata_on_error(realm_sync_client_config_t*, bool) RLM_API_NOEXCEPT;
 RLM_API void realm_sync_client_config_set_log_callback(realm_sync_client_config_t*, realm_log_func_t, void* userdata,
                                                        realm_free_userdata_func_t) RLM_API_NOEXCEPT;
 RLM_API void realm_sync_client_config_set_log_level(realm_sync_client_config_t*, realm_log_level_e) RLM_API_NOEXCEPT;

--- a/src/realm/object-store/c_api/sync.cpp
+++ b/src/realm/object-store/c_api/sync.cpp
@@ -248,12 +248,6 @@ RLM_API void realm_sync_client_config_set_encryption_key(realm_sync_client_confi
     config->custom_encryption_key = std::vector<char>(key, key + 64);
 }
 
-RLM_API void realm_sync_client_config_set_reset_metadata_on_error(realm_sync_client_config_t* config,
-                                                                  bool reset) noexcept
-{
-    config->reset_metadata_on_error = reset;
-}
-
 RLM_API void realm_sync_client_config_set_log_callback(realm_sync_client_config_t* config, realm_log_func_t callback,
                                                        void* userdata,
                                                        realm_free_userdata_func_t userdata_free) noexcept

--- a/src/realm/object-store/impl/apple/keychain_helper.cpp
+++ b/src/realm/object-store/impl/apple/keychain_helper.cpp
@@ -18,7 +18,6 @@
 
 #include <realm/object-store/impl/apple/keychain_helper.hpp>
 
-
 #include <realm/util/cf_ptr.hpp>
 #include <realm/util/optional.hpp>
 
@@ -26,21 +25,21 @@
 
 #include <string>
 
-using realm::util::adoptCF;
-using realm::util::CFPtr;
-using realm::util::retainCF;
-
-namespace realm {
-namespace keychain {
-
-KeychainAccessException::KeychainAccessException(int32_t error_code)
-    : std::runtime_error(util::format("Keychain returned unexpected status code: %1", error_code))
-{
-}
+using namespace realm;
+using util::adoptCF;
+using util::CFPtr;
+using util::retainCF;
 
 namespace {
 
+std::runtime_error keychain_access_exception(int32_t error_code)
+{
+    return std::runtime_error(util::format("Keychain returned unexpected status code: %1", error_code));
+}
+
 constexpr size_t key_size = 64;
+const CFStringRef s_account = CFSTR("metadata");
+const CFStringRef s_legacy_service = CFSTR("io.realm.sync.keychain");
 
 #if !TARGET_IPHONE_SIMULATOR
 CFPtr<CFStringRef> convert_string(const std::string& string)
@@ -73,74 +72,133 @@ CFPtr<CFMutableDictionaryRef> build_search_dictionary(CFStringRef account, CFStr
     return d;
 }
 
-/// Get the encryption key for a given service, returning it only if it exists.
-util::Optional<std::vector<char>> get_key(CFStringRef account, CFStringRef service)
+/// Get the encryption key for a given service, returning true if it either exists or the keychain is not usable.
+bool get_key(CFStringRef account, CFStringRef service, util::Optional<std::vector<char>>& result)
 {
     auto search_dictionary = build_search_dictionary(account, service, none);
     CFDataRef retained_key_data;
-    if (OSStatus status = SecItemCopyMatching(search_dictionary.get(), (CFTypeRef*)&retained_key_data)) {
-        if (status != errSecItemNotFound)
-            throw KeychainAccessException(status);
+    switch (OSStatus status = SecItemCopyMatching(search_dictionary.get(), (CFTypeRef*)&retained_key_data)) {
+        case errSecSuccess: {
+            // Key was previously stored. Extract it.
+            CFPtr<CFDataRef> key_data = adoptCF(retained_key_data);
+            if (key_size != CFDataGetLength(key_data.get()))
+                return false;
 
-        // Key was not found.
-        return none;
+            auto key_bytes = reinterpret_cast<const char*>(CFDataGetBytePtr(key_data.get()));
+            result.emplace(key_bytes, key_bytes + key_size);
+            return true;
+        }
+        case errSecItemNotFound:
+            return false;
+        case errSecUserCanceled:
+            // Keychain is locked, and user did not enter the password to unlock it.
+        case errSecInvalidKeychain:
+            // The keychain is corrupted and cannot be used.
+        case errSecInteractionNotAllowed:
+            // We asked for it to not prompt the user and a prompt was needed
+            return true;
+        default:
+            throw keychain_access_exception(status);
     }
-
-    // Key was previously stored. Extract it.
-    CFPtr<CFDataRef> key_data = adoptCF(retained_key_data);
-    if (key_size != CFDataGetLength(key_data.get()))
-        throw std::runtime_error("Password stored in keychain was not expected size.");
-
-    auto key_bytes = reinterpret_cast<const char*>(CFDataGetBytePtr(key_data.get()));
-    return std::vector<char>(key_bytes, key_bytes + key_size);
 }
 
-void set_key(const std::vector<char>& key, CFStringRef account, CFStringRef service)
+void set_key(util::Optional<std::vector<char>>& key, CFStringRef account, CFStringRef service)
 {
+    if (!key)
+        return;
+
     auto search_dictionary = build_search_dictionary(account, service, none);
     CFDictionaryAddValue(search_dictionary.get(), kSecAttrAccessible, kSecAttrAccessibleAfterFirstUnlock);
-    auto key_data = adoptCF(CFDataCreate(nullptr, reinterpret_cast<const UInt8*>(key.data()), key_size));
+    auto key_data = adoptCF(CFDataCreate(nullptr, reinterpret_cast<const UInt8*>(key->data()), key_size));
     if (!key_data)
         throw std::bad_alloc();
 
     CFDictionaryAddValue(search_dictionary.get(), kSecValueData, key_data.get());
-    if (OSStatus status = SecItemAdd(search_dictionary.get(), nullptr))
-        throw KeychainAccessException(status);
+    switch (OSStatus status = SecItemAdd(search_dictionary.get(), nullptr)) {
+        case errSecSuccess:
+            return;
+        case errSecDuplicateItem:
+            // A keychain item already exists but we didn't fine it in get_key(),
+            // meaning that we didn't have permission to access it.
+        case errSecUserCanceled:
+        case errSecInteractionNotAllowed:
+        case errSecInvalidKeychain:
+            // We were unable to save the key for "expected" reasons, so proceeed unencrypted
+            key = none;
+            return;
+        default:
+            // Unexpected keychain failure happened
+            throw keychain_access_exception(status);
+    }
+}
+
+void delete_key(CFStringRef account, CFStringRef service)
+{
+    auto search_dictionary = build_search_dictionary(account, service, none);
+    auto status = SecItemDelete(search_dictionary.get());
+    REALM_ASSERT(status == errSecSuccess || status == errSecItemNotFound);
+}
+
+CFPtr<CFStringRef> get_service_name(bool& have_bundle_id)
+{
+    CFPtr<CFStringRef> service;
+    if (CFStringRef bundle_id = CFBundleGetIdentifier(CFBundleGetMainBundle())) {
+        service = adoptCF(CFStringCreateWithFormat(NULL, NULL, CFSTR("%@ - Realm Sync Metadata Key"), bundle_id));
+        have_bundle_id = true;
+    }
+    else {
+        service = retainCF(s_legacy_service);
+        have_bundle_id = false;
+    }
+    return service;
 }
 
 } // anonymous namespace
 
-std::vector<char> metadata_realm_encryption_key(bool check_legacy_service)
+namespace realm::keychain {
+
+util::Optional<std::vector<char>> get_existing_metadata_realm_key()
 {
-    CFStringRef account = CFSTR("metadata");
-    CFStringRef legacy_service = CFSTR("io.realm.sync.keychain");
+    bool have_bundle_id = false;
+    CFPtr<CFStringRef> service = get_service_name(have_bundle_id);
 
-    CFPtr<CFStringRef> service;
-    if (CFStringRef bundle_id = CFBundleGetIdentifier(CFBundleGetMainBundle()))
-        service = adoptCF(CFStringCreateWithFormat(NULL, NULL, CFSTR("%@ - Realm Sync Metadata Key"), bundle_id));
-    else {
-        service = retainCF(legacy_service);
-        check_legacy_service = false;
+    // Try retrieving the existing key.
+    util::Optional<std::vector<char>> key;
+    if (get_key(s_account, service.get(), key)) {
+        return key;
     }
 
-    // Try retrieving the key.
-    if (auto existing_key = get_key(account, service.get())) {
-        return *existing_key;
-    }
-    else if (check_legacy_service) {
+    if (have_bundle_id) {
         // See if there's a key stored using the legacy shared keychain item.
-        if (auto existing_legacy_key = get_key(account, legacy_service)) {
+        if (get_key(s_account, s_legacy_service, key)) {
             // If so, copy it to the per-app keychain item before returning it.
-            set_key(*existing_legacy_key, account, service.get());
-            return *existing_legacy_key;
+            set_key(key, s_account, service.get());
+            return key;
         }
     }
-    // Make a completely new key.
-    std::vector<char> key(key_size);
-    arc4random_buf(key.data(), key_size);
-    set_key(key, account, service.get());
+    return util::none;
+}
+
+util::Optional<std::vector<char>> create_new_metadata_realm_key()
+{
+    bool have_bundle_id = false;
+    CFPtr<CFStringRef> service = get_service_name(have_bundle_id);
+
+    util::Optional<std::vector<char>> key;
+    key.emplace(key_size);
+    arc4random_buf(key->data(), key_size);
+    set_key(key, s_account, service.get());
     return key;
 }
 
-} // namespace keychain
-} // namespace realm
+void delete_metadata_realm_encryption_key()
+{
+    delete_key(s_account, s_legacy_service);
+    if (CFStringRef bundle_id = CFBundleGetIdentifier(CFBundleGetMainBundle())) {
+        auto service =
+            adoptCF(CFStringCreateWithFormat(NULL, NULL, CFSTR("%@ - Realm Sync Metadata Key"), bundle_id));
+        delete_key(s_account, service.get());
+    }
+}
+
+} // namespace realm::keychain

--- a/src/realm/object-store/impl/apple/keychain_helper.hpp
+++ b/src/realm/object-store/impl/apple/keychain_helper.hpp
@@ -19,21 +19,32 @@
 #ifndef REALM_OS_KEYCHAIN_HELPER_HPP
 #define REALM_OS_KEYCHAIN_HELPER_HPP
 
-#include <cstdint>
-#include <stdexcept>
+#include <realm/util/features.h>
+
+#if REALM_PLATFORM_APPLE
+
+#include <realm/util/optional.hpp>
 #include <vector>
 
-namespace realm {
-namespace keychain {
+namespace realm::keychain {
 
-std::vector<char> metadata_realm_encryption_key(bool check_legacy_service);
+// Get the stored encryption key for the metadata realm if one exists.
+util::Optional<std::vector<char>> get_existing_metadata_realm_key();
+// Create a new encryption key and store it in the keychain. Returns none if
+// the key could not be stored.
+util::Optional<std::vector<char>> create_new_metadata_realm_key();
 
-class KeychainAccessException : public std::runtime_error {
-public:
-    KeychainAccessException(int32_t error_code);
-};
+// Delete the encryption key for the metadata realm from the keychain.
+void delete_metadata_realm_encryption_key();
 
-} // namespace keychain
-} // namespace realm
+} // namespace realm::keychain
+
+#else // REALM_PLATFORM_APPLE
+
+namespace realm::keychain {
+inline void delete_metadata_realm_encryption_key() {}
+} // namespace realm::keychain
+
+#endif // REALM_PLATFORM_APPLE
 
 #endif // REALM_OS_KEYCHAIN_HELPER_HPP

--- a/src/realm/object-store/sync/impl/sync_metadata.hpp
+++ b/src/realm/object-store/sync/impl/sync_metadata.hpp
@@ -277,6 +277,9 @@ private:
     SyncAppMetadata::Schema m_app_metadata_schema;
 
     std::shared_ptr<Realm> get_realm() const;
+    std::shared_ptr<Realm> try_get_realm() const;
+    std::shared_ptr<Realm> open_realm(bool should_encrypt, bool caller_supplied_key);
+
 
     util::Optional<SyncAppMetadata> m_app_metadata;
 };

--- a/src/realm/object-store/sync/sync_manager.cpp
+++ b/src/realm/object-store/sync/sync_manager.cpp
@@ -85,19 +85,8 @@ void SyncManager::configure(std::shared_ptr<app::App> app, const std::string& sy
             }
 
             bool encrypt = m_config.metadata_mode == MetadataMode::Encryption;
-            try {
-                m_metadata_manager = std::make_unique<SyncMetadataManager>(m_file_manager->metadata_path(), encrypt,
-                                                                           m_config.custom_encryption_key);
-            }
-            catch (RealmFileException const&) {
-                if (m_config.reset_metadata_on_error && m_file_manager->remove_metadata_realm()) {
-                    m_metadata_manager = std::make_unique<SyncMetadataManager>(
-                        m_file_manager->metadata_path(), encrypt, std::move(m_config.custom_encryption_key));
-                }
-                else {
-                    throw;
-                }
-            }
+            m_metadata_manager = std::make_unique<SyncMetadataManager>(m_file_manager->metadata_path(), encrypt,
+                                                                       m_config.custom_encryption_key);
 
             REALM_ASSERT(m_metadata_manager);
 

--- a/src/realm/object-store/sync/sync_manager.hpp
+++ b/src/realm/object-store/sync/sync_manager.hpp
@@ -71,7 +71,6 @@ struct SyncClientConfig {
     std::string base_file_path;
     MetadataMode metadata_mode = MetadataMode::Encryption;
     util::Optional<std::vector<char>> custom_encryption_key;
-    bool reset_metadata_on_error = false;
 
     using LoggerFactory = std::function<std::unique_ptr<util::Logger>(util::Logger::Level)>;
     LoggerFactory logger_factory;

--- a/test/object-store/sync/sync_manager.cpp
+++ b/test/object-store/sync/sync_manager.cpp
@@ -739,36 +739,6 @@ TEST_CASE("sync_manager: file actions", "[sync]") {
     }
 }
 
-TEST_CASE("sync_manager: metadata") {
-    TestSyncManager init_sync_manager(
-        TestSyncManager::Config(base_path, realm::SyncManager::MetadataMode::NoEncryption));
-    auto sync_manager = init_sync_manager.app()->sync_manager();
-
-    auto cleanup = util::make_scope_exit([=]() noexcept {
-        sync_manager->reset_for_testing();
-    });
-    reset_test_directory(base_path);
-
-    app::App::Config app_config;
-    app_config.app_id = "foo_app_id";
-    app_config.base_url = base_path;
-    app_config.platform = "OS Test Platform";
-    app_config.platform_version = "OS Test Platform Version";
-    app_config.sdk_version = "SDK Version";
-
-    SECTION("should be reset in case of decryption error") {
-        SyncClientConfig config;
-        config.base_file_path = base_path;
-        config.metadata_mode = SyncManager::MetadataMode::Encryption;
-        config.custom_encryption_key = make_test_encryption_key();
-
-        sync_manager->reset_for_testing();
-
-        config.custom_encryption_key = make_test_encryption_key(1);
-        config.reset_metadata_on_error = true;
-    }
-}
-
 TEST_CASE("sync_manager: has_active_sessions", "[active_sessions]") {
     reset_test_directory(base_path);
 


### PR DESCRIPTION
While on iOS the keychain basically just always works, on macOS the keychain is a user-managed thing with permissions and accessing it can either fail or pop up a prompt for the user to approve or reject it, and we need to not just crash when that happens.

If we can't access the keychain, this makes it so that we simply store the metadata realm unencrypted. This isn't a great solution: ideally we'd expose some customization hooks in the SDK to let the app configure the authentication dialog, gracefully recover from keychain access being rejected, and decide whether to disable encryption. That would be a much larger project, though.

Most of this error handling can't be automatically tested. macOS 12 deprecated a lot of the advanced keychain management functionality, so we can no longer programmatically create a keychain, set it as default, lock it, and verify that things behave properly. Instead I had to manually test each of the paths via Keychain Access.

Fixes https://github.com/realm/realm-swift/issues/7438.