### PR TITLE
Fix SessionWrapper use-after-free crash when tearing down sessions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 * Access token refresh for websockets was not updating the location metadata ([#6630](https://github.com/realm/realm-core/issues/6630), since v13.9.3)
 * Fix several UBSan failures which did not appear to result in functional bugs ([#6649](https://github.com/realm/realm-core/pull/6649)).
 * Fix an out-of-bounds read in sectioned results when sectioned are removed by modifying all objects in that section to no longer appear in that section ([#6649](https://github.com/realm/realm-core/pull/6649), since v13.12.0)
+* Fix SessionWrapper use-after-free crash when tearing down sessions ([#6656](https://github.com/realm/realm-core/issues/6656), since v13.9.3)
 
 ### Breaking changes
 * None.


### PR DESCRIPTION
## What, How & Why?
There was a race condition between the `SessionWrapper` and the `ClientImpl::Session` being torn down, where the Session could outlive the SessionWrapper, leading to a use after free error and causing a seg fault.
The fixes to address this issue include:
* Updated the SessionWrapper pointer in Session to be a bind_ptr that will extend the lifetime of the SessionWrapper until the Session has been deleted and the SessionWrapper has been finalized.
* Added finalized flag in SessionWrapper and added extra checks to make sure functions that rely on the SessionWrapper state aren't called after it has been finalized. 
* Added session ident history to `ClientImpl::Connection` to track the history of previous sessions that have been opened so a protocol error is not thrown if a stale binary message is received after the Session has been deactivated.
* Added checks to the session binary message processing to ignore all incoming messages, other than UNBOUND, if the Session is not in the 'Active' state.

Unfortunately, this issue was hard to test in core, although the SDKs have been able to reproduce the issue more easily. I will continue to investigate adding a test after this is integrated.

Fixes #6656 

## ☑️ ToDos
* [X] 📝 Changelog update
* ~~[ ] 🚦 Tests (or not relevant)~~
* ~~[ ] C-API, if public C++ API changed.~~
