### PR TITLE
Change CollectionBase::set_owner() interface

### DIFF
--- a/src/realm/collection.hpp
+++ b/src/realm/collection.hpp
@@ -122,7 +122,7 @@ public:
         return ndx;
     }
 
-    virtual void set_owner(const Obj& obj, CollectionParent::Index index) = 0;
+    virtual void set_owner(const Obj& obj, ColKey) = 0;
     virtual void set_owner(std::shared_ptr<CollectionParent> parent, CollectionParent::Index index) = 0;
 
 
@@ -442,11 +442,11 @@ protected:
         return !(*this == other);
     }
 
-    void set_owner(const Obj& obj, CollectionParent::Index index) override
+    void set_owner(const Obj& obj, ColKey ck) override
     {
         m_obj_mem = obj;
         m_parent = &m_obj_mem;
-        m_index = index;
+        m_index = ck;
         if (obj) {
             m_alloc = &obj.get_alloc();
         }
@@ -461,7 +461,10 @@ protected:
         if (m_obj_mem) {
             m_alloc = &m_obj_mem.get_alloc();
         }
+        // Force update on next access
+        m_content_version = 0;
     }
+
 
     ref_type get_collection_ref() const noexcept
     {

--- a/src/realm/dictionary.hpp
+++ b/src/realm/dictionary.hpp
@@ -146,9 +146,9 @@ public:
 
     void migrate();
 
-    void set_owner(const Obj& obj, CollectionParent::Index index) override
+    void set_owner(const Obj& obj, ColKey ck) override
     {
-        Base::set_owner(obj, index);
+        Base::set_owner(obj, ck);
         get_key_type();
     }
 
@@ -402,9 +402,9 @@ public:
         return nullptr;
     }
 
-    void set_owner(const Obj& obj, CollectionParent::Index index) override
+    void set_owner(const Obj& obj, ColKey ck) override
     {
-        m_source.set_owner(obj, index);
+        m_source.set_owner(obj, ck);
     }
 
     void set_owner(std::shared_ptr<CollectionParent> parent, CollectionParent::Index index) override

--- a/src/realm/list.hpp
+++ b/src/realm/list.hpp
@@ -498,9 +498,9 @@ public:
         return m_list.get_tree();
     }
 
-    void set_owner(const Obj& obj, CollectionParent::Index index) override
+    void set_owner(const Obj& obj, ColKey ck) override
     {
-        m_list.set_owner(obj, index);
+        m_list.set_owner(obj, ck);
     }
 
     void set_owner(std::shared_ptr<CollectionParent> parent, CollectionParent::Index index) override

--- a/src/realm/object-store/dictionary.cpp
+++ b/src/realm/object-store/dictionary.cpp
@@ -108,9 +108,9 @@ public:
     {
         REALM_TERMINATE("not implemented");
     }
-    void set_owner(const Obj& obj, CollectionParent::Index index) override
+    void set_owner(const Obj& obj, ColKey ck) override
     {
-        m_dictionary->set_owner(obj, index);
+        m_dictionary->set_owner(obj, ck);
     }
     void set_owner(std::shared_ptr<CollectionParent> parent, CollectionParent::Index index) override
     {

--- a/src/realm/set.hpp
+++ b/src/realm/set.hpp
@@ -405,9 +405,9 @@ public:
         return iterator{this, size()};
     }
 
-    void set_owner(const Obj& obj, CollectionParent::Index index) override
+    void set_owner(const Obj& obj, ColKey ck) override
     {
-        m_set.set_owner(obj, index);
+        m_set.set_owner(obj, ck);
     }
 
     void set_owner(std::shared_ptr<CollectionParent> parent, CollectionParent::Index index) override


### PR DESCRIPTION
Make it clear that when an Obj is the owner, then the index must be a ColKey

