### PR TITLE
Change interface to Query::do_find_all

### DIFF
--- a/src/realm/array.cpp
+++ b/src/realm/array.cpp
@@ -1396,8 +1396,7 @@ bool QueryStateFindAll<KeyColumn>::match(size_t index, Mixed) noexcept
 {
     ++m_match_count;
 
-    REALM_ASSERT(m_key_values);
-    int64_t key_value = m_key_values->get(index) + m_key_offset;
+    int64_t key_value = (m_key_values ? m_key_values->get(index) : index) + m_key_offset;
     m_keys.add(ObjKey(key_value));
 
     return (m_limit > m_match_count);

--- a/src/realm/array_unsigned.hpp
+++ b/src/realm/array_unsigned.hpp
@@ -110,17 +110,6 @@ private:
     uint64_t _get(size_t ndx, uint8_t width) const;
 };
 
-class ClusterKeyArray : public ArrayUnsigned {
-public:
-    using ArrayUnsigned::ArrayUnsigned;
-
-    uint64_t get(size_t ndx) const
-    {
-        return (m_data != nullptr) ? ArrayUnsigned::get(ndx) : uint64_t(ndx);
-    }
-};
-
-
 } // namespace realm
 
 #endif /* REALM_ARRAY_UNSIGNED_HPP */

--- a/src/realm/cluster.hpp
+++ b/src/realm/cluster.hpp
@@ -187,9 +187,9 @@ public:
     {
         return ObjKey(get_key_value(ndx) + m_offset);
     }
-    const ClusterKeyArray* get_key_array() const
+    const ArrayUnsigned* get_key_array() const
     {
-        return &m_keys;
+        return m_keys.is_attached() ? &m_keys : nullptr;
     }
     void set_offset(uint64_t offs)
     {
@@ -208,6 +208,16 @@ protected:
 #endif
 
     static constexpr size_t cluster_node_size = 1 << node_shift_factor;
+
+    class ClusterKeyArray : public ArrayUnsigned {
+    public:
+        using ArrayUnsigned::ArrayUnsigned;
+
+        uint64_t get(size_t ndx) const
+        {
+            return (m_data != nullptr) ? ArrayUnsigned::get(ndx) : uint64_t(ndx);
+        }
+    };
 
     const ClusterTree& m_tree_top;
     ClusterKeyArray m_keys;

--- a/src/realm/query.cpp
+++ b/src/realm/query.cpp
@@ -1006,7 +1006,8 @@ void Query::aggregate(QueryStateBase& st, ColKey column_key) const
                 for (size_t i = 0; i < num_keys; ++i) {
                     auto obj = m_table->get_object(keys->get(i));
                     if (pn->m_children.empty() || eval_object(obj)) {
-                        st.match(size_t(obj.get_key().value), obj.get<T>(column_key));
+                        st.m_key_offset = obj.get_key().value;
+                        st.match(0, obj.get<T>(column_key));
                     }
                 }
             }
@@ -1031,7 +1032,8 @@ void Query::aggregate(QueryStateBase& st, ColKey column_key) const
         else {
             m_view->for_each([&](const Obj& obj) {
                 if (eval_object(obj)) {
-                    st.match(size_t(obj.get_key().value), obj.get<T>(column_key));
+                    st.m_key_offset = obj.get_key().value;
+                    st.match(0, obj.get<T>(column_key));
                 }
                 return IteratorControl::AdvanceToNext;
             });
@@ -1309,7 +1311,8 @@ void Query::do_find_all(QueryStateBase& st) const
         for (size_t t = 0; t < sz; t++) {
             const Obj obj = m_view->get_object(t);
             if (eval_object(obj)) {
-                if (!st.match(size_t(obj.get_key().value), Mixed()))
+                st.m_key_offset = obj.get_key().value;
+                if (!st.match(0, Mixed()))
                     break;
             }
         }
@@ -1345,15 +1348,16 @@ void Query::do_find_all(QueryStateBase& st) const
                 const size_t num_keys = keys->size();
                 for (size_t i = 0; i < num_keys; ++i) {
                     ObjKey key = keys->get(i);
+                    st.m_key_offset = key.value;
                     if (pn->m_children.empty()) {
                         // No more conditions - just add key
-                        if (!st.match(size_t(key.value), Mixed()))
+                        if (!st.match(0, Mixed()))
                             break;
                     }
                     else {
                         auto obj = m_table->get_object(key);
                         if (eval_object(obj)) {
-                            if (!st.match(size_t(key.value), Mixed()))
+                            if (!st.match(0, Mixed()))
                                 break;
                         }
                     }

--- a/src/realm/query.hpp
+++ b/src/realm/query.hpp
@@ -359,7 +359,7 @@ private:
     void aggregate_internal(ParentNode* pn, QueryStateBase* st, size_t start, size_t end,
                             ArrayPayload* source_column) const;
 
-    void do_find_all(TableView& tv, size_t limit) const;
+    void do_find_all(QueryStateBase& st) const;
     size_t do_count(size_t limit = size_t(-1)) const;
     void delete_nodes() noexcept;
 

--- a/src/realm/query_conditions_tpl.hpp
+++ b/src/realm/query_conditions_tpl.hpp
@@ -68,7 +68,7 @@ public:
                 return true; // no match, continue searching
             }
             ++m_match_count;
-            m_minmax_key = (m_key_values ? m_key_values->get(index) : 0) + m_key_offset;
+            m_minmax_key = (m_key_values ? m_key_values->get(index) : index) + m_key_offset;
         }
         return m_limit > m_match_count;
     }

