### PR TITLE
Expose `Obj::get_parent_object` in the C API

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ### Enhancements
 * <New feature description> (PR [#????](https://github.com/realm/realm-core/pull/????))
 * Convert object_store::Collection types into Results (PR [#5845](https://github.com/realm/realm-core/pull/5845))
+* Expose `realm_object_get_parent` in the C API (PR [#5851](https://github.com/realm/realm-core/pull/5851))
 
 ### Fixed
 * <How do the end-user experience this issue? what was the impact?> ([#????](https://github.com/realm/realm-core/issues/????), since v?.?.?)

--- a/src/realm.h
+++ b/src/realm.h
@@ -1409,6 +1409,12 @@ RLM_API bool realm_get_num_versions(const realm_t*, uint64_t* out_versions_count
 RLM_API realm_object_t* realm_get_object(const realm_t*, realm_class_key_t class_key, realm_object_key_t obj_key);
 
 /**
+ * Get the parent object for the object passed as argument.
+ *  @return A non-NULL pointer if the parent object exists.
+ */
+RLM_API bool realm_object_get_parent(const realm_object_t* object, realm_object_t* parent);
+
+/**
  * Find an object with a particular primary key value.
  *
  * @param out_found A pointer to a boolean that will be set to true or false if

--- a/src/realm/object-store/c_api/object.cpp
+++ b/src/realm/object-store/c_api/object.cpp
@@ -28,6 +28,16 @@ RLM_API realm_object_t* realm_get_object(const realm_t* realm, realm_class_key_t
     });
 }
 
+RLM_API bool realm_object_get_parent(const realm_object_t* object, realm_object_t* parent)
+{
+    return wrap_err([&]() {
+        if (parent)
+            *parent = realm_object_t{realm::Object{object->get_realm(), object->obj().get_parent_object()}};
+        return true;
+    });
+}
+
+
 RLM_API realm_object_t* realm_object_find_with_primary_key(const realm_t* realm, realm_class_key_t class_key,
                                                            realm_value_t pk, bool* out_found)
 {

--- a/src/realm/object-store/c_api/query.cpp
+++ b/src/realm/object-store/c_api/query.cpp
@@ -244,15 +244,11 @@ RLM_API realm_query_t* realm_query_parse_for_list(const realm_list_t* list, cons
                                                   const realm_query_arg_t* args)
 {
     return wrap_err([&]() {
-        auto existing_query = list->get_query();
         auto realm = list->get_realm();
         auto table = list->get_table();
         auto query = parse_and_apply_query(realm, table, query_string, num_args, args);
-        auto combined = existing_query.and_query(query);
-        auto ordering_copy = util::make_bind<DescriptorOrdering>();
-        if (auto ordering = query.get_ordering())
-            ordering_copy->append(*ordering);
-        return new realm_query_t{std::move(query), std::move(ordering_copy), realm};
+        auto ordering = query.get_ordering();
+        return new realm_query_t{std::move(query), std::move(ordering), realm};
     });
 }
 

--- a/src/realm/object-store/c_api/query.cpp
+++ b/src/realm/object-store/c_api/query.cpp
@@ -244,11 +244,15 @@ RLM_API realm_query_t* realm_query_parse_for_list(const realm_list_t* list, cons
                                                   const realm_query_arg_t* args)
 {
     return wrap_err([&]() {
+        auto existing_query = list->get_query();
         auto realm = list->get_realm();
         auto table = list->get_table();
         auto query = parse_and_apply_query(realm, table, query_string, num_args, args);
-        auto ordering = query.get_ordering();
-        return new realm_query_t{std::move(query), std::move(ordering), realm};
+        auto combined = existing_query.and_query(query);
+        auto ordering_copy = util::make_bind<DescriptorOrdering>();
+        if (auto ordering = query.get_ordering())
+            ordering_copy->append(*ordering);
+        return new realm_query_t{std::move(query), std::move(ordering_copy), realm};
     });
 }
 


### PR DESCRIPTION
## What, How & Why?
Fixes: https://github.com/realm/realm-core/issues/5837

## ☑️ ToDos
* [ ] 📝 Changelog update
* [ ] 🚦 Tests (or not relevant)
* [ ] C-API, if public C++ API changed.
