### PR TITLE
Remove Realm::file_format_upgraded_from_version() from header

### DIFF
--- a/src/realm/object-store/shared_realm.hpp
+++ b/src/realm/object-store/shared_realm.hpp
@@ -421,9 +421,6 @@ public:
      */
     static void delete_files(const std::string& realm_file_path, bool* did_delete_realm = nullptr);
 
-    // returns the file format version upgraded from if an upgrade took place
-    util::Optional<int> file_format_upgraded_from_version() const;
-
     bool has_pending_async_work() const;
 
     Realm(const Realm&) = delete;


### PR DESCRIPTION
The function was deleted in https://github.com/realm/realm-core/commit/a1812736201fb19ba681011366d0fb7a53603217, but the declaration was orphaned in the header.

## What, How & Why?
<!-- Describe the changes and give some hints to guide your reviewers if possible. -->
<!-- Link to relevant issue this fixes -->

## ☑️ ToDos
* ~~[ ] 📝 Changelog update~~
* ~~[ ] 🚦 Tests (or not relevant)~~
* ~~[ ] C-API, if public C++ API changed.~~
