### PR TITLE
Fix Jenkins iOS builds

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,6 +22,9 @@ Makefile
 Realm.xcodeproj
 CMakeScripts
 /build*
+/debug*
+/_CPack_Packages*
+realm-*.tar.gz
 
 # Ignore all user files except one which includes execution path for test
 *.user

--- a/.gitignore
+++ b/.gitignore
@@ -21,10 +21,10 @@ CTestTestfile.cmake
 Makefile
 Realm.xcodeproj
 CMakeScripts
+
+# Ignore build artifacts
 /build*
 /debug*
-/_CPack_Packages*
-realm-*.tar.gz
 
 # Ignore all user files except one which includes execution path for test
 *.user
@@ -56,6 +56,10 @@ compile_commands.json
 
 # ref doc
 /doc/ref_cpp/html/*
+
+# cpack artifacts
+/_CPack_Packages*
+/realm-*.tar.gz
 
 # sh build.sh build-cocoa
 /core-*.zip

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,7 @@
 * Processing a pending bootstrap before the sync client connects will properly surface errors to the user's error handler ([#5707](https://github.com/realm/realm-core/issues/5707), since v12.0.0)
 * Opening a read-only Realm for the first time via `Realm::get_synchronized_realm()` would remove any columns present on the server but not in the local schema (since 12.5.0).
 * Parsing a constant list of strings from RealmJS SDK to QueryParser would result in a "use after free situation". ([#5735](https://github.com/realm/realm-core/issues/5735))
- 
+
 ### Breaking changes
 * None.
 
@@ -22,6 +22,7 @@
 
 ### Internals
 * The top function of an assertion stack trace now includes the core version number.
+* Unset SDKROOT env variable when building ios targets with tools/build-apple-device.sh
 
 ----------------------------------------------
 
@@ -106,7 +107,7 @@
 * Fix a UBSan failure when mapping encrypted pages.
 * Improved performance of sync clients during integration of changesets with many small strings (totalling > 1024 bytes per changeset) on iOS 14, and devices which have restrictive or fragmented memory. ([#5614](https://github.com/realm/realm-core/issues/5614))
 * Fixed a bug that prevented the detection of tables being changed to or from asymmetric during migrations. ([#5603](https://github.com/realm/realm-core/pull/5603), since v12.1.0)
- 
+
 ### Breaking changes
 * In Realm JS, the client reset callback can result in the fatal error `Realm accessed on incorrect thread`. Using a thread safe reference instead of Realm instance fixes the issue. (Issue [realm/realm-js#4410](https://github.com/realm/realm-js/issues/4410))
 
@@ -134,7 +135,7 @@
 * Fixed a missing backlink removal when setting a Mixed from a TypedLink to null or any other non-link value. Users may have seen exception of "key not found" or assertion failures such as `mixed.hpp:165: [realm-core-12.1.0] Assertion failed: m_type` when removing the destination link object. ([#5574](https://github.com/realm/realm-core/pull/5573), since the introduction of Mixed in v11.0.0)
 * Asymmetric sync now works with embedded objects. (Issue [#5565](https://github.com/realm/realm-core/issues/5565), since v12.1.0)
 * Fixed an issue on Windows that would cause high CPU usage by the sync client when there are no active sync sessions. (Issue [#5591](https://github.com/realm/realm-core/issues/5591), since the introduction of Sync support for Windows)
- 
+
 ### Breaking changes
 * `realm_sync_before_client_reset_func_t` and `realm_sync_after_client_reset_func_t` in the C API now return a boolean value to indicate whether the callback succeeded or not, which signals to the sync client that a fatal error occurred. (PR [#5564](https://github.com/realm/realm-core/pull/5564))
 

--- a/tools/build-apple-device.sh
+++ b/tools/build-apple-device.sh
@@ -5,12 +5,11 @@ set -eo pipefail
 # Make sure SDKROOT variable is not set before building
 unset SDKROOT
 
-# Make sure the DEVELOPER_DIR variable is set before building
-if [[ -z "${DEVELOPER_DIR}" || ! -d "${DEVELOPER_DIR}" ]]; then
-    echo "error: DEVELOPER_DIR must be set to the xcode developer directory"
+# If set, make sure the DEVELOPER_DIR variable is set to a valid directory
+if [[ -n "${DEVELOPER_DIR}" && ! -d "${DEVELOPER_DIR}" ]]; then
+    echo "error: DEVELOPER_DIR is not a valid directory: ${DEVELOPER_DIR}"
     exit 1
 fi
-
 
 SCRIPT="$(basename "${BASH_SOURCE[0]}")"
 VERSION="$(git describe)"

--- a/tools/build-apple-device.sh
+++ b/tools/build-apple-device.sh
@@ -3,7 +3,7 @@
 set -eo pipefail
 
 # Make sure SDKROOT variable is not set before building
-export SDKROOT=
+unset SDKROOT
 
 # Make sure the DEVELOPER_DIR variable is set before building
 if [[ -z "${DEVELOPER_DIR}" || ! -d "${DEVELOPER_DIR}" ]]; then

--- a/tools/build-apple-device.sh
+++ b/tools/build-apple-device.sh
@@ -2,6 +2,16 @@
 
 set -eo pipefail
 
+# Make sure SDKROOT variable is not set before building
+export SDKROOT=
+
+# Make sure the DEVELOPER_DIR variable is set before building
+if [[ -z "${DEVELOPER_DIR}" || ! -d "${DEVELOPER_DIR}" ]]; then
+    echo "error: DEVELOPER_DIR must be set to the xcode developer directory"
+    exit 1
+fi
+
+
 SCRIPT="$(basename "${BASH_SOURCE[0]}")"
 VERSION="$(git describe)"
 


### PR DESCRIPTION
## What, How & Why?
Jenkins iOS builds were failing because the SDKROOT variable was already set to a MacOS SDK.
When running tools/build-apple-device.sh, the script will now unset the SDKROOT env variable and validate that the DEVELOPER_DIR env variable is set to a valid directory.

## ☑️ ToDos
* [x] 📝 Changelog update
