### PR TITLE
Fix a race condition when recording audit write events

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@
 * Fix compilation failures on watchOS platforms which do not support thread-local storage. ([#7694](https://github.com/realm/realm-swift/issues/7694), [#7695](https://github.com/realm/realm-swift/issues/7695) since v11.7.0)
 * Fix a data race when committing a transaction while multiple threads are waiting for the write lock on platforms using emulated interprocess condition variables (most platforms other than non-Android Linux).
 * Fix a data race when writing audit events which could occur if the sync client thread was busy with other work when the event Realm was opened.
+* Audit event scopes containing only write events and no read events would occasionally throw a `BadVersion` exception when a write transaction was committed (since v11.17.0).
 
 ### Breaking changes
 * None.

--- a/src/realm/object-store/audit.hpp
+++ b/src/realm/object-store/audit.hpp
@@ -72,6 +72,7 @@ public:
     // record_write() should be handled automatically
     virtual void record_query(VersionID, const TableView&) = 0;
     virtual void record_read(VersionID, const Obj& obj, const Obj& parent, ColKey col) = 0;
+    virtual void prepare_for_write(VersionID old_version) = 0;
     virtual void record_write(VersionID old_version, VersionID new_version) = 0;
 
     // -- Audit functionality which should be exposed in the SDK

--- a/src/realm/object-store/shared_realm.cpp
+++ b/src/realm/object-store/shared_realm.cpp
@@ -972,6 +972,9 @@ void Realm::commit_transaction()
     }
 
     DB::VersionID prev_version = transaction().get_version_of_current_transaction();
+    if (auto audit = audit_context()) {
+        audit->prepare_for_write(prev_version);
+    }
 
     m_coordinator->commit_write(*this, /* commit_to_disk */ true);
     cache_new_schema();


### PR DESCRIPTION
Recording audit write events requires having access to the old and new versions of the objects so that we can report the old value of properties in the events. This was done by beginning a read Transaction at the old version after committing the write transaction, but this is too late; if another write transaction happens on a different thread (say, by the sync client) in between the commit and the call to `record_write()` the old version may be cleaned up already.

No new test since this requires a very tight timing window, and if it wasn't for that one of the Swift tests coincidentally hits this ~5% of the time I would have thought it couldn't actually happen in practice.