### PR TITLE
Refactoring around encryption

### DIFF
--- a/src/realm/alloc.hpp
+++ b/src/realm/alloc.hpp
@@ -576,7 +576,7 @@ inline char* Allocator::translate_critical(RefTranslation* ref_translation_ptr, 
             return translate_less_critical(ref_translation_ptr, ref);
         }
     }
-    realm::util::terminate("Invalid ref translation entry", __FILE__, __LINE__, txl.cookie, 0x1234567890);
+    realm::util::terminate("Invalid ref translation entry", __FILE__, __LINE__, txl.cookie, 0x1234567890, ref, idx);
     return nullptr;
 }
 

--- a/src/realm/alloc_slab.cpp
+++ b/src/realm/alloc_slab.cpp
@@ -41,6 +41,7 @@
 #include <realm/util/scope_exit.hpp>
 #include <realm/array.hpp>
 #include <realm/alloc_slab.hpp>
+#include <realm/group.hpp>
 
 using namespace realm;
 using namespace realm::util;
@@ -796,8 +797,7 @@ ref_type SlabAlloc::attach_file(const std::string& file_path, Config& cfg)
 
         if (top_ref) {
             // Get the expected file size by looking up logical file size stored in top array
-            constexpr size_t file_size_ndx = 2; // This MUST match definition of s_file_size_ndx in Group
-            constexpr size_t max_top_size = (file_size_ndx + 1) * 8 + sizeof(Header);
+            constexpr size_t max_top_size = (Group::s_file_size_ndx + 1) * 8 + sizeof(Header);
             size_t top_page_base = top_ref & ~(page_size() - 1);
             size_t top_offset = top_ref - top_page_base;
             size_t map_size = std::min(max_top_size + top_offset, size - top_page_base);
@@ -806,13 +806,13 @@ ref_type SlabAlloc::attach_file(const std::string& file_path, Config& cfg)
             auto top_header = map_top.get_addr() + top_offset;
             auto top_data = NodeHeader::get_data_from_header(top_header);
             auto w = NodeHeader::get_width_from_header(top_header);
-            auto logical_size = size_t(get_direct(top_data, w, file_size_ndx)) >> 1;
+            auto logical_size = size_t(get_direct(top_data, w, Group::s_file_size_ndx)) >> 1;
             expected_size = round_up_to_page_size(logical_size);
         }
     }
