### PR TITLE
Fix crash when upserting into mongo collection

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,7 +23,7 @@
 * Disable auto refresh for old realm instance passed to migration callbacks. ([#5856](https://github.com/realm/realm-core/pull/5856)).
 * If a case insensitive query searched for a string including an 4-byte UTF8 character, the program would crash ([#5825](https://github.com/realm/realm-core/issues/5825), since v2.3.0)
 * Throw exception if `Realm::Convert` tries to convert to flexible sync. ([#5798](https://github.com/realm/realm-core/issues/5798), since v11.16.0).
-* Fix crash when upserting a document into a mongo collection. ([#5345](https://github.com/realm/realm-core/issues/5345), since v10.0.0).
+* Fix crash when upserting a document with the primary key not an ObjectId into a mongo collection. ([#5345](https://github.com/realm/realm-core/issues/5345), since v10.0.0).
 
 ### Breaking changes
 * The typed aggregation functions (e.g. `minimum_int`) on `Table`, `TableView`, and `Query` have been removed and replaced with simpler untyped versions which return `Mixed`. This does not effect SDKs which only used them via the Object Store types.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@
 * Disable auto refresh for old realm instance passed to migration callbacks. ([#5856](https://github.com/realm/realm-core/pull/5856)).
 * If a case insensitive query searched for a string including an 4-byte UTF8 character, the program would crash ([#5825](https://github.com/realm/realm-core/issues/5825), since v2.3.0)
 * Throw exception if `Realm::Convert` tries to convert to flexible sync. ([#5798](https://github.com/realm/realm-core/issues/5798), since v11.16.0).
+* Fix crash when upserting a document into a mongo collection. ([#5345](https://github.com/realm/realm-core/issues/5345), since v10.0.0).
 
 ### Breaking changes
 * The typed aggregation functions (e.g. `minimum_int`) on `Table`, `TableView`, and `Query` have been removed and replaced with simpler untyped versions which return `Mixed`. This does not effect SDKs which only used them via the Object Store types.

--- a/src/realm/global_key.hpp
+++ b/src/realm/global_key.hpp
@@ -36,7 +36,7 @@ class Mixed;
 /// We define a way to map from 128-bit on-write GlobalKeys to local 64-bit ObjKeys.
 ///
 /// The three object ID types are:
-/// a. Global Keyss for objects in tables without primary keys.
+/// a. Global Keys for objects in tables without primary keys.
 /// b. Global Keys for objects in tables with integer primary keys.
 /// c. Global Keys for objects in tables with other primary key types.
 ///

--- a/src/realm/object-store/sync/mongo_collection.cpp
+++ b/src/realm/object-store/sync/mongo_collection.cpp
@@ -68,7 +68,7 @@ ResponseHandler<util::Optional<Bson>> get_update_handler(ResponseHandler<MongoCo
             auto& document = static_cast<const BsonDocument&>(*value).entries();
             return completion(MongoCollection::UpdateResult{get<int32_t>(document, "matchedCount").value_or(0),
                                                             get<int32_t>(document, "modifiedCount").value_or(0),
-                                                            get<ObjectId>(document, "upsertedId")},
+                                                            get<Bson>(document, "upsertedId")},
                               std::move(error));
         }
         catch (const std::exception& e) {
@@ -216,7 +216,7 @@ void MongoCollection::update_one(const BsonDocument& filter_bson, const BsonDocu
 void MongoCollection::update_one(const BsonDocument& filter_bson, const BsonDocument& update_bson,
                                  ResponseHandler<MongoCollection::UpdateResult>&& completion)
 {
-    update_one(filter_bson, update_bson, {}, std::move(completion));
+    update_one(filter_bson, update_bson, false, std::move(completion));
 }
 
 void MongoCollection::update_many(const BsonDocument& filter_bson, const BsonDocument& update_bson, bool upsert,
@@ -228,7 +228,7 @@ void MongoCollection::update_many(const BsonDocument& filter_bson, const BsonDoc
 void MongoCollection::update_many(const BsonDocument& filter_bson, const BsonDocument& update_bson,
                                   ResponseHandler<MongoCollection::UpdateResult>&& completion)
 {
-    update_many(filter_bson, update_bson, {}, std::move(completion));
+    update_many(filter_bson, update_bson, false, std::move(completion));
 }
 
 void MongoCollection::find_one_and_update(const BsonDocument& filter_bson, const BsonDocument& update_bson,

--- a/src/realm/object-store/sync/mongo_collection.hpp
+++ b/src/realm/object-store/sync/mongo_collection.hpp
@@ -41,7 +41,7 @@ public:
         /// The number of documents modified.
         int32_t modified_count;
         /// The identifier of the inserted document if an upsert took place.
-        util::Optional<ObjectId> upserted_id;
+        util::Optional<bson::Bson> upserted_id;
     };
 
     /// Options to use when executing a `find` command on a `MongoCollection`.

--- a/test/object-store/sync/app.cpp
+++ b/test/object-store/sync/app.cpp
@@ -806,7 +806,7 @@ TEST_CASE("app: remote mongo client", "[sync][app]") {
         {"breed", "french bulldog"},
     };
 
-    auto cat_id_string = ObjectId::gen().to_string();
+    auto cat_id_string = random_string(10);
     bson::BsonDocument cat_document{
         {"_id", cat_id_string},
         {"name", "luna"},

--- a/test/object-store/sync/app.cpp
+++ b/test/object-store/sync/app.cpp
@@ -792,6 +792,7 @@ TEST_CASE("app: remote mongo client", "[sync][app]") {
     auto remote_client = app->current_user()->mongo_client("BackingDB");
     auto db = remote_client.db(get_runtime_app_session("").config.mongo_dbname);
     auto dog_collection = db["Dog"];
+    auto cat_collection = db["Cat"];
     auto person_collection = db["Person"];
 
     bson::BsonDocument dog_document{{"name", "fido"}, {"breed", "king charles"}};
@@ -803,6 +804,13 @@ TEST_CASE("app: remote mongo client", "[sync][app]") {
         {"_id", dog3_object_id},
         {"name", "petunia"},
         {"breed", "french bulldog"},
+    };
+
+    auto cat_id_string = ObjectId::gen().to_string();
+    bson::BsonDocument cat_document{
+        {"_id", cat_id_string},
+        {"name", "luna"},
+        {"breed", "scottish fold"},
     };
 
     bson::BsonDocument person_document{
@@ -855,7 +863,17 @@ TEST_CASE("app: remote mongo client", "[sync][app]") {
             CHECK(static_cast<ObjectId>(bson["insertedId"]) == dog3_object_id);
         });
 
+        cat_collection.insert_one_bson(cat_document, [&](Optional<bson::Bson> value, Optional<AppError> error) {
+            REQUIRE_FALSE(error);
+            auto bson = static_cast<bson::BsonDocument>(*value);
+            CHECK(static_cast<std::string>(bson["insertedId"]) == cat_id_string);
+        });
+
         dog_collection.delete_many({}, [&](uint64_t, Optional<AppError> error) {
+            REQUIRE_FALSE(error);
+        });
+
+        cat_collection.delete_one(cat_document, [&](uint64_t, Optional<AppError> error) {
             REQUIRE_FALSE(error);
         });
 
@@ -882,6 +900,12 @@ TEST_CASE("app: remote mongo client", "[sync][app]") {
             CHECK(static_cast<ObjectId>(*object_id) == dog3_object_id);
         });
 
+        cat_collection.insert_one(cat_document, [&](Optional<bson::Bson> object_id, Optional<AppError> error) {
+            REQUIRE_FALSE(error);
+            CHECK(object_id->type() == bson::Bson::Type::String);
+            CHECK(static_cast<std::string>(*object_id) == cat_id_string);
+        });
+
         person_document["dogs"] = bson::BsonArray({dog_object_id, dog2_object_id, dog3_object_id});
         person_collection.insert_one(person_document, [&](Optional<bson::Bson> object_id, Optional<AppError> error) {
             REQUIRE_FALSE(error);
@@ -889,6 +913,10 @@ TEST_CASE("app: remote mongo client", "[sync][app]") {
         });
 
         dog_collection.delete_many({}, [&](uint64_t, Optional<AppError> error) {
+            REQUIRE_FALSE(error);
+        });
+
+        cat_collection.delete_one(cat_document, [&](uint64_t, Optional<AppError> error) {
             REQUIRE_FALSE(error);
         });
 
@@ -1220,7 +1248,18 @@ TEST_CASE("app: remote mongo client", "[sync][app]") {
                                       CHECK(!result.upserted_id);
                                   });
 
+        cat_collection.update_one({}, cat_document, true,
+                                  [&](MongoCollection::UpdateResult result, Optional<AppError> error) {
+                                      REQUIRE_FALSE(error);
+                                      CHECK(result.upserted_id->type() == bson::Bson::Type::String);
+                                      CHECK(result.upserted_id == cat_id_string);
+                                  });
+
         dog_collection.delete_many({}, [&](uint64_t, Optional<AppError> error) {
+            REQUIRE_FALSE(error);
+        });
+
+        cat_collection.delete_many({}, [&](uint64_t, Optional<AppError> error) {
             REQUIRE_FALSE(error);
         });
 
@@ -1238,6 +1277,14 @@ TEST_CASE("app: remote mongo client", "[sync][app]") {
                                            auto document = static_cast<bson::BsonDocument>(*bson);
                                            auto foundUpsertedId = document.find("upsertedId") != document.end();
                                            REQUIRE(!foundUpsertedId);
+                                       });
+
+        cat_collection.update_one_bson({}, cat_document, true,
+                                       [&](Optional<bson::Bson> bson, Optional<AppError> error) {
+                                           REQUIRE_FALSE(error);
+                                           auto upserted_id = static_cast<bson::BsonDocument>(*bson)["upsertedId"];
+                                           REQUIRE(upserted_id.type() == bson::Bson::Type::String);
+                                           REQUIRE(upserted_id == cat_id_string);
                                        });
 
         person_document["dogs"] = bson::BsonArray();

--- a/test/object-store/util/baas_admin_api.cpp
+++ b/test/object-store/util/baas_admin_api.cpp
@@ -771,6 +771,11 @@ AppCreateConfig default_app_config(const std::string& base_url)
                              realm::Property("breed", PropertyType::String | PropertyType::Nullable),
                              realm::Property("name", PropertyType::String),
                              realm::Property("realm_id", PropertyType::String | PropertyType::Nullable)});
+    const auto cat_schema =
+        ObjectSchema("Cat", {realm::Property("_id", PropertyType::String | PropertyType::Nullable, true),
+                             realm::Property("breed", PropertyType::String | PropertyType::Nullable),
+                             realm::Property("name", PropertyType::String),
+                             realm::Property("realm_id", PropertyType::String | PropertyType::Nullable)});
     const auto person_schema =
         ObjectSchema("Person", {realm::Property("_id", PropertyType::ObjectId | PropertyType::Nullable, true),
                                 realm::Property("age", PropertyType::Int),
@@ -778,7 +783,7 @@ AppCreateConfig default_app_config(const std::string& base_url)
                                 realm::Property("firstName", PropertyType::String),
                                 realm::Property("lastName", PropertyType::String),
                                 realm::Property("realm_id", PropertyType::String | PropertyType::Nullable)});
-    realm::Schema default_schema({dog_schema, person_schema});
+    realm::Schema default_schema({dog_schema, cat_schema, person_schema});
 
     Property partition_key("realm_id", PropertyType::String | PropertyType::Nullable);
 


### PR DESCRIPTION
## What, How & Why?
When upserting into a mongo collection, the code expected that the type of the `upsertedId` was always `ObjectId` when in fact it should be the same as the primary key (i.e, `_id`). This PR addresses that.
Fixes #5345.

## ☑️ ToDos
* [x] 📝 Changelog update
* [x] 🚦 Tests (or not relevant)
* [ ] ~~C-API, if public C++ API changed.~~
