### PR TITLE
Add REALM_ENABLE_GEOSPATIAL cmake option to disable feature

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -254,6 +254,7 @@ option(REALM_VALGRIND "Tell the test suite we are running with valgrind" OFF)
 option(REALM_METRICS "Enable various metric tracking" ON)
 option(REALM_INCLUDE_CERTS "Include a list of trust certificates in the build for SSL certificate verification" ${REALM_INCLUDE_CERTS_DEFAULT})
 set(REALM_MAX_BPNODE_SIZE "1000" CACHE STRING "Max B+ tree node size.")
+option(REALM_ENABLE_GEOSPATIAL "Enable geospatial types and queries." ON)
 
 # Find dependencies
 set(THREADS_PREFER_PTHREAD_FLAG ON)

--- a/Package.swift
+++ b/Package.swift
@@ -16,6 +16,7 @@ var cxxSettings: [CXXSetting] = [
     .define("REALM_ENABLE_ASSERTIONS", to: "1"),
     .define("REALM_ENABLE_ENCRYPTION", to: "1"),
     .define("REALM_ENABLE_SYNC", to: "1"),
+    .define("REALM_ENABLE_GEOSPATIAL", to: "1"),
 
     .define("REALM_VERSION_MAJOR", to: String(versionCompontents[0])),
     .define("REALM_VERSION_MINOR", to: String(versionCompontents[1])),

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -1,6 +1,9 @@
 add_subdirectory(realm)
 add_subdirectory(external/IntelRDFPMathLib20U2)
-add_subdirectory(external/s2)
+
+if (REALM_ENABLE_GEOSPATIAL)
+    add_subdirectory(external/s2)
+endif()
 
 if(CMAKE_SYSTEM_NAME MATCHES "^Windows")
   add_subdirectory(win32)

--- a/src/realm/CMakeLists.txt
+++ b/src/realm/CMakeLists.txt
@@ -31,7 +31,6 @@ set(REALM_SOURCES
     dictionary.cpp
     disable_sync_to_disk.cpp
     exceptions.cpp
-    geospatial.cpp
     group.cpp
     db.cpp
     group_writer.cpp
@@ -152,7 +151,6 @@ set(REALM_INSTALL_HEADERS
     error_codes.h
     error_codes.hpp
     exceptions.hpp
-    geospatial.hpp
     global_key.hpp
     group.hpp
     group_writer.hpp
@@ -291,6 +289,19 @@ if(NOT MSVC)
     list(APPEND REALM_SOURCES util/interprocess_mutex.cpp)
 endif()
 
+if (REALM_ENABLE_GEOSPATIAL)
+    list(APPEND REALM_SOURCES geospatial.cpp)
+    list(APPEND REALM_INSTALL_HEADERS geospatial.hpp)
+
+    set_source_files_properties(geospatial.cpp PROPERTIES
+        INCLUDE_DIRECTORIES "${RealmCore_SOURCE_DIR}/src/external"
+        # the only flag not supported with pragma diagnostic disable in src file by gcc until 13.
+        COMPILE_FLAGS "$<$<CXX_COMPILER_ID:GNU>: -Wno-unknown-pragmas>"
+    )
+
+    list(APPEND REALM_OBJECT_FILES $<TARGET_OBJECTS:s2geometry>)
+endif()
+
 add_library(Storage STATIC
     ${REALM_SOURCES}
     ${UTIL_SOURCES}
@@ -298,8 +309,12 @@ add_library(Storage STATIC
     ${REALM_NOINST_HEADERS}
     ${REALM_OBJECT_FILES}
     $<TARGET_OBJECTS:Bid>
-    $<TARGET_OBJECTS:s2geometry>
 )
+
+if (REALM_ENABLE_GEOSPATIAL)
+    target_compile_definitions(Storage PUBLIC REALM_ENABLE_GEOSPATIAL=1)
+endif()
+
 add_library(Realm::Storage ALIAS Storage)
 
 set_target_properties(Storage PROPERTIES
@@ -324,12 +339,6 @@ target_include_directories(Storage INTERFACE
     $<BUILD_INTERFACE:${RealmCore_SOURCE_DIR}/src>
     $<BUILD_INTERFACE:${RealmCore_BINARY_DIR}/src>
     $<INSTALL_INTERFACE:include>
-)
-
-set_source_files_properties(geospatial.cpp PROPERTIES
-    INCLUDE_DIRECTORIES "${RealmCore_SOURCE_DIR}/src/external"
-    # the only flag not supported with pragma diagnostic disable in src file by gcc until 13.
-    COMPILE_FLAGS "$<$<CXX_COMPILER_ID:GNU>: -Wno-unknown-pragmas>"
 )
 
 # On systems without a built-in SHA-1 implementation (or one provided by a dependency)

--- a/src/realm/data_type.hpp
+++ b/src/realm/data_type.hpp
@@ -152,7 +152,9 @@ static constexpr DataType type_OldDateTime = DataType{7};
 static_assert(!type_OldTable.is_valid());
 static_assert(!type_OldDateTime.is_valid());
 static constexpr DataType type_TypeOfValue = DataType{18};
+#if REALM_ENABLE_GEOSPATIAL
 static constexpr DataType type_Geospatial = DataType{19};
+#endif
 
 constexpr inline DataType::operator util::Printable() const noexcept
 {
@@ -195,9 +197,11 @@ constexpr inline DataType::operator util::Printable() const noexcept
     if (*this == type_TypeOfValue) {
         return "type_TypeOfValue";
     }
+#if REALM_ENABLE_GEOSPATIAL
     if (*this == type_Geospatial) {
         return "type_Geospatial";
     }
+#endif
     return "type_UNKNOWN";
 }
 

--- a/src/realm/mixed.hpp
+++ b/src/realm/mixed.hpp
@@ -27,7 +27,9 @@
 #include <realm/keys.hpp>
 #include <realm/binary_data.hpp>
 #include <realm/data_type.hpp>
+#if REALM_ENABLE_GEOSPATIAL
 #include <realm/geospatial.hpp>
+#endif
 #include <realm/string_data.hpp>
 #include <realm/timestamp.hpp>
 #include <realm/decimal128.hpp>
@@ -147,7 +149,9 @@ public:
     Mixed(UUID) noexcept;
     Mixed(util::Optional<UUID>) noexcept;
     Mixed(const Obj&) noexcept;
+#if REALM_ENABLE_GEOSPATIAL
     Mixed(Geospatial*) noexcept;
+#endif
 
     // These are shortcuts for Mixed(StringData(c_str)), and are
     // needed to avoid unwanted implicit conversion of char* to bool.
@@ -267,7 +271,9 @@ protected:
         Decimal128 decimal_val;
         ObjLink link_val;
         UUID uuid_val;
+#if REALM_ENABLE_GEOSPATIAL
         Geospatial* geospatial_val;
+#endif
     };
 
 private:
@@ -514,11 +520,13 @@ inline Mixed::Mixed(Decimal128 v)
     }
 }
 
+#if REALM_ENABLE_GEOSPATIAL
 inline Mixed::Mixed(Geospatial* store) noexcept
 {
     m_type = int(type_Geospatial) + 1;
     geospatial_val = store;
 }
+#endif
 
 inline Mixed::Mixed(ObjectId v) noexcept
 {
@@ -771,6 +779,7 @@ inline ObjLink Mixed::get<ObjLink>() const noexcept
     return link_val;
 }
 
+#if REALM_ENABLE_GEOSPATIAL
 template <>
 inline Geospatial Mixed::get<Geospatial>() const noexcept
 {
@@ -781,6 +790,7 @@ inline Geospatial Mixed::get<Geospatial>() const noexcept
     }
     REALM_UNREACHABLE();
 }
+#endif
 
 template <>
 inline Mixed Mixed::get<Mixed>() const noexcept

--- a/src/realm/obj.cpp
+++ b/src/realm/obj.cpp
@@ -32,7 +32,9 @@
 #include "realm/cluster_tree.hpp"
 #include "realm/column_type_traits.hpp"
 #include "realm/dictionary.hpp"
+#if REALM_ENABLE_GEOSPATIAL
 #include "realm/geospatial.hpp"
+#endif
 #include "realm/link_translator.hpp"
 #include "realm/index_string.hpp"
 #include "realm/object_converter.hpp"
@@ -279,6 +281,8 @@ T Obj::get(ColKey col_key) const
     return _get<T>(col_key.get_index());
 }
 
