### PR TITLE
use a null pointer rather than empty string for error case in App::call_function callback

### DIFF
--- a/src/realm/object-store/c_api/app.cpp
+++ b/src/realm/object-store/c_api/app.cpp
@@ -695,13 +695,13 @@ RLM_API bool realm_app_call_function(const realm_app_t* app, const realm_user_t*
 {
     return wrap_err([&] {
         auto cb = [callback, userdata = SharedUserdata{userdata, FreeUserdata(userdata_free)}](
-                      const std::string& reply, util::Optional<AppError> error) {
+                      const std::string* reply, util::Optional<AppError> error) {
             if (error) {
                 realm_app_error_t c_error(to_capi(*error));
                 callback(userdata.get(), nullptr, &c_error);
             }
             else {
-                callback(userdata.get(), reply.c_str(), nullptr);
+                callback(userdata.get(), reply->c_str(), nullptr);
             }
         };
         (*app)->call_function(*user, function_name, serialized_ejson_payload, /*service_name=*/std::nullopt,

--- a/src/realm/object-store/sync/app.hpp
+++ b/src/realm/object-store/sync/app.hpp
@@ -304,7 +304,7 @@ public:
 
     void call_function(const std::shared_ptr<SyncUser>& user, const std::string& name, std::string_view args_ejson,
                        const util::Optional<std::string>& service_name,
-                       util::UniqueFunction<void(const std::string&, util::Optional<AppError>)>&& completion) final;
+                       util::UniqueFunction<void(const std::string*, util::Optional<AppError>)>&& completion) final;
 
     void call_function(
         const std::shared_ptr<SyncUser>& user, const std::string& name, const bson::BsonArray& args_bson,

--- a/src/realm/object-store/sync/app_service_client.hpp
+++ b/src/realm/object-store/sync/app_service_client.hpp
@@ -42,11 +42,13 @@ public:
     /// @param args_ejson The arguments array to be provided to the function encoded as an ejson string.
     /// @param service_name The name of the service, this is optional.
     /// @param completion Returns the result from the intended call, will return an Optional AppError is an
-    /// error is thrown and ejson-encoded reply if successful
+    ///        error is thrown and ejson-encoded reply if successful. The reply string will be a null pointer only in
+    ///        the case of error. Using a string* rather than optional<string> to avoid copying a potentially large
+    ///        string.
     virtual void
     call_function(const std::shared_ptr<SyncUser>& user, const std::string& name, std::string_view args_ejson,
                   const util::Optional<std::string>& service_name,
-                  util::UniqueFunction<void(const std::string&, util::Optional<AppError>)>&& completion) = 0;
+                  util::UniqueFunction<void(const std::string*, util::Optional<AppError>)>&& completion) = 0;
 
     /// Calls the Realm Cloud function with the provided name and arguments.
     /// @param user The sync user to perform this request.


### PR DESCRIPTION
This makes it easier to bind to since you can use normal nullable pointer logic, rather than needing a special case for empty string.

Follow-up to #5984.

## What, How & Why?
<!-- Describe the changes and give some hints to guide your reviewers if possible. -->
<!-- Link to relevant issue this fixes -->

## ☑️ ToDos
* ~~[ ] 📝 Changelog update~~ Modification of something not yet released, or consumed by any SDK
* ~~[ ] 🚦 Tests (or not relevant)~~
* ~~[ ] C-API, if public C++ API changed.~~
