### PR TITLE
Port upload/download completion API to Status

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,7 +17,7 @@
 -----------
 
 ### Internals
-* None.
+* `wait_for_upload_completion`/`wait_for_download_completion` internal API was changed to use `Status`'s instead of `std::error_code`. The SDK-facing was already `Status` oriented, so this change should only result in better error messages. ([PR #6796](https://github.com/realm/realm-core/pull/6796))
 
 ----------------------------------------------
 

--- a/src/realm/sync/client.cpp
+++ b/src/realm/sync/client.cpp
@@ -1474,7 +1474,7 @@ void SessionWrapper::async_wait_for(bool upload_completion, bool download_comple
         REALM_ASSERT(self->m_actualized);
         if (REALM_UNLIKELY(!self->m_sess)) {
             // Already finalized
-            handler(util::error::operation_aborted); // Throws
+            handler({ErrorCodes::OperationAborted, "Session finalized before callback could run"}); // Throws
             return;
         }
         if (upload_completion) {
@@ -1732,20 +1732,19 @@ void SessionWrapper::finalize()
     while (!m_upload_completion_handlers.empty()) {
         auto handler = std::move(m_upload_completion_handlers.back());
         m_upload_completion_handlers.pop_back();
-        std::error_code ec = error::operation_aborted;
-        handler(ec); // Throws
+        handler(
+            {ErrorCodes::OperationAborted, "Sync session is being finalized before upload was complete"}); // Throws
     }
     while (!m_download_completion_handlers.empty()) {
         auto handler = std::move(m_download_completion_handlers.back());
         m_download_completion_handlers.pop_back();
-        std::error_code ec = error::operation_aborted;
-        handler(ec); // Throws
+        handler(
+            {ErrorCodes::OperationAborted, "Sync session is being finalized before download was complete"}); // Throws
     }
     while (!m_sync_completion_handlers.empty()) {
         auto handler = std::move(m_sync_completion_handlers.back());
         m_sync_completion_handlers.pop_back();
-        std::error_code ec = error::operation_aborted;
-        handler(ec); // Throws
+        handler({ErrorCodes::OperationAborted, "Sync session is being finalized before sync was complete"}); // Throws
     }
 }
 
@@ -1783,8 +1782,7 @@ void SessionWrapper::on_upload_completion()
     while (!m_upload_completion_handlers.empty()) {
         auto handler = std::move(m_upload_completion_handlers.back());
         m_upload_completion_handlers.pop_back();
-        std::error_code ec; // Success
-        handler(ec);        // Throws
+        handler(Status::OK()); // Throws
     }
     while (!m_sync_completion_handlers.empty()) {
         auto handler = std::move(m_sync_completion_handlers.back());
@@ -1804,8 +1802,7 @@ void SessionWrapper::on_download_completion()
     while (!m_download_completion_handlers.empty()) {
         auto handler = std::move(m_download_completion_handlers.back());
         m_download_completion_handlers.pop_back();
-        std::error_code ec; // Success
-        handler(ec);        // Throws
+        handler(Status::OK()); // Throws
     }
     while (!m_sync_completion_handlers.empty()) {
         auto handler = std::move(m_sync_completion_handlers.back());
@@ -1921,13 +1918,13 @@ void SessionWrapper::handle_pending_client_reset_acknowledgement()
     m_sess->logger.info("Tracking pending client reset of type \"%1\" from %2", pending_reset->type,
                         pending_reset->time);
     util::bind_ptr<SessionWrapper> self(this);
-    async_wait_for(true, true, [self = std::move(self), pending_reset = *pending_reset](std::error_code ec) {
-        if (ec == util::error::operation_aborted) {
+    async_wait_for(true, true, [self = std::move(self), pending_reset = *pending_reset](Status status) {
+        if (status == ErrorCodes::OperationAborted) {
             return;
         }
         auto& logger = self->m_sess->logger;
-        if (ec) {
-            logger.error("Error while tracking client reset acknowledgement: %1", ec.message());
+        if (!status.is_ok()) {
+            logger.error("Error while tracking client reset acknowledgement: %1", status);
             return;
         }
 

--- a/src/realm/sync/client.hpp
+++ b/src/realm/sync/client.hpp
@@ -177,7 +177,7 @@ public:
     using ProgressHandler = void(std::uint_fast64_t downloaded_bytes, std::uint_fast64_t downloadable_bytes,
                                  std::uint_fast64_t uploaded_bytes, std::uint_fast64_t uploadable_bytes,
                                  std::uint_fast64_t progress_version, std::uint_fast64_t snapshot_version);
-    using WaitOperCompletionHandler = util::UniqueFunction<void(std::error_code)>;
+    using WaitOperCompletionHandler = util::UniqueFunction<void(Status)>;
     using SSLVerifyCallback = bool(const std::string& server_address, port_type server_port, const char* pem_data,
                                    size_t pem_size, int preverify_ok, int depth);
 
@@ -661,10 +661,10 @@ public:
     /// If incomplete wait operations exist when the session is terminated,
     /// those wait operations will be canceled. Session termination is an event
     /// that happens in the context of the client's event loop thread shortly
-    /// after the destruction of the session object. The std::error_code
+    /// after the destruction of the session object. The Status
     /// argument passed to the completion handler of a canceled wait operation
-    /// will be `util::error::operation_aborted`. For uncanceled wait operations
-    /// it will be `std::error_code{}`. Note that as long as the client's event
+    /// will be `ErrorCodes::OperationAborted`. For uncanceled wait operations
+    /// it will be `Status::OK()`. Note that as long as the client's event
     /// loop thread is running, all completion handlers will be called
     /// regardless of whether the operations get canceled or not.
     ///

--- a/test/test_sync.cpp
+++ b/test/test_sync.cpp
@@ -185,8 +185,8 @@ TEST(Sync_AsyncWaitForUploadCompletion)
 
     auto wait = [&] {
         BowlOfStonesSemaphore bowl;
-        auto handler = [&](std::error_code ec) {
-            if (CHECK_NOT(ec))
+        auto handler = [&](Status status) {
+            if (CHECK(status.is_ok()))
                 bowl.add_stone();
         };
         session.async_wait_for_upload_completion(handler);
@@ -228,8 +228,8 @@ TEST(Sync_AsyncWaitForUploadCompletionNoPendingLocalChanges)
 
     auto pf = util::make_promise_future<bool>();
     session.async_wait_for_upload_completion(
-        [promise = std::move(pf.promise), tr = db->start_read()](std::error_code ec) mutable {
-            REALM_ASSERT(!ec);
+        [promise = std::move(pf.promise), tr = db->start_read()](Status status) mutable {
+            REALM_ASSERT(status.is_ok());
             tr->advance_read();
             promise.emplace_value(tr->get_history()->no_pending_local_changes(tr->get_version()));
         });
@@ -247,8 +247,8 @@ TEST(Sync_AsyncWaitForDownloadCompletion)
 
     auto wait = [&](Session& session) {
         BowlOfStonesSemaphore bowl;
-        auto handler = [&](std::error_code ec) {
-            if (CHECK_NOT(ec))
+        auto handler = [&](Status status) {
+            if (CHECK(status.is_ok()))
                 bowl.add_stone();
         };
         session.async_wait_for_download_completion(handler);
@@ -309,8 +309,8 @@ TEST(Sync_AsyncWaitForSyncCompletion)
 
     auto wait = [&](Session& session) {
         BowlOfStonesSemaphore bowl;
-        auto handler = [&](std::error_code ec) {
-            if (CHECK_NOT(ec))
+        auto handler = [&](Status status) {
+            if (CHECK(status.is_ok()))
                 bowl.add_stone();
         };
         session.async_wait_for_sync_completion(handler);
@@ -355,23 +355,15 @@ TEST(Sync_AsyncWaitCancellation)
     ClientServerFixture fixture(dir, test_context);
 
     BowlOfStonesSemaphore bowl;
-    auto upload_completion_handler = [&](std::error_code ec) {
-        CHECK_EQUAL(util::error::operation_aborted, ec);
-        bowl.add_stone();
-    };
-    auto download_completion_handler = [&](std::error_code ec) {
-        CHECK_EQUAL(util::error::operation_aborted, ec);
-        bowl.add_stone();
-    };
-    auto sync_completion_handler = [&](std::error_code ec) {
-        CHECK_EQUAL(util::error::operation_aborted, ec);
+    auto completion_handler = [&](Status status) {
+        CHECK_EQUAL(status, ErrorCodes::OperationAborted);
         bowl.add_stone();
     };
     {
         Session session = fixture.make_bound_session(db, "/test");
-        session.async_wait_for_upload_completion(upload_completion_handler);
-        session.async_wait_for_download_completion(download_completion_handler);
-        session.async_wait_for_sync_completion(sync_completion_handler);
+        session.async_wait_for_upload_completion(completion_handler);
+        session.async_wait_for_download_completion(completion_handler);
+        session.async_wait_for_sync_completion(completion_handler);
         // Destruction of session cancels wait operations
     }
     fixture.start();
@@ -552,7 +544,7 @@ TEST(Sync_WaitForSessionTerminations)
     // Note: Atomicity would not be needed if
     // Session::async_wait_for_download_completion() was assumed to work.
     std::atomic<bool> called{false};
-    auto handler = [&](std::error_code) {
+    auto handler = [&](Status) {
         called = true;
     };
     session.async_wait_for_download_completion(std::move(handler));


### PR DESCRIPTION
## What, How & Why?
This changes the upload/download completion API on `sync::Session` to use Status instead of std::error_code. The SDK-facing API had already been ported to use Status so this change should only result in better error messages and no user-facing changes.

## ☑️ ToDos
* [x] 📝 Changelog update
* [x] 🚦 Tests (or not relevant)
* [ ] C-API, if public C++ API changed.
