### PR TITLE
Remove non-void overloads of Session::bind()

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@
 ### Internals
 * Add CAPI test for Binding Callback Thread Observer. ([PR #6156](https://github.com/realm/realm-core/pull/6156))
 * Implement MigrationStore to support migration from PBS to FLX ([PR #6324](https://github.com/realm/realm-core/pull/6324))
+* Removed overloads of `Session::bind()` that allow binding a sync session to server other than the one configured in `Session::Config` ([PR #6358](https://github.com/realm/realm-core/pull/6358)).
 
 ----------------------------------------------
 

--- a/src/realm/sync/client.cpp
+++ b/src/realm/sync/client.cpp
@@ -189,8 +189,6 @@ public:
     void set_connection_state_change_listener(util::UniqueFunction<ConnectionStateChangeListener>);
 
     void initiate();
-    void initiate(ProtocolEnvelope, std::string server_address, port_type server_port, std::string virt_path,
-                  std::string signed_access_token);
 
     void force_close();
 
@@ -1240,21 +1238,7 @@ SessionWrapper::set_connection_state_change_listener(util::UniqueFunction<Connec
 
 inline void SessionWrapper::initiate()
 {
-    // FIXME: Storing connection related information in the session object seems
-    // unnecessary and goes against the idea that a session should be truely
-    // lightweight (when many share a single connection). The original idea was
-    // that all connection related information is passed directly from the
-    // caller of initiate() to the connection constructor.
     do_initiate(m_protocol_envelope, m_server_address, m_server_port); // Throws
-}
-
-
-inline void SessionWrapper::initiate(ProtocolEnvelope protocol, std::string server_address, port_type server_port,
-                                     std::string virt_path, std::string signed_access_token)
-{
-    m_virt_path = std::move(virt_path);
-    m_signed_access_token = std::move(signed_access_token);
-    do_initiate(protocol, std::move(server_address), server_port); // Throws
 }
 
 
@@ -1969,27 +1953,6 @@ void Session::set_connection_state_change_listener(util::UniqueFunction<Connecti
 void Session::bind()
 {
     m_impl->initiate(); // Throws
-}
-
-
-void Session::bind(std::string server_url, std::string signed_access_token)
-{
-    ClientImpl& client = m_impl->get_client();
-    ProtocolEnvelope protocol = {};
-    std::string address;
-    port_type port = {};
-    std::string path;
-    if (!client.decompose_server_url(server_url, protocol, address, port, path)) // Throws
-        throw BadServerUrl(server_url);
-    bind(std::move(address), std::move(path), std::move(signed_access_token), port, protocol); // Throws
-}
-
-
-void Session::bind(std::string server_address, std::string realm_identifier, std::string signed_access_token,
-                   port_type server_port, ProtocolEnvelope protocol)
-{
-    m_impl->initiate(protocol, std::move(server_address), server_port, std::move(realm_identifier),
-                     std::move(signed_access_token)); // Throws
 }
 
 

--- a/src/realm/sync/client.hpp
+++ b/src/realm/sync/client.hpp
@@ -553,23 +553,7 @@ public:
     ///
     /// The two other forms of bind() are convenience functions.
     void bind();
-    /// \brief parses parameters and replaces the parameters in the Session::Config object
-    /// before the session is bound.
-    /// \param server_url For example "realm://sync.realm.io/test". See
-    /// server_address, server_path, and server_port in Session::Config for
-    /// information about the individual components of the URL. See
-    /// ProtocolEnvelope for the list of available URL schemes and the
-    /// associated default ports.
-    ///
-    /// \throw BadServerUrl if the specified server URL is malformed.
-    void bind(std::string server_url, std::string signed_user_token);
-    /// void bind(std::string server_address, std::string server_path,
-    ///           std::string signed_user_token, port_type server_port = 0,
-    ///           ProtocolEnvelope protocol = ProtocolEnvelope::realm);
-    /// replaces the corresponding parameters from the Session::Config object
-    /// before the session is bound.
-    void bind(std::string server_address, std::string server_path, std::string signed_user_token,
-              port_type server_port = 0, ProtocolEnvelope protocol = ProtocolEnvelope::realm);
+
     /// @}
 
     /// \brief Refresh the access token associated with this session.

--- a/test/benchmark-sync/bench_transform.cpp
+++ b/test/benchmark-sync/bench_transform.cpp
@@ -85,10 +85,10 @@ void transform_transactions(TestContext& test_context)
             return SyncClientHookAction::NoAction;
         };
 
-        Session session_1 = fixture.make_session(0, db_1, std::move(session_config));
-        fixture.bind_session(session_1, 0, "/test");
-        Session session_2 = fixture.make_session(1, db_2);
-        fixture.bind_session(session_2, 0, "/test");
+        Session session_1 = fixture.make_session(0, 0, db_1, "/test", std::move(session_config));
+        session_1.bind();
+        Session session_2 = fixture.make_session(1, 0, db_2, "/test");
+        session_2.bind();
 
         // Start server and upload changes of second client.
         fixture.start_server(0);
@@ -166,10 +166,10 @@ void transform_instructions(TestContext& test_context)
 
             return SyncClientHookAction::NoAction;
         };
-        Session session_1 = fixture.make_session(0, db_1, std::move(session_config));
-        fixture.bind_session(session_1, 0, "/test");
-        Session session_2 = fixture.make_session(1, db_2);
-        fixture.bind_session(session_2, 0, "/test");
+        Session session_1 = fixture.make_session(0, 0, db_1, "/test", std::move(session_config));
+        session_1.bind();
+        Session session_2 = fixture.make_session(1, 0, db_2, "/test");
+        session_2.bind();
 
         // Start server and upload changes of second client.
         fixture.start_server(0);
@@ -245,10 +245,10 @@ void connected_objects(TestContext& test_context)
 
             return SyncClientHookAction::NoAction;
         };
-        Session session_1 = fixture.make_session(0, db_1, std::move(session_config));
-        fixture.bind_session(session_1, 0, "/test");
-        Session session_2 = fixture.make_session(1, db_2);
-        fixture.bind_session(session_2, 0, "/test");
+        Session session_1 = fixture.make_session(0, 0, db_1, "/test", std::move(session_config));
+        session_1.bind();
+        Session session_2 = fixture.make_session(1, 0, db_2, "/test");
+        session_2.bind();
 
         // Start server and upload changes of second client.
         fixture.start_server(0);

--- a/test/sync_fixtures.hpp
+++ b/test/sync_fixtures.hpp
@@ -691,11 +691,15 @@ public:
         return *m_servers[server_index];
     }
 
-    Session make_session(int client_index, DBRef db, Session::Config config = {})
+    Session make_session(int client_index, int server_index, DBRef db, std::string realm_identifier,
+                         Session::Config config = {})
     {
         //  *ClientServerFixture uses the service identifier "/realm-sync" to distinguish Sync
         //  connections, while the MongoDB/Stitch-based Sync server does not.
         config.service_identifier = "/realm-sync";
+        config.realm_identifier = std::move(realm_identifier);
+        config.server_port = m_server_ports[server_index];
+        config.server_address = "localhost";
 
         Session session{*m_clients[client_index], std::move(db), nullptr, std::move(config)};
         if (m_connection_state_change_listeners[client_index]) {
@@ -719,16 +723,6 @@ public:
         return session;
     }
 
-    void bind_session(Session& session, int server_index, std::string server_path,
-                      std::string signed_user_token = g_signed_test_user_token,
-                      ProtocolEnvelope protocol = ProtocolEnvelope::realm)
-    {
-        std::string server_address = "localhost";
-        port_type server_port = m_server_ports[server_index];
-        session.bind(std::move(server_address), std::move(server_path), std::move(signed_user_token), server_port,
-                     protocol);
-    }
-
     Session make_bound_session(int client_index, DBRef db, int server_index, std::string server_path,
                                Session::Config config = {})
     {
@@ -739,9 +733,10 @@ public:
     Session make_bound_session(int client_index, DBRef db, int server_index, std::string server_path,
                                std::string signed_user_token, Session::Config config = {})
     {
-        Session session = make_session(client_index, std::move(db), std::move(config));
-        bind_session(session, server_index, std::move(server_path), std::move(signed_user_token),
-                     config.protocol_envelope);
+        config.signed_user_token = std::move(signed_user_token);
+        Session session =
+            make_session(client_index, server_index, std::move(db), std::move(server_path), std::move(config));
+        session.bind();
         return session;
     }
 
@@ -896,22 +891,16 @@ public:
         return MultiClientServerFixture::get_server(0);
     }
 
-    Session make_session(DBRef db, Session::Config&& config = {})
+    Session make_session(DBRef db, std::string realm_identifier, Session::Config&& config = {})
     {
-        return MultiClientServerFixture::make_session(0, std::move(db), std::move(config));
+        return MultiClientServerFixture::make_session(0, 0, std::move(db), std::move(realm_identifier),
+                                                      std::move(config));
     }
-    Session make_session(std::string const& path, Session::Config&& config = {})
+    Session make_session(std::string const& path, std::string realm_identifier, Session::Config&& config = {})
     {
         auto db = DB::create(make_client_replication(), path);
-        return MultiClientServerFixture::make_session(0, std::move(db), std::move(config));
-    }
-
-    void bind_session(Session& session, std::string server_path,
-                      std::string signed_user_token = g_signed_test_user_token,
-                      ProtocolEnvelope protocol = ProtocolEnvelope::realm)
-    {
-        MultiClientServerFixture::bind_session(session, 0, std::move(server_path), std::move(signed_user_token),
-                                               protocol);
+        return MultiClientServerFixture::make_session(0, 0, std::move(db), std::move(realm_identifier),
+                                                      std::move(config));
     }
 
     Session make_bound_session(DBRef db, std::string server_path = "/test", Session::Config&& config = {})
@@ -999,25 +988,26 @@ private:
 
 inline RealmFixture::RealmFixture(ClientServerFixture& client_server_fixture, const std::string& real_path,
                                   const std::string& virt_path, Config config)
-    : m_self_ref{std::make_shared<SelfRef>(this)}                            // Throws
-    , m_db{DB::create(make_client_replication(), real_path)}                 // Throws
-    , m_session{client_server_fixture.make_session(m_db, std::move(config))} // Throws
+    : m_self_ref{std::make_shared<SelfRef>(this)}                                       // Throws
+    , m_db{DB::create(make_client_replication(), real_path)}                            // Throws
+    , m_session{client_server_fixture.make_session(m_db, virt_path, std::move(config))} // Throws
 {
     if (config.error_handler)
         setup_error_handler(std::move(config.error_handler));
-    client_server_fixture.bind_session(m_session, virt_path);
+    m_session.bind();
 }
 
 
 inline RealmFixture::RealmFixture(MultiClientServerFixture& client_server_fixture, int client_index, int server_index,
                                   const std::string& real_path, const std::string& virt_path, Config config)
-    : m_self_ref{std::make_shared<SelfRef>(this)}                                          // Throws
-    , m_db{DB::create(make_client_replication(), real_path)}                               // Throws
-    , m_session{client_server_fixture.make_session(client_index, m_db, std::move(config))} // Throws
+    : m_self_ref{std::make_shared<SelfRef>(this)}            // Throws
+    , m_db{DB::create(make_client_replication(), real_path)} // Throws
+    , m_session{client_server_fixture.make_session(client_index, server_index, m_db, virt_path, std::move(config))}
+// Throws
 {
     if (config.error_handler)
         setup_error_handler(std::move(config.error_handler));
-    client_server_fixture.bind_session(m_session, server_index, virt_path);
+    m_session.bind();
 }
 
 inline RealmFixture::~RealmFixture() noexcept

--- a/test/test_client_reset.cpp
+++ b/test/test_client_reset.cpp
@@ -120,8 +120,8 @@ TEST(ClientReset_NoLocalChanges)
         session.nonsync_transact_notify(wt.commit());
         session.wait_for_upload_complete_or_client_stopped();
 
-        Session session_2 = fixture.make_session(path_2);
-        fixture.bind_session(session_2, server_path);
+        Session session_2 = fixture.make_session(path_2, server_path);
+        session_2.bind();
         session_2.wait_for_download_complete_or_client_stopped();
     }
 
@@ -156,17 +156,17 @@ TEST(ClientReset_NoLocalChanges)
                 bowl.add_stone();
             };
 
-            Session session = fixture.make_session(path_2);
+            Session session = fixture.make_session(path_2, server_path);
             session.set_connection_state_change_listener(listener);
-            fixture.bind_session(session, server_path);
+            session.bind();
             bowl.get_stone();
         }
 
         // get a fresh copy from the server to reset against
         SHARED_GROUP_TEST_PATH(path_fresh);
         {
-            Session session_fresh = fixture.make_session(path_fresh);
-            fixture.bind_session(session_fresh, server_path);
+            Session session_fresh = fixture.make_session(path_fresh, server_path);
+            session_fresh.bind();
             session_fresh.wait_for_download_complete_or_client_stopped();
         }
         DBRef sg_fresh = DB::create(make_client_replication(), path_fresh);
@@ -197,9 +197,9 @@ TEST(ClientReset_NoLocalChanges)
                 client_reset_config.fresh_copy = std::move(sg_fresh);
                 session_config.client_reset_config = std::move(client_reset_config);
             }
-            Session session = fixture.make_session(sg, std::move(session_config));
+            Session session = fixture.make_session(sg, server_path, std::move(session_config));
             session.set_sync_transact_callback(std::move(sync_transact_callback));
-            fixture.bind_session(session, server_path);
+            session.bind();
             session.wait_for_download_complete_or_client_stopped();
             CHECK(sync_transact_callback_called);
         }
