### PR TITLE
Ignore external directories in coverage data

### DIFF
--- a/evergreen/config.yml
+++ b/evergreen/config.yml
@@ -759,6 +759,8 @@ tasks:
             --service-flag-name="${coveralls_flag_name}" \
             --commit-sha="${github_commit}" \
             --vcs-branch="${branch_name}" \
+            --ignore='external/**' \
+            --ignore='src/external/**' \
             --parallel \
             --output-path=coveralls_${task_name}.json
 


### PR DESCRIPTION
## What, How & Why?
Adds `./external/**` and `./src/external/**` to the ignored list of files in coverage reports so we don't get dinged for not covering all of catch2 and s2. Makes our coverage go up to 90%!

## ☑️ ToDos
* [ ] 📝 Changelog update
* [ ] 🚦 Tests (or not relevant)
* [ ] C-API, if public C++ API changed.
