### PR TITLE
Fix ignoring ordering for queries passed into sync subscription in the C API

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,8 +5,8 @@
 * None.
 
 ### Fixed
-* <How do the end-user experience this issue? what was the impact?> ([#????](https://github.com/realm/realm-core/issues/????), since v?.?.?)
 * `SyncManager::path_for_realm` now allows custom file names for Flexible Sync enabled Realms. (Issue [#5473](https://github.com/realm/realm-core/issues/5473)).
+* Fix ignoring ordering for queries passed into sync subscriptions in the C API. (Issue [#5504](https://github.com/realm/realm-core/issues/5504)).
 
 ### Breaking changes
 * None.

--- a/src/realm/object-store/c_api/sync.cpp
+++ b/src/realm/object-store/c_api/sync.cpp
@@ -632,8 +632,12 @@ realm_sync_subscription_set_insert_or_assign_results(realm_flx_sync_mutable_subs
 {
     REALM_ASSERT(subscription_set != nullptr && results != nullptr);
     return wrap_err([&]() {
-        const auto [it, successful] = name ? subscription_set->insert_or_assign(name, results->get_query())
-                                           : subscription_set->insert_or_assign(results->get_query());
+        auto realm_query = results->get_query();
+        const auto& ordering_copy = util::make_bind<DescriptorOrdering>();
+        *ordering_copy = results->get_ordering();
+        realm_query.set_ordering(ordering_copy);
+        const auto [it, successful] = name ? subscription_set->insert_or_assign(name, realm_query)
+                                           : subscription_set->insert_or_assign(realm_query);
         *index = std::distance(subscription_set->begin(), it);
         *inserted = successful;
         return true;
@@ -647,8 +651,12 @@ realm_sync_subscription_set_insert_or_assign_query(realm_flx_sync_mutable_subscr
 {
     REALM_ASSERT(subscription_set != nullptr && query != nullptr);
     return wrap_err([&]() {
-        const auto [it, successful] = name ? subscription_set->insert_or_assign(name, query->get_query())
-                                           : subscription_set->insert_or_assign(query->get_query());
+        auto& realm_query = query->get_query();
+        const auto& ordering_copy = util::make_bind<DescriptorOrdering>();
+        *ordering_copy = query->get_ordering();
+        realm_query.set_ordering(ordering_copy);
+        const auto [it, successful] = name ? subscription_set->insert_or_assign(name, realm_query)
+                                           : subscription_set->insert_or_assign(realm_query);
         *index = std::distance(subscription_set->begin(), it);
         *inserted = successful;
         return true;

--- a/src/realm/object-store/c_api/sync.cpp
+++ b/src/realm/object-store/c_api/sync.cpp
@@ -633,7 +633,7 @@ realm_sync_subscription_set_insert_or_assign_results(realm_flx_sync_mutable_subs
     REALM_ASSERT(subscription_set != nullptr && results != nullptr);
     return wrap_err([&]() {
         auto realm_query = results->get_query();
-        const auto& ordering_copy = util::make_bind<DescriptorOrdering>();
+        auto ordering_copy = util::make_bind<DescriptorOrdering>();
         *ordering_copy = results->get_ordering();
         realm_query.set_ordering(ordering_copy);
         const auto [it, successful] = name ? subscription_set->insert_or_assign(name, realm_query)
@@ -651,8 +651,8 @@ realm_sync_subscription_set_insert_or_assign_query(realm_flx_sync_mutable_subscr
 {
     REALM_ASSERT(subscription_set != nullptr && query != nullptr);
     return wrap_err([&]() {
-        auto& realm_query = query->get_query();
-        const auto& ordering_copy = util::make_bind<DescriptorOrdering>();
+        auto realm_query = query->get_query();
+        auto ordering_copy = util::make_bind<DescriptorOrdering>();
         *ordering_copy = query->get_ordering();
         realm_query.set_ordering(ordering_copy);
         const auto [it, successful] = name ? subscription_set->insert_or_assign(name, realm_query)

--- a/src/realm/object-store/results.cpp
+++ b/src/realm/object-store/results.cpp
@@ -935,9 +935,8 @@ Query Results::get_query() const
     return do_get_query();
 }
 
-DescriptorOrdering Results::get_ordering() const REQUIRES(!m_mutex)
+const DescriptorOrdering& Results::get_ordering() const REQUIRES(!m_mutex)
 {
-    util::CheckedUniqueLock lock(m_mutex);
     return m_descriptor_ordering;
 }
 

--- a/src/realm/object-store/results.cpp
+++ b/src/realm/object-store/results.cpp
@@ -935,6 +935,12 @@ Query Results::get_query() const
     return do_get_query();
 }
 
+DescriptorOrdering Results::get_ordering() const REQUIRES(!m_mutex)
+{
+    util::CheckedUniqueLock lock(m_mutex);
+    return m_descriptor_ordering;
+}
+
 ConstTableRef Results::get_table() const
 {
     util::CheckedUniqueLock lock(m_mutex);

--- a/src/realm/object-store/results.hpp
+++ b/src/realm/object-store/results.hpp
@@ -78,7 +78,7 @@ public:
     Query get_query() const REQUIRES(!m_mutex);
 
     // Get ordering for thr query associated with the result
-    DescriptorOrdering get_ordering() const REQUIRES(!m_mutex);
+    const DescriptorOrdering& get_ordering() const;
 
     // Get the Collection this Results is derived from, if any
     const std::shared_ptr<CollectionBase>& get_collection() const

--- a/src/realm/object-store/results.hpp
+++ b/src/realm/object-store/results.hpp
@@ -77,6 +77,9 @@ public:
     // Returned query will not be valid if the current mode is Empty
     Query get_query() const REQUIRES(!m_mutex);
 
+    // Get ordering for thr query associated with the result
+    DescriptorOrdering get_ordering() const REQUIRES(!m_mutex);
+
     // Get the Collection this Results is derived from, if any
     const std::shared_ptr<CollectionBase>& get_collection() const
     {


### PR DESCRIPTION
## What, How & Why?
Quick fix in order to avoid ordering for queries passed to sync subscriptions. 
Fixes: https://github.com/realm/realm-core/issues/5504

## ☑️ ToDos
* [ ] 📝 Changelog update
* [ ] 🚦 Tests (or not relevant)
