### PR TITLE
Add stricter checks for valid reads on encrypted files 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 ### Fixed
 * <How do the end-user experience this issue? what was the impact?> ([#????](https://github.com/realm/realm-core/issues/????), since v?.?.?)
 * Calling `SectionedResults::reset_section_callback()` on a `SectionedResults` which had been evaluated would result in an assertion failure the next time the sections are evaluated ([PR #5965](https://github.com/realm/realm-core/pull/5965), since v12.10.0).
+* Opening an unencrypted file with an encryption key would sometimes report a misleading error message that indicated that the problem was something other than a decryption failure ([PR #5915](https://github.com/realm/realm-core/pull/5915), since 0.86.1).
 
 ### Breaking changes
 * Websocket errors caused by the client sending a websocket message that is too large (i.e. greater than 16MB) now get reported as a `ProtocolError::limits_exceeded` error with a `ClientReset` requested by the server ([#5209](https://github.com/realm/realm-core/issues/5209)).

--- a/src/realm/alloc_slab.cpp
+++ b/src/realm/alloc_slab.cpp
@@ -731,7 +731,7 @@ ref_type SlabAlloc::attach_file(const std::string& file_path, Config& cfg)
     if (cfg.encryption_key && size == 0 && physical_file_size != 0) {
         // The opened file holds data, but is so small it cannot have
         // been created with encryption
-        throw std::runtime_error("Attempt to open unencrypted file with encryption key");
+        throw InvalidDatabase("Attempt to open unencrypted file with encryption key", path);
     }
     if (size == 0 || cfg.clear_file) {
         if (REALM_UNLIKELY(cfg.read_only))
@@ -756,16 +756,21 @@ ref_type SlabAlloc::attach_file(const std::string& file_path, Config& cfg)
         note_reader_start(this);
         // we'll read header and (potentially) footer
         File::Map<char> map_header(m_file, File::access_ReadOnly, sizeof(Header));
-        // if file is too small we'll catch it in validate_header - but we need to prevent an invalid mapping first
-        size_t footer_ref = size < (sizeof(StreamingFooter) + sizeof(Header)) ? 0 : (size - sizeof(StreamingFooter));
-        size_t footer_page_base = footer_ref & ~(page_size() - 1);
-        size_t footer_offset = footer_ref - footer_page_base;
-        File::Map<char> map_footer(m_file, footer_page_base, File::access_ReadOnly,
-                                   sizeof(StreamingFooter) + footer_offset, 0);
         realm::util::encryption_read_barrier(map_header, 0, sizeof(Header));
-        realm::util::encryption_read_barrier(map_footer, footer_offset, sizeof(StreamingFooter));
         auto header = reinterpret_cast<const Header*>(map_header.get_addr());
-        auto footer = reinterpret_cast<const StreamingFooter*>(map_footer.get_addr() + footer_offset);
+
+        File::Map<char> map_footer;
+        const StreamingFooter* footer = nullptr;
+        if (is_file_on_streaming_form(*header) && size >= sizeof(StreamingFooter) + sizeof(Header)) {
+            size_t footer_ref = size - sizeof(StreamingFooter);
+            size_t footer_page_base = footer_ref & ~(page_size() - 1);
+            size_t footer_offset = footer_ref - footer_page_base;
+            map_footer = File::Map<char>(m_file, footer_page_base, File::access_ReadOnly,
+                                         sizeof(StreamingFooter) + footer_offset, 0);
+            realm::util::encryption_read_barrier(map_footer, footer_offset, sizeof(StreamingFooter));
+            footer = reinterpret_cast<const StreamingFooter*>(map_footer.get_addr() + footer_offset);
+        }
+
         top_ref = validate_header(header, footer, size, path); // Throws
         m_attach_mode = cfg.is_shared ? attach_SharedFile : attach_UnsharedFile;
         m_data = map_header.get_addr(); // <-- needed below
@@ -1009,6 +1014,7 @@ ref_type SlabAlloc::validate_header(const Header* header, const StreamingFooter*
             std::string msg = "Invalid streaming format size (" + util::to_string(size) + ")";
             throw InvalidDatabase(msg, path);
         }
+        REALM_ASSERT(footer);
         top_ref = footer->m_top_ref;
         if (REALM_UNLIKELY(footer->m_magic_cookie != footer_magic_cookie)) {
             std::string msg = "Invalid streaming format cookie (" + util::to_string(footer->m_magic_cookie) + ")";

--- a/src/realm/group_writer.cpp
+++ b/src/realm/group_writer.cpp
@@ -154,7 +154,7 @@ char* GroupWriter::MapWindow::translate(ref_type ref)
 
 void GroupWriter::MapWindow::encryption_read_barrier(void* start_addr, size_t size)
 {
-    realm::util::encryption_read_barrier(start_addr, size, m_map.get_encrypted_mapping());
+    realm::util::encryption_read_barrier_for_write(start_addr, size, m_map.get_encrypted_mapping());
 }
 
 void GroupWriter::MapWindow::encryption_write_barrier(void* start_addr, size_t size)

--- a/src/realm/util/aes_cryptor.hpp
+++ b/src/realm/util/aes_cryptor.hpp
@@ -37,8 +37,7 @@
 #include <openssl/evp.h>
 #endif
 
-namespace realm {
-namespace util {
+namespace realm::util {
 
 struct iv_table;
 class EncryptedFileMapping;
@@ -53,6 +52,8 @@ public:
     bool read(FileDesc fd, off_t pos, char* dst, size_t size);
     void try_read_block(FileDesc fd, off_t pos, char* dst) noexcept;
     void write(FileDesc fd, off_t pos, const char* src, size_t size) noexcept;
+
+    void check_key(const uint8_t* key);
 
 private:
     enum EncryptionMode {
@@ -74,10 +75,10 @@ private:
 #elif defined(_WIN32)
     BCRYPT_KEY_HANDLE m_aes_key_handle;
 #else
-    uint8_t m_aesKey[32];
     EVP_CIPHER_CTX* m_ctx;
 #endif
 
+    uint8_t m_aesKey[32];
     uint8_t m_hmacKey[32];
     std::vector<iv_table> m_iv_buffer;
     std::unique_ptr<char[]> m_rw_buffer;
@@ -106,9 +107,8 @@ struct SharedFileInfo {
     size_t progress_index = 0;
     std::vector<ReaderInfo> readers;
 
-    SharedFileInfo(const uint8_t* key, FileDesc file_descriptor);
+    SharedFileInfo(const uint8_t* key);
 };
-}
-}
+} // namespace realm::util
 
 #endif // REALM_ENABLE_ENCRYPTION

--- a/src/realm/util/encrypted_file_mapping.hpp
+++ b/src/realm/util/encrypted_file_mapping.hpp
@@ -29,8 +29,7 @@ typedef size_t (*Header_to_size)(const char* addr);
 
 #include <vector>
 
-namespace realm {
-namespace util {
+namespace realm::util {
 
 struct SharedFileInfo;
 class EncryptedFileMapping;
@@ -54,7 +53,7 @@ public:
 
     // Make sure that memory in the specified range is synchronized with any
     // changes made globally visible through call to write_barrier or mark_for_refresh
-    void read_barrier(const void* addr, size_t size, Header_to_size header_to_size);
+    void read_barrier(const void* addr, size_t size, Header_to_size header_to_size, bool allow_missing);
 
     // Ensures that any changes made to memory in the specified range
     // becomes visible to any later calls to read_barrier()
@@ -147,7 +146,7 @@ private:
 
     void mark_outdated(size_t local_page_ndx) noexcept;
     bool copy_up_to_date_page(size_t local_page_ndx) noexcept;
-    void refresh_page(size_t local_page_ndx);
+    void refresh_page(size_t local_page_ndx, bool allow_missing);
     void write_and_update_all(size_t local_page_ndx, size_t begin_offset, size_t end_offset) noexcept;
     void reclaim_page(size_t page_ndx);
     void validate_page(size_t local_page_ndx) noexcept;
@@ -171,15 +170,11 @@ inline bool EncryptedFileMapping::contains_page(size_t page_in_file) const
     return page_in_file >= m_first_page && page_in_file - m_first_page < m_page_state.size();
 }
 
-
-} // namespace util
-} // namespace realm
+} // namespace realm::util
 
 #endif // REALM_ENABLE_ENCRYPTION
 
-namespace realm {
-namespace util {
-
+namespace realm::util {
 /// Thrown by EncryptedFileMapping if a file opened is non-empty and does not
 /// contain valid encrypted data
 struct DecryptionFailed : util::File::AccessError {
@@ -188,7 +183,6 @@ struct DecryptionFailed : util::File::AccessError {
     {
     }
 };
-} // namespace util
-} // namespace realm
+} // namespace realm::util
 
 #endif // REALM_UTIL_ENCRYPTED_FILE_MAPPING_HPP

--- a/src/realm/util/file.hpp
+++ b/src/realm/util/file.hpp
@@ -843,6 +843,11 @@ public:
     /// a call to File::unmap().
     T* release() noexcept;
 
+    bool is_writeable() const noexcept
+    {
+        return m_access_mode == access_ReadWrite;
+    }
+
 #if REALM_ENABLE_ENCRYPTION
     /// Get the encrypted file mapping corresponding to this mapping
     inline EncryptedFileMapping* get_encrypted_mapping() const

--- a/src/realm/util/file_mapper.hpp
+++ b/src/realm/util/file_mapper.hpp
@@ -107,7 +107,7 @@ void extend_encrypted_mapping(EncryptedFileMapping* mapping, void* addr, size_t 
                               size_t new_size);
 void remove_encrypted_mapping(void* addr, size_t size);
 void do_encryption_read_barrier(const void* addr, size_t size, HeaderToSize header_to_size,
-                                EncryptedFileMapping* mapping);
+                                EncryptedFileMapping* mapping, bool allow_missing);
 
 void do_encryption_write_barrier(const void* addr, size_t size, EncryptedFileMapping* mapping);
 
@@ -115,7 +115,13 @@ void inline encryption_read_barrier(const void* addr, size_t size, EncryptedFile
                                     HeaderToSize header_to_size = nullptr)
 {
     if (REALM_UNLIKELY(mapping))
-        do_encryption_read_barrier(addr, size, header_to_size, mapping);
+        do_encryption_read_barrier(addr, size, header_to_size, mapping, true);
+}
+
+void inline encryption_read_barrier_for_write(const void* addr, size_t size, EncryptedFileMapping* mapping)
+{
+    if (REALM_UNLIKELY(mapping))
+        do_encryption_read_barrier(addr, size, nullptr, mapping, true);
 }
 
 void inline encryption_write_barrier(const void* addr, size_t size, EncryptedFileMapping* mapping)
@@ -134,10 +140,10 @@ void inline encryption_flush(EncryptedFileMapping* mapping)
 }
 
 inline void do_encryption_read_barrier(const void* addr, size_t size, HeaderToSize header_to_size,
-                                       EncryptedFileMapping* mapping)
+                                       EncryptedFileMapping* mapping, bool allow_missing)
 {
     UniqueLock lock(mapping_mutex);
-    mapping->read_barrier(addr, size, header_to_size);
+    mapping->read_barrier(addr, size, header_to_size, allow_missing);
 }
 
 inline void do_encryption_write_barrier(const void* addr, size_t size, EncryptedFileMapping* mapping)
@@ -148,18 +154,19 @@ inline void do_encryption_write_barrier(const void* addr, size_t size, Encrypted
 
 #else
 
-void inline set_page_reclaim_governor(PageReclaimGovernor*) {}
 
 size_t inline get_num_decrypted_pages()
 {
     return 0;
 }
 
+void inline set_page_reclaim_governor(PageReclaimGovernor*) {}
 void inline encryption_read_barrier(const void*, size_t, EncryptedFileMapping*, HeaderToSize = nullptr) {}
-
+void inline encryption_read_barrier_for_write(const void*, size_t, EncryptedFileMapping*) {}
 void inline encryption_write_barrier(const void*, size_t) {}
-
 void inline encryption_write_barrier(const void*, size_t, EncryptedFileMapping*) {}
+void inline do_encryption_read_barrier(const void*, size_t, HeaderToSize, EncryptedFileMapping*, bool) {}
+void inline do_encryption_write_barrier(const void*, size_t, EncryptedFileMapping*) {}
 
 #endif
 
@@ -167,15 +174,18 @@ void inline encryption_write_barrier(const void*, size_t, EncryptedFileMapping*)
 template <typename T>
 void encryption_read_barrier(const File::Map<T>& map, size_t index, size_t num_elements = 1)
 {
-    T* addr = map.get_addr();
-    encryption_read_barrier(addr + index, sizeof(T) * num_elements, map.get_encrypted_mapping());
+    if (auto mapping = map.get_encrypted_mapping(); REALM_UNLIKELY(mapping)) {
+        do_encryption_read_barrier(map.get_addr() + index, sizeof(T) * num_elements, nullptr, mapping,
+                                   map.is_writeable());
+    }
 }
 
 template <typename T>
 void encryption_write_barrier(const File::Map<T>& map, size_t index, size_t num_elements = 1)
 {
-    T* addr = map.get_addr();
-    encryption_write_barrier(addr + index, sizeof(T) * num_elements, map.get_encrypted_mapping());
+    if (auto mapping = map.get_encrypted_mapping(); REALM_UNLIKELY(mapping)) {
+        do_encryption_write_barrier(map.get_addr() + index, sizeof(T) * num_elements, mapping);
+    }
 }
 
 File::SizeType encrypted_size_to_data_size(File::SizeType size) noexcept;

--- a/test/test_alloc.cpp
+++ b/test/test_alloc.cpp
@@ -26,6 +26,7 @@
 #include <vector>
 
 #include <realm/alloc_slab.hpp>
+#include <realm/group.hpp>
 #include <realm/impl/simulated_failure.hpp>
 #include <realm/util/file.hpp>
 
@@ -318,6 +319,9 @@ TEST(Alloc_Fuzzy)
 NONCONCURRENT_TEST_IF(Alloc_MapFailureRecovery, _impl::SimulatedFailure::is_enabled())
 {
     GROUP_TEST_PATH(path);
+
+    // Write a minimal file in streaming form so that it'll try to map the footer
+    Group().write(path);
 
     SlabAlloc::Config cfg;
     SlabAlloc alloc;

--- a/test/test_lang_bind_helper.cpp
+++ b/test/test_lang_bind_helper.cpp
@@ -5753,14 +5753,7 @@ TEST(LangBindHelper_OpenAsEncrypted)
     {
         const char* key = crypt_key(true);
         std::unique_ptr<Replication> hist_encrypt(make_in_realm_history());
-        bool is_okay = false;
-        try {
-            DBRef sg_encrypt = DB::create(*hist_encrypt, path, DBOptions(key));
-        }
-        catch (std::runtime_error&) {
-            is_okay = true;
-        }
-        CHECK(is_okay);
+        CHECK_THROW(DB::create(*hist_encrypt, path, DBOptions(key)), InvalidDatabase);
     }
 }
 #endif

--- a/test/test_shared.cpp
+++ b/test/test_shared.cpp
@@ -2199,10 +2199,7 @@ TEST(Shared_EncryptionKeyCheck_2)
 }
 
 // if opened by one key, it cannot be opened by a different key
-// disabled for now... needs to add a check in the encryption layer
-// based on a hash of the key.
-#if 0 // in principle this should be implemented.....
-ONLY(Shared_EncryptionKeyCheck_3)
+TEST(Shared_EncryptionKeyCheck_3)
 {
     SHARED_GROUP_TEST_PATH(path);
     const char* first_key = crypt_key(true);
@@ -2210,16 +2207,9 @@ ONLY(Shared_EncryptionKeyCheck_3)
     memcpy(second_key, first_key, 64);
     second_key[3] = ~second_key[3];
     DBRef sg = DB::create(path, false, DBOptions(first_key));
-    bool ok = false;
-    try {
-        DBRef sg_2 = DB::create(path, false, DBOptions(second_key));
-    } catch (std::runtime_error&) {
-        ok = true;
-    }
-    CHECK(ok);
+    CHECK_THROW(DB::create(path, false, DBOptions(second_key)), InvalidDatabase);
     DBRef sg3 = DB::create(path, false, DBOptions(first_key));
 }
-#endif
 
 #endif
 

--- a/test/test_shared.cpp
+++ b/test/test_shared.cpp
@@ -20,12 +20,12 @@
 #ifdef TEST_SHARED
 
 #include <condition_variable>
-#include <streambuf>
 #include <fstream>
-#include <tuple>
 #include <iostream>
-#include <fstream>
+#include <memory>
+#include <streambuf>
 #include <thread>
+#include <tuple>
 
 // Need fork() and waitpid() for Shared_RobustAgainstDeathDuringWrite
 #ifndef _WIN32
@@ -41,15 +41,15 @@
 #endif
 
 #include <realm.hpp>
+#include <realm/util/encrypted_file_mapping.hpp>
 #include <realm/util/features.h>
-#include <realm/util/safe_int_ops.hpp>
-#include <memory>
-#include <realm/util/terminate.hpp>
 #include <realm/util/file.hpp>
+#include <realm/util/safe_int_ops.hpp>
+#include <realm/util/terminate.hpp>
 #include <realm/util/thread.hpp>
 #include <realm/util/to_string.hpp>
-#include <realm/impl/simulated_failure.hpp>
 #include <realm/impl/copy_replication.hpp>
+#include <realm/impl/simulated_failure.hpp>
 
 #include "fuzz_group.hpp"
 
@@ -58,7 +58,6 @@
 
 extern unsigned int unit_test_random_seed;
 
-using namespace std;
 using namespace realm;
 using namespace realm::util;
 using namespace realm::test_util;
@@ -1585,7 +1584,7 @@ TEST(Shared_RobustAgainstDeathDuringWrite)
             DBRef sg = DB::create(path, false, DBOptions(crypt_key()));
             WriteTransaction wt(sg);
             wt.get_group().verify();
-            TableRef table = wt.get_or_add_table("alpha");
+            wt.get_or_add_table("alpha");
             _Exit(42); // Die hard with an active write transaction
         }
         else {
@@ -2185,14 +2184,7 @@ TEST(Shared_EncryptionKeyCheck)
 {
     SHARED_GROUP_TEST_PATH(path);
     DBRef sg = DB::create(path, false, DBOptions(crypt_key(true)));
-    bool ok = false;
-    try {
-        DBRef sg_2 = DB::create(path, false, DBOptions());
-    }
-    catch (std::runtime_error&) {
-        ok = true;
-    }
-    CHECK(ok);
+    CHECK_THROW(DB::create(path, false, DBOptions()), InvalidDatabase);
     DBRef sg3 = DB::create(path, false, DBOptions(crypt_key(true)));
 }
 
@@ -2202,14 +2194,7 @@ TEST(Shared_EncryptionKeyCheck_2)
 {
     SHARED_GROUP_TEST_PATH(path);
     DBRef sg = DB::create(path, false, DBOptions());
-    bool ok = false;
-    try {
-        DBRef sg_2 = DB::create(path, false, DBOptions(crypt_key(true)));
-    }
-    catch (std::runtime_error&) {
-        ok = true;
-    }
-    CHECK(ok);
+    CHECK_THROW(DB::create(path, false, DBOptions(crypt_key(true))), InvalidDatabase);
     DBRef sg3 = DB::create(path, false, DBOptions());
 }
 

--- a/test/util/unit_test.cpp
+++ b/test/util/unit_test.cpp
@@ -478,10 +478,15 @@ class TestList::ThreadContextImpl : public ThreadContext {
 public:
     IntraTestLogger intra_test_logger;
     SharedContextImpl& shared_context;
+
+    // Each instance of this type is only used on one thread spawned by the
+    // test runner, but the tests themselves may spawn additional threads that
+    // perform checks, so it still needs to be somewhat thread-safe.
     Mutex mutex;
     std::atomic<long long> num_checks;
     long long num_failed_checks;
     long num_failed_tests;
+    std::atomic<long> last_line_seen;
     bool errors_seen;
 
     ThreadContextImpl(SharedContextImpl& sc, int ti, util::Logger* attached_logger)
@@ -503,6 +508,7 @@ private:
         num_checks = 0;
         num_failed_checks = 0;
         num_failed_tests = 0;
+        last_line_seen = 0;
     }
 };
 
@@ -745,6 +751,7 @@ void TestList::ThreadContextImpl::run(SharedContextImpl::Entry entry, UniqueLock
     shared_context.reporter.begin(test_context);
     lock.unlock();
 
+    last_line_seen = test.details.line_number;
     errors_seen = false;
     Timer timer;
     try {
@@ -752,11 +759,11 @@ void TestList::ThreadContextImpl::run(SharedContextImpl::Entry entry, UniqueLock
     }
     catch (std::exception& ex) {
         std::string message = "Unhandled exception " + get_type_name(ex) + ": " + ex.what();
-        test_context.test_failed(message);
+        test_context.test_failed(
+            util::format("Unhandled exception after line %1 %2: %3", last_line_seen, get_type_name(ex), ex.what()));
     }
     catch (...) {
-        std::string message = "Unhandled exception of unknown type";
-        test_context.test_failed(message);
+        test_context.test_failed(util::format("Unhandled exception after line %1 of unknown type", last_line_seen));
     }
     double elapsed_time = timer.get_elapsed_time();
     if (errors_seen)
@@ -795,9 +802,10 @@ TestContext::TestContext(TestList::ThreadContextImpl& tc, const TestDetails& td,
 }
 
 
-void TestContext::check_succeeded()
+void TestContext::check_succeeded(long line)
 {
     ++m_thread_context.num_checks;
+    m_thread_context.last_line_seen.store(line, std::memory_order_relaxed);
 }
 
 
@@ -813,6 +821,7 @@ REALM_NORETURN void TestContext::abort()
 
 void TestContext::check_failed(const char* file, long line, const std::string& message)
 {
+    m_thread_context.last_line_seen = line;
     {
         LockGuard lock(m_thread_context.mutex);
         ++m_thread_context.num_checks;

--- a/test/util/unit_test.hpp
+++ b/test/util/unit_test.hpp
@@ -104,7 +104,7 @@
             test_context.throw_failed(__FILE__, __LINE__, #expr, #exception_class);                                  \
         }                                                                                                            \
         catch (exception_class&) {                                                                                   \
-            test_context.check_succeeded();                                                                          \
+            test_context.check_succeeded(__LINE__);                                                                  \
             return true;                                                                                             \
         }                                                                                                            \
         return false;                                                                                                \
@@ -118,7 +118,7 @@
         }                                                                                                            \
         catch (exception_class & e) {                                                                                \
             if (exception_cond) {                                                                                    \
-                test_context.check_succeeded();                                                                      \
+                test_context.check_succeeded(__LINE__);                                                              \
                 return true;                                                                                         \
             }                                                                                                        \
             test_context.throw_ex_cond_failed(__FILE__, __LINE__, e.what(), #expr, #exception_class,                 \
@@ -134,7 +134,7 @@
             test_context.throw_any_failed(__FILE__, __LINE__, #expr);                                                \
         }                                                                                                            \
         catch (...) {                                                                                                \
-            test_context.check_succeeded();                                                                          \
+            test_context.check_succeeded(__LINE__);                                                                  \
             return true;                                                                                             \
         }                                                                                                            \
         return false;                                                                                                \
@@ -147,7 +147,7 @@
             test_context.throw_any_failed(__FILE__, __LINE__, #expr);                                                \
         }                                                                                                            \
         catch (const std::exception& e) {                                                                            \
-            test_context.check_succeeded();                                                                          \
+            test_context.check_succeeded(__LINE__);                                                                  \
             message = e.what();                                                                                      \
         }                                                                                                            \
     }())
@@ -167,7 +167,7 @@
     ([&] {                                                                                                           \
         try {                                                                                                        \
             (expr);                                                                                                  \
-            test_context.check_succeeded();                                                                          \
+            test_context.check_succeeded(__LINE__);                                                                  \
             return true;                                                                                             \
         }                                                                                                            \
         catch (std::exception & ex) {                                                                                \
@@ -533,7 +533,7 @@ public:
     bool check_definitely_greater(long double a, long double b, long double eps, const char* file, long line,
                                   const char* a_text, const char* b_text, const char* eps_text);
 
-    void check_succeeded();
+    void check_succeeded(long line);
 
     void throw_failed(const char* file, long line, const char* expr_text, const char* exception_name);
     void throw_ex_failed(const char* file, long line, const char* expr_text, const char* exception_name,
@@ -784,7 +784,7 @@ inline bool TestContext::check_cond(bool cond, const char* file, long line, cons
                                     const char* cond_text)
 {
     if (REALM_LIKELY(cond)) {
-        check_succeeded();
+        check_succeeded(line);
     }
     else {
         cond_failed(file, line, macro_name, cond_text);
@@ -807,7 +807,7 @@ inline bool TestContext::check_compare(bool cond, const A& a, const B& b, const 
                                        const char* macro_name, const char* a_text, const char* b_text)
 {
     if (REALM_LIKELY(cond)) {
-        check_succeeded();
+        check_succeeded(line);
     }
     else {
         std::string a_val, b_val;
@@ -823,7 +823,7 @@ inline bool TestContext::check_inexact_compare(bool cond, long double a, long do
                                                const char* a_text, const char* b_text, const char* eps_text)
 {
     if (REALM_LIKELY(cond)) {
-        check_succeeded();
+        check_succeeded(line);
     }
     else {
         inexact_compare_failed(file, line, macro_name, a_text, b_text, eps_text, a, b, eps);


### PR DESCRIPTION
If a read on an encrypted file failed for any reason other than the hmac check failing, we simply ignored the failure and skipped the read. This is required for when we're only reading a page so that we can subsequently write to it and is almost okay the rest of the time, but it resulted in misleading errors in some cases.

I thought this'd have more severe consequences in some scenario, but I was unable to find any. The incorrect error message is something that has tripped up users before (the most common being that a smallish unencrypted streaming-format file would report an incorrect mnemonic rather than a decryption failure)