### PR TITLE
Supply symbolizer for ASAN builds on Ubuntu

### DIFF
--- a/evergreen/config.yml
+++ b/evergreen/config.yml
@@ -183,6 +183,10 @@ functions:
 
           TEST_FLAGS="--no-tests=error $TEST_FLAGS ${test_flags|}"
 
+          if [[ -n "${llvm_symbolizer}" ]]; then
+              export ASAN_SYMBOLIZER_PATH="$(./evergreen/abspath.sh ${llvm_symbolizer})"
+          fi
+
           export UNITTEST_EVERGREEN_TEST_RESULTS="$(./evergreen/abspath.sh ${task_name}_results.json)"
           export UNITTEST_PROGRESS=1
           if [[ -n "${report_test_progress|}" ]]; then
@@ -530,6 +534,8 @@ tasks:
   exec_timeout_secs: 2100
   commands:
   - func: "compile"
+    vars:
+      target_to_build: "ObjectStoreTests"
   # If we need to start a local copy of baas, do it in the background here in a separate script.
   # Evergreen should take care of the lifetime of the processes we start here automatically.
   - command: shell.exec
@@ -742,6 +748,7 @@ buildvariants:
     run_tests_against_baas: On
     c_compiler: "./clang_binaries/bin/clang"
     cxx_compiler: "./clang_binaries/bin/clang++"
+    llvm_symbolizer: "./clang_binaries/bin/llvm-symbolizer"
     run_with_encryption: On
     enable_asan: On
   tasks:
@@ -785,6 +792,7 @@ buildvariants:
     enable_asan: On
     c_compiler: "./clang_binaries/bin/clang"
     cxx_compiler: "./clang_binaries/bin/clang++"
+    llvm_symbolizer: "./clang_binaries/bin/llvm-symbolizer"
   tasks:
   - name: compile_test
     distros:


### PR DESCRIPTION
## What, How & Why?
I've noticed that the evergreen ASAN builds do not have symbolized stacktraces - which is deeply unhelpful for using them to actually diagnose what went wrong. This just passes the correct path to the llvm-symbolizer to ASAN on ubuntu so that we get nice stacktraces. It also makes it so that if you run just the object-store tests in an evergreen patch build, only the object store tests will be compiled.

## ☑️ ToDos
* [ ] 📝 Changelog update
~* [ ] 🚦 Tests (or not relevant)~
~* [ ] C-API, if public C++ API changed.~
