### PR TITLE
Wait for download completion when downloading fresh FLX realm in client reset

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@
 * Fix sorting order for `realm_query_find_first` in the C API.([#5720](https://github.com/realm/realm-core/issues/5720))
 * Upload completion callbacks may have called before the download message that completed them was fully integrated. ([#4865](https://github.com/realm/realm-core/issues/4865)).
 * Syncing of a Decimal128 with big significand could result in a crash. ([#5728](https://github.com/realm/realm-core/issues/5728))
+* Recovery/discardLocal client reset modes will now wait for FLX sync realms to be fully synchronized before beginning recovery operations ([#5705](https://github.com/realm/realm-core/issues/5705))
 
 
 ### Breaking changes


### PR DESCRIPTION
## What, How & Why?
This is a stop-gap fix for #5705 that makes it so that downloading a fresh realm waits for download completion when handling a client reset with FLX sync. @ironage  is there anywhere else that we'd need to add a wait_for_download_completion?

## ☑️ ToDos
* [x] 📝 Changelog update
~* [ ] 🚦 Tests (or not relevant)~
~* [ ] C-API, if public C++ API changed.~
