### PR TITLE
Set the schema version when doing an async open in read-only mode

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 ### Fixed
 * Fix error message when validating outgoing links from asymmetric objects to non-embedded objects. ([PR #5702](https://github.com/realm/realm-core/pull/5702))
 * Fix a use-after-free when an AuditContext is destroyed while a different thread is in the completion handler for an audit Realm upload. ([PR #5714](https://github.com/realm/realm-core/pull/5714))
+* Opening a read-only Realm for the first time via `Realm::get_synchronized_realm()` did not set the schema version, which could lead to `m_schema_version != ObjectStore::NotVersioned` assertion failures.
 
 ### Breaking changes
 * None.

--- a/src/realm/object-store/shared_realm.cpp
+++ b/src/realm/object-store/shared_realm.cpp
@@ -295,7 +295,7 @@ bool Realm::schema_change_needs_write_transaction(Schema& schema, std::vector<Sc
             REALM_FALLTHROUGH;
         case SchemaMode::ReadOnly:
             ObjectStore::verify_compatible_for_immutable_and_readonly(changes);
-            return false;
+            return m_schema_version == ObjectStore::NotVersioned;
 
         case SchemaMode::SoftResetFile:
             if (m_schema_version == ObjectStore::NotVersioned)

--- a/src/realm/util/bind_ptr.hpp
+++ b/src/realm/util/bind_ptr.hpp
@@ -260,6 +260,12 @@ private:
     friend class bind_ptr;
 };
 
+// Deduction guides
+template <class T>
+bind_ptr(T*) -> bind_ptr<T>;
+template <class T>
+bind_ptr(T*, bind_ptr_base::adopt_tag) -> bind_ptr<T>;
+
 template <class T, typename... Args>
 bind_ptr<T> make_bind(Args&&... __args)
 {


### PR DESCRIPTION
The schema version of a synchronized Realm is a local concept, so it doesn't get set by the sync client when downloading. We don't bother performing a write if the schema version is the only thing that's changed, but we do need to set the schema version if it's NotVersioned.