### PR TITLE
[bindgen] Expose DeviceInfo::bundle_id

### DIFF
--- a/bindgen/spec.yml
+++ b/bindgen/spec.yml
@@ -620,6 +620,7 @@ records:
       device_version: std::string
       framework_name: std::string
       framework_version: std::string
+      bundle_id: std::string
 
   AppConfig:
     cppName: app::App::Config


### PR DESCRIPTION
## What, How & Why?
<!-- Describe the changes and give some hints to guide your reviewers if possible. -->
<!-- Link to relevant issue this fixes -->

We need to expose `bundle_id` to complete the sync connection parameter project.

## ☑️ ToDos
* [ ] 📝 Changelog update
* [ ] 🚦 Tests (or not relevant)
* [ ] C-API, if public C++ API changed.
