### PR TITLE
Expose  in C-API realm_convert_with*

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@
 
 ### Fixed
 * <How do the end-user experience this issue? what was the impact?> ([#????](https://github.com/realm/realm-core/issues/????), since v?.?.?)
-* None.
+* Exposed the boolean `merge_with_existing` in the C-API's functions `realm_convert_with_config` and `realm_convert_with_path`. ([#5713](https://github.com/realm/realm-core/issues/5713))
  
 ### Breaking changes
 * None.

--- a/src/realm.h
+++ b/src/realm.h
@@ -919,22 +919,31 @@ RLM_API realm_t* realm_open(const realm_config_t* config);
 /**
  * Copy or convert a Realm using a config.
  *
- * If the file already exists, data will be copied over object per object.
+ * If the file already exists and merge_with_existing is true, data will be copied over object per object.
+ * When merging, all classes must have a pk called '_id" otherwise an exception is thrown.
+ * If the file exists and merge_with_existing is false, an exception is thrown.
  * If the file does not exist, the realm file will be exported to the new location and if the
  * configuration object contains a sync part, a sync history will be synthesized.
  *
  * @param config The realm configuration that should be used to create a copy.
  *               This can be a local or a synced Realm, encrypted or not.
+ * @param merge_with_existing If this is true and the destination file exists, data will be copied over object by
+ * object. Otherwise, if this is false and the destination file exists, an exception is thrown.
  */
-RLM_API bool realm_convert_with_config(const realm_t* realm, const realm_config_t* config);
+RLM_API bool realm_convert_with_config(const realm_t* realm, const realm_config_t* config, bool merge_with_existing);
 /**
  * Copy a Realm using a path.
  *
  * @param path The path the realm should be copied to. Local realms will remain local, synced
  *             realms will remain synced realms.
  * @param encryption_key The optional encryption key for the new realm.
+ * @param merge_with_existing If this is true and the destination file exists, data will be copied over object by
+ object.
+ *  Otherwise, if this is false and the destination file exists, an exception is thrown.
+
  */
-RLM_API bool realm_convert_with_path(const realm_t* realm, const char* path, realm_binary_t encryption_key);
+RLM_API bool realm_convert_with_path(const realm_t* realm, const char* path, realm_binary_t encryption_key,
+                                     bool merge_with_existing);
 
 /**
  * Deletes the following files for the given `realm_file_path` if they exist:

--- a/src/realm/object-store/c_api/realm.cpp
+++ b/src/realm/object-store/c_api/realm.cpp
@@ -68,15 +68,16 @@ RLM_API realm_t* realm_open(const realm_config_t* config)
     });
 }
 
-RLM_API bool realm_convert_with_config(const realm_t* realm, const realm_config_t* config)
+RLM_API bool realm_convert_with_config(const realm_t* realm, const realm_config_t* config, bool merge_with_existing)
 {
     return wrap_err([&]() {
-        (*realm)->convert(*config);
+        (*realm)->convert(*config, merge_with_existing);
         return true;
     });
 }
 
-RLM_API bool realm_convert_with_path(const realm_t* realm, const char* path, realm_binary_t encryption_key)
+RLM_API bool realm_convert_with_path(const realm_t* realm, const char* path, realm_binary_t encryption_key,
+                                     bool merge_with_existing)
 {
     return wrap_err([&]() {
         Realm::Config config;
@@ -84,7 +85,7 @@ RLM_API bool realm_convert_with_path(const realm_t* realm, const char* path, rea
         if (encryption_key.data) {
             config.encryption_key.assign(encryption_key.data, encryption_key.data + encryption_key.size);
         }
-        (*realm)->convert(config);
+        (*realm)->convert(config, merge_with_existing);
         return true;
     });
 }

--- a/test/object-store/c_api/c_api.cpp
+++ b/test/object-store/c_api/c_api.cpp
@@ -3982,6 +3982,87 @@ TEST_CASE("C API", "[c_api]") {
     realm_release(realm);
 }
 
+TEST_CASE("C API: convert", "[c_api]") {
+    TestFile test_file;
+    TestFile dest_test_file;
+    realm_t* realm;
+    ObjectSchema object_schema = {"Foo",
+                                  {
+                                      {"_id", PropertyType::Int, Property::IsPrimary{true}},
+                                      {"string_value", PropertyType::String},
+                                  }};
+
+    { // seed a Realm with an object
+        auto config = make_config(test_file.path.c_str(), false);
+        config->schema = Schema{object_schema};
+        config->schema_version = 0;
+        realm = realm_open(config.get());
+        REQUIRE(checked(realm));
+        CHECK(!realm_equals(realm, nullptr));
+        realm_class_info_t class_foo;
+        bool found = false;
+        CHECK(checked(realm_find_class(realm, "Foo", &found, &class_foo)));
+        REQUIRE(found);
+
+        realm_property_key_t foo_str_col_key;
+        realm_property_info_t info;
+        found = false;
+        REQUIRE(realm_find_property(realm, class_foo.key, "string_value", &found, &info));
+        REQUIRE(found);
+        CHECK(info.key != RLM_INVALID_PROPERTY_KEY);
+        foo_str_col_key = info.key;
+
+        CPtr<realm_object_t> obj1;
+        checked(realm_begin_write(realm));
+        realm_value_t pk = rlm_int_val(42);
+        obj1 = cptr_checked(realm_object_create_with_primary_key(realm, class_foo.key, pk));
+        CHECK(obj1);
+        CHECK(checked(realm_set_value(obj1.get(), foo_str_col_key, rlm_str_val("Hello, World!"), false)));
+        checked(realm_commit(realm));
+        checked(realm_refresh(realm));
+
+        size_t foo_count;
+        CHECK(checked(realm_get_num_objects(realm, class_foo.key, &foo_count)));
+        REQUIRE(foo_count == 1);
+    }
+
+    CHECK(realm_get_num_classes(realm) == 1);
+
+    SECTION("convert with path") {
+        bool merge_with_existing = false;
+        realm_binary encryption_key{nullptr, 0};
+
+        REQUIRE(realm_convert_with_path(realm, dest_test_file.path.c_str(), encryption_key, merge_with_existing));
+
+        SECTION("convert again without merge should fail") {
+            REQUIRE_FALSE(
+                realm_convert_with_path(realm, dest_test_file.path.c_str(), encryption_key, merge_with_existing));
+        }
+        SECTION("convert again with merge should succeed") {
+            merge_with_existing = true;
+            REQUIRE(realm_convert_with_path(realm, dest_test_file.path.c_str(), encryption_key, merge_with_existing));
+        }
+    }
+
+    SECTION("convert with config") {
+        auto dest_config = make_config(dest_test_file.path.c_str(), false);
+        dest_config->schema = Schema{object_schema};
+        dest_config->schema_version = 0;
+        bool merge_with_existing = false;
+        REQUIRE(realm_convert_with_config(realm, dest_config.get(), merge_with_existing));
+        SECTION("convert again without merge should fail") {
+            REQUIRE_FALSE(realm_convert_with_config(realm, dest_config.get(), merge_with_existing));
+        }
+        SECTION("convert again with merge should succeed") {
+            merge_with_existing = true;
+            REQUIRE(realm_convert_with_config(realm, dest_config.get(), merge_with_existing));
+        }
+    }
+    realm_close(realm);
+    REQUIRE(realm_is_closed(realm));
+    realm_release(realm);
+}
+
 struct Userdata {
     std::atomic<bool> called{false};
     bool has_error;


### PR DESCRIPTION
Fixes https://github.com/realm/realm-core/issues/5713.

The C-API wrapper was missing the parameter which gives control over what to do with an existing destination file.

## ☑️ ToDos
* [x] 📝 Changelog update
* [x] 🚦 Tests (or not relevant)
* [x] C-API, if public C++ API changed.
