### PR TITLE
Fix default enabled debug output during realm-sync-tests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,7 @@
 * Add c_api error category for resolve errors instead of reporting unknown category, part 2. ([PR #6186](https://github.com/realm/realm-core/pull/6186))
 * Remove `File::is_removed` ([#6222](https://github.com/realm/realm-core/pull/6222))
 * Client reset recovery froze Realms for the callbacks in an invalid way. It is unclear if this resulted in any actual problems.
+* Fix default enabled debug output during realm-sync-tests ([#6233](https://github.com/realm/realm-core/issues/6233))
 
 ----------------------------------------------
 

--- a/src/realm/util/logger.cpp
+++ b/src/realm/util/logger.cpp
@@ -71,4 +71,8 @@ void PrefixLogger::do_log(Level level, const std::string& message)
     Logger::do_log(m_chained_logger, level, m_prefix + message); // Throws
 }
 
+void LocalThresholdLogger::do_log(Logger::Level level, std::string const& message)
+{
+    Logger::do_log(*m_chained_logger, level, message); // Throws
+}
 } // namespace realm::util

--- a/test/test_util_logger.cpp
+++ b/test/test_util_logger.cpp
@@ -94,34 +94,89 @@ TEST(Util_Logger_LevelThreshold)
     auto prefix_logger = PrefixLogger("test", threadsafe_logger); // created using Logger shared_ptr
     auto prefix_logger2 = PrefixLogger("test2", prefix_logger);   // created using PrefixLogger
 
-    REALM_ASSERT(base_logger->get_level_threshold() == Logger::default_log_level);
-    REALM_ASSERT(threadsafe_logger->get_level_threshold() == Logger::default_log_level);
-    REALM_ASSERT(prefix_logger.get_level_threshold() == Logger::default_log_level);
-    REALM_ASSERT(prefix_logger2.get_level_threshold() == Logger::default_log_level);
+    CHECK(base_logger->get_level_threshold() == Logger::default_log_level);
+    CHECK(threadsafe_logger->get_level_threshold() == Logger::default_log_level);
+    CHECK(prefix_logger.get_level_threshold() == Logger::default_log_level);
+    CHECK(prefix_logger2.get_level_threshold() == Logger::default_log_level);
 
     base_logger->set_level_threshold(Logger::Level::error);
-    REALM_ASSERT(base_logger->get_level_threshold() == Logger::Level::error);
-    REALM_ASSERT(threadsafe_logger->get_level_threshold() == Logger::Level::error);
-    REALM_ASSERT(prefix_logger.get_level_threshold() == Logger::Level::error);
-    REALM_ASSERT(prefix_logger2.get_level_threshold() == Logger::Level::error);
+    CHECK(base_logger->get_level_threshold() == Logger::Level::error);
+    CHECK(threadsafe_logger->get_level_threshold() == Logger::Level::error);
+    CHECK(prefix_logger.get_level_threshold() == Logger::Level::error);
+    CHECK(prefix_logger2.get_level_threshold() == Logger::Level::error);
 
     threadsafe_logger->set_level_threshold(Logger::Level::trace);
-    REALM_ASSERT(base_logger->get_level_threshold() == Logger::Level::trace);
-    REALM_ASSERT(threadsafe_logger->get_level_threshold() == Logger::Level::trace);
-    REALM_ASSERT(prefix_logger.get_level_threshold() == Logger::Level::trace);
-    REALM_ASSERT(prefix_logger2.get_level_threshold() == Logger::Level::trace);
+    CHECK(base_logger->get_level_threshold() == Logger::Level::trace);
+    CHECK(threadsafe_logger->get_level_threshold() == Logger::Level::trace);
+    CHECK(prefix_logger.get_level_threshold() == Logger::Level::trace);
+    CHECK(prefix_logger2.get_level_threshold() == Logger::Level::trace);
 
     prefix_logger.set_level_threshold(Logger::Level::debug);
-    REALM_ASSERT(base_logger->get_level_threshold() == Logger::Level::debug);
-    REALM_ASSERT(threadsafe_logger->get_level_threshold() == Logger::Level::debug);
-    REALM_ASSERT(prefix_logger.get_level_threshold() == Logger::Level::debug);
-    REALM_ASSERT(prefix_logger2.get_level_threshold() == Logger::Level::debug);
+    CHECK(base_logger->get_level_threshold() == Logger::Level::debug);
+    CHECK(threadsafe_logger->get_level_threshold() == Logger::Level::debug);
+    CHECK(prefix_logger.get_level_threshold() == Logger::Level::debug);
+    CHECK(prefix_logger2.get_level_threshold() == Logger::Level::debug);
 
     prefix_logger2.set_level_threshold(Logger::Level::info);
-    REALM_ASSERT(base_logger->get_level_threshold() == Logger::Level::info);
-    REALM_ASSERT(threadsafe_logger->get_level_threshold() == Logger::Level::info);
-    REALM_ASSERT(prefix_logger.get_level_threshold() == Logger::Level::info);
-    REALM_ASSERT(prefix_logger2.get_level_threshold() == Logger::Level::info);
+    CHECK(base_logger->get_level_threshold() == Logger::Level::info);
+    CHECK(threadsafe_logger->get_level_threshold() == Logger::Level::info);
+    CHECK(prefix_logger.get_level_threshold() == Logger::Level::info);
+    CHECK(prefix_logger2.get_level_threshold() == Logger::Level::info);
+
+    auto ll_logger = std::make_shared<LocalThresholdLogger>(base_logger);
+    auto ll_logger2 = std::make_shared<LocalThresholdLogger>(base_logger, Logger::Level::trace);
+    CHECK(base_logger->get_level_threshold() == Logger::Level::info);
+    CHECK(ll_logger->get_level_threshold() == Logger::Level::info);
+    CHECK(ll_logger2->get_level_threshold() == Logger::Level::trace);
+
+    ll_logger->set_level_threshold(Logger::Level::error);
+    ll_logger2->set_level_threshold(Logger::Level::debug);
+    CHECK(base_logger->get_level_threshold() == Logger::Level::info);
+    CHECK(ll_logger->get_level_threshold() == Logger::Level::error);
+    CHECK(ll_logger2->get_level_threshold() == Logger::Level::debug);
+
+    auto prefix_logger3 = PrefixLogger("test3", ll_logger);
+    auto prefix_logger4 = PrefixLogger("test4", ll_logger2);
+}
+
+
+TEST(Util_Logger_LocalThresholdLogger)
+{
+    using namespace realm::util;
+    auto base_logger = std::make_shared<StderrLogger>();
+    auto lt_logger = std::make_shared<LocalThresholdLogger>(base_logger);
+    auto lt_logger2 = std::make_shared<LocalThresholdLogger>(base_logger, Logger::Level::trace);
+    auto prefix_logger = PrefixLogger("test", lt_logger);
+    auto prefix_logger2 = PrefixLogger("test2", lt_logger2);
+
+    CHECK(base_logger->get_level_threshold() == Logger::Level::info);
+    CHECK(lt_logger->get_level_threshold() == Logger::Level::info);
+    CHECK(lt_logger2->get_level_threshold() == Logger::Level::trace);
+    CHECK(prefix_logger.get_level_threshold() == Logger::Level::info);
+    CHECK(prefix_logger2.get_level_threshold() == Logger::Level::trace);
+
+    lt_logger->set_level_threshold(Logger::Level::error);
+    lt_logger2->set_level_threshold(Logger::Level::debug);
+    CHECK(base_logger->get_level_threshold() == Logger::Level::info);
+    CHECK(lt_logger->get_level_threshold() == Logger::Level::error);
+    CHECK(prefix_logger.get_level_threshold() == Logger::Level::error);
+    CHECK(lt_logger2->get_level_threshold() == Logger::Level::debug);
+    CHECK(prefix_logger2.get_level_threshold() == Logger::Level::debug);
+
+    prefix_logger.set_level_threshold(Logger::Level::off);
+    prefix_logger2.set_level_threshold(Logger::Level::all);
+    CHECK(base_logger->get_level_threshold() == Logger::Level::info);
+    CHECK(lt_logger->get_level_threshold() == Logger::Level::off);
+    CHECK(prefix_logger.get_level_threshold() == Logger::Level::off);
+    CHECK(lt_logger2->get_level_threshold() == Logger::Level::all);
+    CHECK(prefix_logger2.get_level_threshold() == Logger::Level::all);
+
+    base_logger->set_level_threshold(Logger::Level::error);
+    CHECK(base_logger->get_level_threshold() == Logger::Level::error);
+    CHECK(lt_logger->get_level_threshold() == Logger::Level::off);
+    CHECK(prefix_logger.get_level_threshold() == Logger::Level::off);
+    CHECK(lt_logger2->get_level_threshold() == Logger::Level::all);
+    CHECK(prefix_logger2.get_level_threshold() == Logger::Level::all);
 }
 
 

--- a/test/util/unit_test.cpp
+++ b/test/util/unit_test.cpp
@@ -428,7 +428,6 @@ public:
     }
 
 protected:
-    Level m_local_log_level;
     std::shared_ptr<Logger> m_chained_logger;
 };
 

--- a/test/util/unit_test.cpp
+++ b/test/util/unit_test.cpp
@@ -409,29 +409,6 @@ private:
     patterns m_include, m_exclude;
 };
 
