### PR TITLE
Turn methods into no-op if the user logged out

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,6 +34,7 @@
 * Fix `Results.distinct(keypaths)` and `Results.sort(keypaths)` not correctly handling keypaths names for properties that have a public/private(column) property name ([PR #5952](https://github.com/realm/realm-core/pull/5952).
 * Bootstraps will not be applied in a single write transaction - they will be applied 1MB of changesets at a time, or as configured by the SDK ([#5999](https://github.com/realm/realm-core/pull/5999), since v12.0.0).
 * Fix database corruption and encryption issues on apple platforms, reported in several bugs listed in the PR. ([PR #5993](https://github.com/realm/realm-core/pull/5993), since v11.8.0)
+* Fetching a user's profile while the user logs out would result in an assertion failure. ([PR #6017](https://github.com/realm/realm-core/issues/5571), since v11.0.3)
 
 ### Breaking changes
 * None.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@
 
 ### Fixed
 * <How do the end-user experience this issue? what was the impact?> ([#????](https://github.com/realm/realm-core/issues/????), since v?.?.?)
-* None.
+* Fetching a user's profile while the user logs out would result in an assertion failure. ([PR #6017](https://github.com/realm/realm-core/issues/5571), since v11.0.3)
  
 ### Breaking changes
 * None.
@@ -34,7 +34,6 @@
 * Fix `Results.distinct(keypaths)` and `Results.sort(keypaths)` not correctly handling keypaths names for properties that have a public/private(column) property name ([PR #5952](https://github.com/realm/realm-core/pull/5952).
 * Bootstraps will not be applied in a single write transaction - they will be applied 1MB of changesets at a time, or as configured by the SDK ([#5999](https://github.com/realm/realm-core/pull/5999), since v12.0.0).
 * Fix database corruption and encryption issues on apple platforms, reported in several bugs listed in the PR. ([PR #5993](https://github.com/realm/realm-core/pull/5993), since v11.8.0)
-* Fetching a user's profile while the user logs out would result in an assertion failure. ([PR #6017](https://github.com/realm/realm-core/issues/5571), since v11.0.3)
 
 ### Breaking changes
 * None.

--- a/src/realm/object-store/sync/sync_user.cpp
+++ b/src/realm/object-store/sync/sync_user.cpp
@@ -305,7 +305,10 @@ std::vector<SyncUserIdentity> SyncUser::identities() const
 void SyncUser::update_identities(std::vector<SyncUserIdentity> identities)
 {
     util::CheckedLockGuard lock(m_mutex);
-    REALM_ASSERT(m_state == SyncUser::State::LoggedIn);
+    if (m_state != SyncUser::State::LoggedIn) {
+        return;
+    }
+
     m_user_identities = identities;
 
     m_sync_manager->perform_metadata_update([&](const auto& manager) {
@@ -436,7 +439,9 @@ util::Optional<bson::BsonDocument> SyncUser::custom_data() const
 void SyncUser::update_user_profile(const SyncUserProfile& profile)
 {
     util::CheckedLockGuard lock(m_mutex);
-    REALM_ASSERT(m_state == SyncUser::State::LoggedIn);
+    if (m_state != SyncUser::State::LoggedIn) {
+        return;
+    }
 
     m_user_profile = profile;
 

--- a/test/object-store/sync/app.cpp
+++ b/test/object-store/sync/app.cpp
@@ -4793,7 +4793,7 @@ TEST_CASE("app: user logs out while profile is fetched", "[sync][app]") {
                    });
 
     auto cur_user = std::move(cur_user_future).get();
-    CHECK(state.state == TestState::profile);
+    CHECK(state.get() == TestState::profile);
     CHECK(cur_user);
     CHECK(cur_user == logged_in_user);
 

--- a/test/object-store/sync/app.cpp
+++ b/test/object-store/sync/app.cpp
@@ -659,7 +659,7 @@ TEST_CASE("app: link_user integration", "[sync][app]") {
     TestAppSession session;
     auto app = session.app();
 
-    SECTION("link_user intergration") {
+    SECTION("link_user integration") {
         AutoVerifiedEmailCredentials creds;
         bool processed = false;
         std::shared_ptr<SyncUser> sync_user;
@@ -4702,3 +4702,100 @@ TEST_CASE("app: app cannot get deallocated during log in", "[sync][app]") {
     mock_transport_worker.mark_complete();
 }
 #endif
+
+TEST_CASE("app: user logs our while profile is fetched", "[sync][app]") {
+    AsyncMockNetworkTransport mock_transport_worker;
+    enum class TestState { unknown, location, login, profile };
+    struct TestStateBundle {
+        void advance_to(TestState new_state)
+        {
+            std::lock_guard<std::mutex> lk(mutex);
+            state = new_state;
+            cond.notify_one();
+        }
+
+        TestState get() const
+        {
+            std::lock_guard<std::mutex> lk(mutex);
+            return state;
+        }
+
+        void wait_for(TestState new_state)
+        {
+            std::unique_lock<std::mutex> lk(mutex);
+            cond.wait(lk, [&] {
+                return state == new_state;
+            });
+        }
+
+        mutable std::mutex mutex;
+        std::condition_variable cond;
+
+        TestState state = TestState::unknown;
+    } state;
+    struct transport : public GenericNetworkTransport {
+        transport(AsyncMockNetworkTransport& worker, TestStateBundle& state,
+                  std::shared_ptr<SyncUser>& logged_in_user)
+            : mock_transport_worker(worker)
+            , state(state)
+            , logged_in_user(logged_in_user)
+        {
+        }
+
+        void send_request_to_server(const Request& request,
+                                    util::UniqueFunction<void(const Response&)>&& completion) override
+        {
+            if (request.url.find("/login") != std::string::npos) {
+                state.advance_to(TestState::login);
+                mock_transport_worker.add_work_item(
+                    Response{200, 0, {}, user_json(encode_fake_jwt("access token")).dump()}, std::move(completion));
+            }
+            else if (request.url.find("/profile") != std::string::npos) {
+                logged_in_user->log_out();
+                state.advance_to(TestState::profile);
+                mock_transport_worker.add_work_item(Response{200, 0, {}, user_profile_json().dump()},
+                                                    std::move(completion));
+            }
+            else if (request.url.find("/location") != std::string::npos) {
+                CHECK(request.method == HttpMethod::get);
+                state.advance_to(TestState::location);
+                mock_transport_worker.add_work_item(
+                    Response{200,
+                             0,
+                             {},
+                             "{\"deployment_model\":\"GLOBAL\",\"location\":\"US-VA\",\"hostname\":"
+                             "\"http://localhost:9090\",\"ws_hostname\":\"ws://localhost:9090\"}"},
+                    std::move(completion));
+            }
+        }
+
+        AsyncMockNetworkTransport& mock_transport_worker;
+        TestStateBundle& state;
+        std::shared_ptr<SyncUser>& logged_in_user;
+    };
+
+    std::shared_ptr<SyncUser> logged_in_user;
+    auto transporter = std::make_shared<transport>(mock_transport_worker, state, logged_in_user);
+
+    TestSyncManager sync_manager(get_config(transporter));
+    auto app = sync_manager.app();
+
+    logged_in_user = app->sync_manager()->get_user(UnitTestTransport::user_id, good_access_token, good_access_token,
+                                                   "anon-user", dummy_device_id);
+    auto custom_credentials = AppCredentials::facebook("a_token");
+    auto [cur_user_promise, cur_user_future] = util::make_promise_future<std::shared_ptr<SyncUser>>();
+
+    app->link_user(logged_in_user, custom_credentials,
+                   [promise = std::move(cur_user_promise)](std::shared_ptr<SyncUser> user,
+                                                           util::Optional<AppError> error) mutable {
+                       REQUIRE_FALSE(error);
+                       promise.emplace_value(std::move(user));
+                   });
+
+    state.wait_for(TestState::profile);
+    auto cur_user = std::move(cur_user_future).get();
+    CHECK(cur_user);
+    CHECK(cur_user == logged_in_user);
+
+    mock_transport_worker.mark_complete();
+}

--- a/test/object-store/sync/app.cpp
+++ b/test/object-store/sync/app.cpp
@@ -4703,7 +4703,7 @@ TEST_CASE("app: app cannot get deallocated during log in", "[sync][app]") {
 }
 #endif
 
-TEST_CASE("app: user logs our while profile is fetched", "[sync][app]") {
+TEST_CASE("app: user logs out while profile is fetched", "[sync][app]") {
     AsyncMockNetworkTransport mock_transport_worker;
     enum class TestState { unknown, location, login, profile };
     struct TestStateBundle {
@@ -4792,8 +4792,8 @@ TEST_CASE("app: user logs our while profile is fetched", "[sync][app]") {
                        promise.emplace_value(std::move(user));
                    });
 
-    state.wait_for(TestState::profile);
     auto cur_user = std::move(cur_user_future).get();
+    CHECK(state.state == TestState::profile);
     CHECK(cur_user);
     CHECK(cur_user == logged_in_user);
 


### PR DESCRIPTION
## What, How & Why?
It was possible that while the profile of a user was fetched from the server, the user logged out causing an assertion crash.
This PR addressed that by making some methods a no-op if the user is not logged in anymore.

Fixes #5571.

## ☑️ ToDos
* [x] 📝 Changelog update
* [x] 🚦 Tests (or not relevant)
* [ ] ~~C-API, if public C++ API changed.~~
