### PR TITLE
Recovery benchmarks

### DIFF
--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -1,12 +1,11 @@
 add_subdirectory(util)
+add_custom_target(benchmarks)
 add_subdirectory(object-store)
 
 # AFL not yet supported by Windows
 if(NOT CMAKE_SYSTEM_NAME MATCHES "^Windows")
     add_subdirectory(fuzzy)
 endif()
-
-add_custom_target(benchmarks)
 
 add_subdirectory(benchmark-common-tasks)
 add_subdirectory(benchmark-crud)

--- a/test/object-store/benchmarks/CMakeLists.txt
+++ b/test/object-store/benchmarks/CMakeLists.txt
@@ -31,7 +31,6 @@ endif()
 add_executable(object-store-benchmarks ${SOURCES} ${HEADERS})
 
 target_include_directories(object-store-benchmarks PRIVATE 
-    ${CATCH_INCLUDE_DIR}
     ..
 )
 
@@ -43,3 +42,5 @@ target_link_libraries(object-store-benchmarks ObjectStore Catch2::Catch2)
 set_target_properties(object-store-benchmarks PROPERTIES
       EXCLUDE_FROM_ALL 1
       EXCLUDE_FROM_DEFAULT_BUILD 1)
+
+add_dependencies(benchmarks object-store-benchmarks)

