### PR TITLE
Reverted minimum swift version to fix failing CI tests

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -1,4 +1,4 @@
-// swift-tools-version:5.6
+// swift-tools-version:5.5
 
 import PackageDescription
 import Foundation


### PR DESCRIPTION
## What, How & Why?
Reverted the Swift minimum version update to 5.6 from 5.5 in #6647, since the `swift-build-and-test` CI tests were failing during the build step on realm core master on Evergreen. The current Mac OS hosts in Evergreen only support OS version 11.x, which does not support Swift version 5.6. There are Mac OS 13.x hosts in process of being added soon and these changes can be reapplied at that point with updates to the evergreen config to use the new hosts.

Verified that the `swift-build-and-test` CI tests run with this fix on a separate patch:
https://spruce.mongodb.com/version/64825c9d9ccd4e91f1fda66a/tasks?sorts=STATUS%3AASC%3BBASE_STATUS%3ADESC

## ☑️ ToDos
* ~~[ ] 📝 Changelog update~~
* ~~[ ] 🚦 Tests (or not relevant)~~
* ~~[ ] C-API, if public C++ API changed.~~
