### PR TITLE
Experimenting with  barrier which proved to be killing our performance

### DIFF
--- a/src/realm/group_writer.cpp
+++ b/src/realm/group_writer.cpp
@@ -928,7 +928,6 @@ void GroupWriter::commit(ref_type new_top_ref)
     flush_all_mappings();
     if (!disable_sync) {
         sync_all_mappings();
-        m_alloc.get_file().barrier();
     }
     // Flip the slot selector bit.
     using type_2 = std::remove_reference<decltype(file_header.m_flags)>::type;
@@ -939,7 +938,6 @@ void GroupWriter::commit(ref_type new_top_ref)
     window->flush();
     if (!disable_sync) {
         window->sync();
-        m_alloc.get_file().barrier();
     }
 }
 


### PR DESCRIPTION
## What, How & Why?
The barrier is killing our performance while writing. `Msync` seems enough and guarantees the database consistency. 
However, I don't have a new device to use for testing this. The barrier might be needed on other version of IOS.
But most probably, we have been really conservative.  `Msync` guarantees that the page is flushed to disk. 

```
Core 12.12 without barrier.
Req runs: 1000  AddTable (Full   , EncryptionOff):           
min     86us     max    415us     median    146us     avg    151us     stddev     41us
Req runs: 1000  AddTable (Full   , EncryptionOn):            
min    187us     max    544us     median    239us     avg    252us     stddev     40us
Req runs: 1000  AddTable (MemOnly, EncryptionOff):           
min     57us     max    293us     median    112us    avg    108us     stddev     30us

Core 12.12 with barrier.
Req runs: 1000  AddTable (Full   , EncryptionOff):  
min    614us     max 120.43ms     median   3.31ms     avg   3.36ms     stddev   5.05ms
Req runs: 1000  AddTable (Full   , EncryptionOn):            
min    926us     max 116.36ms     median      4ms     avg   3.94ms     stddev   3.64ms
Req runs: 1000  AddTable (MemOnly, EncryptionOff):           
min     57us     max    289us     median    111us     avg    108us     stddev     29us

Core 12.11
Req runs: 1000  AddTable (Full   , EncryptionOff):           
min    475us     max   6.80ms     median   1.53ms   avg   1.56ms     stddev    416us
Req runs: 1000  AddTable (Full   , EncryptionOn):            
min    401us     max     54ms     median   1.83ms     avg   1.81ms     stddev   1.87ms
Req runs: 1000  AddTable (MemOnly, EncryptionOff):           
min     21us     max    129us     median     22us     avg     23us     stddev      8us
```

There still is a problem for in memory realms, which seems to be related to all the `flushes()` we do, which are basically no op, but the amount of calls we make seems to be the root cause of the slow-down. 

## ☑️ ToDos
* [ ] 📝 Changelog update
* [ ] 🚦 Tests (or not relevant)
* [ ] C-API, if public C++ API changed.
