### PR TITLE
RealmEnumerate tool

### DIFF
--- a/src/realm/exec/CMakeLists.txt
+++ b/src/realm/exec/CMakeLists.txt
@@ -22,6 +22,13 @@ set_target_properties(RealmTrawler PROPERTIES
 )
 target_link_libraries(RealmTrawler Storage)
 
+add_executable(RealmEnumerate EXCLUDE_FROM_ALL realm_enumerate.cpp )
+set_target_properties(RealmEnumerate PROPERTIES
+    OUTPUT_NAME "realm-enumerate"
+    DEBUG_POSTFIX ${CMAKE_DEBUG_POSTFIX}
+)
+target_link_libraries(RealmEnumerate ObjectStore)
+
 add_executable(RealmDecrypt EXCLUDE_FROM_ALL realm_decrypt.cpp )
 set_target_properties(RealmDecrypt PROPERTIES
     OUTPUT_NAME "realm-decrypt"

--- a/src/realm/exec/realm_enumerate.cpp
+++ b/src/realm/exec/realm_enumerate.cpp
@@ -8,6 +8,7 @@
 #include <realm/history.hpp>
 #include <realm/object-store/shared_realm.hpp>
 #include <realm/sort_descriptor.hpp>
+#include <realm/table_view.hpp>
 #include <realm/transaction.hpp>
 
 #include <fstream>
@@ -40,10 +41,10 @@ static void enumerate_strings(realm::SharedRealm realm, double threshold)
                     std::unique_ptr<realm::DescriptorOrdering> distinct =
                         std::make_unique<realm::DescriptorOrdering>();
                     distinct->append_distinct(realm::DistinctDescriptor({{col_key}}));
-                    size_t uniques = t->where().set_ordering(std::move(distinct)).count();
+                    size_t uniques = t->where().count(*distinct.get());
                     size_t num_compressible = table_size - uniques;
-                    double utilization = num_compressible / table_size;
-                    realm::util::format(std::cout, "contains %1 unique values (%2%%) ", uniques, utilization * 100);
+                    double utilization = num_compressible / double(table_size);
+                    realm::util::format(std::cout, "contains %1 unique values (%2%%) ", uniques, utilization * 100.0);
                     if (utilization >= threshold / 100) {
                         std::cout << "[converting]\n";
                         t->enumerate_string_column(col_key);
@@ -104,6 +105,7 @@ int main(int argc, const char* argv[])
                     enumerate_strings(realm, threshold);
                     realm->compact();
                     std::cout << std::endl;
+                    return 0;
                 }
             }
         }

