### PR TITLE
Add nested collection path in transaction log

### DIFF
--- a/src/realm/collection.hpp
+++ b/src/realm/collection.hpp
@@ -26,6 +26,10 @@ public:
     {
         return {};
     }
+    Path get_short_path() const noexcept final
+    {
+        return {};
+    }
     void add_index(Path&, Index) const noexcept final {}
 
     TableRef get_table() const noexcept final
@@ -79,6 +83,11 @@ public:
     {
         throw IllegalOperation("set_collection is not legal on this collection type");
     }
+    // Returns the path to the collection. Uniquely identifies the collection within the Group.
+    virtual FullPath get_path() const = 0;
+    // Returns the path from the owning object. Starting with the column key. Identifies
+    // the collection within the object
+    virtual Path get_short_path() const = 0;
 };
 
 using CollectionPtr = std::shared_ptr<Collection>;
@@ -406,11 +415,18 @@ class CollectionBaseImpl : public Interface, protected ArrayParent {
 public:
     static_assert(std::is_base_of_v<CollectionBase, Interface>);
 
-    FullPath get_path() const
+    FullPath get_path() const override
     {
         auto path = m_parent->get_path();
         m_parent->add_index(path.path_from_top, m_index);
         return path;
+    }
+
+    Path get_short_path() const override
+    {
+        Path ret = m_parent->get_short_path();
+        m_parent->add_index(ret, m_index);
+        return ret;
     }
 
     // Overriding members of CollectionBase:
@@ -423,6 +439,7 @@ public:
     {
         return m_obj_mem;
     }
+
 
     /// Returns true if the accessor has changed since the last time
     /// `has_changed()` was called.

--- a/src/realm/collection_list.cpp
+++ b/src/realm/collection_list.cpp
@@ -175,6 +175,13 @@ auto CollectionList::get_path() const noexcept -> FullPath
     return path;
 }
 
