### PR TITLE
C API for custom websocket

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 * Converting flexible sync realms to bundled and local realms is now supported ([#6076](https://github.com/realm/realm-core/pull/6076))
 * Compensating write errors are now surfaced to the SDK/user after the compensating write has been applied in a download message ([#6095](https://github.com/realm/realm-core/pull/6095)).
 * Normalize sync connection parameters for device information ([#6029](https://github.com/realm/realm-core/issues/6029))
+* Add support for providing custom websocket implementations in the C API ([#5917](https://github.com/realm/realm-core/issues/5917))
 
 ### Fixed
 * <How do the end-user experience this issue? what was the impact?> ([#????](https://github.com/realm/realm-core/issues/????), since v?.?.?)

--- a/src/realm.h
+++ b/src/realm.h
@@ -396,6 +396,46 @@ typedef bool (*realm_scheduler_is_same_as_func_t)(const realm_userdata_t schedul
 typedef bool (*realm_scheduler_can_deliver_notifications_func_t)(realm_userdata_t userdata);
 typedef realm_scheduler_t* (*realm_scheduler_default_factory_func_t)(realm_userdata_t userdata);
 
+/* Sync Socket Provider types */
+typedef struct realm_websocket_endpoint {
+    const char* address;    // Host address
+    uint16_t port;          // Host port number
+    const char* path;       // Includes access token in query.
+    const char** protocols; // Array of one or more websocket protocols
+    size_t num_protocols;   // Number of protocols in array
+    bool is_ssl;            // true if SSL should be used
+} realm_websocket_endpoint_t;
+
+typedef struct realm_sync_socket realm_sync_socket_t;
+typedef struct realm_sync_socket_callback realm_sync_socket_callback_t;
+typedef void* realm_sync_socket_timer_t;
+typedef void* realm_sync_socket_websocket_t;
+typedef struct realm_websocket_observer realm_websocket_observer_t;
+
+typedef void (*realm_sync_socket_post_func_t)(realm_userdata_t userdata,
+                                              realm_sync_socket_callback_t* realm_callback);
+
+typedef realm_sync_socket_timer_t (*realm_sync_socket_create_timer_func_t)(
+    realm_userdata_t userdata, uint64_t delay_ms, realm_sync_socket_callback_t* realm_callback);
+
+typedef void (*realm_sync_socket_timer_canceled_func_t)(realm_userdata_t userdata,
+                                                        realm_sync_socket_timer_t timer_userdata);
+
+typedef void (*realm_sync_socket_timer_free_func_t)(realm_userdata_t userdata,
+                                                    realm_sync_socket_timer_t timer_userdata);
+
+typedef realm_sync_socket_websocket_t (*realm_sync_socket_connect_func_t)(
+    realm_userdata_t userdata, realm_websocket_endpoint_t endpoint,
+    realm_websocket_observer_t* realm_websocket_observer);
+
+typedef void (*realm_sync_socket_websocket_async_write_func_t)(realm_userdata_t userdata,
+                                                               realm_sync_socket_websocket_t websocket_userdata,
+                                                               const char* data, size_t size,
+                                                               realm_sync_socket_callback_t* realm_callback);
+
+typedef void (*realm_sync_socket_websocket_free_func_t)(realm_userdata_t userdata,
+                                                        realm_sync_socket_websocket_t websocket_userdata);
+
 /**
  * Get the VersionID of the current transaction.
  *
@@ -4248,5 +4288,53 @@ RLM_API bool realm_mongo_collection_find_one_and_delete(realm_mongodb_collection
                                                         realm_userdata_t data, realm_free_userdata_func_t delete_data,
                                                         realm_mongodb_callback_t callback);
 
+typedef enum status_error_code {
+    STATUS_OK = 0,
+    STATUS_UNKNOWN_ERROR = 1,
+    STATUS_RUNTIME_ERROR = 2,
+    STATUS_LOGIC_ERROR = 3,
+    STATUS_BROKEN_PROMISE = 4,
+    STATUS_OPERATION_ABORTED = 5,
+
+    /// WEBSOCKET ERRORS
+    // STATUS_WEBSOCKET_OK = 1000 IS NOT USED, JUST USE OK INSTEAD
+    STATUS_WEBSOCKET_GOING_AWAY = 1001,
+    STATUS_WEBSOCKET_PROTOCOL_ERROR = 1002,
+    STATUS_WEBSOCKET_UNSUPPORTED_DATA = 1003,
+    STATUS_WEBSOCKET_RESERVED = 1004,
+    STATUS_WEBSOCKET_NO_STATUS_RECEIVED = 1005,
+    STATUS_WEBSOCKET_ABNORMAL_CLOSURE = 1006,
+    STATUS_WEBSOCKET_INVALID_PAYLOAD_DATA = 1007,
+    STATUS_WEBSOCKET_POLICY_VIOLATION = 1008,
+    STATUS_WEBSOCKET_MESSAGE_TOO_BIG = 1009,
+    STATUS_WEBSOCKET_INAVALID_EXTENSION = 1010,
+    STATUS_WEBSOCKET_INTERNAL_SERVER_ERROR = 1011,
+    STATUS_WEBSOCKET_TLS_HANDSHAKE_FAILED = 1015, // USED BY DEFAULT WEBSOCKET
+} status_error_code_e;
+
+RLM_API realm_sync_socket_t* realm_sync_socket_new(
+    realm_userdata_t userdata, realm_free_userdata_func_t userdata_free, realm_sync_socket_post_func_t post_func,
+    realm_sync_socket_create_timer_func_t create_timer_func,
+    realm_sync_socket_timer_canceled_func_t cancel_timer_func, realm_sync_socket_timer_free_func_t free_timer_func,
+    realm_sync_socket_connect_func_t websocket_connect_func,
+    realm_sync_socket_websocket_async_write_func_t websocket_write_func,
+    realm_sync_socket_websocket_free_func_t websocket_free_func);
+
+RLM_API void realm_sync_socket_callback_complete(realm_sync_socket_callback_t* realm_callback,
+                                                 status_error_code_e status, const char* reason);
+
+RLM_API void realm_sync_socket_websocket_connected(realm_websocket_observer_t* realm_websocket_observer,
+                                                   const char* protocol);
+
+RLM_API void realm_sync_socket_websocket_error(realm_websocket_observer_t* realm_websocket_observer);
+
+RLM_API void realm_sync_socket_websocket_message(realm_websocket_observer_t* realm_websocket_observer,
+                                                 const char* data, size_t data_size);
+
+RLM_API void realm_sync_socket_websocket_closed(realm_websocket_observer_t* realm_websocket_observer, bool was_clean,
+                                                status_error_code_e status, const char* reason);
+
+RLM_API void realm_sync_client_config_set_sync_socket(realm_sync_client_config_t*,
+                                                      realm_sync_socket_t*) RLM_API_NOEXCEPT;
 
 #endif // REALM_H

--- a/src/realm/object-store/c_api/CMakeLists.txt
+++ b/src/realm/object-store/c_api/CMakeLists.txt
@@ -26,6 +26,7 @@ if(REALM_ENABLE_SYNC)
         http.cpp
         logging.cpp
         sync.cpp
+        socket_provider.cpp
     )
 endif()
 

--- a/src/realm/object-store/c_api/realm.cpp
+++ b/src/realm/object-store/c_api/realm.cpp
@@ -312,7 +312,6 @@ RLM_API bool realm_remove_table(realm_t* realm, const char* table_name, bool* ta
             *table_deleted = true;
         }
         return true;
-        ;
     });
 }
 

--- a/src/realm/object-store/c_api/schema.cpp
+++ b/src/realm/object-store/c_api/schema.cpp
@@ -5,7 +5,7 @@
 namespace realm::c_api {
 
 RLM_API realm_schema_t* realm_schema_new(const realm_class_info_t* classes, size_t num_classes,
-                                         const realm_property_info** class_properties)
+                                         const realm_property_info_t** class_properties)
 {
     return wrap_err([&]() {
         std::vector<ObjectSchema> object_schemas;

--- a/src/realm/object-store/c_api/socket_provider.cpp
+++ b/src/realm/object-store/c_api/socket_provider.cpp
@@ -47,7 +47,8 @@ public:
                   realm_sync_socket_websocket_async_write_func_t websocket_write_func,
                   realm_sync_socket_websocket_free_func_t websocket_free_func, realm_websocket_observer_t* observer,
                   sync::WebSocketEndpoint&& endpoint)
-        : m_userdata(userdata)
+        : m_observer(observer)
+        , m_userdata(userdata)
         , m_websocket_connect(websocket_connect_func)
         , m_websocket_async_write(websocket_write_func)
         , m_websocket_free(websocket_free_func)
@@ -73,6 +74,7 @@ public:
     ~CAPIWebSocket()
     {
         m_websocket_free(m_userdata, m_socket);
+        realm_release(m_observer);
     }
 
     void async_write_binary(util::Span<const char> data, sync::SyncSocketProvider::FunctionHandler&& handler) final
@@ -84,6 +86,7 @@ public:
 
 private:
     realm_sync_socket_websocket_t m_socket = nullptr;
+    realm_websocket_observer_t* m_observer = nullptr;
     realm_userdata_t m_userdata = nullptr;
 
     realm_sync_socket_connect_func_t m_websocket_connect = nullptr;

--- a/src/realm/object-store/c_api/socket_provider.cpp
+++ b/src/realm/object-store/c_api/socket_provider.cpp
@@ -214,7 +214,10 @@ RLM_API realm_sync_socket_t* realm_sync_socket_new(
 RLM_API void realm_sync_socket_callback_complete(realm_sync_socket_callback* realm_callback,
                                                  status_error_code_e status, const char* reason)
 {
-    (*(realm_callback->get()))(Status{static_cast<ErrorCodes::Error>(status), reason});
+    auto complete_status = status == status_error_code_e::STATUS_OK
+                               ? Status::OK()
+                               : Status{static_cast<ErrorCodes::Error>(status), reason};
+    (*(realm_callback->get()))(complete_status);
 }
 
 RLM_API void realm_sync_socket_websocket_connected(realm_websocket_observer_t* realm_websocket_observer,
@@ -237,8 +240,10 @@ RLM_API void realm_sync_socket_websocket_message(realm_websocket_observer_t* rea
 RLM_API void realm_sync_socket_websocket_closed(realm_websocket_observer_t* realm_websocket_observer, bool was_clean,
                                                 status_error_code_e status, const char* reason)
 {
-    realm_websocket_observer->get()->websocket_closed_handler(was_clean,
-                                                              Status{static_cast<ErrorCodes::Error>(status), reason});
+    auto closed_status = status == status_error_code_e::STATUS_OK
+                             ? Status::OK()
+                             : Status{static_cast<ErrorCodes::Error>(status), reason};
+    realm_websocket_observer->get()->websocket_closed_handler(was_clean, closed_status);
 }
 
 RLM_API void realm_sync_client_config_set_sync_socket(realm_sync_client_config_t* config,

--- a/src/realm/object-store/c_api/socket_provider.cpp
+++ b/src/realm/object-store/c_api/socket_provider.cpp
@@ -218,6 +218,7 @@ RLM_API void realm_sync_socket_callback_complete(realm_sync_socket_callback* rea
                                ? Status::OK()
                                : Status{static_cast<ErrorCodes::Error>(status), reason};
     (*(realm_callback->get()))(complete_status);
+    realm_release(realm_callback);
 }
 
 RLM_API void realm_sync_socket_websocket_connected(realm_websocket_observer_t* realm_websocket_observer,

--- a/src/realm/object-store/c_api/socket_provider.cpp
+++ b/src/realm/object-store/c_api/socket_provider.cpp
@@ -1,0 +1,250 @@
+#include <realm/error_codes.hpp>
+#include <realm/status.hpp>
+#include <realm/object-store/c_api/util.hpp>
+#include <realm/sync/socket_provider.hpp>
+
+namespace realm::c_api {
+namespace {
+
+struct CAPITimer : sync::SyncSocketProvider::Timer {
+public:
+    CAPITimer(realm_userdata_t userdata, int64_t delay_ms, realm_sync_socket_callback_t* handler,
+              realm_sync_socket_create_timer_func_t create_timer_func,
+              realm_sync_socket_timer_canceled_func_t cancel_timer_func,
+              realm_sync_socket_timer_free_func_t free_timer_func)
+        : m_timer_create(create_timer_func)
+        , m_timer_cancel(cancel_timer_func)
+        , m_timer_free(free_timer_func)
+    {
+        m_timer = m_timer_create(userdata, delay_ms, handler);
+    }
+
+    /// Cancels the timer and destroys the timer instance.
+    ~CAPITimer()
+    {
+        m_timer_cancel(m_userdata, m_timer);
+        m_timer_free(m_userdata, m_timer);
+    }
+
+    /// Cancel the timer immediately.
+    void cancel() override
+    {
+        m_timer_cancel(m_userdata, m_timer);
+    }
+
+private:
+    realm_sync_socket_timer_t m_timer = nullptr;
+
+    realm_userdata_t m_userdata = nullptr;
+    realm_sync_socket_create_timer_func_t m_timer_create = nullptr;
+    realm_sync_socket_timer_canceled_func_t m_timer_cancel = nullptr;
+    realm_sync_socket_timer_free_func_t m_timer_free = nullptr;
+};
+
+struct CAPIWebSocket : sync::WebSocketInterface {
+public:
+    CAPIWebSocket(realm_userdata_t userdata, realm_sync_socket_connect_func_t websocket_connect_func,
+                  realm_sync_socket_websocket_async_write_func_t websocket_write_func,
+                  realm_sync_socket_websocket_free_func_t websocket_free_func, realm_websocket_observer_t* observer,
+                  sync::WebSocketEndpoint&& endpoint)
+        : m_userdata(userdata)
+        , m_websocket_connect(websocket_connect_func)
+        , m_websocket_async_write(websocket_write_func)
+        , m_websocket_free(websocket_free_func)
+    {
+        realm_websocket_endpoint_t capi_endpoint;
+        capi_endpoint.address = endpoint.address.c_str();
+        capi_endpoint.port = endpoint.port;
+        capi_endpoint.path = endpoint.path.c_str();
+
+        std::vector<const char*> protocols;
+        for (size_t i = 0; i < endpoint.protocols.size(); ++i) {
+            auto& protocol = endpoint.protocols[i];
+            protocols.push_back(protocol.c_str());
+        }
+        capi_endpoint.protocols = protocols.data();
+        capi_endpoint.num_protocols = protocols.size();
+        capi_endpoint.is_ssl = endpoint.is_ssl;
+
+        m_socket = m_websocket_connect(m_userdata, capi_endpoint, observer);
+    }
+
+    /// Destroys the web socket instance.
+    ~CAPIWebSocket()
+    {
+        m_websocket_free(m_userdata, m_socket);
+    }
+
+    void async_write_binary(util::Span<const char> data, sync::SyncSocketProvider::FunctionHandler&& handler) final
+    {
+        auto shared_handler = std::make_shared<sync::SyncSocketProvider::FunctionHandler>(std::move(handler));
+        m_websocket_async_write(m_userdata, m_socket, data.data(), data.size(),
+                                new realm_sync_socket_callback_t(std::move(shared_handler)));
+    }
+
+private:
+    realm_sync_socket_websocket_t m_socket = nullptr;
+    realm_userdata_t m_userdata = nullptr;
+
+    realm_sync_socket_connect_func_t m_websocket_connect = nullptr;
+    realm_sync_socket_websocket_async_write_func_t m_websocket_async_write = nullptr;
+    realm_sync_socket_websocket_free_func_t m_websocket_free = nullptr;
+};
+
+struct CAPIWebSocketObserver : sync::WebSocketObserver {
+public:
+    CAPIWebSocketObserver(sync::WebSocketObserver& observer)
+        : m_observer(observer)
+    {
+    }
+
+    ~CAPIWebSocketObserver() = default;
+
+    void websocket_connected_handler(const std::string& protocol) final
+    {
+        m_observer.websocket_connected_handler(protocol);
+    }
+
+    void websocket_error_handler() final
+    {
+        m_observer.websocket_error_handler();
+    }
+
+    bool websocket_binary_message_received(util::Span<const char> data) final
+    {
+        return m_observer.websocket_binary_message_received(data);
+    }
+
+    bool websocket_closed_handler(bool was_clean, Status status) final
+    {
+        return m_observer.websocket_closed_handler(was_clean, status);
+    }
+
+private:
+    sync::WebSocketObserver& m_observer;
+};
+
+struct CAPISyncSocketProvider : sync::SyncSocketProvider {
+    realm_userdata_t m_userdata = nullptr;
+    realm_free_userdata_func_t m_free = nullptr;
+    realm_sync_socket_post_func_t m_post = nullptr;
+    realm_sync_socket_create_timer_func_t m_timer_create = nullptr;
+    realm_sync_socket_timer_canceled_func_t m_timer_cancel = nullptr;
+    realm_sync_socket_timer_free_func_t m_timer_free = nullptr;
+    realm_sync_socket_connect_func_t m_websocket_connect = nullptr;
+    realm_sync_socket_websocket_async_write_func_t m_websocket_async_write = nullptr;
+    realm_sync_socket_websocket_free_func_t m_websocket_free = nullptr;
+
+    CAPISyncSocketProvider() = default;
+    CAPISyncSocketProvider(CAPISyncSocketProvider&& other)
+        : m_userdata(std::exchange(other.m_userdata, nullptr))
+        , m_free(std::exchange(other.m_free, nullptr))
+        , m_post(std::exchange(other.m_post, nullptr))
+        , m_timer_create(std::exchange(other.m_timer_create, nullptr))
+        , m_timer_cancel(std::exchange(other.m_timer_cancel, nullptr))
+        , m_timer_free(std::exchange(other.m_timer_free, nullptr))
+        , m_websocket_connect(std::exchange(other.m_websocket_connect, nullptr))
+        , m_websocket_async_write(std::exchange(other.m_websocket_async_write, nullptr))
+        , m_websocket_free(std::exchange(other.m_websocket_free, nullptr))
+    {
+        REALM_ASSERT(m_free);
+        REALM_ASSERT(m_post);
+        REALM_ASSERT(m_timer_create);
+        REALM_ASSERT(m_timer_cancel);
+        REALM_ASSERT(m_timer_free);
+        REALM_ASSERT(m_websocket_connect);
+        REALM_ASSERT(m_websocket_async_write);
+        REALM_ASSERT(m_websocket_free);
+    }
+
+    ~CAPISyncSocketProvider()
+    {
+        m_free(m_userdata);
+    }
+
+    std::unique_ptr<sync::WebSocketInterface> connect(sync::WebSocketObserver* observer,
+                                                      sync::WebSocketEndpoint&& endpoint) final
+    {
+        auto capi_observer = std::make_shared<CAPIWebSocketObserver>(*observer);
+        return std::make_unique<CAPIWebSocket>(m_userdata, m_websocket_connect, m_websocket_async_write,
+                                               m_websocket_free, new realm_websocket_observer_t(capi_observer),
+                                               std::move(endpoint));
+    }
+
+    void post(FunctionHandler&& handler) final
+    {
+        auto shared_handler = std::make_shared<FunctionHandler>(std::move(handler));
+        m_post(m_userdata, new realm_sync_socket_callback_t(std::move(shared_handler)));
+    }
+
+    SyncTimer create_timer(std::chrono::milliseconds delay, FunctionHandler&& handler) final
+    {
+        auto shared_handler = std::make_shared<FunctionHandler>(std::move(handler));
+        return std::make_unique<CAPITimer>(m_userdata, delay.count(),
+                                           new realm_sync_socket_callback_t(std::move(shared_handler)),
+                                           m_timer_create, m_timer_cancel, m_timer_free);
+    }
+};
+
+} // namespace
+
+RLM_API realm_sync_socket_t* realm_sync_socket_new(
+    realm_userdata_t userdata, realm_free_userdata_func_t userdata_free, realm_sync_socket_post_func_t post_func,
+    realm_sync_socket_create_timer_func_t create_timer_func,
+    realm_sync_socket_timer_canceled_func_t cancel_timer_func, realm_sync_socket_timer_free_func_t free_timer_func,
+    realm_sync_socket_connect_func_t websocket_connect_func,
+    realm_sync_socket_websocket_async_write_func_t websocket_write_func,
+    realm_sync_socket_websocket_free_func_t websocket_free_func)
+{
+    return wrap_err([&]() {
+        auto capi_socket_provider = std::make_shared<CAPISyncSocketProvider>();
+        capi_socket_provider->m_userdata = userdata;
+        capi_socket_provider->m_free = userdata_free;
+        capi_socket_provider->m_post = post_func;
+        capi_socket_provider->m_timer_create = create_timer_func;
+        capi_socket_provider->m_timer_cancel = cancel_timer_func;
+        capi_socket_provider->m_timer_free = free_timer_func;
+        capi_socket_provider->m_websocket_connect = websocket_connect_func;
+        capi_socket_provider->m_websocket_async_write = websocket_write_func;
+        capi_socket_provider->m_websocket_free = websocket_free_func;
+        return new realm_sync_socket_t(std::move(capi_socket_provider));
+    });
+}
+
+RLM_API void realm_sync_socket_callback_complete(realm_sync_socket_callback* realm_callback,
+                                                 status_error_code_e status, const char* reason)
+{
+    (*(realm_callback->get()))(Status{static_cast<ErrorCodes::Error>(status), reason});
+}
+
+RLM_API void realm_sync_socket_websocket_connected(realm_websocket_observer_t* realm_websocket_observer,
+                                                   const char* protocol)
+{
+    realm_websocket_observer->get()->websocket_connected_handler(protocol);
+}
+
+RLM_API void realm_sync_socket_websocket_error(realm_websocket_observer_t* realm_websocket_observer)
+{
+    realm_websocket_observer->get()->websocket_error_handler();
+}
+
+RLM_API void realm_sync_socket_websocket_message(realm_websocket_observer_t* realm_websocket_observer,
+                                                 const char* data, size_t data_size)
+{
+    realm_websocket_observer->get()->websocket_binary_message_received(util::Span{data, data_size});
+}
+
+RLM_API void realm_sync_socket_websocket_closed(realm_websocket_observer_t* realm_websocket_observer, bool was_clean,
+                                                status_error_code_e status, const char* reason)
+{
+    realm_websocket_observer->get()->websocket_closed_handler(was_clean,
+                                                              Status{static_cast<ErrorCodes::Error>(status), reason});
+}
+
+RLM_API void realm_sync_client_config_set_sync_socket(realm_sync_client_config_t* config,
+                                                      realm_sync_socket_t* sync_socket) RLM_API_NOEXCEPT
+{
+    config->sync_socket = *sync_socket;
+}
+
+} // namespace realm::c_api

--- a/src/realm/object-store/c_api/types.hpp
+++ b/src/realm/object-store/c_api/types.hpp
@@ -779,6 +779,67 @@ struct realm_mongodb_collection : realm::c_api::WrapC, realm::app::MongoCollecti
     }
 };
 
+struct realm_sync_socket : realm::c_api::WrapC, std::shared_ptr<realm::sync::SyncSocketProvider> {
+    explicit realm_sync_socket(std::shared_ptr<realm::sync::SyncSocketProvider> ptr)
+        : std::shared_ptr<realm::sync::SyncSocketProvider>(std::move(ptr))
+    {
+    }
+
+    realm_sync_socket* clone() const override
+    {
+        return new realm_sync_socket{*this};
+    }
+
+    bool equals(const WrapC& other) const noexcept final
+    {
+        if (auto ptr = dynamic_cast<const realm_sync_socket*>(&other)) {
+            return get() == ptr->get();
+        }
+        return false;
+    }
+};
+
+struct realm_websocket_observer : realm::c_api::WrapC, std::shared_ptr<realm::sync::WebSocketObserver> {
+    explicit realm_websocket_observer(std::shared_ptr<realm::sync::WebSocketObserver> ptr)
+        : std::shared_ptr<realm::sync::WebSocketObserver>(std::move(ptr))
+    {
+    }
+
+    realm_websocket_observer* clone() const override
+    {
+        return new realm_websocket_observer{*this};
+    }
+
+    bool equals(const WrapC& other) const noexcept final
+    {
+        if (auto ptr = dynamic_cast<const realm_websocket_observer*>(&other)) {
+            return get() == ptr->get();
+        }
+        return false;
+    }
+};
+
+struct realm_sync_socket_callback : realm::c_api::WrapC,
+                                    std::shared_ptr<realm::sync::SyncSocketProvider::FunctionHandler> {
+    explicit realm_sync_socket_callback(std::shared_ptr<realm::sync::SyncSocketProvider::FunctionHandler> ptr)
+        : std::shared_ptr<realm::sync::SyncSocketProvider::FunctionHandler>(std::move(ptr))
+    {
+    }
+
+    realm_sync_socket_callback* clone() const override
+    {
+        return new realm_sync_socket_callback{*this};
+    }
+
+    bool equals(const WrapC& other) const noexcept final
+    {
+        if (auto ptr = dynamic_cast<const realm_sync_socket_callback*>(&other)) {
+            return get() == ptr->get();
+        }
+        return false;
+    }
+};
+
 #endif // REALM_ENABLE_SYNC
 
 #endif // REALM_OBJECT_STORE_C_API_TYPES_HPP


### PR DESCRIPTION
## What, How & Why?
Extend the C API so SDK's can provider their own platform specific implementation of websockets and event loop.

Fixes #5917.

## ☑️ ToDos
* [x] 📝 Changelog update
* [ ] ~~🚦 Tests (or not relevant)~~ To be added in #6169
* [x] C-API, if public C++ API changed.
