### PR TITLE
Mention C-API in PR template

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -5,3 +5,4 @@
 ## ☑️ ToDos
 * [ ] 📝 Changelog update
 * [ ] 🚦 Tests (or not relevant)
+* [ ] C-API, if public C++ API changed.


### PR DESCRIPTION
Add mention of C-API to PR template since we need to keep public C++ API and C-API in Sync.