### PR TITLE
Add typedef for realm_app_call_function callbacks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 * <New feature description> (PR [#????](https://github.com/realm/realm-core/pull/????))
 * App::call_function now supports taking and receiving ejson strings, bypassing parsing/serialization in core. ([#4182](https://github.com/realm/realm-core/issues/4182))
 * Flexible sync will now wait for the server to have sent all pending history after a bootstrap before marking a subscription as Complete. ([#5795](https://github.com/realm/realm-core/pull/5795))
+* Add typedef for realm_app_call_function callbacks. ([#5996](https://github.com/realm/realm-core/pull/5996))
 
 ### Fixed
 * <How do the end-user experience this issue? what was the impact?> ([#????](https://github.com/realm/realm-core/issues/????), since v?.?.?)

--- a/src/realm.h
+++ b/src/realm.h
@@ -2839,6 +2839,7 @@ typedef void (*realm_return_apikey_func_t)(realm_userdata_t userdata, realm_app_
 typedef void (*realm_return_apikey_list_func_t)(realm_userdata_t userdata, realm_app_user_apikey_t[], size_t count,
                                                 realm_app_error_t*);
 
+typedef void (*realm_return_string_func_t)(realm_userdata_t userdata, const char* serialized_ejson_response, const realm_app_error_t*);
 /**
  * Generic completion callback for asynchronous Realm App operations.
  *
@@ -3219,8 +3220,7 @@ RLM_API bool realm_app_push_notification_client_deregister_device(const realm_ap
  */
 RLM_API bool realm_app_call_function(const realm_app_t*, const realm_user_t*, const char* function_name,
                                      const char* serialized_ejson_args,
-                                     void (*)(realm_userdata_t userdata, const char* serialized_ejson_response,
-                                              const realm_app_error_t*),
+                                     realm_return_string_func_t callback,
                                      realm_userdata_t userdata, realm_free_userdata_func_t userdata_free);
 
 /**

--- a/src/realm.h
+++ b/src/realm.h
@@ -2839,7 +2839,8 @@ typedef void (*realm_return_apikey_func_t)(realm_userdata_t userdata, realm_app_
 typedef void (*realm_return_apikey_list_func_t)(realm_userdata_t userdata, realm_app_user_apikey_t[], size_t count,
                                                 realm_app_error_t*);
 
-typedef void (*realm_return_string_func_t)(realm_userdata_t userdata, const char* serialized_ejson_response, const realm_app_error_t*);
+typedef void (*realm_return_string_func_t)(realm_userdata_t userdata, const char* serialized_ejson_response,
+                                           const realm_app_error_t*);
 /**
  * Generic completion callback for asynchronous Realm App operations.
  *
@@ -3219,8 +3220,7 @@ RLM_API bool realm_app_push_notification_client_deregister_device(const realm_ap
  * @return true, if no error occurred.
  */
 RLM_API bool realm_app_call_function(const realm_app_t*, const realm_user_t*, const char* function_name,
-                                     const char* serialized_ejson_args,
-                                     realm_return_string_func_t callback,
+                                     const char* serialized_ejson_args, realm_return_string_func_t callback,
                                      realm_userdata_t userdata, realm_free_userdata_func_t userdata_free);
 
 /**

--- a/src/realm/object-store/c_api/app.cpp
+++ b/src/realm/object-store/c_api/app.cpp
@@ -691,7 +691,7 @@ RLM_API bool realm_app_push_notification_client_deregister_device(const realm_ap
 
 RLM_API bool realm_app_call_function(
     const realm_app_t* app, const realm_user_t* user, const char* function_name, const char* serialized_ejson_payload,
-    void (*callback)(realm_userdata_t userdata, const char* serialized_ejson_response, const realm_app_error_t*),
+    realm_return_string_func_t callback,
     realm_userdata_t userdata, realm_free_userdata_func_t userdata_free)
 {
     return wrap_err([&] {

--- a/src/realm/object-store/c_api/app.cpp
+++ b/src/realm/object-store/c_api/app.cpp
@@ -689,10 +689,9 @@ RLM_API bool realm_app_push_notification_client_deregister_device(const realm_ap
     });
 }
 
-RLM_API bool realm_app_call_function(
-    const realm_app_t* app, const realm_user_t* user, const char* function_name, const char* serialized_ejson_payload,
-    realm_return_string_func_t callback,
-    realm_userdata_t userdata, realm_free_userdata_func_t userdata_free)
+RLM_API bool realm_app_call_function(const realm_app_t* app, const realm_user_t* user, const char* function_name,
+                                     const char* serialized_ejson_payload, realm_return_string_func_t callback,
+                                     realm_userdata_t userdata, realm_free_userdata_func_t userdata_free)
 {
     return wrap_err([&] {
         auto cb = [callback, userdata = SharedUserdata{userdata, FreeUserdata(userdata_free)}](


### PR DESCRIPTION
## What, How & Why?
Adds a typedef for `realm_app_call_function` callback function. This is required because `SWIG` in the Kotlin SDK cannot map it properly to a Java type.

## ☑️ ToDos
* [x] 📝 Changelog update
* [x] 🚦 Tests (or not relevant)
* [x] C-API, if public C++ API changed.
