### PR TITLE
Disable support for async writes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,6 @@
 ### Fixed
 * <How do the end-user experience this issue? what was the impact?> ([#????](https://github.com/realm/realm-core/issues/????), since v?.?.?)
 * Added auth code and id token support for google c_api ([#5347]https://github.com/realm/realm-core/issues/5347)
-* Fixed various corruption bugs when encryption is used. Issues were caused by a missing "flush" of pending changes. Since v11.8.0. Fixes meta-issue https://github.com/realm/realm-core/issues/5360: (https://github.com/realm/realm-core/issues/5332, https://github.com/realm/realm-swift/issues/7659, https://github.com/realm/realm-core/issues/5230, https://github.com/realm/realm-core/issues/5190, https://github.com/realm/realm-swift/issues/7640, https://github.com/realm/realm-js/issues/4428, https://github.com/realm/realm-java/issues/7652, https://github.com/realm/realm-js/issues/4358)
 * Added AppCredentials::serialize_as_json() support for c_api ([#5348]https://github.com/realm/realm-core/issues/5348)
 * Changeset upload batching did not calculate the accumulated size correctly, resulting in "error reading body failed to read: read limited at 16777217 bytes" errors from the server when writing large amounts of data (since 11.13.0).
 
@@ -20,7 +19,7 @@
 -----------
 
 ### Internals
-* None.
+* Ability to make async writes is disabled
 
 ----------------------------------------------
 

--- a/src/realm/object-store/impl/realm_coordinator.cpp
+++ b/src/realm/object-store/impl/realm_coordinator.cpp
@@ -502,7 +502,8 @@ void RealmCoordinator::open_db()
         }
 
         DBOptions options;
-        options.enable_async_writes = true;
+        // FIXME: async writes seems not to work with encryption enabled
+        // options.enable_async_writes = true;
         options.durability = m_config.in_memory ? DBOptions::Durability::MemOnly : DBOptions::Durability::Full;
         options.is_immutable = m_config.immutable();
 

--- a/src/realm/object-store/shared_realm.hpp
+++ b/src/realm/object-store/shared_realm.hpp
@@ -255,7 +255,8 @@ public:
     //   executed in order.
     // * A later call to async_begin_transaction() will wait for any earlier write blocks.
     using AsyncHandle = unsigned;
-    AsyncHandle async_begin_transaction(util::UniqueFunction<void()>&& the_block, bool notify_only = false);
+    [[deprecated("Not enabled")]] AsyncHandle async_begin_transaction(util::UniqueFunction<void()>&& the_block,
+                                                                      bool notify_only = false);
 
     // Asynchronous commit.
     // * 'the_done_block' is queued for execution on the scheduler associated with

--- a/test/object-store/realm.cpp
+++ b/test/object-store/realm.cpp
@@ -52,6 +52,8 @@
 
 #include <array>
 
+#define ASYNC_WRITES_ENABLED 0
+
 namespace realm {
 class TestHelper {
 public:
@@ -66,10 +68,12 @@ public:
     }
 };
 
+#if ASYNC_WRITES_ENABLED
 static bool operator==(IndexSet const& a, IndexSet const& b)
 {
     return std::equal(a.as_indexes().begin(), a.as_indexes().end(), b.as_indexes().begin(), b.as_indexes().end());
 }
+#endif
 } // namespace realm
 
 using namespace realm;
@@ -935,6 +939,7 @@ TEST_CASE("Get Realm using Async Open", "[asyncOpen]") {
 }
 #endif
 
+#if ASYNC_WRITES_ENABLED
 #ifndef _WIN32
 TEST_CASE("SharedRealm: async writes") {
     _impl::RealmCoordinator::assert_no_open_realms();
@@ -1751,6 +1756,7 @@ TEST_CASE("SharedRealm: async writes") {
     });
 }
 #endif
+
 // Our libuv scheduler currently does not support background threads, so we can
 // only run this on apple platforms
 #if REALM_PLATFORM_APPLE
@@ -2003,6 +2009,7 @@ TEST_CASE("SharedRealm: async_writes_2") {
     REQUIRE(done);
 }
 #endif
+#endif
 
 TEST_CASE("SharedRealm: notifications") {
     if (!util::EventLoop::has_implementation())
@@ -2064,6 +2071,7 @@ TEST_CASE("SharedRealm: notifications") {
         REQUIRE(change_count == 1);
     }
 
+#if ASYNC_WRITES_ENABLED
     SECTION("notifications created in async transaction are sent synchronously") {
         realm->async_begin_transaction([&] {
             REQUIRE(change_count == 0);
@@ -2079,6 +2087,7 @@ TEST_CASE("SharedRealm: notifications") {
             return !realm->has_pending_async_work();
         });
     }
+#endif
 #endif
     SECTION("refresh() from within changes_available() refreshes") {
         context->changes_available_fn = [&] {


### PR DESCRIPTION
## What, How & Why?
Reduce the complexity around committing. The hope is that it changes the pattern around issues we see when encryption is enabled.

## ☑️ ToDos
* [x] 📝 Changelog update
* [x] 🚦 Tests (or not relevant)
