### PR TITLE
Fix a lock order inversion in tests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@
 
 ### Internals
 * Simplify the implementation of query expression nodes which have a btree leaf cache.
+* Fix a lock order inversion hit by object store tests running on linux. The cycle required test-specific code and so is not applicable to non-tests.
 
 ----------------------------------------------
 


### PR DESCRIPTION
The cycle was DaemonThread::m_running_on_change_mutex => RealmCoordinator::m_realm_mutex  => SyncManager::m_mutex  => RealmCoordinator::s_coordinator_mutex  =>
DaemonThread::m_running_on_change_mutex, and it happened due to DaemonThread::remove() being called inside RealmCoordinator::clear_cache() while holding s_coordinator_mutex. Fortunately we don't actually need to be doing that.

As the cycle required RealmCoordinator::clear_all_caches(), this was only applicable to tests.

Fixes the failure seen at https://evergreen.mongodb.com/task_log_raw/realm_core_stable_ubuntu2004_tsan_object_store_tests_patch_61da27ef08da7f5d14d5ae9b35815f02a4da2c1a_646d698b32f417862ba06fae_23_05_24_01_34_04/0?type=T&text=true.