### PR TITLE
Compare linked pk instead of object key in test

### DIFF
--- a/test/object-store/sync/app.cpp
+++ b/test/object-store/sync/app.cpp
@@ -1630,7 +1630,17 @@ TEST_CASE("app: mixed lists with object links", "[sync][app]") {
         auto list = util::any_cast<List&&>(obj.get_property_value<std::any>(c, "mixed_array"));
         for (size_t idx = 0; idx < list.size(); ++idx) {
             Mixed mixed = list.get_any(idx);
-            CHECK(mixed == util::any_cast<Mixed>(mixed_list_values[idx]));
+            if (idx == 3) {
+                CHECK(mixed.is_type(type_TypedLink));
+                auto link = mixed.get<ObjLink>();
+                auto link_table = realm->read_group().get_table(link.get_table_key());
+                CHECK(link_table->get_name() == "class_Target");
+                auto link_obj = link_table->get_object(link.get_obj_key());
+                CHECK(link_obj.get_primary_key() == target_id);
+            }
+            else {
+                CHECK(mixed == util::any_cast<Mixed>(mixed_list_values[idx]));
+            }
         }
     }
 }


### PR DESCRIPTION
This test has started failing. Likely due to server changes discussed in https://github.com/realm/realm-core/pull/5986.
The test was wrong to compare object keys (and table keys) across different Realms as those are internal values. The fix is to compare by linked table name and linked primary key instead.

Fixes this failure:
```
[2022/11/04 16:35:40.346] 3: -------------------------------------------------------------------------------
[2022/11/04 16:35:40.346] 3: app: mixed lists with object links
[2022/11/04 16:35:40.346] 3: -------------------------------------------------------------------------------
[2022/11/04 16:35:40.346] 3: /System/Volumes/Data/data/mci/7fe61e07991afa19bd95c327a80373bc/realm-core/test/object-store/sync/app.cpp:1572
[2022/11/04 16:35:40.346] 3: ...............................................................................
[2022/11/04 16:35:40.346] 3:
[2022/11/04 16:35:40.346] 3: /System/Volumes/Data/data/mci/7fe61e07991afa19bd95c327a80373bc/realm-core/test/object-store/sync/app.cpp:1633: FAILED:
[2022/11/04 16:35:40.346] 3:   CHECK( mixed == util::any_cast<Mixed>(mixed_list_values[idx]) )
[2022/11/04 16:35:40.346] 3: with expansion:
[2022/11/04 16:35:40.346] 3:   {TableKey(1),ObjKey(1)}
[2022/11/04 16:35:40.346] 3:   ==
[2022/11/04 16:35:40.346] 3:   {TableKey(1),ObjKey(0)}
[2022/11/04 16:35:40.346] 3:
[2022/11/04 16:35:40.346] 3: Assertion failure: /System/Volumes/Data/data/mci/7fe61e07991afa19bd95c327a80373bc/realm-core/test/object-store/sync/app.cpp:1633
[2022/11/04 16:35:40.346] 3: 	 from expresion: 'mixed == util::any_cast<Mixed>(mixed_list_values[idx])'
[2022/11/04 16:35:40.346] 3: 	 with expansion: '{TableKey(1),ObjKey(1)}
[2022/11/04 16:35:40.346] 3: ==
[2022/11/04 16:35:40.346] 3: {TableKey(1),ObjKey(0)}'
```