### PR TITLE
Fix created bundled sync Realms

### DIFF
--- a/src/realm/db.cpp
+++ b/src/realm/db.cpp
@@ -1515,10 +1515,9 @@ bool DB::compact(bool bump_version_number, util::Optional<const char*> output_en
     return true;
 }
 
-void DB::write_copy(StringData path, util::Optional<const char*> output_encryption_key, bool allow_overwrite)
+void DB::write_copy(StringData path, const char* output_encryption_key)
 {
     SharedInfo* info = m_file_map.get_addr();
-    const char* write_key = bool(output_encryption_key) ? *output_encryption_key : m_key;
 
     auto tr = start_read();
     if (auto hist = tr->get_history()) {
@@ -1542,10 +1541,10 @@ void DB::write_copy(StringData path, util::Optional<const char*> output_encrypti
     } writer;
 
     File file;
-    file.open(path, File::access_ReadWrite, allow_overwrite ? File::create_Auto : File::create_Must, 0);
+    file.open(path, File::access_ReadWrite, File::create_Must, 0);
     file.resize(0);
 
-    tr->write(file, write_key, info->latest_version_number, writer);
+    tr->write(file, output_encryption_key, info->latest_version_number, writer);
 }
 
 uint_fast64_t DB::get_number_of_versions()

--- a/src/realm/db.hpp
+++ b/src/realm/db.hpp
@@ -300,8 +300,7 @@ public:
     /// WARNING: Compact() is not thread-safe with respect to a concurrent close()
     bool compact(bool bump_version_number = false, util::Optional<const char*> output_encryption_key = util::none);
 
-    void write_copy(StringData path, util::Optional<const char*> output_encryption_key = util::none,
-                    bool allow_overwrite = false);
+    void write_copy(StringData path, const char* output_encryption_key);
 
 #ifdef REALM_DEBUG
     void test_ringbuf();

--- a/src/realm/object-store/c_api/realm.cpp
+++ b/src/realm/object-store/c_api/realm.cpp
@@ -79,7 +79,12 @@ RLM_API bool realm_convert_with_config(const realm_t* realm, const realm_config_
 RLM_API bool realm_convert_with_path(const realm_t* realm, const char* path, realm_binary_t encryption_key)
 {
     return wrap_err([&]() {
-        (*realm)->convert(path, from_capi(encryption_key));
+        Realm::Config config;
+        config.path = path;
+        if (encryption_key.data) {
+            config.encryption_key.assign(encryption_key.data, encryption_key.data + encryption_key.size);
+        }
+        (*realm)->convert(config);
         return true;
     });
 }

--- a/src/realm/object-store/impl/realm_coordinator.cpp
+++ b/src/realm/object-store/impl/realm_coordinator.cpp
@@ -1265,9 +1265,9 @@ bool RealmCoordinator::compact()
     return m_db->compact();
 }
 
-void RealmCoordinator::write_copy(StringData path, BinaryData key, bool allow_overwrite)
+void RealmCoordinator::write_copy(StringData path, const char* key)
 {
-    m_db->write_copy(path, key.data(), allow_overwrite);
+    m_db->write_copy(path, key);
 }
 
 void RealmCoordinator::async_request_write_mutex(Realm& realm)

--- a/src/realm/object-store/impl/realm_coordinator.hpp
+++ b/src/realm/object-store/impl/realm_coordinator.hpp
@@ -197,7 +197,7 @@ public:
 
     void close();
     bool compact();
-    void write_copy(StringData path, BinaryData key, bool allow_overwrite);
+    void write_copy(StringData path, const char* key);
 
     template <typename Pred>
     util::CheckedUniqueLock wait_for_notifiers(Pred&& wait_predicate) REQUIRES(!m_notifier_mutex);

--- a/src/realm/object-store/shared_realm.hpp
+++ b/src/realm/object-store/shared_realm.hpp
@@ -341,40 +341,40 @@ public:
     // WARNING / FIXME: compact() should NOT be exposed publicly on Windows
     // because it's not crash safe! It may corrupt your database if something fails
     bool compact();
+
     /**
-     * The overloaded Realm::convert function offers a way to copy and/or convert a realm.
+     * Copy this Realm's data into another Realm file.
      *
-     * The following options are supported:
-     * - local -> local (config or path)
-     * - local -> sync (config only)
-     * - sync -> local (config only)
-     * - sync -> sync  (config or path)
-     * - sync -> bundlable sync (client file identifier removed)
+     * If the file at `config.path` already exists and \a merge_into_existing
+     * is true, the contents of this Realm will be copied into the existing
+     * Realm at that path. If \a merge_into_existing is false, an exception
+     * will be thrown instead.
      *
-     * Note that for bundled realms it is required that all local changes are synchronized with the
-     * server before the copy can be written. This is to be sure that the file can be used as a
-     * stating point for a newly installed application. The function will throw if there are
-     * pending uploads.
+     * If the destination file does not exist, the action performed depends on
+     * the type of the source and destimation files. If the destination
+     * configuration is a non-sync local Realm configuration, a compacted copy
+     * of the current Transaction's data (which includes uncommitted changes if
+     * applicable!) is written in streaming form, with no history.
+     *
+     * If the target configuration is a sync configuration and the source Realm
+     * is a local Realm, a sync Realm with no file identifier is created and
+     * sync history is synthesized for all of the current objects in the Realm.
+     *
+     * If the target configuration is a sync configuration and the source Realm
+     * is also a sync Realm, a sync Realm with no file identifier is created,
+     * but the existing history is retained instead of synthesizing new
+     * history. This mode requires that the source Realm does not have any
+     * unuploaded changesets, and will thrown an exception if that is not the
+     * case.
+     *
+     * @param config The realm configuration that specifies what file should be
+     *               produced. This can be a local or a synced Realm, encrypted or not.
+     * @param merge_into_existing If true, converting into an existing file
+     *                            will write this Realm's data into that file
+     *                            rather than throwing an exception.
      */
-    /**
-     * Copy or convert a Realm using a config.
-     *
-     * If the file already exists, data will be copied over object per object.
-     * If the file does not exist, the realm file will be exported to the new location and if the
-     * configuration object contains a sync part, a sync history will be synthesized.
-     *
-     * @param config The realm configuration that should be used to create a copy.
-     *               This can be a local or a synced Realm, encrypted or not.
-     */
-    void convert(const Config& config);
-    /**
-     * Copy a Realm using a path.
-     *
-     * @param path The path the realm should be copied to. Local realms will remain local, synced
-     *             realms will remain synced realms.
-     * @param encryption_key The optional encryption key for the new realm.
-     */
-    void convert(const std::string& path, BinaryData encryption_key);
+    void convert(const Config& config, bool merge_into_existing = true);
+
     OwnedBinaryData write_copy();
 
     void verify_thread() const;

--- a/test/object-store/realm.cpp
+++ b/test/object-store/realm.cpp
@@ -108,13 +108,13 @@ private:
 
 TEST_CASE("SharedRealm: get_shared_realm()") {
     TestFile config;
-    config.cache = true;
     config.schema_version = 1;
     config.schema = Schema{
         {"object", {{"value", PropertyType::Int}}},
     };
 
     SECTION("should return the same instance when caching is enabled") {
+        config.cache = true;
         auto realm1 = Realm::get_shared_realm(config);
         auto realm2 = Realm::get_shared_realm(config);
         REQUIRE(realm1.get() == realm2.get());
@@ -181,12 +181,6 @@ TEST_CASE("SharedRealm: get_shared_realm()") {
     }
 
     SECTION("should reject mismatched config") {
-        SECTION("cached") {
-        }
-        SECTION("uncached") {
-            config.cache = false;
-        }
-
         SECTION("schema version") {
             auto realm = Realm::get_shared_realm(config);
             config.schema_version = 2;
@@ -334,7 +328,6 @@ TEST_CASE("SharedRealm: get_shared_realm()") {
         Realm::get_shared_realm(config);
 
         config.schema = util::none;
-        config.cache = false;
         config.schema_mode = SchemaMode::AdditiveExplicit;
         config.schema_version = 0;
 
@@ -406,7 +399,6 @@ TEST_CASE("SharedRealm: get_shared_realm()") {
     }
 
     SECTION("should support using different table subsets on different threads") {
-        config.cache = false;
         auto realm1 = Realm::get_shared_realm(config);
 
         config.schema = Schema{
@@ -451,6 +443,7 @@ TEST_CASE("SharedRealm: get_shared_realm()") {
 #endif
 
     SECTION("should get different instances on different threads") {
+        config.cache = true;
         auto realm1 = Realm::get_shared_realm(config);
         std::thread([&] {
             auto realm2 = Realm::get_shared_realm(config);
@@ -494,6 +487,7 @@ TEST_CASE("SharedRealm: get_shared_realm()") {
     };
 
     SECTION("should get different instances for different explicitly different schedulers") {
+        config.cache = true;
         config.scheduler = std::make_shared<SimpleScheduler>(1);
         auto realm1 = Realm::get_shared_realm(config);
         config.scheduler = std::make_shared<SimpleScheduler>(2);
@@ -507,6 +501,7 @@ TEST_CASE("SharedRealm: get_shared_realm()") {
     }
 
     SECTION("can use Realm with explicit scheduler on different thread") {
+        config.cache = true;
         config.scheduler = std::make_shared<SimpleScheduler>(1);
         auto realm = Realm::get_shared_realm(config);
         std::thread([&] {
@@ -515,6 +510,7 @@ TEST_CASE("SharedRealm: get_shared_realm()") {
     }
 
     SECTION("should get same instance for same explicit execution context on different thread") {
+        config.cache = true;
         config.scheduler = std::make_shared<SimpleScheduler>(1);
         auto realm1 = Realm::get_shared_realm(config);
         std::thread([&] {
@@ -524,6 +520,7 @@ TEST_CASE("SharedRealm: get_shared_realm()") {
     }
 
     SECTION("should not modify the schema when fetching from the cache") {
+        config.cache = true;
         auto realm = Realm::get_shared_realm(config);
         auto object_schema = &*realm->schema().find("object");
         Realm::get_shared_realm(config);
@@ -531,6 +528,7 @@ TEST_CASE("SharedRealm: get_shared_realm()") {
     }
 
     SECTION("should not use cached frozen Realm if versions don't match") {
+        config.cache = true;
         auto realm = Realm::get_shared_realm(config);
         realm->read_group();
         auto frozen1 = realm->freeze();
@@ -612,7 +610,6 @@ TEST_CASE("Get Realm using Async Open", "[asyncOpen]") {
     config.schema = Schema{object_schema};
     SyncTestFile config2(init_sync_manager.app(), "default");
     config2.schema = config.schema;
-    config2.cache = false;
 
     std::mutex mutex;
     SECTION("can open synced Realms that don't already exist") {
@@ -637,7 +634,6 @@ TEST_CASE("Get Realm using Async Open", "[asyncOpen]") {
         ThreadSafeReference realm_ref;
         SyncTestFile config3(init_sync_manager.app(), "default");
         config3.schema = config.schema;
-        config3.cache = false;
         uint64_t client_file_id;
 
         // Create some content
@@ -668,12 +664,7 @@ TEST_CASE("Get Realm using Async Open", "[asyncOpen]") {
             wait_for_download(*realm);
             client_file_id = realm->read_group().get_sync_file_id();
 
-            SECTION("copy using the path") {
-                realm->convert(config3.path, BinaryData());
-            }
-            SECTION("copy using the config") {
-                realm->convert(config3);
-            }
+            realm->convert(config3);
         }
 
         // Create some more content on the server
@@ -706,7 +697,6 @@ TEST_CASE("Get Realm using Async Open", "[asyncOpen]") {
     SECTION("can copy a synced realm to a synced realm") {
         SyncTestFile sync_realm_config1(init_sync_manager.app(), "default");
         sync_realm_config1.schema = config.schema;
-        sync_realm_config1.cache = false;
 
         // Create some content
         auto sync_realm1 = Realm::get_shared_realm(sync_realm_config1);
@@ -719,26 +709,29 @@ TEST_CASE("Get Realm using Async Open", "[asyncOpen]") {
         // Copy to a new sync config
         SyncTestFile sync_realm_config2(init_sync_manager.app(), "default");
         sync_realm_config2.schema = config.schema;
-        sync_realm_config2.cache = false;
 
-
-        SECTION("copy using the path") {
-            sync_realm1->convert(sync_realm_config2.path, BinaryData());
-        }
-        SECTION("copy using the config") {
-            sync_realm1->convert(sync_realm_config2);
-        }
+        sync_realm1->convert(sync_realm_config2);
 
         auto sync_realm2 = Realm::get_shared_realm(sync_realm_config2);
 
         // Check that the data also exists in the new realm
         REQUIRE(sync_realm2->read_group().get_table("class_object")->size() == 1);
+
+        // Verify that sync works and objects created in the new copy will get
+        // synchronized to the old copy
+        sync_realm2->begin_transaction();
+        sync_realm2->read_group().get_table("class_object")->create_object_with_primary_key(1);
+        sync_realm2->commit_transaction();
+        wait_for_upload(*sync_realm2);
+        wait_for_download(*sync_realm1);
+
+        sync_realm1->refresh();
+        REQUIRE(sync_realm1->read_group().get_table("class_object")->size() == 2);
     }
 
     SECTION("can convert a synced realm to a local realm") {
         SyncTestFile sync_realm_config(init_sync_manager.app(), "default");
         sync_realm_config.schema = config.schema;
-        sync_realm_config.cache = false;
 
         // Create some content
         auto sync_realm = Realm::get_shared_realm(sync_realm_config);
@@ -751,7 +744,7 @@ TEST_CASE("Get Realm using Async Open", "[asyncOpen]") {
         // Copy to a new sync config
         TestFile local_realm_config;
         local_realm_config.schema = config.schema;
-        local_realm_config.cache = false;
+        local_realm_config.schema_version = sync_realm_config.schema_version;
 
         sync_realm->convert(local_realm_config);
 
@@ -764,7 +757,6 @@ TEST_CASE("Get Realm using Async Open", "[asyncOpen]") {
     SECTION("can convert a local realm to a synced realm") {
         TestFile local_realm_config;
         local_realm_config.schema = config.schema;
-        local_realm_config.cache = false;
 
         // Create some content
         auto local_realm = Realm::get_shared_realm(local_realm_config);
@@ -789,7 +781,6 @@ TEST_CASE("Get Realm using Async Open", "[asyncOpen]") {
     SECTION("can copy a local realm to a local realm") {
         TestFile local_realm_config1;
         local_realm_config1.schema = config.schema;
-        local_realm_config1.cache = false;
 
         // Create some content
         auto local_realm1 = Realm::get_shared_realm(local_realm_config1);
@@ -800,15 +791,9 @@ TEST_CASE("Get Realm using Async Open", "[asyncOpen]") {
         // Copy to a new sync config
         TestFile local_realm_config2;
         local_realm_config2.schema = config.schema;
-        local_realm_config2.cache = false;
 
 
-        SECTION("copy using the path") {
-            local_realm1->convert(local_realm_config2.path, BinaryData());
-        }
-        SECTION("copy using the config") {
-            local_realm1->convert(local_realm_config2);
-        }
+        local_realm1->convert(local_realm_config2);
 
         auto local_realm2 = Realm::get_shared_realm(local_realm_config2);
 
@@ -1061,7 +1046,6 @@ TEST_CASE("SharedRealm: async writes") {
         return;
 
     TestFile config;
-    config.cache = false;
     config.schema_version = 0;
     config.schema = Schema{
         {"object", {{"value", PropertyType::Int}, {"ints", PropertyType::Array | PropertyType::Int}}},
@@ -2128,7 +2112,6 @@ TEST_CASE("SharedRealm: notifications") {
         return;
 
     TestFile config;
-    config.cache = false;
     config.schema_version = 0;
     config.schema = Schema{
         {"object", {{"value", PropertyType::Int}}},
@@ -2511,7 +2494,6 @@ TEST_CASE("ShareRealm: in-memory mode from buffer") {
 TEST_CASE("ShareRealm: realm closed in did_change callback") {
     TestFile config;
     config.schema_version = 1;
-    config.cache = false;
     config.schema = Schema{
         {"object", {{"value", PropertyType::Int}}},
     };
@@ -2971,7 +2953,6 @@ TEST_CASE("SharedRealm: SchemaChangedFunction") {
     size_t schema_changed_called = 0;
     Schema changed_fixed_schema;
     TestFile config;
-    config.cache = false;
     auto dynamic_config = config;
 
     config.schema = Schema{{"object1",
@@ -3590,7 +3571,6 @@ TEST_CASE("RealmCoordinator: get_unbound_realm()") {
 
 TEST_CASE("KeyPathMapping generation") {
     TestFile config;
-    config.cache = true;
     realm::query_parser::KeyPathMapping mapping;
 
     SECTION("class aliasing") {

--- a/test/object-store/sync/metadata.cpp
+++ b/test/object-store/sync/metadata.cpp
@@ -523,14 +523,9 @@ TEST_CASE("sync metadata: can open old metadata realms", "[sync]") {
         out_path.append(util::format("sync-metadata-v%1.realm", schema_version));
 
         // Write a compacted copy of the metadata realm to the test directory
-        SECTION("copy using the path") {
-            realm->convert(out_path, BinaryData());
-        }
-        SECTION("copy by passing the config") {
-            Realm::Config out_config;
-            out_config.path = out_path;
-            realm->convert(out_config);
-        }
+        Realm::Config out_config;
+        out_config.path = out_path;
+        realm->convert(out_config);
 
         std::cout << "Wrote metadata realm to: " << out_path << "\n";
         return;

--- a/test/test_shared.cpp
+++ b/test/test_shared.cpp
@@ -3920,14 +3920,13 @@ TEST(Shared_WriteCopy)
         t->add_column(type_Int, "value");
         tr->commit();
 
-        db->write_copy(path2.c_str());
-        CHECK_THROW_ANY(db->write_copy(path2.c_str())); // Not allowed to overwrite
-        db->write_copy(path2.c_str(), {}, true);        // Overwrite allowed
+        db->write_copy(path2.c_str(), nullptr);
+        CHECK_THROW_ANY(db->write_copy(path2.c_str(), nullptr)); // Not allowed to overwrite
     }
     {
         auto hist = make_in_realm_history();
         DBRef db = DB::create(*hist, path2);
-        db->write_copy(path3.c_str());
+        db->write_copy(path3.c_str(), nullptr);
     }
     auto hist = make_in_realm_history();
     DBRef db = DB::create(*hist, path3);

--- a/test/test_sync.cpp
+++ b/test/test_sync.cpp
@@ -7130,13 +7130,13 @@ TEST(Sync_BundledRealmFile)
     });
 
     // We cannot write out file if changes are not synced to server
-    CHECK_THROW_ANY(db->write_copy(path.c_str()));
+    CHECK_THROW_ANY(db->write_copy(path.c_str(), nullptr));
 
     session.wait_for_upload_complete_or_client_stopped();
     session.wait_for_download_complete_or_client_stopped();
 
     // Now we can
-    db->write_copy(path.c_str());
+    db->write_copy(path.c_str(), nullptr);
 }
 
 TEST(Sync_UpgradeToClientHistory)


### PR DESCRIPTION
#5432 made it so that sync -> sync convert() synthesizes new sync history, which makes the end result not work as a bundled Realm. The tests did not catch this because none of the tests actually verified that sync worked with the end result (opening the Realm worked, but it'd just result in bad changeset errors from the server).

The path version of `write_copy()` was just a compatibility wrapper to avoid forcing SDKs to update their code, but that's pointless when the function is renamed anyway.

No changelog message since we didn't actually ship it.