### PR TITLE
Align SubscriptionSet callback signature to rest of C-API.

### DIFF
--- a/src/realm.h
+++ b/src/realm.h
@@ -3165,7 +3165,7 @@ typedef enum realm_flx_sync_subscription_set_state {
     RLM_SYNC_SUBSCRIPTION_ERROR,
     RLM_SYNC_SUBSCRIPTION_SUPERSEDED,
 } realm_flx_sync_subscription_set_state_e;
-typedef void (*realm_sync_on_subscription_state_changed)(void* userdata,
+typedef void (*realm_sync_on_subscription_state_changed_t)(void* userdata,
                                                          realm_flx_sync_subscription_set_state_e state);
 
 /**
@@ -3302,7 +3302,7 @@ RLM_API realm_flx_sync_subscription_set_state_e realm_sync_on_subscription_set_s
  */
 RLM_API bool realm_sync_on_subscription_set_state_change_async(
     const realm_flx_sync_subscription_set_t* subscription_set, realm_flx_sync_subscription_set_state_e notify_when,
-    realm_sync_on_subscription_state_changed callback, void* userdata, realm_free_userdata_func_t userdata_free);
+    realm_sync_on_subscription_state_changed_t, void* userdata, realm_free_userdata_func_t userdata_free);
 
 /**
  *  Retrieve version for the subscription set passed as parameter

--- a/src/realm/object-store/c_api/sync.cpp
+++ b/src/realm/object-store/c_api/sync.cpp
@@ -508,7 +508,7 @@ realm_sync_on_subscription_set_state_change_wait(const realm_flx_sync_subscripti
 
 RLM_API bool realm_sync_on_subscription_set_state_change_async(
     const realm_flx_sync_subscription_set_t* subscription_set, realm_flx_sync_subscription_set_state_e notify_when,
-    realm_sync_on_subscription_state_changed callback, void* userdata, realm_free_userdata_func_t userdata_free)
+    realm_sync_on_subscription_state_changed_t callback, void* userdata, realm_free_userdata_func_t userdata_free)
 {
     REALM_ASSERT(subscription_set != nullptr && callback != nullptr);
     return wrap_err([&]() {


### PR DESCRIPTION
For some reason the API for listening to SubscriptionSet changes are different than any other callback API in the C-API. 

This was breaking the Kotlin code generation as we depend on pattern matching for these callbacks. While we could just change it to support the Core signature, there seems to be no good reason for it being different, so this aligns the signature with the rest of the Sync API's in the C-API.