+#if REALM_ENABLE_GEOSPATIAL
+
 template <>
 Geospatial Obj::get(ColKey col_key) const
 {
@@ -301,6 +305,8 @@ std::optional<Geospatial> Obj::get(ColKey col_key) const
     }
     return Geospatial::from_link(geo);
 }
+
+#endif
 
 template <class T>
 T Obj::_get(ColKey::Idx col_ndx) const
@@ -1701,6 +1707,8 @@ inline void Obj::set_spec<ArrayString>(ArrayString& values, ColKey col_key)
     values.set_spec(spec, spec_ndx);
 }
 
+#if REALM_ENABLE_GEOSPATIAL
+
 template <>
 Obj& Obj::set(ColKey col_key, Geospatial value, bool)
 {
@@ -1749,6 +1757,8 @@ Obj& Obj::set(ColKey col_key, std::optional<Geospatial> value, bool)
     }
     return *this;
 }
+
+#endif
 
 template <class T>
 Obj& Obj::set(ColKey col_key, T value, bool is_default)

--- a/src/realm/object-store/c_api/query.cpp
+++ b/src/realm/object-store/c_api/query.cpp
@@ -104,6 +104,7 @@ struct QueryArgumentsAdapter : query_parser::Arguments {
         return from_capi(m_args[i].arg[0].link);
     }
 
