### PR TITLE
fix a race in the test 'a Realm can be reset twice'

### DIFF
--- a/test/object-store/sync/sync_test_utils.cpp
+++ b/test/object-store/sync/sync_test_utils.cpp
@@ -394,13 +394,14 @@ struct BaasClientReset : public TestClientReset {
             std::string pk_col_name = table->get_column_name(table->get_primary_key_column());
             obj.set(col, 1);
             obj.set(col, 2);
-            obj.set(col, 3);
+            constexpr int64_t last_synced_value = 3;
+            obj.set(col, last_synced_value);
             realm->commit_transaction();
             wait_for_upload(*realm);
             wait_for_download(*realm);
 
             wait_for_object_to_persist(m_local_config.sync_config->user, app_session, object_schema_name,
-                                       {{pk_col_name, m_pk_driving_reset}});
+                                       {{pk_col_name, m_pk_driving_reset}, {"value", last_synced_value}});
 
             session->log_out();
 


### PR DESCRIPTION
The client reset test harness relies on finding a recently added object in the backend before continuing. For the test "a Realm can be reset twice" this object already exists from the first reset, so we also need to wait for an expected field value to persist before continuing.

This should fix the following test failure:

```
[2022/09/02 20:09:12.901] 7.759 s: sync: client reset
[2022/09/02 20:09:12.901] ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
[2022/09/02 20:09:12.901] realm-object-store-tests is a Catch2 v3.0.1 host application.
[2022/09/02 20:09:12.901] Run with -? for options
[2022/09/02 20:09:12.901] -------------------------------------------------------------------------------
[2022/09/02 20:09:12.901] sync: client reset
[2022/09/02 20:09:12.901]   discard local
[2022/09/02 20:09:12.901]   modify
[2022/09/02 20:09:12.901]   a Realm can be reset twice
[2022/09/02 20:09:12.901] -------------------------------------------------------------------------------
[2022/09/02 20:09:12.901] ../test/object-store/sync/client_reset.cpp:620
[2022/09/02 20:09:12.901] ...............................................................................
[2022/09/02 20:09:12.901] ../test/object-store/sync/sync_test_utils.cpp:451: FAILED:
[2022/09/02 20:09:12.901]   REQUIRE( obj.get_any(col) == Mixed{3} )
[2022/09/02 20:09:12.901] with expansion:
[2022/09/02 20:09:12.901]   6 == 3
[2022/09/02 20:09:12.901] Assertion failure: ../test/object-store/sync/sync_test_utils.cpp:451
[2022/09/02 20:09:12.901] 	 from expresion: 'obj.get_any(col) == Mixed{3}'
[2022/09/02 20:09:12.901] 	 with expansion: '6 == 3'
[2022/09/02 20:09:12.901] Connection[6]: Session[6]: Initiating deactivation
[2022/09/02 20:09:12.901] Connection[6]: Session[6]: Sending: UNBIND
[2022/09/02 20:09:12.902] Connection[6]: Session[6]: Deactivation completed
[2022/09/02 20:09:12.902] Connection[6]: Disconnected
```
