### PR TITLE
Added c_api error category for resolve errors instead of unknown category

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,7 @@
 * Create DefaultSyncSocket class ([PR #6116](https://github.com/realm/realm-core/pull/6116))
 * Improve detection of Windows target architecture when downloading prebuild dependencies. ([#6135](https://github.com/realm/realm-core/issues/6135))
 * App services request ID now logged at info level when sync client connects ([#6143](https://github.com/realm/realm-core/pull/6143]))
+* Add c_api error category for resolve errors since it was reported as unknown category. ([PR #6157](https://github.com/realm/realm-core/pull/6157))
 
 ----------------------------------------------
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,7 +35,7 @@
 * Create DefaultSyncSocket class ([PR #6116](https://github.com/realm/realm-core/pull/6116))
 * Improve detection of Windows target architecture when downloading prebuild dependencies. ([#6135](https://github.com/realm/realm-core/issues/6135))
 * App services request ID now logged at info level when sync client connects ([#6143](https://github.com/realm/realm-core/pull/6143]))
-* Add c_api error category for resolve errors since it was reported as unknown category. ([PR #6157](https://github.com/realm/realm-core/pull/6157))
+* Add c_api error category for resolve errors instead of reporting unknown category. ([PR #6157](https://github.com/realm/realm-core/pull/6157))
 
 ----------------------------------------------
 

--- a/src/realm.h
+++ b/src/realm.h
@@ -3411,6 +3411,7 @@ typedef enum realm_sync_error_category {
     RLM_SYNC_ERROR_CATEGORY_CLIENT,
     RLM_SYNC_ERROR_CATEGORY_CONNECTION,
     RLM_SYNC_ERROR_CATEGORY_SESSION,
+    RLM_SYNC_ERROR_CATEGORY_RESOLVE,
 
     /**
      * System error - POSIX errno, Win32 HRESULT, etc.

--- a/src/realm/object-store/c_api/conversion.hpp
+++ b/src/realm/object-store/c_api/conversion.hpp
@@ -457,6 +457,8 @@ static inline realm_version_id_t to_capi(const VersionID& v)
     return version_id;
 }
 
+realm_sync_error_code_t to_capi(const std::error_code& error_code, std::string& message);
+
 } // namespace realm::c_api
 
 

--- a/src/realm/object-store/c_api/sync.cpp
+++ b/src/realm/object-store/c_api/sync.cpp
@@ -19,6 +19,7 @@
 #include <realm/sync/config.hpp>
 #include <realm/sync/client.hpp>
 #include <realm/sync/protocol.hpp>
+#include <realm/sync/network/network.hpp>
 #include <realm/object-store/c_api/conversion.hpp>
 #include <realm/object-store/sync/sync_manager.hpp>
 #include <realm/object-store/sync/sync_session.hpp>
@@ -241,7 +242,7 @@ static_assert(realm_flx_sync_subscription_set_state_e(SubscriptionSet::State::Un
 
 } // namespace
 
-static realm_sync_error_code_t to_capi(const std::error_code& error_code, std::string& message)
+realm_sync_error_code_t to_capi(const std::error_code& error_code, std::string& message)
 {
     auto ret = realm_sync_error_code_t();
 
@@ -268,6 +269,9 @@ static realm_sync_error_code_t to_capi(const std::error_code& error_code, std::s
     }
     else if (category == std::system_category() || category == *realm_basic_system_category) {
         ret.category = RLM_SYNC_ERROR_CATEGORY_SYSTEM;
+    }
+    else if (category == realm::sync::network::resolve_error_category()) {
+        ret.category = RLM_SYNC_ERROR_CATEGORY_RESOLVE;
     }
     else {
         ret.category = RLM_SYNC_ERROR_CATEGORY_UNKNOWN;

--- a/src/realm/sync/network/network.cpp
+++ b/src/realm/sync/network/network.cpp
@@ -2604,16 +2604,15 @@ public:
     }
 };
 
-ResolveErrorCategory g_resolve_error_category;
-
 const std::error_category& resolve_error_category() noexcept
 {
-    return g_resolve_error_category;
+    static const ResolveErrorCategory resolve_error_category;
+    return resolve_error_category;
 }
 
 std::error_code make_error_code(ResolveErrors err)
 {
-    return std::error_code(int(err), g_resolve_error_category);
+    return std::error_code(int(err), resolve_error_category());
 }
 
 } // namespace realm::sync::network

--- a/src/realm/sync/network/network.hpp
+++ b/src/realm/sync/network/network.hpp
@@ -1396,20 +1396,11 @@ enum class ResolveErrors {
     socket_type_not_supported
 };
 
-class ResolveErrorCategory : public std::error_category {
-public:
-    const char* name() const noexcept override final;
-    std::string message(int) const override final;
-};
-
 /// The error category associated with ResolveErrors. The name of this category is
-/// `realm.util.network.resolve`.
-extern ResolveErrorCategory resolve_error_category;
+/// `realm.sync.network.resolve`.
+const std::error_category& resolve_error_category() noexcept;
 
-inline std::error_code make_error_code(ResolveErrors err)
-{
-    return std::error_code(int(err), resolve_error_category);
-}
+std::error_code make_error_code(ResolveErrors err);
 
 } // namespace realm::sync::network
 

--- a/src/realm/sync/network/network_ssl.cpp
+++ b/src/realm/sync/network/network_ssl.cpp
@@ -162,7 +162,7 @@ ErrorCategory error_category;
 
 const char* ErrorCategory::name() const noexcept
 {
-    return "realm.util.network.ssl";
+    return "realm.sync.network.ssl";
 }
 
 

--- a/src/realm/sync/network/network_ssl.hpp
+++ b/src/realm/sync/network/network_ssl.hpp
@@ -57,7 +57,7 @@ public:
 };
 
 /// The error category associated with \ref Errors. The name of this category is
-/// `realm.util.network.ssl`.
+/// `realm.sync.network.ssl`.
 extern ErrorCategory error_category;
 
 inline std::error_code make_error_code(Errors err)

--- a/test/client/peer.cpp
+++ b/test/client/peer.cpp
@@ -84,7 +84,7 @@ Peer::Error map_error(std::error_code ec) noexcept
         }
         return Peer::Error::system_other;
     }
-    if (category == sync::network::resolve_error_category) {
+    if (category == sync::network::resolve_error_category()) {
         using sync::network::ResolveErrors;
         switch (ResolveErrors(ec.value())) {
             case ResolveErrors::host_not_found:


### PR DESCRIPTION
## What, How & Why?
Added error category for resolve errors (e.g. when no connection or DNS server is unreachable) instead of returning unknown category.

Fixes #6015

## ☑️ ToDos
* [x] 📝 Changelog update
* [X] 🚦 Tests (or not relevant)
* [X] C-API, if public C++ API changed.
