### PR TITLE
Ignore warnings in generated code

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -16,6 +16,7 @@ ctest_cmd = "ctest -VV"
 warningFilters = [
     excludeFile('/external/*'), // submodules and external libraries
     excludeFile('/libuv-src/*'), // libuv, where it was downloaded and built inside cmake
+    excludeFile('/src/realm/parser/generated/*'), // the auto generated parser code we didn't write
 ]
 
 jobWrapper {

--- a/src/realm/array_basic.hpp
+++ b/src/realm/array_basic.hpp
@@ -129,7 +129,7 @@ public:
 
     static util::Optional<T> default_value(bool nullable)
     {
-        return nullable ? util::Optional<T>() : util::Optional<T>(0.0);
+        return nullable ? util::Optional<T>() : util::Optional<T>(T{0.0});
     }
     void set(size_t ndx, util::Optional<T> value)
     {

--- a/test/test_util_future.cpp
+++ b/test/test_util_future.cpp
@@ -1053,7 +1053,7 @@ struct Widget {
         return val == w.val;
     }
 
-    int val;
+    int val{0};
 };
 
 std::ostream& operator<<(std::ostream& stream, const Widget& widget)


### PR DESCRIPTION
There is another warning in https://github.com/realm/realm-core/pull/5681 reported for windows-Win32-Release-uwp builders.

```
query_flex.ll:2182 | C4018 | Normal | 1
-- | -- | -- | --
'>': signed/unsigned mismatch (compiling source file C:\jenkins\workspace\realm_realm-core_PR-5681\src\realm\parser\generated\query_flex.cpp)

query_flex.ll:2182	[C4018](https://ci.realm.io/job/realm/job/realm-core/job/PR-5681/1/windows-Win32-Release-uwp-16f2e064-1cec-4e52-a7e9-51ee7d30d30b/category.63472742/)	[Normal](https://ci.realm.io/job/realm/job/realm-core/job/PR-5681/1/windows-Win32-Release-uwp-16f2e064-1cec-4e52-a7e9-51ee7d30d30b/NORMAL)	1
'>': signed/unsigned mismatch (compiling source file C:\jenkins\workspace\realm_realm-core_PR-5681\src\realm\parser\generated\query_flex.cpp)
```

This change ignores warnings in the "generated" directory.