### PR TITLE
Detect and prevent client reset cycles

### DIFF
--- a/how-to-build.md
+++ b/how-to-build.md
@@ -171,7 +171,7 @@ Once authorized, run the following docker command from the top directory to star
 
 ```
 export MDBREALM_TEST_SERVER_TAG=$(grep MDBREALM_TEST_SERVER_TAG dependencies.list |cut -f 2 -d=)
-docker run --rm -p 9090:9090 -v ~/.aws/credentials:/root/.aws/credentials -it docker.pkg.github.com/realm/ci/mongodb-realm-test-server:${MDBREALM_TEST_SERVER_TAG}
+docker run --rm -p 9090:9090 -v ~/.aws/credentials:/root/.aws/credentials -it ghcr.io/realm/ci/mongodb-realm-test-server:${MDBREALM_TEST_SERVER_TAG}
 ```
 
 This will make the stitch UI available in your browser at `localhost:9090` where you can login with "unique_user@domain.com" and "password".

--- a/src/realm/object-store/sync/sync_session.cpp
+++ b/src/realm/object-store/sync/sync_session.cpp
@@ -439,6 +439,8 @@ void SyncSession::handle_error(SyncError error)
                         break;
                     case ClientResyncMode::DiscardLocal:
                         [[fallthrough]];
+                    case ClientResyncMode::RecoverOrDiscard:
+                        [[fallthrough]];
                     case ClientResyncMode::Recover:
                         download_fresh_realm();
                         return; // do not propgate the error to the user at this point
