### PR TITLE
Fix an exception during recovery of lists

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 * Changed the signature of `Realm::async_cancel_transaction` to return a boolean indicating whether the removal of the scheduled callback was successful (true) or not (false). Previously, the method returned void. (PR [#5546](https://github.com/realm/realm-core/pull/5546))
 
 ### Fixed
+* Fixed an exception "key not found" during client reset recovery if a list had local moves or deletes and the base object was also deleted. ([#5593](https://github.com/realm/realm-core/issues/5593) since the introduction of recovery in v11.16.0)
 * Fixed a segfault in sync compiled by MSVC 2022. ([#5557](https://github.com/realm/realm-core/pull/5557), since 12.1.0)
 * Fix a data race when opening a flexible sync Realm (since v12.1.0).
 * Fixed a missing backlink removal when setting a Mixed from a TypedLink to null or any other non-link value. Users may have seen exception of "key not found" or assertion failures such as `mixed.hpp:165: [realm-core-12.1.0] Assertion failed: m_type` when removing the destination link object. ([#5574](https://github.com/realm/realm-core/pull/5573), since the introduction of Mixed in v11.0.0)

--- a/test/object-store/sync/client_reset.cpp
+++ b/test/object-store/sync/client_reset.cpp
@@ -2532,8 +2532,12 @@ TEMPLATE_TEST_CASE("client reset collections of links", "[client reset][local][l
                          {dest_pk_1, dest_pk_2, dest_pk_3, dest_pk_5}, 1);
     }
     if (test_mode == ClientResyncMode::Recover) {
-        SECTION("local removes source object, remote modifies list") {
+        SECTION("local adds a list item and removes source object, remote modifies list") {
             reset_collection_removing_source_object({Add{dest_pk_4}, RemoveObject{"source", source_pk}},
+                                                    {Add{dest_pk_5}});
+        }
+        SECTION("local erases list item then removes source object, remote modifies list") {
+            reset_collection_removing_source_object({Remove{dest_pk_1}, RemoveObject{"source", source_pk}},
                                                     {Add{dest_pk_5}});
         }
         SECTION("remote removes source object, recover local modifications") {


### PR DESCRIPTION
Specifically: erasing or moving a list item to trigger verbatim copying of the list, but also erasing the base object locally later on in the recovery. The way exceptions are handled during recovery is to fallback to a manual client reset (or discard local if in recoverOrDiscard mode) so the impact of this is expected to be minimal, especially because SDKs have not released recovery yet.

I found this issue when writing benchmarks.

## ☑️ ToDos
* [x] 📝 Changelog update
* [x] 🚦 Tests (or not relevant)