### PR TITLE
verbose asserts in the Admin API

### DIFF
--- a/test/object-store/util/baas_admin_api.cpp
+++ b/test/object-store/util/baas_admin_api.cpp
@@ -462,7 +462,7 @@ AdminAPISession AdminAPISession::login(const std::string& base_url, const std::s
         login_req_body.dump(),
     };
     auto login_resp = do_http_request(std::move(auth_req));
-    REALM_ASSERT(login_resp.http_status_code == 200);
+    REALM_ASSERT_EX(login_resp.http_status_code == 200, login_resp.http_status_code, login_resp.body);
     auto login_resp_body = nlohmann::json::parse(login_resp.body);
 
     std::string access_token = login_resp_body["access_token"];
@@ -479,21 +479,21 @@ void AdminAPISession::revoke_user_sessions(const std::string& user_id, const std
 {
     auto endpoint = apps()[app_id]["users"][user_id]["logout"];
     auto response = endpoint.put("");
-    REALM_ASSERT(response.http_status_code == 204);
+    REALM_ASSERT_EX(response.http_status_code == 204, response.http_status_code, response.body);
 }
 
 void AdminAPISession::disable_user_sessions(const std::string& user_id, const std::string& app_id) const
 {
     auto endpoint = apps()[app_id]["users"][user_id]["disable"];
     auto response = endpoint.put("");
-    REALM_ASSERT(response.http_status_code == 204);
+    REALM_ASSERT_EX(response.http_status_code == 204, response.http_status_code, response.body);
 }
 
 void AdminAPISession::enable_user_sessions(const std::string& user_id, const std::string& app_id) const
 {
     auto endpoint = apps()[app_id]["users"][user_id]["enable"];
     auto response = endpoint.put("");
-    REALM_ASSERT(response.http_status_code == 204);
+    REALM_ASSERT_EX(response.http_status_code == 204, response.http_status_code, response.body);
 }
 
 // returns false for an invalid/expired access token
@@ -530,7 +530,7 @@ void AdminAPISession::delete_app(const std::string& app_id) const
 {
     auto app_endpoint = apps()[app_id];
     auto resp = app_endpoint.del();
-    REALM_ASSERT(resp.http_status_code == 204);
+    REALM_ASSERT_EX(resp.http_status_code == 204, resp.http_status_code, resp.body);
 }
 
 std::vector<AdminAPISession::Service> AdminAPISession::get_services(const std::string& app_id) const


### PR DESCRIPTION
I had a test [fail](https://spruce.mongodb.com/task/realm_core_stable_macos_release_object_store_tests_patch_7eac25f920a7d11255f8c416b1b43cfe1e8c9a06_641c918c61837da0da50f3a5_23_03_23_17_51_10/logs?execution=0&sortBy=STATUS&sortDir=ASC) on an unrelated change in one of these asserts.
There's not much more I can do without knowing the response code and body, so I'm adding this info here in case it happens again.
