### PR TITLE
Traversal functions use IteratorControl values rather than true/false

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,7 +25,7 @@
 -----------
 
 ### Internals
-* None.
+* Traversal functions use a typed IteratorControl value rather than true/false. ([#5857](https://github.com/realm/realm-core/issues/5857))
 
 ----------------------------------------------
 

--- a/src/realm/bplustree.cpp
+++ b/src/realm/bplustree.cpp
@@ -218,7 +218,7 @@ size_t BPlusTreeLeaf::bptree_erase(size_t ndx, EraseFunc func)
 
 bool BPlusTreeLeaf::bptree_traverse(TraverseFunc func)
 {
-    return func(this, 0);
+    return func(this, 0) == IteratorControl::Stop;
 }
 
 /****************************** BPlusTreeInner *******************************/
@@ -465,7 +465,7 @@ bool BPlusTreeInner::bptree_traverse(TraverseFunc func)
         bool child_is_leaf = !Array::get_is_inner_bptree_node_from_header(child_header);
         if (child_is_leaf) {
             auto leaf = cache_leaf(mem, i, child_offset + m_my_offset);
-            done = func(leaf, child_offset + m_my_offset);
+            done = (func(leaf, child_offset + m_my_offset) == IteratorControl::Stop);
         }
         else {
             BPlusTreeInner node(m_tree);

--- a/src/realm/bplustree.hpp
+++ b/src/realm/bplustree.hpp
@@ -50,8 +50,8 @@ public:
     // Erase element at erase_pos. May cause nodes to be merged
     using EraseFunc = util::FunctionRef<size_t(BPlusTreeNode*, size_t erase_pos)>;
     // Function to be called for all leaves in the tree until the function
-    // returns 'true'. 'offset' gives index of the first element in the leaf.
-    using TraverseFunc = util::FunctionRef<bool(BPlusTreeNode*, size_t offset)>;
+    // returns 'IteratorControl::Stop'. 'offset' gives index of the first element in the leaf.
+    using TraverseFunc = util::FunctionRef<IteratorControl(BPlusTreeNode*, size_t offset)>;
 
     BPlusTreeNode(BPlusTreeBase* tree)
         : m_tree(tree)
@@ -392,7 +392,7 @@ public:
             for (size_t i = 0; i < sz; i++) {
                 all_values.push_back(leaf->get(i));
             }
-            return false;
+            return IteratorControl::AdvanceToNext;
         };
 
         m_root->bptree_traverse(func);
@@ -497,9 +497,9 @@ public:
             auto i = leaf->find_first(value, 0, sz);
             if (i < sz) {
                 result = i + offset;
-                return true;
+                return IteratorControl::Stop;
             }
-            return false;
+            return IteratorControl::AdvanceToNext;
         };
 
         m_root->bptree_traverse(func);
@@ -516,7 +516,7 @@ public:
             while ((i = leaf->find_first(value, i + 1, sz)) < sz) {
                 callback(i + offset);
             }
-            return false;
+            return IteratorControl::AdvanceToNext;
         };
 
         m_root->bptree_traverse(func);
@@ -532,7 +532,7 @@ public:
             for (size_t i = 0; i < sz; i++) {
                 o << indent << leaf->get(i) << std::endl;
             }
-            return false;
+            return IteratorControl::AdvanceToNext;
         };
 
         m_root->bptree_traverse(func);
@@ -593,7 +593,7 @@ typename SumAggType<T>::ResultType bptree_sum(const BPlusTree<T>& tree, size_t* 
             auto val = leaf->get(i);
             agg.accumulate(val);
         }
-        return false;
+        return IteratorControl::AdvanceToNext;
     };
 
     tree.traverse(func);
@@ -625,7 +625,7 @@ util::Optional<typename util::RemoveOptional<T>::type> bptree_min_max(const BPlu
                 *return_ndx = i + offset;
             }
         }
-        return false;
+        return IteratorControl::AdvanceToNext;
     };
 
     tree.traverse(func);

--- a/src/realm/cluster.cpp
+++ b/src/realm/cluster.cpp
@@ -133,7 +133,7 @@ void Cluster::create()
             arr.create();
             arr.set_parent(this, col_ndx.val + s_first_col_index);
             arr.update_parent();
