### PR TITLE
Make MemRef trivially destructible

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@
 
 ### Internals
 * Add support for running the object store tests and some of the benchmarks on iOS ([PR #5577](https://github.com/realm/realm-core/pull/5577)).
+* MemRef is now trivially copyable.
 
 ----------------------------------------------
 

--- a/src/realm/alloc.hpp
+++ b/src/realm/alloc.hpp
@@ -52,8 +52,7 @@ int64_t to_int64(size_t value) noexcept;
 
 class MemRef {
 public:
-    MemRef() noexcept;
-    ~MemRef() noexcept;
+    MemRef() noexcept = default;
 
     MemRef(char* addr, ref_type ref, Allocator& alloc) noexcept;
     MemRef(ref_type ref, Allocator& alloc) noexcept;
@@ -64,14 +63,15 @@ public:
     void set_addr(char* addr);
 
 private:
-    char* m_addr;
-    ref_type m_ref;
+    char* m_addr = nullptr;
+    ref_type m_ref = 0;
 #if REALM_ENABLE_MEMDEBUG
     // Allocator that created m_ref. Used to verify that the ref is valid whenever you call
     // get_ref()/get_addr and that it e.g. has not been free'ed
     const Allocator* m_alloc = nullptr;
 #endif
 };
+static_assert(std::is_trivially_copyable_v<MemRef>);
 
 
 /// The common interface for Realm allocators.
@@ -131,7 +131,7 @@ public:
     /// therefore, is not part of an actual database.
     static Allocator& get_default() noexcept;
 
-    virtual ~Allocator() noexcept;
+    virtual ~Allocator() noexcept = default;
 
     // Disable copying. Copying an allocator can produce double frees.
     Allocator(const Allocator&) = delete;
@@ -443,15 +443,6 @@ inline int64_t to_int64(size_t value) noexcept
     return static_cast<int64_t>(value);
 }
 
-
-inline MemRef::MemRef() noexcept
-    : m_addr(nullptr)
-    , m_ref(0)
-{
-}
-
-inline MemRef::~MemRef() noexcept {}
-
 inline MemRef::MemRef(char* addr, ref_type ref, Allocator& alloc) noexcept
     : m_addr(addr)
     , m_ref(ref)
@@ -562,8 +553,6 @@ inline Allocator::Allocator() noexcept
     m_instance_versioning_counter = 0;
     m_ref_translation_ptr = nullptr;
 }
-
-inline Allocator::~Allocator() noexcept {}
 
 // performance critical part of the translation process. Less critical code is in translate_less_critical.
 inline char* Allocator::translate_critical(RefTranslation* ref_translation_ptr, ref_type ref) const noexcept

