### PR TITLE
Add App::call_function overload working with raw ejson strings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,8 @@
 # NEXT RELEASE
 
 ### Enhancements
+* <New feature description> (PR [#????](https://github.com/realm/realm-core/pull/????))
+* App::call_function now supports taking and receiving ejson strings, bypassing parsing/serialization in core. ([#4182](https://github.com/realm/realm-core/issues/4182))
 * Flexible sync will now wait for the server to have sent all pending history after a bootstrap before marking a subscription as Complete. ([#5795](https://github.com/realm/realm-core/pull/5795))
 
 ### Fixed

--- a/src/realm/object-store/c_api/app.cpp
+++ b/src/realm/object-store/c_api/app.cpp
@@ -696,16 +696,17 @@ RLM_API bool realm_app_call_function(
 {
     return wrap_err([&] {
         auto cb = [callback, userdata = SharedUserdata{userdata, FreeUserdata(userdata_free)}](
-                      util::Optional<bson::Bson>&& bson, util::Optional<AppError> error) {
+                      const std::string& reply, util::Optional<AppError> error) {
             if (error) {
                 realm_app_error_t c_error(to_capi(*error));
                 callback(userdata.get(), nullptr, &c_error);
             }
             else {
-                callback(userdata.get(), bson->toJson().c_str(), nullptr);
+                callback(userdata.get(), reply.c_str(), nullptr);
             }
         };
-        (*app)->call_function(*user, function_name, parse_ejson_array(serialized_ejson_payload), std::move(cb));
+        (*app)->call_function(*user, function_name, serialized_ejson_payload, /*service_name=*/std::nullopt,
+                              std::move(cb));
         return true;
     });
 }

--- a/src/realm/object-store/sync/app.cpp
+++ b/src/realm/object-store/sync/app.cpp
@@ -16,6 +16,7 @@
 //
 ////////////////////////////////////////////////////////////////////////////
 
+#include "external/json/json.hpp"
 #include <realm/object-store/sync/app.hpp>
 
 #include <realm/util/base64.hpp>
@@ -26,6 +27,7 @@
 #include <realm/object-store/sync/sync_manager.hpp>
 #include <realm/object-store/sync/sync_user.hpp>
 
+#include <sstream>
 #include <string>
 
 using namespace realm;
@@ -1048,51 +1050,68 @@ std::string App::function_call_url_path() const
     return util::format("%1/app/%2/functions/call", m_base_route, m_config.app_id);
 }
 
+void App::call_function(const std::shared_ptr<SyncUser>& user, const std::string& name, std::string_view args_ejson,
+                        const Optional<std::string>& service_name_opt,
+                        UniqueFunction<void(const std::string&, Optional<AppError>)>&& completion)
+{
+    auto service_name = service_name_opt ? *service_name_opt : "<none>";
+    if (would_log()) {
+        log("App: call_function: %1 service_name: %2 args_bson: %3", name, service_name, args_ejson);
+    }
+
+    auto args = util::format("{\"arguments\":%1,\"name\":%2%3}", args_ejson, nlohmann::json(name).dump(),
+                             service_name_opt ? (",\"service\":" + nlohmann::json(service_name).dump()) : "");
+
+    do_authenticated_request(
+        Request{HttpMethod::post, function_call_url_path(), m_request_timeout_ms, {}, std::move(args), false}, user,
+        [self = shared_from_this(), name = name, service_name = std::move(service_name),
+         completion = std::move(completion)](const Response& response) {
+            if (auto error = AppUtils::check_for_errors(response)) {
+                self->log("App: call_function: %1 service_name: %2 -> %3 ERROR: %4", name, service_name,
+                          response.http_status_code, error->message);
+                return completion({}, error);
+            }
+            completion(response.body, util::none);
+        });
+}
+
 void App::call_function(const std::shared_ptr<SyncUser>& user, const std::string& name, const BsonArray& args_bson,
                         const Optional<std::string>& service_name,
                         UniqueFunction<void(Optional<Bson>&&, Optional<AppError>)>&& completion)
 {
     auto service_name2 = service_name ? *service_name : "<none>";
-    if (would_log()) {
-        std::string query_stg = "[ ";
-        for (auto&& item : args_bson) {
-            query_stg += item.to_string() + ", ";
-        }
-        query_stg += "]";
-        log("App: call_function: %1 service_name: %2 args_bson: %3", name, service_name2, query_stg);
+    std::stringstream args_ejson;
+    args_ejson << "[";
+    for (auto&& arg : args_bson) {
+        if (&arg != &args_bson.front())
+            args_ejson << ',';
+        args_ejson << arg.toJson();
     }
-    auto handler = [self = shared_from_this(), name = name, service_name = service_name2,
-                    completion = std::move(completion)](const Response& response) {
-        if (auto error = AppUtils::check_for_errors(response)) {
-            self->log("App: call_function: %1 service_name: %2 -> %3 ERROR: %4", name, service_name,
-                      response.http_status_code, error->message);
-            return completion(util::none, error);
-        }
-        util::Optional<Bson> body_as_bson;
-        try {
-            body_as_bson = bson::parse(response.body);
-            if (self->would_log()) {
-                self->log("App: call_function: %1 service_name: %2 - results: %3", name, service_name,
-                          body_as_bson ? body_as_bson->to_string() : "<none>");
-            }
-        }
-        catch (const std::exception& e) {
-            self->log("App: call_function: %1 service_name: %2 - error parsing result: %3", name, service_name,
-                      e.what());
-            return completion(util::none, AppError(make_error_code(JSONErrorCode::bad_bson_parse), e.what()));
-        };
-        completion(std::move(body_as_bson), util::none);
-    };
+    args_ejson << "]";
 
-    BsonDocument args{{"arguments", args_bson}, {"name", name}};
 
-    if (service_name) {
-        args["service"] = *service_name;
-    }
-
-    do_authenticated_request(
-        Request{HttpMethod::post, function_call_url_path(), m_request_timeout_ms, {}, Bson(args).toJson(), false},
-        user, std::move(handler));
+    call_function(user, name, std::move(args_ejson).str(), service_name,
+                  [self = shared_from_this(), name, service_name = std::move(service_name2),
+                   completion = std::move(completion)](const std::string& response, util::Optional<AppError>&& err) {
+                      if (err) {
+                          return completion({}, err);
+                      }
+                      util::Optional<Bson> body_as_bson;
+                      try {
+                          body_as_bson = bson::parse(response);
+                          if (self->would_log()) {
+                              self->log("App: call_function: %1 service_name: %2 - results: %3", name, service_name,
+                                        body_as_bson ? body_as_bson->to_string() : "<none>");
+                          }
+                      }
+                      catch (const std::exception& e) {
+                          self->log("App: call_function: %1 service_name: %2 - error parsing result: %3", name,
+                                    service_name, e.what());
+                          return completion(util::none,
+                                            AppError(make_error_code(JSONErrorCode::bad_bson_parse), e.what()));
+                      };
+                      completion(std::move(body_as_bson), util::none);
+                  });
 }
 
 void App::call_function(const std::shared_ptr<SyncUser>& user, const std::string& name, const BsonArray& args_bson,

--- a/src/realm/object-store/sync/app.hpp
+++ b/src/realm/object-store/sync/app.hpp
@@ -302,22 +302,26 @@ public:
         return T(this);
     }
 
+    void call_function(const std::shared_ptr<SyncUser>& user, const std::string& name, std::string_view args_ejson,
+                       const util::Optional<std::string>& service_name,
+                       util::UniqueFunction<void(const std::string&, util::Optional<AppError>)>&& completion) final;
+
     void call_function(
         const std::shared_ptr<SyncUser>& user, const std::string& name, const bson::BsonArray& args_bson,
         const util::Optional<std::string>& service_name,
-        util::UniqueFunction<void(util::Optional<bson::Bson>&&, util::Optional<AppError>)>&& completion) override;
+        util::UniqueFunction<void(util::Optional<bson::Bson>&&, util::Optional<AppError>)>&& completion) final;
 
     void call_function(
         const std::shared_ptr<SyncUser>& user, const std::string&, const bson::BsonArray& args_bson,
-        util::UniqueFunction<void(util::Optional<bson::Bson>&&, util::Optional<AppError>)>&& completion) override;
+        util::UniqueFunction<void(util::Optional<bson::Bson>&&, util::Optional<AppError>)>&& completion) final;
 
     void call_function(
         const std::string& name, const bson::BsonArray& args_bson, const util::Optional<std::string>& service_name,
-        util::UniqueFunction<void(util::Optional<bson::Bson>&&, util::Optional<AppError>)>&& completion) override;
+        util::UniqueFunction<void(util::Optional<bson::Bson>&&, util::Optional<AppError>)>&& completion) final;
 
     void call_function(
         const std::string&, const bson::BsonArray& args_bson,
-        util::UniqueFunction<void(util::Optional<bson::Bson>&&, util::Optional<AppError>)>&& completion) override;
+        util::UniqueFunction<void(util::Optional<bson::Bson>&&, util::Optional<AppError>)>&& completion) final;
 
     template <typename T>
     void call_function(const std::shared_ptr<SyncUser>& user, const std::string& name,

--- a/src/realm/object-store/sync/app_service_client.hpp
+++ b/src/realm/object-store/sync/app_service_client.hpp
@@ -39,6 +39,18 @@ public:
     /// Calls the Realm Cloud function with the provided name and arguments.
     /// @param user The sync user to perform this request.
     /// @param name The name of the Realm Cloud function to be called.
+    /// @param args_ejson The arguments array to be provided to the function encoded as an ejson string.
+    /// @param service_name The name of the service, this is optional.
+    /// @param completion Returns the result from the intended call, will return an Optional AppError is an
+    /// error is thrown and ejson-encoded reply if successful
+    virtual void
+    call_function(const std::shared_ptr<SyncUser>& user, const std::string& name, std::string_view args_ejson,
+                  const util::Optional<std::string>& service_name,
+                  util::UniqueFunction<void(const std::string&, util::Optional<AppError>)>&& completion) = 0;
+
+    /// Calls the Realm Cloud function with the provided name and arguments.
+    /// @param user The sync user to perform this request.
+    /// @param name The name of the Realm Cloud function to be called.
     /// @param args_bson The `BSONArray` of arguments to be provided to the function.
     /// @param service_name The name of the service, this is optional.
     /// @param completion Returns the result from the intended call, will return an Optional AppError is an


### PR DESCRIPTION
## What, How & Why?
<!-- Describe the changes and give some hints to guide your reviewers if possible. -->
<!-- Link to relevant issue this fixes -->


Closes #4182

## ☑️ ToDos
* [x] 📝 Changelog update
* [ ] 🚦  ~~Tests (or not relevant)~~
  * New function used as implementation for old overloads, so existing coverage should be sufficient
* [x] C-API, if public C++ API changed.
  * C-API was already string based. Now it avoids extra parsing and serialization overhead.
