### PR TITLE
Delete set_backlink_class_prefix() and the serializer options to set the prefix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@
 ### Internals
 * Remove the unused utility function `copy_dir_recursive()`.
 * StringData and Timestamp are now constexpr-constructible.
+* Remove `set_backlink_class_prefix()` and just always use the `class_` prefix when parsing or serializing queries.
 
 ----------------------------------------------
 

--- a/src/realm/object-store/keypath_helpers.hpp
+++ b/src/realm/object-store/keypath_helpers.hpp
@@ -26,8 +26,6 @@ namespace realm {
 /// Populate the mapping from public name to internal name for queries.
 inline void populate_keypath_mapping(query_parser::KeyPathMapping& mapping, Realm& realm)
 {
-    mapping.set_backlink_class_prefix("class_");
-
     for (auto& object_schema : realm.schema()) {
         TableRef table;
         auto get_table = [&] {

--- a/src/realm/parser/driver.hpp
+++ b/src/realm/parser/driver.hpp
@@ -533,8 +533,6 @@ public:
         parse_error = true;
     }
 
-    StringData get_printable_name(StringData table_name) const;
-
     template <class T>
     Query simple_query(int op, ColKey col_key, T val, bool case_sensitive);
     template <class T>

--- a/src/realm/parser/keypath_mapping.hpp
+++ b/src/realm/parser/keypath_mapping.hpp
@@ -72,17 +72,11 @@ public:
     bool remove_table_mapping(std::string alias_to_remove);
     bool has_table_mapping(const std::string& alias) const;
     util::Optional<std::string> get_table_mapping(const std::string name) const;
-    void set_backlink_class_prefix(std::string prefix);
-    const std::string& get_backlink_class_prefix() const
-    {
-        return m_backlink_class_prefix;
-    }
     std::string translate(LinkChain&, const std::string& identifier);
     std::string translate(ConstTableRef table, const std::string& identifier);
     std::string translate_table_name(const std::string& identifier);
 
 protected:
-    std::string m_backlink_class_prefix;
     std::unordered_map<std::pair<TableKey, std::string>, std::string, TableAndColHash> m_mapping;
     std::unordered_map<std::string, std::string> m_table_mappings;
 };

--- a/src/realm/parser/query_parser.hpp
+++ b/src/realm/parser/query_parser.hpp
@@ -109,7 +109,7 @@ public:
         : m_count(num_args)
     {
     }
-    virtual ~Arguments();
+    virtual ~Arguments() = default;
     virtual bool bool_for_argument(size_t argument_index) = 0;
     virtual long long long_for_argument(size_t argument_index) = 0;
     virtual float float_for_argument(size_t argument_index) = 0;

--- a/src/realm/query.cpp
+++ b/src/realm/query.cpp
@@ -1627,9 +1627,9 @@ util::bind_ptr<DescriptorOrdering> Query::get_ordering()
     return std::move(m_ordering);
 }
 
-std::string Query::get_description(const std::string& class_prefix) const
+std::string Query::get_description() const
 {
-    util::serializer::SerialisationState state(class_prefix, m_table->get_parent_group());
+    util::serializer::SerialisationState state(m_table->get_parent_group());
     return get_description(state);
 }
 

--- a/src/realm/query.hpp
+++ b/src/realm/query.hpp
@@ -306,7 +306,7 @@ public:
     // or empty vector if the query is not associated with a table.
     TableVersions sync_view_if_needed() const;
 
-    std::string get_description(const std::string& class_prefix = "") const;
+    std::string get_description() const;
     std::string get_description(util::serializer::SerialisationState& state) const;
 
     Query& set_ordering(util::bind_ptr<DescriptorOrdering> ordering);

--- a/src/realm/query_expression.hpp
+++ b/src/realm/query_expression.hpp
@@ -3822,7 +3822,7 @@ public:
 
     virtual std::string description(util::serializer::SerialisationState& state) const override
     {
-        util::serializer::SerialisationState empty_state(state.class_prefix, state.group);
+        util::serializer::SerialisationState empty_state(state.group);
         return state.describe_columns(m_link_map, ColKey()) + util::serializer::value_separator +
                Operation::description() + util::serializer::value_separator + m_column.description(empty_state);
     }

--- a/src/realm/table.cpp
+++ b/src/realm/table.cpp
@@ -341,8 +341,9 @@ void LinkChain::add(ColKey ck)
     }
     else {
         // Only last column in link chain is allowed to be non-link
-        throw std::runtime_error(util::format("%1.%2 is not an object reference property",
-                                              m_current_table->get_name(), m_current_table->get_column_name(ck)));
+        throw std::runtime_error(util::format("Property '%1.%2' is not an object reference",
+                                              m_current_table->get_class_name(),
+                                              m_current_table->get_column_name(ck)));
     }
     m_link_cols.push_back(ck);
 }

