### PR TITLE
Remove inclusion of index_string.hpp from table.hpp

### DIFF
--- a/src/realm/table.cpp
+++ b/src/realm/table.cpp
@@ -336,6 +336,46 @@ void LinkChain::add(ColKey ck)
 
 // -- Table ---------------------------------------------------------------------------------
 
+Table::Table(Allocator& alloc)
+    : m_alloc(alloc)
+    , m_top(m_alloc)
+    , m_spec(m_alloc)
+    , m_clusters(this, m_alloc, top_position_for_cluster_tree)
+    , m_index_refs(m_alloc)
+    , m_opposite_table(m_alloc)
+    , m_opposite_column(m_alloc)
+    , m_repl(&g_dummy_replication)
+    , m_own_ref(this, alloc.get_instance_version())
+{
+    m_spec.set_parent(&m_top, top_position_for_spec);
+    m_index_refs.set_parent(&m_top, top_position_for_search_indexes);
+    m_opposite_table.set_parent(&m_top, top_position_for_opposite_table);
+    m_opposite_column.set_parent(&m_top, top_position_for_opposite_column);
+
+    ref_type ref = create_empty_table(m_alloc); // Throws
+    ArrayParent* parent = nullptr;
+    size_t ndx_in_parent = 0;
+    init(ref, parent, ndx_in_parent, true, false);
+}
+
+Table::Table(Replication* const* repl, Allocator& alloc)
+    : m_alloc(alloc)
+    , m_top(m_alloc)
+    , m_spec(m_alloc)
+    , m_clusters(this, m_alloc, top_position_for_cluster_tree)
+    , m_index_refs(m_alloc)
+    , m_opposite_table(m_alloc)
+    , m_opposite_column(m_alloc)
+    , m_repl(repl)
+    , m_own_ref(this, alloc.get_instance_version())
+{
+    m_spec.set_parent(&m_top, top_position_for_spec);
+    m_index_refs.set_parent(&m_top, top_position_for_search_indexes);
+    m_opposite_table.set_parent(&m_top, top_position_for_opposite_table);
+    m_opposite_column.set_parent(&m_top, top_position_for_opposite_column);
+    m_cookie = cookie_created;
+}
+
 ColKey Table::add_column(DataType type, StringData name, bool nullable)
 {
     if (REALM_UNLIKELY(is_link_type(ColumnType(type))))

--- a/src/realm/table.hpp
+++ b/src/realm/table.hpp
@@ -35,7 +35,6 @@
 #include <realm/table_cluster_tree.hpp>
 #include <realm/keys.hpp>
 #include <realm/global_key.hpp>
-#include <realm/index_string.hpp>
 
 // Only set this to one when testing the code paths that exercise object ID
 // hash collisions. It artificially limits the "optimistic" local ID to use
@@ -60,6 +59,7 @@ class ColKeys;
 struct GlobalKey;
 class LinkChain;
 class Subexpr;
+class StringIndex;
 
 struct Link {
 };
@@ -1198,46 +1198,6 @@ inline DataType Table::get_dictionary_key_type(ColKey column_key) const noexcept
     return m_spec.get_dictionary_key_type(spec_ndx);
 }
 
-
-inline Table::Table(Allocator& alloc)
-    : m_alloc(alloc)
-    , m_top(m_alloc)
-    , m_spec(m_alloc)
-    , m_clusters(this, m_alloc, top_position_for_cluster_tree)
-    , m_index_refs(m_alloc)
-    , m_opposite_table(m_alloc)
-    , m_opposite_column(m_alloc)
-    , m_repl(&g_dummy_replication)
-    , m_own_ref(this, alloc.get_instance_version())
-{
-    m_spec.set_parent(&m_top, top_position_for_spec);
-    m_index_refs.set_parent(&m_top, top_position_for_search_indexes);
-    m_opposite_table.set_parent(&m_top, top_position_for_opposite_table);
-    m_opposite_column.set_parent(&m_top, top_position_for_opposite_column);
-
-    ref_type ref = create_empty_table(m_alloc); // Throws
-    ArrayParent* parent = nullptr;
-    size_t ndx_in_parent = 0;
-    init(ref, parent, ndx_in_parent, true, false);
-}
-
-inline Table::Table(Replication* const* repl, Allocator& alloc)
-    : m_alloc(alloc)
-    , m_top(m_alloc)
-    , m_spec(m_alloc)
-    , m_clusters(this, m_alloc, top_position_for_cluster_tree)
-    , m_index_refs(m_alloc)
-    , m_opposite_table(m_alloc)
-    , m_opposite_column(m_alloc)
-    , m_repl(repl)
-    , m_own_ref(this, alloc.get_instance_version())
-{
-    m_spec.set_parent(&m_top, top_position_for_spec);
-    m_index_refs.set_parent(&m_top, top_position_for_search_indexes);
-    m_opposite_table.set_parent(&m_top, top_position_for_opposite_table);
-    m_opposite_column.set_parent(&m_top, top_position_for_opposite_column);
-    m_cookie = cookie_created;
-}
 
 inline void Table::revive(Replication* const* repl, Allocator& alloc, bool writable)
 {


### PR DESCRIPTION
This will prevent re-compilation of all test files when updating the interface to index, which should be internal only. It has the consequence that we have to remove inlining of Table constructors, but that is probably not a bad thing either. The header file was included when we introduced smart pointers to hold the indexes.
