### PR TITLE
Fix a data race on write_validator_factory

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@
 
 ### Fixed
 * Fixed a segfault in sync compiled by MSVC 2022. ([#5557](https://github.com/realm/realm-core/pull/5557), since 12.1.0)
-* Fix a data race when openg a flexible sync Realm (since v12.1.0).
+* Fix a data race when opening a flexible sync Realm (since v12.1.0).
  
 ### Breaking changes
 * None.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 
 ### Fixed
 * Fixed a segfault in sync compiled by MSVC 2022. ([#5557](https://github.com/realm/realm-core/pull/5557), since 12.1.0)
+* Fix a data race when openg a flexible sync Realm (since v12.1.0).
  
 ### Breaking changes
 * None.


### PR DESCRIPTION
PendingBootstrapStore is created early in session initialization, which performs a write and thus reads the write validator. This can race with setting the write validator on the thread which created the sync session, and tsan complains about it.

Moving the initialization to SyncSession's constructor ensures that it's set before we create the `sync::Session`.