--- a/src/realm/table.hpp
+++ b/src/realm/table.hpp
@@ -983,7 +983,8 @@ public:
     {
         auto ck = m_current_table->get_column_key(col_name);
         if (!ck) {
-            throw std::runtime_error(util::format("%1 has no property %2", m_current_table->get_name(), col_name));
+            throw std::runtime_error(
+                util::format("'%1' has no property '%2'", m_current_table->get_class_name(), col_name));
         }
         add(ck);
         return *this;

--- a/src/realm/util/serializer.cpp
+++ b/src/realm/util/serializer.cpp
@@ -192,14 +192,6 @@ std::string print_value<>(realm::UUID uuid)
     return "uuid(" + uuid.to_string() + ")";
 }
 
-StringData get_printable_table_name(StringData name, const std::string& prefix)
-{
-    if (prefix.size() && name.size() > prefix.size() && strncmp(name.data(), prefix.data(), prefix.size()) == 0) {
-        name = StringData(name.data() + prefix.size(), name.size() - prefix.size());
-    }
-    return name;
-}
-
 template <>
 std::string print_value<>(realm::TypeOfValue type)
 {
@@ -251,7 +243,7 @@ std::string SerialisationState::get_column_name(ConstTableRef table, ColKey col_
     if (col_type == col_type_BackLink) {
         const Table::BacklinkOrigin origin = table->find_backlink_origin(col_key);
         REALM_ASSERT(origin);
-        std::string source_table_name = get_printable_table_name(origin->first->get_name(), class_prefix);
+        std::string source_table_name = origin->first->get_class_name();
         std::string source_col_name = get_column_name(origin->first, origin->second);
 
         return "@links" + util::serializer::value_separator + source_table_name + util::serializer::value_separator +

--- a/src/realm/util/serializer.hpp
+++ b/src/realm/util/serializer.hpp
@@ -96,12 +96,9 @@ std::string print_value(Optional<T> value)
     }
 }
 
-StringData get_printable_table_name(StringData name, const std::string& prefix);
-
 struct SerialisationState {
-    SerialisationState(const std::string& prefix, Group* g)
-        : class_prefix(prefix)
-        , group(g)
+    SerialisationState(Group* g = nullptr) noexcept
+        : group(g)
     {
     }
     std::string describe_column(ConstTableRef table, ColKey col_key);
@@ -111,7 +108,6 @@ struct SerialisationState {
     std::string get_backlink_column_name(ConstTableRef from, ColKey col_key);
     std::string get_variable_name(ConstTableRef table);
     std::vector<std::string> subquery_prefix_list;
-    std::string class_prefix;
     Group* group;
     ConstTableRef target_table;
 };

--- a/test/test_parser.cpp
+++ b/test/test_parser.cpp
@@ -414,7 +414,7 @@ static Query verify_query(test_util::unit_test::TestContext& test_context, Table
 
     size_t q_count = q.count();
     CHECK_EQUAL(q_count, num_results);
-    std::string description = q.get_description(mapping.get_backlink_class_prefix());
+    std::string description = q.get_description();
     // std::cerr << "original: " << query_string << "\tdescribed: " << description << "\n";
     Query q2 = t->query(description, args, mapping);
 
@@ -1468,14 +1468,11 @@ TEST(Parser_substitution)
     verify_query_sub(test_context, t, "(age > $0 || fees == $1) && age == $0", args, num_args, 1);
 
     // negative index
-    // FIXME: Should the error be std::out_of_range or SyntaxError?
-    CHECK_THROW(verify_query_sub(test_context, t, "age > $-1", args, num_args, 0), std::runtime_error);
+    CHECK_THROW(verify_query_sub(test_context, t, "age > $-1", args, num_args, 0), query_parser::InvalidQueryError);
     // missing index
-    // FIXME: Should the error be SyntaxError?
-    CHECK_THROW(verify_query_sub(test_context, t, "age > $", args, num_args, 0), std::runtime_error);
+    CHECK_THROW(verify_query_sub(test_context, t, "age > $", args, num_args, 0), query_parser::InvalidQueryError);
     // non-numerical index
-    // FIXME: Should the error be SyntaxError?
-    CHECK_THROW(verify_query_sub(test_context, t, "age > $age", args, num_args, 0), std::runtime_error);
+    CHECK_THROW(verify_query_sub(test_context, t, "age > $age", args, num_args, 0), query_parser::InvalidQueryError);
     // leading zero index
     verify_query_sub(test_context, t, "name CONTAINS[c] $002", args, num_args, 2);
     // double digit index
@@ -2338,7 +2335,7 @@ TEST_TYPES(Parser_list_of_primitive_element_lengths, StringData, BinaryData)
 
     std::string message;
     CHECK_THROW_ANY_GET_MESSAGE(verify_query(test_context, t, "values.len == 2", 0), message);
-    CHECK_EQUAL(message, "Property 'values' in 'table' is not an Object");
+    CHECK_EQUAL(message, "Property 'table.values' is not an object reference");
 }
 
 TEST_TYPES(Parser_list_of_primitive_types, Prop<Int>, Nullable<Int>, Prop<Bool>, Nullable<Bool>, Prop<Float>,
@@ -2418,13 +2415,13 @@ TEST_TYPES(Parser_list_of_primitive_types, Prop<Int>, Nullable<Int>, Prop<Bool>,
     }
     std::string message;
     CHECK_THROW_ANY_GET_MESSAGE(verify_query(test_context, t, "missing.length == 2", 0), message);
-    CHECK_EQUAL(message, "'table' has no property: 'missing'");
+    CHECK_EQUAL(message, "'table' has no property 'missing'");
     if constexpr (realm::is_any_v<underlying_type, StringData, BinaryData>) {
         verify_query(test_context, t, "values.length == 0", 1);
     }
     else {
         CHECK_THROW_ANY_GET_MESSAGE(verify_query(test_context, t, "values.length == 2", 0), message);
-        CHECK_EQUAL(message, "Property 'values' in 'table' is not an Object");
+        CHECK_EQUAL(message, "Property 'table.values' is not an object reference");
     }
 }
 
@@ -2628,7 +2625,7 @@ TEST(Parser_SortAndDistinctSerialisation)
 static TableView get_sorted_view(TableRef t, std::string query_string, query_parser::KeyPathMapping mapping = {})
 {
     Query q = t->query(query_string, std::vector<Mixed>{}, mapping);
-    std::string query_description = q.get_description(mapping.get_backlink_class_prefix());
+    std::string query_description = q.get_description();
     Query q2 = t->query(query_description, std::vector<Mixed>{}, mapping);
     return q2.find_all();
 }
@@ -3092,52 +3089,50 @@ TEST(Parser_Backlinks)
     Query q = items->backlink(*t, fav_col).column<Double>(account_col) > 20;
     CHECK_EQUAL(q.count(), 1);
     std::string desc = q.get_description();
-    CHECK(desc.find("@links.class_Person.fav\\ item.account_balance") != std::string::npos);
+    CHECK(desc.find("@links.Person.fav\\ item.account_balance") != std::string::npos);
 
     q = items->backlink(*t, items_col).column<Double>(account_col) > 20;
     CHECK_EQUAL(q.count(), 2);
     desc = q.get_description();
-    CHECK(desc.find("@links.class_Person.items.account_balance") != std::string::npos);
+    CHECK(desc.find("@links.Person.items.account_balance") != std::string::npos);
 
     // favourite items bought by people who have > 20 in their account
-    verify_query(test_context, items, "@links.class_Person.fav\\ item.account_balance > 20", 1); // backlinks via link
+    verify_query(test_context, items, "@links.Person.fav\\ item.account_balance > 20", 1); // backlinks via link
     // items bought by people who have > 20 in their account
-    verify_query(test_context, items, "@links.class_Person.items.account_balance > 20", 2); // backlinks via list
+    verify_query(test_context, items, "@links.Person.items.account_balance > 20", 2); // backlinks via list
     // items bought by people who have 'J' as the first letter of their name
-    verify_query(test_context, items, "@links.class_Person.items.name LIKE[c] 'j*'", 3);
-    verify_query(test_context, items, "@links.class_Person.items.name BEGINSWITH 'J'", 3);
+    verify_query(test_context, items, "@links.Person.items.name LIKE[c] 'j*'", 3);
+    verify_query(test_context, items, "@links.Person.items.name BEGINSWITH 'J'", 3);
 
     // items purchased more than twice
-    verify_query(test_context, items, "@links.class_Person.items.@count > 2", 2);
-    verify_query(test_context, items, "@links.class_Person.items.@size > 2", 2);
+    verify_query(test_context, items, "@links.Person.items.@count > 2", 2);
+    verify_query(test_context, items, "@links.Person.items.@size > 2", 2);
     // items bought by people with only $10 in their account
-    verify_query(test_context, items, "@links.class_Person.items.@min.account_balance <= 10", 4);
+    verify_query(test_context, items, "@links.Person.items.@min.account_balance <= 10", 4);
     // items bought by people with more than $10 in their account
-    verify_query(test_context, items, "@links.class_Person.items.@max.account_balance > 10", 3);
+    verify_query(test_context, items, "@links.Person.items.@max.account_balance > 10", 3);
     // items bought where the sum of the account balance of purchasers is more than $20
-    verify_query(test_context, items, "@links.class_Person.items.@sum.account_balance > 20", 3);
-    verify_query(test_context, items, "@links.class_Person.items.@avg.account_balance > 20", 1);
+    verify_query(test_context, items, "@links.Person.items.@sum.account_balance > 20", 3);
+    verify_query(test_context, items, "@links.Person.items.@avg.account_balance > 20", 1);
     // subquery over backlinks
-    verify_query(test_context, items, "SUBQUERY(@links.class_Person.items, $x, $x.account_balance >= 20).@count > 2",
-                 1);
+    verify_query(test_context, items, "SUBQUERY(@links.Person.items, $x, $x.account_balance >= 20).@count > 2", 1);
 
     // backlinks over link
     // people having a favourite item which is also the favourite item of another person
-    verify_query(test_context, t, "fav\\ item.@links.class_Person.fav\\ item.@count > 1", 0);
+    verify_query(test_context, t, "fav\\ item.@links.Person.fav\\ item.@count > 1", 0);
     // people having a favourite item which is purchased more than once (by anyone)
-    verify_query(test_context, t, "fav\\ item.@links.class_Person.items.@count > 1 ", 2);
+    verify_query(test_context, t, "fav\\ item.@links.Person.items.@count > 1 ", 2);
 
     std::string message;
-    CHECK_THROW_ANY_GET_MESSAGE(verify_query(test_context, items, "@links.class_Person.items == NULL", 1), message);
-    CHECK_EQUAL(message, "Cannot compare linklist ('@links.class_Person.items') with NULL");
-    CHECK_THROW_ANY_GET_MESSAGE(verify_query(test_context, items, "@links.class_Person.fav\\ item == NULL", 1),
-                                message);
-    CHECK_EQUAL(message, "Cannot compare linklist ('@links.class_Person.fav\\ item') with NULL");
+    CHECK_THROW_ANY_GET_MESSAGE(verify_query(test_context, items, "@links.Person.items == NULL", 1), message);
+    CHECK_EQUAL(message, "Cannot compare linklist ('@links.Person.items') with NULL");
+    CHECK_THROW_ANY_GET_MESSAGE(verify_query(test_context, items, "@links.Person.fav\\ item == NULL", 1), message);
+    CHECK_EQUAL(message, "Cannot compare linklist ('@links.Person.fav\\ item') with NULL");
     CHECK_THROW_ANY(verify_query(test_context, items, "@links.attr. > 0", 1));
 
     // check that arbitrary aliasing for named backlinks works
     query_parser::KeyPathMapping mapping;
-    mapping.add_mapping(items, "purchasers", "@links.class_Person.items");
+    mapping.add_mapping(items, "purchasers", "@links.Person.items");
     mapping.add_mapping(t, "money", "account_balance");
     mapping.add_table_mapping(t, "my-custom-class-name");
 
@@ -3145,9 +3140,7 @@ TEST(Parser_Backlinks)
     verify_query(test_context, items, "purchasers.@max.money >= 20", 3, mapping);
     verify_query(test_context, items, "@links.my-custom-class-name.items.@count > 2", 2, mapping);
 
-    // check that arbitrary aliasing for named backlinks works with a arbitrary prefix
     query_parser::KeyPathMapping mapping_with_prefix;
-    mapping_with_prefix.set_backlink_class_prefix("class_");
     mapping_with_prefix.add_mapping(items, "purchasers", "@links.Person.items");
     mapping_with_prefix.add_mapping(t, "things", "items");
     mapping_with_prefix.add_mapping(t, "money", "account_balance");
@@ -3269,25 +3262,25 @@ TEST(Parser_BacklinkCount)
     verify_query(test_context, t, "items.@links.@count == 10 && customer_id == 2", 1);  // 5 + 5
 
     // backlink count through backlinks first
-    verify_query(test_context, items, "@links.class_Items.self.@links.@count == 1 && item_id == 14", 1);
-    verify_query(test_context, items, "@links.class_Person.items.@links.@count == 0", 5);
+    verify_query(test_context, items, "@links.Items.self.@links.@count == 1 && item_id == 14", 1);
+    verify_query(test_context, items, "@links.Person.items.@links.@count == 0", 5);
 
     // backlink count through backlinks and forward links
-    verify_query(test_context, items, "@links.class_Person.fav_item.items.@links.@count == 130 && item_id == 2", 1);
-    verify_query(test_context, items, "@links.class_Person.fav_item.fav_item.@links.@count == 3 && item_id == 2", 1);
+    verify_query(test_context, items, "@links.Person.fav_item.items.@links.@count == 130 && item_id == 2", 1);
+    verify_query(test_context, items, "@links.Person.fav_item.fav_item.@links.@count == 3 && item_id == 2", 1);
 
     // backlink count compared to int
     verify_query(test_context, items, "@links.@count == 0", 1);
     verify_query(test_context, items, "@links.@count >= item_id", 2); // 2 items have an id less than
                                                                       // their backlink count
-    verify_query(test_context, items, "@links.@count >= @links.class_Person.fav_item.customer_id", 3);
+    verify_query(test_context, items, "@links.@count >= @links.Person.fav_item.customer_id", 3);
 
     // backlink count compared to double
     verify_query(test_context, items, "@links.@count == 0.0", 1);
     verify_query(test_context, items, "@links.@count >= double_col", 3);
 
     // backlink count compared to float
-    verify_query(test_context, items, "@links.@count >= @links.class_Person.fav_item.float_col", 3);
+    verify_query(test_context, items, "@links.@count >= @links.Person.fav_item.float_col", 3);
 
     // backlink count compared to link count
     verify_query(test_context, items, "@links.@count >= self.@count", 5);
@@ -3295,9 +3288,9 @@ TEST(Parser_BacklinkCount)
 
     // all backlinks count compared to single column backlink count
     // this is essentially checking if a single column contains all backlinks of a object
-    verify_query(test_context, items, "@links.@count == @links.class_Person.fav_item.@count", 1); // item 5 (0 links)
-    verify_query(test_context, items, "@links.@count == @links.class_Person.items.@count", 1);    // item 5 (0 links)
-    verify_query(test_context, items, "@links.@count == @links.class_Items.self.@count", 2); // items 4,5 (1,0 links)
+    verify_query(test_context, items, "@links.@count == @links.Person.fav_item.@count", 1); // item 5 (0 links)
+    verify_query(test_context, items, "@links.@count == @links.Person.items.@count", 1);    // item 5 (0 links)
+    verify_query(test_context, items, "@links.@count == @links.Items.self.@count", 2);      // items 4,5 (1,0 links)
 
     std::string message;
     // backlink count requires comparison to a numeric type
@@ -3326,7 +3319,7 @@ TEST(Parser_BacklinksIndex)
 {
     Group g;
 
-    TableRef items = g.add_table("items");
+    TableRef items = g.add_table("class_items");
     auto col_id = items->add_column(type_Int, "item_id");
 
     std::vector<int64_t> item_ids{5, 2, 12, 14, 20};
@@ -3335,7 +3328,7 @@ TEST(Parser_BacklinksIndex)
         items->create_object(item_keys[i]).set(col_id, item_ids[i]);
     }
 
-    auto person = g.add_table("person");
+    auto person = g.add_table("class_person");
     auto col_age = person->add_column(type_Int, "age");
     person->add_search_index(col_age);
     auto col_link = person->add_column_list(*items, "owns");
@@ -3367,7 +3360,7 @@ TEST(Parser_BacklinksIndex)
 TEST(Parser_SubqueryVariableNames)
 {
     Group g;
-    util::serializer::SerialisationState test_state("", nullptr);
+    util::serializer::SerialisationState test_state;
 
     TableRef test_table = g.add_table("test");
 
@@ -3499,7 +3492,7 @@ TEST(Parser_Subquery)
                 items->column<Link>(item_contains_col).count() > 1;
     Query q = t->column<Link>(items_col, sub).count() > 1;
 
-    std::string subquery_description = q.get_description("class_");
+    std::string subquery_description = q.get_description();
     CHECK(subquery_description.find("SUBQUERY(items, $x,") != std::string::npos);
     CHECK(subquery_description.find(" $x.name ") != std::string::npos);
     CHECK(subquery_description.find(" $x.price ") != std::string::npos);
@@ -3558,7 +3551,7 @@ TEST(Parser_Subquery)
     std::string message;
     CHECK_THROW_ANY_GET_MESSAGE(verify_query(test_context, t,
                                              "SUBQUERY(items, $x, "
-                                             "SUBQUERY($x.discount.@links.class_Items.discount, $x, "
+                                             "SUBQUERY($x.discount.@links.Items.discount, $x, "
                                              "$x.price > 5).@count > 0).@count > 0",
                                              2),
                                 message);
@@ -3697,10 +3690,10 @@ TEST_TYPES(Parser_AggregateShortcuts, std::true_type, std::false_type)
     verify_query(test_context, t, "SUBQUERY(items, $x, NONE $x.allergens.name CONTAINS[c] 'WHEAT').@count > 0", 2);
 
     // backlinks
-    verify_query(test_context, items, "ANY @links.class_Person.items.account_balance > 15", 3);
-    verify_query(test_context, items, "SOME @links.class_Person.items.account_balance > 15", 3);
-    verify_query(test_context, items, "ALL @links.class_Person.items.account_balance > 15", 0);
-    verify_query(test_context, items, "NONE @links.class_Person.items.account_balance > 15", 1);
+    verify_query(test_context, items, "ANY @links.Person.items.account_balance > 15", 3);
+    verify_query(test_context, items, "SOME @links.Person.items.account_balance > 15", 3);
+    verify_query(test_context, items, "ALL @links.Person.items.account_balance > 15", 0);
+    verify_query(test_context, items, "NONE @links.Person.items.account_balance > 15", 1);
 
     // links in prefix
     verify_query(test_context, t, "ANY fav_item.allergens.name CONTAINS 'dairy'", 2);
@@ -3709,10 +3702,10 @@ TEST_TYPES(Parser_AggregateShortcuts, std::true_type, std::false_type)
     verify_query(test_context, t, "NONE fav_item.allergens.name CONTAINS 'dairy'", 1);
 
     // links in suffix
-    verify_query(test_context, items, "ANY @links.class_Person.items.fav_item.name CONTAINS 'milk'", 4);
-    verify_query(test_context, items, "SOME @links.class_Person.items.fav_item.name CONTAINS 'milk'", 4);
-    verify_query(test_context, items, "ALL @links.class_Person.items.fav_item.name CONTAINS 'milk'", 1);
-    verify_query(test_context, items, "NONE @links.class_Person.items.fav_item.name CONTAINS 'milk'", 0);
+    verify_query(test_context, items, "ANY @links.Person.items.fav_item.name CONTAINS 'milk'", 4);
+    verify_query(test_context, items, "SOME @links.Person.items.fav_item.name CONTAINS 'milk'", 4);
+    verify_query(test_context, items, "ALL @links.Person.items.fav_item.name CONTAINS 'milk'", 1);
+    verify_query(test_context, items, "NONE @links.Person.items.fav_item.name CONTAINS 'milk'", 0);
 
     // compare with property
     verify_query(test_context, t, "ANY items.name == fav_item.name", 2);
@@ -3893,7 +3886,7 @@ TEST(Parser_OperatorIN)
     verify_query(test_context, t, "'MiLk' IN[c] items.name", 2);            // string compare with insensitivity
     verify_query(test_context, t, "NULL IN items.price", 0);                // null
     verify_query(test_context, t, "'dairy' IN fav_item.allergens.name", 2); // through link prefix
-    verify_query(test_context, items, "20 IN @links.class_Person.items.account_balance", 1); // backlinks
+    verify_query(test_context, items, "20 IN @links.Person.items.account_balance", 1); // backlinks
     verify_query(test_context, t, "fav_item.price IN items.price", 2); // single property in list
 
     // list property compared to a constant list
@@ -4591,8 +4584,8 @@ TEST(Parser_Decimal128)
 TEST(Parser_Mixed)
 {
     Group g;
-    auto table = g.add_table("Foo");
-    auto origin = g.add_table("Origin");
+    auto table = g.add_table("class_Foo");
+    auto origin = g.add_table("class_Origin");
     auto col_any = table->add_column(type_Mixed, "mixed");
     auto col_int = table->add_column(type_Int, "int");
     auto col_link = origin->add_column(*table, "link");
@@ -4696,8 +4689,8 @@ TEST(Parser_Mixed)
 TEST(Parser_TypeOfValue)
 {
     Group g;
-    auto table = g.add_table("Foo");
-    auto origin = g.add_table("Origin");
+    auto table = g.add_table("class_Foo");
+    auto origin = g.add_table("class_Origin");
     auto col_any = table->add_column(type_Mixed, "mixed");
     auto col_int = table->add_column(type_Int, "int");
     auto col_primitive_list = table->add_column_list(type_Mixed, "list");
@@ -4853,8 +4846,8 @@ TEST(Parser_TypeOfValue)
 TEST(Parser_Dictionary)
 {
     Group g;
-    auto foo = g.add_table("foo");
-    auto origin = g.add_table("origin");
+    auto foo = g.add_table("class_foo");
+    auto origin = g.add_table("class_origin");
     auto col_dict = foo->add_column_dictionary(type_Mixed, "dict");
     auto col_link = origin->add_column(*foo, "link");
     auto col_links = origin->add_column_list(*foo, "links");
@@ -4950,7 +4943,7 @@ TEST(Parser_Dictionary)
     std::string message;
 
     CHECK_THROW_ANY_GET_MESSAGE(verify_query(test_context, origin, "link.dict.Value > 50", 3), message);
-    CHECK_EQUAL(message, "Property 'dict' in 'foo' is not an Object");
+    CHECK_EQUAL(message, "Property 'foo.dict' is not an object reference");
 
     // aggregates still work with mixed types
     verify_query(test_context, foo, "dict.@max == 100", 2);
@@ -5394,29 +5387,6 @@ TEST(Parser_Threads)
         });
     for (auto& w : workers)
         w.join();
-}
-
-TEST(Parser_ClassPrefix)
-{
-    for (const char* prefix : {"class_", "cl#"}) {
-        Group g;
-        std::string table_name = std::string(prefix) + "foo";
-        auto table = g.add_table(table_name);
-        auto col = table->add_column(type_Int, "val");
-        auto col_link = table->add_column(*table, "parent");
-        auto top = table->create_object();
-        for (int64_t i : {1, 2, 3, 4, 5}) {
-            table->create_object().set(col, i).set(col_link, top.get_key());
-        }
-        query_parser::KeyPathMapping mapping_with_prefix;
-        mapping_with_prefix.set_backlink_class_prefix(prefix);
-
-        verify_query(test_context, table, "val > 3", 2, mapping_with_prefix);
-        verify_query(test_context, table, "@links.foo.parent.val > 0", 1, mapping_with_prefix);
-        std::string message;
-        CHECK_THROW_ANY_GET_MESSAGE(verify_query(test_context, table, "id > 5", 0, mapping_with_prefix), message);
-        CHECK_EQUAL(message, "'foo' has no property: 'id'");
-    }
 }
 
 TEST(Parser_UTF8)


### PR DESCRIPTION
Way back in 2014 we had the idea that the new object database SDKs might be used alongside the older language bindings which exposed core's table-based API. The `class_` prefix was something done by the object database SDKs to mark tables which they were using. The query parser was originally written to work in this world, and so supports both object database class names, core table names, and whatever other namespaces we might come up with (we never did).

That's now all just historical cruft and the query parsing and serialization can just always assume that the `class_` prefix is being used. In practice the only call to `set_backlink_class_prefix()` outside of core's tests was in `populate_keypath_mapping()`, which sets it to a hardcoded `class_`.

The modified or deleted tests here are all things which were testing scenarios that were never hit by SDKs (using no prefix or a different prefix), and there's no behavioral change here for the thing actually used other than some error messages being tweaked.