### PR TITLE
C API expose a suitable API for listening to thread observer events

### DIFF
--- a/src/realm.h
+++ b/src/realm.h
@@ -61,7 +61,7 @@ typedef struct realm_scheduler realm_scheduler_t;
 typedef struct realm_thread_safe_reference realm_thread_safe_reference_t;
 typedef void (*realm_free_userdata_func_t)(realm_userdata_t userdata);
 typedef realm_userdata_t (*realm_clone_userdata_func_t)(const realm_userdata_t userdata);
-typedef void (*realm_on_object_store_thread_callback_t)(realm_userdata_t userdata); 
+typedef void (*realm_on_object_store_thread_callback_t)(realm_userdata_t userdata);
 typedef void (*realm_on_object_store_error_callback_t)(realm_userdata_t userdata, const char*);
 
 /* Accessor types */
@@ -4000,15 +4000,14 @@ RLM_API void realm_register_user_code_callback_error(realm_userdata_t usercode_e
  * runs.
  * @param on_thread_create callback invoked when the object store thread is created
  * @param on_thread_destroy callback invoked when the object store thread is destroyed
- * @param on_error callback invoked to signal to the listener that some error has occured. 
+ * @param on_error callback invoked to signal to the listener that some error has occured.
  * @return a token that has to be released in order to stop receiving notifications
  */
-RLM_API realm_thread_observer_token_t* realm_set_binding_callback_thread_observer(
-    realm_on_object_store_thread_callback_t on_thread_create,
-    realm_on_object_store_thread_callback_t on_thread_destroy, 
-    realm_on_object_store_error_callback_t on_error,
-    realm_userdata_t,
-    realm_free_userdata_func_t free_userdata);
+RLM_API realm_thread_observer_token_t*
+realm_set_binding_callback_thread_observer(realm_on_object_store_thread_callback_t on_thread_create,
+                                           realm_on_object_store_thread_callback_t on_thread_destroy,
+                                           realm_on_object_store_error_callback_t on_error, realm_userdata_t,
+                                           realm_free_userdata_func_t free_userdata);
 
 typedef struct realm_mongodb_collection realm_mongodb_collection_t;
 

--- a/src/realm.h
+++ b/src/realm.h
@@ -59,9 +59,10 @@ typedef struct shared_realm realm_t;
 typedef struct realm_schema realm_schema_t;
 typedef struct realm_scheduler realm_scheduler_t;
 typedef struct realm_thread_safe_reference realm_thread_safe_reference_t;
-typedef struct realm_callback_interface_thread_observer realm_interface_callback_thread_observer_t;
 typedef void (*realm_free_userdata_func_t)(realm_userdata_t userdata);
 typedef realm_userdata_t (*realm_clone_userdata_func_t)(const realm_userdata_t userdata);
+typedef void (*realm_on_object_store_thread_callback_t)(realm_userdata_t userdata); 
+typedef void (*realm_on_object_store_error_callback_t)(realm_userdata_t userdata, const char*);
 
 /* Accessor types */
 typedef struct realm_object realm_object_t;
@@ -368,6 +369,7 @@ typedef enum realm_property_flags {
 typedef struct realm_notification_token realm_notification_token_t;
 typedef struct realm_callback_token realm_callback_token_t;
 typedef struct realm_refresh_callback_token realm_refresh_callback_token_t;
+typedef struct realm_thread_observer_token realm_thread_observer_token_t;
 typedef struct realm_object_changes realm_object_changes_t;
 typedef struct realm_collection_changes realm_collection_changes_t;
 typedef void (*realm_on_object_change_func_t)(realm_userdata_t userdata, const realm_object_changes_t*);
@@ -3991,16 +3993,22 @@ RLM_API void realm_sync_session_handle_error_for_testing(const realm_sync_sessio
  * Most importantly the SDK is responsible to handle the memory pointed by usercode_error.
  * @param usercode_error pointer representing whatever object the SDK treats as exception/error.
  */
-RLM_API void realm_register_user_code_callback_error(void* usercode_error) RLM_API_NOEXCEPT;
+RLM_API void realm_register_user_code_callback_error(realm_userdata_t usercode_error) RLM_API_NOEXCEPT;
 
 /**
  * Register a callback handler for bindings interested in registering callbacks before/after the ObjectStore thread
  * runs.
- * @param thread_observer a ptr to an implementation class that can receive these notifications. If nullptr is passed
- * instead, this will have the effect of unregistering the callback.
+ * @param on_thread_create callback invoked when the object store thread is created
+ * @param on_thread_destroy callback invoked when the object store thread is destroyed
+ * @param on_error callback invoked to signal to the listener that some error has occured. 
+ * @return a token that has to be released in order to stop receiving notifications
  */
-RLM_API void realm_set_binding_callback_thread_observer(realm_interface_callback_thread_observer_t* thread_observer)
-    RLM_API_NOEXCEPT;
+RLM_API realm_thread_observer_token_t* realm_set_binding_callback_thread_observer(
+    realm_on_object_store_thread_callback_t on_thread_create,
+    realm_on_object_store_thread_callback_t on_thread_destroy, 
+    realm_on_object_store_error_callback_t on_error,
+    realm_userdata_t,
+    realm_free_userdata_func_t free_userdata);
 
 typedef struct realm_mongodb_collection realm_mongodb_collection_t;
 

--- a/src/realm/object-store/c_api/realm.cpp
+++ b/src/realm/object-store/c_api/realm.cpp
@@ -17,6 +17,11 @@ realm_refresh_callback_token::~realm_refresh_callback_token()
     realm::c_api::CBindingContext::get(*m_realm).realm_pending_refresh_callbacks().remove(m_token);
 }
 
+realm_thread_observer_token::~realm_thread_observer_token()
+{
+    realm::g_binding_callback_thread_observer = nullptr;
+}
+
 namespace realm::c_api {
 
 
@@ -335,6 +340,34 @@ void CBindingContext::did_change(std::vector<ObserverState> const&, std::vector<
         m_realm_pending_refresh_callbacks.invoke(version_id.version);
     }
     m_realm_changed_callbacks.invoke();
+}
+
+RLM_API
+realm_thread_observer_token_t*
+realm_set_binding_callback_thread_observer(realm_on_object_store_thread_callback_t on_thread_create,
+                                           realm_on_object_store_thread_callback_t on_thread_destroy,
+                                           realm_on_object_store_error_callback_t on_error, realm_userdata_t userdata,
+                                           realm_free_userdata_func_t free_userdata)
+{
+    realm::c_api::CBindingThreadObserver::ThreadCallback thread_create =
+        [on_thread_create, userdata = UserdataPtr{userdata, free_userdata}]() {
+            on_thread_create(userdata.get());
+        };
+
+    realm::c_api::CBindingThreadObserver::ThreadCallback thread_destroyed =
+        [on_thread_destroy, userdata = UserdataPtr{userdata, free_userdata}]() {
+            on_thread_destroy(userdata.get());
+        };
+
+    realm::c_api::CBindingThreadObserver::ErrorCallback error =
+        [on_error, userdata = UserdataPtr{userdata, free_userdata}](const char* error) {
+            on_error(userdata.get(), error);
+        };
+
+    auto& instance = realm::c_api::CBindingThreadObserver::create();
+    instance.set(thread_create, thread_destroyed, error);
+    g_binding_callback_thread_observer = &instance;
+    return new realm_thread_observer_token_t();
 }
 
 } // namespace realm::c_api

--- a/src/realm/object-store/c_api/realm.cpp
+++ b/src/realm/object-store/c_api/realm.cpp
@@ -365,7 +365,7 @@ realm_set_binding_callback_thread_observer(realm_on_object_store_thread_callback
         };
 
     auto& instance = realm::c_api::CBindingThreadObserver::create();
-    instance.set(thread_create, thread_destroyed, error);
+    instance.set(std::move(thread_create), std::move(thread_destroyed), std::move(error));
     g_binding_callback_thread_observer = &instance;
     return new realm_thread_observer_token_t();
 }

