### PR TITLE
Add realm_list_move to c-api

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,7 @@
 * App::call_function now supports taking and receiving ejson strings, bypassing parsing/serialization in core. ([#4182](https://github.com/realm/realm-core/issues/4182))
 * Flexible sync will now wait for the server to have sent all pending history after a bootstrap before marking a subscription as Complete. ([#5795](https://github.com/realm/realm-core/pull/5795))
 * Add typedef for realm_app_call_function callbacks. ([#5996](https://github.com/realm/realm-core/pull/5996))
+* Expose List::move on C api as realm_list_move. ([#6032](https://github.com/realm/realm-core/pull/6032))
 
 ### Fixed
 * Fix a race condition which could result in "operation cancelled" errors being delivered to async open callbacks rather than the actual sync error which caused things to fail ([PR #5968](https://github.com/realm/realm-core/pull/5968), since the introduction of async open).

--- a/src/realm.h
+++ b/src/realm.h
@@ -1746,6 +1746,15 @@ RLM_API bool realm_list_set(realm_list_t*, size_t index, realm_value_t value);
 RLM_API bool realm_list_insert(realm_list_t*, size_t index, realm_value_t value);
 
 /**
+ * Move the element at @a from_index to @a to_index.
+ *
+ * @param from_index The index of the element to move.
+ * @param to_index The index to move the element to.
+ * @return True if no exception occurred.
+ */
+RLM_API bool realm_list_move(realm_list_t*, size_t from_index, size_t to_index);
+
+/**
  * Insert an embedded object at a given position.
  *
  * @return A non-NULL pointer if the object was created successfully.

--- a/src/realm/object-store/c_api/list.cpp
+++ b/src/realm/object-store/c_api/list.cpp
@@ -83,6 +83,15 @@ RLM_API bool realm_list_insert(realm_list_t* list, size_t index, realm_value_t v
     });
 }
 
+RLM_API bool realm_list_move(realm_list_t* list, size_t from_index, size_t to_index)
+{
+    return wrap_err([&]() {
+        list->move(from_index, to_index);
+        return true;
+    });
+}
+
+
 RLM_API bool realm_list_set(realm_list_t* list, size_t index, realm_value_t value)
 {
     return wrap_err([&]() {

--- a/test/object-store/c_api/c_api.cpp
+++ b/test/object-store/c_api/c_api.cpp
@@ -2804,6 +2804,42 @@ TEST_CASE("C API", "[c_api]") {
                 CHECK(rlm_val_eq(value, null));
             }
 
+            SECTION("move") {
+                auto int_list = cptr_checked(realm_get_list(obj1.get(), foo_properties["int_list"]));
+                write([&]() {
+                    for (int i = 0; i < 10; ++i) {
+                        CHECK(realm_list_insert(int_list.get(), i, rlm_int_val(i)));
+                    }
+                });
+
+                realm_value_t value;
+                auto expected = std::vector<int64_t>{0, 1, 2, 3, 4, 5, 6, 7, 8, 9};
+                for (int i = 0; i < 10; ++i) {
+                    CHECK(realm_list_get(int_list.get(), i, &value));
+                    CHECK(rlm_val_eq(value, rlm_int_val(expected[i])));
+                }
+
+                write([&]() {
+                    CHECK(realm_list_move(int_list.get(), 0, 1));
+                });
+
+                expected = std::vector<int64_t>{1, 0, 2, 3, 4, 5, 6, 7, 8, 9};
+                for (int i = 0; i < 10; ++i) {
+                    CHECK(realm_list_get(int_list.get(), i, &value));
+                    CHECK(rlm_val_eq(value, rlm_int_val(expected[i])));
+                }
+
+                write([&]() {
+                    CHECK(realm_list_move(int_list.get(), 3, 2));
+                });
+
+                expected = std::vector<int64_t>{1, 0, 3, 2, 4, 5, 6, 7, 8, 9};
+                for (int i = 0; i < 10; ++i) {
+                    CHECK(realm_list_get(int_list.get(), i, &value));
+                    CHECK(rlm_val_eq(value, rlm_int_val(expected[i])));
+                }
+            }
+
             SECTION("links") {
                 CPtr<realm_list_t> bars;
 


### PR DESCRIPTION
## What, How & Why?
This expose `List::move` on the C-Api. Needed for https://github.com/realm/realm-dart/issues/794

## ☑️ ToDos
* [x] 📝 Changelog update
* [x] 🚦 Tests (or not relevant)
* [x] C-API, if public C++ API changed.
