### PR TITLE
Remove CMAKE_OSX_ARCHITECTURES from the Xcode toolchain

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,7 +17,7 @@
 -----------
 
 ### Internals
-* None.
+* The Xcode toolchain no longer explicitly sets `CMAKE_OSX_ARCHITECTURES`. This was a problem with the latest Xcode release complaining about explicit mentions of `i386`.
 
 ----------------------------------------------
 

--- a/tools/cmake/xcode.toolchain.cmake
+++ b/tools/cmake/xcode.toolchain.cmake
@@ -18,13 +18,6 @@ set(CMAKE_XCODE_ATTRIBUTE_MACOSX_DEPLOYMENT_TARGET "$(MACOSX_DEPLOYMENT_TARGET_C
 set(CMAKE_XCODE_ATTRIBUTE_MACOSX_DEPLOYMENT_TARGET_CATALYST_NO "10.9")
 set(CMAKE_XCODE_ATTRIBUTE_MACOSX_DEPLOYMENT_TARGET_CATALYST_YES "10.15")
 
-if(NOT CMAKE_OSX_ARCHITECTURES)
-    # Explicitly enumerate all the possible architectures this build tree can produce.
-    # The actual build-time values are overriden below in the ARCHS setting,
-    # but CMake needs this list at configure-time to generate multi-arch build rules.
-    set(CMAKE_OSX_ARCHITECTURES "arm64;i386;x86_64;armv7;armv7k;arm64_32")
-endif()
-
 set(CMAKE_XCODE_ATTRIBUTE_ARCHS "$(ARCHS_STANDARD)")
 set(CMAKE_XCODE_ATTRIBUTE_ARCHS[sdk=iphoneos*] "armv7 arm64")
 


### PR DESCRIPTION
## What, How & Why?
Turns out they weren't actually needed after all.

## ☑️ ToDos
* [x] 📝 Changelog update
* [x] 🚦 Tests (or not relevant)
