### PR TITLE
Assorted binary size improvements

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -390,6 +390,12 @@ let package = Package(
         .target(
             name: "s2geometry",
             path: "src/external/s2",
+            exclude: [
+                "s2cellunion.cc",
+                "s2regioncoverer.cc",
+                "s2regionintersection.cc",
+                "s2regionunion.cc"
+            ],
             publicHeadersPath: ".",
             cxxSettings: ([
                 .headerSearchPath(".."),

--- a/src/external/IntelRDFPMathLib20U2/CMakeLists.txt
+++ b/src/external/IntelRDFPMathLib20U2/CMakeLists.txt
@@ -27,3 +27,5 @@ check_cxx_compiler_flag(-Wunused-but-set-variable HAVE-Wunused-but-set-variable)
 if(HAVE-Wunused-but-set-variable)
     target_compile_options(Bid PRIVATE -Wno-unused-but-set-variable)
 endif()
+
+set_target_properties(Bid PROPERTIES CXX_VISIBILITY_PRESET hidden)

--- a/src/external/s2/CMakeLists.txt
+++ b/src/external/s2/CMakeLists.txt
@@ -24,6 +24,51 @@ set(S2_SOURCES
     s2regioncoverer.cc
     s2regionintersection.cc
     s2regionunion.cc
+
+    base/basictypes.h
+    base/casts.h
+    base/commandlineflags.h
+    base/definer.h
+    base/integral_types.h
+    base/logging.h
+    base/macros.h
+    base/stl_decl.h
+    base/stl_decl_msvc.h
+    base/stl_decl_osx.h
+    base/template_util.h
+    hash.h
+    r1interval.h
+    s1angle.h
+    s1interval.h
+    s2.h
+    s2cap.h
+    s2cell.h
+    s2cellid.h
+    s2cellunion.h
+    s2edgeindex.h
+    s2edgeutil.h
+    s2latlng.h
+    s2latlngrect.h
+    s2loop.h
+    s2pointregion.h
+    s2polygon.h
+    s2polygonbuilder.h
+    s2polyline.h
+    s2r2rect.h
+    s2region.h
+    s2regioncoverer.h
+    s2regionintersection.h
+    s2regionunion.h
+    util/math/mathlimits.h
+    util/math/mathutil.h
+    util/math/matrix3x3-inl.h
+    util/math/matrix3x3.h
+    util/math/vector2-inl.h
+    util/math/vector2.h
+    util/math/vector3-inl.h
+    util/math/vector3.h
+    util/math/vector4-inl.h
+    util/math/vector4.h
 )
 
 set(S2_UTIL_MATH_SOURCES

--- a/src/external/s2/CMakeLists.txt
+++ b/src/external/s2/CMakeLists.txt
@@ -83,6 +83,7 @@ target_include_directories(s2geometry PRIVATE "." "..")
 target_compile_options(s2geometry PRIVATE
     $<$<CXX_COMPILER_ID:MSVC>: /wd4068 /wd4244 /wd4267 /wd4305>
 )
+set_target_properties(s2geometry PROPERTIES CXX_VISIBILITY_PRESET hidden)
 if (NOT MSVC)
     set(CMAKE_REQUIRED_QUIET ON)
     add_target_option_if_supported(s2geometry PRIVATE

--- a/src/external/s2/CMakeLists.txt
+++ b/src/external/s2/CMakeLists.txt
@@ -10,7 +10,6 @@ set(S2_SOURCES
     s1interval.cc
     s2cap.cc
     s2cell.cc
-    s2cellunion.cc
     s2edgeindex.cc
     s2edgeutil.cc
     s2latlngrect.cc
@@ -21,9 +20,6 @@ set(S2_SOURCES
     s2polyline.cc
     s2r2rect.cc
     s2region.cc
-    s2regioncoverer.cc
-    s2regionintersection.cc
-    s2regionunion.cc
 
     base/basictypes.h
     base/casts.h

--- a/src/realm/alloc.hpp
+++ b/src/realm/alloc.hpp
@@ -327,7 +327,7 @@ private:
     friend class Group;
     friend class WrappedAllocator;
     friend class Obj;
-    template <class, class>
+    template <class>
     friend class CollectionBaseImpl;
     friend class Dictionary;
 };

--- a/src/realm/collection.hpp
+++ b/src/realm/collection.hpp
@@ -326,7 +326,7 @@ struct AverageHelper<T, std::void_t<ColumnSumType<T>>> {
 /// Convenience base class for collections, which implements most of the
 /// relevant interfaces for a collection that is bound to an object accessor and
 /// representable as a BPlusTree<T>.
-template <class Interface, class Derived>
+template <class Interface>
 class CollectionBaseImpl : public Interface, protected ArrayParent {
 public:
     static_assert(std::is_base_of_v<CollectionBase, Interface>);
@@ -368,6 +368,17 @@ public:
     using Interface::get_table;
     using Interface::get_target_table;
 
+    bool operator==(const CollectionBaseImpl& other) const noexcept
+    {
+        return get_table() == other.get_table() && get_owner_key() == other.get_owner_key() &&
+               get_col_key() == other.get_col_key();
+    }
+
+    bool operator!=(const CollectionBaseImpl& other) const noexcept
+    {
+        return !(*this == other);
+    }
+
 protected:
     Obj m_obj;
     ColKey m_col_key;
@@ -391,17 +402,6 @@ protected:
 
     CollectionBaseImpl& operator=(const CollectionBaseImpl& other) = default;
     CollectionBaseImpl& operator=(CollectionBaseImpl&& other) = default;
-
-    bool operator==(const Derived& other) const noexcept
-    {
-        return get_table() == other.get_table() && get_owner_key() == other.get_owner_key() &&
-               get_col_key() == other.get_col_key();
-    }
-
-    bool operator!=(const Derived& other) const noexcept
-    {
-        return !(*this == other);
-    }
 
     /// Refresh the associated `Obj` (if needed), and update the internal
     /// content version number. This is meant to be called from a derived class

--- a/src/realm/dictionary.hpp
+++ b/src/realm/dictionary.hpp
@@ -26,9 +26,9 @@
 
 namespace realm {
 
-class Dictionary final : public CollectionBaseImpl<CollectionBase, Dictionary> {
+class Dictionary final : public CollectionBaseImpl<CollectionBase> {
 public:
-    using Base = CollectionBaseImpl<CollectionBase, Dictionary>;
+    using Base = CollectionBaseImpl<CollectionBase>;
     class Iterator;
 
     Dictionary() {}
@@ -42,8 +42,6 @@ public:
         *this = other;
     }
     Dictionary& operator=(const Dictionary& other);
-
-    using Base::operator==;
 
     DataType get_key_data_type() const;
     DataType get_value_data_type() const;

--- a/src/realm/geospatial.cpp
+++ b/src/realm/geospatial.cpp
@@ -64,42 +64,24 @@ namespace realm {
 
 std::string Geospatial::get_type_string() const noexcept
 {
-    return mpark::visit(util::overload{[&](const GeoPoint&) {
-                                           return "Point";
-                                       },
-                                       [&](const GeoBox&) {
-                                           return "Box";
-                                       },
-                                       [&](const GeoPolygon&) {
-                                           return "Polygon";
-                                       },
-                                       [&](const GeoCenterSphere&) {
-                                           return "CenterSphere";
-                                       },
-                                       [&](const mpark::monostate&) {
-                                           return "Invalid";
-                                       }},
-                        m_value);
+    switch (get_type()) {
+        case Type::Point:
+            return "Point";
+        case Type::Box:
+            return "Box";
+        case Type::Polygon:
+            return "Polygon";
+        case Type::CenterSphere:
+            return "CenterSphere";
+        case Type::Invalid:
+            return "Invalid";
+    }
+    REALM_UNREACHABLE();
 }
 
 Geospatial::Type Geospatial::get_type() const noexcept
 {
-    return mpark::visit(util::overload{[&](const GeoPoint&) {
-                                           return Type::Point;
-                                       },
-                                       [&](const GeoBox&) {
-                                           return Type::Box;
-                                       },
-                                       [&](const GeoPolygon&) {
-                                           return Type::Polygon;
-                                       },
-                                       [&](const GeoCenterSphere&) {
-                                           return Type::CenterSphere;
-                                       },
-                                       [&](const mpark::monostate&) {
-                                           return Type::Invalid;
-                                       }},
-                        m_value);
+    return static_cast<Type>(m_value.index());
 }
 
 bool Geospatial::is_geospatial(const TableRef table, ColKey link_col)
@@ -231,47 +213,53 @@ void Geospatial::assign_to(Obj& link) const
     }
 }
 
-S2Region& Geospatial::get_region() const
+std::unique_ptr<S2Region> Geospatial::get_region() const
 {
-    if (m_region)
-        return *m_region.get();
+    struct Visitor {
+        std::unique_ptr<S2Region> operator()(const GeoBox& box) const
+        {
+            return std::make_unique<S2LatLngRect>(S2LatLng::FromDegrees(box.lo.latitude, box.lo.longitude),
+                                                  S2LatLng::FromDegrees(box.hi.latitude, box.hi.longitude));
+        }
 
-    mpark::visit(util::overload{
-                     [&](const GeoPoint&) {
-                         REALM_UNREACHABLE();
-                     },
-                     [&](const GeoBox& box) {
-                         m_region =
-                             std::make_unique<S2LatLngRect>(S2LatLng::FromDegrees(box.lo.latitude, box.lo.longitude),
-                                                            S2LatLng::FromDegrees(box.hi.latitude, box.hi.longitude));
-                     },
-                     [&](const GeoPolygon& polygon) {
-                         REALM_ASSERT(polygon.points.size() >= 1);
-                         std::vector<S2Loop*> loops;
-                         for (size_t i = 0; i < polygon.points.size(); ++i) {
-                             std::vector<S2Point> points;
-                             points.reserve(polygon.points[i].size());
-                             for (auto&& p : polygon.points[i]) {
-                                 // FIXME rewrite without copying
-                                 points.emplace_back(S2LatLng::FromDegrees(p.latitude, p.longitude).ToPoint());
-                             }
-                             loops.push_back(new S2Loop(points));
-                         }
-                         // S2Polygon takes ownership of all the S2Loop pointers
-                         m_region = std::make_unique<S2Polygon>(&loops);
-                     },
-                     [&](const GeoCenterSphere& sphere) {
-                         auto center =
-                             S2LatLng::FromDegrees(sphere.center.latitude, sphere.center.longitude).ToPoint();
-                         auto radius = S1Angle::Radians(sphere.radius_radians);
-                         m_region.reset(S2Cap::FromAxisAngle(center, radius).Clone()); // FIXME without extra copy
-                     },
-                     [&](const mpark::monostate&) {
-                         REALM_UNREACHABLE();
-                     }},
-                 m_value);
+        std::unique_ptr<S2Region> operator()(const GeoPolygon& polygon) const
+        {
+            REALM_ASSERT(polygon.points.size() >= 1);
+            std::vector<S2Loop*> loops;
+            loops.reserve(polygon.points.size());
+            std::vector<S2Point> points;
+            for (auto& geo_points : polygon.points) {
+                points.clear();
+                points.reserve(geo_points.size());
+                for (auto&& p : geo_points) {
+                    // FIXME rewrite without copying
+                    points.push_back(S2LatLng::FromDegrees(p.latitude, p.longitude).ToPoint());
+                }
+                loops.push_back(new S2Loop(points));
+            }
+            // S2Polygon takes ownership of all the S2Loop pointers
+            return std::make_unique<S2Polygon>(&loops);
+        }
 
-    return *m_region.get();
+        std::unique_ptr<S2Region> operator()(const GeoCenterSphere& sphere) const
+        {
+            auto center = S2LatLng::FromDegrees(sphere.center.latitude, sphere.center.longitude).ToPoint();
+            auto radius = S1Angle::Radians(sphere.radius_radians);
+            return std::make_unique<S2Cap>(S2Cap::FromAxisAngle(center, radius));
+        }
+
+        std::unique_ptr<S2Region> operator()(const mpark::monostate&) const
+        {
+            REALM_UNREACHABLE();
+        }
+
+        std::unique_ptr<S2Region> operator()(const GeoPoint&) const
+        {
+            REALM_UNREACHABLE();
+        }
+    };
+
+    return mpark::visit(Visitor(), m_value);
 }
 
 bool Geospatial::is_within(const Geospatial& geometry) const noexcept
@@ -281,42 +269,27 @@ bool Geospatial::is_within(const Geospatial& geometry) const noexcept
     auto&& geo_point = mpark::get<GeoPoint>(m_value);
     auto point = S2LatLng::FromDegrees(geo_point.latitude, geo_point.longitude).ToPoint();
 
-    auto& region = geometry.get_region();
-    return mpark::visit(util::overload{[&](const GeoPoint&) {
-                                           return false;
-                                       },
-                                       [&](const GeoBox&) {
-                                           return static_cast<S2LatLngRect&>(region).Contains(point);
-                                       },
-                                       [&](const GeoPolygon&) {
-                                           return static_cast<S2Polygon&>(region).Contains(point);
-                                       },
-                                       [&](const GeoCenterSphere&) {
-                                           return static_cast<S2Cap&>(region).Contains(point);
-                                       },
-                                       [&](const mpark::monostate&) {
-                                           return false;
-                                       }},
-                        geometry.m_value);
+    return geometry.get_region()->VirtualContainsPoint(point);
+}
+
+static std::string point_str(const GeoPoint& point)
+{
+    if (point.has_altitude()) {
+        return util::format("[%1, %2, %3]", point.longitude, point.latitude, point.altitude);
+    }
+    return util::format("[%1, %2]", point.longitude, point.latitude);
 }
 
 std::string Geospatial::to_string() const
 {
-    auto point_str = [&](const GeoPoint& point) -> std::string {
-        if (point.get_altitude()) {
-            return util::format("[%1, %2, %3]", point.longitude, point.latitude, *point.get_altitude());
-        }
-        return util::format("[%1, %2]", point.longitude, point.latitude);
-    };
-
     return mpark::visit(
-        util::overload{[&](const GeoPoint& point) {
+        util::overload{[](const GeoPoint& point) {
                            return util::format("GeoPoint(%1)", point_str(point));
                        },
-                       [&](const GeoBox& box) {
+                       [](const GeoBox& box) {
                            return util::format("GeoBox(%1, %2)", point_str(box.lo), point_str(box.hi));
                        },
-                       [&](const GeoPolygon& poly) {
+                       [](const GeoPolygon& poly) {
                            std::string points = "";
                            for (size_t i = 0; i < poly.points.size(); ++i) {
                                if (i != 0) {
@@ -330,14 +303,13 @@ std::string Geospatial::to_string() const
                            }
                            return util::format("GeoPolygon(%1)", points);
                        },
-                       [&](const GeoCenterSphere& sphere) {
+                       [](const GeoCenterSphere& sphere) {
                            return util::format("GeoSphere(%1, %2)", point_str(sphere.center), sphere.radius_radians);
                        },
-                       [&](const mpark::monostate&) {
+                       [](const mpark::monostate&) {
                            return std::string("NULL");
                        }},
         m_value);
-    return "NULL";
 }
 
 std::ostream& operator<<(std::ostream& ostr, const Geospatial& geo)

--- a/src/realm/geospatial.hpp
+++ b/src/realm/geospatial.hpp
@@ -234,7 +234,18 @@ private:
     // Must be in the same order as the Type enum
     mpark::variant<mpark::monostate, GeoPoint, GeoBox, GeoPolygon, GeoCenterSphere> m_value;
 
-    std::unique_ptr<S2Region> get_region() const;
+    friend class GeoRegion;
+};
+
+class GeoRegion {
+public:
+    GeoRegion(const Geospatial& geo);
+    ~GeoRegion();
+
+    bool contains(const GeoPoint& point) const noexcept;
+
+private:
+    std::unique_ptr<S2Region> m_region;
 };
 
 template <>

--- a/src/realm/geospatial.hpp
+++ b/src/realm/geospatial.hpp
@@ -166,7 +166,7 @@ struct GeoCenterSphere {
 
 class Geospatial {
 public:
-    enum class Type : uint8_t { Point, Box, Polygon, CenterSphere, Invalid };
+    enum class Type : uint8_t { Invalid, Point, Box, Polygon, CenterSphere };
 
     Geospatial()
         : m_value(mpark::monostate{})
@@ -231,10 +231,10 @@ public:
     constexpr static std::string_view c_geo_point_coords_col_name = "coordinates";
 
 private:
+    // Must be in the same order as the Type enum
     mpark::variant<mpark::monostate, GeoPoint, GeoBox, GeoPolygon, GeoCenterSphere> m_value;
 
-    mutable std::shared_ptr<S2Region> m_region;
-    S2Region& get_region() const;
+    std::unique_ptr<S2Region> get_region() const;
 };
 
 template <>

--- a/src/realm/list.hpp
+++ b/src/realm/list.hpp
@@ -72,9 +72,9 @@ protected:
 };
 
 template <class T>
-class Lst final : public CollectionBaseImpl<LstBase, Lst<T>> {
+class Lst final : public CollectionBaseImpl<LstBase> {
 public:
-    using Base = CollectionBaseImpl<LstBase, Lst<T>>;
+    using Base = CollectionBaseImpl<LstBase>;
     using iterator = LstIterator<T>;
     using value_type = T;
 
@@ -84,8 +84,6 @@ public:
     Lst(Lst&&) noexcept;
     Lst& operator=(const Lst& other);
     Lst& operator=(Lst&& other) noexcept;
-
-    using Base::operator==;
 
     iterator begin() const noexcept
     {

--- a/src/realm/obj.hpp
+++ b/src/realm/obj.hpp
@@ -340,7 +340,7 @@ private:
     friend class TableView;
     template <class, class>
     friend class Collection;
-    template <class, class>
+    template <class>
     friend class CollectionBaseImpl;
     template <class>
     friend class Lst;

--- a/src/realm/query_expression.cpp
+++ b/src/realm/query_expression.cpp
@@ -73,7 +73,7 @@ std::string LinkMap::description(util::serializer::SerialisationState& state) co
     return s;
 }
 
-void LinkMap::map_links(size_t column, ObjKey key, LinkMapFunction& lm) const
+void LinkMap::map_links(size_t column, ObjKey key, LinkMapFunction lm) const
 {
     bool last = (column + 1 == m_link_column_keys.size());
     ColumnType type = m_link_types[column];
@@ -86,7 +86,7 @@ void LinkMap::map_links(size_t column, ObjKey key, LinkMapFunction& lm) const
             if (ObjKey k = coll->get_key(t)) {
                 // Unresolved links are filtered out
                 if (last) {
-                    lm.consume(k);
+                    lm(k);
                 }
                 else
                     map_links(column + 1, k, lm);
@@ -97,7 +97,7 @@ void LinkMap::map_links(size_t column, ObjKey key, LinkMapFunction& lm) const
         if (ObjKey k = obj.get<ObjKey>(column_key)) {
             if (!k.is_unresolved()) {
                 if (last)
-                    lm.consume(k);
+                    lm(k);
                 else
                     map_links(column + 1, k, lm);
             }
@@ -107,7 +107,7 @@ void LinkMap::map_links(size_t column, ObjKey key, LinkMapFunction& lm) const
         auto backlinks = obj.get_all_backlinks(column_key);
         for (auto k : backlinks) {
             if (last) {
-                lm.consume(k);
+                lm(k);
             }
             else
                 map_links(column + 1, k, lm);
@@ -125,7 +125,7 @@ ref_type LinkMap::get_ref(const ArrayPayload* array_payload, ColumnType type, si
     return static_cast<const ArrayKey*>(array_payload)->get_as_ref(row);
 }
 
-void LinkMap::map_links(size_t column, size_t row, LinkMapFunction& lm) const
+void LinkMap::map_links(size_t column, size_t row, LinkMapFunction lm) const
 {
     REALM_ASSERT(m_leaf_ptr != nullptr);
 
@@ -156,7 +156,7 @@ void LinkMap::map_links(size_t column, size_t row, LinkMapFunction& lm) const
                             auto k = link.get_obj_key();
                             if (!k.is_unresolved()) {
                                 if (last)
-                                    lm.consume(k);
+                                    lm(k);
                                 else
                                     map_links(column + 1, k, lm);
                             }
@@ -171,7 +171,7 @@ void LinkMap::map_links(size_t column, size_t row, LinkMapFunction& lm) const
             if (ObjKey k = static_cast<const ArrayKey*>(m_leaf_ptr)->get(row)) {
                 if (!k.is_unresolved()) {
                     if (last)
-                        lm.consume(k);
+                        lm(k);
                     else
                         map_links(column + 1, k, lm);
                 }
@@ -187,7 +187,7 @@ void LinkMap::map_links(size_t column, size_t row, LinkMapFunction& lm) const
                 ObjKey k = links.get(t);
                 if (!k.is_unresolved()) {
                     if (last) {
-                        if (!lm.consume(k)) {
+                        if (!lm(k)) {
                             return;
                         }
                     }
@@ -203,8 +203,7 @@ void LinkMap::map_links(size_t column, size_t row, LinkMapFunction& lm) const
         for (size_t t = 0; t < sz; t++) {
             ObjKey k = back_links->get_backlink(row, t);
             if (last) {
-                bool continue2 = lm.consume(k);
-                if (!continue2)
+                if (!lm(k))
                     return;
             }
             else

--- a/src/realm/set.hpp
+++ b/src/realm/set.hpp
@@ -46,9 +46,9 @@ protected:
 };
 
 template <class T>
-class Set final : public CollectionBaseImpl<SetBase, Set<T>> {
+class Set final : public CollectionBaseImpl<SetBase> {
 public:
-    using Base = CollectionBaseImpl<SetBase, Set>;
+    using Base = CollectionBaseImpl<SetBase>;
     using value_type = T;
     using iterator = CollectionIterator<Set<T>>;
 
@@ -58,8 +58,6 @@ public:
     Set(Set&& other) noexcept;
     Set& operator=(const Set& other);
     Set& operator=(Set&& other) noexcept;
-    using Base::operator==;
-    using Base::operator!=;
 
     SetBasePtr clone() const final
     {

--- a/src/realm/util/functional.hpp
+++ b/src/realm/util/functional.hpp
@@ -138,23 +138,6 @@ public:
     operator std::function<Signature>() const = delete;
 
 private:
-    // These overload helpers are needed to squelch problems in the `T ()` -> `void ()` case.
-    template <typename Functor>
-    static void call_regular_void(const std::true_type is_void, Functor& f, Args&&... args)
-    {
-        // The result of this call is not cast to void, to help preserve detection of
-        // `[[nodiscard]]` violations.
-        static_cast<void>(is_void);
-        f(std::forward<Args>(args)...);
-    }
-
-    template <typename Functor>
-    static RetType call_regular_void(const std::false_type is_not_void, Functor& f, Args&&... args)
-    {
-        static_cast<void>(is_not_void);
-        return f(std::forward<Args>(args)...);
-    }
-
     template <typename Functor>
     struct SpecificImpl : Impl {
         template <typename F>
@@ -165,7 +148,14 @@ private:
 
         RetType call(Args&&... args) override
         {
-            return call_regular_void(std::is_void<RetType>(), f, std::forward<Args>(args)...);
+            if constexpr (std::is_void_v<RetType>) {
+                // The result of this call is not cast to void, to help preserve detection of
+                // `[[nodiscard]]` violations.
+                f(std::forward<Args>(args)...);
+            }
+            else {
+                return f(std::forward<Args>(args)...);
+            }
         }
 
         Functor f;

--- a/src/realm/util/serializer.cpp
+++ b/src/realm/util/serializer.cpp
@@ -267,11 +267,10 @@ std::string SerialisationState::get_column_name(ConstTableRef table, ColKey col_
     if (col_type == col_type_BackLink) {
         const Table::BacklinkOrigin origin = table->find_backlink_origin(col_key);
         REALM_ASSERT(origin);
-        std::string source_table_name = origin->first->get_class_name();
+        StringData source_table_name = origin->first->get_class_name();
         std::string source_col_name = get_column_name(origin->first, origin->second);
 
-        return "@links" + util::serializer::value_separator + source_table_name + util::serializer::value_separator +
-               source_col_name;
+        return format("@links.%1.%2", source_table_name, source_col_name);
     }
     else if (col_key != ColKey()) {
         std::string col_name = table->get_column_name(col_key);

--- a/src/realm/util/serializer.hpp
+++ b/src/realm/util/serializer.hpp
@@ -47,9 +47,7 @@ enum class ExpressionComparisonType : unsigned char;
 class Geospatial;
 #endif // REALM_ENABLE_GEOSPATIAL
 
-namespace util {
-namespace serializer {
-
+namespace util::serializer {
 
 // Definitions
 template <typename T>
@@ -58,7 +56,7 @@ std::string print_value(T value);
 template <typename T>
 std::string print_value(Optional<T> value);
 
-const static std::string value_separator = ".";
+constexpr static const char value_separator[] = ".";
 
 // Specializations declared here to be defined in the cpp file
 template <> std::string print_value<>(BinaryData);
@@ -122,8 +120,7 @@ struct SerialisationState {
     ConstTableRef target_table;
 };
 
-} // namespace serializer
-} // namespace util
+} // namespace util::serializer
 } // namespace realm
 
 #endif // REALM_UTIL_SERIALIZER_HPP


### PR DESCRIPTION
Some easy size improvements that jumped out at me when looking at the binary size change from adding geospatial in bloaty. Sizes below are the size of the dylib resulting from `./tools/build-cocoa.sh -bmx && lipo -thin arm64 core/librealm-monorepo-macosx.a -output out.a && clang++ -dynamiclib -Wl,-all_load out.a -lcompression -framework Security -lz -o out.dylib`.

The size for Realm.framework (macOS arm64 only) is 7525808 bytes with 13.10.1, and 7542208 bytes with these changes and geospatial queries enabled.

| Commit | Size | Change | Net Change |
| ------ | ---- | ------ | ---------- |
| Initial | 6955960 | 0 | 0 |
| Geospatial Enabled | 7262136 | 306176 | 306176 |
| value_separator | 7240472 | -21664 | 284512 |
| CollectionBaseImpl | 7147400 | -93072 | 191440 |
| Compare | 7122984 | -24416 | 167024 |
| Geospatial | 7103000 | -19984 | 147040 |
| Unused s2 | 7072968 | -30032 | 117008 |
| UniqueFunction | 7050440 | -22528 | 94480 |
| fvisibility | 7046937 | -3503 | 90977 |

util::serializer::value_separator defined a *different* const std::string in every file which imported the header due to being static. Changing this to a const char* results in them being deduplicated.

CollectionBaseImpl was templated on the derived type so that it could define the comparison operator, but otherwise didn't use the derived type, resulting in a bunch of duplicated functions.
Comparisons between different derived types work fine and didn't really need to be type-specific anyway.

Compare had some functionality which didn't actually use TCond and so didn't need to be duplicated in each template instantiation.

Variant visitation has sort of awful codegen, so avoiding it where straightforward is somewhat helpful. `Geospatial::m_region` was just unnecessary; we currently never call `get_region()` multiple times on a single `Geospatial` instance.

There's a few s2geometry files which we currently aren't using at all, so I excluded them from the build.

I'm not really sure why the UniqueFunction changes reduced the size.

We don't build the Cocoa library with -fvisibilty=hidden because some of the tests use core directly while linked against the binary library, but we can set it on the third-party deps.
