### PR TITLE
Support Bindgen opt-in list

### DIFF
--- a/bindgen/CMakeLists.txt
+++ b/bindgen/CMakeLists.txt
@@ -34,7 +34,7 @@ set_property(TARGET BindgenSpecJsonSchema PROPERTY NPX "${NPX}")
 
 function(bindgen)
     set(options)
-    set(oneValueArgs TEMPLATE OUTDIR)
+    set(oneValueArgs TEMPLATE OUTDIR OPTIN)
     set(multiValueArgs OUTPUTS SPECS SOURCES)
     cmake_parse_arguments(PARSE_ARGV 0 BINDGEN "${options}" "${oneValueArgs}" "${multiValueArgs}")
 
@@ -64,6 +64,7 @@ function(bindgen)
         WORKING_DIRECTORY ${CMAKE_CURRENT_FUNCTION_LIST_DIR}
         COMMAND ${NPX} tsx -- "${CMAKE_CURRENT_FUNCTION_LIST_DIR}/realm-bindgen.ts"
             --spec "$<JOIN:${CORE_SPEC_FILE};${BINDGEN_SPECS},;--spec;>"
+            "$<$<BOOL:${BINDGEN_OPTIN}>:--opt-in;${BINDGEN_OPTIN}>"
             --template "${BINDGEN_TEMPLATE}"
             --output "${BINDGEN_OUTDIR}"
         COMMAND_EXPAND_LISTS
@@ -78,6 +79,7 @@ function(bindgen)
             # from sdk
             ${BINDGEN_SPECS}
             ${BINDGEN_SOURCES}
+            ${BINDGEN_OPTIN}
     )
 
     foreach(FILE ${BINDGEN_OUTPUTS})

--- a/bindgen/CMakeLists.txt
+++ b/bindgen/CMakeLists.txt
@@ -25,17 +25,7 @@ add_custom_command(
         # (Right now there are no imports)
 )
 
-set(OPT_IN_SCHEMA_FILE ${CMAKE_CURRENT_SOURCE_DIR}/generated/opt-in-spec.schema.json)
-add_custom_command(
-    OUTPUT ${OPT_IN_SCHEMA_FILE}
-    WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
-    COMMAND ${NPX} typescript-json-schema ${CMAKE_CURRENT_SOURCE_DIR}/tsconfig.json OptInSpec --include ${CMAKE_CURRENT_SOURCE_DIR}/src/spec/model.ts --out ${OPT_IN_SCHEMA_FILE} --required --noExtraProps
-    VERBATIM
-    MAIN_DEPENDENCY src/spec/model.ts
-    DEPENDS
-)
-
-add_custom_target(BindgenSpecJsonSchema DEPENDS ${SCHEMA_FILE} ${OPT_IN_SCHEMA_FILE})
+add_custom_target(BindgenSpecJsonSchema DEPENDS ${SCHEMA_FILE})
 
 # Stash these variables as properties so they can be read from the bindgen() function.
 # Using the BindgenSpecJsonSchema target for scoping, not because it actually has anything to do with that.

--- a/bindgen/CMakeLists.txt
+++ b/bindgen/CMakeLists.txt
@@ -25,7 +25,17 @@ add_custom_command(
         # (Right now there are no imports)
 )
 
-add_custom_target(BindgenSpecJsonSchema DEPENDS ${SCHEMA_FILE})
+set(OPT_IN_SCHEMA_FILE ${CMAKE_CURRENT_SOURCE_DIR}/generated/opt-in-spec.schema.json)
+add_custom_command(
+    OUTPUT ${OPT_IN_SCHEMA_FILE}
+    WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
+    COMMAND ${NPX} typescript-json-schema ${CMAKE_CURRENT_SOURCE_DIR}/tsconfig.json OptInSpec --include ${CMAKE_CURRENT_SOURCE_DIR}/src/spec/model.ts --out ${OPT_IN_SCHEMA_FILE} --required --noExtraProps
+    VERBATIM
+    MAIN_DEPENDENCY src/spec/model.ts
+    DEPENDS
+)
+
+add_custom_target(BindgenSpecJsonSchema DEPENDS ${SCHEMA_FILE} ${OPT_IN_SCHEMA_FILE})
 
 # Stash these variables as properties so they can be read from the bindgen() function.
 # Using the BindgenSpecJsonSchema target for scoping, not because it actually has anything to do with that.

