### PR TITLE
upgrade macos builders to macos 11.0

### DIFF
--- a/evergreen/config.yml
+++ b/evergreen/config.yml
@@ -789,9 +789,9 @@ buildvariants:
     distros:
     - ubuntu2004-arm64-large
 
-- name: macos-1015
-  display_name: "MacOS 10.15 x86_64"
-  run_on: macos-1015
+- name: macos
+  display_name: "MacOS 11.0 x86_64"
+  run_on: macos-1100
   expansions:
     cmake_url: "https://s3.amazonaws.com/static.realm.io/evergreen-assets/cmake-3.20.3-macos-universal.tar.gz"
     cmake_bindir: "./cmake_binaries/CMake.app/Contents/bin"
@@ -805,9 +805,9 @@ buildvariants:
   - name: compile_test
   - name: swift-build-and-test
 
-- name: macos-1015-encrypted
-  display_name: "MacOS 10.15 x86_64 (Encryption enabled)"
-  run_on: macos-1015
+- name: macos-encrypted
+  display_name: "MacOS 11.0 x86_64 (Encryption enabled)"
+  run_on: macos-1100
   expansions:
     cmake_url: "https://s3.amazonaws.com/static.realm.io/evergreen-assets/cmake-3.20.3-macos-universal.tar.gz"
     cmake_bindir: "./cmake_binaries/CMake.app/Contents/bin"
@@ -821,9 +821,9 @@ buildvariants:
   tasks:
   - name: compile_core_tests
 
-- name: macos-1015-release
-  display_name: "MacOS 10.15 x86_64 (Release build)"
-  run_on: macos-1015
+- name: macos-release
+  display_name: "MacOS 11.0 x86_64 (Release build)"
+  run_on: macos-1100
   expansions:
     cmake_url: "https://s3.amazonaws.com/static.realm.io/evergreen-assets/cmake-3.20.3-macos-universal.tar.gz"
     cmake_bindir: "./cmake_binaries/CMake.app/Contents/bin"


### PR DESCRIPTION
## What, How & Why?
We've been having issues with some of the hosts in the macos 10.15 pool on evergreen. Instead of mucking around older macos hosts, I figured we can just upgrade to macos 11 which has newer and more builders available.
