### PR TITLE
Fix sometimes running out of disk space when running exFAT tests on CI

### DIFF
--- a/tools/run-tests-on-exfat.sh
+++ b/tools/run-tests-on-exfat.sh
@@ -34,6 +34,7 @@ device=$(echo "$hdiutil_out" | head -n1 | cut -f1 | awk '{$1=$1};1')
 path=$(echo "$hdiutil_out" | tail -n1 | cut -f3)
 
 UNITTEST_ENABLE_SYNC_TO_DISK=1 "$build_prefix/realm-tests.app/Contents/MacOS/realm-tests" "$path/"
-UNITTEST_ENABLE_SYNC_TO_DISK=1 "$build_prefix/realm-sync-tests.app/Contents/MacOS/realm-sync-tests" "$path/"
+# one test runner because several sync tests make large uploads which if run together may exceed our 400MB space limit
+UNITTEST_THREADS=1 UNITTEST_ENABLE_SYNC_TO_DISK=1 "$build_prefix/realm-sync-tests.app/Contents/MacOS/realm-sync-tests" "$path/"
 echo "finished running tests"
 


### PR DESCRIPTION
I noticed that sometimes the new exFAT tests [recently added](https://github.com/realm/realm-core/pull/5806) to CI are failing ([example](https://evergreen.mongodb.com/task/realm_core_stable_macos_release_test_on_exfat_c3b8e14a5f6b0d8dc7f655a8ac5ca040dc35beda_22_09_06_16_07_15)) with out of disk space errors such as:
`[2022/09/06 18:45:09.158] Thread[05]: /System/Volumes/Data/data/mci/3bb701c34a8c7885799a55fd63607d5f/realm-core/test/test_sync.cpp:4845: ERROR in Sync_VerifyServerHistoryAfterLargeUpload: Unhandled exception realm::OutOfDiskSpace: write() failed: No space left on device`

I think happens because we are running several tests that use a lot of disk space together in parallel. The fix is to use one test thread.