+#if REALM_ENABLE_GEOSPATIAL
     Geospatial geospatial_for_argument(size_t i) final
     {
         verify_ndx(i);
@@ -112,6 +113,7 @@ struct QueryArgumentsAdapter : query_parser::Arguments {
             ErrorCodes::RuntimeError,
             util::format("geospatial in the C-API is not yet implemented (for argument %1)", i)}; // LCOV_EXCL_LINE
     }
+#endif
 
     bool is_argument_null(size_t i) final
     {

--- a/src/realm/parser/driver.cpp
+++ b/src/realm/parser/driver.cpp
@@ -245,10 +245,12 @@ public:
     {
         return mixed_for_argument(n).get<ObjLink>();
     }
+#if REALM_ENABLE_GEOSPATIAL
     Geospatial geospatial_for_argument(size_t n) final
     {
         return mixed_for_argument(n).get<Geospatial>();
     }
+#endif
     std::vector<Mixed> list_for_argument(size_t n) final
     {
         Arguments::verify_ndx(n);
@@ -743,6 +745,7 @@ Query StringOpsNode::visit(ParserDriver* drv)
     return {};
 }
 
+#if REALM_ENABLE_GEOSPATIAL
 Query GeoWithinNode::visit(ParserDriver* drv)
 {
     auto left = prop->visit(drv);
@@ -777,6 +780,7 @@ Query GeoWithinNode::visit(ParserDriver* drv)
 
     REALM_UNREACHABLE();
 }
+#endif
 
 Query TrueOrFalseNode::visit(ParserDriver* drv)
 {
@@ -1345,6 +1349,7 @@ std::unique_ptr<Subexpr> ConstantNode::visit(ParserDriver* drv, DataType hint)
     return ret;
 }
 
+#if REALM_ENABLE_GEOSPATIAL
 GeospatialNode::GeospatialNode(GeospatialNode::Box, GeoPoint& p1, GeoPoint& p2)
     : m_geo{Geospatial{GeoBox{p1, p2}}}
 {
@@ -1371,6 +1376,7 @@ std::unique_ptr<Subexpr> GeospatialNode::visit(ParserDriver*, DataType)
     ret = std::make_unique<ConstantGeospatialValue>(m_geo); // FIXME: Mixed value type
     return ret;
 }
+#endif
 
 std::unique_ptr<Subexpr> ListNode::visit(ParserDriver* drv, DataType hint)
 {

--- a/src/realm/parser/driver.hpp
+++ b/src/realm/parser/driver.hpp
@@ -204,6 +204,7 @@ public:
     };
     struct Sphere {
     };
+#if REALM_ENABLE_GEOSPATIAL
     GeospatialNode(Box, GeoPoint& p1, GeoPoint& p2);
     GeospatialNode(Sphere, GeoPoint& p, double radius);
     GeospatialNode(Polygon, GeoPoint& p);
@@ -214,6 +215,21 @@ public:
     }
     std::unique_ptr<Subexpr> visit(ParserDriver*, DataType) override;
     Geospatial m_geo;
