### PR TITLE
Fix failing "sync: non-synced metadata table doesn't result in non-additive schema change" tests

### DIFF
--- a/test/object-store/util/test_utils.cpp
+++ b/test/object-store/util/test_utils.cpp
@@ -129,7 +129,7 @@ std::string encode_fake_jwt(const std::string& in, util::Optional<int64_t> exp, 
     using namespace std::chrono_literals;
     if (!exp) {
         std::chrono::system_clock::time_point now = std::chrono::system_clock::now();
-        exp = std::chrono::system_clock::to_time_t(now + 30min);
+        exp = std::chrono::system_clock::to_time_t(now + 60min);
     }
     if (!iat) {
         std::chrono::system_clock::time_point now = std::chrono::system_clock::now();


### PR DESCRIPTION
## What, How & Why?
The "sync: non-synced metadata table doesn't result in non-additive schema change" has been failing occasionally, even though it doesn't perform anything really different than other tests. It turns out that the test was timing out due while trying to query the location info from `https://realm.mongodb.com/api/client/v2.0/app/app_id/location` (which doesn't exist) while trying to refresh the user access token when using the local SyncServer. For all the other tests that use the SyncServer, the access token is still valid and is not attempted to be refreshed.

The current timeout is 30 minutes, which is valid beginning from the time the test program starts. When the test was failing, more than 30 minutes had elapsed and the access token was no longer valid. The access token timeout was increased to 60 minutes to allow for ample time for the tests to complete.

## ☑️ ToDos
* ~~[ ] 📝 Changelog update~~
* ~~[ ] 🚦 Tests (or not relevant)~~
* ~~[ ] C-API, if public C++ API changed.~~
