### PR TITLE
Allow frozen Realms to be opened with additive schema changes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,11 +2,11 @@
 
 ### Enhancements
 * <New feature description> (PR [#????](https://github.com/realm/realm-core/pull/????))
-* None.
+* It is now allowed to open old frozen versions with a schema that contains additional classes, but not additional properties. ([PR 6693](https://github.com/realm/realm-core/issues/6693))
 
 ### Fixed
 * <How do the end-user experience this issue? what was the impact?> ([#????](https://github.com/realm/realm-core/issues/????), since v?.?.?)
-* None.
+* Properties in the frozen _before_ Realm instance in the client reset callbacks may have had properties reordered which could lead to exceptions if accessed. ([PR 6693](https://github.com/realm/realm-core/issues/6693), since v13.11.0)
 
 ### Breaking changes
 * None.

--- a/src/realm/object-store/schema.cpp
+++ b/src/realm/object-store/schema.cpp
@@ -34,6 +34,18 @@ bool operator==(Schema const& a, Schema const& b) noexcept
 {
     return static_cast<Schema::base const&>(a) == static_cast<Schema::base const&>(b);
 }
+
+std::ostream& operator<<(std::ostream& os, const Schema& schema)
+{
+    for (auto& o : schema) {
+        os << o.name << ":\n";
+        for (auto& p : o.persisted_properties) {
+            os << util::format("\t%1<%2>\n", p.name, string_for_property_type(p.type));
+        }
+    }
+    return os;
+}
+
 } // namespace realm
 
 Schema::Schema() noexcept = default;

--- a/src/realm/object-store/schema.hpp
+++ b/src/realm/object-store/schema.hpp
@@ -19,6 +19,7 @@
 #ifndef REALM_SCHEMA_HPP
 #define REALM_SCHEMA_HPP
 
+#include <ostream>
 #include <string>
 #include <vector>
 
@@ -200,6 +201,7 @@ public:
     {
         return !(a == b);
     }
+    friend std::ostream& operator<<(std::ostream&, const Schema&);
 
     using base::begin;
     using base::const_iterator;

--- a/src/realm/object-store/shared_realm.cpp
+++ b/src/realm/object-store/shared_realm.cpp
@@ -406,7 +406,9 @@ void Realm::update_schema(Schema schema, uint64_t version, MigrationFunction mig
     Schema actual_schema = get_full_schema();
 
     // Frozen Realms never modify the schema on disk and we just need to verify
-    // that the requested schema is a subset of what actually exists
+    // that the requested schema is compatible with what actually exists on disk
+    // at that frozen version. Adding new tables is allowed as those can be backed
+    // by empty Results, breaking changes are not allowed.
     if (m_frozen_version) {
         ObjectStore::verify_compatible_for_immutable_and_readonly(
             actual_schema.compare(schema, m_config.schema_mode, true));

--- a/src/realm/object-store/shared_realm.cpp
+++ b/src/realm/object-store/shared_realm.cpp
@@ -407,8 +407,9 @@ void Realm::update_schema(Schema schema, uint64_t version, MigrationFunction mig
 
     // Frozen Realms never modify the schema on disk and we just need to verify
     // that the requested schema is compatible with what actually exists on disk
-    // at that frozen version. Adding new tables is allowed as those can be backed
-    // by empty Results, breaking changes are not allowed.
+    // at that frozen version. Tables are allowed to be missing as those can be
+    // represented by empty Results, but tables which exist must have all of the
+    // requested properties with the correct type.
     if (m_frozen_version) {
         ObjectStore::verify_compatible_for_immutable_and_readonly(
             actual_schema.compare(schema, m_config.schema_mode, true));

--- a/src/realm/object-store/shared_realm.cpp
+++ b/src/realm/object-store/shared_realm.cpp
@@ -408,7 +408,7 @@ void Realm::update_schema(Schema schema, uint64_t version, MigrationFunction mig
     // Frozen Realms never modify the schema on disk and we just need to verify
     // that the requested schema is a subset of what actually exists
     if (m_frozen_version) {
-        ObjectStore::verify_valid_external_changes(schema.compare(actual_schema, m_config.schema_mode, true));
+        ObjectStore::verify_compatible_for_immutable_and_readonly(actual_schema.compare(schema, m_config.schema_mode, true));
         set_schema(actual_schema, std::move(schema));
         return;
     }

--- a/src/realm/object-store/shared_realm.cpp
+++ b/src/realm/object-store/shared_realm.cpp
@@ -408,7 +408,8 @@ void Realm::update_schema(Schema schema, uint64_t version, MigrationFunction mig
     // Frozen Realms never modify the schema on disk and we just need to verify
     // that the requested schema is a subset of what actually exists
     if (m_frozen_version) {
-        ObjectStore::verify_compatible_for_immutable_and_readonly(actual_schema.compare(schema, m_config.schema_mode, true));
+        ObjectStore::verify_compatible_for_immutable_and_readonly(
+            actual_schema.compare(schema, m_config.schema_mode, true));
         set_schema(actual_schema, std::move(schema));
         return;
     }

--- a/test/object-store/sync/flx_sync.cpp
+++ b/test/object-store/sync/flx_sync.cpp
@@ -273,7 +273,7 @@ static auto make_client_reset_handler()
 }
 
 TEST_CASE("flx: client reset", "[sync][flx][app][client reset]") {
-    Schema schema{
+    std::vector<ObjectSchema> schema{
         {"TopLevel",
          {
              {"_id", PropertyType::ObjectId, Property::IsPrimary{true}},
@@ -897,6 +897,59 @@ TEST_CASE("flx: client reset", "[sync][flx][app][client reset]") {
             auto sync_error = wait_for_future(std::move(err_future)).get();
             CHECK(sync_error.get_system_error() ==
                   sync::make_error_code(sync::ClientError::auto_client_reset_failure));
+        }
+    }
+
+    SECTION("DiscardLocal: schema indexes match in before and after states") {
+        {
+            config_local.sync_config->error_handler = [](std::shared_ptr<SyncSession>, SyncError) {
+                // ignore spurious failures on this instance
+            };
+            SharedRealm realm = Realm::get_shared_realm(config_local);
+            subscribe_to_and_add_objects(realm, 1);
+            auto subs = realm->get_latest_subscription_set();
+            auto result = subs.get_state_change_notification(sync::SubscriptionSet::State::Complete).get();
+            CHECK(result == sync::SubscriptionSet::State::Complete);
+            reset_utils::trigger_client_reset(harness.session().app_session(), realm);
+            realm->close();
+        }
+        {
+            Realm::Config config_copy = config_local;
+            config_copy.sync_config->error_handler = [](std::shared_ptr<SyncSession>, SyncError err) {
+                FAIL(err);
+            };
+            // reorder a property such that it does not match the on disk property order
+            std::vector<ObjectSchema> local_schema = schema;
+            std::swap(local_schema[0].persisted_properties[1], local_schema[0].persisted_properties[2]);
+            config_copy.schema = local_schema;
+            config_copy.sync_config->client_resync_mode = ClientResyncMode::Recover;
+            auto [promise, future] = util::make_promise_future<void>();
+            auto shared_promise = std::make_shared<decltype(promise)>(std::move(promise));
+            config_copy.sync_config->notify_before_client_reset = [&](SharedRealm frozen_before) {
+                ++before_reset_count;
+                REQUIRE(frozen_before->schema().size() > 0);
+                REQUIRE(frozen_before->schema_version() != ObjectStore::NotVersioned);
+                REQUIRE(frozen_before->schema() == Schema(local_schema));
+            };
+            config_copy.sync_config->notify_after_client_reset =
+                [&, promise = std::move(shared_promise)](SharedRealm frozen_before, ThreadSafeReference after_ref,
+                                                         bool did_recover) {
+                    ++after_reset_count;
+                    REQUIRE(frozen_before->schema().size() > 0);
+                    REQUIRE(frozen_before->schema_version() != ObjectStore::NotVersioned);
+                    REQUIRE(frozen_before->schema() == Schema(local_schema));
+                    SharedRealm after =
+                        Realm::get_shared_realm(std::move(after_ref), util::Scheduler::make_default());
+                    REQUIRE(after);
+                    REQUIRE(after->schema() == Schema(local_schema));
+                    REQUIRE(did_recover);
+                    promise->emplace_value();
+                };
+
+            SharedRealm realm = Realm::get_shared_realm(config_copy);
+            future.get();
+            CHECK(before_reset_count == 1);
+            CHECK(after_reset_count == 1);
         }
     }
 }


### PR DESCRIPTION
We had a report that since https://github.com/realm/realm-core/pull/6602 there was an issue with the frozen Realm instance passed to the client reset notify callbacks not retaining the same schema property indexes as in the live version. This is because the change in 6602 had reset the schema which used whatever order there was on disk rather than the schema passed to the configuration.

This change undoes the previous fix to restore the property ordering. This brings up the original issue of how to pass schema validation in the case of an async open client reset where the frozen Realm has no schema set yet. I have chosen to address this by changing the schema validation on a frozen Realm to allow new classes. I reason that this should be fine, since we allow Results to be backed by nothing.

## ☑️ ToDos
* [x] 📝 Changelog update
* [x] 🚦 Tests (or not relevant)
* [x] C-API, if public C++ API changed.