### PR TITLE
Fix `Results.distinct(keypaths)` and `Results.sort(keypaths)` not correctly handling keypaths names.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@
 * <How do the end-user experience this issue? what was the impact?> ([#????](https://github.com/realm/realm-core/issues/????), since v?.?.?)
 * Fix a race condition which could result in "operation cancelled" errors being delivered to async open callbacks rather than the actual sync error which caused things to fail ([PR #5968](https://github.com/realm/realm-core/pull/5968), since the introduction of async open).
 * The name of one of the RLM_SYNC_BOOTSTRAPPING enum member in the C api was updated to match the naming convention of the other members in the enum.
-* Fix `Results.distinct(keypaths)` and `Results.sort(keypaths)` not correctly handling keypaths names for properties that have a public/private(column) property name.
+* Fix `Results.distinct(keypaths)` and `Results.sort(keypaths)` not correctly handling keypaths names for properties that have a public/private(column) property name ([PR #5952](https://github.com/realm/realm-core/pull/5952).
 
 ### Breaking changes
 * None.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 * <How do the end-user experience this issue? what was the impact?> ([#????](https://github.com/realm/realm-core/issues/????), since v?.?.?)
 * Fix a race condition which could result in "operation cancelled" errors being delivered to async open callbacks rather than the actual sync error which caused things to fail ([PR #5968](https://github.com/realm/realm-core/pull/5968), since the introduction of async open).
 * The name of one of the RLM_SYNC_BOOTSTRAPPING enum member in the C api was updated to match the naming convention of the other members in the enum.
+* Fix `Results.distinct(keypaths)` and `Results.sort(keypaths)` not correctly handling keypaths names for properties that have a public/private(column) property name.
 
 ### Breaking changes
 * None.

--- a/src/realm/object-store/results.cpp
+++ b/src/realm/object-store/results.cpp
@@ -811,7 +811,7 @@ static std::vector<ColKey> parse_keypath(StringData keypath, Schema const& schem
         StringData key(begin, sep - begin);
         begin = sep + (sep != end);
 
-        auto prop = object_schema->property_for_public_name(key) ?: object_schema->property_for_name(key);
+        auto prop = object_schema->property_for_public_name(key);
         check(prop, "property '%1.%2' does not exist", object_schema->name, key);
         check(is_sortable_type(prop->type), "property '%1.%2' is of unsupported type '%3'", object_schema->name, key,
               string_for_property_type(prop->type));

--- a/src/realm/object-store/results.cpp
+++ b/src/realm/object-store/results.cpp
@@ -811,7 +811,7 @@ static std::vector<ColKey> parse_keypath(StringData keypath, Schema const& schem
         StringData key(begin, sep - begin);
         begin = sep + (sep != end);
 
-        auto prop = object_schema->property_for_name(key);
+        auto prop = object_schema->property_for_public_name(key) ?: object_schema->property_for_name(key);
         check(prop, "property '%1.%2' does not exist", object_schema->name, key);
         check(is_sortable_type(prop->type), "property '%1.%2' is of unsupported type '%3'", object_schema->name, key,
               string_for_property_type(prop->type));

--- a/src/realm/object-store/results.hpp
+++ b/src/realm/object-store/results.hpp
@@ -146,11 +146,14 @@ public:
 
     // Create a new Results by further filtering or sorting this Results
     Results filter(Query&& q) const REQUIRES(!m_mutex);
+    // Create a new Results by sorting this Result.
     Results sort(SortDescriptor&& sort) const REQUIRES(!m_mutex);
+    // Create a new Results by sorting this Result based on the specified key paths.
     Results sort(std::vector<std::pair<std::string, bool>> const& keypaths) const REQUIRES(!m_mutex);
 
-    // Create a new Results by removing duplicates
+    // Create a new Results by removing duplicates.
     Results distinct(DistinctDescriptor&& uniqueness) const REQUIRES(!m_mutex);
+    // Create a new Results by removing duplicates based on the specified key paths.
     Results distinct(std::vector<std::string> const& keypaths) const REQUIRES(!m_mutex);
 
     // Create a new Results with only the first `max_count` entries

--- a/test/object-store/results.cpp
+++ b/test/object-store/results.cpp
@@ -4803,7 +4803,7 @@ TEST_CASE("results: public name declared") {
     config.schema = Schema{
         {"object",
          {
-             {"value", PropertyType::Int, false, false, "public_value"},
+             {"value", PropertyType::Int, Property::IsPrimary{false}, Property::IsIndexed{false}, "public_value"},
          }},
     };
 

--- a/test/object-store/results.cpp
+++ b/test/object-store/results.cpp
@@ -4796,6 +4796,52 @@ TEST_CASE("results: limit", "[limit]") {
     }
 }
 
+TEST_CASE("results: public name declared") {
+    InMemoryTestFile config;
+    // config.cache = false;
+    config.automatic_change_notifications = false;
+    config.schema = Schema{
+        {"object",
+         {
+             {"value", PropertyType::Int, false, false, "public_value"},
+         }},
+    };
+
+    auto realm = Realm::get_shared_realm(config);
+    auto table = realm->read_group().get_table("class_object");
+    auto col = table->get_column_key("value");
+
+    realm->begin_transaction();
+    for (int i = 0; i < 8; ++i) {
+        table->create_object().set(col, (i + 2) % 4);
+    }
+    realm->commit_transaction();
+    Results r(realm, table);
+
+    SECTION("sorted") {
+        auto sorted = r.sort({{"public_value", true}});
+        REQUIRE(sorted.limit(0).size() == 0);
+        REQUIRE_ORDER(sorted.limit(1), 2);
+        REQUIRE_ORDER(sorted.limit(2), 2, 6);
+        REQUIRE_ORDER(sorted.limit(8), 2, 6, 3, 7, 0, 4, 1, 5);
+        REQUIRE_ORDER(sorted.limit(100), 2, 6, 3, 7, 0, 4, 1, 5);
+    }
+
+    SECTION("distinct") {
+        auto sorted = r.distinct({"public_value"});
+        REQUIRE(sorted.limit(0).size() == 0);
+        REQUIRE_ORDER(sorted.limit(1), 0);
+        REQUIRE_ORDER(sorted.limit(2), 0, 1);
+        REQUIRE_ORDER(sorted.limit(8), 0, 1, 2, 3);
+
+        sorted = r.sort({{"public_value", true}}).distinct({"public_value"});
+        REQUIRE(sorted.limit(0).size() == 0);
+        REQUIRE_ORDER(sorted.limit(1), 2);
+        REQUIRE_ORDER(sorted.limit(2), 2, 3);
+        REQUIRE_ORDER(sorted.limit(8), 2, 3, 0, 1);
+    }
+}
+
 TEST_CASE("notifications: objects with PK recreated") {
 #ifndef _WIN32
     _impl::RealmCoordinator::assert_no_open_realms();


### PR DESCRIPTION
Fix `Results.distinct(keypaths)` and `Results.sort(keypaths)` not correctly handling keypaths names for properties that have a public/private(column) property name.
This is a fix to enable custom column names in the Realm Swift SDK.

## What, How & Why?
<!-- Describe the changes and give some hints to guide your reviewers if possible. -->
<!-- Link to relevant issue this fixes -->

## ☑️ ToDos
* [x] 📝 Changelog update
* [x] 🚦 Tests (or not relevant)
* [ ] C-API, if public C++ API changed.
