### PR TITLE
Don't compress download message if compression is disabled

### DIFF
--- a/src/realm/sync/noinst/server/server.cpp
+++ b/src/realm/sync/noinst/server/server.cpp
@@ -2905,7 +2905,7 @@ private:
                     BinaryData uncompressed = {out.data(), uncompressed_body_size};
                     body = uncompressed.data();
                     std::size_t max_uncompressed = 1024;
-                    if (uncompressed.size() > max_uncompressed) {
+                    if (!config.disable_download_compaction && uncompressed.size() > max_uncompressed) {
                         compression::CompressMemoryArena& arena = server.get_compress_memory_arena();
                         std::vector<char>& buffer = server.get_misc_buffers().compress;
                         compression::allocate_and_compress(arena, uncompressed, buffer); // Throws


### PR DESCRIPTION
Fixes issue #5673

## What, How & Why?
The server runs on a single thread and when download messages are compressed for each of the users, users with large messages can freeze the server for everyone else.

It should be possible to disable compaction.

## ☑️ ToDos
* [ ] 📝 Changelog update
* [ ] 🚦 Tests (or not relevant)
* [ ] C-API, if public C++ API changed.
