### PR TITLE
Adjust log levels to be more SDK friendly

### DIFF
--- a/src/realm/db.cpp
+++ b/src/realm/db.cpp
@@ -915,7 +915,7 @@ void DB::open(const std::string& path, bool no_create_file, const DBOptions& opt
         m_replication->set_logger(m_logger.get());
     }
     if (m_logger)
-        m_logger->log(util::Logger::Level::info, "Open file: %1", path);
+        m_logger->log(util::Logger::Level::detail, "Open file: %1", path);
     SlabAlloc& alloc = m_alloc;
     if (options.is_immutable) {
         SlabAlloc::Config cfg;
@@ -1838,7 +1838,7 @@ void DB::close_internal(std::unique_lock<InterprocessMutex> lock, bool allow_ope
         }
         m_info = nullptr;
         if (m_logger)
-            m_logger->log(util::Logger::Level::info, "DB closed");
+            m_logger->log(util::Logger::Level::detail, "DB closed");
     }
 }
 

--- a/src/realm/sync/client.cpp
+++ b/src/realm/sync/client.cpp
@@ -1487,7 +1487,7 @@ void SessionWrapper::actualize(ServerEndpoint endpoint)
             m_flx_pending_bootstrap_store = std::make_unique<PendingBootstrapStore>(m_db, sess->logger);
         }
 
-        sess->logger.detail("Binding '%1' to '%2'", m_db->get_path(), m_virt_path); // Throws
+        sess->logger.info("Binding '%1' to '%2'", m_db->get_path(), m_virt_path); // Throws
         m_sess = sess.get();
         conn.activate_session(std::move(sess)); // Throws
 

--- a/src/realm/sync/noinst/client_impl_base.cpp
+++ b/src/realm/sync/noinst/client_impl_base.cpp
@@ -150,10 +150,10 @@ ClientImpl::ClientImpl(ClientConfig config)
     // FIXME: Would be better if seeding was up to the application.
     util::seed_prng_nondeterministically(m_random); // Throws
 
-    logger.debug("Realm sync client (%1)", REALM_VER_CHUNK); // Throws
+    logger.info("Realm sync client (%1)", REALM_VER_CHUNK); // Throws
     logger.debug("Supported protocol versions: %1-%2", get_oldest_supported_protocol_version(),
                  get_current_protocol_version()); // Throws
-    logger.debug("Platform: %1", util::get_platform_info());
+    logger.info("Platform: %1", util::get_platform_info());
     const char* build_mode;
 #if REALM_DEBUG
     build_mode = "Debug";


### PR DESCRIPTION
As part of adding support for the new logging framework, the SDKs have reviewed the current log output and have a few suggestions for modifications that we think provide a better compromise between verbosity and information needed when debugging at the default level.

Currently, the ide is that all SDKs will set INFO as the default level going forward. 

