### PR TITLE
Remove catch() clause to prevent truncating stack trace in AsyncOper::do_recycle_and_execute()

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@
 
 ### Internals
 * Simplify the implementation of query expression nodes which have a btree leaf cache.
+* Remove catch() clause to prevent truncating stack trace in AsyncOper::do_recycle_and_execute() ([PR #6667](https://github.com/realm/realm-core/pull/6667))
 
 ----------------------------------------------
 

--- a/src/realm/sync/network/network.hpp
+++ b/src/realm/sync/network/network.hpp
@@ -2747,28 +2747,24 @@ inline void Service::AsyncOper::do_recycle_and_execute(bool orphaned, H& handler
     // the memory is available for a new post operation that might be initiated
     // during the execution of the handler.
     bool was_recycled = false;
-    try {
-        // We need to copy or move all arguments to be passed to the handler,
-        // such that there is no risk of references to the recycled operation
-        // object being passed to the handler (the passed arguments may be
-        // references to members of the recycled operation object). The easiest
-        // way to achive this, is by forwarding the reference arguments (passed
-        // to this function) to a helper function whose arguments have
-        // nonreference type (`Args...` rather than `Args&&...`).
-        //
-        // Note that the copying and moving of arguments may throw, and it is
-        // important that the operation is still recycled even if that
-        // happens. For that reason, copying and moving of arguments must not
-        // happen until we are in a scope (this scope) that catches and deals
-        // correctly with such exceptions.
-        do_recycle_and_execute_helper(orphaned, was_recycled, std::move(handler),
-                                      std::forward<Args>(args)...); // Throws
-    }
-    catch (...) {
-        if (!was_recycled)
-            do_recycle(orphaned);
-        throw;
-    }
+
+    // We need to copy or move all arguments to be passed to the handler,
+    // such that there is no risk of references to the recycled operation
+    // object being passed to the handler (the passed arguments may be
+    // references to members of the recycled operation object). The easiest
+    // way to achive this, is by forwarding the reference arguments (passed
+    // to this function) to a helper function whose arguments have
+    // nonreference type (`Args...` rather than `Args&&...`).
+    //
+    // Note that the copying and moving of arguments may throw, and it is
+    // important that the operation is still recycled even if that
+    // happens. For that reason, copying and moving of arguments must not
+    // happen until we are in a scope (this scope) that catches and deals
+    // correctly with such exceptions.
+    do_recycle_and_execute_helper(orphaned, was_recycled, std::move(handler),
+                                  std::forward<Args>(args)...); // Throws
+
+    // Removed catch to prevent truncating the stack trace on exception
 }
 
 template <class H, class... Args>


### PR DESCRIPTION
## What, How & Why?
Remove the catch clause from `AsyncOper::do_recycle_and_execute()` to avoid truncating the stack trace when an exception occurs on the event loop. This has the side effect that `do_recycle()` may have not been called on the `AsyncOper` object, but these exceptions are fatal and it doesn't matter if the memory is deleted or reclaimed at this point.

#Fixes #6665

## ☑️ ToDos
* [x] 📝 Changelog update
* ~~[ ] 🚦 Tests (or not relevant)~~
* ~~[ ] C-API, if public C++ API changed.~~
