### PR TITLE
Fix reporting string primary keys in CompensatingWriteErrorInfo

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@
 
 ### Fixed
 * <How do the end-user experience this issue? what was the impact?> ([#????](https://github.com/realm/realm-core/issues/????), since v?.?.?)
-* None.
+* CompensatingWriteErrorInfo reported string primary keys as boolean values instead ([PR #5938](https://github.com/realm/realm-core/pull/5938), since the introduction of CompensatingWriteErrorInfo in 12.1.0).
  
 ### Breaking changes
 * Rename RealmConfig::automatic_handle_backlicks_in_migrations to RealmConfig::automatically_handle_backlinks_in_migrations ([PR #5897](https://github.com/realm/realm-core/pull/5897)).

--- a/src/realm/mixed.hpp
+++ b/src/realm/mixed.hpp
@@ -290,6 +290,59 @@ private:
     }
 };
 
+class OwnedMixed : public Mixed {
+public:
+    explicit OwnedMixed(std::string&& str)
+        : m_owned_string(std::move(str))
+    {
+        m_type = int(type_String) + 1;
+        string_val = m_owned_string;
+    }
+
+    OwnedMixed(OwnedMixed&& m) noexcept
+        : Mixed(m)
+        , m_owned_string(std::move(m.m_owned_string))
+    {
+        if (is_type(type_String)) {
+            string_val = m_owned_string;
+        }
+    }
+
+    OwnedMixed(const OwnedMixed& m)
+        : Mixed(m)
+        , m_owned_string(m.m_owned_string)
+    {
+        if (is_type(type_String)) {
+            string_val = m_owned_string;
+        }
+    }
+
+    OwnedMixed& operator=(OwnedMixed&& m) noexcept
+    {
+        *static_cast<Mixed*>(this) = m;
+        if (is_type(type_String)) {
+            m_owned_string = std::move(m.m_owned_string);
+            string_val = m_owned_string;
+        }
+        return *this;
+    }
+
+    OwnedMixed& operator=(const OwnedMixed& m)
+    {
+        *static_cast<Mixed*>(this) = m;
+        if (is_type(type_String)) {
+            m_owned_string = m.m_owned_string;
+            string_val = m_owned_string;
+        }
+        return *this;
+    }
+
+    using Mixed::Mixed;
+
+private:
+    std::string m_owned_string;
+};
+
 // Implementation:
 
 inline Mixed::Mixed(int64_t v) noexcept

--- a/src/realm/sync/changeset_parser.hpp
+++ b/src/realm/sync/changeset_parser.hpp
@@ -2,7 +2,7 @@
 #ifndef REALM_SYNC_CHANGESET_PARSER_HPP
 #define REALM_SYNC_CHANGESET_PARSER_HPP
 
-#include "realm/mixed.hpp"
+#include <realm/mixed.hpp>
 #include <realm/sync/changeset.hpp>
 #include <realm/util/input_stream.hpp>
 
@@ -11,21 +11,6 @@ namespace sync {
 
 void parse_changeset(util::NoCopyInputStream&, Changeset& out_log);
 void parse_changeset(util::InputStream&, Changeset& out_log);
-
-class OwnedMixed : public Mixed {
-public:
-    explicit OwnedMixed(std::string&& str)
-        : m_owned_string(std::move(str))
-    {
-        m_type = int(type_String);
-        string_val = m_owned_string;
-    }
-
-    using Mixed::Mixed;
-
-private:
-    std::string m_owned_string;
-};
 
 // The server may send us primary keys of objects in json-encoded error messages as base64-encoded changeset payloads.
 // This function takes such a base64-encoded payload and returns it parsed as an owned Mixed value. If it cannot

--- a/src/realm/sync/protocol.hpp
+++ b/src/realm/sync/protocol.hpp
@@ -199,7 +199,7 @@ struct SyncProgress {
 
 struct CompensatingWriteErrorInfo {
     std::string object_name;
-    Mixed primary_key;
+    OwnedMixed primary_key;
     std::string reason;
 };
 

--- a/test/object-store/util/baas_admin_api.cpp
+++ b/test/object-store/util/baas_admin_api.cpp
@@ -964,31 +964,21 @@ AppSession create_app(const AppCreateConfig& config)
             std::transform(config.flx_sync_config->default_roles.begin(), config.flx_sync_config->default_roles.end(),
                            std::back_inserter(default_roles), [](const AppCreateConfig::FLXSyncRole& role_def) {
                                nlohmann::json ret{{"name", role_def.name}, {"applyWhen", role_def.apply_when}};
-                               if (auto read_bool_ptr = mpark::get_if<bool>(&role_def.read)) {
-                                   ret["read"] = *read_bool_ptr;
-                               }
-                               else {
-                                   ret["read"] = mpark::get<nlohmann::json>(role_def.read);
-                               }
-                               if (auto write_bool_ptr = mpark::get_if<bool>(&role_def.write)) {
-                                   ret["write"] = *write_bool_ptr;
-                               }
-                               else {
-                                   ret["write"] = mpark::get<nlohmann::json>(role_def.write);
-                               }
+                               ret["read"] = role_def.read;
+                               ret["write"] = role_def.write;
                                return ret;
                            });
         }
-        mongo_service_def["config"]["flexible_sync"] = nlohmann::json{{"state", "enabled"},
-                                                                      {"database_name", config.mongo_dbname},
-                                                                      {"queryable_fields_names", queryable_fields},
-                                                                      {"asymmetric_tables", asymmetric_tables},
-                                                                      {"permissions",
-                                                                       {{"rules", nlohmann::json::object()},
-                                                                        {
-                                                                            "defaultRoles",
-                                                                            default_roles,
-                                                                        }}}};
+        mongo_service_def["config"]["flexible_sync"] = {{"state", "enabled"},
+                                                        {"database_name", config.mongo_dbname},
+                                                        {"queryable_fields_names", queryable_fields},
+                                                        {"asymmetric_tables", asymmetric_tables},
+                                                        {"permissions",
+                                                         {{"rules", nlohmann::json::object()},
+                                                          {
+                                                              "defaultRoles",
+                                                              default_roles,
+                                                          }}}};
     }
     else {
         sync_config = nlohmann::json{

--- a/test/object-store/util/baas_admin_api.hpp
+++ b/test/object-store/util/baas_admin_api.hpp
@@ -157,8 +157,8 @@ struct AppCreateConfig {
     struct FLXSyncRole {
         std::string name;
         nlohmann::json apply_when = nlohmann::json::object();
-        mpark::variant<bool, nlohmann::json> read;
-        mpark::variant<bool, nlohmann::json> write;
+        nlohmann::json read;
+        nlohmann::json write;
     };
 
     struct FLXSyncConfig {

--- a/test/object-store/util/test_file.cpp
+++ b/test/object-store/util/test_file.cpp
@@ -130,9 +130,8 @@ SyncTestFile::SyncTestFile(std::shared_ptr<SyncUser> user, bson::Bson partition,
     sync_config = std::make_shared<realm::SyncConfig>(user, partition);
     sync_config->stop_policy = SyncSessionStopPolicy::Immediately;
     sync_config->error_handler = [](std::shared_ptr<SyncSession>, SyncError error) {
-        std::cerr << util::format("An unexpected sync error was caught by the default SyncTestFile handler: '%1'",
-                                  error.message)
-                  << std::endl;
+        util::format(std::cerr, "An unexpected sync error was caught by the default SyncTestFile handler: '%1'\n",
+                     error.message);
         abort();
     };
     schema_version = 1;
@@ -146,10 +145,9 @@ SyncTestFile::SyncTestFile(std::shared_ptr<realm::SyncUser> user, realm::Schema 
     sync_config = std::make_shared<realm::SyncConfig>(user, SyncConfig::FLXSyncEnabled{});
     sync_config->stop_policy = SyncSessionStopPolicy::Immediately;
     sync_config->error_handler = [](std::shared_ptr<SyncSession> session, SyncError error) {
-        std::cerr << util::format(
-                         "An unexpected sync error was caught by the default SyncTestFile handler: '%1' for '%2'",
-                         error.message, session->path())
-                  << std::endl;
+        util::format(std::cerr,
+                     "An unexpected sync error was caught by the default SyncTestFile handler: '%1' for '%2'",
+                     error.message, session->path());
         abort();
     };
     schema_version = 1;


### PR DESCRIPTION
OwnedMixed didn't work (it set the Mixed to the incorrect type and didn't handle copying or moving), and also wasn't actually used in CompensatingWriteErrorInfo. The net result was that every string PK was instead reported as a bool, typically false.