-            return false;
+            return IteratorControl::AdvanceToNext;
         }
         switch (type) {
             case col_type_Int:
@@ -192,7 +192,7 @@ void Cluster::create()
             default:
                 throw LogicError(LogicError::illegal_type);
         }
-        return false;
+        return IteratorControl::AdvanceToNext;
     };
     m_tree_top.for_each_and_every_column(column_initialize);
 
@@ -373,7 +373,7 @@ void Cluster::insert_row(size_t ndx, ObjKey k, const FieldValues& init_values)
             arr.set_parent(this, col_ndx.val + s_first_col_index);
             arr.init_from_parent();
             arr.insert(ndx, 0);
-            return false;
+            return IteratorControl::AdvanceToNext;
         }
 
         bool nullable = attr.test(col_attr_Nullable);
@@ -434,7 +434,7 @@ void Cluster::insert_row(size_t ndx, ObjKey k, const FieldValues& init_values)
                 REALM_ASSERT(false);
                 break;
         }
-        return false;
+        return IteratorControl::AdvanceToNext;
     };
     m_tree_top.for_each_and_every_column(insert_in_column);
 }
@@ -464,7 +464,7 @@ void Cluster::move(size_t ndx, ClusterNode* new_node, int64_t offset)
 
         if (attr.test(col_attr_Collection)) {
             do_move<ArrayRef>(ndx, col_key, new_leaf);
-            return false;
+            return IteratorControl::AdvanceToNext;
         }
 
         switch (type) {
@@ -523,7 +523,7 @@ void Cluster::move(size_t ndx, ClusterNode* new_node, int64_t offset)
                 REALM_ASSERT(false);
                 break;
         }
-        return false;
+        return IteratorControl::AdvanceToNext;
     };
     m_tree_top.for_each_and_every_column(move_from_column);
     for (size_t i = ndx; i < m_keys.size(); i++) {
@@ -878,7 +878,7 @@ size_t Cluster::erase(ObjKey key, CascadeState& state)
 
             values.erase(ndx);
 
-            return false;
+            return IteratorControl::AdvanceToNext;
         }
 
         switch (col_type) {
@@ -942,7 +942,7 @@ size_t Cluster::erase(ObjKey key, CascadeState& state)
                 REALM_ASSERT(false);
                 break;
         }
-        return false;
+        return IteratorControl::AdvanceToNext;
     };
     m_tree_top.for_each_and_every_column(erase_in_column);
 
@@ -1003,7 +1003,7 @@ void Cluster::nullify_incoming_links(ObjKey key, CascadeState& state)
         values.copy_on_write();
         values.nullify_fwd_links(ndx, state);
 
-        return false;
+        return IteratorControl::AdvanceToNext;
     };
 
     m_tree_top.get_owning_table()->for_each_backlink_column(nullify_fwd_links);
@@ -1165,7 +1165,7 @@ void Cluster::verify() const
                     // FIXME: Nullable primitives
                     break;
             }
-            return false;
+            return IteratorControl::AdvanceToNext;
         }
         else if (attr.test(col_attr_Dictionary)) {
             ArrayRef arr(get_alloc());
@@ -1186,7 +1186,7 @@ void Cluster::verify() const
                     cluster.verify();
                 }
             }
-            return false;
+            return IteratorControl::AdvanceToNext;
         }
         else if (attr.test(col_attr_Set)) {
             ArrayRef arr(get_alloc());
@@ -1242,7 +1242,7 @@ void Cluster::verify() const
                     // FIXME: Nullable primitives
                     break;
             }
-            return false;
+            return IteratorControl::AdvanceToNext;
         }
 
         switch (col_type) {
@@ -1293,7 +1293,7 @@ void Cluster::verify() const
             default:
                 break;
         }
-        return false;
+        return IteratorControl::AdvanceToNext;
     };
 
     m_tree_top.for_each_and_every_column(verify_column);
@@ -1339,7 +1339,7 @@ void Cluster::dump_objects(int64_t key_offset, std::string lead) const
                     }
                 }
                 std::cout << "}";
-                return false;
+                return IteratorControl::AdvanceToNext;
             }
 
             switch (col.get_type()) {
@@ -1391,7 +1391,6 @@ void Cluster::dump_objects(int64_t key_offset, std::string lead) const
                         std::cout << ", " << *val;
                     else
                         std::cout << ", null";
-                    break;
                     break;
                 }
                 case col_type_String: {
@@ -1477,7 +1476,7 @@ void Cluster::dump_objects(int64_t key_offset, std::string lead) const
                     std::cout << ", Error";
                     break;
             }
