### PR TITLE
Translate I/O errors during TLS handshake to a connection failed error

### DIFF
--- a/src/realm/status_with.hpp
+++ b/src/realm/status_with.hpp
@@ -74,6 +74,7 @@ public:
     StatusWith(Status status)
         : m_status(std::move(status))
     {
+        REALM_ASSERT(!is_ok());
     }
 
     StatusWith(T value)

--- a/test/test_util_network_ssl.cpp
+++ b/test/test_util_network_ssl.cpp
@@ -542,50 +542,6 @@ TEST(Util_DefaultWebsocketTLS_PrematureEndOfInputOnHandshakeRead)
 }
 
 
-TEST(Util_DefaultWebsocketTLS_PrematureEndOfInputOnHandshakeWrite)
-{
-    websocket::DefaultSocketProvider client_socket_provider(test_context.logger, "Fake User Agent");
-
-    network::Service service_server;
-    network::Acceptor acceptor(service_server);
-    network::Endpoint server_endpoint = bind_acceptor(acceptor);
-
-    // Use a separate thread to consume data written by Stream::handshake(),
-    // such that we can be sure not to block.
-    auto consumer = [&] {
-        network::Socket server_socket(service_server);
-        acceptor.accept(server_socket);
-        server_socket.shutdown(network::Socket::shutdown_receive);
-        constexpr std::size_t size = 4096;
-        std::unique_ptr<char[]> buffer(new char[size]);
-        std::error_code ec;
-        do {
-            server_socket.read_some(buffer.get(), size, ec);
-        } while (!ec);
-        REALM_ASSERT(ec == MiscExtErrors::end_of_input);
-    };
-
-    std::thread thread(std::move(consumer));
-
-    WebSocketEndpoint endpoint;
-    endpoint.address = util::format("%1", server_endpoint.address());
-    endpoint.port = server_endpoint.port();
-    endpoint.path = "/foo/bar/bizz/buzz";
-    endpoint.is_ssl = true;
-    endpoint.verify_servers_ssl_certificate = false;
-
-    auto [observer, error_future] = ErrorOnlyWebSocketObserver::make(test_context);
-    auto unused_websocket = client_socket_provider.connect(std::move(observer), std::move(endpoint));
-
-    auto res = error_future.get();
-    CHECK(!res.was_clean);
-    CHECK_EQUAL(res.status.get_std_error_code(),
-                websocket::make_error_code(websocket::WebSocketError::websocket_connection_failed));
-    unused_websocket.reset();
-    thread.join();
-}
-
-
 #ifndef _WIN32 // FIXME: winsock doesn't have EPIPE, what's the equivalent?
 TEST(Util_Network_SSL_BrokenPipeOnHandshakeWrite)
 {

--- a/test/test_util_network_ssl.cpp
+++ b/test/test_util_network_ssl.cpp
@@ -531,13 +531,67 @@ TEST(Util_DefaultWebsocketTLS_PrematureEndOfInputOnHandshakeRead)
     endpoint.verify_servers_ssl_certificate = false;
 
     auto [observer, error_future] = ErrorOnlyWebSocketObserver::make(test_context);
-    auto unused_websocket = client_socket_provider.connect(std::move(observer), std::move(endpoint));
+    auto websocket = client_socket_provider.connect(std::move(observer), std::move(endpoint));
 
     auto res = error_future.get();
     CHECK(!res.was_clean);
     CHECK_EQUAL(res.status.get_std_error_code(),
                 websocket::make_error_code(websocket::WebSocketError::websocket_connection_failed));
-    unused_websocket.reset();
+    client_socket_provider.post_with_completion([websocket = std::move(websocket)](Status status) mutable {
+        REALM_ASSERT(status.is_ok());
+        websocket.reset();
+    }).get();
+
+    client_socket_provider.stop(true);
+    thread.join();
+}
+
+
+TEST(Util_DefaultWebsocketTLS_PrematureEndOfInputOnHandshakeWrite)
+{
+    websocket::DefaultSocketProvider client_socket_provider(test_context.logger, "Fake User Agent");
+
+    network::Service service_server;
+    network::Acceptor acceptor(service_server);
+    network::Endpoint server_endpoint = bind_acceptor(acceptor);
+
+    // Use a separate thread to consume data written by Stream::handshake(),
+    // such that we can be sure not to block.
+    auto consumer = [&] {
+        network::Socket server_socket(service_server);
+        acceptor.accept(server_socket);
+        server_socket.shutdown(network::Socket::shutdown_receive);
+        constexpr std::size_t size = 4096;
+        std::unique_ptr<char[]> buffer(new char[size]);
+        std::error_code ec;
+        do {
+            server_socket.read_some(buffer.get(), size, ec);
+        } while (!ec);
+        REALM_ASSERT(ec == MiscExtErrors::end_of_input);
+    };
+
+    std::thread thread(std::move(consumer));
+
+    WebSocketEndpoint endpoint;
+    endpoint.address = util::format("%1", server_endpoint.address());
+    endpoint.port = server_endpoint.port();
+    endpoint.path = "/foo/bar/bizz/buzz";
+    endpoint.is_ssl = true;
+    endpoint.verify_servers_ssl_certificate = false;
+
+    auto [observer, error_future] = ErrorOnlyWebSocketObserver::make(test_context);
+    auto websocket = client_socket_provider.connect(std::move(observer), std::move(endpoint));
+
+    auto res = error_future.get();
+    CHECK(!res.was_clean);
+    CHECK_EQUAL(res.status.get_std_error_code(),
+                websocket::make_error_code(websocket::WebSocketError::websocket_connection_failed));
+    client_socket_provider.post_with_completion([websocket = std::move(websocket)](Status status) mutable {
+        REALM_ASSERT(status.is_ok());
+        websocket.reset();
+    }).get();
+
+    client_socket_provider.stop(true);
     thread.join();
 }
 