@@ -229,8 +229,8 @@ TEST(ClientReset_InitialLocalChanges)
     ClientServerFixture fixture(dir, test_context);
     fixture.start();
 
-    Session session_1 = fixture.make_session(path_1);
-    fixture.bind_session(session_1, server_path);
+    Session session_1 = fixture.make_session(path_1, server_path);
+    session_1.bind();
 
     // First we make a changeset and upload it
     {
@@ -256,8 +256,8 @@ TEST(ClientReset_InitialLocalChanges)
     // get a fresh copy from the server to reset against
     SHARED_GROUP_TEST_PATH(path_fresh);
     {
-        Session session_fresh = fixture.make_session(path_fresh);
-        fixture.bind_session(session_fresh, server_path);
+        Session session_fresh = fixture.make_session(path_fresh, server_path);
+        session_fresh.bind();
         session_fresh.wait_for_download_complete_or_client_stopped();
     }
     DBRef sg_fresh = DB::create(make_client_replication(), path_fresh);
@@ -270,8 +270,8 @@ TEST(ClientReset_InitialLocalChanges)
         client_reset_config.fresh_copy = std::move(sg_fresh);
         session_config_2.client_reset_config = std::move(client_reset_config);
     }
-    Session session_2 = fixture.make_session(path_2, std::move(session_config_2));
-    fixture.bind_session(session_2, server_path);
+    Session session_2 = fixture.make_session(path_2, server_path, std::move(session_config_2));
+    session_2.bind();
     session_2.wait_for_upload_complete_or_client_stopped();
     session_2.wait_for_download_complete_or_client_stopped();
 