-            return false;
+            return IteratorControl::AdvanceToNext;
         });
         std::cout << std::endl;
     }

--- a/src/realm/cluster_tree.cpp
+++ b/src/realm/cluster_tree.cpp
@@ -692,7 +692,7 @@ bool ClusterNodeInner::traverse(ClusterTree::TraverseFunction func, int64_t key_
         if (child_is_leaf) {
             Cluster leaf(offs, m_alloc, m_tree_top);
             leaf.init(mem);
-            if (func(&leaf)) {
+            if (func(&leaf) == IteratorControl::Stop) {
                 return true;
             }
         }
@@ -994,7 +994,7 @@ bool ClusterTree::get_leaf(ObjKey key, ClusterNode::IteratorState& state) const 
 bool ClusterTree::traverse(TraverseFunction func) const
 {
     if (m_root->is_leaf()) {
-        return func(static_cast<Cluster*>(m_root.get()));
+        return func(static_cast<Cluster*>(m_root.get())) == IteratorControl::Stop;
     }
     else {
         return static_cast<ClusterNodeInner*>(m_root.get())->traverse(func, 0);
@@ -1016,7 +1016,7 @@ void ClusterTree::verify() const
 #ifdef REALM_DEBUG
     traverse([](const Cluster* cluster) {
         cluster->verify();
-        return false;
+        return IteratorControl::AdvanceToNext;
     });
 #endif
 }

--- a/src/realm/cluster_tree.hpp
+++ b/src/realm/cluster_tree.hpp
@@ -29,9 +29,9 @@ class Cluster;
 class ClusterTree {
 public:
     class Iterator;
-    using TraverseFunction = util::FunctionRef<bool(const Cluster*)>;
+    using TraverseFunction = util::FunctionRef<IteratorControl(const Cluster*)>;
     using UpdateFunction = util::FunctionRef<void(Cluster*)>;
-    using ColIterateFunction = util::FunctionRef<bool(ColKey)>;
+    using ColIterateFunction = util::FunctionRef<IteratorControl(ColKey)>;
 
     ClusterTree(Allocator& alloc);
     virtual ~ClusterTree();
@@ -146,7 +146,7 @@ public:
     size_t get_ndx(ObjKey k) const noexcept;
     // Find the leaf containing the requested object
     bool get_leaf(ObjKey key, ClusterNode::IteratorState& state) const noexcept;
-    // Visit all leaves and call the supplied function. Stop when function returns true.
+    // Visit all leaves and call the supplied function. Stop when function returns IteratorControl::Stop.
     // Not allowed to modify the tree
     bool traverse(TraverseFunction func) const;
     // Visit all leaves and call the supplied function. The function can modify the leaf.

--- a/src/realm/collection.cpp
+++ b/src/realm/collection.cpp
@@ -24,14 +24,14 @@ size_t virtual2real(const BPlusTree<ObjKey>* tree, size_t ndx) noexcept
             size_t sz = leaf->size();
             for (size_t i = 0; i < sz; i++) {
                 if (i + offset == ndx) {
-                    return true;
+                    return IteratorControl::Stop;
                 }
                 auto k = leaf->get(i);
                 if (k.is_unresolved()) {
                     adjust++;
                 }
             }
-            return false;
+            return IteratorControl::AdvanceToNext;
         };
 
         tree->traverse(func);
@@ -63,7 +63,7 @@ void update_unresolved(std::vector<size_t>& vec, const BPlusTree<ObjKey>* tree)
                     vec.push_back(i + offset);
                 }
             }
-            return false;
+            return IteratorControl::AdvanceToNext;
         };
 
         tree->traverse(func);

--- a/src/realm/dictionary.cpp
+++ b/src/realm/dictionary.cpp
@@ -197,8 +197,7 @@ void DictionaryClusterTree::do_accumulate(size_t* return_ndx, AggregateType& agg
             }
         }
         start_ndx += e;
-        // Continue
-        return false;
+        return IteratorControl::AdvanceToNext;
     });
 
     if (return_ndx)
