### PR TITLE
Update Connection and DefaultWebSocketImpl to use the new WebSocketObserver callbacks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,7 @@
 * Fix failures in Metrics_TransactionTimings core test ([#6164](https://github.com/realm/realm-core/issues/6164))
 * Make log level threshold atomic and shared ([#6009](https://github.com/realm/realm-core/issues/6009))
 * Add c_api error category for resolve errors instead of reporting unknown category, part 2. ([PR #6186](https://github.com/realm/realm-core/pull/6186))
+* Update ClientImpl::Connection and DefaultWebSocketImpl to use the new WebSocketObserver callbacks ([PR #6219](https://github.com/realm/realm-core/pull/6219))
 
 ----------------------------------------------
 

--- a/src/realm/error_codes.cpp
+++ b/src/realm/error_codes.cpp
@@ -41,6 +41,10 @@ StringData ErrorCodes::error_string(Error code)
             return "ResolveFailed";
         case ErrorCodes::ConnectionFailed:
             return "ConnectionFailed";
+        case ErrorCodes::Retry:
+            return "Retry";
+        case ErrorCodes::Fatal:
+            return "Fatal";
 
         /// WebSocket error codes
         case ErrorCodes::WebSocket_GoingAway:

--- a/src/realm/error_codes.cpp
+++ b/src/realm/error_codes.cpp
@@ -91,7 +91,7 @@ StringData ErrorCodes::error_string(Error code)
 
 namespace {
 
-class CloseStatusErrorCategory : public std::error_category {
+class StatusErrorCategory : public std::error_category {
     const char* name() const noexcept final
     {
         return "realm::sync::websocket::CloseStatus";
@@ -109,15 +109,15 @@ class CloseStatusErrorCategory : public std::error_category {
 
 } // unnamed namespace
 
-const std::error_category& websocket_close_status_category() noexcept
+const std::error_category& close_status_category() noexcept
 {
-    static const CloseStatusErrorCategory category = {};
+    static const StatusErrorCategory category = {};
     return category;
 }
 
 std::error_code make_error_code(ErrorCodes::Error error) noexcept
 {
-    return std::error_code{error, websocket_close_status_category()};
+    return std::error_code{error, close_status_category()};
 }
 
 } // namespace realm

--- a/src/realm/error_codes.cpp
+++ b/src/realm/error_codes.cpp
@@ -41,10 +41,10 @@ StringData ErrorCodes::error_string(Error code)
             return "ResolveFailed";
         case ErrorCodes::ConnectionFailed:
             return "ConnectionFailed";
-        case ErrorCodes::Retry:
-            return "Retry";
-        case ErrorCodes::Fatal:
-            return "Fatal";
+        case ErrorCodes::WebSocket_Retry_Error:
+            return "WebSocket: Retry Error";
+        case ErrorCodes::WebSocket_Fatal_Error:
+            return "WebSocket: Fatal Error";
 
         /// WebSocket error codes
         case ErrorCodes::WebSocket_GoingAway:
@@ -91,37 +91,6 @@ StringData ErrorCodes::error_string(Error code)
         default:
             return "UnknownError";
     }
-}
-
-namespace {
-
-class StatusErrorCategory : public std::error_category {
-    const char* name() const noexcept final
-    {
-        return "realm::sync::websocket::CloseStatus";
-    }
-    std::string message(int error_code) const final
-    {
-        // Converts an error_code to one of the pre-defined status codes in
-        // https://tools.ietf.org/html/rfc6455#section-7.4.1
-        if (error_code == 1000 || error_code == 0) {
-            return ErrorCodes::error_string(ErrorCodes::OK);
-        }
-        return ErrorCodes::error_string(static_cast<ErrorCodes::Error>(error_code));
-    }
-};
-
-} // unnamed namespace
-
-const std::error_category& close_status_category() noexcept
-{
-    static const StatusErrorCategory category = {};
-    return category;
-}
-
-std::error_code make_error_code(ErrorCodes::Error error) noexcept
-{
-    return std::error_code{error, close_status_category()};
 }
 
 } // namespace realm

--- a/src/realm/error_codes.hpp
+++ b/src/realm/error_codes.hpp
@@ -63,13 +63,12 @@ public:
         WebSocket_Client_Too_Old = 4004,
         WebSocket_Client_Too_New = 4005,
         WebSocket_Protocol_Mismatch = 4006,
-        WebSocket_5xx_Server_Errors = 4007,
     };
 
     static StringData error_string(Error code);
 };
 
-const std::error_category& websocket_close_status_category() noexcept;
+const std::error_category& close_status_category() noexcept;
 std::error_code make_error_code(ErrorCodes::Error) noexcept;
 
 } // namespace realm

--- a/src/realm/error_codes.hpp
+++ b/src/realm/error_codes.hpp
@@ -36,6 +36,10 @@ public:
         LogicError = 3,
         BrokenPromise = 4,
         OperationAborted = 5,
+        ReadError = 7,
+        WriteError = 8,
+        ResolveFailed = 9,
+        ConnectionFailed = 10,
 
         /// WebSocket Errors
         // WebSocket_OK = 1000 is not used, just use OK instead
@@ -51,9 +55,21 @@ public:
         WebSocket_InavalidExtension = 1010,
         WebSocket_InternalServerError = 1011,
         WebSocket_TLSHandshakeFailed = 1015, // Used by default WebSocket
+
+        /// WebSocket Errors - reported by server
+        WebSocket_Unauthorized = 4001,
+        WebSocket_Forbidden = 4002,
+        WebSocket_MovedPermanently = 4003,
+        WebSocket_Client_Too_Old = 4004,
+        WebSocket_Client_Too_New = 4005,
+        WebSocket_Protocol_Mismatch = 4006,
+        WebSocket_5xx_Server_Errors = 4007,
     };
 
     static StringData error_string(Error code);
 };
+
+const std::error_category& websocket_close_status_category() noexcept;
+std::error_code make_error_code(ErrorCodes::Error) noexcept;
 
 } // namespace realm

--- a/src/realm/error_codes.hpp
+++ b/src/realm/error_codes.hpp
@@ -40,6 +40,8 @@ public:
         WriteError = 8,
         ResolveFailed = 9,
         ConnectionFailed = 10,
+        Retry = 11,
+        Fatal = 12,
 
         /// WebSocket Errors
         // WebSocket_OK = 1000 is not used, just use OK instead
@@ -69,6 +71,7 @@ public:
 };
 
 const std::error_category& close_status_category() noexcept;
+
 std::error_code make_error_code(ErrorCodes::Error) noexcept;
 
 } // namespace realm

