### PR TITLE
Handle uploading logs in evg tasks on feature branches

### DIFF
--- a/evergreen/config.yml
+++ b/evergreen/config.yml
@@ -292,7 +292,7 @@ functions:
       aws_key: '${artifacts_aws_access_key}'
       aws_secret: '${artifacts_aws_secret_key}'
       local_file: 'realm-core/baas-work-dir/baas_server.log'
-      remote_file: '${project}/${branch_name}/${task_id}/${execution}/baas_server.log'
+      remote_file: 'realm-core-stable/${branch_name}/${task_id}/${execution}/baas_server.log'
       bucket: mciuploads
       permissions: public-read
       content_type: text/text
@@ -303,7 +303,7 @@ functions:
       aws_key: '${artifacts_aws_access_key}'
       aws_secret: '${artifacts_aws_secret_key}'
       local_file: 'realm-core/install_baas_output.log'
-      remote_file: '${project}/${branch_name}/${task_id}/${execution}/install_baas_output.log'
+      remote_file: 'realm-core-stable/${branch_name}/${task_id}/${execution}/install_baas_output.log'
       bucket: mciuploads
       permissions: public-read
       content_type: text/text
@@ -314,7 +314,7 @@ functions:
       aws_key: '${artifacts_aws_access_key}'
       aws_secret: '${artifacts_aws_secret_key}'
       local_file: 'realm-core/baas-work-dir/mongodb-dbpath/mongod.log'
-      remote_file: '${project}/${branch_name}/${task_id}/${execution}/mongod.log'
+      remote_file: 'realm-core-stable/${branch_name}/${task_id}/${execution}/mongod.log'
       bucket: mciuploads
       permissions: public-read
       content_type: text/text


### PR DESCRIPTION
## What, How & Why?
This just updates the evergreen config so object store tests don't fail on branches besides master. If you aren't on the "main" branch of the evergreen project it doesn't fill in the `${project}` expansion which causes our s3 upload paths to be invalid. Since we now only have one evergreen project I think its safe to hardcode these paths and just rely on the `${branch}` expansion to differentiate between branches. For an example of how this could fail you can look at this [patch failure](https://spruce.mongodb.com/task/__feature_sync_error_unification_macos_1100_arm64_object_store_tests_patch_fdf34f4795d83fb79a6a9aac3b6ccdd852685129_64bfeaace3c331fa1e4a1ffd_23_07_25_15_30_54/logs?execution=1).

## ☑️ ToDos
* [ ] 📝 Changelog update
* [ ] 🚦 Tests (or not relevant)
* [ ] C-API, if public C++ API changed.
