### PR TITLE
Fix a bunch of throw statements to use Realm exceptions

### DIFF
--- a/src/realm/sync/noinst/client_reset_recovery.cpp
+++ b/src/realm/sync/noinst/client_reset_recovery.cpp
@@ -231,8 +231,8 @@ InternDictKey InterningBuffer::get_interned_key(const std::string_view& str) con
             return key;
         }
     }
-    throw std::runtime_error(
-        util::format("InterningBuffer::get_interned_key(%1) did not contain the requested key", str));
+    throw RuntimeError(ErrorCodes::InvalidArgument,
+                       util::format("InterningBuffer::get_interned_key(%1) did not contain the requested key", str));
     return {};
 }
 

--- a/src/realm/sync/noinst/migration_store.cpp
+++ b/src/realm/sync/noinst/migration_store.cpp
@@ -83,7 +83,8 @@ bool MigrationStore::load_data(bool read_only)
     // Load the metadata schema unless it was just created
     if (!m_migration_table) {
         if (*schema_version != c_schema_version) {
-            throw std::runtime_error("Invalid schema version for flexible sync migration store metadata");
+            throw RuntimeError(ErrorCodes::UnsupportedFileFormatVersion,
+                               "Invalid schema version for flexible sync migration store metadata");
         }
         load_sync_metadata_schema(tr, &internal_tables);
     }

