### PR TITLE
Enable the use of encryption in OS tests

### DIFF
--- a/test/object-store/CMakeLists.txt
+++ b/test/object-store/CMakeLists.txt
@@ -3,6 +3,7 @@ set(HEADERS
     util/index_helpers.hpp
     util/test_file.hpp
     util/test_utils.hpp
+    ../util/crypt_key.hpp
     collection_fixtures.hpp
 )
 
@@ -31,6 +32,7 @@ set(SOURCES
     util/event_loop.cpp
     util/test_file.cpp
     util/test_utils.cpp
+    ../util/crypt_key.cpp
 )
 
 if(REALM_ENABLE_AUTH_TESTS)

--- a/test/object-store/backup.cpp
+++ b/test/object-store/backup.cpp
@@ -63,6 +63,7 @@ TEST_CASE("Automated backup") {
     TestFile config;
     std::string copy_from_file_name = "test_backup-olden-and-golden.realm";
     config.path = "test_backup.realm";
+    config.encryption_key.clear();
     REQUIRE(util::File::exists(copy_from_file_name));
     util::File::copy(copy_from_file_name, config.path);
     REQUIRE(util::File::exists(config.path));

--- a/test/object-store/main.cpp
+++ b/test/object-store/main.cpp
@@ -24,6 +24,7 @@
 #include <catch2/catch.hpp>
 #include <external/json/json.hpp>
 #include <realm/util/to_string.hpp>
+#include "../util/crypt_key.hpp"
 
 #include <limits.h>
 
@@ -71,6 +72,16 @@ int main(int argc, char** argv)
     else if (const char* str = getenv("UNITTEST_XML"); str && strlen(str) != 0) {
         config.reporterName = "junit";
         config.outputFilename = "unit-test-report.xml";
+    }
+
+    if (const char* env = getenv("UNITTEST_ENCRYPT_ALL")) {
+        std::string str(env);
+        for (auto& c : str) {
+            c = tolower(c);
+        }
+        if (str == "1" || str == "on" || str == "yes") {
+            realm::test_util::enable_always_encrypt();
+        }
     }
 
     Catch::Session session;

--- a/test/object-store/sync/sync_test_utils.cpp
+++ b/test/object-store/sync/sync_test_utils.cpp
@@ -239,7 +239,9 @@ struct FakeLocalClientReset : public TestClientReset {
         m_local_config.force_sync_history = true;
         m_remote_config.force_sync_history = true;
         m_local_config.in_memory = true;
+        m_local_config.encryption_key = std::vector<char>();
         m_remote_config.in_memory = true;
+        m_remote_config.encryption_key = std::vector<char>();
     }
 
     void run() override

--- a/test/object-store/util/test_file.cpp
+++ b/test/object-store/util/test_file.cpp
@@ -20,6 +20,7 @@
 
 #include "baas_admin_api.hpp"
 #include "test_utils.hpp"
+#include "../util/crypt_key.hpp"
 #include <realm/object-store/impl/realm_coordinator.hpp>
 
 #if REALM_ENABLE_SYNC
@@ -65,6 +66,9 @@ TestFile::TestFile()
     disable_sync_to_disk();
     m_temp_dir = util::make_temp_dir();
     path = (fs::path(m_temp_dir) / "realm.XXXXXX").string();
+    if (const char* crypt_key = test_util::crypt_key()) {
+        encryption_key = std::vector<char>(crypt_key, crypt_key + 64);
+    }
     int fd = mkstemp(path.data());
     if (fd < 0) {
         int err = errno;
@@ -104,6 +108,7 @@ DBOptions TestFile::options() const
 InMemoryTestFile::InMemoryTestFile()
 {
     in_memory = true;
+    encryption_key = std::vector<char>();
 }
 
 #if REALM_ENABLE_SYNC


### PR DESCRIPTION
Set environment variable UNITTEST_ENCRYPT_ALL in order to use encryption
as default.

## What, How & Why?
Fixes #5567 