--- a/src/realm/exec/realm_enumerate.cpp
+++ b/src/realm/exec/realm_enumerate.cpp
@@ -1,0 +1,114 @@
+/*
+ * Useage: realm-enumerate [--key crypt_key] [--threshold 0.xx] <realm-file-name>
+ * Changes string columns which pass the threshold of unique values to enumerated columns
+ * and compacts the Realm in place.
+ */
+
+#include <realm/db.hpp>
+#include <realm/history.hpp>
+#include <realm/object-store/shared_realm.hpp>
+#include <realm/transaction.hpp>
+
+#include <fstream>
+#include <iostream>
+
+static void enumerate_strings(realm::SharedRealm realm, double threshold)
+{
+    realm->begin_transaction();
+    auto& group = realm->read_group();
+    auto table_keys = group.get_table_keys();
+    for (auto table_key : table_keys) {
+        realm::TableRef t = group.get_table(table_key);
+        size_t table_size = t->size();
+        realm::util::format(std::cout, "Begin table '%1' of size %2:\n", t->get_name(), table_size);
+        if (table_size == 0)
+            continue;
+        bool found_str_col = false;
+        t->for_each_public_column([&](realm::ColKey col_key) {
+            if (col_key.get_type() == realm::col_type_String) {
+                found_str_col = true;
+                realm::util::format(std::cout, "\tcolumn '%1' contains: ", t->get_column_name(col_key));
+                size_t uniques = t->get_num_unique_values(col_key);
+                size_t num_compressible = table_size - uniques;
+                double utilization = num_compressible / table_size;
+                realm::util::format(std::cout, "%1 unique values (%2%%) ", uniques, utilization * 100);
+                if (t->is_enumerated(col_key)) {
+                    std::cout << "[already enumerated]\n";
+                }
+                else if (utilization >= threshold / 100) {
+                    std::cout << "[converting]\n";
+                    t->enumerate_string_column(col_key);
+                }
+                else {
+                    std::cout << "[skipping due to threshold]\n";
+                }
+            }
+            return realm::IteratorControl::AdvanceToNext;
+        });
+        if (!found_str_col) {
+            std::cout << "\tNo string columns found.\n";
+        }
+    }
+    realm->commit_transaction();
+}
+
+int main(int argc, const char* argv[])
+{
+    if (argc > 1) {
+        try {
+            const char* key_ptr = nullptr;
+            char key[64];
+            double threshold = 101; // by default don't convert, just compact
+            for (int curr_arg = 1; curr_arg < argc; curr_arg++) {
+                if (strcmp(argv[curr_arg], "--key") == 0) {
+                    std::ifstream key_file(argv[curr_arg + 1]);
+                    key_file.read(key, sizeof(key));
+                    key_ptr = key;
+                    curr_arg++;
+                }
+                else if (strcmp(argv[curr_arg], "--threshold") == 0) {
+                    threshold = strtod(argv[curr_arg + 1], nullptr);
+                    curr_arg++;
+                }
+                else {
+                    realm::util::format(std::cout, "File name '%1' for threshold '%2'%%\n", argv[curr_arg],
+                                        threshold);
+
+                    realm::Realm::Config config;
+                    config.path = argv[curr_arg];
+                    if (key_ptr) {
+                        config.encryption_key.resize(64);
+                        memcpy(&config.encryption_key[0], &key_ptr[0], 64);
+                    }
+                    realm::SharedRealm realm;
+                    try {
+                        realm = realm::Realm::get_shared_realm(config);
+                    }
+                    catch (const realm::RealmFileException& e) {
+                        std::cout << "trying to open as a sync Realm\n" << std::endl;
+                        config.force_sync_history = true;
+                        realm = realm::Realm::get_shared_realm(config);
+                    }
+                    enumerate_strings(realm, threshold);
+                    realm->compact();
+                    std::cout << std::endl;
+                }
+            }
+        }
+        catch (const std::exception& e) {
+            std::cout << e.what() << std::endl;
+        }
+    }
+    else {
+        std::cout << "Usage: realm-enumerate [--key crypt_key] [--threshold 0.xx] <realmfile>" << std::endl;
+        std::cout << "The optional crypt_key arg is a filename which contains the 64 byte key." << std::endl;
+        std::cout
+            << "The optional threshold is a number between [0, 100] indicating the percentage of duplicate strings "
+               "above which columns will be converted. At a value of 100, columns with only one unique value will be "
+               "converted. For value of 50 only columns which have more than 50% duplicate values will be converted."
+               "If not set, the threshold default is 101 which just compacts the file without converting anything."
+            << std::endl;
+    }
+
+    return 0;
+}

