### PR TITLE
Fix build MacOsDebug for Audit and REALM_SYNC disabled

### DIFF
--- a/src/realm/object-store/audit.hpp
+++ b/src/realm/object-store/audit.hpp
@@ -103,8 +103,6 @@ public:
     virtual void wait_for_uploads() = 0;
 };
 
-std::shared_ptr<AuditInterface> make_audit_context(std::shared_ptr<DB>, RealmConfig const& parent_config);
-
 // Hooks for testing. Do not use outside of tests.
 namespace audit_test_hooks {
 void set_maximum_shard_size(int64_t max_size);
@@ -112,11 +110,15 @@ void set_maximum_shard_size(int64_t max_size);
 void set_clock(util::UniqueFunction<Timestamp()>&&);
 } // namespace audit_test_hooks
 
-#if !REALM_PLATFORM_APPLE
+#if REALM_ENABLE_SYNC
+#if REALM_PLATFORM_APPLE
+std::shared_ptr<AuditInterface> make_audit_context(std::shared_ptr<DB>, RealmConfig const& parent_config);
+#else
 inline std::shared_ptr<AuditInterface> make_audit_context(std::shared_ptr<DB>, RealmConfig const&)
 {
     REALM_TERMINATE("Audit not supported on this platform");
 }
+#endif
 #endif
 
 } // namespace realm

--- a/src/realm/object-store/impl/realm_coordinator.cpp
+++ b/src/realm/object-store/impl/realm_coordinator.cpp
@@ -349,12 +349,15 @@ void RealmCoordinator::do_get_realm(Realm::Config config, std::shared_ptr<Realm>
     if (realm->config().sync_config)
         create_sync_session();
 
+#if REALM_ENABLE_SYNC
     if (realm->config().audit_config) {
         if (m_audit_context)
             m_audit_context->update_metadata(realm->config().audit_config->metadata);
         else
             m_audit_context = make_audit_context(m_db, realm->config());
     }
+#endif
+
 
     realm_lock.unlock_unchecked();
     if (schema) {


### PR DESCRIPTION
## What, How & Why?
Fix MacOsDebug build when REALM_SYNC is disabled and `make_audit_context` does not get linked. 

