### PR TITLE
Fix an assertion failure if an async write callback ran during a write transaction

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 * Access token refresh for websockets was not updating the location metadata ([#6630](https://github.com/realm/realm-core/issues/6630), since v13.9.3)
 * Fix several UBSan failures which did not appear to result in functional bugs ([#6649](https://github.com/realm/realm-core/pull/6649)).
 * Fix an out-of-bounds read in sectioned results when sectioned are removed by modifying all objects in that section to no longer appear in that section ([#6649](https://github.com/realm/realm-core/pull/6649), since v13.12.0)
+* Using both synchronous and asynchronous transactions on the same thread or scheduler could hit the assertion failure "!realm.is_in_transaction()" if one of the callbacks for an asynchronous transaction happened to be scheduled during a synchronous transaction ([#6659](https://github.com/realm/realm-core/issues/6659), since v11.8.0)
 
 ### Breaking changes
 * None.

--- a/src/realm/object-store/shared_realm.cpp
+++ b/src/realm/object-store/shared_realm.cpp
@@ -789,6 +789,12 @@ void Realm::run_writes()
         // writes as we can't add commits while in that state
         return;
     }
+    if (is_in_transaction()) {
+        // This is scheduled asynchronously after acquiring the write lock, so
+        // in that time a synchronous transaction may have been started. If so,
+        // we'll be re-invoked when that transaction ends.
+        return;
+    }
 
     CountGuard running_writes(m_is_running_async_writes);
     int run_limit = 20; // max number of commits without full sync to disk

--- a/test/object-store/util/event_loop.cpp
+++ b/test/object-store/util/event_loop.cpp
@@ -81,6 +81,9 @@ struct EventLoop::Impl {
     // Schedule execution of the given function on the event loop.
     void perform(util::UniqueFunction<void()>);
 
+    // Run the event loop until all currently pending work has been run.
+    void run_pending();
+
     ~Impl();
 
 private:
@@ -122,6 +125,11 @@ void EventLoop::run_until(util::FunctionRef<bool()> predicate)
 void EventLoop::perform(util::UniqueFunction<void()> function)
 {
     return m_impl->perform(std::move(function));
+}
+
+void EventLoop::run_pending()
+{
+    return m_impl->run_pending();
 }
 
 #if REALM_USE_UV
@@ -204,6 +212,11 @@ void EventLoop::Impl::perform(util::UniqueFunction<void()> f)
     uv_async_send(&m_perform_work);
 }
 
+void EventLoop::Impl::run_pending()
+{
+    uv_run(m_loop, UV_RUN_NOWAIT);
+}
+
 #elif REALM_PLATFORM_APPLE
 
 bool EventLoop::has_implementation()
@@ -254,6 +267,12 @@ void EventLoop::Impl::perform(util::UniqueFunction<void()> func)
     CFRunLoopWakeUp(m_loop.get());
 }
 
+void EventLoop::Impl::run_pending()
+{
+    while (CFRunLoopRunInMode(kCFRunLoopDefaultMode, 0, true) == kCFRunLoopRunHandledSource)
+        ;
+}
+
 #else
 
 bool EventLoop::has_implementation()
@@ -270,6 +289,10 @@ void EventLoop::Impl::run_until(util::FunctionRef<bool()>)
     printf("WARNING: there is no event loop implementation and nothing is happening.\n");
 }
 void EventLoop::Impl::perform(util::UniqueFunction<void()>)
+{
+    printf("WARNING: there is no event loop implementation and nothing is happening.\n");
+}
+void EventLoop::Impl::run_pending()
 {
     printf("WARNING: there is no event loop implementation and nothing is happening.\n");
 }

--- a/test/object-store/util/event_loop.hpp
+++ b/test/object-store/util/event_loop.hpp
@@ -39,6 +39,9 @@ struct EventLoop {
     // Schedule execution of the given function on the event loop.
     void perform(util::UniqueFunction<void()>);
 
+    // Run the event loop until all currently pending work has been run.
+    void run_pending();
+
     EventLoop(EventLoop&&) = default;
     EventLoop& operator=(EventLoop&&) = default;
     ~EventLoop();


### PR DESCRIPTION
Between when the callback after acquiring the write lock is scheduled and when it's invoked a synchronous write transaction can be begun, and if it's not ended before the next time the scheduler gets to run, the scheduled callback will be invoked inside the write. When this happens we want to just do nothing. Ending the synchronous write transaction will take care of rescheduling the async write it preempted.

Fixes #6649.