### PR TITLE
Run core tests with encryption enabled on windows

### DIFF
--- a/evergreen/config.yml
+++ b/evergreen/config.yml
@@ -529,6 +529,8 @@ tasks:
   exec_timeout_secs: 1800
   commands:
   - func: "compile"
+    vars:
+      target_to_build: "CoreTests"
   - func: "run tests"
     vars:
       test_filter: CoreTests
@@ -696,8 +698,7 @@ task_groups:
   - compile
   - .test_suite
 
-- name: compile_core_tests
-  max_hosts: 1
+- name: core_tests-group
   setup_group_can_fail_task: true
   setup_group:
   - func: "fetch source"
@@ -707,7 +708,6 @@ task_groups:
   timeout:
   - func: "run hang analyzer"
   tasks:
-  - compile
   - core-tests
 
 - name: benchmarks
@@ -771,7 +771,7 @@ buildvariants:
     run_with_encryption: On
     enable_tsan: On
   tasks:
-  - name: compile_core_tests
+  - name: core_tests_group
     distros:
     - ubuntu2004-large
 
@@ -790,7 +790,7 @@ buildvariants:
     run_with_encryption: On
     enable_asan: On
   tasks:
-  - name: compile_core_tests
+  - name: core_tests_group
     distros:
     - ubuntu2004-large
 
@@ -948,7 +948,7 @@ buildvariants:
     extra_flags: -DCMAKE_SYSTEM_NAME=Darwin -DCMAKE_OSX_ARCHITECTURES=x86_64
     run_with_encryption: On
   tasks:
-  - name: compile_core_tests
+  - name: core_tests_group
 
 - name: macos-release
   display_name: "MacOS 11.0 x86_64 (Release build)"
@@ -1009,7 +1009,7 @@ buildvariants:
 
 - name: windows-64-vs2019
   display_name: "Windows x86_64 (VS 2019)"
-  run_on: windows-vsCurrent-small
+  run_on: windows-vsCurrent-large
   expansions:
     cmake_url: "https://s3.amazonaws.com/static.realm.io/evergreen-assets/cmake-3.20.3-windows-x86_64.zip"
     cmake_bindir: "./cmake-3.20.3-windows-x86_64/bin"
@@ -1021,13 +1021,27 @@ buildvariants:
     python3: "/cygdrive/c/python/python37/python.exe"
   tasks:
   - name: compile_test_and_package
-    distros:
-    - windows-vsCurrent-large
   - name: long-running-tests
+
+- name: windows-64-encryption
+  display_name: "Windows x86_64 (Encryption enabled)"
+  run_on: windows-vsCurrent-large
+  expansions:
+    cmake_url: "https://s3.amazonaws.com/static.realm.io/evergreen-assets/cmake-3.20.3-windows-x86_64.zip"
+    cmake_bindir: "./cmake-3.20.3-windows-x86_64/bin"
+    cmake_generator: "Visual Studio 16 2019"
+    extra_flags: "-A x64"
+    max_jobs: $(($(grep -c proc /proc/cpuinfo) / 2))
+    fetch_missing_dependencies: On
+    build_zlib: On
+    python3: "/cygdrive/c/python/python37/python.exe"
+    run_with_encryption: On
+  tasks:
+  - name: core_tests_group
 
 - name: windows-64-vs2019-release
   display_name: "Windows x86_64 (VS 2019 Release build)"
-  run_on: windows-vsCurrent-small
+  run_on: windows-vsCurrent-large
   expansions:
     cmake_url: "https://s3.amazonaws.com/static.realm.io/evergreen-assets/cmake-3.20.3-windows-x86_64.zip"
     cmake_bindir: "./cmake-3.20.3-windows-x86_64/bin"
@@ -1040,5 +1054,3 @@ buildvariants:
     python3: "/cygdrive/c/python/python37/python.exe"
   tasks:
   - name: compile_test
-    distros:
-    - windows-vsCurrent-large

--- a/evergreen/config.yml
+++ b/evergreen/config.yml
@@ -698,7 +698,7 @@ task_groups:
   - compile
   - .test_suite
 
-- name: core_tests-group
+- name: core_tests_group
   setup_group_can_fail_task: true
   setup_group:
   - func: "fetch source"


### PR DESCRIPTION
## What, How & Why?
Adds an evergreen builder for the core tests with encryption enabled on Windows.

## ☑️ ToDos
* [ ] 📝 Changelog update
* [ ] 🚦 Tests (or not relevant)
* [ ] C-API, if public C++ API changed.
