### PR TITLE
pass down a result object instead of an explicit query

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 * Added `realm_object_to_string()` support for c_api. ([#5414](https://github.com/realm/realm-core/issues/5414))
 * Added `ObjectStore::rename_property()` support for c_api. ([#5424]https://github.com/realm/realm-core/issues/5424)
 * Remove deprecated sync protocol errors `disabled_session` and `superseded`. ([#5421]https://github.com/realm/realm-core/issues/5421)
+* Use `realm_results_t` instead of `realm_query_t` for `realm_sync_subscription_set_insert_or_assign` c_api. ([#5431]https://github.com/realm/realm-core/issues/5431) 
 
 ### Fixed
 * <How do the end-user experience this issue? what was the impact?> ([#????](https://github.com/realm/realm-core/issues/????), since v?.?.?)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@
 * Added `realm_object_to_string()` support for c_api. ([#5414](https://github.com/realm/realm-core/issues/5414))
 * Added `ObjectStore::rename_property()` support for c_api. ([#5424]https://github.com/realm/realm-core/issues/5424)
 * Remove deprecated sync protocol errors `disabled_session` and `superseded`. ([#5421]https://github.com/realm/realm-core/issues/5421)
-* Use `realm_results_t` instead of `realm_query_t` for `realm_sync_subscription_set_insert_or_assign` c_api. ([#5431]https://github.com/realm/realm-core/issues/5431) 
+* Support `realm_results_t` and `realm_query_t` for `realm_sync_subscription_set_insert_or_assign` in the c_api. ([#5431]https://github.com/realm/realm-core/issues/5431) 
 
 ### Fixed
 * <How do the end-user experience this issue? what was the impact?> ([#????](https://github.com/realm/realm-core/issues/????), since v?.?.?)

--- a/src/realm.h
+++ b/src/realm.h
@@ -3260,7 +3260,7 @@ realm_sync_make_subscription_set_mutable(realm_flx_sync_subscription_set_t*) RLM
 RLM_API bool realm_sync_subscription_set_clear(realm_flx_sync_mutable_subscription_set_t*) RLM_API_NOEXCEPT;
 
 /**
- *  Insert ot update a query for the subscription set passed as parameter, if successful the index where the query was
+ *  Insert ot update a result for the subscription set passed as parameter, if successful the index where the query was
  * inserted or updated is returned along with the info whether a new query was inserted or not. It is possible to
  * specify a name for the query inserted (optional).
  *  @return true/false if operation was successful

--- a/src/realm.h
+++ b/src/realm.h
@@ -3260,13 +3260,22 @@ realm_sync_make_subscription_set_mutable(realm_flx_sync_subscription_set_t*) RLM
 RLM_API bool realm_sync_subscription_set_clear(realm_flx_sync_mutable_subscription_set_t*) RLM_API_NOEXCEPT;
 
 /**
- *  Insert ot update a result for the subscription set passed as parameter, if successful the index where the query was
- * inserted or updated is returned along with the info whether a new query was inserted or not. It is possible to
+ * Insert ot update the query contained inside a result object for the subscription set passed as parameter, if successful the index where the query
+ * was inserted or updated is returned along with the info whether a new query was inserted or not. It is possible to
  * specify a name for the query inserted (optional).
  *  @return true/false if operation was successful
  */
-RLM_API bool realm_sync_subscription_set_insert_or_assign(realm_flx_sync_mutable_subscription_set_t*, realm_results_t*,
-                                                          const char* name, size_t* out_index,
+RLM_API bool realm_sync_subscription_set_insert_or_assign_results(realm_flx_sync_mutable_subscription_set_t*,
+                                                          realm_results_t*, const char* name, size_t* out_index,
+                                                          bool* out_inserted) RLM_API_NOEXCEPT;
+/**
+ * Insert ot update a query for the subscription set passed as parameter, if successful the index where the query
+ * was inserted or updated is returned along with the info whether a new query was inserted or not. It is possible to
+ * specify a name for the query inserted (optional).
+ *  @return true/false if operation was successful
+ */
+RLM_API bool realm_sync_subscription_set_insert_or_assign_query(realm_flx_sync_mutable_subscription_set_t*,
+                                                          realm_query_t*, const char* name, size_t* out_index,
                                                           bool* out_inserted) RLM_API_NOEXCEPT;
 /**
  *  Erase from subscription set by name

--- a/src/realm.h
+++ b/src/realm.h
@@ -3265,7 +3265,7 @@ RLM_API bool realm_sync_subscription_set_clear(realm_flx_sync_mutable_subscripti
  * specify a name for the query inserted (optional).
  *  @return true/false if operation was successful
  */
-RLM_API bool realm_sync_subscription_set_insert_or_assign(realm_flx_sync_mutable_subscription_set_t*, realm_query_t*,
+RLM_API bool realm_sync_subscription_set_insert_or_assign(realm_flx_sync_mutable_subscription_set_t*, realm_results_t*,
                                                           const char* name, size_t* out_index,
                                                           bool* out_inserted) RLM_API_NOEXCEPT;
 /**

--- a/src/realm.h
+++ b/src/realm.h
@@ -3260,14 +3260,15 @@ realm_sync_make_subscription_set_mutable(realm_flx_sync_subscription_set_t*) RLM
 RLM_API bool realm_sync_subscription_set_clear(realm_flx_sync_mutable_subscription_set_t*) RLM_API_NOEXCEPT;
 
 /**
- * Insert ot update the query contained inside a result object for the subscription set passed as parameter, if successful the index where the query
- * was inserted or updated is returned along with the info whether a new query was inserted or not. It is possible to
- * specify a name for the query inserted (optional).
+ * Insert ot update the query contained inside a result object for the subscription set passed as parameter, if
+ * successful the index where the query was inserted or updated is returned along with the info whether a new query
+ * was inserted or not. It is possible to specify a name for the query inserted (optional).
  *  @return true/false if operation was successful
  */
 RLM_API bool realm_sync_subscription_set_insert_or_assign_results(realm_flx_sync_mutable_subscription_set_t*,
-                                                          realm_results_t*, const char* name, size_t* out_index,
-                                                          bool* out_inserted) RLM_API_NOEXCEPT;
+                                                                  realm_results_t*, const char* name,
+                                                                  size_t* out_index,
+                                                                  bool* out_inserted) RLM_API_NOEXCEPT;
 /**
  * Insert ot update a query for the subscription set passed as parameter, if successful the index where the query
  * was inserted or updated is returned along with the info whether a new query was inserted or not. It is possible to
@@ -3275,8 +3276,8 @@ RLM_API bool realm_sync_subscription_set_insert_or_assign_results(realm_flx_sync
  *  @return true/false if operation was successful
  */
 RLM_API bool realm_sync_subscription_set_insert_or_assign_query(realm_flx_sync_mutable_subscription_set_t*,
-                                                          realm_query_t*, const char* name, size_t* out_index,
-                                                          bool* out_inserted) RLM_API_NOEXCEPT;
+                                                                realm_query_t*, const char* name, size_t* out_index,
+                                                                bool* out_inserted) RLM_API_NOEXCEPT;
 /**
  *  Erase from subscription set by name
  *  @return true/false if operation was successful

--- a/src/realm/object-store/c_api/sync.cpp
+++ b/src/realm/object-store/c_api/sync.cpp
@@ -545,13 +545,13 @@ RLM_API bool realm_sync_subscription_set_clear(realm_flx_sync_mutable_subscripti
 }
 
 RLM_API bool realm_sync_subscription_set_insert_or_assign(realm_flx_sync_mutable_subscription_set_t* subscription_set,
-                                                          realm_query_t* query, const char* name, size_t* index,
+                                                          realm_results_t* results, const char* name, size_t* index,
                                                           bool* inserted) noexcept
 {
-    REALM_ASSERT(subscription_set != nullptr && query != nullptr);
+    REALM_ASSERT(subscription_set != nullptr && results != nullptr);
     return wrap_err([&]() {
-        const auto [it, successful] = name ? subscription_set->insert_or_assign(name, query->get_query())
-                                           : subscription_set->insert_or_assign(query->get_query());
+        const auto [it, successful] = name ? subscription_set->insert_or_assign(name, results->get_query())
+                                           : subscription_set->insert_or_assign(results->get_query());
         *index = std::distance(subscription_set->begin(), it);
         *inserted = successful;
         return true;

--- a/src/realm/object-store/c_api/sync.cpp
+++ b/src/realm/object-store/c_api/sync.cpp
@@ -544,14 +544,30 @@ RLM_API bool realm_sync_subscription_set_clear(realm_flx_sync_mutable_subscripti
     });
 }
 
-RLM_API bool realm_sync_subscription_set_insert_or_assign(realm_flx_sync_mutable_subscription_set_t* subscription_set,
-                                                          realm_results_t* results, const char* name, size_t* index,
-                                                          bool* inserted) noexcept
+RLM_API bool
+realm_sync_subscription_set_insert_or_assign_results(realm_flx_sync_mutable_subscription_set_t* subscription_set,
+                                                     realm_results_t* results, const char* name, size_t* index,
+                                                     bool* inserted) noexcept
 {
     REALM_ASSERT(subscription_set != nullptr && results != nullptr);
     return wrap_err([&]() {
         const auto [it, successful] = name ? subscription_set->insert_or_assign(name, results->get_query())
                                            : subscription_set->insert_or_assign(results->get_query());
+        *index = std::distance(subscription_set->begin(), it);
+        *inserted = successful;
+        return true;
+    });
+}
+
+RLM_API bool
+realm_sync_subscription_set_insert_or_assign_query(realm_flx_sync_mutable_subscription_set_t* subscription_set,
+                                                   realm_query_t* query, const char* name, size_t* index,
+                                                   bool* inserted) noexcept
+{
+    REALM_ASSERT(subscription_set != nullptr && query != nullptr);
+    return wrap_err([&]() {
+        const auto [it, successful] = name ? subscription_set->insert_or_assign(name, query->get_query())
+                                           : subscription_set->insert_or_assign(query->get_query());
         *index = std::distance(subscription_set->begin(), it);
         *inserted = successful;
         return true;

--- a/test/object-store/c_api/c_api.cpp
+++ b/test/object-store/c_api/c_api.cpp
@@ -3915,8 +3915,9 @@ TEST_CASE("app: flx-sync basic tests", "[c_api][flx][syc]") {
             auto new_subs = realm_sync_make_subscription_set_mutable(sub);
             std::size_t index = -1;
             bool inserted = false;
-            auto res =
-                realm_sync_subscription_set_insert_or_assign(new_subs, c_wrap_query_foo, nullptr, &index, &inserted);
+            auto results = realm_query_find_all(c_wrap_query_foo);
+            // realm_results_t
+            auto res = realm_sync_subscription_set_insert_or_assign(new_subs, results, nullptr, &index, &inserted);
             CHECK(inserted == true);
             CHECK(index == 0);
             CHECK(res);
@@ -3927,6 +3928,7 @@ TEST_CASE("app: flx-sync basic tests", "[c_api][flx][syc]") {
             realm_release(sub);
             realm_release(new_subs);
             realm_release(subs);
+            realm_release(results);
         }
 
         wait_for_download(*realm);
@@ -3948,7 +3950,8 @@ TEST_CASE("app: flx-sync basic tests", "[c_api][flx][syc]") {
             auto mut_sub = realm_sync_make_subscription_set_mutable(sub);
             std::size_t index = -1;
             bool inserted = false;
-            realm_sync_subscription_set_insert_or_assign(mut_sub, c_wrap_query_bar, nullptr, &index, &inserted);
+            auto results = realm_query_find_all(c_wrap_query_bar);
+            realm_sync_subscription_set_insert_or_assign(mut_sub, results, nullptr, &index, &inserted);
             CHECK(inserted);
             auto sub_c = realm_sync_subscription_set_commit(mut_sub);
             auto state = realm_sync_on_subscription_set_state_change_wait(
@@ -3957,6 +3960,7 @@ TEST_CASE("app: flx-sync basic tests", "[c_api][flx][syc]") {
             realm_release(sub);
             realm_release(mut_sub);
             realm_release(sub_c);
+            realm_release(results);
         }
 
         {
@@ -3978,8 +3982,8 @@ TEST_CASE("app: flx-sync basic tests", "[c_api][flx][syc]") {
             auto c_wrap_new_query_bar = realm_query_parse(&c_wrap_realm, table_info.key, "name = 'bar'", 0, nullptr);
             std::size_t index = -1;
             bool inserted = false;
-            bool updated = realm_sync_subscription_set_insert_or_assign(mut_sub, c_wrap_new_query_bar, nullptr,
-                                                                        &index, &inserted);
+            auto results = realm_query_find_all(c_wrap_new_query_bar);
+            bool updated = realm_sync_subscription_set_insert_or_assign(mut_sub, results, nullptr, &index, &inserted);
             CHECK(!inserted);
             CHECK(updated);
             auto sub_c = realm_sync_subscription_set_commit(mut_sub);
@@ -3990,6 +3994,7 @@ TEST_CASE("app: flx-sync basic tests", "[c_api][flx][syc]") {
             realm_release(sub);
             realm_release(mut_sub);
             realm_release(sub_c);
+            realm_release(results);
             realm_release(c_wrap_new_query_bar);
         }
 
@@ -4035,8 +4040,8 @@ TEST_CASE("app: flx-sync basic tests", "[c_api][flx][syc]") {
             auto mut_sub = realm_sync_make_subscription_set_mutable(sub);
             std::size_t index = -1;
             bool inserted = false;
-            bool success =
-                realm_sync_subscription_set_insert_or_assign(mut_sub, c_wrap_new_query_bar, "bar", &index, &inserted);
+            auto results = realm_query_find_all(c_wrap_new_query_bar);
+            bool success = realm_sync_subscription_set_insert_or_assign(mut_sub, results, "bar", &index, &inserted);
             CHECK(inserted);
             CHECK(success);
             auto sub_c = realm_sync_subscription_set_commit(mut_sub);
@@ -4046,6 +4051,7 @@ TEST_CASE("app: flx-sync basic tests", "[c_api][flx][syc]") {
             realm_release(sub);
             realm_release(mut_sub);
             realm_release(sub_c);
+            realm_release(results);
             realm_release(c_wrap_new_query_bar);
         }
 
@@ -4086,8 +4092,8 @@ TEST_CASE("app: flx-sync basic tests", "[c_api][flx][syc]") {
             auto mut_sub = realm_sync_make_subscription_set_mutable(sub);
             std::size_t index = -1;
             bool inserted = false;
-            bool success =
-                realm_sync_subscription_set_insert_or_assign(mut_sub, c_wrap_query_bar, nullptr, &index, &inserted);
+            auto results = realm_query_find_all(c_wrap_query_bar);
+            bool success = realm_sync_subscription_set_insert_or_assign(mut_sub, results, nullptr, &index, &inserted);
             CHECK(inserted);
             CHECK(success);
             auto sub_c = realm_sync_subscription_set_commit(mut_sub);
@@ -4135,6 +4141,7 @@ TEST_CASE("app: flx-sync basic tests", "[c_api][flx][syc]") {
             realm_release(sub);
             realm_release(mut_sub);
             realm_release(sub_c);
+            realm_release(results);
             realm_release(test_query);
         }
         realm_release(c_wrap_query_foo);

--- a/test/object-store/c_api/c_api.cpp
+++ b/test/object-store/c_api/c_api.cpp
@@ -3915,9 +3915,9 @@ TEST_CASE("app: flx-sync basic tests", "[c_api][flx][syc]") {
             auto new_subs = realm_sync_make_subscription_set_mutable(sub);
             std::size_t index = -1;
             bool inserted = false;
-            auto results = realm_query_find_all(c_wrap_query_foo);
             // realm_results_t
-            auto res = realm_sync_subscription_set_insert_or_assign(new_subs, results, nullptr, &index, &inserted);
+            auto res = realm_sync_subscription_set_insert_or_assign_query(new_subs, c_wrap_query_foo, nullptr, &index,
+                                                                          &inserted);
             CHECK(inserted == true);
             CHECK(index == 0);
             CHECK(res);
@@ -3928,7 +3928,6 @@ TEST_CASE("app: flx-sync basic tests", "[c_api][flx][syc]") {
             realm_release(sub);
             realm_release(new_subs);
             realm_release(subs);
-            realm_release(results);
         }
 
         wait_for_download(*realm);
@@ -3950,8 +3949,7 @@ TEST_CASE("app: flx-sync basic tests", "[c_api][flx][syc]") {
             auto mut_sub = realm_sync_make_subscription_set_mutable(sub);
             std::size_t index = -1;
             bool inserted = false;
-            auto results = realm_query_find_all(c_wrap_query_bar);
-            realm_sync_subscription_set_insert_or_assign(mut_sub, results, nullptr, &index, &inserted);
+            realm_sync_subscription_set_insert_or_assign_query(mut_sub, c_wrap_query_bar, nullptr, &index, &inserted);
             CHECK(inserted);
             auto sub_c = realm_sync_subscription_set_commit(mut_sub);
             auto state = realm_sync_on_subscription_set_state_change_wait(
@@ -3960,7 +3958,6 @@ TEST_CASE("app: flx-sync basic tests", "[c_api][flx][syc]") {
             realm_release(sub);
             realm_release(mut_sub);
             realm_release(sub_c);
-            realm_release(results);
         }
 
         {
@@ -3983,7 +3980,8 @@ TEST_CASE("app: flx-sync basic tests", "[c_api][flx][syc]") {
             std::size_t index = -1;
             bool inserted = false;
             auto results = realm_query_find_all(c_wrap_new_query_bar);
-            bool updated = realm_sync_subscription_set_insert_or_assign(mut_sub, results, nullptr, &index, &inserted);
+            bool updated =
+                realm_sync_subscription_set_insert_or_assign_results(mut_sub, results, nullptr, &index, &inserted);
             CHECK(!inserted);
             CHECK(updated);
             auto sub_c = realm_sync_subscription_set_commit(mut_sub);
@@ -4041,7 +4039,8 @@ TEST_CASE("app: flx-sync basic tests", "[c_api][flx][syc]") {
             std::size_t index = -1;
             bool inserted = false;
             auto results = realm_query_find_all(c_wrap_new_query_bar);
-            bool success = realm_sync_subscription_set_insert_or_assign(mut_sub, results, "bar", &index, &inserted);
+            bool success =
+                realm_sync_subscription_set_insert_or_assign_results(mut_sub, results, "bar", &index, &inserted);
             CHECK(inserted);
             CHECK(success);
             auto sub_c = realm_sync_subscription_set_commit(mut_sub);
@@ -4093,7 +4092,8 @@ TEST_CASE("app: flx-sync basic tests", "[c_api][flx][syc]") {
             std::size_t index = -1;
             bool inserted = false;
             auto results = realm_query_find_all(c_wrap_query_bar);
-            bool success = realm_sync_subscription_set_insert_or_assign(mut_sub, results, nullptr, &index, &inserted);
+            bool success =
+                realm_sync_subscription_set_insert_or_assign_results(mut_sub, results, nullptr, &index, &inserted);
             CHECK(inserted);
             CHECK(success);
             auto sub_c = realm_sync_subscription_set_commit(mut_sub);


### PR DESCRIPTION
## What, How & Why?
Use `realm_results_t` rather than explicit `realm_query_t` to better adhere to sdk usage of queries. 
Fixes https://github.com/realm/realm-core/issues/5431

## ☑️ ToDos
* [ ] 📝 Changelog update
* [ ] 🚦 Tests (or not relevant)