--- a/test/test_util_network_ssl.cpp
+++ b/test/test_util_network_ssl.cpp
@@ -537,10 +537,12 @@ TEST(Util_DefaultWebsocketTLS_PrematureEndOfInputOnHandshakeRead)
     CHECK(!res.was_clean);
     CHECK_EQUAL(res.status.get_std_error_code(),
                 websocket::make_error_code(websocket::WebSocketError::websocket_connection_failed));
-    client_socket_provider.post_with_completion([websocket = std::move(websocket)](Status status) mutable {
-        REALM_ASSERT(status.is_ok());
-        websocket.reset();
-    }).get();
+    client_socket_provider
+        .post_with_completion([websocket = std::move(websocket)](Status status) mutable {
+            REALM_ASSERT(status.is_ok());
+            websocket.reset();
+        })
+        .get();
 
     client_socket_provider.stop(true);
     thread.join();
@@ -586,10 +588,12 @@ TEST(Util_DefaultWebsocketTLS_PrematureEndOfInputOnHandshakeWrite)
     CHECK(!res.was_clean);
     CHECK_EQUAL(res.status.get_std_error_code(),
                 websocket::make_error_code(websocket::WebSocketError::websocket_connection_failed));
-    client_socket_provider.post_with_completion([websocket = std::move(websocket)](Status status) mutable {
-        REALM_ASSERT(status.is_ok());
-        websocket.reset();
-    }).get();
+    client_socket_provider
+        .post_with_completion([websocket = std::move(websocket)](Status status) mutable {
+            REALM_ASSERT(status.is_ok());
+            websocket.reset();
+        })
+        .get();
 
     client_socket_provider.stop(true);
     thread.join();


### PR DESCRIPTION
## What, How & Why?
If the default socket provider gets disconnected during the TLS handshake, that will get reported as the same kind of error as a bad certificate, which results in a long retry interval. This narrows the what causes a `tls_handshake_failed` error to just error codes with the `openssl_error_category` or `secure_transport_error_category`

## ☑️ ToDos
* [ ] 📝 Changelog update
* [x] 🚦 Tests (or not relevant)
* [ ] C-API, if public C++ API changed.
