### PR TITLE
Updated Array_get_sum test to force 64bit integers in some instances

### DIFF
--- a/test/test_array.cpp
+++ b/test/test_array.cpp
@@ -1539,13 +1539,13 @@ TEST(Array_get_sum)
     for (uint64_t i = 0; i < size; ++i) {
         c.add(0x10000);
     }
-    CHECK_EQUAL(c.get_sum(), 0x10000 * size);
+    CHECK_EQUAL(c.get_sum(), 0x10000LL * size);
 
     // test multiple chunks w=32
     c.clear();
     for (uint64_t i = 0; i < size; ++i)
         c.add(0x100000);
-    CHECK_EQUAL(c.get_sum(), 0x100000 * size);
+    CHECK_EQUAL(c.get_sum(), 0x100000LL * size);
 
     // test multiple chunks w=64
     c.clear();


### PR DESCRIPTION
## What, How & Why?
The `Array_get_sum` core test was failing in the `checkWindows_x86_Release` run on Jenkins CI. Updated test to force x64 integer math.

## ☑️ ToDos
* ~~[ ] 📝 Changelog update~~
* [X] 🚦 Tests (or not relevant)
* ~~[ ] C-API, if public C++ API changed.~~