--- a/src/realm/sync/noinst/client_reset_recovery.cpp
+++ b/src/realm/sync/noinst/client_reset_recovery.cpp
@@ -914,7 +914,6 @@ void RecoverLocalChangesetsHandler::operator()(const Instruction::ArrayErase& in
         }
         Status on_list_index(LstBase& list, uint32_t index) override
         {
-            auto obj = list.get_obj();
             uint32_t translated_index;
             bool allowed_to_delete =
                 m_recovery_applier->m_lists.at(m_list_path).remove(static_cast<uint32_t>(index), translated_index);

--- a/test/benchmark-common-tasks/main.cpp
+++ b/test/benchmark-common-tasks/main.cpp
@@ -817,7 +817,7 @@ struct BenchmarkQueryIntListSize : Benchmark {
         TableRef t = tr.add_table(name());
         int_list_col_ndx = t->add_column_list(type_Int, "ints");
         for (size_t i = 0; i < num_rows; ++i) {
-            auto obj = t->create_object().set_list_values<Int>(int_list_col_ndx, {0, 1, 2});
+            t->create_object().set_list_values<Int>(int_list_col_ndx, {0, 1, 2});
         }
         tr.commit();
     }

--- a/test/object-store/audit.cpp
+++ b/test/object-store/audit.cpp
@@ -749,7 +749,7 @@ TEST_CASE("audit object serialization") {
     SECTION("link access tracking") {
         realm->begin_transaction();
         table->create_object_with_primary_key(1);
-        auto target_obj = target_table->create_object_with_primary_key(0);
+        target_table->create_object_with_primary_key(0);
         auto obj = table->create_object_with_primary_key(2);
         obj.set("object", target_table->create_object_with_primary_key(1).set_all(1).get_key());
         obj.create_and_set_linked_object(table->get_column_key("embedded object")).set_all(200);
@@ -1028,7 +1028,7 @@ TEST_CASE("audit object serialization") {
 
     SECTION("reads mixed with deletions") {
         realm->begin_transaction();
-        auto obj1 = table->create_object_with_primary_key(1);
+        table->create_object_with_primary_key(1);
         auto obj2 = table->create_object_with_primary_key(2);
         auto obj3 = table->create_object_with_primary_key(3);
         realm->commit_transaction();

--- a/test/object-store/dictionary.cpp
+++ b/test/object-store/dictionary.cpp
@@ -919,8 +919,8 @@ TEMPLATE_TEST_CASE("dictionary of objects", "[dictionary][links]", cf::MixedVal,
     auto target = r->read_group().get_table("class_target");
     r->begin_transaction();
     Obj obj = table->create_object();
-    Obj obj1 = table->create_object(); // empty dictionary
-    Obj empty_target = target->create_object();
+    table->create_object(); // empty dictionary
+    target->create_object();
     ColKey col_links = table->get_column_key("links");
     ColKey col_target_value = target->get_column_key("value");
 
@@ -1003,7 +1003,7 @@ TEST_CASE("dictionary with mixed links", "[dictionary]") {
     ColKey col_link1 = target1->get_column_key("link1");
     r->begin_transaction();
     Obj obj = table->create_object();
-    Obj obj1 = table->create_object(); // empty dictionary
+    table->create_object(); // empty dictionary
     Obj target1_obj = target1->create_object().set(col_value1, 100);
     Obj target2_obj = target2->create_object().set(col_value2, 200);
     ColKey col = table->get_column_key("value");

--- a/test/object-store/frozen_objects.cpp
+++ b/test/object-store/frozen_objects.cpp
@@ -265,7 +265,7 @@ TEST_CASE("Freeze Results", "[freeze_results]") {
         ordering.append_sort(SortDescriptor({{value_col}}, {false}));
         TableView tv = q.find_all();
         Results query_results(realm, tv, ordering);
-        auto obj = query_results.get(0);
+        query_results.get(0);
         Results frozen_res = query_results.freeze(frozen_realm);
         JoiningThread thread([&] {
             auto obj = frozen_res.get(0);

--- a/test/object-store/primitive_list.cpp
+++ b/test/object-store/primitive_list.cpp
@@ -830,7 +830,7 @@ TEST_CASE("list of mixed links", "[primitives]") {
     ColKey col_link1 = target1->get_column_key("link1");
     r->begin_transaction();
     Obj obj = table->create_object();
-    Obj obj1 = table->create_object(); // empty dictionary
+    table->create_object(); // empty dictionary
     Obj target1_obj = target1->create_object().set(col_value1, 100);
     Obj target2_obj = target2->create_object().set(col_value2, 200);
     ColKey col = table->get_column_key("value");

--- a/test/object-store/realm.cpp
+++ b/test/object-store/realm.cpp
@@ -539,7 +539,7 @@ TEST_CASE("SharedRealm: get_shared_realm()") {
 
         auto table = realm->read_group().get_table("class_object");
         realm->begin_transaction();
-        Obj obj = table->create_object();
+        table->create_object();
         realm->commit_transaction();
 
         REQUIRE(realm->read_transaction_version() > frozen1->read_transaction_version());
@@ -1479,7 +1479,7 @@ TEST_CASE("SharedRealm: async writes") {
 
         realm->begin_transaction();
         auto table = realm->read_group().get_table("class_object");
-        auto obj = table->create_object();
+        table->create_object();
         REQUIRE_THROWS_WITH(realm->async_commit_transaction([&](std::exception_ptr) {
             done = true;
         }),
@@ -1729,7 +1729,7 @@ TEST_CASE("SharedRealm: async writes") {
                 auto r = realm.lock();
                 r->begin_transaction();
                 auto table = r->read_group().get_table("class_object");
-                auto obj = table->create_object();
+                table->create_object();
                 if (++change_count == 1) {
                     r->commit_transaction();
                 }
@@ -1745,7 +1745,7 @@ TEST_CASE("SharedRealm: async writes") {
 
         realm->begin_transaction();
         auto table = realm->read_group().get_table("class_object");
-        auto obj = table->create_object();
+        table->create_object();
         bool persisted = false;
         realm->async_commit_transaction([&persisted](auto) {
             persisted = true;

--- a/test/object-store/set.cpp
+++ b/test/object-store/set.cpp
@@ -1293,7 +1293,7 @@ TEST_CASE("set with mixed links", "[set]") {
     ColKey col_link1 = target1->get_column_key("link1");
     r->begin_transaction();
     Obj obj = table->create_object();
-    Obj obj1 = table->create_object(); // empty set
+    table->create_object(); // empty set
     Obj target1_obj = target1->create_object().set(col_value1, 100);
     Obj target2_obj = target2->create_object().set(col_value2, 200);
     ColKey col = table->get_column_key("value");

--- a/test/object-store/transaction_log_parsing.cpp
+++ b/test/object-store/transaction_log_parsing.cpp
@@ -1007,7 +1007,7 @@ TEST_CASE("Transaction log parsing: changeset calcuation") {
 
         auto obj0 = origin->create_object_with_primary_key(5).set("link", target_keys[5]);
         auto obj1 = origin->create_object_with_primary_key(6).set("link", target_keys[6]);
-        auto obj2 = origin->create_object_with_primary_key(7);
+        origin->create_object_with_primary_key(7);
 
         auto lv = obj0.get_linklist(origin_cols[2]);
         for (auto key : target_keys)

--- a/test/test_decimal128.cpp
+++ b/test/test_decimal128.cpp
@@ -301,7 +301,7 @@ TEST(Decimal_Distinct)
         auto table = wt->add_table("Foo");
         auto col_dec = table->add_column(type_Decimal, "price", true);
         for (int i = 1; i < 100; i++) {
-            auto obj = table->create_object().set(col_dec, Decimal128(i % 10));
+            table->create_object().set(col_dec, Decimal128(i % 10));
         }
 
         wt->commit();

--- a/test/test_embedded_objects.cpp
+++ b/test/test_embedded_objects.cpp
@@ -414,7 +414,7 @@ TEST(EmbeddedObjects_DiscardThroughImplicitErase)
             sub->add_column(type_Int, "i");
 
             auto top_obj = top->create_object_with_primary_key(123);
-            auto sub_obj = top_obj.create_and_set_linked_object(top->get_column_key("sub")).set("i", 5);
+            top_obj.create_and_set_linked_object(top->get_column_key("sub")).set("i", 5);
         });
 
         it.sync_all();
@@ -613,7 +613,7 @@ TEST(EmbeddedObjects_CreateEraseCreateSequencePreservesObject)
             auto embedded = tr.add_table("class_embedded", Table::Type::Embedded);
             embedded->add_column(type_Int, "int");
             table->add_column(*embedded, "embedded");
-            auto obj = table->create_object_with_primary_key(123);
+            table->create_object_with_primary_key(123);
             // Note: embedded object is NULL at this stage.
         });
 
@@ -681,7 +681,7 @@ TEST(EmbeddedObjects_CreateEraseCreateSequencePreservesObject_Nested)
             embedded->add_column(type_Int, "int");
             embedded->add_column(*embedded, "embedded");
             table->add_column(*embedded, "embedded");
-            auto obj = table->create_object_with_primary_key(123);
+            table->create_object_with_primary_key(123);
             // Note: embedded object is NULL at this stage.
         });
 

--- a/test/test_index_string.cpp
+++ b/test/test_index_string.cpp
@@ -1782,7 +1782,7 @@ TEST(StringIndex_QuerySingleObject)
 {
     Group g;
     auto table = g.add_table_with_primary_key("class_StringClass", type_String, "name", true);
-    auto obj = table->create_object_with_primary_key("Foo");
+    table->create_object_with_primary_key("Foo");
 
     auto q = table->where().equal(table->get_column_key("name"), "Foo", true);
     CHECK_EQUAL(q.count(), 1);

--- a/test/test_json.cpp
+++ b/test/test_json.cpp
@@ -510,7 +510,7 @@ TEST(Xjson_LinkList1)
 
     // add some rows
     auto obj0 = table1->create_object_with_primary_key("t1o1").set(table1Coll, 100);
-    auto obj2 = table1->create_object_with_primary_key("t1o3").set(table1Coll, 300);
+    table1->create_object_with_primary_key("t1o3").set(table1Coll, 300);
     auto obj1 = table1->create_object_with_primary_key("t1o2").set(table1Coll, 200);
 
 
@@ -568,7 +568,7 @@ TEST(Xjson_LinkSet1)
 
     // add some rows
     auto obj0 = table1->create_object_with_primary_key("t1o1").set(table1Coll, 100);
-    auto obj2 = table1->create_object_with_primary_key("t1o3").set(table1Coll, 300);
+    table1->create_object_with_primary_key("t1o3").set(table1Coll, 300);
     auto obj1 = table1->create_object_with_primary_key("t1o2").set(table1Coll, 200);
 
 
@@ -624,7 +624,7 @@ TEST(Xjson_LinkDictionary1)
 
     // add some rows
     auto obj0 = table1->create_object_with_primary_key("t1o1").set(table1Coll, 100);
-    auto obj2 = table1->create_object_with_primary_key("t1o3").set(table1Coll, 300);
+    table1->create_object_with_primary_key("t1o3").set(table1Coll, 300);
     auto obj1 = table1->create_object_with_primary_key("t1o2").set(table1Coll, 200);
 
 

--- a/test/test_lang_bind_helper.cpp
+++ b/test/test_lang_bind_helper.cpp
@@ -2670,7 +2670,7 @@ TEST(LangBindHelper_RollbackAndContinueAsRead_Links)
     auto col0 = origin->add_column(*target, "");
     target->add_column(type_Int, "");
     auto o0 = origin->create_object();
-    auto t0 = target->create_object();
+    target->create_object();
     auto t1 = target->create_object();
     auto t2 = target->create_object();
 
@@ -4346,7 +4346,7 @@ TEST(LangBindHelper_HandoverLinkView)
     ColKey col_link2 = table2->add_column_list(*table1, "linklist");
 
     auto o1 = table2->create_object();
-    auto o2 = table2->create_object();
+    table2->create_object();
     LnkLstPtr lvr = o1.get_linklist_ptr(col_link2);
     lvr->clear();
     lvr->add(to1.get_key());
@@ -4407,7 +4407,7 @@ TEST(LangBindHelper_HandoverDistinctView)
             TableRef table = writer->add_table("table2");
             auto col = table->add_column(type_Int, "first");
             auto obj1 = table->create_object().set_all(100);
-            auto obj2 = table->create_object().set_all(100);
+            table->create_object().set_all(100);
 
             writer->commit_and_continue_as_read();
             tv1 = table->where().find_all();
@@ -4579,8 +4579,8 @@ TEST(LangBindHelper_HandoverWithLinkQueries)
     // add some rows
     auto o10 = table1->create_object().set_all(100, "foo");
     auto o11 = table1->create_object().set_all(200, "!");
-    auto o12 = table1->create_object().set_all(300, "bar");
-    auto o20 = table2->create_object().set_all(400, "hello");
+    table1->create_object().set_all(300, "bar");
+    table2->create_object().set_all(400, "hello");
     auto o21 = table2->create_object().set_all(500, "world");
     auto o22 = table2->create_object().set_all(600, "!");
 
@@ -5342,9 +5342,9 @@ TEST(LangBindHelper_RollbackInsertZeroRows)
     auto t1 = g->add_table("t1");
 
     auto col = t0->add_column(*t1, "t0_link_to_t1");
-    auto o0 = t0->create_object();
+    t0->create_object();
     auto o1 = t0->create_object();
-    auto v0 = t1->create_object();
+    t1->create_object();
     auto v1 = t1->create_object();
     o1.set(col, v1.get_key());
 
@@ -5382,9 +5382,9 @@ TEST(LangBindHelper_RollbackRemoveZeroRows)
     auto t1 = g->add_table("t1");
 
     auto col = t0->add_column(*t1, "t0_link_to_t1");
-    auto o0 = t0->create_object();
+    t0->create_object();
     auto o1 = t0->create_object();
-    auto v0 = t1->create_object();
+    t1->create_object();
     auto v1 = t1->create_object();
     o1.set(col, v1.get_key());
 

--- a/test/test_link_query_view.cpp
+++ b/test/test_link_query_view.cpp
@@ -76,7 +76,7 @@ TEST(LinkList_Basic1)
     auto c2 = table1->add_column(type_Binary, "bin1", true /*nullable*/);
 
     // add some rows
-    auto o0 = table1->create_object().set_all(100, "foo", BinaryData("foo"));
+    table1->create_object().set_all(100, "foo", BinaryData("foo"));
     auto o1 = table1->create_object().set_all(200, "!", BinaryData("", 0));
     auto o2 = table1->create_object().set_all(300, "bar", BinaryData());
 
@@ -142,13 +142,13 @@ TEST(LinkList_MissingDeepCopy)
     auto c1 = table1->add_column(type_String, "str1");
 
     // add some rows
-    auto o1 = table1->create_object().set_all(100, "foo");
+    table1->create_object().set_all(100, "foo");
     auto o2 = table1->create_object().set_all(200, "!");
     auto o3 = table1->create_object().set_all(300, "bar");
 
     auto col_link2 = table2->add_column(*table1, "link");
     auto o20 = table2->create_object().set_all(o2.get_key());
-    auto o21 = table2->create_object().set_all(o3.get_key());
+    table2->create_object().set_all(o3.get_key());
 
     char* c = new char[10000000];
     c[10000000 - 1] = '!';
@@ -178,7 +178,7 @@ TEST(LinkList_Basic2)
     auto o10 = table1->create_object().set_all(100, "foo");
     auto o11 = table1->create_object().set_all(200, "!");
     table1->create_object().set_all(300, "bar");
-    auto o20 = table2->create_object().set_all(400, "hello");
+    table2->create_object().set_all(400, "hello");
     auto o21 = table2->create_object().set_all(500, "world");
     auto o22 = table2->create_object().set_all(600, "!");
 
@@ -487,7 +487,7 @@ TEST(LinkList_MultiLinkQuery)
     lvr = o21.get_linklist(col_linklist3);
     lvr.add(ObjKey(2));
 
-    auto o22 = table2->create_object(ObjKey(2));
+    table2->create_object(ObjKey(2));
 
     auto o10 = table1->create_object();
     o10.set(col_link2, ObjKey(1));

--- a/test/test_object_id.cpp
+++ b/test/test_object_id.cpp
@@ -416,7 +416,7 @@ TEST(ObjectId_Distinct)
         auto table = wt->add_table("Foo");
         auto col_id = table->add_column(type_ObjectId, "id", true);
         for (int i = 1; i < 10; i++) {
-            auto obj = table->create_object().set(col_id, ids[i % ids.size()]);
+            table->create_object().set(col_id, ids[i % ids.size()]);
         }
         wt->commit();
     }

--- a/test/test_parser.cpp
+++ b/test/test_parser.cpp
@@ -2002,7 +2002,7 @@ TEST(Parser_list_of_primitive_ints)
             list1.add(it->get_key());
         }
         // empty object, null link, empty list
-        Obj obj2 = t2->create_object();
+        t2->create_object();
     }
 
     for (size_t i = 0; i < num_objects; ++i) {
@@ -2031,7 +2031,7 @@ TEST(Parser_list_of_primitive_ints)
     verify_query(test_context, t, "integers.@size == 1", num_objects);
 
     // add two more objects; one with defaults, one with null in the list
-    Obj obj_defaults = t->create_object();
+    t->create_object();
     Obj obj_nulls_in_lists = t->create_object();
     obj_nulls_in_lists.get_list<Optional<Int>>(col_int_list_nullable).add(Optional<Int>());
     num_objects += 2;
@@ -2115,7 +2115,6 @@ TEST(Parser_list_of_primitive_ints)
     verify_query(test_context, t2, "ALL list.integers == 1", 2);  // row 0 matches {1}. row 1 matches (any of) {} {1}
     verify_query(test_context, t2, "NONE list.integers == 1", 1); // row 1 matches (any of) {}, {0}, {2}, {3} ...
 
-    Obj obj0 = *t->begin();
     util::Any args[] = {Int(1)};
     size_t num_args = 1;
     verify_query_sub(test_context, t, "integers == $0", args, num_args, 1);
@@ -2189,7 +2188,7 @@ TEST(Parser_list_of_primitive_strings)
         std::string si = get_string(i);
         obj.get_list<String>(col_str_list).add(si);
     }
-    Obj obj_empty_list = t->create_object();
+    t->create_object();
     Obj obj_with_null = t->create_object();
     obj_with_null.get_list<String>(col_str_list).add(StringData(realm::null()));
     Obj obj_with_empty_string = t->create_object();
@@ -2258,7 +2257,7 @@ TEST_TYPES(Parser_list_of_primitive_element_lengths, StringData, BinaryData)
     t->add_column(type_Int, "length"); // "length" is still a usable column name
     auto col_link = t->add_column(*t, "link");
 
-    Obj obj_empty_list = t->create_object();
+    t->create_object();
     Obj obj_with_null = t->create_object();
     TEST_TYPE null_value;
     CHECK(null_value.is_null());
@@ -2342,7 +2341,7 @@ TEST_TYPES(Parser_list_of_primitive_types, Prop<Int>, Nullable<Int>, Prop<Bool>,
     auto obj1 = t->create_object();
     std::vector<type> values = gen.values_from_int<type>({0, 9, 4, 2, 7, 4, 1, 8, 11, 3, 4, 5, 22});
     obj1.set_list_values(col, values);
-    auto obj2 = t->create_object(); // empty list
+    t->create_object();             // empty list
     auto obj3 = t->create_object(); // {1}
     underlying_type value_1 = gen.convert_for_test<underlying_type>(1);
     obj3.get_list<type>(col).add(value_1);
@@ -3052,7 +3051,7 @@ TEST(Parser_Backlinks)
     }
 
     {
-        auto obj1 = things->create_object().set(int_col, 1);
+        things->create_object().set(int_col, 1);
         auto obj2 = things->create_object().set(int_col, 2);
         auto obj3 = things->create_object().set(int_col, 3);
         obj3.set(link_col, obj2.get_key());

--- a/test/test_query.cpp
+++ b/test/test_query.cpp
@@ -145,9 +145,9 @@ TEST(Query_Parser)
     books.add_column(type_String, "author");
     books.add_column(type_Int, "pages");
 
-    Obj obj1 = books.create_object().set_all("Computer Architecture and Organization", "B. Govindarajalu", 752);
+    books.create_object().set_all("Computer Architecture and Organization", "B. Govindarajalu", 752);
     Obj obj2 = books.create_object().set_all("Introduction to Quantum Mechanics", "David Griffiths", 480);
-    Obj obj3 = books.create_object().set_all("Biophysics: Searching for Principles", "William Bialek", 640);
+    books.create_object().set_all("Biophysics: Searching for Principles", "William Bialek", 640);
 
     // Typed table:
     Query q = books.query("pages >= $0 && author == $1", {{200, "David Griffiths"}});
@@ -2227,7 +2227,7 @@ TEST(Query_TwoColsVaryOperators)
 
     Obj obj0 = table.create_object().set_all(5, 10, 5.0f, 10.0f, 5.0, 10.0);
     Obj obj1 = table.create_object().set_all(10, 5, 10.0f, 5.0f, 10.0, 5.0);
-    Obj obj2 = table.create_object().set_all(-10, -5, -10.0f, -5.0f, -10.0, -5.0);
+    table.create_object().set_all(-10, -5, -10.0f, -5.0f, -10.0, -5.0);
 
     CHECK_EQUAL(null_key, table.where().equal(col_int0, col_int1).find());
     CHECK_EQUAL(obj0.get_key(), table.where().not_equal(col_int0, col_int1).find());
@@ -5538,7 +5538,7 @@ NONCONCURRENT_TEST(Query_IntPerformance)
     auto col_2 = table.add_column(type_Int, "2");
 
     for (int i = 0; i < 1000; i++) {
-        Obj o = table.create_object().set(col_1, i).set(col_2, i == 500 ? 500 : 2);
+        table.create_object().set(col_1, i).set(col_2, i == 500 ? 500 : 2);
     }
 
     Query q1 = table.where().equal(col_2, 2);

--- a/test/test_query2.cpp
+++ b/test/test_query2.cpp
@@ -5034,7 +5034,7 @@ TEST_IF(Query_IntOrQueryPerformance, TEST_DURATION > 0)
             ++num_nulls_added;
         }
         else {
-            auto o = table->create_object().set_all(i, i);
+            table->create_object().set_all(i, i);
         }
     }
 
@@ -5765,10 +5765,10 @@ TEST(Query_DictionaryTypedLinks)
     auto fido = dog->create_object().set(col_dog_name, "Fido");
     auto pluto = dog->create_object().set(col_dog_name, "Pluto");
     pluto.set(col_dog_parent, fido.get_key());
-    auto vaks = dog->create_object().set(col_dog_name, "Vaks");
+    dog->create_object().set(col_dog_name, "Vaks");
     auto marie = cat->create_object().set(col_cat_name, "Marie");
-    auto berlioz = cat->create_object().set(col_cat_name, "Berlioz");
-    auto toulouse = cat->create_object().set(col_cat_name, "Toulouse");
+    cat->create_object().set(col_cat_name, "Berlioz");
+    cat->create_object().set(col_cat_name, "Toulouse");
 
     auto john = person->create_object().get_dictionary(col_data);
     auto paul = person->create_object().get_dictionary(col_data);

--- a/test/test_set.cpp
+++ b/test/test_set.cpp
@@ -203,7 +203,7 @@ TEST(Set_Links)
 
     auto cab1 = cabs->create_object();
     auto cab2 = cabs->create_object();
-    auto cab3 = cabs->create_object();
+    cabs->create_object();
 
     auto set_links = foo.get_set<ObjKey>(col_links);
     auto lnkset_links = foo.get_setbase_ptr(col_links);

--- a/test/test_sync.cpp
+++ b/test/test_sync.cpp
@@ -5892,7 +5892,7 @@ NONCONCURRENT_TEST_TYPES(Sync_PrimaryKeyTypes, Int, String, ObjectId, UUID, util
         auto obj_1 = table_1->create_object_with_primary_key(sequence_next<underlying_type>());
         auto obj_2 = table_2->create_object_with_primary_key(sequence_next<underlying_type>());
         if constexpr (is_optional) {
-            auto obj_3 = table_2->create_object_with_primary_key(default_or_null);
+            table_2->create_object_with_primary_key(default_or_null);
         }
 
         auto list = obj_1.template get_list<TEST_TYPE>("oids");
@@ -6491,7 +6491,7 @@ TEST(Sync_BundledRealmFile)
 
     write_transaction_notifying_session(db, session, [](WriteTransaction& tr) {
         auto foos = tr.get_group().add_table_with_primary_key("class_Foo", type_Int, "id");
-        auto foo = foos->create_object_with_primary_key(123);
+        foos->create_object_with_primary_key(123);
     });
 
     // We cannot write out file if changes are not synced to server
@@ -6570,7 +6570,7 @@ TEST(Sync_UpgradeToClientHistory)
         auto col_link = baas->add_column(*foos, "link");
 
         auto foo = foos->create_object_with_primary_key("123").set(col_str, "Goodbye");
-        auto baa = baas->create_object_with_primary_key(888).set(col_link, foo.get_key());
+        baas->create_object_with_primary_key(888).set(col_link, foo.get_key());
 
         tr->commit();
     }
@@ -6589,7 +6589,7 @@ TEST(Sync_UpgradeToClientHistory)
 
     write_transaction_notifying_session(db_1, session_1, [](WriteTransaction& tr) {
         auto foos = tr.get_group().get_table("class_Foo");
-        auto foo = foos->create_object_with_primary_key("456");
+        foos->create_object_with_primary_key("456");
     });
     session_1.wait_for_upload_complete_or_client_stopped();
     session_2.wait_for_upload_complete_or_client_stopped();

--- a/test/test_table.cpp
+++ b/test/test_table.cpp
@@ -2999,7 +2999,6 @@ TEST_TYPES(Table_ListOps, Prop<Int>, Prop<Float>, Prop<Double>, Prop<Decimal>, P
     ColKey col = table.add_column_list(TEST_TYPE::data_type, "values", TEST_TYPE::is_nullable);
 
     Obj obj = table.create_object();
-    Obj obj1 = obj;
     Lst<type> list = obj.get_list<type>(col);
     list.add(gen.convert_for_test<underlying_type>(1));
     list.add(gen.convert_for_test<underlying_type>(2));
@@ -3496,7 +3495,7 @@ NONCONCURRENT_TEST(Table_object_sequential)
 
         for (int j = 0; j < num_runs; ++j) {
             for (int i = 0; i < nb_rows; i++) {
-                const Obj o = table->get_object(ObjKey(i));
+                table->get_object(ObjKey(i));
             }
         }
 
@@ -3657,7 +3656,7 @@ NONCONCURRENT_TEST(Table_object_seq_rnd)
 
         for (int j = 0; j < num_runs; ++j) {
             for (int i = 0; i < nb_rows; i++) {
-                const Obj o = table->get_object(ObjKey(key_values[i]));
+                table->get_object(ObjKey(key_values[i]));
             }
         }
 
@@ -3779,7 +3778,7 @@ NONCONCURRENT_TEST(Table_object_random)
 
         for (int j = 0; j < num_runs; ++j) {
             for (int i = 0; i < nb_rows; i++) {
-                const Obj o = table->get_object(ObjKey(key_values[i]));
+                table->get_object(ObjKey(key_values[i]));
             }
         }
 
@@ -5034,19 +5033,19 @@ void test_tables(TestContext& test_context, DBRef sg, const realm::DataType type
     // insert elements 0 - 999
     for (int j = 0; j < 1000; ++j) {
         managed<T> value = generator<T>::get(optional);
-        Obj o = table->create_object(ObjKey(j)).set_all(value.value);
+        table->create_object(ObjKey(j)).set_all(value.value);
         reference[j] = std::move(value);
     }
     // insert elements 10000 - 10999
     for (int j = 10000; j < 11000; ++j) {
         managed<T> value = generator<T>::get(optional);
-        Obj o = table->create_object(ObjKey(j)).set_all(value.value);
+        table->create_object(ObjKey(j)).set_all(value.value);
         reference[j] = std::move(value);
     }
     // insert in between previous groups
     for (int j = 4000; j < 7000; ++j) {
         managed<T> value = generator<T>::get(optional);
-        Obj o = table->create_object(ObjKey(j)).set_all(value.value);
+        table->create_object(ObjKey(j)).set_all(value.value);
         reference[j] = std::move(value);
     }
     check_table_values(test_context, table, col, reference);
@@ -5057,8 +5056,7 @@ void test_tables(TestContext& test_context, DBRef sg, const realm::DataType type
         if (it == reference.end()) // skip over holes in the key range
             continue;
         managed<T> value = generator<T>::get(optional);
-        Obj o = table->get_object(ObjKey(j));
-        o.set<T>(col, value.value);
+        table->get_object(ObjKey(j)).set<T>(col, value.value);
         it->second = value;
     }
     check_table_values(test_context, table, col, reference);
@@ -5120,8 +5118,7 @@ void test_dynamic_conversion(TestContext& test_context, DBRef sg, realm::DataTyp
     value_copier<TFrom, TTo> copier(false);
     for (int j = 0; j < 10; ++j) {
         managed<TFrom> value = generator<TFrom>::get(from_nullable);
-        Obj o =
-            table->create_object(ObjKey(j)).set_all(value.value); // <-- so set_all works even if it doesn't set all?
+        table->create_object(ObjKey(j)).set_all(value.value);
         TTo conv_value = copier(
             value.value, to_nullable); // one may argue that using the same converter for ref and dut is.. mmmh...
         reference[j] = managed<TTo>{conv_value};
@@ -5453,7 +5450,7 @@ TEST(Table_EmbeddedObjectCreateAndDestroyList)
     auto parent_ll = o.get_linklist(ck);
     Obj o2 = parent_ll.create_and_insert_linked_object(0);
     Obj o3 = parent_ll.create_and_insert_linked_object(1);
-    Obj o4 = parent_ll.create_and_insert_linked_object(0);
+    parent_ll.create_and_insert_linked_object(0);
     auto o2_ll = o2.get_linklist(col_recurse);
     auto o3_ll = o3.get_linklist(col_recurse);
     o2_ll.create_and_insert_linked_object(0);
@@ -5501,7 +5498,7 @@ TEST(Table_EmbeddedObjectCreateAndDestroyDictionary)
     CHECK_EQUAL(obj_path.path_from_top[0].index.get_string(), "one");
 
     Obj o3 = parent_dict.create_and_insert_linked_object("two");
-    Obj o4 = parent_dict.create_and_insert_linked_object("three");
+    parent_dict.create_and_insert_linked_object("three");
 
     CHECK_EQUAL(parent_dict.get_object("one").get_key(), o2.get_key());
 

--- a/test/test_transform.cpp
+++ b/test/test_transform.cpp
@@ -1705,7 +1705,7 @@ TEST(Transform_AddIntegerSurvivesSetDefault)
         client_1->transaction([&](Peer& c) {
             auto table = c.group->add_table_with_primary_key("class_table", type_Int, "pk");
             table->add_column(type_Int, "int");
-            auto obj = table->create_object_with_primary_key(0);
+            table->create_object_with_primary_key(0);
         });
 
         it.sync_all();
@@ -1761,7 +1761,7 @@ TEST(Transform_AddIntegerSurvivesSetDefault_NoRegularSets)
         client_1->transaction([&](Peer& c) {
             auto table = c.group->add_table_with_primary_key("class_table", type_Int, "pk");
             table->add_column(type_Int, "int");
-            auto obj = table->create_object_with_primary_key(0);
+            table->create_object_with_primary_key(0);
         });
 
         it.sync_all();
@@ -2028,13 +2028,11 @@ TEST(Transform_ArrayEraseVsArrayErase)
     synchronize(server.get(), {client_3.get(), client_4.get(), client_5.get()});
 
     client_5->transaction([](Peer& p) {
-        Obj obj = *p.table("class_A")->begin();
         auto ll = p.table("class_A")->begin()->get_list<String>("h");
         ll.insert(0, "5abc");
     });
 
     client_4->transaction([](Peer& p) {
-        Obj obj = *p.table("class_A")->begin();
         auto ll = p.table("class_A")->begin()->get_list<String>("h");
         ll.insert(0, "4abc");
     });
@@ -2043,13 +2041,11 @@ TEST(Transform_ArrayEraseVsArrayErase)
     server->integrate_next_changeset_from(*client_4);
 
     client_3->transaction([](Peer& p) {
-        Obj obj = *p.table("class_A")->begin();
         auto ll = p.table("class_A")->begin()->get_list<String>("h");
         ll.insert(0, "3abc");
     });
 
     client_5->transaction([](Peer& p) {
-        Obj obj = *p.table("class_A")->begin();
         auto ll = p.table("class_A")->begin()->get_list<String>("h");
         ll.insert(0, "5def");
     });
@@ -2058,13 +2054,11 @@ TEST(Transform_ArrayEraseVsArrayErase)
     server->integrate_next_changeset_from(*client_5);
 
     client_4->transaction([](Peer& p) {
-        Obj obj = *p.table("class_A")->begin();
         auto ll = p.table("class_A")->begin()->get_list<String>("h");
         ll.remove(0);
     });
 
     client_5->transaction([](Peer& p) {
-        Obj obj = *p.table("class_A")->begin();
         auto ll = p.table("class_A")->begin()->get_list<String>("h");
         ll.remove(0);
     });

--- a/test/test_typed_links.cpp
+++ b/test/test_typed_links.cpp
@@ -219,7 +219,7 @@ TEST(TypedLinks_Clear)
     auto col_list_mixed = person->add_column_list(type_Mixed, "mixed_list");
 
     auto pluto = dog->create_object();
-    auto garfield = cat->create_object();
+    cat->create_object();
     auto paul = person->create_object();
 
     paul.set(col_typed, ObjLink{dog->get_key(), pluto.get_key()});

--- a/test/test_uuid.cpp
+++ b/test/test_uuid.cpp
@@ -620,7 +620,7 @@ TEST(UUID_Distinct)
         auto table = wt->add_table("Foo");
         auto col_id = table->add_column(type_UUID, "id", true);
         for (int i = 1; i < 10; i++) {
-            auto obj = table->create_object().set(col_id, ids[i % ids.size()]);
+            table->create_object().set(col_id, ids[i % ids.size()]);
         }
 
         wt->commit();

--- a/test/util/compare_groups.cpp
+++ b/test/util/compare_groups.cpp
@@ -758,8 +758,6 @@ bool compare_objects(const Obj& obj_1, const Obj& obj_2, const std::vector<Colum
             continue;
         }
 
-        auto obj_a = obj_1;
-        auto obj_b = obj_2;
         const bool nullable = table_1.is_nullable(col.key_1);
         REALM_ASSERT(table_2.is_nullable(col.key_2) == nullable);
         switch (col.get_type()) {


### PR DESCRIPTION
This makes it so that it is passed in registers rather than on the stack (on Itanium ABI platforms), which gives a small but measurable performance improvement to basically everything.

A side effect of this is that Obj becomes trivially destructible as well, which results in clang now warning about unused Obj variables.