### PR TITLE
Add thread-safety annotations to SyncSession

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 * Fixed a potential crash if a sync session is stopped in the middle of a `DiscardLocal` client reset. ([#5295](https://github.com/realm/realm-core/issues/5295), since v11.5.0) 
 * Opening an encrypted Realm while the keychain is locked on macOS would crash ([Swift #7438](https://github.com/realm/realm-swift/issues/7438)).
 * Updating subscription while refreshing the access token would crash ([#5343](https://github.com/realm/realm-core/issues/5343), since v11.8.0)
+* Fix several race conditions in SyncSession related to calling `update_configuration()` on one thread while using the SyncSession on another thread. It does not appear that it was possible to hit the broken scenarios via the SDKs public APIs.
  
 ### Breaking changes
 * None.

--- a/src/realm/db.hpp
+++ b/src/realm/db.hpp
@@ -173,6 +173,11 @@ public:
         return m_db_path;
     }
 
+    const char* get_encryption_key() const noexcept
+    {
+        return m_key;
+    }
+
 #ifdef REALM_DEBUG
     /// Deprecated method, only called from a unit test
     ///

--- a/src/realm/object-store/impl/realm_coordinator.cpp
+++ b/src/realm/object-store/impl/realm_coordinator.cpp
@@ -100,56 +100,6 @@ void RealmCoordinator::create_sync_session()
     if (m_sync_session)
         return;
 
-    // Create the fresh config copy here. A copy is needed so that a self reference doesn't keep the sync config alive
-    // and so that the function below can access the config even if it is called from a diferent thread on a dying
-    // session
-    auto copy_config = m_config;
-    copy_config.schema = util::none;
-    copy_config.realm_data = BinaryData{};
-    copy_config.audit_factory = {};
-    // Do not use 'discard local' mode on the fresh Realm. Use manual mode so that
-    // any error during the download is propagated back to the original session.
-    // This prevents a cycle if the fresh copy itself experiences a client reset.
-    // To make this change and not have it affect the actual sync session, an explicit
-    // copy must be made of the sync config because it is a shared pointer.
-    copy_config.sync_config = std::make_shared<SyncConfig>(*m_config.sync_config);
-    copy_config.sync_config->client_resync_mode = ClientResyncMode::Manual;
-
-    m_config.sync_config->get_fresh_realm_for_path =
-        [copy_config](const std::string& path,
-                      util::UniqueFunction<void(DBRef, util::Optional<std::string>)> callback) {
-            try {
-                auto config = copy_config; // a locally mutable copy
-                // Get a fully downloaded Realm using the current configuration but changing the
-                // on disk path to the one provided. The current sync session is not affected.
-                REALM_ASSERT(!path.empty());
-                REALM_ASSERT_EX(path != config.path, path);
-                REALM_ASSERT(config.sync_config);
-                config.path = path;
-                std::shared_ptr<RealmCoordinator> rc = get_coordinator(config);
-                REALM_ASSERT(rc);
-                auto task = rc->get_synchronized_realm(config);
-                task->start([callback = std::move(callback), path](ThreadSafeReference, std::exception_ptr err) {
-                    try {
-                        if (err) {
-                            std::rethrow_exception(err);
-                        }
-                        else {
-                            std::shared_ptr<RealmCoordinator> rc = RealmCoordinator::get_coordinator(path);
-                            rc->m_sync_session->log_out();
-                            rc->m_sync_session->close();
-                            callback(rc->m_db, util::none);
-                        }
-                    }
-                    catch (const std::exception& e) {
-                        callback(nullptr, util::make_optional<std::string>(e.what()));
-                    }
-                });
-            }
-            catch (const std::exception& e) {
-                callback(nullptr, util::make_optional<std::string>(e.what()));
-            }
-        };
     m_sync_session = m_config.sync_config->user->sync_manager()->get_session(m_db, *m_config.sync_config);
 
     std::weak_ptr<RealmCoordinator> weak_self = shared_from_this();

--- a/src/realm/object-store/sync/sync_session.hpp
+++ b/src/realm/object-store/sync/sync_session.hpp
@@ -121,8 +121,8 @@ public:
     using ProgressDirection = _impl::SyncProgressNotifier::NotifierType;
 
     ~SyncSession();
-    State state() const;
-    ConnectionState connection_state() const;
+    State state() const REQUIRES(!m_state_mutex);
+    ConnectionState connection_state() const REQUIRES(!m_state_mutex);
 
     // The on-disk path of the Realm file backing the Realm this `SyncSession` represents.
     std::string const& path() const;
@@ -130,11 +130,12 @@ public:
     // Register a callback that will be called when all pending uploads have completed.
     // The callback is run asynchronously, and upon whatever thread the underlying sync client
     // chooses to run it on.
-    void wait_for_upload_completion(util::UniqueFunction<void(std::error_code)>&& callback);
+    void wait_for_upload_completion(util::UniqueFunction<void(std::error_code)>&& callback) REQUIRES(!m_state_mutex);
 
     // Register a callback that will be called when all pending downloads have been completed.
     // Works the same way as `wait_for_upload_completion()`.
-    void wait_for_download_completion(util::UniqueFunction<void(std::error_code)>&& callback);
+    void wait_for_download_completion(util::UniqueFunction<void(std::error_code)>&& callback)
+        REQUIRES(!m_state_mutex);
 
     // Register a notifier that updates the app regarding progress.
     //
@@ -174,53 +175,55 @@ public:
     // If the sync session is currently `Dying`, ask it to stay alive instead.
     // If the sync session is currently `Inactive`, recreate it.
     // Otherwise, a no-op.
-    void revive_if_needed();
+    void revive_if_needed() REQUIRES(!m_state_mutex, !m_config_mutex);
 
     // Perform any actions needed in response to regaining network connectivity.
-    void handle_reconnect();
+    void handle_reconnect() REQUIRES(!m_state_mutex);
 
     // Inform the sync session that it should close.
-    void close();
+    void close() REQUIRES(!m_state_mutex, !m_config_mutex);
 
     // Inform the sync session that it should log out.
-    void log_out();
+    void log_out() REQUIRES(!m_state_mutex);
 
     // Shut down the synchronization session (sync::Session) and wait for the Realm file to no
     // longer be open on behalf of it.
-    void shutdown_and_wait();
+    void shutdown_and_wait() REQUIRES(!m_state_mutex);
 
     // The access token needs to periodically be refreshed and this is how to
     // let the sync session know to update it's internal copy.
-    void update_access_token(std::string signed_token);
+    void update_access_token(const std::string& signed_token) REQUIRES(!m_state_mutex, !m_config_mutex);
 
     // Request an updated access token from this session's sync user.
-    void initiate_access_token_refresh();
+    void initiate_access_token_refresh() REQUIRES(!m_config_mutex);
 
     // Update the sync configuration used for this session. The new configuration must have the
     // same user and reference realm url as the old configuration. The session will immediately
     // disconnect (if it was active), and then attempt to connect using the new configuration.
-    void update_configuration(SyncConfig new_config);
+    void update_configuration(SyncConfig new_config) REQUIRES(!m_state_mutex, !m_config_mutex);
 
     // An object representing the user who owns the Realm this `SyncSession` represents.
-    std::shared_ptr<SyncUser> user() const
+    std::shared_ptr<SyncUser> user() const REQUIRES(!m_config_mutex)
     {
+        util::CheckedLockGuard lock(m_config_mutex);
         return m_config.user;
     }
 
     // A copy of the configuration object describing the Realm this `SyncSession` represents.
-    const SyncConfig& config() const
+    SyncConfig config() const REQUIRES(!m_config_mutex)
     {
+        util::CheckedLockGuard lock(m_config_mutex);
         return m_config;
     }
 
     // If the `SyncSession` has been configured, the full remote URL of the Realm
     // this `SyncSession` represents.
-    util::Optional<std::string> full_realm_url() const
+    util::Optional<std::string> full_realm_url() const REQUIRES(!m_config_mutex)
     {
+        util::CheckedLockGuard lock(m_config_mutex);
         return m_server_url;
     }
 
-    bool has_flx_subscription_store() const;
     sync::SubscriptionStore* get_flx_subscription_store();
 
     // Create an external reference to this session. The sync session attempts to remain active
@@ -305,75 +308,83 @@ private:
     }
     // }
 
-    std::shared_ptr<SyncManager> sync_manager() const;
-    std::shared_ptr<sync::SubscriptionStore> make_flx_subscription_store();
+    std::shared_ptr<SyncManager> sync_manager() const REQUIRES(!m_state_mutex);
 
     static util::UniqueFunction<void(util::Optional<app::AppError>)>
     handle_refresh(const std::shared_ptr<SyncSession>&);
 
     SyncSession(_impl::SyncClient&, std::shared_ptr<DB>, SyncConfig, SyncManager* sync_manager);
 
-    void handle_fresh_realm_downloaded(DBRef db, util::Optional<std::string> error_message);
-    void handle_error(SyncError);
+    void download_fresh_realm() REQUIRES(!m_config_mutex, !m_state_mutex);
+    void handle_fresh_realm_downloaded(DBRef db, util::Optional<std::string> error_message)
+        REQUIRES(!m_state_mutex, !m_config_mutex);
+    void handle_error(SyncError) REQUIRES(!m_state_mutex, !m_config_mutex);
     void handle_bad_auth(const std::shared_ptr<SyncUser>& user, std::error_code error_code,
-                         const std::string& context_message);
-    void cancel_pending_waits(std::unique_lock<std::mutex>&, std::error_code);
+                         const std::string& context_message) REQUIRES(!m_state_mutex, !m_config_mutex);
+    void cancel_pending_waits(util::CheckedUniqueLock, std::error_code) RELEASE(m_state_mutex);
     enum class ShouldBackup { yes, no };
-    void update_error_and_mark_file_for_deletion(SyncError&, ShouldBackup);
-    std::string get_recovery_file_path();
+    void update_error_and_mark_file_for_deletion(SyncError&, ShouldBackup) REQUIRES(m_state_mutex, !m_config_mutex);
     void handle_progress_update(uint64_t, uint64_t, uint64_t, uint64_t, uint64_t, uint64_t);
     void handle_new_flx_sync_query(int64_t version);
 
-    void set_sync_transact_callback(util::UniqueFunction<TransactionCallback>);
-    void nonsync_transact_notify(VersionID::version_type);
+    void set_sync_transact_callback(util::UniqueFunction<TransactionCallback>) REQUIRES(!m_state_mutex);
+    void nonsync_transact_notify(VersionID::version_type) REQUIRES(!m_state_mutex);
 
-    void create_sync_session();
-    void do_create_sync_session();
-    void did_drop_external_reference() REQUIRES(!m_external_reference_mutex);
-    void detach_from_sync_manager();
-    void close(std::unique_lock<std::mutex>&);
+    void create_sync_session() REQUIRES(m_state_mutex, !m_config_mutex);
+    void did_drop_external_reference() REQUIRES(!m_state_mutex, !m_config_mutex, !m_external_reference_mutex);
+    void detach_from_sync_manager() REQUIRES(!m_state_mutex);
+    void close(util::CheckedUniqueLock) RELEASE(m_state_mutex) REQUIRES(!m_config_mutex);
 
-    void become_active(std::unique_lock<std::mutex>&);
-    void become_dying(std::unique_lock<std::mutex>&);
-    void become_inactive(std::unique_lock<std::mutex>&);
-    void become_waiting_for_access_token(std::unique_lock<std::mutex>&);
+    void become_active() REQUIRES(m_state_mutex, !m_config_mutex);
+    void become_dying(util::CheckedUniqueLock) RELEASE(m_state_mutex);
+    void become_inactive(util::CheckedUniqueLock, std::error_code ec = {}) RELEASE(m_state_mutex);
+    void become_waiting_for_access_token() REQUIRES(m_state_mutex);
 
+    void add_completion_callback(util::UniqueFunction<void(std::error_code)> callback, ProgressDirection direction)
+        REQUIRES(m_state_mutex);
 
-    void add_completion_callback(const std::unique_lock<std::mutex>&,
-                                 util::UniqueFunction<void(std::error_code)> callback, ProgressDirection direction);
+    util::UniqueFunction<TransactionCallback> m_sync_transact_callback GUARDED_BY(m_state_mutex);
 
-    util::UniqueFunction<TransactionCallback> m_sync_transact_callback;
+    template <typename Field>
+    auto config(Field f) REQUIRES(!m_config_mutex)
+    {
+        util::CheckedLockGuard lock(m_config_mutex);
+        return m_config.*f;
+    }
 
-    mutable std::mutex m_state_mutex;
+    void assert_mutex_unlocked() ASSERT_CAPABILITY(!m_state_mutex) ASSERT_CAPABILITY(!m_config_mutex) {}
 
-    State m_state = State::Inactive;
+    mutable util::CheckedMutex m_state_mutex;
+
+    State m_state GUARDED_BY(m_state_mutex) = State::Inactive;
 
     // The underlying state of the connection. Even when sharing connections, the underlying session
     // will always start out as disconnected and then immediately transition to the correct state when calling
     // bind().
-    ConnectionState m_connection_state = ConnectionState::Disconnected;
-    size_t m_death_count = 0;
+    ConnectionState m_connection_state GUARDED_BY(m_state_mutex) = ConnectionState::Disconnected;
+    size_t m_death_count GUARDED_BY(m_state_mutex) = 0;
 
-    SyncConfig m_config;
-    std::shared_ptr<DB> m_db;
-    std::shared_ptr<sync::SubscriptionStore> m_flx_subscription_store;
-    bool m_force_client_reset = false;
-    DBRef m_client_reset_fresh_copy;
+    mutable util::CheckedMutex m_config_mutex;
+    SyncConfig m_config GUARDED_BY(m_config_mutex);
+    const std::shared_ptr<DB> m_db;
+    const std::shared_ptr<sync::SubscriptionStore> m_flx_subscription_store;
+    bool m_force_client_reset GUARDED_BY(m_state_mutex) = false;
+    DBRef m_client_reset_fresh_copy GUARDED_BY(m_state_mutex);
     _impl::SyncClient& m_client;
-    SyncManager* m_sync_manager = nullptr;
+    SyncManager* m_sync_manager GUARDED_BY(m_state_mutex) = nullptr;
 
-    int64_t m_completion_request_counter = 0;
-    CompletionCallbacks m_completion_callbacks;
+    int64_t m_completion_request_counter GUARDED_BY(m_state_mutex) = 0;
+    CompletionCallbacks m_completion_callbacks GUARDED_BY(m_state_mutex);
 
     // The underlying `Session` object that is owned and managed by this `SyncSession`.
     // The session is first created when the `SyncSession` is moved out of its initial `inactive` state.
     // The session might be destroyed if the `SyncSession` becomes inactive again (for example, if the
     // user owning the session logs out). It might be created anew if the session is revived (if a
     // logged-out user logs back in, the object store sync code will revive their sessions).
-    std::unique_ptr<sync::Session> m_session;
+    std::unique_ptr<sync::Session> m_session GUARDED_BY(m_state_mutex);
 
     // The fully-resolved URL of this Realm, including the server and the path.
-    util::Optional<std::string> m_server_url;
+    util::Optional<std::string> m_server_url GUARDED_BY(m_config_mutex);
 
     _impl::SyncProgressNotifier m_progress_notifier;
     ConnectionChangeNotifier m_connection_change_notifier;

--- a/src/realm/sync/client.cpp
+++ b/src/realm/sync/client.cpp
@@ -1564,7 +1564,7 @@ bool Session::wait_for_download_complete_or_client_stopped()
 }
 
 
-void Session::refresh(std::string signed_access_token)
+void Session::refresh(const std::string& signed_access_token)
 {
     m_impl->refresh(signed_access_token); // Throws
 }

--- a/src/realm/sync/client.hpp
+++ b/src/realm/sync/client.hpp
@@ -575,7 +575,7 @@ public:
     ///
     /// \param signed_user_token A cryptographically signed token describing the
     /// identity and access rights of the current user. See ProtocolEnvelope.
-    void refresh(std::string signed_user_token);
+    void refresh(const std::string& signed_user_token);
 
     /// \brief Inform the synchronization agent about changes of local origin.
     ///

--- a/src/realm/sync/config.hpp
+++ b/src/realm/sync/config.hpp
@@ -160,8 +160,6 @@ struct SyncConfig {
     ClientResyncMode client_resync_mode = ClientResyncMode::Manual;
     std::function<void(std::shared_ptr<Realm> before_frozen)> notify_before_client_reset;
     std::function<void(std::shared_ptr<Realm> before_frozen, std::shared_ptr<Realm> after)> notify_after_client_reset;
-    std::function<void(const std::string&, util::UniqueFunction<void(DBRef, util::Optional<std::string>)>)>
-        get_fresh_realm_for_path;
 
     explicit SyncConfig(std::shared_ptr<SyncUser> user, bson::Bson partition);
     explicit SyncConfig(std::shared_ptr<SyncUser> user, std::string partition);

--- a/test/object-store/sync/flx_sync.cpp
+++ b/test/object-store/sync/flx_sync.cpp
@@ -618,7 +618,7 @@ TEST_CASE("flx: no subscription store created for PBS app", "[sync][flx][app]") 
     CHECK(!wait_for_download(*realm));
     CHECK(!wait_for_upload(*realm));
 
-    CHECK(!realm->sync_session()->has_flx_subscription_store());
+    CHECK(!realm->sync_session()->get_flx_subscription_store());
 }
 
 TEST_CASE("flx: connect to FLX as PBS returns an error", "[sync][flx][app]") {
@@ -741,8 +741,8 @@ TEST_CASE("flx: commit subscription while refreshing the access token", "[sync][
                 REQUIRE(!seen_waiting_for_access_token);
                 seen_waiting_for_access_token = true;
 
-                REQUIRE(session->has_flx_subscription_store());
                 auto store = session->get_flx_subscription_store();
+                REQUIRE(store);
                 auto mut_subs = store->get_latest().make_mutable_copy();
                 std::move(mut_subs).commit();
             }
@@ -755,4 +755,4 @@ TEST_CASE("flx: commit subscription while refreshing the access token", "[sync][
 }
 } // namespace realm::app
 
-#endif
+#endif // REALM_ENABLE_AUTH_TESTS


### PR DESCRIPTION
And fix a few problems exposed by them, mostly related to that `m_config` was used unguarded despite being mutable. This adds a new mutex to guard `m_config` because reusing the state mutex for that made some code I wanted to write on the audit branch deadlock.