### PR TITLE
More consistent exception handling for nested collections

### DIFF
--- a/src/realm/collection.hpp
+++ b/src/realm/collection.hpp
@@ -53,7 +53,7 @@ public:
 protected:
     Obj m_obj;
     ref_type m_ref;
-    UpdateStatus update_if_needed_with_status() const noexcept final
+    UpdateStatus update_if_needed_with_status() const final
     {
         return UpdateStatus::Updated;
     }
@@ -474,15 +474,30 @@ public:
         return m_obj_mem;
     }
 
+    // The tricky thing here is that we should return true, even if the
+    // collection has not yet been created.
     bool is_attached() const noexcept final
     {
-        UpdateStatus status = m_parent ? m_parent->update_if_needed_with_status() : UpdateStatus::Detached;
-        if (status == UpdateStatus::Updated) {
-            // Make sure to update next time around
-            m_content_version = 0;
+        if (m_parent) {
+            try {
+                // Update the parent. Will throw if parent is not existing.
+                switch (m_parent->update_if_needed_with_status()) {
+                    case UpdateStatus::Updated:
+                        // Make sure to update next time around
+                        m_content_version = 0;
+                        [[fallthrough]];
+                    case UpdateStatus::NoChange:
+                        // Check if it would be legal to try and get a ref from parent
+                        // Will return true even if the current ref is 0.
+                        return m_parent->check_collection_ref(m_index, Interface::s_collection_type);
+                    case UpdateStatus::Detached:
+                        break;
+                }
+            }
+            catch (...) {
+            }
         }
-        return (status != UpdateStatus::Detached) &&
-               m_parent->check_collection_ref(m_index, Interface::s_collection_type);
+        return false;
     }
 
     /// Returns true if the accessor has changed since the last time
@@ -492,16 +507,19 @@ public:
     ///
     /// Note: This involves a call to `update_if_needed()`.
     ///
-    /// Note: This function does not return true for an accessor that became
-    /// detached since the last call, even though it may look to the caller as
-    /// if the size of the collection suddenly became zero.
+    /// Note: This function returns false for an accessor that became
+    /// detached since the last call
     bool has_changed() const noexcept final
     {
-        // `has_changed()` sneakily modifies internal state.
-        update_if_needed_with_status();
-        if (m_last_content_version != m_content_version) {
-            m_last_content_version = m_content_version;
-            return true;
+        try {
+            // `has_changed()` sneakily modifies internal state.
+            update_if_needed_with_status();
+            if (m_last_content_version != m_content_version) {
+                m_last_content_version = m_content_version;
+                return true;
+            }
+        }
+        catch (...) {
         }
         return false;
     }
@@ -626,7 +644,7 @@ protected:
         m_parent->set_collection_ref(m_index, ref, Interface::s_collection_type);
     }
 
-    UpdateStatus get_update_status() const noexcept
+    UpdateStatus get_update_status() const
     {
         UpdateStatus status = m_parent ? m_parent->update_if_needed_with_status() : UpdateStatus::Detached;
 
@@ -767,13 +785,12 @@ private:
     /// must invoke `init_from_parent()` or similar on its internal state
     /// accessors to refresh its view of the data.
     ///
-    /// If the owning object (or parent container) was deleted, this returns
-    /// `UpdateStatus::Detached`, and the caller is allowed to enter a
-    /// degenerate state.
+    /// If the owning object (or parent container) was deleted, an exception will
+    /// be thrown and the caller should enter a degenerate state.
     ///
     /// If no change has happened to the data, this function returns
     /// `UpdateStatus::NoChange`, and the caller is allowed to not do anything.
-    virtual UpdateStatus update_if_needed_with_status() const noexcept = 0;
+    virtual UpdateStatus update_if_needed_with_status() const = 0;
 };
 
 namespace _impl {

--- a/src/realm/collection_parent.hpp
+++ b/src/realm/collection_parent.hpp
@@ -172,9 +172,9 @@ protected:
     }
 
     virtual ~CollectionParent();
-    /// Update the accessor (and return `UpdateStatus::Detached` if the parent
-    /// is no longer valid, rather than throwing an exception).
-    virtual UpdateStatus update_if_needed_with_status() const noexcept = 0;
+    /// Update the accessor (and return `UpdateStatus::Detached` if the
+    // collection is not initialized.
+    virtual UpdateStatus update_if_needed_with_status() const = 0;
     /// Check if the storage version has changed and update if it has
     /// Return true if the object was updated
     virtual bool update_if_needed() const = 0;

--- a/src/realm/dictionary.hpp
+++ b/src/realm/dictionary.hpp
@@ -117,7 +117,7 @@ public:
     // throws std::out_of_range if key is not found
     Mixed get(Mixed key) const;
     // Noexcept version
-    util::Optional<Mixed> try_get(Mixed key) const noexcept;
+    util::Optional<Mixed> try_get(Mixed key) const;
     // adds entry if key is not found
     const Mixed operator[](Mixed key);
 
@@ -205,7 +205,7 @@ public:
     {
         return get_obj().get_table();
     }
-    UpdateStatus update_if_needed_with_status() const noexcept override;
+    UpdateStatus update_if_needed_with_status() const override;
     bool update_if_needed() const override;
     const Obj& get_object() const noexcept override
     {
@@ -253,7 +253,6 @@ private:
     void do_accumulate(size_t* return_ndx, AggregateType& agg) const;
 
     void ensure_created();
-    void ensure_attached() const;
     inline bool update() const
     {
         return update_if_needed_with_status() != UpdateStatus::Detached;

--- a/src/realm/keys.hpp
+++ b/src/realm/keys.hpp
@@ -37,6 +37,22 @@ enum class CollectionType {
     Dictionary = 21
 };
 
+inline std::ostream& operator<<(std::ostream& os, CollectionType ct)
+{
+    switch (ct) {
+        case CollectionType::List:
+            os << "list";
+            break;
+        case CollectionType::Set:
+            os << "set";
+            break;
+        case CollectionType::Dictionary:
+            os << "dictionary";
+            break;
+    }
+    return os;
+}
+
 struct TableKey {
     static constexpr uint32_t null_value = uint32_t(-1) >> 1; // free top bit
 

--- a/src/realm/list.hpp
+++ b/src/realm/list.hpp
@@ -183,7 +183,7 @@ public:
         return *m_tree;
     }
 
-    UpdateStatus update_if_needed_with_status() const noexcept final
+    UpdateStatus update_if_needed_with_status() const final
     {
         auto status = Base::get_update_status();
         switch (status) {
@@ -210,8 +210,10 @@ public:
     void ensure_created()
     {
         if (Base::should_update() || !(m_tree && m_tree->is_attached())) {
-            bool attached = init_from_parent(true);
-            REALM_ASSERT(attached);
+            // When allow_create is true, init_from_parent will always succeed
+            // In case of errors, an exception is thrown.
+            constexpr bool allow_create = true;
+            init_from_parent(allow_create); // Throws
             Base::update_content_version();
         }
     }
@@ -447,35 +449,15 @@ public:
         return *m_tree;
     }
 
-    UpdateStatus update_if_needed_with_status() const noexcept final
-    {
-        auto status = Base::get_update_status();
-        switch (status) {
-            case UpdateStatus::Detached: {
-                m_tree.reset();
-                return UpdateStatus::Detached;
-            }
-            case UpdateStatus::NoChange:
-                if (m_tree && m_tree->is_attached()) {
-                    return UpdateStatus::NoChange;
-                }
-                // The tree has not been initialized yet for this accessor, so
-                // perform lazy initialization by treating it as an update.
-                [[fallthrough]];
-            case UpdateStatus::Updated: {
-                bool attached = init_from_parent(false);
-                Base::update_content_version();
-                return attached ? UpdateStatus::Updated : UpdateStatus::Detached;
-            }
-        }
-        REALM_UNREACHABLE();
-    }
+    UpdateStatus update_if_needed_with_status() const final;
 
     void ensure_created()
     {
         if (Base::should_update() || !(m_tree && m_tree->is_attached())) {
-            init_from_parent(true);
-            ensure_attached();
+            // When allow_create is true, init_from_parent will always succeed
+            // In case of errors, an exception is thrown.
+            constexpr bool allow_create = true;
+            init_from_parent(allow_create); // Throws
             Base::update_content_version();
         }
     }
@@ -559,16 +541,9 @@ private:
             return Mixed{};
         return value;
     }
-    void ensure_attached() const
-    {
-        if (!m_tree->is_attached()) {
-            throw IllegalOperation("This is an ex-list");
-        }
-    }
     Mixed do_get(size_t ndx, const char* msg) const
     {
         const auto current_size = size();
-        ensure_attached();
         CollectionBase::validate_index(msg, ndx, current_size);
 
         return unresolved_to_null(m_tree->get(ndx));

--- a/src/realm/obj.cpp
+++ b/src/realm/obj.cpp
@@ -392,7 +392,7 @@ inline bool Obj::_update_if_needed() const
     return false;
 }
 
-UpdateStatus Obj::update_if_needed_with_status() const noexcept
+UpdateStatus Obj::update_if_needed_with_status() const
 {
     if (!m_table) {
         // Table deleted
@@ -2349,9 +2349,9 @@ ref_type Obj::get_collection_ref(Index index, CollectionType type) const
         if (val.is_type(DataType(int(type)))) {
             return val.get_ref();
         }
+        throw realm::IllegalOperation(util::format("Not a %1", type));
     }
-    // This exception should never escape to the application
-    throw StaleAccessor("This collection has joined the choir invisible");
+    throw StaleAccessor("This collection is no more");
 }
 
 bool Obj::check_collection_ref(Index index, CollectionType type) const noexcept

--- a/src/realm/obj.hpp
+++ b/src/realm/obj.hpp
@@ -69,7 +69,7 @@ public:
     Obj(TableRef table, MemRef mem, ObjKey key, size_t row_ndx);
 
     // Overriding members of CollectionParent:
-    UpdateStatus update_if_needed_with_status() const noexcept final;
+    UpdateStatus update_if_needed_with_status() const final;
     // Get the path in a minimal format without including object accessors.
     // If you need to obtain additional information for each object in the path,
     // you should use get_fat_path() or traverse_path() instead (see below).

--- a/src/realm/set.hpp
+++ b/src/realm/set.hpp
@@ -167,7 +167,7 @@ public:
         return *m_tree;
     }
 
-    UpdateStatus update_if_needed_with_status() const noexcept final
+    UpdateStatus update_if_needed_with_status() const final
     {
         auto status = Base::get_update_status();
         switch (status) {
@@ -194,10 +194,10 @@ public:
     void ensure_created()
     {
         if (Base::should_update() || !(m_tree && m_tree->is_attached())) {
-            bool attached = init_from_parent(true);
-            if (!attached) {
-                throw IllegalOperation("This is an ex-set");
-            }
+            // When allow_create is true, init_from_parent will always succeed
+            // In case of errors, an exception is thrown.
+            constexpr bool allow_create = true;
+            init_from_parent(allow_create); // Throws
             Base::update_content_version();
         }
     }
@@ -245,7 +245,7 @@ private:
         }
         catch (...) {
             m_tree->detach();
-            return false;
+            throw;
         }
         return true;
     }


### PR DESCRIPTION
## What, How & Why?
<!-- Describe the changes and give some hints to guide your reviewers if possible. -->
<!-- Link to relevant issue this fixes -->
This commit fixes the problem that trying to access position 0 in a newly created nested list would give an exception saying that the collection was gone instead of an out-of-bounds exception. This was because we had a test for attached before validating the index.
    
The solution selected is to remove "ensure_attached" and let the exceptions thrown in "get_collection_ref" flow all the way to the client. This is kind of fundamental change in that we must remove the noexcept specification from  "update_if_needed_with_status" and make the "init_from_parent" functions rethrow the exceptions caught. The noexcept functions calling "update_if_..." must add a try..catch block.

## ☑️ ToDos
* [ ] 📝 Changelog update
* [ ] 🚦 Tests (or not relevant)
* [ ] C-API, if public C++ API changed.
