### PR TITLE
Add [baas] and [local] tags to object store sync tests to identify the tests that rely on BAAS or not

### DIFF
--- a/test/object-store/sync/app.cpp
+++ b/test/object-store/sync/app.cpp
@@ -153,7 +153,7 @@ static std::string create_jwt(const std::string& appId)
 
 // MARK: - Login with Credentials Tests
 
-TEST_CASE("app: login_with_credentials integration", "[sync][app]") {
+TEST_CASE("app: login_with_credentials integration", "[sync][app][baas]") {
     SECTION("login") {
         TestAppSession session;
         auto app = session.app();
@@ -190,7 +190,7 @@ TEST_CASE("app: login_with_credentials integration", "[sync][app]") {
 
 // MARK: - UsernamePasswordProviderClient Tests
 
-TEST_CASE("app: UsernamePasswordProviderClient integration", "[sync][app]") {
+TEST_CASE("app: UsernamePasswordProviderClient integration", "[sync][app][baas]") {
     const std::string base_url = get_base_url();
     AutoVerifiedEmailCredentials creds;
     auto email = creds.email;
@@ -368,7 +368,7 @@ TEST_CASE("app: UsernamePasswordProviderClient integration", "[sync][app]") {
 
 // MARK: - UserAPIKeyProviderClient Tests
 
-TEST_CASE("app: UserAPIKeyProviderClient integration", "[sync][app]") {
+TEST_CASE("app: UserAPIKeyProviderClient integration", "[sync][app][baas]") {
     TestAppSession session;
     auto app = session.app();
     auto client = app->provider_client<App::UserAPIKeyProviderClient>();
@@ -630,7 +630,7 @@ TEST_CASE("app: UserAPIKeyProviderClient integration", "[sync][app]") {
 
 // MARK: - Auth Providers Function Tests
 
-TEST_CASE("app: auth providers function integration", "[sync][app]") {
+TEST_CASE("app: auth providers function integration", "[sync][app][baas]") {
     TestAppSession session;
     auto app = session.app();
 
@@ -644,7 +644,7 @@ TEST_CASE("app: auth providers function integration", "[sync][app]") {
 
 // MARK: - Link User Tests
 
-TEST_CASE("app: link_user integration", "[sync][app]") {
+TEST_CASE("app: link_user integration", "[sync][app][baas]") {
     TestAppSession session;
     auto app = session.app();
 
@@ -677,7 +677,7 @@ TEST_CASE("app: link_user integration", "[sync][app]") {
 
 // MARK: - Delete User Tests
 
-TEST_CASE("app: delete anonymous user integration", "[sync][app]") {
+TEST_CASE("app: delete anonymous user integration", "[sync][app][baas]") {
     TestAppSession session;
     auto app = session.app();
 
@@ -719,7 +719,7 @@ TEST_CASE("app: delete anonymous user integration", "[sync][app]") {
     }
 }
 
-TEST_CASE("app: delete user with credentials integration", "[sync][app]") {
+TEST_CASE("app: delete user with credentials integration", "[sync][app][baas]") {
     TestAppSession session;
     auto app = session.app();
     app->remove_user(app->current_user(), [](auto) {});
@@ -760,7 +760,7 @@ TEST_CASE("app: delete user with credentials integration", "[sync][app]") {
 
 // MARK: - Call Function Tests
 
-TEST_CASE("app: call function", "[sync][app]") {
+TEST_CASE("app: call function", "[sync][app][baas]") {
     TestAppSession session;
     auto app = session.app();
 
@@ -776,7 +776,7 @@ TEST_CASE("app: call function", "[sync][app]") {
 
 // MARK: - Remote Mongo Client Tests
 
-TEST_CASE("app: remote mongo client", "[sync][app]") {
+TEST_CASE("app: remote mongo client", "[sync][app][baas]") {
     TestAppSession session;
     auto app = session.app();
 
@@ -1444,7 +1444,7 @@ TEST_CASE("app: remote mongo client", "[sync][app]") {
 
 // MARK: - Push Notifications Tests
 
-TEST_CASE("app: push notifications", "[sync][app]") {
+TEST_CASE("app: push notifications", "[sync][app][baas]") {
     TestAppSession session;
     auto app = session.app();
     std::shared_ptr<SyncUser> sync_user = app->current_user();
@@ -1526,7 +1526,7 @@ TEST_CASE("app: push notifications", "[sync][app]") {
 
 // MARK: - Token refresh
 
-TEST_CASE("app: token refresh", "[sync][app][token]") {
+TEST_CASE("app: token refresh", "[sync][app][token][baas]") {
     TestAppSession session;
     auto app = session.app();
     std::shared_ptr<SyncUser> sync_user = app->current_user();
@@ -1558,7 +1558,7 @@ TEST_CASE("app: token refresh", "[sync][app][token]") {
 
 // MARK: - Sync Tests
 
-TEST_CASE("app: mixed lists with object links", "[sync][app]") {
+TEST_CASE("app: mixed lists with object links", "[sync][app][baas]") {
     std::string base_url = get_base_url();
     const std::string valid_pk_name = "_id";
     REQUIRE(!base_url.empty());
@@ -1634,7 +1634,7 @@ TEST_CASE("app: mixed lists with object links", "[sync][app]") {
     }
 }
 
-TEST_CASE("app: roundtrip values", "[sync][app]") {
+TEST_CASE("app: roundtrip values", "[sync][app][baas]") {
     std::string base_url = get_base_url();
     const std::string valid_pk_name = "_id";
     REQUIRE(!base_url.empty());
@@ -1683,7 +1683,7 @@ TEST_CASE("app: roundtrip values", "[sync][app]") {
     }
 }
 
-TEST_CASE("app: upgrade from local to synced realm", "[sync][app]") {
+TEST_CASE("app: upgrade from local to synced realm", "[sync][app][baas]") {
     std::string base_url = get_base_url();
     const std::string valid_pk_name = "_id";
     REQUIRE(!base_url.empty());
@@ -1785,7 +1785,7 @@ TEST_CASE("app: upgrade from local to synced realm", "[sync][app]") {
     // r1->read_group().to_json(std::cout);
 }
 
-TEST_CASE("app: set new embedded object", "[sync][app]") {
+TEST_CASE("app: set new embedded object", "[sync][app][baas]") {
     std::string base_url = get_base_url();
     const std::string valid_pk_name = "_id";
     REQUIRE(!base_url.empty());
@@ -1923,7 +1923,7 @@ TEST_CASE("app: set new embedded object", "[sync][app]") {
     }
 }
 
-TEST_CASE("app: make distributable client file", "[sync][app]") {
+TEST_CASE("app: make distributable client file", "[sync][app][baas]") {
     TestAppSession session;
     auto app = session.app();
 
@@ -1997,7 +1997,7 @@ TEST_CASE("app: make distributable client file", "[sync][app]") {
     }
 }
 
-TEST_CASE("app: sync integration", "[sync][app]") {
+TEST_CASE("app: sync integration", "[sync][app][baas]") {
     auto logger = std::make_shared<util::StderrLogger>(realm::util::Logger::Level::TEST_LOGGING_LEVEL);
 
     const auto schema = default_app_config("").schema;
@@ -3221,7 +3221,7 @@ TEST_CASE("app: sync integration", "[sync][app]") {
     }
 }
 
-TEST_CASE("app: custom user data integration tests", "[sync][app]") {
+TEST_CASE("app: custom user data integration tests", "[sync][app][baas]") {
     TestAppSession session;
     auto app = session.app();
     auto user = app->current_user();
@@ -3246,7 +3246,7 @@ TEST_CASE("app: custom user data integration tests", "[sync][app]") {
     }
 }
 
-TEST_CASE("app: jwt login and metadata tests", "[sync][app]") {
+TEST_CASE("app: jwt login and metadata tests", "[sync][app][baas]") {
     TestAppSession session;
     auto app = session.app();
     auto jwt = create_jwt(session.app()->config().app_id);
@@ -3277,7 +3277,7 @@ TEST_CASE("app: jwt login and metadata tests", "[sync][app]") {
 }
 
 namespace cf = realm::collection_fixtures;
-TEMPLATE_TEST_CASE("app: collections of links integration", "[sync][app][collections]", cf::ListOfObjects,
+TEMPLATE_TEST_CASE("app: collections of links integration", "[sync][app][baas][collections]", cf::ListOfObjects,
                    cf::ListOfMixedLinks, cf::SetOfObjects, cf::SetOfMixedLinks, cf::DictionaryOfObjects,
                    cf::DictionaryOfMixedLinks)
 {
@@ -3428,7 +3428,7 @@ TEMPLATE_TEST_CASE("app: collections of links integration", "[sync][app][collect
     }
 }
 
-TEMPLATE_TEST_CASE("app: partition types", "[sync][app][partition]", cf::Int, cf::String, cf::OID, cf::UUID,
+TEMPLATE_TEST_CASE("app: partition types", "[sync][app][baas][partition]", cf::Int, cf::String, cf::OID, cf::UUID,
                    cf::BoxedOptional<cf::Int>, cf::UnboxedOptional<cf::String>, cf::BoxedOptional<cf::OID>,
                    cf::BoxedOptional<cf::UUID>)
 {
@@ -3517,7 +3517,7 @@ TEMPLATE_TEST_CASE("app: partition types", "[sync][app][partition]", cf::Int, cf
 
 #endif // REALM_ENABLE_AUTH_TESTS
 
-TEST_CASE("app: custom error handling", "[sync][app][custom_errors]") {
+TEST_CASE("app: custom error handling", "[sync][app][baas][custom_errors]") {
     class CustomErrorTransport : public GenericNetworkTransport {
     public:
         CustomErrorTransport(int code, const std::string& message)
@@ -3811,7 +3811,7 @@ const std::string UnitTestTransport::user_id = "Ailuropoda melanoleuca";
 const std::string UnitTestTransport::identity_0_id = "Ursus arctos isabellinus";
 const std::string UnitTestTransport::identity_1_id = "Ursus arctos horribilis";
 
-TEST_CASE("subscribable unit tests", "[sync][app]") {
+TEST_CASE("subscribable unit tests", "[sync][app][local]") {
     struct Foo : public Subscribable<Foo> {
         void event()
         {
@@ -3880,7 +3880,7 @@ TEST_CASE("subscribable unit tests", "[sync][app]") {
     }
 }
 
-TEST_CASE("app: login_with_credentials unit_tests", "[sync][app]") {
+TEST_CASE("app: login_with_credentials unit_tests", "[sync][app][local]") {
     auto config = get_config();
 
     SECTION("login_anonymous good") {
@@ -3968,7 +3968,7 @@ TEST_CASE("app: login_with_credentials unit_tests", "[sync][app]") {
     }
 }
 
-TEST_CASE("app: UserAPIKeyProviderClient unit_tests", "[sync][app]") {
+TEST_CASE("app: UserAPIKeyProviderClient unit_tests", "[sync][app][local]") {
     TestSyncManager sync_manager(get_config(), {});
     auto app = sync_manager.app();
     auto client = app->provider_client<App::UserAPIKeyProviderClient>();
@@ -4015,7 +4015,7 @@ TEST_CASE("app: UserAPIKeyProviderClient unit_tests", "[sync][app]") {
 }
 
 
-TEST_CASE("app: user_semantics", "[app]") {
+TEST_CASE("app: user_semantics", "[app][local]") {
     TestSyncManager tsm(get_config(), {});
     auto app = tsm.app();
 
@@ -4160,7 +4160,7 @@ private:
     Response* m_response;
 };
 
-TEST_CASE("app: response error handling", "[sync][app]") {
+TEST_CASE("app: response error handling", "[sync][app][local]") {
     std::string response_body = nlohmann::json({{"access_token", good_access_token},
                                                 {"refresh_token", good_access_token},
                                                 {"user_id", "Brown Bear"},
@@ -4243,7 +4243,7 @@ TEST_CASE("app: response error handling", "[sync][app]") {
     }
 }
 
-TEST_CASE("app: switch user", "[sync][app]") {
+TEST_CASE("app: switch user", "[sync][app][local]") {
     TestSyncManager tsm(get_config(), {});
     auto app = tsm.app();
 
@@ -4299,7 +4299,7 @@ TEST_CASE("app: switch user", "[sync][app]") {
     }
 }
 
-TEST_CASE("app: remove anonymous user", "[sync][app]") {
+TEST_CASE("app: remove anonymous user", "[sync][app][local]") {
     TestSyncManager tsm(get_config(), {});
     auto app = tsm.app();
 
@@ -4341,7 +4341,7 @@ TEST_CASE("app: remove anonymous user", "[sync][app]") {
     }
 }
 
-TEST_CASE("app: remove user with credentials", "[sync][app]") {
+TEST_CASE("app: remove user with credentials", "[sync][app][local]") {
     TestSyncManager tsm(get_config(), {});
     auto app = tsm.app();
 
@@ -4374,7 +4374,7 @@ TEST_CASE("app: remove user with credentials", "[sync][app]") {
     }
 }
 
-TEST_CASE("app: link_user", "[sync][app]") {
+TEST_CASE("app: link_user", "[sync][app][local]") {
     TestSyncManager tsm(get_config(), {});
     auto app = tsm.app();
 
@@ -4413,7 +4413,7 @@ TEST_CASE("app: link_user", "[sync][app]") {
     }
 }
 
-TEST_CASE("app: auth providers", "[sync][app]") {
+TEST_CASE("app: auth providers", "[sync][app][local]") {
     SECTION("auth providers facebook") {
         auto credentials = AppCredentials::facebook("a_token");
         CHECK(credentials.provider() == AuthProvider::FACEBOOK);
@@ -4493,7 +4493,7 @@ TEST_CASE("app: auth providers", "[sync][app]") {
     }
 }
 
-TEST_CASE("app: refresh access token unit tests", "[sync][app]") {
+TEST_CASE("app: refresh access token unit tests", "[sync][app][local]") {
     auto setup_user = [](std::shared_ptr<App> app) {
         if (app->sync_manager()->get_current_user()) {
             return;
@@ -4714,7 +4714,7 @@ private:
 
 } // namespace
 
-TEST_CASE("app: app destroyed during token refresh", "[sync][app]") {
+TEST_CASE("app: app destroyed during token refresh", "[sync][app][local]") {
     AsyncMockNetworkTransport mock_transport_worker;
     enum class TestState { unknown, location, login, profile_1, profile_2, refresh_1, refresh_2, refresh_3 };
     struct TestStateBundle {
@@ -4864,7 +4864,7 @@ TEST_CASE("app: app destroyed during token refresh", "[sync][app]") {
     mock_transport_worker.mark_complete();
 }
 
-TEST_CASE("app: metadata is persisted between sessions", "[sync][app]") {
+TEST_CASE("app: metadata is persisted between sessions", "[sync][app][local]") {
     static const auto test_hostname = "proto://host:1234";
     static const auto test_ws_hostname = "wsproto://host:1234";
 
@@ -4918,7 +4918,7 @@ TEST_CASE("app: metadata is persisted between sessions", "[sync][app]") {
     }
 }
 
-TEST_CASE("app: make_streaming_request", "[sync][app]") {
+TEST_CASE("app: make_streaming_request", "[sync][app][local]") {
     UnitTestTransport::access_token = good_access_token;
 
     constexpr uint64_t timeout_ms = 60000;
@@ -4992,7 +4992,7 @@ TEST_CASE("app: make_streaming_request", "[sync][app]") {
     }
 }
 
-TEST_CASE("app: sync_user_profile unit tests", "[sync][app]") {
+TEST_CASE("app: sync_user_profile unit tests", "[sync][app][local]") {
     SECTION("with empty map") {
         auto profile = SyncUserProfile(bson::BsonDocument());
         CHECK(profile.name() == util::none);
@@ -5030,7 +5030,7 @@ TEST_CASE("app: sync_user_profile unit tests", "[sync][app]") {
 }
 
 #if 0
-TEST_CASE("app: app cannot get deallocated during log in", "[sync][app]") {
+TEST_CASE("app: app cannot get deallocated during log in", "[sync][app][local]") {
     AsyncMockNetworkTransport mock_transport_worker;
     enum class TestState { unknown, location, login, app_deallocated, profile };
     struct TestStateBundle {
@@ -5122,7 +5122,7 @@ TEST_CASE("app: app cannot get deallocated during log in", "[sync][app]") {
 }
 #endif
 
-TEST_CASE("app: user logs out while profile is fetched", "[sync][app]") {
+TEST_CASE("app: user logs out while profile is fetched", "[sync][app][local]") {
     AsyncMockNetworkTransport mock_transport_worker;
     enum class TestState { unknown, location, login, profile };
     struct TestStateBundle {
@@ -5219,7 +5219,7 @@ TEST_CASE("app: user logs out while profile is fetched", "[sync][app]") {
     mock_transport_worker.mark_complete();
 }
 
-TEST_CASE("app: shared instances", "[sync][app]") {
+TEST_CASE("app: shared instances", "[sync][app][local]") {
     App::Config base_config;
     set_app_config_defaults(base_config, instance_of<UnitTestTransport>);
 

--- a/test/object-store/sync/client_reset.cpp
+++ b/test/object-store/sync/client_reset.cpp
@@ -109,7 +109,7 @@ TableRef get_table(Realm& realm, StringData object_type)
 namespace cf = realm::collection_fixtures;
 using reset_utils::create_object;
 
-TEST_CASE("sync: large reset with recovery is restartable", "[client reset]") {
+TEST_CASE("sync: large reset with recovery is restartable", "[client reset][baas]") {
     const reset_utils::Partition partition{"realm_id", random_string(20)};
     Property partition_prop = {partition.property_name, PropertyType::String | PropertyType::Nullable};
     Schema schema{
@@ -204,7 +204,7 @@ TEST_CASE("sync: large reset with recovery is restartable", "[client reset]") {
     REQUIRE(expected_obj_ids == found_object_ids);
 }
 
-TEST_CASE("sync: pending client resets are cleared when downloads are complete", "[client reset]") {
+TEST_CASE("sync: pending client resets are cleared when downloads are complete", "[client reset][baas]") {
     const reset_utils::Partition partition{"realm_id", random_string(20)};
     Property partition_prop = {partition.property_name, PropertyType::String | PropertyType::Nullable};
     Schema schema{
@@ -261,7 +261,7 @@ TEST_CASE("sync: pending client resets are cleared when downloads are complete",
     wait_for_download(*realm, std::chrono::minutes(10));
 }
 
-TEST_CASE("sync: client reset", "[client reset]") {
+TEST_CASE("sync: client reset", "[client reset][baas]") {
     if (!util::EventLoop::has_implementation())
         return;
 
@@ -1781,7 +1781,7 @@ TEST_CASE("sync: client reset", "[client reset]") {
     } // end: The server can prohibit recovery
 }
 
-TEST_CASE("sync: Client reset during async open", "[client reset]") {
+TEST_CASE("sync: Client reset during async open", "[client reset][baas]") {
     const reset_utils::Partition partition{"realm_id", random_string(20)};
     Property partition_prop = {partition.property_name, PropertyType::String | PropertyType::Nullable};
     Schema schema{

--- a/test/object-store/sync/file.cpp
+++ b/test/object-store/sync/file.cpp
@@ -28,7 +28,7 @@ using namespace realm;
 using namespace realm::util;
 using File = realm::util::File;
 
-TEST_CASE("sync_file: percent-encoding APIs", "[sync]") {
+TEST_CASE("sync_file: percent-encoding APIs", "[sync][local]") {
     SECTION("does not encode a string that has no restricted characters") {
         const std::string expected = "abcdefghijklmnopqrstuvwxyz0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZ_-";
         auto actual = make_percent_encoded_string(expected);
@@ -64,7 +64,7 @@ TEST_CASE("sync_file: percent-encoding APIs", "[sync]") {
     }
 }
 
-TEST_CASE("sync_file: URL manipulation APIs", "[sync]") {
+TEST_CASE("sync_file: URL manipulation APIs", "[sync][local]") {
     SECTION("properly concatenates a path when the path has a trailing slash") {
         const std::string expected = "/foo/bar";
         const std::string path = "/foo";
@@ -130,7 +130,7 @@ TEST_CASE("sync_file: URL manipulation APIs", "[sync]") {
     }
 }
 
-TEST_CASE("sync_file: SyncFileManager APIs", "[sync]") {
+TEST_CASE("sync_file: SyncFileManager APIs", "[sync][local]") {
     TestSyncManager tsm;
 
     const std::string identity = "abcdefghi";

--- a/test/object-store/sync/flx_migration.cpp
+++ b/test/object-store/sync/flx_migration.cpp
@@ -110,7 +110,7 @@ static std::vector<ObjectId> fill_test_data(SyncTestFile& config, std::optional<
 }
 
 
-TEST_CASE("Test server migration and rollback", "[flx][migration]") {
+TEST_CASE("Test server migration and rollback", "[flx][migration][baas]") {
     std::shared_ptr<util::Logger> logger_ptr =
         std::make_shared<util::StderrLogger>(realm::util::Logger::Level::TEST_LOGGING_LEVEL);
 
@@ -260,7 +260,7 @@ TEST_CASE("Test server migration and rollback", "[flx][migration]") {
     }
 }
 
-TEST_CASE("Test client migration and rollback", "[flx][migration]") {
+TEST_CASE("Test client migration and rollback", "[flx][migration][baas]") {
     std::shared_ptr<util::Logger> logger_ptr =
         std::make_shared<util::StderrLogger>(realm::util::Logger::Level::TEST_LOGGING_LEVEL);
 
@@ -317,7 +317,7 @@ TEST_CASE("Test client migration and rollback", "[flx][migration]") {
     }
 }
 
-TEST_CASE("Test client migration and rollback with recovery", "[flx][migration]") {
+TEST_CASE("Test client migration and rollback with recovery", "[flx][migration][baas]") {
     std::shared_ptr<util::Logger> logger_ptr =
         std::make_shared<util::StderrLogger>(realm::util::Logger::Level::TEST_LOGGING_LEVEL);
 
@@ -468,7 +468,7 @@ TEST_CASE("Test client migration and rollback with recovery", "[flx][migration]"
     }
 }
 
-TEST_CASE("An interrupted migration or rollback can recover on the next session", "[flx][migration]") {
+TEST_CASE("An interrupted migration or rollback can recover on the next session", "[flx][migration][baas]") {
     std::shared_ptr<util::Logger> logger_ptr =
         std::make_shared<util::StderrLogger>(realm::util::Logger::Level::TEST_LOGGING_LEVEL);
 
@@ -580,7 +580,7 @@ TEST_CASE("An interrupted migration or rollback can recover on the next session"
     }
 }
 
-TEST_CASE("Update to native FLX after migration", "[flx][migration]") {
+TEST_CASE("Update to native FLX after migration", "[flx][migration][baas]") {
     std::shared_ptr<util::Logger> logger_ptr =
         std::make_shared<util::StderrLogger>(realm::util::Logger::Level::TEST_LOGGING_LEVEL);
 
@@ -700,7 +700,7 @@ TEST_CASE("Update to native FLX after migration", "[flx][migration]") {
     }
 }
 
-TEST_CASE("New table is synced after migration", "[flx][migration]") {
+TEST_CASE("New table is synced after migration", "[flx][migration][baas]") {
     std::shared_ptr<util::Logger> logger_ptr =
         std::make_shared<util::StderrLogger>(realm::util::Logger::Level::TEST_LOGGING_LEVEL);
 
@@ -809,7 +809,7 @@ TEST_CASE("New table is synced after migration", "[flx][migration]") {
 // This hits the update_schema() check that makes sure that the frozen Realm's schema is
 // a subset of the one found on disk. Since it is not, a schema exception is thrown
 // which is eventually forwarded to the sync error handler and client reset fails.
-TEST_CASE("Async open + client reset", "[flx][migration]") {
+TEST_CASE("Async open + client reset", "[flx][migration][baas]") {
     std::shared_ptr<util::Logger> logger_ptr =
         std::make_shared<util::StderrLogger>(realm::util::Logger::Level::TEST_LOGGING_LEVEL);
 

--- a/test/object-store/sync/flx_sync.cpp
+++ b/test/object-store/sync/flx_sync.cpp
@@ -127,7 +127,7 @@ std::vector<ObjectId> fill_large_array_schema(FLXSyncTestHarness& harness)
 
 } // namespace
 
-TEST_CASE("flx: connect to FLX-enabled app", "[sync][flx][app]") {
+TEST_CASE("flx: connect to FLX-enabled app", "[sync][flx][app][baas]") {
     FLXSyncTestHarness harness("basic_flx_connect");
 
     auto foo_obj_id = ObjectId::gen();
@@ -226,7 +226,7 @@ TEST_CASE("flx: connect to FLX-enabled app", "[sync][flx][app]") {
     });
 }
 
-TEST_CASE("flx: test commands work") {
+TEST_CASE("flx: test commands work", "[baas]") {
     FLXSyncTestHarness harness("test_commands");
     harness.do_with_new_realm([&](const SharedRealm& realm) {
         wait_for_upload(*realm);
@@ -272,7 +272,7 @@ static auto make_client_reset_handler()
     return std::make_pair(std::move(reset_future), std::move(fn));
 }
 
-TEST_CASE("flx: client reset", "[sync][flx][app][client reset]") {
+TEST_CASE("flx: client reset", "[sync][flx][app][baas][client reset]") {
     std::vector<ObjectSchema> schema{
         {"TopLevel",
          {
@@ -967,7 +967,7 @@ TEST_CASE("flx: client reset", "[sync][flx][app][client reset]") {
     }
 }
 
-TEST_CASE("flx: creating an object on a class with no subscription throws", "[sync][flx][app]") {
+TEST_CASE("flx: creating an object on a class with no subscription throws", "[sync][flx][app][baas]") {
     FLXSyncTestHarness harness("flx_bad_query", {g_simple_embedded_obj_schema, {"queryable_str_field"}});
     harness.do_with_new_user([&](auto user) {
         SyncTestFile config(user, harness.schema(), SyncConfig::FLXSyncEnabled{});
@@ -1016,7 +1016,7 @@ TEST_CASE("flx: creating an object on a class with no subscription throws", "[sy
     });
 }
 
-TEST_CASE("flx: uploading an object that is out-of-view results in compensating write", "[sync][flx][app]") {
+TEST_CASE("flx: uploading an object that is out-of-view results in compensating write", "[sync][flx][app][baas]") {
     static std::optional<FLXSyncTestHarness> harness;
     if (!harness) {
         Schema schema{{"TopLevel",
@@ -1301,7 +1301,7 @@ TEST_CASE("flx: uploading an object that is out-of-view results in compensating 
     }
 }
 
-TEST_CASE("flx: query on non-queryable field results in query error message", "[sync][flx][app]") {
+TEST_CASE("flx: query on non-queryable field results in query error message", "[sync][flx][app][baas]") {
     static std::optional<FLXSyncTestHarness> harness;
     if (!harness) {
         harness.emplace("flx_bad_query");
@@ -1379,7 +1379,7 @@ TEST_CASE("flx: query on non-queryable field results in query error message", "[
 }
 
 #if REALM_ENABLE_GEOSPATIAL
-TEST_CASE("flx: geospatial", "[sync][flx][app]") {
+TEST_CASE("flx: geospatial", "[sync][flx][app][baas]") {
     static std::optional<FLXSyncTestHarness> harness;
     if (!harness) {
         Schema schema{
@@ -1569,7 +1569,7 @@ TEST_CASE("flx: geospatial", "[sync][flx][app]") {
 }
 #endif // REALM_ENABLE_GEOSPATIAL
 
-TEST_CASE("flx: interrupted bootstrap restarts/recovers on reconnect", "[sync][flx][app]") {
+TEST_CASE("flx: interrupted bootstrap restarts/recovers on reconnect", "[sync][flx][app][baas]") {
     FLXSyncTestHarness harness("flx_bootstrap_batching", {g_large_array_schema, {"queryable_int_field"}});
 
     std::vector<ObjectId> obj_ids_at_end = fill_large_array_schema(harness);
@@ -1657,7 +1657,7 @@ TEST_CASE("flx: interrupted bootstrap restarts/recovers on reconnect", "[sync][f
     REQUIRE(active_subs.version() == int64_t(1));
 }
 
-TEST_CASE("flx: dev mode uploads schema before query change", "[sync][flx][app]") {
+TEST_CASE("flx: dev mode uploads schema before query change", "[sync][flx][app][baas]") {
     FLXSyncTestHarness::ServerSchema server_schema;
     auto default_schema = FLXSyncTestHarness::default_server_schema();
     server_schema.queryable_fields = default_schema.queryable_fields;
@@ -1714,7 +1714,7 @@ TEST_CASE("flx: dev mode uploads schema before query change", "[sync][flx][app]"
 }
 
 // This is a test case for the server's fix for RCORE-969
-TEST_CASE("flx: change-of-query history divergence", "[sync][flx][app]") {
+TEST_CASE("flx: change-of-query history divergence", "[sync][flx][app][baas]") {
     FLXSyncTestHarness harness("flx_coq_divergence");
 
     // first we create an object on the server and upload it.
@@ -1781,7 +1781,7 @@ TEST_CASE("flx: change-of-query history divergence", "[sync][flx][app]") {
     });
 }
 
-TEST_CASE("flx: writes work offline", "[sync][flx][app]") {
+TEST_CASE("flx: writes work offline", "[sync][flx][app][baas]") {
     FLXSyncTestHarness harness("flx_offline_writes");
 
     harness.do_with_new_realm([&](SharedRealm realm) {
@@ -1861,7 +1861,7 @@ TEST_CASE("flx: writes work offline", "[sync][flx][app]") {
     });
 }
 
-TEST_CASE("flx: writes work without waiting for sync", "[sync][flx][app]") {
+TEST_CASE("flx: writes work without waiting for sync", "[sync][flx][app][baas]") {
     FLXSyncTestHarness harness("flx_offline_writes");
 
     harness.do_with_new_realm([&](SharedRealm realm) {
@@ -1937,7 +1937,7 @@ TEST_CASE("flx: writes work without waiting for sync", "[sync][flx][app]") {
     });
 }
 
-TEST_CASE("flx: verify PBS/FLX websocket protocol number and prefixes", "[sync][flx]") {
+TEST_CASE("flx: verify PBS/FLX websocket protocol number and prefixes", "[sync][flx][local]") {
     // Update the expected value whenever the protocol version is updated - this ensures
     // that the current protocol version does not change unexpectedly.
     REQUIRE(9 == sync::get_current_protocol_version());
@@ -1946,7 +1946,7 @@ TEST_CASE("flx: verify PBS/FLX websocket protocol number and prefixes", "[sync][
     REQUIRE("com.mongodb.realm-query-sync#" == sync::get_flx_websocket_protocol_prefix());
 }
 
-TEST_CASE("flx: subscriptions persist after closing/reopening", "[sync][flx][app]") {
+TEST_CASE("flx: subscriptions persist after closing/reopening", "[sync][flx][app][baas]") {
     FLXSyncTestHarness harness("flx_bad_query");
     SyncTestFile config(harness.app()->current_user(), harness.schema(), SyncConfig::FLXSyncEnabled{});
 
@@ -1966,7 +1966,7 @@ TEST_CASE("flx: subscriptions persist after closing/reopening", "[sync][flx][app
     }
 }
 
-TEST_CASE("flx: no subscription store created for PBS app", "[sync][flx][app]") {
+TEST_CASE("flx: no subscription store created for PBS app", "[sync][flx][app][baas]") {
     const std::string base_url = get_base_url();
     auto server_app_config = minimal_app_config(base_url, "flx_connect_as_pbs", g_minimal_schema);
     TestAppSession session(create_app(server_app_config));
@@ -1982,7 +1982,7 @@ TEST_CASE("flx: no subscription store created for PBS app", "[sync][flx][app]") 
     CHECK_THROWS_AS(realm->get_latest_subscription_set(), IllegalOperation);
 }
 
-TEST_CASE("flx: connect to FLX as PBS returns an error", "[sync][flx][app]") {
+TEST_CASE("flx: connect to FLX as PBS returns an error", "[sync][flx][app][baas]") {
     FLXSyncTestHarness harness("connect_to_flx_as_pbs");
     SyncTestFile config(harness.app(), bson::Bson{}, harness.schema());
     std::mutex sync_error_mutex;
@@ -2001,7 +2001,7 @@ TEST_CASE("flx: connect to FLX as PBS returns an error", "[sync][flx][app]") {
     CHECK(sync_error->server_requests_action == sync::ProtocolErrorInfo::Action::ApplicationBug);
 }
 
-TEST_CASE("flx: connect to FLX with partition value returns an error", "[sync][flx][app]") {
+TEST_CASE("flx: connect to FLX with partition value returns an error", "[sync][flx][app][baas]") {
     FLXSyncTestHarness harness("connect_to_flx_as_pbs");
     SyncTestFile config(harness.app()->current_user(), harness.schema(), SyncConfig::FLXSyncEnabled{});
     config.sync_config->partition_value = "\"foobar\"";
@@ -2010,7 +2010,7 @@ TEST_CASE("flx: connect to FLX with partition value returns an error", "[sync][f
                       "Cannot specify a partition value when flexible sync is enabled");
 }
 
-TEST_CASE("flx: connect to PBS as FLX returns an error", "[sync][flx][app]") {
+TEST_CASE("flx: connect to PBS as FLX returns an error", "[sync][flx][app][baas]") {
     const std::string base_url = get_base_url();
 
     auto server_app_config = minimal_app_config(base_url, "flx_connect_as_pbs", g_minimal_schema);
@@ -2043,7 +2043,7 @@ TEST_CASE("flx: connect to PBS as FLX returns an error", "[sync][flx][app]") {
     CHECK(sync_error->server_requests_action == sync::ProtocolErrorInfo::Action::ApplicationBug);
 }
 
-TEST_CASE("flx: commit subscription while refreshing the access token", "[sync][flx][app]") {
+TEST_CASE("flx: commit subscription while refreshing the access token", "[sync][flx][app][baas]") {
     class HookedTransport : public SynchronousTestTransport {
     public:
         void send_request_to_server(const Request& request,
@@ -2094,7 +2094,7 @@ TEST_CASE("flx: commit subscription while refreshing the access token", "[sync][
     REQUIRE(seen_waiting_for_access_token);
 }
 
-TEST_CASE("flx: bootstrap batching prevents orphan documents", "[sync][flx][app]") {
+TEST_CASE("flx: bootstrap batching prevents orphan documents", "[sync][flx][app][baas]") {
     FLXSyncTestHarness harness("flx_bootstrap_batching", {g_large_array_schema, {"queryable_int_field"}});
 
     std::vector<ObjectId> obj_ids_at_end = fill_large_array_schema(harness);
@@ -2400,7 +2400,7 @@ TEST_CASE("flx: bootstrap batching prevents orphan documents", "[sync][flx][app]
     }
 }
 
-TEST_CASE("flx: asymmetric sync", "[sync][flx][app]") {
+TEST_CASE("flx: asymmetric sync", "[sync][flx][app][baas]") {
     static auto server_schema = [] {
         FLXSyncTestHarness::ServerSchema server_schema;
         server_schema.queryable_fields = {"queryable_str_field"};
@@ -2606,7 +2606,7 @@ TEST_CASE("flx: asymmetric sync", "[sync][flx][app]") {
 }
 
 // TODO this test has been failing very frequently. We need to fix it and re-enable it in RCORE-1149.
-TEST_CASE("flx: asymmetric sync - dev mode", "[sync][flx][app]") {
+TEST_CASE("flx: asymmetric sync - dev mode", "[sync][flx][app][baas]") {
     FLXSyncTestHarness::ServerSchema server_schema;
     server_schema.dev_mode_enabled = true;
     server_schema.schema = Schema{};
@@ -2648,7 +2648,7 @@ TEST_CASE("flx: asymmetric sync - dev mode", "[sync][flx][app]") {
         schema);
 }
 
-TEST_CASE("flx: send client error", "[sync][flx][app]") {
+TEST_CASE("flx: send client error", "[sync][flx][app][baas]") {
     FLXSyncTestHarness harness("flx_client_error");
 
     // An integration error is simulated while bootstrapping.
@@ -2684,7 +2684,7 @@ TEST_CASE("flx: send client error", "[sync][flx][app]") {
     CHECK(error_count == 2);
 }
 
-TEST_CASE("flx: bootstraps contain all changes", "[sync][flx][app]") {
+TEST_CASE("flx: bootstraps contain all changes", "[sync][flx][app][baas]") {
     FLXSyncTestHarness harness("bootstrap_full_sync");
 
     auto setup_subs = [](SharedRealm& realm) {
@@ -2903,7 +2903,7 @@ TEST_CASE("flx: bootstraps contain all changes", "[sync][flx][app]") {
     }
 }
 
-TEST_CASE("flx: convert flx sync realm to bundled realm", "[app][flx][sync]") {
+TEST_CASE("flx: convert flx sync realm to bundled realm", "[app][flx][sync][baas]") {
     static auto foo_obj_id = ObjectId::gen();
     static auto bar_obj_id = ObjectId::gen();
     static auto bizz_obj_id = ObjectId::gen();
@@ -3062,7 +3062,7 @@ TEST_CASE("flx: convert flx sync realm to bundled realm", "[app][flx][sync]") {
     }
 }
 
-TEST_CASE("flx: compensating write errors get re-sent across sessions", "[sync][flx][app]") {
+TEST_CASE("flx: compensating write errors get re-sent across sessions", "[sync][flx][app][baas]") {
     AppCreateConfig::ServiceRole role;
     role.name = "compensating_write_perms";
 
@@ -3221,7 +3221,7 @@ TEST_CASE("flx: compensating write errors get re-sent across sessions", "[sync][
     REQUIRE(top_level_table->is_empty());
 }
 
-TEST_CASE("flx: bootstrap changesets are applied continuously", "[sync][flx][app]") {
+TEST_CASE("flx: bootstrap changesets are applied continuously", "[sync][flx][app][baas]") {
     FLXSyncTestHarness harness("flx_bootstrap_batching", {g_large_array_schema, {"queryable_int_field"}});
     fill_large_array_schema(harness);
 

--- a/test/object-store/sync/metadata.cpp
+++ b/test/object-store/sync/metadata.cpp
@@ -40,7 +40,7 @@ using SyncAction = SyncFileActionMetadata::Action;
 static const std::string base_path = util::make_temp_dir() + "realm_objectstore_sync_metadata";
 static const std::string metadata_path = base_path + "/metadata.realm";
 
-TEST_CASE("sync_metadata: user metadata", "[sync]") {
+TEST_CASE("sync_metadata: user metadata", "[sync][local]") {
     util::try_make_dir(base_path);
     auto close = util::make_scope_exit([=]() noexcept {
         util::try_remove_dir_recursive(base_path);
@@ -139,7 +139,7 @@ TEST_CASE("sync_metadata: user metadata", "[sync]") {
     }
 }
 
-TEST_CASE("sync_metadata: user metadata APIs", "[sync]") {
+TEST_CASE("sync_metadata: user metadata APIs", "[sync][local]") {
     util::try_make_dir(base_path);
     auto close = util::make_scope_exit([=]() noexcept {
         util::try_remove_dir_recursive(base_path);
@@ -178,7 +178,7 @@ TEST_CASE("sync_metadata: user metadata APIs", "[sync]") {
     }
 }
 
-TEST_CASE("sync_metadata: file action metadata", "[sync]") {
+TEST_CASE("sync_metadata: file action metadata", "[sync][local]") {
     util::try_make_dir(base_path);
     auto close = util::make_scope_exit([=]() noexcept {
         util::try_remove_dir_recursive(base_path);
@@ -229,7 +229,7 @@ TEST_CASE("sync_metadata: file action metadata", "[sync]") {
     }
 }
 
-TEST_CASE("sync_metadata: file action metadata APIs", "[sync]") {
+TEST_CASE("sync_metadata: file action metadata APIs", "[sync][local]") {
     util::try_make_dir(base_path);
     auto close = util::make_scope_exit([=]() noexcept {
         util::try_remove_dir_recursive(base_path);
@@ -258,7 +258,7 @@ TEST_CASE("sync_metadata: file action metadata APIs", "[sync]") {
     }
 }
 
-TEST_CASE("sync_metadata: results", "[sync]") {
+TEST_CASE("sync_metadata: results", "[sync][local]") {
     util::try_make_dir(base_path);
     auto close = util::make_scope_exit([=]() noexcept {
         util::try_remove_dir_recursive(base_path);
@@ -309,7 +309,7 @@ TEST_CASE("sync_metadata: results", "[sync]") {
     }
 }
 
-TEST_CASE("sync_metadata: persistence across metadata manager instances", "[sync]") {
+TEST_CASE("sync_metadata: persistence across metadata manager instances", "[sync][local]") {
     util::try_make_dir(base_path);
     auto close = util::make_scope_exit([=]() noexcept {
         util::try_remove_dir_recursive(base_path);
@@ -337,7 +337,7 @@ TEST_CASE("sync_metadata: persistence across metadata manager instances", "[sync
     }
 }
 
-TEST_CASE("sync_metadata: encryption", "[sync]") {
+TEST_CASE("sync_metadata: encryption", "[sync][local]") {
     util::try_make_dir(base_path);
     auto close = util::make_scope_exit([=]() noexcept {
         util::try_remove_dir_recursive(base_path);
@@ -492,7 +492,7 @@ TEST_CASE("sync_metadata: encryption", "[sync]") {
 }
 
 #ifndef SWIFT_PACKAGE // The SPM build currently doesn't copy resource files
-TEST_CASE("sync metadata: can open old metadata realms", "[sync]") {
+TEST_CASE("sync metadata: can open old metadata realms", "[sync][local]") {
     util::try_make_dir(base_path);
     auto close = util::make_scope_exit([=]() noexcept {
         util::try_remove_dir_recursive(base_path);

--- a/test/object-store/sync/migration_store_test.cpp
+++ b/test/object-store/sync/migration_store_test.cpp
@@ -114,16 +114,16 @@ static void check_subscription(const sync::SubscriptionSet& sub_set, const std::
     REQUIRE(table_sub->name == sub_name);
 }
 
-TEST_CASE("Migration store", "[flx][migration]") {
+TEST_CASE("Migration store", "[flx][migration][local]") {
     std::string file_path = util::make_temp_dir() + "/migration_store.realm";
     auto mig_db = DB::create(sync::make_client_replication(), file_path);
     auto migration_store = sync::MigrationStore::create(mig_db);
 
-    SECTION("Migration store default", "[flx][migration]") {
+    SECTION("Migration store default") {
         check_not_migrated(migration_store);
     }
 
-    SECTION("Migration store complete and cancel", "[flx][migration]") {
+    SECTION("Migration store complete and cancel") {
         // Start the migration and check the state
         migration_store->migrate_to_flx(rql_string, migrated_partition);
         check_migration_in_progress(migration_store);
@@ -141,7 +141,7 @@ TEST_CASE("Migration store", "[flx][migration]") {
         check_not_migrated(migration_store);
     }
 
-    SECTION("Migration store complete and rollback", "[flx][migration]") {
+    SECTION("Migration store complete and rollback") {
         // Start the migration and check the state
         migration_store->migrate_to_flx(rql_string, migrated_partition);
         check_migration_in_progress(migration_store);
@@ -167,7 +167,7 @@ TEST_CASE("Migration store", "[flx][migration]") {
         check_not_migrated(migration_store);
     }
 
-    SECTION("Migration store complete without in progress", "[flx][migration]") {
+    SECTION("Migration store complete without in progress") {
         check_not_migrated(migration_store);
 
         // Complete the migration and check the state - should be not migrated
@@ -175,7 +175,7 @@ TEST_CASE("Migration store", "[flx][migration]") {
         check_not_migrated(migration_store);
     }
 
-    SECTION("Migration store subscriptions", "[flx][migration]") {
+    SECTION("Migration store subscriptions") {
         auto sub_store = sync::SubscriptionStore::create(mig_db, [](int64_t) {});
         auto orig_version = sub_store->get_latest().version();
 

--- a/test/object-store/sync/sync_manager.cpp
+++ b/test/object-store/sync/sync_manager.cpp
@@ -52,7 +52,7 @@ bool validate_user_in_vector(std::vector<std::shared_ptr<SyncUser>> vector, cons
 }
 } // anonymous namespace
 
-TEST_CASE("sync_manager: basic properties and APIs", "[sync]") {
+TEST_CASE("sync_manager: basic properties and APIs", "[sync][local]") {
     TestSyncManager init_sync_manager;
     auto app = init_sync_manager.app();
 
@@ -61,7 +61,7 @@ TEST_CASE("sync_manager: basic properties and APIs", "[sync]") {
     }
 }
 
-TEST_CASE("sync_manager: `path_for_realm` API", "[sync]") {
+TEST_CASE("sync_manager: `path_for_realm` API", "[sync][local]") {
     const std::string auth_server_url = "https://realm.example.org";
     const std::string raw_url = "realms://realm.example.org/a/b/~/123456/xyz";
 
@@ -179,7 +179,7 @@ TEST_CASE("sync_manager: `path_for_realm` API", "[sync]") {
     }
 }
 
-TEST_CASE("sync_manager: user state management", "[sync]") {
+TEST_CASE("sync_manager: user state management", "[sync][local]") {
     TestSyncManager init_sync_manager(SyncManager::MetadataMode::NoEncryption);
     auto sync_manager = init_sync_manager.app()->sync_manager();
 
@@ -278,7 +278,7 @@ TEST_CASE("sync_manager: user state management", "[sync]") {
     }
 }
 
-TEST_CASE("sync_manager: persistent user state management", "[sync]") {
+TEST_CASE("sync_manager: persistent user state management", "[sync][local]") {
     TestSyncManager::Config config;
     auto app_id = config.app_config.app_id = "app_id-" + random_string(10);
     config.metadata_mode = SyncManager::MetadataMode::NoEncryption;
@@ -460,7 +460,7 @@ TEST_CASE("sync_manager: persistent user state management", "[sync]") {
     }
 }
 
-TEST_CASE("sync_manager: file actions", "[sync]") {
+TEST_CASE("sync_manager: file actions", "[sync][local]") {
     using Action = SyncFileActionMetadata::Action;
     reset_test_directory(base_path.string());
 
@@ -728,7 +728,7 @@ TEST_CASE("sync_manager: file actions", "[sync]") {
     }
 }
 
-TEST_CASE("sync_manager: set_session_multiplexing") {
+TEST_CASE("sync_manager: set_session_multiplexing", "[sync][local]") {
     TestSyncManager::Config tsm_config;
     tsm_config.start_sync_client = false;
     TestSyncManager tsm(std::move(tsm_config));
@@ -764,7 +764,7 @@ TEST_CASE("sync_manager: set_session_multiplexing") {
     }
 }
 
-TEST_CASE("sync_manager: has_active_sessions", "[active_sessions]") {
+TEST_CASE("sync_manager: has_existing_sessions", "[sync][local][active_sessions]") {
     TestSyncManager init_sync_manager({}, {false});
     auto sync_manager = init_sync_manager.app()->sync_manager();
 

--- a/test/object-store/sync/user.cpp
+++ b/test/object-store/sync/user.cpp
@@ -35,7 +35,7 @@ using File = realm::util::File;
 static const std::string base_path = util::make_temp_dir() + "realm_objectstore_sync_user/";
 static const std::string dummy_device_id = "123400000000000000000000";
 
-TEST_CASE("sync_user: SyncManager `get_user()` API", "[sync]") {
+TEST_CASE("sync_user: SyncManager `get_user()` API", "[sync][local]") {
     TestSyncManager init_sync_manager;
     auto sync_manager = init_sync_manager.app()->sync_manager();
     const std::string identity = "sync_test_identity";
@@ -89,7 +89,7 @@ TEST_CASE("sync_user: SyncManager `get_user()` API", "[sync]") {
     }
 }
 
-TEST_CASE("sync_user: update state and tokens", "[sync]") {
+TEST_CASE("sync_user: update state and tokens", "[sync][local]") {
     TestSyncManager init_sync_manager;
     auto sync_manager = init_sync_manager.app()->sync_manager();
     const std::string identity = "sync_test_identity";
@@ -118,7 +118,7 @@ TEST_CASE("sync_user: update state and tokens", "[sync]") {
     sync_manager->remove_user(identity);
 }
 
-TEST_CASE("sync_user: SyncManager `get_existing_logged_in_user()` API", "[sync]") {
+TEST_CASE("sync_user: SyncManager `get_existing_logged_in_user()` API", "[sync][local]") {
     TestSyncManager init_sync_manager(SyncManager::MetadataMode::NoMetadata);
     auto sync_manager = init_sync_manager.app()->sync_manager();
     const std::string identity = "sync_test_identity";
@@ -153,7 +153,7 @@ TEST_CASE("sync_user: SyncManager `get_existing_logged_in_user()` API", "[sync]"
     }
 }
 
-TEST_CASE("sync_user: logout", "[sync]") {
+TEST_CASE("sync_user: logout", "[sync][local]") {
     TestSyncManager init_sync_manager(SyncManager::MetadataMode::NoMetadata);
     auto sync_manager = init_sync_manager.app()->sync_manager();
     const std::string identity = "sync_test_identity";
@@ -169,7 +169,7 @@ TEST_CASE("sync_user: logout", "[sync]") {
     }
 }
 
-TEST_CASE("sync_user: user persistence", "[sync]") {
+TEST_CASE("sync_user: user persistence", "[sync][local]") {
     TestSyncManager tsm(SyncManager::MetadataMode::NoEncryption);
     auto sync_manager = tsm.app()->sync_manager();
     auto file_manager = SyncFileManager(tsm.base_file_path(), tsm.app()->config().app_id);


### PR DESCRIPTION
## What, How & Why?
Add tags to the sync test cases in the object store tests executable to separate out the tests that rely on BAAS vs those that can run locally either against the sync server or do not require a server at all. This will be used to split the test into two different executables, based on the tags assigned.

## ☑️ ToDos
* ~~[ ] 📝 Changelog update~~
* ~~[ ] 🚦 Tests (or not relevant)~~
* ~~[ ] C-API, if public C++ API changed.~~
