### PR TITLE
[C API] Merge identical typedefs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 
 ### Breaking changes
 * Removed scheduler argument to the C API `realm_*_add_notification_callback` functions, because it wasn't actually used. (PR [#5541](https://github.com/realm/realm-core/pull/5541)).
+* Merged the `realm_sync_upload_completion_func_t` and the `realm_sync_download_completion_func_t` typedefs in the C API because they were identical. The new typedef is `realm_sync_wait_for_completion_func_t`. (PR [#5548](https://github.com/realm/realm-core/pull/5548))
 
 ### Compatibility
 * Fileformat: Generates files with format v22. Reads and automatically upgrade from fileformat v5.

--- a/src/realm.h
+++ b/src/realm.h
@@ -3298,8 +3298,16 @@ typedef struct realm_sync_error {
     size_t user_info_length;
 } realm_sync_error_t;
 
-typedef void (*realm_sync_upload_completion_func_t)(realm_userdata_t userdata, realm_sync_error_code_t*);
-typedef void (*realm_sync_download_completion_func_t)(realm_userdata_t userdata, realm_sync_error_code_t*);
+/**
+ * Callback function invoked by the sync session once it has uploaded or download
+ * all available changesets. See @a realm_sync_session_wait_for_upload and
+ * @a realm_sync_session_wait_for_download.
+ *
+ * This callback is invoked on the sync client's worker thread.
+ *
+ * @param error Null, if the operation completed successfully.
+ */
+typedef void (*realm_sync_wait_for_completion_func_t)(realm_userdata_t userdata, realm_sync_error_code_t* error);
 typedef void (*realm_sync_connection_state_changed_func_t)(realm_userdata_t userdata,
                                                            realm_sync_connection_state_e old_state,
                                                            realm_sync_connection_state_e new_state);
@@ -3724,14 +3732,15 @@ RLM_API void realm_sync_session_unregister_progress_notifier(realm_sync_session_
  * Register a callback that will be invoked when all pending downloads have completed.
  */
 RLM_API void
-realm_sync_session_wait_for_download_completion(realm_sync_session_t*, realm_sync_download_completion_func_t,
+realm_sync_session_wait_for_download_completion(realm_sync_session_t*, realm_sync_wait_for_completion_func_t,
                                                 realm_userdata_t userdata,
                                                 realm_free_userdata_func_t userdata_free) RLM_API_NOEXCEPT;
 
 /**
  * Register a callback that will be invoked when all pending uploads have completed.
  */
-RLM_API void realm_sync_session_wait_for_upload_completion(realm_sync_session_t*, realm_sync_upload_completion_func_t,
+RLM_API void realm_sync_session_wait_for_upload_completion(realm_sync_session_t*,
+                                                           realm_sync_wait_for_completion_func_t,
                                                            realm_userdata_t userdata,
                                                            realm_free_userdata_func_t userdata_free) RLM_API_NOEXCEPT;
 

--- a/src/realm/object-store/c_api/sync.cpp
+++ b/src/realm/object-store/c_api/sync.cpp
@@ -910,7 +910,7 @@ RLM_API void realm_sync_session_unregister_progress_notifier(realm_sync_session_
 }
 
 RLM_API void realm_sync_session_wait_for_download_completion(realm_sync_session_t* session,
-                                                             realm_sync_download_completion_func_t done,
+                                                             realm_sync_wait_for_completion_func_t done,
                                                              realm_userdata_t userdata,
                                                              realm_free_userdata_func_t userdata_free) noexcept
 {
@@ -929,7 +929,7 @@ RLM_API void realm_sync_session_wait_for_download_completion(realm_sync_session_
 }
 
 RLM_API void realm_sync_session_wait_for_upload_completion(realm_sync_session_t* session,
-                                                           realm_sync_upload_completion_func_t done,
+                                                           realm_sync_wait_for_completion_func_t done,
                                                            realm_userdata_t userdata,
                                                            realm_free_userdata_func_t userdata_free) noexcept
 {


### PR DESCRIPTION
## What, How & Why?
Merged the `realm_sync_upload_completion_func_t` and the `realm_sync_download_completion_func_t` typedefs in the C API because they were identical.

## ☑️ ToDos
* [x] 📝 Changelog update
* [x] 🚦 Tests (or not relevant)
* [x] C-API, if public C++ API changed.
