### PR TITLE
Use OwnedBinaryData rather than vector<char> for encryption keys

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@
 * Fixed undefined behaviour on queries involving a constant and an indexed column on some property types like UUID and Timestamp. ([#5753](https://github.com/realm/realm-core/issues/5753), since 12.5.0)
  
 ### Breaking changes
-* None.
+* `RealmConfig::encryption_key` and `SyncClientConfig::custom_encryption_key` now both use `OwnedBinaryData`. They both treat empty and null keys as equivalent. (PR [#5760](https://github.com/realm/realm-core/pull/5760))
 
 ### Compatibility
 * Fileformat: Generates files with format v22. Reads and automatically upgrade from fileformat v5.

--- a/src/realm/binary_data.hpp
+++ b/src/realm/binary_data.hpp
@@ -78,6 +78,10 @@ public:
     {
         return m_size;
     }
+    bool empty() const noexcept
+    {
+        return m_size == 0;
+    }
 
     /// Is this a null reference?
     ///

--- a/src/realm/object-store/c_api/realm.cpp
+++ b/src/realm/object-store/c_api/realm.cpp
@@ -1,5 +1,6 @@
 #include <realm/object-store/c_api/types.hpp>
 #include "realm.hpp"
+#include "realm/binary_data.hpp"
 
 realm_callback_token_realm::~realm_callback_token_realm()
 {
@@ -88,8 +89,9 @@ RLM_API bool realm_convert_with_path(const realm_t* realm, const char* path, rea
     return wrap_err([&]() {
         Realm::Config config;
         config.path = path;
-        if (encryption_key.data) {
-            config.encryption_key.assign(encryption_key.data, encryption_key.data + encryption_key.size);
+        if (encryption_key.size) {
+            config.encryption_key =
+                BinaryData(reinterpret_cast<const char*>(encryption_key.data), encryption_key.size);
         }
         (*realm)->convert(config, merge_with_existing);
         return true;

--- a/src/realm/object-store/c_api/sync.cpp
+++ b/src/realm/object-store/c_api/sync.cpp
@@ -26,6 +26,7 @@
 #include <realm/util/basic_system_errors.hpp>
 
 #include "logging.hpp"
+#include "realm/binary_data.hpp"
 #include "types.hpp"
 #include "util.hpp"
 
@@ -289,7 +290,7 @@ RLM_API void realm_sync_client_config_set_metadata_mode(realm_sync_client_config
 RLM_API void realm_sync_client_config_set_metadata_encryption_key(realm_sync_client_config_t* config,
                                                                   const uint8_t key[64]) noexcept
 {
-    config->custom_encryption_key = std::vector<char>(key, key + 64);
+    config->custom_encryption_key = OwnedBinaryData(reinterpret_cast<const char*>(&key), 64);
 }
 
 RLM_API void realm_sync_client_config_set_log_callback(realm_sync_client_config_t* config, realm_log_func_t callback,

--- a/src/realm/object-store/impl/apple/keychain_helper.hpp
+++ b/src/realm/object-store/impl/apple/keychain_helper.hpp
@@ -29,10 +29,10 @@
 namespace realm::keychain {
 
 // Get the stored encryption key for the metadata realm if one exists.
-util::Optional<std::vector<char>> get_existing_metadata_realm_key();
+OwnedBinaryData get_existing_metadata_realm_key();
 // Create a new encryption key and store it in the keychain. Returns none if
 // the key could not be stored.
-util::Optional<std::vector<char>> create_new_metadata_realm_key();
+OwnedBinaryData create_new_metadata_realm_key();
 
 // Delete the encryption key for the metadata realm from the keychain.
 void delete_metadata_realm_encryption_key();

--- a/src/realm/object-store/impl/generic/external_commit_helper.cpp
+++ b/src/realm/object-store/impl/generic/external_commit_helper.cpp
@@ -31,7 +31,7 @@ ExternalCommitHelper::ExternalCommitHelper(RealmCoordinator& parent)
     , m_history(realm::make_in_realm_history())
     , m_sg(DB::create(*m_history, parent.get_path(),
                       DBOptions(parent.is_in_memory() ? DBOptions::Durability::MemOnly : DBOptions::Durability::Full,
-                                parent.get_encryption_key().data())))
+                                parent.get_encryption_key().empty() ? nullptr : parent.get_encryption_key().data())))
     , m_thread(std::async(std::launch::async, [=] {
         auto tr = m_sg->start_read();
         while (m_sg->wait_for_change(tr)) {

--- a/src/realm/object-store/impl/realm_coordinator.cpp
+++ b/src/realm/object-store/impl/realm_coordinator.cpp
@@ -16,6 +16,7 @@
 //
 ////////////////////////////////////////////////////////////////////////////
 
+#include "realm/null.hpp"
 #include <realm/object-store/impl/realm_coordinator.hpp>
 
 #include <realm/object-store/impl/collection_notifier.hpp>
@@ -115,7 +116,7 @@ void RealmCoordinator::create_sync_session()
 
 void RealmCoordinator::set_config(const Realm::Config& config)
 {
-    if (config.encryption_key.data() && config.encryption_key.size() != 64)
+    if (!config.encryption_key.empty() && config.encryption_key.size() != 64)
         throw InvalidEncryptionKeyException();
     if (config.schema_mode == SchemaMode::Immutable && config.sync_config)
         throw std::logic_error("Synchronized Realms cannot be opened in immutable mode");
@@ -171,7 +172,7 @@ void RealmCoordinator::set_config(const Realm::Config& config)
             throw MismatchedConfigException("Realm at path '%1' already opened with different inMemory settings.",
                                             config.path);
         }
-        if (m_config.encryption_key != config.encryption_key) {
+        if (m_config.encryption_key.get() != config.encryption_key.get()) {
             throw MismatchedConfigException("Realm at path '%1' already opened with a different encryption key.",
                                             config.path);
         }
@@ -512,7 +513,7 @@ void RealmCoordinator::open_db()
         if (!m_config.fifo_files_fallback_path.empty()) {
             options.temp_dir = util::normalize_dir(m_config.fifo_files_fallback_path);
         }
-        options.encryption_key = m_config.encryption_key.data();
+        options.encryption_key = m_config.encryption_key_ptr();
         options.allow_file_format_upgrade = !m_config.disable_format_upgrade && !schema_mode_reset_file;
         if (history) {
             options.backup_at_file_format_change = m_config.backup_at_file_format_change;

--- a/src/realm/object-store/impl/realm_coordinator.hpp
+++ b/src/realm/object-store/impl/realm_coordinator.hpp
@@ -102,9 +102,9 @@ public:
     {
         return m_config.path;
     }
-    const std::vector<char>& get_encryption_key() const noexcept
+    BinaryData get_encryption_key() const noexcept
     {
-        return m_config.encryption_key;
+        return m_config.encryption_key.get();
     }
     bool is_in_memory() const noexcept
     {

--- a/src/realm/object-store/shared_realm.cpp
+++ b/src/realm/object-store/shared_realm.cpp
@@ -1100,20 +1100,18 @@ void Realm::convert(const Config& config, bool merge_into_existing)
         bool dst_is_sync = config.sync_config || config.force_sync_history;
 
         if (dst_is_sync) {
-            m_coordinator->write_copy(config.path, config.encryption_key.data());
+            m_coordinator->write_copy(config.path, config.encryption_key_ptr());
             if (!src_is_sync) {
 #if REALM_ENABLE_SYNC
                 DBOptions options;
-                if (config.encryption_key.size()) {
-                    options.encryption_key = config.encryption_key.data();
-                }
+                options.encryption_key = config.encryption_key_ptr();
                 auto db = DB::create(make_in_realm_history(), config.path, options);
                 db->create_new_history(sync::make_client_replication());
 #endif
             }
         }
         else {
-            tr.write(config.path, config.encryption_key.data());
+            tr.write(config.path, config.encryption_key_ptr());
         }
     }
     catch (...) {

--- a/src/realm/object-store/shared_realm.hpp
+++ b/src/realm/object-store/shared_realm.hpp
@@ -95,7 +95,13 @@ struct RealmConfig {
     std::string path;
     BinaryData realm_data;
     // User-supplied encryption key. Must be either empty or 64 bytes.
-    std::vector<char> encryption_key;
+    OwnedBinaryData encryption_key;
+
+    // Treats empty and null encryption keys the same.
+    const char* encryption_key_ptr() const
+    {
+        return encryption_key.empty() ? nullptr : encryption_key.data();
+    }
 
     // Core and Object Store will in some cases need to create named pipes alongside the Realm file.
     // But on some filesystems this can be a problem (e.g. external storage on Android that uses FAT32).

--- a/src/realm/object-store/sync/impl/sync_metadata.hpp
+++ b/src/realm/object-store/sync/impl/sync_metadata.hpp
@@ -265,8 +265,7 @@ public:
     /// If the platform supports it, setting `should_encrypt` to `true` and not specifying an encryption key will make
     /// the object store handle generating and persisting an encryption key for the metadata database. Otherwise, an
     /// exception will be thrown.
-    SyncMetadataManager(std::string path, bool should_encrypt,
-                        util::Optional<std::vector<char>> encryption_key = none);
+    SyncMetadataManager(std::string path, bool should_encrypt, OwnedBinaryData encryption_key = {});
 
 private:
     SyncUserMetadataResults get_users(bool marked) const;

--- a/src/realm/object-store/sync/sync_manager.hpp
+++ b/src/realm/object-store/sync/sync_manager.hpp
@@ -19,6 +19,7 @@
 #ifndef REALM_OS_SYNC_MANAGER_HPP
 #define REALM_OS_SYNC_MANAGER_HPP
 
+#include "realm/binary_data.hpp"
 #include <realm/object-store/shared_realm.hpp>
 
 #include <realm/util/checked_mutex.hpp>
@@ -71,7 +72,7 @@ struct SyncClientConfig {
 
     std::string base_file_path;
     MetadataMode metadata_mode = MetadataMode::Encryption;
-    util::Optional<std::vector<char>> custom_encryption_key;
+    OwnedBinaryData custom_encryption_key;
 
     using LoggerFactory = std::function<std::unique_ptr<util::Logger>(util::Logger::Level)>;
     LoggerFactory logger_factory;

--- a/src/realm/owned_data.hpp
+++ b/src/realm/owned_data.hpp
@@ -23,6 +23,7 @@
 
 #include <cstring>
 #include <memory>
+#include <utility>
 
 namespace realm {
 
@@ -59,8 +60,16 @@ public:
     }
     OwnedData& operator=(const OwnedData& other);
 
-    OwnedData(OwnedData&&) = default;
-    OwnedData& operator=(OwnedData&&) = default;
+    OwnedData(OwnedData&& other) noexcept
+        : OwnedData(std::move(other.m_data), std::exchange(other.m_size, 0))
+    {
+    }
+    OwnedData& operator=(OwnedData&& other) noexcept
+    {
+        m_data = std::move(other.m_data);
+        m_size = std::exchange(other.m_size, 0);
+        return *this;
+    }
 
     const char* data() const
     {
@@ -69,6 +78,11 @@ public:
     size_t size() const
     {
         return m_size;
+    }
+
+    bool empty() const
+    {
+        return m_size == 0;
     }
 
 private:

--- a/test/object-store/backup.cpp
+++ b/test/object-store/backup.cpp
@@ -64,7 +64,7 @@ TEST_CASE("Automated backup") {
     TestFile config;
     std::string copy_from_file_name = test_util::get_test_resource_path() + "test_backup-olden-and-golden.realm";
     config.path = test_util::get_test_path_prefix() + "test_backup.realm";
-    config.encryption_key.clear();
+    config.encryption_key = {};
     REQUIRE(util::File::exists(copy_from_file_name));
     util::File::copy(copy_from_file_name, config.path);
     REQUIRE(util::File::exists(config.path));

--- a/test/object-store/sync/client_reset.cpp
+++ b/test/object-store/sync/client_reset.cpp
@@ -838,7 +838,7 @@ TEST_CASE("sync: client reset", "[client reset]") {
         }
 
         SECTION("should honor encryption key for downloaded Realm") {
-            local_config.encryption_key.resize(64, 'a');
+            local_config.encryption_key = BinaryData(std::string(64, 'a').data(), 64);
 
             make_reset(local_config, remote_config)
                 ->on_post_reset([&](SharedRealm realm) {

--- a/test/object-store/sync/sync_test_utils.cpp
+++ b/test/object-store/sync/sync_test_utils.cpp
@@ -234,9 +234,9 @@ struct FakeLocalClientReset : public TestClientReset {
         m_local_config.force_sync_history = true;
         m_remote_config.force_sync_history = true;
         m_local_config.in_memory = true;
-        m_local_config.encryption_key = std::vector<char>();
+        m_local_config.encryption_key = {};
         m_remote_config.in_memory = true;
-        m_remote_config.encryption_key = std::vector<char>();
+        m_remote_config.encryption_key = {};
     }
 
     void run() override

--- a/test/object-store/util/test_file.cpp
+++ b/test/object-store/util/test_file.cpp
@@ -67,7 +67,7 @@ TestFile::TestFile()
     m_temp_dir = util::make_temp_dir();
     path = (fs::path(m_temp_dir) / "realm.XXXXXX").string();
     if (const char* crypt_key = test_util::crypt_key()) {
-        encryption_key = std::vector<char>(crypt_key, crypt_key + 64);
+        encryption_key = BinaryData(crypt_key, 64);
     }
     int fd = mkstemp(path.data());
     if (fd < 0) {
@@ -108,7 +108,7 @@ DBOptions TestFile::options() const
 InMemoryTestFile::InMemoryTestFile()
 {
     in_memory = true;
-    encryption_key = std::vector<char>();
+    encryption_key = {};
 }
 
 #if REALM_ENABLE_SYNC

--- a/test/object-store/util/test_utils.cpp
+++ b/test/object-store/util/test_utils.cpp
@@ -59,14 +59,13 @@ void reset_test_directory(const std::string& base_path)
     util::make_dir(base_path);
 }
 
-std::vector<char> make_test_encryption_key(const char start)
+OwnedBinaryData make_test_encryption_key(const char start)
 {
-    std::vector<char> vector;
-    vector.reserve(64);
+    auto key = std::make_unique<char[]>(64);
     for (int i = 0; i < 64; i++) {
-        vector.emplace_back((start + i) % 128);
+        key[i] = (start + i) % 128;
     }
-    return vector;
+    return {std::move(key), 64};
 }
 
 // FIXME: Catch2 limitation on old compilers (currently our android CI)

--- a/test/object-store/util/test_utils.hpp
+++ b/test/object-store/util/test_utils.hpp
@@ -19,6 +19,7 @@
 #ifndef REALM_TEST_UTILS_HPP
 #define REALM_TEST_UTILS_HPP
 
+#include "realm/binary_data.hpp"
 #include <catch2/catch_all.hpp>
 #include <catch2/matchers/catch_matchers_all.hpp>
 #include <realm/util/file.hpp>
@@ -33,7 +34,7 @@ namespace realm {
 /// Open a Realm at a given path, creating its files.
 bool create_dummy_realm(std::string path);
 void reset_test_directory(const std::string& base_path);
-std::vector<char> make_test_encryption_key(const char start = 0);
+OwnedBinaryData make_test_encryption_key(const char start = 0);
 void catch2_ensure_section_run_workaround(bool did_run_a_section, std::string section_name,
                                           util::FunctionRef<void()> func);
 


### PR DESCRIPTION
## What, How & Why?
<!-- Describe the changes and give some hints to guide your reviewers if possible. -->
<!-- Link to relevant issue this fixes -->

This is a better semantic fit for the data, and will make it easier to automatically generate bindings.

## ☑️ ToDos
* [x] 📝 Changelog update
* ~~[ ] 🚦 Tests (or not relevant)~~
* ~~[ ] C-API, if public C++ API changed.~~
