### PR TITLE
Bugfix for client reset with recovery

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 * <How do the end-user experience this issue? what was the impact?> ([#????](https://github.com/realm/realm-core/issues/????), since v?.?.?)
 * CompensatingWriteErrorInfo reported string primary keys as boolean values instead ([PR #5938](https://github.com/realm/realm-core/pull/5938), since the introduction of CompensatingWriteErrorInfo in 12.1.0).
 * Fix a use-after-free if the last external reference to an encrypted Realm was closed between when a client reset error was received and when the download of the new Realm began. ([PR #5949](https://github.com/realm/realm-core/pull/5949), since 12.4.0).
+* Fixed an assertion failure during client reset with recovery when recovering a list operation on an embedded object that has a link column in the path prefix to the list from the top level object. ([PR #5957](https://github.com/realm/realm-core/issues/5957), since introduction of automatic recovery in v11.16.0).
 
 ### Breaking changes
 * Rename RealmConfig::automatic_handle_backlicks_in_migrations to RealmConfig::automatically_handle_backlinks_in_migrations ([PR #5897](https://github.com/realm/realm-core/pull/5897)).

--- a/src/realm/sync/noinst/client_reset_recovery.cpp
+++ b/src/realm/sync/noinst/client_reset_recovery.cpp
@@ -521,8 +521,7 @@ bool RecoverLocalChangesetsHandler::resolve_path(ListPath& path, Obj remote_obj,
                 REALM_UNREACHABLE();
             }
         }
-        else {
-            REALM_ASSERT(col.is_dictionary());
+        else if (col.is_dictionary()) {
             ++it;
             REALM_ASSERT(it != path.end());
             REALM_ASSERT(it->type == ListPath::Element::Type::InternKey);
@@ -537,6 +536,15 @@ bool RecoverLocalChangesetsHandler::resolve_path(ListPath& path, Obj remote_obj,
             else {
                 return false;
             }
+        }
+        else { // single link to embedded object
+            // Neither embedded object sets nor Mixed(TypedLink) to embedded objects are supported.
+            REALM_ASSERT_EX(!col.is_collection(), col);
+            REALM_ASSERT_EX(col.get_type() == col_type_Link, col);
+            StringData col_name = remote_obj.get_table()->get_column_name(col);
+            remote_obj = remote_obj.get_linked_object(col);
+            local_obj = local_obj.get_linked_object(col_name);
+            ++it;
         }
     }
     return false;

--- a/test/object-store/sync/client_reset.cpp
+++ b/test/object-store/sync/client_reset.cpp
@@ -3165,7 +3165,6 @@ TEST_CASE("client reset with embedded object", "[client reset][local][embedded o
     }
     SECTION("with shared initial state") {
         TopLevelContent initial;
-        initial.link_value = util::none;
         test_reset->setup([&](SharedRealm realm) {
             auto table = get_table(*realm, "TopLevel");
             REQUIRE(table);
@@ -3198,6 +3197,22 @@ TEST_CASE("client reset with embedded object", "[client reset][local][embedded o
                 local.array_values.begin()->second_level->dict_values.begin());
             local.array_values.begin()->second_level->set_of_objects.clear();
             remote.array_values.erase(remote.array_values.begin());
+            TopLevelContent expected_recovered = local;
+            reset_embedded_object({local}, {remote}, expected_recovered);
+        }
+        SECTION("local ArraySet to an embedded object through a deep link->linklist element which is removed by the "
+                "remote "
+                "triggers a list copy") {
+            local.link_value->array_vals[0] = 12345;
+            remote.link_value->array_vals.erase(remote.link_value->array_vals.begin());
+            TopLevelContent expected_recovered = local;
+            reset_embedded_object({local}, {remote}, expected_recovered);
+        }
+        SECTION("local ArrayErase to an embedded object through a deep link->linklist element which is removed by "
+                "the remote "
+                "triggers a list copy") {
+            local.link_value->array_vals.erase(local.link_value->array_vals.begin());
+            remote.link_value->array_vals.clear();
             TopLevelContent expected_recovered = local;
             reset_embedded_object({local}, {remote}, expected_recovered);
         }


### PR DESCRIPTION
The path iteration code was missing handling of single link columns.

This could result in an assertion failure during recovery as reported by [internal link](https://jira.mongodb.org/browse/HELP-38625).

```
/Users/realm/workspace/realm_realm-core_release_12.9.0/src/realm/sync/noinst/client_reset_recovery.cpp:525: [realm-core-12.9.0] Assertion failed: col.is_dictionary()
0   Realm                               0x0000000114867c8c _ZN5realm4utilL18terminate_internalERNSt3__118basic_stringstreamIcNS1_11char_traitsIcEENS1_9allocatorIcEEEE + 28
1   Realm                               0x0000000114867b91 _ZN5realm4util9terminateEPKcS2_lOSt16initializer_listINS0_9PrintableEE + 385
2   Realm                               0x00000001148f07a2 _ZN5realm5_impl12client_reset29RecoverLocalChangesetsHandler12resolve_pathERNS1_8ListPathENS_3ObjES5_NS_4util14UniqueFunctionIFvRNS_7LstBaseES9_EEE + 1250
3   Realm                               0x00000001148f01de _ZN5realm5_impl12client_reset29RecoverLocalChangesetsHandler7resolveERNS1_8ListPathENS_4util14UniqueFunctionIFvRNS_7LstBaseES8_EEE + 702
4   Realm                               0x00000001148efd9d _ZN5realm5_impl12client_reset29RecoverLocalChangesetsHandler37copy_lists_with_unrecoverable_changesEv + 301
5   Realm                               0x00000001148ef2e3 _ZN5realm5_impl12client_reset29RecoverLocalChangesetsHandler18process_changesetsERKNSt3__16vectorINS_4sync13ClientHistory11LocalChangeENS3_9allocatorIS7_EEEEONS4_INS5_15SubscriptionSetENS8_ISD_EEEE + 819
6   Realm                               0x00000001148ea9d2 _ZN5realm5_impl12client_reset25perform_client_reset_diffENSt3__110shared_ptrINS_2DBEEES5_NS_4sync15SaltedFileIdentERNS_4util6LoggerENS_16ClientResyncModeEbPbPNS6_17SubscriptionStoreENS8_14UniqueFunctionIFvxEEE + 2002
7   Realm                               0x00000001148ecadc _ZN5realm5_impl20ClientResetOperation8finalizeENS_4sync15SaltedFileIdentEPNS2_17SubscriptionStoreENS_4util14UniqueFunctionIFvxEEE + 444
8   Realm                               0x00000001148d7a29 _ZN5realm4sync10ClientImpl7Session21receive_ident_messageENS0_15SaltedFileIdentE + 297
9   Realm                               0x00000001148d78ce _ZN5realm4sync10ClientImpl10Connection21receive_ident_messageEyNS0_15SaltedFileIdentE + 286
10  Realm                               0x00000001148d386d _ZN5realm5_impl14ClientProtocol22parse_message_receivedINS_4sync10ClientImpl10ConnectionEEEvRT_NSt3__117basic_string_viewIcNS8_11char_traitsIcEEEE + 557
11  Realm                               0x00000001148d11a4 _ZN5realm4sync10ClientImpl10Connection33websocket_binary_message_receivedEPKcm + 52
12  Realm                               0x000000011493aeac _ZN12_GLOBAL__N_19WebSocket17frame_reader_loopEv + 1436
13  Realm                               0x000000011492d1a0 _ZN5realm4util7network7Service9AsyncOper22do_recycle_and_executeINS0_14UniqueFunctionIFvNSt3__110error_codeEmEEEJRS7_RmEEEvbRT_DpOT0_ + 160
14  Realm                               0x000000011492ccc2 _ZN5realm4util7network7Service14BasicStreamOpsINS1_3ssl6StreamEE16BufferedReadOperINS0_14UniqueFunctionIFvNSt3__110error_codeEmEEEE19recycle_and_executeEv + 178
15  Realm                               0x000000011492fe35 _ZN5realm4util7network7Service4Impl3runEv + 517
16  Realm                               0x00000001148a0add _ZN5realm4sync6Client3runEv + 29
```

## ☑️ ToDos
* [x] 📝 Changelog update
* [x] 🚦 Tests (or not relevant)
* [x] C-API, if public C++ API changed.