+auto CollectionList::get_short_path() const noexcept -> Path
+{
+    auto path = m_parent->get_short_path();
+    m_parent->add_index(path, m_index);
+    return path;
+}
+
 void CollectionList::add_index(Path& path, Index index) const noexcept
 {
     if (m_coll_type == CollectionType::List) {

--- a/src/realm/collection_list.hpp
+++ b/src/realm/collection_list.hpp
@@ -60,6 +60,7 @@ public:
     bool update_if_needed() const final;
 
     FullPath get_path() const noexcept final;
+    Path get_short_path() const noexcept final;
     void add_index(Path& path, Index ndx) const noexcept final;
 
     TableRef get_table() const noexcept final

--- a/src/realm/collection_parent.cpp
+++ b/src/realm/collection_parent.cpp
@@ -35,6 +35,9 @@ std::ostream& operator<<(std::ostream& ostr, const PathElement& elem)
     if (elem.is_ndx()) {
         ostr << elem.get_ndx();
     }
+    else if (elem.is_col_key()) {
+        ostr << elem.get_col_key();
+    }
     else if (elem.is_key()) {
         ostr << "'" << elem.get_key() << "'";
     }

--- a/src/realm/collection_parent.hpp
+++ b/src/realm/collection_parent.hpp
@@ -82,34 +82,39 @@ struct PathElement {
         std::string string_val;
         int64_t int_val;
     };
-    enum Type { string, integer } m_type;
+    enum Type { column, key, index } m_type;
 
+    PathElement(ColKey col_key)
+        : int_val(col_key.value)
+        , m_type(Type::column)
+    {
+    }
     PathElement(int ndx)
         : int_val(ndx)
-        , m_type(Type::integer)
+        , m_type(Type::index)
     {
         REALM_ASSERT(ndx >= 0);
     }
     PathElement(size_t ndx)
         : int_val(int64_t(ndx))
-        , m_type(Type::integer)
+        , m_type(Type::index)
     {
     }
 
     PathElement(StringData str)
         : string_val(str)
-        , m_type(Type::string)
+        , m_type(Type::key)
     {
     }
     PathElement(const char* str)
         : string_val(str)
-        , m_type(Type::string)
+        , m_type(Type::key)
     {
     }
     PathElement(const PathElement& other)
         : m_type(other.m_type)
     {
-        if (other.m_type == Type::string) {
+        if (other.m_type == Type::key) {
             new (&string_val) std::string(other.string_val);
         }
         else {
@@ -120,7 +125,7 @@ struct PathElement {
     PathElement(PathElement&& other) noexcept
         : m_type(other.m_type)
     {
-        if (other.m_type == Type::string) {
+        if (other.m_type == Type::key) {
             new (&string_val) std::string(std::move(other.string_val));
         }
         else {
@@ -129,20 +134,29 @@ struct PathElement {
     }
     ~PathElement()
     {
-        if (m_type == Type::string) {
+        if (m_type == Type::key) {
             string_val.std::string::~string();
         }
     }
 
+    bool is_col_key() const noexcept
+    {
+        return m_type == Type::column;
+    }
     bool is_ndx() const noexcept
     {
-        return m_type == Type::integer;
+        return m_type == Type::index;
     }
     bool is_key() const noexcept
     {
-        return m_type == Type::string;
+        return m_type == Type::key;
     }
 
+    ColKey get_col_key() const noexcept
+    {
+        REALM_ASSERT(is_col_key());
+        return ColKey(int_val);
+    }
     size_t get_ndx() const noexcept
     {
         REALM_ASSERT(is_ndx());
@@ -157,7 +171,7 @@ struct PathElement {
     PathElement& operator=(const PathElement& other)
     {
         m_type = other.m_type;
-        if (other.m_type == Type::string) {
+        if (other.m_type == Type::key) {
             string_val = other.string_val;
         }
         else {
@@ -168,17 +182,21 @@ struct PathElement {
     bool operator==(const PathElement& other) const
     {
         if (m_type == other.m_type) {
-            return (m_type == Type::string) ? string_val == other.string_val : int_val == other.int_val;
+            return (m_type == Type::key) ? string_val == other.string_val : int_val == other.int_val;
         }
         return false;
     }
     bool operator==(const char* str) const
     {
-        return (m_type == Type::string) ? string_val == str : false;
+        return (m_type == Type::key) ? string_val == str : false;
     }
-    bool operator==(int64_t i) const
+    bool operator==(size_t i) const
     {
-        return (m_type == Type::integer) ? int_val == i : false;
+        return (m_type == Type::index) ? size_t(int_val) == i : false;
+    }
+    bool operator==(ColKey ck) const
+    {
+        return (m_type == Type::column) ? int_val == ck.value : false;
     }
 };
 

--- a/src/realm/collection_parent.hpp
+++ b/src/realm/collection_parent.hpp
@@ -72,6 +72,11 @@ enum class UpdateStatus {
     NoChange,
 };
 
+
+// Given an object as starting point, a collection can be identified by
+// a sequence of PathElements. The first element should always be a
+// column key. The next elements are either an index into a list or a key
+// to an entry in a dictionary
 struct PathElement {
     union {
         std::string string_val;
@@ -200,12 +205,15 @@ public:
     // Return the path to this object. The path is calculated from
     // the topmost Obj - which must be an Obj with a primary key.
     virtual FullPath get_path() const = 0;
+    // Return path from owning object
+    virtual Path get_short_path() const = 0;
     // Add a translation of Index to PathElement
     virtual void add_index(Path& path, Index ndx) const = 0;
     /// Get table of owning object
     virtual TableRef get_table() const noexcept = 0;
 
 protected:
+    friend class Collection;
     template <class>
     friend class CollectionBaseImpl;
     friend class CollectionList;

--- a/src/realm/dictionary.cpp
+++ b/src/realm/dictionary.cpp
@@ -620,11 +620,6 @@ Dictionary::Iterator Dictionary::find(Mixed key) const noexcept
     return end();
 }
 
-FullPath Dictionary::get_path() const
-{
-    return Base::get_path();
-}
-
 void Dictionary::add_index(Path& path, Index index) const
 {
     path.emplace_back(mpark::get<std::string>(index));

--- a/src/realm/dictionary.hpp
+++ b/src/realm/dictionary.hpp
@@ -178,7 +178,16 @@ public:
     void migrate();
 
     // Overriding members in CollectionParent
-    FullPath get_path() const final;
+    FullPath get_path() const override
+    {
+        return Base::get_path();
+    }
+
+    Path get_short_path() const override
+    {
+        return Base::get_short_path();
+    }
+
     void add_index(Path& path, Index ndx) const final;
     TableRef get_table() const noexcept override
     {
@@ -449,6 +458,16 @@ public:
     void set_owner(std::shared_ptr<CollectionParent> parent, CollectionParent::Index index) override
     {
         m_source.set_owner(std::move(parent), index);
+    }
+
+    FullPath get_path() const noexcept final
+    {
+        return m_source.get_path();
+    }
+
+    Path get_short_path() const noexcept final
+    {
+        return m_source.get_short_path();
     }
 
 private:

--- a/src/realm/history.cpp
+++ b/src/realm/history.cpp
@@ -29,7 +29,9 @@ using namespace realm;
 namespace {
 
 // As new schema versions come into existence, describe them here.
-constexpr int g_history_schema_version = 0;
+// 0: legacy version
+// 1: nested collections
+constexpr int g_history_schema_version = 1;
 
 
 /// This class is a basis for implementing the Replication API for the purpose
@@ -238,17 +240,14 @@ public:
 
     bool is_upgradable_history_schema(int stored_schema_version) const noexcept override
     {
-        // Never called because only one schema version exists so far.
         static_cast<void>(stored_schema_version);
-        REALM_ASSERT(false);
-        return false;
+        return true;
     }
 
     void upgrade_history_schema(int stored_schema_version) override
     {
-        // Never called because only one schema version exists so far.
+        // No need to upgrade, because the old entries will not be used
         static_cast<void>(stored_schema_version);
-        REALM_ASSERT(false);
     }
 
     _impl::History* _get_history_write() override

--- a/src/realm/impl/transact_log.cpp
+++ b/src/realm/impl/transact_log.cpp
@@ -28,12 +28,35 @@ bool TransactLogEncoder::select_table(TableKey key)
     return true;
 }
 
-bool TransactLogEncoder::select_collection(ColKey col_key, ObjKey key)
+bool TransactLogEncoder::select_collection(ColKey col_key, ObjKey key, const std::vector<PathElement>& path)
 {
-    append_simple_instr(instr_SelectCollection, col_key, key.value); // Throws
+    auto path_size = path.size();
+    if (path_size > 1) {
+        append_simple_instr(instr_SelectCollectionByPath, col_key, key.value, path_size - 1);
+        for (size_t n = 1; n < path_size; n++) {
+            if (path[n].is_ndx()) {
+                append_simple_instr(path[n].get_ndx());
+            }
+            else if (path[n].is_key()) {
+                append_simple_instr(-1);
+                encode_string(StringData(path[n].get_key().c_str()));
+            }
+        }
+    }
+    else {
+        append_simple_instr(instr_SelectCollection, col_key, key.value); // Throws
+    }
     return true;
 }
 
+void TransactLogEncoder::encode_string(StringData string)
+{
+    size_t max_required_bytes = max_enc_bytes_per_int + string.size();
+    char* ptr = reserve(max_required_bytes); // Throws
+    ptr = encode(ptr, size_t(string.size()));
+    ptr = std::copy(string.data(), string.data() + string.size(), ptr);
+    advance(ptr);
+}
 
 REALM_NORETURN
 void TransactLogParser::parser_error() const

--- a/src/realm/impl/transact_log.hpp
+++ b/src/realm/impl/transact_log.hpp
@@ -73,6 +73,13 @@ enum Instruction {
     // the number of backlink columns to change. This can happen
     // when a TypedLink is created for the first time to a Table.
     instr_TypedLinkChange = 43,
+
+    // dictionary clear should be moved up with the other instructions once we
+    // release the next file format breaking change
+    instr_DictionaryClear = 44,
+
+    // This instruction includes a path to the collection
+    instr_SelectCollectionByPath = 45,
 };
 
 class TransactLogStream {
@@ -127,7 +134,7 @@ public:
     {
         return true;
     }
-    bool select_collection(ColKey, ObjKey)
+    bool select_collection(ColKey, ObjKey, const std::vector<PathElement>&)
     {
         return true;
     }
@@ -241,7 +248,7 @@ public:
     bool set_link_type(ColKey col_key);
 
     // Must have collection selected:
-    bool select_collection(ColKey col_key, ObjKey key);
+    bool select_collection(ColKey col_key, ObjKey key, const std::vector<PathElement>& path);
     bool collection_set(size_t collection_ndx);
     bool collection_insert(size_t ndx);
     bool collection_move(size_t from_ndx, size_t to_ndx);
@@ -321,6 +328,9 @@ private:
 
     template <class T>
     static char* encode_int(char*, T value);
+
+    void encode_string(StringData string);
+
     friend class TransactLogParser;
 };
 
@@ -743,6 +753,7 @@ void TransactLogParser::parse_one(InstructionHandler& handler)
             return;
         }
         case instr_SetClear:
+        case instr_DictionaryClear:
         case instr_CollectionClear: {
             size_t old_size = read_int<size_t>();    // Throws
             if (!handler.collection_clear(old_size)) // Throws
@@ -776,10 +787,24 @@ void TransactLogParser::parse_one(InstructionHandler& handler)
                 parser_error();
             return;
         }
-        case instr_SelectCollection: {
+        case instr_SelectCollection:
+        case instr_SelectCollectionByPath: {
             ColKey col_key = ColKey(read_int<int64_t>()); // Throws
             ObjKey key = ObjKey(read_int<int64_t>());     // Throws
-            if (!handler.select_collection(col_key, key)) // Throws
+            size_t nesting_level = instr == instr_SelectCollectionByPath ? read_int<uint32_t>() : 0;
+            std::vector<PathElement> path;
+            path.push_back(size_t(col_key.value));
+            for (size_t l = 0; l < nesting_level; l++) {
+                auto ndx = read_int<int64_t>();
+                if (ndx < 0) {
+                    auto key = read_string(m_string_buffer);
+                    path.emplace_back(key);
+                }
+                else {
+                    path.emplace_back(size_t(ndx));
+                }
+            }
+            if (!handler.select_collection(col_key, key, path)) // Throws
                 parser_error();
             return;
         }
@@ -953,10 +978,16 @@ public:
         return {m_current_linkview_col, m_current_linkview_obj};
     }
 
+    const std::vector<PathElement>& get_path() const
+    {
+        return m_path;
+    }
+
 private:
     TableKey m_current_table;
     ColKey m_current_linkview_col;
     ObjKey m_current_linkview_obj;
+    std::vector<PathElement> m_path;
 
 public:
     void parse_complete() {}
@@ -967,10 +998,11 @@ public:
         return true;
     }
 
-    bool select_collection(ColKey col_key, ObjKey obj_key)
+    bool select_collection(ColKey col_key, ObjKey obj_key, const std::vector<PathElement>& path)
     {
         m_current_linkview_col = col_key;
         m_current_linkview_obj = obj_key;
+        m_path = path;
         return true;
     }
 

--- a/src/realm/impl/transact_log.hpp
+++ b/src/realm/impl/transact_log.hpp
@@ -938,6 +938,109 @@ void parse_transact_log(util::InputStream& is, Handler& handler)
     handler.parse_complete();
 }
 
+// A base class for transaction log parsers so that tests which want to test
+// just a single part of the transaction log handling don't have to implement
+// the entire interface
+class NoOpTransactionLogParser {
+public:
+    TableKey get_current_table() const
+    {
+        return m_current_table;
+    }
+
+    std::pair<ColKey, ObjKey> get_current_linkview() const
+    {
+        return {m_current_linkview_col, m_current_linkview_obj};
+    }
+
+private:
+    TableKey m_current_table;
+    ColKey m_current_linkview_col;
+    ObjKey m_current_linkview_obj;
+
+public:
+    void parse_complete() {}
+
+    bool select_table(TableKey t)
+    {
+        m_current_table = t;
+        return true;
+    }
+
+    bool select_collection(ColKey col_key, ObjKey obj_key)
+    {
+        m_current_linkview_col = col_key;
+        m_current_linkview_obj = obj_key;
+        return true;
+    }
+
+    // Default no-op implementations of all of the mutation instructions
+    bool insert_group_level_table(TableKey)
+    {
+        return false;
+    }
+    bool erase_class(TableKey)
+    {
+        return false;
+    }
+    bool rename_class(TableKey)
+    {
+        return false;
+    }
+    bool insert_column(ColKey)
+    {
+        return false;
+    }
+    bool erase_column(ColKey)
+    {
+        return false;
+    }
+    bool rename_column(ColKey)
+    {
+        return false;
+    }
+    bool set_link_type(ColKey)
+    {
+        return false;
+    }
+    bool create_object(ObjKey)
+    {
+        return false;
+    }
+    bool remove_object(ObjKey)
+    {
+        return false;
+    }
+    bool collection_set(size_t)
+    {
+        return false;
+    }
+    bool collection_clear(size_t)
+    {
+        return false;
+    }
+    bool collection_erase(size_t)
+    {
+        return false;
+    }
+    bool collection_insert(size_t)
+    {
+        return false;
+    }
+    bool collection_move(size_t, size_t)
+    {
+        return false;
+    }
+    bool modify_object(ColKey, ObjKey)
+    {
+        return false;
+    }
+    bool typed_link_change(ColKey, TableKey)
+    {
+        return true;
+    }
+};
+
 } // namespace _impl
 } // namespace realm
 

--- a/src/realm/list.cpp
+++ b/src/realm/list.cpp
@@ -665,11 +665,6 @@ void Lst<Mixed>::set_collection_ref(Index index, ref_type ref, CollectionType ty
     m_tree->set(ndx, Mixed(ref, type));
 }
 
-FullPath Lst<Mixed>::get_path() const
-{
-    return Base::get_path();
-}
-
 void Lst<Mixed>::add_index(Path& path, Index index) const
 {
     auto ndx = m_tree->find_key(mpark::get<int64_t>(index));

--- a/src/realm/list.hpp
+++ b/src/realm/list.hpp
@@ -481,7 +481,15 @@ public:
     }
 
     // Overriding members in CollectionParent
-    FullPath get_path() const final;
+    FullPath get_path() const override
+    {
+        return Base::get_path();
+    }
+
+    Path get_short_path() const override
+    {
+        return Base::get_short_path();
+    }
     void add_index(Path& path, Index ndx) const final;
     TableRef get_table() const noexcept override
     {
@@ -715,6 +723,16 @@ public:
     CollectionType get_collection_type() const noexcept override
     {
         return CollectionType::List;
+    }
+
+    FullPath get_path() const noexcept final
+    {
+        return m_list.get_path();
+    }
+
+    Path get_short_path() const noexcept final
+    {
+        return m_list.get_short_path();
     }
 
     // Overriding members of LstBase:

--- a/src/realm/obj.cpp
+++ b/src/realm/obj.cpp
@@ -1011,6 +1011,11 @@ FullPath Obj::get_path() const
     return result;
 }
 
+Path Obj::get_short_path() const noexcept
+{
+    return {};
+}
+
 void Obj::add_index(Path& path, Index index) const
 {
     auto col_key = mpark::get<ColKey>(index);

--- a/src/realm/obj.cpp
+++ b/src/realm/obj.cpp
@@ -996,7 +996,12 @@ FullPath Obj::get_path() const
                 }
                 else {
                     result = obj.get_path();
-                    result.path_from_top.push_back(obj.get_table()->get_column_name(next_col_key));
+                    if (result.path_from_top.empty()) {
+                        result.path_from_top.push_back(next_col_key);
+                    }
+                    else {
+                        result.path_from_top.push_back(obj.get_table()->get_column_name(next_col_key));
+                    }
                 }
 
                 return IteratorControl::Stop; // early out
@@ -1019,8 +1024,13 @@ Path Obj::get_short_path() const noexcept
 void Obj::add_index(Path& path, Index index) const
 {
     auto col_key = mpark::get<ColKey>(index);
-    StringData col_name = get_table()->get_column_name(col_key);
-    path.emplace_back(std::string(col_name));
+    if (path.empty()) {
+        path.emplace_back(col_key);
+    }
+    else {
+        StringData col_name = get_table()->get_column_name(col_key);
+        path.emplace_back(col_name);
+    }
 }
 
 void Obj::to_json(std::ostream& out, size_t link_depth, const std::map<std::string, std::string>& renames,

--- a/src/realm/obj.hpp
+++ b/src/realm/obj.hpp
@@ -74,6 +74,7 @@ public:
     // If you need to obtain additional information for each object in the path,
     // you should use get_fat_path() or traverse_path() instead (see below).
     FullPath get_path() const final;
+    Path get_short_path() const noexcept final;
     void add_index(Path& path, Index ndx) const final;
 
     bool update_if_needed() const final;

--- a/src/realm/object-store/audit.mm
+++ b/src/realm/object-store/audit.mm
@@ -282,7 +282,7 @@ public:
         return true;
     }
 
-    bool select_collection(ColKey, ObjKey obj) noexcept
+    bool select_collection(ColKey, ObjKey obj, const std::vector<PathElement>&) noexcept
     {
         REALM_ASSERT(m_active_table);
         m_active_table->modifications.push_back(obj);

--- a/src/realm/object-store/dictionary.cpp
+++ b/src/realm/object-store/dictionary.cpp
@@ -87,6 +87,16 @@ public:
         return m_dictionary->has_changed();
     }
 
+    FullPath get_path() const noexcept final
+    {
+        return m_dictionary->get_path();
+    }
+
+    Path get_short_path() const noexcept final
+    {
+        return m_dictionary->get_short_path();
+    }
+
     // -------------------------------------------------------------------------
     // Things not applicable to the adapter
 

--- a/src/realm/object-store/impl/transact_log_handler.cpp
+++ b/src/realm/object-store/impl/transact_log_handler.cpp
@@ -320,7 +320,7 @@ struct TransactLogValidator : public TransactLogValidationMixin {
     {
         return true;
     }
-    bool select_collection(ColKey, ObjKey)
+    bool select_collection(ColKey, ObjKey, const std::vector<PathElement>&)
     {
         return true;
     }
@@ -362,10 +362,11 @@ public:
         return true;
     }
 
-    bool select_collection(ColKey col, ObjKey obj)
+    bool select_collection(ColKey col, ObjKey obj, const std::vector<PathElement>&)
     {
         modify_object(col, obj);
         auto table = current_table();
+        // FIXME
         for (auto& c : m_info.collections) {
             if (c.table_key == table && c.obj_key == obj && c.col_key == col) {
                 m_active_collection = c.changes;

--- a/src/realm/replication.cpp
+++ b/src/realm/replication.cpp
@@ -19,6 +19,7 @@
 #include <realm/replication.hpp>
 
 #include <realm/list.hpp>
+#include <iostream>
 
 using namespace realm;
 using namespace realm::util;
@@ -98,9 +99,10 @@ void Replication::do_select_collection(const CollectionBase& list)
     select_table(list.get_table().unchecked_ptr());
     ColKey col_key = list.get_col_key();
     ObjKey key = list.get_owner_key();
+    auto path = list.get_short_path();
 
-    m_encoder.select_collection(col_key, key); // Throws
-    m_selected_list = CollectionId(list.get_table()->get_key(), key, col_key);
+    m_encoder.select_collection(col_key, key, path); // Throws
+    m_selected_list = CollectionId(list.get_table()->get_key(), key, std::move(path));
 }
 
 void Replication::list_clear(const CollectionBase& list)

--- a/src/realm/replication.hpp
+++ b/src/realm/replication.hpp
@@ -397,24 +397,24 @@ private:
     struct CollectionId {
         TableKey table_key;
         ObjKey object_key;
-        ColKey col_id;
+        std::vector<PathElement> path;
 
         CollectionId() = default;
         CollectionId(const CollectionBase& list)
             : table_key(list.get_table()->get_key())
             , object_key(list.get_owner_key())
-            , col_id(list.get_col_key())
+            , path(list.get_short_path())
         {
         }
-        CollectionId(TableKey t, ObjKey k, ColKey c)
+        CollectionId(TableKey t, ObjKey k, std::vector<PathElement>&& p)
             : table_key(t)
             , object_key(k)
-            , col_id(c)
+            , path(std::move(p))
         {
         }
         bool operator!=(const CollectionId& other)
         {
-            return object_key != other.object_key || table_key != other.table_key || col_id != other.col_id;
+            return object_key != other.object_key || table_key != other.table_key || path != other.path;
         }
     };
 

--- a/src/realm/set.hpp
+++ b/src/realm/set.hpp
@@ -343,6 +343,16 @@ public:
         return CollectionType::Set;
     }
 
+    FullPath get_path() const noexcept final
+    {
+        return m_set.get_path();
+    }
+
+    Path get_short_path() const noexcept final
+    {
+        return m_set.get_short_path();
+    }
+
     // Overriding members of SetBase:
     SetBasePtr clone() const override
     {

--- a/src/realm/sync/instruction_replication.hpp
+++ b/src/realm/sync/instruction_replication.hpp
@@ -128,7 +128,7 @@ private:
 
     Instruction::PrimaryKey as_primary_key(Mixed);
     Instruction::PrimaryKey primary_key_for_object(const Table&, ObjKey key);
-    void populate_path_instr(Instruction::PathInstruction&, const Table&, ObjKey key, StringData field_name);
+    void populate_path_instr(Instruction::PathInstruction&, const Table&, ObjKey key, ColKey col_key);
     void populate_path_instr(Instruction::PathInstruction&, const CollectionBase&);
     void populate_path_instr(Instruction::PathInstruction&, const CollectionBase&, uint32_t ndx);
 
@@ -138,7 +138,7 @@ private:
     // lookups.
     const Table* m_last_table = nullptr;
     ObjKey m_last_object;
-    std::string m_last_field_name;
+    StringData m_last_field_name;
     InternString m_last_class_name;
     util::Optional<Instruction::PrimaryKey> m_last_primary_key;
     InternString m_last_interned_field_name;

--- a/test/test_lang_bind_helper.cpp
+++ b/test/test_lang_bind_helper.cpp
@@ -1980,117 +1980,6 @@ TEST(LangBindHelper_AdvanceReadTransact_UnorderedTableViewClear)
 }
 
 namespace {
-// A base class for transaction log parsers so that tests which want to test
-// just a single part of the transaction log handling don't have to implement
-// the entire interface
-class NoOpTransactionLogParser {
-public:
-    NoOpTransactionLogParser(TestContext& context)
-        : test_context(context)
-    {
-    }
-
-    TableKey get_current_table() const
-    {
-        return m_current_table;
-    }
-
-    std::pair<ColKey, ObjKey> get_current_linkview() const
-    {
-        return {m_current_linkview_col, m_current_linkview_row};
-    }
-
-protected:
-    TestContext& test_context;
-
-private:
-    TableKey m_current_table;
-    ColKey m_current_linkview_col;
-    ObjKey m_current_linkview_row;
-
-public:
-    void parse_complete() {}
-
-    bool select_table(TableKey t)
-    {
-        m_current_table = t;
-        return true;
-    }
-
-    bool select_collection(ColKey col_key, ObjKey obj_key)
-    {
-        m_current_linkview_col = col_key;
-        m_current_linkview_row = obj_key;
-        return true;
-    }
-
-    // Default no-op implementations of all of the mutation instructions
-    bool insert_group_level_table(TableKey)
-    {
-        return false;
-    }
-    bool erase_class(TableKey)
-    {
-        return false;
-    }
-    bool rename_class(TableKey)
-    {
-        return false;
-    }
-    bool insert_column(ColKey)
-    {
-        return false;
-    }
-    bool erase_column(ColKey)
-    {
-        return false;
-    }
-    bool rename_column(ColKey)
-    {
-        return false;
-    }
-    bool set_link_type(ColKey)
-    {
-        return false;
-    }
-    bool create_object(ObjKey)
-    {
-        return false;
-    }
-    bool remove_object(ObjKey)
-    {
-        return false;
-    }
-    bool collection_set(size_t)
-    {
-        return false;
-    }
-    bool collection_clear(size_t)
-    {
-        return false;
-    }
-    bool collection_erase(size_t)
-    {
-        return false;
-    }
-    bool collection_insert(size_t)
-    {
-        return false;
-    }
-    bool collection_move(size_t, size_t)
-    {
-        return false;
-    }
-    bool modify_object(ColKey, ObjKey)
-    {
-        return false;
-    }
-    bool typed_link_change(ColKey, TableKey)
-    {
-        return true;
-    }
-};
-
 struct AdvanceReadTransact {
     template <typename Func>
     static void call(TransactionRef tr, Func* func)
@@ -2127,8 +2016,12 @@ TEST_TYPES(LangBindHelper_AdvanceReadTransact_TransactLog, AdvanceReadTransact, 
 
     {
         // With no changes, the handler should not be called at all
-        struct : NoOpTransactionLogParser {
-            using NoOpTransactionLogParser::NoOpTransactionLogParser;
+        struct Parser : _impl::NoOpTransactionLogParser {
+            TestContext& test_context;
+            Parser(TestContext& context)
+                : test_context(context)
+            {
+            }
             void parse_complete()
             {
                 CHECK(false);
@@ -2142,10 +2035,15 @@ TEST_TYPES(LangBindHelper_AdvanceReadTransact_TransactLog, AdvanceReadTransact, 
         auto wt = sg->start_write();
         wt->commit();
 
-        struct foo : NoOpTransactionLogParser {
-            using NoOpTransactionLogParser::NoOpTransactionLogParser;
-
+        struct Parser : _impl::NoOpTransactionLogParser {
+            TestContext& test_context;
             bool called = false;
+
+            Parser(TestContext& context)
+                : test_context(context)
+            {
+            }
+
             void parse_complete()
             {
                 called = true;
@@ -2157,12 +2055,16 @@ TEST_TYPES(LangBindHelper_AdvanceReadTransact_TransactLog, AdvanceReadTransact, 
     ObjKey o0, o1;
     {
         // Make a simple modification and verify that the appropriate handler is called
-        struct foo : NoOpTransactionLogParser {
-            using NoOpTransactionLogParser::NoOpTransactionLogParser;
-
+        struct Parser : _impl::NoOpTransactionLogParser {
+            TestContext& test_context;
             size_t expected_table = 0;
             TableKey t1;
             TableKey t2;
+
+            Parser(TestContext& context)
+                : test_context(context)
+            {
+            }
 
             bool create_object(ObjKey)
             {
@@ -2206,8 +2108,12 @@ TEST_TYPES(LangBindHelper_AdvanceReadTransact_TransactLog, AdvanceReadTransact, 
         wt.get_table("table 2")->remove_object(o1);
         wt.commit();
 
-        struct : NoOpTransactionLogParser {
-            using NoOpTransactionLogParser::NoOpTransactionLogParser;
+        struct Parser : _impl::NoOpTransactionLogParser {
+            TestContext& test_context;
+            Parser(TestContext& context)
+                : test_context(context)
+            {
+            }
 
             bool remove_object(ObjKey o)
             {
@@ -2259,8 +2165,12 @@ TEST_TYPES(LangBindHelper_AdvanceReadTransact_TransactLog, AdvanceReadTransact, 
         WriteTransaction wt(sg);
         wt.get_table("link origin")->begin()->get_linklist(c3).clear();
         wt.commit();
-        struct : NoOpTransactionLogParser {
-            using NoOpTransactionLogParser::NoOpTransactionLogParser;
+        struct Parser : _impl::NoOpTransactionLogParser {
+            TestContext& test_context;
+            Parser(TestContext& context)
+                : test_context(context)
+            {
+            }
 
             bool collection_clear(size_t old_size) const
             {
@@ -2302,8 +2212,12 @@ TEST(LangBindHelper_AdvanceReadTransact_ErrorInObserver)
     struct ObserverError {
     };
     try {
-        struct : NoOpTransactionLogParser {
-            using NoOpTransactionLogParser::NoOpTransactionLogParser;
+        struct Parser : _impl::NoOpTransactionLogParser {
+            TestContext& test_context;
+            Parser(TestContext& context)
+                : test_context(context)
+            {
+            }
 
             bool modify_object(ColKey, ObjKey) const
             {

--- a/test/test_lang_bind_helper.cpp
+++ b/test/test_lang_bind_helper.cpp
@@ -2120,7 +2120,7 @@ TEST_TYPES(LangBindHelper_AdvanceReadTransact_TransactLog, AdvanceReadTransact, 
                 CHECK(o == o1 || o == o0);
                 return true;
             }
-            bool select_collection(ColKey col, ObjKey o)
+            bool select_collection(ColKey col, ObjKey o, const std::vector<PathElement>&)
             {
                 CHECK(col == link_list_col);
                 CHECK(o == okey);

--- a/test/test_list.cpp
+++ b/test/test_list.cpp
@@ -1236,7 +1236,8 @@ TEST(List_NestedList_Path)
     auto dict_col =
         top_table->add_column(*embedded_table, "embedded_dict", {CollectionType::Dictionary, CollectionType::List});
     auto string_col = top_table->add_column_list(type_String, "strings");
-    top_table->add_column(type_Float, "floats", false, {CollectionType::Dictionary, CollectionType::List});
+    auto float_col =
+        top_table->add_column(type_Float, "floats", false, {CollectionType::Dictionary, CollectionType::List});
     embedded_table->add_column(type_Int, "integers", false, {CollectionType::Dictionary, CollectionType::List});
     auto col_any = top_table->add_column(type_Mixed, "Any");
 
@@ -1247,7 +1248,7 @@ TEST(List_NestedList_Path)
         auto list_string = o.get_list<String>(string_col);
         auto path = list_string.get_path();
         CHECK_EQUAL(path.path_from_top.size(), 1);
-        CHECK_EQUAL(path.path_from_top[0], "strings");
+        CHECK_EQUAL(path.path_from_top[0], string_col);
     }
 
     // List nested in Dictionary
@@ -1256,7 +1257,7 @@ TEST(List_NestedList_Path)
         list_float->add(5.f);
         auto path = list_float->get_path();
         CHECK_EQUAL(path.path_from_top.size(), 2);
-        CHECK_EQUAL(path.path_from_top[0], "floats");
+        CHECK_EQUAL(path.path_from_top[0], float_col);
         CHECK_EQUAL(path.path_from_top[1], "Foo");
     }
 
@@ -1274,7 +1275,7 @@ TEST(List_NestedList_Path)
         list_int->add(5);
         auto path = list_int->get_path();
         CHECK_EQUAL(path.path_from_top.size(), 5);
-        CHECK_EQUAL(path.path_from_top[0], "embedded_list");
+        CHECK_EQUAL(path.path_from_top[0], list_col);
         CHECK_EQUAL(path.path_from_top[1], 2);
         CHECK_EQUAL(path.path_from_top[2], 1);
         CHECK_EQUAL(path.path_from_top[3], "integers");
@@ -1295,7 +1296,7 @@ TEST(List_NestedList_Path)
         list_int->add(5);
         auto path = list_int->get_path();
         CHECK_EQUAL(path.path_from_top.size(), 5);
-        CHECK_EQUAL(path.path_from_top[0], "embedded_dict");
+        CHECK_EQUAL(path.path_from_top[0], dict_col);
         CHECK_EQUAL(path.path_from_top[1], "C");
         CHECK_EQUAL(path.path_from_top[2], 1);
         CHECK_EQUAL(path.path_from_top[3], "integers");
@@ -1312,7 +1313,7 @@ TEST(List_NestedList_Path)
         auto dict2 = list->get_dictionary(1);
         auto path = dict2->get_path();
         CHECK_EQUAL(path.path_from_top.size(), 3);
-        CHECK_EQUAL(path.path_from_top[0], "Any");
+        CHECK_EQUAL(path.path_from_top[0], col_any);
         CHECK_EQUAL(path.path_from_top[1], "List");
         CHECK_EQUAL(path.path_from_top[2], 1);
     }

--- a/test/test_table.cpp
+++ b/test/test_table.cpp
@@ -4923,7 +4923,7 @@ TEST(Table_EmbeddedObjectCreateAndDestroyDictionary)
 
     auto obj_path = o2.get_path();
     CHECK_EQUAL(obj_path.path_from_top.size(), 2);
-    CHECK_EQUAL(obj_path.path_from_top[0], "theGreatColumn");
+    CHECK_EQUAL(obj_path.path_from_top[0], ck);
     CHECK_EQUAL(obj_path.path_from_top[1], "one");
 
     Obj o3 = parent_dict.create_and_insert_linked_object("two");
@@ -4941,14 +4941,14 @@ TEST(Table_EmbeddedObjectCreateAndDestroyDictionary)
 
     obj_path = o2_dict.get_object("foo1").get_path();
     CHECK_EQUAL(obj_path.path_from_top.size(), 4);
-    CHECK_EQUAL(obj_path.path_from_top[0], "theGreatColumn");
+    CHECK_EQUAL(obj_path.path_from_top[0], ck);
     CHECK_EQUAL(obj_path.path_from_top[1], "one");
     CHECK_EQUAL(obj_path.path_from_top[2], "theRecursiveBit");
     CHECK_EQUAL(obj_path.path_from_top[3], "foo1");
 
     obj_path = o4_dict.get_object("foo4").get_path();
     CHECK_EQUAL(obj_path.path_from_top.size(), 3);
-    CHECK_EQUAL(obj_path.path_from_top[0], "theLesserColumn");
+    CHECK_EQUAL(obj_path.path_from_top[0], ck1);
     CHECK_EQUAL(obj_path.path_from_top[1], "theRecursiveBit");
     CHECK_EQUAL(obj_path.path_from_top[2], "foo4");
 


### PR DESCRIPTION
Enables support for notifications on nested collections. There is a FIXME in `src/realm/object-store/impl/transact_log_handler.cpp` that indicates where this support should take off.