--- a/src/realm/exec/realm_enumerate.cpp
+++ b/src/realm/exec/realm_enumerate.cpp
@@ -16,7 +16,6 @@
 
 static void enumerate_strings(realm::SharedRealm realm, double threshold)
 {
-    realm->begin_transaction();
     auto& group = realm->read_group();
     auto table_keys = group.get_table_keys();
     for (auto table_key : table_keys) {
@@ -26,44 +25,54 @@ static void enumerate_strings(realm::SharedRealm realm, double threshold)
         if (table_size == 0)
             continue;
         bool found_str_col = false;
+        auto do_convert = [&realm, &t](realm::ColKey col) {
+            auto start = std::chrono::steady_clock::now();
+            std::cout << "[converting]" << std::flush;
+            realm->begin_transaction();
+            t->enumerate_string_column(col);
+            realm->commit_transaction();
+            std::chrono::duration<double> diff = std::chrono::steady_clock::now() - start;
+            std::cout << " (" << diff.count() << " seconds)" << std::endl;
+        };
         t->for_each_public_column([&](realm::ColKey col_key) {
             if (col_key.get_type() == realm::col_type_String && !col_key.is_collection()) {
                 found_str_col = true;
                 realm::util::format(std::cout, "\tcolumn '%1' ", t->get_column_name(col_key));
+                std::cout << std::flush;
                 if (t->is_enumerated(col_key)) {
-                    std::cout << "[already enumerated]\n";
+                    std::cout << "[already enumerated]" << std::endl;
                 }
-                else if (threshold <= 0) {
-                    std::cout << "[converting]\n";
-                    t->enumerate_string_column(col_key);
+                else if (t->get_primary_key_column() == col_key) {
+                    std::cout << "[pk - skipping]" << std::endl;
                 }
-                else if (threshold <= 100) {
+                else if (threshold >= 100) {
+                    do_convert(col_key);
+                }
+                else if (threshold < 100 && threshold > 0) {
                     std::unique_ptr<realm::DescriptorOrdering> distinct =
                         std::make_unique<realm::DescriptorOrdering>();
                     distinct->append_distinct(realm::DistinctDescriptor({{col_key}}));
                     size_t uniques = t->where().count(*distinct.get());
-                    size_t num_compressible = table_size - uniques;
-                    double utilization = num_compressible / double(table_size);
+                    double utilization = uniques / double(table_size);
                     realm::util::format(std::cout, "contains %1 unique values (%2%%) ", uniques, utilization * 100.0);
-                    if (utilization >= threshold / 100) {
-                        std::cout << "[converting]\n";
-                        t->enumerate_string_column(col_key);
+                    std::cout << std::flush;
+                    if (utilization <= threshold / 100) {
+                        do_convert(col_key);
                     }
                     else {
-                        std::cout << "[skipping due to threshold]\n";
+                        std::cout << "[skipping due to threshold]" << std::endl;
                     }
                 }
                 else {
-                    std::cout << "[skipping due to threshold]\n";
+                    std::cout << "[skipping due to threshold]" << std::endl;
                 }
             }
             return realm::IteratorControl::AdvanceToNext;
         });
         if (!found_str_col) {
-            std::cout << "\tNo string columns found.\n";
+            std::cout << "\tNo string columns found." << std::endl;
         }
     }
-    realm->commit_transaction();
 }
 
 int main(int argc, const char* argv[])
@@ -72,7 +81,7 @@ int main(int argc, const char* argv[])
         try {
             const char* key_ptr = nullptr;
             char key[64];
-            double threshold = 101; // by default don't convert, just compact
+            double threshold = 0; // by default don't convert, just compact
             for (int curr_arg = 1; curr_arg < argc; curr_arg++) {
                 if (strcmp(argv[curr_arg], "--key") == 0) {
                     std::ifstream key_file(argv[curr_arg + 1]);
@@ -86,7 +95,7 @@ int main(int argc, const char* argv[])
                 }
                 else {
                     realm::util::format(std::cout, "File name '%1' for threshold %2%%\n", argv[curr_arg], threshold);
-
+                    auto start = std::chrono::steady_clock::now();
                     realm::Realm::Config config;
                     config.path = argv[curr_arg];
                     if (key_ptr) {
@@ -104,6 +113,8 @@ int main(int argc, const char* argv[])
                     }
                     enumerate_strings(realm, threshold);
                     realm->compact();
+                    std::chrono::duration<double> diff = std::chrono::steady_clock::now() - start;
+                    std::cout << "Done in " << diff.count() << " seconds." << std::endl;
                     std::cout << std::endl;
                     return 0;
                 }
@@ -117,10 +128,10 @@ int main(int argc, const char* argv[])
         std::cout << "Usage: realm-enumerate [--key crypt_key] [--threshold 0.xx] <realmfile>" << std::endl;
         std::cout << "The optional crypt_key arg is a filename which contains the 64 byte key." << std::endl;
         std::cout
-            << "The optional threshold is a number between [0, 100] indicating the percentage of duplicate strings "
-               "above which columns will be converted. At a value of 100, columns with only one unique value will be "
-               "converted. For value of 50 only columns which have more than 50% duplicate values will be converted."
-               "If not set, the threshold default is 101 which just compacts the file without converting anything."
+            << "The optional threshold is a number between [0, 100] indicating the percentage of unique strings "
+               "below which columns will be converted. At a value of 100, all columns will be converted. "
+               "For value of 50 only columns which have 50% or fewer unique values will be converted."
+               "If not set, the threshold default is 0 which just compacts the file without converting anything."
             << std::endl;
     }
 

--- a/src/realm/table.cpp
+++ b/src/realm/table.cpp
@@ -964,7 +964,7 @@ void Table::enumerate_string_column(ColKey col_key)
     check_column(col_key);
     size_t column_ndx = colkey2spec_ndx(col_key);
     ColumnType type = col_key.get_type();
-    if (type == col_type_String && !m_spec.is_string_enum_type(column_ndx)) {
+    if (type == col_type_String && !col_key.is_collection() && !m_spec.is_string_enum_type(column_ndx)) {
         m_clusters.enumerate_string_column(col_key);
     }
 }


### PR DESCRIPTION
Introducing a utility to convert Realm files to use enumerated columns. This enables us to check the space savings of a Realm if it were to use the string enum type. It can also double as a compaction utility if the threshold parameter is set to 0 or less.