### PR TITLE
extend wait times in a c_api test

### DIFF
--- a/test/object-store/c_api/c_api.cpp
+++ b/test/object-store/c_api/c_api.cpp
@@ -4663,9 +4663,10 @@ TEST_CASE("app: flx-sync basic tests", "[c_api][flx][sync]") {
                 {
                     using namespace std::chrono_literals;
                     std::unique_lock<std::mutex> lock{m_mutex};
-                    m_cv.wait_for(lock, 300ms, [this]() {
+                    bool completed_within_time_limit = m_cv.wait_for(lock, 5s, [this]() {
                         return m_state == RLM_SYNC_SUBSCRIPTION_COMPLETE && m_userdata != nullptr;
                     });
+                    CHECK(completed_within_time_limit);
                     return m_state;
                 }
             };


### PR DESCRIPTION
I got a sporadic failure in CI while working on something unrelated. This is an attempt to fix it.

```
[2022/06/17 18:18:01.156] 3: ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
[2022/06/17 18:18:01.156] 3: realm-object-store-tests is a Catch2 v3.0.1 host application.
[2022/06/17 18:18:01.156] 3: Run with -? for options
[2022/06/17 18:18:01.156] 3:
[2022/06/17 18:18:01.156] 3: -------------------------------------------------------------------------------
[2022/06/17 18:18:01.156] 3: app: flx-sync basic tests
[2022/06/17 18:18:01.156] 3: -------------------------------------------------------------------------------
[2022/06/17 18:18:01.156] 3: /System/Volumes/Data/data/mci/caa9b8efc23df0ce69bdd3301a401077/realm-core/test/object-store/c_api/c_api.cpp:4401
[2022/06/17 18:18:01.156] 3: ...............................................................................
[2022/06/17 18:18:01.156] 3:
[2022/06/17 18:18:01.156] 3: /System/Volumes/Data/data/mci/caa9b8efc23df0ce69bdd3301a401077/realm-core/test/object-store/c_api/c_api.cpp:4681: FAILED:
[2022/06/17 18:18:01.156] 3:   CHECK( SyncObject::create().wait_state() == realm_flx_sync_subscription_set_state_e::RLM_SYNC_SUBSCRIPTION_COMPLETE )
[2022/06/17 18:18:01.156] 3: with expansion:
[2022/06/17 18:18:01.156] 3:   0 == 3
[2022/06/17 18:18:01.156] 3:
[2022/06/17 18:18:01.156] 3: Assertion failure: /System/Volumes/Data/data/mci/caa9b8efc23df0ce69bdd3301a401077/realm-core/test/object-store/c_api/c_api.cpp:4681
[2022/06/17 18:18:01.156] 3: 	 from expresion: 'SyncObject::create().wait_state() == realm_flx_sync_subscription_set_state_e::RLM_SYNC_SUBSCRIPTION_COMPLETE'
[2022/06/17 18:18:01.156] 3: 	 with expansion: '0 == 3'
[2022/06/17 18:18:01.156] 3:
[2022/06/17 18:18:02.603] 3: 18.264 s: app: flx-sync basic tests
```