### PR TITLE
Add support for CCache when CMake XCode Generator.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -5,6 +5,9 @@ project(RealmCore)
 
 list(APPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_SOURCE_DIR}/tools/cmake")
 
+# Load work-around for using ccache with XCode generator
+include(XCodeGeneratorCCacheSupport)
+
 if(NOT CMAKE_SOURCE_DIR STREQUAL ${CMAKE_CURRENT_SOURCE_DIR})
     # Realm Core is being built as part of another project, likely an SDK
     set(REALM_CORE_SUBMODULE_BUILD ON)

--- a/tools/cmake/XCodeGeneratorCCacheSupport.cmake
+++ b/tools/cmake/XCodeGeneratorCCacheSupport.cmake
@@ -4,14 +4,15 @@
 #
 # See # See https://crascit.com/2016/04/09/using-ccache-with-cmake/#h-improved-functionality-from-cmake-3-4
 #
-# The work-around mentioned in the above link modified slightly to also work when Realm Core is used through
+# The work-around mentioned in the above link is modified to also work when Realm Core is used through
 # `add_subdirectory()`.
-#
+
 find_program(CCACHE_PROGRAM ccache)
 if(CCACHE_PROGRAM)
-    message(STATUS "Found ccache. Copying launcher scripts from ${PROJECT_SOURCE_DIR} to ${PROJECT_BINARY_DIR}")
-
     # Set up wrapper scripts
+    # Note: this will override any other user-defined CMAKE_C_COMPILER_LAUNCHER or CMAKE_CXX_COMPILER_LAUNCHER settings.
+
+    message(STATUS "Found ccache. Copying launcher scripts from ${PROJECT_SOURCE_DIR} to ${PROJECT_BINARY_DIR}")
     set(C_LAUNCHER   "${CCACHE_PROGRAM}")
     set(CXX_LAUNCHER "${CCACHE_PROGRAM}")
     configure_file("${PROJECT_SOURCE_DIR}/tools/cmake/launch-c.in" "${PROJECT_BINARY_DIR}/launch-c")

--- a/tools/cmake/XCodeGeneratorCCacheSupport.cmake
+++ b/tools/cmake/XCodeGeneratorCCacheSupport.cmake
@@ -1,17 +1,13 @@
 # Work-around for the XCode Generator not working correctly with CCache.
-# While not needed for Ninja and Makefiles, use the same helper scripts 
+# While not needed for Ninja and Makefiles, we use the same helper scripts 
 # to ensure that all build types are routed through the same code path.
 #
-# See # See https://crascit.com/2016/04/09/using-ccache-with-cmake/#h-improved-functionality-from-cmake-3-4
-#
-# The work-around mentioned in the above link is modified to also work when Realm Core is used through
-# `add_subdirectory()`.
-
+# The work-around was lifted from https://crascit.com/2016/04/09/using-ccache-with-cmake/#h-improved-functionality-from-cmake-3-4
+# and modified, so it also works when Realm Core is added using `add_subdirectory()`.
 find_program(CCACHE_PROGRAM ccache)
 if(CCACHE_PROGRAM)
     # Set up wrapper scripts
-    # Note: this will override any other user-defined CMAKE_C_COMPILER_LAUNCHER or CMAKE_CXX_COMPILER_LAUNCHER settings.
-
+    # Note: this will override any user-defined CMAKE_C_COMPILER_LAUNCHER or CMAKE_CXX_COMPILER_LAUNCHER settings.
     message(STATUS "Found ccache. Copying launcher scripts from ${PROJECT_SOURCE_DIR} to ${PROJECT_BINARY_DIR}")
     set(C_LAUNCHER   "${CCACHE_PROGRAM}")
     set(CXX_LAUNCHER "${CCACHE_PROGRAM}")

--- a/tools/cmake/XCodeGeneratorCCacheSupport.cmake
+++ b/tools/cmake/XCodeGeneratorCCacheSupport.cmake
@@ -1,31 +1,36 @@
 # Work-around for the XCode Generator not working correctly with CCache.
