### PR TITLE
Add macCatalyst to the platforms which link Foundation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 ### Fixed
 * <How do the end-user experience this issue? what was the impact?> ([#????](https://github.com/realm/realm-core/issues/????), since v?.?.?)
 * Fix failed assertion for unknown app server errors ([#6758](https://github.com/realm/realm-core/issues/6758), since v12.9.0).
+* The Swift package failed to link required libraries when building for macCatalyst.
 
 ### Breaking changes
 * None.

--- a/Package.swift
+++ b/Package.swift
@@ -426,8 +426,8 @@ let package = Package(
             linkerSettings: [
                 .linkedLibrary("compression"),
                 .linkedLibrary("z"),
-                .linkedFramework("Foundation", .when(platforms: [.macOS, .iOS, .tvOS, .watchOS])),
-                .linkedFramework("Security", .when(platforms: [.macOS, .iOS, .tvOS, .watchOS])),
+                .linkedFramework("Foundation", .when(platforms: [.macOS, .iOS, .tvOS, .watchOS, .macCatalyst])),
+                .linkedFramework("Security", .when(platforms: [.macOS, .iOS, .tvOS, .watchOS, .macCatalyst])),
             ]),
         .target(
             name: "RealmQueryParser",


### PR DESCRIPTION
This is required when SPM decides to link core as a dynamic library. It normally doesn't, but we now have tests which try to hit every possible configuration.