### PR TITLE
Ensure ChangesetIndex ranges are sorted by version and order within download message

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 * `SyncManager::path_for_realm` now allows custom file names for Flexible Sync enabled Realms. (Issue [#5473](https://github.com/realm/realm-core/issues/5473)).
 * Fix ignoring ordering for queries passed into sync subscriptions in the C API. (Issue [#5504](https://github.com/realm/realm-core/issues/5504)).
 * Fix adding Flx Sync error codes to the C API. (Issue [#5519](https://github.com/realm/realm-core/issues/5519)).
+* OT may have failed with an assertion in debug builds for FLX sync bootstrap messages because changesets were being sorted by version number, which does not increase within a bootstrap. ([#5527](https://github.com/realm/realm-core/pull/5527))
 
 ### Breaking changes
 * None.

--- a/src/realm/sync/changeset.hpp
+++ b/src/realm/sync/changeset.hpp
@@ -177,6 +177,18 @@ struct Changeset {
     /// untransformed changeset was produced.
     file_ident_type origin_file_ident = 0;
 
+    /// Must be set before passing this Changeset to Transformer::transform_remote_changesets
+    /// to the index of this changeset within the received changesets.
+    ///
+    /// In FLX sync the server may send multiple idempotent changesets with the same server version
+    /// when bootstrapping data. Internal data structures within the OT Transformer require the
+    /// input changesets to be sortable in the order that they were received. If the version number
+    /// is not increasing, this will be used to determine the correct sort order.
+    ///
+    /// FIXME: This is a hack that we need to figure out a better way of fixing. This can maybe
+    /// be part of refactoring the ChangesetIndex
+    size_t transform_sequence = 0;
+
     /// Compare for exact equality, including that interned strings have the
     /// same integer values, and there is the same number of interned strings,
     /// same topology of tombstones, etc.

--- a/src/realm/sync/noinst/changeset_index.hpp
+++ b/src/realm/sync/noinst/changeset_index.hpp
@@ -31,6 +31,9 @@ struct ChangesetIndex {
     struct CompareChangesetPointersByVersion {
         bool operator()(const Changeset* a, const Changeset* b) const noexcept
         {
+            if (a->version == b->version) {
+                return a->transform_sequence < b->transform_sequence;
+            }
             return a->version < b->version;
         }
     };

--- a/src/realm/sync/noinst/client_history_impl.cpp
+++ b/src/realm/sync/noinst/client_history_impl.cpp
@@ -416,6 +416,7 @@ void ClientHistory::integrate_server_changesets(const SyncProgress& progress,
 
             parse_remote_changeset(changeset, changesets[i]); // Throws
 
+            changesets[i].transform_sequence = i;
             // It is possible that the synchronization history has been trimmed
             // to a point where a prefix of the merge window is no longer
             // available, but this can only happen if that prefix consisted


### PR DESCRIPTION
## What, How & Why?
This came out of troubleshooting some test failures @ironage had passed to me. The bug here is that the client's ChangesetIndex stores Changesets in a Map sorted by version but has a bunch of checks to make sure that they are transformed in the order they are received. Since bootstraps can contain the same version number over and over again and the sort in the map is not stable, that means we can sometimes hit REALM_ASSERT's when Changesets get "out-of-order" with respect to where they appeared in the incoming message.

I think this is super blocking for World, so I threw together this quick fix that adds a new parameter to the sort in the ChangesetIndex to represent the position of the Changeset within the download message. I think we should absolutely rip out this quick fix with a better fix later, but there's a pretty serious time crunch in the very short term.

I also added minimal repro to this and confirmed it's the same crash @ironage was seeing in #5331.

## ☑️ ToDos
* [x] 📝 Changelog update
* [x] 🚦 Tests (or not relevant)
~* [ ] C-API, if public C++ API changed.~
