### PR TITLE
Update ClientImpl shutdown so event loop can continue running

### DIFF
--- a/src/realm/sync/client.hpp
+++ b/src/realm/sync/client.hpp
@@ -98,7 +98,9 @@ public:
                               port_type& port, std::string& path) const;
 
 private:
-    std::unique_ptr<ClientImpl> m_impl;
+    std::shared_ptr<util::Logger> m_logger_ptr;
+    std::shared_ptr<SyncSocketProvider> m_socket_provider;
+    std::shared_ptr<ClientImpl> m_impl;
     friend class Session;
 };
 

--- a/src/realm/sync/network/default_socket.hpp
+++ b/src/realm/sync/network/default_socket.hpp
@@ -65,7 +65,8 @@ public:
     /// Stops the internal event loop (provided by network::Service)
     void stop(bool wait_for_stop = false) override;
 
-    std::unique_ptr<WebSocketInterface> connect(WebSocketObserver*, WebSocketEndpoint&&) override;
+    std::shared_ptr<WebSocketInterface> connect(const std::shared_ptr<WebSocketObserver>&,
+                                                WebSocketEndpoint&&) override;
 
     void post(FunctionHandler&& handler) override
     {

--- a/src/realm/sync/socket_provider.hpp
+++ b/src/realm/sync/socket_provider.hpp
@@ -97,7 +97,7 @@ public:
     /// websocket will call directly to the handlers provided by the observer.
     /// The WebSocketObserver guarantees that the WebSocket object will be
     /// closed/destroyed before the observer is terminated/destroyed.
-    virtual std::unique_ptr<WebSocketInterface> connect(WebSocketObserver* observer,
+    virtual std::shared_ptr<WebSocketInterface> connect(const std::shared_ptr<WebSocketObserver>& observer,
                                                         WebSocketEndpoint&& endpoint) = 0;
 
     /// Submit a handler function to be executed by the event loop (thread).


### PR DESCRIPTION
## What, How & Why?
The current ClientImpl stop operations relies on the event loop being stopped to prevent new events from being posted onto the event loop and the event loop will halt as soon as the current batch of pending events has been processed. The goal of this task is to update the ClientImpl shutdown procedure so it is performed cleanly even if the event loop continues to run during and after the ClientImpl has been destroyed.

Here is the first pass at trying to keep the event loop running while the sync client is being stopped/destroyed. Unfortunately, there are tons of race conditions between the destruction of the `ClientImpl`, `ClientImpl::Connection`, `ClientImpl::Session` and the `SessionWrappers` and function handlers on the event loop, which led to trying to fix individual issues by trying to use weak_ptrs (which can make object destruction non-deterministic) and other things. At this point, `realm-sync-tests` will pass sometimes, but usually there is a crash as a result of these data races or something being destroyed out of order.

Some of the causes for the crashes:
* Pending websocket::Websocket events call into the DefaultWebsocketImpl callbacks, even after the DefaultWebsocketImpl has been destroyed
* Websocket message event calls into ClientImpl::Connection (the WebSocketObserver) after it is destroyed
* actualize_and_finalize_trigger events are processed after the ClientImpl serverSlot (or its components) have been destroyed
* Heap, double free and malloc errors since pointers are no longer valid

NOTE: There is still debug in place in this commit that was used during testing.

I think a better approach is to wait in `~ClientImpl()` until all the sessions and connections have completed their close operations (the sync sessions must be destroyed before destroying the sync client) and then proceed with destroying the ClientImpl and everything it holds.

Fixes #6161

## ☑️ ToDos
* [ ] 📝 Changelog update
* [ ] 🚦 Tests (or not relevant)
* [ ] C-API, if public C++ API changed.
