### PR TITLE
Updating subscription while refreshing the access token would crash

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 * <How do the end-user experience this issue? what was the impact?> ([#????](https://github.com/realm/realm-core/issues/????), since v?.?.?)
 * Fixed a potential crash if a sync session is stopped in the middle of a `DiscardLocal` client reset. ([#5295](https://github.com/realm/realm-core/issues/5295), since v11.5.0) 
 * Opening an encrypted Realm while the keychain is locked on macOS would crash ([Swift #7438](https://github.com/realm/realm-swift/issues/7438)).
+* Updating subscription while refreshing the access token would crash ([#5343](https://github.com/realm/realm-core/issues/5343), since v11.8.0)
  
 ### Breaking changes
 * None.

--- a/src/realm/object-store/sync/sync_session.cpp
+++ b/src/realm/object-store/sync/sync_session.cpp
@@ -256,7 +256,10 @@ std::shared_ptr<sync::SubscriptionStore> SyncSession::make_flx_subscription_stor
         if (m_state != State::Active && m_state != State::WaitingForAccessToken) {
             return;
         }
-        m_session->on_new_flx_sync_subscription(new_version);
+        // There may be no session yet (i.e., waiting to refresh the access token).
+        if (m_session) {
+            m_session->on_new_flx_sync_subscription(new_version);
+        }
     });
 }
 


### PR DESCRIPTION
## What, How & Why?
While refreshing the access token, there is no session. If at the same time a subscription set is updated, the session is accessed resulting in a crash.
We have now guarded access to the session for this specific case. Fixes #5343.

## ☑️ ToDos
* [x] 📝 Changelog update
* [x] 🚦 Tests (or not relevant)
