### PR TITLE
Handle compensating writes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,7 @@
 # NEXT RELEASE
 
 ### Enhancements
-* <New feature description> (PR [#????](https://github.com/realm/realm-core/pull/????))
-* None.
+* The sync client will gracefully handle compensating write error messages from the server and pass detailed info to the SDK's sync error handler about which objects caused the compensating write to occur. ([#5528](https://github.com/realm/realm-core/pull/5528))
 
 ### Fixed
 * Added better comparator for `realm_user_t` and `realm_flx_sync_subscription_t` when using `realm_equals`.(Issue [#5522])(https://github.com/realm/realm-core/issues/5522).

--- a/evergreen/config.yml
+++ b/evergreen/config.yml
@@ -108,6 +108,10 @@ functions:
               set_cmake_var realm_vars REALM_TEST_SYNC_LOGGING BOOL On
           fi
 
+          if [ -n "${realm_enable_compensating_writes_tests|}" ]; then
+              set_cmake_var realm_vars REALM_ENABLE_COMPENSATING_WRITES_TESTS BOOL On
+          fi
+
           GENERATOR="${cmake_generator}"
           if [ -z "${cmake_generator|}" ]; then
               GENERATOR="Ninja Multi-Config"
@@ -504,7 +508,12 @@ tasks:
                 export DEVELOPER_DIR="${xcode_developer_dir}"
             fi
 
-            ./evergreen/install_baas.sh -w ./baas-work-dir
+            INSTALL_BAAS_BRANCH=""
+            if [ -n "${baas_branch}" ]; then
+                INSTALL_BAAS_BRANCH="-b ${baas_branch}"
+            fi
+
+            ./evergreen/install_baas.sh -w ./baas-work-dir $INSTALL_BAAS_BRANCH
         fi
 
   - command: shell.exec
@@ -656,6 +665,24 @@ buildvariants:
     cxx_compiler: "./clang_binaries/bin/clang++"
   tasks:
   - name: lint
+  - name: compile_test
+    distros:
+    - ubuntu2004-large
+
+- name: ubuntu2004-compensating-writes
+  display_name: "Ubuntu 20.04 x86_64 (Clang 11 Compensating Writes)"
+  run_on: ubuntu2004-small
+  expansions:
+    clang_url: "https://s3.amazonaws.com/static.realm.io/evergreen-assets/clang%2Bllvm-11.0.0-x86_64-linux-gnu-ubuntu-20.04.tar.xz"
+    cmake_url: "https://s3.amazonaws.com/static.realm.io/evergreen-assets/cmake-3.20.3-linux-x86_64.tar.gz"
+    cmake_bindir: "./cmake_binaries/bin"
+    fetch_missing_dependencies: On
+    run_tests_against_baas: On
+    realm_enable_compensating_writes_tests: On
+    c_compiler: "./clang_binaries/bin/clang"
+    cxx_compiler: "./clang_binaries/bin/clang++"
+    baas_branch: master
+  tasks:
   - name: compile_test
     distros:
     - ubuntu2004-large

--- a/src/realm/mixed.hpp
+++ b/src/realm/mixed.hpp
@@ -286,21 +286,6 @@ private:
     }
 };
 
-class OwnedMixed : public Mixed {
-public:
-    explicit OwnedMixed(std::string str)
-        : m_owned_string(std::move(str))
-    {
-        m_type = int(type_String);
-        string_val = m_owned_string;
-    }
-
-    using Mixed::Mixed;
-
-private:
-    std::string m_owned_string;
-};
-
 // Implementation:
 
 inline Mixed::Mixed(int64_t v) noexcept

--- a/src/realm/mixed.hpp
+++ b/src/realm/mixed.hpp
@@ -288,6 +288,20 @@ private:
     }
 };
 
+class OwnedMixed : public Mixed {
+public:
+    explicit OwnedMixed(std::string str)
+        : m_owned_string(std::move(str))
+    {
+        m_type = int(type_String);
+        string_val = m_owned_string;
+    }
+
+    using Mixed::Mixed;
+private:
+    std::string m_owned_string;
+};
+
 // Implementation:
 
 inline Mixed::Mixed(int64_t v) noexcept

--- a/src/realm/mixed.hpp
+++ b/src/realm/mixed.hpp
@@ -158,9 +158,7 @@ public:
     {
     }
 
-    ~Mixed() noexcept
-    {
-    }
+    ~Mixed() noexcept {}
 
     DataType get_type() const noexcept
     {
@@ -298,6 +296,7 @@ public:
     }
 
     using Mixed::Mixed;
+
 private:
     std::string m_owned_string;
 };

--- a/src/realm/object-store/sync/sync_session.cpp
+++ b/src/realm/object-store/sync/sync_session.cpp
@@ -746,6 +746,7 @@ void SyncSession::create_sync_session()
                     case cs::connected:
                         return ConnectionState::Connected;
                 }
+                REALM_UNREACHABLE();
             }();
             util::CheckedUniqueLock lock(self->m_connection_state_mutex);
             auto old_state = self->m_connection_state;

--- a/src/realm/object-store/sync/sync_session.cpp
+++ b/src/realm/object-store/sync/sync_session.cpp
@@ -737,18 +737,16 @@ void SyncSession::create_sync_session()
                 return;
             }
             using cs = sync::ConnectionState;
-            ConnectionState new_state;
-            switch (state) {
-                case cs::disconnected:
-                    new_state = ConnectionState::Disconnected;
-                    break;
-                case cs::connecting:
-                    new_state = ConnectionState::Connecting;
-                    break;
-                case cs::connected:
-                    new_state = ConnectionState::Connected;
-                    break;
-            }
+            ConnectionState new_state = [&] {
+                switch (state) {
+                    case cs::disconnected:
+                        return ConnectionState::Disconnected;
+                    case cs::connecting:
+                        return ConnectionState::Connecting;
+                    case cs::connected:
+                        return ConnectionState::Connected;
+                }
+            }();
             util::CheckedUniqueLock lock(self->m_connection_state_mutex);
             auto old_state = self->m_connection_state;
             self->m_connection_state = new_state;

--- a/src/realm/object-store/sync/sync_session.cpp
+++ b/src/realm/object-store/sync/sync_session.cpp
@@ -16,7 +16,6 @@
 //
 ////////////////////////////////////////////////////////////////////////////
 
-#include "realm/sync/client_base.hpp"
 #include <realm/object-store/sync/sync_session.hpp>
 
 #include <realm/object-store/impl/realm_coordinator.hpp>
@@ -29,6 +28,7 @@
 
 #include <realm/db_options.hpp>
 #include <realm/sync/client.hpp>
+#include <realm/sync/config.hpp>
 #include <realm/sync/noinst/client_history_impl.hpp>
 #include <realm/sync/noinst/client_reset_operation.hpp>
 #include <realm/sync/protocol.hpp>
@@ -457,6 +457,8 @@ void SyncSession::handle_error(SyncError error)
                 // The SDK doesn't need to be aware of these because they are strictly informational, and do not
                 // represent actual errors.
                 return;
+            case SimplifiedProtocolError::CompensatingWrite:
+                break; // not fatal, but should be bubbled up to the user below.
             case SimplifiedProtocolError::BadAuthentication:
                 next_state = NextStateAfterError::inactive;
                 log_out_user = true;
@@ -726,33 +728,39 @@ void SyncSession::create_sync_session()
 
     // Sets up the connection state listener. This callback is used for both reporting errors as well as changes to
     // the connection state.
