### PR TITLE
Wait for upload after creating asymmetric sync objects in tests

### DIFF
--- a/test/object-store/sync/flx_sync.cpp
+++ b/test/object-store/sync/flx_sync.cpp
@@ -2060,6 +2060,7 @@ TEST_CASE("flx: asymmetric sync", "[sync][flx][app]") {
             Object::create(c, realm, "Asymmetric", std::any(AnyDict{{"_id", foo_obj_id}, {"location", "foo"s}}));
             Object::create(c, realm, "Asymmetric", std::any(AnyDict{{"_id", bar_obj_id}, {"location", "bar"s}}));
             realm->commit_transaction();
+            wait_for_upload(*realm);
         });
 
         harness->do_with_new_realm([&](SharedRealm realm) {
@@ -2084,6 +2085,7 @@ TEST_CASE("flx: asymmetric sync", "[sync][flx][app]") {
                 "Attempting to create an object of type 'Asymmetric' with an existing primary key value 'not "
                 "implemented'");
             realm->commit_transaction();
+            wait_for_upload(*realm);
         });
 
         harness->do_with_new_realm([&](SharedRealm realm) {
@@ -2170,6 +2172,7 @@ TEST_CASE("flx: asymmetric sync", "[sync][flx][app]") {
             Object::create(c, realm, "Asymmetric",
                            std::any(AnyDict{{"_id", ObjectId::gen()}, {"embedded_obj", AnyDict{{"value", "foo"s}}}}));
             realm->commit_transaction();
+            wait_for_upload(*realm);
         });
 
         harness->do_with_new_realm([&](SharedRealm realm) {
@@ -2232,7 +2235,6 @@ TEST_CASE("flx: asymmetric sync", "[sync][flx][app]") {
 }
 
 // TODO this test has been failing very frequently. We need to fix it and re-enable it in RCORE-1149.
-#if 0
 TEST_CASE("flx: asymmetric sync - dev mode", "[sync][flx][app]") {
     FLXSyncTestHarness::ServerSchema server_schema;
     server_schema.dev_mode_enabled = true;
@@ -2274,7 +2276,6 @@ TEST_CASE("flx: asymmetric sync - dev mode", "[sync][flx][app]") {
         },
         schema);
 }
-#endif
 
 TEST_CASE("flx: send client error", "[sync][flx][app]") {
     FLXSyncTestHarness harness("flx_client_error");


### PR DESCRIPTION
## What, How & Why?
This makes our tests for asymmetric sync wait for upload after creating objects to ensure that the server doesn't leave any open mongo transactions that may cause subsequent tests to hang. This fix was suggested by @benredmond.

## ☑️ ToDos
* [ ] 📝 Changelog update
* [x] 🚦 Tests (or not relevant)
* [ ] C-API, if public C++ API changed.
