### PR TITLE
Added flag to CollectionChangeSet to indicate cleared collection

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,7 @@
 # NEXT RELEASE
 
 ### Enhancements
-* <New feature description> (PR [#????](https://github.com/realm/realm-core/pull/????))
-* None.
+* Added a new flag to `CollectionChangeSet` to indicate when collections are cleared. ([#5340](https://github.com/realm/realm-core/pull/5340))
 
 ### Fixed
 * <How do the end-user experience this issue? what was the impact?> ([#????](https://github.com/realm/realm-core/issues/????), since v?.?.?)

--- a/src/realm/object-store/collection_notifications.hpp
+++ b/src/realm/object-store/collection_notifications.hpp
@@ -89,6 +89,9 @@ struct CollectionChangeSet {
     // unreported moves which show up only as a delete/insert pair.
     std::vector<Move> moves;
 
+    // This flag indicates if the collection was cleared. 
+    bool collection_was_cleared = false;
+
     // This flag indicates whether the underlying object which is the source of this
     // collection was deleted. This applies to lists, dictionaries and sets.
     // This enables notifiers to report a change on empty collections that have been deleted.
@@ -100,7 +103,7 @@ struct CollectionChangeSet {
     bool empty() const noexcept
     {
         return deletions.empty() && insertions.empty() && modifications.empty() && modifications_new.empty() &&
-               moves.empty() && !collection_root_was_deleted;
+               moves.empty() && !collection_root_was_deleted  && !collection_was_cleared;
     }
 };
 

--- a/src/realm/object-store/collection_notifications.hpp
+++ b/src/realm/object-store/collection_notifications.hpp
@@ -89,7 +89,7 @@ struct CollectionChangeSet {
     // unreported moves which show up only as a delete/insert pair.
     std::vector<Move> moves;
 
-    // This flag indicates if the collection was cleared. 
+    // This flag indicates if the collection was cleared.
     bool collection_was_cleared = false;
 
     // This flag indicates whether the underlying object which is the source of this
@@ -103,7 +103,7 @@ struct CollectionChangeSet {
     bool empty() const noexcept
     {
         return deletions.empty() && insertions.empty() && modifications.empty() && modifications_new.empty() &&
-               moves.empty() && !collection_root_was_deleted  && !collection_was_cleared;
+               moves.empty() && !collection_root_was_deleted && !collection_was_cleared;
     }
 };
 

--- a/src/realm/object-store/collection_notifications.hpp
+++ b/src/realm/object-store/collection_notifications.hpp
@@ -89,13 +89,13 @@ struct CollectionChangeSet {
     // unreported moves which show up only as a delete/insert pair.
     std::vector<Move> moves;
 
-    // This flag indicates if the collection was cleared.
-    bool collection_was_cleared = false;
-
     // This flag indicates whether the underlying object which is the source of this
     // collection was deleted. This applies to lists, dictionaries and sets.
     // This enables notifiers to report a change on empty collections that have been deleted.
     bool collection_root_was_deleted = false;
+
+    // This flag indicates if the collection was cleared.
+    bool collection_was_cleared = false;
 
     // Per-column version of `modifications`
     std::unordered_map<int64_t, IndexSet> columns;

--- a/src/realm/object-store/impl/collection_change_builder.cpp
+++ b/src/realm/object-store/impl/collection_change_builder.cpp
@@ -704,6 +704,7 @@ CollectionChangeSet CollectionChangeBuilder::finalize() &&
     // but we don't want inserts in the final modification set
     modifications.remove(insertions);
 
-    return {std::move(deletions), std::move(insertions),  std::move(modifications_in_old), std::move(modifications),
-            std::move(moves), collection_root_was_deleted, collection_was_cleared, std::move(columns)};
+    return {std::move(deletions),     std::move(insertions), std::move(modifications_in_old),
+            std::move(modifications), std::move(moves),      collection_root_was_deleted,
+            collection_was_cleared,   std::move(columns)};
 }

--- a/src/realm/object-store/impl/collection_change_builder.cpp
+++ b/src/realm/object-store/impl/collection_change_builder.cpp
@@ -26,13 +26,14 @@ using namespace realm;
 using namespace realm::_impl;
 
 CollectionChangeBuilder::CollectionChangeBuilder(IndexSet deletions, IndexSet insertions, IndexSet modifications,
-                                                 std::vector<Move> moves, bool collection_was_cleared, bool root_was_deleted)
+                                                 std::vector<Move> moves, bool collection_was_cleared,
+                                                 bool root_was_deleted)
     : CollectionChangeSet({std::move(deletions),
                            std::move(insertions),
                            std::move(modifications),
                            {},
                            std::move(moves),
-                           collection_was_cleared, 
+                           collection_was_cleared,
                            root_was_deleted})
 {
     for (auto&& move : this->moves) {
@@ -237,7 +238,7 @@ void CollectionChangeBuilder::clear(size_t old_size)
     moves.clear();
     columns.clear();
     deletions.set(old_size);
-    collection_was_cleared = true; 
+    collection_was_cleared = true;
 }
 
 void CollectionChangeBuilder::move(size_t from, size_t to)
@@ -699,7 +700,6 @@ CollectionChangeSet CollectionChangeBuilder::finalize() &&
     // but we don't want inserts in the final modification set
     modifications.remove(insertions);
 
-    return {std::move(deletions),     std::move(insertions), std::move(modifications_in_old),
-            std::move(modifications), std::move(moves),  collection_was_cleared, collection_root_was_deleted,
-            std::move(columns)};
+    return {std::move(deletions), std::move(insertions),  std::move(modifications_in_old), std::move(modifications),
+            std::move(moves),     collection_was_cleared, collection_root_was_deleted,     std::move(columns)};
 }

--- a/src/realm/object-store/impl/collection_change_builder.cpp
+++ b/src/realm/object-store/impl/collection_change_builder.cpp
@@ -149,6 +149,8 @@ void CollectionChangeBuilder::merge(CollectionChangeBuilder&& c)
         collection_root_was_deleted = true;
     }
 
+    collection_was_cleared = c.collection_was_cleared;
+
     c = {};
     verify();
 }

--- a/src/realm/object-store/impl/collection_change_builder.cpp
+++ b/src/realm/object-store/impl/collection_change_builder.cpp
@@ -26,12 +26,13 @@ using namespace realm;
 using namespace realm::_impl;
 
 CollectionChangeBuilder::CollectionChangeBuilder(IndexSet deletions, IndexSet insertions, IndexSet modifications,
-                                                 std::vector<Move> moves, bool root_was_deleted)
+                                                 std::vector<Move> moves, bool collection_was_cleared, bool root_was_deleted)
     : CollectionChangeSet({std::move(deletions),
                            std::move(insertions),
                            std::move(modifications),
                            {},
                            std::move(moves),
+                           collection_was_cleared, 
                            root_was_deleted})
 {
     for (auto&& move : this->moves) {
@@ -236,6 +237,7 @@ void CollectionChangeBuilder::clear(size_t old_size)
     moves.clear();
     columns.clear();
     deletions.set(old_size);
+    collection_was_cleared = true; 
 }
 
 void CollectionChangeBuilder::move(size_t from, size_t to)
@@ -698,6 +700,6 @@ CollectionChangeSet CollectionChangeBuilder::finalize() &&
     modifications.remove(insertions);
 
     return {std::move(deletions),     std::move(insertions), std::move(modifications_in_old),
-            std::move(modifications), std::move(moves),      collection_root_was_deleted,
+            std::move(modifications), std::move(moves),  collection_was_cleared, collection_root_was_deleted,
             std::move(columns)};
 }

--- a/src/realm/object-store/impl/collection_change_builder.cpp
+++ b/src/realm/object-store/impl/collection_change_builder.cpp
@@ -26,15 +26,15 @@ using namespace realm;
 using namespace realm::_impl;
 
 CollectionChangeBuilder::CollectionChangeBuilder(IndexSet deletions, IndexSet insertions, IndexSet modifications,
-                                                 std::vector<Move> moves, bool collection_was_cleared,
-                                                 bool root_was_deleted)
+                                                 std::vector<Move> moves, bool root_was_deleted,
+                                                 bool collection_was_cleared)
     : CollectionChangeSet({std::move(deletions),
                            std::move(insertions),
                            std::move(modifications),
                            {},
                            std::move(moves),
-                           collection_was_cleared,
-                           root_was_deleted})
+                           root_was_deleted,
+                           collection_was_cleared})
 {
     for (auto&& move : this->moves) {
         this->deletions.add(move.from);
@@ -206,6 +206,8 @@ void CollectionChangeBuilder::insert(size_t index, size_t count, bool track_move
         if (move.to >= index)
             move.to += count;
     }
+
+    collection_was_cleared = false;
 }
 
 void CollectionChangeBuilder::erase(size_t index)
@@ -703,5 +705,5 @@ CollectionChangeSet CollectionChangeBuilder::finalize() &&
     modifications.remove(insertions);
 
     return {std::move(deletions), std::move(insertions),  std::move(modifications_in_old), std::move(modifications),
-            std::move(moves),     collection_was_cleared, collection_root_was_deleted,     std::move(columns)};
+            std::move(moves), collection_root_was_deleted, collection_was_cleared, std::move(columns)};
 }

