### PR TITLE
Wait for sessions to drain during sync client shutdown

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,8 +5,7 @@
 * None.
 
 ### Fixed
-* <How do the end-user experience this issue? what was the impact?> ([#????](https://github.com/realm/realm-core/issues/????), since v?.?.?)
-* None.
+* Sync client may [have failed an assertion](https://github.com/realm/realm-core/blob/006660c8d20c4941d3838f74aec6f3561ebf6784/src/realm/sync/noinst/client_impl_base.cpp#L388) during shutdown if all sessions hadn't been ready to finalize by the time the Client destructor ran. (PR [#6293](https://github.com/realm/realm-core/pull/6293), since v13.4.1)
 
 ### Breaking changes
 * None.

--- a/src/realm/object-store/sync/impl/sync_client.hpp
+++ b/src/realm/object-store/sync/impl/sync_client.hpp
@@ -95,7 +95,7 @@ struct SyncClient {
 
     void stop()
     {
-        m_client.stop();
+        m_client.shutdown();
     }
 
     std::unique_ptr<sync::Session> make_session(std::shared_ptr<DB> db,

--- a/src/realm/sync/client.cpp
+++ b/src/realm/sync/client.cpp
@@ -600,7 +600,7 @@ void ClientImpl::actualize_and_finalize_session_wrappers()
     while (util::bind_ptr<SessionWrapper> wrapper = abandoned_session_wrappers.pop())
         wrapper->finalize(); // Throws
     if (stopped) {
-        for (auto& p: unactualized_session_wrappers) {
+        for (auto& p : unactualized_session_wrappers) {
             SessionWrapper& wrapper = *p.first;
             wrapper.finalize_before_actualization();
         }

--- a/src/realm/sync/client.cpp
+++ b/src/realm/sync/client.cpp
@@ -400,7 +400,7 @@ ClientImpl::~ClientImpl()
     // Since no other thread is allowed to be accessing this client or any of
     // its subobjects at this time, no mutex locking is necessary.
 
-    drain();
+    shutdown_and_wait();
     // Session wrappers are removed from m_unactualized_session_wrappers as they
     // are abandoned.
     REALM_ASSERT(m_stopped);
@@ -499,9 +499,9 @@ void ClientImpl::drain_connections_on_loop()
     });
 }
 
-void ClientImpl::drain()
+void ClientImpl::shutdown_and_wait()
 {
-    stop();
+    shutdown();
     std::unique_lock lock{m_drain_mutex};
     if (m_drained) {
         return;
@@ -515,7 +515,7 @@ void ClientImpl::drain()
     m_drained = true;
 }
 
-void ClientImpl::stop() noexcept
+void ClientImpl::shutdown() noexcept
 {
     {
         std::lock_guard lock{m_mutex};
@@ -1906,14 +1906,14 @@ Client::Client(Client&& client) noexcept
 Client::~Client() noexcept {}
 
 
-void Client::stop() noexcept
+void Client::shutdown() noexcept
 {
-    m_impl->stop();
+    m_impl->shutdown();
 }
 
-void Client::drain()
+void Client::shutdown_and_wait()
 {
-    m_impl->drain();
+    m_impl->shutdown_and_wait();
 }
 
 void Client::cancel_reconnect_delay()

--- a/src/realm/sync/client.hpp
+++ b/src/realm/sync/client.hpp
@@ -46,11 +46,11 @@ public:
     /// See run().
     ///
     /// Thread-safe.
-    void stop() noexcept;
+    void shutdown() noexcept;
 
     /// Forces all connections to close and waits for any pending work on the event
-    /// loop to complete. All sessions must be destroyed before calling drain.
-    void drain();
+    /// loop to complete. All sessions must be destroyed before calling shutdown_and_wait.
+    void shutdown_and_wait();
 
     /// \brief Cancel current or next reconnect delay for all servers.
     ///

--- a/src/realm/sync/noinst/client_impl_base.cpp
+++ b/src/realm/sync/noinst/client_impl_base.cpp
@@ -228,6 +228,7 @@ void ClientImpl::post(SyncSocketProvider::FunctionHandler&& handler)
         handler(status);
 
         std::lock_guard lock(m_drain_mutex);
+        REALM_ASSERT(m_outstanding_posts);
         --m_outstanding_posts;
         m_drain_cv.notify_all();
     });
@@ -266,6 +267,7 @@ SyncSocketProvider::SyncTimer ClientImpl::create_timer(std::chrono::milliseconds
         handler(status);
 
         std::lock_guard lock(m_drain_mutex);
+        REALM_ASSERT(m_outstanding_posts);
         --m_outstanding_posts;
         m_drain_cv.notify_all();
     });
@@ -301,6 +303,7 @@ void Connection::activate()
 void Connection::activate_session(std::unique_ptr<Session> sess)
 {
     REALM_ASSERT(&sess->m_conn == this);
+    REALM_ASSERT(!m_force_closed);
     Session& sess_2 = *sess;
     session_ident_type ident = sess->m_ident;
     auto p = m_sessions.emplace(ident, std::move(sess)); // Throws
@@ -318,15 +321,14 @@ void Connection::activate_session(std::unique_ptr<Session> sess)
 void Connection::initiate_session_deactivation(Session* sess)
 {
     REALM_ASSERT(&sess->m_conn == this);
+    REALM_ASSERT(m_num_active_sessions);
     if (REALM_UNLIKELY(--m_num_active_sessions == 0)) {
         if (m_activated && m_state == ConnectionState::disconnected)
             m_on_idle->trigger();
     }
     sess->initiate_deactivation(); // Throws
     if (sess->m_state == Session::Deactivated) {
-        // Session is now deactivated, so remove and destroy it.
-        session_ident_type ident = sess->m_ident;
-        m_sessions.erase(ident);
+        finish_session_deactivation(sess);
     }
 }
 
@@ -376,27 +378,37 @@ void Connection::cancel_reconnect_delay()
     // soon as there are any sessions that are both active and unsuspended.
 }
 
+void ClientImpl::Connection::finish_session_deactivation(Session* sess)
+{
+    REALM_ASSERT(sess->m_state == Session::Deactivated);
+    auto ident = sess->m_ident;
+    m_sessions.erase(ident);
+}
 
 void Connection::force_close()
 {
+    logger.debug("force close");
+    if (m_force_closed) {
+        return;
+    }
+
     m_force_closed = true;
-    if (m_disconnect_delay_in_progress || m_reconnect_delay_in_progress) {
-        m_reconnect_disconnect_timer.reset();
-        m_disconnect_delay_in_progress = false;
-        m_reconnect_delay_in_progress = false;
+    if (m_state != ConnectionState::disconnected) {
+        voluntary_disconnect();
     }
 
-    if (m_num_active_unsuspended_sessions || m_num_active_sessions) {
-        logger.detail("Connection will close when remaining sessions are destroyed");
-        return;
+    std::vector<Session*> to_close;
+    for (auto& session_pair : m_sessions) {
+        if (session_pair.second->m_state == Session::State::Active) {
+            to_close.push_back(session_pair.second.get());
+        }
     }
 
-    if (m_state == ConnectionState::disconnected) {
-        return;
+    for (auto& sess : to_close) {
+        sess->force_close();
     }
 
-    voluntary_disconnect();
-    logger.info("Force disconnected");
+    logger.debug("Force closed idle connection");
 }
 
 
@@ -440,6 +452,10 @@ void Connection::websocket_connected_handler(const std::string& protocol)
 
 bool Connection::websocket_binary_message_received(util::Span<const char> data)
 {
+    if (get_client().m_stopped) {
+        logger.debug("Received binary message after client stop");
+        return false;
+    }
     std::error_code ec;
     using sf = SimulatedFailure;
     if (sf::trigger(sf::sync_client__read_head, ec)) {
@@ -460,6 +476,10 @@ void Connection::websocket_error_handler()
 
 bool Connection::websocket_closed_handler(bool was_clean, Status status)
 {
+    if (get_client().m_stopped) {
+        logger.debug("Received websocket close message after client stop");
+        return false;
+    }
     logger.info("Closing the websocket with status='%1', was_clean='%2'", status, was_clean);
     // Return early.
     if (status.is_ok()) {
@@ -547,6 +567,11 @@ void Connection::initiate_reconnect_wait()
     REALM_ASSERT(m_activated);
     REALM_ASSERT(!m_reconnect_delay_in_progress);
     REALM_ASSERT(!m_disconnect_delay_in_progress);
+
+    // If we've been force closed then we don't need/want to reconnect. Just return early here.
+    if (m_force_closed) {
+        return;
+    }
 
     using milliseconds_lim = ReconnectInfo::milliseconds_lim;
 
@@ -1018,9 +1043,7 @@ void Connection::handle_write_message()
 {
     m_sending_session->message_sent(); // Throws
     if (m_sending_session->m_state == Session::Deactivated) {
-        // Session is now deactivated, so remove and destroy it.
-        session_ident_type ident = m_sending_session->m_ident;
-        m_sessions.erase(ident);
+        finish_session_deactivation(m_sending_session);
     }
     m_sending_session = nullptr;
     m_sending = false;
@@ -1048,9 +1071,7 @@ void Connection::send_next_message()
         sess.send_message(); // Throws
 
         if (sess.m_state == Session::Deactivated) {
-            // Session is now deactivated, so remove and destroy it.
-            session_ident_type ident = sess.m_ident;
-            m_sessions.erase(ident);
+            finish_session_deactivation(&sess);
         }
 
         // An enlisted session may choose to not send a message. In that case,
@@ -1332,9 +1353,7 @@ void Connection::receive_error_message(const ProtocolErrorInfo& info, session_id
         }
 
         if (sess->m_state == Session::Deactivated) {
-            // Session is now deactivated, so remove and destroy it.
-            session_ident_type ident = sess->m_ident;
-            m_sessions.erase(ident);
+            finish_session_deactivation(sess);
         }
         return;
     }
@@ -1448,9 +1467,7 @@ void Connection::receive_unbound_message(session_ident_type session_ident)
     }
 
     if (sess->m_state == Session::Deactivated) {
-        // Session is now deactivated, so remove and destroy it.
-        session_ident_type ident = sess->m_ident;
-        m_sessions.erase(ident);
+        finish_session_deactivation(sess);
     }
 }
 

--- a/src/realm/sync/noinst/client_impl_base.cpp
+++ b/src/realm/sync/noinst/client_impl_base.cpp
@@ -452,8 +452,8 @@ void Connection::websocket_connected_handler(const std::string& protocol)
 
 bool Connection::websocket_binary_message_received(util::Span<const char> data)
 {
-    if (get_client().m_stopped) {
-        logger.debug("Received binary message after client stop");
+    if (m_force_closed) {
+        logger.debug("Received binary message after connection was force closed");
         return false;
     }
     std::error_code ec;
@@ -476,8 +476,8 @@ void Connection::websocket_error_handler()
 
 bool Connection::websocket_closed_handler(bool was_clean, Status status)
 {
-    if (get_client().m_stopped) {
-        logger.debug("Received websocket close message after client stop");
+    if (m_force_closed) {
+        logger.debug("Received websocket close message after connection was force closed");
         return false;
     }
     logger.info("Closing the websocket with status='%1', was_clean='%2'", status, was_clean);

--- a/src/realm/sync/noinst/client_impl_base.cpp
+++ b/src/realm/sync/noinst/client_impl_base.cpp
@@ -379,14 +379,18 @@ void Connection::cancel_reconnect_delay()
 
 void Connection::force_close()
 {
+    m_force_closed = true;
     if (m_disconnect_delay_in_progress || m_reconnect_delay_in_progress) {
         m_reconnect_disconnect_timer.reset();
         m_disconnect_delay_in_progress = false;
         m_reconnect_delay_in_progress = false;
     }
 
-    REALM_ASSERT(m_num_active_unsuspended_sessions == 0);
-    REALM_ASSERT(m_num_active_sessions == 0);
+    if (m_num_active_unsuspended_sessions || m_num_active_sessions) {
+        logger.detail("Connection will close when remaining sessions are destroyed");
+        return;
+    }
+
     if (m_state == ConnectionState::disconnected) {
         return;
     }

--- a/src/realm/sync/noinst/client_impl_base.cpp
+++ b/src/realm/sync/noinst/client_impl_base.cpp
@@ -387,14 +387,21 @@ void ClientImpl::Connection::finish_session_deactivation(Session* sess)
 
 void Connection::force_close()
 {
-    logger.debug("force close");
     if (m_force_closed) {
         return;
     }
 
     m_force_closed = true;
+
     if (m_state != ConnectionState::disconnected) {
         voluntary_disconnect();
+    }
+
+    REALM_ASSERT(m_state == ConnectionState::disconnected);
+    if (m_reconnect_delay_in_progress || m_disconnect_delay_in_progress) {
+        m_reconnect_disconnect_timer.reset();
+        m_reconnect_delay_in_progress = false;
+        m_disconnect_delay_in_progress = false;
     }
 
     std::vector<Session*> to_close;

--- a/src/realm/sync/noinst/client_impl_base.cpp
+++ b/src/realm/sync/noinst/client_impl_base.cpp
@@ -1754,8 +1754,9 @@ void Session::activate()
     }
     catch (const IntegrationException& error) {
         logger.error("Error integrating bootstrap changesets: %1", error.what());
-        on_suspended(SessionErrorInfo{error.code(), false});
+        m_suspended = true;
         m_conn.one_less_active_unsuspended_session(); // Throws
+        on_suspended(SessionErrorInfo{error.code(), false});
     }
 
     if (has_pending_client_reset) {

--- a/src/realm/sync/noinst/client_impl_base.cpp
+++ b/src/realm/sync/noinst/client_impl_base.cpp
@@ -404,6 +404,9 @@ void Connection::force_close()
         m_disconnect_delay_in_progress = false;
     }
 
+    // We must copy any session pointers we want to close to a vector because force_closing
+    // the session may remove it from m_sessions and invalidate the iterator uses to loop
+    // through the map. By copying to a separate vector we ensure our iterators remain valid.
     std::vector<Session*> to_close;
     for (auto& session_pair : m_sessions) {
         if (session_pair.second->m_state == Session::State::Active) {

--- a/src/realm/sync/noinst/client_impl_base.hpp
+++ b/src/realm/sync/noinst/client_impl_base.hpp
@@ -569,6 +569,8 @@ private:
 
     bool m_websocket_error_received = false;
 
+    bool m_force_closed = false;
+
     // The timer will be constructed on demand, and will only be destroyed when
     // canceling a reconnect or disconnect delay.
     //
@@ -1264,6 +1266,12 @@ inline void ClientImpl::Connection::one_less_active_unsuspended_session()
 {
     if (--m_num_active_unsuspended_sessions != 0)
         return;
+
+    if (m_force_closed) {
+        voluntary_disconnect();
+        logger.info("Connection force closed after all sessions destroyed");
+        return;
+    }
     // Dropped from one to zero
     if (m_state != ConnectionState::disconnected)
         initiate_disconnect_wait(); // Throws

--- a/src/realm/sync/noinst/client_impl_base.hpp
+++ b/src/realm/sync/noinst/client_impl_base.hpp
@@ -1267,7 +1267,7 @@ inline void ClientImpl::Connection::one_less_active_unsuspended_session()
     if (--m_num_active_unsuspended_sessions != 0)
         return;
 
-    if (m_force_closed) {
+    if (m_force_closed && m_state != ConnectionState::disconnected) {
         voluntary_disconnect();
         logger.info("Connection force closed after all sessions destroyed");
         return;

--- a/src/realm/sync/noinst/client_impl_base.hpp
+++ b/src/realm/sync/noinst/client_impl_base.hpp
@@ -136,9 +136,9 @@ public:
 
     static constexpr int get_oldest_supported_protocol_version() noexcept;
 
-    void stop() noexcept;
+    void shutdown() noexcept;
 
-    void drain();
+    void shutdown_and_wait();
 
     const std::string& get_user_agent_string() const noexcept;
     ReconnectMode get_reconnect_mode() const noexcept;
@@ -219,7 +219,7 @@ private:
 
     std::mutex m_mutex;
 
-    std::atomic<bool> m_stopped = false;
+    bool m_stopped = false;                       // Protected by `m_mutex`
     bool m_sessions_terminated = false;           // Protected by `m_mutex`
     bool m_actualize_and_finalize_needed = false; // Protected by `m_mutex`
 

--- a/test/sync_fixtures.hpp
+++ b/test/sync_fixtures.hpp
@@ -566,7 +566,9 @@ public:
     {
         unit_test::TestContext& test_context = m_test_context;
         stop();
-        m_clients.clear();
+        for (int i = 0; i < m_num_clients; ++i) {
+            m_clients[i]->shutdown_and_wait();
+        }
         m_client_socket_providers.clear();
         for (int i = 0; i < m_num_servers; ++i) {
             if (m_server_threads[i].joinable())
@@ -668,13 +670,13 @@ public:
             });
         }
         // We can't wait for clearing the simulated failure since some tests stop the client early
-        client.drain();
+        client.shutdown_and_wait();
     }
 
     void stop()
     {
         for (int i = 0; i < m_num_clients; ++i)
-            m_clients[i]->stop();
+            m_clients[i]->shutdown();
         for (int i = 0; i < m_num_servers; ++i)
             m_servers[i]->stop();
     }

--- a/test/test_sync.cpp
+++ b/test/test_sync.cpp
@@ -2980,7 +2980,7 @@ TEST_IF(Sync_SSL_Certificate_Verify_Callback_External, false)
                                   " preverify_ok = %4, depth = %5",
                                   server_address, server_port, pem, preverify_ok, depth);
         if (depth == 0)
-            client.stop();
+            client.shutdown();
         return true;
     };
 
@@ -2996,7 +2996,7 @@ TEST_IF(Sync_SSL_Certificate_Verify_Callback_External, false)
     session.bind();
     session.wait_for_download_complete_or_client_stopped();
 
-    client.drain();
+    client.shutdown_and_wait();
 }
 
 #endif // REALM_HAVE_OPENSSL

--- a/test/test_sync.cpp
+++ b/test/test_sync.cpp
@@ -2273,7 +2273,7 @@ TEST_IF(Sync_ReadOnlyClient, false)
     fixture.set_client_side_error_handler(1, [&](std::error_code ec, bool, const std::string&) {
         CHECK_EQUAL(ProtocolError::permission_denied, ec);
         did_get_permission_denied = true;
-        fixture.get_client(1).stop();
+        fixture.get_client(1).shutdown();
     });
     fixture.start();
 
@@ -3154,7 +3154,7 @@ TEST(Sync_UploadDownloadProgress_1)
             return cond_var_signaled;
         });
 
-        client.stop();
+        client.shutdown();
         CHECK_EQUAL(number_of_handler_calls, 1);
     }
 }
@@ -3698,7 +3698,7 @@ TEST(Sync_UploadDownloadProgress_6)
         session->bind();
     }
 
-    client.drain();
+    client.shutdown_and_wait();
     server.stop();
     server_thread.join();
 
@@ -5035,7 +5035,7 @@ TEST_IF(Sync_SSL_Certificates, false)
                     error_info->error_code, error_info->is_fatal(), error_info->message);
                 // We expect to get through the SSL handshake but will hit an error due to the wrong token.
                 CHECK_NOT_EQUAL(error_info->error_code, Client::Error::ssl_server_cert_rejected);
-                client.stop();
+                client.shutdown();
             }
         };
 


### PR DESCRIPTION
## What, How & Why?
There's a race when force closing a connection where sessions may still be getting finalized. This makes it so that if there are still any active sessions on a connection, force_close() makes it so that the connection will close as soon as the last session has ended and will skip all the linger period timing.

## ☑️ ToDos
* [x] 📝 Changelog update
* [x] 🚦 Tests (or not relevant)
* [ ] C-API, if public C++ API changed.
