### PR TITLE
Make ObjectId ctor explict and take StringData rather than const char*

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@
 * None.
  
 ### Breaking changes
-* ObjectId constructor made explicit, so no more implicit conversions from const char* or array of 12 bytes. It now accepts a StringData.
+* ObjectId constructor made explicit, so no more implicit conversions from const char* or array of 12 bytes. It now accepts a StringData. ([#6059](https://github.com/realm/realm-core/pull/6059))
 
 ### Compatibility
 * Fileformat: Generates files with format v23. Reads and automatically upgrade from fileformat v5.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@
 * None.
  
 ### Breaking changes
-* None.
+* ObjectId constructor made explicit, so no more implicit conversions from const char* or array of 12 bytes. It now accepts a StringData.
 
 ### Compatibility
 * Fileformat: Generates files with format v23. Reads and automatically upgrade from fileformat v5.

--- a/src/realm/object_id.cpp
+++ b/src/realm/object_id.cpp
@@ -56,7 +56,7 @@ bool ObjectId::is_valid_str(StringData str) noexcept
            std::all_of(str.data(), str.data() + str.size(), [](unsigned char c) { return std::isxdigit(c); });
 }
 
-ObjectId::ObjectId(const char* init) noexcept
+ObjectId::ObjectId(StringData init) noexcept
 {
     char buf[3] = "";
     REALM_ASSERT(is_valid_str(init));

--- a/src/realm/object_id.hpp
+++ b/src/realm/object_id.hpp
@@ -43,12 +43,12 @@ public:
     /**
      * Constructs an ObjectId from 24 hex characters.
      */
-    ObjectId(const char* init) noexcept;
+    explicit ObjectId(StringData init) noexcept;
 
     /**
      * Constructs an ObjectID from an array of 12 unsigned bytes
      */
-    ObjectId(const ObjectIdBytes& init) noexcept;
+    explicit ObjectId(const ObjectIdBytes& init) noexcept;
 
     /**
      * Constructs an ObjectId with the specified inputs, and a random number

--- a/test/test_object_id.cpp
+++ b/test/test_object_id.cpp
@@ -20,6 +20,7 @@
 #include <realm/array_fixed_bytes.hpp>
 #include <chrono>
 
+#include "realm/object_id.hpp"
 #include "test.hpp"
 
 
@@ -63,9 +64,9 @@ TEST(ObjectId_Array)
     ArrayObjectId arr(Allocator::get_default());
     arr.create();
 
-    arr.add({str0});
-    arr.add({str1});
-    arr.insert(1, {str2});
+    arr.add(ObjectId{str0});
+    arr.add(ObjectId{str1});
+    arr.insert(1, ObjectId{str2});
 
     ObjectId id2(str2);
     CHECK_EQUAL(arr.get(0), ObjectId(str0));
@@ -97,9 +98,9 @@ TEST(ObjectId_ArrayNull)
     ArrayObjectIdNull arr(Allocator::get_default());
     arr.create();
 
-    arr.add({str0});
-    arr.add({str1});
-    arr.insert(1, {str2});
+    arr.add(ObjectId{str0});
+    arr.add(ObjectId{str1});
+    arr.insert(1, ObjectId{str2});
     ObjectId id2(str2);
     CHECK(!arr.is_null(0));
     CHECK_EQUAL(arr.get(0), ObjectId(str0));
@@ -146,10 +147,10 @@ TEST(ObjectId_ArrayNullMove)
 
     auto get_value_for_ndx = [&](size_t ndx) -> util::Optional<ObjectId> {
         if (ndx % 3 == 0) {
-            return {str0};
+            return ObjectId{str0};
         }
         else if (ndx % 3 == 1) {
-            return {str1};
+            return ObjectId{str1};
         }
         else {
             return util::none;
@@ -162,8 +163,8 @@ TEST(ObjectId_ArrayNullMove)
 
     ArrayObjectIdNull arr1(Allocator::get_default());
     arr1.create();
-    arr1.add({str0});
-    arr1.add({str1});
+    arr1.add(ObjectId{str0});
+    arr1.add(ObjectId{str1});
     arr1.add(util::none);
     arr.move(arr1, 0);
 
@@ -411,7 +412,11 @@ TEST(ObjectId_Distinct)
     DBRef db = DB::create(path);
 
     {
-        std::vector<ObjectId> ids{"000004560000000000170232", "000004560000000000170233", "000004550000000000170232"};
+        std::vector<ObjectId> ids{
+            ObjectId("000004560000000000170232"),
+            ObjectId("000004560000000000170233"),
+            ObjectId("000004550000000000170232"),
+        };
         auto wt = db->start_write();
         auto table = wt->add_table("Foo");
         auto col_id = table->add_column(type_ObjectId, "id", true);


### PR DESCRIPTION
## What, How & Why?
<!-- Describe the changes and give some hints to guide your reviewers if possible. -->
<!-- Link to relevant issue this fixes -->

My main motivation for adding the `StringData` constructor was to match the APIs of `UUID` and `Decimal128`. This will let me remove the special case at https://github.com/realm/realm-js/blob/64dd59e6df591fa0e28bc80d3cc417a228f51da1/packages/bindgen/src/templates/node.ts#L315-L321

I made the constructors explicit both because it caused an ambiguity in `bson.h`, but also because it seems like the right thing to do. The implicit conversions don't seem like a good idea here, especially from arbitrary strings. If somebody _really_ wants the conversion from `std::array<uint8_t, 12>` to be implicit, I can bring that one back, but it doesn't seem useful to me.

## ☑️ ToDos
* [x] 📝 Changelog update
* ~~[ ] 🚦 Tests (or not relevant)~~
* ~~[ ] C-API, if public C++ API changed.~~
