### PR TITLE
Add an evergreen job to validate that all installed headers build

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@
 
 ### Fixed
 * <How do the end-user experience this issue? what was the impact?> ([#????](https://github.com/realm/realm-core/issues/????), since v?.?.?)
-* None.
+* realm/sync/network/websocket_error.hpp was missing from the install package ([PR #6954](https://github.com/realm/realm-core/pull/6954), since v13.18.0).
 
 ### Breaking changes
 * None.
@@ -17,7 +17,7 @@
 -----------
 
 ### Internals
-* None.
+* Add a CI job to validate that the headers in the installation package all build ([PR #6954](https://github.com/realm/realm-core/pull/6954)).
 
 ----------------------------------------------
 

--- a/evergreen/config.yml
+++ b/evergreen/config.yml
@@ -649,6 +649,28 @@ tasks:
         xcrun swift build
         xcrun swift run ObjectStoreTests
 
+- name: validate-installed-headers
+  exec_timeout_secs: 1800
+  commands:
+  - func: "fetch source"
+  - func: "fetch binaries"
+  - command: shell.exec
+    params:
+      working_dir: realm-core
+      shell: /bin/bash
+      script: |-
+        #!/bin/bash
+        set -o errexit
+        set -o pipefail
+        set -o verbose
+
+        if [ -n "${xcode_developer_dir}" ]; then
+            export DEVELOPER_DIR="${xcode_developer_dir}"
+        fi
+
+        ./tools/build-cocoa.sh -bm
+        find core/include/realm -name '*.hpp' -print0 | xargs -0 -P "${max_jobs}" -n 1 clang++ -c -o /dev/null -Icore/include -std=c++17
+
 - name: test-on-exfat
   exec_timeout_secs: 2700
   commands:
@@ -1352,6 +1374,7 @@ buildvariants:
   tasks:
   - name: compile_test
   - name: swift-build-and-test
+  - name: validate-installed-headers
 
 - name: macos-encrypted
   display_name: "MacOS 11.0 x86_64 (Encryption enabled)"

--- a/src/realm/array_basic_tpl.hpp
+++ b/src/realm/array_basic_tpl.hpp
@@ -21,9 +21,8 @@
 
 #include <algorithm>
 #include <limits>
-#include <stdexcept>
-#include <iomanip>
 
+#include <realm/array_basic.hpp>
 #include <realm/node.hpp>
 
 namespace realm {

--- a/src/realm/array_bool.hpp
+++ b/src/realm/array_bool.hpp
@@ -20,6 +20,7 @@
 #define REALM_ARRAY_BOOL_HPP
 
 #include <realm/array.hpp>
+#include <realm/mixed.hpp>
 
 namespace realm {
 

--- a/src/realm/array_list.hpp
+++ b/src/realm/array_list.hpp
@@ -20,6 +20,7 @@
 #define REALM_ARRAY_LIST_HPP
 
 #include <realm/array.hpp>
+#include <realm/mixed.hpp>
 
 namespace realm {
 

--- a/src/realm/array_typed_link.hpp
+++ b/src/realm/array_typed_link.hpp
@@ -19,9 +19,10 @@
 #ifndef REALM_ARRAY_TYPED_LINK_HPP
 #define REALM_ARRAY_TYPED_LINK_HPP
 
+#include <realm/array.hpp>
 #include <realm/data_type.hpp>
 #include <realm/keys.hpp>
-#include <realm/array.hpp>
+#include <realm/mixed.hpp>
 
 namespace realm {
 

--- a/src/realm/object-store/util/copyable_atomic.hpp
+++ b/src/realm/object-store/util/copyable_atomic.hpp
@@ -19,8 +19,9 @@
 #ifndef REALM_OS_COPYABLE_ATOMIC_HPP
 #define REALM_OS_COPYABLE_ATOMIC_HPP
 
-namespace realm {
-namespace util {
+#include <atomic>
+
+namespace realm::util {
 
 // std::atomic is not copyable because the resulting semantics are not useful
 // for many of the things atomics can be used for (in particular, anything
@@ -51,6 +52,5 @@ struct CopyableAtomic : std::atomic<T> {
     }
 };
 
-} // namespace util
-} // namespace realm
+} // namespace realm::util
 #endif // REALM_OS_COPYABLE_ATOMIC_HPP

--- a/src/realm/sync/CMakeLists.txt
+++ b/src/realm/sync/CMakeLists.txt
@@ -60,6 +60,7 @@ set(SYNC_NETWORK_INSTALL_HEADERS
     network/network.hpp
     network/network_ssl.hpp
     network/websocket.hpp
+    network/websocket_error.hpp
 )
 
 set(NOINST_HEADERS

--- a/src/realm/util/serializer.cpp
+++ b/src/realm/util/serializer.cpp
@@ -27,11 +27,10 @@
 #include <realm/table.hpp>
 #include <realm/timestamp.hpp>
 #include <realm/util/base64.hpp>
-#include <realm/table.hpp>
 
 #include <cctype>
 #include <cmath>
-
+#include <iomanip>
 
 namespace realm {
 


### PR DESCRIPTION
We've had a few issues with headers being added as dependencies of an installed header but not being installed, so add a CI job that validates that all installed headers can be compiled with only the other installed headers available. This also catches some incidental missing header inclusions where a header failes to include everything it depends on.

Only runs on macOS since Cocoa seems to be the only SDK which relies on this being valid.