### PR TITLE
Client reset w/recovery can throw a MultipleSyncAgents if interrupted during the fresh realm download

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@
 * Fixed diverging history in flexible sync if writes occur during bootstrap to objects that just came into view ([#5804](https://github.com/realm/realm-core/issues/5804), since v11.7.0)
 * Fix several data races when opening cached frozen Realms. New frozen Realms were added to the cache and the lock released before they were fully initialized, resulting in races if they were immediately read from the cache on another thread ([PR #6211](https://github.com/realm/realm-core/pull/6211), since v6.0.0).
 * Properties and types not present in the requested schema would be missing from the reported schema in several scenarios, such as if the Realm was being opened with a different schema version than the persisted one, and if the new tables or columns were added while the Realm instance did not have an active read transaction ([PR #6211](https://github.com/realm/realm-core/pull/6211), since v13.2.0).
+* If a client reset w/recovery or discard local is interrupted while the "fresh" realm is being downloaded, the sync client may crash with a MultpleSyncAgents exception ([#6217](https://github.com/realm/realm-core/issues/6217), since v11.13.0)
 
 ### Breaking changes
 * `SyncSession::log_out()` has been renamed to `SyncSession::force_close()` to reflect what it actually does ([#6183](https://github.com/realm/realm-core/pull/6183))

--- a/src/realm/object-store/sync/sync_session.hpp
+++ b/src/realm/object-store/sync/sync_session.hpp
@@ -347,7 +347,7 @@ private:
 
     void download_fresh_realm(sync::ProtocolErrorInfo::Action server_requests_action)
         REQUIRES(!m_config_mutex, !m_state_mutex, !m_connection_state_mutex);
-    void handle_fresh_realm_downloaded(DBRef db, util::Optional<std::string> error_message,
+    void handle_fresh_realm_downloaded(DBRef db, Status status,
                                        sync::ProtocolErrorInfo::Action server_requests_action)
         REQUIRES(!m_state_mutex, !m_config_mutex, !m_connection_state_mutex);
     void handle_error(SyncError) REQUIRES(!m_state_mutex, !m_config_mutex, !m_connection_state_mutex);

--- a/test/object-store/sync/client_reset.cpp
+++ b/test/object-store/sync/client_reset.cpp
@@ -140,11 +140,6 @@ TEST_CASE("sync: large reset with recovery is restartable", "[client reset]") {
             return;
         }
 
-        if (err.error_code == sync::ClientError::auto_client_reset_failure &&
-            err.message == "A fatal error occured during client reset: 'Operation canceled'") {
-            return;
-        }
-
         FAIL(util::format("got error from server: %1: %2", err.error_code.value(), err.message));
     };
 


### PR DESCRIPTION
## What, How & Why?
This changes the `SyncSession::download_fresh_realm()` function to use the `SyncManager` to handle the lifetime of the sync session of the fresh realm. This should make it so that if we need to re-open the fresh realm after an aborted attempt, there should already be a `SyncSession` available to re-use (and we won't accidentally try to open a new sync session that will conflict with any existing ones).

## ☑️ ToDos
* [x] 📝 Changelog update
* [x] 🚦 Tests (or not relevant)
* [ ] C-API, if public C++ API changed.