--- a/src/realm/object-store/c_api/realm.hpp
+++ b/src/realm/object-store/c_api/realm.hpp
@@ -63,4 +63,47 @@ private:
     CallbackRegistry<const Schema&> m_schema_changed_callbacks;
 };
 
+class CBindingThreadObserver : public realm::BindingCallbackThreadObserver {
+public:
+    using ThreadCallback = util::UniqueFunction<void()>;
+    using ErrorCallback = util::UniqueFunction<void(const char*)>;
+
+    static CBindingThreadObserver& create()
+    {
+        static CBindingThreadObserver instance;
+        return instance;
+    }
+
+    void set(ThreadCallback&& on_create, ThreadCallback&& on_destroy, ErrorCallback&& on_error)
+    {
+        m_create_callback = std::move(on_create);
+        m_destroy_callback = std::move(on_destroy);
+        m_error_callback = std::move(on_error);
+    }
+
+    void did_create_thread() override
+    {
+        if (m_create_callback)
+            m_create_callback();
+    }
+
+    void will_destroy_thread() override
+    {
+        if (m_destroy_callback)
+            m_destroy_callback();
+    }
+
+    void handle_error(std::exception const& e) override
+    {
+        if (m_error_callback)
+            m_error_callback(e.what());
+    }
+
+private:
+    CBindingThreadObserver() = default;
+    ThreadCallback m_create_callback;
+    ThreadCallback m_destroy_callback;
+    ErrorCallback m_error_callback;
+};
+
 } // namespace realm::c_api

