### PR TITLE
Fix bloaty CI test that is currently failing on master

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,9 +7,9 @@
 
 ### Fixed
 * <How do the end-user experience this issue? what was the impact?> ([#????](https://github.com/realm/realm-core/issues/????), since v?.?.?)
-* Fix exception when decoding interned strings in realm-apply-to-state tool. ([#5628](https://github.com/realm/realm-core/pull/5628))
+* Fix exception when decoding interned strings in realm-apply-to-state tool. ([PR #5628](https://github.com/realm/realm-core/pull/5628))
 * Fix some warnings when building with Xcode 14 ([PR #5577](https://github.com/realm/realm-core/pull/5577)).
-* Throw `runtime_error` if subscription set is requested and flexible sync is not enabled. ([#5637](https://github.com/realm/realm-core/pull/5637))
+* Throw `runtime_error` if subscription set is requested and flexible sync is not enabled. ([PR #5637](https://github.com/realm/realm-core/pull/5637))
 * Fix compilation failures on watchOS platforms which do not support thread-local storage. ([#7694](https://github.com/realm/realm-swift/issues/7694), [#7695](https://github.com/realm/realm-swift/issues/7695) since v11.7.0)
 
 ### Breaking changes
@@ -22,6 +22,7 @@
 
 ### Internals
 * Add support for running the object store tests and some of the benchmarks on iOS ([PR #5577](https://github.com/realm/realm-core/pull/5577)).
+* Fix bloaty CI test that is currently failing on master ([PR #5650](https://github.com/realm/realm-core/pull/5650))
 
 ----------------------------------------------
 

--- a/evergreen/config.yml
+++ b/evergreen/config.yml
@@ -380,7 +380,7 @@ tasks:
         BLOATY=$(pwd)/bin/bloaty
         cd ..
 
-        FILES_TO_ANALYZE="./build/src/realm/object-store/c_api/librealm-ffi.so"
+        FILES_TO_ANALYZE="./build/src/realm/object-store/c_api/${cmake_build_type|Debug}/librealm-ffi.so"
 
         mkdir bloaty-results
         for input_path in $FILES_TO_ANALYZE; do


### PR DESCRIPTION
## What, How & Why?
* The bloaty test is failing after the compile step due to the compile output file 'librealm-ffi.so' not being found when the bloaty analysis is run.
* The path to the file did not include the target directory (e.g. `RelWithDebInfo`). The list of files passed to the bloaty tool was updated with the cmake build type variable to point to the correct directory.

## ☑️ ToDos
* [x] 📝 Changelog update
* [ ] ~~🚦 Tests (or not relevant)~~
* [ ] ~~C-API, if public C++ API changed.~~
