### PR TITLE
expose Obj::add_int in the CAPI

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ### Enhancements
 * <New feature description> (PR [#????](https://github.com/realm/realm-core/pull/????))
 * Notify when read transaction version is advanced. ([PR #5704](https://github.com/realm/realm-core/pull/5704)).
+* Expose `Obj::add_int()` in the CAPI. ([PR #5770](https://github.com/realm/realm-core/pull/5770)).
 
 ### Fixed
 * <How do the end-user experience this issue? what was the impact?> ([#????](https://github.com/realm/realm-core/issues/????), since v?.?.?)

--- a/src/realm.h
+++ b/src/realm.h
@@ -1448,6 +1448,15 @@ RLM_API bool realm_object_delete(realm_object_t*);
 RLM_API bool realm_object_resolve_in(const realm_object_t* live_object, const realm_t* target_realm,
                                      realm_object_t** resolved);
 
+/**
+ * Increment atomically property specified as parameter by value, for the object passed as argument.
+ * @param object valid ptr to an object store in the database
+ * @param property_key id of the property to change
+ * @param value increment for the property passed as argument
+ * @return True if not exception occurred.
+ */
+RLM_API bool realm_object_add_int(realm_object_t* object, realm_property_key_t property_key, int64_t value);
+
 
 RLM_API realm_object_t* _realm_object_from_native_copy(const void* pobj, size_t n);
 RLM_API realm_object_t* _realm_object_from_native_move(void* pobj, size_t n);

--- a/src/realm/object-store/c_api/object.cpp
+++ b/src/realm/object-store/c_api/object.cpp
@@ -202,6 +202,16 @@ RLM_API bool realm_object_resolve_in(const realm_object_t* from_object, const re
     });
 }
 
+RLM_API bool realm_object_add_int(realm_object_t* object, realm_property_key_t property_key, int64_t value)
+{
+    REALM_ASSERT(object);
+    return wrap_err([&]() {
+        object->obj().add_int(ColKey(property_key), value);
+        return true;
+    });
+}
+
+
 RLM_API bool realm_object_is_valid(const realm_object_t* obj)
 {
     return obj->is_valid();

--- a/src/realm/object-store/c_api/object.cpp
+++ b/src/realm/object-store/c_api/object.cpp
@@ -206,6 +206,7 @@ RLM_API bool realm_object_add_int(realm_object_t* object, realm_property_key_t p
 {
     REALM_ASSERT(object);
     return wrap_err([&]() {
+        object->verify_attached();
         object->obj().add_int(ColKey(property_key), value);
         return true;
     });

--- a/test/object-store/c_api/c_api.cpp
+++ b/test/object-store/c_api/c_api.cpp
@@ -1716,6 +1716,18 @@ TEST_CASE("C API", "[c_api]") {
             });
         }
 
+        SECTION("realm_object_add_int errors") {
+            SECTION("SUCCESS") {
+                realm_begin_write(realm);
+                CHECK(realm_object_add_int(obj1.get(), foo_int_key, 10));
+                realm_commit(realm);
+            }
+            SECTION("ERROR") {
+                CHECK(!realm_object_add_int(obj1.get(), foo_int_key, 10));
+                CHECK_ERR(RLM_ERR_NOT_IN_A_TRANSACTION);
+            }
+        }
+
         SECTION("get/set all property types") {
             realm_value_t null = rlm_null();
             realm_value_t integer = rlm_int_val(987);


### PR DESCRIPTION
## What, How & Why?
Expose `Obj::add_int()` in the CAPI.
FIxes: https://github.com/realm/realm-core/issues/5763

## ☑️ ToDos
* [ ] 📝 Changelog update
* [ ] 🚦 Tests (or not relevant)
* [ ] C-API, if public C++ API changed.
