### PR TITLE
Remove SyncSession::OnlyForTesting::handle_error(SyncError)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@
 * Add admin api and test for performing the PBS->FLX migration and roll back on the server. (PR [#6366](https://github.com/realm/realm-core/pull/6366))
 * Integrate protocol support for PBS->FLX client migration ([PR #6355](https://github.com/realm/realm-core/pull/6355))
 * `SyncManager::reset_for_testing()` could race with SyncSession's being torn down in other threads causing an assertion for `REALM_ASSERT_RELEASE(no_sessions)` to fail. `SyncManager::reset_for_testing()` now waits/yields for up to 5 seconds for sessions being torn down in other threads to finish tearing down before checking this assertion. ([#6271](https://github.com/realm/realm-core/issues/6271))
+* `SyncSession::OnlyForTesting::handle_error()` now takes a `realm::sync:SessionErrorInfo` instead of a `realm::SyncError` to reflect internal refactoring ([PR #6433](https://github.com/realm/realm-core/pull/6433)).
 
 ----------------------------------------------
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -18,6 +18,7 @@ include(Utilities)
 include(SpecialtyBuilds)
 include(GetVersion)
 include(CheckCXXCompilerFlag)
+include(CheckCXXSourceCompiles)
 include(CheckCXXSourceRuns)
 include(AcquireRealmDependency)
 

--- a/src/realm/object-store/sync/sync_session.cpp
+++ b/src/realm/object-store/sync/sync_session.cpp
@@ -570,11 +570,6 @@ void SyncSession::OnlyForTesting::handle_error(SyncSession& session, sync::Sessi
     session.handle_error(std::move(error));
 }
 
-void SyncSession::OnlyForTesting::handle_error(SyncSession& session, SyncError&& error)
-{
-    session.handle_error({error.get_system_error(), std::string(error.reason()), !error.is_fatal});
-}
-
 // This method should only be called from within the error handler callback registered upon the underlying
 // `m_session`.
 void SyncSession::handle_error(sync::SessionErrorInfo error)

--- a/src/realm/object-store/sync/sync_session.hpp
+++ b/src/realm/object-store/sync/sync_session.hpp
@@ -291,7 +291,6 @@ public:
     // Expose some internal functionality to testing code.
     struct OnlyForTesting {
         static void handle_error(SyncSession& session, sync::SessionErrorInfo&& error);
-        static void handle_error(SyncSession& session, SyncError&& error);
         static void nonsync_transact_notify(SyncSession& session, VersionID::version_type version)
         {
             session.nonsync_transact_notify(version);


### PR DESCRIPTION
The conversion from SyncError to SessionErrorInfo in this function is incorrect (it drops most of the fields of the SyncError) and it isn't really worth fixing as updating the code using this test hook to just construct a SessionErrorInfo was trivial.