### PR TITLE
Fix a few thread sanitizer failures

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@
 * Throw `runtime_error` if subscription set is requested and flexible sync is not enabled. ([#5637](https://github.com/realm/realm-core/pull/5637))
 * Fix compilation failures on watchOS platforms which do not support thread-local storage. ([#7694](https://github.com/realm/realm-swift/issues/7694), [#7695](https://github.com/realm/realm-swift/issues/7695) since v11.7.0)
 * Fix a data race when committing a transaction while multiple threads are waiting for the write lock on platforms using emulated interprocess condition variables (most platforms other than non-Android Linux).
+* Fix a data race when writing audit events which could occur if the sync client thread was busy with other work when the event Realm was opened.
 
 ### Breaking changes
 * None.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
 * Fix some warnings when building with Xcode 14 ([PR #5577](https://github.com/realm/realm-core/pull/5577)).
 * Throw `runtime_error` if subscription set is requested and flexible sync is not enabled. ([#5637](https://github.com/realm/realm-core/pull/5637))
 * Fix compilation failures on watchOS platforms which do not support thread-local storage. ([#7694](https://github.com/realm/realm-swift/issues/7694), [#7695](https://github.com/realm/realm-swift/issues/7695) since v11.7.0)
+* Fix a data race when committing a transaction while multiple threads are waiting for the write lock on platforms using emulated interprocess condition variables (most platforms other than non-Android Linux).
 
 ### Breaking changes
 * None.

--- a/src/realm/db.cpp
+++ b/src/realm/db.cpp
@@ -2575,7 +2575,6 @@ DisableReplication::DisableReplication(Transaction& t)
     , m_version(t.get_version())
 {
     m_owner->set_replication(nullptr);
-    t.get_version();
     t.m_history = nullptr;
 }
 

--- a/src/realm/db.cpp
+++ b/src/realm/db.cpp
@@ -2085,14 +2085,12 @@ void DB::do_end_write() noexcept
     SharedInfo* info = m_file_map.get_addr();
     info->next_served.fetch_add(1, std::memory_order_relaxed);
 
-    {
-        std::lock_guard<std::recursive_mutex> local_lock(m_mutex);
-        REALM_ASSERT(m_write_transaction_open);
-        m_alloc.set_read_only(true);
-        m_write_transaction_open = false;
-        m_writemutex.unlock();
-    }
+    std::lock_guard<std::recursive_mutex> local_lock(m_mutex);
+    REALM_ASSERT(m_write_transaction_open);
+    m_alloc.set_read_only(true);
+    m_write_transaction_open = false;
     m_pick_next_writer.notify_all();
+    m_writemutex.unlock();
 }
 
 

--- a/src/realm/table.hpp
+++ b/src/realm/table.hpp
@@ -640,6 +640,24 @@ public:
     ColKey get_opposite_column(ColKey col_key) const;
     ColKey find_opposite_column(ColKey col_key) const;
 
+    class DisableReplication {
+    public:
+        DisableReplication(Table& table) noexcept
+            : m_table(table)
+            , m_repl(table.m_repl)
+        {
+            m_table.m_repl = &g_dummy_replication;
+        }
+        ~DisableReplication()
+        {
+            m_table.m_repl = m_repl;
+        }
+
+    private:
+        Table& m_table;
+        Replication* const* m_repl;
+    };
+
 private:
     enum LifeCycleCookie {
         cookie_created = 0x1234,


### PR DESCRIPTION
The emulated implementation of InterprocessCondVar requires that the associated mutex be held when `notify_all()` is called because it performs non-atomic reads and writes on the shared part, which would be a data race if done without a mutex covering the access. This is already noted as a precondition of the function, which DB::do_end_write() violated.

Calling `DB::set_replication()` inside a write transaction is _almost_ safe to do, but it turns out that there's a few scenarios where the sync client will call `DB::get_replication()` outside of a write. Scoping the replication setting to just the specific Table fixes this (as live Table accessors actually are thread-confined) and also simplifies the logic a bit.