### PR TITLE
reorg GroupWriter and GroupComitter so that each is their own

### DIFF
--- a/src/realm/alloc_slab.hpp
+++ b/src/realm/alloc_slab.hpp
@@ -721,7 +721,7 @@ private:
     friend class DB;
     friend class Group;
     friend class GroupWriter;
-    friend class GroupComitter;
+    friend class GroupCommitter;
 };
 
 

--- a/src/realm/db.cpp
+++ b/src/realm/db.cpp
@@ -2512,7 +2512,7 @@ void DB::low_level_commit(uint_fast64_t new_version, Transaction& transaction, b
         out.sync_according_to_durability();
         if (Durability(info->durability) == Durability::Full || Durability(info->durability) == Durability::Unsafe) {
             if (commit_to_disk) {
-                GroupComitter cm(transaction, Durability(info->durability), m_marker_observer.get());
+                GroupCommitter cm(transaction, Durability(info->durability), m_marker_observer.get());
                 cm.commit(new_top_ref);
             }
         }

--- a/src/realm/db.cpp
+++ b/src/realm/db.cpp
@@ -2482,7 +2482,7 @@ void DB::low_level_commit(uint_fast64_t new_version, Transaction& transaction, b
 
     GroupWriter out(transaction, Durability(info->durability), m_marker_observer.get()); // Throws
     out.set_versions(new_version, top_refs, any_new_unreachables);
-    out.check_evacuation();
+    out.prepare_evacuation();
     auto t1 = std::chrono::steady_clock::now();
     auto commit_size = m_alloc.get_commit_size();
     if (m_logger) {

--- a/src/realm/group.hpp
+++ b/src/realm/group.hpp
@@ -834,7 +834,7 @@ private:
 
     friend class Table;
     friend class GroupWriter;
-    friend class GroupComitter;
+    friend class GroupCommitter;
     friend class DB;
     friend class _impl::GroupFriend;
     friend class metrics::QueryInfo;

--- a/src/realm/group_writer.cpp
+++ b/src/realm/group_writer.cpp
@@ -307,6 +307,19 @@ GroupWriter::GroupWriter(Group& group, Durability dura, WriteMarker* write_marke
     m_backoff = 0;
 }
 
+
+void GroupWriter::sync_according_to_durability()
+{
+    switch (m_durability) {
+        case Durability::Full:
+        case Durability::Unsafe:
+            m_window_mgr.sync_all_mappings();
+            break;
+        case Durability::MemOnly:
+            m_window_mgr.flush_all_mappings();
+    }
+}
+
 GroupWriter::~GroupWriter() = default;
 
 size_t GroupWriter::get_file_size() const noexcept

--- a/src/realm/group_writer.cpp
+++ b/src/realm/group_writer.cpp
@@ -232,7 +232,7 @@ WriteWindowMgr::WriteWindowMgr(SlabAlloc& alloc, Durability dura, WriteMarker* w
 #endif
 }
 
-GroupComitter::GroupComitter(Group& group, Durability dura, WriteMarker* write_marker)
+GroupCommitter::GroupCommitter(Group& group, Durability dura, WriteMarker* write_marker)
     : m_group(group)
     , m_alloc(group.m_alloc)
     , m_durability(dura)
@@ -240,7 +240,7 @@ GroupComitter::GroupComitter(Group& group, Durability dura, WriteMarker* write_m
 {
 }
 
-GroupComitter::~GroupComitter() = default;
+GroupCommitter::~GroupCommitter() = default;
 
 GroupWriter::GroupWriter(Group& group, Durability dura, WriteMarker* write_marker)
     : m_group(group)
@@ -1369,7 +1369,7 @@ void GroupWriter::write_array_at(T* translator, ref_type ref, const char* data, 
 }
 
 
-void GroupComitter::commit(ref_type new_top_ref)
+void GroupCommitter::commit(ref_type new_top_ref)
 {
     using _impl::SimulatedFailure;
     SimulatedFailure::trigger(SimulatedFailure::group_writer__commit); // Throws

--- a/src/realm/group_writer.cpp
+++ b/src/realm/group_writer.cpp
@@ -70,7 +70,7 @@ private:
 
 
 // Class controlling a memory mapped window into a file
-class GroupComitter::MapWindow {
+class WriteWindowMgr::MapWindow {
 public:
     MapWindow(size_t alignment, util::File& f, ref_type start_ref, size_t initial_size,
               util::WriteMarker* write_marker = nullptr);
@@ -101,7 +101,7 @@ private:
 };
 
 // True if a requested block fall within a memory mapping.
-bool GroupComitter::MapWindow::matches(ref_type start_ref, size_t size)
+bool WriteWindowMgr::MapWindow::matches(ref_type start_ref, size_t size)
 {
     if (start_ref < m_base_ref)
         return false;
@@ -117,14 +117,14 @@ bool GroupComitter::MapWindow::matches(ref_type start_ref, size_t size)
 //
 // In cases where a 1MB window would stretch beyond the end of the file, we choose
 // a smaller window. Anything mapped after the end of file would be undefined anyways.
-ref_type GroupComitter::MapWindow::aligned_to_mmap_block(ref_type start_ref)
+ref_type WriteWindowMgr::MapWindow::aligned_to_mmap_block(ref_type start_ref)
 {
     // align to 1MB boundary
     size_t page_mask = m_alignment - 1;
     return start_ref & ~page_mask;
 }
 
-size_t GroupComitter::MapWindow::get_window_size(util::File& f, ref_type start_ref, size_t size)
+size_t WriteWindowMgr::MapWindow::get_window_size(util::File& f, ref_type start_ref, size_t size)
 {
     size_t window_size = start_ref + size - m_base_ref;
     // always map at least to match alignment
@@ -146,7 +146,7 @@ size_t GroupComitter::MapWindow::get_window_size(util::File& f, ref_type start_r
 //
 // extends_to_match() will extend an existing mapping to accomodate a new request if possible
 // and return true. If the request falls in a different 1MB window, it'll return false.
-bool GroupComitter::MapWindow::extends_to_match(util::File& f, ref_type start_ref, size_t size)
+bool WriteWindowMgr::MapWindow::extends_to_match(util::File& f, ref_type start_ref, size_t size)
 {
     size_t aligned_ref = aligned_to_mmap_block(start_ref);
     if (aligned_ref != m_base_ref)
@@ -158,8 +158,8 @@ bool GroupComitter::MapWindow::extends_to_match(util::File& f, ref_type start_re
     return true;
 }
 
-GroupComitter::MapWindow::MapWindow(size_t alignment, util::File& f, ref_type start_ref, size_t size,
-                                    util::WriteMarker* write_marker)
+WriteWindowMgr::MapWindow::MapWindow(size_t alignment, util::File& f, ref_type start_ref, size_t size,
+                                     util::WriteMarker* write_marker)
     : m_alignment(alignment)
 {
     m_base_ref = aligned_to_mmap_block(start_ref);
@@ -173,43 +173,42 @@ GroupComitter::MapWindow::MapWindow(size_t alignment, util::File& f, ref_type st
 #endif
 }
 
-GroupComitter::MapWindow::~MapWindow()
+WriteWindowMgr::MapWindow::~MapWindow()
 {
     m_map.sync();
     m_map.unmap();
 }
 
-void GroupComitter::MapWindow::flush()
+void WriteWindowMgr::MapWindow::flush()
 {
     m_map.flush();
 }
 
-void GroupComitter::MapWindow::sync()
+void WriteWindowMgr::MapWindow::sync()
 {
     flush();
     m_map.sync();
 }
 
-char* GroupComitter::MapWindow::translate(ref_type ref)
+char* WriteWindowMgr::MapWindow::translate(ref_type ref)
 {
     return m_map.get_addr() + (ref - m_base_ref);
 }
 
-void GroupComitter::MapWindow::encryption_read_barrier(void* start_addr, size_t size)
+void WriteWindowMgr::MapWindow::encryption_read_barrier(void* start_addr, size_t size)
 {
     realm::util::encryption_read_barrier_for_write(start_addr, size, m_map.get_encrypted_mapping());
 }
 
-void GroupComitter::MapWindow::encryption_write_barrier(void* start_addr, size_t size)
+void WriteWindowMgr::MapWindow::encryption_write_barrier(void* start_addr, size_t size)
 {
     realm::util::encryption_write_barrier(start_addr, size, m_map.get_encrypted_mapping());
 }
 
-GroupComitter::GroupComitter(Group& group, Durability dura, WriteMarker* write_marker)
-    : m_group(group)
-    , m_alloc(group.m_alloc)
-    , m_write_marker(write_marker)
+WriteWindowMgr::WriteWindowMgr(SlabAlloc& alloc, Durability dura, WriteMarker* write_marker)
+    : m_alloc(alloc)
     , m_durability(dura)
+    , m_write_marker(write_marker)
 {
     m_map_windows.reserve(num_map_windows);
 #if REALM_PLATFORM_APPLE && REALM_MOBILE
@@ -233,10 +232,21 @@ GroupComitter::GroupComitter(Group& group, Durability dura, WriteMarker* write_m
 #endif
 }
 
+GroupComitter::GroupComitter(Group& group, Durability dura, WriteMarker* write_marker)
+    : m_group(group)
+    , m_alloc(group.m_alloc)
+    , m_durability(dura)
+    , m_window_mgr(group.m_alloc, dura, write_marker)
+{
+}
+
 GroupComitter::~GroupComitter() = default;
 
 GroupWriter::GroupWriter(Group& group, Durability dura, WriteMarker* write_marker)
-    : GroupComitter(group, dura, write_marker)
+    : m_group(group)
+    , m_alloc(group.m_alloc)
+    , m_durability(dura)
+    , m_window_mgr(group.m_alloc, dura, write_marker)
     , m_free_positions(m_alloc)
     , m_free_lengths(m_alloc)
     , m_free_versions(m_alloc)
@@ -305,14 +315,14 @@ size_t GroupWriter::get_file_size() const noexcept
     return sz;
 }
 
-void GroupComitter::flush_all_mappings()
+void WriteWindowMgr::flush_all_mappings()
 {
     for (const auto& window : m_map_windows) {
         window->flush();
     }
 }
 
-void GroupComitter::sync_all_mappings()
+void WriteWindowMgr::sync_all_mappings()
 {
     if (m_durability == Durability::Unsafe)
         return;
@@ -325,7 +335,7 @@ void GroupComitter::sync_all_mappings()
 // existing one (possibly extended to accomodate the new request). Maintain a
 // cache of open windows which are sync'ed and closed following a least recently
 // used policy. Entries in the cache are kept in MRU order.
-GroupComitter::MapWindow* GroupComitter::get_window(ref_type start_ref, size_t size)
+WriteWindowMgr::MapWindow* WriteWindowMgr::get_window(ref_type start_ref, size_t size)
 {
     auto match = std::find_if(m_map_windows.begin(), m_map_windows.end(), [&](const auto& window) {
         return window->matches(start_ref, size) || window->extends_to_match(m_alloc.get_file(), start_ref, size);
@@ -581,7 +591,7 @@ void GroupWriter::backdate()
     }
 }
 
-void GroupWriter::check_evacuation()
+void GroupWriter::prepare_evacuation()
 {
     Array& top = m_group.m_top;
     if (top.size() > Group::s_evacuation_point_ndx) {
@@ -662,7 +672,7 @@ ref_type GroupWriter::write_group()
         if (ref_type history_ref = top.get_as_ref(Group::s_hist_ref_ndx)) {
             Allocator& alloc = top.get_alloc();
             ref_type new_history_ref = Array::write(history_ref, alloc, *writer, only_if_modified); // Throws
-            top.set(Group::s_hist_ref_ndx, from_ref(new_history_ref));                            // Throws
+            top.set(Group::s_hist_ref_ndx, from_ref(new_history_ref));                              // Throws
         }
     }
     if (top.size() > Group::s_evacuation_point_ndx) {
@@ -900,7 +910,7 @@ ref_type GroupWriter::write_group()
         write_array_at(translator, top_ref, top.get_header(), top_byte_size); // Throws
     }
     else {
-        MapWindow* window = get_window(reserve_ref, end_ref - reserve_ref);
+        MapWindow* window = m_window_mgr.get_window(reserve_ref, end_ref - reserve_ref);
         char* start_addr = window->translate(reserve_ref);
         window->encryption_read_barrier(start_addr, used);
         write_array_at(window, free_positions_ref, m_free_positions.get_header(), free_positions_size); // Throws
@@ -1318,7 +1328,7 @@ ref_type GroupWriter::write_array(const char* data, size_t size, uint32_t checks
     size_t pos = get_free_space(size);
 
     // Write the block
-    MapWindow* window = get_window(pos, size);
+    MapWindow* window = m_window_mgr.get_window(pos, size);
     char* dest_addr = window->translate(pos);
     REALM_ASSERT_RELEASE(is_aligned(dest_addr));
     window->encryption_read_barrier(dest_addr, size);
@@ -1351,7 +1361,7 @@ void GroupComitter::commit(ref_type new_top_ref)
     using _impl::SimulatedFailure;
     SimulatedFailure::trigger(SimulatedFailure::group_writer__commit); // Throws
 
-    MapWindow* window = get_window(0, sizeof(SlabAlloc::Header));
+    MapWindow* window = m_window_mgr.get_window(0, sizeof(SlabAlloc::Header));
     SlabAlloc::Header& file_header = *reinterpret_cast<SlabAlloc::Header*>(window->translate(0));
     window->encryption_read_barrier(&file_header, sizeof file_header);
 
@@ -1384,9 +1394,9 @@ void GroupComitter::commit(ref_type new_top_ref)
     // Make sure that that all data relating to the new snapshot is written to
     // stable storage before flipping the slot selector
     window->encryption_write_barrier(&file_header, sizeof file_header);
-    flush_all_mappings();
+    m_window_mgr.flush_all_mappings();
     if (!disable_sync) {
-        sync_all_mappings();
+        m_window_mgr.sync_all_mappings();
         m_alloc.get_file().barrier();
     }
 

--- a/src/realm/group_writer.hpp
+++ b/src/realm/group_writer.hpp
@@ -87,12 +87,12 @@ protected:
     util::WriteMarker* m_write_marker = nullptr;
 };
 
-class GroupComitter {
+class GroupCommitter {
 public:
     using Durability = DBOptions::Durability;
     using MapWindow = WriteWindowMgr::MapWindow;
-    GroupComitter(Group&, Durability dura = Durability::Full, util::WriteMarker* write_marker = nullptr);
-    ~GroupComitter();
+    GroupCommitter(Group&, Durability dura = Durability::Full, util::WriteMarker* write_marker = nullptr);
+    ~GroupCommitter();
     /// Flush changes to physical medium, then write the new top ref
     /// to the file header, then flush again. Pass the top ref
     /// returned by write_group().

--- a/src/realm/group_writer.hpp
+++ b/src/realm/group_writer.hpp
@@ -57,25 +57,24 @@ public:
 using TopRefMap = std::map<uint64_t, VersionInfo>;
 using VersionVector = std::vector<uint64_t>;
 
-class GroupComitter {
+class WriteWindowMgr {
 public:
     using Durability = DBOptions::Durability;
-    GroupComitter(Group&, Durability dura = Durability::Full, util::WriteMarker* write_marker = nullptr);
-    ~GroupComitter();
-    /// Flush changes to physical medium, then write the new top ref
-    /// to the file header, then flush again. Pass the top ref
-    /// returned by write_group().
-    void commit(ref_type new_top_ref);
+    WriteWindowMgr(SlabAlloc& alloc, Durability dura, util::WriteMarker* write_marker);
     // Flush all cached memory mappings
     // Sync all cached memory mappings to disk - includes flush if needed
     void sync_all_mappings();
     // Flush all cached memory mappings from private to shared cache.
     void flush_all_mappings();
+    class MapWindow;
+    // Get a suitable memory mapping for later access:
+    // potentially adding it to the cache, potentially closing
+    // the least recently used and sync'ing it to disk
+    MapWindow* get_window(ref_type start_ref, size_t size);
 
 protected:
-    class MapWindow;
-    Group& m_group;
     SlabAlloc& m_alloc;
+    Durability m_durability;
     // Currently cached memory mappings. We keep as many as 16 1MB windows
     // open for writing. The allocator will favor sequential allocation
     // from a modest number of windows, depending upon fragmentation, so
@@ -85,19 +84,33 @@ protected:
     const static int num_map_windows = 16;
     std::vector<std::unique_ptr<MapWindow>> m_map_windows;
     size_t m_window_alignment;
-    util::WriteMarker* m_write_marker;
-    Durability m_durability;
+    util::WriteMarker* m_write_marker = nullptr;
+};
 
-    // Get a suitable memory mapping for later access:
-    // potentially adding it to the cache, potentially closing
-    // the least recently used and sync'ing it to disk
-    MapWindow* get_window(ref_type start_ref, size_t size);
+class GroupComitter {
+public:
+    using Durability = DBOptions::Durability;
+    using MapWindow = WriteWindowMgr::MapWindow;
+    GroupComitter(Group&, Durability dura = Durability::Full, util::WriteMarker* write_marker = nullptr);
+    ~GroupComitter();
+    /// Flush changes to physical medium, then write the new top ref
+    /// to the file header, then flush again. Pass the top ref
+    /// returned by write_group().
+    void commit(ref_type new_top_ref);
+
+protected:
+    Group& m_group;
+    SlabAlloc& m_alloc;
+    Durability m_durability;
+    WriteWindowMgr m_window_mgr;
 };
 
 /// This class is not supposed to be reused for multiple write sessions. In
 /// particular, do not reuse it in case any of the functions throw.
-class GroupWriter : public GroupComitter, public _impl::ArrayWriterBase {
+class GroupWriter : public _impl::ArrayWriterBase {
 public:
+    using Durability = DBOptions::Durability;
+    using MapWindow = WriteWindowMgr::MapWindow;
     enum class EvacuationStage { idle, evacuating, waiting, blocked };
     // For groups in transactional mode (Group::m_is_shared), this constructor
     // must be called while a write transaction is in progress.
@@ -153,8 +166,8 @@ public:
         return m_free_positions.size() * size_per_free_list_entry();
     }
 
-    /// Check if evacuation is in progress
-    void check_evacuation();
+    /// Prepare for a round of evacuation (if applicable)
+    void prepare_evacuation();
 
     std::vector<size_t>& get_evacuation_progress()
     {
@@ -199,6 +212,10 @@ private:
     static void move_free_in_file_to_size_map(const std::vector<GroupWriter::FreeSpaceEntry>& list,
                                               std::multimap<size_t, size_t>& size_map);
 
+    Group& m_group;
+    SlabAlloc& m_alloc;
+    Durability m_durability;
+    WriteWindowMgr m_window_mgr;
     Array m_free_positions; // 4th slot in Group::m_top
     Array m_free_lengths;   // 5th slot in Group::m_top
     Array m_free_versions;  // 6th slot in Group::m_top

--- a/src/realm/group_writer.hpp
+++ b/src/realm/group_writer.hpp
@@ -193,6 +193,7 @@ public:
             }
         }
     }
+    void sync_according_to_durability();
 
 private:
     friend class InMemoryWriter;

--- a/src/realm/transaction.cpp
+++ b/src/realm/transaction.cpp
@@ -725,7 +725,7 @@ void Transaction::complete_async_commit()
         if (db->m_logger) {
             db->m_logger->log(util::Logger::Level::trace, "Comitting ref %1 to disk", read_lock.m_top_ref);
         }
-        GroupComitter out(*this);
+        GroupCommitter out(*this);
         out.commit(read_lock.m_top_ref); // Throws
         // we must release the write mutex before the callback, because the callback
         // is allowed to re-request it.


### PR DESCRIPTION
## What, How & Why?

An attempt to simplify GroupWriter and GroupComiter as a follow up on the fix in https://github.com/realm/realm-core/pull/6962

WIP.
