### PR TITLE
Distinguish between an empty and a null (not existing)  reciprocal changeset

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@
 
 ### Fixed
 * <How do the end-user experience this issue? what was the impact?> ([#????](https://github.com/realm/realm-core/issues/????), since v?.?.?)
-* Fixed a case of history diverging when empty reciprocal changesets are part of the merging window in OT ([#6191](https://github.com/realm/realm-core/issues/6191), since v11.13.0)
+* Fixed a case of history diverging when empty reciprocal changesets are part of the merging window in OT. This may have resulted in arrays being in different orders on different devices. ([#6191](https://github.com/realm/realm-core/issues/6191), since v11.13.0)
 
 ### Breaking changes
 * You can no longer associate a Logger Factory with the SyncManager. Instead you can install one default logger via Logger::set_default_logger(). This logger will then be used all over Core. Logging cmake flags updated to use REALM_TEST_LOGGING and REALM_TEST_LOGGING_LEVEL

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@
 
 ### Fixed
 * <How do the end-user experience this issue? what was the impact?> ([#????](https://github.com/realm/realm-core/issues/????), since v?.?.?)
-* Fixed a case of history diverging when empty reciprocal changesets are part of the merging window in OT ([#6191](https://github.com/realm/realm-core/issues/6191), since v10.2.0)
+* Fixed a case of history diverging when empty reciprocal changesets are part of the merging window in OT ([#6191](https://github.com/realm/realm-core/issues/6191), since v11.13.0)
 
 ### Breaking changes
 * You can no longer associate a Logger Factory with the SyncManager. Instead you can install one default logger via Logger::set_default_logger(). This logger will then be used all over Core. Logging cmake flags updated to use REALM_TEST_LOGGING and REALM_TEST_LOGGING_LEVEL

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@
 
 ### Fixed
 * <How do the end-user experience this issue? what was the impact?> ([#????](https://github.com/realm/realm-core/issues/????), since v?.?.?)
-* None.
+* Fixed a case of history diverging when empty reciprocal changesets are part of the merging window in OT ([#6191](https://github.com/realm/realm-core/issues/6191), since v10.2.0)
 
 ### Breaking changes
 * You can no longer associate a Logger Factory with the SyncManager. Instead you can install one default logger via Logger::set_default_logger(). This logger will then be used all over Core. Logging cmake flags updated to use REALM_TEST_LOGGING and REALM_TEST_LOGGING_LEVEL

--- a/src/realm/sync/changeset.hpp
+++ b/src/realm/sync/changeset.hpp
@@ -61,7 +61,6 @@ struct Changeset {
     struct IteratorImpl;
     using iterator = IteratorImpl<false>;
     using const_iterator = IteratorImpl<true>;
-    using value_type = Instruction;
     iterator begin() noexcept;
     iterator end() noexcept;
     const_iterator begin() const noexcept;

--- a/src/realm/sync/changeset_encoder.cpp
+++ b/src/realm/sync/changeset_encoder.cpp
@@ -414,19 +414,14 @@ void ChangesetEncoder::reset() noexcept
 
 void ChangesetEncoder::encode_single(const Changeset& log)
 {
-    // Checking if the log is empty avoids serialized interned strings in a
-    // changeset where all meaningful instructions have been discarded due to
-    // merge or compaction.
-    if (!log.empty()) {
-        add_string_range(log.string_data());
-        const auto& strings = log.interned_strings();
-        for (size_t i = 0; i < strings.size(); ++i) {
-            set_intern_string(uint32_t(i), strings[i]); // Throws
-        }
-        for (auto instr : log) {
-            if (!instr)
-                continue;
-            (*this)(*instr); // Throws
-        }
+    add_string_range(log.string_data());
+    const auto& strings = log.interned_strings();
+    for (size_t i = 0; i < strings.size(); ++i) {
+        set_intern_string(uint32_t(i), strings[i]); // Throws
+    }
+    for (auto instr : log) {
+        if (!instr)
+            continue;
+        (*this)(*instr); // Throws
     }
 }

--- a/src/realm/sync/noinst/client_history_impl.cpp
+++ b/src/realm/sync/noinst/client_history_impl.cpp
@@ -764,6 +764,7 @@ Replication::version_type ClientHistory::add_changeset(BinaryData ct_changeset, 
 
 void ClientHistory::add_sync_history_entry(const HistoryEntry& entry)
 {
+    REALM_ASSERT(m_arrays->changesets.size() == sync_history_size());
     REALM_ASSERT(m_arrays->reciprocal_transforms.size() == sync_history_size());
     REALM_ASSERT(m_arrays->remote_versions.size() == sync_history_size());
     REALM_ASSERT(m_arrays->origin_file_idents.size() == sync_history_size());
@@ -1175,6 +1176,7 @@ void ClientHistory::update_from_ref_and_version(ref_type ref, version_type versi
 
     m_ct_history_base_version = version - ct_history_size();
     m_sync_history_base_version = version - sync_history_size();
+    REALM_ASSERT(m_arrays->changesets.size() == sync_history_size());
     REALM_ASSERT(m_arrays->reciprocal_transforms.size() == sync_history_size());
     REALM_ASSERT(m_arrays->remote_versions.size() == sync_history_size());
     REALM_ASSERT(m_arrays->origin_file_idents.size() == sync_history_size());

--- a/src/realm/sync/noinst/client_history_impl.cpp
+++ b/src/realm/sync/noinst/client_history_impl.cpp
@@ -627,6 +627,11 @@ void ClientHistory::set_reciprocal_transform(version_type version, BinaryData da
     std::size_t index = size_t(version - m_sync_history_base_version) - 1;
     REALM_ASSERT(index < sync_history_size());
 
+    if (data.is_null()) {
+        m_arrays->reciprocal_transforms.set(index, BinaryData{"", 0}); // Throws
+        return;
+    }
+
     auto compressed = util::compression::allocate_and_compress_nonportable(data);
     m_arrays->reciprocal_transforms.set(index, BinaryData{compressed.data(), compressed.size()}); // Throws
 }
@@ -776,7 +781,7 @@ void ClientHistory::add_sync_history_entry(const HistoryEntry& entry)
         m_arrays->changesets.add(BinaryData{compressed.data(), compressed.size()}); // Throws
     }
     else {
-        m_arrays->changesets.add(BinaryData()); // Throws
+        m_arrays->changesets.add(BinaryData("", 0)); // Throws
     }
 
     m_arrays->reciprocal_transforms.add(BinaryData{});                                            // Throws

--- a/test/test_sync.cpp
+++ b/test/test_sync.cpp
@@ -6760,7 +6760,7 @@ TEST(Sync_SetAndGetEmptyReciprocalChangeset)
     if (is_compressed) {
         size_t total_size;
         auto decompressed = util::compression::decompress_nonportable_input_stream(in, total_size);
-        REALM_ASSERT(decompressed);
+        CHECK(decompressed);
         sync::parse_changeset(*decompressed, reciprocal_changeset); // Throws
     }
     else {

--- a/test/test_sync.cpp
+++ b/test/test_sync.cpp
@@ -6770,4 +6770,85 @@ TEST(Sync_SetAndGetEmptyReciprocalChangeset)
     CHECK(reciprocal_changeset.empty());
 }
 
+TEST(Sync_TransformAgainstEmptyReciprocalChangeset)
+{
+    TEST_DIR(dir);
+    TEST_CLIENT_DB(seed_db);
+    TEST_CLIENT_DB(db_1);
+    TEST_CLIENT_DB(db_2);
+
+    {
+        auto tr = seed_db->start_write();
+        // Create schema: single table with array of ints as property.
+        auto table = tr->add_table_with_primary_key("class_table", type_Int, "_id");
+        table->add_column_list(type_Int, "ints");
+        table->add_column(type_String, "string");
+        tr->commit_and_continue_writing();
+
+        // Create object and initialize array.
+        table = tr->get_table("class_table");
+        auto obj = table->create_object_with_primary_key(42);
+        auto ints = obj.get_list<int64_t>("ints");
+        for (auto i = 0; i < 8; ++i) {
+            ints.insert(i, i);
+        }
+        tr->commit();
+    }
+
+    MultiClientServerFixture fixture(3, 1, dir, test_context);
+    fixture.start();
+
+    util::Optional<Session> seed_session = fixture.make_bound_session(0, seed_db, 0, "/test");
+    util::Optional<Session> db_1_session = fixture.make_bound_session(1, db_1, 0, "/test");
+    util::Optional<Session> db_2_session = fixture.make_bound_session(2, db_2, 0, "/test");
+
+    seed_session->wait_for_upload_complete_or_client_stopped();
+    db_1_session->wait_for_download_complete_or_client_stopped();
+    db_2_session->wait_for_download_complete_or_client_stopped();
+    seed_session.reset();
+    db_2_session.reset();
+
+    auto move_element = [&](const DBRef& db, size_t from, size_t to, size_t string_size = 0) {
+        auto wt = db->start_write();
+        auto table = wt->get_table("class_table");
+        auto obj = table->get_object_with_primary_key(42);
+        auto ints = obj.get_list<int64_t>("ints");
+        ints.move(from, to);
+        obj.set("string", std::string(string_size, 'a'));
+        wt->commit();
+    };
+
+    // Client 1 uploads two move instructions.
+    move_element(db_1, 7, 2);
+    move_element(db_1, 7, 6);
+
+    db_1_session->wait_for_upload_complete_or_client_stopped();
+
+    std::this_thread::sleep_for(std::chrono::milliseconds{10});
+
+    // Client 2 uploads two move instructions.
+    // The sync client uploads at most 128 KB of data so we make the first changeset large enough so two upload
+    // messages are sent to the server instead of one. Each change is transformed against the changes from Client 1.
+
+    // First change discards the first change (move(7, 2)) of Client 1.
+    move_element(db_2, 7, 0, 200 * 1024);
+    // Second change is tranformed against an empty reciprocal changeset as result of the change above.
+    move_element(db_2, 7, 5);
+    db_2_session = fixture.make_bound_session(2, db_2, 0, "/test");
+
+    db_1_session->wait_for_upload_complete_or_client_stopped();
+    db_2_session->wait_for_upload_complete_or_client_stopped();
+
+    db_1_session->wait_for_download_complete_or_client_stopped();
+    db_2_session->wait_for_download_complete_or_client_stopped();
+
+    ReadTransaction rt_1(db_1);
+    ReadTransaction rt_2(db_2);
+    const Group& group_1 = rt_1;
+    const Group& group_2 = rt_2;
+    group_1.verify();
+    group_2.verify();
+    CHECK(compare_groups(rt_1, rt_2));
+}
+
 } // unnamed namespace


### PR DESCRIPTION
## What, How & Why?
Once a reciprocal changeset has all its instructions discarded during OT, it is stored as a null changeset in the realm. This makes it hard to differentiate it from a non-existing reciprocal changeset and was causing histories to diverge among clients. A fix was put in place so that an empty reciprocal changeset is indeed saved as an empty changeset in the realm.

Fixes #6191.

## ☑️ ToDos
* [x] 📝 Changelog update
* [x] 🚦 Tests (or not relevant)
* [ ] ~~C-API, if public C++ API changed.~~
