### PR TITLE
POC deferred SubscriptionSet commit

### DIFF
--- a/src/realm/object-store/impl/realm_coordinator.cpp
+++ b/src/realm/object-store/impl/realm_coordinator.cpp
@@ -720,6 +720,12 @@ void RealmCoordinator::commit_write(Realm& realm, bool commit_to_disk)
     REALM_ASSERT(realm.is_in_transaction());
 
     Transaction& tr = Realm::Internal::get_transaction(realm);
+#if REALM_ENABLE_SYNC
+    if (m_sync_session) {
+        SyncSession::Internal::flush_subscription_changes(*m_sync_session, tr);
+    }
+#endif
+
     VersionID new_version;
     {
         // Need to acquire this lock before committing or another process could

--- a/src/realm/object-store/sync/sync_session.hpp
+++ b/src/realm/object-store/sync/sync_session.hpp
@@ -282,6 +282,11 @@ public:
             session.nonsync_transact_notify(version);
         }
 
+        static void flush_subscription_changes(SyncSession& session, Transaction& tr)
+        {
+            session.flush_subscription_changes(tr);
+        }
+
         static std::shared_ptr<DB> get_db(SyncSession& session)
         {
             return session.m_db;
@@ -396,6 +401,7 @@ private:
 
     void set_sync_transact_callback(std::function<TransactionCallback>&&) REQUIRES(!m_state_mutex);
     void nonsync_transact_notify(VersionID::version_type) REQUIRES(!m_state_mutex);
+    void flush_subscription_changes(Transaction&) REQUIRES(!m_state_mutex);
 
     void create_sync_session() REQUIRES(m_state_mutex, !m_config_mutex);
     void did_drop_external_reference()

--- a/src/realm/sync/client.cpp
+++ b/src/realm/sync/client.cpp
@@ -1697,6 +1697,7 @@ void SessionWrapper::on_download_completion()
     }
 
     if (m_flx_subscription_store && m_flx_pending_mark_version != SubscriptionSet::EmptyVersion) {
+        REALM_ASSERT_3(m_flx_pending_mark_version, ==, m_flx_active_version);
         m_sess->logger.debug("Marking query version %1 as complete after receiving MARK message",
                              m_flx_pending_mark_version);
         auto mutable_subs = m_flx_subscription_store->get_mutable_by_version(m_flx_pending_mark_version);

--- a/src/realm/sync/client.cpp
+++ b/src/realm/sync/client.cpp
@@ -1219,9 +1219,7 @@ void SessionWrapper::on_flx_sync_error(int64_t version, std::string_view err_msg
     auto mut_subs = store->get_mutable_by_version(version);
     mut_subs.update_state(SubscriptionSet::State::Error, err_msg);
     mut_subs.commit();
-    auto wt = m_db->start_write();
-    store->flush_changes(*wt);
-    wt->commit();
+    store->flush_changes();
 }
 
 void SessionWrapper::on_flx_sync_version_complete(int64_t version)
@@ -1272,9 +1270,7 @@ void SessionWrapper::on_flx_sync_progress(int64_t new_version, DownloadBatchStat
     auto mut_subs = store->get_mutable_by_version(new_version);
     mut_subs.update_state(new_state);
     mut_subs.commit();
-    auto tr = m_db->start_write();
-    store->flush_changes(*tr);
-    tr->commit();
+    store->flush_changes();
 }
 
 SubscriptionStore* SessionWrapper::get_flx_subscription_store()
@@ -1703,9 +1699,7 @@ void SessionWrapper::on_download_completion()
         auto mutable_subs = m_flx_subscription_store->get_mutable_by_version(m_flx_pending_mark_version);
         mutable_subs.update_state(SubscriptionSet::State::Complete);
         mutable_subs.commit();
-        auto wt = m_db->start_write();
-        m_flx_subscription_store->flush_changes(*wt);
-        wt->commit();
+        m_flx_subscription_store->flush_changes();
         m_flx_pending_mark_version = SubscriptionSet::EmptyVersion;
     }
 

--- a/src/realm/sync/noinst/client_reset_recovery.cpp
+++ b/src/realm/sync/noinst/client_reset_recovery.cpp
@@ -364,8 +364,7 @@ std::string ListPath::path_to_string(Transaction& remote, const InterningBuffer&
 
 RecoverLocalChangesetsHandler::RecoverLocalChangesetsHandler(Transaction& dest_wt,
                                                              Transaction& frozen_pre_local_state,
-                                                             util::Logger& logger,
-                                                             SubscriptionStore* sub_store)
+                                                             util::Logger& logger, SubscriptionStore* sub_store)
     : InstructionApplier(dest_wt)
     , m_frozen_pre_local_state{frozen_pre_local_state}
     , m_logger{logger}

