### PR TITLE
QueryParser: Make handling of list of strings more robust

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 ### Fixed
 * <How do the end-user experience this issue? what was the impact?> ([#????](https://github.com/realm/realm-core/issues/????), since v?.?.?)
 * Exposed the boolean `merge_with_existing` in the C-API's functions `realm_convert_with_config` and `realm_convert_with_path`. ([#5713](https://github.com/realm/realm-core/issues/5713))
+* Parsing a constant list of strings from RealmJS SDK to QueryParser would result in a "use after free situation". ([#5735](https://github.com/realm/realm-core/issues/5735))
  
 ### Breaking changes
 * None.

--- a/src/realm/parser/driver.cpp
+++ b/src/realm/parser/driver.cpp
@@ -1042,16 +1042,14 @@ std::unique_ptr<Subexpr> ConstantNode::visit(ParserDriver* drv, DataType hint)
             }
             REALM_ASSERT_DEBUG_EX(*decoded_size <= encoded_size, *decoded_size, encoded_size);
             decode_buffer.resize(*decoded_size); // truncate
-            drv->m_args.buffer_space.push_back(OwnedData{decode_buffer.data(), decode_buffer.size()});
-            const char* data = drv->m_args.buffer_space.back().data();
             if (hint == type_String) {
-                ret = std::make_unique<ConstantStringValue>(StringData(data, decode_buffer.size()));
+                ret = std::make_unique<ConstantStringValue>(StringData(decode_buffer.data(), decode_buffer.size()));
             }
             if (hint == type_Binary) {
-                ret = std::make_unique<Value<BinaryData>>(BinaryData(data, decode_buffer.size()));
+                ret = std::make_unique<ConstantBinaryValue>(BinaryData(decode_buffer.data(), decode_buffer.size()));
             }
             if (hint == type_Mixed) {
-                ret = std::make_unique<Value<BinaryData>>(BinaryData(data, decode_buffer.size()));
+                ret = std::make_unique<ConstantBinaryValue>(BinaryData(decode_buffer.data(), decode_buffer.size()));
             }
             break;
         }

--- a/src/realm/parser/query_parser.hpp
+++ b/src/realm/parser/query_parser.hpp
@@ -146,11 +146,6 @@ public:
     {
         return m_count;
     }
-
-    // dynamic conversion space with lifetime tied to this
-    // it is used for storing literal binary/string data
-    std::vector<OwnedData> buffer_space;
-
 protected:
     void verify_ndx(size_t ndx) const
     {

--- a/src/realm/query_expression.hpp
+++ b/src/realm/query_expression.hpp
@@ -1320,6 +1320,38 @@ private:
     std::string m_buffer;
 };
 
+class ConstantMixedList : public Value<Mixed> {
+public:
+    ConstantMixedList(size_t nb_values)
+        : Value()
+        , m_buffer(nb_values)
+    {
+        this->init(true, nb_values);
+    }
+    void set(size_t n, Mixed val)
+    {
+        Value<Mixed>::set(n, val);
+        (*this)[n].use_buffer(m_buffer[n]);
+    }
+
+    std::unique_ptr<Subexpr> clone() const override
+    {
+        return std::unique_ptr<Subexpr>(new ConstantMixedList(*this));
+    }
+
+private:
+    ConstantMixedList(const ConstantMixedList& other)
+        : Value(other)
+        , m_buffer(other.size())
+    {
+        for (size_t i = 0; i < size(); i++) {
+            (*this)[i].use_buffer(m_buffer[i]);
+        }
+    }
+
+    std::vector<std::string> m_buffer;
+};
+
 class ConstantStringValue : public Value<StringData> {
 public:
     ConstantStringValue(const StringData& string)


### PR DESCRIPTION
Storing the string in the argument buffer space is not sufficient as the query
may live longer than the arguments object.

## What, How & Why?
Fixes #5735 

## ☑️ ToDos
* [x] 📝 Changelog update
* [x] 🚦 Tests (or not relevant)
* [x] C-API, if public C++ API changed.
