### PR TITLE
Unify sync client testing hooks

### DIFF
--- a/src/realm/object-store/sync/sync_session.cpp
+++ b/src/realm/object-store/sync/sync_session.cpp
@@ -739,29 +739,11 @@ void SyncSession::create_sync_session()
     session_config.ssl_verify_callback = sync_config.ssl_verify_callback;
     session_config.proxy_config = sync_config.proxy_config;
     session_config.simulate_integration_error = sync_config.simulate_integration_error;
-    if (sync_config.on_download_message_received_hook) {
-        session_config.on_download_message_received_hook =
-            [hook = sync_config.on_download_message_received_hook,
-             anchor = weak_from_this()](const sync::SyncProgress& progress, int64_t query_version,
-                                        sync::DownloadBatchState batch_state, size_t num_changesets) {
-                hook(anchor, progress, query_version, batch_state, num_changesets);
-            };
-    }
-    if (sync_config.on_bootstrap_message_processed_hook) {
-        session_config.on_bootstrap_message_processed_hook =
-            [hook = sync_config.on_bootstrap_message_processed_hook,
-             anchor = weak_from_this()](const sync::SyncProgress& progress, int64_t query_version,
-                                        sync::DownloadBatchState batch_state) -> bool {
-            return hook(anchor, progress, query_version, batch_state);
+    if (sync_config.on_sync_client_event_hook) {
+        session_config.on_sync_client_event_hook = [hook = sync_config.on_sync_client_event_hook,
+                                                    anchor = weak_from_this()](const SyncClientHookData& data) {
+            return hook(anchor, data);
         };
-    }
-    if (sync_config.on_download_message_integrated_hook) {
-        session_config.on_download_message_integrated_hook =
-            [hook = sync_config.on_download_message_integrated_hook,
-             anchor = weak_from_this()](const sync::SyncProgress& progress, int64_t query_version,
-                                        sync::DownloadBatchState batch_state, size_t num_changesets) {
-                hook(anchor, progress, query_version, batch_state, num_changesets);
-            };
     }
 
     {

--- a/src/realm/sync/client.cpp
+++ b/src/realm/sync/client.cpp
@@ -246,9 +246,7 @@ private:
     util::UniqueFunction<ProgressHandler> m_progress_handler;
     util::UniqueFunction<ConnectionStateChangeListener> m_connection_state_change_listener;
 
-    std::function<void(const SyncProgress&, int64_t, DownloadBatchState, size_t)> m_on_download_message_received_hook;
-    std::function<bool(const SyncProgress&, int64_t, DownloadBatchState)> m_on_bootstrap_message_processed_hook;
-    std::function<void(const SyncProgress&, int64_t, DownloadBatchState, size_t)> on_download_message_integrated_hook;
+    std::function<SyncClientHookAction(SyncClientHookData data)> m_debug_hook;
 
     std::shared_ptr<SubscriptionStore> m_flx_subscription_store;
     int64_t m_flx_active_version = 0;
@@ -753,8 +751,8 @@ bool SessionImpl::process_flx_bootstrap_message(const SyncProgress& progress, Do
         on_flx_sync_progress(query_version, DownloadBatchState::MoreToCome);
     }
 
-    if (m_wrapper.m_on_bootstrap_message_processed_hook &&
-        !m_wrapper.m_on_bootstrap_message_processed_hook(progress, query_version, batch_state)) {
+    if (call_debug_hook(SyncClientHookEvent::BootstrapMessageProcessed, progress, query_version, batch_state,
+                        received_changesets.size()) == SyncClientHookAction::EarlyReturn) {
         return true;
     }
 
@@ -815,7 +813,8 @@ void SessionImpl::process_pending_flx_bootstrap()
             get_transact_reporter());
         progress = *pending_batch.progress;
 
-        download_message_integrated_hook(progress, query_version, batch_state, pending_batch.changesets.size());
+        REALM_ASSERT(call_debug_hook(SyncClientHookEvent::DownloadMessageIntegrated, progress, query_version,
+                                     batch_state, pending_batch.changesets.size()) == SyncClientHookAction::NoAction);
 
         logger.info("Integrated %1 changesets from pending bootstrap for query version %2, producing client version "
                     "%3. %4 changesets remaining in bootstrap",
@@ -860,23 +859,21 @@ void SessionImpl::non_sync_flx_completion(int64_t version)
     m_wrapper.on_flx_sync_version_complete(version);
 }
 
-void SessionImpl::receive_download_message_hook(const SyncProgress& progress, int64_t query_version,
-                                                DownloadBatchState batch_state, size_t num_changesets)
+SyncClientHookAction SessionImpl::call_debug_hook(SyncClientHookEvent event, const SyncProgress& progress,
+                                                  int64_t query_version, DownloadBatchState batch_state,
+                                                  size_t num_changesets)
 {
-    if (REALM_LIKELY(!m_wrapper.m_on_download_message_received_hook)) {
-        return;
-    }
-    m_wrapper.m_on_download_message_received_hook(progress, query_version, batch_state, num_changesets);
-}
-
-void SessionImpl::download_message_integrated_hook(const SyncProgress& progress, int64_t query_version,
-                                                   DownloadBatchState batch_state, size_t num_changesets)
-{
-    if (REALM_LIKELY(!m_wrapper.on_download_message_integrated_hook)) {
-        return;
+    if (REALM_LIKELY(!m_wrapper.m_debug_hook)) {
+        return SyncClientHookAction::NoAction;
     }
 
-    m_wrapper.on_download_message_integrated_hook(progress, query_version, batch_state, num_changesets);
+    SyncClientHookData data;
+    data.event = event;
+    data.batch_state = batch_state;
+    data.progress = progress;
+    data.num_changesets = num_changesets;
+    data.query_version = query_version;
+    return m_wrapper.m_debug_hook(data);
 }
 
 bool SessionImpl::is_steady_state_download_message(DownloadBatchState batch_state, int64_t query_version)
@@ -945,9 +942,7 @@ SessionWrapper::SessionWrapper(ClientImpl& client, DBRef db, std::shared_ptr<Sub
     , m_signed_access_token{std::move(config.signed_user_token)}
     , m_client_reset_config{std::move(config.client_reset_config)}
     , m_proxy_config{config.proxy_config} // Throws
-    , m_on_download_message_received_hook(std::move(config.on_download_message_received_hook))
-    , m_on_bootstrap_message_processed_hook(config.on_bootstrap_message_processed_hook)
-    , on_download_message_integrated_hook{std::move(config.on_download_message_integrated_hook)}
+    , m_debug_hook(std::move(config.on_sync_client_event_hook))
     , m_flx_subscription_store(std::move(flx_sub_store))
 {
     REALM_ASSERT(m_db);

--- a/src/realm/sync/client.hpp
+++ b/src/realm/sync/client.hpp
@@ -325,6 +325,8 @@ public:
         /// Will be called after a download message is integrated. For testing only.
         std::function<void(const sync::SyncProgress&, int64_t, sync::DownloadBatchState, size_t)>
             on_download_message_integrated_hook;
+
+        std::function<SyncClientHookAction(const SyncClientHookData&)> on_sync_client_event_hook;
     };
 
     /// \brief Start a new session for the specified client-side Realm.

--- a/src/realm/sync/client.hpp
+++ b/src/realm/sync/client.hpp
@@ -313,19 +313,6 @@ public:
         /// This feature exists exclusively for testing purposes at this time.
         bool simulate_integration_error = false;
 
-        /// Will be called after a download message is received and validated by
-        /// the client but befefore it's been transformed or applied. To be used in
-        /// testing only.
-        std::function<void(const sync::SyncProgress&, int64_t, sync::DownloadBatchState, size_t)>
-            on_download_message_received_hook;
-        /// Will be called after each bootstrap message is added to the pending bootstrap store,
-        /// but before processing a finalized bootstrap. For testing only.
-        std::function<bool(const sync::SyncProgress&, int64_t, sync::DownloadBatchState)>
-            on_bootstrap_message_processed_hook;
-        /// Will be called after a download message is integrated. For testing only.
-        std::function<void(const sync::SyncProgress&, int64_t, sync::DownloadBatchState, size_t)>
-            on_download_message_integrated_hook;
-
         std::function<SyncClientHookAction(const SyncClientHookData&)> on_sync_client_event_hook;
     };
 

--- a/src/realm/sync/noinst/client_impl_base.cpp
+++ b/src/realm/sync/noinst/client_impl_base.cpp
@@ -2201,8 +2201,9 @@ void Session::receive_download_message(const SyncProgress& progress, std::uint_f
         }
     }
 
-    REALM_ASSERT(call_debug_hook(SyncClientHookEvent::DownloadMessageReceived, progress, query_version, batch_state,
-                                 received_changesets.size()) == SyncClientHookAction::NoAction);
+    auto hook_action = call_debug_hook(SyncClientHookEvent::DownloadMessageReceived, progress, query_version,
+                                       batch_state, received_changesets.size());
+    REALM_ASSERT(hook_action == SyncClientHookAction::NoAction);
 
     if (process_flx_bootstrap_message(progress, batch_state, query_version, received_changesets)) {
         clear_resumption_delay_state();
@@ -2211,8 +2212,9 @@ void Session::receive_download_message(const SyncProgress& progress, std::uint_f
 
     initiate_integrate_changesets(downloadable_bytes, batch_state, progress, received_changesets); // Throws
 
-    REALM_ASSERT(call_debug_hook(SyncClientHookEvent::DownloadMessageIntegrated, progress, query_version, batch_state,
-                                 received_changesets.size()) == SyncClientHookAction::NoAction);
+    hook_action = call_debug_hook(SyncClientHookEvent::DownloadMessageIntegrated, progress, query_version,
+                                  batch_state, received_changesets.size());
+    REALM_ASSERT(hook_action == SyncClientHookAction::NoAction);
 
     // When we receive a DOWNLOAD message successfully, we can clear the backoff timer value used to reconnect
     // after a retryable session error.

--- a/src/realm/sync/noinst/client_impl_base.cpp
+++ b/src/realm/sync/noinst/client_impl_base.cpp
@@ -2201,7 +2201,8 @@ void Session::receive_download_message(const SyncProgress& progress, std::uint_f
         }
     }
 
-    receive_download_message_hook(progress, query_version, batch_state, received_changesets.size());
+    REALM_ASSERT(call_debug_hook(SyncClientHookEvent::DownloadMessageReceived, progress, query_version, batch_state,
+                                 received_changesets.size()) == SyncClientHookAction::NoAction);
 
     if (process_flx_bootstrap_message(progress, batch_state, query_version, received_changesets)) {
         clear_resumption_delay_state();
@@ -2210,7 +2211,8 @@ void Session::receive_download_message(const SyncProgress& progress, std::uint_f
 
     initiate_integrate_changesets(downloadable_bytes, batch_state, progress, received_changesets); // Throws
 
-    download_message_integrated_hook(progress, query_version, batch_state, received_changesets.size());
+    REALM_ASSERT(call_debug_hook(SyncClientHookEvent::DownloadMessageIntegrated, progress, query_version, batch_state,
+                                 received_changesets.size()) == SyncClientHookAction::NoAction);
 
     // When we receive a DOWNLOAD message successfully, we can clear the backoff timer value used to reconnect
     // after a retryable session error.

--- a/src/realm/sync/noinst/client_impl_base.hpp
+++ b/src/realm/sync/noinst/client_impl_base.hpp
@@ -1093,8 +1093,9 @@ private:
     bool check_received_sync_progress(const SyncProgress&, int&) noexcept;
     void check_for_upload_completion();
     void check_for_download_completion();
-    void receive_download_message_hook(const SyncProgress&, int64_t, DownloadBatchState, size_t);
-    void download_message_integrated_hook(const SyncProgress&, int64_t, DownloadBatchState, size_t);
+
+    SyncClientHookAction call_debug_hook(SyncClientHookEvent event, const SyncProgress&, int64_t, DownloadBatchState,
+                                         size_t);
 
     bool is_steady_state_download_message(DownloadBatchState batch_state, int64_t query_version);
 

--- a/test/benchmark-sync/bench_transform.cpp
+++ b/test/benchmark-sync/bench_transform.cpp
@@ -65,20 +65,25 @@ void transform_transactions(TestContext& test_context)
         Timer t{Timer::type_RealTime};
 
         Session::Config session_config;
-        session_config.on_download_message_received_hook =
-            [&](const sync::SyncProgress&, int64_t, sync::DownloadBatchState batch_state, size_t num_changesets) {
-                CHECK(batch_state == sync::DownloadBatchState::SteadyState);
-                if (num_changesets == 0)
-                    return;
-                t.reset();
-            };
-        session_config.on_download_message_integrated_hook =
-            [&](const sync::SyncProgress&, int64_t, sync::DownloadBatchState batch_state, size_t num_changesets) {
-                CHECK(batch_state == sync::DownloadBatchState::SteadyState);
-                if (num_changesets == 0)
-                    return;
-                results->submit(ident.c_str(), t.get_elapsed_time());
-            };
+        session_config.on_sync_client_event_hook = [&](const SyncClientHookData& data) {
+            CHECK(data.batch_state == sync::DownloadBatchState::SteadyState);
+            if (data.num_changesets == 0) {
+                return SyncClientHookAction::NoAction;
+            }
+
+            switch (data.event) {
+                case realm::SyncClientHookEvent::DownloadMessageReceived:
+                    t.reset();
+                    break;
+                case realm::SyncClientHookEvent::DownloadMessageIntegrated:
+                    results->submit(ident.c_str(), t.get_elapsed_time());
+                    break;
+                default:
+                    break;
+            }
+
+            return SyncClientHookAction::NoAction;
+        };
 
         Session session_1 = fixture.make_session(0, db_1, std::move(session_config));
         fixture.bind_session(session_1, 0, "/test");
@@ -141,20 +146,25 @@ void transform_instructions(TestContext& test_context)
         Timer t{Timer::type_RealTime};
 
         Session::Config session_config;
-        session_config.on_download_message_received_hook =
-            [&](const sync::SyncProgress&, int64_t, sync::DownloadBatchState batch_state, size_t num_changesets) {
-                CHECK(batch_state == sync::DownloadBatchState::SteadyState);
-                if (num_changesets == 0)
-                    return;
-                t.reset();
-            };
-        session_config.on_download_message_integrated_hook =
-            [&](const sync::SyncProgress&, int64_t, sync::DownloadBatchState batch_state, size_t num_changesets) {
-                CHECK(batch_state == sync::DownloadBatchState::SteadyState);
-                if (num_changesets == 0)
-                    return;
-                results->submit(ident.c_str(), t.get_elapsed_time());
-            };
+        session_config.on_sync_client_event_hook = [&](const SyncClientHookData& data) {
+            CHECK(data.batch_state == sync::DownloadBatchState::SteadyState);
+            if (data.num_changesets == 0) {
+                return SyncClientHookAction::NoAction;
+            }
+
+            switch (data.event) {
+                case realm::SyncClientHookEvent::DownloadMessageReceived:
+                    t.reset();
+                    break;
+                case realm::SyncClientHookEvent::DownloadMessageIntegrated:
+                    results->submit(ident.c_str(), t.get_elapsed_time());
+                    break;
+                default:
+                    break;
+            }
+
+            return SyncClientHookAction::NoAction;
+        };
         Session session_1 = fixture.make_session(0, db_1, std::move(session_config));
         fixture.bind_session(session_1, 0, "/test");
         Session session_2 = fixture.make_session(1, db_2);
@@ -214,20 +224,25 @@ void connected_objects(TestContext& test_context)
         Timer t{Timer::type_RealTime};
 
         Session::Config session_config;
-        session_config.on_download_message_received_hook =
-            [&](const sync::SyncProgress&, int64_t, sync::DownloadBatchState batch_state, size_t num_changesets) {
-                CHECK(batch_state == sync::DownloadBatchState::SteadyState);
-                if (num_changesets == 0)
-                    return;
-                t.reset();
-            };
-        session_config.on_download_message_integrated_hook =
-            [&](const sync::SyncProgress&, int64_t, sync::DownloadBatchState batch_state, size_t num_changesets) {
-                CHECK(batch_state == sync::DownloadBatchState::SteadyState);
-                if (num_changesets == 0)
-                    return;
-                results->submit(ident.c_str(), t.get_elapsed_time());
-            };
+        session_config.on_sync_client_event_hook = [&](const SyncClientHookData& data) {
+            CHECK(data.batch_state == sync::DownloadBatchState::SteadyState);
+            if (data.num_changesets == 0) {
+                return SyncClientHookAction::NoAction;
+            }
+
+            switch (data.event) {
+                case realm::SyncClientHookEvent::DownloadMessageReceived:
+                    t.reset();
+                    break;
+                case realm::SyncClientHookEvent::DownloadMessageIntegrated:
+                    results->submit(ident.c_str(), t.get_elapsed_time());
+                    break;
+                default:
+                    break;
+            }
+
+            return SyncClientHookAction::NoAction;
+        };
         Session session_1 = fixture.make_session(0, db_1, std::move(session_config));
         fixture.bind_session(session_1, 0, "/test");
         Session session_2 = fixture.make_session(1, db_2);

--- a/test/object-store/sync/flx_sync.cpp
+++ b/test/object-store/sync/flx_sync.cpp
@@ -1063,23 +1063,27 @@ TEST_CASE("flx: interrupted bootstrap restarts/recovers on reconnect", "[sync][f
         Realm::Config config = interrupted_realm_config;
         config.sync_config = std::make_shared<SyncConfig>(*interrupted_realm_config.sync_config);
         auto shared_promise = std::make_shared<util::Promise<void>>(std::move(interrupted_promise));
-        config.sync_config->on_download_message_received_hook = [promise = std::move(shared_promise)](
-                                                                    std::weak_ptr<SyncSession> weak_session,
-                                                                    const sync::SyncProgress&, int64_t query_version,
-                                                                    sync::DownloadBatchState batch_state,
-                                                                    size_t) mutable {
+        config.sync_config->on_sync_client_event_hook = [promise = std::move(shared_promise)](
+                                                            std::weak_ptr<SyncSession> weak_session,
+                                                            const SyncClientHookData& data) mutable {
+            if (data.event != SyncClientHookEvent::DownloadMessageReceived) {
+                return SyncClientHookAction::NoAction;
+            }
+
             auto session = weak_session.lock();
             if (!session) {
-                return;
+                return SyncClientHookAction::NoAction;
             }
 
             auto latest_subs = session->get_flx_subscription_store()->get_latest();
             if (latest_subs.version() == 1 && latest_subs.state() == sync::SubscriptionSet::State::Bootstrapping) {
-                REQUIRE(query_version == 1);
-                REQUIRE(batch_state == sync::DownloadBatchState::MoreToCome);
+                REQUIRE(data.query_version == 1);
+                REQUIRE(data.batch_state == sync::DownloadBatchState::MoreToCome);
                 session->close();
                 promise->emplace_value();
             }
+
+            return SyncClientHookAction::NoAction;
         };
 
         auto realm = Realm::get_shared_realm(config);
@@ -1521,21 +1525,23 @@ TEST_CASE("flx: bootstrap batching prevents orphan documents", "[sync][flx][app]
             Realm::Config config = interrupted_realm_config;
             config.sync_config = std::make_shared<SyncConfig>(*interrupted_realm_config.sync_config);
             auto shared_promise = std::make_shared<util::Promise<void>>(std::move(interrupted_promise));
-            config.sync_config->on_bootstrap_message_processed_hook =
+            config.sync_config->on_sync_client_event_hook =
                 [promise = std::move(shared_promise)](std::weak_ptr<SyncSession> weak_session,
-                                                      const sync::SyncProgress&, int64_t query_version,
-                                                      sync::DownloadBatchState batch_state) mutable {
+                                                      const SyncClientHookData& data) mutable {
+                    if (data.event != SyncClientHookEvent::BootstrapMessageProcessed) {
+                        return SyncClientHookAction::NoAction;
+                    }
                     auto session = weak_session.lock();
                     if (!session) {
-                        return true;
+                        return SyncClientHookAction::NoAction;
                     }
 
-                    if (query_version == 1 && batch_state == sync::DownloadBatchState::LastInBatch) {
+                    if (data.query_version == 1 && data.batch_state == sync::DownloadBatchState::LastInBatch) {
                         session->close();
                         promise->emplace_value();
-                        return false;
+                        return SyncClientHookAction::EarlyReturn;
                     }
-                    return true;
+                    return SyncClientHookAction::NoAction;
                 };
             auto realm = Realm::get_shared_realm(config);
             {
@@ -1586,21 +1592,23 @@ TEST_CASE("flx: bootstrap batching prevents orphan documents", "[sync][flx][app]
             Realm::Config config = interrupted_realm_config;
             config.sync_config = std::make_shared<SyncConfig>(*interrupted_realm_config.sync_config);
             auto shared_promise = std::make_shared<util::Promise<void>>(std::move(interrupted_promise));
-            config.sync_config->on_bootstrap_message_processed_hook =
+            config.sync_config->on_sync_client_event_hook =
                 [promise = std::move(shared_promise)](std::weak_ptr<SyncSession> weak_session,
-                                                      const sync::SyncProgress&, int64_t query_version,
-                                                      sync::DownloadBatchState batch_state) mutable {
+                                                      const SyncClientHookData& data) mutable {
+                    if (data.event != SyncClientHookEvent::BootstrapMessageProcessed) {
+                        return SyncClientHookAction::NoAction;
+                    }
                     auto session = weak_session.lock();
                     if (!session) {
-                        return true;
+                        return SyncClientHookAction::NoAction;
                     }
 
-                    if (query_version == 1 && batch_state == sync::DownloadBatchState::MoreToCome) {
+                    if (data.query_version == 1 && data.batch_state == sync::DownloadBatchState::MoreToCome) {
                         session->close();
                         promise->emplace_value();
-                        return false;
+                        return SyncClientHookAction::EarlyReturn;
                     }
-                    return true;
+                    return SyncClientHookAction::NoAction;
                 };
             auto realm = Realm::get_shared_realm(config);
             {
@@ -1661,21 +1669,23 @@ TEST_CASE("flx: bootstrap batching prevents orphan documents", "[sync][flx][app]
             Realm::Config config = interrupted_realm_config;
             config.sync_config = std::make_shared<SyncConfig>(*interrupted_realm_config.sync_config);
             auto shared_promise = std::make_shared<util::Promise<void>>(std::move(interrupted_promise));
-            config.sync_config->on_bootstrap_message_processed_hook =
+            config.sync_config->on_sync_client_event_hook =
                 [promise = std::move(shared_promise)](std::weak_ptr<SyncSession> weak_session,
-                                                      const sync::SyncProgress, int64_t query_version,
-                                                      sync::DownloadBatchState batch_state) mutable {
+                                                      const SyncClientHookData& data) mutable {
+                    if (data.event != SyncClientHookEvent::BootstrapMessageProcessed) {
+                        return SyncClientHookAction::NoAction;
+                    }
                     auto session = weak_session.lock();
                     if (!session) {
-                        return true;
+                        return SyncClientHookAction::NoAction;
                     }
 
-                    if (query_version == 1 && batch_state == sync::DownloadBatchState::LastInBatch) {
+                    if (data.query_version == 1 && data.batch_state == sync::DownloadBatchState::LastInBatch) {
                         session->close();
                         promise->emplace_value();
-                        return false;
+                        return SyncClientHookAction::EarlyReturn;
                     }
-                    return true;
+                    return SyncClientHookAction::NoAction;
                 };
             auto realm = Realm::get_shared_realm(config);
             {
@@ -1718,17 +1728,19 @@ TEST_CASE("flx: bootstrap batching prevents orphan documents", "[sync][flx][app]
         // This hook will let us check what the state of the realm is before it's integrated any new download
         // messages from the server. This should be the full 5 object bootstrap that was received before we
         // called mutate_realm().
-        interrupted_realm_config.sync_config->on_download_message_received_hook =
+        interrupted_realm_config.sync_config->on_sync_client_event_hook =
             [&, promise = std::move(shared_saw_valid_state_promise)](std::weak_ptr<SyncSession> weak_session,
-                                                                     const sync::SyncProgress&, int64_t query_version,
-                                                                     sync::DownloadBatchState batch_state, size_t) {
+                                                                     const SyncClientHookData& data) {
+                if (data.event != SyncClientHookEvent::DownloadMessageReceived) {
+                    return SyncClientHookAction::NoAction;
+                }
                 auto session = weak_session.lock();
                 if (!session) {
-                    return;
+                    return SyncClientHookAction::NoAction;
                 }
 
-                if (query_version != 1 || batch_state == sync::DownloadBatchState::MoreToCome) {
-                    return;
+                if (data.query_version != 1 || data.batch_state == sync::DownloadBatchState::MoreToCome) {
+                    return SyncClientHookAction::NoAction;
                 }
 
                 auto latest_sub_set = session->get_flx_subscription_store()->get_latest();
@@ -1746,6 +1758,7 @@ TEST_CASE("flx: bootstrap batching prevents orphan documents", "[sync][flx][app]
                 }
 
                 promise->emplace_value();
+                return SyncClientHookAction::NoAction;
             };
 
         // Finally re-open the realm whose bootstrap we interrupted and just wait for it to finish downloading.


### PR DESCRIPTION
## What, How & Why?
I've been writing tests that need to add more and more hooks into the sync client to be able to deterministically check our state/inject faults, so I decided to unify them into a single hook that takes a struct and an event and returns an action, rather than adding more and more discrete hooks.

## ☑️ ToDos
* [ ] 📝 Changelog update
* [ ] 🚦 Tests (or not relevant)
* [ ] C-API, if public C++ API changed.
