### PR TITLE
Revert "throw inside realm convert if realm uses flx sync (#5846)"

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,7 +20,6 @@
 * Fixed not allowing asymmetric tables in partition based sync ([#5691](https://github.com/realm/realm-core/issues/5691)).
 * Disable auto refresh for old realm instance passed to migration callbacks. ([#5856](https://github.com/realm/realm-core/pull/5856)).
 * If a case insensitive query searched for a string including an 4-byte UTF8 character, the program would crash ([#5825](https://github.com/realm/realm-core/issues/5825), since v2.3.0)
-* Throw exception if `Realm::Convert` tries to convert to flexible sync. ([#5798](https://github.com/realm/realm-core/issues/5798), since v11.16.0).
 
 ### Breaking changes
 * None.

--- a/src/realm/object-store/shared_realm.cpp
+++ b/src/realm/object-store/shared_realm.cpp
@@ -1085,13 +1085,6 @@ bool Realm::compact()
 void Realm::convert(const Config& config, bool merge_into_existing)
 {
     verify_thread();
-
-#if REALM_ENABLE_SYNC
-    if (config.sync_config && config.sync_config->flx_sync_requested) {
-        throw std::logic_error("Realm cannot be converted if flexible sync is enabled");
-    }
-#endif
-
     if (merge_into_existing && util::File::exists(config.path)) {
         auto destination_realm = Realm::get_shared_realm(config);
         destination_realm->begin_transaction();

--- a/test/object-store/realm.cpp
+++ b/test/object-store/realm.cpp
@@ -40,7 +40,6 @@
 #include <realm/object-store/sync/async_open_task.hpp>
 #include <realm/object-store/sync/impl/sync_metadata.hpp>
 #include <realm/sync/noinst/client_history_impl.hpp>
-#include "sync/flx_sync_harness.hpp"
 #endif
 
 #include <realm/db.hpp>
@@ -1080,18 +1079,6 @@ TEST_CASE("SharedRealm: convert") {
 
         // Check that the data also exists in the new realm
         REQUIRE(sync_realm->read_group().get_table("class_object")->size() == 1);
-    }
-
-    SECTION("cannot convert from local realm to flx sync") {
-        SyncTestFile sync_config(tsm.app()->current_user(), schema, SyncConfig::FLXSyncEnabled{});
-        auto local_realm = Realm::get_shared_realm(local_config1);
-        REQUIRE_THROWS(local_realm->convert(sync_config));
-    }
-
-    SECTION("convert from flx sync realm to local") {
-        SyncTestFile sync_config(tsm.app()->current_user(), schema, SyncConfig::FLXSyncEnabled{});
-        auto flx_sync_realm = Realm::get_shared_realm(sync_config);
-        REQUIRE_NOTHROW(flx_sync_realm->convert(local_config1));
     }
 
     SECTION("can copy a local realm to a local realm") {


### PR DESCRIPTION
This reverts commit 001911c555a747af87d5f221cacc60f099c51b5b.

## What, How & Why?
Revert this commit because CI has failed on the release run.

## ☑️ ToDos
* [ ] 📝 Changelog update
* [ ] 🚦 Tests (or not relevant)
* [ ] C-API, if public C++ API changed.
