### PR TITLE
Fix version corruption during client reset with recovery with a single FLX subscription

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@
 * Core should not alter the order of the properties for additive schemas. ([#6134](https://github.com/realm/realm-core/issues/6134))
 * Core should not use the version passed in `Realm` constructor to load the schema at some particular version, but only for setting `m_frozen_version`.
 * Fixed possible segfault in sync client where async callback was using object after being deallocated ([#6053](https://github.com/realm/realm-core/issues/6053), since v11.7.0)
+* Fixed crash when using client reset with recovery and flexible sync with a single subscription ([#6070](https://github.com/realm/realm-core/issues/6070), since v12.3.0)
  
 ### Breaking changes
 * Core no longer provides any vcpkg infrastructure (the ports submodule and overlay triplets), because it handles dependant libraries internally now.

--- a/src/realm/sync/noinst/client_reset_recovery.cpp
+++ b/src/realm/sync/noinst/client_reset_recovery.cpp
@@ -423,6 +423,13 @@ void RecoverLocalChangesetsHandler::process_changesets(const std::vector<ClientH
 
         sync::Changeset parsed_changeset;
         sync::parse_changeset(*decompressed, parsed_changeset); // Throws
+#if REALM_DEBUG
+        if (m_logger.would_log(util::Logger::Level::trace)) {
+            std::stringstream dumped_changeset;
+            parsed_changeset.print(dumped_changeset);
+            m_logger.trace("Recovering changeset: %1", dumped_changeset.str());
+        }
+#endif
 
         InstructionApplier::begin_apply(parsed_changeset, &m_logger);
         for (auto instr : parsed_changeset) {

--- a/test/object-store/sync/flx_sync.cpp
+++ b/test/object-store/sync/flx_sync.cpp
@@ -411,8 +411,31 @@ TEST_CASE("flx: client reset", "[sync][flx][app][client reset]") {
         config_local.sync_config->notify_after_client_reset = reset_handler;
         auto test_reset = reset_utils::make_baas_flx_client_reset(config_local, config_remote, harness.session());
         test_reset
+            ->populate_initial_object([&](SharedRealm realm) {
+                auto pk_of_added_object = ObjectId::gen();
+                auto mut_subs = realm->get_latest_subscription_set().make_mutable_copy();
+                auto table = realm->read_group().get_table(ObjectStore::table_name_for_object_type("TopLevel"));
+                REALM_ASSERT(table);
+                mut_subs.insert_or_assign(Query(table));
+                mut_subs.commit();
+
+                realm->begin_transaction();
+                CppContext c(realm);
+                int64_t r1 = random_int();
+                int64_t r2 = random_int();
+                int64_t r3 = random_int();
+                int64_t sum = uint64_t(r1) + r2 + r3;
+
+                Object::create(c, realm, "TopLevel",
+                               std::any(AnyDict{{"_id"s, pk_of_added_object},
+                                                {"queryable_str_field"s, "initial value"s},
+                                                {"list_of_ints_field", std::vector<std::any>{r1, r2, r3}},
+                                                {"sum_of_list_field", sum}}));
+
+                realm->commit_transaction();
+                return pk_of_added_object;
+            })
             ->make_local_changes([&](SharedRealm local_realm) {
-                // add_subscription_for_new_object(local_realm, str_field_value, local_added_int);
                 add_object(local_realm, str_field_value, local_added_int);
             })
             ->make_remote_changes([&](SharedRealm remote_realm) {
@@ -424,15 +447,9 @@ TEST_CASE("flx: client reset", "[sync][flx][app][client reset]") {
                 REQUIRE(actual == sync::SubscriptionSet::State::Complete);
             })
             ->on_post_reset([&, client_reset_future = std::move(reset_future)](SharedRealm local_realm) {
+                wait_for_advance(*local_realm);
                 ClientResyncMode mode = client_reset_future.get();
                 REQUIRE(mode == ClientResyncMode::Recover);
-                auto subs = local_realm->get_latest_subscription_set();
-                subs.get_state_change_notification(sync::SubscriptionSet::State::Complete).get();
-                // make sure that the subscription for "foo" survived the reset
-                size_t count_of_foo = count_queries_with_str(subs, util::format("\"%1\"", str_field_value));
-                REQUIRE(subs.state() == sync::SubscriptionSet::State::Complete);
-                REQUIRE(count_of_foo == 1);
-                local_realm->refresh();
                 auto table = local_realm->read_group().get_table("class_TopLevel");
                 auto str_col = table->get_column_key("queryable_str_field");
                 auto int_col = table->get_column_key("queryable_int_field");

--- a/test/object-store/sync/sync_test_utils.hpp
+++ b/test/object-store/sync/sync_test_utils.hpp
@@ -148,9 +148,13 @@ Obj create_object(Realm& realm, StringData object_type, util::Optional<ObjectId>
 
 struct TestClientReset {
     using Callback = util::UniqueFunction<void(const SharedRealm&)>;
+    using InitialObjectCallback = util::UniqueFunction<ObjectId(const SharedRealm&)>;
     TestClientReset(const Realm::Config& local_config, const Realm::Config& remote_config);
     virtual ~TestClientReset();
     TestClientReset* setup(Callback&& on_setup);
+
+    // Only used in FLX sync client reset tests.
+    TestClientReset* populate_initial_object(InitialObjectCallback&& callback);
     TestClientReset* make_local_changes(Callback&& changes_local);
     TestClientReset* make_remote_changes(Callback&& changes_remote);
     TestClientReset* on_post_local_changes(Callback&& post_local);
@@ -166,6 +170,7 @@ protected:
     realm::Realm::Config m_remote_config;
 
     Callback m_on_setup;
+    InitialObjectCallback m_populate_initial_object;
     Callback m_make_local_changes;
     Callback m_make_remote_changes;
     Callback m_on_post_local;


### PR DESCRIPTION
## What, How & Why?
This fixes a crash if client reset with recovery is used when flexible sync is enabled and there is only one subscription set defined. For a write-up of how the crash occurs, see [#6070](https://github.com/realm/realm-core/issues/6070#issuecomment-1362218681).

## ☑️ ToDos
* [x] 📝 Changelog update
* [x] 🚦 Tests (or not relevant)
* [ ] C-API, if public C++ API changed.
