### PR TITLE
Don't crash in Query.count() when table is not defined

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 * Changing the log level on the fly would not affect the core level log output ([#6440](https://github.com/realm/realm-core/issues/6440), since 13.7.0)
 * `SyncManager::immediately_run_file_actions()` no longer ignores the result of trying to remove a realm. This could have resulted in a client reset action being reported as successful when it actually failed on windows if the `Realm` was still open ([#6050](https://github.com/realm/realm-core/issues/6050)).
 * Fix a data race in `DB::VersionManager`. If one thread committed a write transaction which increased the number of live versions above the previous highest seen during the current session at the same time as another thread began a read, the reading thread could read from a no-longer-valid memory mapping ([PR #6411](https://github.com/realm/realm-core/pull/6411), since v13.0.0).
+* Performing count() on an undefined Query would crash. ([#6443](https://github.com/realm/realm-core/issues/6443), since v13.7.0)
 
 ### Breaking changes
 * None.

--- a/src/realm/query.cpp
+++ b/src/realm/query.cpp
@@ -1183,6 +1183,11 @@ Query& Query::Or()
 
 ObjKey Query::find() const
 {
+    ObjKey ret;
+
+    if (!m_table)
+        return ret;
+
 #if REALM_METRICS
     std::unique_ptr<MetricTimer> metric_timer = QueryInfo::track(this, QueryInfo::type_Find);
 #endif
@@ -1197,7 +1202,6 @@ ObjKey Query::find() const
         do_log = true;
     }
 
-    ObjKey ret;
     init();
 
     // ordering could change the way in which objects are returned, in this case we need to run find_all()
@@ -1495,6 +1499,8 @@ size_t Query::count() const
 #if REALM_METRICS
     std::unique_ptr<MetricTimer> metric_timer = QueryInfo::track(this, QueryInfo::type_Count);
 #endif
+    if (!m_table)
+        return 0;
     return do_count();
 }
 
@@ -1536,6 +1542,8 @@ size_t Query::count(const DescriptorOrdering& descriptor) const
 #if REALM_METRICS
     std::unique_ptr<MetricTimer> metric_timer = QueryInfo::track(this, QueryInfo::type_Count);
 #endif
+    if (!m_table)
+        return 0;
     realm::util::Optional<size_t> min_limit = descriptor.get_min_limit();
 
     if (bool(min_limit) && *min_limit == 0)


### PR DESCRIPTION
## What, How & Why?
<!-- Describe the changes and give some hints to guide your reviewers if possible. -->
<!-- Link to relevant issue this fixes -->

Fixes #6443 

## ☑️ ToDos
* [x] 📝 Changelog update
* [x] 🚦 Tests (or not relevant)
* [x] C-API, if public C++ API changed.
