### PR TITLE
Add test case for OT-ing across a bootstrap

### DIFF
--- a/test/object-store/sync/flx_sync_harness.hpp
+++ b/test/object-store/sync/flx_sync_harness.hpp
@@ -124,6 +124,11 @@ public:
         return m_test_session;
     }
 
+    SyncTestFile make_test_file() const
+    {
+        return SyncTestFile(app()->current_user(), schema(), realm::SyncConfig::FLXSyncEnabled{});
+    }
+
 private:
     TestAppSession m_test_session;
     Schema m_schema;


### PR DESCRIPTION
## What, How & Why?
This is some low hanging fruit from the compensating writes project. We had an error on the server during our initial implementation where the EraseObject instructions sent as part of a bootstrap to make bootstraps idempotent were not in the merge window for uploaded objects. So you could create some objects that conflict with an object on the server and you would end up getting those objects replaced locally, but other realms would get the objects you created - ending up with diverging histories.

This was fixed as part of the server-side compensating writes project and this change just adds an integration test to make sure it works and we catch any future breakage.

## ☑️ ToDos
* [ ] 📝 Changelog update
* [x] 🚦 Tests (or not relevant)
* [ ] C-API, if public C++ API changed.
