### PR TITLE
More detailed error message for SystemError exceptions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@
 
 ### Internals
 * Prebuilt binaries for non-Apple platforms are no longer published as nothing was using them ([PR #6746](https://github.com/realm/realm-core/pull/6746)).
+* SystemError exceptions now have a more detailed error message. ([#6739](https://github.com/realm/realm-core/issues/6739))
 
 ----------------------------------------------
 

--- a/src/realm/exceptions.hpp
+++ b/src/realm/exceptions.hpp
@@ -356,7 +356,7 @@ private:
 struct SystemError : RuntimeError {
     SystemError(std::error_code err, std::string_view msg)
         : RuntimeError(ErrorCodes::SystemError,
-                       util::format("%1. SystemError %2: %3", msg, err.value(), err.message()))
+                       util::format("%1 (SystemError %2: %3)", msg, err.value(), err.message()))
     {
         const_cast<Status&>(to_status()).set_std_error_code(err);
     }

--- a/src/realm/exceptions.hpp
+++ b/src/realm/exceptions.hpp
@@ -355,7 +355,8 @@ private:
 
 struct SystemError : RuntimeError {
     SystemError(std::error_code err, std::string_view msg)
-        : RuntimeError(ErrorCodes::SystemError, msg)
+        : RuntimeError(ErrorCodes::SystemError,
+                       util::format("%1. SystemError %2: %3", msg, err.value(), err.message()))
     {
         const_cast<Status&>(to_status()).set_std_error_code(err);
     }

--- a/src/realm/exceptions.hpp
+++ b/src/realm/exceptions.hpp
@@ -362,7 +362,7 @@ struct SystemError : RuntimeError {
     }
 
     SystemError(int err_no, std::string_view msg)
-        : SystemError(std::error_code(err_no, std::system_category()), msg)
+        : SystemError(std::error_code(err_no, std::generic_category()), msg)
     {
     }
 

--- a/test/object-store/sync/app.cpp
+++ b/test/object-store/sync/app.cpp
@@ -2771,7 +2771,8 @@ TEST_CASE("app: sync integration", "[sync][app][baas]") {
                 sync_error_handler_called.store(true);
                 REQUIRE(error.get_system_error() ==
                         sync::make_error_code(realm::sync::ProtocolError::bad_authentication));
-                REQUIRE(error.reason() == "Unable to refresh the user access token.");
+                REQUIRE_THAT(std::string(error.reason()),
+                             Catch::Matchers::ContainsSubstring("Unable to refresh the user access token."));
             };
             auto r = Realm::get_shared_realm(config);
             timed_wait_for([&] {
@@ -2871,7 +2872,8 @@ TEST_CASE("app: sync integration", "[sync][app][baas]") {
                 sync_error_handler_called.store(true);
                 REQUIRE(error.get_system_error() ==
                         sync::make_error_code(realm::sync::ProtocolError::bad_authentication));
-                REQUIRE(error.reason() == "Unable to refresh the user access token.");
+                REQUIRE_THAT(std::string(error.reason()),
+                             Catch::Matchers::ContainsSubstring("Unable to refresh the user access token."));
             };
 
             auto transport = static_cast<SynchronousTestTransport*>(session.transport());
@@ -3101,8 +3103,9 @@ TEST_CASE("app: sync integration", "[sync][app][baas]") {
 
         auto error = wait_for_future(std::move(pf.future), std::chrono::minutes(5)).get();
         REQUIRE(error.get_system_error() == make_error_code(sync::ProtocolError::limits_exceeded));
-        REQUIRE(error.reason() == "Sync websocket closed because the server received a message that was too large: "
-                                  "read limited at 16777217 bytes");
+        REQUIRE_THAT(std::string(error.reason()),
+                     Catch::Matchers::ContainsSubstring("Sync websocket closed because the server received a message "
+                                                        "that was too large: read limited at 16777217 bytes"));
         REQUIRE(error.is_client_reset_requested());
         REQUIRE(error.server_requests_action == sync::ProtocolErrorInfo::Action::ClientReset);
     }

--- a/test/test_util_file.cpp
+++ b/test/test_util_file.cpp
@@ -308,7 +308,7 @@ TEST(Utils_File_SystemErrorMessage)
 {
     std::error_code err = std::make_error_code(std::errc::too_many_files_open);
     std::string_view message = "my message";
-    std::string expected = util::format("%1. SystemError %2: %3", message, err.value(), "Too many open files");
+    std::string expected = util::format("%1 (SystemError %2: %3)", message, err.value(), "Too many open files");
     CHECK_THROW_CONTAINING_MESSAGE(throw SystemError(err, message), expected);
     CHECK_THROW_CONTAINING_MESSAGE(throw SystemError(err.value(), message), expected);
 }

--- a/test/test_util_file.cpp
+++ b/test/test_util_file.cpp
@@ -308,7 +308,11 @@ TEST(Utils_File_SystemErrorMessage)
 {
     std::error_code err = std::make_error_code(std::errc::too_many_files_open);
     std::string_view message = "my message";
+#ifdef _WIN32
+    std::string expected = util::format("%1 (SystemError %2: %3)", message, err.value(), "too many files open");
+#else
     std::string expected = util::format("%1 (SystemError %2: %3)", message, err.value(), "Too many open files");
+#endif
     CHECK_THROW_CONTAINING_MESSAGE(throw SystemError(err, message), expected);
     CHECK_THROW_CONTAINING_MESSAGE(throw SystemError(err.value(), message), expected);
 }

--- a/test/test_util_file.cpp
+++ b/test/test_util_file.cpp
@@ -304,4 +304,13 @@ TEST(Utils_File_Lock)
     CHECK_NOT(f2.try_rw_lock_exclusive());
 }
 
+TEST(Utils_File_SystemErrorMessage)
+{
+    std::error_code err = std::make_error_code(std::errc::too_many_files_open);
+    std::string_view message = "my message";
+    std::string expected = util::format("%1. SystemError %2: %3", message, err.value(), "Too many open files");
+    CHECK_THROW_CONTAINING_MESSAGE(throw SystemError(err, message), expected);
+    CHECK_THROW_CONTAINING_MESSAGE(throw SystemError(err.value(), message), expected);
+}
+
 #endif


### PR DESCRIPTION
Issues like https://github.com/realm/realm-core/issues/6739 would be much easier to diagnose if the reported exception message had the details about what the error code was. The std error code was already stored there, so this change just appends the details to the existing message.

## ☑️ ToDos
* [x] 📝 Changelog update
* [x] 🚦 Tests (or not relevant)
* [x] C-API, if public C++ API changed.