### PR TITLE
Fix missing dependencies on install

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 
 ### Fixed
 * Fixed a crash or exception when doing a fulltext search for multiple keywords when the intersection of results is not equal. ([#6465](https://github.com/realm/realm-core/issues/6465) since v13.2.0).
+* Fixed issue where build would not succeed when consuming core as an installed dependancy due to missing install headers ([#6479](https://github.com/realm/realm-core/pull/6479) since v13.4.1).
 
 ### Breaking changes
 * None.

--- a/src/realm/CMakeLists.txt
+++ b/src/realm/CMakeLists.txt
@@ -238,7 +238,9 @@ set(REALM_INSTALL_HEADERS
     util/miscellaneous.hpp
     util/optional.hpp
     util/overload.hpp
+    util/platform_info.hpp
     util/priority_queue.hpp
+    util/random.hpp
     util/safe_int_ops.hpp
     util/scope_exit.hpp
     util/serializer.hpp
@@ -272,9 +274,7 @@ set(REALM_NOINST_HEADERS
     util/get_file_size.hpp
     util/json_parser.hpp
     util/load_file.hpp
-    util/platform_info.hpp
     util/quote.hpp
-    util/random.hpp
     util/resource_limits.hpp
     util/scratch_allocator.hpp
     util/signal_blocker.hpp

--- a/src/realm/sync/CMakeLists.txt
+++ b/src/realm/sync/CMakeLists.txt
@@ -52,16 +52,19 @@ set(SYNC_INSTALL_HEADERS
     protocol.hpp
     subscriptions.hpp
     transform.hpp
+)
 
+set(SYNC_NETWORK_INSTALL_HEADERS
+    network/default_socket.hpp
     network/http.hpp
+    network/network.hpp
+    network/network_ssl.hpp
+    network/websocket.hpp
 )
 
 set(NOINST_HEADERS
     trigger.hpp
-    network/default_socket.hpp
-    network/network.hpp
-    network/network_ssl.hpp
-    network/websocket.hpp
+
     noinst/changeset_index.hpp
     noinst/client_history_impl.hpp
     noinst/client_impl_base.hpp
@@ -119,6 +122,10 @@ install(FILES ${IMPL_INSTALL_HEADERS}
 
 install(FILES ${SYNC_INSTALL_HEADERS}
         DESTINATION include/realm/sync
+        COMPONENT devel)
+
+install(FILES ${SYNC_NETWORK_INSTALL_HEADERS}
+        DESTINATION include/realm/sync/network
         COMPONENT devel)
 
 install(FILES ${UTIL_INSTALL_HEADERS}


### PR DESCRIPTION
Build would not succeed when consuming core as an installed dependancy due to missing headers on install.

## ☑️ ToDos
* [x] 📝 Changelog update
* [ ] 🚦 Tests (or not relevant)
* [ ] C-API, if public C++ API changed.