--- a/src/realm/sync/noinst/client_reset_recovery.hpp
+++ b/src/realm/sync/noinst/client_reset_recovery.hpp
@@ -154,7 +154,8 @@ private:
 };
 
 struct RecoverLocalChangesetsHandler : public sync::InstructionApplier {
-    RecoverLocalChangesetsHandler(Transaction& dest_wt, Transaction& frozen_pre_local_state, util::Logger& logger, sync::SubscriptionStore* sub_store);
+    RecoverLocalChangesetsHandler(Transaction& dest_wt, Transaction& frozen_pre_local_state, util::Logger& logger,
+                                  sync::SubscriptionStore* sub_store);
     virtual ~RecoverLocalChangesetsHandler();
     void process_changesets(const std::vector<sync::ClientHistory::LocalChange>& changesets,
                             std::vector<sync::SubscriptionSet>&& pending_subs);

--- a/src/realm/sync/noinst/client_reset_recovery.hpp
+++ b/src/realm/sync/noinst/client_reset_recovery.hpp
@@ -154,7 +154,7 @@ private:
 };
 
 struct RecoverLocalChangesetsHandler : public sync::InstructionApplier {
-    RecoverLocalChangesetsHandler(Transaction& dest_wt, Transaction& frozen_pre_local_state, util::Logger& logger);
+    RecoverLocalChangesetsHandler(Transaction& dest_wt, Transaction& frozen_pre_local_state, util::Logger& logger, sync::SubscriptionStore* sub_store);
     virtual ~RecoverLocalChangesetsHandler();
     void process_changesets(const std::vector<sync::ClientHistory::LocalChange>& changesets,
                             std::vector<sync::SubscriptionSet>&& pending_subs);
@@ -212,6 +212,8 @@ private:
     // Track any recovered operations on lists to make sure that they are allowed.
     // If not, the lists here will be copied verbatim from the local state to the remote.
     util::FlatMap<ListPath, ListTracker> m_lists;
+
+    sync::SubscriptionStore* m_sub_store;
 };
 
 } // namespace realm::_impl::client_reset

--- a/src/realm/sync/noinst/migration_store.cpp
+++ b/src/realm/sync/noinst/migration_store.cpp
@@ -304,7 +304,7 @@ Subscription MigrationStore::make_subscription(const std::string& object_class_n
     return Subscription{subscription_name, object_class_name, rql_query_string};
 }
 