--- a/bindgen/src/bound-model.ts
+++ b/bindgen/src/bound-model.ts
@@ -341,7 +341,11 @@ export class Class extends NamedType {
   needsDeref = false;
   iterable?: Type;
 
-  get methods(): Readonly<Method[]> {
+  /**
+   * Get a new array containing the methods.
+   * For adding a method onto `this` instance, use `addMethod`.
+   */
+  get methods() {
     return Object.values(this._methods);
   }
 
@@ -403,7 +407,11 @@ export class Struct extends NamedType {
   cppName!: string;
   private _fields: { [name: string]: Field } = {};
 
-  get fields(): Readonly<Field[]> {
+  /**
+   * Get a new array containing the fields.
+   * For adding a field onto `this` instance, use `addField`.
+   */
+  get fields() {
     return Object.values(this._fields);
   }
 

--- a/bindgen/src/bound-model.ts
+++ b/bindgen/src/bound-model.ts
@@ -347,7 +347,7 @@ export class Class extends NamedType {
 
   /**
    * Get a new array containing the methods.
-   * For adding a method onto `this` instance, use `addMethod`.
+   * For adding a method onto `this` instance, use `addMethod()`.
    */
   get methods() {
     return Object.values(this._methods);
@@ -395,7 +395,11 @@ export class Class extends NamedType {
 }
 
 export class Field {
-  /** Whether this field is opted in to by the consumer/SDK. */
+  /**
+   * Whether this field is opted in to by the consumer/SDK.
+   * For this to be true you must pass an opt-in list to the
+   * binding generator and call `BoundSpec.applyOptInList()`.
+   */
   isOptedInTo = false;
   constructor(
     public name: string,
@@ -413,7 +417,7 @@ export class Struct extends NamedType {
 
   /**
    * Get a new array containing the fields.
-   * For adding a field onto `this` instance, use `addField`.
+   * For adding a field onto `this` instance, use `addField()`.
    */
   get fields() {
     return Object.values(this._fields);

--- a/bindgen/src/bound-model.ts
+++ b/bindgen/src/bound-model.ts
@@ -17,7 +17,7 @@
 ////////////////////////////////////////////////////////////////////////////
 import { strict as assert } from "assert";
 
-import { Spec, TypeSpec, MethodSpec } from "./spec";
+import { OptInSpec, Spec, TypeSpec, MethodSpec } from "./spec";
 
 abstract class TypeBase {
   abstract readonly kind: TypeKind;
@@ -29,31 +29,31 @@ abstract class TypeBase {
 
   // This is mostly because TS doesn't know that Type covers all types derived from TypeBase.
   is<Kind extends TypeKind>(kind: Kind): this is Type & { kind: Kind } {
-    return this.kind == kind;
+    return this.kind === kind;
   }
 
   isOptional(): this is Template & { name: "util::Optional" };
   isOptional(type: string): boolean;
   isOptional(type?: string): boolean {
-    return this.isTemplate("util::Optional") && (!type || ("name" in this.args[0] && this.args[0].name == type));
+    return this.isTemplate("util::Optional") && (!type || ("name" in this.args[0] && this.args[0].name === type));
   }
 
   isNullable(): this is Template & { name: "Nullable" };
   isNullable(type: string): boolean;
   isNullable(type?: string): boolean {
-    return this.isTemplate("Nullable") && (!type || ("name" in this.args[0] && this.args[0].name == type));
+    return this.isTemplate("Nullable") && (!type || ("name" in this.args[0] && this.args[0].name === type));
   }
 
   isTemplate(): this is Template;
   isTemplate<Name extends string>(type: Name): this is Template & { name: Name };
   isTemplate(type?: string): boolean {
-    return this.is("Template") && (!type || this.name == type);
+    return this.is("Template") && (!type || this.name === type);
   }
 
   isPrimitive(): this is Primitive;
   isPrimitive<Name extends string>(type: Name): this is Primitive & { name: Name };
   isPrimitive(type?: string): boolean {
-    return this.is("Primitive") && (!type || this.name == type);
+    return this.is("Primitive") && (!type || this.name === type);
   }
 
   isVoid(): this is Primitive & { name: "void" } {
@@ -172,7 +172,7 @@ export class Func extends TypeBase {
   asyncTransform(): Func | undefined {
     if (!this.ret.isVoid()) return undefined;
     const voidType = this.ret;
-    if (this.args.length == 0) return undefined;
+    if (this.args.length === 0) return undefined;
     const lastArgType = this.args[this.args.length - 1].type.removeConstRef();
     if (!lastArgType.isTemplate("AsyncCallback")) return undefined;
 
@@ -196,7 +196,7 @@ export class Func extends TypeBase {
         `but got ${lastCbArgType}`,
     );
     let res: Type = voidType;
-    if (cb.args.length == 2) {
+    if (cb.args.length === 2) {
       res = cb.args[0].type.removeConstRef();
       if (res.isOptional() || res.isNullable()) {
         res = res.args[0];
@@ -263,6 +263,8 @@ export type MethodCallSig = ({ self }: { self: string }, ...args: string[]) => s
 
 export abstract class Method {
   isConstructor = false;
+  /** Whether this method is opted in to by the consumer/SDK. */
+  isOptedInTo = false;
   abstract isStatic: boolean;
   constructor(
     public on: Class,
@@ -334,10 +336,29 @@ export class Class extends NamedType {
   abstract = false;
   base?: Class;
   subclasses: Class[] = [];
-  methods: Method[] = [];
+  private _methods: { [uniqueName: string]: Method } = {};
   sharedPtrWrapped = false;
   needsDeref = false;
   iterable?: Type;
+
+  get methods(): Readonly<Method[]> {
+    return Object.values(this._methods);
+  }
+
+  addMethod(method: Method) {
+    assert(
+      !(method.unique_name in this._methods),
+      `Duplicate unique method name on class '${this.name}': '${method.unique_name}'`,
+    );
+    this._methods[method.unique_name] = method;
+  }
+
+  getMethod(uniqueName: string) {
+    const method = this._methods[uniqueName];
+    assert(method, `Method '${uniqueName}' does not exist on class '${this.name}'.`);
+
+    return method;
+  }
 
   toString() {
     return `class ${this.name}`;
@@ -356,16 +377,18 @@ export class Class extends NamedType {
     return cls;
   }
 
-  *decedents(): Iterable<Class> {
+  *descendants(): Iterable<Class> {
     for (const sub of this.subclasses) {
       assert.notEqual(sub, this, `base class loop detected on ${this.name}`);
       yield sub;
-      yield* sub.decedents();
+      yield* sub.descendants();
     }
   }
 }
 
 export class Field {
+  /** Whether this field is opted in to by the consumer/SDK. */
+  isOptedInTo = false;
   constructor(
     public name: string,
     public cppName: string,
@@ -378,7 +401,23 @@ export class Field {
 export class Struct extends NamedType {
   readonly kind = "Struct";
   cppName!: string;
-  fields: Field[] = [];
+  private _fields: { [name: string]: Field } = {};
+
+  get fields(): Readonly<Field[]> {
+    return Object.values(this._fields);
+  }
+
+  addField(field: Field) {
+    assert(!(field.name in this._fields), `Duplicate field name on record/struct '${this.name}': '${field.name}'.`);
+    this._fields[field.name] = field;
+  }
+
+  getField(name: string) {
+    const field = this._fields[name];
+    assert(field, `Field '${name}' does not exist on record/struct '${this.name}'.`);
+
+    return field;
+  }
 
   toString() {
     return `struct ${this.name}`;
@@ -485,7 +524,7 @@ type MixedInfo = {
   ctors: Type[];
 };
 
-export function bindModel(spec: Spec): BoundSpec {
+export function bindModel(spec: Spec, optInSpec?: OptInSpec): BoundSpec {
   const templates: Map<string, Spec["templates"][string]> = new Map();
   const rootClasses: Class[] = [];
 
@@ -493,7 +532,7 @@ export function bindModel(spec: Spec): BoundSpec {
 
   function addType<T extends Type>(name: string, type: T | (new (name: string) => T)) {
     assert(!(name in out.types));
-    if (typeof type == "function") type = new type(name);
+    if (typeof type === "function") type = new type(name);
 
     out.types[name] = type;
     return type;
@@ -548,7 +587,7 @@ export function bindModel(spec: Spec): BoundSpec {
   ) {
     for (const [name, overloads] of Object.entries(methods)) {
       for (const overload of overloads) {
-        on.methods.push(
+        on.addMethod(
           new OutType(
             on,
             name,
@@ -561,7 +600,7 @@ export function bindModel(spec: Spec): BoundSpec {
     }
   }
 
-  // Attach names to instences of Type in types
+  // Attach names to instances of Type in types
   for (const [name, args] of Object.entries(spec.templates)) {
     templates.set(name, args);
   }
@@ -606,12 +645,12 @@ export function bindModel(spec: Spec): BoundSpec {
   for (const [name, { cppName, fields }] of Object.entries(spec.records)) {
     const struct = out.types[name] as Struct;
     struct.cppName = cppName ?? name;
-    struct.fields = Object.entries(fields).map(([name, field]) => {
+    for (const [name, field] of Object.entries(fields)) {
       const type = resolveTypes(field.type);
       // Optional and Nullable fields are never required.
       const required = field.default === undefined && !(type.isNullable() || type.isOptional());
-      return new Field(name, field.cppName ?? name, type, required, field.default);
-    });
+      struct.addField(new Field(name, field.cppName ?? name, type, required, field.default));
+    }
   }
 
   for (const [name, type] of Object.entries(spec.keyTypes)) {
@@ -642,23 +681,24 @@ export function bindModel(spec: Spec): BoundSpec {
 
     // Constructors are exported to js as named static methods. The "real" js constructors
     // are only used internally for attaching the C++ instance to a JS object.
-    cls.methods.push(
-      ...Object.entries(raw.constructors).flatMap(([name, rawSig]) => {
-        const sig = resolveTypes(rawSig);
-        // Constructors implicitly return the type of the class.
-        assert(sig.kind == "Func" && sig.ret.isVoid());
-        sig.ret = cls.sharedPtrWrapped ? new Template("std::shared_ptr", [cls]) : cls;
-        return new Constructor(cls, name, sig);
-      }),
-    );
+    const constructors = Object.entries(raw.constructors).flatMap(([name, rawSig]) => {
+      const sig = resolveTypes(rawSig);
+      // Constructors implicitly return the type of the class.
+      assert(sig.kind === "Func" && sig.ret.isVoid());
+      sig.ret = cls.sharedPtrWrapped ? new Template("std::shared_ptr", [cls]) : cls;
+      return new Constructor(cls, name, sig);
+    });
+    for (const constructor of constructors) {
+      cls.addMethod(constructor);
+    }
 
     for (const [name, type] of Object.entries(raw.properties ?? {})) {
-      cls.methods.push(new Property(cls, name, resolveTypes(type)));
+      cls.addMethod(new Property(cls, name, resolveTypes(type)));
     }
   }
 
   for (const cls of rootClasses) {
-    out.classes.push(cls, ...cls.decedents());
+    out.classes.push(cls, ...cls.descendants());
   }
 
   out.mixedInfo = {
@@ -672,6 +712,25 @@ export function bindModel(spec: Spec): BoundSpec {
       .map((t) => out.types[t])
       .concat(Object.values(spec.mixedInfo.dataTypes).map(({ type }) => out.types[type])),
   };
+
+  // Mark methods and fields in the opt-in list as `isOptedInTo` which the consumer/SDK
+  // then can choose to handle accordingly.
+
+  for (const [optInClassName, optInRaw] of Object.entries(optInSpec?.classes ?? {})) {
+    const boundClass = out.types[optInClassName];
+    assert(boundClass instanceof Class);
+    for (const optInMethodName of optInRaw.methods) {
+      boundClass.getMethod(optInMethodName).isOptedInTo = true;
+    }
+  }
+
+  for (const [optInStructName, optInRaw] of Object.entries(optInSpec?.records ?? {})) {
+    const boundStruct = out.types[optInStructName];
+    assert(boundStruct instanceof Struct);
+    for (const optInFieldName of optInRaw.fields) {
+      boundStruct.getField(optInFieldName).isOptedInTo = true;
+    }
+  }
 
   return out;
 }

--- a/bindgen/src/bound-model.ts
+++ b/bindgen/src/bound-model.ts
@@ -363,7 +363,10 @@ export class Class extends NamedType {
 
   getMethod(uniqueName: string) {
     const method = this._methods[uniqueName];
-    assert(method, `Method '${uniqueName}' does not exist on class '${this.name}'.`);
+    assert(
+      method,
+      `Method '${uniqueName}' does not exist on class '${this.name}'. The method in the opt-in list must correspond to a method in the general spec.`,
+    );
 
     return method;
   }
@@ -430,7 +433,10 @@ export class Struct extends NamedType {
 
   getField(name: string) {
     const field = this._fields[name];
-    assert(field, `Field '${name}' does not exist on record/struct '${this.name}'.`);
+    assert(
+      field,
+      `Field '${name}' does not exist on record/struct '${this.name}'. The field in the opt-in list must correspond to a field in the general spec.`,
+    );
 
     return field;
   }

--- a/bindgen/src/context.ts
+++ b/bindgen/src/context.ts
@@ -18,10 +18,11 @@
 
 import { Formatter } from "./formatter";
 import { Outputter } from "./outputter";
-import { Spec } from "./spec";
+import { OptInSpec, Spec } from "./spec";
 
 export type TemplateContext = {
   spec: Spec;
+  optInSpec?: OptInSpec;
   /**
    * @param path The file path, relative to the output directory.
    * @param formatter An optional formatter to run after the template has returned.

--- a/bindgen/src/context.ts
+++ b/bindgen/src/context.ts
@@ -16,13 +16,14 @@
 //
 ////////////////////////////////////////////////////////////////////////////
 
+import { BoundSpec } from "./bound-model";
 import { Formatter } from "./formatter";
 import { Outputter } from "./outputter";
-import { OptInSpec, Spec } from "./spec";
+import { Spec } from "./spec";
 
 export type TemplateContext = {
-  spec: Spec;
-  optInSpec?: OptInSpec;
+  rawSpec: Spec;
+  spec: BoundSpec;
   /**
    * @param path The file path, relative to the output directory.
    * @param formatter An optional formatter to run after the template has returned.

--- a/bindgen/src/generator.ts
+++ b/bindgen/src/generator.ts
@@ -16,12 +16,13 @@
 //
 ////////////////////////////////////////////////////////////////////////////
 
-import { Spec } from "./spec";
+import { OptInSpec, Spec } from "./spec";
 import { Template } from "./templates";
 import { createOutputDirectory } from "./output-directory";
 
 type GenerateOptions = {
   spec: Spec;
+  optInSpec?: OptInSpec;
   template: Template;
   outputPath: string;
 };
@@ -31,12 +32,13 @@ type GenerateOptions = {
  *
  * @param options The spec to generate from, the template to apply and the path of the directory to write output
  */
-export function generate({ spec, template, outputPath }: GenerateOptions): void {
+export function generate({ spec, optInSpec, template, outputPath }: GenerateOptions): void {
   // Apply the template
   const outputDirectory = createOutputDirectory(outputPath);
   try {
     template({
       spec,
+      optInSpec,
       file: outputDirectory.file.bind(outputDirectory),
     });
   } finally {

--- a/bindgen/src/generator.ts
+++ b/bindgen/src/generator.ts
@@ -18,10 +18,11 @@
 
 import { OptInSpec, Spec } from "./spec";
 import { Template } from "./templates";
+import { bindModel } from "./bound-model";
 import { createOutputDirectory } from "./output-directory";
 
 type GenerateOptions = {
-  spec: Spec;
+  rawSpec: Spec;
   optInSpec?: OptInSpec;
   template: Template;
   outputPath: string;
@@ -32,13 +33,13 @@ type GenerateOptions = {
  *
  * @param options The spec to generate from, the template to apply and the path of the directory to write output
  */
-export function generate({ spec, optInSpec, template, outputPath }: GenerateOptions): void {
+export function generate({ rawSpec, optInSpec, template, outputPath }: GenerateOptions): void {
   // Apply the template
   const outputDirectory = createOutputDirectory(outputPath);
   try {
     template({
-      spec,
-      optInSpec,
+      rawSpec,
+      spec: bindModel(rawSpec, optInSpec),
       file: outputDirectory.file.bind(outputDirectory),
     });
   } finally {

--- a/bindgen/src/program.ts
+++ b/bindgen/src/program.ts
@@ -23,11 +23,12 @@ import path from "path";
 
 import { debug, enableDebugging } from "./debug";
 import { generate } from "./generator";
-import { InvalidSpecError, parseSpecs } from "./spec";
+import { OptInSpec, InvalidSpecError, parseOptInList, parseSpecs } from "./spec";
 import { Template, importTemplate } from "./templates";
 
 type GenerateOptions = {
   spec: ReadonlyArray<string>;
+  optIn?: string;
   template: Promise<Template>;
   output: string;
   debug: boolean;
@@ -67,11 +68,13 @@ const specOption = program
   .argParser((arg, previous: ReadonlyArray<string> = []) => [...previous, parseExistingFilePath(arg)])
   .makeOptionMandatory();
 
+const optInOption = program
+  .createOption("-a, --opt-in <opt-in list>", "Path of the 'opt-in list' specification")
+  .argParser(parseExistingFilePath);
+
 const templateOption = program
   .createOption("-t, --template <template>", "Path to template source file to apply when generating")
-  .argParser((name) => {
-    return importTemplate(name);
-  })
+  .argParser(importTemplate)
   .makeOptionMandatory();
 
 const outputOption = program
@@ -84,18 +87,23 @@ const debugOption = program.createOption("-d, --debug", "Turn on debug printing"
 program
   .command("generate", { isDefault: true })
   .addOption(specOption)
+  .addOption(optInOption)
   .addOption(templateOption)
   .addOption(outputOption)
   .addOption(debugOption)
   .action(async (args: GenerateOptions) => {
-    const { spec: specPaths, template, output: outputPath, debug: isDebugging } = args;
+    const { spec: specPaths, optIn: optInPath, template, output: outputPath, debug: isDebugging } = args;
     if (isDebugging) {
       enableDebugging();
       debug("Debugging enabled");
     }
     try {
       const spec = parseSpecs(specPaths);
-      generate({ spec, template: await template, outputPath });
+      let optInSpec: OptInSpec | undefined;
+      if (optInPath) {
+        optInSpec = parseOptInList(optInPath);
+      }
+      generate({ spec, optInSpec, template: await template, outputPath });
       process.exit(0);
     } catch (err) {
       printError(err);

--- a/bindgen/src/program.ts
+++ b/bindgen/src/program.ts
@@ -23,7 +23,7 @@ import path from "path";
 
 import { debug, enableDebugging } from "./debug";
 import { generate } from "./generator";
-import { OptInSpec, InvalidSpecError, parseOptInList, parseSpecs } from "./spec";
+import { OptInSpec, InvalidSpecError, parseOptInSpec, parseSpecs } from "./spec";
 import { Template, importTemplate } from "./templates";
 
 type GenerateOptions = {
@@ -106,7 +106,7 @@ program
       const rawSpec = parseSpecs(specPaths);
       let optInSpec: OptInSpec | undefined;
       if (optInPath) {
-        optInSpec = parseOptInList(optInPath);
+        optInSpec = parseOptInSpec(optInPath);
       }
       generate({ rawSpec, optInSpec, template: await template, outputPath });
       process.exit(0);

--- a/bindgen/src/program.ts
+++ b/bindgen/src/program.ts
@@ -69,7 +69,7 @@ const specOption = program
   .makeOptionMandatory();
 
 const optInOption = program
-  .createOption("-a, --opt-in <opt-in list>", "Path of the 'opt-in list' specification")
+  .createOption("--opt-in <opt-in list>", "Path of the 'opt-in list' specification")
   .argParser(parseExistingFilePath);
 
 const templateOption = program
@@ -98,12 +98,12 @@ program
       debug("Debugging enabled");
     }
     try {
-      const spec = parseSpecs(specPaths);
+      const rawSpec = parseSpecs(specPaths);
       let optInSpec: OptInSpec | undefined;
       if (optInPath) {
         optInSpec = parseOptInList(optInPath);
       }
-      generate({ spec, optInSpec, template: await template, outputPath });
+      generate({ rawSpec, optInSpec, template: await template, outputPath });
       process.exit(0);
     } catch (err) {
       printError(err);

--- a/bindgen/src/program.ts
+++ b/bindgen/src/program.ts
@@ -68,6 +68,11 @@ const specOption = program
   .argParser((arg, previous: ReadonlyArray<string> = []) => [...previous, parseExistingFilePath(arg)])
   .makeOptionMandatory();
 
+/**
+ * If provided, methods and fields in the opt-in list that are accessed by
+ * the SDK's `generate()` function will have a property `isOptedInTo = true`,
+ * otherwise it will be set to `false`.
+ */
 const optInOption = program
   .createOption("--opt-in <opt-in list>", "Path of the 'opt-in list' specification")
   .argParser(parseExistingFilePath);

--- a/bindgen/src/program.ts
+++ b/bindgen/src/program.ts
@@ -69,9 +69,9 @@ const specOption = program
   .makeOptionMandatory();
 
 /**
- * If provided, methods and fields in the opt-in list that are accessed by
- * the SDK's `generate()` function will have a property `isOptedInTo = true`,
- * otherwise it will be set to `false`.
+ * If provided (and once `BoundSpec.applyOptInList()` has been invoked by the SDK),
+ * the methods and fields on the `BoundSpec` that also appear in the opt-in list
+ * will have the property `isOptedInTo = true`, otherwise it will be set to `false`.
  */
 const optInOption = program
   .createOption("--opt-in <opt-in list>", "Path of the 'opt-in list' specification")

--- a/bindgen/src/spec.ts
+++ b/bindgen/src/spec.ts
@@ -69,10 +69,6 @@ const schemaFile = new URL("../generated/spec.schema.json", import.meta.url);
 const schemaJson = JSON.parse(fs.readFileSync(schemaFile, { encoding: "utf8" }));
 export const validate = ajv.compile<RelaxedSpec>(schemaJson);
 
-const optInSchemaFile = new URL("../generated/opt-in-spec.schema.json", import.meta.url);
-const optInSchemaJson = JSON.parse(fs.readFileSync(optInSchemaFile, { encoding: "utf8" }));
-export const validateOptInSpec = ajv.compile<OptInSpec>(optInSchemaJson);
-
 function parseYaml(filePath: string): unknown {
   const text = fs.readFileSync(filePath, { encoding: "utf8" });
   return yaml.parse(text);
@@ -117,11 +113,11 @@ export function parseSpec(filePath: string): AnySpec {
 
 export function parseOptInSpec(filePath: string): OptInSpec {
   const parsed = parseYaml(filePath);
-  const isValid = validateOptInSpec(parsed);
-  if (isValid) {
-    return parsed;
-  }
-  throw new InvalidSpecError(filePath, validateOptInSpec.errors || []);
+
+  // TODO:
+  // Validate parsed spec.
+
+  return parsed as OptInSpec;
 }
 
 /**

--- a/bindgen/src/spec.ts
+++ b/bindgen/src/spec.ts
@@ -28,6 +28,7 @@ import {
   FieldSpec,
   FunctionTypeSpec,
   MethodSpec,
+  OptInSpec,
   RecordSpec,
   AnySpec,
   ValueType,
@@ -104,6 +105,16 @@ export function parseSpec(filePath: string): AnySpec {
   } else {
     throw new InvalidSpecError(filePath, validate.errors || []);
   }
+}
+
+export function parseOptInList(filePath: string): OptInSpec {
+  const text = fs.readFileSync(filePath, { encoding: "utf8" });
+  const parsed = yaml.parse(text) as unknown;
+
+  return parsed as OptInSpec;
+
+  // TODO:
+  // Validate shape of spec
 }
 
 /**

--- a/bindgen/src/spec/model.ts
+++ b/bindgen/src/spec/model.ts
@@ -34,6 +34,32 @@ export type Spec = ReplaceFields<
   }
 >;
 
+/**
+ * @example
+ * // Spec/yaml file example:
+ * classes:
+ *   Obj:
+ *     methods:
+ *       - get_any
+ *       - get_any_by_name
+ *       - is_null
+ *
+ * records:
+ *   Property:
+ *     fields:
+ *       - name
+ *       - public_name
+ *       - type
+ */
+export type OptInSpec = {
+  classes: {
+    [cppName: string]: { methods: string[] };
+  };
+  records: {
+    [cppName: string]: { fields: string[] };
+  };
+};
+
 type AdditionalSpec = ReplaceFields<
   Spec,
   {

--- a/bindgen/src/spec/model.ts
+++ b/bindgen/src/spec/model.ts
@@ -63,10 +63,10 @@ export type Spec = ReplaceFields<
  */
 export type OptInSpec = {
   classes?: {
-    [cppName: string]: { methods: string[] };
+    [name: string]: { methods: string[] };
   };
   records?: {
-    [cppName: string]: { fields: string[] };
+    [name: string]: { fields: string[] };
   };
 };
 

--- a/bindgen/src/spec/model.ts
+++ b/bindgen/src/spec/model.ts
@@ -52,10 +52,10 @@ export type Spec = ReplaceFields<
  *       - type
  */
 export type OptInSpec = {
-  classes: {
+  classes?: {
     [cppName: string]: { methods: string[] };
   };
-  records: {
+  records?: {
     [cppName: string]: { fields: string[] };
   };
 };

--- a/bindgen/src/spec/model.ts
+++ b/bindgen/src/spec/model.ts
@@ -37,19 +37,29 @@ export type Spec = ReplaceFields<
 /**
  * @example
  * // Spec/yaml file example:
- * classes:
- *   Obj:
- *     methods:
- *       - get_any
- *       - get_any_by_name
- *       - is_null
- *
  * records:
  *   Property:
  *     fields:
  *       - name
  *       - public_name
  *       - type
+ *   ObjectSchema:
+ *     fields:
+ *       - name
+ *       - persisted_properties
+ *       - computed_properties
+ *
+ * classes:
+ *   Results:
+ *     methods:
+ *       - from_table
+ *       - is_valid
+ *       - sort_by_names
+ *   Realm:
+ *     methods:
+ *       - get_shared_realm
+ *       - config
+ *       - begin_transaction
  */
 export type OptInSpec = {
   classes?: {


### PR DESCRIPTION
## What, How & Why?

Adds initial support for an opt-in list for the Bindgen spec. This allows SDKs to use only some of the classes and records/structs of the [general spec](https://github.com/realm/realm-core/blob/bindgen/bindgen/spec.yml) and generate bindings only for the items in the opt-in list.

### Added Behavior:
* Command option
  * The `realm-bindgen` command now accepts an optional `--opt-in` option specifying the path of the opt-in list.
  * If omitted, none of the bound methods or fields will be marked as opted in to.
  * Examples (showing only the opt-in option):
```sh
# Command line
realm-bindgen --opt-in path/to/opt/in/spec.yml
```
```CMake
# CMake
bindgen(OPTIN path/to/opt/in/spec.yml)
```
* Spec/yaml opt-in file
  * The opt-in file should list:
    * The `records` along with their `fields` (names).
    * The `classes` along with their `methods` (unique names).
  * Example:
```yaml
records:
  Property:
    fields:
      - name
      - public_name
      - type
  ObjectSchema:
    fields:
      - name
      - persisted_properties
      - computed_properties

classes:
  Results:
    methods:
      - from_table
      - is_valid
      - sort_by_names
  Realm:
    methods:
      - get_shared_realm
      - config
      - begin_transaction
```

### SDK Requirements:
* Applying the opt-in list
  * The SDK's `generate()` function will receive a `BoundSpec` containing all of the entries of the general spec.
  * Since the SDK may add its own custom methods/fields onto the `BoundSpec`, the SDK is responsible for calling the instance method `BoundSpec.applyOptInList()` if an opt-in list was provided.
  * Once applied, the methods and fields on the `BoundSpec` that also appear in the opt-in list will have the property `isOptedInTo = true`, otherwise it will be set to `false`.
  * (See usage examples below.)

### Updated Type:
* The SDK's `generate()` function accepts an object as an argument which now also contains the `BoundSpec`.
  * The object properties have been renamed:
```TypeScript
// Argument passed to `generate()`
export type TemplateContext = {
  rawSpec: Spec;      // Previously called `spec`
  spec: BoundSpec;    // Newly added
  file: (path: string, formatter?: Formatter) => Outputter;  // Unchanged
};
```

### SDK Usage Examples:

#### Example using CMake:
* When calling the `bindgen()` function for each of your templates in `CMakeLists.txt`, pass the path of the opt-in list.
```CMake
set(OPT_IN_FILE ${SDK_DIR}/path/to/opt/in/spec.yml)

bindgen(
    # ...
    OPTIN ${OPT_IN_FILE}
)
```

#### Example of the `generate()` function:
* The methods and fields of the `BoundSpec` have an `isOptedInTo` boolean property that the consumer can handle accordingly.
  * TypeScript example:
```TypeScript
export function generate({ rawSpec, spec, file }: TemplateContext): void {
  const out = file("output/file/path");
  // ...
  spec.applyOptInList();
  for (const cls of spec.classes) {
    // ...
    for (const method of cls.methods) {
      if (!method.isOptedInTo) {
        out(`/** @deprecated */`); // Or: continue;
      }
      // ...
    }
  }
}
```

### Potential Additions in Upcoming Iterations:
* Opt in to all methods/fields of a class/record without listing them.
  * Current behavior:
    * Can only opt in to methods and fields. So in order to opt in to all methods of a class, you'd need to explicitly list them all.
  * Alternative:
    * Provide an easy way to indicate that all of its methods/fields are opted in to.
* Opt out of an entire class/record.
  * Current behavior:
    * Even if a class/record is omitted from the opt-in list, it will still be generated, but w/o its methods/fields.
  * Alternative:
    * Provide `isOptedInTo` on the bound class/record itself so that it can be assigned `false` if omitted.

## ☑️ ToDos
* [ ] 📝 Changelog update
* [ ] 🚦 Tests (or not relevant)
* [ ] C-API, if public C++ API changed.
