### PR TITLE
Allow collections of non-embedded objects in asymmetric objects

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ### Enhancements
 * <New feature description> (PR [#????](https://github.com/realm/realm-core/pull/????))
-* None.
+* Allow collections of non-embedded links in asymmetric objects. ([PR #7003](https://github.com/realm/realm-core/pull/7003))
 
 ### Fixed
 * <How do the end-user experience this issue? what was the impact?> ([#????](https://github.com/realm/realm-core/issues/????), since v?.?.?)

--- a/src/realm/table.cpp
+++ b/src/realm/table.cpp
@@ -459,10 +459,6 @@ ColKey Table::add_column_list(Table& target, StringData name)
     Group* target_group = target.get_parent_group();
     REALM_ASSERT_RELEASE(origin_group && target_group);
     REALM_ASSERT_RELEASE(origin_group == target_group);
-    // Only links to embedded objects are allowed.
-    if (is_asymmetric() && !target.is_embedded()) {
-        throw IllegalOperation("List of objects not supported in asymmetric table");
-    }
     // Incoming links from an asymmetric table are not allowed.
     if (target.is_asymmetric()) {
         throw IllegalOperation("List of ephemeral objects not supported");
@@ -486,10 +482,6 @@ ColKey Table::add_column_set(Table& target, StringData name)
     REALM_ASSERT_RELEASE(origin_group == target_group);
     if (target.is_embedded())
         throw IllegalOperation("Set of embedded objects not supported");
-    // Outgoing links from an asymmetric table are not allowed.
-    if (is_asymmetric()) {
-        throw IllegalOperation("Set of objects not supported in asymmetric table");
-    }
     // Incoming links from an asymmetric table are not allowed.
     if (target.is_asymmetric()) {
         throw IllegalOperation("Set of ephemeral objects not supported");
@@ -533,10 +525,6 @@ ColKey Table::add_column_dictionary(Table& target, StringData name, DataType key
     Group* target_group = target.get_parent_group();
     REALM_ASSERT_RELEASE(origin_group && target_group);
     REALM_ASSERT_RELEASE(origin_group == target_group);
-    // Only links to embedded objects are allowed.
-    if (is_asymmetric() && !target.is_embedded()) {
-        throw IllegalOperation("Dictionary of objects not supported in asymmetric table");
-    }
     // Incoming links from an asymmetric table are not allowed.
     if (target.is_asymmetric()) {
         throw IllegalOperation("Dictionary of ephemeral objects not supported");

--- a/test/object-store/realm.cpp
+++ b/test/object-store/realm.cpp
@@ -3561,7 +3561,7 @@ TEST_CASE("SharedRealm: SchemaChangedFunction") {
     size_t schema_changed_called = 0;
     Schema changed_fixed_schema;
     TestFile config;
-    auto dynamic_config = config;
+    RealmConfig dynamic_config = config;
 
     config.schema = Schema{{"object1",
                             {

--- a/test/object-store/thread_safe_reference.cpp
+++ b/test/object-store/thread_safe_reference.cpp
@@ -332,7 +332,7 @@ TEST_CASE("thread safe reference") {
 
             SECTION("read-only `ThreadSafeReference` to `Results`") {
                 auto thread_safe_results = ThreadSafeReference(results);
-                JoiningThread([thread_safe_results = std::move(thread_safe_results), config, int_obj_col]() mutable {
+                JoiningThread([&thread_safe_results, &config, int_obj_col]() mutable {
                     SharedRealm realm_in_thread = Realm::get_shared_realm(config);
                     Results resolved_results = thread_safe_results.resolve<Results>(realm_in_thread);
                     REQUIRE(resolved_results.size() == 1);
@@ -343,7 +343,7 @@ TEST_CASE("thread safe reference") {
             SECTION("read-only `ThreadSafeReference` to an `Object`") {
                 Object object(read_only_realm, results.get(0));
                 auto thread_safe_object = ThreadSafeReference(object);
-                JoiningThread([thread_safe_object = std::move(thread_safe_object), config, int_obj_col]() mutable {
+                JoiningThread([&thread_safe_object, &config, int_obj_col]() mutable {
                     SharedRealm realm_in_thread = Realm::get_shared_realm(config);
                     auto resolved_object = thread_safe_object.resolve<Object>(realm_in_thread);
                     REQUIRE(resolved_object.is_valid());
@@ -569,7 +569,7 @@ TEST_CASE("thread safe reference") {
             REQUIRE(results.get<int64_t>(1) == 1);
             REQUIRE(results.get<int64_t>(2) == 2);
             auto ref = ThreadSafeReference(results);
-            JoiningThread([ref = std::move(ref), config]() mutable {
+            JoiningThread([&ref, &config]() mutable {
                 config.scheduler = util::Scheduler::make_frozen(VersionID());
                 SharedRealm r = Realm::get_shared_realm(config);
                 Results results = ref.resolve<Results>(r);
@@ -621,7 +621,7 @@ TEST_CASE("thread safe reference") {
             REQUIRE(results.get<int64_t>(2) == 3);
 
             auto ref = ThreadSafeReference(results);
-            JoiningThread([ref = std::move(ref), config]() mutable {
+            JoiningThread([&ref, &config]() mutable {
                 config.scheduler = util::Scheduler::make_frozen(VersionID());
                 SharedRealm r = Realm::get_shared_realm(config);
                 Results results = ref.resolve<Results>(r);

--- a/test/object-store/util/sync/flx_sync_harness.hpp
+++ b/test/object-store/util/sync/flx_sync_harness.hpp
@@ -115,17 +115,7 @@ public:
     {
         SyncTestFile config(m_test_session.app()->current_user(), schema(), SyncConfig::FLXSyncEnabled{});
         auto realm = Realm::get_shared_realm(config);
-        auto mut_subs = realm->get_latest_subscription_set().make_mutable_copy();
-        for (const auto& table : realm->schema()) {
-            if (table.table_type != ObjectSchema::ObjectType::TopLevel) {
-                continue;
-            }
-            Query query_for_table(realm->read_group().get_table(table.table_key));
-            mut_subs.insert_or_assign(query_for_table);
-        }
-        auto subs = std::move(mut_subs).commit();
-        subs.get_state_change_notification(sync::SubscriptionSet::State::Complete).get();
-        wait_for_download(*realm);
+        subscribe_to_all_and_bootstrap(*realm);
 
         realm->begin_transaction();
         func(realm);

--- a/test/object-store/util/sync/sync_test_utils.hpp
+++ b/test/object-store/util/sync/sync_test_utils.hpp
@@ -141,6 +141,8 @@ TestSyncManager::Config get_config(Transport&& transport)
     return config;
 }
 
+void subscribe_to_all_and_bootstrap(Realm& realm);
+
 #if REALM_ENABLE_AUTH_TESTS
 
 #ifdef REALM_MONGODB_ENDPOINT

--- a/test/object-store/util/test_file.hpp
+++ b/test/object-store/util/test_file.hpp
@@ -204,6 +204,9 @@ public:
         return m_transport.get();
     }
 
+    std::vector<realm::bson::BsonDocument> get_documents(realm::SyncUser& user, const std::string& object_type,
+                                                         size_t expected_count) const;
+
 private:
     std::shared_ptr<realm::app::App> m_app;
     std::unique_ptr<realm::AppSession> m_app_session;

--- a/test/object-store/util/test_file.hpp
+++ b/test/object-store/util/test_file.hpp
@@ -73,6 +73,9 @@ struct TestFile : realm::Realm::Config {
     TestFile();
     ~TestFile();
 
+    TestFile(const TestFile&) = delete;
+    TestFile& operator=(const TestFile&) = delete;
+
     // The file should outlive the object, ie. should not be deleted in destructor
     void persist()
     {


### PR DESCRIPTION
The schema validation checks forbidding this were removed in https://github.com/realm/realm-core/pull/6981, but Table
also had its own validation. Most of the changes here are just making the asymmetric sync tests verify that the expected documents are actually created on the server.