### PR TITLE
Reporting correct error message on HTTP errors for Emscripten target

### DIFF
--- a/src/realm/object-store/sync/impl/emscripten/network_transport.cpp
+++ b/src/realm/object-store/sync/impl/emscripten/network_transport.cpp
@@ -73,7 +73,7 @@ static void error(emscripten_fetch_t* fetch)
         emscripten_fetch_close(fetch);
     });
     std::unique_ptr<FetchState> state(reinterpret_cast<FetchState*>(fetch->userData));
-    state->completion_block({0, 0, {}, {}, {}});
+    state->completion_block({fetch->status, 0, {}, std::string(fetch->data, size_t(fetch->numBytes)), ErrorCodes::HTTPError});
 }
 
 void EmscriptenNetworkTransport::send_request_to_server(


### PR DESCRIPTION
Currently, Http errors report as 
```
[json.exception.parse_error.101] parse error at line 1, column 1: syntax error while parsing value - unexpected end of input; expected '[', '{', or a literal
```

This fixes the network transport for Emscripten to report errors properly 

```
{"error":"password must be between 6 and 128 characters","error_code":"BadRequest","link":"https://realm.mongodb.com/groups/5d84ec2dcf09a2dcb343aa7a/apps/63d93da2dad7c0ff7cabdd5f/logs?co_id=6480656e2dac9d38f50821a5"}. Client Error: 400
```