### PR TITLE
Fix warnings in evergreen config

### DIFF
--- a/evergreen/config.yml
+++ b/evergreen/config.yml
@@ -1,3 +1,6 @@
+# Some tests take up to 4 hours to run, so give a very generous timeout project-wide, but generally try to complete tasks within 30 minutes.
+exec_timeout_secs: 14400
+
 functions:
   "fetch binaries":
     - command: shell.exec
@@ -700,7 +703,6 @@ tasks:
       verbose_test_output: true
 
 - name: process_coverage_data
-  display_name: Process Coverage Data
   tags: [ "for_pull_requests" ]
   exec_timeout_secs: 1800
   commands:
@@ -765,7 +767,6 @@ tasks:
         curl -X POST https://coveralls.io/api/v1/jobs -F 'json_file=@coveralls_${task_name}.json'
 
 - name: finalize_coverage_data
-  display_name: Finalize Coverage Data
   tags: [ "for_pull_requests" ]
   depends_on:
     - name: "process_coverage_data"


### PR DESCRIPTION
## What, How & Why?
This just fixes some warnings from running the evegreen CLI validate command.

Before
```~/evergreen validate evergreen/config.yml
WARNING: error unmarshalling strictly: load project error(s): error unmarshalling yaml strict: yaml: unmarshal errors:
  line 703: field display_name not found in type model.parserTask
  line 768: field display_name not found in type model.parserTask
WARNING: no exec_timeout_secs defined at the top-level or on one or more tasks; these tasks will default to a timeout of 6 hours
evergreen/config.yml is valid with warnings
```

After
```
evergreen/config.yml is valid
```
😌