### PR TITLE
[C API] Integration test for websocket provider

### DIFF
--- a/src/realm/object-store/c_api/socket_provider.cpp
+++ b/src/realm/object-store/c_api/socket_provider.cpp
@@ -12,7 +12,8 @@ public:
               realm_sync_socket_create_timer_func_t create_timer_func,
               realm_sync_socket_timer_canceled_func_t cancel_timer_func,
               realm_sync_socket_timer_free_func_t free_timer_func)
-        : m_timer_create(create_timer_func)
+        : m_handler(handler)
+        , m_timer_create(create_timer_func)
         , m_timer_cancel(cancel_timer_func)
         , m_timer_free(free_timer_func)
     {
@@ -24,6 +25,7 @@ public:
     {
         m_timer_cancel(m_userdata, m_timer);
         m_timer_free(m_userdata, m_timer);
+        realm_release(m_handler);
     }
 
     /// Cancel the timer immediately.
@@ -36,6 +38,7 @@ private:
     realm_sync_socket_timer_t m_timer = nullptr;
 
     realm_userdata_t m_userdata = nullptr;
+    realm_sync_socket_callback_t* m_handler = nullptr;
     realm_sync_socket_create_timer_func_t m_timer_create = nullptr;
     realm_sync_socket_timer_canceled_func_t m_timer_cancel = nullptr;
     realm_sync_socket_timer_free_func_t m_timer_free = nullptr;

--- a/test/object-store/c_api/c_api.cpp
+++ b/test/object-store/c_api/c_api.cpp
@@ -5902,6 +5902,7 @@ TEST_CASE("C API app: websocket provider", "[c_api][sync][app]") {
     auto realm = Realm::get_shared_realm(test_config);
     wait_for_download(*realm);
 
+    default_socket_provider.stop(true);
     realm_release(socket_provider);
 }
 #endif // REALM_ENABLE_AUTH_TESTS

--- a/test/object-store/sync/flx_sync_harness.hpp
+++ b/test/object-store/sync/flx_sync_harness.hpp
@@ -72,17 +72,20 @@ public:
         ServerSchema server_schema;
         std::shared_ptr<GenericNetworkTransport> transport = instance_of<SynchronousTestTransport>;
         ReconnectMode reconnect_mode = ReconnectMode::testing;
+        std::shared_ptr<realm::sync::SyncSocketProvider> custom_socket_provider = nullptr;
     };
 
     explicit FLXSyncTestHarness(Config&& config)
         : m_test_session(make_app_from_server_schema(config.test_name, config.server_schema), config.transport, true,
-                         config.reconnect_mode)
+                         config.reconnect_mode, config.custom_socket_provider)
         , m_schema(std::move(config.server_schema.schema))
     {
     }
     FLXSyncTestHarness(const std::string& test_name, ServerSchema server_schema = default_server_schema(),
-                       std::shared_ptr<GenericNetworkTransport> transport = instance_of<SynchronousTestTransport>)
-        : m_test_session(make_app_from_server_schema(test_name, server_schema), std::move(transport))
+                       std::shared_ptr<GenericNetworkTransport> transport = instance_of<SynchronousTestTransport>,
+                       std::shared_ptr<realm::sync::SyncSocketProvider> custom_socket_provider = nullptr)
+        : m_test_session(make_app_from_server_schema(test_name, server_schema), std::move(transport), true,
+                         realm::ReconnectMode::normal, custom_socket_provider)
         , m_schema(std::move(server_schema.schema))
     {
     }


### PR DESCRIPTION
## What, How & Why?
E2E C API test using DefaultSocketProvider as custom websocket provider. This tests the existing C API and makes sure everything works as expected.
Fixes #6169.

## ☑️ ToDos
* [ ] ~~📝 Changelog update~~
* [x] 🚦 Tests (or not relevant)
* [ ] ~~C-API, if public C++ API changed.~~
