### PR TITLE
Use arm64-native BaaS on m1

### DIFF
--- a/evergreen/install_baas.sh
+++ b/evergreen/install_baas.sh
@@ -11,17 +11,29 @@ set -o pipefail
 
 case $(uname -s) in
     Darwin)
-        STITCH_SUPPORT_LIB_URL="https://s3.amazonaws.com/stitch-artifacts/stitch-support/stitch-support-macos-debug-4.3.2-721-ge791a2e-patch-5e2a6ad2a4cf473ae2e67b09.tgz"
-        STITCH_ASSISTED_AGG_URL="https://stitch-artifacts.s3.amazonaws.com/stitch-mongo-libs/stitch_mongo_libs_osx_0bdbed3d42ea136e166b3aad8f6fd09f336b1668_22_03_29_14_36_02/assisted_agg"
-        MONGODB_DOWNLOAD_URL="https://downloads.mongodb.com/osx/mongodb-macos-x86_64-enterprise-5.0.3.tgz"
-        GO_URL="https://s3.amazonaws.com/static.realm.io/evergreen-assets/go1.17.2.darwin-amd64.tar.gz"
+        if [[ "$(uname -m)" == "arm64" ]]; then
+            export GOARCH=arm64
+            STITCH_SUPPORT_LIB_URL="https://mciuploads.s3.amazonaws.com/mongodb-mongo-master-nightly/stitch-support/macos-arm64/796351fa200293a91413699c8da073eb314ac2cd/stitch-support-6.1.0-alpha-527-g796351f.tgz"
+            STITCH_ASSISTED_AGG_URL="https://stitch-artifacts.s3.amazonaws.com/stitch-mongo-libs/stitch_mongo_libs_osx_patch_f323e4411e1b2d9011b88d7f6855654c8432f2ee_6179e0e92a60ed55e5ecc820_21_10_27_23_30_03/assisted_agg"
+            GO_URL="https://go.dev/dl/go1.18.3.darwin-arm64.tar.gz"
+            MONGODB_DOWNLOAD_URL="https://downloads.mongodb.com/osx/mongodb-macos-arm64-enterprise-6.0.0-rc13.tgz"
+            MONGOSH_DOWNLOAD_URL="https://downloads.mongodb.com/compass/mongosh-1.5.0-darwin-arm64.zip"
+
+            # Go's scheduler is not BIG.little aware, and by default will spawn
+            # threads until they end up getting scheduled on efficiency cores,
+            # which is slower than just not using them. Limiting the threads to
+            # the number of performance cores results in them usually not
+            # running on efficiency cores.
+            export GOMAXPROCS="$(sysctl -n hw.perflevel0.logicalcpu)"
+        else
+            export GOARCH=amd64
+            STITCH_SUPPORT_LIB_URL="https://s3.amazonaws.com/stitch-artifacts/stitch-support/stitch-support-macos-debug-4.3.2-721-ge791a2e-patch-5e2a6ad2a4cf473ae2e67b09.tgz"
+            STITCH_ASSISTED_AGG_URL="https://stitch-artifacts.s3.amazonaws.com/stitch-mongo-libs/stitch_mongo_libs_osx_0bdbed3d42ea136e166b3aad8f6fd09f336b1668_22_03_29_14_36_02/assisted_agg"
+            GO_URL="https://s3.amazonaws.com/static.realm.io/evergreen-assets/go1.17.2.darwin-amd64.tar.gz"
+            MONGODB_DOWNLOAD_URL="https://downloads.mongodb.com/osx/mongodb-macos-x86_64-enterprise-5.0.3.tgz"
+        fi
 
         NODE_URL="https://nodejs.org/dist/v14.17.0/node-v14.17.0-darwin-x64.tar.gz"
-        # For now, we build everything as x64_64 since we don't have mongo binaries for ARM64
-        export GOARCH=amd64
-        # Until there are ARM64 builds of the stitch support libraries, we'll need to explicitly enable CGO
-        export CGO_ENABLED=1
-
         JQ_DOWNLOAD_URL="https://s3.amazonaws.com/static.realm.io/evergreen-assets/jq-1.6-darwin-amd64"
     ;;
     Linux)