-# While not needed for Ninja and Makefiles, they use the same helper scripts 
+# While not needed for Ninja and Makefiles, use the same helper scripts 
 # to ensure that all build types are routed through the same code path.
 #
 # See # See https://crascit.com/2016/04/09/using-ccache-with-cmake/#h-improved-functionality-from-cmake-3-4
-
+#
+# The work-around mentioned in the above link modified slightly to also work when Realm Core is used through
+# `add_subdirectory()`.
+#
 find_program(CCACHE_PROGRAM ccache)
 if(CCACHE_PROGRAM)
+    message(STATUS "Found ccache. Copying launcher scripts from ${PROJECT_SOURCE_DIR} to ${PROJECT_BINARY_DIR}")
+
     # Set up wrapper scripts
     set(C_LAUNCHER   "${CCACHE_PROGRAM}")
     set(CXX_LAUNCHER "${CCACHE_PROGRAM}")
-    configure_file(./tools/cmake/launch-c.in launch-c)
-    configure_file(./tools/cmake/launch-cxx.in launch-cxx)
+    configure_file("${PROJECT_SOURCE_DIR}/tools/cmake/launch-c.in" "${PROJECT_BINARY_DIR}/launch-c")
+    configure_file("${PROJECT_SOURCE_DIR}/tools/cmake/launch-cxx.in" "${PROJECT_BINARY_DIR}/launch-cxx")
     execute_process(COMMAND chmod a+rx
-                     "${CMAKE_BINARY_DIR}/launch-c"
-                     "${CMAKE_BINARY_DIR}/launch-cxx"
+                     "${PROJECT_BINARY_DIR}/launch-c"
+                     "${PROJECT_BINARY_DIR}/launch-cxx"
     )
 
     if(CMAKE_GENERATOR STREQUAL "Xcode")
         # Set Xcode project attributes to route compilation and linking
         # through our scripts
-        set(CMAKE_XCODE_ATTRIBUTE_CC         "${CMAKE_BINARY_DIR}/launch-c")
-        set(CMAKE_XCODE_ATTRIBUTE_CXX        "${CMAKE_BINARY_DIR}/launch-cxx")
-        set(CMAKE_XCODE_ATTRIBUTE_LD         "${CMAKE_BINARY_DIR}/launch-c")
-        set(CMAKE_XCODE_ATTRIBUTE_LDPLUSPLUS "${CMAKE_BINARY_DIR}/launch-cxx")
+        set(CMAKE_XCODE_ATTRIBUTE_CC         "${PROJECT_BINARY_DIR}/launch-c")
+        set(CMAKE_XCODE_ATTRIBUTE_CXX        "${PROJECT_BINARY_DIR}/launch-cxx")
+        set(CMAKE_XCODE_ATTRIBUTE_LD         "${PROJECT_BINARY_DIR}/launch-c")
+        set(CMAKE_XCODE_ATTRIBUTE_LDPLUSPLUS "${PROJECT_BINARY_DIR}/launch-cxx")
     else()
         # Support Unix Makefiles and Ninja
-        set(CMAKE_C_COMPILER_LAUNCHER   "${CMAKE_BINARY_DIR}/launch-c")
-        set(CMAKE_CXX_COMPILER_LAUNCHER "${CMAKE_BINARY_DIR}/launch-cxx")
+        set(CMAKE_C_COMPILER_LAUNCHER   "${PROJECT_BINARY_DIR}/launch-c")
+        set(CMAKE_CXX_COMPILER_LAUNCHER "${PROJECT_BINARY_DIR}/launch-cxx")
     endif()
  endif()