+#else
+    template <typename... Ts>
+    GeospatialNode(Ts&&...)
+    {
+        throw realm::LogicError(ErrorCodes::NotSupported, "Support for Geospatial queries is not enabled");
+    }
+    template <typename Point>
+    void add_point_to_polygon(Point&&)
+    {
+    }
+    std::unique_ptr<Subexpr> visit(ParserDriver*, DataType) override
+    {
+        return {};
+    }
+#endif
 };
 
 class ListNode : public ValueNode {
@@ -461,6 +477,7 @@ public:
 
 class GeoWithinNode : public CompareNode {
 public:
+#if REALM_ENABLE_GEOSPATIAL
     PropertyNode* prop;
     GeospatialNode* geo = nullptr;
     std::string argument;
@@ -475,6 +492,17 @@ public:
         argument = arg;
     }
     Query visit(ParserDriver*) override;
+#else
+    template <typename... Ts>
+    GeoWithinNode(Ts&&...)
+    {
+        throw realm::LogicError(ErrorCodes::NotSupported, "Support for Geospatial queries is not enabled");
+    }
+    virtual Query visit(ParserDriver*) override
+    {
+        return {};
+    }
+#endif
 };
 
 /******************************** Other Nodes ********************************/

--- a/src/realm/parser/query_parser.hpp
+++ b/src/realm/parser/query_parser.hpp
@@ -122,7 +122,9 @@ public:
     virtual Decimal128 decimal128_for_argument(size_t argument_index) = 0;
     virtual UUID uuid_for_argument(size_t argument_index) = 0;
     virtual ObjLink objlink_for_argument(size_t argument_index) = 0;
+#if REALM_ENABLE_GEOSPATIAL
     virtual Geospatial geospatial_for_argument(size_t argument_index) = 0;
+#endif
     virtual std::vector<Mixed> list_for_argument(size_t argument_index) = 0;
     virtual bool is_argument_null(size_t argument_index) = 0;
     virtual bool is_argument_list(size_t argument_index) = 0;
@@ -208,10 +210,12 @@ public:
     {
         return get<ObjLink>(i);
     }
+#if REALM_ENABLE_GEOSPATIAL
     Geospatial geospatial_for_argument(size_t i) override
     {
         return get<Geospatial>(i);
     }
