### PR TITLE
Allow embedded objects with asymmetric sync

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 ### Fixed
 * Fixed a segfault in sync compiled by MSVC 2022. ([#5557](https://github.com/realm/realm-core/pull/5557), since 12.1.0)
 * Fix a data race when opening a flexible sync Realm (since v12.1.0).
+* Asymmetric sync now works with embedded objects. (Issue [#5565](https://github.com/realm/realm-core/issues/5565), since 12.1.0)
  
 ### Breaking changes
 * None.

--- a/src/realm/obj.cpp
+++ b/src/realm/obj.cpp
@@ -1543,7 +1543,7 @@ Obj Obj::create_and_set_linked_object(ColKey col_key, bool is_default)
         throw LogicError(LogicError::illegal_type);
     TableRef target_table = get_target_table(col_key);
     Table& t = *target_table;
-    // Outgoing links from asymmetric objects are disallowed.
+    // Only links to embedded objects are allowed.
     REALM_ASSERT(t.is_embedded() || !get_table()->is_asymmetric());
     // Incoming links to asymmetric objects are disallowed.
     REALM_ASSERT(!t.is_asymmetric());

--- a/src/realm/obj.cpp
+++ b/src/realm/obj.cpp
@@ -1536,8 +1536,6 @@ Obj& Obj::set<ObjLink>(ColKey col_key, ObjLink target_link, bool is_default)
 Obj Obj::create_and_set_linked_object(ColKey col_key, bool is_default)
 {
     update_if_needed();
-    // Outgoing links from asymmetric objects are disallowed.
-    REALM_ASSERT(!get_table()->is_asymmetric());
     get_table()->check_column(col_key);
     ColKey::Idx col_ndx = col_key.get_index();
     ColumnType type = col_key.get_type();
@@ -1545,6 +1543,8 @@ Obj Obj::create_and_set_linked_object(ColKey col_key, bool is_default)
         throw LogicError(LogicError::illegal_type);
     TableRef target_table = get_target_table(col_key);
     Table& t = *target_table;
+    // Outgoing links from asymmetric objects are disallowed.
+    REALM_ASSERT(t.is_embedded() || !get_table()->is_asymmetric());
     // Incoming links to asymmetric objects are disallowed.
     REALM_ASSERT(!t.is_asymmetric());
     TableKey target_table_key = t.get_key();

--- a/src/realm/object-store/object_schema.cpp
+++ b/src/realm/object-store/object_schema.cpp
@@ -314,14 +314,14 @@ static void validate_property(Schema const& schema, ObjectSchema const& parent_o
                                 object_name, prop.name, prop.object_type);
         return;
     }
-    if (parent_object_schema.is_asymmetric) {
+    if (parent_object_schema.is_asymmetric && !it->is_embedded) {
         exceptions.emplace_back("Asymmetric table with property '%1.%2' of type '%3' cannot have an object type.",
                                 object_name, prop.name, string_for_property_type(prop.type));
         return;
     }
     if (it->is_asymmetric) {
-        exceptions.emplace_back("Property '%1.%2' of type '%3' cannot have an asymmetric object type ('%4').",
-                                object_name, prop.name, string_for_property_type(prop.type), prop.object_type);
+        exceptions.emplace_back("Property '%1.%2' of type '%3' cannot be a link to an asymmetric object.",
+                                object_name, prop.name, string_for_property_type(prop.type));
         return;
     }
     if (prop.type != PropertyType::LinkingObjects)

--- a/src/realm/table.cpp
+++ b/src/realm/table.cpp
@@ -360,7 +360,7 @@ ColKey Table::add_column(Table& target, StringData name)
     if (origin_group != target_group)
         throw LogicError(LogicError::group_mismatch);
     // Outgoing links from an asymmetric table are not allowed.
-    if (is_asymmetric()) {
+    if (is_asymmetric() && !target.is_embedded()) {
         throw LogicError(LogicError::wrong_kind_of_table);
     }
     // Incoming links from an asymmetric table are not allowed.

--- a/test/object-store/schema.cpp
+++ b/test/object-store/schema.cpp
@@ -395,7 +395,7 @@ TEST_CASE("Schema") {
             };
             REQUIRE_THROWS_CONTAINING(
                 schema.validate(SchemaValidationMode::Sync),
-                "Property 'object.link' of type 'object' cannot have an asymmetric object type ('link target').");
+                "Property 'object.link' of type 'object' cannot be a link to an asymmetric object.");
         }
 
         SECTION("rejects link properties with asymmetric origin object") {
@@ -408,6 +408,17 @@ TEST_CASE("Schema") {
             REQUIRE_THROWS_CONTAINING(
                 schema.validate(SchemaValidationMode::Sync),
                 "Asymmetric table with property 'object.link' of type 'object' cannot have an object type.");
+        }
+
+        SECTION("allow embedded objects with asymmetric sync") {
+            Schema schema = {
+                {"object",
+                 ObjectSchema::IsAsymmetric{true},
+                 {{"_id", PropertyType::Int, Property::IsPrimary{true}},
+                  {"link", PropertyType::Object | PropertyType::Nullable, "link target"}}},
+                {"link target", ObjectSchema::IsEmbedded{true}, {{"value", PropertyType::Int}}},
+            };
+            schema.validate(SchemaValidationMode::Sync);
         }
 
         SECTION("rejects array properties with no target object") {

--- a/test/object-store/sync/flx_sync.cpp
+++ b/test/object-store/sync/flx_sync.cpp
@@ -1195,6 +1195,8 @@ TEST_CASE("flx: asymmetric sync", "[sync][flx][app]") {
         });
 
         harness.do_with_new_realm([&](SharedRealm realm) {
+            wait_for_download(*realm);
+
             auto table = realm->read_group().get_table("class_Asymmetric");
             REQUIRE(table->size() == 0);
             auto new_query = realm->get_latest_subscription_set().make_mutable_copy();
@@ -1343,6 +1345,13 @@ TEST_CASE("flx: asymmetric sync with embedded objects") {
             Object::create(c, realm, "Asymmetric",
                            util::Any(AnyDict{{"_id", ObjectId::gen()},
                                              {"embedded_obj", AnyDict{{"value", std::string{"foo"}}}}}));
+        });
+
+        harness.do_with_new_realm([&](SharedRealm realm) {
+            wait_for_download(*realm);
+
+            auto table = realm->read_group().get_table("class_Asymmetric");
+            REQUIRE(table->size() == 0);
         });
     }
 

--- a/test/object-store/sync/flx_sync.cpp
+++ b/test/object-store/sync/flx_sync.cpp
@@ -1166,7 +1166,6 @@ TEST_CASE("flx: bootstrap batching prevents orphan documents", "[sync][flx][app]
 
 TEST_CASE("flx: asymmetric sync", "[sync][flx][app]") {
     FLXSyncTestHarness::ServerSchema server_schema;
-    server_schema.dev_mode_enabled = true;
     server_schema.queryable_fields = {"queryable_str_field"};
     server_schema.schema = {
         {"Asymmetric",
@@ -1318,6 +1317,33 @@ TEST_CASE("flx: asymmetric sync", "[sync][flx][app]") {
             CHECK(ec.value() == int(realm::sync::ClientError::bad_changeset));
         });
     }
+}
+
+TEST_CASE("flx: asymmetric sync with embedded objects") {
+    FLXSyncTestHarness::ServerSchema server_schema;
+    // server_schema.queryable_fields = {"queryable_str_field"};
+    server_schema.schema = {
+        {"Asymmetric",
+         ObjectSchema::IsAsymmetric{true},
+         {
+             {"_id", PropertyType::ObjectId, Property::IsPrimary{true}},
+             {"embedded_obj", PropertyType::Object | PropertyType::Nullable, "Asymmetric_embedded_obj"},
+         }},
+        {"Asymmetric_embedded_obj",
+         ObjectSchema::IsEmbedded{true},
+         {
+             {"value", PropertyType::String | PropertyType::Nullable},
+         }},
+    };
+
+    FLXSyncTestHarness harness("asymmetric_sync", server_schema);
+
+    harness.load_initial_data([&](SharedRealm realm) {
+        CppContext c(realm);
+        Object::create(
+            c, realm, "Asymmetric",
+            util::Any(AnyDict{{"_id", ObjectId::gen()}, {"embedded_obj", AnyDict{{"value", std::string{"foo"}}}}}));
+    });
 }
 
 } // namespace realm::app

--- a/test/object-store/sync/flx_sync_harness.hpp
+++ b/test/object-store/sync/flx_sync_harness.hpp
@@ -95,7 +95,7 @@ public:
         auto realm = Realm::get_shared_realm(config);
         auto mut_subs = realm->get_latest_subscription_set().make_mutable_copy();
         for (const auto& table : realm->schema()) {
-            if (table.is_asymmetric) {
+            if (table.is_asymmetric || table.is_embedded) {
                 continue;
             }
             Query query_for_table(realm->read_group().get_table(table.table_key));


### PR DESCRIPTION
## What, How & Why?
Embedded objects were wrongly not allowed in asymmetric sync. This PR addresses that.
Fixes #5565.

## ☑️ ToDos
* [x] 📝 Changelog update
* [x] 🚦 Tests (or not relevant)
* ~~[ ] C-API, if public C++ API changed.~~
