### PR TITLE
Fix failures in Metrics_TransactionTimings core test

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -63,6 +63,7 @@
 * Add c_api error category for resolve errors instead of reporting unknown category. ([PR #6157](https://github.com/realm/realm-core/pull/6157))
 * Add permanent redirect (308) as a supported redirect response from the server. ([#6162](https://github.com/realm/realm-core/issues/6162))
 * Integrate DefaultSocketProvider as SyncSocketProvider in sync client. ([PR #6171](https://github.com/realm/realm-core/pull/6171))
+* Fix failures in Metrics_TransactionTimings core test ([#6164](https://github.com/realm/realm-core/issues/6164))
 
 ----------------------------------------------
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,7 +17,7 @@
 -----------
 
 ### Internals
-* None.
+* Fix failures in Metrics_TransactionTimings core test ([#6164](https://github.com/realm/realm-core/issues/6164))
 
 ----------------------------------------------
 
@@ -63,7 +63,6 @@
 * Add c_api error category for resolve errors instead of reporting unknown category. ([PR #6157](https://github.com/realm/realm-core/pull/6157))
 * Add permanent redirect (308) as a supported redirect response from the server. ([#6162](https://github.com/realm/realm-core/issues/6162))
 * Integrate DefaultSocketProvider as SyncSocketProvider in sync client. ([PR #6171](https://github.com/realm/realm-core/pull/6171))
-* Fix failures in Metrics_TransactionTimings core test ([#6164](https://github.com/realm/realm-core/issues/6164))
 
 ----------------------------------------------
 

--- a/test/test_metrics.cpp
+++ b/test/test_metrics.cpp
@@ -796,7 +796,10 @@ NONCONCURRENT_TEST(Metrics_TransactionTimings)
                 metrics::TransactionInfo::TransactionType::write_transaction);
     CHECK_GREATER(transactions->at(3).get_transaction_time_nanoseconds(), 10'000);     // > 10us
     CHECK_LESS(transactions->at(3).get_transaction_time_nanoseconds(), 2'000'000'000); // <  2s
-    CHECK_GREATER(transactions->at(3).get_fsync_time_nanoseconds(), 0); // fsync on write takes some time
+    // This check returns 0 for get_fsync_time_nanoseconds if sync to disk is disabled
+    if (!get_disable_sync_to_disk()) {
+        CHECK_GREATER(transactions->at(3).get_fsync_time_nanoseconds(), 0); // fsync on write takes some time
+    }
 }
 
 


### PR DESCRIPTION
## What, How & Why?
Update the `Metrics_TransactionTimings` so it doesn't check the fsync timing if sync to disk is disabled. The test is looking for an fsync time greater than 0 and this value will be 0 if sync to disk happens to be disabled (by another concurrent test) when this test runs. The `for()` loop in this test already checks to see if sync to disk is disabled before checking the fsync timing value, but the last fsync check was always checking the value.

Fixes #6164

## ☑️ ToDos
* [x] 📝 Changelog update
* [X] 🚦 Tests (or not relevant)
* ~~[ ] C-API, if public C++ API changed.~~
