### PR TITLE
Make getting a complete view of the schema optional

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ### Enhancements
 * `SyncSession::pause()` and `SyncSession::resume()` allow users to suspend a Realm's sync session until it is explicitly resumed in ([#6183](https://github.com/realm/realm-core/pull/6183)). Previously `SyncSession::log_out()` and `SyncSession::close()` could be resumed under a number of circumstances where `SyncSession::revive_if_needed()` were called (like when freezing a realm) - fixes ([#6085](https://github.com/realm/realm-core/issues/6085))
+* Improve the performance of `Realm::freeze()` by eliminating some redudant work around schema initialization and validation. These optimizations do not apply to Realm::get_frozen_realm() ([PR #6211](https://github.com/realm/realm-core/pull/6211)).
 
 ### Fixed
 * <How do the end-user experience this issue? what was the impact?> ([#????](https://github.com/realm/realm-core/issues/????), since v?.?.?)
@@ -9,10 +10,13 @@
 * Value in List of Mixed would not be updated if new value is Binary and old value is StringData and the values otherwise matches ([#6201](https://github.com/realm/realm-core/issues/6201), since v6.0.0)
 * When client reset with recovery is used and the recovery does not actually result in any new local commits, the sync client may have gotten stuck in a cycle with a `A fatal error occured during client reset: 'A previous 'Recovery' mode reset from <timestamp> did not succeed, giving up on 'Recovery' mode to prevent a cycle'` error message. ([#6195](https://github.com/realm/realm-core/issues/6195), since v11.16.0)
 * Fixed diverging history in flexible sync if writes occur during bootstrap to objects that just came into view ([#5804](https://github.com/realm/realm-core/issues/5804), since v11.7.0)
+* Fix several data races when opening cached frozen Realms. New frozen Realms were added to the cache and the lock released before they were fully initialized, resulting in races if they were immediately read from the cache on another thread ([PR #6211](https://github.com/realm/realm-core/pull/6211), since v6.0.0).
+* Properties and types not present in the requested schema would be missing from the reported schema in several scenarios, such as if the Realm was being opened with a different schema version than the persisted one, and if the new tables or columns were added while the Realm instance did not have an active read transaction ([PR #6211](https://github.com/realm/realm-core/pull/6211), since v13.2.0).
 
 ### Breaking changes
 * `SyncSession::log_out()` has been renamed to `SyncSession::force_close()` to reflect what it actually does ([#6183](https://github.com/realm/realm-core/pull/6183))
 * Passing an empty `key_path_array` to `add_notification_callback now` now ignores nested property changes. Pass `std::nullopt` to achieve the old meaning. ([#6122](https://github.com/realm/realm-core/pull/6122))
+* Whether to report the file's complete schema or only the requested schema is now an option on RealmConfig (schema_subset_mode) rather than always being enabled for Additive schema modes. All schema modes which this applies to are now supported ([PR #6211](https://github.com/realm/realm-core/pull/6211)).
 
 ### Compatibility
 * Fileformat: Generates files with format v23. Reads and automatically upgrade from fileformat v5.
@@ -79,7 +83,7 @@
  
 ### Breaking changes
 * FLX Subscription API reworked to better match SDK consumption patterns ([#6065](https://github.com/realm/realm-core/pull/6065)). Not all changes are breaking, but listing them all here together.
-  * `Subscription` is now a plain struct with public fields rather than getter functions    * `has_name()` and `name()` were merged into a single `optional<string> name` field
+  * `Subscription` is now a plain struct with public fields rather than getter functions
   * `has_name()` and `name()` were merged into a single `optional<string> name` field
   * `SubscriptionSet` now uses the same types for `iterator` and `const_iterator` since neither was intended to support direct mutability
   * `SubscriptionSet::get_state_change_notification()` now offers a callback-taking overload

--- a/src/realm/object-store/dictionary.cpp
+++ b/src/realm/object-store/dictionary.cpp
@@ -335,9 +335,10 @@ private:
     Dictionary::CBFunc m_cb;
 };
 
-NotificationToken Dictionary::add_key_based_notification_callback(CBFunc cb, KeyPathArray key_path_array) &
+NotificationToken Dictionary::add_key_based_notification_callback(CBFunc cb,
+                                                                  std::optional<KeyPathArray> key_path_array) &
 {
-    return add_notification_callback(NotificationHandler(dict(), std::move(cb)), key_path_array);
+    return add_notification_callback(NotificationHandler(dict(), std::move(cb)), std::move(key_path_array));
 }
 
 Dictionary Dictionary::freeze(const std::shared_ptr<Realm>& frozen_realm) const

--- a/src/realm/object-store/dictionary.hpp
+++ b/src/realm/object-store/dictionary.hpp
@@ -118,7 +118,8 @@ public:
     Results get_values() const;
 
     using CBFunc = util::UniqueFunction<void(DictionaryChangeSet)>;
-    NotificationToken add_key_based_notification_callback(CBFunc cb, KeyPathArray key_path_array = {}) &;
+    NotificationToken
+    add_key_based_notification_callback(CBFunc cb, std::optional<KeyPathArray> key_path_array = std::nullopt) &;
 
     Iterator begin() const;
     Iterator end() const;

--- a/src/realm/object-store/impl/realm_coordinator.cpp
+++ b/src/realm/object-store/impl/realm_coordinator.cpp
@@ -247,9 +247,7 @@ std::shared_ptr<Realm> RealmCoordinator::get_realm(Realm::Config config, util::O
     util::CheckedUniqueLock lock(m_realm_mutex);
     set_config(config);
     if ((realm = do_get_cached_realm(config))) {
-        if (version) {
-            REALM_ASSERT(realm->read_transaction_version() == *version);
-        }
+        REALM_ASSERT(!version || realm->read_transaction_version() == *version);
         return realm;
     }
     do_get_realm(std::move(config), realm, version, lock);
@@ -269,15 +267,34 @@ std::shared_ptr<Realm> RealmCoordinator::get_realm(std::shared_ptr<util::Schedul
     return realm;
 }
 
+std::shared_ptr<Realm> RealmCoordinator::freeze_realm(const Realm& source_realm)
+{
+    std::shared_ptr<Realm> realm;
+    util::CheckedUniqueLock lock(m_realm_mutex);
+
+    auto version = source_realm.read_transaction_version();
+    auto scheduler = util::Scheduler::make_frozen(version);
+    if ((realm = do_get_cached_realm(source_realm.config(), scheduler))) {
+        return realm;
+    }
+
+    auto config = source_realm.config();
+    config.scheduler = scheduler;
+    realm = Realm::make_shared_realm(std::move(config), version, shared_from_this());
+    Realm::Internal::copy_schema(*realm, source_realm);
+    m_weak_realm_notifiers.emplace_back(realm, config.cache);
+    return realm;
+}
+
 ThreadSafeReference RealmCoordinator::get_unbound_realm()
 {
     std::shared_ptr<Realm> realm;
     util::CheckedUniqueLock lock(m_realm_mutex);
-    do_get_realm(m_config, realm, none, lock);
+    do_get_realm(RealmConfig(m_config), realm, none, lock);
     return ThreadSafeReference(realm);
 }
 
-void RealmCoordinator::do_get_realm(Realm::Config config, std::shared_ptr<Realm>& realm,
+void RealmCoordinator::do_get_realm(RealmConfig&& config, std::shared_ptr<Realm>& realm,
                                     util::Optional<VersionID> version, util::CheckedUniqueLock& realm_lock)
 {
     open_db();
@@ -304,6 +321,15 @@ void RealmCoordinator::do_get_realm(Realm::Config config, std::shared_ptr<Realm>
     if (realm->config().audit_config)
         REALM_TERMINATE("Cannot use Audit interface if Realm Core is built without Sync");
 #endif
+
+    // Cached frozen Realms need to initialize their schema before releasing
+    // the lock as otherwise they could be read from the cache on another thread
+    // before the schema initialization happens. They'll never perform a write
+    // transaction, so unlike with live Realms this is safe to do.
+    if (config.cache && version && schema) {
+        realm->update_schema(std::move(*schema));
+        schema.reset();
+    }
 
     realm_lock.unlock_unchecked();
     if (schema) {

--- a/src/realm/object-store/impl/realm_coordinator.hpp
+++ b/src/realm/object-store/impl/realm_coordinator.hpp
@@ -60,6 +60,11 @@ public:
         REQUIRES(!m_realm_mutex, !m_schema_cache_mutex);
     std::shared_ptr<Realm> get_realm(std::shared_ptr<util::Scheduler> = nullptr)
         REQUIRES(!m_realm_mutex, !m_schema_cache_mutex);
+
+    // Return a frozen copy of the source Realm. May return a cached instance
+    // if the source Realm has caching enabled.
+    std::shared_ptr<Realm> freeze_realm(const Realm& source_realm) REQUIRES(!m_realm_mutex);
+
 #if REALM_ENABLE_SYNC
     // Get a thread-local shared Realm with the given configuration
     // If the Realm is not already present, it will be fully downloaded before being returned.
@@ -262,7 +267,7 @@ private:
     std::shared_ptr<Realm> do_get_cached_realm(Realm::Config const& config,
                                                std::shared_ptr<util::Scheduler> scheduler = nullptr)
         REQUIRES(m_realm_mutex);
-    void do_get_realm(Realm::Config config, std::shared_ptr<Realm>& realm, util::Optional<VersionID> version,
+    void do_get_realm(Realm::Config&& config, std::shared_ptr<Realm>& realm, util::Optional<VersionID> version,
                       util::CheckedUniqueLock& realm_lock) REQUIRES(m_realm_mutex);
     void run_async_notifiers() REQUIRES(!m_notifier_mutex, m_running_notifiers_mutex);
     void clean_up_dead_notifiers() REQUIRES(m_notifier_mutex);

--- a/src/realm/object-store/object_accessor.hpp
+++ b/src/realm/object-store/object_accessor.hpp
@@ -264,7 +264,7 @@ Object Object::create(ContextType& ctx, std::shared_ptr<Realm> const& realm, Obj
     // considered a primary key by core, and so will need to be set.
     bool skip_primary = true;
     // If the input value is missing values for any of the properties we want to
-    // set the propery to the default value for new objects, but leave it
+    // set the property to the default value for new objects, but leave it
     // untouched for existing objects.
     bool created = false;
 

--- a/src/realm/object-store/object_store.cpp
+++ b/src/realm/object-store/object_store.cpp
@@ -875,7 +875,6 @@ void ObjectStore::apply_schema_changes(Transaction& group, uint64_t schema_versi
     }
 
     if (mode == SchemaMode::Manual) {
-        set_schema_keys(group, target_schema);
         if (migration_function) {
             migration_function();
         }

--- a/src/realm/object-store/schema.cpp
+++ b/src/realm/object-store/schema.cpp
@@ -313,12 +313,10 @@ void Schema::zip_matching(T&& a, U&& b, Func&& func)
             ++j;
         }
     }
-    for (; i < a.size(); ++i) {
+    for (; i < a.size(); ++i)
         func(&a[i], nullptr);
-    }
-    for (; j < b.size(); ++j) {
+    for (; j < b.size(); ++j)
         func(nullptr, &b[j]);
-    }
 }
 
 std::vector<SchemaChange> Schema::compare(Schema const& target_schema, SchemaMode mode,
@@ -343,10 +341,8 @@ std::vector<SchemaChange> Schema::compare(Schema const& target_schema, SchemaMod
 
     // Modify columns
     zip_matching(target_schema, *this, [&](const ObjectSchema* target, const ObjectSchema* existing) {
-        if (target && existing) {
+        if (target && existing)
             ::compare(*existing, *target, changes);
-        }
-
         else if (target && !orphans.count(target->name)) {
             // Target is a new table -- add all properties
             changes.emplace_back(schema_change::AddInitialProperties{target});
@@ -364,35 +360,31 @@ std::vector<SchemaChange> Schema::compare(Schema const& target_schema, SchemaMod
     return changes;
 }
 
-void Schema::copy_keys_from(Schema const& other, bool is_schema_additive)
+void Schema::copy_keys_from(realm::Schema const& other, SchemaSubsetMode subset_mode)
 {
-    std::vector<ObjectSchema> other_classes;
-    zip_matching(*this, other, [&](ObjectSchema const* existing, ObjectSchema const* other) {
-        if (is_schema_additive && !existing && other) {
-            other_classes.push_back(*other);
-        }
+    std::vector<const ObjectSchema*> other_classes;
+    zip_matching(*this, other, [&](ObjectSchema* existing, const ObjectSchema* other) {
+        if (subset_mode.include_types && !existing && other)
+            other_classes.push_back(other);
         if (!existing || !other)
             return;
-        update_or_append_properties(const_cast<ObjectSchema*>(existing), other, is_schema_additive);
+
+        existing->table_key = other->table_key;
+        for (auto& current_prop : other->persisted_properties) {
+            if (auto target_prop = existing->property_for_name(current_prop.name)) {
+                target_prop->column_key = current_prop.column_key;
+            }
+            else if (subset_mode.include_properties) {
+                existing->persisted_properties.push_back(current_prop);
+            }
+        }
     });
 
     if (!other_classes.empty()) {
-        insert(end(), other_classes.begin(), other_classes.end());
+        reserve(size() + other_classes.size());
+        for (auto other : other_classes)
+            push_back(*other);
         sort_schema();
-    }
-}
-
-void Schema::update_or_append_properties(ObjectSchema* existing, const ObjectSchema* other, bool is_schema_additive)
-{
-    existing->table_key = other->table_key;
-    for (auto& current_prop : other->persisted_properties) {
-        auto target_prop = existing->property_for_name(current_prop.name);
-        if (target_prop) {
-            target_prop->column_key = current_prop.column_key;
-        }
-        else if (is_schema_additive) {
-            existing->persisted_properties.push_back(current_prop);
-        }
     }
 }
 

--- a/src/realm/object-store/shared_realm.cpp
+++ b/src/realm/object-store/shared_realm.cpp
@@ -77,10 +77,13 @@ private:
 Realm::Realm(Config config, util::Optional<VersionID> version, std::shared_ptr<_impl::RealmCoordinator> coordinator,
              MakeSharedTag)
     : m_config(std::move(config))
-    , m_frozen_version(std::move(version))
+    , m_frozen_version(version)
     , m_scheduler(m_config.scheduler)
 {
-    if (!coordinator->get_cached_schema(m_schema, m_schema_version, m_schema_transaction_version)) {
+    if (version) {
+        m_auto_refresh = false;
+    }
+    else if (!coordinator->get_cached_schema(m_schema, m_schema_version, m_schema_transaction_version)) {
         m_transaction = coordinator->begin_read();
         read_schema_from_group_if_needed();
         coordinator->cache_schema(m_schema, m_schema_version, m_schema_transaction_version);
@@ -110,9 +113,8 @@ Group& Realm::read_group()
 Transaction& Realm::transaction()
 {
     verify_open();
-    if (!m_transaction) {
+    if (!m_transaction)
         begin_read(m_frozen_version.value_or(VersionID{}));
-    }
     return *m_transaction;
 }
 
@@ -160,9 +162,7 @@ SharedRealm Realm::get_shared_realm(Config config)
 SharedRealm Realm::get_frozen_realm(Config config, VersionID version)
 {
     auto coordinator = RealmCoordinator::get_coordinator(config.path);
-    SharedRealm realm = coordinator->get_realm(std::move(config), util::Optional<VersionID>(version));
-    realm->set_auto_refresh(false);
-    return realm;
+    return coordinator->get_realm(std::move(config), version);
 }
 
 SharedRealm Realm::get_shared_realm(ThreadSafeReference ref, std::shared_ptr<util::Scheduler> scheduler)
@@ -218,7 +218,7 @@ sync::SubscriptionSet Realm::get_active_subscription_set()
 void Realm::set_schema(Schema const& reference, Schema schema)
 {
     m_dynamic_schema = false;
-    schema.copy_keys_from(reference, m_config.is_schema_additive());
+    schema.copy_keys_from(reference, m_config.schema_subset_mode);
     m_schema = std::move(schema);
     notify_schema_changed();
 }
@@ -233,12 +233,12 @@ void Realm::read_schema_from_group_if_needed()
         }
         return;
     }
+
     Group& group = read_group();
     auto current_version = transaction().get_version_of_current_transaction().version;
     if (m_schema_transaction_version == current_version)
         return;
 
-    auto previous_transaction_version = m_schema_transaction_version;
     m_schema_transaction_version = current_version;
     m_schema_version = ObjectStore::get_schema_version(group);
     auto schema = ObjectStore::schema_from_group(group);
@@ -249,20 +249,16 @@ void Realm::read_schema_from_group_if_needed()
     if (m_dynamic_schema) {
         if (m_schema == schema) {
             // The structure of the schema hasn't changed. Bring the table column indices up to date.
-            m_schema.copy_keys_from(schema);
+            m_schema.copy_keys_from(schema, SchemaSubsetMode::Strict);
         }
         else {
             // The structure of the schema has changed, so replace our copy of the schema.
             m_schema = std::move(schema);
         }
     }
-    else if (m_config.is_schema_additive() && m_schema_transaction_version < previous_transaction_version) {
-        // no verification of schema changes when opening a past version of the schema
-        m_schema.copy_keys_from(schema, m_config.is_schema_additive());
-    }
     else {
         ObjectStore::verify_valid_external_changes(m_schema.compare(schema, m_config.schema_mode));
-        m_schema.copy_keys_from(schema);
+        m_schema.copy_keys_from(schema, m_config.schema_subset_mode);
     }
     notify_schema_changed();
 }
@@ -339,16 +335,12 @@ Schema Realm::get_full_schema()
         do_refresh();
 
     // If the user hasn't specified a schema previously then m_schema is always
-    // the full schema
-    if (m_dynamic_schema) {
+    // the full schema if it's been read
+    if (m_dynamic_schema && !m_schema.empty())
         return m_schema;
-    }
 
     // Otherwise we may have a subset of the file's schema, so we need to get
     // the complete thing to calculate what changes to make
-    if (m_config.immutable())
-        return ObjectStore::schema_from_group(read_group());
-
     Schema actual_schema;
     uint64_t actual_version;
     uint64_t version = -1;
@@ -407,8 +399,16 @@ void Realm::update_schema(Schema schema, uint64_t version, MigrationFunction mig
 
     bool was_in_read_transaction = is_in_read_transaction();
     Schema actual_schema = get_full_schema();
-    std::vector<SchemaChange> required_changes = actual_schema.compare(schema, m_config.schema_mode);
 
+    // Frozen Realms never modify the schema on disk and we just need to verify
+    // that the requested schema is a subset of what actually exists
+    if (m_frozen_version) {
+        ObjectStore::verify_valid_external_changes(schema.compare(actual_schema, m_config.schema_mode, true));
+        set_schema(actual_schema, std::move(schema));
+        return;
+    }
+
+    std::vector<SchemaChange> required_changes = actual_schema.compare(schema, m_config.schema_mode);
     if (!schema_change_needs_write_transaction(schema, required_changes, version)) {
         if (!was_in_read_transaction)
             m_transaction = nullptr;
@@ -444,9 +444,13 @@ void Realm::update_schema(Schema schema, uint64_t version, MigrationFunction mig
         cache_new_schema();
     }
 
+    schema.copy_keys_from(actual_schema, m_config.schema_subset_mode);
+
     uint64_t old_schema_version = m_schema_version;
-    bool is_schema_additive = m_config.is_schema_additive();
-    if (migration_function && !is_schema_additive) {
+    bool additive = m_config.schema_mode == SchemaMode::AdditiveDiscovered ||
+                    m_config.schema_mode == SchemaMode::AdditiveExplicit ||
+                    m_config.schema_mode == SchemaMode::ReadOnly;
+    if (migration_function && !additive) {
         auto wrapper = [&] {
             auto config = m_config;
             config.schema_mode = SchemaMode::ReadOnly;
@@ -476,7 +480,7 @@ void Realm::update_schema(Schema schema, uint64_t version, MigrationFunction mig
     else {
         ObjectStore::apply_schema_changes(transaction(), m_schema_version, schema, version, m_config.schema_mode,
                                           required_changes, m_config.automatically_handle_backlinks_in_migrations);
-        REALM_ASSERT_DEBUG(is_schema_additive ||
+        REALM_ASSERT_DEBUG(additive ||
                            (required_changes = ObjectStore::schema_from_group(read_group()).compare(schema)).empty());
     }
 
@@ -522,7 +526,7 @@ void Realm::add_schema_change_handler()
             m_schema = *m_new_schema;
         }
         else {
-            m_schema.copy_keys_from(*m_new_schema, m_config.is_schema_additive());
+            m_schema.copy_keys_from(*m_new_schema, m_config.schema_subset_mode);
         }
         notify_schema_changed();
     });
@@ -530,15 +534,17 @@ void Realm::add_schema_change_handler()
 
 void Realm::cache_new_schema()
 {
-    if (!is_closed()) {
-        auto new_version = transaction().get_version_of_current_transaction().version;
-        if (m_new_schema)
-            m_coordinator->cache_schema(std::move(*m_new_schema), m_schema_version, new_version);
-        else
-            m_coordinator->advance_schema_cache(m_schema_transaction_version, new_version);
-        m_schema_transaction_version = new_version;
-        m_new_schema = util::none;
+    if (is_closed()) {
+        return;
     }
+
+    auto new_version = transaction().get_version_of_current_transaction().version;
+    if (m_new_schema)
+        m_coordinator->cache_schema(std::move(*m_new_schema), m_schema_version, new_version);
+    else
+        m_coordinator->advance_schema_cache(m_schema_transaction_version, new_version);
+    m_schema_transaction_version = new_version;
+    m_new_schema = util::none;
 }
 
 void Realm::translate_schema_error()
@@ -1311,12 +1317,18 @@ bool Realm::is_frozen() const
 
 SharedRealm Realm::freeze()
 {
-    auto config = m_config;
-    auto version = read_transaction_version();
-    config.scheduler = util::Scheduler::make_frozen(version);
-    auto frozen_realm = Realm::get_frozen_realm(std::move(config), version);
-    frozen_realm->set_schema(frozen_realm->m_schema, m_schema);
-    return frozen_realm;
+    read_group(); // Freezing requires a read transaction
+    return m_coordinator->freeze_realm(*this);
+}
+
+void Realm::copy_schema_from(const Realm& source)
+{
+    REALM_ASSERT(is_frozen());
+    REALM_ASSERT(m_frozen_version == source.read_transaction_version());
+    m_schema = source.m_schema;
+    m_schema_version = source.m_schema_version;
+    m_schema_transaction_version = source.m_schema_transaction_version;
+    m_dynamic_schema = false;
 }
 
 void Realm::close()

--- a/src/realm/object-store/shared_realm.hpp
+++ b/src/realm/object-store/shared_realm.hpp
@@ -104,6 +104,7 @@ struct RealmConfig {
 
     bool in_memory = false;
     SchemaMode schema_mode = SchemaMode::Automatic;
+    SchemaSubsetMode schema_subset_mode = SchemaSubsetMode::Strict;
 
     // Optional schema for the file.
     // If the schema and schema version are supplied, update_schema() is
@@ -134,11 +135,6 @@ struct RealmConfig {
     bool read_only() const
     {
         return schema_mode == SchemaMode::ReadOnly;
-    }
-    bool is_schema_additive() const
-    {
-        return schema_mode == SchemaMode::AdditiveExplicit || schema_mode == SchemaMode::AdditiveDiscovered ||
-               schema_mode == SchemaMode::ReadOnly;
     }
 
     // If false, always return a new Realm instance, and don't return
@@ -477,6 +473,11 @@ public:
             realm.run_writes();
         }
 
+        static void copy_schema(Realm& target_realm, const Realm& source_realm)
+        {
+            target_realm.copy_schema_from(source_realm);
+        }
+
         // CollectionNotifier needs to be able to access the owning
         // coordinator to wake up the worker thread when a callback is
         // added, and coordinators need to be able to get themselves from a Realm
@@ -556,6 +557,7 @@ private:
     void cache_new_schema();
     void translate_schema_error();
     void notify_schema_changed();
+    void copy_schema_from(const Realm&);
 
     Transaction& transaction();
     Transaction& transaction() const;

--- a/test/object-store/migrations.cpp
+++ b/test/object-store/migrations.cpp
@@ -211,199 +211,6 @@ auto create_objects(Table& table, size_t count)
 }
 } // anonymous namespace
 
-TEST_CASE("migration: Additive mode returns OS schema - Automatic migration") {
-
-    SECTION("Check OS schema returned in additive mode") {
-        InMemoryTestFile config;
-        config.automatic_change_notifications = false;
-        config.schema_mode = SchemaMode::AdditiveExplicit;
-        auto realm = Realm::get_shared_realm(config);
-
-        auto update_schema = [](Realm& r, Schema& s, uint64_t version) {
-            REQUIRE_NOTHROW((r).update_schema(s, version));
-            VERIFY_SCHEMA(r, false);
-            auto schema = (r).schema();
-            for (const auto& other : s) {
-                REQUIRE(schema.find(other.name) != schema.end());
-            }
-        };
-
-        Schema schema1 = {};
-        Schema schema2 = add_table(schema1, {"A", {{"value", PropertyType::Int}}});
-        Schema schema3 = add_table(schema2, {"B", {{"value", PropertyType::Int}}});
-        Schema schema4 = add_table(schema3, {"C", {{"value", PropertyType::Int}}});
-        Schema schema5 = add_table(schema4, {"Z", {{"value", PropertyType::Int}}});
-        update_schema(*realm, schema1, 0);
-        REQUIRE(realm->schema().size() == 0);
-        update_schema(*realm, schema2, 0);
-        REQUIRE(realm->schema().size() == 1);
-        update_schema(*realm, schema3, 0);
-        REQUIRE(realm->schema().size() == 2);
-        update_schema(*realm, schema4, 0);
-        REQUIRE(realm->schema().size() == 3);
-        update_schema(*realm, schema5, 0);
-        REQUIRE(realm->schema().size() == 4);
-
-        // schema size is decremented.
-        // after deletion the schema size is decremented but the just deleted object can still be found.
-        // the object that was just deleted is still there, thus find should return a valid iterator
-        SECTION("delete in reverse order") {
-            auto new_schema = schema5;
-            Schema delete_schema = remove_table(new_schema, "Z");
-            update_schema(*realm, delete_schema, 0);
-            auto schema = realm->schema();
-            REQUIRE(schema.size() == 4);
-            REQUIRE(schema.find("Z") != schema.end());
-            delete_schema = remove_table(schema4, "C");
-            update_schema(*realm, delete_schema, 0);
-            schema = realm->schema();
-            REQUIRE(schema.size() == 4);
-            REQUIRE(schema.find("C") != schema.end());
-            REQUIRE(schema.find("Z") != schema.end());
-            delete_schema = remove_table(schema3, "B");
-            update_schema(*realm, delete_schema, 0);
-            schema = realm->schema();
-            REQUIRE(schema.size() == 4);
-            REQUIRE(schema.find("C") != schema.end());
-            REQUIRE(schema.find("Z") != schema.end());
-            REQUIRE(schema.find("B") != schema.end());
-            delete_schema = remove_table(schema2, "A");
-            update_schema(*realm, delete_schema, 0);
-            schema = realm->schema();
-            REQUIRE(schema.size() == 4);
-            REQUIRE(schema.find("C") != schema.end());
-            REQUIRE(schema.find("Z") != schema.end());
-            REQUIRE(schema.find("A") != schema.end());
-            REQUIRE(schema.find("B") != schema.end());
-        }
-        SECTION("delete 1 element") {
-            auto new_schema = schema5;
-            Schema delete_schema = remove_table(new_schema, "Z");
-            // A B C Z vs A B C ==> Z (other classes)
-            update_schema(*realm, delete_schema, 0);
-            auto schema = realm->schema();
-            REQUIRE(schema.size() == 4);
-            REQUIRE(schema.find("C") != schema.end());
-            REQUIRE(schema.find("Z") != schema.end());
-            REQUIRE(schema.find("A") != schema.end());
-            REQUIRE(schema.find("B") != schema.end());
-            delete_schema = remove_table(new_schema, "C");
-            schema = realm->schema();
-            // A B C vs A B Z => Z
-            update_schema(*realm, delete_schema, 0);
-            schema = realm->schema();
-            REQUIRE(schema.size() == 4);
-            REQUIRE(schema.find("C") != schema.end());
-            REQUIRE(schema.find("Z") != schema.end());
-            REQUIRE(schema.find("A") != schema.end());
-            REQUIRE(schema.find("B") != schema.end());
-            delete_schema = remove_table(new_schema, "B");
-            // A B Z vs A C Z => B
-            update_schema(*realm, delete_schema, 0);
-            schema = realm->schema();
-            REQUIRE(schema.find("C") != schema.end());
-            REQUIRE(schema.find("Z") != schema.end());
-            REQUIRE(schema.find("A") != schema.end());
-            REQUIRE(schema.find("B") != schema.end());
-            delete_schema = remove_table(new_schema, "A");
-            // A B Z vs B C Z => A
-            update_schema(*realm, delete_schema, 0);
-            schema = realm->schema();
-            REQUIRE(schema.size() == 4);
-            REQUIRE(schema.find("C") != schema.end());
-            REQUIRE(schema.find("Z") != schema.end());
-            REQUIRE(schema.find("A") != schema.end());
-            REQUIRE(schema.find("B") != schema.end());
-        }
-        SECTION("delete 2 elements") {
-            auto new_schema = schema5;
-            Schema delete_schema;
-            delete_schema = remove_table(new_schema, "Z");
-            delete_schema = remove_table(delete_schema, "A");
-            // A B C Z vs B C ==> A,Z (other classes)
-            update_schema(*realm, delete_schema, 0);
-            auto schema = realm->schema();
-            REQUIRE(schema.size() == 4);
-            REQUIRE(schema.find("C") != schema.end());
-            REQUIRE(schema.find("Z") != schema.end());
-            REQUIRE(schema.find("A") != schema.end());
-            REQUIRE(schema.find("B") != schema.end());
-        }
-        SECTION("delete 3 elements") {
-            auto new_schema = schema5;
-            Schema delete_schema;
-            delete_schema = remove_table(new_schema, "Z");
-            delete_schema = remove_table(delete_schema, "A");
-            delete_schema = remove_table(delete_schema, "C");
-            // A B C Z vs B  ==> A,C,Z (other classes)
-            update_schema(*realm, delete_schema, 0);
-            auto schema = realm->schema();
-            REQUIRE(schema.size() == 4);
-            REQUIRE(schema.find("C") != schema.end());
-            REQUIRE(schema.find("Z") != schema.end());
-            REQUIRE(schema.find("A") != schema.end());
-            REQUIRE(schema.find("B") != schema.end());
-        }
-        SECTION("delete all elements") {
-            auto new_schema = schema5;
-            Schema delete_schema;
-            delete_schema = remove_table(new_schema, "Z");
-            delete_schema = remove_table(delete_schema, "A");
-            delete_schema = remove_table(delete_schema, "C");
-            delete_schema = remove_table(delete_schema, "B");
-            // A B C Z vs None  ==> A,C,Z,B (other classes)
-            update_schema(*realm, delete_schema, 0);
-            auto schema = realm->schema();
-            REQUIRE(schema.size() == 4);
-            REQUIRE(schema.find("C") != schema.end());
-            REQUIRE(schema.find("Z") != schema.end());
-            REQUIRE(schema.find("A") != schema.end());
-            REQUIRE(schema.find("B") != schema.end());
-        }
-        SECTION("unsorted schema object names") {
-            InMemoryTestFile config;
-            config.automatic_change_notifications = false;
-            config.schema_mode = SchemaMode::AdditiveExplicit;
-            auto realm = Realm::get_shared_realm(config);
-
-            Schema schema1 = {};
-            Schema schema2 = add_table(schema1, {"Z", {{"value", PropertyType::Int}}});
-            Schema schema3 = add_table(schema2, {"B", {{"value", PropertyType::Int}}});
-            Schema schema4 = add_table(schema3, {"A", {{"value", PropertyType::Int}}});
-            Schema schema5 = add_table(schema4, {"C", {{"value", PropertyType::Int}}});
-            update_schema(*realm, schema5, 0);
-
-            Schema delete_schema;
-            delete_schema = remove_table(schema5, "Z");
-            delete_schema = remove_table(delete_schema, "A");
-            // Z B A C vs Z A => B C (others)
-            update_schema(*realm, delete_schema, 0);
-            auto schema = realm->schema();
-            REQUIRE(schema.size() == 4);
-            REQUIRE(schema.find("C") != schema.end());
-            REQUIRE(schema.find("Z") != schema.end());
-            REQUIRE(schema.find("A") != schema.end());
-            REQUIRE(schema.find("B") != schema.end());
-        }
-
-        SECTION("frozen realm schema can be updated if it is a subset of OS schema") {
-            InMemoryTestFile config;
-            config.automatic_change_notifications = false;
-            config.schema_mode = SchemaMode::AdditiveExplicit;
-            auto realm = Realm::get_shared_realm(config);
-            Schema schema1 = {};
-            Schema schema2 = add_table(schema1, {"Z", {{"value", PropertyType::Int}}});
-            Schema schema3 = add_table(schema2, {"B", {{"value", PropertyType::Int}}});
-            Schema schema4 = add_table(schema3, {"A", {{"value", PropertyType::Int}}});
-            update_schema(*realm, schema4, 0);
-            auto frozen_realm = realm->freeze();
-            auto subset_schema = remove_table(schema4, "Z");
-            update_schema(*realm, subset_schema, 0);
-            REQUIRE_NOTHROW(frozen_realm->update_schema(realm->schema()));
-        }
-    }
-}
-
 TEST_CASE("migration: Automatic") {
     InMemoryTestFile config;
     config.automatic_change_notifications = false;
@@ -2537,7 +2344,7 @@ TEST_CASE("migration: Additive") {
         REQUIRE_NOTHROW(realm->update_schema(remove_property(schema, "object", "value")));
         REQUIRE(ObjectStore::table_for_object_type(realm->read_group(), "object")->get_column_count() == 2);
         auto const& properties = realm->schema().find("object")->persisted_properties;
-        REQUIRE(properties.size() == 2);
+        REQUIRE(properties.size() == 1);
         auto col_keys = table->get_column_keys();
         REQUIRE(col_keys.size() == 2);
         REQUIRE(properties[0].column_key == col_keys[1]);
@@ -2592,10 +2399,7 @@ TEST_CASE("migration: Additive") {
         }));
     }
 
-    SECTION("add new columns from different SG") {
-        using vec = std::vector<SchemaChange>;
-        using namespace schema_change;
-
+    SECTION("new columns added externally are ignored") {
         auto realm2 = Realm::get_shared_realm(config);
         auto& group = realm2->read_group();
         realm2->begin_transaction();
@@ -2605,19 +2409,17 @@ TEST_CASE("migration: Additive") {
         realm2->commit_transaction();
 
         REQUIRE_NOTHROW(realm->refresh());
-        auto schema_diff = schema.compare(realm->schema());
-        REQUIRE(schema_diff.size() == 1);
-        REQUIRE(schema_diff == vec{(AddProperty{&*schema.find("object"),
-                                                &realm->schema().find("object")->persisted_properties[2]})});
+        REQUIRE(realm->schema() == schema);
         REQUIRE(realm->schema().find("object")->persisted_properties[0].column_key == col_keys[0]);
         REQUIRE(realm->schema().find("object")->persisted_properties[1].column_key == col_keys[1]);
-        REQUIRE(realm->schema().find("object")->persisted_properties[2].column_key == col_keys[2]);
+
+        auto frozen = realm->freeze();
+        REQUIRE(frozen->schema() == schema);
+        REQUIRE(frozen->schema().find("object")->persisted_properties[0].column_key == col_keys[0]);
+        REQUIRE(frozen->schema().find("object")->persisted_properties[1].column_key == col_keys[1]);
     }
 
     SECTION("opening new Realms uses the correct schema after an external change") {
-        using vec = std::vector<SchemaChange>;
-        using namespace schema_change;
-
         auto realm2 = Realm::get_shared_realm(config);
         auto& group = realm2->read_group();
         realm2->begin_transaction();
@@ -2627,13 +2429,9 @@ TEST_CASE("migration: Additive") {
         realm2->commit_transaction();
 
         REQUIRE_NOTHROW(realm->refresh());
-        auto schema_diff = schema.compare(realm->schema());
-        REQUIRE(schema_diff.size() == 1);
-        REQUIRE(schema_diff == vec{(AddProperty{&*schema.find("object"),
-                                                &realm->schema().find("object")->persisted_properties[2]})});
+        REQUIRE(realm->schema() == schema);
         REQUIRE(realm->schema().find("object")->persisted_properties[0].column_key == col_keys[0]);
         REQUIRE(realm->schema().find("object")->persisted_properties[1].column_key == col_keys[1]);
-        REQUIRE(realm->schema().find("object")->persisted_properties[2].column_key == col_keys[2]);
 
         // Gets the schema from the RealmCoordinator
         auto realm3 = Realm::get_shared_realm(config);
@@ -2645,17 +2443,49 @@ TEST_CASE("migration: Additive") {
         realm2.reset();
         realm3.reset();
 
-        // In case of additive schemas, changes to an external realm are on purpose
-        // propagated between different realm instances.
         realm = Realm::get_shared_realm(config);
-        schema_diff = schema.compare(realm->schema());
-        REQUIRE(schema_diff.size() == 1);
-        REQUIRE(schema_diff == vec{(AddProperty{&*schema.find("object"),
-                                                &realm->schema().find("object")->persisted_properties[2]})});
-        REQUIRE(realm->schema().find("object")->persisted_properties.size() == 3);
+        REQUIRE(realm->schema() == schema);
         REQUIRE(realm->schema().find("object")->persisted_properties[0].column_key == col_keys[0]);
         REQUIRE(realm->schema().find("object")->persisted_properties[1].column_key == col_keys[1]);
-        REQUIRE(realm->schema().find("object")->persisted_properties[2].column_key == col_keys[2]);
+    }
+
+    SECTION("obtaining a frozen Realm from before an external schema change") {
+        auto realm2 = Realm::get_shared_realm(config);
+        realm->read_group();
+        realm2->read_group();
+        auto table = ObjectStore::table_for_object_type(realm->read_group(), "object");
+        auto col_keys = table->get_column_keys();
+
+        {
+            auto write_realm = Realm::get_shared_realm(config);
+            write_realm->begin_transaction();
+            auto table = ObjectStore::table_for_object_type(write_realm->read_group(), "object");
+            table->add_column(type_Double, "newcol");
+            write_realm->commit_transaction();
+        }
+
+        // Before refreshing when we haven't seen the new version at all
+        auto frozen = realm->freeze();
+        REQUIRE(frozen->schema() == schema);
+        REQUIRE(frozen->schema().find("object")->persisted_properties[0].column_key == col_keys[0]);
+        REQUIRE(frozen->schema().find("object")->persisted_properties[1].column_key == col_keys[1]);
+        frozen = Realm::get_frozen_realm(config, realm->read_transaction_version());
+        REQUIRE(frozen->schema() == schema);
+        REQUIRE(frozen->schema().find("object")->persisted_properties[0].column_key == col_keys[0]);
+        REQUIRE(frozen->schema().find("object")->persisted_properties[1].column_key == col_keys[1]);
+
+        // Refresh the other instance so that the schema cache is updated, and
+        // then repeat
+        realm2->refresh();
+
+        frozen = realm->freeze();
+        REQUIRE(frozen->schema() == schema);
+        REQUIRE(frozen->schema().find("object")->persisted_properties[0].column_key == col_keys[0]);
+        REQUIRE(frozen->schema().find("object")->persisted_properties[1].column_key == col_keys[1]);
+        frozen = Realm::get_frozen_realm(config, realm->read_transaction_version());
+        REQUIRE(frozen->schema() == schema);
+        REQUIRE(frozen->schema().find("object")->persisted_properties[0].column_key == col_keys[0]);
+        REQUIRE(frozen->schema().find("object")->persisted_properties[1].column_key == col_keys[1]);
     }
 
     SECTION("can have different subsets of columns in different Realm instances") {
@@ -2671,11 +2501,11 @@ TEST_CASE("migration: Additive") {
         auto realm3 = Realm::get_shared_realm(config3);
         REQUIRE(realm->schema().find("object")->persisted_properties.size() == 2);
         REQUIRE(realm2->schema().find("object")->persisted_properties.size() == 3);
-        REQUIRE(realm3->schema().find("object")->persisted_properties.size() == 3);
+        REQUIRE(realm3->schema().find("object")->persisted_properties.size() == 1);
 
         realm->refresh();
         realm2->refresh();
-        REQUIRE(realm->schema().find("object")->persisted_properties.size() == 3);
+        REQUIRE(realm->schema().find("object")->persisted_properties.size() == 2);
         REQUIRE(realm2->schema().find("object")->persisted_properties.size() == 3);
 
         // No schema specified; should see all of them
@@ -2722,7 +2552,7 @@ TEST_CASE("migration: Additive") {
         REQUIRE_THROWS_CONTAINING(
             realm->update_schema(add_property(schema, "object", {"value 3", PropertyType::Float})),
             "Property 'object.value 3' has been changed from 'int' to 'float'.");
-        REQUIRE(realm->schema().find("object")->persisted_properties.size() == 3);
+        REQUIRE(realm->schema().find("object")->persisted_properties.size() == 2);
     }
 
     SECTION("update_schema() does not begin a write transaction when extra columns are present") {


### PR DESCRIPTION
Rather than tying this to the Additive schema mode, make it an option which can be used with all applicable schema modes. It turns out that adding additional properties to the end of persisted_properties does cause problems, as it makes `Object::create()` expect values for those properties. However, we do (sometimes) want the additional tables to be added to the schema and not just in Additive mode, so that's a separate option.

This also fixes several bugs in the implementation which would result in it failing to actually have a complete view of the schema in some cases, and could result in frozen Realms having an incorrect schema.

This also incidentally improves the performance of freezing Realms as part of the fix for the schema management and fixes a few race conditions related to cached frozen Realms.