### PR TITLE
Simplify Logger class a bit

### DIFF
--- a/src/realm/db.hpp
+++ b/src/realm/db.hpp
@@ -509,7 +509,7 @@ private:
     std::function<void(int, int)> m_upgrade_callback;
     std::shared_ptr<metrics::Metrics> m_metrics;
     std::unique_ptr<AsyncCommitHelper> m_commit_helper;
-    std::shared_ptr<util::Logger> m_logger;
+    std::unique_ptr<util::Logger> m_logger;
     bool m_is_sync_agent = false;
     // Id for this DB to be used in logging. We will just use some bits from the pointer.
     // The path cannot be used as this would not allow us to distinguish between two DBs opening

--- a/src/realm/util/logger.hpp
+++ b/src/realm/util/logger.hpp
@@ -82,13 +82,13 @@ public:
     template <class... Params>
     void log(Level, const char* message, Params&&...);
 
-    virtual Level get_level_threshold() const noexcept
+    Level get_level_threshold() const noexcept
     {
         // Don't need strict ordering, mainly that the gets/sets are atomic
         return m_level_threshold.load(std::memory_order_relaxed);
     }
 
-    virtual void set_level_threshold(Level level) noexcept
+    void set_level_threshold(Level level) noexcept
     {
         // Don't need strict ordering, mainly that the gets/sets are atomic
         m_level_threshold.store(level, std::memory_order_relaxed);
@@ -109,9 +109,6 @@ public:
     static const std::string_view level_to_string(Level level) noexcept;
 
 protected:
-    // Used by subclasses that link to a base logger
-    std::shared_ptr<Logger> m_base_logger_ptr;
-
     // Shared level threshold for subclasses that link to a base logger
     // See PrefixLogger and ThreadSafeLogger
     std::atomic<Level>& m_level_threshold;
@@ -128,9 +125,8 @@ protected:
     {
     }
 
-    explicit Logger(const std::shared_ptr<Logger>& base_logger) noexcept
-        : m_base_logger_ptr{base_logger}
-        , m_level_threshold{m_base_logger_ptr->m_level_threshold}
+    explicit Logger(const Logger& base_logger) noexcept
+        : m_level_threshold{base_logger.m_level_threshold}
     {
     }
 
@@ -229,6 +225,7 @@ protected:
 
 private:
     Mutex m_mutex;
+    std::shared_ptr<Logger> m_base_logger_ptr;
 };
 
 
@@ -247,6 +244,7 @@ protected:
 private:
     const std::string m_prefix;
     // The next logger in the chain for chained PrefixLoggers or the base_logger
+    std::shared_ptr<Logger> m_owned_logger;
     Logger& m_chained_logger;
 };
 
@@ -270,29 +268,6 @@ public:
 
 protected:
     std::shared_ptr<Logger> m_chained_logger;
-};
-
-
-/// A logger that essentially performs a noop when logging functions are called
-/// The log level threshold for this logger is always Logger::Level::off and
-/// cannot be changed.
-class NullLogger : public Logger {
-public:
-    NullLogger()
-        : Logger{Level::off}
-    {
-    }
-
-    Level get_level_threshold() const noexcept override
-    {
-        return Level::off;
-    }
-
-    void set_level_threshold(Level) noexcept override {}
-
-protected:
-    // Since we don't want to log anything, do_log() does nothing
-    void do_log(Level, const std::string&) override {}
 };
 
 
@@ -459,14 +434,15 @@ inline AppendToFileLogger::AppendToFileLogger(util::File file)
 }
 
 inline ThreadSafeLogger::ThreadSafeLogger(const std::shared_ptr<Logger>& base_logger) noexcept
-    : Logger(base_logger)
+    : Logger(*base_logger)
+    , m_base_logger_ptr(base_logger)
 {
 }
 
 // Construct a PrefixLogger from another PrefixLogger object for chaining the prefixes on log output
 inline PrefixLogger::PrefixLogger(std::string prefix, PrefixLogger& prefix_logger) noexcept
     // Save an alias of the base_logger shared_ptr from the passed in PrefixLogger
-    : Logger(prefix_logger.m_base_logger_ptr)
+    : Logger(prefix_logger)
     , m_prefix{std::move(prefix)}
     , m_chained_logger{prefix_logger} // do_log() writes to the chained logger
 {
@@ -477,9 +453,10 @@ inline PrefixLogger::PrefixLogger(std::string prefix, PrefixLogger& prefix_logge
 // created, will point back to this logger shared_ptr for referencing the level_threshold when
 // logging output.
 inline PrefixLogger::PrefixLogger(std::string prefix, const std::shared_ptr<Logger>& base_logger) noexcept
-    : Logger(base_logger) // Save an alias of the passed in base_logger shared_ptr
+    : Logger(*base_logger) // Save an alias of the passed in base_logger shared_ptr
     , m_prefix{std::move(prefix)}
-    , m_chained_logger{*base_logger} // do_log() writes to the chained logger
+    , m_owned_logger{base_logger}
+    , m_chained_logger{*m_owned_logger} // do_log() writes to the chained logger
 {
 }
 

--- a/test/object-store/util/test_file.cpp
+++ b/test/object-store/util/test_file.cpp
@@ -195,13 +195,7 @@ SyncServer::SyncServer(const SyncServer::Config& config)
     , m_server(m_local_root_dir, util::none, ([&] {
                    using namespace std::literals::chrono_literals;
 
-#if TEST_ENABLE_LOGGING
-                   auto logger = new util::StderrLogger(realm::util::Logger::Level::TEST_LOGGING_LEVEL);
-                   m_logger.reset(logger);
-#else
-                   // Logging is disabled, use a NullLogger to prevent printing anything
-                   m_logger.reset(new util::NullLogger());
-#endif
+                   m_logger = std::make_shared<util::StderrLogger>(realm::util::Logger::Level::TEST_LOGGING_LEVEL);
 
                    sync::Server::Config c;
                    c.logger = m_logger;

--- a/test/util/compare_groups.cpp
+++ b/test/util/compare_groups.cpp
@@ -957,12 +957,6 @@ bool compare_objects(sync::PrimaryKey& oid, const Table& table_1, const Table& t
 
 namespace realm::test_util {
 
-bool compare_tables(const Table& table_1, const Table& table_2)
-{
-    util::NullLogger logger;
-    return compare_tables(table_1, table_2, logger);
-}
-
 bool compare_tables(const Table& table_1, const Table& table_2, util::Logger& logger)
 {
     bool equal = true;
@@ -1039,7 +1033,7 @@ bool compare_tables(const Table& table_1, const Table& table_2, util::Logger& lo
 
 bool compare_groups(const Transaction& group_1, const Transaction& group_2)
 {
-    util::NullLogger logger;
+    util::StderrLogger logger;
     return compare_groups(group_1, group_2, logger);
 }
 


### PR DESCRIPTION
## What, How & Why?
Logger::m_base_logger_ptr seems not to be used in the class itself. The member is added to the sub-classes that need it.
get/set level_threshold need not be virtual is we remove support for NullLogger.

## ☑️ ToDos
* [ ] 📝 Changelog update
* [ ] 🚦 Tests (or not relevant)
* [ ] C-API, if public C++ API changed.
