### PR TITLE
Fix install_baas.sh script on exotic linuxes

### DIFF
--- a/evergreen/install_baas.sh
+++ b/evergreen/install_baas.sh
@@ -62,7 +62,7 @@ case $(uname -s) in
                 esac
             ;;
             *)
-                if [[ -z "MONGODB_DOWNLOAD_URL" ]]; then
+                if [[ -z "$MONGODB_DOWNLOAD_URL" ]]; then
                     echo "Missing MONGODB_DOWNLOAD_URL env variable to download mongodb from."
                     exit 1
                 fi
@@ -78,7 +78,7 @@ case $(uname -s) in
         esac
     ;;
     *)
-        if [[ -z "MONGODB_DOWNLOAD_URL" ]]; then
+        if [[ -z "$MONGODB_DOWNLOAD_URL" ]]; then
             echo "Missing MONGODB_DOWNLOAD_URL env variable to download mongodb from."
             exit 1
         fi


### PR DESCRIPTION
## What, How & Why?
This does what it says on the tin. If you aren't on one of the platforms we build in evergreen, install_baas.sh now lets you specify local paths to the various binary dependencies for baas so you can do local testing on exotic linux distros.

## ☑️ ToDos
* [ ] 📝 Changelog update
* ~[ ] 🚦 Tests (or not relevant)~
