### PR TITLE
Sync progress for download messages from server state is updated wrongly

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 
 ### Fixed
 * Trying to search a full-text indexes created as a result of an additive schema change (i.e. applying the differences between the local schema and a synchronized realm's schema) could have resulted in an IllegalOperation error with the error code `Column has no fulltext index`. ([PR #6823](https://github.com/realm/realm-core/pull/6823)).
+* Sync progress for DOWNLOAD messages from server state was updated wrongly. This may have resulted in an extra round-trip to the server. ([#6827](https://github.com/realm/realm-core/issues/6827), since v12.9.0)
 
 ### Breaking changes
 * None.

--- a/src/realm/sync/noinst/client_history_impl.cpp
+++ b/src/realm/sync/noinst/client_history_impl.cpp
@@ -454,11 +454,14 @@ void ClientHistory::integrate_server_changesets(
             update_sync_progress(progress, downloadable_bytes, transact); // Throws
         }
         // Always update progress for download messages from steady state.
-        else if (batch_state == DownloadBatchState::SteadyState) {
+        else if (batch_state == DownloadBatchState::SteadyState && !changesets_to_integrate.empty()) {
             auto partial_progress = progress;
             partial_progress.download.server_version = last_changeset.remote_version;
             partial_progress.download.last_integrated_client_version = last_changeset.last_integrated_local_version;
             update_sync_progress(partial_progress, downloadable_bytes, transact); // Throws
+        }
+        else if (batch_state == DownloadBatchState::SteadyState && changesets_to_integrate.empty()) {
+            update_sync_progress(progress, downloadable_bytes, transact); // Throws
         }
         if (run_in_write_tr) {
             run_in_write_tr(transact, changesets_for_cb);

--- a/src/realm/sync/noinst/client_impl_base.cpp
+++ b/src/realm/sync/noinst/client_impl_base.cpp
@@ -2353,8 +2353,11 @@ void Session::receive_download_message(const SyncProgress& progress, std::uint_f
     for (const Transformer::RemoteChangeset& changeset : received_changesets) {
         // Check that per-changeset server version is strictly increasing, except in FLX sync where the server version
         // must be increasing, but can stay the same during bootstraps.
-        bool good_server_version = m_is_flx_sync_session ? (changeset.remote_version >= server_version)
-                                                         : (changeset.remote_version > server_version);
+        bool good_server_version = m_is_flx_sync_session
+                                       ? (changeset.remote_version >= server_version &&
+                                          changeset.remote_version <= progress.download.server_version)
+                                       : (changeset.remote_version > server_version &&
+                                          changeset.remote_version < progress.download.server_version);
         if (!good_server_version) {
             logger.error("Bad server version in changeset header (DOWNLOAD) (%1, %2, %3)", changeset.remote_version,
                          server_version, progress.download.server_version);

--- a/src/realm/sync/noinst/client_impl_base.cpp
+++ b/src/realm/sync/noinst/client_impl_base.cpp
@@ -2353,11 +2353,10 @@ void Session::receive_download_message(const SyncProgress& progress, std::uint_f
     for (const Transformer::RemoteChangeset& changeset : received_changesets) {
         // Check that per-changeset server version is strictly increasing, except in FLX sync where the server version
         // must be increasing, but can stay the same during bootstraps.
-        bool good_server_version = m_is_flx_sync_session
-                                       ? (changeset.remote_version >= server_version &&
-                                          changeset.remote_version <= progress.download.server_version)
-                                       : (changeset.remote_version > server_version &&
-                                          changeset.remote_version < progress.download.server_version);
+        bool good_server_version = m_is_flx_sync_session ? (changeset.remote_version >= server_version)
+                                                         : (changeset.remote_version > server_version);
+        // Each server version cannot be greater than the one in the header of the download message.
+        good_server_version = good_server_version && (changeset.remote_version <= progress.download.server_version);
         if (!good_server_version) {
             logger.error("Bad server version in changeset header (DOWNLOAD) (%1, %2, %3)", changeset.remote_version,
                          server_version, progress.download.server_version);

--- a/src/realm/sync/noinst/client_impl_base.hpp
+++ b/src/realm/sync/noinst/client_impl_base.hpp
@@ -949,7 +949,7 @@ private:
     ///
     /// The synchronization progress passed to
     /// ClientReplication::integrate_server_changesets() must be obtained
-    /// by calling get_sync_progress(), and that call must occur after the last
+    /// by calling get_status(), and that call must occur after the last
     /// invocation of initiate_integrate_changesets() whose changesets are
     /// included in what is passed to
     /// ClientReplication::integrate_server_changesets().

--- a/test/test_sync.cpp
+++ b/test/test_sync.cpp
@@ -6650,7 +6650,7 @@ TEST(Sync_NonIncreasingServerVersions)
         return ++timestamp;
     });
 
-    auto latest_local_verson = [&] {
+    auto latest_local_version = [&] {
         auto tr = db->start_write();
         tr->add_table_with_primary_key("class_foo", type_String, "_id")->add_column(type_Int, "int_col");
         return tr->commit();
@@ -6660,7 +6660,7 @@ TEST(Sync_NonIncreasingServerVersions)
     auto prep_changeset = [&](auto pk_name, auto int_col_val) {
         Changeset changeset;
         changeset.version = 10;
-        changeset.last_integrated_remote_version = latest_local_verson - 1;
+        changeset.last_integrated_remote_version = latest_local_version - 1;
         changeset.origin_timestamp = ++timestamp;
         changeset.origin_file_ident = 1;
         instr::PrimaryKey pk{changeset.intern_string(pk_name)};
@@ -6700,7 +6700,7 @@ TEST(Sync_NonIncreasingServerVersions)
 
     SyncProgress progress = {};
     progress.download.server_version = server_changesets.back().version;
-    progress.download.last_integrated_client_version = latest_local_verson - 1;
+    progress.download.last_integrated_client_version = latest_local_version - 1;
     progress.latest_server_version.version = server_changesets.back().version;
     progress.latest_server_version.salt = 0x7876543217654321;
 
@@ -6801,7 +6801,7 @@ TEST(Sync_SetAndGetEmptyReciprocalChangeset)
         return ++timestamp;
     });
 
-    auto latest_local_verson = [&] {
+    auto latest_local_version = [&] {
         auto tr = db->start_write();
         // Create schema: single table with array of ints as property.
         tr->add_table_with_primary_key("class_table", type_Int, "_id")->add_column_list(type_Int, "ints");
@@ -6834,7 +6834,7 @@ TEST(Sync_SetAndGetEmptyReciprocalChangeset)
     instr.prior_size = 8;
     changeset.push_back(instr);
     changeset.version = 1;
-    changeset.last_integrated_remote_version = latest_local_verson - 1;
+    changeset.last_integrated_remote_version = latest_local_version - 1;
     changeset.origin_timestamp = timestamp;
     changeset.origin_file_ident = 2;
 
@@ -6847,7 +6847,7 @@ TEST(Sync_SetAndGetEmptyReciprocalChangeset)
 
     SyncProgress progress = {};
     progress.download.server_version = changeset.version;
-    progress.download.last_integrated_client_version = latest_local_verson - 1;
+    progress.download.last_integrated_client_version = latest_local_version - 1;
     progress.latest_server_version.version = changeset.version;
     progress.latest_server_version.salt = 0x7876543217654321;
 
@@ -6859,7 +6859,7 @@ TEST(Sync_SetAndGetEmptyReciprocalChangeset)
                                         DownloadBatchState::SteadyState, logger, transact);
 
     bool is_compressed = false;
-    auto data = history.get_reciprocal_transform(latest_local_verson, is_compressed);
+    auto data = history.get_reciprocal_transform(latest_local_version, is_compressed);
     Changeset reciprocal_changeset;
     ChunkedBinaryInputStream in{data};
     if (is_compressed) {
@@ -6957,6 +6957,67 @@ TEST(Sync_TransformAgainstEmptyReciprocalChangeset)
     group_1.verify();
     group_2.verify();
     CHECK(compare_groups(rt_1, rt_2));
+}
+
+TEST(Sync_ServerVersionsSkippedFromDownloadCursor)
+{
+    TEST_CLIENT_DB(db);
+
+    auto& history = get_history(db);
+    history.set_client_file_ident(SaltedFileIdent{2, 0x1234567812345678}, false);
+    timestamp_type timestamp{1};
+    history.set_local_origin_timestamp_source([&] {
+        return ++timestamp;
+    });
+
+    auto latest_local_version = [&] {
+        auto tr = db->start_write();
+        tr->add_table_with_primary_key("class_foo", type_String, "_id")->add_column(type_Int, "int_col");
+        return tr->commit();
+    }();
+
+    Changeset server_changeset;
+    server_changeset.version = 10;
+    server_changeset.last_integrated_remote_version = latest_local_version - 1;
+    server_changeset.origin_timestamp = ++timestamp;
+    server_changeset.origin_file_ident = 1;
+
+    std::vector<ChangesetEncoder::Buffer> encoded;
+    std::vector<Transformer::RemoteChangeset> server_changesets_encoded;
+    encoded.emplace_back();
+    encode_changeset(server_changeset, encoded.back());
+    server_changesets_encoded.emplace_back(server_changeset.version, server_changeset.last_integrated_remote_version,
+                                           BinaryData(encoded.back().data(), encoded.back().size()),
+                                           server_changeset.origin_timestamp, server_changeset.origin_file_ident);
+
+    SyncProgress progress = {};
+    // The server skips 10 server versions.
+    progress.download.server_version = server_changeset.version + 10;
+    progress.download.last_integrated_client_version = latest_local_version - 1;
+    progress.latest_server_version.version = server_changeset.version + 15;
+    progress.latest_server_version.salt = 0x7876543217654321;
+
+    uint_fast64_t downloadable_bytes = 0;
+    VersionInfo version_info;
+    util::StderrLogger logger;
+    auto transact = db->start_read();
+    history.integrate_server_changesets(progress, &downloadable_bytes, server_changesets_encoded, version_info,
+                                        DownloadBatchState::SteadyState, logger, transact);
+
+    version_type current_version;
+    SaltedFileIdent file_ident;
+    SyncProgress expected_progress;
+    history.get_status(current_version, file_ident, expected_progress);
+
+    // Check progress is reported correctly.
+    CHECK_EQUAL(progress.latest_server_version.salt, expected_progress.latest_server_version.salt);
+    CHECK_EQUAL(progress.latest_server_version.version, expected_progress.latest_server_version.version);
+    CHECK_EQUAL(progress.download.last_integrated_client_version,
+                expected_progress.download.last_integrated_client_version);
+    CHECK_EQUAL(progress.download.server_version, expected_progress.download.server_version);
+    CHECK_EQUAL(progress.upload.client_version, expected_progress.upload.client_version);
+    CHECK_EQUAL(progress.upload.last_integrated_server_version,
+                expected_progress.upload.last_integrated_server_version);
 }
 
 } // unnamed namespace


### PR DESCRIPTION
## What, How & Why?
We report partial progress for download messages from state when the sync client decides to split such a message if it's too large. The partial progress is the download cursor of the last changeset in that chunk. This happens for all chunks. But the last chunk should report the download cursor of the message (not the last changeset). Sometimes the download cursor of last changeset is not the same as the download cursor of the message (i.e, server skips versions). This may result in an extra  round-trip to the server to receive and ack the skipped versions.

Fixes #6827.

## ☑️ ToDos
* [x] 📝 Changelog update
* [x] 🚦 Tests (or not relevant)
* [ ] ~~C-API, if public C++ API changed.~~
