### PR TITLE
Don't apply schema changes other than setting the schema version in read-only mode

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,8 @@
 ### Fixed
 * <How do the end-user experience this issue? what was the impact?> ([#????](https://github.com/realm/realm-core/issues/????), since v?.?.?)
 * Exposed the boolean `merge_with_existing` in the C-API's functions `realm_convert_with_config` and `realm_convert_with_path`. ([#5713](https://github.com/realm/realm-core/issues/5713))
- 
+* Opening a read-only Realm for the first time via `Realm::get_synchronized_realm()` would remove any columns present on the server but not in the local schema (since 12.5.0).
+
 ### Breaking changes
 * None.
 

--- a/src/realm/object-store/object_store.cpp
+++ b/src/realm/object-store/object_store.cpp
@@ -859,7 +859,9 @@ void ObjectStore::apply_schema_changes(Transaction& group, uint64_t schema_versi
     }
 
     if (schema_version == ObjectStore::NotVersioned) {
-        create_initial_tables(group, changes);
+        if (mode != SchemaMode::ReadOnly) {
+            create_initial_tables(group, changes);
+        }
         set_schema_version(group, target_schema_version);
         set_schema_keys(group, target_schema);
         return;

--- a/src/realm/object-store/shared_realm.cpp
+++ b/src/realm/object-store/shared_realm.cpp
@@ -436,7 +436,8 @@ void Realm::update_schema(Schema schema, uint64_t version, MigrationFunction mig
 
     uint64_t old_schema_version = m_schema_version;
     bool additive = m_config.schema_mode == SchemaMode::AdditiveDiscovered ||
-                    m_config.schema_mode == SchemaMode::AdditiveExplicit;
+                    m_config.schema_mode == SchemaMode::AdditiveExplicit ||
+                    m_config.schema_mode == SchemaMode::ReadOnly;
     if (migration_function && !additive) {
         auto wrapper = [&] {
             auto config = m_config;


### PR DESCRIPTION
#5696 accidentally made it so that we apply more changes than intended. `create_initial_tables()` will remove columns from the tables which aren't in the schema, which we don't want to do. I ported over all of the remaining relevant tests from Cocoa, so hopefully this is now correct.