### PR TITLE
Update MacOS builds to print SDKROOT value

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,7 +21,7 @@
 ### Internals
 * Updates for upcoming Platform Networking feature, including new SyncSocketProvider class. ([PR #6096](https://github.com/realm/realm-core/pull/6096))
 * Updated namespaces for files moved to realm/sync/network ([PR #6109](https://github.com/realm/realm-core/pull/6109))
-* Updated Jenkins file to set SDKROOT for macos builds ([]())
+* Updated Jenkins file to set SDKROOT for macos builds ([PR #6127](https://github.com/realm/realm-core/pull/6127))
 
 ----------------------------------------------
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,7 +21,7 @@
 ### Internals
 * Updates for upcoming Platform Networking feature, including new SyncSocketProvider class. ([PR #6096](https://github.com/realm/realm-core/pull/6096))
 * Updated namespaces for files moved to realm/sync/network ([PR #6109](https://github.com/realm/realm-core/pull/6109))
-* Updated Jenkins file to set SDKROOT for macos builds ([PR #6127](https://github.com/realm/realm-core/pull/6127))
+* Updated Jenkins file to print the SDKROOT for macos builds ([PR #6127](https://github.com/realm/realm-core/pull/6127))
 
 ----------------------------------------------
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@
 ### Internals
 * Updates for upcoming Platform Networking feature, including new SyncSocketProvider class. ([PR #6096](https://github.com/realm/realm-core/pull/6096))
 * Updated namespaces for files moved to realm/sync/network ([PR #6109](https://github.com/realm/realm-core/pull/6109))
+* Updated Jenkins file to set SDKROOT for macos builds ([]())
 
 ----------------------------------------------
 

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -664,7 +664,7 @@ def doBuildMacOs(Map options = [:]) {
     }
 
     def cmakeDefinitions = cmakeOptions.collect { k,v -> "-D$k=\"$v\"" }.join(' ')
-    def xcode-version="Xcode-13.1"
+    def xcodeVersion = "Xcode-13.1"
 
     return {
         rlmNode('osx') {
@@ -672,8 +672,10 @@ def doBuildMacOs(Map options = [:]) {
 
             dir('build-macosx') {
                 // Forcing SDKROOT to be based off DEVELOPER_DIR, since it is being set to Xcode-14.1, which is incompatible with 13.1
-                withEnv(["DEVELOPER_DIR=/Applications/${xcode-version}.app/Contents/Developer/",
-                         "SDKROOT=/Applications/${xcode-version}.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk"]) {
+                withEnv([
+                    "DEVELOPER_DIR=/Applications/${xcodeVersion}.app/Contents/Developer/",
+                    "SDKROOT=/Applications/${xcodeVersion}.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk"
+                ]) {
                     // This is a dirty trick to work around a bug in xcode
                     // It will hang if launched on the same project (cmake trying the compiler out)
                     // in parallel.
@@ -682,6 +684,8 @@ def doBuildMacOs(Map options = [:]) {
                             sh "cmake ${cmakeDefinitions} -G Xcode .."
                         }
                     }
+
+                    sh 'echo DEVELOPER_DIR=$DEVELOPER_DIR && echo SDKROOT=$SDKROOT'
 
                     runAndCollectWarnings(
                         parser: 'clang',

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -664,18 +664,13 @@ def doBuildMacOs(Map options = [:]) {
     }
 
     def cmakeDefinitions = cmakeOptions.collect { k,v -> "-D$k=\"$v\"" }.join(' ')
-    def xcodeVersion = "Xcode-13.1"
 
     return {
         rlmNode('osx') {
             getArchive()
 
             dir('build-macosx') {
-                // Forcing SDKROOT to be based off DEVELOPER_DIR, since it is being set to Xcode-14.1, which is incompatible with 13.1
-                withEnv([
-                    "DEVELOPER_DIR=/Applications/${xcodeVersion}.app/Contents/Developer/",
-                    "SDKROOT=/Applications/${xcodeVersion}.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk"
-                ]) {
+                withEnv(['DEVELOPER_DIR=/Applications/Xcode-13.1.app/Contents/Developer/']) {
                     // This is a dirty trick to work around a bug in xcode
                     // It will hang if launched on the same project (cmake trying the compiler out)
                     // in parallel.
@@ -685,7 +680,7 @@ def doBuildMacOs(Map options = [:]) {
                         }
                     }
 
-                    sh 'echo DEVELOPER_DIR=$DEVELOPER_DIR && echo SDKROOT=$SDKROOT'
+                    sh 'echo "DEVELOPER_DIR=$DEVELOPER_DIR\nSDKROOT=$SDKROOT"'
 
                     runAndCollectWarnings(
                         parser: 'clang',

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -664,13 +664,16 @@ def doBuildMacOs(Map options = [:]) {
     }
 
     def cmakeDefinitions = cmakeOptions.collect { k,v -> "-D$k=\"$v\"" }.join(' ')
+    def xcode-version="Xcode-13.1"
 
     return {
         rlmNode('osx') {
             getArchive()
 
             dir('build-macosx') {
-                withEnv(['DEVELOPER_DIR=/Applications/Xcode-13.1.app/Contents/Developer/']) {
+                // Forcing SDKROOT to be based off DEVELOPER_DIR, since it is being set to Xcode-14.1, which is incompatible with 13.1
+                withEnv(["DEVELOPER_DIR=/Applications/${xcode-version}.app/Contents/Developer/",
+                         "SDKROOT=/Applications/${xcode-version}.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk"]) {
                     // This is a dirty trick to work around a bug in xcode
                     // It will hang if launched on the same project (cmake trying the compiler out)
                     // in parallel.


### PR DESCRIPTION
## What, How & Why?
The Jenkins `checkMacOsRelease_Sync` build step was failing due to `SDKROOT` being set incorrectly. This change forces `SDKROOT` to the correct value when compiling the MacOS source.

## ☑️ ToDos
* [X] 📝 Changelog update
* ~~[ ] 🚦 Tests (or not relevant)~~
* ~~[ ] C-API, if public C++ API changed.~~