--- a/tools/cmake/XCodeGeneratorCCacheSupport.cmake
+++ b/tools/cmake/XCodeGeneratorCCacheSupport.cmake
@@ -1,0 +1,31 @@
+# Work-around for the XCode Generator not working correctly with CCache.
+# While not needed for Ninja and Makefiles, they use the same helper scripts 
+# to ensure that all build types are routed through the same code path.
+#
+# See # See https://crascit.com/2016/04/09/using-ccache-with-cmake/#h-improved-functionality-from-cmake-3-4
+
+find_program(CCACHE_PROGRAM ccache)
+if(CCACHE_PROGRAM)
+    # Set up wrapper scripts
+    set(C_LAUNCHER   "${CCACHE_PROGRAM}")
+    set(CXX_LAUNCHER "${CCACHE_PROGRAM}")
+    configure_file(./tools/cmake/launch-c.in launch-c)
+    configure_file(./tools/cmake/launch-cxx.in launch-cxx)
+    execute_process(COMMAND chmod a+rx
+                     "${CMAKE_BINARY_DIR}/launch-c"
+                     "${CMAKE_BINARY_DIR}/launch-cxx"
+    )
+
+    if(CMAKE_GENERATOR STREQUAL "Xcode")
+        # Set Xcode project attributes to route compilation and linking
+        # through our scripts
+        set(CMAKE_XCODE_ATTRIBUTE_CC         "${CMAKE_BINARY_DIR}/launch-c")
+        set(CMAKE_XCODE_ATTRIBUTE_CXX        "${CMAKE_BINARY_DIR}/launch-cxx")
+        set(CMAKE_XCODE_ATTRIBUTE_LD         "${CMAKE_BINARY_DIR}/launch-c")
+        set(CMAKE_XCODE_ATTRIBUTE_LDPLUSPLUS "${CMAKE_BINARY_DIR}/launch-cxx")
+    else()
+        # Support Unix Makefiles and Ninja
+        set(CMAKE_C_COMPILER_LAUNCHER   "${CMAKE_BINARY_DIR}/launch-c")
+        set(CMAKE_CXX_COMPILER_LAUNCHER "${CMAKE_BINARY_DIR}/launch-cxx")
+    endif()
+ endif()

--- a/tools/cmake/launch-c.in
+++ b/tools/cmake/launch-c.in
@@ -1,0 +1,12 @@
+#!/bin/sh
+
+# See https://crascit.com/2016/04/09/using-ccache-with-cmake/#h-improved-functionality-from-cmake-3-4
+
+# Xcode generator doesn't include the compiler as the
+# first argument, Ninja and Makefiles do. Handle both cases.
+if [[ "$1" = "${CMAKE_C_COMPILER}" ]] ; then
+    shift
+fi
+
+export CCACHE_CPP2=true
+exec "${C_LAUNCHER}" "${CMAKE_C_COMPILER}" "$@"

--- a/tools/cmake/launch-cxx.in
+++ b/tools/cmake/launch-cxx.in
@@ -1,0 +1,12 @@
+#!/bin/sh
+
+# See https://crascit.com/2016/04/09/using-ccache-with-cmake/#h-improved-functionality-from-cmake-3-4
+
+# Xcode generator doesn't include the compiler as the
+# first argument, Ninja and Makefiles do. Handle both cases.
+if [[ "$1" = "${CMAKE_CXX_COMPILER}" ]] ; then
+    shift
+fi
+
+export CCACHE_CPP2=true
+exec "${CXX_LAUNCHER}" "${CMAKE_CXX_COMPILER}" "$@"


### PR DESCRIPTION
After trying to enable ccache for building Core on Github Actions, it turned out that there was a problem with it not working when using the XCode generator. This is described here: https://crascit.com/2016/04/09/using-ccache-with-cmake/#h-improved-functionality-from-cmake-3-4

This PR adds the required changes so the XCode Generator also works with ccache. The changes have been validated on the Kotlin project which both uses Make and XCode generators. 

I'm a bit unsure if you want to add this support as is, or if I should put in some kind of opt-in flag? Right now it picks up ccache automatically if found on the environment path.