### PR TITLE
Use a real transaction version for immutable Realms

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 * <How do the end-user experience this issue? what was the impact?> ([#????](https://github.com/realm/realm-core/issues/????), since v?.?.?)
 * Sharing Realm files between a Catalyst app and Realm Studio did not properly synchronize access to the Realm file ([PR #6258](https://github.com/realm/realm-core/pull/6258), since v6.21.0).
 * Fix websocket redirection after server migration if user is logged in ([#6056](https://github.com/realm/realm-core/issues/6056), since v12.9.0)
+* Freezing an immutable Realm would hit an assertion failure ([#6260]https://github.com/realm/realm-core/issues/6260), since v13.3.0).
 
 ### Breaking changes
 * None.

--- a/src/realm/db.hpp
+++ b/src/realm/db.hpp
@@ -440,6 +440,7 @@ private:
             auto res = std::make_unique<ReadLockInfo>();
             res->m_top_ref = top_ref;
             res->m_file_size = file_size;
+            res->m_version = 1;
             return res;
         }
         void check() const noexcept

--- a/src/realm/object-store/shared_realm.cpp
+++ b/src/realm/object-store/shared_realm.cpp
@@ -231,6 +231,7 @@ void Realm::read_schema_from_group_if_needed()
         if (m_schema.empty()) {
             m_schema_version = ObjectStore::get_schema_version(*m_transaction);
             m_schema = ObjectStore::schema_from_group(*m_transaction);
+            m_schema_transaction_version = m_transaction->get_version_of_current_transaction().version;
         }
         return;
     }
@@ -678,10 +679,10 @@ void Realm::enable_wait_for_change()
 
 bool Realm::wait_for_change()
 {
-    if (m_frozen_version) {
+    if (m_frozen_version || m_config.schema_mode == SchemaMode::Immutable) {
         return false;
     }
-    return m_transaction ? m_coordinator->wait_for_change(transaction_ref()) : false;
+    return m_transaction && m_coordinator->wait_for_change(m_transaction);
 }
 
 void Realm::wait_for_change_release()

--- a/test/object-store/realm.cpp
+++ b/test/object-store/realm.cpp
@@ -788,11 +788,30 @@ TEST_CASE("SharedRealm: schema_subset_mode") {
             tr->commit();
         }
 
+        auto reset_schema = GENERATE(false, true);
+        if (reset_schema) {
+            config.schema.reset();
+        }
+
         for (size_t i = 0; i < 10; ++i) {
             auto& r = *realms[i];
             REQUIRE(r.schema().size() == i + 1);
-            REQUIRE(r.freeze()->schema().size() == i + 1);
-            REQUIRE(Realm::get_frozen_realm(config, r.read_transaction_version())->schema().size() == i + 1);
+            auto frozen = r.freeze();
+            REQUIRE(frozen->schema().size() == i + 1);
+            REQUIRE(frozen->schema_version() == config.schema_version);
+            frozen = Realm::get_frozen_realm(config, r.read_transaction_version());
+            REQUIRE(frozen->schema().size() == i + 1);
+            REQUIRE(frozen->schema_version() == config.schema_version);
+        }
+
+        SECTION("schema not set in config") {
+            config.schema = std::nullopt;
+            for (size_t i = 0; i < 10; ++i) {
+                auto& r = *realms[i];
+                REQUIRE(r.schema().size() == i + 1);
+                REQUIRE(r.freeze()->schema().size() == i + 1);
+                REQUIRE(Realm::get_frozen_realm(config, r.read_transaction_version())->schema().size() == i + 1);
+            }
         }
     }
 
@@ -3357,32 +3376,6 @@ TEST_CASE("SharedRealm: SchemaChangedFunction") {
     }
 }
 
-TEST_CASE("SharedRealm: Schema version set correctly") {
-    SECTION("Set schema versions") {
-        TestFile config;
-
-        auto schema = Schema{{"object1",
-                              {
-                                  {"value", PropertyType::Int},
-                              }},
-                             {"object2",
-                              {
-                                  {"value", PropertyType::Int},
-                              }}};
-        auto r1 = Realm::get_shared_realm(config);
-        r1->read_group();
-        auto frozen = Realm::get_frozen_realm(config, r1->read_transaction_version());
-        CHECK(r1->schema_version() == ObjectStore::NotVersioned);
-        CHECK(frozen->schema_version() == ObjectStore::NotVersioned);
-        r1->update_schema(schema);
-        frozen = Realm::get_frozen_realm(config, r1->read_transaction_version());
-        frozen->set_schema_subset(schema);
-
-        CHECK(r1->schema_version() != ObjectStore::NotVersioned);
-        CHECK(frozen->schema_version() != ObjectStore::NotVersioned);
-    }
-}
-
 TEST_CASE("SharedRealm: compact on launch") {
     // Make compactable Realm
     TestFile config;
@@ -3447,61 +3440,31 @@ TEST_CASE("SharedRealm: compact on launch") {
 }
 
 struct ModeAutomatic {
-    static SchemaMode mode()
-    {
-        return SchemaMode::Automatic;
-    }
-    static bool should_call_init_on_version_bump()
-    {
-        return false;
-    }
+    static constexpr SchemaMode mode = SchemaMode::Automatic;
+    static constexpr bool should_call_init_on_version_bump = false;
 };
 struct ModeAdditive {
-    static SchemaMode mode()
-    {
-        return SchemaMode::AdditiveExplicit;
-    }
-    static bool should_call_init_on_version_bump()
-    {
-        return false;
-    }
+    static constexpr SchemaMode mode = SchemaMode::AdditiveExplicit;
+    static constexpr bool should_call_init_on_version_bump = false;
 };
 struct ModeManual {
-    static SchemaMode mode()
-    {
-        return SchemaMode::Manual;
-    }
-    static bool should_call_init_on_version_bump()
-    {
-        return false;
-    }
+    static constexpr SchemaMode mode = SchemaMode::Manual;
+    static constexpr bool should_call_init_on_version_bump = false;
 };
 struct ModeSoftResetFile {
-    static SchemaMode mode()
-    {
-        return SchemaMode::SoftResetFile;
-    }
-    static bool should_call_init_on_version_bump()
-    {
-        return true;
-    }
+    static constexpr SchemaMode mode = SchemaMode::SoftResetFile;
+    static constexpr bool should_call_init_on_version_bump = true;
 };
 struct ModeHardResetFile {
-    static SchemaMode mode()
-    {
-        return SchemaMode::HardResetFile;
-    }
-    static bool should_call_init_on_version_bump()
-    {
-        return true;
-    }
+    static constexpr SchemaMode mode = SchemaMode::HardResetFile;
+    static constexpr bool should_call_init_on_version_bump = true;
 };
 
 TEMPLATE_TEST_CASE("SharedRealm: update_schema with initialization_function", "[init][update_schema]", ModeAutomatic,
                    ModeAdditive, ModeManual, ModeSoftResetFile, ModeHardResetFile)
 {
     TestFile config;
-    config.schema_mode = TestType::mode();
+    config.schema_mode = TestType::mode;
     bool initialization_function_called = false;
     uint64_t schema_version_in_callback = -1;
     Schema schema_in_callback;
@@ -3546,8 +3509,8 @@ TEMPLATE_TEST_CASE("SharedRealm: update_schema with initialization_function", "[
         config.schema_version = 1;
         config.initialization_function = initialization_function;
         Realm::get_shared_realm(config);
-        REQUIRE(initialization_function_called == TestType::should_call_init_on_version_bump());
-        if (TestType::should_call_init_on_version_bump()) {
+        REQUIRE(initialization_function_called == TestType::should_call_init_on_version_bump);
+        if (TestType::should_call_init_on_version_bump) {
             REQUIRE(schema_version_in_callback == 1);
             REQUIRE(schema_in_callback.compare(schema).size() == 0);
         }
@@ -3832,6 +3795,97 @@ TEST_CASE("RealmCoordinator: get_unbound_realm()") {
         config.cache = true;
         auto r4 = Realm::get_shared_realm(config);
         REQUIRE(r4 == r2);
+    }
+}
+
+TEST_CASE("Immutable Realms") {
+    TestFile config; // can't be in-memory because we have to write a file to open in immutable mode
+    config.schema_version = 1;
+    config.schema = Schema{{"object", {{"value", PropertyType::Int}}}};
+
+    {
+        auto realm = Realm::get_shared_realm(config);
+        realm->begin_transaction();
+        realm->read_group().get_table("class_object")->create_object();
+        realm->commit_transaction();
+    }
+
+    config.schema_mode = SchemaMode::Immutable;
+    auto realm = Realm::get_shared_realm(config);
+    realm->read_group();
+
+    SECTION("unsupported functions") {
+        SECTION("update_schema()") {
+            REQUIRE_THROWS_AS(realm->compact(), std::logic_error);
+        }
+        SECTION("begin_transaction()") {
+            REQUIRE_THROWS_AS(realm->begin_transaction(), std::logic_error);
+        }
+        SECTION("async_begin_transaction()") {
+            REQUIRE_THROWS_AS(realm->async_begin_transaction(nullptr), std::logic_error);
+        }
+        SECTION("refresh()") {
+            REQUIRE_THROWS_AS(realm->refresh(), std::logic_error);
+        }
+        SECTION("compact()") {
+            REQUIRE_THROWS_AS(realm->compact(), std::logic_error);
+        }
+    }
+
+    SECTION("supported functions") {
+        SECTION("is_in_transaction()") {
+            REQUIRE_FALSE(realm->is_in_transaction());
+        }
+        SECTION("is_in_async_transaction()") {
+            REQUIRE_FALSE(realm->is_in_transaction());
+        }
+        SECTION("freeze()") {
+            std::shared_ptr<Realm> frozen;
+            REQUIRE_NOTHROW(frozen = realm->freeze());
+            REQUIRE(frozen->read_group().get_table("class_object")->size() == 1);
+            REQUIRE_NOTHROW(frozen = Realm::get_frozen_realm(config, realm->read_transaction_version()));
+            REQUIRE(frozen->read_group().get_table("class_object")->size() == 1);
+        }
+        SECTION("notify()") {
+            REQUIRE_NOTHROW(realm->notify());
+        }
+        SECTION("is_in_read_transaction()") {
+            REQUIRE(realm->is_in_read_transaction());
+        }
+        SECTION("last_seen_transaction_version()") {
+            REQUIRE(realm->last_seen_transaction_version() == 1);
+        }
+        SECTION("get_number_of_versions()") {
+            REQUIRE(realm->get_number_of_versions() == 1);
+        }
+        SECTION("read_transaction_version()") {
+            REQUIRE(realm->read_transaction_version() == VersionID{1, 0});
+        }
+        SECTION("current_transaction_version()") {
+            REQUIRE(realm->current_transaction_version() == VersionID{1, 0});
+        }
+        SECTION("latest_snapshot_version()") {
+            REQUIRE(realm->latest_snapshot_version() == 1);
+        }
+        SECTION("duplicate()") {
+            auto duplicate = realm->duplicate();
+            REQUIRE(duplicate->get_table("class_object")->size() == 1);
+        }
+        SECTION("invalidate()") {
+            REQUIRE_NOTHROW(realm->invalidate());
+            REQUIRE_FALSE(realm->is_in_read_transaction());
+            REQUIRE(realm->read_group().get_table("class_object")->size() == 1);
+        }
+        SECTION("close()") {
+            REQUIRE_NOTHROW(realm->close());
+            REQUIRE(realm->is_closed());
+        }
+        SECTION("has_pending_async_work()") {
+            REQUIRE_FALSE(realm->has_pending_async_work());
+        }
+        SECTION("wait_for_change()") {
+            REQUIRE_FALSE(realm->wait_for_change());
+        }
     }
 }
 


### PR DESCRIPTION
Immutable Realms have a fake read lock to make them behave mostly like mutable Realms that happen to not change, but the version on that read lock was VersionID(), which is used as a sentinel value. Switch to using VersionID(1, 0) so that the version read from an immutable Realm appears to be a normal valid VersionID.

Fixes #6260.