### PR TITLE
Properly handle exceptions thrown during bootstrap application before bind/ident

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 ### Fixed
 * <How do the end-user experience this issue? what was the impact?> ([#????](https://github.com/realm/realm-core/issues/????), since v?.?.?)
 * Exposed the boolean `merge_with_existing` in the C-API's functions `realm_convert_with_config` and `realm_convert_with_path`. ([#5713](https://github.com/realm/realm-core/issues/5713))
+* Processing a pending bootstrap before the sync client connects will properly surface errors to the user's error handler ([#5707](https://github.com/realm/realm-core/issues/5707), since v12.0.0)
  
 ### Breaking changes
 * None.

--- a/src/realm/object-store/sync/sync_session.cpp
+++ b/src/realm/object-store/sync/sync_session.cpp
@@ -729,6 +729,7 @@ void SyncSession::create_sync_session()
     session_config.ssl_trust_certificate_path = sync_config.ssl_trust_certificate_path;
     session_config.ssl_verify_callback = sync_config.ssl_verify_callback;
     session_config.proxy_config = sync_config.proxy_config;
+    session_config.simulate_integration_error = sync_config.simulate_integration_error;
     if (sync_config.on_download_message_received_hook) {
         session_config.on_download_message_received_hook =
             [hook = sync_config.on_download_message_received_hook, anchor = weak_from_this()](

--- a/src/realm/sync/client.cpp
+++ b/src/realm/sync/client.cpp
@@ -1259,9 +1259,8 @@ void SessionWrapper::actualize(ServerEndpoint endpoint)
         m_actualized = true;
     }
     catch (...) {
-        if (was_created) {
+        if (was_created)
             m_client.remove_connection(conn);
-        }
         throw;
     }
 

--- a/src/realm/sync/client.cpp
+++ b/src/realm/sync/client.cpp
@@ -753,6 +753,10 @@ bool SessionImpl::process_flx_bootstrap_message(const SyncProgress& progress, Do
         return true;
     }
 
+    if (batch_state == DownloadBatchState::MoreToCome) {
+        return true;
+    }
+
     try {
         process_pending_flx_bootstrap();
     }

--- a/src/realm/sync/client.cpp
+++ b/src/realm/sync/client.cpp
@@ -747,15 +747,7 @@ bool SessionImpl::process_flx_bootstrap_message(const SyncProgress& progress, Do
     }
     bootstrap_store->add_batch(query_version, std::move(maybe_progress), received_changesets);
 
-    if (batch_state == DownloadBatchState::MoreToCome) {
-        on_flx_sync_progress(query_version, batch_state);
-        if (m_wrapper.m_on_bootstrap_message_processed_hook) {
-            m_wrapper.m_on_bootstrap_message_processed_hook(progress, query_version, batch_state);
-        }
-
-        return true;
-    }
-
+    on_flx_sync_progress(query_version, DownloadBatchState::MoreToCome);
     if (m_wrapper.m_on_bootstrap_message_processed_hook &&
         !m_wrapper.m_on_bootstrap_message_processed_hook(progress, query_version, batch_state)) {
         return true;
@@ -970,7 +962,7 @@ void SessionWrapper::on_flx_sync_progress(int64_t new_version, DownloadBatchStat
     REALM_ASSERT(new_version >= m_flx_last_seen_version);
     REALM_ASSERT(new_version >= m_flx_active_version);
 
-    SubscriptionSet::State new_state = SubscriptionSet::State::Complete; // Initialize to make compiler happy
+    SubscriptionSet::State new_state = SubscriptionSet::State::Uncommitted; // Initialize to make compiler happy
 
     switch (batch_state) {
         case DownloadBatchState::LastInBatch:

--- a/src/realm/sync/config.hpp
+++ b/src/realm/sync/config.hpp
@@ -195,6 +195,8 @@ struct SyncConfig {
     std::function<bool(std::weak_ptr<SyncSession>, const sync::SyncProgress&, int64_t, sync::DownloadBatchState)>
         on_bootstrap_message_processed_hook;
 
+    bool simulate_integration_error = false;
+
     explicit SyncConfig(std::shared_ptr<SyncUser> user, bson::Bson partition);
     explicit SyncConfig(std::shared_ptr<SyncUser> user, std::string partition);
     explicit SyncConfig(std::shared_ptr<SyncUser> user, const char* partition);

--- a/src/realm/sync/noinst/client_impl_base.cpp
+++ b/src/realm/sync/noinst/client_impl_base.cpp
@@ -1500,10 +1500,17 @@ void Session::activate()
     reset_protocol_state();
     m_state = Active;
 
-    process_pending_flx_bootstrap();
-
     REALM_ASSERT(!m_suspended);
     m_conn.one_more_active_unsuspended_session(); // Throws
+
+    try {
+        process_pending_flx_bootstrap();
+    }
+    catch (const IntegrationException& error) {
+        logger.error("Error integrating bootstrap changesets: %1", error.what());
+        on_suspended(SessionErrorInfo{error.code(), false});
+        m_conn.one_less_active_unsuspended_session(); // Throws
+    }
 }
 
 

--- a/src/realm/sync/noinst/client_impl_base.hpp
+++ b/src/realm/sync/noinst/client_impl_base.hpp
@@ -1169,6 +1169,7 @@ inline void ClientImpl::Connection::voluntary_disconnect()
 }
 
 inline void ClientImpl::Connection::involuntary_disconnect(const SessionErrorInfo& info)
+
 {
     REALM_ASSERT(m_reconnect_info.m_reason && !was_voluntary(*m_reconnect_info.m_reason));
     disconnect(info); // Throws

--- a/src/realm/sync/noinst/client_impl_base.hpp
+++ b/src/realm/sync/noinst/client_impl_base.hpp
@@ -1169,7 +1169,6 @@ inline void ClientImpl::Connection::voluntary_disconnect()
 }
 
 inline void ClientImpl::Connection::involuntary_disconnect(const SessionErrorInfo& info)
-
 {
     REALM_ASSERT(m_reconnect_info.m_reason && !was_voluntary(*m_reconnect_info.m_reason));
     disconnect(info); // Throws

--- a/src/realm/sync/noinst/pending_bootstrap_store.cpp
+++ b/src/realm/sync/noinst/pending_bootstrap_store.cpp
@@ -120,7 +120,8 @@ PendingBootstrapStore::PendingBootstrapStore(DBRef db, util::Logger* logger)
 }
 
 void PendingBootstrapStore::add_batch(int64_t query_version, util::Optional<SyncProgress> progress,
-                                      const _impl::ClientProtocol::ReceivedChangesets& changesets)
+                                      const _impl::ClientProtocol::ReceivedChangesets& changesets,
+                                      bool* created_new_batch)
 {
     std::vector<util::AppendBuffer<char>> compressed_changesets;
     compressed_changesets.reserve(changesets.size());
@@ -141,8 +142,7 @@ void PendingBootstrapStore::add_batch(int64_t query_version, util::Optional<Sync
     });
     incomplete_bootstraps.clear();
 
-    bool did_create = false;
-    auto bootstrap_obj = bootstrap_table->create_object_with_primary_key(Mixed{query_version}, &did_create);
+    auto bootstrap_obj = bootstrap_table->create_object_with_primary_key(Mixed{query_version}, created_new_batch);
     if (progress) {
         auto progress_obj = bootstrap_obj.create_and_set_linked_object(m_progress);
         progress_obj.set(m_progress_latest_server_version, int64_t(progress->latest_server_version.version));
@@ -169,7 +169,7 @@ void PendingBootstrapStore::add_batch(int64_t query_version, util::Optional<Sync
 
     tr->commit();
 
-    if (did_create) {
+    if (*created_new_batch) {
         m_logger->trace("Created new pending bootstrap object for query version %1", query_version);
     }
     else {

--- a/src/realm/sync/noinst/pending_bootstrap_store.hpp
+++ b/src/realm/sync/noinst/pending_bootstrap_store.hpp
@@ -72,7 +72,7 @@ public:
 
     // Adds a set of changesets to the store.
     void add_batch(int64_t query_version, util::Optional<SyncProgress> progress,
-                   const std::vector<Transformer::RemoteChangeset>& changesets);
+                   const std::vector<Transformer::RemoteChangeset>& changesets, bool* created_new_batch);
 
     void clear();
 

--- a/test/object-store/sync/flx_sync_harness.hpp
+++ b/test/object-store/sync/flx_sync_harness.hpp
@@ -101,6 +101,7 @@ public:
         }
         auto subs = std::move(mut_subs).commit();
         subs.get_state_change_notification(sync::SubscriptionSet::State::Complete).get();
+        wait_for_download(*realm);
 
         realm->begin_transaction();
         func(realm);


### PR DESCRIPTION
## What, How & Why?
This PR changes where/how we handle errors while processing/applying bootstrap changesets in FLX sync mode. The old way relied on calling `on_integration_error()` and doing the normal download processing error handling. Apparently that didn't work because all that error handling assumed you were actually connected to the server and had a bunch of invariants that would fail. This changes things around a bit to handle the special case of a bootstrap error happening before we've connected/sent the BIND/IDENT messages.

## ☑️ ToDos
* [ ] 📝 Changelog update
* [x] 🚦 Tests (or not relevant)
* [ ] C-API, if public C++ API changed.
