### PR TITLE
BadChangesetError and TransformError notify users to contact support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ### Enhancements
 * <New feature description> (PR [#????](https://github.com/realm/realm-core/pull/????))
-* None.
+* IntegrationException's which require help from support team mention 'Please contact support' in their message ([#6283](https://github.com/realm/realm-core/pull/6283))
 
 ### Fixed
 * <How do the end-user experience this issue? what was the impact?> ([#????](https://github.com/realm/realm-core/issues/????), since v?.?.?)

--- a/src/realm/sync/changeset.hpp
+++ b/src/realm/sync/changeset.hpp
@@ -13,7 +13,10 @@ namespace sync {
 using InternStrings = std::vector<StringBufferRange>;
 
 struct BadChangesetError : ExceptionWithBacktrace<std::runtime_error> {
-    using ExceptionWithBacktrace<std::runtime_error>::ExceptionWithBacktrace;
+    BadChangesetError(const std::string& msg)
+        : ExceptionWithBacktrace<std::runtime_error>(util::format("%1. Please contact support", msg))
+    {
+    }
 };
 
 struct Changeset {

--- a/src/realm/sync/transform.cpp
+++ b/src/realm/sync/transform.cpp
@@ -908,7 +908,7 @@ REALM_NORETURN void bad_merge(_impl::TransformerImpl::Side& side, Instruction::P
 {
     std::stringstream ss;
     side.m_changeset->print_path(ss, instr.table, instr.object, instr.field, &instr.path);
-    bad_merge("%1 (instruction target: %2)", msg, ss.str());
+    bad_merge("%1 (instruction target: %2). Please contact support", msg, ss.str());
 }
 
 template <class LeftInstruction, class RightInstruction, class Enable = void>


### PR DESCRIPTION
## What, How & Why?
There are errors/exceptions which require help from support. Therefore, such error messages will mention `Please contact support`.

By default, all BadChangesetError's will contain the message above.
Additionally, TransformError's not related to schema will contain the message above.

## ☑️ ToDos
* [x] 📝 Changelog update
* [ ] ~~🚦 Tests (or not relevant)~~
* [ ] ~~C-API, if public C++ API changed.~~
