### PR TITLE
Fix a use after free error in tests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 ### Fixed
 * <How do the end-user experience this issue? what was the impact?> ([#????](https://github.com/realm/realm-core/issues/????), since v?.?.?)
 * Fix an error during async open and client reset if properties have been added to the schema. This fix applies to PBS to FLX migration if async open is used. ([#6707](https://github.com/realm/realm-core/issues/6707), since v12.3.0)
+* Fixed a double move (undefined behaviour) if an async open resulted in an error. ([#6768](https://github.com/realm/realm-core/pull/6768), since v13.16.0)
 
 ### Breaking changes
 * None.

--- a/src/realm/object-store/sync/async_open_task.cpp
+++ b/src/realm/object-store/sync/async_open_task.cpp
@@ -55,8 +55,10 @@ void AsyncOpenTask::start(AsyncOpenCallback async_open_complete)
             coordinator = std::move(m_coordinator);
         }
 
-        if (!status.is_ok())
+        if (!status.is_ok()) {
             self->async_open_complete(std::move(async_open_complete), coordinator, status);
+            return;
+        }
 
         auto config = coordinator->get_config();
         if (config.sync_config && config.sync_config->flx_sync_requested &&

--- a/test/object-store/sync/flx_migration.cpp
+++ b/test/object-store/sync/flx_migration.cpp
@@ -858,23 +858,21 @@ TEST_CASE("Async open + client reset", "[flx][migration][baas]") {
         shared_object.persisted_properties.push_back({"oid_field", PropertyType::ObjectId | PropertyType::Nullable});
         config->schema = {shared_object, locally_added};
 
-        auto [ref, error] = async_open_realm(*config);
-        REQUIRE(ref);
-        REQUIRE_FALSE(error);
+        async_open_realm(*config, [&](ThreadSafeReference&& ref, std::exception_ptr error) {
+            REQUIRE(ref);
+            REQUIRE_FALSE(error);
 
-        auto realm = Realm::get_shared_realm(std::move(ref));
+            auto realm = Realm::get_shared_realm(std::move(ref));
 
-        auto table = realm->read_group().get_table("class_Object");
-        REQUIRE(table->size() == 0);
-        REQUIRE(num_before_reset_notifications == 1);
-        REQUIRE(num_after_reset_notifications == 1);
+            auto table = realm->read_group().get_table("class_Object");
+            REQUIRE(table->size() == 0);
+            REQUIRE(num_before_reset_notifications == 1);
+            REQUIRE(num_after_reset_notifications == 1);
 
-        auto locally_added_table = realm->read_group().get_table("class_LocallyAdded");
-        REQUIRE(locally_added_table);
-        REQUIRE(locally_added_table->size() == 0);
-        auto sync_session = realm->sync_session();
-        REQUIRE(sync_session);
-        sync_session->shutdown_and_wait();
+            auto locally_added_table = realm->read_group().get_table("class_LocallyAdded");
+            REQUIRE(locally_added_table);
+            REQUIRE(locally_added_table->size() == 0);
+        });
     }
 
     SECTION("initial state") {
@@ -893,23 +891,21 @@ TEST_CASE("Async open + client reset", "[flx][migration][baas]") {
                 {"oid_field", PropertyType::ObjectId | PropertyType::Nullable});
             config->schema = {shared_object, locally_added};
 
-            auto [ref, error] = async_open_realm(*config);
-            REQUIRE(ref);
-            REQUIRE_FALSE(error);
+            async_open_realm(*config, [&](ThreadSafeReference&& ref, std::exception_ptr error) {
+                REQUIRE(ref);
+                REQUIRE_FALSE(error);
 
-            auto realm = Realm::get_shared_realm(std::move(ref));
+                auto realm = Realm::get_shared_realm(std::move(ref));
 
-            auto table = realm->read_group().get_table("class_Object");
-            REQUIRE(table->size() == 1);
-            REQUIRE(num_before_reset_notifications == 1);
-            REQUIRE(num_after_reset_notifications == 1);
+                auto table = realm->read_group().get_table("class_Object");
+                REQUIRE(table->size() == 1);
+                REQUIRE(num_before_reset_notifications == 1);
+                REQUIRE(num_after_reset_notifications == 1);
 
-            auto locally_added_table = realm->read_group().get_table("class_LocallyAdded");
-            REQUIRE(locally_added_table);
-            REQUIRE(locally_added_table->size() == 0);
-            auto sync_session = realm->sync_session();
-            REQUIRE(sync_session);
-            sync_session->shutdown_and_wait();
+                auto locally_added_table = realm->read_group().get_table("class_LocallyAdded");
+                REQUIRE(locally_added_table);
+                REQUIRE(locally_added_table->size() == 0);
+            });
         }
     }
 }

--- a/test/object-store/sync/sync_test_utils.cpp
+++ b/test/object-store/sync/sync_test_utils.cpp
@@ -236,22 +236,21 @@ void wait_for_advance(Realm& realm)
     realm.m_binding_context = nullptr;
 }
 
-std::pair<ThreadSafeReference, std::exception_ptr> async_open_realm(const Realm::Config& config)
+void async_open_realm(const Realm::Config& config,
+                      util::UniqueFunction<void(ThreadSafeReference&& ref, std::exception_ptr e)> finish)
 {
     std::mutex mutex;
-    ThreadSafeReference realm_ref;
-    std::exception_ptr error;
+    bool did_finish = false;
     auto task = Realm::get_synchronized_realm(config);
     task->start([&](ThreadSafeReference&& ref, std::exception_ptr e) {
+        finish(std::move(ref), e);
         std::lock_guard lock(mutex);
-        realm_ref = std::move(ref);
-        error = e;
+        did_finish = true;
     });
     util::EventLoop::main().run_until([&] {
         std::lock_guard lock(mutex);
-        return realm_ref || error;
+        return did_finish;
     });
-    return std::pair(std::move(realm_ref), error);
 }
 
 #endif // REALM_ENABLE_AUTH_TESTS

--- a/test/object-store/sync/sync_test_utils.hpp
+++ b/test/object-store/sync/sync_test_utils.hpp
@@ -156,7 +156,8 @@ AutoVerifiedEmailCredentials create_user_and_log_in(app::SharedApp app);
 
 void wait_for_advance(Realm& realm);
 
-std::pair<ThreadSafeReference, std::exception_ptr> async_open_realm(const Realm::Config&);
+void async_open_realm(const Realm::Config& config,
+                      util::UniqueFunction<void(ThreadSafeReference&& ref, std::exception_ptr e)> finish);
 
 #endif // REALM_ENABLE_AUTH_TESTS
 


### PR DESCRIPTION
Although the recent merge of my [PR](https://github.com/realm/realm-core/pull/6723) was running green on CI, it has caused failures after being merged. 

I haven't been able to reproduce this locally on my mac, but the various failures on CI have given clues to the following hypothesis:

The async open task has a notifier registered on the session that gets invoked even after the `async_open_realm()` function has returned. The fix is to cancel the task which unregisters the notifier and shuts down the session.

The new tests triggered the unhappy path of async open which uncovered a recently added double call to std::move introduced in https://github.com/realm/realm-core/pull/6722

~~The exception pointer passed out of the newly added async open utility was causing a use-after-free when dereferenced to check the error messages in the tests. A [recent](https://github.com/realm/realm-core/pull/6756) PR updated exceptions to change the error messaging to a new formatted string (instead of a simple pointer to constant char* somewhere in the code). The fix I attempt here is to use a callback pattern which keeps the exception_ptr in a valid scope when rethrown to get the error message.~~