### PR TITLE
Fix compilation on musl

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@
 * Fix sorting order for `realm_query_find_first` in the C API.([#5720](https://github.com/realm/realm-core/issues/5720))
 * Upload completion callbacks may have called before the download message that completed them was fully integrated. ([#4865](https://github.com/realm/realm-core/issues/4865)).
 * Syncing of a Decimal128 with big significand could result in a crash. ([#5728](https://github.com/realm/realm-core/issues/5728))
+* Fix compilation on musl libc ([realm-dotnet #2847](https://github.com/realm/realm-dotnet/issues/2847))
 
 
 ### Breaking changes

--- a/src/realm/util/backtrace.cpp
+++ b/src/realm/util/backtrace.cpp
@@ -23,13 +23,13 @@
 #include <cstdlib>
 #include <cstring>
 
-#if REALM_PLATFORM_APPLE || (defined(__linux__) && !REALM_ANDROID)
+#if REALM_PLATFORM_APPLE || (defined(__linux__) && !REALM_ANDROID && __GLIBC__)
 #include <execinfo.h>
 #endif
 
 using namespace realm::util;
 
-#if REALM_PLATFORM_APPLE || (defined(__linux__) && !REALM_ANDROID)
+#if REALM_PLATFORM_APPLE || (defined(__linux__) && !REALM_ANDROID && __GLIBC__)
 static const size_t g_backtrace_depth = 128;
 #endif
 static const char* g_backtrace_error = "<error calculating backtrace>";
@@ -105,7 +105,7 @@ Backtrace& Backtrace::operator=(const Backtrace& other) noexcept
 
 Backtrace Backtrace::capture() noexcept
 {
-#if REALM_PLATFORM_APPLE || (defined(__linux__) && !REALM_ANDROID)
+#if REALM_PLATFORM_APPLE || (defined(__linux__) && !REALM_ANDROID && __GLIBC__)
     static_cast<void>(g_backtrace_unsupported_error);
     void* callstack[g_backtrace_depth];
     int frames = ::backtrace(callstack, g_backtrace_depth);

--- a/src/realm/util/basic_system_errors.cpp
+++ b/src/realm/util/basic_system_errors.cpp
@@ -65,7 +65,7 @@ std::string system_category::message(int value) const
         }
     }
 
-#elif !REALM_ANDROID && _GNU_SOURCE // GNU specific version
+#elif !REALM_ANDROID && __GLIBC__ // GNU specific version
 
     {
         char* msg = nullptr;

--- a/src/realm/util/file.cpp
+++ b/src/realm/util/file.cpp
@@ -835,12 +835,6 @@ void File::prealloc(size_t size)
 #endif
     };
 
-#if defined(_POSIX_C_SOURCE) && _POSIX_C_SOURCE >= 200112L // POSIX.1-2001 version
-    // Mostly Linux only
-    if (!prealloc_if_supported(0, new_size)) {
-        consume_space_interlocked();
-    }
-#else // Non-atomic fallback
 #if REALM_PLATFORM_APPLE
     // posix_fallocate() is not supported on MacOS or iOS, so use a combination of fcntl(F_PREALLOCATE) and
     // ftruncate().
@@ -901,15 +895,14 @@ void File::prealloc(size_t size)
         // so this is some other runtime error and not OutOfDiskSpace
         throw std::system_error(err, std::system_category(), "ftruncate() inside prealloc() failed");
     }
-#elif REALM_ANDROID || defined(_WIN32)
-
-    consume_space_interlocked();
-
 #else
-#error Please check if/how your OS supports file preallocation
-#endif
 
-#endif // !(_POSIX_C_SOURCE >= 200112L)
+    // Mostly Linux only
+    if (!prealloc_if_supported(0, new_size)) {
+        consume_space_interlocked();
+    }
+
+#endif // REALM_PLATFORM_APPLE
 }
 
 

--- a/src/realm/util/file.hpp
+++ b/src/realm/util/file.hpp
@@ -30,6 +30,7 @@
 
 #ifndef _WIN32
 #include <dirent.h> // POSIX.1-2001
+#include <sys/stat.h>
 #endif
 
 #include <realm/utilities.hpp>


### PR DESCRIPTION
## What, How & Why?
Add glibc guard for execinfo.h usage, rejigger File::prealloc ifdefs to avoid a #error, and do a few other small things to fix compilation errors on musl

We should probably switch to [FindBacktrace](https://cmake.org/cmake/help/latest/module/FindBacktrace.html) rather than using #ifdef guards for backtrace support, I can take a look at that in the near future if you'd like. In addition, I don't think your usage of _POSIX_C_SOURCE to test whether posix_fallocate is available is correct - iiuc feature test macros like that are used by the program to get libc to expose things, not for the program to test whether libc supports them. I'm not really sure what the alternative is, though. This isn't a huge deal - the fallback here is perfectly fine and (I'm guessing) will only be unnecessarily hit on musl, but let me know if you have any insights.

## ☑️ ToDos
* [x] 📝 Changelog update