### PR TITLE
Fix a use-after-free in client reset when the original RealmCoordinator is gone

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 ### Fixed
 * <How do the end-user experience this issue? what was the impact?> ([#????](https://github.com/realm/realm-core/issues/????), since v?.?.?)
 * CompensatingWriteErrorInfo reported string primary keys as boolean values instead ([PR #5938](https://github.com/realm/realm-core/pull/5938), since the introduction of CompensatingWriteErrorInfo in 12.1.0).
+* Fix a use-after-free if the last external reference to an encrypted Realm was closed between when a client reset error was received and when the download of the new Realm began. ([PR #5949](https://github.com/realm/realm-core/pull/5949), since 12.4.0).
 
 ### Breaking changes
 * Rename RealmConfig::automatic_handle_backlicks_in_migrations to RealmConfig::automatically_handle_backlinks_in_migrations ([PR #5897](https://github.com/realm/realm-core/pull/5897)).

--- a/src/realm/db.hpp
+++ b/src/realm/db.hpp
@@ -172,7 +172,7 @@ public:
 
     const char* get_encryption_key() const noexcept
     {
-        return m_key;
+        return m_alloc.m_file.get_encryption_key();
     }
 
 #ifdef REALM_DEBUG
@@ -461,7 +461,6 @@ private:
     std::string m_lockfile_prefix;
     std::string m_db_path;
     std::string m_coordination_dir;
-    const char* m_key;
     int m_file_format_version = 0;
     util::InterprocessMutex m_writemutex;
     std::unique_ptr<ReadLockInfo> m_fake_read_lock_if_immutable;

--- a/src/realm/object-store/sync/sync_session.cpp
+++ b/src/realm/object-store/sync/sync_session.cpp
@@ -335,10 +335,18 @@ void SyncSession::download_fresh_realm(sync::ProtocolErrorInfo::Action server_re
                 server_requests_action);
         }
     }
+
+    std::vector<char> encryption_key;
+    {
+        util::CheckedLockGuard lock(m_config_mutex);
+        encryption_key = m_config.encryption_key;
+    }
+
     DBOptions options;
-    options.encryption_key = m_db->get_encryption_key();
     options.allow_file_format_upgrade = false;
     options.enable_async_writes = false;
+    if (!encryption_key.empty())
+        options.encryption_key = encryption_key.data();
 
     std::shared_ptr<DB> db;
     auto fresh_path = ClientResetOperation::get_fresh_path_for(m_db->get_path());


### PR DESCRIPTION
`DB::get_encryption_key()` returns a pointer to a buffer owned by the thing which created the DB, which may no longer be valid when we're downloading the new Realm for client reset.

This was hit by the "callbacks are seeded with Realm instances even if the coordinator dies" client reset test when running with encrypt all enabled.