-void MigrationStore::create_subscriptions(const SubscriptionStore& subs_store)
+void MigrationStore::create_subscriptions(SubscriptionStore& subs_store)
 {
     std::unique_lock lock{m_mutex};
     if (m_state != MigrationState::Migrated) {
@@ -315,7 +315,7 @@ void MigrationStore::create_subscriptions(const SubscriptionStore& subs_store)
     create_subscriptions(subs_store, *m_query_string);
 }
 
-void MigrationStore::create_subscriptions(const SubscriptionStore& subs_store, const std::string& rql_query_string)
+void MigrationStore::create_subscriptions(SubscriptionStore& subs_store, const std::string& rql_query_string)
 {
     if (rql_query_string.empty()) {
         return;
@@ -354,7 +354,7 @@ void MigrationStore::create_subscriptions(const SubscriptionStore& subs_store, c
     mut_sub.commit();
 }
 
-void MigrationStore::create_sentinel_subscription_set(const SubscriptionStore& subs_store)
+void MigrationStore::create_sentinel_subscription_set(SubscriptionStore& subs_store)
 {
     std::lock_guard lock{m_mutex};
     if (m_state != MigrationState::Migrated) {

--- a/src/realm/sync/noinst/migration_store.hpp
+++ b/src/realm/sync/noinst/migration_store.hpp
@@ -78,13 +78,13 @@ public:
 
     // Create subscriptions for each table that does not have a subscription.
     // If subscriptions are created, they are commited and a change of query is sent to the server.
-    void create_subscriptions(const SubscriptionStore& subs_store);
-    void create_subscriptions(const SubscriptionStore& subs_store, const std::string& rql_query_string);
+    void create_subscriptions(SubscriptionStore& subs_store);
+    void create_subscriptions(SubscriptionStore& subs_store, const std::string& rql_query_string);
 
     // Create a subscription set used as sentinel. No-op if not in 'Migrated' state.
     // This method is idempotent (i.e, at most one subscription set can be createad during the lifetime of a
     // migration)
-    void create_sentinel_subscription_set(const SubscriptionStore& subs_store);
+    void create_sentinel_subscription_set(SubscriptionStore& subs_store);
     std::optional<int64_t> get_sentinel_subscription_set_version();
 
 protected:

--- a/src/realm/sync/subscriptions.cpp
+++ b/src/realm/sync/subscriptions.cpp
@@ -974,7 +974,7 @@ bool SubscriptionStore::flush_changes_impl(Transaction& tr, CommitMode commit_mo
     }
     supercede_prior_to(tr, m_min_outstanding_version);
 
-    switch(commit_mode) {
+    switch (commit_mode) {
         case CommitMode::Commit:
             tr.commit();
             break;

--- a/src/realm/sync/subscriptions.hpp
+++ b/src/realm/sync/subscriptions.hpp
@@ -362,7 +362,7 @@ public:
 
     struct PendingSubscription {
         int64_t query_version;
-        std::optional<DB::version_type> snapshot_version;
+        DB::version_type snapshot_version;
     };
 
     util::Optional<PendingSubscription> get_next_pending_version(int64_t last_query_version,
@@ -379,6 +379,10 @@ public:
     // with the subscription store.
     void terminate();
 
+    // Applies any changes to mutable subscription sets to the supplied transaction - if the transaction
+    // is not a write transaction then it will be promoted to write and committed within this function.
+    //
+    // Returns false if there were no changes to flush.
     bool flush_changes(Transaction& tr);
 
 private:
@@ -388,7 +392,7 @@ private:
 protected:
     friend class MutableSubscriptionSet;
     friend struct OutstandingMutableGuard;
-    void store_mutable_subscription_set(const MutableSubscriptionSet& mut_sub_set);
+    void cache_mutable_subscription_set(const MutableSubscriptionSet& mut_sub_set);
     void release_outstanding_mutable_sub_set();
     void process_notifications_for(const SubscriptionSet& mut_sub_set);
 

--- a/src/realm/sync/subscriptions.hpp
+++ b/src/realm/sync/subscriptions.hpp
@@ -384,6 +384,7 @@ public:
     //
     // Returns false if there were no changes to flush.
     bool flush_changes(Transaction& tr);
+    bool flush_changes();
 
 private:
     using std::enable_shared_from_this<SubscriptionStore>::weak_from_this;
@@ -421,6 +422,8 @@ protected:
                                         std::optional<TransactionRef> opt_tr);
     util::Optional<PendingSubscription> get_next_pending_version_from_db(int64_t last_query_version,
                                                                          DB::version_type after_client_version);
+    enum class CommitMode { NoCommit, ContinueAsRead, Commit };
+    bool flush_changes_impl(Transaction&, CommitMode mode);
 
     // Ensure the subscriptions table is properly initialized
     // If clear_table is true, the subscriptions table will be cleared before initialization

--- a/src/realm/sync/subscriptions.hpp
+++ b/src/realm/sync/subscriptions.hpp
@@ -379,7 +379,7 @@ public:
     // with the subscription store.
     void terminate();
 
-    void flush_changes(Transaction& tr);
+    bool flush_changes(Transaction& tr);
 
 private:
     using std::enable_shared_from_this<SubscriptionStore>::weak_from_this;

--- a/src/realm/util/scope_exit.hpp
+++ b/src/realm/util/scope_exit.hpp
@@ -52,6 +52,11 @@ public:
             (*m_handler)();
     }
 
+    void release() noexcept
+    {
+        m_handler = none;
+    }
+
     static_assert(noexcept(std::declval<H>()()), "Handler must be nothrow executable");
     static_assert(std::is_nothrow_destructible<H>::value, "Handler must be nothrow destructible");
 

--- a/test/object-store/sync/flx_sync.cpp
+++ b/test/object-store/sync/flx_sync.cpp
@@ -141,7 +141,6 @@ TEST_CASE("flx: connect to FLX-enabled app", "[sync][flx][app]") {
                                         {"non_queryable_field", "non queryable 2"s}}));
     });
 
-
     harness.do_with_new_realm([&](SharedRealm realm) {
         wait_for_download(*realm);
         {
@@ -1382,7 +1381,7 @@ TEST_CASE("flx: interrupted bootstrap restarts/recovers on reconnect", "[sync][f
         DBOptions options;
         options.encryption_key = test_util::crypt_key();
         auto realm = DB::create(sync::make_client_replication(), interrupted_realm_config.path, options);
-        auto sub_store = sync::SubscriptionStore::create(realm, [](int64_t) {});
+        auto sub_store = sync::SubscriptionStore::create(realm, util::Logger::get_default_logger(), [](int64_t) {});
         auto version_info = sub_store->get_version_info();
         REQUIRE(version_info.active == 0);
         REQUIRE(version_info.latest == 1);
@@ -1861,7 +1860,7 @@ TEST_CASE("flx: bootstrap batching prevents orphan documents", "[sync][flx][app]
         REQUIRE(top_level);
         REQUIRE(top_level->is_empty());
 
-        auto sub_store = sync::SubscriptionStore::create(realm, [](int64_t) {});
+        auto sub_store = sync::SubscriptionStore::create(realm, util::Logger::get_default_logger(), [](int64_t) {});
         auto version_info = sub_store->get_version_info();
         REQUIRE(version_info.latest == 1);
         REQUIRE(version_info.active == 0);
@@ -2390,10 +2389,8 @@ TEST_CASE("flx: asymmetric sync - dev mode", "[sync][flx][app]") {
 
             CppContext c(realm);
             realm->begin_transaction();
-            Object::create(c, realm, "Asymmetric",
-                           std::any(AnyDict{{"_id", foo_obj_id}, {"location", "foo"s}}));
-            Object::create(c, realm, "Asymmetric",
-                           std::any(AnyDict{{"_id", bar_obj_id}, {"location", "bar"s}}));
+            Object::create(c, realm, "Asymmetric", std::any(AnyDict{{"_id", foo_obj_id}, {"location", "foo"s}}));
+            Object::create(c, realm, "Asymmetric", std::any(AnyDict{{"_id", bar_obj_id}, {"location", "bar"s}}));
             realm->commit_transaction();
 
             wait_for_upload(*realm);

--- a/test/object-store/sync/migration_store_test.cpp
+++ b/test/object-store/sync/migration_store_test.cpp
@@ -176,7 +176,7 @@ TEST_CASE("Migration store", "[flx][migration]") {
     }
 
     SECTION("Migration store subscriptions", "[flx][migration]") {
-        auto sub_store = sync::SubscriptionStore::create(mig_db, [](int64_t) {});
+        auto sub_store = sync::SubscriptionStore::create(mig_db, util::Logger::get_default_logger(), [](int64_t) {});
         auto orig_version = sub_store->get_latest().version();
 
         // Create some dummy tables

--- a/test/test_sync_subscriptions.cpp
+++ b/test/test_sync_subscriptions.cpp
@@ -514,12 +514,12 @@ TEST(Sync_SubscriptionStoreNextPendingVersion)
     auto pending_version = store->get_next_pending_version(0, DB::version_type{});
     CHECK(pending_version);
     CHECK_EQUAL(pending_version->query_version, bootstrapping_set);
-    CHECK_NOT(pending_version->snapshot_version);
+    CHECK_EQUAL(pending_version->snapshot_version, std::numeric_limits<DB::version_type>::max());
 
     pending_version = store->get_next_pending_version(bootstrapping_set, DB::version_type{});
     CHECK(pending_set);
     CHECK_EQUAL(pending_version->query_version, pending_set);
-    CHECK_NOT(pending_version->snapshot_version);
+    CHECK_EQUAL(pending_version->snapshot_version, std::numeric_limits<DB::version_type>::max());
 
     pending_version = store->get_next_pending_version(pending_set, DB::version_type{});
     CHECK(!pending_version);


### PR DESCRIPTION
## What, How & Why?
This is a prototype of making it so that MutableSubscriptionSets are no longer tied directly to database writes. Instead calling `MutableSubscriptionSet::commit()` caches the subscription set in memory until `SubscriptionStore::flush_changes()` is called. The sync client flushes changes whenever it updates the state of a subscription set in response to receiving a `DOWNLOAD` or `QUERY_ERROR` message. The `RealmCoordinator` also flushes any changes to the `SubscriptionStore` as part of committing a user write. The goal of the PR is that updating your list of subscriptions no longer has to be coupled to the lifetime of write transactions in the database. The only rule that is relaxed by this PR is that if you update your subscriptions, don't do any subsequent user writes, and the app restarts before any changesets for the subscription are received from the server, the subscription change won't be recorded and when you restart the app you'll have to re-create your subscription changes.

## ☑️ ToDos
* [ ] 📝 Changelog update
* [ ] 🚦 Tests (or not relevant)
* [ ] C-API, if public C++ API changed.
