### PR TITLE
Updated evergreen definitions for nightly tests

### DIFF
--- a/evergreen/config.yml
+++ b/evergreen/config.yml
@@ -3,8 +3,8 @@
 # * Pull Requests:
 #   * add the "for_pull_requests" tag to the task to run for pull requests
 # * Nightly Builds:
-#   * Add the 'patch_only: true' configuration setting to the task to run for nightly test runs
 #   * Add the '"for_nightly_tests"'' tag to the task for the "nightly_tests" alias to work
+#   * Add the 'activate: false' setting to the task under the build variant for each task to run during the nightly test runs
 # * Commit Builds:
 #   * All other tasks will be included in the set run when a PR is merged to master
 
@@ -666,7 +666,6 @@ tasks:
 - name: valgrind
   exec_timeout_secs: 14400
   tags: [ "for_nightly_tests" ]
-  patch_only: true
   commands:
   - func: "fetch source"
   - func: "fetch binaries"
@@ -786,7 +785,6 @@ tasks:
 
 - name: long-running-core-tests
   tags: [ "for_nightly_tests" ]
-  patch_only: true
   commands:
   - func: "run tests"
     # The long-running tests can take a really long time on Windows, so we give the test up to 4
@@ -1017,7 +1015,6 @@ tasks:
 
 - name: fuzzer
   tags: [ "for_nightly_tests" ]
-  patch_only: true
   commands:
   - command: shell.exec
     params:
@@ -1233,6 +1230,7 @@ buildvariants:
     distros:
     - ubuntu2004-large
   - name: long-running-tests
+    activate: false
   - name: bloaty
 
 - name: ubuntu2004-asan
@@ -1299,7 +1297,7 @@ buildvariants:
     enable_fuzzer: On
   tasks:
   - name: fuzzer-tests
-    patchable: true
+    activate: false
 
 - name: rhel70
   display_name: "RHEL 7 x86_64"
@@ -1327,6 +1325,7 @@ buildvariants:
     cmake_build_type: RelWithDebInfo
   tasks:
   - name: valgrind
+    activate: false
 
 - name: ubuntu2004-arm64
   display_name: "Ubuntu 20.04 ARM64"


### PR DESCRIPTION
## What, How & Why?
The last set of changes to add `patch_only: true` did not work as expected; they removed the tasks from both the commit and the nightly test runs.
After speaking with evergreen support, using the `activate: false` setting to the tasks defined for a build variant should remove the task from the set of tasks run for the commit test runs and allow it to be started "manually" for the nightly test runs.

## ☑️ ToDos
* ~~[ ] 📝 Changelog update~~
* ~~[ ] 🚦 Tests (or not relevant)~~
* ~~[ ] C-API, if public C++ API changed.~~
