### PR TITLE
Align C-API parameter naming

### DIFF
--- a/src/realm.h
+++ b/src/realm.h
@@ -3556,7 +3556,7 @@ RLM_API bool realm_sync_subscription_set_insert_or_assign_query(realm_flx_sync_m
  *  @return true if no error occurred, false otherwise (use realm_get_last_error for fetching the error).
  */
 RLM_API bool realm_sync_subscription_set_erase_by_id(realm_flx_sync_mutable_subscription_set_t*,
-                                                     const realm_object_id_t*, bool*);
+                                                     const realm_object_id_t*, bool* erased);
 /**
  *  Erase from subscription set by name. If operation completes successfully set the bool out param.
  *  @return true if no error occurred, false otherwise (use realm_get_last_error for fetching the error)


### PR DESCRIPTION
Similar to https://github.com/realm/realm-core/pull/5492

Kotlin uses pattern matching in our code generation layer, and this was messing some things up. This just align the `erased` parameter, so it uses the same name as the similar methods around it.