### PR TITLE
Do not allow migrations with asymmetric tables

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,9 +32,10 @@
 * Fixed a segfault in sync compiled by MSVC 2022. ([#5557](https://github.com/realm/realm-core/pull/5557), since 12.1.0)
 * Fix a data race when opening a flexible sync Realm (since v12.1.0).
 * Fixed a missing backlink removal when setting a Mixed from a TypedLink to null or any other non-link value. Users may have seen exception of "key not found" or assertion failures such as `mixed.hpp:165: [realm-core-12.1.0] Assertion failed: m_type` when removing the destination link object. ([#5574](https://github.com/realm/realm-core/pull/5573), since the introduction of Mixed in v11.0.0)
-* Asymmetric sync now works with embedded objects. (Issue [#5565](https://github.com/realm/realm-core/issues/5565), since 12.1.0)
+* Asymmetric sync now works with embedded objects. (Issue [#5565](https://github.com/realm/realm-core/issues/5565), since v12.1.0)
 * Fixed an issue on Windows that would cause high CPU usage by the sync client when there are no active sync sessions. (Issue [#5591](https://github.com/realm/realm-core/issues/5591), since the introduction of Sync support for Windows)
-
+* Fixed a bug that prevented the detection of tables being changed to or from asymmetric during migrations. ([#5603](https://github.com/realm/realm-core/pull/5603), since v12.1.0)
+ 
 ### Breaking changes
 * `realm_sync_before_client_reset_func_t` and `realm_sync_after_client_reset_func_t` in the C API now return a boolean value to indicate whether the callback succeeded or not, which signals to the sync client that a fatal error occurred. (PR [#5564](https://github.com/realm/realm-core/pull/5564))
 

--- a/evergreen/config.yml
+++ b/evergreen/config.yml
@@ -506,7 +506,7 @@ tasks:
 
 - name: object-store-tests
   tags: [ "test_suite", "for_pull_requests" ]
-  exec_timeout_secs: 1800
+  exec_timeout_secs: 2100
   commands:
   - func: "compile"
   # If we need to start a local copy of baas, do it in the background here in a separate script.

--- a/src/realm.h
+++ b/src/realm.h
@@ -332,6 +332,8 @@ typedef struct realm_class_info {
 typedef enum realm_class_flags {
     RLM_CLASS_NORMAL = 0,
     RLM_CLASS_EMBEDDED = 1,
+    RLM_CLASS_ASYMMETRIC = 2,
+    RLM_CLASS_MASK = 3,
 } realm_class_flags_e;
 
 typedef enum realm_property_flags {

--- a/src/realm/exec/realm_trawler.cpp
+++ b/src/realm/exec/realm_trawler.cpp
@@ -24,6 +24,7 @@
 #include <realm/array.hpp>
 #include <realm/column_type.hpp>
 #include <realm/data_type.hpp>
+#include <realm/table.hpp>
 
 #include <iostream>
 #include <fstream>
@@ -268,8 +269,7 @@ public:
             }
             if (size() > 12) {
                 auto flags = get_val(12);
-                m_is_embedded = (flags & 0x3) == 1;
-                m_is_asymmetric = (flags & 0x3) == 2;
+                m_table_type = static_cast<realm::Table::Type>(flags & 0x3);
             }
         }
     }
@@ -301,8 +301,7 @@ private:
     Array m_column_colkeys;
     Array m_opposite_table;
     realm::ColKey m_pk_col;
-    bool m_is_embedded = false;
-    bool m_is_asymmetric = false;
+    realm::Table::Type m_table_type = realm::Table::Type::TopLevel;
 };
 
 class Group : public Array {
@@ -455,10 +454,7 @@ std::ostream& operator<<(std::ostream& ostr, const Group& g)
 
 void Table::print_columns(const Group& group) const
 {
-    if (m_is_embedded)
-        std::cout << "        <embedded>" << std::endl;
-    if (m_is_asymmetric)
-        std::cout << "        <asymmetric>" << std::endl;
+    std::cout << "        <" << m_table_type << ">" << std::endl;
     for (unsigned i = 0; i < m_column_names.size(); i++) {
         auto type = realm::ColumnType(m_column_types.get_val(i) & 0xFFFF);
         auto attr = realm::ColumnAttr(m_column_attributes.get_val(i));

--- a/src/realm/object-store/c_api/conversion.hpp
+++ b/src/realm/object-store/c_api/conversion.hpp
@@ -423,14 +423,21 @@ static inline realm_class_info_t to_capi(const ObjectSchema& o)
     info.num_properties = o.persisted_properties.size();
     info.num_computed_properties = o.computed_properties.size();
     info.key = o.table_key.value;
-    if (o.table_type == ObjectSchema::TableType::Embedded) {
-        info.flags = RLM_CLASS_EMBEDDED;
-    }
-    else if (o.table_type == ObjectSchema::TableType::TopLevelAsymmetric) {
-        info.flags = RLM_CLASS_ASYMMETRIC;
-    }
-    else {
-        info.flags = RLM_CLASS_NORMAL;
+    switch (o.table_type) {
+        case ObjectSchema::ObjectType::Embedded: {
+            info.flags = RLM_CLASS_EMBEDDED;
+            break;
+        }
+        case ObjectSchema::ObjectType::TopLevelAsymmetric: {
+            info.flags = RLM_CLASS_ASYMMETRIC;
+            break;
+        }
+        case ObjectSchema::ObjectType::TopLevel: {
+            info.flags = RLM_CLASS_NORMAL;
+            break;
+        }
+        default:
+            REALM_TERMINATE(util::format("Invalid table type: %1", uint8_t(o.table_type)).c_str());
     }
     return info;
 }

--- a/src/realm/object-store/c_api/conversion.hpp
+++ b/src/realm/object-store/c_api/conversion.hpp
@@ -423,8 +423,11 @@ static inline realm_class_info_t to_capi(const ObjectSchema& o)
     info.num_properties = o.persisted_properties.size();
     info.num_computed_properties = o.computed_properties.size();
     info.key = o.table_key.value;
-    if (o.is_embedded) {
+    if (o.table_type == ObjectSchema::TableType::Embedded) {
         info.flags = RLM_CLASS_EMBEDDED;
+    }
+    else if (o.table_type == ObjectSchema::TableType::TopLevelAsymmetric) {
+        info.flags = RLM_CLASS_ASYMMETRIC;
     }
     else {
         info.flags = RLM_CLASS_NORMAL;

--- a/src/realm/object-store/c_api/schema.cpp
+++ b/src/realm/object-store/c_api/schema.cpp
@@ -19,7 +19,7 @@ RLM_API realm_schema_t* realm_schema_new(const realm_class_info_t* classes, size
             ObjectSchema object_schema;
             object_schema.name = class_info.name;
             object_schema.primary_key = class_info.primary_key;
-            object_schema.table_type = static_cast<ObjectSchema::TableType>(class_info.flags & RLM_CLASS_MASK);
+            object_schema.table_type = static_cast<ObjectSchema::ObjectType>(class_info.flags & RLM_CLASS_MASK);
             object_schema.persisted_properties.reserve(class_info.num_properties);
             object_schema.computed_properties.reserve(class_info.num_computed_properties);
 

--- a/src/realm/object-store/c_api/schema.cpp
+++ b/src/realm/object-store/c_api/schema.cpp
@@ -19,7 +19,7 @@ RLM_API realm_schema_t* realm_schema_new(const realm_class_info_t* classes, size
             ObjectSchema object_schema;
             object_schema.name = class_info.name;
             object_schema.primary_key = class_info.primary_key;
-            object_schema.is_embedded = ObjectSchema::IsEmbedded{bool(class_info.flags & RLM_CLASS_EMBEDDED)};
+            object_schema.table_type = static_cast<ObjectSchema::TableType>(class_info.flags & RLM_CLASS_MASK);
             object_schema.persisted_properties.reserve(class_info.num_properties);
             object_schema.computed_properties.reserve(class_info.num_computed_properties);
 

--- a/src/realm/object-store/object_accessor.hpp
+++ b/src/realm/object-store/object_accessor.hpp
@@ -271,7 +271,7 @@ Object Object::create(ContextType& ctx, std::shared_ptr<Realm> const& realm, Obj
     auto table = realm->read_group().get_table(object_schema.table_key);
 
     // Asymmetric objects cannot be updated through Object::create.
-    if (object_schema.table_type == ObjectSchema::TableType::TopLevelAsymmetric) {
+    if (object_schema.table_type == ObjectSchema::ObjectType::TopLevelAsymmetric) {
         REALM_ASSERT(!policy.update);
         REALM_ASSERT(!current_obj);
         REALM_ASSERT(object_schema.primary_key_property());
@@ -323,7 +323,7 @@ Object Object::create(ContextType& ctx, std::shared_ptr<Realm> const& realm, Obj
     if (!obj) {
         if (current_obj)
             obj = table->get_object(current_obj);
-        else if (object_schema.table_type == ObjectSchema::TableType::Embedded)
+        else if (object_schema.table_type == ObjectSchema::ObjectType::Embedded)
             obj = ctx.create_embedded_object();
         else
             obj = table->create_object();
@@ -334,7 +334,7 @@ Object Object::create(ContextType& ctx, std::shared_ptr<Realm> const& realm, Obj
     // KVO in Cocoa requires that the obj ivar on the wrapper object be set
     // *before* we start setting the properties, so it passes in a pointer to
     // that.
-    if (out_row && object_schema.table_type != ObjectSchema::TableType::TopLevelAsymmetric)
+    if (out_row && object_schema.table_type != ObjectSchema::ObjectType::TopLevelAsymmetric)
         *out_row = obj;
     for (size_t i = 0; i < object_schema.persisted_properties.size(); ++i) {
         auto& prop = object_schema.persisted_properties[i];
@@ -361,7 +361,7 @@ Object Object::create(ContextType& ctx, std::shared_ptr<Realm> const& realm, Obj
         if (v)
             object.set_property_value_impl(ctx, prop, *v, policy, is_default);
     }
-    if (object_schema.table_type == ObjectSchema::TableType::TopLevelAsymmetric) {
+    if (object_schema.table_type == ObjectSchema::ObjectType::TopLevelAsymmetric) {
         return Object{};
     }
     return object;

--- a/src/realm/object-store/object_accessor.hpp
+++ b/src/realm/object-store/object_accessor.hpp
@@ -271,7 +271,7 @@ Object Object::create(ContextType& ctx, std::shared_ptr<Realm> const& realm, Obj
     auto table = realm->read_group().get_table(object_schema.table_key);
 
     // Asymmetric objects cannot be updated through Object::create.
-    if (object_schema.is_asymmetric) {
+    if (object_schema.table_type == ObjectSchema::TableType::TopLevelAsymmetric) {
         REALM_ASSERT(!policy.update);
         REALM_ASSERT(!current_obj);
         REALM_ASSERT(object_schema.primary_key_property());
@@ -323,7 +323,7 @@ Object Object::create(ContextType& ctx, std::shared_ptr<Realm> const& realm, Obj
     if (!obj) {
         if (current_obj)
             obj = table->get_object(current_obj);
-        else if (object_schema.is_embedded)
+        else if (object_schema.table_type == ObjectSchema::TableType::Embedded)
             obj = ctx.create_embedded_object();
         else
             obj = table->create_object();
@@ -334,7 +334,7 @@ Object Object::create(ContextType& ctx, std::shared_ptr<Realm> const& realm, Obj
     // KVO in Cocoa requires that the obj ivar on the wrapper object be set
     // *before* we start setting the properties, so it passes in a pointer to
     // that.
-    if (out_row && !object_schema.is_asymmetric)
+    if (out_row && object_schema.table_type != ObjectSchema::TableType::TopLevelAsymmetric)
         *out_row = obj;
     for (size_t i = 0; i < object_schema.persisted_properties.size(); ++i) {
         auto& prop = object_schema.persisted_properties[i];
@@ -361,7 +361,7 @@ Object Object::create(ContextType& ctx, std::shared_ptr<Realm> const& realm, Obj
         if (v)
             object.set_property_value_impl(ctx, prop, *v, policy, is_default);
     }
-    if (object_schema.is_asymmetric) {
+    if (object_schema.table_type == ObjectSchema::TableType::TopLevelAsymmetric) {
         return Object{};
     }
     return object;

--- a/src/realm/object-store/object_schema.cpp
+++ b/src/realm/object-store/object_schema.cpp
@@ -37,48 +37,25 @@ ObjectSchema::ObjectSchema(std::string name, std::initializer_list<Property> per
 {
 }
 
-ObjectSchema::ObjectSchema(std::string name, IsEmbedded is_embedded,
+ObjectSchema::ObjectSchema(std::string name, TableType table_type,
                            std::initializer_list<Property> persisted_properties)
-    : ObjectSchema(std::move(name), is_embedded, persisted_properties, {})
-{
-}
-
-ObjectSchema::ObjectSchema(std::string name, IsAsymmetric is_asymmetric,
-                           std::initializer_list<Property> persisted_properties)
-    : ObjectSchema(std::move(name), is_asymmetric, persisted_properties, {})
+    : ObjectSchema(std::move(name), table_type, persisted_properties, {})
 {
 }
 
 ObjectSchema::ObjectSchema(std::string name, std::initializer_list<Property> persisted_properties,
                            std::initializer_list<Property> computed_properties, std::string name_alias)
-    : ObjectSchema(std::move(name), IsEmbedded{false}, persisted_properties, computed_properties, name_alias)
+    : ObjectSchema(std::move(name), TableType::TopLevel, persisted_properties, computed_properties, name_alias)
 {
 }
 
-ObjectSchema::ObjectSchema(std::string name, IsEmbedded is_embedded,
+ObjectSchema::ObjectSchema(std::string name, TableType table_type,
                            std::initializer_list<Property> persisted_properties,
                            std::initializer_list<Property> computed_properties, std::string name_alias)
     : name(std::move(name))
     , persisted_properties(persisted_properties)
     , computed_properties(computed_properties)
-    , is_embedded(is_embedded)
-    , alias(name_alias)
-{
-    for (auto const& prop : persisted_properties) {
-        if (prop.is_primary) {
-            primary_key = prop.name;
-            break;
-        }
-    }
-}
-
-ObjectSchema::ObjectSchema(std::string name, IsAsymmetric is_asymmetric,
-                           std::initializer_list<Property> persisted_properties,
-                           std::initializer_list<Property> computed_properties, std::string name_alias)
-    : name(std::move(name))
-    , persisted_properties(persisted_properties)
-    , computed_properties(computed_properties)
-    , is_asymmetric(is_asymmetric)
+    , table_type(table_type)
     , alias(name_alias)
 {
     for (auto const& prop : persisted_properties) {
@@ -153,8 +130,7 @@ ObjectSchema::ObjectSchema(Group const& group, StringData name, TableKey key)
         table = ObjectStore::table_for_object_type(group, name);
     }
     table_key = table->get_key();
-    is_embedded = table->is_embedded();
-    is_asymmetric = table->is_asymmetric();
+    table_type = static_cast<ObjectSchema::TableType>(table->get_table_type());
 
     size_t count = table->get_column_count();
     ColKey pk_col = table->get_primary_key_column();
@@ -308,18 +284,19 @@ static void validate_property(Schema const& schema, ObjectSchema const& parent_o
                                 string_for_property_type(prop.type), prop.object_type);
         return;
     }
-    if (is_set(prop.type) && it->is_embedded) {
+    if (is_set(prop.type) && it->table_type == ObjectSchema::TableType::Embedded) {
         exceptions.emplace_back("Set property '%1.%2' cannot contain embedded object type '%3'. Set semantics are "
                                 "not applicable to embedded objects.",
                                 object_name, prop.name, prop.object_type);
         return;
     }
-    if (parent_object_schema.is_asymmetric && !it->is_embedded) {
+    if (parent_object_schema.table_type == ObjectSchema::TableType::TopLevelAsymmetric &&
+        it->table_type != ObjectSchema::TableType::Embedded) {
         exceptions.emplace_back("Asymmetric table with property '%1.%2' of type '%3' cannot have an object type.",
                                 object_name, prop.name, string_for_property_type(prop.type));
         return;
     }
-    if (it->is_asymmetric) {
+    if (it->table_type == ObjectSchema::TableType::TopLevelAsymmetric) {
         exceptions.emplace_back("Property '%1.%2' of type '%3' cannot be a link to an asymmetric object.",
                                 object_name, prop.name, string_for_property_type(prop.type));
         return;
@@ -426,14 +403,14 @@ void ObjectSchema::validate(Schema const& schema, std::vector<ObjectSchemaValida
         validate_property(schema, *this, prop, &primary, exceptions);
     }
 
-    if (!primary_key.empty() && is_embedded) {
+    if (!primary_key.empty() && table_type == ObjectSchema::TableType::Embedded) {
         exceptions.emplace_back("Embedded object type '%1' cannot have a primary key.", name);
     }
     if (!primary_key.empty() && !primary && !primary_key_property()) {
         exceptions.emplace_back("Specified primary key '%1.%2' does not exist.", name, primary_key);
     }
 
-    if (for_sync && !is_embedded) {
+    if (for_sync && table_type != ObjectSchema::TableType::Embedded) {
         if (primary_key.empty()) {
             exceptions.emplace_back(util::format("There must be a primary key property named '_id' on a synchronized "
                                                  "Realm but none was found for type '%1'",
@@ -446,7 +423,7 @@ void ObjectSchema::validate(Schema const& schema, std::vector<ObjectSchemaValida
         }
     }
 
-    if (!for_sync && is_asymmetric) {
+    if (!for_sync && table_type == ObjectSchema::TableType::TopLevelAsymmetric) {
         exceptions.emplace_back(util::format("Asymmetric table '%1' not allowed in a local Realm", name));
     }
 }
@@ -454,8 +431,7 @@ void ObjectSchema::validate(Schema const& schema, std::vector<ObjectSchemaValida
 namespace realm {
 bool operator==(ObjectSchema const& a, ObjectSchema const& b) noexcept
 {
-    return std::tie(a.name, a.is_embedded, a.is_asymmetric, a.primary_key, a.persisted_properties,
-                    a.computed_properties) == std::tie(b.name, b.is_embedded, b.is_asymmetric, b.primary_key,
-                                                       b.persisted_properties, b.computed_properties);
+    return std::tie(a.name, a.table_type, a.primary_key, a.persisted_properties, a.computed_properties) ==
+           std::tie(b.name, b.table_type, b.primary_key, b.persisted_properties, b.computed_properties);
 }
 } // namespace realm

--- a/src/realm/object-store/object_schema.hpp
+++ b/src/realm/object-store/object_schema.hpp
@@ -19,8 +19,6 @@
 #ifndef REALM_OBJECT_SCHEMA_HPP
 #define REALM_OBJECT_SCHEMA_HPP
 
-#include <realm/object-store/util/tagged_bool.hpp>
-
 #include <realm/keys.hpp>
 #include <realm/string_data.hpp>
 
@@ -37,18 +35,16 @@ struct Property;
 
 class ObjectSchema {
 public:
-    using IsEmbedded = util::TaggedBool<class IsEmbeddedTag>;
-    using IsAsymmetric = util::TaggedBool<class IsAsymmetricTag>;
+    /// The type of tables supported by a realm.
+    /// Note: Enumeration value assignments must be kept in sync with <realm/table.hpp>.
+    enum class TableType : uint8_t { TopLevel = 0, Embedded = 0x1, TopLevelAsymmetric = 0x2 };
 
     ObjectSchema();
     ObjectSchema(std::string name, std::initializer_list<Property> persisted_properties);
-    ObjectSchema(std::string name, IsEmbedded is_embedded, std::initializer_list<Property> persisted_properties);
-    ObjectSchema(std::string name, IsAsymmetric is_asymmetric, std::initializer_list<Property> persisted_properties);
+    ObjectSchema(std::string name, TableType table_type, std::initializer_list<Property> persisted_properties);
     ObjectSchema(std::string name, std::initializer_list<Property> persisted_properties,
                  std::initializer_list<Property> computed_properties, std::string name_alias = "");
-    ObjectSchema(std::string name, IsEmbedded is_embedded, std::initializer_list<Property> persisted_properties,
-                 std::initializer_list<Property> computed_properties, std::string name_alias = "");
-    ObjectSchema(std::string name, IsAsymmetric is_asymmetric, std::initializer_list<Property> persisted_properties,
+    ObjectSchema(std::string name, TableType table_type, std::initializer_list<Property> persisted_properties,
                  std::initializer_list<Property> computed_properties, std::string name_alias = "");
     ~ObjectSchema();
 
@@ -66,9 +62,7 @@ public:
     std::vector<Property> computed_properties;
     std::string primary_key;
     TableKey table_key;
-    // Cannot be both true at the same time.
-    IsEmbedded is_embedded = false;
-    IsAsymmetric is_asymmetric = false;
+    TableType table_type = TableType::TopLevel;
     std::string alias;
 
     Property* property_for_public_name(StringData public_name) noexcept;
@@ -96,6 +90,25 @@ public:
 private:
     void set_primary_key_property() noexcept;
 };
+
+inline std::ostream& operator<<(std::ostream& o, ObjectSchema::TableType table_type)
+{
+    switch (table_type) {
+        case ObjectSchema::TableType::TopLevel:
+            o << "TopLevel";
+            break;
+        case ObjectSchema::TableType::Embedded:
+            o << "Embedded";
+            break;
+        case ObjectSchema::TableType::TopLevelAsymmetric:
+            o << "TopLevelAsymmetric";
+            break;
+        default:
+            o << "Unknown table type";
+    }
+    return o;
+}
+
 } // namespace realm
 
 #endif /* defined(REALM_OBJECT_SCHEMA_HPP) */

--- a/src/realm/object-store/object_schema.hpp
+++ b/src/realm/object-store/object_schema.hpp
@@ -37,14 +37,14 @@ class ObjectSchema {
 public:
     /// The type of tables supported by a realm.
     /// Note: Enumeration value assignments must be kept in sync with <realm/table.hpp>.
-    enum class TableType : uint8_t { TopLevel = 0, Embedded = 0x1, TopLevelAsymmetric = 0x2 };
+    enum class ObjectType : uint8_t { TopLevel = 0, Embedded = 0x1, TopLevelAsymmetric = 0x2 };
 
     ObjectSchema();
     ObjectSchema(std::string name, std::initializer_list<Property> persisted_properties);
-    ObjectSchema(std::string name, TableType table_type, std::initializer_list<Property> persisted_properties);
+    ObjectSchema(std::string name, ObjectType table_type, std::initializer_list<Property> persisted_properties);
     ObjectSchema(std::string name, std::initializer_list<Property> persisted_properties,
                  std::initializer_list<Property> computed_properties, std::string name_alias = "");
-    ObjectSchema(std::string name, TableType table_type, std::initializer_list<Property> persisted_properties,
+    ObjectSchema(std::string name, ObjectType table_type, std::initializer_list<Property> persisted_properties,
                  std::initializer_list<Property> computed_properties, std::string name_alias = "");
     ~ObjectSchema();
 
@@ -62,7 +62,7 @@ public:
     std::vector<Property> computed_properties;
     std::string primary_key;
     TableKey table_key;
-    TableType table_type = TableType::TopLevel;
+    ObjectType table_type = ObjectType::TopLevel;
     std::string alias;
 
     Property* property_for_public_name(StringData public_name) noexcept;
@@ -91,22 +91,17 @@ private:
     void set_primary_key_property() noexcept;
 };
 
-inline std::ostream& operator<<(std::ostream& o, ObjectSchema::TableType table_type)
+inline std::ostream& operator<<(std::ostream& o, ObjectSchema::ObjectType table_type)
 {
     switch (table_type) {
-        case ObjectSchema::TableType::TopLevel:
-            o << "TopLevel";
-            break;
-        case ObjectSchema::TableType::Embedded:
-            o << "Embedded";
-            break;
-        case ObjectSchema::TableType::TopLevelAsymmetric:
-            o << "TopLevelAsymmetric";
-            break;
-        default:
-            o << "Unknown table type";
+        case ObjectSchema::ObjectType::TopLevel:
+            return o << "TopLevel";
+        case ObjectSchema::ObjectType::Embedded:
+            return o << "Embedded";
+        case ObjectSchema::ObjectType::TopLevelAsymmetric:
+            return o << "TopLevelAsymmetric";
     }
-    return o;
+    return o << "Invalid table type: " << uint8_t(table_type);
 }
 
 } // namespace realm

--- a/src/realm/object-store/object_store.cpp
+++ b/src/realm/object-store/object_store.cpp
@@ -162,18 +162,18 @@ TableRef create_table(Group& group, ObjectSchema const& object_schema)
         return table;
 
     if (auto* pk_property = object_schema.primary_key_property()) {
-        auto table_type = object_schema.table_type == ObjectSchema::TableType::TopLevelAsymmetric
+        auto table_type = object_schema.table_type == ObjectSchema::ObjectType::TopLevelAsymmetric
                               ? Table::Type::TopLevelAsymmetric
                               : Table::Type::TopLevel;
         table = group.add_table_with_primary_key(name, to_core_type(pk_property->type), pk_property->name,
                                                  is_nullable(pk_property->type), table_type);
     }
     else {
-        if (object_schema.table_type == ObjectSchema::TableType::Embedded) {
+        if (object_schema.table_type == ObjectSchema::ObjectType::Embedded) {
             table = group.add_table(name, Table::Type::Embedded);
         }
         else {
-            auto table_type = object_schema.table_type == ObjectSchema::TableType::TopLevelAsymmetric
+            auto table_type = object_schema.table_type == ObjectSchema::ObjectType::TopLevelAsymmetric
                                   ? Table::Type::TopLevelAsymmetric
                                   : Table::Type::TopLevel;
             table = group.get_or_add_table(name, table_type);

--- a/src/realm/object-store/schema.cpp
+++ b/src/realm/object-store/schema.cpp
@@ -118,7 +118,7 @@ std::string do_check(Schema const& schema, const ObjectSchema& start)
             if (prop.type == PropertyType::Object) {
                 auto it = schema.find(prop.object_type);
                 REALM_ASSERT(it != schema.end()); // this succeeds if the schema is otherwise valid
-                if (it->table_type != ObjectSchema::TableType::Embedded) {
+                if (it->table_type != ObjectSchema::ObjectType::Embedded) {
                     // the server does support links to top level objects (serialized as a PK)
                     // so if we encounter this type of link, no need to check further along this path
                     continue;
@@ -143,7 +143,7 @@ void check_for_embedded_objects_loop(Schema const& schema, std::vector<ObjectSch
     // so we only need to run this check from embedded objects. This is an optimization to exclude entire
     // object graphs which do not contain embedded objects.
     for (auto const& object : schema) {
-        if (object.table_type == ObjectSchema::TableType::Embedded) {
+        if (object.table_type == ObjectSchema::ObjectType::Embedded) {
             std::string loop = do_check(schema, object);
             if (!loop.empty()) {
                 exceptions.push_back(
@@ -157,7 +157,7 @@ std::unordered_set<std::string> get_embedded_object_orphans(const Schema& schema
 {
     std::queue<const ObjectSchema*> to_check;
     for (auto& object : schema) {
-        if (object.table_type != ObjectSchema::TableType::Embedded) {
+        if (object.table_type != ObjectSchema::ObjectType::Embedded) {
             to_check.push(&object);
         }
     }
@@ -171,7 +171,7 @@ std::unordered_set<std::string> get_embedded_object_orphans(const Schema& schema
             if (prop.type == PropertyType::Object) {
                 auto it = schema.find(prop.object_type);
                 REALM_ASSERT(it != schema.end());
-                if (it->table_type == ObjectSchema::TableType::Embedded && reachable.insert(&*it).second) {
+                if (it->table_type == ObjectSchema::ObjectType::Embedded && reachable.insert(&*it).second) {
                     to_check.push(&*it);
                 }
             }
@@ -181,7 +181,7 @@ std::unordered_set<std::string> get_embedded_object_orphans(const Schema& schema
     // Any object types which weren't found above are orphans
     std::unordered_set<std::string> orphans;
     for (auto& object : schema) {
-        if (object.table_type == ObjectSchema::TableType::Embedded && !reachable.count(&object)) {
+        if (object.table_type == ObjectSchema::ObjectType::Embedded && !reachable.count(&object)) {
             orphans.insert(object.name);
         }
     }

--- a/src/realm/object-store/schema.hpp
+++ b/src/realm/object-store/schema.hpp
@@ -22,10 +22,10 @@
 #include <string>
 #include <vector>
 
+#include <realm/object-store/object_schema.hpp>
 #include <realm/util/features.h>
 
 namespace realm {
-class ObjectSchema;
 class SchemaChange;
 class StringData;
 struct TableKey;
@@ -107,7 +107,7 @@ enum class SchemaMode : uint8_t {
     // is not linked from any top level object types is included.
     AdditiveExplicit,
 
-    // Verify that the schema version has increased, call the migraiton
+    // Verify that the schema version has increased, call the migration
     // function, and then verify that the schema now matches.
     // The migration function is mandatory for this mode.
     //
@@ -184,6 +184,8 @@ struct RemoveTable {
 
 struct ChangeTableType {
     const ObjectSchema* object;
+    const ObjectSchema::TableType* old_table_type;
+    const ObjectSchema::TableType* new_table_type;
 };
 
 struct AddInitialProperties {

--- a/src/realm/object-store/schema.hpp
+++ b/src/realm/object-store/schema.hpp
@@ -184,8 +184,8 @@ struct RemoveTable {
 
 struct ChangeTableType {
     const ObjectSchema* object;
-    const ObjectSchema::TableType* old_table_type;
-    const ObjectSchema::TableType* new_table_type;
+    const ObjectSchema::ObjectType* old_table_type;
+    const ObjectSchema::ObjectType* new_table_type;
 };
 
 struct AddInitialProperties {

--- a/src/realm/table.cpp
+++ b/src/realm/table.cpp
@@ -359,7 +359,7 @@ ColKey Table::add_column(Table& target, StringData name)
         throw LogicError(LogicError::wrong_kind_of_table);
     if (origin_group != target_group)
         throw LogicError(LogicError::group_mismatch);
-    // Outgoing links from an asymmetric table are not allowed.
+    // Only links to embedded objects are allowed.
     if (is_asymmetric() && !target.is_embedded()) {
         throw LogicError(LogicError::wrong_kind_of_table);
     }
@@ -409,8 +409,8 @@ ColKey Table::add_column_list(Table& target, StringData name)
         throw LogicError(LogicError::wrong_kind_of_table);
     if (origin_group != target_group)
         throw LogicError(LogicError::group_mismatch);
-    // Outgoing links from an asymmetric table are not allowed.
-    if (is_asymmetric()) {
+    // Only links to embedded objects are allowed.
+    if (is_asymmetric() && !target.is_embedded()) {
         throw LogicError(LogicError::wrong_kind_of_table);
     }
     // Incoming links from an asymmetric table are not allowed.
@@ -487,8 +487,8 @@ ColKey Table::add_column_dictionary(Table& target, StringData name, DataType key
         throw LogicError(LogicError::wrong_kind_of_table);
     if (origin_group != target_group)
         throw LogicError(LogicError::group_mismatch);
-    // Outgoing links from an asymmetric table are not allowed.
-    if (is_asymmetric()) {
+    // Only links to embedded objects are allowed.
+    if (is_asymmetric() && !target.is_embedded()) {
         throw LogicError(LogicError::wrong_kind_of_table);
     }
     // Incoming links from an asymmetric table are not allowed.

--- a/src/realm/table.cpp
+++ b/src/realm/table.cpp
@@ -2677,12 +2677,7 @@ void Table::schema_to_json(std::ostream& out, const std::map<std::string, std::s
         out << ",";
         out << "\"primaryKey\":\"" << this->get_column_name(m_primary_key_col) << "\"";
     }
-    if (is_embedded()) {
-        out << ",\"isEmbedded\":true";
-    }
-    if (is_asymmetric()) {
-        out << ",\"isAsymmetric\":true";
-    }
+    out << ",\"tableType\":\"" << this->get_table_type() << "\"";
     out << ",\"properties\":[";
     auto col_keys = get_column_keys();
     int sz = int(col_keys.size());

--- a/src/realm/table.hpp
+++ b/src/realm/table.hpp
@@ -868,18 +868,13 @@ inline std::ostream& operator<<(std::ostream& o, Table::Type table_type)
 {
     switch (table_type) {
         case Table::Type::TopLevel:
-            o << "TopLevel";
-            break;
+            return o << "TopLevel";
         case Table::Type::Embedded:
-            o << "Embedded";
-            break;
+            return o << "Embedded";
         case Table::Type::TopLevelAsymmetric:
-            o << "TopLevelAsymmetric";
-            break;
-        default:
-            o << "Unknown table type";
+            return o << "TopLevelAsymmetric";
     }
-    return o;
+    return o << "Invalid table type: " << uint8_t(table_type);
 }
 
 class ColKeyIterator {

--- a/src/realm/table.hpp
+++ b/src/realm/table.hpp
@@ -88,6 +88,8 @@ class Table {
 public:
     /// The type of tables supported by a realm.
     /// Note: Any change to this enum is a file-format breaking change.
+    /// Note: Enumeration value assignments must be kept in sync with
+    /// <realm/object-store/object_schema.hpp>.
     enum class Type : uint8_t { TopLevel = 0, Embedded = 0x1, TopLevelAsymmetric = 0x2 };
     constexpr static uint8_t table_type_mask = 0x3;
 
@@ -874,6 +876,8 @@ inline std::ostream& operator<<(std::ostream& o, Table::Type table_type)
         case Table::Type::TopLevelAsymmetric:
             o << "TopLevelAsymmetric";
             break;
+        default:
+            o << "Unknown table type";
     }
     return o;
 }

--- a/test/object-store/audit.cpp
+++ b/test/object-store/audit.cpp
@@ -307,7 +307,7 @@ TEST_CASE("audit object serialization") {
           {"embedded object dictionary", PropertyType::Object | PropertyType::Nullable | PropertyType::Dictionary,
            "embedded target"}}},
         {"target", {{"_id", PropertyType::Int, Property::IsPrimary{true}}, {"value", PropertyType::Int}}},
-        {"embedded target", ObjectSchema::IsEmbedded{true}, {{"value", PropertyType::Int}}}};
+        {"embedded target", ObjectSchema::TableType::Embedded, {{"value", PropertyType::Int}}}};
     config.audit_config = std::make_shared<AuditConfig>();
     auto serializer = std::make_shared<CustomSerializer>();
     config.audit_config->serializer = serializer;

--- a/test/object-store/audit.cpp
+++ b/test/object-store/audit.cpp
@@ -307,7 +307,7 @@ TEST_CASE("audit object serialization") {
           {"embedded object dictionary", PropertyType::Object | PropertyType::Nullable | PropertyType::Dictionary,
            "embedded target"}}},
         {"target", {{"_id", PropertyType::Int, Property::IsPrimary{true}}, {"value", PropertyType::Int}}},
-        {"embedded target", ObjectSchema::TableType::Embedded, {{"value", PropertyType::Int}}}};
+        {"embedded target", ObjectSchema::ObjectType::Embedded, {{"value", PropertyType::Int}}}};
     config.audit_config = std::make_shared<AuditConfig>();
     auto serializer = std::make_shared<CustomSerializer>();
     config.audit_config->serializer = serializer;

--- a/test/object-store/dictionary.cpp
+++ b/test/object-store/dictionary.cpp
@@ -854,7 +854,7 @@ TEST_CASE("embedded dictionary", "[dictionary]") {
     config.automatic_change_notifications = false;
     config.schema = Schema{
         {"origin", {{"links", PropertyType::Dictionary | PropertyType::Object | PropertyType::Nullable, "target"}}},
-        {"target", ObjectSchema::IsEmbedded{true}, {{"value", PropertyType::Int}}}};
+        {"target", ObjectSchema::TableType::Embedded, {{"value", PropertyType::Int}}}};
 
     auto r = Realm::get_shared_realm(config);
 

--- a/test/object-store/dictionary.cpp
+++ b/test/object-store/dictionary.cpp
@@ -854,7 +854,7 @@ TEST_CASE("embedded dictionary", "[dictionary]") {
     config.automatic_change_notifications = false;
     config.schema = Schema{
         {"origin", {{"links", PropertyType::Dictionary | PropertyType::Object | PropertyType::Nullable, "target"}}},
-        {"target", ObjectSchema::TableType::Embedded, {{"value", PropertyType::Int}}}};
+        {"target", ObjectSchema::ObjectType::Embedded, {{"value", PropertyType::Int}}}};
 
     auto r = Realm::get_shared_realm(config);
 

--- a/test/object-store/list.cpp
+++ b/test/object-store/list.cpp
@@ -1215,9 +1215,9 @@ TEST_CASE("embedded List") {
         {"origin",
          {{"pk", PropertyType::Int, Property::IsPrimary{true}},
           {"array", PropertyType::Array | PropertyType::Object, "target"}}},
-        {"target", ObjectSchema::TableType::Embedded, {{"value", PropertyType::Int}}},
+        {"target", ObjectSchema::ObjectType::Embedded, {{"value", PropertyType::Int}}},
         {"other_origin", {{"array", PropertyType::Array | PropertyType::Object, "other_target"}}},
-        {"other_target", ObjectSchema::TableType::Embedded, {{"value", PropertyType::Int}}},
+        {"other_target", ObjectSchema::ObjectType::Embedded, {{"value", PropertyType::Int}}},
     });
 
     auto& coordinator = *_impl::RealmCoordinator::get_coordinator(config.path);
@@ -1647,7 +1647,7 @@ TEST_CASE("list of embedded objects") {
              {"array", PropertyType::Object | PropertyType::Array, "embedded"},
          }},
         {"embedded",
-         ObjectSchema::TableType::Embedded,
+         ObjectSchema::ObjectType::Embedded,
          {
              {"value", PropertyType::Int},
          }},

--- a/test/object-store/list.cpp
+++ b/test/object-store/list.cpp
@@ -1215,9 +1215,9 @@ TEST_CASE("embedded List") {
         {"origin",
          {{"pk", PropertyType::Int, Property::IsPrimary{true}},
           {"array", PropertyType::Array | PropertyType::Object, "target"}}},
-        {"target", ObjectSchema::IsEmbedded{true}, {{"value", PropertyType::Int}}},
+        {"target", ObjectSchema::TableType::Embedded, {{"value", PropertyType::Int}}},
         {"other_origin", {{"array", PropertyType::Array | PropertyType::Object, "other_target"}}},
-        {"other_target", ObjectSchema::IsEmbedded{true}, {{"value", PropertyType::Int}}},
+        {"other_target", ObjectSchema::TableType::Embedded, {{"value", PropertyType::Int}}},
     });
 
     auto& coordinator = *_impl::RealmCoordinator::get_coordinator(config.path);
@@ -1647,7 +1647,7 @@ TEST_CASE("list of embedded objects") {
              {"array", PropertyType::Object | PropertyType::Array, "embedded"},
          }},
         {"embedded",
-         ObjectSchema::IsEmbedded{true},
+         ObjectSchema::TableType::Embedded,
          {
              {"value", PropertyType::Int},
          }},

--- a/test/object-store/object.cpp
+++ b/test/object-store/object.cpp
@@ -1939,12 +1939,12 @@ TEST_CASE("Embedded Object") {
              {"array", PropertyType::Object | PropertyType::Array, "array target"},
          }},
         {"link target",
-         ObjectSchema::IsEmbedded{true},
+         ObjectSchema::TableType::Embedded,
          {
              {"value", PropertyType::Int},
          }},
         {"array target",
-         ObjectSchema::IsEmbedded{true},
+         ObjectSchema::TableType::Embedded,
          {
              {"value", PropertyType::Int},
          }},
@@ -2171,14 +2171,14 @@ TEST_CASE("Embedded Object") {
 TEST_CASE("Asymmetric Object") {
     Schema schema{
         {"asymmetric",
-         ObjectSchema::IsAsymmetric{true},
+         ObjectSchema::TableType::TopLevelAsymmetric,
          {
              {"_id", PropertyType::Int, Property::IsPrimary{true}},
              {"location", PropertyType::Int},
              {"reading", PropertyType::Int},
          }},
         {"asymmetric_link",
-         ObjectSchema::IsAsymmetric{true},
+         ObjectSchema::TableType::TopLevelAsymmetric,
          {
              {"_id", PropertyType::Int, Property::IsPrimary{true}},
              {"location", PropertyType::Mixed | PropertyType::Nullable},

--- a/test/object-store/object.cpp
+++ b/test/object-store/object.cpp
@@ -1939,12 +1939,12 @@ TEST_CASE("Embedded Object") {
              {"array", PropertyType::Object | PropertyType::Array, "array target"},
          }},
         {"link target",
-         ObjectSchema::TableType::Embedded,
+         ObjectSchema::ObjectType::Embedded,
          {
              {"value", PropertyType::Int},
          }},
         {"array target",
-         ObjectSchema::TableType::Embedded,
+         ObjectSchema::ObjectType::Embedded,
          {
              {"value", PropertyType::Int},
          }},
@@ -2171,14 +2171,14 @@ TEST_CASE("Embedded Object") {
 TEST_CASE("Asymmetric Object") {
     Schema schema{
         {"asymmetric",
-         ObjectSchema::TableType::TopLevelAsymmetric,
+         ObjectSchema::ObjectType::TopLevelAsymmetric,
          {
              {"_id", PropertyType::Int, Property::IsPrimary{true}},
              {"location", PropertyType::Int},
              {"reading", PropertyType::Int},
          }},
         {"asymmetric_link",
-         ObjectSchema::TableType::TopLevelAsymmetric,
+         ObjectSchema::ObjectType::TopLevelAsymmetric,
          {
              {"_id", PropertyType::Int, Property::IsPrimary{true}},
              {"location", PropertyType::Mixed | PropertyType::Nullable},

--- a/test/object-store/realm.cpp
+++ b/test/object-store/realm.cpp
@@ -583,7 +583,7 @@ TEST_CASE("SharedRealm: get_shared_realm()") {
     SECTION("freeze with orphaned embedded tables") {
         auto schema = Schema{
             {"object1", {{"value", PropertyType::Int}}},
-            {"object2", ObjectSchema::TableType::Embedded, {{"value", PropertyType::Int}}},
+            {"object2", ObjectSchema::ObjectType::Embedded, {{"value", PropertyType::Int}}},
         };
         config.schema = schema;
         config.schema_mode = SchemaMode::AdditiveDiscovered;
@@ -2922,7 +2922,7 @@ TEST_CASE("SharedRealm: declaring an object as embedded results in creating an e
 
     // Prepopulate the Realm with the schema.
     config.schema = Schema{{"object1",
-                            ObjectSchema::TableType::Embedded,
+                            ObjectSchema::ObjectType::Embedded,
                             {
                                 {"value", PropertyType::Int},
                             }},

--- a/test/object-store/realm.cpp
+++ b/test/object-store/realm.cpp
@@ -583,7 +583,7 @@ TEST_CASE("SharedRealm: get_shared_realm()") {
     SECTION("freeze with orphaned embedded tables") {
         auto schema = Schema{
             {"object1", {{"value", PropertyType::Int}}},
-            {"object2", ObjectSchema::IsEmbedded{true}, {{"value", PropertyType::Int}}},
+            {"object2", ObjectSchema::TableType::Embedded, {{"value", PropertyType::Int}}},
         };
         config.schema = schema;
         config.schema_mode = SchemaMode::AdditiveDiscovered;
@@ -2922,7 +2922,7 @@ TEST_CASE("SharedRealm: declaring an object as embedded results in creating an e
 
     // Prepopulate the Realm with the schema.
     config.schema = Schema{{"object1",
-                            ObjectSchema::IsEmbedded{true},
+                            ObjectSchema::TableType::Embedded,
                             {
                                 {"value", PropertyType::Int},
                             }},

--- a/test/object-store/schema.cpp
+++ b/test/object-store/schema.cpp
@@ -58,7 +58,7 @@ struct SchemaChangePrinter {
     REALM_SC_PRINT(AddProperty, v.object, v.property)
     REALM_SC_PRINT(AddTable, v.object)
     REALM_SC_PRINT(RemoveTable, v.object)
-    REALM_SC_PRINT(ChangeTableType, v.object)
+    REALM_SC_PRINT(ChangeTableType, v.object, v.old_table_type, v.new_table_type)
     REALM_SC_PRINT(AddInitialProperties, v.object)
     REALM_SC_PRINT(ChangePrimaryKey, v.object, v.property)
     REALM_SC_PRINT(ChangePropertyType, v.object, v.old_property, v.new_property)
@@ -232,12 +232,10 @@ TEST_CASE("ObjectSchema") {
         REQUIRE(os.table_key == table->get_key());
         ObjectSchema os1(g, "embedded", {});
         REQUIRE(os1.table_key == embedded->get_key());
-        REQUIRE(os1.is_embedded);
-        REQUIRE(!os1.is_asymmetric);
+        REQUIRE(os1.table_type == ObjectSchema::TableType::Embedded);
         ObjectSchema os2(g, "asymmetric", asymmetric->get_key());
         REQUIRE(os2.table_key == asymmetric->get_key());
-        REQUIRE(os2.is_asymmetric);
-        REQUIRE(!os2.is_embedded);
+        REQUIRE(os2.table_type == ObjectSchema::TableType::TopLevelAsymmetric);
 
 #define REQUIRE_PROPERTY(name, type, ...)                                                                            \
     do {                                                                                                             \
@@ -368,10 +366,10 @@ TEST_CASE("Schema") {
         SECTION("allow asymmetric tables") {
             Schema schema = {
                 {"sensor",
-                 ObjectSchema::IsAsymmetric{true},
+                 ObjectSchema::TableType::TopLevelAsymmetric,
                  {{"_id", PropertyType::Int, Property::IsPrimary{true}}, {"reading", PropertyType::Int}}},
                 {"location",
-                 ObjectSchema::IsAsymmetric{true},
+                 ObjectSchema::TableType::TopLevelAsymmetric,
                  {{"_id", PropertyType::Int, Property::IsPrimary{true}}, {"street", PropertyType::String}}},
             };
             REQUIRE_NOTHROW(schema.validate(SchemaValidationMode::Sync));
@@ -380,7 +378,7 @@ TEST_CASE("Schema") {
         SECTION("asymmetric tables not allowed in local realm") {
             Schema schema = {
                 {"location",
-                 ObjectSchema::IsAsymmetric{true},
+                 ObjectSchema::TableType::TopLevelAsymmetric,
                  {{"_id", PropertyType::Int, Property::IsPrimary{true}}, {"street", PropertyType::String}}},
             };
             REQUIRE_THROWS_CONTAINING(schema.validate(), "Asymmetric table 'location' not allowed in a local Realm");
@@ -390,7 +388,7 @@ TEST_CASE("Schema") {
             Schema schema = {
                 {"object", {{"link", PropertyType::Object | PropertyType::Nullable, "link target"}}},
                 {"link target",
-                 ObjectSchema::IsAsymmetric{true},
+                 ObjectSchema::TableType::TopLevelAsymmetric,
                  {{"_id", PropertyType::Int, Property::IsPrimary{true}}}},
             };
             REQUIRE_THROWS_CONTAINING(
@@ -401,7 +399,7 @@ TEST_CASE("Schema") {
         SECTION("rejects link properties with asymmetric origin object") {
             Schema schema = {
                 {"object",
-                 ObjectSchema::IsAsymmetric{true},
+                 ObjectSchema::TableType::TopLevelAsymmetric,
                  {{"link", PropertyType::Object | PropertyType::Nullable, "link target"}}},
                 {"link target", {{"value", PropertyType::Int}}},
             };
@@ -413,10 +411,10 @@ TEST_CASE("Schema") {
         SECTION("allow embedded objects with asymmetric sync") {
             Schema schema = {
                 {"object",
-                 ObjectSchema::IsAsymmetric{true},
+                 ObjectSchema::TableType::TopLevelAsymmetric,
                  {{"_id", PropertyType::Int, Property::IsPrimary{true}},
                   {"link", PropertyType::Object | PropertyType::Nullable, "link target"}}},
-                {"link target", ObjectSchema::IsEmbedded{true}, {{"value", PropertyType::Int}}},
+                {"link target", ObjectSchema::TableType::Embedded, {{"value", PropertyType::Int}}},
             };
             schema.validate(SchemaValidationMode::Sync);
         }
@@ -445,7 +443,7 @@ TEST_CASE("Schema") {
 
         SECTION("allows embedded objects in lists and dictionaries") {
             Schema schema = {
-                {"target", ObjectSchema::IsEmbedded{true}, {{"value", PropertyType::Int}}},
+                {"target", ObjectSchema::TableType::Embedded, {{"value", PropertyType::Int}}},
                 {"object",
                  {
                      {"list", PropertyType::Object | PropertyType::Array, "target"},
@@ -458,7 +456,7 @@ TEST_CASE("Schema") {
 
         SECTION("rejects embedded objects in sets") {
             Schema schema = {
-                {"target", ObjectSchema::IsEmbedded{true}, {{"value", PropertyType::Int}}},
+                {"target", ObjectSchema::TableType::Embedded, {{"value", PropertyType::Int}}},
                 {"object", {{"set", PropertyType::Object | PropertyType::Set, "target"}}},
             };
             REQUIRE_THROWS_CONTAINING(schema.validate(),
@@ -469,7 +467,7 @@ TEST_CASE("Schema") {
         SECTION("rejects explicitly included embedded object orphans") {
             Schema schema = {{"target", {{"value", PropertyType::Int}}},
                              {"origin",
-                              ObjectSchema::IsEmbedded{true},
+                              ObjectSchema::TableType::Embedded,
                               {{"link", PropertyType::Object | PropertyType::Nullable, "target"}}}};
             REQUIRE_NOTHROW(schema.validate());
             REQUIRE_THROWS_CONTAINING(
@@ -478,11 +476,14 @@ TEST_CASE("Schema") {
         }
 
         SECTION("allows embedded object chains starting from a top level object") {
-            Schema schema = {
-                {"top", {{"linkA", PropertyType::Object | PropertyType::Nullable, "A"}}},
-                {"A", ObjectSchema::IsEmbedded{true}, {{"link", PropertyType::Object | PropertyType::Nullable, "B"}}},
-                {"B", ObjectSchema::IsEmbedded{true}, {{"link", PropertyType::Object | PropertyType::Nullable, "C"}}},
-                {"C", ObjectSchema::IsEmbedded{true}, {{"value", PropertyType::Int}}}};
+            Schema schema = {{"top", {{"linkA", PropertyType::Object | PropertyType::Nullable, "A"}}},
+                             {"A",
+                              ObjectSchema::TableType::Embedded,
+                              {{"link", PropertyType::Object | PropertyType::Nullable, "B"}}},
+                             {"B",
+                              ObjectSchema::TableType::Embedded,
+                              {{"link", PropertyType::Object | PropertyType::Nullable, "C"}}},
+                             {"C", ObjectSchema::TableType::Embedded, {{"value", PropertyType::Int}}}};
             REQUIRE_NOTHROW(schema.validate());
             REQUIRE_NOTHROW(schema.validate(SchemaValidationMode::RejectEmbeddedOrphans));
         }
@@ -492,7 +493,7 @@ TEST_CASE("Schema") {
                               {{"value", PropertyType::Int},
                                {"link_to_embedded_object", PropertyType::Object | PropertyType::Nullable, "origin"}}},
                              {"origin",
-                              ObjectSchema::IsEmbedded{true},
+                              ObjectSchema::TableType::Embedded,
                               {{"link", PropertyType::Object | PropertyType::Nullable, "target"}}}};
             REQUIRE_NOTHROW(schema.validate());
         }
@@ -502,14 +503,14 @@ TEST_CASE("Schema") {
                               {{"value", PropertyType::Int},
                                {"link_to_embedded_object", PropertyType::Object | PropertyType::Array, "origin"}}},
                              {"origin",
-                              ObjectSchema::IsEmbedded{true},
+                              ObjectSchema::TableType::Embedded,
                               {{"array", PropertyType::Array | PropertyType::Object, "target"}}}};
             REQUIRE_NOTHROW(schema.validate());
         }
 
         SECTION("allows linking objects from embedded to top-level") {
             Schema schema = {{"target",
-                              ObjectSchema::IsEmbedded{true},
+                              ObjectSchema::TableType::Embedded,
                               {{"value", PropertyType::Int}},
                               {{"incoming", PropertyType::Array | PropertyType::LinkingObjects, "origin", "array"}}},
                              {"origin", {{"array", PropertyType::Array | PropertyType::Object, "target"}}}};
@@ -521,7 +522,7 @@ TEST_CASE("Schema") {
                 {"TopLevelObject",
                  {{"link_to_embedded_object", PropertyType::Object | PropertyType::Nullable, "EmbeddedObject"}}},
                 {"EmbeddedObject",
-                 ObjectSchema::IsEmbedded{true},
+                 ObjectSchema::TableType::Embedded,
                  {{"link_to_top_level_object", PropertyType::Object | PropertyType::Nullable, "TopLevelObject"}}}};
             REQUIRE_NOTHROW(schema.validate());
             REQUIRE_NOTHROW(schema.validate(SchemaValidationMode::RejectEmbeddedOrphans));
@@ -533,7 +534,7 @@ TEST_CASE("Schema") {
                  {{"link_to_self", PropertyType::Object | PropertyType::Nullable, "TopLevelObject"},
                   {"link_to_embedded_object", PropertyType::Object | PropertyType::Nullable, "EmbeddedObject"}}},
                 {"EmbeddedObject",
-                 ObjectSchema::IsEmbedded{true},
+                 ObjectSchema::TableType::Embedded,
                  {{"link_to_top_level_object", PropertyType::Object | PropertyType::Nullable, "TopLevelObject"}}}};
             REQUIRE_NOTHROW(schema.validate());
         }
@@ -543,7 +544,7 @@ TEST_CASE("Schema") {
                 {"TopLevelObject",
                  {{"link_to_embedded_object", PropertyType::Object | PropertyType::Nullable, "EmbeddedObject"}}},
                 {"EmbeddedObject",
-                 ObjectSchema::IsEmbedded{true},
+                 ObjectSchema::TableType::Embedded,
                  {{"link_to_self", PropertyType::Object | PropertyType::Nullable, "EmbeddedObject"}}}};
             REQUIRE_THROWS_CONTAINING(
                 schema.validate(),
@@ -555,7 +556,7 @@ TEST_CASE("Schema") {
                 {"TopLevelObject",
                  {{"link_to_embedded_object", PropertyType::Object | PropertyType::Nullable, "EmbeddedObject"}}},
                 {"EmbeddedObject",
-                 ObjectSchema::IsEmbedded{true},
+                 ObjectSchema::TableType::Embedded,
                  {{"link_to_self", PropertyType::Object | PropertyType::Array, "EmbeddedObject"}}}};
             REQUIRE_THROWS_CONTAINING(
                 schema.validate(),
@@ -567,10 +568,10 @@ TEST_CASE("Schema") {
                 {"TopLevelObject",
                  {{"link_to_embedded_object", PropertyType::Object | PropertyType::Nullable, "EmbeddedObjectA"}}},
                 {"EmbeddedObjectA",
-                 ObjectSchema::IsEmbedded{true},
+                 ObjectSchema::TableType::Embedded,
                  {{"link_to_b", PropertyType::Object | PropertyType::Array, "EmbeddedObjectB"}}},
                 {"EmbeddedObjectB",
-                 ObjectSchema::IsEmbedded{true},
+                 ObjectSchema::TableType::Embedded,
                  {{"link_to_a", PropertyType::Object | PropertyType::Nullable, "EmbeddedObjectA"}}}};
             REQUIRE_THROWS_CONTAINING(schema.validate(), "Cycles containing embedded objects are not currently "
                                                          "supported: 'EmbeddedObjectA.link_to_b.link_to_a'");
@@ -581,14 +582,14 @@ TEST_CASE("Schema") {
                 {"TopLevelObject",
                  {{"link_to_embedded_object", PropertyType::Object | PropertyType::Nullable, "EmbeddedObjectA"}}},
                 {"EmbeddedObjectA",
-                 ObjectSchema::IsEmbedded{true},
+                 ObjectSchema::TableType::Embedded,
                  {{"link_to_c", PropertyType::Object | PropertyType::Array, "EmbeddedObjectC"},
                   {"link_to_b", PropertyType::Object | PropertyType::Array, "EmbeddedObjectB"}}},
                 {"EmbeddedObjectB",
-                 ObjectSchema::IsEmbedded{true},
+                 ObjectSchema::TableType::Embedded,
                  {{"link_to_a", PropertyType::Object | PropertyType::Nullable, "EmbeddedObjectA"}}},
                 {"EmbeddedObjectC",
-                 ObjectSchema::IsEmbedded{true},
+                 ObjectSchema::TableType::Embedded,
                  {{"link_to_a", PropertyType::Object | PropertyType::Nullable, "EmbeddedObjectA"}}}};
             std::string message;
             try {
@@ -616,10 +617,10 @@ TEST_CASE("Schema") {
                 {"TopLevelObjectB",
                  {{"link_to_top_a", PropertyType::Object | PropertyType::Nullable, "TopLevelObjectA"}}},
                 {"EmbeddedObjectA",
-                 ObjectSchema::IsEmbedded{true},
+                 ObjectSchema::TableType::Embedded,
                  {{"link_to_b", PropertyType::Object | PropertyType::Array, "TopLevelObjectB"}}},
                 {"EmbeddedObjectB",
-                 ObjectSchema::IsEmbedded{true},
+                 ObjectSchema::TableType::Embedded,
                  {{"link_to_a", PropertyType::Object | PropertyType::Nullable, "EmbeddedObjectA"}}}};
             REQUIRE_NOTHROW(schema.validate());
             REQUIRE_NOTHROW(schema.validate(SchemaValidationMode::RejectEmbeddedOrphans));
@@ -630,7 +631,7 @@ TEST_CASE("Schema") {
                 {"TopLevelObjectA",
                  {{"link1_to_embedded", PropertyType::Object | PropertyType::Nullable, "EmbeddedObjectA"},
                   {"link2_to_embedded", PropertyType::Object | PropertyType::Nullable, "EmbeddedObjectA"}}},
-                {"EmbeddedObjectA", ObjectSchema::IsEmbedded{true}, {{"prop", PropertyType::Int}}},
+                {"EmbeddedObjectA", ObjectSchema::TableType::Embedded, {{"prop", PropertyType::Int}}},
             };
             REQUIRE_NOTHROW(schema.validate());
             REQUIRE_NOTHROW(schema.validate(SchemaValidationMode::RejectEmbeddedOrphans));
@@ -642,15 +643,15 @@ TEST_CASE("Schema") {
                  {{"link_to_embedded_A", PropertyType::Object | PropertyType::Nullable, "EmbeddedObjectA"},
                   {"link_to_embedded_B", PropertyType::Object | PropertyType::Nullable, "EmbeddedObjectB"}}},
                 {"EmbeddedObjectA",
-                 ObjectSchema::IsEmbedded{true},
+                 ObjectSchema::TableType::Embedded,
                  {{"link_to_c", PropertyType::Object | PropertyType::Nullable, "EmbeddedObjectC"},
                   {"link_to_b", PropertyType::Object | PropertyType::Nullable, "EmbeddedObjectB"}}},
                 {"EmbeddedObjectB",
-                 ObjectSchema::IsEmbedded{true},
+                 ObjectSchema::TableType::Embedded,
                  {
                      {"link_to_c", PropertyType::Object | PropertyType::Nullable, "EmbeddedObjectC"},
                  }},
-                {"EmbeddedObjectC", ObjectSchema::IsEmbedded{true}, {{"prop", PropertyType::Int}}}
+                {"EmbeddedObjectC", ObjectSchema::TableType::Embedded, {{"prop", PropertyType::Int}}}
 
             };
             REQUIRE_NOTHROW(schema.validate());
@@ -824,7 +825,7 @@ TEST_CASE("Schema") {
 
         SECTION("rejects primary key on embedded table") {
             Schema schema = {{"object",
-                              ObjectSchema::IsEmbedded{true},
+                              ObjectSchema::TableType::Embedded,
                               {
                                   {"pk1", PropertyType::Int, Property::IsPrimary{true}},
                                   {"int", PropertyType::Int},
@@ -1076,7 +1077,7 @@ TEST_CASE("Schema") {
             Schema schema1 = {{"object 1", {{"int", PropertyType::Int}}}};
             Schema schema2 = {
                 {"object 1", {{"int", PropertyType::Int}}},
-                {"object 2", ObjectSchema::IsEmbedded{true}, {{"int", PropertyType::Int}}},
+                {"object 2", ObjectSchema::TableType::Embedded, {{"int", PropertyType::Int}}},
             };
 
             SECTION("AdditiveDiscovered") {
@@ -1097,9 +1098,9 @@ TEST_CASE("Schema") {
         }
 
         SECTION("add property to orphaned table") {
-            Schema schema1 = {{"object", ObjectSchema::IsEmbedded{true}, {{"int 1", PropertyType::Int}}}};
+            Schema schema1 = {{"object", ObjectSchema::TableType::Embedded, {{"int 1", PropertyType::Int}}}};
             Schema schema2 = {{"object",
-                               ObjectSchema::IsEmbedded{true},
+                               ObjectSchema::TableType::Embedded,
                                {{"int 1", PropertyType::Int}, {"int 2", PropertyType::Int}}}};
 
             SECTION("AdditiveDiscovered") {
@@ -1205,7 +1206,7 @@ TEST_CASE("Schema") {
         REQUIRE(os.table_key == table->get_key());
         ObjectSchema os1(g, "embedded", {});
         REQUIRE(os1.table_key == embedded->get_key());
-        REQUIRE(os1.is_embedded);
+        REQUIRE(os1.table_type == ObjectSchema::TableType::Embedded);
 
         Schema schema = {os, os1};
         REQUIRE_NOTHROW(schema.validate());

--- a/test/object-store/sync/app.cpp
+++ b/test/object-store/sync/app.cpp
@@ -1697,17 +1697,17 @@ TEST_CASE("app: set new embedded object", "[sync][app]") {
               "TopLevel_embedded_dict"},
          }},
         {"TopLevel_array_of_objs",
-         ObjectSchema::IsEmbedded{true},
+         ObjectSchema::TableType::Embedded,
          {
              {"array", PropertyType::Int | PropertyType::Array},
          }},
         {"TopLevel_embedded_obj",
-         ObjectSchema::IsEmbedded{true},
+         ObjectSchema::TableType::Embedded,
          {
              {"array", PropertyType::Int | PropertyType::Array},
          }},
         {"TopLevel_embedded_dict",
-         ObjectSchema::IsEmbedded{true},
+         ObjectSchema::TableType::Embedded,
          {
              {"array", PropertyType::Int | PropertyType::Array},
          }},

--- a/test/object-store/sync/app.cpp
+++ b/test/object-store/sync/app.cpp
@@ -1697,17 +1697,17 @@ TEST_CASE("app: set new embedded object", "[sync][app]") {
               "TopLevel_embedded_dict"},
          }},
         {"TopLevel_array_of_objs",
-         ObjectSchema::TableType::Embedded,
+         ObjectSchema::ObjectType::Embedded,
          {
              {"array", PropertyType::Int | PropertyType::Array},
          }},
         {"TopLevel_embedded_obj",
-         ObjectSchema::TableType::Embedded,
+         ObjectSchema::ObjectType::Embedded,
          {
              {"array", PropertyType::Int | PropertyType::Array},
          }},
         {"TopLevel_embedded_dict",
-         ObjectSchema::TableType::Embedded,
+         ObjectSchema::ObjectType::Embedded,
          {
              {"array", PropertyType::Int | PropertyType::Array},
          }},

--- a/test/object-store/sync/client_reset.cpp
+++ b/test/object-store/sync/client_reset.cpp
@@ -2661,7 +2661,7 @@ TEST_CASE("client reset with embedded object", "[client reset][local][embedded o
               "EmbeddedObject"},
          }},
         {"EmbeddedObject",
-         ObjectSchema::TableType::Embedded,
+         ObjectSchema::ObjectType::Embedded,
          {
              {"array", PropertyType::Int | PropertyType::Array},
              {"name", PropertyType::String | PropertyType::Nullable},
@@ -2670,7 +2670,7 @@ TEST_CASE("client reset with embedded object", "[client reset][local][embedded o
              {"int_value", PropertyType::Int},
          }},
         {"EmbeddedObject2",
-         ObjectSchema::TableType::Embedded,
+         ObjectSchema::ObjectType::Embedded,
          {
              {"notes", PropertyType::String | PropertyType::Dictionary | PropertyType::Nullable},
              {"set_of_ids", PropertyType::Set | PropertyType::ObjectId | PropertyType::Nullable},

--- a/test/object-store/sync/client_reset.cpp
+++ b/test/object-store/sync/client_reset.cpp
@@ -2661,7 +2661,7 @@ TEST_CASE("client reset with embedded object", "[client reset][local][embedded o
               "EmbeddedObject"},
          }},
         {"EmbeddedObject",
-         ObjectSchema::IsEmbedded{true},
+         ObjectSchema::TableType::Embedded,
          {
              {"array", PropertyType::Int | PropertyType::Array},
              {"name", PropertyType::String | PropertyType::Nullable},
@@ -2670,7 +2670,7 @@ TEST_CASE("client reset with embedded object", "[client reset][local][embedded o
              {"int_value", PropertyType::Int},
          }},
         {"EmbeddedObject2",
-         ObjectSchema::IsEmbedded{true},
+         ObjectSchema::TableType::Embedded,
          {
              {"notes", PropertyType::String | PropertyType::Dictionary | PropertyType::Nullable},
              {"set_of_ids", PropertyType::Set | PropertyType::ObjectId | PropertyType::Nullable},

--- a/test/object-store/sync/flx_sync.cpp
+++ b/test/object-store/sync/flx_sync.cpp
@@ -83,7 +83,7 @@ const Schema g_simple_embedded_obj_schema{
       {"queryable_str_field", PropertyType::String | PropertyType::Nullable},
       {"embedded_obj", PropertyType::Object | PropertyType::Nullable, "TopLevel_embedded_obj"}}},
     {"TopLevel_embedded_obj",
-     ObjectSchema::TableType::Embedded,
+     ObjectSchema::ObjectType::Embedded,
      {
          {"str_field", PropertyType::String | PropertyType::Nullable},
      }},
@@ -1644,14 +1644,14 @@ TEST_CASE("flx: asymmetric sync", "[sync][flx][app]") {
         server_schema.queryable_fields = {"queryable_str_field"};
         server_schema.schema = {
             {"Asymmetric",
-             ObjectSchema::TableType::TopLevelAsymmetric,
+             ObjectSchema::ObjectType::TopLevelAsymmetric,
              {
                  {"_id", PropertyType::ObjectId, Property::IsPrimary{true}},
                  {"location", PropertyType::String | PropertyType::Nullable},
                  {"embedded_obj", PropertyType::Object | PropertyType::Nullable, "Embedded"},
              }},
             {"Embedded",
-             ObjectSchema::TableType::Embedded,
+             ObjectSchema::ObjectType::Embedded,
              {
                  {"value", PropertyType::String | PropertyType::Nullable},
              }},
@@ -1769,7 +1769,7 @@ TEST_CASE("flx: asymmetric sync", "[sync][flx][app]") {
 
     SECTION("open with schema mismatch on IsAsymmetric") {
         auto schema = server_schema.schema;
-        schema.find("Asymmetric")->table_type = ObjectSchema::TableType::TopLevel;
+        schema.find("Asymmetric")->table_type = ObjectSchema::ObjectType::TopLevel;
 
         harness->do_with_new_user([&](std::shared_ptr<SyncUser> user) {
             SyncTestFile config(user, schema, SyncConfig::FLXSyncEnabled{});
@@ -1854,7 +1854,7 @@ TEST_CASE("flx: asymmetric sync - dev mode", "[sync][flx][app]") {
     server_schema.schema = Schema{};
 
     auto schema = Schema{{"Asymmetric",
-                          ObjectSchema::TableType::TopLevelAsymmetric,
+                          ObjectSchema::ObjectType::TopLevelAsymmetric,
                           {
                               {"_id", PropertyType::ObjectId, Property::IsPrimary{true}},
                               {"location", PropertyType::String | PropertyType::Nullable},

--- a/test/object-store/sync/flx_sync.cpp
+++ b/test/object-store/sync/flx_sync.cpp
@@ -83,7 +83,7 @@ const Schema g_simple_embedded_obj_schema{
       {"queryable_str_field", PropertyType::String | PropertyType::Nullable},
       {"embedded_obj", PropertyType::Object | PropertyType::Nullable, "TopLevel_embedded_obj"}}},
     {"TopLevel_embedded_obj",
-     ObjectSchema::IsEmbedded{true},
+     ObjectSchema::TableType::Embedded,
      {
          {"str_field", PropertyType::String | PropertyType::Nullable},
      }},
@@ -1644,14 +1644,14 @@ TEST_CASE("flx: asymmetric sync", "[sync][flx][app]") {
         server_schema.queryable_fields = {"queryable_str_field"};
         server_schema.schema = {
             {"Asymmetric",
-             ObjectSchema::IsAsymmetric{true},
+             ObjectSchema::TableType::TopLevelAsymmetric,
              {
                  {"_id", PropertyType::ObjectId, Property::IsPrimary{true}},
                  {"location", PropertyType::String | PropertyType::Nullable},
                  {"embedded_obj", PropertyType::Object | PropertyType::Nullable, "Embedded"},
              }},
             {"Embedded",
-             ObjectSchema::IsEmbedded{true},
+             ObjectSchema::TableType::Embedded,
              {
                  {"value", PropertyType::String | PropertyType::Nullable},
              }},
@@ -1769,7 +1769,7 @@ TEST_CASE("flx: asymmetric sync", "[sync][flx][app]") {
 
     SECTION("open with schema mismatch on IsAsymmetric") {
         auto schema = server_schema.schema;
-        schema.find("Asymmetric")->is_asymmetric = ObjectSchema::IsAsymmetric{false};
+        schema.find("Asymmetric")->table_type = ObjectSchema::TableType::TopLevel;
 
         harness->do_with_new_user([&](std::shared_ptr<SyncUser> user) {
             SyncTestFile config(user, schema, SyncConfig::FLXSyncEnabled{});

--- a/test/object-store/sync/flx_sync_harness.hpp
+++ b/test/object-store/sync/flx_sync_harness.hpp
@@ -93,7 +93,7 @@ public:
         auto realm = Realm::get_shared_realm(config);
         auto mut_subs = realm->get_latest_subscription_set().make_mutable_copy();
         for (const auto& table : realm->schema()) {
-            if (table.is_asymmetric || table.is_embedded) {
+            if (table.table_type != ObjectSchema::TableType::TopLevel) {
                 continue;
             }
             Query query_for_table(realm->read_group().get_table(table.table_key));

--- a/test/object-store/sync/flx_sync_harness.hpp
+++ b/test/object-store/sync/flx_sync_harness.hpp
@@ -93,7 +93,7 @@ public:
         auto realm = Realm::get_shared_realm(config);
         auto mut_subs = realm->get_latest_subscription_set().make_mutable_copy();
         for (const auto& table : realm->schema()) {
-            if (table.table_type != ObjectSchema::TableType::TopLevel) {
+            if (table.table_type != ObjectSchema::ObjectType::TopLevel) {
                 continue;
             }
             Query query_for_table(realm->read_group().get_table(table.table_key));

--- a/test/object-store/util/baas_admin_api.cpp
+++ b/test/object-store/util/baas_admin_api.cpp
@@ -128,7 +128,7 @@ nlohmann::json BaasRuleBuilder::property_to_jsonschema(const Property& prop, con
         auto target_obj = m_schema.find(prop.object_type);
         REALM_ASSERT(target_obj != m_schema.end());
 
-        if (target_obj->is_embedded) {
+        if (target_obj->table_type == ObjectSchema::TableType::Embedded) {
             m_current_path.push_back(prop.name);
             if (is_collection(prop.type)) {
                 m_current_path.push_back("[]");
@@ -902,7 +902,7 @@ AppSession create_app(const AppCreateConfig& config)
         std::copy(queryable_fields_src.begin(), queryable_fields_src.end(), std::back_inserter(queryable_fields));
         auto asymmetric_tables = nlohmann::json::array();
         for (const auto& obj_schema : config.schema) {
-            if (obj_schema.is_asymmetric) {
+            if (obj_schema.table_type == ObjectSchema::TableType::TopLevelAsymmetric) {
                 asymmetric_tables.emplace_back(obj_schema.name);
             }
         }
@@ -1062,7 +1062,7 @@ TEST_CASE("app: baas admin api", "[sync][app]") {
                        {{"_id", PropertyType::String, true},
                         {"location", PropertyType::Object | PropertyType::Nullable, "location"}}},
                       {"location",
-                       ObjectSchema::IsEmbedded{true},
+                       ObjectSchema::TableType::Embedded,
                        {{"coordinates", PropertyType::Double | PropertyType::Array}}}};
 
         auto test_app_config = minimal_app_config(base_url, "test", schema);
@@ -1074,7 +1074,9 @@ TEST_CASE("app: baas admin api", "[sync][app]") {
             {"a",
              {{"_id", PropertyType::String, true},
               {"b_link", PropertyType::Object | PropertyType::Array | PropertyType::Nullable, "b"}}},
-            {"b", ObjectSchema::IsEmbedded{true}, {{"c_link", PropertyType::Object | PropertyType::Nullable, "c"}}},
+            {"b",
+             ObjectSchema::TableType::Embedded,
+             {{"c_link", PropertyType::Object | PropertyType::Nullable, "c"}}},
             {"c", {{"_id", PropertyType::String, true}, {"d_str", PropertyType::String}}},
         };
         auto test_app_config = minimal_app_config(base_url, "test", schema);

--- a/test/object-store/util/baas_admin_api.cpp
+++ b/test/object-store/util/baas_admin_api.cpp
@@ -128,7 +128,7 @@ nlohmann::json BaasRuleBuilder::property_to_jsonschema(const Property& prop, con
         auto target_obj = m_schema.find(prop.object_type);
         REALM_ASSERT(target_obj != m_schema.end());
 
-        if (target_obj->table_type == ObjectSchema::TableType::Embedded) {
+        if (target_obj->table_type == ObjectSchema::ObjectType::Embedded) {
             m_current_path.push_back(prop.name);
             if (is_collection(prop.type)) {
                 m_current_path.push_back("[]");
@@ -902,7 +902,7 @@ AppSession create_app(const AppCreateConfig& config)
         std::copy(queryable_fields_src.begin(), queryable_fields_src.end(), std::back_inserter(queryable_fields));
         auto asymmetric_tables = nlohmann::json::array();
         for (const auto& obj_schema : config.schema) {
-            if (obj_schema.table_type == ObjectSchema::TableType::TopLevelAsymmetric) {
+            if (obj_schema.table_type == ObjectSchema::ObjectType::TopLevelAsymmetric) {
                 asymmetric_tables.emplace_back(obj_schema.name);
             }
         }
@@ -1062,7 +1062,7 @@ TEST_CASE("app: baas admin api", "[sync][app]") {
                        {{"_id", PropertyType::String, true},
                         {"location", PropertyType::Object | PropertyType::Nullable, "location"}}},
                       {"location",
-                       ObjectSchema::TableType::Embedded,
+                       ObjectSchema::ObjectType::Embedded,
                        {{"coordinates", PropertyType::Double | PropertyType::Array}}}};
 
         auto test_app_config = minimal_app_config(base_url, "test", schema);
@@ -1075,7 +1075,7 @@ TEST_CASE("app: baas admin api", "[sync][app]") {
              {{"_id", PropertyType::String, true},
               {"b_link", PropertyType::Object | PropertyType::Array | PropertyType::Nullable, "b"}}},
             {"b",
-             ObjectSchema::TableType::Embedded,
+             ObjectSchema::ObjectType::Embedded,
              {{"c_link", PropertyType::Object | PropertyType::Nullable, "c"}}},
             {"c", {{"_id", PropertyType::String, true}, {"d_str", PropertyType::String}}},
         };

--- a/test/test_embedded_objects.cpp
+++ b/test/test_embedded_objects.cpp
@@ -40,6 +40,38 @@ TEST(EmbeddedObjects_Basic)
     CHECK(compare_groups(read_server, read_client_2));
 }
 
+TEST(AsymmetricTable_EmbeddedObjects_Basic)
+{
+    auto changeset_dump_dir_gen = get_changeset_dump_dir_generator(test_context);
+    auto server = Peer::create_server(test_context, changeset_dump_dir_gen.get());
+    auto client_1 = Peer::create_client(test_context, 2, changeset_dump_dir_gen.get());
+    auto client_2 = Peer::create_client(test_context, 3, changeset_dump_dir_gen.get());
+
+    client_1->create_schema([](WriteTransaction& tr) {
+        TableRef top = tr.get_group().add_table_with_primary_key("class_Top", type_Int, "pk", false,
+                                                                 Table::Type::TopLevelAsymmetric);
+        TableRef sub = tr.add_table("class_Sub", Table::Type::Embedded);
+        top->add_column(*sub, "sub");
+        sub->add_column(type_Int, "i");
+    });
+
+    client_1->transaction([&](auto& c) {
+        auto& tr = *c.group;
+        auto top = tr.get_table("class_Top");
+        auto top_obj = top->create_object_with_primary_key(123);
+        auto sub_col = top->get_column_key("sub");
+        top_obj.create_and_set_linked_object(sub_col).set("i", 1);
+    });
+
+    synchronize(server.get(), {client_1.get(), client_2.get()});
+
+    ReadTransaction read_server(server->shared_group);
+    ReadTransaction read_client_1(client_1->shared_group);
+    ReadTransaction read_client_2(client_2->shared_group);
+    CHECK(compare_groups(read_server, read_client_1, test_context.logger));
+    CHECK(compare_groups(read_server, read_client_2));
+}
+
 TEST(Table_EmbeddedObjectsCircular)
 {
     auto changeset_dump_dir_gen = get_changeset_dump_dir_generator(test_context);
@@ -103,6 +135,41 @@ TEST(EmbeddedObjects_ArrayOfObjects)
     CHECK(compare_groups(read_server, read_client_2));
 }
 
+TEST(AsymmetricTable_EmbeddedObjects_ArrayOfObjects)
+{
+    auto changeset_dump_dir_gen = get_changeset_dump_dir_generator(test_context);
+    auto server = Peer::create_server(test_context, changeset_dump_dir_gen.get());
+    auto client_1 = Peer::create_client(test_context, 2, changeset_dump_dir_gen.get());
+    auto client_2 = Peer::create_client(test_context, 3, changeset_dump_dir_gen.get());
+
+    client_1->create_schema([](WriteTransaction& tr) {
+        TableRef top = tr.get_group().add_table_with_primary_key("class_Top", type_Int, "pk", false,
+                                                                 Table::Type::TopLevelAsymmetric);
+        TableRef sub = tr.add_table("class_Sub", Table::Type::Embedded);
+        top->add_column_list(*sub, "sub");
+        sub->add_column(type_Int, "i");
+    });
+
+    client_1->transaction([&](auto& c) {
+        auto& tr = *c.group;
+        auto top = tr.get_table("class_Top");
+        auto top_obj = top->create_object_with_primary_key(123);
+        auto sub_col = top->get_column_key("sub");
+        auto obj_list = top_obj.get_linklist(sub_col);
+        for (size_t i = 0; i < 10; ++i) {
+            obj_list.create_and_insert_linked_object(i).set("i", int64_t(i));
+        }
+    });
+
+    synchronize(server.get(), {client_1.get(), client_2.get()});
+
+    ReadTransaction read_server(server->shared_group);
+    ReadTransaction read_client_1(client_1->shared_group);
+    ReadTransaction read_client_2(client_2->shared_group);
+    CHECK(compare_groups(read_server, read_client_1, test_context.logger));
+    CHECK(compare_groups(read_server, read_client_2));
+}
+
 TEST(EmbeddedObjects_DictionaryOfObjects)
 {
     auto changeset_dump_dir_gen = get_changeset_dump_dir_generator(test_context);
@@ -112,6 +179,41 @@ TEST(EmbeddedObjects_DictionaryOfObjects)
 
     client_1->create_schema([](WriteTransaction& tr) {
         TableRef top = tr.get_group().add_table_with_primary_key("class_Top", type_Int, "pk");
+        TableRef sub = tr.add_table("class_Sub", Table::Type::Embedded);
+        top->add_column_dictionary(*sub, "sub");
+        sub->add_column(type_Int, "i");
+    });
+
+    client_1->transaction([&](auto& c) {
+        auto& tr = *c.group;
+        auto top = tr.get_table("class_Top");
+        auto top_obj = top->create_object_with_primary_key(123);
+        auto sub_col = top->get_column_key("sub");
+        auto dict = top_obj.get_dictionary(sub_col);
+        for (int64_t i = 0; i < 10; ++i) {
+            dict.create_and_insert_linked_object(util::to_string(i)).set("i", i);
+        }
+    });
+
+    synchronize(server.get(), {client_1.get(), client_2.get()});
+
+    ReadTransaction read_server(server->shared_group);
+    ReadTransaction read_client_1(client_1->shared_group);
+    ReadTransaction read_client_2(client_2->shared_group);
+    CHECK(compare_groups(read_server, read_client_1, test_context.logger));
+    CHECK(compare_groups(read_server, read_client_2));
+}
+
+TEST(AsymmetricTable_EmbeddedObjects_DictionaryOfObjects)
+{
+    auto changeset_dump_dir_gen = get_changeset_dump_dir_generator(test_context);
+    auto server = Peer::create_server(test_context, changeset_dump_dir_gen.get());
+    auto client_1 = Peer::create_client(test_context, 2, changeset_dump_dir_gen.get());
+    auto client_2 = Peer::create_client(test_context, 3, changeset_dump_dir_gen.get());
+
+    client_1->create_schema([](WriteTransaction& tr) {
+        TableRef top = tr.get_group().add_table_with_primary_key("class_Top", type_Int, "pk", false,
+                                                                 Table::Type::TopLevelAsymmetric);
         TableRef sub = tr.add_table("class_Sub", Table::Type::Embedded);
         top->add_column_dictionary(*sub, "sub");
         sub->add_column(type_Int, "i");

--- a/test/test_json.cpp
+++ b/test/test_json.cpp
@@ -847,14 +847,14 @@ TEST(Json_Schema)
     const std::string json = ss.str();
     std::string expected =
         "[\n"
-        "{\"name\":\"person\",\"properties\":["
+        "{\"name\":\"person\",\"tableType\":\"TopLevel\",\"properties\":["
         "{\"name\":\"name\",\"type\":\"string\"},"
         "{\"name\":\"isMarried\",\"type\":\"bool\"},"
         "{\"name\":\"age\",\"type\":\"int\",\"isOptional\":true},"
         "{\"name\":\"dates\",\"type\":\"timestamp\",\"isArray\":true},"
         "{\"name\":\"pet\",\"type\":\"object\",\"objectType\":\"dog\",\"isArray\":true}"
         "]},\n"
-        "{\"name\":\"dog\",\"isEmbedded\":true,\"properties\":[{\"name\":\"name\",\"type\":\"string\"}]}\n"
+        "{\"name\":\"dog\",\"tableType\":\"Embedded\",\"properties\":[{\"name\":\"name\",\"type\":\"string\"}]}\n"
         "]\n";
     CHECK_EQUAL(expected, json);
 }


### PR DESCRIPTION
## What, How & Why?
This PR fixes and improves several things around asymmetric sync.

- The bug in RCORE-1120 resulted as an implementation oversight due to using boolean values for asymmetric and embedded properties in ObjectSchema. This is now replaced by an Enum value.
- Migration tests were added to make sure it is not allowed to migrate to or from an asymmetric table.
- Asymmetric objects can now contain lists and dictionaries of embedded objects.
- Integration test was added to validate an asymmetric table can be added in development mode.

Fixes RCORE-1120.

(Commits are logically separated to make review easier)

## ☑️ ToDos
* [x] 📝 Changelog update
* [x] 🚦 Tests (or not relevant)
* ~~[ ] C-API, if public C++ API changed.~~
