### PR TITLE
[C-API] - Added missing `ProtocolError::compensating_write`

### DIFF
--- a/src/realm.h
+++ b/src/realm.h
@@ -3328,6 +3328,7 @@ typedef enum realm_sync_errno_session {
     RLM_SYNC_ERR_SESSION_SERVER_PERMISSIONS_CHANGED = 228,
     RLM_SYNC_ERR_SESSION_INITIAL_SYNC_NOT_COMPLETED = 229,
     RLM_SYNC_ERR_SESSION_WRITE_NOT_ALLOWED = 230,
+    RLM_SYNC_ERR_SESSION_COMPENSATING_WRITE = 231,
 } realm_sync_errno_session_e;
 
 typedef struct realm_sync_session realm_sync_session_t;

--- a/src/realm/object-store/c_api/sync.cpp
+++ b/src/realm/object-store/c_api/sync.cpp
@@ -196,6 +196,8 @@ static_assert(realm_sync_errno_session_e(ProtocolError::server_permissions_chang
 static_assert(realm_sync_errno_session_e(ProtocolError::initial_sync_not_completed) ==
               RLM_SYNC_ERR_SESSION_INITIAL_SYNC_NOT_COMPLETED);
 static_assert(realm_sync_errno_session_e(ProtocolError::write_not_allowed) == RLM_SYNC_ERR_SESSION_WRITE_NOT_ALLOWED);
+static_assert(realm_sync_errno_session_e(ProtocolError::compensating_write) ==
+              RLM_SYNC_ERR_SESSION_COMPENSATING_WRITE);
 } // namespace
 
 static realm_sync_error_code_t to_capi(const std::error_code& error_code, std::string& message)


### PR DESCRIPTION
## What, How & Why?
Added missing `ProtocolError::compensating_write` to the C-API.

## ☑️ ToDos
* [ ] 📝 Changelog update
* [ ] 🚦 Tests (or not relevant)
* [ ] C-API, if public C++ API changed.
