### PR TITLE
Improve error handling on collections of non-nullable Mixed

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 ### Fixed
 * <How do the end-user experience this issue? what was the impact?> ([#????](https://github.com/realm/realm-core/issues/????), since v?.?.?)
 * Fix a data race reported by thread sanitizer when preparing to deliver change notifications. This probably did not cause observable problems in practice ([PR #5892](https://github.com/realm/realm-core/pull/5892) since 12.7.0).
+* Changed the behaviour of creating a collection of non-nullable Mixed type to throw a descriptive error message rather than asserting in debug mode. ([#5894](https://github.com/realm/realm-core/issues/5894), since the introduction of the Mixed type).
 
 ### Breaking changes
 * None.

--- a/src/realm/object-store/object_schema.cpp
+++ b/src/realm/object-store/object_schema.cpp
@@ -239,7 +239,7 @@ static void validate_property(Schema const& schema, ObjectSchema const& parent_o
              !(is_array(prop.type) || is_set(prop.type))) {
         exceptions.emplace_back("Property '%1.%2' of type 'object' must be nullable.", object_name, prop.name);
     }
-    else if (prop.type == PropertyType::Mixed && !is_nullable(prop.type) && !is_collection(prop.type)) {
+    else if (prop.type == PropertyType::Mixed && !is_nullable(prop.type)) {
         exceptions.emplace_back("Property '%1.%2' of type 'Mixed' must be nullable.", object_name, prop.name);
     }
 

--- a/test/object-store/realm.cpp
+++ b/test/object-store/realm.cpp
@@ -3601,3 +3601,25 @@ TEST_CASE("KeyPathMapping generation") {
         REQUIRE(q.count() == 0);
     }
 }
+
+TEST_CASE("collections with non nullable mixed should throw") {
+    InMemoryTestFile config;
+    config.cache = false;
+    config.automatic_change_notifications = false;
+
+    constexpr std::string_view expected_msg = "Property 'object.value' of type 'Mixed' must be nullable";
+    SECTION("array") {
+        config.schema = Schema{{"object", {{"value", PropertyType::Array | PropertyType::Mixed}}}};
+        REQUIRE_THROWS_CONTAINING(Realm::get_shared_realm(config), std::string(expected_msg));
+    }
+
+    SECTION("dictionary") {
+        config.schema = Schema{{"object", {{"value", PropertyType::Dictionary | PropertyType::Mixed}}}};
+        REQUIRE_THROWS_CONTAINING(Realm::get_shared_realm(config), std::string(expected_msg));
+    }
+
+    SECTION("set") {
+        config.schema = Schema{{"object", {{"value", PropertyType::Set | PropertyType::Mixed}}}};
+        REQUIRE_THROWS_CONTAINING(Realm::get_shared_realm(config), std::string(expected_msg));
+    }
+}

--- a/test/object-store/realm.cpp
+++ b/test/object-store/realm.cpp
@@ -3601,25 +3601,3 @@ TEST_CASE("KeyPathMapping generation") {
         REQUIRE(q.count() == 0);
     }
 }
-
-TEST_CASE("collections with non nullable mixed should throw") {
-    InMemoryTestFile config;
-    config.cache = false;
-    config.automatic_change_notifications = false;
-
-    constexpr std::string_view expected_msg = "Property 'object.value' of type 'Mixed' must be nullable";
-    SECTION("array") {
-        config.schema = Schema{{"object", {{"value", PropertyType::Array | PropertyType::Mixed}}}};
-        REQUIRE_THROWS_CONTAINING(Realm::get_shared_realm(config), std::string(expected_msg));
-    }
-
-    SECTION("dictionary") {
-        config.schema = Schema{{"object", {{"value", PropertyType::Dictionary | PropertyType::Mixed}}}};
-        REQUIRE_THROWS_CONTAINING(Realm::get_shared_realm(config), std::string(expected_msg));
-    }
-
-    SECTION("set") {
-        config.schema = Schema{{"object", {{"value", PropertyType::Set | PropertyType::Mixed}}}};
-        REQUIRE_THROWS_CONTAINING(Realm::get_shared_realm(config), std::string(expected_msg));
-    }
-}

--- a/test/object-store/schema.cpp
+++ b/test/object-store/schema.cpp
@@ -786,6 +786,22 @@ TEST_CASE("Schema") {
                                       "Property 'object.dictionary' of type 'object' must be nullable.");
         }
 
+        SECTION("rejects non-nullable Mixed dictionary properties") {
+            Schema schema = {{"object", {{"dictionary", PropertyType::Dictionary | PropertyType::Mixed}}}};
+            REQUIRE_THROWS_CONTAINING(schema.validate(),
+                                      "Property 'object.dictionary' of type 'Mixed' must be nullable.");
+        }
+
+        SECTION("rejects non-nullable Mixed list properties") {
+            Schema schema = {{"object", {{"array", PropertyType::Array | PropertyType::Mixed}}}};
+            REQUIRE_THROWS_CONTAINING(schema.validate(), "Property 'object.array' of type 'Mixed' must be nullable.");
+        }
+
+        SECTION("rejects non-nullable Mixed set properties") {
+            Schema schema = {{"object", {{"set", PropertyType::Set | PropertyType::Mixed}}}};
+            REQUIRE_THROWS_CONTAINING(schema.validate(), "Property 'object.set' of type 'Mixed' must be nullable.");
+        }
+
         SECTION("rejects nullable array properties") {
             Schema schema = {
                 {"object",


### PR DESCRIPTION
Fixes https://github.com/realm/realm-core/issues/5894

Mixed in an inherently nullable type. Somehow we allowed collections of nullable Mixed types passed schema validation. If this had happened in a Debug build for Dictionaries users would have seen an obscure debug assertion, and if this had happened in Release mode where the assertion was disabled, the dictionary would be created as nullable anyhow.

## ☑️ ToDos
* [x] 📝 Changelog update
* [x] 🚦 Tests (or not relevant)
* [x] C-API, if public C++ API changed.
