### PR TITLE
Add an option to pass a live Realm to the before-reset callback

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ### Enhancements
 * Sync connection and session reconnect timing/backoff logic has been unified into a single implementation and is now configurable. Previously some errors would cause an hour-long wait before attempting to reconnect, now - by default - the sync client will wait for 1 second before retrying and double the timeout after each subsequent attempt up to 5 minutes, after which a retry will be attempted every 5 minutes. If the cause of the error changes, the backoff will be reset. If the sync client voluntarily disconnects, no backoff will be used. (PR [#6526](https://github.com/realm/realm-core/pull/6526)).
+* Add support for the SDK initializing the schema inside a before-client-reset callback ([PR #6780](https://github.com/realm/realm-core/pull/6780)).
 
 ### Fixed
 * <How do the end-user experience this issue? what was the impact?> ([#????](https://github.com/realm/realm-core/issues/????), since v?.?.?)

--- a/src/realm.h
+++ b/src/realm.h
@@ -1169,7 +1169,7 @@ RLM_API bool realm_compact(realm_t*, bool* did_compact);
  * Find and delete the table passed as parementer for the realm instance passed to this function.
  * @param table_name for the table the user wants to delete
  * @param table_deleted in order to indicate if the table was actually deleted from realm
- * @return true if no error has occured, false otherwise
+ * @return true if no error has occurred, false otherwise
  */
 RLM_API bool realm_remove_table(realm_t*, const char* table_name, bool* table_deleted);
 
@@ -1958,7 +1958,7 @@ RLM_API void realm_collection_changes_get_ranges(
     realm_collection_move_t* out_moves, size_t max_moves);
 
 /**
- * Returns the number of changes occured to the dictionary passed as argument
+ * Returns the number of changes occurred to the dictionary passed as argument
  *
  * @param changes valid ptr to the dictionary changes structure
  * @param out_deletions_size number of deletions
@@ -2282,7 +2282,7 @@ RLM_API bool realm_dictionary_get_keys(realm_dictionary_t*, size_t* out_size, re
  *
  * @param key to search in the dictionary
  * @param found True if the such key exists
- * @return True if no exception occured
+ * @return True if no exception occurred
  */
 RLM_API bool realm_dictionary_contains_key(const realm_dictionary_t*, realm_value_t key, bool* found);
 
@@ -2291,7 +2291,7 @@ RLM_API bool realm_dictionary_contains_key(const realm_dictionary_t*, realm_valu
  *
  * @param value to search in the dictionary
  * @param index the index of the value in the dictionry if such value exists
- * @return True if no exception occured
+ * @return True if no exception occurred
  */
 RLM_API bool realm_dictionary_contains_value(const realm_dictionary_t*, realm_value_t value, size_t* index);
 
@@ -2480,7 +2480,7 @@ RLM_API bool realm_query_delete_all(const realm_query_t*);
 
 /**
  * Set the boolean passed as argument to true or false whether the realm_results passed is valid or not
- * @return true/false if no exception has occured.
+ * @return true/false if no exception has occurred.
  */
 RLM_API bool realm_results_is_valid(const realm_results_t*, bool*);
 
@@ -2552,7 +2552,7 @@ RLM_API bool realm_results_get(realm_results_t*, size_t index, realm_value_t* ou
  *  @param value the value to find inside the realm results
  *  @param out_index the index where the object has been found, or realm::not_found
  *  @param out_found boolean indicating if the value has been found or not
- *  @return true if no error occured, false otherwise
+ *  @return true if no error occurred, false otherwise
  */
 RLM_API bool realm_results_find(realm_results_t*, realm_value_t* value, size_t* out_index, bool* out_found);
 
@@ -2577,7 +2577,7 @@ RLM_API realm_object_t* realm_results_get_object(realm_results_t*, size_t index)
  * Return the query associated to the results passed as argument.
  *
  * @param results the ptr to a valid results object.
- * @return a valid ptr to realm_query_t if no error has occured
+ * @return a valid ptr to realm_query_t if no error has occurred
  */
 RLM_API realm_query_t* realm_results_get_query(realm_results_t* results);
 
@@ -2586,7 +2586,7 @@ RLM_API realm_query_t* realm_results_get_query(realm_results_t* results);
  *  @param value the value to find inside the realm results
  *  @param out_index the index where the object has been found, or realm::not_found
  *  @param out_found boolean indicating if the value has been found or not
- *  @return true if no error occured, false otherwise
+ *  @return true if no error occurred, false otherwise
  */
 RLM_API bool realm_results_find_object(realm_results_t*, realm_object_t* value, size_t* out_index, bool* out_found);
 

--- a/src/realm/object-store/c_api/sync.cpp
+++ b/src/realm/object-store/c_api/sync.cpp
@@ -272,7 +272,7 @@ RLM_API void realm_sync_client_config_set_fast_reconnect_limit(realm_sync_client
 /// @param config pointer to sync client config created by realm_sync_client_config_new()
 /// @param on_thread_create callback invoked when the object store thread is created
 /// @param on_thread_destroy callback invoked when the object store thread is destroyed
-/// @param on_error callback invoked to signal to the listener that some error has occured.
+/// @param on_error callback invoked to signal to the listener that some error has occurred.
 /// @param user_data pointer to user defined data that is provided to each of the callback functions
 /// @param free_userdata callback invoked when the user_data is to be freed
 RLM_API void realm_sync_client_config_set_default_binding_thread_observer(

--- a/src/realm/object-store/sync/sync_session.cpp
+++ b/src/realm/object-store/sync/sync_session.cpp
@@ -582,7 +582,7 @@ void SyncSession::handle_fresh_realm_downloaded(DBRef db, Status status,
         const bool try_again = false;
         sync::SessionErrorInfo synthetic(
             make_error_code(sync::Client::Error::auto_client_reset_failure),
-            util::format("A fatal error occured during client reset: '%1'", status.reason()), try_again);
+            util::format("A fatal error occurred during client reset: '%1'", status.reason()), try_again);
         handle_error(synthetic);
         return;
     }
@@ -865,47 +865,51 @@ void SyncSession::handle_progress_update(uint64_t downloaded, uint64_t downloada
     m_progress_notifier.update(downloaded, downloadable, uploaded, uploadable, download_version, snapshot_version);
 }
 
-static sync::Session::Config::ClientReset make_client_reset_config(RealmConfig session_config, DBRef&& fresh_copy,
-                                                                   bool recovery_is_allowed)
+static sync::Session::Config::ClientReset make_client_reset_config(const RealmConfig& base_config,
+                                                                   const std::shared_ptr<SyncConfig>& sync_config,
+                                                                   DBRef&& fresh_copy, bool recovery_is_allowed)
 {
-    REALM_ASSERT(session_config.sync_config->client_resync_mode != ClientResyncMode::Manual);
+    REALM_ASSERT(sync_config->client_resync_mode != ClientResyncMode::Manual);
 
     sync::Session::Config::ClientReset config;
-    config.mode = session_config.sync_config->client_resync_mode;
+    config.mode = sync_config->client_resync_mode;
     config.fresh_copy = std::move(fresh_copy);
     config.recovery_is_allowed = recovery_is_allowed;
 
-    session_config.sync_config = std::make_shared<SyncConfig>(*session_config.sync_config); // deep copy
-    session_config.scheduler = nullptr;
-    if (session_config.sync_config->notify_after_client_reset) {
-        config.notify_after_client_reset = [config = session_config](VersionID previous_version, bool did_recover) {
-            auto local_coordinator = RealmCoordinator::get_coordinator(config);
-            REALM_ASSERT(local_coordinator);
-            ThreadSafeReference active_after = local_coordinator->get_unbound_realm();
-            SharedRealm frozen_before = local_coordinator->get_realm(config, previous_version);
+    // The conditions here are asymmetric because if we have *either* a before
+    // or after callback we need to make sure to initialize the local schema
+    // before the client reset happens.
+    if (!sync_config->notify_before_client_reset && !sync_config->notify_after_client_reset)
+        return config;
+
+    RealmConfig realm_config = base_config;
+    realm_config.sync_config = std::make_shared<SyncConfig>(*sync_config); // deep copy
+    realm_config.scheduler = util::Scheduler::make_dummy();
+
+    if (sync_config->notify_after_client_reset) {
+        config.notify_after_client_reset = [realm_config](VersionID previous_version, bool did_recover) {
+            auto coordinator = _impl::RealmCoordinator::get_coordinator(realm_config);
+            ThreadSafeReference active_after = coordinator->get_unbound_realm();
+            SharedRealm frozen_before = coordinator->get_realm(realm_config, previous_version);
             REALM_ASSERT(frozen_before);
             REALM_ASSERT(frozen_before->is_frozen());
-            config.sync_config->notify_after_client_reset(std::move(frozen_before), std::move(active_after),
-                                                          did_recover);
+            realm_config.sync_config->notify_after_client_reset(std::move(frozen_before), std::move(active_after),
+                                                                did_recover);
         };
     }
-    config.notify_before_client_reset = [config = session_config]() -> VersionID {
-        auto coordinator = RealmCoordinator::get_coordinator(config);
+    config.notify_before_client_reset = [config = std::move(realm_config)]() -> VersionID {
         // Opening the Realm live here may make a write if the schema is different
         // than what exists on disk. It is necessary to pass a fully usable Realm
         // to the user here. Note that the schema changes made here will be considered
         // an "offline write" to be recovered if this is recovery mode.
-        auto no_notifier = util::Scheduler::make_dummy();
-        auto realm_updated = coordinator->get_realm(no_notifier);
-        auto frozen = realm_updated->freeze(); // throws
-        REALM_ASSERT_EX(frozen, config.path);
-        REALM_ASSERT(frozen->is_frozen());
-        util::Optional<VersionID> version = frozen->current_transaction_version();
-        REALM_ASSERT(version);
-        if (config.sync_config->notify_before_client_reset) {
-            config.sync_config->notify_before_client_reset(frozen);
+        auto before = Realm::get_shared_realm(config);
+        before->read_group();
+        if (auto& notify_before = config.sync_config->notify_before_client_reset) {
+            notify_before(config.sync_config->freeze_before_reset_realm ? before->freeze() : before);
         }
-        return *version;
+        // Note that if the SDK requested a live Realm this may be a different
+        // version than what we had before calling the callback.
+        return before->read_transaction_version();
     };
 
     return config;
@@ -964,10 +968,8 @@ void SyncSession::create_sync_session()
                                         m_server_requests_action == sync::ProtocolErrorInfo::Action::MigrateToFLX ||
                                         m_server_requests_action == sync::ProtocolErrorInfo::Action::RevertToPBS;
         // Use the original sync config, not the updated one from the migration store
-        RealmConfig client_reset_config = m_config;
-        client_reset_config.sync_config = m_original_sync_config;
-        session_config.client_reset_config =
-            make_client_reset_config(client_reset_config, std::move(m_client_reset_fresh_copy), allowed_to_recover);
+        session_config.client_reset_config = make_client_reset_config(
+            m_config, m_original_sync_config, std::move(m_client_reset_fresh_copy), allowed_to_recover);
         m_server_requests_action = sync::ProtocolErrorInfo::Action::NoAction;
     }
 

--- a/src/realm/sync/config.hpp
+++ b/src/realm/sync/config.hpp
@@ -213,9 +213,12 @@ struct SyncConfig {
     // a client reset in ClientResyncMode::Manual mode
     util::Optional<std::string> recovery_directory;
     ClientResyncMode client_resync_mode = ClientResyncMode::Manual;
-    std::function<void(std::shared_ptr<Realm> before_frozen)> notify_before_client_reset;
-    std::function<void(std::shared_ptr<Realm> before_frozen, ThreadSafeReference after, bool did_recover)>
+    std::function<void(std::shared_ptr<Realm> before)> notify_before_client_reset;
+    std::function<void(std::shared_ptr<Realm> frozen_before, ThreadSafeReference after, bool did_recover)>
         notify_after_client_reset;
+    // If true, the Realm passed as the `before` argument to the before reset
+    // callbacks will be frozen
+    bool freeze_before_reset_realm = true;
 
     // Used by core testing to hook into the sync client when various events occur and maybe inject
     // errors/disconnects deterministically.

--- a/src/realm/sync/noinst/client_impl_base.cpp
+++ b/src/realm/sync/noinst/client_impl_base.cpp
@@ -2287,7 +2287,7 @@ std::error_code Session::receive_ident_message(SaltedFileIdent client_file_ident
         did_client_reset = client_reset_if_needed();
     }
     catch (const std::exception& e) {
-        auto err_msg = util::format("A fatal error occured during client reset: '%1'", e.what());
+        auto err_msg = util::format("A fatal error occurred during client reset: '%1'", e.what());
         logger.error(err_msg.c_str());
         SessionErrorInfo err_info(make_error_code(ClientError::auto_client_reset_failure), err_msg, false);
         suspend(err_info);

--- a/src/realm/sync/noinst/pending_bootstrap_store.hpp
+++ b/src/realm/sync/noinst/pending_bootstrap_store.hpp
@@ -43,7 +43,7 @@ public:
 class PendingBootstrapStore {
 public:
     // Constructs from a DBRef. Constructing is destructive - since pending bootstraps are only valid for the
-    // session they occured in, this will drop/clear all data when the bootstrap store is constructed.
+    // session they occurred in, this will drop/clear all data when the bootstrap store is constructed.
     //
     // Underneath this creates a table which stores each download message's changesets.
     explicit PendingBootstrapStore(DBRef db, util::Logger& logger);

--- a/test/fuzz_tester.hpp
+++ b/test/fuzz_tester.hpp
@@ -960,7 +960,7 @@ void FuzzTester<S>::round(unit_test::TestContext& test_context, std::string path
                 }
                 if (m_trace && identical_initial_schema_creating_transaction) {
                     std::cerr << "// Special handling of identical initial "
-                                 "schema-creating transaction occured\n";
+                                 "schema-creating transaction occurred\n";
                 }
                 continue;
             }

--- a/test/object-store/sync/client_reset.cpp
+++ b/test/object-store/sync/client_reset.cpp
@@ -371,12 +371,12 @@ TEST_CASE("sync: client reset", "[client reset][baas]") {
     local_config.cache = false;
     local_config.automatic_change_notifications = false;
     const std::string fresh_path = realm::_impl::ClientResetOperation::get_fresh_path_for(local_config.path);
-    size_t before_callback_invoctions = 0;
+    size_t before_callback_invocations = 0;
     size_t after_callback_invocations = 0;
     std::mutex mtx;
     local_config.sync_config->notify_before_client_reset = [&](SharedRealm before) {
         std::lock_guard<std::mutex> lock(mtx);
-        ++before_callback_invoctions;
+        ++before_callback_invocations;
         REQUIRE(before);
         REQUIRE(before->is_frozen());
         REQUIRE(before->read_group().get_table("class_object"));
@@ -437,7 +437,7 @@ TEST_CASE("sync: client reset", "[client reset][baas]") {
                 ->on_post_reset([&](SharedRealm realm) {
                     REQUIRE_NOTHROW(advance_and_notify(*realm));
 
-                    CHECK(before_callback_invoctions == 1);
+                    CHECK(before_callback_invocations == 1);
                     CHECK(after_callback_invocations == 1);
                     CHECK(results.size() == 1);
                     CHECK(results.get<Obj>(0).get<Int>("value") == 4);
@@ -490,7 +490,7 @@ TEST_CASE("sync: client reset", "[client reset][baas]") {
                 })
                 ->on_post_reset([&](SharedRealm realm) {
                     REQUIRE_NOTHROW(advance_and_notify(*realm));
-                    CHECK(before_callback_invoctions == 1);
+                    CHECK(before_callback_invocations == 1);
                     CHECK(after_callback_invocations == 1);
                     CHECK(results.size() == 1);
                     CHECK(results.get<Obj>(0).get<Int>("value") == 4);
@@ -527,7 +527,7 @@ TEST_CASE("sync: client reset", "[client reset][baas]") {
                 })
                 ->on_post_reset([&](SharedRealm realm) {
                     REQUIRE_NOTHROW(advance_and_notify(*realm));
-                    CHECK(before_callback_invoctions == 1);
+                    CHECK(before_callback_invocations == 1);
                     CHECK(after_callback_invocations == 1);
                     CHECK(results.size() == 2);
                     CHECK(results.get<Obj>(0).get<Int>("value") == 4);
@@ -688,7 +688,7 @@ TEST_CASE("sync: client reset", "[client reset][baas]") {
             wait_for_upload(*remote);
             wait_for_download(*remote);
             verify_changes(remote);
-            REQUIRE(before_callback_invoctions == 1);
+            REQUIRE(before_callback_invocations == 1);
             REQUIRE(after_callback_invocations == 1);
         }
 
@@ -735,7 +735,7 @@ TEST_CASE("sync: client reset", "[client reset][baas]") {
                 ->run();
             REQUIRE(err);
             REQUIRE(err.value()->is_client_reset_requested());
-            REQUIRE(before_callback_invoctions == 1);
+            REQUIRE(before_callback_invocations == 1);
             REQUIRE(after_callback_invocations == 0);
         }
     } // end recovery section
@@ -755,7 +755,7 @@ TEST_CASE("sync: client reset", "[client reset][baas]") {
                 ->on_post_reset([&](SharedRealm realm) {
                     REQUIRE_NOTHROW(advance_and_notify(*realm));
 
-                    CHECK(before_callback_invoctions == 1);
+                    CHECK(before_callback_invocations == 1);
                     CHECK(after_callback_invocations == 1);
                     CHECK(results.size() == 1);
                     CHECK(results.get<Obj>(0).get<Int>("value") == 6);
@@ -808,7 +808,7 @@ TEST_CASE("sync: client reset", "[client reset][baas]") {
                     })
                     ->on_post_reset([&](SharedRealm) {
                         REQUIRE_NOTHROW(advance_and_notify(*object.get_realm()));
-                        CHECK(before_callback_invoctions == 2);
+                        CHECK(before_callback_invocations == 2);
                         CHECK(after_callback_invocations == 2);
                         // 4 -> 6
                         CHECK(results.size() == 1);
@@ -829,7 +829,7 @@ TEST_CASE("sync: client reset", "[client reset][baas]") {
             local_config.sync_config->notify_before_client_reset = nullptr;
             local_config.sync_config->notify_after_client_reset = nullptr;
             make_reset(local_config, remote_config)->run();
-            REQUIRE(before_callback_invoctions == 0);
+            REQUIRE(before_callback_invocations == 0);
             REQUIRE(after_callback_invocations == 0);
         }
 
@@ -845,7 +845,7 @@ TEST_CASE("sync: client reset", "[client reset][baas]") {
                 ->run();
             auto local_coordinator = realm::_impl::RealmCoordinator::get_existing_coordinator(local_config.path);
             REQUIRE(!local_coordinator);
-            REQUIRE(before_callback_invoctions == 0);
+            REQUIRE(before_callback_invocations == 0);
             REQUIRE(after_callback_invocations == 0);
             timed_sleeping_wait_for(
                 [&]() -> bool {
@@ -854,13 +854,13 @@ TEST_CASE("sync: client reset", "[client reset][baas]") {
                 },
                 std::chrono::seconds(60));
             // this test also relies on the test config above to verify the Realm instances in the callbacks
-            REQUIRE(before_callback_invoctions == 1);
+            REQUIRE(before_callback_invocations == 1);
             REQUIRE(after_callback_invocations == 1);
         }
 
         SECTION("notifiers work if the session instance changes") {
             // run this test with ASAN to check for use after free
-            size_t before_callback_invoctions_2 = 0;
+            size_t before_callback_invocations_2 = 0;
             size_t after_callback_invocations_2 = 0;
             std::shared_ptr<SyncSession> session;
             std::unique_ptr<SyncConfig> config_copy;
@@ -873,7 +873,7 @@ TEST_CASE("sync: client reset", "[client reset][baas]") {
                     std::lock_guard<std::mutex> lock(mtx);
                     REQUIRE(before_realm);
                     REQUIRE(before_realm->schema_version() != ObjectStore::NotVersioned);
-                    ++before_callback_invoctions_2;
+                    ++before_callback_invocations_2;
                 };
                 config_copy->notify_after_client_reset = [&](SharedRealm, ThreadSafeReference, bool) {
                     std::lock_guard<std::mutex> lock(mtx);
@@ -882,7 +882,7 @@ TEST_CASE("sync: client reset", "[client reset][baas]") {
 
                 temp_config.sync_config->notify_before_client_reset = [&](SharedRealm before_realm) {
                     std::lock_guard<std::mutex> lock(mtx);
-                    ++before_callback_invoctions;
+                    ++before_callback_invocations;
                     REQUIRE(session);
                     REQUIRE(config_copy);
                     REQUIRE(before_realm);
@@ -905,13 +905,13 @@ TEST_CASE("sync: client reset", "[client reset][baas]") {
             timed_sleeping_wait_for(
                 [&]() -> bool {
                     std::lock_guard<std::mutex> lock(mtx);
-                    return before_callback_invoctions > 0;
+                    return before_callback_invocations > 0;
                 },
                 std::chrono::seconds(120));
             millisleep(500); // just make some space for the after callback to be attempted
-            REQUIRE(before_callback_invoctions == 1);
+            REQUIRE(before_callback_invocations == 1);
             REQUIRE(after_callback_invocations == 0);
-            REQUIRE(before_callback_invoctions_2 == 0);
+            REQUIRE(before_callback_invocations_2 == 0);
             REQUIRE(after_callback_invocations_2 == 0);
         }
 
@@ -927,7 +927,7 @@ TEST_CASE("sync: client reset", "[client reset][baas]") {
                     ->run();
             }
             catch (const SessionInterruption&) {
-                REQUIRE(before_callback_invoctions == 0);
+                REQUIRE(before_callback_invocations == 0);
                 REQUIRE(after_callback_invocations == 0);
                 test_reset.reset();
                 auto realm = Realm::get_shared_realm(local_config);
@@ -951,7 +951,7 @@ TEST_CASE("sync: client reset", "[client reset][baas]") {
             }
             {
                 std::lock_guard<std::mutex> lock(mtx);
-                REQUIRE(before_callback_invoctions == 1);
+                REQUIRE(before_callback_invocations == 1);
                 REQUIRE(after_callback_invocations == 1);
             }
         }
@@ -985,7 +985,7 @@ TEST_CASE("sync: client reset", "[client reset][baas]") {
 
             {
                 std::lock_guard<std::mutex> lock(mtx);
-                REQUIRE(before_callback_invoctions == 1);
+                REQUIRE(before_callback_invocations == 1);
                 REQUIRE(after_callback_invocations == 1);
             }
         }
@@ -1003,7 +1003,7 @@ TEST_CASE("sync: client reset", "[client reset][baas]") {
 
             make_reset(local_config, remote_config)->run();
             REQUIRE(!err);
-            REQUIRE(before_callback_invoctions == 1);
+            REQUIRE(before_callback_invocations == 1);
             REQUIRE(after_callback_invocations == 1);
         }
 
@@ -1201,7 +1201,7 @@ TEST_CASE("sync: client reset", "[client reset][baas]") {
                 ->run();
             REQUIRE(err);
             REQUIRE(err.value()->is_client_reset_requested());
-            REQUIRE(before_callback_invoctions == 1);
+            REQUIRE(before_callback_invocations == 1);
             REQUIRE(after_callback_invocations == 0);
         }
 
@@ -1237,7 +1237,7 @@ TEST_CASE("sync: client reset", "[client reset][baas]") {
 
             REQUIRE(err);
             REQUIRE(err.value()->is_client_reset_requested());
-            REQUIRE(before_callback_invoctions == 1);
+            REQUIRE(before_callback_invocations == 1);
             REQUIRE(after_callback_invocations == 0);
         }
 
@@ -1594,7 +1594,7 @@ TEST_CASE("sync: client reset", "[client reset][baas]") {
                 auto flag = has_reset_cycle_flag(realm);
                 REQUIRE(!flag);
                 std::lock_guard<std::mutex> lock(mtx);
-                ++before_callback_invoctions;
+                ++before_callback_invocations;
             };
             local_config.sync_config->notify_after_client_reset = [&](SharedRealm, ThreadSafeReference realm_ref,
                                                                       bool did_recover) {
@@ -1613,7 +1613,7 @@ TEST_CASE("sync: client reset", "[client reset][baas]") {
                 })
                 ->run();
             REQUIRE(!err);
-            REQUIRE(before_callback_invoctions == 1);
+            REQUIRE(before_callback_invocations == 1);
             REQUIRE(after_callback_invocations == 1);
         }
         SECTION("In DiscardLocal mode: a previous failed discard reset is detected and generates an error") {
@@ -2219,7 +2219,7 @@ TEMPLATE_TEST_CASE("client reset types", "[client reset][local]", cf::MixedVal, 
                             expected_state[it.first] = it.second;
                         }
                         if (local_state.find(dict_key) == local_state.end()) {
-                            expected_state.erase(dict_key); // explict erasure of initial state occured
+                            expected_state.erase(dict_key); // explict erasure of initial state occurred
                         }
                     }
                     check_dictionary(results.get<Obj>(0), expected_state);
@@ -2331,7 +2331,7 @@ TEMPLATE_TEST_CASE("client reset types", "[client reset][local]", cf::MixedVal, 
                             expected.insert(e);
                         }
                         if (do_erase_initial) {
-                            expected.erase(Mixed{values[0]}); // explicit erase of initial element occured
+                            expected.erase(Mixed{values[0]}); // explicit erase of initial element occurred
                         }
                     }
                     check_set(results.get<Obj>(0), expected);

--- a/test/object-store/sync/flx_sync.cpp
+++ b/test/object-store/sync/flx_sync.cpp
@@ -660,7 +660,7 @@ TEST_CASE("flx: client reset", "[sync][flx][app][baas][client reset]") {
         // The local changes here are a bit contrived because removing a column is disallowed
         // at the object store layer for sync'd Realms. The only reason a recovery should fail in production
         // during the apply stage is due to programmer error or external factors such as out of disk space.
-        // Any schema discrepencies are caught by the initial diff, so the way to make a recovery fail here is
+        // Any schema discrepancies are caught by the initial diff, so the way to make a recovery fail here is
         // to add and remove a column at the core level such that the schema diff passes, but instructions are
         // generated which will fail when applied.
         reset_utils::TestClientReset::Callback make_local_changes_that_will_fail = [&](SharedRealm local_realm) {
@@ -917,49 +917,51 @@ TEST_CASE("flx: client reset", "[sync][flx][app][baas][client reset]") {
     };
 
     auto setup_reset_handlers_for_schema_validation =
-        [&before_reset_count,
-         &after_reset_count](RealmConfig& config, Schema expected_schema,
-                             std::shared_ptr<util::future_details::Promise<void>> shared_promise) {
-            config.sync_config->error_handler = [](std::shared_ptr<SyncSession>, SyncError err) {
+        [&before_reset_count, &after_reset_count](RealmConfig& config, Schema expected_schema) {
+            auto& sync_config = *config.sync_config;
+            sync_config.error_handler = [](std::shared_ptr<SyncSession>, SyncError err) {
                 FAIL(err);
             };
-            config.sync_config->notify_before_client_reset = [&before_reset_count,
-                                                              expected = expected_schema](SharedRealm frozen_before) {
+            sync_config.notify_before_client_reset = [&before_reset_count,
+                                                      expected = expected_schema](SharedRealm frozen_before) {
                 ++before_reset_count;
                 REQUIRE(frozen_before->schema().size() > 0);
                 REQUIRE(frozen_before->schema_version() != ObjectStore::NotVersioned);
                 REQUIRE(frozen_before->schema() == expected);
             };
-            config.sync_config->notify_after_client_reset = [&after_reset_count, promise = std::move(shared_promise),
-                                                             expected = expected_schema,
-                                                             reset_mode = config.sync_config->client_resync_mode](
-                                                                SharedRealm frozen_before,
-                                                                ThreadSafeReference after_ref, bool did_recover) {
-                ++after_reset_count;
-                REQUIRE(frozen_before->schema().size() > 0);
-                REQUIRE(frozen_before->schema_version() != ObjectStore::NotVersioned);
-                REQUIRE(frozen_before->schema() == expected);
-                SharedRealm after = Realm::get_shared_realm(std::move(after_ref), util::Scheduler::make_default());
-                REQUIRE(after);
-                REQUIRE(after->schema() == expected);
-                // the above check is sufficent unless operator==() is changed to not care about ordering
-                // so future proof that by explicitly checking the order of properties here as well
-                REQUIRE(after->schema().size() == frozen_before->schema().size());
-                auto after_it = after->schema().find("TopLevel");
-                auto before_it = frozen_before->schema().find("TopLevel");
-                REQUIRE(after_it != after->schema().end());
-                REQUIRE(before_it != frozen_before->schema().end());
-                REQUIRE(after_it->name == before_it->name);
-                REQUIRE(after_it->persisted_properties.size() == before_it->persisted_properties.size());
-                REQUIRE(after_it->persisted_properties[1].name == "queryable_int_field");
-                REQUIRE(after_it->persisted_properties[2].name == "queryable_str_field");
-                REQUIRE(before_it->persisted_properties[1].name == "queryable_int_field");
-                REQUIRE(before_it->persisted_properties[2].name == "queryable_str_field");
-                REQUIRE(did_recover == (reset_mode == ClientResyncMode::Recover));
-                if (promise) {
-                    promise->emplace_value();
-                }
-            };
+
+            auto [promise, future] = util::make_promise_future<void>();
+            sync_config.notify_after_client_reset =
+                [&after_reset_count, promise = util::CopyablePromiseHolder<void>(std::move(promise)), expected_schema,
+                 reset_mode = config.sync_config->client_resync_mode, has_schema = config.schema.has_value()](
+                    SharedRealm frozen_before, ThreadSafeReference after_ref, bool did_recover) mutable {
+                    ++after_reset_count;
+                    REQUIRE(frozen_before->schema().size() > 0);
+                    REQUIRE(frozen_before->schema_version() != ObjectStore::NotVersioned);
+                    REQUIRE(frozen_before->schema() == expected_schema);
+                    SharedRealm after = Realm::get_shared_realm(std::move(after_ref), util::Scheduler::make_dummy());
+                    if (!has_schema) {
+                        after->set_schema_subset(expected_schema);
+                    }
+                    REQUIRE(after);
+                    REQUIRE(after->schema() == expected_schema);
+                    // the above check is sufficient unless operator==() is changed to not care about ordering
+                    // so future proof that by explicitly checking the order of properties here as well
+                    REQUIRE(after->schema().size() == frozen_before->schema().size());
+                    auto after_it = after->schema().find("TopLevel");
+                    auto before_it = frozen_before->schema().find("TopLevel");
+                    REQUIRE(after_it != after->schema().end());
+                    REQUIRE(before_it != frozen_before->schema().end());
+                    REQUIRE(after_it->name == before_it->name);
+                    REQUIRE(after_it->persisted_properties.size() == before_it->persisted_properties.size());
+                    REQUIRE(after_it->persisted_properties[1].name == "queryable_int_field");
+                    REQUIRE(after_it->persisted_properties[2].name == "queryable_str_field");
+                    REQUIRE(before_it->persisted_properties[1].name == "queryable_int_field");
+                    REQUIRE(before_it->persisted_properties[2].name == "queryable_str_field");
+                    REQUIRE(did_recover == (reset_mode == ClientResyncMode::Recover));
+                    promise.get_promise().emplace_value();
+                };
+            return std::move(future); // move is not redundant here because of how destructing works
         };
 
     SECTION("Recover: schema indexes match in before and after states") {
@@ -971,9 +973,7 @@ TEST_CASE("flx: client reset", "[sync][flx][app][baas][client reset]") {
             {"queryable_oid_field", PropertyType::ObjectId | PropertyType::Nullable});
         config_local.schema = local_schema;
         config_local.sync_config->client_resync_mode = ClientResyncMode::Recover;
-        auto [promise, future] = util::make_promise_future<void>();
-        auto shared_promise = std::make_shared<decltype(promise)>(std::move(promise));
-        setup_reset_handlers_for_schema_validation(config_local, local_schema, shared_promise);
+        auto future = setup_reset_handlers_for_schema_validation(config_local, local_schema);
         SharedRealm realm = Realm::get_shared_realm(config_local);
         future.get();
         CHECK(before_reset_count == 1);
@@ -983,31 +983,67 @@ TEST_CASE("flx: client reset", "[sync][flx][app][baas][client reset]") {
     SECTION("Adding a local property matching a server addition is allowed") {
         auto mode = GENERATE(ClientResyncMode::DiscardLocal, ClientResyncMode::Recover);
         config_local.sync_config->client_resync_mode = mode;
-        SECTION(util::format("In %1 mode", mode)) {
-            seed_realm(config_local, ResetMode::InitiateClientReset);
-            std::vector<ObjectSchema> changed_schema = schema;
-            changed_schema[0].persisted_properties.push_back(
-                {"queryable_oid_field", PropertyType::ObjectId | PropertyType::Nullable});
-            // In a separate Realm, make the property addition.
-            // Since this is dev mode, it will be added to the server's schema.
-            config_remote.schema = changed_schema;
-            seed_realm(config_remote, ResetMode::NoReset);
-            std::swap(changed_schema[0].persisted_properties[1], changed_schema[0].persisted_properties[2]);
-            config_local.schema = changed_schema;
-            auto [promise, future] = util::make_promise_future<void>();
-            auto shared_promise = std::make_shared<decltype(promise)>(std::move(promise));
-            setup_reset_handlers_for_schema_validation(config_local, changed_schema, shared_promise);
+        seed_realm(config_local, ResetMode::InitiateClientReset);
+        std::vector<ObjectSchema> changed_schema = schema;
+        changed_schema[0].persisted_properties.push_back(
+            {"queryable_oid_field", PropertyType::ObjectId | PropertyType::Nullable});
+        // In a separate Realm, make the property addition.
+        // Since this is dev mode, it will be added to the server's schema.
+        config_remote.schema = changed_schema;
+        seed_realm(config_remote, ResetMode::NoReset);
+        std::swap(changed_schema[0].persisted_properties[1], changed_schema[0].persisted_properties[2]);
+        config_local.schema = changed_schema;
+        auto future = setup_reset_handlers_for_schema_validation(config_local, changed_schema);
 
-            async_open_realm(config_local,
-                             [&, fut = std::move(future)](ThreadSafeReference&& ref, std::exception_ptr error) {
-                                 REQUIRE(ref);
-                                 REQUIRE_FALSE(error);
-                                 auto realm = Realm::get_shared_realm(std::move(ref));
-                                 fut.get();
-                                 CHECK(before_reset_count == 1);
-                                 CHECK(after_reset_count == 1);
-                             });
-        }
+        async_open_realm(config_local,
+                         [&, fut = std::move(future)](ThreadSafeReference&& ref, std::exception_ptr error) {
+                             REQUIRE(ref);
+                             REQUIRE_FALSE(error);
+                             auto realm = Realm::get_shared_realm(std::move(ref));
+                             fut.get();
+                             CHECK(before_reset_count == 1);
+                             CHECK(after_reset_count == 1);
+                         });
+    }
+
+    SECTION("Adding a local property matching a server addition inside the before reset callback is allowed") {
+        auto mode = GENERATE(ClientResyncMode::DiscardLocal, ClientResyncMode::Recover);
+        config_local.sync_config->client_resync_mode = mode;
+        seed_realm(config_local, ResetMode::InitiateClientReset);
+        std::vector<ObjectSchema> changed_schema = schema;
+        changed_schema[0].persisted_properties.push_back(
+            {"queryable_oid_field", PropertyType::ObjectId | PropertyType::Nullable});
+        // In a separate Realm, make the property addition.
+        // Since this is dev mode, it will be added to the server's schema.
+        config_remote.schema = changed_schema;
+        seed_realm(config_remote, ResetMode::NoReset);
+        std::swap(changed_schema[0].persisted_properties[1], changed_schema[0].persisted_properties[2]);
+        config_local.schema.reset();
+        config_local.sync_config->freeze_before_reset_realm = false;
+        auto future = setup_reset_handlers_for_schema_validation(config_local, changed_schema);
+
+        auto notify_before = std::move(config_local.sync_config->notify_before_client_reset);
+        config_local.sync_config->notify_before_client_reset = [=](std::shared_ptr<Realm> realm) {
+            realm->update_schema(changed_schema);
+            notify_before(realm);
+        };
+
+        auto notify_after = std::move(config_local.sync_config->notify_after_client_reset);
+        config_local.sync_config->notify_after_client_reset = [=](std::shared_ptr<Realm> before,
+                                                                  ThreadSafeReference after, bool did_recover) {
+            before->set_schema_subset(changed_schema);
+            notify_after(before, std::move(after), did_recover);
+        };
+
+        async_open_realm(config_local,
+                         [&, fut = std::move(future)](ThreadSafeReference&& ref, std::exception_ptr error) {
+                             REQUIRE(ref);
+                             REQUIRE_FALSE(error);
+                             auto realm = Realm::get_shared_realm(std::move(ref));
+                             fut.get();
+                             CHECK(before_reset_count == 1);
+                             CHECK(after_reset_count == 1);
+                         });
     }
 
     auto make_additive_changes = [](std::vector<ObjectSchema> schema) {
@@ -1026,9 +1062,7 @@ TEST_CASE("flx: client reset", "[sync][flx][app][baas][client reset]") {
         std::vector<ObjectSchema> changed_schema = make_additive_changes(schema);
         config_local.schema = changed_schema;
         config_local.sync_config->client_resync_mode = ClientResyncMode::Recover;
-        auto [promise, future] = util::make_promise_future<void>();
-        auto shared_promise = std::make_shared<decltype(promise)>(std::move(promise));
-        setup_reset_handlers_for_schema_validation(config_local, changed_schema, shared_promise);
+        auto future = setup_reset_handlers_for_schema_validation(config_local, changed_schema);
         async_open_realm(config_local, [&](ThreadSafeReference&& ref, std::exception_ptr error) {
             REQUIRE(ref);
             REQUIRE_FALSE(error);
@@ -1076,7 +1110,7 @@ TEST_CASE("flx: client reset", "[sync][flx][app][baas][client reset]") {
             REQUIRE(!ref);
             REQUIRE(error);
             REQUIRE_THROWS_CONTAINING(std::rethrow_exception(error),
-                                      "A fatal error occured during client reset: 'Client reset cannot recover when "
+                                      "A fatal error occurred during client reset: 'Client reset cannot recover when "
                                       "classes have been removed: {AddedClass}'");
         });
         error_future.get();
@@ -1096,7 +1130,7 @@ TEST_CASE("flx: client reset", "[sync][flx][app][baas][client reset]") {
             REQUIRE(!ref);
             REQUIRE(error);
             REQUIRE_THROWS_CONTAINING(std::rethrow_exception(error),
-                                      "A fatal error occured during client reset: 'The following changes cannot be "
+                                      "A fatal error occurred during client reset: 'The following changes cannot be "
                                       "made in additive-only schema mode:\n"
                                       "- Property 'TopLevel._id' has been changed from 'object id' to 'uuid'.'");
         });
@@ -1115,7 +1149,7 @@ TEST_CASE("flx: client reset", "[sync][flx][app][baas][client reset]") {
             std::vector<ObjectSchema> changed_schema = make_additive_changes(schema);
             config_local.schema = changed_schema;
             config_local.sync_config->client_resync_mode = ClientResyncMode::Recover;
-            setup_reset_handlers_for_schema_validation(config_local, changed_schema, nullptr);
+            (void)setup_reset_handlers_for_schema_validation(config_local, changed_schema);
             auto&& [error_future, err_handler] = make_error_handler();
             config_local.sync_config->error_handler = err_handler;
             async_open_realm(config_local, [&](ThreadSafeReference&& ref, std::exception_ptr error) {
@@ -1146,6 +1180,7 @@ TEST_CASE("flx: client reset", "[sync][flx][app][baas][client reset]") {
             CHECK(after_reset_count == 1);
         }
     }
+
     // the previous section turns off dev mode, undo that now for later tests
     const AppSession& app_session = harness.session().app_session();
     app_session.admin_api.set_development_mode_to(app_session.server_app_id, true);

--- a/test/test_query2.cpp
+++ b/test/test_query2.cpp
@@ -1341,7 +1341,7 @@ TEST(Query_DeepCopyTest)
 
 TEST(Query_StringIndexCrash)
 {
-    // Test for a crash which occured when a query testing for equality on a
+    // Test for a crash which occurred when a query testing for equality on a
     // string index was deep-copied after being run
     Table table;
     auto col = table.add_column(type_String, "s", true);


### PR DESCRIPTION
For complicated performance reasons, Cocoa doesn't pass the schema in the RealmConfig and instead calls update_schema() later. This means that when a client reset happens during an async open, the object store code doesn't have access to the actual schema yet, and the write to update the schema needs to happen in the SDK code.