### PR TITLE
Avoid blocking in Transaction::close() when there's a cancelled async write when possible

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 * Changing the log level on the fly would not affect the core level log output ([#6440](https://github.com/realm/realm-core/issues/6440), since 13.7.0)
 * `SyncManager::immediately_run_file_actions()` no longer ignores the result of trying to remove a realm. This could have resulted in a client reset action being reported as successful when it actually failed on windows if the `Realm` was still open ([#6050](https://github.com/realm/realm-core/issues/6050)).
 * Fix a data race in `DB::VersionManager`. If one thread committed a write transaction which increased the number of live versions above the previous highest seen during the current session at the same time as another thread began a read, the reading thread could read from a no-longer-valid memory mapping ([PR #6411](https://github.com/realm/realm-core/pull/6411), since v13.0.0).
+* Fix a deadlock when closing a Transaction with a cancelled asynchronous write scheduled while another Transaction holds the write lock ([PR #6413](https://github.com/realm/realm-core/pull/6413), since v11.10.0).
 
 ### Breaking changes
 * None.

--- a/src/realm/db.hpp
+++ b/src/realm/db.hpp
@@ -261,7 +261,7 @@ public:
     // ask for write mutex. Callback takes place when mutex has been acquired.
     // callback may occur on ANOTHER THREAD. Must not be called if write mutex
     // has already been acquired.
-    void async_request_write_mutex(TransactionRef& tr, util::UniqueFunction<void()>&& when_acquired);
+    void async_request_write_mutex(const TransactionRef& tr, util::UniqueFunction<void()>&& when_acquired);
 
     // report statistics of last commit done on THIS DB.
     // The free space reported is what can be expected to be freed
@@ -500,7 +500,7 @@ private:
     util::InterprocessCondVar m_pick_next_writer;
     std::function<void(int, int)> m_upgrade_callback;
     std::shared_ptr<metrics::Metrics> m_metrics;
-    std::unique_ptr<AsyncCommitHelper> m_commit_helper;
+    std::shared_ptr<AsyncCommitHelper> m_commit_helper;
     std::shared_ptr<util::Logger> m_logger;
     bool m_is_sync_agent = false;
 
@@ -612,7 +612,7 @@ private:
     void close_internal(std::unique_lock<util::InterprocessMutex>, bool allow_open_read_transactions)
         REQUIRES(!m_mutex);
 
-    void async_begin_write(util::UniqueFunction<void()> fn);
+    void async_begin_write(util::UniqueFunction<bool()> fn);
     void async_end_write();
     void async_sync_to_disk(util::UniqueFunction<void()> fn);
 

--- a/src/realm/transaction.cpp
+++ b/src/realm/transaction.cpp
@@ -766,15 +766,7 @@ void Transaction::prepare_for_close()
             break;
 
         case AsyncState::Requesting:
-            // We don't have the ability to cancel a wait on the write lock, so
-            // unfortunately we have to wait for it to be acquired.
-            REALM_ASSERT(m_transact_stage == DB::transact_Reading);
-            REALM_ASSERT(!m_oldest_version_not_persisted);
-            m_waiting_for_write_lock = true;
-            m_async_cv.wait(lck.native_handle(), [this]() REQUIRES(m_async_mutex) {
-                return !m_waiting_for_write_lock;
-            });
-            db->end_write_on_correct_thread();
+            m_async_stage = AsyncState::Idle;
             break;
 
         case AsyncState::HasLock:

--- a/src/realm/transaction.hpp
+++ b/src/realm/transaction.hpp
@@ -204,7 +204,6 @@ private:
     util::CheckedMutex m_async_mutex;
     std::condition_variable m_async_cv GUARDED_BY(m_async_mutex);
     AsyncState m_async_stage GUARDED_BY(m_async_mutex) = AsyncState::Idle;
-    std::chrono::steady_clock::time_point m_request_time_point;
     bool m_waiting_for_write_lock GUARDED_BY(m_async_mutex) = false;
     bool m_waiting_for_sync GUARDED_BY(m_async_mutex) = false;
 

--- a/test/object-store/sync/sync_test_utils.cpp
+++ b/test/object-store/sync/sync_test_utils.cpp
@@ -87,29 +87,6 @@ bool ReturnsTrueWithinTimeLimit::match(util::FunctionRef<bool()> condition) cons
     return predicate_returned_true;
 }
 
-void timed_wait_for(util::FunctionRef<bool()> condition, std::chrono::milliseconds max_ms)
-{
-    const auto wait_start = std::chrono::steady_clock::now();
-    util::EventLoop::main().run_until([&] {
-        if (std::chrono::steady_clock::now() - wait_start > max_ms) {
-            throw std::runtime_error(util::format("timed_wait_for exceeded %1 ms", max_ms.count()));
-        }
-        return condition();
-    });
-}
-
-void timed_sleeping_wait_for(util::FunctionRef<bool()> condition, std::chrono::milliseconds max_ms,
-                             std::chrono::milliseconds sleep_ms)
-{
-    const auto wait_start = std::chrono::steady_clock::now();
-    while (!condition()) {
-        if (std::chrono::steady_clock::now() - wait_start > max_ms) {
-            throw std::runtime_error(util::format("timed_sleeping_wait_for exceeded %1 ms", max_ms.count()));
-        }
-        std::this_thread::sleep_for(sleep_ms);
-    }
-}
-
 auto do_hash = [](const std::string& name) -> std::string {
     std::array<unsigned char, 32> hash;
     util::sha256(name.data(), name.size(), hash.data());

--- a/test/object-store/sync/sync_test_utils.hpp
+++ b/test/object-store/sync/sync_test_utils.hpp
@@ -28,7 +28,6 @@
 #include <realm/util/functional.hpp>
 #include <realm/util/function_ref.hpp>
 
-#include "util/event_loop.hpp"
 #include "util/test_file.hpp"
 #include "util/test_utils.hpp"
 
@@ -46,13 +45,6 @@ namespace realm {
 bool results_contains_user(SyncUserMetadataResults& results, const std::string& identity,
                            const std::string& auth_server);
 bool results_contains_original_name(SyncFileActionMetadataResults& results, const std::string& original_name);
-
-void timed_wait_for(util::FunctionRef<bool()> condition,
-                    std::chrono::milliseconds max_ms = std::chrono::milliseconds(5000));
-
-void timed_sleeping_wait_for(util::FunctionRef<bool()> condition,
-                             std::chrono::milliseconds max_ms = std::chrono::seconds(30),
-                             std::chrono::milliseconds sleep_ms = std::chrono::milliseconds(1));
 
 class ReturnsTrueWithinTimeLimit : public Catch::Matchers::MatcherGenericBase {
 public:

--- a/test/object-store/util/test_utils.hpp
+++ b/test/object-store/util/test_utils.hpp
@@ -19,11 +19,13 @@
 #ifndef REALM_TEST_UTILS_HPP
 #define REALM_TEST_UTILS_HPP
 
-#include <catch2/catch_all.hpp>
-#include <catch2/matchers/catch_matchers_all.hpp>
+#include "util/event_loop.hpp"
+
 #include <realm/util/file.hpp>
 #include <realm/util/optional.hpp>
 
+#include <catch2/catch_all.hpp>
+#include <catch2/matchers/catch_matchers_all.hpp>
 #include <functional>
 #include <filesystem>
 namespace fs = std::filesystem;
@@ -145,6 +147,12 @@ bool chmod_supported(const std::string& path);
 int get_permissions(const std::string& path);
 void chmod(const std::string& path, int permissions);
 
+void timed_wait_for(util::FunctionRef<bool()> condition,
+                    std::chrono::milliseconds max_ms = std::chrono::milliseconds(5000));
+
+void timed_sleeping_wait_for(util::FunctionRef<bool()> condition,
+                             std::chrono::milliseconds max_ms = std::chrono::seconds(30),
+                             std::chrono::milliseconds sleep_ms = std::chrono::milliseconds(1));
 } // namespace realm
 
 #define REQUIRE_DIR_EXISTS(macro_path)                                                                               \


### PR DESCRIPTION
We can't cancel the wait for the write lock if another process currently holds it, but if the DB for the current Transaction holds it and we're just waiting in the write queue then we can safely close the Transaction immediately and simply skip over it when it would get its turn to write.

This used to require writing some pretty convoluted code to run into, but with structured concurrency it's much easier to accidentally write something that'll deadlock. For example, the following code does:

```swift
let realm = try Realm()
realm.beginWrite()
let task = Task {
    let realm = try Realm()
    try await realm.write {
        ...
    }
}
task.cancel()
try await task.value
```