@@ -375,12 +374,11 @@ size_t Dictionary::find_any(Mixed value) const
             for (size_t i = 0; i < e; i++) {
                 if (leaf.get(i) == value) {
                     ret = start_ndx + i;
-                    return true;
+                    return IteratorControl::Stop;
                 }
             }
             start_ndx += e;
-            // Continue
-            return false;
+            return IteratorControl::AdvanceToNext;
         });
     }
 

--- a/src/realm/dictionary.hpp
+++ b/src/realm/dictionary.hpp
@@ -112,8 +112,7 @@ public:
                 for (size_t i = 0; i < e; i++) {
                     f(leaf.get(i));
                 }
-                // Continue
-                return false;
+                return IteratorControl::AdvanceToNext;
             };
             m_clusters->traverse(trv_func);
         }
@@ -132,8 +131,7 @@ public:
                 for (size_t i = 0; i < e; i++) {
                     f(leaf.get(i));
                 }
-                // Continue
-                return false;
+                return IteratorControl::AdvanceToNext;
             };
             m_clusters->traverse(trv_func);
         }

--- a/src/realm/obj_list.hpp
+++ b/src/realm/obj_list.hpp
@@ -76,7 +76,7 @@ public:
         auto sz = size();
         for (size_t i = 0; i < sz; i++) {
             auto o = try_get_object(i);
-            if (o && func(o))
+            if (o && func(o) == IteratorControl::Stop)
                 return;
         }
     }

--- a/src/realm/object-store/impl/deep_change_checker.cpp
+++ b/src/realm/object-store/impl/deep_change_checker.cpp
@@ -82,7 +82,7 @@ void DeepChangeChecker::find_related_tables(std::vector<RelatedTable>& related_t
                 })) {
                 backlinks->backlink_tables.push_back(cur_table->get_link_target(backlink_col_key)->get_key());
             }
-            return false;
+            return IteratorControl::AdvanceToNext;
         });
     }
 

--- a/src/realm/query_expression.cpp
+++ b/src/realm/query_expression.cpp
@@ -160,8 +160,7 @@ void LinkMap::map_links(size_t column, size_t row, LinkMapFunction& lm) const
                             }
                         }
                     }
-                    // Continue
-                    return false;
+                    return IteratorControl::AdvanceToNext;
                 });
             }
         }
@@ -344,8 +343,7 @@ void ColumnDictionaryKeys::evaluate(size_t index, ValueBase& destination)
                     destination.set(n, leaf.get(i));
                     n++;
                 }
-                // Continue
-                return false;
+                return IteratorControl::AdvanceToNext;
             });
         }
     }
@@ -482,8 +480,7 @@ void Columns<Dictionary>::evaluate(size_t index, ValueBase& destination)
                     destination.set(n, leaf.get(i));
                     n++;
                 }
-                // Continue
-                return false;
+                return IteratorControl::AdvanceToNext;
             });
         }
     }

--- a/src/realm/sync/noinst/pending_bootstrap_store.cpp
+++ b/src/realm/sync/noinst/pending_bootstrap_store.cpp
@@ -138,7 +138,7 @@ void PendingBootstrapStore::add_batch(int64_t query_version, util::Optional<Sync
     auto incomplete_bootstraps = Query(bootstrap_table).not_equal(m_query_version, query_version).find_all();
     incomplete_bootstraps.for_each([&](Obj obj) {
         m_logger->debug("Clearing incomplete bootstrap for query version %1", obj.get<int64_t>(m_query_version));
-        return false;
+        return IteratorControl::AdvanceToNext;
     });
     incomplete_bootstraps.clear();
 

--- a/src/realm/table.cpp
+++ b/src/realm/table.cpp
@@ -1104,7 +1104,7 @@ void Table::set_embedded(bool embedded)
     bool has_backlink_columns = false;
     for_each_backlink_column([&has_backlink_columns](ColKey) {
         has_backlink_columns = true;
-        return true;
+        return IteratorControl::Stop;
     });
     if (!has_backlink_columns) {
         throw std::logic_error(
@@ -1135,7 +1135,7 @@ void Table::set_embedded(bool embedded)
                     throw std::logic_error(
                         util::format("At least one object in '%1' does have multiple backlinks.", get_name()));
                 }
-                return false; // continue
+                return IteratorControl::AdvanceToNext; // continue
             });
 
             if (backlink_count == 0) {
@@ -1554,7 +1554,7 @@ void Table::create_columns()
     size_t cnt;
     auto get_column_cnt = [&cnt](const Cluster* cluster) {
         cnt = cluster->nb_columns();
-        return true;
+        return IteratorControl::Stop;
     };
     traverse_clusters(get_column_cnt);
 
@@ -2008,7 +2008,7 @@ void Table::ensure_graveyard()
         m_tombstones->init_from_parent();
         for_each_and_every_column([ts = m_tombstones.get()](ColKey col) {
             ts->insert_column(col);
-            return false;
+            return IteratorControl::AdvanceToNext;
         });
     }
 }
