### PR TITLE
The top of an assertion failed stack trace now includes the core version

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,7 +17,7 @@
 -----------
 
 ### Internals
-* None.
+* The top function of an assertion stack trace now includes the core version number.
 
 ----------------------------------------------
 


### PR DESCRIPTION
We often get stack traces from assertion failures reported from iOS users that do not have stderr output attached. Then the first thing we have to do is ask which version was used. This embeds the core version number into the stack trace so we can see it without asking. Example:

![Screen Shot 2022-08-10 at 12 54 22 PM](https://user-images.githubusercontent.com/2826060/184008768-b056211a-d2af-4dbf-b019-8f2880544504.png)
