### PR TITLE
Make thread-safe-ref transferable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@
 ### Fixed
 * C API client reset callbacks don't leak the `realm_t` parameter. ([#5464](https://github.com/realm/realm-core/pull/5464))
 * The sync client may have sent a corrupted upload cursor leading to a fatal error from the server due to an uninitialized variable. ([#5460](https://github.com/realm/realm-core/pull/5460), since v11.14.0)
+* The realm_async_open_task_start() in C API was not really useful as the received realm reference could not be transferred to another thread. ([#5465](https://github.com/realm/realm-core/pull/5465), since v11.5.0)
  
 ### Breaking changes
 * Extra `realm_free_userdata_func_t` parameter added on some realm_config_set_... functions in the C API. The userdata will be freed when the config object is freed.

--- a/src/realm.h
+++ b/src/realm.h
@@ -3173,6 +3173,8 @@ typedef void (*realm_sync_on_subscription_state_changed)(void* userdata,
  * @param realm Downloaded realm instance, or null if an error occurred.
  *              Move to the thread you want to use it on and
  *              thaw with @a realm_from_thread_safe_reference().
+ *              Be aware that once received through this call, you own
+ *              the object and must release it when used.
  * @param error Null, if the operation complete successfully.
  */
 typedef void (*realm_async_open_task_completion_func_t)(void* userdata, realm_thread_safe_reference_t* realm,

--- a/src/realm/object-store/c_api/sync.cpp
+++ b/src/realm/object-store/c_api/sync.cpp
@@ -683,7 +683,9 @@ realm_sync_subscription_set_commit(realm_flx_sync_mutable_subscription_set_t* su
 
 RLM_API realm_async_open_task_t* realm_open_synchronized(realm_config_t* config) noexcept
 {
-    return new realm_async_open_task_t(Realm::get_synchronized_realm(*config));
+    return wrap_err([config] {
+        return new realm_async_open_task_t(Realm::get_synchronized_realm(*config));
+    });
 }
 
 RLM_API void realm_async_open_task_start(realm_async_open_task_t* task, realm_async_open_task_completion_func_t done,
@@ -696,8 +698,8 @@ RLM_API void realm_async_open_task_start(realm_async_open_task_t* task, realm_as
             done(userdata.get(), nullptr, &c_error);
         }
         else {
-            realm_t::thread_safe_reference c_realm(std::move(realm));
-            done(userdata.get(), &c_realm, nullptr);
+            auto tsr = new realm_t::thread_safe_reference(std::move(realm));
+            done(userdata.get(), tsr, nullptr);
         }
     };
     (*task)->start(std::move(cb));

--- a/test/object-store/c_api/c_api.cpp
+++ b/test/object-store/c_api/c_api.cpp
@@ -4,6 +4,7 @@
 #include <realm/object-store/object.hpp>
 #include <realm/object-store/c_api/types.hpp>
 #include <realm/object-store/sync/generic_network_transport.hpp>
+#include <realm/util/base64.hpp>
 
 #include "sync/flx_sync_harness.hpp"
 #include "util/test_file.hpp"
@@ -233,7 +234,7 @@ CPtr<T> clone_cptr(const T* ptr)
         }                                                                                                            \
     } while (false);
 
-TEST_CASE("C API (C)") {
+TEST_CASE("C API (C)", "[c_api]") {
     const char* file_name = "c_api_test_c.realm";
 
     // FIXME: Use a better test file guard.
@@ -244,7 +245,7 @@ TEST_CASE("C API (C)") {
     CHECK(realm_c_api_tests(file_name) == 0);
 }
 
-TEST_CASE("C API (non-database)") {
+TEST_CASE("C API (non-database)", "[c_api]") {
     SECTION("realm_get_library_version_numbers()") {
         int major, minor, patch;
         const char* extra;
@@ -778,7 +779,7 @@ bool should_compact_on_launch(void* userdata_p, uint64_t, uint64_t)
 
 } // anonymous namespace
 
-TEST_CASE("C API") {
+TEST_CASE("C API", "[c_api]") {
     TestFile test_file;
 
     SECTION("schema in config") {
@@ -3888,8 +3889,103 @@ TEST_CASE("C API") {
     realm_release(realm);
 }
 
+struct Userdata {
+    std::atomic<bool> called{false};
+    bool has_error;
+    realm_error_t error;
+    realm_thread_safe_reference_t* realm_ref = nullptr;
+};
+
+void task_completion_func(void* p, realm_thread_safe_reference_t* realm, const realm_async_error_t* async_error)
+{
+    auto userdata_p = static_cast<Userdata*>(p);
+
+    userdata_p->realm_ref = realm;
+    userdata_p->has_error = async_error != nullptr;
+    if (userdata_p->has_error)
+        realm_get_async_error(async_error, &userdata_p->error);
+    userdata_p->called = true;
+}
+
+TEST_CASE("C API - async_open", "[c_api][sync]") {
+    TestSyncManager init_sync_manager;
+    SyncTestFile test_config(init_sync_manager.app(), "default");
+    test_config.cache = false;
+    ObjectSchema object_schema = {"object",
+                                  {
+                                      {"_id", PropertyType::Int, Property::IsPrimary{true}},
+                                      {"value", PropertyType::Int},
+                                  }};
+    test_config.schema = Schema{object_schema};
+
+    SECTION("can open synced Realms that don't already exist") {
+        realm_config_t* config = realm_config_new();
+        config->schema = Schema{object_schema};
+        realm_user user(init_sync_manager.app()->current_user());
+        realm_sync_config_t* sync_config = realm_sync_config_new(&user, "default");
+        realm_config_set_path(config, test_config.path.c_str());
+        realm_config_set_sync_config(config, sync_config);
+        realm_config_set_schema_version(config, 1);
+        Userdata userdata;
+        realm_async_open_task_t* task = realm_open_synchronized(config);
+        REQUIRE(task);
+        realm_async_open_task_start(task, task_completion_func, &userdata, nullptr);
+        util::EventLoop::main().run_until([&] {
+            return userdata.called.load();
+        });
+        REQUIRE(userdata.called);
+        REQUIRE(userdata.realm_ref);
+        realm_release(task);
+
+        realm_t* realm = realm_from_thread_safe_reference(userdata.realm_ref, nullptr);
+        realm_release(userdata.realm_ref);
+
+        bool found;
+        realm_class_info_t class_info;
+        realm_find_class(realm, "object", &found, &class_info);
+        REQUIRE(found);
+        realm_release(realm);
+        realm_release(config);
+        realm_release(sync_config);
+    }
+
+    SECTION("cancels download and reports an error on auth error") {
+        // Create a token which can be parsed as a JWT but is not valid
+        std::string unencoded_body = nlohmann::json({{"exp", 123}, {"iat", 456}}).dump();
+        std::string encoded_body;
+        encoded_body.resize(util::base64_encoded_size(unencoded_body.size()));
+        util::base64_encode(unencoded_body.data(), unencoded_body.size(), &encoded_body[0], encoded_body.size());
+        auto invalid_token = "." + encoded_body + ".";
+
+
+        realm_config_t* config = realm_config_new();
+        config->schema = Schema{object_schema};
+        realm_user user(init_sync_manager.app()->current_user());
+        realm_sync_config_t* sync_config = realm_sync_config_new(&user, "realm");
+        sync_config->user->update_refresh_token(std::string(invalid_token));
+        sync_config->user->update_access_token(std::move(invalid_token));
+
+        realm_config_set_path(config, test_config.path.c_str());
+        realm_config_set_sync_config(config, sync_config);
+        realm_config_set_schema_version(config, 1);
+        Userdata userdata;
+        realm_async_open_task_t* task = realm_open_synchronized(config);
+        REQUIRE(task);
+        realm_async_open_task_start(task, task_completion_func, &userdata, nullptr);
+        init_sync_manager.network_callback(app::Response{403});
+        util::EventLoop::main().run_until([&] {
+            return userdata.called.load();
+        });
+        REQUIRE(userdata.called);
+        REQUIRE(!userdata.realm_ref);
+        realm_release(task);
+        realm_release(config);
+        realm_release(sync_config);
+    }
+}
+
 #ifdef REALM_ENABLE_AUTH_TESTS
-TEST_CASE("app: flx-sync basic tests", "[c_api][flx][syc]") {
+TEST_CASE("app: flx-sync basic tests", "[c_api][flx][sync]") {
     using namespace realm::app;
 
     auto make_schema = [] {

--- a/test/object-store/c_api/c_api.cpp
+++ b/test/object-store/c_api/c_api.cpp
@@ -8,11 +8,17 @@
 
 #include "sync/flx_sync_harness.hpp"
 #include "util/test_file.hpp"
+#include "util/event_loop.hpp"
 #include "realm/object-store/impl/object_accessor_impl.hpp"
 
 #include <cstring>
 #include <numeric>
 #include <thread>
+
+#if REALM_ENABLE_SYNC
+#include <realm/object-store/sync/sync_user.hpp>
+#include <external/json/json.hpp>
+#endif
 
 using namespace realm;
 
@@ -3896,7 +3902,9 @@ struct Userdata {
     realm_thread_safe_reference_t* realm_ref = nullptr;
 };
 
-void task_completion_func(void* p, realm_thread_safe_reference_t* realm, const realm_async_error_t* async_error)
+#if REALM_ENABLE_SYNC
+static void task_completion_func(void* p, realm_thread_safe_reference_t* realm,
+                                 const realm_async_error_t* async_error)
 {
     auto userdata_p = static_cast<Userdata*>(p);
 
@@ -3983,6 +3991,7 @@ TEST_CASE("C API - async_open", "[c_api][sync]") {
         realm_release(sync_config);
     }
 }
+#endif
 
 #ifdef REALM_ENABLE_AUTH_TESTS
 TEST_CASE("app: flx-sync basic tests", "[c_api][flx][sync]") {


### PR DESCRIPTION
The callback function called during realm_async_open_task_start must
receive a pointer to a thread-safe-ref that can be transferred to another thread.
For that to be possible the object must be allocated on the heap so that the
callee owns the object. Previously the pointer was pointing to a stack based
local variable.

## What, How & Why?
<!-- Describe the changes and give some hints to guide your reviewers if possible. -->
<!-- Link to relevant issue this fixes -->

## ☑️ ToDos
* [x] 📝 Changelog update
* [x] 🚦 Tests (or not relevant)
