### PR TITLE
Fix undefined behaviour dereferencing an empty optional

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@
 
 ### Fixed
 * <How do the end-user experience this issue? what was the impact?> ([#????](https://github.com/realm/realm-core/issues/????), since v?.?.?)
-* None.
+* Fixed undefined behaviour on queries involving a constant and an indexed column on some property types like UUID and Timestamp. ([#5753](https://github.com/realm/realm-core/issues/5753), since 12.5.0)
  
 ### Breaking changes
 * None.

--- a/src/realm/query_expression.hpp
+++ b/src/realm/query_expression.hpp
@@ -4060,7 +4060,9 @@ public:
                     column = m_left.get();
                 }
 
-                if (column->has_search_index() && *column->get_comparison_type() == ExpressionComparisonType::Any) {
+                if (column->has_search_index() &&
+                    column->get_comparison_type().value_or(ExpressionComparisonType::Any) ==
+                        ExpressionComparisonType::Any) {
                     if (const_value.is_null()) {
                         const ObjPropertyBase* prop = dynamic_cast<const ObjPropertyBase*>(m_right.get());
                         // when checking for null across links, null links are considered matches,


### PR DESCRIPTION
This was a bug Introduced in https://github.com/realm/realm-core/pull/5663.

Dereferencing an empty optional is undefined behaviour. It didn't seem to manifest except in our Windows x64 Debug builds.