### PR TITLE
`bindgen`: Refactored formatter to take callbacks

### DIFF
--- a/bindgen/src/context.ts
+++ b/bindgen/src/context.ts
@@ -16,11 +16,11 @@
 //
 ////////////////////////////////////////////////////////////////////////////
 
-import { FormatterName } from "./formatter";
+import { Formatter } from "./formatter";
 import { Outputter } from "./outputter";
 import { Spec } from "./spec";
 
 export type TemplateContext = {
   spec: Spec;
-  file: (path: string, ...formatters: FormatterName[]) => Outputter;
+  file: (path: string, ...formatters: Formatter[]) => Outputter;
 };

--- a/bindgen/src/context.ts
+++ b/bindgen/src/context.ts
@@ -22,5 +22,12 @@ import { Spec } from "./spec";
 
 export type TemplateContext = {
   spec: Spec;
+  /**
+   * @param path The file path, relative to the output directory.
+   * @param formatters A list of formatters to run after the template has returned.
+   * The invocation of these are batched, such that a single formatter is only ever executed once but passed all file paths which list the formatter.
+   * NOTE: The order of invocation is the order in which formatters has been referenced globally not the order they're passed on the individual invocation of this method.
+   * @returns An outputter, which can be used to write to the file.
+   */
   file: (path: string, ...formatters: Formatter[]) => Outputter;
 };

--- a/bindgen/src/context.ts
+++ b/bindgen/src/context.ts
@@ -24,10 +24,9 @@ export type TemplateContext = {
   spec: Spec;
   /**
    * @param path The file path, relative to the output directory.
-   * @param formatters A list of formatters to run after the template has returned.
-   * The invocation of these are batched, such that a single formatter is only ever executed once but passed all file paths which list the formatter.
-   * NOTE: The order of invocation is the order in which formatters has been referenced globally not the order they're passed on the individual invocation of this method.
+   * @param formatter An optional formatter to run after the template has returned.
+   * The invocation is batched, such that a single formatter is only ever executed once but passed all file paths which use
    * @returns An outputter, which can be used to write to the file.
    */
-  file: (path: string, ...formatters: Formatter[]) => Outputter;
+  file: (path: string, formatter?: Formatter) => Outputter;
 };

--- a/bindgen/src/formatter.ts
+++ b/bindgen/src/formatter.ts
@@ -46,8 +46,6 @@ export function createCommandFormatter(formatterName: string, [command, ...args]
   return formatter;
 }
 
-export const clangFormatter = createCommandFormatter("clang", ["npx", "clang-format", "-i"]);
-
 export class FormatError extends Error {
   constructor(formatterName: string, filePaths: string[], cause: Error) {
     super(`Failure when running the '${formatterName}' formatter on ${JSON.stringify(filePaths)}: ${cause.message}`);
@@ -68,3 +66,5 @@ export function format(formatter: Formatter, cwd: string, filePaths: string[]): 
     }
   }
 }
+
+export const clangFormat = createCommandFormatter("clang", ["npx", "clang-format", "-i"]);

--- a/bindgen/src/formatter.ts
+++ b/bindgen/src/formatter.ts
@@ -22,17 +22,42 @@ import cp from "child_process";
 import { extend } from "./debug";
 const debug = extend("format");
 
