### PR TITLE
tsan fixes

### DIFF
--- a/src/realm/timestamp.hpp
+++ b/src/realm/timestamp.hpp
@@ -19,6 +19,7 @@
 #ifndef REALM_TIMESTAMP_HPP
 #define REALM_TIMESTAMP_HPP
 
+#include <array>
 #include <cstdint>
 #include <ostream>
 #include <chrono>

--- a/src/realm/timestamp.hpp
+++ b/src/realm/timestamp.hpp
@@ -182,8 +182,7 @@ public:
         return size_t(m_seconds) ^ size_t(m_nanoseconds);
     }
 
-    // Buffer must be at least 32 bytes long
-    const char* to_string(char* buffer) const;
+    const char* to_string(std::array<char, 32>& buffer) const;
 
     template <class Ch, class Tr>
     friend std::basic_ostream<Ch, Tr>& operator<<(std::basic_ostream<Ch, Tr>& out, const Timestamp&);
@@ -199,7 +198,7 @@ private:
 template <class C, class T>
 inline std::basic_ostream<C, T>& operator<<(std::basic_ostream<C, T>& out, const Timestamp& d)
 {
-    char buffer[32];
+    std::array<char, 32> buffer{};
     out << d.to_string(buffer);
     return out;
 }

--- a/src/realm/util/serializer.cpp
+++ b/src/realm/util/serializer.cpp
@@ -75,7 +75,7 @@ static void out_dec(char** buffer, unsigned val, int width)
 static constexpr long epoc_julian_days = date_to_julian(1970, 1, 1); // 2440588
 static constexpr int seconds_in_a_day = 24 * 60 * 60;
 
-const char* Timestamp::to_string(char* buffer) const
+const char* Timestamp::to_string(std::array<char, 32>& buffer) const
 {
     if (is_null()) {
         return "null";
@@ -106,7 +106,7 @@ const char* Timestamp::to_string(char* buffer) const
 
     julian_to_date(julian_days, &year, &month, &day);
 
-    char* p = buffer;
+    char* p = buffer.data();
     if (year < 0) {
         *p++ = '-';
         year = -year;
@@ -124,9 +124,9 @@ const char* Timestamp::to_string(char* buffer) const
     out_dec(&p, secs, 2);
     *p = '\0';
     if (nano) {
-        snprintf(p, 32 - (p - buffer), ".%09d", nano);
+        snprintf(p, 32 - (p - buffer.data()), ".%09d", nano);
     }
-    return buffer;
+    return buffer.data();
 }
 
 namespace util {

--- a/test/object-store/util/sync/sync_test_utils.cpp
+++ b/test/object-store/util/sync/sync_test_utils.cpp
@@ -246,16 +246,20 @@ void async_open_realm(const Realm::Config& config,
     std::mutex mutex;
     bool did_finish = false;
     auto task = Realm::get_synchronized_realm(config);
-    task->start([&, callback = std::move(finish)](ThreadSafeReference&& ref, std::exception_ptr e) {
-        callback(std::move(ref), e);
+    ThreadSafeReference tsr;
+    std::exception_ptr err = nullptr;
+    task->start([&](ThreadSafeReference&& ref, std::exception_ptr e) {
         std::lock_guard lock(mutex);
         did_finish = true;
+        tsr = std::move(ref);
+        err = e;
     });
     util::EventLoop::main().run_until([&] {
         std::lock_guard lock(mutex);
         return did_finish;
     });
     task->cancel(); // don't run the above notifier again on this session
+    finish(std::move(tsr), err);
 }
 
 #endif // REALM_ENABLE_AUTH_TESTS

--- a/test/test_json.cpp
+++ b/test/test_json.cpp
@@ -865,16 +865,16 @@ using namespace std::chrono;
 
 TEST(Json_Timestamp)
 {
-    char buffer1[31];
-    char buffer2[31];
+    std::array<char, 32> buffer1{};
+    std::array<char, 32> buffer2{};
     Timestamp(-63549305085, 0).to_string(buffer1);
-    CHECK(strcmp(buffer1, "-0044-03-15 15:15:15") == 0);
+    CHECK(strcmp(buffer1.data(), "-0044-03-15 15:15:15") == 0);
     Timestamp(0, 0).to_string(buffer1);
-    CHECK(strcmp(buffer1, "1970-01-01 00:00:00") == 0);
+    CHECK(strcmp(buffer1.data(), "1970-01-01 00:00:00") == 0);
     Timestamp(-1, 0).to_string(buffer1);
-    CHECK(strcmp(buffer1, "1969-12-31 23:59:59") == 0);
+    CHECK(strcmp(buffer1.data(), "1969-12-31 23:59:59") == 0);
     Timestamp(-1, -100000000).to_string(buffer1);
-    CHECK(strcmp(buffer1, "1969-12-31 23:59:58.900000000") == 0);
+    CHECK(strcmp(buffer1.data(), "1969-12-31 23:59:58.900000000") == 0);
 
     // Compare our own to_string with standard implementation
     // for years 1900 to 2050
@@ -895,8 +895,8 @@ TEST(Json_Timestamp)
 #else
         gmtime_r(&seconds, &buf);
 #endif
-        strftime(buffer2, sizeof(buffer2), "%Y-%m-%d %H:%M:%S", &buf);
-        CHECK(strcmp(buffer1, buffer2) == 0);
+        strftime(buffer2.data(), sizeof(buffer2), "%Y-%m-%d %H:%M:%S", &buf);
+        CHECK(strcmp(buffer1.data(), buffer2.data()) == 0);
     }
     /*
     auto t1 = steady_clock::now();


### PR DESCRIPTION
I haven't been able to get TSAN to report the errors locally so this is a best guess as to what the problem could be. I'll let CI verify.

I think the first problem was that the test `Json_Timestamp` was using an insufficient buffer size. I changed the size to be part of the type so that an incorrect size is a compiler error.

The thread issue about using Catch macros on a different thread I think I have solved by invoking the finish callback from our `async_open_realm` test utility on the calling thread.