--- a/src/realm/object-store/impl/collection_change_builder.hpp
+++ b/src/realm/object-store/impl/collection_change_builder.hpp
@@ -39,7 +39,8 @@ public:
     CollectionChangeBuilder& operator=(CollectionChangeBuilder&&) = default;
 
     CollectionChangeBuilder(IndexSet deletions = {}, IndexSet insertions = {}, IndexSet modification = {},
-                            std::vector<Move> moves = {}, bool collection_was_cleared = false, bool root_was_deleted = false);
+                            std::vector<Move> moves = {}, bool collection_was_cleared = false,
+                            bool root_was_deleted = false);
 
     // Calculate where objects need to be inserted or deleted from old_objs to turn
     // it into new_objs, and check all matching objects for modifications

--- a/src/realm/object-store/impl/collection_change_builder.hpp
+++ b/src/realm/object-store/impl/collection_change_builder.hpp
@@ -39,7 +39,7 @@ public:
     CollectionChangeBuilder& operator=(CollectionChangeBuilder&&) = default;
 
     CollectionChangeBuilder(IndexSet deletions = {}, IndexSet insertions = {}, IndexSet modification = {},
-                            std::vector<Move> moves = {}, bool root_was_deleted = false);
+                            std::vector<Move> moves = {}, bool collection_was_cleared = false, bool root_was_deleted = false);
 
     // Calculate where objects need to be inserted or deleted from old_objs to turn
     // it into new_objs, and check all matching objects for modifications

