### PR TITLE
Run object-store tests with debug logging by default

### DIFF
--- a/evergreen/config.yml
+++ b/evergreen/config.yml
@@ -104,9 +104,8 @@ functions:
               set_cmake_var realm_vars CMAKE_TOOLCHAIN_FILE PATH "${cmake_toolchain_file}"
           fi
 
-          if [ -n "${enable_logging|}" ]; then
-              set_cmake_var realm_vars REALM_TEST_SYNC_LOGGING BOOL On
-          fi
+          set_cmake_var realm_vars REALM_TEST_SYNC_LOGGING BOOL On
+          set_cmake_var realm_vars REALM_TEST_SYNC_LOGGING_LEVEL STRING "debug"
 
           GENERATOR="${cmake_generator}"
           if [ -z "${cmake_generator|}" ]; then
@@ -171,7 +170,14 @@ functions:
           if [[ -n "${test_filter}" ]]; then
               TEST_FLAGS="-R ${test_filter}"
           fi
-          TEST_FLAGS="$TEST_FLAGS ${test_flags|}"
+
+          if [[ -n "${verbose_test_output}" ]]; then
+              TEST_FLAGS="$TEST_FLAGS -VV"
+          else
+              TEST_FLAGS="$TEST_FLAGS -V"
+          fi
+
+          TEST_FLAGS="--no-tests=error $TEST_FLAGS ${test_flags|}"
 
           export UNITTEST_EVERGREEN_TEST_RESULTS="$(./evergreen/abspath.sh ${task_name}_results.json)"
           export UNITTEST_PROGRESS=1
@@ -184,7 +190,7 @@ functions:
           fi
 
           cd build
-          $CTEST -C ${cmake_build_type|Debug} -V $TEST_FLAGS
+          $CTEST -C ${cmake_build_type|Debug} $TEST_FLAGS
 
   "upload test results":
   - command: attach.results
@@ -565,6 +571,7 @@ tasks:
   - func: "run tests"
     vars:
       test_filter: ObjectStoreTests
+      verbose_test_output: true
 
 - name: lint
   tags: [ "for_pull_requests" ]

--- a/src/realm/sync/noinst/client_impl_base.cpp
+++ b/src/realm/sync/noinst/client_impl_base.cpp
@@ -1492,9 +1492,9 @@ void Session::activate()
     m_download_progress = m_progress.download;
     REALM_ASSERT(m_last_version_available >= m_progress.upload.client_version);
 
