### PR TITLE
Update App to support 308 redirect response

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,6 +38,7 @@
 * Improve detection of Windows target architecture when downloading prebuild dependencies. ([#6135](https://github.com/realm/realm-core/issues/6135))
 * App services request ID now logged at info level when sync client connects ([#6143](https://github.com/realm/realm-core/pull/6143]))
 * Add c_api error category for resolve errors instead of reporting unknown category. ([PR #6157](https://github.com/realm/realm-core/pull/6157))
+* Add 308 as a supported redirect response from the server ([#6162](https://github.com/realm/realm-core/issues/6162))
 
 ----------------------------------------------
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,7 +38,7 @@
 * Improve detection of Windows target architecture when downloading prebuild dependencies. ([#6135](https://github.com/realm/realm-core/issues/6135))
 * App services request ID now logged at info level when sync client connects ([#6143](https://github.com/realm/realm-core/pull/6143]))
 * Add c_api error category for resolve errors instead of reporting unknown category. ([PR #6157](https://github.com/realm/realm-core/pull/6157))
-* Add 308 as a supported redirect response from the server ([#6162](https://github.com/realm/realm-core/issues/6162))
+* Add permanent redirect (308) as a supported redirect response from the server. ([#6162](https://github.com/realm/realm-core/issues/6162))
 
 ----------------------------------------------
 

--- a/src/realm/object-store/sync/app.cpp
+++ b/src/realm/object-store/sync/app.cpp
@@ -928,7 +928,8 @@ void App::handle_possible_redirect_response(Request&& request, const Response& r
                                             UniqueFunction<void(const Response&)>&& completion)
 {
     // If the response contains a redirection, then process it
-    if (sync::HTTPStatus(response.http_status_code) == sync::HTTPStatus::MovedPermanently) {
+    if (sync::HTTPStatus(response.http_status_code) == sync::HTTPStatus::MovedPermanently ||
+        sync::HTTPStatus(response.http_status_code) == sync::HTTPStatus::PermanentRedirect) {
         handle_redirect_response(std::move(request), response, std::move(completion));
     }
     else {

--- a/src/realm/object-store/sync/app.cpp
+++ b/src/realm/object-store/sync/app.cpp
@@ -927,9 +927,10 @@ void App::do_request(Request&& request, UniqueFunction<void(const Response&)>&& 
 void App::handle_possible_redirect_response(Request&& request, const Response& response,
                                             UniqueFunction<void(const Response&)>&& completion)
 {
+    using namespace realm::sync;
     // If the response contains a redirection, then process it
-    if (sync::HTTPStatus(response.http_status_code) == sync::HTTPStatus::MovedPermanently ||
-        sync::HTTPStatus(response.http_status_code) == sync::HTTPStatus::PermanentRedirect) {
+    auto status_code = HTTPStatus(response.http_status_code);
+    if (status_code == HTTPStatus::MovedPermanently || status_code == HTTPStatus::PermanentRedirect) {
         handle_redirect_response(std::move(request), response, std::move(completion));
     }
     else {

--- a/test/object-store/sync/app.cpp
+++ b/test/object-store/sync/app.cpp
@@ -2271,7 +2271,7 @@ TEST_CASE("app: sync integration", "[sync][app]") {
                 logger->trace("request.url (%1): %2", request_count, request.url);
                 REQUIRE(request_count <= 21);
                 redir_transport->simulated_response = {
-                    308,
+                    request_count % 2 == 1 ? 308 : 301,
                     0,
                     {{"Location", "http://somehost:9090"}, {"Content-Type", "application/json"}},
                     "Some body data"};

--- a/test/object-store/sync/app.cpp
+++ b/test/object-store/sync/app.cpp
@@ -2219,7 +2219,7 @@ TEST_CASE("app: sync integration", "[sync][app]") {
                     logger->trace("request.url (%1): %2", request_count, request.url);
                     REQUIRE(request.url.find("somehost:9090") != std::string::npos);
                     redir_transport->simulated_response = {
-                        301, 0, {{"Location", redirect_url}, {"Content-Type", "application/json"}}, "Some body data"};
+                        308, 0, {{"Location", redirect_url}, {"Content-Type", "application/json"}}, "Some body data"};
                     request_count++;
                 }
                 else if (request_count == 3) {
@@ -2271,7 +2271,7 @@ TEST_CASE("app: sync integration", "[sync][app]") {
                 logger->trace("request.url (%1): %2", request_count, request.url);
                 REQUIRE(request_count <= 21);
                 redir_transport->simulated_response = {
-                    301,
+                    308,
                     0,
                     {{"Location", "http://somehost:9090"}, {"Content-Type", "application/json"}},
                     "Some body data"};


### PR DESCRIPTION
## What, How & Why?
Update App to support both 301 and 308 redirect response from the server when the deployment model is changed. Also added support to `handle_refresh` to handle the "too many redirects" or redirect response. Updated the App redirect tests to use both 301 and 308 in the simulated http response.

Fixes #6162

## ☑️ ToDos
* [X] 📝 Changelog update
* [X] 🚦 Tests (or not relevant)
* ~~[ ] C-API, if public C++ API changed.~~
