### PR TITLE
Improve some sync test things and fix a probably irrelevant bug

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,8 @@
 ### Fixed
 * <How do the end-user experience this issue? what was the impact?> ([#????](https://github.com/realm/realm-core/issues/????), since v?.?.?)
 * Adding an object to a Set, deleting the parent object, and then deleting the previously mentioned object causes crash ([#5387](https://github.com/realm/realm-core/issues/5387), since 11.0.0)
- 
+* Synchronized Realm files which were first created using SDK version released in the second half of August 2020 would be redownloaded instead of using the existing file, possibly resulting in the loss of any unsynchronized data in those files (since v11.6.1).
+
 ### Breaking changes
 * None.
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -88,7 +88,7 @@ else()
         add_compile_options(-Wno-uninitialized)
     elseif(${CMAKE_CXX_COMPILER_ID} MATCHES ".*[Cc]lang")
         # FIXME: Re-introduce -Wold-style-cast 
-        add_compile_options(-Wunreachable-code -Wshorten-64-to-32 -Wconditional-uninitialized -Wextra-semi -Wno-nested-anon-types -Wdocumentation -Wthread-safety -Wthread-safety-negative)
+        add_compile_options(-Wunreachable-code -Wshorten-64-to-32 -Wconditional-uninitialized -Wextra-semi -Wno-nested-anon-types -Wdocumentation -Wthread-safety -Wthread-safety-negative -Wmissing-prototypes)
     endif()
 
     if(CMAKE_CXX_STANDARD EQUAL 20)

--- a/src/realm/backup_restore.cpp
+++ b/src/realm/backup_restore.cpp
@@ -45,12 +45,12 @@ version_time_list_t BackupHandler::delete_versions_{
 
 
 // helper functions
-std::string backup_name(std::string prefix, int version)
+static std::string backup_name(const std::string& prefix, int version)
 {
-    return prefix + "v" + std::to_string(version) + ".backup.realm";
+    return util::format("%1v%2.backup.realm", prefix, version);
 }
 
-bool backup_exists(std::string prefix, int version)
+static bool backup_exists(const std::string& prefix, int version)
 {
     std::string fname = backup_name(prefix, version);
     return util::File::exists(fname);

--- a/src/realm/decimal128.cpp
+++ b/src/realm/decimal128.cpp
@@ -25,11 +25,10 @@
 #include <cstring>
 #include <stdexcept>
 
+namespace realm {
+
 namespace {
 constexpr int DECIMAL_EXPONENT_BIAS_128 = 6176;
-} // namespace
-
-namespace realm {
 
 Decimal128 to_decimal128(const BID_UINT128& val)
 {
@@ -44,6 +43,8 @@ BID_UINT128 to_BID_UINT128(const Decimal128& val)
     memcpy(&ret, val.raw(), sizeof(BID_UINT128));
     return ret;
 }
+
+} // namespace
 
 Decimal128::Decimal128()
 {
@@ -1576,7 +1577,7 @@ bool Decimal128::operator>=(const Decimal128& rhs) const
     return compare(rhs) >= 0;
 }
 
-Decimal128 do_multiply(BID_UINT128 x, BID_UINT128 mul)
+static Decimal128 do_multiply(BID_UINT128 x, BID_UINT128 mul)
 {
     unsigned flags = 0;
     BID_UINT128 res;
@@ -1611,7 +1612,7 @@ Decimal128 Decimal128::operator*(Decimal128 mul) const
     return do_multiply(x, y);
 }
 
-Decimal128 do_divide(BID_UINT128 x, BID_UINT128 div)
+static Decimal128 do_divide(BID_UINT128 x, BID_UINT128 div)
 {
     unsigned flags = 0;
     BID_UINT128 res;

--- a/src/realm/group.cpp
+++ b/src/realm/group.cpp
@@ -126,6 +126,8 @@ Group::Group(SlabAlloc* alloc) noexcept
     init_array_parents();
 }
 
+namespace {
+
 class TableRecycler : public std::vector<Table*> {
 public:
     ~TableRecycler()
@@ -149,6 +151,8 @@ auto& g_table_recycler_2 = *new TableRecycler;
 // without crashing.
 const static int g_table_recycling_delay = 100;
 auto& g_table_recycler_mutex = *new std::mutex;
+
+} // namespace
 
 TableKeyIterator& TableKeyIterator::operator++()
 {

--- a/src/realm/object-store/c_api/sync.cpp
+++ b/src/realm/object-store/c_api/sync.cpp
@@ -242,8 +242,8 @@ RLM_API void realm_sync_client_config_set_metadata_mode(realm_sync_client_config
     config->metadata_mode = SyncClientConfig::MetadataMode(mode);
 }
 
-RLM_API void realm_sync_client_config_set_encryption_key(realm_sync_client_config_t* config,
-                                                         const uint8_t key[64]) noexcept
+RLM_API void realm_sync_client_config_set_metadata_encryption_key(realm_sync_client_config_t* config,
+                                                                  const uint8_t key[64]) noexcept
 {
     config->custom_encryption_key = std::vector<char>(key, key + 64);
 }

--- a/src/realm/object-store/sync/app.cpp
+++ b/src/realm/object-store/sync/app.cpp
@@ -190,6 +190,13 @@ SharedApp App::get_shared_app(const Config& config, const SyncClientConfig& sync
     return app;
 }
 
+SharedApp App::get_uncached_app(const Config& config, const SyncClientConfig& sync_client_config)
+{
+    auto app = std::make_shared<App>(config);
+    app->configure(sync_client_config);
+    return app;
+}
+
 std::shared_ptr<App> App::get_cached_app(const std::string& app_id)
 {
     std::lock_guard<std::mutex> lock(s_apps_mutex);

--- a/src/realm/object-store/sync/app.hpp
+++ b/src/realm/object-store/sync/app.hpp
@@ -231,6 +231,7 @@ public:
     };
 
     static SharedApp get_shared_app(const Config& config, const SyncClientConfig& sync_client_config);
+    static SharedApp get_uncached_app(const Config& config, const SyncClientConfig& sync_client_config);
     static std::shared_ptr<App> get_cached_app(const std::string& app_id);
 
     /// Log in a user and asynchronously retrieve a user object.

--- a/src/realm/object-store/sync/impl/sync_file.cpp
+++ b/src/realm/object-store/sync/impl/sync_file.cpp
@@ -354,6 +354,12 @@ util::Optional<std::string> SyncFileManager::get_existing_realm_file_path(const 
         return hashed_path;
     }
 
+    // The legacy fallback paths are not applicable to flexible sync
+    if (partition.empty()) {
+        REALM_ASSERT(realm_file_name == "flx_sync_default");
+        return util::none;
+    }
+
     // We used to hash the string value of the partition. For compatibility, check that SHA256
     // hash file name exists, and if it does, continue to use it.
     if (!partition.empty()) {
@@ -370,7 +376,7 @@ util::Optional<std::string> SyncFileManager::get_existing_realm_file_path(const 
             return old_path;
         }
         // retain support for legacy local identity paths
-        std::string old_local_identity_path = legacy_local_identity_path(local_user_identity, realm_file_name);
+        std::string old_local_identity_path = legacy_local_identity_path(local_user_identity, partition);
         if (try_file_exists(old_local_identity_path)) {
             return old_local_identity_path;
         }

--- a/src/realm/object-store/sync/sync_manager.cpp
+++ b/src/realm/object-store/sync/sync_manager.cpp
@@ -541,35 +541,24 @@ struct UnsupportedBsonPartition : public std::logic_error {
 
 static std::string string_from_partition(const std::string& partition)
 {
-    try {
-        bson::Bson partition_value = bson::parse(partition);
-        switch (partition_value.type()) {
-            case bson::Bson::Type::Int32:
-                return util::format("i_%1", static_cast<int32_t>(partition_value));
-            case bson::Bson::Type::Int64:
-                return util::format("l_%1", static_cast<int64_t>(partition_value));
-            case bson::Bson::Type::String:
-                return util::format("s_%1", static_cast<std::string>(partition_value));
-            case bson::Bson::Type::ObjectId:
-                return util::format("o_%1", static_cast<ObjectId>(partition_value).to_string());
-            case bson::Bson::Type::Uuid:
-                return util::format("u_%1", static_cast<UUID>(partition_value).to_string());
-            case bson::Bson::Type::Null:
-                return "null";
-            default:
-                throw UnsupportedBsonPartition(util::format("Unsupported partition key value: '%1'. Only int, string "
-                                                            "UUID and ObjectId types are currently supported.",
-                                                            partition_value.to_string()));
-        }
-    }
-    catch (const UnsupportedBsonPartition&) {
-        throw;
-    }
-    catch (...) {
-        // FIXME: the partition wasn't a bson formatted string, this can happen when using the
-        // test sync server which only accepts filesystem type paths, in this case return the raw partition.
-        // Once we migrate away from using the sync server in tests, this code path should not be necessary.
-        return partition;
+    bson::Bson partition_value = bson::parse(partition);
+    switch (partition_value.type()) {
+        case bson::Bson::Type::Int32:
+            return util::format("i_%1", static_cast<int32_t>(partition_value));
+        case bson::Bson::Type::Int64:
+            return util::format("l_%1", static_cast<int64_t>(partition_value));
+        case bson::Bson::Type::String:
+            return util::format("s_%1", static_cast<std::string>(partition_value));
+        case bson::Bson::Type::ObjectId:
+            return util::format("o_%1", static_cast<ObjectId>(partition_value).to_string());
+        case bson::Bson::Type::Uuid:
+            return util::format("u_%1", static_cast<UUID>(partition_value).to_string());
+        case bson::Bson::Type::Null:
+            return "null";
+        default:
+            throw UnsupportedBsonPartition(util::format("Unsupported partition key value: '%1'. Only int, string "
+                                                        "UUID and ObjectId types are currently supported.",
+                                                        partition_value.to_string()));
     }
 }
 

--- a/src/realm/object-store/sync/sync_manager.hpp
+++ b/src/realm/object-store/sync/sync_manager.hpp
@@ -30,7 +30,8 @@
 #include <mutex>
 #include <unordered_map>
 
-struct TestSyncManager;
+class TestAppSession;
+class TestSyncManager;
 
 namespace realm {
 
@@ -89,7 +90,8 @@ struct SyncClientConfig {
 
 class SyncManager : public std::enable_shared_from_this<SyncManager> {
     friend class SyncSession;
-    friend struct ::TestSyncManager;
+    friend class ::TestSyncManager;
+    friend class ::TestAppSession;
 
 public:
     using MetadataMode = SyncClientConfig::MetadataMode;

--- a/src/realm/object-store/sync/sync_session.cpp
+++ b/src/realm/object-store/sync/sync_session.cpp
@@ -560,7 +560,7 @@ void SyncSession::handle_progress_update(uint64_t downloaded, uint64_t downloada
     m_progress_notifier.update(downloaded, downloadable, uploaded, uploadable, download_version, snapshot_version);
 }
 
-sync::Session::Config::ClientReset make_client_reset_config(SyncConfig& session_config, DBRef&& fresh_copy)
+static sync::Session::Config::ClientReset make_client_reset_config(SyncConfig& session_config, DBRef&& fresh_copy)
 {
     sync::Session::Config::ClientReset config;
     config.discard_local = (session_config.client_resync_mode == ClientResyncMode::DiscardLocal);

--- a/src/realm/parser/keypath_mapping.cpp
+++ b/src/realm/parser/keypath_mapping.cpp
@@ -135,23 +135,6 @@ std::string KeyPathMapping::translate(LinkChain& link_chain, const std::string& 
     return translate(table, identifier);
 }
 
-
-// This may be premature optimisation, but it'll be super fast and it doesn't
-// bother dragging in anything locale specific for case insensitive comparisons.
-bool is_backlinks_prefix(const std::string& s)
-{
-    return s.size() == 6 && s[0] == '@' && (s[1] == 'l' || s[1] == 'L') && (s[2] == 'i' || s[2] == 'I') &&
-           (s[3] == 'n' || s[3] == 'N') && (s[4] == 'k' || s[4] == 'K') && (s[5] == 's' || s[5] == 'S');
-}
-
-bool is_length_suffix(const std::string& s)
-{
-    return s.size() == 6 && (s[0] == 'l' || s[0] == 'L') && (s[1] == 'e' || s[1] == 'E') &&
-           (s[2] == 'n' || s[2] == 'N') && (s[3] == 'g' || s[3] == 'G') && (s[4] == 't' || s[4] == 'T') &&
-           (s[5] == 'h' || s[5] == 'H');
-}
-
-
 void KeyPathMapping::set_backlink_class_prefix(std::string prefix)
 {
     m_backlink_class_prefix = prefix;

--- a/src/realm/query_value.cpp
+++ b/src/realm/query_value.cpp
@@ -16,14 +16,17 @@
  *
  **************************************************************************/
 
-#include <numeric>
-#include <unordered_map>
-#include <algorithm>
-
 #include <realm/query_value.hpp>
+
 #include <realm/mixed.hpp>
 
+#include <algorithm>
+#include <numeric>
+#include <unordered_map>
+
 using namespace realm;
+
+namespace {
 
 // These keys must be stored as lowercase. Some naming comes from MongoDB's conventions
 // see https://docs.mongodb.com/manual/reference/operator/query/type/
@@ -113,6 +116,7 @@ TypeOfValue::Attribute attribute_from(DataType type)
     }
     throw std::runtime_error(util::format("Invalid value '%1' cannot be converted to 'TypeOfValue'", type));
 }
+} // anonymous namespace
 
 namespace realm {
 
@@ -161,14 +165,14 @@ bool TypeOfValue::matches(const class Mixed& value) const
     return matches(TypeOfValue(value));
 }
 
-util::Optional<std::string> get_attribute_name_of(int64_t att)
+static const std::string* get_attribute_name_of(int64_t att)
 {
     for (const auto& it : attribute_map) {
         if (it.second == att) {
-            return it.first;
+            return &it.first;
         }
     }
-    return util::none;
+    return nullptr;
 }
 
 std::string TypeOfValue::to_string() const

--- a/src/realm/sync/noinst/changeset_index.cpp
+++ b/src/realm/sync/noinst/changeset_index.cpp
@@ -334,7 +334,7 @@ auto ChangesetIndex::erase_instruction(RangeIterator pos) -> RangeIterator
 }
 
 #if REALM_DEBUG
-std::ostream& operator<<(std::ostream& os, GlobalID gid)
+static std::ostream& operator<<(std::ostream& os, GlobalID gid)
 {
     return os << gid.table_name << "/" << format_pk(gid.object_id);
 }

--- a/src/realm/sync/noinst/server/encryption_transformer.cpp
+++ b/src/realm/sync/noinst/server/encryption_transformer.cpp
@@ -66,9 +66,6 @@ private:
     IntegrationReporter m_integration_reporter;
 };
 
-} // unnamed namespace
-
-
 Replication::HistoryType peek_history_type(const std::string& file_name, const char* read_key)
 {
     Group group{file_name, read_key};
@@ -149,6 +146,8 @@ void parallel_transform(const std::vector<std::string>& paths, const char* read_
         thread.join();
     }
 }
+
+} // unnamed namespace
 
 size_t encryption_transformer::encrypt_transform(const encryption_transformer::Configuration& config)
 {

--- a/src/realm/sync/tools/inspect_client_realm.cpp
+++ b/src/realm/sync/tools/inspect_client_realm.cpp
@@ -5,7 +5,8 @@
 
 #include <realm/sync/noinst/client_history_impl.hpp>
 
-namespace realm {
+namespace {
+using namespace realm;
 
 void print_tables(const Group& group)
 {
@@ -43,13 +44,12 @@ void inspect_client_realm(const std::string& path)
     std::cout << "\n\n";
 }
 
-} // namespace realm
-
 void usage(char* prog)
 {
     std::cerr << "Synopsis: " << prog << " PATH\n";
 }
 
+} // namespace
 int main(int argc, char* argv[])
 {
     if (argc != 2) {
@@ -59,7 +59,7 @@ int main(int argc, char* argv[])
 
     const std::string path = argv[1];
 
-    realm::inspect_client_realm(path);
+    inspect_client_realm(path);
 
     return 0;
 }

--- a/src/realm/sync/tools/print_changeset.cpp
+++ b/src/realm/sync/tools/print_changeset.cpp
@@ -11,6 +11,8 @@
 
 using namespace realm;
 
+namespace {
+
 sync::Changeset changeset_binary_to_sync_changeset(const std::string& changeset_binary)
 {
     util::SimpleInputStream input_stream{changeset_binary};
@@ -88,6 +90,8 @@ void print_changeset(const std::string& path, bool hex, bool compressed)
     std::cout << "changeset printing is disabled in Release mode, build in Debug mode to use this tool" << std::endl;
 #endif
 }
+
+} // namespace
 
 int main(int argc, char* argv[])
 {

--- a/src/realm/table.hpp
+++ b/src/realm/table.hpp
@@ -625,12 +625,6 @@ public:
     ColKey get_opposite_column(ColKey col_key) const;
     ColKey find_opposite_column(ColKey col_key) const;
 
-protected:
-    /// Compare the objects of two tables under the assumption that the two tables
-    /// have the same number of columns, and the same data type at each column
-    /// index (as expressed through the DataType enum).
-    bool compare_objects(const Table&) const;
-
 private:
     enum LifeCycleCookie {
         cookie_created = 0x1234,

--- a/src/realm/util/serializer.cpp
+++ b/src/realm/util/serializer.cpp
@@ -87,7 +87,7 @@ std::string print_value<>(realm::null)
     return "NULL";
 }
 
-bool contains_invalids(StringData data)
+static bool contains_invalids(StringData data)
 {
     // the custom whitelist is different from std::isprint because it doesn't include quotations
     const static std::string whitelist = " {|}~:;<=>?@!#$%&()*+,-./[]^_`";

--- a/src/realm/util/terminate.cpp
+++ b/src/realm/util/terminate.cpp
@@ -123,13 +123,6 @@ REALM_NORETURN static void terminate_internal(std::stringstream& ss) noexcept
     please_report_this_issue_in_github_realm_realm_core();
 }
 
-REALM_NORETURN void terminate(const char* message, const char* file, long line) noexcept
-{
-    std::stringstream ss;
-    ss << file << ":" << line << ": " REALM_VER_CHUNK " " << message << '\n';
-    terminate_internal(ss);
-}
-
 REALM_NORETURN void terminate(const char* message, const char* file, long line,
                               std::initializer_list<Printable>&& values) noexcept
 {

--- a/src/realm/uuid.cpp
+++ b/src/realm/uuid.cpp
@@ -16,14 +16,15 @@
  *
  **************************************************************************/
 
-#include <realm.hpp>
 #include <realm/uuid.hpp>
 #include <realm/string_data.hpp>
 #include <realm/util/assert.hpp>
-#include "realm/util/base64.hpp"
+#include <realm/util/base64.hpp>
+
 #include <atomic>
 #include <cctype>
 
+namespace {
 constexpr char hex_digits[] = "0123456789abcdef";
 constexpr size_t size_of_uuid_string = 36;
 constexpr char null_uuid_string[] = "00000000-0000-0000-0000-000000000000";
@@ -39,7 +40,7 @@ constexpr size_t hyphen_pos_2 = 18;
 constexpr size_t hyphen_pos_3 = 23;
 constexpr char hyphen = '-';
 
-inline bool is_hex_digit(unsigned char c)
+bool is_hex_digit(unsigned char c)
 {
     return (c >= '0' && c <= '9') || (c >= 'a' && c <= 'f') || (c >= 'A' && c <= 'F');
 }
@@ -54,6 +55,7 @@ char parse_xdigit(char ch)
         return ch - 'A' + 10;
     return char(-1);
 }
+} // anonymous namespace
 
 namespace realm {
 

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -185,90 +185,46 @@ add_test(NAME StorageTests COMMAND realm-tests)
 
 if(REALM_ENABLE_SYNC)
 
-    set(TEST_UTIL_SOURCES
-        test_all.cpp
-        util/benchmark_results.cpp
-        util/compare_groups.cpp
-        util/crypt_key.cpp
-        util/demangle.cpp
-        util/dump_changesets.cpp
-        util/misc.cpp
-        util/mock_metrics.cpp
-        util/quote.cpp
-        util/random.cpp
-        util/resource_limits.cpp
-        util/test_only.cpp
-        util/test_path.cpp
-        util/timer.cpp
-        util/unit_test.cpp
-        util/wildcard.cpp
-    )
-
-    set(TEST_UTIL_HEADERS
-        test.hpp
-        test_all.hpp
-        util/benchmark_results.hpp
-        util/check_logic_error.hpp
-        util/check_system_error.hpp
-        util/crypt_key.hpp
-        util/demangle.hpp
-        util/misc.hpp
-        util/mock_metrics.hpp
-        util/number_names.hpp
-        util/quote.hpp
-        util/random.hpp
-        util/resource_limits.hpp
-        util/semaphore.hpp
-        util/super_int.hpp
-        util/test_logger.hpp
-        util/test_only.hpp
-        util/test_path.hpp
-        util/test_types.hpp
-        util/thread_wrapper.hpp
-        util/timer.hpp
-        util/unit_test.hpp
-        util/verified_integer.hpp
-        util/verified_string.hpp
-        util/wildcard.hpp
-    )
-
     set(TEST_MAIN_SOURCES
         main.cpp
     )
 
     set(SYNC_TESTS
+        test_all.cpp
         test_allocation_metrics.cpp
         test_array_sync.cpp
-        test_client_reset.cpp
         test_changeset_encoding.cpp
-        test_crypto.cpp
+        test_client_reset.cpp
         test_compact_changesets.cpp
+        test_crypto.cpp
         test_embedded_objects.cpp
         test_encrypt_fingerprint.cpp
         test_encrypt_transform.cpp
         test_instruction_replication.cpp
         test_lang_bind_helper_sync.cpp
-        test_server_history.cpp
+        test_noinst_server_dir.cpp
+        test_noinst_vacuum.cpp
         test_scratch_allocator.cpp
+        test_server_history.cpp
         test_stable_ids.cpp
         test_sync.cpp
         test_sync_auth.cpp
         test_sync_history_migration.cpp
         test_sync_subscriptions.cpp
         test_transform.cpp
-        test_util_circular_buffer.cpp
         test_util_buffer_stream.cpp
+        test_util_circular_buffer.cpp
         test_util_http.cpp
         test_util_json_parser.cpp
         test_util_network.cpp
         test_util_network_ssl.cpp
         test_util_uri.cpp
         test_util_websocket.cpp
-        test_noinst_server_dir.cpp
-        test_noinst_vacuum.cpp
     )
 
     set(TEST_HEADERS
+        test.hpp
+        test_all.hpp
         fuzz_tester.hpp
         peer.hpp
         sync_fixtures.hpp
@@ -291,9 +247,6 @@ if(REALM_ENABLE_SYNC)
         test_all.cpp
     )
 
-    add_library(TestUtils STATIC ${TEST_UTIL_SOURCES} ${TEST_UTIL_HEADERS})
-    target_link_libraries(TestUtils PUBLIC Storage)
-
     if(${CMAKE_SYSTEM_NAME} STREQUAL "Windows")
         # Embed the manifest on Windows. The manifest allows very long paths (>255).
         list(APPEND SYNC_TESTS test.manifest)
@@ -301,7 +254,7 @@ if(REALM_ENABLE_SYNC)
 
     add_executable(SyncTests ${SYNC_TESTS} ${TEST_MAIN_SOURCES} ${TEST_HEADERS})
     set_target_properties(SyncTests PROPERTIES OUTPUT_NAME "realm-sync-tests")
-    target_link_libraries(SyncTests Sync SyncServer TestUtils)
+    target_link_libraries(SyncTests Sync SyncServer TestUtil)
     add_test(NAME SyncTests COMMAND realm-sync-tests)
 
     if(UNIX AND NOT APPLE)
@@ -311,7 +264,7 @@ if(REALM_ENABLE_SYNC)
 
     add_executable(BenchTransform EXCLUDE_FROM_ALL ${BENCH_TRANSFORM_SOURCES})
     set_target_properties(BenchTransform PROPERTIES OUTPUT_NAME "bench-transform")
-    target_link_libraries(BenchTransform TestUtils Sync)
+    target_link_libraries(BenchTransform TestUtil Sync)
 
     if(REALM_BUILD_DOGLESS)
         add_executable(SyncTestClient ${TEST_CLIENT_SOURCES} ${TEST_CLIENT_HEADERS})

--- a/test/benchmark-common-tasks/compatibility.cpp
+++ b/test/benchmark-common-tasks/compatibility.cpp
@@ -23,7 +23,7 @@ using realm::DBOptions;
 
 namespace compatibility {
 
-DBOptions::Durability durability(RealmDurability level)
+static DBOptions::Durability durability(RealmDurability level)
 {
     switch (level) {
     case RealmDurability::Full:

--- a/test/benchmark-common-tasks/stats.cpp
+++ b/test/benchmark-common-tasks/stats.cpp
@@ -12,6 +12,8 @@ using namespace realm;
 using ColKey = size_t;
 #endif
 
+namespace {
+
 namespace function {
 
 const static std::string binary = "store_binary";
@@ -103,6 +105,8 @@ void create_realm_with_transactions(std::string file_name,
         tr.commit();
     }
 }
+
+} // namespace
 
 int main(int argc, const char* argv[])
 {

--- a/test/fuzz_group.cpp
+++ b/test/fuzz_group.cpp
@@ -16,6 +16,8 @@
  *
  **************************************************************************/
 
+#include "fuzz_group.hpp"
+
 #include <realm.hpp>
 #include <realm/history.hpp>
 #include <realm/index_string.hpp>
@@ -48,6 +50,8 @@ using namespace realm::util;
     do {                                                                                                             \
     } while (false)
 #endif
+
+namespace {
 
 struct EndOfFile {
 };
@@ -156,22 +160,8 @@ std::pair<int64_t, int32_t> get_timestamp_values(State& s)
     return {seconds, nanoseconds};
 }
 
-// returns random binary blob data in a string, logs to a variable called "blob" if logging is enabled
-std::string construct_binary_payload(State& s, util::Optional<std::ostream&> log)
-{
-    size_t rand_char = get_next(s);
-    size_t blob_size = static_cast<uint64_t>(get_int64(s)) % (ArrayBlob::max_binary_size + 1);
-    std::string buffer(blob_size, static_cast<unsigned char>(rand_char));
-    if (log) {
-        *log << "std::string blob(" << blob_size << ", static_cast<unsigned char>(" << rand_char << "));\n";
-    }
-    return buffer;
-}
-
-namespace {
 int table_index = 0;
 int column_index = 0;
-} // namespace
 
 std::string create_column_name(DataType t)
 {
@@ -238,11 +228,10 @@ std::string get_current_time_stamp()
     return str_buffer;
 }
 
-namespace {
 // You can use this variable to make a conditional breakpoint if you know that
 // a problem occurs after a certain amount of iterations.
-int iteration;
-} // namespace
+int iteration = 0;
+} // anonymous namespace
 
 void parse_and_apply_instructions(std::string& in, const std::string& path, util::Optional<std::ostream&> log)
 {
@@ -748,7 +737,7 @@ void parse_and_apply_instructions(std::string& in, const std::string& path, util
 }
 
 
-void usage(const char* argv[])
+static void usage(const char* argv[])
 {
     fprintf(stderr,
             "Usage: %s {FILE | --} [--log] [--name NAME] [--prefix PATH]\n"
@@ -762,7 +751,6 @@ void usage(const char* argv[])
             argv[0]);
     exit(1);
 }
-
 
 int run_fuzzy(int argc, const char* argv[])
 {

--- a/test/object-store/CMakeLists.txt
+++ b/test/object-store/CMakeLists.txt
@@ -39,9 +39,10 @@ endif()
 
 if(REALM_ENABLE_SYNC)
     list(APPEND HEADERS
-        sync/sync_test_utils.hpp
         sync/flx_sync_harness.hpp
         sync/session/session_util.hpp
+        sync/sync_test_utils.hpp
+        util/baas_admin_api.hpp
     )
     list(APPEND SOURCES
         bson.cpp

--- a/test/object-store/c_api/c_api.c
+++ b/test/object-store/c_api/c_api.c
@@ -29,6 +29,7 @@ static void check_property_info_equal(const realm_property_info_t* lhs, const re
     assert(lhs->flags == rhs->flags);
 }
 
+int realm_c_api_tests(const char* file);
 int realm_c_api_tests(const char* file)
 {
     const realm_class_info_t def_classes[] = {

--- a/test/object-store/c_api/c_api.cpp
+++ b/test/object-store/c_api/c_api.cpp
@@ -17,6 +17,7 @@ using namespace realm;
 
 extern "C" int realm_c_api_tests(const char* file);
 
+namespace {
 template <class T>
 T checked(T x)
 {
@@ -215,6 +216,7 @@ CPtr<T> clone_cptr(const T* ptr)
     void* clone = realm_clone(ptr);
     return CPtr<T>{static_cast<T*>(clone)};
 }
+} // anonymous namespace
 
 #define CHECK_ERR(err)                                                                                               \
     do {                                                                                                             \
@@ -442,6 +444,8 @@ TEST_CASE("C API (non-database)") {
     }
 }
 
+namespace {
+
 /// Generate realm_property_info_t for all possible property types.
 std::vector<realm_property_info_t> all_property_types(const char* link_target)
 {
@@ -591,23 +595,10 @@ std::vector<realm_property_info_t> all_property_types(const char* link_target)
     // properties.push_back(mixed);
     // properties.push_back(mixed_list);
 
-    // FIXME: Object Store schema handling does not support TypedLink yet.
-    // realm_property_info_t typed_link{
-    //     "typed_link", "", RLM_PROPERTY_TYPE_OBJECT, RLM_COLLECTION_TYPE_NONE,
-    //     "",           "", RLM_INVALID_PROPERTY_KEY, RLM_PROPERTY_NULLABLE,
-    // };
-    // realm_property_info_t typed_link_list{
-    //     "typed_link_list",   "", RLM_PROPERTY_TYPE_OBJECT, RLM_COLLECTION_TYPE_LIST, "", "",
-    //     RLM_INVALID_PROPERTY_KEY, RLM_PROPERTY_NORMAL,
-    // };
-
-    // properties.push_back(typed_link);
-    // properties.push_back(typed_link_list);
-
     return properties;
 }
 
-static CPtr<realm_schema_t> make_schema()
+CPtr<realm_schema_t> make_schema()
 {
     auto foo_properties = all_property_types("Bar");
 
@@ -726,6 +717,8 @@ bool should_compact_on_launch(void* userdata_p, uint64_t, uint64_t)
     ++userdata->num_compact_on_launch;
     return false;
 }
+
+} // anonymous namespace
 
 TEST_CASE("C API") {
     TestFile test_file;

--- a/test/object-store/c_api/c_api.cpp
+++ b/test/object-store/c_api/c_api.cpp
@@ -3713,11 +3713,11 @@ TEST_CASE("C API") {
 TEST_CASE("app: flx-sync basic tests", "[c_api][flx][syc]") {
     using namespace realm::app;
 
-    auto make_schema = []() -> auto
-    {
-        Schema schema{ObjectSchema("Obj", {{"_id", PropertyType::ObjectId, Property::IsPrimary{true}},
-                                           {"name", PropertyType::String | PropertyType::Nullable},
-                                           {"value", PropertyType::Int | PropertyType::Nullable}})};
+    auto make_schema = [] {
+        Schema schema{{"Obj",
+                       {{"_id", PropertyType::ObjectId, Property::IsPrimary{true}},
+                        {"name", PropertyType::String | PropertyType::Nullable},
+                        {"value", PropertyType::Int | PropertyType::Nullable}}}};
 
         return FLXSyncTestHarness::ServerSchema{std::move(schema), {"name", "value"}};
     };
@@ -3726,18 +3726,14 @@ TEST_CASE("app: flx-sync basic tests", "[c_api][flx][syc]") {
     auto foo_obj_id = ObjectId::gen();
     auto bar_obj_id = ObjectId::gen();
 
-    harness.load_initial_data([&](SharedRealm realm) {
+    harness.load_initial_data([&](SharedRealm& realm) {
         CppContext c(realm);
-        realm->begin_transaction();
         Object::create(c, realm, "Obj",
                        util::Any(AnyDict{
                            {"_id", foo_obj_id}, {"name", std::string{"foo"}}, {"value", static_cast<int64_t>(5)}}));
         Object::create(c, realm, "Obj",
                        util::Any(AnyDict{
                            {"_id", bar_obj_id}, {"name", std::string{"bar"}}, {"value", static_cast<int64_t>(10)}}));
-
-        realm->commit_transaction();
-        wait_for_upload(*realm);
     });
 
     harness.do_with_new_realm([&](SharedRealm realm) {

--- a/test/object-store/list.cpp
+++ b/test/object-store/list.cpp
@@ -1777,9 +1777,6 @@ TEST_CASE("list with unresolved links") {
     auto r1 = Realm::get_shared_realm(config1);
     auto r2 = Realm::get_shared_realm(config2);
 
-    auto coordinator = _impl::RealmCoordinator::get_coordinator(config2.path);
-    coordinator->enable_wait_for_change();
-
     auto origin = r1->read_group().get_table("class_origin");
     auto target = r1->read_group().get_table("class_target");
     ColKey col_link = origin->get_column_key("array");

--- a/test/object-store/migrations.cpp
+++ b/test/object-store/migrations.cpp
@@ -2517,12 +2517,12 @@ TEST_CASE("migration: AdditiveDiscovered") {
         }
 
         DYNAMIC_SECTION("can have different subsets of columns in different Realm instances" << mode_string) {
-            auto config2 = config;
+            Realm::Config config2 = config;
             config2.schema = add_property(schema, "object", {"value 3", PropertyType::Int});
-            auto config3 = config;
+            Realm::Config config3 = config;
             config3.schema = remove_property(schema, "object", "value 2");
 
-            auto config4 = config;
+            Realm::Config config4 = config;
             config4.schema = util::none;
 
             auto realm2 = Realm::get_shared_realm(config2);
@@ -2542,7 +2542,7 @@ TEST_CASE("migration: AdditiveDiscovered") {
         }
 
         DYNAMIC_SECTION("updating a schema to include already-present column" << mode_string) {
-            auto config2 = config;
+            Realm::Config config2 = config;
             config2.schema = add_property(schema, "object", {"value 3", PropertyType::Int});
             auto realm2 = Realm::get_shared_realm(config2);
             auto& properties2 = realm2->schema().find("object")->persisted_properties;
@@ -2567,14 +2567,14 @@ TEST_CASE("migration: AdditiveDiscovered") {
             Schema schema1 = realm1->schema();
             realm1->close();
 
-            auto config2 = config1;
+            Realm::Config config2 = config1;
             config2.schema_version = 1;
             auto realm2 = Realm::get_shared_realm(config2);
             REQUIRE(realm2->schema() == schema1);
         }
 
         DYNAMIC_SECTION("invalid schema update leaves the schema untouched" << mode_string) {
-            auto config2 = config;
+            Realm::Config config2 = config;
             config2.schema = add_property(schema, "object", {"value 3", PropertyType::Int});
             auto realm2 = Realm::get_shared_realm(config2);
 

--- a/test/object-store/sync/app.cpp
+++ b/test/object-store/sync/app.cpp
@@ -162,10 +162,9 @@ std::string create_jwt(const std::string appId)
 
 TEST_CASE("app: login_with_credentials integration", "[sync][app]") {
     SECTION("login") {
-        auto config = get_integration_config();
-        TestSyncManager sync_manager(config, {});
-        auto app = sync_manager.app();
-        bool processed = false;
+        TestAppSession session;
+        auto app = session.app();
+        app->log_out([](auto) {});
 
         int subscribe_processed = 0;
         auto token = app->subscribe([&subscribe_processed](auto& app) {
@@ -183,6 +182,7 @@ TEST_CASE("app: login_with_credentials integration", "[sync][app]") {
         CHECK(!user->device_id().empty());
         CHECK(user->has_device_id());
 
+        bool processed = false;
         app->log_out([&](auto error) {
             REQUIRE_FALSE(error);
             processed = true;
@@ -203,9 +203,8 @@ TEST_CASE("app: UsernamePasswordProviderClient integration", "[sync][app]") {
     auto email = creds.email;
     auto password = creds.password;
 
-    auto config = get_integration_config();
-    TestSyncManager sync_manager(config, {});
-    auto app = sync_manager.app();
+    TestAppSession session;
+    auto app = session.app();
     auto client = app->provider_client<App::UsernamePasswordProviderClient>();
 
     bool processed = false;
@@ -344,6 +343,7 @@ TEST_CASE("app: UsernamePasswordProviderClient integration", "[sync][app]") {
     }
 
     SECTION("log in, remove, log in") {
+        app->remove_user(app->current_user(), [](auto) {});
         CHECK(app->sync_manager()->all_users().size() == 0);
         CHECK(app->sync_manager()->get_current_user() == nullptr);
 
@@ -378,15 +378,14 @@ TEST_CASE("app: UsernamePasswordProviderClient integration", "[sync][app]") {
 // MARK: - UserAPIKeyProviderClient Tests
 
 TEST_CASE("app: UserAPIKeyProviderClient integration", "[sync][app]") {
-    TestSyncManager sync_manager(get_integration_config(), {});
-    auto app = sync_manager.app();
+    TestAppSession session;
+    auto app = session.app();
     auto client = app->provider_client<App::UserAPIKeyProviderClient>();
 
     bool processed = false;
     App::UserAPIKey api_key;
 
     SECTION("api-key") {
-        create_user_and_log_in(app);
         std::shared_ptr<SyncUser> logged_in_user = app->current_user();
         auto api_key_name = util::format("%1", random_string(15));
         client.create_api_key(api_key_name, logged_in_user,
@@ -513,7 +512,6 @@ TEST_CASE("app: UserAPIKeyProviderClient integration", "[sync][app]") {
     }
 
     SECTION("api-key against the wrong user") {
-        create_user_and_log_in(app);
         std::shared_ptr<SyncUser> first_user = app->current_user();
         create_user_and_log_in(app);
         std::shared_ptr<SyncUser> second_user = app->current_user();
@@ -642,8 +640,8 @@ TEST_CASE("app: UserAPIKeyProviderClient integration", "[sync][app]") {
 // MARK: - Auth Providers Function Tests
 
 TEST_CASE("app: auth providers function integration", "[sync][app]") {
-    TestSyncManager sync_manager(get_integration_config(), {});
-    auto app = sync_manager.app();
+    TestAppSession session;
+    auto app = session.app();
 
     SECTION("auth providers function integration") {
         bson::BsonDocument function_params{{"realmCustomAuthFuncUserId", "123456"}};
@@ -656,8 +654,8 @@ TEST_CASE("app: auth providers function integration", "[sync][app]") {
 // MARK: - Link User Tests
 
 TEST_CASE("app: link_user integration", "[sync][app]") {
-    TestSyncManager sync_manager(get_integration_config(), {});
-    auto app = sync_manager.app();
+    TestAppSession session;
+    auto app = session.app();
 
     SECTION("link_user intergration") {
         AutoVerifiedEmailCredentials creds;
@@ -689,14 +687,14 @@ TEST_CASE("app: link_user integration", "[sync][app]") {
 // MARK: - Delete User Tests
 
 TEST_CASE("app: delete anonymous user integration", "[sync][app]") {
-    TestSyncManager tsm(get_integration_config(), {});
-    auto app = tsm.app();
+    TestAppSession session;
+    auto app = session.app();
 
     SECTION("delete user expect success") {
-        CHECK(app->sync_manager()->all_users().size() == 0);
+        CHECK(app->sync_manager()->all_users().size() == 1);
 
         // Log in user 1
-        auto user_a = log_in(app);
+        auto user_a = app->current_user();
         CHECK(user_a->state() == SyncUser::State::LoggedIn);
         app->delete_user(user_a, [&](Optional<app::AppError> error) {
             REQUIRE_FALSE(error);
@@ -731,8 +729,9 @@ TEST_CASE("app: delete anonymous user integration", "[sync][app]") {
 }
 
 TEST_CASE("app: delete user with credentials integration", "[sync][app]") {
-    TestSyncManager tsm(get_integration_config(), {});
-    auto app = tsm.app();
+    TestAppSession session;
+    auto app = session.app();
+    app->remove_user(app->current_user(), [](auto) {});
 
     SECTION("log in and delete") {
         CHECK(app->sync_manager()->all_users().size() == 0);
@@ -771,10 +770,8 @@ TEST_CASE("app: delete user with credentials integration", "[sync][app]") {
 // MARK: - Call Function Tests
 
 TEST_CASE("app: call function", "[sync][app]") {
-    TestSyncManager sync_manager(get_integration_config(), {});
-    auto app = sync_manager.app();
-
-    create_user_and_log_in(app);
+    TestAppSession session;
+    auto app = session.app();
 
     bson::BsonArray toSum(5);
     std::iota(toSum.begin(), toSum.end(), static_cast<int64_t>(1));
@@ -789,10 +786,8 @@ TEST_CASE("app: call function", "[sync][app]") {
 // MARK: - Remote Mongo Client Tests
 
 TEST_CASE("app: remote mongo client", "[sync][app]") {
-    TestSyncManager sync_manager(get_integration_config(), {});
-    auto app = sync_manager.app();
-
-    create_user_and_log_in(app);
+    TestAppSession session;
+    auto app = session.app();
 
     auto remote_client = app->current_user()->mongo_client("BackingDB");
     auto db = remote_client.db(get_runtime_app_session("").config.mongo_dbname);
@@ -1412,10 +1407,8 @@ TEST_CASE("app: remote mongo client", "[sync][app]") {
 // MARK: - Push Notifications Tests
 
 TEST_CASE("app: push notifications", "[sync][app]") {
-    TestSyncManager sync_manager(get_integration_config(), {});
-    auto app = sync_manager.app();
-
-    create_user_and_log_in(app);
+    TestAppSession session;
+    auto app = session.app();
     std::shared_ptr<SyncUser> sync_user = app->current_user();
 
     SECTION("register") {
@@ -1496,10 +1489,8 @@ TEST_CASE("app: push notifications", "[sync][app]") {
 // MARK: - Token refresh
 
 TEST_CASE("app: token refresh", "[sync][app][token]") {
-    TestSyncManager sync_manager(get_integration_config(), {});
-    auto app = sync_manager.app();
-
-    create_user_and_log_in(app);
+    TestAppSession session;
+    auto app = session.app();
     std::shared_ptr<SyncUser> sync_user = app->current_user();
     sync_user->update_access_token(ENCODE_FAKE_JWT("fake_access_token"));
 
@@ -1549,12 +1540,8 @@ TEST_CASE("app: mixed lists with object links", "[sync][app]") {
 
     auto server_app_config = minimal_app_config(base_url, "set_new_embedded_object", schema);
     auto app_session = create_app(server_app_config);
-    auto app_config = get_config(instance_of<SynchronousTestTransport>, app_session);
     auto partition = random_string(100);
 
-    auto email = std::string("realm_tests_do_autoverify-test@example.com");
-    auto password = std::string{"password"};
-    auto creds = AppCredentials::username_password(email, password);
     auto obj_id = ObjectId::gen();
     auto target_id = ObjectId::gen();
     auto mixed_list_values = AnyVector{
@@ -1563,14 +1550,8 @@ TEST_CASE("app: mixed lists with object links", "[sync][app]") {
         Mixed{target_id},
     };
     {
-        TestSyncManager sync_manager(app_config, {});
-        auto app = sync_manager.app();
-        app->provider_client<App::UsernamePasswordProviderClient>().register_email(email, password,
-                                                                                   [&](Optional<AppError> error) {
-                                                                                       REQUIRE_FALSE(error);
-                                                                                   });
-        log_in(app, creds);
-        SyncTestFile config(app, partition, schema);
+        TestAppSession test_session(app_session, nullptr, DeleteApp{false});
+        SyncTestFile config(test_session.app(), partition, schema);
         auto realm = Realm::get_shared_realm(config);
 
         CppContext c(realm);
@@ -1591,11 +1572,8 @@ TEST_CASE("app: mixed lists with object links", "[sync][app]") {
     }
 
     {
-        TestSyncManager sync_manager(app_config, {});
-        auto app = sync_manager.app();
-        auto user = log_in(app, creds);
-
-        SyncTestFile config(app, partition, schema);
+        TestAppSession test_session(app_session);
+        SyncTestFile config(test_session.app(), partition, schema);
         auto realm = Realm::get_shared_realm(config);
 
         CHECK(!wait_for_download(*realm));
@@ -1631,8 +1609,6 @@ TEST_CASE("app: upgrade from local to synced realm", "[sync][app]") {
 
     /*             Create local realm             */
     TestFile local_config;
-    local_config.cache = true;
-    local_config.schema_version = 1;
     local_config.schema = schema;
     auto local_realm = Realm::get_shared_realm(local_config);
     {
@@ -1651,14 +1627,9 @@ TEST_CASE("app: upgrade from local to synced realm", "[sync][app]") {
 
     /* Create a synced realm and upload some data */
     auto server_app_config = minimal_app_config(base_url, "upgrade_from_local", schema);
-    auto app_session = create_app(server_app_config);
-    auto app_config = get_config(instance_of<SynchronousTestTransport>, app_session);
+    TestAppSession test_session(create_app(server_app_config));
     auto partition = random_string(100);
-    TestSyncManager sync_manager(app_config, {});
-    auto app = sync_manager.app();
-
-    create_user_and_log_in(app);
-    auto user1 = app->current_user();
+    auto user1 = test_session.app()->current_user();
     SyncTestFile config1(user1, partition, schema);
 
     auto r1 = Realm::get_shared_realm(config1);
@@ -1677,8 +1648,8 @@ TEST_CASE("app: upgrade from local to synced realm", "[sync][app]") {
     CHECK(!wait_for_upload(*r1));
 
     /* Copy local realm data over in a synced one*/
-    create_user_and_log_in(app);
-    auto user2 = app->current_user();
+    create_user_and_log_in(test_session.app());
+    auto user2 = test_session.app()->current_user();
     REQUIRE(user1 != user2);
 
     SyncTestFile config2(user1, partition, schema);
@@ -1743,31 +1714,15 @@ TEST_CASE("app: set new embedded object", "[sync][app]") {
     };
 
     auto server_app_config = minimal_app_config(base_url, "set_new_embedded_object", schema);
-    auto app_session = create_app(server_app_config);
-    auto app_config = get_config(instance_of<SynchronousTestTransport>, app_session);
+    TestAppSession test_session(create_app(server_app_config));
     auto partition = random_string(100);
 
     auto array_of_objs_id = ObjectId::gen();
     auto embedded_obj_id = ObjectId::gen();
     auto dict_obj_id = ObjectId::gen();
-    auto email = std::string("realm_tests_do_autoverify-test@example.com");
-    auto password = std::string{"password"};
-    auto creds = AppCredentials::username_password(email, password);
 
     {
-        TestSyncManager sync_manager(app_config, {});
-        auto app = sync_manager.app();
-        app->provider_client<App::UsernamePasswordProviderClient>().register_email(email, password,
-                                                                                   [&](Optional<AppError> error) {
-                                                                                       REQUIRE_FALSE(error);
-                                                                                   });
-        app->log_in_with_credentials(AppCredentials::username_password(email, password),
-                                     [&](std::shared_ptr<SyncUser> user, Optional<AppError> error) {
-                                         REQUIRE(user);
-                                         REQUIRE_FALSE(error);
-                                     });
-
-        SyncTestFile config(app, partition, schema);
+        SyncTestFile config(test_session.app(), partition, schema);
         auto realm = Realm::get_shared_realm(config);
 
         CppContext c(realm);
@@ -1827,10 +1782,7 @@ TEST_CASE("app: set new embedded object", "[sync][app]") {
     }
 
     {
-        TestSyncManager sync_manager(TestSyncManager::Config(app_config), {});
-        auto app = sync_manager.app();
-        log_in(app, creds);
-        SyncTestFile config(app, partition, schema);
+        SyncTestFile config(test_session.app(), partition, schema);
         auto realm = Realm::get_shared_realm(config);
 
         CHECK(!wait_for_download(*realm));
@@ -1869,7 +1821,6 @@ TEST_CASE("app: set new embedded object", "[sync][app]") {
 }
 
 TEST_CASE("app: make distributable client file", "[sync][app]") {
-    auto config = get_integration_config();
     auto base_path = util::make_temp_dir();
     util::try_remove_dir_recursive(base_path);
     util::try_make_dir(base_path);
@@ -1878,33 +1829,15 @@ TEST_CASE("app: make distributable client file", "[sync][app]") {
 
     // Create realm file without client file id
     {
-        TestSyncManager sync_manager(TestSyncManager::Config(config), {});
-        auto app = sync_manager.app();
-        app->log_in_with_credentials(AppCredentials::anonymous(),
-                                     [&](std::shared_ptr<SyncUser> user, Optional<AppError> error) {
-                                         REQUIRE(!error);
-                                         REQUIRE(user);
-                                     });
+        TestAppSession session;
+        auto app = session.app();
 
-        ThreadSafeReference realm_ref;
-
-        realm::Realm::Config realm_config;
-        realm_config.sync_config = std::make_shared<realm::SyncConfig>(app->current_user(), bson::Bson("foo"));
-        realm_config.schema_version = 1;
-        realm_config.path = base_path + "/orig/default.realm";
-
-        std::mutex mutex;
-        auto task = realm::Realm::get_synchronized_realm(realm_config);
-        task->start([&](ThreadSafeReference ref, std::exception_ptr error) {
-            std::lock_guard<std::mutex> lock(mutex);
-            REQUIRE(!error);
-            realm_ref = std::move(ref);
-        });
-        util::EventLoop::main().run_until([&] {
-            std::lock_guard<std::mutex> lock(mutex);
-            return bool(realm_ref);
-        });
-        SharedRealm realm = Realm::get_shared_realm(std::move(realm_ref));
+        Realm::Config config;
+        config.sync_config = std::make_shared<realm::SyncConfig>(app->current_user(), bson::Bson("foo"));
+        config.path = base_path + "/orig/default.realm";
+        config.schema = default_app_config("").schema;
+        config.schema_version = 0;
+        SharedRealm realm = Realm::get_shared_realm(std::move(config));
 
         // Write some data
         realm->begin_transaction();
@@ -1932,19 +1865,11 @@ TEST_CASE("app: make distributable client file", "[sync][app]") {
     }
     // Starting a new session based on the copy
     {
-        TestSyncManager sync_manager(TestSyncManager::Config(config), {});
-        auto app = sync_manager.app();
-        app->log_in_with_credentials(AppCredentials::anonymous(),
-                                     [&](std::shared_ptr<SyncUser> user, Optional<AppError> error) {
-                                         REQUIRE(!error);
-                                         REQUIRE(user);
-                                     });
-
-        ThreadSafeReference realm_ref;
+        TestAppSession session;
+        auto app = session.app();
 
         realm::Realm::Config realm_config;
         realm_config.sync_config = std::make_shared<realm::SyncConfig>(app->current_user(), bson::Bson("foo"));
-        realm_config.schema_version = 1;
         realm_config.path = base_path + "/copy/default.realm";
 
         SharedRealm realm = realm::Realm::get_shared_realm(realm_config);
@@ -1970,41 +1895,11 @@ constexpr size_t minus_25_percent(size_t val)
 }
 
 TEST_CASE("app: sync integration", "[sync][app]") {
-    const auto schema = Schema{{"Dog",
-                                {{"_id", PropertyType::ObjectId | PropertyType::Nullable, true},
-                                 {"breed", PropertyType::String | PropertyType::Nullable},
-                                 {"name", PropertyType::String}}},
-                               {"Person",
-                                {{"_id", PropertyType::ObjectId | PropertyType::Nullable, true},
-                                 {"age", PropertyType::Int},
-                                 {"dogs", PropertyType::Object | PropertyType::Array, "Dog"},
-                                 {"firstName", PropertyType::String},
-                                 {"lastName", PropertyType::String}}}};
+    const auto schema = default_app_config("").schema;
 
     auto get_dogs = [](SharedRealm r) -> Results {
-        auto& config = r->config();
-        auto session = config.sync_config->user->sync_manager()->get_existing_session(config.path);
-        std::atomic<bool> called{false};
-        session->wait_for_upload_completion([&](std::error_code err) {
-            REQUIRE(err == std::error_code{});
-            called.store(true);
-        });
-        timed_wait_for(
-            [&] {
-                return called.load();
-            },
-            std::chrono::milliseconds(10000));
-        REQUIRE(called);
-        called.store(false);
-        session->wait_for_download_completion([&](std::error_code err) {
-            REQUIRE(err == std::error_code{});
-            called.store(true);
-        });
-        timed_wait_for(
-            [&] {
-                return called.load();
-            },
-            std::chrono::milliseconds(10000));
+        wait_for_upload(*r, std::chrono::seconds(10));
+        wait_for_download(*r, std::chrono::seconds(10));
         return Results(r, r->read_group().get_table("class_Dog"));
     };
 
@@ -2019,15 +1914,13 @@ TEST_CASE("app: sync integration", "[sync][app]") {
         r->commit_transaction();
     };
 
-    auto app_config = get_integration_config();
+    TestAppSession session;
+    auto app = session.app();
     const auto partition = random_string(100);
 
     // MARK: Add Objects -
     SECTION("Add Objects") {
         {
-            TestSyncManager sync_manager(app_config, {});
-            auto app = sync_manager.app();
-            create_user_and_log_in(app);
             SyncTestFile config(app, partition, schema);
             auto r = Realm::get_shared_realm(config);
 
@@ -2037,8 +1930,6 @@ TEST_CASE("app: sync integration", "[sync][app]") {
         }
 
         {
-            TestSyncManager sync_manager(app_config, {});
-            auto app = sync_manager.app();
             create_user_and_log_in(app);
             SyncTestFile config(app, partition, schema);
             auto r = Realm::get_shared_realm(config);
@@ -2052,9 +1943,6 @@ TEST_CASE("app: sync integration", "[sync][app]") {
     // MARK: Expired Session Refresh -
     SECTION("Invalid Access Token is Refreshed") {
         {
-            TestSyncManager sync_manager(app_config, {});
-            auto app = sync_manager.app();
-            create_user_and_log_in(app);
             SyncTestFile config(app, partition, schema);
             auto r = Realm::get_shared_realm(config);
             REQUIRE(get_dogs(r).size() == 0);
@@ -2063,8 +1951,6 @@ TEST_CASE("app: sync integration", "[sync][app]") {
         }
 
         {
-            TestSyncManager sync_manager(app_config, {});
-            auto app = sync_manager.app();
             create_user_and_log_in(app);
             auto user = app->current_user();
             // set a bad access token. this will trigger a refresh when the sync session opens
@@ -2100,10 +1986,6 @@ TEST_CASE("app: sync integration", "[sync][app]") {
 
     SECTION("Fast clock on client") {
         {
-            TestSyncManager sync_manager(app_config, {});
-            auto app = sync_manager.app();
-            create_user_and_log_in(app);
-            std::shared_ptr<SyncUser> user = app->current_user();
             SyncTestFile config(app, partition, schema);
             auto r = Realm::get_shared_realm(config);
 
@@ -2113,11 +1995,8 @@ TEST_CASE("app: sync integration", "[sync][app]") {
         }
 
         auto transport = std::make_shared<HookedTransport>();
-        app_config.transport = transport;
-
-        TestSyncManager sync_manager(app_config, {});
-        auto app = sync_manager.app();
-        auto creds = create_user_and_log_in(app);
+        TestAppSession hooked_session(session.app_session(), transport, DeleteApp{false});
+        auto app = hooked_session.app();
         std::shared_ptr<SyncUser> user = app->current_user();
         REQUIRE(user);
         REQUIRE(!user->access_token_refresh_required());
@@ -2153,9 +2032,6 @@ TEST_CASE("app: sync integration", "[sync][app]") {
     SECTION("Expired Tokens") {
         sync::AccessToken token;
         {
-            TestSyncManager sync_manager(app_config, {});
-            auto app = sync_manager.app();
-            create_user_and_log_in(app);
             std::shared_ptr<SyncUser> user = app->current_user();
             SyncTestFile config(app, partition, schema);
             auto r = Realm::get_shared_realm(config);
@@ -2177,11 +2053,8 @@ TEST_CASE("app: sync integration", "[sync][app]") {
         }
 
         auto transport = std::make_shared<HookedTransport>();
-        app_config.transport = transport;
-
-        TestSyncManager sync_manager(app_config, {});
-        auto app = sync_manager.app();
-        auto creds = create_user_and_log_in(app);
+        TestAppSession hooked_session(session.app_session(), transport, DeleteApp{false});
+        auto app = hooked_session.app();
         std::shared_ptr<SyncUser> user = app->current_user();
         REQUIRE(user);
         REQUIRE(!user->access_token_refresh_required());
@@ -2288,7 +2161,7 @@ TEST_CASE("app: sync integration", "[sync][app]") {
     }
 
     SECTION("Invalid refresh token") {
-        auto app_session = get_runtime_app_session("");
+        auto& app_session = session.app_session();
         std::mutex mtx;
         auto verify_error_on_sync_with_invalid_refresh_token = [&](std::shared_ptr<SyncUser> user,
                                                                    Realm::Config config) {
@@ -2318,7 +2191,7 @@ TEST_CASE("app: sync integration", "[sync][app]") {
                 REQUIRE(error.message == "Unable to refresh the user access token.");
             };
 
-            auto transport = static_cast<SynchronousTestTransport*>(app_config.transport.get());
+            auto transport = static_cast<SynchronousTestTransport*>(session.transport());
             transport->block(); // don't let the token refresh happen until we're ready for it
             auto r = Realm::get_shared_realm(config);
             auto session = user->session_for_on_disk_path(config.path);
@@ -2348,9 +2221,7 @@ TEST_CASE("app: sync integration", "[sync][app]") {
         };
 
         SECTION("Disabled user results in a sync error") {
-            TestSyncManager sync_manager(app_config, {});
-            auto app = sync_manager.app();
-            auto creds = create_user_and_log_in(sync_manager.app());
+            auto creds = create_user_and_log_in(app);
             SyncTestFile config(app, partition, schema);
             auto user = app->current_user();
             REQUIRE(user);
@@ -2381,9 +2252,7 @@ TEST_CASE("app: sync integration", "[sync][app]") {
         }
 
         SECTION("Revoked refresh token results in a sync error") {
-            TestSyncManager sync_manager(app_config, {});
-            auto app = sync_manager.app();
-            auto creds = create_user_and_log_in(sync_manager.app());
+            auto creds = create_user_and_log_in(app);
             SyncTestFile config(app, partition, schema);
             auto user = app->current_user();
             REQUIRE(app_session.admin_api.verify_access_token(user->access_token(), app_session.server_app_id));
@@ -2415,8 +2284,7 @@ TEST_CASE("app: sync integration", "[sync][app]") {
         }
 
         SECTION("Revoked refresh token on an anonymous user results in a sync error") {
-            TestSyncManager sync_manager(app_config, {});
-            auto app = sync_manager.app();
+            app->current_user()->log_out();
             auto anon_user = log_in(app);
             REQUIRE(app->current_user() == anon_user);
             SyncTestFile config(app, partition, schema);
@@ -2449,8 +2317,6 @@ TEST_CASE("app: sync integration", "[sync][app]") {
         }
 
         SECTION("Opening a Realm with a removed email user results produces an exception") {
-            TestSyncManager sync_manager(app_config, {});
-            auto app = sync_manager.app();
             auto creds = create_user_and_log_in(app);
             auto email_user = app->current_user();
             const std::string user_ident = email_user->identity();
@@ -2490,9 +2356,6 @@ TEST_CASE("app: sync integration", "[sync][app]") {
     }
 
     SECTION("large write transactions which would be too large if batched") {
-        TestSyncManager sync_manager(TestSyncManager::Config{app_config});
-        auto app = sync_manager.app();
-        create_user_and_log_in(app);
         SyncTestFile config(app, partition, schema);
 
         std::mutex mutex;
@@ -2531,9 +2394,6 @@ TEST_CASE("app: sync integration", "[sync][app]") {
     }
 
     SECTION("too large sync message error handling") {
-        TestSyncManager sync_manager(TestSyncManager::Config{app_config});
-        auto app = sync_manager.app();
-        create_user_and_log_in(app);
         SyncTestFile config(app, partition, schema);
 
         std::mutex sync_error_mutex;
@@ -2572,9 +2432,6 @@ TEST_CASE("app: sync integration", "[sync][app]") {
     }
 
     SECTION("validation") {
-        TestSyncManager sync_manager(app_config, {});
-        auto app = sync_manager.app();
-        auto creds = create_user_and_log_in(sync_manager.app());
         SyncTestFile config(app, partition, schema);
 
         SECTION("invalid partition error handling") {
@@ -2621,16 +2478,13 @@ TEST_CASE("app: sync integration", "[sync][app]") {
 }
 
 TEST_CASE("app: custom user data integration tests", "[sync][app]") {
-    auto app_config = get_integration_config();
+    TestAppSession session;
+    auto app = session.app();
+    auto user = app->current_user();
 
     SECTION("custom user data happy path") {
-        TestSyncManager sync_manager(app_config);
-        auto app = sync_manager.app();
-
         bool processed = false;
-
-        std::shared_ptr<SyncUser> user = log_in(app);
-        app->call_function(user, "updateUserData", {bson::BsonDocument({{"favorite_color", "green"}})},
+        app->call_function("updateUserData", {bson::BsonDocument({{"favorite_color", "green"}})},
                            [&](auto response, auto error) {
                                CHECK(error == none);
                                CHECK(response);
@@ -2649,13 +2503,11 @@ TEST_CASE("app: custom user data integration tests", "[sync][app]") {
 }
 
 TEST_CASE("app: jwt login and metadata tests", "[sync][app]") {
-    auto app_config = get_integration_config();
-    auto jwt = create_jwt(app_config.app_id);
+    TestAppSession session;
+    auto app = session.app();
+    auto jwt = create_jwt(session.app()->config().app_id);
 
     SECTION("jwt happy path") {
-        TestSyncManager sync_manager(app_config);
-        auto app = sync_manager.app();
-
         bool processed = false;
 
         std::shared_ptr<SyncUser> user = log_in(app, AppCredentials::custom(jwt));
@@ -2700,10 +2552,7 @@ TEMPLATE_TEST_CASE("app: collections of links integration", "[sync][app][collect
                           {"realm_id", PropertyType::String | PropertyType::Nullable},
                       }}};
     auto server_app_config = minimal_app_config(base_url, "collections_of_links", schema);
-    auto app_session = create_app(server_app_config);
-    auto app_config = get_config(instance_of<SynchronousTestTransport>, app_session);
-    TestSyncManager sync_manager({app_config, &app_session});
-    auto app = sync_manager.app();
+    TestAppSession test_session(create_app(server_app_config));
 
     auto wait_for_num_objects_to_equal = [](realm::SharedRealm r, const std::string& table_name, size_t count) {
         timed_sleeping_wait_for([&]() -> bool {
@@ -2755,12 +2604,12 @@ TEMPLATE_TEST_CASE("app: collections of links integration", "[sync][app][collect
     };
 
     SECTION("integration testing") {
-        create_user_and_log_in(sync_manager.app());
+        auto app = test_session.app();
         SyncTestFile config1(app, partition, schema); // uses the current user created above
         auto r1 = realm::Realm::get_shared_realm(config1);
         Results r1_source_objs = realm::Results(r1, r1->read_group().get_table("class_source"));
 
-        create_user_and_log_in(sync_manager.app());
+        create_user_and_log_in(app);
         SyncTestFile config2(app, partition, schema); // uses the user created above
         auto r2 = realm::Realm::get_shared_realm(config2);
         Results r2_source_objs = realm::Results(r2, r2->read_group().get_table("class_source"));
@@ -2852,10 +2701,8 @@ TEMPLATE_TEST_CASE("app: partition types", "[sync][app][partition]", cf::Int, cf
                       }}};
     auto server_app_config = minimal_app_config(base_url, "partition_types_app_name", schema);
     server_app_config.partition_key = partition_property;
-    auto app_session = create_app(server_app_config);
-    auto app_config = get_config(instance_of<SynchronousTestTransport>, app_session);
-    TestSyncManager sync_manager({app_config, &app_session});
-    auto app = sync_manager.app();
+    TestAppSession test_session(create_app(server_app_config));
+    auto app = test_session.app();
 
     auto wait_for_num_objects_to_equal = [](realm::SharedRealm r, const std::string& table_name, size_t count) {
         timed_sleeping_wait_for([&]() -> bool {
@@ -2890,9 +2737,8 @@ TEMPLATE_TEST_CASE("app: partition types", "[sync][app][partition]", cf::Int, cf
 
     SECTION("can round trip an object") {
         auto values = TestType::values();
-        create_user_and_log_in(sync_manager.app());
         auto user1 = app->current_user();
-        create_user_and_log_in(sync_manager.app());
+        create_user_and_log_in(app);
         auto user2 = app->current_user();
         REQUIRE(user1);
         REQUIRE(user2);
@@ -2948,9 +2794,10 @@ TEST_CASE("app: custom error handling", "[sync][app][custom_errors]") {
     };
 
     SECTION("custom code and message is sent back") {
-        TestSyncManager tsm(get_config(std::make_shared<CustomErrorTransport>(1001, "Boom!")), {});
-        auto app = tsm.app();
-        auto error = failed_log_in(app);
+        TestSyncManager::Config config;
+        config.transport = std::make_shared<CustomErrorTransport>(1001, "Boom!");
+        TestSyncManager tsm(config);
+        auto error = failed_log_in(tsm.app());
         CHECK(error.is_custom_error());
         CHECK(error.error_code.value() == 1001);
         CHECK(error.message == "Boom!");
@@ -3045,11 +2892,11 @@ private:
         CHECK(request.headers.at("Content-Type") == "application/json;charset=utf-8");
         CHECK(nlohmann::json::parse(request.body)["options"] ==
               nlohmann::json({{"device",
-                               {{"appId", "app name"},
+                               {{"appId", "app_id"},
                                 {"appVersion", "A Local App Version"},
-                                {"platform", "Object Store Platform Tests"},
-                                {"platformVersion", "Object Store Platform Version Blah"},
-                                {"sdkVersion", "An sdk version"}}}}));
+                                {"platform", "Object Store Test Platform"},
+                                {"platformVersion", "Object Store Test Platform Version"},
+                                {"sdkVersion", "SDK Version"}}}}));
 
         CHECK(request.timeout_ms == 60000);
 
@@ -3169,7 +3016,7 @@ public:
     }
 };
 
-App::Config get_config()
+TestSyncManager::Config get_config()
 {
     return get_config(instance_of<UnitTestTransport>);
 }
@@ -3269,16 +3116,14 @@ TEST_CASE("subscribable unit tests", "[sync][app]") {
 }
 
 TEST_CASE("app: login_with_credentials unit_tests", "[sync][app]") {
+    auto config = get_config();
+
     SECTION("login_anonymous good") {
         UnitTestTransport::access_token = good_access_token;
-
-        auto config = get_config();
-        auto base_path = util::make_temp_dir();
+        config.base_path = util::make_temp_dir();
+        config.should_teardown_test_directory = false;
         {
-            auto conf = TestSyncManager::Config(config);
-            conf.should_teardown_test_directory = false;
-            conf.base_path = base_path;
-            TestSyncManager tsm(conf, {});
+            TestSyncManager tsm(config);
             auto app = tsm.app();
 
             auto user = log_in(app);
@@ -3301,9 +3146,7 @@ TEST_CASE("app: login_with_credentials unit_tests", "[sync][app]") {
         App::clear_cached_apps();
         // assert everything is stored properly between runs
         {
-            auto conf = TestSyncManager::Config(config);
-            conf.base_path = base_path;
-            TestSyncManager tsm(conf, {});
+            TestSyncManager tsm(config);
             auto app = tsm.app();
             REQUIRE(app->all_users().size() == 1);
             auto user = app->all_users()[0];
@@ -3338,10 +3181,9 @@ TEST_CASE("app: login_with_credentials unit_tests", "[sync][app]") {
             }
         };
 
-        TestSyncManager tsm(get_config(instance_of<transport>), {});
-        auto app = tsm.app();
-
-        auto error = failed_log_in(app);
+        config.transport = instance_of<transport>;
+        TestSyncManager tsm(config);
+        auto error = failed_log_in(tsm.app());
         CHECK(error.message == std::string("jwt missing parts"));
         CHECK(error.error_code.message() == "bad token");
         CHECK(error.error_code.category() == json_error_category());
@@ -3551,7 +3393,7 @@ TEST_CASE("app: response error handling", "[sync][app]") {
 
     Response response{200, 0, {{"Content-Type", "application/json"}}, response_body};
 
-    TestSyncManager tsm(get_config(std::make_shared<ErrorCheckingTransport>(&response)), {});
+    TestSyncManager tsm(get_config(std::make_shared<ErrorCheckingTransport>(&response)));
     auto app = tsm.app();
 
     SECTION("http 404") {
@@ -4275,13 +4117,14 @@ TEST_CASE("app: metadata is persisted between sessions", "[sync][app]") {
         app->log_in_with_credentials(AppCredentials::anonymous(), [](auto, auto error) {
             REQUIRE_FALSE(error);
         });
+        REQUIRE(app->sync_manager()->sync_route().rfind(test_ws_hostname, 0) != std::string::npos);
     }
 
     App::clear_cached_apps();
     config.override_sync_route = false;
     config.should_teardown_test_directory = true;
     {
-        TestSyncManager sync_manager(config, {});
+        TestSyncManager sync_manager(config);
         auto app = sync_manager.app();
         REQUIRE(app->sync_manager()->sync_route().rfind(test_ws_hostname, 0) != std::string::npos);
         app->call_function("function", {}, [](auto error, auto) {
@@ -4295,15 +4138,15 @@ TEST_CASE("app: make_streaming_request", "[sync][app]") {
 
     constexpr uint64_t timeout_ms = 60000;
     auto config = get_config();
-    config.default_request_timeout_ms = timeout_ms;
-    TestSyncManager tsm(TestSyncManager::Config(config), {});
+    config.app_config.default_request_timeout_ms = timeout_ms;
+    TestSyncManager tsm(config);
     auto app = tsm.app();
 
     std::shared_ptr<SyncUser> user = log_in(app);
 
     using Headers = decltype(Request().headers);
 
-    const auto url_prefix = "field/api/client/v2.0/app/app name/functions/call?baas_request="sv;
+    const auto url_prefix = "field/api/client/v2.0/app/app_id/functions/call?baas_request="sv;
     const auto get_request_args = [&](const Request& req) {
         REQUIRE(req.url.substr(0, url_prefix.size()) == url_prefix);
         auto args = req.url.substr(url_prefix.size());

--- a/test/object-store/sync/app.cpp
+++ b/test/object-store/sync/app.cpp
@@ -115,7 +115,7 @@ static std::string HMAC_SHA256(std::string_view key, std::string_view data)
 #endif
 }
 
-std::string create_jwt(const std::string appId)
+static std::string create_jwt(const std::string& appId)
 {
     nlohmann::json header = {{"alg", "HS256"}, {"typ", "JWT"}};
     nlohmann::json payload = {{"aud", appId}, {"sub", "someUserId"}, {"exp", 1661896476}};
@@ -3016,7 +3016,7 @@ public:
     }
 };
 
-TestSyncManager::Config get_config()
+static TestSyncManager::Config get_config()
 {
     return get_config(instance_of<UnitTestTransport>);
 }

--- a/test/object-store/sync/client_reset.cpp
+++ b/test/object-store/sync/client_reset.cpp
@@ -77,16 +77,22 @@ struct StringMaker<ThreadSafeSyncError> {
 };
 } // namespace Catch
 
-namespace realm {
-struct PartitionPair {
-    std::string property_name;
-    std::string value;
-};
+using namespace realm;
 
+namespace {
 TableRef get_table(Realm& realm, StringData object_type)
 {
     return ObjectStore::table_for_object_type(realm.read_group(), object_type);
 }
+} // anonymous namespace
+
+#if REALM_ENABLE_AUTH_TESTS
+
+namespace {
+struct PartitionPair {
+    std::string property_name;
+    std::string value;
+};
 
 Obj create_object(Realm& realm, StringData object_type, PartitionPair partition,
                   util::Optional<int64_t> primary_key = util::none)
@@ -97,8 +103,7 @@ Obj create_object(Realm& realm, StringData object_type, PartitionPair partition,
     FieldValues values = {{table->get_column_key(partition.property_name), partition.value}};
     return table->create_object_with_primary_key(primary_key ? *primary_key : pk++, std::move(values));
 }
-
-#if REALM_ENABLE_AUTH_TESTS
+} // anonymous namespace
 
 TEST_CASE("sync: client reset", "[client reset]") {
     if (!util::EventLoop::has_implementation())
@@ -2074,5 +2079,3 @@ TEST_CASE("client reset with embedded object", "[client reset][discard local][em
                                                "{EmbeddedObject, EmbeddedObject2, TopLevel}");
     }
 }
-
-} // namespace realm

--- a/test/object-store/sync/client_reset.cpp
+++ b/test/object-store/sync/client_reset.cpp
@@ -139,11 +139,8 @@ TEST_CASE("sync: client reset", "[client reset]") {
     REQUIRE(!base_url.empty());
     auto server_app_config = minimal_app_config(base_url, "client_reset_tests", schema);
     server_app_config.partition_key = partition_prop;
-    AppSession app_session = create_app(server_app_config);
-    auto app_config = get_config(instance_of<SynchronousTestTransport>, app_session);
-
-    TestSyncManager sync_manager(TestSyncManager::Config(app_config, &app_session), {});
-    auto app = sync_manager.app();
+    TestAppSession test_app_session(create_app(server_app_config));
+    auto app = test_app_session.app();
     auto get_valid_config = [&]() -> SyncTestFile {
         create_user_and_log_in(app);
         return SyncTestFile(app->current_user(), partition.value, schema);
@@ -152,7 +149,7 @@ TEST_CASE("sync: client reset", "[client reset]") {
     SyncTestFile remote_config = get_valid_config();
     auto make_reset = [&](Realm::Config config_local,
                           Realm::Config config_remote) -> std::unique_ptr<reset_utils::TestClientReset> {
-        return reset_utils::make_baas_client_reset(config_local, config_remote, sync_manager);
+        return reset_utils::make_baas_client_reset(config_local, config_remote, test_app_session);
     };
 
     // this is just for ease of debugging
@@ -174,7 +171,7 @@ TEST_CASE("sync: client reset", "[client reset]") {
             recovery_path = recovery_path_it->second;
             REQUIRE(util::File::exists(orig_path));
             REQUIRE(!util::File::exists(recovery_path));
-            bool did_reset_files = sync_manager.app()->sync_manager()->immediately_run_file_actions(orig_path);
+            bool did_reset_files = test_app_session.app()->sync_manager()->immediately_run_file_actions(orig_path);
             REQUIRE(did_reset_files);
             REQUIRE(!util::File::exists(orig_path));
             REQUIRE(util::File::exists(recovery_path));
@@ -386,7 +383,7 @@ TEST_CASE("sync: client reset", "[client reset]") {
                 auto realm = Realm::get_shared_realm(temp_config);
                 wait_for_download(*realm);
 
-                session = sync_manager.app()->sync_manager()->get_existing_session(temp_config.path);
+                session = test_app_session.app()->sync_manager()->get_existing_session(temp_config.path);
                 REQUIRE(session);
             }
             realm::SyncError synthetic(sync::make_error_code(sync::ProtocolError::bad_client_file),
@@ -437,7 +434,7 @@ TEST_CASE("sync: client reset", "[client reset]") {
                     },
                     std::chrono::seconds(20));
             }
-            auto session = sync_manager.app()->sync_manager()->get_existing_session(local_config.path);
+            auto session = test_app_session.app()->sync_manager()->get_existing_session(local_config.path);
             if (session) {
                 session->shutdown_and_wait();
             }

--- a/test/object-store/sync/sync_manager.cpp
+++ b/test/object-store/sync/sync_manager.cpp
@@ -464,13 +464,13 @@ TEST_CASE("sync_manager: file actions", "[sync]") {
     using Action = SyncFileActionMetadata::Action;
     reset_test_directory(base_path.string());
 
-    auto file_manager = SyncFileManager(base_path, "bar_app_id");
+    auto file_manager = SyncFileManager(base_path.string(), "bar_app_id");
     // Open the metadata separately, so we can investigate it ourselves.
     SyncMetadataManager manager(file_manager.metadata_path(), false);
 
     TestSyncManager::Config config;
     config.app_config.app_id = "bar_app_id";
-    config.base_path = base_path;
+    config.base_path = base_path.string();
     config.metadata_mode = SyncManager::MetadataMode::NoEncryption;
     config.should_teardown_test_directory = false;
 
@@ -650,7 +650,7 @@ TEST_CASE("sync_manager: file actions", "[sync]") {
         }
 
         SECTION("should change the action to delete if copy succeeds but delete fails") {
-            if (!chmod_supported(base_path)) {
+            if (!chmod_supported(base_path.string())) {
                 return;
             }
             // Create some Realms

--- a/test/object-store/sync/sync_manager.cpp
+++ b/test/object-store/sync/sync_manager.cpp
@@ -339,7 +339,7 @@ TEST_CASE("sync_manager: persistent user state management", "[sync]") {
     }
 
     struct TestPath {
-        std::string partition;
+        bson::Bson partition;
         std::string expected_path;
         bool pre_create = true;
     };
@@ -359,10 +359,11 @@ TEST_CASE("sync_manager: persistent user state management", "[sync]") {
         auto u3 = manager.get_or_make_user_metadata(identity_3, provider_type);
 
         {
-            auto expected_u1_path = [&](std::string partition) {
-                return ExpectedRealmPaths(tsm.base_file_path(), app_id, u1->identity(), u1->local_uuid(), partition);
+            auto expected_u1_path = [&](const bson::Bson& partition) {
+                return ExpectedRealmPaths(tsm.base_file_path(), app_id, u1->identity(), u1->local_uuid(),
+                                          partition.to_string());
             };
-            std::string partition = "partition1";
+            bson::Bson partition = "partition1";
             auto expected_paths = expected_u1_path(partition);
             paths_under_test.push_back({partition, expected_paths.current_preferred_path, false});
 
@@ -407,15 +408,15 @@ TEST_CASE("sync_manager: persistent user state management", "[sync]") {
                 }
             }
 
-            paths = {sync_manager->path_for_realm(SyncConfig{user1, "123456789"}),
-                     sync_manager->path_for_realm(SyncConfig{user1, "foo"}),
-                     sync_manager->path_for_realm(SyncConfig{user2, "partition"}, {"123456789"}),
-                     sync_manager->path_for_realm(SyncConfig{user3, "foo"}),
-                     sync_manager->path_for_realm(SyncConfig{user3, "bar"}),
-                     sync_manager->path_for_realm(SyncConfig{user3, "baz"})};
+            paths = {sync_manager->path_for_realm(SyncConfig{user1, bson::Bson("123456789")}),
+                     sync_manager->path_for_realm(SyncConfig{user1, bson::Bson("foo")}),
+                     sync_manager->path_for_realm(SyncConfig{user2, bson::Bson("partition")}, {"123456789"}),
+                     sync_manager->path_for_realm(SyncConfig{user3, bson::Bson("foo")}),
+                     sync_manager->path_for_realm(SyncConfig{user3, bson::Bson("bar")}),
+                     sync_manager->path_for_realm(SyncConfig{user3, bson::Bson("baz")})};
 
             for (auto& test : paths_under_test) {
-                std::string actual = tsm.app()->sync_manager()->path_for_realm(SyncConfig{user1, test.partition});
+                std::string actual = sync_manager->path_for_realm(SyncConfig{user1, test.partition});
                 REQUIRE(actual == test.expected_path);
                 paths.push_back(actual);
             }

--- a/test/object-store/sync/sync_manager.cpp
+++ b/test/object-store/sync/sync_manager.cpp
@@ -32,8 +32,7 @@ using namespace realm;
 using namespace realm::util;
 using File = realm::util::File;
 
-static const std::string base_path =
-    fs::path{util::make_temp_dir() + "/realm_objectstore_sync_manager"}.make_preferred().string();
+static const auto base_path = fs::path{util::make_temp_dir()}.make_preferred() / "realm_objectstore_sync_manager";
 static const std::string dummy_device_id = "123400000000000000000000";
 
 namespace {
@@ -71,150 +70,117 @@ TEST_CASE("sync_manager: basic properties and APIs", "[sync]") {
 TEST_CASE("sync_manager: `path_for_realm` API", "[sync]") {
     const std::string auth_server_url = "https://realm.example.org";
     const std::string raw_url = "realms://realm.example.org/a/b/~/123456/xyz";
-    using Cfg = TestSyncManager::Config;
-
-    // Get a sync user
-    TestSyncManager init_sync_manager(Cfg(base_path, SyncManager::MetadataMode::NoMetadata));
-    auto sync_manager = init_sync_manager.app()->sync_manager();
-    const std::string identity = "foobarbaz";
-    auto user = sync_manager->get_user(identity, ENCODE_FAKE_JWT("dummy_token"), ENCODE_FAKE_JWT("not_a_real_token"),
-                                       auth_server_url, dummy_device_id);
-    auto server_identity = user->identity();
-    REQUIRE(server_identity == identity);
 
     SECTION("should work properly without metadata") {
-        TestSyncManager init_sync_manager(Cfg(base_path, SyncManager::MetadataMode::NoMetadata));
-        const auto expected =
-            fs::path{
-                base_path +
-                "/mongodb-realm/app_id/foobarbaz/realms%3A%2F%2Frealm.example.org%2Fa%2Fb%2F%7E%2F123456%2Fxyz.realm"}
-                .make_preferred()
-                .string();
-        auto user = init_sync_manager.app()->sync_manager()->get_user(identity, ENCODE_FAKE_JWT("dummy_token"),
-                                                                      ENCODE_FAKE_JWT("not_a_real_token"),
-                                                                      auth_server_url, dummy_device_id);
+        TestSyncManager tsm(SyncManager::MetadataMode::NoMetadata);
+        auto sync_manager = tsm.app()->sync_manager();
+        const std::string identity = random_string(10);
+        auto base_path = fs::path{tsm.base_file_path()}.make_preferred() / "mongodb-realm" / "app_id" / identity;
+        const auto expected = base_path / "realms%3A%2F%2Frealm.example.org%2Fa%2Fb%2F%7E%2F123456%2Fxyz.realm";
+        auto user = tsm.app()->sync_manager()->get_user(identity, ENCODE_FAKE_JWT("dummy_token"),
+                                                        ENCODE_FAKE_JWT("not_a_real_token"), auth_server_url,
+                                                        dummy_device_id);
+        REQUIRE(user->identity() == identity);
         SyncConfig config(user, bson::Bson{});
-        REQUIRE(init_sync_manager.app()->sync_manager()->path_for_realm(config, raw_url) == expected);
+        REQUIRE(tsm.app()->sync_manager()->path_for_realm(config, raw_url) == expected);
         // This API should also generate the directory if it doesn't already exist.
-        REQUIRE_DIR_EXISTS(fs::path{base_path + "/mongodb-realm/app_id/foobarbaz"}.make_preferred().string());
+        REQUIRE_DIR_PATH_EXISTS(base_path);
     }
 
     SECTION("should work properly with metadata") {
-        TestSyncManager init_sync_manager(Cfg(base_path, SyncManager::MetadataMode::NoEncryption));
-        const auto expected = fs::path{base_path + "/mongodb-realm/app_id/" + server_identity +
-                                       "/realms%3A%2F%2Frealm.example.org%2Fa%2Fb%2F%7E%2F123456%2Fxyz.realm"}
-                                  .make_preferred()
-                                  .string();
+        TestSyncManager tsm(SyncManager::MetadataMode::NoEncryption);
+        auto sync_manager = tsm.app()->sync_manager();
+        const std::string identity = random_string(10);
+        auto base_path = fs::path{tsm.base_file_path()}.make_preferred() / "mongodb-realm" / "app_id" / identity;
+        const auto expected = base_path / "realms%3A%2F%2Frealm.example.org%2Fa%2Fb%2F%7E%2F123456%2Fxyz.realm";
+        auto user = tsm.app()->sync_manager()->get_user(identity, ENCODE_FAKE_JWT("dummy_token"),
+                                                        ENCODE_FAKE_JWT("not_a_real_token"), auth_server_url,
+                                                        dummy_device_id);
+        REQUIRE(user->identity() == identity);
         SyncConfig config(user, bson::Bson{});
-        REQUIRE(init_sync_manager.app()->sync_manager()->path_for_realm(config, raw_url) == expected);
-
+        REQUIRE(tsm.app()->sync_manager()->path_for_realm(config, raw_url) == expected);
         // This API should also generate the directory if it doesn't already exist.
-        REQUIRE_DIR_EXISTS(
-            fs::path{base_path + "/mongodb-realm/app_id/" + server_identity}.make_preferred().string());
+        REQUIRE_DIR_PATH_EXISTS(base_path);
     }
 
-    SECTION("should produce the expected path for a string partition") {
-        TestSyncManager init_sync_manager(Cfg(base_path, SyncManager::MetadataMode::NoMetadata));
-        const bson::Bson partition("string-partition-value&^#");
-        SyncConfig config(user, partition);
-        const auto expected =
-            fs::path(base_path + "/mongodb-realm/app_id/foobarbaz/s_string-partition-value%26%5E%23.realm")
-                .make_preferred()
-                .string();
-        REQUIRE(init_sync_manager.app()->sync_manager()->path_for_realm(config) == expected);
-        // This API should also generate the directory if it doesn't already exist.
-        REQUIRE_DIR_EXISTS(fs::path{base_path + "/mongodb-realm/app_id/foobarbaz"}.make_preferred().string());
-    }
+    SECTION("should produce the expected path for all partition key types") {
+        TestSyncManager tsm(SyncManager::MetadataMode::NoMetadata);
+        auto sync_manager = tsm.app()->sync_manager();
+        const std::string identity = random_string(10);
+        auto base_path = fs::path{tsm.base_file_path()}.make_preferred() / "mongodb-realm" / "app_id" / identity;
+        auto user = tsm.app()->sync_manager()->get_user(identity, ENCODE_FAKE_JWT("dummy_token"),
+                                                        ENCODE_FAKE_JWT("not_a_real_token"), auth_server_url,
+                                                        dummy_device_id);
 
-    SECTION("should produce a hashed path for string partitions which exceed file system path length limits") {
-        TestSyncManager init_sync_manager(Cfg(base_path, SyncManager::MetadataMode::NoMetadata));
-        const std::string name_too_long(500, 'b');
-        REQUIRE(name_too_long.length() == 500);
-        const bson::Bson partition(name_too_long);
-        SyncConfig config(user, partition);
-        const std::string expected_prefix = fs::path{base_path + "/mongodb-realm/app_id"}.make_preferred().string();
-        const std::string expected_suffix = ".realm";
-        std::string actual = init_sync_manager.app()->sync_manager()->path_for_realm(config);
-        size_t expected_length = expected_prefix.length() + 64 + expected_suffix.length();
-        // std::fs does not include path terminator
-        REQUIRE(actual.length() == 1 + expected_length);
-        REQUIRE(actual.find(expected_prefix) == 0);
-        REQUIRE(actual.find(expected_suffix) != std::string::npos);
-    }
+        // Directory should not be created until we get the path
+        REQUIRE_DIR_PATH_DOES_NOT_EXIST(base_path);
 
-    SECTION("should produce the expected path for a int32 partition") {
-        TestSyncManager init_sync_manager(Cfg(base_path, SyncManager::MetadataMode::NoMetadata));
-        const bson::Bson partition(int32_t(-25));
-        SyncConfig config(user, partition);
-        const auto expected =
-            fs::path{base_path + "/mongodb-realm/app_id/foobarbaz/i_-25.realm"}.make_preferred().string();
-        REQUIRE(init_sync_manager.app()->sync_manager()->path_for_realm(config) == expected);
-        // This API should also generate the directory if it doesn't already exist.
-        REQUIRE_DIR_EXISTS(fs::path{base_path + "/mongodb-realm/app_id/foobarbaz"}.make_preferred().string());
-    }
+        SECTION("string") {
+            const bson::Bson partition("string-partition-value&^#");
+            SyncConfig config(user, partition);
+            REQUIRE(sync_manager->path_for_realm(config) == base_path / "s_string-partition-value%26%5E%23.realm");
+        }
 
-    SECTION("should produce the expected path for a int64 partition") {
-        TestSyncManager init_sync_manager(Cfg(base_path, SyncManager::MetadataMode::NoMetadata));
-        const bson::Bson partition(int64_t(1.15e18)); // > 32 bits
-        SyncConfig config(user, partition);
-        const auto expected = fs::path{base_path + "/mongodb-realm/app_id/foobarbaz/l_1150000000000000000.realm"}
-                                  .make_preferred()
-                                  .string();
-        REQUIRE(init_sync_manager.app()->sync_manager()->path_for_realm(config) == expected);
-        // This API should also generate the directory if it doesn't already exist.
-        REQUIRE_DIR_EXISTS(fs::path{base_path + "/mongodb-realm/app_id/foobarbaz"}.make_preferred().string());
-    }
+        SECTION("string which exeecds the file system path length limit") {
+            const std::string name_too_long(500, 'b');
+            REQUIRE(name_too_long.length() == 500);
+            const bson::Bson partition(name_too_long);
+            SyncConfig config(user, partition);
 
-    SECTION("should produce the expected path for a ObjectId partition") {
-        TestSyncManager init_sync_manager(Cfg(base_path, SyncManager::MetadataMode::NoMetadata));
-        const bson::Bson partition(ObjectId("0123456789abcdefffffffff"));
-        SyncConfig config(user, partition);
-        const auto expected = fs::path{base_path + "/mongodb-realm/app_id/foobarbaz/o_0123456789abcdefffffffff.realm"}
-                                  .make_preferred()
-                                  .string();
-        REQUIRE(init_sync_manager.app()->sync_manager()->path_for_realm(config) == expected);
-        // This API should also generate the directory if it doesn't already exist.
-        REQUIRE_DIR_EXISTS(fs::path(base_path + "/mongodb-realm/app_id/foobarbaz").make_preferred().string());
-    }
+            // Note: does not include `identity` as that's in the hashed part
+            auto base_path = fs::path{tsm.base_file_path()}.make_preferred() / "mongodb-realm" / "app_id";
+            const std::string expected_suffix = ".realm";
+            std::string actual = sync_manager->path_for_realm(config);
+            size_t expected_length = base_path.string().length() + 1 + 64 + expected_suffix.length();
+            REQUIRE(actual.length() == expected_length);
+            REQUIRE(StringData(actual).begins_with(base_path.string()));
+            REQUIRE(StringData(actual).ends_with(expected_suffix));
+        }
 
-    SECTION("should produce the expected path for a UUID partition") {
-        TestSyncManager init_sync_manager(Cfg(base_path, SyncManager::MetadataMode::NoMetadata));
-        const bson::Bson partition(UUID("3b241101-e2bb-4255-8caf-4136c566a961"));
-        SyncConfig config(user, partition);
-        const auto expected =
-            fs::path{base_path + "/mongodb-realm/app_id/foobarbaz/u_3b241101-e2bb-4255-8caf-4136c566a961.realm"}
-                .make_preferred()
-                .string();
-        REQUIRE(init_sync_manager.app()->sync_manager()->path_for_realm(config) == expected);
-        // This API should also generate the directory if it doesn't already exist.
-        REQUIRE_DIR_EXISTS(fs::path{base_path + "/mongodb-realm/app_id/foobarbaz"}.make_preferred().string());
-    }
+        SECTION("int32") {
+            const bson::Bson partition(int32_t(-25));
+            SyncConfig config(user, partition);
+            REQUIRE(sync_manager->path_for_realm(config) == base_path / "i_-25.realm");
+        }
 
-    SECTION("should produce the expected path for a Null partition") {
-        TestSyncManager init_sync_manager(Cfg(base_path, SyncManager::MetadataMode::NoMetadata));
-        const bson::Bson partition;
-        REQUIRE(partition.type() == bson::Bson::Type::Null);
-        SyncConfig config(user, partition);
-        const auto expected =
-            fs::path{base_path + "/mongodb-realm/app_id/foobarbaz/null.realm"}.make_preferred().string();
-        REQUIRE(init_sync_manager.app()->sync_manager()->path_for_realm(config) == expected);
-        // This API should also generate the directory if it doesn't already exist.
-        REQUIRE_DIR_EXISTS(fs::path{base_path + "/mongodb-realm/app_id/foobarbaz"}.make_preferred().string());
-    }
+        SECTION("int64") {
+            const bson::Bson partition(int64_t(1.15e18)); // > 32 bits
+            SyncConfig config(user, partition);
+            REQUIRE(sync_manager->path_for_realm(config) == base_path / "l_1150000000000000000.realm");
+        }
 
-    SECTION("should produce the FLX sync path when FLX sync is enabled") {
-        TestSyncManager init_sync_manager(Cfg(base_path, SyncManager::MetadataMode::NoMetadata));
-        SyncConfig config(user, SyncConfig::FLXSyncEnabled{});
-        const auto expected =
-            fs::path{base_path + "/mongodb-realm/app_id/foobarbaz/flx_sync_default.realm"}.make_preferred().string();
-        REQUIRE(init_sync_manager.app()->sync_manager()->path_for_realm(config) == expected);
-        // This API should also generate the directory if it doesn't already exist.
-        REQUIRE_DIR_EXISTS(fs::path{base_path + "/mongodb-realm/app_id/foobarbaz"}.make_preferred().string());
+        SECTION("UUID") {
+            const bson::Bson partition(UUID("3b241101-e2bb-4255-8caf-4136c566a961"));
+            SyncConfig config(user, partition);
+            REQUIRE(sync_manager->path_for_realm(config) ==
+                    base_path / "u_3b241101-e2bb-4255-8caf-4136c566a961.realm");
+        }
+
+        SECTION("ObjectId") {
+            const bson::Bson partition(ObjectId("0123456789abcdefffffffff"));
+            SyncConfig config(user, partition);
+            REQUIRE(sync_manager->path_for_realm(config) == base_path / "o_0123456789abcdefffffffff.realm");
+        }
+
+        SECTION("Null") {
+            const bson::Bson partition;
+            REQUIRE(partition.type() == bson::Bson::Type::Null);
+            SyncConfig config(user, partition);
+            REQUIRE(sync_manager->path_for_realm(config) == base_path / "null.realm");
+        }
+
+        SECTION("Flexible sync") {
+            SyncConfig config(user, SyncConfig::FLXSyncEnabled{});
+            REQUIRE(sync_manager->path_for_realm(config) == base_path / "flx_sync_default.realm");
+        }
+
+        // Should now exist after getting the path
+        REQUIRE_DIR_PATH_EXISTS(base_path);
     }
 }
 
 TEST_CASE("sync_manager: user state management", "[sync]") {
-    TestSyncManager init_sync_manager(TestSyncManager::Config(base_path, SyncManager::MetadataMode::NoEncryption));
+    TestSyncManager init_sync_manager(SyncManager::MetadataMode::NoEncryption);
     auto sync_manager = init_sync_manager.app()->sync_manager();
 
     const std::string url_1 = "https://realm.example.org/1/";
@@ -313,13 +279,15 @@ TEST_CASE("sync_manager: user state management", "[sync]") {
 }
 
 TEST_CASE("sync_manager: persistent user state management", "[sync]") {
-
-    reset_test_directory(base_path);
-    const std::string app_id = "test_app_id*$#@!%1";
-    auto file_manager = SyncFileManager(base_path, app_id);
+    TestSyncManager::Config config;
+    auto app_id = config.app_config.app_id = "app_id-" + random_string(10);
+    config.metadata_mode = SyncManager::MetadataMode::NoEncryption;
+    TestSyncManager tsm(config);
+    config.base_path = tsm.base_file_path();
+    config.should_teardown_test_directory = false;
+    auto file_manager = SyncFileManager(tsm.base_file_path(), app_id);
     // Open the metadata separately, so we can investigate it ourselves.
     SyncMetadataManager manager(file_manager.metadata_path(), false);
-    using Cfg = TestSyncManager::Config;
 
     const std::string url_1 = "https://realm.example.org/1/";
     const std::string url_2 = "https://realm.example.org/2/";
@@ -353,7 +321,8 @@ TEST_CASE("sync_manager: persistent user state management", "[sync]") {
         REQUIRE(manager.all_unmarked_users().size() == 4);
 
         SECTION("they should be added to the active users list when metadata is enabled") {
-            TestSyncManager tsm(Cfg(app_id, base_path, SyncManager::MetadataMode::NoEncryption));
+            config.metadata_mode = SyncManager::MetadataMode::NoEncryption;
+            TestSyncManager tsm(config);
             auto users = tsm.app()->sync_manager()->all_users();
             REQUIRE(users.size() == 3);
             REQUIRE(validate_user_in_vector(users, identity_1, url_1, r_token_1, a_token_1, dummy_device_id));
@@ -362,15 +331,12 @@ TEST_CASE("sync_manager: persistent user state management", "[sync]") {
         }
 
         SECTION("they should not be added to the active users list when metadata is disabled") {
-            TestSyncManager tsm(Cfg(base_path, SyncManager::MetadataMode::NoMetadata));
+            config.metadata_mode = SyncManager::MetadataMode::NoMetadata;
+            TestSyncManager tsm(config);
             auto users = tsm.app()->sync_manager()->all_users();
             REQUIRE(users.size() == 0);
         }
     }
-
-    const std::string expected_clean_app_id = "test_app_id%2A%24%23%40%21%251";
-    const std::string manager_path =
-        fs::path{base_path + "/mongodb-realm/" + expected_clean_app_id}.make_preferred().string();
 
     struct TestPath {
         std::string partition;
@@ -394,7 +360,7 @@ TEST_CASE("sync_manager: persistent user state management", "[sync]") {
 
         {
             auto expected_u1_path = [&](std::string partition) {
-                return ExpectedRealmPaths(base_path, app_id, u1->identity(), u1->local_uuid(), partition);
+                return ExpectedRealmPaths(tsm.base_file_path(), app_id, u1->identity(), u1->local_uuid(), partition);
             };
             std::string partition = "partition1";
             auto expected_paths = expected_u1_path(partition);
@@ -421,19 +387,17 @@ TEST_CASE("sync_manager: persistent user state management", "[sync]") {
                                   expected_paths.legacy_sync_directories_to_make.end());
         }
 
-        auto shared_test_config = Cfg(app_id, base_path, SyncManager::MetadataMode::NoEncryption);
         std::vector<std::string> paths;
         {
-            shared_test_config.should_teardown_test_directory = false;
-            TestSyncManager tsm(shared_test_config);
+            auto sync_manager = tsm.app()->sync_manager();
 
             // Pre-populate the user directories.
-            auto user1 = tsm.app()->sync_manager()->get_user(u1->identity(), r_token_1, a_token_1,
-                                                             u1->provider_type(), dummy_device_id);
-            auto user2 = tsm.app()->sync_manager()->get_user(u2->identity(), r_token_2, a_token_2,
-                                                             u2->provider_type(), dummy_device_id);
-            auto user3 = tsm.app()->sync_manager()->get_user(u3->identity(), r_token_3, a_token_3,
-                                                             u3->provider_type(), dummy_device_id);
+            auto user1 =
+                sync_manager->get_user(u1->identity(), r_token_1, a_token_1, u1->provider_type(), dummy_device_id);
+            auto user2 =
+                sync_manager->get_user(u2->identity(), r_token_2, a_token_2, u2->provider_type(), dummy_device_id);
+            auto user3 =
+                sync_manager->get_user(u3->identity(), r_token_3, a_token_3, u3->provider_type(), dummy_device_id);
             for (auto& dir : dirs_to_create) {
                 try_make_dir(dir);
             }
@@ -443,12 +407,12 @@ TEST_CASE("sync_manager: persistent user state management", "[sync]") {
                 }
             }
 
-            paths = {tsm.app()->sync_manager()->path_for_realm(SyncConfig{user1, "123456789"}),
-                     tsm.app()->sync_manager()->path_for_realm(SyncConfig{user1, "foo"}),
-                     tsm.app()->sync_manager()->path_for_realm(SyncConfig{user2, "partition"}, {"123456789"}),
-                     tsm.app()->sync_manager()->path_for_realm(SyncConfig{user3, "foo"}),
-                     tsm.app()->sync_manager()->path_for_realm(SyncConfig{user3, "bar"}),
-                     tsm.app()->sync_manager()->path_for_realm(SyncConfig{user3, "baz"})};
+            paths = {sync_manager->path_for_realm(SyncConfig{user1, "123456789"}),
+                     sync_manager->path_for_realm(SyncConfig{user1, "foo"}),
+                     sync_manager->path_for_realm(SyncConfig{user2, "partition"}, {"123456789"}),
+                     sync_manager->path_for_realm(SyncConfig{user3, "foo"}),
+                     sync_manager->path_for_realm(SyncConfig{user3, "bar"}),
+                     sync_manager->path_for_realm(SyncConfig{user3, "baz"})};
 
             for (auto& test : paths_under_test) {
                 std::string actual = tsm.app()->sync_manager()->path_for_realm(SyncConfig{user1, test.partition});
@@ -459,16 +423,16 @@ TEST_CASE("sync_manager: persistent user state management", "[sync]") {
             for (auto& path : paths) {
                 create_dummy_realm(path);
             }
-            tsm.app()->sync_manager()->remove_user(u1->identity());
-            tsm.app()->sync_manager()->remove_user(u2->identity());
+            sync_manager->remove_user(u1->identity());
+            sync_manager->remove_user(u2->identity());
         }
         for (auto& path : paths) {
             REQUIRE_REALM_EXISTS(path);
         }
-        app::App::clear_cached_apps();
 
+        config.should_teardown_test_directory = false;
         SECTION("they should be cleaned up if metadata is enabled") {
-            TestSyncManager tsm(shared_test_config);
+            TestSyncManager tsm(config);
             auto users = tsm.app()->sync_manager()->all_users();
             REQUIRE(users.size() == 1);
             REQUIRE(validate_user_in_vector(users, identity_3, provider_type, r_token_3, a_token_3, dummy_device_id));
@@ -484,9 +448,9 @@ TEST_CASE("sync_manager: persistent user state management", "[sync]") {
             }
         }
         SECTION("they should be left alone if metadata is disabled") {
-            shared_test_config.should_teardown_test_directory = true;
-            shared_test_config.metadata_mode = SyncManager::MetadataMode::NoMetadata;
-            TestSyncManager tsm(shared_test_config);
+            config.should_teardown_test_directory = true;
+            config.metadata_mode = SyncManager::MetadataMode::NoMetadata;
+            TestSyncManager tsm(config);
             auto users = tsm.app()->sync_manager()->all_users();
             for (auto& path : paths) {
                 REQUIRE_REALM_EXISTS(path);
@@ -497,12 +461,17 @@ TEST_CASE("sync_manager: persistent user state management", "[sync]") {
 
 TEST_CASE("sync_manager: file actions", "[sync]") {
     using Action = SyncFileActionMetadata::Action;
-    using Cfg = TestSyncManager::Config;
-    reset_test_directory(base_path);
+    reset_test_directory(base_path.string());
 
     auto file_manager = SyncFileManager(base_path, "bar_app_id");
     // Open the metadata separately, so we can investigate it ourselves.
     SyncMetadataManager manager(file_manager.metadata_path(), false);
+
+    TestSyncManager::Config config;
+    config.app_config.app_id = "bar_app_id";
+    config.base_path = base_path;
+    config.metadata_mode = SyncManager::MetadataMode::NoEncryption;
+    config.should_teardown_test_directory = false;
 
     const std::string realm_url = "https://example.realm.com/~/1";
     const std::string partition = "partition_foo";
@@ -533,7 +502,7 @@ TEST_CASE("sync_manager: file actions", "[sync]") {
             create_dummy_realm(realm_path_1);
             create_dummy_realm(realm_path_2);
             create_dummy_realm(realm_path_3);
-            TestSyncManager tsm(Cfg("bar_app_id", base_path, SyncManager::MetadataMode::NoEncryption));
+            TestSyncManager tsm(config);
             // File actions should be cleared.
             auto pending_actions = manager.all_pending_actions();
             CHECK(pending_actions.size() == 0);
@@ -548,7 +517,7 @@ TEST_CASE("sync_manager: file actions", "[sync]") {
             REQUIRE_REALM_DOES_NOT_EXIST(realm_path_1);
             REQUIRE_REALM_DOES_NOT_EXIST(realm_path_2);
             REQUIRE_REALM_DOES_NOT_EXIST(realm_path_3);
-            TestSyncManager tsm(Cfg("bar_app_id", base_path, SyncManager::MetadataMode::NoEncryption));
+            TestSyncManager tsm(config);
             auto pending_actions = manager.all_pending_actions();
             CHECK(pending_actions.size() == 0);
         }
@@ -558,7 +527,8 @@ TEST_CASE("sync_manager: file actions", "[sync]") {
             create_dummy_realm(realm_path_1);
             create_dummy_realm(realm_path_2);
             create_dummy_realm(realm_path_3);
-            TestSyncManager tsm(Cfg("bar_app_id", base_path, SyncManager::MetadataMode::NoMetadata));
+            config.metadata_mode = SyncManager::MetadataMode::NoMetadata;
+            TestSyncManager tsm(config);
             // All file actions should still be present.
             auto pending_actions = manager.all_pending_actions();
             CHECK(pending_actions.size() == 3);
@@ -587,7 +557,7 @@ TEST_CASE("sync_manager: file actions", "[sync]") {
             create_dummy_realm(realm_path_1);
             create_dummy_realm(realm_path_2);
             create_dummy_realm(realm_path_3);
-            TestSyncManager tsm(Cfg("bar_app_id", base_path, SyncManager::MetadataMode::NoEncryption));
+            TestSyncManager tsm(config);
             // File actions should be cleared.
             auto pending_actions = manager.all_pending_actions();
             CHECK(pending_actions.size() == 0);
@@ -616,7 +586,7 @@ TEST_CASE("sync_manager: file actions", "[sync]") {
             REQUIRE(pending_actions.size() == 4);
 
             // Simulate client launch.
-            TestSyncManager tsm(Cfg("bar_app_id", base_path, SyncManager::MetadataMode::NoEncryption));
+            TestSyncManager tsm(config);
 
             CHECK(pending_actions.size() == 0);
             CHECK(File::exists(recovery_path));
@@ -628,7 +598,7 @@ TEST_CASE("sync_manager: file actions", "[sync]") {
             REQUIRE_REALM_DOES_NOT_EXIST(realm_path_1);
             REQUIRE_REALM_DOES_NOT_EXIST(realm_path_2);
             REQUIRE_REALM_DOES_NOT_EXIST(realm_path_3);
-            TestSyncManager tsm(Cfg("bar_app_id", base_path, SyncManager::MetadataMode::NoEncryption));
+            TestSyncManager tsm(config);
             // File actions should be cleared.
             auto pending_actions = manager.all_pending_actions();
             CHECK(pending_actions.size() == 0);
@@ -643,7 +613,7 @@ TEST_CASE("sync_manager: file actions", "[sync]") {
             // Create a Realm file
             create_dummy_realm(realm_path_4);
             // Configure the system
-            TestSyncManager tsm(Cfg("bar_app_id", base_path, SyncManager::MetadataMode::NoEncryption));
+            TestSyncManager tsm(config);
             REQUIRE(manager.all_pending_actions().size() == 0);
             // Add a file action after the system is configured.
             REQUIRE_REALM_EXISTS(realm_path_4);
@@ -665,7 +635,7 @@ TEST_CASE("sync_manager: file actions", "[sync]") {
             create_dummy_realm(realm_path_2);
             create_dummy_realm(realm_path_3);
             create_dummy_realm(recovery_1);
-            TestSyncManager tsm(Cfg("bar_app_id", base_path, SyncManager::MetadataMode::NoEncryption));
+            TestSyncManager tsm(config);
             // Most file actions should be cleared.
             auto pending_actions = manager.all_pending_actions();
             CHECK(pending_actions.size() == 1);
@@ -695,7 +665,7 @@ TEST_CASE("sync_manager: file actions", "[sync]") {
             int original_perms = get_permissions(realm3_dir);
             realm::chmod(realm3_dir, original_perms & (~0b010000000)); // without owner_write
             // run the actions
-            TestSyncManager tsm({"bar_app_id", base_path, SyncManager::MetadataMode::NoEncryption});
+            TestSyncManager tsm(config);
             // restore write permissions to the directory
             realm::chmod(realm3_dir, original_perms);
             // Everything succeeded except deleting realm_path_3
@@ -723,7 +693,8 @@ TEST_CASE("sync_manager: file actions", "[sync]") {
             create_dummy_realm(realm_path_1);
             create_dummy_realm(realm_path_2);
             create_dummy_realm(realm_path_3);
-            TestSyncManager tsm(Cfg("bar_app_id", base_path, SyncManager::MetadataMode::NoMetadata));
+            config.metadata_mode = SyncManager::MetadataMode::NoMetadata;
+            TestSyncManager tsm(config);
             // All file actions should still be present.
             auto pending_actions = manager.all_pending_actions();
             CHECK(pending_actions.size() == 3);
@@ -740,10 +711,7 @@ TEST_CASE("sync_manager: file actions", "[sync]") {
 }
 
 TEST_CASE("sync_manager: has_active_sessions", "[active_sessions]") {
-    reset_test_directory(base_path);
-
-    TestSyncManager init_sync_manager(TestSyncManager::Config(base_path, SyncManager::MetadataMode::NoEncryption),
-                                      {false});
+    TestSyncManager init_sync_manager({}, {false});
     auto sync_manager = init_sync_manager.app()->sync_manager();
 
     SECTION("no active sessions") {

--- a/test/object-store/sync/sync_test_utils.cpp
+++ b/test/object-store/sync/sync_test_utils.cpp
@@ -131,26 +131,21 @@ ExpectedRealmPaths::ExpectedRealmPaths(const std::string& base_path, const std::
     }
     std::string clean_name = name ? util::make_percent_encoded_string(*name) : cleaned_partition;
     std::string cleaned_app_id = util::make_percent_encoded_string(app_id);
-    std::string manager_path = fs::path{base_path + "/mongodb-realm/" + cleaned_app_id}.make_preferred().string();
-    std::string preferred_name = fs::path{manager_path + "/" + identity + "/" + clean_name}.make_preferred().string();
-    current_preferred_path = fs::path{preferred_name + ".realm"}.make_preferred().string();
-    fallback_hashed_path =
-        fs::path{manager_path + "/" + do_hash(preferred_name) + ".realm"}.make_preferred().string();
-    legacy_sync_directories_to_make.push_back(
-        fs::path{manager_path + "/" + local_identity}.make_preferred().string());
+    const auto manager_path = fs::path{base_path}.make_preferred() / "mongodb-realm" / cleaned_app_id;
+    const auto preferred_name = manager_path / identity / clean_name;
+    current_preferred_path = preferred_name.string() + ".realm";
+    fallback_hashed_path = (manager_path / do_hash(preferred_name)).string() + ".realm";
+    legacy_sync_directories_to_make.push_back((manager_path / local_identity).string());
     std::string encoded_partition = util::make_percent_encoded_string(partition);
-    legacy_local_id_path = fs::path{manager_path + "/" + local_identity + "/" +
-                                    (name ? util::make_percent_encoded_string(*name) : encoded_partition) + ".realm"}
-                               .make_preferred()
-                               .string();
-    auto dir_builder = fs::path{manager_path + "/realm-object-server"}.make_preferred().string();
-    legacy_sync_directories_to_make.push_back(dir_builder);
-    dir_builder = fs::path{dir_builder + "/" + local_identity}.make_preferred().string();
-    legacy_sync_directories_to_make.push_back(dir_builder);
-    legacy_sync_path =
-        fs::path{dir_builder + "/" + (name ? util::make_percent_encoded_string(*name) : cleaned_partition)}
-            .make_preferred()
+    legacy_local_id_path =
+        (manager_path / local_identity / (name ? util::make_percent_encoded_string(*name) : encoded_partition))
+            .concat(".realm")
             .string();
+    auto dir_builder = manager_path / "realm-object-server";
+    legacy_sync_directories_to_make.push_back(dir_builder.string());
+    dir_builder /= local_identity;
+    legacy_sync_directories_to_make.push_back(dir_builder.string());
+    legacy_sync_path = (dir_builder / (name ? util::make_percent_encoded_string(*name) : cleaned_partition)).string();
 }
 
 #if REALM_ENABLE_SYNC

--- a/test/object-store/sync/sync_test_utils.cpp
+++ b/test/object-store/sync/sync_test_utils.cpp
@@ -200,6 +200,7 @@ AutoVerifiedEmailCredentials create_user_and_log_in(app::SharedApp app)
 #endif // REALM_ENABLE_SYNC
 
 namespace reset_utils {
+namespace {
 
 struct Partition {
     std::string property_name;
@@ -302,6 +303,7 @@ struct FakeLocalClientReset : public TestClientReset {
         }
     }
 };
+} // anonymous namespace
 
 #if REALM_ENABLE_SYNC
 

--- a/test/object-store/sync/sync_test_utils.hpp
+++ b/test/object-store/sync/sync_test_utils.hpp
@@ -54,8 +54,7 @@ void timed_sleeping_wait_for(util::FunctionRef<bool()> condition,
 
 struct ExpectedRealmPaths {
     ExpectedRealmPaths(const std::string& base_path, const std::string& app_id, const std::string& user_identity,
-                       const std::string& local_identity, const std::string& partition,
-                       util::Optional<std::string> name = util::none);
+                       const std::string& local_identity, const std::string& partition);
     std::string current_preferred_path;
     std::string fallback_hashed_path;
     std::string legacy_local_id_path;

--- a/test/object-store/sync/sync_test_utils.hpp
+++ b/test/object-store/sync/sync_test_utils.hpp
@@ -65,25 +65,17 @@ struct ExpectedRealmPaths {
 
 #if REALM_ENABLE_SYNC
 
-void wait_for_sync_changes(std::shared_ptr<SyncSession> session);
-
 template <typename Transport>
 const std::shared_ptr<app::GenericNetworkTransport> instance_of = std::make_shared<Transport>();
 
 std::ostream& operator<<(std::ostream& os, util::Optional<app::AppError> error);
 
-template <typename Factory>
-app::App::Config get_config(Factory factory)
+template <typename Transport>
+TestSyncManager::Config get_config(Transport&& transport)
 {
-    return {"app name",
-            factory,
-            util::none,
-            util::none,
-            util::Optional<std::string>("A Local App Version"),
-            util::none,
-            "Object Store Platform Tests",
-            "Object Store Platform Version Blah",
-            "An sdk version"};
+    TestSyncManager::Config config;
+    config.transport = transport;
+    return config;
 }
 
 #if REALM_ENABLE_AUTH_TESTS
@@ -135,7 +127,7 @@ protected:
 #if REALM_ENABLE_AUTH_TESTS
 std::unique_ptr<TestClientReset> make_baas_client_reset(const Realm::Config& local_config,
                                                         const Realm::Config& remote_config,
-                                                        TestSyncManager& test_sync_manager);
+                                                        TestAppSession& test_app_session);
 #endif // REALM_ENABLE_AUTH_TESTS
 
 #endif // REALM_ENABLE_SYNC

--- a/test/object-store/sync/user.cpp
+++ b/test/object-store/sync/user.cpp
@@ -36,7 +36,7 @@ static const std::string base_path = util::make_temp_dir() + "realm_objectstore_
 static const std::string dummy_device_id = "123400000000000000000000";
 
 TEST_CASE("sync_user: SyncManager `get_user()` API", "[sync]") {
-    TestSyncManager init_sync_manager(TestSyncManager::Config(base_path), {});
+    TestSyncManager init_sync_manager;
     auto sync_manager = init_sync_manager.app()->sync_manager();
     const std::string identity = "sync_test_identity";
     const std::string refresh_token = ENCODE_FAKE_JWT("1234567890-fake-refresh-token");
@@ -88,8 +88,9 @@ TEST_CASE("sync_user: SyncManager `get_user()` API", "[sync]") {
         REQUIRE(second->state() == SyncUser::State::LoggedIn);
     }
 }
+
 TEST_CASE("sync_user: update state and tokens", "[sync]") {
-    TestSyncManager init_sync_manager(TestSyncManager::Config(base_path), {});
+    TestSyncManager init_sync_manager;
     auto sync_manager = init_sync_manager.app()->sync_manager();
     const std::string identity = "sync_test_identity";
     const std::string refresh_token = ENCODE_FAKE_JWT("fake-refresh-token-1");
@@ -118,7 +119,7 @@ TEST_CASE("sync_user: update state and tokens", "[sync]") {
 }
 
 TEST_CASE("sync_user: SyncManager `get_existing_logged_in_user()` API", "[sync]") {
-    TestSyncManager init_sync_manager(TestSyncManager::Config(base_path, SyncManager::MetadataMode::NoMetadata));
+    TestSyncManager init_sync_manager(SyncManager::MetadataMode::NoMetadata);
     auto sync_manager = init_sync_manager.app()->sync_manager();
     const std::string identity = "sync_test_identity";
     const std::string refresh_token = ENCODE_FAKE_JWT("1234567890-fake-refresh-token");
@@ -153,7 +154,7 @@ TEST_CASE("sync_user: SyncManager `get_existing_logged_in_user()` API", "[sync]"
 }
 
 TEST_CASE("sync_user: logout", "[sync]") {
-    TestSyncManager init_sync_manager(TestSyncManager::Config(base_path, SyncManager::MetadataMode::NoMetadata));
+    TestSyncManager init_sync_manager(SyncManager::MetadataMode::NoMetadata);
     auto sync_manager = init_sync_manager.app()->sync_manager();
     const std::string identity = "sync_test_identity";
     const std::string refresh_token = ENCODE_FAKE_JWT("1234567890-fake-refresh-token");
@@ -169,10 +170,9 @@ TEST_CASE("sync_user: logout", "[sync]") {
 }
 
 TEST_CASE("sync_user: user persistence", "[sync]") {
-    TestSyncManager init_sync_manager(
-        TestSyncManager::Config("baz_app_id", base_path, SyncManager::MetadataMode::NoEncryption));
-    auto sync_manager = init_sync_manager.app()->sync_manager();
-    auto file_manager = SyncFileManager(base_path, "baz_app_id");
+    TestSyncManager tsm(SyncManager::MetadataMode::NoEncryption);
+    auto sync_manager = tsm.app()->sync_manager();
+    auto file_manager = SyncFileManager(tsm.base_file_path(), tsm.app()->config().app_id);
     // Open the metadata separately, so we can investigate it ourselves.
     SyncMetadataManager manager(file_manager.metadata_path(), false);
 

--- a/test/object-store/util/baas_admin_api.cpp
+++ b/test/object-store/util/baas_admin_api.cpp
@@ -543,7 +543,7 @@ AdminAPISession::Service AdminAPISession::get_sync_service(const std::string& ap
     return *sync_service;
 }
 
-nlohmann::json convert_config(AdminAPISession::ServiceConfig config)
+static nlohmann::json convert_config(AdminAPISession::ServiceConfig config)
 {
     return nlohmann::json{
         {"database_name", config.database_name}, {"partition", config.partition}, {"state", config.state}};

--- a/test/object-store/util/baas_admin_api.hpp
+++ b/test/object-store/util/baas_admin_api.hpp
@@ -66,12 +66,12 @@ public:
                                  const std::string& password);
 
     AdminAPIEndpoint apps() const;
-    void revoke_user_sessions(const std::string& user_id, const std::string& app_id);
-    void disable_user_sessions(const std::string& user_id, const std::string& app_id);
-    void enable_user_sessions(const std::string& user_id, const std::string& app_id);
-    bool verify_access_token(const std::string& access_token, const std::string& app_id);
-    void set_development_mode_to(const std::string& app_id, bool enable);
-    void delete_app(const std::string& app_id);
+    void revoke_user_sessions(const std::string& user_id, const std::string& app_id) const;
+    void disable_user_sessions(const std::string& user_id, const std::string& app_id) const;
+    void enable_user_sessions(const std::string& user_id, const std::string& app_id) const;
+    bool verify_access_token(const std::string& access_token, const std::string& app_id) const;
+    void set_development_mode_to(const std::string& app_id, bool enable) const;
+    void delete_app(const std::string& app_id) const;
 
     struct Service {
         std::string id;
@@ -85,13 +85,16 @@ public:
         nlohmann::json partition;
         std::string state;
     };
-    std::vector<Service> get_services(const std::string& app_id);
-    Service get_sync_service(const std::string& app_id);
-    ServiceConfig get_config(const std::string& app_id, const Service& service);
-    ServiceConfig disable_sync(const std::string& app_id, const std::string& service_id, ServiceConfig sync_config);
-    ServiceConfig pause_sync(const std::string& app_id, const std::string& service_id, ServiceConfig sync_config);
-    ServiceConfig enable_sync(const std::string& app_id, const std::string& service_id, ServiceConfig sync_config);
-    bool is_sync_enabled(const std::string& app_id);
+    std::vector<Service> get_services(const std::string& app_id) const;
+    Service get_sync_service(const std::string& app_id) const;
+    ServiceConfig get_config(const std::string& app_id, const Service& service) const;
+    ServiceConfig disable_sync(const std::string& app_id, const std::string& service_id,
+                               ServiceConfig sync_config) const;
+    ServiceConfig pause_sync(const std::string& app_id, const std::string& service_id,
+                             ServiceConfig sync_config) const;
+    ServiceConfig enable_sync(const std::string& app_id, const std::string& service_id,
+                              ServiceConfig sync_config) const;
+    bool is_sync_enabled(const std::string& app_id) const;
 
     const std::string& base_url() const noexcept
     {
@@ -106,7 +109,7 @@ private:
     {
     }
 
-    AdminAPIEndpoint service_config_endpoint(const std::string& app_id, const std::string& service_id);
+    AdminAPIEndpoint service_config_endpoint(const std::string& app_id, const std::string& service_id) const;
 
     std::string m_base_url;
     std::string m_access_token;
@@ -210,9 +213,6 @@ inline app::App::Config get_config(Factory factory, const AppSession& app_sessio
             "Object Store Platform Version Blah",
             "An sdk version"};
 }
-
-// Get an App config suitable for integration testing against BaaS
-app::App::Config get_integration_config();
 
 } // namespace realm
 

--- a/test/object-store/util/test_file.cpp
+++ b/test/object-store/util/test_file.cpp
@@ -64,10 +64,7 @@ TestFile::TestFile()
 {
     disable_sync_to_disk();
     m_temp_dir = util::make_temp_dir();
-    if (m_temp_dir.size() == 0 || m_temp_dir[m_temp_dir.size() - 1] != '/') {
-        m_temp_dir = m_temp_dir + "/";
-    }
-    path = fs::path(util::format("%1realm.XXXXXX", m_temp_dir)).string();
+    path = (fs::path(m_temp_dir) / "realm.XXXXXX").string();
     int fd = mkstemp(path.data());
     if (fd < 0) {
         int err = errno;

--- a/test/object-store/util/test_file.cpp
+++ b/test/object-store/util/test_file.cpp
@@ -112,14 +112,7 @@ InMemoryTestFile::InMemoryTestFile()
 #if REALM_ENABLE_SYNC
 SyncTestFile::SyncTestFile(std::shared_ptr<app::App> app, std::string name, std::string user_name)
 {
-    if (!app)
-        throw std::runtime_error("Must provide `app` for SyncTestFile");
-
-    if (name.empty())
-        name = path.substr(path.rfind('/') + 1);
-
-    if (name[0] != '/')
-        name = "/" + name;
+    REALM_ASSERT(app);
 
     std::string fake_refresh_token = ENCODE_FAKE_JWT("not_a_real_token");
     std::string fake_access_token = ENCODE_FAKE_JWT("also_not_real");
@@ -127,7 +120,7 @@ SyncTestFile::SyncTestFile(std::shared_ptr<app::App> app, std::string name, std:
     sync_config =
         std::make_shared<SyncConfig>(app->sync_manager()->get_user(user_name, fake_refresh_token, fake_access_token,
                                                                    app->base_url(), fake_device_id),
-                                     name);
+                                     bson::Bson(name));
     sync_config->stop_policy = SyncSessionStopPolicy::Immediately;
     sync_config->error_handler = [](auto, SyncError error) {
         std::cerr << util::format("An unexpected sync error was caught by the default SyncTestFile handler: '%1'",
@@ -140,9 +133,7 @@ SyncTestFile::SyncTestFile(std::shared_ptr<app::App> app, std::string name, std:
 
 SyncTestFile::SyncTestFile(std::shared_ptr<realm::SyncUser> user, bson::Bson partition, realm::Schema _schema)
 {
-    if (!user)
-        throw std::runtime_error("Must provide `user` for SyncTestFile");
-
+    REALM_ASSERT(user);
     sync_config = std::make_shared<realm::SyncConfig>(user, partition);
     sync_config->stop_policy = SyncSessionStopPolicy::Immediately;
     sync_config->error_handler = [](std::shared_ptr<SyncSession>, SyncError error) {
@@ -158,9 +149,7 @@ SyncTestFile::SyncTestFile(std::shared_ptr<realm::SyncUser> user, bson::Bson par
 
 SyncTestFile::SyncTestFile(std::shared_ptr<realm::SyncUser> user, realm::Schema _schema, SyncConfig::FLXSyncEnabled)
 {
-    if (!user)
-        throw std::runtime_error("Must provide `user` for SyncTestFile");
-
+    REALM_ASSERT(user);
     sync_config = std::make_shared<realm::SyncConfig>(user, SyncConfig::FLXSyncEnabled{});
     sync_config->stop_policy = SyncSessionStopPolicy::Immediately;
     sync_config->error_handler = [](std::shared_ptr<SyncSession>, SyncError error) {

--- a/test/object-store/util/test_file.hpp
+++ b/test/object-store/util/test_file.hpp
@@ -262,8 +262,8 @@ inline TestSyncManager::Config::Config(const realm::app::App::Config& app_cfg, r
 {
 }
 
-std::error_code wait_for_upload(realm::Realm& realm);
-std::error_code wait_for_download(realm::Realm& realm);
+std::error_code wait_for_upload(realm::Realm& realm, std::chrono::seconds timeout = std::chrono::seconds(60));
+std::error_code wait_for_download(realm::Realm& realm, std::chrono::seconds timeout = std::chrono::seconds(60));
 
 #endif // REALM_ENABLE_SYNC
 

--- a/test/object-store/util/test_utils.cpp
+++ b/test/object-store/util/test_utils.cpp
@@ -111,7 +111,7 @@ std::string encode_fake_jwt(const std::string& in, util::Optional<int64_t> exp, 
     return encoded_prefix + "." + encoded_body + "." + suffix;
 }
 
-bool file_is_on_exfat(const std::string& path)
+static bool file_is_on_exfat(const std::string& path)
 {
 #if REALM_PLATFORM_APPLE
     if (path.empty())

--- a/test/object-store/util/test_utils.hpp
+++ b/test/object-store/util/test_utils.hpp
@@ -70,9 +70,19 @@ std::string get_parent_directory(const std::string& path);
         CHECK(util::File::is_dir(macro_path) == true);                                                               \
     } while (0)
 
+#define REQUIRE_DIR_PATH_EXISTS(macro_path)                                                                          \
+    do {                                                                                                             \
+        REQUIRE(util::File::is_dir((macro_path).string()));                                                          \
+    } while (0)
+
 #define REQUIRE_DIR_DOES_NOT_EXIST(macro_path)                                                                       \
     do {                                                                                                             \
         CHECK(util::File::exists(macro_path) == false);                                                              \
+    } while (0)
+
+#define REQUIRE_DIR_PATH_DOES_NOT_EXIST(macro_path)                                                                  \
+    do {                                                                                                             \
+        REQUIRE_FALSE(util::File::exists((macro_path).string()));                                                    \
     } while (0)
 
 #define REQUIRE_REALM_EXISTS(macro_path)                                                                             \

--- a/test/test_encrypt_transform.cpp
+++ b/test/test_encrypt_transform.cpp
@@ -13,8 +13,8 @@ using namespace realm::fixtures;
 
 #if REALM_ENABLE_ENCRYPTION
 
-const size_t num_rows = 100;
-void populate(DBRef& sg)
+static const size_t num_rows = 100;
+static void populate(DBRef& sg)
 {
     WriteTransaction wt{sg};
     TableRef t = wt.add_table("table");
@@ -28,7 +28,7 @@ void populate(DBRef& sg)
     wt.commit();
 }
 
-bool verify_populated(DBRef& sg)
+static bool verify_populated(DBRef& sg)
 {
     auto rt = sg->start_read();
     auto table_key = rt->find_table("table");

--- a/test/test_group.cpp
+++ b/test/test_group.cpp
@@ -1288,7 +1288,7 @@ TEST(Group_CascadeNotify_TableViewClearWeak)
 
 
 // more levels of cascade delete.... this does not seem to add any additional coverage
-void make_tree(Table& table, Obj& obj, ColKey left, ColKey right, int depth)
+static void make_tree(Table& table, Obj& obj, ColKey left, ColKey right, int depth)
 {
     if (depth < 4) {
         auto o_l = obj.create_and_set_linked_object(left);

--- a/test/test_lang_bind_helper.cpp
+++ b/test/test_lang_bind_helper.cpp
@@ -3091,12 +3091,12 @@ TEST(LangBindHelper_ImplicitTransactions_MultipleTrackers)
 
 #if !REALM_ANDROID && !REALM_IOS
 
-std::stringstream ss;
-void signal_handler(int signal)
+static std::stringstream s_ss;
+static void signal_handler(int signal)
 {
     std::cout << "signal handler: " << signal << std::endl;
-    util::Backtrace::capture().print(ss);
-    std::cout << "trace: " << ss.str() << std::endl;
+    util::Backtrace::capture().print(s_ss);
+    std::cout << "trace: " << s_ss.str() << std::endl;
     exit(signal);
 }
 

--- a/test/test_metrics.cpp
+++ b/test/test_metrics.cpp
@@ -195,7 +195,7 @@ TEST(Metrics_QueryTypes)
     CHECK_EQUAL(queries->at(16).get_type(), QueryInfo::type_Minimum);
 }
 
-size_t find_count(std::string haystack, std::string needle)
+static size_t find_count(std::string haystack, std::string needle)
 {
     size_t find_pos = 0;
     size_t count = 0;
@@ -209,7 +209,7 @@ size_t find_count(std::string haystack, std::string needle)
     return count;
 }
 
-void populate(DBRef sg)
+static void populate(DBRef sg)
 {
     auto wt = sg->start_write();
     auto person = wt->add_table("person");

--- a/test/test_parser.cpp
+++ b/test/test_parser.cpp
@@ -396,8 +396,8 @@ TEST(Parser_invalid_queries)
     }
 }
 
-Query verify_query(test_util::unit_test::TestContext& test_context, TableRef t, std::string query_string,
-                   size_t num_results, query_parser::KeyPathMapping mapping = {})
+static Query verify_query(test_util::unit_test::TestContext& test_context, TableRef t, std::string query_string,
+                          size_t num_results, query_parser::KeyPathMapping mapping = {})
 {
     realm::query_parser::NoArguments args;
     Query q = t->query(query_string, args, mapping);
@@ -416,8 +416,8 @@ Query verify_query(test_util::unit_test::TestContext& test_context, TableRef t, 
     return q2;
 }
 
-void verify_query_sub(test_util::unit_test::TestContext& test_context, TableRef t, std::string query_string,
-                      const util::Any* arg_list, size_t num_args, size_t num_results)
+static void verify_query_sub(test_util::unit_test::TestContext& test_context, TableRef t, std::string query_string,
+                             const util::Any* arg_list, size_t num_args, size_t num_results)
 {
     query_parser::AnyContext ctx;
     realm::query_parser::ArgumentConverter<util::Any, query_parser::AnyContext> args(ctx, arg_list, num_args);
@@ -437,8 +437,8 @@ void verify_query_sub(test_util::unit_test::TestContext& test_context, TableRef 
     }
 }
 
-void verify_query_sub(test_util::unit_test::TestContext& test_context, TableRef t, std::string query_string,
-                      std::vector<Mixed> args, size_t num_results)
+static void verify_query_sub(test_util::unit_test::TestContext& test_context, TableRef t, std::string query_string,
+                             std::vector<Mixed> args, size_t num_results)
 {
     Query q = t->query(query_string, args, {});
     size_t q_count = q.count();
@@ -2595,7 +2595,7 @@ TEST(Parser_SortAndDistinctSerialisation)
     CHECK(description.find("SORT(account.balance ASC, account.num_transactions DESC)") != std::string::npos);
 }
 
-TableView get_sorted_view(TableRef t, std::string query_string, query_parser::KeyPathMapping mapping = {})
+static TableView get_sorted_view(TableRef t, std::string query_string, query_parser::KeyPathMapping mapping = {})
 {
     Query q = t->query(query_string, {}, mapping);
     std::string query_description = q.get_description(mapping.get_backlink_class_prefix());

--- a/test/test_query.cpp
+++ b/test/test_query.cpp
@@ -2325,7 +2325,7 @@ TEST(Query_TwoSameCols)
     CHECK_EQUAL(2, q8.count());
 }
 
-void construct_all_types_table(Table& table)
+static void construct_all_types_table(Table& table)
 {
     table.add_column(type_Int, "int");
     table.add_column(type_Float, "float");

--- a/test/test_table_view.cpp
+++ b/test/test_table_view.cpp
@@ -2814,7 +2814,7 @@ public:
     }
 };
 
-TestTableView get_table_view(TestTableView val)
+static TestTableView get_table_view(TestTableView val)
 {
     return val;
 }

--- a/test/test_util_backtrace.cpp
+++ b/test/test_util_backtrace.cpp
@@ -7,7 +7,7 @@
 using namespace realm;
 using namespace realm::util;
 
-REALM_NOINLINE void throw_logic_error(LogicError::ErrorKind kind)
+REALM_NOINLINE static void throw_logic_error(LogicError::ErrorKind kind)
 {
     throw LogicError{kind};
 }

--- a/test/test_util_to_string.cpp
+++ b/test/test_util_to_string.cpp
@@ -137,7 +137,7 @@ TEST(ToString_DataTypes)
 
 struct StreamableType {
 };
-std::ostream& operator<<(std::ostream& os, StreamableType)
+static std::ostream& operator<<(std::ostream& os, StreamableType)
 {
     return os << "Custom streamable type";
 }
@@ -146,6 +146,8 @@ TEST(ToString_OStreamFallback)
 {
     CHECK_EQUAL(to_string(StreamableType()), "Custom streamable type");
 }
+
+namespace {
 
 struct ImplicitlyConvertibleToPrintable {
     operator util::Printable() const noexcept
@@ -165,10 +167,13 @@ struct ExplicitlyConvertibleToPrintableAndStreamable {
         return "conversion to printable";
     }
 };
+std::ostream& operator<<(std::ostream&, const ExplicitlyConvertibleToPrintableAndStreamable&) REALM_UNUSED;
 std::ostream& operator<<(std::ostream&, const ExplicitlyConvertibleToPrintableAndStreamable&)
 {
     throw std::runtime_error("called stream operator instead of conversion");
 }
+
+} // namespace
 
 TEST(ToString_ConversionsToPrintable)
 {

--- a/test/test_uuid.cpp
+++ b/test/test_uuid.cpp
@@ -25,6 +25,8 @@
 
 using namespace realm;
 
+namespace {
+
 struct WithIndex {
     constexpr static bool do_add_index = true;
 };
@@ -55,6 +57,8 @@ util::Optional<UUID> generate_random_nullable_uuid()
     }
     return util::Optional<UUID>(generate_random_uuid());
 }
+
+} // namespace
 
 TEST(UUID_Basics)
 {

--- a/test/util/CMakeLists.txt
+++ b/test/util/CMakeLists.txt
@@ -1,21 +1,57 @@
 set(TEST_UTIL_SOURCES
     benchmark_results.cpp
-    demangle.cpp
-    timer.cpp
-    random.cpp
-    quote.cpp
-    wildcard.cpp
-    unit_test.cpp
-    test_path.cpp
-    test_only.cpp
     crypt_key.cpp
+    demangle.cpp
     misc.cpp
+    quote.cpp
+    random.cpp
+    resource_limits.cpp
+    test_only.cpp
+    test_path.cpp
+    timer.cpp
+    unit_test.cpp
     verified_integer.cpp
     verified_string.cpp
-    resource_limits.cpp
+    wildcard.cpp
 ) # TEST_UTIL_SOURCES
 
-add_library(TestUtil ${TEST_UTIL_SOURCES})
+set(TEST_UTIL_HEADERS
+    benchmark_results.hpp
+    check_logic_error.hpp
+    check_system_error.hpp
+    compare_groups.hpp
+    crypt_key.hpp
+    demangle.hpp
+    dump_changesets.hpp
+    misc.hpp
+    mock_metrics.hpp
+    number_names.hpp
+    quote.hpp
+    random.hpp
+    resource_limits.hpp
+    semaphore.hpp
+    super_int.hpp
+    test_logger.hpp
+    test_only.hpp
+    test_path.hpp
+    test_types.hpp
+    thread_wrapper.hpp
+    timer.hpp
+    unit_test.hpp
+    verified_integer.hpp
+    verified_string.hpp
+    wildcard.hpp
+) # TEST_UTIL_HEADERS
+
+if(REALM_ENABLE_SYNC)
+    list(APPEND TEST_UTIL_SOURCES
+        compare_groups.cpp
+        dump_changesets.cpp
+        mock_metrics.cpp
+    )
+endif()
+
+add_library(TestUtil STATIC ${TEST_UTIL_SOURCES} ${TEST_UTIL_HEADERS})
 
 target_link_libraries(TestUtil Storage)
 

--- a/test/util/compare_groups.cpp
+++ b/test/util/compare_groups.cpp
@@ -275,10 +275,6 @@ ObjKey row_for_primary_key(const Table& table, sync::PrimaryKey key)
     return {};
 }
 
-} // unnamed namespace
-
-namespace realm::test_util {
-
 bool compare_objects(const Obj& obj_1, const Obj& obj_2, const std::vector<Column>& columns, util::Logger& logger);
 bool compare_objects(sync::PrimaryKey& oid, const Table& table_1, const Table& table_2,
                      const std::vector<Column>& columns, util::Logger& logger);
@@ -965,6 +961,10 @@ bool compare_objects(sync::PrimaryKey& oid, const Table& table_1, const Table& t
     const Obj obj_2 = table_2.get_object(row_2);
     return compare_objects(obj_1, obj_2, columns, logger);
 }
+
+} // anonymous namespace
+
+namespace realm::test_util {
 
 bool compare_tables(const Table& table_1, const Table& table_2)
 {

--- a/test/util/compare_groups.hpp
+++ b/test/util/compare_groups.hpp
@@ -6,11 +6,7 @@
 #include <realm/group.hpp>
 #include <realm/table.hpp>
 
-namespace realm {
-namespace sync {
-struct TableInfoCache;
-} // namespace sync
-namespace test_util {
+namespace realm::test_util {
 
 bool compare_tables(const Table& table_1, const Table& table_2, util::Logger&);
 
@@ -36,7 +32,6 @@ inline bool compare_groups(const Transaction& group_1, const Transaction& group_
         logger);
 }
 
-} // namespace test_util
-} // namespace realm
+} // namespace realm::test_util
 
 #endif // REALM_TEST_UTIL_COMPARE_GROUPS_HPP


### PR DESCRIPTION
This is some assorted cleanups to the sync tests that ended up exposing an actual (probably irrelevant) bug.

### Add a timeout to wait_for_upload()/wait_for_download()

Should be obvious.

### Decouple baas test and test sync server test initialization

Baas tests were also launching the sync server. This had a small performance hit, but more importantly it made it possible to accidentally use the wrong server in tests. I don't think any of the currently existing tests did so (but I hit this while writing audit tests).

I fixed this by splitting it into two separate types, and tried to make those two types better suited to what the tests using them actually want. There were quite a few tests which previously had just the bare minimum changes done to them to adopt to SyncManager no longer being a singleton and were doing some rather strange things.

### Unify the redundant TestUtil and TestUtils targets and add some missing headers

Some headers were missing from the test target, and when trying to add them I discovered that the test targets were really weird due to how the core and sync tests were mashed together.

### Add -Wmissing-prototype and fix resulting warnings

I spent an awkwardly long time tracking down a bug which would have been caught by Wmissing-prototype. Enabling it revealed a lot of unnecessarily extern things and a few unused functions.

### Loosen the test server's virtual path requirements

This makes it so that the test server accepts a limited subset of bson partition keys as virtual paths, which eliminates the most visible difference between it and baas, and enables removing the code in object store which works around that difference. All of the object store tests now use partition strings to open synchronized Realms regardless of which server is in use.

Unsurprisingly in retrospect, it also exposed a bug.

### Fix incorrect handling of legacy percent-encoded local identity paths

Between object store commits a8cf94a0c122a2d1ce5a60ef3c60d93eea535a4d and 9d554831383b35a1d4129d3ec0d6109bd1891477 (a two week period in 2020...), we opened sync Realms with the path format "$appId/$localId/$percentEncodedPartitionString", but the code which tried to handle that instead checked "$appId/$localId/$readablePartitionString". The tests which were specifically trying to validate this failed to do so because they weren't using partition strings at all, and so couldn't discover that the wrong partition key encoding was being used. One of the tests was still using legacy ROS URLs to identify Realm files too.

### Regenerate the sync test certificates as they expired

We use some test certificates which expired April 19, resulting in a bunch of sync tests breaking. This commit is just following the instructions in `certificate-authority/HOW_TO_UPDATE.md`.

