### PR TITLE
Maybe fix a race in a test

### DIFF
--- a/test/object-store/sync/flx_sync.cpp
+++ b/test/object-store/sync/flx_sync.cpp
@@ -1383,8 +1383,8 @@ TEST_CASE("flx: geospatial", "[sync][flx][app]") {
                 size_t local_matches = query.find_all().size();
                 REQUIRE(local_matches == 2);
 
-                reset_utils::wait_for_object_to_persist_to_atlas(
-                    harness->app()->current_user(), harness->session().app_session(), "restaurant", {{"_id", pk}});
+                reset_utils::wait_for_num_objects_in_atlas(
+                    harness->app()->current_user(), harness->session().app_session(), "restaurant", points.size());
 
                 bson::BsonDocument filter = make_polygon_filter(bounds);
                 size_t server_results = run_query_on_server(filter);

--- a/test/object-store/sync/sync_test_utils.hpp
+++ b/test/object-store/sync/sync_test_utils.hpp
@@ -217,6 +217,9 @@ std::unique_ptr<TestClientReset> make_baas_flx_client_reset(const Realm::Config&
 void wait_for_object_to_persist_to_atlas(std::shared_ptr<SyncUser> user, const AppSession& app_session,
                                          const std::string& schema_name, const bson::BsonDocument& filter_bson);
 
+void wait_for_num_objects_in_atlas(std::shared_ptr<SyncUser> user, const AppSession& app_session,
+                                   const std::string& schema_name, size_t expected_size);
+
 void trigger_client_reset(const AppSession& app_session);
 void trigger_client_reset(const AppSession& app_session, const SharedRealm& realm);
 #endif // REALM_ENABLE_AUTH_TESTS


### PR DESCRIPTION
We recently had a test [failure](https://spruce.mongodb.com/task/realm_core_stable_macos_release_object_store_tests_patch_2d8fb23633293d0e9bab2c904f5695b25546f9fb_6467e53c7742aea9a51e981c_23_05_19_21_08_12/tests?execution=0&sortBy=STATUS&sortDir=ASC):

```
[2023/05/19 21:49:25.696] 3: ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
[2023/05/19 21:49:25.696] 3: realm-object-store-tests is a Catch2 v3.3.2 host application.
[2023/05/19 21:49:25.696] 3: Run with -? for options
[2023/05/19 21:49:25.696] 3:
[2023/05/19 21:49:25.696] 3: -------------------------------------------------------------------------------
[2023/05/19 21:49:25.696] 3: flx: geospatial
[2023/05/19 21:49:25.696] 3:   non-geospatial FLX query syncs data which can be queried locally
[2023/05/19 21:49:25.696] 3: -------------------------------------------------------------------------------
[2023/05/19 21:49:25.696] 3: /System/Volumes/Data/data/mci/612ed872f807f3e7bdfb3a535d790f2c/realm-core/test/object-store/sync/flx_sync.cpp:1283
[2023/05/19 21:49:25.696] 3: ...............................................................................
[2023/05/19 21:49:25.696] 3:
[2023/05/19 21:49:25.696] 3: /System/Volumes/Data/data/mci/612ed872f807f3e7bdfb3a535d790f2c/realm-core/test/object-store/sync/flx_sync.cpp:1391: FAILED:
[2023/05/19 21:49:25.696] 3:   CHECK( server_results == local_matches )
[2023/05/19 21:49:25.696] 3: with expansion:
[2023/05/19 21:49:25.696] 3:   0 == 2
[2023/05/19 21:49:25.696] 3:
[2023/05/19 21:49:25.696] 3: Assertion failure: /System/Volumes/Data/data/mci/612ed872f807f3e7bdfb3a535d790f2c/realm-core/test/object-store/sync/flx_sync.cpp:1391
[2023/05/19 21:49:25.696] 3: 	 from expresion: 'server_results == local_matches'
[2023/05/19 21:49:25.696] 3: 	 with expansion: '0 == 2'
```

This may be due to a race in the test. The test was checking if the last object was persisted to the Atlas backend (different than being reported as uploaded which just means the translator has received it). It may be that this one object was persisted, but the others were not. This is important for the test because it goes on to run a query against Atlas directly. Instead of waiting for the last written object, this changes the test to wait for a specific number of objects to be counted. That should ensure that the dataset is ready for the query.