### PR TITLE
Prevent advancing to intermediate versions when advancing notifications

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@
 ### Internals
 * Catch2 was updated to 2.13.8. ([#5327](https://github.com/realm/realm-core/pull/5327))
 * Mutating a committed MutableSubscriptionSet will throw a LogicError. ([#5162](https://github.com/realm/realm-core/pull/5162))
+* When advancing the notifiers we will no longer attach to intermediate versions. We will always work from the latest version.
 
 ----------------------------------------------
 

--- a/src/realm/object-store/impl/results_notifier.cpp
+++ b/src/realm/object-store/impl/results_notifier.cpp
@@ -324,7 +324,7 @@ void ListResultsNotifier::calculate_changes()
 
 void ListResultsNotifier::run()
 {
-    if (!m_list->is_attached()) {
+    if (!m_list || !m_list->is_attached()) {
         // List was deleted, so report all of the rows being removed
         m_change = {};
         m_change.deletions.set(m_previous_indices.size());

--- a/src/realm/object-store/impl/transact_log_handler.cpp
+++ b/src/realm/object-store/impl/transact_log_handler.cpp
@@ -678,6 +678,13 @@ void advance(Transaction& tr, TransactionChangeInfo& info, VersionID version)
     }
 }
 
+void observe(Transaction& tr, TransactionChangeInfo& info, VersionID from_version, VersionID to_version)
+{
+    if (info.track_all || !info.tables.empty() || !info.lists.empty()) {
+        tr.observe(TransactLogObserver(info), from_version, to_version);
+    }
+}
+
 } // namespace transaction
 } // namespace _impl
 } // namespace realm

--- a/src/realm/object-store/impl/transact_log_handler.hpp
+++ b/src/realm/object-store/impl/transact_log_handler.hpp
@@ -54,6 +54,9 @@ void cancel(Transaction& sg, BindingContext* binding_context);
 
 // Advance the read transaction version, with change information gathered in info
 void advance(Transaction& sg, TransactionChangeInfo& info, VersionID version = VersionID{});
+
+void observe(Transaction& tr, TransactionChangeInfo& info, VersionID from_version, VersionID to_version);
+
 } // namespace transaction
 } // namespace _impl
 } // namespace realm

--- a/test/test_shared.cpp
+++ b/test/test_shared.cpp
@@ -3773,9 +3773,9 @@ TEST_IF(Shared_LinksToSameCluster, REALM_ENABLE_ENCRYPTION)
     std::unique_ptr<Replication> hist(make_in_realm_history());
     DBRef db = DB::create(*hist, path, DBOptions(key));
     std::vector<ObjKey> keys;
+    auto rt = db->start_read();
     {
         auto wt = db->start_write();
-        auto rt = db->start_read();
         std::vector<TableView> table_views;
 
         auto t = wt->add_table("Table_0");


### PR DESCRIPTION
We would like to avoid to advance to versions that are not currently "alive",
meaning that they have at least one read transaction attached to it. This will
make it easier to free space accupied by "dead" versions.

We can instead start a transaction at the lastest version  and use the
history information here to advance the notifiers. The history
contains the changesets from the oldest referenced version up to the current..

## What, How & Why?
<!-- Describe the changes and give some hints to guide your reviewers if possible. -->
<!-- Link to relevant issue this fixes -->

## ☑️ ToDos
* [ ] 📝 Changelog update
* [ ] 🚦 Tests (or not relevant)
