### PR TITLE
Make MemRef (and therefore Obj) trivially copyable

### DIFF
--- a/src/realm/alloc.hpp
+++ b/src/realm/alloc.hpp
@@ -53,7 +53,6 @@ int64_t to_int64(size_t value) noexcept;
 class MemRef {
 public:
     MemRef() noexcept;
-    ~MemRef() noexcept;
 
     MemRef(char* addr, ref_type ref, Allocator& alloc) noexcept;
     MemRef(ref_type ref, Allocator& alloc) noexcept;
@@ -449,8 +448,6 @@ inline MemRef::MemRef() noexcept
     , m_ref(0)
 {
 }
-
-inline MemRef::~MemRef() noexcept {}
 
 inline MemRef::MemRef(char* addr, ref_type ref, Allocator& alloc) noexcept
     : m_addr(addr)


### PR DESCRIPTION
## What, How & Why?
<!-- Describe the changes and give some hints to guide your reviewers if possible. -->
<!-- Link to relevant issue this fixes -->

Adding a destructor like this has unfortunate consequences. Unless you really need to write a destructor (or copy/move constructor/assignment operator), it is better to just let the compiler do it for you.

On a practical level, this shaves ~4K off of the realm-js  node x64 linux library. Not that that is a platform where we care about the size, but it was the easiest to measure and shows that this does save some bytes.

## ☑️ ToDos
* [ ] ~~📝 Changelog update~~
* [ ] ~~🚦 Tests (or not relevant)~~
* [ ] ~~C-API, if public C++ API changed.~~

None of these seem worth doing for a trivial change like this.
