### PR TITLE
Set interface nested collections

### DIFF
--- a/src/realm.h
+++ b/src/realm.h
@@ -1815,6 +1815,15 @@ RLM_API bool realm_list_set_collection(realm_list_t* list, size_t index, realm_c
 RLM_API realm_list_t* realm_list_get_list(realm_list_t* list, size_t index);
 
 /**
+ * Returns a nested set if such collection exists and it is a leaf collection, NULL otherwise.
+ *
+ * @param list pointer to the list that containes the nested collection into
+ * @param index position of collection in the list
+ * @return a pointer to the the nested dictionary found at index passed as argument
+ */
+RLM_API realm_set_t* realm_list_get_set(realm_list_t* list, size_t index);
+
+/**
  * Returns a nested dictionary if such collection exists, NULL otherwise.
  *
  * @param list pointer to the list that containes the nested collection into
@@ -2310,6 +2319,12 @@ RLM_API bool realm_dictionary_insert_collection(realm_dictionary_t*, realm_value
  * @return a valid list that needs to be deleted by the caller or nullptr in case of an error.
  */
 RLM_API realm_list_t* realm_dictionary_get_list(realm_dictionary_t* dictionary, realm_value_t key);
+
+/**
+ * Fetch a set from a dictionary.
+ * @return a valid dictionary that needs to be deleted by the caller or nullptr in case of an error.
+ */
+RLM_API realm_set_t* realm_dictionary_get_set(realm_dictionary_t* dictionary, realm_value_t key);
 
 /**
  * Fetch a dictioanry from a dictionary.

--- a/src/realm/collection.hpp
+++ b/src/realm/collection.hpp
@@ -172,6 +172,10 @@ public:
     {
         return nullptr;
     }
+    virtual SetMixedPtr get_set(const PathElement&) const
+    {
+        return nullptr;
+    }
     virtual ListMixedPtr get_list(const PathElement&) const
     {
         return nullptr;

--- a/src/realm/collection.hpp
+++ b/src/realm/collection.hpp
@@ -170,15 +170,15 @@ public:
 
     virtual DictionaryPtr get_dictionary(const PathElement&) const
     {
-        return nullptr;
+        throw IllegalOperation("get_dictionary for this collection is not allowed");
     }
     virtual SetMixedPtr get_set(const PathElement&) const
     {
-        return nullptr;
+        throw IllegalOperation("get_set for this collection is not allowed");
     }
     virtual ListMixedPtr get_list(const PathElement&) const
     {
-        return nullptr;
+        throw IllegalOperation("get_list for this collection is not allowed");
     }
 
     virtual void set_owner(const Obj& obj, ColKey) = 0;

--- a/src/realm/collection_parent.hpp
+++ b/src/realm/collection_parent.hpp
@@ -40,6 +40,9 @@ class SetBase;
 class Dictionary;
 
 template <class T>
+class Set;
+
+template <class T>
 class Lst;
 
 using CollectionPtr = std::shared_ptr<Collection>;
@@ -49,6 +52,7 @@ using CollectionBasePtr = std::shared_ptr<CollectionBase>;
 using CollectionListPtr = std::shared_ptr<CollectionList>;
 using ListMixedPtr = std::shared_ptr<Lst<Mixed>>;
 using DictionaryPtr = std::shared_ptr<Dictionary>;
+using SetMixedPtr = std::shared_ptr<Set<Mixed>>;
 
 /// The status of an accessor after a call to `update_if_needed()`.
 enum class UpdateStatus {

--- a/src/realm/dictionary.cpp
+++ b/src/realm/dictionary.cpp
@@ -22,6 +22,7 @@
 #include <realm/array_ref.hpp>
 #include <realm/group.hpp>
 #include <realm/list.hpp>
+#include <realm/set.hpp>
 #include <realm/replication.hpp>
 
 #include <algorithm>
@@ -435,6 +436,15 @@ DictionaryPtr Dictionary::get_dictionary(const PathElement& path_elem) const
     auto weak = const_cast<Dictionary*>(this)->weak_from_this();
     auto shared = weak.expired() ? std::make_shared<Dictionary>(*this) : weak.lock();
     DictionaryPtr ret = std::make_shared<Dictionary>(m_col_key, get_level() + 1);
+    ret->set_owner(shared, path_elem.get_key());
+    return ret;
+}
+
+SetMixedPtr Dictionary::get_set(const PathElement& path_elem) const
+{
+    auto weak = const_cast<Dictionary*>(this)->weak_from_this();
+    auto shared = weak.expired() ? std::make_shared<Dictionary>(*this) : weak.lock();
+    auto ret = std::make_shared<Set<Mixed>>(m_obj_mem, m_col_key);
     ret->set_owner(shared, path_elem.get_key());
     return ret;
 }
@@ -1030,6 +1040,12 @@ void Dictionary::to_json(std::ostream& out, size_t link_depth, JSONOutputMode ou
             DummyParent parent(this->get_table(), val.get_ref());
             Lst<Mixed> list(parent, 0);
             list.to_json(out, link_depth, output_mode, fn);
+        }
+        else if (val.is_type(type_Set)) {
+            auto parent = std::make_shared<DummyParent>(this->get_table(), val.get_ref());
+            Set<Mixed> set(m_obj_mem, m_col_key);
+            set.set_owner(parent, i);
+            set.to_json(out, link_depth, output_mode, fn);
         }
         else {
             val.to_json(out, output_mode);

--- a/src/realm/dictionary.cpp
+++ b/src/realm/dictionary.cpp
@@ -1042,9 +1042,8 @@ void Dictionary::to_json(std::ostream& out, size_t link_depth, JSONOutputMode ou
             list.to_json(out, link_depth, output_mode, fn);
         }
         else if (val.is_type(type_Set)) {
-            auto parent = std::make_shared<DummyParent>(this->get_table(), val.get_ref());
-            Set<Mixed> set(m_obj_mem, m_col_key);
-            set.set_owner(parent, i);
+            DummyParent parent(this->get_table(), val.get_ref());
+            Set<Mixed> set(parent, 0);
             set.to_json(out, link_depth, output_mode, fn);
         }
         else {

--- a/src/realm/dictionary.hpp
+++ b/src/realm/dictionary.hpp
@@ -108,6 +108,7 @@ public:
 
     void insert_collection(const PathElement&, CollectionType dict_or_list) override;
     DictionaryPtr get_dictionary(const PathElement& path_elem) const override;
+    SetMixedPtr get_set(const PathElement&) const override;
     ListMixedPtr get_list(const PathElement& path_elem) const override;
 
     // throws std::out_of_range if key is not found

--- a/src/realm/exceptions.hpp
+++ b/src/realm/exceptions.hpp
@@ -160,7 +160,7 @@ struct InvalidArgument : LogicError {
 struct InvalidColumnKey : InvalidArgument {
     template <class T>
     InvalidColumnKey(const T& name)
-        : InvalidArgument(ErrorCodes::InvalidProperty, util::format("Invalid property for object type %1", name))
+        : InvalidArgument(ErrorCodes::InvalidProperty, util::format("Invalid property for object type: %1", name))
     {
     }
     InvalidColumnKey()

--- a/src/realm/list.cpp
+++ b/src/realm/list.cpp
@@ -459,6 +459,15 @@ DictionaryPtr Lst<Mixed>::get_dictionary(const PathElement& path_elem) const
     return ret;
 }
 
+SetMixedPtr Lst<Mixed>::get_set(const PathElement& path_elem) const
+{
+    auto weak = const_cast<Lst<Mixed>*>(this)->weak_from_this();
+    auto shared = weak.expired() ? std::make_shared<Lst<Mixed>>(*this) : weak.lock();
+    auto ret = std::make_shared<Set<Mixed>>(m_obj_mem, m_col_key);
+    ret->set_owner(shared, m_tree->get_key(path_elem.get_ndx()));
+    return ret;
+}
+
 std::shared_ptr<Lst<Mixed>> Lst<Mixed>::get_list(const PathElement& path_elem) const
 {
     auto weak = const_cast<Lst<Mixed>*>(this)->weak_from_this();
@@ -618,6 +627,12 @@ void Lst<Mixed>::to_json(std::ostream& out, size_t link_depth, JSONOutputMode ou
             DummyParent parent(this->get_table(), val.get_ref());
             Lst<Mixed> list(parent, i);
             list.to_json(out, link_depth, output_mode, fn);
+        }
+        else if (val.is_type(type_Set)) {
+            auto parent = std::make_shared<DummyParent>(this->get_table(), val.get_ref());
+            Set<Mixed> set(m_obj_mem, m_col_key);
+            set.set_owner(parent, i);
+            set.to_json(out, link_depth, output_mode, fn);
         }
         else {
             val.to_json(out, output_mode);

--- a/src/realm/list.cpp
+++ b/src/realm/list.cpp
@@ -629,9 +629,8 @@ void Lst<Mixed>::to_json(std::ostream& out, size_t link_depth, JSONOutputMode ou
             list.to_json(out, link_depth, output_mode, fn);
         }
         else if (val.is_type(type_Set)) {
-            auto parent = std::make_shared<DummyParent>(this->get_table(), val.get_ref());
-            Set<Mixed> set(m_obj_mem, m_col_key);
-            set.set_owner(parent, i);
+            DummyParent parent(this->get_table(), val.get_ref());
+            Set<Mixed> set(parent, 0);
             set.to_json(out, link_depth, output_mode, fn);
         }
         else {

--- a/src/realm/list.hpp
+++ b/src/realm/list.hpp
@@ -348,7 +348,9 @@ public:
     void insert_collection(const PathElement&, CollectionType dict_or_list) override;
     void set_collection(const PathElement& path_element, CollectionType dict_or_list) override;
     DictionaryPtr get_dictionary(const PathElement& path_elem) const override;
+    SetMixedPtr get_set(const PathElement& path_elem) const override;
     ListMixedPtr get_list(const PathElement& path_elem) const override;
+
 
     // Overriding members of CollectionBase:
     size_t size() const final

--- a/src/realm/mixed.cpp
+++ b/src/realm/mixed.cpp
@@ -339,7 +339,7 @@ int Mixed::compare(const Mixed& b) const noexcept
             if (type == type_TypeOfValue && b.get_type() == type_TypeOfValue) {
                 return TypeOfValue(int_val).matches(TypeOfValue(b.int_val)) ? 0 : compare_generic(int_val, b.int_val);
             }
-            if ((type == type_List || type == type_Dictionary)) {
+            if ((type == type_List || type == type_Dictionary || type == type_Set)) {
                 return m_type == b.m_type ? 0 : m_type < b.m_type ? -1 : 1;
             }
             REALM_ASSERT_RELEASE(false && "Compare not supported for this column type");

--- a/src/realm/obj.cpp
+++ b/src/realm/obj.cpp
@@ -1100,6 +1100,12 @@ void Obj::to_json(std::ostream& out, size_t link_depth, const std::map<std::stri
                     Dictionary dict(parent, 0);
                     dict.to_json(out, link_depth, output_mode, print_link);
                 }
+                else if (val.is_type(type_Set)) {
+                    auto parent = std::make_shared<DummyParent>(this->get_table(), val.get_ref());
+                    Set<Mixed> set(*this, ck);
+                    set.set_owner(parent, 0);
+                    set.to_json(out, link_depth, output_mode, print_link);
+                }
                 else if (val.is_type(type_List)) {
                     DummyParent parent(m_table, val.get_ref());
                     Lst<Mixed> list(parent, 0);
@@ -2049,6 +2055,9 @@ CollectionBasePtr Obj::get_collection_ptr(ColKey col_key) const
     auto val = get<Mixed>(col_key);
     if (val.is_type(type_List)) {
         return std::make_shared<Lst<Mixed>>(*this, col_key);
+    }
+    else if (val.is_type(type_Set)) {
+        return std::make_shared<Set<Mixed>>(*this, col_key);
     }
     REALM_ASSERT(val.is_type(type_Dictionary));
     return std::make_shared<Dictionary>(*this, col_key);

--- a/src/realm/obj.cpp
+++ b/src/realm/obj.cpp
@@ -1101,9 +1101,8 @@ void Obj::to_json(std::ostream& out, size_t link_depth, const std::map<std::stri
                     dict.to_json(out, link_depth, output_mode, print_link);
                 }
                 else if (val.is_type(type_Set)) {
-                    auto parent = std::make_shared<DummyParent>(this->get_table(), val.get_ref());
-                    Set<Mixed> set(*this, ck);
-                    set.set_owner(parent, 0);
+                    DummyParent parent(this->get_table(), val.get_ref());
+                    Set<Mixed> set(parent, 0);
                     set.to_json(out, link_depth, output_mode, print_link);
                 }
                 else if (val.is_type(type_List)) {

--- a/src/realm/object-store/c_api/dictionary.cpp
+++ b/src/realm/object-store/c_api/dictionary.cpp
@@ -137,6 +137,18 @@ RLM_API realm_dictionary_t* realm_dictionary_get_dictionary(realm_dictionary_t* 
     });
 }
 
+RLM_API realm_set_t* realm_dictionary_get_set(realm_dictionary_t* dictionary, realm_value_t key)
+{
+    return wrap_err([&]() {
+        if (key.type != RLM_TYPE_STRING) {
+            throw InvalidArgument{"Only string keys are supported in dictionaries"};
+        }
+
+        StringData k{key.string.data, key.string.size};
+        return new realm_set_t{dictionary->get_set(k)};
+    });
+}
+
 RLM_API realm_object_t* realm_dictionary_get_linked_object(realm_dictionary_t* dict, realm_value_t key)
 {
     return wrap_err([&]() {

--- a/src/realm/object-store/c_api/list.cpp
+++ b/src/realm/object-store/c_api/list.cpp
@@ -107,6 +107,13 @@ RLM_API realm_list_t* realm_list_get_list(realm_list_t* list, size_t index)
     });
 }
 
+RLM_API realm_set_t* realm_list_get_set(realm_list_t* list, size_t index)
+{
+    return wrap_err([&]() {
+        return new realm_set_t{list->get_set(index)};
+    });
+}
+
 RLM_API realm_dictionary_t* realm_list_get_dictionary(realm_list_t* list, size_t index)
 {
     return wrap_err([&]() {

--- a/src/realm/object-store/collection.cpp
+++ b/src/realm/object-store/collection.cpp
@@ -27,6 +27,7 @@
 #include <realm/object-store/shared_realm.hpp>
 #include <realm/object-store/list.hpp>
 #include <realm/object-store/dictionary.hpp>
+#include <realm/object-store/set.hpp>
 
 namespace realm::object_store {
 
@@ -284,5 +285,11 @@ Dictionary Collection::get_dictionary(const PathElement& path) const
 {
     return Dictionary{m_realm, m_coll_base->get_dictionary(path)};
 }
+
+Set Collection::get_set(const PathElement& path) const
+{
+    return Set{m_realm, m_coll_base->get_set(path)};
+}
+
 
 } // namespace realm::object_store

--- a/src/realm/object-store/collection.hpp
+++ b/src/realm/object-store/collection.hpp
@@ -38,6 +38,7 @@ class ListNotifier;
 
 namespace object_store {
 class Dictionary;
+class Set;
 class Collection {
 public:
     Collection(PropertyType type) noexcept;
@@ -119,6 +120,7 @@ public:
     void set_collection(const PathElement&, CollectionType);
     List get_list(const PathElement&) const;
     Dictionary get_dictionary(const PathElement&) const;
+    Set get_set(const PathElement&) const;
 
 protected:
     std::shared_ptr<Realm> m_realm;

--- a/src/realm/set.hpp
+++ b/src/realm/set.hpp
@@ -70,6 +70,10 @@ public:
 
         check_column_type<value_type>(m_col_key);
     }
+    Set(CollectionParent& parent, CollectionParent::Index index)
+        : Base(parent, index)
+    {
+    }
     Set(const Set& other);
     Set(Set&& other) noexcept;
     Set& operator=(const Set& other);

--- a/src/realm/set.hpp
+++ b/src/realm/set.hpp
@@ -64,7 +64,7 @@ public:
     Set(ColKey col_key)
         : Base(col_key)
     {
-        if (!col_key.is_set()) {
+        if (!(col_key.is_set() || col_key.get_type() == col_type_Mixed)) {
             throw InvalidArgument(ErrorCodes::TypeMismatch, "Property not a set");
         }
 

--- a/test/object-store/c_api/c_api.cpp
+++ b/test/object-store/c_api/c_api.cpp
@@ -4920,9 +4920,17 @@ TEST_CASE("C API: nested collections", "[c_api]") {
         auto dict2 = cptr_checked(realm_dictionary_get_dictionary(dict.get(), rlm_str_val("Hi")));
         checked(realm_dictionary_insert(dict2.get(), rlm_str_val("Nested-Hello"), rlm_str_val("Nested-World"),
                                         nullptr, nullptr));
+        // dict -> set
+        realm_dictionary_insert_collection(dict.get(), rlm_str_val("Leaf-Set"), RLM_COLLECTION_TYPE_SET);
+        auto set = cptr_checked(realm_dictionary_get_set(dict.get(), rlm_str_val("Leaf-Set")));
+        bool inserted;
+        size_t index;
+        realm_set_insert(set.get(), rlm_str_val("Set-Hello"), &index, &inserted);
+        CHECK(index == 0);
+        CHECK(inserted);
         size_t size;
         checked(realm_dictionary_size(dict.get(), &size));
-        REQUIRE(size == 3);
+        REQUIRE(size == 4);
     }
 
     SECTION("list") {
@@ -4942,9 +4950,17 @@ TEST_CASE("C API: nested collections", "[c_api]") {
         auto list2 = cptr_checked(realm_list_get_list(list.get(), 2));
         realm_list_insert(list2.get(), 0, rlm_str_val("Nested-Hello"));
         realm_list_insert(list2.get(), 1, rlm_str_val("Nested-World"));
+        // list -> set
+        realm_list_insert_collection(list.get(), 3, RLM_COLLECTION_TYPE_SET);
+        auto set = cptr_checked(realm_list_get_set(list.get(), 3));
+        bool inserted;
+        size_t index;
+        realm_set_insert(set.get(), rlm_str_val("Set-Hello"), &index, &inserted);
+        CHECK(index == 0);
+        CHECK(inserted);
         size_t size;
         checked(realm_list_size(list.get(), &size));
-        REQUIRE(size == 4);
+        REQUIRE(size == 5);
     }
     realm_release(realm);
 }


### PR DESCRIPTION
## What, How & Why?
Sets can also be held inside a collection. The only caveat is that, `sets` can only be a "terminal" node (leaf), they cannot hold other collections. 
We lack support for adding and getting a `set` into a collection (list/dictionary). The trick is that, although you can fetch such a collection, trying to nest another collection into, will result in some exception to be thrown.
This is the invariant to ensure that if a `Mixed` contains a nested collection, doing something like this:
Set<Mixed> set;
set.insert_collection(); //fails

However, doing something like this is still doable (and probably harmless).

```
obj.set_collection(col, CollectionType::Set);
object_store::Set set{r, obj, col};
auto col2 = table->add_column(type_Mixed, "any_val2");
obj.set_collection(col2, CollectionType::Set);
object_store::Set set2{r, obj, col2};
set2.insert_any(set.get_impl().get_obj());
....
....
auto mixed = set2.get_any(0); //if you know the index, the set can be reconstructed.
auto link = mixed.get_link();
auto hidden_obj = table->get_object(link.get_obj_key());
object_store::Set other_set{r, hidden_obj, col};
```

