### PR TITLE
Allow Collections to be owned by Collections

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -62,6 +62,7 @@ let notSyncServerSources: [String] = [
     "realm/cluster.cpp",
     "realm/cluster_tree.cpp",
     "realm/collection.cpp",
+    "realm/collection_parent.cpp",
     "realm/column_binary.cpp",
     "realm/db.cpp",
     "realm/decimal128.cpp",

--- a/src/realm/CMakeLists.txt
+++ b/src/realm/CMakeLists.txt
@@ -24,6 +24,7 @@ set(REALM_SOURCES
     chunked_binary.cpp
     cluster.cpp
     collection.cpp
+    collection_parent.cpp
     cluster_tree.cpp
     error_codes.cpp
     column_binary.cpp
@@ -138,6 +139,7 @@ set(REALM_INSTALL_HEADERS
     cluster.hpp
     cluster_tree.hpp
     collection.hpp
+    collection_parent.hpp
     column_binary.hpp
     column_fwd.hpp
     column_integer.hpp

--- a/src/realm/collection.hpp
+++ b/src/realm/collection.hpp
@@ -119,6 +119,10 @@ public:
         return ndx;
     }
 
+    virtual void set_owner(const Obj& obj, CollectionParent::Index index) = 0;
+    virtual void set_owner(std::shared_ptr<CollectionParent> parent, CollectionParent::Index index) = 0;
+
+
     StringData get_property_name() const
     {
         return get_table()->get_column_name(get_col_key());
@@ -339,9 +343,23 @@ public:
 
     const Obj& get_obj() const noexcept final
     {
-        return m_obj;
+        return m_obj_mem;
     }
 
+    ref_type get_collection_ref() const noexcept
+    {
+        try {
+            return m_parent->get_collection_ref(m_index);
+        }
+        catch (const KeyNotFound&) {
+            return ref_type(0);
+        }
+    }
+
+    void set_collection_ref(ref_type ref)
+    {
+        m_parent->set_collection_ref(m_index, ref);
+    }
 
     /// Returns true if the accessor has changed since the last time
     /// `has_changed()` was called.
@@ -364,12 +382,37 @@ public:
         return false;
     }
 
+    void set_owner(const Obj& obj, CollectionParent::Index index) override
+    {
+        m_obj_mem = obj;
+        m_parent = &m_obj_mem;
+        m_index = index;
+        if (obj) {
+            m_alloc = &obj.get_alloc();
+        }
+    }
+
+    void set_owner(std::shared_ptr<CollectionParent> parent, CollectionParent::Index index) override
+    {
+        m_obj_mem = parent->get_object();
+        m_col_parent = std::move(parent);
+        m_parent = m_col_parent.get();
+        m_index = index;
+        if (m_obj_mem) {
+            m_alloc = &m_obj_mem.get_alloc();
+        }
+    }
+
     using Interface::get_owner_key;
     using Interface::get_table;
     using Interface::get_target_table;
 
 protected:
-    Obj m_obj;
+    Obj m_obj_mem;
+    std::shared_ptr<CollectionParent> m_col_parent;
+    CollectionParent* m_parent = nullptr;
+    CollectionParent::Index m_index;
+    Allocator* m_alloc = nullptr;
     ColKey m_col_key;
     bool m_nullable = false;
 
@@ -379,18 +422,49 @@ protected:
     mutable uint_fast64_t m_last_content_version = 0;
 
     CollectionBaseImpl() = default;
-    CollectionBaseImpl(const CollectionBaseImpl& other) = default;
-    CollectionBaseImpl(CollectionBaseImpl&& other) = default;
+    CollectionBaseImpl(const CollectionBaseImpl& other)
+        : m_obj_mem(other.m_obj_mem)
+        , m_col_parent(other.m_col_parent)
+        , m_parent(m_col_parent ? m_col_parent.get() : &m_obj_mem)
+        , m_index(other.m_index)
+        , m_alloc(other.m_alloc)
+        , m_col_key(other.m_col_key)
+        , m_nullable(other.m_nullable)
+    {
+    }
 
     CollectionBaseImpl(const Obj& obj, ColKey col_key) noexcept
-        : m_obj(obj)
+        : m_obj_mem(obj)
+        , m_parent(&m_obj_mem)
+        , m_index(col_key)
         , m_col_key(col_key)
+        , m_nullable(col_key.is_nullable())
+    {
+        if (obj) {
+            m_alloc = &m_obj_mem.get_alloc();
+        }
+    }
+
+    CollectionBaseImpl(ColKey col_key) noexcept
+        : m_col_key(col_key)
         , m_nullable(col_key.is_nullable())
     {
     }
 
-    CollectionBaseImpl& operator=(const CollectionBaseImpl& other) = default;
-    CollectionBaseImpl& operator=(CollectionBaseImpl&& other) = default;
+    CollectionBaseImpl& operator=(const CollectionBaseImpl& other)
+    {
+        if (this != &other) {
+            m_obj_mem = other.m_obj_mem;
+            m_col_parent = other.m_col_parent;
+            m_parent = m_col_parent ? m_col_parent.get() : &m_obj_mem;
+            m_alloc = other.m_alloc;
+            m_index = other.m_index;
+            m_col_key = other.m_col_key;
+            m_nullable = other.m_nullable;
+        }
+
+        return *this;
+    }
 
     bool operator==(const Derived& other) const noexcept
     {
@@ -420,10 +494,10 @@ protected:
     /// `UpdateStatus::NoChange`, and the caller is allowed to not do anything.
     virtual UpdateStatus update_if_needed() const
     {
-        UpdateStatus status = m_obj.update_if_needed_with_status();
+        UpdateStatus status = m_parent ? m_parent->update_if_needed_with_status() : UpdateStatus::Detached;
 
         if (status != UpdateStatus::Detached) {
-            auto content_version = m_obj.get_alloc().get_content_version();
+            auto content_version = m_alloc->get_content_version();
             if (content_version != m_content_version) {
                 m_content_version = content_version;
                 status = UpdateStatus::Updated;
@@ -445,8 +519,8 @@ protected:
     /// method will never return `UpdateStatus::Detached`.
     virtual UpdateStatus ensure_created()
     {
-        bool changed = m_obj.update_if_needed(); // Throws if the object does not exist.
-        auto content_version = m_obj.get_alloc().get_content_version();
+        bool changed = m_parent->update_if_needed(); // Throws if the object does not exist.
+        auto content_version = m_alloc->get_content_version();
 
         if (changed || content_version != m_content_version) {
             m_content_version = content_version;
@@ -457,7 +531,7 @@ protected:
 
     void bump_content_version()
     {
-        m_content_version = m_obj.bump_content_version();
+        m_content_version = m_parent->bump_content_version();
     }
 
     /// Reset the accessor's tracking of the content version. Derived classes
@@ -474,18 +548,13 @@ protected:
     ref_type get_child_ref(size_t child_ndx) const noexcept final
     {
         static_cast<void>(child_ndx);
-        try {
-            return to_ref(m_obj._get<int64_t>(m_col_key.get_index()));
-        }
-        catch (const KeyNotFound&) {
-            return ref_type(0);
-        }
+        return get_collection_ref();
     }
 
     void update_child_ref(size_t child_ndx, ref_type new_ref) final
     {
         static_cast<void>(child_ndx);
-        m_obj.set_int(m_col_key, from_ref(new_ref));
+        set_collection_ref(new_ref);
     }
 };
 
@@ -763,6 +832,26 @@ private:
     mutable value_type m_val;
     const L* m_list;
     size_t m_ndx = size_t(-1);
+};
+
+template <class T>
+class IteratorAdapter {
+public:
+    IteratorAdapter(T* keys)
+        : m_list(keys)
+    {
+    }
+    CollectionIterator<T> begin() const
+    {
+        return CollectionIterator<T>(m_list, 0);
+    }
+    CollectionIterator<T> end() const
+    {
+        return CollectionIterator<T>(m_list, m_list->size());
+    }
+
+private:
+    T* m_list;
 };
 
 } // namespace realm

--- a/src/realm/collection_parent.cpp
+++ b/src/realm/collection_parent.cpp
@@ -1,0 +1,263 @@
+/*************************************************************************
+ *
+ * Copyright 2023 Realm Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ **************************************************************************/
+
+#include <realm/collection_parent.hpp>
+#include "realm/list.hpp"
+#include "realm/set.hpp"
+#include "realm/dictionary.hpp"
+
+namespace realm {
+
+/***************************** CollectionParent ******************************/
+
+CollectionParent::~CollectionParent() {}
+
+void CollectionParent::set_backlink(ColKey col_key, ObjLink new_link) const
+{
+    if (new_link && new_link.get_obj_key()) {
+        auto t = get_table();
+        auto target_table = t->get_parent_group()->get_table(new_link.get_table_key());
+        ColKey backlink_col_key;
+        auto type = col_key.get_type();
+        if (type == col_type_TypedLink || type == col_type_Mixed || col_key.is_dictionary()) {
+            // This may modify the target table
+            backlink_col_key = target_table->find_or_add_backlink_column(col_key, t->get_key());
+            // it is possible that this was a link to the same table and that adding a backlink column has
+            // caused the need to update this object as well.
+            update_if_needed();
+        }
+        else {
+            backlink_col_key = t->get_opposite_column(col_key);
+        }
+        auto obj_key = new_link.get_obj_key();
+        auto target_obj = obj_key.is_unresolved() ? target_table->try_get_tombstone(obj_key)
+                                                  : target_table->try_get_object(obj_key);
+        if (!target_obj) {
+            throw InvalidArgument(ErrorCodes::KeyNotFound, "Target object not found");
+        }
+        target_obj.add_backlink(backlink_col_key, get_object().get_key());
+    }
+}
+
+bool CollectionParent::replace_backlink(ColKey col_key, ObjLink old_link, ObjLink new_link, CascadeState& state) const
+{
+    bool recurse = remove_backlink(col_key, old_link, state);
+    set_backlink(col_key, new_link);
+
+    return recurse;
+}
+
+bool CollectionParent::remove_backlink(ColKey col_key, ObjLink old_link, CascadeState& state) const
+{
+    if (old_link && old_link.get_obj_key()) {
+        auto t = get_table();
+        REALM_ASSERT(t->valid_column(col_key));
+        ObjKey old_key = old_link.get_obj_key();
+        auto target_obj = t->get_parent_group()->get_object(old_link);
+        TableRef target_table = target_obj.get_table();
+        ColKey backlink_col_key;
+        auto type = col_key.get_type();
+        if (type == col_type_TypedLink || type == col_type_Mixed || col_key.is_dictionary()) {
+            backlink_col_key = target_table->find_or_add_backlink_column(col_key, t->get_key());
+        }
+        else {
+            backlink_col_key = t->get_opposite_column(col_key);
+        }
+
+        bool strong_links = target_table->is_embedded();
+        bool is_unres = old_key.is_unresolved();
+
+        bool last_removed = target_obj.remove_one_backlink(backlink_col_key, get_object().get_key()); // Throws
+        if (is_unres) {
+            if (last_removed) {
+                // Check is there are more backlinks
+                if (!target_obj.has_backlinks(false)) {
+                    // Tombstones can be erased right away - there is no cascading effect
+                    target_table->m_tombstones->erase(old_key, state);
+                }
+            }
+        }
+        else {
+            return state.enqueue_for_cascade(target_obj, strong_links, last_removed);
+        }
+    }
+
+    return false;
+}
+
+LstBasePtr CollectionParent::get_listbase_ptr(ColKey col_key) const
+{
+    auto table = get_table();
+    auto attr = table->get_column_attr(col_key);
+    REALM_ASSERT(attr.test(col_attr_List));
+    bool nullable = attr.test(col_attr_Nullable);
+
+    switch (table->get_column_type(col_key)) {
+        case type_Int: {
+            if (nullable)
+                return std::make_unique<Lst<util::Optional<Int>>>(col_key);
+            else
+                return std::make_unique<Lst<Int>>(col_key);
+        }
+        case type_Bool: {
+            if (nullable)
+                return std::make_unique<Lst<util::Optional<Bool>>>(col_key);
+            else
+                return std::make_unique<Lst<Bool>>(col_key);
+        }
+        case type_Float: {
+            if (nullable)
+                return std::make_unique<Lst<util::Optional<Float>>>(col_key);
+            else
+                return std::make_unique<Lst<Float>>(col_key);
+        }
+        case type_Double: {
+            if (nullable)
+                return std::make_unique<Lst<util::Optional<Double>>>(col_key);
+            else
+                return std::make_unique<Lst<Double>>(col_key);
+        }
+        case type_String: {
+            return std::make_unique<Lst<String>>(col_key);
+        }
+        case type_Binary: {
+            return std::make_unique<Lst<Binary>>(col_key);
+        }
+        case type_Timestamp: {
+            return std::make_unique<Lst<Timestamp>>(col_key);
+        }
+        case type_Decimal: {
+            return std::make_unique<Lst<Decimal128>>(col_key);
+        }
+        case type_ObjectId: {
+            if (nullable)
+                return std::make_unique<Lst<util::Optional<ObjectId>>>(col_key);
+            else
+                return std::make_unique<Lst<ObjectId>>(col_key);
+        }
+        case type_UUID: {
+            if (nullable)
+                return std::make_unique<Lst<util::Optional<UUID>>>(col_key);
+            else
+                return std::make_unique<Lst<UUID>>(col_key);
+        }
+        case type_TypedLink: {
+            return std::make_unique<Lst<ObjLink>>(col_key);
+        }
+        case type_Mixed: {
+            return std::make_unique<Lst<Mixed>>(col_key);
+        }
+        case type_LinkList:
+            return std::make_unique<LnkLst>(col_key);
+        case type_Link:
+            break;
+    }
+    REALM_TERMINATE("Unsupported column type");
+}
+
+SetBasePtr CollectionParent::get_setbase_ptr(ColKey col_key) const
+{
+    auto table = get_table();
+    auto attr = table->get_column_attr(col_key);
+    REALM_ASSERT(attr.test(col_attr_Set));
+    bool nullable = attr.test(col_attr_Nullable);
+
+    switch (table->get_column_type(col_key)) {
+        case type_Int: {
+            if (nullable)
+                return std::make_unique<Set<util::Optional<Int>>>(col_key);
+            else
+                return std::make_unique<Set<Int>>(col_key);
+        }
+        case type_Bool: {
+            if (nullable)
+                return std::make_unique<Set<util::Optional<Bool>>>(col_key);
+            else
+                return std::make_unique<Set<Bool>>(col_key);
+        }
+        case type_Float: {
+            if (nullable)
+                return std::make_unique<Set<util::Optional<Float>>>(col_key);
+            else
+                return std::make_unique<Set<Float>>(col_key);
+        }
+        case type_Double: {
+            if (nullable)
+                return std::make_unique<Set<util::Optional<Double>>>(col_key);
+            else
+                return std::make_unique<Set<Double>>(col_key);
+        }
+        case type_String: {
+            return std::make_unique<Set<String>>(col_key);
+        }
+        case type_Binary: {
+            return std::make_unique<Set<Binary>>(col_key);
+        }
+        case type_Timestamp: {
+            return std::make_unique<Set<Timestamp>>(col_key);
+        }
+        case type_Decimal: {
+            return std::make_unique<Set<Decimal128>>(col_key);
+        }
+        case type_ObjectId: {
+            if (nullable)
+                return std::make_unique<Set<util::Optional<ObjectId>>>(col_key);
+            else
+                return std::make_unique<Set<ObjectId>>(col_key);
+        }
+        case type_UUID: {
+            if (nullable)
+                return std::make_unique<Set<util::Optional<UUID>>>(col_key);
+            else
+                return std::make_unique<Set<UUID>>(col_key);
+        }
+        case type_TypedLink: {
+            return std::make_unique<Set<ObjLink>>(col_key);
+        }
+        case type_Mixed: {
+            return std::make_unique<Set<Mixed>>(col_key);
+        }
+        case type_Link: {
+            return std::make_unique<LnkSet>(col_key);
+        }
+        case type_LinkList:
+            break;
+    }
+    REALM_TERMINATE("Unsupported column type.");
+}
+
+DictionaryPtr CollectionParent::get_dictionary_ptr(ColKey col_key) const
+{
+    return std::make_unique<Dictionary>(col_key);
+}
+
+CollectionBasePtr CollectionParent::get_collection_ptr(ColKey col_key) const
+{
+    if (col_key.is_list()) {
+        return get_listbase_ptr(col_key);
+    }
+    else if (col_key.is_set()) {
+        return get_setbase_ptr(col_key);
+    }
+    else if (col_key.is_dictionary()) {
+        return get_dictionary_ptr(col_key);
+    }
+    return {};
+}
+
+} // namespace realm

--- a/src/realm/collection_parent.hpp
+++ b/src/realm/collection_parent.hpp
@@ -1,0 +1,106 @@
+/*************************************************************************
+ *
+ * Copyright 2023 Realm Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ **************************************************************************/
+
+#ifndef REALM_COLLECTION_PARENT_HPP
+#define REALM_COLLECTION_PARENT_HPP
+
+#include <realm/alloc.hpp>
+#include <realm/table_ref.hpp>
+#include <realm/keys.hpp>
+
+#include <external/mpark/variant.hpp>
+
+namespace realm {
+
+class Obj;
+class Replication;
+class CascadeState;
+
+class CollectionBase;
+class CollectionList;
+class LstBase;
+class SetBase;
+class Dictionary;
+
+using LstBasePtr = std::unique_ptr<LstBase>;
+using SetBasePtr = std::unique_ptr<SetBase>;
+using CollectionBasePtr = std::unique_ptr<CollectionBase>;
+using CollectionListPtr = std::shared_ptr<CollectionList>;
+using DictionaryPtr = std::unique_ptr<Dictionary>;
+
+/// The status of an accessor after a call to `update_if_needed()`.
+enum class UpdateStatus {
+    /// The owning object or column no longer exist, and the accessor could
+    /// not be updated. The accessor should be left in a detached state
+    /// after this, and further calls to `update_if_needed()` are not
+    /// guaranteed to reattach the accessor.
+    Detached,
+
+    /// The underlying data of the accessor was changed since the last call
+    /// to `update_if_needed()`. The accessor is still valid.
+    Updated,
+
+    /// The underlying data of the accessor did not change since the last
+    /// call to `update_if_needed()`, and the accessor is still valid in its
+    /// current state.
+    NoChange,
+};
+
+class CollectionParent {
+public:
+    using Index = mpark::variant<ColKey, int64_t, std::string>;
+
+    // Return the nesting level of the parent
+    virtual size_t get_level() const noexcept = 0;
+    virtual Replication* get_replication() const = 0;
+    /// Update the accessor (and return `UpdateStatus::Detached` if the parent
+    /// is no longer valid, rather than throwing an exception).
+    virtual UpdateStatus update_if_needed_with_status() const = 0;
+    /// Check if the storage version has changed and update if it has
+    /// Return true if the object was updated
+    virtual bool update_if_needed() const = 0;
+    virtual int_fast64_t bump_content_version() = 0;
+    virtual void bump_both_versions() = 0;
+    /// Get table of owning object
+    virtual TableRef get_table() const noexcept = 0;
+    /// Get owning object
+    virtual const Obj& get_object() const noexcept = 0;
+    /// Get the top ref from pareht
+    virtual ref_type get_collection_ref(Index) const noexcept = 0;
+    /// Set the top ref from pareht
+    virtual void set_collection_ref(Index, ref_type ref) = 0;
+
+    // Used when inserting a new link. You will not remove existing links in this process
+    void set_backlink(ColKey col_key, ObjLink new_link) const;
+    // Used when replacing a link, return true if CascadeState contains objects to remove
+    bool replace_backlink(ColKey col_key, ObjLink old_link, ObjLink new_link, CascadeState& state) const;
+    // Used when removing a backlink, return true if CascadeState contains objects to remove
+    bool remove_backlink(ColKey col_key, ObjLink old_link, CascadeState& state) const;
+
+protected:
+    virtual ~CollectionParent();
+
+    LstBasePtr get_listbase_ptr(ColKey col_key) const;
+    SetBasePtr get_setbase_ptr(ColKey col_key) const;
+    DictionaryPtr get_dictionary_ptr(ColKey col_key) const;
+    CollectionBasePtr get_collection_ptr(ColKey col_key) const;
+};
+
+} // namespace realm
+
+#endif

--- a/src/realm/collection_parent.hpp
+++ b/src/realm/collection_parent.hpp
@@ -67,17 +67,20 @@ public:
 
     // Return the nesting level of the parent
     virtual size_t get_level() const noexcept = 0;
-    virtual Replication* get_replication() const = 0;
+    /// Get table of owning object
+    virtual TableRef get_table() const noexcept = 0;
+
+protected:
+    template <class, class>
+    friend class CollectionBaseImpl;
+
+    virtual ~CollectionParent();
     /// Update the accessor (and return `UpdateStatus::Detached` if the parent
     /// is no longer valid, rather than throwing an exception).
     virtual UpdateStatus update_if_needed_with_status() const = 0;
     /// Check if the storage version has changed and update if it has
     /// Return true if the object was updated
     virtual bool update_if_needed() const = 0;
-    virtual int_fast64_t bump_content_version() = 0;
-    virtual void bump_both_versions() = 0;
-    /// Get table of owning object
-    virtual TableRef get_table() const noexcept = 0;
     /// Get owning object
     virtual const Obj& get_object() const noexcept = 0;
     /// Get the top ref from pareht
@@ -91,9 +94,6 @@ public:
     bool replace_backlink(ColKey col_key, ObjLink old_link, ObjLink new_link, CascadeState& state) const;
     // Used when removing a backlink, return true if CascadeState contains objects to remove
     bool remove_backlink(ColKey col_key, ObjLink old_link, CascadeState& state) const;
-
-protected:
-    virtual ~CollectionParent();
 
     LstBasePtr get_listbase_ptr(ColKey col_key) const;
     SetBasePtr get_setbase_ptr(ColKey col_key) const;

--- a/src/realm/dictionary.cpp
+++ b/src/realm/dictionary.cpp
@@ -41,45 +41,24 @@ void validate_key_value(const Mixed& key)
     }
 }
 
-template <class T>
-class SortedKeys {
-public:
-    SortedKeys(T* keys)
-        : m_list(keys)
-    {
-    }
-    CollectionIterator<T> begin() const
-    {
-        return CollectionIterator<T>(m_list, 0);
-    }
-    CollectionIterator<T> end() const
-    {
-        return CollectionIterator<T>(m_list, m_list->size());
-    }
-
-private:
-    T* m_list;
-};
 } // namespace
 
 
 /******************************** Dictionary *********************************/
 
-Dictionary::Dictionary(const Obj& obj, ColKey col_key)
-    : Base(obj, col_key)
-    , m_key_type(m_obj.get_table()->get_dictionary_key_type(m_col_key))
+Dictionary::Dictionary(ColKey col_key)
+    : Base(col_key)
 {
     if (!col_key.is_dictionary()) {
         throw InvalidArgument(ErrorCodes::TypeMismatch, "Property not a dictionary");
     }
-    if (!(m_key_type == type_String || m_key_type == type_Int))
-        throw Exception(ErrorCodes::InvalidDictionaryKey, "Dictionary keys can only be strings or integers");
 }
 
 Dictionary::Dictionary(Allocator& alloc, ColKey col_key, ref_type ref)
     : Base(Obj{}, col_key)
     , m_key_type(type_String)
 {
+    this->m_alloc = &alloc;
     REALM_ASSERT(ref);
     m_dictionary_top.reset(new Array(alloc));
     m_dictionary_top->init_from_ref(ref);
@@ -405,13 +384,13 @@ void Dictionary::sort_keys(std::vector<size_t>& indices, bool ascending) const
         // We rely in the design that the keys are already sorted
         switch (m_key_type) {
             case type_String: {
-                SortedKeys help(static_cast<BPlusTree<StringData>*>(m_keys.get()));
+                IteratorAdapter help(static_cast<BPlusTree<StringData>*>(m_keys.get()));
                 auto is_sorted = std::is_sorted(help.begin(), help.end());
                 REALM_ASSERT(is_sorted);
                 break;
             }
             case type_Int: {
-                SortedKeys help(static_cast<BPlusTree<Int>*>(m_keys.get()));
+                IteratorAdapter help(static_cast<BPlusTree<Int>*>(m_keys.get()));
                 auto is_sorted = std::is_sorted(help.begin(), help.end());
                 REALM_ASSERT(is_sorted);
                 break;
@@ -488,7 +467,7 @@ std::pair<Dictionary::Iterator, bool> Dictionary::insert(Mixed key, Mixed value)
     }
     else {
         if (m_col_key.get_type() == col_type_Link && value.get_type() == type_TypedLink) {
-            if (m_obj.get_table()->get_opposite_table_key(m_col_key) != value.get<ObjLink>().get_table_key()) {
+            if (m_parent->get_table()->get_opposite_table_key(m_col_key) != value.get<ObjLink>().get_table_key()) {
                 throw InvalidArgument(ErrorCodes::InvalidDictionaryValue, "Dictionary::insert: Wrong object type");
             }
         }
@@ -504,10 +483,10 @@ std::pair<Dictionary::Iterator, bool> Dictionary::insert(Mixed key, Mixed value)
     if (value.is_type(type_TypedLink)) {
         new_link = value.get<ObjLink>();
         if (!new_link.is_unresolved())
-            m_obj.get_table()->get_parent_group()->validate(new_link);
+            m_parent->get_table()->get_parent_group()->validate(new_link);
     }
     else if (value.is_type(type_Link)) {
-        auto target_table = m_obj.get_table()->get_opposite_table(m_col_key);
+        auto target_table = m_parent->get_table()->get_opposite_table(m_col_key);
         auto key = value.get<ObjKey>();
         if (!key.is_unresolved() && !target_table->is_valid(key)) {
             throw InvalidArgument(ErrorCodes::KeyNotFound, "Target object not found");
@@ -540,7 +519,7 @@ std::pair<Dictionary::Iterator, bool> Dictionary::insert(Mixed key, Mixed value)
         old_entry = true;
     }
 
-    if (Replication* repl = this->m_obj.get_replication()) {
+    if (Replication* repl = this->m_parent->get_replication()) {
         if (old_entry) {
             repl->dictionary_set(*this, ndx, key, value);
         }
@@ -562,9 +541,9 @@ std::pair<Dictionary::Iterator, bool> Dictionary::insert(Mixed key, Mixed value)
 
     if (new_link != old_link) {
         CascadeState cascade_state(CascadeState::Mode::Strong);
-        bool recurse = m_obj.replace_backlink(m_col_key, old_link, new_link, cascade_state);
+        bool recurse = m_parent->replace_backlink(m_col_key, old_link, new_link, cascade_state);
         if (recurse)
-            _impl::TableFriend::remove_recursive(*m_obj.get_table(), cascade_state); // Throws
+            _impl::TableFriend::remove_recursive(*m_parent->get_table(), cascade_state); // Throws
     }
 
     return {Iterator(this, ndx), !old_entry};
@@ -694,7 +673,7 @@ void Dictionary::nullify(Mixed key)
     auto ndx = do_find_key(key);
     REALM_ASSERT(ndx != realm::npos);
 
-    if (Replication* repl = this->m_obj.get_replication()) {
+    if (Replication* repl = m_parent->get_replication()) {
         repl->dictionary_set(*this, ndx, key, Mixed());
     }
 
@@ -711,7 +690,8 @@ void Dictionary::remove_backlinks(CascadeState& state) const
 void Dictionary::clear()
 {
     if (size() > 0) {
-        Replication* repl = m_obj.get_replication();
+        // TODO: Should we have a "dictionary_clear" instruction?
+        Replication* repl = m_parent->get_replication();
         bool recurse = false;
         CascadeState cascade_state(CascadeState::Mode::Strong);
         if (repl) {
@@ -728,31 +708,31 @@ void Dictionary::clear()
         update_child_ref(0, 0);
 
         if (recurse)
-            _impl::TableFriend::remove_recursive(*m_obj.get_table(), cascade_state); // Throws
+            _impl::TableFriend::remove_recursive(*m_parent->get_table(), cascade_state); // Throws
     }
 }
 
 bool Dictionary::init_from_parent(bool allow_create) const
 {
-    auto ref = m_obj._get<int64_t>(m_col_key.get_index());
+    auto ref = get_collection_ref();
 
     if ((ref || allow_create) && !m_dictionary_top) {
-        m_dictionary_top.reset(new Array(m_obj.get_alloc()));
-        m_dictionary_top->set_parent(const_cast<Dictionary*>(this), m_obj.get_row_ndx());
+        m_dictionary_top.reset(new Array(*m_alloc));
+        m_dictionary_top->set_parent(const_cast<Dictionary*>(this), m_parent->get_object().get_row_ndx());
         switch (m_key_type) {
             case type_String: {
-                m_keys.reset(new BPlusTree<StringData>(m_obj.get_alloc()));
+                m_keys.reset(new BPlusTree<StringData>(*m_alloc));
                 break;
             }
             case type_Int: {
-                m_keys.reset(new BPlusTree<Int>(m_obj.get_alloc()));
+                m_keys.reset(new BPlusTree<Int>(*m_alloc));
                 break;
             }
             default:
                 break;
         }
         m_keys->set_parent(m_dictionary_top.get(), 0);
-        m_values.reset(new BPlusTree<Mixed>(m_obj.get_alloc()));
+        m_values.reset(new BPlusTree<Mixed>(*m_alloc));
         m_values->set_parent(m_dictionary_top.get(), 1);
     }
 
@@ -796,7 +776,7 @@ std::pair<size_t, Mixed> Dictionary::find_impl(Mixed key) const noexcept
             case type_String: {
                 auto keys = static_cast<BPlusTree<StringData>*>(m_keys.get());
                 StringData val = key.get<StringData>();
-                SortedKeys help(keys);
+                IteratorAdapter help(keys);
                 auto it = std::lower_bound(help.begin(), help.end(), val);
                 if (it.index() < sz) {
                     actual = *it;
@@ -807,7 +787,7 @@ std::pair<size_t, Mixed> Dictionary::find_impl(Mixed key) const noexcept
             case type_Int: {
                 auto keys = static_cast<BPlusTree<Int>*>(m_keys.get());
                 Int val = key.get<Int>();
-                SortedKeys help(keys);
+                IteratorAdapter help(keys);
                 auto it = std::lower_bound(help.begin(), help.end(), val);
                 if (it.index() < sz) {
                     actual = *it;
@@ -845,9 +825,9 @@ void Dictionary::do_erase(size_t ndx, Mixed key)
     CascadeState cascade_state(CascadeState::Mode::Strong);
     bool recurse = clear_backlink(old_value, cascade_state);
     if (recurse)
-        _impl::TableFriend::remove_recursive(*m_obj.get_table(), cascade_state); // Throws
+        _impl::TableFriend::remove_recursive(*m_parent->get_table(), cascade_state); // Throws
 
-    if (Replication* repl = this->m_obj.get_replication()) {
+    if (Replication* repl = this->m_parent->get_replication()) {
         repl->dictionary_erase(*this, ndx, key);
     }
 
@@ -881,7 +861,7 @@ std::pair<Mixed, Mixed> Dictionary::do_get_pair(size_t ndx) const
 bool Dictionary::clear_backlink(Mixed value, CascadeState& state) const
 {
     if (value.is_type(type_TypedLink)) {
-        return m_obj.remove_backlink(m_col_key, value.get_link(), state);
+        return m_parent->remove_backlink(m_col_key, value.get_link(), state);
     }
     return false;
 }
@@ -892,7 +872,7 @@ void Dictionary::swap_content(Array& fields1, Array& fields2, size_t index1, siz
 
     // Swap keys
     REALM_ASSERT(m_key_type == type_String);
-    ArrayString keys(m_obj.get_alloc());
+    ArrayString keys(*m_alloc);
     keys.set_parent(&fields1, 1);
     keys.init_from_parent();
     buf1 = keys.get(index1);
@@ -907,7 +887,7 @@ void Dictionary::swap_content(Array& fields1, Array& fields2, size_t index1, siz
     keys.set(index1, buf2);
 
     // Swap values
-    ArrayMixed values(m_obj.get_alloc());
+    ArrayMixed values(*m_alloc);
     values.set_parent(&fields1, 2);
     values.init_from_parent();
     Mixed val1 = values.get(index1);
@@ -937,6 +917,13 @@ void Dictionary::verify() const
     REALM_ASSERT(m_keys->size() == m_values->size());
 }
 
+void Dictionary::get_key_type()
+{
+    m_key_type = m_parent->get_table()->get_dictionary_key_type(m_col_key);
+    if (!(m_key_type == type_String || m_key_type == type_Int))
+        throw Exception(ErrorCodes::InvalidDictionaryKey, "Dictionary keys can only be strings or integers");
+}
+
 void Dictionary::migrate()
 {
     // Dummy implementation of legacy dictionary cluster tree
@@ -957,15 +944,15 @@ void Dictionary::migrate()
         ArrayParent* m_owner;
     };
 
-    if (auto dict_ref = m_obj._get<int64_t>(get_col_key().get_index())) {
-        DictionaryClusterTree cluster_tree(this, m_obj.get_alloc(), m_obj.get_row_ndx());
+    if (auto dict_ref = get_collection_ref()) {
+        DictionaryClusterTree cluster_tree(this, *m_alloc, m_parent->get_object().get_row_ndx());
         if (cluster_tree.init_from_parent()) {
             // Create an empty dictionary in the old ones place
-            m_obj.set_int(get_col_key(), 0);
+            set_collection_ref(0);
             ensure_created();
 
-            ArrayString keys(m_obj.get_alloc()); // We only support string type keys.
-            ArrayMixed values(m_obj.get_alloc());
+            ArrayString keys(*m_alloc); // We only support string type keys.
+            ArrayMixed values(*m_alloc);
             constexpr ColKey key_col(ColKey::Idx{0}, col_type_String, ColumnAttrMask(), 0);
             constexpr ColKey value_col(ColKey::Idx{1}, col_type_Mixed, ColumnAttrMask(), 0);
             size_t nb_elements = cluster_tree.size();
@@ -986,7 +973,7 @@ void Dictionary::migrate()
                 return IteratorControl::AdvanceToNext;
             });
             REALM_ASSERT(size() == nb_elements);
-            Array::destroy_deep(to_ref(dict_ref), m_obj.get_alloc());
+            Array::destroy_deep(to_ref(dict_ref), *m_alloc);
         }
         else {
             REALM_UNREACHABLE();

--- a/src/realm/dictionary.hpp
+++ b/src/realm/dictionary.hpp
@@ -34,7 +34,12 @@ public:
     Dictionary() {}
     ~Dictionary();
 
-    Dictionary(const Obj& obj, ColKey col_key);
+    Dictionary(const Obj& obj, ColKey col_key)
+        : Dictionary(col_key)
+    {
+        this->set_owner(obj, col_key);
+    }
+    Dictionary(ColKey col_key);
     Dictionary(const Dictionary& other)
         : Base(static_cast<const Base&>(other))
         , m_key_type(other.m_key_type)
@@ -101,7 +106,7 @@ public:
     void for_all_values(T&& f)
     {
         if (update()) {
-            BPlusTree<Mixed> values(m_obj.get_alloc());
+            BPlusTree<Mixed> values(*m_alloc);
             values.init_from_ref(m_dictionary_top->get_as_ref(1));
             auto func = [&f](BPlusTreeNode* node, size_t) {
                 auto leaf = static_cast<BPlusTree<Mixed>::LeafNode*>(node);
@@ -120,7 +125,7 @@ public:
     void for_all_keys(Func&& f)
     {
         if (update()) {
-            BPlusTree<T> keys(m_obj.get_alloc());
+            BPlusTree<T> keys(*m_alloc);
             keys.init_from_ref(m_dictionary_top->get_as_ref(0));
             auto func = [&f](BPlusTreeNode* node, size_t) {
                 auto leaf = static_cast<typename BPlusTree<T>::LeafNode*>(node);
@@ -140,6 +145,18 @@ public:
     Iterator end() const;
 
     void migrate();
+
+    void set_owner(const Obj& obj, CollectionParent::Index index) override
+    {
+        Base::set_owner(obj, index);
+        get_key_type();
+    }
+
+    void set_owner(std::shared_ptr<CollectionParent> parent, CollectionParent::Index index) override
+    {
+        Base::set_owner(std::move(parent), index);
+        get_key_type();
+    }
 
 private:
     template <typename T, typename Op>
@@ -183,6 +200,7 @@ private:
         return update_if_needed() != UpdateStatus::Detached;
     }
     void verify() const;
+    void get_key_type();
 };
 
 class Dictionary::Iterator {
@@ -373,7 +391,7 @@ public:
     {
         return m_source.update_if_needed();
     }
-    BPlusTree<ObjKey>* get_mutable_tree() const
+    BPlusTree<ObjKey>* get_mutable_tree() const final
     {
         // We are faking being an ObjList because the underlying storage is not
         // actually a BPlusTree<ObjKey> for dictionaries it is all mixed values.
@@ -382,6 +400,16 @@ public:
         // the same way as for LnkSet and LnkLst. This means that the functions
         // that call get_mutable_tree do not need to do anything for dictionaries.
         return nullptr;
+    }
+
+    void set_owner(const Obj& obj, CollectionParent::Index index) override
+    {
+        m_source.set_owner(obj, index);
+    }
+
+    void set_owner(std::shared_ptr<CollectionParent> parent, CollectionParent::Index index) override
+    {
+        m_source.set_owner(std::move(parent), index);
     }
 
 private:
@@ -396,7 +424,7 @@ inline std::pair<Dictionary::Iterator, bool> Dictionary::insert(Mixed key, const
 
 inline std::unique_ptr<CollectionBase> Dictionary::clone_collection() const
 {
-    return m_obj.get_dictionary_ptr(m_col_key);
+    return m_obj_mem.get_dictionary_ptr(this->get_col_key());
 }
 
 

--- a/src/realm/dictionary.hpp
+++ b/src/realm/dictionary.hpp
@@ -106,7 +106,7 @@ public:
     void for_all_values(T&& f)
     {
         if (update()) {
-            BPlusTree<Mixed> values(*m_alloc);
+            BPlusTree<Mixed> values(get_alloc());
             values.init_from_ref(m_dictionary_top->get_as_ref(1));
             auto func = [&f](BPlusTreeNode* node, size_t) {
                 auto leaf = static_cast<BPlusTree<Mixed>::LeafNode*>(node);
@@ -125,7 +125,7 @@ public:
     void for_all_keys(Func&& f)
     {
         if (update()) {
-            BPlusTree<T> keys(*m_alloc);
+            BPlusTree<T> keys(get_alloc());
             keys.init_from_ref(m_dictionary_top->get_as_ref(0));
             auto func = [&f](BPlusTreeNode* node, size_t) {
                 auto leaf = static_cast<typename BPlusTree<T>::LeafNode*>(node);

--- a/src/realm/obj.cpp
+++ b/src/realm/obj.cpp
@@ -2329,12 +2329,12 @@ ref_type Obj::Internal::get_ref(const Obj& obj, ColKey col_key)
 
 ref_type Obj::get_collection_ref(Index index) const noexcept
 {
-    return _get<int64_t>(mpark::get<ColKey>(index).get_index());
+    return to_ref(_get<int64_t>(mpark::get<ColKey>(index).get_index()));
 }
 
 void Obj::set_collection_ref(Index index, ref_type ref)
 {
-    set_int(mpark::get<ColKey>(index), ref);
+    set_int(mpark::get<ColKey>(index), from_ref(ref));
 }
 
 } // namespace realm

--- a/src/realm/obj.cpp
+++ b/src/realm/obj.cpp
@@ -31,19 +31,20 @@
 #include "realm/array_typed_link.hpp"
 #include "realm/cluster_tree.hpp"
 #include "realm/column_type_traits.hpp"
+#include "realm/list.hpp"
+#include "realm/set.hpp"
 #include "realm/dictionary.hpp"
 #include "realm/link_translator.hpp"
 #include "realm/index_string.hpp"
 #include "realm/object_converter.hpp"
 #include "realm/replication.hpp"
-#include "realm/set.hpp"
 #include "realm/spec.hpp"
 #include "realm/table_view.hpp"
 #include "realm/util/base64.hpp"
 
 namespace realm {
 
-/********************************* Obj **********************************/
+/*********************************** Obj *************************************/
 
 Obj::Obj(TableRef table, MemRef mem, ObjKey key, size_t row_ndx)
     : m_table(table)
@@ -1914,76 +1915,6 @@ void Obj::nullify_link(ColKey origin_col_key, ObjLink target_link) &&
     get_alloc().bump_content_version();
 }
 
-void Obj::set_backlink(ColKey col_key, ObjLink new_link) const
-{
-    if (new_link && new_link.get_obj_key()) {
-        auto target_table = m_table->get_parent_group()->get_table(new_link.get_table_key());
-        ColKey backlink_col_key;
-        auto type = col_key.get_type();
-        if (type == col_type_TypedLink || type == col_type_Mixed || col_key.is_dictionary()) {
-            // This may modify the target table
-            backlink_col_key = target_table->find_or_add_backlink_column(col_key, get_table_key());
-            // it is possible that this was a link to the same table and that adding a backlink column has
-            // caused the need to update this object as well.
-            update_if_needed();
-        }
-        else {
-            backlink_col_key = m_table->get_opposite_column(col_key);
-        }
-        auto obj_key = new_link.get_obj_key();
-        auto target_obj = obj_key.is_unresolved() ? target_table->try_get_tombstone(obj_key)
-                                                  : target_table->try_get_object(obj_key);
-        if (!target_obj) {
-            throw InvalidArgument(ErrorCodes::KeyNotFound, "Target object not found");
-        }
-        target_obj.add_backlink(backlink_col_key, m_key);
-    }
-}
-
-bool Obj::replace_backlink(ColKey col_key, ObjLink old_link, ObjLink new_link, CascadeState& state) const
-{
-    bool recurse = remove_backlink(col_key, old_link, state);
-    set_backlink(col_key, new_link);
-
-    return recurse;
-}
-
-bool Obj::remove_backlink(ColKey col_key, ObjLink old_link, CascadeState& state) const
-{
-    if (old_link && old_link.get_obj_key()) {
-        REALM_ASSERT(m_table->valid_column(col_key));
-        ObjKey old_key = old_link.get_obj_key();
-        auto target_obj = m_table->get_parent_group()->get_object(old_link);
-        TableRef target_table = target_obj.get_table();
-        ColKey backlink_col_key;
-        auto type = col_key.get_type();
-        if (type == col_type_TypedLink || type == col_type_Mixed || col_key.is_dictionary()) {
-            backlink_col_key = target_table->find_or_add_backlink_column(col_key, get_table_key());
-        }
-        else {
-            backlink_col_key = m_table->get_opposite_column(col_key);
-        }
-
-        bool strong_links = target_table->is_embedded();
-        bool is_unres = old_key.is_unresolved();
-
-        bool last_removed = target_obj.remove_one_backlink(backlink_col_key, m_key); // Throws
-        if (is_unres) {
-            if (last_removed) {
-                // Check is there are more backlinks
-                if (!target_obj.has_backlinks(false)) {
-                    // Tombstones can be erased right away - there is no cascading effect
-                    target_table->m_tombstones->erase(old_key, state);
-                }
-            }
-        }
-        else {
-            return state.enqueue_for_cascade(target_obj, strong_links, last_removed);
-        }
-    }
-
-    return false;
-}
 
 struct EmbeddedObjectLinkMigrator : public LinkTranslator {
     EmbeddedObjectLinkMigrator(Obj origin, ColKey origin_col, Obj dest_orig, Obj dest_replace)
@@ -2081,6 +2012,20 @@ void Obj::handle_multiple_backlinks_during_schema_migration()
     m_table->for_each_backlink_column(copy_links);
 }
 
+LstBasePtr Obj::get_listbase_ptr(ColKey col_key) const
+{
+    auto list = CollectionParent::get_listbase_ptr(col_key);
+    list->set_owner(*this, col_key);
+    return list;
+}
+
+SetBasePtr Obj::get_setbase_ptr(ColKey col_key) const
+{
+    auto set = CollectionParent::get_setbase_ptr(col_key);
+    set->set_owner(*this, col_key);
+    return set;
+}
+
 Dictionary Obj::get_dictionary(ColKey col_key) const
 {
     REALM_ASSERT(col_key.is_dictionary());
@@ -2090,7 +2035,9 @@ Dictionary Obj::get_dictionary(ColKey col_key) const
 
 DictionaryPtr Obj::get_dictionary_ptr(ColKey col_key) const
 {
-    return std::make_unique<Dictionary>(Obj(*this), col_key);
+    auto dict = CollectionParent::get_dictionary_ptr(col_key);
+    dict->set_owner(*this, col_key);
+    return dict;
 }
 
 Dictionary Obj::get_dictionary(StringData col_name) const
@@ -2378,6 +2325,16 @@ ColKey Obj::get_primary_key_column() const
 ref_type Obj::Internal::get_ref(const Obj& obj, ColKey col_key)
 {
     return to_ref(obj._get<int64_t>(col_key.get_index()));
+}
+
+ref_type Obj::get_collection_ref(Index index) const noexcept
+{
+    return _get<int64_t>(mpark::get<ColKey>(index).get_index());
+}
+
+void Obj::set_collection_ref(Index index, ref_type ref)
+{
+    set_int(mpark::get<ColKey>(index), ref);
 }
 
 } // namespace realm

--- a/src/realm/obj.hpp
+++ b/src/realm/obj.hpp
@@ -80,11 +80,8 @@ public:
     {
         return 0;
     }
-    Replication* get_replication() const override;
-    UpdateStatus update_if_needed_with_status() const override;
-    bool update_if_needed() const override;
-    int_fast64_t bump_content_version() override;
-    void bump_both_versions() override;
+    UpdateStatus update_if_needed_with_status() const final;
+    bool update_if_needed() const final;
     TableRef get_table() const noexcept final
     {
         return m_table.cast_away_const();
@@ -93,8 +90,8 @@ public:
     {
         return *this;
     }
-    ref_type get_collection_ref(Index index) const noexcept override;
-    void set_collection_ref(Index index, ref_type ref) override;
+    ref_type get_collection_ref(Index index) const noexcept final;
+    void set_collection_ref(Index index, ref_type ref) final;
 
     // Operator overloads
     bool operator==(const Obj& other) const;
@@ -107,6 +104,7 @@ public:
 
     // Simple getters
     Allocator& get_alloc() const;
+    Replication* get_replication() const;
     ObjKey get_key() const noexcept
     {
         return m_key;
@@ -383,6 +381,8 @@ private:
     size_t colkey2spec_ndx(ColKey);
     bool ensure_writeable();
     void sync(Node& arr);
+    int_fast64_t bump_content_version();
+    void bump_both_versions();
     template <class T>
     void do_set_null(ColKey col_key);
 

--- a/src/realm/object-store/dictionary.cpp
+++ b/src/realm/object-store/dictionary.cpp
@@ -108,6 +108,14 @@ public:
     {
         REALM_TERMINATE("not implemented");
     }
+    void set_owner(const Obj& obj, CollectionParent::Index index) override
+    {
+        m_dictionary->set_owner(obj, index);
+    }
+    void set_owner(std::shared_ptr<CollectionParent> parent, CollectionParent::Index index) override
+    {
+        m_dictionary->set_owner(std::move(parent), index);
+    }
 
 private:
     std::shared_ptr<Dictionary> m_dictionary;

--- a/src/realm/set.cpp
+++ b/src/realm/set.cpp
@@ -32,77 +32,6 @@
 
 namespace realm {
 
-// FIXME: This method belongs in obj.cpp.
-SetBasePtr Obj::get_setbase_ptr(ColKey col_key) const
-{
-    auto attr = get_table()->get_column_attr(col_key);
-    REALM_ASSERT(attr.test(col_attr_Set));
-    bool nullable = attr.test(col_attr_Nullable);
-
-    switch (get_table()->get_column_type(col_key)) {
-        case type_Int: {
-            if (nullable)
-                return std::make_unique<Set<util::Optional<Int>>>(*this, col_key);
-            else
-                return std::make_unique<Set<Int>>(*this, col_key);
-        }
-        case type_Bool: {
-            if (nullable)
-                return std::make_unique<Set<util::Optional<Bool>>>(*this, col_key);
-            else
-                return std::make_unique<Set<Bool>>(*this, col_key);
-        }
-        case type_Float: {
-            if (nullable)
-                return std::make_unique<Set<util::Optional<Float>>>(*this, col_key);
-            else
-                return std::make_unique<Set<Float>>(*this, col_key);
-        }
-        case type_Double: {
-            if (nullable)
-                return std::make_unique<Set<util::Optional<Double>>>(*this, col_key);
-            else
-                return std::make_unique<Set<Double>>(*this, col_key);
-        }
-        case type_String: {
-            return std::make_unique<Set<String>>(*this, col_key);
-        }
-        case type_Binary: {
-            return std::make_unique<Set<Binary>>(*this, col_key);
-        }
-        case type_Timestamp: {
-            return std::make_unique<Set<Timestamp>>(*this, col_key);
-        }
-        case type_Decimal: {
-            return std::make_unique<Set<Decimal128>>(*this, col_key);
-        }
-        case type_ObjectId: {
-            if (nullable)
-                return std::make_unique<Set<util::Optional<ObjectId>>>(*this, col_key);
-            else
-                return std::make_unique<Set<ObjectId>>(*this, col_key);
-        }
-        case type_UUID: {
-            if (nullable)
-                return std::make_unique<Set<util::Optional<UUID>>>(*this, col_key);
-            else
-                return std::make_unique<Set<UUID>>(*this, col_key);
-        }
-        case type_TypedLink: {
-            return std::make_unique<Set<ObjLink>>(*this, col_key);
-        }
-        case type_Mixed: {
-            return std::make_unique<Set<Mixed>>(*this, col_key);
-        }
-        case type_Link: {
-            return std::make_unique<LnkSet>(*this, col_key);
-        }
-        case type_LinkList:
-            break;
-    }
-    REALM_TERMINATE("Unsupported column type.");
-}
-
 void SetBase::insert_repl(Replication* repl, size_t index, Mixed value) const
 {
     repl->set_insert(*this, index, value);
@@ -133,9 +62,9 @@ std::vector<Mixed> SetBase::convert_to_mixed_set(const CollectionBase& rhs)
 template <>
 void Set<ObjKey>::do_insert(size_t ndx, ObjKey target_key)
 {
-    auto origin_table = m_obj.get_table();
+    auto origin_table = m_parent->get_table();
     auto target_table_key = origin_table->get_opposite_table_key(m_col_key);
-    m_obj.set_backlink(m_col_key, {target_table_key, target_key});
+    m_parent->set_backlink(m_col_key, {target_table_key, target_key});
     m_tree->insert(ndx, target_key);
     if (target_key.is_unresolved()) {
         m_tree->set_context_flag(true);
@@ -145,12 +74,12 @@ void Set<ObjKey>::do_insert(size_t ndx, ObjKey target_key)
 template <>
 void Set<ObjKey>::do_erase(size_t ndx)
 {
-    auto origin_table = m_obj.get_table();
+    auto origin_table = m_parent->get_table();
     auto target_table_key = origin_table->get_opposite_table_key(m_col_key);
     ObjKey old_key = get(ndx);
     CascadeState state(old_key.is_unresolved() ? CascadeState::Mode::All : CascadeState::Mode::Strong);
 
-    bool recurse = m_obj.remove_backlink(m_col_key, {target_table_key, old_key}, state);
+    bool recurse = m_parent->remove_backlink(m_col_key, {target_table_key, old_key}, state);
 
     m_tree->erase(ndx);
 
@@ -180,7 +109,7 @@ void Set<ObjKey>::do_clear()
 template <>
 void Set<ObjLink>::do_insert(size_t ndx, ObjLink target_link)
 {
-    m_obj.set_backlink(m_col_key, target_link);
+    m_parent->set_backlink(m_col_key, target_link);
     m_tree->insert(ndx, target_link);
 }
 
@@ -190,12 +119,12 @@ void Set<ObjLink>::do_erase(size_t ndx)
     ObjLink old_link = get(ndx);
     CascadeState state(old_link.get_obj_key().is_unresolved() ? CascadeState::Mode::All : CascadeState::Mode::Strong);
 
-    bool recurse = m_obj.remove_backlink(m_col_key, old_link, state);
+    bool recurse = m_parent->remove_backlink(m_col_key, old_link, state);
 
     m_tree->erase(ndx);
 
     if (recurse) {
-        auto table = m_obj.get_table();
+        auto table = m_parent->get_table();
         _impl::TableFriend::remove_recursive(*table, state); // Throws
     }
 }
@@ -205,8 +134,8 @@ void Set<Mixed>::do_insert(size_t ndx, Mixed value)
 {
     if (value.is_type(type_TypedLink)) {
         auto target_link = value.get<ObjLink>();
-        m_obj.get_table()->get_parent_group()->validate(target_link);
-        m_obj.set_backlink(m_col_key, target_link);
+        m_parent->get_table()->get_parent_group()->validate(target_link);
+        m_parent->set_backlink(m_col_key, target_link);
     }
     m_tree->insert(ndx, value);
 }
@@ -219,12 +148,12 @@ void Set<Mixed>::do_erase(size_t ndx)
 
         CascadeState state(old_link.get_obj_key().is_unresolved() ? CascadeState::Mode::All
                                                                   : CascadeState::Mode::Strong);
-        bool recurse = m_obj.remove_backlink(m_col_key, old_link, state);
+        bool recurse = m_parent->remove_backlink(m_col_key, old_link, state);
 
         m_tree->erase(ndx);
 
         if (recurse) {
-            auto table = m_obj.get_table();
+            auto table = m_parent->get_table();
             _impl::TableFriend::remove_recursive(*table, state); // Throws
         }
     }

--- a/src/realm/set.cpp
+++ b/src/realm/set.cpp
@@ -62,9 +62,9 @@ std::vector<Mixed> SetBase::convert_to_mixed_set(const CollectionBase& rhs)
 template <>
 void Set<ObjKey>::do_insert(size_t ndx, ObjKey target_key)
 {
-    auto origin_table = m_parent->get_table();
+    auto origin_table = get_table_unchecked();
     auto target_table_key = origin_table->get_opposite_table_key(m_col_key);
-    m_parent->set_backlink(m_col_key, {target_table_key, target_key});
+    set_backlink(m_col_key, {target_table_key, target_key});
     m_tree->insert(ndx, target_key);
     if (target_key.is_unresolved()) {
         m_tree->set_context_flag(true);
@@ -74,12 +74,12 @@ void Set<ObjKey>::do_insert(size_t ndx, ObjKey target_key)
 template <>
 void Set<ObjKey>::do_erase(size_t ndx)
 {
-    auto origin_table = m_parent->get_table();
+    auto origin_table = get_table_unchecked();
     auto target_table_key = origin_table->get_opposite_table_key(m_col_key);
     ObjKey old_key = get(ndx);
     CascadeState state(old_key.is_unresolved() ? CascadeState::Mode::All : CascadeState::Mode::Strong);
 
-    bool recurse = m_parent->remove_backlink(m_col_key, {target_table_key, old_key}, state);
+    bool recurse = remove_backlink(m_col_key, {target_table_key, old_key}, state);
 
     m_tree->erase(ndx);
 
@@ -109,7 +109,7 @@ void Set<ObjKey>::do_clear()
 template <>
 void Set<ObjLink>::do_insert(size_t ndx, ObjLink target_link)
 {
-    m_parent->set_backlink(m_col_key, target_link);
+    set_backlink(m_col_key, target_link);
     m_tree->insert(ndx, target_link);
 }
 
@@ -119,12 +119,12 @@ void Set<ObjLink>::do_erase(size_t ndx)
     ObjLink old_link = get(ndx);
     CascadeState state(old_link.get_obj_key().is_unresolved() ? CascadeState::Mode::All : CascadeState::Mode::Strong);
 
-    bool recurse = m_parent->remove_backlink(m_col_key, old_link, state);
+    bool recurse = remove_backlink(m_col_key, old_link, state);
 
     m_tree->erase(ndx);
 
     if (recurse) {
-        auto table = m_parent->get_table();
+        auto table = get_table_unchecked();
         _impl::TableFriend::remove_recursive(*table, state); // Throws
     }
 }
@@ -134,8 +134,8 @@ void Set<Mixed>::do_insert(size_t ndx, Mixed value)
 {
     if (value.is_type(type_TypedLink)) {
         auto target_link = value.get<ObjLink>();
-        m_parent->get_table()->get_parent_group()->validate(target_link);
-        m_parent->set_backlink(m_col_key, target_link);
+        get_table_unchecked()->get_parent_group()->validate(target_link);
+        set_backlink(m_col_key, target_link);
     }
     m_tree->insert(ndx, value);
 }
@@ -148,12 +148,12 @@ void Set<Mixed>::do_erase(size_t ndx)
 
         CascadeState state(old_link.get_obj_key().is_unresolved() ? CascadeState::Mode::All
                                                                   : CascadeState::Mode::Strong);
-        bool recurse = m_parent->remove_backlink(m_col_key, old_link, state);
+        bool recurse = remove_backlink(m_col_key, old_link, state);
 
         m_tree->erase(ndx);
 
         if (recurse) {
-            auto table = m_parent->get_table();
+            auto table = get_table_unchecked();
             _impl::TableFriend::remove_recursive(*table, state); // Throws
         }
     }

--- a/src/realm/set.hpp
+++ b/src/realm/set.hpp
@@ -222,15 +222,14 @@ private:
     mutable std::unique_ptr<BPlusTree<T>> m_tree;
 
     using Base::bump_content_version;
-    using Base::m_alloc;
+    using Base::get_alloc;
     using Base::m_col_key;
     using Base::m_nullable;
-    using Base::m_parent;
 
     bool init_from_parent(bool allow_create) const
     {
         if (!m_tree) {
-            m_tree.reset(new BPlusTree<T>(*m_alloc));
+            m_tree.reset(new BPlusTree<T>(get_alloc()));
             const ArrayParent* parent = this;
             m_tree->set_parent(const_cast<ArrayParent*>(parent), 0);
         }
@@ -668,7 +667,7 @@ std::pair<size_t, bool> Set<T>::insert(T value)
         return {it.index(), false};
     }
 
-    if (Replication* repl = m_parent->get_replication()) {
+    if (Replication* repl = Base::get_replication()) {
         // FIXME: We should emit an instruction regardless of element presence for the purposes of conflict
         // resolution in synchronized databases. The reason is that the new insertion may come at a later time
         // than an interleaving erase instruction, so emitting the instruction ensures that last "write" wins.
@@ -705,7 +704,7 @@ std::pair<size_t, bool> Set<T>::erase(T value)
         return {npos, false};
     }
 
-    if (Replication* repl = m_parent->get_replication()) {
+    if (Replication* repl = Base::get_replication()) {
         this->erase_repl(repl, it.index(), value);
     }
     do_erase(it.index());
@@ -757,7 +756,7 @@ template <class T>
 inline void Set<T>::clear()
 {
     if (size() > 0) {
-        if (Replication* repl = this->m_parent->get_replication()) {
+        if (Replication* repl = Base::get_replication()) {
             this->clear_repl(repl);
         }
         do_clear();

--- a/src/realm/table.hpp
+++ b/src/realm/table.hpp
@@ -860,6 +860,7 @@ private:
     friend class ClusterTree;
     friend class ColKeyIterator;
     friend class Obj;
+    friend class CollectionParent;
     friend class LnkLst;
     friend class Dictionary;
     friend class IncludeDescriptor;

--- a/src/realm/table.hpp
+++ b/src/realm/table.hpp
@@ -123,6 +123,12 @@ public:
     /// otherwise null is returned.
     Group* get_parent_group() const noexcept;
 
+
+    Replication* get_repl() const noexcept
+    {
+        return *m_repl;
+    }
+
     // Whether or not elements can be null.
     bool is_nullable(ColKey col_key) const;
 
@@ -798,7 +804,6 @@ private:
     void nullify_links(CascadeState&);
     void remove_recursive(CascadeState&);
 
-    Replication* get_repl() const noexcept;
     util::Logger* get_logger() const noexcept;
 
     void set_ndx_in_parent(size_t ndx_in_parent) noexcept;
@@ -1266,11 +1271,6 @@ inline bool Table::operator!=(const Table& t) const
 inline bool Table::is_link_type(ColumnType col_type) noexcept
 {
     return col_type == col_type_Link || col_type == col_type_LinkList;
-}
-
-inline Replication* Table::get_repl() const noexcept
-{
-    return *m_repl;
 }
 
 inline void Table::set_ndx_in_parent(size_t ndx_in_parent) noexcept

--- a/test/test_links.cpp
+++ b/test/test_links.cpp
@@ -743,6 +743,13 @@ TEST(ListList_Clear)
     if (links.size() > 1)
         links.set(1, key0);
     links.clear();
+
+    group->commit_and_continue_as_read();
+    group->promote_to_write();
+
+    obj3.remove();
+    auto links2 = links.clone();
+    CHECK_EQUAL(links2->size(), 0);
 }
 
 TEST(Links_AddBacklinkToTableWithEnumColumns)

--- a/test/test_table.cpp
+++ b/test/test_table.cpp
@@ -3152,8 +3152,13 @@ TEST(Table_ListOfPrimitives)
     timestamp_list.max(&return_ndx);
     CHECK_EQUAL(return_ndx, 1);
 
+    auto timestamp_list2 = timestamp_list.clone();
+    CHECK_EQUAL(timestamp_list2->size(), timestamp_list.size());
+
     t->remove_object(ObjKey(7));
+    auto timestamp_list3 = timestamp_list.clone();
     CHECK_NOT(timestamp_list.is_attached());
+    CHECK_EQUAL(timestamp_list3->size(), 0);
 }
 
 TEST_TYPES(Table_ListOfPrimitivesSort, Prop<int64_t>, Prop<float>, Prop<double>, Prop<Decimal128>, Prop<ObjectId>,


### PR DESCRIPTION
## What, How & Why?
<!-- Describe the changes and give some hints to guide your reviewers if possible. -->
<!-- Link to relevant issue this fixes -->
Fixes #6362 

No functional changes - just a refactoring.
A collection does not use the Obj interface to access its parent object, but rather an interface defined in CollectionParent, which Obj then inherits from. This enables that the parent can be other than Obj.
