### PR TITLE
Pass the nightly version string to the Xcode build script

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -775,7 +775,7 @@ def doBuildApplePlatform(String platform, String buildType, boolean test = false
 
             withEnv(['DEVELOPER_DIR=/Applications/Xcode-13.1.app/Contents/Developer/',
                      'XCODE_14_DEVELOPER_DIR=/Applications/Xcode-14.app/Contents/Developer/']) {
-                sh "tools/build-apple-device.sh -p '${platform}' -c '${buildType}'"
+                sh "tools/build-apple-device.sh -p '${platform}' -c '${buildType}' -v '${gitDescribeVersion}'"
 
                 if (test) {
                     dir('build-xcode-platforms') {

--- a/tools/build-apple-device.sh
+++ b/tools/build-apple-device.sh
@@ -6,7 +6,7 @@ SCRIPT="$(basename "${BASH_SOURCE[0]}")"
 VERSION="$(git describe)"
 
 function usage {
-    echo "Usage: ${SCRIPT} -p <platform> [-c <configuration>] [-f <cmake-flags>]"
+    echo "Usage: ${SCRIPT} -p <platform> [-c <configuration>] [-v <version>] [-f <cmake-flags>]"
     echo ""
     echo "Supported platforms:"
     echo "  iphoneos iphonesimulator"
@@ -17,15 +17,17 @@ function usage {
     echo "Arguments:"
     echo "   -p : Platform to build"
     echo "   -c : Configuration to build [Debug|Release|RelWithDebugSymbols]"
+    echo "   -v : Version string to use"
     echo "   -f : additional configuration flags to pass to cmake"
     exit 1;
 }
 buildType="Debug"
 CMAKE_FLAGS=''
-while getopts ":p:c:f:" opt; do
+while getopts ":p:c:v:f:" opt; do
     case "${opt}" in
         p) platform="${OPTARG}";;
         c) buildType="${OPTARG}";;
+        v) VERSION="${OPTARG}";;
         f) CMAKE_FLAGS=${OPTARG};;
         *) usage;;
     esac


### PR DESCRIPTION
This ensures that the CPack tarballs have the correct version in their filename in nightly builds.
