### PR TITLE
Log app services request ID at info level on connection

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,7 +29,8 @@
 * Updated namespaces for files moved to realm/sync/network ([PR #6109](https://github.com/realm/realm-core/pull/6109))
 * Replace util::network::Trigger with a Sync client custom trigger. ([PR #6121](https://github.com/realm/realm-core/pull/6121))
 * Create DefaultSyncSocket class ([PR #6116](https://github.com/realm/realm-core/pull/6116))
-* Improve detection of Windows target architecture when downloading prebuild dependencies. ([#6135](https://github.com/realm/realm-core/issues/6135)) 
+* Improve detection of Windows target architecture when downloading prebuild dependencies. ([#6135](https://github.com/realm/realm-core/issues/6135))
+* App services request ID now logged at info level when sync client connects ([#6143](https://github.com/realm/realm-core/pull/6143]))
 
 ----------------------------------------------
 

--- a/src/realm/sync/network/default_socket.cpp
+++ b/src/realm/sync/network/default_socket.cpp
@@ -31,6 +31,11 @@ public:
         });
     }
 
+    std::string_view get_appservices_request_id() const noexcept override
+    {
+        return m_app_services_coid;
+    }
+
     // public for HTTPClient CRTP, but not on the EZSocket interface, so de-facto private
     void async_read(char*, std::size_t, ReadCompletionHandler) override;
     void async_read_until(char*, std::size_t, char, ReadCompletionHandler) override;
@@ -51,6 +56,9 @@ private:
     void websocket_handshake_completion_handler(const HTTPHeaders& headers) override
     {
         const std::string empty;
+        if (auto it = headers.find("X-Appservices-Request-Id"); it != headers.end()) {
+            m_app_services_coid = it->second;
+        }
         auto it = headers.find("Sec-WebSocket-Protocol");
         m_observer.websocket_handshake_completion_handler(it == headers.end() ? empty : it->second);
     }
@@ -105,6 +113,7 @@ private:
     std::mt19937_64& m_random;
     network::Service& m_service;
     const std::string m_user_agent;
+    std::string m_app_services_coid;
 
     EZObserver& m_observer;
 

--- a/src/realm/sync/noinst/client_impl_base.cpp
+++ b/src/realm/sync/noinst/client_impl_base.cpp
@@ -731,6 +731,11 @@ void Connection::handle_connection_established()
 
     m_state = ConnectionState::connected;
 
+    // TODO(RCORE-1380) get this information in-band rather than from the websocket.
+    if (auto coid = m_websocket->get_appservices_request_id(); !coid.empty()) {
+        logger.info("Connected to app services with request id: \"%1\"", coid);
+    }
+
     milliseconds_type now = monotonic_clock_now();
     m_pong_wait_started_at = now; // Initially, no time was spent waiting for a PONG message
     initiate_ping_delay(now);     // Throws

--- a/src/realm/sync/socket_provider.hpp
+++ b/src/realm/sync/socket_provider.hpp
@@ -165,6 +165,18 @@ struct WebSocketInterface {
     /// is destroyed
     virtual ~WebSocketInterface() = default;
 
+
+    /// For implementations that support it, return the app services request ID header
+    /// value, i.e. the "X-Appservices-Request-Id" header value.
+    ///
+    /// TODO: This will go away with RCORE-1380 since it's not strictly available in the
+    /// websocket spec. If HTTP headers aren't available, the default implementation of
+    /// returning an empty string is okay.
+    virtual std::string_view get_appservices_request_id() const noexcept
+    {
+        return {};
+    }
+
     /// Write data asynchronously to the WebSocket connection. The handler function
     /// will be called when the data has been sent successfully. The WebSocketOberver
     /// provided when the WebSocket was created will be called if any errors occur


### PR DESCRIPTION
## What, How & Why?
The app services request ID is super useful for correlating sync client problems with server logs, but we currently only log it in trace level output of all the HTTP headers we receive. This punches a hole in our websocket implementation to log the request id at the info level when the sync client connection gets connected.

In #6142 we'll move this information in-band so we don't need to access the HTTP headers to get this, since not all websocket implementations expose this info. However, for now, it's very helpful to debug customer issues so I think exposing this implementation detail is worth it.

## ☑️ ToDos
* [x] 📝 Changelog update
* [ ] 🚦 Tests (or not relevant)
* [ ] C-API, if public C++ API changed.