@@ -347,8 +347,8 @@ TEST_TYPES(ClientReset_LocalChangesWhenOffline, std::true_type, std::false_type)
     {
         // Download a new Realm. The state is empty.
         Session::Config session_config_1;
-        Session session_1 = fixture.make_session(sg, std::move(session_config_1));
-        fixture.bind_session(session_1, server_path);
+        Session session_1 = fixture.make_session(sg, server_path, std::move(session_config_1));
+        session_1.bind();
         session_1.wait_for_download_complete_or_client_stopped();
 
         WriteTransaction wt{sg};
@@ -360,8 +360,8 @@ TEST_TYPES(ClientReset_LocalChangesWhenOffline, std::true_type, std::false_type)
     }
 
     DBRef sg_2 = DB::create(make_client_replication(), path_2);
-    Session session_2 = fixture.make_session(sg_2);
-    fixture.bind_session(session_2, server_path);
+    Session session_2 = fixture.make_session(sg_2, server_path);
+    session_2.bind();
     session_2.wait_for_upload_complete_or_client_stopped();
     session_2.wait_for_download_complete_or_client_stopped();
 
@@ -385,8 +385,8 @@ TEST_TYPES(ClientReset_LocalChangesWhenOffline, std::true_type, std::false_type)
     // get a fresh copy from the server to reset against
     SHARED_GROUP_TEST_PATH(path_fresh1);
     {
-        Session session4 = fixture.make_session(path_fresh1);
-        fixture.bind_session(session4, server_path);
+        Session session4 = fixture.make_session(path_fresh1, server_path);
+        session4.bind();
         session4.wait_for_download_complete_or_client_stopped();
     }
     DBRef sg_fresh1 = DB::create(make_client_replication(), path_fresh1);