-    m_session->set_connection_state_change_listener([weak_self](sync::ConnectionState state,
-                                                                util::Optional<sync::Session::ErrorInfo> error) {
-        // If the OS SyncSession object is destroyed, we ignore any events from the underlying Session as there is
-        // nothing useful we can do with them.
-        if (auto self = weak_self.lock()) {
-            util::CheckedUniqueLock lock(self->m_connection_state_mutex);
-            auto old_state = self->m_connection_state;
+    m_session->set_connection_state_change_listener(
+        [weak_self](sync::ConnectionState state, util::Optional<sync::Session::ErrorInfo> error) {
+            // If the OS SyncSession object is destroyed, we ignore any events from the underlying Session as there is
+            // nothing useful we can do with them.
+            auto self = weak_self.lock();
+            if (!self) {
+                return;
+            }
             using cs = sync::ConnectionState;
+            ConnectionState new_state;
             switch (state) {
                 case cs::disconnected:
-                    self->m_connection_state = ConnectionState::Disconnected;
+                    new_state = ConnectionState::Disconnected;
                     break;
                 case cs::connecting:
-                    self->m_connection_state = ConnectionState::Connecting;
+                    new_state = ConnectionState::Connecting;
                     break;
                 case cs::connected:
-                    self->m_connection_state = ConnectionState::Connected;
+                    new_state = ConnectionState::Connected;
                     break;
-                default:
-                    REALM_UNREACHABLE();
             }
-            auto new_state = self->m_connection_state;
+            util::CheckedUniqueLock lock(self->m_connection_state_mutex);
+            auto old_state = self->m_connection_state;
+            self->m_connection_state = new_state;
             lock.unlock();
-            self->m_connection_change_notifier.invoke_callbacks(old_state, new_state);
+
+            if (old_state != new_state) {
+                self->m_connection_change_notifier.invoke_callbacks(old_state, new_state);
+            }
+
             if (error) {
                 SyncError sync_error{error->error_code, std::string(error->message), error->is_fatal(),
-                                     error->logURL};
+                                     error->log_url, std::move(error->compensating_writes)};
                 if (error->should_client_reset) {
                     if (*error->should_client_reset) {
                         sync_error.server_requests_client_reset =
@@ -766,8 +774,7 @@ void SyncSession::create_sync_session()
                 }
                 self->handle_error(std::move(sync_error));
             }
-        }
-    });
+        });
 }
 
 void SyncSession::set_sync_transact_callback(util::UniqueFunction<sync::Session::SyncTransactCallback> callback)

--- a/src/realm/sync/changeset_parser.cpp
+++ b/src/realm/sync/changeset_parser.cpp
@@ -90,12 +90,14 @@ struct State {
 };
 
 struct UnreachableInstructionHandler : public InstructionHandler {
-    void set_intern_string(uint32_t, StringBufferRange) override
+    void set_intern_string(uint32_t, StringBufferRange)
+    override
     {
         REALM_UNREACHABLE();
     }
 
-    StringBufferRange add_string_range(StringData) override
+    StringBufferRange add_string_range(StringData)
+    override
     {
         REALM_UNREACHABLE();
     }
@@ -712,8 +714,7 @@ OwnedMixed parse_base64_encoded_primary_key(std::string_view str)
         case Type::UUID:
             return OwnedMixed{state.read_uuid()};
         default:
-            throw BadChangesetError(util::format("invalid primary key type %1", type));
-
+            throw BadChangesetError(util::format("invalid primary key type %1", static_cast<int>(type)));
     }
 }
 

--- a/src/realm/sync/changeset_parser.cpp
+++ b/src/realm/sync/changeset_parser.cpp
@@ -712,7 +712,8 @@ OwnedMixed parse_base64_encoded_primary_key(std::string_view str)
         case Type::UUID:
             return OwnedMixed{state.read_uuid()};
         default:
-            throw BadChangesetError("invalid primary key type");
+            throw BadChangesetError(util::format("invalid primary key type %1", type));
+
     }
 }
 

