### PR TITLE
Cosmetic changes to the slab allocator to improve code coverage

### DIFF
--- a/src/realm/alloc.hpp
+++ b/src/realm/alloc.hpp
@@ -344,7 +344,7 @@ public:
         m_ref_translation_ptr.store(m_alloc->m_ref_translation_ptr);
     }
 
-    ~WrappedAllocator() {}
+    virtual ~WrappedAllocator() {}
 
     void switch_underlying_allocator(Allocator& underlying_allocator)
     {

--- a/src/realm/alloc_slab.hpp
+++ b/src/realm/alloc_slab.hpp
@@ -63,7 +63,7 @@ struct InvalidDatabase;
 /// of slabs.
 class SlabAlloc : public Allocator {
 public:
-    ~SlabAlloc() noexcept override;
+    virtual ~SlabAlloc() noexcept override;
     SlabAlloc();
 
     // Disable copying. Copying an allocator can produce double frees.
@@ -310,7 +310,7 @@ public:
     /// of an existing mapping is changed. Such a change requires all refs to be
     /// retranslated to new pointers. This will happen whenever the reader view
     /// is extended unless the old size was aligned to a section boundary.
-    uint64_t get_mapping_version()
+    inline uint64_t get_mapping_version()
     {
         return m_mapping_version;
     }
@@ -321,7 +321,7 @@ public:
     bool is_free_space_clean() const noexcept;
 
     /// Returns the amount of memory requested by calls to SlabAlloc::alloc().
-    size_t get_commit_size() const
+    inline size_t get_commit_size() const
     {
         return m_commit_size;
     }

--- a/test/test_alloc.cpp
+++ b/test/test_alloc.cpp
@@ -87,7 +87,6 @@ size_t get_capacity(const char* header)
 
 } // anonymous namespace
 
-
 TEST(Alloc_1)
 {
     SlabAlloc alloc;
@@ -122,6 +121,10 @@ TEST(Alloc_1)
     CHECK_EQUAL(static_cast<void*>(mr2.get_addr()), alloc.translate(mr2.get_ref()));
     CHECK_EQUAL(static_cast<void*>(mr3.get_addr()), alloc.translate(mr3.get_ref()));
     CHECK_EQUAL(static_cast<void*>(mr4.get_addr()), alloc.translate(mr4.get_ref()));
+
+    auto size = alloc.get_baseline();
+    CHECK(size);
+
 
     alloc.free_(mr3.get_ref(), mr3.get_addr());
     alloc.free_(mr4.get_ref(), mr4.get_addr());

--- a/test/test_destroy_guard.cpp
+++ b/test/test_destroy_guard.cpp
@@ -83,9 +83,7 @@ public:
         m_baseline = 8;
     }
 
-    ~FooAlloc() noexcept
-    {
-    }
+    virtual ~FooAlloc() noexcept {}
 
     MemRef do_alloc(const size_t size) override
     {


### PR DESCRIPTION
## What, How & Why?
I am running our core tests with code coverage enabled. These small changes improved some coverage, and also we had an allocator base class with a virtual dtor and derived classes that did not have the keyword virtual in front of their dtor. 
I don't think we are leaking memory, but the dtor was not run for the derived classes. 

