### PR TITLE
Integrate default socket provider as SyncSocketProvider in sync client

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,6 +39,7 @@
 * App services request ID now logged at info level when sync client connects ([#6143](https://github.com/realm/realm-core/pull/6143]))
 * Add c_api error category for resolve errors instead of reporting unknown category. ([PR #6157](https://github.com/realm/realm-core/pull/6157))
 * Add permanent redirect (308) as a supported redirect response from the server. ([#6162](https://github.com/realm/realm-core/issues/6162))
+* Integrate DefaultSocketProvider as SyncSocketProvider in sync client. ([]())
 
 ----------------------------------------------
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,7 +39,7 @@
 * App services request ID now logged at info level when sync client connects ([#6143](https://github.com/realm/realm-core/pull/6143]))
 * Add c_api error category for resolve errors instead of reporting unknown category. ([PR #6157](https://github.com/realm/realm-core/pull/6157))
 * Add permanent redirect (308) as a supported redirect response from the server. ([#6162](https://github.com/realm/realm-core/issues/6162))
-* Integrate DefaultSocketProvider as SyncSocketProvider in sync client. ([]())
+* Integrate DefaultSocketProvider as SyncSocketProvider in sync client. ([PR #6171](https://github.com/realm/realm-core/pull/6171))
 
 ----------------------------------------------
 

--- a/src/realm.h
+++ b/src/realm.h
@@ -3659,13 +3659,18 @@ RLM_API void realm_sync_config_set_session_stop_policy(realm_sync_config_t*,
 RLM_API void realm_sync_config_set_error_handler(realm_sync_config_t*, realm_sync_error_handler_func_t,
                                                  realm_userdata_t userdata,
                                                  realm_free_userdata_func_t userdata_free) RLM_API_NOEXCEPT;
+/// DEPRECATED - Will be removed in a future release
 RLM_API void realm_sync_config_set_client_validate_ssl(realm_sync_config_t*, bool) RLM_API_NOEXCEPT;
+/// DEPRECATED - Will be removed in a future release
 RLM_API void realm_sync_config_set_ssl_trust_certificate_path(realm_sync_config_t*, const char*) RLM_API_NOEXCEPT;
+/// DEPRECATED - Will be removed in a future release
 RLM_API void realm_sync_config_set_ssl_verify_callback(realm_sync_config_t*, realm_sync_ssl_verify_func_t,
                                                        realm_userdata_t userdata,
                                                        realm_free_userdata_func_t userdata_free) RLM_API_NOEXCEPT;
 RLM_API void realm_sync_config_set_cancel_waits_on_nonfatal_error(realm_sync_config_t*, bool) RLM_API_NOEXCEPT;
+/// DEPRECATED - Will be removed in a future release
 RLM_API void realm_sync_config_set_authorization_header_name(realm_sync_config_t*, const char*) RLM_API_NOEXCEPT;
+/// DEPRECATED - Will be removed in a future release
 RLM_API void realm_sync_config_set_custom_http_header(realm_sync_config_t*, const char* name,
                                                       const char* value) RLM_API_NOEXCEPT;
 RLM_API void realm_sync_config_set_recovery_directory_path(realm_sync_config_t*, const char*) RLM_API_NOEXCEPT;

--- a/src/realm/object-store/sync/impl/sync_client.hpp
+++ b/src/realm/object-store/sync/impl/sync_client.hpp
@@ -42,8 +42,10 @@ struct SyncClient {
         : m_client([&] {
             sync::Client::Config c;
             c.logger = logger;
+            c.socket_provider = config.socket_provider;
             c.reconnect_mode = config.reconnect_mode;
             c.one_connection_per_session = !config.multiplex_sessions;
+            /// DEPRECATED - Will be removed in a future release
             c.user_agent_application_info =
                 util::format("%1 %2", config.user_agent_binding_info, config.user_agent_application_info);
 

--- a/src/realm/object-store/sync/sync_manager.hpp
+++ b/src/realm/object-store/sync/sync_manager.hpp
@@ -83,7 +83,7 @@ struct SyncClientConfig {
 
     // The SyncSocket instance used by the Sync Client for event synchronization
     // and creating WebSockets. If not provided the default implementation will be used.
-    std::shared_ptr<sync::SyncSocketProvider> sync_socket;
+    std::shared_ptr<sync::SyncSocketProvider> socket_provider;
 
     // {@
     // Optional information about the binding/application that is sent as part of the User-Agent

--- a/src/realm/sync/client.cpp
+++ b/src/realm/sync/client.cpp
@@ -492,14 +492,14 @@ void ClientImpl::stop() noexcept
         return;
     m_stopped = true;
     m_wait_or_client_stopped_cond.notify_all();
-    m_service.stop();
+    m_socket_provider->stop();
 }
 
 
 void ClientImpl::run()
 {
     auto ta = util::make_temp_assign(m_running, true);
-    m_service.run(); // Throws
+    m_socket_provider->run();
 }
 
 
@@ -1660,16 +1660,16 @@ ClientImpl::Connection::Connection(ClientImpl& client, connection_ident_type ide
     , m_protocol_envelope{std::get<0>(endpoint)}
     , m_address{std::get<1>(endpoint)}
     , m_port{std::get<2>(endpoint)}
-    , m_verify_servers_ssl_certificate{verify_servers_ssl_certificate}
-    , m_ssl_trust_certificate_path{std::move(ssl_trust_certificate_path)}
-    , m_ssl_verify_callback{std::move(ssl_verify_callback)}
-    , m_proxy_config{std::move(proxy_config)}
+    , m_verify_servers_ssl_certificate{verify_servers_ssl_certificate}    // DEPRECATED
+    , m_ssl_trust_certificate_path{std::move(ssl_trust_certificate_path)} // DEPRECATED
+    , m_ssl_verify_callback{std::move(ssl_verify_callback)}               // DEPRECATED
+    , m_proxy_config{std::move(proxy_config)}                             // DEPRECATED
     , m_reconnect_info{reconnect_info}
     , m_sync_mode(sync_mode)
     , m_ident{ident}
     , m_server_endpoint{std::move(endpoint)}
-    , m_authorization_header_name{authorization_header_name}
-    , m_custom_http_headers{custom_http_headers}
+    , m_authorization_header_name{authorization_header_name} // DEPRECATED
+    , m_custom_http_headers{custom_http_headers}             // DEPRECATED
 {
     m_on_idle = m_client.create_trigger([this](Status status) {
         if (status == ErrorCodes::OperationAborted)

--- a/src/realm/sync/client.hpp
+++ b/src/realm/sync/client.hpp
@@ -208,12 +208,18 @@ public:
         /// change in the C++ mock server.
         std::string service_identifier = "";
 
+        ///
+        /// DEPRECATED - Will be removed in a future release
+        ///
         /// authorization_header_name is the name of the HTTP header containing
         /// the Realm access token. The value of the HTTP header is "Bearer <token>".
         /// authorization_header_name does not participate in session
         /// multiplexing partitioning.
         std::string authorization_header_name = "Authorization";
 
+        ///
+        /// DEPRECATED - Will be removed in a future release
+        ///
         /// custom_http_headers is a map of custom HTTP headers. The keys of the map
         /// are HTTP header names, and the values are the corresponding HTTP
         /// header values.
@@ -221,10 +227,16 @@ public:
         /// authorization_header_name must be set to anther value.
         std::map<std::string, std::string> custom_http_headers;
 
+        ///
+        /// DEPRECATED - Will be removed in a future release
+        ///
         /// Controls whether the server certificate is verified for SSL
         /// connections. It should generally be true in production.
         bool verify_servers_ssl_certificate = true;
 
+        ///
+        /// DEPRECATED - Will be removed in a future release
+        ///
         /// ssl_trust_certificate_path is the path of a trust/anchor
         /// certificate used by the client to verify the server certificate.
         /// ssl_trust_certificate_path is only used if the protocol is ssl and
@@ -242,6 +254,9 @@ public:
         /// store is used otherwise.
         util::Optional<std::string> ssl_trust_certificate_path;
 
+        ///
+        /// DEPRECATED - Will be removed in a future release
+        ///
         /// If Client::Config::ssl_verify_callback is set, that function is called
         /// to verify the certificate, unless verify_servers_ssl_certificate is
         /// false.
@@ -304,6 +319,9 @@ public:
         using ClientReset = sync::ClientReset;
         util::Optional<ClientReset> client_reset_config;
 
+        ///
+        /// DEPRECATED - Will be removed in a future release
+        ///
         util::Optional<SyncConfig::ProxyConfig> proxy_config;
 
         /// When integrating a flexible sync bootstrap, process this many bytes of

--- a/src/realm/sync/client_base.hpp
+++ b/src/realm/sync/client_base.hpp
@@ -4,6 +4,7 @@
 #include <realm/transaction.hpp>
 #include <realm/sync/config.hpp>
 #include <realm/sync/protocol.hpp>
+#include <realm/sync/socket_provider.hpp>
 #include <realm/util/functional.hpp>
 
 namespace realm::sync {
@@ -133,6 +134,9 @@ static constexpr milliseconds_type default_fast_reconnect_limit = 60000;    // 1
 using RoundtripTimeHandler = void(milliseconds_type roundtrip_time);
 
 struct ClientConfig {
+    ///
+    /// DEPRECATED - Will be removed in a future release
+    ///
     /// An optional custom platform description to be sent to server as part
     /// of a user agent description (HTTP `User-Agent` header).
     ///
@@ -140,6 +144,9 @@ struct ClientConfig {
     /// by util::get_platform_info().
     std::string user_agent_platform_info;
 
+    ///
+    /// DEPRECATED - Will be removed in a future release
+    ///
     /// Optional information about the application to be added to the user
     /// agent description as sent to the server. The intention is that the
     /// application describes itself using the following (rough) syntax:
@@ -174,6 +181,10 @@ struct ClientConfig {
     /// all logging happens either on behalf of the constructor or on behalf
     /// of the invocation of run().
     std::shared_ptr<util::Logger> logger;
+
+    // The SyncSocket instance used by the Sync Client for event synchronization
+    // and creating WebSockets. If not provided the default implementation will be used.
+    std::shared_ptr<sync::SyncSocketProvider> socket_provider;
 
     /// Use ports 80 and 443 by default instead of 7800 and 7801
     /// respectively. Ideally, these default ports should have been made

--- a/src/realm/sync/config.hpp
+++ b/src/realm/sync/config.hpp
@@ -177,6 +177,7 @@ struct SyncConfig {
     size_t flx_bootstrap_batch_size_bytes = 1024 * 1024;
 
     // {@
+    /// DEPRECATED - Will be removed in a future release
     // The following parameters are only used by the default SyncSocket implementation. Custom SyncSocket
     // implementations must handle these directly, if these features are supported.
     util::Optional<std::string> authorization_header_name; // not used

--- a/src/realm/sync/network/default_socket.hpp
+++ b/src/realm/sync/network/default_socket.hpp
@@ -17,69 +17,6 @@ class Service;
 namespace realm::sync::websocket {
 using port_type = sync::port_type;
 
-// TODO figure out what belongs on config and what belongs on endpoint.
-struct EZEndpoint {
-    std::string address;
-    port_type port;
-    std::string path;      // Includes auth token in query.
-    std::string protocols; // separated with ", "
-    bool is_ssl;
-
-    // The remaining fields are just passing through values from the SyncConfig. They can be ignored if SDK chooses
-    // not to support the related config options. This may be necessary when using websocket libraries without
-    // low-level control.
-    std::map<std::string, std::string> headers; // Only includes "custom" headers.
-    bool verify_servers_ssl_certificate;
-    util::Optional<std::string> ssl_trust_certificate_path;
-    std::function<SyncConfig::SSLVerifyCallback> ssl_verify_callback;
-    util::Optional<SyncConfig::ProxyConfig> proxy;
-};
-
-class EZObserver {
-public:
-    /// websocket_handshake_completion_handler() is called when the websocket is connected, .i.e.
-    /// after the handshake is done. It is not allowed to send messages on the socket before the
-    /// handshake is done. No message_received callbacks will be called before the handshake is done.
-    virtual void websocket_handshake_completion_handler(const std::string& protocol) = 0;
-
-    //@{
-    /// websocket_read_error_handler() and websocket_write_error_handler() are called when an
-    /// error occurs on the underlying stream given by the async_read and async_write functions above.
-    /// The error_code is passed through.
-    ///
-    /// websocket_handshake_error_handler() will be called when there is an error in the handshake
-    /// such as "404 Not found".
-    ///
-    /// websocket_protocol_error_handler() is called when there is an protocol error in the incoming
-    /// websocket messages.
-    ///
-    /// After calling any of these error callbacks, the Socket will move into the stopped state, and
-    /// no more messages should be sent, or will be received.
-    /// It is safe to destroy the WebSocket object in these handlers.
-    /// TODO there are too many error handlers. Try to get down to just one.
-    virtual void websocket_connect_error_handler(std::error_code) = 0;
-    virtual void websocket_ssl_handshake_error_handler(std::error_code) = 0;
-    virtual void websocket_read_or_write_error_handler(std::error_code) = 0;
-    virtual void websocket_handshake_error_handler(std::error_code, const std::string_view* body) = 0;
-    virtual void websocket_protocol_error_handler(std::error_code) = 0;
-    //@}
-
-    //@{
-    /// The five callback functions below are called whenever a full message has arrived.
-    /// The Socket defragments fragmented messages internally and delivers a full message.
-    /// \param data size The message is delivered in this buffer
-    /// The buffer is only valid until the function returns.
-    /// \return value designates whether the WebSocket object should continue
-    /// processing messages. The normal return value is true. False must be returned if the
-    /// websocket object is destroyed during execution of the function.
-    virtual bool websocket_binary_message_received(const char* data, size_t size) = 0;
-    virtual bool websocket_close_message_received(std::error_code error_code, StringData message) = 0;
-    //@}
-
-protected:
-    ~EZObserver() = default;
-};
-
 class DefaultSocketProvider : public SyncSocketProvider {
 public:
     class Timer : public SyncSocketProvider::Timer {
@@ -122,18 +59,17 @@ public:
     DefaultSocketProvider(DefaultSocketProvider&&) = delete;
 
     // Temporary workaround until event loop is completely moved here
-    network::Service& get_service()
+    void run() override
     {
-        return *m_service;
+        m_service->run();
     }
 
-    // Temporary workaround until Client::Connection is updated to use WebSocketObserver
-    std::unique_ptr<WebSocketInterface> connect_legacy(EZObserver* observer, EZEndpoint&& endpoint);
-
-    std::unique_ptr<WebSocketInterface> connect(WebSocketObserver*, WebSocketEndpoint&&) override
+    void stop() override
     {
-        return nullptr;
+        m_service->stop();
     }
+
+    std::unique_ptr<WebSocketInterface> connect(WebSocketObserver*, WebSocketEndpoint&&) override;
 
     void post(FunctionHandler&& handler) override
     {

--- a/src/realm/sync/socket_provider.hpp
+++ b/src/realm/sync/socket_provider.hpp
@@ -139,6 +139,11 @@ public:
     /// timer. The timer will also be canceled if the Timer object returned is
     /// destroyed.
     virtual SyncTimer create_timer(std::chrono::milliseconds delay, FunctionHandler&& handler) = 0;
+
+    /// Temporary functions added to support the default socket provider until
+    /// it is fully integrated. Will be removed in future PRs.
+    virtual void run() {}
+    virtual void stop() {}
 };
 
 /// Struct that defines the endpoint to create a new websocket connection.
@@ -152,6 +157,14 @@ struct WebSocketEndpoint {
     std::string path;                   // Includes access token in query.
     std::vector<std::string> protocols; // Array of one or more websocket protocols
     bool is_ssl;                        // true if SSL should be used
+
+    /// DEPRECATED - These will be removed in a future release
+    /// These fields are deprecated and should not be used by custom socket provider implementations
+    std::map<std::string, std::string> headers; // Only includes "custom" headers.
+    bool verify_servers_ssl_certificate;
+    util::Optional<std::string> ssl_trust_certificate_path;
+    std::function<SyncConfig::SSLVerifyCallback> ssl_verify_callback;
+    util::Optional<SyncConfig::ProxyConfig> proxy;
 };
 
 
@@ -235,6 +248,17 @@ struct WebSocketObserver {
     ///         is returned, the WebSocket object will be destroyed at some point
     ///         in the future.
     virtual bool websocket_closed_handler(bool was_clean, Status status) = 0;
+
+    //@{
+    /// DEPRECATED - Will be removed in a future release
+    /// These functions are deprecated and should not be called by custom socket provider implementations
+    virtual void websocket_connect_error_handler(std::error_code) = 0;
+    virtual void websocket_ssl_handshake_error_handler(std::error_code) = 0;
+    virtual void websocket_read_or_write_error_handler(std::error_code) = 0;
+    virtual void websocket_handshake_error_handler(std::error_code, const std::string_view* body) = 0;
+    virtual void websocket_protocol_error_handler(std::error_code) = 0;
+    virtual bool websocket_close_message_received(std::error_code error_code, StringData message) = 0;
+    //@}
 };
 
 } // namespace realm::sync


### PR DESCRIPTION
## What, How & Why?
Migrated ClientImpl to use a reference to a SyncSocketProvider (instead of DefaultSocketProvider) and integrated changes to match the base class interface. Some temporary additions were made to the base interface to support the DefaultSocketProvider until it is completely integrated with the new interface.

Marked items that will be removed as "deprecated" to start to get the word out that these items will be going away.

Fixes #6165 

## ☑️ ToDos
* [x] 📝 Changelog update
* ~~[ ] 🚦 Tests (or not relevant)~~
* ~~[ ] C-API, if public C++ API changed.~~
