### PR TITLE
Fix potential issue in creating tombstones for invalidated objects

### DIFF
--- a/src/realm/table.cpp
+++ b/src/realm/table.cpp
@@ -3058,16 +3058,7 @@ ObjKey Table::get_objkey_from_primary_key(const Mixed& primary_key)
     // Object does not exist - create tombstone
     GlobalKey object_id{primary_key};
     ObjKey object_key = global_to_local_object_id_hashed(object_id);
-    auto tombstone = get_or_create_tombstone(object_key, {{m_primary_key_col, primary_key}});
-    auto existing_pk_value = tombstone.get_any(m_primary_key_col);
-    // It may just be the same object
-    if (existing_pk_value == primary_key) {
-        return tombstone.get_key();
-    }
-    // We have a collision - create new ObjKey
-    GlobalKey existing_id{existing_pk_value};
-    object_key = allocate_local_id_after_hash_collision(object_id, existing_id, object_key);
-    return get_or_create_tombstone(object_key, {{m_primary_key_col, primary_key}}).get_key();
+    return get_or_create_tombstone(object_key, m_primary_key_col, primary_key).get_key();
 }
 
 ObjKey Table::get_objkey_from_global_key(GlobalKey global_key)
@@ -3080,7 +3071,7 @@ ObjKey Table::get_objkey_from_global_key(GlobalKey global_key)
         return object_key;
     }
 
-    return get_or_create_tombstone(object_key, {{}}).get_key();
+    return get_or_create_tombstone(object_key, {}, {}).get_key();
 }
 
 ObjKey Table::get_objkey(GlobalKey global_key) const
@@ -3268,26 +3259,34 @@ ObjKey Table::allocate_local_id_after_hash_collision(GlobalKey incoming_id, Glob
     return new_local_id;
 }
 
-Obj Table::get_or_create_tombstone(ObjKey key, const FieldValues& values)
+Obj Table::get_or_create_tombstone(ObjKey key, ColKey pk_col, Mixed pk_val)
 {
     auto unres_key = key.get_unresolved();
 
     ensure_graveyard();
-
-    try {
-        Obj tombstone = m_tombstones->insert(unres_key, values);
-        bump_content_version();
-        bump_storage_version();
+    auto tombstone = m_tombstones->try_get_obj(unres_key);
+    if (tombstone) {
+        if (pk_col) {
+            auto existing_pk_value = tombstone.get_any(pk_col);
+            // It may just be the same object
+            if (existing_pk_value != pk_val) {
+                // We have a collision - create new ObjKey
+                key = allocate_local_id_after_hash_collision({pk_val}, {existing_pk_value}, key);
+                return get_or_create_tombstone(key, pk_col, pk_val);
+            }
+        }
         return tombstone;
     }
-    catch (const KeyAlreadyUsed&) {
-        return m_tombstones->get(unres_key);
-    }
+    return m_tombstones->insert(unres_key, {{pk_col, pk_val}});
 }
 
 void Table::free_local_id_after_hash_collision(ObjKey key)
 {
     if (ref_type collision_map_ref = to_ref(m_top.get(top_position_for_collision_map))) {
+        if (key.is_unresolved()) {
+            // Keys will always be inserted as resolved
+            key = key.get_unresolved();
+        }
         // Possible optimization: Cache these accessors
         Array collision_map{m_alloc};
         Array local_id{m_alloc};
@@ -3379,10 +3378,10 @@ ObjKey Table::invalidate_object(ObjKey key)
             auto pk = obj.get_any(primary_key_col);
             GlobalKey object_id{pk};
             auto unres_key = global_to_local_object_id_hashed(object_id);
-            tombstone = get_or_create_tombstone(unres_key, {{primary_key_col, pk}});
+            tombstone = get_or_create_tombstone(unres_key, primary_key_col, pk);
         }
         else {
-            tombstone = get_or_create_tombstone(key, {{}});
+            tombstone = get_or_create_tombstone(key, {}, {});
         }
         tombstone.assign_pk_and_backlinks(obj);
     }

--- a/src/realm/table.hpp
+++ b/src/realm/table.hpp
@@ -753,7 +753,7 @@ private:
     ObjKey allocate_local_id_after_hash_collision(GlobalKey incoming_id, GlobalKey colliding_id,
                                                   ObjKey colliding_local_id);
     /// Create a placeholder for a not yet existing object and return key to it
-    Obj get_or_create_tombstone(ObjKey key, const FieldValues& values);
+    Obj get_or_create_tombstone(ObjKey key, ColKey pk_col, Mixed pk_val);
     /// Should be called when an object is deleted
     void free_local_id_after_hash_collision(ObjKey key);
     /// Should be called when last entry is removed - or when table is cleared


### PR DESCRIPTION
Collision in the generated unresolved key would not be detected.

## What, How & Why?
<!-- Describe the changes and give some hints to guide your reviewers if possible. -->
<!-- Link to relevant issue this fixes -->

## ☑️ ToDos
* [ ] 📝 Changelog update
* [x] 🚦 Tests (or not relevant)