--- a/test/object-store/collection_change_indices.cpp
+++ b/test/object-store/collection_change_indices.cpp
@@ -720,15 +720,15 @@ TEST_CASE("collection_change: merge()") {
         REQUIRE(c.collection_was_cleared);
 
         c = {{1, 2, 3}, {}, {}, {}, true};
-        c.merge({{}, {1, 2 ,3}, {}, {}, false});
+        c.merge({{}, {1, 2, 3}, {}, {}, false});
         REQUIRE(!c.collection_was_cleared);
 
         c = {{1, 2, 3}, {}, {}, {}, true};
-        c.merge({{1, 2, 3}, {1, 2 ,3}, {}, {}, true});
+        c.merge({{1, 2, 3}, {1, 2, 3}, {}, {}, true});
         REQUIRE(c.collection_was_cleared);
 
         c = {{1, 2, 3}, {4, 5}, {}, {}, false};
-        c.merge({{}, {1, 2 ,3}, {}, {}, false});
+        c.merge({{}, {1, 2, 3}, {}, {}, false});
         REQUIRE(!c.collection_was_cleared);
     }
 

--- a/test/object-store/collection_change_indices.cpp
+++ b/test/object-store/collection_change_indices.cpp
@@ -698,6 +698,40 @@ TEST_CASE("collection_change: merge()") {
         REQUIRE_MOVES(c, {8, 9});
     }
 
