### PR TITLE
Reset page reclaimer on a test using `fork()`

### DIFF
--- a/src/realm/util/file_mapper.cpp
+++ b/src/realm/util/file_mapper.cpp
@@ -292,22 +292,6 @@ void set_page_reclaim_governor(PageReclaimGovernor* new_governor)
     ensure_reclaimer_thread_runs();
 }
 
-void clear_mappings_before_test_forks()
-{
-#if !REALM_PLATFORM_APPLE
-    if (reclaimer_thread) {
-        reclaimer_shutdown = true;
-        reclaimer_thread->join();
-        reclaimer_thread = nullptr;
-        reclaimer_shutdown = false;
-    }
-#endif
-    UniqueLock lock(mapping_mutex);
-    mappings_by_addr.clear();
-    mappings_by_file.clear();
-    num_decrypted_pages = 0;
-}
-
 size_t get_num_decrypted_pages()
 {
     return num_decrypted_pages.load();
@@ -715,7 +699,26 @@ void* mmap_fixed(FileDesc fd, void* address_request, size_t size, File::AccessMo
 }
 
 
+#endif // REALM_ENABLE_ENCRYPTION
+
+void clear_mappings_before_test_forks()
+{
+#if REALM_ENABLE_ENCRYPTION
+#if !REALM_PLATFORM_APPLE
+    if (reclaimer_thread) {
+        reclaimer_shutdown = true;
+        reclaimer_thread->join();
+        reclaimer_thread = nullptr;
+        reclaimer_shutdown = false;
+    }
 #endif
+    UniqueLock lock(mapping_mutex);
+    mappings_by_addr.clear();
+    mappings_by_file.clear();
+    num_decrypted_pages = 0;
+#endif // REALM_ENABLE_ENCRYPTION
+}
+
 
 void* mmap_anon(size_t size)
 {

--- a/src/realm/util/file_mapper.cpp
+++ b/src/realm/util/file_mapper.cpp
@@ -249,10 +249,13 @@ struct ReclaimerThreadStopper {
 #else // REALM_PLATFORM_APPLE
 static dispatch_source_t reclaimer_timer;
 static dispatch_queue_t reclaimer_queue;
+static bool did_init_reclaimer = false;
+static int pid_of_creator = -1;
 
 static void ensure_reclaimer_thread_runs()
 {
-    if (!reclaimer_timer) {
+    if (!did_init_reclaimer) {
+        pid_of_creator = getpid();
         if (__builtin_available(iOS 10, macOS 12, tvOS 10, watchOS 3, *)) {
             reclaimer_queue = dispatch_queue_create_with_target("io.realm.page-reclaimer", DISPATCH_QUEUE_SERIAL,
                                                                 dispatch_get_global_queue(QOS_CLASS_BACKGROUND, 0));
@@ -266,19 +269,21 @@ static void ensure_reclaimer_thread_runs()
             reclaim_pages();
         });
         dispatch_resume(reclaimer_timer);
+        did_init_reclaimer = true;
     }
 }
 
 struct ReclaimerThreadStopper {
     ~ReclaimerThreadStopper()
     {
-        if (reclaimer_timer) {
+        if (did_init_reclaimer && getpid() == pid_of_creator) {
             dispatch_source_cancel(reclaimer_timer);
             // Block until any currently-running timer tasks are done
             dispatch_sync(reclaimer_queue, ^{
                           });
             dispatch_release(reclaimer_timer);
             dispatch_release(reclaimer_queue);
+            did_init_reclaimer = false;
         }
     }
 } reclaimer_thread_stopper;
@@ -290,6 +295,22 @@ void set_page_reclaim_governor(PageReclaimGovernor* new_governor)
     UniqueLock lock(mapping_mutex);
     governor = new_governor ? new_governor : &default_governor;
     ensure_reclaimer_thread_runs();
+}
+
+void clear_mappings_before_test_forks()
+{
+#if !REALM_PLATFORM_APPLE
+    if (reclaimer_thread) {
+        reclaimer_shutdown = true;
+        reclaimer_thread->join();
+        reclaimer_thread = nullptr;
+        reclaimer_shutdown = false;
+    }
+#endif
+    UniqueLock lock(mapping_mutex);
+    mappings_by_addr.clear();
+    mappings_by_file.clear();
+    num_decrypted_pages = 0;
 }
 
 size_t get_num_decrypted_pages()

--- a/src/realm/util/file_mapper.hpp
+++ b/src/realm/util/file_mapper.hpp
@@ -72,6 +72,14 @@ inline void set_page_reclaim_governor_to_default()
     set_page_reclaim_governor(nullptr);
 }
 
+// There are several globals that rely on being process specific.
+// The unit tests which use fork() should start with empty mappings.
+// This also resets the page reclaimer thread because if fork happens while
+// running with the global mutex `mapping_mutex` locked, the child process
+// will hang due to that mutex never being unlocked.
+// We do not support fork() in production.
+void clear_mappings_before_test_forks();
+
 // Retrieves the number of in memory decrypted pages, across all open files.
 size_t get_num_decrypted_pages();
 

--- a/test/test_lang_bind_helper.cpp
+++ b/test/test_lang_bind_helper.cpp
@@ -3135,6 +3135,7 @@ NONCONCURRENT_TEST_IF(LangBindHelper_ImplicitTransactions_InterProcess, !running
     int writepids[write_process_count];
     SHARED_GROUP_TEST_PATH(path);
 
+    clear_mappings_before_test_forks();
     int pid = fork();
     REALM_ASSERT(pid >= 0);
     if (pid == 0) {


### PR DESCRIPTION
Fixes https://github.com/realm/realm-core/issues/5908

To guarantee that the global `mapping_mutex` is not locked during `fork()` the page reclaimer thread is turned off for this test. It will be turned back on automatically by other tests using encryption because of the idempotent nature of `ensure_reclaimer_thread_runs()` which will be triggered during attempts to access encrypted data.

I ran into a related problem with the page reclaimer not working well across `fork()` in https://github.com/realm/realm-core/pull/5786 so I've extracted the solution I wrote from there.

## ☑️ ToDos
* [ ] 📝 Changelog update
* [ ] 🚦 Tests (or not relevant)
* [ ] C-API, if public C++ API changed.