@@ -395,8 +395,8 @@ TEST_TYPES(ClientReset_LocalChangesWhenOffline, std::true_type, std::false_type)
     session_config_3.client_reset_config = Session::Config::ClientReset{};
     session_config_3.client_reset_config->mode = recover ? ClientResyncMode::Recover : ClientResyncMode::DiscardLocal;
     session_config_3.client_reset_config->fresh_copy = std::move(sg_fresh1);
-    Session session_3 = fixture.make_session(sg, std::move(session_config_3));
-    fixture.bind_session(session_3, server_path);
+    Session session_3 = fixture.make_session(sg, server_path, std::move(session_config_3));
+    session_3.bind();
     session_3.wait_for_upload_complete_or_client_stopped();
     session_3.wait_for_download_complete_or_client_stopped();
 
@@ -486,10 +486,10 @@ TEST(ClientReset_ThreeClients)
             wt.commit();
         }
 
-        Session session_1 = fixture.make_session(path_1);
-        fixture.bind_session(session_1, server_path);
-        Session session_2 = fixture.make_session(path_2);
-        fixture.bind_session(session_2, server_path);
+        Session session_1 = fixture.make_session(path_1, server_path);
+        session_1.bind();
+        Session session_2 = fixture.make_session(path_2, server_path);
+        session_2.bind();
 
         session_1.wait_for_upload_complete_or_client_stopped();
         session_2.wait_for_upload_complete_or_client_stopped();