--- a/src/realm/sync/noinst/sync_metadata_schema.cpp
+++ b/src/realm/sync/noinst/sync_metadata_schema.cpp
@@ -38,7 +38,8 @@ void create_sync_metadata_schema(const TransactionRef& tr, std::vector<SyncMetad
     util::FlatMap<std::string_view, TableRef> found_tables;
     for (auto& table : *tables) {
         if (tr->has_table(table.name)) {
-            throw std::runtime_error(
+            throw RuntimeError(
+                ErrorCodes::RuntimeError,
                 util::format("table %1 already existed when creating internal tables for sync", table.name));
         }
         TableRef table_ref;
@@ -64,18 +65,18 @@ void create_sync_metadata_schema(const TransactionRef& tr, std::vector<SyncMetad
             if (column.data_type == type_LinkList) {
                 auto target_table_it = found_tables.find(column.target_table);
                 if (target_table_it == found_tables.end()) {
-                    throw std::runtime_error(
-                        util::format("cannot link to non-existant table %1 from internal sync table %2",
-                                     column.target_table, table.name));
+                    throw LogicError(ErrorCodes::InvalidArgument,
+                                     util::format("cannot link to non-existant table %1 from internal sync table %2",
+                                                  column.target_table, table.name));
                 }
                 *column.key_out = table_ref->add_column_list(*target_table_it->second, column.name);
             }
             else if (column.data_type == type_Link) {
                 auto target_table_it = found_tables.find(column.target_table);
                 if (target_table_it == found_tables.end()) {
-                    throw std::runtime_error(
-                        util::format("cannot link to non-existant table %1 from internal sync table %2",
-                                     column.target_table, table.name));
+                    throw LogicError(ErrorCodes::InvalidArgument,
+                                     util::format("cannot link to non-existant table %1 from internal sync table %2",
+                                                  column.target_table, table.name));
                 }
                 *column.key_out = table_ref->add_column(*target_table_it->second, column.name);
             }
@@ -91,63 +92,75 @@ void load_sync_metadata_schema(const TransactionRef& tr, std::vector<SyncMetadat
     for (auto& table : *tables) {
         auto table_ref = tr->get_table(table.name);
         if (!table_ref) {
-            throw std::runtime_error(util::format("could not find internal sync table %1", table.name));
+            throw RuntimeError(ErrorCodes::RuntimeError,
+                               util::format("could not find internal sync table %1", table.name));
         }
 
         *table.key_out = table_ref->get_key();
         if (table.pk_info) {
             auto pk_col = table_ref->get_primary_key_column();
             if (auto pk_name = table_ref->get_column_name(pk_col); pk_name != table.pk_info->name) {
-                throw std::runtime_error(util::format(
-                    "primary key name of sync internal table %1 does not match (stored: %2, defined: %3)", table.name,
-                    pk_name, table.pk_info->name));
+                throw RuntimeError(
+                    ErrorCodes::RuntimeError,
+                    util::format(
+                        "primary key name of sync internal table %1 does not match (stored: %2, defined: %3)",
+                        table.name, pk_name, table.pk_info->name));
             }
             if (auto pk_type = table_ref->get_column_type(pk_col); pk_type != table.pk_info->data_type) {
-                throw std::runtime_error(util::format(
-                    "primary key type of sync internal table %1 does not match (stored: %2, defined: %3)", table.name,
-                    pk_type, table.pk_info->data_type));
+                throw RuntimeError(
+                    ErrorCodes::RuntimeError,
+                    util::format(
+                        "primary key type of sync internal table %1 does not match (stored: %2, defined: %3)",
+                        table.name, pk_type, table.pk_info->data_type));
             }
             if (auto is_nullable = table_ref->is_nullable(pk_col); is_nullable != table.pk_info->is_optional) {
-                throw std::runtime_error(util::format(
-                    "primary key nullabilty of sync internal table %1 does not match (stored: %2, defined: %3)",
-                    table.name, is_nullable, table.pk_info->is_optional));
+                throw RuntimeError(
+                    ErrorCodes::RuntimeError,
+                    util::format(
+                        "primary key nullabilty of sync internal table %1 does not match (stored: %2, defined: %3)",
+                        table.name, is_nullable, table.pk_info->is_optional));
             }
             *table.pk_info->key_out = pk_col;
         }
         else if (table.is_embedded && !table_ref->is_embedded()) {
-            throw std::runtime_error(
-                util::format("internal sync table %1 should be embedded, but is not", table.name));
+            throw RuntimeError(ErrorCodes::RuntimeError,
+                               util::format("internal sync table %1 should be embedded, but is not", table.name));
         }
 
         if (table.columns.size() + size_t(table.pk_info ? 1 : 0) != table_ref->get_column_count()) {
-            throw std::runtime_error(
+            throw RuntimeError(
+                ErrorCodes::RuntimeError,
                 util::format("sync internal table %1 has a different number of columns than its schema", table.name));
         }
 
         for (auto& col : table.columns) {
             auto col_key = table_ref->get_column_key(col.name);
             if (!col_key) {
-                throw std::runtime_error(
+                throw RuntimeError(
+                    ErrorCodes::RuntimeError,
                     util::format("column %1 is missing in sync internal table %2", col.name, table.name));
             }
 
             auto found_col_type = table_ref->get_column_type(col_key);
             if (found_col_type != col.data_type) {
-                throw std::runtime_error(
+                throw RuntimeError(
+                    ErrorCodes::RuntimeError,
                     util::format("column %1 in sync internal table %2 is the wrong type", col.name, table.name));
             }
 
             if (col.is_optional != table_ref->is_nullable(col_key)) {
-                throw std::runtime_error(
+                throw RuntimeError(
+                    ErrorCodes::RuntimeError,
                     util::format("column %1 in sync internal table %2 has different nullabilty than in its schema",
                                  col.name, table.name));
             }
 
             if (col.data_type == type_LinkList &&
                 table_ref->get_link_target(col_key)->get_name() != col.target_table) {
-                throw std::runtime_error(
-                    util::format("column %1 in sync internal table %2 links to the wrong table %3", col.name,
-                                 table.name, table_ref->get_link_target(col_key)->get_name()));
+                throw RuntimeError(ErrorCodes::RuntimeError,
+                                   util::format("column %1 in sync internal table %2 links to the wrong table %3",
+                                                col.name, table.name,
+                                                table_ref->get_link_target(col_key)->get_name()));
             }
             *col.key_out = col_key;
         }

--- a/src/realm/sync/subscriptions.cpp
+++ b/src/realm/sync/subscriptions.cpp
@@ -85,7 +85,8 @@ SubscriptionSet::State state_from_storage(int64_t value)
         case SubscriptionStateForStorage::Error:
             return SubscriptionSet::State::Error;
         default:
-            throw std::runtime_error(util::format("Invalid state for SubscriptionSet stored on disk: %1", value));
+            throw RuntimeError(ErrorCodes::InvalidArgument,
+                               util::format("Invalid state for SubscriptionSet stored on disk: %1", value));
     }
 }
 
@@ -191,7 +192,7 @@ std::shared_ptr<const SubscriptionStore> SubscriptionSet::get_flx_subscription_s
     if (auto mgr = m_mgr.lock()) {
         return mgr;
     }
-    throw std::logic_error("Active SubscriptionSet without a SubscriptionStore");
+    throw RuntimeError(ErrorCodes::BrokenInvariant, "Active SubscriptionSet without a SubscriptionStore");
 }
 
 int64_t SubscriptionSet::version() const
@@ -367,19 +368,21 @@ void MutableSubscriptionSet::update_state(State new_state, util::Optional<std::s
     check_is_mutable();
     auto old_state = state();
     if (error_str && new_state != State::Error) {
-        throw std::logic_error("Cannot supply an error message for a subscription set when state is not Error");
+        throw LogicError(ErrorCodes::InvalidArgument,
+                         "Cannot supply an error message for a subscription set when state is not Error");
     }
     switch (new_state) {
         case State::Uncommitted:
-            throw std::logic_error("cannot set subscription set state to uncommitted");
+            throw LogicError(ErrorCodes::InvalidArgument, "cannot set subscription set state to uncommitted");
 
         case State::Error:
             if (old_state != State::Bootstrapping && old_state != State::Pending && old_state != State::Uncommitted) {
-                throw std::logic_error(
-                    "subscription set must be in Bootstrapping or Pending to update state to error");
+                throw LogicError(ErrorCodes::InvalidArgument,
+                                 "subscription set must be in Bootstrapping or Pending to update state to error");
             }
             if (!error_str) {
-                throw std::logic_error("Must supply an error message when setting a subscription to the error state");
+                throw LogicError(ErrorCodes::InvalidArgument,
+                                 "Must supply an error message when setting a subscription to the error state");
             }
 
             m_state = new_state;
@@ -397,10 +400,10 @@ void MutableSubscriptionSet::update_state(State new_state, util::Optional<std::s
             break;
         }
         case State::Superseded:
-            throw std::logic_error("Cannot set a subscription to the superseded state");
+            throw LogicError(ErrorCodes::InvalidArgument, "Cannot set a subscription to the superseded state");
             break;
         case State::Pending:
-            throw std::logic_error("Cannot set subscription set to the pending state");
+            throw LogicError(ErrorCodes::InvalidArgument, "Cannot set subscription set to the pending state");
             break;
     }
 }
@@ -528,7 +531,7 @@ void MutableSubscriptionSet::process_notifications()
 SubscriptionSet MutableSubscriptionSet::commit()
 {
     if (m_tr->get_transact_stage() != DB::transact_Writing) {
-        throw std::logic_error("SubscriptionSet is not in a commitable state");
+        throw RuntimeError(ErrorCodes::WrongTransactionState, "SubscriptionSet is not in a commitable state");
     }
     auto mgr = get_flx_subscription_store(); // Throws
 
@@ -669,7 +672,8 @@ SubscriptionStore::SubscriptionStore(DBRef db, util::UniqueFunction<void(int64_t
     }
     else {
         if (*schema_version != c_flx_schema_version) {
-            throw std::runtime_error("Invalid schema version for flexible sync metadata");
+            throw RuntimeError(ErrorCodes::UnsupportedFileFormatVersion,
+                               "Invalid schema version for flexible sync metadata");
         }
         load_sync_metadata_schema(tr, &internal_tables);
     }

--- a/test/test_sync_subscriptions.cpp
+++ b/test/test_sync_subscriptions.cpp
@@ -412,7 +412,7 @@ TEST(Sync_SubscriptionStoreRefreshSubscriptionSetInvalid)
     store.reset();
 
     // Throws since the SubscriptionStore is gone.
-    CHECK_THROW(latest->refresh(), std::logic_error);
+    CHECK_THROW(latest->refresh(), RuntimeError);
 }
 
 TEST(Sync_SubscriptionStoreInternalSchemaMigration)


### PR DESCRIPTION
## What, How & Why?
This updates a bunch of places where we were throwing std::exception types to throw Realm exception types instead.

## ☑️ ToDos
* [ ] 📝 Changelog update
* [ ] 🚦 Tests (or not relevant)
* [ ] C-API, if public C++ API changed.
