### PR TITLE
Relax polygon closed ring rule

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 * None.
 
 ### Fixed
+* Geospatial polygons no longer enfoce that rings be closed. If the first point is not equal to the last, then the ring is automatically closed instead of throwing an error. This is in line with MongoDB behaviour. ([PR 6694](https://github.com/realm/realm-core/issues/6694), since v13.12.0)
 * <How do the end-user experience this issue? what was the impact?> ([#????](https://github.com/realm/realm-core/issues/????), since v?.?.?)
 * None.
 


### PR DESCRIPTION
It was discovered that even though MongoDB's [docs](https://www.mongodb.com/docs/manual/reference/geojson/#polygon) say that polygons must have at least 4 points and the first must be equal to the last, the actual behaviour is that rings are automatically closed when the first point does not equal the last one. We aim to align with the server side behaviour so we change the client side accordingly.

## ☑️ ToDos
* [x] 📝 Changelog update
* [x] 🚦 Tests (or not relevant)
* [x] C-API, if public C++ API changed.
