### PR TITLE
Consolidate the implementation of Results::index_of

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 * A GeoBox is now just a shortcut for the equivilent GeoPolygon. This provides consistent query results and error checking. ([#6703](https://github.com/realm/realm-core/issues/6703), since v13.11.0) 
 * Fixed several corner cases (eg. around the poles) where invalid points matched a geoWithin query.
 * Disallow full text search index for primary key columns. ([#6657](https://github.com/realm/realm-core/issues/6657), since v13.2.0)
+* Searching for objects in Results would not always find the requested item. This is particularly the case when the C API is used. ([#6695](https://github.com/realm/realm-core/issues/6695), since v10.0.0)
 
 ### Breaking changes
 * None.

--- a/src/realm/object-store/results.hpp
+++ b/src/realm/object-store/results.hpp
@@ -417,6 +417,17 @@ auto Results::last(Context& ctx)
     });
 }
 
+template <>
+size_t Results::index_of(Obj const& obj);
+template <>
+size_t Results::index_of(Mixed const& value);
+
+template <typename T>
+inline size_t Results::index_of(T const& value)
+{
+    return index_of(Mixed(value));
+}
+
 template <typename Context, typename T>
 size_t Results::index_of(Context& ctx, T value)
 {

--- a/test/object-store/c_api/c_api.cpp
+++ b/test/object-store/c_api/c_api.cpp
@@ -2700,10 +2700,17 @@ TEST_CASE("C API", "[c_api]") {
                     CHECK(value.type == RLM_TYPE_LINK);
                     CHECK(value.link.target_table == class_foo.key);
                     CHECK(value.link.target == realm_object_get_key(obj1.get()));
-                    CHECK(!realm_results_get(r.get(), 1, &value));
-                    CHECK_ERR(RLM_ERR_INDEX_OUT_OF_BOUNDS);
                     size_t index = -1;
                     bool found = false;
+                    CHECK(realm_results_find(r.get(), &value, &index, &found));
+                    CHECK(index == 0);
+                    CHECK(found == true);
+
+                    value = rlm_null();
+                    CHECK(!realm_results_get(r.get(), 1, &value));
+                    CHECK_ERR(RLM_ERR_INDEX_OUT_OF_BOUNDS);
+                    index = -1;
+                    found = false;
                     CHECK(realm_results_find(r.get(), &value, &index, &found));
                     CHECK(index == realm::not_found);
                     CHECK(found == false);


### PR DESCRIPTION
## What, How & Why?
<!-- Describe the changes and give some hints to guide your reviewers if possible. -->
<!-- Link to relevant issue this fixes -->
Make a single implementation that will work for all types. This is to ensure consistent behavior.

Fixes #6695

## ☑️ ToDos
* [x] 📝 Changelog update
* [x] 🚦 Tests (or not relevant)
* [x] C-API, if public C++ API changed.
