### PR TITLE
Handle collection notifiers not being ready in a QoS-friendly way 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,8 +6,9 @@
 
 ### Fixed
 * <How do the end-user experience this issue? what was the impact?> ([#????](https://github.com/realm/realm-core/issues/????), since v?.?.?)
-* None.
- 
+* Fix a data race on RealmCoordinator::m_sync_session which could occur if multiple threads performed the initial open of a Realm at once. (since v11.8.0).
+* If a SyncSession outlived the parent Realm and then was adopted by a new Realm for the same file, other processes would not get notified for sync writes on that file.
+
 ### Breaking changes
 * None.
 
@@ -44,7 +45,6 @@
 * Fixed an exception "fcntl() with F_BARRIERFSYNC failed: Inappropriate ioctl for device" when running with MacOS on an exFAT drive. ([#5789](https://github.com/realm/realm-core/issues/5789) since 12.0.0) 
 * Syncing of a Decimal128 with big significand could result in a crash. ([#5728](https://github.com/realm/realm-core/issues/5728))
 * Recovery/discardLocal client reset modes will now wait for FLX sync realms to be fully synchronized before beginning recovery operations ([#5705](https://github.com/realm/realm-core/issues/5705))
-
 
 ### Breaking changes
 * None.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@
 * <How do the end-user experience this issue? what was the impact?> ([#????](https://github.com/realm/realm-core/issues/????), since v?.?.?)
 * Fix a data race on RealmCoordinator::m_sync_session which could occur if multiple threads performed the initial open of a Realm at once. (since v11.8.0).
 * If a SyncSession outlived the parent Realm and then was adopted by a new Realm for the same file, other processes would not get notified for sync writes on that file.
+* Fix one cause of QoS inversion warnings when performing writes on the main thread on Apple platforms. Waiting for async notifications to be ready is now done in a QoS-aware ways.
+* `Realm::refresh()` did not actually advance to the latest version in some cases. If there was a version newer than the current version which did not require blocking it would advance to that instead, contrary to the documented behavior.
 
 ### Breaking changes
 * None.

--- a/src/realm/object-store/impl/apple/external_commit_helper.cpp
+++ b/src/realm/object-store/impl/apple/external_commit_helper.cpp
@@ -89,7 +89,7 @@ void ExternalCommitHelper::FdHolder::close()
 // signal the runloop source and wake up the target runloop, and when data is
 // written to the anonymous pipe the background thread removes the runloop
 // source from the runloop and and shuts down.
-ExternalCommitHelper::ExternalCommitHelper(RealmCoordinator& parent)
+ExternalCommitHelper::ExternalCommitHelper(RealmCoordinator& parent, const RealmConfig& config)
     : m_parent(parent)
 {
     m_kq = kqueue();
@@ -119,19 +119,18 @@ ExternalCommitHelper::ExternalCommitHelper(RealmCoordinator& parent)
     // in correctness problems.
 
     std::string path;
-    std::string temp_dir = util::normalize_dir(parent.get_config().fifo_files_fallback_path);
+    std::string temp_dir = util::normalize_dir(config.fifo_files_fallback_path);
     std::string sys_temp_dir = util::normalize_dir(DBOptions::get_sys_tmp_dir());
-    path = DB::get_core_file(parent.get_path(), DB::CoreFileType::Note);
+    path = DB::get_core_file(config.path, DB::CoreFileType::Note);
     bool fifo_created = realm::util::try_create_fifo(path);
     if (!fifo_created && !temp_dir.empty()) {
-        path = DB::get_core_file(util::format("%1realm_%2", temp_dir, std::hash<std::string>()(parent.get_path())),
+        path = DB::get_core_file(util::format("%1realm_%2", temp_dir, std::hash<std::string>()(config.path)),
                                  DB::CoreFileType::Note);
         fifo_created = realm::util::try_create_fifo(path);
     }
     if (!fifo_created && !sys_temp_dir.empty()) {
-        path =
-            DB::get_core_file(util::format("%1realm_%2", sys_temp_dir, std::hash<std::string>()(parent.get_path())),
-                              DB::CoreFileType::Note);
+        path = DB::get_core_file(util::format("%1realm_%2", sys_temp_dir, std::hash<std::string>()(config.path)),
+                                 DB::CoreFileType::Note);
         realm::util::create_fifo(path);
     }
 

--- a/src/realm/object-store/impl/apple/external_commit_helper.hpp
+++ b/src/realm/object-store/impl/apple/external_commit_helper.hpp
@@ -20,13 +20,14 @@
 
 namespace realm {
 class Realm;
+struct RealmConfig;
 
 namespace _impl {
 class RealmCoordinator;
 
 class ExternalCommitHelper {
 public:
-    ExternalCommitHelper(RealmCoordinator& parent);
+    ExternalCommitHelper(RealmCoordinator& parent, const RealmConfig& config);
     ~ExternalCommitHelper();
 
     void notify_others();

--- a/src/realm/object-store/impl/collection_notifier.hpp
+++ b/src/realm/object-store/impl/collection_notifier.hpp
@@ -34,8 +34,7 @@
 #include <mutex>
 #include <unordered_set>
 
-namespace realm {
-namespace _impl {
+namespace realm::_impl {
 
 // A `NotificationCallback` is added to a collection when observing it.
 // It contains all information necessary in case we need to notify about changes
@@ -329,6 +328,10 @@ public:
 class NotifierPackage {
 public:
     NotifierPackage() = default;
+
+    // Create a package which contains notifiers which have already been pacakged for delivery
+    NotifierPackage(std::vector<std::shared_ptr<CollectionNotifier>> notifiers);
+    // Create a package which can have package_and_wait() called on it later
     NotifierPackage(std::vector<std::shared_ptr<CollectionNotifier>> notifiers, RealmCoordinator* coordinator);
 
     explicit operator bool() const noexcept
@@ -343,11 +346,10 @@ public:
         return m_version;
     }
 
-    // If a version is given, block until notifications are ready for that
-    // version, and then regardless of whether or not a version was given filter
-    // the notifiers to just the ones which have anything to deliver.
+    // Block until notifications are ready for the given version, and then filter
+    // out any notifiers which don't have anything to deliver.
     // No-op if called multiple times
-    void package_and_wait(util::Optional<VersionID::version_type> target_version);
+    void package_and_wait(VersionID::version_type target_version);
 
     // Send the before-change notifications
     void before_advance();
@@ -359,11 +361,11 @@ public:
 private:
     util::Optional<VersionID> m_version;
     std::vector<std::shared_ptr<CollectionNotifier>> m_notifiers;
-
     RealmCoordinator* m_coordinator = nullptr;
+
+    void set_version();
 };
 
-} // namespace _impl
-} // namespace realm
+} // namespace realm::_impl
 
 #endif /* REALM_BACKGROUND_COLLECTION_HPP */

--- a/src/realm/object-store/impl/epoll/external_commit_helper.cpp
+++ b/src/realm/object-store/impl/epoll/external_commit_helper.cpp
@@ -137,11 +137,11 @@ void ExternalCommitHelper::FdHolder::close()
     m_fd = -1;
 }
 
-ExternalCommitHelper::ExternalCommitHelper(RealmCoordinator& parent)
+ExternalCommitHelper::ExternalCommitHelper(RealmCoordinator& parent, const RealmConfig& config)
     : m_parent(parent)
 {
     std::string path;
-    std::string temp_dir = util::normalize_dir(parent.get_config().fifo_files_fallback_path);
+    std::string temp_dir = util::normalize_dir(config.fifo_files_fallback_path);
     std::string sys_temp_dir = util::normalize_dir(DBOptions::get_sys_tmp_dir());
 
     // Object Store needs to create a named pipe in order to coordinate notifications.
@@ -162,14 +162,14 @@ ExternalCommitHelper::ExternalCommitHelper(RealmCoordinator& parent)
     // Note that hash collisions are okay here because they just result in doing extra work instead of resulting
     // in correctness problems.
 
-    path = parent.get_path() + ".note";
+    path = config.path + ".note";
     bool fifo_created = util::try_create_fifo(path);
     if (!fifo_created && !temp_dir.empty()) {
-        path = util::format("%1realm_%2.note", temp_dir, std::hash<std::string>()(parent.get_path()));
+        path = util::format("%1realm_%2.note", temp_dir, std::hash<std::string>()(config.path));
         fifo_created = util::try_create_fifo(path);
     }
     if (!fifo_created && !sys_temp_dir.empty()) {
-        path = util::format("%1realm_%2.note", sys_temp_dir, std::hash<std::string>()(parent.get_path()));
+        path = util::format("%1realm_%2.note", sys_temp_dir, std::hash<std::string>()(config.path));
         util::create_fifo(path);
     }
 

--- a/src/realm/object-store/impl/epoll/external_commit_helper.hpp
+++ b/src/realm/object-store/impl/epoll/external_commit_helper.hpp
@@ -22,13 +22,14 @@
 #include <vector>
 
 namespace realm {
+struct RealmConfig;
 
 namespace _impl {
 class RealmCoordinator;
 
 class ExternalCommitHelper {
 public:
-    ExternalCommitHelper(RealmCoordinator& parent);
+    ExternalCommitHelper(RealmCoordinator& parent, const RealmConfig&);
     ~ExternalCommitHelper();
 
     void notify_others();

--- a/src/realm/object-store/impl/epoll/external_commit_helper.hpp
+++ b/src/realm/object-store/impl/epoll/external_commit_helper.hpp
@@ -17,8 +17,6 @@
 ////////////////////////////////////////////////////////////////////////////
 
 #include <memory>
-#include <mutex>
-#include <thread>
 #include <vector>
 
 namespace realm {
@@ -26,6 +24,35 @@ struct RealmConfig;
 
 namespace _impl {
 class RealmCoordinator;
+
+// A RAII holder for a file descriptor which automatically closes the wrapped
+// fd when it's deallocated
+class FdHolder {
+public:
+    FdHolder() = default;
+    ~FdHolder()
+    {
+        close();
+    }
+    operator int() const
+    {
+        return m_fd;
+    }
+
+    FdHolder& operator=(int new_fd)
+    {
+        close();
+        m_fd = new_fd;
+        return *this;
+    }
+
+private:
+    int m_fd = -1;
+    void close();
+
+    FdHolder& operator=(FdHolder const&) = delete;
+    FdHolder(FdHolder const&) = delete;
+};
 
 class ExternalCommitHelper {
 public:
@@ -35,37 +62,6 @@ public:
     void notify_others();
 
 private:
-    // A RAII holder for a file descriptor which automatically closes the wrapped
-    // fd when it's deallocated
-    class FdHolder {
-    public:
-        FdHolder() = default;
-        ~FdHolder()
-        {
-            close();
-        }
-        operator int() const
-        {
-            return m_fd;
-        }
-
-        FdHolder& operator=(int new_fd)
-        {
-            close();
-            m_fd = new_fd;
-            return *this;
-        }
-
-    private:
-        int m_fd = -1;
-        void close();
-
-        FdHolder& operator=(FdHolder const&) = delete;
-        FdHolder(FdHolder const&) = delete;
-    };
-
-    class DaemonThread;
-
     RealmCoordinator& m_parent;
 
     // Read-write file descriptor for the named pipe which is waited on for

--- a/src/realm/object-store/impl/generic/external_commit_helper.cpp
+++ b/src/realm/object-store/impl/generic/external_commit_helper.cpp
@@ -26,10 +26,9 @@
 using namespace realm;
 using namespace realm::_impl;
 
-ExternalCommitHelper::ExternalCommitHelper(RealmCoordinator& parent)
+ExternalCommitHelper::ExternalCommitHelper(RealmCoordinator& parent, const RealmConfig& config)
     : m_parent(parent)
-    , m_history(realm::make_in_realm_history())
-    , m_sg(DB::create(*m_history, parent.get_path(),
+    , m_sg(DB::create(realm::make_in_realm_history(), config.path,
                       DBOptions(parent.is_in_memory() ? DBOptions::Durability::MemOnly : DBOptions::Durability::Full,
                                 parent.get_encryption_key().data())))
     , m_thread(std::async(std::launch::async, [=] {

--- a/src/realm/object-store/impl/generic/external_commit_helper.hpp
+++ b/src/realm/object-store/impl/generic/external_commit_helper.hpp
@@ -21,14 +21,14 @@
 #include <future>
 
 namespace realm {
-class Replication;
+struct RealmConfig;
 
 namespace _impl {
 class RealmCoordinator;
 
 class ExternalCommitHelper {
 public:
-    ExternalCommitHelper(RealmCoordinator& parent);
+    ExternalCommitHelper(RealmCoordinator& parent, const RealmConfig&);
     ~ExternalCommitHelper();
 
     // A no-op in this version, but needed for the Apple version
@@ -37,8 +37,7 @@ public:
 private:
     RealmCoordinator& m_parent;
 
-    // A shared group used to listen for changes
-    std::unique_ptr<Replication> m_history;
+    // A DB used to listen for changes
     DBRef m_sg;
 
     // The listener thread

--- a/src/realm/object-store/impl/realm_coordinator.cpp
+++ b/src/realm/object-store/impl/realm_coordinator.cpp
@@ -852,13 +852,6 @@ void RealmCoordinator::clean_up_dead_notifiers()
 
 void RealmCoordinator::on_change()
 {
-    run_async_notifiers();
-
-    util::CheckedLockGuard lock(m_realm_mutex);
-    for (auto& realm : m_weak_realm_notifiers) {
-        realm.notify();
-    }
-
 #if REALM_ENABLE_SYNC
     // Invoke realm sync if another process has notified for a change
     if (m_sync_session) {
@@ -866,6 +859,13 @@ void RealmCoordinator::on_change()
         SyncSession::Internal::nonsync_transact_notify(*m_sync_session, version);
     }
 #endif
+
+    run_async_notifiers();
+
+    util::CheckedLockGuard lock(m_realm_mutex);
+    for (auto& realm : m_weak_realm_notifiers) {
+        realm.notify();
+    }
 }
 
 namespace {

--- a/src/realm/object-store/impl/realm_coordinator.hpp
+++ b/src/realm/object-store/impl/realm_coordinator.hpp
@@ -199,6 +199,10 @@ public:
     bool compact();
     void write_copy(StringData path, const char* key);
 
+    // Close the DB, delete the file, and then reopen it. This operation is *not*
+    // implemented in a safe manner and will only work in fairly specific circumstances
+    void delete_and_reopen() REQUIRES(!m_realm_mutex);
+
     template <typename Pred>
     util::CheckedUniqueLock wait_for_notifiers(Pred&& wait_predicate) REQUIRES(!m_notifier_mutex);
 
@@ -241,10 +245,10 @@ private:
 
     std::shared_ptr<AuditInterface> m_audit_context;
 
-    void open_db();
+    void open_db() REQUIRES(m_realm_mutex);
 
     void set_config(const Realm::Config&) REQUIRES(m_realm_mutex, !m_schema_cache_mutex);
-    void create_sync_session();
+    void init_external_helpers() REQUIRES(m_realm_mutex);
     std::shared_ptr<Realm> do_get_cached_realm(Realm::Config const& config,
                                                std::shared_ptr<util::Scheduler> scheduler = nullptr)
         REQUIRES(m_realm_mutex);

--- a/src/realm/object-store/impl/realm_coordinator.hpp
+++ b/src/realm/object-store/impl/realm_coordinator.hpp
@@ -162,23 +162,23 @@ public:
     void unregister_realm(Realm* realm) REQUIRES(!m_realm_mutex, !m_notifier_mutex);
 
     // Called by m_notifier when there's a new commit to send notifications for
-    void on_change() REQUIRES(!m_realm_mutex, !m_notifier_mutex);
+    void on_change() REQUIRES(!m_realm_mutex, !m_notifier_mutex, !m_running_notifiers_mutex);
 
     static void register_notifier(std::shared_ptr<CollectionNotifier> notifier);
 
     TransactionRef begin_read(VersionID version = {}, bool frozen_transaction = false);
 
-    // Check if advance_to_ready() would actually advance the Realm's read version
+    // Returns true if there are any versions after the Realm's read version
     bool can_advance(Realm& realm);
 
     // Advance the Realm to the most recent transaction version which all async
     // work is complete for
     void advance_to_ready(Realm& realm) REQUIRES(!m_notifier_mutex);
 
-    // Advance the Realm to the most recent transaction version, blocking if
-    // async notifiers are not yet ready for that version
-    // returns whether it actually changed the version
-    bool advance_to_latest(Realm& realm) REQUIRES(!m_notifier_mutex);
+    // Advance the Realm to the most recent transaction version, running the
+    // async notifiers if they aren't ready for that version
+    // returns true if actually changed the version
+    bool advance_to_latest(Realm& realm) REQUIRES(!m_notifier_mutex, !m_running_notifiers_mutex);
 
     // Deliver any notifications which are ready for the Realm's version
     void process_available_async(Realm& realm) REQUIRES(!m_notifier_mutex);
@@ -203,8 +203,19 @@ public:
     // implemented in a safe manner and will only work in fairly specific circumstances
     void delete_and_reopen() REQUIRES(!m_realm_mutex);
 
-    template <typename Pred>
-    util::CheckedUniqueLock wait_for_notifiers(Pred&& wait_predicate) REQUIRES(!m_notifier_mutex);
+    using NotifierVector = std::vector<std::shared_ptr<_impl::CollectionNotifier>>;
+    // Called by NotifierPackage in the cases where we don't know what version
+    // we need to notifiers for until after we begin advancing (e.g. when
+    // starting a write transaction).
+    void package_notifiers(NotifierVector& notifiers, VersionID::version_type)
+        REQUIRES(!m_notifier_mutex, !m_running_notifiers_mutex);
+
+    // testing hook only to verify that notifiers are not being run at times
+    // they shouldn't be
+    std::unique_lock<std::mutex> block_notifier_execution() REQUIRES(!m_running_notifiers_mutex)
+    {
+        return std::move(util::CheckedUniqueLock(m_running_notifiers_mutex).native_handle());
+    }
 
     void async_request_write_mutex(Realm& realm);
 
@@ -228,11 +239,11 @@ private:
     std::vector<WeakRealmNotifier> m_weak_realm_notifiers GUARDED_BY(m_realm_mutex);
 
     util::CheckedMutex m_notifier_mutex;
-    std::condition_variable m_notifier_cv GUARDED_BY(m_notifier_mutex);
-    std::vector<std::shared_ptr<_impl::CollectionNotifier>> m_new_notifiers GUARDED_BY(m_notifier_mutex);
-    std::vector<std::shared_ptr<_impl::CollectionNotifier>> m_notifiers GUARDED_BY(m_notifier_mutex);
+    NotifierVector m_new_notifiers GUARDED_BY(m_notifier_mutex);
+    NotifierVector m_notifiers GUARDED_BY(m_notifier_mutex);
     VersionID m_notifier_skip_version GUARDED_BY(m_notifier_mutex) = {0, 0};
 
+    util::CheckedMutex m_running_notifiers_mutex;
     // Transaction used for actually running async notifiers
     // Will have a read transaction iff m_notifiers is non-empty
     std::shared_ptr<Transaction> m_notifier_sg;
@@ -254,31 +265,13 @@ private:
         REQUIRES(m_realm_mutex);
     void do_get_realm(Realm::Config config, std::shared_ptr<Realm>& realm, util::Optional<VersionID> version,
                       util::CheckedUniqueLock& realm_lock) REQUIRES(m_realm_mutex);
-    void run_async_notifiers() REQUIRES(!m_notifier_mutex);
-    void advance_helper_shared_group_to_latest();
+    void run_async_notifiers() REQUIRES(!m_notifier_mutex, m_running_notifiers_mutex);
     void clean_up_dead_notifiers() REQUIRES(m_notifier_mutex);
 
-    std::vector<std::shared_ptr<_impl::CollectionNotifier>> notifiers_for_realm(Realm&) REQUIRES(m_notifier_mutex);
+    NotifierVector notifiers_for_realm(Realm&) REQUIRES(m_notifier_mutex);
 };
 
 void translate_file_exception(StringData path, bool immutable = false);
-
-template <typename Pred>
-util::CheckedUniqueLock RealmCoordinator::wait_for_notifiers(Pred&& wait_predicate)
-{
-    util::CheckedUniqueLock lock(m_notifier_mutex);
-    bool first = true;
-    m_notifier_cv.wait(lock.native_handle(), [&] {
-        if (wait_predicate())
-            return true;
-        if (first) {
-            wake_up_notifier_worker();
-            first = false;
-        }
-        return false;
-    });
-    return lock;
-}
 
 } // namespace _impl
 } // namespace realm

--- a/src/realm/object-store/impl/realm_coordinator.hpp
+++ b/src/realm/object-store/impl/realm_coordinator.hpp
@@ -205,7 +205,7 @@ public:
 
     using NotifierVector = std::vector<std::shared_ptr<_impl::CollectionNotifier>>;
     // Called by NotifierPackage in the cases where we don't know what version
-    // we need to notifiers for until after we begin advancing (e.g. when
+    // we need notifiers for until after we begin advancing (e.g. when
     // starting a write transaction).
     void package_notifiers(NotifierVector& notifiers, VersionID::version_type)
         REQUIRES(!m_notifier_mutex, !m_running_notifiers_mutex);

--- a/src/realm/object-store/impl/results_notifier.cpp
+++ b/src/realm/object-store/impl/results_notifier.cpp
@@ -288,12 +288,9 @@ bool ListResultsNotifier::need_to_run()
 {
     REALM_ASSERT(m_info);
 
-    {
-        auto lock = lock_target();
-        // Don't run the query if the results aren't actually going to be used
-        if (!get_realm() || (!have_callbacks() && !m_results_were_used))
-            return false;
-    }
+    // Don't run the query if the results aren't actually going to be used
+    if (!is_alive() || (!have_callbacks() && !m_results_were_used))
+        return false;
 
     return !has_run() || m_list->has_changed();
 }
@@ -363,8 +360,7 @@ void ListResultsNotifier::do_prepare_handover(Transaction& sg)
 
 bool ListResultsNotifier::prepare_to_deliver()
 {
-    auto lock = lock_target();
-    if (!get_realm()) {
+    if (!is_alive()) {
         return false;
     }
     if (!m_handover_indices)

--- a/src/realm/object-store/impl/transact_log_handler.cpp
+++ b/src/realm/object-store/impl/transact_log_handler.cpp
@@ -584,12 +584,12 @@ void advance_with_notifications(BindingContext* context, const std::shared_ptr<T
         auto new_version = sg->get_version_of_current_transaction();
         if (context && old_version != new_version)
             context->did_change({}, {});
-        // did_change() could close the Realm. Just return if it does.
+        // Each of these places where we call back to the user could close the
+        // Realm. Just return early if that happens.
         if (sg->get_transact_stage() == DB::transact_Ready)
             return;
         if (context)
             context->will_send_notifications();
-        // will_send_notifications() could close the Realm. Just return if it does.
         if (sg->get_transact_stage() == DB::transact_Ready)
             return;
         notifiers.after_advance();
@@ -631,7 +631,7 @@ void advance(Transaction& tr, BindingContext*, VersionID version)
     tr.advance_read(&validator, version);
 }
 
-void advance(const std::shared_ptr<Transaction>& tr, BindingContext* context, NotifierPackage& notifiers)
+void advance(const std::shared_ptr<Transaction>& tr, BindingContext* context, NotifierPackage&& notifiers)
 {
     advance_with_notifications(
         context, tr,
@@ -641,7 +641,7 @@ void advance(const std::shared_ptr<Transaction>& tr, BindingContext* context, No
         notifiers);
 }
 
-void begin(const std::shared_ptr<Transaction>& tr, BindingContext* context, NotifierPackage& notifiers)
+void begin(const std::shared_ptr<Transaction>& tr, BindingContext* context, NotifierPackage&& notifiers)
 {
     advance_with_notifications(
         context, tr,

--- a/src/realm/object-store/impl/transact_log_handler.hpp
+++ b/src/realm/object-store/impl/transact_log_handler.hpp
@@ -40,13 +40,13 @@ struct UnsupportedSchemaChange : std::logic_error {
 namespace transaction {
 // Advance the read transaction version, with change notifications sent to delegate
 // Must not be called from within a write transaction.
-void advance(const std::shared_ptr<Transaction>& sg, BindingContext* binding_context, NotifierPackage&);
+void advance(const std::shared_ptr<Transaction>& sg, BindingContext* binding_context, NotifierPackage&&);
 void advance(Transaction& sg, BindingContext* binding_context, VersionID);
 
 // Begin a write transaction
 // If the read transaction version is not up to date, will first advance to the
 // most recent read transaction and sent notifications to delegate
-void begin(const std::shared_ptr<Transaction>& sg, BindingContext* binding_context, NotifierPackage&);
+void begin(const std::shared_ptr<Transaction>& sg, BindingContext* binding_context, NotifierPackage&&);
 
 // Cancel a write transaction and roll back all changes, with change notifications
 // for reverting to the old values sent to delegate

--- a/src/realm/object-store/impl/windows/external_commit_helper.hpp
+++ b/src/realm/object-store/impl/windows/external_commit_helper.hpp
@@ -22,6 +22,7 @@
 #include <windows.h>
 
 namespace realm {
+struct RealmConfig;
 namespace _impl {
 class RealmCoordinator;
 
@@ -101,7 +102,7 @@ private:
 
 class ExternalCommitHelper {
 public:
-    ExternalCommitHelper(RealmCoordinator& parent);
+    ExternalCommitHelper(RealmCoordinator& parent, const RealmConfig&);
     ~ExternalCommitHelper();
 
     void notify_others();

--- a/src/realm/object-store/shared_realm.cpp
+++ b/src/realm/object-store/shared_realm.cpp
@@ -267,8 +267,7 @@ bool Realm::reset_file(Schema& schema, std::vector<SchemaChange>& required_chang
     // synchronization. The latter is probably fixable, but making it
     // multi-process-safe requires some sort of multi-process exclusive lock
     m_transaction = nullptr;
-    m_coordinator->close();
-    util::File::remove(m_config.path);
+    m_coordinator->delete_and_reopen();
 
     m_schema = ObjectStore::schema_from_group(read_group());
     m_schema_version = ObjectStore::get_schema_version(read_group());

--- a/test/object-store/results.cpp
+++ b/test/object-store/results.cpp
@@ -450,116 +450,91 @@ TEST_CASE("notifications: async delivery") {
 
     SECTION("handling of results not ready") {
         make_remote_change();
+        auto initial_version = r->read_transaction_version().version;
 
-        SECTION("notify() does nothing") {
+        SECTION("notify() does nothing if no notifiers are ready") {
             r->notify();
             REQUIRE(notification_calls == 1);
+            REQUIRE(r->read_transaction_version().version == initial_version);
+
             coordinator->on_change();
             r->notify();
             REQUIRE(notification_calls == 2);
+            REQUIRE(r->read_transaction_version().version == initial_version + 1);
         }
 
-        SECTION("refresh() blocks") {
-            REQUIRE(notification_calls == 1);
-            JoiningThread thread([&] {
-                std::this_thread::sleep_for(std::chrono::microseconds(5000));
-                coordinator->on_change();
-            });
-            r->refresh();
-            REQUIRE(notification_calls == 2);
-        }
-
-        SECTION("refresh() advances to the first version with notifiers ready that is at least a recent as the "
-                "newest at the time it is called") {
-            JoiningThread thread([&] {
-                std::this_thread::sleep_for(std::chrono::microseconds(5000));
-                make_remote_change();
-                coordinator->on_change();
-                make_remote_change();
-            });
-            // advances to the version after the one it was waiting for, but still
-            // not the latest
-            r->refresh();
-            REQUIRE(notification_calls == 2);
-
-            thread.join();
-            REQUIRE(notification_calls == 2);
-
-            // now advances to the latest
+        SECTION("notify() advances to a stale ready version") {
             coordinator->on_change();
-            r->refresh();
+            make_remote_change();
+
+            r->notify();
+            REQUIRE(notification_calls == 2);
+            REQUIRE(r->read_transaction_version().version == initial_version + 1);
+
+            coordinator->on_change();
+            r->notify();
             REQUIRE(notification_calls == 3);
+            REQUIRE(r->read_transaction_version().version == initial_version + 2);
         }
 
-        SECTION("begin_transaction() blocks") {
+        SECTION("refresh() runs the stale notifiers") {
             REQUIRE(notification_calls == 1);
-            JoiningThread thread([&] {
-                std::this_thread::sleep_for(std::chrono::microseconds(5000));
-                coordinator->on_change();
-            });
+            // note: no on_change()
+            r->refresh();
+            REQUIRE(notification_calls == 2);
+            REQUIRE(r->read_transaction_version().version == initial_version + 1);
+        }
+
+        SECTION("refresh() runs stale notifiers even if there's an older version with notifications ready") {
+            coordinator->on_change();
+            make_remote_change();
+            r->refresh();
+            REQUIRE(notification_calls == 2);
+            REQUIRE(r->read_transaction_version().version == initial_version + 2);
+        }
+
+        SECTION("begin_transaction() runs the stale notifiers") {
+            REQUIRE(notification_calls == 1);
             r->begin_transaction();
             REQUIRE(notification_calls == 2);
+            REQUIRE(r->read_transaction_version().version == initial_version + 1);
             r->cancel_transaction();
         }
 
-        SECTION("refresh() does not block for results without callbacks") {
+        SECTION(
+            "begin_transaction() runs stale notifiers even if there's an older version with notifications ready") {
+            coordinator->on_change();
+            make_remote_change();
+            r->begin_transaction();
+            REQUIRE(notification_calls == 2);
+            REQUIRE(r->read_transaction_version().version == initial_version + 2);
+            r->cancel_transaction();
+        }
+
+        SECTION("refresh() does not run stale notifiers if there are no callbacks") {
             token = {};
-            // this would deadlock if it waits for the notifier to be ready
+            // this would deadlock if it waits for the notifier to be ready or tries to run the notifiers
+            auto lock = coordinator->block_notifier_execution();
             r->refresh();
         }
 
-        SECTION("begin_transaction() does not block for results without callbacks") {
+        SECTION("begin_transaction() does not run stale notifiers if there are no callbacks") {
             token = {};
-            // this would deadlock if it waits for the notifier to be ready
+            // this would deadlock if it waits for the notifier to be ready or tries to run the notifiers
+            auto lock = coordinator->block_notifier_execution();
             r->begin_transaction();
             r->cancel_transaction();
         }
 
-        SECTION("begin_transaction() does not block for Results for different Realms") {
+        SECTION("begin_transaction() does not run stale notifiers if they are for a different Realm") {
             // this would deadlock if beginning the write on the secondary Realm
             // waited for the primary Realm to be ready
+            auto lock = coordinator->block_notifier_execution();
             make_remote_change();
 
             // sanity check that the notifications never did run
             r->notify();
             REQUIRE(notification_calls == 1);
-        }
-    }
-
-    SECTION("handling of stale results") {
-        make_remote_change();
-        coordinator->on_change();
-        make_remote_change();
-
-        SECTION("notify() uses the older version") {
-            r->notify();
-            REQUIRE(notification_calls == 2);
-            coordinator->on_change();
-            r->notify();
-            REQUIRE(notification_calls == 3);
-            r->notify();
-            REQUIRE(notification_calls == 3);
-        }
-
-        SECTION("refresh() blocks") {
-            REQUIRE(notification_calls == 1);
-            JoiningThread thread([&] {
-                std::this_thread::sleep_for(std::chrono::microseconds(5000));
-                coordinator->on_change();
-            });
-            r->refresh();
-            REQUIRE(notification_calls == 2);
-        }
-
-        SECTION("begin_transaction() blocks") {
-            REQUIRE(notification_calls == 1);
-            JoiningThread thread([&] {
-                std::this_thread::sleep_for(std::chrono::microseconds(5000));
-                coordinator->on_change();
-            });
-            r->begin_transaction();
-            REQUIRE(notification_calls == 2);
-            r->cancel_transaction();
         }
     }
 

--- a/test/object-store/sync/flx_sync.cpp
+++ b/test/object-store/sync/flx_sync.cpp
@@ -45,19 +45,6 @@
 #include <iostream>
 #include <stdexcept>
 
-namespace realm {
-
-class TestHelper {
-public:
-    static bool can_advance(const SharedRealm& realm)
-    {
-        auto& coord = Realm::Internal::get_coordinator(*realm);
-        return coord.can_advance(*realm);
-    }
-};
-
-} // namespace realm
-
 namespace realm::app {
 
 namespace {
@@ -117,37 +104,25 @@ std::vector<ObjectId> fill_large_array_schema(FLXSyncTestHarness& harness)
     return ret;
 }
 
-void wait_for_advance(const SharedRealm& realm)
+void wait_for_error_to_persist(const AppSession& app_session, const std::string& err)
 {
-    timed_wait_for([&] {
-        return !TestHelper::can_advance(realm);
-    });
-}
-
 // TODO: Re-enable it in RCORE-1241.
 #if 0
-// Returns true if `err` is among the erros received from the server, false otherwise.
-bool wait_for_error_to_persist(const AppSession& app_session, const std::string& err)
-{
-    bool error_found = false;
     timed_sleeping_wait_for(
         [&]() -> bool {
             auto errors = app_session.admin_api.get_errors(app_session.server_app_id);
-            auto it = std::find_if(errors.begin(), errors.end(), [&err](const auto& error) {
-                return err == error;
-            });
-
+            auto it = std::find(errors.begin(), errors.end(), err);
             if (it == errors.end()) {
                 millisleep(500); // don't spam the server too much
             }
-            error_found = it != errors.end();
-            return error_found;
+            return it != errors.end();
         },
         std::chrono::minutes(10));
-
-    return error_found;
-}
+#else
+    static_cast<void>(app_session);
+    static_cast<void>(err);
 #endif
+}
 } // namespace
 
 TEST_CASE("flx: connect to FLX-enabled app", "[sync][flx][app]") {
@@ -192,7 +167,7 @@ TEST_CASE("flx: connect to FLX-enabled app", "[sync][flx][app]") {
 
         wait_for_download(*realm);
         {
-            wait_for_advance(realm);
+            realm->refresh();
             Results results(realm, table);
             CHECK(results.size() == 1);
             auto obj = results.get<Obj>(0);
@@ -210,7 +185,7 @@ TEST_CASE("flx: connect to FLX-enabled app", "[sync][flx][app]") {
         }
 
         {
-            wait_for_advance(realm);
+            realm->refresh();
             Results results(realm, Query(table));
             CHECK(results.size() == 2);
         }
@@ -228,7 +203,7 @@ TEST_CASE("flx: connect to FLX-enabled app", "[sync][flx][app]") {
         }
 
         {
-            wait_for_advance(realm);
+            realm->refresh();
             Results results(realm, Query(table));
             CHECK(results.size() == 1);
             auto obj = results.get<Obj>(0);
@@ -244,7 +219,7 @@ TEST_CASE("flx: connect to FLX-enabled app", "[sync][flx][app]") {
         }
 
         {
-            wait_for_advance(realm);
+            realm->refresh();
             Results results(realm, table);
             CHECK(results.size() == 0);
         }
@@ -857,7 +832,7 @@ TEST_CASE("flx: uploading an object that is out-of-view results in compensating 
                 std::move(error_future).get(), invalid_obj,
                 util::format("write to '%1' in table \"TopLevel\" not allowed", invalid_obj.to_string()));
 
-            wait_for_advance(realm);
+            realm->refresh();
 
             auto top_level_table = realm->read_group().get_table("class_TopLevel");
             REQUIRE(top_level_table->is_empty());
@@ -901,7 +876,7 @@ TEST_CASE("flx: uploading an object that is out-of-view results in compensating 
                 std::move(error_future).get(), invalid_obj,
                 util::format("write to '%1' in table \"TopLevel\" not allowed", invalid_obj.to_string()));
 
-            wait_for_advance(realm);
+            realm->refresh();
 
             obj = Object::get_for_primary_key(c, realm, "TopLevel", std::any(invalid_obj));
             embedded_obj = util::any_cast<Object&&>(obj.get_property_value<std::any>(c, "embedded_obj"));
@@ -917,7 +892,7 @@ TEST_CASE("flx: uploading an object that is out-of-view results in compensating 
             wait_for_upload(*realm);
             wait_for_download(*realm);
 
-            wait_for_advance(realm);
+            realm->refresh();
             obj = Object::get_for_primary_key(c, realm, "TopLevel", std::any(invalid_obj));
             embedded_obj = util::any_cast<Object&&>(obj.get_property_value<std::any>(c, "embedded_obj"));
             REQUIRE(util::any_cast<std::string&&>(embedded_obj.get_property_value<std::any>(c, "str_field")) ==
@@ -960,7 +935,7 @@ TEST_CASE("flx: uploading an object that is out-of-view results in compensating 
             validate_sync_error(std::move(error_future).get(), invalid_obj,
                                 "object is outside of the current query view");
 
-            wait_for_advance(realm);
+            realm->refresh();
 
             auto top_level_table = realm->read_group().get_table("class_TopLevel");
             REQUIRE(top_level_table->size() == 1);
@@ -1078,7 +1053,7 @@ TEST_CASE("flx: interrupted bootstrap restarts/recovers on reconnect", "[sync][f
     wait_for_upload(*realm);
     wait_for_download(*realm);
 
-    wait_for_advance(realm);
+    realm->refresh();
     REQUIRE(table->size() == obj_ids_at_end.size());
     for (auto& id : obj_ids_at_end) {
         REQUIRE(table->find_primary_key(Mixed{id}));
@@ -1476,7 +1451,7 @@ TEST_CASE("flx: bootstrap batching prevents orphan documents", "[sync][flx][app]
     auto mutate_realm = [&] {
         harness.load_initial_data([&](SharedRealm realm) {
             auto table = realm->read_group().get_table("class_TopLevel");
-            wait_for_advance(realm);
+            realm->refresh();
             Results res(realm, Query(table).greater(table->get_column_key("queryable_int_field"), int64_t(10)));
             REQUIRE(res.size() == 2);
             res.clear();
@@ -1614,7 +1589,7 @@ TEST_CASE("flx: bootstrap batching prevents orphan documents", "[sync][flx][app]
         wait_for_upload(*realm);
         wait_for_download(*realm);
 
-        wait_for_advance(realm);
+        realm->refresh();
         auto expected_obj_ids = util::Span<ObjectId>(obj_ids_at_end).sub_span(0, 3);
 
         REQUIRE(table->size() == expected_obj_ids.size());
@@ -1726,7 +1701,7 @@ TEST_CASE("flx: bootstrap batching prevents orphan documents", "[sync][flx][app]
             .get();
         wait_for_upload(*realm);
         wait_for_download(*realm);
-        wait_for_advance(realm);
+        realm->refresh();
 
         auto expected_obj_ids = util::Span<ObjectId>(obj_ids_at_end).sub_span(0, 3);
 
@@ -1894,13 +1869,10 @@ TEST_CASE("flx: asymmetric sync", "[sync][flx][app]") {
             CHECK(ec.value() == int(realm::sync::ClientError::bad_changeset));
         });
 
-// TODO: Re-enable it in RCORE-1241.
-#if 0
-        REQUIRE(wait_for_error_to_persist(
+        REQUIRE_NOTHROW(wait_for_error_to_persist(
             harness->session().app_session(),
             "Failed to transform received changeset: Schema mismatch: 'Asymmetric' is asymmetric "
             "on one side, but not on the other. (ProtocolErrorCode=112)"));
-#endif
     }
 
     SECTION("basic embedded object construction") {
@@ -2002,8 +1974,6 @@ TEST_CASE("flx: asymmetric sync - dev mode", "[sync][flx][app]") {
 }
 #endif
 
-// TODO: Re-enable it in RCORE-1241.
-#if 0
 TEST_CASE("flx: send client error", "[sync][flx][app]") {
     FLXSyncTestHarness harness("flx_client_error");
 
@@ -2021,9 +1991,9 @@ TEST_CASE("flx: send client error", "[sync][flx][app]") {
 
     error_future.get();
 
-    REQUIRE(wait_for_error_to_persist(harness.session().app_session(), "simulated failure (ProtocolErrorCode=112)"));
+    REQUIRE_NOTHROW(
+        wait_for_error_to_persist(harness.session().app_session(), "simulated failure (ProtocolErrorCode=112)"));
 }
-#endif
 
 } // namespace realm::app
 

--- a/test/object-store/sync/flx_sync.cpp
+++ b/test/object-store/sync/flx_sync.cpp
@@ -23,6 +23,7 @@
 #include "flx_sync_harness.hpp"
 #include "sync/sync_test_utils.hpp"
 #include "util/test_file.hpp"
+#include "realm/object-store/binding_context.hpp"
 #include "realm/object-store/impl/object_accessor_impl.hpp"
 #include "realm/object-store/impl/realm_coordinator.hpp"
 #include "realm/object-store/schema.hpp"
@@ -34,12 +35,12 @@
 #include "realm/sync/config.hpp"
 #include "realm/sync/noinst/client_history_impl.hpp"
 #include "realm/sync/noinst/pending_bootstrap_store.hpp"
+#include "realm/sync/noinst/server/access_token.hpp"
 #include "realm/sync/protocol.hpp"
 #include "realm/sync/subscriptions.hpp"
 #include "realm/util/future.hpp"
 #include "realm/util/logger.hpp"
 #include "util/test_file.hpp"
-#include <realm/sync/noinst/server/access_token.hpp>
 
 #include <filesystem>
 #include <iostream>
@@ -102,6 +103,35 @@ std::vector<ObjectId> fill_large_array_schema(FLXSyncTestHarness& harness)
         }
     });
     return ret;
+}
+
+void wait_for_advance(Realm& realm)
+{
+    struct Context : BindingContext {
+        Realm& realm;
+        DB::version_type target_version;
+        bool& done;
+        Context(Realm& realm, bool& done)
+            : realm(realm)
+            , target_version(*realm.latest_snapshot_version())
+            , done(done)
+        {
+        }
+
+        void did_change(std::vector<ObserverState> const&, std::vector<void*> const&, bool) override
+        {
+            if (realm.read_transaction_version().version >= target_version) {
+                done = true;
+            }
+        }
+    };
+
+    bool done = false;
+    realm.m_binding_context = std::make_unique<Context>(realm, done);
+    timed_wait_for([&] {
+        return done;
+    });
+    realm.m_binding_context = nullptr;
 }
 
 void wait_for_error_to_persist(const AppSession& app_session, const std::string& err)
@@ -167,7 +197,7 @@ TEST_CASE("flx: connect to FLX-enabled app", "[sync][flx][app]") {
 
         wait_for_download(*realm);
         {
-            realm->refresh();
+            wait_for_advance(*realm);
             Results results(realm, table);
             CHECK(results.size() == 1);
             auto obj = results.get<Obj>(0);
@@ -185,7 +215,7 @@ TEST_CASE("flx: connect to FLX-enabled app", "[sync][flx][app]") {
         }
 
         {
-            realm->refresh();
+            wait_for_advance(*realm);
             Results results(realm, Query(table));
             CHECK(results.size() == 2);
         }
@@ -203,7 +233,7 @@ TEST_CASE("flx: connect to FLX-enabled app", "[sync][flx][app]") {
         }
 
         {
-            realm->refresh();
+            wait_for_advance(*realm);
             Results results(realm, Query(table));
             CHECK(results.size() == 1);
             auto obj = results.get<Obj>(0);
@@ -219,7 +249,7 @@ TEST_CASE("flx: connect to FLX-enabled app", "[sync][flx][app]") {
         }
 
         {
-            realm->refresh();
+            wait_for_advance(*realm);
             Results results(realm, table);
             CHECK(results.size() == 0);
         }
@@ -832,7 +862,7 @@ TEST_CASE("flx: uploading an object that is out-of-view results in compensating 
                 std::move(error_future).get(), invalid_obj,
                 util::format("write to '%1' in table \"TopLevel\" not allowed", invalid_obj.to_string()));
 
-            realm->refresh();
+            wait_for_advance(*realm);
 
             auto top_level_table = realm->read_group().get_table("class_TopLevel");
             REQUIRE(top_level_table->is_empty());
@@ -876,7 +906,7 @@ TEST_CASE("flx: uploading an object that is out-of-view results in compensating 
                 std::move(error_future).get(), invalid_obj,
                 util::format("write to '%1' in table \"TopLevel\" not allowed", invalid_obj.to_string()));
 
-            realm->refresh();
+            wait_for_advance(*realm);
 
             obj = Object::get_for_primary_key(c, realm, "TopLevel", std::any(invalid_obj));
             embedded_obj = util::any_cast<Object&&>(obj.get_property_value<std::any>(c, "embedded_obj"));
@@ -892,7 +922,7 @@ TEST_CASE("flx: uploading an object that is out-of-view results in compensating 
             wait_for_upload(*realm);
             wait_for_download(*realm);
 
-            realm->refresh();
+            wait_for_advance(*realm);
             obj = Object::get_for_primary_key(c, realm, "TopLevel", std::any(invalid_obj));
             embedded_obj = util::any_cast<Object&&>(obj.get_property_value<std::any>(c, "embedded_obj"));
             REQUIRE(util::any_cast<std::string&&>(embedded_obj.get_property_value<std::any>(c, "str_field")) ==
@@ -935,7 +965,7 @@ TEST_CASE("flx: uploading an object that is out-of-view results in compensating 
             validate_sync_error(std::move(error_future).get(), invalid_obj,
                                 "object is outside of the current query view");
 
-            realm->refresh();
+            wait_for_advance(*realm);
 
             auto top_level_table = realm->read_group().get_table("class_TopLevel");
             REQUIRE(top_level_table->size() == 1);
@@ -1035,7 +1065,7 @@ TEST_CASE("flx: interrupted bootstrap restarts/recovers on reconnect", "[sync][f
         realm->close();
     }
 
-    _impl::RealmCoordinator::clear_all_caches();
+    _impl::RealmCoordinator::assert_no_open_realms();
 
     {
         auto realm = DB::create(sync::make_client_replication(), interrupted_realm_config.path);
@@ -1053,7 +1083,7 @@ TEST_CASE("flx: interrupted bootstrap restarts/recovers on reconnect", "[sync][f
     wait_for_upload(*realm);
     wait_for_download(*realm);
 
-    realm->refresh();
+    wait_for_advance(*realm);
     REQUIRE(table->size() == obj_ids_at_end.size());
     for (auto& id : obj_ids_at_end) {
         REQUIRE(table->find_primary_key(Mixed{id}));
@@ -1451,7 +1481,6 @@ TEST_CASE("flx: bootstrap batching prevents orphan documents", "[sync][flx][app]
     auto mutate_realm = [&] {
         harness.load_initial_data([&](SharedRealm realm) {
             auto table = realm->read_group().get_table("class_TopLevel");
-            realm->refresh();
             Results res(realm, Query(table).greater(table->get_column_key("queryable_int_field"), int64_t(10)));
             REQUIRE(res.size() == 2);
             res.clear();
@@ -1493,7 +1522,7 @@ TEST_CASE("flx: bootstrap batching prevents orphan documents", "[sync][flx][app]
             realm->close();
         }
 
-        _impl::RealmCoordinator::clear_all_caches();
+        _impl::RealmCoordinator::assert_no_open_realms();
 
         // Open up the realm without the sync client attached and verify that the realm got interrupted in the state
         // we expected it to be in.
@@ -1558,7 +1587,7 @@ TEST_CASE("flx: bootstrap batching prevents orphan documents", "[sync][flx][app]
             realm->close();
         }
 
-        _impl::RealmCoordinator::clear_all_caches();
+        _impl::RealmCoordinator::assert_no_open_realms();
 
         // Open up the realm without the sync client attached and verify that the realm got interrupted in the state
         // we expected it to be in.
@@ -1589,7 +1618,7 @@ TEST_CASE("flx: bootstrap batching prevents orphan documents", "[sync][flx][app]
         wait_for_upload(*realm);
         wait_for_download(*realm);
 
-        realm->refresh();
+        wait_for_advance(*realm);
         auto expected_obj_ids = util::Span<ObjectId>(obj_ids_at_end).sub_span(0, 3);
 
         REQUIRE(table->size() == expected_obj_ids.size());
@@ -1633,7 +1662,7 @@ TEST_CASE("flx: bootstrap batching prevents orphan documents", "[sync][flx][app]
             realm->close();
         }
 
-        _impl::RealmCoordinator::clear_all_caches();
+        _impl::RealmCoordinator::assert_no_open_realms();
 
         // Open up the realm without the sync client attached and verify that the realm got interrupted in the state
         // we expected it to be in.
@@ -1658,7 +1687,6 @@ TEST_CASE("flx: bootstrap batching prevents orphan documents", "[sync][flx][app]
         auto [saw_valid_state_promise, saw_valid_state_future] = util::make_promise_future<void>();
         auto shared_saw_valid_state_promise =
             std::make_shared<decltype(saw_valid_state_promise)>(std::move(saw_valid_state_promise));
-        SharedRealm realm;
         // This hook will let us check what the state of the realm is before it's integrated any new download
         // messages from the server. This should be the full 5 object bootstrap that was received before we
         // called mutate_realm().
@@ -1693,7 +1721,7 @@ TEST_CASE("flx: bootstrap batching prevents orphan documents", "[sync][flx][app]
             };
 
         // Finally re-open the realm whose bootstrap we interrupted and just wait for it to finish downloading.
-        realm = Realm::get_shared_realm(interrupted_realm_config);
+        auto realm = Realm::get_shared_realm(interrupted_realm_config);
         saw_valid_state_future.get();
         auto table = realm->read_group().get_table("class_TopLevel");
         realm->get_latest_subscription_set()
@@ -1701,7 +1729,7 @@ TEST_CASE("flx: bootstrap batching prevents orphan documents", "[sync][flx][app]
             .get();
         wait_for_upload(*realm);
         wait_for_download(*realm);
-        realm->refresh();
+        wait_for_advance(*realm);
 
         auto expected_obj_ids = util::Span<ObjectId>(obj_ids_at_end).sub_span(0, 3);
 


### PR DESCRIPTION
On Apple platforms, waiting on a condition variable does not support donating the waiting thread's priority to the thread doing the work, as the OS doesn't know what thread will notify the CV. This can result in stalls from QoS inversions where a high priority thread is waiting on a low priority thread to complete work, but the low priority thread doesn't get scheduled.

Instead of using a condition variable, we now guard `run_async_notifiers()` with a mutex. If notifiers aren't ready, we try to acquire the mutex on the advancing thread. If the background thread is actively running the notifiers, this'll block and donate the advancing thread's priority and time slice to the background thread. If it's not, then we just call `run_async_notifiers()` on the current thread.

Updating the tests to work with this revealed something that was working as designed, but contrary to what all of our SDK documentation says because the design was weird and bad. Previously, `refresh()` did not always actually advance to the most recent version. Instead, if there was a newer version which notifiers were ready for it would advance to that even if it's not the latest version. If it couldn't advance without blocking, then it would block until the most recent version was ready.

This behavior made `refresh()` mostly useless as it didn't guarantee that committing a write transaction on one thread and then refreshing on another would make the second thread see the write, but it also wasn't a best-effort advance without blocking (which is done via `notify()`). Removing this behavior is arguably a breaking change, but it's aligning the actual behavior with the documented behavior so I'm calling it a bug fix.

Adjusting the locking in RealmCoordinator made the pre-existing race condition with ExternalCommitHelper and SyncSession's init start actually causing thread sanitizer errors. I shuffled around the initialization order so that we always do create sync session -> create external commit helper -> set sync session callback (which references the helper) while holding the realm mutex, which I think is fully safe and doesn't require mutex locking on further usage.

Fixes https://github.com/realm/realm-swift/issues/7625. Does not fully fix the qos inversion issues (https://github.com/realm/realm-core/issues/5697, https://github.com/realm/realm-swift/issues/7902), but should eliminate the most common cause of qos inversions.