--- a/src/realm/error_codes.hpp
+++ b/src/realm/error_codes.hpp
@@ -40,8 +40,8 @@ public:
         WriteError = 8,
         ResolveFailed = 9,
         ConnectionFailed = 10,
-        Retry = 11,
-        Fatal = 12,
+        WebSocket_Retry_Error = 11,
+        WebSocket_Fatal_Error = 12,
 
         /// WebSocket Errors
         // WebSocket_OK = 1000 is not used, just use OK instead
@@ -69,9 +69,5 @@ public:
 
     static StringData error_string(Error code);
 };
-
-const std::error_category& close_status_category() noexcept;
-
-std::error_code make_error_code(ErrorCodes::Error) noexcept;
 
 } // namespace realm

--- a/src/realm/object-store/c_api/socket_provider.cpp
+++ b/src/realm/object-store/c_api/socket_provider.cpp
@@ -123,17 +123,6 @@ public:
         return m_observer.websocket_closed_handler(was_clean, status);
     }
 
-    // DEPRECATED
-    void websocket_connect_error_handler(std::error_code) final {}
-    void websocket_ssl_handshake_error_handler(std::error_code) final {}
-    void websocket_read_or_write_error_handler(std::error_code) final {}
-    void websocket_handshake_error_handler(std::error_code, const std::string_view*) final {}
-    void websocket_protocol_error_handler(std::error_code) final {}
-    bool websocket_close_message_received(std::error_code, StringData) final
-    {
-        return false;
-    }
-
 private:
     sync::WebSocketObserver& m_observer;
 };

--- a/src/realm/object-store/sync/sync_session.cpp
+++ b/src/realm/object-store/sync/sync_session.cpp
@@ -652,7 +652,9 @@ void SyncSession::handle_error(SyncError error)
         // is disabled. In this scenario we attempt an automatic token refresh and if that succeeds continue as
         // normal. If the refresh request also fails with 401 then we need to stop retrying and pass along the error;
         // see handle_refresh().
