### PR TITLE
Add pause_async to SyncSession

### DIFF
--- a/src/realm/object-store/sync/impl/sync_client.hpp
+++ b/src/realm/object-store/sync/impl/sync_client.hpp
@@ -132,6 +132,18 @@ struct SyncClient {
         m_client.wait_for_session_terminations_or_client_stopped();
     }
 
+    void notify_session_terminated(util::UniqueFunction<void()> callback)
+    {
+        m_client.post([callback = std::move(callback)](Status status) {
+            if (status == ErrorCodes::OperationAborted)
+                return;
+            else if (!status.is_ok())
+                throw Exception(status);
+
+            callback();
+        });
+    }
+
     ~SyncClient() {}
 
 private:

--- a/src/realm/object-store/sync/impl/sync_client.hpp
+++ b/src/realm/object-store/sync/impl/sync_client.hpp
@@ -132,20 +132,10 @@ struct SyncClient {
         m_client.wait_for_session_terminations_or_client_stopped();
     }
 
+    // Async version of wait_for_session_terminations().
     util::Future<void> notify_session_terminated()
     {
-        auto pf = util::make_promise_future<void>();
-        m_client.post([promise = std::move(pf.promise)](Status status) mutable {
-            // Includes operation_aborted
-            if (!status.is_ok()) {
-                promise.set_error(status);
-                return;
-            }
-
-            promise.emplace_value();
-        });
-
-        return std::move(pf.future);
+        return m_client.notify_session_terminated();
     }
 
     ~SyncClient() {}

--- a/src/realm/object-store/sync/sync_session.cpp
+++ b/src/realm/object-store/sync/sync_session.cpp
@@ -1217,7 +1217,7 @@ void SyncSession::shutdown_and_wait()
     m_client.wait_for_session_terminations();
 }
 
-void SyncSession::shutdown(CloseCallback&& callback)
+util::Future<void> SyncSession::shutdown()
 {
     {
         util::CheckedUniqueLock lock(m_state_mutex);
@@ -1225,7 +1225,7 @@ void SyncSession::shutdown(CloseCallback&& callback)
             become_inactive(std::move(lock));
         }
     }
-    m_client.notify_session_terminated(std::move(callback));
+    return m_client.notify_session_terminated();
 }
 
 void SyncSession::update_access_token(const std::string& signed_token)

