### PR TITLE
wolfSSL integration for Linux 

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -125,7 +125,7 @@ else()
     if(ANDROID)
         add_compile_options(-Wno-uninitialized)
     elseif(${CMAKE_CXX_COMPILER_ID} MATCHES ".*[Cc]lang")
-        # FIXME: Re-introduce -Wold-style-cast 
+        # FIXME: Re-introduce -Wold-style-cast
         add_compile_options(-Wunreachable-code -Wshorten-64-to-32 -Wconditional-uninitialized -Wextra-semi -Wno-nested-anon-types -Wdocumentation -Wthread-safety -Wthread-safety-negative -Wmissing-prototypes)
     endif()
 
@@ -162,7 +162,7 @@ if(ANDROID)
     # - `-fomit-frame-pointer` is inherited from NDK r10e.
     # - On some architectures char is unsigned by default. Make it signed
     # - Compile with -Oz in Release because on Android we favor code size over performance
-    # 
+    #
     add_compile_options(-fdata-sections -ffunction-sections -fomit-frame-pointer -fsigned-char -fstrict-aliasing -funwind-tables -no-canonical-prefixes $<$<CONFIG:Release>:-Oz>)
 endif()
 
@@ -262,11 +262,52 @@ elseif(REALM_ENABLE_ENCRYPTION AND CMAKE_SYSTEM_NAME MATCHES "Linux|Android")
     set(REALM_NEEDS_OPENSSL TRUE)
 endif()
 
-if(REALM_NEEDS_OPENSSL OR REALM_FORCE_OPENSSL)
+# If the system determines we should use openSSL, and the user wants to substitute wolfSSL
+# we allow this combination for only Linux builds
+if(REALM_USE_WOLFSSL)
+    if(REALM_FORCE_OPENSSL)
+        message(FATAL_ERROR "option \"REALM_FORCE_OPENSSL\" incompatible with option \"REALM_USE_WOLFSSL\"")
+    endif()
+
+    if(NOT CMAKE_SYSTEM_NAME STREQUAL "Linux")
+        message(FATAL_ERROR "WolfSSL support only available on Linux, for now...")
+    endif()
+
+    if(NOT REALM_NEEDS_OPENSSL)
+        message(FATAL_ERROR "WolfSSL support only available for builds that would otherwise use OpenSSL")
+    endif()
+
+    set(REALM_NEEDS_WOLFSSL TRUE)
+    message(STATUS "Using wolfSSL compatibility layer over OpenSSL")
+endif()
+
+
+if(REALM_NEEDS_WOLFSSL AND REALM_NEEDS_OPENSSL)
+    # NOTE: this logic should eventually be changed to point to realm's self-hosted prebuilt WolfSSL
+    # and grab it using realm_aquire_dependency. For now we just allow pointing to an install directory
+    if (NOT REALM_USE_SYSTEM_WOLFSSL)
+        if(NOT DEFINED REALM_WOLFSSL_ROOT_DIR)
+            message(FATAL_ERROR "REALM_WOLFSSL_ROOT_DIR undefined. If you wish to build against the wolfSSL compatibility layer, define this variable \
+            to hold the path to your wolfSSL installation directory using -DREALM_WOLFSSL_ROOT_DIR=/path/to/wolfssl/install/dir")
+        endif()
+        set(WOLFSSL_ROOT_DIR ${REALM_WOLFSSL_ROOT_DIR})
+    else()
+        if(DEFINED REALM_WOLFSSL_ROOT_DIR)
+            message(FATAL_ERROR "option \"REALM_WOLFSSL_ROOT_DIR\" incompatible with option \"REALM_USE_SYSTEM_WOLFSSL\"")
+        endif()
+    endif()
+
+    set(WOLFSSL_USE_STATIC_LIBS ON)
+    find_package(WolfSSL REQUIRED)
+
+    set(REALM_HAVE_WOLFSSL ON)
+    # We also need to set REALM_HAVE_OPENSSL to enable the standard OpenSSL code paths
+    set(REALM_HAVE_OPENSSL ON)
+elseif(REALM_NEEDS_OPENSSL OR REALM_FORCE_OPENSSL)
+    message(STATUS "using OpenSSL")
     if(NOT REALM_USE_SYSTEM_OPENSSL AND (ANDROID OR WIN32 OR CMAKE_SYSTEM_NAME STREQUAL "Linux"))
         # Use our own prebuilt OpenSSL
         realm_acquire_dependency(openssl ${DEP_OPENSSL_VERSION} OPENSSL_CMAKE_INCLUDE_FILE)
-
         include(${OPENSSL_CMAKE_INCLUDE_FILE})
     endif()
 

