### PR TITLE
Guard more of GroupWriter::map_reachable() with REALM_ALLOC_DEBUG

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,7 @@
 * Make log level threshold atomic and shared ([#6009](https://github.com/realm/realm-core/issues/6009))
 * Add c_api error category for resolve errors instead of reporting unknown category, part 2. ([PR #6186](https://github.com/realm/realm-core/pull/6186))
 * Remove `File::is_removed` ([#6222](https://github.com/realm/realm-core/pull/6222))
+* Improve performance of committting write transactions in debug builds. Small writes are potentially upwards of twice as fast. Release builds are uneffected ([PR #6226](https://github.com/realm/realm-core/pull/6226)).
 
 ----------------------------------------------
 

--- a/src/realm/group_writer.cpp
+++ b/src/realm/group_writer.cpp
@@ -340,9 +340,9 @@ GroupWriter::MapWindow* GroupWriter::get_window(ref_type start_ref, size_t size)
 #define ALLOC_DBG_COUT(args)
 #endif
 
-#ifdef REALM_DEBUG
 void GroupWriter::map_reachable()
 {
+#if REALM_ALLOC_DEBUG
     class Collector : public Array::MemUsageHandler {
     public:
         Collector(std::vector<Reachable>& reachable)
@@ -370,7 +370,6 @@ void GroupWriter::map_reachable()
                   });
     }
 
-#if REALM_ALLOC_DEBUG
     std::cout << "  Reachable: ";
     // this really should be inverted, showing all versions pr entry instead of all entries pr version
     for (auto& [version, info] : m_top_ref_map) {
@@ -380,9 +379,8 @@ void GroupWriter::map_reachable()
         }
     }
     std::cout << std::endl << "  Backdating:";
-#endif
+#endif // REALM_ALLOC_DEBUG
 }
-#endif
 
 void GroupWriter::backdate()
 {
@@ -557,9 +555,7 @@ void GroupWriter::backdate()
     };
 
 
-#ifdef REALM_DEBUG
     map_reachable();
-#endif
     for (auto&& entry : m_not_free_in_file) {
         backdate_single_entry(entry);
     }


### PR DESCRIPTION
This was collecting the memory usage information and then not doing anything with it in non-REALM_ALLOC_DEBUG debug builds, which ended up being >50% of the time taken to commit small writes.
