### PR TITLE
Add REALM_ARCHITECTURE macros for ARM architectures

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,7 +17,7 @@
 -----------
 
 ### Internals
-* None.
+* Added `REALM_ARCHITECTURE_ARM32` and `REALM_ARCHITECTURE_ARM64` macros to `features.h` for easier platform detection. ([#6256](https://github.com/realm/realm-core/pull/6256))
 
 ----------------------------------------------
 

--- a/src/realm/util/features.h
+++ b/src/realm/util/features.h
@@ -124,18 +124,6 @@
 #define REALM_DIAG_IGNORE_UNSIGNED_MINUS()
 #endif
 
-/* Compiler is MSVC (Microsoft Visual C++) */
-#if defined(_MSC_VER) && _MSC_VER >= 1600
-#define REALM_HAVE_AT_LEAST_MSVC_10_2010 1
-#endif
-#if defined(_MSC_VER) && _MSC_VER >= 1700
-#define REALM_HAVE_AT_LEAST_MSVC_11_2012 1
-#endif
-#if defined(_MSC_VER) && _MSC_VER >= 1800
-#define REALM_HAVE_AT_LEAST_MSVC_12_2013 1
-#endif
-
-
 /* The way to specify that a function never returns. */
 #if REALM_HAVE_AT_LEAST_GCC(4, 8) || REALM_HAVE_CLANG_FEATURE(cxx_attributes)
 #define REALM_NORETURN [[noreturn]]
@@ -303,6 +291,18 @@
 #define REALM_ARCHITECTURE_X86_64 1
 #else
 #define REALM_ARCHITECTURE_X86_64 0
+#endif
+
+#if defined(__arm__) || defined(_M_ARM)
+#define REALM_ARCHITECTURE_ARM32 1
+#else
+#define REALM_ARCHITECTURE_ARM32 0
+#endif
+
+#if defined(__aarch64__) || defined(_M_ARM64) || defined(_M_ARM64EC)
+#define REALM_ARCHITECTURE_ARM64 1
+#else
+#define REALM_ARCHITECTURE_ARM64 0
 #endif
 
 // Address Sanitizer


### PR DESCRIPTION
## What, How & Why?
Add macros to more easily distinguish ARM targets across targets.

## ☑️ ToDos
* [x] 📝 Changelog update
* [x] 🚦 Tests (or not relevant)
* [x] C-API, if public C++ API changed.
