### PR TITLE
Normalize sync connection parameters

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,8 @@
 * Core no longer provides any vcpkg infrastructure (the ports submodule and overlay triplets), because it handles dependant libraries internally now.
 * Allow Realm instances to have a complete view of their schema, if mode is additive. ([PR #5784](https://github.com/realm/realm-core/pull/5784)).
 * `realm_sync_immediately_run_file_actions` (c-api) now takes a third argument `bool* did_run` that will be set to the result of `SyncManager::immediately_run_file_actions`. ((#6117)[https://github.com/realm/realm-core/pull/6117]) 
+* Device information in sync connection parameters was moved into a new `device_info` structure in App::Config ([PR #6066](https://github.com/realm/realm-core/pull/6066))
+* `sdk` is now a required field in the `device_device` structure in App::Config ([PR #6066](https://github.com/realm/realm-core/pull/6066))
 
 ### Compatibility
 * Fileformat: Generates files with format v23. Reads and automatically upgrade from fileformat v5.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 * Upgrade OpenSSL from 1.1.1n to 3.0.7. ([#6097](https://github.com/realm/realm-core/pull/6097))
 * Converting flexible sync realms to bundled and local realms is now supported ([#6076](https://github.com/realm/realm-core/pull/6076))
 * Compensating write errors are now surfaced to the SDK/user after the compensating write has been applied in a download message ([#6095](https://github.com/realm/realm-core/pull/6095)).
+* Normalize sync connection parameters for device information ([#6029](https://github.com/realm/realm-core/issues/6029))
 
 ### Fixed
 * Compare actual users (`SyncUser::operator!=`), not pointers (`shared_ptr<SyncUser>::operator!=`). ([#realm/realm-dart#1055](https://github.com/realm/realm-dart/issues/1055), since v10.2.0)

--- a/doc/CHANGELOG_template.md
+++ b/doc/CHANGELOG_template.md
@@ -7,7 +7,7 @@
 ### Fixed
 * <How do the end-user experience this issue? what was the impact?> ([#????](https://github.com/realm/realm-core/issues/????), since v?.?.?)
 * None.
- 
+
 ### Breaking changes
 * None.
 

--- a/src/realm.h
+++ b/src/realm.h
@@ -2909,6 +2909,16 @@ RLM_API void realm_app_config_set_default_request_timeout(realm_app_config_t*, u
 RLM_API void realm_app_config_set_platform(realm_app_config_t*, const char*) RLM_API_NOEXCEPT;
 RLM_API void realm_app_config_set_platform_version(realm_app_config_t*, const char*) RLM_API_NOEXCEPT;
 RLM_API void realm_app_config_set_sdk_version(realm_app_config_t*, const char*) RLM_API_NOEXCEPT;
+RLM_API void realm_app_config_set_sdk(realm_app_config_t* config, const char* sdk) RLM_API_NOEXCEPT;
+RLM_API void realm_app_config_set_cpu_arch(realm_app_config_t* config, const char* cpu_arch) RLM_API_NOEXCEPT;
+RLM_API void realm_app_config_set_device_name(realm_app_config_t* config, const char* device_name) RLM_API_NOEXCEPT;
+RLM_API void realm_app_config_set_device_version(realm_app_config_t* config,
+                                                 const char* device_version) RLM_API_NOEXCEPT;
+RLM_API void realm_app_config_set_framework_name(realm_app_config_t* config,
+                                                 const char* framework_name) RLM_API_NOEXCEPT;
+RLM_API void realm_app_config_set_framework_version(realm_app_config_t* config,
+                                                    const char* framework_version) RLM_API_NOEXCEPT;
+
 /**
  * Get an existing @a realm_app_credentials_t and return it's json representation
  * Note: the caller must delete the pointer to the string via realm_release

--- a/src/realm/object-store/c_api/app.cpp
+++ b/src/realm/object-store/c_api/app.cpp
@@ -330,17 +330,48 @@ RLM_API void realm_app_config_set_default_request_timeout(realm_app_config_t* co
 
 RLM_API void realm_app_config_set_platform(realm_app_config_t* config, const char* platform) noexcept
 {
-    config->platform = std::string(platform);
+    config->device.platform = std::string(platform);
 }
 
 RLM_API void realm_app_config_set_platform_version(realm_app_config_t* config, const char* platform_version) noexcept
 {
-    config->platform_version = std::string(platform_version);
+    config->device.platform_version = std::string(platform_version);
 }
 
 RLM_API void realm_app_config_set_sdk_version(realm_app_config_t* config, const char* sdk_version) noexcept
 {
-    config->sdk_version = std::string(sdk_version);
+    config->device.sdk_version = std::string(sdk_version);
+}
+
+RLM_API void realm_app_config_set_sdk(realm_app_config_t* config, const char* sdk) noexcept
+{
+    config->device.sdk = std::string(sdk);
+}
+
+RLM_API void realm_app_config_set_cpu_arch(realm_app_config_t* config, const char* cpu_arch) noexcept
+{
+    config->device.cpu_arch = std::string(cpu_arch);
+}
+
+RLM_API void realm_app_config_set_device_name(realm_app_config_t* config, const char* device_name) noexcept
+{
+    config->device.device_name = std::string(device_name);
+}
+
+RLM_API void realm_app_config_set_device_version(realm_app_config_t* config, const char* device_version) noexcept
+{
+    config->device.device_version = std::string(device_version);
+}
+
+RLM_API void realm_app_config_set_framework_name(realm_app_config_t* config, const char* framework_name) noexcept
+{
+    config->device.framework_name = std::string(framework_name);
+}
+
+RLM_API void realm_app_config_set_framework_version(realm_app_config_t* config,
+                                                    const char* framework_version) noexcept
+{
+    config->device.framework_version = std::string(framework_version);
 }
 
 RLM_API const char* realm_app_credentials_serialize_as_json(realm_app_credentials_t* app_credentials) noexcept

--- a/src/realm/object-store/c_api/app.cpp
+++ b/src/realm/object-store/c_api/app.cpp
@@ -330,48 +330,48 @@ RLM_API void realm_app_config_set_default_request_timeout(realm_app_config_t* co
 
 RLM_API void realm_app_config_set_platform(realm_app_config_t* config, const char* platform) noexcept
 {
-    config->device.platform = std::string(platform);
+    config->device_info.platform = std::string(platform);
 }
 
 RLM_API void realm_app_config_set_platform_version(realm_app_config_t* config, const char* platform_version) noexcept
 {
-    config->device.platform_version = std::string(platform_version);
+    config->device_info.platform_version = std::string(platform_version);
 }
 
 RLM_API void realm_app_config_set_sdk_version(realm_app_config_t* config, const char* sdk_version) noexcept
 {
-    config->device.sdk_version = std::string(sdk_version);
+    config->device_info.sdk_version = std::string(sdk_version);
 }
 
 RLM_API void realm_app_config_set_sdk(realm_app_config_t* config, const char* sdk) noexcept
 {
-    config->device.sdk = std::string(sdk);
+    config->device_info.sdk = std::string(sdk);
 }
 
 RLM_API void realm_app_config_set_cpu_arch(realm_app_config_t* config, const char* cpu_arch) noexcept
 {
-    config->device.cpu_arch = std::string(cpu_arch);
+    config->device_info.cpu_arch = std::string(cpu_arch);
 }
 
 RLM_API void realm_app_config_set_device_name(realm_app_config_t* config, const char* device_name) noexcept
 {
-    config->device.device_name = std::string(device_name);
+    config->device_info.device_name = std::string(device_name);
 }
 
 RLM_API void realm_app_config_set_device_version(realm_app_config_t* config, const char* device_version) noexcept
 {
-    config->device.device_version = std::string(device_version);
+    config->device_info.device_version = std::string(device_version);
 }
 
 RLM_API void realm_app_config_set_framework_name(realm_app_config_t* config, const char* framework_name) noexcept
 {
-    config->device.framework_name = std::string(framework_name);
+    config->device_info.framework_name = std::string(framework_name);
 }
 
 RLM_API void realm_app_config_set_framework_version(realm_app_config_t* config,
                                                     const char* framework_version) noexcept
 {
-    config->device.framework_version = std::string(framework_version);
+    config->device_info.framework_version = std::string(framework_version);
 }
 
 RLM_API const char* realm_app_credentials_serialize_as_json(realm_app_credentials_t* app_credentials) noexcept

--- a/src/realm/object-store/sync/app.cpp
+++ b/src/realm/object-store/sync/app.cpp
@@ -225,27 +225,27 @@ void App::close_all_sync_sessions()
 
 App::App(const Config& config)
     : m_config(std::move(config))
-    , m_base_url(config.base_url.value_or(default_base_url))
+    , m_base_url(m_config.base_url.value_or(default_base_url))
     , m_base_route(m_base_url + base_path)
-    , m_app_route(m_base_route + app_path + "/" + config.app_id)
+    , m_app_route(m_base_route + app_path + "/" + m_config.app_id)
     , m_auth_route(m_app_route + auth_path)
-    , m_request_timeout_ms(config.default_request_timeout_ms.value_or(default_timeout_ms))
+    , m_request_timeout_ms(m_config.default_request_timeout_ms.value_or(default_timeout_ms))
 {
     REALM_ASSERT(m_config.transport);
 
-    if (m_config.device.platform.empty()) {
+    if (m_config.device_info.platform.empty()) {
         throw std::runtime_error("You must specify the Platform in App::Config::device");
     }
 
-    if (m_config.device.platform_version.empty()) {
+    if (m_config.device_info.platform_version.empty()) {
         throw std::runtime_error("You must specify the Platform Version in App::Config::device");
     }
 
-    if (m_config.device.sdk.empty()) {
+    if (m_config.device_info.sdk.empty()) {
         throw std::runtime_error("You must specify the SDK Name in App::Config::device");
     }
 
-    if (m_config.device.sdk_version.empty()) {
+    if (m_config.device_info.sdk_version.empty()) {
         throw std::runtime_error("You must specify the SDK Version in App::Config::device");
     }
 
@@ -574,18 +574,18 @@ void App::attach_auth_options(BsonDocument& body)
     }
 
     log_debug("App: version info: platform: %1  version: %2 - sdk: %3 - sdk version: %4 - core version: %5",
-              m_config.device.platform, m_config.device.platform_version, m_config.device.sdk,
-              m_config.device.sdk_version, REALM_VERSION_STRING);
+              m_config.device_info.platform, m_config.device_info.platform_version, m_config.device_info.sdk,
+              m_config.device_info.sdk_version, REALM_VERSION_STRING);
     options["appId"] = m_config.app_id;
-    options["platform"] = m_config.device.platform;
-    options["platformVersion"] = m_config.device.platform_version;
-    options["sdk"] = m_config.device.sdk;
-    options["sdkVersion"] = m_config.device.sdk_version;
-    options["cpuArch"] = m_config.device.cpu_arch;
-    options["deviceName"] = m_config.device.device_name;
-    options["deviceVersion"] = m_config.device.device_version;
-    options["frameworkName"] = m_config.device.framework_name;
-    options["frameworkVersion"] = m_config.device.framework_version;
+    options["platform"] = m_config.device_info.platform;
+    options["platformVersion"] = m_config.device_info.platform_version;
+    options["sdk"] = m_config.device_info.sdk;
+    options["sdkVersion"] = m_config.device_info.sdk_version;
+    options["cpuArch"] = m_config.device_info.cpu_arch;
+    options["deviceName"] = m_config.device_info.device_name;
+    options["deviceVersion"] = m_config.device_info.device_version;
+    options["frameworkName"] = m_config.device_info.framework_name;
+    options["frameworkVersion"] = m_config.device_info.framework_version;
     options["coreVersion"] = REALM_VERSION_STRING;
 
     body["options"] = BsonDocument({{"device", options}});

--- a/src/realm/object-store/sync/app.cpp
+++ b/src/realm/object-store/sync/app.cpp
@@ -574,8 +574,8 @@ void App::attach_auth_options(BsonDocument& body)
     }
 
     log_debug("App: version info: platform: %1  version: %2 - sdk: %3 - sdk version: %4 - core version: %5",
-              m_config.device.platform, m_config.device.platform_version, m_config.device.sdk_version,
-              REALM_VERSION_STRING);
+              m_config.device.platform, m_config.device.platform_version, m_config.device.sdk,
+              m_config.device.sdk_version, REALM_VERSION_STRING);
     options["appId"] = m_config.app_id;
     options["platform"] = m_config.device.platform;
     options["platformVersion"] = m_config.device.platform_version;

--- a/src/realm/object-store/sync/app.cpp
+++ b/src/realm/object-store/sync/app.cpp
@@ -233,16 +233,20 @@ App::App(const Config& config)
 {
     REALM_ASSERT(m_config.transport);
 
-    if (m_config.platform.empty()) {
-        throw std::runtime_error("You must specify the Platform in App::Config");
+    if (m_config.device.platform.empty()) {
+        throw std::runtime_error("You must specify the Platform in App::Config::device");
     }
 
-    if (m_config.platform_version.empty()) {
-        throw std::runtime_error("You must specify the Platform Version in App::Config");
+    if (m_config.device.platform_version.empty()) {
+        throw std::runtime_error("You must specify the Platform Version in App::Config::device");
     }
 
-    if (m_config.sdk_version.empty()) {
-        throw std::runtime_error("You must specify the SDK Version in App::Config");
+    if (m_config.device.sdk.empty()) {
+        throw std::runtime_error("You must specify the SDK Name in App::Config::device");
+    }
+
+    if (m_config.device.sdk_version.empty()) {
+        throw std::runtime_error("You must specify the SDK Version in App::Config::device");
     }
 
     // change the scheme in the base url to ws from http to satisfy the sync client

--- a/src/realm/object-store/sync/app.cpp
+++ b/src/realm/object-store/sync/app.cpp
@@ -573,12 +573,19 @@ void App::attach_auth_options(BsonDocument& body)
         options["appVersion"] = *m_config.local_app_version;
     }
 
-    log_debug("App: version info: platform: %1  version: %1 - sdk version: %3 - core version: %4", m_config.platform,
-              m_config.platform_version, m_config.sdk_version, REALM_VERSION_STRING);
+    log_debug("App: version info: platform: %1  version: %2 - sdk: %3 - sdk version: %4 - core version: %5",
+              m_config.device.platform, m_config.device.platform_version, m_config.device.sdk_version,
+              REALM_VERSION_STRING);
     options["appId"] = m_config.app_id;
-    options["platform"] = m_config.platform;
-    options["platformVersion"] = m_config.platform_version;
-    options["sdkVersion"] = m_config.sdk_version;
+    options["platform"] = m_config.device.platform;
+    options["platformVersion"] = m_config.device.platform_version;
+    options["sdk"] = m_config.device.sdk;
+    options["sdkVersion"] = m_config.device.sdk_version;
+    options["cpuArch"] = m_config.device.cpu_arch;
+    options["deviceName"] = m_config.device.device_name;
+    options["deviceVersion"] = m_config.device.device_version;
+    options["frameworkName"] = m_config.device.framework_name;
+    options["frameworkVersion"] = m_config.device.framework_version;
     options["coreVersion"] = REALM_VERSION_STRING;
 
     body["options"] = BsonDocument({{"device", options}});

--- a/src/realm/object-store/sync/app.hpp
+++ b/src/realm/object-store/sync/app.hpp
@@ -59,17 +59,17 @@ public:
     struct Config {
         // Information about the device where the app is running
         struct DeviceInfo {
-            std::string platform;         // required, originally App::Config::platform
-            std::string platform_version; // required,  originally App::Config::platform_version
-            std::string sdk_version;      // required, originally App::Config::sdk_version
-            std::string sdk;              // required,
-            std::string cpu_arch;
-            // device_id is stored with the user configuration
-            std::string device_name;
-            std::string device_version;
-            std::string framework_name;
-            std::string framework_version;
-            // core_version is populated by Sync when the device info is sent
+            std::string platform;          // json: platform
+            std::string platform_version;  // json: platformVersion
+            std::string sdk_version;       // json: sdkVersion
+            std::string sdk;               // json: sdk
+            std::string cpu_arch;          // json: cpuArch
+            std::string device_name;       // json: deviceName
+            std::string device_version;    // json: deviceVersion
+            std::string framework_name;    // json: frameworkName
+            std::string framework_version; // json: frameworkVersion
+            // Other parameters provided to server no included here:
+            // * CoreVersion - populated by Sync when the device info is sent
         };
 
         std::string app_id;
@@ -78,7 +78,7 @@ public:
         util::Optional<std::string> local_app_name;
         util::Optional<std::string> local_app_version;
         util::Optional<uint64_t> default_request_timeout_ms;
-        DeviceInfo device;
+        DeviceInfo device_info;
     };
 
     // `enable_shared_from_this` is unsafe with public constructors; use `get_shared_app` instead

--- a/src/realm/object-store/sync/app.hpp
+++ b/src/realm/object-store/sync/app.hpp
@@ -57,15 +57,28 @@ class App : public std::enable_shared_from_this<App>,
             public Subscribable<App> {
 public:
     struct Config {
+        // Information about the device where the app is running
+        struct DeviceInfo {
+            std::string platform;         // required, originally App::Config::platform
+            std::string platform_version; // required,  originally App::Config::platform_version
+            std::string sdk_version;      // required, originally App::Config::sdk_version
+            std::string sdk;              // required,
+            std::string cpu_arch;
+            // device_id is stored with the user configuration
+            std::string device_name;
+            std::string device_version;
+            std::string framework_name;
+            std::string framework_version;
+            // core_version is populated by Sync when the device info is sent
+        };
+
         std::string app_id;
         std::shared_ptr<GenericNetworkTransport> transport;
         util::Optional<std::string> base_url;
         util::Optional<std::string> local_app_name;
         util::Optional<std::string> local_app_version;
         util::Optional<uint64_t> default_request_timeout_ms;
-        std::string platform;
-        std::string platform_version;
-        std::string sdk_version;
+        DeviceInfo device;
     };
 
     // `enable_shared_from_this` is unsafe with public constructors; use `get_shared_app` instead

--- a/test/object-store/c_api/c_api.cpp
+++ b/test/object-store/c_api/c_api.cpp
@@ -15,6 +15,7 @@
 #include <cstring>
 #include <numeric>
 #include <thread>
+#include <iostream>
 
 #if REALM_ENABLE_SYNC
 #include <realm/object-store/sync/sync_user.hpp>
@@ -22,6 +23,7 @@
 #endif
 
 #if REALM_ENABLE_AUTH_TESTS
+#include <realm/object-store/sync/app_utils.hpp>
 #include "sync/sync_test_utils.hpp"
 #include "util/baas_admin_api.hpp"
 #endif
@@ -246,6 +248,119 @@ CPtr<T> clone_cptr(const T* ptr)
         }                                                                                                            \
     } while (false);
 
+#if REALM_ENABLE_AUTH_TESTS
+class CApiUnitTestTransport : public app::GenericNetworkTransport {
+    std::string m_provider_type;
+
+public:
+    CApiUnitTestTransport(const std::string& provider_type = "anon-user")
+        : m_provider_type(provider_type)
+    {
+        profile_0 = nlohmann::json({{"name", "profile_0_name"},
+                                    {"first_name", "profile_0_first_name"},
+                                    {"last_name", "profile_0_last_name"},
+                                    {"email", "profile_0_email"},
+                                    {"picture_url", "profile_0_picture_url"},
+                                    {"gender", "profile_0_gender"},
+                                    {"birthday", "profile_0_birthday"},
+                                    {"min_age", "profile_0_min_age"},
+                                    {"max_age", "profile_0_max_age"}});
+    }
+
+    void set_provider_type(const std::string& provider_type)
+    {
+        m_provider_type = provider_type;
+    }
+
+    const std::string access_token =
+        "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9."
+        "eyJleHAiOjE1ODE1MDc3OTYsImlhdCI6MTU4MTUwNTk5NiwiaXNzIjoiNWU0M2RkY2M2MzZlZTEwNmVhYTEyYmRjIiwic3RpdGNoX2Rldklk"
+        "IjoiMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwIiwic3RpdGNoX2RvbWFpbklkIjoiNWUxNDk5MTNjOTBiNGFmMGViZTkzNTI3Iiwic3ViIjoi"
+        "NWU0M2RkY2M2MzZlZTEwNmVhYTEyYmRhIiwidHlwIjoiYWNjZXNzIn0.0q3y9KpFxEnbmRwahvjWU1v9y1T1s3r2eozu93vMc3s";
+    const std::string user_id = "awelfkewjfewkefkeafj";
+    const std::string identity_0_id = "eflkjf393flkj33fjf3";
+    const std::string identity_1_id = "aewfjklewfwoifejjef";
+    nlohmann::json profile_0;
+
+
+private:
+    void handle_profile(const app::Request&, util::UniqueFunction<void(const app::Response&)>&& completion)
+    {
+        std::string response =
+            nlohmann::json({{"user_id", user_id},
+                            {"identities",
+                             {{{"id", identity_0_id}, {"provider_type", m_provider_type}, {"provider_id", "lol"}},
+                              {{"id", identity_1_id}, {"provider_type", "lol_wut"}, {"provider_id", "nah_dawg"}}}},
+                            {"data", profile_0}})
+                .dump();
+
+        completion(app::Response{200, 0, {}, response});
+    }
+
+    void handle_login(const app::Request& request, util::UniqueFunction<void(const app::Response&)>&& completion)
+    {
+        CHECK(request.method == app::HttpMethod::post);
+        auto item = app::AppUtils::find_header("Content-Type", request.headers);
+        CHECK(item);
+        CHECK(item->second == "application/json;charset=utf-8");
+        // Verify against
+        CHECK(nlohmann::json::parse(request.body)["options"] ==
+              nlohmann::json({{"device",
+                               {{"appId", "app_id_123"},
+                                {"appVersion", "some_app_version"},
+                                {"platform", "some_platform_name"},
+                                {"platformVersion", "some_platform_version"},
+                                {"sdk", "some_sdk_name"},
+                                {"sdkVersion", "some_sdk_version"},
+                                {"cpuArch", "some_cpu_arch"},
+                                {"deviceName", "some_device_name"},
+                                {"deviceVersion", "some_device_version"},
+                                {"frameworkName", "some_framework_name"},
+                                {"frameworkVersion", "some_framework_version"},
+                                {"coreVersion", REALM_VERSION_STRING}}}}));
+
+        CHECK(request.timeout_ms == 60000);
+
+        std::string response = nlohmann::json({{"access_token", access_token},
+                                               {"refresh_token", access_token},
+                                               {"user_id", user_id},
+                                               {"device_id", "Panda Bear"}})
+                                   .dump();
+
+        completion(app::Response{200, 0, {}, response});
+    }
+
+    void handle_location(const app::Request&, util::UniqueFunction<void(const app::Response&)>&& completion)
+    {
+        std::string response = nlohmann::json({{"deployment_model", "this"},
+                                               {"hostname", "field"},
+                                               {"ws_hostname", "shouldn't"},
+                                               {"location", "matter"}})
+                                   .dump();
+
+        completion(app::Response{200, 0, {}, response});
+    }
+
+public:
+    void send_request_to_server(const app::Request& request,
+                                util::UniqueFunction<void(const app::Response&)>&& completion) override
+    {
+        if (request.url.find("/login") != std::string::npos) {
+            handle_login(request, std::move(completion));
+        }
+        else if (request.url.find("/profile") != std::string::npos) {
+            handle_profile(request, std::move(completion));
+        }
+        else if (request.url.find("/location") != std::string::npos && request.method == app::HttpMethod::get) {
+            handle_location(request, std::move(completion));
+        }
+        else {
+            completion(app::Response{200, 0, {}, "something arbitrary"});
+        }
+    }
+};
+#endif // REALM_ENABLE_AUTH_TESTS
+
 TEST_CASE("C API (C)", "[c_api]") {
     TestFile file;
     CHECK(realm_c_api_tests(file.path.c_str()) == 0);
@@ -450,98 +565,65 @@ TEST_CASE("C API (non-database)", "[c_api]") {
         }
     }
 
-#if REALM_ENABLE_SYNC
-    SECTION("realm_app_config_t") {
-        // realm_http_transport is not defined if REALM_ENABLE_SYNC is not set
-        auto http_transport = realm_http_transport(nullptr);
-        auto app_config = cptr(realm_app_config_new("some_app_id", &http_transport));
-
 #if REALM_ENABLE_AUTH_TESTS
-        SECTION("realm_app_config_t with transport") {
-            std::shared_ptr<app::GenericNetworkTransport> transport = std::make_shared<SynchronousTestTransport>();
-            auto http_transport = realm_http_transport(transport);
-            app_config = cptr(realm_app_config_new("app_id_123", &http_transport));
-            CHECK(app_config.get() != nullptr);
-            CHECK(app_config->app_id == "app_id_123");
-            CHECK(app_config->transport == transport);
-        }
-#else
-        // SynchronousTestTransport is not available if SYNC is not enabled
-        SECTION("realm_app_config_t with transport") {
-            auto http_transport = realm_http_transport(nullptr);
-            app_config = cptr(realm_app_config_new("app_id_123", &http_transport));
-            CHECK(app_config.get() != nullptr);
-            CHECK(app_config->app_id == "app_id_123");
-            CHECK(app_config->transport == nullptr);
-        }
-#endif // REALM_ENABLE_AUTH_TESTS
+    SECTION("realm_app_config_t") {
+        std::shared_ptr<app::GenericNetworkTransport> transport = std::make_shared<CApiUnitTestTransport>();
+        auto http_transport = realm_http_transport(transport);
+        auto app_config = cptr(realm_app_config_new("app_id_123", &http_transport));
+        CHECK(app_config.get() != nullptr);
+        CHECK(app_config->app_id == "app_id_123");
+        CHECK(app_config->transport == transport);
 
-        SECTION("realm_app_config_set_base_url()") {
-            realm_app_config_set_base_url(app_config.get(), "https://path/to/app");
-            CHECK(app_config->base_url == "https://path/to/app");
-        }
+        realm_app_config_set_base_url(app_config.get(), "https://path/to/app");
+        CHECK(app_config->base_url == "https://path/to/app");
 
-        SECTION("realm_app_config_set_local_app_name()") {
-            realm_app_config_set_local_app_name(app_config.get(), "some_app_name");
-            CHECK(app_config->local_app_name == "some_app_name");
-        }
+        realm_app_config_set_local_app_name(app_config.get(), "some_app_name");
+        CHECK(app_config->local_app_name == "some_app_name");
 
-        SECTION("realm_app_config_set_local_app_version()") {
-            realm_app_config_set_local_app_version(app_config.get(), "some_app_version");
-            CHECK(app_config->local_app_version == "some_app_version");
-        }
+        realm_app_config_set_local_app_version(app_config.get(), "some_app_version");
+        CHECK(app_config->local_app_version == "some_app_version");
 
-        SECTION("realm_app_config_set_default_request_timeout()") {
-            realm_app_config_set_default_request_timeout(app_config.get(), 2500);
-            CHECK(app_config->default_request_timeout_ms == 2500);
-        }
+        realm_app_config_set_default_request_timeout(app_config.get(), 2500);
+        CHECK(app_config->default_request_timeout_ms == 2500);
 
-        SECTION("realm_app_config_set_platform()") {
-            realm_app_config_set_platform(app_config.get(), "some_platform_name");
-            CHECK(app_config->device.platform == "some_platform_name");
-        }
+        realm_app_config_set_platform(app_config.get(), "some_platform_name");
+        CHECK(app_config->device_info.platform == "some_platform_name");
 
-        SECTION("realm_app_config_set_platform_version()") {
-            realm_app_config_set_platform_version(app_config.get(), "some_platform_version");
-            CHECK(app_config->device.platform_version == "some_platform_version");
-        }
+        realm_app_config_set_platform_version(app_config.get(), "some_platform_version");
+        CHECK(app_config->device_info.platform_version == "some_platform_version");
 
-        SECTION("realm_app_config_set_sdk_version()") {
-            realm_app_config_set_sdk_version(app_config.get(), "some_sdk_version");
-            CHECK(app_config->device.sdk_version == "some_sdk_version");
-        }
+        realm_app_config_set_sdk_version(app_config.get(), "some_sdk_version");
+        CHECK(app_config->device_info.sdk_version == "some_sdk_version");
 
-        SECTION("realm_app_config_set_sdk()") {
-            realm_app_config_set_sdk(app_config.get(), "some_sdk_name");
-            CHECK(app_config->device.sdk == "some_sdk_name");
-        }
+        realm_app_config_set_sdk(app_config.get(), "some_sdk_name");
+        CHECK(app_config->device_info.sdk == "some_sdk_name");
 
-        SECTION("realm_app_config_set_cpu_arch()") {
-            realm_app_config_set_cpu_arch(app_config.get(), "some_cpu_arch");
-            CHECK(app_config->device.cpu_arch == "some_cpu_arch");
-        }
+        realm_app_config_set_cpu_arch(app_config.get(), "some_cpu_arch");
+        CHECK(app_config->device_info.cpu_arch == "some_cpu_arch");
 
-        SECTION("realm_app_config_set_device_name()") {
-            realm_app_config_set_device_name(app_config.get(), "some_device_name");
-            CHECK(app_config->device.device_name == "some_device_name");
-        }
+        realm_app_config_set_device_name(app_config.get(), "some_device_name");
+        CHECK(app_config->device_info.device_name == "some_device_name");
 
-        SECTION("realm_app_config_set_device_version()") {
-            realm_app_config_set_device_version(app_config.get(), "some_device_version");
-            CHECK(app_config->device.device_version == "some_device_version");
-        }
+        realm_app_config_set_device_version(app_config.get(), "some_device_version");
+        CHECK(app_config->device_info.device_version == "some_device_version");
 
-        SECTION("realm_app_config_set_framework_name()") {
-            realm_app_config_set_framework_name(app_config.get(), "some_framework_name");
-            CHECK(app_config->device.framework_name == "some_framework_name");
-        }
+        realm_app_config_set_framework_name(app_config.get(), "some_framework_name");
+        CHECK(app_config->device_info.framework_name == "some_framework_name");
 
-        SECTION("realm_app_config_set_framework_version()") {
-            realm_app_config_set_framework_version(app_config.get(), "some_framework_version");
-            CHECK(app_config->device.framework_version == "some_framework_version");
-        }
+        realm_app_config_set_framework_version(app_config.get(), "some_framework_version");
+        CHECK(app_config->device_info.framework_version == "some_framework_version");
+
+        auto test_app = std::make_shared<app::App>(*app_config);
+        auto credentials = app::AppCredentials::anonymous();
+        test_app->log_in_with_credentials(credentials, [&](const std::shared_ptr<realm::SyncUser>&,
+                                                           realm::util::Optional<realm::app::AppError> error) {
+            if (error) {
+                std::cerr << "ERROR: " << error->message << std::endl;
+            }
+            CHECK(!error);
+        });
     }
-#endif // REALM_ENABLE_SYNC
+#endif // REALM_ENABLE_AUTH_TESTS
 }
 
 namespace {

--- a/test/object-store/c_api/c_api.cpp
+++ b/test/object-store/c_api/c_api.cpp
@@ -15,7 +15,6 @@
 #include <cstring>
 #include <numeric>
 #include <thread>
-#include <iostream>
 
 #if REALM_ENABLE_SYNC
 #include <realm/object-store/sync/sync_user.hpp>

--- a/test/object-store/c_api/c_api.cpp
+++ b/test/object-store/c_api/c_api.cpp
@@ -449,10 +449,12 @@ TEST_CASE("C API (non-database)", "[c_api]") {
             CHECK(std::string{realm_config_get_fifo_path(config.get())} == "test_path.FIFO");
         }
     }
+
+#if REALM_ENABLE_SYNC
     SECTION("realm_app_config_t") {
+        // realm_http_transport is not defined if REALM_ENABLE_SYNC is not set
         auto http_transport = realm_http_transport(nullptr);
         auto app_config = cptr(realm_app_config_new("some_app_id", &http_transport));
-
 
 #if REALM_ENABLE_AUTH_TESTS
         SECTION("realm_app_config_t with transport") {
@@ -472,7 +474,7 @@ TEST_CASE("C API (non-database)", "[c_api]") {
             CHECK(app_config->app_id == "app_id_123");
             CHECK(app_config->transport == nullptr);
         }
-#endif
+#endif //REALM_ENABLE_AUTH_TESTS
 
         SECTION("realm_app_config_set_base_url()") {
             realm_app_config_set_base_url(app_config.get(), "https://path/to/app");
@@ -539,6 +541,7 @@ TEST_CASE("C API (non-database)", "[c_api]") {
             CHECK(app_config->device.framework_version == "some_framework_version");
         }
     }
+#endif // REALM_ENABLE_SYNC
 }
 
 namespace {

--- a/test/object-store/c_api/c_api.cpp
+++ b/test/object-store/c_api/c_api.cpp
@@ -474,7 +474,7 @@ TEST_CASE("C API (non-database)", "[c_api]") {
             CHECK(app_config->app_id == "app_id_123");
             CHECK(app_config->transport == nullptr);
         }
-#endif //REALM_ENABLE_AUTH_TESTS
+#endif // REALM_ENABLE_AUTH_TESTS
 
         SECTION("realm_app_config_set_base_url()") {
             realm_app_config_set_base_url(app_config.get(), "https://path/to/app");

--- a/test/object-store/c_api/c_api.cpp
+++ b/test/object-store/c_api/c_api.cpp
@@ -453,6 +453,8 @@ TEST_CASE("C API (non-database)", "[c_api]") {
         auto http_transport = realm_http_transport(nullptr);
         auto app_config = cptr(realm_app_config_new("some_app_id", &http_transport));
 
+
+#if REALM_ENABLE_AUTH_TESTS
         SECTION("realm_app_config_t with transport") {
             std::shared_ptr<app::GenericNetworkTransport> transport = std::make_shared<SynchronousTestTransport>();
             auto http_transport = realm_http_transport(transport);
@@ -461,6 +463,16 @@ TEST_CASE("C API (non-database)", "[c_api]") {
             CHECK(app_config->app_id == "app_id_123");
             CHECK(app_config->transport == transport);
         }
+#else
+        // SynchronousTestTransport is not available if SYNC is not enabled
+        SECTION("realm_app_config_t with transport") {
+            auto http_transport = realm_http_transport(nullptr);
+            app_config = cptr(realm_app_config_new("app_id_123", &http_transport));
+            CHECK(app_config.get() != nullptr);
+            CHECK(app_config->app_id == "app_id_123");
+            CHECK(app_config->transport == nullptr);
+        }
+#endif
 
         SECTION("realm_app_config_set_base_url()") {
             realm_app_config_set_base_url(app_config.get(), "https://path/to/app");

--- a/test/object-store/c_api/c_api.cpp
+++ b/test/object-store/c_api/c_api.cpp
@@ -615,11 +615,9 @@ TEST_CASE("C API (non-database)", "[c_api]") {
 
         auto test_app = std::make_shared<app::App>(*app_config);
         auto credentials = app::AppCredentials::anonymous();
+        // Verify the values above are included in the login request
         test_app->log_in_with_credentials(credentials, [&](const std::shared_ptr<realm::SyncUser>&,
                                                            realm::util::Optional<realm::app::AppError> error) {
-            if (error) {
-                std::cerr << "ERROR: " << error->message << std::endl;
-            }
             CHECK(!error);
         });
     }

--- a/test/object-store/c_api/c_api.cpp
+++ b/test/object-store/c_api/c_api.cpp
@@ -449,6 +449,84 @@ TEST_CASE("C API (non-database)", "[c_api]") {
             CHECK(std::string{realm_config_get_fifo_path(config.get())} == "test_path.FIFO");
         }
     }
+    SECTION("realm_app_config_t") {
+        auto http_transport = realm_http_transport(nullptr);
+        auto app_config = cptr(realm_app_config_new("some_app_id", &http_transport));
+
+        SECTION("realm_app_config_t with transport") {
+            std::shared_ptr<app::GenericNetworkTransport> transport = std::make_shared<SynchronousTestTransport>();
+            auto http_transport = realm_http_transport(transport);
+            app_config = cptr(realm_app_config_new("app_id_123", &http_transport));
+            CHECK(app_config.get() != nullptr);
+            CHECK(app_config->app_id == "app_id_123");
+            CHECK(app_config->transport == transport);
+        }
+
+        SECTION("realm_app_config_set_base_url()") {
+            realm_app_config_set_base_url(app_config.get(), "https://path/to/app");
+            CHECK(app_config->base_url == "https://path/to/app");
+        }
+
+        SECTION("realm_app_config_set_local_app_name()") {
+            realm_app_config_set_local_app_name(app_config.get(), "some_app_name");
+            CHECK(app_config->local_app_name == "some_app_name");
+        }
+
+        SECTION("realm_app_config_set_local_app_version()") {
+            realm_app_config_set_local_app_version(app_config.get(), "some_app_version");
+            CHECK(app_config->local_app_version == "some_app_version");
+        }
+
+        SECTION("realm_app_config_set_default_request_timeout()") {
+            realm_app_config_set_default_request_timeout(app_config.get(), 2500);
+            CHECK(app_config->default_request_timeout_ms == 2500);
+        }
+
+        SECTION("realm_app_config_set_platform()") {
+            realm_app_config_set_platform(app_config.get(), "some_platform_name");
+            CHECK(app_config->device.platform == "some_platform_name");
+        }
+
+        SECTION("realm_app_config_set_platform_version()") {
+            realm_app_config_set_platform_version(app_config.get(), "some_platform_version");
+            CHECK(app_config->device.platform_version == "some_platform_version");
+        }
+
+        SECTION("realm_app_config_set_sdk_version()") {
+            realm_app_config_set_sdk_version(app_config.get(), "some_sdk_version");
+            CHECK(app_config->device.sdk_version == "some_sdk_version");
+        }
+
+        SECTION("realm_app_config_set_sdk()") {
+            realm_app_config_set_sdk(app_config.get(), "some_sdk_name");
+            CHECK(app_config->device.sdk == "some_sdk_name");
+        }
+
+        SECTION("realm_app_config_set_cpu_arch()") {
+            realm_app_config_set_cpu_arch(app_config.get(), "some_cpu_arch");
+            CHECK(app_config->device.cpu_arch == "some_cpu_arch");
+        }
+
+        SECTION("realm_app_config_set_device_name()") {
+            realm_app_config_set_device_name(app_config.get(), "some_device_name");
+            CHECK(app_config->device.device_name == "some_device_name");
+        }
+
+        SECTION("realm_app_config_set_device_version()") {
+            realm_app_config_set_device_version(app_config.get(), "some_device_version");
+            CHECK(app_config->device.device_version == "some_device_version");
+        }
+
+        SECTION("realm_app_config_set_framework_name()") {
+            realm_app_config_set_framework_name(app_config.get(), "some_framework_name");
+            CHECK(app_config->device.framework_name == "some_framework_name");
+        }
+
+        SECTION("realm_app_config_set_framework_version()") {
+            realm_app_config_set_framework_version(app_config.get(), "some_framework_version");
+            CHECK(app_config->device.framework_version == "some_framework_version");
+        }
+    }
 }
 
 namespace {

--- a/test/object-store/sync/app.cpp
+++ b/test/object-store/sync/app.cpp
@@ -2007,23 +2007,6 @@ constexpr size_t minus_25_percent(size_t val)
     return val * .75 - 10;
 }
 
-static void set_app_config_defaults(app::App::Config& app_config,
-                                    const std::shared_ptr<app::GenericNetworkTransport>& transport)
-{
-    if (!app_config.transport)
-        app_config.transport = transport;
-    if (app_config.platform.empty())
-        app_config.platform = "Object Store Test Platform";
-    if (app_config.platform_version.empty())
-        app_config.platform_version = "Object Store Test Platform Version";
-    if (app_config.sdk_version.empty())
-        app_config.sdk_version = "SDK Version";
-    if (app_config.app_id.empty())
-        app_config.app_id = "app_id";
-    if (!app_config.local_app_version)
-        app_config.local_app_version.emplace("A Local App Version");
-}
-
 TEST_CASE("app: sync integration", "[sync][app]") {
     auto logger = std::make_unique<util::StderrLogger>(realm::util::Logger::Level::TEST_ENABLE_SYNC_LOGGING_LEVEL);
 
@@ -3240,7 +3223,13 @@ private:
                                 {"appVersion", "A Local App Version"},
                                 {"platform", "Object Store Test Platform"},
                                 {"platformVersion", "Object Store Test Platform Version"},
+                                {"sdk", "SDK Name"},
                                 {"sdkVersion", "SDK Version"},
+                                {"cpuArch", "CPU Arch"},
+                                {"deviceName", "Device Name"},
+                                {"deviceVersion", "Device Version"},
+                                {"frameworkName", "Framework Name"},
+                                {"frameworkVersion", "Framework Version"},
                                 {"coreVersion", REALM_VERSION_STRING}}}}));
 
         CHECK(request.timeout_ms == 60000);

--- a/test/object-store/util/baas_admin_api.hpp
+++ b/test/object-store/util/baas_admin_api.hpp
@@ -238,9 +238,8 @@ inline app::App::Config get_config(Factory factory, const AppSession& app_sessio
             util::none,
             util::Optional<std::string>("A Local App Version"),
             util::none,
-            "Object Store Platform Tests",
-            "Object Store Platform Version Blah",
-            "An sdk version"};
+            {"Object Store Platform Tests", "Object Store Platform Version Blah", "An sdk version", "An sdk name",
+             "A cpu arch", "A device name", "A device version", "A framework name", "A framework version"}};
 }
 
 } // namespace realm

--- a/test/object-store/util/test_file.cpp
+++ b/test/object-store/util/test_file.cpp
@@ -258,24 +258,34 @@ std::error_code wait_for_download(Realm& realm, std::chrono::seconds timeout)
     return wait_for_session(realm, &SyncSession::wait_for_download_completion, timeout);
 }
 
-namespace {
 void set_app_config_defaults(app::App::Config& app_config,
                              const std::shared_ptr<app::GenericNetworkTransport>& transport)
 {
     if (!app_config.transport)
         app_config.transport = transport;
-    if (app_config.platform.empty())
-        app_config.platform = "Object Store Test Platform";
-    if (app_config.platform_version.empty())
-        app_config.platform_version = "Object Store Test Platform Version";
-    if (app_config.sdk_version.empty())
-        app_config.sdk_version = "SDK Version";
+    if (app_config.device.platform.empty())
+        app_config.device.platform = "Object Store Test Platform";
+    if (app_config.device.platform_version.empty())
+        app_config.device.platform_version = "Object Store Test Platform Version";
+    if (app_config.device.sdk_version.empty())
+        app_config.device.sdk_version = "SDK Version";
+    if (app_config.device.sdk.empty())
+        app_config.device.sdk = "SDK Name";
+    if (app_config.device.cpu_arch.empty())
+        app_config.device.cpu_arch = "CPU Arch";
+    if (app_config.device.device_name.empty())
+        app_config.device.device_name = "Device Name";
+    if (app_config.device.device_version.empty())
+        app_config.device.device_version = "Device Version";
+    if (app_config.device.framework_name.empty())
+        app_config.device.framework_name = "Framework Name";
+    if (app_config.device.framework_version.empty())
+        app_config.device.framework_version = "Framework Version";
     if (app_config.app_id.empty())
         app_config.app_id = "app_id";
     if (!app_config.local_app_version)
         app_config.local_app_version.emplace("A Local App Version");
 }
-} // anonymous namespace
 
 // MARK: - TestAppSession
 

--- a/test/object-store/util/test_file.cpp
+++ b/test/object-store/util/test_file.cpp
@@ -263,24 +263,24 @@ void set_app_config_defaults(app::App::Config& app_config,
 {
     if (!app_config.transport)
         app_config.transport = transport;
-    if (app_config.device.platform.empty())
-        app_config.device.platform = "Object Store Test Platform";
-    if (app_config.device.platform_version.empty())
-        app_config.device.platform_version = "Object Store Test Platform Version";
-    if (app_config.device.sdk_version.empty())
-        app_config.device.sdk_version = "SDK Version";
-    if (app_config.device.sdk.empty())
-        app_config.device.sdk = "SDK Name";
-    if (app_config.device.cpu_arch.empty())
-        app_config.device.cpu_arch = "CPU Arch";
-    if (app_config.device.device_name.empty())
-        app_config.device.device_name = "Device Name";
-    if (app_config.device.device_version.empty())
-        app_config.device.device_version = "Device Version";
-    if (app_config.device.framework_name.empty())
-        app_config.device.framework_name = "Framework Name";
-    if (app_config.device.framework_version.empty())
-        app_config.device.framework_version = "Framework Version";
+    if (app_config.device_info.platform.empty())
+        app_config.device_info.platform = "Object Store Test Platform";
+    if (app_config.device_info.platform_version.empty())
+        app_config.device_info.platform_version = "Object Store Test Platform Version";
+    if (app_config.device_info.sdk_version.empty())
+        app_config.device_info.sdk_version = "SDK Version";
+    if (app_config.device_info.sdk.empty())
+        app_config.device_info.sdk = "SDK Name";
+    if (app_config.device_info.cpu_arch.empty())
+        app_config.device_info.cpu_arch = "CPU Arch";
+    if (app_config.device_info.device_name.empty())
+        app_config.device_info.device_name = "Device Name";
+    if (app_config.device_info.device_version.empty())
+        app_config.device_info.device_version = "Device Version";
+    if (app_config.device_info.framework_name.empty())
+        app_config.device_info.framework_name = "Framework Name";
+    if (app_config.device_info.framework_version.empty())
+        app_config.device_info.framework_version = "Framework Version";
     if (app_config.app_id.empty())
         app_config.app_id = "app_id";
     if (!app_config.local_app_version)

--- a/test/object-store/util/test_file.hpp
+++ b/test/object-store/util/test_file.hpp
@@ -274,6 +274,9 @@ inline TestSyncManager::TestSyncManager(realm::SyncManager::MetadataMode mode)
 std::error_code wait_for_upload(realm::Realm& realm, std::chrono::seconds timeout = std::chrono::seconds(60));
 std::error_code wait_for_download(realm::Realm& realm, std::chrono::seconds timeout = std::chrono::seconds(60));
 
+void set_app_config_defaults(app::App::Config& app_config,
+                             const std::shared_ptr<app::GenericNetworkTransport>& transport);
+
 #endif // REALM_ENABLE_SYNC
 
 #endif

--- a/test/object-store/util/test_file.hpp
+++ b/test/object-store/util/test_file.hpp
@@ -274,8 +274,8 @@ inline TestSyncManager::TestSyncManager(realm::SyncManager::MetadataMode mode)
 std::error_code wait_for_upload(realm::Realm& realm, std::chrono::seconds timeout = std::chrono::seconds(60));
 std::error_code wait_for_download(realm::Realm& realm, std::chrono::seconds timeout = std::chrono::seconds(60));
 
-void set_app_config_defaults(app::App::Config& app_config,
-                             const std::shared_ptr<app::GenericNetworkTransport>& transport);
+void set_app_config_defaults(realm::app::App::Config& app_config,
+                             const std::shared_ptr<realm::app::GenericNetworkTransport>& transport);
 
 #endif // REALM_ENABLE_SYNC
 


### PR DESCRIPTION
## What, How & Why?
Add new sync connection parameters that allow the sdk to indicate additional metrics information regarding the device where realm is running.

SDK breaking changes:
* Device information in sync connection parameters was moved into a new `device` structure in App::Config
* `sdk` is now a required field in the `device` structure in App::Config

Fixes #6029 

## ☑️ ToDos
* [X] 📝 Changelog update
* [X] 🚦 Tests (or not relevant)
* [X] C-API, if public C++ API changed.
