### PR TITLE
Further separate SubscriptionSets from DB

### DIFF
--- a/src/realm/sync/subscriptions.cpp
+++ b/src/realm/sync/subscriptions.cpp
@@ -382,10 +382,6 @@ SubscriptionSet MutableSubscriptionSet::commit() &&
         throw std::logic_error("SubscriptionSet is not in a commitable state");
     }
     auto mgr = get_flx_subscription_store(); // Throws
-    if (!mgr) {
-        throw std::runtime_error(
-            "Trying to commit a MutableSubscriptionSet after its SubscriptionStore was destroyed");
-    }
 
     if (m_old_state == State::Uncommitted) {
         if (m_state == State::Uncommitted) {

--- a/src/realm/sync/subscriptions.hpp
+++ b/src/realm/sync/subscriptions.hpp
@@ -363,12 +363,14 @@ protected:
     };
 
     void supercede_prior_to(TransactionRef tr, int64_t version_id);
-
     SubscriptionSet get_by_version_impl(int64_t flx_version, util::Optional<DB::VersionID> version) const;
     MutableSubscriptionSet make_mutable_copy(const SubscriptionSet& set) const;
     SubscriptionSet post_commit_update_for(SubscriptionSet&& set);
     util::Future<SubscriptionSet::State> get_notification_future_for(const SubscriptionSet& set,
                                                                      SubscriptionSet::State notify_when);
+
+    void update_live_sub_sets(const SubscriptionSet& new_set);
+    void process_notifications_for(const SubscriptionSet& new_set);
 
     friend class MutableSubscriptionSet;
     friend class Subscription;

--- a/test/test_sync_subscriptions.cpp
+++ b/test/test_sync_subscriptions.cpp
@@ -396,7 +396,7 @@ TEST(Sync_SubscriptionStoreNotifications)
     CHECK_EQUAL(std::move(fut).get(), SubscriptionSet::State::Complete);
 }
 
-TEST(Sync_RefreshSubscriptionSetInvalidSubscriptionStore)
+TEST(Sync_SubscriptionStoreRefreshInvalidSubscriptionStore)
 {
     SHARED_GROUP_TEST_PATH(sub_store_path)
     SubscriptionStoreFixture fixture(sub_store_path);
@@ -408,7 +408,7 @@ TEST(Sync_RefreshSubscriptionSetInvalidSubscriptionStore)
     store.reset();
 
     // Throws since the SubscriptionStore is gone.
-    CHECK_THROW(latest->refresh(), std::logic_error);
+    CHECK_THROW(latest->refresh(), std::runtime_error);
 }
 
 } // namespace realm::sync

--- a/test/test_sync_subscriptions.cpp
+++ b/test/test_sync_subscriptions.cpp
@@ -363,7 +363,7 @@ TEST(Sync_SubscriptionStoreNotifications)
 
     sub_set = store->get_mutable_by_version(6);
     sub_set.update_state(SubscriptionSet::State::Complete);
-    std::move(sub_set).commit();
+    auto committed_sub_set = std::move(sub_set).commit();
 
     CHECK_EQUAL(notification_futures[4].get(), SubscriptionSet::State::Superseded);
     CHECK_EQUAL(notification_futures[5].get(), SubscriptionSet::State::Complete);
@@ -376,7 +376,7 @@ TEST(Sync_SubscriptionStoreNotifications)
 
     // Check that asking for a state change that is less than the current state of the sub set gets filled
     // immediately.
-    CHECK_EQUAL(sub_set.get_state_change_notification(SubscriptionSet::State::Bootstrapping).get(),
+    CHECK_EQUAL(committed_sub_set.get_state_change_notification(SubscriptionSet::State::Bootstrapping).get(),
                 SubscriptionSet::State::Complete);
 
     // Check that if a subscription set gets updated to a new state and the SubscriptionSet returned by commit() is


### PR DESCRIPTION
## What, How & Why?
This is some refactoring of `SubscriptionStore` and its friends to further decouple them from reading from the database. The `SubscriptionStore` will now cache the latest/active versions so that if you just want to read them you don't have to actually read anything from disk. For RCORE-1068 this will make it cheaper to check whether subscriptions have been opened for a table on every write.

I also refactored the places where `SubscriptionSet`/`MutableSubscriptionSet` call into `SubscriptionStore` so that we don't have a bunch of mutable members, don't need to read from the DB for a `SubscriptionSet` we just committed, and reducing the number of methods we need to call from `MutableSubscriptionSet::commit()` to update `SubscriptionStore`'s internal state.

## ☑️ ToDos
* [ ] 📝 Changelog update
* [ ] 🚦 Tests (or not relevant)
