### PR TITLE
Fix failing "app destroyed during token refresh" test

### DIFF
--- a/test/object-store/sync/app.cpp
+++ b/test/object-store/sync/app.cpp
@@ -4432,8 +4432,8 @@ TEST_CASE("app: app destroyed during token refresh", "[sync][app]") {
         config.sync_config->error_handler = [](std::shared_ptr<SyncSession> session, SyncError error) mutable {
             // Ignore websocket errors, since there's not really an app out there...
             if (error.message.find("Bad WebSocket")) {
-                util::format(std::cerr, "An expected possible WebSocket error was caught: '%1' for '%2'", error.message,
-                             session->path());
+                util::format(std::cerr, "An expected possible WebSocket error was caught: '%1' for '%2'",
+                             error.message, session->path());
             }
             else {
                 util::format(std::cerr,

--- a/test/object-store/sync/app.cpp
+++ b/test/object-store/sync/app.cpp
@@ -4428,6 +4428,20 @@ TEST_CASE("app: app destroyed during token refresh", "[sync][app]") {
         CHECK(cur_user);
 
         SyncTestFile config(app->current_user(), bson::Bson("foo"));
+        // Ignore websocket errors, since sometimes a websocket connection gets started during the test
+        config.sync_config->error_handler = [](std::shared_ptr<SyncSession> session, SyncError error) mutable {
+            // Ignore websocket errors, since there's not really an app out there...
+            if (error.message.find("Bad WebSocket")) {
+                util::format(std::cerr, "An expected possible WebSocket error was caught: '%1' for '%2'", error.message,
+                             session->path());
+            }
+            else {
+                util::format(std::cerr,
+                             "An unexpected sync error was caught by the default SyncTestFile handler: '%1' for '%2'",
+                             error.message, session->path());
+                abort();
+            }
+        };
         auto r = Realm::get_shared_realm(config);
         auto session = r->sync_session();
         mock_transport_worker.add_work_item([session] {

--- a/test/object-store/sync/app.cpp
+++ b/test/object-store/sync/app.cpp
@@ -4431,13 +4431,16 @@ TEST_CASE("app: app destroyed during token refresh", "[sync][app]") {
         // Ignore websocket errors, since sometimes a websocket connection gets started during the test
         config.sync_config->error_handler = [](std::shared_ptr<SyncSession> session, SyncError error) mutable {
             // Ignore websocket errors, since there's not really an app out there...
-            if (error.message.find("Bad WebSocket")) {
-                util::format(std::cerr, "An expected possible WebSocket error was caught: '%1' for '%2'",
+            if (error.message.find("Bad WebSocket") != std::string::npos) {
+                util::format(std::cerr,
+                             "An expected possible WebSocket error was caught during test: 'app destroyed during "
+                             "token refresh': '%1' for '%2'",
                              error.message, session->path());
             }
             else {
                 util::format(std::cerr,
-                             "An unexpected sync error was caught by the default SyncTestFile handler: '%1' for '%2'",
+                             "An unexpected sync error was caught during test: 'app destroyed during token refresh': "
+                             "'%1' for '%2'",
                              error.message, session->path());
                 abort();
             }


### PR DESCRIPTION
## What, How & Why?
Since an app is not being created on the server for the "app: app destroyed during token refresh" test, the websocket connection would occasionally receive a 404 response while attempting to connect, which causes the test to fail. The test quickly creates a session, requests token refresh and then closes the session, but sometimes, the websocket attempts to connect to a "fake app" on the server, which returns a 404 (not found) response back to the client.

This fix adds a custom error_handler to this test to ignore websocket errors while still printing and aborting the test when other errors are received.

Fixes #6013 

## ☑️ ToDos
* [ ] ~~📝 Changelog update~~
* [X] 🚦 Tests (or not relevant)
* [ ] ~~C-API, if public C++ API changed.~~