@@ -605,12 +605,12 @@ TEST(ClientReset_ThreeClients)
                 bowl.add_stone();
             };
 
-            Session session_1 = fixture.make_session(path_1);
+            Session session_1 = fixture.make_session(path_1, server_path);
             session_1.set_connection_state_change_listener(listener);
-            fixture.bind_session(session_1, server_path);
-            Session session_2 = fixture.make_session(path_2);
+            session_1.bind();
+            Session session_2 = fixture.make_session(path_2, server_path);
             session_2.set_connection_state_change_listener(listener);
-            fixture.bind_session(session_2, server_path);
+            session_2.bind();
             bowl.get_stone();
             bowl.get_stone();
         }
@@ -619,15 +619,15 @@ TEST(ClientReset_ThreeClients)
         SHARED_GROUP_TEST_PATH(path_fresh1);
         SHARED_GROUP_TEST_PATH(path_fresh2);
         {
-            Session session4 = fixture.make_session(path_fresh1);
-            fixture.bind_session(session4, server_path);
+            Session session4 = fixture.make_session(path_fresh1, server_path);
+            session4.bind();
             session4.wait_for_download_complete_or_client_stopped();
         }
         DBRef sg_fresh1 = DB::create(make_client_replication(), path_fresh1);
 
         {
-            Session session4 = fixture.make_session(path_fresh2);
-            fixture.bind_session(session4, server_path);
+            Session session4 = fixture.make_session(path_fresh2, server_path);
+            session4.bind();
             session4.wait_for_download_complete_or_client_stopped();
         }
         DBRef sg_fresh2 = DB::create(make_client_replication(), path_fresh2);
@@ -648,10 +648,10 @@ TEST(ClientReset_ThreeClients)
                 client_reset_config.fresh_copy = std::move(sg_fresh2);
                 session_config_2.client_reset_config = std::move(client_reset_config);
             }
-            Session session_1 = fixture.make_session(path_1, std::move(session_config_1));
-            fixture.bind_session(session_1, server_path);
-            Session session_2 = fixture.make_session(path_2, std::move(session_config_2));
-            fixture.bind_session(session_2, server_path);
+            Session session_1 = fixture.make_session(path_1, server_path, std::move(session_config_1));
+            session_1.bind();
+            Session session_2 = fixture.make_session(path_2, server_path, std::move(session_config_2));
+            session_2.bind();
 
             session_1.wait_for_download_complete_or_client_stopped();
             session_2.wait_for_download_complete_or_client_stopped();
@@ -676,10 +676,10 @@ TEST(ClientReset_ThreeClients)
         }
 
         // Upload and download complete the clients.
-        Session session_1 = fixture.make_session(path_1);
-        fixture.bind_session(session_1, server_path);
-        Session session_2 = fixture.make_session(path_2);
-        fixture.bind_session(session_2, server_path);
+        Session session_1 = fixture.make_session(path_1, server_path);
+        session_1.bind();
+        Session session_2 = fixture.make_session(path_2, server_path);
+        session_2.bind();
 
         session_1.wait_for_upload_complete_or_client_stopped();
         session_2.wait_for_upload_complete_or_client_stopped();
