### PR TITLE
Updates to Realm2JSON and RealmTrawler

### DIFF
--- a/src/realm/exec/CMakeLists.txt
+++ b/src/realm/exec/CMakeLists.txt
@@ -50,13 +50,15 @@ set_target_properties(RealmBrowser PROPERTIES
 )
 target_link_libraries(RealmBrowser Storage)
 
+if(REALM_ENABLE_SYNC)
 add_executable(Realm2JSON realm2json.cpp )
 set_target_properties(Realm2JSON PROPERTIES
-    OUTPUT_NAME "realm2json-10"
+    OUTPUT_NAME "realm2json"
     DEBUG_POSTFIX ${CMAKE_DEBUG_POSTFIX}
 )
-target_link_libraries(Realm2JSON Storage QueryParser)
+target_link_libraries(Realm2JSON Storage QueryParser Sync)
 list(APPEND ExecTargetsToInstall Realm2JSON)
+endif()
 
 add_executable(RealmDump EXCLUDE_FROM_ALL realm_dump.c)
 set_target_properties(RealmDump PROPERTIES

--- a/src/realm/exec/realm2json.cpp
+++ b/src/realm/exec/realm2json.cpp
@@ -1,4 +1,5 @@
 #include <realm.hpp>
+#include <realm/sync/noinst/client_history_impl.hpp>
 #include <iostream>
 
 const char* legend =
@@ -89,15 +90,12 @@ int main(int argc, char const* argv[])
 
     std::string path = argv[argc - 1];
 
-    try {
-        // First we try to open in read_only mode. In this way we can also open
-        // realms with a client history
-        realm::Group g(path);
+    auto print = [&](realm::TransactionRef tr) {
         if (output_schema) {
-            g.schema_to_json(std::cout, &renames);
+            tr->schema_to_json(std::cout, &renames);
         }
         else if (table_filter.size()) {
-            realm::TableRef target = g.get_table(table_filter);
+            realm::TableRef target = tr->get_table(table_filter);
             abort_if(!target, "table not found: '%s'", table_filter.c_str());
             realm::Query q = target->query(query_filter);
             realm::TableView results = q.find_all();
@@ -106,22 +104,37 @@ int main(int argc, char const* argv[])
             results.to_json(std::cout, link_depth, renames, output_mode);
         }
         else {
-            g.to_json(std::cout, link_depth, &renames, output_mode);
+            tr->to_json(std::cout, link_depth, &renames, output_mode);
         }
-    }
-    catch (const realm::FileFormatUpgradeRequired&) {
-        // In realm history
-        // Last chance - this one must succeed
-        auto hist = realm::make_in_realm_history();
-        realm::DBOptions options;
-        options.allow_file_format_upgrade = true;
+    };
 
-        auto db = realm::DB::create(*hist, path, options);
+    auto hist = realm::make_in_realm_history();
+    realm::DBOptions options;
+    // First we try to open in read_only mode.
+    options.allow_file_format_upgrade = false;
+    options.is_immutable = true;
 
-        std::cerr << "File upgraded to latest version: " << path << std::endl;
-
-        auto tr = db->start_read();
-        tr->to_json(std::cout, link_depth, &renames, output_mode);
+    for (;;) {
+        try {
+            auto db = realm::DB::create(*hist, path, options);
+            if (options.allow_file_format_upgrade) {
+                std::cerr << "File upgraded to latest version: " << path << std::endl;
+            }
+            print(db->start_read());
+            return 0;
+        }
+        catch (const realm::FileFormatUpgradeRequired&) {
+            options.allow_file_format_upgrade = true;
+            options.is_immutable = false;
+        }
+        catch (const realm::IncompatibleHistories& e) {
+            hist = realm::sync::make_client_replication();
+            options.allow_file_format_upgrade = false;
+            options.is_immutable = true;
+        }
+        catch (...) {
+            break;
+        }
     }
 
     return 0;

--- a/src/realm/exec/realm_trawler.cpp
+++ b/src/realm/exec/realm_trawler.cpp
@@ -261,6 +261,7 @@ public:
             m_column_attributes.init(alloc, spec.get_ref(2));
             if (spec.size() > 5) {
                 // Must be a Core-6 file.
+                m_enum_keys.init(alloc, spec.get_ref(4));
                 m_column_colkeys.init(alloc, spec.get_ref(5));
             }
             else if (spec.size() > 3) {
@@ -331,6 +332,7 @@ private:
     Array m_column_types;
     Array m_column_names;
     Array m_column_attributes;
+    Array m_enum_keys;
     Array m_column_subspecs;
     Array m_column_colkeys;
     Array m_opposite_table;
@@ -580,6 +582,9 @@ void Table::print_columns(const Group& group) const
             type_str += "?";
         if (attr & realm::col_attr_Indexed)
             type_str += " (indexed)";
+        if (m_enum_keys.valid() && m_enum_keys.get_val(i)) {
+            type_str += " (enumerated)";
+        }
         std::string star = (m_pk_col && (m_pk_col == col_key)) ? "*" : "";
         std::cout << "        " << i << ": " << star << m_column_names.get_string(i) << ": " << type_str << std::endl;
     }

--- a/src/realm/sync/noinst/client_history_impl.hpp
+++ b/src/realm/sync/noinst/client_history_impl.hpp
@@ -403,7 +403,6 @@ private:
 
     void initialize(DB& db) noexcept
     {
-        REALM_ASSERT(!m_db);
         m_db = &db;
     }
 


### PR DESCRIPTION
Realm2JSON makes a better attempt on using the proper parameters (replication, read-only) to open a realm file.

RealmTrawler can detect enumerated string columns.