--- a/src/realm/query_expression.hpp
+++ b/src/realm/query_expression.hpp
@@ -2290,8 +2290,7 @@ public:
             m_link_map.set_cluster(cluster);
         }
         else {
-            m_keys = cluster->get_key_array();
-            m_offset = cluster->get_offset();
+            m_cluster = cluster;
         }
     }
 
@@ -2307,8 +2306,7 @@ public:
             count = m_link_map.count_all_backlinks(index);
         }
         else {
-            ObjKey key(m_keys->get(index) + m_offset);
-            const Obj obj = m_link_map.get_base_table()->get_object(key);
+            const Obj obj = m_link_map.get_base_table()->get_object(m_cluster->get_real_key(index));
             count = obj.get_backlink_count();
         }
         destination = Value<int64_t>(count);
@@ -2325,8 +2323,7 @@ public:
     }
 
 private:
-    const ClusterKeyArray* m_keys = nullptr;
-    uint64_t m_offset = 0;
+    const Cluster* m_cluster = nullptr;
     LinkMap m_link_map;
 };
 

--- a/src/realm/query_state.hpp
+++ b/src/realm/query_state.hpp
@@ -30,14 +30,14 @@ enum Action { act_ReturnFirst, act_Sum, act_Max, act_Min, act_Count, act_FindAll
 // Array::VTable only uses the first 4 conditions (enums) in an array of function pointers
 enum { cond_Equal, cond_NotEqual, cond_Greater, cond_Less, cond_VTABLE_FINDER_COUNT, cond_None, cond_LeftNotNull };
 
-class ClusterKeyArray;
+class ArrayUnsigned;
 class Mixed;
 
 class QueryStateBase {
 public:
     int64_t m_minmax_key = -1; // used only for min/max, to save index of current min/max value
     uint64_t m_key_offset = 0;
-    const ClusterKeyArray* m_key_values = nullptr;
+    const ArrayUnsigned* m_key_values = nullptr;
     QueryStateBase(size_t limit = -1)
         : m_limit(limit)
     {

--- a/src/realm/table_view.cpp
+++ b/src/realm/table_view.cpp
@@ -489,7 +489,8 @@ void TableView::do_sync()
 
         if (m_query->m_view)
             m_query->m_view->sync_if_needed();
-        m_query->do_find_all(*const_cast<TableView*>(this), m_limit);
+        QueryStateFindAll<KeyColumn> st(m_key_values, m_limit);
+        m_query->do_find_all(st);
     }
 
     do_sort(m_descriptor_ordering);

--- a/test/test_query.cpp
+++ b/test/test_query.cpp
@@ -3697,7 +3697,7 @@ TEST(Query_Simple)
 
     ObjKey k0 = ttt.create_object().set_all(1, "a").get_key();
     ObjKey k1 = ttt.create_object().set_all(2, "a").get_key();
-    ObjKey k2 = ttt.create_object().set_all(3, "X").get_key();
+    ObjKey k2 = ttt.create_object(ObjKey(0xc001ede1b0)).set_all(3, "X").get_key();
 
     Query q0 = ttt.where();
 
@@ -3716,7 +3716,20 @@ TEST(Query_Simple)
     TableView tv2 = q2.find_all();
     CHECK_EQUAL(1, tv2.size());
     CHECK_EQUAL(k2, tv2.get_key(0));
+
+    ttt.add_search_index(col_str);
+
+    q2 = ttt.where().equal(col_str, "X");
+    tv2 = q2.find_all();
+    CHECK_EQUAL(1, tv2.size());
+    CHECK_EQUAL(k2, tv2.get_key(0));
+
+    q2 = ttt.where().equal(col_str, "X").equal(col_int, 3);
+    tv2 = q2.find_all();
+    CHECK_EQUAL(1, tv2.size());
+    CHECK_EQUAL(k2, tv2.get_key(0));
 }
+
 
 TEST(Query_Sort1)
 {


### PR DESCRIPTION
Replace TableView and limit with a single QueryStateBase object. This will in principle allow us to call do_find_all with an alternative QueryState object with some enhanced functionality.

This change triggered some other small refactorings.

## What, How & Why?
More flexibility in the future

## ☑️ ToDos
* [ ] 📝 Changelog update
* [ ] 🚦 Tests (or not relevant)
* [ ] C-API, if public C++ API changed.