+#endif
     std::vector<Mixed> list_for_argument(size_t i) override
     {
         return get<std::vector<Mixed>>(i);
@@ -309,10 +313,12 @@ public:
     {
         throw NoArgsError();
     }
+#if REALM_ENABLE_GEOSPATIAL
     Geospatial geospatial_for_argument(size_t)
     {
         throw NoArgsError();
     }
+#endif
     bool is_argument_list(size_t)
     {
         throw NoArgsError();

--- a/src/realm/query_expression.hpp
+++ b/src/realm/query_expression.hpp
@@ -139,7 +139,9 @@ The Columns class encapsulates all this into a simple class that, for any type T
 #include <realm/column_integer.hpp>
 #include <realm/column_type_traits.hpp>
 #include <realm/dictionary.hpp>
+#if REALM_ENABLE_GEOSPATIAL
 #include <realm/geospatial.hpp>
+#endif
 #include <realm/table.hpp>
 #include <realm/index_string.hpp>
 #include <realm/query.hpp>
@@ -1166,6 +1168,7 @@ public:
     }
 };
 
+#if REALM_ENABLE_GEOSPATIAL
 template <>
 class Subexpr2<Geospatial> : public Subexpr, public Overloads<Geospatial, Geospatial> {
 public:
@@ -1175,6 +1178,7 @@ public:
         return type_Geospatial;
     }
 };
+#endif
 
 struct TrueExpression : Expression {
     size_t find_first(size_t start, size_t end) const override
@@ -1446,6 +1450,7 @@ private:
     OwnedBinaryData m_buffer;
 };
 
+#if REALM_ENABLE_GEOSPATIAL
 class ConstantGeospatialValue : public Value<Geospatial> {
 public:
     ConstantGeospatialValue(const Geospatial& geo)
@@ -1473,7 +1478,7 @@ private:
     }
     Geospatial m_geospatial;
 };
-
+#endif
 
 // Classes used for LinkMap (see below).
 struct LinkMapFunction {
@@ -2411,6 +2416,7 @@ private:
     LinkMap m_link_map;
 };
 
+#if REALM_ENABLE_GEOSPATIAL
 class GeoWithinCompare : public Expression {
 public:
     GeoWithinCompare(const LinkMap& lm, Geospatial bounds)
@@ -2506,6 +2512,7 @@ private:
     mutable ColKey m_type_col;
     mutable ColKey m_coords_col;
 };
+#endif
 
 template <class T, class TExpr>
 class SizeOperator : public Subexpr2<Int> {
@@ -2727,10 +2734,12 @@ public:
         return make_expression<UnaryLinkCompare<true>>(m_link_map);
     }
 
+#if REALM_ENABLE_GEOSPATIAL
     Query geo_within(Geospatial bounds) const
     {
         return make_expression<GeoWithinCompare>(m_link_map, bounds);
     }
+#endif
 
     LinkCount count() const
     {

--- a/src/realm/table.cpp
+++ b/src/realm/table.cpp
@@ -313,8 +313,10 @@ const char* get_data_type_name(DataType type) noexcept
         default:
             if (type == type_TypeOfValue)
                 return "@type";
+#if REALM_ENABLE_GEOSPATIAL
             else if (type == type_Geospatial)
                 return "geospatial";
+#endif
             else if (type == ColumnTypeTraits<null>::id)
                 return "null";
     }

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -58,7 +58,6 @@ set(CORE_TEST_SOURCES
     test_object_id.cpp
     test_optional.cpp
     test_priority_queue.cpp
-    test_query_geo.cpp
     test_replication.cpp
     test_safe_int_ops.cpp
     test_self.cpp
@@ -93,10 +92,14 @@ set(CORE_TEST_SOURCES
     test_util_scope_exit.cpp
     test_util_to_string.cpp
     test_uuid.cpp
-    )
+)
 
 if (REALM_ENABLE_ENCRYPTION)
     list(APPEND CORE_TEST_SOURCES test_encrypted_file_mapping.cpp)
