### PR TITLE
Speed up the asymmetric sync tests

### DIFF
--- a/test/object-store/util/baas_admin_api.cpp
+++ b/test/object-store/util/baas_admin_api.cpp
@@ -116,6 +116,7 @@ nlohmann::json BaasRuleBuilder::object_schema_to_jsonschema(const ObjectSchema& 
     return {
         {"properties", properties},
         {"required", required},
+        {"title", obj_schema.name},
     };
 }
 
@@ -179,7 +180,6 @@ nlohmann::json BaasRuleBuilder::object_schema_to_baas_schema(const ObjectSchema&
     m_relationships.clear();
 
     auto schema_json = object_schema_to_jsonschema(obj_schema, include_prop, true);
-    schema_json.emplace("title", obj_schema.name);
     auto& prop_sub_obj = schema_json["properties"];
     if (!prop_sub_obj.contains(m_partition_key.name)) {
         prop_sub_obj.emplace(m_partition_key.name, property_to_jsonschema(m_partition_key, include_prop));


### PR DESCRIPTION
Reusing a single app for all of the asymmetric sync tests makes them run in 20 seconds instead of 3 minutes on my machine. This doesn't really solve the broader problem of the baas-enabled tests taking way too long to run (it's still 25 minutes for me) but it's a step in the right direction at least.