### PR TITLE
Fix importing Results with deleted collection

### DIFF
--- a/src/realm/object-store/results.cpp
+++ b/src/realm/object-store/results.cpp
@@ -1091,14 +1091,15 @@ Results Results::import_copy_into_realm(std::shared_ptr<Realm> const& realm)
     validate_read();
 
     switch (m_mode) {
+        case Mode::Table:
+            return Results(realm, realm->import_copy_of(m_table));
         case Mode::Collection:
             if (std::shared_ptr<CollectionBase> collection = realm->import_copy_of(*m_collection)) {
                 return Results(realm, collection, m_descriptor_ordering);
             }
-            // If collection is gone, fallback to pure table.
-            [[fallthrough]];
-        case Mode::Table:
-            return Results(realm, realm->import_copy_of(m_table));
+            // If collection is gone, fallback to empty selection on table.
+            return Results(realm, TableView(realm->import_copy_of(m_table)));
+            break;
         case Mode::Query:
             return Results(realm, *realm->import_copy_of(m_query, PayloadPolicy::Copy), m_descriptor_ordering);
         case Mode::TableView: {

--- a/test/object-store/frozen_objects.cpp
+++ b/test/object-store/frozen_objects.cpp
@@ -373,7 +373,11 @@ TEST_CASE("Freeze Results", "[freeze_results]") {
                     // Snapshot should not be affected by the removed collection
                     REQUIRE(snapshot.size() == 5);
                 });
-                VERIFY_VALID_RESULTS(results, realm);
+                REQUIRE(results.is_valid());
+                REQUIRE(results.size() == 0);
+                auto frozen = results.freeze(realm);
+                REQUIRE(frozen.is_valid());
+                REQUIRE(frozen.size() == 0);
             }
         }
 


### PR DESCRIPTION
The result should be an empty result, not the whole table.
