### PR TITLE
Optimize Realm::freeze()

### DIFF
--- a/src/realm/object-store/shared_realm.hpp
+++ b/src/realm/object-store/shared_realm.hpp
@@ -486,6 +486,8 @@ public:
 private:
     struct MakeSharedTag {
     };
+    struct MakeFrozenTag {
+    };
 
     std::shared_ptr<_impl::RealmCoordinator> m_coordinator;
 
@@ -568,6 +570,7 @@ public:
     // `enable_shared_from_this` is unsafe with public constructors; use `make_shared_realm` instead
     Realm(Config config, util::Optional<VersionID> version, std::shared_ptr<_impl::RealmCoordinator> coordinator,
           MakeSharedTag);
+    Realm(const Realm&, MakeFrozenTag);
 };
 
 class RealmFileException : public std::runtime_error {

--- a/test/object-store/frozen_objects.cpp
+++ b/test/object-store/frozen_objects.cpp
@@ -165,7 +165,7 @@ TEST_CASE("Freeze Results", "[freeze_results]") {
     realm->commit_transaction();
 
     Results results(realm, table);
-    auto frozen_realm = Realm::get_frozen_realm(config, realm->read_transaction_version());
+    auto frozen_realm = realm->freeze();
     Results frozen_results = results.freeze(frozen_realm);
 
     SECTION("is_frozen") {


### PR DESCRIPTION
Just stumbled across the implementation of Realm::freeze(). It worked by constructing a new Realm totally from scratch based on the config of the old realm. That seems to be a waste of time as we could just take a copy of the old Realm except for the transaction where we would get a new frozen one.