--- a/test/object-store/benchmarks/CMakeLists.txt
+++ b/test/object-store/benchmarks/CMakeLists.txt
@@ -10,6 +10,7 @@ set(SOURCES
     object.cpp
     results.cpp
 
+    ../../util/crypt_key.cpp
     ../util/event_loop.cpp
     ../util/test_file.cpp
     ../util/test_utils.cpp
@@ -38,7 +39,7 @@ if(REALM_ENABLE_SYNC)
     target_link_libraries(object-store-benchmarks SyncServer)
 endif()
 
-target_link_libraries(object-store-benchmarks ObjectStore)
+target_link_libraries(object-store-benchmarks ObjectStore Catch2::Catch2)
 set_target_properties(object-store-benchmarks PROPERTIES
       EXCLUDE_FROM_ALL 1
       EXCLUDE_FROM_DEFAULT_BUILD 1)

--- a/test/object-store/benchmarks/main.cpp
+++ b/test/object-store/benchmarks/main.cpp
@@ -27,6 +27,7 @@
 #pragma comment(lib, "Shlwapi.lib")
 #else
 #include <libgen.h>
+#include <unistd.h>
 #endif
 
 int main(int argc, char** argv)

--- a/test/object-store/benchmarks/object.cpp
+++ b/test/object-store/benchmarks/object.cpp
@@ -76,17 +76,17 @@ struct TestContext : CppContext {
 TEST_CASE("Benchmark index change calculations", "[benchmark]") {
     _impl::CollectionChangeBuilder c;
 
-    auto all_modified = [](size_t) {
+    auto all_modified = [](ObjKey) {
         return true;
     };
-    auto none_modified = [](size_t) {
+    auto none_modified = [](ObjKey) {
         return false;
     };
 
     SECTION("reports inserts/deletes for simple reorderings") {
-        auto calc = [&](std::vector<int64_t> old_rows, std::vector<int64_t> new_rows,
-                        util::UniqueFunction<bool(size_t)> modifications) {
-            return _impl::CollectionChangeBuilder::calculate(old_rows, new_rows, std::move(modifications), false);
+        auto calc = [&](const ObjKeys& old_keys, const ObjKeys& new_keys,
+                        util::UniqueFunction<bool(ObjKey)> modifications) {
+            return _impl::CollectionChangeBuilder::calculate(old_keys, new_keys, std::move(modifications), false);
         };
         std::vector<int64_t> indices = {};
         constexpr size_t indices_size = 10000;
@@ -94,17 +94,18 @@ TEST_CASE("Benchmark index change calculations", "[benchmark]") {
         for (size_t i = 0; i < indices_size; ++i) {
             indices.push_back(i);
         }
+        ObjKeys objkeys(indices);
 
         BENCHMARK("no changes")
         {
-            c = calc(indices, indices, none_modified);
+            c = calc(objkeys, objkeys, none_modified);
         };
         REQUIRE(c.insertions.empty());
         REQUIRE(c.deletions.empty());
 
         BENCHMARK("all modified")
         {
-            c = calc(indices, indices, all_modified);
+            c = calc(objkeys, objkeys, all_modified);
         };
         REQUIRE(c.insertions.empty());
         REQUIRE(c.deletions.empty());


### PR DESCRIPTION
Update the object store benchmarks to fix build errors and add some basic recovery benchmarks.

Fixes https://github.com/realm/realm-core/issues/5291

Baseline results from my local machine:

```
Filters: client reset
Randomness seeded to: 330187956

~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
object-store-benchmarks is a Catch2 v3.0.1 host application.
Run with -? for options

-------------------------------------------------------------------------------
client reset
  DiscardLocal: from empty initial state
-------------------------------------------------------------------------------
/Users/js/Documents/code/realm-core2/test/object-store/benchmarks/client_reset.cpp:279
...............................................................................

benchmark name                       samples       iterations    estimated
                                     mean          low mean      high mean
                                     std dev       low std dev   high std dev
-------------------------------------------------------------------------------
no changes                                     100             1     23.687 ms 
                                        263.789 us    252.516 us    279.768 us 
                                        68.0198 us    53.1203 us    96.3599 us 
                                                                               

-------------------------------------------------------------------------------
client reset
  DiscardLocal: populated with 10000 simple objects
  no change
-------------------------------------------------------------------------------
/Users/js/Documents/code/realm-core2/test/object-store/benchmarks/client_reset.cpp:291
...............................................................................

benchmark name                       samples       iterations    estimated
                                     mean          low mean      high mean
                                     std dev       low std dev   high std dev
-------------------------------------------------------------------------------
reset                                          100             1     17.3413 s 
                                        181.243 ms    174.106 ms    206.805 ms 
                                        61.5231 ms    16.0201 ms    141.038 ms 
                                                                               

-------------------------------------------------------------------------------
client reset
  DiscardLocal: populated with 10000 simple objects
  remote removes half the local data
-------------------------------------------------------------------------------
/Users/js/Documents/code/realm-core2/test/object-store/benchmarks/client_reset.cpp:297
...............................................................................

benchmark name                       samples       iterations    estimated
                                     mean          low mean      high mean
                                     std dev       low std dev   high std dev
-------------------------------------------------------------------------------
reset                                          100             1     26.9028 s 
                                        263.785 ms     256.27 ms    283.651 ms 
                                        57.9082 ms    27.1336 ms     121.87 ms 
                                                                               

-------------------------------------------------------------------------------
client reset
  DiscardLocal: populated with 10000 simple objects
  local removes half the objects
-------------------------------------------------------------------------------
/Users/js/Documents/code/realm-core2/test/object-store/benchmarks/client_reset.cpp:306
...............................................................................

benchmark name                       samples       iterations    estimated
                                     mean          low mean      high mean
                                     std dev       low std dev   high std dev
-------------------------------------------------------------------------------
reset                                          100             1     1.18796 m 
                                          610.4 ms    607.054 ms    614.476 ms 
                                        18.8551 ms    15.6103 ms    23.5826 ms 
                                                                               

-------------------------------------------------------------------------------
client reset
  DiscardLocal: 5000 source objects linked to 5000 dest objects
  no change
-------------------------------------------------------------------------------
/Users/js/Documents/code/realm-core2/test/object-store/benchmarks/client_reset.cpp:323
...............................................................................

benchmark name                       samples       iterations    estimated
                                     mean          low mean      high mean
                                     std dev       low std dev   high std dev
-------------------------------------------------------------------------------
reset                                          100             1     28.9307 s 
                                          270.8 ms     269.29 ms    272.799 ms 
                                        8.81061 ms    7.00688 ms    11.6857 ms 
                                                                               

-------------------------------------------------------------------------------
client reset
  DiscardLocal: 5000 source objects linked to 5000 dest objects
  remote removes half the local data
-------------------------------------------------------------------------------
/Users/js/Documents/code/realm-core2/test/object-store/benchmarks/client_reset.cpp:329
...............................................................................

benchmark name                       samples       iterations    estimated
                                     mean          low mean      high mean
                                     std dev       low std dev   high std dev
-------------------------------------------------------------------------------
reset                                          100             1     49.1141 s 
                                        478.084 ms     473.54 ms    484.817 ms 
                                        27.8182 ms    20.7857 ms    42.8792 ms 
                                                                               

-------------------------------------------------------------------------------
client reset
  DiscardLocal: 5000 source objects linked to 5000 dest objects
  local removes half the objects
-------------------------------------------------------------------------------
/Users/js/Documents/code/realm-core2/test/object-store/benchmarks/client_reset.cpp:339
...............................................................................

benchmark name                       samples       iterations    estimated
                                     mean          low mean      high mean
                                     std dev       low std dev   high std dev
-------------------------------------------------------------------------------
reset                                          100             1     1.44226 m 
                                        880.281 ms    871.608 ms    893.844 ms 
                                        54.3754 ms    39.6045 ms    83.7376 ms 
                                                                               

-------------------------------------------------------------------------------
client reset
  Recover: from empty initial state
-------------------------------------------------------------------------------
/Users/js/Documents/code/realm-core2/test/object-store/benchmarks/client_reset.cpp:279
...............................................................................

benchmark name                       samples       iterations    estimated
                                     mean          low mean      high mean
                                     std dev       low std dev   high std dev
-------------------------------------------------------------------------------
no changes                                     100             1    39.1086 ms 
                                        378.205 us    363.502 us    395.408 us 
                                        81.1075 us    70.3394 us    94.6091 us 
                                                                               

-------------------------------------------------------------------------------
client reset
  Recover: populated with 10000 simple objects
  no change
-------------------------------------------------------------------------------
/Users/js/Documents/code/realm-core2/test/object-store/benchmarks/client_reset.cpp:291
...............................................................................

benchmark name                       samples       iterations    estimated
                                     mean          low mean      high mean
                                     std dev       low std dev   high std dev
-------------------------------------------------------------------------------
reset                                          100             1      17.032 s 
                                        172.566 ms      170.6 ms    175.365 ms 
                                        11.8616 ms    8.76179 ms    17.0827 ms 
                                                                               

-------------------------------------------------------------------------------
client reset
  Recover: populated with 10000 simple objects
  remote removes half the local data
-------------------------------------------------------------------------------
/Users/js/Documents/code/realm-core2/test/object-store/benchmarks/client_reset.cpp:297
...............................................................................

benchmark name                       samples       iterations    estimated
                                     mean          low mean      high mean
                                     std dev       low std dev   high std dev
-------------------------------------------------------------------------------
reset                                          100             1     25.9469 s 
                                        252.298 ms    250.419 ms    254.211 ms 
                                        9.67512 ms    8.76948 ms    11.1025 ms 
                                                                               

-------------------------------------------------------------------------------
client reset
  Recover: populated with 10000 simple objects
  local removes half the objects
-------------------------------------------------------------------------------
/Users/js/Documents/code/realm-core2/test/object-store/benchmarks/client_reset.cpp:306
...............................................................................

benchmark name                       samples       iterations    estimated
                                     mean          low mean      high mean
                                     std dev       low std dev   high std dev
-------------------------------------------------------------------------------
reset                                          100             1     25.1134 s 
                                        259.482 ms    257.053 ms    264.801 ms 
                                        17.5078 ms    9.92798 ms    35.1019 ms 
                                                                               

-------------------------------------------------------------------------------
client reset
  Recover: 5000 source objects linked to 5000 dest objects
  no change
-------------------------------------------------------------------------------
/Users/js/Documents/code/realm-core2/test/object-store/benchmarks/client_reset.cpp:323
...............................................................................

benchmark name                       samples       iterations    estimated
                                     mean          low mean      high mean
                                     std dev       low std dev   high std dev
-------------------------------------------------------------------------------
reset                                          100             1       27.31 s 
                                        285.894 ms    283.148 ms    289.402 ms 
                                        15.7863 ms    12.9249 ms    22.3099 ms 
                                                                               

-------------------------------------------------------------------------------
client reset
  Recover: 5000 source objects linked to 5000 dest objects
  remote removes half the local data
-------------------------------------------------------------------------------
/Users/js/Documents/code/realm-core2/test/object-store/benchmarks/client_reset.cpp:329
...............................................................................

benchmark name                       samples       iterations    estimated
                                     mean          low mean      high mean
                                     std dev       low std dev   high std dev
-------------------------------------------------------------------------------
reset                                          100             1     51.6466 s 
                                        486.238 ms    483.216 ms    489.827 ms 
                                        16.7872 ms    14.2605 ms    20.3039 ms 
                                                                               

-------------------------------------------------------------------------------
client reset
  Recover: 5000 source objects linked to 5000 dest objects
  local removes half the objects
-------------------------------------------------------------------------------
/Users/js/Documents/code/realm-core2/test/object-store/benchmarks/client_reset.cpp:339
...............................................................................

benchmark name                       samples       iterations    estimated
                                     mean          low mean      high mean
                                     std dev       low std dev   high std dev
-------------------------------------------------------------------------------
reset                                          100             1     1.06414 m 
                                         638.36 ms    634.023 ms    644.704 ms 
                                        26.4535 ms    19.5982 ms    37.3816 ms 
                                                                               

===============================================================================
All tests passed (76 assertions in 1 test case)
```
