### PR TITLE
Updated namespaces for sync/network files

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,7 +18,7 @@
 -----------
 
 ### Internals
-* Updates for upcoming Platform Networking feature, including new SyncSocketProvider class. ([PR #6096](https://github.com/realm/realm-core/pull/6096))
+* Updates for upcoming Platform Networking feature, including new SyncSocketProvider class. ([PR #6096](https://github.com/realm/realm-core/pull/6096), [PR #6109](https://github.com/realm/realm-core/pull/6109))
 
 ----------------------------------------------
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,7 +18,8 @@
 -----------
 
 ### Internals
-* Updates for upcoming Platform Networking feature, including new SyncSocketProvider class. ([PR #6096](https://github.com/realm/realm-core/pull/6096), [PR #6109](https://github.com/realm/realm-core/pull/6109))
+* Updates for upcoming Platform Networking feature, including new SyncSocketProvider class. ([PR #6096](https://github.com/realm/realm-core/pull/6096))
+* Updated namespaces for files moved to realm/sync/network ([PR #6109](https://github.com/realm/realm-core/pull/6109))
 
 ----------------------------------------------
 

--- a/src/realm/object-store/sync/app.cpp
+++ b/src/realm/object-store/sync/app.cpp
@@ -917,7 +917,7 @@ void App::handle_possible_redirect_response(Request&& request, const Response& r
                                             UniqueFunction<void(const Response&)>&& completion)
 {
     // If the response contains a redirection, then process it
-    if (util::HTTPStatus(response.http_status_code) == util::HTTPStatus::MovedPermanently) {
+    if (sync::HTTPStatus(response.http_status_code) == sync::HTTPStatus::MovedPermanently) {
         handle_redirect_response(std::move(request), response, std::move(completion));
     }
     else {

--- a/src/realm/object-store/sync/sync_session.cpp
+++ b/src/realm/object-store/sync/sync_session.cpp
@@ -598,7 +598,7 @@ void SyncSession::handle_error(SyncError error)
         // is disabled. In this scenario we attempt an automatic token refresh and if that succeeds continue as
         // normal. If the refresh request also fails with 401 then we need to stop retrying and pass along the error;
         // see handle_refresh().
-        if (error_code == util::websocket::make_error_code(util::websocket::Error::bad_response_401_unauthorized)) {
+        if (error_code == sync::websocket::make_error_code(sync::websocket::Error::bad_response_401_unauthorized)) {
             if (auto u = user()) {
                 u->refresh_custom_data(handle_refresh(shared_from_this()));
                 return;

--- a/src/realm/sync/client.cpp
+++ b/src/realm/sync/client.cpp
@@ -1607,7 +1607,7 @@ ClientImpl::Connection::Connection(ClientImpl& client, connection_ident_type ide
             // Connection object may be destroyed now.
         }
     };
-    m_on_idle = util::network::Trigger{client.get_service(), std::move(handler)}; // Throws
+    m_on_idle = network::Trigger{client.get_service(), std::move(handler)}; // Throws
 }
 
 inline connection_ident_type ClientImpl::Connection::get_ident() const noexcept

--- a/src/realm/sync/config.cpp
+++ b/src/realm/sync/config.cpp
@@ -27,7 +27,7 @@
 namespace realm {
 
 // sync defines its own copy of port_type to avoid depending on network.hpp, but they should be the same.
-static_assert(std::is_same_v<sync::port_type, util::network::Endpoint::port_type>);
+static_assert(std::is_same_v<sync::port_type, sync::network::Endpoint::port_type>);
 
 using ProtocolError = realm::sync::ProtocolError;
 

--- a/src/realm/sync/network/default_socket.cpp
+++ b/src/realm/sync/network/default_socket.cpp
@@ -4,10 +4,10 @@
 #include <realm/sync/network/network_ssl.hpp>
 #include <realm/sync/network/websocket.hpp>
 
-namespace realm::util::websocket {
+namespace realm::sync::websocket {
 
 namespace {
-class EZSocketImpl final : public EZSocket, public websocket::Config {
+class EZSocketImpl final : public EZSocket, public Config {
 public:
     EZSocketImpl(EZConfig& config, EZObserver& observer, EZEndpoint&& endpoint)
         : m_logger_ptr{config.logger}
@@ -44,7 +44,7 @@ private:
         return m_random;
     }
 
-    void websocket_handshake_completion_handler(const util::HTTPHeaders& headers) override
+    void websocket_handshake_completion_handler(const HTTPHeaders& headers) override
     {
         const std::string empty;
         auto it = headers.find("Sec-WebSocket-Protocol");
@@ -60,7 +60,7 @@ private:
         m_logger.error("Writing failed: %1", ec.message()); // Throws
         m_observer.websocket_read_or_write_error_handler(ec);
     }
-    void websocket_handshake_error_handler(std::error_code ec, const util::HTTPHeaders*,
+    void websocket_handshake_error_handler(std::error_code ec, const HTTPHeaders*,
                                            const std::string_view* body) override
     {
         m_observer.websocket_handshake_error_handler(ec, body);
@@ -79,9 +79,9 @@ private:
     }
 
     void initiate_resolve();
-    void handle_resolve(std::error_code, util::network::Endpoint::List);
-    void initiate_tcp_connect(util::network::Endpoint::List, std::size_t);
-    void handle_tcp_connect(std::error_code, util::network::Endpoint::List, std::size_t);
+    void handle_resolve(std::error_code, network::Endpoint::List);
+    void initiate_tcp_connect(network::Endpoint::List, std::size_t);
+    void handle_tcp_connect(std::error_code, network::Endpoint::List, std::size_t);
     void initiate_http_tunnel();
     void handle_http_tunnel(std::error_code);
     void initiate_websocket_or_ssl_handshake();
@@ -99,19 +99,19 @@ private:
     const std::shared_ptr<util::Logger> m_logger_ptr;
     util::Logger& m_logger;
     std::mt19937_64& m_random;
-    util::network::Service& m_service;
+    network::Service& m_service;
     std::string m_user_agent;
 
     EZObserver& m_observer;
 
     const EZEndpoint m_endpoint;
-    util::Optional<util::network::Resolver> m_resolver;
-    util::Optional<util::network::Socket> m_socket;
-    util::Optional<util::network::ssl::Context> m_ssl_context;
-    util::Optional<util::network::ssl::Stream> m_ssl_stream;
-    util::network::ReadAheadBuffer m_read_ahead_buffer;
-    util::websocket::Socket m_websocket;
-    util::Optional<util::HTTPClient<EZSocketImpl>> m_proxy_client;
+    util::Optional<network::Resolver> m_resolver;
+    util::Optional<network::Socket> m_socket;
+    util::Optional<network::ssl::Context> m_ssl_context;
+    util::Optional<network::ssl::Stream> m_ssl_stream;
+    network::ReadAheadBuffer m_read_ahead_buffer;
+    websocket::Socket m_websocket;
+    util::Optional<HTTPClient<EZSocketImpl>> m_proxy_client;
 };
 
 
@@ -162,8 +162,8 @@ void EZSocketImpl::initiate_resolve()
 
     m_logger.detail("Resolving '%1:%2'", address, port); // Throws
 
-    util::network::Resolver::Query query(address, util::to_string(port)); // Throws
-    auto handler = [this](std::error_code ec, util::network::Endpoint::List endpoints) {
+    network::Resolver::Query query(address, util::to_string(port)); // Throws
+    auto handler = [this](std::error_code ec, network::Endpoint::List endpoints) {
         // If the operation is aborted, the connection object may have been
         // destroyed.
         if (ec != util::error::operation_aborted)
@@ -174,7 +174,7 @@ void EZSocketImpl::initiate_resolve()
 }
 
 
-void EZSocketImpl::handle_resolve(std::error_code ec, util::network::Endpoint::List endpoints)
+void EZSocketImpl::handle_resolve(std::error_code ec, network::Endpoint::List endpoints)
 {
     if (ec) {
         m_logger.error("Failed to resolve '%1:%2': %3", m_endpoint.address, m_endpoint.port, ec.message()); // Throws
@@ -186,11 +186,11 @@ void EZSocketImpl::handle_resolve(std::error_code ec, util::network::Endpoint::L
 }
 
 
-void EZSocketImpl::initiate_tcp_connect(util::network::Endpoint::List endpoints, std::size_t i)
+void EZSocketImpl::initiate_tcp_connect(network::Endpoint::List endpoints, std::size_t i)
 {
     REALM_ASSERT(i < endpoints.size());
 
-    util::network::Endpoint ep = *(endpoints.begin() + i);
+    network::Endpoint ep = *(endpoints.begin() + i);
     std::size_t n = endpoints.size();
     m_socket.emplace(m_service); // Throws
     m_socket->async_connect(ep, [this, endpoints = std::move(endpoints), i](std::error_code ec) mutable {
@@ -203,10 +203,10 @@ void EZSocketImpl::initiate_tcp_connect(util::network::Endpoint::List endpoints,
 }
 
 
-void EZSocketImpl::handle_tcp_connect(std::error_code ec, util::network::Endpoint::List endpoints, std::size_t i)
+void EZSocketImpl::handle_tcp_connect(std::error_code ec, network::Endpoint::List endpoints, std::size_t i)
 {
     REALM_ASSERT(i < endpoints.size());
-    const util::network::Endpoint& ep = *(endpoints.begin() + i);
+    const network::Endpoint& ep = *(endpoints.begin() + i);
     if (ec) {
         m_logger.error("Failed to connect to endpoint '%1:%2': %3", ep.address(), ep.port(),
                        ec.message()); // Throws
@@ -222,7 +222,7 @@ void EZSocketImpl::handle_tcp_connect(std::error_code ec, util::network::Endpoin
     }
 
     REALM_ASSERT(m_socket);
-    util::network::Endpoint ep_2 = m_socket->local_endpoint();
+    network::Endpoint ep_2 = m_socket->local_endpoint();
     m_logger.info("Connected to endpoint '%1:%2' (from '%3:%4')", ep.address(), ep.port(), ep_2.address(),
                   ep_2.port()); // Throws
 
@@ -263,7 +263,7 @@ void EZSocketImpl::initiate_http_tunnel()
         if (response.status != HTTPStatus::Ok) {
             m_logger.error("Proxy server returned response '%1 %2'", response.status, response.reason); // Throws
             std::error_code ec2 =
-                util::websocket::Error::bad_response_unexpected_status_code; // FIXME: is this the right error?
+                websocket::Error::bad_response_unexpected_status_code; // FIXME: is this the right error?
             m_observer.websocket_connect_error_handler(ec2);                 // Throws
             return;
         }
@@ -276,7 +276,7 @@ void EZSocketImpl::initiate_http_tunnel()
 
 void EZSocketImpl::initiate_ssl_handshake()
 {
-    using namespace util::network::ssl;
+    using namespace network::ssl;
 
     if (!m_ssl_context) {
         m_ssl_context.emplace(); // Throws
@@ -336,7 +336,7 @@ void EZSocketImpl::handle_ssl_handshake(std::error_code ec)
 
 void EZSocketImpl::initiate_websocket_handshake()
 {
-    auto headers = util::HTTPHeaders(m_endpoint.headers.begin(), m_endpoint.headers.end());
+    auto headers = HTTPHeaders(m_endpoint.headers.begin(), m_endpoint.headers.end());
     headers["User-Agent"] = m_user_agent;
 
     // Compute the value of the "Host" header.
@@ -356,4 +356,4 @@ std::unique_ptr<EZSocket> EZSocketFactory::connect(EZObserver* observer, EZEndpo
     return std::make_unique<EZSocketImpl>(m_config, *observer, std::move(endpoint));
 }
 
-} // namespace realm::util::websocket
+} // namespace realm::sync::websocket

--- a/src/realm/sync/network/default_socket.cpp
+++ b/src/realm/sync/network/default_socket.cpp
@@ -263,7 +263,7 @@ void EZSocketImpl::initiate_http_tunnel()
         if (response.status != HTTPStatus::Ok) {
             m_logger.error("Proxy server returned response '%1 %2'", response.status, response.reason); // Throws
             std::error_code ec2 =
-                websocket::Error::bad_response_unexpected_status_code; // FIXME: is this the right error?
+                websocket::Error::bad_response_unexpected_status_code;       // FIXME: is this the right error?
             m_observer.websocket_connect_error_handler(ec2);                 // Throws
             return;
         }

--- a/src/realm/sync/network/default_socket.hpp
+++ b/src/realm/sync/network/default_socket.hpp
@@ -1,5 +1,4 @@
-#ifndef REALM_UTIL_EZ_WEBSOCKET_HPP
-#define REALM_UTIL_EZ_WEBSOCKET_HPP
+#pragma once
 
 #include <random>
 #include <system_error>
@@ -8,18 +7,18 @@
 #include <realm/sync/config.hpp>
 #include <realm/sync/network/http.hpp>
 
-namespace realm::util::network {
+namespace realm::sync::network {
 class Service;
 }
 
-namespace realm::util::websocket {
+namespace realm::sync::websocket {
 using port_type = sync::port_type;
 
 // TODO figure out what belongs on config and what belongs on endpoint.
 struct EZConfig {
     std::shared_ptr<util::Logger> logger;
     std::mt19937_64& random;
-    util::network::Service& service;
+    network::Service& service;
     std::string user_agent;
 };
 
@@ -108,6 +107,4 @@ private:
     EZConfig m_config;
 };
 
-} // namespace realm::util::websocket
-
-#endif // REALM_UTIL_EZ_WEBSOCKET_HPP
+} // namespace realm::sync::websocket

--- a/src/realm/sync/network/default_socket.hpp
+++ b/src/realm/sync/network/default_socket.hpp
@@ -9,7 +9,7 @@
 
 namespace realm::sync::network {
 class Service;
-}
+} // namespace realm::sync::network
 
 namespace realm::sync::websocket {
 using port_type = sync::port_type;

--- a/src/realm/sync/network/http.cpp
+++ b/src/realm/sync/network/http.cpp
@@ -31,7 +31,7 @@ struct HTTPParserErrorCategory : std::error_category {
 
     std::string message(int condition) const override
     {
-        using util::HTTPParserError;
+        using sync::HTTPParserError;
         switch (HTTPParserError(condition)) {
             case HTTPParserError::None:
                 return "None";
@@ -55,7 +55,7 @@ const HTTPParserErrorCategory g_http_parser_error_category;
 
 
 namespace realm {
-namespace util {
+namespace sync {
 
 bool valid_http_status_code(unsigned int code)
 {
@@ -184,7 +184,7 @@ bool HTTPParserBase::parse_header_line(size_t len)
 }
 
 
-Optional<HTTPMethod> HTTPParserBase::parse_method_string(StringData method)
+util::Optional<HTTPMethod> HTTPParserBase::parse_method_string(StringData method)
 {
     if (method == "OPTIONS")
         return HTTPMethod::Options;
@@ -482,5 +482,5 @@ std::error_code make_error_code(HTTPParserError error)
     return std::error_code(static_cast<int>(error), g_http_parser_error_category);
 }
 
-} // namespace util
+} // namespace sync
 } // namespace realm

--- a/src/realm/sync/network/http.cpp
+++ b/src/realm/sync/network/http.cpp
@@ -54,8 +54,7 @@ const HTTPParserErrorCategory g_http_parser_error_category;
 } // unnamed namespace
 
 
-namespace realm {
-namespace sync {
+namespace realm::sync {
 
 bool valid_http_status_code(unsigned int code)
 {
@@ -482,5 +481,4 @@ std::error_code make_error_code(HTTPParserError error)
     return std::error_code(static_cast<int>(error), g_http_parser_error_category);
 }
 
-} // namespace sync
-} // namespace realm
+} // namespace realm::sync

--- a/src/realm/sync/network/http.hpp
+++ b/src/realm/sync/network/http.hpp
@@ -30,8 +30,7 @@
 #include <realm/util/logger.hpp>
 #include <realm/string_data.hpp>
 
-namespace realm {
-namespace sync {
+namespace realm::sync {
 enum class HTTPParserError {
     None = 0,
     ContentTooLong,
@@ -41,8 +40,7 @@ enum class HTTPParserError {
     BadRequest,
 };
 std::error_code make_error_code(HTTPParserError);
-} // namespace sync
-} // namespace realm
+} // namespace realm::sync
 
 namespace std {
 template <>
@@ -50,8 +48,7 @@ struct is_error_code_enum<realm::sync::HTTPParserError> : std::true_type {
 };
 } // namespace std
 
-namespace realm {
-namespace sync {
+namespace realm::sync {
 
 /// See: https://www.w3.org/Protocols/rfc2616/rfc2616-sec10.html
 ///
@@ -533,5 +530,4 @@ private:
     }
 };
 
-} // namespace sync
-} // namespace realm
+} // namespace realm::sync

--- a/src/realm/sync/network/http.hpp
+++ b/src/realm/sync/network/http.hpp
@@ -16,8 +16,7 @@
  *
  **************************************************************************/
 
-#ifndef REALM_UTIL_HTTP_HPP
-#define REALM_UTIL_HTTP_HPP
+#pragma once
 
 #include <cstdint>
 #include <type_traits>
@@ -32,7 +31,7 @@
 #include <realm/string_data.hpp>
 
 namespace realm {
-namespace util {
+namespace sync {
 enum class HTTPParserError {
     None = 0,
     ContentTooLong,
@@ -42,17 +41,17 @@ enum class HTTPParserError {
     BadRequest,
 };
 std::error_code make_error_code(HTTPParserError);
-} // namespace util
+} // namespace sync
 } // namespace realm
 
 namespace std {
 template <>
-struct is_error_code_enum<realm::util::HTTPParserError> : std::true_type {
+struct is_error_code_enum<realm::sync::HTTPParserError> : std::true_type {
 };
 } // namespace std
 
 namespace realm {
-namespace util {
+namespace sync {
 
 /// See: https://www.w3.org/Protocols/rfc2616/rfc2616-sec10.html
 ///
@@ -171,7 +170,7 @@ struct HTTPRequest {
     /// set to a string representation of the number of bytes in the body.
     /// FIXME: Relax this restriction, and also support Transfer-Encoding
     /// and other HTTP/1.1 features.
-    Optional<std::string> body;
+    util::Optional<std::string> body;
 };
 
 struct HTTPResponse {
@@ -183,7 +182,7 @@ struct HTTPResponse {
     // Content-Length header.
     // FIXME: Support other transfer methods, including Transfer-Encoding and
     // HTTP/1.1 features.
-    Optional<std::string> body;
+    util::Optional<std::string> body;
 };
 
 
@@ -221,7 +220,7 @@ struct HTTPParserBase {
 
     std::string m_write_buffer;
     std::unique_ptr<char[], CallocDeleter> m_read_buffer;
-    Optional<size_t> m_found_content_length;
+    util::Optional<size_t> m_found_content_length;
     static const size_t read_buffer_size = 8192;
     static const size_t max_header_line_length = read_buffer_size;
 
@@ -239,7 +238,7 @@ struct HTTPParserBase {
 
     /// If the input matches a known HTTP method string, return the appropriate
     /// HTTPMethod enum value. Otherwise, returns none.
-    static Optional<HTTPMethod> parse_method_string(StringData method);
+    static util::Optional<HTTPMethod> parse_method_string(StringData method);
 
     /// Interpret line as the first line of an HTTP request. If the return value
     /// is true, out_method and out_uri have been assigned the appropriate
@@ -268,7 +267,7 @@ struct HTTPParser : protected HTTPParserBase {
     void read_first_line()
     {
         auto handler = [this](std::error_code ec, size_t n) {
-            if (ec == error::operation_aborted) {
+            if (ec == util::error::operation_aborted) {
                 return;
             }
             if (ec) {
@@ -288,7 +287,7 @@ struct HTTPParser : protected HTTPParserBase {
     void read_headers()
     {
         auto handler = [this](std::error_code ec, size_t n) {
-            if (ec == error::operation_aborted) {
+            if (ec == util::error::operation_aborted) {
                 return;
             }
             if (ec) {
@@ -321,7 +320,7 @@ struct HTTPParser : protected HTTPParserBase {
             }
 
             auto handler = [this](std::error_code ec, size_t n) {
-                if (ec == error::operation_aborted) {
+                if (ec == util::error::operation_aborted) {
                     return;
                 }
                 if (!ec) {
@@ -380,7 +379,7 @@ struct HTTPClient : protected HTTPParser<Socket> {
         m_handler = std::move(handler);
         this->write_buffer([this](std::error_code ec, size_t bytes_written) {
             static_cast<void>(bytes_written);
-            if (ec == error::operation_aborted) {
+            if (ec == util::error::operation_aborted) {
                 return;
             }
             if (ec) {
@@ -487,7 +486,7 @@ struct HTTPServer : protected HTTPParser<Socket> {
         m_respond_handler = std::move(handler);
         this->set_write_buffer(response);
         this->write_buffer([this](std::error_code ec, size_t) {
-            if (ec == error::operation_aborted) {
+            if (ec == util::error::operation_aborted) {
                 return;
             }
             m_request_handler = nullptr;
@@ -534,8 +533,5 @@ private:
     }
 };
 
-} // namespace util
+} // namespace sync
 } // namespace realm
-
-
-#endif // REALM_UTIL_HTTP_HPP

--- a/src/realm/sync/network/network.cpp
+++ b/src/realm/sync/network/network.cpp
@@ -69,7 +69,7 @@
 #endif
 
 using namespace realm::util;
-using namespace realm::util::network;
+using namespace realm::sync::network;
 
 
 namespace {
@@ -2508,7 +2508,7 @@ bool ReadAheadBuffer::read(char*& begin, char* end, int delim, std::error_code& 
 
 
 namespace realm {
-namespace util {
+namespace sync {
 namespace network {
 
 std::string host_name()
@@ -2610,5 +2610,5 @@ std::string ResolveErrorCategory::message(int value) const
 }
 
 } // namespace network
-} // namespace util
+} // namespace sync
 } // namespace realm

--- a/src/realm/sync/network/network.cpp
+++ b/src/realm/sync/network/network.cpp
@@ -2507,9 +2507,7 @@ bool ReadAheadBuffer::read(char*& begin, char* end, int delim, std::error_code& 
 }
 
 
-namespace realm {
-namespace sync {
-namespace network {
+namespace realm::sync::network {
 
 std::string host_name()
 {
@@ -2609,6 +2607,4 @@ std::string ResolveErrorCategory::message(int value) const
     return {};
 }
 
-} // namespace network
-} // namespace sync
-} // namespace realm
+} // namespace realm::sync::network

--- a/src/realm/sync/network/network.hpp
+++ b/src/realm/sync/network/network.hpp
@@ -53,9 +53,7 @@
 
 // FIXME: Unfinished business around `Address::m_ip_v6_scope_id`.
 
-
-namespace realm {
-namespace sync {
+namespace realm::sync::network {
 
 /// \brief TCP/IP networking API.
 ///
@@ -127,7 +125,6 @@ namespace sync {
 /// the event loop, there is still no guarantee that an asynchronous operation
 /// remains cancelable up until the point in time where the completion handler
 /// starts to execute.
-namespace network {
 
 std::string host_name();
 
@@ -1482,9 +1479,7 @@ inline std::error_code make_error_code(ResolveErrors err)
     return std::error_code(int(err), resolve_error_category);
 }
 
-} // namespace network
-} // namespace sync
-} // namespace realm
+} // namespace realm::sync::network
 
 namespace std {
 
@@ -1496,10 +1491,7 @@ public:
 
 } // namespace std
 
-namespace realm {
-namespace sync {
-namespace network {
-
+namespace realm::sync::network {
 
 // Implementation
 
@@ -3712,6 +3704,4 @@ inline bool ReadAheadBuffer::refill_async(S& stream, std::error_code& ec, Want& 
     return true;
 }
 
-} // namespace network
-} // namespace sync
-} // namespace realm
+} // namespace realm::sync::network

--- a/src/realm/sync/network/network.hpp
+++ b/src/realm/sync/network/network.hpp
@@ -1,5 +1,4 @@
-#ifndef REALM_UTIL_NETWORK_HPP
-#define REALM_UTIL_NETWORK_HPP
+#pragma once
 
 #include <cstddef>
 #include <memory>
@@ -56,7 +55,7 @@
 
 
 namespace realm {
-namespace util {
+namespace sync {
 
 /// \brief TCP/IP networking API.
 ///
@@ -265,7 +264,7 @@ public:
     List& operator=(List&&) noexcept = default;
 
 private:
-    Buffer<Endpoint> m_endpoints;
+    util::Buffer<Endpoint> m_endpoints;
 
     friend class Service;
 };
@@ -1484,13 +1483,13 @@ inline std::error_code make_error_code(ResolveErrors err)
 }
 
 } // namespace network
-} // namespace util
+} // namespace sync
 } // namespace realm
 
 namespace std {
 
 template <>
-class is_error_code_enum<realm::util::network::ResolveErrors> {
+class is_error_code_enum<realm::sync::network::ResolveErrors> {
 public:
     static const bool value = true;
 };
@@ -1498,7 +1497,7 @@ public:
 } // namespace std
 
 namespace realm {
-namespace util {
+namespace sync {
 namespace network {
 
 
@@ -1579,7 +1578,7 @@ inline std::basic_ostream<C, T>& operator<<(std::basic_ostream<C, T>& out, const
 #endif
     const char* ret = ::inet_ntop(af, src, buffer, sizeof buffer);
     if (ret == 0) {
-        std::error_code ec = make_basic_system_error_code(errno);
+        std::error_code ec = util::make_basic_system_error_code(errno);
         throw std::system_error(ec);
     }
     out << ret;
@@ -2021,7 +2020,7 @@ protected:
     friend class Service;
 };
 
-class Service::TriggerExecOperBase : public AsyncOper, public AtomicRefCountBase {
+class Service::TriggerExecOperBase : public AsyncOper, public util::AtomicRefCountBase {
 public:
     TriggerExecOperBase(Impl& service) noexcept
         : AsyncOper{0, false}
@@ -2034,7 +2033,7 @@ public:
         REALM_ASSERT(in_use());
         REALM_ASSERT(!m_service);
         // Note: Potential suicide when `self` goes out of scope
-        util::bind_ptr<TriggerExecOperBase> self{this, bind_ptr_base::adopt_tag{}};
+        util::bind_ptr<TriggerExecOperBase> self{this, util::bind_ptr_base::adopt_tag{}};
     }
     void orphan() noexcept override final
     {
@@ -2646,7 +2645,7 @@ public:
         bool orphaned = !s.m_stream;
         std::error_code ec = s.m_error_code;
         if (s.is_canceled())
-            ec = error::operation_aborted;
+            ec = util::error::operation_aborted;
         std::size_t num_bytes_transferred = std::size_t(s.m_curr - s.m_begin);
         // Note: do_recycle_and_execute() commits suicide.
         s.template do_recycle_and_execute<H>(orphaned, s.m_handler, ec,
@@ -2676,7 +2675,7 @@ public:
         bool orphaned = !s.m_stream;
         std::error_code ec = s.m_error_code;
         if (s.is_canceled())
-            ec = error::operation_aborted;
+            ec = util::error::operation_aborted;
         std::size_t num_bytes_transferred = std::size_t(s.m_curr - s.m_begin);
         // Note: do_recycle_and_execute() commits suicide.
         s.template do_recycle_and_execute<H>(orphaned, s.m_handler, ec,
@@ -2709,7 +2708,7 @@ public:
         bool orphaned = !s.m_stream;
         std::error_code ec = s.m_error_code;
         if (s.is_canceled())
-            ec = error::operation_aborted;
+            ec = util::error::operation_aborted;
         std::size_t num_bytes_transferred = std::size_t(s.m_curr - s.m_begin);
         // Note: do_recycle_and_execute() commits suicide.
         s.template do_recycle_and_execute<H>(orphaned, s.m_handler, ec,
@@ -2891,7 +2890,7 @@ public:
         bool orphaned = !m_resolver;
         std::error_code ec = m_error_code;
         if (is_canceled())
-            ec = error::operation_aborted;
+            ec = util::error::operation_aborted;
         // Note: do_recycle_and_execute() commits suicide.
         do_recycle_and_execute<H>(orphaned, m_handler, ec, std::move(m_endpoints)); // Throws
     }
@@ -3171,7 +3170,7 @@ public:
         bool orphaned = !m_socket;
         std::error_code ec = m_error_code;
         if (is_canceled())
-            ec = error::operation_aborted;
+            ec = util::error::operation_aborted;
         // Note: do_recycle_and_execute() commits suicide.
         do_recycle_and_execute<H>(orphaned, m_handler, ec); // Throws
     }
@@ -3386,7 +3385,7 @@ inline std::size_t Socket::do_read_some_async(char* buffer, std::size_t size, st
 {
     std::error_code ec_2;
     std::size_t n = m_desc.read_some(buffer, size, ec_2);
-    bool success = (!ec_2 || ec_2 == error::resource_unavailable_try_again);
+    bool success = (!ec_2 || ec_2 == util::error::resource_unavailable_try_again);
     if (REALM_UNLIKELY(!success)) {
         ec = ec_2;
         want = Want::nothing; // Failure
@@ -3402,7 +3401,7 @@ inline std::size_t Socket::do_write_some_async(const char* data, std::size_t siz
 {
     std::error_code ec_2;
     std::size_t n = m_desc.write_some(data, size, ec_2);
-    bool success = (!ec_2 || ec_2 == error::resource_unavailable_try_again);
+    bool success = (!ec_2 || ec_2 == util::error::resource_unavailable_try_again);
     if (REALM_UNLIKELY(!success)) {
         ec = ec_2;
         want = Want::nothing; // Failure
@@ -3480,7 +3479,7 @@ public:
         bool orphaned = !m_acceptor;
         std::error_code ec = m_error_code;
         if (is_canceled())
-            ec = error::operation_aborted;
+            ec = util::error::operation_aborted;
         // Note: do_recycle_and_execute() commits suicide.
         do_recycle_and_execute<H>(orphaned, m_handler, ec); // Throws
     }
@@ -3555,7 +3554,7 @@ inline Acceptor::Want Acceptor::do_accept_async(Socket& socket, Endpoint* ep, st
 {
     std::error_code ec_2;
     m_desc.accept(socket.m_desc, m_protocol, ep, ec_2);
-    if (ec_2 == error::resource_unavailable_try_again)
+    if (ec_2 == util::error::resource_unavailable_try_again)
         return Want::read;
     ec = ec_2;
     return Want::nothing;
@@ -3586,7 +3585,7 @@ public:
         bool orphaned = !m_timer;
         std::error_code ec;
         if (is_canceled())
-            ec = error::operation_aborted;
+            ec = util::error::operation_aborted;
         // Note: do_recycle_and_execute() commits suicide.
         do_recycle_and_execute<H>(orphaned, m_handler, ec); // Throws
     }
@@ -3635,7 +3634,7 @@ public:
     {
         REALM_ASSERT(in_use());
         // Note: Potential suicide when `self` goes out of scope
-        util::bind_ptr<TriggerExecOperBase> self{this, bind_ptr_base::adopt_tag{}};
+        util::bind_ptr<TriggerExecOperBase> self{this, util::bind_ptr_base::adopt_tag{}};
         if (m_service) {
             Service::reset_trigger_exec(*m_service, *this);
             m_handler(); // Throws
@@ -3714,7 +3713,5 @@ inline bool ReadAheadBuffer::refill_async(S& stream, std::error_code& ec, Want& 
 }
 
 } // namespace network
-} // namespace util
+} // namespace sync
 } // namespace realm
-
-#endif // REALM_UTIL_NETWORK_HPP

--- a/src/realm/sync/network/network_ssl.cpp
+++ b/src/realm/sync/network/network_ssl.cpp
@@ -21,8 +21,8 @@
 
 using namespace realm;
 using namespace realm::util;
-using namespace realm::util::network;
-using namespace realm::util::network::ssl;
+using namespace realm::sync::network;
+using namespace realm::sync::network::ssl;
 
 
 namespace {
@@ -153,7 +153,7 @@ OpensslInit::~OpensslInit()
 
 
 namespace realm {
-namespace util {
+namespace sync {
 namespace network {
 namespace ssl {
 
@@ -1525,5 +1525,5 @@ bool is_server_cert_rejected_error(std::error_code&)
 
 } // namespace ssl
 } // namespace network
-} // namespace util
+} // namespace sync
 } // namespace realm

--- a/src/realm/sync/network/network_ssl.hpp
+++ b/src/realm/sync/network/network_ssl.hpp
@@ -1196,7 +1196,7 @@ std::size_t Stream::ssl_perform(Oper oper, std::error_code& ec, Want& want) noex
             return 0;
         case SSL_ERROR_SYSCALL:
             if (REALM_UNLIKELY(sys_error != 0)) {
-                ec = make_basic_system_error_code(sys_error);
+                ec = util::make_basic_system_error_code(sys_error);
             }
             else if (REALM_UNLIKELY(m_bio_error_code)) {
                 ec = m_bio_error_code;

--- a/src/realm/sync/network/network_ssl.hpp
+++ b/src/realm/sync/network/network_ssl.hpp
@@ -43,10 +43,7 @@
 // case in teh future.
 
 
-namespace realm {
-namespace sync {
-namespace network {
-namespace ssl {
+namespace realm::sync::network::ssl {
 
 enum class Errors {
     certificate_rejected = 1,
@@ -73,10 +70,7 @@ inline std::error_condition make_error_condition(Errors err)
     return std::error_condition(int(err), error_category);
 }
 
-} // namespace ssl
-} // namespace network
-} // namespace sync
-} // namespace realm
+} // namespace realm::sync::network::ssl
 
 namespace std {
 
@@ -88,9 +82,7 @@ public:
 
 } // namespace std
 
-namespace realm {
-namespace sync {
-namespace network {
+namespace realm::sync::network {
 
 class OpensslErrorCategory : public std::error_category {
 public:
@@ -111,7 +103,6 @@ public:
 /// The error category associated with error codes produced by Apple's
 /// SecureTransport library. The name of this category is `securetransport`.
 extern SecureTransportErrorCategory secure_transport_error_category;
-
 
 namespace ssl {
 
@@ -1346,6 +1337,4 @@ std::size_t Stream::ssl_perform(Oper oper, std::error_code& ec, Want& want) noex
 #endif // REALM_HAVE_OPENSSL / REALM_HAVE_SECURE_TRANSPORT
 
 } // namespace ssl
-} // namespace network
-} // namespace sync
-} // namespace realm
+} // namespace realm::sync::network

--- a/src/realm/sync/network/websocket.cpp
+++ b/src/realm/sync/network/websocket.cpp
@@ -7,7 +7,7 @@
 #include <realm/util/sha_crypto.hpp>
 
 using namespace realm;
-using namespace util;
+using namespace sync;
 using Error = websocket::Error;
 
 
@@ -44,7 +44,7 @@ std::string make_random_sec_websocket_key(std::mt19937_64& random)
     }
 
     char out_buffer[24];
-    size_t encoded_size = base64_encode(random_bytes, 16, out_buffer, 24);
+    size_t encoded_size = util::base64_encode(random_bytes, 16, out_buffer, 24);
     REALM_ASSERT(encoded_size == 24);
 
     return std::string{out_buffer, 24};
@@ -65,7 +65,7 @@ std::string make_sec_websocket_accept(StringData sec_websocket_key)
     util::sha1(sha1_input.data(), sha1_input.length(), sha1_output);
 
     char base64_output[28];
-    size_t base64_output_size = base64_encode(reinterpret_cast<char*>(sha1_output), 20, base64_output, 28);
+    size_t base64_output_size = util::base64_encode(reinterpret_cast<char*>(sha1_output), 20, base64_output, 28);
     REALM_ASSERT(base64_output_size == 28);
 
     return std::string(base64_output, 28);
@@ -1081,7 +1081,7 @@ class ErrorCategoryImpl : public std::error_category {
 public:
     const char* name() const noexcept override final
     {
-        return "realm::util::websocket::Error";
+        return "realm::sync::websocket::Error";
     }
     std::string message(int error_code) const override final
     {
@@ -1098,7 +1098,7 @@ ErrorCategoryImpl g_error_category;
 class CloseStatusErrorCategory : public std::error_category {
     const char* name() const noexcept final
     {
-        return "realm::util::websocket::CloseStatus";
+        return "realm::sync::websocket::CloseStatus";
     }
     std::string message(int error_code) const final
     {

--- a/src/realm/sync/network/websocket.cpp
+++ b/src/realm/sync/network/websocket.cpp
@@ -7,7 +7,7 @@
 #include <realm/util/sha_crypto.hpp>
 
 using namespace realm;
-using namespace sync;
+using namespace realm::sync;
 using Error = websocket::Error;
 
 

--- a/src/realm/sync/network/websocket.hpp
+++ b/src/realm/sync/network/websocket.hpp
@@ -1,6 +1,4 @@
-
-#ifndef REALM_UTIL_WEBSOCKET_HPP
-#define REALM_UTIL_WEBSOCKET_HPP
+#pragma once
 
 #include <realm/sync/network/http.hpp>
 #include <realm/util/functional.hpp>
@@ -10,7 +8,7 @@
 #include <system_error>
 #include <map>
 
-namespace realm::util::websocket {
+namespace realm::sync::websocket {
 
 using WriteCompletionHandler = util::UniqueFunction<void(std::error_code, size_t num_bytes_transferred)>;
 using ReadCompletionHandler = util::UniqueFunction<void(std::error_code, size_t num_bytes_transferred)>;
@@ -220,15 +218,13 @@ const std::error_category& error_category() noexcept;
 
 std::error_code make_error_code(Error) noexcept;
 
-} // namespace realm::util::websocket
+} // namespace realm::sync::websocket
 
 namespace std {
 
 template <>
-struct is_error_code_enum<realm::util::websocket::Error> {
+struct is_error_code_enum<realm::sync::websocket::Error> {
     static const bool value = true;
 };
 
 } // namespace std
-
-#endif // REALM_UTIL_WEBSOCKET_HPP

--- a/src/realm/sync/noinst/client_impl_base.cpp
+++ b/src/realm/sync/noinst/client_impl_base.cpp
@@ -112,7 +112,7 @@ ClientImpl::ClientImpl(ClientConfig config)
     , m_roundtrip_time_handler{std::move(config.roundtrip_time_handler)}
     , m_user_agent_string{make_user_agent_string(config)} // Throws
     , m_service{}                                         // Throws
-    , m_socket_factory(util::websocket::EZConfig{
+    , m_socket_factory(websocket::EZConfig{
           logger_ptr,
           m_random,
           m_service,
@@ -184,7 +184,7 @@ ClientImpl::ClientImpl(ClientConfig config)
     auto handler = [this] {
         actualize_and_finalize_session_wrappers(); // Throws
     };
-    m_actualize_and_finalize = util::network::Trigger{get_service(), std::move(handler)}; // Throws
+    m_actualize_and_finalize = network::Trigger{get_service(), std::move(handler)}; // Throws
 
     start_keep_running_timer(); // Throws
 }
@@ -340,14 +340,14 @@ void Connection::websocket_read_or_write_error_handler(std::error_code ec)
 void Connection::websocket_handshake_error_handler(std::error_code ec, const std::string_view* body)
 {
     bool is_fatal;
-    if (ec == util::websocket::Error::bad_response_3xx_redirection ||
-        ec == util::websocket::Error::bad_response_301_moved_permanently ||
-        ec == util::websocket::Error::bad_response_401_unauthorized ||
-        ec == util::websocket::Error::bad_response_5xx_server_error ||
-        ec == util::websocket::Error::bad_response_500_internal_server_error ||
-        ec == util::websocket::Error::bad_response_502_bad_gateway ||
-        ec == util::websocket::Error::bad_response_503_service_unavailable ||
-        ec == util::websocket::Error::bad_response_504_gateway_timeout) {
+    if (ec == websocket::Error::bad_response_3xx_redirection ||
+        ec == websocket::Error::bad_response_301_moved_permanently ||
+        ec == websocket::Error::bad_response_401_unauthorized ||
+        ec == websocket::Error::bad_response_5xx_server_error ||
+        ec == websocket::Error::bad_response_500_internal_server_error ||
+        ec == websocket::Error::bad_response_502_bad_gateway ||
+        ec == websocket::Error::bad_response_503_service_unavailable ||
+        ec == websocket::Error::bad_response_504_gateway_timeout) {
         is_fatal = false;
         m_reconnect_info.m_reason = ConnectionTerminationReason::http_response_says_nonfatal_error;
     }
@@ -659,7 +659,7 @@ void Connection::initiate_reconnect()
     }
 
     m_websocket =
-        m_client.m_socket_factory.connect(this, util::websocket::EZEndpoint{
+        m_client.m_socket_factory.connect(this, websocket::EZEndpoint{
                                                     m_address,
                                                     m_port,
                                                     get_http_request_path(),
@@ -875,7 +875,7 @@ void Connection::send_next_message()
     while (!m_sessions_enlisted_to_send.empty()) {
         // The state of being connected is not supposed to be able to change
         // across this loop thanks to the "no callback reentrance" guarantee
-        // provided by util::Websocket::async_write_text(), and friends.
+        // provided by Websocket::async_write_text(), and friends.
         REALM_ASSERT(m_state == ConnectionState::connected);
 
         Session& sess = *m_sessions_enlisted_to_send.front();

--- a/src/realm/sync/noinst/client_impl_base.hpp
+++ b/src/realm/sync/noinst/client_impl_base.hpp
@@ -34,7 +34,7 @@ namespace sync {
 //
 // `protocol` is included for convenience, even though it is not strictly part
 // of an endpoint.
-using ServerEndpoint = std::tuple<ProtocolEnvelope, std::string, util::network::Endpoint::port_type>;
+using ServerEndpoint = std::tuple<ProtocolEnvelope, std::string, network::Endpoint::port_type>;
 
 class SessionWrapper;
 
@@ -62,7 +62,7 @@ public:
     class Connection;
     class Session;
 
-    using port_type = util::network::Endpoint::port_type;
+    using port_type = network::Endpoint::port_type;
     using OutputBuffer = util::ResettableExpandableBufferOutputStream;
     using ClientProtocol = _impl::ClientProtocol;
     using ClientResetOperation = _impl::ClientResetOperation;
@@ -132,7 +132,7 @@ public:
     const std::string& get_user_agent_string() const noexcept;
     ReconnectMode get_reconnect_mode() const noexcept;
     bool is_dry_run() const noexcept;
-    util::network::Service& get_service() noexcept;
+    network::Service& get_service() noexcept;
     std::mt19937_64& get_random() noexcept;
 
     /// Returns false if the specified URL is invalid.
@@ -158,15 +158,15 @@ private:
     const bool m_fix_up_object_ids;
     const std::function<RoundtripTimeHandler> m_roundtrip_time_handler;
     const std::string m_user_agent_string;
-    util::network::Service m_service;
+    network::Service m_service;
     std::mt19937_64 m_random;
-    util::websocket::EZSocketFactory m_socket_factory;
+    websocket::EZSocketFactory m_socket_factory;
     ClientProtocol m_client_protocol;
     session_ident_type m_prev_session_ident = 0;
 
     const bool m_one_connection_per_session;
-    util::network::Trigger m_actualize_and_finalize;
-    util::network::DeadlineTimer m_keep_running_timer;
+    network::Trigger m_actualize_and_finalize;
+    network::DeadlineTimer m_keep_running_timer;
 
     // Note: There is one server slot per server endpoint (hostname, port,
     // session_multiplex_ident), and it survives from one connection object to
@@ -301,7 +301,7 @@ enum class ClientImpl::ConnectionTerminationReason {
 
 /// All use of connection objects, including construction and destruction, must
 /// occur on behalf of the event loop thread of the associated client object.
-class ClientImpl::Connection final : public util::websocket::EZObserver {
+class ClientImpl::Connection final : public websocket::EZObserver {
 public:
     using connection_ident_type = std::int_fast64_t;
     using SSLVerifyCallback = SyncConfig::SSLVerifyCallback;
@@ -374,7 +374,7 @@ public:
     /// than or equal to get_current_protocol_version().
     int get_negotiated_protocol_version() noexcept;
 
-    // Overriding methods in util::websocket::EZObserver
+    // Overriding methods in websocket::EZObserver
     void websocket_handshake_completion_handler(const std::string& protocol) override;
     void websocket_connect_error_handler(std::error_code) override;
     void websocket_ssl_handshake_error_handler(std::error_code) override;
@@ -489,7 +489,7 @@ private:
     friend class Session;
 
     ClientImpl& m_client;
-    std::unique_ptr<util::websocket::EZSocket> m_websocket;
+    std::unique_ptr<websocket::EZSocket> m_websocket;
     const ProtocolEnvelope m_protocol_envelope;
     const std::string m_address;
     const port_type m_port;
@@ -506,7 +506,7 @@ private:
 
     std::size_t m_num_active_unsuspended_sessions = 0;
     std::size_t m_num_active_sessions = 0;
-    util::network::Trigger m_on_idle;
+    network::Trigger m_on_idle;
 
     // activate() has been called
     bool m_activated = false;
@@ -545,16 +545,16 @@ private:
     // before the completion handler of the previous canceled wait operation
     // starts executing. Such an overlap is not allowed for wait operations on
     // the same timer instance.
-    util::Optional<util::network::DeadlineTimer> m_reconnect_disconnect_timer;
+    util::Optional<network::DeadlineTimer> m_reconnect_disconnect_timer;
 
     // Timer for connect operation watchdog. For why this timer is optional, see
     // `m_reconnect_disconnect_timer`.
-    util::Optional<util::network::DeadlineTimer> m_connect_timer;
+    util::Optional<network::DeadlineTimer> m_connect_timer;
 
     // This timer is used to schedule the sending of PING messages, and as a
     // watchdog for timely reception of PONG messages. For why this timer is
     // optional, see `m_reconnect_disconnect_timer`.
-    util::Optional<util::network::DeadlineTimer> m_heartbeat_timer;
+    util::Optional<network::DeadlineTimer> m_heartbeat_timer;
 
     milliseconds_type m_pong_wait_started_at = 0;
     milliseconds_type m_last_ping_sent_at = 0;
@@ -904,7 +904,7 @@ private:
 
     bool m_suspended = false;
 
-    util::Optional<util::network::DeadlineTimer> m_try_again_activation_timer;
+    util::Optional<network::DeadlineTimer> m_try_again_activation_timer;
     ResumptionDelayInfo m_try_again_delay_info;
     util::Optional<ProtocolError> m_try_again_error_code;
     util::Optional<std::chrono::milliseconds> m_current_try_again_delay_interval;
@@ -1123,7 +1123,7 @@ inline bool ClientImpl::is_dry_run() const noexcept
     return m_dry_run;
 }
 
-inline util::network::Service& ClientImpl::get_service() noexcept
+inline network::Service& ClientImpl::get_service() noexcept
 {
     return m_service;
 }

--- a/src/realm/sync/noinst/server/server.cpp
+++ b/src/realm/sync/noinst/server/server.cpp
@@ -90,7 +90,7 @@ using UploadChangeset = ServerProtocol::UploadChangeset;
 
 using UploadChangesets = std::vector<UploadChangeset>;
 
-using EventLoopMetricsHandler = util::network::Service::EventLoopMetricsHandler;
+using EventLoopMetricsHandler = network::Service::EventLoopMetricsHandler;
 
 
 static_assert(std::numeric_limits<session_ident_type>::digits >= 63, "Bad session identifier type");
@@ -753,12 +753,12 @@ public:
     const std::shared_ptr<util::Logger> logger_ptr;
     util::Logger& logger;
 
-    util::network::Service& get_service() noexcept
+    network::Service& get_service() noexcept
     {
         return m_service;
     }
 
-    const util::network::Service& get_service() const noexcept
+    const network::Service& get_service() const noexcept
     {
         return m_service;
     }
@@ -783,7 +783,7 @@ public:
         return m_root_dir;
     }
 
-    util::network::ssl::Context& get_ssl_context() noexcept
+    network::ssl::Context& get_ssl_context() noexcept
     {
         return *m_ssl_context;
     }
@@ -848,7 +848,7 @@ public:
         start(); // Throws
     }
 
-    util::network::Endpoint listen_endpoint() const
+    network::Endpoint listen_endpoint() const
     {
         return m_acceptor.local_endpoint();
     }
@@ -974,7 +974,7 @@ public:
 
 private:
     Server::Config m_config;
-    util::network::Service m_service;
+    network::Service m_service;
     std::mt19937_64 m_random;
     const std::size_t m_max_upload_backlog;
     const std::string m_root_dir;
@@ -994,14 +994,14 @@ private:
     // file-system level intervention.
     std::set<std::string> m_realm_names;
 
-    std::unique_ptr<util::network::ssl::Context> m_ssl_context;
+    std::unique_ptr<network::ssl::Context> m_ssl_context;
     ServerFileAccessCache m_file_access_cache;
     Worker m_worker;
     std::map<std::string, util::bind_ptr<ServerFile>> m_files; // Key is virtual path
-    util::network::Acceptor m_acceptor;
+    network::Acceptor m_acceptor;
     std::int_fast64_t m_next_conn_id = 0;
     std::unique_ptr<HTTPConnection> m_next_http_conn;
-    util::network::Endpoint m_next_http_conn_endpoint;
+    network::Endpoint m_next_http_conn_endpoint;
     std::map<std::int_fast64_t, std::unique_ptr<HTTPConnection>> m_http_connections;
     std::map<std::int_fast64_t, std::unique_ptr<SyncConnection>> m_sync_connections;
     ServerProtocol m_server_protocol;
@@ -1010,7 +1010,7 @@ private:
     std::unique_ptr<Transformer> m_transformer;
     util::Buffer<char> m_transform_buffer;
     int_fast64_t m_current_server_session_ident;
-    Optional<util::network::DeadlineTimer> m_connection_reaper_timer;
+    Optional<network::DeadlineTimer> m_connection_reaper_timer;
     bool m_allow_load_balancing = false;
 
     util::Mutex m_mutex;
@@ -1067,13 +1067,13 @@ private:
 
 // ============================ SyncConnection ============================
 
-class SyncConnection : public util::websocket::Config {
+class SyncConnection : public websocket::Config {
 public:
     util::PrefixLogger logger;
 
-    SyncConnection(ServerImpl& serv, std::int_fast64_t id, std::unique_ptr<util::network::Socket>&& socket,
-                   std::unique_ptr<util::network::ssl::Stream>&& ssl_stream,
-                   std::unique_ptr<util::network::ReadAheadBuffer>&& read_ahead_buffer, int client_protocol_version,
+    SyncConnection(ServerImpl& serv, std::int_fast64_t id, std::unique_ptr<network::Socket>&& socket,
+                   std::unique_ptr<network::ssl::Stream>&& ssl_stream,
+                   std::unique_ptr<network::ReadAheadBuffer>&& read_ahead_buffer, int client_protocol_version,
                    std::string client_user_agent, std::string remote_endpoint)
         : logger{make_logger_prefix(id), serv.logger} // Throws
         , m_server{serv}
@@ -1090,12 +1090,12 @@ public:
         // expand the buffer
         m_output_buffer.exceptions(std::ios_base::badbit | std::ios_base::failbit);
 
-        util::network::Service& service = m_server.get_service();
+        network::Service& service = m_server.get_service();
         auto handler = [this] {
             if (!m_is_sending)
                 send_next_message(); // Throws
         };
-        m_send_trigger = util::network::Trigger{service, std::move(handler)}; // Throws
+        m_send_trigger = network::Trigger{service, std::move(handler)}; // Throws
     }
 
     ~SyncConnection() noexcept;
@@ -1164,7 +1164,7 @@ public:
         return true;
     }
 
-    void async_write(const char* data, size_t size, util::websocket::WriteCompletionHandler handler) final override
+    void async_write(const char* data, size_t size, websocket::WriteCompletionHandler handler) final override
     {
         if (m_ssl_stream) {
             m_ssl_stream->async_write(data, size, std::move(handler)); // Throws
@@ -1174,7 +1174,7 @@ public:
         }
     }
 
-    void async_read(char* buffer, size_t size, util::websocket::ReadCompletionHandler handler) final override
+    void async_read(char* buffer, size_t size, websocket::ReadCompletionHandler handler) final override
     {
         if (m_ssl_stream) {
             m_ssl_stream->async_read(buffer, size, *m_read_ahead_buffer, std::move(handler)); // Throws
@@ -1185,7 +1185,7 @@ public:
     }
 
     void async_read_until(char* buffer, size_t size, char delim,
-                          util::websocket::ReadCompletionHandler handler) final override
+                          websocket::ReadCompletionHandler handler) final override
     {
         if (m_ssl_stream) {
             m_ssl_stream->async_read_until(buffer, size, delim, *m_read_ahead_buffer,
@@ -1231,7 +1231,7 @@ public:
         return m_id;
     }
 
-    util::network::Socket& get_socket() noexcept
+    network::Socket& get_socket() noexcept
     {
         return *m_socket;
     }
@@ -1295,11 +1295,11 @@ public:
 private:
     ServerImpl& m_server;
     const int_fast64_t m_id;
-    std::unique_ptr<util::network::Socket> m_socket;
-    std::unique_ptr<util::network::ssl::Stream> m_ssl_stream;
-    std::unique_ptr<util::network::ReadAheadBuffer> m_read_ahead_buffer;
+    std::unique_ptr<network::Socket> m_socket;
+    std::unique_ptr<network::ssl::Stream> m_ssl_stream;
+    std::unique_ptr<network::ReadAheadBuffer> m_read_ahead_buffer;
 
-    util::websocket::Socket m_websocket;
+    websocket::Socket m_websocket;
     std::unique_ptr<char[]> m_input_body_buffer;
     OutputBuffer m_output_buffer;
     std::map<session_ident_type, std::unique_ptr<Session>> m_sessions;
@@ -1334,7 +1334,7 @@ private:
     bool m_send_pong = false;
     bool m_sending_pong = false;
 
-    util::network::Trigger m_send_trigger;
+    network::Trigger m_send_trigger;
 
     milliseconds_type m_last_ping_timestamp = 0;
 
@@ -1439,8 +1439,8 @@ public:
         : logger{make_logger_prefix(id), serv.logger} // Throws
         , m_server{serv}
         , m_id{id}
-        , m_socket{new util::network::Socket{serv.get_service()}} // Throws
-        , m_read_ahead_buffer{new util::network::ReadAheadBuffer} // Throws
+        , m_socket{new network::Socket{serv.get_service()}} // Throws
+        , m_read_ahead_buffer{new network::ReadAheadBuffer} // Throws
         , m_http_server{*this, logger}
     {
         // Make the output buffer stream throw std::bad_alloc if it fails to
@@ -1448,7 +1448,7 @@ public:
         m_output_buffer.exceptions(std::ios_base::badbit | std::ios_base::failbit);
 
         if (is_ssl) {
-            using namespace util::network::ssl;
+            using namespace network::ssl;
             Context& ssl_context = serv.get_ssl_context();
             m_ssl_stream = std::make_unique<Stream>(*m_socket, ssl_context,
                                                     Stream::server); // Throws
@@ -1465,7 +1465,7 @@ public:
         return m_id;
     }
 
-    util::network::Socket& get_socket() noexcept
+    network::Socket& get_socket() noexcept
     {
         return *m_socket;
     }
@@ -1571,9 +1571,9 @@ public:
 private:
     ServerImpl& m_server;
     const int_fast64_t m_id;
-    std::unique_ptr<util::network::Socket> m_socket;
-    std::unique_ptr<util::network::ssl::Stream> m_ssl_stream;
-    std::unique_ptr<util::network::ReadAheadBuffer> m_read_ahead_buffer;
+    std::unique_ptr<network::Socket> m_socket;
+    std::unique_ptr<network::ssl::Stream> m_ssl_stream;
+    std::unique_ptr<network::ReadAheadBuffer> m_read_ahead_buffer;
     HTTPServer<HTTPConnection> m_http_server;
     OutputBuffer m_output_buffer;
     bool m_is_sending = false;
@@ -3381,7 +3381,7 @@ void ServerFile::worker_process_work_unit(WorkerState& state)
         group_postprocess_stage_1(); // Throws
         // Suicide may have happened at this point
     };
-    util::network::Service& service = m_server.get_service();
+    network::Service& service = m_server.get_service();
     service.post(std::move(handler)); // Throws
 }
 
@@ -3772,7 +3772,7 @@ ServerImpl::ServerImpl(const std::string& root_dir, util::Optional<sync::PKey> p
     , m_compress_memory_arena{} // Throws
 {
     if (m_config.ssl) {
-        m_ssl_context = std::make_unique<util::network::ssl::Context>();          // Throws
+        m_ssl_context = std::make_unique<network::ssl::Context>();          // Throws
         m_ssl_context->use_certificate_chain_file(m_config.ssl_certificate_path); // Throws
         m_ssl_context->use_private_key_file(m_config.ssl_certificate_key_path);   // Throws
     }
@@ -3935,11 +3935,11 @@ util::Buffer<char>& ServerImpl::get_transform_buffer() noexcept
 
 void ServerImpl::listen()
 {
-    util::network::Resolver resolver{get_service()};
-    util::network::Resolver::Query query(m_config.listen_address, m_config.listen_port,
-                                         util::network::Resolver::Query::passive |
-                                             util::network::Resolver::Query::address_configured);
-    util::network::Endpoint::List endpoints = resolver.resolve(query); // Throws
+    network::Resolver resolver{get_service()};
+    network::Resolver::Query query(m_config.listen_address, m_config.listen_port,
+                                         network::Resolver::Query::passive |
+                                             network::Resolver::Query::address_configured);
+    network::Endpoint::List endpoints = resolver.resolve(query); // Throws
 
     auto i = endpoints.begin();
     auto end = endpoints.end();
@@ -3947,7 +3947,7 @@ void ServerImpl::listen()
         std::error_code ec;
         m_acceptor.open(i->protocol(), ec);
         if (!ec) {
-            using SocketBase = util::network::SocketBase;
+            using SocketBase = network::SocketBase;
             m_acceptor.set_option(SocketBase::reuse_address(m_config.reuse_address), ec);
             if (!ec) {
                 m_acceptor.bind(*i, ec);
@@ -3971,7 +3971,7 @@ void ServerImpl::listen()
 
     m_acceptor.listen(m_config.listen_backlog);
 
-    util::network::Endpoint local_endpoint = m_acceptor.local_endpoint();
+    network::Endpoint local_endpoint = m_acceptor.local_endpoint();
     const char* ssl_mode = (m_ssl_context ? "TLS" : "non-TLS");
     logger.info("Listening on %1:%2 (max backlog is %3, %4)", local_endpoint.address(), local_endpoint.port(),
                 m_config.listen_backlog, ssl_mode); // Throws
@@ -4020,7 +4020,7 @@ void ServerImpl::handle_accept(std::error_code ec)
     else {
         HTTPConnection& conn = *m_next_http_conn;
         if (m_config.tcp_no_delay)
-            conn.get_socket().set_option(util::network::SocketBase::no_delay(true)); // Throws
+            conn.get_socket().set_option(network::SocketBase::no_delay(true)); // Throws
         m_http_connections.emplace(conn.get_id(), std::move(m_next_http_conn));      // Throws
         Formatter& formatter = m_misc_buffers.formatter;
         formatter.reset();
@@ -4600,7 +4600,7 @@ void SyncConnection::handle_write_error()
     REALM_ASSERT(m_is_closing);
     if (!m_ssl_stream) {
         std::error_code ec;
-        m_socket->shutdown(util::network::Socket::shutdown_send, ec);
+        m_socket->shutdown(network::Socket::shutdown_send, ec);
         if (ec && ec != make_basic_system_error_code(ENOTCONN))
             throw std::system_error(ec);
     }
@@ -4752,7 +4752,7 @@ void Server::start(const std::string& listen_address, const std::string& listen_
 }
 
 
-util::network::Endpoint Server::listen_endpoint() const
+network::Endpoint Server::listen_endpoint() const
 {
     return m_impl->listen_endpoint(); // Throws
 }

--- a/src/realm/sync/noinst/server/server.cpp
+++ b/src/realm/sync/noinst/server/server.cpp
@@ -3772,7 +3772,7 @@ ServerImpl::ServerImpl(const std::string& root_dir, util::Optional<sync::PKey> p
     , m_compress_memory_arena{} // Throws
 {
     if (m_config.ssl) {
-        m_ssl_context = std::make_unique<network::ssl::Context>();          // Throws
+        m_ssl_context = std::make_unique<network::ssl::Context>();                // Throws
         m_ssl_context->use_certificate_chain_file(m_config.ssl_certificate_path); // Throws
         m_ssl_context->use_private_key_file(m_config.ssl_certificate_key_path);   // Throws
     }
@@ -3937,8 +3937,7 @@ void ServerImpl::listen()
 {
     network::Resolver resolver{get_service()};
     network::Resolver::Query query(m_config.listen_address, m_config.listen_port,
-                                         network::Resolver::Query::passive |
-                                             network::Resolver::Query::address_configured);
+                                   network::Resolver::Query::passive | network::Resolver::Query::address_configured);
     network::Endpoint::List endpoints = resolver.resolve(query); // Throws
 
     auto i = endpoints.begin();
@@ -4020,7 +4019,7 @@ void ServerImpl::handle_accept(std::error_code ec)
     else {
         HTTPConnection& conn = *m_next_http_conn;
         if (m_config.tcp_no_delay)
-            conn.get_socket().set_option(network::SocketBase::no_delay(true)); // Throws
+            conn.get_socket().set_option(network::SocketBase::no_delay(true));       // Throws
         m_http_connections.emplace(conn.get_id(), std::move(m_next_http_conn));      // Throws
         Formatter& formatter = m_misc_buffers.formatter;
         formatter.reset();

--- a/src/realm/sync/noinst/server/server.hpp
+++ b/src/realm/sync/noinst/server/server.hpp
@@ -188,7 +188,7 @@ public:
         /// `/proc/sys/net/core/somaxconn`). You can change the value of that
         /// parameter using `sysctl -w net.core.somaxconn=...`. It is usually
         /// 128 by default.
-        int listen_backlog = util::network::Acceptor::max_connections;
+        int listen_backlog = network::Acceptor::max_connections;
 
         /// Set the `TCP_NODELAY` option on all TCP/IP sockets. This disables
         /// the Nagle algorithm. Disabling it, can in some cases be used to
@@ -271,7 +271,7 @@ public:
     void start(const std::string& listen_address, const std::string& listen_port, bool reuse_address = true);
 
     /// Return the resolved and bound endpoint of the listening socket.
-    util::network::Endpoint listen_endpoint() const;
+    network::Endpoint listen_endpoint() const;
 
     /// Run the internal network event-loop of the server. At most one thread
     /// may execute run() at any given time. It is an error if run() is called

--- a/test/benchmark-util-network/main.cpp
+++ b/test/benchmark-util-network/main.cpp
@@ -10,7 +10,7 @@
 #include "../util/benchmark_results.hpp"
 
 using namespace realm;
-using namespace realm::util;
+using namespace realm::sync;
 using namespace realm::test_util;
 
 

--- a/test/client/auth.hpp
+++ b/test/client/auth.hpp
@@ -48,7 +48,7 @@ std::error_code make_error_code(Error) noexcept;
 
 class Client {
 public:
-    using port_type = util::network::Endpoint::port_type;
+    using port_type = network::Endpoint::port_type;
     using LoginHandler = void(std::error_code, std::string access_token, std::string refresh_token);
     using RefreshHandler = void(std::error_code, std::string access_token);
     using SSLVerifyCallback = bool(const std::string& server_address, port_type server_port, const char* pem_data,
@@ -121,7 +121,7 @@ public:
     /// This functions is thread-safe.
     void refresh(std::string refresh_token, std::function<RefreshHandler>);
 
-    util::network::Service& get_service();
+    network::Service& get_service();
     const std::string& get_auth_address();
     port_type get_auth_port();
     void request_is_done(std::int_fast64_t request_counter);
@@ -135,7 +135,7 @@ private:
     class LoginRequest;
     class RefreshRequest;
 
-    util::network::Service m_service;
+    network::Service m_service;
     const bool m_auth_ssl;
     const std::string m_auth_address;
     const port_type m_auth_port;
@@ -149,7 +149,7 @@ private:
 
     std::mt19937_64 m_random;
 
-    util::network::DeadlineTimer m_keep_running_timer;
+    network::DeadlineTimer m_keep_running_timer;
 
     std::int_fast64_t m_request_counter = 0;
 

--- a/test/client/main.cpp
+++ b/test/client/main.cpp
@@ -203,14 +203,14 @@ inline void MainEventLoop::end_of_test_proc() noexcept
 
 
 struct PeerControl {
-    PeerControl(util::network::Service&);
+    PeerControl(sync::network::Service&);
     int phase_ndx = 0;
     int transact_ndx = 0;
     int download_wait_ndx = 0;
-    util::network::DeadlineTimer transact_timer;
+    sync::network::DeadlineTimer transact_timer;
 };
 
-inline PeerControl::PeerControl(util::network::Service& service)
+inline PeerControl::PeerControl(sync::network::Service& service)
     : transact_timer{service}
 {
 }
@@ -1099,7 +1099,7 @@ int main(int argc, char* argv[])
 
     sync::ProtocolEnvelope protocol_envelope;
     std::string server_address;
-    util::network::Endpoint::port_type server_port = 0;
+    sync::network::Endpoint::port_type server_port = 0;
     if (have_server_url) {
         std::string path;
         bool good_url =
@@ -1137,7 +1137,7 @@ int main(int argc, char* argv[])
     util::Optional<std::string> ssl_trust_certificate_path =
         (ssl_trust_cert == "" ? util::none : util::Optional<std::string>(ssl_trust_cert));
 
-    util::network::Service test_proc_service;
+    sync::network::Service test_proc_service;
 
     auto on_sync_error = [&](bool is_fatal) {
         switch (abort_on_error) {
@@ -1167,7 +1167,7 @@ int main(int argc, char* argv[])
         std::string username;
         std::vector<std::string> queries;
     };
-    std::string host_name = util::network::host_name();
+    std::string host_name = sync::network::host_name();
     std::unique_ptr<PeerParams[]> peer_params = std::make_unique<PeerParams[]>(num_peers);
     {
         int peer_ndx = 0;
@@ -1550,7 +1550,7 @@ int main(int argc, char* argv[])
         }
     };
 
-    util::network::DeadlineTimer growth_timer{test_proc_service};
+    sync::network::DeadlineTimer growth_timer{test_proc_service};
     int current_num_peers = 0;
     int growth_ndx = 0;
     std::function<void()> grow = [&] {
@@ -1587,7 +1587,7 @@ int main(int argc, char* argv[])
         test_proc_service.post(func);
     }
 
-    util::network::DeadlineTimer keep_alive_timer{test_proc_service};
+    sync::network::DeadlineTimer keep_alive_timer{test_proc_service};
     std::function<void()> sched_keep_alive_wait;
     sched_keep_alive_wait = [&] {
         auto handler = [&](std::error_code ec) {

--- a/test/client/peer.cpp
+++ b/test/client/peer.cpp
@@ -84,8 +84,8 @@ Peer::Error map_error(std::error_code ec) noexcept
         }
         return Peer::Error::system_other;
     }
-    if (category == util::network::resolve_error_category) {
-        using util::network::ResolveErrors;
+    if (category == sync::network::resolve_error_category) {
+        using sync::network::ResolveErrors;
         switch (ResolveErrors(ec.value())) {
             case ResolveErrors::host_not_found:
             case ResolveErrors::host_not_found_try_again:
@@ -99,41 +99,41 @@ Peer::Error map_error(std::error_code ec) noexcept
         return Peer::Error::network_other;
     }
     bool is_ssl_related =
-        (category == util::network::ssl::error_category || category == util::network::openssl_error_category ||
-         category == util::network::secure_transport_error_category);
+        (category == sync::network::ssl::error_category || category == sync::network::openssl_error_category ||
+         category == sync::network::secure_transport_error_category);
     if (is_ssl_related)
         return Peer::Error::ssl;
-    if (std::strcmp(category_name, "realm::util::websocket::Error") == 0) {
-        switch (util::websocket::Error(ec.value())) {
-            case util::websocket::Error::bad_request_malformed_http:
-            case util::websocket::Error::bad_request_header_upgrade:
-            case util::websocket::Error::bad_request_header_connection:
-            case util::websocket::Error::bad_request_header_websocket_version:
-            case util::websocket::Error::bad_request_header_websocket_key:
+    if (std::strcmp(category_name, "realm::sync::websocket::Error") == 0) {
+        switch (sync::websocket::Error(ec.value())) {
+            case sync::websocket::Error::bad_request_malformed_http:
+            case sync::websocket::Error::bad_request_header_upgrade:
+            case sync::websocket::Error::bad_request_header_connection:
+            case sync::websocket::Error::bad_request_header_websocket_version:
+            case sync::websocket::Error::bad_request_header_websocket_key:
                 break;
-            case util::websocket::Error::bad_response_invalid_http:
+            case sync::websocket::Error::bad_response_invalid_http:
                 return Peer::Error::websocket_malformed_response;
-            case util::websocket::Error::bad_response_2xx_successful:
-            case util::websocket::Error::bad_response_200_ok:
+            case sync::websocket::Error::bad_response_2xx_successful:
+            case sync::websocket::Error::bad_response_200_ok:
                 break;
-            case util::websocket::Error::bad_response_3xx_redirection:
-            case util::websocket::Error::bad_response_301_moved_permanently:
+            case sync::websocket::Error::bad_response_3xx_redirection:
+            case sync::websocket::Error::bad_response_301_moved_permanently:
                 return Peer::Error::websocket_3xx;
-            case util::websocket::Error::bad_response_4xx_client_errors:
-            case util::websocket::Error::bad_response_401_unauthorized:
-            case util::websocket::Error::bad_response_403_forbidden:
-            case util::websocket::Error::bad_response_404_not_found:
-            case util::websocket::Error::bad_response_410_gone:
+            case sync::websocket::Error::bad_response_4xx_client_errors:
+            case sync::websocket::Error::bad_response_401_unauthorized:
+            case sync::websocket::Error::bad_response_403_forbidden:
+            case sync::websocket::Error::bad_response_404_not_found:
+            case sync::websocket::Error::bad_response_410_gone:
                 return Peer::Error::websocket_4xx;
-            case util::websocket::Error::bad_response_5xx_server_error:
-            case util::websocket::Error::bad_response_500_internal_server_error:
-            case util::websocket::Error::bad_response_502_bad_gateway:
-            case util::websocket::Error::bad_response_503_service_unavailable:
-            case util::websocket::Error::bad_response_504_gateway_timeout:
+            case sync::websocket::Error::bad_response_5xx_server_error:
+            case sync::websocket::Error::bad_response_500_internal_server_error:
+            case sync::websocket::Error::bad_response_502_bad_gateway:
+            case sync::websocket::Error::bad_response_503_service_unavailable:
+            case sync::websocket::Error::bad_response_504_gateway_timeout:
                 return Peer::Error::websocket_5xx;
-            case util::websocket::Error::bad_response_unexpected_status_code:
-            case util::websocket::Error::bad_response_header_protocol_violation:
-            case util::websocket::Error::bad_message:
+            case sync::websocket::Error::bad_response_unexpected_status_code:
+            case sync::websocket::Error::bad_response_header_protocol_violation:
+            case sync::websocket::Error::bad_message:
                 break;
         }
         return Peer::Error::websocket_other;

--- a/test/client/peer.hpp
+++ b/test/client/peer.hpp
@@ -115,7 +115,7 @@ private:
     DBRef m_receive_shared_group;
     TransactionRef m_receive_group = nullptr;
     std::string m_refresh_token;
-    util::Optional<util::network::DeadlineTimer> m_access_token_refresh_timer;
+    util::Optional<sync::network::DeadlineTimer> m_access_token_refresh_timer;
     std::atomic<bool> m_receive_enabled{false}; // Release-Acquire ordering
     milliseconds_type m_start_time = 0;
     ConnectionState m_connection_state = ConnectionState::disconnected;
@@ -142,14 +142,14 @@ class Peer::Context {
 public:
     sync::Client& client;
     sync::auth::Client& auth;
-    util::network::Service& test_proc_service;
+    sync::network::Service& test_proc_service;
     std::mt19937_64& test_proc_random;
     Metrics& metrics;
     const bool disable_sync_to_disk;
     const bool report_roundtrip_times;
     const bool reset_on_reconnect;
 
-    Context(sync::Client&, sync::auth::Client&, util::network::Service&, std::mt19937_64&, Metrics&, bool dstd,
+    Context(sync::Client&, sync::auth::Client&, sync::network::Service&, std::mt19937_64&, Metrics&, bool dstd,
             bool rrt, bool ror) noexcept;
 
     void init_metrics_gauges(bool report_propagation_time);
@@ -175,7 +175,7 @@ private:
     std::vector<milliseconds_type> m_roundtrip_times;   // Protected by m_metrics_aggregation_mutex
     std::vector<milliseconds_type> m_propagation_times; // Protected by m_metrics_aggregation_mutex
 
-    util::network::DeadlineTimer m_metrics_aggregation_timer{test_proc_service};
+    sync::network::DeadlineTimer m_metrics_aggregation_timer{test_proc_service};
 
     std::map<Error, int> m_error_counters;
 
@@ -215,7 +215,7 @@ inline sync::Session& Peer::get_session() noexcept
     return m_session;
 }
 
-inline Peer::Context::Context(sync::Client& c, sync::auth::Client& a, util::network::Service& tps,
+inline Peer::Context::Context(sync::Client& c, sync::auth::Client& a, sync::network::Service& tps,
                               std::mt19937_64& tpr, Metrics& m, bool dstd, bool rrt, bool ror) noexcept
     : client{c}
     , auth{a}

--- a/test/sync_fixtures.hpp
+++ b/test/sync_fixtures.hpp
@@ -301,7 +301,7 @@ public:
 
     util::PrefixLogger logger;
 
-    HTTPRequestClient(util::Logger& logger, const util::network::Endpoint& endpoint, const util::HTTPRequest& request)
+    HTTPRequestClient(util::Logger& logger, const network::Endpoint& endpoint, const HTTPRequest& request)
         : logger{"HTTP client: ", logger}
         , m_endpoint{endpoint}
         , m_http_client{*this, logger}
@@ -319,7 +319,7 @@ public:
 
     // get_response is used to retrieve the response after
     // fetch_response returns.
-    util::HTTPResponse& get_response()
+    HTTPResponse& get_response()
     {
         return m_response;
     }
@@ -340,13 +340,13 @@ public:
     }
 
 private:
-    util::network::Service m_service;
-    util::network::Socket m_socket{m_service};
-    util::network::ReadAheadBuffer m_read_ahead_buffer;
-    util::network::Endpoint m_endpoint;
-    util::HTTPClient<HTTPRequestClient> m_http_client;
-    util::HTTPRequest m_request;
-    util::HTTPResponse m_response;
+    network::Service m_service;
+    network::Socket m_socket{m_service};
+    network::ReadAheadBuffer m_read_ahead_buffer;
+    network::Endpoint m_endpoint;
+    HTTPClient<HTTPRequestClient> m_http_client;
+    HTTPRequest m_request;
+    HTTPResponse m_response;
 
     void initiate_tcp_connect()
     {
@@ -367,7 +367,7 @@ private:
             return;
         }
 
-        m_socket.set_option(util::network::SocketBase::no_delay(true));
+        m_socket.set_option(network::SocketBase::no_delay(true));
         logger.debug("Connected to endpoint '%1:%2'", m_endpoint.address(), m_endpoint.port());
 
 
@@ -376,7 +376,7 @@ private:
 
     void initiate_http_request()
     {
-        auto handler = [this](util::HTTPResponse response, std::error_code ec) {
+        auto handler = [this](HTTPResponse response, std::error_code ec) {
             if (ec != util::error::operation_aborted) {
                 if (ec) {
                     logger.debug("HTTP response error, ec = %1", ec.message());
@@ -389,7 +389,7 @@ private:
         m_http_client.async_request(m_request, handler);
     }
 
-    void handle_http_response(const util::HTTPResponse response)
+    void handle_http_response(const HTTPResponse response)
     {
         logger.debug("HTTP response received, status = %1", int(response.status));
         m_response = response;

--- a/test/test_handshake.cpp
+++ b/test/test_handshake.cpp
@@ -1,5 +1,6 @@
 #include <realm/sync/client.hpp>
 #include <realm/sync/network/http.hpp>
+#include <realm/sync/network/network.hpp>
 #include <realm/sync/network/websocket.hpp>
 
 #include "test.hpp"
@@ -9,9 +10,7 @@ using namespace realm;
 using namespace realm::sync;
 using namespace realm::test_util;
 
-using namespace realm::test_util;
-
-using port_type = util::network::Endpoint::port_type;
+using port_type = network::Endpoint::port_type;
 using ConnectionStateChangeListener = Session::ConnectionStateChangeListener;
 using ErrorInfo = Session::ErrorInfo;
 
@@ -33,7 +32,7 @@ public:
 
     void start()
     {
-        m_acceptor.open(util::network::StreamProtocol::ip_v4());
+        m_acceptor.open(network::StreamProtocol::ip_v4());
         m_acceptor.listen();
 
         auto handler = [this](std::error_code ec) {
@@ -53,7 +52,7 @@ public:
         m_service.stop();
     }
 
-    util::network::Endpoint listen_endpoint() const
+    network::Endpoint listen_endpoint() const
     {
         return m_acceptor.local_endpoint();
     }
@@ -69,11 +68,11 @@ public:
     }
 
 private:
-    util::network::Service m_service;
-    util::network::Acceptor m_acceptor;
-    util::network::Socket m_socket;
-    util::network::ReadAheadBuffer m_read_ahead_buffer;
-    util::HTTPServer<SurpriseServer> m_http_server;
+    network::Service m_service;
+    network::Acceptor m_acceptor;
+    network::Socket m_socket;
+    network::ReadAheadBuffer m_read_ahead_buffer;
+    HTTPServer<SurpriseServer> m_http_server;
     std::string m_response;
 
     void handle_accept()
@@ -340,7 +339,7 @@ namespace {
 TEST(Handshake_HTTP_Version)
 {
     const std::string server_path = "/http_1_0";
-    std::error_code ec = util::websocket::Error::bad_response_invalid_http;
+    std::error_code ec = websocket::Error::bad_response_invalid_http;
     bool is_fatal = true;
     run_client_surprise_server(test_context, server_path, ec, is_fatal);
 }
@@ -348,7 +347,7 @@ TEST(Handshake_HTTP_Version)
 TEST(Handshake_InvalidStatusCode)
 {
     const std::string server_path = "/invalid-status-code";
-    std::error_code ec = util::websocket::Error::bad_response_invalid_http;
+    std::error_code ec = websocket::Error::bad_response_invalid_http;
     bool is_fatal = true;
     run_client_surprise_server(test_context, server_path, ec, is_fatal);
 }
@@ -356,7 +355,7 @@ TEST(Handshake_InvalidStatusCode)
 TEST(Handshake_MissingWebSocketHeaders)
 {
     const std::string server_path = "/missing-websocket-headers";
-    std::error_code ec = util::websocket::Error::bad_response_header_protocol_violation;
+    std::error_code ec = websocket::Error::bad_response_header_protocol_violation;
     bool is_fatal = true;
     run_client_surprise_server(test_context, server_path, ec, is_fatal);
 }
@@ -364,7 +363,7 @@ TEST(Handshake_MissingWebSocketHeaders)
 TEST(Handshake_200)
 {
     const std::string server_path = "/200";
-    std::error_code ec = util::websocket::Error::bad_response_200_ok;
+    std::error_code ec = websocket::Error::bad_response_200_ok;
     bool is_fatal = true;
     run_client_surprise_server(test_context, server_path, ec, is_fatal);
 }
@@ -372,7 +371,7 @@ TEST(Handshake_200)
 TEST(Handshake_201)
 {
     const std::string server_path = "/201";
-    std::error_code ec = util::websocket::Error::bad_response_2xx_successful;
+    std::error_code ec = websocket::Error::bad_response_2xx_successful;
     bool is_fatal = true;
     run_client_surprise_server(test_context, server_path, ec, is_fatal);
 }
@@ -380,7 +379,7 @@ TEST(Handshake_201)
 TEST(Handshake_300)
 {
     const std::string server_path = "/300";
-    std::error_code ec = util::websocket::Error::bad_response_3xx_redirection;
+    std::error_code ec = websocket::Error::bad_response_3xx_redirection;
     bool is_fatal = false;
     run_client_surprise_server(test_context, server_path, ec, is_fatal);
 }
@@ -388,7 +387,7 @@ TEST(Handshake_300)
 TEST(Handshake_301)
 {
     const std::string server_path = "/301";
-    std::error_code ec = util::websocket::Error::bad_response_301_moved_permanently;
+    std::error_code ec = websocket::Error::bad_response_301_moved_permanently;
     bool is_fatal = false;
     run_client_surprise_server(test_context, server_path, ec, is_fatal);
 }
@@ -396,7 +395,7 @@ TEST(Handshake_301)
 TEST(Handshake_400)
 {
     const std::string server_path = "/400";
-    std::error_code ec = util::websocket::Error::bad_response_4xx_client_errors;
+    std::error_code ec = websocket::Error::bad_response_4xx_client_errors;
     bool is_fatal = true;
     run_client_surprise_server(test_context, server_path, ec, is_fatal);
 }
@@ -404,7 +403,7 @@ TEST(Handshake_400)
 TEST(Handshake_401)
 {
     const std::string server_path = "/401";
-    std::error_code ec = util::websocket::Error::bad_response_401_unauthorized;
+    std::error_code ec = websocket::Error::bad_response_401_unauthorized;
     bool is_fatal = true;
     run_client_surprise_server(test_context, server_path, ec, is_fatal);
 }
@@ -412,7 +411,7 @@ TEST(Handshake_401)
 TEST(Handshake_403)
 {
     const std::string server_path = "/403";
-    std::error_code ec = util::websocket::Error::bad_response_403_forbidden;
+    std::error_code ec = websocket::Error::bad_response_403_forbidden;
     bool is_fatal = true;
     run_client_surprise_server(test_context, server_path, ec, is_fatal);
 }
@@ -420,7 +419,7 @@ TEST(Handshake_403)
 TEST(Handshake_404)
 {
     const std::string server_path = "/404";
-    std::error_code ec = util::websocket::Error::bad_response_404_not_found;
+    std::error_code ec = websocket::Error::bad_response_404_not_found;
     bool is_fatal = true;
     run_client_surprise_server(test_context, server_path, ec, is_fatal);
 }
@@ -428,7 +427,7 @@ TEST(Handshake_404)
 TEST(Handshake_500)
 {
     const std::string server_path = "/500";
-    std::error_code ec = util::websocket::Error::bad_response_500_internal_server_error;
+    std::error_code ec = websocket::Error::bad_response_500_internal_server_error;
     bool is_fatal = false;
     run_client_surprise_server(test_context, server_path, ec, is_fatal);
 }
@@ -436,7 +435,7 @@ TEST(Handshake_500)
 TEST(Handshake_501)
 {
     const std::string server_path = "/501";
-    std::error_code ec = util::websocket::Error::bad_response_5xx_server_error;
+    std::error_code ec = websocket::Error::bad_response_5xx_server_error;
     bool is_fatal = false;
     run_client_surprise_server(test_context, server_path, ec, is_fatal);
 }
@@ -444,7 +443,7 @@ TEST(Handshake_501)
 TEST(Handshake_502)
 {
     const std::string server_path = "/502";
-    std::error_code ec = util::websocket::Error::bad_response_502_bad_gateway;
+    std::error_code ec = websocket::Error::bad_response_502_bad_gateway;
     bool is_fatal = false;
     run_client_surprise_server(test_context, server_path, ec, is_fatal);
 }
@@ -452,7 +451,7 @@ TEST(Handshake_502)
 TEST(Handshake_503)
 {
     const std::string server_path = "/503";
-    std::error_code ec = util::websocket::Error::bad_response_503_service_unavailable;
+    std::error_code ec = websocket::Error::bad_response_503_service_unavailable;
     bool is_fatal = false;
     run_client_surprise_server(test_context, server_path, ec, is_fatal);
 }
@@ -460,7 +459,7 @@ TEST(Handshake_503)
 TEST(Handshake_504)
 {
     const std::string server_path = "/504";
-    std::error_code ec = util::websocket::Error::bad_response_504_gateway_timeout;
+    std::error_code ec = websocket::Error::bad_response_504_gateway_timeout;
     bool is_fatal = false;
     run_client_surprise_server(test_context, server_path, ec, is_fatal);
 }
@@ -469,7 +468,7 @@ TEST(Handshake_504)
 TEST_IF(Handshake_Timeout, false)
 {
     // const std::string server_path = "/nothing";
-    // std::error_code ec = util::websocket::Error::; // CHANGE
+    // std::error_code ec = websocket::Error::; // CHANGE
     // bool is_fatal = false;
     // run_client_surprise_server(test_context, server_path, ec, is_fatal);
 }
@@ -507,7 +506,7 @@ TEST_IF(Handshake_ExternalServer, false)
                                                                                  const ErrorInfo* error_info) {
         if (error_info) {
             CHECK(connection_state == ConnectionState::disconnected);
-            std::error_code ec = util::websocket::Error::bad_response_301_moved_permanently;
+            std::error_code ec = websocket::Error::bad_response_301_moved_permanently;
             CHECK_EQUAL(ec, error_info->error_code);
             CHECK_EQUAL(true, error_info->is_fatal);
             client.stop();

--- a/test/test_sync.cpp
+++ b/test/test_sync.cpp
@@ -1676,14 +1676,14 @@ TEST(Sync_HTTP404NotFound)
     util::Optional<PKey> public_key = PKey::load_public(test_server_key_path());
     Server server(server_dir, std::move(public_key), server_config);
     server.start();
-    util::network::Endpoint endpoint = server.listen_endpoint();
+    network::Endpoint endpoint = server.listen_endpoint();
 
     ThreadWrapper server_thread;
     server_thread.start([&] {
         server.run();
     });
 
-    util::HTTPRequest request;
+    HTTPRequest request;
     request.path = "/not-found";
 
     HTTPRequestClient client(*(test_context.logger), endpoint, request);
@@ -1693,9 +1693,9 @@ TEST(Sync_HTTP404NotFound)
 
     server_thread.join();
 
-    const util::HTTPResponse& response = client.get_response();
+    const HTTPResponse& response = client.get_response();
 
-    CHECK(response.status == util::HTTPStatus::NotFound);
+    CHECK(response.status == HTTPStatus::NotFound);
     CHECK(response.headers.find("Server")->second == "RealmSync/" REALM_VERSION_STRING);
 }
 
@@ -1704,8 +1704,8 @@ namespace {
 
 class RequestWithContentLength {
 public:
-    RequestWithContentLength(test_util::unit_test::TestContext& test_context, util::network::Service& service,
-                             const util::network::Endpoint& endpoint, const std::string& content_length,
+    RequestWithContentLength(test_util::unit_test::TestContext& test_context, network::Service& service,
+                             const network::Endpoint& endpoint, const std::string& content_length,
                              const std::string& expected_response_line)
         : test_context{test_context}
         , m_socket{service}
@@ -1751,11 +1751,11 @@ public:
 
 private:
     test_util::unit_test::TestContext& test_context;
-    util::network::Socket m_socket;
-    util::network::ReadAheadBuffer m_read_ahead_buffer;
+    network::Socket m_socket;
+    network::ReadAheadBuffer m_read_ahead_buffer;
     static constexpr size_t m_buf_size = 1000;
     char m_buffer[m_buf_size];
-    const util::network::Endpoint& m_endpoint;
+    const network::Endpoint& m_endpoint;
     const std::string m_content_length;
     std::string m_request;
     const std::string m_expected_response_line;
@@ -1780,14 +1780,14 @@ TEST(Sync_HTTP_ContentLength)
     util::Optional<PKey> public_key = PKey::load_public(test_server_key_path());
     Server server(server_dir, std::move(public_key), server_config);
     server.start();
-    util::network::Endpoint endpoint = server.listen_endpoint();
+    network::Endpoint endpoint = server.listen_endpoint();
 
     ThreadWrapper server_thread;
     server_thread.start([&] {
         server.run();
     });
 
-    util::network::Service service;
+    network::Service service;
 
     RequestWithContentLength req_0(test_context, service, endpoint, "0", "HTTP/1.1 404 Not Found\r\n");
 

--- a/test/test_util_http.cpp
+++ b/test/test_util_http.cpp
@@ -6,7 +6,7 @@
 #include <thread>
 
 using namespace realm;
-using namespace realm::util;
+using namespace realm::sync;
 
 namespace {
 
@@ -127,8 +127,8 @@ TEST(HTTP_RequestResponse)
     ep = acceptor.local_endpoint();
     acceptor.listen();
 
-    Optional<HTTPRequest> received_request;
-    Optional<HTTPResponse> received_response;
+    util::Optional<HTTPRequest> received_request;
+    util::Optional<HTTPResponse> received_response;
 
     std::thread server_thread{[&] {
         BufferedSocket c(server);

--- a/test/test_util_network.cpp
+++ b/test/test_util_network.cpp
@@ -44,6 +44,7 @@ using namespace realm::test_util;
 // `experiments/testcase.cpp` and then run `sh build.sh
 // check-testcase` (or one of its friends) from the command line.
 
+using namespace realm::sync;
 
 namespace {
 

--- a/test/test_util_network_ssl.cpp
+++ b/test/test_util_network_ssl.cpp
@@ -5,9 +5,10 @@
 #include "test.hpp"
 #include "util/semaphore.hpp"
 
-using namespace realm::util;
+using namespace realm;
+using namespace realm::sync;
 using namespace realm::test_util;
-
+using namespace realm::util;
 
 // Test independence and thread-safety
 // -----------------------------------
@@ -148,7 +149,7 @@ public:
     }
 
     // Must be called by thread associated with `client_service`
-    void delay_client(realm::util::UniqueFunction<void()> handler, int n = 512)
+    void delay_client(UniqueFunction<void()> handler, int n = 512)
     {
         m_handler = std::move(handler);
         m_num = n;
@@ -159,7 +160,7 @@ private:
     network::Socket m_server_socket, m_client_socket;
     char m_server_char = 0, m_client_char = 0;
     int m_num;
-    realm::util::UniqueFunction<void()> m_handler;
+    UniqueFunction<void()> m_handler;
 
     void initiate_server_read()
     {
@@ -196,7 +197,7 @@ private:
     void initiate_client_write()
     {
         if (m_num <= 0) {
-            realm::util::UniqueFunction<void()> handler = std::move(m_handler);
+            UniqueFunction<void()> handler = std::move(m_handler);
             m_handler = nullptr;
             handler();
             return;
@@ -729,7 +730,7 @@ TEST(Util_Network_SSL_StressTest)
         network::DeadlineTimer read_timer{service};
         network::DeadlineTimer write_timer{service};
         bool read_done = false, write_done = false;
-        realm::util::UniqueFunction<void()> shedule_cancellation = [&] {
+        UniqueFunction<void()> shedule_cancellation = [&] {
             auto handler = [&](std::error_code ec) {
                 REALM_ASSERT(!ec || ec == error::operation_aborted);
                 if (ec == error::operation_aborted)
@@ -746,7 +747,7 @@ TEST(Util_Network_SSL_StressTest)
         char* read_begin = read_buffer.get();
         char* read_end = read_buffer.get() + original_size;
         int num_read_cycles = 0;
-        realm::util::UniqueFunction<void()> read = [&] {
+        UniqueFunction<void()> read = [&] {
             if (read_begin == read_end) {
                 log("<R%1>", id);
                 CHECK(std::equal(read_original, read_original + original_size, read_buffer.get()));
@@ -792,7 +793,7 @@ TEST(Util_Network_SSL_StressTest)
         const char* write_begin = write_original;
         const char* write_end = write_original + original_size;
         int num_write_cycles = 0;
-        realm::util::UniqueFunction<void()> write = [&] {
+        UniqueFunction<void()> write = [&] {
             if (write_begin == write_end) {
                 log("<W%1>", id);
                 ++num_write_cycles;
@@ -882,7 +883,7 @@ TEST(Util_Network_SSL_Certificate_CN_SAN)
     ssl_stream_1.set_logger(test_context.logger.get());
     ssl_stream_2.set_logger(test_context.logger.get());
 
-    ssl_stream_2.set_verify_mode(realm::util::network::ssl::VerifyMode::peer);
+    ssl_stream_2.set_verify_mode(network::ssl::VerifyMode::peer);
 
     // We expect success because the certificate is signed for www.example.com
     // in both Common Name and SAN.
@@ -927,7 +928,7 @@ TEST(Util_Network_SSL_Certificate_SAN)
     ssl_stream_1.set_logger(test_context.logger.get());
     ssl_stream_2.set_logger(test_context.logger.get());
 
-    ssl_stream_2.set_verify_mode(realm::util::network::ssl::VerifyMode::peer);
+    ssl_stream_2.set_verify_mode(network::ssl::VerifyMode::peer);
 
     ssl_stream_2.set_host_name("support.example.com");
 
@@ -974,7 +975,7 @@ TEST(Util_Network_SSL_Certificate_CN)
     ssl_stream_1.set_logger(test_context.logger.get());
     ssl_stream_2.set_logger(test_context.logger.get());
 
-    ssl_stream_2.set_verify_mode(realm::util::network::ssl::VerifyMode::peer);
+    ssl_stream_2.set_verify_mode(network::ssl::VerifyMode::peer);
 
     ssl_stream_2.set_host_name("www.example.com");
 
@@ -1022,7 +1023,7 @@ TEST(Util_Network_SSL_Certificate_IP)
     ssl_stream_1.set_logger(test_context.logger.get());
     ssl_stream_2.set_logger(test_context.logger.get());
 
-    ssl_stream_2.set_verify_mode(realm::util::network::ssl::VerifyMode::peer);
+    ssl_stream_2.set_verify_mode(network::ssl::VerifyMode::peer);
 
     ssl_stream_2.set_host_name("127.0.0.1");
 
@@ -1073,7 +1074,7 @@ TEST(Util_Network_SSL_Certificate_Failure)
     ssl_stream_1.set_logger(test_context.logger.get());
     ssl_stream_2.set_logger(test_context.logger.get());
 
-    ssl_stream_2.set_verify_mode(realm::util::network::ssl::VerifyMode::peer);
+    ssl_stream_2.set_verify_mode(network::ssl::VerifyMode::peer);
 
     // We expect failure because the certificate is signed for www.example.com
     ssl_stream_2.set_host_name("www.another-example.com");

--- a/test/test_util_websocket.cpp
+++ b/test/test_util_websocket.cpp
@@ -4,7 +4,7 @@
 #include <realm/sync/network/websocket.hpp>
 
 using namespace realm;
-using namespace realm::util;
+using namespace realm::sync;
 
 using WriteCompletionHandler = websocket::WriteCompletionHandler;
 using ReadCompletionHandler = websocket::ReadCompletionHandler;
@@ -103,7 +103,7 @@ private:
     {
         m_logger.trace("delim_not_found");
         m_reader_waiting = false;
-        m_handler(MiscExtErrors::delim_not_found, 0);
+        m_handler(util::MiscExtErrors::delim_not_found, 0);
     }
 };
 


### PR DESCRIPTION
## What, How & Why?
Updated namespaces for the files moved from util/ to sync/network to be `realm::sync` instead of `realm::util`
Fixes #6108 

## ☑️ ToDos
* [X] 📝 Changelog update
* ~~[ ] 🚦 Tests (or not relevant)~~
* ~~[ ] C-API, if public C++ API changed.~~
