### PR TITLE
fix missing includes of cstdint surfaced by gcc13

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 
 ### Fixed
 * Fixed a fatal error (reported to the sync error handler) during client reset (or automatic PBS to FLX migration) if the reset has been triggered during an async open and the schema being applied has added new classes. ([#6601](https://github.com/realm/realm-core/issues/6601), since automatic client resets were introduced in v11.5.0)
+* Added missing includes of `<cstdint>` surfaced by gcc13 ([#6616](https://github.com/realm/realm-core/pull/6616))
 
 ### Breaking changes
 * None.

--- a/src/realm/error_codes.hpp
+++ b/src/realm/error_codes.hpp
@@ -18,6 +18,7 @@
 
 #pragma once
 
+#include <cstdint>
 #include <type_traits>
 #include <string>
 #include <vector>

--- a/src/realm/table_ref.hpp
+++ b/src/realm/table_ref.hpp
@@ -19,6 +19,7 @@
 #ifndef REALM_TABLE_REF_HPP
 #define REALM_TABLE_REF_HPP
 
+#include <cstdint>
 #include <cstddef>
 #include <ostream>
 namespace realm {

--- a/src/realm/util/to_string.hpp
+++ b/src/realm/util/to_string.hpp
@@ -19,6 +19,7 @@
 #ifndef REALM_UTIL_TO_STRING_HPP
 #define REALM_UTIL_TO_STRING_HPP
 
+#include <cstdint>
 #include <iosfwd>
 #include <ostream>
 #include <string>


### PR DESCRIPTION
## What, How & Why?

We still have some build failures in catch (which hopefully will be fixed by https://github.com/realm/realm-core/pull/6605), but they don't interfere with building the realm lib

## ☑️ ToDos
* [x] 📝 Changelog update
* ~~[ ] 🚦 Tests (or not relevant)~~
* ~~[ ] C-API, if public C++ API changed.~~
