### PR TITLE
Resending pending subscriptions can result in inconsistent sync progress

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
 * When using OpenSSL (i.e. on non-Apple platforms) the `TlsHandshakeFailed` error code would never be reported and instead TLS errors would be reported as `SyncConnectFailed` ([PR #6938](https://github.com/realm/realm-core/pull/6938)).
 * When using SecureTransport (i.e. on Apple platforms) only some TLS errors were reported as `TlsHandshakeFailed` and most were reported as `SyncConnectFailed` ([PR #6938](https://github.com/realm/realm-core/pull/6938)).
 * Sync errors originating from OpenSSL used the error message from the wrong end of the error stack, often resulting in very unhelpful error message ([PR #6938](https://github.com/realm/realm-core/pull/6938)).
+* Sending empty UPLOAD messages may lead to 'Bad server version' errors and client reset. ([6966](https://github.com/realm/realm-core/issues/6966), since v11.8.0)
 
 ### Breaking changes
 * None.

--- a/src/realm/sync/noinst/client_impl_base.cpp
+++ b/src/realm/sync/noinst/client_impl_base.cpp
@@ -2024,6 +2024,8 @@ void Session::send_upload_message()
         // If we need to limit upload up to some version other than the last client version available and there are no
         // changes to upload, then there is no need to send an empty message.
         if (target_upload_version != m_upload_target_version) {
+            logger.debug("Empty UPLOAD was skipped (progress_client_version=%1, progress_server_version=%2)",
+                         m_upload_progress.client_version, m_upload_progress.last_integrated_server_version);
             // Other messages may be waiting to be sent
             return enlist_to_send(); // Throws
         }

--- a/src/realm/sync/noinst/client_impl_base.cpp
+++ b/src/realm/sync/noinst/client_impl_base.cpp
@@ -2021,7 +2021,7 @@ void Session::send_upload_message()
         // Nothing more to upload right now
         check_for_upload_completion(); // Throws
         // If we need to limit upload up to some version other than the last client version available and there are no
-        // changes to upload, then there is no point in sending an empty message.
+        // changes to upload, then there is no need to send an empty message.
         if (target_upload_version != m_upload_target_version) {
             // Other messages may be waiting to be sent
             return enlist_to_send(); // Throws
@@ -2697,6 +2697,12 @@ Status ClientImpl::Session::check_received_sync_progress(const SyncProgress& pro
                                "of the download cursor cannot be greater than the latest client version integrated "
                                "on the server (download: %1, upload: %2)",
                                b.download.last_integrated_client_version, b.upload.client_version);
+    }
+    if (b.download.server_version < b.upload.last_integrated_server_version) {
+        message = util::format(
+            "The server version of the download cursor cannot be less than the server version integrated in the "
+            "latest client version acknowledged by the server (download: %1, upload: %2)",
+            b.download.server_version, b.upload.last_integrated_server_version);
     }
 
     if (message.empty()) {


### PR DESCRIPTION
## What, How & Why?
When a change of query (COQ) needs to be sent to the server, the sync client first uploads the local changes up to the client version associated to the query. Sometimes, these upload messages are empty. If the the client disconnects and reconnects before the query was fully bootstrapped, the sync client re-sends the upload and COQ messages to the server. This is a problem especially if the upload message is empty. Due to history trimming, the sync client may not know anymore the last_integrated_server_version associated with the client version sent in the upload message. This results in the server issuing a `Bad server version` error (and a client reset) due to inconsistent sync progress (same client version is sent with two different server versions).

This PR fixes the issue by making the sync client skip sending empty upload messages before a COQ (the server does not need these empty messages).

Fixes #6966.

## ☑️ ToDos
* [x] 📝 Changelog update
* [X] 🚦 Tests (or not relevant)
* ~~[ ] C-API, if public C++ API changed.~~