+endif()
+
+if (REALM_ENABLE_GEOSPATIAL)
+    list(APPEND CORE_TEST_SOURCES test_query_geo.cpp)
 endif()
 
 set(LARGE_TEST_SOURCES

--- a/test/object-store/CMakeLists.txt
+++ b/test/object-store/CMakeLists.txt
@@ -14,7 +14,6 @@ set(SOURCES
     collection_change_indices.cpp
     dictionary.cpp
     frozen_objects.cpp
-    geospatial.cpp
     index_set.cpp
     list.cpp
     main.cpp
@@ -40,6 +39,10 @@ set(SOURCES
     util/test_file.cpp
     util/test_utils.cpp
 )
+
+if (REALM_ENABLE_GEOSPATIAL)
+    list(APPEND SOURCES geospatial.cpp)
+endif()
 
 file(GLOB RESOURCES RELATIVE ${CMAKE_CURRENT_BINARY_DIR}
      "*.realm")

--- a/test/test_parser.cpp
+++ b/test/test_parser.cpp
@@ -293,7 +293,7 @@ static std::vector<std::string> invalid_queries = {
     "0 contains1",
     "a contains_something",
     "endswith 0",
-    "link geoWithin 5.0"
+    "link geoWithin 5.0",
 
     // atoms/groups
     "0=0)",
@@ -5656,10 +5656,28 @@ TEST(Parser_Geospatial)
     auto geo_table = g.add_table("Position", Table::Type::Embedded);
     geo_table->add_column(type_String, "type");
     geo_table->add_column_list(type_Double, "coordinates");
-    auto col_link = table->add_column(*geo_table, "link");
     table->add_column_list(*geo_table, "links");
     table->add_column(*table, "self_link");
 
+#if !REALM_ENABLE_GEOSPATIAL
+    auto error = "Support for Geospatial queries is not enabled";
+
+#define CHECK_QUERY(query)                                                                                           \
+    do {                                                                                                             \
+        CHECK_THROW_EX(verify_query(test_context, table, query, 1), realm::LogicError,                               \
+                       CHECK(std::string(e.what()).find(error) != std::string::npos));                               \
+    } while (false)
+
+    CHECK_QUERY("link geoWithin geoBox([0.2, 0.2], [0.7, 0.7])");
+    CHECK_QUERY("link geoWithin geoBox([0.2, 0.2, 0.2], [0.7, 0.7, 0.7])");
+    CHECK_QUERY("link geoWithin geoSphere([0.3, 0.3], 1000.0)");
+    CHECK_QUERY("link geoWithin geoSphere([0.3, 0.3, 0.3], 1000.0)");
+    CHECK_QUERY("link geoWithin geoPolygon([0.0, 0.0], [1.0, 0.0], [1, 1], [0, 1])");
+
+    CHECK_THROW_EX(verify_query_sub(test_context, table, "link GEOWITHIN $0", {}, 1), realm::LogicError,
+                   CHECK(std::string(e.what()).find(error) != std::string::npos));
+#else
+    auto col_link = table->add_column(*geo_table, "link");
     std::vector<Geospatial> point_data = {GeoPoint{0, 0}, GeoPoint{0.5, 0.5}, GeoPoint{1, 1}, GeoPoint{2, 2}};
     for (auto& geo : point_data) {
         table->create_object_with_primary_key(ObjectId::gen()).set(col_link, geo);
@@ -5729,6 +5747,7 @@ TEST(Parser_Geospatial)
                    query_parser::InvalidQueryError,
                    CHECK(std::string(e.what()).find("The right hand side of 'geoWithin' must be a valid "
                                                     "Geospatial value, got 'NULL'") != std::string::npos));
+#endif
 }
 
 TEST(Parser_RecursiveLogial)


### PR DESCRIPTION
## What, How & Why?
Add opt-out REALM_ENABLE_GEOSPATIAL option for cmake to disable the feature code almost completely. Leave only relevant classes fro grammar to raise useful error for RQL with 'geowithin' operator

## ☑️ ToDos
* ~~[ ] 📝 Changelog update~~
* [x] 🚦 Tests (or not relevant)
* ~~[ ] C-API, if public C++ API changed.~~
