### PR TITLE
Fix sync benchmarks

### DIFF
--- a/test/benchmark-sync/bench_transform.cpp
+++ b/test/benchmark-sync/bench_transform.cpp
@@ -95,6 +95,7 @@ void transform_transactions(TestContext& test_context)
         fixture.start_client(1);
         session_2.wait_for_upload_complete_or_client_stopped();
         session_2.wait_for_download_complete_or_client_stopped();
+        session_2.detach();
         fixture.stop_client(1);
 
         // Upload changes of first client and wait to integrate changes from second client.
@@ -175,6 +176,7 @@ void transform_instructions(TestContext& test_context)
         fixture.start_client(1);
         session_2.wait_for_upload_complete_or_client_stopped();
         session_2.wait_for_download_complete_or_client_stopped();
+        session_2.detach();
         fixture.stop_client(1);
 
         // Upload changes of first client and wait to integrate changes from second client.

--- a/test/benchmark-sync/bench_transform.cpp
+++ b/test/benchmark-sync/bench_transform.cpp
@@ -255,6 +255,7 @@ void connected_objects(TestContext& test_context)
         fixture.start_client(1);
         session_2.wait_for_upload_complete_or_client_stopped();
         session_2.wait_for_download_complete_or_client_stopped();
+        session_2.detach();
         fixture.stop_client(1);
 
         // Upload changes of first client and wait to integrate changes from second client.


### PR DESCRIPTION
## What, How & Why?
This updates our sync benchmarks to detach any sessions before explicitly stopping/draining their associated sync clients. I updated the evergreen build to build/run the benchmarks as part of the testing for this PR.

## ☑️ ToDos
* [ ] 📝 Changelog update
* [x] 🚦 Tests (or not relevant)
* [ ] C-API, if public C++ API changed.
