### PR TITLE
Use an enum class instead of int constants

### DIFF
--- a/src/realm/parser/driver.cpp
+++ b/src/realm/parser/driver.cpp
@@ -72,21 +72,6 @@ const char* expression_cmp_type_to_str(util::Optional<ExpressionComparisonType> 
     return "";
 }
 
-
-static std::map<int, std::string> opstr = {
-    {CompareNode::EQUAL, "="},
-    {CompareNode::NOT_EQUAL, "!="},
-    {CompareNode::GREATER, ">"},
-    {CompareNode::LESS, "<"},
-    {CompareNode::GREATER_EQUAL, ">="},
-    {CompareNode::LESS_EQUAL, "<="},
-    {CompareNode::BEGINSWITH, "beginswith"},
-    {CompareNode::ENDSWITH, "endswith"},
-    {CompareNode::CONTAINS, "contains"},
-    {CompareNode::LIKE, "like"},
-    {CompareNode::IN, "in"},
-};
-
 std::string print_pretty_objlink(const ObjLink& link, const Group* g)
 {
     REALM_ASSERT(g);
@@ -348,7 +333,7 @@ Query AndNode::visit(ParserDriver* drv)
     return q;
 }
 
-static void verify_only_string_types(DataType type, const std::string& op_string)
+static void verify_only_string_types(DataType type, std::string_view op_string)
 {
     if (type != type_String && type != type_Binary && type != type_Mixed) {
         throw InvalidQueryError(util::format(
@@ -502,7 +487,7 @@ Query EqualityNode::visit(ParserDriver* drv)
         }
     }
 
-    if (op == CompareNode::IN) {
+    if (op == CompareType::IN) {
         Subexpr* r = right.get();
         if (!r->has_multiple_values()) {
             throw InvalidQueryArgError("The keypath following 'IN' must contain a list. Found '" +
@@ -523,11 +508,11 @@ Query EqualityNode::visit(ParserDriver* drv)
                 for (auto val : *link_values) {
                     values.emplace_back(val.is_null() ? ObjKey() : val.get<ObjKey>());
                 }
-                if (op == CompareNode::EQUAL) {
+                if (op == CompareType::EQUAL) {
                     return drv->m_base_table->where().links_to(link_column->link_map().get_first_column_key(),
                                                                values);
                 }
-                else if (op == CompareNode::NOT_EQUAL) {
+                else if (op == CompareType::NOT_EQUAL) {
                     return drv->m_base_table->where().not_links_to(link_column->link_map().get_first_column_key(),
                                                                    values);
                 }
@@ -541,11 +526,21 @@ Query EqualityNode::visit(ParserDriver* drv)
             auto col_key = prop->column_key();
             if (val.is_null()) {
                 switch (op) {
-                    case CompareNode::EQUAL:
-                    case CompareNode::IN:
+                    case CompareType::EQUAL:
+                    case CompareType::IN:
                         return drv->m_base_table->where().equal(col_key, realm::null());
-                    case CompareNode::NOT_EQUAL:
+                    case CompareType::NOT_EQUAL:
                         return drv->m_base_table->where().not_equal(col_key, realm::null());
+                    case CompareType::GREATER:
+                    case CompareType::LESS:
+                    case CompareType::GREATER_EQUAL:
+                    case CompareType::LESS_EQUAL:
+                    case CompareType::BEGINSWITH:
+                    case CompareType::ENDSWITH:
+                    case CompareType::CONTAINS:
+                    case CompareType::LIKE:
+                    case CompareType::TEXT:
+                        break;
                 }
             }
             switch (left->get_type()) {
@@ -578,22 +573,26 @@ Query EqualityNode::visit(ParserDriver* drv)
     }
     if (case_sensitive) {
         switch (op) {
-            case CompareNode::EQUAL:
-            case CompareNode::IN:
+            case CompareType::EQUAL:
+            case CompareType::IN:
                 return Query(std::unique_ptr<Expression>(new Compare<Equal>(std::move(left), std::move(right))));
-            case CompareNode::NOT_EQUAL:
+            case CompareType::NOT_EQUAL:
                 return Query(std::unique_ptr<Expression>(new Compare<NotEqual>(std::move(left), std::move(right))));
+            default:
+                break;
         }
     }
     else {
-        verify_only_string_types(right_type, opstr[op] + "[c]");
+        verify_only_string_types(right_type, util::format("%1%2", string_for_op(op), "[c]"));
         switch (op) {
-            case CompareNode::EQUAL:
-            case CompareNode::IN:
+            case CompareType::EQUAL:
+            case CompareType::IN:
                 return Query(std::unique_ptr<Expression>(new Compare<EqualIns>(std::move(left), std::move(right))));
-            case CompareNode::NOT_EQUAL:
+            case CompareType::NOT_EQUAL:
                 return Query(
                     std::unique_ptr<Expression>(new Compare<NotEqualIns>(std::move(left), std::move(right))));
+            default:
+                break;
         }
     }
     return {};
@@ -615,8 +614,8 @@ Query BetweenNode::visit(ParserDriver* drv)
 
     auto& min(limits->elements.at(0));
     auto& max(limits->elements.at(1));
-    RelationalNode cmp1(prop, CompareNode::GREATER_EQUAL, min);
-    RelationalNode cmp2(prop, CompareNode::LESS_EQUAL, max);
+    RelationalNode cmp1(prop, CompareType::GREATER_EQUAL, min);
+    RelationalNode cmp2(prop, CompareType::LESS_EQUAL, max);
 
     Query q(drv->m_base_table);
     q.and_query(cmp1.visit(drv));
@@ -638,7 +637,7 @@ Query RelationalNode::visit(ParserDriver* drv)
     if (left_type == type_Link || left_type == type_TypeOfValue) {
         throw InvalidQueryError(util::format(
             "Unsupported operator %1 in query. Only equal (==) and not equal (!=) are supported for this type.",
-            opstr[op]));
+            string_for_op(op)));
     }
 
     if (!(left_type_is_null || right_type_is_null) && (!left_type.is_valid() || !right_type.is_valid() ||
@@ -685,14 +684,16 @@ Query RelationalNode::visit(ParserDriver* drv)
         }
     }
     switch (op) {
-        case CompareNode::GREATER:
+        case CompareType::GREATER:
             return Query(std::unique_ptr<Expression>(new Compare<Greater>(std::move(left), std::move(right))));
-        case CompareNode::LESS:
+        case CompareType::LESS:
             return Query(std::unique_ptr<Expression>(new Compare<Less>(std::move(left), std::move(right))));
-        case CompareNode::GREATER_EQUAL:
+        case CompareType::GREATER_EQUAL:
             return Query(std::unique_ptr<Expression>(new Compare<GreaterEqual>(std::move(left), std::move(right))));
-        case CompareNode::LESS_EQUAL:
+        case CompareType::LESS_EQUAL:
             return Query(std::unique_ptr<Expression>(new Compare<LessEqual>(std::move(left), std::move(right))));
+        default:
+            break;
     }
     return {};
 }
@@ -705,7 +706,7 @@ Query StringOpsNode::visit(ParserDriver* drv)
     auto right_type = right->get_type();
     const ObjPropertyBase* prop = dynamic_cast<const ObjPropertyBase*>(left.get());
 
-    verify_only_string_types(right_type, opstr[op]);
+    verify_only_string_types(right_type, string_for_op(op));
 
     if (prop && !prop->links_exist() && right->has_single_value() &&
         (left_type == right_type || left_type == type_Mixed)) {
@@ -714,64 +715,98 @@ Query StringOpsNode::visit(ParserDriver* drv)
             StringData val = right->get_mixed().get_string();
 
             switch (op) {
-                case CompareNode::BEGINSWITH:
+                case CompareType::BEGINSWITH:
                     return drv->m_base_table->where().begins_with(col_key, val, case_sensitive);
-                case CompareNode::ENDSWITH:
+                case CompareType::ENDSWITH:
                     return drv->m_base_table->where().ends_with(col_key, val, case_sensitive);
-                case CompareNode::CONTAINS:
+                case CompareType::CONTAINS:
                     return drv->m_base_table->where().contains(col_key, val, case_sensitive);
-                case CompareNode::LIKE:
+                case CompareType::LIKE:
                     return drv->m_base_table->where().like(col_key, val, case_sensitive);
-                case CompareNode::TEXT:
+                case CompareType::TEXT:
                     return drv->m_base_table->where().fulltext(col_key, val);
+                case CompareType::IN:
+                case CompareType::EQUAL:
+                case CompareType::NOT_EQUAL:
+                case CompareType::GREATER:
+                case CompareType::LESS:
+                case CompareType::GREATER_EQUAL:
+                case CompareType::LESS_EQUAL:
+                    break;
             }
         }
         else if (right_type == type_Binary) {
             BinaryData val = right->get_mixed().get_binary();
 
             switch (op) {
-                case CompareNode::BEGINSWITH:
+                case CompareType::BEGINSWITH:
                     return drv->m_base_table->where().begins_with(col_key, val, case_sensitive);
-                case CompareNode::ENDSWITH:
+                case CompareType::ENDSWITH:
                     return drv->m_base_table->where().ends_with(col_key, val, case_sensitive);
-                case CompareNode::CONTAINS:
+                case CompareType::CONTAINS:
                     return drv->m_base_table->where().contains(col_key, val, case_sensitive);
-                case CompareNode::LIKE:
+                case CompareType::LIKE:
                     return drv->m_base_table->where().like(col_key, val, case_sensitive);
+                case CompareType::TEXT:
+                case CompareType::IN:
+                case CompareType::EQUAL:
+                case CompareType::NOT_EQUAL:
+                case CompareType::GREATER:
+                case CompareType::LESS:
+                case CompareType::GREATER_EQUAL:
+                case CompareType::LESS_EQUAL:
+                    break;
             }
         }
     }
 
     if (case_sensitive) {
         switch (op) {
-            case CompareNode::BEGINSWITH:
+            case CompareType::BEGINSWITH:
                 return Query(std::unique_ptr<Expression>(new Compare<BeginsWith>(std::move(right), std::move(left))));
-            case CompareNode::ENDSWITH:
+            case CompareType::ENDSWITH:
                 return Query(std::unique_ptr<Expression>(new Compare<EndsWith>(std::move(right), std::move(left))));
-            case CompareNode::CONTAINS:
+            case CompareType::CONTAINS:
                 return Query(std::unique_ptr<Expression>(new Compare<Contains>(std::move(right), std::move(left))));
-            case CompareNode::LIKE:
+            case CompareType::LIKE:
                 return Query(std::unique_ptr<Expression>(new Compare<Like>(std::move(right), std::move(left))));
-            case CompareNode::TEXT: {
+            case CompareType::TEXT: {
                 StringData val = right->get_mixed().get_string();
                 auto string_prop = dynamic_cast<Columns<StringData>*>(left.get());
                 return string_prop->fulltext(val);
             }
+            case CompareType::IN:
+            case CompareType::EQUAL:
+            case CompareType::NOT_EQUAL:
+            case CompareType::GREATER:
+            case CompareType::LESS:
+            case CompareType::GREATER_EQUAL:
+            case CompareType::LESS_EQUAL:
+                break;
         }
     }
     else {
         switch (op) {
-            case CompareNode::BEGINSWITH:
+            case CompareType::BEGINSWITH:
                 return Query(
                     std::unique_ptr<Expression>(new Compare<BeginsWithIns>(std::move(right), std::move(left))));
-            case CompareNode::ENDSWITH:
+            case CompareType::ENDSWITH:
                 return Query(
                     std::unique_ptr<Expression>(new Compare<EndsWithIns>(std::move(right), std::move(left))));
-            case CompareNode::CONTAINS:
+            case CompareType::CONTAINS:
                 return Query(
                     std::unique_ptr<Expression>(new Compare<ContainsIns>(std::move(right), std::move(left))));
-            case CompareNode::LIKE:
+            case CompareType::LIKE:
                 return Query(std::unique_ptr<Expression>(new Compare<LikeIns>(std::move(right), std::move(left))));
+            case CompareType::IN:
+            case CompareType::EQUAL:
+            case CompareType::NOT_EQUAL:
+            case CompareType::GREATER:
+            case CompareType::LESS:
+            case CompareType::GREATER_EQUAL:
+            case CompareType::LESS_EQUAL:
+            case CompareType::TEXT:
+                break;
         }
     }
     return {};

--- a/src/realm/parser/driver.cpp
+++ b/src/realm/parser/driver.cpp
@@ -296,6 +296,37 @@ namespace realm {
 
 namespace query_parser {
 
+std::string_view string_for_op(CompareType op)
+{
+    switch (op) {
+        case CompareType::EQUAL:
+            return "=";
+        case CompareType::NOT_EQUAL:
+            return "!=";
+        case CompareType::GREATER:
+            return ">";
+        case CompareType::LESS:
+            return "<";
+        case CompareType::GREATER_EQUAL:
+            return ">=";
+        case CompareType::LESS_EQUAL:
+            return "<=";
+        case CompareType::BEGINSWITH:
+            return "beginswith";
+        case CompareType::ENDSWITH:
+            return "endswith";
+        case CompareType::CONTAINS:
+            return "contains";
+        case CompareType::LIKE:
+            return "like";
+        case CompareType::IN:
+            return "in";
+        case CompareType::TEXT:
+            return "text";
+    }
+    return ""; // appease MSVC warnings
+}
+
 NoArguments ParserDriver::s_default_args;
 query_parser::KeyPathMapping ParserDriver::s_default_mapping;
 
@@ -531,15 +562,7 @@ Query EqualityNode::visit(ParserDriver* drv)
                         return drv->m_base_table->where().equal(col_key, realm::null());
                     case CompareType::NOT_EQUAL:
                         return drv->m_base_table->where().not_equal(col_key, realm::null());
-                    case CompareType::GREATER:
-                    case CompareType::LESS:
-                    case CompareType::GREATER_EQUAL:
-                    case CompareType::LESS_EQUAL:
-                    case CompareType::BEGINSWITH:
-                    case CompareType::ENDSWITH:
-                    case CompareType::CONTAINS:
-                    case CompareType::LIKE:
-                    case CompareType::TEXT:
+                    default:
                         break;
                 }
             }

--- a/src/realm/parser/driver.hpp
+++ b/src/realm/parser/driver.hpp
@@ -410,29 +410,60 @@ public:
 
 /******************************* Compare Nodes *******************************/
 
-class CompareNode : public QueryNode {
-public:
-    static constexpr int EQUAL = 0;
-    static constexpr int NOT_EQUAL = 1;
-    static constexpr int GREATER = 2;
-    static constexpr int LESS = 3;
-    static constexpr int GREATER_EQUAL = 4;
-    static constexpr int LESS_EQUAL = 5;
-    static constexpr int BEGINSWITH = 6;
-    static constexpr int ENDSWITH = 7;
-    static constexpr int CONTAINS = 8;
-    static constexpr int LIKE = 9;
-    static constexpr int IN = 10;
-    static constexpr int TEXT = 11;
+enum class CompareType : char {
+    EQUAL,
+    NOT_EQUAL,
+    GREATER,
+    LESS,
+    GREATER_EQUAL,
+    LESS_EQUAL,
+    BEGINSWITH,
+    ENDSWITH,
+    CONTAINS,
+    LIKE,
+    IN,
+    TEXT,
 };
+
+static std::string_view string_for_op(CompareType op)
+{
+    switch (op) {
+        case CompareType::EQUAL:
+            return "=";
+        case CompareType::NOT_EQUAL:
+            return "!=";
+        case CompareType::GREATER:
+            return ">";
+        case CompareType::LESS:
+            return "<";
+        case CompareType::GREATER_EQUAL:
+            return ">=";
+        case CompareType::LESS_EQUAL:
+            return "<=";
+        case CompareType::BEGINSWITH:
+            return "beginswith";
+        case CompareType::ENDSWITH:
+            return "endswith";
+        case CompareType::CONTAINS:
+            return "contains";
+        case CompareType::LIKE:
+            return "like";
+        case CompareType::IN:
+            return "in";
+        case CompareType::TEXT:
+            return "text";
+    }
+}
+
+class CompareNode : public QueryNode {};
 
 class EqualityNode : public CompareNode {
 public:
     std::vector<ExpressionNode*> values;
-    int op;
+    CompareType op;
     bool case_sensitive = true;
 
-    EqualityNode(ExpressionNode* left, int t, ExpressionNode* right)
+    EqualityNode(ExpressionNode* left, CompareType t, ExpressionNode* right)
         : op(t)
     {
         values.emplace_back(left);
@@ -444,9 +475,9 @@ public:
 class RelationalNode : public CompareNode {
 public:
     std::vector<ExpressionNode*> values;
-    int op;
+    CompareType op;
 
-    RelationalNode(ExpressionNode* left, int t, ExpressionNode* right)
+    RelationalNode(ExpressionNode* left, CompareType t, ExpressionNode* right)
         : op(t)
     {
         values.emplace_back(left);
@@ -471,10 +502,10 @@ public:
 class StringOpsNode : public CompareNode {
 public:
     std::vector<ExpressionNode*> values;
-    int op;
+    CompareType op;
     bool case_sensitive = true;
 
-    StringOpsNode(ValueNode* left, int t, ValueNode* right)
+    StringOpsNode(ValueNode* left, CompareType t, ValueNode* right)
         : op(t)
     {
         values.emplace_back(left);
@@ -628,9 +659,9 @@ public:
     double get_arg_for_coordinate(const std::string&);
 
     template <class T>
-    Query simple_query(int op, ColKey col_key, T val, bool case_sensitive);
+    Query simple_query(CompareType op, ColKey col_key, T val, bool case_sensitive);
     template <class T>
-    Query simple_query(int op, ColKey col_key, T val);
+    Query simple_query(CompareType op, ColKey col_key, T val);
     std::pair<SubexprPtr, SubexprPtr> cmp(const std::vector<ExpressionNode*>& values);
     SubexprPtr column(LinkChain&, const std::string&);
     SubexprPtr dictionary_column(LinkChain&, const std::string&);
@@ -649,35 +680,39 @@ private:
 };
 
 template <class T>
-Query ParserDriver::simple_query(int op, ColKey col_key, T val, bool case_sensitive)
+Query ParserDriver::simple_query(CompareType op, ColKey col_key, T val, bool case_sensitive)
 {
     switch (op) {
-        case CompareNode::IN:
-        case CompareNode::EQUAL:
+        case CompareType::IN:
+        case CompareType::EQUAL:
             return m_base_table->where().equal(col_key, val, case_sensitive);
-        case CompareNode::NOT_EQUAL:
+        case CompareType::NOT_EQUAL:
             return m_base_table->where().not_equal(col_key, val, case_sensitive);
+        default:
+            break;
     }
     return m_base_table->where();
 }
 
 template <class T>
-Query ParserDriver::simple_query(int op, ColKey col_key, T val)
+Query ParserDriver::simple_query(CompareType op, ColKey col_key, T val)
 {
     switch (op) {
-        case CompareNode::IN:
-        case CompareNode::EQUAL:
+        case CompareType::IN:
+        case CompareType::EQUAL:
             return m_base_table->where().equal(col_key, val);
-        case CompareNode::NOT_EQUAL:
+        case CompareType::NOT_EQUAL:
             return m_base_table->where().not_equal(col_key, val);
-        case CompareNode::GREATER:
+        case CompareType::GREATER:
             return m_base_table->where().greater(col_key, val);
-        case CompareNode::LESS:
+        case CompareType::LESS:
             return m_base_table->where().less(col_key, val);
-        case CompareNode::GREATER_EQUAL:
+        case CompareType::GREATER_EQUAL:
             return m_base_table->where().greater_equal(col_key, val);
-        case CompareNode::LESS_EQUAL:
+        case CompareType::LESS_EQUAL:
             return m_base_table->where().less_equal(col_key, val);
+        default:
+            break;
     }
     return m_base_table->where();
 }

--- a/src/realm/parser/driver.hpp
+++ b/src/realm/parser/driver.hpp
@@ -453,6 +453,7 @@ static std::string_view string_for_op(CompareType op)
         case CompareType::TEXT:
             return "text";
     }
+    return ""; // appease MSVC warnings
 }
 
 class CompareNode : public QueryNode {};

--- a/src/realm/parser/driver.hpp
+++ b/src/realm/parser/driver.hpp
@@ -425,36 +425,7 @@ enum class CompareType : char {
     TEXT,
 };
 
-static std::string_view string_for_op(CompareType op)
-{
-    switch (op) {
-        case CompareType::EQUAL:
-            return "=";
-        case CompareType::NOT_EQUAL:
-            return "!=";
-        case CompareType::GREATER:
-            return ">";
-        case CompareType::LESS:
-            return "<";
-        case CompareType::GREATER_EQUAL:
-            return ">=";
-        case CompareType::LESS_EQUAL:
-            return "<=";
-        case CompareType::BEGINSWITH:
-            return "beginswith";
-        case CompareType::ENDSWITH:
-            return "endswith";
-        case CompareType::CONTAINS:
-            return "contains";
-        case CompareType::LIKE:
-            return "like";
-        case CompareType::IN:
-            return "in";
-        case CompareType::TEXT:
-            return "text";
-    }
-    return ""; // appease MSVC warnings
-}
+std::string_view string_for_op(CompareType op);
 
 class CompareNode : public QueryNode {};
 

--- a/src/realm/parser/generated/query_bison.cpp
+++ b/src/realm/parser/generated/query_bison.cpp
@@ -198,6 +198,12 @@ namespace yy {
         value.YY_MOVE_OR_COPY< AggrNode* > (YY_MOVE (that.value));
         break;
 
+      case symbol_kind::SYM_equality: // equality
+      case symbol_kind::SYM_relational: // relational
+      case symbol_kind::SYM_stringop: // stringop
+        value.YY_MOVE_OR_COPY< CompareType > (YY_MOVE (that.value));
+        break;
+
       case symbol_kind::SYM_constant: // constant
       case symbol_kind::SYM_primary_key: // primary_key
         value.YY_MOVE_OR_COPY< ConstantNode* > (YY_MOVE (that.value));
@@ -275,9 +281,6 @@ namespace yy {
 
       case symbol_kind::SYM_comp_type: // comp_type
       case symbol_kind::SYM_aggr_op: // aggr_op
-      case symbol_kind::SYM_equality: // equality
-      case symbol_kind::SYM_relational: // relational
-      case symbol_kind::SYM_stringop: // stringop
         value.YY_MOVE_OR_COPY< int > (YY_MOVE (that.value));
         break;
 
@@ -337,6 +340,12 @@ namespace yy {
     {
       case symbol_kind::SYM_aggregate: // aggregate
         value.move< AggrNode* > (YY_MOVE (that.value));
+        break;
+
+      case symbol_kind::SYM_equality: // equality
+      case symbol_kind::SYM_relational: // relational
+      case symbol_kind::SYM_stringop: // stringop
+        value.move< CompareType > (YY_MOVE (that.value));
         break;
 
       case symbol_kind::SYM_constant: // constant
@@ -416,9 +425,6 @@ namespace yy {
 
       case symbol_kind::SYM_comp_type: // comp_type
       case symbol_kind::SYM_aggr_op: // aggr_op
-      case symbol_kind::SYM_equality: // equality
-      case symbol_kind::SYM_relational: // relational
-      case symbol_kind::SYM_stringop: // stringop
         value.move< int > (YY_MOVE (that.value));
         break;
 
@@ -478,6 +484,12 @@ namespace yy {
     {
       case symbol_kind::SYM_aggregate: // aggregate
         value.copy< AggrNode* > (that.value);
+        break;
+
+      case symbol_kind::SYM_equality: // equality
+      case symbol_kind::SYM_relational: // relational
+      case symbol_kind::SYM_stringop: // stringop
+        value.copy< CompareType > (that.value);
         break;
 
       case symbol_kind::SYM_constant: // constant
@@ -557,9 +569,6 @@ namespace yy {
 
       case symbol_kind::SYM_comp_type: // comp_type
       case symbol_kind::SYM_aggr_op: // aggr_op
-      case symbol_kind::SYM_equality: // equality
-      case symbol_kind::SYM_relational: // relational
-      case symbol_kind::SYM_stringop: // stringop
         value.copy< int > (that.value);
         break;
 
@@ -617,6 +626,12 @@ namespace yy {
     {
       case symbol_kind::SYM_aggregate: // aggregate
         value.move< AggrNode* > (that.value);
+        break;
+
+      case symbol_kind::SYM_equality: // equality
+      case symbol_kind::SYM_relational: // relational
+      case symbol_kind::SYM_stringop: // stringop
+        value.move< CompareType > (that.value);
         break;
 
       case symbol_kind::SYM_constant: // constant
@@ -696,9 +711,6 @@ namespace yy {
 
       case symbol_kind::SYM_comp_type: // comp_type
       case symbol_kind::SYM_aggr_op: // aggr_op
-      case symbol_kind::SYM_equality: // equality
-      case symbol_kind::SYM_relational: // relational
-      case symbol_kind::SYM_stringop: // stringop
         value.move< int > (that.value);
         break;
 
@@ -1187,15 +1199,15 @@ namespace yy {
         break;
 
       case symbol_kind::SYM_equality: // equality
-                 { yyo << yysym.value.template as < int > (); }
+                 { yyo << string_for_op(yysym.value.template as < CompareType > ()); }
         break;
 
       case symbol_kind::SYM_relational: // relational
-                 { yyo << yysym.value.template as < int > (); }
+                 { yyo << string_for_op(yysym.value.template as < CompareType > ()); }
         break;
 
       case symbol_kind::SYM_stringop: // stringop
-                 { yyo << yysym.value.template as < int > (); }
+                 { yyo << string_for_op(yysym.value.template as < CompareType > ()); }
         break;
 
       case symbol_kind::SYM_path: // path
@@ -1438,6 +1450,12 @@ namespace yy {
         yylhs.value.emplace< AggrNode* > ();
         break;
 
+      case symbol_kind::SYM_equality: // equality
+      case symbol_kind::SYM_relational: // relational
+      case symbol_kind::SYM_stringop: // stringop
+        yylhs.value.emplace< CompareType > ();
+        break;
+
       case symbol_kind::SYM_constant: // constant
       case symbol_kind::SYM_primary_key: // primary_key
         yylhs.value.emplace< ConstantNode* > ();
@@ -1515,9 +1533,6 @@ namespace yy {
 
       case symbol_kind::SYM_comp_type: // comp_type
       case symbol_kind::SYM_aggr_op: // aggr_op
-      case symbol_kind::SYM_equality: // equality
-      case symbol_kind::SYM_relational: // relational
-      case symbol_kind::SYM_stringop: // stringop
         yylhs.value.emplace< int > ();
         break;
 
@@ -1603,32 +1618,32 @@ namespace yy {
     break;
 
   case 9: // compare: expr equality expr
-                                { yylhs.value.as < QueryNode* > () = drv.m_parse_nodes.create<EqualityNode>(yystack_[2].value.as < ExpressionNode* > (), yystack_[1].value.as < int > (), yystack_[0].value.as < ExpressionNode* > ()); }
+                                { yylhs.value.as < QueryNode* > () = drv.m_parse_nodes.create<EqualityNode>(yystack_[2].value.as < ExpressionNode* > (), yystack_[1].value.as < CompareType > (), yystack_[0].value.as < ExpressionNode* > ()); }
     break;
 
   case 10: // compare: expr equality "[c]" expr
                                 {
-                                    auto tmp = drv.m_parse_nodes.create<EqualityNode>(yystack_[3].value.as < ExpressionNode* > (), yystack_[2].value.as < int > (), yystack_[0].value.as < ExpressionNode* > ());
+                                    auto tmp = drv.m_parse_nodes.create<EqualityNode>(yystack_[3].value.as < ExpressionNode* > (), yystack_[2].value.as < CompareType > (), yystack_[0].value.as < ExpressionNode* > ());
                                     tmp->case_sensitive = false;
                                     yylhs.value.as < QueryNode* > () = tmp;
                                 }
     break;
 
   case 11: // compare: expr relational expr
-                                { yylhs.value.as < QueryNode* > () = drv.m_parse_nodes.create<RelationalNode>(yystack_[2].value.as < ExpressionNode* > (), yystack_[1].value.as < int > (), yystack_[0].value.as < ExpressionNode* > ()); }
+                                { yylhs.value.as < QueryNode* > () = drv.m_parse_nodes.create<RelationalNode>(yystack_[2].value.as < ExpressionNode* > (), yystack_[1].value.as < CompareType > (), yystack_[0].value.as < ExpressionNode* > ()); }
     break;
 
   case 12: // compare: value stringop value
-                                { yylhs.value.as < QueryNode* > () = drv.m_parse_nodes.create<StringOpsNode>(yystack_[2].value.as < ValueNode* > (), yystack_[1].value.as < int > (), yystack_[0].value.as < ValueNode* > ()); }
+                                { yylhs.value.as < QueryNode* > () = drv.m_parse_nodes.create<StringOpsNode>(yystack_[2].value.as < ValueNode* > (), yystack_[1].value.as < CompareType > (), yystack_[0].value.as < ValueNode* > ()); }
     break;
 
   case 13: // compare: value "fulltext" value
-                                { yylhs.value.as < QueryNode* > () = drv.m_parse_nodes.create<StringOpsNode>(yystack_[2].value.as < ValueNode* > (), CompareNode::TEXT, yystack_[0].value.as < ValueNode* > ()); }
+                                { yylhs.value.as < QueryNode* > () = drv.m_parse_nodes.create<StringOpsNode>(yystack_[2].value.as < ValueNode* > (), CompareType::TEXT, yystack_[0].value.as < ValueNode* > ()); }
     break;
 
   case 14: // compare: value stringop "[c]" value
                                 {
-                                    auto tmp = drv.m_parse_nodes.create<StringOpsNode>(yystack_[3].value.as < ValueNode* > (), yystack_[2].value.as < int > (), yystack_[0].value.as < ValueNode* > ());
+                                    auto tmp = drv.m_parse_nodes.create<StringOpsNode>(yystack_[3].value.as < ValueNode* > (), yystack_[2].value.as < CompareType > (), yystack_[0].value.as < ValueNode* > ());
                                     tmp->case_sensitive = false;
                                     yylhs.value.as < QueryNode* > () = tmp;
                                 }
@@ -1973,47 +1988,47 @@ namespace yy {
     break;
 
   case 97: // equality: "=="
-                                { yylhs.value.as < int > () = CompareNode::EQUAL; }
+                                { yylhs.value.as < CompareType > () = CompareType::EQUAL; }
     break;
 
   case 98: // equality: "!="
-                                { yylhs.value.as < int > () = CompareNode::NOT_EQUAL; }
+                                { yylhs.value.as < CompareType > () = CompareType::NOT_EQUAL; }
     break;
 
   case 99: // equality: "in"
-                                { yylhs.value.as < int > () = CompareNode::IN; }
+                                { yylhs.value.as < CompareType > () = CompareType::IN; }
     break;
 
   case 100: // relational: "<"
-                                { yylhs.value.as < int > () = CompareNode::LESS; }
+                                { yylhs.value.as < CompareType > () = CompareType::LESS; }
     break;
 
   case 101: // relational: "<="
-                                { yylhs.value.as < int > () = CompareNode::LESS_EQUAL; }
+                                { yylhs.value.as < CompareType > () = CompareType::LESS_EQUAL; }
     break;
 
   case 102: // relational: ">"
-                                { yylhs.value.as < int > () = CompareNode::GREATER; }
+                                { yylhs.value.as < CompareType > () = CompareType::GREATER; }
     break;
 
   case 103: // relational: ">="
-                                { yylhs.value.as < int > () = CompareNode::GREATER_EQUAL; }
+                                { yylhs.value.as < CompareType > () = CompareType::GREATER_EQUAL; }
     break;
 
   case 104: // stringop: "beginswith"
-                                { yylhs.value.as < int > () = CompareNode::BEGINSWITH; }
+                                { yylhs.value.as < CompareType > () = CompareType::BEGINSWITH; }
     break;
 
   case 105: // stringop: "endswith"
-                                { yylhs.value.as < int > () = CompareNode::ENDSWITH; }
+                                { yylhs.value.as < CompareType > () = CompareType::ENDSWITH; }
     break;
 
   case 106: // stringop: "contains"
-                                { yylhs.value.as < int > () = CompareNode::CONTAINS; }
+                                { yylhs.value.as < CompareType > () = CompareType::CONTAINS; }
     break;
 
   case 107: // stringop: "like"
-                                { yylhs.value.as < int > () = CompareNode::LIKE; }
+                                { yylhs.value.as < CompareType > () = CompareType::LIKE; }
     break;
 
   case 108: // path: path_elem
@@ -2745,19 +2760,19 @@ namespace yy {
   const short
   parser::yyrline_[] =
   {
-       0,   187,   187,   190,   191,   192,   193,   194,   195,   198,
-     199,   204,   205,   206,   207,   212,   213,   214,   217,   218,
-     219,   220,   221,   222,   225,   226,   227,   228,   229,   232,
-     233,   236,   240,   246,   249,   252,   253,   254,   257,   258,
-     261,   262,   264,   267,   268,   271,   272,   273,   276,   277,
-     278,   279,   281,   284,   285,   287,   290,   291,   293,   296,
-     297,   299,   300,   303,   304,   305,   308,   309,   310,   311,
-     312,   313,   314,   315,   316,   317,   318,   319,   320,   321,
-     329,   330,   331,   332,   333,   336,   337,   340,   341,   342,
-     345,   346,   347,   350,   351,   352,   353,   356,   357,   358,
-     361,   362,   363,   364,   367,   368,   369,   370,   373,   374,
-     377,   378,   379,   380,   383,   384,   385,   386,   387,   388,
-     389,   390,   391,   392,   393,   394,   395,   396,   397
+       0,   191,   191,   194,   195,   196,   197,   198,   199,   202,
+     203,   208,   209,   210,   211,   216,   217,   218,   221,   222,
+     223,   224,   225,   226,   229,   230,   231,   232,   233,   236,
+     237,   240,   244,   250,   253,   256,   257,   258,   261,   262,
+     265,   266,   268,   271,   272,   275,   276,   277,   280,   281,
+     282,   283,   285,   288,   289,   291,   294,   295,   297,   300,
+     301,   303,   304,   307,   308,   309,   312,   313,   314,   315,
+     316,   317,   318,   319,   320,   321,   322,   323,   324,   325,
+     333,   334,   335,   336,   337,   340,   341,   344,   345,   346,
+     349,   350,   351,   354,   355,   356,   357,   360,   361,   362,
+     365,   366,   367,   368,   371,   372,   373,   374,   377,   378,
+     381,   382,   383,   384,   387,   388,   389,   390,   391,   392,
+     393,   394,   395,   396,   397,   398,   399,   400,   401
   };
 
   void

--- a/src/realm/parser/generated/query_bison.hpp
+++ b/src/realm/parser/generated/query_bison.hpp
@@ -72,6 +72,8 @@
     class DescriptorNode;
     class PropertyNode;
     class SubqueryNode;
+
+    enum class CompareType: char;
     struct PathElem {
         std::string id;
         Mixed index;
@@ -447,74 +449,76 @@ namespace yy {
       // aggregate
       char dummy1[sizeof (AggrNode*)];
 
+      // equality
+      // relational
+      // stringop
+      char dummy2[sizeof (CompareType)];
+
       // constant
       // primary_key
-      char dummy2[sizeof (ConstantNode*)];
+      char dummy3[sizeof (ConstantNode*)];
 
       // distinct
       // distinct_param
       // sort
       // sort_param
       // limit
-      char dummy3[sizeof (DescriptorNode*)];
+      char dummy4[sizeof (DescriptorNode*)];
 
       // post_query
-      char dummy4[sizeof (DescriptorOrderingNode*)];
+      char dummy5[sizeof (DescriptorOrderingNode*)];
 
       // expr
-      char dummy5[sizeof (ExpressionNode*)];
+      char dummy6[sizeof (ExpressionNode*)];
 
       // geoloop_content
       // geoloop
       // geopoly_content
       // geospatial
-      char dummy6[sizeof (GeospatialNode*)];
+      char dummy7[sizeof (GeospatialNode*)];
 
       // list
       // list_content
-      char dummy7[sizeof (ListNode*)];
+      char dummy8[sizeof (ListNode*)];
 
       // path_elem
-      char dummy8[sizeof (PathElem)];
+      char dummy9[sizeof (PathElem)];
 
       // path
-      char dummy9[sizeof (PathNode*)];
+      char dummy10[sizeof (PathNode*)];
 
       // post_op
-      char dummy10[sizeof (PostOpNode*)];
+      char dummy11[sizeof (PostOpNode*)];
 
       // prop
       // simple_prop
-      char dummy11[sizeof (PropertyNode*)];
+      char dummy12[sizeof (PropertyNode*)];
 
       // query
       // compare
-      char dummy12[sizeof (QueryNode*)];
+      char dummy13[sizeof (QueryNode*)];
 
       // subquery
-      char dummy13[sizeof (SubqueryNode*)];
+      char dummy14[sizeof (SubqueryNode*)];
 
       // boolexpr
-      char dummy14[sizeof (TrueOrFalseNode*)];
+      char dummy15[sizeof (TrueOrFalseNode*)];
 
       // value
-      char dummy15[sizeof (ValueNode*)];
+      char dummy16[sizeof (ValueNode*)];
 
       // direction
-      char dummy16[sizeof (bool)];
+      char dummy17[sizeof (bool)];
 
       // coordinate
-      char dummy17[sizeof (double)];
+      char dummy18[sizeof (double)];
 
       // comp_type
       // aggr_op
-      // equality
-      // relational
-      // stringop
-      char dummy18[sizeof (int)];
+      char dummy19[sizeof (int)];
 
       // geopoint
-      char dummy19[sizeof (std::optional<GeoPoint>)];
+      char dummy20[sizeof (std::optional<GeoPoint>)];
 
       // "identifier"
       // "string"
@@ -548,7 +552,7 @@ namespace yy {
       // "@type"
       // "key or value"
       // id
-      char dummy20[sizeof (std::string)];
+      char dummy21[sizeof (std::string)];
     };
 
     /// The size of the largest semantic type.
@@ -819,6 +823,12 @@ namespace yy {
         value.move< AggrNode* > (std::move (that.value));
         break;
 
+      case symbol_kind::SYM_equality: // equality
+      case symbol_kind::SYM_relational: // relational
+      case symbol_kind::SYM_stringop: // stringop
+        value.move< CompareType > (std::move (that.value));
+        break;
+
       case symbol_kind::SYM_constant: // constant
       case symbol_kind::SYM_primary_key: // primary_key
         value.move< ConstantNode* > (std::move (that.value));
@@ -896,9 +906,6 @@ namespace yy {
 
       case symbol_kind::SYM_comp_type: // comp_type
       case symbol_kind::SYM_aggr_op: // aggr_op
-      case symbol_kind::SYM_equality: // equality
-      case symbol_kind::SYM_relational: // relational
-      case symbol_kind::SYM_stringop: // stringop
         value.move< int > (std::move (that.value));
         break;
 
@@ -969,6 +976,18 @@ namespace yy {
       {}
 #else
       basic_symbol (typename Base::kind_type t, const AggrNode*& v)
+        : Base (t)
+        , value (v)
+      {}
+#endif
+
+#if 201103L <= YY_CPLUSPLUS
+      basic_symbol (typename Base::kind_type t, CompareType&& v)
+        : Base (t)
+        , value (std::move (v))
+      {}
+#else
+      basic_symbol (typename Base::kind_type t, const CompareType& v)
         : Base (t)
         , value (v)
       {}
@@ -1227,18 +1246,6 @@ namespace yy {
                     { }
         break;
 
-      case symbol_kind::SYM_equality: // equality
-                    { }
-        break;
-
-      case symbol_kind::SYM_relational: // relational
-                    { }
-        break;
-
-      case symbol_kind::SYM_stringop: // stringop
-                    { }
-        break;
-
        default:
           break;
         }
@@ -1248,6 +1255,12 @@ switch (yykind)
     {
       case symbol_kind::SYM_aggregate: // aggregate
         value.template destroy< AggrNode* > ();
+        break;
+
+      case symbol_kind::SYM_equality: // equality
+      case symbol_kind::SYM_relational: // relational
+      case symbol_kind::SYM_stringop: // stringop
+        value.template destroy< CompareType > ();
         break;
 
       case symbol_kind::SYM_constant: // constant
@@ -1327,9 +1340,6 @@ switch (yykind)
 
       case symbol_kind::SYM_comp_type: // comp_type
       case symbol_kind::SYM_aggr_op: // aggr_op
-      case symbol_kind::SYM_equality: // equality
-      case symbol_kind::SYM_relational: // relational
-      case symbol_kind::SYM_stringop: // stringop
         value.template destroy< int > ();
         break;
 
@@ -2861,6 +2871,12 @@ switch (yykind)
         value.copy< AggrNode* > (YY_MOVE (that.value));
         break;
 
+      case symbol_kind::SYM_equality: // equality
+      case symbol_kind::SYM_relational: // relational
+      case symbol_kind::SYM_stringop: // stringop
+        value.copy< CompareType > (YY_MOVE (that.value));
+        break;
+
       case symbol_kind::SYM_constant: // constant
       case symbol_kind::SYM_primary_key: // primary_key
         value.copy< ConstantNode* > (YY_MOVE (that.value));
@@ -2938,9 +2954,6 @@ switch (yykind)
 
       case symbol_kind::SYM_comp_type: // comp_type
       case symbol_kind::SYM_aggr_op: // aggr_op
-      case symbol_kind::SYM_equality: // equality
-      case symbol_kind::SYM_relational: // relational
-      case symbol_kind::SYM_stringop: // stringop
         value.copy< int > (YY_MOVE (that.value));
         break;
 
@@ -3016,6 +3029,12 @@ switch (yykind)
     {
       case symbol_kind::SYM_aggregate: // aggregate
         value.move< AggrNode* > (YY_MOVE (s.value));
+        break;
+
+      case symbol_kind::SYM_equality: // equality
+      case symbol_kind::SYM_relational: // relational
+      case symbol_kind::SYM_stringop: // stringop
+        value.move< CompareType > (YY_MOVE (s.value));
         break;
 
       case symbol_kind::SYM_constant: // constant
@@ -3095,9 +3114,6 @@ switch (yykind)
 
       case symbol_kind::SYM_comp_type: // comp_type
       case symbol_kind::SYM_aggr_op: // aggr_op
-      case symbol_kind::SYM_equality: // equality
-      case symbol_kind::SYM_relational: // relational
-      case symbol_kind::SYM_stringop: // stringop
         value.move< int > (YY_MOVE (s.value));
         break;
 

--- a/src/realm/parser/query_bison.yy
+++ b/src/realm/parser/query_bison.yy
@@ -34,6 +34,8 @@
     class DescriptorNode;
     class PropertyNode;
     class SubqueryNode;
+
+    enum class CompareType: char;
     struct PathElem {
         std::string id;
         Mixed index;
@@ -136,7 +138,8 @@ using namespace realm::query_parser;
 %token <std::string> TYPE "@type"
 %token <std::string> KEY_VAL "key or value"
 %type  <bool> direction
-%type  <int> equality relational stringop aggr_op
+%type  <CompareType> equality relational stringop
+%type  <int> aggr_op
 %type  <double> coordinate
 %type  <ConstantNode*> constant primary_key
 %type  <GeospatialNode*> geospatial geoloop geoloop_content geopoly_content
@@ -173,6 +176,7 @@ using namespace realm::query_parser;
 %printer { yyo << $$.id; } <PathElem>;
 %printer { yyo << $$; } <*>;
 %printer { yyo << "<>"; } <>;
+%printer { yyo << string_for_op($$); } <CompareType>;
 
 %%
 %start final;
@@ -193,7 +197,7 @@ query
     | NOT query                 { $$ = drv.m_parse_nodes.create<NotNode>($2); }
     | '(' query ')'             { $$ = $2; }
     | boolexpr                  { $$ =$1; }
-
+ 
 compare
     : expr equality expr        { $$ = drv.m_parse_nodes.create<EqualityNode>($1, $2, $3); }
     | expr equality CASE expr   {
@@ -203,7 +207,7 @@ compare
                                 }
     | expr relational expr      { $$ = drv.m_parse_nodes.create<RelationalNode>($1, $2, $3); }
     | value stringop value      { $$ = drv.m_parse_nodes.create<StringOpsNode>($1, $2, $3); }
-    | value TEXT value          { $$ = drv.m_parse_nodes.create<StringOpsNode>($1, CompareNode::TEXT, $3); }
+    | value TEXT value          { $$ = drv.m_parse_nodes.create<StringOpsNode>($1, CompareType::TEXT, $3); }
     | value stringop CASE value {
                                     auto tmp = drv.m_parse_nodes.create<StringOpsNode>($1, $2, $4);
                                     tmp->case_sensitive = false;
@@ -353,21 +357,21 @@ aggr_op
     | '.' AVG                   { $$ = int(AggrNode::AVG);}
 
 equality
-    : EQUAL                     { $$ = CompareNode::EQUAL; }
-    | NOT_EQUAL                 { $$ = CompareNode::NOT_EQUAL; }
-    | IN                        { $$ = CompareNode::IN; }
+    : EQUAL                     { $$ = CompareType::EQUAL; }
+    | NOT_EQUAL                 { $$ = CompareType::NOT_EQUAL; }
+    | IN                        { $$ = CompareType::IN; }
 
 relational
-    : LESS                      { $$ = CompareNode::LESS; }
-    | LESS_EQUAL                { $$ = CompareNode::LESS_EQUAL; }
-    | GREATER                   { $$ = CompareNode::GREATER; }
-    | GREATER_EQUAL             { $$ = CompareNode::GREATER_EQUAL; }
+    : LESS                      { $$ = CompareType::LESS; }
+    | LESS_EQUAL                { $$ = CompareType::LESS_EQUAL; }
+    | GREATER                   { $$ = CompareType::GREATER; }
+    | GREATER_EQUAL             { $$ = CompareType::GREATER_EQUAL; }
 
 stringop
-    : BEGINSWITH                { $$ = CompareNode::BEGINSWITH; }
-    | ENDSWITH                  { $$ = CompareNode::ENDSWITH; }
-    | CONTAINS                  { $$ = CompareNode::CONTAINS; }
-    | LIKE                      { $$ = CompareNode::LIKE; }
+    : BEGINSWITH                { $$ = CompareType::BEGINSWITH; }
+    | ENDSWITH                  { $$ = CompareType::ENDSWITH; }
+    | CONTAINS                  { $$ = CompareType::CONTAINS; }
+    | LIKE                      { $$ = CompareType::LIKE; }
 
 path
     : path_elem                 { $$ = drv.m_parse_nodes.create<PathNode>($1); }


### PR DESCRIPTION
TSAN reported a data [race](https://evergreen.mongodb.com/task_log_raw/realm_core_stable_ubuntu2004_tsan_core_tests_patch_a3717e492ec606e42995169cf706a82fc1cd0698_65000bc93e8e8688b5e7890c_23_09_12_06_57_15/0?type=T&text=true) between a couple unit tests. The cause was because we were using a static map to translate integer values into a human readable string for error messaging purposes. This was working fine for read only access, except that we had forgotten to handle a new comparison type for the TEXT operator, so accessing the map for that value added an empty entry from multiple tests that used full text search. To fix this and make it more future proof, I changed from using static constant ints, to using an enum class. This means that for values we add in the future, we will get a compiler warning if we forget to handle it in a switch statement somewhere.

## ☑️ ToDos
* [ ] 📝 Changelog update
* [ ] 🚦 Tests (or not relevant)
* [ ] C-API, if public C++ API changed.
