### PR TITLE
Fix linker errors when building OS benchmarks on non-Apple arm64 

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -99,6 +99,11 @@ else()
         add_cxx_flag_if_supported(-Wno-deprecated-declarations)
     endif()
 
+    # By default GCC warns that it changed how it passes bitfields by value as
+    # function arguments on arm64 every time this happens. This warning is just
+    # an FYI and not pointing out a problem, so just disable it.
+    add_cxx_flag_if_supported(-Wno-psabi)
+
     add_cxx_flag_if_supported(-Wpartial-availability)
 
     # This warning is too agressive. It warns about moves that are not redundant on older

--- a/src/realm/obj.hpp
+++ b/src/realm/obj.hpp
@@ -436,7 +436,18 @@ private:
 std::ostream& operator<<(std::ostream&, const Obj& obj);
 
 template <>
+int64_t Obj::get(ColKey) const;
+template <>
+bool Obj::get(ColKey) const;
+
+template <>
 int64_t Obj::_get(ColKey::Idx col_ndx) const;
+template <>
+StringData Obj::_get(ColKey::Idx col_ndx) const;
+template <>
+BinaryData Obj::_get(ColKey::Idx col_ndx) const;
+template <>
+ObjKey Obj::_get(ColKey::Idx col_ndx) const;
 
 struct Obj::FatPathElement {
     Obj obj;        // Object which embeds...

--- a/src/realm/table_view.cpp
+++ b/src/realm/table_view.cpp
@@ -166,6 +166,7 @@ Mixed TableView::aggregate(ColKey column_key, size_t* result_count, ObjKey* retu
     }
     else {
         static_cast<void>(last_accumulated_key);
+        static_cast<void>(return_key);
     }
 
     if (!agg.is_null()) {

--- a/test/object-store/benchmarks/results.cpp
+++ b/test/object-store/benchmarks/results.cpp
@@ -375,7 +375,7 @@ TEST_CASE("aggregates") {
 
     const auto value_count = GENERATE(0, 100, 1'000'000);
     for (int i = 0; i < value_count; ++i) {
-        auto key = table->create_object().set_all(1LL).get_key();
+        auto key = table->create_object().set_all(int64_t(1)).get_key();
         obj_list.add(key);
         obj_set.insert(key);
         obj_dict.insert(std::to_string(i), key);


### PR DESCRIPTION
On non-Apple arm64 `int64_t` is `long`, so `set_all(1LL)` is invalid as it calls the nonexistent `Obj::set<long long>()`.

This also fixes some arm64+gcc specific warnings which I noticed while tracking this down.