### PR TITLE
Fix corruption of freelist during compaction

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 ### Fixed
 * <How do the end-user experience this issue? what was the impact?> ([#????](https://github.com/realm/realm-core/issues/????), since v?.?.?)
 * Fixed wrong assertion on query error that could result in a crash. ([#6038](https://github.com/realm/realm-core/issues/6038), since v11.7.0)
+* Freelist may be corrupted if compaction was initiated ([#6054](https://github.com/realm/realm-core/pull/6054), since v13.0.0)
 
 ### Breaking changes
 * Updated `logger_factory` in SyncClientConfig to return a `shared_ptr` instead of a `unique_ptr` ([PR #5980](https://github.com/realm/realm-core/pull/5980))

--- a/test/test_compaction.cpp
+++ b/test/test_compaction.cpp
@@ -59,11 +59,11 @@ TEST(Compaction_WhileGrowing)
     for (int i = 0; i < 5000; ++i) {
         w[i] = '0' + (i % 64);
     }
-    int num = (REALM_MAX_BPNODE_SIZE == 1000) ? 1490 : 1400;
+    int num = (REALM_MAX_BPNODE_SIZE == 1000) ? 1400 : 1300;
     tr->promote_to_write();
     CHECK(db->get_evacuation_stage() == DB::EvacStage::idle);
     for (int j = 0; j < num; ++j) {
-        table1->create_object().set(col_bin1, BinaryData(w, 400));
+        table1->create_object().set(col_bin1, BinaryData(w, 450));
         table2->create_object().set(col_bin2, BinaryData(w, 200));
         if (j % 10 == 0) {
             tr->commit_and_continue_as_read();

--- a/test/test_compaction.cpp
+++ b/test/test_compaction.cpp
@@ -113,7 +113,7 @@ TEST(Compaction_WhileGrowing)
     tr->commit_and_continue_as_read();
     // Now there should be room for compaction
 
-    auto n = 20; // Ensure that test will end
+    auto n = 50; // Ensure that test will end
     do {
         tr->promote_to_write();
         tr->commit_and_continue_as_read();


### PR DESCRIPTION
## What, How & Why?
Wrong value for the size of the top array was used because values were added after the sizes were calculated. Now the decision to compact the realm is moved to a point before the sizes are calculated so that the correct top array size is used. The reason for moving the logic to the point after the calculation of the sizes was to use an updated values for the free space size - mostly in order to get a test passing, but that was obviously a wrong decision.

## ☑️ ToDos
* [x] 📝 Changelog update
* [x] 🚦 Tests (or not relevant)
* [x] C-API, if public C++ API changed.
