### PR TITLE
Add support for Android using C++SDK

### DIFF
--- a/src/realm/util/basic_system_errors.cpp
+++ b/src/realm/util/basic_system_errors.cpp
@@ -65,7 +65,7 @@ std::string system_category::message(int value) const
         }
     }
 
-#elif !REALM_ANDROID && _GNU_SOURCE // GNU specific version
+#elif (!REALM_ANDROID && _GNU_SOURCE) || (defined(__USE_GNU) && __ANDROID_API__ >= 23)
 
     {
         char* msg = nullptr;

--- a/src/realm/util/http.cpp
+++ b/src/realm/util/http.cpp
@@ -158,7 +158,7 @@ bool HTTPParserBase::parse_header_line(size_t len)
         return false;
     }
 
-    if (key == "Content-Length") {
+    if (key == "Content-Length" || key == "content-length") {
         if (value.size() == 0) {
             // We consider the empty Content-Length to mean 0.
             // A warning is logged.


### PR DESCRIPTION
## What, How & Why?
The C++ SDK with reuse the networking stack that sync relies on when using Android. I found a few gotchas along the way:

- HTTP parser looks for "Content-Length" in a response, but the `realm.mongodb.com` endpoint returns this as all lower case so this needed to be handled.
- `basic_system_errors` required additional header guards to let `strerror_r ` use the correct branch.