--- a/src/realm/CMakeLists.txt
+++ b/src/realm/CMakeLists.txt
@@ -325,7 +325,7 @@ target_include_directories(Storage INTERFACE
 
 # On systems without a built-in SHA-1 implementation (or one provided by a dependency)
 # we need to bundle the public domain implementation.
-if(NOT APPLE AND NOT CMAKE_SYSTEM_NAME MATCHES "^Windows" AND NOT REALM_HAVE_OPENSSL)
+if(NOT APPLE AND NOT CMAKE_SYSTEM_NAME MATCHES "^Windows" AND NOT REALM_HAVE_OPENSSL AND NOT REALM_HAVE_WOLFSSL)
     add_library(sha1 OBJECT ../external/sha-1/sha1.c)
     target_include_directories(Storage PRIVATE ../external/sha-1)
     target_sources(Storage PRIVATE $<TARGET_OBJECTS:sha1>)
@@ -334,7 +334,7 @@ endif()
 # On systems without a built-in SHA-2 implementation (or one provided by a dependency)
 # we need to bundle the public domain implementation.
 # Note: This is also used on Windows because Windows lacks a native SHA224 hash needed for realm encryption
-if(NOT APPLE AND NOT REALM_HAVE_OPENSSL OR WIN32)
+if(NOT APPLE AND NOT REALM_HAVE_OPENSSL AND NOT REALM_HAVE_WOLFSSL OR WIN32)
     add_library(sha2 OBJECT ../external/sha-2/sha224.cpp ../external/sha-2/sha256.cpp)
     target_include_directories(Storage PRIVATE ../external/sha-2)
     target_sources(Storage PRIVATE $<TARGET_OBJECTS:sha2>)
@@ -355,8 +355,12 @@ endif()
 
 target_link_libraries(Storage INTERFACE Threads::Threads)
 
-if(REALM_ENABLE_ENCRYPTION AND UNIX AND NOT APPLE AND REALM_HAVE_OPENSSL)
-    target_link_libraries(Storage PUBLIC OpenSSL::Crypto)
+if(REALM_ENABLE_ENCRYPTION AND UNIX AND NOT APPLE)
+    if (REALM_HAVE_WOLFSSL)
+        target_link_libraries(Storage PUBLIC WolfSSL)
+    elseif (REALM_HAVE_OPENSSL)
+        target_link_libraries(Storage PUBLIC OpenSSL::Crypto)
+    endif()
 endif()
 
 # Use Zlib if the imported target is defined, otherise use -lz on Apple platforms

--- a/src/realm/sync/CMakeLists.txt
+++ b/src/realm/sync/CMakeLists.txt
@@ -99,6 +99,8 @@ target_link_libraries(Sync PUBLIC Storage)
 
 if(APPLE AND NOT REALM_FORCE_OPENSSL)
     target_link_options(Sync INTERFACE "SHELL:-framework Security")
+elseif(REALM_HAVE_WOLFSSL)
+    target_link_libraries(Sync PUBLIC WolfSSL)
 elseif(REALM_HAVE_OPENSSL)
     target_link_libraries(Sync PUBLIC OpenSSL::SSL)
 endif()

--- a/src/realm/sync/noinst/server/CMakeLists.txt
+++ b/src/realm/sync/noinst/server/CMakeLists.txt
@@ -31,6 +31,6 @@ target_link_libraries(SyncServer PUBLIC Sync QueryParser)
 
 if(APPLE AND NOT REALM_FORCE_OPENSSL)
     target_sources(SyncServer PRIVATE crypto_server_apple.mm)
-elseif(REALM_HAVE_OPENSSL)
+elseif(REALM_HAVE_OPENSSL OR REALM_HAVE_WOLFSSL)
     target_sources(SyncServer PRIVATE crypto_server_openssl.cpp)
 endif()

--- a/src/realm/sync/noinst/server/crypto_server_openssl.cpp
+++ b/src/realm/sync/noinst/server/crypto_server_openssl.cpp
@@ -1,5 +1,15 @@
 #include <realm/sync/noinst/server/crypto_server.hpp>
 
+#if REALM_HAVE_WOLFSSL
+#ifdef HAVE_CONFIG_H
+#include <config.h>
+#endif
+#ifndef WOLFSSL_USER_SETTINGS
+#include <wolfssl/options.h>
+#endif
+#include <wolfssl/wolfcrypt/settings.h>
+#endif
+
 #include <openssl/bio.h>
 #include <openssl/pem.h>
 #include <openssl/evp.h>

--- a/src/realm/util/aes_cryptor.hpp
+++ b/src/realm/util/aes_cryptor.hpp
@@ -54,6 +54,16 @@ public:
 #include <bcrypt.h>
 #pragma comment(lib, "bcrypt.lib")
 #else
+#if REALM_HAVE_WOLFSSL
+#ifdef HAVE_CONFIG_H
+#include <config.h>
+#endif
+#ifndef WOLFSSL_USER_SETTINGS
+#include <wolfssl/options.h>
+#endif
+#include <wolfssl/wolfcrypt/settings.h>
+#endif
+
 #include <openssl/sha.h>
 #include <openssl/evp.h>
 #endif

--- a/src/realm/util/config.h.in
+++ b/src/realm/util/config.h.in
@@ -4,6 +4,7 @@
 // Realm-specific configuration
 #cmakedefine01 REALM_HAVE_READDIR64
 #cmakedefine01 REALM_HAVE_OPENSSL
+#cmakedefine01 REALM_HAVE_WOLFSSL
 #cmakedefine01 REALM_HAVE_SECURE_TRANSPORT
 #cmakedefine01 REALM_INCLUDE_CERTS
 #cmakedefine01 REALM_HAVE_DOGLESS

--- a/src/realm/util/sha_crypto.cpp
+++ b/src/realm/util/sha_crypto.cpp
@@ -29,6 +29,17 @@
 #pragma comment(lib, "bcrypt.lib")
 #define REALM_USE_BUNDLED_SHA2 1
 #elif REALM_HAVE_OPENSSL
+
+#if REALM_HAVE_WOLFSSL
+#ifdef HAVE_CONFIG_H
+#include <config.h>
+#endif
+#ifndef WOLFSSL_USER_SETTINGS
+#include <wolfssl/options.h>
+#endif
+#include <wolfssl/wolfcrypt/settings.h>
+#endif
+
 #include <openssl/sha.h>
 #include <openssl/evp.h>
 #include <openssl/hmac.h>

--- a/tools/cmake/FindWolfSSL.cmake
+++ b/tools/cmake/FindWolfSSL.cmake
@@ -1,0 +1,96 @@
+#[=======================================================================[.rst:
+FindWolfSSL
+---------
+
+Find WolfSSL includes and library. For now this only works when pointed to the output directory
+of a wolfSSL build that was configured using the following configure line:
+./configure --enable-static --enable-certgen --enable-opensslall --enable-opensslextra \
+    --enable-context-extra-user-data --prefix=/path/to/output-dir
+
+
+Imported Targets
+^^^^^^^^^^^^^^^^
+
+An :ref:`imported target <Imported targets>` named
+``WolfSSL`` is provided if WolfSSL has been found.
+
+Result Variables
+^^^^^^^^^^^^^^^^
+
+This module defines the following variables:
+
+``WolfSSL_FOUND``
+  True if WolfSSL was found, false otherwise.
+``WolfSSL_INCLUDE_DIRS``
+  Include directories needed to include WolfSSL headers.
+``WolfSSL_LIBRARIES``
+  Libraries needed to link to WolfSSL.
+
+
+Hints
+^^^^^
+
+The following variables may be set to control search behavior:
+
+``WOLFSSL_ROOT_DIR``
+  Set to the root directory of a wolfSSL installation.
+
+``WOLFSSL_USE_STATIC_LIBS``
+  Set to ``TRUE`` to look for static libraries.
+
+
+#]=======================================================================]
+
+#-----------------------------------------------------------------------------
+if(NOT CMAKE_SYSTEM_NAME STREQUAL "Linux")
+    message(FATAL_ERROR "FindWolfSSL.cmake only supports Linux, for now...")
+endif()
+
+# Support preference of static libs by adjusting CMAKE_FIND_LIBRARY_SUFFIXES
+if(WOLFSSL_USE_STATIC_LIBS)
+  # save the original find library ordering so we can restore it later
+  set(WOLFSSL_ORIG_CMAKE_FIND_LIBRARY_SUFFIXES ${CMAKE_FIND_LIBRARY_SUFFIXES})
+  # replace with our static lib suffix
+  set(CMAKE_FIND_LIBRARY_SUFFIXES .a )
+endif()
+
+if(EXISTS ${WOLFSSL_ROOT_DIR})
+    set(CMAKE_PREFIX_PATH ${WOLFSSL_ROOT_DIR})
+endif()
+
+find_library(WolfSSL_LIBRARY NAMES wolfssl libwolfssl HINTS ${WOLFSSL_ROOT_DIR})
+mark_as_advanced(WolfSSL_LIBRARY)
+
+find_path(WolfSSL_INCLUDE_DIR NAMES wolfssl/ssl.h HINTS ${WOLFSSL_ROOT_DIR})
+mark_as_advanced(WolfSSL_INCLUDE_DIR)
+
+# we need to add one additional include for the openssl compatibility layer
+find_path(WolfSSL_OpenSSL_Compat_INCLUDE_DIR NAMES openssl/ssl.h HINTS ${WOLFSSL_ROOT_DIR} PATH_SUFFIXES "wolfssl")
+list(APPEND WolfSSL_INCLUDE_DIR ${WolfSSL_OpenSSL_Compat_INCLUDE_DIR})
+
+include(FindPackageHandleStandardArgs)
+FIND_PACKAGE_HANDLE_STANDARD_ARGS(WolfSSL
+    FOUND_VAR WolfSSL_FOUND
+    REQUIRED_VARS WolfSSL_LIBRARY WolfSSL_INCLUDE_DIR
+    )
+set(WOLFSSL_FOUND ${WolfSSL_FOUND})
+
+#-----------------------------------------------------------------------------
+# Provide documented result variables and targets.
+if(WolfSSL_FOUND)
+    set(WolfSSL_INCLUDE_DIRS ${WolfSSL_INCLUDE_DIR})
+    set(WolfSSL_LIBRARIES ${WolfSSL_LIBRARY})
+    if(NOT TARGET WolfSSL)
+        add_library(WolfSSL UNKNOWN IMPORTED)
+        set_target_properties(WolfSSL PROPERTIES
+            IMPORTED_LOCATION "${WolfSSL_LIBRARY}"
+            INTERFACE_INCLUDE_DIRECTORIES "${WolfSSL_INCLUDE_DIRS}"
+            )
+    endif()
+endif()
+
+
+if(WOLFSSL_USE_STATIC_LIBS)
+    set(CMAKE_FIND_LIBRARY_SUFFIXES ${WOLFSSL_ORIG_CMAKE_FIND_LIBRARY_SUFFIXES})
+endif()
+unset(CMAKE_PREFIX_PATH)


### PR DESCRIPTION
## What, How & Why?
This PR enables realm to use [wolfSSL](https://www.wolfssl.com/) for TLS and crypto operations via wolfSSL's built-in [OpenSSL compatibility layer](https://www.wolfssl.com/documentation/manuals/wolfssl/chapter13.html). Support is added for Linux targets as a proof of concept. Support for other platforms including android, iOS, and Windows can be added in the future.

The wolfSSL embedded TLS library is a lightweight, portable, C-language-based SSL/TLS library targeted at IoT, embedded, and RTOS environments because of its size, speed, and feature set. It works seamlessly in desktop, enterprise, and cloud environments as well. wolfSSL supports industry standards up to the current [TLS 1.3](https://www.wolfssl.com/docs/tls13) and DTLS 1.3, is up to 20 times smaller than OpenSSL, offers a simple API, an OpenSSL compatibility layer, OCSP and CRL support, is backed by the robust wolfCrypt cryptography library, and [much more](https://www.wolfssl.com/products/wolfssl/). 



## Steps to build wolfSSL and the compatible version of realm on a Linux host: 
The following steps detail how to build wolfSSL with the appropriate options enabling compatibility with realm. If realm wishes to host a static library package on their servers that is downloaded via `realm_acquire_dependency()` similar to OpenSSL, that can be easily added using the `REALM_WOLFSSL_ROOT_DIR` option. 

### Build and install a compatible version of wolfSSL:
1. Clone the repository from GitHub 
```
git clone https://github.com/wolfSSL/wolfssl.git
```
2. Configure wolfSSL using either of the following options 
```
# to install wolfSSL system-wide, run:
./configure --enable-static --enable-certgen --enable-opensslall --enable-opensslextra --enable-context-extra-user-data

# to install wolfSSL into a portable directory, use the --prefix option:
./configure --enable-static --enable-certgen --enable-opensslall --enable-opensslextra --enable-context-extra-user-data --prefix=/path/to/wolfssl-install-dir
```
3. Build and install 
```
make
make install
```

### Configure and build wolfSSL-compatible realm: 
1. Configure realm to use wolfSSL via the `-DREALM_USE_WOLFSSL` option. This configures realm to use the system install of wolfSSL by default. If you wish to link against a local install of wolfSSL, use the `-DREALM_WOLFSSL_ROOT_DIR=/path/to/wolfssl-install-dir` option
```
mkdir build_compat.debug 

# System install of wolfSSL
cmake -B build_compat.debug -DREALM_ENABLE_ENCRYPTION=1 -DREALM_ENABLE_SYNC=1 -DREALM_USE_WOLFSSL=1 

# Or, use a local install of wolfSSL
cmake -B build_compat.debug -DREALM_ENABLE_ENCRYPTION=1 -DREALM_ENABLE_SYNC=1 -DREALM_USE_WOLFSSL=1 -DREALM_WOLFSSL_ROOT_DIR=-DREALM_WOLFSSL_ROOT_DIR=/path/to/wolfssl-install-dir
```

```
cmake --build build_compat.debug
```



## ☑️ ToDos
* [ ] 📝 Changelog update
* [ ] 🚦 Tests (or not relevant)
* [ ] C-API, if public C++ API changed.