-const FORMATTERS: Record<string, string[]> = {
-  eslint: ["npx", "eslint", "--fix", "--format=stylish"],
-  "clang-format": ["npx", "clang-format", "-i"],
+type Formatter = (cwd: string, filePaths: string[]) => void;
+
+export function executeCommand(cwd: string, command: string, ...args: string[]) {
+  console.log(chalk.dim(command, ...args));
+  const result = cp.spawnSync(command, args, {
+    cwd,
+    encoding: "utf8",
+    stdio: "inherit",
+    shell: true,
+  });
+  if (result.error) throw result.error;
+  if (result.status) {
+    throw new Error(`Exited with status ${result.status}`)
+  }
+}
+
+function createCommandFormatter(commandAndArgs: string[]): Formatter {
+  return (cwd, filePaths) => {
+    const [command, ...args] = [...commandAndArgs, ...filePaths];
+    executeCommand(cwd, command, ...args);
+  };
+}
+
+const FORMATTERS: Record<string, Formatter> = {
+  eslint: createCommandFormatter(["npx", "eslint", "--fix", "--format=stylish"]),
+  "clang-format": createCommandFormatter(["npx", "clang-format", "-i"]),
   // "typescript-checker": ["npx", "tsc", "--noEmit"],
 };
 
-export function addFormatter(name: string, commandAndArgs: string[]) {
+export function addFormatter(name: string, callbackOrCommandAndArgs: Formatter | string[]) {
   if (name in FORMATTERS) {
     throw new Error(`Cannot add ${name} as it's already there`);
+  } else if (Array.isArray(callbackOrCommandAndArgs)) {
+    FORMATTERS[name] = createCommandFormatter(callbackOrCommandAndArgs);
   } else {
-    FORMATTERS[name] = commandAndArgs;
+    FORMATTERS[name] = callbackOrCommandAndArgs;
   }
 }
 
@@ -43,8 +68,8 @@ export function getFormatterNames() {
 export type FormatterName = string;
 
 export class FormatError extends Error {
-  constructor(formatterName: string, filePaths: string[]) {
-    super(`Failure when running the '${formatterName}' formatter on ${JSON.stringify(filePaths)}`);
+  constructor(formatterName: string, filePaths: string[], cause: Error) {
+    super(`Failure when running the '${formatterName}' formatter on ${JSON.stringify(filePaths)}: ${cause.message}`);
   }
 }
 
@@ -55,17 +80,11 @@ export function format(formatterName: FormatterName, cwd: string, filePaths: str
   } else {
     debug(chalk.dim("Running formatter '%s' on %d files"), formatterName, filePaths.length);
     if (formatterName in FORMATTERS) {
-      const [command, ...args] = FORMATTERS[formatterName].concat(filePaths);
-      console.log(`Running '${formatterName}' formatter`, chalk.dim(command, ...args));
-      const result = cp.spawnSync(command, args, {
-        cwd,
-        encoding: "utf8",
-        stdio: "inherit",
-        shell: true,
-      });
-      if (result.error) throw result.error;
-      if (result.status) {
-        throw new FormatError(formatterName, filePaths);
+      console.log(`Running '${formatterName}' formatter`);
+      try {
+        FORMATTERS[formatterName](cwd, filePaths);
+      } catch (err) {
+        throw new FormatError(formatterName, filePaths, err instanceof Error ? err : new Error(String(err)));
       }
     }
   }

--- a/bindgen/src/output-directory.ts
+++ b/bindgen/src/output-directory.ts
@@ -31,7 +31,7 @@ type OutputFile = {
   fd: number;
   resolvedPath: string;
   debug: Debugger;
-  formatters: Formatter[];
+  formatter?: Formatter;
 };
 
 export type OutputDirectory = {
@@ -64,7 +64,7 @@ export function createOutputDirectory(outputPath: string): OutputDirectory {
   }
   const openFiles: OutputFile[] = [];
   return {
-    file(filePath: string, ...formatters: Formatter[]) {
+    file(filePath: string, formatter?: Formatter) {
       const resolvedPath = path.resolve(outputPath, filePath);
       const parentDirectoryPath = path.dirname(resolvedPath);
       if (!fs.existsSync(parentDirectoryPath)) {
@@ -75,9 +75,9 @@ export function createOutputDirectory(outputPath: string): OutputDirectory {
 
       fileDebug(chalk.dim("Opening", resolvedPath));
       const fd = fs.openSync(resolvedPath, "w");
-      openFiles.push({ fd, formatters, resolvedPath, debug: fileDebug });
+      openFiles.push({ fd, formatter, resolvedPath, debug: fileDebug });
 
-      for (const formatter of formatters) {
+      if (formatter) {
         usedFormatters.add(formatter);
       }
 
@@ -93,7 +93,7 @@ export function createOutputDirectory(outputPath: string): OutputDirectory {
     },
     format() {
       for (const formatter of usedFormatters) {
-        const relevantFiles = openFiles.filter((f) => f.formatters.includes(formatter)).map((f) => f.resolvedPath);
+        const relevantFiles = openFiles.filter((file) => file.formatter === formatter).map((f) => f.resolvedPath);
         format(formatter, outputPath, relevantFiles);
       }
     },

--- a/bindgen/src/output-directory.ts
+++ b/bindgen/src/output-directory.ts
@@ -23,7 +23,7 @@ import path from "path";
 
 import { extend } from "./debug";
 import { Outputter, createOutputter } from "./outputter";
-import { FormatterName, format, getFormatterNames } from "./formatter";
+import { format, Formatter } from "./formatter";
 
 const debug = extend("out");
 
@@ -31,7 +31,7 @@ type OutputFile = {
   fd: number;
   resolvedPath: string;
   debug: Debugger;
-  formatters: FormatterName[];
+  formatters: Formatter[];
 };
 
 export type OutputDirectory = {
@@ -40,7 +40,7 @@ export type OutputDirectory = {
    * @param formatter An optional formatter to apply after the file has been closed.
    * @returns An outputter, able to write into the file.
    */
-  file(filePath: string, ...formatters: FormatterName[]): Outputter;
+  file(filePath: string, ...formatters: Formatter[]): Outputter;
   /**
    * Close all files opened during the lifetime of the output directory.
    */
@@ -50,6 +50,8 @@ export type OutputDirectory = {
    */
   format(): void;
 };
+
+export const usedFormatters = new Set<Formatter>();
 
 /**
  * @param outputPath Path on disk, to the output directory.
@@ -62,7 +64,7 @@ export function createOutputDirectory(outputPath: string): OutputDirectory {
   }
   const openFiles: OutputFile[] = [];
   return {
-    file(filePath: string, ...formatters: FormatterName[]) {
+    file(filePath: string, ...formatters: Formatter[]) {
       const resolvedPath = path.resolve(outputPath, filePath);
       const parentDirectoryPath = path.dirname(resolvedPath);
       if (!fs.existsSync(parentDirectoryPath)) {
@@ -71,16 +73,13 @@ export function createOutputDirectory(outputPath: string): OutputDirectory {
       }
       const fileDebug = debug.extend(filePath);
 
-      // Check that all formatters are known
-      const knownFormatters = getFormatterNames();
-      const missingFormatters = formatters.filter((name) => !knownFormatters.includes(name));
-      if (missingFormatters.length > 0) {
-        throw new Error(`Unexpected formatter(s): ${missingFormatters}`);
-      }
-
       fileDebug(chalk.dim("Opening", resolvedPath));
       const fd = fs.openSync(resolvedPath, "w");
       openFiles.push({ fd, formatters, resolvedPath, debug: fileDebug });
+
+      for (const formatter of formatters) {
+        usedFormatters.add(formatter);
+      }
 
       return createOutputter((data) => {
         fs.writeFileSync(fd, data, { encoding: "utf8" });
@@ -93,9 +92,9 @@ export function createOutputDirectory(outputPath: string): OutputDirectory {
       }
     },
     format() {
-      for (const formatterName of getFormatterNames()) {
-        const relevantFiles = openFiles.filter((f) => f.formatters.includes(formatterName)).map((f) => f.resolvedPath);
-        format(formatterName, outputPath, relevantFiles);
+      for (const formatter of usedFormatters) {
+        const relevantFiles = openFiles.filter((f) => f.formatters.includes(formatter)).map((f) => f.resolvedPath);
+        format(formatter, outputPath, relevantFiles);
       }
     },
   };


### PR DESCRIPTION
## What, How & Why?

This change `file` to take a rest list of `formatter` functions instead of names of pre-registered callbacks.

## ☑️ ToDos
* [ ] 📝 Changelog update
* [ ] 🚦 Tests (or not relevant)
* [ ] C-API, if public C++ API changed.
