### PR TITLE
C API: Return result of get_as_realm_error_t from realm_get_async_error

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@
 * `ProtocolError` is no longer a `std::error_code` enum and is no longer directly exposed by the sync error API ([PR #6869](https://github.com/realm/realm-core/pull/6869))
 * The ClientError enum/`std::error_code` in the sync client has been removed in favor of a simplified error set using Status/ErrorCodes ([PR #6846](https://github.com/realm/realm-core/pull/6846)).
 * SyncError now contains a Status to hold the error information from the sync client instead of a `std::error_code`/`std::string` ([PR #6824](https://github.com/realm/realm-core/pull/6824)).
+* C API: return whether or not an error is present from realm_get_async_error() ([#6897](https://github.com/realm/realm-core/issues/6897))
 
 ### Compatibility
 * Fileformat: Generates files with format v23. Reads and automatically upgrade from fileformat v5.

--- a/src/realm.h
+++ b/src/realm.h
@@ -443,9 +443,10 @@ RLM_API bool realm_get_last_error(realm_error_t* err);
  *
  * @param err A pointer to a `realm_error_t` struct that will be populated with
  *            information about the error. May not be NULL.
+ * @return A bool indicating whether or not an error is available to be returned
  * @see realm_get_last_error()
  */
-RLM_API void realm_get_async_error(const realm_async_error_t* err, realm_error_t* out_err);
+RLM_API bool realm_get_async_error(const realm_async_error_t* err, realm_error_t* out_err);
 
 /**
  * Convert the last error to `realm_async_error_t`, which can safely be passed

--- a/src/realm/object-store/c_api/error.cpp
+++ b/src/realm/object-store/c_api/error.cpp
@@ -224,9 +224,12 @@ RLM_API realm_async_error_t* realm_get_last_error_as_async_error(void)
     return new realm_async_error_t{*ErrorStorage::get_thread_local()};
 }
 
-RLM_API void realm_get_async_error(const realm_async_error_t* async_err, realm_error_t* out_err)
+RLM_API bool realm_get_async_error(const realm_async_error_t* async_err, realm_error_t* out_err)
 {
-    async_err->error_storage.get_as_realm_error_t(out_err);
+    if (!async_err)
+        return false;
+
+    return async_err->error_storage.get_as_realm_error_t(out_err);
 }
 
 } // namespace realm::c_api

--- a/test/object-store/c_api/c_api.cpp
+++ b/test/object-store/c_api/c_api.cpp
@@ -484,7 +484,7 @@ TEST_CASE("C API (non-database)", "[c_api]") {
         CHECK(async_err);
 
         realm_error_t err;
-        realm_get_async_error(async_err, &err);
+        CHECK(realm_get_async_error(async_err, &err));
 
         CHECK(err.error == RLM_ERR_RUNTIME);
         CHECK(std::string{err.message} == "Synthetic error");
@@ -493,7 +493,7 @@ TEST_CASE("C API (non-database)", "[c_api]") {
             auto cloned = clone_cptr(async_err);
             CHECK(realm_equals(async_err, cloned.get()));
             realm_error_t err2;
-            realm_get_async_error(cloned.get(), &err2);
+            CHECK(realm_get_async_error(cloned.get(), &err2));
             CHECK(err2.error == RLM_ERR_RUNTIME);
             CHECK(std::string{err2.message} == "Synthetic error");
         }
@@ -5044,9 +5044,7 @@ static void task_completion_func(void* p, realm_thread_safe_reference_t* realm,
     auto userdata_p = static_cast<Userdata*>(p);
 
     userdata_p->realm_ref = realm;
-    userdata_p->has_error = async_error != nullptr;
-    if (userdata_p->has_error)
-        realm_get_async_error(async_error, &userdata_p->error);
+    userdata_p->has_error = realm_get_async_error(async_error, &userdata_p->error);
     userdata_p->called = true;
 }
 

--- a/test/object-store/c_api/c_api.cpp
+++ b/test/object-store/c_api/c_api.cpp
@@ -485,6 +485,7 @@ TEST_CASE("C API (non-database)", "[c_api]") {
 
         realm_error_t err;
         CHECK(realm_get_async_error(async_err, &err));
+        CHECK_FALSE(realm_get_async_error(nullptr, &err));
 
         CHECK(err.error == RLM_ERR_RUNTIME);
         CHECK(std::string{err.message} == "Synthetic error");


### PR DESCRIPTION
## What, How & Why?
When the `realm_get_async_error()` function was added it is ignoring the result of the `get_as_realm_error_t()` function that is called. Update `realm_get_async_error()` to return whether or not an error is present in the `async_err` parameter (the return value from `get_as_realm_error_t()`).

Fixes #6897 

## ☑️ ToDos
* [ ] 📝 Changelog update
* [X] 🚦 Tests (or not relevant)
* [X] C-API, if public C++ API changed.
