### PR TITLE
add freelist verification at more points during commit

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,7 +17,7 @@
 -----------
 
 ### Internals
-* None.
+* Added additional checks in response to reported freelist corruptions (PR [#6763](https://github.com/realm/realm-core/pull/6763))
 
 ----------------------------------------------
 

--- a/src/realm/group_writer.cpp
+++ b/src/realm/group_writer.cpp
@@ -951,8 +951,18 @@ void GroupWriter::read_in_freelist()
                     continue;
                 }
             }
-
             free_in_file.emplace_back(ref, size, 0);
+            // try to provoke an error by zeroing the block:
+            if (m_alloc.is_in_memory()) {
+                // do nothing for now
+            }
+            else {
+                MapWindow* window = get_window(ref, size);
+                char* start_addr = window->translate(ref);
+                window->encryption_read_barrier(start_addr, size);
+                memset(start_addr, 0, size);
+                window->encryption_write_barrier(start_addr, size);
+            }
         }
 
         // This will imply a copy-on-write

--- a/src/realm/group_writer.cpp
+++ b/src/realm/group_writer.cpp
@@ -778,7 +778,8 @@ ref_type GroupWriter::write_group()
     // Function returns index of element holding the space reserved for the free
     // lists in the file.
     size_t reserve_ndx = recreate_freelist(reserve_pos);
-
+    REALM_ASSERT_RELEASE(reserve_pos == m_free_positions.get(reserve_ndx));
+    REALM_ASSERT_RELEASE(reserve_size == m_free_lengths.get(reserve_ndx));
     ALLOC_DBG_COUT("  Freelist size after merge: " << m_free_positions.size() << "   freelist space required: "
                                                    << max_free_space_needed << std::endl);
     // Before we calculate the actual sizes of the free-list arrays, we must
@@ -845,6 +846,8 @@ ref_type GroupWriter::write_group()
         }
     }
 
+    REALM_ASSERT_RELEASE(reserve_pos == m_free_positions.get(reserve_ndx));
+    REALM_ASSERT_RELEASE(reserve_size == m_free_lengths.get(reserve_ndx));
     // Get final sizes
     size_t top_byte_size = top.get_byte_size();
     ref_type end_ref = top_ref + top_byte_size;

--- a/src/realm/group_writer.cpp
+++ b/src/realm/group_writer.cpp
@@ -1019,7 +1019,6 @@ void GroupWriter::read_in_freelist()
 
 std::vector<GroupWriter::AugmentedFreeSpaceEntry> GroupWriter::create_combined_freelist()
 {
-
     std::vector<AugmentedFreeSpaceEntry> free_in_file;
     auto& new_free_space = m_group.m_alloc.get_free_read_only(); // Throws
     auto nb_elements =

--- a/src/realm/group_writer.cpp
+++ b/src/realm/group_writer.cpp
@@ -978,17 +978,6 @@ void GroupWriter::read_in_freelist()
                 }
             }
             free_in_file.emplace_back(ref, size, 0);
-            // try to provoke an error by zeroing the block:
-            if (m_alloc.is_in_memory()) {
-                // do nothing for now
-            }
-            else {
-                MapWindow* window = get_window(ref, size);
-                char* start_addr = window->translate(ref);
-                window->encryption_read_barrier(start_addr, size);
-                memset(start_addr, 0, size);
-                window->encryption_write_barrier(start_addr, size);
-            }
         }
 
         // This will imply a copy-on-write
@@ -1379,7 +1368,7 @@ void GroupWriter::write_array_at(T* translator, ref_type ref, const char* data, 
 {
     size_t pos = size_t(ref);
 
-    REALM_ASSERT_3(pos + size, <=, to_size_t(m_group.m_top.get(2) / 2));
+    REALM_ASSERT_RELEASE(pos + size <= to_size_t(m_group.m_top.get(2) / 2));
     // REALM_ASSERT_3(pos + size, <=, m_file_map.get_size());
     char* dest_addr = translator->translate(pos);
     REALM_ASSERT_RELEASE(is_aligned(dest_addr));

--- a/src/realm/group_writer.cpp
+++ b/src/realm/group_writer.cpp
@@ -740,6 +740,7 @@ ref_type GroupWriter::write_group()
     // using the maximum size possible, we still do not end up with a zero size
     // free-space chunk as we deduct the actually used size from it.
     auto reserve = reserve_free_space(max_free_space_needed + 8); // Throws
+    m_allocation_allowed = false;
     size_t reserve_pos = reserve->second;
     size_t reserve_size = reserve->first;
     verify_freelists();
@@ -812,7 +813,7 @@ ref_type GroupWriter::write_group()
     // deduction of the actually used space from the reserved chunk,) will not
     // change the byte-size of those arrays.
     // size_t reserve_pos = to_size_t(m_free_positions.get(reserve_ndx));
-    REALM_ASSERT_RELEASE(reserve_size > max_free_space_needed);
+    REALM_ASSERT_RELEASE(reserve_size >= max_free_space_needed + 8);
     int_fast64_t value_4 = to_int64(reserve_pos + max_free_space_needed);
 
 #if REALM_ENABLE_MEMDEBUG
@@ -1237,6 +1238,7 @@ GroupWriter::FreeListElement GroupWriter::search_free_space_in_part_of_freelist(
 
 GroupWriter::FreeListElement GroupWriter::reserve_free_space(size_t size)
 {
+    REALM_ASSERT_RELEASE(m_allocation_allowed);
     auto chunk = search_free_space_in_part_of_freelist(size);
     while (chunk == m_size_map.end()) {
         if (!m_under_evacuation.empty()) {

--- a/src/realm/group_writer.hpp
+++ b/src/realm/group_writer.hpp
@@ -212,6 +212,7 @@ private:
     std::multimap<size_t, size_t> m_size_map;
     std::vector<size_t> m_evacuation_progress;
     using FreeListElement = std::multimap<size_t, size_t>::iterator;
+    bool m_allocation_allowed = true;
 
     void read_in_freelist();
     size_t recreate_freelist(size_t reserve_pos);

--- a/src/realm/node_header.hpp
+++ b/src/realm/node_header.hpp
@@ -239,6 +239,6 @@ public:
         return num_bytes;
     }
 };
-}
+} // namespace realm
 
 #endif /* REALM_NODE_HEADER_HPP */


### PR DESCRIPTION
## Improve checks for free list corruptions

* Enable some checks in release mode, which where otherwise only present in debug mode.
* Run check for overlapping free blocks (free list corruption) in more places during commit.

This is in the hope of getting back better clues about the root cause of reported free list corruptions.

