### PR TITLE
Verify SyncClientConfig on App::get_shared_app is the same for already cached Apps

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@
 * None.
 
 ### Breaking changes
-* None.
+* App::get_shared_app now verifies that the SyncClientConfig is the same for constructed apps on subsequent calls, and throws InvalidArgument exception if parameters changed.
 
 ### Compatibility
 * Fileformat: Generates files with format v23. Reads and automatically upgrade from fileformat v5.

--- a/src/realm/object-store/sync/app.cpp
+++ b/src/realm/object-store/sync/app.cpp
@@ -219,6 +219,13 @@ SharedApp App::get_shared_app(const Config& config, const SyncClientConfig& sync
         app = std::make_shared<App>(config);
         app->configure(sync_client_config);
     }
+    else {
+        auto&& scc = app->sync_manager()->config();
+        if (scc.metadata_mode != sync_client_config.metadata_mode)
+            throw InvalidArgument("Metadata mode doesn't match the one in cached app");
+        if (scc.base_file_path != sync_client_config.base_file_path)
+            throw InvalidArgument("Base file path doesn't match the one in cached app");
+    }
     return app;
 }
 

--- a/test/object-store/sync/app.cpp
+++ b/test/object-store/sync/app.cpp
@@ -5251,6 +5251,7 @@ TEST_CASE("app: shared instances", "[sync][app]") {
     auto app1_4 = App::get_shared_app(config2, sync_config);
     auto app1_5 = App::get_cached_app(config1.app_id);
 
+    CHECK(app1_1);
     CHECK(app1_1 == app1_2);
     CHECK(app1_1 == app1_3);
     CHECK(app1_1 == app1_4);
@@ -5261,14 +5262,25 @@ TEST_CASE("app: shared instances", "[sync][app]") {
     auto app2_2 = App::get_cached_app(config3.app_id, config3.base_url);
     auto app2_3 = App::get_shared_app(config4, sync_config);
     auto app2_4 = App::get_cached_app(config3.app_id);
+
     auto app2_5 = App::get_cached_app(config4.app_id, "https://some.different.url");
+
+    CHECK(app2_1);
 
     CHECK(app2_1 == app2_2);
     CHECK(app2_1 != app2_3);
     CHECK(app2_4 != nullptr);
+    CHECK((app2_4 == app2_1 || app2_4 == app2_3)); // random with same app_id
     CHECK(app2_5 == nullptr);
 
     CHECK(app1_1 != app2_1);
     CHECK(app1_1 != app2_3);
     CHECK(app1_1 != app2_4);
+
+    auto other_sync_config = sync_config;
+    other_sync_config.metadata_mode = SyncClientConfig::MetadataMode::Encryption;
+    CHECK_THROWS_AS(App::get_shared_app(config3, other_sync_config), InvalidArgument);
+    other_sync_config = sync_config;
+    other_sync_config.base_file_path = util::make_temp_dir() + random_string(10);
+    CHECK_THROWS_AS(App::get_shared_app(config3, other_sync_config), InvalidArgument);
 }


### PR DESCRIPTION
## What, How & Why?
It's not supposed to apply changes in config for already constructed apps. Add sanity check and throw an exception if user code erroneously tries to do that.

Fixes #6810

## ☑️ ToDos
* [x] 📝 Changelog update
* [x] 🚦 Tests (or not relevant)
~* [ ] C-API, if public C++ API changed.~