-        if (error_code == sync::websocket::make_error_code(sync::websocket::Error::bad_response_401_unauthorized)) {
+        if (error_code.category() == websocket_close_status_category() &&
+            (error_code.value() == ErrorCodes::WebSocket_Unauthorized ||
+             error_code.value() == ErrorCodes::WebSocket_AbnormalClosure)) {
             if (auto u = user()) {
                 u->refresh_custom_data(handle_refresh(shared_from_this()));
                 return;

--- a/src/realm/object-store/sync/sync_session.cpp
+++ b/src/realm/object-store/sync/sync_session.cpp
@@ -662,7 +662,7 @@ void SyncSession::handle_error(SyncError error)
         // is disabled. In this scenario we attempt an automatic token refresh and if that succeeds continue as
         // normal. If the refresh request also fails with 401 then we need to stop retrying and pass along the error;
         // see handle_refresh().
-        if (error_code.category() == close_status_category() &&
+        if (error_code.category() == sync::websocket::websocket_close_status_category() &&
             (error_code.value() == ErrorCodes::WebSocket_Unauthorized ||
              error_code.value() == ErrorCodes::WebSocket_AbnormalClosure ||
              error_code.value() == ErrorCodes::WebSocket_MovedPermanently)) {

--- a/src/realm/object-store/sync/sync_session.cpp
+++ b/src/realm/object-store/sync/sync_session.cpp
@@ -652,9 +652,10 @@ void SyncSession::handle_error(SyncError error)
         // is disabled. In this scenario we attempt an automatic token refresh and if that succeeds continue as
         // normal. If the refresh request also fails with 401 then we need to stop retrying and pass along the error;
         // see handle_refresh().
-        if (error_code.category() == websocket_close_status_category() &&
+        if (error_code.category() == close_status_category() &&
             (error_code.value() == ErrorCodes::WebSocket_Unauthorized ||
-             error_code.value() == ErrorCodes::WebSocket_AbnormalClosure)) {
+             error_code.value() == ErrorCodes::WebSocket_AbnormalClosure ||
+             error_code.value() == ErrorCodes::WebSocket_MovedPermanently)) {
             if (auto u = user()) {
                 u->refresh_custom_data(handle_refresh(shared_from_this()));
                 return;

--- a/src/realm/sync/network/default_socket.cpp
+++ b/src/realm/sync/network/default_socket.cpp
@@ -92,7 +92,7 @@ private:
             error = ErrorCodes::WebSocket_MovedPermanently;
         }
         else if (ec == websocket::Error::bad_response_3xx_redirection) {
-            error = ErrorCodes::Retry;
+            error = ErrorCodes::WebSocket_Retry_Error;
             was_clean = false;
         }
         else if (ec == websocket::Error::bad_response_401_unauthorized) {
@@ -110,7 +110,7 @@ private:
             was_clean = false;
         }
         else {
-            error = ErrorCodes::Fatal;
+            error = ErrorCodes::WebSocket_Fatal_Error;
             was_clean = false;
             if (body) {
                 std::string_view identifier = "REALM_SYNC_PROTOCOL_MISMATCH";

--- a/src/realm/sync/network/default_socket.cpp
+++ b/src/realm/sync/network/default_socket.cpp
@@ -65,25 +65,84 @@ private:
     void websocket_read_error_handler(std::error_code ec) override
     {
         m_logger.error("Reading failed: %1", ec.message()); // Throws
-        m_observer.websocket_read_or_write_error_handler(ec);
+        constexpr bool was_clean = false;
+        websocket_error_and_close_handler(was_clean, Status{ErrorCodes::ReadError, ec.message()});
     }
     void websocket_write_error_handler(std::error_code ec) override
     {
         m_logger.error("Writing failed: %1", ec.message()); // Throws
-        m_observer.websocket_read_or_write_error_handler(ec);
+        constexpr bool was_clean = false;
+        websocket_error_and_close_handler(was_clean, Status{ErrorCodes::WriteError, ec.message()});
     }
     void websocket_handshake_error_handler(std::error_code ec, const HTTPHeaders*,
                                            const std::string_view* body) override
     {
-        m_observer.websocket_handshake_error_handler(ec, body);
+        ErrorCodes::Error error;
+
+        if (ec == websocket::Error::bad_response_3xx_redirection ||
+            ec == websocket::Error::bad_response_301_moved_permanently) {
+            error = ErrorCodes::WebSocket_MovedPermanently;
+        }
+        else if (ec == websocket::Error::bad_response_401_unauthorized) {
+            error = ErrorCodes::WebSocket_Unauthorized;
+        }
+        else if (ec == websocket::Error::bad_response_403_forbidden) {
+            error = ErrorCodes::WebSocket_Forbidden;
+        }
+        else if (ec == websocket::Error::bad_response_5xx_server_error ||
+                 ec == websocket::Error::bad_response_500_internal_server_error ||
+                 ec == websocket::Error::bad_response_502_bad_gateway ||
+                 ec == websocket::Error::bad_response_503_service_unavailable ||
+                 ec == websocket::Error::bad_response_504_gateway_timeout) {
+            error = ErrorCodes::WebSocket_5xx_Server_Errors;
+        }
+        else {
+            error = ErrorCodes::WebSocket_Protocol_Mismatch;
+            if (body) {
+                std::string_view identifier = "REALM_SYNC_PROTOCOL_MISMATCH";
+                auto i = body->find(identifier);
+                if (i != std::string_view::npos) {
+                    std::string_view rest = body->substr(i + identifier.size());
+                    // FIXME: Use std::string_view::begins_with() in C++20.
+                    auto begins_with = [](std::string_view string, std::string_view prefix) {
+                        return (string.size() >= prefix.size() &&
+                                std::equal(string.data(), string.data() + prefix.size(), prefix.data()));
+                    };
+                    if (begins_with(rest, ":CLIENT_TOO_OLD")) {
+                        error = ErrorCodes::WebSocket_Client_Too_Old;
+                    }
+                    else if (begins_with(rest, ":CLIENT_TOO_NEW")) {
+                        error = ErrorCodes::WebSocket_Client_Too_Old;
+                    }
+                }
+            }
+        }
+
+        constexpr bool was_clean = false;
+        websocket_error_and_close_handler(was_clean, Status{error, ec.message()});
     }
     void websocket_protocol_error_handler(std::error_code ec) override
     {
-        m_observer.websocket_protocol_error_handler(ec);
+        constexpr bool was_clean = false;
+        websocket_error_and_close_handler(was_clean, Status{ErrorCodes::WebSocket_ProtocolError, ec.message()});
     }
     bool websocket_close_message_received(std::error_code ec, StringData message) override
     {
-        return m_observer.websocket_close_message_received(ec, message);
+        constexpr bool was_clean = true;
+
+        // Normal closure.
+        if (ec.value() == 1000) {
+            return websocket_error_and_close_handler(was_clean, Status::OK());
+        }
+        return websocket_error_and_close_handler(was_clean,
+                                                 Status{static_cast<ErrorCodes::Error>(ec.value()), message});
+    }
+    bool websocket_error_and_close_handler(bool was_clean, Status status)
+    {
+        if (!was_clean) {
+            m_observer.websocket_error_handler();
+        }
+        return m_observer.websocket_closed_handler(was_clean, status);
     }
     bool websocket_binary_message_received(const char* ptr, std::size_t size) override
     {
@@ -95,7 +154,6 @@ private:
     void initiate_tcp_connect(network::Endpoint::List, std::size_t);
     void handle_tcp_connect(std::error_code, network::Endpoint::List, std::size_t);
     void initiate_http_tunnel();
-    void handle_http_tunnel(std::error_code);
     void initiate_websocket_or_ssl_handshake();
     void initiate_ssl_handshake();
     void handle_ssl_handshake(std::error_code);
@@ -191,7 +249,8 @@ void DefaultWebSocketImpl::handle_resolve(std::error_code ec, network::Endpoint:
 {
     if (ec) {
         m_logger.error("Failed to resolve '%1:%2': %3", m_endpoint.address, m_endpoint.port, ec.message()); // Throws
-        m_observer.websocket_connect_error_handler(ec);                                                     // Throws
+        constexpr bool was_clean = false;
+        websocket_error_and_close_handler(was_clean, Status{ErrorCodes::ResolveFailed, ec.message()}); // Throws
         return;
     }
 
@@ -230,7 +289,8 @@ void DefaultWebSocketImpl::handle_tcp_connect(std::error_code ec, network::Endpo
         }
         // All endpoints failed
         m_logger.error("Failed to connect to '%1:%2': All endpoints failed", m_endpoint.address, m_endpoint.port);
-        m_observer.websocket_connect_error_handler(ec); // Throws
+        constexpr bool was_clean = false;
+        websocket_error_and_close_handler(was_clean, Status{ErrorCodes::ConnectionFailed, ec.message()}); // Throws
         return;
     }
 
@@ -269,15 +329,17 @@ void DefaultWebSocketImpl::initiate_http_tunnel()
     auto handler = [this](HTTPResponse response, std::error_code ec) {
         if (ec && ec != util::error::operation_aborted) {
             m_logger.error("Failed to establish HTTP tunnel: %1", ec.message());
-            m_observer.websocket_connect_error_handler(ec); // Throws
+            constexpr bool was_clean = false;
+            websocket_error_and_close_handler(was_clean,
+                                              Status{ErrorCodes::ConnectionFailed, ec.message()}); // Throws
             return;
         }
 
         if (response.status != HTTPStatus::Ok) {
             m_logger.error("Proxy server returned response '%1 %2'", response.status, response.reason); // Throws
-            std::error_code ec2 =
-                websocket::Error::bad_response_unexpected_status_code;       // FIXME: is this the right error?
-            m_observer.websocket_connect_error_handler(ec2);                 // Throws
+            constexpr bool was_clean = false;
+            websocket_error_and_close_handler(was_clean,
+                                              Status{ErrorCodes::ConnectionFailed, response.reason}); // Throws
             return;
         }
 
@@ -339,7 +401,9 @@ void DefaultWebSocketImpl::handle_ssl_handshake(std::error_code ec)
 {
     if (ec) {
         REALM_ASSERT(ec != util::error::operation_aborted);
-        m_observer.websocket_ssl_handshake_error_handler(ec); // Throws
+        constexpr bool was_clean = false;
+        websocket_error_and_close_handler(was_clean,
+                                          Status{ErrorCodes::WebSocket_TLSHandshakeFailed, ec.message()}); // Throws
         return;
     }
 

--- a/src/realm/sync/network/websocket.cpp
+++ b/src/realm/sync/network/websocket.cpp
@@ -945,7 +945,7 @@ private:
             error_message = StringData(data + 2, size - 2);
         }
 
-        std::error_code error_code_with_category{error_code, websocket::websocket_close_status_category()};
+        std::error_code error_code_with_category{error_code, websocket_close_status_category()};
         return std::make_pair(error_code_with_category, error_message);
     }
 
@@ -1096,48 +1096,6 @@ public:
 
 ErrorCategoryImpl g_error_category;
 
-class CloseStatusErrorCategory : public std::error_category {
-    const char* name() const noexcept final
-    {
-        return "realm::sync::websocket::CloseStatus";
-    }
-    std::string message(int error_code) const final
-    {
-        // Converts an error_code to one of the pre-defined status codes in
-        // https://tools.ietf.org/html/rfc6455#section-7.4.1
-        switch (error_code) {
-            case 1000:
-                return "normal closure";
-            case 1001:
-                return "endpoint going away";
-            case 1002:
-                return "protocol error";
-            case 1003:
-                return "invalid data type";
-            case 1004:
-                return "reserved";
-            case 1005:
-                return "no status code present";
-            case 1006:
-                return "no close control frame sent";
-            case 1007:
-                return "message data type mis-match";
-            case 1008:
-                return "policy violation";
-            case 1009:
-                return "message too big";
-            case 1010:
-                return "missing extension";
-            case 1011:
-                return "unexpected error";
-            case 1015:
-                return "TLS handshake failure";
-            default:
-                return "unknown error";
-        };
-    }
-};
-
 } // unnamed namespace
 
 
@@ -1257,12 +1215,6 @@ util::Optional<HTTPResponse> websocket::make_http_response(const HTTPRequest& re
 const std::error_category& websocket::error_category() noexcept
 {
     return g_error_category;
-}
-
-const std::error_category& websocket::websocket_close_status_category() noexcept
-{
-    static const CloseStatusErrorCategory category = {};
-    return category;
 }
 
 std::error_code websocket::make_error_code(Error error_code) noexcept

--- a/src/realm/sync/network/websocket.cpp
+++ b/src/realm/sync/network/websocket.cpp
@@ -770,6 +770,8 @@ private:
             ec = Error::bad_response_2xx_successful;
         else if (status_code == 301)
             ec = Error::bad_response_301_moved_permanently;
+        else if (status_code == 308)
+            ec = Error::bad_response_308_permanent_redirect;
         else if (status_code >= 300 && status_code < 400)
             ec = Error::bad_response_3xx_redirection;
         else if (status_code == 401)
@@ -945,7 +947,7 @@ private:
             error_message = StringData(data + 2, size - 2);
         }
 
-        std::error_code error_code_with_category{error_code, websocket_close_status_category()};
+        std::error_code error_code_with_category{error_code, close_status_category()};
         return std::make_pair(error_code_with_category, error_message);
     }
 
@@ -1047,6 +1049,8 @@ const char* get_error_message(Error error_code)
             return "Bad WebSocket response 3xx redirection";
         case Error::bad_response_301_moved_permanently:
             return "Bad WebSocket response 301 moved permanently";
+        case Error::bad_response_308_permanent_redirect:
+            return "Bad WebSocket response 308 permanent redirect";
         case Error::bad_response_4xx_client_errors:
             return "Bad WebSocket response 4xx client errors";
         case Error::bad_response_401_unauthorized:

--- a/src/realm/sync/network/websocket.hpp
+++ b/src/realm/sync/network/websocket.hpp
@@ -197,6 +197,7 @@ enum class Error {
     bad_response_200_ok,
     bad_response_3xx_redirection,
     bad_response_301_moved_permanently,
+    bad_response_308_permanent_redirect,
     bad_response_4xx_client_errors,
     bad_response_401_unauthorized,
     bad_response_403_forbidden,
@@ -211,8 +212,6 @@ enum class Error {
     bad_response_header_protocol_violation,
     bad_message
 };
-
-const std::error_category& websocket_close_status_category() noexcept;
 
 const std::error_category& error_category() noexcept;
 

--- a/src/realm/sync/network/websocket.hpp
+++ b/src/realm/sync/network/websocket.hpp
@@ -213,6 +213,10 @@ enum class Error {
     bad_message
 };
 
+const std::error_category& websocket_close_status_category() noexcept;
+
+std::error_code make_error_code(ErrorCodes::Error error) noexcept;
+
 const std::error_category& error_category() noexcept;
 
 std::error_code make_error_code(Error) noexcept;

--- a/src/realm/sync/noinst/client_impl_base.cpp
+++ b/src/realm/sync/noinst/client_impl_base.cpp
@@ -386,65 +386,6 @@ void Connection::websocket_connected_handler(const std::string& protocol)
 }
 
 
-void Connection::websocket_read_or_write_error_handler(std::error_code ec)
-{
-    read_or_write_error(ec); // Throws
-}
-
-
-void Connection::websocket_handshake_error_handler(std::error_code ec, const std::string_view* body)
-{
-    bool is_fatal;
-    if (ec == websocket::Error::bad_response_3xx_redirection ||
-        ec == websocket::Error::bad_response_301_moved_permanently ||
-        ec == websocket::Error::bad_response_401_unauthorized ||
-        ec == websocket::Error::bad_response_5xx_server_error ||
-        ec == websocket::Error::bad_response_500_internal_server_error ||
-        ec == websocket::Error::bad_response_502_bad_gateway ||
-        ec == websocket::Error::bad_response_503_service_unavailable ||
-        ec == websocket::Error::bad_response_504_gateway_timeout) {
-        is_fatal = false;
-        m_reconnect_info.m_reason = ConnectionTerminationReason::http_response_says_nonfatal_error;
-    }
-    else {
-        is_fatal = true;
-        m_reconnect_info.m_reason = ConnectionTerminationReason::http_response_says_fatal_error;
-        if (body) {
-            std::string_view identifier = "REALM_SYNC_PROTOCOL_MISMATCH";
-            auto i = body->find(identifier);
-            if (i != std::string_view::npos) {
-                std::string_view rest = body->substr(i + identifier.size());
-                // FIXME: Use std::string_view::begins_with() in C++20.
-                auto begins_with = [](std::string_view string, std::string_view prefix) {
-                    return (string.size() >= prefix.size() &&
-                            std::equal(string.data(), string.data() + prefix.size(), prefix.data()));
-                };
-                if (begins_with(rest, ":CLIENT_TOO_OLD")) {
-                    ec = ClientError::client_too_old_for_server;
-                }
-                else if (begins_with(rest, ":CLIENT_TOO_NEW")) {
-                    ec = ClientError::client_too_new_for_server;
-                }
-                else {
-                    // Other more complicated forms of mismatch
-                    ec = ClientError::protocol_mismatch;
-                }
-            }
-        }
-    }
-
-    close_due_to_client_side_error(ec, std::nullopt, is_fatal); // Throws
-}
-
-
-void Connection::websocket_protocol_error_handler(std::error_code ec)
-{
-    m_reconnect_info.m_reason = ConnectionTerminationReason::websocket_protocol_violation;
-    bool is_fatal = true;                                       // A WebSocket protocol violation is a fatal error
-    close_due_to_client_side_error(ec, std::nullopt, is_fatal); // Throws
-}
-
-
 bool Connection::websocket_binary_message_received(util::Span<const char> data)
 {
     std::error_code ec;
@@ -459,30 +400,79 @@ bool Connection::websocket_binary_message_received(util::Span<const char> data)
 }
 
 
-bool Connection::websocket_close_message_received(std::error_code error_code, StringData message)
+void Connection::websocket_error_handler()
 {
-    if (error_code.category() == websocket::websocket_close_status_category() && error_code.value() != 1005 &&
-        error_code.value() != 1000) {
-        m_reconnect_info.m_reason = ConnectionTerminationReason::websocket_protocol_violation;
+    m_error_received = true;
+}
 
+
+bool Connection::websocket_closed_handler(bool was_clean, Status status)
+{
+    logger.info("Closing the websocket with status='%1', was_clean='%2'", status, was_clean);
+    auto&& status_code = status.code();
+    std::error_code error_code{static_cast<int>(status_code), websocket_close_status_category()};
+
+    // TODO: Use a switch statement once websocket errors have their own category in exception unification.
+    if (status_code == ErrorCodes::ResolveFailed || status_code == ErrorCodes::ConnectionFailed) {
+        m_reconnect_info.m_reason = ConnectionTerminationReason::connect_operation_failed;
         constexpr bool try_again = true;
-        SessionErrorInfo error_info{error_code, message, try_again};
-
-        // If the server sends a websocket close message with code 1009, then it's because we've sent an
-        // UPLOAD message that is too large for the server to process. Simply disconnecting/reconnecting will not
-        // be sufficient because when we re-connect we'll just try to send the same bad upload message.
-        //
-        // Since the handling of this error happens at a layer below the standard `ERROR` message handling
-        // we need to synthesize an `ERROR` message-like error info here to client reset when this error
-        // is received.
-        if (error_code.value() == 1009) {
-            error_info.error_code = make_error_code(ProtocolError::limits_exceeded);
-            error_info.server_requests_action = ProtocolErrorInfo::Action::ClientReset;
-            error_info.message = util::format(
-                "Sync websocket closed because the server received a message that was too large: %1", message);
-        }
-
+        involuntary_disconnect(SessionErrorInfo{error_code, try_again}); // Throws
+    }
+    else if (status_code == ErrorCodes::ReadError || status_code == ErrorCodes::WriteError) {
+        read_or_write_error(error_code);
+    }
+    else if (status_code == ErrorCodes::WebSocket_GoingAway || status_code == ErrorCodes::WebSocket_ProtocolError ||
+             status_code == ErrorCodes::WebSocket_UnsupportedData || status_code == ErrorCodes::WebSocket_Reserved ||
+             status_code == ErrorCodes::WebSocket_AbnormalClosure ||
+             status_code == ErrorCodes::WebSocket_InvalidPayloadData ||
+             status_code == ErrorCodes::WebSocket_PolicyViolation ||
+             status_code == ErrorCodes::WebSocket_InavalidExtension ||
+             status_code == ErrorCodes::WebSocket_InternalServerError) {
+        m_reconnect_info.m_reason = ConnectionTerminationReason::websocket_protocol_violation;
+        constexpr bool try_again = true;
+        SessionErrorInfo error_info{error_code, status.reason(), try_again};
         involuntary_disconnect(std::move(error_info));
+    }
+    else if (status_code == ErrorCodes::WebSocket_MessageTooBig) {
+        m_reconnect_info.m_reason = ConnectionTerminationReason::websocket_protocol_violation;
+        constexpr bool try_again = true;
+        auto ec = make_error_code(ProtocolError::limits_exceeded);
+        auto message = util::format(
+            "Sync websocket closed because the server received a message that was too large: %1", status.reason());
+        SessionErrorInfo error_info(ec, message, try_again);
+        error_info.server_requests_action = ProtocolErrorInfo::Action::ClientReset;
+        involuntary_disconnect(std::move(error_info));
+    }
+    else if (status_code == ErrorCodes::WebSocket_TLSHandshakeFailed) {
+        error_code = ClientError::ssl_server_cert_rejected;
+        constexpr bool is_fatal = true;
+        m_reconnect_info.m_reason = ConnectionTerminationReason::ssl_certificate_rejected;
+        close_due_to_client_side_error(error_code, std::nullopt, is_fatal); // Throws
+    }
+    else if (status_code == ErrorCodes::WebSocket_Client_Too_Old) {
+        error_code = ClientError::client_too_old_for_server;
+        constexpr bool is_fatal = true;
+        m_reconnect_info.m_reason = ConnectionTerminationReason::http_response_says_fatal_error;
+        close_due_to_client_side_error(error_code, std::nullopt, is_fatal); // Throws
+    }
+    else if (status_code == ErrorCodes::WebSocket_Client_Too_New) {
+        error_code = ClientError::client_too_new_for_server;
+        constexpr bool is_fatal = true;
+        m_reconnect_info.m_reason = ConnectionTerminationReason::http_response_says_fatal_error;
+        close_due_to_client_side_error(error_code, std::nullopt, is_fatal); // Throws
+    }
+    else if (status_code == ErrorCodes::WebSocket_Protocol_Mismatch) {
+        error_code = ClientError::protocol_mismatch;
+        constexpr bool is_fatal = true;
+        m_reconnect_info.m_reason = ConnectionTerminationReason::http_response_says_fatal_error;
+        close_due_to_client_side_error(error_code, std::nullopt, is_fatal); // Throws
+    }
+    else if (status_code == ErrorCodes::WebSocket_Unauthorized || status_code == ErrorCodes::WebSocket_Forbidden ||
+             status_code == ErrorCodes::WebSocket_MovedPermanently ||
+             status_code == ErrorCodes::WebSocket_5xx_Server_Errors) {
+        constexpr bool is_fatal = false;
+        m_reconnect_info.m_reason = ConnectionTerminationReason::http_response_says_nonfatal_error;
+        close_due_to_client_side_error(error_code, std::nullopt, is_fatal); // Throws
     }
 
     return bool(m_websocket);
@@ -700,6 +690,7 @@ void Connection::initiate_reconnect()
         }
     }
 
+    m_error_received = false;
     m_websocket = m_client.m_socket_provider->connect(
         this, WebSocketEndpoint{
                   m_address,
@@ -890,6 +881,10 @@ void Connection::handle_pong_timeout()
 
 void Connection::initiate_write_message(const OutputBuffer& out, Session* sess)
 {
+    // Stop sending messages if an error was received.
+    if (m_error_received)
+        return;
+
     m_websocket->async_write_binary(util::Span<const char>{out.data(), out.size()}, [this](Status status) {
         if (status == ErrorCodes::OperationAborted)
             return;
@@ -1043,36 +1038,6 @@ void Connection::handle_disconnect_wait(Status status)
 }
 
 
-void Connection::websocket_connect_error_handler(std::error_code ec)
-{
-    m_reconnect_info.m_reason = ConnectionTerminationReason::connect_operation_failed;
-    constexpr bool try_again = true;
-    involuntary_disconnect(SessionErrorInfo{ec, try_again}); // Throws
-}
-
-void Connection::websocket_ssl_handshake_error_handler(std::error_code ec)
-{
-    logger.error("SSL handshake failed: %1", ec.message()); // Throws
-    // FIXME: Some error codes (those from OpenSSL) most likely indicate a
-    // fatal error (SSL protocol violation), but other errors codes
-    // (read/write error from underlying socket) most likely indicate a
-    // nonfatal error.
-    bool is_fatal = false;
-    std::error_code ec2;
-    if (ec == network::ssl::Errors::certificate_rejected) {
-        m_reconnect_info.m_reason = ConnectionTerminationReason::ssl_certificate_rejected;
-        ec2 = ClientError::ssl_server_cert_rejected;
-        is_fatal = true;
-    }
-    else {
-        m_reconnect_info.m_reason = ConnectionTerminationReason::read_or_write_error;
-        ec2 = ec;
-        is_fatal = false;
-    }
-    close_due_to_client_side_error(ec2, std::nullopt, is_fatal); // Throws
-}
-
-
 void Connection::read_or_write_error(std::error_code ec)
 {
     m_reconnect_info.m_reason = ConnectionTerminationReason::read_or_write_error;
@@ -1086,15 +1051,6 @@ void Connection::close_due_to_protocol_error(std::error_code ec, std::optional<s
     m_reconnect_info.m_reason = ConnectionTerminationReason::sync_protocol_violation;
     bool is_fatal = true;                              // A sync protocol violation is a fatal error
     close_due_to_client_side_error(ec, msg, is_fatal); // Throws
-}
-
-
-void Connection::close_due_to_missing_protocol_feature()
-{
-    m_reconnect_info.m_reason = ConnectionTerminationReason::missing_protocol_feature;
-    std::error_code ec = ClientError::missing_protocol_feature;
-    bool is_fatal = true;                                       // A missing protocol feature is a fatal error
-    close_due_to_client_side_error(ec, std::nullopt, is_fatal); // Throws
 }
 
 

--- a/src/realm/sync/noinst/client_impl_base.hpp
+++ b/src/realm/sync/noinst/client_impl_base.hpp
@@ -550,7 +550,7 @@ private:
     // At least one PING message was sent since connection was established
     bool m_ping_sent = false;
 
-    bool m_error_received = false;
+    bool m_websocket_error_received = false;
 
     // The timer will be constructed on demand, and will only be destroyed when
     // canceling a reconnect or disconnect delay.

--- a/src/realm/sync/noinst/client_impl_base.hpp
+++ b/src/realm/sync/noinst/client_impl_base.hpp
@@ -398,21 +398,8 @@ public:
     // Methods from WebSocketObserver interface for websockets from the Socket Provider
     void websocket_connected_handler(const std::string& protocol) override;
     bool websocket_binary_message_received(util::Span<const char> data) override;
-    // Will be implemented when the functions below are removed
-    void websocket_error_handler() override {}
-    bool websocket_closed_handler(bool, Status) override
-    {
-        return false;
-    }
-
-    /// DEPRECATED - Will be removed in a future release
-    // Methods from WebsocketObserver that will be going away soon
-    void websocket_connect_error_handler(std::error_code) override;
-    void websocket_ssl_handshake_error_handler(std::error_code) override;
-    void websocket_read_or_write_error_handler(std::error_code) override;
-    void websocket_handshake_error_handler(std::error_code, const std::string_view*) override;
-    void websocket_protocol_error_handler(std::error_code) override;
-    bool websocket_close_message_received(std::error_code error_code, StringData message) override;
+    void websocket_error_handler() override;
+    bool websocket_closed_handler(bool, Status) override;
 
     connection_ident_type get_ident() const noexcept;
     const ServerEndpoint& get_server_endpoint() const noexcept;
@@ -482,7 +469,6 @@ private:
     void handle_disconnect_wait(Status status);
     void read_or_write_error(std::error_code);
     void close_due_to_protocol_error(std::error_code, std::optional<std::string_view> msg = std::nullopt);
-    void close_due_to_missing_protocol_feature();
     void close_due_to_client_side_error(std::error_code, std::optional<std::string_view> msg, bool is_fatal);
     void close_due_to_server_side_error(ProtocolError, const ProtocolErrorInfo& info);
     void voluntary_disconnect();
@@ -569,6 +555,8 @@ private:
 
     // At least one PING message was sent since connection was established
     bool m_ping_sent = false;
+
+    bool m_error_received = false;
 
     // The timer will be constructed on demand, and will only be destroyed when
     // canceling a reconnect or disconnect delay.

--- a/src/realm/sync/socket_provider.hpp
+++ b/src/realm/sync/socket_provider.hpp
@@ -248,17 +248,6 @@ struct WebSocketObserver {
     ///         is returned, the WebSocket object will be destroyed at some point
     ///         in the future.
     virtual bool websocket_closed_handler(bool was_clean, Status status) = 0;
-
-    //@{
-    /// DEPRECATED - Will be removed in a future release
-    /// These functions are deprecated and should not be called by custom socket provider implementations
-    virtual void websocket_connect_error_handler(std::error_code) = 0;
-    virtual void websocket_ssl_handshake_error_handler(std::error_code) = 0;
-    virtual void websocket_read_or_write_error_handler(std::error_code) = 0;
-    virtual void websocket_handshake_error_handler(std::error_code, const std::string_view* body) = 0;
-    virtual void websocket_protocol_error_handler(std::error_code) = 0;
-    virtual bool websocket_close_message_received(std::error_code error_code, StringData message) = 0;
-    //@}
 };
 
 } // namespace realm::sync

--- a/test/object-store/sync/client_reset.cpp
+++ b/test/object-store/sync/client_reset.cpp
@@ -131,7 +131,7 @@ TEST_CASE("sync: pending client resets are cleared when downloads are complete",
     SyncTestFile realm_config(app->current_user(), partition.value, schema);
     realm_config.sync_config->client_resync_mode = ClientResyncMode::Recover;
     realm_config.sync_config->error_handler = [&](std::shared_ptr<SyncSession>, SyncError err) {
-        if (err.error_code == util::make_error_code(util::MiscExtErrors::end_of_input)) {
+        if (err.error_code == make_error_code(ErrorCodes::ReadError)) {
             return;
         }
 

--- a/test/object-store/sync/client_reset.cpp
+++ b/test/object-store/sync/client_reset.cpp
@@ -29,6 +29,7 @@
 #include <realm/sync/noinst/client_reset.hpp>
 #include <realm/sync/noinst/client_reset_operation.hpp>
 #include <realm/sync/noinst/client_history_impl.hpp>
+#include <realm/sync/network/websocket.hpp>
 
 #include <realm/object-store/thread_safe_reference.hpp>
 #include <realm/object-store/util/scheduler.hpp>
@@ -226,7 +227,7 @@ TEST_CASE("sync: pending client resets are cleared when downloads are complete",
     SyncTestFile realm_config(app->current_user(), partition.value, schema);
     realm_config.sync_config->client_resync_mode = ClientResyncMode::Recover;
     realm_config.sync_config->error_handler = [&](std::shared_ptr<SyncSession>, SyncError err) {
-        if (err.error_code == make_error_code(ErrorCodes::ReadError)) {
+        if (err.error_code == sync::websocket::make_error_code(ErrorCodes::ReadError)) {
             return;
         }
 

--- a/test/object-store/util/test_file.hpp
+++ b/test/object-store/util/test_file.hpp
@@ -96,7 +96,7 @@ void on_change_but_no_notify(realm::Realm& realm);
 #if REALM_ENABLE_SYNC
 
 #ifndef TEST_ENABLE_SYNC_LOGGING
-#define TEST_ENABLE_SYNC_LOGGING 1 // change to 1 to enable trace-level logging
+#define TEST_ENABLE_SYNC_LOGGING 0 // change to 1 to enable trace-level logging
 #endif
 
 #ifndef TEST_ENABLE_SYNC_LOGGING_LEVEL

--- a/test/object-store/util/test_file.hpp
+++ b/test/object-store/util/test_file.hpp
@@ -96,7 +96,7 @@ void on_change_but_no_notify(realm::Realm& realm);
 #if REALM_ENABLE_SYNC
 
 #ifndef TEST_ENABLE_SYNC_LOGGING
-#define TEST_ENABLE_SYNC_LOGGING 0 // change to 1 to enable trace-level logging
+#define TEST_ENABLE_SYNC_LOGGING 1 // change to 1 to enable trace-level logging
 #endif
 
 #ifndef TEST_ENABLE_SYNC_LOGGING_LEVEL

--- a/test/test_sync.cpp
+++ b/test/test_sync.cpp
@@ -4458,7 +4458,7 @@ TEST(Sync_ServerDiscardDeadConnections)
 
     BowlOfStonesSemaphore bowl;
     auto error_handler = [&](std::error_code ec, bool, const std::string&) {
-        bool valid_error = ec == make_error_code(ErrorCodes::ReadError);
+        bool valid_error = ec == sync::websocket::make_error_code(ErrorCodes::ReadError);
         CHECK(valid_error);
         bowl.add_stone();
     };

--- a/test/test_sync.cpp
+++ b/test/test_sync.cpp
@@ -4469,12 +4469,7 @@ TEST(Sync_ServerDiscardDeadConnections)
 
     BowlOfStonesSemaphore bowl;
     auto error_handler = [&](std::error_code ec, bool, const std::string&) {
-        using syserr = util::error::basic_system_errors;
-        bool valid_error = (util::MiscExtErrors::end_of_input == ec) ||
-                           (util::MiscExtErrors::premature_end_of_input == ec) ||
-                           // FIXME: this is the error on Windows. is it correct?
-                           (util::make_basic_system_error_code(syserr::connection_reset) == ec) ||
-                           (util::make_basic_system_error_code(syserr::connection_aborted) == ec);
+        bool valid_error = ec == make_error_code(ErrorCodes::ReadError);
         CHECK(valid_error);
         bowl.add_stone();
     };


### PR DESCRIPTION
## What, How & Why?
Remove the deprecated callbacks in`WebSocketObserver` and update `ClientImpl::Connection` and `DefaultWebSocketImpl` to use the ones according to the websocket rfc.

Fixes #6094.

## ☑️ ToDos
* [x] 📝 Changelog update
* [ ] ~~🚦 Tests (or not relevant)~~
* [ ] ~~C-API, if public C++ API changed.~~
