### PR TITLE
[C API] Use a redefinable userdata type

### DIFF
--- a/src/realm/object-store/c_api/app.cpp
+++ b/src/realm/object-store/c_api/app.cpp
@@ -179,7 +179,7 @@ static inline realm_app_user_apikey_t to_capi(const App::UserAPIKey& apikey)
     return {to_capi(apikey.id), apikey.key ? apikey.key->c_str() : nullptr, apikey.name.c_str(), apikey.disabled};
 }
 
-static inline auto make_callback(realm_app_void_completion_func_t callback, void* userdata,
+static inline auto make_callback(realm_app_void_completion_func_t callback, realm_userdata_t userdata,
                                  realm_free_userdata_func_t userdata_free)
 {
     return
@@ -194,7 +194,7 @@ static inline auto make_callback(realm_app_void_completion_func_t callback, void
         };
 }
 
-static inline auto make_callback(realm_app_user_completion_func_t callback, void* userdata,
+static inline auto make_callback(realm_app_user_completion_func_t callback, realm_userdata_t userdata,
                                  realm_free_userdata_func_t userdata_free)
 {
     return [callback, userdata = SharedUserdata(userdata, FreeUserdata(userdata_free))](
@@ -210,8 +210,9 @@ static inline auto make_callback(realm_app_user_completion_func_t callback, void
     };
 }
 
-static inline auto make_callback(void (*callback)(void* userdata, realm_app_user_apikey_t*, const realm_app_error_t*),
-                                 void* userdata, realm_free_userdata_func_t userdata_free)
+static inline auto make_callback(void (*callback)(realm_userdata_t userdata, realm_app_user_apikey_t*,
+                                                  const realm_app_error_t*),
+                                 realm_userdata_t userdata, realm_free_userdata_func_t userdata_free)
 {
     return [callback, userdata = SharedUserdata(userdata, FreeUserdata(userdata_free))](
                App::UserAPIKey apikey, util::Optional<AppError> error) {
@@ -399,7 +400,7 @@ RLM_API bool realm_app_get_all_users(const realm_app_t* app, realm_user_t** out_
 }
 
 RLM_API bool realm_app_log_in_with_credentials(realm_app_t* app, realm_app_credentials_t* credentials,
-                                               realm_app_user_completion_func_t callback, void* userdata,
+                                               realm_app_user_completion_func_t callback, realm_userdata_t userdata,
                                                realm_free_userdata_func_t userdata_free)
 {
     return wrap_err([&] {
@@ -409,7 +410,7 @@ RLM_API bool realm_app_log_in_with_credentials(realm_app_t* app, realm_app_crede
 }
 
 RLM_API bool realm_app_log_out_current_user(realm_app_t* app, realm_app_void_completion_func_t callback,
-                                            void* userdata, realm_free_userdata_func_t userdata_free)
+                                            realm_userdata_t userdata, realm_free_userdata_func_t userdata_free)
 {
     return wrap_err([&] {
         (*app)->log_out(make_callback(callback, userdata, userdata_free));
@@ -418,7 +419,7 @@ RLM_API bool realm_app_log_out_current_user(realm_app_t* app, realm_app_void_com
 }
 
 RLM_API bool realm_app_refresh_custom_data(realm_app_t* app, realm_user_t* user,
-                                           realm_app_void_completion_func_t callback, void* userdata,
+                                           realm_app_void_completion_func_t callback, realm_userdata_t userdata,
                                            realm_free_userdata_func_t userdata_free)
 {
     return wrap_err([&] {
@@ -428,7 +429,7 @@ RLM_API bool realm_app_refresh_custom_data(realm_app_t* app, realm_user_t* user,
 }
 
 RLM_API bool realm_app_log_out(realm_app_t* app, realm_user_t* user, realm_app_void_completion_func_t callback,
-                               void* userdata, realm_free_userdata_func_t userdata_free)
+                               realm_userdata_t userdata, realm_free_userdata_func_t userdata_free)
 {
     return wrap_err([&] {
         (*app)->log_out(*user, make_callback(callback, userdata, userdata_free));
@@ -437,7 +438,7 @@ RLM_API bool realm_app_log_out(realm_app_t* app, realm_user_t* user, realm_app_v
 }
 
 RLM_API bool realm_app_link_user(realm_app_t* app, realm_user_t* user, realm_app_credentials_t* credentials,
-                                 realm_app_user_completion_func_t callback, void* userdata,
+                                 realm_app_user_completion_func_t callback, realm_userdata_t userdata,
                                  realm_free_userdata_func_t userdata_free)
 {
     return wrap_err([&] {
@@ -458,7 +459,7 @@ RLM_API bool realm_app_switch_user(realm_app_t* app, realm_user_t* user, realm_u
 }
 
 RLM_API bool realm_app_remove_user(realm_app_t* app, realm_user_t* user, realm_app_void_completion_func_t callback,
-                                   void* userdata, realm_free_userdata_func_t userdata_free)
+                                   realm_userdata_t userdata, realm_free_userdata_func_t userdata_free)
 {
     return wrap_err([&] {
         (*app)->remove_user(*user, make_callback(callback, userdata, userdata_free));
@@ -469,7 +470,7 @@ RLM_API bool realm_app_remove_user(realm_app_t* app, realm_user_t* user, realm_a
 RLM_API bool realm_app_email_password_provider_client_register_email(realm_app_t* app, const char* email,
                                                                      realm_string_t password,
                                                                      realm_app_void_completion_func_t callback,
-                                                                     void* userdata,
+                                                                     realm_userdata_t userdata,
                                                                      realm_free_userdata_func_t userdata_free)
 {
     return wrap_err([&] {
@@ -482,7 +483,7 @@ RLM_API bool realm_app_email_password_provider_client_register_email(realm_app_t
 RLM_API bool realm_app_email_password_provider_client_confirm_user(realm_app_t* app, const char* token,
                                                                    const char* token_id,
                                                                    realm_app_void_completion_func_t callback,
-                                                                   void* userdata,
+                                                                   realm_userdata_t userdata,
                                                                    realm_free_userdata_func_t userdata_free)
 {
     return wrap_err([&] {
@@ -493,7 +494,7 @@ RLM_API bool realm_app_email_password_provider_client_confirm_user(realm_app_t* 
 }
 
 RLM_API bool realm_app_email_password_provider_client_resend_confirmation_email(
-    realm_app_t* app, const char* email, realm_app_void_completion_func_t callback, void* userdata,
+    realm_app_t* app, const char* email, realm_app_void_completion_func_t callback, realm_userdata_t userdata,
     realm_free_userdata_func_t userdata_free)
 {
     return wrap_err([&] {
@@ -504,7 +505,7 @@ RLM_API bool realm_app_email_password_provider_client_resend_confirmation_email(
 }
 
 RLM_API bool realm_app_email_password_provider_client_send_reset_password_email(
-    realm_app_t* app, const char* email, realm_app_void_completion_func_t callback, void* userdata,
+    realm_app_t* app, const char* email, realm_app_void_completion_func_t callback, realm_userdata_t userdata,
     realm_free_userdata_func_t userdata_free)
 {
     return wrap_err([&] {
@@ -515,7 +516,7 @@ RLM_API bool realm_app_email_password_provider_client_send_reset_password_email(
 }
 
 RLM_API bool realm_app_email_password_provider_client_retry_custom_confirmation(
-    realm_app_t* app, const char* email, realm_app_void_completion_func_t callback, void* userdata,
+    realm_app_t* app, const char* email, realm_app_void_completion_func_t callback, realm_userdata_t userdata,
     realm_free_userdata_func_t userdata_free)
 {
     return wrap_err([&] {
@@ -528,7 +529,7 @@ RLM_API bool realm_app_email_password_provider_client_retry_custom_confirmation(
 RLM_API bool realm_app_email_password_provider_client_reset_password(realm_app_t* app, realm_string_t password,
                                                                      const char* token, const char* token_id,
                                                                      realm_app_void_completion_func_t callback,
-                                                                     void* userdata,
+                                                                     realm_userdata_t userdata,
                                                                      realm_free_userdata_func_t userdata_free)
 {
     return wrap_err([&] {
@@ -540,7 +541,7 @@ RLM_API bool realm_app_email_password_provider_client_reset_password(realm_app_t
 
 RLM_API bool realm_app_email_password_provider_client_call_reset_password_function(
     realm_app_t* app, const char* email, realm_string_t password, const char* serialized_ejson_payload,
-    realm_app_void_completion_func_t callback, void* userdata, realm_free_userdata_func_t userdata_free)
+    realm_app_void_completion_func_t callback, realm_userdata_t userdata, realm_free_userdata_func_t userdata_free)
 {
     return wrap_err([&] {
         bson::BsonArray args = parse_ejson_array(serialized_ejson_payload);
@@ -552,8 +553,8 @@ RLM_API bool realm_app_email_password_provider_client_call_reset_password_functi
 
 RLM_API bool realm_app_user_apikey_provider_client_create_apikey(
     const realm_app_t* app, const realm_user_t* user, const char* name,
-    void (*callback)(void* userdata, realm_app_user_apikey_t*, const realm_app_error_t*), void* userdata,
-    realm_free_userdata_func_t userdata_free)
+    void (*callback)(realm_userdata_t userdata, realm_app_user_apikey_t*, const realm_app_error_t*),
+    realm_userdata_t userdata, realm_free_userdata_func_t userdata_free)
 {
     return wrap_err([&] {
         (*app)->provider_client<App::UserAPIKeyProviderClient>().create_api_key(
@@ -564,8 +565,8 @@ RLM_API bool realm_app_user_apikey_provider_client_create_apikey(
 
 RLM_API bool realm_app_user_apikey_provider_client_fetch_apikey(
     const realm_app_t* app, const realm_user_t* user, realm_object_id_t id,
-    void (*callback)(void* userdata, realm_app_user_apikey_t*, const realm_app_error_t*), void* userdata,
-    realm_free_userdata_func_t userdata_free)
+    void (*callback)(realm_userdata_t userdata, realm_app_user_apikey_t*, const realm_app_error_t*),
+    realm_userdata_t userdata, realm_free_userdata_func_t userdata_free)
 {
     return wrap_err([&] {
         (*app)->provider_client<App::UserAPIKeyProviderClient>().fetch_api_key(
@@ -576,8 +577,8 @@ RLM_API bool realm_app_user_apikey_provider_client_fetch_apikey(
 
 RLM_API bool realm_app_user_apikey_provider_client_fetch_apikeys(
     const realm_app_t* app, const realm_user_t* user,
-    void (*callback)(void* userdata, realm_app_user_apikey_t[], size_t count, realm_app_error_t*), void* userdata,
-    realm_free_userdata_func_t userdata_free)
+    void (*callback)(realm_userdata_t userdata, realm_app_user_apikey_t[], size_t count, realm_app_error_t*),
+    realm_userdata_t userdata, realm_free_userdata_func_t userdata_free)
 {
     return wrap_err([&] {
         auto cb = [callback, userdata = SharedUserdata{userdata, FreeUserdata(userdata_free)}](
@@ -604,7 +605,7 @@ RLM_API bool realm_app_user_apikey_provider_client_fetch_apikeys(
 RLM_API bool realm_app_user_apikey_provider_client_delete_apikey(const realm_app_t* app, const realm_user_t* user,
                                                                  realm_object_id_t id,
                                                                  realm_app_void_completion_func_t callback,
-                                                                 void* userdata,
+                                                                 realm_userdata_t userdata,
                                                                  realm_free_userdata_func_t userdata_free)
 {
     return wrap_err([&] {
@@ -617,7 +618,7 @@ RLM_API bool realm_app_user_apikey_provider_client_delete_apikey(const realm_app
 RLM_API bool realm_app_user_apikey_provider_client_enable_apikey(const realm_app_t* app, const realm_user_t* user,
                                                                  realm_object_id_t id,
                                                                  realm_app_void_completion_func_t callback,
-                                                                 void* userdata,
+                                                                 realm_userdata_t userdata,
                                                                  realm_free_userdata_func_t userdata_free)
 {
     return wrap_err([&] {
@@ -630,7 +631,7 @@ RLM_API bool realm_app_user_apikey_provider_client_enable_apikey(const realm_app
 RLM_API bool realm_app_user_apikey_provider_client_disable_apikey(const realm_app_t* app, const realm_user_t* user,
                                                                   realm_object_id_t id,
                                                                   realm_app_void_completion_func_t callback,
-                                                                  void* userdata,
+                                                                  realm_userdata_t userdata,
                                                                   realm_free_userdata_func_t userdata_free)
 {
     return wrap_err([&] {
@@ -642,7 +643,7 @@ RLM_API bool realm_app_user_apikey_provider_client_disable_apikey(const realm_ap
 
 RLM_API bool realm_app_push_notification_client_register_device(
     const realm_app_t* app, const realm_user_t* user, const char* service_name, const char* registration_token,
-    realm_app_void_completion_func_t callback, void* userdata, realm_free_userdata_func_t userdata_free)
+    realm_app_void_completion_func_t callback, realm_userdata_t userdata, realm_free_userdata_func_t userdata_free)
 {
     return wrap_err([&] {
         (*app)
@@ -655,7 +656,7 @@ RLM_API bool realm_app_push_notification_client_register_device(
 RLM_API bool realm_app_push_notification_client_deregister_device(const realm_app_t* app, const realm_user_t* user,
                                                                   const char* service_name,
                                                                   realm_app_void_completion_func_t callback,
-                                                                  void* userdata,
+                                                                  realm_userdata_t userdata,
                                                                   realm_free_userdata_func_t userdata_free)
 {
     return wrap_err([&] {
@@ -666,11 +667,10 @@ RLM_API bool realm_app_push_notification_client_deregister_device(const realm_ap
     });
 }
 
-RLM_API bool realm_app_call_function(const realm_app_t* app, const realm_user_t* user, const char* function_name,
-                                     const char* serialized_ejson_payload,
-                                     void (*callback)(void* userdata, const char* serialized_ejson_response,
-                                                      const realm_app_error_t*),
-                                     void* userdata, realm_free_userdata_func_t userdata_free)
+RLM_API bool realm_app_call_function(
+    const realm_app_t* app, const realm_user_t* user, const char* function_name, const char* serialized_ejson_payload,
+    void (*callback)(realm_userdata_t userdata, const char* serialized_ejson_response, const realm_app_error_t*),
+    realm_userdata_t userdata, realm_free_userdata_func_t userdata_free)
 {
     return wrap_err([&] {
         auto cb = [callback, userdata = SharedUserdata{userdata, FreeUserdata(userdata_free)}](

--- a/src/realm/object-store/c_api/config.cpp
+++ b/src/realm/object-store/c_api/config.cpp
@@ -82,8 +82,8 @@ RLM_API void realm_config_set_schema_mode(realm_config_t* config, realm_schema_m
     config->schema_mode = from_capi(mode);
 }
 
-RLM_API void realm_config_set_migration_function(realm_config_t* config, realm_migration_func_t func, void* userdata,
-                                                 realm_free_userdata_func_t callback)
+RLM_API void realm_config_set_migration_function(realm_config_t* config, realm_migration_func_t func,
+                                                 realm_userdata_t userdata, realm_free_userdata_func_t callback)
 {
     if (func) {
         auto migration_func = [=](SharedRealm old_realm, SharedRealm new_realm, Schema& schema) {
@@ -105,7 +105,8 @@ RLM_API void realm_config_set_migration_function(realm_config_t* config, realm_m
 }
 
 RLM_API void realm_config_set_data_initialization_function(realm_config_t* config,
-                                                           realm_data_initialization_func_t func, void* userdata,
+                                                           realm_data_initialization_func_t func,
+                                                           realm_userdata_t userdata,
                                                            realm_free_userdata_func_t callback)
 {
     if (func) {
@@ -127,7 +128,8 @@ RLM_API void realm_config_set_data_initialization_function(realm_config_t* confi
 
 RLM_API void realm_config_set_should_compact_on_launch_function(realm_config_t* config,
                                                                 realm_should_compact_on_launch_func_t func,
-                                                                void* userdata, realm_free_userdata_func_t callback)
+                                                                realm_userdata_t userdata,
+                                                                realm_free_userdata_func_t callback)
 {
     if (func) {
         auto should_func = [=](uint64_t total_bytes, uint64_t used_bytes) -> bool {

--- a/src/realm/object-store/c_api/http.cpp
+++ b/src/realm/object-store/c_api/http.cpp
@@ -78,8 +78,8 @@ private:
 } // namespace
 } // namespace realm::c_api
 
-RLM_API realm_http_transport_t* realm_http_transport_new(realm_http_request_func_t request_executor, void* userdata,
-                                                         realm_free_userdata_func_t free)
+RLM_API realm_http_transport_t* realm_http_transport_new(realm_http_request_func_t request_executor,
+                                                         realm_userdata_t userdata, realm_free_userdata_func_t free)
 {
     auto transport = std::make_shared<realm::c_api::CNetworkTransport>(realm::c_api::UserdataPtr{userdata, free},
                                                                        request_executor);

--- a/src/realm/object-store/c_api/logging.cpp
+++ b/src/realm/object-store/c_api/logging.cpp
@@ -56,7 +56,7 @@ private:
 };
 } // namespace
 
-realm::SyncClientConfig::LoggerFactory make_logger_factory(realm_log_func_t logger, void* userdata,
+realm::SyncClientConfig::LoggerFactory make_logger_factory(realm_log_func_t logger, realm_userdata_t userdata,
                                                            realm_free_userdata_func_t free_userdata)
 {
     return [logger, userdata = SharedUserdata{userdata, free_userdata}](Logger::Level level) {

--- a/src/realm/object-store/c_api/notifications.cpp
+++ b/src/realm/object-store/c_api/notifications.cpp
@@ -86,9 +86,11 @@ KeyPathArray build_key_path_array(realm_key_path_array_t* key_path_array)
 
 } // namespace
 
-RLM_API realm_notification_token_t* realm_object_add_notification_callback(
-    realm_object_t* obj, void* userdata, realm_free_userdata_func_t free, realm_key_path_array_t* key_path_array,
-    realm_on_object_change_func_t on_change, realm_callback_error_func_t on_error, realm_scheduler_t*)
+RLM_API realm_notification_token_t*
+realm_object_add_notification_callback(realm_object_t* obj, realm_userdata_t userdata,
+                                       realm_free_userdata_func_t free, realm_key_path_array_t* key_path_array,
+                                       realm_on_object_change_func_t on_change, realm_callback_error_func_t on_error,
+                                       realm_scheduler_t*)
 {
     return wrap_err([&]() {
         ObjectNotificationsCallback cb;
@@ -127,9 +129,11 @@ RLM_API size_t realm_object_changes_get_modified_properties(const realm_object_c
     return i;
 }
 
-RLM_API realm_notification_token_t* realm_list_add_notification_callback(
-    realm_list_t* list, void* userdata, realm_free_userdata_func_t free, realm_key_path_array_t* key_path_array,
-    realm_on_collection_change_func_t on_change, realm_callback_error_func_t on_error, realm_scheduler_t*)
+RLM_API realm_notification_token_t*
+realm_list_add_notification_callback(realm_list_t* list, realm_userdata_t userdata, realm_free_userdata_func_t free,
+                                     realm_key_path_array_t* key_path_array,
+                                     realm_on_collection_change_func_t on_change,
+                                     realm_callback_error_func_t on_error, realm_scheduler_t*)
 {
     return wrap_err([&]() {
         CollectionNotificationsCallback cb;
@@ -141,9 +145,12 @@ RLM_API realm_notification_token_t* realm_list_add_notification_callback(
     });
 }
 
-RLM_API realm_notification_token_t* realm_set_add_notification_callback(
-    realm_set_t* set, void* userdata, realm_free_userdata_func_t free, realm_key_path_array_t* key_path_array,
-    realm_on_collection_change_func_t on_change, realm_callback_error_func_t on_error, realm_scheduler_t*)
+RLM_API realm_notification_token_t* realm_set_add_notification_callback(realm_set_t* set, realm_userdata_t userdata,
+                                                                        realm_free_userdata_func_t free,
+                                                                        realm_key_path_array_t* key_path_array,
+                                                                        realm_on_collection_change_func_t on_change,
+                                                                        realm_callback_error_func_t on_error,
+                                                                        realm_scheduler_t*)
 {
     return wrap_err([&]() {
         CollectionNotificationsCallback cb;
@@ -155,9 +162,11 @@ RLM_API realm_notification_token_t* realm_set_add_notification_callback(
     });
 }
 
-RLM_API realm_notification_token_t* realm_dictionary_add_notification_callback(
-    realm_dictionary_t* dict, void* userdata, realm_free_userdata_func_t free, realm_key_path_array_t* key_path_array,
-    realm_on_collection_change_func_t on_change, realm_callback_error_func_t on_error, realm_scheduler_t*)
+RLM_API realm_notification_token_t*
+realm_dictionary_add_notification_callback(realm_dictionary_t* dict, realm_userdata_t userdata,
+                                           realm_free_userdata_func_t free, realm_key_path_array_t* key_path_array,
+                                           realm_on_collection_change_func_t on_change,
+                                           realm_callback_error_func_t on_error, realm_scheduler_t*)
 {
     return wrap_err([&]() {
         CollectionNotificationsCallback cb;
@@ -169,9 +178,11 @@ RLM_API realm_notification_token_t* realm_dictionary_add_notification_callback(
     });
 }
 
-RLM_API realm_notification_token_t* realm_results_add_notification_callback(
-    realm_results_t* results, void* userdata, realm_free_userdata_func_t free, realm_key_path_array_t* key_path_array,
-    realm_on_collection_change_func_t on_change, realm_callback_error_func_t on_error, realm_scheduler_t*)
+RLM_API realm_notification_token_t*
+realm_results_add_notification_callback(realm_results_t* results, realm_userdata_t userdata,
+                                        realm_free_userdata_func_t free, realm_key_path_array_t* key_path_array,
+                                        realm_on_collection_change_func_t on_change,
+                                        realm_callback_error_func_t on_error, realm_scheduler_t*)
 {
     return wrap_err([&]() {
         CollectionNotificationsCallback cb;

--- a/src/realm/object-store/c_api/realm.cpp
+++ b/src/realm/object-store/c_api/realm.cpp
@@ -163,7 +163,7 @@ RLM_API bool realm_rollback(realm_t* realm)
 
 RLM_API realm_callback_token_t* realm_add_realm_changed_callback(realm_t* realm,
                                                                  realm_on_realm_change_func_t callback,
-                                                                 void* userdata,
+                                                                 realm_userdata_t userdata,
                                                                  realm_free_userdata_func_t free_userdata)
 {
     util::UniqueFunction<void()> func = [callback, userdata = UserdataPtr{userdata, free_userdata}]() {

--- a/src/realm/object-store/c_api/scheduler.cpp
+++ b/src/realm/object-store/c_api/scheduler.cpp
@@ -100,7 +100,7 @@ struct DefaultFactory {
     // which must be copyable.
     std::shared_ptr<Inner> m_inner;
 
-    DefaultFactory(void* userdata, realm_free_userdata_func_t free_func,
+    DefaultFactory(realm_userdata_t userdata, realm_free_userdata_func_t free_func,
                    realm_scheduler_default_factory_func_t factory_func)
         : m_inner(std::make_shared<Inner>())
     {
@@ -124,8 +124,8 @@ struct DefaultFactory {
 } // namespace
 
 RLM_API realm_scheduler_t*
-realm_scheduler_new(void* userdata, realm_free_userdata_func_t free_func, realm_scheduler_notify_func_t notify_func,
-                    realm_scheduler_is_on_thread_func_t is_on_thread_func,
+realm_scheduler_new(realm_userdata_t userdata, realm_free_userdata_func_t free_func,
+                    realm_scheduler_notify_func_t notify_func, realm_scheduler_is_on_thread_func_t is_on_thread_func,
                     realm_scheduler_is_same_as_func_t is_same_as,
                     realm_scheduler_can_deliver_notifications_func_t can_deliver_notifications_func)
 {
@@ -178,7 +178,7 @@ RLM_API bool realm_scheduler_has_default_factory()
 #endif
 }
 
-RLM_API bool realm_scheduler_set_default_factory(void* userdata, realm_free_userdata_func_t free_func,
+RLM_API bool realm_scheduler_set_default_factory(realm_userdata_t userdata, realm_free_userdata_func_t free_func,
                                                  realm_scheduler_default_factory_func_t factory_func)
 {
     return wrap_err([&]() {

--- a/src/realm/object-store/c_api/schema.cpp
+++ b/src/realm/object-store/c_api/schema.cpp
@@ -250,7 +250,7 @@ RLM_API bool realm_find_property_by_public_name(const realm_t* realm, realm_clas
 
 RLM_API realm_callback_token_t* realm_add_schema_changed_callback(realm_t* realm,
                                                                   realm_on_schema_change_func_t callback,
-                                                                  void* userdata,
+                                                                  realm_userdata_t userdata,
                                                                   realm_free_userdata_func_t free_userdata)
 {
     util::UniqueFunction<void(const Schema&)> func =

--- a/src/realm/object-store/c_api/sync.cpp
+++ b/src/realm/object-store/c_api/sync.cpp
@@ -248,7 +248,7 @@ RLM_API void realm_sync_client_config_set_metadata_encryption_key(realm_sync_cli
 }
 
 RLM_API void realm_sync_client_config_set_log_callback(realm_sync_client_config_t* config, realm_log_func_t callback,
-                                                       void* userdata,
+                                                       realm_userdata_t userdata,
                                                        realm_free_userdata_func_t userdata_free) noexcept
 {
     config->logger_factory = make_logger_factory(callback, userdata, userdata_free);
@@ -335,7 +335,8 @@ RLM_API void realm_sync_config_set_session_stop_policy(realm_sync_config_t* conf
 }
 
 RLM_API void realm_sync_config_set_error_handler(realm_sync_config_t* config, realm_sync_error_handler_func_t handler,
-                                                 void* userdata, realm_free_userdata_func_t userdata_free) noexcept
+                                                 realm_userdata_t userdata,
+                                                 realm_free_userdata_func_t userdata_free) noexcept
 {
     auto cb = [handler, userdata = SharedUserdata(userdata, FreeUserdata(userdata_free))](
                   std::shared_ptr<SyncSession> session, SyncError error) {
@@ -375,7 +376,8 @@ RLM_API void realm_sync_config_set_ssl_trust_certificate_path(realm_sync_config_
 }
 
 RLM_API void realm_sync_config_set_ssl_verify_callback(realm_sync_config_t* config,
-                                                       realm_sync_ssl_verify_func_t callback, void* userdata,
+                                                       realm_sync_ssl_verify_func_t callback,
+                                                       realm_userdata_t userdata,
                                                        realm_free_userdata_func_t userdata_free) noexcept
 {
     auto cb = [callback, userdata = SharedUserdata(userdata, FreeUserdata(userdata_free))](
@@ -456,7 +458,7 @@ realm_sync_subscription_updated_at(const realm_flx_sync_subscription_t* subscrip
 
 RLM_API void realm_sync_config_set_before_client_reset_handler(realm_sync_config_t* config,
                                                                realm_sync_before_client_reset_func_t callback,
-                                                               void* userdata,
+                                                               realm_userdata_t userdata,
                                                                realm_free_userdata_func_t userdata_free) noexcept
 {
     auto cb = [callback, userdata = SharedUserdata(userdata, FreeUserdata(userdata_free))](SharedRealm before_realm) {
@@ -468,7 +470,7 @@ RLM_API void realm_sync_config_set_before_client_reset_handler(realm_sync_config
 
 RLM_API void realm_sync_config_set_after_client_reset_handler(realm_sync_config_t* config,
                                                               realm_sync_after_client_reset_func_t callback,
-                                                              void* userdata,
+                                                              realm_userdata_t userdata,
                                                               realm_free_userdata_func_t userdata_free) noexcept
 {
     auto cb = [callback, userdata = SharedUserdata(userdata, FreeUserdata(userdata_free))](
@@ -506,9 +508,11 @@ realm_sync_on_subscription_set_state_change_wait(const realm_flx_sync_subscripti
     return realm_flx_sync_subscription_set_state_e(static_cast<int>(state));
 }
 
-RLM_API bool realm_sync_on_subscription_set_state_change_async(
-    const realm_flx_sync_subscription_set_t* subscription_set, realm_flx_sync_subscription_set_state_e notify_when,
-    realm_sync_on_subscription_state_changed_t callback, void* userdata, realm_free_userdata_func_t userdata_free)
+RLM_API bool
+realm_sync_on_subscription_set_state_change_async(const realm_flx_sync_subscription_set_t* subscription_set,
+                                                  realm_flx_sync_subscription_set_state_e notify_when,
+                                                  realm_sync_on_subscription_state_changed_t callback,
+                                                  realm_userdata_t userdata, realm_free_userdata_func_t userdata_free)
 {
     REALM_ASSERT(subscription_set != nullptr && callback != nullptr);
     return wrap_err([&]() {
@@ -731,7 +735,7 @@ RLM_API realm_async_open_task_t* realm_open_synchronized(realm_config_t* config)
 }
 
 RLM_API void realm_async_open_task_start(realm_async_open_task_t* task, realm_async_open_task_completion_func_t done,
-                                         void* userdata, realm_free_userdata_func_t userdata_free) noexcept
+                                         realm_userdata_t userdata, realm_free_userdata_func_t userdata_free) noexcept
 {
     auto cb = [done, userdata = SharedUserdata(userdata, FreeUserdata(userdata_free))](ThreadSafeReference realm,
                                                                                        std::exception_ptr error) {
@@ -753,7 +757,7 @@ RLM_API void realm_async_open_task_cancel(realm_async_open_task_t* task) noexcep
 }
 
 RLM_API uint64_t realm_async_open_task_register_download_progress_notifier(
-    realm_async_open_task_t* task, realm_sync_progress_func_t notifier, void* userdata,
+    realm_async_open_task_t* task, realm_sync_progress_func_t notifier, realm_userdata_t userdata,
     realm_free_userdata_func_t userdata_free) noexcept
 {
     auto cb = [notifier, userdata = SharedUserdata(userdata, FreeUserdata(userdata_free))](uint64_t transferred,
@@ -822,7 +826,7 @@ RLM_API bool realm_sync_immediately_run_file_actions(realm_app* app, const char*
 }
 
 RLM_API uint64_t realm_sync_session_register_connection_state_change_callback(
-    realm_sync_session_t* session, realm_sync_connection_state_changed_func_t callback, void* userdata,
+    realm_sync_session_t* session, realm_sync_connection_state_changed_func_t callback, realm_userdata_t userdata,
     realm_free_userdata_func_t userdata_free) noexcept
 {
     std::function<realm::SyncSession::ConnectionStateChangeCallback> cb =
@@ -842,7 +846,7 @@ RLM_API void realm_sync_session_unregister_connection_state_change_callback(real
 RLM_API uint64_t realm_sync_session_register_progress_notifier(realm_sync_session_t* session,
                                                                realm_sync_progress_func_t notifier,
                                                                realm_sync_progress_direction_e direction,
-                                                               bool is_streaming, void* userdata,
+                                                               bool is_streaming, realm_userdata_t userdata,
                                                                realm_free_userdata_func_t userdata_free) noexcept
 {
     std::function<realm::SyncSession::ProgressNotifierCallback> cb =
@@ -861,7 +865,7 @@ RLM_API void realm_sync_session_unregister_progress_notifier(realm_sync_session_
 
 RLM_API void realm_sync_session_wait_for_download_completion(realm_sync_session_t* session,
                                                              realm_sync_download_completion_func_t done,
-                                                             void* userdata,
+                                                             realm_userdata_t userdata,
                                                              realm_free_userdata_func_t userdata_free) noexcept
 {
     util::UniqueFunction<void(std::error_code)> cb =
@@ -879,7 +883,8 @@ RLM_API void realm_sync_session_wait_for_download_completion(realm_sync_session_
 }
 
 RLM_API void realm_sync_session_wait_for_upload_completion(realm_sync_session_t* session,
-                                                           realm_sync_upload_completion_func_t done, void* userdata,
+                                                           realm_sync_upload_completion_func_t done,
+                                                           realm_userdata_t userdata,
                                                            realm_free_userdata_func_t userdata_free) noexcept
 {
     util::UniqueFunction<void(std::error_code)> cb =


### PR DESCRIPTION
## What, How & Why?
Allow SDKs to use a specific pointer type for userdata. For Dart this would be `struct _Dart_Handle*`, which unlocks special functionality in Dart's ffigen tool that can save us a lot of tedious conversions by hand.

## ☑️ ToDos
* [ ] 📝 Changelog update
* [ ] 🚦 Tests (or not relevant)
