### PR TITLE
allow RQL geo args to be strings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ### Enhancements
 * <New feature description> (PR [#????](https://github.com/realm/realm-core/pull/????))
 * Add a distinct error code for timeouts (SyncConnectTimeout) rather than using the same one as for less transient failures ([PR #6932](https://github.com/realm/realm-core/pull/6932)).
+* Allow arguments to RQL to be a string representation of a geospatial object for GEOWITHIN queries. This enables SDKs using the CAPI to marshal geo objects to strings. ([PR 6934](https://github.com/realm/realm-core/issues/6934))
 
 ### Fixed
 * <How do the end-user experience this issue? what was the impact?> ([#????](https://github.com/realm/realm-core/issues/????), since v?.?.?)

--- a/src/realm/parser/driver.cpp
+++ b/src/realm/parser/driver.cpp
@@ -794,66 +794,65 @@ Query GeoWithinNode::visit(ParserDriver* drv)
         auto geo_value = dynamic_cast<const ConstantGeospatialValue*>(right.get());
         return link_column->geo_within(geo_value->get_mixed().get<Geospatial>());
     }
+
+    REALM_ASSERT_3(argument.size(), >, 1);
+    REALM_ASSERT_3(argument[0], ==, '$');
+    size_t arg_no = size_t(strtol(argument.substr(1).c_str(), nullptr, 10));
+    auto right_type = drv->m_args.is_argument_null(arg_no) ? DataType(-1) : drv->m_args.type_for_argument(arg_no);
+
+    Geospatial geo_from_argument;
+    if (right_type == type_Geospatial) {
+        geo_from_argument = drv->m_args.geospatial_for_argument(arg_no);
+    }
+    else if (right_type == type_String) {
+        // This is a "hack" to allow users to pass in geospatial objects
+        // serialized as a string instead of as a native type. This is because
+        // the CAPI doesn't have support for marshalling polygons (of variable length)
+        // yet and that project was deprioritized to geospatial phase 2. This should be
+        // removed once SDKs are all using the binding generator.
+        std::string str_val = drv->m_args.string_for_argument(arg_no);
+        const std::string simulated_prefix = "simulated GEOWITHIN ";
+        str_val = simulated_prefix + str_val;
+        ParserDriver sub_driver;
+        try {
+            sub_driver.parse(str_val);
+        }
+        catch (const std::exception& ex) {
+            std::string doctored_err = ex.what();
+            size_t prefix_location = doctored_err.find(simulated_prefix);
+            if (prefix_location != std::string::npos) {
+                doctored_err.erase(prefix_location, simulated_prefix.size());
+            }
+            throw InvalidQueryError(util::format(
+                "Invalid syntax in serialized geospatial object at argument %1: '%2'", arg_no, doctored_err));
+        }
+        GeoWithinNode* node = dynamic_cast<GeoWithinNode*>(sub_driver.result);
+        REALM_ASSERT(node);
+        if (node->geo) {
+            if (node->geo->m_geo.get_type() != Geospatial::Type::Invalid) {
+                geo_from_argument = node->geo->m_geo;
+            }
+            else {
+                geo_from_argument = GeoPolygon{node->geo->m_points};
+            }
+        }
+    }
     else {
-        size_t arg_no = size_t(strtol(argument.substr(1).c_str(), nullptr, 10));
-        auto right_type = drv->m_args.is_argument_null(arg_no) ? DataType(-1) : drv->m_args.type_for_argument(arg_no);
-
-        Geospatial geo;
-        if (right_type == type_Geospatial) {
-            geo = drv->m_args.geospatial_for_argument(arg_no);
-        }
-        else if (right_type == type_String) {
-            // This is a "hack" to allow users to pass in geospatial objects
-            // serialized as a string instead of as a native type. This is because
-            // the CAPI doesn't have support for marshalling polygons (of variable length)
-            // yet and that project was deprioritized to geospatial phase 2. This should be
-            // removed once SDKs are all using the binding generator.
-            std::string str_val = drv->m_args.string_for_argument(arg_no);
-            const std::string simulated_prefix = "simulated GEOWITHIN ";
-            str_val = simulated_prefix + str_val;
-            ParserDriver sub_driver;
-            try {
-                sub_driver.parse(str_val);
-            }
-            catch (const std::exception& ex) {
-                std::string doctored_err = ex.what();
-                size_t prefix_location = doctored_err.find(simulated_prefix);
-                if (prefix_location != std::string::npos) {
-                    doctored_err.erase(prefix_location, simulated_prefix.size());
-                }
-                throw InvalidQueryError(util::format(
-                    "Invalid syntax in serialized geospatial object at argument %1: '%2'", arg_no, doctored_err));
-            }
-            if (GeoWithinNode* node = dynamic_cast<GeoWithinNode*>(sub_driver.result)) {
-                if (node->geo) {
-                    if (node->geo->m_geo.get_type() != Geospatial::Type::Invalid) {
-                        geo = node->geo->m_geo;
-                    }
-                    else {
-                        geo = GeoPolygon{node->geo->m_points};
-                    }
-                }
-            }
-        }
-        else {
-            throw InvalidQueryError(util::format("The right hand side of 'geoWithin' must be a geospatial constant "
-                                                 "value. But the provided type is '%1'",
-                                                 get_data_type_name(right_type)));
-        }
-
-        if (geo.get_type() == Geospatial::Type::Invalid) {
-            throw InvalidQueryError(
-                util::format("The right hand side of 'geoWithin' must be a valid Geospatial value, got '%1'", geo));
-        }
-        Status geo_status = geo.is_valid();
-        if (!geo_status.is_ok()) {
-            throw InvalidQueryError(
-                util::format("The Geospatial query argument region is invalid: '%1'", geo_status.reason()));
-        }
-        return link_column->geo_within(geo);
+        throw InvalidQueryError(util::format("The right hand side of 'geoWithin' must be a geospatial constant "
+                                             "value. But the provided type is '%1'",
+                                             get_data_type_name(right_type)));
     }
 
-    REALM_UNREACHABLE();
+    if (geo_from_argument.get_type() == Geospatial::Type::Invalid) {
+        throw InvalidQueryError(util::format(
+            "The right hand side of 'geoWithin' must be a valid Geospatial value, got '%1'", geo_from_argument));
+    }
+    Status geo_status = geo_from_argument.is_valid();
+    if (!geo_status.is_ok()) {
+        throw InvalidQueryError(
+            util::format("The Geospatial query argument region is invalid: '%1'", geo_status.reason()));
+    }
+    return link_column->geo_within(geo_from_argument);
 }
 #endif
 


### PR DESCRIPTION
The SDKs who use the CAPI do not have support for passing geospatial objects as arguments to the query parser. It is not trivial to enable that and so that work was postponed to geospatial phase 2 which has since been deprioritized. This PR enables this by allowing SDKs to pass the geo object as a serialized string instead which is then parsed by core and the geo object reconstructed. In an ideal world, this problem would be solved by the binding generator, but given our timelines this should work as a temporary solution.

Also see this [comment in the scope](https://docs.google.com/document/d/1Z7CK79CqebEtVllVHTNEq8neKhoMWeFCDjKBrn_pq1Y/edit?disco=AAAAwzW2Z5g) as to why a proper solution in the CAPI support was not implemented. 

## ☑️ ToDos
* [x] 📝 Changelog update
* [x] 🚦 Tests (or not relevant)
* [ ] C-API, if public C++ API changed.
