### PR TITLE
don't shrink_to_fit on large changesets

### DIFF
--- a/src/realm/sync/changeset_encoder.cpp
+++ b/src/realm/sync/changeset_encoder.cpp
@@ -272,7 +272,10 @@ void ChangesetEncoder::append_bytes(const void* bytes, size_t size)
 {
     // FIXME: It would be better to move ownership of `m_buffer` to the caller,
     // potentially reducing the number of allocations to zero (amortized).
-    m_buffer.reserve(1024); // lower the amount of reallocations
+    constexpr size_t min_buffer_capacity = 1024;
+    if (m_buffer.capacity() < min_buffer_capacity) {
+        m_buffer.reserve(min_buffer_capacity); // lower the amount of reallocations
+    }
     m_buffer.append(static_cast<const char*>(bytes), size);
 }
 


### PR DESCRIPTION
After https://github.com/realm/realm-core/pull/5614 I did a code search for reserve, and I found this other place using the same pattern. When a client is creating a large (> 1024 byte) changeset with many small strings, we don't want to incur the cost of shrink_to_fit. Although this didn't show up in any profiling, it seems to me it could be problematic in the same way.