### PR TITLE
Add validator to local writes that happen during a bootstrap

### DIFF
--- a/src/realm/exceptions.hpp
+++ b/src/realm/exceptions.hpp
@@ -176,6 +176,11 @@ public:
     NoSubscriptionForWrite(const std::string& msg);
 };
 
+class WriteNotAllowed : public std::runtime_error {
+public:
+    WriteNotAllowed(const std::string& msg);
+};
+
 namespace query_parser {
 
 /// Exception thrown when parsing fails due to invalid syntax.
@@ -397,6 +402,11 @@ inline InvalidPathError::InvalidPathError(const std::string& msg)
 }
 
 inline NoSubscriptionForWrite::NoSubscriptionForWrite(const std::string& msg)
+    : std::runtime_error(msg)
+{
+}
+
+inline WriteNotAllowed::WriteNotAllowed(const std::string& msg)
     : std::runtime_error(msg)
 {
 }

--- a/src/realm/object-store/sync/sync_session.cpp
+++ b/src/realm/object-store/sync/sync_session.cpp
@@ -276,7 +276,7 @@ SyncSession::SyncSession(SyncClient& client, std::shared_ptr<DB> db, const Realm
                     if (table.get_table_type() != Table::Type::TopLevel) {
                         return;
                     }
-                    auto object_class_name = Group::table_name_to_class_name(table.get_name());
+                    auto object_class_name = table.get_class_name();
                     if (tables.find(object_class_name) == tables.end()) {
                         throw NoSubscriptionForWrite(util::format(
                             "Cannot write to class %1 when no flexible sync subscription has been created.",

--- a/src/realm/replication.hpp
+++ b/src/realm/replication.hpp
@@ -356,8 +356,7 @@ protected:
 
     //@{
 
-    /// do_initiate_transact() is called by initiate_transact(), and likewise
-    /// for do_prepare_commit()
+    /// do_initiate_transact() is called by initiate_transact()
     ///
     /// With respect to exception safety, the Replication implementation has two
     /// options: It can prepare to accept the accumulated changeset in

--- a/src/realm/sync/instruction_replication.cpp
+++ b/src/realm/sync/instruction_replication.cpp
@@ -718,9 +718,9 @@ void SyncReplication::unsupported_instruction() const
 bool SyncReplication::select_table(const Table& table, util::Optional<PrimaryKey> key)
 {
     if (is_short_circuited()) {
-        if (m_bootstrap_write_validator && key.has_value()) {
+        if (m_bootstrap_write_validator && key) {
             // Register bootstrap object.
-            m_bootstrap_write_validator->add_bootstrap_object(table, key.value());
+            m_bootstrap_write_validator->add_bootstrap_object(table, *key);
         }
         return false;
     }
@@ -733,9 +733,9 @@ bool SyncReplication::select_table(const Table& table, util::Optional<PrimaryKey
         return false;
     }
 
-    if (m_bootstrap_write_validator && key.has_value()) {
+    if (m_bootstrap_write_validator && key) {
         // Validate modification to local object.
-        m_bootstrap_write_validator->validate_local_write(table, key.value());
+        m_bootstrap_write_validator->validate_local_write(table, *key);
     }
 
     m_last_class_name = emit_class_name(table);

--- a/src/realm/sync/noinst/client_history_impl.hpp
+++ b/src/realm/sync/noinst/client_history_impl.hpp
@@ -401,6 +401,8 @@ private:
 
     util::UniqueFunction<timestamp_type()> m_local_origin_timestamp_source = generate_changeset_timestamp;
 
+    bool m_bootstrap_in_progress = false;
+
     void initialize(DB& db) noexcept
     {
         REALM_ASSERT(!m_db);

--- a/src/realm/sync/subscriptions.hpp
+++ b/src/realm/sync/subscriptions.hpp
@@ -148,7 +148,7 @@ public:
     // Returns a future that will resolve either with an error status if this subscription set encounters an
     // error, or resolves when the subscription set reaches at least that state. It's possible for a subscription
     // set to skip a state (i.e. go from Pending to Complete or Pending to Superseded), and the future value
-    // will the the state it actually reached.
+    // will be the state it actually reached.
     util::Future<State> get_state_change_notification(State notify_when) const;
     void get_state_change_notification(
         State notify_when, util::UniqueFunction<void(util::Optional<State>, util::Optional<Status>)> callback) const;


### PR DESCRIPTION
## What, How & Why?
History can diverge in flexible sync if writes occur during bootstraps. Only writes to objects that come into/go out of view are affected, so we disallow it. This happens because each side (client & server) sees their write as the most recent one. `WriteNotAllowed` will be thrown in such cases.
Fixes #5804.

## ☑️ ToDos
* [ ] 📝 Changelog update
* [ ] 🚦 Tests (or not relevant)
* [ ] ~~C-API, if public C++ API changed.~~
