### PR TITLE
Fix benchmark-common-tasks test failures

### DIFF
--- a/test/object-store/CMakeLists.txt
+++ b/test/object-store/CMakeLists.txt
@@ -1,7 +1,4 @@
 set(HEADERS
-    ../util/crypt_key.hpp
-    ../util/spawned_process.hpp
-    ../util/test_path.hpp
     util/event_loop.hpp
     util/index_helpers.hpp
     util/test_file.hpp
@@ -32,9 +29,6 @@ set(SOURCES
     c_api/c_api.cpp
     c_api/c_api.c
 
-    ../util/crypt_key.cpp
-    ../util/spawned_process.cpp
-    ../util/test_path.cpp
     util/event_loop.cpp
     util/test_file.cpp
     util/test_utils.cpp
@@ -91,7 +85,7 @@ if(MSVC)
     target_compile_options(ObjectStoreTests PRIVATE /bigobj)
 endif()
 
-target_link_libraries(ObjectStoreTests Catch2::Catch2 ObjectStore RealmFFIStatic)
+target_link_libraries(ObjectStoreTests Catch2::Catch2 ObjectStore TestUtil RealmFFIStatic)
 enable_stdfilesystem(ObjectStoreTests)
 create_coverage_target(generate-coverage ObjectStoreTests)
 

--- a/test/object-store/benchmarks/CMakeLists.txt
+++ b/test/object-store/benchmarks/CMakeLists.txt
@@ -10,7 +10,6 @@ set(SOURCES
     object.cpp
     results.cpp
 
-    ../../util/crypt_key.cpp
     ../util/event_loop.cpp
     ../util/test_file.cpp
     ../util/test_utils.cpp
@@ -39,7 +38,7 @@ if(REALM_ENABLE_SYNC)
     enable_stdfilesystem(object-store-benchmarks)
 endif()
 
-target_link_libraries(object-store-benchmarks ObjectStore Catch2::Catch2)
+target_link_libraries(object-store-benchmarks ObjectStore TestUtil Catch2::Catch2)
 set_target_properties(object-store-benchmarks PROPERTIES
       EXCLUDE_FROM_ALL 1
       EXCLUDE_FROM_DEFAULT_BUILD 1)


### PR DESCRIPTION
## What, How & Why?
The `benchmarck-common-tasks` test was failing to compile in the evergreen CI for the nightly and master commit test runs.

These changes address the compilation failures by importing the `TestUtil` library as a `target_link_library` when building the `realm-object-store-tests` and `realm-benchmark-common-tasks` executables instead of including individual files from the `test/util/` directory.

## ☑️ ToDos
* ~~[] 📝 Changelog update~~
* ~~[ ] 🚦 Tests (or not relevant)~~
* ~~[ ] C-API, if public C++ API changed.~~