@@ -242,6 +254,15 @@ if [ ! -x "$WORK_PATH/mongodb-binaries/bin/mongod" ]; then
     chmod +x ./mongodb-binaries/bin/*
 fi
 
+if [[ -n "$MONGOSH_DOWNLOAD_URL" ]] && [[ ! -x "$WORK_PATH/mongodb-binaries/bin/mongosh" ]]; then
+    echo "Downloading mongosh"
+    $CURL -sLS $MONGOSH_DOWNLOAD_URL --output mongosh-binaries.zip
+    unzip -jnqq mongosh-binaries.zip '*/bin/*' -d mongodb-binaries/bin/
+    rm mongosh-binaries.zip
+fi
+
+[[ -n "$MONGOSH_DOWNLOAD_URL" ]] && MONGOSH="mongosh" || MONGOSH="mongo"
+
 ulimit -n 32000
 
 if [[ -d mongodb-dbpath ]]; then
@@ -289,13 +310,17 @@ echo "Starting mongodb"
     --dbpath "$WORK_PATH/mongodb-dbpath/" \
     --pidfilepath "$WORK_PATH/mongod.pid" &
 
-./mongodb-binaries/bin/mongo \
-    --nodb \
-    --eval 'assert.soon(function(x){try{var d = new Mongo("localhost:26000"); return true}catch(e){return false}}, "timed out connecting")' \
-> /dev/null
-
 echo "Initializing replica set"
-./mongodb-binaries/bin/mongo --port 26000 --eval 'rs.initiate()' > /dev/null
+retries=0
+until "./mongodb-binaries/bin/$MONGOSH"  --port 26000 --eval 'try { rs.initiate(); } catch (e) { if (e.codeName != "AlreadyInitialized") { throw e; } }' > /dev/null
+do
+    if (( retries++ < 5 )); then
+        sleep 1
+    else
+        echo 'Failed to connect to mongodb'
+        exit 1
+    fi
+done
 
 cd "$WORK_PATH/baas"
 echo "Adding stitch user"

--- a/evergreen/install_baas.sh
+++ b/evergreen/install_baas.sh
@@ -97,7 +97,7 @@ esac
 # Allow path to $CURL to be overloaded by an environment variable
 CURL="${CURL:=$LAUNCHER curl}"
 
-BASE_PATH="$(cd $(dirname "$0"); pwd)"
+BASE_PATH="$(cd "$(dirname "$0")"; pwd)"
 
 REALPATH="$BASE_PATH/abspath.sh"
 
@@ -180,12 +180,12 @@ if [[ ! -d $WORK_PATH/baas/etc/dylib/lib ]]; then
     if [[ -n "$STITCH_SUPPORT_LIB_PATH" ]]; then
         echo "Copying stitch support library from $STITCH_SUPPORT_LIB_PATH"
         mkdir baas/etc/dylib
-        cp -rav $STITCH_SUPPORT_LIB_PATH/* $WORK_PATH/baas/etc/dylib
+        cp -rav "$STITCH_SUPPORT_LIB_PATH"/* "$WORK_PATH/baas/etc/dylib"
     else
         echo "Downloading stitch support library"
         mkdir baas/etc/dylib
         cd baas/etc/dylib
-        $CURL -LsS $STITCH_SUPPORT_LIB_URL | tar -xz --strip-components=1
+        $CURL -LsS "$STITCH_SUPPORT_LIB_URL" | tar -xz --strip-components=1
         cd -
     fi
 fi
@@ -195,27 +195,27 @@ export DYLD_LIBRARY_PATH="$WORK_PATH/baas/etc/dylib/lib"
 if [[ ! -x $WORK_PATH/baas_dep_binaries/libmongo.so ]]; then
     if [[ -n "$STITCH_ASSISTED_AGG_LIB_PATH" ]]; then
         echo "Copying stitch support library from $STITCH_ASSISTED_AGG_LIB_PATH"
-        cp -rav $STITCH_ASSISTED_AGG_LIB_PATH $WORK_PATH/baas_dep_binaries/libmongo.so
-        chmod 755 $WORK_PATH/baas_dep_binaries/libmongo.so
+        cp -rav "$STITCH_ASSISTED_AGG_LIB_PATH" "$WORK_PATH/baas_dep_binaries/libmongo.so"
+        chmod 755 "$WORK_PATH/baas_dep_binaries/libmongo.so"
     elif [[ -n "$STITCH_ASSISTED_AGG_LIB_URL" ]]; then
         echo "Downloading assisted agg library"
         cd "$WORK_PATH/baas_dep_binaries"
-        $CURL -LsS $STITCH_ASSISTED_AGG_LIB_URL > libmongo.so
+        $CURL -LsS "$STITCH_ASSISTED_AGG_LIB_URL" > libmongo.so
         chmod 755 libmongo.so
         cd -
     fi
 fi
 
-if [[ ! -x $WORK_PATH/baas_dep_binaries/assisted_agg && -n "$STITCH_ASSISTED_AGG_URL" ]]; then
+if [[ ! -x "$WORK_PATH/baas_dep_binaries/assisted_agg" && -n "$STITCH_ASSISTED_AGG_URL" ]]; then
     echo "Downloading assisted agg binary"
     cd "$WORK_PATH/baas_dep_binaries"
-    $CURL -LsS $STITCH_ASSISTED_AGG_URL > assisted_agg
+    $CURL -LsS "$STITCH_ASSISTED_AGG_URL" > assisted_agg
     chmod 755 assisted_agg
     cd -
 fi
 
-YARN=$WORK_PATH/yarn/bin/yarn
-if [[ ! -x $YARN ]]; then
+YARN="$WORK_PATH/yarn/bin/yarn"
+if [[ ! -x "$YARN" ]]; then
     echo "Getting yarn"
     mkdir yarn && cd yarn
     $CURL -LsS https://s3.amazonaws.com/stitch-artifacts/yarn/latest.tar.gz | tar -xz --strip-components=1
@@ -312,7 +312,7 @@ echo "Starting stitch app server"
 [[ -f $WORK_PATH/baas_server.pid ]] && rm "$WORK_PATH/baas_server.pid"
 go build -o "$WORK_PATH/baas_server" cmd/server/main.go
 "$WORK_PATH/baas_server" \
-    --configFile=etc/configs/test_config.json --configFile="$BASE_PATH"/config_overrides.json 2>&1 > "$WORK_PATH/baas_server.log" &
+    --configFile=etc/configs/test_config.json --configFile="$BASE_PATH"/config_overrides.json > "$WORK_PATH/baas_server.log" 2>&1 &
 echo $! > "$WORK_PATH/baas_server.pid"
 "$BASE_PATH"/wait_for_baas.sh "$WORK_PATH/baas_server.pid"
 

--- a/src/realm/array_basic.hpp
+++ b/src/realm/array_basic.hpp
@@ -39,7 +39,7 @@ public:
 
     static T default_value(bool)
     {
-        return T(0.0);
+        return T{};
     }
 
     void init_from_ref(ref_type ref) noexcept override
@@ -129,7 +129,7 @@ public:
 
     static util::Optional<T> default_value(bool nullable)
     {
-        return nullable ? util::Optional<T>() : util::Optional<T>(T{0.0});
+        return nullable ? util::Optional<T>() : util::Optional<T>(T{});
     }
     void set(size_t ndx, util::Optional<T> value)
     {

--- a/src/realm/util/websocket.cpp
+++ b/src/realm/util/websocket.cpp
@@ -683,6 +683,7 @@ public:
             }
 
             auto is_socket_closed_err = (ec == util::error::make_error_code(util::error::connection_reset) ||
+                                         ec == util::error::make_error_code(util::error::broken_pipe) ||
                                          ec == util::make_error_code(util::MiscExtErrors::end_of_input));
             // If the socket has been closed then we should continue to read from it until we've drained
             // the receive buffer. Eventually we will either receive an in-band error message from the

--- a/test/object-store/main.cpp
+++ b/test/object-store/main.cpp
@@ -33,7 +33,7 @@
 
 int main(int argc, const char** argv)
 {
-    realm::test_util::initialize_test_path(argc, argv);
+    realm::test_util::initialize_test_path(1, argv);
 
     Catch::ConfigData config;
 


### PR DESCRIPTION
This gives less of a speedup than I was hoping, but it does cut 2 minutes off the test suite runtime (~10%). The `GOMAXPROCS` has no meaningful effect over the course of the entire test suite, but it makes it so that running a single test takes twice as long as usual less often.