### PR TITLE
Fix an error in client reset notifiers when using async open

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,8 +4,7 @@
 * The query engine now supports `geowithin` queries on points. Points are embedded objects conforming to the geoJSON format, trying to use a geospatial query on data in the incorrect format produces a run time exception. Example RQL query: `location geoWithin geoPolygon({{-178.0, 10.0}, {178.0, 10.0}, {178.0, -10.0}, {-178.0, -10.0}, {-178.0, 10.0}})`. For SDKs who do not wish to add this yet, the feature can be compiled out by adding `-DREALM_ENABLE_GEOSPATIAL=OFF` to the cmake config. ([#6562](https://github.com/realm/realm-core/issues/6562))
 
 ### Fixed
-* <How do the end-user experience this issue? what was the impact?> ([#????](https://github.com/realm/realm-core/issues/????), since v?.?.?)
-* None.
+* Fixed a fatal error (reported to the sync error handler) during client reset (or automatic PBS to FLX migration) if the reset has been triggered during an async open and the schema being applied has added new classes. ([#6601](https://github.com/realm/realm-core/issues/6601), since automatic client resets were introduced in v11.5.0)
 
 ### Breaking changes
 * None.

--- a/src/realm/object-store/sync/sync_session.cpp
+++ b/src/realm/object-store/sync/sync_session.cpp
@@ -883,12 +883,20 @@ static sync::Session::Config::ClientReset make_client_reset_config(RealmConfig s
 
     session_config.sync_config = std::make_shared<SyncConfig>(*session_config.sync_config); // deep copy
     session_config.scheduler = nullptr;
+    auto make_frozen_config = [](RealmConfig config) {
+        // Opening without using any explicit schema implies that we will use whatever is on disk without making any
+        // schema changes. Otherwise we may hit a schema error if we are in a client reset when opening a Realm that
+        // has additional tables in the schema config than the one on disk. This may happen in an async open.
+        config.schema.reset();
+        return config;
+    };
     if (session_config.sync_config->notify_after_client_reset) {
-        config.notify_after_client_reset = [config = session_config](VersionID previous_version, bool did_recover) {
+        config.notify_after_client_reset = [config = session_config, &make_frozen_config](VersionID previous_version,
+                                                                                          bool did_recover) {
             auto local_coordinator = RealmCoordinator::get_coordinator(config);
             REALM_ASSERT(local_coordinator);
             ThreadSafeReference active_after = local_coordinator->get_unbound_realm();
-            SharedRealm frozen_before = local_coordinator->get_realm(config, previous_version);
+            SharedRealm frozen_before = local_coordinator->get_realm(make_frozen_config(config), previous_version);
             REALM_ASSERT(frozen_before);
             REALM_ASSERT(frozen_before->is_frozen());
             config.sync_config->notify_after_client_reset(std::move(frozen_before), std::move(active_after),
@@ -896,8 +904,9 @@ static sync::Session::Config::ClientReset make_client_reset_config(RealmConfig s
         };
     }
     if (session_config.sync_config->notify_before_client_reset) {
-        config.notify_before_client_reset = [config = session_config](VersionID version) {
-            config.sync_config->notify_before_client_reset(Realm::get_frozen_realm(config, version));
+        config.notify_before_client_reset = [config = session_config, &make_frozen_config](VersionID version) {
+            config.sync_config->notify_before_client_reset(
+                Realm::get_frozen_realm(make_frozen_config(config), version));
         };
     }
 


### PR DESCRIPTION
There is a sequence of events where we tried to open a frozen Realm with new object types in the schema and this fails schema validation causing client reset to fail.

- Add a new class to the schema, but use async open to initiate sync without any schema.
- Have the server send a client reset.
- The client tries to populate the notify_before callback with a frozen Realm using the schema with the new class, but the class is not stored on disk yet. This hits the `update_schema()` check that makes sure that the frozen Realm's schema is a subset of the one found on disk. Since it is not, a schema exception is thrown which is eventually forwarded to the sync error handler and client reset fails.

This was discovered during PBS->FLX migration which uses client reset. In particular, when using async open on a new Realm (adding classes to an empty state), which initiates a client reset on the "empty" Realm (there is some metadata in the internal tables but no state or public classes yet). Noting that performing a client reset on an essentially empty Realm is inefficient, it should still work without causing any errors.

Fixes https://github.com/realm/realm-core/issues/6601
Thanks to @danieltabacaru for the reproduction case.

## ☑️ ToDos
* [x] 📝 Changelog update
* [x] 🚦 Tests (or not relevant)
* [x] C-API, if public C++ API changed.
