### PR TITLE
Silence a Valgrind error

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,7 +19,7 @@
 -----------
 
 ### Internals
-* None.
+* Fixed Valgrind error ([#6643](https://github.com/realm/realm-core/issues/6643))
 
 ----------------------------------------------
 

--- a/src/realm/impl/copy_replication.cpp
+++ b/src/realm/impl/copy_replication.cpp
@@ -171,17 +171,17 @@ void CopyReplication::dictionary_insert(const CollectionBase& coll, size_t, Mixe
     if (value.is_type(type_Link, type_TypedLink)) {
         value = handle_link(col_key, value, [&](TableRef dest_target_table) {
             // Check if dictionary obj has embedded obj already
-            auto tmp = dict.try_get(key);
-            Obj embedded;
-            if (tmp && tmp->is_type(type_TypedLink)) {
-                ObjKey key = tmp->get<ObjKey>();
-                embedded = dest_target_table->get_object(key);
+            size_t ndx = dict.find_any_key(key);
+            if (ndx != realm::not_found) {
+                auto val = dict.get_any(ndx);
+                if (val.is_type(type_Link)) {
+                    ObjKey key = val.get<ObjKey>();
+                    m_current.obj_in_destination = dest_target_table->get_object(key);
+                    return;
+                }
             }
-            else {
-                // If not, create one
-                embedded = dict.create_and_insert_linked_object(key);
-            }
-            m_current.obj_in_destination = embedded;
+            // If not, create one
+            m_current.obj_in_destination = dict.create_and_insert_linked_object(key);
         });
         if (value.is_null())
             return;


### PR DESCRIPTION
## What, How & Why?

This error was introduced in 601805bd148aa8, where the destructor on Mixed was removed. It was not possible to actually prove that Valgrind was right in reporting a read from uninitialized memory, but changing the logic a bit could make the error go away. The new code is probably slightly slower, but it is not on the critical path.

Fixes #6643 

<!-- Describe the changes and give some hints to guide your reviewers if possible. -->
<!-- Link to relevant issue this fixes -->

## ☑️ ToDos
* [x] 📝 Changelog update
* [x] 🚦 Tests (or not relevant)
* [x] C-API, if public C++ API changed.
