### PR TITLE
Fix wrong handling of WebSocket_Retry_Error

### DIFF
--- a/src/realm/sync/noinst/client_impl_base.cpp
+++ b/src/realm/sync/noinst/client_impl_base.cpp
@@ -518,7 +518,7 @@ bool Connection::websocket_closed_handler(bool was_clean, Status status)
         m_reconnect_info.m_reason = ConnectionTerminationReason::http_response_says_fatal_error;
         close_due_to_client_side_error(error_code, std::nullopt, is_fatal); // Throws
     }
-    else if (status_code == ErrorCodes::WebSocket_Retry_Error || status_code == ErrorCodes::WebSocket_Forbidden) {
+    else if (status_code == ErrorCodes::WebSocket_Fatal_Error || status_code == ErrorCodes::WebSocket_Forbidden) {
         constexpr bool is_fatal = true;
         m_reconnect_info.m_reason = ConnectionTerminationReason::http_response_says_fatal_error;
         close_due_to_client_side_error(error_code, std::nullopt, is_fatal); // Throws


### PR DESCRIPTION
## What, How & Why?
WebSocket_Fatal_Error error code was never handled. Instead WebSocket_Retry_Error was handled twice.

## ☑️ ToDos
* [ ] ~~📝 Changelog update~~
* [ ] ~~🚦 Tests (or not relevant)~~
* [ ] ~~C-API, if public C++ API changed.~~
