### PR TITLE
fix hangs in LangBindHelper_ImplicitTransactions_InterProcess

### DIFF
--- a/test/test_lang_bind_helper.cpp
+++ b/test/test_lang_bind_helper.cpp
@@ -3082,13 +3082,14 @@ TEST(LangBindHelper_ImplicitTransactions_MultipleTrackers)
 
 #ifndef _WIN32
 
-#if !REALM_ENABLE_ENCRYPTION
-// Interprocess communication does not work with encryption enabled
-
 #if !REALM_ANDROID && !REALM_IOS
 // fork should not be used on android or ios.
-
-TEST(LangBindHelper_ImplicitTransactions_InterProcess)
+// Interprocess communication does not work with encryption turned on.
+// This test must be non-concurrant due to fork. If a child process
+// is created while a static mutex is locked (eg. util::GlobalRandom::m_mutex)
+// then any attempt to use the mutex would hang infinitely and the child would
+// crash upon exit(0) when attempting to destroy a locked mutex.
+NONCONCURRENT_TEST(LangBindHelper_ImplicitTransactions_InterProcess)
 {
     const int write_process_count = 7;
     const int read_process_count = 3;
@@ -3194,7 +3195,6 @@ TEST(LangBindHelper_ImplicitTransactions_InterProcess)
 }
 
 #endif // !REALM_ANDROID && !REALM_IOS
-#endif // not REALM_ENABLE_ENCRYPTION
 #endif // not defined _WIN32
 
 TEST(LangBindHelper_ImplicitTransactions_NoExtremeFileSpaceLeaks)

--- a/test/test_lang_bind_helper.cpp
+++ b/test/test_lang_bind_helper.cpp
@@ -3083,7 +3083,14 @@ TEST(LangBindHelper_ImplicitTransactions_MultipleTrackers)
 
 #ifndef _WIN32
 
+#if !(REALM_ENABLE_ENCRYPTION && REALM_PLATFORM_APPLE)
+// Interprocess communication does not work with encryption enabled on Apple.
+// This is because fork() does not play well with Apple primitives such as
+// dispatch_queue_t in ReclaimerThreadStopper. This could possibly be fixed if
+// we need more tests like this.
+
 #if !REALM_ANDROID && !REALM_IOS
+
 std::stringstream ss;
 void signal_handler(int signal)
 {
@@ -3211,6 +3218,7 @@ NONCONCURRENT_TEST_IF(LangBindHelper_ImplicitTransactions_InterProcess, !running
 }
 
 #endif // !REALM_ANDROID && !REALM_IOS
+#endif // not REALM_ENABLE_ENCRYPTION
 #endif // not defined _WIN32
 
 TEST(LangBindHelper_ImplicitTransactions_NoExtremeFileSpaceLeaks)

--- a/test/test_lang_bind_helper.cpp
+++ b/test/test_lang_bind_helper.cpp
@@ -3117,19 +3117,19 @@ NONCONCURRENT_TEST_IF(LangBindHelper_ImplicitTransactions_InterProcess, !running
         do {
             ret = waitpid(pid, status, options);
         } while (ret == -1 && errno == EINTR);
-        REALM_ASSERT_EX(ret != -1, errno, pid, info);
+        REALM_ASSERT_RELEASE_EX(ret != -1, errno, pid, info);
 
         bool signaled_to_stop = WIFSIGNALED(*status);
-        REALM_ASSERT_EX(!signaled_to_stop, WTERMSIG(*status), WCOREDUMP(*status), pid, info);
+        REALM_ASSERT_RELEASE_EX(!signaled_to_stop, WTERMSIG(*status), WCOREDUMP(*status), pid, info);
 
         bool stopped = WIFSTOPPED(*status);
-        REALM_ASSERT_EX(!stopped, WSTOPSIG(*status), pid, info);
+        REALM_ASSERT_RELEASE_EX(!stopped, WSTOPSIG(*status), pid, info);
 
         bool exited_normally = WIFEXITED(*status);
-        REALM_ASSERT_EX(exited_normally, pid, info);
+        REALM_ASSERT_RELEASE_EX(exited_normally, pid, info);
 
         auto exit_status = WEXITSTATUS(*status);
-        REALM_ASSERT_EX(exit_status == 0, exit_status, pid, info);
+        REALM_ASSERT_RELEASE_EX(exit_status == 0, exit_status, pid, info);
     };
 
     int readpids[read_process_count];


### PR DESCRIPTION
Due to the [extra assertions ](https://github.com/realm/realm-core/pull/5297) added to this test, I found a [failure in CI](https://ci.realm.io/blue/organizations/jenkins/realm%2Frealm-core/detail/PR-5325/2/pipeline/) with the "populate" child giving an assertion failure on exit `1: /mnt/jenkins/workspace/realm_realm-core_PR-5325@2/src/realm/util/thread.cpp:186: [realm-core-11.11.0] Destruction of mutex in use`

There are three static Mutexes in use in the tests: in utilities.cpp, test_util_type_list.cpp, and random.hpp. Notably, GlobalRandom makes use of a mutex when sourcing randoms. Given this, I think the source of the hangs is that if the call to `fork()` happens while some concurrent test has the GlobalRandom mutex locked, then that state is copied over to the child process and the mutex is never unlocked. Since the writers spawned by this test make use of the GlobalRandom to [seed](https://github.com/realm/realm-core/compare/js/test-race?expand=1#diff-9215d027423d090703d5f1f443d70bc4b6d22b65600fbaf8b9b4dd5a6db9600eR2988) a generator, acquiring the lock will hang indefinitely. 

The solution here is to make this test non-concurrent. This will ensure that no static mutexes are in use at the time of `fork()`.

Replaces https://github.com/realm/realm-core/pull/5096 