### PR TITLE
Replace timed_wait_for with Catch matchers

### DIFF
--- a/test/object-store/audit.cpp
+++ b/test/object-store/audit.cpp
@@ -173,7 +173,7 @@ static std::vector<AuditEvent> get_audit_events_from_baas(TestAppSession& sessio
     std::vector<AuditEvent> events;
     static const std::set<std::string> nonmetadata_fields = {"activity", "event", "data", "realm_id"};
 
-    timed_wait_for(
+    REQUIRE_THAT(
         [&] {
             uint64_t count = 0;
             collection.count({}, [&](uint64_t c, util::Optional<app::AppError> error) {
@@ -186,7 +186,7 @@ static std::vector<AuditEvent> get_audit_events_from_baas(TestAppSession& sessio
             }
             return true;
         },
-        std::chrono::minutes(5));
+        ReturnsTrueWithinTimeLimit{std::chrono::minutes(5)});
 
     collection.find({}, {},
                     [&](util::Optional<std::vector<bson::Bson>>&& result, util::Optional<app::AppError> error) {
@@ -1710,12 +1710,12 @@ TEST_CASE("audit integration tests") {
         auto realm = Realm::get_shared_realm(config);
         fn(realm, 0);
 
-        timed_wait_for(
+        REQUIRE_THAT(
             [&] {
                 std::lock_guard lock(mutex);
                 return (bool)error;
             },
-            std::chrono::seconds(30));
+            ReturnsTrueWithinTimeLimit{std::chrono::seconds(30)});
         REQUIRE(bool(error));
         return *error;
     };

--- a/test/object-store/sync/flx_migration.cpp
+++ b/test/object-store/sync/flx_migration.cpp
@@ -35,7 +35,7 @@ static void trigger_server_migration(const AppSession& app_session, bool switch_
     }();
     const int duration = 300; // 5 minutes, for now, since it sometimes takes longet than 90 seconds
     try {
-        timed_sleeping_wait_for(
+        REQUIRE_THAT(
             [&] {
                 status = app_session.admin_api.get_migration_status(app_session.server_app_id);
                 if (logger && last_status != status.statusMessage) {
@@ -45,7 +45,7 @@ static void trigger_server_migration(const AppSession& app_session, bool switch_
                 return status.complete;
             },
             // Query the migration status every 0.5 seconds for up to 90 seconds
-            std::chrono::seconds(duration), std::chrono::milliseconds(500));
+            ReturnsTrueWithinTimeLimitWithSleeps(std::chrono::seconds(duration), std::chrono::milliseconds(500)));
     }
     catch (const std::runtime_error&) {
         if (logger)

--- a/test/object-store/sync/flx_sync.cpp
+++ b/test/object-store/sync/flx_sync.cpp
@@ -1621,10 +1621,12 @@ TEST_CASE("flx: connect to FLX as PBS returns an error", "[sync][flx][app]") {
         sync_error = std::move(error);
     };
     auto realm = Realm::get_shared_realm(config);
-    timed_wait_for([&] {
-        std::lock_guard<std::mutex> lk(sync_error_mutex);
-        return static_cast<bool>(sync_error);
-    });
+    REQUIRE_THAT(
+        [&] {
+            std::lock_guard<std::mutex> lk(sync_error_mutex);
+            return static_cast<bool>(sync_error);
+        },
+        ReturnsTrueWithinTimeLimit{});
 
     CHECK(sync_error->get_system_error() == make_error_code(sync::ProtocolError::switch_to_flx_sync));
     CHECK(sync_error->server_requests_action == sync::ProtocolErrorInfo::Action::ApplicationBug);
@@ -1663,10 +1665,12 @@ TEST_CASE("flx: connect to PBS as FLX returns an error", "[sync][flx][app]") {
     latest_subs.insert_or_assign(std::move(new_query_a));
     latest_subs.commit();
 
-    timed_wait_for([&] {
-        std::lock_guard<std::mutex> lk(sync_error_mutex);
-        return static_cast<bool>(sync_error);
-    });
+    REQUIRE_THAT(
+        [&] {
+            std::lock_guard<std::mutex> lk(sync_error_mutex);
+            return static_cast<bool>(sync_error);
+        },
+        ReturnsTrueWithinTimeLimit{});
 
     CHECK(sync_error->get_system_error() == make_error_code(sync::ProtocolError::switch_to_pbs));
     CHECK(sync_error->server_requests_action == sync::ProtocolErrorInfo::Action::ApplicationBug);

--- a/test/object-store/sync/sync_test_utils.hpp
+++ b/test/object-store/sync/sync_test_utils.hpp
@@ -47,13 +47,6 @@ bool results_contains_user(SyncUserMetadataResults& results, const std::string& 
                            const std::string& auth_server);
 bool results_contains_original_name(SyncFileActionMetadataResults& results, const std::string& original_name);
 
-void timed_wait_for(util::FunctionRef<bool()> condition,
-                    std::chrono::milliseconds max_ms = std::chrono::milliseconds(5000));
-
-void timed_sleeping_wait_for(util::FunctionRef<bool()> condition,
-                             std::chrono::milliseconds max_ms = std::chrono::seconds(30),
-                             std::chrono::milliseconds sleep_ms = std::chrono::milliseconds(1));
-
 class ReturnsTrueWithinTimeLimit : public Catch::Matchers::MatcherGenericBase {
 public:
     ReturnsTrueWithinTimeLimit(std::chrono::milliseconds max_ms = std::chrono::milliseconds(5000))
@@ -65,11 +58,32 @@ public:
 
     std::string describe() const override
     {
-        return util::format("PredicateReturnsTrueAfter %1ms", m_max_ms.count());
+        return util::format("ReturnsTrueWithinTimeLimit %1ms", m_max_ms.count());
     }
 
 private:
     std::chrono::milliseconds m_max_ms;
+};
+
+class ReturnsTrueWithinTimeLimitWithSleeps : public Catch::Matchers::MatcherGenericBase {
+public:
+    ReturnsTrueWithinTimeLimitWithSleeps(std::chrono::milliseconds max_ms = std::chrono::seconds(30),
+                                         std::chrono::milliseconds sleep_ms = std::chrono::milliseconds(1))
+        : m_max_ms(max_ms)
+        , m_sleep_ms(sleep_ms)
+    {
+    }
+
+    bool match(util::FunctionRef<bool()> condition) const;
+
+    std::string describe() const override
+    {
+        return util::format("ReturnsTrueWithinTimeLimitWithSleeps %1ms", m_max_ms.count());
+    }
+
+private:
+    std::chrono::milliseconds m_max_ms;
+    std::chrono::milliseconds m_sleep_ms;
 };
 
 template <typename T>


### PR DESCRIPTION
## What, How & Why?
This replaces the timed_wait_for/timed_sleeping_wait_for functions in our tests with Catch matchers that do the same behavior but will result in a nice test failure message with the line of code that failed rather than a SIGABRT due to a thrown exception.

## ☑️ ToDos
* [ ] 📝 Changelog update
* [x] 🚦 Tests (or not relevant)
* [ ] C-API, if public C++ API changed.
