### PR TITLE
Fix queries sometimes matching on invalid geospatial points

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 ### Fixed
 * <How do the end-user experience this issue? what was the impact?> ([#????](https://github.com/realm/realm-core/issues/????), since v?.?.?)
 * A GeoBox is now just a shortcut for the equivilent GeoPolygon. This provides consistent query results and error checking. ([#6703](https://github.com/realm/realm-core/issues/6703), since v13.11.0) 
+* Fixed several corner cases (eg. around the poles) where invalid points matched a geoWithin query.
 
 ### Breaking changes
 * None.

--- a/src/realm/geospatial.cpp
+++ b/src/realm/geospatial.cpp
@@ -543,8 +543,11 @@ bool GeoRegion::contains(const std::optional<GeoPoint>& geo_point) const noexcep
     if (!m_status.is_ok() || !geo_point) {
         return false;
     }
-    auto point = S2LatLng::FromDegrees(geo_point->latitude, geo_point->longitude).ToPoint();
-    return m_region->VirtualContainsPoint(point);
+    auto point = S2LatLng::FromDegrees(geo_point->latitude, geo_point->longitude);
+    if (!point.is_valid()) {
+        return false;
+    }
+    return m_region->VirtualContainsPoint(point.ToPoint());
 }
 
 Status GeoRegion::get_conversion_status() const noexcept

--- a/test/object-store/sync/flx_sync.cpp
+++ b/test/object-store/sync/flx_sync.cpp
@@ -1512,6 +1512,7 @@ TEST_CASE("flx: geospatial", "[sync][flx][app][baas]") {
                 GeoPoint{0, 90},                                  // north pole
                 GeoPoint{-82.68193, 84.74653},                    // northern point that falls within a box later
                 GeoPoint{82.55243, 84.54981}, // another northern point, but on the other side of the pole
+                GeoPoint{2129, 89},           // invalid
             };
             for (auto& point : points) {
                 add_point(point);
@@ -1545,6 +1546,12 @@ TEST_CASE("flx: geospatial", "[sync][flx][app][baas]") {
                         {{GeoPoint{-80, 40.7128}, GeoPoint{20, 60}, GeoPoint{20, 20}, GeoPoint{-80, 40.7128}}}};
                     size_t local_matches = run_query_locally(bounds);
                     size_t server_results = run_query_on_server(make_polygon_filter(bounds));
+                    CHECK(server_results == local_matches);
+                }
+                {
+                    GeoCircle circle{.5, GeoPoint{0, 90}};
+                    size_t local_matches = run_query_locally(circle);
+                    size_t server_results = run_query_on_server(make_circle_filter(circle));
                     CHECK(server_results == local_matches);
                 }
                 { // a ring with 3 points without a matching begin/end is an error


### PR DESCRIPTION
Reported by @papafe.

S2 may report matches on points that are invalid. It appears that MongoDB does not allow invalid points into its geo index and so would never return a match. The fix is an early out if the point is not valid.

## ☑️ ToDos
* [x] 📝 Changelog update
* [x] 🚦 Tests (or not relevant)
* [x] C-API, if public C++ API changed.