### PR TITLE
Point fix for client reset DiscardLocalChanges crash

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,7 +17,7 @@
 * Core should not use the version passed in `Realm` constructor to load the schema at some particular version, but only for setting `m_frozen_version`.
 * Fixed possible segfault in sync client where async callback was using object after being deallocated ([#6053](https://github.com/realm/realm-core/issues/6053), since v11.7.0)
 * Fixed crash when using client reset with recovery and flexible sync with a single subscription ([#6070](https://github.com/realm/realm-core/issues/6070), since v12.3.0)
-* Fixed crash with wrong transaction state, when using client reset with discard local mode ([#6144](https://github.com/realm/realm-core/issues/6144), since v13.0.0)
+* Fixed crash with wrong transaction state, during realm migration if realm is frozen due to schema mismatch ([#6144](https://github.com/realm/realm-core/issues/6144), since v13.0.0)
  
 ### Breaking changes
 * Core no longer provides any vcpkg infrastructure (the ports submodule and overlay triplets), because it handles dependant libraries internally now.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@
 * Core should not use the version passed in `Realm` constructor to load the schema at some particular version, but only for setting `m_frozen_version`.
 * Fixed possible segfault in sync client where async callback was using object after being deallocated ([#6053](https://github.com/realm/realm-core/issues/6053), since v11.7.0)
 * Fixed crash when using client reset with recovery and flexible sync with a single subscription ([#6070](https://github.com/realm/realm-core/issues/6070), since v12.3.0)
+* Fixed crash with wrong transaction state, when using client reset with discard local mode ([#6144](https://github.com/realm/realm-core/issues/6144), since v13.0.0)
  
 ### Breaking changes
 * Core no longer provides any vcpkg infrastructure (the ports submodule and overlay triplets), because it handles dependant libraries internally now.

--- a/src/realm/object-store/shared_realm.cpp
+++ b/src/realm/object-store/shared_realm.cpp
@@ -1314,9 +1314,9 @@ SharedRealm Realm::freeze()
     auto config = m_config;
     auto version = read_transaction_version();
     config.scheduler = util::Scheduler::make_frozen(version);
-    config.schema = m_schema;
-    config.schema_version = m_schema_version;
-    return Realm::get_frozen_realm(std::move(config), version);
+    auto frozen_realm = Realm::get_frozen_realm(std::move(config), version);
+    frozen_realm->set_schema(frozen_realm->m_schema, m_schema);
+    return frozen_realm;
 }
 
 void Realm::close()


### PR DESCRIPTION
## What, How & Why?
Point Fix for client reset crashed with `DiscardLocalChanges` set. 
Fixes: https://github.com/realm/realm-core/issues/6144

## ☑️ ToDos
* [ ] 📝 Changelog update
* [ ] 🚦 Tests (or not relevant)
* [ ] C-API, if public C++ API changed.
