### PR TITLE
Check if there are any new versions before refreshing in SubscriptionSet

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,12 +4,11 @@
 * <New feature description> (PR [#????](https://github.com/realm/realm-core/pull/????))
 * Allow multiple anonymous sessions. ([PR #5693](https://github.com/realm/realm-core/pull/5693)).
 * Introducing query parser support for constant list expressions such as `fruit IN {'apple', 'orange'}`. This also includes general query support for list vs list matching such as `NONE fruits IN {'apple', 'orange'}`. ([Issue #4266](https://github.com/realm/realm-core/issues/4266))
+* SubscriptionSet::refresh() does less work if no commits have been made since the last call to refresh(). ([PR #5695](https://github.com/realm/realm-core/pull/5695))
 
 ### Fixed
 * Fix error message when validating outgoing links from asymmetric objects to non-embedded objects. ([PR #5702](https://github.com/realm/realm-core/pull/5702))
 
-
- 
 ### Breaking changes
 * None.
 

--- a/src/realm/sync/subscriptions.hpp
+++ b/src/realm/sync/subscriptions.hpp
@@ -328,6 +328,9 @@ public:
     // affect the mutable subscription identified by the parameter.
     void supercede_all_except(MutableSubscriptionSet& mut_sub) const;
 
+    // Returns true if there have been commits to the DB since the given version
+    bool would_refresh(DB::version_type version) const noexcept;
+
     using TableSet = std::set<std::string, std::less<>>;
     TableSet get_tables_for_latest(const Transaction& tr) const;
 


### PR DESCRIPTION
This is pretty minor but there's some scenarios where we end up calling `refresh()` on a SubscriptionSet that definitely hasn't changed a bunch of times and it does a nontrivial amount of work even if there's no newer transaction versions.

https://github.com/realm/realm-core/pull/5150 added a second call to `get_by_version(version())` and I don't see how the first call could possibly have any effect, so I removed it.