### PR TITLE
Add missing [baas] tag that is causing failing tests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,6 @@
 
 ### Fixed
 * Trying to search a full-text indexes created as a result of an additive schema change (i.e. applying the differences between the local schema and a synchronized realm's schema) could have resulted in an IllegalOperation error with the error code `Column has no fulltext index`. ([PR #6823](https://github.com/realm/realm-core/pull/6823)).
-* None.
 
 ### Breaking changes
 * None.

--- a/evergreen/config.yml
+++ b/evergreen/config.yml
@@ -852,7 +852,7 @@ tasks:
   commands:
   - func: "launch remote baas"
     vars:
-      baas_branch: 1a0d1c021460d2215b21bc4f7c7f668714ce81c7
+      baas_branch: 2ca95f7d44d81527227854a476351200c91fcad2
   - func: "compile"
     vars:
       target_to_build: ObjectStoreTests

--- a/evergreen/config.yml
+++ b/evergreen/config.yml
@@ -852,7 +852,7 @@ tasks:
   commands:
   - func: "launch remote baas"
     vars:
-      baas_branch: 2ca95f7d44d81527227854a476351200c91fcad2
+      baas_branch: 874421612788cf71b3edf2981ad63ed4699705b9
   - func: "compile"
     vars:
       target_to_build: ObjectStoreTests

--- a/evergreen/config.yml
+++ b/evergreen/config.yml
@@ -852,7 +852,7 @@ tasks:
   commands:
   - func: "launch remote baas"
     vars:
-      baas_branch: 2ca95f7d44d81527227854a476351200c91fcad2
+      baas_branch: 1a0d1c021460d2215b21bc4f7c7f668714ce81c7
   - func: "compile"
     vars:
       target_to_build: ObjectStoreTests

--- a/evergreen/config.yml
+++ b/evergreen/config.yml
@@ -852,7 +852,7 @@ tasks:
   commands:
   - func: "launch remote baas"
     vars:
-      baas_branch: 874421612788cf71b3edf2981ad63ed4699705b9
+      baas_branch: 2ca95f7d44d81527227854a476351200c91fcad2
   - func: "compile"
     vars:
       target_to_build: ObjectStoreTests

--- a/test/object-store/sync/app.cpp
+++ b/test/object-store/sync/app.cpp
@@ -3518,7 +3518,7 @@ TEMPLATE_TEST_CASE("app: partition types", "[sync][pbs][app][partition][baas]", 
     }
 }
 
-TEST_CASE("app: full-text compatible with sync", "[sync][app]") {
+TEST_CASE("app: full-text compatible with sync", "[sync][app][baas]") {
     std::string base_url = get_base_url();
     const std::string valid_pk_name = "_id";
     REQUIRE(!base_url.empty());


### PR DESCRIPTION
## What, How & Why?
A new test that was added in PR #6823 was missing the `"[baas]"` tag and was not being run against the baas server during the Evergreen CI tests. (I didn't see that this test was added when merging and missed adding the tag.)

## ☑️ ToDos
* ~~[ ] 📝 Changelog update~~
* ~~[ ] 🚦 Tests (or not relevant)~~
* ~~[ ] C-API, if public C++ API changed.~~
