### PR TITLE
Continuously apply bootstrap changesets without releasing the write lock

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 ### Fixed
 * <How do the end-user experience this issue? what was the impact?> ([#????](https://github.com/realm/realm-core/issues/????), since v?.?.?)
 * "find first" on Decimal128 field with value NaN does not find objects ([6182](https://github.com/realm/realm-core/issues/6182), since v6.0.0)
+* Fixed diverging history in flexible sync if writes occur during bootstraps ([#5804](https://github.com/realm/realm-core/issues/5804), since v11.7.0)
 
 ### Breaking changes
 * `SyncSession::log_out()` has been renamed to `SyncSession::force_close()` to reflect what it actually does ([#6183](https://github.com/realm/realm-core/pull/6183))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@
 * <How do the end-user experience this issue? what was the impact?> ([#????](https://github.com/realm/realm-core/issues/????), since v?.?.?)
 * "find first" on Decimal128 field with value NaN does not find objects ([6182](https://github.com/realm/realm-core/issues/6182), since v6.0.0)
 * Value in List of Mixed would not be updated if new value is Binary and old value is StringData and the values otherwise matches ([#6201](https://github.com/realm/realm-core/issues/6201), since v6.0.0)
-* Fixed diverging history in flexible sync if writes occur during bootstraps ([#5804](https://github.com/realm/realm-core/issues/5804), since v11.7.0)
+* Fixed diverging history in flexible sync if writes occur during bootstrap to objects that just came into view ([#5804](https://github.com/realm/realm-core/issues/5804), since v11.7.0)
 
 ### Breaking changes
 * `SyncSession::log_out()` has been renamed to `SyncSession::force_close()` to reflect what it actually does ([#6183](https://github.com/realm/realm-core/pull/6183))

--- a/src/realm/sync/client.cpp
+++ b/src/realm/sync/client.cpp
@@ -843,7 +843,6 @@ void SessionImpl::process_pending_flx_bootstrap()
                     std::chrono::duration_cast<std::chrono::milliseconds>(duration).count(),
                     pending_batch.remaining_changesets);
     }
-    REALM_ASSERT_3(transact->get_transact_stage(), ==, DB::transact_Reading);
     on_changesets_integrated(new_version.realm_version, progress);
 
     REALM_ASSERT_3(query_version, !=, -1);

--- a/src/realm/sync/noinst/client_history_impl.cpp
+++ b/src/realm/sync/noinst/client_history_impl.cpp
@@ -408,8 +408,9 @@ void ClientHistory::integrate_server_changesets(
     const bool allow_lock_release = batch_state == DownloadBatchState::SteadyState;
 
     // Ideally, this loop runs only once, but it can run up to `incoming_changesets.size()` times, depending on the
-    // number of times the sync client yields the write lock to allow the user to commit their changes. In each
-    // iteration, at least one changeset is transformed and committed.
+    // number of times the sync client yields the write lock to allow the user to commit their changes.
+    // In each iteration, at least one changeset is transformed and committed.
+    // In FLX, all changesets are committed at once in the bootstrap phase (i.e, in one iteration).
     while (!changesets_to_integrate.empty()) {
         if (batch_state == DownloadBatchState::SteadyState) {
             transact = m_db->start_write(); // Throws

--- a/src/realm/sync/noinst/client_history_impl.hpp
+++ b/src/realm/sync/noinst/client_history_impl.hpp
@@ -246,13 +246,17 @@ public:
     /// about byte-level progress, this function updates the persistent record
     /// of the estimate of the number of remaining bytes to be downloaded.
     ///
+    /// \param transact If specified, it is a write transaction to be used to
+    /// commit the server changesets after they were transformed.
+    /// Note: Left in reading state when all tranformed changesets are commited.
+    ///
     /// \param transact_reporter An optional callback which will be called with the
     /// version immediately processing the sync transaction and that of the sync
     /// transaction.
     void integrate_server_changesets(
         const SyncProgress& progress, const std::uint_fast64_t* downloadable_bytes,
         util::Span<const RemoteChangeset> changesets, VersionInfo& new_version, DownloadBatchState download_type,
-        util::Logger&,
+        util::Logger&, TransactionRef transact = nullptr,
         util::UniqueFunction<void(const TransactionRef&, util::Span<Changeset>)> run_in_write_tr = nullptr,
         SyncTransactReporter* transact_reporter = nullptr);
 
@@ -416,7 +420,8 @@ private:
                                                   version_type end_version) const noexcept;
 
     size_t transform_and_apply_server_changesets(util::Span<Changeset> changesets_to_integrate, TransactionRef,
-                                                 util::Logger&, std::uint64_t& downloaded_bytes);
+                                                 util::Logger&, std::uint64_t& downloaded_bytes,
+                                                 bool allow_lock_release);
 
     void prepare_for_write();
     Replication::version_type add_changeset(BinaryData changeset, BinaryData sync_changeset);

--- a/src/realm/sync/noinst/client_history_impl.hpp
+++ b/src/realm/sync/noinst/client_history_impl.hpp
@@ -246,9 +246,10 @@ public:
     /// about byte-level progress, this function updates the persistent record
     /// of the estimate of the number of remaining bytes to be downloaded.
     ///
-    /// \param transact If specified, it is a write transaction to be used to
-    /// commit the server changesets after they were transformed.
-    /// Note: Left in reading state when all tranformed changesets are commited.
+    /// \param transact If specified, it is a transaction to be used to commit
+    /// the server changesets after they were transformed.
+    /// Note: In FLX, the transaction is left in reading state when bootstrap ends.
+    /// In all other cases, the transaction is left in reading state when the function returns.
     ///
     /// \param transact_reporter An optional callback which will be called with the
     /// version immediately processing the sync transaction and that of the sync
@@ -256,7 +257,7 @@ public:
     void integrate_server_changesets(
         const SyncProgress& progress, const std::uint_fast64_t* downloadable_bytes,
         util::Span<const RemoteChangeset> changesets, VersionInfo& new_version, DownloadBatchState download_type,
-        util::Logger&, TransactionRef transact = nullptr,
+        util::Logger&, const TransactionRef& transact,
         util::UniqueFunction<void(const TransactionRef&, util::Span<Changeset>)> run_in_write_tr = nullptr,
         SyncTransactReporter* transact_reporter = nullptr);
 

--- a/src/realm/sync/noinst/client_impl_base.cpp
+++ b/src/realm/sync/noinst/client_impl_base.cpp
@@ -1473,8 +1473,9 @@ void Session::integrate_changesets(ClientReplication& repl, const SyncProgress& 
     }
 
     std::vector<ProtocolErrorInfo> pending_compensating_write_errors;
+    auto transact = get_db()->start_read();
     history.integrate_server_changesets(
-        progress, &downloadable_bytes, received_changesets, version_info, download_batch_state, logger, nullptr,
+        progress, &downloadable_bytes, received_changesets, version_info, download_batch_state, logger, transact,
         [&](const TransactionRef&, util::Span<Changeset> changesets) {
             gather_pending_compensating_writes(changesets, &pending_compensating_write_errors);
         },

--- a/src/realm/sync/noinst/client_impl_base.cpp
+++ b/src/realm/sync/noinst/client_impl_base.cpp
@@ -1474,7 +1474,7 @@ void Session::integrate_changesets(ClientReplication& repl, const SyncProgress& 
 
     std::vector<ProtocolErrorInfo> pending_compensating_write_errors;
     history.integrate_server_changesets(
-        progress, &downloadable_bytes, received_changesets, version_info, download_batch_state, logger,
+        progress, &downloadable_bytes, received_changesets, version_info, download_batch_state, logger, nullptr,
         [&](const TransactionRef&, util::Span<Changeset> changesets) {
             gather_pending_compensating_writes(changesets, &pending_compensating_write_errors);
         },

--- a/src/realm/sync/tools/apply_to_state_command.cpp
+++ b/src/realm/sync/tools/apply_to_state_command.cpp
@@ -286,10 +286,11 @@ int main(int argc, const char** argv)
         mpark::visit(realm::util::overload{
                          [&](const DownloadMessage& download_message) {
                              realm::sync::VersionInfo version_info;
+                             auto transact = local_db->start_read();
                              history.integrate_server_changesets(download_message.progress,
                                                                  &download_message.downloadable_bytes,
                                                                  download_message.changesets, version_info,
-                                                                 download_message.batch_state, *logger, nullptr);
+                                                                 download_message.batch_state, *logger, transact);
                          },
                          [&](const UploadMessage& upload_message) {
                              for (const auto& changeset : upload_message.changesets) {

--- a/src/realm/sync/tools/apply_to_state_command.cpp
+++ b/src/realm/sync/tools/apply_to_state_command.cpp
@@ -286,7 +286,7 @@ int main(int argc, const char** argv)
         mpark::visit(realm::util::overload{
                          [&](const DownloadMessage& download_message) {
                              realm::sync::VersionInfo version_info;
-                             auto transact = local_db->start_read();
+                             auto transact = bool(flx_sync_arg) ? local_db->start_write() : local_db->start_read();
                              history.integrate_server_changesets(download_message.progress,
                                                                  &download_message.downloadable_bytes,
                                                                  download_message.changesets, version_info,

--- a/src/realm/transaction.cpp
+++ b/src/realm/transaction.cpp
@@ -272,7 +272,7 @@ VersionID Transaction::commit_and_continue_as_read(bool commit_to_disk)
     }
 }
 
-void Transaction::commit_and_continue_writing()
+VersionID Transaction::commit_and_continue_writing()
 {
     if (!is_attached())
         throw LogicError(LogicError::wrong_transact_state);
@@ -284,7 +284,7 @@ void Transaction::commit_and_continue_writing()
     // before committing, allow any accessors at group level or below to sync
     flush_accessors_for_commit();
 
-    db->do_commit(*this); // Throws
+    DB::version_type version = db->do_commit(*this); // Throws
 
     // We need to set m_read_lock in order for wait_for_change to work.
     // To set it, we grab a readlock on the latest available snapshot
@@ -299,6 +299,7 @@ void Transaction::commit_and_continue_writing()
 
     bool writable = true;
     remap_and_update_refs(m_read_lock.m_top_ref, m_read_lock.m_file_size, writable); // Throws
+    return VersionID{version, lock_after_commit.m_reader_idx};
 }
 
 TransactionRef Transaction::freeze()

--- a/src/realm/transaction.hpp
+++ b/src/realm/transaction.hpp
@@ -60,7 +60,7 @@ public:
 
     // Live transactions state changes, often taking an observer functor:
     VersionID commit_and_continue_as_read(bool commit_to_disk = true) REQUIRES(!m_async_mutex);
-    void commit_and_continue_writing();
+    VersionID commit_and_continue_writing();
     template <class O>
     void rollback_and_continue_as_read(O* observer) REQUIRES(!m_async_mutex);
     void rollback_and_continue_as_read() REQUIRES(!m_async_mutex)

--- a/test/test_sync.cpp
+++ b/test/test_sync.cpp
@@ -6704,7 +6704,7 @@ TEST(Sync_InvalidChangesetFromServer)
     util::StderrLogger logger;
     auto transact = db->start_read();
     CHECK_THROW_EX(history.integrate_server_changesets({}, nullptr, util::Span(&server_changeset, 1), version_info,
-                                                       DownloadBatchState::LastInBatch, logger, transact),
+                                                       DownloadBatchState::SteadyState, logger, transact),
                    sync::IntegrationException,
                    StringData(e.what()).contains("Failed to parse received changeset: Invalid interned string"));
 }

--- a/test/test_sync.cpp
+++ b/test/test_sync.cpp
@@ -6702,8 +6702,9 @@ TEST(Sync_InvalidChangesetFromServer)
 
     VersionInfo version_info;
     util::StderrLogger logger;
+    auto transact = db->start_read();
     CHECK_THROW_EX(history.integrate_server_changesets({}, nullptr, util::Span(&server_changeset, 1), version_info,
-                                                       DownloadBatchState::LastInBatch, logger),
+                                                       DownloadBatchState::LastInBatch, logger, transact),
                    sync::IntegrationException,
                    StringData(e.what()).contains("Failed to parse received changeset: Invalid interned string"));
 }

--- a/test/test_sync.cpp
+++ b/test/test_sync.cpp
@@ -6674,8 +6674,9 @@ TEST(Sync_NonIncreasingServerVersions)
     uint_fast64_t downloadable_bytes = 0;
     VersionInfo version_info;
     util::StderrLogger logger;
+    auto transact = db->start_read();
     history.integrate_server_changesets(progress, &downloadable_bytes, server_changesets_encoded, version_info,
-                                        DownloadBatchState::SteadyState, logger);
+                                        DownloadBatchState::SteadyState, logger, transact);
 }
 
 TEST(Sync_InvalidChangesetFromServer)


### PR DESCRIPTION
## What, How & Why?
In flexible sync, history can diverge if writes occur during bootstraps. Only writes to objects that come into/go out of view are affected. This happens because each side (client & server) sees their write as the most recent one.
In this PR, bootstrap changesets are applied and committed continuously without releasing the write lock so the user cannot commit their changes until bootstrap is done.

Fixes [#5804](https://github.com/realm/realm-core/issues/5804).

## ☑️ ToDos
* [x] 📝 Changelog update
* [x] 🚦 Tests (or not relevant)
* [ ] ~~C-API, if public C++ API changed.~~
