### PR TITLE
Update yarn download path in install_baas.sh

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@
   * The following APIs are now implemented using std::filesystem: `try_make_dir`/`make_dir`, `make_dir_recursive`, `try_remove_dir`/`remove_dir`, `try_remove_dir_recursive`/`remove_dir_recursive`, `File::exists`, `File::is_dir`, `File::try_remove`/`File::remove`, `File::move`, `File::copy`, `File::last_write_time`, `File::get_free_space`
   * `File::get_unique_id` now works on Windows
   * Replaced manual path string conversion with `std::filesystem::path`
+* Update yarn download path in install_baas.sh ([PR #6309](https://github.com/realm/realm-core/pull/6309))
 
 ----------------------------------------------
 

--- a/evergreen/install_baas.sh
+++ b/evergreen/install_baas.sh
@@ -227,7 +227,7 @@ YARN="$WORK_PATH/yarn/bin/yarn"
 if [[ ! -x "$YARN" ]]; then
     echo "Getting yarn"
     mkdir yarn && cd yarn
-    $CURL -LsS https://s3.amazonaws.com/stitch-artifacts/yarn/latest.tar.gz | tar -xz --strip-components=1
+    $CURL -LsS https://yarnpkg.com/latest.tar.gz | tar -xz --strip-components=1
     cd -
     mkdir "$WORK_PATH/yarn_cache"
 fi


### PR DESCRIPTION
## What, How & Why?
Yarn was failing to download from stitch-artifacts, since it had been moved to Glacier long term storage. Updated download path to use the official yarn download site: https://yarnpkg.com/latest.tar.gz


## ☑️ ToDos
* [x] 📝 Changelog update
* ~~[ ] 🚦 Tests (or not relevant)~~
* ~~[ ] C-API, if public C++ API changed.~~
