### PR TITLE
add mention of lock file format update in 13.9.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,6 +37,7 @@
 
 ### Compatibility
 * Fileformat: Generates files with format v23. Reads and automatically upgrade from fileformat v5.
+* Lock file format: New format introduced for multiprocess encryption. All processes accessing the file must be upgraded to the new format.
 
 -----------
 


### PR DESCRIPTION
## What, How & Why?

lock file format was bumped on 13.9, this need to be in the CHANGELOG.md