@@ -2141,7 +2141,7 @@ size_t Table::count_decimal(ColKey col_key, Decimal128 value) const
                 cnt++;
             }
         }
-        return false;
+        return IteratorControl::AdvanceToNext;
     };
 
     traverse_clusters(f);
@@ -2363,7 +2363,7 @@ Decimal128 Table::maximum_decimal(ColKey col_key, ObjKey* return_ndx) const
                 ret_key = cluster->get_real_key(i);
             }
         }
-        return false;
+        return IteratorControl::AdvanceToNext;
     };
 
     traverse_clusters(f);
@@ -2421,9 +2421,9 @@ ObjKey Table::find_first(ColKey col_key, T value) const
         size_t row = leaf.find_first(value, 0, cluster->node_size());
         if (row != realm::npos) {
             key = cluster->get_real_key(row);
-            return true;
+            return IteratorControl::Stop;
         }
-        return false;
+        return IteratorControl::AdvanceToNext;
     };
 
     traverse_clusters(f);
@@ -2916,7 +2916,9 @@ bool Table::is_cross_table_link_target() const noexcept
     auto is_cross_link = [this](ColKey col_key) {
         auto t = col_key.get_type();
         // look for a backlink with a different target than ourselves
-        return (t == col_type_BackLink && get_opposite_table_key(col_key) != get_key());
+        return (t == col_type_BackLink && get_opposite_table_key(col_key) != get_key())
+                   ? IteratorControl::Stop
+                   : IteratorControl::AdvanceToNext;
     };
     return for_each_backlink_column(is_cross_link);
 }
@@ -3553,9 +3555,9 @@ Table::BacklinkOrigin Table::find_backlink_origin(StringData origin_table_name,
         if (origin_table->get_name() == origin_table_name &&
             origin_table->get_column_name(origin_link_col) == origin_col_name) {
             ret = BacklinkOrigin{{origin_table, origin_link_col}};
-            return true;
+            return IteratorControl::Stop;
         }
-        return false;
+        return IteratorControl::AdvanceToNext;
     };
     this->for_each_backlink_column(f);
     return ret;
@@ -3590,7 +3592,7 @@ std::vector<std::pair<TableKey, ColKey>> Table::get_incoming_link_columns() cons
         auto origin_table_key = get_opposite_table_key(backlink_col_key);
         auto origin_link_col = get_opposite_column(backlink_col_key);
         origins.emplace_back(origin_table_key, origin_link_col);
-        return false;
+        return IteratorControl::AdvanceToNext;
     };
     this->for_each_backlink_column(f);
     return origins;
@@ -3974,10 +3976,10 @@ bool Table::has_any_embedded_objects()
                 auto target_table = get_parent_group()->get_table(target_table_key);
                 if (target_table->is_embedded()) {
                     m_has_any_embedded_objects = true;
-                    return true; // early out
+                    return IteratorControl::Stop; // early out
                 }
             }
-            return false;
+            return IteratorControl::AdvanceToNext;
         });
     }
     return *m_has_any_embedded_objects;

--- a/src/realm/table.hpp
+++ b/src/realm/table.hpp
@@ -474,14 +474,14 @@ public:
     ColKey set_nullability(ColKey col_key, bool nullable, bool throw_on_null);
 
     // Iterate through (subset of) columns. The supplied function may abort iteration
-    // by returning 'true' (early out).
+    // by returning 'IteratorControl::Stop' (early out).
     template <typename Func>
     bool for_each_and_every_column(Func func) const
     {
         for (auto col_key : m_leaf_ndx2colkey) {
             if (!col_key)
                 continue;
-            if (func(col_key))
+            if (func(col_key) == IteratorControl::Stop)
                 return true;
         }
         return false;
@@ -494,7 +494,7 @@ public:
                 continue;
             if (col_key.get_type() == col_type_BackLink)
                 continue;
-            if (func(col_key))
+            if (func(col_key) == IteratorControl::Stop)
                 return true;
         }
         return false;