-    catch (const DecryptionFailed&) {
+    catch (const DecryptionFailed& e) {
         note_reader_end(this);
-        throw InvalidDatabase("Realm file decryption failed", path);
+        throw InvalidDatabase(util::format("Realm file decryption failed (%1)", e.message()), path);
     }
     catch (const std::exception& e) {
         note_reader_end(this);

--- a/src/realm/array.hpp
+++ b/src/realm/array.hpp
@@ -711,7 +711,7 @@ int64_t Array::get(size_t ndx) const noexcept
 inline int64_t Array::get(size_t ndx) const noexcept
 {
     REALM_ASSERT_DEBUG(is_attached());
-    REALM_ASSERT_DEBUG(ndx < m_size);
+    REALM_ASSERT_DEBUG_EX(ndx < m_size, ndx, m_size);
     return (this->*m_getter)(ndx);
 
     // Two ideas that are not efficient but may be worth looking into again:
@@ -744,7 +744,7 @@ inline int64_t Array::back() const noexcept
 inline ref_type Array::get_as_ref(size_t ndx) const noexcept
 {
     REALM_ASSERT_DEBUG(is_attached());
-    REALM_ASSERT_DEBUG(m_has_refs);
+    REALM_ASSERT_DEBUG_EX(m_has_refs, m_ref, ndx, m_size);
     int64_t v = get(ndx);
     return to_ref(v);
 }

--- a/src/realm/group.cpp
+++ b/src/realm/group.cpp
@@ -211,7 +211,7 @@ void Group::set_size() const noexcept
     int retval = 0;
     if (is_attached() && m_table_names.is_attached()) {
         size_t max_index = m_tables.size();
-        REALM_ASSERT(max_index < (1 << 16));
+        REALM_ASSERT_EX(max_index < (1 << 16), max_index);
         for (size_t j = 0; j < max_index; ++j) {
             RefOrTagged rot = m_tables.get_as_ref_or_tagged(j);
             if (rot.is_ref() && rot.get_as_ref()) {

--- a/src/realm/group.hpp
+++ b/src/realm/group.hpp
@@ -843,6 +843,7 @@ private:
     friend class Transaction;
     friend class TableKeyIterator;
     friend class CascadeState;
+    friend class SlabAlloc;
 };
 
 class TableKeyIterator {

--- a/src/realm/history.cpp
+++ b/src/realm/history.cpp
@@ -137,13 +137,14 @@ InRealmHistory::version_type InRealmHistory::add_changeset(BinaryData changeset)
 void InRealmHistory::get_changesets(version_type begin_version, version_type end_version,
                                     BinaryIterator* buffer) const noexcept
 {
-    REALM_ASSERT(begin_version <= end_version);
-    REALM_ASSERT(begin_version >= m_base_version);
-    REALM_ASSERT(end_version <= m_base_version + m_size);
+    REALM_ASSERT_EX(begin_version <= end_version, begin_version, end_version, m_base_version);
+    REALM_ASSERT_EX(begin_version >= m_base_version, begin_version, end_version, m_base_version);
+    REALM_ASSERT_EX(end_version <= m_base_version + m_size, end_version, m_base_version, m_size);
     version_type n_version_type = end_version - begin_version;
     version_type offset_version_type = begin_version - m_base_version;
-    REALM_ASSERT(!util::int_cast_has_overflow<size_t>(n_version_type) &&
-                 !util::int_cast_has_overflow<size_t>(offset_version_type));
+    REALM_ASSERT_EX(!util::int_cast_has_overflow<size_t>(n_version_type) &&
+                        !util::int_cast_has_overflow<size_t>(offset_version_type),
+                    begin_version, end_version, m_base_version);
     size_t n = size_t(n_version_type);
     size_t offset = size_t(offset_version_type);
     for (size_t i = 0; i < n; ++i)
@@ -160,7 +161,7 @@ void InRealmHistory::set_oldest_bound_version(version_type version)
         // The new changeset is always added before set_oldest_bound_version()
         // is called. Therefore, the trimming operation can never leave the
         // history empty.
-        REALM_ASSERT(num_entries_to_erase < m_size);
+        REALM_ASSERT_EX(num_entries_to_erase < m_size, num_entries_to_erase, m_size);
         for (size_t i = 0; i < num_entries_to_erase; ++i)
             m_changesets->erase(0); // Throws
         m_base_version += num_entries_to_erase;

--- a/src/realm/util/encrypted_file_mapping.cpp
+++ b/src/realm/util/encrypted_file_mapping.cpp
@@ -820,7 +820,8 @@ void EncryptedFileMapping::write_barrier(const void* addr, size_t size) noexcept
 
     // propagate changes to first page (update may be partial, may also be to last page)
     if (first_accessed_local_page < pages_size) {
-        REALM_ASSERT(is(m_page_state[first_accessed_local_page], UpToDate));
+        REALM_ASSERT_EX(is(m_page_state[first_accessed_local_page], UpToDate),
+                        m_page_state[first_accessed_local_page]);
         if (first_accessed_local_page == last_accessed_local_page) {
             size_t last_offset = last_accessed_address - page_addr(first_accessed_local_page);
             write_and_update_all(first_accessed_local_page, first_offset, last_offset + 1);

--- a/src/realm/util/file.cpp
+++ b/src/realm/util/file.cpp
@@ -1278,7 +1278,7 @@ void File::unlock() noexcept
 
 void* File::map(AccessMode a, size_t size, int /*map_flags*/, size_t offset) const
 {
-    return realm::util::mmap(m_fd, size, a, offset, m_encryption_key.get());
+    return realm::util::mmap({m_fd, m_path, a, m_encryption_key.get()}, size, offset);
 }
 
 void* File::map_fixed(AccessMode a, void* address, size_t size, int /* map_flags */, size_t offset) const
@@ -1307,7 +1307,7 @@ void* File::map_reserve(AccessMode a, size_t size, size_t offset) const
 #if REALM_ENABLE_ENCRYPTION
 void* File::map(AccessMode a, size_t size, EncryptedFileMapping*& mapping, int /*map_flags*/, size_t offset) const
 {
-    return realm::util::mmap(m_fd, size, a, offset, m_encryption_key.get(), mapping);
+    return realm::util::mmap({m_fd, m_path, a, m_encryption_key.get()}, size, offset, mapping);
 }
 
 void* File::map_fixed(AccessMode a, void* address, size_t size, EncryptedFileMapping* mapping, int /* map_flags */,
@@ -1331,11 +1331,11 @@ void* File::map_reserve(AccessMode a, size_t size, size_t offset, EncryptedFileM
 {
     if (m_encryption_key.get()) {
         // encrypted file - just mmap it, the encryption layer handles if the mapping extends beyond eof
-        return realm::util::mmap(m_fd, size, a, offset, m_encryption_key.get(), mapping);
+        return realm::util::mmap({m_fd, m_path, a, m_encryption_key.get()}, size, offset, mapping);
     }
 #ifndef _WIN32
     // not encrypted, do a proper reservation on Unixes'
-    return realm::util::mmap_reserve(m_fd, size, a, offset, nullptr, mapping);
+    return realm::util::mmap_reserve({m_fd, m_path, a, nullptr}, size, offset, mapping);
 #else
     // on windows, this is a no-op
     return nullptr;
@@ -1353,7 +1353,7 @@ void File::unmap(void* addr, size_t size) noexcept
 void* File::remap(void* old_addr, size_t old_size, AccessMode a, size_t new_size, int /*map_flags*/,
                   size_t file_offset) const
 {
-    return realm::util::mremap(m_fd, file_offset, old_addr, old_size, a, new_size, m_encryption_key.get());
+    return realm::util::mremap({m_fd, m_path, a, m_encryption_key.get()}, file_offset, old_addr, old_size, new_size);
 }
 
 
@@ -1755,7 +1755,8 @@ bool File::MapBase::try_reserve(const File& file, AccessMode a, size_t size, siz
     m_offset = offset;
 #if REALM_ENABLE_ENCRYPTION
     if (file.m_encryption_key) {
-        m_encrypted_mapping = util::reserve_mapping(addr, m_fd, offset, a, file.m_encryption_key.get());
+        m_encrypted_mapping =
+            util::reserve_mapping(addr, {m_fd, file.get_path(), a, file.m_encryption_key.get()}, offset);
     }
 #endif
 #endif

--- a/src/realm/util/file_mapper.cpp
+++ b/src/realm/util/file_mapper.cpp
@@ -103,7 +103,7 @@ struct mappings_for_file {
 
 // Group the information we need to map a SIGSEGV address to an
 // EncryptedFileMapping for the sake of cache-friendliness with 3+ active
-// mappings (and no worse with only two
+// mappings (and no worse with only two)
 struct mapping_and_addr {
     std::shared_ptr<EncryptedFileMapping> mapping;
     void* addr;

--- a/src/realm/util/file_mapper.cpp
+++ b/src/realm/util/file_mapper.cpp
@@ -499,19 +499,18 @@ SharedFileInfo* get_file_info_for_file(File& file)
 
 
 namespace {
-EncryptedFileMapping* add_mapping(void* addr, size_t size, FileDesc fd, size_t file_offset, File::AccessMode access,
-                                  const char* encryption_key)
+EncryptedFileMapping* add_mapping(void* addr, size_t size, const FileAttributes& file, size_t file_offset)
 {
 #ifndef _WIN32
     struct stat st;
 
-    if (fstat(fd, &st)) {
+    if (fstat(file.fd, &st)) {
         int err = errno; // Eliminate any risk of clobbering
         throw std::system_error(err, std::system_category(), "fstat() failed");
     }
 #endif
 
-    size_t fs = to_size_t(File::get_size_static(fd));
+    size_t fs = to_size_t(File::get_size_static(file.fd));
     if (fs > 0 && fs < page_size())
         throw DecryptionFailed();
 
@@ -520,7 +519,7 @@ EncryptedFileMapping* add_mapping(void* addr, size_t size, FileDesc fd, size_t f
     std::vector<mappings_for_file>::iterator it;
     for (it = mappings_by_file.begin(); it != mappings_by_file.end(); ++it) {
 #ifdef _WIN32
-        if (File::is_same_file_static(it->handle, fd))
+        if (File::is_same_file_static(it->handle, file.fd))
             break;
 #else
         if (it->inode == st.st_ino && it->device == st.st_dev)
@@ -534,22 +533,22 @@ EncryptedFileMapping* add_mapping(void* addr, size_t size, FileDesc fd, size_t f
     if (it == mappings_by_file.end()) {
         mappings_by_file.reserve(mappings_by_file.size() + 1);
         mappings_for_file f;
-        f.info = std::make_shared<SharedFileInfo>(reinterpret_cast<const uint8_t*>(encryption_key));
+        f.info = std::make_shared<SharedFileInfo>(reinterpret_cast<const uint8_t*>(file.encryption_key));
 
+        FileDesc fd_duped;
 #ifdef _WIN32
-        FileDesc fd2;
-        if (!DuplicateHandle(GetCurrentProcess(), fd, GetCurrentProcess(), &fd2, 0, FALSE, DUPLICATE_SAME_ACCESS))
+        if (!DuplicateHandle(GetCurrentProcess(), file.fd, GetCurrentProcess(), &fd_duped, 0, FALSE,
+                             DUPLICATE_SAME_ACCESS))
             throw std::system_error(GetLastError(), std::system_category(), "DuplicateHandle() failed");
-        fd = fd2;
-        f.info->fd = f.handle = fd;
+        f.info->fd = f.handle = fd_duped;
 #else
-        fd = dup(fd);
+        fd_duped = dup(file.fd);
 
-        if (fd == -1) {
+        if (fd_duped == -1) {
             int err = errno; // Eliminate any risk of clobbering
             throw std::system_error(err, std::system_category(), "dup() failed");
         }
-        f.info->fd = fd;
+        f.info->fd = fd_duped;
         f.device = st.st_dev;
         f.inode = st.st_ino;
 #endif
@@ -558,14 +557,14 @@ EncryptedFileMapping* add_mapping(void* addr, size_t size, FileDesc fd, size_t f
         it = mappings_by_file.end() - 1;
     }
     else {
-        it->info->cryptor.check_key(reinterpret_cast<const uint8_t*>(encryption_key));
+        it->info->cryptor.check_key(reinterpret_cast<const uint8_t*>(file.encryption_key));
     }
 
     try {
         mapping_and_addr m;
         m.addr = addr;
         m.size = size;
-        m.mapping = std::make_shared<EncryptedFileMapping>(*it->info, file_offset, addr, size, access);
+        m.mapping = std::make_shared<EncryptedFileMapping>(*it->info, file_offset, addr, size, file.access);
         mappings_by_addr.push_back(m); // can't throw due to reserve() above
         return m.mapping.get();
     }
@@ -612,27 +611,25 @@ void remove_mapping(void* addr, size_t size)
 }
 } // anonymous namespace
 
-void* mmap(FileDesc fd, size_t size, File::AccessMode access, size_t offset, const char* encryption_key,
-           EncryptedFileMapping*& mapping)
+void* mmap(const FileAttributes& file, size_t size, size_t offset, EncryptedFileMapping*& mapping)
 {
     _impl::SimulatedFailure::trigger_mmap(size);
-    if (encryption_key) {
+    if (file.encryption_key) {
         size = round_up_to_page_size(size);
         void* addr = mmap_anon(size);
-        mapping = add_mapping(addr, size, fd, offset, access, encryption_key);
+        mapping = add_mapping(addr, size, file, offset);
         return addr;
     }
     else {
         mapping = nullptr;
-        return mmap(fd, size, access, offset, nullptr);
+        return mmap(file, size, offset);
     }
 }
 
 
-EncryptedFileMapping* reserve_mapping(void* addr, FileDesc fd, size_t offset, File::AccessMode access,
-                                      const char* encryption_key)
+EncryptedFileMapping* reserve_mapping(void* addr, const FileAttributes& file, size_t offset)
 {
-    return add_mapping(addr, 0, fd, offset, access, encryption_key);
+    return add_mapping(addr, 0, file, offset);
 }
 
 void extend_encrypted_mapping(EncryptedFileMapping* mapping, void* addr, size_t offset, size_t old_size,
@@ -650,15 +647,15 @@ void remove_encrypted_mapping(void* addr, size_t size)
     remove_mapping(addr, size);
 }
 
-void* mmap_reserve(FileDesc fd, size_t reservation_size, File::AccessMode access, size_t offset_in_file,
-                   const char* enc_key, EncryptedFileMapping*& mapping)
+void* mmap_reserve(const FileAttributes& file, size_t reservation_size, size_t offset_in_file,
+                   EncryptedFileMapping*& mapping)
 {
-    auto addr = mmap_reserve(fd, reservation_size, offset_in_file);
-    if (enc_key) {
+    auto addr = mmap_reserve(file.fd, reservation_size, offset_in_file);
+    if (file.encryption_key) {
         REALM_ASSERT(reservation_size == round_up_to_page_size(reservation_size));
         // we create a mapping for the entire reserved area. This causes full initialization of some fairly
         // large std::vectors, which it would be nice to avoid. This is left as a future optimization.
-        mapping = add_mapping(addr, reservation_size, fd, offset_in_file, access, enc_key);
+        mapping = add_mapping(addr, reservation_size, file, offset_in_file);
     }
     else {
         mapping = nullptr;
@@ -784,25 +781,25 @@ void* mmap_reserve(FileDesc fd, size_t reservation_size, size_t offset_in_file)
 }
 
 
-void* mmap(FileDesc fd, size_t size, File::AccessMode access, size_t offset, const char* encryption_key)
+void* mmap(const FileAttributes& file, size_t size, size_t offset)
 {
     _impl::SimulatedFailure::trigger_mmap(size);
 #if REALM_ENABLE_ENCRYPTION
-    if (encryption_key) {
+    if (file.encryption_key) {
         size = round_up_to_page_size(size);
         void* addr = mmap_anon(size);
-        add_mapping(addr, size, fd, offset, access, encryption_key);
+        add_mapping(addr, size, file, offset);
         return addr;
     }
     else
 #else
-    REALM_ASSERT(!encryption_key);
+    REALM_ASSERT(!file.encryption_key);
 #endif
     {
 
 #ifndef _WIN32
         int prot = PROT_READ;
-        switch (access) {
+        switch (file.access) {
             case File::access_ReadWrite:
                 prot |= PROT_WRITE;
                 break;
@@ -810,7 +807,7 @@ void* mmap(FileDesc fd, size_t size, File::AccessMode access, size_t offset, con
                 break;
         }
 
-        void* addr = ::mmap(nullptr, size, prot, MAP_SHARED, fd, offset);
+        void* addr = ::mmap(nullptr, size, prot, MAP_SHARED, file.fd, offset);
         if (addr != MAP_FAILED)
             return addr;
 
@@ -829,7 +826,7 @@ void* mmap(FileDesc fd, size_t size, File::AccessMode access, size_t offset, con
 
         DWORD protect = PAGE_READONLY;
         DWORD desired_access = FILE_MAP_READ;
-        switch (access) {
+        switch (file.access) {
             case File::access_ReadOnly:
                 break;
             case File::access_ReadWrite:
@@ -840,7 +837,7 @@ void* mmap(FileDesc fd, size_t size, File::AccessMode access, size_t offset, con
         LARGE_INTEGER large_int;
         if (int_cast_with_overflow_detect(offset + size, large_int.QuadPart))
             throw std::runtime_error("Map size is too large");
-        HANDLE map_handle = CreateFileMappingFromApp(fd, 0, protect, offset + size, nullptr);
+        HANDLE map_handle = CreateFileMappingFromApp(file.fd, 0, protect, offset + size, nullptr);
         if (!map_handle)
             throw AddressSpaceExhausted(get_errno_msg("CreateFileMapping() failed: ", GetLastError()) +
                                         " size: " + util::to_string(size) + " offset: " + util::to_string(offset));
@@ -879,11 +876,10 @@ void munmap(void* addr, size_t size)
 #endif
 }
 
-void* mremap(FileDesc fd, size_t file_offset, void* old_addr, size_t old_size, File::AccessMode a, size_t new_size,
-             const char* encryption_key)
+void* mremap(const FileAttributes& file, size_t file_offset, void* old_addr, size_t old_size, size_t new_size)
 {
 #if REALM_ENABLE_ENCRYPTION
-    if (encryption_key) {
+    if (file.encryption_key) {
         LockGuard lock(mapping_mutex);
         size_t rounded_old_size = round_up_to_page_size(old_size);
         if (mapping_and_addr* m = find_mapping_for_addr(old_addr, rounded_old_size)) {
@@ -912,8 +908,6 @@ void* mremap(FileDesc fd, size_t file_offset, void* old_addr, size_t old_size, F
         // the encryption key which is an error.
         REALM_UNREACHABLE();
     }
-#else
-    static_cast<void>(encryption_key);
 #endif
 
 #ifdef _GNU_SOURCE
@@ -937,7 +931,7 @@ void* mremap(FileDesc fd, size_t file_offset, void* old_addr, size_t old_size, F
     }
 #endif
 
-    void* new_addr = mmap(fd, new_size, a, file_offset, nullptr);
+    void* new_addr = mmap(file, new_size, file_offset);
 
 #ifdef _WIN32
     if (!UnmapViewOfFile(old_addr))

--- a/src/realm/util/file_mapper.hpp
+++ b/src/realm/util/file_mapper.hpp
@@ -28,13 +28,19 @@
 namespace realm {
 namespace util {
 
-void* mmap(FileDesc fd, size_t size, File::AccessMode access, size_t offset, const char* encryption_key);
+struct FileAttributes {
+    FileDesc fd;
+    std::string path;
+    File::AccessMode access;
+    const char* encryption_key = nullptr;
+};
+
+void* mmap(const FileAttributes& file, size_t size, size_t offset);
 void* mmap_fixed(FileDesc fd, void* address_request, size_t size, File::AccessMode access, size_t offset,
                  const char* enc_key);
 void* mmap_reserve(FileDesc fd, size_t size, size_t offset);
 void munmap(void* addr, size_t size);
-void* mremap(FileDesc fd, size_t file_offset, void* old_addr, size_t old_size, File::AccessMode a, size_t new_size,
-             const char* encryption_key);
+void* mremap(const FileAttributes& file, size_t file_offset, void* old_addr, size_t old_size, size_t new_size);
 void msync(FileDesc fd, void* addr, size_t size);
 void* mmap_anon(size_t size);
 
@@ -92,16 +98,13 @@ SharedFileInfo* get_file_info_for_file(File& file);
 
 // This variant allows the caller to obtain direct access to the encrypted file mapping
 // for optimization purposes.
-void* mmap(FileDesc fd, size_t size, File::AccessMode access, size_t offset, const char* encryption_key,
-           EncryptedFileMapping*& mapping);
+void* mmap(const FileAttributes& file, size_t size, size_t offset, EncryptedFileMapping*& mapping);
 void* mmap_fixed(FileDesc fd, void* address_request, size_t size, File::AccessMode access, size_t offset,
                  const char* enc_key, EncryptedFileMapping* mapping);
 
-void* mmap_reserve(FileDesc fd, size_t size, File::AccessMode am, size_t offset, const char* enc_key,
-                   EncryptedFileMapping*& mapping);
+void* mmap_reserve(const FileAttributes& file, size_t size, size_t offset, EncryptedFileMapping*& mapping);
 
-EncryptedFileMapping* reserve_mapping(void* addr, FileDesc fd, size_t offset, File::AccessMode access,
-                                      const char* encryption_key);
+EncryptedFileMapping* reserve_mapping(void* addr, const FileAttributes& file, size_t offset);
 
 void extend_encrypted_mapping(EncryptedFileMapping* mapping, void* addr, size_t offset, size_t old_size,
                               size_t new_size);


### PR DESCRIPTION
I'm extracting several changes from the multiprocess encryption branch to declutter it a little bit.
This includes strengthening the debug assertions with more information, and a refactoring around memory mapping files.
No functional changes, so no changelog or tests.