### PR TITLE
Expose `SyncUser::access_token()` and `SyncUser::refresh_token()` C API

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,7 +34,7 @@
 * Added `ObjectStore::rename_property()` support for C API. ([#5424]https://github.com/realm/realm-core/issues/5424)
 * Removed deprecated sync protocol errors `disabled_session` and `superseded`. ([#5421]https://github.com/realm/realm-core/issues/5421)
 * Support `realm_results_t` and `realm_query_t` for `realm_sync_subscription_set_insert_or_assign` in the c_api. ([#5431]https://github.com/realm/realm-core/issues/5431) 
-* Added `access_token()` and `refresh_token()` to C API. ([#5421]https://github.com/realm/realm-core/issues/5421)
+* Added `access_token()` and `refresh_token()` to C API. ([#5419]https://github.com/realm/realm-core/issues/5419)
 
 ### Fixed
 * Adding an object to a Set, deleting the parent object, and then deleting the previously mentioned object causes crash ([#5387](https://github.com/realm/realm-core/issues/5387), since 11.0.0)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,10 +30,11 @@
 * `App::link_user()` and `App::delete_user()` now correctly report `ClientErrorCode::user_not_found` and `ClientErrorCode::user_not_logged_in` instead of only using `ClientErrorCode::user_not_found` for both error cases. ([#5402](https://github.com/realm/realm-core/issues/5402))
 * Avoid leaking unresolved mixed links for Lst<Mixed>. ([#5418](https://github.com/realm/realm-core/pull/5418))
 * Add support for embedded objects in the C API. ([#5408](https://github.com/realm/realm-core/issues/5408))
-* Added `realm_object_to_string()` support for c_api. ([#5414](https://github.com/realm/realm-core/issues/5414))
-* Added `ObjectStore::rename_property()` support for c_api. ([#5424]https://github.com/realm/realm-core/issues/5424)
-* Remove deprecated sync protocol errors `disabled_session` and `superseded`. ([#5421]https://github.com/realm/realm-core/issues/5421)
+* Added `realm_object_to_string()` support for C API. ([#5414](https://github.com/realm/realm-core/issues/5414))
+* Added `ObjectStore::rename_property()` support for C API. ([#5424]https://github.com/realm/realm-core/issues/5424)
+* Removed deprecated sync protocol errors `disabled_session` and `superseded`. ([#5421]https://github.com/realm/realm-core/issues/5421)
 * Support `realm_results_t` and `realm_query_t` for `realm_sync_subscription_set_insert_or_assign` in the c_api. ([#5431]https://github.com/realm/realm-core/issues/5431) 
+* Added `access_token()` and `refresh_token()` to C API. ([#5421]https://github.com/realm/realm-core/issues/5421)
 
 ### Fixed
 * Adding an object to a Set, deleting the parent object, and then deleting the previously mentioned object causes crash ([#5387](https://github.com/realm/realm-core/issues/5387), since 11.0.0)

--- a/src/realm.h
+++ b/src/realm.h
@@ -2949,6 +2949,19 @@ RLM_API char* realm_user_get_custom_data(const realm_user_t*) RLM_API_NOEXCEPT;
  */
 RLM_API char* realm_user_get_profile_data(const realm_user_t*);
 
+/**
+ * Return the access token associated with the user.
+ * @return a string that rapresents the access token
+ */
+RLM_API char* realm_user_get_access_token(const realm_user_t*);
+
+/**
+ * Return the refresh token associated with the user.
+ * @return a string that represents the refresh token
+ */
+RLM_API char* realm_user_get_refresh_token(const realm_user_t*);
+
+
 /* Sync */
 typedef enum realm_sync_client_metadata_mode {
     RLM_SYNC_CLIENT_METADATA_MODE_PLAINTEXT,

--- a/src/realm/object-store/c_api/app.cpp
+++ b/src/realm/object-store/c_api/app.cpp
@@ -801,4 +801,18 @@ RLM_API char* realm_user_get_custom_data(const realm_user_t* user) noexcept
     return nullptr;
 }
 
+RLM_API char* realm_user_get_access_token(const realm_user_t* user)
+{
+    return wrap_err([&] {
+        return duplicate_string((*user)->access_token());
+    });
+}
+
+RLM_API char* realm_user_get_refresh_token(const realm_user_t* user)
+{
+    return wrap_err([&] {
+        return duplicate_string((*user)->refresh_token());
+    });
+}
+
 } // namespace realm::c_api


### PR DESCRIPTION
## What, How & Why?
Expose `SyncUser::access_token()` and `SyncUser::refresh_token()` in the C API
Fixes: https://github.com/realm/realm-core/issues/5419

## ☑️ ToDos
* [ ] 📝 Changelog update
* [ ] 🚦 Tests (or not relevant)
