### PR TITLE
Use a variant for query args so we can distinguish scalars from single-element lists

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@
 * Fetching a user's profile while the user logs out would result in an assertion failure. ([PR #6017](https://github.com/realm/realm-core/issues/5571), since v11.0.3)
  
 ### Breaking changes
-* None.
+* `Table::query()` overload taking `vector<vector<Mixed>>` now takes `vector<variant<Mixed, vector<Mixed>>>` in order to distinguish scalar arguments from single-element lists. ([#5973](https://github.com/realm/realm-core/pull/5973))
 
 ### Compatibility
 * Fileformat: Generates files with format v22. Reads and automatically upgrade from fileformat v5.

--- a/src/realm/parser/driver.cpp
+++ b/src/realm/parser/driver.cpp
@@ -20,13 +20,17 @@
 #include "realm/parser/keypath_mapping.hpp"
 #include "realm/parser/query_parser.hpp"
 #include "realm/sort_descriptor.hpp"
-#include <realm/decimal128.hpp>
-#include <realm/uuid.hpp>
+#include "realm/decimal128.hpp"
+#include "realm/uuid.hpp"
 #include "realm/util/base64.hpp"
+#include "realm/util/overload.hpp"
 
 #define YY_NO_UNISTD_H 1
 #define YY_NO_INPUT 1
 #include "realm/parser/generated/query_flex.hpp"
+
+#include <external/mpark/variant.hpp>
+#include <stdexcept>
 
 using namespace realm;
 using namespace std::string_literals;
@@ -174,105 +178,114 @@ inline T string_to(const std::string& s)
 
 class MixedArguments : public query_parser::Arguments {
 public:
+    using Arg = mpark::variant<Mixed, std::vector<Mixed>>;
+
     MixedArguments(const std::vector<Mixed>& args)
         : Arguments(args.size())
-        , m_args([](const std::vector<Mixed>& list) -> std::vector<std::vector<Mixed>> {
-            std::vector<std::vector<Mixed>> ret;
-            for (const Mixed& m : list) {
-                ret.push_back({m});
+        , m_args([](const std::vector<Mixed>& args) -> std::vector<Arg> {
+            std::vector<Arg> ret;
+            ret.reserve(args.size());
+            for (const Mixed& m : args) {
+                ret.push_back(m);
             }
             return ret;
         }(args))
     {
     }
-    MixedArguments(const std::vector<std::vector<Mixed>>& args)
+    MixedArguments(const std::vector<Arg>& args)
         : Arguments(args.size())
         , m_args(args)
     {
     }
     bool bool_for_argument(size_t n) final
     {
-        Arguments::verify_ndx(n);
-        return m_args.at(n)[0].get<bool>();
+        return mixed_for_argument(n).get<bool>();
     }
     long long long_for_argument(size_t n) final
     {
-        Arguments::verify_ndx(n);
-        return m_args.at(n)[0].get<int64_t>();
+        return mixed_for_argument(n).get<int64_t>();
     }
     float float_for_argument(size_t n) final
     {
-        Arguments::verify_ndx(n);
-        return m_args.at(n)[0].get<float>();
+        return mixed_for_argument(n).get<float>();
     }
     double double_for_argument(size_t n) final
     {
-        Arguments::verify_ndx(n);
-        return m_args.at(n)[0].get<double>();
+        return mixed_for_argument(n).get<double>();
     }
     StringData string_for_argument(size_t n) final
     {
-        Arguments::verify_ndx(n);
-        return m_args.at(n)[0].get<StringData>();
+        return mixed_for_argument(n).get<StringData>();
     }
     BinaryData binary_for_argument(size_t n) final
     {
-        Arguments::verify_ndx(n);
-        return m_args.at(n)[0].get<BinaryData>();
+        return mixed_for_argument(n).get<BinaryData>();
     }
     Timestamp timestamp_for_argument(size_t n) final
     {
-        Arguments::verify_ndx(n);
-        return m_args.at(n)[0].get<Timestamp>();
+        return mixed_for_argument(n).get<Timestamp>();
     }
     ObjectId objectid_for_argument(size_t n) final
     {
-        Arguments::verify_ndx(n);
-        return m_args.at(n)[0].get<ObjectId>();
+        return mixed_for_argument(n).get<ObjectId>();
     }
     UUID uuid_for_argument(size_t n) final
     {
-        Arguments::verify_ndx(n);
-        return m_args.at(n)[0].get<UUID>();
+        return mixed_for_argument(n).get<UUID>();
     }
     Decimal128 decimal128_for_argument(size_t n) final
     {
-        Arguments::verify_ndx(n);
-        return m_args.at(n)[0].get<Decimal128>();
+        return mixed_for_argument(n).get<Decimal128>();
     }
     ObjKey object_index_for_argument(size_t n) final
     {
-        Arguments::verify_ndx(n);
-        return m_args.at(n)[0].get<ObjKey>();
+        return mixed_for_argument(n).get<ObjKey>();
     }
     ObjLink objlink_for_argument(size_t n) final
     {
-        Arguments::verify_ndx(n);
-        return m_args.at(n)[0].get<ObjLink>();
+        return mixed_for_argument(n).get<ObjLink>();
     }
     std::vector<Mixed> list_for_argument(size_t n) final
     {
         Arguments::verify_ndx(n);
-        return m_args.at(n);
+        return mpark::get<std::vector<Mixed>>(m_args[n]);
     }
     bool is_argument_null(size_t n) final
     {
         Arguments::verify_ndx(n);
-        return m_args.at(n).size() == 0 || m_args.at(n)[0].is_null();
+        return visit(util::overload{
+                         [](const Mixed& m) {
+                             return m.is_null();
+                         },
+                         [](const std::vector<Mixed>&) {
+                             return false;
+                         },
+                     },
+                     m_args[n]);
     }
     bool is_argument_list(size_t n) final
     {
         Arguments::verify_ndx(n);
-        return m_args.at(n).size() > 1;
+        static_assert(std::is_same_v<mpark::variant_alternative_t<1, Arg>, std::vector<Mixed>>);
+        return m_args[n].index() == 1;
     }
     DataType type_for_argument(size_t n)
     {
-        Arguments::verify_ndx(n);
-        return m_args.at(n)[0].get_type();
+        return mixed_for_argument(n).get_type();
     }
 
 private:
-    const std::vector<std::vector<Mixed>> m_args;
+    const Mixed& mixed_for_argument(size_t n) {
+        Arguments::verify_ndx(n);
+        if (is_argument_list(n)) {
+            throw std::invalid_argument(
+                util::format("Request for scalar argument at index %1 but a list was provided", n));
+        }
+
+        return mpark::get<Mixed>(m_args[n]);
+    }
+
+    const std::vector<Arg> m_args;
 };
 
 Timestamp get_timestamp_if_valid(int64_t seconds, int32_t nanoseconds)
@@ -1571,7 +1584,7 @@ std::string check_escapes(const char* str)
 
 } // namespace query_parser
 
-Query Table::query(const std::string& query_string, const std::vector<std::vector<Mixed>>& arguments) const
+Query Table::query(const std::string& query_string, const std::vector<MixedArguments::Arg>& arguments) const
 {
     MixedArguments args(arguments);
     return query(query_string, args, {});
@@ -1590,7 +1603,7 @@ Query Table::query(const std::string& query_string, const std::vector<Mixed>& ar
     return query(query_string, args, mapping);
 }
 
-Query Table::query(const std::string& query_string, const std::vector<std::vector<Mixed>>& arguments,
+Query Table::query(const std::string& query_string, const std::vector<MixedArguments::Arg>& arguments,
                    const query_parser::KeyPathMapping& mapping) const
 {
     MixedArguments args(arguments);

--- a/src/realm/parser/driver.cpp
+++ b/src/realm/parser/driver.cpp
@@ -275,7 +275,8 @@ public:
     }
 
 private:
-    const Mixed& mixed_for_argument(size_t n) {
+    const Mixed& mixed_for_argument(size_t n)
+    {
         Arguments::verify_ndx(n);
         if (is_argument_list(n)) {
             throw std::invalid_argument(

--- a/src/realm/table.hpp
+++ b/src/realm/table.hpp
@@ -19,6 +19,7 @@
 #ifndef REALM_TABLE_HPP
 #define REALM_TABLE_HPP
 
+#include "external/mpark/variant.hpp"
 #include <algorithm>
 #include <map>
 #include <utility>
@@ -547,11 +548,13 @@ public:
     }
     Query where(const DictionaryLinkValues& dictionary_of_links) const;
 
-    Query query(const std::string& query_string, const std::vector<std::vector<Mixed>>& arguments = {}) const;
+    Query query(const std::string& query_string,
+                const std::vector<mpark::variant<Mixed, std::vector<Mixed>>>& arguments = {}) const;
     Query query(const std::string& query_string, const std::vector<Mixed>& arguments) const;
     Query query(const std::string& query_string, const std::vector<Mixed>& arguments,
                 const query_parser::KeyPathMapping& mapping) const;
-    Query query(const std::string& query_string, const std::vector<std::vector<Mixed>>& arguments,
+    Query query(const std::string& query_string,
+                const std::vector<mpark::variant<Mixed, std::vector<Mixed>>>& arguments,
                 const query_parser::KeyPathMapping& mapping) const;
     Query query(const std::string& query_string, query_parser::Arguments& arguments,
                 const query_parser::KeyPathMapping&) const;

--- a/test/test_parser.cpp
+++ b/test/test_parser.cpp
@@ -407,8 +407,8 @@ TEST(Parser_invalid_queries)
 }
 
 static Query verify_query(test_util::unit_test::TestContext& test_context, TableRef t, std::string query_string,
-                          std::vector<mpark::variant<Mixed, std::vector<Mixed>>> args,
-                          size_t num_results, query_parser::KeyPathMapping mapping = {})
+                          std::vector<mpark::variant<Mixed, std::vector<Mixed>>> args, size_t num_results,
+                          query_parser::KeyPathMapping mapping = {})
 {
     Query q = t->query(query_string, args, mapping);
 

--- a/test/test_parser.cpp
+++ b/test/test_parser.cpp
@@ -407,6 +407,26 @@ TEST(Parser_invalid_queries)
 }
 
 static Query verify_query(test_util::unit_test::TestContext& test_context, TableRef t, std::string query_string,
+                          std::vector<mpark::variant<Mixed, std::vector<Mixed>>> args,
+                          size_t num_results, query_parser::KeyPathMapping mapping = {})
+{
+    Query q = t->query(query_string, args, mapping);
+
+    size_t q_count = q.count();
+    CHECK_EQUAL(q_count, num_results);
+    std::string description = q.get_description();
+    // std::cerr << "original: " << query_string << "\tdescribed: " << description << "\n";
+    Query q2 = t->query(description, args, mapping);
+
+    size_t q2_count = q2.count();
+    CHECK_EQUAL(q2_count, num_results);
+    if (q_count != num_results || q2_count != num_results) {
+        std::cout << "the query for the above failure is: '" << description << "'" << std::endl;
+    }
+    return q2;
+}
+
+static Query verify_query(test_util::unit_test::TestContext& test_context, TableRef t, std::string query_string,
                           size_t num_results, query_parser::KeyPathMapping mapping = {})
 {
     realm::query_parser::NoArguments args;
@@ -553,6 +573,7 @@ TEST(Parser_basic_serialisation)
 
     Query q = t->where();
 
+    // constant values
     verify_query(test_context, t, "time == NULL", 1);
     verify_query(test_context, t, "time == NIL", 1);
     verify_query(test_context, t, "time != NULL", 4);
@@ -579,6 +600,23 @@ TEST(Parser_basic_serialisation)
     verify_query(test_context, t, "fees BETWEEN {2.20, 2.25}", 3);
     verify_query(test_context, t, "fees = 2 || fees = 3 || fees = 4", 1);
     verify_query(test_context, t, "fees = 0 || fees = 1", 0);
+
+    // params
+    verify_query(test_context, t, "time == $0", {null()}, 1);
+    verify_query(test_context, t, "time != $0", {null()}, 4);
+    verify_query(test_context, t, "age > $0", {2}, 2);
+    verify_query(test_context, t, "!(age >= $0)", {2}, 2);
+    verify_query(test_context, t, "!(age => $0)", {2}, 2);
+    verify_query(test_context, t, "$0 <= age", {3}, 2);
+    verify_query(test_context, t, "$0 =< age", {3}, 2);
+    verify_query(test_context, t, "age > $0 and age < $1", {2, 4}, 1);
+    verify_query(test_context, t, "age = $0 || age == $1", {1, 3}, 2);
+    verify_query(test_context, t, "fees = $0 || fees = $1", {1.2, 2.23}, 1);
+    verify_query(test_context, t, "fees = $0 || fees = $1", {2, 3}, 1);
+    verify_query(test_context, t, "fees BETWEEN {$0, $1}", {2, 3}, 4);
+    verify_query(test_context, t, "fees BETWEEN {$0, $1}", {2.2, 2.25}, 3);
+    verify_query(test_context, t, "fees = $0 || fees = $1 || fees = $2", {2, 3, 4}, 1);
+    verify_query(test_context, t, "fees = $0 || fees = $1", {0, 1}, 0);
 
     verify_query(test_context, t, "fees != 2.22 && fees > 2.2", 3);
     verify_query(test_context, t, "fees > 2.0E0", 4);
@@ -3852,6 +3890,35 @@ TEST(Parser_OperatorIN)
     verify_query(test_context, t, "fav_item.name endswith {'lk', 'EAL', 'GeS'}", 1);
     verify_query(test_context, t, "fav_item.name endswith[c] {'lk', 'EAL', 'GeS'}", 2);
     verify_query(test_context, t, "fav_item.name like {'*lk', '*zz*'}", 2);
+
+    // RHS is a param
+    using Vec = std::vector<Mixed>;
+    verify_query(test_context, t, "customer_id IN $0", {Vec{0, 1, 2}}, 3);
+    verify_query(test_context, t, "NOT customer_id IN $0", {Vec{0}}, 2);
+    verify_query(test_context, t, "customer_id != $0", {Vec{0}}, 2);
+    verify_query(test_context, t, "customer_id != $0", {Vec{0, 1}}, 3);
+    verify_query(test_context, t, "NOT customer_id IN $0", {Vec{0, 1}}, 1);
+    verify_query(test_context, t, "customer_id != $0", {Vec{0, 1, 2}}, 3);
+    verify_query(test_context, t, "customer_id > $0", {Vec{0, 1}}, 2);
+    verify_query(test_context, t, "customer_id > $0", {Vec{4, 5, 6}}, 0);
+    verify_query(test_context, t, "customer_id < $0", {Vec{0, 1}}, 1);
+    verify_query(test_context, t, "customer_id < $0", {Vec{0}}, 0);
+    verify_query(test_context, t, "customer_id >= $0", {Vec{0, 1}}, 3);
+    verify_query(test_context, t, "customer_id >= $0", {Vec{2, 3, 4}}, 1);
+    verify_query(test_context, t, "customer_id <= $0", {Vec{0, 1}}, 2);
+    verify_query(test_context, t, "customer_id <= $0", {Vec{-1}}, 0);
+
+    verify_query(test_context, t, "fav_item.name IN $0", {Vec{"milk", "oranges", "cereal"}}, 2);
+    verify_query(test_context, t, "fav_item.price IN $0", {Vec{6.5, 9.5}}, 1);
+    verify_query(test_context, t, "fav_item.name IN $0",
+                 {Vec{0, null{}, -1, "not found", 3.14, ObjectId("000000000000000000000000")}}, 0);
+    verify_query(test_context, t, "fav_item.name != $0", {Vec{"milk", "oranges"}}, 3);
+    verify_query(test_context, t, "NOT fav_item.name IN $0", {Vec{"milk", "oranges"}}, 1);
+    verify_query(test_context, t, "fav_item.name contains[c] $0", {Vec{"ILK", "Range"}}, 2);
+    verify_query(test_context, t, "fav_item.name beginswith[c] $0", {Vec{"MIL", "CERe"}}, 1);
+    verify_query(test_context, t, "fav_item.name endswith $0", {Vec{"lk", "EAL", "GeS"}}, 1);
+    verify_query(test_context, t, "fav_item.name endswith[c] $0", {Vec{"lk", "EAL", "GeS"}}, 2);
+    verify_query(test_context, t, "fav_item.name like $0", {Vec{"*lk", "*zz*"}}, 2);
 
     std::vector<Mixed> int_list = {0, 1, 2};
     std::vector<Mixed> strings_list = {"milk", "oranges", "cereal"};

--- a/test/test_parser.cpp
+++ b/test/test_parser.cpp
@@ -3864,6 +3864,7 @@ TEST(Parser_OperatorIN)
     }
 
     // RHS is a constant list
+    verify_query(test_context, t, "customer_id IN {}", 0);
     verify_query(test_context, t, "customer_id IN {0, 1, 2}", 3);
     verify_query(test_context, t, "NOT customer_id IN {0}", 2);
     verify_query(test_context, t, "customer_id != {0}", 2);
@@ -3893,6 +3894,7 @@ TEST(Parser_OperatorIN)
 
     // RHS is a param
     using Vec = std::vector<Mixed>;
+    verify_query(test_context, t, "customer_id IN $0", {Vec{}}, 0);
     verify_query(test_context, t, "customer_id IN $0", {Vec{0, 1, 2}}, 3);
     verify_query(test_context, t, "NOT customer_id IN $0", {Vec{0}}, 2);
     verify_query(test_context, t, "customer_id != $0", {Vec{0}}, 2);


### PR DESCRIPTION
I verified that this works with realm-js on top of bindgen, which is using this API. Previously [this test](https://github.com/realm/realm-js/blob/c2fba8876c0b12025a531597eaa7f3d127632fc5/integration-tests/tests/src/tests/queries.ts#L122) was failing (note that JS uses varargs for query args, so mentally add an extra layer of vector wrapping).

## What, How & Why?
<!-- Describe the changes and give some hints to guide your reviewers if possible. -->
<!-- Link to relevant issue this fixes -->

## ☑️ ToDos
* [ ] 📝 Changelog update
* [ ] 🚦 Tests (or not relevant)
* [ ] C-API, if public C++ API changed.
