### PR TITLE
Reduce the memory footprint of an automatic reset

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,7 +17,7 @@
 -----------
 
 ### Internals
-* None.
+* Reduce the memory footprint of an automatic (discard or recover) client reset when there are large incoming changes from the server. ([#6567](https://github.com/realm/realm-core/issues/6567))
 
 ----------------------------------------------
 

--- a/src/realm/sync/noinst/client_reset.cpp
+++ b/src/realm/sync/noinst/client_reset.cpp
@@ -78,10 +78,7 @@ void transfer_group(const Transaction& group_src, Transaction& group_dst, util::
     // away immediately after anyways. This reduces the memory footprint of a client reset.
     ClientReplication* client_repl = dynamic_cast<ClientReplication*>(group_dst.get_replication());
     REALM_ASSERT_RELEASE(client_repl);
-    client_repl->set_short_circuit(true);
-    util::ScopeExit sync_history_guard([client_repl]() noexcept {
-        client_repl->set_short_circuit(false);
-    });
+    TempShortCircuitReplication sync_history_guard(*client_repl);
 
     // Find all tables in dst that should be removed.
     std::set<std::string> tables_to_remove;


### PR DESCRIPTION
The sync history can be short circuited because it will be discarded right after `transfer_group()`

I made a temporary client reset test that inserted a bunch of large strings on the server state so that transfer_group had to insert them and recorded the memory use before and after using `/usr/bin/time -l ./test/object-store/realm-object-store-tests.app/Contents/MacOS/realm-object-store-tests "sync: client reset" -c "recovery" -c "insert" -d yes`
The amount of memory difference will vary widely based on the actual data, but I take the following improvement from my synthetic test to be an indication of improvement:
Before: `17581760  peak memory footprint`
After:    `13338304  peak memory footprint`