### PR TITLE
Separate local and baas object store tests into separate evergreen tasks and allow custom test specification

### DIFF
--- a/evergreen/config.yml
+++ b/evergreen/config.yml
@@ -195,7 +195,9 @@ functions:
               export DEVELOPER_DIR="${xcode_developer_dir}"
           fi
 
-          if [[ -n "${test_filter}" ]]; then
+          if [[ -n "${test_label}" ]]; then
+              TEST_FLAGS="-L ${test_label}"
+          elif [[ -n "${test_filter}" ]]; then
               TEST_FLAGS="-R ${test_filter}"
           fi
 
@@ -218,19 +220,25 @@ functions:
               [[ -d coverage_data ]] || mkdir coverage_data
               [[ -d coverage_binaries ]] || mkdir coverage_binaries
               export LLVM_PROFILE_FILE="$(pwd)/coverage_data/${task_name}-%p.profraw"
-              EXECUTABLE_PATH=$(find build -name ${test_executable_name} -type f)
-              EXECUTABLE_PATH=$(./evergreen/abspath.sh $EXECUTABLE_PATH)
+              EXECUTABLE_FILE="$(find build -name "${test_executable_name}" -type f)"
+              EXECUTABLE_PATH="$(./evergreen/abspath.sh "$EXECUTABLE_FILE")"
               if [[ -z "$EXECUTABLE_PATH" || ! -f "$EXECUTABLE_PATH" ]]; then
                 echo "Invalid executable path $EXECUTABLE_PATH"
                 exit 1
               fi
-              ln -s $EXECUTABLE_PATH coverage_binaries/${test_executable_name}
+              # The sym link may have been created by a previous task run
+              if [[ ! -f "coverage_binaries/${test_executable_name}" ]]; then
+                ln -s "$EXECUTABLE_PATH" "coverage_binaries/${test_executable_name}"
+              fi
           fi
 
           export UNITTEST_EVERGREEN_TEST_RESULTS="$(./evergreen/abspath.sh ${task_name}_results.json)"
+          if [[ -n "$UNITTEST_EVERGREEN_TEST_RESULTS" && -f "$UNITTEST_EVERGREEN_TEST_RESULTS" ]]; then
+              rm "$UNITTEST_EVERGREEN_TEST_RESULTS"
+          fi
           export UNITTEST_PROGRESS=1
           if [[ -n "${report_test_progress|}" ]]; then
-              export UNITTEST_PROGRESS=${report_test_progress|}
+              export UNITTEST_PROGRESS="${report_test_progress|}"
           fi
 
           if [[ -n "${run_with_encryption}" ]]; then
@@ -819,6 +827,19 @@ tasks:
       test_filter: SyncTests
       test_executable_name: "realm-sync-tests"
 
+- name: object-store-tests-local
+  tags: [ "test_suite_local_baas", "test_suite_remote_baas", "for_pull_requests" ]
+  exec_timeout_secs: 3600
+  commands:
+  - func: "compile"
+    vars:
+      target_to_build: ObjectStoreTests
+  - func: "run tests"
+    vars:
+      test_label: objstore-local
+      test_executable_name: "realm-object-store-tests"
+      verbose_test_output: true
+
 - name: object-store-tests-local-baas
   tags: [ "test_suite_local_baas", "for_pull_requests" ]
   exec_timeout_secs: 3600
@@ -832,12 +853,12 @@ tasks:
   - func: "wait for baas to start"
   - func: "run tests"
     vars:
-      test_filter: ObjectStoreTests
+      test_label: objstore-baas
       test_executable_name: "realm-object-store-tests"
       verbose_test_output: true
 
 # Default object store tests will use a remote host for baas
-- name: object-store-tests
+- name: object-store-tests-baas
   tags: [ "test_suite_remote_baas", "for_pull_requests" ]
   exec_timeout_secs: 3600
   commands:
@@ -850,7 +871,7 @@ tasks:
   - func: "wait for baas to start"
   - func: "run tests"
     vars:
-      test_filter: ObjectStoreTests
+      test_label: objstore-baas
       test_executable_name: "realm-object-store-tests"
       verbose_test_output: true
 

--- a/test/object-store/CMakeLists.txt
+++ b/test/object-store/CMakeLists.txt
@@ -93,7 +93,28 @@ endif()
 target_link_libraries(ObjectStoreTests Catch2::Catch2 ObjectStore RealmFFIStatic)
 enable_stdfilesystem(ObjectStoreTests)
 create_coverage_target(generate-coverage ObjectStoreTests)