@@ -508,7 +508,7 @@ public:
                 continue;
             if (col_key.get_type() != col_type_BackLink)
                 continue;
-            if (func(col_key))
+            if (func(col_key) == IteratorControl::Stop)
                 return true;
         }
         return false;

--- a/src/realm/table_cluster_tree.cpp
+++ b/src/realm/table_cluster_tree.cpp
@@ -72,8 +72,7 @@ void TableClusterTree::clear(CascadeState& state)
             for (size_t i = 0; i < sz; i++) {
                 repl->remove_object(m_owner, cluster->get_real_key(i));
             }
-            // Continue
-            return false;
+            return IteratorControl::AdvanceToNext;
         });
     }
 
@@ -102,7 +101,7 @@ void TableClusterTree::enumerate_string_column(ColKey col_key)
             }
         }
 
-        return false; // Continue
+        return IteratorControl::AdvanceToNext;
     };
 
     auto upgrade = [col_key, &keys](Cluster* cluster) {
@@ -171,7 +170,7 @@ void TableClusterTree::remove_all_links(CascadeState& state)
             // Furthermore it is a prerequisite for using 'traverse' that the tree
             // is not modified
             if (get_owning_table()->links_to_self(col_key)) {
-                return false;
+                return IteratorControl::AdvanceToNext;
             }
             auto col_type = col_key.get_type();
             if (col_key.is_list() || col_key.is_set()) {
@@ -247,8 +246,7 @@ void TableClusterTree::remove_all_links(CascadeState& state)
                                     links.push_back(mix.get<ObjLink>());
                                 }
                             }
-                            // Continue
-                            return false;
+                            return IteratorControl::AdvanceToNext;
                         });
 
                         if (links.size() > 0) {
@@ -303,11 +301,10 @@ void TableClusterTree::remove_all_links(CascadeState& state)
                     }
                 }
             }
-            return false;
+            return IteratorControl::AdvanceToNext;
         };
         m_owner->for_each_and_every_column(remove_link_from_column);
-        // Continue
-        return false;
+        return IteratorControl::AdvanceToNext;
     };
 
     // Go through all clusters

--- a/src/realm/table_tpl.hpp
+++ b/src/realm/table_tpl.hpp
@@ -42,8 +42,7 @@ void Table::aggregate(QueryStateBase& st, ColKey column_key) const
             auto v = leaf.get(local_index);
             cont = st.match(local_index, v);
         }
-        // We should continue
-        return false;
+        return IteratorControl::AdvanceToNext;
     };
 
     traverse_clusters(f);

--- a/src/realm/table_view.cpp
+++ b/src/realm/table_view.cpp
@@ -235,7 +235,7 @@ Timestamp TableView::minmax_timestamp(ColKey column_key, ObjKey* return_key) con
             best_value = ts;
             best_key = obj.get_key();
         }
-        return false;
+        return IteratorControl::AdvanceToNext;
     });
     if (return_key)
         *return_key = best_key;

--- a/src/realm/utilities.hpp
+++ b/src/realm/utilities.hpp
@@ -393,6 +393,8 @@ typedef int FileDesc;
 #endif
 
 
+enum class IteratorControl { AdvanceToNext, Stop };
+
 } // namespace realm
 
 #endif // REALM_UTILITIES_HPP

--- a/test/test_table.cpp
+++ b/test/test_table.cpp
@@ -3327,7 +3327,7 @@ TEST(Table_object_forward_iterator)
     size_t tree_size = 0;
     auto f = [&tree_size](const Cluster* cluster) {
         tree_size += cluster->node_size();
-        return false;
+        return IteratorControl::AdvanceToNext;
     };
     table.traverse_clusters(f);
     CHECK_EQUAL(tree_size, size_t(nb_rows));


### PR DESCRIPTION
This change is for readability. Whenever I come across this pattern in the code I have to look up what true and false means contextually. Having a verbose type makes it easier to see what is going on without this mental indirection.

## ☑️ ToDos
* [x] 📝 Changelog update