### PR TITLE
Remove confusing message for flock unlock failure on Android

### DIFF
--- a/src/realm/util/file.cpp
+++ b/src/realm/util/file.cpp
@@ -1101,14 +1101,7 @@ static void _unlock(int m_fd)
         r = flock(m_fd, LOCK_UN);
     } while (r != 0 && errno == EINTR);
     if (r) {
-        std::string message =
-            "File::unlock() has failed, this is likely due to some limitation in the OS file system.";
-#ifdef REALM_ANDROID
-        message +=
-            " The most common cause is trying to use Realm on external storage. From Android API 30 this is no "
-            "longer supported. See https://developer.android.com/about/versions/11/privacy/storage for more details.";
-#endif
-        throw SystemError(errno, message);
+        throw SystemError(errno, "File::unlock() has failed");
     }
 }
 #endif


### PR DESCRIPTION
## What, How & Why?
There is no clear suggestion that it was the case. Besides the original reports mentioned activating needed manifest for external storage access. What is supported on external storage from the realm side is not yet clear and need clarification.
