### PR TITLE
Suppress -Wmaybe-uninitialized warnings in selected places

### DIFF
--- a/src/realm/status_with.hpp
+++ b/src/realm/status_with.hpp
@@ -99,12 +99,14 @@ public:
     const T& get_value() const
     {
         REALM_ASSERT_DEBUG(is_ok());
+        REALM_ASSERT_RELEASE(m_value);
         return *m_value;
     }
 
     T& get_value()
     {
         REALM_ASSERT_DEBUG(is_ok());
+        REALM_ASSERT_RELEASE(m_value);
         return *m_value;
     }
 

--- a/src/realm/sync/client.cpp
+++ b/src/realm/sync/client.cpp
@@ -963,7 +963,9 @@ void SessionWrapper::on_flx_sync_progress(int64_t new_version, DownloadBatchStat
     }
     REALM_ASSERT(new_version >= m_flx_last_seen_version);
     REALM_ASSERT(new_version >= m_flx_active_version);
-    SubscriptionSet::State new_state;
+
+    SubscriptionSet::State new_state = SubscriptionSet::State::Complete; // Initialize to make compiler happy
+
     switch (batch_state) {
         case DownloadBatchState::LastInBatch:
             if (m_flx_active_version == new_version) {


### PR DESCRIPTION
## What, How & Why?
Remove some warnings in release builds