### PR TITLE
Delete deleted implicit conversion from int to StringData

### DIFF
--- a/src/realm/string_data.hpp
+++ b/src/realm/string_data.hpp
@@ -86,8 +86,6 @@ public:
     /// Construct a null reference.
     StringData() noexcept;
 
-    StringData(int) = delete;
-
     /// If \a external_data is 'null', \a data_size must be zero.
     StringData(const char* external_data, size_t data_size) noexcept;
 


### PR DESCRIPTION
This made `object_store::Dictionary::get_any(size_t)` ambiguous with the `StringData` overload.

## What, How & Why?
<!-- Describe the changes and give some hints to guide your reviewers if possible. -->
<!-- Link to relevant issue this fixes -->

## ☑️ ToDos
* ~[ ] 📝 Changelog update~
* ~[ ] 🚦 Tests (or not relevant)~
* ~[ ] C-API, if public C++ API changed.~
