### PR TITLE
Fix open async when rerun on open is set.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@
 * When using SecureTransport (i.e. on Apple platforms) only some TLS errors were reported as `TlsHandshakeFailed` and most were reported as `SyncConnectFailed` ([PR #6938](https://github.com/realm/realm-core/pull/6938)).
 * Sync errors originating from OpenSSL used the error message from the wrong end of the error stack, often resulting in very unhelpful error message ([PR #6938](https://github.com/realm/realm-core/pull/6938)).
 * Sending empty UPLOAD messages may lead to 'Bad server version' errors and client reset. ([6966](https://github.com/realm/realm-core/issues/6966), since v11.8.0)
+* Fix open async in order to invoke the subscription callback correctly when rerun_on_open is set to true. ([#6937](https://github.com/realm/realm-core/pull/6937), since v13.16.0).
 
 ### Breaking changes
 * None.

--- a/src/realm/object-store/impl/realm_coordinator.cpp
+++ b/src/realm/object-store/impl/realm_coordinator.cpp
@@ -278,7 +278,7 @@ std::shared_ptr<Realm> RealmCoordinator::get_realm(Realm::Config config, util::O
     return realm;
 }
 
-std::shared_ptr<Realm> RealmCoordinator::get_realm(std::shared_ptr<util::Scheduler> scheduler)
+std::shared_ptr<Realm> RealmCoordinator::get_realm(std::shared_ptr<util::Scheduler> scheduler, bool first_time_open)
 {
     std::shared_ptr<Realm> realm;
     util::CheckedUniqueLock lock(m_realm_mutex);
@@ -287,7 +287,7 @@ std::shared_ptr<Realm> RealmCoordinator::get_realm(std::shared_ptr<util::Schedul
     if ((realm = do_get_cached_realm(config))) {
         return realm;
     }
-    do_get_realm(std::move(config), realm, none, lock);
+    do_get_realm(std::move(config), realm, none, lock, first_time_open);
     return realm;
 }
 
@@ -319,19 +319,21 @@ ThreadSafeReference RealmCoordinator::get_unbound_realm()
 }
 
 void RealmCoordinator::do_get_realm(RealmConfig&& config, std::shared_ptr<Realm>& realm,
-                                    util::Optional<VersionID> version, util::CheckedUniqueLock& realm_lock)
+                                    util::Optional<VersionID> version, util::CheckedUniqueLock& realm_lock,
+                                    bool first_time_open)
 {
-    const auto db_opened_first_time = open_db();
+    const auto db_created = open_db();
 #ifdef REALM_ENABLE_SYNC
     SyncConfig::SubscriptionInitializerCallback subscription_function = nullptr;
     bool rerun_on_open = false;
     if (config.sync_config && config.sync_config->flx_sync_requested &&
         config.sync_config->subscription_initializer) {
-        subscription_function = std::move(config.sync_config->subscription_initializer);
+        subscription_function = config.sync_config->subscription_initializer;
         rerun_on_open = config.sync_config->rerun_init_subscription_on_open;
     }
 #else
-    static_cast<void>(db_opened_first_time);
+    static_cast<void>(first_time_open);
+    static_cast<void>(db_created);
 #endif
 
     auto schema = std::move(config.schema);
@@ -379,7 +381,14 @@ void RealmCoordinator::do_get_realm(RealmConfig&& config, std::shared_ptr<Realm>
     // rerun_on_open was set
     if (subscription_function) {
         const auto current_subscription = realm->get_latest_subscription_set();
-        if ((current_subscription.version() == 0) || (rerun_on_open && db_opened_first_time)) {
+        const auto subscription_version = current_subscription.version();
+        // in case we are hitting this check while during a normal open, we need to take in
+        // consideration if the db was created during this call. Since this may be the first time
+        // we are actually creating a realm. For async open this does not apply, infact db_created
+        // will always be false.
+        first_time_open |= db_created;
+        if (subscription_version == 0 || (first_time_open && rerun_on_open)) {
+            // if the tasks is cancelled, the subscription may or may not be run.
             subscription_function(realm);
         }
     }

--- a/src/realm/object-store/impl/realm_coordinator.cpp
+++ b/src/realm/object-store/impl/realm_coordinator.cpp
@@ -386,7 +386,8 @@ void RealmCoordinator::do_get_realm(RealmConfig&& config, std::shared_ptr<Realm>
         // consideration if the db was created during this call. Since this may be the first time
         // we are actually creating a realm. For async open this does not apply, infact db_created
         // will always be false.
-        first_time_open |= db_created;
+        if (!first_time_open)
+            first_time_open = db_created;
         if (subscription_version == 0 || (first_time_open && rerun_on_open)) {
             // if the tasks is cancelled, the subscription may or may not be run.
             subscription_function(realm);

--- a/src/realm/object-store/impl/realm_coordinator.hpp
+++ b/src/realm/object-store/impl/realm_coordinator.hpp
@@ -58,7 +58,7 @@ public:
     // can be read from any thread.
     std::shared_ptr<Realm> get_realm(Realm::Config config, util::Optional<VersionID> version)
         REQUIRES(!m_realm_mutex, !m_schema_cache_mutex);
-    std::shared_ptr<Realm> get_realm(std::shared_ptr<util::Scheduler> = nullptr)
+    std::shared_ptr<Realm> get_realm(std::shared_ptr<util::Scheduler> = nullptr, bool first_time_open = false)
         REQUIRES(!m_realm_mutex, !m_schema_cache_mutex);
 
     // Return a frozen copy of the source Realm. May return a cached instance
@@ -269,7 +269,7 @@ private:
                                                std::shared_ptr<util::Scheduler> scheduler = nullptr)
         REQUIRES(m_realm_mutex);
     void do_get_realm(Realm::Config&& config, std::shared_ptr<Realm>& realm, util::Optional<VersionID> version,
-                      util::CheckedUniqueLock& realm_lock) REQUIRES(m_realm_mutex);
+                      util::CheckedUniqueLock& realm_lock, bool first_time_open = false) REQUIRES(m_realm_mutex);
     void run_async_notifiers() REQUIRES(!m_notifier_mutex, m_running_notifiers_mutex);
     void clean_up_dead_notifiers() REQUIRES(m_notifier_mutex);
 

--- a/src/realm/object-store/sync/async_open_task.cpp
+++ b/src/realm/object-store/sync/async_open_task.cpp
@@ -61,8 +61,7 @@ void AsyncOpenTask::start(AsyncOpenCallback async_open_complete)
         }
 
         auto config = coordinator->get_config();
-        if (config.sync_config && config.sync_config->flx_sync_requested &&
-            config.sync_config->subscription_initializer) {
+        if (config.sync_config && config.sync_config->flx_sync_requested) {
             const bool rerun_on_launch = config.sync_config->rerun_init_subscription_on_open;
             self->attach_to_subscription_initializer(std::move(async_open_complete), coordinator, rerun_on_launch);
         }
@@ -130,10 +129,11 @@ void AsyncOpenTask::attach_to_subscription_initializer(AsyncOpenCallback&& async
     // 2. we are instructed to run the subscription initializer via sync_config->rerun_init_subscription_on_open.
     //    But we do that only if this is the first time we open realm.
 
-    auto shared_realm = coordinator->get_realm();
+    auto shared_realm = coordinator->get_realm(nullptr, m_db_first_open);
     const auto init_subscription = shared_realm->get_latest_subscription_set();
+    const auto sub_state = init_subscription.state();
 
-    if (init_subscription.version() == 1 || (rerun_on_launch && m_db_first_open)) {
+    if ((sub_state != sync::SubscriptionSet::State::Complete) || (m_db_first_open && rerun_on_launch)) {
         // We need to wait until subscription initializer completes
         std::shared_ptr<AsyncOpenTask> self(shared_from_this());
         init_subscription.get_state_change_notification(sync::SubscriptionSet::State::Complete)

--- a/src/realm/object-store/sync/async_open_task.cpp
+++ b/src/realm/object-store/sync/async_open_task.cpp
@@ -61,7 +61,8 @@ void AsyncOpenTask::start(AsyncOpenCallback async_open_complete)
         }
 
         auto config = coordinator->get_config();
-        if (config.sync_config && config.sync_config->flx_sync_requested) {
+        if (config.sync_config && config.sync_config->flx_sync_requested &&
+            config.sync_config->subscription_initializer) {
             const bool rerun_on_launch = config.sync_config->rerun_init_subscription_on_open;
             self->attach_to_subscription_initializer(std::move(async_open_complete), coordinator, rerun_on_launch);
         }

--- a/test/object-store/sync/flx_sync.cpp
+++ b/test/object-store/sync/flx_sync.cpp
@@ -3752,19 +3752,20 @@ TEST_CASE("flx: open realm + register subscription callack while bootstrapping",
     std::atomic<bool> subscription_invoked = false;
     auto subscription_pf = util::make_promise_future<bool>();
     // create a subscription to commit when realm is open for the first time or asked to rerun on open
-    auto init_subscription_callback = [&, promise_holder = util::CopyablePromiseHolder(std::move(
-                                              subscription_pf.promise))](std::shared_ptr<Realm> realm) mutable {
-        REQUIRE(realm);
-        auto table = realm->read_group().get_table("class_TopLevel");
-        Query query(table);
-        auto subscription = realm->get_latest_subscription_set();
-        auto mutable_subscription = subscription.make_mutable_copy();
-        mutable_subscription.insert_or_assign(query);
-        auto promise = promise_holder.get_promise();
-        mutable_subscription.commit();
-        subscription_invoked = true;
-        promise.emplace_value(true);
-    };
+    auto init_subscription_callback_with_promise =
+        [&, promise_holder = util::CopyablePromiseHolder(std::move(subscription_pf.promise))](
+            std::shared_ptr<Realm> realm) mutable {
+            REQUIRE(realm);
+            auto table = realm->read_group().get_table("class_TopLevel");
+            Query query(table);
+            auto subscription = realm->get_latest_subscription_set();
+            auto mutable_subscription = subscription.make_mutable_copy();
+            mutable_subscription.insert_or_assign(query);
+            auto promise = promise_holder.get_promise();
+            mutable_subscription.commit();
+            subscription_invoked = true;
+            promise.emplace_value(true);
+        };
     // verify that the subscription has changed the database
     auto verify_subscription = [](SharedRealm realm) {
         REQUIRE(realm);
@@ -3785,7 +3786,7 @@ TEST_CASE("flx: open realm + register subscription callack while bootstrapping",
         // sync open with subscription callback. Subscription will be run, since this is the first time that realm is
         // opened
         subscription_invoked = false;
-        config.sync_config->subscription_initializer = init_subscription_callback;
+        config.sync_config->subscription_initializer = init_subscription_callback_with_promise;
         auto realm = Realm::get_shared_realm(config);
         REQUIRE(subscription_pf.future.get());
         auto sb = realm->get_latest_subscription_set();
@@ -3794,6 +3795,58 @@ TEST_CASE("flx: open realm + register subscription callack while bootstrapping",
         REQUIRE(state == realm::sync::SubscriptionSet::State::Complete);
         realm->refresh(); // refresh is needed otherwise table_ref->size() would be 0
         REQUIRE(verify_subscription(realm));
+    }
+
+    SECTION("Sync Open + Async Open") {
+        {
+            subscription_invoked = false;
+            config.sync_config->subscription_initializer = init_subscription_callback_with_promise;
+            auto realm = Realm::get_shared_realm(config);
+            REQUIRE(subscription_pf.future.get());
+            auto sb = realm->get_latest_subscription_set();
+            auto future = sb.get_state_change_notification(realm::sync::SubscriptionSet::State::Complete);
+            auto state = future.get();
+            REQUIRE(state == realm::sync::SubscriptionSet::State::Complete);
+            realm->refresh(); // refresh is needed otherwise table_ref->size() would be 0
+            REQUIRE(verify_subscription(realm));
+        }
+        {
+            auto subscription_pf_async = util::make_promise_future<bool>();
+            auto init_subscription_asyc_callback =
+                [promise_holder_async = util::CopyablePromiseHolder(std::move(subscription_pf_async.promise))](
+                    std::shared_ptr<Realm> realm) mutable {
+                    REQUIRE(realm);
+                    auto table = realm->read_group().get_table("class_TopLevel");
+                    Query query(table);
+                    auto subscription = realm->get_latest_subscription_set();
+                    auto mutable_subscription = subscription.make_mutable_copy();
+                    mutable_subscription.insert_or_assign(query);
+                    auto promise = promise_holder_async.get_promise();
+                    mutable_subscription.commit();
+                    promise.emplace_value(true);
+                };
+            auto open_realm_pf = util::make_promise_future<bool>();
+            auto open_realm_completed_callback =
+                [&, promise_holder = util::CopyablePromiseHolder(std::move(open_realm_pf.promise))](
+                    ThreadSafeReference ref, std::exception_ptr err) mutable {
+                    auto promise = promise_holder.get_promise();
+                    if (err)
+                        promise.emplace_value(false);
+                    else
+                        promise.emplace_value(verify_subscription(Realm::get_shared_realm(std::move(ref))));
+                };
+
+            config.sync_config->subscription_initializer = init_subscription_asyc_callback;
+            config.sync_config->rerun_init_subscription_on_open = true;
+            auto async_open = Realm::get_synchronized_realm(config);
+            async_open->start(open_realm_completed_callback);
+            REQUIRE(open_realm_pf.future.get());
+            REQUIRE(subscription_pf_async.future.get());
+            config.sync_config->rerun_init_subscription_on_open = false;
+            auto realm = Realm::get_shared_realm(config);
+            REQUIRE(realm->get_latest_subscription_set().version() == 2);
+            REQUIRE(realm->get_active_subscription_set().version() == 2);
+        }
     }
 
     SECTION("Async open") {
@@ -3810,19 +3863,18 @@ TEST_CASE("flx: open realm + register subscription callack while bootstrapping",
                         promise.emplace_value(verify_subscription(Realm::get_shared_realm(std::move(ref))));
                 };
 
-            subscription_invoked = false;
-            config.sync_config->subscription_initializer = init_subscription_callback;
+            config.sync_config->subscription_initializer = init_subscription_callback_with_promise;
             auto async_open = Realm::get_synchronized_realm(config);
             async_open->start(open_realm_completed_callback);
             REQUIRE(open_realm_pf.future.get());
             REQUIRE(subscription_pf.future.get());
 
-            SECTION("subscription not run because realm alredy opened no error") {
+            SECTION("rerun on open = false. Subscription not run") {
                 subscription_invoked = false;
                 auto async_open = Realm::get_synchronized_realm(config);
                 auto open_realm_pf = util::make_promise_future<bool>();
                 auto open_realm_completed_callback =
-                    [&, promise_holder = util::CopyablePromiseHolder(std::move(open_realm_pf.promise))](
+                    [promise_holder = util::CopyablePromiseHolder(std::move(open_realm_pf.promise))](
                         ThreadSafeReference, std::exception_ptr) mutable {
                         // no need to verify if the subscription has changed the db, since it has not run as we test
                         // below
@@ -3833,29 +3885,10 @@ TEST_CASE("flx: open realm + register subscription callack while bootstrapping",
                 REQUIRE_FALSE(subscription_invoked.load());
             }
 
-            SECTION("rerun on open set, but this is not the first time the file is opened") {
+            SECTION("rerun on open = true. Subscription not run cause realm already opened once") {
                 subscription_invoked = false;
-                config.sync_config->rerun_init_subscription_on_open = true;
-                auto async_open = Realm::get_synchronized_realm(config);
-                auto open_realm_pf = util::make_promise_future<bool>();
-                auto open_realm_completed_callback =
-                    [&, promise_holder = util::CopyablePromiseHolder(std::move(open_realm_pf.promise))](
-                        ThreadSafeReference, std::exception_ptr) mutable {
-                        // no need to verify if the subscription has changed the db, since it has not run as we test
-                        // below
-                        promise_holder.get_promise().emplace_value(true);
-                    };
-                async_open->start(open_realm_completed_callback);
-                REQUIRE(open_realm_pf.future.get());
-                REQUIRE_FALSE(subscription_invoked.load());
-            }
-        }
-
-        SECTION("rerun on open set for multiple async open tasks (subscription runs only once)") {
-            auto subscription_pf = util::make_promise_future<bool>();
-            auto init_subscription_callback =
-                [&, promise_holder = util::CopyablePromiseHolder(std::move(subscription_pf.promise))](
-                    std::shared_ptr<Realm> realm) mutable {
+                auto realm = Realm::get_shared_realm(config);
+                auto init_subscription = [&subscription_invoked](std::shared_ptr<Realm> realm) mutable {
                     REQUIRE(realm);
                     auto table = realm->read_group().get_table("class_TopLevel");
                     Query query(table);
@@ -3863,45 +3896,110 @@ TEST_CASE("flx: open realm + register subscription callack while bootstrapping",
                     auto mutable_subscription = subscription.make_mutable_copy();
                     mutable_subscription.insert_or_assign(query);
                     mutable_subscription.commit();
-                    promise_holder.get_promise().emplace_value(true);
+                    subscription_invoked.store(true);
                 };
-            config.sync_config->subscription_initializer = init_subscription_callback;
+                config.sync_config->rerun_init_subscription_on_open = true;
+                config.sync_config->subscription_initializer = init_subscription;
+                auto async_open = Realm::get_synchronized_realm(config);
+                auto open_realm_pf = util::make_promise_future<bool>();
+                auto open_realm_completed_callback =
+                    [promise_holder = util::CopyablePromiseHolder(std::move(open_realm_pf.promise))](
+                        ThreadSafeReference, std::exception_ptr) mutable {
+                        // no need to verify if the subscription has changed the db, since it has not run as we test
+                        // below
+                        promise_holder.get_promise().emplace_value(true);
+                    };
+                async_open->start(open_realm_completed_callback);
+                REQUIRE(open_realm_pf.future.get());
+                REQUIRE_FALSE(subscription_invoked.load());
+                REQUIRE(realm->get_latest_subscription_set().version() == 1);
+                REQUIRE(realm->get_active_subscription_set().version() == 1);
+            }
+        }
+
+        SECTION("rerun on open set for multiple async open tasks (subscription runs only once)") {
+            auto init_subscription = [](std::shared_ptr<Realm> realm) mutable {
+                REQUIRE(realm);
+                auto table = realm->read_group().get_table("class_TopLevel");
+                Query query(table);
+                auto subscription = realm->get_latest_subscription_set();
+                auto mutable_subscription = subscription.make_mutable_copy();
+                mutable_subscription.insert_or_assign(query);
+                mutable_subscription.commit();
+            };
+
+            auto open_task1_pf = util::make_promise_future<SharedRealm>();
+            auto open_task2_pf = util::make_promise_future<SharedRealm>();
+            auto open_callback1 = [promise_holder = util::CopyablePromiseHolder(std::move(open_task1_pf.promise))](
+                                      ThreadSafeReference ref, std::exception_ptr err) mutable {
+                REQUIRE_FALSE(err);
+                auto realm = Realm::get_shared_realm(std::move(ref));
+                REQUIRE(realm);
+                promise_holder.get_promise().emplace_value(realm);
+            };
+            auto open_callback2 = [promise_holder = util::CopyablePromiseHolder(std::move(open_task2_pf.promise))](
+                                      ThreadSafeReference ref, std::exception_ptr err) mutable {
+                REQUIRE_FALSE(err);
+                auto realm = Realm::get_shared_realm(std::move(ref));
+                REQUIRE(realm);
+                promise_holder.get_promise().emplace_value(realm);
+            };
+
             config.sync_config->rerun_init_subscription_on_open = true;
+            config.sync_config->subscription_initializer = init_subscription;
 
-            auto async_open_task1 = Realm::get_synchronized_realm(config);
-            auto async_open_task2 = Realm::get_synchronized_realm(config);
+            SECTION("Realm was already created, but we want to rerun on first open using multiple tasks") {
+                {
+                    subscription_invoked = false;
+                    auto realm = Realm::get_shared_realm(config);
+                    auto sb = realm->get_latest_subscription_set();
+                    auto future = sb.get_state_change_notification(realm::sync::SubscriptionSet::State::Complete);
+                    auto state = future.get();
+                    REQUIRE(state == realm::sync::SubscriptionSet::State::Complete);
+                    realm->refresh(); // refresh is needed otherwise table_ref->size() would be 0
+                    REQUIRE(verify_subscription(realm));
+                    REQUIRE(realm->get_latest_subscription_set().version() == 1);
+                    REQUIRE(realm->get_active_subscription_set().version() == 1);
+                }
 
-            auto open_t1_pf = util::make_promise_future<SharedRealm>();
-            auto open_t2_pf = util::make_promise_future<SharedRealm>();
+                auto async_open_task1 = Realm::get_synchronized_realm(config);
+                auto async_open_task2 = Realm::get_synchronized_realm(config);
+                async_open_task1->start(open_callback1);
+                async_open_task2->start(open_callback2);
 
-            auto open_callback_task_1 = [&,
-                                         promise_holder = util::CopyablePromiseHolder(std::move(open_t1_pf.promise))](
-                                            ThreadSafeReference ref, std::exception_ptr err) mutable {
-                REQUIRE_FALSE(err);
-                auto realm = Realm::get_shared_realm(std::move(ref));
-                REQUIRE(realm);
-                promise_holder.get_promise().emplace_value(realm);
-            };
-            auto open_callback_task_2 = [&,
-                                         promise_holder = util::CopyablePromiseHolder(std::move(open_t2_pf.promise))](
-                                            ThreadSafeReference ref, std::exception_ptr err) mutable {
-                REQUIRE_FALSE(err);
-                auto realm = Realm::get_shared_realm(std::move(ref));
-                REQUIRE(realm);
-                promise_holder.get_promise().emplace_value(realm);
-            };
+                auto realm1 = open_task1_pf.future.get();
+                auto realm2 = open_task2_pf.future.get();
 
-            async_open_task1->start(open_callback_task_1);
-            async_open_task2->start(open_callback_task_2);
+                const auto version_expected = 2;
+                auto r1_latest = realm1->get_latest_subscription_set().version();
+                auto r1_active = realm1->get_active_subscription_set().version();
+                REQUIRE(realm2->get_latest_subscription_set().version() == r1_latest);
+                REQUIRE(realm2->get_active_subscription_set().version() == r1_active);
+                REQUIRE(r1_latest == version_expected);
+                REQUIRE(r1_active == version_expected);
+            }
+            SECTION("First time realm is created but opened via open async. Both tasks could run the subscription") {
+                auto async_open_task1 = Realm::get_synchronized_realm(config);
+                auto async_open_task2 = Realm::get_synchronized_realm(config);
+                async_open_task1->start(open_callback1);
+                async_open_task2->start(open_callback2);
+                auto realm1 = open_task1_pf.future.get();
+                auto realm2 = open_task2_pf.future.get();
 
-            // subscription init called only once but realm opened twice
-            auto realm1 = open_t1_pf.future.get();
-            auto realm2 = open_t2_pf.future.get();
-            REQUIRE(realm1->get_latest_subscription_set().version() == 1);
-            REQUIRE(realm1->get_active_subscription_set().version() == 1);
-            REQUIRE(realm2->get_latest_subscription_set().version() == 1);
-            REQUIRE(realm2->get_active_subscription_set().version() == 1);
-            REQUIRE(subscription_pf.future.get());
+                auto r1_latest = realm1->get_latest_subscription_set().version();
+                auto r1_active = realm1->get_active_subscription_set().version();
+                REQUIRE(realm2->get_latest_subscription_set().version() == r1_latest);
+                REQUIRE(realm2->get_active_subscription_set().version() == r1_active);
+                // the callback may be run twice, if task1 is the first task to open realm
+                // but it is scheduled after tasks2, which have opened realm later but
+                // by the time it runs, subscription version is equal to 0 (realm creation).
+                // This can only happen the first time that realm is created. All the other times
+                // the init_sb callback is guaranteed to run once.
+                REQUIRE(r1_latest >= 1);
+                REQUIRE(r1_latest <= 2);
+                REQUIRE(r1_active >= 1);
+                REQUIRE(r1_active <= 2);
+            }
         }
     }
 }


### PR DESCRIPTION
## What, How & Why?
1. Fix open async logic when rerun on open is set. 
2. Consolidate tests
3. Fix wrong use of `std::move `for `init_sb_callback`.

