### PR TITLE
Expose sync session shutdown and realm delete files in one API

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,8 @@
 ### Enhancements
 * <New feature description> (PR [#????](https://github.com/realm/realm-core/pull/????))
 * Add support for building with Xcode 14 using the CMake project ([PR #5577](https://github.com/realm/realm-core/pull/5577)).
-* Add support in the C API for constructing a new `realm_app_t` object via `realm_app_create`. ([PR #5570](https://github.com/realm/realm-core/issues/5570))
+* Add support in the C API for constructing a new `realm_app_t` object via `realm_app_create. ([PR #5570](https://github.com/realm/realm-core/issues/5570))
+* Add support in the C API for closing a sync session and delete all realm files if possible. ([#5542](https://github.com/realm/realm-core/issues/5542))
 
 ### Fixed
 * <How do the end-user experience this issue? what was the impact?> ([#????](https://github.com/realm/realm-core/issues/????), since v?.?.?)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
 ### Enhancements
 * <New feature description> (PR [#????](https://github.com/realm/realm-core/pull/????))
 * Add support for building with Xcode 14 using the CMake project ([PR #5577](https://github.com/realm/realm-core/pull/5577)).
-* Add support in the C API for constructing a new `realm_app_t` object via `realm_app_create. ([PR #5570](https://github.com/realm/realm-core/issues/5570))
+* Add support in the C API for constructing a new `realm_app_t` object via `realm_app_create. ([#5570](https://github.com/realm/realm-core/issues/5570))
 * Add support in the C API for closing a sync session and delete all realm files if possible. ([#5542](https://github.com/realm/realm-core/issues/5542))
 
 ### Fixed

--- a/src/realm.h
+++ b/src/realm.h
@@ -3802,6 +3802,17 @@ RLM_API void realm_sync_session_handle_error_for_testing(const realm_sync_sessio
                                                          int category, const char* error_message, bool is_fatal);
 
 /**
+ * Wrapper for SyncSession::shutdown_and_wait + delete realm files.
+ * The realm files can/cannot be deleted. SyncSession::shutdown_and_wait will block until
+ * the sync session does not get closed.
+ * @param session ptr to a valid sync session
+ * @param realm_path a null terminated string containing the path where the realm files are
+ * @param did_delete a boolean flag indicating whether the files were deleted or not
+ * @return False in case of errors, otherwise returns True.
+ */
+RLM_API bool realm_sync_shutdown_and_delete_realm(const realm_sync_session_t* session, const char* realm_path, bool* did_delete);
+
+/**
  * In case of exception thrown in user code callbacks, this api will allow the sdk to store the user code exception
  * and retrieve a it later via realm_get_last_error.
  * Most importantly the SDK is responsible to handle the memory pointed by usercode_error.

--- a/src/realm.h
+++ b/src/realm.h
@@ -3810,7 +3810,8 @@ RLM_API void realm_sync_session_handle_error_for_testing(const realm_sync_sessio
  * @param did_delete a boolean flag indicating whether the files were deleted or not
  * @return False in case of errors, otherwise returns True.
  */
-RLM_API bool realm_sync_shutdown_and_delete_realm(const realm_sync_session_t* session, const char* realm_path, bool* did_delete);
+RLM_API bool realm_sync_shutdown_and_delete_realm(const realm_sync_session_t* session, const char* realm_path,
+                                                  bool* did_delete);
 
 /**
  * In case of exception thrown in user code callbacks, this api will allow the sdk to store the user code exception

--- a/src/realm.h
+++ b/src/realm.h
@@ -3806,12 +3806,10 @@ RLM_API void realm_sync_session_handle_error_for_testing(const realm_sync_sessio
  * The realm files can/cannot be deleted. SyncSession::shutdown_and_wait will block until
  * the sync session does not get closed.
  * @param session ptr to a valid sync session
- * @param realm_path a null terminated string containing the path where the realm files are
  * @param did_delete a boolean flag indicating whether the files were deleted or not
  * @return False in case of errors, otherwise returns True.
  */
-RLM_API bool realm_sync_shutdown_and_delete_realm(const realm_sync_session_t* session, const char* realm_path,
-                                                  bool* did_delete);
+RLM_API bool realm_sync_shutdown_and_delete_realm(const realm_sync_session_t* session, bool* did_delete);
 
 /**
  * In case of exception thrown in user code callbacks, this api will allow the sdk to store the user code exception

--- a/src/realm/object-store/c_api/sync.cpp
+++ b/src/realm/object-store/c_api/sync.cpp
@@ -962,14 +962,12 @@ RLM_API void realm_sync_session_handle_error_for_testing(const realm_sync_sessio
     SyncSession::OnlyForTesting::handle_error(*session->get(), {err, error_message, is_fatal});
 }
 
-RLM_API bool realm_sync_shutdown_and_delete_realm(const realm_sync_session_t* session, const char* realm_path,
-                                                  bool* did_delete)
+RLM_API bool realm_sync_shutdown_and_delete_realm(const realm_sync_session_t* session, bool* did_delete)
 {
     REALM_ASSERT(session);
-    REALM_ASSERT(realm_path);
     return wrap_err([&]() {
         (*session)->shutdown_and_wait();
-        return realm_delete_files(realm_path, did_delete);
+        return realm_delete_files((*session)->path().c_str(), did_delete);
     });
 }
 

--- a/src/realm/object-store/c_api/sync.cpp
+++ b/src/realm/object-store/c_api/sync.cpp
@@ -962,12 +962,12 @@ RLM_API void realm_sync_session_handle_error_for_testing(const realm_sync_sessio
     SyncSession::OnlyForTesting::handle_error(*session->get(), {err, error_message, is_fatal});
 }
 
-RLM_API bool realm_sync_shutdown_and_delete_realm(const realm_sync_session_t* session,
-                                                  const char* realm_path, bool* did_delete)
+RLM_API bool realm_sync_shutdown_and_delete_realm(const realm_sync_session_t* session, const char* realm_path,
+                                                  bool* did_delete)
 {
     REALM_ASSERT(session);
     REALM_ASSERT(realm_path);
-    return wrap_err([&](){
+    return wrap_err([&]() {
         (*session)->shutdown_and_wait();
         return realm_delete_files(realm_path, did_delete);
     });

--- a/src/realm/object-store/c_api/sync.cpp
+++ b/src/realm/object-store/c_api/sync.cpp
@@ -962,4 +962,15 @@ RLM_API void realm_sync_session_handle_error_for_testing(const realm_sync_sessio
     SyncSession::OnlyForTesting::handle_error(*session->get(), {err, error_message, is_fatal});
 }
 
+RLM_API bool realm_sync_shutdown_and_delete_realm(const realm_sync_session_t* session,
+                                                  const char* realm_path, bool* did_delete)
+{
+    REALM_ASSERT(session);
+    REALM_ASSERT(realm_path);
+    return wrap_err([&](){
+        (*session)->shutdown_and_wait();
+        return realm_delete_files(realm_path, did_delete);
+    });
+}
+
 } // namespace realm::c_api


### PR DESCRIPTION
## What, How & Why?
Expose new C API for closing realm sync session and deleting files.
Fixes: https://github.com/realm/realm-core/issues/5542

## ☑️ ToDos
* [ ] 📝 Changelog update
* [x] 🚦 Tests (or not relevant)
* [ ] C-API, if public C++ API changed.
