### PR TITLE
Install util/http.hpp

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@
 
 ### Internals
 * Reenable sync benchmark.
+* Add util/http.hpp to the release package.
 
 ----------------------------------------------
 

--- a/src/realm/CMakeLists.txt
+++ b/src/realm/CMakeLists.txt
@@ -233,6 +233,7 @@ set(REALM_INSTALL_HEADERS
     util/functional.hpp
     util/future.hpp
     util/hex_dump.hpp
+    util/http.hpp
     util/input_stream.hpp
     util/inspect.hpp
     util/interprocess_condvar.hpp

--- a/src/realm/util/http.hpp
+++ b/src/realm/util/http.hpp
@@ -1,3 +1,20 @@
+/*************************************************************************
+ *
+ * Copyright 2022 Realm Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ **************************************************************************/
 
 #ifndef REALM_UTIL_HTTP_HPP
 #define REALM_UTIL_HTTP_HPP


### PR DESCRIPTION
#5743 added an inclusion of this file to a public header so it needs to be included in the release package.