### PR TITLE
Optimize acquiring and releasing read locks when one is already held

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ### Enhancements
 * <New feature description> (PR [#????](https://github.com/realm/realm-core/pull/????))
-* Upgrade OpenSSL from 1.1.1n to 3.0.7. ([#6097](https://github.com/realm/realm-core/pull/6097))
+* Improve performance of acquiring read locks when a read lock for that version is already held. This speeds up many operations related to change notifications, and particularly refreshing a Realm which has change notifiers registered.
 
 ### Fixed
 * <How do the end-user experience this issue? what was the impact?> ([#????](https://github.com/realm/realm-core/issues/????), since v?.?.?)

--- a/src/realm/db.cpp
+++ b/src/realm/db.cpp
@@ -52,7 +52,7 @@
 #include <process.h>
 #endif
 
-//#define REALM_ENABLE_LOGFILE
+// #define REALM_ENABLE_LOGFILE
 
 
 using namespace realm;
@@ -689,6 +689,8 @@ private:
                 return r.count_live;
             case ReadLockInfo::Full:
                 return r.count_full;
+            default:
+                REALM_UNREACHABLE(); // silence a warning
         }
     }
 

--- a/src/realm/db.cpp
+++ b/src/realm/db.cpp
@@ -541,6 +541,18 @@ public:
 
     void release_read_lock(const ReadLockInfo& read_lock)
     {
+        {
+            std::lock_guard lock(m_local_mutex);
+            REALM_ASSERT(read_lock.m_reader_idx < m_local_readers.size());
+            auto& r = m_local_readers[read_lock.m_reader_idx];
+            auto& f = field_for_type(r, read_lock.m_type);
+            REALM_ASSERT(f > 0);
+            if (--f > 0)
+                return;
+            if (r.count_live == 0 && r.count_full == 0 && r.count_frozen == 0)
+                r.version = 0;
+        }
+
         std::lock_guard lock(m_mutex);
         // we should not need to call ensure_full_reader_mapping,
         // since releasing a read lock means it has been grabbed
@@ -548,31 +560,22 @@ public:
         REALM_ASSERT(read_lock.m_reader_idx < m_local_max_entry);
         auto& r = m_info->readers.get(read_lock.m_reader_idx);
         REALM_ASSERT(read_lock.m_version == r.version);
-        switch (read_lock.m_type) {
-            case ReadLockInfo::Frozen: {
-                --r.count_frozen;
-                break;
-            }
-            case ReadLockInfo::Live: {
-                --r.count_live;
-                break;
-            }
-            case ReadLockInfo::Full: {
-                --r.count_full;
-                break;
-            }
-        }
+        --field_for_type(r, read_lock.m_type);
     }
 
     ReadLockInfo grab_read_lock(ReadLockInfo::Type type, VersionID version_id = {})
     {
         ReadLockInfo read_lock;
-        std::lock_guard lock(m_mutex);
-        ensure_full_reader_mapping();
+        if (try_grab_local_read_lock(read_lock, type, version_id))
+            return read_lock;
+
         const bool pick_specific = version_id.version != VersionID().version;
+
+        std::lock_guard lock(m_mutex);
         auto newest = m_info->readers.newest.load();
         REALM_ASSERT(newest != VersionList::nil);
         read_lock.m_reader_idx = pick_specific ? version_id.index : newest;
+        ensure_full_reader_mapping();
         bool picked_newest = read_lock.m_reader_idx == (unsigned)newest;
         auto& r = m_info->readers.get(read_lock.m_reader_idx);
         if (pick_specific && version_id.version != r.version)
@@ -583,24 +586,18 @@ public:
             if (type != ReadLockInfo::Frozen && r.count_live == 0)
                 throw BadVersion();
         }
-        switch (type) {
-            case ReadLockInfo::Frozen: {
-                ++r.count_frozen;
-                break;
-            }
-            case ReadLockInfo::Live: {
-                ++r.count_live;
-                break;
-            }
-            case ReadLockInfo::Full: {
-                ++r.count_full;
-                break;
-            }
+        populate_read_lock(read_lock, r, type);
+
+        std::lock_guard local_lock(m_local_mutex);
+        grow_local_cache(read_lock.m_reader_idx + 1);
+        auto& r2 = m_local_readers[read_lock.m_reader_idx];
+        if (!r2.is_active()) {
+            r2 = r;
+            r2.count_full = r2.count_live = r2.count_frozen = 0;
         }
-        read_lock.m_type = type;
-        read_lock.m_version = r.version;
-        read_lock.m_top_ref = static_cast<ref_type>(r.current_top);
-        read_lock.m_file_size = static_cast<size_t>(r.filesize);
+        REALM_ASSERT(field_for_type(r2, type) == 0);
+        field_for_type(r2, type) = 1;
+
         return read_lock;
     }
 
@@ -646,6 +643,58 @@ private:
             m_info = m_reader_map.get_addr();
         }
     }
+
+    void grow_local_cache(size_t new_size)
+    {
+        if (new_size > m_local_readers.size())
+            m_local_readers.resize(new_size, VersionList::ReadCount{});
+    }
+
+    void populate_read_lock(ReadLockInfo& read_lock, VersionList::ReadCount& r, ReadLockInfo::Type type)
+    {
+        ++field_for_type(r, type);
+        read_lock.m_type = type;
+        read_lock.m_version = r.version;
+        read_lock.m_top_ref = static_cast<ref_type>(r.current_top);
+        read_lock.m_file_size = static_cast<size_t>(r.filesize);
+    }
+
+    bool try_grab_local_read_lock(ReadLockInfo& read_lock, ReadLockInfo::Type type, VersionID version_id)
+    {
+        const bool pick_specific = version_id.version != VersionID().version;
+        auto index = pick_specific ? version_id.index : m_info->readers.newest.load();
+        std::lock_guard local_lock(m_local_mutex);
+        if (index >= m_local_readers.size())
+            return false;
+
+        auto& r = m_local_readers[index];
+        if (!r.is_active())
+            return false;
+        if (pick_specific && r.version != version_id.version)
+            return false;
+        if (field_for_type(r, type) == 0)
+            return false;
+
+        read_lock.m_reader_idx = index;
+        populate_read_lock(read_lock, r, type);
+        return true;
+    }
+
+    static uint32_t& field_for_type(VersionList::ReadCount& r, ReadLockInfo::Type type)
+    {
+        switch (type) {
+            case ReadLockInfo::Frozen:
+                return r.count_frozen;
+            case ReadLockInfo::Live:
+                return r.count_live;
+            case ReadLockInfo::Full:
+                return r.count_full;
+        }
+    }
+
+    std::mutex m_local_mutex;
+    std::vector<VersionList::ReadCount> m_local_readers;
+
     unsigned int m_local_max_entry;
     SharedInfo* m_info;
     File& m_file;

--- a/src/realm/version_id.hpp
+++ b/src/realm/version_id.hpp
@@ -34,36 +34,34 @@ struct VersionID {
     version_type version = std::numeric_limits<version_type>::max();
     uint_fast32_t index = 0;
 
-    VersionID()
-    {
-    }
-    VersionID(version_type initial_version, uint_fast32_t initial_index)
+    constexpr VersionID() = default;
+    constexpr VersionID(version_type initial_version, uint_fast32_t initial_index) noexcept
     {
         version = initial_version;
         index = initial_index;
     }
 
-    bool operator==(const VersionID& other) const
+    constexpr bool operator==(const VersionID& other) const noexcept
     {
         return version == other.version;
     }
-    bool operator!=(const VersionID& other) const
+    constexpr bool operator!=(const VersionID& other) const noexcept
     {
         return version != other.version;
     }
-    bool operator<(const VersionID& other) const
+    constexpr bool operator<(const VersionID& other) const noexcept
     {
         return version < other.version;
     }
-    bool operator<=(const VersionID& other) const
+    constexpr bool operator<=(const VersionID& other) const noexcept
     {
         return version <= other.version;
     }
-    bool operator>(const VersionID& other) const
+    constexpr bool operator>(const VersionID& other) const noexcept
     {
         return version > other.version;
     }
-    bool operator>=(const VersionID& other) const
+    constexpr bool operator>=(const VersionID& other) const noexcept
     {
         return version >= other.version;
     }

--- a/test/benchmark-common-tasks/main.cpp
+++ b/test/benchmark-common-tasks/main.cpp
@@ -1941,6 +1941,22 @@ struct IterateTableByIndexStringPrimaryKey : IterateTableByIndexNoPrimaryKey {
     }
 };
 
+struct TransactionDuplicate : Benchmark {
+    const char* name() const
+    {
+        return "TransactionDuplicate";
+    }
+
+    void operator()(DBRef db)
+    {
+        auto tr = db->start_read();
+        for (int i = 0; i < 10'000; ++i)
+            tr->duplicate();
+    }
+    void before_each(DBRef) {}
+    void after_each(DBRef) {}
+};
+
 const char* to_lead_cstr(RealmDurability level)
 {
     switch (level) {
@@ -2142,6 +2158,8 @@ int benchmark_common_tasks_main()
     BENCH(BenchmarkWithIntUIDsRandomOrderRandomAccess);
     BENCH(BenchmarkWithIntUIDsRandomOrderRandomDelete);
     BENCH(BenchmarkWithIntUIDsRandomOrderRandomCreate);
+
+    BENCH(TransactionDuplicate);
 
 #undef BENCH
 #undef BENCH2


### PR DESCRIPTION
Acquiring the file lock which guards the lock file is an expensive operation which dominates the runtime of creating a new Transaction. To avoid doing that when possible, this makes it so that we only update the lock file when transitioning between zero and one of each lock type, and all other refcounting is done purely in memory.

This replaces a file lock with a much cheaper local mutex whenever we already have a read lock of that type for the given version (or when releasing, if we still have a read lock of that type). This makes the temporary Transactions used for things like notifications much cheaper.

Benchmark results:

TransactionDuplicate (v13.1.2): 10.52ms
TransactionDuplicate (this): 1.80ms

OS notification delivery (tg/notifier-badversion): 800ms in do_refresh()
OS notification delivery (this): 413ms in do_refresh()
OS notification delivery (v13.1.2): 277ms in do_refresh()
