### PR TITLE
Filter out unresolved links in Dictionary::get_any()

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 * We could crash when removing backlinks in cases where forward links did not have a corresponding backlink due to corruption. We now silently ignore this inconsistency in release builds, allowing the app to continue. ([#6585](https://github.com/realm/realm-core/issues/6585), v6.0.0)
 * If you freeze a Results based on a collection of objects, the result will be invalid if you delete the collection ([#6635](https://github.com/realm/realm-core/issues/6635), since V13.11.0)
 * Geospatial polygons now have built in normalization and validation in line with the MongoDB server side behaviour and the geoJSON standard. ([#6607](https://github.com/realm/realm-core/pull/6607), since v13.11.0)
+* Dictionary::get_any() would expose unresolved links rather than mapping them to null. In addition to allowing invalid objects to be read from Dictionaries, this resulted in queries on Dictionaries sometimes having incorrect results ([#6644](https://github.com/realm/realm-core/pull/6644)).
 
 ### Breaking changes
 * `platform` and `cpu_arch` fields in the `device_info` structure in App::Config can no longer be provided by the SDK's, they are inferred by the library ([PR #6612](https://github.com/realm/realm-core/pull/6612))

--- a/src/realm/bplustree.hpp
+++ b/src/realm/bplustree.hpp
@@ -529,11 +529,18 @@ public:
     template <typename Func>
     void for_all(Func&& callback) const
     {
+        using Ret = std::invoke_result_t<Func, T>;
         m_root->bptree_traverse([&callback](BPlusTreeNode* node, size_t) {
             LeafNode* leaf = static_cast<LeafNode*>(node);
             size_t sz = leaf->size();
             for (size_t i = 0; i < sz; i++) {
-                callback(leaf->get(i));
+                if constexpr (std::is_same_v<Ret, void>) {
+                    callback(leaf->get(i));
+                }
+                else {
+                    if (!callback(leaf->get(i)))
+                        return IteratorControl::Stop;
+                }
             }
             return IteratorControl::AdvanceToNext;
         });

--- a/src/realm/dictionary.cpp
+++ b/src/realm/dictionary.cpp
@@ -133,7 +133,7 @@ Mixed Dictionary::get_any(size_t ndx) const
 {
     // Note: `size()` calls `update_if_needed()`.
     CollectionBase::validate_index("get_any()", ndx, size());
-    return m_values->get(ndx);
+    return do_get(ndx);
 }
 
 std::pair<Mixed, Mixed> Dictionary::get_pair(size_t ndx) const
@@ -833,12 +833,8 @@ Mixed Dictionary::do_get(size_t ndx) const
     Mixed val = m_values->get(ndx);
 
     // Filter out potential unresolved links
-    if (val.is_type(type_TypedLink)) {
-        auto link = val.get<ObjLink>();
-        auto key = link.get_obj_key();
-        if (key.is_unresolved()) {
-            return {};
-        }
+    if (val.is_type(type_TypedLink) && val.get<ObjKey>().is_unresolved()) {
+        return {};
     }
     return val;
 }

--- a/src/realm/query_expression.cpp
+++ b/src/realm/query_expression.cpp
@@ -73,9 +73,14 @@ std::string LinkMap::description(util::serializer::SerialisationState& state) co
     return s;
 }
 
-void LinkMap::map_links(size_t column, ObjKey key, LinkMapFunction lm) const
+bool LinkMap::map_links(size_t column, ObjKey key, LinkMapFunction lm) const
 {
-    bool last = (column + 1 == m_link_column_keys.size());
+    if (!key || key.is_unresolved())
+        return true;
+    if (column == m_link_column_keys.size()) {
+        return lm(key);
+    }
+
     ColumnType type = m_link_types[column];
     ColKey column_key = m_link_column_keys[column];
     const Obj obj = m_tables[column]->get_object(key);
@@ -83,39 +88,24 @@ void LinkMap::map_links(size_t column, ObjKey key, LinkMapFunction lm) const
         auto coll = obj.get_linkcollection_ptr(column_key);
         size_t sz = coll->size();
         for (size_t t = 0; t < sz; t++) {
-            if (ObjKey k = coll->get_key(t)) {
-                // Unresolved links are filtered out
-                if (last) {
-                    lm(k);
-                }
-                else
-                    map_links(column + 1, k, lm);
-            }
+            if (!map_links(column + 1, coll->get_key(t), lm))
+                return false;
         }
     }
     else if (type == col_type_Link) {
-        if (ObjKey k = obj.get<ObjKey>(column_key)) {
-            if (!k.is_unresolved()) {
-                if (last)
-                    lm(k);
-                else
-                    map_links(column + 1, k, lm);
-            }
-        }
+        return map_links(column + 1, obj.get<ObjKey>(column_key), lm);
     }
     else if (type == col_type_BackLink) {
         auto backlinks = obj.get_all_backlinks(column_key);
         for (auto k : backlinks) {
-            if (last) {
-                lm(k);
-            }
-            else
-                map_links(column + 1, k, lm);
+            if (!map_links(column + 1, k, lm))
+                return false;
         }
     }
     else {
-        REALM_ASSERT(false);
+        REALM_TERMINATE("Invalid column type in LinkMap::map_links()");
     }
+    return true;
 }
 
 ref_type LinkMap::get_ref(const ArrayPayload* array_payload, ColumnType type, size_t row)
@@ -129,7 +119,6 @@ void LinkMap::map_links(size_t column, size_t row, LinkMapFunction lm) const
 {
     REALM_ASSERT(m_leaf_ptr != nullptr);
 
-    bool last = (column + 1 == m_link_column_keys.size());
     ColumnType type = m_link_types[column];
     ColKey column_key = m_link_column_keys[column];
     if (type == col_type_Link && !column_key.is_set()) {
@@ -145,31 +134,25 @@ void LinkMap::map_links(size_t column, size_t row, LinkMapFunction lm) const
                 values.init_from_parent();
 
                 // Iterate through values and insert all link values
-                values.for_all([&](Mixed val) {
-                    if (val.is_type(type_TypedLink)) {
-                        auto link = val.get_link();
-                        REALM_ASSERT(link.get_table_key() == this->m_tables[column + 1]->get_key());
-                        auto k = link.get_obj_key();
-                        if (!k.is_unresolved()) {
-                            if (last)
-                                lm(k);
-                            else
-                                map_links(column + 1, k, lm);
+                values.traverse([&](BPlusTreeNode* node, size_t) {
+                    auto bplustree_leaf = static_cast<BPlusTree<Mixed>::LeafNode*>(node);
+                    auto sz = bplustree_leaf->size();
+                    for (size_t i = 0; i < sz; i++) {
+                        auto m = bplustree_leaf->get(i);
+                        if (m.is_type(type_TypedLink)) {
+                            auto link = m.get_link();
+                            REALM_ASSERT(link.get_table_key() == this->m_tables[column + 1]->get_key());
+                            if (!map_links(column + 1, link.get_obj_key(), lm))
+                                return IteratorControl::Stop;
                         }
                     }
+                    return IteratorControl::AdvanceToNext;
                 });
             }
         }
         else {
             REALM_ASSERT(!column_key.is_collection());
-            if (ObjKey k = static_cast<const ArrayKey*>(m_leaf_ptr)->get(row)) {
-                if (!k.is_unresolved()) {
-                    if (last)
-                        lm(k);
-                    else
-                        map_links(column + 1, k, lm);
-                }
-            }
+            map_links(column + 1, static_cast<const ArrayKey*>(m_leaf_ptr)->get(row), lm);
         }
     }
     else if (type == col_type_LinkList || (type == col_type_Link && column_key.is_set())) {
@@ -178,16 +161,8 @@ void LinkMap::map_links(size_t column, size_t row, LinkMapFunction lm) const
             links.init_from_ref(ref);
             size_t sz = links.size();
             for (size_t t = 0; t < sz; t++) {
-                ObjKey k = links.get(t);
-                if (!k.is_unresolved()) {
-                    if (last) {
-                        if (!lm(k)) {
-                            return;
-                        }
-                    }
-                    else
-                        map_links(column + 1, k, lm);
-                }
+                if (!map_links(column + 1, links.get(t), lm))
+                    break;
             }
         }
     }
@@ -196,12 +171,8 @@ void LinkMap::map_links(size_t column, size_t row, LinkMapFunction lm) const
         size_t sz = back_links->get_backlink_count(row);
         for (size_t t = 0; t < sz; t++) {
             ObjKey k = back_links->get_backlink(row, t);
-            if (last) {
-                if (!lm(k))
-                    return;
-            }
-            else
-                map_links(column + 1, k, lm);
+            if (!map_links(column + 1, k, lm))
+                break;
         }
     }
     else {

--- a/src/realm/query_expression.cpp
+++ b/src/realm/query_expression.cpp
@@ -134,19 +134,14 @@ void LinkMap::map_links(size_t column, size_t row, LinkMapFunction lm) const
                 values.init_from_parent();
 
                 // Iterate through values and insert all link values
-                values.traverse([&](BPlusTreeNode* node, size_t) {
-                    auto bplustree_leaf = static_cast<BPlusTree<Mixed>::LeafNode*>(node);
-                    auto sz = bplustree_leaf->size();
-                    for (size_t i = 0; i < sz; i++) {
-                        auto m = bplustree_leaf->get(i);
-                        if (m.is_type(type_TypedLink)) {
-                            auto link = m.get_link();
-                            REALM_ASSERT(link.get_table_key() == this->m_tables[column + 1]->get_key());
-                            if (!map_links(column + 1, link.get_obj_key(), lm))
-                                return IteratorControl::Stop;
-                        }
+                values.for_all([&](Mixed m) {
+                    if (m.is_type(type_TypedLink)) {
+                        auto link = m.get_link();
+                        REALM_ASSERT(link.get_table_key() == this->m_tables[column + 1]->get_key());
+                        if (!map_links(column + 1, link.get_obj_key(), lm))
+                            return false;
                     }
-                    return IteratorControl::AdvanceToNext;
+                    return true;
                 });
             }
         }

--- a/src/realm/query_expression.hpp
+++ b/src/realm/query_expression.hpp
@@ -1633,7 +1633,7 @@ public:
     static ref_type get_ref(const ArrayPayload* array_payload, ColumnType type, size_t ndx);
 
 private:
-    void map_links(size_t column, ObjKey key, LinkMapFunction lm) const;
+    bool map_links(size_t column, ObjKey key, LinkMapFunction lm) const;
     void map_links(size_t column, size_t row, LinkMapFunction lm) const;
 
     void get_links(size_t row, std::vector<ObjKey>& result) const

--- a/src/realm/sort_descriptor.hpp
+++ b/src/realm/sort_descriptor.hpp
@@ -91,7 +91,7 @@ public:
         bool any_is_null(IndexPair i) const
         {
             return std::any_of(m_columns.begin(), m_columns.end(), [=](auto&& col) {
-                return col.is_null.empty() ? false : col.is_null[i.index_in_view];
+                return !col.translated_keys.empty() && !col.translated_keys[i.index_in_view];
             });
         }
         void cache_first_column(IndexPairs& v);
@@ -104,7 +104,6 @@ public:
                 , ascending(a)
             {
             }
-            std::vector<bool> is_null;
             std::vector<ObjKey> translated_keys;
 
             const Table* table;


### PR DESCRIPTION
While trying to understand some details of what the code dealing with unresolved links was doing I discovered that some of it was not covered by tests. Adding some more tests ended up exposing a bug: Dictionary::get_any() was missing the check for unresolved links that the other getters have. This is the getter used for queries on dictionaries, so it resulted in queries using tombstone objects.