### PR TITLE
User/Server API key provider becomes a single 'API key' provider

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@
 * None.
 
 ### Breaking changes
-* None.
+* A new provider called `IdentityProviderAPIKey` replaces both `IdentityProviderUserAPIKey` and `IdentityProviderServerAPIKey` since those two did the same thing. If SDKs wish to keep the old behaviour without requiring users to make code changes, they can adapt both their existing server and user API key providers to use the new core type. ([#5914](https://github.com/realm/realm-core/issues/5914))
 
 ### Compatibility
 * Fileformat: Generates files with format v23. Reads and automatically upgrade from fileformat v5.

--- a/src/realm.h
+++ b/src/realm.h
@@ -2751,8 +2751,7 @@ typedef enum realm_auth_provider {
     RLM_AUTH_PROVIDER_CUSTOM,
     RLM_AUTH_PROVIDER_EMAIL_PASSWORD,
     RLM_AUTH_PROVIDER_FUNCTION,
-    RLM_AUTH_PROVIDER_USER_API_KEY,
-    RLM_AUTH_PROVIDER_SERVER_API_KEY,
+    RLM_AUTH_PROVIDER_API_KEY,
 } realm_auth_provider_e;
 
 typedef struct realm_app_user_apikey {
@@ -2828,8 +2827,7 @@ RLM_API realm_app_credentials_t* realm_app_credentials_new_apple(const char* id_
 RLM_API realm_app_credentials_t* realm_app_credentials_new_jwt(const char* jwt_token) RLM_API_NOEXCEPT;
 RLM_API realm_app_credentials_t* realm_app_credentials_new_email_password(const char* email,
                                                                           realm_string_t password) RLM_API_NOEXCEPT;
-RLM_API realm_app_credentials_t* realm_app_credentials_new_user_api_key(const char* api_key) RLM_API_NOEXCEPT;
-RLM_API realm_app_credentials_t* realm_app_credentials_new_server_api_key(const char* api_key) RLM_API_NOEXCEPT;
+RLM_API realm_app_credentials_t* realm_app_credentials_new_api_key(const char* api_key) RLM_API_NOEXCEPT;
 
 /**
  * Create Custom Function authentication app credentials.

--- a/src/realm/object-store/c_api/app.cpp
+++ b/src/realm/object-store/c_api/app.cpp
@@ -39,8 +39,7 @@ static_assert(realm_auth_provider_e(AuthProvider::APPLE) == RLM_AUTH_PROVIDER_AP
 static_assert(realm_auth_provider_e(AuthProvider::CUSTOM) == RLM_AUTH_PROVIDER_CUSTOM);
 static_assert(realm_auth_provider_e(AuthProvider::USERNAME_PASSWORD) == RLM_AUTH_PROVIDER_EMAIL_PASSWORD);
 static_assert(realm_auth_provider_e(AuthProvider::FUNCTION) == RLM_AUTH_PROVIDER_FUNCTION);
-static_assert(realm_auth_provider_e(AuthProvider::USER_API_KEY) == RLM_AUTH_PROVIDER_USER_API_KEY);
-static_assert(realm_auth_provider_e(AuthProvider::SERVER_API_KEY) == RLM_AUTH_PROVIDER_SERVER_API_KEY);
+static_assert(realm_auth_provider_e(AuthProvider::API_KEY) == RLM_AUTH_PROVIDER_API_KEY);
 
 
 static realm_app_error_t to_capi(const AppError& error)
@@ -169,14 +168,9 @@ RLM_API realm_app_credentials_t* realm_app_credentials_new_function(const char* 
     });
 }
 
-RLM_API realm_app_credentials_t* realm_app_credentials_new_user_api_key(const char* api_key) noexcept
+RLM_API realm_app_credentials_t* realm_app_credentials_new_api_key(const char* api_key) noexcept
 {
-    return new realm_app_credentials_t(AppCredentials::user_api_key(api_key));
-}
-
-RLM_API realm_app_credentials_t* realm_app_credentials_new_server_api_key(const char* api_key) noexcept
-{
-    return new realm_app_credentials_t(AppCredentials::server_api_key(api_key));
+    return new realm_app_credentials_t(AppCredentials::api_key(api_key));
 }
 
 RLM_API realm_auth_provider_e realm_auth_credentials_get_provider(realm_app_credentials_t* credentials) noexcept

--- a/src/realm/object-store/sync/app_credentials.cpp
+++ b/src/realm/object-store/sync/app_credentials.cpp
@@ -30,8 +30,7 @@ IdentityProvider const IdentityProviderApple = "oauth2-apple";
 IdentityProvider const IdentityProviderUsernamePassword = "local-userpass";
 IdentityProvider const IdentityProviderCustom = "custom-token";
 IdentityProvider const IdentityProviderFunction = "custom-function";
-IdentityProvider const IdentityProviderUserAPIKey = "api-key";
-IdentityProvider const IdentityProviderServerAPIKey = "api-key";
+IdentityProvider const IdentityProviderAPIKey = "api-key";
 
 IdentityProvider provider_type_from_enum(AuthProvider provider)
 {
@@ -51,10 +50,8 @@ IdentityProvider provider_type_from_enum(AuthProvider provider)
             return IdentityProviderUsernamePassword;
         case AuthProvider::FUNCTION:
             return IdentityProviderFunction;
-        case AuthProvider::USER_API_KEY:
-            return IdentityProviderUserAPIKey;
-        case AuthProvider::SERVER_API_KEY:
-            return IdentityProviderServerAPIKey;
+        case AuthProvider::API_KEY:
+            return IdentityProviderAPIKey;
     }
     throw InvalidArgument("unknown provider type in provider_type_from_enum");
 }
@@ -82,11 +79,8 @@ AuthProvider enum_from_provider_type(const IdentityProvider& provider)
     else if (provider == IdentityProviderFunction) {
         return AuthProvider::FUNCTION;
     }
-    else if (provider == IdentityProviderUserAPIKey) {
-        return AuthProvider::USER_API_KEY;
-    }
-    else if (provider == IdentityProviderServerAPIKey) {
-        return AuthProvider::SERVER_API_KEY;
+    else if (provider == IdentityProviderAPIKey) {
+        return AuthProvider::API_KEY;
     }
     else {
         REALM_UNREACHABLE();
@@ -179,14 +173,9 @@ AppCredentials AppCredentials::function(const std::string& serialized_payload)
 }
 
 
-AppCredentials AppCredentials::user_api_key(std::string api_key)
+AppCredentials AppCredentials::api_key(std::string api_key)
 {
-    return AppCredentials(AuthProvider::USER_API_KEY, {{"key", api_key}});
-}
-
-AppCredentials AppCredentials::server_api_key(std::string api_key)
-{
-    return AppCredentials(AuthProvider::SERVER_API_KEY, {{"key", api_key}});
+    return AppCredentials(AuthProvider::API_KEY, {{"key", api_key}});
 }
 
 AppCredentials::AppCredentials(const AppCredentials& credentials)

--- a/src/realm/object-store/sync/app_credentials.hpp
+++ b/src/realm/object-store/sync/app_credentials.hpp
@@ -63,12 +63,8 @@ extern IdentityProvider const IdentityProviderApple;
 extern IdentityProvider const IdentityProviderFunction;
 
 // A credential which can be used to log in as a Stitch user
-// using the User API Key authentication provider.
-extern IdentityProvider const IdentityProviderUserAPIKey;
-
-// A credential which can be used to log in as a Stitch user
-// using the Server API Key authentication provider.
-extern IdentityProvider const IdentityProviderServerAPIKey;
+// using the Server's API Key authentication provider.
+extern IdentityProvider const IdentityProviderAPIKey;
 
 enum class AuthProvider {
     ANONYMOUS,
@@ -79,8 +75,7 @@ enum class AuthProvider {
     CUSTOM,
     USERNAME_PASSWORD,
     FUNCTION,
-    USER_API_KEY,
-    SERVER_API_KEY
+    API_KEY,
 };
 
 IdentityProvider provider_type_from_enum(AuthProvider provider);
@@ -118,12 +113,8 @@ struct AppCredentials {
     // The payload is a MongoDB document as json
     static AppCredentials function(const std::string& serialized_payload);
 
-    // Construct and return credentials with the user api key.
-    static AppCredentials user_api_key(std::string api_key);
-
-    // Construct and return credentials with the server api key.
-    static AppCredentials server_api_key(std::string api_key);
-
+    // Construct and return credentials with the api key.
+    static AppCredentials api_key(std::string api_key);
 
     // The provider of the credential
     AuthProvider provider() const;

--- a/test/object-store/sync/app.cpp
+++ b/test/object-store/sync/app.cpp
@@ -4484,18 +4484,12 @@ TEST_CASE("app: auth providers", "[sync][app]") {
         CHECK(credentials.serialize_as_bson() == bson::BsonDocument{{"name", "mongo"}});
     }
 
-    SECTION("auth providers user api key") {
-        auto credentials = AppCredentials::user_api_key("a key");
-        CHECK(credentials.provider() == AuthProvider::USER_API_KEY);
-        CHECK(credentials.provider_as_string() == IdentityProviderUserAPIKey);
+    SECTION("auth providers api key") {
+        auto credentials = AppCredentials::api_key("a key");
+        CHECK(credentials.provider() == AuthProvider::API_KEY);
+        CHECK(credentials.provider_as_string() == IdentityProviderAPIKey);
         CHECK(credentials.serialize_as_bson() == bson::BsonDocument{{"provider", "api-key"}, {"key", "a key"}});
-    }
-
-    SECTION("auth providers server api key") {
-        auto credentials = AppCredentials::server_api_key("a key");
-        CHECK(credentials.provider() == AuthProvider::SERVER_API_KEY);
-        CHECK(credentials.provider_as_string() == IdentityProviderServerAPIKey);
-        CHECK(credentials.serialize_as_bson() == bson::BsonDocument{{"provider", "api-key"}, {"key", "a key"}});
+        CHECK(enum_from_provider_type(provider_type_from_enum(AuthProvider::API_KEY)) == AuthProvider::API_KEY);
     }
 }
 


### PR DESCRIPTION
Fixes https://github.com/realm/realm-core/issues/5914

As reported, both the user and server API key providers are actually the same on the server side called "api-key". This can lead to confusion and weird things like `enum_from_provider_type(provider_type_from_enum(AuthProvider::SERVER_API_KEY)) != AuthProvider::SERVER_API_KEY;`

This replaces both with a new provider called "API key". I'm not sure how SDKs downstream want to handle this change, but if they don't want to break any user code, it should be fine to wrap the old two to point to this new provider as it does the same thing as the old behaviour.

## ☑️ ToDos
* [x] 📝 Changelog update
* [x] 🚦 Tests (or not relevant)
* [x] C-API, if public C++ API changed.
