### PR TITLE
Fix serialization of large timestamps

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,8 +5,7 @@
 * None.
 
 ### Fixed
-* <How do the end-user experience this issue? what was the impact?> ([#????](https://github.com/realm/realm-core/issues/????), since v?.?.?)
-* None.
+* Serialization of large offsets from epoch fixed. ((PR [#6893](https://github.com/realm/realm-core/pull/6893))
 
 ### Breaking changes
 * None.

--- a/src/realm/util/serializer.cpp
+++ b/src/realm/util/serializer.cpp
@@ -34,101 +34,6 @@
 
 
 namespace realm {
-
-/* Uses Fliegel & Van Flandern algorithm */
-static constexpr long date_to_julian(int y, int m, int d)
-{
-    return (1461 * (y + 4800 + (m - 14) / 12)) / 4 + (367 * (m - 2 - 12 * ((m - 14) / 12))) / 12 -
-           (3 * ((y + 4900 + (m - 14) / 12) / 100)) / 4 + d - 32075;
-}
-
-static void julian_to_date(int jd, int* y, int* m, int* d)
-{
-    int L = jd + 68569;
-    int n = (4 * L) / 146097;
-    int i, j;
-
-    L = L - (146097 * n + 3) / 4;
-    i = (4000 * (L + 1)) / 1461001;
-    L = L - (1461 * i) / 4 + 31;
-    j = (80 * L) / 2447;
-    *d = L - (2447 * j) / 80;
-    L = j / 11;
-    *m = j + 2 - (12 * L);
-    *y = 100 * (n - 49) + i + L;
-}
-
-// Confirmed to work for all val < 16389
-static void out_dec(char** buffer, unsigned val, int width)
-{
-    int w = width;
-    char* p = *buffer;
-    while (width > 0) {
-        width--;
-        unsigned div10 = (val * 6554) >> 16;
-        p[width] = char(val - div10 * 10) + '0';
-        val = div10;
-    }
-    *buffer += w;
-}
-
-static constexpr long epoc_julian_days = date_to_julian(1970, 1, 1); // 2440588
-static constexpr int seconds_in_a_day = 24 * 60 * 60;
-
-const char* Timestamp::to_string(char* buffer) const
-{
-    if (is_null()) {
-        return "null";
-    }
-    int64_t seconds = get_seconds();
-    int32_t nano = get_nanoseconds();
-    if (nano < 0) {
-        nano += Timestamp::nanoseconds_per_second;
-        seconds--;
-    }
-
-    int64_t days = seconds / seconds_in_a_day;
-    int julian_days = int(days + epoc_julian_days);
-
-    int seconds_in_day = int(seconds - days * seconds_in_a_day);
-    if (seconds_in_day < 0) {
-        seconds_in_day += seconds_in_a_day;
-        julian_days--;
-    }
-
-    int year;
-    int month;
-    int day;
-    int hours = seconds_in_day / 3600;
-    int remainingSeconds = seconds_in_day - hours * 3600;
-    int minutes = remainingSeconds / 60;
-    int secs = remainingSeconds - minutes * 60;
-
-    julian_to_date(julian_days, &year, &month, &day);
-
-    char* p = buffer;
-    if (year < 0) {
-        *p++ = '-';
-        year = -year;
-    }
-    out_dec(&p, year, 4);
-    *p++ = '-';
-    out_dec(&p, month, 2);
-    *p++ = '-';
-    out_dec(&p, day, 2);
-    *p++ = ' ';
-    out_dec(&p, hours, 2);
-    *p++ = ':';
-    out_dec(&p, minutes, 2);
-    *p++ = ':';
-    out_dec(&p, secs, 2);
-    *p = '\0';
-    if (nano) {
-        snprintf(p, 32 - (p - buffer), ".%09d", nano);
-    }
-    return buffer;
-}
-
 namespace util {
 namespace serializer {
 
@@ -249,12 +154,7 @@ std::string print_value<>(realm::Timestamp t)
         return "NULL";
     }
     std::stringstream ss;
-    if (t.is_null()) {
-        ss << "null";
-    }
-    else {
-        ss << "T" << t.get_seconds() << ":" << t.get_nanoseconds();
-    }
+    ss << t;
     return ss.str();
 }
 


### PR DESCRIPTION
- Increase timestamp serialization buffer
- Update CHANGELOG

## What, How & Why?
Fixes #6892 by increasing buffer size

## ☑️ ToDos
* [X] 📝 Changelog update
* [ ] 🚦 Tests (or not relevant)
* [X] ~~C-API, if public C++ API changed.~~
