### PR TITLE
Make SyncError/SessionErrorInfo Status-aware

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@
 ### Internals
 * `wait_for_upload_completion`/`wait_for_download_completion` internal API was changed to use `Status`'s instead of `std::error_code`. The SDK-facing was already `Status` oriented, so this change should only result in better error messages. ([PR #6796](https://github.com/realm/realm-core/pull/6796))
 * Separate local and baas object store tests into separate evergreen tasks and allow custom test specification. ([PR #6805](https://github.com/realm/realm-core/pull/6805))
+* SyncError now contains a Status to hold the error information from the sync client instead of a `std::error_code`/`std::string` ([PR #6824](https://github.com/realm/realm-core/pull/6824)).
 
 ----------------------------------------------
 

--- a/src/realm/object-store/audit.mm
+++ b/src/realm/object-store/audit.mm
@@ -786,7 +786,7 @@ void AuditRealmPool::wait_for_upload(std::shared_ptr<SyncSession> session)
             if (status.get_std_error_code()) {
                 m_logger->error("Events: Upload on '%1' failed with error '%2'.", path, status.reason());
                 if (m_error_handler) {
-                    m_error_handler(SyncError(status.get_std_error_code(), status.reason(), false));
+                    m_error_handler(SyncError(std::move(status), false));
                 }
             }
             else {
@@ -873,8 +873,7 @@ void AuditRealmPool::open_new_realm()
     sync_config->error_handler = [error_handler = m_error_handler, weak_self = weak_from_this()](auto,
                                                                                                  SyncError error) {
         if (auto self = weak_self.lock()) {
-            self->m_logger->error("Events: Received sync error: %1 (ec=%2)", error.what(),
-                                  error.get_system_error().value());
+            self->m_logger->error("Events: Received sync error: %1", error.status);
         }
         if (error_handler) {
             error_handler(error);

--- a/src/realm/object-store/c_api/sync.cpp
+++ b/src/realm/object-store/c_api/sync.cpp
@@ -314,8 +314,8 @@ RLM_API void realm_sync_config_set_error_handler(realm_sync_config_t* config, re
         auto c_error = realm_sync_error_t();
 
         std::string error_code_message;
-        c_error.error_code = to_capi(error.to_status(), error_code_message);
-        c_error.detailed_message = error.what();
+        c_error.error_code = to_capi(error.status, error_code_message);
+        c_error.detailed_message = error.status.reason().c_str();
         c_error.is_fatal = error.is_fatal;
         c_error.is_unrecognized_by_client = error.is_unrecognized_by_client;
         c_error.is_client_reset_requested = error.is_client_reset_requested();
@@ -894,7 +894,8 @@ RLM_API void realm_sync_session_handle_error_for_testing(const realm_sync_sessio
                                        error_message};
     std::error_code err;
     sync_error_to_error_code(sync_error, &err);
-    SyncSession::OnlyForTesting::handle_error(*session->get(), sync::SessionErrorInfo{err, error_message, !is_fatal});
+    SyncSession::OnlyForTesting::handle_error(*session->get(),
+                                              sync::SessionErrorInfo{Status{err, error_message}, !is_fatal});
 }
 
 } // namespace realm::c_api

--- a/src/realm/sync/client.cpp
+++ b/src/realm/sync/client.cpp
@@ -1089,8 +1089,8 @@ SyncClientHookAction SessionImpl::call_debug_hook(const SyncClientHookData& data
     auto action = m_wrapper.m_debug_hook(data);
     switch (action) {
         case realm::SyncClientHookAction::SuspendWithRetryableError: {
-            SessionErrorInfo err_info(make_error_code(ProtocolError::other_session_error), "hook requested error",
-                                      true);
+            SessionErrorInfo err_info(
+                Status{make_error_code(ProtocolError::other_session_error), "hook requested error"}, true);
             err_info.server_requests_action = ProtocolErrorInfo::Action::Transient;
 
             auto err_processing_err = receive_error_message(err_info);

--- a/src/realm/sync/client_base.hpp
+++ b/src/realm/sync/client_base.hpp
@@ -305,22 +305,19 @@ struct ClientConfig {
 ///
 /// \sa set_connection_state_change_listener().
 struct SessionErrorInfo : public ProtocolErrorInfo {
-    SessionErrorInfo(const ProtocolErrorInfo& info, const std::error_code& ec)
+    SessionErrorInfo(const ProtocolErrorInfo& info, Status status)
         : ProtocolErrorInfo(info)
-        , error_code(ec)
+        , status(std::move(status))
     {
     }
-    SessionErrorInfo(const std::error_code& ec, bool try_again)
-        : ProtocolErrorInfo(ec.value(), ec.message(), try_again)
-        , error_code(ec)
+
+    SessionErrorInfo(Status status, bool try_again)
+        : ProtocolErrorInfo(0, {}, try_again)
+        , status(std::move(status))
     {
     }
-    SessionErrorInfo(const std::error_code& ec, const std::string& msg, bool try_again)
-        : ProtocolErrorInfo(ec.value(), msg, try_again)
-        , error_code(ec)
-    {
-    }
-    std::error_code error_code;
+
+    Status status;
 };
 
 enum class ConnectionState { disconnected, connecting, connected };

--- a/src/realm/sync/client_base.hpp
+++ b/src/realm/sync/client_base.hpp
@@ -312,7 +312,7 @@ struct SessionErrorInfo : public ProtocolErrorInfo {
     }
 
     SessionErrorInfo(Status status, bool try_again)
-        : ProtocolErrorInfo(0, {}, try_again)
+        : ProtocolErrorInfo(status.get_std_error_code().value(), status.reason(), try_again)
         , status(std::move(status))
     {
     }

--- a/src/realm/sync/config.cpp
+++ b/src/realm/sync/config.cpp
@@ -25,48 +25,34 @@
 #include <ostream>
 
 namespace realm {
+namespace {
 
+constexpr static std::string_view s_middle_part(" Logs: ");
+std::string format_sync_error_message(Status status, std::optional<std::string_view> log_url)
+{
+    if (!log_url) {
+        return status.reason();
+    }
+
+    return util::format("%1%2%3", status.reason(), s_middle_part, *log_url);
+}
+
+} // namespace
 // sync defines its own copy of port_type to avoid depending on network.hpp, but they should be the same.
 static_assert(std::is_same_v<sync::port_type, sync::network::Endpoint::port_type>);
 
 using ProtocolError = realm::sync::ProtocolError;
 
-static const constexpr std::string_view s_middle(" Logs: ");
-
-SyncError::SyncError(std::error_code error_code, std::string_view msg, bool is_fatal,
-                     std::optional<std::string_view> serverLog,
+SyncError::SyncError(Status orig_status, bool is_fatal, std::optional<std::string_view> server_log,
                      std::vector<sync::CompensatingWriteErrorInfo> compensating_writes)
-    : SystemError(error_code, serverLog ? util::format("%1%2%3", msg, s_middle, *serverLog) : std::string(msg))
+    : status(orig_status.code(), format_sync_error_message(orig_status, server_log))
     , is_fatal(is_fatal)
-    , simple_message(std::string_view(what(), msg.size()))
+    , simple_message(std::string_view(status.reason()).substr(0, orig_status.reason().size()))
     , compensating_writes_info(std::move(compensating_writes))
 {
-    if (serverLog) {
-        logURL = std::string_view(what() + msg.size() + s_middle.size(), serverLog->size());
+    if (server_log) {
+        logURL = std::string_view(status.reason()).substr(simple_message.size() + s_middle_part.size());
     }
-}
-
-bool SyncError::is_client_error() const
-{
-    return get_category() == realm::sync::client_error_category();
-}
-
-/// The error is a protocol error, which may either be connection-level or session-level.
-bool SyncError::is_connection_level_protocol_error() const
-{
-    if (get_category() != realm::sync::protocol_error_category()) {
-        return false;
-    }
-    return !realm::sync::is_session_level_error(static_cast<ProtocolError>(get_system_error().value()));
-}
-
-/// The error is a connection-level protocol error.
-bool SyncError::is_session_level_protocol_error() const
-{
-    if (get_category() != realm::sync::protocol_error_category()) {
-        return false;
-    }
-    return realm::sync::is_session_level_error(static_cast<ProtocolError>(get_system_error().value()));
 }
 
 /// The error indicates a client reset situation.
@@ -76,7 +62,7 @@ bool SyncError::is_client_reset_requested() const
         server_requests_action == sync::ProtocolErrorInfo::Action::ClientResetNoRecovery) {
         return true;
     }
-    if (get_system_error() == make_error_code(sync::Client::Error::auto_client_reset_failure)) {
+    if (status.get_std_error_code() == make_error_code(sync::Client::Error::auto_client_reset_failure)) {
         return true;
     }
     return false;

--- a/src/realm/sync/config.hpp
+++ b/src/realm/sync/config.hpp
@@ -51,6 +51,10 @@ struct SyncError {
     Status status;
 
     bool is_fatal;
+
+    // The following two string_view's are views into the reason string of the status member. Users of
+    // SyncError should take care not to modify the status if they are going to access these views into
+    // the reason string.
     // Just the minimal error message, without any log URL.
     std::string_view simple_message;
     // The URL to the associated server log if any. If not supplied by the server, this will be `empty()`.

--- a/src/realm/sync/config.hpp
+++ b/src/realm/sync/config.hpp
@@ -45,8 +45,10 @@ using port_type = std::uint_fast16_t;
 enum class ProtocolError;
 } // namespace sync
 
-struct SyncError : public SystemError {
+struct SyncError {
     enum class ClientResetModeAllowed { DoNotClientReset, RecoveryPermitted, RecoveryNotPermitted };
+
+    Status status;
 
     bool is_fatal;
     // Just the minimal error message, without any log URL.
@@ -68,24 +70,21 @@ struct SyncError : public SystemError {
     // that caused a compensating write and why the write was illegal.
     std::vector<sync::CompensatingWriteErrorInfo> compensating_writes_info;
 
-    SyncError(std::error_code error_code, std::string_view msg, bool is_fatal,
-              std::optional<std::string_view> serverLog = std::nullopt,
+    SyncError(Status status, bool is_fatal, std::optional<std::string_view> server_log = std::nullopt,
               std::vector<sync::CompensatingWriteErrorInfo> compensating_writes = {});
 
     static constexpr const char c_original_file_path_key[] = "ORIGINAL_FILE_PATH";
     static constexpr const char c_recovery_file_path_key[] = "RECOVERY_FILE_PATH";
 
-    /// The error is a client error, which applies to the client and all its sessions.
-    bool is_client_error() const;
-
-    /// The error is a protocol error, which may either be connection-level or session-level.
-    bool is_connection_level_protocol_error() const;
-
-    /// The error is a connection-level protocol error.
-    bool is_session_level_protocol_error() const;
-
     /// The error indicates a client reset situation.
     bool is_client_reset_requested() const;
+
+    // TODO Remove this temporary function after we've fully converted the sync codebase to using
+    // Status without std::error_code.
+    std::error_code get_system_error() const noexcept
+    {
+        return status.get_std_error_code();
+    }
 };
 
 using SyncSessionErrorHandler = void(std::shared_ptr<SyncSession>, SyncError);
@@ -167,8 +166,7 @@ struct SyncClientHookData {
 };
 
 struct SyncConfig {
-    struct FLXSyncEnabled {
-    };
+    struct FLXSyncEnabled {};
 
     struct ProxyConfig {
         using port_type = sync::port_type;

--- a/src/realm/sync/noinst/client_impl_base.cpp
+++ b/src/realm/sync/noinst/client_impl_base.cpp
@@ -560,7 +560,8 @@ bool Connection::websocket_closed_handler(bool was_clean, Status status)
         }
         case WebSocketError::websocket_tls_handshake_failed: {
             error_code = ClientError::ssl_server_cert_rejected;
-            close_due_to_client_side_error(std::move(status), IsFatal{false},
+            close_due_to_client_side_error(Status(ClientError::ssl_server_cert_rejected, status.reason()),
+                                           IsFatal{false},
                                            ConnectionTerminationReason::ssl_certificate_rejected); // Throws
             break;
         }

--- a/src/realm/sync/noinst/client_impl_base.hpp
+++ b/src/realm/sync/noinst/client_impl_base.hpp
@@ -566,6 +566,7 @@ private:
     void read_or_write_error(std::error_code ec, std::string_view msg);
     void close_due_to_protocol_error(std::error_code, std::optional<std::string_view> msg = std::nullopt);
 
+    void close_due_to_client_side_error(Status status, IsFatal is_fatal, ConnectionTerminationReason reason);
     void close_due_to_client_side_error(std::error_code, std::optional<std::string_view> msg, IsFatal is_fatal,
                                         ConnectionTerminationReason reason);
     void close_due_to_server_side_error(ProtocolError, const ProtocolErrorInfo& info);
@@ -1311,7 +1312,7 @@ inline void ClientImpl::Connection::voluntary_disconnect()
 {
     m_reconnect_info.update(ConnectionTerminationReason::closed_voluntarily, std::nullopt);
     constexpr bool try_again = true;
-    disconnect(SessionErrorInfo{ClientError::connection_closed, try_again}); // Throws
+    disconnect(SessionErrorInfo{Status{ClientError::connection_closed, "Connection closed"}, try_again}); // Throws
 }
 
 inline void ClientImpl::Connection::involuntary_disconnect(const SessionErrorInfo& info,

--- a/test/object-store/audit.cpp
+++ b/test/object-store/audit.cpp
@@ -1782,7 +1782,7 @@ TEST_CASE("audit integration tests", "[sync][pbs][audit][baas]") {
     SECTION("invalid metadata properties") {
         config.audit_config->metadata = {{"invalid key", "value"}};
         auto error = expect_error(config, generate_event);
-        REQUIRE_THAT(error.what(), StartsWith("Invalid schema change"));
+        REQUIRE_THAT(error.status.reason(), StartsWith("Invalid schema change"));
         REQUIRE(error.is_fatal);
     }
 
@@ -1815,7 +1815,7 @@ TEST_CASE("audit integration tests", "[sync][pbs][audit][baas]") {
         config.audit_config = std::make_shared<AuditConfig>();
 
         auto error = expect_error(config, generate_event);
-        REQUIRE_THAT(error.what(), StartsWith("Invalid schema change"));
+        REQUIRE_THAT(error.status.reason(), StartsWith("Invalid schema change"));
         REQUIRE(error.is_fatal);
     }
 
@@ -1890,7 +1890,7 @@ TEST_CASE("audit integration tests", "[sync][pbs][audit][baas]") {
         SECTION("auditing with a flexible sync user reports a sync error") {
             config.audit_config->audit_user = harness.app()->current_user();
             auto error = expect_error(config, generate_event);
-            REQUIRE_THAT(error.what(),
+            REQUIRE_THAT(error.status.reason(),
                          Catch::Matchers::ContainsSubstring(
                              "Client connected using partition-based sync when app is using flexible sync"));
             REQUIRE(error.is_fatal);

--- a/test/object-store/sync/app.cpp
+++ b/test/object-store/sync/app.cpp
@@ -2480,7 +2480,7 @@ TEST_CASE("app: sync integration", "[sync][pbs][app][baas]") {
                 return;
             }
             util::format(std::cerr, "An unexpected sync error was caught by the default SyncTestFile handler: '%1'\n",
-                         error.what());
+                         error.status);
             abort();
         };
 
@@ -2771,7 +2771,7 @@ TEST_CASE("app: sync integration", "[sync][pbs][app][baas]") {
                 sync_error_handler_called.store(true);
                 REQUIRE(error.get_system_error() ==
                         sync::make_error_code(realm::sync::ProtocolError::bad_authentication));
-                REQUIRE(error.reason() == "Unable to refresh the user access token.");
+                REQUIRE(error.status.reason() == "Unable to refresh the user access token.");
             };
             auto r = Realm::get_shared_realm(config);
             timed_wait_for([&] {
@@ -2871,7 +2871,7 @@ TEST_CASE("app: sync integration", "[sync][pbs][app][baas]") {
                 sync_error_handler_called.store(true);
                 REQUIRE(error.get_system_error() ==
                         sync::make_error_code(realm::sync::ProtocolError::bad_authentication));
-                REQUIRE(error.reason() == "Unable to refresh the user access token.");
+                REQUIRE(error.status.reason() == "Unable to refresh the user access token.");
             };
 
             auto transport = static_cast<SynchronousTestTransport*>(session.transport());
@@ -3101,8 +3101,9 @@ TEST_CASE("app: sync integration", "[sync][pbs][app][baas]") {
 
         auto error = wait_for_future(std::move(pf.future), std::chrono::minutes(5)).get();
         REQUIRE(error.get_system_error() == make_error_code(sync::ProtocolError::limits_exceeded));
-        REQUIRE(error.reason() == "Sync websocket closed because the server received a message that was too large: "
-                                  "read limited at 16777217 bytes");
+        REQUIRE(error.status.reason() ==
+                "Sync websocket closed because the server received a message that was too large: "
+                "read limited at 16777217 bytes");
         REQUIRE(error.is_client_reset_requested());
         REQUIRE(error.server_requests_action == sync::ProtocolErrorInfo::Action::ClientReset);
     }
@@ -3182,8 +3183,9 @@ TEST_CASE("app: sync integration", "[sync][pbs][app][baas]") {
             config.sync_config->partition_value = "not a bson serialized string";
             std::atomic<bool> error_did_occur = false;
             config.sync_config->error_handler = [&error_did_occur](std::shared_ptr<SyncSession>, SyncError error) {
-                CHECK(error.reason().find("Illegal Realm path (BIND): serialized partition 'not a bson serialized "
-                                          "string' is invalid") != std::string::npos);
+                CHECK(error.status.reason().find(
+                          "Illegal Realm path (BIND): serialized partition 'not a bson serialized "
+                          "string' is invalid") != std::string::npos);
                 error_did_occur.store(true);
             };
             auto r = Realm::get_shared_realm(config);
@@ -4833,18 +4835,18 @@ TEST_CASE("app: app destroyed during token refresh", "[sync][app][user][token]")
         // Ignore websocket errors, since sometimes a websocket connection gets started during the test
         config.sync_config->error_handler = [](std::shared_ptr<SyncSession> session, SyncError error) mutable {
             // Ignore websocket errors, since there's not really an app out there...
-            if (error.reason().find("Bad WebSocket") != std::string::npos ||
-                error.reason().find("Connection Failed") != std::string::npos ||
-                error.reason().find("user has been removed") != std::string::npos) {
+            if (error.status.reason().find("Bad WebSocket") != std::string::npos ||
+                error.status.reason().find("Connection Failed") != std::string::npos ||
+                error.status.reason().find("user has been removed") != std::string::npos) {
                 util::format(std::cerr,
                              "An expected possible WebSocket error was caught during test: 'app destroyed during "
                              "token refresh': '%1' for '%2'",
-                             error.what(), session->path());
+                             error.status, session->path());
             }
             else {
                 std::string err_msg(util::format("An unexpected sync error was caught during test: 'app destroyed "
                                                  "during token refresh': '%1' for '%2'",
-                                                 error.what(), session->path()));
+                                                 error.status, session->path()));
                 std::cerr << err_msg << std::endl;
                 throw std::runtime_error(err_msg);
             }

--- a/test/object-store/sync/flx_migration.cpp
+++ b/test/object-store/sync/flx_migration.cpp
@@ -231,7 +231,7 @@ TEST_CASE("Test server migration and rollback", "[sync][flx][flx migration][baas
         flx_config.sync_config->error_handler =
             [&logger_ptr, error_promise = std::move(promise)](std::shared_ptr<SyncSession>, SyncError err) mutable {
                 // This situation should return the switch_to_pbs error
-                logger_ptr->error("Server rolled back - connect as FLX received error: %1", err.reason());
+                logger_ptr->error("Server rolled back - connect as FLX received error: %1", err.status);
                 error_promise.get_promise().emplace_value(std::move(err));
             };
         auto flx_realm = Realm::get_shared_realm(flx_config);
@@ -691,7 +691,7 @@ TEST_CASE("Update to native FLX after migration", "[sync][flx][flx migration][ba
         flx_config.sync_config->error_handler =
             [&logger_ptr, error_promise = std::move(promise)](std::shared_ptr<SyncSession>, SyncError err) mutable {
                 // This situation should return the switch_to_pbs error
-                logger_ptr->error("Server rolled back - connect as FLX received error: %1", err.reason());
+                logger_ptr->error("Server rolled back - connect as FLX received error: %1", err.status);
                 error_promise.get_promise().emplace_value(std::move(err));
             };
         auto flx_realm = Realm::get_shared_realm(flx_config);

--- a/test/object-store/sync/session/session.cpp
+++ b/test/object-store/sync/session/session.cpp
@@ -402,7 +402,7 @@ TEST_CASE("sync: error handling", "[sync][session]") {
 
     SECTION("Doesn't treat unknown system errors as being fatal") {
         std::error_code code = std::error_code{EBADF, std::generic_category()};
-        sync::SessionErrorInfo err{code, "Not a real error message", true};
+        sync::SessionErrorInfo err{Status{code, "Not a real error message"}, true};
         err.server_requests_action = ProtocolErrorInfo::Action::Transient;
         SyncSession::OnlyForTesting::handle_error(*session, std::move(err));
         CHECK(!sessions_are_inactive(*session));
@@ -431,8 +431,8 @@ TEST_CASE("sync: error handling", "[sync][session]") {
             code = static_cast<int>(ProtocolError::diverging_histories);
         }
 
-        sync::SessionErrorInfo initial_error{std::error_code{code, realm::sync::protocol_error_category()},
-                                             "Something bad happened", true};
+        sync::SessionErrorInfo initial_error{
+            Status{std::error_code{code, realm::sync::protocol_error_category()}, "Something bad happened"}, true};
         initial_error.server_requests_action = ProtocolErrorInfo::Action::ClientReset;
         std::time_t just_before_raw = std::time(nullptr);
         SyncSession::OnlyForTesting::handle_error(*session, std::move(initial_error));
@@ -554,7 +554,7 @@ TEMPLATE_TEST_CASE("sync: stop policy behavior", "[sync][session]", RegularUser)
         SECTION("transitions to Inactive if a fatal error occurs") {
             std::error_code code =
                 std::error_code{static_cast<int>(ProtocolError::bad_syntax), realm::sync::protocol_error_category()};
-            sync::SessionErrorInfo err{code, "Not a real error message", false};
+            sync::SessionErrorInfo err{Status{code, "Not a real error message"}, false};
             err.server_requests_action = realm::sync::ProtocolErrorInfo::Action::ProtocolViolation;
             SyncSession::OnlyForTesting::handle_error(*session, std::move(err));
             CHECK(sessions_are_inactive(*session));
@@ -566,7 +566,7 @@ TEMPLATE_TEST_CASE("sync: stop policy behavior", "[sync][session]", RegularUser)
             // Fire a simulated *non-fatal* error.
             std::error_code code =
                 std::error_code{static_cast<int>(ProtocolError::other_error), realm::sync::protocol_error_category()};
-            sync::SessionErrorInfo err{code, "Not a real error message", true};
+            sync::SessionErrorInfo err{Status{code, "Not a real error message"}, true};
             err.server_requests_action = realm::sync::ProtocolErrorInfo::Action::Transient;
             SyncSession::OnlyForTesting::handle_error(*session, std::move(err));
             REQUIRE(session->state() == SyncSession::State::Dying);

--- a/test/object-store/sync/session/wait_for_completion.cpp
+++ b/test/object-store/sync/session/wait_for_completion.cpp
@@ -107,7 +107,7 @@ TEST_CASE("SyncSession: wait_for_download_completion() API", "[sync][pbs][sessio
         });
         REQUIRE(handler_called == false);
         // Now trigger an error
-        sync::SessionErrorInfo err{code, "Not a real error message", false};
+        sync::SessionErrorInfo err{Status{code, "Not a real error message"}, false};
         err.server_requests_action = sync::ProtocolErrorInfo::Action::ProtocolViolation;
         SyncSession::OnlyForTesting::handle_error(*session, std::move(err));
         EventLoop::main().run_until([&] {

--- a/test/object-store/util/test_file.cpp
+++ b/test/object-store/util/test_file.cpp
@@ -146,7 +146,7 @@ SyncTestFile::SyncTestFile(std::shared_ptr<SyncUser> user, bson::Bson partition,
     sync_config->stop_policy = SyncSessionStopPolicy::Immediately;
     sync_config->error_handler = [](std::shared_ptr<SyncSession>, SyncError error) {
         util::format(std::cerr, "An unexpected sync error was caught by the default SyncTestFile handler: '%1'\n",
-                     error.what());
+                     error.status);
         abort();
     };
     schema_version = 1;
@@ -175,7 +175,7 @@ SyncTestFile::SyncTestFile(std::shared_ptr<realm::SyncUser> user, realm::Schema 
     sync_config->error_handler = [](std::shared_ptr<SyncSession> session, SyncError error) {
         util::format(std::cerr,
                      "An unexpected sync error was caught by the default SyncTestFile handler: '%1' for '%2'",
-                     error.what(), session->path());
+                     error.status, session->path());
         abort();
     };
     schema_version = 1;

--- a/test/sync_fixtures.hpp
+++ b/test/sync_fixtures.hpp
@@ -593,7 +593,7 @@ public:
             if (state != ConnectionState::disconnected)
                 return;
             REALM_ASSERT(error_info);
-            std::error_code ec = error_info->error_code;
+            std::error_code ec = error_info->status.get_std_error_code();
             bool is_fatal = error_info->is_fatal();
             const std::string& detailed_message = error_info->message;
             handler(ec, is_fatal, detailed_message);
@@ -715,8 +715,8 @@ public:
                     return;
                 REALM_ASSERT(error);
                 unit_test::TestContext& test_context = m_test_context;
-                test_context.logger->error("Client disconnect: %1: %2 (is_fatal=%3)", error->error_code,
-                                           error->message, error->is_fatal());
+                test_context.logger->error("Client disconnect: %1: %2 (is_fatal=%3)",
+                                           error->status.get_std_error_code(), error->message, error->is_fatal());
                 bool client_error_occurred = true;
                 CHECK_NOT(client_error_occurred);
                 stop();
@@ -1081,7 +1081,7 @@ inline void RealmFixture::setup_error_handler(util::UniqueFunction<ErrorHandler>
         if (state != ConnectionState::disconnected)
             return;
         REALM_ASSERT(error_info);
-        std::error_code ec = error_info->error_code;
+        std::error_code ec = error_info->status.get_std_error_code();
         bool is_fatal = error_info->is_fatal();
         const std::string& detailed_message = error_info->message;
         handler(ec, is_fatal, detailed_message);

--- a/test/test_client_reset.cpp
+++ b/test/test_client_reset.cpp
@@ -152,7 +152,7 @@ TEST(ClientReset_NoLocalChanges)
                 if (state != ConnectionState::disconnected)
                     return;
                 REALM_ASSERT(error_info);
-                std::error_code ec = error_info->error_code;
+                std::error_code ec = error_info->status.get_std_error_code();
                 CHECK_EQUAL(ec, sync::ProtocolError::bad_server_version);
                 bowl.add_stone();
             };
@@ -601,7 +601,7 @@ TEST(ClientReset_ThreeClients)
                 if (state != ConnectionState::disconnected)
                     return;
                 REALM_ASSERT(error_info);
-                std::error_code ec = error_info->error_code;
+                std::error_code ec = error_info->status.get_std_error_code();
                 CHECK_EQUAL(ec, sync::ProtocolError::bad_server_version);
                 bowl.add_stone();
             };
@@ -775,7 +775,7 @@ TEST(ClientReset_DoNotRecoverSchema)
                 if (state != ConnectionState::disconnected)
                     return;
                 REALM_ASSERT(error_info);
-                std::error_code ec = error_info->error_code;
+                std::error_code ec = error_info->status.get_std_error_code();
                 CHECK_EQUAL(ec, sync::Client::Error::auto_client_reset_failure);
                 bowl.add_stone();
             });

--- a/test/test_sync.cpp
+++ b/test/test_sync.cpp
@@ -146,7 +146,7 @@ TEST(Sync_BadVirtualPath)
         if (state != ConnectionState::disconnected)
             return;
         REALM_ASSERT(error_info);
-        std::error_code ec = error_info->error_code;
+        std::error_code ec = error_info->status.get_std_error_code();
         bool is_fatal = error_info->is_fatal();
         CHECK_EQUAL(sync::ProtocolError::illegal_realm_path, ec);
         CHECK(is_fatal);
@@ -572,7 +572,7 @@ TEST(Sync_TokenWithoutExpirationAllowed)
             if (state != ConnectionState::disconnected)
                 return;
             REALM_ASSERT(error_info);
-            std::error_code ec = error_info->error_code;
+            std::error_code ec = error_info->status.get_std_error_code();
             CHECK(ec == sync::ProtocolError::token_expired || ec == sync::ProtocolError::bad_authentication ||
                   ec == sync::ProtocolError::permission_denied);
             did_fail = true;
@@ -785,7 +785,7 @@ struct ExpectChangesetError {
         if (!error_info)
             return;
         REALM_ASSERT(error_info);
-        std::error_code ec = error_info->error_code;
+        std::error_code ec = error_info->status.get_std_error_code();
         CHECK_EQUAL(ec, sync::Client::Error::bad_changeset);
         CHECK(ec.category() == client_error_category());
         CHECK(!error_info->is_fatal());
@@ -3884,7 +3884,7 @@ TEST(Sync_CancelReconnectDelay)
 
         BowlOfStonesSemaphore bowl;
         auto handler = [&](const SessionErrorInfo& info) {
-            if (CHECK_EQUAL(info.error_code, ProtocolError::connection_closed))
+            if (CHECK_EQUAL(info.status.get_std_error_code(), ProtocolError::connection_closed))
                 bowl.add_stone();
         };
         Session session = fixture.make_session(db, "/test");
@@ -3906,7 +3906,7 @@ TEST(Sync_CancelReconnectDelay)
 
         BowlOfStonesSemaphore bowl;
         auto handler = [&](const SessionErrorInfo& info) {
-            if (CHECK_EQUAL(info.error_code, ProtocolError::connection_closed))
+            if (CHECK_EQUAL(info.status.get_std_error_code(), ProtocolError::connection_closed))
                 bowl.add_stone();
         };
         Session session = fixture.make_session(db, "/test");
@@ -3929,7 +3929,7 @@ TEST(Sync_CancelReconnectDelay)
         {
             BowlOfStonesSemaphore bowl;
             auto handler = [&](const SessionErrorInfo& info) {
-                if (CHECK_EQUAL(info.error_code, ProtocolError::connection_closed))
+                if (CHECK_EQUAL(info.status.get_std_error_code(), ProtocolError::connection_closed))
                     bowl.add_stone();
             };
             Session session = fixture.make_session(db, "/test");
@@ -3965,7 +3965,7 @@ TEST(Sync_CancelReconnectDelay)
 
         BowlOfStonesSemaphore bowl;
         auto handler = [&](const SessionErrorInfo& info) {
-            if (CHECK_EQUAL(info.error_code, ProtocolError::illegal_realm_path))
+            if (CHECK_EQUAL(info.status.get_std_error_code(), ProtocolError::illegal_realm_path))
                 bowl.add_stone();
         };
         Session session = fixture.make_session(db, "/..");
@@ -3988,7 +3988,7 @@ TEST(Sync_CancelReconnectDelay)
 
         BowlOfStonesSemaphore bowl;
         auto handler = [&](const SessionErrorInfo& info) {
-            if (CHECK_EQUAL(info.error_code, ProtocolError::illegal_realm_path))
+            if (CHECK_EQUAL(info.status.get_std_error_code(), ProtocolError::illegal_realm_path))
                 bowl.add_stone();
         };
         Session session = fixture.make_session(db, "/..");
@@ -5172,9 +5172,9 @@ TEST_IF(Sync_SSL_Certificates, false)
                 CHECK(error_info);
                 client_logger->debug(
                     "State change: disconnected, error_code = %1, is_fatal = %2, detailed_message = %3",
-                    error_info->error_code, error_info->is_fatal(), error_info->message);
+                    error_info->status.get_std_error_code(), error_info->is_fatal(), error_info->message);
                 // We expect to get through the SSL handshake but will hit an error due to the wrong token.
-                CHECK_NOT_EQUAL(error_info->error_code, Client::Error::ssl_server_cert_rejected);
+                CHECK_NOT_EQUAL(error_info->status.get_std_error_code(), Client::Error::ssl_server_cert_rejected);
                 client.shutdown();
             }
         };
@@ -5248,7 +5248,7 @@ TEST(Sync_BadChangeset)
             if (state != ConnectionState::disconnected)
                 return;
             REALM_ASSERT(error_info);
-            std::error_code ec = error_info->error_code;
+            std::error_code ec = error_info->status.get_std_error_code();
             bool is_fatal = error_info->is_fatal();
             CHECK_EQUAL(sync::ProtocolError::bad_changeset, ec);
             CHECK(is_fatal);


### PR DESCRIPTION
## What, How & Why?
This is a transitional PR to make SyncError and sync::SessionErrorInfo aware of Status and use it instead of std::error_code to capture error information. Just in this PR all the actual errors are still `std::error_code` via the SystemError type, but this change lets me start to transition our various error types without having to change all our tests/call sites at once.

## ☑️ ToDos
* [x] 📝 Changelog update
* [x] 🚦 Tests (or not relevant)
* [ ] C-API, if public C++ API changed.
