### PR TITLE
Add handling of hex encoded key to realm-trawler

### DIFF
--- a/src/realm/exec/realm_trawler.cpp
+++ b/src/realm/exec/realm_trawler.cpp
@@ -1102,27 +1102,10 @@ int main(int argc, const char* argv[])
                 else if (strcmp(argv[curr_arg], "--hexkey") == 0) {
                     std::ifstream key_file(argv[curr_arg + 1]);
                     curr_arg++;
-                    char chars[128];
-                    std::cout << "Using key: ";
-                    for (int idx = 0; idx < 128; ++idx) {
-                        char c;
-                        do {
-                            key_file.get(c);
-                            // todo: check for failure
-                        } while (!is_hex(c));
-                        chars[idx] = c;
-                        std::cout << c;
-                    }
-                    std::cout << std::endl;
+                    const char* chars = argv[curr_arg];
                     for (int idx = 0; idx < 64; ++idx) {
                         key[idx] = hex_to_bin(chars[idx * 2], chars[idx * 2 + 1]);
                     }
-                    std::cout << "Key again: ";
-                    for (int idx = 0; idx < 64; ++idx) {
-                        char c = key[idx];
-                        std::cout << to_hex_char(c >> 4) << to_hex_char(c & 0xf);
-                    }
-                    std::cout << std::endl;
                     key_ptr = key;
                 }
                 else if (strcmp(argv[curr_arg], "--top") == 0) {

--- a/src/realm/exec/realm_trawler.cpp
+++ b/src/realm/exec/realm_trawler.cpp
@@ -1093,14 +1093,13 @@ int main(int argc, const char* argv[])
             const char* key_ptr = nullptr;
             char key[64];
             for (int curr_arg = 1; curr_arg < argc; curr_arg++) {
-                if (strcmp(argv[curr_arg], "--key") == 0) {
+                if (strcmp(argv[curr_arg], "--keyfile") == 0) {
                     std::ifstream key_file(argv[curr_arg + 1]);
                     key_file.read(key, sizeof(key));
                     key_ptr = key;
                     curr_arg++;
                 }
                 else if (strcmp(argv[curr_arg], "--hexkey") == 0) {
-                    std::ifstream key_file(argv[curr_arg + 1]);
                     curr_arg++;
                     const char* chars = argv[curr_arg];
                     for (int idx = 0; idx < 64; ++idx) {
@@ -1165,7 +1164,10 @@ int main(int argc, const char* argv[])
         }
     }
     else {
-        std::cout << "Usage: realm-trawler [-afmsw] [--key crypt_key] [--top top_ref] <realmfile>" << std::endl;
+        std::cout << "Usage: realm-trawler [-afmsw] [--keyfile file-with-binary-crypt-key] [--hexkey "
+                     "crypt-key-in-hex] [--top "
+                     "top_ref] <realmfile>"
+                  << std::endl;
         std::cout << "   f : free list analysis" << std::endl;
         std::cout << "   m : memory leak check" << std::endl;
         std::cout << "   s : schema dump" << std::endl;

--- a/src/realm/exec/realm_trawler.cpp
+++ b/src/realm/exec/realm_trawler.cpp
@@ -1071,14 +1071,6 @@ unsigned int hex_to_bin(char first, char second)
     return (hex_char_to_bin(first) << 4) | hex_char_to_bin(second);
 }
 
-char to_hex_char(char c)
-{
-    if (c < 10)
-        return c + '0';
-    if (c < 16)
-        return c - 10 + 'a';
-    return '!';
-}
 
 int main(int argc, const char* argv[])
 {
@@ -1103,6 +1095,9 @@ int main(int argc, const char* argv[])
                     curr_arg++;
                     const char* chars = argv[curr_arg];
                     for (int idx = 0; idx < 64; ++idx) {
+                        if (!is_hex(chars[idx * 2] || !is_hex(chars[idx * 2 + 1]))) {
+                            throw std::runtime_error("Illegal key (wrong length or not hex)");
+                        }
                         key[idx] = hex_to_bin(chars[idx * 2], chars[idx * 2 + 1]);
                     }
                     key_ptr = key;

--- a/src/realm/exec/realm_trawler.cpp
+++ b/src/realm/exec/realm_trawler.cpp
@@ -1044,17 +1044,6 @@ void RealmFile::changes() const
     }
 }
 
-bool is_hex(char c)
-{
-    if (c >= '0' && c <= '9')
-        return true;
-    if (c >= 'a' && c <= 'f')
-        return true;
-    if (c >= 'A' && c <= 'F')
-        return true;
-    return false;
-}
-
 unsigned int hex_char_to_bin(char c)
 {
     if (c >= '0' && c <= '9')
@@ -1063,7 +1052,7 @@ unsigned int hex_char_to_bin(char c)
         return c - 'a' + 10;
     if (c >= 'A' && c <= 'F')
         return c - 'A' + 10;
-    exit(-1);
+    throw std::invalid_argument("Illegal key (not a hex digit)");
 }
 
 unsigned int hex_to_bin(char first, char second)
@@ -1094,10 +1083,10 @@ int main(int argc, const char* argv[])
                 else if (strcmp(argv[curr_arg], "--hexkey") == 0) {
                     curr_arg++;
                     const char* chars = argv[curr_arg];
+                    if (strlen(chars) != 128) {
+                        throw std::invalid_argument("Key string must be 128 chars long");
+                    }
                     for (int idx = 0; idx < 64; ++idx) {
-                        if (!is_hex(chars[idx * 2] || !is_hex(chars[idx * 2 + 1]))) {
-                            throw std::runtime_error("Illegal key (wrong length or not hex)");
-                        }
                         key[idx] = hex_to_bin(chars[idx * 2], chars[idx * 2 + 1]);
                     }
                     key_ptr = key;


### PR DESCRIPTION
## What, How & Why?

Add a new option "--hexkey \<the-very-long-key\>" to realm-trawler.
This option allows the trawler to get the key to an encrypted realm directly on the command line instead of via a binary file.
