### PR TITLE
fix undefined symbol crypt_key in swift builds

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -481,8 +481,14 @@ let package = Package(
                 .define("CATCH_CONFIG_NO_CPP17_UNCAUGHT_EXCEPTIONS")
             ] + cxxSettings) as [CXXSetting]),
         .target(
+            name: "CoreTestUtils",
+            dependencies: ["RealmCore"],
+            path: "test/util",
+            publicHeadersPath: ".",
+            cxxSettings: (cxxSettings) as [CXXSetting]),
+        .target(
             name: "ObjectStoreTestUtils",
-            dependencies: ["RealmCore", "SyncServer", "Catch2"],
+            dependencies: ["RealmCore", "SyncServer", "Catch2", "CoreTestUtils"],
             path: "test/object-store/util",
             exclude: [
                 "baas_admin_api.hpp",

--- a/Package.swift
+++ b/Package.swift
@@ -473,6 +473,7 @@ let package = Package(
             path: "external/catch/src",
             exclude: [
                 "CMakeLists.txt",
+                "catch2/catch_user_config.hpp.in",
                 "catch2/internal/catch_main.cpp"
                 ],
             publicHeadersPath: ".",
@@ -484,6 +485,9 @@ let package = Package(
             name: "CoreTestUtils",
             dependencies: ["RealmCore"],
             path: "test/util",
+            exclude: [
+                "CMakeLists.txt"
+            ],
             publicHeadersPath: ".",
             cxxSettings: (cxxSettings) as [CXXSetting]),
         .target(


### PR DESCRIPTION
This appears to have been broken since https://github.com/realm/realm-core/pull/5568

The error was:

```
Undefined symbols for architecture x86_64:
  "__ZN5realm9test_util21enable_always_encryptEv", referenced from:
      _main in main.cpp.o
  "__ZN5realm9test_util9crypt_keyEb", referenced from:
      __ZN8TestFileC2Ev in test_file.cpp.o
ld: symbol(s) not found for architecture x86_64
[124/140] Compiling Capi schema.cpp
```

This is because the object-store tests now require building with "../util/crypt_key.cpp" which is part of the core test utils. The solution here is to add the core test utils as a dependency of the object store tests. A better long term solution might be to combine our test suites.