### PR TITLE
Add support in the C API in order to create a new `realm_app_t` without caching app in core

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ### Enhancements
 * <New feature description> (PR [#????](https://github.com/realm/realm-core/pull/????))
 * Add support for building with Xcode 14 using the CMake project ([PR #5577](https://github.com/realm/realm-core/pull/5577)).
+* Add support in the C API for constructing a new `realm_app_t` object via `realm_app_create`. ([PR #5570](https://github.com/realm/realm-core/issues/5570))
 
 ### Fixed
 * <How do the end-user experience this issue? what was the impact?> ([#????](https://github.com/realm/realm-core/issues/????), since v?.?.?)

--- a/src/realm.h
+++ b/src/realm.h
@@ -2732,6 +2732,15 @@ RLM_API void realm_app_config_set_sdk_version(realm_app_config_t*, const char*) 
 RLM_API const char* realm_app_credentials_serialize_as_json(realm_app_credentials_t*) RLM_API_NOEXCEPT;
 
 /**
+ * Create realm_app_t* instance given a valid realm configuration and sync client configuration.
+ * 
+ * @return A non-null pointer if no error occurred.
+ */
+RLM_API realm_app_t* realm_app_create(const realm_app_config_t*, const realm_sync_client_config_t*);
+
+/**
+ * @note this API will be removed and it is now deprecated in favour of realm_app_create
+ *
  * Get an existing @a realm_app_t* instance with the same app id, or create it with the
  * configuration if it doesn't exist.
  *
@@ -2740,6 +2749,8 @@ RLM_API const char* realm_app_credentials_serialize_as_json(realm_app_credential
 RLM_API realm_app_t* realm_app_get(const realm_app_config_t*, const realm_sync_client_config_t*);
 
 /**
+ * @note this API will be removed and it is now deprecated in favour of realm_app_create
+ *
  * Get an existing @a realm_app_t* instance from the cache.
  *
  * @return Cached app instance, or null if no cached app exists for this @a app_id.

--- a/src/realm/object-store/c_api/app.cpp
+++ b/src/realm/object-store/c_api/app.cpp
@@ -347,6 +347,14 @@ RLM_API const char* realm_app_credentials_serialize_as_json(realm_app_credential
     });
 }
 
+RLM_API realm_app_t* realm_app_create(const realm_app_config_t* app_config,
+                                      const realm_sync_client_config_t* sync_client_config)
+{
+    return wrap_err([&] {
+        return new realm_app_t(App::get_uncached_app(*app_config, *sync_client_config));
+    });
+}
+
 RLM_API realm_app_t* realm_app_get(const realm_app_config_t* app_config,
                                    const realm_sync_client_config_t* sync_client_config)
 {


### PR DESCRIPTION
## What, How & Why?
Added a new C API function called `realm_app_create` in order to create a new `realm_app_t` object without caching it in core. 
This change deprecates: `realm_app_get` and `realm_app_get_cached` which will be removed in another PR.
Fixes: https://github.com/realm/realm-core/issues/5570

