### PR TITLE
Only allow system_clock timepoints when creating a Timestamp

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,7 +17,7 @@
 -----------
 
 ### Internals
-* None.
+* Timestamp objects can now only be created from a system clock timepoint. ([#6112](https://github.com/realm/realm-core/issues/6112))
 
 ----------------------------------------------
 

--- a/src/realm/timestamp.hpp
+++ b/src/realm/timestamp.hpp
@@ -80,8 +80,7 @@ public:
     constexpr Timestamp(const Timestamp&) = default;
     constexpr Timestamp& operator=(const Timestamp&) = default;
 
-    template <typename C = std::chrono::system_clock, typename D = typename C::duration>
-    constexpr Timestamp(std::chrono::time_point<C, D> tp)
+    constexpr Timestamp(std::chrono::time_point<std::chrono::system_clock, std::chrono::system_clock::duration> tp)
         : m_is_null(false)
     {
         int64_t native_nano = std::chrono::duration_cast<std::chrono::nanoseconds>(tp.time_since_epoch()).count();

--- a/test/test_object_id.cpp
+++ b/test/test_object_id.cpp
@@ -264,7 +264,7 @@ TEST(ObjectId_PrimaryKey)
 {
     SHARED_GROUP_TEST_PATH(path);
     DBRef db = DB::create(path);
-    Timestamp now{std::chrono::steady_clock::now()};
+    Timestamp now{std::chrono::system_clock::now()};
     ObjectId id{now, 0, 0};
     ObjKey key;
     {
@@ -314,7 +314,7 @@ TEST_TYPES(ObjectId_Query, WithIndex, WithoutIndex)
 {
     SHARED_GROUP_TEST_PATH(path);
     DBRef db = DB::create(path);
-    auto now = std::chrono::steady_clock::now();
+    auto now = std::chrono::system_clock::now();
     ObjectId t0;
     ObjectId t25;
     ObjectId alternative_id("000004560000000000170232");


### PR DESCRIPTION
## What, How & Why?
Fixes #6112 

## ☑️ ToDos
* [x] 📝 Changelog update
* [x] 🚦 Tests (or not relevant)
* [x] C-API, if public C++ API changed.
