### PR TITLE
Fix incorrect error types during SSL handshake

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 * If session multiplexing was enabled and an automatic client reset failed, it could cause all sessions to fail with a fatal ProtocolError rather than just the session that failed to client reset. This would mean that no other sync session would be able to be opened for up to an hour without restarting the app. ([PR #6320](https://github.com/realm/realm-core/pull/6320), since v11.5.0)
 * If a DOWNLOAD message was received after a sync session was de-activated but before the UNBOUND message was received by the client, a use-after-free error may have occurred when the sync session tried to process the download messaage. So far this has only been reproducible if session multiplexing was enabled. ([PR #6320](https://github.com/realm/realm-core/pull/6320), since v12.9.0)
 * HTTP and Websocket redirections are not properly updating URL locations if the network transport implementation handles redirect responses internally ([#6485](https://github.com/realm/realm-core/issues/6485), since v12.9.0)
+* Don't report non ssl related errors during ssl handshake as fatal in default socket provider. ([#6434](https://github.com/realm/realm-core/issues/6434), since v13.3.0)
 
 ### Breaking changes
 * None.

--- a/src/realm/sync/noinst/client_impl_base.cpp
+++ b/src/realm/sync/noinst/client_impl_base.cpp
@@ -545,7 +545,7 @@ bool Connection::websocket_closed_handler(bool was_clean, Status status)
         }
         case WebSocketError::websocket_tls_handshake_failed: {
             error_code = ClientError::ssl_server_cert_rejected;
-            constexpr bool is_fatal = true;
+            constexpr bool is_fatal = false;
             m_reconnect_info.m_reason = ConnectionTerminationReason::ssl_certificate_rejected;
             close_due_to_client_side_error(error_code, status.reason(), is_fatal); // Throws
             break;


### PR DESCRIPTION
## What, How & Why?
This fixes the (non) fatal error that is causing an abort when the AuditRealmPool attempts to open a synced realm, but the connection does not complete successfully during the SSL handshake. Any errors that occur during the SSL Handshake are being reported as fatal handshake errors.

This fix brings back the original ssl handshake error handling from before the platform networking changes: https://github.com/realm/realm-core/blob/v13.2.0/src/realm/sync/noinst/client_impl_base.cpp#L1023-L1043

Fixes https://github.com/realm/realm-core/issues/6434

## ☑️ ToDos
* [x] 📝 Changelog update
* ~~[ ] 🚦 Tests (or not relevant)~~
* ~~[ ] C-API, if public C++ API changed.~~
