### PR TITLE
Bump Xcode version in evergreen to 13.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,7 +22,7 @@
 -----------
 
 ### Internals
-* None.
+* Evergreen builders for MacOS now build with Xcode 13.1 on MacOS 11.0
 
 ----------------------------------------------
 

--- a/evergreen/config.yml
+++ b/evergreen/config.yml
@@ -800,7 +800,7 @@ buildvariants:
     cmake_generator: Xcode
     max_jobs: $(sysctl -n hw.logicalcpu)
     run_tests_against_baas: On
-    xcode_developer_dir: /Applications/Xcode12.4.app/Contents/Developer
+    xcode_developer_dir: /Applications/Xcode13.1.app/Contents/Developer
     extra_flags: -DCMAKE_SYSTEM_NAME=Darwin -DCMAKE_OSX_ARCHITECTURES=x86_64
   tasks:
   - name: compile_test
@@ -816,7 +816,7 @@ buildvariants:
     cmake_generator: Xcode
     max_jobs: $(sysctl -n hw.logicalcpu)
     run_tests_against_baas: On
-    xcode_developer_dir: /Applications/Xcode12.4.app/Contents/Developer
+    xcode_developer_dir: /Applications/Xcode13.1.app/Contents/Developer
     extra_flags: -DCMAKE_SYSTEM_NAME=Darwin -DCMAKE_OSX_ARCHITECTURES=x86_64
     run_with_encryption: On
   tasks:
@@ -833,7 +833,7 @@ buildvariants:
     max_jobs: $(sysctl -n hw.logicalcpu)
     run_tests_against_baas: On
     cmake_build_type: Release
-    xcode_developer_dir: /Applications/Xcode12.4.app/Contents/Developer
+    xcode_developer_dir: /Applications/Xcode13.1.app/Contents/Developer
     extra_flags: -DCMAKE_SYSTEM_NAME=Darwin -DCMAKE_OSX_ARCHITECTURES=x86_64
   tasks:
   - name: compile_test_and_package
@@ -851,7 +851,7 @@ buildvariants:
     cmake_generator: Xcode
     max_jobs: $(sysctl -n hw.logicalcpu)
     run_tests_against_baas: On
-    xcode_developer_dir: /Applications/Xcode12.4.app/Contents/Developer
+    xcode_developer_dir: /Applications/Xcode13.1.app/Contents/Developer
     extra_flags: -DCMAKE_SYSTEM_NAME=Darwin -DCMAKE_OSX_ARCHITECTURES=arm64
   tasks:
   - name: compile_test
@@ -870,7 +870,7 @@ buildvariants:
     max_jobs: $(sysctl -n hw.logicalcpu)
     cmake_build_type: Release
     run_tests_against_baas: On
-    xcode_developer_dir: /Applications/Xcode12.4.app/Contents/Developer
+    xcode_developer_dir: /Applications/Xcode13.1.app/Contents/Developer
     extra_flags: -DCMAKE_SYSTEM_NAME=Darwin -DCMAKE_OSX_ARCHITECTURES=arm64
   tasks:
   - name: compile_test_and_package


### PR DESCRIPTION
## What, How & Why?
This just bumps the version of Xcode we build with on MacOS builders in evergreen from 12.4 to 13.1.

## ☑️ ToDos
* [x] 📝 Changelog update
* [ ] 🚦 Tests (or not relevant)
* [ ] C-API, if public C++ API changed.
