### PR TITLE
Handle badchangeset error when printing changeset contents in debug

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@
 ### Internals
 * Add information about the reason a synchronization session is used for to flexible sync client BIND message. ([PR #6902](https://github.com/realm/realm-core/pull/6902))
 * Sync protocol version bumped to 10. ([PR #6902](https://github.com/realm/realm-core/pull/6902))
+* Handle badchangeset error when printing changeset contents in debug. ([PR #6921](https://github.com/realm/realm-core/pull/6921))
 
 ----------------------------------------------
 

--- a/evergreen/config.yml
+++ b/evergreen/config.yml
@@ -297,7 +297,7 @@ functions:
         export BAAS_HOST_NAME
 
         ssh_user="$(printf "ubuntu@%s" "$BAAS_HOST_NAME")"
-        ssh_options="-o ForwardAgent=yes -o IdentitiesOnly=yes -o StrictHostKeyChecking=no -o ConnectTimeout=10 -i .baas_ssh_key"
+        ssh_options="-o ForwardAgent=yes -o IdentitiesOnly=yes -o StrictHostKeyChecking=no -o ConnectTimeout=60 -i .baas_ssh_key"
 
         # Copy the baas_server.log and mongod.log files from the remote baas host
         REMOTE_PATH=/data/baas-remote/baas-work-dir

--- a/src/realm/sync/noinst/client_impl_base.cpp
+++ b/src/realm/sync/noinst/client_impl_base.cpp
@@ -2053,10 +2053,15 @@ void Session::send_upload_message()
 #if REALM_DEBUG
             ChunkedBinaryInputStream in{changeset_data};
             Changeset log;
-            parse_changeset(in, log);
-            std::stringstream ss;
-            log.print(ss);
-            logger.trace("Changeset (parsed):\n%1", ss.str());
+            try {
+                parse_changeset(in, log);
+                std::stringstream ss;
+                log.print(ss);
+                logger.trace("Changeset (parsed):\n%1", ss.str());
+            }
+            catch (const BadChangesetError& err) {
+                logger.error("Unable to parse changeset: %1", err.what());
+            }
 #endif
         }
 

--- a/test/test_changeset_encoding.cpp
+++ b/test/test_changeset_encoding.cpp
@@ -327,7 +327,7 @@ TEST(ChangesetParser_BadInstruction)
 {
     util::AppendBuffer<char> buffer;
     encode_instruction(buffer, 0x3e);
-    CHECK_BADCHANGESET(buffer, "unknown instruction");
+    CHECK_BADCHANGESET(buffer, "Unknown instruction type");
 }
 
 TEST(ChangesetParser_GoodInternString)


### PR DESCRIPTION
## What, How & Why?
After the updates from the unify core error handling project, the realm-sync-tests were crashing due to an "unknown instruction type" if debug level trace or higher was enabled. This was due to an exception being thrown by `parse_changeset()` during the `Sync_BadChangeset` test, which intentionally creates a bad changeset.

Updated debug output handling to catch the `BadChangesetError` exception and print a message instead of passing this exception up.

Also, fixed the race condition in the `Sync_DetectSchemaMismatch_*` tests that was resulting in the `realm::TableNameInUse: The specified table name is already in use` error. This was due to the first session completing sync before the write transaction transaction on the second session was completed. Moved the call to 	`nonsync_transact_nofity()` until after both write transactions were completed.

Also, updated the ssh connection timeout to 60 secs for scp and ssh operations when starting remote baas, since the startup of the remote baas was sometimes failing out. This was likely due to the original connection timeout of 10 seconds.

## ☑️ ToDos
* [x] 📝 Changelog update
* ~~[ ] 🚦 Tests (or not relevant)~~
* ~~[ ] C-API, if public C++ API changed.~~
