### PR TITLE
Bump protocol to v9 to indicate client has fix for client reset error during async open

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@
 ### Internals
 * Add initial support for targeting WebAssembly with Emscripten ([PR #6263](https://github.com/realm/realm-core/pull/6263)).
 * Sync session multiplexing is now enabled by default. The method `SyncManager::enable_session_multiplexing()` has been renamed `SyncManager::set_session_multiplexing()`. (PR [#6557](https://github.com/realm/realm-core/pull/6557))
+* Bump protocol to v9 to indicate client has fix for client reset error during async open ([#6609](https://github.com/realm/realm-core/issues/6609))
 
 ----------------------------------------------
 

--- a/src/realm/sync/protocol.hpp
+++ b/src/realm/sync/protocol.hpp
@@ -39,6 +39,10 @@ namespace sync {
 //     FLX sync BIND message can include JSON data in place of server path string
 //     Updated format for Sec-Websocket-Protocol strings
 //
+//   9 Client reset updated to not provide the local schema when creating frozen
+//     realms - this informs the server to not send the schema before sending the
+//     migrate to FLX server action
+//
 //  XX Changes:
 //     - TBD
 //
@@ -46,7 +50,7 @@ constexpr int get_current_protocol_version() noexcept
 {
     // Also update the current protocol version test in flx_sync.cpp when
     // updating this value
-    return 8;
+    return 9;
 }
 
 constexpr std::string_view get_pbs_websocket_protocol_prefix() noexcept

--- a/test/object-store/sync/flx_sync.cpp
+++ b/test/object-store/sync/flx_sync.cpp
@@ -1693,7 +1693,7 @@ TEST_CASE("flx: writes work without waiting for sync", "[sync][flx][app]") {
 TEST_CASE("flx: verify PBS/FLX websocket protocol number and prefixes", "[sync][flx]") {
     // Update the expected value whenever the protocol version is updated - this ensures
     // that the current protocol version does not change unexpectedly.
-    REQUIRE(8 == sync::get_current_protocol_version());
+    REQUIRE(9 == sync::get_current_protocol_version());
     // This was updated in Protocol V8 to use '#' instead of '/' to support the Web SDK
     REQUIRE("com.mongodb.realm-sync#" == sync::get_pbs_websocket_protocol_prefix());
     REQUIRE("com.mongodb.realm-query-sync#" == sync::get_flx_websocket_protocol_prefix());


### PR DESCRIPTION
## What, How & Why?
Bump the protocol version to 9 to indicate to the server that the client has the client reset fix when async opening a realm identified in #6601.

Fixes #6609

## ☑️ ToDos
* [x] 📝 Changelog update
* [X] 🚦 Tests (or not relevant)
* ~~[ ] C-API, if public C++ API changed.~~
