### PR TITLE
Check for stale accessors to a collction embedded in a dictionary

### DIFF
--- a/src/realm/CMakeLists.txt
+++ b/src/realm/CMakeLists.txt
@@ -143,6 +143,7 @@ set(REALM_INSTALL_HEADERS
     column_binary.hpp
     column_fwd.hpp
     column_integer.hpp
+    column_mixed.hpp
     column_type.hpp
     column_type_traits.hpp
     data_type.hpp

--- a/src/realm/collection.hpp
+++ b/src/realm/collection.hpp
@@ -35,7 +35,11 @@ public:
     {
         return {};
     }
-    void add_index(Path&, Index) const noexcept final {}
+    void add_index(Path&, const Index&) const noexcept final {}
+    size_t find_index(const Index&) const noexcept final
+    {
+        return realm::npos;
+    }
 
     TableRef get_table() const noexcept final
     {

--- a/src/realm/collection_parent.hpp
+++ b/src/realm/collection_parent.hpp
@@ -24,8 +24,6 @@
 #include <realm/path.hpp>
 #include <realm/mixed.hpp>
 
-#include <external/mpark/variant.hpp>
-
 namespace realm {
 
 class Obj;
@@ -73,93 +71,62 @@ enum class UpdateStatus {
 
 /*
  * In order to detect stale collection objects (objects referring to entities that have
- * been deleted from the DB) nested directly in an Obj object, we need a structure that
- * both holds an index of the relevant column as well as a somewhat unique key. The key
- * is generated when the collection is assigned to the property and stored alongside the
- * ref of the collection. The stored key is regenerated/cleared when a new value is
- * assigned to the property.
+ * been deleted from the DB), we need a structure that both holds a somewhat unique salt
+ * and possibly an index of the relevant column. The salt is generated when the collection
+ * is assigned to the property and stored alongside the ref of the collection. The stored
+ * salt is regenerated/cleared when a new value is assigned to the property/collection
+ * element.
  */
-class ColIndex {
+class StableIndex {
 public:
-    ColIndex()
+    StableIndex()
     {
-        value.col_index = 0x7fff;
+        value.raw = 0;
     }
-    ColIndex(ColKey col_key, int64_t key)
+    StableIndex(ColKey col_key, int64_t salt)
     {
         value.col_index = col_key.get_index().val;
         value.is_collection = col_key.is_collection();
-        value.key = uint16_t(key);
+        value.is_column = true;
+        value.salt = int32_t(salt);
+    }
+    StableIndex(int64_t salt)
+    {
+        value.raw = 0;
+        value.salt = int32_t(salt);
+    }
+    int64_t get_salt() const
+    {
+        return value.salt;
     }
     ColKey::Idx get_index() const noexcept
     {
         return {unsigned(value.col_index)};
-    }
-    int64_t get_key() const noexcept
-    {
-        return int16_t(value.key);
     }
     bool is_collection() const noexcept
     {
         return value.is_collection;
     }
 
-    bool operator==(const ColIndex& other) const noexcept
+    bool operator==(const StableIndex& other) const noexcept
     {
-        // Compare only index
-        return value.col_index == other.value.col_index;
-    }
-
-private:
-    struct {
-        uint32_t col_index : 15;
-        uint32_t is_collection : 1;
-        uint32_t key : 16;
-    } value;
-};
-
-static_assert(sizeof(ColIndex) == sizeof(uint32_t));
-
-class KeyIndex {
-public:
-    KeyIndex()
-    {
-        value.raw = 0;
-    }
-    KeyIndex(StringData string_key, int64_t key)
-    {
-        size_t sz = string_key.size();
-        const char* str = string_key.data();
-        for (size_t i = 0; i < 4; i++) {
-            value.str[i] = (i < sz) ? str[i] : 0;
-        }
-        value.key = int32_t(key);
-    }
-    const char* get_string() const
-    {
-        return value.str;
-    }
-    int64_t get_key() const
-    {
-        return value.key;
-    }
-
-    bool operator==(const KeyIndex& other) const noexcept
-    {
-        return value.raw == other.value.raw;
+        return value.is_column ? value.col_index == other.value.col_index : value.salt == other.value.salt;
     }
 
 private:
     union {
         struct {
-            char str[4];
-            int32_t key;
+            bool is_column;
+            bool is_collection;
+            int16_t col_index;
+            int32_t salt;
         };
-        uint64_t raw;
+        int64_t raw;
     } value;
 };
 
-using StableIndex = mpark::variant<ColIndex, int64_t, KeyIndex>;
+static_assert(sizeof(StableIndex) == 8);
+
 using StablePath = std::vector<StableIndex>;
 
 class CollectionParent : public std::enable_shared_from_this<CollectionParent> {

--- a/src/realm/column_mixed.hpp
+++ b/src/realm/column_mixed.hpp
@@ -1,0 +1,87 @@
+/*************************************************************************
+ *
+ * Copyright 2023 Realm Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ **************************************************************************/
+
+#ifndef REALM_COLUMN_MIXED_HPP
+#define REALM_COLUMN_MIXED_HPP
+
+#include <realm/bplustree.hpp>
+#include <realm/array_mixed.hpp>
+
+namespace realm {
+
+class BPlusTreeMixed : public BPlusTree<Mixed> {
+public:
+    BPlusTreeMixed(Allocator& alloc)
+        : BPlusTree<Mixed>(alloc)
+    {
+    }
+
+    void ensure_keys()
+    {
+        auto func = [&](BPlusTreeNode* node, size_t) {
+            return static_cast<LeafNode*>(node)->ensure_keys() ? IteratorControl::Stop
+                                                               : IteratorControl::AdvanceToNext;
+        };
+
+        m_root->bptree_traverse(func);
+    }
+    size_t find_key(int64_t key) const noexcept
+    {
+        size_t ret = realm::npos;
+        auto func = [&](BPlusTreeNode* node, size_t offset) {
+            LeafNode* leaf = static_cast<LeafNode*>(node);
+            auto pos = leaf->find_key(key);
+            if (pos != realm::not_found) {
+                ret = pos + offset;
+                return IteratorControl::Stop;
+            }
+            else {
+                return IteratorControl::AdvanceToNext;
+            }
+        };
+
+        m_root->bptree_traverse(func);
+        return ret;
+    }
+
+    void set_key(size_t ndx, int64_t key) const noexcept
+    {
+        auto func = [key](BPlusTreeNode* node, size_t ndx) {
+            LeafNode* leaf = static_cast<LeafNode*>(node);
+            leaf->set_key(ndx, key);
+        };
+
+        m_root->bptree_access(ndx, func);
+    }
+
+    int64_t get_key(size_t ndx) const noexcept
+    {
+        int64_t ret = 0;
+        auto func = [&ret](BPlusTreeNode* node, size_t ndx) {
+            LeafNode* leaf = static_cast<LeafNode*>(node);
+            ret = leaf->get_key(ndx);
+        };
+
+        m_root->bptree_access(ndx, func);
+        return ret;
+    }
+};
+
+} // namespace realm
+
+#endif /* REALM_COLUMN_MIXED_HPP */

--- a/src/realm/dictionary.cpp
+++ b/src/realm/dictionary.cpp
@@ -645,7 +645,7 @@ Dictionary::Iterator Dictionary::find(Mixed key) const noexcept
 
 void Dictionary::add_index(Path& path, const Index& index) const
 {
-    auto ndx = m_values->find_key(mpark::get<KeyIndex>(index).get_key());
+    auto ndx = m_values->find_key(index.get_salt());
     auto keys = static_cast<BPlusTree<StringData>*>(m_keys.get());
     path.emplace_back(keys->get(ndx));
 }
@@ -653,7 +653,7 @@ void Dictionary::add_index(Path& path, const Index& index) const
 size_t Dictionary::find_index(const Index& index) const
 {
     update();
-    return m_values->find_key(mpark::get<KeyIndex>(index).get_key());
+    return m_values->find_key(index.get_salt());
 }
 
 UpdateStatus Dictionary::update_if_needed_with_status() const noexcept
@@ -1055,11 +1055,11 @@ Mixed Dictionary::find_value(Mixed value) const noexcept
     return (ndx == realm::npos) ? Mixed{} : do_get_key(ndx);
 }
 
-KeyIndex Dictionary::build_index(Mixed key) const
+StableIndex Dictionary::build_index(Mixed key) const
 {
     auto it = find(key);
     int64_t index = (it != end()) ? m_values->get_key(it.index()) : 0;
-    return {key.get_string(), index};
+    return {index};
 }
 
 
@@ -1184,7 +1184,7 @@ void Dictionary::to_json(std::ostream& out, size_t link_depth, JSONOutputMode ou
 
 ref_type Dictionary::get_collection_ref(Index index, CollectionType type) const
 {
-    auto ndx = m_values->find_key(mpark::get<KeyIndex>(index).get_key());
+    auto ndx = m_values->find_key(index.get_salt());
     if (ndx != realm::not_found) {
         auto val = m_values->get(ndx);
         if (val.is_type(DataType(int(type)))) {
@@ -1198,7 +1198,7 @@ ref_type Dictionary::get_collection_ref(Index index, CollectionType type) const
 
 bool Dictionary::check_collection_ref(Index index, CollectionType type) const noexcept
 {
-    auto ndx = m_values->find_key(mpark::get<KeyIndex>(index).get_key());
+    auto ndx = m_values->find_key(index.get_salt());
     if (ndx != realm::not_found) {
         return m_values->get(ndx).is_type(DataType(int(type)));
     }
@@ -1207,7 +1207,7 @@ bool Dictionary::check_collection_ref(Index index, CollectionType type) const no
 
 void Dictionary::set_collection_ref(Index index, ref_type ref, CollectionType type)
 {
-    auto ndx = m_values->find_key(mpark::get<KeyIndex>(index).get_key());
+    auto ndx = m_values->find_key(index.get_salt());
     if (ndx == realm::not_found) {
         throw StaleAccessor("Collection has been deleted");
     }

--- a/src/realm/dictionary.cpp
+++ b/src/realm/dictionary.cpp
@@ -66,7 +66,7 @@ Dictionary::Dictionary(Allocator& alloc, ColKey col_key, ref_type ref)
     m_dictionary_top.reset(new Array(alloc));
     m_dictionary_top->init_from_ref(ref);
     m_keys.reset(new BPlusTree<StringData>(alloc));
-    m_values.reset(new BPlusTree<Mixed>(alloc));
+    m_values.reset(new BPlusTreeMixed(alloc));
     m_keys->set_parent(m_dictionary_top.get(), 0);
     m_values->set_parent(m_dictionary_top.get(), 1);
     m_keys->init_from_parent();
@@ -433,7 +433,14 @@ Obj Dictionary::create_and_insert_linked_object(Mixed key)
 void Dictionary::insert_collection(const PathElement& path_elem, CollectionType dict_or_list)
 {
     check_level();
-    insert(path_elem.get_key(), Mixed(0, dict_or_list));
+    ensure_created();
+    m_values->ensure_keys();
+    auto [it, inserted] = insert(path_elem.get_key(), Mixed(0, dict_or_list));
+    int64_t key = generate_key(size());
+    while (m_values->find_key(key) != realm::not_found) {
+        key++;
+    }
+    m_values->set_key(it.index(), key);
 }
 
 DictionaryPtr Dictionary::get_dictionary(const PathElement& path_elem) const
@@ -442,7 +449,7 @@ DictionaryPtr Dictionary::get_dictionary(const PathElement& path_elem) const
     auto weak = const_cast<Dictionary*>(this)->weak_from_this();
     auto shared = weak.expired() ? std::make_shared<Dictionary>(*this) : weak.lock();
     DictionaryPtr ret = std::make_shared<Dictionary>(m_col_key, get_level() + 1);
-    ret->set_owner(shared, path_elem.get_key());
+    ret->set_owner(shared, build_index(path_elem.get_key()));
     return ret;
 }
 
@@ -452,7 +459,7 @@ SetMixedPtr Dictionary::get_set(const PathElement& path_elem) const
     auto weak = const_cast<Dictionary*>(this)->weak_from_this();
     auto shared = weak.expired() ? std::make_shared<Dictionary>(*this) : weak.lock();
     auto ret = std::make_shared<Set<Mixed>>(m_obj_mem, m_col_key);
-    ret->set_owner(shared, path_elem.get_key());
+    ret->set_owner(shared, build_index(path_elem.get_key()));
     return ret;
 }
 
@@ -462,7 +469,7 @@ std::shared_ptr<Lst<Mixed>> Dictionary::get_list(const PathElement& path_elem) c
     auto weak = const_cast<Dictionary*>(this)->weak_from_this();
     auto shared = weak.expired() ? std::make_shared<Dictionary>(*this) : weak.lock();
     std::shared_ptr<Lst<Mixed>> ret = std::make_shared<Lst<Mixed>>(m_col_key, get_level() + 1);
-    ret->set_owner(shared, path_elem.get_key());
+    ret->set_owner(shared, build_index(path_elem.get_key()));
     return ret;
 }
 
@@ -636,9 +643,17 @@ Dictionary::Iterator Dictionary::find(Mixed key) const noexcept
     return end();
 }
 
-void Dictionary::add_index(Path& path, Index index) const
+void Dictionary::add_index(Path& path, const Index& index) const
 {
-    path.emplace_back(mpark::get<std::string>(index));
+    auto ndx = m_values->find_key(mpark::get<KeyIndex>(index).get_key());
+    auto keys = static_cast<BPlusTree<StringData>*>(m_keys.get());
+    path.emplace_back(keys->get(ndx));
+}
+
+size_t Dictionary::find_index(const Index& index) const
+{
+    update();
+    return m_values->find_key(mpark::get<KeyIndex>(index).get_key());
 }
 
 UpdateStatus Dictionary::update_if_needed_with_status() const noexcept
@@ -671,6 +686,7 @@ void Dictionary::ensure_created()
     if (Base::should_update() || !(m_dictionary_top && m_dictionary_top->is_attached())) {
         init_from_parent(true);
         ensure_attached();
+        Base::update_content_version();
     }
 }
 
@@ -860,7 +876,7 @@ bool Dictionary::init_from_parent(bool allow_create) const
                     break;
             }
             m_keys->set_parent(m_dictionary_top.get(), 0);
-            m_values.reset(new BPlusTree<Mixed>(alloc));
+            m_values.reset(new BPlusTreeMixed(alloc));
             m_values->set_parent(m_dictionary_top.get(), 1);
         }
 
@@ -1039,6 +1055,14 @@ Mixed Dictionary::find_value(Mixed value) const noexcept
     return (ndx == realm::npos) ? Mixed{} : do_get_key(ndx);
 }
 
+KeyIndex Dictionary::build_index(Mixed key) const
+{
+    auto it = find(key);
+    int64_t index = (it != end()) ? m_values->get_key(it.index()) : 0;
+    return {key.get_string(), index};
+}
+
+
 void Dictionary::verify() const
 {
     m_keys->verify();
@@ -1160,7 +1184,7 @@ void Dictionary::to_json(std::ostream& out, size_t link_depth, JSONOutputMode ou
 
 ref_type Dictionary::get_collection_ref(Index index, CollectionType type) const
 {
-    auto ndx = do_find_key(StringData(mpark::get<std::string>(index)));
+    auto ndx = m_values->find_key(mpark::get<KeyIndex>(index).get_key());
     if (ndx != realm::not_found) {
         auto val = m_values->get(ndx);
         if (val.is_type(DataType(int(type)))) {
@@ -1174,7 +1198,7 @@ ref_type Dictionary::get_collection_ref(Index index, CollectionType type) const
 
 bool Dictionary::check_collection_ref(Index index, CollectionType type) const noexcept
 {
-    auto ndx = do_find_key(StringData(mpark::get<std::string>(index)));
+    auto ndx = m_values->find_key(mpark::get<KeyIndex>(index).get_key());
     if (ndx != realm::not_found) {
         return m_values->get(ndx).is_type(DataType(int(type)));
     }
@@ -1183,7 +1207,7 @@ bool Dictionary::check_collection_ref(Index index, CollectionType type) const no
 
 void Dictionary::set_collection_ref(Index index, ref_type ref, CollectionType type)
 {
-    auto ndx = do_find_key(StringData(mpark::get<std::string>(index)));
+    auto ndx = m_values->find_key(mpark::get<KeyIndex>(index).get_key());
     if (ndx == realm::not_found) {
         throw StaleAccessor("Collection has been deleted");
     }

--- a/src/realm/dictionary.hpp
+++ b/src/realm/dictionary.hpp
@@ -214,7 +214,7 @@ public:
     ref_type get_collection_ref(Index, CollectionType) const override;
     bool check_collection_ref(Index, CollectionType) const noexcept override;
     void set_collection_ref(Index, ref_type ref, CollectionType) override;
-    KeyIndex build_index(Mixed key) const;
+    StableIndex build_index(Mixed key) const;
 
     void to_json(std::ostream&, size_t, JSONOutputMode, util::FunctionRef<void(const Mixed&)>) const override;
 

--- a/src/realm/dictionary.hpp
+++ b/src/realm/dictionary.hpp
@@ -22,7 +22,7 @@
 #include <realm/collection.hpp>
 #include <realm/obj.hpp>
 #include <realm/mixed.hpp>
-#include <realm/array_mixed.hpp>
+#include <realm/column_mixed.hpp>
 
 namespace realm {
 
@@ -198,7 +198,9 @@ public:
         return Base::get_stable_path();
     }
 
-    void add_index(Path& path, Index ndx) const final;
+    void add_index(Path& path, const Index& ndx) const final;
+    size_t find_index(const Index&) const final;
+
     TableRef get_table() const noexcept override
     {
         return get_obj().get_table();
@@ -212,6 +214,7 @@ public:
     ref_type get_collection_ref(Index, CollectionType) const override;
     bool check_collection_ref(Index, CollectionType) const noexcept override;
     void set_collection_ref(Index, ref_type ref, CollectionType) override;
+    KeyIndex build_index(Mixed key) const;
 
     void to_json(std::ostream&, size_t, JSONOutputMode, util::FunctionRef<void(const Mixed&)>) const override;
 
@@ -223,7 +226,7 @@ private:
 
     mutable std::unique_ptr<Array> m_dictionary_top;
     mutable std::unique_ptr<BPlusTreeBase> m_keys;
-    mutable std::unique_ptr<BPlusTree<Mixed>> m_values;
+    mutable std::unique_ptr<BPlusTreeMixed> m_values;
     DataType m_key_type = type_String;
 
     Dictionary(Allocator& alloc, ColKey col_key, ref_type ref);

--- a/src/realm/impl/transact_log.cpp
+++ b/src/realm/impl/transact_log.cpp
@@ -37,17 +37,7 @@ bool TransactLogEncoder::select_collection(ColKey col_key, ObjKey key, const Sta
         append_simple_instr(path_size - 1);
 
         for (size_t n = 1; n < path_size; n++) {
-            if (const auto int64_ptr = mpark::get_if<int64_t>(&path[n])) {
-                append_simple_instr(*int64_ptr);
-            }
-            else if (const auto key_index_ptr = mpark::get_if<KeyIndex>(&path[n])) {
-                append_simple_instr(0); // this is based solely on the fact that stable indices cannot be zero.
-                char buffer[5];
-                memcpy(buffer, key_index_ptr->get_string(), 4);
-                buffer[4] = '\0';
-                encode_string(StringData(buffer));
-                append_simple_instr(key_index_ptr->get_key());
-            }
+            append_simple_instr(path[n].get_salt());
         }
     }
     else {

--- a/src/realm/impl/transact_log.cpp
+++ b/src/realm/impl/transact_log.cpp
@@ -40,9 +40,13 @@ bool TransactLogEncoder::select_collection(ColKey col_key, ObjKey key, const Sta
             if (const auto int64_ptr = mpark::get_if<int64_t>(&path[n])) {
                 append_simple_instr(*int64_ptr);
             }
-            else if (const auto string_ptr = mpark::get_if<std::string>(&path[n])) {
+            else if (const auto key_index_ptr = mpark::get_if<KeyIndex>(&path[n])) {
                 append_simple_instr(0); // this is based solely on the fact that stable indices cannot be zero.
-                encode_string(StringData((*string_ptr).c_str()));
+                char buffer[5];
+                memcpy(buffer, key_index_ptr->get_string(), 4);
+                buffer[4] = '\0';
+                encode_string(StringData(buffer));
+                append_simple_instr(key_index_ptr->get_key());
             }
         }
     }

--- a/src/realm/impl/transact_log.hpp
+++ b/src/realm/impl/transact_log.hpp
@@ -793,17 +793,10 @@ void TransactLogParser::parse_one(InstructionHandler& handler)
             ObjKey key = ObjKey(read_int<int64_t>());     // Throws
             size_t nesting_level = instr == instr_SelectCollectionByPath ? read_int<uint32_t>() : 0;
             StablePath path;
-            path.push_back(ColIndex(col_key, 0));
+            path.push_back(StableIndex(col_key, 0));
             for (size_t l = 0; l < nesting_level; l++) {
                 auto ndx = read_int<int64_t>();
-                if (ndx == 0) {
-                    auto str = read_string(m_string_buffer);
-                    auto key = read_int<int64_t>();
-                    path.emplace_back(KeyIndex(str, key));
-                }
-                else {
-                    path.emplace_back(ndx);
-                }
+                path.emplace_back(ndx);
             }
             if (!handler.select_collection(col_key, key, path)) // Throws
                 parser_error();

--- a/src/realm/impl/transact_log.hpp
+++ b/src/realm/impl/transact_log.hpp
@@ -797,8 +797,9 @@ void TransactLogParser::parse_one(InstructionHandler& handler)
             for (size_t l = 0; l < nesting_level; l++) {
                 auto ndx = read_int<int64_t>();
                 if (ndx == 0) {
-                    auto key = read_string(m_string_buffer);
-                    path.emplace_back(key);
+                    auto str = read_string(m_string_buffer);
+                    auto key = read_int<int64_t>();
+                    path.emplace_back(KeyIndex(str, key));
                 }
                 else {
                     path.emplace_back(ndx);

--- a/src/realm/index_string.cpp
+++ b/src/realm/index_string.cpp
@@ -1955,7 +1955,7 @@ void StringIndex::dump_node_structure(const Array& node, std::ostream& out, int 
         for (size_t i = 0; i != subnode.size(); ++i) {
             if (i != 0)
                 out << ", ";
-            out_hex(out, subnode.get(i));
+            out_hex(out, uint32_t(subnode.get(i)));
         }
     }
     out << ")\n";

--- a/src/realm/list.cpp
+++ b/src/realm/list.cpp
@@ -723,11 +723,17 @@ void Lst<Mixed>::set_collection_ref(Index index, ref_type ref, CollectionType ty
     m_tree->set(ndx, Mixed(ref, type));
 }
 
-void Lst<Mixed>::add_index(Path& path, Index index) const
+void Lst<Mixed>::add_index(Path& path, const Index& index) const
 {
     auto ndx = m_tree->find_key(mpark::get<int64_t>(index));
     REALM_ASSERT(ndx != realm::not_found);
     path.emplace_back(ndx);
+}
+
+size_t Lst<Mixed>::find_index(const Index& ndx) const
+{
+    update();
+    return m_tree->find_key(mpark::get<int64_t>(ndx));
 }
 
 bool Lst<Mixed>::nullify(ObjLink link)

--- a/src/realm/list.cpp
+++ b/src/realm/list.cpp
@@ -693,7 +693,7 @@ void Lst<Mixed>::to_json(std::ostream& out, size_t link_depth, JSONOutputMode ou
 
 ref_type Lst<Mixed>::get_collection_ref(Index index, CollectionType type) const
 {
-    auto ndx = m_tree->find_key(mpark::get<int64_t>(index));
+    auto ndx = m_tree->find_key(index.get_salt());
     if (ndx != realm::not_found) {
         auto val = get(ndx);
         if (val.is_type(DataType(int(type)))) {
@@ -707,7 +707,7 @@ ref_type Lst<Mixed>::get_collection_ref(Index index, CollectionType type) const
 
 bool Lst<Mixed>::check_collection_ref(Index index, CollectionType type) const noexcept
 {
-    auto ndx = m_tree->find_key(mpark::get<int64_t>(index));
+    auto ndx = m_tree->find_key(index.get_salt());
     if (ndx != realm::not_found) {
         return get(ndx).is_type(DataType(int(type)));
     }
@@ -716,7 +716,7 @@ bool Lst<Mixed>::check_collection_ref(Index index, CollectionType type) const no
 
 void Lst<Mixed>::set_collection_ref(Index index, ref_type ref, CollectionType type)
 {
-    auto ndx = m_tree->find_key(mpark::get<int64_t>(index));
+    auto ndx = m_tree->find_key(index.get_salt());
     if (ndx == realm::not_found) {
         throw StaleAccessor("Collection has been deleted");
     }
@@ -725,15 +725,15 @@ void Lst<Mixed>::set_collection_ref(Index index, ref_type ref, CollectionType ty
 
 void Lst<Mixed>::add_index(Path& path, const Index& index) const
 {
-    auto ndx = m_tree->find_key(mpark::get<int64_t>(index));
+    auto ndx = m_tree->find_key(index.get_salt());
     REALM_ASSERT(ndx != realm::not_found);
     path.emplace_back(ndx);
 }
 
-size_t Lst<Mixed>::find_index(const Index& ndx) const
+size_t Lst<Mixed>::find_index(const Index& index) const
 {
     update();
-    return m_tree->find_key(mpark::get<int64_t>(ndx));
+    return m_tree->find_key(index.get_salt());
 }
 
 bool Lst<Mixed>::nullify(ObjLink link)

--- a/src/realm/obj.cpp
+++ b/src/realm/obj.cpp
@@ -1042,7 +1042,7 @@ StablePath Obj::get_stable_path() const noexcept
     return {};
 }
 
-void Obj::add_index(Path& path, Index index) const
+void Obj::add_index(Path& path, const Index& index) const
 {
     auto col_index = mpark::get<ColIndex>(index);
     if (path.empty()) {
@@ -2004,18 +2004,13 @@ CollectionPtr Obj::get_collection_by_stable_path(const StablePath& path) const
         auto get_ref = [&]() -> std::pair<Mixed, PathElement> {
             if (collection->get_collection_type() == CollectionType::List) {
                 auto list_of_mixed = dynamic_cast<Lst<Mixed>*>(collection.get());
-                size_t ndx = list_of_mixed->find_key(mpark::get<int64_t>(index));
+                size_t ndx = list_of_mixed->find_index(index);
                 return {list_of_mixed->get(ndx), PathElement(ndx)};
             }
-            else if (collection->get_collection_type() == CollectionType::Set) {
-                auto set_of_mixed = dynamic_cast<Set<Mixed>*>(collection.get());
-                size_t ndx = set_of_mixed->find_any(mpark::get<int64_t>(index));
-                return {set_of_mixed->get(ndx), PathElement(ndx)};
-            }
             else {
-                std::string key = mpark::get<std::string>(index);
-                auto ref = dynamic_cast<Dictionary*>(collection.get())->get(key);
-                return {ref, key};
+                auto dict = dynamic_cast<Dictionary*>(collection.get());
+                size_t ndx = dict->find_index(index);
+                return {dict->get_any(ndx), PathElement(dict->get_key(ndx).get_string())};
             }
         };
         auto [ref, path_elem] = get_ref();

--- a/src/realm/obj.cpp
+++ b/src/realm/obj.cpp
@@ -153,7 +153,7 @@ const Spec& Obj::get_spec() const
     return m_table.unchecked_ptr()->m_spec;
 }
 
-ColIndex Obj::build_index(ColKey col_key) const
+StableIndex Obj::build_index(ColKey col_key) const
 {
     if (col_key.is_collection()) {
         return {col_key, 0};
@@ -166,7 +166,7 @@ ColIndex Obj::build_index(ColKey col_key) const
     return {col_key, key};
 }
 
-bool Obj::check_index(ColIndex index) const
+bool Obj::check_index(StableIndex index) const
 {
     if (index.is_collection()) {
         return true;
@@ -175,7 +175,7 @@ bool Obj::check_index(ColIndex index) const
     ref_type ref = to_ref(Array::get(m_mem.get_addr(), index.get_index().val + 1));
     values.init_from_ref(ref);
     auto key = values.get_key(m_row_ndx);
-    return key == index.get_key();
+    return key == index.get_salt();
 }
 
 Replication* Obj::get_replication() const
@@ -1044,12 +1044,11 @@ StablePath Obj::get_stable_path() const noexcept
 
 void Obj::add_index(Path& path, const Index& index) const
 {
-    auto col_index = mpark::get<ColIndex>(index);
     if (path.empty()) {
-        path.emplace_back(get_table()->get_column_key(col_index));
+        path.emplace_back(get_table()->get_column_key(index));
     }
     else {
-        StringData col_name = get_table()->get_column_name(col_index);
+        StringData col_name = get_table()->get_column_name(index);
         path.emplace_back(col_name);
     }
 }
@@ -1995,7 +1994,7 @@ CollectionPtr Obj::get_collection_ptr(const Path& path) const
 CollectionPtr Obj::get_collection_by_stable_path(const StablePath& path) const
 {
     // First element in path is phony column key
-    ColKey col_key = m_table->get_column_key(mpark::get<ColIndex>(path[0]));
+    ColKey col_key = m_table->get_column_key(path[0]);
     size_t level = 1;
     CollectionBasePtr collection = get_collection_ptr(col_key);
 
@@ -2339,12 +2338,11 @@ ref_type Obj::Internal::get_ref(const Obj& obj, ColKey col_key)
 
 ref_type Obj::get_collection_ref(Index index, CollectionType type) const
 {
-    ColIndex col_index = mpark::get<ColIndex>(index);
-    if (col_index.is_collection()) {
-        return to_ref(_get<int64_t>(col_index.get_index()));
+    if (index.is_collection()) {
+        return to_ref(_get<int64_t>(index.get_index()));
     }
-    if (check_index(col_index)) {
-        auto val = _get<Mixed>(col_index.get_index());
+    if (check_index(index)) {
+        auto val = _get<Mixed>(index.get_index());
         if (val.is_type(DataType(int(type)))) {
             return val.get_ref();
         }
@@ -2355,24 +2353,22 @@ ref_type Obj::get_collection_ref(Index index, CollectionType type) const
 
 bool Obj::check_collection_ref(Index index, CollectionType type) const noexcept
 {
-    ColIndex col_index = mpark::get<ColIndex>(index);
-    if (col_index.is_collection()) {
+    if (index.is_collection()) {
         return true;
     }
-    if (check_index(col_index)) {
-        return _get<Mixed>(col_index.get_index()).is_type(DataType(int(type)));
+    if (check_index(index)) {
+        return _get<Mixed>(index.get_index()).is_type(DataType(int(type)));
     }
     return false;
 }
 
 void Obj::set_collection_ref(Index index, ref_type ref, CollectionType type)
 {
-    ColIndex col_index = mpark::get<ColIndex>(index);
-    if (col_index.is_collection()) {
-        set_int(col_index.get_index(), from_ref(ref));
+    if (index.is_collection()) {
+        set_int(index.get_index(), from_ref(ref));
         return;
     }
-    set_ref(col_index.get_index(), ref, type);
+    set_ref(index.get_index(), ref, type);
 }
 
 } // namespace realm

--- a/src/realm/obj.hpp
+++ b/src/realm/obj.hpp
@@ -94,8 +94,8 @@ public:
     ref_type get_collection_ref(Index, CollectionType) const final;
     bool check_collection_ref(Index, CollectionType) const noexcept final;
     void set_collection_ref(Index, ref_type, CollectionType) final;
-    ColIndex build_index(ColKey) const;
-    bool check_index(ColIndex) const;
+    StableIndex build_index(ColKey) const;
+    bool check_index(StableIndex) const;
 
     // Operator overloads
     bool operator==(const Obj& other) const;

--- a/src/realm/obj.hpp
+++ b/src/realm/obj.hpp
@@ -76,7 +76,11 @@ public:
     FullPath get_path() const final;
     Path get_short_path() const noexcept final;
     StablePath get_stable_path() const noexcept final;
-    void add_index(Path& path, Index ndx) const final;
+    void add_index(Path& path, const Index& ndx) const final;
+    size_t find_index(const Index&) const final
+    {
+        return realm::npos;
+    }
 
     bool update_if_needed() const final;
     TableRef get_table() const noexcept final

--- a/src/realm/object-store/impl/transact_log_handler.cpp
+++ b/src/realm/object-store/impl/transact_log_handler.cpp
@@ -87,7 +87,7 @@ KVOAdapter::KVOAdapter(std::vector<BindingContext::ObserverState>& observers, Bi
         tables[tbl] = {};
     for (auto& list : m_lists)
         collections.push_back({list.observer->table_key, list.observer->obj_key,
-                               StablePath{{ColIndex(list.col_key, 0)}}, &list.builder});
+                               StablePath{{StableIndex(list.col_key, 0)}}, &list.builder});
 }
 
 void KVOAdapter::before(Transaction& sg)

--- a/src/realm/sync/instruction_applier.cpp
+++ b/src/realm/sync/instruction_applier.cpp
@@ -1620,14 +1620,14 @@ InstructionApplier::PathResolver::resolve_dictionary_element(Dictionary& dict, I
         auto val = dict.get(string_key);
         if (val.is_type(type_Dictionary)) {
             if (auto pfield = mpark::get_if<InternString>(&*m_it_begin)) {
-                Dictionary d(dict, string_key);
+                Dictionary d(dict, dict.build_index(string_key));
                 ++m_it_begin;
                 return resolve_dictionary_element(d, *pfield);
             }
         }
         if (val.is_type(type_List)) {
             if (auto pindex = mpark::get_if<uint32_t>(&*m_it_begin)) {
-                Lst<Mixed> l(dict, string_key);
+                Lst<Mixed> l(dict, dict.build_index(string_key));
                 ++m_it_begin;
                 return resolve_list_element(l, *pindex);
             }

--- a/src/realm/sync/instruction_replication.hpp
+++ b/src/realm/sync/instruction_replication.hpp
@@ -198,7 +198,7 @@ private:
     bool m_was_short_circuited;
 };
 
-constexpr bool SYNC_SUPPORTS_NESTED_COLLECTIONS = true;
+constexpr bool SYNC_SUPPORTS_NESTED_COLLECTIONS = false;
 
 } // namespace sync
 } // namespace realm

--- a/src/realm/table.hpp
+++ b/src/realm/table.hpp
@@ -145,11 +145,11 @@ public:
     size_t get_column_count() const noexcept;
     DataType get_column_type(ColKey column_key) const;
     StringData get_column_name(ColKey column_key) const;
-    StringData get_column_name(ColIndex) const;
+    StringData get_column_name(StableIndex) const;
     ColumnAttrMask get_column_attr(ColKey column_key) const noexcept;
     DataType get_dictionary_key_type(ColKey column_key) const noexcept;
     ColKey get_column_key(StringData name) const noexcept;
-    ColKey get_column_key(ColIndex) const noexcept;
+    ColKey get_column_key(StableIndex) const noexcept;
     ColKeys get_column_keys() const;
     typedef util::Optional<std::pair<ConstTableRef, ColKey>> BacklinkOrigin;
     BacklinkOrigin find_backlink_origin(StringData origin_table_name, StringData origin_col_name) const noexcept;
@@ -1202,7 +1202,7 @@ inline StringData Table::get_column_name(ColKey column_key) const
     return m_spec.get_column_name(spec_ndx);
 }
 
-inline StringData Table::get_column_name(ColIndex index) const
+inline StringData Table::get_column_name(StableIndex index) const
 {
     return m_spec.get_column_name(m_leaf_ndx2spec_ndx[index.get_index().val]);
 }
@@ -1215,7 +1215,7 @@ inline ColKey Table::get_column_key(StringData name) const noexcept
     return spec_ndx2colkey(spec_ndx);
 }
 
-inline ColKey Table::get_column_key(ColIndex index) const noexcept
+inline ColKey Table::get_column_key(StableIndex index) const noexcept
 {
     return m_leaf_ndx2colkey[index.get_index().val];
 }

--- a/test/test_list.cpp
+++ b/test/test_list.cpp
@@ -1020,7 +1020,7 @@ TEST(List_Nested_Replication)
         StablePath expected_path;
     } parser(test_context);
 
-    parser.expected_path.push_back(KeyIndex());
+    parser.expected_path.push_back(StableIndex());
     parser.expected_path.push_back(dict->build_index("level1"));
     tr->advance_read(&parser);
 }

--- a/test/test_list.cpp
+++ b/test/test_list.cpp
@@ -636,6 +636,7 @@ TEST(List_AggOps)
 TEST(List_Nested_InMixed)
 {
     SHARED_GROUP_TEST_PATH(path);
+    std::string message;
     DBRef db = DB::create(make_in_realm_history(), path);
     auto tr = db->start_write();
     auto table = tr->add_table("table");
@@ -727,6 +728,13 @@ TEST(List_Nested_InMixed)
     CHECK_EQUAL(dynamic_cast<Lst<Mixed>*>(list.get())->get(0).get_int(), 8);
 
     tr->promote_to_write();
+    dict->insert("Dict", Mixed());
+    CHECK_THROW_ANY_GET_MESSAGE(dict2->insert("Five", 5), message); // This dictionary ceased to be
+    CHECK_EQUAL(message, "This is an ex-dictionary");
+    // Try to insert a new dictionary. The old dict2 shoulg still be stale
+    dict->insert_collection("Dict", CollectionType::Dictionary);
+    CHECK_THROW_ANY_GET_MESSAGE(dict2->insert("Five", 5), message); // This dictionary ceased to be
+    CHECK_EQUAL(message, "This is an ex-dictionary");
     // Assign another value. The old dictionary should be disposed.
     obj.set(col_any, Mixed(5));
     tr->verify();
@@ -775,7 +783,6 @@ TEST(List_Nested_InMixed)
       ]
     }
     */
-    std::string message;
     CHECK_EQUAL(list2->get(1), Mixed("Hello"));
     tr->promote_to_write();
     list2->remove(1);
@@ -1013,7 +1020,7 @@ TEST(List_Nested_Replication)
         StablePath expected_path;
     } parser(test_context);
 
-    parser.expected_path.push_back("");
-    parser.expected_path.push_back("level1");
+    parser.expected_path.push_back(KeyIndex());
+    parser.expected_path.push_back(dict->build_index("level1"));
     tr->advance_read(&parser);
 }


### PR DESCRIPTION
## What, How & Why?
Change the index held by the collection object from std::string to a structure (KeyIndex) ) containing both the beginning of the dictionary key (mostly for debugging purposes) and an index key generated for that particular collection. The key value is stored alongside the ref and compared with the key value found in index when trying to obtain the ref for the collection.

This is equivalent to what was previously done for Obj.

At the same time StableIndex is made simpler in that it is no longer an mpark::variant, but just a more simple structure. Main reason that this is now possible is that we are dropping storing the Dictionary key in the index, but only the salt.

<!-- Describe the changes and give some hints to guide your reviewers if possible. -->
<!-- Link to relevant issue this fixes -->

## ☑️ ToDos
* [ ] 📝 Changelog update
* [ ] 🚦 Tests (or not relevant)
* [ ] C-API, if public C++ API changed.