--- a/src/realm/sync/changeset_parser.cpp
+++ b/src/realm/sync/changeset_parser.cpp
@@ -90,14 +90,12 @@ struct State {
 };
 
 struct UnreachableInstructionHandler : public InstructionHandler {
-    void set_intern_string(uint32_t, StringBufferRange)
-    override
+    void set_intern_string(uint32_t, StringBufferRange) override
     {
         REALM_UNREACHABLE();
     }
 
-    StringBufferRange add_string_range(StringData)
-    override
+    StringBufferRange add_string_range(StringData) override
     {
         REALM_UNREACHABLE();
     }

--- a/src/realm/sync/changeset_parser.cpp
+++ b/src/realm/sync/changeset_parser.cpp
@@ -1,13 +1,20 @@
 
-#include <realm/util/metered/set.hpp>
+#include "realm/global_key.hpp"
+#include "realm/mixed.hpp"
+#include "realm/sync/changeset.hpp"
+#include "realm/sync/instructions.hpp"
+#include "realm/util/base64.hpp"
+#include <realm/sync/changeset_parser.hpp>
 #include <realm/sync/noinst/integer_codec.hpp>
 #include <realm/table.hpp>
-#include <realm/sync/changeset_parser.hpp>
+#include <realm/util/metered/set.hpp>
 
 using namespace realm;
 using namespace realm::sync;
 
-struct ChangesetParser::State {
+namespace {
+
+struct State {
     util::NoCopyInputStream& m_input;
     InstructionHandler& m_handler;
 
@@ -82,16 +89,51 @@ struct ChangesetParser::State {
     } // Throws
 };
 
+struct UnreachableInstructionHandler : public InstructionHandler {
+    void set_intern_string(uint32_t, StringBufferRange) override
+    {
+        REALM_UNREACHABLE();
+    }
 
-void ChangesetParser::parse(util::NoCopyInputStream& input, InstructionHandler& handler)
-{
-    State state{input, handler};
+    StringBufferRange add_string_range(StringData) override
+    {
+        REALM_UNREACHABLE();
+    }
 
-    while (state.has_next())
-        state.parse_one();
-}
+    void operator()(const Instruction&) override
+    {
+        REALM_UNREACHABLE();
+    }
+};
 
-Instruction::Payload::Type ChangesetParser::State::read_payload_type()
+struct InstructionBuilder : InstructionHandler {
+    explicit InstructionBuilder(Changeset& log)
+        : m_log(log)
+    {
+    }
+    Changeset& m_log;
+
+    void operator()(const Instruction& instr) final
+    {
+        m_log.push_back(instr);
+    }
+
+    StringBufferRange add_string_range(StringData string) final
+    {
+        return m_log.append_string(string);
+    }
+
+    void set_intern_string(uint32_t index, StringBufferRange range) final
+    {
+        InternStrings& strings = m_log.interned_strings();
+        if (strings.size() <= index) {
+            strings.resize(index + 1, StringBufferRange{0, 0});
+        }
+        strings[index] = range;
+    }
+};
+
+Instruction::Payload::Type State::read_payload_type()
 {
     using Type = Instruction::Payload::Type;
     auto type = Instruction::Payload::Type(read_int());
@@ -133,7 +175,7 @@ Instruction::Payload::Type ChangesetParser::State::read_payload_type()
     parser_error("Unsupported data type");
 }
 
-Instruction::AddColumn::CollectionType ChangesetParser::State::read_collection_type()
+Instruction::AddColumn::CollectionType State::read_collection_type()
 {
     using CollectionType = Instruction::AddColumn::CollectionType;
     auto type = Instruction::AddColumn::CollectionType(read_int<uint8_t>());
@@ -151,7 +193,7 @@ Instruction::AddColumn::CollectionType ChangesetParser::State::read_collection_t
     parser_error("Unsupported collection type");
 }
 
-Instruction::Payload ChangesetParser::State::read_payload()
+Instruction::Payload State::read_payload()
 {
     using Type = Instruction::Payload::Type;
 
@@ -222,7 +264,7 @@ Instruction::Payload ChangesetParser::State::read_payload()
     parser_error("Unsupported payload type");
 }
 
-Instruction::PrimaryKey ChangesetParser::State::read_object_key()
+Instruction::PrimaryKey State::read_object_key()
 {
     using Type = Instruction::Payload::Type;
     Type type = read_payload_type();
@@ -245,14 +287,14 @@ Instruction::PrimaryKey ChangesetParser::State::read_object_key()
     parser_error("Unsupported object key type");
 }
 
-Instruction::Payload::Link ChangesetParser::State::read_link()
+Instruction::Payload::Link State::read_link()
 {
     auto target_class = read_intern_string();
     auto key = read_object_key();
     return Instruction::Payload::Link{target_class, key};
 }
 
-Instruction::Path ChangesetParser::State::read_path()
+Instruction::Path State::read_path()
 {
     Instruction::Path path;
     size_t path_len = read_int<uint32_t>();
@@ -276,7 +318,7 @@ Instruction::Path ChangesetParser::State::read_path()
     return path;
 }
 
-void ChangesetParser::State::read_path_instr(Instruction::PathInstruction& instr)
+void State::read_path_instr(Instruction::PathInstruction& instr)
 {
     instr.table = read_intern_string();
     instr.object = read_object_key();
@@ -284,7 +326,7 @@ void ChangesetParser::State::read_path_instr(Instruction::PathInstruction& instr
     instr.path = read_path();
 }
 
-void ChangesetParser::State::parse_one()
+void State::parse_one()
 {
     uint64_t t = read_int<uint64_t>();
 
@@ -454,12 +496,12 @@ void ChangesetParser::State::parse_one()
 }
 
 
-bool ChangesetParser::State::has_next() noexcept
+bool State::has_next() noexcept
 {
     return m_input_begin != m_input_end || next_input_buffer();
 }
 
-bool ChangesetParser::State::next_input_buffer() noexcept
+bool State::next_input_buffer() noexcept
 {
     auto next = m_input.next_block();
     m_input_begin = next.begin();
@@ -468,7 +510,7 @@ bool ChangesetParser::State::next_input_buffer() noexcept
 }
 
 template <class T>
-T ChangesetParser::State::read_int()
+T State::read_int()
 {
     T value = 0;
     if (REALM_LIKELY(_impl::decode_int(*this, value)))
@@ -476,7 +518,7 @@ T ChangesetParser::State::read_int()
     parser_error("bad changeset - integer decoding failure");
 }
 
-bool ChangesetParser::State::read_char(char& c) noexcept
+bool State::read_char(char& c) noexcept
 {
     if (m_input_begin == m_input_end && !next_input_buffer())
         return false;
@@ -484,7 +526,7 @@ bool ChangesetParser::State::read_char(char& c) noexcept
     return true;
 }
 
-void ChangesetParser::State::read_bytes(char* data, size_t size)
+void State::read_bytes(char* data, size_t size)
 {
     for (;;) {
         const size_t avail = m_input_end - m_input_begin;
@@ -501,12 +543,12 @@ void ChangesetParser::State::read_bytes(char* data, size_t size)
     m_input_begin = to;
 }
 
-bool ChangesetParser::State::read_bool()
+bool State::read_bool()
 {
     return read_int<uint8_t>(); // Throws
 }
 
-float ChangesetParser::State::read_float()
+float State::read_float()
 {
     static_assert(std::numeric_limits<float>::is_iec559 &&
                       sizeof(float) * std::numeric_limits<unsigned char>::digits == 32,
@@ -516,7 +558,7 @@ float ChangesetParser::State::read_float()
     return value;
 }
 
-double ChangesetParser::State::read_double()
+double State::read_double()
 {
     static_assert(std::numeric_limits<double>::is_iec559 &&
                       sizeof(double) * std::numeric_limits<unsigned char>::digits == 64,
@@ -526,7 +568,7 @@ double ChangesetParser::State::read_double()
     return value;
 }
 
-InternString ChangesetParser::State::read_intern_string()
+InternString State::read_intern_string()
 {
     uint32_t index = read_int<uint32_t>(); // Throws
     if (m_valid_interned_strings.find(index) == m_valid_interned_strings.end())
@@ -534,14 +576,14 @@ InternString ChangesetParser::State::read_intern_string()
     return InternString{index};
 }
 
-GlobalKey ChangesetParser::State::read_global_key()
+GlobalKey State::read_global_key()
 {
     uint64_t hi = read_int<uint64_t>(); // Throws
     uint64_t lo = read_int<uint64_t>(); // Throws
     return GlobalKey{hi, lo};
 }
 
-Timestamp ChangesetParser::State::read_timestamp()
+Timestamp State::read_timestamp()
 {
     int64_t seconds = read_int<int64_t>();     // Throws
     int64_t nanoseconds = read_int<int64_t>(); // Throws
@@ -550,7 +592,7 @@ Timestamp ChangesetParser::State::read_timestamp()
     return Timestamp{seconds, int32_t(nanoseconds)};
 }
 
-ObjectId ChangesetParser::State::read_object_id()
+ObjectId State::read_object_id()
 {
     // FIXME: This is completely wrong and unsafe.
     ObjectId id;
@@ -558,14 +600,14 @@ ObjectId ChangesetParser::State::read_object_id()
     return id;
 }
 
-UUID ChangesetParser::State::read_uuid()
+UUID State::read_uuid()
 {
     UUID::UUIDBytes bytes{};
     read_bytes(reinterpret_cast<char*>(bytes.data()), bytes.size());
     return UUID(bytes);
 }
 
-Decimal128 ChangesetParser::State::read_decimal()
+Decimal128 State::read_decimal()
 {
     _impl::Bid128 cx;
     if (!_impl::decode_int(*this, cx))
@@ -578,7 +620,7 @@ Decimal128 ChangesetParser::State::read_decimal()
     return Decimal128(tmp, exp, sign);
 }
 
-StringData ChangesetParser::State::read_string()
+StringData State::read_string()
 {
     uint64_t size = read_int<uint64_t>(); // Throws
 
@@ -591,7 +633,7 @@ StringData ChangesetParser::State::read_string()
     return StringData{buffer.data(), size_t(size)};
 }
 
-BinaryData ChangesetParser::State::read_binary()
+BinaryData State::read_binary()
 {
     uint64_t size = read_int<uint64_t>(); // Throws
 
@@ -601,7 +643,7 @@ BinaryData ChangesetParser::State::read_binary()
     return read_buffer(size_t(size));
 }
 
-BinaryData ChangesetParser::State::read_buffer(size_t size)
+BinaryData State::read_buffer(size_t size)
 {
     const size_t avail = m_input_end - m_input_begin;
     if (avail >= size) {
@@ -615,39 +657,12 @@ BinaryData ChangesetParser::State::read_buffer(size_t size)
     return BinaryData(m_buffer.data(), size);
 }
 
-void ChangesetParser::State::parser_error(const char* complaints)
+void State::parser_error(const char* complaints)
 {
     throw BadChangesetError{complaints};
 }
 
-namespace {
-struct InstructionBuilder : InstructionHandler {
-    explicit InstructionBuilder(Changeset& log)
-        : m_log(log)
-    {
-    }
-    Changeset& m_log;
-
-    void operator()(const Instruction& instr) final
-    {
-        m_log.push_back(instr);
-    }
-
-    StringBufferRange add_string_range(StringData string) final
-    {
-        return m_log.append_string(string);
-    }
-
-    void set_intern_string(uint32_t index, StringBufferRange range) final
-    {
-        InternStrings& strings = m_log.interned_strings();
-        if (strings.size() <= index) {
-            strings.resize(index + 1, StringBufferRange{0, 0});
-        }
-        strings[index] = range;
-    }
-};
-} // unnamed namespace
+} // anonymous namespace
 
 namespace realm {
 namespace sync {
@@ -661,9 +676,44 @@ void parse_changeset(util::InputStream& input, Changeset& out_log)
 
 void parse_changeset(util::NoCopyInputStream& input, Changeset& out_log)
 {
-    ChangesetParser parser;
     InstructionBuilder builder{out_log};
-    parser.parse(input, builder);
+    State state{input, builder};
+
+    while (state.has_next())
+        state.parse_one();
+}
+
+OwnedMixed parse_base64_encoded_primary_key(std::string_view str)
+{
+    auto bin_encoded = util::base64_decode_to_vector(str);
+    if (!bin_encoded) {
+        throw BadChangesetError("invalid base64 in base64-encoded primary key");
+    }
+    util::SimpleNoCopyInputStream stream(*bin_encoded);
+    UnreachableInstructionHandler fake_encoder;
+    State state{stream, fake_encoder};
+    using Type = Instruction::Payload::Type;
+    Type type = state.read_payload_type();
+    switch (type) {
+        case Type::Null:
+            return OwnedMixed{};
+        case Type::Int:
+            return OwnedMixed{state.read_int()};
+        case Type::String: {
+            auto str = state.read_string();
+            return OwnedMixed{std::string{str.data(), str.size()}};
+        }
+        case Type::GlobalKey:
+            // GlobalKey's are not actually used as primary keys in sync. We currently have wire protocol support
+            // for them, but we've never sent them to the sync server.
+            REALM_UNREACHABLE();
+        case Type::ObjectId:
+            return OwnedMixed{state.read_object_id()};
+        case Type::UUID:
+            return OwnedMixed{state.read_uuid()};
+        default:
+            throw BadChangesetError("invalid primary key type");
+    }
 }
 
 } // namespace sync

--- a/src/realm/sync/changeset_parser.hpp
+++ b/src/realm/sync/changeset_parser.hpp
@@ -15,6 +15,22 @@ void parse_changeset(util::InputStream&, Changeset& out_log);
 // The server may send us primary keys of objects in json-encoded error messages as base64-encoded changeset payloads.
 // This function takes such a base64-encoded payload and returns it parsed as an owned Mixed value. If it cannot
 // be decoded, this throws a BadChangset exception.
+
+class OwnedMixed : public Mixed {
+public:
+    explicit OwnedMixed(std::string&& str)
+        : m_owned_string(std::move(str))
+    {
+        m_type = int(type_String);
+        string_val = m_owned_string;
+    }
+
+    using Mixed::Mixed;
+
+private:
+    std::string m_owned_string;
+};
+
 OwnedMixed parse_base64_encoded_primary_key(std::string_view str);
 
 } // namespace sync

--- a/src/realm/sync/changeset_parser.hpp
+++ b/src/realm/sync/changeset_parser.hpp
@@ -2,26 +2,20 @@
 #ifndef REALM_SYNC_CHANGESET_PARSER_HPP
 #define REALM_SYNC_CHANGESET_PARSER_HPP
 
+#include "realm/mixed.hpp"
 #include <realm/sync/changeset.hpp>
 #include <realm/util/input_stream.hpp>
 
 namespace realm {
 namespace sync {
 
-struct ChangesetParser {
-    /// Throws BadChangesetError if parsing fails.
-    ///
-    /// FIXME: Consider using std::error_code instead of throwing exceptions on
-    /// parse errors.
-    void parse(util::NoCopyInputStream&, InstructionHandler&);
-
-private:
-    struct State;
-};
-
 void parse_changeset(util::NoCopyInputStream&, Changeset& out_log);
 void parse_changeset(util::InputStream&, Changeset& out_log);
 
+// The server may send us primary keys of objects in json-encoded error messages as base64-encoded changeset payloads.
+// This function takes such a base64-encoded payload and returns it parsed as an owned Mixed value. If it cannot
+// be decoded, this throws a BadChangset exception.
+OwnedMixed parse_base64_encoded_primary_key(std::string_view str);
 
 } // namespace sync
 } // namespace realm

--- a/src/realm/sync/changeset_parser.hpp
+++ b/src/realm/sync/changeset_parser.hpp
@@ -12,10 +12,6 @@ namespace sync {
 void parse_changeset(util::NoCopyInputStream&, Changeset& out_log);
 void parse_changeset(util::InputStream&, Changeset& out_log);
 
-// The server may send us primary keys of objects in json-encoded error messages as base64-encoded changeset payloads.
-// This function takes such a base64-encoded payload and returns it parsed as an owned Mixed value. If it cannot
-// be decoded, this throws a BadChangset exception.
-
 class OwnedMixed : public Mixed {
 public:
     explicit OwnedMixed(std::string&& str)
@@ -31,6 +27,9 @@ private:
     std::string m_owned_string;
 };
 
+// The server may send us primary keys of objects in json-encoded error messages as base64-encoded changeset payloads.
+// This function takes such a base64-encoded payload and returns it parsed as an owned Mixed value. If it cannot
+// be decoded, this throws a BadChangeset exception.
 OwnedMixed parse_base64_encoded_primary_key(std::string_view str);
 
 } // namespace sync

--- a/src/realm/sync/client.cpp
+++ b/src/realm/sync/client.cpp
@@ -1403,13 +1403,6 @@ void SessionWrapper::on_resumed()
 void SessionWrapper::on_connection_state_changed(ConnectionState state,
                                                  const util::Optional<SessionErrorInfo>& error_info)
 {
-    if (state == ConnectionState::connected && m_sess) {
-        ClientImpl::Connection& conn = m_sess->get_connection();
-        if (conn.is_flx_sync_connection()) {
-            get_flx_subscription_store();
-        }
-    }
-
     if (m_connection_state_change_listener) {
         if (!m_suspended)
             m_connection_state_change_listener(state, error_info); // Throws

--- a/src/realm/sync/client.cpp
+++ b/src/realm/sync/client.cpp
@@ -638,8 +638,8 @@ void ClientImpl::remove_connection(ClientImpl::Connection& conn) noexcept
 // ################ SessionImpl ################
 
 
-inline void SessionImpl::on_connection_state_changed(ConnectionState state,
-                                                     const util::Optional<SessionErrorInfo>& error_info)
+void SessionImpl::on_connection_state_changed(ConnectionState state,
+                                              const util::Optional<SessionErrorInfo>& error_info)
 {
     m_wrapper.on_connection_state_changed(state, error_info); // Throws
 }

--- a/src/realm/sync/client_base.hpp
+++ b/src/realm/sync/client_base.hpp
@@ -326,12 +326,12 @@ struct SessionErrorInfo : public ProtocolErrorInfo {
     {
     }
     SessionErrorInfo(const std::error_code& ec, bool try_again)
-        : ProtocolErrorInfo(ec.message(), try_again)
+        : ProtocolErrorInfo(ec.value(), ec.message(), try_again)
         , error_code(ec)
     {
     }
     SessionErrorInfo(const std::error_code& ec, const std::string& msg, bool try_again)
-        : ProtocolErrorInfo(msg, try_again)
+        : ProtocolErrorInfo(ec.value(), msg, try_again)
         , error_code(ec)
     {
     }

--- a/src/realm/sync/config.cpp
+++ b/src/realm/sync/config.cpp
@@ -32,10 +32,12 @@ static_assert(std::is_same_v<sync::port_type, util::network::Endpoint::port_type
 using ProtocolError = realm::sync::ProtocolError;
 
 SyncError::SyncError(std::error_code error_code, std::string msg, bool is_fatal,
-                     util::Optional<std::string> serverLog)
+                     util::Optional<std::string> serverLog,
+                     std::vector<sync::CompensatingWriteErrorInfo> compensating_writes)
     : error_code(std::move(error_code))
     , is_fatal(is_fatal)
     , message(std::move(msg))
+    , compensating_writes_info(std::move(compensating_writes))
 {
     if (serverLog) {
         size_t msg_length = message.size();

--- a/src/realm/sync/config.cpp
+++ b/src/realm/sync/config.cpp
@@ -172,6 +172,8 @@ SimplifiedProtocolError get_simplified_error(sync::ProtocolError err)
         case ProtocolError::server_permissions_changed:
         case ProtocolError::write_not_allowed:
             return SimplifiedProtocolError::ClientResetRequested;
+        case ProtocolError::compensating_write:
+            return SimplifiedProtocolError::CompensatingWrite;
     }
     return SimplifiedProtocolError::UnexpectedInternalIssue; // always return a value to appease MSVC.
 }

--- a/src/realm/sync/config.hpp
+++ b/src/realm/sync/config.hpp
@@ -48,6 +48,7 @@ enum class SimplifiedProtocolError {
     BadAuthentication,
     PermissionDenied,
     ClientResetRequested,
+    CompensatingWrite,
 };
 
 namespace sync {

--- a/src/realm/sync/config.hpp
+++ b/src/realm/sync/config.hpp
@@ -19,7 +19,6 @@
 #ifndef REALM_SYNC_CONFIG_HPP
 #define REALM_SYNC_CONFIG_HPP
 
-#include "realm/sync/protocol.hpp"
 #include <realm/db.hpp>
 #include <realm/util/assert.hpp>
 #include <realm/util/optional.hpp>

--- a/src/realm/sync/config.hpp
+++ b/src/realm/sync/config.hpp
@@ -19,6 +19,7 @@
 #ifndef REALM_SYNC_CONFIG_HPP
 #define REALM_SYNC_CONFIG_HPP
 
+#include "realm/sync/protocol.hpp"
 #include <realm/db.hpp>
 #include <realm/util/assert.hpp>
 #include <realm/util/optional.hpp>
@@ -80,9 +81,13 @@ struct SyncError {
     // the server may explicitly send down "IsClientReset" as part of an error
     // if this is set, it overrides the clients interpretation of the error
     util::Optional<ClientResetModeAllowed> server_requests_client_reset = util::none;
+    // If this error resulted from a compensating write, this vector will contain information about each object
+    // that caused a compensating write and why the write was illegal.
+    std::vector<sync::CompensatingWriteErrorInfo> compensating_writes_info;
 
     SyncError(std::error_code error_code, std::string msg, bool is_fatal,
-              util::Optional<std::string> serverLog = util::none);
+              util::Optional<std::string> serverLog = util::none,
+              std::vector<sync::CompensatingWriteErrorInfo> compensating_writes = {});
 
     static constexpr const char c_original_file_path_key[] = "ORIGINAL_FILE_PATH";
     static constexpr const char c_recovery_file_path_key[] = "RECOVERY_FILE_PATH";

--- a/src/realm/sync/noinst/client_impl_base.cpp
+++ b/src/realm/sync/noinst/client_impl_base.cpp
@@ -1,3 +1,4 @@
+#include "realm/sync/protocol.hpp"
 #include <system_error>
 #include <sstream>
 
@@ -2171,6 +2172,11 @@ std::error_code Session::receive_error_message(int error_code_int, const Protoco
     if (REALM_UNLIKELY(!is_session_level_error(error_code))) {
         logger.error("Not a session level error code"); // Throws
         return ClientError::bad_error_code;
+    }
+
+    if (!session_level_error_requires_suspend(error_code)) {
+        on_connection_state_changed(m_conn.get_state(), SessionErrorInfo{info, make_error_code(error_code)});
+        return {}; // Success
     }
 
     REALM_ASSERT(!m_suspended);

--- a/src/realm/sync/noinst/client_impl_base.cpp
+++ b/src/realm/sync/noinst/client_impl_base.cpp
@@ -1164,7 +1164,7 @@ void Connection::receive_pong(milliseconds_type timestamp)
 }
 
 
-void Connection::receive_error_message(int raw_error_code, const ProtocolErrorInfo& info,
+void Connection::receive_error_message(const ProtocolErrorInfo& info,
                                        session_ident_type session_ident)
 {
     Session* sess = nullptr;
@@ -1176,7 +1176,7 @@ void Connection::receive_error_message(int raw_error_code, const ProtocolErrorIn
             close_due_to_protocol_error(ClientError::bad_session_ident); // Throws
             return;
         }
-        std::error_code ec = sess->receive_error_message(raw_error_code, info); // Throws
+        std::error_code ec = sess->receive_error_message(info); // Throws
         if (ec) {
             close_due_to_protocol_error(ec); // Throws
             return;
@@ -1191,11 +1191,11 @@ void Connection::receive_error_message(int raw_error_code, const ProtocolErrorIn
     }
 
     logger.info("Received: ERROR \"%1\" (error_code=%2, try_again=%3, session_ident=%4)", info.message,
-                raw_error_code, info.try_again, session_ident); // Throws
+                info.error_code, info.try_again, session_ident); // Throws
 
-    bool known_error_code = bool(get_protocol_error_message(raw_error_code));
+    bool known_error_code = bool(get_protocol_error_message(info.error_code));
     if (REALM_LIKELY(known_error_code)) {
-        ProtocolError error_code = ProtocolError(raw_error_code);
+        ProtocolError error_code = ProtocolError(info.error_code);
         if (REALM_LIKELY(!is_session_level_error(error_code))) {
             close_due_to_server_side_error(error_code, info); // Throws
             return;
@@ -2151,10 +2151,10 @@ std::error_code Session::receive_query_error_message(int error_code, std::string
 
 // The caller (Connection) must discard the session if the session has become
 // deactivated upon return.
-std::error_code Session::receive_error_message(int error_code_int, const ProtocolErrorInfo& info)
+std::error_code Session::receive_error_message(const ProtocolErrorInfo& info)
 {
     logger.info("Received: ERROR \"%1\" (error_code=%2, try_again=%3, recovery_disabled=%4)", info.message,
-                error_code_int, info.try_again, info.client_reset_recovery_is_disabled); // Throws
+                info.error_code, info.try_again, info.client_reset_recovery_is_disabled); // Throws
 
     bool legal_at_this_time = (m_bind_message_sent && !m_error_message_received && !m_unbound_message_received);
     if (REALM_UNLIKELY(!legal_at_this_time)) {
@@ -2162,12 +2162,12 @@ std::error_code Session::receive_error_message(int error_code_int, const Protoco
         return ClientError::bad_message_order;
     }
 
-    bool known_error_code = bool(get_protocol_error_message(error_code_int));
+    bool known_error_code = bool(get_protocol_error_message(info.error_code));
     if (REALM_UNLIKELY(!known_error_code)) {
         logger.error("Unknown error code"); // Throws
         return ClientError::bad_error_code;
     }
-    ProtocolError error_code = ProtocolError(error_code_int);
+    ProtocolError error_code = ProtocolError(info.error_code);
     if (REALM_UNLIKELY(!is_session_level_error(error_code))) {
         logger.error("Not a session level error code"); // Throws
         return ClientError::bad_error_code;
@@ -2207,7 +2207,7 @@ std::error_code Session::receive_error_message(int error_code_int, const Protoco
     }
 
     if (info.try_again) {
-        begin_resumption_delay();
+        begin_resumption_delay(info);
     }
 
     // Ready to send the UNBIND message, if it has not been sent already
@@ -2217,19 +2217,29 @@ std::error_code Session::receive_error_message(int error_code_int, const Protoco
     return {};
 }
 
-void Session::begin_resumption_delay()
+void Session::begin_resumption_delay(const ProtocolErrorInfo& error_info)
 {
     REALM_ASSERT(!m_try_again_activation_timer);
     m_try_again_activation_timer.emplace(m_conn.get_client().get_service());
-    logger.debug("Will attempt to resume session after %1 milliseconds", m_try_again_activation_delay.count());
-    m_try_again_activation_timer->async_wait(m_try_again_activation_delay, [this](std::error_code ec) {
+    if (error_info.resumption_delay_interval) {
+        m_try_again_delay_info = *error_info.resumption_delay_interval;
+    }
+    if (!m_current_try_again_delay_interval ||
+        (m_try_again_error_code && *m_try_again_error_code != ProtocolError(error_info.error_code))) {
+        m_current_try_again_delay_interval = m_try_again_delay_info.resumption_delay_interval;
+    } else if (ProtocolError(error_info.error_code) == ProtocolError::session_closed) {
+        m_current_try_again_delay_interval = std::chrono::milliseconds{1000};
+    }
+    m_try_again_error_code = ProtocolError(error_info.error_code);
+    logger.debug("Will attempt to resume session after %1 milliseconds", m_current_try_again_delay_interval->count());
+    m_try_again_activation_timer->async_wait(*m_current_try_again_delay_interval, [this](std::error_code ec) {
         if (ec == util::error::operation_aborted) {
             return;
         }
 
         m_try_again_activation_timer.reset();
-        if (m_try_again_activation_delay < std::chrono::minutes{5}) {
-            m_try_again_activation_delay *= 2;
+        if (m_current_try_again_delay_interval < m_try_again_delay_info.max_resumption_delay_interval) {
+            *m_current_try_again_delay_interval *= m_try_again_delay_info.resumption_delay_backoff_multiplier;
         }
         cancel_resumption_delay();
     });
@@ -2239,7 +2249,7 @@ void Session::clear_resumption_delay_state()
 {
     if (m_try_again_activation_timer) {
         logger.debug("Clearing resumption delay state after successful download");
-        m_try_again_activation_delay = std::chrono::milliseconds{1000};
+        m_current_try_again_delay_interval = util::none;
     }
 }
 

--- a/src/realm/sync/noinst/client_impl_base.cpp
+++ b/src/realm/sync/noinst/client_impl_base.cpp
@@ -1677,6 +1677,7 @@ void Session::send_ident_message()
                      active_query_body); // Throws
         protocol.make_flx_ident_message(out, session_ident, m_client_file_ident, m_progress,
                                         active_query_set.version(), active_query_body); // Throws
+        m_last_sent_flx_query_version = active_query_set.version();
     }
     else {
         logger.debug("Sending: IDENT(client_file_ident=%1, client_file_ident_salt=%2, "
@@ -1720,8 +1721,6 @@ void Session::send_query_change_message()
     m_conn.initiate_write_message(out, this);
 
     m_last_sent_flx_query_version = latest_sub_set.version();
-    m_pending_flx_sub_set =
-        sub_store->get_next_pending_version(m_last_sent_flx_query_version, m_pending_flx_sub_set->snapshot_version);
 
     enlist_to_send(); // throws
 }

--- a/src/realm/sync/noinst/client_impl_base.hpp
+++ b/src/realm/sync/noinst/client_impl_base.hpp
@@ -457,7 +457,7 @@ private:
     void change_state_to_disconnected() noexcept;
     // These are only called from ClientProtocol class.
     void receive_pong(milliseconds_type timestamp);
-    void receive_error_message(int error_code, const ProtocolErrorInfo& info, session_ident_type);
+    void receive_error_message(const ProtocolErrorInfo& info, session_ident_type);
     void receive_query_error_message(int error_code, std::string_view message, int64_t query_version,
                                      session_ident_type);
     void receive_ident_message(session_ident_type, SaltedFileIdent);
@@ -870,7 +870,7 @@ private:
     // Processes any pending FLX bootstraps, if one exists. Otherwise this is a noop.
     void process_pending_flx_bootstrap();
 
-    void begin_resumption_delay();
+    void begin_resumption_delay(const ProtocolErrorInfo& error_info);
     void clear_resumption_delay_state();
 
 private:
@@ -888,7 +888,9 @@ private:
     bool m_suspended = false;
 
     util::Optional<util::network::DeadlineTimer> m_try_again_activation_timer;
-    std::chrono::milliseconds m_try_again_activation_delay{1000};
+    ResumptionDelayInfo m_try_again_delay_info;
+    util::Optional<ProtocolError> m_try_again_error_code;
+    util::Optional<std::chrono::milliseconds> m_current_try_again_delay_interval;
 
     DownloadBatchState m_download_batch_state = DownloadBatchState::LastInBatch;
 
@@ -1055,7 +1057,7 @@ private:
                                   DownloadBatchState last_in_batch, int64_t query_version, const ReceivedChangesets&);
     std::error_code receive_mark_message(request_ident_type);
     std::error_code receive_unbound_message();
-    std::error_code receive_error_message(int error_code, const ProtocolErrorInfo& info);
+    std::error_code receive_error_message(const ProtocolErrorInfo& info);
     std::error_code receive_query_error_message(int error_code, std::string_view message, int64_t query_version);
 
     void initiate_rebind();

--- a/src/realm/sync/noinst/protocol_codec.hpp
+++ b/src/realm/sync/noinst/protocol_codec.hpp
@@ -261,7 +261,7 @@ public:
             }
             else if (message_type == "json_error") { // introduced in protocol 4
                 sync::ProtocolErrorInfo info{};
-                info.error_code = msg.read_next<int>();
+                info.raw_error_code = msg.read_next<int>();
                 auto message_size = msg.read_next<size_t>();
                 auto session_ident = msg.read_next<session_ident_type>('\n');
                 auto json_raw = msg.read_sized_data<std::string_view>(message_size);
@@ -311,7 +311,7 @@ public:
                     // If any of the above json fields are not present, this is a fatal error
                     // however, additional optional fields may be added in the future.
                     return report_error(Error::bad_syntax, "Failed to parse 'json_error' with error_code %1: '%2'",
-                                        info.error_code, e.what());
+                                        info.raw_error_code, e.what());
                 }
                 connection.receive_error_message(info, session_ident); // Throws
             }

--- a/src/realm/sync/noinst/protocol_codec.hpp
+++ b/src/realm/sync/noinst/protocol_codec.hpp
@@ -267,10 +267,11 @@ public:
                 auto json_raw = msg.read_sized_data<std::string_view>(message_size);
                 try {
                     auto json = nlohmann::json::parse(json_raw);
+                    logger.trace("Error message encoded as json: %1", json_raw);
                     info.client_reset_recovery_is_disabled = json["isRecoveryModeDisabled"];
                     info.try_again = json["tryAgain"];
                     info.message = json["message"];
-                    info.logURL = util::make_optional<std::string>(json["logURL"]);
+                    info.log_url = util::make_optional<std::string>(json["logURL"]);
                     info.should_client_reset = util::make_optional<bool>(json["shouldClientReset"]);
                 }
                 catch (const nlohmann::json::exception& e) {

--- a/src/realm/sync/protocol.cpp
+++ b/src/realm/sync/protocol.cpp
@@ -138,8 +138,9 @@ const char* get_protocol_error_message(int error_code) noexcept
             return "Client attempted a write that is disallowed by permissions, or modifies an object outside the "
                    "current query - requires client reset";
         case ProtocolError::compensating_write:
-            return "Client attempted a write that is disallowed by permissions, or modifies and object outside the "
-                   "current query, and the server undid the modification";
+            return "Client attempted a write that is disallowed by permissions, or modifies an object outside the "
+                   "current query, and the server undid the change";
+            ;
     }
     return nullptr;
 }

--- a/src/realm/sync/protocol.cpp
+++ b/src/realm/sync/protocol.cpp
@@ -137,6 +137,9 @@ const char* get_protocol_error_message(int error_code) noexcept
         case ProtocolError::write_not_allowed:
             return "Client attempted a write that is disallowed by permissions, or modifies an object outside the "
                    "current query - requires client reset";
+        case ProtocolError::compensating_write:
+            return "Client attempted a write that is disallowed by permissions, or modifies and object outside the "
+                   "current query, and the server undid the modification";
     }
     return nullptr;
 }

--- a/src/realm/sync/protocol.hpp
+++ b/src/realm/sync/protocol.hpp
@@ -206,14 +206,14 @@ struct ResumptionDelayInfo {
 struct ProtocolErrorInfo {
     ProtocolErrorInfo() = default;
     ProtocolErrorInfo(int error_code, const std::string& msg, bool do_try_again)
-        : error_code(error_code)
+        : raw_error_code(error_code)
         , message(msg)
         , try_again(do_try_again)
         , client_reset_recovery_is_disabled(false)
         , should_client_reset(util::none)
     {
     }
-    int error_code = 0;
+    int raw_error_code = 0;
     std::string message;
     bool try_again = false;
     bool client_reset_recovery_is_disabled = false;

--- a/src/realm/sync/protocol.hpp
+++ b/src/realm/sync/protocol.hpp
@@ -191,6 +191,12 @@ struct SyncProgress {
     UploadCursor upload = {0, 0};
 };
 
+struct CompensatingWriteErrorInfo {
+    std::string object_name;
+    Mixed primary_key;
+    std::string reason;
+};
+
 struct ProtocolErrorInfo {
     ProtocolErrorInfo() = default;
     ProtocolErrorInfo(const std::string& msg, bool do_try_again)
@@ -205,6 +211,7 @@ struct ProtocolErrorInfo {
     bool client_reset_recovery_is_disabled = false;
     util::Optional<bool> should_client_reset;
     util::Optional<std::string> log_url;
+    std::vector<CompensatingWriteErrorInfo> compensating_writes;
 
     bool is_fatal() const
     {
@@ -344,11 +351,11 @@ constexpr bool is_session_level_error(ProtocolError error)
 
 constexpr bool session_level_error_requires_suspend(ProtocolError error)
 {
-    switch(error) {
-    case ProtocolError::compensating_write:
-        return false;
-    default:
-        return true;
+    switch (error) {
+        case ProtocolError::compensating_write:
+            return false;
+        default:
+            return true;
     }
 }
 

--- a/src/realm/sync/protocol.hpp
+++ b/src/realm/sync/protocol.hpp
@@ -197,27 +197,37 @@ struct CompensatingWriteErrorInfo {
     std::string reason;
 };
 
+struct ResumptionDelayInfo {
+    std::chrono::milliseconds max_resumption_delay_interval = std::chrono::minutes{5};
+    std::chrono::milliseconds resumption_delay_interval = std::chrono::seconds{1};
+    int resumption_delay_backoff_multiplier = 2;
+};
+
 struct ProtocolErrorInfo {
     ProtocolErrorInfo() = default;
-    ProtocolErrorInfo(const std::string& msg, bool do_try_again)
-        : message(msg)
+    ProtocolErrorInfo(int error_code, const std::string& msg, bool do_try_again)
+        : error_code(error_code)
+        , message(msg)
         , try_again(do_try_again)
         , client_reset_recovery_is_disabled(false)
         , should_client_reset(util::none)
     {
     }
+    int error_code = 0;
     std::string message;
     bool try_again = false;
     bool client_reset_recovery_is_disabled = false;
     util::Optional<bool> should_client_reset;
     util::Optional<std::string> log_url;
     std::vector<CompensatingWriteErrorInfo> compensating_writes;
+    util::Optional<ResumptionDelayInfo> resumption_delay_interval;
 
     bool is_fatal() const
     {
         return !try_again;
     }
 };
+
 
 /// \brief Protocol errors discovered by the server, and reported to the client
 /// by way of ERROR messages.

--- a/test/object-store/CMakeLists.txt
+++ b/test/object-store/CMakeLists.txt
@@ -89,7 +89,12 @@ add_test(NAME ObjectStoreTests COMMAND realm-object-store-tests)
 
 if(REALM_ENABLE_SYNC)
     target_link_libraries(ObjectStoreTests SyncServer)
-
+    option(REALM_ENABLE_COMPENSATING_WRITES_TESTS "" OFF)
+    if (REALM_ENABLE_COMPENSATING_WRITES_TESTS)
+        target_compile_definitions(ObjectStoreTests PRIVATE
+            REALM_ENABLE_COMPENSATING_WRITES_TESTS=1
+        )
+    endif()
     option(REALM_ENABLE_AUTH_TESTS "" OFF)
     if(REALM_ENABLE_AUTH_TESTS)
         if(NOT REALM_MONGODB_ENDPOINT)

--- a/test/object-store/sync/flx_sync.cpp
+++ b/test/object-store/sync/flx_sync.cpp
@@ -275,10 +275,14 @@ TEST_CASE("flx: uploading an object that is out-of-view results in compensating 
             Object::create(c, realm, "TopLevel",
                            util::Any(AnyDict{{"_id", invalid_obj}, {"queryable_str_field", std::string{"bizz"}}}));
             realm->commit_transaction();
+
+            wait_for_upload(*realm);
+            wait_for_download(*realm);
+
             validate_sync_error(
                 std::move(error_future).get(), invalid_obj,
                 util::format("write to '%1' in table \"TopLevel\" not allowed", invalid_obj.to_string()));
-            wait_for_download(*realm);
+
             realm->refresh();
 
             auto top_level_table = realm->read_group().get_table("class_TopLevel");
@@ -317,11 +321,12 @@ TEST_CASE("flx: uploading an object that is out-of-view results in compensating 
             embedded_obj.set_property_value(c, "str_field", util::Any{std::string{"baz"}});
             realm->commit_transaction();
 
+            wait_for_upload(*realm);
+            wait_for_download(*realm);
             validate_sync_error(
                 std::move(error_future).get(), invalid_obj,
                 util::format("write to '%1' in table \"TopLevel\" not allowed", invalid_obj.to_string()));
 
-            wait_for_download(*realm);
             realm->refresh();
 
             obj = Object::get_for_primary_key(c, realm, "TopLevel", util::Any(invalid_obj));
@@ -363,9 +368,10 @@ TEST_CASE("flx: uploading an object that is out-of-view results in compensating 
                            }));
             realm->commit_transaction();
 
-            validate_sync_error(std::move(error_future).get(), invalid_obj, "before opening a subscription on it");
-
+            wait_for_upload(*realm);
             wait_for_download(*realm);
+
+            validate_sync_error(std::move(error_future).get(), invalid_obj, "before opening a subscription on it");
             realm->refresh();
 
             auto top_level_table = realm->read_group().get_table("class_TopLevel");
@@ -403,10 +409,11 @@ TEST_CASE("flx: uploading an object that is out-of-view results in compensating 
                            }));
             realm->commit_transaction();
 
+            wait_for_upload(*realm);
+            wait_for_download(*realm);
+
             validate_sync_error(std::move(error_future).get(), invalid_obj,
                                 "object is outside of the current query view");
-
-            wait_for_download(*realm);
             realm->refresh();
 
             auto top_level_table = realm->read_group().get_table("class_TopLevel");

--- a/test/object-store/sync/flx_sync.cpp
+++ b/test/object-store/sync/flx_sync.cpp
@@ -190,6 +190,7 @@ TEST_CASE("flx: connect to FLX-enabled app", "[sync][flx][app]") {
     });
 }
 
+#if REALM_ENABLE_COMPENSATING_WRITES_TESTS
 TEST_CASE("flx: uploading an object that is out-of-view results in compensating write", "[sync][flx][app]") {
     FLXSyncTestHarness harness("flx_bad_query");
 
@@ -300,6 +301,7 @@ TEST_CASE("flx: uploading an object that is out-of-view results in compensating 
         });
     }
 }
+#endif
 
 TEST_CASE("flx: query on non-queryable field results in query error message", "[sync][flx][app]") {
     FLXSyncTestHarness harness("flx_bad_query");

--- a/test/object-store/sync/flx_sync_harness.hpp
+++ b/test/object-store/sync/flx_sync_harness.hpp
@@ -31,6 +31,7 @@ public:
     struct ServerSchema {
         Schema schema;
         std::vector<std::string> queryable_fields;
+        std::vector<AppCreateConfig::FLXSyncRole> default_roles;
         bool dev_mode_enabled = false;
     };
 
@@ -56,6 +57,7 @@ public:
         server_app_config.dev_mode_enabled = server_schema.dev_mode_enabled;
         AppCreateConfig::FLXSyncConfig flx_config;
         flx_config.queryable_fields = server_schema.queryable_fields;
+        flx_config.default_roles = server_schema.default_roles;
 
         server_app_config.flx_sync_config = std::move(flx_config);
         return create_app(server_app_config);

--- a/test/object-store/util/baas_admin_api.cpp
+++ b/test/object-store/util/baas_admin_api.cpp
@@ -17,6 +17,8 @@
 ////////////////////////////////////////////////////////////////////////////
 
 #include "baas_admin_api.hpp"
+#include "external/mpark/variant.hpp"
+#include "realm/object-store/sync/app_credentials.hpp"
 
 #if REALM_ENABLE_AUTH_TESTS
 
@@ -376,7 +378,8 @@ app::Response AdminAPIEndpoint::del() const
 nlohmann::json AdminAPIEndpoint::get_json() const
 {
     auto resp = get();
-    REALM_ASSERT(resp.http_status_code >= 200 && resp.http_status_code < 300);
+    REALM_ASSERT_EX(resp.http_status_code >= 200 && resp.http_status_code < 300,
+                    util::format("url: %1, reply: %2", m_url, resp.body));
     return nlohmann::json::parse(resp.body.empty() ? "{}" : resp.body);
 }
 
@@ -392,7 +395,8 @@ app::Response AdminAPIEndpoint::post(std::string body) const
 nlohmann::json AdminAPIEndpoint::post_json(nlohmann::json body) const
 {
     auto resp = post(body.dump());
-    REALM_ASSERT(resp.http_status_code >= 200 && resp.http_status_code < 300);
+    REALM_ASSERT_EX(resp.http_status_code >= 200 && resp.http_status_code < 300,
+                    util::format("url: %1 request: %2, reply: %3", m_url, body.dump(), resp.body));
     return nlohmann::json::parse(resp.body.empty() ? "{}" : resp.body);
 }
 
@@ -408,7 +412,8 @@ app::Response AdminAPIEndpoint::put(std::string body) const
 nlohmann::json AdminAPIEndpoint::put_json(nlohmann::json body) const
 {
     auto resp = put(body.dump());
-    REALM_ASSERT(resp.http_status_code >= 200 && resp.http_status_code < 300);
+    REALM_ASSERT_EX(resp.http_status_code >= 200 && resp.http_status_code < 300,
+                    util::format("url: %1 request: %2, reply: %3", m_url, body.dump(), resp.body));
     return nlohmann::json::parse(resp.body.empty() ? "{}" : resp.body);
 }
 
@@ -424,7 +429,8 @@ app::Response AdminAPIEndpoint::patch(std::string body) const
 nlohmann::json AdminAPIEndpoint::patch_json(nlohmann::json body) const
 {
     auto resp = patch(body.dump());
-    REALM_ASSERT(resp.http_status_code >= 200 && resp.http_status_code < 300);
+    REALM_ASSERT_EX(resp.http_status_code >= 200 && resp.http_status_code < 300,
+                    util::format("url: %1 request: %2, reply: %3", m_url, body.dump(), resp.body));
     return nlohmann::json::parse(resp.body.empty() ? "{}" : resp.body);
 }
 
@@ -867,15 +873,39 @@ AppSession create_app(const AppCreateConfig& config)
         auto queryable_fields = nlohmann::json::array();
         const auto& queryable_fields_src = config.flx_sync_config->queryable_fields;
         std::copy(queryable_fields_src.begin(), queryable_fields_src.end(), std::back_inserter(queryable_fields));
-        mongo_service_def["config"]["flexible_sync"] = nlohmann::json{
-            {"state", "enabled"},
-            {"database_name", config.mongo_dbname},
-            {"queryable_fields_names", queryable_fields},
-            {"permissions",
-             {{"rules", nlohmann::json::object()},
-              {"defaultRoles",
-               nlohmann::json::array(
-                   {{{"name", "all"}, {"applyWhen", nlohmann::json::object()}, {"read", true}, {"write", true}}})}}}};
+        auto default_roles = nlohmann::json::array();
+        if (config.flx_sync_config->default_roles.empty()) {
+            default_roles = nlohmann::json::array(
+                {{{"name", "all"}, {"applyWhen", nlohmann::json::object()}, {"read", true}, {"write", true}}});
+        }
+        else {
+            std::transform(config.flx_sync_config->default_roles.begin(), config.flx_sync_config->default_roles.end(),
+                           std::back_inserter(default_roles), [](const AppCreateConfig::FLXSyncRole& role_def) {
+                               nlohmann::json ret{{"name", role_def.name}, {"applyWhen", role_def.apply_when}};
+                               if (auto read_bool_ptr = mpark::get_if<bool>(&role_def.read)) {
+                                   ret["read"] = *read_bool_ptr;
+                               }
+                               else {
+                                   ret["read"] = mpark::get<nlohmann::json>(role_def.read);
+                               }
+                               if (auto write_bool_ptr = mpark::get_if<bool>(&role_def.write)) {
+                                   ret["write"] = *write_bool_ptr;
+                               }
+                               else {
+                                   ret["write"] = mpark::get<nlohmann::json>(role_def.write);
+                               }
+                               return ret;
+                           });
+        }
+        mongo_service_def["config"]["flexible_sync"] = nlohmann::json{{"state", "enabled"},
+                                                                      {"database_name", config.mongo_dbname},
+                                                                      {"queryable_fields_names", queryable_fields},
+                                                                      {"permissions",
+                                                                       {{"rules", nlohmann::json::object()},
+                                                                        {
+                                                                            "defaultRoles",
+                                                                            default_roles,
+                                                                        }}}};
     }
     else {
         sync_config = nlohmann::json{
@@ -900,21 +930,24 @@ AppSession create_app(const AppCreateConfig& config)
     auto rules = services[mongo_service_id]["rules"];
     auto schemas = app["schemas"];
 
-    auto pk_only = [&](const Property& prop) {
+    auto pk_and_queryable_only = [&](const Property& prop) {
+        if (config.flx_sync_config) {
+            const auto& queryable_fields = config.flx_sync_config->queryable_fields;
+
+            if (std::find(queryable_fields.begin(), queryable_fields.end(), prop.name) != queryable_fields.end()) {
+                return true;
+            }
+        }
         return prop.name == "_id" || prop.name == config.partition_key.name;
     };
 
     // Create the rules in two passes: first populate just the primary key and
-    // parition key, then add the rest of the properties. This ensures that the
+    // partition key, then add the rest of the properties. This ensures that the
     // targest of links exist before adding the links.
     std::vector<std::pair<std::string, const ObjectSchema*>> object_schema_to_create;
     BaasRuleBuilder rule_builder(config.schema, config.partition_key, mongo_service_name, config.mongo_dbname);
     for (const auto& obj_schema : config.schema) {
-        if (auto pk_prop = obj_schema.primary_key_property(); pk_prop == nullptr || pk_prop->name != "_id") {
-            continue;
-        }
-
-        auto schema_to_create = rule_builder.object_schema_to_baas_schema(obj_schema, pk_only);
+        auto schema_to_create = rule_builder.object_schema_to_baas_schema(obj_schema, pk_and_queryable_only);
         auto schema_create_resp = schemas.post_json(schema_to_create);
         object_schema_to_create.push_back({schema_create_resp["_id"], &obj_schema});
 

--- a/test/object-store/util/baas_admin_api.hpp
+++ b/test/object-store/util/baas_admin_api.hpp
@@ -21,11 +21,13 @@
 #include "realm/object-store/property.hpp"
 #include "realm/object-store/object_schema.hpp"
 #include "realm/object-store/schema.hpp"
+#include "realm/object-store/sync/app_credentials.hpp"
 #include "realm/object-store/sync/generic_network_transport.hpp"
 
 #include "sync/sync_test_utils.hpp"
 
 #include "external/json/json.hpp"
+#include "external/mpark/variant.hpp"
 
 #if REALM_ENABLE_AUTH_TESTS
 namespace realm {
@@ -138,8 +140,16 @@ struct AppCreateConfig {
         bool run_reset_function;
     };
 
+    struct FLXSyncRole {
+        std::string name;
+        nlohmann::json apply_when = nlohmann::json::object();
+        mpark::variant<bool, nlohmann::json> read;
+        mpark::variant<bool, nlohmann::json> write;
+    };
+
     struct FLXSyncConfig {
         std::vector<std::string> queryable_fields;
+        std::vector<FLXSyncRole> default_roles;
     };
 
     std::string app_name;


### PR DESCRIPTION
## What, How & Why?
This adds support to the sync client and object store for handling compensating write errors from the server. There are some new fields in the SyncError class that represent which objects caused the compensating writes and why. The changeset parser has been refactored a bit to support parsing some of the values encoded in compensating write errors. The test that previously checked that uploading an object out-of-view results in a client reset now checks that a compensating write error is received. The test for compensating writes is only enabled on a special build variant that runs against the master branch of baas - this will be undone when baas releases next week.

## ☑️ ToDos
* [x] 📝 Changelog update
* [x] 🚦 Tests (or not relevant)
* [ ] C-API, if public C++ API changed.