-add_bundled_test(ObjectStoreTests)
+
+# add_bundled_test(ObjectStoreTests)
+add_labeled_test(ObjectStoreTests-local objstore-local ObjectStoreTests "~[baas]")
+
+# Keep the OBJ_STORE_TESTS variable in the block scope
+set(OBJSTORE_TESTS_FILE "${CMAKE_CURRENT_SOURCE_DIR}/object-store-tests.lst")
+# Rebuild cmake config if the tests file changes
+set_property(DIRECTORY APPEND PROPERTY CMAKE_CONFIGURE_DEPENDS ${OBJSTORE_TESTS_FILE})
+# Extract the list of entries from the tests file
+parse_list_file("${OBJSTORE_TESTS_FILE}" OBJSTORE_TEST_LIST)
+# Convert the list from tests file, if any, to object store tests for each line
+if (OBJSTORE_TEST_LIST)
+    set(_test_cnt 1)
+    foreach(_test_item ${OBJSTORE_TEST_LIST})
+        message(STATUS "Adding ObjectStoreTests-${_test_cnt}: 'realm-object-store-tests ${_test_item}'")
+        separate_arguments(_test_args NATIVE_COMMAND "${_test_item}")
+        add_labeled_test("ObjectStoreTests-${_test_cnt}" "objstore-baas" ObjectStoreTests ${_test_args})
+        MATH(EXPR _test_cnt "${_test_cnt}+1")
+    endforeach()
+else()
+    add_labeled_test(ObjectStoreTests-baas objstore-baas ObjectStoreTests "[baas]")
+endif()
 
 if(REALM_ENABLE_SYNC)
     target_link_libraries(ObjectStoreTests SyncServer)

--- a/test/object-store/main.cpp
+++ b/test/object-store/main.cpp
@@ -16,8 +16,8 @@
 //
 ////////////////////////////////////////////////////////////////////////////
 
-#include "util/crypt_key.hpp"
-#include "util/test_path.hpp"
+#include <util/crypt_key.hpp>
+#include <util/test_path.hpp>
 
 #include <realm/util/features.h>
 #include <realm/util/to_string.hpp>
@@ -28,8 +28,11 @@
 #include <catch2/reporters/catch_reporter_registrars.hpp>
 #include <external/json/json.hpp>
 
+#include <filesystem>
+#include <fstream>
 #include <iostream>
 #include <limits.h>
