### PR TITLE
Re-create all objects before updating their properties during client_reset::transfer_group()

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 * <How do the end-user experience this issue? what was the impact?> ([#????](https://github.com/realm/realm-core/issues/????), since v?.?.?)
 * App 301/308 redirection support doesn't use new location if metadata mode is set to 'NoMetadata'. ([#6280](https://github.com/realm/realm-core/issues/6280), since v12.9.0)
 * Expose ad hoc interface for querying dictionary key changes in the C-API. ([#6228](https://github.com/realm/realm-core/issues/6228), since v10.3.3)
+* Client reset with recovery or discard local could fail if there were dangling links in lists that got ressurected while the list was being transferred from the fresh realm ([#6292](https://github.com/realm/realm-core/issues/6292), since v11.5.0)
 
 ### Breaking changes
 * None.

--- a/src/realm/sync/noinst/client_reset.cpp
+++ b/src/realm/sync/noinst/client_reset.cpp
@@ -335,6 +335,8 @@ void transfer_group(const Transaction& group_src, Transaction& group_dst, util::
     for (auto table_key : group_src.get_table_keys()) {
         ConstTableRef table_src = group_src.get_table(table_key);
         auto table_name = table_src->get_name();
+        if (should_skip_table(group_src, table_key) || table_src->is_embedded())
+            continue;
         TableRef table_dst = group_dst.get_table(table_name);
         auto pk_col = table_src->get_primary_key_column();
         REALM_ASSERT(pk_col);

--- a/src/realm/sync/noinst/client_reset.cpp
+++ b/src/realm/sync/noinst/client_reset.cpp
@@ -329,7 +329,7 @@ void transfer_group(const Transaction& group_src, Transaction& group_dst, util::
         }
     }
 
-    // We must re-create any missing objects that are abscent in dst before trying to copy
+    // We must re-create any missing objects that are absent in dst before trying to copy
     // their properties because creating them may re-create any dangling links which would
     // otherwise cause inconsistencies when re-creating lists of links.
     for (auto table_key : group_src.get_table_keys()) {
@@ -344,9 +344,9 @@ void transfer_group(const Transaction& group_src, Transaction& group_dst, util::
                      "primary_key_col = %3, primary_key_type = %4",
                      table_name, table_src->size(), pk_col.get_index().val, pk_col.get_type());
         for (const Obj& src : *table_src) {
-            bool updated = false;
-            table_dst->create_object_with_primary_key(src.get_primary_key(), &updated);
-            if (updated) {
+            bool created = false;
+            table_dst->create_object_with_primary_key(src.get_primary_key(), &created);
+            if (created) {
                 logger.debug("   created %1", src.get_primary_key());
             }
         }
@@ -379,7 +379,7 @@ void transfer_group(const Transaction& group_src, Transaction& group_dst, util::
 
         for (const Obj& src : *table_src) {
             auto src_pk = src.get_primary_key();
-            // get or create the object
+            // create the object - it should have been created above.
             auto dst = table_dst->get_object_with_primary_key(src_pk);
             REALM_ASSERT(dst);
 

--- a/src/realm/sync/noinst/client_reset.cpp
+++ b/src/realm/sync/noinst/client_reset.cpp
@@ -329,8 +329,28 @@ void transfer_group(const Transaction& group_src, Transaction& group_dst, util::
         }
     }
 
-    converters::EmbeddedObjectConverter embedded_tracker;
+    // We must re-create any missing objects that are abscent in dst before trying to copy
+    // their properties because creating them may re-create any dangling links which would
+    // otherwise cause inconsistencies when re-creating lists of links.
+    for (auto table_key : group_src.get_table_keys()) {
+        ConstTableRef table_src = group_src.get_table(table_key);
+        auto table_name = table_src->get_name();
+        TableRef table_dst = group_dst.get_table(table_name);
+        auto pk_col = table_src->get_primary_key_column();
+        REALM_ASSERT(pk_col);
+        logger.debug("Creating missing objects for table '%1', number of rows = %2, "
+                     "primary_key_col = %3, primary_key_type = %4",
+                     table_name, table_src->size(), pk_col.get_index().val, pk_col.get_type());
+        for (const Obj& src : *table_src) {
+            bool updated = false;
+            table_dst->create_object_with_primary_key(src.get_primary_key(), &updated);
+            if (updated) {
+                logger.debug("   created %1", src.get_primary_key());
+            }
+        }
+    }
 
+    converters::EmbeddedObjectConverter embedded_tracker;
     // Now src and dst have identical schemas and no extraneous objects from dst.
     // There may be missing object from src and the values of existing objects may
     // still differ. Diff all the values and create missing objects on the fly.
@@ -357,11 +377,11 @@ void transfer_group(const Transaction& group_src, Transaction& group_dst, util::
 
         for (const Obj& src : *table_src) {
             auto src_pk = src.get_primary_key();
-            bool updated = false;
             // get or create the object
-            auto dst = table_dst->create_object_with_primary_key(src_pk, &updated);
+            auto dst = table_dst->get_object_with_primary_key(src_pk);
             REALM_ASSERT(dst);
 
+            bool updated = false;
             converter.copy(src, dst, &updated);
             if (updated) {
                 logger.debug("  updating %1", src_pk);

--- a/test/test_client_reset.cpp
+++ b/test/test_client_reset.cpp
@@ -54,14 +54,12 @@ TEST(ClientReset_TransferGroupWithDanglingLinks)
     auto sg_2 = setup_realm(path_2);
 
     auto rt = sg_1->start_read();
-
-    rt->commit_and_continue_as_read();
-
     auto wt = sg_2->start_write();
-    auto target_2 = wt->get_table("class_target");
 
+    auto target_2 = wt->get_table("class_target");
     auto obj = target_2->get_object_with_primary_key(Mixed{5});
     obj.invalidate();
+
     wt->commit_and_continue_writing();
     _impl::client_reset::transfer_group(*rt, *wt, *test_context.logger);
 }

--- a/test/test_client_reset.cpp
+++ b/test/test_client_reset.cpp
@@ -6,6 +6,9 @@
 #include <realm/list.hpp>
 #include <realm/table_view.hpp>
 
+#include <realm/object_converter.hpp>
+#include <realm/sync/noinst/client_reset.hpp>
+
 #include "test.hpp"
 #include "sync_fixtures.hpp"
 #include "util/semaphore.hpp"
@@ -19,6 +22,49 @@ using namespace realm::fixtures;
 namespace {
 
 using ErrorInfo = Session::ErrorInfo;
+
+TEST(ClientReset_TransferGroupWithDanglingLinks)
+{
+    SHARED_GROUP_TEST_PATH(path_1);
+    SHARED_GROUP_TEST_PATH(path_2);
+
+    auto setup_realm = [](auto& path) {
+        DBRef sg = DB::create(make_client_replication(), path);
+
+        auto wt = sg->start_write();
+
+        // The ordering of creating the tables matters here. The bug this test is verifying depends
+        // on tablekeys being created such that the table that links come from is transferred before
+        // the table that links are linking to.
+        auto table = wt->add_table_with_primary_key("class_table", type_String, "_id");
+        auto target = wt->add_table_with_primary_key("class_target", type_Int, "_id");
+        table->add_column_list(*target, "list");
+        auto obj = table->create_object_with_primary_key(Mixed{"the_object"});
+        auto lst = obj.get_linklist("list");
+        for (int64_t i = 0; i < 10; ++i) {
+            target->create_object_with_primary_key(i);
+            lst.add(target->create_object_with_primary_key(i).get_key());
+        }
+        wt->commit();
+
+        return sg;
+    };
+
+    auto sg_1 = setup_realm(path_1);
+    auto sg_2 = setup_realm(path_2);
+
+    auto rt = sg_1->start_read();
+
+    rt->commit_and_continue_as_read();
+
+    auto wt = sg_2->start_write();
+    auto target_2 = wt->get_table("class_target");
+
+    auto obj = target_2->get_object_with_primary_key(Mixed{5});
+    obj.invalidate();
+    wt->commit_and_continue_writing();
+    _impl::client_reset::transfer_group(*rt, *wt, *test_context.logger);
+}
 
 TEST(ClientReset_NoLocalChanges)
 {


### PR DESCRIPTION
## What, How & Why?
This fixes a crash in automatic client resets where there are dangling links in the destination realm (i.e. the realm being client reset). The `transfer_group()` function takes a fresh copy of a realm and transfers a source realm's contents to a target by comparing each property in each object in each table, and creating/setting properties as needed if they don't exist or do not match. If the target table has a list of links where some of them are dangling, and the dangling link targets exist in the source realm, it will create the target objects, thereby resurrecting the dangling link, and end up with duplicate entries in the list. This violates an invariant in the IntraRealmObjectConverter class.

## ☑️ ToDos
* [x] 📝 Changelog update
* [x] 🚦 Tests (or not relevant)
* [ ] C-API, if public C++ API changed.