@@ -564,25 +566,26 @@ void SyncSession::handle_progress_update(uint64_t downloaded, uint64_t downloada
 static sync::Session::Config::ClientReset make_client_reset_config(SyncConfig& session_config, DBRef&& fresh_copy)
 {
     sync::Session::Config::ClientReset config;
-    config.discard_local = (session_config.client_resync_mode == ClientResyncMode::DiscardLocal);
-    config.notify_after_client_reset =
-        [notify = session_config.notify_after_client_reset](std::string local_path, VersionID previous_version) {
-            REALM_ASSERT(!local_path.empty());
-            SharedRealm frozen_before, active_after;
-            if (auto local_coordinator = RealmCoordinator::get_existing_coordinator(local_path)) {
-                auto local_config = local_coordinator->get_config();
-                active_after = local_coordinator->get_realm(local_config, util::none);
-                local_config.scheduler = nullptr;
-                frozen_before = local_coordinator->get_realm(local_config, previous_version);
-                REALM_ASSERT(active_after);
-                REALM_ASSERT(!active_after->is_frozen());
-                REALM_ASSERT(frozen_before);
-                REALM_ASSERT(frozen_before->is_frozen());
-            }
-            if (notify) {
-                notify(frozen_before, active_after);
-            }
-        };
+    REALM_ASSERT(session_config.client_resync_mode != ClientResyncMode::Manual);
+    config.mode = session_config.client_resync_mode;
+    config.notify_after_client_reset = [notify = session_config.notify_after_client_reset](
+                                           std::string local_path, VersionID previous_version, bool did_recover) {
+        REALM_ASSERT(!local_path.empty());
+        SharedRealm frozen_before, active_after;
+        if (auto local_coordinator = RealmCoordinator::get_existing_coordinator(local_path)) {
+            auto local_config = local_coordinator->get_config();
+            active_after = local_coordinator->get_realm(local_config, util::none);
+            local_config.scheduler = nullptr;
+            frozen_before = local_coordinator->get_realm(local_config, previous_version);
+            REALM_ASSERT(active_after);
+            REALM_ASSERT(!active_after->is_frozen());
+            REALM_ASSERT(frozen_before);
+            REALM_ASSERT(frozen_before->is_frozen());
+        }
+        if (notify) {
+            notify(frozen_before, active_after, did_recover);
+        }
+    };
     config.notify_before_client_reset = [notify = session_config.notify_before_client_reset](std::string local_path) {
         REALM_ASSERT(!local_path.empty());
         SharedRealm frozen_local;

--- a/src/realm/sync/client.cpp
+++ b/src/realm/sync/client.cpp
@@ -643,9 +643,9 @@ const std::string& SessionImpl::get_realm_path() const noexcept
     return m_wrapper.m_db->get_path();
 }
 
-DB& SessionImpl::get_db() const noexcept
+DBRef SessionImpl::get_db() const noexcept
 {
-    return *m_wrapper.m_db;
+    return m_wrapper.m_db;
 }
 
 SyncTransactReporter* SessionImpl::get_transact_reporter() noexcept

--- a/src/realm/sync/client_base.hpp
+++ b/src/realm/sync/client_base.hpp
@@ -4,6 +4,7 @@
 #include <realm/db.hpp>
 #include <realm/sync/config.hpp>
 #include <realm/sync/protocol.hpp>
+#include <realm/sync/noinst/client_reset.hpp>
 #include <realm/util/functional.hpp>
 
 namespace realm::sync {
@@ -58,10 +59,11 @@ class SessionWrapper;
 /// either void async_wait_for_download_completion(WaitOperCompletionHandler) or
 /// bool wait_for_download_complete_or_client_stopped().
 struct ClientReset {
-    bool discard_local = false;
+    realm::ClientResyncMode mode;
     DBRef fresh_copy;
     util::UniqueFunction<void(std::string path)> notify_before_client_reset;
-    util::UniqueFunction<void(std::string path, VersionID before_version)> notify_after_client_reset;
+    util::UniqueFunction<void(std::string path, VersionID before_version, bool did_recover)>
+        notify_after_client_reset;
 };
 
 /// \brief Protocol errors discovered by the client.

--- a/src/realm/sync/config.cpp
+++ b/src/realm/sync/config.cpp
@@ -31,22 +31,6 @@ static_assert(std::is_same_v<sync::port_type, util::network::Endpoint::port_type
 
 using ProtocolError = realm::sync::ProtocolError;
 
-std::ostream& operator<<(std::ostream& os, const ClientResyncMode& mode)
-{
-    switch (mode) {
-        case ClientResyncMode::Manual:
-            os << "Manual";
-            break;
-        case ClientResyncMode::DiscardLocal:
-            os << "DiscardLocal";
-            break;
-        case ClientResyncMode::Recover:
-            os << "Recover";
-            break;
-    }
-    return os;
-}
-
 bool SyncError::is_client_error() const
 {
     return error_code.category() == realm::sync::client_error_category();

--- a/src/realm/sync/config.hpp
+++ b/src/realm/sync/config.hpp
@@ -22,6 +22,7 @@
 #include <realm/db.hpp>
 #include <realm/util/assert.hpp>
 #include <realm/util/optional.hpp>
+#include <realm/sync/noinst/client_reset.hpp>
 
 #include <functional>
 #include <memory>
@@ -92,17 +93,6 @@ struct SyncError {
 
 using SyncSessionErrorHandler = void(std::shared_ptr<SyncSession>, SyncError);
 
-enum class ClientResyncMode : unsigned char {
-    // Fire a client reset error
-    Manual,
-    // Discard local changes, without disrupting accessors or closing the Realm
-    DiscardLocal,
-    // Attempt to recover unsynchronized but committed changes.
-    Recover,
-};
-
-std::ostream& operator<<(std::ostream& os, const ClientResyncMode& mode);
-
 enum class ReconnectMode {
     /// This is the mode that should always be used in production. In this
     /// mode the client uses a scheme for determining a reconnect delay that
@@ -163,7 +153,8 @@ struct SyncConfig {
     util::Optional<std::string> recovery_directory;
     ClientResyncMode client_resync_mode = ClientResyncMode::Manual;
     std::function<void(std::shared_ptr<Realm> before_frozen)> notify_before_client_reset;
-    std::function<void(std::shared_ptr<Realm> before_frozen, std::shared_ptr<Realm> after)> notify_after_client_reset;
+    std::function<void(std::shared_ptr<Realm> before_frozen, std::shared_ptr<Realm> after, bool did_recover)>
+        notify_after_client_reset;
 
     explicit SyncConfig(std::shared_ptr<SyncUser> user, bson::Bson partition);
     explicit SyncConfig(std::shared_ptr<SyncUser> user, std::string partition);

--- a/src/realm/sync/noinst/client_history_impl.cpp
+++ b/src/realm/sync/noinst/client_history_impl.cpp
@@ -778,6 +778,13 @@ void ClientHistory::update_sync_progress(const SyncProgress& progress, const std
                  RefOrTagged::make_tagged(progress.upload.last_integrated_server_version)); // Throws
     }
     if (previous_upload_client_version < progress.upload.client_version) {
+        // This is part of the client reset cycle detection.
+        // A client reset operation will write a flag to an internal table indicating that
+        // the changes there are a result of a successful reset. However, it is not possible to
+        // know if a recovery has been successful until the changes have been acknowledged by the
+        // server. The situation we want to avoid is that a recovery itself causes another reset
+        // which creates a reset cycle. However, at this point, upload progress has been made
+        // and we can remove the cycle detection flag if there is one.
         _impl::client_reset::remove_pending_client_resets(wt);
     }
     if (downloadable_bytes) {

--- a/src/realm/sync/noinst/client_history_impl.hpp
+++ b/src/realm/sync/noinst/client_history_impl.hpp
@@ -407,7 +407,7 @@ private:
     void prepare_for_write();
     Replication::version_type add_changeset(BinaryData changeset, BinaryData sync_changeset);
     void add_sync_history_entry(HistoryEntry);
-    void update_sync_progress(const SyncProgress&, const std::uint_fast64_t* downloadable_bytes);
+    void update_sync_progress(const SyncProgress&, const std::uint_fast64_t* downloadable_bytes, TransactionRef);
     void trim_ct_history();
     void trim_sync_history();
     void do_trim_sync_history(std::size_t n);

--- a/src/realm/sync/noinst/client_impl_base.cpp
+++ b/src/realm/sync/noinst/client_impl_base.cpp
@@ -1478,7 +1478,7 @@ void Session::activate()
                     (client_reset_config && file_exists) ? "true" : "false"); // Throws
         if (client_reset_config && !m_client_reset_operation) {
             m_client_reset_operation = std::make_unique<_impl::ClientResetOperation>(
-                logger, get_db(), std::move(client_reset_config->fresh_copy), client_reset_config->discard_local,
+                logger, get_db(), std::move(client_reset_config->fresh_copy), client_reset_config->mode,
                 std::move(client_reset_config->notify_before_client_reset),
                 std::move(client_reset_config->notify_after_client_reset)); // Throws
         }

--- a/src/realm/sync/noinst/client_impl_base.hpp
+++ b/src/realm/sync/noinst/client_impl_base.hpp
@@ -762,7 +762,7 @@ private:
     const std::string& get_virt_path() const noexcept;
 
     const std::string& get_realm_path() const noexcept;
-    DB& get_db() const noexcept;
+    DBRef get_db() const noexcept;
     SyncTransactReporter* get_transact_reporter() noexcept;
 
     /// The implementation need only ensure that the returned reference stays valid

--- a/src/realm/sync/noinst/client_reset.cpp
+++ b/src/realm/sync/noinst/client_reset.cpp
@@ -875,7 +875,7 @@ void track_reset(TransactionRef wt, ClientResyncMode mode)
                                            {type_col, mode_val}});
 }
 
-ClientResyncMode reset_precheck_guard(TransactionRef wt, ClientResyncMode mode, util::Logger& logger)
+static ClientResyncMode reset_precheck_guard(TransactionRef wt, ClientResyncMode mode, util::Logger& logger)
 {
     REALM_ASSERT(wt);
     if (auto previous_reset = has_pending_reset(wt)) {

--- a/src/realm/sync/noinst/client_reset.cpp
+++ b/src/realm/sync/noinst/client_reset.cpp
@@ -18,6 +18,7 @@
 
 #include <realm/db.hpp>
 #include <realm/dictionary.hpp>
+#include <realm/table_view.hpp>
 #include <realm/set.hpp>
 
 #include <realm/sync/history.hpp>
@@ -31,11 +32,36 @@
 #include <realm/util/flat_map.hpp>
 
 #include <algorithm>
+#include <chrono>
 #include <vector>
 
 using namespace realm;
 using namespace _impl;
 using namespace sync;
+
+namespace realm {
+
+std::ostream& operator<<(std::ostream& os, const ClientResyncMode& mode)
+{
+    switch (mode) {
+        case ClientResyncMode::Manual:
+            os << "Manual";
+            break;
+        case ClientResyncMode::DiscardLocal:
+            os << "DiscardLocal";
+            break;
+        case ClientResyncMode::Recover:
+            os << "Recover";
+            break;
+        case ClientResyncMode::RecoverOrDiscard:
+            os << "RecoveOrDiscard";
+            break;
+    }
+    return os;
+}
+
+} // namespace realm
+
 
 namespace realm::_impl::client_reset::converters {
 
@@ -456,7 +482,9 @@ void InterRealmObjectConverter::populate_columns_from_table(ConstTableRef table_
 } // namespace realm::_impl::client_reset::converters
 
 
-void client_reset::transfer_group(const Transaction& group_src, Transaction& group_dst, util::Logger& logger)
+namespace realm::_impl::client_reset {
+
+void transfer_group(const Transaction& group_src, Transaction& group_dst, util::Logger& logger)
 {
     logger.debug("transfer_group, src size = %1, dst size = %2", group_src.size(), group_dst.size());
 
@@ -757,17 +785,142 @@ void client_reset::transfer_group(const Transaction& group_src, Transaction& gro
     }
 }
 
-client_reset::LocalVersionIDs client_reset::perform_client_reset_diff(DB& db_local, DBRef db_remote,
-                                                                      sync::SaltedFileIdent client_file_ident,
-                                                                      util::Logger& logger,
-                                                                      bool recover_local_changes)
+// A table without a "class_" prefix will not generate sync instructions.
+constexpr static std::string_view s_meta_reset_table_name("client_reset_metadata");
+constexpr static std::string_view s_pk_col_name("id");
+constexpr static std::string_view s_version_column_name("version");
+constexpr static std::string_view s_timestamp_col_name("event_time");
+constexpr static std::string_view s_reset_type_col_name("type_of_reset");
+constexpr int64_t metadata_version = 1;
+
+void remove_pending_client_resets(TransactionRef wt)
+{
+    REALM_ASSERT(wt);
+    if (auto table = wt->get_table(s_meta_reset_table_name)) {
+        if (table->size()) {
+            table->clear();
+        }
+    }
+}
+
+util::Optional<PendingReset> has_pending_reset(Transaction& rt)
+{
+    ConstTableRef table = rt.get_table(s_meta_reset_table_name);
+    if (!table || table->size() == 0) {
+        return util::none;
+    }
+    ColKey timestamp_col = table->get_column_key(s_timestamp_col_name);
+    ColKey type_col = table->get_column_key(s_reset_type_col_name);
+    ColKey version_col = table->get_column_key(s_version_column_name);
+    REALM_ASSERT(timestamp_col);
+    REALM_ASSERT(type_col);
+    REALM_ASSERT(version_col);
+    if (table->size() > 1) {
+        // this may happen if a future version of this code changes the format and expectations around reset metadata.
+        throw ClientResetFailed(
+            util::format("Previous client resets detected (%1) but only one is expected.", table->size()));
+    }
+    Obj first = *table->begin();
+    REALM_ASSERT(first);
+    PendingReset pending;
+    int64_t version = first.get<int64_t>(version_col);
+    pending.time = first.get<Timestamp>(timestamp_col);
+    if (version > metadata_version) {
+        throw ClientResetFailed(util::format("Unsupported client reset metadata version: %1 vs %2, from %3", version,
+                                             metadata_version, pending.time));
+    }
+    int64_t type = first.get<int64_t>(type_col);
+    if (type == 0) {
+        pending.type = ClientResyncMode::DiscardLocal;
+    }
+    else if (type == 1) {
+        pending.type = ClientResyncMode::Recover;
+    }
+    else {
+        throw ClientResetFailed(
+            util::format("Unsupported client reset metadata type: %1 from %2", type, pending.time));
+    }
+    return pending;
+}
+
+void track_reset(Transaction& wt, ClientResyncMode mode)
+{
+    REALM_ASSERT(mode != ClientResyncMode::Manual);
+    TableRef table = wt.get_table(s_meta_reset_table_name);
+    ColKey version_col, timestamp_col, type_col;
+    if (!table) {
+        table = wt.add_table_with_primary_key(s_meta_reset_table_name, type_ObjectId, s_pk_col_name);
+        REALM_ASSERT(table);
+        version_col = table->add_column(type_Int, s_version_column_name);
+        timestamp_col = table->add_column(type_Timestamp, s_timestamp_col_name);
+        type_col = table->add_column(type_Int, s_reset_type_col_name);
+    }
+    else {
+        version_col = table->get_column_key(s_version_column_name);
+        timestamp_col = table->get_column_key(s_timestamp_col_name);
+        type_col = table->get_column_key(s_reset_type_col_name);
+    }
+    REALM_ASSERT(version_col);
+    REALM_ASSERT(timestamp_col);
+    REALM_ASSERT(type_col);
+    int64_t mode_val = 0; // Discard
+    if (mode == ClientResyncMode::Recover || mode == ClientResyncMode::RecoverOrDiscard) {
+        mode_val = 1; // Recover
+    }
+    table->create_object_with_primary_key(ObjectId::gen(),
+                                          {{version_col, metadata_version},
+                                           {timestamp_col, Timestamp(std::chrono::system_clock::now())},
+                                           {type_col, mode_val}});
+}
+
+ClientResyncMode reset_precheck_guard(Transaction& wt, ClientResyncMode mode, util::Logger& logger)
+{
+    if (auto previous_reset = has_pending_reset(wt)) {
+        logger.info("A previous reset was detected of type: '%1' at: %2", previous_reset->type, previous_reset->time);
+        switch (previous_reset->type) {
+            case ClientResyncMode::Manual:
+                REALM_UNREACHABLE();
+                break;
+            case ClientResyncMode::DiscardLocal:
+                throw ClientResetFailed(util::format("A previous '%1' mode reset from %2 did not succeed, "
+                                                     "giving up on '%3' mode to prevent a cycle",
+                                                     previous_reset->type, previous_reset->time, mode));
+            case ClientResyncMode::Recover:
+                if (mode == ClientResyncMode::Recover) {
+                    throw ClientResetFailed(util::format("A previous '%1' mode reset from %2 did not succeed, "
+                                                         "giving up on '%3' mode to prevent a cycle",
+                                                         previous_reset->type, previous_reset->time, mode));
+                }
+                else if (mode == ClientResyncMode::RecoverOrDiscard) {
+                    mode = ClientResyncMode::DiscardLocal;
+                    logger.info("A previous '%1' mode reset from %2 downgrades this mode ('%3') to DiscardLocal",
+                                previous_reset->type, previous_reset->time, mode);
+                }
+                else if (mode == ClientResyncMode::DiscardLocal) {
+                    // previous mode Recover and this mode is Discard, this is not a cycle yet
+                }
+                else {
+                    REALM_UNREACHABLE();
+                }
+                break;
+            case ClientResyncMode::RecoverOrDiscard:
+                throw ClientResetFailed(util::format("Unexpected previous '%1' mode reset from %2 did not "
+                                                     "succeed, giving up on '%3' mode to prevent a cycle",
+                                                     previous_reset->type, previous_reset->time, mode));
+        }
+    }
+    track_reset(wt, mode);
+    return mode;
+}
+
+LocalVersionIDs perform_client_reset_diff(DB& db_local, DB& db_remote, sync::SaltedFileIdent client_file_ident,
+                                          util::Logger& logger, ClientResyncMode mode, bool* did_recover_out)
 {
     logger.info("Client reset, path_local = %1, "
                 "client_file_ident.ident = %2, "
                 "client_file_ident.salt = %3,"
                 "remote = %4, mode = %5",
-                db_local.get_path(), client_file_ident.ident, client_file_ident.salt,
-                (db_remote ? db_remote->get_path() : "<none>"), recover_local_changes ? "recover" : "discardLocal");
+                db_local.get_path(), client_file_ident.ident, client_file_ident.salt, db_remote.get_path(), mode);
 
     auto wt_local = db_local.start_write();
     auto history_local = dynamic_cast<ClientHistory*>(wt_local->get_replication()->_get_history_write());
@@ -778,6 +931,9 @@ client_reset::LocalVersionIDs client_reset::perform_client_reset_diff(DB& db_loc
     BinaryData recovered_changeset;
     std::vector<ChunkedBinaryData> local_changes;
 
+    mode = reset_precheck_guard(*wt_local, mode, logger);
+    bool recover_local_changes = (mode == ClientResyncMode::Recover || mode == ClientResyncMode::RecoverOrDiscard);
+
     if (recover_local_changes) {
         local_changes = history_local->get_local_changes(current_version_local);
         logger.info("Local changesets to recover: %1", local_changes.size());
@@ -785,38 +941,39 @@ client_reset::LocalVersionIDs client_reset::perform_client_reset_diff(DB& db_loc
 
     sync::SaltedVersion fresh_server_version = {0, 0};
 
-    if (db_remote) {
-        auto wt_remote = db_remote->start_write();
-        auto history_remote = dynamic_cast<ClientHistory*>(wt_remote->get_replication()->_get_history_write());
-        REALM_ASSERT(history_remote);
-        sync::version_type current_version_remote = wt_remote->get_version();
-        history_local->set_client_file_ident_in_wt(current_version_local, client_file_ident);
-        history_remote->set_client_file_ident_in_wt(current_version_remote, client_file_ident);
+    auto wt_remote = db_remote.start_write();
+    auto history_remote = dynamic_cast<ClientHistory*>(wt_remote->get_replication()->_get_history_write());
+    REALM_ASSERT(history_remote);
+    sync::version_type current_version_remote = wt_remote->get_version();
+    history_local->set_client_file_ident_in_wt(current_version_local, client_file_ident);
+    history_remote->set_client_file_ident_in_wt(current_version_remote, client_file_ident);
 
-        sync::version_type remote_version;
-        SaltedFileIdent remote_ident;
-        SyncProgress remote_progress;
-        history_remote->get_status(remote_version, remote_ident, remote_progress);
-        fresh_server_version = remote_progress.latest_server_version;
+    sync::version_type remote_version;
+    SaltedFileIdent remote_ident;
+    SyncProgress remote_progress;
+    history_remote->get_status(remote_version, remote_ident, remote_progress);
+    fresh_server_version = remote_progress.latest_server_version;
 
-        if (recover_local_changes) {
-            RecoverLocalChangesetsHandler handler{*wt_remote, *wt_local, logger};
-            handler.process_changesets(local_changes); // throws on error
-            ClientReplication* client_repl = dynamic_cast<ClientReplication*>(wt_remote->get_replication());
-            REALM_ASSERT_RELEASE(client_repl);
-            ChangesetEncoder& encoder = client_repl->get_instruction_encoder();
-            const sync::ChangesetEncoder::Buffer& buffer = encoder.buffer();
-            recovered_changeset = {buffer.data(), buffer.size()};
-        }
-
-        transfer_group(*wt_remote, *wt_local, logger);
+    if (recover_local_changes) {
+        RecoverLocalChangesetsHandler handler{*wt_remote, *wt_local, logger};
+        handler.process_changesets(local_changes); // throws on error
+        ClientReplication* client_repl = dynamic_cast<ClientReplication*>(wt_remote->get_replication());
+        REALM_ASSERT_RELEASE(client_repl);
+        ChangesetEncoder& encoder = client_repl->get_instruction_encoder();
+        const sync::ChangesetEncoder::Buffer& buffer = encoder.buffer();
+        recovered_changeset = {buffer.data(), buffer.size()};
     }
+
+    transfer_group(*wt_remote, *wt_local, logger);
 
     history_local->set_client_reset_adjustments(current_version_local, client_file_ident, fresh_server_version,
                                                 recovered_changeset);
 
     // Finally, the local Realm is committed. The changes to the remote Realm are discarded.
     wt_local->commit_and_continue_as_read();
+    if (did_recover_out) {
+        *did_recover_out = recover_local_changes;
+    }
     VersionID new_version_local = wt_local->get_version_of_current_transaction();
     logger.info("perform_client_reset_diff is done, old_version.version = %1, "
                 "old_version.index = %2, new_version.version = %3, "
@@ -826,3 +983,5 @@ client_reset::LocalVersionIDs client_reset::perform_client_reset_diff(DB& db_loc
 
     return LocalVersionIDs{old_version_local, new_version_local};
 }
+
+} // namespace realm::_impl::client_reset

--- a/src/realm/sync/noinst/client_reset.hpp
+++ b/src/realm/sync/noinst/client_reset.hpp
@@ -73,8 +73,8 @@ struct PendingReset {
     Timestamp time;
 };
 void remove_pending_client_resets(TransactionRef wt);
-util::Optional<PendingReset> has_pending_reset(Transaction& wt);
-void track_reset(Transaction& wt, ClientResyncMode mode);
+util::Optional<PendingReset> has_pending_reset(TransactionRef wt);
+void track_reset(TransactionRef wt, ClientResyncMode mode);
 
 // preform_client_reset_diff() takes the Realm performs a client reset on
 // the Realm in 'path_local' given the Realm 'path_fresh' as the source of truth.
@@ -90,7 +90,7 @@ struct LocalVersionIDs {
     realm::VersionID old_version;
     realm::VersionID new_version;
 };
-LocalVersionIDs perform_client_reset_diff(DB& db, DB& db_remote, sync::SaltedFileIdent client_file_ident,
+LocalVersionIDs perform_client_reset_diff(DBRef db, DBRef db_remote, sync::SaltedFileIdent client_file_ident,
                                           util::Logger& logger, ClientResyncMode mode, bool* did_recover_out);
 
 namespace converters {

--- a/src/realm/sync/noinst/client_reset_operation.cpp
+++ b/src/realm/sync/noinst/client_reset_operation.cpp
@@ -25,7 +25,7 @@
 
 namespace realm::_impl {
 
-ClientResetOperation::ClientResetOperation(util::Logger& logger, DB& db, DBRef db_fresh, ClientResyncMode mode,
+ClientResetOperation::ClientResetOperation(util::Logger& logger, DBRef db, DBRef db_fresh, ClientResyncMode mode,
                                            CallbackBeforeType notify_before, CallbackAfterType notify_after)
     : m_logger{logger}
     , m_db{db}
@@ -34,8 +34,9 @@ ClientResetOperation::ClientResetOperation(util::Logger& logger, DB& db, DBRef d
     , m_notify_before(std::move(notify_before))
     , m_notify_after(std::move(notify_after))
 {
+    REALM_ASSERT(m_db);
     REALM_ASSERT_RELEASE(m_mode != ClientResyncMode::Manual);
-    logger.debug("Create ClientResetOperation, realm_path = %1, mode = %2", m_db.get_path(), m_mode);
+    logger.debug("Create ClientResetOperation, realm_path = %1, mode = %2", m_db->get_path(), m_mode);
 }
 
 std::string ClientResetOperation::get_fresh_path_for(const std::string& path)
@@ -54,18 +55,18 @@ bool ClientResetOperation::finalize(sync::SaltedFileIdent salted_file_ident)
     // only do the reset if there is data to reset
     // if there is nothing in this Realm, then there is nothing to reset and
     // sync should be able to continue as normal
-    bool local_realm_exists = m_db.get_version_of_latest_snapshot() != 0;
+    bool local_realm_exists = m_db->get_version_of_latest_snapshot() != 0;
     if (local_realm_exists) {
-        REALM_ASSERT_EX(m_db_fresh, m_db.get_path(), m_mode);
+        REALM_ASSERT_EX(m_db_fresh, m_db->get_path(), m_mode);
         m_logger.debug("ClientResetOperation::finalize, realm_path = %1, local_realm_exists = %2, mode = %3",
-                       m_db.get_path(), local_realm_exists, m_mode);
+                       m_db->get_path(), local_realm_exists, m_mode);
 
         client_reset::LocalVersionIDs local_version_ids;
         auto always_try_clean_up = util::make_scope_exit([&]() noexcept {
             clean_up_state();
         });
 
-        std::string local_path = m_db.get_path();
+        std::string local_path = m_db->get_path();
         if (m_notify_before) {
             m_notify_before(local_path);
         }
@@ -73,10 +74,10 @@ bool ClientResetOperation::finalize(sync::SaltedFileIdent salted_file_ident)
         // If m_notify_after is set, pin the previous state to keep it around.
         TransactionRef previous_state;
         if (m_notify_after) {
-            previous_state = m_db.start_frozen();
+            previous_state = m_db->start_frozen();
         }
         bool did_recover_out = false;
-        local_version_ids = client_reset::perform_client_reset_diff(m_db, *m_db_fresh, m_salted_file_ident, m_logger,
+        local_version_ids = client_reset::perform_client_reset_diff(m_db, m_db_fresh, m_salted_file_ident, m_logger,
                                                                     m_mode, &did_recover_out); // throws
 
         if (m_notify_after) {

--- a/src/realm/sync/noinst/client_reset_operation.hpp
+++ b/src/realm/sync/noinst/client_reset_operation.hpp
@@ -31,9 +31,9 @@ namespace realm::_impl {
 class ClientResetOperation {
 public:
     using CallbackBeforeType = util::UniqueFunction<void(std::string)>;
-    using CallbackAfterType = util::UniqueFunction<void(std::string, VersionID)>;
+    using CallbackAfterType = util::UniqueFunction<void(std::string, VersionID, bool)>;
 
-    ClientResetOperation(util::Logger& logger, DB& db, DBRef db_fresh, bool discard_local,
+    ClientResetOperation(util::Logger& logger, DB& db, DBRef db_fresh, ClientResyncMode mode,
                          CallbackBeforeType notify_before, CallbackAfterType notify_after);
 
     // When the client has received the salted file ident from the server, it
@@ -52,7 +52,7 @@ private:
     util::Logger& m_logger;
     DB& m_db;
     DBRef m_db_fresh;
-    bool m_discard_local;
+    ClientResyncMode m_mode;
     sync::SaltedFileIdent m_salted_file_ident = {0, 0};
     realm::VersionID m_client_reset_old_version;
     realm::VersionID m_client_reset_new_version;

--- a/src/realm/sync/noinst/client_reset_operation.hpp
+++ b/src/realm/sync/noinst/client_reset_operation.hpp
@@ -33,7 +33,7 @@ public:
     using CallbackBeforeType = util::UniqueFunction<void(std::string)>;
     using CallbackAfterType = util::UniqueFunction<void(std::string, VersionID, bool)>;
 
-    ClientResetOperation(util::Logger& logger, DB& db, DBRef db_fresh, ClientResyncMode mode,
+    ClientResetOperation(util::Logger& logger, DBRef db, DBRef db_fresh, ClientResyncMode mode,
                          CallbackBeforeType notify_before, CallbackAfterType notify_after);
 
     // When the client has received the salted file ident from the server, it
@@ -50,7 +50,7 @@ private:
     void clean_up_state() noexcept;
 
     util::Logger& m_logger;
-    DB& m_db;
+    DBRef m_db;
     DBRef m_db_fresh;
     ClientResyncMode m_mode;
     sync::SaltedFileIdent m_salted_file_ident = {0, 0};

--- a/test/object-store/sync/client_reset.cpp
+++ b/test/object-store/sync/client_reset.cpp
@@ -1360,7 +1360,7 @@ TEST_CASE("sync: client reset", "[client reset]") {
         auto has_reset_cycle_flag = [](SharedRealm realm) -> util::Optional<_impl::client_reset::PendingReset> {
             auto db = TestHelper::get_db(realm);
             auto rt = db->start_read();
-            return _impl::client_reset::has_pending_reset(*rt);
+            return _impl::client_reset::has_pending_reset(rt);
         };
         ThreadSafeSyncError err;
         local_config.sync_config->error_handler = [&](std::shared_ptr<SyncSession>, SyncError error) {
@@ -1370,7 +1370,7 @@ TEST_CASE("sync: client reset", "[client reset]") {
             local_config.sync_config->notify_before_client_reset = [previous_type = type](SharedRealm realm) {
                 auto db = TestHelper::get_db(realm);
                 auto wt = db->start_write();
-                _impl::client_reset::track_reset(*wt, previous_type);
+                _impl::client_reset::track_reset(wt, previous_type);
                 wt->commit();
             };
         };

--- a/test/object-store/sync/client_reset.cpp
+++ b/test/object-store/sync/client_reset.cpp
@@ -27,6 +27,7 @@
 #include "util/test_utils.hpp"
 
 #include <realm/sync/noinst/client_reset_operation.hpp>
+#include <realm/sync/noinst/client_history_impl.hpp>
 
 #include <realm/object-store/impl/object_accessor_impl.hpp>
 #include <realm/object-store/property.hpp>
@@ -83,6 +84,16 @@ struct StringMaker<ThreadSafeSyncError> {
 } // namespace Catch
 
 using namespace realm;
+
+namespace realm {
+class TestHelper {
+public:
+    static DBRef& get_db(SharedRealm const& shared_realm)
+    {
+        return Realm::Internal::get_db(*shared_realm);
+    }
+};
+} // namespace realm
 
 namespace {
 TableRef get_table(Realm& realm, StringData object_type)
@@ -235,7 +246,7 @@ TEST_CASE("sync: client reset", "[client reset]") {
         REQUIRE(before->config().path == local_config.path);
         REQUIRE(util::File::exists(local_config.path));
     };
-    local_config.sync_config->notify_after_client_reset = [&](SharedRealm before, SharedRealm after) {
+    local_config.sync_config->notify_after_client_reset = [&](SharedRealm before, SharedRealm after, bool) {
         std::lock_guard<std::mutex> lock(mtx);
         ++after_callback_invocations;
         REQUIRE(before);
@@ -584,7 +595,7 @@ TEST_CASE("sync: client reset", "[client reset]") {
             REQUIRE(before_callback_invoctions == 1);
             REQUIRE(after_callback_invocations == 0);
         }
-    }
+    } // end recovery section
 
     SECTION("discard local") {
         local_config.sync_config->client_resync_mode = ClientResyncMode::DiscardLocal;
@@ -692,7 +703,7 @@ TEST_CASE("sync: client reset", "[client reset]") {
                     std::lock_guard<std::mutex> lock(mtx);
                     ++before_callback_invoctions_2;
                 };
-                config_copy->notify_after_client_reset = [&](SharedRealm, SharedRealm) {
+                config_copy->notify_after_client_reset = [&](SharedRealm, SharedRealm, bool) {
                     std::lock_guard<std::mutex> lock(mtx);
                     ++after_callback_invocations_2;
                 };
@@ -706,7 +717,7 @@ TEST_CASE("sync: client reset", "[client reset]") {
                 };
 
                 auto realm = Realm::get_shared_realm(temp_config);
-                wait_for_download(*realm);
+                wait_for_upload(*realm);
 
                 session = test_app_session.app()->sync_manager()->get_existing_session(temp_config.path);
                 REQUIRE(session);
@@ -1343,7 +1354,152 @@ TEST_CASE("sync: client reset", "[client reset]") {
                 })
                 ->run();
         }
-    }
+    } // end discard local section
+
+    SECTION("cycle detection") {
+        auto has_reset_cycle_flag = [](SharedRealm realm) -> util::Optional<_impl::client_reset::PendingReset> {
+            auto db = TestHelper::get_db(realm);
+            auto rt = db->start_read();
+            return _impl::client_reset::has_pending_reset(*rt);
+        };
+        ThreadSafeSyncError err;
+        local_config.sync_config->error_handler = [&](std::shared_ptr<SyncSession>, SyncError error) {
+            err = error;
+        };
+        auto make_fake_previous_reset = [&local_config](ClientResyncMode type) {
+            local_config.sync_config->notify_before_client_reset = [previous_type = type](SharedRealm realm) {
+                auto db = TestHelper::get_db(realm);
+                auto wt = db->start_write();
+                _impl::client_reset::track_reset(*wt, previous_type);
+                wt->commit();
+            };
+        };
+        SECTION("a normal reset adds and removes a cycle detection flag") {
+            local_config.sync_config->client_resync_mode = ClientResyncMode::RecoverOrDiscard;
+            local_config.sync_config->notify_before_client_reset = [&](SharedRealm realm) {
+                auto flag = has_reset_cycle_flag(realm);
+                REQUIRE(!flag);
+                std::lock_guard<std::mutex> lock(mtx);
+                ++before_callback_invoctions;
+            };
+            local_config.sync_config->notify_after_client_reset = [&](SharedRealm, SharedRealm realm,
+                                                                      bool did_recover) {
+                auto flag = has_reset_cycle_flag(realm);
+                REQUIRE(bool(flag));
+                REQUIRE(flag->type == ClientResyncMode::Recover);
+                REQUIRE(did_recover);
+                std::lock_guard<std::mutex> lock(mtx);
+                ++after_callback_invocations;
+            };
+            make_reset(local_config, remote_config)
+                ->on_post_local_changes([&](SharedRealm realm) {
+                    auto flag = has_reset_cycle_flag(realm);
+                    REQUIRE(!flag);
+                })
+                ->run();
+            REQUIRE(!err);
+            REQUIRE(before_callback_invoctions == 1);
+            REQUIRE(after_callback_invocations == 1);
+        }
+        SECTION("In DiscardLocal mode: a previous failed discard reset is detected and generates an error") {
+            local_config.sync_config->client_resync_mode = ClientResyncMode::DiscardLocal;
+            make_fake_previous_reset(ClientResyncMode::DiscardLocal);
+            make_reset(local_config, remote_config)->run();
+            timed_sleeping_wait_for([&]() -> bool {
+                return !!err;
+            });
+            REQUIRE(err.value()->is_client_reset_requested());
+        }
+        SECTION("In Recover mode: a previous failed recover reset is detected and generates an error") {
+            local_config.sync_config->client_resync_mode = ClientResyncMode::Recover;
+            make_fake_previous_reset(ClientResyncMode::Recover);
+            make_reset(local_config, remote_config)->run();
+            timed_sleeping_wait_for([&]() -> bool {
+                return !!err;
+            });
+            REQUIRE(err.value()->is_client_reset_requested());
+        }
+        SECTION("In Recover mode: a previous failed discard reset is detected and generates an error") {
+            local_config.sync_config->client_resync_mode = ClientResyncMode::Recover;
+            make_fake_previous_reset(ClientResyncMode::DiscardLocal);
+            make_reset(local_config, remote_config)->run();
+            timed_sleeping_wait_for([&]() -> bool {
+                return !!err;
+            });
+            REQUIRE(err.value()->is_client_reset_requested());
+        }
+        SECTION("In RecoverOrDiscard mode: a previous failed discard reset is detected and generates an error") {
+            local_config.sync_config->client_resync_mode = ClientResyncMode::RecoverOrDiscard;
+            make_fake_previous_reset(ClientResyncMode::DiscardLocal);
+            make_reset(local_config, remote_config)->run();
+            timed_sleeping_wait_for([&]() -> bool {
+                return !!err;
+            });
+            REQUIRE(err.value()->is_client_reset_requested());
+        }
+        const int64_t added_pk = 12345;
+        auto has_added_object = [&](SharedRealm realm) -> bool {
+            REQUIRE_NOTHROW(realm->refresh());
+            auto table = get_table(*realm, "object");
+            REQUIRE(table);
+            ObjKey key = table->find_primary_key(added_pk);
+            return !!key;
+        };
+        SECTION(
+            "In RecoverOrDiscard mode: a previous failed recovery is detected and triggers a DiscardLocal reset") {
+            local_config.sync_config->client_resync_mode = ClientResyncMode::RecoverOrDiscard;
+            make_fake_previous_reset(ClientResyncMode::Recover);
+            local_config.sync_config->notify_after_client_reset = [&](SharedRealm before, SharedRealm after,
+                                                                      bool did_recover) {
+                REQUIRE(!did_recover);
+                REQUIRE(has_added_object(before));
+                REQUIRE(!has_added_object(after)); // discarded insert due to fallback to DiscardLocal mode
+                std::lock_guard<std::mutex> lock(mtx);
+                ++after_callback_invocations;
+            };
+            make_reset(local_config, remote_config)
+                ->make_local_changes([&](SharedRealm realm) {
+                    auto table = get_table(*realm, "object");
+                    REQUIRE(table);
+                    create_object(*realm, "object", partition, {added_pk});
+                })
+                ->run();
+            timed_sleeping_wait_for(
+                [&]() -> bool {
+                    std::lock_guard<std::mutex> lock(mtx);
+                    return after_callback_invocations > 0 || err;
+                },
+                std::chrono::seconds(120));
+            REQUIRE(!err);
+        }
+        SECTION("In DiscardLocal mode: a previous failed recovery does not cause an error") {
+            local_config.sync_config->client_resync_mode = ClientResyncMode::DiscardLocal;
+            make_fake_previous_reset(ClientResyncMode::Recover);
+            local_config.sync_config->notify_after_client_reset = [&](SharedRealm before, SharedRealm after,
+                                                                      bool did_recover) {
+                REQUIRE(!did_recover);
+                REQUIRE(has_added_object(before));
+                REQUIRE(!has_added_object(after)); // not recovered
+                std::lock_guard<std::mutex> lock(mtx);
+                ++after_callback_invocations;
+            };
+            make_reset(local_config, remote_config)
+                ->make_local_changes([&](SharedRealm realm) {
+                    auto table = get_table(*realm, "object");
+                    REQUIRE(table);
+                    create_object(*realm, "object", partition, {added_pk});
+                })
+                ->run();
+            timed_sleeping_wait_for(
+                [&]() -> bool {
+                    std::lock_guard<std::mutex> lock(mtx);
+                    return after_callback_invocations > 0 || err;
+                },
+                std::chrono::seconds(120));
+            REQUIRE(!err);
+        }
+
+    } // end cycle detection
 }
 
 #endif // REALM_ENABLE_AUTH_TESTS

--- a/test/object-store/sync/sync_test_utils.cpp
+++ b/test/object-store/sync/sync_test_utils.cpp
@@ -312,7 +312,7 @@ struct FakeLocalClientReset : public TestClientReset {
             auto local_db = TestHelper::get_db(local_realm);
             auto remote_db = TestHelper::get_db(remote_realm);
             using _impl::client_reset::perform_client_reset_diff;
-            perform_client_reset_diff(*local_db, *remote_db, fake_ident, logger, m_mode, nullptr);
+            perform_client_reset_diff(local_db, remote_db, fake_ident, logger, m_mode, nullptr);
 
             remote_realm->close();
             if (m_on_post_reset) {

--- a/test/object-store/sync/sync_test_utils.cpp
+++ b/test/object-store/sync/sync_test_utils.cpp
@@ -309,11 +309,10 @@ struct FakeLocalClientReset : public TestClientReset {
 
             TestLogger logger;
             sync::SaltedFileIdent fake_ident{1, 123456789};
-            const bool recover = m_mode == ClientResyncMode::Recover;
             auto local_db = TestHelper::get_db(local_realm);
             auto remote_db = TestHelper::get_db(remote_realm);
             using _impl::client_reset::perform_client_reset_diff;
-            perform_client_reset_diff(*local_db, remote_db, fake_ident, logger, recover);
+            perform_client_reset_diff(*local_db, *remote_db, fake_ident, logger, m_mode, nullptr);
 
             remote_realm->close();
             if (m_on_post_reset) {

--- a/test/test_client_reset.cpp
+++ b/test/test_client_reset.cpp
@@ -149,7 +149,7 @@ TEST(ClientReset_NoLocalChanges)
             Session::Config session_config;
             {
                 Session::Config::ClientReset client_reset_config;
-                client_reset_config.discard_local = true;
+                client_reset_config.mode = ClientResyncMode::DiscardLocal;
                 client_reset_config.fresh_copy = std::move(sg_fresh);
                 session_config.client_reset_config = std::move(client_reset_config);
             }
@@ -222,7 +222,7 @@ TEST(ClientReset_InitialLocalChanges)
     Session::Config session_config_2;
     {
         Session::Config::ClientReset client_reset_config;
-        client_reset_config.discard_local = true;
+        client_reset_config.mode = ClientResyncMode::DiscardLocal;
         client_reset_config.fresh_copy = std::move(sg_fresh);
         session_config_2.client_reset_config = std::move(client_reset_config);
     }
@@ -349,7 +349,7 @@ TEST_TYPES(ClientReset_LocalChangesWhenOffline, std::true_type, std::false_type)
 
     Session::Config session_config_3;
     session_config_3.client_reset_config = Session::Config::ClientReset{};
-    session_config_3.client_reset_config->discard_local = !recover;
+    session_config_3.client_reset_config->mode = recover ? ClientResyncMode::Recover : ClientResyncMode::DiscardLocal;
     session_config_3.client_reset_config->fresh_copy = std::move(sg_fresh1);
     Session session_3 = fixture.make_session(sg, std::move(session_config_3));
     fixture.bind_session(session_3, server_path);
@@ -593,14 +593,14 @@ TEST(ClientReset_ThreeClients)
             Session::Config session_config_1;
             {
                 Session::Config::ClientReset client_reset_config;
-                client_reset_config.discard_local = true;
+                client_reset_config.mode = ClientResyncMode::DiscardLocal;
                 client_reset_config.fresh_copy = std::move(sg_fresh1);
                 session_config_1.client_reset_config = std::move(client_reset_config);
             }
             Session::Config session_config_2;
             {
                 Session::Config::ClientReset client_reset_config;
-                client_reset_config.discard_local = true;
+                client_reset_config.mode = ClientResyncMode::DiscardLocal;
                 client_reset_config.fresh_copy = std::move(sg_fresh2);
                 session_config_2.client_reset_config = std::move(client_reset_config);
             }
@@ -719,7 +719,7 @@ TEST(ClientReset_DoNotRecoverSchema)
         Session::Config session_config;
         {
             Session::Config::ClientReset client_reset_config;
-            client_reset_config.discard_local = true;
+            client_reset_config.mode = ClientResyncMode::DiscardLocal;
             client_reset_config.fresh_copy = std::move(sg_fresh1);
             session_config.client_reset_config = std::move(client_reset_config);
         }
@@ -805,7 +805,7 @@ TEST(ClientReset_PinnedVersion)
         Session::Config session_config;
         {
             session_config.client_reset_config = Session::Config::ClientReset{};
-            session_config.client_reset_config->discard_local = true;
+            session_config.client_reset_config->mode = ClientResyncMode::DiscardLocal;
             session_config.client_reset_config->fresh_copy = std::move(sg_fresh);
         }
 

--- a/test/util/compare_groups.cpp
+++ b/test/util/compare_groups.cpp
@@ -1061,7 +1061,7 @@ bool compare_groups(const Transaction& group_1, const Transaction& group_2,
         for (auto i : table_keys) {
             ConstTableRef table = group.get_table(i);
             StringData name = table->get_name();
-            if (name != "pk" && name != "metadata" && filter_func(name))
+            if (name != "pk" && name != "metadata" && name != "client_reset_metadata" && filter_func(name))
                 tables.push_back(name);
         }
     };


### PR DESCRIPTION
Fixes https://github.com/realm/realm-core/issues/5289
Introduces a third mode `RecoverOrDiscard` which gives better control of the automatic reset behaviour. This is to allow clients to opt in to Recovery mode _only_ without attempting to discard data if it comes to that. It is expected that `RecoverOrDiscard` will be the default in the future. This also introduces a boolean to the notify_after callback so that users can know which type of automatic reset actually happened.

The cycle detection operates by writing to an internal non-sync'd table which is created as needed. An entry is created there  when starting a reset, and it is erased on the next successful sync upload to the server. If a reset is started while a previous reset has been detected either an error is generated or a different mode is started:


| detected  | current  | result  |
|---|---|---|
| discard  |  discard |  error |
| recover  |  discard | discard  |
| none  | discard  | discard |
| discard  | recover  | error  |
| recover  | recover  | error  |
| none  | recover | recover |
| discard  | recoverOrDiscard  | error  |
| recover  | recoverOrDiscard  | discard |
| none  | recoverOrDiscard  | recover |
