### PR TITLE
Optimize sort followed by limit

### DIFF
--- a/src/realm/query.cpp
+++ b/src/realm/query.cpp
@@ -1398,9 +1398,12 @@ TableView Query::find_all(size_t limit) const
 
     TableView ret(*this, limit);
     if (m_ordering) {
+        // apply_descriptor_ordering will call do_sync
         ret.apply_descriptor_ordering(*m_ordering);
     }
-    ret.do_sync();
+    else {
+        ret.do_sync();
+    }
     return ret;
 }
 

--- a/src/realm/sort_descriptor.cpp
+++ b/src/realm/sort_descriptor.cpp
@@ -311,7 +311,7 @@ void SortDescriptor::execute(IndexPairs& v, const Sorter& predicate, const BaseD
         IndexPairs buffer;
         buffer.reserve(limit + 1);
         for (auto& elem : v) {
-            auto it = std::lower_bound(buffer.begin(), buffer.end(), elem, predicate);
+            auto it = std::lower_bound(buffer.begin(), buffer.end(), elem, std::ref(predicate));
             buffer.insert(it, elem);
             if (buffer.size() > limit) {
                 buffer.pop_back();

--- a/src/realm/sort_descriptor.cpp
+++ b/src/realm/sort_descriptor.cpp
@@ -301,7 +301,29 @@ BaseDescriptor::Sorter SortDescriptor::sorter(Table const& table, const IndexPai
 
 void SortDescriptor::execute(IndexPairs& v, const Sorter& predicate, const BaseDescriptor* next) const
 {
-    std::sort(v.begin(), v.end(), std::ref(predicate));
+    size_t limit = size_t(-1);
+    if (next && next->get_type() == DescriptorType::Limit) {
+        limit = static_cast<const LimitDescriptor*>(next)->get_limit();
+    }
+    // Measurements shows that if limit is smaller than size / 16, then
+    // it is quicker to make a sorted insert into a smaller vector
+    if (limit < (v.size() >> 4)) {
+        IndexPairs buffer;
+        buffer.reserve(limit + 1);
+        for (auto& elem : v) {
+            auto it = std::lower_bound(buffer.begin(), buffer.end(), elem, predicate);
+            buffer.insert(it, elem);
+            if (buffer.size() > limit) {
+                buffer.pop_back();
+            }
+        }
+        v.m_removed_by_limit += v.size() - limit;
+        v.erase(v.begin() + limit, v.end());
+        std::move(buffer.begin(), buffer.end(), v.begin());
+    }
+    else {
+        std::sort(v.begin(), v.end(), std::ref(predicate));
+    }
 
     // not doing this on the last step is an optimisation
     if (next) {


### PR DESCRIPTION
If the limit is much smaller than the total size of the TableView, then it is faster to make a sorted insert into a vector that is kept at the limit size.

## What, How & Why?
<!-- Describe the changes and give some hints to guide your reviewers if possible. -->
<!-- Link to relevant issue this fixes -->

## ☑️ ToDos
* [ ] 📝 Changelog update
* [ ] 🚦 Tests (or not relevant)
* [ ] C-API, if public C++ API changed.
