### PR TITLE
Create DefaultSocketProvider class

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,7 +23,7 @@
 * Updates for upcoming Platform Networking feature, including new SyncSocketProvider class. ([PR #6096](https://github.com/realm/realm-core/pull/6096))
 * Updated namespaces for files moved to realm/sync/network ([PR #6109](https://github.com/realm/realm-core/pull/6109))
 * Replace util::network::Trigger with a Sync client custom trigger. ([PR #6121](https://github.com/realm/realm-core/pull/6121))
-* Partial implementation of DefaultSyncSocket ([]())
+* Create DefaultSyncSocket class ([PR #6116](https://github.com/realm/realm-core/pull/6116))
 
 ----------------------------------------------
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@
 * Updates for upcoming Platform Networking feature, including new SyncSocketProvider class. ([PR #6096](https://github.com/realm/realm-core/pull/6096))
 * Updated namespaces for files moved to realm/sync/network ([PR #6109](https://github.com/realm/realm-core/pull/6109))
 * Replace util::network::Trigger with a Sync client custom trigger. ([PR #6121](https://github.com/realm/realm-core/pull/6121))
+* Partial implementation of DefaultSyncSocket ([]())
 
 ----------------------------------------------
 

--- a/src/realm/status.hpp
+++ b/src/realm/status.hpp
@@ -54,6 +54,8 @@ public:
     inline Status& operator=(Status&& other) noexcept;
 
     inline bool is_ok() const noexcept;
+    // return true if error occurred
+    inline operator bool() const noexcept;
     inline const std::string& reason() const noexcept;
     inline ErrorCodes::Error code() const noexcept;
     inline StringData code_string() const noexcept;
@@ -199,7 +201,12 @@ inline Status& Status::operator=(Status&& other) noexcept
 
 inline bool Status::is_ok() const noexcept
 {
-    return !m_error;
+    return !m_error || m_error->m_code == ErrorCodes::OK;
+}
+
+inline Status::operator bool() const noexcept
+{
+    return !is_ok();
 }
 
 inline const std::string& Status::reason() const noexcept

--- a/src/realm/status.hpp
+++ b/src/realm/status.hpp
@@ -54,8 +54,6 @@ public:
     inline Status& operator=(Status&& other) noexcept;
 
     inline bool is_ok() const noexcept;
-    // return true if error occurred
-    inline operator bool() const noexcept;
     inline const std::string& reason() const noexcept;
     inline ErrorCodes::Error code() const noexcept;
     inline StringData code_string() const noexcept;
@@ -201,12 +199,7 @@ inline Status& Status::operator=(Status&& other) noexcept
 
 inline bool Status::is_ok() const noexcept
 {
-    return !m_error || m_error->m_code == ErrorCodes::OK;
-}
-
-inline Status::operator bool() const noexcept
-{
-    return !is_ok();
+    return !m_error;
 }
 
 inline const std::string& Status::reason() const noexcept

--- a/src/realm/sync/client.cpp
+++ b/src/realm/sync/client.cpp
@@ -405,7 +405,7 @@ ClientImpl::~ClientImpl()
 void ClientImpl::cancel_reconnect_delay()
 {
     // Thread safety required
-    event_loop_post([this](Status status) mutable {
+    event_loop_post([this](Status status) {
         if (status == ErrorCodes::OperationAborted)
             return;
         for (auto& p : m_server_slots) {

--- a/src/realm/sync/network/default_socket.cpp
+++ b/src/realm/sync/network/default_socket.cpp
@@ -3,18 +3,21 @@
 #include <realm/sync/network/network.hpp>
 #include <realm/sync/network/network_ssl.hpp>
 #include <realm/sync/network/websocket.hpp>
+#include <realm/util/random.hpp>
 
 namespace realm::sync::websocket {
 
 namespace {
-class EZSocketImpl final : public EZSocket, public Config {
+class DefaultWebSocketImpl final : public DefaultWebSocket, public Config {
 public:
-    EZSocketImpl(EZConfig& config, EZObserver& observer, EZEndpoint&& endpoint)
-        : m_logger_ptr{config.logger}
+    DefaultWebSocketImpl(const std::shared_ptr<util::Logger>& logger_ptr, network::Service& service,
+                         std::mt19937_64& random, const std::string user_agent, EZObserver& observer,
+                         EZEndpoint&& endpoint)
+        : m_logger_ptr{logger_ptr}
         , m_logger{*m_logger_ptr}
-        , m_random{config.random}
-        , m_service{config.service}
-        , m_user_agent{config.user_agent}
+        , m_service{service}
+        , m_user_agent{user_agent}
+        , m_random{random}
         , m_observer{observer}
         , m_endpoint{std::move(endpoint)}
         , m_websocket(*this)
@@ -98,9 +101,9 @@ private:
 
     const std::shared_ptr<util::Logger> m_logger_ptr;
     util::Logger& m_logger;
-    std::mt19937_64& m_random;
     network::Service& m_service;
-    std::string m_user_agent;
+    const std::string m_user_agent;
+    std::mt19937_64& m_random;
 
     EZObserver& m_observer;
 
@@ -111,11 +114,11 @@ private:
     util::Optional<network::ssl::Stream> m_ssl_stream;
     network::ReadAheadBuffer m_read_ahead_buffer;
     websocket::Socket m_websocket;
-    util::Optional<HTTPClient<EZSocketImpl>> m_proxy_client;
+    util::Optional<HTTPClient<DefaultWebSocketImpl>> m_proxy_client;
 };
 
 
-void EZSocketImpl::async_read(char* buffer, std::size_t size, ReadCompletionHandler handler)
+void DefaultWebSocketImpl::async_read(char* buffer, std::size_t size, ReadCompletionHandler handler)
 {
     REALM_ASSERT(m_socket);
     if (m_ssl_stream) {
@@ -127,7 +130,7 @@ void EZSocketImpl::async_read(char* buffer, std::size_t size, ReadCompletionHand
 }
 
 
-void EZSocketImpl::async_read_until(char* buffer, std::size_t size, char delim, ReadCompletionHandler handler)
+void DefaultWebSocketImpl::async_read_until(char* buffer, std::size_t size, char delim, ReadCompletionHandler handler)
 {
     REALM_ASSERT(m_socket);
     if (m_ssl_stream) {
@@ -139,7 +142,7 @@ void EZSocketImpl::async_read_until(char* buffer, std::size_t size, char delim, 
 }
 
 
-void EZSocketImpl::async_write(const char* data, std::size_t size, WriteCompletionHandler handler)
+void DefaultWebSocketImpl::async_write(const char* data, std::size_t size, WriteCompletionHandler handler)
 {
     REALM_ASSERT(m_socket);
     if (m_ssl_stream) {
@@ -151,7 +154,7 @@ void EZSocketImpl::async_write(const char* data, std::size_t size, WriteCompleti
 }
 
 
-void EZSocketImpl::initiate_resolve()
+void DefaultWebSocketImpl::initiate_resolve()
 {
     const std::string& address = m_endpoint.proxy ? m_endpoint.proxy->address : m_endpoint.address;
     const port_type& port = m_endpoint.proxy ? m_endpoint.proxy->port : m_endpoint.port;
@@ -174,7 +177,7 @@ void EZSocketImpl::initiate_resolve()
 }
 
 
-void EZSocketImpl::handle_resolve(std::error_code ec, network::Endpoint::List endpoints)
+void DefaultWebSocketImpl::handle_resolve(std::error_code ec, network::Endpoint::List endpoints)
 {
     if (ec) {
         m_logger.error("Failed to resolve '%1:%2': %3", m_endpoint.address, m_endpoint.port, ec.message()); // Throws
@@ -186,7 +189,7 @@ void EZSocketImpl::handle_resolve(std::error_code ec, network::Endpoint::List en
 }
 
 
-void EZSocketImpl::initiate_tcp_connect(network::Endpoint::List endpoints, std::size_t i)
+void DefaultWebSocketImpl::initiate_tcp_connect(network::Endpoint::List endpoints, std::size_t i)
 {
     REALM_ASSERT(i < endpoints.size());
 
@@ -203,7 +206,7 @@ void EZSocketImpl::initiate_tcp_connect(network::Endpoint::List endpoints, std::
 }
 
 
-void EZSocketImpl::handle_tcp_connect(std::error_code ec, network::Endpoint::List endpoints, std::size_t i)
+void DefaultWebSocketImpl::handle_tcp_connect(std::error_code ec, network::Endpoint::List endpoints, std::size_t i)
 {
     REALM_ASSERT(i < endpoints.size());
     const network::Endpoint& ep = *(endpoints.begin() + i);
@@ -235,7 +238,7 @@ void EZSocketImpl::handle_tcp_connect(std::error_code ec, network::Endpoint::Lis
     initiate_websocket_or_ssl_handshake(); // Throws
 }
 
-void EZSocketImpl::initiate_websocket_or_ssl_handshake()
+void DefaultWebSocketImpl::initiate_websocket_or_ssl_handshake()
 {
     if (m_endpoint.is_ssl) {
         initiate_ssl_handshake(); // Throws
@@ -245,7 +248,7 @@ void EZSocketImpl::initiate_websocket_or_ssl_handshake()
     }
 }
 
-void EZSocketImpl::initiate_http_tunnel()
+void DefaultWebSocketImpl::initiate_http_tunnel()
 {
     HTTPRequest req;
     req.method = HTTPMethod::Connect;
@@ -274,7 +277,7 @@ void EZSocketImpl::initiate_http_tunnel()
     m_proxy_client->async_request(req, std::move(handler)); // Throws
 }
 
-void EZSocketImpl::initiate_ssl_handshake()
+void DefaultWebSocketImpl::initiate_ssl_handshake()
 {
     using namespace network::ssl;
 
@@ -322,7 +325,7 @@ void EZSocketImpl::initiate_ssl_handshake()
 }
 
 
-void EZSocketImpl::handle_ssl_handshake(std::error_code ec)
+void DefaultWebSocketImpl::handle_ssl_handshake(std::error_code ec)
 {
     if (ec) {
         REALM_ASSERT(ec != util::error::operation_aborted);
@@ -334,7 +337,7 @@ void EZSocketImpl::handle_ssl_handshake(std::error_code ec)
 }
 
 
-void EZSocketImpl::initiate_websocket_handshake()
+void DefaultWebSocketImpl::initiate_websocket_handshake()
 {
     auto headers = HTTPHeaders(m_endpoint.headers.begin(), m_endpoint.headers.end());
     headers["User-Agent"] = m_user_agent;
@@ -349,11 +352,10 @@ void EZSocketImpl::initiate_websocket_handshake()
 }
 } // namespace
 
-EZSocket::~EZSocket() = default;
-
-std::unique_ptr<EZSocket> EZSocketFactory::connect(EZObserver* observer, EZEndpoint&& endpoint)
+std::unique_ptr<DefaultWebSocket> DefaultSocketProvider::connect_legacy(EZObserver* observer, EZEndpoint&& endpoint)
 {
-    return std::make_unique<EZSocketImpl>(m_config, *observer, std::move(endpoint));
+    return std::make_unique<DefaultWebSocketImpl>(m_logger_ptr, *m_service, m_random, m_user_agent, *observer,
+                                                  std::move(endpoint));
 }
 
 } // namespace realm::sync::websocket

--- a/src/realm/sync/network/default_socket.cpp
+++ b/src/realm/sync/network/default_socket.cpp
@@ -3,8 +3,6 @@
 #include <realm/sync/network/network.hpp>
 #include <realm/sync/network/network_ssl.hpp>
 #include <realm/sync/network/websocket.hpp>
-#include <realm/util/random.hpp>
-#include <realm/util/span.hpp>
 
 namespace realm::sync::websocket {
 
@@ -16,9 +14,9 @@ public:
                          EZEndpoint&& endpoint)
         : m_logger_ptr{logger_ptr}
         , m_logger{*m_logger_ptr}
+        , m_random{random}
         , m_service{service}
         , m_user_agent{user_agent}
-        , m_random{random}
         , m_observer{observer}
         , m_endpoint{std::move(endpoint)}
         , m_websocket(*this)
@@ -104,9 +102,9 @@ private:
 
     const std::shared_ptr<util::Logger> m_logger_ptr;
     util::Logger& m_logger;
+    std::mt19937_64& m_random;
     network::Service& m_service;
     const std::string m_user_agent;
-    std::mt19937_64& m_random;
 
     EZObserver& m_observer;
 

--- a/src/realm/sync/network/default_socket.hpp
+++ b/src/realm/sync/network/default_socket.hpp
@@ -80,13 +80,6 @@ protected:
     ~EZObserver() = default;
 };
 
-class DefaultWebSocket {
-public:
-    virtual ~DefaultWebSocket() = default;
-
-    virtual void async_write_binary(const char* data, size_t size, util::UniqueFunction<void()>&& handler) = 0;
-};
-
 class DefaultSocketProvider : public SyncSocketProvider {
 public:
     class Timer : public SyncSocketProvider::Timer {
@@ -132,7 +125,7 @@ public:
     }
 
     // Temporary workaround until Client::Connection is updated to use WebSocketObserver
-    std::unique_ptr<DefaultWebSocket> connect_legacy(EZObserver* observer, EZEndpoint&& endpoint);
+    std::unique_ptr<WebSocketInterface> connect_legacy(EZObserver* observer, EZEndpoint&& endpoint);
 
     std::unique_ptr<WebSocketInterface> connect(WebSocketObserver*, WebSocketEndpoint&&) override
     {

--- a/src/realm/sync/network/default_socket.hpp
+++ b/src/realm/sync/network/default_socket.hpp
@@ -84,11 +84,7 @@ class DefaultSocketProvider : public SyncSocketProvider {
 public:
     class Timer : public SyncSocketProvider::Timer {
     public:
-        Timer(network::Service& service, std::chrono::milliseconds delay, FunctionHandler&& handler)
-            : m_timer{service}
-        {
-            m_timer.async_wait(delay, std::move(handler));
-        }
+        friend class DefaultSocketProvider;
 
         /// Cancels the timer and destroys the timer instance.
         ~Timer() = default;
@@ -97,6 +93,13 @@ public:
         void cancel() override
         {
             m_timer.cancel();
+        }
+
+    protected:
+        Timer(network::Service& service, std::chrono::milliseconds delay, FunctionHandler&& handler)
+            : m_timer{service}
+        {
+            m_timer.async_wait(delay, std::move(handler));
         }
 
     private:
@@ -143,7 +146,7 @@ public:
 
     SyncTimer create_timer(std::chrono::milliseconds delay, FunctionHandler&& handler) override
     {
-        return std::make_unique<DefaultSocketProvider::Timer>(*m_service, delay, std::move(handler));
+        return std::unique_ptr<Timer>(new DefaultSocketProvider::Timer(*m_service, delay, std::move(handler)));
     }
 
 private:

--- a/src/realm/sync/network/default_socket.hpp
+++ b/src/realm/sync/network/default_socket.hpp
@@ -5,7 +5,10 @@
 #include <map>
 
 #include <realm/sync/config.hpp>
+#include <realm/sync/socket_provider.hpp>
 #include <realm/sync/network/http.hpp>
+#include <realm/sync/network/network.hpp>
+#include <realm/util/random.hpp>
 
 namespace realm::sync::network {
 class Service;
@@ -15,13 +18,6 @@ namespace realm::sync::websocket {
 using port_type = sync::port_type;
 
 // TODO figure out what belongs on config and what belongs on endpoint.
-struct EZConfig {
-    std::shared_ptr<util::Logger> logger;
-    std::mt19937_64& random;
-    network::Service& service;
-    std::string user_agent;
-};
-
 struct EZEndpoint {
     std::string address;
     port_type port;
@@ -84,27 +80,106 @@ protected:
     ~EZObserver() = default;
 };
 
-class EZSocket {
+class DefaultWebSocket {
 public:
-    virtual ~EZSocket();
+    virtual ~DefaultWebSocket() = default;
 
     virtual void async_write_binary(const char* data, size_t size, util::UniqueFunction<void()>&& handler) = 0;
 };
 
-class EZSocketFactory {
+class DefaultSocketProvider : public SyncSocketProvider {
 public:
-    EZSocketFactory(EZConfig config)
-        : m_config(config)
+    class Timer : public SyncSocketProvider::Timer {
+    public:
+        Timer(network::Service& service, std::chrono::milliseconds delay, FunctionHandler&& handler)
+            : m_timer{service}
+        {
+            // Temporary workaround until the event loop is updated to use Status
+            auto&& new_handler = [handler = std::move(handler)](std::error_code ec) {
+                Status status = !ec ? Status::OK()
+                                : ec == util::error::operation_aborted
+                                    ? Status{ErrorCodes::OperationAborted, "Timer canceled"}
+                                    : Status{ErrorCodes::RuntimeError, "Timer failed"};
+                handler(status);
+            };
+            m_timer.async_wait(delay, std::move(new_handler));
+        }
+
+        /// Cancels the timer and destroys the timer instance.
+        ~Timer() = default;
+
+        /// Cancel the timer immediately
+        void cancel() override
+        {
+            m_timer.cancel();
+        }
+
+    private:
+        network::DeadlineTimer m_timer;
+    };
+
+    DefaultSocketProvider(const std::shared_ptr<util::Logger>& logger, const std::string user_agent)
+        : m_logger_ptr{logger}
+        , m_service{std::make_shared<network::Service>()}
+        , m_random{}
+        , m_user_agent{user_agent}
     {
-        REALM_ASSERT(m_config.logger); // Make sure the logger is valid
+        REALM_ASSERT(m_logger_ptr);                     // Make sure the logger is valid
+        REALM_ASSERT(m_service);                        // Make sure the service is valid
+        util::seed_prng_nondeterministically(m_random); // Throws
+        start_keep_running_timer();
     }
 
-    EZSocketFactory(EZSocketFactory&&) = delete;
+    // Don't allow move or copy constructor
+    DefaultSocketProvider(DefaultSocketProvider&&) = delete;
 
-    std::unique_ptr<EZSocket> connect(EZObserver* observer, EZEndpoint&& endpoint);
+    // Temporary workaround until event loop is completely moved here
+    network::Service& get_service()
+    {
+        return *m_service;
+    }
+
+    // Temporary workaround until Client::Connection is updated to use WebSocketObserver
+    std::unique_ptr<DefaultWebSocket> connect_legacy(EZObserver* observer, EZEndpoint&& endpoint);
+
+    std::unique_ptr<WebSocketInterface> connect(WebSocketObserver*, WebSocketEndpoint&&) override
+    {
+        return nullptr;
+    }
+
+    void post(FunctionHandler&& handler) override
+    {
+        REALM_ASSERT(m_service);
+        // Don't post empty handlers onto the event loop
+        if (handler) {
+            // Temporary workaround until the event loop is updated to use Status
+            auto&& new_handler = [handler = std::move(handler)]() {
+                handler(Status::OK());
+            };
+            m_service->post(std::move(new_handler));
+        }
+    }
+
+    SyncTimer create_timer(std::chrono::milliseconds delay, FunctionHandler&& handler) override
+    {
+        return std::make_unique<DefaultSocketProvider::Timer>(*m_service, delay, std::move(handler));
+    }
 
 private:
-    EZConfig m_config;
+    void start_keep_running_timer()
+    {
+        auto handler = [this](Status status) {
+            if (status.code() != ErrorCodes::OperationAborted)
+                start_keep_running_timer();
+        };
+        m_keep_running_timer = create_timer(std::chrono::hours(1000), std::move(handler)); // Throws
+    }
+
+    std::shared_ptr<util::Logger> m_logger_ptr;
+    std::shared_ptr<network::Service> m_service;
+    std::mt19937_64 m_random;
+    const std::string m_user_agent;
+    SyncTimer m_keep_running_timer;
 };
 
 } // namespace realm::sync::websocket

--- a/src/realm/sync/network/network.cpp
+++ b/src/realm/sync/network/network.cpp
@@ -1352,24 +1352,23 @@ public:
     {
 #ifdef REALM_UTIL_NETWORK_EVENT_LOOP_METRICS
         m_event_loop_metrics_timer.emplace(service);
-        auto handler_2 = [this, handler = std::move(handler)](std::error_code ec) {
-            REALM_ASSERT(!ec);
-            clock::time_point now = clock::now();
-            clock::duration elapsed_time = now - m_event_loop_metrics_start_time;
-            clock::duration sleep_time = io_reactor.get_and_reset_sleep_time();
-            clock::duration nonsleep_time = elapsed_time - sleep_time;
-            double saturation = double(nonsleep_time.count()) / double(elapsed_time.count());
-            clock::duration internal_exec_time = nonsleep_time - m_handler_exec_time;
-            internal_exec_time += now - m_handler_exec_start_time;
-            double inefficiency = double(internal_exec_time.count()) / double(elapsed_time.count());
-            m_event_loop_metrics_start_time = now;
-            m_handler_exec_start_time = now;
-            m_handler_exec_time = clock::duration::zero();
-            handler(saturation, inefficiency);             // Throws
-            report_event_loop_metrics(std::move(handler)); // Throws
-        };
-        m_event_loop_metrics_timer->async_wait(std::chrono::seconds{30},
-                                               std::move(handler_2)); // Throws
+        m_event_loop_metrics_timer->async_wait(
+            std::chrono::seconds{30}, [this, handler = std::move(handler)](Status status) {
+                REALM_ASSERT(status.is_ok());
+                clock::time_point now = clock::now();
+                clock::duration elapsed_time = now - m_event_loop_metrics_start_time;
+                clock::duration sleep_time = io_reactor.get_and_reset_sleep_time();
+                clock::duration nonsleep_time = elapsed_time - sleep_time;
+                double saturation = double(nonsleep_time.count()) / double(elapsed_time.count());
+                clock::duration internal_exec_time = nonsleep_time - m_handler_exec_time;
+                internal_exec_time += now - m_handler_exec_start_time;
+                double inefficiency = double(internal_exec_time.count()) / double(elapsed_time.count());
+                m_event_loop_metrics_start_time = now;
+                m_handler_exec_start_time = now;
+                m_handler_exec_time = clock::duration::zero();
+                handler(saturation, inefficiency);             // Throws
+                report_event_loop_metrics(std::move(handler)); // Throws
+            });                                                // Throws
 #else
         static_cast<void>(handler);
 #endif

--- a/src/realm/sync/noinst/client_impl_base.cpp
+++ b/src/realm/sync/noinst/client_impl_base.cpp
@@ -111,16 +111,12 @@ ClientImpl::ClientImpl(ClientConfig config)
     , m_fix_up_object_ids{config.fix_up_object_ids}
     , m_roundtrip_time_handler{std::move(config.roundtrip_time_handler)}
     , m_user_agent_string{make_user_agent_string(config)} // Throws
-    , m_service{}                                         // Throws
-    , m_socket_factory(websocket::EZConfig{
-          logger_ptr,
-          m_random,
-          m_service,
-          get_user_agent_string(),
-      })
+    , m_socket_provider{std::make_shared<websocket::DefaultSocketProvider>(logger_ptr, get_user_agent_string())}
     , m_client_protocol{} // Throws
     , m_one_connection_per_session{config.one_connection_per_session}
-    , m_keep_running_timer{get_service()} // Throws
+    // TODO: migrate service thread to DefaultSocketProvider
+    , m_service{m_socket_provider->get_service()}
+    , m_random{}
 {
     // FIXME: Would be better if seeding was up to the application.
     util::seed_prng_nondeterministically(m_random); // Throws
@@ -181,14 +177,12 @@ ClientImpl::ClientImpl(ClientConfig config)
                     "never do this in production");
     }
 
-    m_actualize_and_finalize = Trigger<network::Service>{&get_service(), [this](Status status) {
-                                                             if (!status.is_ok())
-                                                                 return;
+    m_actualize_and_finalize = {&get_service(), [this](Status status) {
+                                    if (!status.is_ok())
+                                        return;
 
-                                                             actualize_and_finalize_session_wrappers(); // Throws
-                                                         }};
-
-    start_keep_running_timer(); // Throws
+                                    actualize_and_finalize_session_wrappers(); // Throws
+                                }};
 }
 
 
@@ -202,6 +196,21 @@ std::string ClientImpl::make_user_agent_string(ClientConfig& config)
     if (!config.user_agent_application_info.empty())
         out << " " << config.user_agent_application_info; // Throws
     return out.str();                                     // Throws
+}
+
+
+void ClientImpl::event_loop_post(SyncSocketProvider::FunctionHandler&& handler)
+{
+    REALM_ASSERT(m_socket_provider);
+    m_socket_provider->post(std::move(handler));
+}
+
+
+SyncTimer ClientImpl::event_loop_create_timer(std::chrono::milliseconds delay,
+                                              SyncSocketProvider::FunctionHandler&& handler)
+{
+    REALM_ASSERT(m_socket_provider);
+    return m_socket_provider->create_timer(delay, std::move(handler));
 }
 
 
@@ -262,7 +271,7 @@ void Connection::cancel_reconnect_delay()
         // operation might have to be initiated before the previous one
         // completes (its completion handler starts to execute), so the new wait
         // operation must be done on a new timer object.
-        m_reconnect_disconnect_timer = util::none;
+        m_reconnect_disconnect_timer.reset();
         m_reconnect_delay_in_progress = false;
         m_reconnect_info.reset();
         initiate_reconnect_wait(); // Throws
@@ -584,26 +593,24 @@ void Connection::initiate_reconnect_wait()
                       remaining_delay); // Throws
     }
 
-    if (!m_reconnect_disconnect_timer)
-        m_reconnect_disconnect_timer.emplace(m_client.get_service()); // Throws
-    auto handler = [this](std::error_code ec) {
+    auto handler = [this](Status status) {
         // If the operation is aborted, the connection object may have been
         // destroyed.
-        if (ec != util::error::operation_aborted)
-            handle_reconnect_wait(ec); // Throws
+        if (status != ErrorCodes::OperationAborted)
+            handle_reconnect_wait(status); // Throws
     };
-    m_reconnect_disconnect_timer->async_wait(std::chrono::milliseconds(remaining_delay),
-                                             std::move(handler)); // Throws
+    m_reconnect_disconnect_timer = m_client.event_loop_create_timer(std::chrono::milliseconds(remaining_delay),
+                                                                    std::move(handler)); // Throws
     m_reconnect_delay_in_progress = true;
     m_nonzero_reconnect_delay = (remaining_delay > 0);
 }
 
 
-void Connection::handle_reconnect_wait(std::error_code ec)
+void Connection::handle_reconnect_wait(Status status)
 {
-    if (ec) {
-        REALM_ASSERT(ec != util::error::operation_aborted);
-        throw std::system_error(ec);
+    if (status) {
+        REALM_ASSERT(status != ErrorCodes::OperationAborted);
+        throw std::system_error(util::error::unknown, format("Reconnect timer failed: %1", status.reason()));
     }
 
     m_reconnect_delay_in_progress = false;
@@ -660,19 +667,19 @@ void Connection::initiate_reconnect()
         sec_websocket_protocol = std::move(out).str();
     }
 
-    m_websocket =
-        m_client.m_socket_factory.connect(this, websocket::EZEndpoint{
-                                                    m_address,
-                                                    m_port,
-                                                    get_http_request_path(),
-                                                    std::move(sec_websocket_protocol),
-                                                    is_ssl(m_protocol_envelope),
-                                                    {m_custom_http_headers.begin(), m_custom_http_headers.end()},
-                                                    m_verify_servers_ssl_certificate,
-                                                    m_ssl_trust_certificate_path,
-                                                    m_ssl_verify_callback,
-                                                    m_proxy_config,
-                                                });
+    m_websocket = m_client.m_socket_provider->connect_legacy(
+        this, websocket::EZEndpoint{
+                  m_address,
+                  m_port,
+                  get_http_request_path(),
+                  std::move(sec_websocket_protocol),
+                  is_ssl(m_protocol_envelope),
+                  {m_custom_http_headers.begin(), m_custom_http_headers.end()},
+                  m_verify_servers_ssl_certificate,
+                  m_ssl_trust_certificate_path,
+                  m_ssl_verify_callback,
+                  m_proxy_config,
+              });
 }
 
 
@@ -682,25 +689,23 @@ void Connection::initiate_connect_wait()
     // fully establish the connection (including SSL and WebSocket
     // handshakes). Without such a watchdog, connect operations could take very
     // long, or even indefinite time.
-    m_connect_timer.emplace(m_client.get_service()); // Throws
-
     milliseconds_type time = m_client.m_connect_timeout;
 
-    auto handler = [this](std::error_code ec) {
+    auto handler = [this](Status status) {
         // If the operation is aborted, the connection object may have been
         // destroyed.
-        if (ec != util::error::operation_aborted)
-            handle_connect_wait(ec); // Throws
+        if (status != ErrorCodes::OperationAborted)
+            handle_connect_wait(status); // Throws
     };
-    m_connect_timer->async_wait(std::chrono::milliseconds(time), std::move(handler)); // Throws
+    m_connect_timer = m_client.event_loop_create_timer(std::chrono::milliseconds(time), std::move(handler)); // Throws
 }
 
 
-void Connection::handle_connect_wait(std::error_code ec)
+void Connection::handle_connect_wait(Status status)
 {
-    if (ec) {
-        REALM_ASSERT(ec != util::error::operation_aborted);
-        throw std::system_error(ec);
+    if (status) {
+        REALM_ASSERT(status != ErrorCodes::OperationAborted);
+        throw std::system_error(util::error::unknown, format("Connect timer failed: %1", status.reason()));
     }
 
     REALM_ASSERT(m_state == ConnectionState::connecting);
@@ -714,7 +719,7 @@ void Connection::handle_connect_wait(std::error_code ec)
 void Connection::handle_connection_established()
 {
     // Cancel connect timeout watchdog
-    m_connect_timer = util::none;
+    m_connect_timer.reset();
 
     m_state = ConnectionState::connected;
 
@@ -742,7 +747,7 @@ void Connection::schedule_urgent_ping()
 {
     REALM_ASSERT(m_state != ConnectionState::disconnected);
     if (m_ping_delay_in_progress) {
-        m_heartbeat_timer = util::none;
+        m_heartbeat_timer.reset();
         m_ping_delay_in_progress = false;
         m_minimize_next_ping_delay = true;
         milliseconds_type now = monotonic_clock_now();
@@ -790,12 +795,12 @@ void Connection::initiate_ping_delay(milliseconds_type now)
 
     m_ping_delay_in_progress = true;
 
-    auto handler = [this](std::error_code ec) {
-        if (ec != util::error::operation_aborted)
+    auto handler = [this](Status status) {
+        if (status != ErrorCodes::OperationAborted)
             handle_ping_delay(); // Throws
     };
-    m_heartbeat_timer.emplace(m_client.get_service());                                   // Throws
-    m_heartbeat_timer->async_wait(std::chrono::milliseconds(delay), std::move(handler)); // Throws
+    m_heartbeat_timer =
+        m_client.event_loop_create_timer(std::chrono::milliseconds(delay), std::move(handler)); // Throws
     logger.debug("Will emit a ping in %1 milliseconds", delay);                          // Throws
 }
 
@@ -823,11 +828,12 @@ void Connection::initiate_pong_timeout()
     m_pong_wait_started_at = monotonic_clock_now();
 
     milliseconds_type time = m_client.m_pong_keepalive_timeout;
-    auto handler = [this](std::error_code ec) {
-        if (ec != util::error::operation_aborted)
+    auto handler = [this](Status status) {
+        if (status != ErrorCodes::OperationAborted)
             handle_pong_timeout(); // Throws
     };
-    m_heartbeat_timer->async_wait(std::chrono::milliseconds(time), std::move(handler)); // Throws
+    m_heartbeat_timer =
+        m_client.event_loop_create_timer(std::chrono::milliseconds(time), std::move(handler)); // Throws
 }
 
 
@@ -952,31 +958,29 @@ void Connection::initiate_disconnect_wait()
     REALM_ASSERT(!m_reconnect_delay_in_progress);
 
     if (m_disconnect_delay_in_progress) {
-        m_reconnect_disconnect_timer = util::none;
+        m_reconnect_disconnect_timer.reset();
         m_disconnect_delay_in_progress = false;
     }
 
     milliseconds_type time = m_client.m_connection_linger_time;
 
-    if (!m_reconnect_disconnect_timer)
-        m_reconnect_disconnect_timer.emplace(m_client.get_service()); // Throws
-    auto handler = [this](std::error_code ec) {
+    auto handler = [this](Status status) {
         // If the operation is aborted, the connection object may have been
         // destroyed.
-        if (ec != util::error::operation_aborted)
-            handle_disconnect_wait(ec); // Throws
+        if (status != ErrorCodes::OperationAborted)
+            handle_disconnect_wait(status); // Throws
     };
-    m_reconnect_disconnect_timer->async_wait(std::chrono::milliseconds(time),
-                                             std::move(handler)); // Throws
+    m_reconnect_disconnect_timer = m_client.event_loop_create_timer(std::chrono::milliseconds(time),
+                                                                    std::move(handler)); // Throws
     m_disconnect_delay_in_progress = true;
 }
 
 
-void Connection::handle_disconnect_wait(std::error_code ec)
+void Connection::handle_disconnect_wait(Status status)
 {
-    if (ec) {
-        REALM_ASSERT(ec != util::error::operation_aborted);
-        throw std::system_error(ec);
+    if (status) {
+        REALM_ASSERT(status != ErrorCodes::OperationAborted);
+        throw std::system_error(util::error::unknown, format("Disconnect timer failed: %1", status.reason()));
     }
 
     m_disconnect_delay_in_progress = false;
@@ -1092,7 +1096,7 @@ void Connection::close_due_to_server_side_error(ProtocolError error_code, const 
 void Connection::disconnect(const SessionErrorInfo& info)
 {
     // Cancel connect timeout watchdog
-    m_connect_timer = util::none;
+    m_connect_timer.reset();
 
     if (m_state == ConnectionState::connected) {
         m_disconnect_time = monotonic_clock_now();
@@ -1122,7 +1126,7 @@ void Connection::disconnect(const SessionErrorInfo& info)
     m_minimize_next_ping_delay = false;
     m_ping_after_scheduled_reset_of_reconnect_info = false;
     m_ping_sent = false;
-    m_heartbeat_timer = util::none;
+    m_heartbeat_timer.reset();
     m_previous_ping_rtt = 0;
 
     m_websocket.reset();
@@ -1173,7 +1177,7 @@ void Connection::receive_pong(milliseconds_type timestamp)
         m_reconnect_info.m_scheduled_reset = false;
     }
 
-    m_heartbeat_timer = util::none;
+    m_heartbeat_timer.reset();
     m_waiting_for_pong = false;
 
     initiate_ping_delay(now); // Throws
@@ -2452,7 +2456,6 @@ std::error_code Session::receive_test_command_response(request_ident_type ident,
 void Session::begin_resumption_delay(const ProtocolErrorInfo& error_info)
 {
     REALM_ASSERT(!m_try_again_activation_timer);
-    m_try_again_activation_timer.emplace(m_conn.get_client().get_service());
     if (error_info.resumption_delay_interval) {
         m_try_again_delay_info = *error_info.resumption_delay_interval;
     }
@@ -2468,17 +2471,18 @@ void Session::begin_resumption_delay(const ProtocolErrorInfo& error_info)
     }
     m_try_again_error_code = ProtocolError(error_info.raw_error_code);
     logger.debug("Will attempt to resume session after %1 milliseconds", m_current_try_again_delay_interval->count());
-    m_try_again_activation_timer->async_wait(*m_current_try_again_delay_interval, [this](std::error_code ec) {
-        if (ec == util::error::operation_aborted) {
-            return;
-        }
+    m_try_again_activation_timer =
+        get_client().event_loop_create_timer(*m_current_try_again_delay_interval, [this](Status status) {
+            if (status == ErrorCodes::OperationAborted) {
+                return;
+            }
 
-        m_try_again_activation_timer.reset();
-        if (m_current_try_again_delay_interval < m_try_again_delay_info.max_resumption_delay_interval) {
-            *m_current_try_again_delay_interval *= m_try_again_delay_info.resumption_delay_backoff_multiplier;
-        }
-        cancel_resumption_delay();
-    });
+            m_try_again_activation_timer.reset();
+            if (m_current_try_again_delay_interval < m_try_again_delay_info.max_resumption_delay_interval) {
+                *m_current_try_again_delay_interval *= m_try_again_delay_info.resumption_delay_backoff_multiplier;
+            }
+            cancel_resumption_delay();
+        });
 }
 
 void Session::clear_resumption_delay_state()

--- a/src/realm/sync/noinst/client_impl_base.cpp
+++ b/src/realm/sync/noinst/client_impl_base.cpp
@@ -842,10 +842,11 @@ void Connection::handle_pong_timeout()
 
 void Connection::initiate_write_message(const OutputBuffer& out, Session* sess)
 {
-    auto handler = [this] {
+    m_websocket->async_write_binary(util::Span<const char>{out.data(), out.size()}, [this](Status status) {
+        if (!status.is_ok())
+            return;
         handle_write_message(); // Throws
-    };
-    m_websocket->async_write_binary(out.data(), out.size(), std::move(handler)); // Throws
+    });                         // Throws
     m_sending_session = sess;
     m_sending = true;
 }
@@ -922,10 +923,11 @@ void Connection::send_ping()
 
 void Connection::initiate_write_ping(const OutputBuffer& out)
 {
-    auto handler = [this] {
+    m_websocket->async_write_binary(util::Span<const char>{out.data(), out.size()}, [this](Status status) {
+        if (!status.is_ok())
+            return;
         handle_write_ping(); // Throws
-    };
-    m_websocket->async_write_binary(out.data(), out.size(), std::move(handler)); // Throws
+    });                      // Throws
     m_sending = true;
 }
 

--- a/src/realm/sync/noinst/client_impl_base.hpp
+++ b/src/realm/sync/noinst/client_impl_base.hpp
@@ -137,6 +137,7 @@ public:
     void event_loop_post(SyncSocketProvider::FunctionHandler&& handler);
     SyncTimer event_loop_create_timer(std::chrono::milliseconds delay, SyncSocketProvider::FunctionHandler&& handler);
 
+    // TODO: This function will be removed once the event loop is integrated
     network::Service& get_service() noexcept;
     std::mt19937_64& get_random() noexcept;
 
@@ -163,10 +164,13 @@ private:
     const bool m_fix_up_object_ids;
     const std::function<RoundtripTimeHandler> m_roundtrip_time_handler;
     const std::string m_user_agent_string;
+    // This will be updated to the SyncSocketProvider interface once the integration is complete
     std::shared_ptr<websocket::DefaultSocketProvider> m_socket_provider;
     ClientProtocol m_client_protocol;
     session_ident_type m_prev_session_ident = 0;
     const bool m_one_connection_per_session;
+
+    // TODO: m_service will be removed once the event loop is integrated
     network::Service& m_service;
     std::mt19937_64 m_random;
     Trigger<network::Service> m_actualize_and_finalize;
@@ -303,6 +307,8 @@ enum class ClientImpl::ConnectionTerminationReason {
 
 /// All use of connection objects, including construction and destruction, must
 /// occur on behalf of the event loop thread of the associated client object.
+
+// TODO: The parent will be updated to WebSocketObserver once the WebSocket integration is complete
 class ClientImpl::Connection final : public websocket::EZObserver {
 public:
     using connection_ident_type = std::int_fast64_t;
@@ -491,6 +497,7 @@ private:
     friend class Session;
 
     ClientImpl& m_client;
+    // TODO: This will be updated to WebSocketInterface once the WebSocket integration is complete
     std::unique_ptr<websocket::DefaultWebSocket> m_websocket;
     const ProtocolEnvelope m_protocol_envelope;
     const std::string m_address;
@@ -1132,6 +1139,7 @@ inline bool ClientImpl::is_dry_run() const noexcept
 }
 
 
+// TODO: This function will be removed once the event loop is integrated
 inline network::Service& ClientImpl::get_service() noexcept
 {
     return m_service;

--- a/src/realm/sync/noinst/client_impl_base.hpp
+++ b/src/realm/sync/noinst/client_impl_base.hpp
@@ -134,8 +134,10 @@ public:
     ReconnectMode get_reconnect_mode() const noexcept;
     bool is_dry_run() const noexcept;
 
-    void event_loop_post(SyncSocketProvider::FunctionHandler&& handler);
-    SyncTimer event_loop_create_timer(std::chrono::milliseconds delay, SyncSocketProvider::FunctionHandler&& handler);
+    // Functions to post onto the event loop and create an event loop timer using the
+    // SyncSocketProvider
+    void post(SyncSocketProvider::FunctionHandler&& handler);
+    SyncTimer create_timer(std::chrono::milliseconds delay, SyncSocketProvider::FunctionHandler&& handler);
 
     // TODO: This function will be removed once the event loop is integrated
     network::Service& get_service() noexcept;

--- a/src/realm/sync/noinst/client_impl_base.hpp
+++ b/src/realm/sync/noinst/client_impl_base.hpp
@@ -498,7 +498,7 @@ private:
 
     ClientImpl& m_client;
     // TODO: This will be updated to WebSocketInterface once the WebSocket integration is complete
-    std::unique_ptr<websocket::DefaultWebSocket> m_websocket;
+    std::unique_ptr<WebSocketInterface> m_websocket;
     const ProtocolEnvelope m_protocol_envelope;
     const std::string m_address;
     const port_type m_port;

--- a/src/realm/sync/noinst/server/server.cpp
+++ b/src/realm/sync/noinst/server/server.cpp
@@ -1098,7 +1098,7 @@ public:
             if (!m_is_sending)
                 send_next_message(); // Throws
         };
-        m_send_trigger = Trigger<network::Service>{&service, std::move(handler)}; // Throws
+        m_send_trigger = std::make_unique<Trigger<network::Service>>(&service, std::move(handler)); // Throws
     }
 
     ~SyncConnection() noexcept;
@@ -1337,7 +1337,7 @@ private:
     bool m_send_pong = false;
     bool m_sending_pong = false;
 
-    Trigger<network::Service> m_send_trigger;
+    std::unique_ptr<Trigger<network::Service>> m_send_trigger;
 
     milliseconds_type m_last_ping_timestamp = 0;
 
@@ -4220,10 +4220,11 @@ void SyncConnection::terminate_if_dead(SteadyTimePoint now)
 
 void SyncConnection::enlist_to_send(Session* sess) noexcept
 {
+    REALM_ASSERT(m_send_trigger);
     REALM_ASSERT(!m_is_closing);
     REALM_ASSERT(!sess->is_enlisted_to_send());
     m_sessions_enlisted_to_send.push_back(sess);
-    m_send_trigger.trigger();
+    m_send_trigger->trigger();
 }
 
 
@@ -4646,6 +4647,7 @@ void SyncConnection::do_initiate_soft_close(ProtocolError error_code, session_id
     REALM_ASSERT(is_session_level_error(error_code) == (session_ident != 0));
     REALM_ASSERT(!is_session_level_error(error_code));
 
+    REALM_ASSERT(m_send_trigger);
     REALM_ASSERT(!m_is_closing);
     m_is_closing = true;
 
@@ -4660,7 +4662,7 @@ void SyncConnection::do_initiate_soft_close(ProtocolError error_code, session_id
 
     terminate_sessions(); // Throws
 
-    m_send_trigger.trigger();
+    m_send_trigger->trigger();
 }
 
 

--- a/src/realm/sync/socket_provider.hpp
+++ b/src/realm/sync/socket_provider.hpp
@@ -84,6 +84,9 @@ public:
         virtual void cancel() = 0;
     };
 
+    /// Other class typedefs
+    using SyncTimer = std::unique_ptr<SyncSocketProvider::Timer>;
+
     /// The event loop implementation must ensure the event loop is stopped and
     /// flushed when the object is destroyed. If the event loop is processed by
     /// a thread, the thread must be joined as part of this operation.
@@ -135,12 +138,8 @@ public:
     /// @return A pointer to the Timer object that can be used to cancel the
     /// timer. The timer will also be canceled if the Timer object returned is
     /// destroyed.
-    virtual std::unique_ptr<Timer> create_timer(std::chrono::milliseconds delay, FunctionHandler&& handler) = 0;
+    virtual SyncTimer create_timer(std::chrono::milliseconds delay, FunctionHandler&& handler) = 0;
 };
-
-// Defines to help make the code a bit cleaner
-using SyncTimer = std::unique_ptr<SyncSocketProvider::Timer>;
-
 
 /// Struct that defines the endpoint to create a new websocket connection.
 /// Many of these values come from the SyncClientConfig passed to SyncManager when

--- a/src/realm/sync/trigger.hpp
+++ b/src/realm/sync/trigger.hpp
@@ -43,7 +43,7 @@ public:
     Trigger(Service* service, SyncSocketProvider::FunctionHandler&& handler);
     ~Trigger() noexcept;
 
-    Trigger() noexcept = default;
+    Trigger() noexcept = delete;
     Trigger(Trigger&&) noexcept = default;
     Trigger& operator=(Trigger&&) noexcept = default;
 
@@ -126,7 +126,7 @@ inline void Trigger<Service>::trigger()
     }
     m_handler_info->state = HandlerInfo::State::Triggered;
 
-    auto handler = [handler_info = util::bind_ptr(m_handler_info)] {
+    auto handler = [handler_info = util::bind_ptr(m_handler_info)](Status status) {
         {
             util::LockGuard lock{handler_info->mutex};
             // Do not execute the handler if the Trigger does not exist anymore.
@@ -135,7 +135,7 @@ inline void Trigger<Service>::trigger()
             }
             handler_info->state = HandlerInfo::State::Idle;
         }
-        handler_info->handler(Status::OK());
+        handler_info->handler(status);
     };
     m_service->post(std::move(handler));
 }

--- a/test/benchmark-util-network/main.cpp
+++ b/test/benchmark-util-network/main.cpp
@@ -3,6 +3,7 @@
 #include <thread>
 #include <iostream>
 
+#include <realm/status.hpp>
 #include <realm/sync/network/network.hpp>
 
 #include "../util/timer.hpp"
@@ -80,7 +81,7 @@ private:
         if (m_num_posts == 0)
             return;
         --m_num_posts;
-        m_service.post([=]() {
+        m_service.post([=](Status) {
             initiate();
         });
     }

--- a/test/test_util_network.cpp
+++ b/test/test_util_network.cpp
@@ -13,6 +13,7 @@
 #include "test.hpp"
 #include "util/semaphore.hpp"
 
+using namespace realm;
 using namespace realm::util;
 using namespace realm::test_util;
 
@@ -125,10 +126,11 @@ TEST(Network_PostOperation)
 {
     network::Service service;
     int var_1 = 381, var_2 = 743;
-    service.post([&] {
+    service.post([&](Status status) {
+        CHECK(status.is_ok());
         var_1 = 824;
     });
-    service.post([&] {
+    service.post([&](Status) {
         var_2 = 216;
     });
     CHECK_EQUAL(var_1, 381);
@@ -136,10 +138,10 @@ TEST(Network_PostOperation)
     service.run();
     CHECK_EQUAL(var_1, 824);
     CHECK_EQUAL(var_2, 216);
-    service.post([&] {
+    service.post([&](Status) {
         var_2 = 191;
     });
-    service.post([&] {
+    service.post([&](Status) {
         var_1 = 476;
     });
     CHECK_EQUAL(var_1, 824);
@@ -157,7 +159,7 @@ TEST(Network_EventLoopStopAndReset_1)
     // Prestop
     int var = 381;
     service.stop();
-    service.post([&] {
+    service.post([&](Status) {
         var = 824;
     });
     service.run(); // Must return immediately
@@ -167,13 +169,13 @@ TEST(Network_EventLoopStopAndReset_1)
 
     // Reset
     service.reset();
-    service.post([&] {
+    service.post([&](Status) {
         var = 824;
     });
     CHECK_EQUAL(var, 381);
     service.run();
     CHECK_EQUAL(var, 824);
-    service.post([&] {
+    service.post([&](Status) {
         var = 476;
     });
     CHECK_EQUAL(var, 824);
@@ -199,7 +201,7 @@ TEST(Network_EventLoopStopAndReset_2)
 
     // Check that the event loop is actually running
     BowlOfStonesSemaphore bowl_1; // Empty
-    service.post([&] {
+    service.post([&](Status) {
         bowl_1.add_stone();
     });
     bowl_1.get_stone(); // Block until the stone is added
@@ -210,7 +212,7 @@ TEST(Network_EventLoopStopAndReset_2)
 
     // Check that the event loop remains in the stopped state
     int var = 381;
-    service.post([&] {
+    service.post([&](Status) {
         var = 824;
     });
     CHECK_EQUAL(var, 381);
@@ -227,13 +229,13 @@ TEST(Network_EventLoopStopAndReset_2)
 
     // Check that the event loop is actually running
     BowlOfStonesSemaphore bowl_2; // Empty
-    service.post([&] {
+    service.post([&](Status) {
         bowl_2.add_stone();
     });
     bowl_2.get_stone(); // Block until the stone is added
 
     // Stop the event loop by canceling the blocking operation
-    service.post([&] {
+    service.post([&](Status) {
         acceptor.cancel();
     });
     CHECK_NOT(thread_2.join());
@@ -900,10 +902,10 @@ TEST(Network_DeadlineTimer)
     // Check that the completion handler is executed
     bool completed = false;
     bool canceled = false;
-    const auto wait_handler = [&](std::error_code ec) {
-        if (!ec)
+    const auto wait_handler = [&](Status status) {
+        if (status.is_ok())
             completed = true;
-        if (ec == error::operation_aborted)
+        if (status == ErrorCodes::OperationAborted)
             canceled = true;
     };
     timer.async_wait(std::chrono::seconds(0), wait_handler);
@@ -949,12 +951,12 @@ TEST(Network_DeadlineTimer_Special)
     network::DeadlineTimer timer_4{service};
     network::DeadlineTimer timer_5{service};
     network::DeadlineTimer timer_6{service};
-    timer_1.async_wait(std::chrono::seconds(3), [](error_code) { std::cerr << "*3*\n";   });
-    timer_2.async_wait(std::chrono::seconds(2), [](error_code) { std::cerr << "*2*\n";   });
-    timer_3.async_wait(std::chrono::seconds(3), [](error_code) { std::cerr << "*3-2*\n"; });
-    timer_4.async_wait(std::chrono::seconds(2), [](error_code) { std::cerr << "*2-2*\n"; });
-    timer_5.async_wait(std::chrono::seconds(1), [](error_code) { std::cerr << "*1*\n";   });
-    timer_6.async_wait(std::chrono::seconds(2), [](error_code) { std::cerr << "*2-3*\n"; });
+    timer_1.async_wait(std::chrono::seconds(3), [](Status) { std::cerr << "*3*\n";   });
+    timer_2.async_wait(std::chrono::seconds(2), [](Status) { std::cerr << "*2*\n";   });
+    timer_3.async_wait(std::chrono::seconds(3), [](Status) { std::cerr << "*3-2*\n"; });
+    timer_4.async_wait(std::chrono::seconds(2), [](Status) { std::cerr << "*2-2*\n"; });
+    timer_5.async_wait(std::chrono::seconds(1), [](Status) { std::cerr << "*1*\n";   });
+    timer_6.async_wait(std::chrono::seconds(2), [](Status) { std::cerr << "*2-3*\n"; });
     service.run();
 }
 */
@@ -967,7 +969,7 @@ TEST(Network_ThrowFromHandlers)
     network::Service service;
     struct TestException1 {
     };
-    service.post([] {
+    service.post([](Status) {
         throw TestException1();
     });
     CHECK_THROW(service.run(), TestException1);
@@ -1030,7 +1032,7 @@ TEST(Network_ThrowFromHandlers)
         network::DeadlineTimer timer{service};
         struct TestException6 {
         };
-        timer.async_wait(std::chrono::seconds(0), [](std::error_code) {
+        timer.async_wait(std::chrono::seconds(0), [](Status) {
             throw TestException6();
         });
         CHECK_THROW(service.run(), TestException6);
@@ -1045,17 +1047,17 @@ TEST(Network_HandlerDealloc)
     {
         // m_post_handlers
         network::Service service;
-        service.post([] {});
+        service.post([](Status) {});
     }
     {
         // m_imm_handlers
         network::Service service;
         // By adding two post handlers that throw, one is going to be left
         // behind in `m_imm_handlers`
-        service.post([&] {
+        service.post([&](Status) {
             throw std::runtime_error("");
         });
-        service.post([&] {
+        service.post([&](Status) {
             throw std::runtime_error("");
         });
         CHECK_THROW(service.run(), std::runtime_error);
@@ -1113,7 +1115,7 @@ struct PostReallocHandler {
         : var(v)
     {
     }
-    void operator()()
+    void operator()(Status)
     {
         var = size;
     }
@@ -1635,7 +1637,7 @@ TEST(Network_HeavyAsyncPost)
 {
     network::Service service;
     network::DeadlineTimer dummy_timer{service};
-    dummy_timer.async_wait(std::chrono::hours(10000), [](std::error_code) {});
+    dummy_timer.async_wait(std::chrono::hours(10000), [](Status) {});
 
     ThreadWrapper looper_thread;
     looper_thread.start([&] {
@@ -1646,7 +1648,7 @@ TEST(Network_HeavyAsyncPost)
     const long num_iterations = 10000L;
     auto func = [&](int thread_index) {
         for (long i = 0; i < num_iterations; ++i)
-            service.post([&entries, thread_index, i] {
+            service.post([&entries, thread_index, i](Status) {
                 entries.emplace_back(thread_index, i);
             });
     };
@@ -1660,7 +1662,7 @@ TEST(Network_HeavyAsyncPost)
     for (int i = 0; i < num_threads; ++i)
         CHECK_NOT(threads[i].join());
 
-    service.post([&] {
+    service.post([&](Status) {
         dummy_timer.cancel();
     });
     CHECK_NOT(looper_thread.join());
@@ -1735,7 +1737,7 @@ TEST(Network_RepeatedCancelAndRestartRead)
                 std::min(random.draw_int<size_t>(1, write_buffer_size), num_bytes_to_write - num_bytes_written);
             socket_1.write(write_buffer, n);
             num_bytes_written += n;
-            service_2.post([&] {
+            service_2.post([&](Status) {
                 socket_2.cancel();
             });
         }
@@ -1792,16 +1794,6 @@ TEST(Network_StressTest)
         bool progress = false;
         bool read_done = false, write_done = false;
         realm::util::UniqueFunction<void()> shedule_cancellation = [&] {
-            auto handler = [&](std::error_code ec) {
-                REALM_ASSERT(!ec || ec == error::operation_aborted);
-                if (ec == error::operation_aborted)
-                    return;
-                if (read_done && write_done)
-                    return;
-                socket.cancel();
-                ++stats.num_cancellations;
-                shedule_cancellation();
-            };
             if (progress) {
                 microseconds_per_cancellation /= 2;
                 progress = false;
@@ -1812,7 +1804,16 @@ TEST(Network_StressTest)
             if (microseconds_per_cancellation < 10)
                 microseconds_per_cancellation = 10;
             cancellation_timer.async_wait(std::chrono::microseconds(microseconds_per_cancellation),
-                                          std::move(handler));
+                                          [&](Status status) {
+                                              REALM_ASSERT(status.is_ok() || status == ErrorCodes::OperationAborted);
+                                              if (status == ErrorCodes::OperationAborted)
+                                                  return;
+                                              if (read_done && write_done)
+                                                  return;
+                                              socket.cancel();
+                                              ++stats.num_cancellations;
+                                              shedule_cancellation();
+                                          });
         };
         shedule_cancellation();
         char* read_begin = read_buffer.get();
@@ -1844,11 +1845,10 @@ TEST(Network_StressTest)
                     progress = true;
                 }
                 if (delayed_read_write_dist(prng) == 0) {
-                    auto handler_2 = [&](std::error_code ec) {
-                        REALM_ASSERT(!ec);
+                    read_timer.async_wait(std::chrono::microseconds(100), [&](Status status) {
+                        REALM_ASSERT(status.is_ok());
                         read();
-                    };
-                    read_timer.async_wait(std::chrono::microseconds(100), std::move(handler_2));
+                    });
                 }
                 else {
                     read();
@@ -1892,11 +1892,10 @@ TEST(Network_StressTest)
                     progress = true;
                 }
                 if (delayed_read_write_dist(prng) == 0) {
-                    auto handler_2 = [&](std::error_code ec) {
-                        REALM_ASSERT(!ec);
+                    write_timer.async_wait(std::chrono::microseconds(100), [&](Status status) {
+                        REALM_ASSERT(status.is_ok());
                         write();
-                    };
-                    write_timer.async_wait(std::chrono::microseconds(100), std::move(handler_2));
+                    });
                 }
                 else {
                     write();
@@ -2017,7 +2016,7 @@ TEST(Sync_Trigger_ThreadSafety)
 {
     network::Service service;
     network::DeadlineTimer keep_alive{service};
-    keep_alive.async_wait(std::chrono::hours(10000), [](std::error_code) {});
+    keep_alive.async_wait(std::chrono::hours(10000), [](Status) {});
     long n_1 = 0, n_2 = 0;
     std::atomic<bool> flag{false};
     auto func = [&](realm::Status) {
@@ -2035,7 +2034,7 @@ TEST(Sync_Trigger_ThreadSafety)
         trigger.trigger();
     flag = true;
     trigger.trigger();
-    service.post([&] {
+    service.post([&](Status) {
         keep_alive.cancel();
     });
     CHECK_NOT(thread.join());


### PR DESCRIPTION
## What, How & Why?
First pass at new DefaultSocketProvider that owns the network::Service object. With these changes, the WebSocket and event loop updates can continue in parallel. The Timers have been updated to SyncTimer classes and the get_service().post() calls have been updated to pass the call to DefaultSocketProvider.

The event loop thread is still owned by the Sync Client and the old WebSocket connect path is still in place. These will be updated later. Triggers have not been touched since these will be updated in a different review.

Fixes #5450 #6124

## ☑️ ToDos
* [X] 📝 Changelog update
* ~~[ ] 🚦 Tests (or not relevant)~~
* ~~[ ] C-API, if public C++ API changed.~~
