### PR TITLE
Reset client reset cycle detection after upload/download complete

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 * <How do the end-user experience this issue? what was the impact?> ([#????](https://github.com/realm/realm-core/issues/????), since v?.?.?)
 * "find first" on Decimal128 field with value NaN does not find objects ([6182](https://github.com/realm/realm-core/issues/6182), since v6.0.0)
 * Value in List of Mixed would not be updated if new value is Binary and old value is StringData and the values otherwise matches ([#6201](https://github.com/realm/realm-core/issues/6201), since v6.0.0)
+* When client reset with recovery is used and the recovery does not actually result in any new local commits, the sync client may have gotten stuck in a cycle with a `A fatal error occured during client reset: 'A previous 'Recovery' mode reset from <timestamp> did not succeed, giving up on 'Recovery' mode to prevent a cycle'` error message. ([#6195](https://github.com/realm/realm-core/issues/6195), since v11.16.0)
 
 ### Breaking changes
 * `SyncSession::log_out()` has been renamed to `SyncSession::force_close()` to reflect what it actually does ([#6183](https://github.com/realm/realm-core/pull/6183))

--- a/src/realm/sync/client.cpp
+++ b/src/realm/sync/client.cpp
@@ -1683,11 +1683,12 @@ void SessionWrapper::handle_pending_client_reset_acknowledgement()
             logger.debug(
                 "Was going to remove client reset tracker for type \"%1\" from %2, but found type \"%3\" from %4.",
                 pending_reset.type, pending_reset.time, cur_pending_reset->type, cur_pending_reset->time);
-            return;
         }
-        logger.debug("Client reset of type \"%1\" from %2 has been acknowledged by the server. "
-                     "Removing cycle detection tracker.",
-                     pending_reset.type, pending_reset.time);
+        else {
+            logger.debug("Client reset of type \"%1\" from %2 has been acknowledged by the server. "
+                         "Removing cycle detection tracker.",
+                         pending_reset.type, pending_reset.time);
+        }
         _impl::client_reset::remove_pending_client_resets(wt);
         wt->commit();
     });

--- a/src/realm/sync/client.cpp
+++ b/src/realm/sync/client.cpp
@@ -1662,7 +1662,7 @@ void SessionWrapper::handle_pending_client_reset_acknowledgement()
     m_sess->logger.info("Tracking pending client reset of type \"%1\" from %2", pending_reset->type,
                         pending_reset->time);
     util::bind_ptr<SessionWrapper> self(this);
-    async_wait_for(true, true, [self = std::move(self), pending_reset = pending_reset.value()](std::error_code ec) {
+    async_wait_for(true, true, [self = std::move(self), pending_reset = *pending_reset](std::error_code ec) {
         if (ec == util::error::operation_aborted) {
             return;
         }

--- a/src/realm/sync/client.cpp
+++ b/src/realm/sync/client.cpp
@@ -8,6 +8,7 @@
 #include "realm/util/optional.hpp"
 #include <realm/sync/client.hpp>
 #include <realm/sync/config.hpp>
+#include <realm/sync/noinst/client_reset.hpp>
 #include <realm/sync/noinst/client_history_impl.hpp>
 #include <realm/sync/noinst/client_impl_base.hpp>
 #include <realm/sync/noinst/pending_bootstrap_store.hpp>
@@ -213,6 +214,8 @@ public:
     void on_new_flx_subscription_set(int64_t new_version);
 
     util::Future<std::string> send_test_command(std::string body);
+
+    void handle_pending_client_reset_acknowledgement();
 
 private:
     ClientImpl& m_client;
@@ -729,6 +732,11 @@ void SessionImpl::on_suspended(const SessionErrorInfo& error_info)
 void SessionImpl::on_resumed()
 {
     m_wrapper.on_resumed(); // Throws
+}
+
+void SessionImpl::handle_pending_client_reset_acknowledgement()
+{
+    m_wrapper.handle_pending_client_reset_acknowledgement();
 }
 
 
@@ -1642,6 +1650,35 @@ util::Future<std::string> SessionWrapper::send_test_command(std::string body)
     }
 
     return m_sess->send_test_command(std::move(body));
+}
+
+void SessionWrapper::handle_pending_client_reset_acknowledgement()
+{
+    auto pending_reset = [&] {
+        auto ft = m_db->start_frozen();
+        return _impl::client_reset::has_pending_reset(ft);
+    }();
+    REALM_ASSERT(pending_reset);
+    m_sess->logger.info("Tracking pending client reset of type \"%1\" from %2", pending_reset->type,
+                        pending_reset->time);
+    util::bind_ptr<SessionWrapper> self(this);
+    async_wait_for(true, true, [self = std::move(self), pending_reset = pending_reset.value()](std::error_code ec) {
+        if (ec == util::error::operation_aborted) {
+            return;
+        }
+        auto& logger = self->m_sess->logger;
+        if (ec) {
+            logger.error("Error while tracking client reset acknowledgement: %1", ec.message());
+            return;
+        }
+
+        logger.debug("Client reset of type \"%1\" from %2 has been acknowledged by the server. "
+                     "Removing cycle detection tracker.",
+                     pending_reset.type, pending_reset.time);
+        auto wt = self->m_db->start_write();
+        _impl::client_reset::remove_pending_client_resets(wt);
+        wt->commit();
+    });
 }
 
 // ################ ClientImpl::Connection ################

--- a/src/realm/sync/client.cpp
+++ b/src/realm/sync/client.cpp
@@ -1676,7 +1676,8 @@ void SessionWrapper::handle_pending_client_reset_acknowledgement()
         auto cur_pending_reset = _impl::client_reset::has_pending_reset(wt);
         if (!cur_pending_reset) {
             logger.debug(
-                "Was going to remove client reset tracker for type \"%1\" from %2, but it was already removed");
+                "Was going to remove client reset tracker for type \"%1\" from %2, but it was already removed",
+                pending_reset.type, pending_reset.time);
             return;
         }
         else if (cur_pending_reset->type != pending_reset.type || cur_pending_reset->time != pending_reset.time) {

--- a/src/realm/sync/noinst/client_history_impl.cpp
+++ b/src/realm/sync/noinst/client_history_impl.cpp
@@ -229,7 +229,7 @@ util::UniqueFunction<SyncReplication::WriteValidator> ClientReplication::make_wr
 }
 
 void ClientHistory::get_status(version_type& current_client_version, SaltedFileIdent& client_file_ident,
-                               SyncProgress& progress) const
+                               SyncProgress& progress, bool* has_pending_client_reset) const
 {
     TransactionRef rt = m_db->start_read(); // Throws
     version_type current_client_version_2 = rt->get_version();
@@ -262,6 +262,10 @@ void ClientHistory::get_status(version_type& current_client_version, SaltedFileI
     REALM_ASSERT(current_client_version >= s_initial_version + 0);
     if (current_client_version == s_initial_version + 0)
         current_client_version = 0;
+
+    if (has_pending_client_reset) {
+        *has_pending_client_reset = _impl::client_reset::has_pending_reset(rt).has_value();
+    }
 }
 
 
@@ -763,7 +767,7 @@ void ClientHistory::add_sync_history_entry(const HistoryEntry& entry)
 
 
 void ClientHistory::update_sync_progress(const SyncProgress& progress, const std::uint_fast64_t* downloadable_bytes,
-                                         TransactionRef wt)
+                                         TransactionRef)
 {
     Array& root = m_arrays->root;
 
@@ -812,16 +816,7 @@ void ClientHistory::update_sync_progress(const SyncProgress& progress, const std
         root.set(s_progress_upload_server_version_iip,
                  RefOrTagged::make_tagged(progress.upload.last_integrated_server_version)); // Throws
     }
-    if (previous_upload_client_version < progress.upload.client_version) {
-        // This is part of the client reset cycle detection.
-        // A client reset operation will write a flag to an internal table indicating that
-        // the changes there are a result of a successful reset. However, it is not possible to
-        // know if a recovery has been successful until the changes have been acknowledged by the
-        // server. The situation we want to avoid is that a recovery itself causes another reset
-        // which creates a reset cycle. However, at this point, upload progress has been made
-        // and we can remove the cycle detection flag if there is one.
-        _impl::client_reset::remove_pending_client_resets(wt);
-    }
+
     if (downloadable_bytes) {
         root.set(s_progress_downloadable_bytes_iip,
                  RefOrTagged::make_tagged(*downloadable_bytes)); // Throws

--- a/src/realm/sync/noinst/client_history_impl.hpp
+++ b/src/realm/sync/noinst/client_history_impl.hpp
@@ -140,8 +140,8 @@ public:
     /// The returned SyncProgress is the one that was last stored by
     /// set_sync_progress(), or `SyncProgress{}` if set_sync_progress() has
     /// never been called.
-    void get_status(version_type& current_client_version, SaltedFileIdent& client_file_ident,
-                    SyncProgress& progress) const;
+    void get_status(version_type& current_client_version, SaltedFileIdent& client_file_ident, SyncProgress& progress,
+                    bool* has_pending_client_reset = nullptr) const;
 
     /// Stores the server assigned client file identifier in the associated
     /// Realm file, such that it is available via get_status() during future

--- a/src/realm/sync/noinst/client_impl_base.hpp
+++ b/src/realm/sync/noinst/client_impl_base.hpp
@@ -107,6 +107,9 @@ public:
         // true. See receive_pong().
         bool m_scheduled_reset = false;
 
+        util::Optional<ResumptionDelayInfo> resumption_delay_info;
+        util::Optional<std::chrono::milliseconds> current_try_again_delay_interval;
+
         friend class Connection;
     };
 
@@ -909,6 +912,8 @@ private:
 
     // Processes any pending FLX bootstraps, if one exists. Otherwise this is a noop.
     void process_pending_flx_bootstrap();
+
+    void handle_pending_client_reset_acknowledgement();
 
     void gather_pending_compensating_writes(util::Span<Changeset> changesets, std::vector<ProtocolErrorInfo>* out);
 

--- a/test/object-store/sync/client_reset.cpp
+++ b/test/object-store/sync/client_reset.cpp
@@ -38,9 +38,6 @@
 #include <realm/object-store/sync/app.hpp>
 #include <realm/object-store/sync/app_credentials.hpp>
 #include <realm/object-store/sync/async_open_task.hpp>
-#include <realm/object-store/sync/mongo_client.hpp>
-#include <realm/object-store/sync/mongo_collection.hpp>
-#include <realm/object-store/sync/mongo_database.hpp>
 #include <realm/object-store/sync/sync_session.hpp>
 #include <realm/util/flat_map.hpp>
 #include <realm/util/overload.hpp>

--- a/test/object-store/sync/client_reset.cpp
+++ b/test/object-store/sync/client_reset.cpp
@@ -156,11 +156,11 @@ TEST_CASE("sync: pending client resets are cleared when downloads are complete",
         reset_utils::wait_for_object_to_persist_to_atlas(app->current_user(), test_app_session.app_session(),
                                                          "object", {{"_id", obj_id}, {"value", 5}});
     }
-    wait_for_download(*realm);
+    wait_for_download(*realm, std::chrono::minutes(10));
 
     reset_utils::trigger_client_reset(test_app_session.app_session());
 
-    wait_for_download(*realm);
+    wait_for_download(*realm, std::chrono::minutes(10));
 
     reset_utils::trigger_client_reset(test_app_session.app_session());
 

--- a/test/object-store/sync/client_reset.cpp
+++ b/test/object-store/sync/client_reset.cpp
@@ -38,6 +38,9 @@
 #include <realm/object-store/sync/app.hpp>
 #include <realm/object-store/sync/app_credentials.hpp>
 #include <realm/object-store/sync/async_open_task.hpp>
+#include <realm/object-store/sync/mongo_client.hpp>
+#include <realm/object-store/sync/mongo_collection.hpp>
+#include <realm/object-store/sync/mongo_database.hpp>
 #include <realm/object-store/sync/sync_session.hpp>
 #include <realm/util/flat_map.hpp>
 #include <realm/util/overload.hpp>
@@ -107,6 +110,65 @@ TableRef get_table(Realm& realm, StringData object_type)
 
 namespace cf = realm::collection_fixtures;
 using reset_utils::create_object;
+
+TEST_CASE("sync: pending client resets are cleared when downloads are complete", "[client reset]") {
+    const reset_utils::Partition partition{"realm_id", random_string(20)};
+    Property partition_prop = {partition.property_name, PropertyType::String | PropertyType::Nullable};
+    Schema schema{
+        {"object",
+         {
+             {"_id", PropertyType::ObjectId, Property::IsPrimary{true}},
+             {"value", PropertyType::Int},
+             partition_prop,
+         }},
+    };
+
+    std::string base_url = get_base_url();
+    REQUIRE(!base_url.empty());
+    auto server_app_config = minimal_app_config(base_url, "client_reset_tests", schema);
+    server_app_config.partition_key = partition_prop;
+    TestAppSession test_app_session(create_app(server_app_config));
+    auto app = test_app_session.app();
+
+    create_user_and_log_in(app);
+    SyncTestFile realm_config(app->current_user(), partition.value, schema);
+    realm_config.sync_config->client_resync_mode = ClientResyncMode::Recover;
+    realm_config.sync_config->error_handler = [&](std::shared_ptr<SyncSession>, SyncError err) {
+        if (err.error_code == util::make_error_code(util::MiscExtErrors::end_of_input)) {
+            return;
+        }
+
+        if (err.server_requests_action == sync::ProtocolErrorInfo::Action::Warning ||
+            err.server_requests_action == sync::ProtocolErrorInfo::Action::Transient) {
+            return;
+        }
+
+        FAIL(util::format("got error from server: %1: %2", err.error_code.value(), err.message));
+    };
+
+    auto realm = Realm::get_shared_realm(realm_config);
+    auto obj_id = ObjectId::gen();
+    {
+        realm->begin_transaction();
+        CppContext c(realm);
+        Object::create(
+            c, realm, "object",
+            std::any(AnyDict{{"_id", obj_id}, {"value", int64_t(5)}, {partition.property_name, partition.value}}));
+        realm->commit_transaction();
+        wait_for_upload(*realm);
+        reset_utils::wait_for_object_to_persist_to_atlas(app->current_user(), test_app_session.app_session(),
+                                                         "object", {{"_id", obj_id}, {"value", 5}});
+    }
+    wait_for_download(*realm);
+
+    reset_utils::trigger_client_reset(test_app_session.app_session());
+
+    wait_for_download(*realm);
+
+    reset_utils::trigger_client_reset(test_app_session.app_session());
+
+    wait_for_download(*realm, std::chrono::minutes(10));
+}
 
 TEST_CASE("sync: client reset", "[client reset]") {
     if (!util::EventLoop::has_implementation())

--- a/test/object-store/sync/sync_test_utils.cpp
+++ b/test/object-store/sync/sync_test_utils.cpp
@@ -330,8 +330,8 @@ private:
 
 #if REALM_ENABLE_AUTH_TESTS
 
-static void wait_for_object_to_persist(std::shared_ptr<SyncUser> user, const AppSession& app_session,
-                                       const std::string& schema_name, const bson::BsonDocument& filter_bson)
+void wait_for_object_to_persist_to_atlas(std::shared_ptr<SyncUser> user, const AppSession& app_session,
+                                         const std::string& schema_name, const bson::BsonDocument& filter_bson)
 {
     // While at this point the object has been sync'd successfully, we must also
     // wait for it to appear in the backing database before terminating sync
@@ -359,6 +359,30 @@ static void wait_for_object_to_persist(std::shared_ptr<SyncUser> user, const App
             return pf.future.get() > 0;
         },
         std::chrono::minutes(15), std::chrono::milliseconds(500));
+}
+
+void trigger_client_reset(const AppSession& app_session)
+{
+    // cause a client reset by restarting the sync service
+    // this causes the server's sync history to be resynthesized
+    auto baas_sync_service = app_session.admin_api.get_sync_service(app_session.server_app_id);
+    auto baas_sync_config = app_session.admin_api.get_config(app_session.server_app_id, baas_sync_service);
+    REQUIRE(app_session.admin_api.is_sync_enabled(app_session.server_app_id));
+    app_session.admin_api.disable_sync(app_session.server_app_id, baas_sync_service.id, baas_sync_config);
+    timed_sleeping_wait_for([&] {
+        return app_session.admin_api.is_sync_terminated(app_session.server_app_id);
+    });
+    app_session.admin_api.enable_sync(app_session.server_app_id, baas_sync_service.id, baas_sync_config);
+    REQUIRE(app_session.admin_api.is_sync_enabled(app_session.server_app_id));
+    if (app_session.config.dev_mode_enabled) { // dev mode is not sticky across a reset
+        app_session.admin_api.set_development_mode_to(app_session.server_app_id, true);
+    }
+
+    if (app_session.config.flx_sync_config) {
+        timed_sleeping_wait_for([&] {
+            return app_session.admin_api.is_initial_sync_complete(app_session.server_app_id);
+        });
+    }
 }
 
 struct BaasClientReset : public TestClientReset {
@@ -414,8 +438,8 @@ struct BaasClientReset : public TestClientReset {
             wait_for_upload(*realm);
             wait_for_download(*realm);
 
-            wait_for_object_to_persist(m_local_config.sync_config->user, app_session, object_schema_name,
-                                       {{pk_col_name, m_pk_driving_reset}, {"value", last_synced_value}});
+            wait_for_object_to_persist_to_atlas(m_local_config.sync_config->user, app_session, object_schema_name,
+                                                {{pk_col_name, m_pk_driving_reset}, {"value", last_synced_value}});
 
             session->pause();
 
@@ -427,24 +451,7 @@ struct BaasClientReset : public TestClientReset {
             realm->commit_transaction();
         }
 
-        // cause a client reset by restarting the sync service
-        // this causes the server's sync history to be resynthesized
-        auto baas_sync_service = app_session.admin_api.get_sync_service(app_session.server_app_id);
-        auto baas_sync_config = app_session.admin_api.get_config(app_session.server_app_id, baas_sync_service);
-        REQUIRE(app_session.admin_api.is_sync_enabled(app_session.server_app_id));
-        app_session.admin_api.disable_sync(app_session.server_app_id, baas_sync_service.id, baas_sync_config);
-        timed_sleeping_wait_for([&] {
-            return app_session.admin_api.is_sync_terminated(app_session.server_app_id);
-        });
-        app_session.admin_api.enable_sync(app_session.server_app_id, baas_sync_service.id, baas_sync_config);
-        REQUIRE(app_session.admin_api.is_sync_enabled(app_session.server_app_id));
-        if (app_session.config.dev_mode_enabled) { // dev mode is not sticky across a reset
-            app_session.admin_api.set_development_mode_to(app_session.server_app_id, true);
-        }
-
-        timed_sleeping_wait_for([&] {
-            return app_session.admin_api.is_initial_sync_complete(app_session.server_app_id);
-        });
+        trigger_client_reset(app_session);
 
         {
             auto realm2 = Realm::get_shared_realm(m_remote_config);
@@ -536,28 +543,16 @@ struct BaasFLXClientReset : public TestClientReset {
             return ret;
         }();
 
-        wait_for_object_to_persist(m_local_config.sync_config->user, app_session, std::string(c_object_schema_name),
-                                   {{std::string(c_id_col_name), pk_of_added_object}});
+        wait_for_object_to_persist_to_atlas(m_local_config.sync_config->user, app_session,
+                                            std::string(c_object_schema_name),
+                                            {{std::string(c_id_col_name), pk_of_added_object}});
         session->pause();
 
         if (m_make_local_changes) {
             m_make_local_changes(realm);
         }
 
-        // cause a client reset by restarting the sync service
-        // this causes the server's sync history to be resynthesized
-        auto baas_sync_service = app_session.admin_api.get_sync_service(app_session.server_app_id);
-        auto baas_sync_config = app_session.admin_api.get_config(app_session.server_app_id, baas_sync_service);
-        REQUIRE(app_session.admin_api.is_sync_enabled(app_session.server_app_id));
-        app_session.admin_api.disable_sync(app_session.server_app_id, baas_sync_service.id, baas_sync_config);
-        timed_sleeping_wait_for([&] {
-            return app_session.admin_api.is_sync_terminated(app_session.server_app_id);
-        });
-        app_session.admin_api.enable_sync(app_session.server_app_id, baas_sync_service.id, baas_sync_config);
-        REQUIRE(app_session.admin_api.is_sync_enabled(app_session.server_app_id));
-        if (app_session.config.dev_mode_enabled) { // dev mode is not sticky across a reset
-            app_session.admin_api.set_development_mode_to(app_session.server_app_id, true);
-        }
+        trigger_client_reset(app_session);
 
         {
             auto realm2 = Realm::get_shared_realm(m_remote_config);

--- a/test/object-store/sync/sync_test_utils.hpp
+++ b/test/object-store/sync/sync_test_utils.hpp
@@ -190,6 +190,11 @@ std::unique_ptr<TestClientReset> make_baas_client_reset(const Realm::Config& loc
 std::unique_ptr<TestClientReset> make_baas_flx_client_reset(const Realm::Config& local_config,
                                                             const Realm::Config& remote_config,
                                                             const TestAppSession& test_app_session);
+
+void wait_for_object_to_persist_to_atlas(std::shared_ptr<SyncUser> user, const AppSession& app_session,
+                                         const std::string& schema_name, const bson::BsonDocument& filter_bson);
+
+void trigger_client_reset(const AppSession& app_session);
 #endif // REALM_ENABLE_AUTH_TESTS
 
 #endif // REALM_ENABLE_SYNC


### PR DESCRIPTION
## What, How & Why?
When we start a client reset with recovery we insert an object into the realm to track whether we've already started a client reset with recovery so that if the client reset fails (say because we recover local changes that cannot be applied to the server) we don't end up in an endless loop. Previously we cleared this tracking tombstone when we received a download message that [advanced the upload progress](https://github.com/realm/realm-core/blob/42e3abcd4d9cf9aca8bf3b4a35924736ad1902b4/src/realm/sync/noinst/client_history_impl.cpp#L823) - the idea being that if the server acknowledged our client reset with a download ack then the recovered changes must have been valid.

It turns out that if client reset with recovery doesn't actually recover anything, then there's nothing for the server to acknowledge and we never clear that tracking tombstone, even though everything succeeded. If there is another client reset, then we'll enter into a cycle where the sync client thinks there's a pending client reset.

This change moves where we remove the tombstone from just whenever we receive a download with an advancing upload cursor to after we've received an upload/download ACK (i.e. a download message with an advancing upload cursor and/or a MARK message indicating the server has nothing else to send us).

I also fixed the connection-level error handling so it respects the retry-timeout info sent from the server rather than a hardcoded 5 minute timeout, and unified the try again backoff logic into a helper class.

## ☑️ ToDos
* [x] 📝 Changelog update
* [x] 🚦 Tests (or not relevant)
~* [ ] C-API, if public C++ API changed.~
