### PR TITLE
Add NotificationToken::unregister()

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 * <New feature description> (PR [#????](https://github.com/realm/realm-core/pull/????))
 * Notify when read transaction version is advanced. ([PR #5704](https://github.com/realm/realm-core/pull/5704)).
 * Action returned from the server in the json error messages is surfaced through the SyncError. ([PR #5690](https://github.com/realm/realm-core/pull/5690)).
-
+* `NotificationToken` grew an `unregister()` method as an alternative to destroying it or doing `token = {};` ([PR #????](https://github.com/realm/realm-core/pull/????)).
 
 ### Fixed
 * <How do the end-user experience this issue? what was the impact?> ([#????](https://github.com/realm/realm-core/issues/????), since v?.?.?)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 * <New feature description> (PR [#????](https://github.com/realm/realm-core/pull/????))
 * Notify when read transaction version is advanced. ([PR #5704](https://github.com/realm/realm-core/pull/5704)).
 * Action returned from the server in the json error messages is surfaced through the SyncError. ([PR #5690](https://github.com/realm/realm-core/pull/5690)).
-* `NotificationToken` grew an `unregister()` method as an alternative to destroying it or doing `token = {};` ([PR #????](https://github.com/realm/realm-core/pull/????)).
+* `NotificationToken` grew an `unregister()` method as an alternative to destroying it or doing `token = {};` ([PR #5776](https://github.com/realm/realm-core/pull/5776)).
 
 ### Fixed
 * <How do the end-user experience this issue? what was the impact?> ([#????](https://github.com/realm/realm-core/issues/????), since v?.?.?)

--- a/src/realm/object-store/collection_notifications.cpp
+++ b/src/realm/object-store/collection_notifications.cpp
@@ -47,7 +47,8 @@ NotificationToken& NotificationToken::operator=(realm::NotificationToken&& rgt)
     return *this;
 }
 
-void NotificationToken::unregister() {
+void NotificationToken::unregister()
+{
     // m_notifier itself (and not just the pointed-to thing) needs to be accessed
     // atomically to ensure that there are no data races when the token is
     // destroyed after being modified on a different thread.

--- a/src/realm/object-store/collection_notifications.hpp
+++ b/src/realm/object-store/collection_notifications.hpp
@@ -45,6 +45,10 @@ struct NotificationToken {
     NotificationToken(NotificationToken const&) = delete;
     NotificationToken& operator=(NotificationToken const&) = delete;
 
+    // Stop sending notifications for the callback associated with this token.
+    // This is equivalent to (*this) = {};
+    void unregister();
+
     void suppress_next();
 
 private:

--- a/test/object-store/object.cpp
+++ b/test/object-store/object.cpp
@@ -359,6 +359,14 @@ TEST_CASE("object") {
             REQUIRE_INDICES(change.deletions, 0);
         }
 
+        SECTION("unregistering prior to deleting the object sends no notification") {
+            auto token = require_no_change(object);
+            token.unregister();
+            write([&] {
+                obj.remove();
+            });
+        }
+
         SECTION("deleting object before first run of notifier") {
             auto token = object.add_notification_callback(
                 [&](CollectionChangeSet c) {


### PR DESCRIPTION
## What, How & Why?
<!-- Describe the changes and give some hints to guide your reviewers if possible. -->
<!-- Link to relevant issue this fixes -->

## ☑️ ToDos
* [x] 📝 Changelog update
* [x] 🚦 Tests (or not relevant)
* ~~[ ] C-API, if public C++ API changed.~~ C-API already has `realm_free` as an explicit deleter call. This change is more necessary when directly binding GC language objects to the C++ API. That said, a C-API version can easily be added if it would be helpful.