@@ -691,8 +691,8 @@ TEST(ClientReset_ThreeClients)
         // A third client downloads the state
         {
             Session::Config session_config;
-            Session session = fixture.make_session(path_3, std::move(session_config));
-            fixture.bind_session(session, server_path);
+            Session session = fixture.make_session(path_3, server_path, std::move(session_config));
+            session.bind();
             session.wait_for_download_complete_or_client_stopped();
         }
     }
@@ -750,8 +750,8 @@ TEST(ClientReset_DoNotRecoverSchema)
     // get a fresh copy from the server to reset against
     SHARED_GROUP_TEST_PATH(path_fresh1);
     {
-        Session session_fresh = fixture.make_session(path_fresh1);
-        fixture.bind_session(session_fresh, server_path_2);
+        Session session_fresh = fixture.make_session(path_fresh1, server_path_2);
+        session_fresh.bind();
         session_fresh.wait_for_download_complete_or_client_stopped();
     }
     DBRef sg_fresh1 = DB::create(make_client_replication(), path_fresh1);
@@ -767,7 +767,7 @@ TEST(ClientReset_DoNotRecoverSchema)
             client_reset_config.fresh_copy = std::move(sg_fresh1);
             session_config.client_reset_config = std::move(client_reset_config);
         }
-        Session session = fixture.make_session(path_1, std::move(session_config));
+        Session session = fixture.make_session(path_1, server_path_2, std::move(session_config));
         BowlOfStonesSemaphore bowl;
         session.set_connection_state_change_listener(
             [&](ConnectionState state, util::Optional<ErrorInfo> error_info) {
@@ -778,7 +778,7 @@ TEST(ClientReset_DoNotRecoverSchema)
                 CHECK_EQUAL(ec, sync::Client::Error::auto_client_reset_failure);
                 bowl.add_stone();
             });
-        fixture.bind_session(session, server_path_2);
+        session.bind();
         bowl.get_stone();
     }
 
@@ -841,8 +841,8 @@ TEST(ClientReset_PinnedVersion)
         // get a fresh copy from the server to reset against
         SHARED_GROUP_TEST_PATH(path_fresh);
         {
-            Session session_fresh = fixture.make_session(path_fresh);
-            fixture.bind_session(session_fresh, server_path_1);
+            Session session_fresh = fixture.make_session(path_fresh, server_path_1);
+            session_fresh.bind();
             session_fresh.wait_for_download_complete_or_client_stopped();
         }
         DBRef sg_fresh = DB::create(make_client_replication(), path_fresh);

--- a/test/test_sync.cpp
+++ b/test/test_sync.cpp
@@ -2711,6 +2711,7 @@ TEST(Sync_SSL_Certificate_1)
     session_config.protocol_envelope = ProtocolEnvelope::realms;
     session_config.verify_servers_ssl_certificate = true;
     session_config.ssl_trust_certificate_path = ca_dir + "crt.pem";
+    session_config.signed_user_token = g_signed_test_user_token;
 
     Session session = fixture.make_session(db, "/test", std::move(session_config));
     session.bind();
@@ -2806,6 +2807,7 @@ TEST(Sync_SSL_Certificate_DER)
     session_config.protocol_envelope = ProtocolEnvelope::realms;
     session_config.verify_servers_ssl_certificate = true;
     session_config.ssl_trust_certificate_path = ca_dir + "localhost-chain.crt.cer";
+    session_config.signed_user_token = g_signed_test_user_token;
 
     Session session = fixture.make_session(db, "/test", std::move(session_config));
     session.bind();


### PR DESCRIPTION
## What, How & Why?
These overloads of `sync::Session::bind()` let you override the server info used to connect to sync and were only being used in tests. This PR removes them and adjusts the sync unit tests to match. As part of fixing session multiplexing, there are more factors to consider when choosing a connection than just the server address/port/envelope, and rather than adding the other factors to these functions, I'd rather just remove them and remove the extra mostly unused code.

## ☑️ ToDos
* [x] 📝 Changelog update
* [x] 🚦 Tests (or not relevant)
* [ ] C-API, if public C++ API changed.
