### PR TITLE
Remove non-compiling hash_value function

### DIFF
--- a/src/external/s2/s2cellid.cc
+++ b/src/external/s2/s2cellid.cc
@@ -520,9 +520,3 @@ string S2CellId::ToString() const {
 ostream& operator<<(ostream& os, S2CellId const& id) {
   return os << id.ToString();
 }
-
-#ifdef OS_WINDOWS
-template<> size_t stdext::hash_value<S2CellId>(const S2CellId &id) {
-    return static_cast<size_t>(id.id() >> 32) + static_cast<size_t>(id.id());
-}
-#endif


### PR DESCRIPTION
## What, How & Why?

`stdext::hash_value` doesn't seem to exist on Windows and we already define a hashing function in https://github.com/realm/realm-core/blob/e07986503e513a4fb949a30a205840d6984a63be/src/external/s2/s2cellid.h#L498-L504
