### PR TITLE
Restore the ability to set loggers per-SyncManager

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ### Enhancements
 * <New feature description> (PR [#????](https://github.com/realm/realm-core/pull/????))
 * Expose `Results::is_valid()` in the C API, in order to prevent to use an invalid Results. (PR [#6407](https://github.com/realm/realm-core/pull/6407))
+* Restore `SyncManager::set_logger_factory()` to enable setting different loggers for different SyncManagers ([PR #6400](https://github.com/realm/realm-core/pull/6400)).
 
 ### Fixed
 * `SyncSession::pause()` could hold a reference to the database open after shutting down the sync session, preventing users from being able to delete the realm. ([#6372](https://github.com/realm/realm-core/issues/6372), since v13.3.0)

--- a/src/realm/object-store/sync/app.cpp
+++ b/src/realm/object-store/sync/app.cpp
@@ -260,7 +260,6 @@ App::~App() {}
 
 void App::configure(const SyncClientConfig& sync_client_config)
 {
-    init_logger();
     auto sync_route = make_sync_route(m_app_route);
     m_sync_manager->configure(shared_from_this(), sync_route, sync_client_config);
     if (auto metadata = m_sync_manager->app_metadata()) {
@@ -272,7 +271,7 @@ void App::configure(const SyncClientConfig& sync_client_config)
 bool App::init_logger()
 {
     if (!m_logger_ptr) {
-        m_logger_ptr = util::Logger::get_default_logger();
+        m_logger_ptr = m_sync_manager->get_logger();
     }
     return bool(m_logger_ptr);
 }

--- a/src/realm/object-store/sync/sync_manager.cpp
+++ b/src/realm/object-store/sync/sync_manager.cpp
@@ -275,9 +275,36 @@ void SyncManager::reset_for_testing()
     }
 }
 
+void SyncManager::set_log_level(util::Logger::Level level) noexcept
+{
+    util::CheckedLockGuard lock(m_mutex);
+    m_config.log_level = level;
+    // Update the level threshold in the already created logger
+    if (m_logger_ptr) {
+        m_logger_ptr->set_level_threshold(level);
+    }
+}
+
+void SyncManager::set_logger_factory(SyncClientConfig::LoggerFactory factory)
+{
+    util::CheckedLockGuard lock(m_mutex);
+    m_config.logger_factory = std::move(factory);
+
+    if (m_sync_client)
+        throw std::logic_error("Cannot set the logger factory after creating the sync client");
+
+    // Create a new logger using the new factory
+    do_make_logger();
+}
+
 void SyncManager::do_make_logger()
 {
-    m_logger_ptr = util::Logger::get_default_logger();
+    if (m_config.logger_factory) {
+        m_logger_ptr = m_config.logger_factory(m_config.log_level);
+    }
+    else {
+        m_logger_ptr = util::Logger::get_default_logger();
+    }
 }
 
 const std::shared_ptr<util::Logger>& SyncManager::get_logger() const
@@ -304,6 +331,12 @@ void SyncManager::reconnect() const
     for (auto& it : m_sessions) {
         it.second->handle_reconnect();
     }
+}
+
+util::Logger::Level SyncManager::log_level() const noexcept
+{
+    util::CheckedLockGuard lock(m_mutex);
+    return m_config.log_level;
 }
 
 bool SyncManager::perform_metadata_update(util::FunctionRef<void(SyncMetadataManager&)> update_function) const


### PR DESCRIPTION
Setting different loggers on different SyncManagers is something we have exposed in our public API so we need to continue to support it. SyncManager will continue to fall back to `Logger::get_default_logger()` if no logger factory is set.