### PR TITLE
Apply clang-format only on staged changes

### DIFF
--- a/tools/pre-commit
+++ b/tools/pre-commit
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 # This pre-commit hook prevents us from creating commits that contains ill-formatted files
 

--- a/tools/pre-commit
+++ b/tools/pre-commit
@@ -2,7 +2,7 @@
 
 # This pre-commit hook prevents us from creating commits that contains ill-formatted files
 
-VIOLATING_FILES=$(git clang-format --diff | grep "\-\-\- a/" | sed 's!\-\-\- a/!!')
+VIOLATING_FILES=$(git clang-format --staged --diff | grep "\-\-\- a/" | sed 's!\-\-\- a/!!')
 
 if [ "${VIOLATING_FILES}" ]; then
   echo "Commit violates formatting rules"
@@ -10,6 +10,6 @@ if [ "${VIOLATING_FILES}" ]; then
 	for i in ${VIOLATING_FILES}; do
 	  echo "   " $i
   done
-  echo "run 'git clang-format'"
+  echo "run 'git clang-format --staged'"
   exit 1
 fi


### PR DESCRIPTION
## What, How & Why?
Apply clang-format in pre-commit only for changes staged for commit ignoring changes not intended to be commited

## ☑️ ToDos
* ~~[ ] 📝 Changelog update~~
* ~~[ ] 🚦 Tests (or not relevant)~~
* ~~[ ] C-API, if public C++ API changed.~~
