### PR TITLE
Use consistent int rounding in S2 math

### DIFF
--- a/src/external/s2/util/math/mathutil.cc
+++ b/src/external/s2/util/math/mathutil.cc
@@ -15,19 +15,6 @@ using std::vector;
 #include "base/integral_types.h"
 #include "base/logging.h"
 
-  template <class IntOut, class FloatIn>
-  IntOut MathUtil::Round(FloatIn x) {
-    COMPILE_ASSERT(!MathLimits<FloatIn>::kIsInteger, FloatIn_is_integer);
-    COMPILE_ASSERT(MathLimits<IntOut>::kIsInteger, IntOut_is_not_integer);
-
-    // We don't use sgn(x) below because there is no need to distinguish the
-    // (x == 0) case.  Also note that there are specialized faster versions
-    // of this function for Intel processors at the bottom of this file.
-    return static_cast<IntOut>(x < 0 ? (x - 0.5) : (x + 0.5));
-  }
-
-template int MathUtil::Round<int,double>(double x);
-
 MathUtil::QuadraticRootType MathUtil::RealRootsForQuadratic(long double a,
                                                         long double b,
                                                         long double c,

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -121,6 +121,12 @@ set(FUZZY_TEST_SOURCES fuzz_group.cpp)
 
 set(CORE_TESTS ${CORE_TEST_SOURCES} ${LARGE_TEST_SOURCES} ${FUZZY_TEST_SOURCES})
 
+set_source_files_properties(test_query_geo.cpp PROPERTIES
+    INCLUDE_DIRECTORIES "${RealmCore_SOURCE_DIR}/src/external"
+    # the only flag not supported with pragma diagnostic disable in src file by gcc until 13.
+    COMPILE_FLAGS "$<$<CXX_COMPILER_ID:GNU>: -Wno-unknown-pragmas>"
+)
+
 # FIXME: Benchmarks
 
 if (MSVC)

--- a/test/test_query_geo.cpp
+++ b/test/test_query_geo.cpp
@@ -21,6 +21,8 @@
 
 #include "test.hpp"
 
+#include "s2/util/math/mathutil.h"
+
 #include <realm/geospatial.hpp>
 #include <realm/group.hpp>
 #include <realm/table.hpp>
@@ -32,6 +34,33 @@
 using namespace realm;
 using namespace realm::util;
 using namespace realm::test_util;
+
+// From https://github.com/10gen/mongo/pull/11605
+// Test which verifies that the rounding functions used by s2 follow 'round to even' rounding
+// behavior.
+TEST(S2VerifyS2RoundingBehavior)
+{
+    const double roundDownToEven = 2.5;
+    CHECK_EQUAL(2, MathUtil::FastIntRound(roundDownToEven));
+    CHECK_EQUAL(2LL, MathUtil::FastInt64Round(roundDownToEven));
+
+    const double roundUpToEven = 3.5;
+    CHECK_EQUAL(4, MathUtil::FastIntRound(roundUpToEven));
+    CHECK_EQUAL(4LL, MathUtil::FastInt64Round(roundUpToEven));
+
+    const double roundDownToEvenNegative = -3.5;
+    CHECK_EQUAL(-4, MathUtil::FastIntRound(roundDownToEvenNegative));
+    CHECK_EQUAL(-4LL, MathUtil::FastInt64Round(roundDownToEvenNegative));
+
+    const double roundUpToEvenNegative = -2.5;
+    CHECK_EQUAL(-2, MathUtil::FastIntRound(roundUpToEvenNegative));
+    CHECK_EQUAL(-2LL, MathUtil::FastInt64Round(roundUpToEvenNegative));
+
+    const double point = 944920918.5;
+    CHECK_EQUAL(944920918, MathUtil::FastIntRound(point));
+    CHECK_EQUAL(944920918LL, MathUtil::FastInt64Round(point));
+}
+
 
 static TableRef setup_with_points(Group& g, const std::vector<Geospatial>& points)
 {


### PR DESCRIPTION
This ports the upcoming changes from https://github.com/10gen/mongo/pull/11605
The underlying issue is that certain numbers are inconsistent in rounding up or down depending on the platform.
IMO we shouldn't wait for the server to merge their fix because it is a bug fix and the app lifecycle is not tied in any way to the server. We don't want to end up in a situation where the server has rolled out their fix, but client side apps are running an old version of geospatial without the fix.