### PR TITLE
Fix a deadlock with simultaneous sync and nonsync commit notifications while tearing down RealmCoordinator

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 ### Fixed
 * <How do the end-user experience this issue? what was the impact?> ([#????](https://github.com/realm/realm-core/issues/????), since v?.?.?)
 * Calling `SectionedResults::reset_section_callback()` on a `SectionedResults` which had been evaluated would result in an assertion failure the next time the sections are evaluated ([PR #5965](https://github.com/realm/realm-core/pull/5965), since v12.10.0).
+* Fix a rare deadlock which could occur when closing a synchronized Realm immediately after committing a write transaction when the sync worker thread has also just finished processing a changeset from the server ([PR #5948](https://github.com/realm/realm-core/pull/5948)).
 
 ### Breaking changes
 * Websocket errors caused by the client sending a websocket message that is too large (i.e. greater than 16MB) now get reported as a `ProtocolError::limits_exceeded` error with a `ClientReset` requested by the server ([#5209](https://github.com/realm/realm-core/issues/5209)).

--- a/src/realm/object-store/sync/sync_session.hpp
+++ b/src/realm/object-store/sync/sync_session.hpp
@@ -245,8 +245,7 @@ public:
     class Internal {
         friend class _impl::RealmCoordinator;
 
-        static void set_sync_transact_callback(SyncSession& session,
-                                               util::UniqueFunction<TransactionCallback> callback)
+        static void set_sync_transact_callback(SyncSession& session, std::function<TransactionCallback>&& callback)
         {
             session.set_sync_transact_callback(std::move(callback));
         }
@@ -346,7 +345,7 @@ private:
     void handle_progress_update(uint64_t, uint64_t, uint64_t, uint64_t, uint64_t, uint64_t);
     void handle_new_flx_sync_query(int64_t version);
 
-    void set_sync_transact_callback(util::UniqueFunction<TransactionCallback>) REQUIRES(!m_state_mutex);
+    void set_sync_transact_callback(std::function<TransactionCallback>&&) REQUIRES(!m_state_mutex);
     void nonsync_transact_notify(VersionID::version_type) REQUIRES(!m_state_mutex);
 
     void create_sync_session() REQUIRES(m_state_mutex, !m_config_mutex);
@@ -365,7 +364,7 @@ private:
 
     util::Future<std::string> send_test_command(std::string body) REQUIRES(!m_state_mutex);
 
-    util::UniqueFunction<TransactionCallback> m_sync_transact_callback GUARDED_BY(m_state_mutex);
+    std::function<TransactionCallback> m_sync_transact_callback GUARDED_BY(m_state_mutex);
 
     template <typename Field>
     auto config(Field f) REQUIRES(!m_config_mutex)


### PR DESCRIPTION
The scenario which deadlocked is the following:

Sync worker thread: Reporting a sync commit made to object store
1. SessionWrapper::report_sync_transact()
2. SyncSession::create_sync_session() wrapped_callback lambda
    Holding strong reference to self and acquires SyncSession::m_state_mutex
    Calls m_sync_transact_callback while holding the mutex
4. RealmCoordinator::init_external_helpers() sync callback lambda
    Acquires strong reference to self, does some work, then releases it, triggering destructor
6. ~RealmCoordinator()
7. ~ExternalCommitHelper()
8. ExternalCommitHelper::m_thread::join()
   Waiting for the ECH thread to complete, while holding SyncSession::m_state_mutex

Notifier thread: Trying to report a non-sync commit to sync
1. ExternalCommitHelper::listen()
2. void RealmCoordinator::on_change()
3. SyncSession::nonsync_transact_notify()
   Trying to acquire SyncSession::m_state_mutex

To fix this, don't hold SyncSession::m_state_mutex while making the SyncSession -> RealmCoordinator call.

I don't see any way to write a test which would consistently hit this. I hit it while running the tests locally, but only once and it's very rare as I don't think I've ever seen it before and it's not a new bug.