### PR TITLE
Remove comment since test is already enabled

### DIFF
--- a/test/object-store/sync/flx_sync.cpp
+++ b/test/object-store/sync/flx_sync.cpp
@@ -2905,7 +2905,6 @@ TEST_CASE("flx: data ingest", "[sync][flx][data ingest][baas]") {
     }
 }
 
-// TODO this test has been failing very frequently. We need to fix it and re-enable it in RCORE-1149.
 TEST_CASE("flx: data ingest - dev mode", "[sync][flx][data ingest][baas]") {
     FLXSyncTestHarness::ServerSchema server_schema;
     server_schema.dev_mode_enabled = true;


### PR DESCRIPTION
## What, How & Why?
The test was already enabled and had been passing on evergreen for a while, so I removed the comment.

Fixes #5640. 

## ☑️ ToDos
* [ ] ~~📝 Changelog update~~
* [ ] ~~🚦 Tests (or not relevant)~~
* [ ] ~~C-API, if public C++ API changed.~~
