### PR TITLE
Fix invalid header dependencies

### DIFF
--- a/src/realm/sync/client_base.hpp
+++ b/src/realm/sync/client_base.hpp
@@ -4,7 +4,6 @@
 #include <realm/db.hpp>
 #include <realm/sync/config.hpp>
 #include <realm/sync/protocol.hpp>
-#include <realm/sync/noinst/client_reset.hpp>
 #include <realm/util/functional.hpp>
 
 namespace realm::sync {

--- a/src/realm/sync/config.hpp
+++ b/src/realm/sync/config.hpp
@@ -22,7 +22,6 @@
 #include <realm/db.hpp>
 #include <realm/util/assert.hpp>
 #include <realm/util/optional.hpp>
-#include <realm/sync/noinst/client_reset.hpp>
 
 #include <functional>
 #include <memory>
@@ -125,6 +124,17 @@ enum class SyncSessionStopPolicy {
     Immediately,          // Immediately stop the session as soon as all Realms/Sessions go out of scope.
     LiveIndefinitely,     // Never stop the session.
     AfterChangesUploaded, // Once all Realms/Sessions go out of scope, wait for uploads to complete and stop.
+};
+
+enum class ClientResyncMode : unsigned char {
+    // Fire a client reset error
+    Manual,
+    // Discard local changes, without disrupting accessors or closing the Realm
+    DiscardLocal,
+    // Attempt to recover unsynchronized but committed changes.
+    Recover,
+    // Attempt recovery and if that fails, discard local.
+    RecoverOrDiscard,
 };
 
 struct SyncConfig {

--- a/src/realm/sync/noinst/client_history_impl.cpp
+++ b/src/realm/sync/noinst/client_history_impl.cpp
@@ -25,6 +25,7 @@
 #include <realm/sync/changeset_parser.hpp>
 #include <realm/sync/instruction_applier.hpp>
 #include <realm/sync/instruction_replication.hpp>
+#include <realm/sync/noinst/client_reset.hpp>
 #include <realm/version.hpp>
 
 #include <algorithm>

--- a/src/realm/sync/noinst/client_reset.hpp
+++ b/src/realm/sync/noinst/client_reset.hpp
@@ -21,22 +21,12 @@
 
 #include <realm/util/logger.hpp>
 #include <realm/util/optional.hpp>
+#include <realm/sync/config.hpp>
 #include <realm/sync/protocol.hpp>
 
 #include <ostream>
 
 namespace realm {
-
-enum class ClientResyncMode : unsigned char {
-    // Fire a client reset error
-    Manual,
-    // Discard local changes, without disrupting accessors or closing the Realm
-    DiscardLocal,
-    // Attempt to recover unsynchronized but committed changes.
-    Recover,
-    // Attempt recovery and if that fails, discard local.
-    RecoverOrDiscard,
-};
 
 std::ostream& operator<<(std::ostream& os, const ClientResyncMode& mode);
 

--- a/test/object-store/sync/client_reset.cpp
+++ b/test/object-store/sync/client_reset.cpp
@@ -26,6 +26,7 @@
 #include "util/test_file.hpp"
 #include "util/test_utils.hpp"
 
+#include <realm/sync/noinst/client_reset.hpp>
 #include <realm/sync/noinst/client_reset_operation.hpp>
 #include <realm/sync/noinst/client_history_impl.hpp>
 


### PR DESCRIPTION
e92de0471 broke using the release packages. Installed headers can't import noinst headers because those are not included in the installed package.