### PR TITLE
Add a dummy file to trick the swift build into working

### DIFF
--- a/external/generated/empty.cpp
+++ b/external/generated/empty.cpp
@@ -1,0 +1,2 @@
+// This empty file forces projects that depend on the Catch2Generated target in Package.swift to generate a .o file
+// for this dependency


### PR DESCRIPTION
This fixes Xcode builds that are using Package.swift directly.
I don't know if there is a better way to set up the swift build dependency, but this seems to do the trick for me.