### PR TITLE
Fix `Results::is_valid()` for invalid results bound to deleted collections + throw if results is constructed using a deleted object.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 * <How do the end-user experience this issue? what was the impact?> ([#????](https://github.com/realm/realm-core/issues/????), since v?.?.?)
 * Changing the log level on the fly would not affect the core level log output ([#6440](https://github.com/realm/realm-core/issues/6440), since 13.7.0)
 * `SyncManager::immediately_run_file_actions()` no longer ignores the result of trying to remove a realm. This could have resulted in a client reset action being reported as successful when it actually failed on windows if the `Realm` was still open ([#6050](https://github.com/realm/realm-core/issues/6050)).
+* Fixed `Results::is_valid()` in order to return `false` if the results is bound to a deleted object. ([#https://github.com/realm/realm-core/issues/6401])
 
 
 ### Breaking changes

--- a/src/realm/object-store/results.cpp
+++ b/src/realm/object-store/results.cpp
@@ -116,14 +116,14 @@ bool Results::is_valid() const
         m_realm->verify_thread();
     }
 
+    if (m_collection)
+        return m_collection->is_attached();
+
     // Here we cannot just use if (m_table) as it combines a check if the
     // reference contains a value and if that value is valid.
     // First we check if a table is referenced ...
     if (m_table.unchecked_ptr() != nullptr)
-        return !!m_table; // ... and then we check if it is valid
-
-    if (m_collection)
-        return m_collection->is_attached();
+        return bool(m_table); // ... and then we check if it is valid
 
     return true;
 }

--- a/src/realm/object-store/results.cpp
+++ b/src/realm/object-store/results.cpp
@@ -1080,9 +1080,9 @@ Results Results::import_copy_into_realm(std::shared_ptr<Realm> const& realm)
     util::CheckedUniqueLock lock(m_mutex);
     if (m_mode == Mode::Empty)
         return *this;
-    if (!is_valid()) 
+    if (!is_valid())
         throw StaleAccessor("Attempt to construct a Results for a deleted object");
-    
+
     switch (m_mode) {
         case Mode::Table:
             return Results(realm, realm->import_copy_of(m_table));

--- a/src/realm/object-store/results.cpp
+++ b/src/realm/object-store/results.cpp
@@ -1080,6 +1080,9 @@ Results Results::import_copy_into_realm(std::shared_ptr<Realm> const& realm)
     util::CheckedUniqueLock lock(m_mutex);
     if (m_mode == Mode::Empty)
         return *this;
+    if (!is_valid()) {
+        throw StaleAccessor("Attempt to construct a Results for a deleted object");
+    }
     switch (m_mode) {
         case Mode::Table:
             return Results(realm, realm->import_copy_of(m_table));

--- a/test/object-store/c_api/c_api.cpp
+++ b/test/object-store/c_api/c_api.cpp
@@ -2546,6 +2546,48 @@ TEST_CASE("C API", "[c_api]") {
                     CHECK(valid);
                 }
 
+                SECTION("realm_results_is_valid delete objects") {
+                    write([&] {
+                        realm_object_delete(obj1.get());
+                        realm_object_delete(obj2.get());
+                        realm_results_delete_all(r.get());
+                    });
+                    bool valid;
+                    CHECK(checked(realm_results_is_valid(r.get(), &valid)));
+                    CHECK(valid);
+                }
+
+                SECTION("realm_results_is_valid delete collection") {
+                    auto strings = cptr_checked(realm_get_list(obj2.get(), bar_strings_key));
+                    CHECK(strings);
+                    CHECK(!realm_is_frozen(strings.get()));
+
+                    realm_value_t a = rlm_str_val("a");
+                    realm_value_t b = rlm_str_val("b");
+                    realm_value_t c = rlm_null();
+
+                    write([&] {
+                        CHECK(checked(realm_list_insert(strings.get(), 0, a)));
+                        CHECK(checked(realm_list_insert(strings.get(), 1, b)));
+                        CHECK(checked(realm_list_insert(strings.get(), 2, c)));
+                    });
+                    bool valid;
+                    auto results = cptr_checked(realm_list_to_results(strings.get()));
+                    CHECK(checked(realm_results_is_valid(results.get(), &valid)));
+                    CHECK(valid);
+
+                    write([&] {
+                        CHECK(checked(realm_object_delete(obj2.get())));
+                    });
+
+                    CHECK(checked(realm_results_is_valid(results.get(), &valid)));
+                    CHECK_FALSE(valid);
+                    size_t count;
+
+                    CHECK_FALSE(realm_results_count(results.get(), &count));
+                    CHECK_ERR(RLM_ERR_STALE_ACCESSOR);
+                }
+
                 SECTION("realm_results_count()") {
                     size_t count;
                     CHECK(checked(realm_results_count(r.get(), &count)));

--- a/test/object-store/c_api/c_api.cpp
+++ b/test/object-store/c_api/c_api.cpp
@@ -2586,6 +2586,9 @@ TEST_CASE("C API", "[c_api]") {
 
                     CHECK_FALSE(realm_results_count(results.get(), &count));
                     CHECK_ERR(RLM_ERR_STALE_ACCESSOR);
+
+                    CHECK_FALSE(realm_results_resolve_in(results.get(), realm));
+                    CHECK_ERR(RLM_ERR_STALE_ACCESSOR);
                 }
 
                 SECTION("realm_results_count()") {


### PR DESCRIPTION
## What, How & Why?
Throw an exception instead of returning empty Results object
