### PR TITLE
Fix benchmark results warnings

### DIFF
--- a/test/benchmark-larger/main.cpp
+++ b/test/benchmark-larger/main.cpp
@@ -48,6 +48,7 @@ int main()
 {
     std::random_device rd;
     std::mt19937 g(rd());
+    volatile int64_t sum = 0; // prevent optimization
 
     auto run_steps = [&](int num_steps, int step_size, step_type st, const char* step_layout,
                          std::vector<int> rw_probes = {}) {
@@ -139,7 +140,6 @@ int main()
                     auto trans = db->start_write();
                     start = std::chrono::steady_clock::now();
                     auto t = trans->get_table("table");
-                    volatile int64_t sum = 0; // prevent optimization
                     auto start_idx = keys.size();
                     if (start_idx > probe_size)
                         start_idx -= probe_size;

--- a/test/benchmark-larger/main.cpp
+++ b/test/benchmark-larger/main.cpp
@@ -48,6 +48,7 @@ int main()
 {
     std::random_device rd;
     std::mt19937 g(rd());
+    volatile int64_t sum = 0; // prevent optimization
 
     auto run_steps = [&](int num_steps, int step_size, step_type st, const char* step_layout,
                          std::vector<int> rw_probes = {}) {
@@ -160,6 +161,9 @@ int main()
                     std::cout << j + step_size << " _ " << probe_size << " " << print_diff.count() / probe_size
                               << std::endl;
                     start = end;
+                    for (size_t i = 0; i < probe_size; ++i) {
+                        sum += objects[i].get<Int>(col2);
+                    }
                     end = std::chrono::steady_clock::now();
                     diff = end - start;
                     print_diff = std::chrono::duration_cast<std::chrono::nanoseconds>(diff);

--- a/test/benchmark-larger/main.cpp
+++ b/test/benchmark-larger/main.cpp
@@ -48,7 +48,6 @@ int main()
 {
     std::random_device rd;
     std::mt19937 g(rd());
-    volatile int64_t sum = 0; // prevent optimization
 
     auto run_steps = [&](int num_steps, int step_size, step_type st, const char* step_layout,
                          std::vector<int> rw_probes = {}) {
@@ -161,9 +160,6 @@ int main()
                     std::cout << j + step_size << " _ " << probe_size << " " << print_diff.count() / probe_size
                               << std::endl;
                     start = end;
-                    for (size_t i = 0; i < probe_size; ++i) {
-                        sum += objects[i].get<Int>(col2);
-                    }
                     end = std::chrono::steady_clock::now();
                     diff = end - start;
                     print_diff = std::chrono::duration_cast<std::chrono::nanoseconds>(diff);

--- a/test/object-store/benchmarks/results.cpp
+++ b/test/object-store/benchmarks/results.cpp
@@ -134,26 +134,26 @@ TEST_CASE("Benchmark results", "[benchmark]") {
 
         BENCHMARK("Table forwards") {
             for (size_t i = 0, size = r.size(); i < size; ++i) {
-                Obj o = r.get<Obj>(i);
+                r.get<Obj>(i);
             }
         };
 
         BENCHMARK("Table reverse") {
             for (size_t i = 0, size = r.size(); i < size; ++i) {
-                Obj o = r.get<Obj>(size - i - 1);
+                r.get<Obj>(size - i - 1);
             }
         };
 
         auto tv = r.snapshot();
         BENCHMARK("TableView forwards") {
             for (size_t i = 0, size = r.size(); i < size; ++i) {
-                Obj o = tv.get<Obj>(i);
+                tv.get<Obj>(i);
             }
         };
 
         BENCHMARK("TableView reverse") {
             for (size_t i = 0, size = r.size(); i < size; ++i) {
-                Obj o = tv.get<Obj>(size - i - 1);
+                tv.get<Obj>(size - i - 1);
             }
         };
     }

--- a/test/object-store/sectioned_results.cpp
+++ b/test/object-store/sectioned_results.cpp
@@ -663,7 +663,7 @@ TEST_CASE("sectioned results", "[sectioned_results]") {
         table->clear();
         auto col_typed_link = table->add_column(type_TypedLink, "typed_link_col");
         auto linked = table->create_object();
-        auto o1 = table->create_object(ObjKey{}, {{col_typed_link, linked.get_link()}});
+        table->create_object(ObjKey{}, {{col_typed_link, linked.get_link()}});
         r->commit_transaction();
 
         // Should throw on `type_TypedLink` being a section key.

--- a/test/object-store/sectioned_results.cpp
+++ b/test/object-store/sectioned_results.cpp
@@ -663,7 +663,7 @@ TEST_CASE("sectioned results", "[sectioned_results]") {
         table->clear();
         auto col_typed_link = table->add_column(type_TypedLink, "typed_link_col");
         auto linked = table->create_object();
-        table->create_object(ObjKey{}, {{col_typed_link, linked.get_link()}});
+        auto o1 = table->create_object(ObjKey{}, {{col_typed_link, linked.get_link()}});
         r->commit_transaction();
 
         // Should throw on `type_TypedLink` being a section key.


### PR DESCRIPTION
## What, How & Why?
Fix warnings for benchmark build. Compiler warnings are treated as errors in evergreen.

