### PR TITLE
Assembly in S2 math is disabled on watchos simulator builds

### DIFF
--- a/src/external/s2/util/math/mathutil.h
+++ b/src/external/s2/util/math/mathutil.h
@@ -20,6 +20,8 @@ using std::vector;
 #include "s2/base/basictypes.h"
 #include "s2/base/logging.h"
 
+#include <realm/util/features.h>
+
 // Returns the sign of x:
 //   -1 if x < 0,
 //   +1 if x > 0,
@@ -379,7 +381,7 @@ class MathUtil {
     // is no advantage to passing an argument type of "float" on Intel
     // architectures anyway.
 
-#if defined __GNUC__ && (defined __i386__ || defined __SSE2__)
+#if defined __GNUC__ && (defined __i386__ || defined __SSE2__) && !(REALM_WATCHOS && !REALM_APPLE_DEVICE)
 #if defined __SSE2__
     // SSE2.
     int32 result;
@@ -404,7 +406,7 @@ class MathUtil {
   }
 
   static int64 FastInt64Round(double x) {
-#if defined __GNUC__ && (defined __i386__ || defined __x86_64__)
+#if defined __GNUC__ && (defined __i386__ || defined __x86_64__) && !(REALM_WATCHOS && !REALM_APPLE_DEVICE)
 #if defined __x86_64__
     // SSE2.
     int64 result;
@@ -688,7 +690,7 @@ class MathUtil {
 
 // ========================================================================= //
 
-#if (defined __i386__ || defined __x86_64__) && defined __GNUC__
+#if (defined __i386__ || defined __x86_64__) && defined __GNUC__ && !(REALM_WATCHOS && !REALM_APPLE_DEVICE)
 
 // We define template specializations of Round() to get the more efficient
 // Intel versions when possible.  Note that gcc does not currently support


### PR DESCRIPTION
A [recent](https://ci.realm.io/blue/organizations/jenkins/realm%2Frealm-core/detail/master/2359/pipeline/974/) nightly build failed with this error for watchos simulator:

```
/Users/realm/workspace/realm_realm-core_master/src/external/s2/util/math/mathutil.h:386:13: error: GNU-style inline assembly is disabled
    __asm__ __volatile__
            ^
/Users/realm/workspace/realm_realm-core_master/src/external/s2/util/math/mathutil.h:411:13: error: GNU-style inline assembly is disabled
    __asm__ __volatile__
            ^
```

This change uses the unoptimized version of the code if we are on a watchos simulator.