### PR TITLE
[C API] remove unused argument

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 
 ### Fixed
 * Added better comparator for `realm_user_t` and `realm_flx_sync_subscription_t` when using `realm_equals`.(Issue [#5522])(https://github.com/realm/realm-core/issues/5522).
+* Removed scheduler argument to the C API `realm_*_add_notification_callback` functions, because it wasn't actually used. (PR [#????](https://github.com/realm/realm-core/pull/????)).
 
 ### Breaking changes
 * None.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@
 
 ### Fixed
 * Added better comparator for `realm_user_t` and `realm_flx_sync_subscription_t` when using `realm_equals`.(Issue [#5522])(https://github.com/realm/realm-core/issues/5522).
-* Removed scheduler argument to the C API `realm_*_add_notification_callback` functions, because it wasn't actually used. (PR [#????](https://github.com/realm/realm-core/pull/????)).
+* Removed scheduler argument to the C API `realm_*_add_notification_callback` functions, because it wasn't actually used. (PR [#5541](https://github.com/realm/realm-core/pull/5541)).
 
 ### Breaking changes
 * None.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,10 +6,9 @@
 
 ### Fixed
 * Added better comparator for `realm_user_t` and `realm_flx_sync_subscription_t` when using `realm_equals`.(Issue [#5522])(https://github.com/realm/realm-core/issues/5522).
-* Removed scheduler argument to the C API `realm_*_add_notification_callback` functions, because it wasn't actually used. (PR [#5541](https://github.com/realm/realm-core/pull/5541)).
 
 ### Breaking changes
-* None.
+* Removed scheduler argument to the C API `realm_*_add_notification_callback` functions, because it wasn't actually used. (PR [#5541](https://github.com/realm/realm-core/pull/5541)).
 
 ### Compatibility
 * Fileformat: Generates files with format v22. Reads and automatically upgrade from fileformat v5.

--- a/src/realm.h
+++ b/src/realm.h
@@ -826,8 +826,8 @@ realm_scheduler_new(realm_userdata_t userdata, realm_free_userdata_func_t userda
  * Performs all of the pending work for the given scheduler.
  *
  * This function must be called from within the scheduler's event loop. It must
- * be called after each time that the notify function passed to the scheduler
- * is involved.
+ * be called each time the notify callback passed to the scheduler
+ * is invoked.
  */
 RLM_API void realm_scheduler_perform_work(realm_scheduler_t*);
 /**
@@ -1446,9 +1446,11 @@ RLM_API realm_link_t realm_object_as_link(const realm_object_t* object);
  *
  * @return A non-null pointer if no exception occurred.
  */
-RLM_API realm_notification_token_t* realm_object_add_notification_callback(
-    realm_object_t*, realm_userdata_t userdata, realm_free_userdata_func_t userdata_free, realm_key_path_array_t*,
-    realm_on_object_change_func_t on_change, realm_callback_error_func_t on_error, realm_scheduler_t*);
+RLM_API realm_notification_token_t* realm_object_add_notification_callback(realm_object_t*, realm_userdata_t userdata,
+                                                                           realm_free_userdata_func_t userdata_free,
+                                                                           realm_key_path_array_t*,
+                                                                           realm_on_object_change_func_t on_change,
+                                                                           realm_callback_error_func_t on_error);
 
 /**
  * Get an object from a thread-safe reference, potentially originating in a
@@ -1696,9 +1698,11 @@ RLM_API bool realm_list_assign(realm_list_t*, const realm_value_t* values, size_
  *
  * @return A non-null pointer if no exception occurred.
  */
-RLM_API realm_notification_token_t* realm_list_add_notification_callback(
-    realm_list_t*, realm_userdata_t userdata, realm_free_userdata_func_t userdata_free, realm_key_path_array_t*,
-    realm_on_collection_change_func_t on_change, realm_callback_error_func_t on_error, realm_scheduler_t*);
+RLM_API realm_notification_token_t* realm_list_add_notification_callback(realm_list_t*, realm_userdata_t userdata,
+                                                                         realm_free_userdata_func_t userdata_free,
+                                                                         realm_key_path_array_t*,
+                                                                         realm_on_collection_change_func_t on_change,
+                                                                         realm_callback_error_func_t on_error);
 
 /**
  * Get an list from a thread-safe reference, potentially originating in a
@@ -1971,10 +1975,11 @@ RLM_API bool realm_set_assign(realm_set_t*, const realm_value_t* values, size_t 
  *
  * @return A non-null pointer if no exception occurred.
  */
-RLM_API realm_notification_token_t*
-realm_set_add_notification_callback(realm_set_t*, realm_userdata_t userdata, realm_free_userdata_func_t userdata_free,
-                                    realm_key_path_array_t*, realm_on_collection_change_func_t on_change,
-                                    realm_callback_error_func_t on_error, realm_scheduler_t*);
+RLM_API realm_notification_token_t* realm_set_add_notification_callback(realm_set_t*, realm_userdata_t userdata,
+                                                                        realm_free_userdata_func_t userdata_free,
+                                                                        realm_key_path_array_t*,
+                                                                        realm_on_collection_change_func_t on_change,
+                                                                        realm_callback_error_func_t on_error);
 /**
  * Get an set from a thread-safe reference, potentially originating in a
  * different `realm_t` instance
@@ -2141,7 +2146,7 @@ RLM_API bool realm_dictionary_assign(realm_dictionary_t*, size_t num_pairs, cons
  */
 RLM_API realm_notification_token_t* realm_dictionary_add_notification_callback(
     realm_dictionary_t*, realm_userdata_t userdata, realm_free_userdata_func_t userdata_free, realm_key_path_array_t*,
-    realm_on_collection_change_func_t on_change, realm_callback_error_func_t on_error, realm_scheduler_t*);
+    realm_on_collection_change_func_t on_change, realm_callback_error_func_t on_error);
 
 /**
  * Get an dictionary from a thread-safe reference, potentially originating in a
@@ -2410,9 +2415,10 @@ RLM_API bool realm_results_sum(realm_results_t*, realm_property_key_t, realm_val
 RLM_API bool realm_results_average(realm_results_t*, realm_property_key_t, realm_value_t* out_average,
                                    bool* out_found);
 
-RLM_API realm_notification_token_t* realm_results_add_notification_callback(
-    realm_results_t*, realm_userdata_t userdata, realm_free_userdata_func_t userdata_free, realm_key_path_array_t*,
-    realm_on_collection_change_func_t, realm_callback_error_func_t, realm_scheduler_t*);
+RLM_API realm_notification_token_t*
+realm_results_add_notification_callback(realm_results_t*, realm_userdata_t userdata,
+                                        realm_free_userdata_func_t userdata_free, realm_key_path_array_t*,
+                                        realm_on_collection_change_func_t, realm_callback_error_func_t);
 
 /**
  * Get an results object from a thread-safe reference, potentially originating

--- a/src/realm/object-store/c_api/notifications.cpp
+++ b/src/realm/object-store/c_api/notifications.cpp
@@ -89,8 +89,7 @@ KeyPathArray build_key_path_array(realm_key_path_array_t* key_path_array)
 RLM_API realm_notification_token_t*
 realm_object_add_notification_callback(realm_object_t* obj, realm_userdata_t userdata,
                                        realm_free_userdata_func_t free, realm_key_path_array_t* key_path_array,
-                                       realm_on_object_change_func_t on_change, realm_callback_error_func_t on_error,
-                                       realm_scheduler_t*)
+                                       realm_on_object_change_func_t on_change, realm_callback_error_func_t on_error)
 {
     return wrap_err([&]() {
         ObjectNotificationsCallback cb;
@@ -129,11 +128,12 @@ RLM_API size_t realm_object_changes_get_modified_properties(const realm_object_c
     return i;
 }
 
-RLM_API realm_notification_token_t*
-realm_list_add_notification_callback(realm_list_t* list, realm_userdata_t userdata, realm_free_userdata_func_t free,
-                                     realm_key_path_array_t* key_path_array,
-                                     realm_on_collection_change_func_t on_change,
-                                     realm_callback_error_func_t on_error, realm_scheduler_t*)
+RLM_API realm_notification_token_t* realm_list_add_notification_callback(realm_list_t* list,
+                                                                         realm_userdata_t userdata,
+                                                                         realm_free_userdata_func_t free,
+                                                                         realm_key_path_array_t* key_path_array,
+                                                                         realm_on_collection_change_func_t on_change,
+                                                                         realm_callback_error_func_t on_error)
 {
     return wrap_err([&]() {
         CollectionNotificationsCallback cb;
@@ -149,8 +149,7 @@ RLM_API realm_notification_token_t* realm_set_add_notification_callback(realm_se
                                                                         realm_free_userdata_func_t free,
                                                                         realm_key_path_array_t* key_path_array,
                                                                         realm_on_collection_change_func_t on_change,
-                                                                        realm_callback_error_func_t on_error,
-                                                                        realm_scheduler_t*)
+                                                                        realm_callback_error_func_t on_error)
 {
     return wrap_err([&]() {
         CollectionNotificationsCallback cb;
@@ -166,7 +165,7 @@ RLM_API realm_notification_token_t*
 realm_dictionary_add_notification_callback(realm_dictionary_t* dict, realm_userdata_t userdata,
                                            realm_free_userdata_func_t free, realm_key_path_array_t* key_path_array,
                                            realm_on_collection_change_func_t on_change,
-                                           realm_callback_error_func_t on_error, realm_scheduler_t*)
+                                           realm_callback_error_func_t on_error)
 {
     return wrap_err([&]() {
         CollectionNotificationsCallback cb;
@@ -182,7 +181,7 @@ RLM_API realm_notification_token_t*
 realm_results_add_notification_callback(realm_results_t* results, realm_userdata_t userdata,
                                         realm_free_userdata_func_t free, realm_key_path_array_t* key_path_array,
                                         realm_on_collection_change_func_t on_change,
-                                        realm_callback_error_func_t on_error, realm_scheduler_t*)
+                                        realm_callback_error_func_t on_error)
 {
     return wrap_err([&]() {
         CollectionNotificationsCallback cb;

--- a/test/object-store/c_api/c_api.cpp
+++ b/test/object-store/c_api/c_api.cpp
@@ -2468,8 +2468,8 @@ TEST_CASE("C API", "[c_api]") {
                 auto null = rlm_null();
 
                 auto require_change = [&]() {
-                    auto token = cptr_checked(realm_list_add_notification_callback(
-                        strings.get(), &state, nullptr, nullptr, on_change, on_error, nullptr));
+                    auto token = cptr_checked(realm_list_add_notification_callback(strings.get(), &state, nullptr,
+                                                                                   nullptr, on_change, on_error));
                     checked(realm_refresh(realm));
                     return token;
                 };
@@ -2480,7 +2480,7 @@ TEST_CASE("C API", "[c_api]") {
                         [](void* p) {
                             static_cast<State*>(p)->destroyed = true;
                         },
-                        nullptr, nullptr, nullptr, nullptr));
+                        nullptr, nullptr, nullptr));
                     CHECK(!state.destroyed);
                     token.reset();
                     CHECK(state.destroyed);
@@ -2526,7 +2526,7 @@ TEST_CASE("C API", "[c_api]") {
                     realm_key_path_t key_path_bar_strings[] = {{1, bar_strings}};
                     realm_key_path_array_t key_path_array = {1, key_path_bar_strings};
                     auto token = cptr_checked(realm_list_add_notification_callback(
-                        bars.get(), &state, nullptr, &key_path_array, on_change, on_error, nullptr));
+                        bars.get(), &state, nullptr, &key_path_array, on_change, on_error));
                     checked(realm_refresh(realm));
 
                     state.called = false;
@@ -2976,8 +2976,8 @@ TEST_CASE("C API", "[c_api]") {
                 auto null = rlm_null();
 
                 auto require_change = [&]() {
-                    auto token = cptr_checked(realm_set_add_notification_callback(
-                        strings.get(), &state, nullptr, nullptr, on_change, on_error, nullptr));
+                    auto token = cptr_checked(realm_set_add_notification_callback(strings.get(), &state, nullptr,
+                                                                                  nullptr, on_change, on_error));
                     checked(realm_refresh(realm));
                     return token;
                 };
@@ -2988,7 +2988,7 @@ TEST_CASE("C API", "[c_api]") {
                         [](void* p) {
                             static_cast<State*>(p)->destroyed = true;
                         },
-                        nullptr, nullptr, nullptr, nullptr));
+                        nullptr, nullptr, nullptr));
                     CHECK(!state.destroyed);
                     token.reset();
                     CHECK(state.destroyed);
@@ -3499,7 +3499,7 @@ TEST_CASE("C API", "[c_api]") {
 
                 auto require_change = [&]() {
                     auto token = cptr_checked(realm_dictionary_add_notification_callback(
-                        strings.get(), &state, nullptr, nullptr, on_change, on_error, nullptr));
+                        strings.get(), &state, nullptr, nullptr, on_change, on_error));
                     checked(realm_refresh(realm));
                     return token;
                 };
@@ -3510,7 +3510,7 @@ TEST_CASE("C API", "[c_api]") {
                         [](void* p) {
                             static_cast<State*>(p)->destroyed = true;
                         },
-                        nullptr, nullptr, nullptr, nullptr));
+                        nullptr, nullptr, nullptr));
                     CHECK(!state.destroyed);
                     token.reset();
                     CHECK(state.destroyed);
@@ -3571,7 +3571,7 @@ TEST_CASE("C API", "[c_api]") {
 
             auto require_change = [&]() {
                 auto token = cptr(realm_object_add_notification_callback(obj1.get(), &state, nullptr, nullptr,
-                                                                         on_change, on_error, nullptr));
+                                                                         on_change, on_error));
                 checked(realm_refresh(realm));
                 return token;
             };
@@ -3616,7 +3616,7 @@ TEST_CASE("C API", "[c_api]") {
                 realm_key_path_t key_path_origin_value[] = {{1, origin_value}};
                 realm_key_path_array_t key_path_array = {1, key_path_origin_value};
                 auto token = cptr(realm_object_add_notification_callback(obj1.get(), &state, nullptr, &key_path_array,
-                                                                         on_change, on_error, nullptr));
+                                                                         on_change, on_error));
                 checked(realm_refresh(realm));
                 state.called = false;
                 write([&]() {


### PR DESCRIPTION
## What, How & Why?
Remove the scheduler argument to the C API `realm_*_add_notification_callback` functions, because it wasn't actually used.

## ☑️ ToDos
* [x] 📝 Changelog update
* [x] 🚦 Tests (or not relevant)
* [x] C-API, if public C++ API changed.
