### PR TITLE
Hold a strong reference to the logger in AuditRealmPool

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,9 +7,8 @@
 
 ### Fixed
 * Fix error message when validating outgoing links from asymmetric objects to non-embedded objects. ([PR #5702](https://github.com/realm/realm-core/pull/5702))
+* Fix a use-after-free when an AuditContext is destroyed while a different thread is in the completion handler for an audit Realm upload. ([PR #5714](https://github.com/realm/realm-core/pull/5714))
 
-
- 
 ### Breaking changes
 * None.
 

--- a/src/realm/object-store/audit.mm
+++ b/src/realm/object-store/audit.mm
@@ -627,7 +627,8 @@ public:
     // Get a pool for the given sync user. Pools are cached internally to avoid
     // creating duplicate ones.
     static std::shared_ptr<AuditRealmPool> get_pool(std::shared_ptr<SyncUser> user,
-                                                    std::string const& partition_prefix, util::Logger& logger,
+                                                    std::string const& partition_prefix,
+                                                    const std::shared_ptr<util::Logger>& logger,
                                                     ErrorHandler error_handler);
 
     // Write to a pooled Realm. The Transaction should not be retained outside
@@ -636,7 +637,7 @@ public:
 
     // Do not call directly; use get_pool().
     AuditRealmPool(std::shared_ptr<SyncUser> user, std::string const& partition_prefix, ErrorHandler error_handler,
-                   util::Logger& logger, std::string_view app_id);
+                   const std::shared_ptr<util::Logger>& logger, std::string_view app_id);
 
     // Block the calling thread until all pooled Realms have been fully uploaded,
     // including ones which do not currently have sync sessions. For testing
@@ -648,7 +649,7 @@ private:
     const std::string m_partition_prefix;
     const ErrorHandler m_error_handler;
     const std::string m_path_root;
-    util::Logger& m_logger;
+    const std::shared_ptr<util::Logger> m_logger;
 
     std::shared_ptr<Realm> m_current_realm;
     std::vector<std::string> m_metadata_columns;
@@ -665,7 +666,8 @@ private:
 };
 
 std::shared_ptr<AuditRealmPool> AuditRealmPool::get_pool(std::shared_ptr<SyncUser> user,
-                                                         std::string const& partition_prefix, util::Logger& logger,
+                                                         std::string const& partition_prefix,
+                                                         const std::shared_ptr<util::Logger>& logger,
                                                          ErrorHandler error_handler) NO_THREAD_SAFETY_ANALYSIS
 {
     struct CachedPool {
@@ -701,7 +703,8 @@ std::shared_ptr<AuditRealmPool> AuditRealmPool::get_pool(std::shared_ptr<SyncUse
 }
 
 AuditRealmPool::AuditRealmPool(std::shared_ptr<SyncUser> user, std::string const& partition_prefix,
-                               ErrorHandler error_handler, util::Logger& logger, std::string_view app_id)
+                               ErrorHandler error_handler, const std::shared_ptr<util::Logger>& logger,
+                               std::string_view app_id)
     : m_user(user)
     , m_partition_prefix(partition_prefix)
     , m_error_handler(error_handler)
@@ -728,8 +731,8 @@ void AuditRealmPool::write(util::FunctionRef<void(Transaction&)> func)
     if (m_current_realm) {
         auto size = util::File::get_size_static(m_current_realm->config().path);
         if (size > g_max_partition_size) {
-            m_logger.info("Audit: Closing Realm at '%1': size %2 > max size %3", m_current_realm->config().path, size,
-                          g_max_partition_size.load());
+            m_logger->info("Audit: Closing Realm at '%1': size %2 > max size %3", m_current_realm->config().path,
+                           size, g_max_partition_size.load());
             auto sync_session = m_current_realm->sync_session();
             {
                 // If we're offline and already have a Realm waiting to upload,
@@ -749,7 +752,7 @@ void AuditRealmPool::write(util::FunctionRef<void(Transaction&)> func)
             m_current_realm = nullptr;
         }
         else {
-            m_logger.detail("Audit: Reusing existing Realm at '%1'", m_current_realm->config().path);
+            m_logger->detail("Audit: Reusing existing Realm at '%1'", m_current_realm->config().path);
         }
     }
 
@@ -771,7 +774,7 @@ void AuditRealmPool::write(util::FunctionRef<void(Transaction&)> func)
 
 void AuditRealmPool::wait_for_upload(std::shared_ptr<SyncSession> session)
 {
-    m_logger.info("Audit: Uploading '%1'", session->path());
+    m_logger->info("Audit: Uploading '%1'", session->path());
     m_upload_sessions.push_back(session);
     session->wait_for_upload_completion([this, weak_self = weak_from_this(), session](std::error_code ec) {
         auto self = weak_self.lock();
@@ -783,17 +786,17 @@ void AuditRealmPool::wait_for_upload(std::shared_ptr<SyncSession> session)
             auto it = std::find(m_upload_sessions.begin(), m_upload_sessions.end(), session);
             REALM_ASSERT(it != m_upload_sessions.end());
             m_upload_sessions.erase(it);
-            auto path = session->path();
+            std::string path = session->path();
             session->close();
             m_open_paths.erase(path);
             if (ec) {
-                m_logger.error("Audit: Upload on '%1' failed with error '%2'.", path, ec.message());
+                m_logger->error("Audit: Upload on '%1' failed with error '%2'.", path, ec.message());
                 if (m_error_handler) {
                     m_error_handler(SyncError(ec, ec.message(), false));
                 }
             }
             else {
-                m_logger.info("Audit: Upload on '%1' completed.", path);
+                m_logger->info("Audit: Upload on '%1' completed.", path);
                 util::File::remove(path);
             }
             if (!m_upload_sessions.empty())
@@ -814,7 +817,7 @@ std::string AuditRealmPool::prefixed_partition(std::string const& partition)
 void AuditRealmPool::scan_for_realms_to_upload()
 {
     util::CheckedLockGuard lock(m_mutex);
-    m_logger.trace("Audit: Scanning for Realms in '%1' to upload", m_path_root);
+    m_logger->trace("Audit: Scanning for Realms in '%1' to upload", m_path_root);
     util::DirScanner dir(m_path_root);
     std::string file_name;
     while (dir.next(file_name)) {
@@ -823,15 +826,15 @@ void AuditRealmPool::scan_for_realms_to_upload()
 
         std::string path = m_path_root + file_name;
         if (m_open_paths.count(path)) {
-            m_logger.trace("Audit: Skipping '%1': file is already open", path);
+            m_logger->trace("Audit: Skipping '%1': file is already open", path);
             continue;
         }
 
-        m_logger.trace("Audit: Checking file '%1'", path);
+        m_logger->trace("Audit: Checking file '%1'", path);
         auto db = DB::create(std::make_unique<sync::ClientReplication>(false), path);
         auto tr = db->start_read();
         if (tr->get_history()->no_pending_local_changes(tr->get_version())) {
-            m_logger.info("Audit: Realm at '%1' is fully uploaded", path);
+            m_logger->info("Audit: Realm at '%1' is fully uploaded", path);
             tr = nullptr;
             db->close();
             util::File::remove(path);
@@ -875,7 +878,7 @@ void AuditRealmPool::open_new_realm()
     sync_config->error_handler = [error_handler = m_error_handler, weak_self = weak_from_this()](auto,
                                                                                                  SyncError error) {
         if (auto self = weak_self.lock()) {
-            self->m_logger.error("Audit: Received sync error: %1 (ec=%2)", error.message, error.error_code.value());
+            self->m_logger->error("Audit: Received sync error: %1 (ec=%2)", error.message, error.error_code.value());
         }
         if (error_handler) {
             error_handler(error);
@@ -895,7 +898,7 @@ void AuditRealmPool::open_new_realm()
     config.schema_version = 0;
     config.sync_config = sync_config;
 
-    m_logger.info("Audit: Opening new Realm at '%1'", config.path);
+    m_logger->info("Audit: Opening new Realm at '%1'", config.path);
     m_current_realm = Realm::get_shared_realm(std::move(config));
     util::CheckedLockGuard lock(m_mutex);
     m_open_paths.insert(m_current_realm->config().path);
@@ -1006,7 +1009,7 @@ AuditContext::AuditContext(std::shared_ptr<DB> source_db, RealmConfig const& par
     if (!m_serializer)
         m_serializer = std::make_shared<AuditObjectSerializer>();
 
-    m_realm_pool = AuditRealmPool::get_pool(audit_user, audit_config.partition_value_prefix, *m_logger,
+    m_realm_pool = AuditRealmPool::get_pool(audit_user, audit_config.partition_value_prefix, m_logger,
                                             audit_config.sync_error_handler);
 }
 


### PR DESCRIPTION
It requires very specific timing, but it's possible for an AuditRealmPool to outlive the parent AuditContext, and trying to use the logger when that happens was a use-after-free.

I tried to find a way to write a test for this, but it doesn't seem to be possible. The specific sequence of events it needs are:
1. Upload completes while the AuditContext is still alive.
2. `auto self = weak_self.lock()` succeeds as the AuditContext is still holding a strong reference
3. AuditContext is destroyed on a different thread. The AuditRealmPool remains alive as it's currently holding a strong reference to itself, but the logger is destroyed.
4. We try to log something and use the destroyed logger.

If the AuditContext is destroyed _before_ the completion callback is invoked `weak_self.lock()` returns nullptr and we don't get in trouble.