### PR TITLE
Bump the expiration date on a jwt token used in a test

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -327,6 +327,7 @@ if(CMAKE_SYSTEM_NAME MATCHES "^Windows")
 elseif(APPLE AND NOT CMAKE_SYSTEM_NAME STREQUAL "Darwin")
     set(CATCH_CONFIG_NO_POSIX_SIGNALS ON CACHE BOOL "Disable Catch support for POSIX signals on Apple platforms other than macOS")
 endif()
+set(CATCH_CONFIG_ENABLE_ALL_STRINGMAKERS ON CACHE BOOL "Enable Catch2's optional standard library stringmakers")
 
 add_subdirectory(external/catch EXCLUDE_FROM_ALL)
 

--- a/test/object-store/sync/app.cpp
+++ b/test/object-store/sync/app.cpp
@@ -118,7 +118,7 @@ static std::string HMAC_SHA256(std::string_view key, std::string_view data)
 static std::string create_jwt(const std::string& appId)
 {
     nlohmann::json header = {{"alg", "HS256"}, {"typ", "JWT"}};
-    nlohmann::json payload = {{"aud", appId}, {"sub", "someUserId"}, {"exp", 1661896476}};
+    nlohmann::json payload = {{"aud", appId}, {"sub", "someUserId"}, {"exp", 1961896476}};
 
     payload["user_data"]["name"] = "Foo Bar";
     payload["user_data"]["occupation"] = "firefighter";


### PR DESCRIPTION
We hit 1661896476 a few hours ago so now the test creating a JWT token with that as an expiration date is failing. I bumped it to be valid for another 10 years. I also enabled the relevant catch2 option to have the failing test print:

```
test/object-store/sync/app.cpp:76: FAILED:
  REQUIRE_FALSE( error )
with expansion:
  !AuthError: invalid custom auth token: token is expired
```
instead of 
```
 ../test/object-store/sync/app.cpp:76: FAILED:
   REQUIRE_FALSE( error )
 with expansion:
   !{?}
```