-
-class IntraTestLogger : public Logger {
-public:
-    // Logger with a local log level used for the different test threads
-    // A new log level threshold atomic will be used for this logger, but
-    // it will write to the base_logger_ptr when do_log() is called
-    IntraTestLogger(const std::shared_ptr<Logger>& base_logger_ptr, Level threshold)
-        : Logger(threshold)
-        , m_chained_logger{base_logger_ptr}
-    {
-        REALM_ASSERT(m_chained_logger);
-    }
-
-    void do_log(Logger::Level level, std::string const& message) override final
-    {
-        Logger::do_log(*m_chained_logger, level, message); // Throws
-    }
-
-protected:
-    std::shared_ptr<Logger> m_chained_logger;
-};
-
-
 } // anonymous namespace
 
 
@@ -489,7 +466,7 @@ public:
     ThreadContextImpl(SharedContextImpl& sc, int ti, const std::shared_ptr<util::Logger>& attached_logger)
         : ThreadContext(sc, ti, attached_logger ? attached_logger : sc.report_logger_ptr)
         , intra_test_logger(
-              std::make_shared<IntraTestLogger>(ThreadContext::report_logger_ptr, sc.intra_test_log_level))
+              std::make_shared<LocalThresholdLogger>(ThreadContext::report_logger_ptr, sc.intra_test_log_level))
         , shared_context(sc)
     {
     }

