### PR TITLE
Migrate service and event loop into DefaultSyncSocket

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -70,7 +70,7 @@
 
 ### Internals
 * Updates for upcoming Platform Networking feature, including new SyncSocketProvider class. ([PR #6096](https://github.com/realm/realm-core/pull/6096))
-* Updated namespaces for files moved to realm/sync/network ([PR #6109](https://github.com/realm/realm-core/pull/6109))
+* Update namespaces for files moved to realm/sync/network ([PR #6109](https://github.com/realm/realm-core/pull/6109))
 * Replace util::network::Trigger with a Sync client custom trigger. ([PR #6121](https://github.com/realm/realm-core/pull/6121))
 * Create DefaultSyncSocket class ([PR #6116](https://github.com/realm/realm-core/pull/6116))
 * Improve detection of Windows target architecture when downloading prebuild dependencies. ([#6135](https://github.com/realm/realm-core/issues/6135))
@@ -78,6 +78,8 @@
 * Add c_api error category for resolve errors instead of reporting unknown category. ([PR #6157](https://github.com/realm/realm-core/pull/6157))
 * Add permanent redirect (308) as a supported redirect response from the server. ([#6162](https://github.com/realm/realm-core/issues/6162))
 * Integrate DefaultSocketProvider as SyncSocketProvider in sync client. ([PR #6171](https://github.com/realm/realm-core/pull/6171))
+* Migrate service and event loop into DefaultSyncSocket ([PR #6151](https://github.com/realm/realm-core/pull/6151))
+* Move BindingCallbackThreadObserver from object-store to sync ([PR #6151](https://github.com/realm/realm-core/pull/6151))
 
 ----------------------------------------------
 

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -282,7 +282,7 @@ def doCheckInDocker(Map options = [:]) {
             def environment = environment()
             environment << 'UNITTEST_XML=unit-test-report.xml'
             environment << "UNITTEST_SUITE_NAME=Linux-${options.buildType}"
-            environment << "UNITTEST_LOG_LEVEL=1"
+            environment << "UNITTEST_LOG_LEVEL=debug"
             if (options.useEncryption) {
                 environment << 'UNITTEST_ENCRYPT_ALL=1'
             }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -282,7 +282,6 @@ def doCheckInDocker(Map options = [:]) {
             def environment = environment()
             environment << 'UNITTEST_XML=unit-test-report.xml'
             environment << "UNITTEST_SUITE_NAME=Linux-${options.buildType}"
-            environment << "UNITTEST_LOG_LEVEL=debug"
             if (options.useEncryption) {
                 environment << 'UNITTEST_ENCRYPT_ALL=1'
             }
@@ -375,8 +374,7 @@ def doCheckSanity(Map options = [:]) {
               'CC=clang',
               'CXX=clang++',
               'UNITTEST_XML=unit-test-report.xml',
-              "UNITTEST_SUITE_NAME=Linux-${options.buildType}",
-              "UNITTEST_LOG_LEVEL=debug"
+              "UNITTEST_SUITE_NAME=Linux-${options.buildType}"
             ]
             buildDockerEnv('testing.Dockerfile').inside(privileged) {
                 withEnv(environment) {

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -282,6 +282,7 @@ def doCheckInDocker(Map options = [:]) {
             def environment = environment()
             environment << 'UNITTEST_XML=unit-test-report.xml'
             environment << "UNITTEST_SUITE_NAME=Linux-${options.buildType}"
+            environment << "UNITTEST_LOG_LEVEL=1"
             if (options.useEncryption) {
                 environment << 'UNITTEST_ENCRYPT_ALL=1'
             }
@@ -375,6 +376,7 @@ def doCheckSanity(Map options = [:]) {
               'CXX=clang++',
               'UNITTEST_XML=unit-test-report.xml',
               "UNITTEST_SUITE_NAME=Linux-${options.buildType}"
+              "UNITTEST_LOG_LEVEL=debug"
             ]
             buildDockerEnv('testing.Dockerfile').inside(privileged) {
                 withEnv(environment) {

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -375,7 +375,7 @@ def doCheckSanity(Map options = [:]) {
               'CC=clang',
               'CXX=clang++',
               'UNITTEST_XML=unit-test-report.xml',
-              "UNITTEST_SUITE_NAME=Linux-${options.buildType}"
+              "UNITTEST_SUITE_NAME=Linux-${options.buildType}",
               "UNITTEST_LOG_LEVEL=debug"
             ]
             buildDockerEnv('testing.Dockerfile').inside(privileged) {

--- a/Package.swift
+++ b/Package.swift
@@ -93,6 +93,7 @@ let notSyncServerSources: [String] = [
     "realm/spec.cpp",
     "realm/status.cpp",
     "realm/string_data.cpp",
+    "realm/sync/binding_callback_thread_observer.cpp",
     "realm/sync/changeset.cpp",
     "realm/sync/changeset_encoder.cpp",
     "realm/sync/changeset_parser.cpp",

--- a/src/realm.h
+++ b/src/realm.h
@@ -370,7 +370,6 @@ typedef enum realm_property_flags {
 typedef struct realm_notification_token realm_notification_token_t;
 typedef struct realm_callback_token realm_callback_token_t;
 typedef struct realm_refresh_callback_token realm_refresh_callback_token_t;
-typedef struct realm_thread_observer_token realm_thread_observer_token_t;
 typedef struct realm_object_changes realm_object_changes_t;
 typedef struct realm_collection_changes realm_collection_changes_t;
 typedef void (*realm_on_object_change_func_t)(realm_userdata_t userdata, const realm_object_changes_t*);
@@ -4072,6 +4071,10 @@ RLM_API void realm_sync_session_handle_error_for_testing(const realm_sync_sessio
  */
 RLM_API void realm_register_user_code_callback_error(realm_userdata_t usercode_error) RLM_API_NOEXCEPT;
 
+#if REALM_ENABLE_SYNC
+
+typedef struct realm_thread_observer_token realm_thread_observer_token_t;
+
 /**
  * Register a callback handler for bindings interested in registering callbacks before/after the ObjectStore thread
  * runs.
@@ -4085,6 +4088,8 @@ realm_set_binding_callback_thread_observer(realm_on_object_store_thread_callback
                                            realm_on_object_store_thread_callback_t on_thread_destroy,
                                            realm_on_object_store_error_callback_t on_error, realm_userdata_t,
                                            realm_free_userdata_func_t free_userdata);
+
+#endif // REALM_ENABLE_SYNC
 
 typedef struct realm_mongodb_collection realm_mongodb_collection_t;
 

--- a/src/realm/error_codes.hpp
+++ b/src/realm/error_codes.hpp
@@ -36,6 +36,7 @@ public:
         LogicError = 3,
         BrokenPromise = 4,
         OperationAborted = 5,
+        EventLoopError = 6,
 
         /// WebSocket Errors
         // WebSocket_OK = 1000 is not used, just use OK instead

--- a/src/realm/error_codes.hpp
+++ b/src/realm/error_codes.hpp
@@ -36,7 +36,6 @@ public:
         LogicError = 3,
         BrokenPromise = 4,
         OperationAborted = 5,
-        EventLoopError = 6,
 
         /// WebSocket Errors
         // WebSocket_OK = 1000 is not used, just use OK instead

--- a/src/realm/object-store/CMakeLists.txt
+++ b/src/realm/object-store/CMakeLists.txt
@@ -1,7 +1,6 @@
 add_subdirectory(c_api)
 
 set(SOURCES
-    binding_callback_thread_observer.cpp
     collection.cpp
     collection_notifications.cpp
     dictionary.cpp
@@ -38,7 +37,6 @@ set(SOURCES
 set(HEADERS
     audit.hpp
     audit_serializer.hpp
-    binding_callback_thread_observer.hpp
     binding_context.hpp
     collection.hpp
     collection_notifications.hpp

--- a/src/realm/object-store/c_api/realm.cpp
+++ b/src/realm/object-store/c_api/realm.cpp
@@ -2,6 +2,13 @@
 #include "realm.hpp"
 
 
+#if !REALM_ENABLE_SYNC
+namespace realm {
+BindingCallbackThreadObserver* g_binding_callback_thread_observer = nullptr;
+} // namespace realm
+#endif
+
+
 realm_callback_token_realm::~realm_callback_token_realm()
 {
     realm::c_api::CBindingContext::get(*m_realm).realm_changed_callbacks().remove(m_token);

--- a/src/realm/object-store/c_api/realm.cpp
+++ b/src/realm/object-store/c_api/realm.cpp
@@ -2,13 +2,6 @@
 #include "realm.hpp"
 
 
-#if !REALM_ENABLE_SYNC
-namespace realm {
-BindingCallbackThreadObserver* g_binding_callback_thread_observer = nullptr;
-} // namespace realm
-#endif
-
-
 realm_callback_token_realm::~realm_callback_token_realm()
 {
     realm::c_api::CBindingContext::get(*m_realm).realm_changed_callbacks().remove(m_token);
@@ -24,10 +17,12 @@ realm_refresh_callback_token::~realm_refresh_callback_token()
     realm::c_api::CBindingContext::get(*m_realm).realm_pending_refresh_callbacks().remove(m_token);
 }
 
+#if REALM_ENABLE_SYNC
 realm_thread_observer_token::~realm_thread_observer_token()
 {
     realm::g_binding_callback_thread_observer = nullptr;
 }
+#endif // REALM_ENABLE_SYNC
 
 namespace realm::c_api {
 
@@ -361,6 +356,8 @@ void CBindingContext::did_change(std::vector<ObserverState> const&, std::vector<
     m_realm_changed_callbacks.invoke();
 }
 
+#if REALM_ENABLE_SYNC
+
 RLM_API
 realm_thread_observer_token_t*
 realm_set_binding_callback_thread_observer(realm_on_object_store_thread_callback_t on_thread_create,
@@ -388,5 +385,7 @@ realm_set_binding_callback_thread_observer(realm_on_object_store_thread_callback
     g_binding_callback_thread_observer = &instance;
     return new realm_thread_observer_token_t();
 }
+
+#endif // REALM_ENABLE_SYNC
 
 } // namespace realm::c_api

--- a/src/realm/object-store/c_api/realm.hpp
+++ b/src/realm/object-store/c_api/realm.hpp
@@ -20,7 +20,7 @@
 
 #include <realm/object-store/c_api/util.hpp>
 #include <realm/object-store/binding_context.hpp>
-#include <realm/object-store/binding_callback_thread_observer.hpp>
+#include <realm/sync/binding_callback_thread_observer.hpp>
 
 namespace realm::c_api {
 

--- a/src/realm/object-store/c_api/realm.hpp
+++ b/src/realm/object-store/c_api/realm.hpp
@@ -20,7 +20,10 @@
 
 #include <realm/object-store/c_api/util.hpp>
 #include <realm/object-store/binding_context.hpp>
+
+#if REALM_ENABLE_SYNC
 #include <realm/sync/binding_callback_thread_observer.hpp>
+#endif // REALM_ENABLE_SYNC
 
 namespace realm::c_api {
 
@@ -64,6 +67,8 @@ private:
     CallbackRegistry<const Schema&> m_schema_changed_callbacks;
 };
 
+#if REALM_ENABLE_SYNC
+
 class CBindingThreadObserver : public realm::BindingCallbackThreadObserver {
 public:
     using ThreadCallback = util::UniqueFunction<void()>;
@@ -106,5 +111,7 @@ private:
     ThreadCallback m_destroy_callback;
     ErrorCallback m_error_callback;
 };
+
+#endif // REALM_ENABLE_SYNC
 
 } // namespace realm::c_api

--- a/src/realm/object-store/c_api/types.hpp
+++ b/src/realm/object-store/c_api/types.hpp
@@ -474,11 +474,6 @@ struct realm_notification_token : realm::c_api::WrapC, realm::NotificationToken 
     }
 };
 
-struct realm_thread_observer_token : realm::c_api::WrapC {
-    explicit realm_thread_observer_token() = default;
-    ~realm_thread_observer_token();
-};
-
 struct realm_callback_token : realm::c_api::WrapC {
 protected:
     realm_callback_token(realm_t* realm, uint64_t token)
@@ -838,6 +833,11 @@ struct realm_sync_socket_callback : realm::c_api::WrapC,
         }
         return false;
     }
+};
+
+struct realm_thread_observer_token : realm::c_api::WrapC {
+    explicit realm_thread_observer_token() = default;
+    ~realm_thread_observer_token();
 };
 
 #endif // REALM_ENABLE_SYNC

--- a/src/realm/object-store/sync/impl/sync_client.hpp
+++ b/src/realm/object-store/sync/impl/sync_client.hpp
@@ -74,12 +74,10 @@ struct SyncClient {
     {
         if (!m_reachability_observer.start_observing())
             m_logger.error("Failed to set up network reachability observer");
-        m_client.run();
     }
 #else
     {
         static_cast<void>(weak_sync_manager);
-        m_client.run();
     }
 #endif
 

--- a/src/realm/object-store/sync/impl/sync_client.hpp
+++ b/src/realm/object-store/sync/impl/sync_client.hpp
@@ -19,8 +19,6 @@
 #ifndef REALM_OS_SYNC_CLIENT_HPP
 #define REALM_OS_SYNC_CLIENT_HPP
 
-#include <realm/object-store/binding_callback_thread_observer.hpp>
-
 #include <realm/sync/client.hpp>
 #include <realm/util/scope_exit.hpp>
 
@@ -65,23 +63,6 @@ struct SyncClient {
         }())
         , m_logger_ptr(logger)
         , m_logger(*m_logger_ptr)
-        , m_thread([this] {
-            if (g_binding_callback_thread_observer) {
-                g_binding_callback_thread_observer->did_create_thread();
-                auto will_destroy_thread = util::make_scope_exit([&]() noexcept {
-                    g_binding_callback_thread_observer->will_destroy_thread();
-                });
-                try {
-                    m_client.run(); // Throws
-                }
-                catch (std::exception const& e) {
-                    g_binding_callback_thread_observer->handle_error(e);
-                }
-            }
-            else {
-                m_client.run(); // Throws
-            }
-        }) // Throws
 #if NETWORK_REACHABILITY_AVAILABLE
         , m_reachability_observer(none, [weak_sync_manager](const NetworkReachabilityStatus status) {
             if (status != NotReachable) {
@@ -93,10 +74,12 @@ struct SyncClient {
     {
         if (!m_reachability_observer.start_observing())
             m_logger.error("Failed to set up network reachability observer");
+        m_client.run();
     }
 #else
     {
         static_cast<void>(weak_sync_manager);
+        m_client.run();
     }
 #endif
 
@@ -108,8 +91,6 @@ struct SyncClient {
     void stop()
     {
         m_client.stop();
-        if (m_thread.joinable())
-            m_thread.join();
     }
 
     std::unique_ptr<sync::Session> make_session(std::shared_ptr<DB> db,
@@ -139,7 +120,6 @@ private:
     sync::Client m_client;
     std::shared_ptr<util::Logger> m_logger_ptr;
     util::Logger& m_logger;
-    std::thread m_thread;
 #if NETWORK_REACHABILITY_AVAILABLE
     NetworkReachabilityObserver m_reachability_observer;
 #endif

--- a/src/realm/sync/CMakeLists.txt
+++ b/src/realm/sync/CMakeLists.txt
@@ -10,6 +10,7 @@ set(SYNC_SOURCES
     noinst/pending_bootstrap_store.cpp
     noinst/protocol_codec.cpp
     noinst/sync_metadata_schema.cpp
+    binding_callback_thread_observer.cpp
     changeset_encoder.cpp
     changeset_parser.cpp
     changeset.cpp
@@ -35,6 +36,7 @@ set(IMPL_INSTALL_HEADERS
 )
 
 set(SYNC_INSTALL_HEADERS
+    binding_callback_thread_observer.hpp
     config.hpp
     changeset_encoder.hpp
     changeset_parser.hpp

--- a/src/realm/sync/binding_callback_thread_observer.cpp
+++ b/src/realm/sync/binding_callback_thread_observer.cpp
@@ -16,7 +16,7 @@
 //
 ////////////////////////////////////////////////////////////////////////////
 
-#include <realm/object-store/binding_callback_thread_observer.hpp>
+#include <realm/sync/binding_callback_thread_observer.hpp>
 
 namespace realm {
 BindingCallbackThreadObserver* g_binding_callback_thread_observer = nullptr;

--- a/src/realm/sync/binding_callback_thread_observer.hpp
+++ b/src/realm/sync/binding_callback_thread_observer.hpp
@@ -32,7 +32,7 @@ public:
     // This method is called just before the thread is being destroyed
     virtual void will_destroy_thread() = 0;
 
-    // This method is called with any exception throws by client.run().
+    // This method is called with any exception thrown by client.run().
     virtual void handle_error(std::exception const& e) = 0;
 };
 

--- a/src/realm/sync/client.cpp
+++ b/src/realm/sync/client.cpp
@@ -498,6 +498,7 @@ void ClientImpl::stop() noexcept
         m_stopped = true;
         m_wait_or_client_stopped_cond.notify_all();
     }
+    // TODO: in the future we will need to block here until all the sessions have been torn down
     m_socket_provider->stop();
 }
 

--- a/src/realm/sync/client.cpp
+++ b/src/realm/sync/client.cpp
@@ -491,19 +491,14 @@ bool ClientImpl::wait_for_session_terminations_or_client_stopped()
 
 void ClientImpl::stop() noexcept
 {
-    util::LockGuard lock{m_mutex};
-    if (m_stopped)
-        return;
-    m_stopped = true;
-    m_socket_provider->stop(false);
-    m_wait_or_client_stopped_cond.notify_all();
-}
-
-
-void ClientImpl::run() noexcept
-{
-    util::LockGuard lock{m_mutex};
-    m_socket_provider->start();
+    {
+        util::LockGuard lock{m_mutex};
+        if (m_stopped)
+            return;
+        m_stopped = true;
+        m_wait_or_client_stopped_cond.notify_all();
+    }
+    m_socket_provider->stop();
 }
 
 
@@ -1838,12 +1833,6 @@ Client::Client(Client&& client) noexcept
 
 
 Client::~Client() noexcept {}
-
-
-void Client::run() noexcept
-{
-    m_impl->run();
-}
 
 
 void Client::stop() noexcept

--- a/src/realm/sync/client.hpp
+++ b/src/realm/sync/client.hpp
@@ -12,6 +12,7 @@
 #include <realm/util/buffer.hpp>
 #include <realm/util/functional.hpp>
 #include <realm/sync/client_base.hpp>
+#include <realm/sync/socket_provider.hpp>
 #include <realm/sync/subscriptions.hpp>
 
 namespace realm::sync {
@@ -37,10 +38,13 @@ public:
     Client(Client&&) noexcept;
     ~Client() noexcept;
 
+    /// Used by testing to post a function handler onto the event loop
+    void post_for_testing(SyncSocketProvider::FunctionHandler&& handler);
+
     /// Run the internal event-loop of the client. At most one thread may
     /// execute run() at any given time. The call will not return until somebody
     /// calls stop().
-    void run();
+    void run() noexcept;
 
     /// See run().
     ///

--- a/src/realm/sync/network/default_socket.cpp
+++ b/src/realm/sync/network/default_socket.cpp
@@ -466,7 +466,8 @@ void DefaultSocketProvider::event_loop()
     lock.lock();
     if (m_state != State::Started) {
         // Stop has already been requested - exit early
-        return;
+        lock.unlock(); // make sure the mutex is unloaded before exiting
+        return;        // early return
     }
     do_state_update(State::Running);
     lock.unlock();

--- a/src/realm/sync/network/default_socket.cpp
+++ b/src/realm/sync/network/default_socket.cpp
@@ -509,7 +509,7 @@ void DefaultSocketProvider::stop(bool wait_for_stop)
 //                                   +-------------------------------------------+
 //                                  \/                                           |
 // State Machine: NotStarted -> Starting -> Started -> Running -> Stopping -> Stopped
-//                                  |          |                     /\
+//                                  |          |                     ^
 //                                  +----------+---------------------+
 
 void DefaultSocketProvider::do_state_update(State new_state)

--- a/src/realm/sync/network/default_socket.cpp
+++ b/src/realm/sync/network/default_socket.cpp
@@ -426,9 +426,9 @@ void DefaultSocketProvider::start()
     m_stop_future = std::move(stop_pf.future);
     m_thread = std::thread{
         [this, start_promise = std::move(start_pf.promise), stop_promise = std::move(stop_pf.promise)]() mutable {
-            // The thread has started
-            start_promise.emplace_value();
             m_logger_ptr->info("Event loop thread running");
+            // The thread has started - release the main start() future
+            start_promise.emplace_value();
             auto will_destroy_thread = util::make_scope_exit([&]() noexcept {
                 if (g_binding_callback_thread_observer) {
                     g_binding_callback_thread_observer->will_destroy_thread();

--- a/src/realm/sync/network/default_socket.hpp
+++ b/src/realm/sync/network/default_socket.hpp
@@ -3,6 +3,7 @@
 #include <random>
 #include <system_error>
 #include <map>
+#include <set>
 
 #include <realm/sync/config.hpp>
 #include <realm/sync/socket_provider.hpp>
@@ -44,9 +45,6 @@ public:
         network::DeadlineTimer m_timer;
     };
 
-    // The current state of the event loop
-    enum State { NotStarted, Started, Running, Stopping, Stopped };
-
     DefaultSocketProvider(const std::shared_ptr<util::Logger>& logger, const std::string user_agent);
 
     // Don't allow move or copy constructor
@@ -54,16 +52,10 @@ public:
 
     ~DefaultSocketProvider();
 
-    /// @{
     /// Temporary workaround until client shutdown has been updated in a separate PR - these functions
     /// will be handled internally when this happens.
-    /// Start the internal event loop (provided by network::Service) or restart the event loop
-    /// if it has been previously stopped - returns whether or not the thread was started
-    /// successfully.
-    void start() override;
-    /// Stop the internal event loop (provided by network::Service)
+    /// Stops the internal event loop (provided by network::Service)
     void stop(bool wait_for_stop = false) override;
-    /// }@
 
     std::unique_ptr<WebSocketInterface> connect(WebSocketObserver*, WebSocketEndpoint&&) override;
 
@@ -81,11 +73,26 @@ public:
     }
 
 private:
-    void thread_update_state(State new_state)
-    {
-        std::lock_guard<std::mutex> lock{m_state_mutex};
-        m_state = new_state;
-    }
+    enum class State : int { NotStarted, Starting, Started, Running, Stopping, Stopped };
+
+    // Start the event loop
+    void start();
+
+    bool state_check(State state);
+    /// Return true if state matches any of the expected states
+    bool state_check(std::set<State>&& expected_states);
+    /// Only update the state and return true if it matches an expected state
+    bool state_transition(std::set<State>&& expected_states, State new_state);
+    /// Only update the state and return true if it matches the expected state
+    bool state_transition(State expected_state, State new_state);
+    /// Update the state
+    void state_update(State new_state);
+    /// Block until the state reaches the expected or later state - return true if state matches expected state
+    bool state_wait_for(State expected_state);
+    /// Internal function for updating the state and signaling the wait_for_state condvar
+    void state_do_update(State new_state);
+
+    std::function<void()> make_event_loop();
 
     // TODO: Revisit Service::run() so the keep running timer is no longer needed
     void start_keep_running_timer()
@@ -103,9 +110,10 @@ private:
     const std::string m_user_agent;
     SyncTimer m_keep_running_timer;
     std::mutex m_state_mutex;
-    State m_state;                                   // protected by m_state_mutex
-    std::thread m_thread;                            // protected by m_state_mutex
-    std::optional<util::Future<void>> m_stop_future; // protected by m_state_mutex
+    State m_state;                      // protected by m_state_mutex
+    std::condition_variable m_state_cv; // uses m_state_mutex
+    std::mutex m_thread_mutex;
+    std::thread m_thread; // protected by m_thread_mutex
 };
 
 } // namespace realm::sync::websocket

--- a/src/realm/sync/network/default_socket.hpp
+++ b/src/realm/sync/network/default_socket.hpp
@@ -73,24 +73,15 @@ public:
     }
 
 private:
-    enum class State : int { NotStarted, Starting, Started, Running, Stopping, Stopped };
+    enum class State : int { Starting, Started, Running, Stopping, Stopped };
 
     // Start the event loop
     void start();
 
-    bool state_check(State state);
-    /// Return true if state matches any of the expected states
-    bool state_check(std::set<State>&& expected_states);
-    /// Only update the state and return true if it matches an expected state
-    bool state_transition(std::set<State>&& expected_states, State new_state);
-    /// Only update the state and return true if it matches the expected state
-    bool state_transition(State expected_state, State new_state);
-    /// Update the state
-    void state_update(State new_state);
     /// Block until the state reaches the expected or later state - return true if state matches expected state
     bool state_wait_for(State expected_state);
     /// Internal function for updating the state and signaling the wait_for_state condvar
-    void state_do_update(State new_state);
+    void do_state_update(State new_state);
 
     std::function<void()> make_event_loop();
 
@@ -109,11 +100,10 @@ private:
     std::mt19937_64 m_random;
     const std::string m_user_agent;
     SyncTimer m_keep_running_timer;
-    std::mutex m_state_mutex;
-    State m_state;                      // protected by m_state_mutex
-    std::condition_variable m_state_cv; // uses m_state_mutex
-    std::mutex m_thread_mutex;
-    std::thread m_thread; // protected by m_thread_mutex
+    std::mutex m_mutex;
+    State m_state;                      // protected by m_mutex
+    std::condition_variable m_state_cv; // uses m_mutex
+    std::thread m_thread;               // protected by m_mutex
 };
 
 } // namespace realm::sync::websocket

--- a/src/realm/sync/network/default_socket.hpp
+++ b/src/realm/sync/network/default_socket.hpp
@@ -45,7 +45,7 @@ public:
     };
 
     // The current state of the event loop
-    enum State {NotStarted, Started, Running, Stopping, Stopped};
+    enum State { NotStarted, Started, Running, Stopping, Stopped };
 
     DefaultSocketProvider(const std::shared_ptr<util::Logger>& logger, const std::string user_agent);
 
@@ -103,8 +103,8 @@ private:
     const std::string m_user_agent;
     SyncTimer m_keep_running_timer;
     std::mutex m_state_mutex;
-    State m_state; // protected by m_state_mutex
-    std::thread m_thread; // protected by m_state_mutex
+    State m_state;                                   // protected by m_state_mutex
+    std::thread m_thread;                            // protected by m_state_mutex
     std::optional<util::Future<void>> m_stop_future; // protected by m_state_mutex
 };
 

--- a/src/realm/sync/network/default_socket.hpp
+++ b/src/realm/sync/network/default_socket.hpp
@@ -78,7 +78,7 @@ private:
     void start();
 
     /// Block until the state reaches the expected or later state - return true if state matches expected state
-    bool state_wait_for(State expected_state);
+    void state_wait_for(State expected_state);
     /// Internal function for updating the state and signaling the wait_for_state condvar
     void do_state_update(State new_state);
     /// The execution code for the event loop thread

--- a/src/realm/sync/network/default_socket.hpp
+++ b/src/realm/sync/network/default_socket.hpp
@@ -8,6 +8,7 @@
 #include <realm/sync/socket_provider.hpp>
 #include <realm/sync/network/http.hpp>
 #include <realm/sync/network/network.hpp>
+#include <realm/util/future.hpp>
 #include <realm/util/random.hpp>
 
 namespace realm::sync::network {
@@ -43,49 +44,49 @@ public:
         network::DeadlineTimer m_timer;
     };
 
-    DefaultSocketProvider(const std::shared_ptr<util::Logger>& logger, const std::string user_agent)
-        : m_logger_ptr{logger}
-        , m_service{std::make_shared<network::Service>()}
-        , m_random{}
-        , m_user_agent{user_agent}
-    {
-        REALM_ASSERT(m_logger_ptr);                     // Make sure the logger is valid
-        REALM_ASSERT(m_service);                        // Make sure the service is valid
-        util::seed_prng_nondeterministically(m_random); // Throws
-        start_keep_running_timer();
-    }
+    // The current state of the event loop
+    enum State {NotStarted, Started, Running, Stopping, Stopped};
+
+    DefaultSocketProvider(const std::shared_ptr<util::Logger>& logger, const std::string user_agent);
 
     // Don't allow move or copy constructor
     DefaultSocketProvider(DefaultSocketProvider&&) = delete;
 
-    // Temporary workaround until event loop is completely moved here
-    void run() override
-    {
-        m_service->run();
-    }
+    ~DefaultSocketProvider();
 
-    void stop() override
-    {
-        m_service->stop();
-    }
+    /// @{
+    /// Temporary workaround until client shutdown has been updated in a separate PR - these functions
+    /// will be handled internally when this happens.
+    /// Start the internal event loop (provided by network::Service) or restart the event loop
+    /// if it has been previously stopped - returns whether or not the thread was started
+    /// successfully.
+    void start() override;
+    /// Stop the internal event loop (provided by network::Service)
+    void stop(bool wait_for_stop = false) override;
+    /// }@
 
     std::unique_ptr<WebSocketInterface> connect(WebSocketObserver*, WebSocketEndpoint&&) override;
 
     void post(FunctionHandler&& handler) override
     {
-        REALM_ASSERT(m_service);
         // Don't post empty handlers onto the event loop
         if (!handler)
             return;
-        m_service->post(std::move(handler));
+        m_service.post(std::move(handler));
     }
 
     SyncTimer create_timer(std::chrono::milliseconds delay, FunctionHandler&& handler) override
     {
-        return std::unique_ptr<Timer>(new DefaultSocketProvider::Timer(*m_service, delay, std::move(handler)));
+        return std::unique_ptr<Timer>(new DefaultSocketProvider::Timer(m_service, delay, std::move(handler)));
     }
 
 private:
+    void thread_update_state(State new_state)
+    {
+        std::lock_guard<std::mutex> lock{m_state_mutex};
+        m_state = new_state;
+    }
+
     // TODO: Revisit Service::run() so the keep running timer is no longer needed
     void start_keep_running_timer()
     {
@@ -97,10 +98,14 @@ private:
     }
 
     std::shared_ptr<util::Logger> m_logger_ptr;
-    std::shared_ptr<network::Service> m_service;
+    network::Service m_service;
     std::mt19937_64 m_random;
     const std::string m_user_agent;
     SyncTimer m_keep_running_timer;
+    std::mutex m_state_mutex;
+    State m_state; // protected by m_state_mutex
+    std::thread m_thread; // protected by m_state_mutex
+    std::optional<util::Future<void>> m_stop_future; // protected by m_state_mutex
 };
 
 } // namespace realm::sync::websocket

--- a/src/realm/sync/network/default_socket.hpp
+++ b/src/realm/sync/network/default_socket.hpp
@@ -3,7 +3,6 @@
 #include <random>
 #include <system_error>
 #include <map>
-#include <set>
 
 #include <realm/sync/config.hpp>
 #include <realm/sync/socket_provider.hpp>
@@ -73,7 +72,7 @@ public:
     }
 
 private:
-    enum class State : int { Starting, Started, Running, Stopping, Stopped };
+    enum class State { Starting, Started, Running, Stopping, Stopped };
 
     // Start the event loop
     void start();
@@ -82,8 +81,8 @@ private:
     bool state_wait_for(State expected_state);
     /// Internal function for updating the state and signaling the wait_for_state condvar
     void do_state_update(State new_state);
-
-    std::function<void()> make_event_loop();
+    /// The execution code for the event loop thread
+    void event_loop();
 
     // TODO: Revisit Service::run() so the keep running timer is no longer needed
     void start_keep_running_timer()

--- a/src/realm/sync/noinst/client_impl_base.cpp
+++ b/src/realm/sync/noinst/client_impl_base.cpp
@@ -288,7 +288,7 @@ void Connection::initiate_session_deactivation(Session* sess)
 {
     REALM_ASSERT(&sess->m_conn == this);
     if (REALM_UNLIKELY(--m_num_active_sessions == 0)) {
-        if (m_on_idle && m_activated && m_state == ConnectionState::disconnected)
+        if (m_activated && m_state == ConnectionState::disconnected)
             m_on_idle->trigger();
     }
     sess->initiate_deactivation(); // Throws

--- a/src/realm/sync/noinst/client_impl_base.cpp
+++ b/src/realm/sync/noinst/client_impl_base.cpp
@@ -216,7 +216,6 @@ ClientImpl::ClientImpl(ClientConfig config)
             return;
         else if (!status.is_ok())
             throw ExceptionForStatus(status);
-
         actualize_and_finalize_session_wrappers(); // Throws
     });
 }
@@ -287,10 +286,9 @@ void Connection::activate_session(std::unique_ptr<Session> sess)
 
 void Connection::initiate_session_deactivation(Session* sess)
 {
-    REALM_ASSERT(m_on_idle);
     REALM_ASSERT(&sess->m_conn == this);
     if (REALM_UNLIKELY(--m_num_active_sessions == 0)) {
-        if (m_activated && m_state == ConnectionState::disconnected)
+        if (m_on_idle && m_activated && m_state == ConnectionState::disconnected)
             m_on_idle->trigger();
     }
     sess->initiate_deactivation(); // Throws

--- a/src/realm/sync/noinst/client_impl_base.hpp
+++ b/src/realm/sync/noinst/client_impl_base.hpp
@@ -136,11 +136,8 @@ public:
 
     static constexpr int get_oldest_supported_protocol_version() noexcept;
 
-    // @{
-    /// These call stop() and run() on the socket provider respectively.
-    void run() noexcept;
+    /// This calls stop() on the socket provider respectively.
     void stop() noexcept;
-    // @}
 
     const std::string& get_user_agent_string() const noexcept;
     ReconnectMode get_reconnect_mode() const noexcept;

--- a/src/realm/sync/noinst/client_impl_base.hpp
+++ b/src/realm/sync/noinst/client_impl_base.hpp
@@ -138,8 +138,8 @@ public:
 
     // @{
     /// These call stop() and run() on the socket provider respectively.
+    void run() noexcept;
     void stop() noexcept;
-    void run();
     // @}
 
     const std::string& get_user_agent_string() const noexcept;
@@ -179,7 +179,6 @@ private:
     const bool m_fix_up_object_ids;
     const std::function<RoundtripTimeHandler> m_roundtrip_time_handler;
     const std::string m_user_agent_string;
-    // This will be updated to the SyncSocketProvider interface once the integration is complete
     std::shared_ptr<SyncSocketProvider> m_socket_provider;
     ClientProtocol m_client_protocol;
     session_ident_type m_prev_session_ident = 0;
@@ -219,8 +218,6 @@ private:
     bool m_stopped = false;                       // Protected by `m_mutex`
     bool m_sessions_terminated = false;           // Protected by `m_mutex`
     bool m_actualize_and_finalize_needed = false; // Protected by `m_mutex`
-
-    std::atomic<bool> m_running{false}; // Debugging facility
 
     // The set of session wrappers that are not yet wrapping a session object,
     // and are not yet abandoned (still referenced by the application).
@@ -1163,7 +1160,6 @@ inline bool ClientImpl::is_dry_run() const noexcept
 {
     return m_dry_run;
 }
-
 
 inline std::mt19937_64& ClientImpl::get_random() noexcept
 {

--- a/src/realm/sync/socket_provider.hpp
+++ b/src/realm/sync/socket_provider.hpp
@@ -142,8 +142,8 @@ public:
 
     /// Temporary functions added to support the default socket provider until
     /// it is fully integrated. Will be removed in future PRs.
-    virtual void run() {}
-    virtual void stop() {}
+    virtual void start() {}
+    virtual void stop(bool) {}
 };
 
 /// Struct that defines the endpoint to create a new websocket connection.

--- a/src/realm/sync/socket_provider.hpp
+++ b/src/realm/sync/socket_provider.hpp
@@ -142,8 +142,7 @@ public:
 
     /// Temporary functions added to support the default socket provider until
     /// it is fully integrated. Will be removed in future PRs.
-    virtual void start() {}
-    virtual void stop(bool) {}
+    virtual void stop(bool = false) {}
 };
 
 /// Struct that defines the endpoint to create a new websocket connection.

--- a/test/benchmark-sync/bench_transform.cpp
+++ b/test/benchmark-sync/bench_transform.cpp
@@ -92,13 +92,11 @@ void transform_transactions(TestContext& test_context)
 
         // Start server and upload changes of second client.
         fixture.start_server(0);
-        fixture.start_client(1);
         session_2.wait_for_upload_complete_or_client_stopped();
         session_2.wait_for_download_complete_or_client_stopped();
         fixture.stop_client(1);
 
         // Upload changes of first client and wait to integrate changes from second client.
-        fixture.start_client(0);
         session_1.wait_for_upload_complete_or_client_stopped();
         session_1.wait_for_download_complete_or_client_stopped();
     }
@@ -172,13 +170,11 @@ void transform_instructions(TestContext& test_context)
 
         // Start server and upload changes of second client.
         fixture.start_server(0);
-        fixture.start_client(1);
         session_2.wait_for_upload_complete_or_client_stopped();
         session_2.wait_for_download_complete_or_client_stopped();
         fixture.stop_client(1);
 
         // Upload changes of first client and wait to integrate changes from second client.
-        fixture.start_client(0);
         session_1.wait_for_upload_complete_or_client_stopped();
         session_1.wait_for_download_complete_or_client_stopped();
     }
@@ -250,13 +246,11 @@ void connected_objects(TestContext& test_context)
 
         // Start server and upload changes of second client.
         fixture.start_server(0);
-        fixture.start_client(1);
         session_2.wait_for_upload_complete_or_client_stopped();
         session_2.wait_for_download_complete_or_client_stopped();
         fixture.stop_client(1);
 
         // Upload changes of first client and wait to integrate changes from second client.
-        fixture.start_client(0);
         session_1.wait_for_upload_complete_or_client_stopped();
         session_1.wait_for_download_complete_or_client_stopped();
     }

--- a/test/sync_fixtures.hpp
+++ b/test/sync_fixtures.hpp
@@ -842,7 +842,7 @@ private:
             // If we're using a simulated failure, post it onto the event loop
             client.post_for_testing([sim = m_simulated_client_error_rates[i]](Status) {
                 sf::prime_random(sf::sync_client__read_head, sim.first, sim.second,
-                                random_int<uint_fast64_t>()); // Seed from global generator
+                                 random_int<uint_fast64_t>()); // Seed from global generator
             });
         }
         client.run();

--- a/test/sync_fixtures.hpp
+++ b/test/sync_fixtures.hpp
@@ -845,7 +845,6 @@ private:
                                  random_int<uint_fast64_t>()); // Seed from global generator
             });
         }
-        client.run();
     }
 };
 

--- a/test/test_handshake.cpp
+++ b/test/test_handshake.cpp
@@ -299,7 +299,6 @@ void run_client_surprise_server(unit_test::TestContext& test_context, const std:
     client_config.one_connection_per_session = true;
     client_config.tcp_no_delay = true;
     Client client(client_config);
-    client.run();
 
     Session::Config session_config;
     session_config.server_address = "localhost";
@@ -484,7 +483,6 @@ TEST_IF(Handshake_ExternalServer, false)
     client_config.one_connection_per_session = true;
     client_config.tcp_no_delay = true;
     Client client(client_config);
-    client.run();
 
     Session::Config session_config;
     session_config.server_address = server_address;

--- a/test/test_handshake.cpp
+++ b/test/test_handshake.cpp
@@ -299,11 +299,7 @@ void run_client_surprise_server(unit_test::TestContext& test_context, const std:
     client_config.one_connection_per_session = true;
     client_config.tcp_no_delay = true;
     Client client(client_config);
-
-    ThreadWrapper client_thread;
-    client_thread.start([&] {
-        client.run();
-    });
+    client.run();
 
     Session::Config session_config;
     session_config.server_address = "localhost";
@@ -326,7 +322,6 @@ void run_client_surprise_server(unit_test::TestContext& test_context, const std:
     session.wait_for_download_complete_or_client_stopped();
 
     client.stop();
-    client_thread.join();
     server.stop();
     server_thread.join();
 }
@@ -489,11 +484,7 @@ TEST_IF(Handshake_ExternalServer, false)
     client_config.one_connection_per_session = true;
     client_config.tcp_no_delay = true;
     Client client(client_config);
-
-    ThreadWrapper client_thread;
-    client_thread.start([&] {
-        client.run();
-    });
+    client.run();
 
     Session::Config session_config;
     session_config.server_address = server_address;
@@ -517,7 +508,6 @@ TEST_IF(Handshake_ExternalServer, false)
     session.wait_for_download_complete_or_client_stopped();
 
     client.stop();
-    client_thread.join();
 }
 
 } // unnamed namespace

--- a/test/test_sync.cpp
+++ b/test/test_sync.cpp
@@ -3722,7 +3722,7 @@ TEST(Sync_UploadDownloadProgress_6)
     // currently wait for the event loop thread to be terminated
     // TODO: Update this after event loop stop is updated
     progress_cv.wait_for(lock, std::chrono::seconds(15), [&]() {
-        return session != nullptr;
+        return session == nullptr;
     });
 
     client.stop();

--- a/test/test_sync.cpp
+++ b/test/test_sync.cpp
@@ -2970,7 +2970,6 @@ TEST_IF(Sync_SSL_Certificate_Verify_Callback_External, false)
     config.logger = std::make_shared<util::PrefixLogger>("Client: ", test_context.logger);
     config.reconnect_mode = ReconnectMode::testing;
     Client client(config);
-    client.run();
 
     auto ssl_verify_callback = [&](const std::string server_address, Session::port_type server_port,
                                    const char* pem_data, size_t pem_size, int preverify_ok, int depth) {
@@ -3120,7 +3119,6 @@ TEST(Sync_UploadDownloadProgress_1)
         config.logger = std::make_shared<util::PrefixLogger>("Client: ", test_context.logger);
         config.reconnect_mode = ReconnectMode::testing;
         Client client(config);
-        client.run();
 
         Session session(client, db, nullptr);
 
@@ -3386,7 +3384,6 @@ TEST(Sync_UploadDownloadProgress_3)
     client_config.logger = std::make_shared<util::PrefixLogger>("Client: ", test_context.logger);
     client_config.reconnect_mode = ReconnectMode::testing;
     Client client(client_config);
-    client.run();
 
     // when connecting to the C++ server, use URL prefix:
     Session::Config config;
@@ -3682,7 +3679,6 @@ TEST(Sync_UploadDownloadProgress_6)
     client_config.reconnect_mode = ReconnectMode::testing;
     client_config.one_connection_per_session = false;
     Client client(client_config);
-    client.run();
 
     Session::Config session_config;
     session_config.server_address = "localhost";
@@ -4329,12 +4325,9 @@ TEST(Sync_MergeMultipleChangesets)
         TEST_DIR(dir);
         MultiClientServerFixture fixture(2, 1, dir, test_context);
 
+        // Start server and upload changes of first client.
         Session session_1 = fixture.make_session(0, db_1);
         fixture.bind_session(session_1, 0, "/test");
-        Session session_2 = fixture.make_session(1, db_2);
-        fixture.bind_session(session_2, 0, "/test");
-
-        // Start server and upload changes of first client.
         fixture.start_server(0);
         fixture.start_client(0);
         session_1.wait_for_upload_complete_or_client_stopped();
@@ -4344,6 +4337,8 @@ TEST(Sync_MergeMultipleChangesets)
 
         // Start the second client and upload their changes.
         // Wait to integrate changes from the first client.
+        Session session_2 = fixture.make_session(1, db_2);
+        fixture.bind_session(session_2, 0, "/test");
         fixture.start_client(1);
         session_2.wait_for_upload_complete_or_client_stopped();
         session_2.wait_for_download_complete_or_client_stopped();
@@ -5042,7 +5037,6 @@ TEST_IF(Sync_SSL_Certificates, false)
         client_config.logger = client_logger;
         client_config.reconnect_mode = ReconnectMode::testing;
         Client client(client_config);
-        client.run();
 
         Session::Config session_config;
         session_config.server_address = server_address[i];

--- a/test/test_sync.cpp
+++ b/test/test_sync.cpp
@@ -1565,17 +1565,6 @@ TEST(Sync_FailingReadsOnClientSide)
 }
 
 
-TEST(Sync_RapidStartStop)
-{
-    TEST_DIR(dir);
-    for (int i = 0; i < 1000; i++) {
-        ClientServerFixture fixture{dir, test_context};
-        fixture.stop();
-        std::cerr << "Fixture start/stop: " << i << std::endl;
-    }
-}
-
-
 TEST(Sync_FailingReadsOnServerSide)
 {
     TEST_CLIENT_DB(db_1);

--- a/test/test_sync.cpp
+++ b/test/test_sync.cpp
@@ -1565,6 +1565,17 @@ TEST(Sync_FailingReadsOnClientSide)
 }
 
 
+TEST(Sync_RapidStartStop)
+{
+    TEST_DIR(dir);
+    for (int i = 0; i < 1000; i++) {
+        ClientServerFixture fixture{dir, test_context};
+        fixture.stop();
+        std::cerr << "Fixture start/stop: " << i << std::endl;
+    }
+}
+
+
 TEST(Sync_FailingReadsOnServerSide)
 {
     TEST_CLIENT_DB(db_1);

--- a/test/test_sync.cpp
+++ b/test/test_sync.cpp
@@ -2996,7 +2996,6 @@ TEST_IF(Sync_SSL_Certificate_Verify_Callback_External, false)
     session.wait_for_download_complete_or_client_stopped();
 
     client.stop();
-    client_thread.join();
 }
 
 #endif // REALM_HAVE_OPENSSL


### PR DESCRIPTION
## What, How & Why?
Migrate the `network::Service` object from `ClientImpl` to `DefaultSyncSocket` and update operation so the event loop thread is no longer owned by `SyncClient`. Update `realm-sync-tests` to work with the new scheme.

The `BindingCallbackThreadObserver` class and global variable was moved from _src/realm/object-store_ to _src/realm/sync_.

First set of updates for #5448

## ☑️ ToDos
* [X] 📝 Changelog update
* [X] 🚦 Tests (or not relevant)
* [X] C-API, if public C++ API changed.
