### PR TITLE
Change interface of realm_sync_immediately_run_file_actions to report…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
 ### Breaking changes
 * Core no longer provides any vcpkg infrastructure (the ports submodule and overlay triplets), because it handles dependant libraries internally now.
 * Allow Realm instances to have a complete view of their schema, if mode is additive. ([PR #5784](https://github.com/realm/realm-core/pull/5784)).
+* `realm_sync_immediately_run_file_actions` (c-api) now takes a third argument `bool* did_run` that will be set to the result of `SyncManager::immediately_run_file_actions`. ((#6117)[https://github.com/realm/realm-core/pull/6117]) 
 
 ### Compatibility
 * Fileformat: Generates files with format v23. Reads and automatically upgrade from fileformat v5.

--- a/src/realm.h
+++ b/src/realm.h
@@ -3940,10 +3940,11 @@ RLM_API void realm_sync_session_resume(realm_sync_session_t*) RLM_API_NOEXCEPT;
  * needed
  * @param realm_app ptr to realm app.
  * @param sync_path path where the sync files are.
- * @param did_run ptr to bool, which will be set to true if operation was successful 
- * @return true if operation was succesful
+ * @param did_run ptr to bool, which will be set to true if operation was successful
+ * @return true if operation was successful
  */
-RLM_API bool realm_sync_immediately_run_file_actions(realm_app_t* realm_app, const char* sync_path, bool* did_run) RLM_API_NOEXCEPT;
+RLM_API bool realm_sync_immediately_run_file_actions(realm_app_t* realm_app, const char* sync_path,
+                                                     bool* did_run) RLM_API_NOEXCEPT;
 
 /**
  * Register a callback that will be invoked every time the session's connection state changes.

--- a/src/realm.h
+++ b/src/realm.h
@@ -3940,9 +3940,10 @@ RLM_API void realm_sync_session_resume(realm_sync_session_t*) RLM_API_NOEXCEPT;
  * needed
  * @param realm_app ptr to realm app.
  * @param sync_path path where the sync files are.
+ * @param did_run ptr to bool, which will be set to true if operation was successful 
  * @return true if operation was succesful
  */
-RLM_API bool realm_sync_immediately_run_file_actions(realm_app_t* realm_app, const char* sync_path) RLM_API_NOEXCEPT;
+RLM_API bool realm_sync_immediately_run_file_actions(realm_app_t* realm_app, const char* sync_path, bool* did_run) RLM_API_NOEXCEPT;
 
 /**
  * Register a callback that will be invoked every time the session's connection state changes.

--- a/src/realm/object-store/c_api/sync.cpp
+++ b/src/realm/object-store/c_api/sync.cpp
@@ -913,7 +913,8 @@ RLM_API void realm_sync_session_resume(realm_sync_session_t* session) noexcept
     (*session)->revive_if_needed();
 }
 
-RLM_API bool realm_sync_immediately_run_file_actions(realm_app_t* realm_app, const char* sync_path, bool* did_run) noexcept
+RLM_API bool realm_sync_immediately_run_file_actions(realm_app_t* realm_app, const char* sync_path,
+                                                     bool* did_run) noexcept
 {
     return wrap_err([&]() {
         *did_run = (*realm_app)->sync_manager()->immediately_run_file_actions(sync_path);

--- a/src/realm/object-store/c_api/sync.cpp
+++ b/src/realm/object-store/c_api/sync.cpp
@@ -913,10 +913,11 @@ RLM_API void realm_sync_session_resume(realm_sync_session_t* session) noexcept
     (*session)->revive_if_needed();
 }
 
-RLM_API bool realm_sync_immediately_run_file_actions(realm_app* app, const char* sync_path) noexcept
+RLM_API bool realm_sync_immediately_run_file_actions(realm_app_t* realm_app, const char* sync_path, bool* did_run) noexcept
 {
     return wrap_err([&]() {
-        return (*app)->sync_manager()->immediately_run_file_actions(sync_path);
+        *did_run = (*realm_app)->sync_manager()->immediately_run_file_actions(sync_path);
+        return true;
     });
 }
 

--- a/test/object-store/c_api/c_api.cpp
+++ b/test/object-store/c_api/c_api.cpp
@@ -4643,7 +4643,8 @@ TEST_CASE("C API - client reset", "[c_api][client-reset]") {
         void reset_realm(const char* path)
         {
             realm_app_t realm_app{m_app};
-            realm_sync_immediately_run_file_actions(&realm_app, path);
+            bool did_run;
+            realm_sync_immediately_run_file_actions(&realm_app, path, &did_run);
         }
         static ResetRealmFiles& instance()
         {


### PR DESCRIPTION
Change C-api to actually report success or failure of `SyncManager::immediately_run_file_actions`. The return value is reserved for reporting exceptions, so result is reported on a new third `bool* did_run` argument.

## ☑️ ToDos
* [x] 📝 Changelog update
* [x] 🚦 Tests (or not relevant)
* [x] C-API, if public C++ API changed.
