### PR TITLE
Disable initial notifications on objects

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,7 @@
 * Changeset upload batching did not calculate the accumulated size correctly, resulting in "error reading body failed to read: read limited at 16777217 bytes" errors from the server when writing large amounts of data (since 11.13.0).
 
 ### Breaking changes
-* None.
+* Removed the initial notification fired when adding a listener on an object. ([#5380](https://github.com/realm/realm-core/issues/5380))
 
 ### Compatibility
 * Fileformat: Generates files with format v22. Reads and automatically upgrade from fileformat v5.

--- a/src/realm/object-store/impl/collection_notifier.cpp
+++ b/src/realm/object-store/impl/collection_notifier.cpp
@@ -150,7 +150,8 @@ static bool all_have_filters(std::vector<NotificationCallback> const& callbacks)
     });
 }
 
-uint64_t CollectionNotifier::add_callback(CollectionChangeCallback callback, KeyPathArray key_path_array)
+uint64_t CollectionNotifier::add_callback(CollectionChangeCallback callback, KeyPathArray key_path_array,
+                                          bool notify_initially)
 {
     m_realm->verify_thread();
 
@@ -163,7 +164,7 @@ uint64_t CollectionNotifier::add_callback(CollectionChangeCallback callback, Key
     }
 
     auto token = m_next_token++;
-    m_callbacks.push_back({std::move(callback), {}, {}, std::move(key_path_array), token, false, false});
+    m_callbacks.push_back({std::move(callback), {}, {}, std::move(key_path_array), token, !notify_initially, false});
 
     if (m_callback_index == npos) { // Don't need to wake up if we're already sending notifications
         Realm::Internal::get_coordinator(*m_realm).wake_up_notifier_worker();

--- a/src/realm/object-store/impl/collection_notifier.hpp
+++ b/src/realm/object-store/impl/collection_notifier.hpp
@@ -92,10 +92,12 @@ public:
      * @param key_path_array An array of all key paths that should be filtered for. If a changed
      *                       table/column combination is not part of the `key_path_array`, no
      *                       notification will be sent.
+     * @param notify_initially Should the callback be called initially?
      *
      * @return A token which can be passed to `remove_callback()`.
      */
-    uint64_t add_callback(CollectionChangeCallback callback, KeyPathArray key_path_array) REQUIRES(!m_callback_mutex);
+    uint64_t add_callback(CollectionChangeCallback callback, KeyPathArray key_path_array,
+                          bool notify_initially = true) REQUIRES(!m_callback_mutex);
 
     /**
      * Remove a previously added token.

--- a/src/realm/object-store/object.cpp
+++ b/src/realm/object-store/object.cpp
@@ -144,7 +144,7 @@ NotificationToken Object::add_notification_callback(CollectionChangeCallback cal
         m_notifier = std::make_shared<_impl::ObjectNotifier>(m_realm, m_obj.get_table()->get_key(), m_obj.get_key());
         _impl::RealmCoordinator::register_notifier(m_notifier);
     }
-    return {m_notifier, m_notifier->add_callback(std::move(callback), std::move(key_path_array))};
+    return {m_notifier, m_notifier->add_callback(std::move(callback), std::move(key_path_array), false)};
 }
 
 void Object::verify_attached() const


### PR DESCRIPTION
## What, How & Why?

This closes #5380 by adding a parameter to the `add_callback` to disable the initial notification and using this when adding object notification callbacks.

## ☑️ ToDos
* [x] 📝 Changelog update
* [ ] 🚦 Tests (or not relevant)
