### PR TITLE
Separate lifecycle of sync Client from its websocket provider

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,7 +17,7 @@
 -----------
 
 ### Internals
-* None.
+* The lifecycle of the sync client is now separated from the event loop/socket provider it uses for async I/O/timers. The sync client will wait for all outstanding callbacks/sockets to be closed during destruction. The SyncSocketProvider passed to the sync client must run until after the sync client is destroyed but does not need to be stopped as part of tearing down the sync client. ([PR #6276](https://github.com/realm/realm-core/pull/6276))
 
 ----------------------------------------------
 

--- a/src/realm/object-store/sync/impl/sync_client.hpp
+++ b/src/realm/object-store/sync/impl/sync_client.hpp
@@ -116,9 +116,7 @@ struct SyncClient {
         m_client.wait_for_session_terminations_or_client_stopped();
     }
 
-    ~SyncClient()
-    {
-    }
+    ~SyncClient() {}
 
 private:
     std::shared_ptr<sync::SyncSocketProvider> m_socket_provider;

--- a/src/realm/object-store/sync/impl/sync_client.hpp
+++ b/src/realm/object-store/sync/impl/sync_client.hpp
@@ -20,6 +20,8 @@
 #define REALM_OS_SYNC_CLIENT_HPP
 
 #include <realm/sync/client.hpp>
+#include <realm/sync/network/default_socket.hpp>
+#include <realm/util/platform_info.hpp>
 #include <realm/util/scope_exit.hpp>
 
 #include <thread>
@@ -37,15 +39,20 @@ namespace _impl {
 struct SyncClient {
     SyncClient(const std::shared_ptr<util::Logger>& logger, SyncClientConfig const& config,
                std::weak_ptr<const SyncManager> weak_sync_manager)
-        : m_client([&] {
+        : m_socket_provider([&]() -> std::shared_ptr<sync::SyncSocketProvider> {
+            if (config.socket_provider) {
+                return config.socket_provider;
+            }
+            auto user_agent = util::format("RealmSync/%1 (%2) %3 %4", REALM_VERSION_STRING, util::get_platform_info(),
+                                           config.user_agent_binding_info, config.user_agent_application_info);
+            return std::make_shared<sync::websocket::DefaultSocketProvider>(logger, std::move(user_agent));
+        }())
+        , m_client([&] {
             sync::Client::Config c;
             c.logger = logger;
-            c.socket_provider = config.socket_provider;
+            c.socket_provider = m_socket_provider;
             c.reconnect_mode = config.reconnect_mode;
             c.one_connection_per_session = !config.multiplex_sessions;
-            /// DEPRECATED - Will be removed in a future release
-            c.user_agent_application_info =
-                util::format("%1 %2", config.user_agent_binding_info, config.user_agent_application_info);
 
             // Only set the timeouts if they have sensible values
             if (config.timeouts.connect_timeout >= 1000)
@@ -111,10 +118,10 @@ struct SyncClient {
 
     ~SyncClient()
     {
-        stop();
     }
 
 private:
+    std::shared_ptr<sync::SyncSocketProvider> m_socket_provider;
     sync::Client m_client;
     std::shared_ptr<util::Logger> m_logger_ptr;
     util::Logger& m_logger;

--- a/src/realm/sync/client.hpp
+++ b/src/realm/sync/client.hpp
@@ -48,6 +48,10 @@ public:
     /// Thread-safe.
     void stop() noexcept;
 
+    /// Forces all connections to close and waits for any pending work on the event
+    /// loop to complete. All sessions must be destroyed before calling drain.
+    void drain();
+
     /// \brief Cancel current or next reconnect delay for all servers.
     ///
     /// This corresponds to calling Session::cancel_reconnect_delay() on all

--- a/src/realm/sync/client_base.hpp
+++ b/src/realm/sync/client_base.hpp
@@ -133,46 +133,6 @@ static constexpr milliseconds_type default_fast_reconnect_limit = 60000;    // 1
 using RoundtripTimeHandler = void(milliseconds_type roundtrip_time);
 
 struct ClientConfig {
-    ///
-    /// DEPRECATED - Will be removed in a future release
-    ///
-    /// An optional custom platform description to be sent to server as part
-    /// of a user agent description (HTTP `User-Agent` header).
-    ///
-    /// If left empty, the platform description will be whatever is returned
-    /// by util::get_platform_info().
-    std::string user_agent_platform_info;
-
-    ///
-    /// DEPRECATED - Will be removed in a future release
-    ///
-    /// Optional information about the application to be added to the user
-    /// agent description as sent to the server. The intention is that the
-    /// application describes itself using the following (rough) syntax:
-    ///
-    ///     <application info>  ::=  (<space> <layer>)*
-    ///     <layer>             ::=  <name> "/" <version> [<space> <details>]
-    ///     <name>              ::=  (<alnum>)+
-    ///     <version>           ::=  <digit> (<alnum> | "." | "-" | "_")*
-    ///     <details>           ::=  <parentherized>
-    ///     <parentherized>     ::=  "(" (<nonpar> | <parentherized>)* ")"
-    ///
-    /// Where `<space>` is a single space character, `<digit>` is a decimal
-    /// digit, `<alnum>` is any alphanumeric character, and `<nonpar>` is
-    /// any character other than `(` and `)`.
-    ///
-    /// When multiple levels are present, the innermost layer (the one that
-    /// is closest to this API) should appear first.
-    ///
-    /// Example:
-    ///
-    ///     RealmJS/2.13.0 RealmStudio/2.9.0
-    ///
-    /// Note: The user agent description is not intended for machine
-    /// interpretation, but should still follow the specified syntax such
-    /// that it remains easily interpretable by human beings.
-    std::string user_agent_application_info;
-
     /// An optional logger to be used by the client. If no logger is
     /// specified, the client will use an instance of util::StderrLogger
     /// with the log level threshold set to util::Logger::Level::info. The

--- a/src/realm/sync/network/default_socket.cpp
+++ b/src/realm/sync/network/default_socket.cpp
@@ -490,7 +490,7 @@ DefaultSocketProvider::~DefaultSocketProvider()
     REALM_ASSERT(m_state == State::Stopped);
 
 
-    //FIXME this should go away when we remove the need for the keep running timer altogether.
+    // FIXME this should go away when we remove the need for the keep running timer altogether.
     m_service.post([this](Status status) {
         REALM_ASSERT(status.is_ok());
         m_keep_running_timer->cancel();

--- a/src/realm/sync/network/default_socket.cpp
+++ b/src/realm/sync/network/default_socket.cpp
@@ -17,14 +17,14 @@ namespace {
 class DefaultWebSocketImpl final : public DefaultWebSocket, public Config {
 public:
     DefaultWebSocketImpl(const std::shared_ptr<util::Logger>& logger_ptr, network::Service& service,
-                         std::mt19937_64& random, const std::string user_agent, WebSocketObserver& observer,
-                         WebSocketEndpoint&& endpoint)
+                         std::mt19937_64& random, const std::string user_agent,
+                         std::unique_ptr<WebSocketObserver> observer, WebSocketEndpoint&& endpoint)
         : m_logger_ptr{logger_ptr}
         , m_logger{*m_logger_ptr}
         , m_random{random}
         , m_service{service}
         , m_user_agent{user_agent}
-        , m_observer{observer}
+        , m_observer{std::move(observer)}
         , m_endpoint{std::move(endpoint)}
         , m_websocket(*this)
     {
@@ -72,7 +72,7 @@ private:
             m_app_services_coid = it->second;
         }
         auto it = headers.find("Sec-WebSocket-Protocol");
-        m_observer.websocket_connected_handler(it == headers.end() ? empty : it->second);
+        m_observer->websocket_connected_handler(it == headers.end() ? empty : it->second);
     }
     void websocket_read_error_handler(std::error_code ec) override
     {
@@ -163,13 +163,13 @@ private:
     bool websocket_error_and_close_handler(bool was_clean, Status status)
     {
         if (!was_clean) {
-            m_observer.websocket_error_handler();
+            m_observer->websocket_error_handler();
         }
-        return m_observer.websocket_closed_handler(was_clean, status);
+        return m_observer->websocket_closed_handler(was_clean, status);
     }
     bool websocket_binary_message_received(const char* ptr, std::size_t size) override
     {
-        return m_observer.websocket_binary_message_received(util::Span<const char>(ptr, size));
+        return m_observer->websocket_binary_message_received(util::Span<const char>(ptr, size));
     }
 
     void initiate_resolve();
@@ -196,7 +196,7 @@ private:
     const std::string m_user_agent;
     std::string m_app_services_coid;
 
-    WebSocketObserver& m_observer;
+    std::unique_ptr<WebSocketObserver> m_observer;
 
     const WebSocketEndpoint m_endpoint;
     util::Optional<network::Resolver> m_resolver;
@@ -484,13 +484,19 @@ DefaultSocketProvider::DefaultSocketProvider(const std::shared_ptr<util::Logger>
 DefaultSocketProvider::~DefaultSocketProvider()
 {
     m_logger_ptr->trace("Default event loop teardown");
-    if (m_keep_running_timer)
-        m_keep_running_timer->cancel();
-
     // Wait for the thread to stop
     stop(true);
     // Shutting down - no need to lock mutex before check
     REALM_ASSERT(m_state == State::Stopped);
+
+
+    //FIXME this should go away when we remove the need for the keep running timer altogether.
+    m_service.post([this](Status status) {
+        REALM_ASSERT(status.is_ok());
+        m_keep_running_timer->cancel();
+    });
+    m_service.reset();
+    m_service.run();
 }
 
 void DefaultSocketProvider::start()
@@ -626,11 +632,11 @@ void DefaultSocketProvider::state_wait_for(std::unique_lock<std::mutex>& lock, S
     });
 }
 
-std::unique_ptr<WebSocketInterface> DefaultSocketProvider::connect(WebSocketObserver* observer,
+std::unique_ptr<WebSocketInterface> DefaultSocketProvider::connect(std::unique_ptr<WebSocketObserver> observer,
                                                                    WebSocketEndpoint&& endpoint)
 {
-    return std::make_unique<DefaultWebSocketImpl>(m_logger_ptr, m_service, m_random, m_user_agent, *observer,
-                                                  std::move(endpoint));
+    return std::make_unique<DefaultWebSocketImpl>(m_logger_ptr, m_service, m_random, m_user_agent,
+                                                  std::move(observer), std::move(endpoint));
 }
 
 } // namespace realm::sync::websocket

--- a/src/realm/sync/noinst/client_impl_base.cpp
+++ b/src/realm/sync/noinst/client_impl_base.cpp
@@ -702,8 +702,8 @@ void Connection::handle_reconnect_wait(Status status)
         initiate_reconnect(); // Throws
 }
 
-struct Connection::WebSocketObserverImpl : public sync::WebSocketObserver {
-    explicit WebSocketObserverImpl(Connection* conn)
+struct Connection::WebSocketObserverShim : public sync::WebSocketObserver {
+    explicit WebSocketObserverShim(Connection* conn)
         : conn(conn)
         , sentinel(conn->m_websocket_sentinel)
     {
@@ -793,7 +793,7 @@ void Connection::initiate_reconnect()
 
     m_websocket_error_received = false;
     m_websocket =
-        m_client.m_socket_provider->connect(std::make_unique<WebSocketObserverImpl>(this),
+        m_client.m_socket_provider->connect(std::make_unique<WebSocketObserverShim>(this),
                                             WebSocketEndpoint{
                                                 m_address,
                                                 m_port,

--- a/src/realm/sync/noinst/client_impl_base.cpp
+++ b/src/realm/sync/noinst/client_impl_base.cpp
@@ -237,7 +237,37 @@ std::string ClientImpl::make_user_agent_string(ClientConfig& config)
 void ClientImpl::post(SyncSocketProvider::FunctionHandler&& handler)
 {
     REALM_ASSERT(m_socket_provider);
-    m_socket_provider->post(std::move(handler));
+    {
+        std::lock_guard lock(m_drain_mutex);
+        ++m_outstanding_posts;
+        m_drained = false;
+    }
+    m_socket_provider->post([handler = std::move(handler), this](Status status) {
+        handler(status);
+
+        std::lock_guard lock(m_drain_mutex);
+        --m_outstanding_posts;
+        m_drain_cv.notify_all();
+    });
+}
+
+
+void ClientImpl::drain_connections()
+{
+    logger.debug("Draining connections during sync client shutdown");
+    for (auto& server_slot_pair : m_server_slots) {
+        auto& server_slot = server_slot_pair.second;
+
+        if (server_slot.connection) {
+            auto& conn = server_slot.connection;
+            conn->force_close();
+        }
+        else {
+            for (auto& conn_pair : server_slot.alt_connections) {
+                conn_pair.second->force_close();
+            }
+        }
+    }
 }
 
 
@@ -245,13 +275,25 @@ SyncSocketProvider::SyncTimer ClientImpl::create_timer(std::chrono::milliseconds
                                                        SyncSocketProvider::FunctionHandler&& handler)
 {
     REALM_ASSERT(m_socket_provider);
-    return m_socket_provider->create_timer(delay, std::move(handler));
+    {
+        std::lock_guard lock(m_drain_mutex);
+        ++m_outstanding_posts;
+        m_drained = false;
+    }
+    return m_socket_provider->create_timer(delay, [handler = std::move(handler), this](Status status) {
+        handler(status);
+
+        std::lock_guard lock(m_drain_mutex);
+        --m_outstanding_posts;
+        m_drain_cv.notify_all();
+    });
 }
+
 
 ClientImpl::SyncTrigger ClientImpl::create_trigger(SyncSocketProvider::FunctionHandler&& handler)
 {
     REALM_ASSERT(m_socket_provider);
-    return std::make_unique<Trigger<SyncSocketProvider>>(m_socket_provider.get(), std::move(handler));
+    return std::make_unique<Trigger<ClientImpl>>(this, std::move(handler));
 }
 
 
@@ -343,6 +385,25 @@ void Connection::cancel_reconnect_delay()
     }
     // Nothing to do in this case. The next reconnect attemp will be made as
     // soon as there are any sessions that are both active and unsuspended.
+}
+
+
+void Connection::force_close()
+{
+    if (m_disconnect_delay_in_progress || m_reconnect_delay_in_progress) {
+        m_reconnect_disconnect_timer.reset();
+        m_disconnect_delay_in_progress = false;
+        m_reconnect_delay_in_progress = false;
+    }
+
+    REALM_ASSERT(m_num_active_unsuspended_sessions == 0);
+    REALM_ASSERT(m_num_active_sessions == 0);
+    if (m_state == ConnectionState::disconnected) {
+        return;
+    }
+
+    voluntary_disconnect();
+    logger.info("Force disconnected");
 }
 
 
@@ -659,6 +720,52 @@ void Connection::handle_reconnect_wait(Status status)
         initiate_reconnect(); // Throws
 }
 
+struct Connection::WebSocketObserverImpl : public sync::WebSocketObserver {
+    explicit WebSocketObserverImpl(Connection* conn)
+        : conn(conn)
+        , sentinel(conn->m_websocket_sentinel)
+    {
+    }
+
+    Connection* conn;
+    util::bind_ptr<LifecycleSentinel> sentinel;
+
+    void websocket_connected_handler(const std::string& protocol) override
+    {
+        if (sentinel->destroyed) {
+            return;
+        }
+
+        return conn->websocket_connected_handler(protocol);
+    }
+
+    void websocket_error_handler() override
+    {
+        if (sentinel->destroyed) {
+            return;
+        }
+
+        conn->websocket_error_handler();
+    }
+
+    bool websocket_binary_message_received(util::Span<const char> data) override
+    {
+        if (sentinel->destroyed) {
+            return false;
+        }
+
+        return conn->websocket_binary_message_received(data);
+    }
+
+    bool websocket_closed_handler(bool was_clean, Status status) override
+    {
+        if (sentinel->destroyed) {
+            return true;
+        }
+
+        return conn->websocket_closed_handler(was_clean, std::move(status));
+    }
+};
 
 void Connection::initiate_reconnect()
 {
@@ -666,6 +773,10 @@ void Connection::initiate_reconnect()
 
     m_state = ConnectionState::connecting;
     report_connection_state_change(ConnectionState::connecting); // Throws
+    if (m_websocket_sentinel) {
+        m_websocket_sentinel->destroyed = true;
+    }
+    m_websocket_sentinel = util::make_bind<LifecycleSentinel>();
     m_websocket.reset();
 
     // In most cases, the reconnect delay will be counting from the point in
@@ -699,20 +810,21 @@ void Connection::initiate_reconnect()
     }
 
     m_websocket_error_received = false;
-    m_websocket = m_client.m_socket_provider->connect(
-        this, WebSocketEndpoint{
-                  m_address,
-                  m_port,
-                  get_http_request_path(),
-                  std::move(sec_websocket_protocol),
-                  is_ssl(m_protocol_envelope),
-                  /// DEPRECATED - The following will be removed in a future release
-                  {m_custom_http_headers.begin(), m_custom_http_headers.end()},
-                  m_verify_servers_ssl_certificate,
-                  m_ssl_trust_certificate_path,
-                  m_ssl_verify_callback,
-                  m_proxy_config,
-              });
+    m_websocket =
+        m_client.m_socket_provider->connect(std::make_unique<WebSocketObserverImpl>(this),
+                                            WebSocketEndpoint{
+                                                m_address,
+                                                m_port,
+                                                get_http_request_path(),
+                                                std::move(sec_websocket_protocol),
+                                                is_ssl(m_protocol_envelope),
+                                                /// DEPRECATED - The following will be removed in a future release
+                                                {m_custom_http_headers.begin(), m_custom_http_headers.end()},
+                                                m_verify_servers_ssl_certificate,
+                                                m_ssl_trust_certificate_path,
+                                                m_ssl_verify_callback,
+                                                m_proxy_config,
+                                            });
 }
 
 
@@ -893,7 +1005,10 @@ void Connection::initiate_write_message(const OutputBuffer& out, Session* sess)
     if (m_websocket_error_received)
         return;
 
-    m_websocket->async_write_binary(util::Span<const char>{out.data(), out.size()}, [this](Status status) {
+    m_websocket->async_write_binary(out.as_span(), [this, sentinel = m_websocket_sentinel](Status status) {
+        if (sentinel->destroyed) {
+            return;
+        }
         if (status == ErrorCodes::OperationAborted)
             return;
         else if (!status.is_ok())
@@ -977,7 +1092,10 @@ void Connection::send_ping()
 
 void Connection::initiate_write_ping(const OutputBuffer& out)
 {
-    m_websocket->async_write_binary(util::Span<const char>{out.data(), out.size()}, [this](Status status) {
+    m_websocket->async_write_binary(out.as_span(), [this, sentinel = m_websocket_sentinel](Status status) {
+        if (sentinel->destroyed) {
+            return;
+        }
         if (status == ErrorCodes::OperationAborted)
             return;
         else if (!status.is_ok())
@@ -1143,6 +1261,8 @@ void Connection::disconnect(const SessionErrorInfo& info)
     m_heartbeat_timer.reset();
     m_previous_ping_rtt = 0;
 
+    m_websocket_sentinel->destroyed = true;
+    m_websocket_sentinel.reset();
     m_websocket.reset();
     m_input_body_buffer.reset();
     m_sending_session = nullptr;

--- a/src/realm/sync/noinst/client_impl_base.cpp
+++ b/src/realm/sync/noinst/client_impl_base.cpp
@@ -278,6 +278,13 @@ ClientImpl::SyncTrigger ClientImpl::create_trigger(SyncSocketProvider::FunctionH
     return std::make_unique<Trigger<ClientImpl>>(this, std::move(handler));
 }
 
+Connection::~Connection()
+{
+    if (m_websocket_sentinel) {
+        m_websocket_sentinel->destroyed = true;
+        m_websocket_sentinel.reset();
+    }
+}
 
 void Connection::activate()
 {

--- a/src/realm/sync/noinst/client_impl_base.hpp
+++ b/src/realm/sync/noinst/client_impl_base.hpp
@@ -1212,8 +1212,6 @@ inline int ClientImpl::Connection::get_negotiated_protocol_version() noexcept
     return m_negotiated_protocol_version;
 }
 
-inline ClientImpl::Connection::~Connection() {}
-
 template <class H>
 void ClientImpl::Connection::for_each_active_session(H handler)
 {

--- a/src/realm/sync/noinst/client_impl_base.hpp
+++ b/src/realm/sync/noinst/client_impl_base.hpp
@@ -325,7 +325,7 @@ enum class ClientImpl::ConnectionTerminationReason {
 /// occur on behalf of the event loop thread of the associated client object.
 
 // TODO: The parent will be updated to WebSocketObserver once the WebSocket integration is complete
-class ClientImpl::Connection final : public WebSocketObserver {
+class ClientImpl::Connection {
 public:
     using connection_ident_type = std::int_fast64_t;
     using SSLVerifyCallback = SyncConfig::SSLVerifyCallback;
@@ -401,10 +401,10 @@ public:
     int get_negotiated_protocol_version() noexcept;
 
     // Methods from WebSocketObserver interface for websockets from the Socket Provider
-    void websocket_connected_handler(const std::string& protocol) override;
-    bool websocket_binary_message_received(util::Span<const char> data) override;
-    void websocket_error_handler() override;
-    bool websocket_closed_handler(bool, Status) override;
+    void websocket_connected_handler(const std::string& protocol);
+    bool websocket_binary_message_received(util::Span<const char> data);
+    void websocket_error_handler();
+    bool websocket_closed_handler(bool, Status);
 
     connection_ident_type get_ident() const noexcept;
     const ServerEndpoint& get_server_endpoint() const noexcept;
@@ -427,7 +427,7 @@ private:
     struct LifecycleSentinel : public util::AtomicRefCountBase {
         bool destroyed = false;
     };
-    struct WebSocketObserverImpl;
+    struct WebSocketObserverShim;
 
     using ReceivedChangesets = ClientProtocol::ReceivedChangesets;
 

--- a/src/realm/sync/noinst/client_impl_base.hpp
+++ b/src/realm/sync/noinst/client_impl_base.hpp
@@ -279,8 +279,6 @@ private:
     void drain_connections();
     void drain_connections_on_loop();
 
-    static std::string make_user_agent_string(ClientConfig&);
-
     session_ident_type get_next_session_ident() noexcept;
 
     friend class ClientImpl::Connection;

--- a/src/realm/sync/noinst/client_impl_base.hpp
+++ b/src/realm/sync/noinst/client_impl_base.hpp
@@ -139,6 +139,8 @@ public:
     /// This calls stop() on the socket provider respectively.
     void stop() noexcept;
 
+    void drain();
+
     const std::string& get_user_agent_string() const noexcept;
     ReconnectMode get_reconnect_mode() const noexcept;
     bool is_dry_run() const noexcept;
@@ -148,7 +150,7 @@ public:
     void post(SyncSocketProvider::FunctionHandler&& handler);
     SyncSocketProvider::SyncTimer create_timer(std::chrono::milliseconds delay,
                                                SyncSocketProvider::FunctionHandler&& handler);
-    using SyncTrigger = std::unique_ptr<Trigger<SyncSocketProvider>>;
+    using SyncTrigger = std::unique_ptr<Trigger<ClientImpl>>;
     SyncTrigger create_trigger(SyncSocketProvider::FunctionHandler&& handler);
 
     std::mt19937_64& get_random() noexcept;
@@ -210,7 +212,13 @@ private:
     // Must be accessed only by event loop thread
     connection_ident_type m_prev_connection_ident = 0;
 
-    util::Mutex m_mutex;
+    std::mutex m_drain_mutex;
+    std::condition_variable m_drain_cv;
+    bool m_drained = false;
+    uint64_t m_outstanding_posts = 0;
+    uint64_t m_num_connections = 0;
+
+    std::mutex m_mutex;
 
     bool m_stopped = false;                       // Protected by `m_mutex`
     bool m_sessions_terminated = false;           // Protected by `m_mutex`
@@ -230,7 +238,7 @@ private:
     SessionWrapperStack m_abandoned_session_wrappers;
 
     // Protected by `m_mutex`.
-    util::CondVar m_wait_or_client_stopped_cond;
+    std::condition_variable m_wait_or_client_stopped_cond;
 
     void register_unactualized_session_wrapper(SessionWrapper*, ServerEndpoint);
     void register_abandoned_session_wrapper(util::bind_ptr<SessionWrapper>) noexcept;
@@ -267,6 +275,9 @@ private:
 
     // Destroys the specified connection.
     void remove_connection(ClientImpl::Connection&) noexcept;
+
+    void drain_connections();
+    void drain_connections_on_loop();
 
     static std::string make_user_agent_string(ClientConfig&);
 
@@ -381,6 +392,8 @@ public:
     /// activated.
     void cancel_reconnect_delay();
 
+    void force_close();
+
     /// Returns zero until the HTTP response is received. After that point in
     /// time, it returns the negotiated protocol version, which is based on the
     /// contents of the `Sec-WebSocket-Protocol` header in the HTTP
@@ -413,6 +426,11 @@ public:
     ~Connection();
 
 private:
+    struct LifecycleSentinel : public util::AtomicRefCountBase {
+        bool destroyed = false;
+    };
+    struct WebSocketObserverImpl;
+
     using ReceivedChangesets = ClientProtocol::ReceivedChangesets;
 
     template <class H>
@@ -499,6 +517,7 @@ private:
     friend class Session;
 
     ClientImpl& m_client;
+    util::bind_ptr<LifecycleSentinel> m_websocket_sentinel;
     std::unique_ptr<WebSocketInterface> m_websocket;
     const ProtocolEnvelope m_protocol_envelope;
     const std::string m_address;

--- a/src/realm/sync/socket_provider.hpp
+++ b/src/realm/sync/socket_provider.hpp
@@ -97,7 +97,7 @@ public:
     /// websocket will call directly to the handlers provided by the observer.
     /// The WebSocketObserver guarantees that the WebSocket object will be
     /// closed/destroyed before the observer is terminated/destroyed.
-    virtual std::unique_ptr<WebSocketInterface> connect(WebSocketObserver* observer,
+    virtual std::unique_ptr<WebSocketInterface> connect(std::unique_ptr<WebSocketObserver> observer,
                                                         WebSocketEndpoint&& endpoint) = 0;
 
     /// Submit a handler function to be executed by the event loop (thread).

--- a/src/realm/util/buffer_stream.hpp
+++ b/src/realm/util/buffer_stream.hpp
@@ -22,6 +22,8 @@
 #include <cstddef>
 #include <sstream>
 
+#include <realm/util/span.hpp>
+
 namespace realm {
 namespace util {
 
@@ -47,6 +49,9 @@ public:
     /// of the stream buffer, or since the last invocation of reset()
     /// (std::basic_streambuf::pptr() - std::basic_streambuf::pbase()).
     std::size_t size() const noexcept;
+
+    util::Span<C> as_span() noexcept;
+    util::Span<const C> as_span() const noexcept;
 };
 
 
@@ -68,6 +73,9 @@ public:
 
     /// Calls BasicResettableExpandableOutputStreambuf::size().
     std::size_t size() const noexcept;
+
+    util::Span<C> as_span() noexcept;
+    util::Span<const C> as_span() const noexcept;
 
 private:
     BasicResettableExpandableOutputStreambuf<C, T, A> m_streambuf;
@@ -109,6 +117,18 @@ inline std::size_t BasicResettableExpandableOutputStreambuf<C, T, A>::size() con
 }
 
 template <class C, class T, class A>
+inline util::Span<C> BasicResettableExpandableOutputStreambuf<C, T, A>::as_span() noexcept
+{
+    return util::Span<C>(data(), size());
+}
+
+template <class C, class T, class A>
+inline util::Span<const C> BasicResettableExpandableOutputStreambuf<C, T, A>::as_span() const noexcept
+{
+    return util::Span<const C>(data(), size());
+}
+
+template <class C, class T, class A>
 inline BasicResettableExpandableBufferOutputStream<C, T, A>::BasicResettableExpandableBufferOutputStream()
     : std::basic_ostream<C, T>(&m_streambuf) // Throws
 {
@@ -138,6 +158,18 @@ template <class C, class T, class A>
 inline std::size_t BasicResettableExpandableBufferOutputStream<C, T, A>::size() const noexcept
 {
     return m_streambuf.size();
+}
+
+template <class C, class T, class A>
+inline util::Span<C> BasicResettableExpandableBufferOutputStream<C, T, A>::as_span() noexcept
+{
+    return util::Span<C>(m_streambuf.data(), m_streambuf.size());
+}
+
+template <class C, class T, class A>
+inline util::Span<const C> BasicResettableExpandableBufferOutputStream<C, T, A>::as_span() const noexcept
+{
+    return util::Span<const C>(m_streambuf.data(), m_streambuf.size());
 }
 
 } // namespace util

--- a/test/object-store/sync/app.cpp
+++ b/test/object-store/sync/app.cpp
@@ -2139,14 +2139,14 @@ TEST_CASE("app: sync integration", "[sync][app]") {
         {
         }
 
-        std::unique_ptr<sync::WebSocketInterface> connect(sync::WebSocketObserver* observer,
+        std::unique_ptr<sync::WebSocketInterface> connect(std::unique_ptr<sync::WebSocketObserver> observer,
                                                           sync::WebSocketEndpoint&& endpoint) override
         {
             int status_code = 101;
             std::string body;
             bool use_simulated_response = websocket_connect_func && websocket_connect_func(status_code, body);
 
-            auto websocket = DefaultSocketProvider::connect(observer, std::move(endpoint));
+            auto websocket = DefaultSocketProvider::connect(std::move(observer), std::move(endpoint));
             if (use_simulated_response) {
                 auto default_websocket = static_cast<sync::websocket::DefaultWebSocket*>(websocket.get());
                 if (default_websocket)

--- a/test/sync_fixtures.hpp
+++ b/test/sync_fixtures.hpp
@@ -567,6 +567,7 @@ public:
     {
         unit_test::TestContext& test_context = m_test_context;
         stop();
+        m_clients.clear();
         m_client_socket_providers.clear();
         for (int i = 0; i < m_num_servers; ++i) {
             if (m_server_threads[i].joinable())
@@ -668,8 +669,7 @@ public:
             });
         }
         // We can't wait for clearing the simulated failure since some tests stop the client early
-        client.stop();
-        m_client_socket_providers[index]->stop(true);
+        client.drain();
     }
 
     void stop()

--- a/test/sync_fixtures.hpp
+++ b/test/sync_fixtures.hpp
@@ -539,7 +539,6 @@ public:
             m_client_socket_providers.push_back(std::make_shared<websocket::DefaultSocketProvider>(
                 m_client_loggers[i], "", websocket::DefaultSocketProvider::AutoStart{false}));
             config_2.socket_provider = m_client_socket_providers.back();
-            config_2.user_agent_application_info = "TestFixture/" REALM_VERSION_STRING;
             config_2.logger = m_client_loggers[i];
             config_2.reconnect_mode = ReconnectMode::testing;
             config_2.ping_keepalive_period = config.client_ping_period;

--- a/test/test_sync.cpp
+++ b/test/test_sync.cpp
@@ -2996,8 +2996,7 @@ TEST_IF(Sync_SSL_Certificate_Verify_Callback_External, false)
     session.bind();
     session.wait_for_download_complete_or_client_stopped();
 
-    client.stop();
-    socket_provider->stop(true);
+    client.drain();
 }
 
 #endif // REALM_HAVE_OPENSSL
@@ -3156,7 +3155,6 @@ TEST(Sync_UploadDownloadProgress_1)
         });
 
         client.stop();
-        socket_provider->stop(true);
         CHECK_EQUAL(number_of_handler_calls, 1);
     }
 }
@@ -3405,9 +3403,7 @@ TEST(Sync_UploadDownloadProgress_3)
     int entry = 0;
 
     bool should_signal_cond_var = false;
-    bool cond_var_signaled = false;
-    std::mutex mutex;
-    std::condition_variable cond_var;
+    auto signal_pf = util::make_promise_future<void>();
 
     uint_fast64_t downloaded_bytes_1 = 123; // Not zero
     uint_fast64_t downloadable_bytes_1 = 123;
@@ -3416,9 +3412,10 @@ TEST(Sync_UploadDownloadProgress_3)
     uint_fast64_t progress_version_1 = 123;
     uint_fast64_t snapshot_version_1 = 0;
 
-    auto progress_handler = [&](uint_fast64_t downloaded_bytes, uint_fast64_t downloadable_bytes,
+    auto progress_handler = [&, promise = util::CopyablePromiseHolder(std::move(signal_pf.promise))](
+                                uint_fast64_t downloaded_bytes, uint_fast64_t downloadable_bytes,
                                 uint_fast64_t uploaded_bytes, uint_fast64_t uploadable_bytes,
-                                uint_fast64_t progress_version, uint_fast64_t snapshot_version) {
+                                uint_fast64_t progress_version, uint_fast64_t snapshot_version) mutable {
         downloaded_bytes_1 = downloaded_bytes;
         downloadable_bytes_1 = downloadable_bytes;
         uploaded_bytes_1 = uploaded_bytes;
@@ -3441,10 +3438,7 @@ TEST(Sync_UploadDownloadProgress_3)
         }
 
         if (should_signal_cond_var) {
-            std::unique_lock<std::mutex> lock(mutex);
-            cond_var_signaled = true;
-            lock.unlock();
-            cond_var.notify_one();
+            promise.get_promise().emplace_value();
         }
 
         entry++;
@@ -3481,12 +3475,7 @@ TEST(Sync_UploadDownloadProgress_3)
         session.nonsync_transact_notify(commited_version);
     }
 
-    {
-        std::unique_lock<std::mutex> lock(mutex);
-        cond_var.wait(lock, [&] {
-            return cond_var_signaled;
-        });
-    }
+    signal_pf.future.get();
 
     CHECK_EQUAL(downloaded_bytes_1, 0);
     CHECK_EQUAL(downloadable_bytes_1, 0);
@@ -3494,10 +3483,7 @@ TEST(Sync_UploadDownloadProgress_3)
     CHECK_NOT_EQUAL(uploadable_bytes_1, 0);
     CHECK_EQUAL(snapshot_version_1, commited_version);
 
-    client.stop();
-
     server_thread.join();
-    socket_provider->stop(true);
 }
 
 
@@ -3621,18 +3607,17 @@ TEST(Sync_UploadDownloadProgress_5)
     TEST_DIR(server_dir);
     TEST_CLIENT_DB(db);
 
-    bool cond_var_signaled = false;
-    std::mutex mutex;
-    std::condition_variable cond_var;
+    auto [progress_handled_promise, progress_handled] = util::make_promise_future<void>();
 
     ClientServerFixture fixture(server_dir, test_context);
     fixture.start();
 
     Session session = fixture.make_session(db);
 
-    auto progress_handler = [&](uint_fast64_t downloaded_bytes, uint_fast64_t downloadable_bytes,
+    auto progress_handler = [&, promise = util::CopyablePromiseHolder(std::move(progress_handled_promise))](
+                                uint_fast64_t downloaded_bytes, uint_fast64_t downloadable_bytes,
                                 uint_fast64_t uploaded_bytes, uint_fast64_t uploadable_bytes,
-                                uint_fast64_t progress_version, uint_fast64_t snapshot_version) {
+                                uint_fast64_t progress_version, uint_fast64_t snapshot_version) mutable {
         CHECK_EQUAL(downloaded_bytes, 0);
         CHECK_EQUAL(downloadable_bytes, 0);
         CHECK_EQUAL(uploaded_bytes, 0);
@@ -3640,20 +3625,14 @@ TEST(Sync_UploadDownloadProgress_5)
 
         if (progress_version > 0) {
             CHECK_EQUAL(snapshot_version, 3);
-            std::unique_lock<std::mutex> lock(mutex);
-            cond_var_signaled = true;
-            lock.unlock();
-            cond_var.notify_one();
+            promise.get_promise().emplace_value();
         }
     };
 
     session.set_progress_handler(progress_handler);
 
-    std::unique_lock<std::mutex> lock(mutex);
     fixture.bind_session(session, "/test");
-    cond_var.wait(lock, [&] {
-        return cond_var_signaled;
-    });
+    progress_handled.get();
 
     // The check is that we reach this point.
 }
@@ -3720,9 +3699,8 @@ TEST(Sync_UploadDownloadProgress_6)
         session->bind();
     }
 
-    client.stop();
+    client.drain();
     server.stop();
-    socket_provider->stop(true);
     server_thread.join();
 
     // The check is that we reach this point without deadlocking.
@@ -4340,6 +4318,7 @@ TEST(Sync_MergeMultipleChangesets)
         fixture.start_client(0);
         session_1.wait_for_upload_complete_or_client_stopped();
         session_1.wait_for_download_complete_or_client_stopped();
+        session_1.detach();
         // Stop first client.
         fixture.stop_client(0);
 
@@ -4458,8 +4437,7 @@ TEST(Sync_ServerDiscardDeadConnections)
 
     BowlOfStonesSemaphore bowl;
     auto error_handler = [&](std::error_code ec, bool, const std::string&) {
-        bool valid_error = ec == sync::websocket::make_error_code(ErrorCodes::ReadError);
-        CHECK(valid_error);
+        CHECK_EQUAL(ec, sync::websocket::make_error_code(ErrorCodes::ReadError));
         bowl.add_stone();
     };
     fixture.set_client_side_error_handler(std::move(error_handler));
@@ -5066,7 +5044,6 @@ TEST_IF(Sync_SSL_Certificates, false)
         session.bind();
 
         session.wait_for_download_complete_or_client_stopped();
-        client.stop();
     }
 }
 

--- a/test/test_sync.cpp
+++ b/test/test_sync.cpp
@@ -3400,7 +3400,6 @@ TEST(Sync_UploadDownloadProgress_3)
     // entry is used to count the number of calls to
     // progress_handler. At the first call, the server is
     // not running, and it is started by progress_handler().
-    int entry = 0;
 
     bool should_signal_cond_var = false;
     auto signal_pf = util::make_promise_future<void>();
@@ -3412,7 +3411,7 @@ TEST(Sync_UploadDownloadProgress_3)
     uint_fast64_t progress_version_1 = 123;
     uint_fast64_t snapshot_version_1 = 0;
 
-    auto progress_handler = [&, promise = util::CopyablePromiseHolder(std::move(signal_pf.promise))](
+    auto progress_handler = [&, entry = int(0), promise = util::CopyablePromiseHolder(std::move(signal_pf.promise))](
                                 uint_fast64_t downloaded_bytes, uint_fast64_t downloadable_bytes,
                                 uint_fast64_t uploaded_bytes, uint_fast64_t uploadable_bytes,
                                 uint_fast64_t progress_version, uint_fast64_t snapshot_version) mutable {

--- a/test/test_sync_history_migration.cpp
+++ b/test/test_sync_history_migration.cpp
@@ -321,6 +321,7 @@ TEST(Sync_HistoryMigration)
 
     auto get_server_path = [&](const std::string& server_dir) {
         fixtures::ClientServerFixture fixture{server_dir, test_context};
+        fixture.start();
         return fixture.map_virtual_to_real_path(virtual_path);
     };
 


### PR DESCRIPTION
## What, How & Why?
This makes it so you can destroy a sync Client without having to destroy or even stop the run loop its using for network I/O, timers, and other asynchronous callbacks. The event loop the sync client is running on must be running in order to tear down the sync client successfully, but the sync client no longer needs to be able to control the event loop or wait for it to stop to safely stop itself.

I've also made a few other minor changes in support of the larger change:
 - replace the use of `util::Mutex`/`util::CondVar` in the sync client with `std::mutex`/`std::condition_variable`.
 - move the creation/lifetime of the `DefaultSocketProvider` out of the sync client itself and into the object store wrapper for the sync client
 - the `SyncSocketProvider` `connect()` method now takes a `WebSocketObserver` wrapped in a `std::unique_ptr` rather than as a bare ptr. This lets the sync client add some extra lifecycle tracking information to its asynchronous I/O handling so that any asynchronous I/O calls that complete after the sync client is destroyed do not call into a destroyed/freed object.

## ☑️ ToDos
* [x] 📝 Changelog update
* [x] 🚦 Tests (or not relevant)
* [ ] C-API, if public C++ API changed.
