### PR TITLE
Fix client reset callbacks not populating Realm instances sometimes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@
 * Fix a data race when writing audit events which could occur if the sync client thread was busy with other work when the event Realm was opened.
 * Fix some cases of running out of virtual address space (seen/reported as mmap failures) ([PR #5645](https://github.com/realm/realm-core/pull/5645))
 * Audit event scopes containing only write events and no read events would occasionally throw a `BadVersion` exception when a write transaction was committed (since v11.17.0).
+* Fixed the client reset callbacks not populating the Realm instance arguments correctly if the Realm coordinator lifetime had ended. ([#5654](https://github.com/realm/realm-core/pull/5654), since the introduction of DiscardLocal reset mode in v11.5.0)
 
 ### Breaking changes
 * None.

--- a/src/realm/object-store/audit.mm
+++ b/src/realm/object-store/audit.mm
@@ -840,7 +840,10 @@ void AuditRealmPool::scan_for_realms_to_upload()
 
         m_open_paths.insert(path);
         auto partition = file_name.substr(0, file_name.size() - 6);
-        wait_for_upload(m_user->sync_manager()->get_session(db, SyncConfig{m_user, prefixed_partition(partition)}));
+        RealmConfig config;
+        config.path = db->get_path();
+        config.sync_config = std::make_shared<SyncConfig>(m_user, prefixed_partition(partition));
+        wait_for_upload(m_user->sync_manager()->get_session(db, config));
         return;
     }
 

--- a/src/realm/object-store/impl/realm_coordinator.cpp
+++ b/src/realm/object-store/impl/realm_coordinator.cpp
@@ -101,7 +101,7 @@ void RealmCoordinator::create_sync_session()
     if (m_sync_session)
         return;
 
-    m_sync_session = m_config.sync_config->user->sync_manager()->get_session(m_db, *m_config.sync_config);
+    m_sync_session = m_config.sync_config->user->sync_manager()->get_session(m_db, m_config);
 
     std::weak_ptr<RealmCoordinator> weak_self = shared_from_this();
     SyncSession::Internal::set_sync_transact_callback(*m_sync_session, [weak_self](VersionID, VersionID) {

--- a/src/realm/object-store/sync/sync_manager.hpp
+++ b/src/realm/object-store/sync/sync_manager.hpp
@@ -139,7 +139,7 @@ public:
     util::Logger::Level log_level() const noexcept REQUIRES(!m_mutex);
 
     std::vector<std::shared_ptr<SyncSession>> get_all_sessions() const REQUIRES(!m_session_mutex);
-    std::shared_ptr<SyncSession> get_session(std::shared_ptr<DB> db, const SyncConfig& config)
+    std::shared_ptr<SyncSession> get_session(std::shared_ptr<DB> db, const RealmConfig& config)
         REQUIRES(!m_mutex, !m_session_mutex);
     std::shared_ptr<SyncSession> get_existing_session(const std::string& path) const REQUIRES(!m_session_mutex);
     std::shared_ptr<SyncSession> get_existing_active_session(const std::string& path) const

--- a/src/realm/object-store/sync/sync_session.cpp
+++ b/src/realm/object-store/sync/sync_session.cpp
@@ -235,7 +235,7 @@ SyncSession::handle_refresh(const std::shared_ptr<SyncSession>& session)
     };
 }
 
-SyncSession::SyncSession(SyncClient& client, std::shared_ptr<DB> db, SyncConfig config, SyncManager* sync_manager)
+SyncSession::SyncSession(SyncClient& client, std::shared_ptr<DB> db, RealmConfig config, SyncManager* sync_manager)
     : m_config(std::move(config))
     , m_db(std::move(db))
     , m_flx_subscription_store([this](bool use_flx_sync) -> std::shared_ptr<sync::SubscriptionStore> {
@@ -253,11 +253,12 @@ SyncSession::SyncSession(SyncClient& client, std::shared_ptr<DB> db, SyncConfig 
                 m_session->on_new_flx_sync_subscription(new_version);
             }
         });
-    }(m_config.flx_sync_requested))
+    }(m_config.sync_config&& m_config.sync_config->flx_sync_requested))
     , m_client(client)
     , m_sync_manager(sync_manager)
 {
-    if (m_config.flx_sync_requested) {
+    REALM_ASSERT(m_config.sync_config);
+    if (m_config.sync_config->flx_sync_requested) {
         std::weak_ptr<sync::SubscriptionStore> weak_sub_mgr(m_flx_subscription_store);
         auto& history = static_cast<sync::ClientReplication&>(*m_db->get_replication());
         history.set_write_validator_factory(
@@ -302,18 +303,19 @@ void SyncSession::update_error_and_mark_file_for_deletion(SyncError& error, Shou
     auto original_path = path();
     error.user_info[SyncError::c_original_file_path_key] = original_path;
     if (should_backup == ShouldBackup::yes) {
-        recovery_path =
-            util::reserve_unique_file_name(m_sync_manager->recovery_directory_path(m_config.recovery_directory),
-                                           util::create_timestamped_template("recovered_realm"));
+        recovery_path = util::reserve_unique_file_name(
+            m_sync_manager->recovery_directory_path(m_config.sync_config->recovery_directory),
+            util::create_timestamped_template("recovered_realm"));
         error.user_info[SyncError::c_recovery_file_path_key] = recovery_path;
     }
     using Action = SyncFileActionMetadata::Action;
     auto action = should_backup == ShouldBackup::yes ? Action::BackUpThenDeleteRealm : Action::DeleteRealm;
-    m_sync_manager->perform_metadata_update(
-        [action, original_path = std::move(original_path), recovery_path = std::move(recovery_path),
-         partition_value = m_config.partition_value, identity = m_config.user->identity()](const auto& manager) {
-            manager.make_file_action_metadata(original_path, partition_value, identity, action, recovery_path);
-        });
+    m_sync_manager->perform_metadata_update([action, original_path = std::move(original_path),
+                                             recovery_path = std::move(recovery_path),
+                                             partition_value = m_config.sync_config->partition_value,
+                                             identity = m_config.sync_config->user->identity()](const auto& manager) {
+        manager.make_file_action_metadata(original_path, partition_value, identity, action, recovery_path);
+    });
 }
 
 void SyncSession::download_fresh_realm(util::Optional<SyncError::ClientResetModeAllowed> allowed_mode)
@@ -363,9 +365,11 @@ void SyncSession::download_fresh_realm(util::Optional<SyncError::ClientResetMode
     std::shared_ptr<SyncSession> sync_session;
     {
         util::CheckedLockGuard config_lock(m_config_mutex);
-        SyncConfig config = m_config;
-        config.stop_policy = SyncSessionStopPolicy::Immediately;
-        config.client_resync_mode = ClientResyncMode::Manual;
+        RealmConfig config = m_config;
+        // deep copy the sync config so we don't modify the live session's config
+        config.sync_config = std::make_shared<SyncConfig>(*m_config.sync_config);
+        config.sync_config->stop_policy = SyncSessionStopPolicy::Immediately;
+        config.sync_config->client_resync_mode = ClientResyncMode::Manual;
         sync_session = create(m_client, db, config, m_sync_manager);
         auto& history = static_cast<sync::ClientReplication&>(*db->get_replication());
         // the fresh Realm may apply writes to this db after it has outlived its sync session
@@ -660,42 +664,40 @@ void SyncSession::handle_progress_update(uint64_t downloaded, uint64_t downloada
     m_progress_notifier.update(downloaded, downloadable, uploaded, uploadable, download_version, snapshot_version);
 }
 
-static sync::Session::Config::ClientReset make_client_reset_config(SyncConfig& session_config, DBRef&& fresh_copy,
+static sync::Session::Config::ClientReset make_client_reset_config(RealmConfig& session_config, DBRef&& fresh_copy,
                                                                    bool recovery_is_allowed)
 {
+    RealmConfig copy_config = session_config;
+    copy_config.sync_config = std::make_shared<SyncConfig>(*session_config.sync_config);
     sync::Session::Config::ClientReset config;
-    REALM_ASSERT(session_config.client_resync_mode != ClientResyncMode::Manual);
-    config.mode = session_config.client_resync_mode;
-    config.notify_after_client_reset = [notify = session_config.notify_after_client_reset](
-                                           std::string local_path, VersionID previous_version, bool did_recover) {
-        REALM_ASSERT(!local_path.empty());
-        SharedRealm frozen_before;
-        ThreadSafeReference active_after;
-        if (auto local_coordinator = RealmCoordinator::get_existing_coordinator(local_path)) {
+    REALM_ASSERT(session_config.sync_config->client_resync_mode != ClientResyncMode::Manual);
+    config.mode = session_config.sync_config->client_resync_mode;
+    config.notify_after_client_reset = [config = copy_config](std::string local_path, VersionID previous_version,
+                                                              bool did_recover) {
+        if (config.sync_config->notify_after_client_reset) {
+            REALM_ASSERT(local_path == config.path);
+            auto local_coordinator = RealmCoordinator::get_coordinator(config);
+            REALM_ASSERT(local_coordinator);
             auto local_config = local_coordinator->get_config();
-            active_after = local_coordinator->get_unbound_realm();
+            ThreadSafeReference active_after = local_coordinator->get_unbound_realm();
             local_config.scheduler = nullptr;
-            frozen_before = local_coordinator->get_realm(local_config, previous_version);
+            SharedRealm frozen_before = local_coordinator->get_realm(local_config, previous_version);
             REALM_ASSERT(frozen_before);
             REALM_ASSERT(frozen_before->is_frozen());
-        }
-        if (notify) {
-            notify(frozen_before, std::move(active_after), did_recover);
+            config.sync_config->notify_after_client_reset(frozen_before, std::move(active_after), did_recover);
         }
     };
-    config.notify_before_client_reset = [notify = session_config.notify_before_client_reset](std::string local_path) {
-        REALM_ASSERT(!local_path.empty());
-        SharedRealm frozen_local;
-        Realm::Config local_config;
-        if (auto local_coordinator = RealmCoordinator::get_existing_coordinator(local_path)) {
-            local_config = local_coordinator->get_config();
+    config.notify_before_client_reset = [config = copy_config](std::string local_path) {
+        if (config.sync_config->notify_before_client_reset) {
+            REALM_ASSERT(local_path == config.path);
+            auto local_coordinator = RealmCoordinator::get_coordinator(config);
+            REALM_ASSERT(local_coordinator);
+            auto local_config = local_coordinator->get_config();
             local_config.scheduler = nullptr;
-            frozen_local = local_coordinator->get_realm(local_config, VersionID());
+            SharedRealm frozen_local = local_coordinator->get_realm(local_config, VersionID());
             REALM_ASSERT(frozen_local);
             REALM_ASSERT(frozen_local->is_frozen());
-        }
-        if (notify) {
-            notify(frozen_local);
+            config.sync_config->notify_before_client_reset(frozen_local);
         }
     };
     config.fresh_copy = std::move(fresh_copy);
@@ -711,25 +713,27 @@ void SyncSession::create_sync_session()
 
     util::CheckedLockGuard config_lock(m_config_mutex);
 
-    REALM_ASSERT(m_config.user);
+    REALM_ASSERT(m_config.sync_config);
+    SyncConfig& sync_config = *m_config.sync_config;
+    REALM_ASSERT(sync_config.user);
 
     sync::Session::Config session_config;
-    session_config.signed_user_token = m_config.user->access_token();
-    session_config.realm_identifier = m_config.partition_value;
-    session_config.verify_servers_ssl_certificate = m_config.client_validate_ssl;
-    session_config.ssl_trust_certificate_path = m_config.ssl_trust_certificate_path;
-    session_config.ssl_verify_callback = m_config.ssl_verify_callback;
-    session_config.proxy_config = m_config.proxy_config;
-    if (m_config.on_download_message_received_hook) {
+    session_config.signed_user_token = sync_config.user->access_token();
+    session_config.realm_identifier = sync_config.partition_value;
+    session_config.verify_servers_ssl_certificate = sync_config.client_validate_ssl;
+    session_config.ssl_trust_certificate_path = sync_config.ssl_trust_certificate_path;
+    session_config.ssl_verify_callback = sync_config.ssl_verify_callback;
+    session_config.proxy_config = sync_config.proxy_config;
+    if (sync_config.on_download_message_received_hook) {
         session_config.on_download_message_received_hook =
-            [hook = m_config.on_download_message_received_hook, anchor = weak_from_this()](
+            [hook = sync_config.on_download_message_received_hook, anchor = weak_from_this()](
                 const sync::SyncProgress& progress, int64_t query_version, sync::DownloadBatchState batch_state) {
                 hook(anchor, progress, query_version, batch_state);
             };
     }
-    if (m_config.on_bootstrap_message_processed_hook) {
+    if (sync_config.on_bootstrap_message_processed_hook) {
         session_config.on_bootstrap_message_processed_hook =
-            [hook = m_config.on_bootstrap_message_processed_hook,
+            [hook = sync_config.on_bootstrap_message_processed_hook,
              anchor = weak_from_this()](const sync::SyncProgress& progress, int64_t query_version,
                                         sync::DownloadBatchState batch_state) -> bool {
             return hook(anchor, progress, query_version, batch_state);
@@ -749,10 +753,10 @@ void SyncSession::create_sync_session()
         m_server_url = sync_route;
     }
 
-    if (m_config.authorization_header_name) {
-        session_config.authorization_header_name = *m_config.authorization_header_name;
+    if (sync_config.authorization_header_name) {
+        session_config.authorization_header_name = *sync_config.authorization_header_name;
     }
-    session_config.custom_http_headers = m_config.custom_http_headers;
+    session_config.custom_http_headers = sync_config.custom_http_headers;
 
     if (m_force_client_reset) {
         const bool allowed_to_recover = *m_force_client_reset == SyncError::ClientResetModeAllowed::RecoveryPermitted;
@@ -1115,8 +1119,8 @@ void SyncSession::update_configuration(SyncConfig new_config)
         util::CheckedUniqueLock config_lock(m_config_mutex);
         REALM_ASSERT(m_state == State::Inactive);
         REALM_ASSERT(!m_session);
-        REALM_ASSERT(m_config.user == new_config.user);
-        m_config = std::move(new_config);
+        REALM_ASSERT(m_config.sync_config->user == new_config.user);
+        m_config.sync_config = std::make_shared<SyncConfig>(std::move(new_config));
         break;
     }
     revive_if_needed();

--- a/src/realm/object-store/sync/sync_session.hpp
+++ b/src/realm/object-store/sync/sync_session.hpp
@@ -20,6 +20,7 @@
 #define REALM_OS_SYNC_SESSION_HPP
 
 #include <realm/object-store/feature_checks.hpp>
+#include <realm/object-store/shared_realm.hpp>
 #include <realm/object-store/sync/generic_network_transport.hpp>
 #include <realm/sync/config.hpp>
 #include <realm/sync/subscriptions.hpp>
@@ -219,14 +220,16 @@ public:
     std::shared_ptr<SyncUser> user() const REQUIRES(!m_config_mutex)
     {
         util::CheckedLockGuard lock(m_config_mutex);
-        return m_config.user;
+        REALM_ASSERT(m_config.sync_config);
+        return m_config.sync_config->user;
     }
 
     // A copy of the configuration object describing the Realm this `SyncSession` represents.
     SyncConfig config() const REQUIRES(!m_config_mutex)
     {
         util::CheckedLockGuard lock(m_config_mutex);
-        return m_config;
+        REALM_ASSERT(m_config.sync_config);
+        return *m_config.sync_config;
     }
 
     // If the `SyncSession` has been configured, the full remote URL of the Realm
@@ -311,16 +314,17 @@ private:
 
     friend class realm::SyncManager;
     // Called by SyncManager {
-    static std::shared_ptr<SyncSession> create(_impl::SyncClient& client, std::shared_ptr<DB> db, SyncConfig config,
+    static std::shared_ptr<SyncSession> create(_impl::SyncClient& client, std::shared_ptr<DB> db, RealmConfig config,
                                                SyncManager* sync_manager)
     {
         struct MakeSharedEnabler : public SyncSession {
-            MakeSharedEnabler(_impl::SyncClient& client, std::shared_ptr<DB> db, SyncConfig config,
+            MakeSharedEnabler(_impl::SyncClient& client, std::shared_ptr<DB> db, RealmConfig config,
                               SyncManager* sync_manager)
                 : SyncSession(client, std::move(db), std::move(config), sync_manager)
             {
             }
         };
+        REALM_ASSERT(config.sync_config);
         return std::make_shared<MakeSharedEnabler>(client, std::move(db), std::move(config), std::move(sync_manager));
     }
     // }
@@ -330,7 +334,7 @@ private:
     static util::UniqueFunction<void(util::Optional<app::AppError>)>
     handle_refresh(const std::shared_ptr<SyncSession>&);
 
-    SyncSession(_impl::SyncClient&, std::shared_ptr<DB>, SyncConfig, SyncManager* sync_manager);
+    SyncSession(_impl::SyncClient&, std::shared_ptr<DB>, RealmConfig, SyncManager* sync_manager);
 
     void download_fresh_realm(util::Optional<SyncError::ClientResetModeAllowed> allowed_mode)
         REQUIRES(!m_config_mutex, !m_state_mutex, !m_connection_state_mutex);
@@ -370,7 +374,7 @@ private:
     auto config(Field f) REQUIRES(!m_config_mutex)
     {
         util::CheckedLockGuard lock(m_config_mutex);
-        return m_config.*f;
+        return m_config.sync_config.get()->*f;
     }
 
     void assert_mutex_unlocked() ASSERT_CAPABILITY(!m_state_mutex) ASSERT_CAPABILITY(!m_config_mutex) {}
@@ -387,7 +391,7 @@ private:
     size_t m_death_count GUARDED_BY(m_state_mutex) = 0;
 
     mutable util::CheckedMutex m_config_mutex;
-    SyncConfig m_config GUARDED_BY(m_config_mutex);
+    RealmConfig m_config GUARDED_BY(m_config_mutex);
     const std::shared_ptr<DB> m_db;
     const std::shared_ptr<sync::SubscriptionStore> m_flx_subscription_store;
     util::Optional<SyncError::ClientResetModeAllowed> m_force_client_reset GUARDED_BY(m_state_mutex) = util::none;

--- a/src/realm/object-store/sync/sync_session.hpp
+++ b/src/realm/object-store/sync/sync_session.hpp
@@ -314,18 +314,18 @@ private:
 
     friend class realm::SyncManager;
     // Called by SyncManager {
-    static std::shared_ptr<SyncSession> create(_impl::SyncClient& client, std::shared_ptr<DB> db, RealmConfig config,
-                                               SyncManager* sync_manager)
+    static std::shared_ptr<SyncSession> create(_impl::SyncClient& client, std::shared_ptr<DB> db,
+                                               const RealmConfig& config, SyncManager* sync_manager)
     {
         struct MakeSharedEnabler : public SyncSession {
-            MakeSharedEnabler(_impl::SyncClient& client, std::shared_ptr<DB> db, RealmConfig config,
+            MakeSharedEnabler(_impl::SyncClient& client, std::shared_ptr<DB> db, const RealmConfig& config,
                               SyncManager* sync_manager)
-                : SyncSession(client, std::move(db), std::move(config), sync_manager)
+                : SyncSession(client, std::move(db), config, sync_manager)
             {
             }
         };
         REALM_ASSERT(config.sync_config);
-        return std::make_shared<MakeSharedEnabler>(client, std::move(db), std::move(config), std::move(sync_manager));
+        return std::make_shared<MakeSharedEnabler>(client, std::move(db), config, std::move(sync_manager));
     }
     // }
 
@@ -334,7 +334,7 @@ private:
     static util::UniqueFunction<void(util::Optional<app::AppError>)>
     handle_refresh(const std::shared_ptr<SyncSession>&);
 
-    SyncSession(_impl::SyncClient&, std::shared_ptr<DB>, RealmConfig, SyncManager* sync_manager);
+    SyncSession(_impl::SyncClient&, std::shared_ptr<DB>, const RealmConfig&, SyncManager* sync_manager);
 
     void download_fresh_realm(util::Optional<SyncError::ClientResetModeAllowed> allowed_mode)
         REQUIRES(!m_config_mutex, !m_state_mutex, !m_connection_state_mutex);

--- a/test/object-store/sync/sync_test_utils.cpp
+++ b/test/object-store/sync/sync_test_utils.cpp
@@ -469,6 +469,9 @@ struct BaasClientReset : public TestClientReset {
         if (m_on_post_local) {
             m_on_post_local(realm);
         }
+        if (!m_wait_for_reset_completion) {
+            return;
+        }
         wait_for_upload(*realm);
         if (m_on_post_reset) {
             m_on_post_reset(realm);
@@ -675,6 +678,11 @@ void TestClientReset::set_pk_of_object_driving_reset(const ObjectId& pk)
 ObjectId TestClientReset::get_pk_of_object_driving_reset() const
 {
     return m_pk_driving_reset;
+}
+
+void TestClientReset::disable_wait_for_reset_completion()
+{
+    m_wait_for_reset_completion = false;
 }
 
 std::unique_ptr<TestClientReset> make_fake_local_client_reset(const Realm::Config& local_config,

--- a/test/object-store/sync/sync_test_utils.hpp
+++ b/test/object-store/sync/sync_test_utils.hpp
@@ -114,6 +114,7 @@ struct TestClientReset {
     TestClientReset* on_post_reset(Callback&& post_reset);
     void set_pk_of_object_driving_reset(const ObjectId& pk);
     ObjectId get_pk_of_object_driving_reset() const;
+    void disable_wait_for_reset_completion();
 
     virtual void run() = 0;
 
@@ -128,6 +129,7 @@ protected:
     Callback m_on_post_reset;
     bool m_did_run = false;
     ObjectId m_pk_driving_reset = ObjectId::gen();
+    bool m_wait_for_reset_completion = true;
 };
 
 #if REALM_ENABLE_SYNC


### PR DESCRIPTION
As reported by @LaPeste, the client reset callbacks would be called with null Realm instances if the call to `RealmCoordinator ::get_existing_coordinator()` returned a nullptr. This can happen if the sync session is running a client reset operation while all references to the Realm have been released. To fix this, we need to get or create a coordinator and the way to do that is to pass in the `RealmConfig`. This is not something that the sync session had, so I added it in place of the SyncConfig that was already there. It is a bit of a heavy handed solution, but a better way wasn't obvious to me.

## ☑️ ToDos
* [x] 📝 Changelog update
* [x] 🚦 Tests (or not relevant)
* [x] C-API, if public C++ API changed.
