### PR TITLE
Fix some warnings

### DIFF
--- a/src/external/IntelRDFPMathLib20U2/LIBRARY/src/bid128_string.c
+++ b/src/external/IntelRDFPMathLib20U2/LIBRARY/src/bid128_string.c
@@ -213,7 +213,11 @@ bid128_to_string (char *str, BID_UINT128 x
 	__L1_Split_MiDi_6_Lead (HI_18Dig, ptr);
 	__L1_Split_MiDi_6 (LO_18Dig, ptr);
       }
-      len = ptr - MiDi;
+
+      // Realm edit: silence warning about lengths by casting
+      // this should not be a problem under the assumption that
+      // we are working with strings with reasonable lengths
+      len = (int)(ptr - MiDi);
       c_ptr_start = &(str[k]);
       c_ptr = c_ptr_start;
 
@@ -222,7 +226,10 @@ bid128_to_string (char *str, BID_UINT128 x
       for (k_lcv = 1; k_lcv < len; k_lcv++) {
 	__L0_MiDi2Str (MiDi[k_lcv], c_ptr);
       }
-      k = k + (c_ptr - c_ptr_start);
+
+      // Realm edit: explicit cast to silence warning
+      // assumes working with strings of reasonable length
+      k = k + (unsigned int)(c_ptr - c_ptr_start);
     }
 
     // print E and sign of exponent

--- a/src/external/s2/base/casts.h
+++ b/src/external/s2/base/casts.h
@@ -161,7 +161,7 @@ template <class Dest, class Source>
 inline Dest bit_cast(const Source& source) {
   // Compile time assertion: sizeof(Dest) == sizeof(Source)
   // A compile error here means your Dest and Source have different sizes.
-  typedef char VerifySizesAreEqual [sizeof(Dest) == sizeof(Source) ? 1 : -1];
+  COMPILE_ASSERT(sizeof(Dest) == sizeof(Source), different_sizes);
 
   Dest dest;
   memcpy(&dest, &source, sizeof(dest));

--- a/src/external/s2/base/logging.h
+++ b/src/external/s2/base/logging.h
@@ -38,7 +38,7 @@
 #define DCHECK_GE(val1, val2) REALM_ASSERT_DEBUG_EX(val1 >= val2, val1, val2)
 #define DCHECK_GT(val1, val2) REALM_ASSERT_DEBUG_EX(val1 > val2, val1, val2)
 
-static std::shared_ptr<realm::util::Logger>& s2_logger()
+static inline std::shared_ptr<realm::util::Logger>& s2_logger()
 {
     return realm::util::Logger::get_default_logger();
 }

--- a/src/external/s2/base/macros.h
+++ b/src/external/s2/base/macros.h
@@ -22,69 +22,8 @@
 #define ABSTRACT = 0
 #endif
 
-// The COMPILE_ASSERT macro can be used to verify that a compile time
-// expression is true. For example, you could use it to verify the
-// size of a static array:
-//
-//   COMPILE_ASSERT(ARRAYSIZE(content_type_names) == CONTENT_NUM_TYPES,
-//                  content_type_names_incorrect_size);
-//
-// or to make sure a struct is smaller than a certain size:
-//
-//   COMPILE_ASSERT(sizeof(foo) < 128, foo_too_large);
-//
-// The second argument to the macro is the name of the variable. If
-// the expression is false, most compilers will issue a warning/error
-// containing the name of the variable.
-
-template <bool>
-struct CompileAssert {
-};
-
 #define COMPILE_ASSERT(expr, msg) \
-  typedef CompileAssert<(bool(expr))> msg[bool(expr) ? 1 : -1]
-
-// Implementation details of COMPILE_ASSERT:
-//
-// - COMPILE_ASSERT works by defining an array type that has -1
-//   elements (and thus is invalid) when the expression is false.
-//
-// - The simpler definition
-//
-//     #define COMPILE_ASSERT(expr, msg) typedef char msg[(expr) ? 1 : -1]
-//
-//   does not work, as gcc supports variable-length arrays whose sizes
-//   are determined at run-time (this is gcc's extension and not part
-//   of the C++ standard).  As a result, gcc fails to reject the
-//   following code with the simple definition:
-//
-//     int foo;
-//     COMPILE_ASSERT(foo, msg); // not supposed to compile as foo is
-//                               // not a compile-time constant.
-//
-// - By using the type CompileAssert<(bool(expr))>, we ensures that
-//   expr is a compile-time constant.  (Template arguments must be
-//   determined at compile-time.)
-//
-// - The outter parentheses in CompileAssert<(bool(expr))> are necessary
-//   to work around a bug in gcc 3.4.4 and 4.0.1.  If we had written
-//
-//     CompileAssert<bool(expr)>
-//
-//   instead, these compilers will refuse to compile
-//
-//     COMPILE_ASSERT(5 > 0, some_message);
-//
-//   (They seem to think the ">" in "5 > 0" marks the end of the
-//   template argument list.)
-//
-// - The array size is (bool(expr) ? 1 : -1), instead of simply
-//
-//     ((expr) ? 1 : -1).
-//
-//   This is to avoid running into a bug in MS VC 7.1, which
-//   causes ((0.0) ? 1 : -1) to incorrectly evaluate to 1.
-
+    static_assert(expr, #msg)
 
 // A macro to disallow the copy constructor and operator= functions
 // This should be used in the private: declarations for a class

--- a/test/test_query_geo.cpp
+++ b/test/test_query_geo.cpp
@@ -19,9 +19,11 @@
 #include "testsettings.hpp"
 #ifdef TEST_GEO
 
-#include "test.hpp"
-
 #include "s2/util/math/mathutil.h"
+// conflicting defines of CHECK from s2
+#undef CHECK
+
+#include "test.hpp"
 
 #include <realm/geospatial.hpp>
 #include <realm/group.hpp>


### PR DESCRIPTION
Some warnings snuck into our builds.
The S2 warnings came in through https://github.com/realm/realm-core/pull/6477 which included some new S2 headers in our tests.

I've seen the Decimal128 warnings for a while and have been ignoring them.