### PR TITLE
remove clang-format from Jenkins CI

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -93,33 +93,6 @@ jobWrapper {
         }
     }
 
-    if (isPullRequest) {
-        stage('FormatCheck') {
-            rlmNode('docker') {
-                getArchive()
-
-                buildDockerEnv('testing.Dockerfile').inside {
-                    echo "Checking code formatting"
-                    modifications = sh(returnStdout: true, script: "git clang-format --diff ${targetSHA1}").trim()
-                    try {
-                        if (!modifications.equals('no modified files to format')) {
-                            if (!modifications.equals('clang-format did not modify any files')) {
-                                echo "Commit violates formatting rules"
-                                sh "git clang-format --diff ${targetSHA1} > format_error.txt"
-                                archiveArtifacts('format_error.txt')
-                                sh 'exit 1'
-                            }
-                        }
-                        currentBuild.result = 'SUCCESS'
-                    } catch (Exception err) {
-                        currentBuild.result = 'FAILURE'
-                        throw err
-                    }
-                }
-            }
-        }
-    }
-
     stage('Checking') {
         def buildOptions = [
             buildType : 'Debug',


### PR DESCRIPTION
We rely solely on the Evergreen lint check now which also runs clang-format.
The Evergreen lint check and the Jenkins format check are running slightly different versions of clang-format which means that it is impossible for some code changes to pass CI because each versions has a different interpretation of what is correctly formatted code. 
Since we intend to eventually move off of Jenkins, I will remove the format check there.
Related to https://github.com/realm/realm-core/pull/6563 where Evergreen's clang-format is updated.