### PR TITLE
baas has different error messages for different versions

### DIFF
--- a/test/object-store/sync/flx_sync.cpp
+++ b/test/object-store/sync/flx_sync.cpp
@@ -234,9 +234,11 @@ TEST_CASE("flx: query on non-queryable field results in query error message", "[
         auto subs = std::move(new_subs).commit();
         auto sub_res = subs.get_state_change_notification(sync::SubscriptionSet::State::Complete).get_no_throw();
         CHECK(!sub_res.is_ok());
-        CHECK(sub_res.get_status().reason() ==
-              "Client provided query with bad syntax: invalid match expression for table "
-              "\"TopLevel\": key \"non_queryable_field\" is not a queryable field");
+        if (sub_res.get_status().reason().find("Client provided query with bad syntax:") == std::string::npos ||
+            sub_res.get_status().reason().find(
+                "\"TopLevel\": key \"non_queryable_field\" is not a queryable field") == std::string::npos) {
+            FAIL(sub_res.get_status().reason());
+        }
 
         CHECK(realm->get_active_subscription_set().version() == 0);
         CHECK(realm->get_latest_subscription_set().version() == 1);


### PR DESCRIPTION
Fix a test failure in "flx: query on non-queryable field results in query error message"

The server error messaged recently changed and so the evergreen tests which pull in the latest version started failing this check. The Jenkins tests pin a specific baas version so they were ok. But this leaves us in a state where we can't check for a specific message. The change here extracts out the beginning and end of the message which are the same for both versions.
old message: `"Client provided query with bad syntax: invalid match expression for table "TopLevel": key "non_queryable_field" is not a queryable field"'`
new message: `'"Client provided query with bad syntax: unsupported query for table "TopLevel": key "non_queryable_field" is not a queryable field"`