### PR TITLE
FLX client reset with recovery

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ### Enhancements
 * Allow flexible sync with discard local client resets. ([#5404](https://github.com/realm/realm-core/pull/5404))
+* Allow flexible sync with recovery client resets. ([#5562](https://github.com/realm/realm-core/issues/5562))
 
 ### Fixed
 * <How do the end-user experience this issue? what was the impact?> ([#????](https://github.com/realm/realm-core/issues/????), since v?.?.?)

--- a/src/realm/object-store/impl/realm_coordinator.cpp
+++ b/src/realm/object-store/impl/realm_coordinator.cpp
@@ -151,14 +151,6 @@ void RealmCoordinator::set_config(const Realm::Config& config)
         if (config.sync_config->flx_sync_requested && !config.sync_config->partition_value.empty()) {
             throw std::logic_error("Cannot specify a partition value when flexible sync is enabled");
         }
-        // TODO(RCORE-912) we definitely do want to support this, but until its implemented we should prevent users
-        // from using something that is currently broken.
-        if (config.sync_config->flx_sync_requested &&
-            (config.sync_config->client_resync_mode != ClientResyncMode::Manual &&
-             config.sync_config->client_resync_mode != ClientResyncMode::DiscardLocal)) {
-            throw std::logic_error(
-                "Only manual or 'discard local' client resets are supported with flexible sync at this time");
-        }
     }
 #endif
 

--- a/src/realm/sync/client.cpp
+++ b/src/realm/sync/client.cpp
@@ -969,7 +969,6 @@ void SessionWrapper::on_flx_sync_progress(int64_t new_version, DownloadBatchStat
             if (m_flx_active_version == new_version) {
                 return;
             }
-
             on_flx_sync_version_complete(new_version);
             new_state = SubscriptionSet::State::Complete;
             break;

--- a/src/realm/sync/noinst/client_history_impl.cpp
+++ b/src/realm/sync/noinst/client_history_impl.cpp
@@ -90,10 +90,10 @@ void ClientHistory::set_client_reset_adjustments(version_type current_version, S
     m_client_reset_changeset = uploadable_changeset; // Picked up by prepare_changeset()
 }
 
-std::vector<ChunkedBinaryData> ClientHistory::get_local_changes(version_type current_version) const
+std::vector<ClientHistory::LocalChange> ClientHistory::get_local_changes(version_type current_version) const
 {
     ensure_updated(current_version); // Throws
-    std::vector<ChunkedBinaryData> changesets;
+    std::vector<ClientHistory::LocalChange> changesets;
     if (!m_arrays || m_arrays->changesets.is_empty())
         return changesets;
 
@@ -115,7 +115,7 @@ std::vector<ChunkedBinaryData> ClientHistory::get_local_changes(version_type cur
         std::int_fast64_t origin_file_ident = m_arrays->origin_file_idents.get(ndx);
         bool not_from_server = (origin_file_ident == 0);
         if (not_from_server) {
-            changesets.push_back(m_arrays->changesets.get(ndx));
+            changesets.push_back({version, m_arrays->changesets.get(ndx)});
         }
     }
     return changesets;

--- a/src/realm/sync/noinst/client_history_impl.hpp
+++ b/src/realm/sync/noinst/client_history_impl.hpp
@@ -113,11 +113,15 @@ public:
     void set_client_reset_adjustments(version_type current_version, SaltedFileIdent client_file_ident,
                                       SaltedVersion server_version, BinaryData uploadable_changeset);
 
+    struct LocalChange {
+        version_type version;
+        ChunkedBinaryData changeset;
+    };
     /// get_local_changes returns a list of changes which have not been uploaded yet
     /// 'current_version' is the version that the history should be updated to.
     ///
     /// The history must be in a transaction when this function is called.
-    std::vector<ChunkedBinaryData> get_local_changes(version_type current_version) const;
+    std::vector<LocalChange> get_local_changes(version_type current_version) const;
 
     /// Get the version of the latest snapshot of the associated Realm, as well
     /// as the client file identifier and the synchronization progress as they

--- a/src/realm/sync/noinst/client_reset.cpp
+++ b/src/realm/sync/noinst/client_reset.cpp
@@ -1038,7 +1038,6 @@ LocalVersionIDs perform_client_reset_diff(DBRef db_local, DBRef db_remote, sync:
     }
     else {
         if (recover_local_changes) {
-            REALM_ASSERT(!sub_store);
             // In PBS recovery, the strategy is to apply all local changes to the remote realm first,
             // and then transfer the modified state all at once to the local Realm. This creates a
             // nice side effect for notifications because only the minimal state change is made.

--- a/src/realm/sync/noinst/client_reset_recovery.cpp
+++ b/src/realm/sync/noinst/client_reset_recovery.cpp
@@ -25,6 +25,7 @@
 #include <realm/sync/noinst/client_history_impl.hpp>
 #include <realm/sync/noinst/client_reset.hpp>
 #include <realm/sync/noinst/client_reset_recovery.hpp>
+#include <realm/sync/subscriptions.hpp>
 
 #include <realm/util/compression.hpp>
 
@@ -358,11 +359,11 @@ std::string ListPath::path_to_string(Transaction& remote, const InterningBuffer&
     return path;
 }
 
-RecoverLocalChangesetsHandler::RecoverLocalChangesetsHandler(Transaction& remote_wt, Transaction& local_wt,
+RecoverLocalChangesetsHandler::RecoverLocalChangesetsHandler(Transaction& dest_wt,
+                                                             Transaction& frozen_pre_local_state,
                                                              util::Logger& logger)
-    : InstructionApplier(remote_wt)
-    , m_remote{remote_wt}
-    , m_local{local_wt}
+    : InstructionApplier(dest_wt)
+    , m_frozen_pre_local_state{frozen_pre_local_state}
     , m_logger{logger}
 {
 }
@@ -377,17 +378,47 @@ REALM_NORETURN void RecoverLocalChangesetsHandler::handle_error(const std::strin
     throw realm::_impl::client_reset::ClientResetFailed(full_message);
 }
 
-void RecoverLocalChangesetsHandler::process_changesets(const std::vector<ChunkedBinaryData>& changesets)
+void RecoverLocalChangesetsHandler::process_changesets(const std::vector<ClientHistory::LocalChange>& changesets,
+                                                       std::vector<sync::SubscriptionSet>&& pending_subscriptions)
 {
-    for (const ChunkedBinaryData& chunked_changeset : changesets) {
-        if (chunked_changeset.size() == 0)
+    // When recovering in PBS, we can iterate through all the changes and apply them in a single commit.
+    // This has the nice property that any exception while applying will revert the entire recovery and leave
+    // the Realm in a "pre reset" state.
+    //
+    // When recovering in FLX mode, we must apply subscription sets interleaved between the correct commits.
+    // This handles the case where some objects were subscribed to for only one commit and then unsubscribed after.
+
+    size_t subscription_index = 0;
+    auto write_pending_subscriptions_up_to = [&](version_type version) {
+        while (subscription_index < pending_subscriptions.size() &&
+               pending_subscriptions[subscription_index].snapshot_version() <= version) {
+            if (m_transaction.get_transact_stage() == DB::TransactStage::transact_Writing) {
+                // List modifications may have happened on an object which we are only subscribed to
+                // for this commit so we need to apply them as we go.
+                copy_lists_with_unrecoverable_changes();
+                m_transaction.commit_and_continue_as_read();
+            }
+            auto pre_sub = pending_subscriptions[subscription_index++];
+            auto post_sub = pre_sub.make_mutable_copy().commit();
+            m_logger.info("Recovering pending subscription version: %1 -> %2, snapshot: %3 -> %4", pre_sub.version(),
+                          post_sub.version(), pre_sub.snapshot_version(), post_sub.snapshot_version());
+        }
+        if (m_transaction.get_transact_stage() != DB::TransactStage::transact_Writing) {
+            m_transaction.promote_to_write();
+        }
+    };
+
+    for (const ClientHistory::LocalChange& change : changesets) {
+        if (change.changeset.size() == 0)
             continue;
 
-        ChunkedBinaryInputStream in{chunked_changeset};
+        ChunkedBinaryInputStream in{change.changeset};
         size_t decompressed_size;
         auto decompressed = util::compression::decompress_nonportable_input_stream(in, decompressed_size);
         if (!decompressed)
             continue;
+
+        write_pending_subscriptions_up_to(change.version);
 
         sync::Changeset parsed_changeset;
         sync::parse_changeset(*decompressed, parsed_changeset); // Throws
@@ -400,6 +431,10 @@ void RecoverLocalChangesetsHandler::process_changesets(const std::vector<Chunked
         }
         InstructionApplier::end_apply();
     }
+
+    // write any remaining subscriptions
+    write_pending_subscriptions_up_to(std::numeric_limits<version_type>::max());
+    REALM_ASSERT_EX(subscription_index == pending_subscriptions.size(), subscription_index);
 
     copy_lists_with_unrecoverable_changes();
 }
@@ -425,7 +460,7 @@ void RecoverLocalChangesetsHandler::copy_lists_with_unrecoverable_changes()
         if (!it.second.requires_manual_copy())
             continue;
 
-        std::string path_str = it.first.path_to_string(m_remote, m_intern_keys);
+        std::string path_str = it.first.path_to_string(m_transaction, m_intern_keys);
         bool did_translate = resolve(it.first, [&](LstBase& remote_list, LstBase& local_list) {
             ConstTableRef local_table = local_list.get_table();
             ConstTableRef remote_table = remote_list.get_table();
@@ -448,6 +483,7 @@ void RecoverLocalChangesetsHandler::copy_lists_with_unrecoverable_changes()
         }
     }
     embedded_object_tracker->process_pending();
+    m_lists.clear();
 }
 
 bool RecoverLocalChangesetsHandler::resolve_path(ListPath& path, Obj remote_obj, Obj local_obj,
@@ -507,11 +543,11 @@ bool RecoverLocalChangesetsHandler::resolve_path(ListPath& path, Obj remote_obj,
 
 bool RecoverLocalChangesetsHandler::resolve(ListPath& path, util::UniqueFunction<void(LstBase&, LstBase&)> callback)
 {
-    auto remote_table = m_remote.get_table(path.table_key());
+    auto remote_table = m_transaction.get_table(path.table_key());
     if (!remote_table)
         return false;
 
-    auto local_table = m_local.get_table(remote_table->get_name());
+    auto local_table = m_frozen_pre_local_state.get_table(remote_table->get_name());
     if (!local_table)
         return false;
 

--- a/src/realm/sync/subscriptions.cpp
+++ b/src/realm/sync/subscriptions.cpp
@@ -717,7 +717,7 @@ std::vector<SubscriptionSet> SubscriptionStore::get_pending_subscriptions() cons
     auto active_sub = get_active();
     auto cur_query_version = active_sub.version();
     DB::version_type db_version = 0;
-    if (active_sub.state() != SubscriptionSet::State::Pending) {
+    if (active_sub.state() == SubscriptionSet::State::Complete) {
         db_version = active_sub.snapshot_version();
     }
     REALM_ASSERT_EX(db_version != DB::version_type(-1), active_sub.state());

--- a/src/realm/sync/subscriptions.cpp
+++ b/src/realm/sync/subscriptions.cpp
@@ -162,6 +162,11 @@ int64_t SubscriptionSet::version() const
     return m_version;
 }
 
+DB::version_type SubscriptionSet::snapshot_version() const
+{
+    return m_snapshot_version;
+}
+
 SubscriptionSet::State SubscriptionSet::state() const
 {
     return m_state;
@@ -704,6 +709,25 @@ SubscriptionStore::get_next_pending_version(int64_t last_query_version, DB::vers
     auto query_version = obj.get_primary_key().get_int();
     auto snapshot_version = obj.get<int64_t>(m_sub_set_snapshot_version);
     return PendingSubscription{query_version, static_cast<DB::version_type>(snapshot_version)};
+}
+
+std::vector<SubscriptionSet> SubscriptionStore::get_pending_subscriptions() const
+{
+    std::vector<SubscriptionSet> subscriptions_to_recover;
+    auto active_sub = get_active();
+    auto cur_query_version = active_sub.version();
+    DB::version_type db_version = 0;
+    if (active_sub.state() != SubscriptionSet::State::Pending) {
+        db_version = active_sub.snapshot_version();
+    }
+    REALM_ASSERT_EX(db_version != DB::version_type(-1), active_sub.state());
+    // get a copy of the pending subscription sets since the active version
+    while (auto next_pending = get_next_pending_version(cur_query_version, db_version)) {
+        cur_query_version = next_pending->query_version;
+        db_version = next_pending->snapshot_version;
+        subscriptions_to_recover.push_back(get_by_version(cur_query_version));
+    }
+    return subscriptions_to_recover;
 }
 
 MutableSubscriptionSet SubscriptionStore::get_mutable_by_version(int64_t version_id)

--- a/src/realm/sync/subscriptions.hpp
+++ b/src/realm/sync/subscriptions.hpp
@@ -208,7 +208,7 @@ protected:
     int64_t m_version = 0;
     State m_state = State::Uncommitted;
     std::string m_error_str;
-    DB::version_type m_snapshot_version = std::numeric_limits<DB::version_type>::max();
+    DB::version_type m_snapshot_version = -1;
     std::vector<Subscription> m_subs;
 };
 

--- a/src/realm/sync/subscriptions.hpp
+++ b/src/realm/sync/subscriptions.hpp
@@ -159,6 +159,9 @@ public:
     // The query version number used in the sync wire protocol to identify this subscription set to the server.
     int64_t version() const;
 
+    // The database version that this subscription set was created at or -1 if Uncommitted.
+    DB::version_type snapshot_version() const;
+
     // The current state of this subscription set
     State state() const;
 
@@ -205,7 +208,7 @@ protected:
     int64_t m_version = 0;
     State m_state = State::Uncommitted;
     std::string m_error_str;
-    DB::version_type m_snapshot_version;
+    DB::version_type m_snapshot_version = std::numeric_limits<DB::version_type>::max();
     std::vector<Subscription> m_subs;
 };
 
@@ -335,6 +338,7 @@ public:
 
     util::Optional<PendingSubscription> get_next_pending_version(int64_t last_query_version,
                                                                  DB::version_type after_client_version) const;
+    std::vector<SubscriptionSet> get_pending_subscriptions() const;
 
 private:
     using std::enable_shared_from_this<SubscriptionStore>::weak_from_this;

--- a/test/object-store/sync/flx_sync.cpp
+++ b/test/object-store/sync/flx_sync.cpp
@@ -423,7 +423,6 @@ TEST_CASE("flx: client reset", "[sync][flx][app][client reset]") {
                 local_realm->refresh();
                 auto latest_subs = local_realm->get_latest_subscription_set();
                 latest_subs.get_state_change_notification(sync::SubscriptionSet::State::Complete).get();
-                REQUIRE(latest_subs.state() == sync::SubscriptionSet::State::Complete);
                 auto table = local_realm->read_group().get_table("class_TopLevel");
                 REQUIRE(table->size() == 1);
                 auto mut_sub = latest_subs.make_mutable_copy();

--- a/test/object-store/sync/flx_sync.cpp
+++ b/test/object-store/sync/flx_sync.cpp
@@ -422,8 +422,13 @@ TEST_CASE("flx: client reset", "[sync][flx][app][client reset]") {
                 REQUIRE(mode == ClientResyncMode::Recover);
                 local_realm->refresh();
                 auto latest_subs = local_realm->get_latest_subscription_set();
-                latest_subs.get_state_change_notification(sync::SubscriptionSet::State::Complete).get();
+                auto state = latest_subs.get_state_change_notification(sync::SubscriptionSet::State::Complete).get();
+                REQUIRE(state == sync::SubscriptionSet::State::Complete);
+                local_realm->refresh();
                 auto table = local_realm->read_group().get_table("class_TopLevel");
+                if (table->size() != 1) {
+                    table->to_json(std::cout, 1, {});
+                }
                 REQUIRE(table->size() == 1);
                 auto mut_sub = latest_subs.make_mutable_copy();
                 mut_sub.clear();

--- a/test/object-store/sync/flx_sync_harness.hpp
+++ b/test/object-store/sync/flx_sync_harness.hpp
@@ -39,12 +39,10 @@ public:
     {
         Schema schema{
             {"TopLevel",
-             {
-                 {"_id", PropertyType::ObjectId, Property::IsPrimary{true}},
-                 {"queryable_str_field", PropertyType::String | PropertyType::Nullable},
-                 {"queryable_int_field", PropertyType::Int | PropertyType::Nullable},
-                 {"non_queryable_field", PropertyType::String | PropertyType::Nullable},
-             }},
+             {{"_id", PropertyType::ObjectId, Property::IsPrimary{true}},
+              {"queryable_str_field", PropertyType::String | PropertyType::Nullable},
+              {"queryable_int_field", PropertyType::Int | PropertyType::Nullable},
+              {"non_queryable_field", PropertyType::String | PropertyType::Nullable}}},
         };
 
         return ServerSchema{std::move(schema), {"queryable_str_field", "queryable_int_field"}};

--- a/test/object-store/sync/sync_test_utils.cpp
+++ b/test/object-store/sync/sync_test_utils.cpp
@@ -566,8 +566,6 @@ struct BaasFLXClientReset : public TestClientReset {
             m_on_post_local(realm);
         }
         wait_for_upload(*realm);
-        auto subs = realm->get_latest_subscription_set();
-        subs.get_state_change_notification(sync::SubscriptionSet::State::Complete).get();
         if (m_on_post_reset) {
             m_on_post_reset(realm);
         }


### PR DESCRIPTION
Enable client reset with recovery in flexible sync mode.

In this mode, changeset recoveries are grouped together in a commit up until the next pending FLX sync subscription, where at that point the corresponding subscription is committed separately as well. This cycle repeats until no local changes remain. In this way, we handle offline writes that only match a temporary subscription.

Built on top of https://github.com/realm/realm-core/pull/5404