+    SECTION("clear collection flag gets propagated") {
+        c = {{1, 2, 3}, {}, {}, {}, true};
+        c.merge({});
+        REQUIRE(c.collection_was_cleared);
+
+        c = {{1, 2, 3}, {4, 5}, {6, 7}, {{8, 9}}, false};
+        c.merge({});
+        REQUIRE(!c.collection_was_cleared);
+
+        c = {};
+        c.merge({{1, 2, 3}, {}, {}, {}, true});
+        REQUIRE(c.collection_was_cleared);
+
+        c = {};
+        c.merge({{1, 2, 3}, {4, 5}, {6, 7}, {{8, 9}}, false});
+        REQUIRE(!c.collection_was_cleared);
+
+        c = {{1, 2, 3}, {4, 5}, {6, 7}, {{8, 9}}, false};
+        c.merge({{1, 2, 3}, {}, {}, {}, true});
+        REQUIRE(c.collection_was_cleared);
+
+        c = {{1, 2, 3}, {}, {}, {}, true};
+        c.merge({{}, {1, 2 ,3}, {}, {}, false});
+        REQUIRE(!c.collection_was_cleared);
+
+        c = {{1, 2, 3}, {}, {}, {}, true};
+        c.merge({{1, 2, 3}, {1, 2 ,3}, {}, {}, true});
+        REQUIRE(c.collection_was_cleared);
+
+        c = {{1, 2, 3}, {4, 5}, {}, {}, false};
+        c.merge({{}, {1, 2 ,3}, {}, {}, false});
+        REQUIRE(!c.collection_was_cleared);
+    }
+
     SECTION("shifts deletions by previous deletions") {
         c = {{5}, {}, {}, {}};
         c.merge({{3}, {}, {}, {}});

--- a/test/object-store/collection_change_indices.cpp
+++ b/test/object-store/collection_change_indices.cpp
@@ -699,36 +699,36 @@ TEST_CASE("collection_change: merge()") {
     }
 
     SECTION("clear collection flag gets propagated") {
-        c = {{1, 2, 3}, {}, {}, {}, true};
+        c = {{1, 2, 3}, {}, {}, {}, false, true};
         c.merge({});
         REQUIRE(c.collection_was_cleared);
 
-        c = {{1, 2, 3}, {4, 5}, {6, 7}, {{8, 9}}, false};
+        c = {{1, 2, 3}, {4, 5}, {6, 7}, {{8, 9}}, false, false};
         c.merge({});
         REQUIRE(!c.collection_was_cleared);
 
         c = {};
-        c.merge({{1, 2, 3}, {}, {}, {}, true});
+        c.merge({{1, 2, 3}, {}, {}, {}, false, true});
         REQUIRE(c.collection_was_cleared);
 
         c = {};
-        c.merge({{1, 2, 3}, {4, 5}, {6, 7}, {{8, 9}}, false});
+        c.merge({{1, 2, 3}, {4, 5}, {6, 7}, {{8, 9}}, false, false});
         REQUIRE(!c.collection_was_cleared);
 
-        c = {{1, 2, 3}, {4, 5}, {6, 7}, {{8, 9}}, false};
-        c.merge({{1, 2, 3}, {}, {}, {}, true});
+        c = {{1, 2, 3}, {4, 5}, {6, 7}, {{8, 9}}, false, false};
+        c.merge({{1, 2, 3}, {}, {}, {}, false, true});
         REQUIRE(c.collection_was_cleared);
 
-        c = {{1, 2, 3}, {}, {}, {}, true};
-        c.merge({{}, {1, 2, 3}, {}, {}, false});
+        c = {{1, 2, 3}, {}, {}, {}, false, true};
+        c.merge({{}, {1, 2, 3}, {}, {}, false, false});
         REQUIRE(!c.collection_was_cleared);
 
-        c = {{1, 2, 3}, {}, {}, {}, true};
-        c.merge({{1, 2, 3}, {1, 2, 3}, {}, {}, true});
+        c = {{1, 2, 3}, {}, {}, {}, false, true};
+        c.merge({{1, 2, 3}, {1, 2, 3}, {}, {}, false, true});
         REQUIRE(c.collection_was_cleared);
 
-        c = {{1, 2, 3}, {4, 5}, {}, {}, false};
-        c.merge({{}, {1, 2, 3}, {}, {}, false});
+        c = {{1, 2, 3}, {4, 5}, {}, {}, false, false};
+        c.merge({{}, {1, 2, 3}, {}, {}, false, false});
         REQUIRE(!c.collection_was_cleared);
     }
 

--- a/test/object-store/list.cpp
+++ b/test/object-store/list.cpp
@@ -154,7 +154,7 @@ TEST_CASE("list") {
             auto token = require_change();
             write([&] {
                 auto size = lst.size();
-                for(size_t i=0; i<size; i++)
+                for (size_t i = 0; i < size; i++)
                     lst.remove(0);
             });
             REQUIRE_INDICES(change.deletions, 0, 1, 2, 3, 4, 5, 6, 7, 8, 9);

--- a/test/object-store/list.cpp
+++ b/test/object-store/list.cpp
@@ -130,6 +130,7 @@ TEST_CASE("list") {
                     lst.remove(5);
             });
             REQUIRE_INDICES(change.deletions, 5);
+            REQUIRE(!change.collection_was_cleared);
         }
 
         SECTION("modifying a different list doesn't send a change notification") {
@@ -140,13 +141,24 @@ TEST_CASE("list") {
             });
         }
 
