### PR TITLE
C-API checks for Set in Mixed.

### DIFF
--- a/src/realm/object-store/c_api/object.cpp
+++ b/src/realm/object-store/c_api/object.cpp
@@ -385,7 +385,7 @@ RLM_API realm_set_t* realm_get_set(realm_object_t* object, realm_property_key_t 
         auto col_key = ColKey(key);
         table->check_column(col_key);
 
-        if (!col_key.is_set()) {
+        if (!(col_key.is_set() || col_key.get_type() == col_type_Mixed)) {
             report_type_mismatch(object->get_realm(), *table, col_key);
         }
 

--- a/test/object-store/c_api/c_api.cpp
+++ b/test/object-store/c_api/c_api.cpp
@@ -5087,6 +5087,31 @@ TEST_CASE("C API: nested collections", "[c_api]") {
         checked(realm_list_size(list.get(), &size));
         REQUIRE(size == 5);
     }
+
+    SECTION("set") {
+        REQUIRE(realm_set_collection(obj1.get(), foo_any_col_key, RLM_COLLECTION_TYPE_SET));
+        realm_value_t value;
+        realm_get_value(obj1.get(), foo_any_col_key, &value);
+        REQUIRE(value.type == RLM_TYPE_SET);
+        auto set = cptr_checked(realm_get_set(obj1.get(), foo_any_col_key));
+        size_t index;
+        bool inserted = false;
+        REQUIRE(realm_set_insert(set.get(), rlm_str_val("Hello"), &index, &inserted));
+        CHECK(index == 0);
+        CHECK(inserted);
+        REQUIRE(realm_set_insert(set.get(), rlm_int_val(42), &index, &inserted));
+        CHECK(index == 0);
+        CHECK(inserted);
+        size_t size;
+        checked(realm_set_size(set.get(), &size));
+        REQUIRE(size == 2);
+        checked(realm_set_get(set.get(), 0, &value));
+        CHECK(value.type == RLM_TYPE_INT);
+        CHECK(value.integer == 42);
+        checked(realm_set_get(set.get(), 1, &value));
+        CHECK(value.type == RLM_TYPE_STRING);
+        CHECK(strncmp(value.string.data, "Hello", value.string.size) == 0);
+    }
     realm_release(realm);
 }
 


### PR DESCRIPTION
## What, How & Why?
I forgot to add a check in the C API for `SETs` that are held into a mixed.

