### PR TITLE
Fix C-API for realm_object_get_parent

### DIFF
--- a/src/realm.h
+++ b/src/realm.h
@@ -60,7 +60,7 @@ typedef struct realm_schema realm_schema_t;
 typedef struct realm_scheduler realm_scheduler_t;
 typedef struct realm_thread_safe_reference realm_thread_safe_reference_t;
 typedef void (*realm_free_userdata_func_t)(realm_userdata_t userdata);
-typedef realm_userdata_t (*realm_clone_userdata_func_t)(const realm_userdata_t userdata);
+typedef realm_userdata_t(*realm_clone_userdata_func_t)(const realm_userdata_t userdata);
 
 /* Accessor types */
 typedef struct realm_object realm_object_t;
@@ -1429,7 +1429,7 @@ RLM_API realm_object_t* realm_get_object(const realm_t*, realm_class_key_t class
  * Get the parent object for the object passed as argument. Only works for embedded objects.
  * @return true, if no errors occurred.
  */
-RLM_API bool realm_object_get_parent(const realm_object_t* object, realm_object_t* parent);
+RLM_API bool realm_object_get_parent(const realm_object_t* object, realm_object_t** parent, realm_class_key_t* class_key);
 
 /**
  * Find an object with a particular primary key value.

--- a/src/realm.h
+++ b/src/realm.h
@@ -60,7 +60,7 @@ typedef struct realm_schema realm_schema_t;
 typedef struct realm_scheduler realm_scheduler_t;
 typedef struct realm_thread_safe_reference realm_thread_safe_reference_t;
 typedef void (*realm_free_userdata_func_t)(realm_userdata_t userdata);
-typedef realm_userdata_t(*realm_clone_userdata_func_t)(const realm_userdata_t userdata);
+typedef realm_userdata_t (*realm_clone_userdata_func_t)(const realm_userdata_t userdata);
 
 /* Accessor types */
 typedef struct realm_object realm_object_t;
@@ -1429,7 +1429,8 @@ RLM_API realm_object_t* realm_get_object(const realm_t*, realm_class_key_t class
  * Get the parent object for the object passed as argument. Only works for embedded objects.
  * @return true, if no errors occurred.
  */
-RLM_API bool realm_object_get_parent(const realm_object_t* object, realm_object_t** parent, realm_class_key_t* class_key);
+RLM_API bool realm_object_get_parent(const realm_object_t* object, realm_object_t** parent,
+                                     realm_class_key_t* class_key);
 
 /**
  * Find an object with a particular primary key value.

--- a/src/realm/object-store/c_api/object.cpp
+++ b/src/realm/object-store/c_api/object.cpp
@@ -28,11 +28,17 @@ RLM_API realm_object_t* realm_get_object(const realm_t* realm, realm_class_key_t
     });
 }
 
-RLM_API bool realm_object_get_parent(const realm_object_t* object, realm_object_t* parent)
+RLM_API bool realm_object_get_parent(const realm_object_t* object, realm_object_t** parent,
+                                     realm_class_key_t* class_key)
 {
     return wrap_err([&]() {
+        auto obj = object->obj().get_parent_object();
+        if (class_key)
+            *class_key = obj.get_table()->get_key().value;
+
         if (parent)
-            *parent = realm_object_t{realm::Object{object->get_realm(), object->obj().get_parent_object()}};
+            *parent = new realm_object_t{Object{object->realm(), std::move(obj)}};
+
         return true;
     });
 }


### PR DESCRIPTION
## What, How & Why?
The previous implementation was taking a pointer to an object, but we needed a pointer to a pointer instead as we need to store a pointer to the object, not the value itself. Additionally, I've added an extra argument to return the class key of the object as without it, there's no way to meaningfully use the `realm_object` value (the SDK would not know what class materialize it into).