-        SECTION("clearing list sets correct flag") {
+        SECTION("clearing list sets cleared flag") {
             auto token = require_change();
             write([&] {
                 lst.remove_all();
             });
             REQUIRE_INDICES(change.deletions, 0, 1, 2, 3, 4, 5, 6, 7, 8, 9);
             REQUIRE(change.collection_was_cleared);
+        }
+
+        SECTION("removing all elements from list does not set cleared flag") {
+            auto token = require_change();
+            write([&] {
+                auto size = lst.size();
+                for(size_t i=0; i<size; i++)
+                    lst.remove(0);
+            });
+            REQUIRE_INDICES(change.deletions, 0, 1, 2, 3, 4, 5, 6, 7, 8, 9);
+            REQUIRE(!change.collection_was_cleared);
         }
 
         SECTION("deleting the list sends a change notification") {

--- a/test/object-store/list.cpp
+++ b/test/object-store/list.cpp
@@ -150,6 +150,18 @@ TEST_CASE("list") {
             REQUIRE(change.collection_was_cleared);
         }
 
+        SECTION("clearing list followed by insertion does not set cleared flag") {
+            auto token = require_change();
+            write([&] {
+                lst.remove_all();
+                Obj obj = target->get_object(target_keys[5]);
+                lst.add(obj);
+            });
+            REQUIRE_INDICES(change.deletions, 0, 1, 2, 3, 4, 5, 6, 7, 8, 9);
+            REQUIRE_INDICES(change.insertions, 0);
+            REQUIRE(!change.collection_was_cleared);
+        }
+
         SECTION("removing all elements from list does not set cleared flag") {
             auto token = require_change();
             write([&] {

--- a/test/object-store/list.cpp
+++ b/test/object-store/list.cpp
@@ -140,10 +140,10 @@ TEST_CASE("list") {
             });
         }
 
-        SECTION("clearing list set correct flag") {
+        SECTION("clearing list sets correct flag") {
             auto token = require_change();
             write([&] {
-                    lst.remove_all();
+                lst.remove_all();
             });
             REQUIRE_INDICES(change.deletions, 0, 1, 2, 3, 4, 5, 6, 7, 8, 9);
             REQUIRE(change.collection_was_cleared);

--- a/test/object-store/list.cpp
+++ b/test/object-store/list.cpp
@@ -140,6 +140,15 @@ TEST_CASE("list") {
             });
         }
 
+        SECTION("clearing list set correct flag") {
+            auto token = require_change();
+            write([&] {
+                    lst.remove_all();
+            });
+            REQUIRE_INDICES(change.deletions, 0, 1, 2, 3, 4, 5, 6, 7, 8, 9);
+            REQUIRE(change.collection_was_cleared);
+        }
+
         SECTION("deleting the list sends a change notification") {
             auto token = require_change();
             write([&] {

--- a/test/object-store/set.cpp
+++ b/test/object-store/set.cpp
@@ -749,6 +749,7 @@ TEMPLATE_TEST_CASE("set", "[set]", CreateNewSet<void>, ReuseSet<void>)
                 link_set.remove_all();
             });
             REQUIRE_INDICES(change.deletions, 0, 1, 2);
+            REQUIRE(change.collection_was_cleared);
 
             // Should not resend delete all notification after another commit
             change = {};


### PR DESCRIPTION
Added a new flag to `CollectionChangeSet` to indicate when `remove_all` is called on collections. 

## ☑️ ToDos
* [x] 📝 Changelog update
* [x] 🚦 Tests
