### PR TITLE
Added realm core version to app login request

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@
 ### Fixed
 * <How do the end-user experience this issue? what was the impact?> ([#????](https://github.com/realm/realm-core/issues/????), since v?.?.?)
 * None.
- 
+
 ### Breaking changes
 * None.
 
@@ -17,7 +17,7 @@
 -----------
 
 ### Internals
-* None.
+* Added realm core version to the app login request ([#5959](https://github.com/realm/realm-core/issues/5959))
 
 ----------------------------------------------
 
@@ -48,7 +48,6 @@
 * StringData and Timestamp are now constexpr-constructible.
 * Remove `set_backlink_class_prefix()` and just always use the `class_` prefix when parsing or serializing queries.
 * Updated `install_baas.sh` to use files stored on s3 ([#5932](https://github.com/realm/realm-core/issues/5932))
-* Added realm core version to the app login request ([#5959](https://github.com/realm/realm-core/issues/5959))
 
 ----------------------------------------------
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -48,6 +48,7 @@
 * StringData and Timestamp are now constexpr-constructible.
 * Remove `set_backlink_class_prefix()` and just always use the `class_` prefix when parsing or serializing queries.
 * Updated `install_baas.sh` to use files stored on s3 ([#5932](https://github.com/realm/realm-core/issues/5932))
+* Added realm core version to the app login request ([#5959](https://github.com/realm/realm-core/issues/5959))
 
 ----------------------------------------------
 

--- a/src/realm/object-store/sync/app.cpp
+++ b/src/realm/object-store/sync/app.cpp
@@ -552,10 +552,13 @@ void App::attach_auth_options(BsonDocument& body)
         options["appVersion"] = *m_config.local_app_version;
     }
 
+    log("App: version info: platform: %1  version: %1 - sdk version: %3 - core version: %4", m_config.platform,
+        m_config.platform_version, m_config.sdk_version, REALM_VERSION_STRING);
     options["appId"] = m_config.app_id;
     options["platform"] = m_config.platform;
     options["platformVersion"] = m_config.platform_version;
     options["sdkVersion"] = m_config.sdk_version;
+    options["coreVersion"] = REALM_VERSION_STRING;
 
     body["options"] = BsonDocument({{"device", options}});
 }
@@ -564,7 +567,13 @@ void App::log_in_with_credentials(
     const AppCredentials& credentials, const std::shared_ptr<SyncUser>& linking_user,
     UniqueFunction<void(const std::shared_ptr<SyncUser>&, Optional<AppError>)>&& completion)
 {
-    log("App: log_in_with_credentials");
+    if (would_log()) {
+        auto app_info = util::format("app_id: %1", m_config.app_id);
+        if (m_config.local_app_version) {
+            app_info += util::format(" - app_version: %1", *m_config.local_app_version);
+        }
+        log("App: log_in_with_credentials: %1", app_info);
+    }
     // if we try logging in with an anonymous user while there
     // is already an anonymous session active, reuse it
     if (credentials.provider() == AuthProvider::ANONYMOUS) {

--- a/test/object-store/sync/app.cpp
+++ b/test/object-store/sync/app.cpp
@@ -3206,7 +3206,8 @@ private:
                                 {"appVersion", "A Local App Version"},
                                 {"platform", "Object Store Test Platform"},
                                 {"platformVersion", "Object Store Test Platform Version"},
-                                {"sdkVersion", "SDK Version"}}}}));
+                                {"sdkVersion", "SDK Version"},
+                                {"coreVersion", REALM_VERSION_STRING}}}}));
 
         CHECK(request.timeout_ms == 60000);
 


### PR DESCRIPTION
## What, How & Why?
The realm core version is already included in the user agent string when a client opens a websocket with the server, but the server is going to be collecting metrics based on the information sent in the body of the app login request.  Currently, this includes the platform and sdk version information. Add the core version so the server doesn't need to maintain a list of sdk version/core version table to translate the sdk version to the core version. This will also help with reporting to the users whether or not all or what percentage of their clients have upgraded to the sdk version that supports PBS->QBS migrations.

Fixes #5959 

## ☑️ ToDos
* [x] 📝 Changelog update
* [X] 🚦 Tests (or not relevant)
* ~~[ ] C-API, if public C++ API changed.~~
