### PR TITLE
Fix an invalid header inclusion

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@
 
 ### Fixed
 * <How do the end-user experience this issue? what was the impact?> ([#????](https://github.com/realm/realm-core/issues/????), since v?.?.?)
-* None.
+* Fix a build error due to an installed header depending on a non-installed on (since v13.9.1).
 
 ### Breaking changes
 * None.

--- a/src/realm/object-store/c_api/types.hpp
+++ b/src/realm/object-store/c_api/types.hpp
@@ -21,6 +21,7 @@
 #include <realm/object-store/sync/sync_user.hpp>
 #include <realm/object-store/sync/mongo_collection.hpp>
 #include <realm/sync/binding_callback_thread_observer.hpp>
+#include <realm/sync/subscriptions.hpp>
 #endif
 
 #include <stdexcept>

--- a/src/realm/sync/client.hpp
+++ b/src/realm/sync/client.hpp
@@ -3,20 +3,21 @@
 
 #include <cstddef>
 #include <cstdint>
-#include <memory>
-#include <utility>
-#include <functional>
 #include <exception>
+#include <functional>
+#include <memory>
 #include <string>
+#include <utility>
 
 #include <realm/util/buffer.hpp>
 #include <realm/util/functional.hpp>
+#include <realm/util/future.hpp>
 #include <realm/sync/client_base.hpp>
-#include <realm/sync/socket_provider.hpp>
-#include <realm/sync/subscriptions.hpp>
-#include <realm/sync/noinst/migration_store.hpp>
 
 namespace realm::sync {
+
+class MigrationStore;
+class SubscriptionStore;
 
 class Client {
 public:

--- a/src/realm/sync/client_base.hpp
+++ b/src/realm/sync/client_base.hpp
@@ -1,15 +1,15 @@
 #ifndef REALM_SYNC_CLIENT_BASE_HPP
 #define REALM_SYNC_CLIENT_BASE_HPP
 
-#include <realm/transaction.hpp>
+#include <realm/db.hpp>
 #include <realm/sync/config.hpp>
 #include <realm/sync/protocol.hpp>
-#include <realm/sync/socket_provider.hpp>
 #include <realm/util/functional.hpp>
 
 namespace realm::sync {
 class ClientImpl;
 class SessionWrapper;
+class SyncSocketProvider;
 
 /// The presence of the ClientReset config indicates an ongoing or requested client
 /// reset operation. If client_reset is util::none or if the local Realm does not

--- a/src/realm/sync/config.hpp
+++ b/src/realm/sync/config.hpp
@@ -20,15 +20,13 @@
 #define REALM_SYNC_CONFIG_HPP
 
 #include <realm/exceptions.hpp>
-#include <realm/db.hpp>
-#include <realm/util/assert.hpp>
-#include <realm/util/optional.hpp>
 #include <realm/sync/protocol.hpp>
 
 #include <functional>
-#include <memory>
-#include <string>
 #include <map>
+#include <memory>
+#include <optional>
+#include <string>
 #include <unordered_map>
 
 namespace realm {

--- a/src/realm/sync/network/default_socket.cpp
+++ b/src/realm/sync/network/default_socket.cpp
@@ -1,10 +1,10 @@
 #include <realm/sync/network/default_socket.hpp>
 
 #include <realm/sync/binding_callback_thread_observer.hpp>
-
 #include <realm/sync/network/network.hpp>
 #include <realm/sync/network/network_ssl.hpp>
 #include <realm/sync/network/websocket.hpp>
+#include <realm/util/random.hpp>
 #include <realm/util/scope_exit.hpp>
 
 namespace realm::sync::websocket {

--- a/src/realm/sync/network/default_socket.hpp
+++ b/src/realm/sync/network/default_socket.hpp
@@ -1,17 +1,17 @@
 #pragma once
 
-#include <random>
-#include <system_error>
-#include <map>
-
 #include <realm/sync/binding_callback_thread_observer.hpp>
 #include <realm/sync/config.hpp>
 #include <realm/sync/socket_provider.hpp>
 #include <realm/sync/network/http.hpp>
 #include <realm/sync/network/network.hpp>
 #include <realm/util/future.hpp>
-#include <realm/util/random.hpp>
 #include <realm/util/tagged_bool.hpp>
+
+#include <map>
+#include <random>
+#include <system_error>
+#include <thread>
 
 namespace realm::sync::network {
 class Service;

--- a/src/realm/sync/noinst/client_history_impl.cpp
+++ b/src/realm/sync/noinst/client_history_impl.cpp
@@ -27,6 +27,7 @@
 #include <realm/sync/instruction_applier.hpp>
 #include <realm/sync/instruction_replication.hpp>
 #include <realm/sync/noinst/client_reset.hpp>
+#include <realm/transaction.hpp>
 #include <realm/version.hpp>
 
 #include <algorithm>

--- a/src/realm/sync/noinst/client_reset_recovery.cpp
+++ b/src/realm/sync/noinst/client_reset_recovery.cpp
@@ -16,16 +16,18 @@
 //
 ////////////////////////////////////////////////////////////////////////////
 
+#include <realm/sync/noinst/client_reset_recovery.hpp>
+
 #include <realm/db.hpp>
 #include <realm/dictionary.hpp>
 #include <realm/object_converter.hpp>
 #include <realm/set.hpp>
+#include <realm/transaction.hpp>
 
 #include <realm/sync/history.hpp>
 #include <realm/sync/changeset_parser.hpp>
 #include <realm/sync/noinst/client_history_impl.hpp>
 #include <realm/sync/noinst/client_reset.hpp>
-#include <realm/sync/noinst/client_reset_recovery.hpp>
 #include <realm/sync/subscriptions.hpp>
 
 #include <realm/util/compression.hpp>

--- a/src/realm/sync/noinst/client_reset_recovery.hpp
+++ b/src/realm/sync/noinst/client_reset_recovery.hpp
@@ -23,12 +23,11 @@
 #include <realm/util/logger.hpp>
 #include <realm/util/optional.hpp>
 #include <realm/sync/instruction_applier.hpp>
+#include <realm/sync/noinst/client_history_impl.hpp>
 #include <realm/sync/protocol.hpp>
 #include <realm/sync/subscriptions.hpp>
 
-namespace realm {
-namespace _impl {
-namespace client_reset {
+namespace realm::_impl::client_reset {
 
 // State tracking of operations on list indices. All list operations in a recovered changeset
 // must apply to a "known" index. An index is known if the element at that position was added
@@ -215,8 +214,6 @@ private:
     util::FlatMap<ListPath, ListTracker> m_lists;
 };
 
-} // namespace client_reset
-} // namespace _impl
-} // namespace realm
+} // namespace realm::_impl::client_reset
 
 #endif // REALM_NOINST_CLIENT_RESET_RECOVERY_HPP

--- a/src/realm/sync/tools/apply_to_state_command.cpp
+++ b/src/realm/sync/tools/apply_to_state_command.cpp
@@ -1,4 +1,5 @@
 #include "realm/db.hpp"
+#include "realm/transaction.hpp"
 #include "realm/sync/history.hpp"
 #include "realm/sync/instruction_applier.hpp"
 #include "realm/sync/impl/clamped_hex_dump.hpp"

--- a/test/object-store/object.cpp
+++ b/test/object-store/object.cpp
@@ -35,6 +35,7 @@
 #include <realm/object-store/impl/object_accessor_impl.hpp>
 
 #include <realm/group.hpp>
+#include <realm/sync/subscriptions.hpp>
 #include <realm/util/any.hpp>
 
 #include <cstdint>

--- a/test/object-store/realm.cpp
+++ b/test/object-store/realm.cpp
@@ -40,6 +40,7 @@
 #include <realm/object-store/sync/async_open_task.hpp>
 #include <realm/object-store/sync/impl/sync_metadata.hpp>
 #include <realm/sync/noinst/client_history_impl.hpp>
+#include <realm/sync/subscriptions.hpp>
 #include "sync/flx_sync_harness.hpp"
 #endif
 

--- a/test/object-store/sync/migration_store_test.cpp
+++ b/test/object-store/sync/migration_store_test.cpp
@@ -1,11 +1,10 @@
+#include <realm/transaction.hpp>
 #include <realm/sync/noinst/client_history_impl.hpp>
 #include <realm/sync/noinst/migration_store.hpp>
 
 #include <catch2/catch_all.hpp>
 
-
-#if REALM_ENABLE_SYNC
-#if REALM_ENABLE_AUTH_TESTS
+#if REALM_ENABLE_SYNC && REALM_ENABLE_AUTH_TESTS
 
 using namespace realm;
 
@@ -208,5 +207,4 @@ TEST_CASE("Migration store", "[flx][migration]") {
     }
 }
 
-#endif // REALM_ENABLE_AUTH_TESTS
-#endif // REALM_ENABLE_SYNC
+#endif // REALM_ENABLE_SYNC && REALM_ENABLE_AUTH_TESTS

--- a/test/sync_fixtures.hpp
+++ b/test/sync_fixtures.hpp
@@ -2,19 +2,19 @@
 #include <stdexcept>
 #include <string>
 #include <vector>
-#include <sstream>
 
+#include <realm/impl/simulated_failure.hpp>
+#include <realm/string_data.hpp>
+#include <realm/sync/client.hpp>
 #include <realm/sync/network/default_socket.hpp>
 #include <realm/sync/network/http.hpp>
 #include <realm/sync/network/network.hpp>
-#include <realm/string_data.hpp>
-#include <realm/impl/simulated_failure.hpp>
-#include <realm/sync/noinst/protocol_codec.hpp>
-#include <realm/sync/noinst/server/server_dir.hpp>
 #include <realm/sync/noinst/client_history_impl.hpp>
-#include <realm/version.hpp>
-#include <realm/sync/client.hpp>
+#include <realm/sync/noinst/protocol_codec.hpp>
 #include <realm/sync/noinst/server/server.hpp>
+#include <realm/sync/noinst/server/server_dir.hpp>
+#include <realm/transaction.hpp>
+#include <realm/version.hpp>
 
 #include "test.hpp"
 

--- a/test/test_sync_subscriptions.cpp
+++ b/test/test_sync_subscriptions.cpp
@@ -1,8 +1,9 @@
 #include <realm/exceptions.hpp>
 #include <realm/object_id.hpp>
+#include <realm/transaction.hpp>
+#include <realm/sync/noinst/client_history_impl.hpp>
 #include <realm/sync/noinst/sync_metadata_schema.hpp>
 #include <realm/sync/subscriptions.hpp>
-#include <realm/sync/noinst/client_history_impl.hpp>
 
 #include "test.hpp"
 #include "util/test_path.hpp"


### PR DESCRIPTION
Installed headers cannot depend on noinst headers as they are not installed. Fortunately it did not actually need it.