### PR TITLE
Fix an invalid use of frozen Realms in client reset

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,7 @@
 * Make log level threshold atomic and shared ([#6009](https://github.com/realm/realm-core/issues/6009))
 * Add c_api error category for resolve errors instead of reporting unknown category, part 2. ([PR #6186](https://github.com/realm/realm-core/pull/6186))
 * Remove `File::is_removed` ([#6222](https://github.com/realm/realm-core/pull/6222))
+* Client reset recovery froze Realms for the callbacks in an invalid way. It is unclear if this resulted in any actual problems.
 
 ----------------------------------------------
 

--- a/src/realm/object-store/impl/realm_coordinator.cpp
+++ b/src/realm/object-store/impl/realm_coordinator.cpp
@@ -238,6 +238,7 @@ std::shared_ptr<Realm> RealmCoordinator::do_get_cached_realm(Realm::Config const
 
 std::shared_ptr<Realm> RealmCoordinator::get_realm(Realm::Config config, util::Optional<VersionID> version)
 {
+    REALM_ASSERT(!version || *version != VersionID());
     if (!config.scheduler)
         config.scheduler = version ? util::Scheduler::make_frozen(*version) : util::Scheduler::make_default();
     // realm must be declared before lock so that the mutex is released before

--- a/src/realm/object-store/shared_realm.cpp
+++ b/src/realm/object-store/shared_realm.cpp
@@ -82,6 +82,7 @@ Realm::Realm(Config config, util::Optional<VersionID> version, std::shared_ptr<_
 {
     if (version) {
         m_auto_refresh = false;
+        REALM_ASSERT(*version != VersionID());
     }
     else if (!coordinator->get_cached_schema(m_schema, m_schema_version, m_schema_transaction_version)) {
         m_transaction = coordinator->begin_read();
@@ -1327,7 +1328,7 @@ void Realm::copy_schema_from(const Realm& source)
     REALM_ASSERT(m_frozen_version == source.read_transaction_version());
     m_schema = source.m_schema;
     m_schema_version = source.m_schema_version;
-    m_schema_transaction_version = source.m_schema_transaction_version;
+    m_schema_transaction_version = m_frozen_version->version;
     m_dynamic_schema = false;
 }
 

--- a/src/realm/sync/client_base.hpp
+++ b/src/realm/sync/client_base.hpp
@@ -62,9 +62,8 @@ struct ClientReset {
     realm::ClientResyncMode mode;
     DBRef fresh_copy;
     bool recovery_is_allowed = true;
-    util::UniqueFunction<void(std::string path)> notify_before_client_reset;
-    util::UniqueFunction<void(std::string path, VersionID before_version, bool did_recover)>
-        notify_after_client_reset;
+    util::UniqueFunction<void(VersionID)> notify_before_client_reset;
+    util::UniqueFunction<void(VersionID before_version, bool did_recover)> notify_after_client_reset;
 };
 
 /// \brief Protocol errors discovered by the client.

--- a/src/realm/sync/noinst/client_reset_operation.cpp
+++ b/src/realm/sync/noinst/client_reset_operation.cpp
@@ -59,42 +59,44 @@ bool ClientResetOperation::finalize(sync::SaltedFileIdent salted_file_ident, syn
     // only do the reset if there is data to reset
     // if there is nothing in this Realm, then there is nothing to reset and
     // sync should be able to continue as normal
-    bool local_realm_exists = m_db->get_version_of_latest_snapshot() != 0;
-    if (local_realm_exists) {
-        REALM_ASSERT_EX(m_db_fresh, m_db->get_path(), m_mode);
-        m_logger.debug("ClientResetOperation::finalize, realm_path = %1, local_realm_exists = %2, mode = %3",
-                       m_db->get_path(), local_realm_exists, m_mode);
+    auto latest_version = m_db->get_version_id_of_latest_snapshot();
 
-        client_reset::LocalVersionIDs local_version_ids;
-        auto always_try_clean_up = util::make_scope_exit([&]() noexcept {
-            clean_up_state();
-        });
-
-        std::string local_path = m_db->get_path();
-        if (m_notify_before) {
-            m_notify_before(local_path);
-        }
-
-        // If m_notify_after is set, pin the previous state to keep it around.
-        TransactionRef previous_state;
-        if (m_notify_after) {
-            previous_state = m_db->start_frozen();
-        }
-        bool did_recover_out = false;
-        local_version_ids = client_reset::perform_client_reset_diff(
-            m_db, m_db_fresh, m_salted_file_ident, m_logger, m_mode, m_recovery_is_allowed, &did_recover_out,
-            sub_store, std::move(on_flx_version_complete)); // throws
-
-        if (m_notify_after) {
-            m_notify_after(local_path, previous_state->get_version_of_current_transaction(), did_recover_out);
-        }
-
-        m_client_reset_old_version = local_version_ids.old_version;
-        m_client_reset_new_version = local_version_ids.new_version;
-
-        return true;
+    bool local_realm_exists = latest_version.version != 0;
+    m_logger.debug("ClientResetOperation::finalize, realm_path = %1, local_realm_exists = %2, mode = %3",
+                   m_db->get_path(), local_realm_exists, m_mode);
+    if (!local_realm_exists) {
+        return false;
     }
-    return false;
+
+    REALM_ASSERT_EX(m_db_fresh, m_db->get_path(), m_mode);
+
+    client_reset::LocalVersionIDs local_version_ids;
+    auto always_try_clean_up = util::make_scope_exit([&]() noexcept {
+        clean_up_state();
+    });
+
+    if (m_notify_before) {
+        m_notify_before(latest_version);
+    }
+
+    // If m_notify_after is set, pin the previous state to keep it around.
+    TransactionRef previous_state;
+    if (m_notify_after) {
+        previous_state = m_db->start_frozen();
+    }
+    bool did_recover_out = false;
+    local_version_ids = client_reset::perform_client_reset_diff(
+        m_db, m_db_fresh, m_salted_file_ident, m_logger, m_mode, m_recovery_is_allowed, &did_recover_out, sub_store,
+        std::move(on_flx_version_complete)); // throws
+
+    if (m_notify_after) {
+        m_notify_after(previous_state->get_version_of_current_transaction(), did_recover_out);
+    }
+
+    m_client_reset_old_version = local_version_ids.old_version;
+    m_client_reset_new_version = local_version_ids.new_version;
+
+    return true;
 }
 
 void ClientResetOperation::clean_up_state() noexcept

--- a/src/realm/sync/noinst/client_reset_operation.hpp
+++ b/src/realm/sync/noinst/client_reset_operation.hpp
@@ -34,8 +34,8 @@ namespace realm::_impl {
 // state Realm download.
 class ClientResetOperation {
 public:
-    using CallbackBeforeType = util::UniqueFunction<void(std::string)>;
-    using CallbackAfterType = util::UniqueFunction<void(std::string, VersionID, bool)>;
+    using CallbackBeforeType = util::UniqueFunction<void(VersionID)>;
+    using CallbackAfterType = util::UniqueFunction<void(VersionID, bool)>;
 
     ClientResetOperation(util::Logger& logger, DBRef db, DBRef db_fresh, ClientResyncMode mode,
                          CallbackBeforeType notify_before, CallbackAfterType notify_after, bool recovery_is_allowed);


### PR DESCRIPTION
This turned out to not be the source of the problem I was looking in to, but `get_realm(config, VersionID())` does strange and invalid things that appears to work in simple cases but can cause weird problems. VersionID() is turned into an actual version only when acquiring a read lock, and won't turn into the same version every time for a given frozen Realm.