### PR TITLE
convert from streaming form *before* any changes to file size

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@
 
 ### Fixed
 * <How do the end-user experience this issue? what was the impact?> ([#????](https://github.com/realm/realm-core/issues/????), since v?.?.?)
-* None.
+* Rare corruption of files on streaming format (often following compact, convert or copying to a new file). ([#6807](https://github.com/realm/realm-core/pull/6807), since v12.12.0)
 
 ### Breaking changes
 * None.

--- a/src/realm/alloc_slab.cpp
+++ b/src/realm/alloc_slab.cpp
@@ -709,8 +709,8 @@ bool SlabAlloc::align_filesize_for_mmap(ref_type top_ref, Config& cfg)
         // Currently, there is no way to detect if this assumption is violated.
         return false;
     }
-    size_t expected_size = (size_t)-1;
-    size_t size = m_file.get_size();
+    size_t expected_size = size_t(-1);
+    size_t size = static_cast<size_t>(m_file.get_size());
 
     // It is not safe to change the size of a file on streaming form, since the footer
     // must remain available and remain at the very end of the file.

--- a/src/realm/alloc_slab.cpp
+++ b/src/realm/alloc_slab.cpp
@@ -557,7 +557,7 @@ void SlabAlloc::do_free(ref_type ref, char* addr)
                 // We can do that just by adding the size
                 if (prev->first + prev->second == ref) {
                     prev->second += size;
-                    return; // Done!
+                    return;                                     // Done!
                 }
                 m_free_read_only.emplace_hint(next, ref, size); // Throws
             }
@@ -697,6 +697,69 @@ std::string SlabAlloc::get_file_path_for_assertions() const
     return m_file.get_path();
 }
 
+bool SlabAlloc::align_filesize_for_mmap(ref_type top_ref, Config& cfg)
+{
+    if (cfg.read_only) {
+        // If the file is opened read-only, we cannot change it. This is not a problem,
+        // because for a read-only file we assume that it will not change while we use it,
+        // hence there will be no need to grow memory mappings.
+        // This assumption obviously will not hold, if the file is shared by multiple
+        // processes or threads with different opening modes.
+        // Currently, there is no way to detect if this assumption is violated.
+        return false;
+    }
+    size_t expected_size = (size_t)-1;
+    size_t size = m_file.get_size();
+    if (top_ref) {
+        // Get the expected file size by looking up logical file size stored in top array
+        constexpr size_t max_top_size = (Group::s_file_size_ndx + 1) * 8 + sizeof(Header);
+        size_t top_page_base = top_ref & ~(page_size() - 1);
+        size_t top_offset = top_ref - top_page_base;
+        size_t map_size = std::min(max_top_size + top_offset, size - top_page_base);
+        File::Map<char> map_top(m_file, top_page_base, File::access_ReadOnly, map_size, 0, m_write_observer);
+        realm::util::encryption_read_barrier(map_top, top_offset, max_top_size);
+        auto top_header = map_top.get_addr() + top_offset;
+        auto top_data = NodeHeader::get_data_from_header(top_header);
+        auto w = NodeHeader::get_width_from_header(top_header);
+        auto logical_size = size_t(get_direct(top_data, w, Group::s_file_size_ndx)) >> 1;
+        // make sure we're page aligned, so the code below doesn't first
+        // truncate the file, then expand it again
+        expected_size = round_up_to_page_size(logical_size);
+    }
+
+    // Check if we can shrink the file
+    if (cfg.session_initiator && expected_size < size && !cfg.read_only) {
+        m_file.resize(expected_size);
+        size = expected_size;
+        return true;
+    }
+
+    // We can only safely mmap the file, if its size matches a page boundary. If not,
+    // we must change the size to match before mmaping it.
+    if (size != round_up_to_page_size(size)) {
+        // The file size did not match a page boundary.
+        // We must extend the file to a page boundary (unless already there)
+        // The file must be extended to match in size prior to being mmapped,
+        // as extending it after mmap has undefined behavior.
+        if (cfg.session_initiator || !cfg.is_shared) {
+            // We can only safely extend the file if we're the session initiator, or if
+            // the file isn't shared at all. Extending the file to a page boundary is ONLY
+            // done to ensure well defined behavior for memory mappings. It does not matter,
+            // that the free space management isn't informed
+            size = round_up_to_page_size(size);
+            m_file.prealloc(size);
+            return true;
+        }
+        else {
+            // Getting here, we have a file of a size that will not work, and without being
+            // allowed to extend it. This should not be possible. But allowing a retry is
+            // arguably better than giving up and crashing...
+            throw Retry();
+        }
+    }
+    return false;
+}
+
 ref_type SlabAlloc::attach_file(const std::string& path, Config& cfg, util::WriteObserver* write_observer)
 {
     m_cfg = cfg;
@@ -794,7 +857,7 @@ ref_type SlabAlloc::attach_file(const std::string& path, Config& cfg, util::Writ
 
         top_ref = validate_header(header, footer, size, path, cfg.encryption_key != nullptr); // Throws
         m_attach_mode = cfg.is_shared ? attach_SharedFile : attach_UnsharedFile;
-        m_data = map_header.get_addr(); // <-- needed below
+        m_data = map_header.get_addr();                                                       // <-- needed below
 
         if (cfg.session_initiator && is_file_on_streaming_form(*header)) {
             // Don't compare file format version fields as they are allowed to differ.
@@ -814,21 +877,6 @@ ref_type SlabAlloc::attach_file(const std::string& path, Config& cfg, util::Writ
             REALM_ASSERT_EX(footer->m_magic_cookie == footer_magic_cookie, footer->m_magic_cookie,
                             get_file_path_for_assertions());
         }
-
-        if (top_ref) {
-            // Get the expected file size by looking up logical file size stored in top array
-            constexpr size_t max_top_size = (Group::s_file_size_ndx + 1) * 8 + sizeof(Header);
-            size_t top_page_base = top_ref & ~(page_size() - 1);
-            size_t top_offset = top_ref - top_page_base;
-            size_t map_size = std::min(max_top_size + top_offset, size - top_page_base);
-            File::Map<char> map_top(m_file, top_page_base, File::access_ReadOnly, map_size, 0, m_write_observer);
-            realm::util::encryption_read_barrier(map_top, top_offset, max_top_size);
-            auto top_header = map_top.get_addr() + top_offset;
-            auto top_data = NodeHeader::get_data_from_header(top_header);
-            auto w = NodeHeader::get_width_from_header(top_header);
-            auto logical_size = size_t(get_direct(top_data, w, Group::s_file_size_ndx)) >> 1;
-            expected_size = round_up_to_page_size(logical_size);
-        }
     }
     catch (const InvalidDatabase&) {
         throw;
@@ -842,6 +890,7 @@ ref_type SlabAlloc::attach_file(const std::string& path, Config& cfg, util::Writ
     catch (...) {
         throw InvalidDatabase("unknown error", path);
     }
+    // m_data not valid at this point!
     m_baseline = 0;
     // make sure that any call to begin_read cause any slab to be placed in free
     // lists correctly
@@ -849,45 +898,6 @@ ref_type SlabAlloc::attach_file(const std::string& path, Config& cfg, util::Writ
 
     // Ensure clean up, if we need to back out:
     DetachGuard dg(*this);
-
-    // Check if we can shrink the file
-    if (cfg.session_initiator && expected_size < size) {
-        m_file.resize(expected_size);
-        size = expected_size;
-    }
-    // We can only safely mmap the file, if its size matches a page boundary. If not,
-    // we must change the size to match before mmaping it.
-    if (size != round_up_to_page_size(size)) {
-        // The file size did not match a page boundary.
-        // We must extend the file to a page boundary (unless already there)
-        // The file must be extended to match in size prior to being mmapped,
-        // as extending it after mmap has undefined behavior.
-        if (cfg.read_only) {
-            // If the file is opened read-only, we cannot extend it. This is not a problem,
-            // because for a read-only file we assume that it will not change while we use it.
-            // This assumption obviously will not hold, if the file is shared by multiple
-            // processes or threads with different opening modes.
-            // Currently, there is no way to detect if this assumption is violated.
-            m_baseline = 0;
-        }
-        else {
-            if (cfg.session_initiator || !cfg.is_shared) {
-                // We can only safely extend the file if we're the session initiator, or if
-                // the file isn't shared at all. Extending the file to a page boundary is ONLY
-                // done to ensure well defined behavior for memory mappings. It does not matter,
-                // that the free space management isn't informed
-                size = round_up_to_page_size(size);
-                m_file.prealloc(size);
-                m_baseline = 0;
-            }
-            else {
-                // Getting here, we have a file of a size that will not work, and without being
-                // allowed to extend it. This should not be possible. But allowing a retry is
-                // arguably better than giving up and crashing...
-                throw Retry();
-            }
-        }
-    }
 
     reset_free_space_tracking();
     update_reader_view(size);
@@ -915,12 +925,12 @@ void SlabAlloc::convert_from_streaming_form(ref_type top_ref)
     {
         File::Map<Header> writable_map(m_file, File::access_ReadWrite, sizeof(Header)); // Throws
         Header& writable_header = *writable_map.get_addr();
-        realm::util::encryption_read_barrier(writable_map, 0);
+        realm::util::encryption_read_barrier_for_write(writable_map, 0);
         writable_header.m_top_ref[1] = top_ref;
         writable_header.m_file_format[1] = writable_header.m_file_format[0];
         realm::util::encryption_write_barrier(writable_map, 0);
         writable_map.sync();
-        realm::util::encryption_read_barrier(writable_map, 0);
+        realm::util::encryption_read_barrier_for_write(writable_map, 0);
         writable_header.m_flags |= flags_SelectBit;
         realm::util::encryption_write_barrier(writable_map, 0);
         writable_map.sync();

--- a/src/realm/alloc_slab.cpp
+++ b/src/realm/alloc_slab.cpp
@@ -558,7 +558,7 @@ void SlabAlloc::do_free(ref_type ref, char* addr)
                 // We can do that just by adding the size
                 if (prev->first + prev->second == ref) {
                     prev->second += size;
-                    return;                                     // Done!
+                    return; // Done!
                 }
                 m_free_read_only.emplace_hint(next, ref, size); // Throws
             }
@@ -867,7 +867,7 @@ ref_type SlabAlloc::attach_file(const std::string& path, Config& cfg, util::Writ
 
         top_ref = validate_header(header, footer, size, path, cfg.encryption_key != nullptr); // Throws
         m_attach_mode = cfg.is_shared ? attach_SharedFile : attach_UnsharedFile;
-        m_data = map_header.get_addr();                                                       // <-- needed below
+        m_data = map_header.get_addr(); // <-- needed below
 
         if (cfg.session_initiator && is_file_on_streaming_form(*header)) {
             // Don't compare file format version fields as they are allowed to differ.

--- a/src/realm/alloc_slab.hpp
+++ b/src/realm/alloc_slab.hpp
@@ -119,8 +119,7 @@ public:
         const char* encryption_key = nullptr;
     };
 
-    struct Retry {
-    };
+    struct Retry {};
 
     /// \brief Attach this allocator to the specified file.
     ///
@@ -152,6 +151,12 @@ public:
     /// \throw FileAccessError
     /// \throw SlabAlloc::Retry
     ref_type attach_file(const std::string& file_path, Config& cfg, util::WriteObserver* write_observer = nullptr);
+
+    /// @brief Expand or contract file
+    /// @param ref_type ref to the top array
+    /// @param cfg configuration, see attach_file
+    /// \return true if the file size was changed
+    bool align_filesize_for_mmap(size_t ref_type, Config& cfg);
 
     /// If the attached file is in streaming form, convert it to normal form.
     ///

--- a/src/realm/alloc_slab.hpp
+++ b/src/realm/alloc_slab.hpp
@@ -209,13 +209,18 @@ public:
 
     /// Detach from a previously attached file or buffer.
     ///
+    /// if 'keep_file_attached' is set, only memory mappings will
+    /// be closed, but the file descriptor remains valid for further
+    /// operations on the file. Caller must close the file explicitly
+    /// to bring the allocator to a fully detached state.
+    ///
     /// This function does not reset free space tracking. To
     /// completely reset the allocator, you must also call
     /// reset_free_space_tracking().
     ///
     /// This function has no effect if the allocator is already in the
     /// detached state (idempotency).
-    void detach() noexcept;
+    void detach(bool keep_file_attached = false) noexcept;
 
     class DetachGuard;
 

--- a/src/realm/db.cpp
+++ b/src/realm/db.cpp
@@ -383,8 +383,8 @@ struct alignas(8) DB::SharedInfo {
     /// compromize version agreement checking.
     uint16_t shared_info_version = g_shared_info_version; // Offset 6
 
-    uint16_t durability;                                  // Offset 8
-    uint16_t free_write_slots = 0;                        // Offset 10
+    uint16_t durability;           // Offset 8
+    uint16_t free_write_slots = 0; // Offset 10
 
     /// Number of participating shared groups
     uint32_t num_participants = 0; // Offset 12
@@ -396,7 +396,7 @@ struct alignas(8) DB::SharedInfo {
     /// Pid of process initiating the session, but only if that process runs
     /// with encryption enabled, zero otherwise. This was used to prevent
     /// multiprocess encryption until support for that was added.
-    uint64_t session_initiator_pid = 0;       // Offset 24
+    uint64_t session_initiator_pid = 0; // Offset 24
 
     std::atomic<uint64_t> number_of_versions; // Offset 32
 
@@ -418,14 +418,14 @@ struct alignas(8) DB::SharedInfo {
     /// Cleared by the daemon when it decides to exit.
     uint8_t daemon_ready = 0; // Offset 42
 
-    uint8_t filler_1;         // Offset 43
+    uint8_t filler_1; // Offset 43
 
     /// Stores a history schema version (as returned by
     /// Replication::get_history_schema_version()). Must match across all
     /// session participants.
-    uint16_t history_schema_version;                 // Offset 44
+    uint16_t history_schema_version; // Offset 44
 
-    uint16_t filler_2;                               // Offset 46
+    uint16_t filler_2; // Offset 46
 
     InterprocessMutex::SharedPart shared_writemutex; // Offset 48
     InterprocessMutex::SharedPart shared_controlmutex;
@@ -457,8 +457,8 @@ struct alignas(8) DB::SharedInfo {
 DB::SharedInfo::SharedInfo(Durability dura, Replication::HistoryType ht, int hsv)
     : size_of_mutex(sizeof(shared_writemutex))
     , size_of_condvar(sizeof(room_to_write))
-    , shared_writemutex()                     // Throws
-    , shared_controlmutex()                   // Throws
+    , shared_writemutex()   // Throws
+    , shared_controlmutex() // Throws
 {
     durability = static_cast<uint16_t>(dura); // durability level is fixed from creation
     REALM_ASSERT(!util::int_cast_has_overflow<decltype(history_type)>(ht + 0));
@@ -945,7 +945,7 @@ void DB::open(const std::string& path, bool no_create_file, const DBOptions& opt
     int target_file_format_version;
     int stored_hist_schema_version = -1; // Signals undetermined
 
-    int retries_left = 10;               // number of times to retry before throwing exceptions
+    int retries_left = 10; // number of times to retry before throwing exceptions
     // in case there is something wrong with the .lock file... the retries allows
     // us to pick a new lockfile initializer in case the first one crashes without
     // completing the initialization
@@ -1412,7 +1412,7 @@ void DB::open(const std::string& path, bool no_create_file, const DBOptions& opt
             fug_1.release(); // Do not unmap
             fcg.release();   // Do not close
         }
-        ulg.release();       // Do not release shared lock
+        ulg.release(); // Do not release shared lock
         break;
     }
 
@@ -2468,7 +2468,7 @@ void DB::low_level_commit(uint_fast64_t new_version, Transaction& transaction, b
     REALM_ASSERT(oldest_version <= new_version);
 #if REALM_METRICS
     transaction.update_num_objects();
-#endif                                                                                   // REALM_METRICS
+#endif // REALM_METRICS
 
     GroupWriter out(transaction, Durability(info->durability), m_marker_observer.get()); // Throws
     out.set_versions(new_version, top_refs, any_new_unreachables);

--- a/src/realm/group.cpp
+++ b/src/realm/group.cpp
@@ -63,7 +63,7 @@ Group::Group()
     init_array_parents();
     m_alloc.attach_empty(); // Throws
     m_file_format_version = get_target_file_format_version_for_session(0, Replication::hist_None);
-    ref_type top_ref = 0; // Instantiate a new empty group
+    ref_type top_ref = 0;   // Instantiate a new empty group
     bool create_group_when_missing = true;
     bool writable = create_group_when_missing;
     attach(top_ref, writable, create_group_when_missing); // Throws
@@ -633,7 +633,7 @@ void Group::create_empty_group()
     m_top.create(Array::type_HasRefs); // Throws
     _impl::DeepArrayDestroyGuard dg_top(&m_top);
     {
-        m_table_names.create(); // Throws
+        m_table_names.create();             // Throws
         _impl::DestroyGuard<ArrayStringShort> dg(&m_table_names);
         m_top.add(m_table_names.get_ref()); // Throws
         dg.release();
@@ -641,7 +641,7 @@ void Group::create_empty_group()
     {
         m_tables.create(Array::type_HasRefs); // Throws
         _impl::DestroyGuard<Array> dg(&m_tables);
-        m_top.add(m_tables.get_ref()); // Throws
+        m_top.add(m_tables.get_ref());        // Throws
         dg.release();
     }
     size_t initial_logical_file_size = sizeof(SlabAlloc::Header);
@@ -1030,7 +1030,7 @@ BinaryData Group::write_to_mem() const
         throw Exception(ErrorCodes::OutOfMemory, "Could not allocate memory while dumping to memory");
     MemoryOutputStream out; // Throws
     out.set_buffer(buffer.get(), buffer.get() + max_size);
-    write(out); // Throws
+    write(out);             // Throws
     size_t buffer_size = out.size();
     return BinaryData(buffer.release(), buffer_size);
 }
@@ -1072,9 +1072,9 @@ void Group::write(std::ostream& out, int file_format_version, TableWriter& table
         ref_type names_ref = table_writer.write_names(out_2);   // Throws
         ref_type tables_ref = table_writer.write_tables(out_2); // Throws
         SlabAlloc new_alloc;
-        new_alloc.attach_empty(); // Throws
+        new_alloc.attach_empty();                               // Throws
         Array top(new_alloc);
-        top.create(Array::type_HasRefs); // Throws
+        top.create(Array::type_HasRefs);                        // Throws
         _impl::ShallowArrayDestroyGuard dg_top(&top);
         int_fast64_t value_1 = from_ref(names_ref);
         int_fast64_t value_2 = from_ref(tables_ref);
@@ -1089,14 +1089,14 @@ void Group::write(std::ostream& out, int file_format_version, TableWriter& table
             Array free_list(new_alloc);
             Array size_list(new_alloc);
             Array version_list(new_alloc);
-            free_list.create(Array::type_Normal); // Throws
+            free_list.create(Array::type_Normal);    // Throws
             _impl::DeepArrayDestroyGuard dg_1(&free_list);
-            size_list.create(Array::type_Normal); // Throws
+            size_list.create(Array::type_Normal);    // Throws
             _impl::DeepArrayDestroyGuard dg_2(&size_list);
             version_list.create(Array::type_Normal); // Throws
             _impl::DeepArrayDestroyGuard dg_3(&version_list);
-            bool deep = true;              // Deep
-            bool only_if_modified = false; // Always
+            bool deep = true;                        // Deep
+            bool only_if_modified = false;           // Always
             ref_type free_list_ref = free_list.write(out_2, deep, only_if_modified);
             ref_type size_list_ref = size_list.write(out_2, deep, only_if_modified);
             ref_type version_list_ref = version_list.write(out_2, deep, only_if_modified);
@@ -1144,8 +1144,6 @@ void Group::write(std::ostream& out, int file_format_version, TableWriter& table
     // footer is aligned to the end of a page
     if (pad_for_encryption) {
 #if REALM_ENABLE_ENCRYPTION
-        // this seems wrong - it aligns the START of the footer to the page boundary,
-        // but what is needed is to align the END of the footer to the page boundary?
         size_t unrounded_size = final_file_size + sizeof(SlabAlloc::StreamingFooter);
         size_t rounded_size = round_up_to_page_size(unrounded_size);
         if (rounded_size != unrounded_size) {

--- a/src/realm/group.cpp
+++ b/src/realm/group.cpp
@@ -63,7 +63,7 @@ Group::Group()
     init_array_parents();
     m_alloc.attach_empty(); // Throws
     m_file_format_version = get_target_file_format_version_for_session(0, Replication::hist_None);
-    ref_type top_ref = 0;   // Instantiate a new empty group
+    ref_type top_ref = 0; // Instantiate a new empty group
     bool create_group_when_missing = true;
     bool writable = create_group_when_missing;
     attach(top_ref, writable, create_group_when_missing); // Throws
@@ -633,7 +633,7 @@ void Group::create_empty_group()
     m_top.create(Array::type_HasRefs); // Throws
     _impl::DeepArrayDestroyGuard dg_top(&m_top);
     {
-        m_table_names.create();             // Throws
+        m_table_names.create(); // Throws
         _impl::DestroyGuard<ArrayStringShort> dg(&m_table_names);
         m_top.add(m_table_names.get_ref()); // Throws
         dg.release();
@@ -641,7 +641,7 @@ void Group::create_empty_group()
     {
         m_tables.create(Array::type_HasRefs); // Throws
         _impl::DestroyGuard<Array> dg(&m_tables);
-        m_top.add(m_tables.get_ref());        // Throws
+        m_top.add(m_tables.get_ref()); // Throws
         dg.release();
     }
     size_t initial_logical_file_size = sizeof(SlabAlloc::Header);
@@ -1030,7 +1030,7 @@ BinaryData Group::write_to_mem() const
         throw Exception(ErrorCodes::OutOfMemory, "Could not allocate memory while dumping to memory");
     MemoryOutputStream out; // Throws
     out.set_buffer(buffer.get(), buffer.get() + max_size);
-    write(out);             // Throws
+    write(out); // Throws
     size_t buffer_size = out.size();
     return BinaryData(buffer.release(), buffer_size);
 }
@@ -1072,9 +1072,9 @@ void Group::write(std::ostream& out, int file_format_version, TableWriter& table
         ref_type names_ref = table_writer.write_names(out_2);   // Throws
         ref_type tables_ref = table_writer.write_tables(out_2); // Throws
         SlabAlloc new_alloc;
-        new_alloc.attach_empty();                               // Throws
+        new_alloc.attach_empty(); // Throws
         Array top(new_alloc);
-        top.create(Array::type_HasRefs);                        // Throws
+        top.create(Array::type_HasRefs); // Throws
         _impl::ShallowArrayDestroyGuard dg_top(&top);
         int_fast64_t value_1 = from_ref(names_ref);
         int_fast64_t value_2 = from_ref(tables_ref);
@@ -1089,14 +1089,14 @@ void Group::write(std::ostream& out, int file_format_version, TableWriter& table
             Array free_list(new_alloc);
             Array size_list(new_alloc);
             Array version_list(new_alloc);
-            free_list.create(Array::type_Normal);    // Throws
+            free_list.create(Array::type_Normal); // Throws
             _impl::DeepArrayDestroyGuard dg_1(&free_list);
-            size_list.create(Array::type_Normal);    // Throws
+            size_list.create(Array::type_Normal); // Throws
             _impl::DeepArrayDestroyGuard dg_2(&size_list);
             version_list.create(Array::type_Normal); // Throws
             _impl::DeepArrayDestroyGuard dg_3(&version_list);
-            bool deep = true;                        // Deep
-            bool only_if_modified = false;           // Always
+            bool deep = true;              // Deep
+            bool only_if_modified = false; // Always
             ref_type free_list_ref = free_list.write(out_2, deep, only_if_modified);
             ref_type size_list_ref = size_list.write(out_2, deep, only_if_modified);
             ref_type version_list_ref = version_list.write(out_2, deep, only_if_modified);

--- a/src/realm/group.cpp
+++ b/src/realm/group.cpp
@@ -1112,6 +1112,8 @@ void Group::write(std::ostream& out, int file_format_version, TableWriter& table
                 top.add(RefOrTagged::make_tagged(history_info.version));
                 top.add(RefOrTagged::make_tagged(history_info.sync_file_id));
                 top_size = s_group_max_size;
+                // ^ this is too large, since the evacuation point entry is not there:
+                // (but the code below is self correcting)
             }
         }
         top_ref = out_2.get_ref_of_next_array();
@@ -1142,6 +1144,8 @@ void Group::write(std::ostream& out, int file_format_version, TableWriter& table
     // footer is aligned to the end of a page
     if (pad_for_encryption) {
 #if REALM_ENABLE_ENCRYPTION
+        // this seems wrong - it aligns the START of the footer to the page boundary,
+        // but what is needed is to align the END of the footer to the page boundary?
         size_t unrounded_size = final_file_size + sizeof(SlabAlloc::StreamingFooter);
         size_t rounded_size = round_up_to_page_size(unrounded_size);
         if (rounded_size != unrounded_size) {

--- a/src/realm/util/file_mapper.hpp
+++ b/src/realm/util/file_mapper.hpp
@@ -179,6 +179,15 @@ void encryption_read_barrier(const File::Map<T>& map, size_t index, size_t num_e
 }
 
 template <typename T>
+void encryption_read_barrier_for_write(const File::Map<T>& map, size_t index, size_t num_elements = 1)
+{
+    if (auto mapping = map.get_encrypted_mapping(); REALM_UNLIKELY(mapping)) {
+        do_encryption_read_barrier(map.get_addr() + index, sizeof(T) * num_elements, nullptr, mapping,
+                                   map.is_writeable());
+    }
+}
+
+template <typename T>
 void encryption_write_barrier(const File::Map<T>& map, size_t index, size_t num_elements = 1)
 {
     if (auto mapping = map.get_encrypted_mapping(); REALM_UNLIKELY(mapping)) {


### PR DESCRIPTION
We changed (in v12.12.0) how we attach files in order to give better errors. Unfortunately this can lead to scenarios in which a file on streaming format (as produced by compact on launch or copy to file) is truncated or expanded before conversion to normal (non-streaming) format. If the app is then terminated (for whatever reason) we can no longer find the file footer and do the conversion later. The end result is a corrupted file - either the footer is lost or it is no longer at the end of the file, as expected.

This PR retains the better error reporting, while only doing file size changing operations *after* the conversion to normal format. 

In response to: https://github.com/realm/realm-kotlin/issues/1440

