### PR TITLE
Add integration test for opening websocket with invalid access token

### DIFF
--- a/test/object-store/sync/flx_sync.cpp
+++ b/test/object-store/sync/flx_sync.cpp
@@ -233,6 +233,18 @@ TEST_CASE("flx: connect to FLX-enabled app", "[sync][flx][baas]") {
     });
 }
 
+TEST_CASE("flx: connect to FLX-enabled app with invalid access token", "[sync][flx][baas]") {
+    FLXSyncTestHarness harness("invalid_access_token");
+    harness.do_with_new_user([&](std::shared_ptr<SyncUser> user) {
+        user->update_access_token(ENCODE_FAKE_JWT("fake_access_token"));
+        SyncTestFile config(user, harness.schema(), SyncConfig::FLXSyncEnabled{});
+
+        // the connection will get an unauthorized error, then re-authenticate, then reconnect successfully
+        const auto realm = Realm::get_shared_realm(config);
+        wait_for_download(*realm);
+    });
+}
+
 TEST_CASE("flx: test commands work", "[sync][flx][test command][baas]") {
     FLXSyncTestHarness harness("test_commands");
     harness.do_with_new_realm([&](const SharedRealm& realm) {


### PR DESCRIPTION
## What, How & Why?
This PR introduces a basic test that opens a websocket connection with an invalid access token and ensures that the client is able to refresh the token and recover

## ☑️ ToDos
* [ ] 📝 Changelog update
* [ ] 🚦 Tests (or not relevant)
* [ ] C-API, if public C++ API changed.