### PR TITLE
The client sending too much data is now reported as a ProtocolError::limits_exceeded

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@
 ### Breaking changes
 * Rename RealmConfig::automatic_handle_backlicks_in_migrations to RealmConfig::automatically_handle_backlinks_in_migrations ([PR #5897](https://github.com/realm/realm-core/pull/5897)).
 * Introduced new callback type realm_return_apikey_list_func_t and realm_return_apikey_func_t in the C-API ([PR #5945](https://github.com/realm/realm-core/pull/5945)).
+* Websocket errors caused by the client sending a websocket message that is too large (i.e. greater than 16MB) now get reported as a `ProtocolError::limits_exceeded` error with a `ClientReset` requested by the server ([#5209](https://github.com/realm/realm-core/issues/5209)).
 
 ### Compatibility
 * Fileformat: Generates files with format v22. Reads and automatically upgrade from fileformat v5.

--- a/src/realm/sync/noinst/client_impl_base.cpp
+++ b/src/realm/sync/noinst/client_impl_base.cpp
@@ -416,8 +416,20 @@ bool Connection::websocket_close_message_received(std::error_code error_code, St
     if (error_code.category() == websocket::websocket_close_status_category() && error_code.value() != 1005 &&
         error_code.value() != 1000) {
         m_reconnect_info.m_reason = ConnectionTerminationReason::websocket_protocol_violation;
+
         constexpr bool try_again = true;
-        involuntary_disconnect(SessionErrorInfo{error_code, message, try_again});
+        SessionErrorInfo error_info{error_code, message, try_again};
+
+        // If the server sends a websocket close message with code 1009, then it's because we've sent an
+        // UPLOAD message that is too large for the server to process. Simply disconnecting/reconnecting
+        if (error_code.value() == 1009) {
+            error_info.error_code = make_error_code(ProtocolError::limits_exceeded);
+            error_info.server_requests_action = ProtocolErrorInfo::Action::ClientReset;
+            error_info.message = util::format(
+                "Sync websocket closed because the server received a message that was too large: %1", message);
+        }
+
+        involuntary_disconnect(std::move(error_info));
     }
 
     return bool(m_websocket);

--- a/src/realm/util/future.hpp
+++ b/src/realm/util/future.hpp
@@ -439,9 +439,9 @@ struct SharedStateImpl final : public SharedStateBase {
 
 // These are in the future_details namespace to get access to its contents, but they are part of the
 // public API.
+using future_details::CopyablePromiseHolder;
 using future_details::Future;
 using future_details::Promise;
-using future_details::CopyablePromiseHolder;
 
 /**
  * This class represents the producer side of a Future.

--- a/src/realm/util/future.hpp
+++ b/src/realm/util/future.hpp
@@ -33,12 +33,12 @@
 
 namespace realm::util {
 
-template <typename T>
-class SharedPromise;
-
 namespace future_details {
 template <typename T>
 class Promise;
+
+template <typename T>
+class SharedPromise;
 
 template <typename T>
 class Future;
@@ -386,6 +386,7 @@ struct SharedStateImpl final : public SharedStateBase {
     {
         REALM_ASSERT_DEBUG(m_state.load() < SSBState::Finished);
         REALM_ASSERT_DEBUG(other.m_state.load() == SSBState::Finished);
+        REALM_ASSERT_DEBUG(m_owned_by_promise.load());
         if (other.m_status.is_ok()) {
             m_data = std::move(other.m_data);
         }
@@ -399,6 +400,7 @@ struct SharedStateImpl final : public SharedStateBase {
     void emplace_value(Args&&... args) noexcept
     {
         REALM_ASSERT_DEBUG(m_state.load() < SSBState::Finished);
+        REALM_ASSERT_DEBUG(m_owned_by_promise.load());
         try {
             m_data.emplace(std::forward<Args>(args)...);
         }
@@ -408,7 +410,7 @@ struct SharedStateImpl final : public SharedStateBase {
         transition_to_finished();
     }
 
-    void set_from(StatusWith<T> roe)
+    void set_from(StatusOrStatusWith<T> roe)
     {
         if (roe.is_ok()) {
             emplace_value(std::move(roe.get_value()));
@@ -417,6 +419,18 @@ struct SharedStateImpl final : public SharedStateBase {
             set_status(roe.get_status());
         }
     }
+
+    void disown() const
+    {
+        REALM_ASSERT(m_owned_by_promise.exchange(false));
+    }
+
+    void claim() const
+    {
+        REALM_ASSERT(!m_owned_by_promise.exchange(true));
+    }
+
+    mutable std::atomic<bool> m_owned_by_promise{true};
 
     util::Optional<T> m_data; // P
 };
@@ -427,6 +441,7 @@ struct SharedStateImpl final : public SharedStateBase {
 // public API.
 using future_details::Future;
 using future_details::Promise;
+using future_details::SharedPromise;
 
 /**
  * This class represents the producer side of a Future.
@@ -513,6 +528,20 @@ private:
     Future<T> get_future() noexcept;
 
     friend class Future<void>;
+    friend class SharedPromise<T>;
+
+    Promise(util::bind_ptr<SharedState<T>> shared_state)
+        : m_shared_state(std::move(shared_state))
+    {
+        m_shared_state->claim();
+    }
+
+    util::bind_ptr<SharedState<T>> release() &&
+    {
+        auto ret = std::move(m_shared_state);
+        ret->disown();
+        return ret;
+    }
 
     template <typename Func>
     void set_impl(Func&& do_set) noexcept
@@ -523,6 +552,33 @@ private:
     }
 
     util::bind_ptr<SharedState<T>> m_shared_state = make_intrusive<SharedState<T>>();
+};
+
+/**
+ * SharedPromise<T> is a lightweight copyable holder for Promises so they can be captured inside
+ * of std::function's and other types that require all members to be copyable.
+ *
+ * The only thing you can do with a SharedPromise is extract a regular promise from it exactly once,
+ * and copy/move it as you would a util::bind_ptr.
+ */
+template <typename T>
+class future_details::SharedPromise {
+public:
+    SharedPromise(Promise<T>&& input)
+        : m_shared_state(std::move(input).release())
+    {
+    }
+
+    SharedPromise(const Promise<T>&) = delete;
+
+    Promise<T> get_promise()
+    {
+        REALM_ASSERT(m_shared_state);
+        return Promise<T>(std::move(m_shared_state));
+    }
+
+private:
+    util::bind_ptr<SharedState<T>> m_shared_state;
 };
 
 /**

--- a/test/object-store/sync/app.cpp
+++ b/test/object-store/sync/app.cpp
@@ -2732,6 +2732,8 @@ TEST_CASE("app: sync integration", "[sync][app]") {
         REQUIRE(error.error_code == make_error_code(sync::ProtocolError::limits_exceeded));
         REQUIRE(error.message == "Sync websocket closed because the server received a message that was too large: "
                                  "read limited at 16777217 bytes");
+        REQUIRE(error.is_client_reset_requested());
+        REQUIRE(error.server_requests_action == sync::ProtocolErrorInfo::Action::ClientReset);
     }
 
     SECTION("validation") {

--- a/test/object-store/sync/app.cpp
+++ b/test/object-store/sync/app.cpp
@@ -2708,16 +2708,11 @@ TEST_CASE("app: sync integration", "[sync][app]") {
     SECTION("too large sync message error handling") {
         SyncTestFile config(app, partition, schema);
 
-        std::mutex sync_error_mutex;
-        bool done = false;
-        config.sync_config->error_handler = [&](auto, SyncError error) {
-            if (error.error_code.category() != util::websocket::websocket_close_status_category())
-                return;
-            std::lock_guard<std::mutex> lk(sync_error_mutex);
-            done = true;
-            REQUIRE(error.error_code.value() == 1009);
-            REQUIRE(error.message == "read limited at 16777217 bytes");
-        };
+        auto pf = util::make_promise_future<SyncError>();
+        config.sync_config->error_handler =
+            [sp = util::SharedPromise(std::move(pf.promise))](auto, SyncError error) mutable {
+                sp.get_promise().emplace_value(std::move(error));
+            };
         auto r = Realm::get_shared_realm(config);
 
         // Create 26 MB worth of dogs in a single transaction - this should all get put into one changeset
@@ -2733,14 +2728,10 @@ TEST_CASE("app: sync integration", "[sync][app]") {
         }
         r->commit_transaction();
 
-        // If we haven't gotten an error in more than 5 minutes, then something has gone wrong
-        // and we should fail the test.
-        timed_wait_for(
-            [&] {
-                std::lock_guard<std::mutex> lk(sync_error_mutex);
-                return done;
-            },
-            std::chrono::minutes(5));
+        auto error = wait_for_future(std::move(pf.future), std::chrono::minutes(5)).get();
+        REQUIRE(error.error_code == make_error_code(sync::ProtocolError::limits_exceeded));
+        REQUIRE(error.message == "Sync websocket closed because the server received a message that was too large: "
+                                 "read limited at 16777217 bytes");
     }
 
     SECTION("validation") {

--- a/test/object-store/sync/app.cpp
+++ b/test/object-store/sync/app.cpp
@@ -2710,7 +2710,7 @@ TEST_CASE("app: sync integration", "[sync][app]") {
 
         auto pf = util::make_promise_future<SyncError>();
         config.sync_config->error_handler =
-            [sp = util::SharedPromise(std::move(pf.promise))](auto, SyncError error) mutable {
+            [sp = util::CopyablePromiseHolder(std::move(pf.promise))](auto, SyncError error) mutable {
                 sp.get_promise().emplace_value(std::move(error));
             };
         auto r = Realm::get_shared_realm(config);


### PR DESCRIPTION
## What, How & Why?
The server sends code 1009 when it receive a message larger than it can process. This is done inside the websocket library so it is impractical for it to send a true "in-band" error message which is how we normally signal client reset cases. Given that an oversized message (typically a giant single transaction) is a "sticky" condition that will keep happening whenever we reconnect, we should treat it as a client reset condition.

## ☑️ ToDos
* [x] 📝 Changelog update
* [x] 🚦 Tests (or not relevant)
* [ ] C-API, if public C++ API changed.
