### PR TITLE
Support typed links in nested collections

### DIFF
--- a/src/realm/dictionary.hpp
+++ b/src/realm/dictionary.hpp
@@ -128,6 +128,8 @@ public:
     bool try_erase(Mixed key);
 
     void nullify(size_t);
+    bool nullify(ObjLink target_link);
+    bool replace_link(ObjLink old_link, ObjLink replace_link);
     void remove_backlinks(CascadeState& state) const;
     size_t find_first(Mixed value) const;
 

--- a/src/realm/list.cpp
+++ b/src/realm/list.cpp
@@ -479,12 +479,24 @@ void Lst<Mixed>::do_insert(size_t ndx, Mixed value)
 
 void Lst<Mixed>::do_remove(size_t ndx)
 {
-    if (Mixed old_value = m_tree->get(ndx); old_value.is_type(type_TypedLink)) {
-        auto old_link = old_value.get<ObjLink>();
+    Mixed old_value = m_tree->get(ndx);
+    if (old_value.is_type(type_TypedLink, type_Dictionary, type_List)) {
 
-        CascadeState state(old_link.get_obj_key().is_unresolved() ? CascadeState::Mode::All
-                                                                  : CascadeState::Mode::Strong);
-        bool recurse = Base::remove_backlink(m_col_key, old_link, state);
+        bool recurse;
+        CascadeState state;
+        if (old_value.is_type(type_TypedLink)) {
+            auto old_link = old_value.get<ObjLink>();
+            if (old_link.get_obj_key().is_unresolved()) {
+                state.m_mode = CascadeState::Mode::All;
+            }
+            recurse = Base::remove_backlink(m_col_key, old_link, state);
+        }
+        else if (old_value.is_type(type_List)) {
+            get_list(ndx)->remove_backlinks(state);
+        }
+        else if (old_value.is_type(type_Dictionary)) {
+            get_dictionary(ndx)->remove_backlinks(state);
+        }
 
         m_tree->erase(ndx);
 
@@ -639,6 +651,84 @@ void Lst<Mixed>::add_index(Path& path, Index index) const
     path.emplace_back(ndx);
 }
 
+bool Lst<Mixed>::nullify(ObjLink link)
+{
+    size_t ndx = find_first(link);
+    if (ndx != realm::not_found) {
+        if (Replication* repl = Base::get_replication()) {
+            repl->list_erase(*this, ndx); // Throws
+        }
+
+        m_tree->erase(ndx);
+        return true;
+    }
+    else {
+        // There must be a link in a nested collection
+        size_t sz = size();
+        for (size_t ndx = 0; ndx < sz; ndx++) {
+            Mixed val = m_tree->get(ndx);
+            if (val.is_type(type_Dictionary)) {
+                auto dict = get_dictionary(ndx);
+                if (dict->nullify(link)) {
+                    return true;
+                }
+            }
+            if (val.is_type(type_List)) {
+                auto list = get_list(ndx);
+                if (list->nullify(link)) {
+                    return true;
+                }
+            }
+        }
+    }
+    return false;
+}
+
+bool Lst<Mixed>::replace_link(ObjLink old_link, ObjLink replace_link)
+{
+    size_t ndx = find_first(old_link);
+    if (ndx != realm::not_found) {
+        set(ndx, replace_link);
+        return true;
+    }
+    else {
+        // There must be a link in a nested collection
+        size_t sz = size();
+        for (size_t ndx = 0; ndx < sz; ndx++) {
+            Mixed val = m_tree->get(ndx);
+            if (val.is_type(type_Dictionary)) {
+                auto dict = get_dictionary(ndx);
+                if (dict->replace_link(old_link, replace_link)) {
+                    return true;
+                }
+            }
+            if (val.is_type(type_List)) {
+                auto list = get_list(ndx);
+                if (list->replace_link(old_link, replace_link)) {
+                    return true;
+                }
+            }
+        }
+    }
+    return false;
+}
+
+void Lst<Mixed>::remove_backlinks(CascadeState& state) const
+{
+    size_t sz = size();
+    for (size_t ndx = 0; ndx < sz; ndx++) {
+        Mixed val = m_tree->get(ndx);
+        if (val.is_type(type_TypedLink)) {
+            Base::remove_backlink(m_col_key, val.get_link(), state);
+        }
+        else if (val.is_type(type_List)) {
+            get_list(ndx)->remove_backlinks(state);
+        }
+        else if (val.is_type(type_Dictionary)) {
+            get_dictionary(ndx)->remove_backlinks(state);
+        }
+    }
+}
 
 bool Lst<Mixed>::update_if_needed() const
 {

--- a/src/realm/list.hpp
+++ b/src/realm/list.hpp
@@ -505,6 +505,9 @@ public:
     }
 
     void add_index(Path& path, Index ndx) const final;
+    bool nullify(ObjLink);
+    bool replace_link(ObjLink old_link, ObjLink replace_link);
+    void remove_backlinks(CascadeState& state) const;
     TableRef get_table() const noexcept override
     {
         return get_obj().get_table();

--- a/src/realm/obj.cpp
+++ b/src/realm/obj.cpp
@@ -1241,6 +1241,15 @@ Obj& Obj::set<Mixed>(ColKey col_key, Mixed value, bool is_default)
     ObjLink new_link{};
     if (old_value.is_type(type_TypedLink)) {
         old_link = old_value.get<ObjLink>();
+        recurse = remove_backlink(col_key, old_link, state);
+    }
+    else if (old_value.is_type(type_Dictionary)) {
+        Dictionary dict(*this, col_key);
+        dict.remove_backlinks(state);
+    }
+    else if (old_value.is_type(type_List)) {
+        Lst<Mixed> list(*this, col_key);
+        list.remove_backlinks(state);
     }
 
     if (value.is_type(type_TypedLink)) {
@@ -1251,8 +1260,8 @@ Obj& Obj::set<Mixed>(ColKey col_key, Mixed value, bool is_default)
         m_table->get_parent_group()->validate(new_link);
         if (new_link == old_link)
             return *this;
+        set_backlink(col_key, new_link);
     }
-    recurse = replace_backlink(col_key, old_link, new_link, state);
 
     StringIndex* index = m_table->get_search_index(col_key);
     // The following check on unresolved is just a precaution as it should not
@@ -1810,6 +1819,40 @@ inline void Obj::nullify_single_link(ColKey col, ValueType target)
                            m_key); // Throws
 }
 
+template <>
+inline void Obj::nullify_single_link<Mixed>(ColKey col, Mixed target)
+{
+    ColKey::Idx origin_col_ndx = col.get_index();
+    Allocator& alloc = get_alloc();
+    Array fallback(alloc);
+    Array& fields = get_tree_top()->get_fields_accessor(fallback, m_mem);
+    ArrayMixed mixed(alloc);
+    mixed.set_parent(&fields, origin_col_ndx.val + 1);
+    mixed.init_from_parent();
+    auto val = mixed.get(m_row_ndx);
+    bool result = false;
+    if (val.is_type(type_TypedLink)) {
+        // Ensure we are nullifying correct link
+        result = (val == target);
+        mixed.set(m_row_ndx, Mixed{});
+        sync(fields);
+
+        if (Replication* repl = get_replication())
+            repl->nullify_link(m_table.unchecked_ptr(), col,
+                               m_key); // Throws
+    }
+    else if (val.is_type(type_Dictionary)) {
+        Dictionary dict(*this, col);
+        result = dict.nullify(target.get_link());
+    }
+    else if (val.is_type(type_List)) {
+        Lst<Mixed> list(*this, col);
+        result = list.nullify(target.get_link());
+    }
+    REALM_ASSERT(result);
+    static_cast<void>(result);
+}
+
 void Obj::nullify_link(ColKey origin_col_key, ObjLink target_link) &&
 {
     REALM_ASSERT(get_alloc().get_storage_version() == m_storage_version);
@@ -1824,9 +1867,9 @@ void Obj::nullify_link(ColKey origin_col_key, ObjLink target_link) &&
         {
             nullify_linklist(m_origin_obj, m_origin_col_key, m_target_link.get_obj_key());
         }
-        void on_list_of_mixed(Lst<Mixed>&) final
+        void on_list_of_mixed(Lst<Mixed>& list) final
         {
-            nullify_linklist(m_origin_obj, m_origin_col_key, Mixed(m_target_link));
+            list.nullify(m_target_link);
         }
         void on_set_of_links(LnkSet&) final
         {
@@ -1836,9 +1879,14 @@ void Obj::nullify_link(ColKey origin_col_key, ObjLink target_link) &&
         {
             nullify_set(m_origin_obj, m_origin_col_key, Mixed(m_target_link));
         }
-        void on_dictionary(Dictionary&) final
+        void on_dictionary(Dictionary& dict) final
         {
-            nullify_dictionary(m_origin_obj, m_origin_col_key, m_target_link);
+            if (m_origin_obj.get_table()->get_nesting_levels(m_origin_col_key)) {
+                nullify_dictionary(m_origin_obj, m_origin_col_key, m_target_link);
+            }
+            else {
+                dict.nullify(m_target_link);
+            }
         }
         void on_link_property(ColKey origin_col_key) final
         {
@@ -2221,10 +2269,9 @@ void Obj::assign_pk_and_backlinks(const Obj& other)
         {
             replace_in_linklist(m_origin_obj, m_origin_col_key, m_dest_orig.get_key(), m_dest_replace.get_key());
         }
-        void on_list_of_mixed(Lst<Mixed>&) final
+        void on_list_of_mixed(Lst<Mixed>& list) final
         {
-            replace_in_linklist<Mixed>(m_origin_obj, m_origin_col_key, m_dest_orig.get_link(),
-                                       m_dest_replace.get_link());
+            list.replace_link(m_dest_orig.get_link(), m_dest_replace.get_link());
         }
         void on_set_of_links(LnkSet&) final
         {
@@ -2235,9 +2282,15 @@ void Obj::assign_pk_and_backlinks(const Obj& other)
             replace_in_linkset<Mixed>(m_origin_obj, m_origin_col_key, m_dest_orig.get_link(),
                                       m_dest_replace.get_link());
         }
-        void on_dictionary(Dictionary&) final
+        void on_dictionary(Dictionary& dict) final
         {
-            replace_in_dictionary(m_origin_obj, m_origin_col_key, m_dest_orig.get_link(), m_dest_replace.get_link());
+            if (m_origin_obj.get_table()->get_nesting_levels(m_origin_col_key)) {
+                replace_in_dictionary(m_origin_obj, m_origin_col_key, m_dest_orig.get_link(),
+                                      m_dest_replace.get_link());
+            }
+            else {
+                dict.replace_link(m_dest_orig.get_link(), m_dest_replace.get_link());
+            }
         }
         void on_link_property(ColKey col) final
         {
@@ -2246,9 +2299,22 @@ void Obj::assign_pk_and_backlinks(const Obj& other)
         }
         void on_mixed_property(ColKey col) final
         {
-            REALM_ASSERT(m_origin_obj.get_any(col).is_null() ||
-                         m_origin_obj.get_any(col).get_link().get_obj_key() == m_dest_orig.get_key());
-            m_origin_obj.set(col, Mixed{m_dest_replace.get_link()});
+            auto val = m_origin_obj.get_any(col);
+            if (val.is_type(type_TypedLink)) {
+                REALM_ASSERT(val.get_link() == m_dest_orig.get_link());
+                m_origin_obj.set(col, Mixed{m_dest_replace.get_link()});
+            }
+            else if (val.is_type(type_Dictionary)) {
+                Dictionary dict(m_origin_obj, m_origin_col_key);
+                dict.replace_link(m_dest_orig.get_link(), m_dest_replace.get_link());
+            }
+            else if (val.is_type(type_List)) {
+                Lst<Mixed> list(m_origin_obj, m_origin_col_key);
+                list.replace_link(m_dest_orig.get_link(), m_dest_replace.get_link());
+            }
+            else {
+                REALM_UNREACHABLE();
+            }
         }
 
     private:

--- a/src/realm/table.cpp
+++ b/src/realm/table.cpp
@@ -420,6 +420,9 @@ ColKey Table::add_column(DataType type, StringData name, bool nullable, std::vec
     Table* invalid_link = nullptr;
     col_key = do_insert_column(col_key, type, name, invalid_link, key_type); // Throws
     if (collection_types.size() > 1) {
+        if (type == type_Mixed) {
+            throw IllegalOperation("Collections of Mixed cannot be statically nested");
+        }
         collection_types.pop_back();
         m_spec.set_nested_column_types(m_leaf_ndx2spec_ndx[col_key.get_index().val], collection_types);
     }


### PR DESCRIPTION
This is about the usual stuff:
 - When a link is inserted, make sure a backlink is created
 - When a link is cleared, make sure the backlink is removed.
 - When object containing a collection containing links is deleted make sure the backlinks are removed.
 - When the linked-to object is deleted the link should be nullified/removed.
 - When the linked-to object is made into a tombstone, the link should be updated.
 - When the linked-to object is recreated, the link should be restored.

## What, How & Why?
<!-- Describe the changes and give some hints to guide your reviewers if possible. -->
<!-- Link to relevant issue this fixes -->

## ☑️ ToDos
* [ ] 📝 Changelog update
* [ ] 🚦 Tests (or not relevant)
* [ ] C-API, if public C++ API changed.
