### PR TITLE
Expose erase and find by results + erase by id for subscriptions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,9 @@
 * Expose client reset functionalities for C API. ([#5425](https://github.com/realm/realm-core/issues/5425))
 * Add missing `userdata` and `userdata_free` arguments to `realm_sync_on_subscription_set_state_change_async` ([#5438](https://github.com/realm/realm-core/pull/5438))
 * Added callbacks for freeing userdata used in callbacks set on RealmConfiguration via C API. ([#5222](https://github.com/realm/realm-core/issues/5222))
-* Expose Subscription properties on C-API ([#5454](https://github.com/realm/realm-core/pull/5454))
+* Expose Subscription properties on C API. ([#5454](https://github.com/realm/realm-core/pull/5454))
+* Erase Subscription by id for C API. ([#5475]https://github.com/realm/realm-core/issues/5475)
+* Erase and Find Subscription by Results for C API. ([#5470](https://github.com/realm/realm-core/issues/5470))
 
 ### Fixed
 * C API client reset callbacks don't leak the `realm_t` parameter. ([#5464](https://github.com/realm/realm-core/pull/5464))

--- a/src/realm.h
+++ b/src/realm.h
@@ -3230,35 +3230,59 @@ RLM_API void realm_sync_config_set_after_client_reset_handler(realm_sync_config_
                                                               realm_sync_after_client_reset_func_t, void* userdata,
                                                               realm_free_userdata_func_t) RLM_API_NOEXCEPT;
 
-RLM_API realm_object_id_t realm_flx_sync_subscription_id(const realm_flx_sync_subscription_t* subscription)
+/**
+ * Fetch subscription id for the subscription passed as argument.
+ * @return realm_object_id_t for the subscription passed as argument
+ */
+RLM_API realm_object_id_t realm_sync_subscription_id(const realm_flx_sync_subscription_t* subscription)
     RLM_API_NOEXCEPT;
 
-RLM_API realm_string_t realm_flx_sync_subscription_name(const realm_flx_sync_subscription_t* subscription)
+/**
+ * Fetch subscription name for the subscription passed as argument.
+ * @return realm_string_t which contains the name of the subscription.
+ */
+RLM_API realm_string_t realm_sync_subscription_name(const realm_flx_sync_subscription_t* subscription)
     RLM_API_NOEXCEPT;
 
+/**
+ * Fetch object class name for the subscription passed as argument.
+ * @return a realm_string_t which contains the class name of the subscription.
+ */
 RLM_API realm_string_t
-realm_flx_sync_subscription_object_class_name(const realm_flx_sync_subscription_t* subscription) RLM_API_NOEXCEPT;
+realm_sync_subscription_object_class_name(const realm_flx_sync_subscription_t* subscription) RLM_API_NOEXCEPT;
 
-RLM_API realm_string_t realm_flx_sync_subscription_query_string(const realm_flx_sync_subscription_t* subscription)
+/**
+ * Fetch the query string associated with the subscription passed as argument.
+ * @return realm_string_t which contains the query associated with the subscription.
+ */
+RLM_API realm_string_t realm_sync_subscription_query_string(const realm_flx_sync_subscription_t* subscription)
     RLM_API_NOEXCEPT;
 
-RLM_API realm_timestamp_t realm_flx_sync_subscription_created_at(const realm_flx_sync_subscription_t* subscription)
+/**
+ * Fetch the timestamp in which the subscription was created for the subscription passed as argument.
+ * @return realm_timestamp_t representing the timestamp in which the subscription for created.
+ */
+RLM_API realm_timestamp_t realm_sync_subscription_created_at(const realm_flx_sync_subscription_t* subscription)
     RLM_API_NOEXCEPT;
 
-RLM_API realm_timestamp_t realm_flx_sync_subscription_updated_at(const realm_flx_sync_subscription_t* subscription)
+/**
+ * Fetch the timestamp in which the subscription was updated for the subscription passed as argument.
+ * @return realm_timestamp_t representing the timestamp in which the subscription was updated.
+ */
+RLM_API realm_timestamp_t realm_sync_subscription_updated_at(const realm_flx_sync_subscription_t* subscription)
     RLM_API_NOEXCEPT;
 
 /**
  * Get latest subscription set
  * @return a non null subscription set pointer if such it exists.
  */
-RLM_API realm_flx_sync_subscription_set_t* realm_sync_get_latest_subscription_set(const realm_t*) RLM_API_NOEXCEPT;
+RLM_API realm_flx_sync_subscription_set_t* realm_sync_get_latest_subscription_set(const realm_t*);
 
 /**
  * Get active subscription set
  * @return a non null subscription set pointer if such it exists.
  */
-RLM_API realm_flx_sync_subscription_set_t* realm_sync_get_active_subscription_set(const realm_t*) RLM_API_NOEXCEPT;
+RLM_API realm_flx_sync_subscription_set_t* realm_sync_get_active_subscription_set(const realm_t*);
 
 /**
  * Wait until subscripton set state is equal to the state passed as parameter.
@@ -3277,7 +3301,7 @@ RLM_API bool
 realm_sync_on_subscription_set_state_change_async(const realm_flx_sync_subscription_set_t* subscription_set,
                                                   realm_flx_sync_subscription_set_state_e notify_when,
                                                   realm_sync_on_subscription_state_changed callback, void* userdata,
-                                                  realm_free_userdata_func_t userdata_free) RLM_API_NOEXCEPT;
+                                                  realm_free_userdata_func_t userdata_free);
 
 /**
  *  Retrieve version for the subscription set passed as parameter
@@ -3309,37 +3333,46 @@ RLM_API size_t realm_sync_subscription_set_size(const realm_flx_sync_subscriptio
  *  @return the subscription or nullptr if the index is not valid
  */
 RLM_API realm_flx_sync_subscription_t* realm_sync_subscription_at(const realm_flx_sync_subscription_set_t*,
-                                                                  size_t index) RLM_API_NOEXCEPT;
-/**
- *  Find subscription by name
- *  @return a pointer to the subscription with the name passed as parameter
- */
-RLM_API realm_flx_sync_subscription_t* realm_sync_find_subscription_by_name(const realm_flx_sync_subscription_set_t*,
-                                                                            const char* name) RLM_API_NOEXCEPT;
+                                                                  size_t index);
 /**
  *  Find subscription associated to the query passed as parameter
  *  @return a pointer to the subscription or nullptr if not found
  */
 RLM_API realm_flx_sync_subscription_t* realm_sync_find_subscription_by_query(const realm_flx_sync_subscription_set_t*,
                                                                              realm_query_t*) RLM_API_NOEXCEPT;
+
+/**
+ *  Find subscription associated to the results set  passed as parameter
+ *  @return a pointer to the subscription or nullptr if not found
+ */
+RLM_API realm_flx_sync_subscription_t* realm_sync_find_subscription_by_results(const realm_flx_sync_subscription_set_t*, realm_results_t*) RLM_API_NOEXCEPT;
+
+
+/**
+ *  Find subscription by name passed as parameter
+ *  @return a pointer to the subscription or nullptr if not found
+ */
+RLM_API realm_flx_sync_subscription_t* realm_sync_find_subscription_by_name(const realm_flx_sync_subscription_set_t*,
+                                                                            const char* name) RLM_API_NOEXCEPT;
+
 /**
  *  Refresh subscription
  *  @return true/false if the operation was successful or not
  */
-RLM_API bool realm_sync_subscription_set_refresh(realm_flx_sync_subscription_set_t*) RLM_API_NOEXCEPT;
+RLM_API bool realm_sync_subscription_set_refresh(realm_flx_sync_subscription_set_t*);
 
 /**
  *  Convert a subscription into a mutable one in order to alter the subscription itself
  *  @return a pointer to a mutable subscription
  */
 RLM_API realm_flx_sync_mutable_subscription_set_t*
-realm_sync_make_subscription_set_mutable(realm_flx_sync_subscription_set_t*) RLM_API_NOEXCEPT;
+realm_flx_sync_make_subscription_set_mutable(realm_flx_sync_subscription_set_t*);
 
 /**
  *  Clear the subscription set passed as parameter
  *  @return true/false if operation was successful
  */
-RLM_API bool realm_sync_subscription_set_clear(realm_flx_sync_mutable_subscription_set_t*) RLM_API_NOEXCEPT;
+RLM_API bool realm_sync_subscription_set_clear(realm_flx_sync_mutable_subscription_set_t*);
 
 /**
  * Insert ot update the query contained inside a result object for the subscription set passed as parameter, if
@@ -3350,7 +3383,7 @@ RLM_API bool realm_sync_subscription_set_clear(realm_flx_sync_mutable_subscripti
 RLM_API bool realm_sync_subscription_set_insert_or_assign_results(realm_flx_sync_mutable_subscription_set_t*,
                                                                   realm_results_t*, const char* name,
                                                                   size_t* out_index,
-                                                                  bool* out_inserted) RLM_API_NOEXCEPT;
+                                                                  bool* out_inserted);
 /**
  * Insert ot update a query for the subscription set passed as parameter, if successful the index where the query
  * was inserted or updated is returned along with the info whether a new query was inserted or not. It is possible to
@@ -3359,25 +3392,37 @@ RLM_API bool realm_sync_subscription_set_insert_or_assign_results(realm_flx_sync
  */
 RLM_API bool realm_sync_subscription_set_insert_or_assign_query(realm_flx_sync_mutable_subscription_set_t*,
                                                                 realm_query_t*, const char* name, size_t* out_index,
-                                                                bool* out_inserted) RLM_API_NOEXCEPT;
+                                                                bool* out_inserted);
 /**
- *  Erase from subscription set by name
- *  @return true/false if operation was successful
+ *  Erase from subscription set by id. If operation completes successfully set the bool out param.
+ *  @return true if no error occurred, false otherwise (use realm_get_last_error for fetching the error).
+ */
+RLM_API bool realm_sync_subscription_set_erase_by_id(realm_flx_sync_mutable_subscription_set_t*,
+                                                        const realm_object_id_t*, bool*);
+/**
+ *  Erase from subscription set by name. If operation completes successfully set the bool out param.
+ *  @return true if no error occurred, false otherwise (use realm_get_last_error for fetching the error)
  */
 RLM_API bool realm_sync_subscription_set_erase_by_name(realm_flx_sync_mutable_subscription_set_t*,
-                                                       const char*) RLM_API_NOEXCEPT;
+                                                       const char*, bool* erased);
 /**
- *  Erase from subscription set by query
- *  @return true/false if operation was successful
+ *  Erase from subscription set by query. If operation completes successfully set the bool out param.
+ *  @return true if no error occurred, false otherwise (use realm_get_last_error for fetching the error)
  */
 RLM_API bool realm_sync_subscription_set_erase_by_query(realm_flx_sync_mutable_subscription_set_t*,
-                                                        realm_query_t*) RLM_API_NOEXCEPT;
+                                                        realm_query_t*, bool* erased);
+/**
+ *  Erase from subscription set by results. If operation completes successfully set the bool out param.
+ *  @return true if no error occurred, false otherwise (use realm_get_last_error for fetching the error)
+ */
+RLM_API bool realm_sync_subscription_set_erase_by_results(realm_flx_sync_mutable_subscription_set_t*,
+                                                        realm_results_t*, bool* erased);
 /**
  *  Commit the subscription_set passed as parameter (in order that all the changes made will take effect)
  *  @return pointer to a valid immutable subscription if commit was successful
  */
 RLM_API realm_flx_sync_subscription_set_t*
-realm_sync_subscription_set_commit(realm_flx_sync_mutable_subscription_set_t*) RLM_API_NOEXCEPT;
+realm_sync_subscription_set_commit(realm_flx_sync_mutable_subscription_set_t*);
 
 /**
  * Create a task that will open a realm with the specific configuration

--- a/src/realm/object-store/c_api/sync.cpp
+++ b/src/realm/object-store/c_api/sync.cpp
@@ -414,41 +414,41 @@ RLM_API void realm_sync_config_set_resync_mode(realm_sync_config_t* config,
     config->client_resync_mode = ClientResyncMode(mode);
 }
 
-RLM_API realm_object_id_t realm_flx_sync_subscription_id(const realm_flx_sync_subscription_t* subscription) noexcept
+RLM_API realm_object_id_t realm_sync_subscription_id(const realm_flx_sync_subscription_t* subscription) noexcept
 {
     REALM_ASSERT(subscription != nullptr);
     return to_capi(subscription->id());
 }
 
-RLM_API realm_string_t realm_flx_sync_subscription_name(const realm_flx_sync_subscription_t* subscription) noexcept
+RLM_API realm_string_t realm_sync_subscription_name(const realm_flx_sync_subscription_t* subscription) noexcept
 {
     REALM_ASSERT(subscription != nullptr);
     return to_capi(subscription->name());
 }
 
 RLM_API realm_string_t
-realm_flx_sync_subscription_object_class_name(const realm_flx_sync_subscription_t* subscription) noexcept
+realm_sync_subscription_object_class_name(const realm_flx_sync_subscription_t* subscription) noexcept
 {
     REALM_ASSERT(subscription != nullptr);
     return to_capi(subscription->object_class_name());
 }
 
 RLM_API realm_string_t
-realm_flx_sync_subscription_query_string(const realm_flx_sync_subscription_t* subscription) noexcept
+realm_sync_subscription_query_string(const realm_flx_sync_subscription_t* subscription) noexcept
 {
     REALM_ASSERT(subscription != nullptr);
     return to_capi(subscription->query_string());
 }
 
 RLM_API realm_timestamp_t
-realm_flx_sync_subscription_created_at(const realm_flx_sync_subscription_t* subscription) noexcept
+realm_sync_subscription_created_at(const realm_flx_sync_subscription_t* subscription) noexcept
 {
     REALM_ASSERT(subscription != nullptr);
     return to_capi(subscription->created_at());
 }
 
 RLM_API realm_timestamp_t
-realm_flx_sync_subscription_updated_at(const realm_flx_sync_subscription_t* subscription) noexcept
+realm_sync_subscription_updated_at(const realm_flx_sync_subscription_t* subscription) noexcept
 {
     REALM_ASSERT(subscription != nullptr);
     return to_capi(subscription->updated_at());
@@ -480,7 +480,7 @@ RLM_API void realm_sync_config_set_after_client_reset_handler(realm_sync_config_
     config->notify_after_client_reset = std::move(cb);
 }
 
-RLM_API realm_flx_sync_subscription_set_t* realm_sync_get_latest_subscription_set(const realm_t* realm) noexcept
+RLM_API realm_flx_sync_subscription_set_t* realm_sync_get_latest_subscription_set(const realm_t* realm)
 {
     REALM_ASSERT(realm != nullptr);
     return wrap_err([&]() {
@@ -488,7 +488,7 @@ RLM_API realm_flx_sync_subscription_set_t* realm_sync_get_latest_subscription_se
     });
 }
 
-RLM_API realm_flx_sync_subscription_set_t* realm_sync_get_active_subscription_set(const realm_t* realm) noexcept
+RLM_API realm_flx_sync_subscription_set_t* realm_sync_get_active_subscription_set(const realm_t* realm)
 {
     REALM_ASSERT(realm != nullptr);
     return wrap_err([&]() {
@@ -506,11 +506,9 @@ realm_sync_on_subscription_set_state_change_wait(const realm_flx_sync_subscripti
     return realm_flx_sync_subscription_set_state_e(static_cast<int>(state));
 }
 
-RLM_API bool
-realm_sync_on_subscription_set_state_change_async(const realm_flx_sync_subscription_set_t* subscription_set,
-                                                  realm_flx_sync_subscription_set_state_e notify_when,
-                                                  realm_sync_on_subscription_state_changed callback, void* userdata,
-                                                  realm_free_userdata_func_t userdata_free) noexcept
+RLM_API bool realm_sync_on_subscription_set_state_change_async(
+    const realm_flx_sync_subscription_set_t* subscription_set, realm_flx_sync_subscription_set_state_e notify_when,
+    realm_sync_on_subscription_state_changed callback, void* userdata, realm_free_userdata_func_t userdata_free)
 {
     REALM_ASSERT(subscription_set != nullptr && callback != nullptr);
     return wrap_err([&]() {
@@ -567,7 +565,18 @@ realm_sync_find_subscription_by_name(const realm_flx_sync_subscription_set_t* su
 }
 
 RLM_API realm_flx_sync_subscription_t*
-realm_sync_subscription_at(const realm_flx_sync_subscription_set_t* subscription_set, size_t index) noexcept
+realm_sync_find_subscription_by_results(const realm_flx_sync_subscription_set_t* subscription_set,
+                                        realm_results_t* results) noexcept
+{
+    REALM_ASSERT(subscription_set != nullptr);
+    auto it = subscription_set->find(results->get_query());
+    if (it == subscription_set->end())
+        return nullptr;
+    return new realm_flx_sync_subscription_t{*it};
+}
+
+RLM_API realm_flx_sync_subscription_t*
+realm_sync_subscription_at(const realm_flx_sync_subscription_set_t* subscription_set, size_t index)
 {
     REALM_ASSERT(subscription_set != nullptr && index < subscription_set->size());
     try {
@@ -589,7 +598,7 @@ realm_sync_find_subscription_by_query(const realm_flx_sync_subscription_set_t* s
     return new realm_flx_sync_subscription_t(*it);
 }
 
-RLM_API bool realm_sync_subscription_set_refresh(realm_flx_sync_subscription_set_t* subscription_set) noexcept
+RLM_API bool realm_sync_subscription_set_refresh(realm_flx_sync_subscription_set_t* subscription_set)
 {
     REALM_ASSERT(subscription_set != nullptr);
     return wrap_err([&]() {
@@ -599,7 +608,7 @@ RLM_API bool realm_sync_subscription_set_refresh(realm_flx_sync_subscription_set
 }
 
 RLM_API realm_flx_sync_mutable_subscription_set_t*
-realm_sync_make_subscription_set_mutable(realm_flx_sync_subscription_set_t* subscription_set) noexcept
+realm_flx_sync_make_subscription_set_mutable(realm_flx_sync_subscription_set_t* subscription_set)
 {
     REALM_ASSERT(subscription_set != nullptr);
     return wrap_err([&]() {
@@ -607,7 +616,7 @@ realm_sync_make_subscription_set_mutable(realm_flx_sync_subscription_set_t* subs
     });
 }
 
-RLM_API bool realm_sync_subscription_set_clear(realm_flx_sync_mutable_subscription_set_t* subscription_set) noexcept
+RLM_API bool realm_sync_subscription_set_clear(realm_flx_sync_mutable_subscription_set_t* subscription_set)
 {
     REALM_ASSERT(subscription_set != nullptr);
     return wrap_err([&]() {
@@ -619,7 +628,7 @@ RLM_API bool realm_sync_subscription_set_clear(realm_flx_sync_mutable_subscripti
 RLM_API bool
 realm_sync_subscription_set_insert_or_assign_results(realm_flx_sync_mutable_subscription_set_t* subscription_set,
                                                      realm_results_t* results, const char* name, size_t* index,
-                                                     bool* inserted) noexcept
+                                                     bool* inserted)
 {
     REALM_ASSERT(subscription_set != nullptr && results != nullptr);
     return wrap_err([&]() {
@@ -634,7 +643,7 @@ realm_sync_subscription_set_insert_or_assign_results(realm_flx_sync_mutable_subs
 RLM_API bool
 realm_sync_subscription_set_insert_or_assign_query(realm_flx_sync_mutable_subscription_set_t* subscription_set,
                                                    realm_query_t* query, const char* name, size_t* index,
-                                                   bool* inserted) noexcept
+                                                   bool* inserted)
 {
     REALM_ASSERT(subscription_set != nullptr && query != nullptr);
     return wrap_err([&]() {
@@ -646,13 +655,32 @@ realm_sync_subscription_set_insert_or_assign_query(realm_flx_sync_mutable_subscr
     });
 }
 
+RLM_API bool realm_sync_subscription_set_erase_by_id(realm_flx_sync_mutable_subscription_set_t* subscription_set,
+                                                     const realm_object_id_t* id, bool* erased)
+{
+    REALM_ASSERT(subscription_set != nullptr && id != nullptr);
+    *erased = false;
+    return wrap_err([&] {
+        auto it = std::find_if(subscription_set->begin(), subscription_set->end(), [id](const Subscription& sub) {
+            return from_capi(*id) == sub.id();
+        });
+        if (it == subscription_set->end())
+            return false;
+        subscription_set->erase(it);
+        *erased = true;
+        return true;
+    });
+}
+
 RLM_API bool realm_sync_subscription_set_erase_by_name(realm_flx_sync_mutable_subscription_set_t* subscription_set,
-                                                       const char* name) noexcept
+                                                       const char* name, bool* erased)
 {
     REALM_ASSERT(subscription_set != nullptr && name != nullptr);
+    *erased = false;
     return wrap_err([&]() {
         if (auto it = subscription_set->find(name); it != subscription_set->end()) {
             subscription_set->erase(it);
+            *erased = true;
             return true;
         }
         return false;
@@ -660,12 +688,29 @@ RLM_API bool realm_sync_subscription_set_erase_by_name(realm_flx_sync_mutable_su
 }
 
 RLM_API bool realm_sync_subscription_set_erase_by_query(realm_flx_sync_mutable_subscription_set_t* subscription_set,
-                                                        realm_query_t* query) noexcept
+                                                        realm_query_t* query, bool* erased)
 {
     REALM_ASSERT(subscription_set != nullptr && query != nullptr);
+    *erased = false;
     return wrap_err([&]() {
         if (auto it = subscription_set->find(query->get_query()); it != subscription_set->end()) {
             subscription_set->erase(it);
+            *erased = true;
+            return true;
+        }
+        return false;
+    });
+}
+
+RLM_API bool realm_sync_subscription_set_erase_by_results(realm_flx_sync_mutable_subscription_set_t* subscription_set,
+                                                          realm_results_t* results, bool* erased)
+{
+    REALM_ASSERT(subscription_set != nullptr && results != nullptr);
+    *erased = false;
+    return wrap_err([&]() {
+        if (auto it = subscription_set->find(results->get_query()); it != subscription_set->end()) {
+            subscription_set->erase(it);
+            *erased = true;
             return true;
         }
         return false;
@@ -673,7 +718,7 @@ RLM_API bool realm_sync_subscription_set_erase_by_query(realm_flx_sync_mutable_s
 }
 
 RLM_API realm_flx_sync_subscription_set_t*
-realm_sync_subscription_set_commit(realm_flx_sync_mutable_subscription_set_t* subscription_set) noexcept
+realm_sync_subscription_set_commit(realm_flx_sync_mutable_subscription_set_t* subscription_set)
 {
     REALM_ASSERT(subscription_set != nullptr);
     return wrap_err([&]() {


### PR DESCRIPTION
## What, How & Why?
Expose more functionalities in the C API for flx sync subscriptions.
Fixes: https://github.com/realm/realm-core/issues/5475, https://github.com/realm/realm-core/issues/5470

## ☑️ ToDos
* [ ] 📝 Changelog update
* [ ] 🚦 Tests (or not relevant)
