### PR TITLE
Remove support for TypedLinks in LinkTranslator

### DIFF
--- a/src/realm/link_translator.cpp
+++ b/src/realm/link_translator.cpp
@@ -42,10 +42,6 @@ void LinkTranslator::run()
             Lst<Mixed> list = m_origin_obj.get_list<Mixed>(m_origin_col_key);
             on_list_of_mixed(list);
         }
-        else if (m_origin_col_key.get_type() == col_type_TypedLink) {
-            Lst<ObjLink> list = m_origin_obj.get_list<ObjLink>(m_origin_col_key);
-            on_list_of_typedlink(list);
-        }
         else {
             throw std::runtime_error(
                 util::format("LinkTranslator unhandled list type: %1", m_origin_col_key.get_type()));
@@ -59,10 +55,6 @@ void LinkTranslator::run()
         else if (m_origin_col_key.get_type() == col_type_Mixed) {
             Set<Mixed> set = m_origin_obj.get_set<Mixed>(m_origin_col_key);
             on_set_of_mixed(set);
-        }
-        else if (m_origin_col_key.get_type() == col_type_TypedLink) {
-            Set<ObjLink> set = m_origin_obj.get_set<ObjLink>(m_origin_col_key);
-            on_set_of_typedlink(set);
         }
         else {
             throw std::runtime_error(
@@ -80,9 +72,6 @@ void LinkTranslator::run()
         }
         else if (m_origin_col_key.get_type() == col_type_Mixed) {
             on_mixed_property(m_origin_col_key);
-        }
-        else if (m_origin_col_key.get_type() == col_type_TypedLink) {
-            on_typedlink_property(m_origin_col_key);
         }
         else {
             throw std::runtime_error(

--- a/src/realm/link_translator.hpp
+++ b/src/realm/link_translator.hpp
@@ -35,14 +35,11 @@ public:
     void run();
     virtual void on_list_of_links(LnkLst& list) = 0;
     virtual void on_list_of_mixed(Lst<Mixed>& list) = 0;
-    virtual void on_list_of_typedlink(Lst<ObjLink>& list) = 0;
     virtual void on_set_of_links(LnkSet& set) = 0;
     virtual void on_set_of_mixed(Set<Mixed>& set) = 0;
-    virtual void on_set_of_typedlink(Set<ObjLink>& set) = 0;
     virtual void on_dictionary(Dictionary& dict) = 0;
     virtual void on_link_property(ColKey col) = 0;
     virtual void on_mixed_property(ColKey col) = 0;
-    virtual void on_typedlink_property(ColKey col) = 0;
 
 protected:
     Obj m_origin_obj;

--- a/src/realm/obj.cpp
+++ b/src/realm/obj.cpp
@@ -906,10 +906,6 @@ void Obj::traverse_path(Visitor v, PathSizer ps, size_t path_length) const
         {
             REALM_UNREACHABLE(); // we don't support Mixed link to embedded object yet
         }
-        void on_list_of_typedlink(Lst<ObjLink>&) final
-        {
-            REALM_UNREACHABLE(); // we don't support TypedLink to embedded object yet
-        }
         void on_set_of_links(LnkSet&) final
         {
             REALM_UNREACHABLE(); // sets of embedded objects are not allowed at the schema level
@@ -918,13 +914,8 @@ void Obj::traverse_path(Visitor v, PathSizer ps, size_t path_length) const
         {
             REALM_UNREACHABLE(); // we don't support Mixed link to embedded object yet
         }
-        void on_set_of_typedlink(Set<ObjLink>&) final
-        {
-            REALM_UNREACHABLE(); // we don't support TypedLink to embedded object yet
-        }
         void on_link_property(ColKey) final {}
         void on_mixed_property(ColKey) final {}
-        void on_typedlink_property(ColKey) final {}
         Mixed result()
         {
             return m_index;
@@ -1885,10 +1876,6 @@ void Obj::nullify_link(ColKey origin_col_key, ObjLink target_link) &&
         {
             nullify_linklist(m_origin_obj, m_origin_col_key, Mixed(m_target_link));
         }
-        void on_list_of_typedlink(Lst<ObjLink>&) final
-        {
-            nullify_linklist(m_origin_obj, m_origin_col_key, m_target_link);
-        }
         void on_set_of_links(LnkSet&) final
         {
             nullify_set(m_origin_obj, m_origin_col_key, m_target_link.get_obj_key());
@@ -1896,10 +1883,6 @@ void Obj::nullify_link(ColKey origin_col_key, ObjLink target_link) &&
         void on_set_of_mixed(Set<Mixed>&) final
         {
             nullify_set(m_origin_obj, m_origin_col_key, Mixed(m_target_link));
-        }
-        void on_set_of_typedlink(Set<ObjLink>&) final
-        {
-            nullify_set(m_origin_obj, m_origin_col_key, m_target_link);
         }
         void on_dictionary(Dictionary&) final
         {
@@ -1912,10 +1895,6 @@ void Obj::nullify_link(ColKey origin_col_key, ObjLink target_link) &&
         void on_mixed_property(ColKey origin_col_key) final
         {
             m_origin_obj.nullify_single_link<Mixed>(origin_col_key, Mixed{m_target_link});
-        }
-        void on_typedlink_property(ColKey origin_col_key) final
-        {
-            m_origin_obj.nullify_single_link<ObjLink>(origin_col_key, m_target_link);
         }
 
     private:
@@ -1966,19 +1945,7 @@ struct EmbeddedObjectLinkMigrator : public LinkTranslator {
         REALM_ASSERT(did_erase_pair.second);
         set.insert(m_dest_replace.get_link());
     }
-    void on_set_of_typedlink(Set<ObjLink>& set) final
-    {
-        auto did_erase_pair = set.erase(m_dest_orig.get_link());
-        REALM_ASSERT(did_erase_pair.second);
-        set.insert(m_dest_replace.get_link());
-    }
     void on_list_of_mixed(Lst<Mixed>& list) final
-    {
-        auto n = list.find_any(m_dest_orig.get_link());
-        REALM_ASSERT(n != realm::npos);
-        list.insert_any(n, m_dest_replace.get_link());
-    }
-    void on_list_of_typedlink(Lst<ObjLink>& list) final
     {
         auto n = list.find_any(m_dest_orig.get_link());
         REALM_ASSERT(n != realm::npos);
@@ -1989,12 +1956,6 @@ struct EmbeddedObjectLinkMigrator : public LinkTranslator {
         REALM_ASSERT(m_origin_obj.get<Mixed>(col).is_null() ||
                      m_origin_obj.get<Mixed>(col) == m_dest_orig.get_link());
         m_origin_obj.set_any(col, m_dest_replace.get_link());
-    }
-    void on_typedlink_property(ColKey col) final
-    {
-        REALM_ASSERT(m_origin_obj.get<ObjLink>(col).is_null() ||
-                     m_origin_obj.get<ObjLink>(col) == m_dest_orig.get_link());
-        m_origin_obj.set(col, m_dest_replace.get_link());
     }
 
 private:
@@ -2313,10 +2274,6 @@ void Obj::assign_pk_and_backlinks(const Obj& other)
             replace_in_linklist<Mixed>(m_origin_obj, m_origin_col_key, m_dest_orig.get_link(),
                                        m_dest_replace.get_link());
         }
-        void on_list_of_typedlink(Lst<ObjLink>&) final
-        {
-            replace_in_linklist(m_origin_obj, m_origin_col_key, m_dest_orig.get_link(), m_dest_replace.get_link());
-        }
         void on_set_of_links(LnkSet&) final
         {
             replace_in_linkset(m_origin_obj, m_origin_col_key, m_dest_orig.get_key(), m_dest_replace.get_key());
@@ -2325,10 +2282,6 @@ void Obj::assign_pk_and_backlinks(const Obj& other)
         {
             replace_in_linkset<Mixed>(m_origin_obj, m_origin_col_key, m_dest_orig.get_link(),
                                       m_dest_replace.get_link());
-        }
-        void on_set_of_typedlink(Set<ObjLink>&) final
-        {
-            replace_in_linkset(m_origin_obj, m_origin_col_key, m_dest_orig.get_link(), m_dest_replace.get_link());
         }
         void on_dictionary(Dictionary&) final
         {
@@ -2344,12 +2297,6 @@ void Obj::assign_pk_and_backlinks(const Obj& other)
             REALM_ASSERT(m_origin_obj.get_any(col).is_null() ||
                          m_origin_obj.get_any(col).get_link().get_obj_key() == m_dest_orig.get_key());
             m_origin_obj.set(col, Mixed{m_dest_replace.get_link()});
-        }
-        void on_typedlink_property(ColKey col) final
-        {
-            REALM_ASSERT(m_origin_obj.get_any(col).is_null() ||
-                         m_origin_obj.get_any(col).get_link().get_obj_key() == m_dest_orig.get_key());
-            m_origin_obj.set(col, m_dest_replace.get_link());
         }
 
     private:

--- a/src/realm/table.cpp
+++ b/src/realm/table.cpp
@@ -395,6 +395,9 @@ ColKey Table::add_column(DataType type, StringData name, bool nullable, std::vec
                          DataType key_type)
 {
     REALM_ASSERT(!is_link_type(ColumnType(type)));
+    if (type == type_TypedLink) {
+        throw IllegalOperation("TypedLink properties not yet supported");
+    }
 
     ColumnAttrMask attr;
     if (!collection_types.empty()) {

--- a/test/object-store/sectioned_results.cpp
+++ b/test/object-store/sectioned_results.cpp
@@ -617,15 +617,15 @@ TEST_CASE("sectioned results", "[sectioned_results]") {
 
         r->begin_transaction();
         table->clear();
-        auto col_typed_link = table->add_column(type_TypedLink, "typed_link_col");
+        auto col_mixed = table->add_column(type_Mixed, "typed_link_col");
         auto linked = table->create_object();
-        table->create_object(ObjKey{}, {{col_typed_link, linked.get_link()}});
+        table->create_object(ObjKey{}, {{col_mixed, linked.get_link()}});
         r->commit_transaction();
 
         // Should throw on `type_TypedLink` being a section key.
         sr = sorted.sectioned_results([&](Mixed value, SharedRealm realm) {
             auto obj = Object(realm, value.get_link());
-            return Mixed(obj.obj().get<ObjLink>(col_typed_link));
+            return obj.obj().get<Mixed>(col_mixed);
         });
         REQUIRE_EXCEPTION(sr.size(), InvalidArgument,
                           "Links are not supported as section keys."); // Trigger calculation

--- a/test/test_dictionary.cpp
+++ b/test/test_dictionary.cpp
@@ -267,14 +267,14 @@ TEST(Dictionary_Clear)
     Group g;
     auto dogs = g.add_table_with_primary_key("dog", type_String, "name");
     auto persons = g.add_table_with_primary_key("person", type_String, "name");
-    auto col_dict_typed = persons->add_column_dictionary(type_TypedLink, "typed");
+    auto col_dict_mixed = persons->add_column_dictionary(type_Mixed, "any");
     auto col_dict_implicit = persons->add_column_dictionary(*dogs, "implicit");
 
     Obj adam = persons->create_object_with_primary_key("adam");
     Obj pluto = dogs->create_object_with_primary_key("pluto");
     Obj lady = dogs->create_object_with_primary_key("lady");
 
-    adam.get_dictionary(col_dict_typed).insert("Dog1", pluto);
+    adam.get_dictionary(col_dict_mixed).insert("Dog1", pluto);
     adam.get_dictionary(col_dict_implicit).insert("DOg2", lady.get_key());
 
     CHECK_EQUAL(lady.get_backlink_count(), 1);

--- a/test/test_set.cpp
+++ b/test/test_set.cpp
@@ -245,7 +245,6 @@ TEST(Set_Links)
     auto cabs = g.add_table("class_Cab");
 
     ColKey col_links = foos->add_column_set(*bars, "links");
-    ColKey col_typed_links = foos->add_column_set(type_TypedLink, "typed_links");
     ColKey col_mixeds = foos->add_column_set(type_Mixed, "mixeds");
 
     auto foo = foos->create_object();
@@ -261,7 +260,6 @@ TEST(Set_Links)
 
     auto set_links = foo.get_set<ObjKey>(col_links);
     auto lnkset_links = foo.get_setbase_ptr(col_links);
-    auto set_typed_links = foo.get_set<ObjLink>(col_typed_links);
     auto set_mixeds = foo.get_set<Mixed>(col_mixeds);
 
     set_links.insert(bar1.get_key());
@@ -282,28 +280,6 @@ TEST(Set_Links)
     CHECK_EQUAL(bar1.get_backlink_count(), 0);
     set_links.insert(bar1.get_key());
 
-    set_typed_links.insert(bar1.get_link());
-    set_typed_links.insert(bar2.get_link());
-    set_typed_links.insert(cab1.get_link());
-    set_typed_links.insert(cab2.get_link());
-    CHECK_EQUAL(set_typed_links.size(), 4);
-
-    set_typed_links.insert(bar1.get_link());
-    CHECK_EQUAL(set_typed_links.size(), 4);
-    set_typed_links.insert(bar2.get_link());
-    CHECK_EQUAL(set_typed_links.size(), 4);
-    set_typed_links.insert(cab1.get_link());
-    CHECK_EQUAL(set_typed_links.size(), 4);
-    set_typed_links.insert(cab2.get_link());
-    CHECK_EQUAL(set_typed_links.size(), 4);
-
-    CHECK_EQUAL(bar1.get_backlink_count(), 2);
-    CHECK_NOT_EQUAL(set_typed_links.find(bar1.get_link()), realm::npos);
-    CHECK_NOT_EQUAL(set_typed_links.find(bar2.get_link()), realm::npos);
-    CHECK_NOT_EQUAL(set_typed_links.find(cab1.get_link()), realm::npos);
-    CHECK_NOT_EQUAL(set_typed_links.find(cab2.get_link()), realm::npos);
-    CHECK_EQUAL(set_typed_links.find(bar3.get_link()), realm::npos);
-
     set_mixeds.insert(bar1.get_link());
     set_mixeds.insert(bar2.get_link());
     set_mixeds.insert(cab1.get_link());
@@ -314,7 +290,7 @@ TEST(Set_Links)
     set_mixeds.insert(cab2.get_link());
 
     CHECK_EQUAL(set_mixeds.size(), 4);
-    CHECK_EQUAL(bar1.get_backlink_count(), 3);
+    CHECK_EQUAL(bar1.get_backlink_count(), 2);
     CHECK_NOT_EQUAL(set_mixeds.find(bar1.get_link()), realm::npos);
     CHECK_NOT_EQUAL(set_mixeds.find(bar2.get_link()), realm::npos);
     CHECK_NOT_EQUAL(set_mixeds.find(cab1.get_link()), realm::npos);
@@ -325,11 +301,9 @@ TEST(Set_Links)
     set_links.insert(bar4.get_key());
 
     CHECK_EQUAL(set_links.size(), 3);
-    CHECK_EQUAL(set_typed_links.size(), 3);
     CHECK_EQUAL(set_mixeds.size(), 3);
 
     CHECK_EQUAL(set_links.find(bar1.get_key()), realm::npos);
-    CHECK_EQUAL(set_typed_links.find(bar1.get_link()), realm::npos);
     CHECK_EQUAL(set_mixeds.find(bar1.get_link()), realm::npos);
 
     auto bar2_key = bar2.get_key();
@@ -338,7 +312,6 @@ TEST(Set_Links)
 
     CHECK_EQUAL(set_links.size(), 3);
     CHECK_EQUAL(lnkset_links->size(), 2); // Unresolved link was hidden from LnkSet
-    CHECK_EQUAL(set_typed_links.size(), 3);
     CHECK_EQUAL(set_mixeds.size(), 3);
 
     CHECK_EQUAL(set_links.find(bar2_key), realm::npos);               // The original bar2 key is no longer in the set
@@ -346,7 +319,6 @@ TEST(Set_Links)
     CHECK_EQUAL(lnkset_links->find_any(bar2.get_key()), realm::npos); // The unresolved bar2 key is hidden by LnkSet
     CHECK_EQUAL(lnkset_links->find_any(bar3.get_key()), 0);
     CHECK_EQUAL(lnkset_links->find_any(bar4.get_key()), 1);
-    CHECK_EQUAL(set_typed_links.find(bar2_link), realm::npos);
     CHECK_EQUAL(set_mixeds.find(bar2_link), realm::npos);
 
     // g.to_json(std::cout);

--- a/test/test_sync.cpp
+++ b/test/test_sync.cpp
@@ -5995,6 +5995,7 @@ TEST(Sync_Mixed)
     }
 }
 
+/*
 TEST(Sync_TypedLinks)
 {
     // Test replication and synchronization of Mixed values and lists.
@@ -6055,6 +6056,7 @@ TEST(Sync_TypedLinks)
         CHECK_EQUAL(l2.get_obj_key(), fops->begin()->get_key());
     }
 }
+*/
 
 TEST(Sync_Dictionary)
 {

--- a/test/test_typed_links.cpp
+++ b/test/test_typed_links.cpp
@@ -28,6 +28,7 @@ using namespace realm;
 using namespace realm::util;
 using namespace realm::test_util;
 
+/*
 TEST(TypedLinks_Single)
 {
     Group g;
@@ -100,6 +101,7 @@ TEST(TypedLinks_List)
     paul.remove();
     CHECK_EQUAL(pluto.get_backlink_count(), 0);
 }
+*/
 
 TEST(TypedLinks_Mixed)
 {
@@ -213,8 +215,6 @@ TEST(TypedLinks_Clear)
     auto dog = g.add_table("dog");
     auto cat = g.add_table("cat");
     auto person = g.add_table("person");
-    auto col_typed = person->add_column(type_TypedLink, "typed");
-    auto col_list_typed = person->add_column_list(type_TypedLink, "typed_list");
     auto col_mixed = person->add_column(type_Mixed, "mixed");
     auto col_list_mixed = person->add_column_list(type_Mixed, "mixed_list");
 
@@ -222,10 +222,8 @@ TEST(TypedLinks_Clear)
     cat->create_object();
     auto paul = person->create_object();
 
-    paul.set(col_typed, ObjLink{dog->get_key(), pluto.get_key()});
-    paul.get_list<ObjLink>(col_list_typed).add({dog->get_key(), pluto.get_key()});
-    paul.set(col_mixed, Mixed(ObjLink{dog->get_key(), pluto.get_key()}));
-    paul.get_list<Mixed>(col_list_mixed).add(ObjLink{dog->get_key(), pluto.get_key()});
+    paul.set(col_mixed, Mixed(pluto.get_link()));
+    paul.get_list<Mixed>(col_list_mixed).add(pluto.get_link());
 
     person->clear();
     g.verify();


### PR DESCRIPTION
Removes some complexity/code. Is easy to re-introduce. Can be safely removed if we disallow creating columns of this type. This can also safely be done, as this feature is not yet used.

## What, How & Why?
<!-- Describe the changes and give some hints to guide your reviewers if possible. -->
<!-- Link to relevant issue this fixes -->

## ☑️ ToDos
* [ ] 📝 Changelog update
* [ ] 🚦 Tests (or not relevant)
* [ ] C-API, if public C++ API changed.
