### PR TITLE
Fix WatchOS simulator not supporting thread_local

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 * Fix exception when decoding interned strings in realm-apply-to-state tool. ([#5628](https://github.com/realm/realm-core/pull/5628))
 * Fix some warnings when building with Xcode 14 ([PR #5577](https://github.com/realm/realm-core/pull/5577)).
 * Throw `runtime_error` if subscription set is requested and flexible sync is not enabled. ([#5637](https://github.com/realm/realm-core/pull/5637))
+* Fix compilation failures on watchOS platforms which do not support thread-local storage. ([#7694](https://github.com/realm/realm-swift/issues/7694), [#7695](https://github.com/realm/realm-swift/issues/7695) since v11.7.0)
 
 ### Breaking changes
 * None.

--- a/src/realm/impl/simulated_failure.cpp
+++ b/src/realm/impl/simulated_failure.cpp
@@ -175,11 +175,10 @@ bool SimulatedFailure::do_check_trigger(FailureType failure_type) noexcept
     return false;
 }
 
-#if (REALM_ARCHITECTURE_X86_32 && REALM_IOS) || (REALM_ARCHITECTURE_X86_32 && REALM_WATCHOS) || (REALM_ARCHITECTURE_X86_64 && REALM_WATCHOS) || (REALM_ARCHITECTURE_ARM_64 && REALM_WATCHOS)
-bool (*s_mmap_predicate)(size_t);
-#else
-thread_local bool (*s_mmap_predicate)(size_t);
-#endif // THREAD_LOCAL NOT SUPPORTED ARCHITECTURES
+#if !defined(__clang__) || REALM_HAVE_CLANG_FEATURE(cxx_thread_local)
+thread_local
+#endif
+    bool (*s_mmap_predicate)(size_t);
 
 void SimulatedFailure::do_prime_mmap(bool (*predicate)(size_t))
 {

--- a/src/realm/impl/simulated_failure.cpp
+++ b/src/realm/impl/simulated_failure.cpp
@@ -175,11 +175,11 @@ bool SimulatedFailure::do_check_trigger(FailureType failure_type) noexcept
     return false;
 }
 
-#if (REALM_ARCHITECTURE_X86_32 && REALM_IOS) || (REALM_ARCHITECTURE_X86_64 && REALM_WATCHOS)
+#if (REALM_ARCHITECTURE_X86_32 && REALM_IOS) || (REALM_ARCHITECTURE_X86_32 && REALM_WATCHOS) || (REALM_ARCHITECTURE_X86_64 && REALM_WATCHOS) || (REALM_ARCHITECTURE_ARM_64 && REALM_WATCHOS)
 bool (*s_mmap_predicate)(size_t);
 #else
 thread_local bool (*s_mmap_predicate)(size_t);
-#endif // REALM_ARCHITECTURE_X86_32 && REALM_IOS
+#endif // THREAD_LOCAL NOT SUPPORTED ARCHITECTURES
 
 void SimulatedFailure::do_prime_mmap(bool (*predicate)(size_t))
 {

--- a/src/realm/util/features.h
+++ b/src/realm/util/features.h
@@ -305,6 +305,13 @@
 #define REALM_ARCHITECTURE_X86_64 0
 #endif
 
+// We're in arm64 mode
+#if defined(__arm64) || defined(__arm64__)
+#define REALM_ARCHITECTURE_ARM_64 1
+#else
+#define REALM_ARCHITECTURE_ARM_64 0
+#endif
+
 // Address Sanitizer
 #if defined(__has_feature) // Clang
 #  if __has_feature(address_sanitizer)

--- a/src/realm/util/features.h
+++ b/src/realm/util/features.h
@@ -305,13 +305,6 @@
 #define REALM_ARCHITECTURE_X86_64 0
 #endif
 
-// We're in arm64 mode
-#if defined(__arm64) || defined(__arm64__)
-#define REALM_ARCHITECTURE_ARM_64 1
-#else
-#define REALM_ARCHITECTURE_ARM_64 0
-#endif
-
 // Address Sanitizer
 #if defined(__has_feature) // Clang
 #  if __has_feature(address_sanitizer)


### PR DESCRIPTION
## What, How & Why?
Fix an error when compiling a watchOS Simulator target on an M1 is not supporting Thread-local storage https://github.com/realm/realm-swift/issues/7694
https://github.com/realm/realm-swift/issues/7695

## ☑️ ToDos
* [x] 📝 Changelog update
* [x] 🚦 Tests (or not relevant)
