### PR TITLE
Fix assertion failures after calling SectionedResults::reset_section_callback()

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@
 
 ### Fixed
 * <How do the end-user experience this issue? what was the impact?> ([#????](https://github.com/realm/realm-core/issues/????), since v?.?.?)
-* None.
+* Calling `SectionedResults::reset_section_callback()` on a `SectionedResults` which had been evaluated would result in an assertion failure the next time the sections are evaluated ([PR #5965](https://github.com/realm/realm-core/pull/5965), since v12.10.0).
 
 ### Breaking changes
 * Websocket errors caused by the client sending a websocket message that is too large (i.e. greater than 16MB) now get reported as a `ProtocolError::limits_exceeded` error with a `ClientReset` requested by the server ([#5209](https://github.com/realm/realm-core/issues/5209)).

--- a/src/realm/object-store/sectioned_results.hpp
+++ b/src/realm/object-store/sectioned_results.hpp
@@ -172,7 +172,7 @@ private:
     SectionedResults(Results&& results, std::map<Mixed, Section>&& sections,
                      std::map<size_t, Mixed>&& current_section_index_to_key_lookup,
                      std::list<std::string>&& current_str_buffers)
-        : has_performed_initial_evalutation(true)
+        : m_has_performed_initial_evalutation(true)
         , m_results(std::move(results))
         , m_sections(std::move(sections))
         , m_current_section_index_to_key_lookup(std::move(current_section_index_to_key_lookup))
@@ -185,7 +185,7 @@ private:
     SectionedResults copy(Results&&) REQUIRES(!m_mutex);
     void calculate_sections_if_required() REQUIRES(m_mutex);
     void calculate_sections() REQUIRES(m_mutex);
-    bool has_performed_initial_evalutation = false;
+    bool m_has_performed_initial_evalutation = false;
     NotificationToken add_notification_callback_for_section(Mixed section_key,
                                                             SectionedResultsNotificatonCallback callback,
                                                             KeyPathArray key_path_array = {});

--- a/test/object-store/sectioned_results.cpp
+++ b/test/object-store/sectioned_results.cpp
@@ -632,7 +632,6 @@ TEST_CASE("sectioned results", "[sectioned_results]") {
     }
 
     SECTION("reset section callback") {
-        algo_run_count = 0;
         sectioned_results.reset_section_callback([&](Mixed value, SharedRealm realm) {
             algo_run_count++;
             auto obj = Object(realm, value.get_link());
@@ -646,6 +645,24 @@ TEST_CASE("sectioned results", "[sectioned_results]") {
         REQUIRE(sectioned_results["ba"].size() == 1);
         REQUIRE(sectioned_results["or"].size() == 1);
         REQUIRE_THROWS(sectioned_results["a"]);
+        REQUIRE(algo_run_count == 5);
+    }
+
+    SECTION("reset section callback after initializing with previous callback") {
+        REQUIRE(sectioned_results.size() == 3);
+        REQUIRE(algo_run_count == 5);
+        algo_run_count = 0;
+
+        sectioned_results.reset_section_callback([&](Mixed value, SharedRealm realm) {
+            algo_run_count++;
+            auto obj = Object(realm, value.get_link());
+            return obj.get_column_value<StringData>("name_col").contains("o");
+        });
+        REQUIRE(algo_run_count == 0);
+        REQUIRE(sectioned_results.size() == 2);
+        REQUIRE(algo_run_count == 5);
+        REQUIRE(sectioned_results[true].size() == 2);
+        REQUIRE(sectioned_results[false].size() == 3);
         REQUIRE(algo_run_count == 5);
     }
 


### PR DESCRIPTION
If the SectionedResults had been previously evaluated, reset_section_callback() would leave it in an inconsistent state where m_has_performed_initial_evalutation was false but the previous run info was non-empty. #5926 introduced some assertions that now fail when this happens, but I suspect the actual behavior was also broken before that.