### PR TITLE
Increase server FLX/PBS migration timeout

### DIFF
--- a/test/object-store/sync/flx_migration.cpp
+++ b/test/object-store/sync/flx_migration.cpp
@@ -31,7 +31,7 @@ static void trigger_server_migration(const AppSession& app_session, bool switch_
         else
             return "FLX->PBS Rollback";
     }();
-    const int duration = 90;
+    const int duration = 300; // 5 minutes, for now, since it sometimes takes longet than 90 seconds
     try {
         timed_sleeping_wait_for(
             [&] {


### PR DESCRIPTION
## What, How & Why?
Increase the allowed timeout for a FLX->PBS or PBS->FLX server migration to 5 minutes since it sometimes (but rarely) takes longer than the original 90 seconds. Eventually, these tests will most likely be moved to a separate test executable.

## ☑️ ToDos
* ~~[ ] 📝 Changelog update~~
* ~~[ ] 🚦 Tests (or not relevant)~~
* ~~[ ] C-API, if public C++ API changed.~~