-    logger.trace("last_version_available  = %1", m_last_version_available);           // Throws
-    logger.trace("progress_server_version = %1", m_progress.download.server_version); // Throws
-    logger.trace("progress_client_version = %1",
+    logger.debug("last_version_available  = %1", m_last_version_available);           // Throws
+    logger.debug("progress_server_version = %1", m_progress.download.server_version); // Throws
+    logger.debug("progress_client_version = %1",
                  m_progress.download.last_integrated_client_version); // Throws
 
     reset_protocol_state();
@@ -1783,7 +1783,7 @@ void Session::send_upload_message()
         protocol.make_upload_message_builder(logger); // Throws
 
     for (const UploadChangeset& uc : uploadable_changesets) {
-        logger.trace("Fetching changeset for upload (client_version=%1, server_version=%2, "
+        logger.debug("Fetching changeset for upload (client_version=%1, server_version=%2, "
                      "changeset_size=%3, origin_timestamp=%4, origin_file_ident=%5)",
                      uc.progress.client_version, uc.progress.last_integrated_server_version, uc.changeset.size(),
                      uc.origin_timestamp, uc.origin_file_ident); // Throws

--- a/src/realm/sync/noinst/protocol_codec.hpp
+++ b/src/realm/sync/noinst/protocol_codec.hpp
@@ -424,14 +424,13 @@ private:
                                     "Server version in downloaded changeset cannot be zero");
             }
             auto changeset_data = msg.read_sized_data<BinaryData>(changeset_size);
-
+            logger.debug("Received: DOWNLOAD CHANGESET(server_version=%1, "
+                         "client_version=%2, origin_timestamp=%3, origin_file_ident=%4, "
+                         "original_changeset_size=%5, changeset_size=%6)",
+                         cur_changeset.remote_version, cur_changeset.last_integrated_local_version,
+                         cur_changeset.origin_timestamp, cur_changeset.origin_file_ident,
+                         cur_changeset.original_changeset_size, changeset_size); // Throws
             if (logger.would_log(util::Logger::Level::trace)) {
-                logger.trace("Received: DOWNLOAD CHANGESET(server_version=%1, "
-                             "client_version=%2, origin_timestamp=%3, origin_file_ident=%4, "
-                             "original_changeset_size=%5, changeset_size=%6)",
-                             cur_changeset.remote_version, cur_changeset.last_integrated_local_version,
-                             cur_changeset.origin_timestamp, cur_changeset.origin_file_ident,
-                             cur_changeset.original_changeset_size, changeset_size); // Throws;
                 if (changeset_data.size() < 1056) {
                     logger.trace("Changeset: %1",
                                  clamped_hex_dump(changeset_data)); // Throws

--- a/test/object-store/CMakeLists.txt
+++ b/test/object-store/CMakeLists.txt
@@ -109,6 +109,12 @@ if(REALM_TEST_SYNC_LOGGING)
     target_compile_definitions(ObjectStoreTests PRIVATE
         TEST_ENABLE_SYNC_LOGGING=1
     )
+
+    if(REALM_TEST_SYNC_LOGGING_LEVEL)
+        target_compile_definitions(ObjectStoreTests PRIVATE
+            TEST_ENABLE_SYNC_LOGGING_LEVEL=${REALM_TEST_SYNC_LOGGING_LEVEL}
+        )
+    endif()
 endif()
 
 target_include_directories(ObjectStoreTests PRIVATE

--- a/test/object-store/util/test_file.cpp
+++ b/test/object-store/util/test_file.cpp
@@ -170,7 +170,7 @@ SyncServer::SyncServer(const SyncServer::Config& config)
 
 #if TEST_ENABLE_SYNC_LOGGING
                    auto logger = new util::StderrLogger();
-                   logger->set_level_threshold(util::Logger::Level::all);
+                   logger->set_level_threshold(realm::util::Logger::Level::TEST_ENABLE_SYNC_LOGGING_LEVEL);
                    m_logger.reset(logger);
 #else
                    m_logger.reset(new TestLogger());
@@ -297,7 +297,7 @@ TestAppSession::TestAppSession(AppSession session,
     util::try_make_dir(m_base_file_path);
     SyncClientConfig sc_config;
     sc_config.base_file_path = m_base_file_path;
-    sc_config.log_level = TEST_ENABLE_SYNC_LOGGING ? util::Logger::Level::all : util::Logger::Level::off;
+    sc_config.log_level = realm::util::Logger::Level::TEST_ENABLE_SYNC_LOGGING_LEVEL;
     sc_config.metadata_mode = realm::SyncManager::MetadataMode::NoEncryption;
 
     m_app = app::App::get_uncached_app(app_config, sc_config);
@@ -342,7 +342,7 @@ TestSyncManager::TestSyncManager(const Config& config, const SyncServer::Config&
     util::try_make_dir(m_base_file_path);
     sc_config.base_file_path = m_base_file_path;
     sc_config.metadata_mode = config.metadata_mode;
-    sc_config.log_level = config.verbose_sync_client_logging ? util::Logger::Level::all : util::Logger::Level::off;
+    sc_config.log_level = config.sync_client_log_level;
 
     m_app = app::App::get_uncached_app(app_config, sc_config);
     if (config.override_sync_route) {

--- a/test/object-store/util/test_file.hpp
+++ b/test/object-store/util/test_file.hpp
@@ -96,8 +96,18 @@ void on_change_but_no_notify(realm::Realm& realm);
 #if REALM_ENABLE_SYNC
 
 #ifndef TEST_ENABLE_SYNC_LOGGING
-#define TEST_ENABLE_SYNC_LOGGING 0 // change to 1 to enable logging
+#define TEST_ENABLE_SYNC_LOGGING 0 // change to 1 to enable trace-level logging
 #endif
+
+#ifndef TEST_ENABLE_SYNC_LOGGING_LEVEL
+#if TEST_ENABLE_SYNC_LOGGING
+#define TEST_ENABLE_SYNC_LOGGING_LEVEL all
+#else
+#define TEST_ENABLE_SYNC_LOGGING_LEVEL off
+#endif // TEST_ENABLE_SYNC_LOGGING
+#endif // TEST_ENABLE_SYNC_LOGGING_LEVEL
+
+
 
 struct TestLogger : realm::util::Logger::LevelThreshold, realm::util::Logger {
     void do_log(realm::util::Logger::Level, std::string const&) override {}
@@ -216,7 +226,7 @@ public:
         std::string base_path;
         realm::SyncManager::MetadataMode metadata_mode = realm::SyncManager::MetadataMode::NoEncryption;
         bool should_teardown_test_directory = true;
-        bool verbose_sync_client_logging = TEST_ENABLE_SYNC_LOGGING;
+        realm::util::Logger::Level sync_client_log_level = realm::util::Logger::Level::TEST_ENABLE_SYNC_LOGGING_LEVEL;
         bool override_sync_route = true;
         std::shared_ptr<realm::app::GenericNetworkTransport> transport;
     };

--- a/test/object-store/util/test_file.hpp
+++ b/test/object-store/util/test_file.hpp
@@ -108,7 +108,6 @@ void on_change_but_no_notify(realm::Realm& realm);
 #endif // TEST_ENABLE_SYNC_LOGGING_LEVEL
 
 
-
 struct TestLogger : realm::util::Logger::LevelThreshold, realm::util::Logger {
     void do_log(realm::util::Logger::Level, std::string const&) override {}
     Level get() const noexcept override


### PR DESCRIPTION
## What, How & Why?
This makes it so evergreen object-store tasks run with debug-level logging turned on so that we can see exactly what was happening when a test failure occurs. I've made some adjustments to exactly what gets logged at trace vs debug to get the most info possible here, but it looks like at debug we don't add significant enough overhead to cause tests to fail/time out just because of logging.

## ☑️ ToDos
* [ ] 📝 Changelog update
* [ ] 🚦 Tests (or not relevant)
* [ ] C-API, if public C++ API changed.
