### PR TITLE
Add schema version to flexible sync client BIND message

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,7 +17,7 @@
 -----------
 
 ### Internals
-* None.
+* Add schema version to flexible sync client BIND message. ([#6840](https://github.com/realm/realm-core/issues/6840))
 
 ----------------------------------------------
 

--- a/src/realm/sync/client.hpp
+++ b/src/realm/sync/client.hpp
@@ -352,6 +352,8 @@ public:
         std::function<SyncClientHookAction(const SyncClientHookData&)> on_sync_client_event_hook;
 
         /// Schema version
+        ///
+        /// Note: Currently set only for FLX sync.
         uint64_t schema_version = -1; // = ObjectStore::NotVersioned
     };
 

--- a/src/realm/sync/client.hpp
+++ b/src/realm/sync/client.hpp
@@ -350,6 +350,9 @@ public:
         bool simulate_integration_error = false;
 
         std::function<SyncClientHookAction(const SyncClientHookData&)> on_sync_client_event_hook;
+
+        /// Schema version
+        uint64_t schema_version = -1; // = ObjectStore::NotVersioned
     };
 
     /// \brief Start a new session for the specified client-side Realm.

--- a/src/realm/sync/noinst/client_impl_base.cpp
+++ b/src/realm/sync/noinst/client_impl_base.cpp
@@ -204,10 +204,8 @@ ClientImpl::ClientImpl(ClientConfig config)
     REALM_ASSERT_EX(m_socket_provider, "Must provide socket provider in sync Client config");
 
     if (m_one_connection_per_session) {
-        // FIXME: Re-enable this warning when the load balancer is able to handle
-        // multiplexing.
-        //        logger.warn("Testing/debugging feature 'one connection per session' enabled - "
-        //            "never do this in production");
+        logger.warn("Testing/debugging feature 'one connection per session' enabled - "
+                    "never do this in production");
     }
 
     if (config.disable_upload_activation_delay) {
@@ -1861,6 +1859,7 @@ void Session::send_bind_message()
         if (auto migrated_partition = get_migration_store()->get_migrated_partition()) {
             bind_json_data["migratedPartition"] = *migrated_partition;
         }
+        bind_json_data["schema_version"] = get_schema_version();
         if (logger.would_log(util::Logger::Level::debug)) {
             std::string json_data_dump;
             if (!bind_json_data.empty()) {

--- a/src/realm/sync/noinst/client_impl_base.hpp
+++ b/src/realm/sync/noinst/client_impl_base.hpp
@@ -927,6 +927,9 @@ private:
     // transfer from the server.
     util::Optional<ClientReset>& get_client_reset_config() noexcept;
 
+    /// Returns the schema version the synchronization session connects with to the server.
+    uint64_t get_schema_version() noexcept;
+
     /// \brief Initiate the integration of downloaded changesets.
     ///
     /// This function must provide for the passed changesets (if any) to


### PR DESCRIPTION
## What, How & Why?
For the Sync Schema Migration project the sync client sends the schema version the realm is opened with as part of the BIND messages. The schema version is added to the JSON data section of the FLX BIND message.

Fixes #6840.

## ☑️ ToDos
* [X] 📝 Changelog update
* ~~[ ] 🚦 Tests (or not relevant)~~
* ~~[ ] C-API, if public C++ API changed.~~
