### PR TITLE
Pass callback and user data by value in realm_mongo_collection_<func>

### DIFF
--- a/src/realm/object-store/c_api/app.cpp
+++ b/src/realm/object-store/c_api/app.cpp
@@ -948,7 +948,7 @@ RLM_API bool realm_mongo_collection_find(realm_mongodb_collection_t* collection,
     return wrap_err([&] {
         collection->find_bson(convert_to_bson<bson::BsonDocument>(filter_ejson),
                               to_mongodb_collection_find_options(options),
-                              [&](util::Optional<bson::Bson> bson, util::Optional<AppError> app_error) {
+                              [=](util::Optional<bson::Bson> bson, util::Optional<AppError> app_error) {
                                   handle_mongodb_collection_result(bson, app_error, {data, delete_data}, callback);
                               });
         return true;
@@ -965,7 +965,7 @@ RLM_API bool realm_mongo_collection_find_one(realm_mongodb_collection_t* collect
     return wrap_err([&] {
         collection->find_one_bson(
             convert_to_bson<bson::BsonDocument>(filter_ejson), to_mongodb_collection_find_options(options),
-            [&](util::Optional<bson::Bson> bson, util::Optional<AppError> app_error) {
+            [=](util::Optional<bson::Bson> bson, util::Optional<AppError> app_error) {
                 handle_mongodb_collection_result(bson, app_error, {data, delete_data}, callback);
             });
         return true;
@@ -980,7 +980,7 @@ RLM_API bool realm_mongo_collection_aggregate(realm_mongodb_collection_t* collec
     return wrap_err([&] {
         collection->aggregate_bson(
             convert_to_bson<bson::BsonArray>(filter_ejson),
-            [&](util::Optional<bson::Bson> bson, util::Optional<AppError> app_error) {
+            [=](util::Optional<bson::Bson> bson, util::Optional<AppError> app_error) {
                 handle_mongodb_collection_result(bson, app_error, {data, delete_data}, callback);
             });
         return true;
@@ -994,7 +994,7 @@ RLM_API bool realm_mongo_collection_count(realm_mongodb_collection_t* collection
     REALM_ASSERT(collection);
     return wrap_err([&] {
         collection->count_bson(convert_to_bson<bson::BsonDocument>(filter_ejson), limit,
-                               [&](util::Optional<bson::Bson> bson, util::Optional<app::AppError> app_error) {
+                               [=](util::Optional<bson::Bson> bson, util::Optional<app::AppError> app_error) {
                                    handle_mongodb_collection_result(bson, app_error, {data, delete_data}, callback);
                                });
         return true;
@@ -1009,7 +1009,7 @@ RLM_API bool realm_mongo_collection_insert_one(realm_mongodb_collection_t* colle
     return wrap_err([&] {
         collection->insert_one_bson(
             convert_to_bson<bson::BsonDocument>(filter_ejson),
-            [&](util::Optional<bson::Bson> bson, util::Optional<AppError> app_error) {
+            [=](util::Optional<bson::Bson> bson, util::Optional<AppError> app_error) {
                 handle_mongodb_collection_result(bson, app_error, {data, delete_data}, callback);
             });
         return true;
@@ -1024,7 +1024,7 @@ RLM_API bool realm_mongo_collection_insert_many(realm_mongodb_collection_t* coll
     return wrap_err([&] {
         collection->insert_many_bson(
             convert_to_bson<bson::BsonArray>(filter_ejson),
-            [&](util::Optional<bson::Bson> bson, util::Optional<AppError> app_error) {
+            [=](util::Optional<bson::Bson> bson, util::Optional<AppError> app_error) {
                 handle_mongodb_collection_result(bson, app_error, {data, delete_data}, callback);
             });
         return true;
@@ -1039,7 +1039,7 @@ RLM_API bool realm_mongo_collection_delete_one(realm_mongodb_collection_t* colle
     return wrap_err([&] {
         collection->delete_one_bson(
             convert_to_bson<bson::BsonDocument>(filter_ejson),
-            [&](util::Optional<bson::Bson> bson, util::Optional<AppError> app_error) {
+            [=](util::Optional<bson::Bson> bson, util::Optional<AppError> app_error) {
                 handle_mongodb_collection_result(bson, app_error, {data, delete_data}, callback);
             });
         return true;
@@ -1054,7 +1054,7 @@ RLM_API bool realm_mongo_collection_delete_many(realm_mongodb_collection_t* coll
     return wrap_err([&] {
         collection->delete_many_bson(
             convert_to_bson<bson::BsonDocument>(filter_ejson),
-            [&](util::Optional<bson::Bson> bson, util::Optional<AppError> app_error) {
+            [=](util::Optional<bson::Bson> bson, util::Optional<AppError> app_error) {
                 handle_mongodb_collection_result(bson, app_error, {data, delete_data}, callback);
             });
         return true;
@@ -1072,7 +1072,7 @@ RLM_API bool realm_mongo_collection_update_one(realm_mongodb_collection_t* colle
         const auto& bson_update = convert_to_bson<bson::BsonDocument>(update_ejson);
         collection->update_one_bson(
             bson_filter, bson_update, upsert,
-            [&](util::Optional<bson::Bson> bson, util::Optional<AppError> app_error) {
+            [=](util::Optional<bson::Bson> bson, util::Optional<AppError> app_error) {
                 handle_mongodb_collection_result(bson, app_error, {data, delete_data}, callback);
             });
         return true;
@@ -1090,7 +1090,7 @@ RLM_API bool realm_mongo_collection_update_many(realm_mongodb_collection_t* coll
         const auto& bson_update = convert_to_bson<bson::BsonDocument>(update_ejson);
         collection->update_many_bson(
             bson_filter, bson_update, upsert,
-            [&](util::Optional<bson::Bson> bson, util::Optional<AppError> app_error) {
+            [=](util::Optional<bson::Bson> bson, util::Optional<AppError> app_error) {
                 handle_mongodb_collection_result(bson, app_error, {data, delete_data}, callback);
             });
         return true;
@@ -1109,7 +1109,7 @@ RLM_API bool realm_mongo_collection_find_one_and_update(realm_mongodb_collection
         const auto& bson_update = convert_to_bson<bson::BsonDocument>(update_ejson);
         collection->find_one_and_update_bson(
             bson_filter, bson_update, to_mongodb_collection_find_one_and_modify_options(options),
-            [&](util::Optional<bson::Bson> bson, util::Optional<AppError> app_error) {
+            [=](util::Optional<bson::Bson> bson, util::Optional<AppError> app_error) {
                 handle_mongodb_collection_result(bson, app_error, {data, delete_data}, callback);
             });
         return true;
@@ -1127,7 +1127,7 @@ RLM_API bool realm_mongo_collection_find_one_and_replace(
         const auto& replacement_bson = convert_to_bson<bson::BsonDocument>(replacement_ejson);
         collection->find_one_and_replace_bson(
             filter_bson, replacement_bson, to_mongodb_collection_find_one_and_modify_options(options),
-            [&](util::Optional<bson::Bson> bson, util::Optional<AppError> app_error) {
+            [=](util::Optional<bson::Bson> bson, util::Optional<AppError> app_error) {
                 handle_mongodb_collection_result(bson, app_error, {data, delete_data}, callback);
             });
         return true;
@@ -1145,7 +1145,7 @@ RLM_API bool realm_mongo_collection_find_one_and_delete(realm_mongodb_collection
         const auto& bson_filter = convert_to_bson<bson::BsonDocument>(filter_ejson);
         collection->find_one_and_delete_bson(
             bson_filter, to_mongodb_collection_find_one_and_modify_options(options),
-            [&](util::Optional<bson::Bson> bson, util::Optional<AppError> app_error) {
+            [=](util::Optional<bson::Bson> bson, util::Optional<AppError> app_error) {
                 handle_mongodb_collection_result(bson, app_error, {data, delete_data}, callback);
             });
         return true;


### PR DESCRIPTION
Fixes the C-API functions like `realm_mongo_collection_find`, `realm_mongo_collection_find_one` and so on.
The callback can not be found if its pointer is passed by reference. 
It was not handled because the tests in `realm-core` don't call these methods with passing callbacks as arguments.
Related to the implementation in https://github.com/realm/realm-dart/pull/1162
## What, How & Why?
<!-- Describe the changes and give some hints to guide your reviewers if possible. -->
<!-- Link to relevant issue this fixes -->

## ☑️ ToDos
* ~~[ ] 📝 Changelog update~~
* ~~[ ] 🚦 Tests (or not relevant)~~
* ~~[ ] C-API, if public C++ API changed.~~
