### PR TITLE
Improve type check when casting to WrapC

### DIFF
--- a/src/realm/object-store/c_api/types.hpp
+++ b/src/realm/object-store/c_api/types.hpp
@@ -106,7 +106,16 @@ struct PropertyTypeMismatch : std::logic_error {
 //// FIXME: END EXCEPTIONS THAT SHOULD BE MOVED INTO OBJECT STORE
 
 struct WrapC {
-    virtual ~WrapC() {}
+    static constexpr uint64_t s_cookie_value = 0xdeadbeefdeadbeef;
+    uint64_t cookie;
+    WrapC()
+        : cookie(s_cookie_value)
+    {
+    }
+    virtual ~WrapC()
+    {
+        cookie = 0;
+    }
 
     virtual WrapC* clone() const
     {

--- a/src/realm/object-store/c_api/util.cpp
+++ b/src/realm/object-store/c_api/util.cpp
@@ -3,20 +3,18 @@
 
 namespace realm::c_api {
 
-template <class T>
-inline T* cast_ptr(void* ptr)
+inline WrapC* cast_ptr(void* ptr)
 {
     auto rptr = static_cast<WrapC*>(ptr);
-    REALM_ASSERT(dynamic_cast<T*>(rptr) != nullptr);
-    return static_cast<T*>(rptr);
+    REALM_ASSERT(rptr->cookie == WrapC::s_cookie_value);
+    return rptr;
 }
 
-template <class T>
-inline const T* cast_ptr(const void* ptr)
+inline const WrapC* cast_const_ptr(const void* ptr)
 {
     auto rptr = static_cast<const WrapC*>(ptr);
-    REALM_ASSERT(dynamic_cast<const T*>(rptr) != nullptr);
-    return static_cast<const T*>(rptr);
+    REALM_ASSERT(rptr->cookie == WrapC::s_cookie_value);
+    return rptr;
 }
 
 RLM_API void realm_free(void* buffer)
@@ -30,19 +28,19 @@ RLM_API void realm_release(void* ptr)
 {
     if (!ptr)
         return;
-    delete cast_ptr<WrapC>(ptr);
+    delete cast_ptr(ptr);
 }
 
 RLM_API void* realm_clone(const void* ptr)
 {
     return wrap_err([=]() {
-        return cast_ptr<WrapC>(ptr)->clone();
+        return cast_const_ptr(ptr)->clone();
     });
 }
 
 RLM_API bool realm_is_frozen(const void* ptr)
 {
-    return cast_ptr<WrapC>(ptr)->is_frozen();
+    return cast_const_ptr(ptr)->is_frozen();
 }
 
 RLM_API bool realm_equals(const void* a, const void* b)


### PR DESCRIPTION
The former check did not work.
dynamic_cast<> to `WrapC` on a pointer that is already a `WrapC` is a null operation.
