### PR TITLE
Turn on durations for object-store tests in evergreen

### DIFF
--- a/evergreen/config.yml
+++ b/evergreen/config.yml
@@ -174,6 +174,7 @@ functions:
           TEST_FLAGS="$TEST_FLAGS ${test_flags|}"
 
           export UNITTEST_EVERGREEN_TEST_RESULTS="$(./evergreen/abspath.sh ${task_name}_results.json)"
+          export UNITTEST_PROGRESS=1
           if [[ -n "${report_test_progress|}" ]]; then
               export UNITTEST_PROGRESS=${report_test_progress|}
           fi


### PR DESCRIPTION
While debugging a hang that I could only trigger on evergreen, I found that the hang analyzer stack traces were not enough to figure out which test sections were problematic. 

These changes will help debug hangs in evergreen by printing out the successful test sections as they complete.