### PR TITLE
Add RealmCoordinator::log_out_all_sync_sessions method

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,7 @@
 * Added a new flag to `CollectionChangeSet` to indicate when collections are cleared. ([#5340](https://github.com/realm/realm-core/pull/5340))
 * Added auth code and id token support for google c_api ([#5347](https://github.com/realm/realm-core/issues/5347))
 * Added AppCredentials::serialize_as_json() support for c_api ([#5348](https://github.com/realm/realm-core/issues/5348))
+* Added `App::close_all_sync_sessions` static method and `SyncManager::close_all_sessions` method ([#5411](https://github.com/realm/realm-core/pull/5411))
 
 ### Fixed
 * Fixed potential future bug in how async write/commit used encryption ([#5369](https://github.com/realm/realm-core/pull/5369))

--- a/src/realm/object-store/sync/app.cpp
+++ b/src/realm/object-store/sync/app.cpp
@@ -213,6 +213,14 @@ void App::clear_cached_apps()
     s_apps_cache.clear();
 }
 
+void App::close_all_sync_sessions()
+{
+    std::lock_guard<std::mutex> lock(s_apps_mutex);
+    for (auto& app : s_apps_cache) {
+        app.second->sync_manager()->close_all_sessions();
+    }
+}
+
 App::App(const Config& config)
     : m_config(std::move(config))
     , m_base_url(config.base_url.value_or(default_base_url))

--- a/src/realm/object-store/sync/app.hpp
+++ b/src/realm/object-store/sync/app.hpp
@@ -351,6 +351,11 @@ public:
 
     static void clear_cached_apps();
 
+    // Immediately close all open sync sessions for all cached apps.
+    // Used by JS SDK to ensure no sync clients remain open when a developer
+    // reloads an app (#5411).
+    static void close_all_sync_sessions();
+
 private:
     friend class Internal;
     friend class OnlyForTesting;

--- a/src/realm/object-store/sync/sync_manager.hpp
+++ b/src/realm/object-store/sync/sync_manager.hpp
@@ -205,6 +205,9 @@ public:
     // Get the app metadata for the active app.
     util::Optional<SyncAppMetadata> app_metadata() const REQUIRES(!m_file_system_mutex);
 
+    // Immediately closes any open sync sessions for this sync manager
+    void close_all_sessions() REQUIRES(!m_mutex, !m_session_mutex);
+
     void set_sync_route(std::string sync_route) REQUIRES(!m_mutex)
     {
         util::CheckedLockGuard lock(m_mutex);


### PR DESCRIPTION
## What, How & Why?

We have an issue with the JS SDK where "hot reloading" (which reloads the JS part of the application on a new JS thread, but keeps the native part running) a React Native app which is using Realm sync can result in a `Multiple sync agents attempted to join the same session` exception (https://github.com/realm/realm-js/issues/4506).

The underlying cause of this is a race condition between the sync client for the "old" JS application being destroyed (which happens [after upload completion](https://github.com/realm/realm-core/blob/master/src/realm/object-store/sync/sync_session.cpp#L115) by default), and the "new" (reloaded) JS application opening its Realm and therefore creating a new sync client.

The React Native [invalidate](https://github.com/realm/realm-js/blob/master/react-native/ios/RealmReact/RealmReact.mm#L263) method, which is called when a hot reload occurs to allow cleanup, is unfortunately [asynchronous](https://github.com/realm/realm-js/blob/master/src/jsc/jsc_init.cpp#L60), i.e. React Native does not wait for the invalidation to complete before restarting the new JS thread. Therefore, as a workaround we would like to add a `log_out_all_sync_sessions` static method in core, to immediately close the sync session for all open Realms, which we can then call when a user hot reloads, in the same way as we already call `clear_all_caches`: https://github.com/realm/realm-js/pull/4509. (Further testing suggested that `invalidate` may actually be synchronous, but in any case terminating the sessions works more cleanly for us based on my testing)

As this method is very similar to the existing `clear_cache`, I have added a helper method to call a function for every open Realm and refactored that to use the helper. 

I could not work out what `clear_all_caches` does differently versus directly calling `clear_cache` (perhaps the implementation used to be different, or have I missed some subtle difference?), so I have refactored the code to make `clear_all_caches` the canonical version (as the name is more accurate) but have kept `clear_cache` around as Swift calls it.

## ☑️ ToDos
* [x] 📝 Changelog update
* [ ] 🚦 Tests (or not relevant)
