### PR TITLE
Fix another race when tearing down the sync manager

### DIFF
--- a/src/realm/object-store/sync/sync_manager.cpp
+++ b/src/realm/object-store/sync/sync_manager.cpp
@@ -685,30 +685,37 @@ void SyncManager::unregister_session(const std::string& path)
     util::CheckedUniqueLock lock(m_session_mutex);
     auto it = m_sessions.find(path);
     if (it == m_sessions.end()) {
-        // There was a race to unregister and there's nothing left to do here.
-        // This is known to happen if the sync session is closing down at the
-        // same time that a local Realm reference is being cleaned up.
+        // The session may already be unregistered. This always happens in the
+        // SyncManager destructor, and can also happen due to multiple threads
+        // tearing things down at once.
         return;
     }
 
-    // If the session has an active external reference, leave it be. This will happen if the session
-    // moves to an inactive state while still externally reference, for instance, as a result of
-    // the session's user being logged out.
+    // Sync session teardown calls this function, so we need to be careful with
+    // locking here. We need to unlock `m_session_mutex` before we do anything
+    // which could result in a re-entrant call or we'll deadlock, which in this
+    // function means unlocking before we destroy a `shared_ptr<SyncSession>`
+    // (either the external reference or internal reference versions).
+    // The external reference version will only be the final reference if
+    // another thread drops a reference while we're in this function.
+    // Dropping the final internal reference does not appear to ever actually
+    // result in a recursive call to this function at the time this comment was
+    // written, but releasing the lock in that case as well is still safer.
+
     if (auto existing_session = it->second->existing_external_reference()) {
-        // The lock must be released before `existing_session` is released. This prevents a
-        // deadlock in the scenario where a strong reference to the existing session is
-        // acquired here but other references are cleaned up before this method is
-        // finished. In that case, `existing_session` becomes the last strong external
-        // reference and the session will attempt to close when it goes out of scope. If
-        // that happens while we still hold the lock here, `unregister_session` will be
-        // called again and will block on `m_session_mutex` which is already held.
-        // Releasing the lock before `existing_session` expires prevents this.
+        // We got here because the session entered the inactive state, but
+        // there's still someone referencing it so we should leave it be. This
+        // can happen if the user was logged out, or if all Realms using the
+        // session were destroyed but the SDK user is holding onto the session.
+
+        // Explicit unlock so that `existing_session`'s destructor runs after
+        // the unlock for the reasons noted above
         lock.unlock();
         return;
     }
 
-    // Release the lock before we destroy the session in case the session's
-    // destructor wants to call back into us
+    // Remove the session from the map while holding the lock, but then defer
+    // destroying it until after we unlock the mutex for the reasons noted above.
     auto session = m_sessions.extract(it);
     lock.unlock();
 }

--- a/src/realm/object-store/sync/sync_session.cpp
+++ b/src/realm/object-store/sync/sync_session.cpp
@@ -143,16 +143,10 @@ void SyncSession::become_inactive(util::CheckedUniqueLock lock, std::error_code 
     std::swap(waits, m_completion_callbacks);
 
     m_session = nullptr;
-    std::shared_ptr<SyncManager> sync_manager;
     if (m_sync_manager) {
-        // This method may be called from the SyncManager's destructor. In this case, using 'shared_from_this()' will
-        // throw 'std::bad_weak_ptr' so we use a weak_ptr as intermediate.
-        sync_manager = m_sync_manager->weak_from_this().lock();
+        m_sync_manager->unregister_session(m_db->get_path());
     }
     m_state_mutex.unlock(lock);
-    if (sync_manager) {
-        sync_manager->unregister_session(m_db->get_path());
-    }
 
     // Send notifications after releasing the lock to prevent deadlocks in the callback.
     if (old_state != new_state) {
@@ -970,14 +964,10 @@ void SyncSession::close(util::CheckedUniqueLock lock)
             m_state_mutex.unlock(lock);
             break;
         case State::Inactive: {
-            std::shared_ptr<SyncManager> sync_manager;
             if (m_sync_manager) {
-                sync_manager = m_sync_manager->weak_from_this().lock();
+                m_sync_manager->unregister_session(m_db->get_path());
             }
             m_state_mutex.unlock(lock);
-            if (sync_manager) {
-                sync_manager->unregister_session(m_db->get_path());
-            }
             break;
         }
         case State::WaitingForAccessToken:


### PR DESCRIPTION
Taking a strong reference to the sync manager in `SyncSession::become_inactive()` can result in the sync manager being destroyed from inside the sync client run loop, which doesn't work. Joining the sync worker thread while on the thread throws `std::resource_deadlock_would_occur`, and detaching instead would just result in use-after-frees as we unwind the stack through a bunch of sync client call frames.

Fortunately `SyncManager::unregister_session()` can be called while holding a lock, so we can just unregister the session before dropping the state lock instead.

This fixes the crash seen in https://spruce.mongodb.com/task/realm_core_stable_ubuntu2004_tsan_object_store_tests_patch_7b087008a19773f1bb92324d410f9e70db17fca9_633765800ae60657c336d99b_22_09_30_21_54_08/logs, which manifested as a tsan failure but is actually `std::resource_deadlock_would_occur` being thrown and then tsan complaining about things before `terminate()` eventually gets called, with tsan's involvement mostly being that it coincidentally hits the bad timing. I was able to consistently reproduce this locally by adding a `sleep(1)` between unlocking the mutex and calling `unregister_session()`, but I couldn't find a reasonable way to write a test for it.

No changelog entry since we haven't cut a release with this yet.