### PR TITLE
Fix race with translator in PBS client reset tests

### DIFF
--- a/evergreen/config.yml
+++ b/evergreen/config.yml
@@ -601,7 +601,7 @@ tasks:
                 export DEVELOPER_DIR="${xcode_developer_dir}"
             fi
 
-            ./evergreen/install_baas.sh -w ./baas-work-dir -b 2721a3361229fd16607b662af80c1cb32dce1162 2>&1 | tee install_baas_output.log
+            ./evergreen/install_baas.sh -w ./baas-work-dir -b master 2>&1 | tee install_baas_output.log
         fi
 
   - command: shell.exec

--- a/evergreen/config.yml
+++ b/evergreen/config.yml
@@ -601,7 +601,7 @@ tasks:
                 export DEVELOPER_DIR="${xcode_developer_dir}"
             fi
 
-            ./evergreen/install_baas.sh -w ./baas-work-dir -b master 2>&1 | tee install_baas_output.log
+            ./evergreen/install_baas.sh -w ./baas-work-dir -b 2721a3361229fd16607b662af80c1cb32dce1162 2>&1 | tee install_baas_output.log
         fi
 
   - command: shell.exec

--- a/test/object-store/sync/sync_test_utils.cpp
+++ b/test/object-store/sync/sync_test_utils.cpp
@@ -86,7 +86,7 @@ void timed_sleeping_wait_for(util::FunctionRef<bool()> condition, std::chrono::m
         if (std::chrono::steady_clock::now() - wait_start > max_ms) {
             throw std::runtime_error(util::format("timed_sleeping_wait_for exceeded %1 ms", max_ms.count()));
         }
-        millisleep(sleep_ms);
+        millisleep(sleep_ms.count());
     }
 }
 

--- a/test/object-store/sync/sync_test_utils.cpp
+++ b/test/object-store/sync/sync_test_utils.cpp
@@ -86,7 +86,7 @@ void timed_sleeping_wait_for(util::FunctionRef<bool()> condition, std::chrono::m
         if (std::chrono::steady_clock::now() - wait_start > max_ms) {
             throw std::runtime_error(util::format("timed_sleeping_wait_for exceeded %1 ms", max_ms.count()));
         }
-        millisleep(sleep_ms.count());
+        std::this_thread::sleep_for(sleep_ms);
     }
 }
 

--- a/test/object-store/sync/sync_test_utils.cpp
+++ b/test/object-store/sync/sync_test_utils.cpp
@@ -78,14 +78,15 @@ void timed_wait_for(util::FunctionRef<bool()> condition, std::chrono::millisecon
     });
 }
 
-void timed_sleeping_wait_for(util::FunctionRef<bool()> condition, std::chrono::milliseconds max_ms)
+void timed_sleeping_wait_for(util::FunctionRef<bool()> condition, std::chrono::milliseconds max_ms,
+                             std::chrono::milliseconds sleep_ms)
 {
     const auto wait_start = std::chrono::steady_clock::now();
     while (!condition()) {
         if (std::chrono::steady_clock::now() - wait_start > max_ms) {
             throw std::runtime_error(util::format("timed_sleeping_wait_for exceeded %1 ms", max_ms.count()));
         }
-        millisleep(1);
+        millisleep(sleep_ms);
     }
 }
 
