### PR TITLE
Fix bootstrap changeset batching

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
 * Fix a race condition which could result in "operation cancelled" errors being delivered to async open callbacks rather than the actual sync error which caused things to fail ([PR #5968](https://github.com/realm/realm-core/pull/5968), since the introduction of async open).
 * The name of one of the RLM_SYNC_BOOTSTRAPPING enum member in the C api was updated to match the naming convention of the other members in the enum.
 * Fix `Results.distinct(keypaths)` and `Results.sort(keypaths)` not correctly handling keypaths names for properties that have a public/private(column) property name ([PR #5952](https://github.com/realm/realm-core/pull/5952).
+* Bootstraps will not be applied in a single write transaction - they will be applied 1MB of changesets at a time, or as configured by the SDK ([#5999](https://github.com/realm/realm-core/pull/5999), since v12.0.0).
 
 ### Breaking changes
 * None.

--- a/src/realm/object-store/sync/sync_session.cpp
+++ b/src/realm/object-store/sync/sync_session.cpp
@@ -727,6 +727,7 @@ void SyncSession::create_sync_session()
     session_config.ssl_verify_callback = sync_config.ssl_verify_callback;
     session_config.proxy_config = sync_config.proxy_config;
     session_config.simulate_integration_error = sync_config.simulate_integration_error;
+    session_config.flx_bootstrap_batch_size_bytes = sync_config.flx_bootstrap_batch_size_bytes;
     if (sync_config.on_sync_client_event_hook) {
         session_config.on_sync_client_event_hook = [hook = sync_config.on_sync_client_event_hook,
                                                     anchor = weak_from_this()](const SyncClientHookData& data) {

--- a/src/realm/sync/client.hpp
+++ b/src/realm/sync/client.hpp
@@ -307,6 +307,10 @@ public:
 
         util::Optional<SyncConfig::ProxyConfig> proxy_config;
 
+        /// When integrating a flexible sync bootstrap, process this many bytes of
+        /// changeset data in a single integration attempt.
+        size_t flx_bootstrap_batch_size_bytes = 1024 * 1024;
+
         /// Set to true to cause the integration of the first received changeset
         /// (in a DOWNLOAD message) to fail.
         ///
@@ -459,7 +463,6 @@ public:
     /// the session object is destroyed. Please see "Callback semantics" section
     /// under Session for more on this.
     void set_progress_handler(util::UniqueFunction<ProgressHandler>);
-
 
     using ConnectionStateChangeListener = void(ConnectionState, util::Optional<SessionErrorInfo>);
 

--- a/src/realm/sync/config.hpp
+++ b/src/realm/sync/config.hpp
@@ -172,6 +172,11 @@ struct SyncConfig {
     std::function<SSLVerifyCallback> ssl_verify_callback;
     util::Optional<ProxyConfig> proxy_config;
     bool flx_sync_requested = false;
+
+    // When integrating a flexible sync bootstrap, process this many bytes of changeset data in a single integration
+    // attempt. This many bytes of changesets will be uncompressed and held in memory while being applied.
+    size_t flx_bootstrap_batch_size_bytes = 1024 * 1024;
+
     bool client_validate_ssl = true;
 
     // If true, upload/download waits are canceled on any sync error and not just fatal ones

--- a/src/realm/sync/noinst/pending_bootstrap_store.cpp
+++ b/src/realm/sync/noinst/pending_bootstrap_store.cpp
@@ -196,6 +196,7 @@ void PendingBootstrapStore::clear()
     auto tr = m_db->start_write();
     auto bootstrap_table = tr->get_table(m_table);
     bootstrap_table->clear();
+    m_has_pending = false;
     tr->commit();
 }
 
@@ -252,6 +253,7 @@ PendingBootstrapStore::PendingBatch PendingBootstrapStore::peek_pending(size_t l
         parsed_changeset.last_integrated_local_version =
             cur_changeset.get<int64_t>(m_changeset_last_integrated_client_version);
         parsed_changeset.data = BinaryData(uncompressed_buffer.data(), uncompressed_buffer.size());
+        bytes_so_far += parsed_changeset.data.size();
         ret.changesets.push_back(std::move(parsed_changeset));
     }
     ret.remaining = changeset_list.size() - ret.changesets.size();

--- a/src/realm/sync/noinst/pending_bootstrap_store.cpp
+++ b/src/realm/sync/noinst/pending_bootstrap_store.cpp
@@ -256,9 +256,34 @@ PendingBootstrapStore::PendingBatch PendingBootstrapStore::peek_pending(size_t l
         bytes_so_far += parsed_changeset.data.size();
         ret.changesets.push_back(std::move(parsed_changeset));
     }
-    ret.remaining = changeset_list.size() - ret.changesets.size();
+    ret.remaining_changesets = changeset_list.size() - ret.changesets.size();
 
     return ret;
+}
+
+PendingBootstrapStore::PendingBatchStats PendingBootstrapStore::pending_stats()
+{
+    auto tr = m_db->start_read();
+    auto bootstrap_table = tr->get_table(m_table);
+    if (bootstrap_table->is_empty()) {
+        return {};
+    }
+
+    REALM_ASSERT(bootstrap_table->size() == 1);
+
+    auto bootstrap_obj = bootstrap_table->get_object(0);
+    auto changeset_list = bootstrap_obj.get_linklist(m_changesets);
+
+    PendingBatchStats stats;
+    stats.query_version = bootstrap_obj.get<int64_t>(m_query_version);
+    stats.pending_changesets = changeset_list.size();
+    changeset_list.for_each([&](Obj& cur_changeset) {
+        stats.pending_changeset_bytes +=
+            static_cast<size_t>(cur_changeset.get<int64_t>(m_changeset_original_changeset_size));
+        return IteratorControl::AdvanceToNext;
+    });
+
+    return stats;
 }
 
 void PendingBootstrapStore::pop_front_pending(const TransactionRef& tr, size_t count)

--- a/src/realm/sync/noinst/pending_bootstrap_store.hpp
+++ b/src/realm/sync/noinst/pending_bootstrap_store.hpp
@@ -59,12 +59,19 @@ public:
         std::vector<Transformer::RemoteChangeset> changesets;
         std::vector<util::AppendBuffer<char>> changeset_data;
         util::Optional<SyncProgress> progress;
-        size_t remaining = 0;
+        size_t remaining_changesets = 0;
     };
 
     // Returns the next batch (download message) of changesets if it exists. The transaction must be in the reading
     // state.
     PendingBatch peek_pending(size_t limit_in_bytes);
+
+    struct PendingBatchStats {
+        int64_t query_version = 0;
+        size_t pending_changesets = 0;
+        size_t pending_changeset_bytes = 0;
+    };
+    PendingBatchStats pending_stats();
 
     // Removes the first set of changesets from the current pending bootstrap batch. The transaction must be in the
     // writing state.

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -185,6 +185,7 @@ if(REALM_ENABLE_SYNC)
         test_sync_auth.cpp
         test_sync_history_migration.cpp
         test_sync_subscriptions.cpp
+        test_sync_pending_bootstraps.cpp
         test_transform.cpp
         test_util_buffer_stream.cpp
         test_util_circular_buffer.cpp

--- a/test/object-store/sync/flx_sync.cpp
+++ b/test/object-store/sync/flx_sync.cpp
@@ -1801,7 +1801,7 @@ TEST_CASE("flx: bootstrap batching prevents orphan documents", "[sync][flx][app]
             auto pending_batch = bootstrap_store.peek_pending(1024 * 1024 * 16);
             REQUIRE(pending_batch.query_version == 1);
             REQUIRE(!pending_batch.progress);
-            REQUIRE(pending_batch.remaining == 0);
+            REQUIRE(pending_batch.remaining_changesets == 0);
             REQUIRE(pending_batch.changesets.size() == 1);
 
             check_interrupted_state(realm);
@@ -1880,7 +1880,7 @@ TEST_CASE("flx: bootstrap batching prevents orphan documents", "[sync][flx][app]
             auto pending_batch = bootstrap_store.peek_pending(1024 * 1024 * 16);
             REQUIRE(pending_batch.query_version == 1);
             REQUIRE(static_cast<bool>(pending_batch.progress));
-            REQUIRE(pending_batch.remaining == 0);
+            REQUIRE(pending_batch.remaining_changesets == 0);
             REQUIRE(pending_batch.changesets.size() == 3);
 
             check_interrupted_state(realm);

--- a/test/test_sync_pending_bootstraps.cpp
+++ b/test/test_sync_pending_bootstraps.cpp
@@ -56,9 +56,14 @@ TEST(Sync_PendingBootstrapStoreBatching)
         sync::PendingBootstrapStore store(db, &test_context.logger);
         CHECK(store.has_pending());
 
+        auto stats = store.pending_stats();
+        CHECK_EQUAL(stats.pending_changeset_bytes, 1024 * 5);
+        CHECK_EQUAL(stats.pending_changesets, 5);
+        CHECK_EQUAL(stats.query_version, 1);
+
         auto pending_batch = store.peek_pending((1024 * 3) - 1);
         CHECK_EQUAL(pending_batch.changesets.size(), 3);
-        CHECK_EQUAL(pending_batch.remaining, 2);
+        CHECK_EQUAL(pending_batch.remaining_changesets, 2);
         CHECK_EQUAL(pending_batch.query_version, 1);
         CHECK(pending_batch.progress);
 
@@ -88,7 +93,7 @@ TEST(Sync_PendingBootstrapStoreBatching)
 
         pending_batch = store.peek_pending(1024 * 2);
         CHECK_EQUAL(pending_batch.changesets.size(), 2);
-        CHECK_EQUAL(pending_batch.remaining, 0);
+        CHECK_EQUAL(pending_batch.remaining_changesets, 0);
         CHECK_EQUAL(pending_batch.query_version, 1);
         CHECK(pending_batch.progress);
         validate_changeset(0, 4, 9, 'd', 4, 2);
@@ -128,7 +133,7 @@ TEST(Sync_PendingBootstrapStoreClear)
     CHECK(store.has_pending());
 
     auto pending_batch = store.peek_pending(1025);
-    CHECK_EQUAL(pending_batch.remaining, 0);
+    CHECK_EQUAL(pending_batch.remaining_changesets, 0);
     CHECK_EQUAL(pending_batch.query_version, 2);
     CHECK(pending_batch.progress);
     CHECK_EQUAL(pending_batch.changesets.size(), 2);
@@ -139,7 +144,7 @@ TEST(Sync_PendingBootstrapStoreClear)
     pending_batch = store.peek_pending(1024);
     CHECK_EQUAL(pending_batch.changesets.size(), 0);
     CHECK_EQUAL(pending_batch.query_version, 0);
-    CHECK_EQUAL(pending_batch.remaining, 0);
+    CHECK_EQUAL(pending_batch.remaining_changesets, 0);
     CHECK_NOT(pending_batch.progress);
 }
 

--- a/test/test_sync_pending_bootstraps.cpp
+++ b/test/test_sync_pending_bootstraps.cpp
@@ -1,0 +1,146 @@
+#include "realm/db.hpp"
+#include "realm/sync/noinst/client_history_impl.hpp"
+#include "realm/sync/noinst/pending_bootstrap_store.hpp"
+
+#include "test.hpp"
+#include "util/test_path.hpp"
+
+namespace realm::sync {
+
+TEST(Sync_PendingBootstrapStoreBatching)
+{
+    SHARED_GROUP_TEST_PATH(db_path);
+    SyncProgress progress;
+    progress.download = {5, 5};
+    progress.latest_server_version = {5, 123456789};
+    progress.upload = {5, 5};
+    {
+        auto db = DB::create(make_client_replication(), db_path);
+        sync::PendingBootstrapStore store(db, &test_context.logger);
+
+        CHECK(!store.has_pending());
+        std::vector<Transformer::RemoteChangeset> changesets;
+        std::vector<std::string> changeset_data;
+
+        changeset_data.emplace_back(1024, 'a');
+        changesets.emplace_back(1, 6, BinaryData(changeset_data.back()), 1, 1);
+        changesets.back().original_changeset_size = 1024;
+        changeset_data.emplace_back(1024, 'b');
+        changesets.emplace_back(2, 7, BinaryData(changeset_data.back()), 2, 1);
+        changesets.back().original_changeset_size = 1024;
+        changeset_data.emplace_back(1024, 'c');
+        changesets.emplace_back(3, 8, BinaryData(changeset_data.back()), 3, 1);
+        changesets.back().original_changeset_size = 1024;
+
+        bool created_new_batch = false;
+        store.add_batch(1, util::none, changesets, &created_new_batch);
+
+        CHECK(created_new_batch);
+        CHECK(store.has_pending());
+
+        changesets.clear();
+        changeset_data.clear();
+        changeset_data.emplace_back(1024, 'd');
+        changesets.emplace_back(4, 9, BinaryData(changeset_data.back()), 4, 2);
+        changesets.back().original_changeset_size = 1024;
+        changeset_data.emplace_back(1024, 'e');
+        changesets.emplace_back(5, 10, BinaryData(changeset_data.back()), 5, 3);
+        changesets.back().original_changeset_size = 1024;
+
+        store.add_batch(1, progress, changesets, &created_new_batch);
+        CHECK(!created_new_batch);
+    }
+
+    {
+        auto db = DB::create(make_client_replication(), db_path);
+        sync::PendingBootstrapStore store(db, &test_context.logger);
+        CHECK(store.has_pending());
+
+        auto pending_batch = store.peek_pending((1024 * 3) - 1);
+        CHECK_EQUAL(pending_batch.changesets.size(), 3);
+        CHECK_EQUAL(pending_batch.remaining, 2);
+        CHECK_EQUAL(pending_batch.query_version, 1);
+        CHECK(pending_batch.progress);
+
+        auto validate_changeset = [&](size_t idx, version_type rv, version_type lv, char val, timestamp_type ts,
+                                      file_ident_type ident) {
+            auto& changeset = pending_batch.changesets[idx];
+            CHECK_EQUAL(changeset.remote_version, rv);
+            CHECK_EQUAL(changeset.last_integrated_local_version, lv);
+            CHECK_EQUAL(changeset.origin_timestamp, ts);
+            CHECK_EQUAL(changeset.origin_file_ident, ident);
+            CHECK_EQUAL(changeset.original_changeset_size, 1024);
+            util::Span<const char> data(changeset.data.get_first_chunk().data(),
+                                        changeset.data.get_first_chunk().size());
+            CHECK(std::all_of(data.begin(), data.end(), [&](char ch) {
+                return ch == val;
+            }));
+        };
+
+        validate_changeset(0, 1, 6, 'a', 1, 1);
+        validate_changeset(1, 2, 7, 'b', 2, 1);
+        validate_changeset(2, 3, 8, 'c', 3, 1);
+
+        auto tr = db->start_write();
+        store.pop_front_pending(tr, pending_batch.changesets.size());
+        tr->commit();
+        CHECK(store.has_pending());
+
+        pending_batch = store.peek_pending(1024 * 2);
+        CHECK_EQUAL(pending_batch.changesets.size(), 2);
+        CHECK_EQUAL(pending_batch.remaining, 0);
+        CHECK_EQUAL(pending_batch.query_version, 1);
+        CHECK(pending_batch.progress);
+        validate_changeset(0, 4, 9, 'd', 4, 2);
+        validate_changeset(1, 5, 10, 'e', 5, 3);
+
+        tr = db->start_write();
+        store.pop_front_pending(tr, pending_batch.changesets.size());
+        tr->commit();
+        CHECK(!store.has_pending());
+    }
+}
+
+TEST(Sync_PendingBootstrapStoreClear)
+{
+    SHARED_GROUP_TEST_PATH(db_path);
+    SyncProgress progress;
+    progress.download = {5, 5};
+    progress.latest_server_version = {5, 123456789};
+    progress.upload = {5, 5};
+    auto db = DB::create(make_client_replication(), db_path);
+    sync::PendingBootstrapStore store(db, &test_context.logger);
+
+    CHECK(!store.has_pending());
+    std::vector<Transformer::RemoteChangeset> changesets;
+    std::vector<std::string> changeset_data;
+
+    changeset_data.emplace_back(1024, 'a');
+    changesets.emplace_back(1, 6, BinaryData(changeset_data.back()), 1, 1);
+    changesets.back().original_changeset_size = 1024;
+    changeset_data.emplace_back(1024, 'b');
+    changesets.emplace_back(2, 7, BinaryData(changeset_data.back()), 2, 1);
+    changesets.back().original_changeset_size = 1024;
+
+    bool created_new_batch = false;
+    store.add_batch(2, progress, changesets, &created_new_batch);
+    CHECK(created_new_batch);
+    CHECK(store.has_pending());
+
+    auto pending_batch = store.peek_pending(1025);
+    CHECK_EQUAL(pending_batch.remaining, 0);
+    CHECK_EQUAL(pending_batch.query_version, 2);
+    CHECK(pending_batch.progress);
+    CHECK_EQUAL(pending_batch.changesets.size(), 2);
+
+    store.clear();
+
+    CHECK_NOT(store.has_pending());
+    pending_batch = store.peek_pending(1024);
+    CHECK_EQUAL(pending_batch.changesets.size(), 0);
+    CHECK_EQUAL(pending_batch.query_version, 0);
+    CHECK_EQUAL(pending_batch.remaining, 0);
+    CHECK_NOT(pending_batch.progress);
+}
+
+} // namespace realm::sync


### PR DESCRIPTION
## What, How & Why?
This fixes an issue where bootstraps are not properly broken up into batches - so if you get a really big set of data in a bootstrap, it can end up being applied all in one transaction. This also adds a unit test for this to make sure we don't regress.

This adds some statistics to the pending bootstrap store and more logging to help with debugging problems with large bootstraps.

Finally, the size of a bootstrap batch is configurable in the SyncConfig, but still defaults to 1MB of changeset data per batch.

## ☑️ ToDos
* [ ] 📝 Changelog update
* [x] 🚦 Tests (or not relevant)
* [ ] C-API, if public C++ API changed.
