### PR TITLE
[C-API] fix refresh and compact

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,8 @@
 
 ### Fixed
 * <How do the end-user experience this issue? what was the impact?> ([#????](https://github.com/realm/realm-core/issues/????), since v?.?.?)
-* None.
+* Fixed `realm_refresh` so it uses an argument value for the refresh result and returns any error conditions as return value. ([#6068](https://github.com/realm/realm-core/pull/6068))
+* Fixed `realm_compact` to actually do the compaction even if the caller did not provide a `did_compact` argument.
  
 ### Breaking changes
 * ObjectId constructor made explicit, so no more implicit conversions from const char* or array of 12 bytes. It now accepts a StringData. ([#6059](https://github.com/realm/realm-core/pull/6059))

--- a/src/realm.h
+++ b/src/realm.h
@@ -1121,7 +1121,7 @@ RLM_API realm_refresh_callback_token_t* realm_add_realm_refresh_callback(realm_t
  * @return True if the realm was successfully refreshed and no exceptions were
  *         thrown.
  */
-RLM_API bool realm_refresh(realm_t*);
+RLM_API bool realm_refresh(realm_t*, bool* did_refresh);
 
 /**
  * Produce a frozen view of this realm.

--- a/src/realm.h
+++ b/src/realm.h
@@ -1120,8 +1120,7 @@ RLM_API realm_refresh_callback_token_t* realm_add_realm_refresh_callback(realm_t
  *
  * This calls `advance_read()` at the Core layer.
  *
- * @return True if the realm was successfully refreshed and no exceptions were
- *         thrown.
+ * @return True if no exceptions are thrown, false otherwise.
  */
 RLM_API bool realm_refresh(realm_t*, bool* did_refresh);
 
@@ -1135,7 +1134,7 @@ RLM_API realm_t* realm_freeze(const realm_t*);
 /**
  * Vacuum the free space from the realm file, reducing its file size.
  *
- * @return True if compaction was successful and no exceptions were thrown.
+ * @return True if no exceptions are thrown, false otherwise.
  */
 RLM_API bool realm_compact(realm_t*, bool* did_compact);
 

--- a/src/realm/object-store/c_api/realm.cpp
+++ b/src/realm/object-store/c_api/realm.cpp
@@ -251,10 +251,15 @@ RLM_API realm_refresh_callback_token_t* realm_add_realm_refresh_callback(realm_t
     return new realm_refresh_callback_token(realm, refresh_callbacks.add(*latest_snapshot_version, std::move(func)));
 }
 
-RLM_API bool realm_refresh(realm_t* realm)
+RLM_API bool realm_refresh(realm_t* realm, bool* did_refresh)
 {
     return wrap_err([&]() {
-        (*realm)->refresh();
+        bool result = (*realm)->refresh();
+        if (did_refresh) {
+            *did_refresh = result;
+        }
+
+        // the call succeeded
         return true;
     });
 }
@@ -271,8 +276,12 @@ RLM_API bool realm_compact(realm_t* realm, bool* did_compact)
 {
     return wrap_err([&]() {
         auto& p = **realm;
-        if (did_compact)
-            *did_compact = p.compact();
+        bool result = p.compact();
+        if (did_compact) {
+            *did_compact = result;
+        }
+
+        // the call succeeded
         return true;
     });
 }

--- a/test/object-store/c_api/c_api.c
+++ b/test/object-store/c_api/c_api.c
@@ -234,7 +234,7 @@ int realm_c_api_tests(const char* file)
     assert(num_bars == 0);
 
     bool did_refresh = false;
-    assert(realm_refresh(realm, &did_refresh))
+    assert(realm_refresh(realm, &did_refresh));
     CHECK_ERROR();
     assert(did_refresh);
 

--- a/test/object-store/c_api/c_api.c
+++ b/test/object-store/c_api/c_api.c
@@ -236,7 +236,7 @@ int realm_c_api_tests(const char* file)
     bool did_refresh = false;
     assert(realm_refresh(realm, &did_refresh));
     CHECK_ERROR();
-    assert(did_refresh);
+    assert(!did_refresh);
 
     realm_object_create(realm, foo_info.key);
     realm_error_t err;

--- a/test/object-store/c_api/c_api.c
+++ b/test/object-store/c_api/c_api.c
@@ -233,8 +233,10 @@ int realm_c_api_tests(const char* file)
     CHECK_ERROR();
     assert(num_bars == 0);
 
-    assert(realm_refresh(realm));
+    bool did_refresh = false;
+    assert(realm_refresh(realm, &did_refresh))
     CHECK_ERROR();
+    assert(did_refresh);
 
     realm_object_create(realm, foo_info.key);
     realm_error_t err;

--- a/test/object-store/c_api/c_api.cpp
+++ b/test/object-store/c_api/c_api.cpp
@@ -1225,7 +1225,7 @@ TEST_CASE("C API", "[c_api]") {
         realm_commit(realm);
 
 
-        realm_refresh(realm2.get());
+        realm_refresh(realm2.get(), nullptr);
         CHECK(realm_refresh_callback_called);
     }
 
@@ -1247,7 +1247,7 @@ TEST_CASE("C API", "[c_api]") {
         realm_begin_write(realm);
         realm_commit(realm);
 
-        realm_refresh(realm2.get());
+        realm_refresh(realm2.get(), nullptr);
         CHECK(counter.load() == 2);
     }
 
@@ -1267,7 +1267,7 @@ TEST_CASE("C API", "[c_api]") {
             },
             &realm_refresh_callback_called, [](void*) {}));
 
-        realm_refresh(realm);
+        realm_refresh(realm, nullptr);
         CHECK(!realm_refresh_callback_called);
     }
 
@@ -1287,7 +1287,7 @@ TEST_CASE("C API", "[c_api]") {
             },
             &realm_refresh_callback_called, [](void*) {}));
 
-        realm_refresh(realm);
+        realm_refresh(realm, nullptr);
         CHECK(token == nullptr);
         CHECK(!realm_refresh_callback_called);
     }
@@ -1392,7 +1392,7 @@ TEST_CASE("C API", "[c_api]") {
         checked(realm_begin_write(realm));
         f();
         checked(realm_commit(realm));
-        checked(realm_refresh(realm));
+        checked(realm_refresh(realm, nullptr));
     };
 
     bool found = false;
@@ -2201,7 +2201,7 @@ TEST_CASE("C API", "[c_api]") {
                 CHECK(checked(realm_set_value(obj1.get(), info_int.key, rlm_int_val(10), false)));
                 CHECK(checked(realm_set_value(obj2.get(), info_int.key, rlm_int_val(11), false)));
                 checked(realm_commit(realm));
-                checked(realm_refresh(realm));
+                checked(realm_refresh(realm, nullptr));
 
                 size_t count = 0;
                 realm_value_t arg_data[1] = {rlm_str_val("Test")};
@@ -2978,7 +2978,7 @@ TEST_CASE("C API", "[c_api]") {
                 auto require_change = [&]() {
                     auto token = cptr_checked(
                         realm_list_add_notification_callback(strings.get(), &state, nullptr, nullptr, on_change));
-                    checked(realm_refresh(realm));
+                    checked(realm_refresh(realm, nullptr));
                     return token;
                 };
 
@@ -3035,7 +3035,7 @@ TEST_CASE("C API", "[c_api]") {
                     realm_key_path_array_t key_path_array = {1, key_path_bar_strings};
                     auto token = cptr_checked(realm_list_add_notification_callback(bars.get(), &state, nullptr,
                                                                                    &key_path_array, on_change));
-                    checked(realm_refresh(realm));
+                    checked(realm_refresh(realm, nullptr));
 
                     state.called = false;
                     write([&]() {
@@ -3497,7 +3497,7 @@ TEST_CASE("C API", "[c_api]") {
                 auto require_change = [&]() {
                     auto token = cptr_checked(
                         realm_set_add_notification_callback(strings.get(), &state, nullptr, nullptr, on_change));
-                    checked(realm_refresh(realm));
+                    checked(realm_refresh(realm, nullptr));
                     return token;
                 };
 
@@ -4014,7 +4014,7 @@ TEST_CASE("C API", "[c_api]") {
                 auto require_change = [&]() {
                     auto token = cptr_checked(realm_dictionary_add_notification_callback(
                         strings.get(), &state, nullptr, nullptr, on_change));
-                    checked(realm_refresh(realm));
+                    checked(realm_refresh(realm, nullptr));
                     return token;
                 };
 
@@ -4081,7 +4081,7 @@ TEST_CASE("C API", "[c_api]") {
             auto require_change = [&]() {
                 auto token =
                     cptr(realm_object_add_notification_callback(obj1.get(), &state, nullptr, nullptr, on_change));
-                checked(realm_refresh(realm));
+                checked(realm_refresh(realm, nullptr));
                 return token;
             };
 
@@ -4126,7 +4126,7 @@ TEST_CASE("C API", "[c_api]") {
                 realm_key_path_array_t key_path_array = {1, key_path_origin_value};
                 auto token = cptr(
                     realm_object_add_notification_callback(obj1.get(), &state, nullptr, &key_path_array, on_change));
-                checked(realm_refresh(realm));
+                checked(realm_refresh(realm, nullptr));
                 state.called = false;
                 write([&]() {
                     checked(realm_set_value(obj1.get(), foo_int_key, rlm_int_val(999), false));
@@ -4500,7 +4500,7 @@ TEST_CASE("C API: convert", "[c_api]") {
         CHECK(obj1);
         CHECK(checked(realm_set_value(obj1.get(), foo_str_col_key, rlm_str_val("Hello, World!"), false)));
         checked(realm_commit(realm));
-        checked(realm_refresh(realm));
+        checked(realm_refresh(realm, nullptr));
 
         size_t foo_count;
         CHECK(checked(realm_get_num_objects(realm, class_foo.key, &foo_count)));
@@ -5124,7 +5124,7 @@ TEST_CASE("app: flx-sync basic tests", "[c_api][flx][sync]") {
 
         wait_for_download(*realm);
         {
-            realm_refresh(&c_wrap_realm);
+            realm_refresh(&c_wrap_realm, nullptr);
             auto results = realm_object_find_all(&c_wrap_realm, table_info.key);
             size_t count = 0;
             realm_results_count(results, &count);
@@ -5153,7 +5153,7 @@ TEST_CASE("app: flx-sync basic tests", "[c_api][flx][sync]") {
         }
 
         {
-            realm_refresh(&c_wrap_realm);
+            realm_refresh(&c_wrap_realm, nullptr);
             auto results = realm_object_find_all(&c_wrap_realm, table_info.key);
             size_t count = 0;
             realm_results_count(results, &count);
@@ -5194,7 +5194,7 @@ TEST_CASE("app: flx-sync basic tests", "[c_api][flx][sync]") {
         }
 
         {
-            realm_refresh(&c_wrap_realm);
+            realm_refresh(&c_wrap_realm, nullptr);
             auto results = realm_object_find_all(&c_wrap_realm, table_info.key);
             size_t count = 0;
             realm_results_count(results, &count);
@@ -5221,7 +5221,7 @@ TEST_CASE("app: flx-sync basic tests", "[c_api][flx][sync]") {
         }
 
         {
-            realm_refresh(&c_wrap_realm);
+            realm_refresh(&c_wrap_realm, nullptr);
             auto results = realm_object_find_all(&c_wrap_realm, table_info.key);
             size_t count = std::numeric_limits<std::size_t>::max();
             realm_results_count(results, &count);
@@ -5276,7 +5276,7 @@ TEST_CASE("app: flx-sync basic tests", "[c_api][flx][sync]") {
         }
 
         {
-            realm_refresh(&c_wrap_realm);
+            realm_refresh(&c_wrap_realm, nullptr);
             auto results = realm_object_find_all(&c_wrap_realm, table_info.key);
             size_t count = std::numeric_limits<std::size_t>::max();
             realm_results_count(results, &count);


### PR DESCRIPTION
This fixes `realm_refresh` so it properly returns the result of the operation and also properly returns error conditions
This also fixes `realm_compact` to actually do a compaction even if the caller does not care for the result by not providing a `did_compact` argument.