--- a/test/util/unit_test.cpp
+++ b/test/util/unit_test.cpp
@@ -413,29 +413,23 @@ private:
 class IntraTestLogger : public Logger {
 public:
     // Logger with a local log level used for the different test threads
+    // A new log level threshold atomic will be used for this logger, but
+    // it will write to the base_logger_ptr when do_log() is called
     IntraTestLogger(const std::shared_ptr<Logger>& base_logger_ptr, Level threshold)
-        : Logger(base_logger_ptr)
-        , m_local_log_level(threshold)
+        : Logger(threshold)
+        , m_chained_logger{base_logger_ptr}
     {
-    }
-
-    Level get_level_threshold() const noexcept override
-    {
-        return m_local_log_level;
-    }
-
-    void set_level_threshold(Level level) noexcept override
-    {
-        m_local_log_level = level;
+        REALM_ASSERT(m_chained_logger);
     }
 
     void do_log(Logger::Level level, std::string const& message) override final
     {
-        Logger::do_log(*m_base_logger_ptr, level, message); // Throws
+        Logger::do_log(*m_chained_logger, level, message); // Throws
     }
 
 protected:
     Level m_local_log_level;
+    std::shared_ptr<Logger> m_chained_logger;
 };
 
 


### PR DESCRIPTION
## What, How & Why?
When the log level threshold was updated to be atomic, the `IntraTestLogger` was updated to provide its own log level threshold, but this value was not being used properly by subsequent loggers that were linked to this object. An instance of the `IntraTestLogger` is used by each of the test threads in a unit test run to prevent changes in one thread from affecting the other threads, but they all print out using a single root logger (protected by a `ThreadSafeLogger`) that is created when the test is started.

Fix the level threshold in the `IntraTestLogger` so it has its own atomic log level threshold that is used by linked loggers.

Fixes #6233 


## ☑️ ToDos
* [x] 📝 Changelog update
* [X] 🚦 Tests (or not relevant)
* ~~[ ] C-API, if public C++ API changed.~~
