### PR TITLE
optimize memory allocation of changesets with many small strings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 ### Fixed
 * <How do the end-user experience this issue? what was the impact?> ([#????](https://github.com/realm/realm-core/issues/????), since v?.?.?)
 * Fix a UBSan failure when mapping encrypted pages.
+* Improved performance of sync clients during integration of changesets with many small strings (totalling > 1024 bytes per changeset) on iOS 14, and devices which have restrictive or fragmented memory. ([#5614](https://github.com/realm/realm-core/issues/5614))
  
 ### Breaking changes
 * None.

--- a/src/realm/sync/changeset.hpp
+++ b/src/realm/sync/changeset.hpp
@@ -539,12 +539,11 @@ inline StringData Changeset::string_data() const noexcept
 
 inline StringBufferRange Changeset::append_string(StringData string)
 {
-    // small string optimization; we expect more strings, but constantly requesting many small allocation increases
-    // to the string buffer can become a performance bottleneck in highly fragmented or low memory devices
+    // We expect more strings. Only do this at the beginning because until C++20, reserve
+    // will shrink_to_fit if the request is less than the current capacity.
     constexpr size_t small_string_buffer_size = 1024;
-    if (m_string_buffer->capacity() - m_string_buffer->size() < string.size() &&
-        string.size() < small_string_buffer_size) {
-        m_string_buffer->reserve(m_string_buffer->capacity() + small_string_buffer_size);
+    if (m_string_buffer->capacity() < small_string_buffer_size) {
+        m_string_buffer->reserve(small_string_buffer_size);
     }
     size_t offset = m_string_buffer->size();
     m_string_buffer->append(string.data(), string.size());


### PR DESCRIPTION
A customer (HELP-34650) reported slow downloads on iOS 14 and android. Profiling sync on an iOS 14 device revealed tons of time being spent requesting memory. I tried to reproduce this on mac, and ubuntu but could not. @ericjordanmossman profiled an actual iOS 14 device, and we found a bottleneck in `InstructionBuilder::add_string_range`:

![Screen Shot 2022-06-23 at 2 33 16 PM](https://user-images.githubusercontent.com/2826060/175406581-ab9b2ba4-cbfa-4e9f-9be5-0e8c398ca724.png)

I noticed that changesets were mostly adding small strings (~10-50 bytes) such that `m_string_buffer` has to constantly request more memory, but only by a little bit each time once it outgrows the initial 1024 reserved capacity. The fix is to keep reserving 1k buffer space in chunks rather than increasing a little bit each time. I think this is not a problem on machines with more memory, because if the initial allocation uses memory that has additional space after the requested block, then subsequent allocations can just extend the range rather than moving the entire block to somewhere else. This wouldn't show up in benchmarks so I haven't added any. However, profiling the same workload as above with this optimization shows a ~60x speedup: 

![Screen Shot 2022-06-23 at 2 34 18 PM](https://user-images.githubusercontent.com/2826060/175407533-323f189b-ccd9-47a5-a459-2ab712af91b6.png)
