### PR TITLE
Fix building Catch2 for tvOS and watchOS

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -310,21 +310,7 @@ set(JSON_INCLUDE_DIR ${CMAKE_CURRENT_SOURCE_DIR}/external/json)
 include_directories(src)
 include_directories(${CMAKE_CURRENT_BINARY_DIR}/src) # For generated files (like config.h)
 
-# Include additional CMakeLists
 add_subdirectory(src)
-add_subdirectory(external/catch)
-
-# This disables a c++17 feature that Apple doesn't support yet and Catch2 uses
-# The following define could be removed if we drop support for MacOS 10.12
-target_compile_definitions(Catch2 PRIVATE
-    CATCH_CONFIG_NO_CPP17_UNCAUGHT_EXCEPTIONS=1
-    PRIVATE _SILENCE_CXX17_UNCAUGHT_EXCEPTION_DEPRECATION_WARNING=1
-)
-
-if(CMAKE_SYSTEM_NAME MATCHES "^Windows")
-    # Increase the Catch2 virtual console width because our test names can be very long and they break test reports
-    set(CATCH_CONFIG_CONSOLE_WIDTH 300)
-endif()
 
 if (REALM_BUILD_DOGLESS)
     set(REALM_HAVE_DOGLESS ON)
@@ -338,6 +324,22 @@ install(FILES LICENSE CHANGELOG.md DESTINATION "doc/realm" COMPONENT devel)
 if(REALM_CORE_SUBMODULE_BUILD)
     return()
 endif()
+
+if(CMAKE_SYSTEM_NAME MATCHES "^Windows")
+    # Increase the Catch2 virtual console width because our test names can be very long and they break test reports
+    set(CATCH_CONFIG_CONSOLE_WIDTH 300)
+elseif(APPLE AND NOT CMAKE_SYSTEM_NAME STREQUAL "Darwin")
+    set(CATCH_CONFIG_NO_POSIX_SIGNALS ON CACHE BOOL "Disable Catch support for POSIX signals on Apple platforms other than macOS")
+endif()
+
+add_subdirectory(external/catch EXCLUDE_FROM_ALL)
+
+# This disables a c++17 feature that Apple doesn't support yet and Catch2 uses
+# The following define could be removed if we drop support for MacOS 10.12
+target_compile_definitions(Catch2 PRIVATE
+    CATCH_CONFIG_NO_CPP17_UNCAUGHT_EXCEPTIONS=1
+    _SILENCE_CXX17_UNCAUGHT_EXCEPTION_DEPRECATION_WARNING=1
+)
 
 # Enable CTest and include unit tests
 enable_testing()

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -126,6 +126,7 @@ jobWrapper {
             buildWindows_ARM64_Debug: doBuildWindows('Debug', false, 'ARM64', false),
             buildUWP_ARM64_Debug    : doBuildWindows('Debug', true, 'ARM64', false),
             checkiOSSimulator_Debug : doBuildApplePlatform('iphonesimulator', 'Debug', true),
+            buildAppleTV_Debug      : doBuildApplePlatform('appletvos', 'Debug', false),
             buildAndroidArm64Debug  : doAndroidBuildInDocker('arm64-v8a', 'Debug'),
             buildAndroidTestsArmeabi: doAndroidBuildInDocker('armeabi-v7a', 'Debug', TestAction.Build),
             threadSanitizer         : doCheckSanity(buildOptions + [enableSync: true, sanitizeMode: 'thread']),


### PR DESCRIPTION
Catch2 uses [sigaltstack](https://developer.apple.com/library/archive/documentation/System/Conceptual/ManPages_iPhoneOS/man2/sigaltstack.2.html), which is unavailable on tvOS and watchOS.

This PR adds a PR build check for tvOS, making sure the code compiles for tvOS on every PR. It also moves the Catch2 include in `CMakeLists.txt` below the `REALM_CORE_SUBMODULE_BUILD` check so it's not picked up by downstream projects including realm-core, removes it from the default build unless explicitly required by another target, and sets `CATCH_CONFIG_NO_POSIX_SIGNALS` to disable the particular functionality requiring `sigaltstack`.