### PR TITLE
Do not revert to full sync barrier for exFat, in order to avoid deadlocks

### DIFF
--- a/evergreen/config.yml
+++ b/evergreen/config.yml
@@ -950,6 +950,7 @@ buildvariants:
     run_with_encryption: On
   tasks:
   - name: core_tests_group
+  - name: test-on-exfat
 
 - name: macos-release
   display_name: "MacOS 11.0 x86_64 (Release build)"

--- a/evergreen/config.yml
+++ b/evergreen/config.yml
@@ -933,7 +933,6 @@ buildvariants:
   tasks:
   - name: compile_test
   - name: swift-build-and-test
-  - name: test-on-exfat
 
 - name: macos-encrypted
   display_name: "MacOS 11.0 x86_64 (Encryption enabled)"
@@ -950,7 +949,6 @@ buildvariants:
     run_with_encryption: On
   tasks:
   - name: core_tests_group
-  - name: test-on-exfat
 
 - name: macos-release
   display_name: "MacOS 11.0 x86_64 (Release build)"

--- a/evergreen/config.yml
+++ b/evergreen/config.yml
@@ -933,6 +933,7 @@ buildvariants:
   tasks:
   - name: compile_test
   - name: swift-build-and-test
+  - name: test-on-exfat
 
 - name: macos-encrypted
   display_name: "MacOS 11.0 x86_64 (Encryption enabled)"

--- a/src/realm/util/file.cpp
+++ b/src/realm/util/file.cpp
@@ -1044,8 +1044,9 @@ void File::barrier()
 #if REALM_PLATFORM_APPLE
     if (::fcntl(m_fd, F_BARRIERFSYNC) == 0)
         return;
-        // If fcntl fails, we fallback to full sync.
-        // This is known to occur on exFAT which does not support F_BARRIERSYNC.
+        // If F_BARRIERSYNC is not suppported (this is known on exFAT) we don't fallback to sync().
+        // This is not longer needed becasue msync already guarantees that the pages are going to be
+        // flushed on disk.
 #endif
 }
 

--- a/src/realm/util/file.cpp
+++ b/src/realm/util/file.cpp
@@ -1047,7 +1047,7 @@ void File::barrier()
         // If fcntl fails, we fallback to full sync.
         // This is known to occur on exFAT which does not support F_BARRIERSYNC.
 #endif
-    sync();
+    // sync();
 }
 
 #ifndef _WIN32

--- a/src/realm/util/file.cpp
+++ b/src/realm/util/file.cpp
@@ -1047,6 +1047,8 @@ void File::barrier()
         // If F_BARRIERSYNC is not suppported (this is known on exFAT) we don't fallback to sync().
         // This is not longer needed becasue msync already guarantees that the pages are going to be
         // flushed on disk.
+#else
+    sync();
 #endif
 }
 

--- a/src/realm/util/file.cpp
+++ b/src/realm/util/file.cpp
@@ -1042,11 +1042,10 @@ void File::sync()
 void File::barrier()
 {
 #if REALM_PLATFORM_APPLE
-    if (::fcntl(m_fd, F_BARRIERFSYNC) == 0)
-        return;
-        // If F_BARRIERSYNC is not suppported (this is known on exFAT) we don't fallback to sync().
-        // This is not longer needed becasue msync already guarantees that the pages are going to be
-        // flushed on disk.
+    // If F_BARRIERSYNC is not suppported (this is known on exFAT) we don't fallback to sync().
+    // This is not longer needed becasue msync already guarantees that the pages are going to be
+    // flushed on disk.
+    ::fcntl(m_fd, F_BARRIERFSYNC);
 #else
     sync();
 #endif

--- a/src/realm/util/file.cpp
+++ b/src/realm/util/file.cpp
@@ -1047,7 +1047,6 @@ void File::barrier()
         // If fcntl fails, we fallback to full sync.
         // This is known to occur on exFAT which does not support F_BARRIERSYNC.
 #endif
-    // sync();
 }
 
 #ifndef _WIN32


### PR DESCRIPTION
## What, How & Why?
Avoid to call explicit full sync barrier if F_BARRIERSYNC is not available (exFat filesystems). Since `msync` should be already enough. 
On exFAT, a full barrier is actually introducing a deadlock and stalling the sync threads, while one thread is writing and falling back to a full barrier the other is actually syncing dirty pages. 
I removed the barrier and ran the sync tests without it on exFAT, and all of them passed.


```
thread #3
[2022/11/10 10:48:51.778]     frame #0: 0x00007fff2047cc8e libsystem_kernel.dylib`__fcntl + 10
[2022/11/10 10:48:51.778]     frame #1: 0x00007fff2047cc47 libsystem_kernel.dylib`fcntl + 170
[2022/11/10 10:48:51.778]     frame #2: 0x000000010f49826f realm-sync-tests`realm::util::File::sync() + 31
[2022/11/10 10:48:51.778]     frame #3: 0x000000010f340071 realm-sync-tests`realm::GroupWriter::commit(unsigned long) 
+ 353

thread #4, name = '-worker'
[2022/11/10 10:48:51.779]     frame #0: 0x00007fff2047c2e6 libsystem_kernel.dylib`semaphore_wait_trap + 10
[2022/11/10 10:48:51.779]     frame #1: 0x00007fff20307c9b libdispatch.dylib`_dispatch_sema4_wait + 16
[2022/11/10 10:48:51.779]     frame #2: 0x00007fff2030816d libdispatch.dylib`_dispatch_semaphore_wait_slow + 98
[2022/11/10 10:48:51.779]     frame #3: 0x000000010f31e2fd realm-sync-tests`realm::DB::do_begin_write() + 61
[2022/11/10 10:48:51.779]     frame #4: 0x000000010f31c544 realm-sync-tests`realm::DB::start_write(bool) + 116

[2022/11/10 10:48:51.779]   thread #6
[2022/11/10 10:48:51.779]     frame #0: 0x00007fff20480ee6 libsystem_kernel.dylib`__msync + 10
[2022/11/10 10:48:51.779]     frame #1: 0x000000010f49ce20 realm-sync-tests`realm::util::msync(int, void*, unsigned long) + 176
[2022/11/10 10:48:51.779]     frame #2: 0x000000010f340053 realm-sync-tests`realm::GroupWriter::commit(unsigned long) 
```

