### PR TITLE
Fix compilation problems with object-store-benchmarks

### DIFF
--- a/test/object-store/benchmarks/object.cpp
+++ b/test/object-store/benchmarks/object.cpp
@@ -265,7 +265,7 @@ TEST_CASE("Benchmark object", "[benchmark]") {
 
         Results result(r, table);
         size_t num_modifications = 0;
-        auto token = result.add_notification_callback([&](CollectionChangeSet c, std::exception_ptr) {
+        auto token = result.add_notification_callback([&](CollectionChangeSet c) {
             num_modifications += c.modifications.count();
         });
 
@@ -299,7 +299,7 @@ TEST_CASE("Benchmark object", "[benchmark]") {
         size_t num_insertions = 0;
         size_t num_deletions = 0;
         size_t num_modifications = 0;
-        auto token = result.add_notification_callback([&](CollectionChangeSet c, std::exception_ptr) {
+        auto token = result.add_notification_callback([&](CollectionChangeSet c) {
             num_insertions += c.insertions.count();
             num_deletions += c.deletions.count();
             num_modifications += c.modifications_new.count();
@@ -328,7 +328,7 @@ TEST_CASE("Benchmark object", "[benchmark]") {
                     {"name", name.str()},
                     {"age", static_cast<int64_t>(i)},
                 };
-                Object::create(d, r, person_schema, Any(person), CreatePolicy::ForceCreate);
+                Object::create(d, r, person_schema, util::Any(person), CreatePolicy::ForceCreate);
             }
             r->commit_transaction();
             meter.measure([&r] {
@@ -365,7 +365,7 @@ TEST_CASE("Benchmark object", "[benchmark]") {
                     {"name", name.str()},
                     {"age", static_cast<int64_t>(i)},
                 };
-                Object::create(d, r, person_schema, Any(person), CreatePolicy::ForceCreate);
+                Object::create(d, r, person_schema, util::Any(person), CreatePolicy::ForceCreate);
             }
             r->commit_transaction();
             advance_and_notify(*r);
@@ -406,7 +406,7 @@ TEST_CASE("Benchmark object", "[benchmark]") {
                     {"name", name.str()},
                     {"age", static_cast<int64_t>(i)},
                 };
-                Object::create(d, r, person_schema, Any(person), CreatePolicy::ForceCreate);
+                Object::create(d, r, person_schema, util::Any(person), CreatePolicy::ForceCreate);
             }
             r->commit_transaction();
             advance_and_notify(*r);
@@ -425,7 +425,7 @@ TEST_CASE("Benchmark object", "[benchmark]") {
                 AnyDict person{
                     {"name", name.str()}, {"age", static_cast<int64_t>(i + 1)}, // age differs
                 };
-                Object::create(d, r, person_schema, Any(person), CreatePolicy::UpdateModified);
+                Object::create(d, r, person_schema, util::Any(person), CreatePolicy::UpdateModified);
             }
             r->commit_transaction();
 
@@ -465,7 +465,7 @@ TEST_CASE("Benchmark object", "[benchmark]") {
             {"date array", AnyVec{}},
             {"object array", AnyVec{AnyDict{{"value", INT64_C(20)}}}},
         };
-        Object obj = Object::create(d, r, schema, Any(values), CreatePolicy::ForceCreate);
+        Object obj = Object::create(d, r, schema, util::Any(values), CreatePolicy::ForceCreate);
         r->commit_transaction();
         advance_and_notify(*r);
 
@@ -502,7 +502,7 @@ TEST_CASE("Benchmark object", "[benchmark]") {
             constexpr size_t num_modifications = 300;
             for (size_t i = 0; i < num_modifications; ++i) {
                 Object o = get_object();
-                auto token = o.add_notification_callback([&notifiers, i](CollectionChangeSet c, std::exception_ptr) {
+                auto token = o.add_notification_callback([&notifiers, i](CollectionChangeSet c) {
                     notifiers[i].num_insertions += c.insertions.count();
                     notifiers[i].num_modifications += c.modifications.count();
                     notifiers[i].num_deletions += c.deletions.count();
@@ -546,7 +546,7 @@ TEST_CASE("Benchmark object", "[benchmark]") {
         size_t num_insertions = 0;
         size_t num_deletions = 0;
         size_t num_modifications = 0;
-        auto token = result.add_notification_callback([&](CollectionChangeSet c, std::exception_ptr) {
+        auto token = result.add_notification_callback([&](CollectionChangeSet c) {
             num_insertions += c.insertions.count();
             num_deletions += c.deletions.count();
             num_modifications += c.modifications_new.count();
@@ -564,7 +564,7 @@ TEST_CASE("Benchmark object", "[benchmark]") {
                     {"name", name.str()},
                     {"age", static_cast<int64_t>(index)},
                 };
-                Object::create(d, r, person_schema, Any(person), CreatePolicy::ForceCreate);
+                Object::create(d, r, person_schema, util::Any(person), CreatePolicy::ForceCreate);
             }
             r->commit_transaction();
         };
@@ -683,7 +683,7 @@ TEST_CASE("Benchmark object", "[benchmark]") {
                     {"name", name.str()},
                     {"age", static_cast<int64_t>(i * 2)},
                 };
-                Object::create(d, r, person_schema, Any(person), CreatePolicy::ForceCreate);
+                Object::create(d, r, person_schema, util::Any(person), CreatePolicy::ForceCreate);
             }
             r->commit_transaction();
 

--- a/test/object-store/benchmarks/results.cpp
+++ b/test/object-store/benchmarks/results.cpp
@@ -234,7 +234,7 @@ TEST_CASE("Benchmark results notifier", "[benchmark]") {
         realm->commit_transaction();
 
         Results r(realm, tables[0]->where());
-        auto token = r.add_notification_callback([](CollectionChangeSet, std::exception_ptr) {});
+        auto token = r.add_notification_callback([](CollectionChangeSet) {});
         auto& coordinator = *_impl::RealmCoordinator::get_coordinator(config.path);
         coordinator.on_change();
 
@@ -299,7 +299,7 @@ TEST_CASE("Benchmark results notifier", "[benchmark]") {
         realm->commit_transaction();
 
         Results r(realm, tables[0]->where());
-        auto token = r.add_notification_callback([](CollectionChangeSet, std::exception_ptr) {});
+        auto token = r.add_notification_callback([](CollectionChangeSet) {});
         auto& coordinator = *_impl::RealmCoordinator::get_coordinator(config.path);
         coordinator.on_change();
 


### PR DESCRIPTION
## What, How & Why?
Object store benchmarks are failing compiling on evergreen, as result stable builds are failing.