+
 
 int main(int argc, const char** argv)
 {
@@ -39,9 +42,18 @@ int main(int argc, const char** argv)
 
     if (const char* str = getenv("UNITTEST_EVERGREEN_TEST_RESULTS"); str && strlen(str) != 0) {
         std::cout << "Configuring evergreen reporter to store test results in " << str << std::endl;
+        // If the output file already exists, make a copy so these results can be appended to it
+        std::map<std::string, std::string> custom_options;
+        if (std::filesystem::exists(str)) {
+            std::string results_copy = realm::util::format("%1.bak", str);
+            std::filesystem::copy(str, results_copy, std::filesystem::copy_options::overwrite_existing);
+            custom_options["json_file"] = results_copy;
+            std::cout << "Existing results file copied to " << results_copy << std::endl;
+        }
         config.showDurations = Catch::ShowDurations::Always; // this is to help debug hangs in Evergreen
         config.reporterSpecifications.push_back(Catch::ReporterSpec{"console", {}, {}, {}});
-        config.reporterSpecifications.push_back(Catch::ReporterSpec{"evergreen", {str}, {}, {}});
+        config.reporterSpecifications.push_back(
+            Catch::ReporterSpec{"evergreen", {str}, {}, std::move(custom_options)});
     }
     else if (const char* str = getenv("UNITTEST_XML"); str && strlen(str) != 0) {
         std::cout << "Configuring jUnit reporter to store test results in " << str << std::endl;
@@ -150,7 +162,29 @@ public:
     }
     void testRunEndedCumulative() override
     {
-        auto results_arr = nlohmann::json::array();
+        auto& options = m_customOptions;
+        auto& json_file = options["json_file"];
+        nlohmann::json results_arr = nlohmann::json::array();
+        // If the results file already exists, include the results from that file
+        try {
+            if (!json_file.empty() && std::filesystem::exists(json_file)) {
+                std::ifstream f(json_file);
+                if (f.is_open() && !f.eof()) {
+                    nlohmann::json existing_data = nlohmann::json::parse(f);
+                    auto results = existing_data.find("results");
+                    if (results != existing_data.end() && results->is_array()) {
+                        std::cout << "Appending tests from previous results" << std::endl;
+                        results_arr = *results;
+                    }
+                }
+            }
+        }
+        catch (nlohmann::json::exception) {
+            // json parse error, ignore the entries
+        }
+        catch (std::exception) {
+            // unable to open/read file, overwrite if it exists
+        }
         for (const auto& [test_name, cur_result] : m_results) {
             auto to_millis = [](const auto& tp) -> double {
                 return static_cast<double>(
@@ -170,6 +204,10 @@ public:
         }
         auto result_file_obj = nlohmann::json{{"results", std::move(results_arr)}};
         m_stream << result_file_obj << std::endl;
+        if (!json_file.empty()) {
+            // Delete the old results file
+            std::filesystem::remove(json_file);
+        }
     }
 
     TestResult m_pending_test;

--- a/test/object-store/object-store-tests.lst
+++ b/test/object-store/object-store-tests.lst
@@ -1,0 +1,9 @@
+# This file can be used to specify specific tests to run during the
+# object-store-tests Evergreen task. These tests will be assigned
+# the 'ObjectStoreTests-<num>' ctest name and the 'objstore-baas' label.
+#
+# Only enter the arguments provided for each test case/section to run,
+# one per line. Comments using '#' are supported.
+# Examples:
+# -c "subscriber can unsubscribe" "subscribable unit tests" # first command
+# -c "login_anonymous bad" "app: login_with_credentials unit_tests"

--- a/tools/cmake/Utilities.cmake
+++ b/tools/cmake/Utilities.cmake
@@ -64,6 +64,47 @@ macro(add_bundled_test _target)
     endif()
 endmacro()
 
+# Additional arguments will be passed to the _target command
+function(add_labeled_test _name _label _target)
+    if(NOT APPLE)
+        add_test(NAME ${_name} COMMAND ${_target} ${ARGN})
+    else()
+        # When given a target name, add_test() is supposed to automatically
+        # determine the path to the executable. However, this is very broken on
+        # Apple platforms. ctest doesn't perform macro expansion, so the path
+        # is left with a `$(EFFECTIVE_PLATFORM_NAME)` in it. The generator
+        # expression `$<TARGET_FILE:target>` is also just wrong on macOS, as it
+        # uses a path suitable for an iOS bundle rather than a macOS bundle. As
+        # a result, we have to construct the path manually.
+        add_test(NAME ${_name} COMMAND $<TARGET_FILE_NAME:${_target}>.app/Contents/MacOS/$<TARGET_FILE_NAME:${_target}> ${ARGN})
+    endif()
+    set_tests_properties(${_name} PROPERTIES LABELS "${_label}")
+endfunction()
+
+# Parse the lines in a text file, removing comments that begin with '#' and
+# removing leading/trailing whitespace.
+function(parse_list_file _path _outlist)
+    if(EXISTS "${_path}")
+        file(STRINGS "${_path}" _test_list)
+    endif()
+    if(_test_list)
+        foreach(_item ${_test_list})
+            # Remove comments
+            if(_item)
+                string(REGEX REPLACE "#.*" "" _item_clean "${_item}")
+            endif()
+            # Trim leading/trailing space
+            string(STRIP "${_item_clean}" _item_trimmed)
+            if(_item_trimmed)
+                list(APPEND _found_tests "${_item_trimmed}")
+            endif()
+        endforeach()
+        if (_found_tests)
+            set(${_outlist} ${_found_tests} PARENT_SCOPE)
+        endif()
+    endif()
+endfunction()
+
 macro(set_macos_only _dir)
     get_property(_targets DIRECTORY "${_dir}" PROPERTY BUILDSYSTEM_TARGETS)
     foreach(_target IN LISTS _targets)


### PR DESCRIPTION
## What, How & Why?
Break out object-store-tests into two different evergreen tasks:

* `object-store-tests-local` - run the object store tests that do not require a baas server (baas server is not started)
* `object-store-tests-baas` - run the object store tests that require a baas server (baas server is started)

Added feature to run one or more specific object store tests by adding the arguments for `realm-object-store-tests` to the _test/object-store/object-store-tests.ls_ file. These tests will be run during the `object-store-tests-baas` evergreen task in case those tests require the baas server.
 
Fixes #6391

## ☑️ ToDos
* [ ] 📝 Changelog update
* [X] 🚦 Tests (or not relevant)
* ~~[ ] C-API, if public C++ API changed.~~
