### PR TITLE
Actually sort in Set<Mixed>::sort()

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@
 * Changesets from the server sent during FLX bootstrapping that are larger than 16MB can cause the sync client to crash with a LogicError (PR [#6218](https://github.com/realm/realm-core/pull/6218), since v12.0.0)
 * Online compaction may cause a single commit to take a long time ([#6245](https://github.com/realm/realm-core/pull/6245), since v13.0.0)
 * Expose `collection_was_cleared` in the C API ([#6200](https://github.com/realm/realm-core/issues/6200), since v.10.4.0)
+* `Set<Mixed>::sort()` used a different sort order from sorting any other collection, including a filtered `Set<Mixed>` ([PR #6238](https://github.com/realm/realm-core/pull/6238), since v13.0.0).
 
 ### Breaking changes
 * `SyncSession::log_out()` has been renamed to `SyncSession::force_close()` to reflect what it actually does ([#6183](https://github.com/realm/realm-core/pull/6183))

--- a/src/realm/list.hpp
+++ b/src/realm/list.hpp
@@ -277,6 +277,20 @@ protected:
             }
         }
     }
+
+private:
+    template <class U>
+    static U unresolved_to_null(U value) noexcept
+    {
+        return value;
+    }
+
+    static Mixed unresolved_to_null(Mixed value) noexcept
+    {
+        if (value.is_type(type_TypedLink) && value.is_unresolved_link())
+            return Mixed{};
+        return value;
+    }
 };
 
 // Specialization of Lst<ObjKey>:
@@ -668,13 +682,7 @@ inline T Lst<T>::get(size_t ndx) const
         throw std::out_of_range("Index out of range");
     }
 
-    auto value = m_tree->get(ndx);
-    if constexpr (std::is_same_v<T, Mixed>) {
-        // return a null for mixed unresolved link
-        if (value.is_type(type_TypedLink) && value.is_unresolved_link())
-            return Mixed{};
-    }
-    return value;
+    return unresolved_to_null(m_tree->get(ndx));
 }
 
 template <class T>

--- a/src/realm/set.hpp
+++ b/src/realm/set.hpp
@@ -792,6 +792,9 @@ inline void Set<T>::sort(std::vector<size_t>& indices, bool ascending) const
     set_sorted_indices(sz, indices, ascending);
 }
 
+template <>
+void Set<Mixed>::sort(std::vector<size_t>& indices, bool ascending) const;
+
 template <class T>
 inline void Set<T>::distinct(std::vector<size_t>& indices, util::Optional<bool> sort_order) const
 {

--- a/test/object-store/collection_fixtures.hpp
+++ b/test/object-store/collection_fixtures.hpp
@@ -288,9 +288,36 @@ struct MixedVal : Base<PropertyType::Mixed, realm::Mixed> {
     enum { is_optional = true };
     static std::vector<realm::Mixed> values()
     {
-        return {Mixed{realm::UUID()}, Mixed{int64_t(1)},      Mixed{},
-                Mixed{"hello world"}, Mixed{Timestamp(1, 1)}, Mixed{Decimal128("300")},
-                Mixed{double(2.2)},   Mixed{float(3.3)}};
+        return {
+            Mixed{realm::UUID()},
+            Mixed{},
+            Mixed{realm::ObjectId()},
+
+            // Mixed sorting considers all numerics to be the same time, so
+            // ensure we have some interleaved values to test that
+            Mixed{int64_t(1)},
+            Mixed{int64_t(2)},
+            Mixed{int64_t(3)},
+
+            Mixed{double(1.2)},
+            Mixed{double(2.2)},
+            Mixed{double(3.2)},
+
+            Mixed{float(1.1)},
+            Mixed{float(2.1)},
+            Mixed{float(3.1)},
+
+            Mixed{Decimal128("1.3")},
+            Mixed{Decimal128("2.3")},
+            Mixed{Decimal128("3.3")},
+
+            // Mixed sorting considers strings and binary to be the same time, so
+            // ensure we have some interleaved values to test that
+            Mixed{"a string"},
+            Mixed{"b string"},
+            Mixed{BinaryData("a binary", 8)},
+            Mixed{BinaryData("b binary", 8)},
+        };
     }
     static PropertyType property_type()
     {
@@ -306,11 +333,13 @@ struct MixedVal : Base<PropertyType::Mixed, realm::Mixed> {
     }
     static Decimal128 sum()
     {
-        return Decimal128("300") + Decimal128(int64_t(1)) + Decimal128(double(2.2)) + Decimal128(float(3.3));
+        return Decimal128{int64_t(1)} + Decimal128{int64_t(2)} + Decimal128{int64_t(3)} + Decimal128{double(1.2)} +
+               Decimal128{double(2.2)} + Decimal128{double(3.2)} + Decimal128{float(1.1)} + Decimal128{float(2.1)} +
+               Decimal128{float(3.1)} + Decimal128("1.3") + Decimal128("2.3") + Decimal128("3.3");
     }
     static Decimal128 average()
     {
-        return (sum() / Decimal128(4));
+        return (sum() / Decimal128(12));
     }
     static Mixed empty_sum_value()
     {

--- a/test/object-store/primitive_list.cpp
+++ b/test/object-store/primitive_list.cpp
@@ -618,15 +618,16 @@ TEMPLATE_TEST_CASE("primitive list", "[primitives]", cf::MixedVal, cf::Int, cf::
         }
 
         SECTION("remove value from list") {
+            size_t index = TestType::can_minmax() ? list.find_any(TestType::min()) : 1;
             advance_and_notify(*r);
             r->begin_transaction();
-            list.remove(1);
+            list.remove(index);
             r->commit_transaction();
 
             advance_and_notify(*r);
-            REQUIRE_INDICES(change.deletions, 1);
-            REQUIRE_INDICES(rchange.deletions, 1);
-            // values[1] is min(), so it's index 0 for non-optional and 1 for
+            REQUIRE_INDICES(change.deletions, index);
+            REQUIRE_INDICES(rchange.deletions, index);
+            // we removed min(), so it's index 0 for non-optional and 1 for
             // optional (as nulls sort to the front)
             REQUIRE_INDICES(srchange.deletions, TestType::is_optional);
         }

--- a/test/util/unit_test.hpp
+++ b/test/util/unit_test.hpp
@@ -772,6 +772,25 @@ void to_string(const T& value, std::string& str)
 }
 
 template <class T>
+void to_string(const std::vector<T>& value, std::string& str)
+{
+    std::ostringstream out;
+    SetPrecision<T, std::is_floating_point<T>::value>::exec(out);
+
+    out << "{";
+    bool first = true;
+    for (auto& v : value) {
+        if (!first) {
+            out << ", ";
+        }
+        out << v;
+        first = false;
+    }
+    out << "}";
+    str = out.str();
+}
+
+template <class T>
 void to_string(const std::optional<T>& value, std::string& str)
 {
     // FIXME: Put string values in quotes, and escape non-printables as well as '"' and '\\'.


### PR DESCRIPTION
Now that Set<Mixed>'s on-disk storage order doesn't match our sort order, Set<Mixed>::sort() needs to actually sort the items rather than being a no-op. It remains a no-op for other types of set.

Adjusting the data used for tests to test this also revealed that Lst::distinct() picked an arbitrary value of the equal ones rather than the first. This isn't necessarily incorrect, but it makes testing distinct more complicated and can have surprising results when the collection isn't sorted. Making it always use the first is simple and doesn't add any overhead, so it now does that.

I took a stab at instead making it so that Mixed::compare() uses Set<Mixed>'s comparison rules, but it quickly became obvious why #5607 didn't do that as there's some pretty reasonable things that rely on the current behavior.

This appears to be the final thing blocking swift from adopting core 13; with this change all of our tests finally pass.