### PR TITLE
remove unnecessary upload/download waiters in tests

### DIFF
--- a/test/object-store/sync/flx_sync.cpp
+++ b/test/object-store/sync/flx_sync.cpp
@@ -1470,9 +1470,6 @@ TEST_CASE("flx: uploading an object that is out-of-view results in compensating 
                        std::any(AnyDict{{"_id", invalid_obj}, {"queryable_str_field", "bizz"s}}));
         realm->commit_transaction();
 
-        wait_for_upload(*realm);
-        wait_for_download(*realm);
-
         validate_sync_error(
             std::move(error_future).get(), invalid_obj, "TopLevel",
             util::format("write to \"%1\" in table \"TopLevel\" not allowed", invalid_obj.to_string()));
@@ -1504,8 +1501,6 @@ TEST_CASE("flx: uploading an object that is out-of-view results in compensating 
         embedded_obj.set_property_value(c, "str_field", std::any{"baz"s});
         realm->commit_transaction();
 
-        wait_for_upload(*realm);
-        wait_for_download(*realm);
         validate_sync_error(
             std::move(error_future).get(), invalid_obj, "TopLevel",
             util::format("write to \"%1\" in table \"TopLevel\" not allowed", invalid_obj.to_string()));
@@ -1551,9 +1546,6 @@ TEST_CASE("flx: uploading an object that is out-of-view results in compensating 
                        }));
         realm->commit_transaction();
 
-        wait_for_upload(*realm);
-        wait_for_download(*realm);
-
         validate_sync_error(std::move(error_future).get(), invalid_obj, "TopLevel",
                             "object is outside of the current query view");
 
@@ -1585,9 +1577,6 @@ TEST_CASE("flx: uploading an object that is out-of-view results in compensating 
             realm->read_group().get_table("class_Int PK")->create_object_with_primary_key(123456);
             realm->commit_transaction();
 
-            wait_for_upload(*realm);
-            wait_for_download(*realm);
-
             validate_sync_error(std::move(error_future).get(), 123456, "Int PK",
                                 "write to \"123456\" in table \"Int PK\" not allowed");
         }
@@ -1599,9 +1588,6 @@ TEST_CASE("flx: uploading an object that is out-of-view results in compensating 
             realm->begin_transaction();
             realm->read_group().get_table("class_String PK")->create_object_with_primary_key("short");
             realm->commit_transaction();
-
-            wait_for_upload(*realm);
-            wait_for_download(*realm);
 
             validate_sync_error(std::move(error_future).get(), "short", "String PK",
                                 "write to \"short\" in table \"String PK\" not allowed");
@@ -1616,9 +1602,6 @@ TEST_CASE("flx: uploading an object that is out-of-view results in compensating 
             realm->read_group().get_table("class_String PK")->create_object_with_primary_key(pk);
             realm->commit_transaction();
 
-            wait_for_upload(*realm);
-            wait_for_download(*realm);
-
             validate_sync_error(std::move(error_future).get(), pk, "String PK",
                                 util::format("write to \"%1\" in table \"String PK\" not allowed", pk));
         }
@@ -1631,9 +1614,6 @@ TEST_CASE("flx: uploading an object that is out-of-view results in compensating 
             UUID pk("01234567-9abc-4def-9012-3456789abcde");
             realm->read_group().get_table("class_UUID PK")->create_object_with_primary_key(pk);
             realm->commit_transaction();
-
-            wait_for_upload(*realm);
-            wait_for_download(*realm);
 
             validate_sync_error(std::move(error_future).get(), pk, "UUID PK",
                                 util::format("write to \"UUID(%1)\" in table \"UUID PK\" not allowed", pk));


### PR DESCRIPTION
I observed several test [failures](https://spruce.mongodb.com/task/realm_core_stable_macos_release_baas_integration_tests_patch_eb34d4cb210b5e5374717c512ea910e3cb7d0bba_650b46f7d6d80a0eb4bca004_23_09_20_19_24_41/tests?execution=0&sortBy=STATUS&sortDir=ASC) with the exception `message: wait_for_session() timed out`.

`wait_for_session()` is called from either `wait_for_upload()` or `wait_for_download()` and there were several unnecessary calls to these in the tests that were failing. They are not needed in the places where I removed them, because immediately afterwards, the test waits on an error future.

My guess as to why these calls were timing out is that by the time the test code gets to call `wait_for_upload()`, sync has already completed the upload on the background thread, so that the test code waits forever. The same could happen for download.