### PR TITLE
Reduce the amount of work the sync client does while holding the write lock

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 * Automatic handling backlinks for schema migrations where a class changes to being embedded. ([PR #5737](https://github.com/realm/realm-core/pull/5737)).
 * Expose `Obj::add_int()` in the CAPI. ([PR #5770](https://github.com/realm/realm-core/pull/5770)).
 * Expose `Realm::async_begin_transaction`, `Realm::async_commit_transaction`, `Realm::async_cancel_transaction` in the CAPI.([PR 5783 #](https://github.com/realm/realm-core/pull/5783)).
+* Improve performance when a new Realm file connects to the server for the first time, especially when significant amounts of data has been written while offline.
 
 ### Fixed
 * <How do the end-user experience this issue? what was the impact?> ([#????](https://github.com/realm/realm-core/issues/????), since v?.?.?)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 * Expose `Realm::async_begin_transaction`, `Realm::async_commit_transaction`, `Realm::async_cancel_transaction` in the CAPI.([PR 5783 #](https://github.com/realm/realm-core/pull/5783)).
 * Improve performance when a new Realm file connects to the server for the first time, especially when significant amounts of data has been written while offline.
 * Shift more of the work done on the sync worker thread out of the write transaction used to apply server changes, reducing how long it blocks other threads from writing.
+* Improve the performance of the sync changeset parser, which speeds up applying changesets from the server.
 
 ### Fixed
 * <How do the end-user experience this issue? what was the impact?> ([#????](https://github.com/realm/realm-core/issues/????), since v?.?.?)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 * Expose `Obj::add_int()` in the CAPI. ([PR #5770](https://github.com/realm/realm-core/pull/5770)).
 * Expose `Realm::async_begin_transaction`, `Realm::async_commit_transaction`, `Realm::async_cancel_transaction` in the CAPI.([PR 5783 #](https://github.com/realm/realm-core/pull/5783)).
 * Improve performance when a new Realm file connects to the server for the first time, especially when significant amounts of data has been written while offline.
+* Shift more of the work done on the sync worker thread out of the write transaction used to apply server changes, reducing how long it blocks other threads from writing.
 
 ### Fixed
 * <How do the end-user experience this issue? what was the impact?> ([#????](https://github.com/realm/realm-core/issues/????), since v?.?.?)

--- a/src/realm/sync/changeset.hpp
+++ b/src/realm/sync/changeset.hpp
@@ -22,10 +22,7 @@ struct Changeset {
     using file_ident_type = uint_fast64_t;
     using version_type = uint_fast64_t; // FIXME: Get from `History`.
 
-    Changeset();
-    struct share_buffers_tag {
-    };
-    Changeset(const Changeset&, share_buffers_tag);
+    Changeset() = default;
     Changeset(Changeset&&) = default;
     Changeset& operator=(Changeset&&) = default;
     Changeset(const Changeset&) = delete;
@@ -195,8 +192,8 @@ struct Changeset {
 
 private:
     std::vector<Instruction> m_instructions;
-    std::shared_ptr<std::string> m_string_buffer;
-    std::shared_ptr<InternStrings> m_strings;
+    std::string m_string_buffer;
+    InternStrings m_strings;
     bool m_is_dirty = false;
 
     iterator const_iterator_to_iterator(const_iterator);
@@ -471,45 +468,44 @@ inline void Changeset::clear() noexcept
 
 inline util::Optional<StringBufferRange> Changeset::try_get_intern_string(InternString string) const noexcept
 {
-    if (string.value >= m_strings->size())
+    if (string.value >= m_strings.size())
         return util::none;
-    return (*m_strings)[string.value];
+    return m_strings[string.value];
 }
 
 inline StringBufferRange Changeset::get_intern_string(InternString string) const noexcept
 {
-    auto str = try_get_intern_string(string);
-    REALM_ASSERT(str);
-    return *str;
+    REALM_ASSERT(string.value < m_strings.size());
+    return m_strings[string.value];
 }
 
 inline InternStrings& Changeset::interned_strings() noexcept
 {
-    return *m_strings;
+    return m_strings;
 }
 
 inline const InternStrings& Changeset::interned_strings() const noexcept
 {
-    return *m_strings;
+    return m_strings;
 }
 
 inline auto Changeset::string_buffer() noexcept -> std::string&
 {
-    return *m_string_buffer;
+    return m_string_buffer;
 }
 
 inline auto Changeset::string_buffer() const noexcept -> const std::string&
 {
-    return *m_string_buffer;
+    return m_string_buffer;
 }
 
 inline util::Optional<StringData> Changeset::try_get_string(StringBufferRange range) const noexcept
 {
-    if (range.offset > m_string_buffer->size())
+    if (range.offset > m_string_buffer.size())
         return util::none;
-    if (range.offset + range.size > m_string_buffer->size())
+    if (range.offset + range.size > m_string_buffer.size())
         return util::none;
-    return StringData{m_string_buffer->data() + range.offset, range.size};
+    return StringData{m_string_buffer.data() + range.offset, range.size};
 }
 
 inline util::Optional<StringData> Changeset::try_get_string(InternString str) const noexcept
@@ -534,7 +530,7 @@ inline StringData Changeset::get_string(InternString string) const noexcept
 
 inline StringData Changeset::string_data() const noexcept
 {
-    return StringData{m_string_buffer->data(), m_string_buffer->size()};
+    return StringData{m_string_buffer.data(), m_string_buffer.size()};
 }
 
 inline StringBufferRange Changeset::append_string(StringData string)
@@ -542,11 +538,11 @@ inline StringBufferRange Changeset::append_string(StringData string)
     // We expect more strings. Only do this at the beginning because until C++20, reserve
     // will shrink_to_fit if the request is less than the current capacity.
     constexpr size_t small_string_buffer_size = 1024;
-    if (m_string_buffer->capacity() < small_string_buffer_size) {
-        m_string_buffer->reserve(small_string_buffer_size);
+    if (m_string_buffer.capacity() < small_string_buffer_size) {
+        m_string_buffer.reserve(small_string_buffer_size);
     }
-    size_t offset = m_string_buffer->size();
-    m_string_buffer->append(string.data(), string.size());
+    size_t offset = m_string_buffer.size();
+    m_string_buffer.append(string.data(), string.size());
     return StringBufferRange{uint32_t(offset), uint32_t(string.size())};
 }
 

--- a/src/realm/sync/changeset.hpp
+++ b/src/realm/sync/changeset.hpp
@@ -22,12 +22,6 @@ struct Changeset {
     using file_ident_type = uint_fast64_t;
     using version_type = uint_fast64_t; // FIXME: Get from `History`.
 
-    Changeset() = default;
-    Changeset(Changeset&&) = default;
-    Changeset& operator=(Changeset&&) = default;
-    Changeset(const Changeset&) = delete;
-    Changeset& operator=(const Changeset&) = delete;
-
     InternString intern_string(StringData);              // Slow!
     InternString find_string(StringData) const noexcept; // Slow!
     StringData string_data() const noexcept;

--- a/src/realm/sync/changeset_encoder.cpp
+++ b/src/realm/sync/changeset_encoder.cpp
@@ -306,16 +306,7 @@ void ChangesetEncoder::append_path_instr(Instruction::Type t, const Instruction:
 template <class T>
 void ChangesetEncoder::append_int(T integer)
 {
-    // One sign bit plus number of value bits
-    const int num_bits = 1 + std::numeric_limits<T>::digits;
-    // Only the first 7 bits are available per byte. Had it not been
-    // for the fact that maximum guaranteed bit width of a char is 8,
-    // this value could have been increased to 15 (one less than the
-    // number of value bits in 'unsigned').
-    const int bits_per_byte = 7;
-    const int max_bytes = (num_bits + (bits_per_byte - 1)) / bits_per_byte;
-
-    char buffer[max_bytes];
+    char buffer[_impl::encode_int_max_bytes<T>()];
     std::size_t n = _impl::encode_int(buffer, integer);
     append_bytes(buffer, n);
 }

--- a/src/realm/sync/changeset_encoder.hpp
+++ b/src/realm/sync/changeset_encoder.hpp
@@ -7,7 +7,7 @@
 namespace realm {
 namespace sync {
 
-struct ChangesetEncoder : InstructionHandler {
+struct ChangesetEncoder {
     using Buffer = util::AppendBuffer<char>;
 
     Buffer release() noexcept;
@@ -15,12 +15,12 @@ struct ChangesetEncoder : InstructionHandler {
     Buffer& buffer() noexcept;
     InternString intern_string(StringData);
 
-    void set_intern_string(uint32_t index, StringBufferRange) override;
+    void set_intern_string(uint32_t index, StringBufferRange);
     // FIXME: This doesn't copy the input, but the drawback is that there can
     // only be a single StringBufferRange per instruction. Luckily, no
     // instructions exist that require two or more.
-    StringBufferRange add_string_range(StringData) override;
-    void operator()(const Instruction&) override;
+    StringBufferRange add_string_range(StringData);
+    void operator()(const Instruction&);
 
 #define REALM_DEFINE_INSTRUCTION_HANDLER(X) void operator()(const Instruction::X&);
     REALM_FOR_EACH_INSTRUCTION_TYPE(REALM_DEFINE_INSTRUCTION_HANDLER)

--- a/src/realm/sync/changeset_parser.cpp
+++ b/src/realm/sync/changeset_parser.cpp
@@ -332,10 +332,10 @@ void State::parse_one()
 
     if (t == InstrTypeInternString) {
         uint32_t index = read_int<uint32_t>();
-        StringData str = read_string();
         if (index != m_intern_strings.size()) {
             parser_error("Unexpected intern index");
         }
+        StringData str = read_string();
         if (!m_intern_strings.insert(str).second) {
             parser_error("Unexpected intern string");
         }

--- a/src/realm/sync/client.cpp
+++ b/src/realm/sync/client.cpp
@@ -809,8 +809,7 @@ void SessionImpl::process_pending_flx_bootstrap()
 
 
         history.integrate_server_changesets(
-            *pending_batch.progress, &downloadable_bytes, pending_batch.changesets.data(),
-            pending_batch.changesets.size(), new_version, batch_state, logger,
+            *pending_batch.progress, &downloadable_bytes, pending_batch.changesets, new_version, batch_state, logger,
             [&](const TransactionRef& tr) {
                 bootstrap_store->pop_front_pending(tr, pending_batch.changesets.size());
             },

--- a/src/realm/sync/client_base.hpp
+++ b/src/realm/sync/client_base.hpp
@@ -291,6 +291,14 @@ struct ClientConfig {
     ///
     /// Testing/debugging feature. Should never be enabled in production.
     bool disable_sync_to_disk = false;
+
+    /// The sync client supports tables without primary keys by synthesizing a
+    /// pk using the client file ident, which means that all changesets waiting
+    /// to be uploaded need to be rewritten with the correct ident the first time
+    /// we connect to the server. The modern server doesn't support this and
+    /// requires pks for all tables, so this is now only applicable to old sync
+    /// tests and so is disabled by default.
+    bool fix_up_object_ids = false;
 };
 
 /// \brief Information about an error causing a session to be temporarily

--- a/src/realm/sync/noinst/client_history_impl.cpp
+++ b/src/realm/sync/noinst/client_history_impl.cpp
@@ -400,7 +400,7 @@ void ClientHistory::integrate_server_changesets(const SyncProgress& progress,
     }
     catch (BadChangesetError& e) {
         throw IntegrationException(ClientError::bad_changeset,
-                                   util::format("Failed to parse, or apply received changeset: %1", e.what()));
+                                   util::format("Failed to parse received changeset: %1", e.what()));
     }
 
     // Changesets are applied to the Realm with replication temporarily
@@ -452,11 +452,11 @@ void ClientHistory::integrate_server_changesets(const SyncProgress& progress,
             }
         }
     }
-    catch (BadChangesetError& e) {
+    catch (const BadChangesetError& e) {
         throw IntegrationException(ClientError::bad_changeset,
-                                   util::format("Failed to parse, or apply received changeset: %1", e.what()));
+                                   util::format("Failed to apply received changeset: %1", e.what()));
     }
-    catch (TransformError& e) {
+    catch (const TransformError& e) {
         throw IntegrationException(ClientError::bad_changeset,
                                    util::format("Failed to transform received changeset: %1", e.what()));
     }

--- a/src/realm/sync/noinst/client_history_impl.cpp
+++ b/src/realm/sync/noinst/client_history_impl.cpp
@@ -799,31 +799,25 @@ void ClientHistory::trim_ct_history()
 {
     version_type begin = m_ct_history_base_version;
     version_type end = m_version_of_oldest_bound_snapshot;
+    REALM_ASSERT(end >= begin);
 
-    // Because `m_version_of_oldest_bound_snapshot` in this history object is
-    // only updated by those transactions that occur on behalf of SharedGroup
-    // object that is associated with this history object, it can happen that
-    // `m_version_of_oldest_bound_snapshot` precedes the beginning of the
-    // history, even though that seems nonsensical. In such a case, no trimming
-    // can be done yet.
-    if (end > begin) {
-        std::size_t n = std::size_t(end - begin);
+    std::size_t n = std::size_t(end - begin);
+    if (n == 0)
+        return;
 
-        // The new changeset is always added before set_oldest_bound_version()
-        // is called. Therefore, the trimming operation can never leave the
-        // history empty.
-        REALM_ASSERT(n < ct_history_size());
+    // The new changeset is always added before set_oldest_bound_version()
+    // is called. Therefore, the trimming operation can never leave the
+    // history empty.
+    REALM_ASSERT(n < ct_history_size());
 
-        for (std::size_t i = 0; i < n; ++i) {
-            std::size_t j = (n - 1) - i;
-            m_arrays->ct_history.erase(j);
-        }
-
-        m_ct_history_base_version += n;
-
-        REALM_ASSERT(m_ct_history_base_version + ct_history_size() ==
-                     m_sync_history_base_version + sync_history_size());
+    for (std::size_t i = 0; i < n; ++i) {
+        std::size_t j = (n - 1) - i;
+        m_arrays->ct_history.erase(j);
     }
+
+    m_ct_history_base_version += n;
+
+    REALM_ASSERT(m_ct_history_base_version + ct_history_size() == m_sync_history_base_version + sync_history_size());
 }
 
 

--- a/src/realm/sync/noinst/client_history_impl.cpp
+++ b/src/realm/sync/noinst/client_history_impl.cpp
@@ -219,15 +219,6 @@ auto ClientReplication::prepare_changeset(const char* data, size_t size, version
     return m_history.add_changeset(ct_changeset, sync_changeset); // Throws
 }
 
-
-// Overriding member function in realm::Replication
-void ClientReplication::finalize_changeset() noexcept
-{
-    // Since the history is in the Realm, the added changeset is
-    // automatically finalized as part of the commit operation.
-    m_history.m_changeset_from_server = util::none;
-}
-
 util::UniqueFunction<SyncReplication::WriteValidator> ClientReplication::make_write_validator(Transaction& tr)
 {
     if (!m_write_validator_factory) {
@@ -395,39 +386,45 @@ void ClientHistory::integrate_server_changesets(const SyncProgress& progress,
 {
     REALM_ASSERT(num_changesets != 0);
 
+    std::uint_fast64_t downloaded_bytes_in_message = 0;
+    std::vector<Changeset> changesets;
+    changesets.resize(num_changesets); // Throws
+
+    try {
+        for (std::size_t i = 0; i < num_changesets; ++i) {
+            const RemoteChangeset& changeset = incoming_changesets[i];
+            downloaded_bytes_in_message += changeset.original_changeset_size;
+            parse_remote_changeset(changeset, changesets[i]); // Throws
+            changesets[i].transform_sequence = i;
+        }
+    }
+    catch (BadChangesetError& e) {
+        throw IntegrationException(ClientError::bad_changeset,
+                                   util::format("Failed to parse, or apply received changeset: %1", e.what()));
+    }
+
     // Changesets are applied to the Realm with replication temporarily
     // disabled. The main reason for disabling replication and manually adding
     // the transformed changesets to the history, is that the replication system
     // (due to technical debt) is unable in some cases to produce a correct
     // changeset while applying another one (i.e., it cannot carbon copy).
 
-    VersionID old_version;
     TransactionRef transact = m_db->start_write(); // Throws
-    old_version = transact->get_version_of_current_transaction();
+    VersionID old_version = transact->get_version_of_current_transaction();
     version_type local_version = old_version.version;
+    auto sync_file_id = transact->get_sync_file_id();
+    REALM_ASSERT(sync_file_id != 0);
 
     ensure_updated(local_version); // Throws
     prepare_for_write();           // Throws
 
-    REALM_ASSERT(transact->get_sync_file_id() != 0);
-
-    std::vector<char> assembled_transformed_changeset;
-    std::vector<Changeset> changesets;
-    changesets.resize(num_changesets); // Throws
-
-    std::uint_fast64_t downloaded_bytes_in_message = 0;
-
+    ChangesetEncoder::Buffer transformed_changeset;
     try {
         for (std::size_t i = 0; i < num_changesets; ++i) {
             const RemoteChangeset& changeset = incoming_changesets[i];
             REALM_ASSERT(changeset.last_integrated_local_version <= local_version);
-            REALM_ASSERT(changeset.origin_file_ident > 0 &&
-                         changeset.origin_file_ident != transact->get_sync_file_id());
-            downloaded_bytes_in_message += changeset.original_changeset_size;
+            REALM_ASSERT(changeset.origin_file_ident > 0 && changeset.origin_file_ident != sync_file_id);
 
-            parse_remote_changeset(changeset, changesets[i]); // Throws
-
-            changesets[i].transform_sequence = i;
             // It is possible that the synchronization history has been trimmed
             // to a point where a prefix of the merge window is no longer
             // available, but this can only happen if that prefix consisted
@@ -444,32 +441,14 @@ void ClientHistory::integrate_server_changesets(const SyncProgress& progress,
 
         if (m_replication.apply_server_changes()) {
             Transformer& transformer = get_transformer(); // Throws
-            transformer.transform_remote_changesets(*this, transact->get_sync_file_id(), local_version,
-                                                    changesets.data(), changesets.size(),
+            transformer.transform_remote_changesets(*this, sync_file_id, local_version, changesets,
                                                     &logger); // Throws
 
+            TempShortCircuitReplication tscr{m_replication};
+            InstructionApplier applier{*transact};
             for (std::size_t i = 0; i < num_changesets; ++i) {
-                ChangesetEncoder::Buffer transformed_changeset;
                 encode_changeset(changesets[i], transformed_changeset);
-
-                InstructionApplier applier{*transact};
-                {
-                    TempShortCircuitReplication tscr{m_replication};
-                    applier.apply(changesets[i], &logger); // Throws
-                }
-
-                // The need to produce a combined changeset is unfortunate from a
-                // memory pressure/allocation cost point of view. It is believed
-                // that the history (list of applied changesets) will be moved into
-                // the main Realm file eventually, and that would probably eliminate
-                // this problem.
-                std::size_t size_1 = assembled_transformed_changeset.size();
-                std::size_t size_2 = size_1;
-                if (util::int_add_with_overflow_detect(size_2, transformed_changeset.size()))
-                    throw util::overflow_error{"Changeset size overflow"};
-                assembled_transformed_changeset.resize(size_2); // Throws
-                std::copy(transformed_changeset.data(), transformed_changeset.data() + transformed_changeset.size(),
-                          assembled_transformed_changeset.data() + size_1);
+                applier.apply(changesets[i], &logger); // Throws
             }
         }
     }
@@ -503,15 +482,14 @@ void ClientHistory::integrate_server_changesets(const SyncProgress& progress,
     entry.origin_timestamp = last_changeset.origin_timestamp;
     entry.origin_file_ident = last_changeset.origin_file_ident;
     entry.remote_version = last_changeset.version;
-    entry.changeset = BinaryData(assembled_transformed_changeset.data(), assembled_transformed_changeset.size());
+    entry.changeset = BinaryData(transformed_changeset.data(), transformed_changeset.size());
 
     // m_changeset_from_server is picked up by prepare_changeset(), which then
     // calls add_sync_history_entry(). prepare_changeset() is called as a result
     // of committing the current transaction even in the "short-circuited" mode,
     // because replication isn't disabled.
-    m_changeset_from_server_owner = std::move(assembled_transformed_changeset);
     REALM_ASSERT(!m_changeset_from_server);
-    m_changeset_from_server = entry;
+    m_changeset_from_server = &entry;
 
     // During the bootstrap phase in flexible sync, the server sends multiple download messages with the same
     // synthetic server version that represents synthetic changesets generated from state on the server.
@@ -522,15 +500,15 @@ void ClientHistory::integrate_server_changesets(const SyncProgress& progress,
         run_in_write_tr(transact);
     }
 
-    version_type new_version = transact->commit_and_continue_as_read().version; // Throws
+    auto new_version = transact->commit_and_continue_as_read(); // Throws
+    REALM_ASSERT(!m_changeset_from_server);
 
     if (transact_reporter) {
-        VersionID new_version_2 = transact->get_version_of_current_transaction();
-        transact_reporter->report_sync_transact(old_version, new_version_2); // Throws
+        transact_reporter->report_sync_transact(old_version, new_version); // Throws
     }
 
-    version_info.realm_version = new_version;
-    version_info.sync_version = {new_version, 0};
+    version_info.realm_version = new_version.version;
+    version_info.sync_version = {new_version.version, 0};
 }
 
 
@@ -682,47 +660,46 @@ Replication::version_type ClientHistory::add_changeset(BinaryData ct_changeset, 
         ct_changeset = BinaryData("", 0);
     m_arrays->ct_history.add(ct_changeset); // Throws
 
-    HistoryEntry entry;
-
     REALM_ASSERT(!m_changeset_from_server || !m_client_reset_changeset);
 
     if (m_changeset_from_server) {
-        entry = *std::move(m_changeset_from_server);
-
         REALM_ASSERT(sync_changeset.size() == 0);
-    }
-    else {
-        BinaryData changeset;
-        if (m_client_reset_changeset) {
-            changeset = *m_client_reset_changeset;
-            m_client_reset_changeset = util::none;
-        }
-        else if (sync_changeset.size()) {
-            changeset = sync_changeset;
-        }
-
-        entry.origin_timestamp = m_local_origin_timestamp_source();
-        entry.origin_file_ident = 0; // Of local origin
-        entry.remote_version = m_progress_download.server_version;
-        entry.changeset = changeset;
-
-        // uploadable_bytes is updated at every local Realm change. The total
-        // number of uploadable bytes must be persisted in the Realm, since the
-        // synchronization history is trimmed. Even if the synchronization
-        // history wasn't trimmed, it would be expensive to traverse the entire
-        // history at every access to uploadable bytes.
-        Array& root = m_arrays->root;
-        std::uint_fast64_t uploadable_bytes = root.get_as_ref_or_tagged(s_progress_uploadable_bytes_iip).get_as_int();
-        uploadable_bytes += entry.changeset.size();
-        root.set(s_progress_uploadable_bytes_iip, RefOrTagged::make_tagged(uploadable_bytes));
+        add_sync_history_entry(*m_changeset_from_server); // Throws
+        m_changeset_from_server = nullptr;
+        return m_ct_history_base_version + ct_history_size();
     }
 
+    BinaryData changeset = sync_changeset;
+    if (m_client_reset_changeset) {
+        // When performing a client reset, `sync_changeset` is generated from
+        // the operations performed to bring the local Realm in sync with the
+        // server, so we don't want to send that to the server. Instead we
+        // send m_client_reset_changeset which is the recovered local writes
+        // (or null in discard local mode).
+        changeset = *std::exchange(m_client_reset_changeset, util::none);
+    }
+
+    HistoryEntry entry;
+    entry.origin_timestamp = m_local_origin_timestamp_source();
+    entry.origin_file_ident = 0; // Of local origin
+    entry.remote_version = m_progress_download.server_version;
+    entry.changeset = changeset;
     add_sync_history_entry(entry); // Throws
+
+    // uploadable_bytes is updated at every local Realm change. The total
+    // number of uploadable bytes must be persisted in the Realm, since the
+    // synchronization history is trimmed. Even if the synchronization
+    // history wasn't trimmed, it would be expensive to traverse the entire
+    // history at every access to uploadable bytes.
+    Array& root = m_arrays->root;
+    std::uint_fast64_t uploadable_bytes = root.get_as_ref_or_tagged(s_progress_uploadable_bytes_iip).get_as_int();
+    uploadable_bytes += entry.changeset.size();
+    root.set(s_progress_uploadable_bytes_iip, RefOrTagged::make_tagged(uploadable_bytes));
 
     return m_ct_history_base_version + ct_history_size();
 }
 
-void ClientHistory::add_sync_history_entry(HistoryEntry entry)
+void ClientHistory::add_sync_history_entry(const HistoryEntry& entry)
 {
     REALM_ASSERT(m_arrays->reciprocal_transforms.size() == sync_history_size());
     REALM_ASSERT(m_arrays->remote_versions.size() == sync_history_size());

--- a/src/realm/sync/noinst/client_history_impl.cpp
+++ b/src/realm/sync/noinst/client_history_impl.cpp
@@ -985,9 +985,9 @@ void ClientHistory::fix_up_client_file_ident_in_stored_changesets(Transaction& g
         return false;
     };
 
+    Group::TableNameBuffer buffer;
     auto get_table_for_class = [&](StringData class_name) -> ConstTableRef {
         REALM_ASSERT(class_name.size() < Group::max_table_name_length - 6);
-        Group::TableNameBuffer buffer;
         return group.get_table(Group::class_name_to_table_name(class_name, buffer));
     };
 
@@ -1003,8 +1003,6 @@ void ClientHistory::fix_up_client_file_ident_in_stored_changesets(Transaction& g
         if (m_arrays->origin_file_idents.get(i) != 0)
             continue;
 
-        // FIXME: We have to do this when transmitting/receiving changesets
-        // over the network instead.
         ChunkedBinaryData changeset{m_arrays->changesets, i};
         ChunkedBinaryInputStream is{changeset};
         size_t decompressed_size;

--- a/src/realm/sync/noinst/client_history_impl.hpp
+++ b/src/realm/sync/noinst/client_history_impl.hpp
@@ -254,7 +254,7 @@ public:
     void integrate_server_changesets(const SyncProgress& progress, const std::uint_fast64_t* downloadable_bytes,
                                      const RemoteChangeset* changesets, std::size_t num_changesets,
                                      VersionInfo& new_version, DownloadBatchState download_type, util::Logger&,
-                                     util::UniqueFunction<void(const TransactionRef&)> run_in_write_tr,
+                                     util::UniqueFunction<void(const TransactionRef&)> run_in_write_tr = nullptr,
                                      SyncTransactReporter* transact_reporter = nullptr);
 
     static void get_upload_download_bytes(DB*, std::uint_fast64_t&, std::uint_fast64_t&, std::uint_fast64_t&,
@@ -381,8 +381,7 @@ private:
     // ServerHistory object.
     mutable util::Optional<Arrays> m_arrays;
 
-    mutable std::vector<char> m_changeset_from_server_owner;
-    mutable util::Optional<HistoryEntry> m_changeset_from_server;
+    mutable const HistoryEntry* m_changeset_from_server = nullptr;
 
     util::Optional<BinaryData> m_client_reset_changeset;
 
@@ -412,7 +411,7 @@ private:
 
     void prepare_for_write();
     Replication::version_type add_changeset(BinaryData changeset, BinaryData sync_changeset);
-    void add_sync_history_entry(HistoryEntry);
+    void add_sync_history_entry(const HistoryEntry&);
     void update_sync_progress(const SyncProgress&, const std::uint_fast64_t* downloadable_bytes, TransactionRef);
     void trim_ct_history();
     void trim_sync_history();
@@ -480,7 +479,6 @@ public:
 
     // Overriding member functions in realm::Replication
     version_type prepare_changeset(const char*, size_t, version_type) override;
-    void finalize_changeset() noexcept override;
 
     ClientHistory& get_history() noexcept
     {

--- a/src/realm/sync/noinst/client_history_impl.hpp
+++ b/src/realm/sync/noinst/client_history_impl.hpp
@@ -379,7 +379,15 @@ private:
     // ServerHistory object.
     mutable util::Optional<Arrays> m_arrays;
 
-    mutable const HistoryEntry* m_changeset_from_server = nullptr;
+    // When applying server changesets, we create a history entry with the data
+    // from the server instead of using the one generated from applying the
+    // instructions to the local data. integrate_server_changesets() sets this
+    // to true to indicate to add_changeset() that it should skip creating a
+    // history entry.
+    //
+    // This field is guarded by the DB's write lock and should only be accessed
+    // while that is held.
+    mutable bool m_applying_server_changeset = false;
 
     util::Optional<BinaryData> m_client_reset_changeset;
 

--- a/src/realm/sync/noinst/client_history_impl.hpp
+++ b/src/realm/sync/noinst/client_history_impl.hpp
@@ -246,14 +246,12 @@ public:
     /// about byte-level progress, this function updates the persistent record
     /// of the estimate of the number of remaining bytes to be downloaded.
     ///
-    /// \param num_changesets The number of passed changesets. Must be non-zero.
-    ///
     /// \param transact_reporter An optional callback which will be called with the
     /// version immediately processing the sync transaction and that of the sync
     /// transaction.
     void integrate_server_changesets(const SyncProgress& progress, const std::uint_fast64_t* downloadable_bytes,
-                                     const RemoteChangeset* changesets, std::size_t num_changesets,
-                                     VersionInfo& new_version, DownloadBatchState download_type, util::Logger&,
+                                     util::Span<const RemoteChangeset> changesets, VersionInfo& new_version,
+                                     DownloadBatchState download_type, util::Logger&,
                                      util::UniqueFunction<void(const TransactionRef&)> run_in_write_tr = nullptr,
                                      SyncTransactReporter* transact_reporter = nullptr);
 

--- a/src/realm/sync/noinst/client_impl_base.cpp
+++ b/src/realm/sync/noinst/client_impl_base.cpp
@@ -115,6 +115,7 @@ ClientImpl::ClientImpl(ClientConfig config)
     , m_dry_run{config.dry_run}
     , m_enable_default_port_hack{config.enable_default_port_hack}
     , m_disable_upload_compaction{config.disable_upload_compaction}
+    , m_fix_up_object_ids{config.fix_up_object_ids}
     , m_roundtrip_time_handler{std::move(config.roundtrip_time_handler)}
     , m_user_agent_string{make_user_agent_string(config)} // Throws
     , m_service{}                                         // Throws
@@ -2000,8 +2001,7 @@ std::error_code Session::receive_ident_message(SaltedFileIdent client_file_ident
         return make_error_code(sync::ClientError::auto_client_reset_failure);
     }
     if (!did_client_reset) {
-        constexpr bool fix_up_object_ids = true;
-        repl.get_history().set_client_file_ident(client_file_ident, fix_up_object_ids); // Throws
+        repl.get_history().set_client_file_ident(client_file_ident, m_fix_up_object_ids); // Throws
         this->m_progress.download.last_integrated_client_version = 0;
         this->m_progress.upload.client_version = 0;
         this->m_last_version_selected_for_upload = 0;

--- a/src/realm/sync/noinst/client_impl_base.cpp
+++ b/src/realm/sync/noinst/client_impl_base.cpp
@@ -1394,17 +1394,15 @@ void Session::integrate_changesets(ClientReplication& repl, const SyncProgress& 
         history.set_sync_progress(progress, &downloadable_bytes, version_info); // Throws
         return;
     }
-    const Transformer::RemoteChangeset* changesets = received_changesets.data();
-    std::size_t num_changesets = received_changesets.size();
-    history.integrate_server_changesets(progress, &downloadable_bytes, changesets, num_changesets, version_info,
+    history.integrate_server_changesets(progress, &downloadable_bytes, received_changesets, version_info,
                                         download_batch_state, logger, {}, get_transact_reporter()); // Throws
-    if (num_changesets == 1) {
+    if (received_changesets.size() == 1) {
         logger.debug("1 remote changeset integrated, producing client version %1",
                      version_info.sync_version.version); // Throws
     }
     else {
         logger.debug("%2 remote changesets integrated, producing client version %1",
-                     version_info.sync_version.version, num_changesets); // Throws
+                     version_info.sync_version.version, received_changesets.size()); // Throws
     }
 }
 

--- a/src/realm/sync/noinst/client_impl_base.hpp
+++ b/src/realm/sync/noinst/client_impl_base.hpp
@@ -153,6 +153,7 @@ private:
     const bool m_dry_run; // For testing purposes only
     const bool m_enable_default_port_hack;
     const bool m_disable_upload_compaction;
+    const bool m_fix_up_object_ids;
     const std::function<RoundtripTimeHandler> m_roundtrip_time_handler;
     const std::string m_user_agent_string;
     util::network::Service m_service;
@@ -904,6 +905,8 @@ private:
 
     bool m_is_flx_sync_session = false;
 
+    bool m_fix_up_object_ids = false;
+
     // These are reset when the session is activated, and again whenever the
     // connection is lost or the rebinding process is initiated.
     bool m_enlisted_to_send;
@@ -1302,6 +1305,7 @@ inline ClientImpl::Session::Session(SessionWrapper& wrapper, Connection& conn, s
     , m_conn{conn}
     , m_ident{ident}
     , m_is_flx_sync_session(conn.is_flx_sync_connection())
+    , m_fix_up_object_ids(get_client().m_fix_up_object_ids)
     , m_wrapper{wrapper}
 {
     if (get_client().m_disable_upload_activation_delay)

--- a/src/realm/sync/noinst/client_impl_base.hpp
+++ b/src/realm/sync/noinst/client_impl_base.hpp
@@ -448,9 +448,9 @@ private:
     void initiate_disconnect_wait();
     void handle_disconnect_wait(std::error_code);
     void read_or_write_error(std::error_code);
-    void close_due_to_protocol_error(std::error_code);
+    void close_due_to_protocol_error(std::error_code, std::optional<std::string_view> msg = std::nullopt);
     void close_due_to_missing_protocol_feature();
-    void close_due_to_client_side_error(std::error_code, bool is_fatal);
+    void close_due_to_client_side_error(std::error_code, std::optional<std::string_view> msg, bool is_fatal);
     void close_due_to_server_side_error(ProtocolError, const ProtocolErrorInfo& info);
     void voluntary_disconnect();
     void involuntary_disconnect(const SessionErrorInfo& info);

--- a/src/realm/sync/noinst/protocol_codec.hpp
+++ b/src/realm/sync/noinst/protocol_codec.hpp
@@ -30,7 +30,6 @@ struct ProtocolCodecException : public std::runtime_error {
 };
 class HeaderLineParser {
 public:
-    HeaderLineParser() = default;
     explicit HeaderLineParser(std::string_view line)
         : m_sv(line)
     {

--- a/src/realm/sync/noinst/server/server_history.cpp
+++ b/src/realm/sync/noinst/server/server_history.cpp
@@ -1197,8 +1197,7 @@ bool ServerHistory::integrate_remote_changesets(file_ident_type remote_file_iden
             TransformHistoryImpl transform_hist{remote_file_ident, *this, recip_hist};
             Transformer& transformer = m_context.get_transformer(); // Throws
             transformer.transform_remote_changesets(transform_hist, m_local_file_ident, current_server_version,
-                                                    parsed_transformed_changesets.data(), num_changesets,
-                                                    &logger); // Throws
+                                                    parsed_transformed_changesets, &logger); // Throws
         }
 
         // Apply the transformed changesets to the Realm state

--- a/src/realm/sync/transform.cpp
+++ b/src/realm/sync/transform.cpp
@@ -2522,8 +2522,8 @@ void TransformerImpl::merge_changesets(file_ident_type local_file_ident, Changes
 }
 
 void TransformerImpl::transform_remote_changesets(TransformHistory& history, file_ident_type local_file_ident,
-                                                  version_type current_local_version, Changeset* parsed_changesets,
-                                                  std::size_t num_changesets, util::Logger* logger)
+                                                  version_type current_local_version,
+                                                  util::Span<Changeset> parsed_changesets, util::Logger* logger)
 {
     REALM_ASSERT(local_file_ident != 0);
 
@@ -2532,8 +2532,8 @@ void TransformerImpl::transform_remote_changesets(TransformHistory& history, fil
     try {
         // p points to the beginning of a range of changesets that share the same
         // "base", i.e. are based on the same local version.
-        auto p = parsed_changesets;
-        auto parsed_changesets_end = parsed_changesets + num_changesets;
+        auto p = parsed_changesets.begin();
+        auto parsed_changesets_end = parsed_changesets.end();
         while (p != parsed_changesets_end) {
             // Find the range of incoming changesets that share the same
             // last_integrated_local_version, which means we can merge them in one go.

--- a/src/realm/sync/transform.cpp
+++ b/src/realm/sync/transform.cpp
@@ -1391,9 +1391,7 @@ DEFINE_MERGE(Instruction::AddTable, Instruction::AddTable)
                 if (left_pk_name != right_pk_name) {
                     std::stringstream ss;
                     ss << "Schema mismatch: '" << left_name << "' has primary key '" << left_pk_name
-                       << "' on one side,"
-                          "but primary key '"
-                       << right_pk_name << "' on the other.";
+                       << "' on one side, but primary key '" << right_pk_name << "' on the other.";
                     throw SchemaMismatchError(ss.str());
                 }
 
@@ -1408,7 +1406,7 @@ DEFINE_MERGE(Instruction::AddTable, Instruction::AddTable)
                 if (left_spec->pk_nullable != right_spec->pk_nullable) {
                     std::stringstream ss;
                     ss << "Schema mismatch: '" << left_name << "' has primary key '" << left_pk_name
-                       << "', which is nullable on one side, but not the other";
+                       << "', which is nullable on one side, but not the other.";
                     throw SchemaMismatchError(ss.str());
                 }
 
@@ -1427,7 +1425,7 @@ DEFINE_MERGE(Instruction::AddTable, Instruction::AddTable)
         else if (mpark::get_if<Instruction::AddTable::EmbeddedTable>(&left.type)) {
             if (!mpark::get_if<Instruction::AddTable::EmbeddedTable>(&right.type)) {
                 std::stringstream ss;
-                ss << "Schema mismatch: '" << left_name << "' is an embedded table on one side, but not the other";
+                ss << "Schema mismatch: '" << left_name << "' is an embedded table on one side, but not the other.";
                 throw SchemaMismatchError(ss.str());
             }
         }

--- a/src/realm/sync/transform.hpp
+++ b/src/realm/sync/transform.hpp
@@ -170,8 +170,8 @@ public:
     /// FIXME: Consider using std::error_code instead of throwing
     /// TransformError.
     virtual void transform_remote_changesets(TransformHistory&, file_ident_type local_file_ident,
-                                             version_type current_local_version, Changeset* changesets,
-                                             std::size_t num_changesets, util::Logger* = nullptr) = 0;
+                                             version_type current_local_version, util::Span<Changeset> changesets,
+                                             util::Logger* = nullptr) = 0;
 
     virtual ~Transformer() noexcept {}
 };
@@ -194,7 +194,7 @@ public:
 
     TransformerImpl();
 
-    void transform_remote_changesets(TransformHistory&, file_ident_type, version_type, Changeset*, std::size_t,
+    void transform_remote_changesets(TransformHistory&, file_ident_type, version_type, util::Span<Changeset>,
                                      util::Logger*) override;
 
     struct Side;

--- a/src/realm/sync/transform.hpp
+++ b/src/realm/sync/transform.hpp
@@ -209,7 +209,7 @@ protected:
                                   Changeset** our_changesets, std::size_t our_size, util::Logger* logger);
 
 private:
-    std::map<version_type, std::unique_ptr<Changeset>> m_reciprocal_transform_cache;
+    std::map<version_type, Changeset> m_reciprocal_transform_cache;
 
     TransactLogParser m_changeset_parser;
 

--- a/test/peer.hpp
+++ b/test/peer.hpp
@@ -486,8 +486,7 @@ inline auto ShortCircuitHistory::integrate_remote_changesets(file_ident_type rem
     }
 
     TransformHistoryImpl transform_hist{*this, remote_file_ident};
-    m_transformer->transform_remote_changesets(transform_hist, m_local_file_ident, local_version, changesets.data(),
-                                               changesets.size(), logger);
+    m_transformer->transform_remote_changesets(transform_hist, m_local_file_ident, local_version, changesets, logger);
 
     sync::ChangesetEncoder::Buffer assembled_transformed_changeset;
 

--- a/test/sync_fixtures.hpp
+++ b/test/sync_fixtures.hpp
@@ -541,6 +541,7 @@ public:
             config_2.disable_upload_compaction = config.disable_upload_compaction;
             config_2.one_connection_per_session = config.one_connection_per_session;
             config_2.disable_upload_activation_delay = config.disable_upload_activation_delay;
+            config_2.fix_up_object_ids = true;
             m_clients[i] = std::make_unique<Client>(std::move(config_2));
         }
 

--- a/test/test_sync.cpp
+++ b/test/test_sync.cpp
@@ -775,312 +775,161 @@ TEST(Sync_Merge)
     CHECK_EQUAL(4, table->size());
 }
 
+struct ExpectChangesetError {
+    unit_test::TestContext& test_context;
+    MultiClientServerFixture& fixture;
+    std::string expected_error;
 
-TEST(Sync_DetectSchemaMismatch_ColumnType)
+    void operator()(ConnectionState state, util::Optional<Session::ErrorInfo> error_info) const noexcept
+    {
+        if (state != ConnectionState::disconnected)
+            return;
+        REALM_ASSERT(error_info);
+        std::error_code ec = error_info->error_code;
+        CHECK_EQUAL(ec, sync::Client::Error::bad_changeset);
+        CHECK(ec.category() == client_error_category());
+        CHECK(error_info->is_fatal());
+        CHECK_EQUAL(error_info->message,
+                    "Bad changeset (DOWNLOAD): Failed to transform received changeset: Schema mismatch: " +
+                        expected_error);
+        fixture.stop();
+    }
+};
+
+void test_schema_mismatch(unit_test::TestContext& test_context, util::FunctionRef<void(WriteTransaction&)> fn_1,
+                          util::FunctionRef<void(WriteTransaction&)> fn_2, const char* expected_error_1,
+                          const char* expected_error_2 = nullptr)
 {
     TEST_CLIENT_DB(db_1);
     TEST_CLIENT_DB(db_2);
 
-    {
-        TEST_DIR(dir);
-        MultiClientServerFixture fixture(2, 1, dir, test_context);
-        fixture.allow_server_errors(0, 1);
-        fixture.start();
+    TEST_DIR(dir);
+    MultiClientServerFixture fixture(2, 1, dir, test_context);
+    fixture.allow_server_errors(0, 1);
+    fixture.start();
 
-        using ErrorInfo = Session::ErrorInfo;
-        auto listener = [&](ConnectionState state, util::Optional<ErrorInfo> error_info) {
-            if (state != ConnectionState::disconnected)
-                return;
-            REALM_ASSERT(error_info);
-            std::error_code ec = error_info->error_code;
-            bool is_fatal = error_info->is_fatal();
-            CHECK(ec == sync::Client::Error::bad_changeset || ec == sync::ProtocolError::invalid_schema_change);
-            CHECK(is_fatal);
-            // FIXME: Check that the message in the log is user-friendly.
-            fixture.stop();
-        };
+    Session session_1 = fixture.make_session(0, db_1);
+    Session session_2 = fixture.make_session(1, db_2);
 
-        Session session_1 = fixture.make_session(0, db_1);
-        Session session_2 = fixture.make_session(1, db_2);
+    if (!expected_error_2)
+        expected_error_2 = expected_error_1;
 
-        session_1.set_connection_state_change_listener(listener);
-        session_2.set_connection_state_change_listener(listener);
+    session_1.set_connection_state_change_listener(ExpectChangesetError{test_context, fixture, expected_error_1});
+    session_2.set_connection_state_change_listener(ExpectChangesetError{test_context, fixture, expected_error_2});
 
-        fixture.bind_session(session_1, 0, "/test");
-        fixture.bind_session(session_2, 0, "/test");
+    fixture.bind_session(session_1, 0, "/test");
+    fixture.bind_session(session_2, 0, "/test");
 
-        write_transaction_notifying_session(db_1, session_1, [](WriteTransaction& wt) {
+    write_transaction_notifying_session(db_1, session_1, fn_1);
+    write_transaction_notifying_session(db_2, session_2, fn_2);
+
+    session_1.wait_for_upload_complete_or_client_stopped();
+    session_2.wait_for_upload_complete_or_client_stopped();
+    session_1.wait_for_download_complete_or_client_stopped();
+    session_2.wait_for_download_complete_or_client_stopped();
+}
+
+
+TEST(Sync_DetectSchemaMismatch_ColumnType)
+{
+    test_schema_mismatch(
+        test_context,
+        [](WriteTransaction& wt) {
             TableRef table = wt.add_table("class_foo");
             ColKey col_ndx = table->add_column(type_Int, "column");
             table->create_object().set<int64_t>(col_ndx, 123);
-        });
-
-        write_transaction_notifying_session(db_2, session_2, [](WriteTransaction& wt) {
+        },
+        [](WriteTransaction& wt) {
             TableRef table = wt.add_table("class_foo");
             ColKey col_ndx = table->add_column(type_String, "column");
             table->create_object().set(col_ndx, "Hello, World!");
-        });
-        session_1.wait_for_upload_complete_or_client_stopped();
-        session_2.wait_for_upload_complete_or_client_stopped();
-        session_1.wait_for_download_complete_or_client_stopped();
-        session_2.wait_for_download_complete_or_client_stopped();
-    }
+        },
+        "Property 'column' in class 'foo' is of type Int on one side and type String on the other.",
+        "Property 'column' in class 'foo' is of type String on one side and type Int on the other.");
 }
 
 
 TEST(Sync_DetectSchemaMismatch_Nullability)
 {
-    TEST_CLIENT_DB(db_1);
-    TEST_CLIENT_DB(db_2);
-
-    {
-        TEST_DIR(dir);
-        MultiClientServerFixture fixture(2, 1, dir, test_context);
-        fixture.allow_server_errors(0, 1);
-        fixture.start();
-
-        using ErrorInfo = Session::ErrorInfo;
-        auto listener = [&](ConnectionState state, util::Optional<ErrorInfo> error_info) {
-            if (state != ConnectionState::disconnected)
-                return;
-            REALM_ASSERT(error_info);
-            std::error_code ec = error_info->error_code;
-            bool is_fatal = error_info->is_fatal();
-            CHECK(ec == sync::Client::Error::bad_changeset || ec == sync::ProtocolError::invalid_schema_change);
-            CHECK(is_fatal);
-            // FIXME: Check that the message in the log is user-friendly.
-            fixture.stop();
-        };
-
-        Session session_1 = fixture.make_session(0, db_1);
-        Session session_2 = fixture.make_session(1, db_2);
-
-        session_1.set_connection_state_change_listener(listener);
-        session_2.set_connection_state_change_listener(listener);
-
-        fixture.bind_session(session_1, 0, "/test");
-        fixture.bind_session(session_2, 0, "/test");
-
-        write_transaction_notifying_session(db_1, session_1, [](WriteTransaction& wt) {
+    test_schema_mismatch(
+        test_context,
+        [](WriteTransaction& wt) {
             TableRef table = wt.add_table("class_foo");
             bool nullable = false;
             ColKey col_ndx = table->add_column(type_Int, "column", nullable);
             table->create_object().set<int64_t>(col_ndx, 123);
-        });
-
-        write_transaction_notifying_session(db_2, session_2, [](WriteTransaction& wt) {
+        },
+        [](WriteTransaction& wt) {
             TableRef table = wt.add_table("class_foo");
             bool nullable = true;
             ColKey col_ndx = table->add_column(type_Int, "column", nullable);
             table->create_object().set<int64_t>(col_ndx, 123);
-        });
-        session_1.wait_for_upload_complete_or_client_stopped();
-        session_2.wait_for_upload_complete_or_client_stopped();
-        session_1.wait_for_download_complete_or_client_stopped();
-        session_2.wait_for_download_complete_or_client_stopped();
-    }
+        },
+        "Property 'column' in class 'foo' is nullable on one side and not on the other.");
 }
 
 
 TEST(Sync_DetectSchemaMismatch_Links)
 {
-    TEST_CLIENT_DB(db_1);
-    TEST_CLIENT_DB(db_2);
-
-    {
-        TEST_DIR(dir);
-        MultiClientServerFixture fixture(2, 1, dir, test_context);
-        fixture.allow_server_errors(0, 1);
-        fixture.start();
-
-        using ErrorInfo = Session::ErrorInfo;
-        auto listener = [&](ConnectionState state, util::Optional<ErrorInfo> error_info) {
-            if (state != ConnectionState::disconnected)
-                return;
-            REALM_ASSERT(error_info);
-            std::error_code ec = error_info->error_code;
-            bool is_fatal = error_info->is_fatal();
-            CHECK(ec == sync::Client::Error::bad_changeset || ec == sync::ProtocolError::invalid_schema_change);
-            CHECK(is_fatal);
-            // FIXME: Check that the message in the log is user-friendly.
-            fixture.stop();
-        };
-
-        Session session_1 = fixture.make_session(0, db_1);
-        Session session_2 = fixture.make_session(1, db_2);
-
-        session_1.set_connection_state_change_listener(listener);
-        session_2.set_connection_state_change_listener(listener);
-
-        fixture.bind_session(session_1, 0, "/test");
-        fixture.bind_session(session_2, 0, "/test");
-
-        write_transaction_notifying_session(db_1, session_1, [](WriteTransaction& wt) {
+    test_schema_mismatch(
+        test_context,
+        [](WriteTransaction& wt) {
             TableRef table = wt.add_table("class_foo");
             TableRef target = wt.add_table("class_bar");
             table->add_column(*target, "column");
-        });
-
-        write_transaction_notifying_session(db_2, session_2, [](WriteTransaction& wt) {
+        },
+        [](WriteTransaction& wt) {
             TableRef table = wt.add_table("class_foo");
             TableRef target = wt.add_table("class_baz");
             table->add_column(*target, "column");
-        });
-        session_1.wait_for_upload_complete_or_client_stopped();
-        session_2.wait_for_upload_complete_or_client_stopped();
-        session_1.wait_for_download_complete_or_client_stopped();
-        session_2.wait_for_download_complete_or_client_stopped();
-    }
+        },
+        "Link property 'column' in class 'foo' points to class 'bar' on one side and to 'baz' on the other.",
+        "Link property 'column' in class 'foo' points to class 'baz' on one side and to 'bar' on the other.");
 }
 
 
 TEST(Sync_DetectSchemaMismatch_PrimaryKeys_Name)
 {
-    TEST_CLIENT_DB(db_1);
-    TEST_CLIENT_DB(db_2);
-
-    {
-        TEST_DIR(dir);
-        MultiClientServerFixture fixture(2, 1, dir, test_context);
-        fixture.allow_server_errors(0, 1);
-        fixture.start();
-
-        using ErrorInfo = Session::ErrorInfo;
-        auto listener = [&](ConnectionState state, util::Optional<ErrorInfo> error_info) {
-            if (state != ConnectionState::disconnected)
-                return;
-            REALM_ASSERT(error_info);
-            std::error_code ec = error_info->error_code;
-            bool is_fatal = error_info->is_fatal();
-            CHECK(ec == sync::Client::Error::bad_changeset || ec == sync::ProtocolError::invalid_schema_change);
-            CHECK(is_fatal);
-            // FIXME: Check that the message in the log is user-friendly.
-            fixture.stop();
-        };
-
-        Session session_1 = fixture.make_session(0, db_1);
-        Session session_2 = fixture.make_session(1, db_2);
-
-        session_1.set_connection_state_change_listener(listener);
-        session_2.set_connection_state_change_listener(listener);
-
-        fixture.bind_session(session_1, 0, "/test");
-        fixture.bind_session(session_2, 0, "/test");
-
-        write_transaction_notifying_session(db_1, session_1, [](WriteTransaction& wt) {
+    test_schema_mismatch(
+        test_context,
+        [](WriteTransaction& wt) {
             wt.get_group().add_table_with_primary_key("class_foo", type_Int, "a");
-        });
-
-        write_transaction_notifying_session(db_2, session_2, [](WriteTransaction& wt) {
+        },
+        [](WriteTransaction& wt) {
             wt.get_group().add_table_with_primary_key("class_foo", type_Int, "b");
-        });
-        session_1.wait_for_upload_complete_or_client_stopped();
-        session_2.wait_for_upload_complete_or_client_stopped();
-        session_1.wait_for_download_complete_or_client_stopped();
-        session_2.wait_for_download_complete_or_client_stopped();
-    }
+        },
+        "'foo' has primary key 'a' on one side, but primary key 'b' on the other.",
+        "'foo' has primary key 'b' on one side, but primary key 'a' on the other.");
 }
 
 
 TEST(Sync_DetectSchemaMismatch_PrimaryKeys_Type)
 {
-    TEST_CLIENT_DB(db_1);
-    TEST_CLIENT_DB(db_2);
-
-    {
-        TEST_DIR(dir);
-        MultiClientServerFixture fixture(2, 1, dir, test_context);
-        fixture.allow_server_errors(0, 1);
-        fixture.start();
-
-        using ErrorInfo = Session::ErrorInfo;
-        auto listener = [&](ConnectionState state, util::Optional<ErrorInfo> error_info) {
-            if (state != ConnectionState::disconnected)
-                return;
-            REALM_ASSERT(error_info);
-            std::error_code ec = error_info->error_code;
-            bool is_fatal = error_info->is_fatal();
-            CHECK(ec == sync::Client::Error::bad_changeset || ec == sync::ProtocolError::invalid_schema_change);
-            CHECK(is_fatal);
-            // FIXME: Check that the message in the log is user-friendly.
-            fixture.stop();
-        };
-
-        Session session_1 = fixture.make_session(0, db_1);
-        Session session_2 = fixture.make_session(1, db_2);
-
-        session_1.set_connection_state_change_listener(listener);
-        session_2.set_connection_state_change_listener(listener);
-
-        fixture.bind_session(session_1, 0, "/test");
-        fixture.bind_session(session_2, 0, "/test");
-
-        write_transaction_notifying_session(db_1, session_1, [](WriteTransaction& wt) {
+    test_schema_mismatch(
+        test_context,
+        [](WriteTransaction& wt) {
             wt.get_group().add_table_with_primary_key("class_foo", type_Int, "a");
-        });
-
-        write_transaction_notifying_session(db_2, session_2, [](WriteTransaction& wt) {
+        },
+        [](WriteTransaction& wt) {
             wt.get_group().add_table_with_primary_key("class_foo", type_String, "a");
-        });
-        session_1.wait_for_upload_complete_or_client_stopped();
-        session_2.wait_for_upload_complete_or_client_stopped();
-        session_1.wait_for_download_complete_or_client_stopped();
-        session_2.wait_for_download_complete_or_client_stopped();
-    }
+        },
+        "'foo' has primary key 'a', which is of type String on one side and type Int on the other.");
 }
 
 
 TEST(Sync_DetectSchemaMismatch_PrimaryKeys_Nullability)
 {
-    TEST_CLIENT_DB(db_1);
-    TEST_CLIENT_DB(db_2);
-
-    {
-        TEST_DIR(dir);
-        MultiClientServerFixture fixture(2, 1, dir, test_context);
-        fixture.allow_server_errors(0, 1);
-        fixture.start();
-
-        bool error_did_occur = false;
-
-        using ErrorInfo = Session::ErrorInfo;
-        auto listener = [&](ConnectionState state, util::Optional<ErrorInfo> error_info) {
-            if (state != ConnectionState::disconnected)
-                return;
-            REALM_ASSERT(error_info);
-            std::error_code ec = error_info->error_code;
-            bool is_fatal = error_info->is_fatal();
-            CHECK(ec == sync::Client::Error::bad_changeset || ec == sync::ProtocolError::invalid_schema_change);
-            CHECK(is_fatal);
-            // FIXME: Check that the message in the log is user-friendly.
-            error_did_occur = true;
-            fixture.stop();
-        };
-
-        Session session_1 = fixture.make_session(0, db_1);
-        Session session_2 = fixture.make_session(1, db_2);
-
-        session_1.set_connection_state_change_listener(listener);
-        session_2.set_connection_state_change_listener(listener);
-
-        fixture.bind_session(session_1, 0, "/test");
-        fixture.bind_session(session_2, 0, "/test");
-
-        write_transaction_notifying_session(db_1, session_1, [](WriteTransaction& wt) {
+    test_schema_mismatch(
+        test_context,
+        [](WriteTransaction& wt) {
             bool nullable = false;
             wt.get_group().add_table_with_primary_key("class_foo", type_Int, "a", nullable);
-        });
-
-        write_transaction_notifying_session(db_2, session_2, [](WriteTransaction& wt) {
+        },
+        [](WriteTransaction& wt) {
             bool nullable = true;
             wt.get_group().add_table_with_primary_key("class_foo", type_Int, "a", nullable);
-        });
-        session_1.wait_for_upload_complete_or_client_stopped();
-        session_2.wait_for_upload_complete_or_client_stopped();
-        session_1.wait_for_download_complete_or_client_stopped();
-        session_2.wait_for_download_complete_or_client_stopped();
-        CHECK(error_did_occur);
-    }
+        },
+        "'foo' has primary key 'a', which is nullable on one side, but not the other.");
 }
 
 

--- a/test/test_sync.cpp
+++ b/test/test_sync.cpp
@@ -6753,7 +6753,7 @@ TEST(Sync_NonIncreasingServerVersions)
     util::StderrLogger logger;
     history.integrate_server_changesets(progress, &downloadable_bytes, server_changesets_encoded.data(),
                                         server_changesets_encoded.size(), version_info,
-                                        DownloadBatchState::LastInBatch, logger, {});
+                                        DownloadBatchState::LastInBatch, logger);
 }
 
 } // unnamed namespace

--- a/test/util/unit_test.cpp
+++ b/test/util/unit_test.cpp
@@ -892,12 +892,12 @@ void TestContext::throw_ex_failed(const char* file, long line, const char* expr_
 }
 
 
-void TestContext::throw_ex_cond_failed(const char* file, long line, const char* expr_text, const char* exception_name,
-                                       const char* exception_cond_text)
+void TestContext::throw_ex_cond_failed(const char* file, long line, const char* exception_what, const char* expr_text,
+                                       const char* exception_name, const char* exception_cond_text)
 {
     std::ostringstream out;
     out << "CHECK_THROW_EX(" << expr_text << ", " << exception_name << ", " << exception_cond_text
-        << ") failed: Did throw, but condition failed";
+        << ") failed: Did throw \"" << exception_what << "\", but condition failed";
     check_failed(file, line, out.str());
 }
 

--- a/test/util/unit_test.hpp
+++ b/test/util/unit_test.hpp
@@ -119,7 +119,8 @@
                 test_context.check_succeeded();                                                                      \
                 return true;                                                                                         \
             }                                                                                                        \
-            test_context.throw_ex_cond_failed(__FILE__, __LINE__, #expr, #exception_class, #exception_cond);         \
+            test_context.throw_ex_cond_failed(__FILE__, __LINE__, e.what(), #expr, #exception_class,                 \
+                                              #exception_cond);                                                      \
         }                                                                                                            \
         return false;                                                                                                \
     }())
@@ -521,8 +522,8 @@ public:
     void throw_failed(const char* file, long line, const char* expr_text, const char* exception_name);
     void throw_ex_failed(const char* file, long line, const char* expr_text, const char* exception_name,
                          const char* exception_cond_text);
-    void throw_ex_cond_failed(const char* file, long line, const char* expr_text, const char* exception_name,
-                              const char* exception_cond_text);
+    void throw_ex_cond_failed(const char* file, long line, const char* exception_what, const char* expr_text,
+                              const char* exception_name, const char* exception_cond_text);
     void throw_any_failed(const char* file, long line, const char* expr_text);
 
     std::string get_test_name() const;


### PR DESCRIPTION
While looking into how to resolve the QoS inversions caused by the sync client, I refreshed my memory on what exactly the sync client even needs to be writing and noticed a few easy spots to make it better behaved.

The sync protocol supports tables without primary keys by effectively synthesizing primary keys using the combination of the local key and the client file ident. We don't know what the client file ident is until we connect to the server for the first time, so this requires rewriting the stored transaction logs to add the client ident. BaaS doesn't support this at all, so we want to skip the rewriting in normal usage and only enable it for compatibility with all of the existing sync tests. Long-term we should probably migrate the sync tests to using primary keys and drop this entirely.

This makes the "open and upload" step of the audit tests which write a bunch of data while offline and then upload the data 10-20% faster.

The sync client parsed changesets from the server while holding the write lock, and there didn't appear to be any reason why it needed to be doing this. A lot of the merging probably also doesn't need to be holding the write lock, but that's a more complicated refactoring.

The changeset parser did quite a bit of work to support InternString indexes being an opaque identifier rather than a monotonically increasing dense value (and wasn't quite successful at doing so). In practice neither the client nor server ever produces InternString instructions that need this, so we can simplify and speed up the handling of InternString instructions by requiring that they be sensible. This speeds up the Transform_Randomized test (which hits the changeset parser but spends most of its time in transform) by ~10%.

Changeset::share_buffers_tag was just long-dead code. It was used for changeset partitioning in the pre-2.0 merge algorithm that didn't use stable IDs, and has been unused ever since.