--- a/src/realm/object-store/sync/sync_session.cpp
+++ b/src/realm/object-store/sync/sync_session.cpp
@@ -1220,6 +1220,11 @@ void SyncSession::shutdown_and_wait()
 util::Future<void> SyncSession::shutdown()
 {
     {
+        // Transition immediately to `inactive` state. Calling this function must guarantee that any
+        // sync::Session object in SyncSession::m_session that existed prior to the time of invocation
+        // must have been destroyed upon return. This allows the caller to follow up with a call to
+        // sync::Client::notify_session_terminated() in order to be notified when the Realm file is closed. This works
+        // so long as this SyncSession object remains in the `inactive` state after the invocation of shutdown().
         util::CheckedUniqueLock lock(m_state_mutex);
         if (m_state != State::Inactive && m_state != State::Paused) {
             become_inactive(std::move(lock));

--- a/src/realm/object-store/sync/sync_session.hpp
+++ b/src/realm/object-store/sync/sync_session.hpp
@@ -118,11 +118,11 @@ public:
         Connected,
     };
 
-    using StateChangeCallback = void(State old_state, State new_state);
     using ConnectionStateChangeCallback = void(ConnectionState old_state, ConnectionState new_state);
     using TransactionCallback = void(VersionID old_version, VersionID new_version);
     using ProgressNotifierCallback = _impl::SyncProgressNotifier::ProgressNotifierCallback;
     using ProgressDirection = _impl::SyncProgressNotifier::NotifierType;
+    using CloseCallback = util::UniqueFunction<void()>;
 
     ~SyncSession();
     State state() const REQUIRES(!m_state_mutex);
@@ -215,6 +215,10 @@ public:
     // Shut down the synchronization session (sync::Session) and wait for the Realm file to no
     // longer be open on behalf of it.
     void shutdown_and_wait() REQUIRES(!m_state_mutex, !m_connection_state_mutex);
+
+    // Get notified asynchronously when the synchronization session (sync::Session) is shut down and
+    // the Realm file is no longer open on behalf of it.
+    void shutdown(CloseCallback&&) REQUIRES(!m_state_mutex, !m_connection_state_mutex);
 
     // DO NOT CALL OUTSIDE OF TESTING CODE.
     void detach_from_sync_manager() REQUIRES(!m_state_mutex, !m_connection_state_mutex);

--- a/src/realm/object-store/sync/sync_session.hpp
+++ b/src/realm/object-store/sync/sync_session.hpp
@@ -26,6 +26,7 @@
 #include <realm/sync/subscriptions.hpp>
 
 #include <realm/util/checked_mutex.hpp>
+#include <realm/util/future.hpp>
 #include <realm/util/optional.hpp>
 #include <realm/version_id.hpp>
 
@@ -122,7 +123,6 @@ public:
     using TransactionCallback = void(VersionID old_version, VersionID new_version);
     using ProgressNotifierCallback = _impl::SyncProgressNotifier::ProgressNotifierCallback;
     using ProgressDirection = _impl::SyncProgressNotifier::NotifierType;
-    using CloseCallback = util::UniqueFunction<void()>;
 
     ~SyncSession();
     State state() const REQUIRES(!m_state_mutex);
@@ -218,7 +218,7 @@ public:
 
     // Get notified asynchronously when the synchronization session (sync::Session) is shut down and
     // the Realm file is no longer open on behalf of it.
-    void shutdown(CloseCallback&&) REQUIRES(!m_state_mutex, !m_connection_state_mutex);
+    util::Future<void> shutdown() REQUIRES(!m_state_mutex, !m_connection_state_mutex);
 
     // DO NOT CALL OUTSIDE OF TESTING CODE.
     void detach_from_sync_manager() REQUIRES(!m_state_mutex, !m_connection_state_mutex);

--- a/src/realm/sync/client.cpp
+++ b/src/realm/sync/client.cpp
@@ -1191,8 +1191,10 @@ util::Future<std::string> SessionImpl::send_test_command(std::string body)
 
     get_client().post([this, promise = std::move(pf.promise), body = std::move(body)](Status status) mutable {
         // Includes operation_aborted
-        if (!status.is_ok())
+        if (!status.is_ok()) {
             promise.set_error(status);
+            return;
+        }
 
         auto id = ++m_last_pending_test_command_ident;
         m_pending_test_commands.push_back(PendingTestCommand{id, std::move(body), std::move(promise)});

--- a/src/realm/sync/client.cpp
+++ b/src/realm/sync/client.cpp
@@ -2125,6 +2125,10 @@ bool Client::wait_for_session_terminations_or_client_stopped()
     return m_impl.get()->wait_for_session_terminations_or_client_stopped();
 }
 
+void Client::post(realm::sync::SyncSocketProvider::FunctionHandler&& handler)
+{
+    m_impl.get()->post(std::move(handler));
+}
 
 bool Client::decompose_server_url(const std::string& url, ProtocolEnvelope& protocol, std::string& address,
                                   port_type& port, std::string& path) const

--- a/src/realm/sync/client.hpp
+++ b/src/realm/sync/client.hpp
@@ -13,6 +13,7 @@
 #include <realm/util/functional.hpp>
 #include <realm/util/future.hpp>
 #include <realm/sync/client_base.hpp>
+#include <realm/sync/socket_provider.hpp>
 
 namespace realm::sync {
 
@@ -40,13 +41,6 @@ public:
     Client(Client&&) noexcept;
     ~Client() noexcept;
 
-    /// Run the internal event-loop of the client. At most one thread may
-    /// execute run() at any given time. The call will not return until somebody
-    /// calls stop().
-    void run() noexcept;
-
-    /// See run().
-    ///
     /// Thread-safe.
     void shutdown() noexcept;
 
@@ -101,6 +95,8 @@ public:
     /// Note: These functions are fully thread-safe. That is, they may be called
     /// by any thread, and by multiple threads concurrently.
     bool wait_for_session_terminations_or_client_stopped();
+
+    void post(SyncSocketProvider::FunctionHandler&& handler);
 
     /// Returns false if the specified URL is invalid.
     bool decompose_server_url(const std::string& url, ProtocolEnvelope& protocol, std::string& address,

--- a/src/realm/sync/client.hpp
+++ b/src/realm/sync/client.hpp
@@ -96,7 +96,8 @@ public:
     /// by any thread, and by multiple threads concurrently.
     bool wait_for_session_terminations_or_client_stopped();
 
-    void post(SyncSocketProvider::FunctionHandler&& handler);
+    /// Async version of wait_for_session_terminations_or_client_stopped().
+    util::Future<void> notify_session_terminated();
 
     /// Returns false if the specified URL is invalid.
     bool decompose_server_url(const std::string& url, ProtocolEnvelope& protocol, std::string& address,

--- a/src/realm/sync/client.hpp
+++ b/src/realm/sync/client.hpp
@@ -13,7 +13,6 @@
 #include <realm/util/functional.hpp>
 #include <realm/util/future.hpp>
 #include <realm/sync/client_base.hpp>
-#include <realm/sync/socket_provider.hpp>
 
 namespace realm::sync {
 

--- a/src/realm/sync/noinst/client_impl_base.hpp
+++ b/src/realm/sync/noinst/client_impl_base.hpp
@@ -234,6 +234,8 @@ public:
 
     void cancel_reconnect_delay();
     bool wait_for_session_terminations_or_client_stopped();
+    // Async version of wait_for_session_terminations_or_client_stopped().
+    util::Future<void> notify_session_terminated();
     void voluntary_disconnect_all_connections();
 
 private:

--- a/test/object-store/sync/session/session.cpp
+++ b/test/object-store/sync/session/session.cpp
@@ -338,7 +338,7 @@ TEST_CASE("SyncSession: shutdown_and_wait() API", "[sync][session]") {
     }
 }
 
-TEST_CASE("SyncSession: shutdown() API", "[sync][session]") {
+TEST_CASE("SyncSession: internal pause_async API", "[sync][session]") {
     TestSyncManager init_sync_manager;
     auto app = init_sync_manager.app();
     auto user = app->sync_manager()->get_user("close-api-tests-user", ENCODE_FAKE_JWT("fake_refresh_token"),
@@ -353,7 +353,7 @@ TEST_CASE("SyncSession: shutdown() API", "[sync][session]") {
     REQUIRE(sessions_are_active(*session));
     auto dbref = SyncSession::OnlyForTesting::get_db(*session);
     auto before = dbref.use_count();
-    auto future = session->shutdown();
+    auto future = SyncSession::OnlyForTesting::pause_async(*session);
     future.get();
     auto after = dbref.use_count();
     // Check SessionImpl released the sync agent as result of SessionWrapper::finalize() being called.

--- a/test/object-store/sync/session/session.cpp
+++ b/test/object-store/sync/session/session.cpp
@@ -351,12 +351,8 @@ TEST_CASE("SyncSession: shutdown() API", "[sync][session]") {
         return sessions_are_active(*session);
     });
     REQUIRE(sessions_are_active(*session));
-    auto done_pf = util::make_promise_future<void>();
-    SyncSession::CloseCallback cb = [promise = std::move(done_pf.promise)]() mutable {
-        promise.emplace_value();
-    };
-    session->shutdown(std::move(cb));
-    done_pf.future.get();
+    auto future = session->shutdown();
+    future.get();
 }
 
 TEST_CASE("SyncSession: update_configuration()", "[sync][session]") {

--- a/test/object-store/sync/session/session.cpp
+++ b/test/object-store/sync/session/session.cpp
@@ -359,7 +359,7 @@ TEST_CASE("SyncSession: shutdown() API", "[sync][session]") {
     // Check SessionImpl released the sync agent as result of SessionWrapper::finalize() being called.
     REQUIRE_NOTHROW(dbref->claim_sync_agent());
     // Check DBRef is released in SessionWrapper::finalize().
-    REQUIRE(after == before - 1);
+    REQUIRE(after < before);
 }
 
 TEST_CASE("SyncSession: update_configuration()", "[sync][session]") {


### PR DESCRIPTION
## What, How & Why?
The SyncSession has a `pause` API which shuts down the synchronization session (sync::Session), but there is no way to know when the Realm file is no longer open on behalf of it.
This PR adds a `pause_async` API (hidden from the public api currently) which returns a Future the users can use to get notified when the realm file is no longer open on behalf of the session.

Fixes #6841.

## ☑️ ToDos
* ~~[ ] 📝 Changelog update~~
* [X] 🚦 Tests (or not relevant)
* ~~[ ] C-API, if public C++ API changed.~~