--- a/src/realm/object-store/c_api/realm.hpp
+++ b/src/realm/object-store/c_api/realm.hpp
@@ -81,19 +81,19 @@ public:
         m_error_callback = std::move(on_error);
     }
 
-    void did_create_thread() override
+    virtual void did_create_thread() override
     {
         if (m_create_callback)
             m_create_callback();
     }
 
-    void will_destroy_thread() override
+    virtual void will_destroy_thread() override
     {
         if (m_destroy_callback)
             m_destroy_callback();
     }
 
-    void handle_error(std::exception const& e) override
+    virtual void handle_error(std::exception const& e) override
     {
         if (m_error_callback)
             m_error_callback(e.what());

--- a/src/realm/object-store/c_api/realm.hpp
+++ b/src/realm/object-store/c_api/realm.hpp
@@ -20,6 +20,7 @@
 
 #include <realm/object-store/c_api/util.hpp>
 #include <realm/object-store/binding_context.hpp>
+#include <realm/object-store/binding_callback_thread_observer.hpp>
 
 namespace realm::c_api {
 
@@ -81,19 +82,19 @@ public:
         m_error_callback = std::move(on_error);
     }
 
-    virtual void did_create_thread() override
+    void did_create_thread() override
     {
         if (m_create_callback)
             m_create_callback();
     }
 
-    virtual void will_destroy_thread() override
+    void will_destroy_thread() override
     {
         if (m_destroy_callback)
             m_destroy_callback();
     }
 
-    virtual void handle_error(std::exception const& e) override
+    void handle_error(std::exception const& e) override
     {
         if (m_error_callback)
             m_error_callback(e.what());

--- a/src/realm/object-store/c_api/sync.cpp
+++ b/src/realm/object-store/c_api/sync.cpp
@@ -997,10 +997,4 @@ RLM_API void realm_sync_session_handle_error_for_testing(const realm_sync_sessio
     SyncSession::OnlyForTesting::handle_error(*session->get(), {err, error_message, is_fatal});
 }
 
-RLM_API void
-realm_set_binding_callback_thread_observer(realm_interface_callback_thread_observer_t* thread_observer) noexcept
-{
-    g_binding_callback_thread_observer = thread_observer;
-}
-
 } // namespace realm::c_api

--- a/src/realm/object-store/c_api/types.hpp
+++ b/src/realm/object-store/c_api/types.hpp
@@ -474,6 +474,11 @@ struct realm_notification_token : realm::c_api::WrapC, realm::NotificationToken 
     }
 };
 
+struct realm_thread_observer_token : realm::c_api::WrapC {
+    explicit realm_thread_observer_token() = default;
+    ~realm_thread_observer_token();
+};
+
 struct realm_callback_token : realm::c_api::WrapC {
 protected:
     realm_callback_token(realm_t* realm, uint64_t token)
@@ -772,9 +777,6 @@ struct realm_mongodb_collection : realm::c_api::WrapC, realm::app::MongoCollecti
         : realm::app::MongoCollection(std::move(collection))
     {
     }
-};
-
-struct realm_callback_interface_thread_observer : public realm::BindingCallbackThreadObserver {
 };
 
 #endif // REALM_ENABLE_SYNC


### PR DESCRIPTION
## What, How & Why?
This actually implements a viable API for consuming object store thread events.
Actually
Fixes: https://github.com/realm/realm-core/issues/5966

## ☑️ ToDos
* [ ] 📝 Changelog update
* [ ] 🚦 Tests (or not relevant)
* [ ] C-API, if public C++ API changed.