@@ -340,22 +341,23 @@ static void wait_for_object_to_persist(std::shared_ptr<SyncUser> user, const App
     app::MongoClient remote_client = user->mongo_client("BackingDB");
     app::MongoDatabase db = remote_client.db(app_session.config.mongo_dbname);
     app::MongoCollection object_coll = db[schema_name];
-    uint64_t count_external = 0;
 
     timed_sleeping_wait_for(
         [&]() -> bool {
-            if (count_external == 0) {
-                object_coll.count(filter_bson, [&](uint64_t count, util::Optional<app::AppError> error) {
-                    REQUIRE(!error);
-                    count_external = count;
-                });
-            }
-            if (count_external == 0) {
-                millisleep(2000); // don't spam the server too much
-            }
-            return count_external > 0;
+            auto pf = util::make_promise_future<uint64_t>();
+            object_coll.count(filter_bson, [promise = std::move(pf.promise)](
+                                               uint64_t count, util::Optional<app::AppError> error) mutable {
+                REQUIRE(!error);
+                if (error) {
+                    promise.set_error({ErrorCodes::RuntimeError, error->message});
+                }
+                else {
+                    promise.emplace_value(count);
+                }
+            });
+            return pf.future.get() > 0;
         },
-        std::chrono::minutes(15));
+        std::chrono::minutes(15), std::chrono::milliseconds(100));
 }
 
 struct BaasClientReset : public TestClientReset {
@@ -438,6 +440,10 @@ struct BaasClientReset : public TestClientReset {
         if (app_session.config.dev_mode_enabled) { // dev mode is not sticky across a reset
             app_session.admin_api.set_development_mode_to(app_session.server_app_id, true);
         }
+
+        timed_sleeping_wait_for([&] {
+            return app_session.admin_api.is_initial_sync_complete(app_session.server_app_id);
+        });
 
         {
             auto realm2 = Realm::get_shared_realm(m_remote_config);

--- a/test/object-store/sync/sync_test_utils.cpp
+++ b/test/object-store/sync/sync_test_utils.cpp
@@ -377,6 +377,10 @@ struct BaasClientReset : public TestClientReset {
         partition_value = partition_value.substr(1, partition_value.size() - 2);
         Partition partition = {app_session.config.partition_key.name, partition_value};
 
+        timed_sleeping_wait_for([&] {
+            return app_session.admin_api.is_initial_sync_complete(app_session.server_app_id);
+        });
+
         auto realm = Realm::get_shared_realm(m_local_config);
         auto session = sync_manager->get_existing_session(realm->config().path);
         const std::string object_schema_name = "object";

--- a/test/object-store/sync/sync_test_utils.hpp
+++ b/test/object-store/sync/sync_test_utils.hpp
@@ -48,7 +48,8 @@ void timed_wait_for(util::FunctionRef<bool()> condition,
                     std::chrono::milliseconds max_ms = std::chrono::milliseconds(5000));
 
 void timed_sleeping_wait_for(util::FunctionRef<bool()> condition,
-                             std::chrono::milliseconds max_ms = std::chrono::seconds(30));
+                             std::chrono::milliseconds max_ms = std::chrono::seconds(30),
+                             std::chrono::milliseconds sleep_ms = std::chrono::milliseconds(1));
 
 template <typename T>
 struct TimedFutureState : public util::AtomicRefCountBase {

--- a/test/object-store/util/baas_admin_api.cpp
+++ b/test/object-store/util/baas_admin_api.cpp
@@ -699,13 +699,13 @@ bool AdminAPISession::is_sync_terminated(const std::string& app_id) const
     return state_result["state"].get<std::string>().empty();
 }
 
-bool AdminAPISession::is_initial_sync_complete(const std::string &app_id) const
+bool AdminAPISession::is_initial_sync_complete(const std::string& app_id) const
 {
     auto progress_endpoint = apps()[app_id]["sync"]["progress"];
     auto progress_result = progress_endpoint.get_json();
     std::cerr << "progress result is " << progress_result.dump() << std::endl;
     if (auto it = progress_result.find("progress"); it != progress_result.end() && it->is_object() && !it->empty()) {
-        for (auto& elem: *it) {
+        for (auto& elem : *it) {
             auto is_complete = elem["complete"];
             if (!is_complete.is_boolean() || !is_complete.get<bool>()) {
                 return false;

--- a/test/object-store/util/baas_admin_api.cpp
+++ b/test/object-store/util/baas_admin_api.cpp
@@ -703,7 +703,6 @@ bool AdminAPISession::is_initial_sync_complete(const std::string& app_id) const
 {
     auto progress_endpoint = apps()[app_id]["sync"]["progress"];
     auto progress_result = progress_endpoint.get_json();
-    std::cerr << "progress result is " << progress_result.dump() << std::endl;
     if (auto it = progress_result.find("progress"); it != progress_result.end() && it->is_object() && !it->empty()) {
         for (auto& elem : *it) {
             auto is_complete = elem["complete"];

--- a/test/object-store/util/baas_admin_api.cpp
+++ b/test/object-store/util/baas_admin_api.cpp
@@ -699,6 +699,23 @@ bool AdminAPISession::is_sync_terminated(const std::string& app_id) const
     return state_result["state"].get<std::string>().empty();
 }
 
+bool AdminAPISession::is_initial_sync_complete(const std::string &app_id) const
+{
+    auto progress_endpoint = apps()[app_id]["sync"]["progress"];
+    auto progress_result = progress_endpoint.get_json();
+    std::cerr << "progress result is " << progress_result.dump() << std::endl;
+    if (auto it = progress_result.find("progress"); it != progress_result.end() && it->is_object() && !it->empty()) {
+        for (auto& elem: *it) {
+            auto is_complete = elem["complete"];
+            if (!is_complete.is_boolean() || !is_complete.get<bool>()) {
+                return false;
+            }
+        }
+        return true;
+    }
+    return false;
+}
+
 AdminAPIEndpoint AdminAPISession::apps() const
 {
     return AdminAPIEndpoint(util::format("%1/api/admin/v3.0/groups/%2/apps", m_base_url, m_group_id), m_access_token);

--- a/test/object-store/util/baas_admin_api.hpp
+++ b/test/object-store/util/baas_admin_api.hpp
@@ -100,6 +100,7 @@ public:
             }
         }
     };
+
     std::vector<Service> get_services(const std::string& app_id) const;
     std::vector<std::string> get_errors(const std::string& app_id) const;
     Service get_sync_service(const std::string& app_id) const;
@@ -114,6 +115,7 @@ public:
                                           ServiceConfig sync_config, bool disable) const;
     bool is_sync_enabled(const std::string& app_id) const;
     bool is_sync_terminated(const std::string& app_id) const;
+    bool is_initial_sync_complete(const std::string& app_id) const;
 
     const std::string& base_url() const noexcept
     {


### PR DESCRIPTION
## What, How & Why?
Talking with @kmorkos, it seems there's always been a narrow race in our PBS tests that some recent changes in the server has exacerbated. We start each client reset test by creating a realm and creating an object in it and then uploading/downloading it, disconnecting, and mutating it while disconnected to create a diverging history with the server. It turns out the translator can pick up our object and then initial sync it back into server history - which in turn deletes/re-creates the object on the client before we can disconnect. This means that when we try to mutate the object to create a diverging local write, we're writing to an object that's been deleted.

The fix is to just wait for initial sync to be fully complete doing any of our local writes.

This can't happen in FLX sync because FLX sync doesn't allow any clients to connect until initial sync is complete.

## ☑️ ToDos
* [ ] 📝 Changelog update
* [ ] 🚦 Tests (or not relevant)
* [ ] C-API, if public C++ API changed.
