### PR TITLE
Actually add full text indexes when processing schema changes that require them

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@
 * None.
 
 ### Fixed
-* <How do the end-user experience this issue? what was the impact?> ([#????](https://github.com/realm/realm-core/issues/????), since v?.?.?)
+* Trying to search a full-text indexes created as a result of an additive schema change (i.e. applying the differences between the local schema and a synchronized realm's schema) could have resulted in an IllegalOperation error with the error code `Column has no fulltext index`. ([PR #6823](https://github.com/realm/realm-core/pull/6823)).
 * None.
 
 ### Breaking changes

--- a/src/realm/object-store/object_store.cpp
+++ b/src/realm/object-store/object_store.cpp
@@ -560,7 +560,6 @@ static void apply_non_migration_changes(Group& group, std::vector<SchemaChange> 
         }
         void operator()(AddIndex op)
         {
-
             table(op.object).add_search_index(op.property->column_key, op.type);
         }
         void operator()(RemoveIndex op)
@@ -634,16 +633,7 @@ static void create_initial_tables(Group& group, std::vector<SchemaChange> const&
         }
         void operator()(AddIndex op)
         {
-            switch (op.type) {
-                case IndexType::General:
-                    table(op.object).add_search_index(op.property->column_key);
-                    break;
-                case IndexType::Fulltext:
-                    table(op.object).add_fulltext_index(op.property->column_key);
-                    break;
-                case IndexType::None:
-                    REALM_UNREACHABLE();
-            }
+            add_search_index(table(op.object), *op.property, op.type);
         }
         void operator()(RemoveIndex op)
         {
@@ -691,16 +681,7 @@ void ObjectStore::apply_additive_changes(Group& group, std::vector<SchemaChange>
         void operator()(AddIndex op)
         {
             if (update_indexes) {
-                switch (op.type) {
-                    case IndexType::General:
-                        table(op.object).add_search_index(op.property->column_key);
-                        break;
-                    case IndexType::Fulltext:
-                        table(op.object).add_fulltext_index(op.property->column_key);
-                        break;
-                    case IndexType::None:
-                        REALM_UNREACHABLE();
-                }
+                add_search_index(table(op.object), *op.property, op.type);
             }
         }
         void operator()(RemoveIndex op)
@@ -772,16 +753,7 @@ static void apply_pre_migration_changes(Group& group, std::vector<SchemaChange> 
         }
         void operator()(AddIndex op)
         {
-            switch (op.type) {
-                case IndexType::General:
-                    table(op.object).add_search_index(op.property->column_key);
-                    break;
-                case IndexType::Fulltext:
-                    table(op.object).add_fulltext_index(op.property->column_key);
-                    break;
-                case IndexType::None:
-                    REALM_UNREACHABLE();
-            }
+            add_search_index(table(op.object), *op.property, op.type);
         }
         void operator()(RemoveIndex op)
         {

--- a/src/realm/object-store/object_store.cpp
+++ b/src/realm/object-store/object_store.cpp
@@ -560,6 +560,7 @@ static void apply_non_migration_changes(Group& group, std::vector<SchemaChange> 
         }
         void operator()(AddIndex op)
         {
+
             table(op.object).add_search_index(op.property->column_key, op.type);
         }
         void operator()(RemoveIndex op)
@@ -633,7 +634,16 @@ static void create_initial_tables(Group& group, std::vector<SchemaChange> const&
         }
         void operator()(AddIndex op)
         {
-            add_search_index(table(op.object), *op.property, op.type);
+            switch (op.type) {
+                case IndexType::General:
+                    table(op.object).add_search_index(op.property->column_key);
+                    break;
+                case IndexType::Fulltext:
+                    table(op.object).add_fulltext_index(op.property->column_key);
+                    break;
+                case IndexType::None:
+                    REALM_UNREACHABLE();
+            }
         }
         void operator()(RemoveIndex op)
         {
@@ -680,8 +690,18 @@ void ObjectStore::apply_additive_changes(Group& group, std::vector<SchemaChange>
         }
         void operator()(AddIndex op)
         {
-            if (update_indexes)
-                table(op.object).add_search_index(op.property->column_key);
+            if (update_indexes) {
+                switch (op.type) {
+                    case IndexType::General:
+                        table(op.object).add_search_index(op.property->column_key);
+                        break;
+                    case IndexType::Fulltext:
+                        table(op.object).add_fulltext_index(op.property->column_key);
+                        break;
+                    case IndexType::None:
+                        REALM_UNREACHABLE();
+                }
+            }
         }
         void operator()(RemoveIndex op)
         {
@@ -752,7 +772,16 @@ static void apply_pre_migration_changes(Group& group, std::vector<SchemaChange> 
         }
         void operator()(AddIndex op)
         {
-            add_search_index(table(op.object), *op.property, op.type);
+            switch (op.type) {
+                case IndexType::General:
+                    table(op.object).add_search_index(op.property->column_key);
+                    break;
+                case IndexType::Fulltext:
+                    table(op.object).add_fulltext_index(op.property->column_key);
+                    break;
+                case IndexType::None:
+                    REALM_UNREACHABLE();
+            }
         }
         void operator()(RemoveIndex op)
         {

--- a/test/object-store/sync/app.cpp
+++ b/test/object-store/sync/app.cpp
@@ -5330,6 +5330,7 @@ TEST_CASE("app: full-text compatible with sync", "[sync][app]") {
     realm->commit_transaction();
 
     auto table = realm->read_group().get_table("class_TopLevel");
+    REQUIRE(table->search_index_type(table->get_column_key("full_text")) == IndexType::Fulltext);
     Results world_results(realm, Query(table).fulltext(table->get_column_key("full_text"), "world"));
     REQUIRE(world_results.size() == 1);
     REQUIRE(world_results.get<Obj>(0).get_primary_key() == Mixed{obj_id_1});

--- a/test/object-store/sync/app.cpp
+++ b/test/object-store/sync/app.cpp
@@ -5334,6 +5334,3 @@ TEST_CASE("app: shared instances", "[sync][app]") {
     CHECK(app1_1 != app2_3);
     CHECK(app1_1 != app2_4);
 }
-
-
-

--- a/test/object-store/sync/app.cpp
+++ b/test/object-store/sync/app.cpp
@@ -3518,6 +3518,67 @@ TEMPLATE_TEST_CASE("app: partition types", "[sync][pbs][app][partition][baas]", 
     }
 }
 
+TEST_CASE("app: full-text compatible with sync", "[sync][app]") {
+    std::string base_url = get_base_url();
+    const std::string valid_pk_name = "_id";
+    REQUIRE(!base_url.empty());
+
+    Schema schema{
+        {"TopLevel",
+         {
+             {valid_pk_name, PropertyType::ObjectId, Property::IsPrimary{true}},
+             {"full_text", Property::IsFulltextIndexed{true}},
+         }},
+    };
+
+    auto server_app_config = minimal_app_config(base_url, "full_text", schema);
+    auto app_session = create_app(server_app_config);
+    const auto partition = random_string(100);
+    TestAppSession test_session(app_session, nullptr);
+    SyncTestFile config(test_session.app(), partition, schema);
+    SharedRealm realm;
+    SECTION("sync open") {
+        INFO("realm opened without async open");
+        realm = Realm::get_shared_realm(config);
+    }
+    SECTION("async open") {
+        INFO("realm opened with async open");
+        auto async_open_task = Realm::get_synchronized_realm(config);
+
+        auto [realm_promise, realm_future] = util::make_promise_future<ThreadSafeReference>();
+        async_open_task->start(
+            [promise = std::move(realm_promise)](ThreadSafeReference ref, std::exception_ptr ouch) mutable {
+                if (ouch) {
+                    try {
+                        std::rethrow_exception(ouch);
+                    }
+                    catch (...) {
+                        promise.set_error(exception_to_status());
+                    }
+                }
+                else {
+                    promise.emplace_value(std::move(ref));
+                }
+            });
+
+        realm = Realm::get_shared_realm(std::move(realm_future.get()));
+    }
+
+    CppContext c(realm);
+    auto obj_id_1 = ObjectId::gen();
+    auto obj_id_2 = ObjectId::gen();
+    realm->begin_transaction();
+    Object::create(c, realm, "TopLevel", std::any(AnyDict{{"_id", obj_id_1}, {"full_text", "Hello, world!"s}}));
+    Object::create(c, realm, "TopLevel", std::any(AnyDict{{"_id", obj_id_2}, {"full_text", "Hello, everyone!"s}}));
+    realm->commit_transaction();
+
+    auto table = realm->read_group().get_table("class_TopLevel");
+    REQUIRE(table->search_index_type(table->get_column_key("full_text")) == IndexType::Fulltext);
+    Results world_results(realm, Query(table).fulltext(table->get_column_key("full_text"), "world"));
+    REQUIRE(world_results.size() == 1);
+    REQUIRE(world_results.get<Obj>(0).get_primary_key() == Mixed{obj_id_1});
+}
+
 #endif // REALM_ENABLE_AUTH_TESTS
 
 TEST_CASE("app: custom error handling", "[sync][app][custom errors][baas]") {
@@ -5275,63 +5336,4 @@ TEST_CASE("app: shared instances", "[sync][app]") {
 }
 
 
-TEST_CASE("app: full-text compatible with sync", "[sync][app]") {
-    std::string base_url = get_base_url();
-    const std::string valid_pk_name = "_id";
-    REQUIRE(!base_url.empty());
 
-    Schema schema{
-        {"TopLevel",
-         {
-             {valid_pk_name, PropertyType::ObjectId, Property::IsPrimary{true}},
-             {"full_text", Property::IsFulltextIndexed{true}},
-         }},
-    };
-
-    auto server_app_config = minimal_app_config(base_url, "full_text", schema);
-    auto app_session = create_app(server_app_config);
-    const auto partition = random_string(100);
-    TestAppSession test_session(app_session, nullptr);
-    SyncTestFile config(test_session.app(), partition, schema);
-    SharedRealm realm;
-    SECTION("sync open") {
-        INFO("realm opened without async open");
-        realm = Realm::get_shared_realm(config);
-    }
-    SECTION("async open") {
-        INFO("realm opened with async open");
-        auto async_open_task = Realm::get_synchronized_realm(config);
-
-        auto [realm_promise, realm_future] = util::make_promise_future<ThreadSafeReference>();
-        async_open_task->start(
-            [promise = std::move(realm_promise)](ThreadSafeReference ref, std::exception_ptr ouch) mutable {
-                if (ouch) {
-                    try {
-                        std::rethrow_exception(ouch);
-                    }
-                    catch (...) {
-                        promise.set_error(exception_to_status());
-                    }
-                }
-                else {
-                    promise.emplace_value(std::move(ref));
-                }
-            });
-
-        realm = Realm::get_shared_realm(std::move(realm_future.get()));
-    }
-
-    CppContext c(realm);
-    auto obj_id_1 = ObjectId::gen();
-    auto obj_id_2 = ObjectId::gen();
-    realm->begin_transaction();
-    Object::create(c, realm, "TopLevel", std::any(AnyDict{{"_id", obj_id_1}, {"full_text", "Hello, world!"s}}));
-    Object::create(c, realm, "TopLevel", std::any(AnyDict{{"_id", obj_id_2}, {"full_text", "Hello, everyone!"s}}));
-    realm->commit_transaction();
-
-    auto table = realm->read_group().get_table("class_TopLevel");
-    REQUIRE(table->search_index_type(table->get_column_key("full_text")) == IndexType::Fulltext);
-    Results world_results(realm, Query(table).fulltext(table->get_column_key("full_text"), "world"));
-    REQUIRE(world_results.size() == 1);
-    REQUIRE(world_results.get<Obj>(0).get_primary_key() == Mixed{obj_id_1});
-}


### PR DESCRIPTION
## What, How & Why?
This makes processing additive schema changes where one of the changes is adding a full-text search index actually add the full text search index. Without this change synchronized realms opened asynchronously could end up without any of their defined full text search indexes created and full text searches throwing an error with the message `Column has no fulltext index`.

## ☑️ ToDos
* [x] 📝 Changelog update
* [x] 🚦 Tests (or not relevant)
* [ ] C-API, if public C++ API changed.
