### PR TITLE
Simplify internal commit notification

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,11 +2,12 @@
 
 ### Enhancements
 * <New feature description> (PR [#????](https://github.com/realm/realm-core/pull/????))
-* None.
+* Empty commits no longer trigger an extra invocation of the sync progress handler reporting the exact same information as the previous invocation ([PR #7031](https://github.com/realm/realm-core/pull/7031)).
 
 ### Fixed
 * <How do the end-user experience this issue? what was the impact?> ([#????](https://github.com/realm/realm-core/issues/????), since v?.?.?)
 * Fixed a bug preventing SSL handshake from completing successfuly due to failed hostname verification when linking against BoringSSL. (PR [#7034](https://github.com/realm/realm-core/pull/7034))
+* Updating subscriptions did not trigger Realm autorefreshes, sometimes resulting in async refresh hanging until another write was performed by something else ([PR #7031](https://github.com/realm/realm-core/pull/7031)).
 
 ### Breaking changes
 * None.

--- a/src/realm/db.hpp
+++ b/src/realm/db.hpp
@@ -439,6 +439,14 @@ public:
     /// To be used only when already holding the lock.
     bool other_writers_waiting_for_lock() const;
 
+    struct CommitListener {
+        virtual ~CommitListener() = default;
+        virtual void on_commit(version_type new_version) = 0;
+    };
+
+    void add_commit_listener(CommitListener*);
+    void remove_commit_listener(CommitListener*);
+
 protected:
     explicit DB(const DBOptions& options);
 
@@ -504,6 +512,8 @@ private:
     std::function<void(int, int)> m_upgrade_callback;
     std::unique_ptr<AsyncCommitHelper> m_commit_helper;
     std::shared_ptr<util::Logger> m_logger;
+    std::mutex m_commit_listener_mutex;
+    std::vector<CommitListener*> m_commit_listeners;
     bool m_is_sync_agent = false;
     // Id for this DB to be used in logging. We will just use some bits from the pointer.
     // The path cannot be used as this would not allow us to distinguish between two DBs opening

--- a/src/realm/object-store/impl/realm_coordinator.cpp
+++ b/src/realm/object-store/impl/realm_coordinator.cpp
@@ -533,7 +533,8 @@ void RealmCoordinator::init_external_helpers()
     // happens on background threads, so to avoid needing locking on every access
     // we have to wire things up in a specific order.
 #if REALM_ENABLE_SYNC
-    // We may have reused an existing sync session that outlived its original RealmCoordinator
+    // We may have reused an existing sync session that outlived its original
+    // RealmCoordinator. If not, we need to create a new one now.
     if (m_config.sync_config && !m_sync_session)
         m_sync_session = m_config.sync_config->user->sync_manager()->get_session(m_db, m_config);
 #endif
@@ -548,18 +549,7 @@ void RealmCoordinator::init_external_helpers()
                                   ex.code().value());
         }
     }
-
-#if REALM_ENABLE_SYNC
-    if (m_sync_session) {
-        std::weak_ptr<RealmCoordinator> weak_self = shared_from_this();
-        SyncSession::Internal::set_sync_transact_callback(*m_sync_session, [weak_self](VersionID, VersionID) {
-            if (auto self = weak_self.lock()) {
-                if (self->m_notifier)
-                    self->m_notifier->notify_others();
-            }
-        });
-    }
-#endif
+    m_db->add_commit_listener(this);
 }
 
 void RealmCoordinator::close()
@@ -649,11 +639,17 @@ RealmCoordinator::~RealmCoordinator()
             }
         }
     }
-    // Waits for the worker thread to join
-    m_notifier = nullptr;
 
-    // Ensure the notifiers aren't holding on to Transactions after we destroy
-    // the History object the DB depends on
+    if (m_db) {
+        m_db->remove_commit_listener(this);
+    }
+
+    // Waits for the worker thread to join
+    m_notifier.reset();
+
+    // If there's any active NotificationTokens they'll keep the notifiers alive,
+    // so tell the notifiers to release their Transactions so that the DB can
+    // be closed immediately.
     // No locking needed here because the worker thread is gone
     for (auto& notifier : m_new_notifiers)
         notifier->release_data();
@@ -789,16 +785,6 @@ void RealmCoordinator::commit_write(Realm& realm, bool commit_to_disk)
         }
     }
 
-#if REALM_ENABLE_SYNC
-    // Realm could be closed in did_change. So send sync notification first before did_change.
-    if (m_sync_session) {
-        SyncSession::Internal::nonsync_transact_notify(*m_sync_session, new_version.version);
-    }
-#endif
-    if (m_notifier) {
-        m_notifier->notify_others();
-    }
-
     if (realm.m_binding_context) {
         realm.m_binding_context->did_change({}, {});
     }
@@ -865,6 +851,13 @@ void RealmCoordinator::clean_up_dead_notifiers()
         m_notifier_skip_version.reset();
     }
     swap_remove(m_new_notifiers);
+}
+
+void RealmCoordinator::on_commit(DB::version_type)
+{
+    if (m_notifier) {
+        m_notifier->notify_others();
+    }
 }
 
 void RealmCoordinator::on_change()

--- a/src/realm/object-store/impl/realm_coordinator.hpp
+++ b/src/realm/object-store/impl/realm_coordinator.hpp
@@ -41,7 +41,7 @@ class WeakRealmNotifier;
 
 // RealmCoordinator manages the weak cache of Realm instances and communication
 // between per-thread Realm instances for a given file
-class RealmCoordinator : public std::enable_shared_from_this<RealmCoordinator> {
+class RealmCoordinator : public std::enable_shared_from_this<RealmCoordinator>, DB::CommitListener {
 public:
     // Get the coordinator for the given path, creating it if neccesary
     static std::shared_ptr<RealmCoordinator> get_coordinator(StringData path);
@@ -265,6 +265,7 @@ private:
 
     void set_config(const Realm::Config&) REQUIRES(m_realm_mutex, !m_schema_cache_mutex);
     void init_external_helpers() REQUIRES(m_realm_mutex);
+    void on_commit(DB::version_type) override;
     std::shared_ptr<Realm> do_get_cached_realm(Realm::Config const& config,
                                                std::shared_ptr<util::Scheduler> scheduler = nullptr)
         REQUIRES(m_realm_mutex);

--- a/src/realm/object-store/sync/sync_session.hpp
+++ b/src/realm/object-store/sync/sync_session.hpp
@@ -272,11 +272,6 @@ public:
     class Internal {
         friend class _impl::RealmCoordinator;
 
-        static void set_sync_transact_callback(SyncSession& session, std::function<TransactionCallback>&& callback)
-        {
-            session.set_sync_transact_callback(std::move(callback));
-        }
-
         static void nonsync_transact_notify(SyncSession& session, VersionID::version_type version)
         {
             session.nonsync_transact_notify(version);
@@ -394,7 +389,6 @@ private:
     void handle_progress_update(uint64_t, uint64_t, uint64_t, uint64_t, uint64_t, uint64_t);
     void handle_new_flx_sync_query(int64_t version);
 
-    void set_sync_transact_callback(std::function<TransactionCallback>&&) REQUIRES(!m_state_mutex);
     void nonsync_transact_notify(VersionID::version_type) REQUIRES(!m_state_mutex);
 
     void create_sync_session() REQUIRES(m_state_mutex, !m_config_mutex);

--- a/src/realm/sync/client.cpp
+++ b/src/realm/sync/client.cpp
@@ -30,7 +30,6 @@ using namespace realm::util;
 
 // clang-format off
 using SessionImpl                     = ClientImpl::Session;
-using SyncTransactReporter            = ClientHistory::SyncTransactReporter;
 using SyncTransactCallback            = Session::SyncTransactCallback;
 using ProgressHandler                 = Session::ProgressHandler;
 using WaitOperCompletionHandler       = Session::WaitOperCompletionHandler;
@@ -82,7 +81,7 @@ using ProxyConfig                     = SyncConfig::ProxyConfig;
 // and initiation of deactivation happens no earlier than during
 // finalization. See also activate_session() and initiate_session_deactivation()
 // in ClientImpl::Connection.
-class SessionWrapper final : public util::AtomicRefCountBase, public SyncTransactReporter {
+class SessionWrapper final : public util::AtomicRefCountBase, DB::CommitListener {
 public:
     SessionWrapper(ClientImpl&, DBRef db, std::shared_ptr<SubscriptionStore>, std::shared_ptr<MigrationStore>,
                    Session::Config);
@@ -97,7 +96,6 @@ public:
 
     MigrationStore* get_migration_store();
 
-    void set_sync_transact_handler(util::UniqueFunction<SyncTransactCallback>);
     void set_progress_handler(util::UniqueFunction<ProgressHandler>);
     void set_connection_state_change_listener(util::UniqueFunction<ConnectionStateChangeListener>);
 
@@ -105,7 +103,7 @@ public:
 
     void force_close();
 
-    void nonsync_transact_notify(version_type new_version);
+    void on_commit(version_type new_version) override;
     void cancel_reconnect_delay();
 
     void async_wait_for(bool upload_completion, bool download_completion, WaitOperCompletionHandler);
@@ -120,11 +118,6 @@ public:
     void actualize(ServerEndpoint);
     void finalize();
     void finalize_before_actualization() noexcept;
-
-    // Overriding member function in SyncTransactReporter
-    void report_sync_transact(VersionID, VersionID) override;
-
-    void on_new_flx_subscription_set(int64_t new_version);
 
     util::Future<std::string> send_test_command(std::string body);
 
@@ -163,7 +156,7 @@ private:
 
     util::Optional<ProxyConfig> m_proxy_config;
 
-    util::UniqueFunction<SyncTransactCallback> m_sync_transact_handler;
+    uint_fast64_t m_last_reported_uploadable_bytes = 0;
     util::UniqueFunction<ProgressHandler> m_progress_handler;
     util::UniqueFunction<ConnectionStateChangeListener> m_connection_state_change_listener;
 
@@ -175,7 +168,6 @@ private:
     std::shared_ptr<SubscriptionStore> m_flx_subscription_store;
     int64_t m_flx_active_version = 0;
     int64_t m_flx_last_seen_version = 0;
-    int64_t m_flx_latest_version = 0;
     int64_t m_flx_pending_mark_version = 0;
     std::unique_ptr<PendingBootstrapStore> m_flx_pending_bootstrap_store;
 
@@ -256,7 +248,7 @@ private:
     void on_flx_sync_error(int64_t version, std::string_view err_msg);
     void on_flx_sync_version_complete(int64_t version);
 
-    void report_progress();
+    void report_progress(bool only_if_new_uploadable_data = false);
 
     friend class SessionWrapperStack;
     friend class ClientImpl::Session;
@@ -694,13 +686,6 @@ DBRef SessionImpl::get_db() const noexcept
     return m_wrapper.m_db;
 }
 
-SyncTransactReporter* SessionImpl::get_transact_reporter() noexcept
-{
-    // Can only be called if the session is active or being activated
-    REALM_ASSERT_EX(m_state == State::Active || m_state == State::Unactivated, m_state);
-    return &m_wrapper;
-}
-
 ClientReplication& SessionImpl::access_realm()
 {
     // Can only be called if the session is active or being activated
@@ -911,12 +896,10 @@ void SessionImpl::process_pending_flx_bootstrap()
 
         history.integrate_server_changesets(
             *pending_batch.progress, &downloadable_bytes, pending_batch.changesets, new_version, batch_state, logger,
-            transact,
-            [&](const TransactionRef& tr, util::Span<Changeset> changesets_applied) {
+            transact, [&](const TransactionRef& tr, util::Span<Changeset> changesets_applied) {
                 REALM_ASSERT_3(changesets_applied.size(), <=, pending_batch.changesets.size());
                 bootstrap_store->pop_front_pending(tr, changesets_applied.size());
-            },
-            get_transact_reporter());
+            });
         progress = *pending_batch.progress;
         changesets_processed += pending_batch.changesets.size();
         auto duration = std::chrono::steady_clock::now() - start_time;
@@ -941,17 +924,6 @@ void SessionImpl::process_pending_flx_bootstrap()
                                   DownloadBatchState::LastInBatch, changesets_processed);
     // NoAction/EarlyReturn are both valid no-op actions to take here.
     REALM_ASSERT_EX(action == SyncClientHookAction::NoAction || action == SyncClientHookAction::EarlyReturn, action);
-}
-
-void SessionImpl::on_new_flx_subscription_set(int64_t new_version)
-{
-    // If m_state == State::Active then we know that we haven't sent an UNBIND message and all we need to
-    // check is that we have completed the IDENT message handshake and have not yet received an ERROR
-    // message to call ensure_enlisted_to_send().
-    if (m_state == State::Active && m_ident_message_sent && !m_error_message_received) {
-        logger.trace("Requesting QUERY change message for new subscription set version %1", new_version);
-        ensure_enlisted_to_send();
-    }
 }
 
 void SessionImpl::on_flx_sync_error(int64_t version, std::string_view err_msg)
@@ -1160,15 +1132,16 @@ SessionWrapper::SessionWrapper(ClientImpl& client, DBRef db, std::shared_ptr<Sub
     if (m_flx_subscription_store) {
         auto versions_info = m_flx_subscription_store->get_version_info();
         m_flx_active_version = versions_info.active;
-        m_flx_latest_version = versions_info.latest;
         m_flx_pending_mark_version = versions_info.pending_mark;
     }
 }
 
 SessionWrapper::~SessionWrapper() noexcept
 {
-    if (m_db && m_actualized)
+    if (m_db && m_actualized) {
+        m_db->remove_commit_listener(this);
         m_db->release_sync_agent();
+    }
 }
 
 
@@ -1189,36 +1162,9 @@ bool SessionWrapper::has_flx_subscription_store() const
     return static_cast<bool>(m_flx_subscription_store);
 }
 
-void SessionWrapper::on_new_flx_subscription_set(int64_t new_version)
-{
-    if (!m_initiated) {
-        return;
-    }
-    REALM_ASSERT(!m_finalized);
-
-    auto self = util::bind_ptr<SessionWrapper>(this);
-    m_client.post([new_version, self = std::move(self)](Status status) {
-        if (status == ErrorCodes::OperationAborted)
-            return;
-        else if (!status.is_ok())
-            throw Exception(status);
-        REALM_ASSERT(self->m_actualized);
-        if (REALM_UNLIKELY(!self->m_sess)) {
-            return; // Already finalized
-        }
-        auto& sess = *self->m_sess;
-        sess.recognize_sync_version(self->m_db->get_version_of_latest_snapshot());
-        self->m_flx_latest_version = new_version;
-        sess.on_new_flx_subscription_set(new_version);
-    });
-}
-
 void SessionWrapper::on_flx_sync_error(int64_t version, std::string_view err_msg)
 {
     REALM_ASSERT(!m_finalized);
-    REALM_ASSERT(m_flx_latest_version != 0);
-    REALM_ASSERT(m_flx_latest_version >= version);
-
     auto mut_subs = get_flx_subscription_store()->get_mutable_by_version(version);
     mut_subs.update_state(SubscriptionSet::State::Error, err_msg);
     mut_subs.commit();
@@ -1293,13 +1239,6 @@ MigrationStore* SessionWrapper::get_migration_store()
     return m_migration_store.get();
 }
 
-inline void SessionWrapper::set_sync_transact_handler(util::UniqueFunction<SyncTransactCallback> handler)
-{
-    REALM_ASSERT(!m_initiated);
-    m_sync_transact_handler = std::move(handler); // Throws
-}
-
-
 inline void SessionWrapper::set_progress_handler(util::UniqueFunction<ProgressHandler> handler)
 {
     REALM_ASSERT(!m_initiated);
@@ -1315,16 +1254,17 @@ SessionWrapper::set_connection_state_change_listener(util::UniqueFunction<Connec
 }
 
 
-inline void SessionWrapper::initiate()
+void SessionWrapper::initiate()
 {
     REALM_ASSERT(!m_initiated);
     ServerEndpoint server_endpoint{m_protocol_envelope, m_server_address, m_server_port, m_user_id, m_sync_mode};
     m_client.register_unactualized_session_wrapper(this, std::move(server_endpoint)); // Throws
     m_initiated = true;
+    m_db->add_commit_listener(this);
 }
 
 
-void SessionWrapper::nonsync_transact_notify(version_type new_version)
+void SessionWrapper::on_commit(version_type new_version)
 {
     // Thread safety required
     REALM_ASSERT(m_initiated);
@@ -1345,8 +1285,9 @@ void SessionWrapper::nonsync_transact_notify(version_type new_version)
             return; // Already finalized
         SessionImpl& sess = *self->m_sess;
         sess.recognize_sync_version(new_version); // Throws
-        self->report_progress();                  // Throws
-    });                                           // Throws
+        bool only_if_new_uploadable_data = true;
+        self->report_progress(only_if_new_uploadable_data); // Throws
+    });
 }
 
 
@@ -1634,6 +1575,9 @@ void SessionWrapper::finalize()
         return;
     }
 
+    // Must be before marking as finalized as we expect m_finalized == false in on_change()
+    m_db->remove_commit_listener(this);
+
     m_finalized = true;
 
     if (!m_force_closed) {
@@ -1684,14 +1628,6 @@ inline void SessionWrapper::finalize_before_actualization() noexcept
     REALM_ASSERT(!m_sess);
     m_actualized = true;
     m_force_closed = true;
-}
-
-
-inline void SessionWrapper::report_sync_transact(VersionID old_version, VersionID new_version)
-{
-    REALM_ASSERT(!m_finalized);
-    if (m_sync_transact_handler)
-        m_sync_transact_handler(old_version, new_version); // Throws
 }
 
 
@@ -1789,7 +1725,7 @@ void SessionWrapper::on_connection_state_changed(ConnectionState state,
 }
 
 
-void SessionWrapper::report_progress()
+void SessionWrapper::report_progress(bool only_if_new_uploadable_data)
 {
     REALM_ASSERT(!m_finalized);
     REALM_ASSERT(m_sess);
@@ -1804,6 +1740,13 @@ void SessionWrapper::report_progress()
     std::uint_fast64_t snapshot_version = 0;
     ClientHistory::get_upload_download_bytes(m_db.get(), downloaded_bytes, downloadable_bytes, uploaded_bytes,
                                              uploadable_bytes, snapshot_version);
+
+    // If this progress notification was triggered by a commit being made we
+    // only want to send it if the uploadable bytes has actually increased,
+    // and not if it was an empty commit.
+    if (only_if_new_uploadable_data && m_last_reported_uploadable_bytes == uploadable_bytes)
+        return;
+    m_last_reported_uploadable_bytes = uploadable_bytes;
 
     // uploadable_bytes is uploaded + remaining to upload, while downloadable_bytes
     // is only the remaining to download. This is confusing, so make them use
@@ -2074,12 +2017,6 @@ Session::Session(Client& client, DBRef db, std::shared_ptr<SubscriptionStore> fl
 }
 
 
-void Session::set_sync_transact_callback(util::UniqueFunction<SyncTransactCallback> handler)
-{
-    m_impl->set_sync_transact_handler(std::move(handler)); // Throws
-}
-
-
 void Session::set_progress_handler(util::UniqueFunction<ProgressHandler> handler)
 {
     m_impl->set_progress_handler(std::move(handler)); // Throws
@@ -2100,7 +2037,7 @@ void Session::bind()
 
 void Session::nonsync_transact_notify(version_type new_version)
 {
-    m_impl->nonsync_transact_notify(new_version); // Throws
+    m_impl->on_commit(new_version); // Throws
 }
 
 
@@ -2141,11 +2078,6 @@ void Session::abandon() noexcept
     // Session constructor
     util::bind_ptr<SessionWrapper> wrapper{m_impl, util::bind_ptr_base::adopt_tag{}};
     SessionWrapper::abandon(std::move(wrapper));
-}
-
-void Session::on_new_flx_sync_subscription(int64_t new_version)
-{
-    m_impl->on_new_flx_subscription_set(new_version);
 }
 
 util::Future<std::string> Session::send_test_command(std::string body)

--- a/src/realm/sync/client.hpp
+++ b/src/realm/sync/client.hpp
@@ -358,8 +358,6 @@ public:
     /// \brief Start a new session for the specified client-side Realm.
     ///
     /// Note that the session is not fully activated until you call bind().
-    /// Also note that if you call set_sync_transact_callback(), it must be
-    /// done before calling bind().
     Session(Client&, std::shared_ptr<DB>, std::shared_ptr<SubscriptionStore>, std::shared_ptr<MigrationStore>,
             Config&& = {});
 
@@ -398,32 +396,6 @@ public:
     /// involving the session object on the left or right-hand side. See move
     /// constructor and assignment operator.
     void detach() noexcept;
-
-    /// \brief Set a function to be called when the local Realm has changed due
-    /// to integration of a downloaded changeset.
-    ///
-    /// Specify the callback function that will be called when one or more
-    /// transactions are performed to integrate downloaded changesets into the
-    /// client-side Realm, that is associated with this session.
-    ///
-    /// The callback function will always be called by the thread that executes
-    /// the event loop (Client::run()), but not until bind() is called. If the
-    /// callback function throws an exception, that exception will "travel" out
-    /// through Client::run().
-    ///
-    /// Note: Any call to this function must have returned before bind() is
-    /// called. If this function is called multiple times, each call overrides
-    /// the previous setting.
-    ///
-    /// Note: This function is **not thread-safe**. That is, it is an error if
-    /// it is called while another thread is executing any member function on
-    /// the same Session object.
-    ///
-    /// CAUTION: The specified callback function may get called before the call
-    /// to bind() returns, and it may get called (or continue to execute) after
-    /// the session object is destroyed. Please see "Callback semantics" section
-    /// under Session for more on this.
-    void set_sync_transact_callback(util::UniqueFunction<SyncTransactCallback>);
 
     /// \brief Set a handler to monitor the state of download and upload
     /// progress.
@@ -548,12 +520,6 @@ public:
     /// No communication takes place on behalf of this session before the
     /// session is bound, but as soon as the session becomes bound, the server
     /// will start to push changes to the client, and vice versa.
-    ///
-    /// If a callback function was set using set_sync_transact_callback(), then
-    /// that callback function will start to be called as changesets are
-    /// downloaded and integrated locally. It is important to understand that
-    /// callback functions are executed by the event loop thread (Client::run())
-    /// and the callback function may therefore be called before bind() returns.
     ///
     /// Note: It is an error if this function is called more than once per
     /// Session object.
@@ -732,8 +698,6 @@ public:
     /// This function is fully thread-safe. That is, it may be called by any
     /// thread, and by multiple threads concurrently.
     void cancel_reconnect_delay();
-
-    void on_new_flx_sync_subscription(int64_t new_version);
 
     util::Future<std::string> send_test_command(std::string command_body);
 

--- a/src/realm/sync/noinst/client_history_impl.cpp
+++ b/src/realm/sync/noinst/client_history_impl.cpp
@@ -385,8 +385,7 @@ void ClientHistory::integrate_server_changesets(
     const SyncProgress& progress, const std::uint_fast64_t* downloadable_bytes,
     util::Span<const RemoteChangeset> incoming_changesets, VersionInfo& version_info, DownloadBatchState batch_state,
     util::Logger& logger, const TransactionRef& transact,
-    util::UniqueFunction<void(const TransactionRef&, util::Span<Changeset>)> run_in_write_tr,
-    SyncTransactReporter* transact_reporter)
+    util::UniqueFunction<void(const TransactionRef&, util::Span<Changeset>)> run_in_write_tr)
 {
     REALM_ASSERT(incoming_changesets.size() != 0);
     REALM_ASSERT(
@@ -491,10 +490,6 @@ void ClientHistory::integrate_server_changesets(
         }
         else {
             new_version = transact->commit_and_continue_as_read(); // Throws
-        }
-
-        if (transact_reporter) {
-            transact_reporter->report_sync_transact(old_version, new_version); // Throws
         }
 
         logger.debug("Integrated %1 changesets out of %2", changesets_transformed_count, num_changesets);

--- a/src/realm/sync/noinst/client_history_impl.hpp
+++ b/src/realm/sync/noinst/client_history_impl.hpp
@@ -92,15 +92,6 @@ public:
         std::unique_ptr<char[]> buffer;
     };
 
-    class SyncTransactReporter {
-    public:
-        virtual void report_sync_transact(VersionID old_version, VersionID new_version) = 0;
-
-    protected:
-        ~SyncTransactReporter() = default;
-    };
-
-
     /// set_client_reset_adjustments() is used by client reset to adjust the
     /// content of the history compartment. The shared group associated with
     /// this history object must be in a write transaction when this function
@@ -245,16 +236,11 @@ public:
     /// the server changesets after they were transformed.
     /// Note: In FLX, the transaction is left in reading state when bootstrap ends.
     /// In all other cases, the transaction is left in reading state when the function returns.
-    ///
-    /// \param transact_reporter An optional callback which will be called with the
-    /// version immediately processing the sync transaction and that of the sync
-    /// transaction.
     void integrate_server_changesets(
         const SyncProgress& progress, const std::uint_fast64_t* downloadable_bytes,
         util::Span<const RemoteChangeset> changesets, VersionInfo& new_version, DownloadBatchState download_type,
         util::Logger&, const TransactionRef& transact,
-        util::UniqueFunction<void(const TransactionRef&, util::Span<Changeset>)> run_in_write_tr = nullptr,
-        SyncTransactReporter* transact_reporter = nullptr);
+        util::UniqueFunction<void(const TransactionRef&, util::Span<Changeset>)> run_in_write_tr = nullptr);
 
     static void get_upload_download_bytes(DB*, std::uint_fast64_t&, std::uint_fast64_t&, std::uint_fast64_t&,
                                           std::uint_fast64_t&, std::uint_fast64_t&);

--- a/src/realm/sync/noinst/client_impl_base.cpp
+++ b/src/realm/sync/noinst/client_impl_base.cpp
@@ -1540,8 +1540,7 @@ void Session::integrate_changesets(ClientReplication& repl, const SyncProgress& 
         progress, &downloadable_bytes, received_changesets, version_info, download_batch_state, logger, transact,
         [&](const TransactionRef&, util::Span<Changeset> changesets) {
             gather_pending_compensating_writes(changesets, &pending_compensating_write_errors);
-        },
-        get_transact_reporter()); // Throws
+        }); // Throws
     if (received_changesets.size() == 1) {
         logger.debug("1 remote changeset integrated, producing client version %1",
                      version_info.sync_version.version); // Throws
@@ -2274,8 +2273,6 @@ Status Session::receive_ident_message(SaltedFileIdent client_file_ident)
                                               std::move(on_flx_subscription_complete))) {
             return false;
         }
-        realm::VersionID client_reset_old_version = client_reset_operation->get_client_reset_old_version();
-        realm::VersionID client_reset_new_version = client_reset_operation->get_client_reset_new_version();
 
         // The fresh Realm has been used to reset the state
         logger.debug("Client reset is completed, path=%1", get_realm_path()); // Throws
@@ -2300,8 +2297,6 @@ Status Session::receive_ident_message(SaltedFileIdent client_file_ident)
         // For both, we want to allow uploads again without needing external changes to download first.
         m_allow_upload = true;
         REALM_ASSERT_EX(m_last_version_selected_for_upload == 0, m_last_version_selected_for_upload);
-
-        get_transact_reporter()->report_sync_transact(client_reset_old_version, client_reset_new_version);
 
         if (has_pending_client_reset) {
             handle_pending_client_reset_acknowledgement();

--- a/src/realm/sync/noinst/client_impl_base.cpp
+++ b/src/realm/sync/noinst/client_impl_base.cpp
@@ -1679,7 +1679,6 @@ void Session::activate()
     }
     logger.debug("client_file_ident = %1, client_file_ident_salt = %2", m_client_file_ident.ident,
                  m_client_file_ident.salt); // Throws
-    m_upload_target_version = m_last_version_available;
     m_upload_progress = m_progress.upload;
     m_last_version_selected_for_upload = m_upload_progress.client_version;
     m_download_progress = m_progress.download;
@@ -1862,9 +1861,7 @@ void Session::send_message()
         return send_query_change_message(); // throws
     }
 
-    REALM_ASSERT_3(m_upload_progress.client_version, <=, m_upload_target_version);
-    REALM_ASSERT_3(m_upload_target_version, <=, m_last_version_available);
-    if (m_allow_upload && (m_upload_target_version > m_upload_progress.client_version)) {
+    if (m_allow_upload && (m_last_version_available > m_upload_progress.client_version)) {
         return send_upload_message(); // Throws
     }
 }
@@ -1997,20 +1994,17 @@ void Session::send_upload_message()
     REALM_ASSERT_EX(m_state == Active, m_state);
     REALM_ASSERT(m_ident_message_sent);
     REALM_ASSERT(!m_unbind_message_sent);
-    REALM_ASSERT_3(m_upload_target_version, >, m_upload_progress.client_version);
 
     if (REALM_UNLIKELY(get_client().is_dry_run()))
         return;
 
-    auto target_upload_version = m_upload_target_version;
-    if (m_is_flx_sync_session) {
-        if (!m_pending_flx_sub_set || m_pending_flx_sub_set->snapshot_version < m_upload_progress.client_version) {
-            m_pending_flx_sub_set = get_flx_subscription_store()->get_next_pending_version(
-                m_last_sent_flx_query_version, m_upload_progress.client_version);
-        }
-        if (m_pending_flx_sub_set && m_pending_flx_sub_set->snapshot_version < m_upload_target_version) {
-            target_upload_version = m_pending_flx_sub_set->snapshot_version;
-        }
+    version_type target_upload_version = get_db()->get_version_of_latest_snapshot();
+    if (m_pending_flx_sub_set) {
+        REALM_ASSERT(m_is_flx_sync_session);
+        target_upload_version = m_pending_flx_sub_set->snapshot_version;
+    }
+    if (target_upload_version > m_last_version_available) {
+        m_last_version_available = target_upload_version;
     }
 
     const ClientReplication& repl = access_realm(); // Throws
@@ -2025,7 +2019,7 @@ void Session::send_upload_message()
         check_for_upload_completion(); // Throws
         // If we need to limit upload up to some version other than the last client version available and there are no
         // changes to upload, then there is no need to send an empty message.
-        if (target_upload_version != m_upload_target_version) {
+        if (m_pending_flx_sub_set) {
             logger.debug("Empty UPLOAD was skipped (progress_client_version=%1, progress_server_version=%2)",
                          m_upload_progress.client_version, m_upload_progress.last_integrated_server_version);
             // Other messages may be waiting to be sent
@@ -2036,7 +2030,7 @@ void Session::send_upload_message()
         m_last_version_selected_for_upload = uploadable_changesets.back().progress.client_version;
     }
 
-    if (m_is_flx_sync_session && m_pending_flx_sub_set && target_upload_version != m_upload_target_version) {
+    if (m_pending_flx_sub_set && target_upload_version < m_last_version_available) {
         logger.trace("Limiting UPLOAD message up to version %1 to send QUERY version %2",
                      m_pending_flx_sub_set->snapshot_version, m_pending_flx_sub_set->query_version);
     }
@@ -2299,7 +2293,6 @@ Status Session::receive_ident_message(SaltedFileIdent client_file_ident)
                         m_progress.upload.last_integrated_server_version);
         logger.trace("last_version_available  = %1", m_last_version_available); // Throws
 
-        m_upload_target_version = m_last_version_available;
         m_upload_progress = m_progress.upload;
         m_download_progress = m_progress.download;
         // In recovery mode, there may be new changesets to upload and nothing left to download.

--- a/src/realm/sync/noinst/client_impl_base.hpp
+++ b/src/realm/sync/noinst/client_impl_base.hpp
@@ -1090,30 +1090,18 @@ private:
     SyncProgress m_progress;
 
     // In general, the local version produced by the last changeset in the local
-    // history. The uploading process will never advance beyond this point. The
-    // changeset that produced this version may, or may not contain changes of
-    // local origin.
+    // history. The changeset that produced this version may, or may not
+    // contain changes of local origin.
     //
     // It is set to the current version of the local Realm at session activation
     // time (although always zero for the initial empty Realm
-    // state). Thereafter, it is generally updated when the application calls
-    // recognize_sync_version() and when changesets are received from the server
-    // and integrated locally.
+    // state). Thereafter, it is updated when the application calls
+    // recognize_sync_version(), when changesets are received from the server
+    // and integrated locally, and when the uploading process discovers newer
+    // versions.
     //
     // INVARIANT: m_progress.upload.client_version <= m_last_version_available
     version_type m_last_version_available = 0;
-
-    // The target version for the upload process. When the upload cursor
-    // (`m_upload_progress`) reaches `m_upload_target_version`, uploading stops.
-    //
-    // In general, `m_upload_target_version` follows `m_last_version_available`
-    // as it is increased, but in some cases, `m_upload_target_version` will be
-    // kept fixed for a while in order to constrain the uploading process.
-    //
-    // Is set equal to `m_last_version_available` at session activation time.
-    //
-    // INVARIANT: m_upload_target_version <= m_last_version_available
-    version_type m_upload_target_version = 0;
 
     // In general, this is the position in the history reached while scanning
     // for changesets to be uploaded.
@@ -1121,10 +1109,9 @@ private:
     // Set to `m_progress.upload` at session activation time and whenever the
     // connection to the server is lost. When the connection is established, the
     // scanning for changesets to be uploaded then progresses from there towards
-    // `m_upload_target_version`.
+    // `m_last_version_available`.
     //
     // INVARIANT: m_progress.upload.client_version <= m_upload_progress.client_version
-    // INVARIANT: m_upload_progress.client_version <= m_upload_target_version
     UploadCursor m_upload_progress = {0, 0};
 
     // Set to `m_progress.upload.client_version` at session activation time and
@@ -1475,7 +1462,6 @@ inline bool ClientImpl::Session::do_recognize_sync_version(version_type version)
 {
     if (REALM_LIKELY(version > m_last_version_available)) {
         m_last_version_available = version;
-        m_upload_target_version = version;
         return true;
     }
     return false;

--- a/src/realm/sync/noinst/client_impl_base.hpp
+++ b/src/realm/sync/noinst/client_impl_base.hpp
@@ -836,9 +836,6 @@ public:
     /// of the normal sync process. This can happen during client reset.
     void on_flx_sync_version_complete(int64_t version);
 
-    /// \brief Callback for when a new subscription set has been created for FLX sync.
-    void on_new_flx_subscription_set(int64_t new_version);
-
     /// If this session is currently suspended, resume it immediately.
     ///
     /// It is an error to call this function before activation of the session,
@@ -885,8 +882,6 @@ public:
     util::Future<std::string> send_test_command(std::string body);
 
 private:
-    using SyncTransactReporter = ClientHistory::SyncTransactReporter;
-
     struct PendingTestCommand {
         request_ident_type id;
         std::string body;
@@ -906,7 +901,6 @@ private:
 
     const std::string& get_realm_path() const noexcept;
     DBRef get_db() const noexcept;
-    SyncTransactReporter* get_transact_reporter() noexcept;
 
     /// The implementation need only ensure that the returned reference stays valid
     /// until the next invocation of access_realm() on one of the session

--- a/src/realm/sync/subscriptions.cpp
+++ b/src/realm/sync/subscriptions.cpp
@@ -603,10 +603,6 @@ SubscriptionSet MutableSubscriptionSet::commit()
 
     process_notifications();
 
-    if (state() == State::Pending) {
-        mgr->m_on_new_subscription_set(flx_version);
-    }
-
     return mgr->get_by_version_impl(flx_version, m_tr->get_version_of_current_transaction());
 }
 
@@ -658,21 +654,20 @@ std::string SubscriptionSet::to_ext_json() const
 namespace {
 class SubscriptionStoreInit : public SubscriptionStore {
 public:
-    explicit SubscriptionStoreInit(DBRef db, util::UniqueFunction<void(int64_t)> on_new_subscription_set)
-        : SubscriptionStore(std::move(db), std::move(on_new_subscription_set))
+    explicit SubscriptionStoreInit(DBRef db)
+        : SubscriptionStore(std::move(db))
     {
     }
 };
 } // namespace
 
-SubscriptionStoreRef SubscriptionStore::create(DBRef db, util::UniqueFunction<void(int64_t)> on_new_subscription_set)
+SubscriptionStoreRef SubscriptionStore::create(DBRef db)
 {
-    return std::make_shared<SubscriptionStoreInit>(std::move(db), std::move(on_new_subscription_set));
+    return std::make_shared<SubscriptionStoreInit>(std::move(db));
 }
 
-SubscriptionStore::SubscriptionStore(DBRef db, util::UniqueFunction<void(int64_t)> on_new_subscription_set)
+SubscriptionStore::SubscriptionStore(DBRef db)
     : m_db(std::move(db))
-    , m_on_new_subscription_set(std::move(on_new_subscription_set))
 {
     std::vector<SyncMetadataTable> internal_tables{
         {&m_sub_set_table,

--- a/src/realm/sync/subscriptions.hpp
+++ b/src/realm/sync/subscriptions.hpp
@@ -301,7 +301,7 @@ using SubscriptionStoreRef = std::shared_ptr<SubscriptionStore>;
 // A SubscriptionStore manages the FLX metadata tables, SubscriptionSets and Subscriptions.
 class SubscriptionStore : public std::enable_shared_from_this<SubscriptionStore> {
 public:
-    static SubscriptionStoreRef create(DBRef db, util::UniqueFunction<void(int64_t)> on_new_subscription_set);
+    static SubscriptionStoreRef create(DBRef db);
 
     SubscriptionStore(const SubscriptionStore&) = delete;
     SubscriptionStore& operator=(const SubscriptionStore&) = delete;
@@ -363,7 +363,7 @@ private:
     DBRef m_db;
 
 protected:
-    explicit SubscriptionStore(DBRef db, util::UniqueFunction<void(int64_t)> on_new_subscription_set);
+    explicit SubscriptionStore(DBRef db);
 
     struct NotificationRequest {
         NotificationRequest(int64_t version, util::Promise<SubscriptionSet::State> promise,
@@ -406,8 +406,6 @@ protected:
     ColKey m_sub_set_state;
     ColKey m_sub_set_error_str;
     ColKey m_sub_set_subscriptions;
-
-    util::UniqueFunction<void(int64_t)> m_on_new_subscription_set;
 
     mutable std::mutex m_pending_notifications_mutex;
     mutable std::condition_variable m_pending_notifications_cv;

--- a/test/object-store/sync/flx_sync.cpp
+++ b/test/object-store/sync/flx_sync.cpp
@@ -2036,7 +2036,7 @@ TEST_CASE("flx: interrupted bootstrap restarts/recovers on reconnect", "[sync][f
         DBOptions options;
         options.encryption_key = test_util::crypt_key();
         auto realm = DB::create(sync::make_client_replication(), interrupted_realm_config.path, options);
-        auto sub_store = sync::SubscriptionStore::create(realm, [](int64_t) {});
+        auto sub_store = sync::SubscriptionStore::create(realm);
         auto version_info = sub_store->get_version_info();
         REQUIRE(version_info.active == 0);
         REQUIRE(version_info.latest == 1);
@@ -2511,7 +2511,7 @@ TEST_CASE("flx: bootstrap batching prevents orphan documents", "[sync][flx][boot
         REQUIRE(top_level);
         REQUIRE(top_level->is_empty());
 
-        auto sub_store = sync::SubscriptionStore::create(realm, [](int64_t) {});
+        auto sub_store = sync::SubscriptionStore::create(realm);
         auto version_info = sub_store->get_version_info();
         REQUIRE(version_info.latest == 1);
         REQUIRE(version_info.active == 0);
@@ -4362,7 +4362,7 @@ TEST_CASE("flx sync: resend pending subscriptions when reconnecting", "[sync][fl
         DBOptions options;
         options.encryption_key = test_util::crypt_key();
         auto realm = DB::create(sync::make_client_replication(), interrupted_realm_config.path, options);
-        auto sub_store = sync::SubscriptionStore::create(realm, [](int64_t) {});
+        auto sub_store = sync::SubscriptionStore::create(realm);
         auto version_info = sub_store->get_version_info();
         REQUIRE(version_info.latest > version_info.active);
     }

--- a/test/object-store/sync/flx_sync.cpp
+++ b/test/object-store/sync/flx_sync.cpp
@@ -1647,13 +1647,13 @@ TEST_CASE("flx: query on non-queryable field results in query error message", "[
 
     auto check_status = [](auto status) {
         CHECK(!status.is_ok());
+        std::string reason = status.get_status().reason();
         // Depending on the version of baas used, it may return 'Invalid query:' or
         // 'Client provided query with bad syntax:'
-        if ((status.get_status().reason().find("Invalid query:") == std::string::npos &&
-             status.get_status().reason().find("Client provided query with bad syntax:") == std::string::npos) ||
-            status.get_status().reason().find("\"TopLevel\": key \"non_queryable_field\" is not a queryable field") ==
-                std::string::npos) {
-            FAIL(status.get_status().reason());
+        if ((reason.find("Invalid query:") == std::string::npos &&
+             reason.find("Client provided query with bad syntax:") == std::string::npos) ||
+            reason.find("\"TopLevel\": key \"non_queryable_field\" is not a queryable field") == std::string::npos) {
+            FAIL(reason);
         }
     };
 

--- a/test/object-store/sync/migration_store_test.cpp
+++ b/test/object-store/sync/migration_store_test.cpp
@@ -195,7 +195,7 @@ TEST_CASE("Migration store", "[sync][flx migration]") {
     }
 
     SECTION("Migration store subscriptions") {
-        auto sub_store = sync::SubscriptionStore::create(mig_db, [](int64_t) {});
+        auto sub_store = sync::SubscriptionStore::create(mig_db);
         auto orig_version = sub_store->get_latest().version();
 
         // Create some dummy tables

--- a/test/peer.hpp
+++ b/test/peer.hpp
@@ -546,7 +546,7 @@ public:
         std::string suffix = out.str();
         std::string test_path = get_test_path(test_context.get_test_name(), suffix);
         return std::unique_ptr<Peer>(
-            new Peer(client_file_ident, test_path, changeset_dump_dir_gen, *(test_context.logger)));
+            new Peer(client_file_ident, test_path, changeset_dump_dir_gen, *test_context.logger));
     }
 
     // FIXME: Remove the dependency on the unit_test namespace.
@@ -562,7 +562,7 @@ public:
         std::string suffix = out.str();
         std::string test_path = get_test_path(test_context.get_test_name(), suffix);
         return std::unique_ptr<Peer>(
-            new Peer(client_file_ident, test_path, changeset_dump_dir_gen, *(test_context.logger)));
+            new Peer(client_file_ident, test_path, changeset_dump_dir_gen, *test_context.logger));
     }
 
     template <class F>
@@ -829,7 +829,7 @@ struct Associativity {
             ReadTransaction read_server{server->shared_group};
             for (auto& client : clients) {
                 ReadTransaction read_client{client->shared_group};
-                if (!CHECK(compare_groups(read_server, read_client, *(test_context.logger)))) {
+                if (!CHECK(compare_groups(read_server, read_client, *test_context.logger))) {
                     return false;
                 }
             }
@@ -874,7 +874,7 @@ struct Associativity {
             // Check that all permutations converge on the same state.
             ReadTransaction read_first{first.server->shared_group};
             ReadTransaction read_current{iter.server->shared_group};
-            if (!CHECK(compare_groups(read_first, read_current, *(test_context.logger)))) {
+            if (!CHECK(compare_groups(read_first, read_current, *test_context.logger))) {
                 return false;
             }
         }

--- a/test/test_array_sync.cpp
+++ b/test/test_array_sync.cpp
@@ -107,11 +107,11 @@ TEST(Array_Example)
     ReadTransaction read_server(server->shared_group);
     {
         ReadTransaction read_client_1(client_1->shared_group);
-        CHECK(compare_groups(read_server, read_client_1));
+        CHECK(compare_groups(read_server, read_client_1, *test_context.logger));
     }
     {
         ReadTransaction read_client_2(client_2->shared_group);
-        CHECK(compare_groups(read_server, read_client_2));
+        CHECK(compare_groups(read_server, read_client_2, *test_context.logger));
     }
 
     std::vector<int64_t> values1, values2;

--- a/test/test_client_reset.cpp
+++ b/test/test_client_reset.cpp
@@ -72,7 +72,7 @@ TEST(ClientReset_NoLocalChanges)
     SHARED_GROUP_TEST_PATH(path_1); // The writer.
     SHARED_GROUP_TEST_PATH(path_2); // The resetting client.
 
-    auto& logger = *(test_context.logger);
+    auto& logger = *test_context.logger;
 
     const std::string server_path = "/data";
 
@@ -270,7 +270,7 @@ TEST(ClientReset_InitialLocalChanges)
     {
         ReadTransaction rt_1(db_1);
         ReadTransaction rt_2(db_2);
-        CHECK(compare_groups(rt_1, rt_2));
+        CHECK(compare_groups(rt_1, rt_2, *test_context.logger));
 
         const Group& group = rt_2.get_group();
         ConstTableRef table = group.get_table("class_table");
@@ -304,8 +304,7 @@ TEST(ClientReset_InitialLocalChanges)
     {
         ReadTransaction rt_1(db_1);
         ReadTransaction rt_2(db_2);
-        util::StderrLogger logger;
-        CHECK(compare_groups(rt_1, rt_2, logger));
+        CHECK(compare_groups(rt_1, rt_2, *test_context.logger));
     }
 }
 
@@ -419,7 +418,7 @@ TEST(ClientReset_ThreeClients)
     SHARED_GROUP_TEST_PATH(path_2);
     SHARED_GROUP_TEST_PATH(path_3);
 
-    auto& logger = *(test_context.logger);
+    auto& logger = *test_context.logger;
 
     const std::string server_path = "/data";
 
@@ -687,9 +686,9 @@ TEST(ClientReset_ThreeClients)
         ReadTransaction rt_1(sg_1);
         ReadTransaction rt_2(sg_2);
         ReadTransaction rt_3(sg_3);
-        CHECK(compare_groups(rt_1, rt_2));
-        CHECK(compare_groups(rt_1, rt_3));
-        CHECK(compare_groups(rt_2, rt_3));
+        CHECK(compare_groups(rt_1, rt_2, *test_context.logger));
+        CHECK(compare_groups(rt_1, rt_3, *test_context.logger));
+        CHECK(compare_groups(rt_2, rt_3, *test_context.logger));
     }
 }
 

--- a/test/test_client_reset.cpp
+++ b/test/test_client_reset.cpp
@@ -90,7 +90,7 @@ TEST(ClientReset_NoLocalChanges)
         WriteTransaction wt{sg};
         TableRef table = wt.get_group().add_table_with_primary_key("class_table", type_Int, "int_pk");
         table->create_object_with_primary_key(int64_t(123));
-        session.nonsync_transact_notify(wt.commit());
+        wt.commit();
         session.wait_for_upload_complete_or_client_stopped();
     }
 
@@ -118,7 +118,7 @@ TEST(ClientReset_NoLocalChanges)
         WriteTransaction wt{sg};
         TableRef table = wt.get_table("class_table");
         table->create_object_with_primary_key(int64_t(456));
-        session.nonsync_transact_notify(wt.commit());
+        wt.commit();
         session.wait_for_upload_complete_or_client_stopped();
 
         Session session_2 = fixture.make_session(path_2, server_path);
@@ -182,16 +182,6 @@ TEST(ClientReset_NoLocalChanges)
             ConstTableRef table = group.get_table("class_table");
             CHECK_EQUAL(table->size(), 2);
 
-            bool sync_transact_callback_called = false;
-            auto sync_transact_callback = [&](VersionID old_version, VersionID new_version) {
-                logger.debug("sync_transact_callback, old_version.version = %1, "
-                             "old_version.index = %2, new_version.version = %3, "
-                             "new_version.index = %4",
-                             old_version.version, old_version.index, new_version.version, new_version.index);
-                CHECK_LESS(old_version.version, new_version.version);
-                sync_transact_callback_called = true;
-            };
-
             Session::Config session_config;
             {
                 Session::Config::ClientReset client_reset_config;
@@ -200,10 +190,8 @@ TEST(ClientReset_NoLocalChanges)
                 session_config.client_reset_config = std::move(client_reset_config);
             }
             Session session = fixture.make_session(sg, server_path, std::move(session_config));
-            session.set_sync_transact_callback(std::move(sync_transact_callback));
             session.bind();
             session.wait_for_download_complete_or_client_stopped();
-            CHECK(sync_transact_callback_called);
         }
     }
 
@@ -231,25 +219,24 @@ TEST(ClientReset_InitialLocalChanges)
     ClientServerFixture fixture(dir, test_context);
     fixture.start();
 
-    Session session_1 = fixture.make_session(path_1, server_path);
+    DBRef db_1 = DB::create(make_client_replication(), path_1);
+    DBRef db_2 = DB::create(make_client_replication(), path_2);
+
+    Session session_1 = fixture.make_session(db_1, server_path);
     session_1.bind();
 
     // First we make a changeset and upload it
     {
-        DBRef sg = DB::create(make_client_replication(), path_1);
-
-        WriteTransaction wt{sg};
+        WriteTransaction wt{db_1};
         TableRef table = wt.get_group().add_table_with_primary_key("class_table", type_Int, "int");
         table->create_object_with_primary_key(int64_t(123));
-        session_1.nonsync_transact_notify(wt.commit());
+        wt.commit();
     }
     session_1.wait_for_upload_complete_or_client_stopped();
 
     // The local changes.
     {
-        DBRef sg = DB::create(make_client_replication(), path_2);
-
-        WriteTransaction wt{sg};
+        WriteTransaction wt{db_2};
         TableRef table = wt.get_group().add_table_with_primary_key("class_table", type_Int, "int");
         table->create_object_with_primary_key(int64_t(456));
         wt.commit();
@@ -272,7 +259,7 @@ TEST(ClientReset_InitialLocalChanges)
         client_reset_config.fresh_copy = std::move(sg_fresh);
         session_config_2.client_reset_config = std::move(client_reset_config);
     }
-    Session session_2 = fixture.make_session(path_2, server_path, std::move(session_config_2));
+    Session session_2 = fixture.make_session(db_2, server_path, std::move(session_config_2));
     session_2.bind();
     session_2.wait_for_upload_complete_or_client_stopped();
     session_2.wait_for_download_complete_or_client_stopped();
@@ -281,11 +268,8 @@ TEST(ClientReset_InitialLocalChanges)
 
     // Check the content in path_2. There should be two rows now.
     {
-        DBRef sg_1 = DB::create(make_client_replication(), path_1);
-        DBRef sg_2 = DB::create(make_client_replication(), path_2);
-
-        ReadTransaction rt_1(sg_1);
-        ReadTransaction rt_2(sg_2);
+        ReadTransaction rt_1(db_1);
+        ReadTransaction rt_2(db_2);
         CHECK(compare_groups(rt_1, rt_2));
 
         const Group& group = rt_2.get_group();
@@ -300,21 +284,17 @@ TEST(ClientReset_InitialLocalChanges)
 
     // Make more changes in path_1.
     {
-        DBRef sg = DB::create(make_client_replication(), path_1);
-
-        WriteTransaction wt{sg};
+        WriteTransaction wt{db_1};
         TableRef table = wt.get_table("class_table");
         table->create_object_with_primary_key(int64_t(1000));
-        session_1.nonsync_transact_notify(wt.commit());
+        wt.commit();
     }
     // Make more changes in path_2.
     {
-        DBRef sg = DB::create(make_client_replication(), path_2);
-
-        WriteTransaction wt{sg};
+        WriteTransaction wt{db_2};
         TableRef table = wt.get_table("class_table");
         table->create_object_with_primary_key(int64_t(2000));
-        session_2.nonsync_transact_notify(wt.commit());
+        wt.commit();
     }
     session_1.wait_for_upload_complete_or_client_stopped();
     session_2.wait_for_upload_complete_or_client_stopped();
@@ -322,12 +302,10 @@ TEST(ClientReset_InitialLocalChanges)
     session_2.wait_for_download_complete_or_client_stopped();
 
     {
-        DBRef sg_1 = DB::create(make_client_replication(), path_1);
-        DBRef sg_2 = DB::create(make_client_replication(), path_2);
-
-        ReadTransaction rt_1(sg_1);
-        ReadTransaction rt_2(sg_2);
-        CHECK(compare_groups(rt_1, rt_2));
+        ReadTransaction rt_1(db_1);
+        ReadTransaction rt_2(db_2);
+        util::StderrLogger logger;
+        CHECK(compare_groups(rt_1, rt_2, logger));
     }
 }
 
@@ -356,7 +334,7 @@ TEST_TYPES(ClientReset_LocalChangesWhenOffline, std::true_type, std::false_type)
         WriteTransaction wt{sg};
         TableRef table = ((Transaction&)wt).add_table_with_primary_key("class_table", type_Int, "_id");
         table->create_object_with_primary_key(123);
-        session_1.nonsync_transact_notify(wt.commit());
+        wt.commit();
         session_1.wait_for_upload_complete_or_client_stopped();
         session_1.wait_for_download_complete_or_client_stopped();
     }

--- a/test/test_embedded_objects.cpp
+++ b/test/test_embedded_objects.cpp
@@ -36,8 +36,8 @@ TEST(EmbeddedObjects_Basic)
     ReadTransaction read_server(server->shared_group);
     ReadTransaction read_client_1(client_1->shared_group);
     ReadTransaction read_client_2(client_2->shared_group);
-    CHECK(compare_groups(read_server, read_client_1, *(test_context.logger)));
-    CHECK(compare_groups(read_server, read_client_2));
+    CHECK(compare_groups(read_server, read_client_1, *test_context.logger));
+    CHECK(compare_groups(read_server, read_client_2, *test_context.logger));
 }
 
 TEST(AsymmetricTable_EmbeddedObjects_Basic)
@@ -68,8 +68,8 @@ TEST(AsymmetricTable_EmbeddedObjects_Basic)
     ReadTransaction read_server(server->shared_group);
     ReadTransaction read_client_1(client_1->shared_group);
     ReadTransaction read_client_2(client_2->shared_group);
-    CHECK(compare_groups(read_server, read_client_1, *(test_context.logger)));
-    CHECK(compare_groups(read_server, read_client_2));
+    CHECK(compare_groups(read_server, read_client_1, *test_context.logger));
+    CHECK(compare_groups(read_server, read_client_2, *test_context.logger));
 }
 
 TEST(Table_EmbeddedObjectsCircular)
@@ -131,8 +131,8 @@ TEST(EmbeddedObjects_ArrayOfObjects)
     ReadTransaction read_server(server->shared_group);
     ReadTransaction read_client_1(client_1->shared_group);
     ReadTransaction read_client_2(client_2->shared_group);
-    CHECK(compare_groups(read_server, read_client_1, *(test_context.logger)));
-    CHECK(compare_groups(read_server, read_client_2));
+    CHECK(compare_groups(read_server, read_client_1, *test_context.logger));
+    CHECK(compare_groups(read_server, read_client_2, *test_context.logger));
 }
 
 TEST(AsymmetricTable_EmbeddedObjects_ArrayOfObjects)
@@ -166,8 +166,8 @@ TEST(AsymmetricTable_EmbeddedObjects_ArrayOfObjects)
     ReadTransaction read_server(server->shared_group);
     ReadTransaction read_client_1(client_1->shared_group);
     ReadTransaction read_client_2(client_2->shared_group);
-    CHECK(compare_groups(read_server, read_client_1, *(test_context.logger)));
-    CHECK(compare_groups(read_server, read_client_2));
+    CHECK(compare_groups(read_server, read_client_1, *test_context.logger));
+    CHECK(compare_groups(read_server, read_client_2, *test_context.logger));
 }
 
 TEST(EmbeddedObjects_DictionaryOfObjects)
@@ -200,8 +200,8 @@ TEST(EmbeddedObjects_DictionaryOfObjects)
     ReadTransaction read_server(server->shared_group);
     ReadTransaction read_client_1(client_1->shared_group);
     ReadTransaction read_client_2(client_2->shared_group);
-    CHECK(compare_groups(read_server, read_client_1, *(test_context.logger)));
-    CHECK(compare_groups(read_server, read_client_2));
+    CHECK(compare_groups(read_server, read_client_1, *test_context.logger));
+    CHECK(compare_groups(read_server, read_client_2, *test_context.logger));
 }
 
 TEST(AsymmetricTable_EmbeddedObjects_DictionaryOfObjects)
@@ -235,8 +235,8 @@ TEST(AsymmetricTable_EmbeddedObjects_DictionaryOfObjects)
     ReadTransaction read_server(server->shared_group);
     ReadTransaction read_client_1(client_1->shared_group);
     ReadTransaction read_client_2(client_2->shared_group);
-    CHECK(compare_groups(read_server, read_client_1, *(test_context.logger)));
-    CHECK(compare_groups(read_server, read_client_2));
+    CHECK(compare_groups(read_server, read_client_1, *test_context.logger));
+    CHECK(compare_groups(read_server, read_client_2, *test_context.logger));
 }
 
 TEST(EmbeddedObjects_NestedArray)
@@ -292,8 +292,8 @@ TEST(EmbeddedObjects_NestedArray)
 
     ReadTransaction read_client_1(client_1->shared_group);
     ReadTransaction read_client_2(client_2->shared_group);
-    CHECK(compare_groups(read_server, read_client_1, *(test_context.logger)));
-    CHECK(compare_groups(read_server, read_client_2));
+    CHECK(compare_groups(read_server, read_client_1, *test_context.logger));
+    CHECK(compare_groups(read_server, read_client_2, *test_context.logger));
 }
 
 TEST(EmbeddedObjects_ImplicitErase)
@@ -501,8 +501,8 @@ TEST(EmbeddedObjects_AdjustPathOnInsert)
     ReadTransaction read_server(server->shared_group);
     ReadTransaction read_client_1(client_1->shared_group);
     ReadTransaction read_client_2(client_2->shared_group);
-    CHECK(compare_groups(read_server, read_client_1, *(test_context.logger)));
-    CHECK(compare_groups(read_server, read_client_2));
+    CHECK(compare_groups(read_server, read_client_1, *test_context.logger));
+    CHECK(compare_groups(read_server, read_client_2, *test_context.logger));
 
     {
         auto top = read_server.get_table("class_Top");
@@ -575,8 +575,8 @@ TEST(EmbeddedObjects_AdjustPathOnErase)
     ReadTransaction read_server(server->shared_group);
     ReadTransaction read_client_1(client_1->shared_group);
     ReadTransaction read_client_2(client_2->shared_group);
-    CHECK(compare_groups(read_server, read_client_1, *(test_context.logger)));
-    CHECK(compare_groups(read_server, read_client_2));
+    CHECK(compare_groups(read_server, read_client_1, *test_context.logger));
+    CHECK(compare_groups(read_server, read_client_2, *test_context.logger));
 
     {
         auto top = read_server.get_table("class_Top");

--- a/test/test_sync.cpp
+++ b/test/test_sync.cpp
@@ -107,12 +107,11 @@ private:
     auto name = DB::create(make_client_replication(), name##_path);
 
 template <typename Function>
-void write_transaction_notifying_session(DBRef db, Session& session, Function&& function)
+void write_transaction(DBRef db, Function&& function)
 {
     WriteTransaction wt(db);
     function(wt);
-    auto new_version = wt.commit();
-    session.nonsync_transact_notify(new_version);
+    wt.commit();
 }
 
 ClientReplication& get_replication(DBRef db)
@@ -195,7 +194,7 @@ TEST(Sync_AsyncWaitForUploadCompletion)
     wait();
 
     // Nonempty
-    write_transaction_notifying_session(db, session, [](WriteTransaction& wt) {
+    write_transaction(db, [](WriteTransaction& wt) {
         wt.get_group().add_table_with_primary_key("class_foo", type_Int, "id");
     });
     wait();
@@ -204,7 +203,7 @@ TEST(Sync_AsyncWaitForUploadCompletion)
     wait();
 
     // More
-    write_transaction_notifying_session(db, session, [](WriteTransaction& wt) {
+    write_transaction(db, [](WriteTransaction& wt) {
         wt.get_group().add_table_with_primary_key("class_bar", type_Int, "id");
     });
     wait();
@@ -220,7 +219,7 @@ TEST(Sync_AsyncWaitForUploadCompletionNoPendingLocalChanges)
 
     Session session = fixture.make_bound_session(db, "/test");
 
-    write_transaction_notifying_session(db, session, [](WriteTransaction& wt) {
+    write_transaction(db, [](WriteTransaction& wt) {
         wt.get_group().add_table_with_primary_key("class_foo", type_Int, "id");
     });
 
@@ -262,7 +261,7 @@ TEST(Sync_AsyncWaitForDownloadCompletion)
 
     // Upload something via session 2
     Session session_2 = fixture.make_bound_session(db_2, "/test");
-    write_transaction_notifying_session(db_2, session_2, [](WriteTransaction& wt) {
+    write_transaction(db_2, [](WriteTransaction& wt) {
         wt.get_group().add_table_with_primary_key("class_foo", type_Int, "id");
     });
     session_2.wait_for_upload_complete_or_client_stopped();
@@ -282,7 +281,7 @@ TEST(Sync_AsyncWaitForDownloadCompletion)
     wait(session_2);
 
     // Upload something via session 1
-    write_transaction_notifying_session(db_1, session_1, [](WriteTransaction& wt) {
+    write_transaction(db_1, [](WriteTransaction& wt) {
         wt.get_group().add_table_with_primary_key("class_bar", type_Int, "id");
     });
     session_1.wait_for_upload_complete_or_client_stopped();
@@ -324,13 +323,13 @@ TEST(Sync_AsyncWaitForSyncCompletion)
 
     // Generate changes to be downloaded (uploading via session 2)
     Session session_2 = fixture.make_bound_session(db_2);
-    write_transaction_notifying_session(db_2, session_2, [](WriteTransaction& wt) {
+    write_transaction(db_2, [](WriteTransaction& wt) {
         wt.get_group().add_table_with_primary_key("class_foo", type_Int, "id");
     });
     session_2.wait_for_upload_complete_or_client_stopped();
 
     // Generate changes to be uploaded
-    write_transaction_notifying_session(db_1, session_1, [](WriteTransaction& wt) {
+    write_transaction(db_1, [](WriteTransaction& wt) {
         wt.get_group().add_table_with_primary_key("class_bar", type_Int, "id");
     });
 
@@ -387,7 +386,7 @@ TEST(Sync_WaitForUploadCompletion)
     session.wait_for_upload_complete_or_client_stopped();
 
     // Nonempty
-    write_transaction_notifying_session(db, session, [](WriteTransaction& wt) {
+    write_transaction(db, [](WriteTransaction& wt) {
         wt.get_group().add_table_with_primary_key("class_foo", type_Int, "id");
     });
     // Since the Realm is no longer empty, the following wait operation cannot
@@ -400,7 +399,7 @@ TEST(Sync_WaitForUploadCompletion)
     session.wait_for_upload_complete_or_client_stopped();
 
     // More changes
-    write_transaction_notifying_session(db, session, [](WriteTransaction& wt) {
+    write_transaction(db, [](WriteTransaction& wt) {
         wt.get_group().add_table_with_primary_key("class_bar", type_Int, "id");
     });
     session.wait_for_upload_complete_or_client_stopped();
@@ -417,15 +416,13 @@ TEST(Sync_WaitForUploadCompletionAfterEmptyTransaction)
     Session session = fixture.make_bound_session(db);
     for (int i = 0; i < 100; ++i) {
         WriteTransaction wt(db);
-        version_type new_version = wt.commit();
-        session.nonsync_transact_notify(new_version);
+        wt.commit();
         session.wait_for_upload_complete_or_client_stopped();
     }
     {
         WriteTransaction wt(db);
         wt.get_group().add_table_with_primary_key("class_foo", type_Int, "id");
-        version_type new_version = wt.commit();
-        session.nonsync_transact_notify(new_version);
+        wt.commit();
         session.wait_for_upload_complete_or_client_stopped();
     }
 }
@@ -448,7 +445,7 @@ TEST(Sync_WaitForDownloadCompletion)
 
     // Upload something via session 2
     Session session_2 = fixture.make_bound_session(db_2);
-    write_transaction_notifying_session(db_2, session_2, [](WriteTransaction& wt) {
+    write_transaction(db_2, [](WriteTransaction& wt) {
         wt.get_group().add_table_with_primary_key("class_foo", type_Int, "id");
     });
     session_2.wait_for_upload_complete_or_client_stopped();
@@ -468,7 +465,7 @@ TEST(Sync_WaitForDownloadCompletion)
     session_2.wait_for_download_complete_or_client_stopped();
 
     // Upload something via session 1
-    write_transaction_notifying_session(db_1, session_1, [](WriteTransaction& wt) {
+    write_transaction(db_1, [](WriteTransaction& wt) {
         wt.get_group().add_table_with_primary_key("class_bar", type_Int, "id");
     });
     session_1.wait_for_upload_complete_or_client_stopped();
@@ -582,7 +579,7 @@ TEST(Sync_TokenWithoutExpirationAllowed)
         Session session = fixture.make_session(db, "/test", std::move(sess_config));
         session.set_connection_state_change_listener(listener);
         session.bind();
-        write_transaction_notifying_session(db, session, [](WriteTransaction& wt) {
+        write_transaction(db, [](WriteTransaction& wt) {
             wt.get_group().add_table_with_primary_key("class_foo", type_Int, "id");
         });
         session.wait_for_upload_complete_or_client_stopped();
@@ -611,7 +608,7 @@ TEST(Sync_TokenWithNullExpirationAllowed)
         Session session = fixture.make_session(db, "/test", std::move(config));
         session.bind();
         {
-            write_transaction_notifying_session(db, session, [](WriteTransaction& wt) {
+            write_transaction(db, [](WriteTransaction& wt) {
                 wt.get_group().add_table_with_primary_key("class_foo", type_Int, "id");
             });
         }
@@ -632,7 +629,7 @@ TEST(Sync_Upload)
     Session session = fixture.make_bound_session(db);
 
     {
-        write_transaction_notifying_session(db, session, [](WriteTransaction& wt) {
+        write_transaction(db, [](WriteTransaction& wt) {
             TableRef table = wt.get_group().add_table_with_primary_key("class_foo", type_Int, "id");
             table->add_column(type_Int, "i");
         });
@@ -640,8 +637,7 @@ TEST(Sync_Upload)
             WriteTransaction wt(db);
             TableRef table = wt.get_table("class_foo");
             table->create_object_with_primary_key(i);
-            version_type new_version = wt.commit();
-            session.nonsync_transact_notify(new_version);
+            wt.commit();
         }
     }
     session.wait_for_upload_complete_or_client_stopped();
@@ -661,20 +657,13 @@ TEST(Sync_Replication)
         ClientServerFixture fixture(dir, test_context);
         fixture.start();
 
-        version_type sync_transact_callback_version = 0;
-        auto sync_transact_callback = [&](VersionID, VersionID new_version) {
-            // May be called once or multiple times depending on timing
-            sync_transact_callback_version = new_version.version;
-        };
-
         Session session_1 = fixture.make_bound_session(db_1);
 
         Session session_2 = fixture.make_session(db_2, "/test");
-        session_2.set_sync_transact_callback(std::move(sync_transact_callback));
         session_2.bind();
 
         // Create schema
-        write_transaction_notifying_session(db_1, session_1, [](WriteTransaction& wt) {
+        write_transaction(db_1, [](WriteTransaction& wt) {
             TableRef table = wt.get_group().add_table_with_primary_key("class_foo", type_Int, "id");
             table->add_column(type_Int, "i");
         });
@@ -685,17 +674,11 @@ TEST(Sync_Replication)
             table->create_object_with_primary_key(i);
             Obj obj = *(table->begin() + random.draw_int_mod(table->size()));
             obj.set<int64_t>("i", random.draw_int_max(0x7FFFFFFFFFFFFFFF));
-            version_type new_version = wt.commit();
-            session_1.nonsync_transact_notify(new_version);
+            wt.commit();
         }
 
         session_1.wait_for_upload_complete_or_client_stopped();
         session_2.wait_for_download_complete_or_client_stopped();
-
-        {
-            ReadTransaction rt(db_2);
-            CHECK_EQUAL(rt.get_version(), sync_transact_callback_version);
-        }
     }
 
     ReadTransaction rt_1(db_1);
@@ -728,24 +711,23 @@ TEST(Sync_Merge)
         session_2.bind();
 
         // Create schema on both clients.
-        auto create_schema = [](Session& sess, DBRef db) {
+        auto create_schema = [](DBRef db) {
             WriteTransaction wt(db);
             if (wt.has_table("class_foo"))
                 return;
             TableRef table = wt.get_group().add_table_with_primary_key("class_foo", type_Int, "id");
             table->add_column(type_Int, "i");
-            version_type new_version = wt.commit();
-            sess.nonsync_transact_notify(new_version);
+            wt.commit();
         };
-        create_schema(session_1, db_1);
-        create_schema(session_2, db_2);
+        create_schema(db_1);
+        create_schema(db_2);
 
-        write_transaction_notifying_session(db_1, session_1, [](WriteTransaction& wt) {
+        write_transaction(db_1, [](WriteTransaction& wt) {
             TableRef table = wt.get_table("class_foo");
             table->create_object_with_primary_key(1).set("i", 5);
             table->create_object_with_primary_key(2).set("i", 6);
         });
-        write_transaction_notifying_session(db_2, session_2, [](WriteTransaction& wt) {
+        write_transaction(db_2, [](WriteTransaction& wt) {
             TableRef table = wt.get_table("class_foo");
             table->create_object_with_primary_key(3).set("i", 7);
             table->create_object_with_primary_key(4).set("i", 8);
@@ -789,20 +771,23 @@ struct ExpectChangesetError {
     }
 };
 
-void test_schema_mismatch(unit_test::TestContext& test_context, util::FunctionRef<void(WriteTransaction&)>&& fn_1,
-                          util::FunctionRef<void(WriteTransaction&)>&& fn_2, const char* expected_error_1,
+void test_schema_mismatch(unit_test::TestContext& test_context, util::FunctionRef<void(WriteTransaction&)> fn_1,
+                          util::FunctionRef<void(WriteTransaction&)> fn_2, const char* expected_error_1,
                           const char* expected_error_2 = nullptr)
 {
-    auto perform_write_transaction = [](DBRef db, util::FunctionRef<void(WriteTransaction&)>&& function) {
+    auto perform_write_transaction = [](DBRef db, util::FunctionRef<void(WriteTransaction&)> function) {
         WriteTransaction wt(db);
         function(wt);
         return wt.commit();
     };
 
+    TEST_DIR(dir);
     TEST_CLIENT_DB(db_1);
     TEST_CLIENT_DB(db_2);
 
-    TEST_DIR(dir);
+    perform_write_transaction(db_1, fn_1);
+    perform_write_transaction(db_2, fn_2);
+
     MultiClientServerFixture fixture(2, 1, dir, test_context);
     fixture.allow_server_errors(0, 1);
     fixture.start();
@@ -818,15 +803,6 @@ void test_schema_mismatch(unit_test::TestContext& test_context, util::FunctionRe
 
     session_1.bind();
     session_2.bind();
-
-    // NOTE: There was a race condition with `write_transaction_notifying_session` where session_2
-    // was completing sync before the write transaction was completed, leading to a
-    // `realm::TableNameInUse` exception. Broke up this function and moved the call to
-    // `nonsync_transact_notify()` to after the write transactions.
-    auto version_1 = perform_write_transaction(db_1, std::move(fn_1));
-    auto version_2 = perform_write_transaction(db_2, std::move(fn_2));
-    session_1.nonsync_transact_notify(version_1);
-    session_2.nonsync_transact_notify(version_2);
 
     session_1.wait_for_upload_complete_or_client_stopped();
     session_2.wait_for_upload_complete_or_client_stopped();
@@ -953,13 +929,13 @@ TEST(Sync_LateBind)
         fixture.start();
 
         Session session_1 = fixture.make_bound_session(db_1);
-        write_transaction_notifying_session(db_1, session_1, [](WriteTransaction& wt) {
+        write_transaction(db_1, [](WriteTransaction& wt) {
             wt.get_group().add_table_with_primary_key("class_foo", type_Int, "id");
         });
         session_1.wait_for_upload_complete_or_client_stopped();
 
         Session session_2 = fixture.make_bound_session(db_2);
-        write_transaction_notifying_session(db_2, session_2, [](WriteTransaction& wt) {
+        write_transaction(db_2, [](WriteTransaction& wt) {
             wt.get_group().add_table_with_primary_key("class_bar", type_Int, "id");
         });
         session_2.wait_for_upload_complete_or_client_stopped();
@@ -995,7 +971,7 @@ TEST(Sync_EarlyUnbind)
     Session session_1 = fixture.make_bound_session(db_1, "/dummy");
     {
         Session session_2 = fixture.make_bound_session(db_2);
-        write_transaction_notifying_session(db_2, session_2, [](WriteTransaction& wt) {
+        write_transaction(db_2, [](WriteTransaction& wt) {
             wt.get_group().add_table_with_primary_key("class_foo", type_Int, "id");
         });
         session_2.wait_for_upload_complete_or_client_stopped();
@@ -1033,8 +1009,7 @@ TEST(Sync_FastRebind)
         TableRef table = wt.get_group().add_table_with_primary_key("class_foo", type_Int, "id");
         table->add_column(type_Int, "i");
         table->create_object_with_primary_key(1);
-        version_type new_version = wt.commit();
-        session_2.nonsync_transact_notify(new_version);
+        wt.commit();
         session_2.wait_for_upload_complete_or_client_stopped();
     }
     for (int i = 0; i < 100; ++i) {
@@ -1042,8 +1017,7 @@ TEST(Sync_FastRebind)
         WriteTransaction wt(db_2);
         TableRef table = wt.get_table("class_foo");
         table->begin()->set<int64_t>("i", i);
-        version_type new_version = wt.commit();
-        session_2.nonsync_transact_notify(new_version);
+        wt.commit();
         session_2.wait_for_upload_complete_or_client_stopped();
     }
 }
@@ -1377,9 +1351,9 @@ TEST(Sync_Randomized)
 {
     constexpr size_t num_clients = 7;
 
-    auto client_test_program = [](DBRef db, Session& session) {
+    auto client_test_program = [](DBRef db) {
         // Create the schema
-        write_transaction_notifying_session(db, session, [](WriteTransaction& wt) {
+        write_transaction(db, [](WriteTransaction& wt) {
             if (wt.has_table("class_foo"))
                 return;
             TableRef table = wt.get_group().add_table_with_primary_key("class_foo", type_Int, "id");
@@ -1399,8 +1373,7 @@ TEST(Sync_Randomized)
                 size_t row_ndx = random.draw_int_mod(table->size());
                 table->get_object(row_ndx).set("i", value);
             }
-            version_type new_version = wt.commit();
-            session.nonsync_transact_notify(new_version);
+            wt.commit();
         }
     };
 
@@ -1426,7 +1399,7 @@ TEST(Sync_Randomized)
 
     auto run_client_test_program = [&](size_t i) {
         try {
-            client_test_program(client_shared_groups[i], *sessions[i]);
+            client_test_program(client_shared_groups[i]);
         }
         catch (...) {
             fixture.stop();
@@ -1526,12 +1499,12 @@ TEST(Sync_FailingReadsOnClientSide)
 
         Session session_2 = fixture.make_bound_session(db_2);
 
-        write_transaction_notifying_session(db_1, session_1, [](WriteTransaction& wt) {
+        write_transaction(db_1, [](WriteTransaction& wt) {
             TableRef table = wt.get_group().add_table_with_primary_key("class_foo", type_Int, "id");
             table->add_column(type_Int, "i");
             table->create_object_with_primary_key(1);
         });
-        write_transaction_notifying_session(db_2, session_2, [](WriteTransaction& wt) {
+        write_transaction(db_2, [](WriteTransaction& wt) {
             TableRef table = wt.get_group().add_table_with_primary_key("class_bar", type_Int, "id");
             table->add_column(type_Int, "i");
             table->create_object_with_primary_key(2);
@@ -1540,11 +1513,11 @@ TEST(Sync_FailingReadsOnClientSide)
             session_1.wait_for_upload_complete_or_client_stopped();
             session_2.wait_for_upload_complete_or_client_stopped();
             for (int i = 0; i < 10; ++i) {
-                write_transaction_notifying_session(db_1, session_1, [=](WriteTransaction& wt) {
+                write_transaction(db_1, [=](WriteTransaction& wt) {
                     TableRef table = wt.get_table("class_foo");
                     table->begin()->set("i", i);
                 });
-                write_transaction_notifying_session(db_2, session_2, [=](WriteTransaction& wt) {
+                write_transaction(db_2, [=](WriteTransaction& wt) {
                     TableRef table = wt.get_table("class_bar");
                     table->begin()->set("i", i);
                 });
@@ -1586,12 +1559,12 @@ TEST(Sync_FailingReadsOnServerSide)
 
         Session session_2 = fixture.make_bound_session(db_2);
 
-        write_transaction_notifying_session(db_1, session_1, [](WriteTransaction& wt) {
+        write_transaction(db_1, [](WriteTransaction& wt) {
             TableRef table = wt.get_group().add_table_with_primary_key("class_foo", type_Int, "id");
             table->add_column(type_Int, "i");
             table->create_object_with_primary_key(1);
         });
-        write_transaction_notifying_session(db_2, session_2, [](WriteTransaction& wt) {
+        write_transaction(db_2, [](WriteTransaction& wt) {
             TableRef table = wt.get_group().add_table_with_primary_key("class_bar", type_Int, "id");
             table->add_column(type_Int, "i");
             table->create_object_with_primary_key(2);
@@ -1600,11 +1573,11 @@ TEST(Sync_FailingReadsOnServerSide)
             session_1.wait_for_upload_complete_or_client_stopped();
             session_2.wait_for_upload_complete_or_client_stopped();
             for (int i = 0; i < 10; ++i) {
-                write_transaction_notifying_session(db_1, session_1, [=](WriteTransaction& wt) {
+                write_transaction(db_1, [=](WriteTransaction& wt) {
                     TableRef table = wt.get_table("class_foo");
                     table->begin()->set("i", i);
                 });
-                write_transaction_notifying_session(db_2, session_2, [=](WriteTransaction& wt) {
+                write_transaction(db_2, [=](WriteTransaction& wt) {
                     TableRef table = wt.get_table("class_bar");
                     table->begin()->set("i", i);
                 });
@@ -1641,8 +1614,7 @@ TEST(Sync_ErrorAfterServerRestore_BadClientFileIdent)
         Session session = fixture.make_bound_session(db, server_path);
         WriteTransaction wt{db};
         wt.get_group().add_table_with_primary_key("class_table", type_Int, "id");
-        auto new_version = wt.commit();
-        session.nonsync_transact_notify(new_version);
+        wt.commit();
         fixture.start();
         session.wait_for_upload_complete_or_client_stopped();
     }
@@ -1835,8 +1807,7 @@ TEST(Sync_ErrorAfterServerRestore_BadServerVersion)
         WriteTransaction wt{db};
         TableRef table = wt.get_group().add_table_with_primary_key("class_table", type_Int, "id");
         table->add_column(type_Int, "column");
-        auto new_version = wt.commit();
-        session.nonsync_transact_notify(new_version);
+        wt.commit();
         fixture.start();
         session.wait_for_upload_complete_or_client_stopped();
     }
@@ -1851,8 +1822,7 @@ TEST(Sync_ErrorAfterServerRestore_BadServerVersion)
         WriteTransaction wt{db};
         TableRef table = wt.get_table("class_table");
         table->create_object_with_primary_key(1);
-        auto new_version = wt.commit();
-        session.nonsync_transact_notify(new_version);
+        wt.commit();
         fixture.start();
         session.wait_for_upload_complete_or_client_stopped();
     }
@@ -1899,8 +1869,7 @@ TEST(Sync_ErrorAfterServerRestore_BadClientVersion)
         WriteTransaction wt{db_1};
         TableRef table = wt.get_group().add_table_with_primary_key("class_table", type_Int, "id");
         table->add_column(type_Int, "column");
-        auto new_version = wt.commit();
-        session_1.nonsync_transact_notify(new_version);
+        wt.commit();
         fixture.start();
         session_1.wait_for_upload_complete_or_client_stopped();
         session_2.wait_for_download_complete_or_client_stopped();
@@ -1916,8 +1885,7 @@ TEST(Sync_ErrorAfterServerRestore_BadClientVersion)
         WriteTransaction wt{db_1};
         TableRef table = wt.get_table("class_table");
         table->create_object_with_primary_key(1);
-        auto new_version = wt.commit();
-        session.nonsync_transact_notify(new_version);
+        wt.commit();
         fixture.start();
         session.wait_for_upload_complete_or_client_stopped();
     }
@@ -1932,8 +1900,7 @@ TEST(Sync_ErrorAfterServerRestore_BadClientVersion)
         WriteTransaction wt{db_2};
         TableRef table = wt.get_table("class_table");
         table->create_object_with_primary_key(2);
-        auto new_version = wt.commit();
-        session.nonsync_transact_notify(new_version);
+        wt.commit();
         fixture.start();
         session.wait_for_upload_complete_or_client_stopped();
     }
@@ -1977,8 +1944,7 @@ TEST(Sync_ErrorAfterServerRestore_BadClientFileIdentSalt)
         WriteTransaction wt{db_1};
         TableRef table = wt.get_group().add_table_with_primary_key("class_table_1", type_Int, "id");
         table->add_column(type_Int, "column");
-        auto new_version = wt.commit();
-        session.nonsync_transact_notify(new_version);
+        wt.commit();
         fixture.start();
         session.wait_for_upload_complete_or_client_stopped();
     }
@@ -2046,8 +2012,7 @@ TEST(Sync_ErrorAfterServerRestore_BadServerVersionSalt)
         WriteTransaction wt{db_1};
         TableRef table = wt.get_group().add_table_with_primary_key("class_table", type_Int, "id");
         table->add_column(type_Int, "column");
-        auto new_version = wt.commit();
-        session_1.nonsync_transact_notify(new_version);
+        wt.commit();
         fixture.start();
         session_1.wait_for_upload_complete_or_client_stopped();
         session_2.wait_for_download_complete_or_client_stopped();
@@ -2066,8 +2031,7 @@ TEST(Sync_ErrorAfterServerRestore_BadServerVersionSalt)
         WriteTransaction wt{db_1};
         TableRef table = wt.get_table("class_table");
         table->create_object_with_primary_key(1);
-        auto new_version = wt.commit();
-        session_1.nonsync_transact_notify(new_version);
+        wt.commit();
         fixture.start();
         session_1.wait_for_upload_complete_or_client_stopped();
         session_2.wait_for_download_complete_or_client_stopped();
@@ -2083,8 +2047,7 @@ TEST(Sync_ErrorAfterServerRestore_BadServerVersionSalt)
         WriteTransaction wt{db_3};
         TableRef table = wt.get_table("class_table");
         table->create_object_with_primary_key(2);
-        auto new_version = wt.commit();
-        session.nonsync_transact_notify(new_version);
+        wt.commit();
         fixture.start();
         session.wait_for_upload_complete_or_client_stopped();
     }
@@ -2160,8 +2123,7 @@ TEST(Sync_MultipleServers)
                     obj.set("file_index", file_index);
                     obj.set("session_index", i);
                     obj.set("transact_index", j);
-                    version_type new_version = wt.commit();
-                    session.nonsync_transact_notify(new_version);
+                    wt.commit();
                 }
                 session.wait_for_upload_complete_or_client_stopped();
             }
@@ -2293,7 +2255,7 @@ TEST_IF(Sync_ReadOnlyClient, false)
         table->add_column(type_Int, "i");
         table->create_object_with_primary_key(1);
         table->begin()->set("i", 123);
-        session_1.nonsync_transact_notify(wt.commit());
+        wt.commit();
         session_1.wait_for_upload_complete_or_client_stopped();
     }
 
@@ -2311,7 +2273,7 @@ TEST_IF(Sync_ReadOnlyClient, false)
             WriteTransaction wt(db_2);
             auto table = wt.get_table("class_foo");
             table->begin()->set("i", 456);
-            session_2.nonsync_transact_notify(wt.commit());
+            wt.commit();
         }
         session_2.wait_for_upload_complete_or_client_stopped();
         CHECK(did_get_permission_denied);
@@ -2375,9 +2337,8 @@ TEST(Sync_SingleClientUploadForever_CreateObjects)
         obj.set(col_str, str_data);
         obj.set(col_dbl, double(number));
         obj.set(col_time, Timestamp{123, 456});
-        version_type version = wt.commit();
+        wt.commit();
         auto before_upload = std::chrono::steady_clock::now();
-        session.nonsync_transact_notify(version);
         session.wait_for_upload_complete_or_client_stopped();
         auto after_upload = std::chrono::steady_clock::now();
 
@@ -2440,9 +2401,8 @@ TEST(Sync_SingleClientUploadForever_MutateObject)
         obj.set(col_str, str_data);
         obj.set(col_dbl, double(number));
         obj.set(col_time, Timestamp{123, 456});
-        version_type version = wt.commit();
+        wt.commit();
         auto before_upload = std::chrono::steady_clock::now();
-        session.nonsync_transact_notify(version);
         session.wait_for_upload_complete_or_client_stopped();
         auto after_upload = std::chrono::steady_clock::now();
 
@@ -2612,8 +2572,7 @@ TEST_IF(Sync_4GB_Messages, false)
                     obj.set(col_key, bd_c);
             }
         }
-        version_type new_version = wt.commit();
-        session_1.nonsync_transact_notify(new_version);
+        wt.commit();
     }
     session_1.wait_for_upload_complete_or_client_stopped();
     session_2.wait_for_download_complete_or_client_stopped();
@@ -2683,7 +2642,6 @@ TEST(Sync_Permissions)
     // Insert some dummy data
     WriteTransaction wt_valid{db_valid};
     wt_valid.get_group().add_table_with_primary_key("class_a", type_Int, "id");
-    session_valid.nonsync_transact_notify(wt_valid.commit());
     session_valid.wait_for_upload_complete_or_client_stopped();
 
     CHECK_NOT(did_see_error_for_valid);
@@ -3084,7 +3042,6 @@ TEST(Sync_UploadDownloadProgress_1)
             TableRef tr = wt.get_group().add_table_with_primary_key("class_table", type_Int, "id");
             tr->add_column(type_Int, "integer column");
             commit_version = wt.commit();
-            session.nonsync_transact_notify(commit_version);
         }
 
         session.wait_for_upload_complete_or_client_stopped();
@@ -3102,7 +3059,6 @@ TEST(Sync_UploadDownloadProgress_1)
             TableRef tr = wt.get_table("class_table");
             tr->create_object_with_primary_key(1).set("integer column", 42);
             commit_version = wt.commit();
-            session.nonsync_transact_notify(commit_version);
         }
 
         session.wait_for_upload_complete_or_client_stopped();
@@ -3255,7 +3211,7 @@ TEST(Sync_UploadDownloadProgress_2)
     CHECK_GREATER(progress_version_2, 0);
     CHECK_GREATER(snapshot_version_2, 0);
 
-    write_transaction_notifying_session(db_1, session_1, [](WriteTransaction& wt) {
+    write_transaction(db_1, [](WriteTransaction& wt) {
         TableRef tr = wt.get_group().add_table_with_primary_key("class_table", type_Int, "id");
         tr->add_column(type_Int, "integer column");
     });
@@ -3280,17 +3236,17 @@ TEST(Sync_UploadDownloadProgress_2)
     CHECK_GREATER(snapshot_version_1, 1);
     CHECK_GREATER(snapshot_version_2, 1);
 
-    write_transaction_notifying_session(db_1, session_1, [](WriteTransaction& wt) {
+    write_transaction(db_1, [](WriteTransaction& wt) {
         TableRef tr = wt.get_table("class_table");
         tr->create_object_with_primary_key(1).set("integer column", 42);
     });
 
-    write_transaction_notifying_session(db_1, session_1, [](WriteTransaction& wt) {
+    write_transaction(db_1, [](WriteTransaction& wt) {
         TableRef tr = wt.get_table("class_table");
         tr->create_object_with_primary_key(2).set("integer column", 44);
     });
 
-    write_transaction_notifying_session(db_2, session_2, [](WriteTransaction& wt) {
+    write_transaction(db_2, [](WriteTransaction& wt) {
         TableRef tr = wt.get_table("class_table");
         tr->create_object_with_primary_key(3).set("integer column", 43);
     });
@@ -3315,12 +3271,12 @@ TEST(Sync_UploadDownloadProgress_2)
     CHECK_GREATER(snapshot_version_1, 4);
     CHECK_GREATER(snapshot_version_2, 3);
 
-    write_transaction_notifying_session(db_1, session_1, [](WriteTransaction& wt) {
+    write_transaction(db_1, [](WriteTransaction& wt) {
         TableRef tr = wt.get_table("class_table");
         tr->begin()->set("integer column", 101);
     });
 
-    write_transaction_notifying_session(db_2, session_2, [](WriteTransaction& wt) {
+    write_transaction(db_2, [](WriteTransaction& wt) {
         TableRef tr = wt.get_table("class_table");
         tr->begin()->set("integer column", 102);
     });
@@ -3489,7 +3445,6 @@ TEST(Sync_UploadDownloadProgress_3)
         TableRef tr = wt.get_table("class_table");
         tr->create_object_with_primary_key(123).set("integer column", 42);
         commited_version = wt.commit();
-        session.nonsync_transact_notify(commited_version);
     }
 
     signal_pf.future.get();
@@ -3554,14 +3509,37 @@ TEST(Sync_UploadDownloadProgress_4)
         CHECK_EQUAL(downloadable_bytes, 0);
         CHECK_NOT_EQUAL(uploadable_bytes, 0);
 
-        if (entry_1 == 0) {
-            CHECK_EQUAL(progress_version, 0);
-            CHECK_EQUAL(uploaded_bytes, 0);
-            CHECK_EQUAL(snapshot_version, 3);
-        }
-        else {
-            CHECK_GREATER(progress_version, 0);
-            CHECK_GREATER(snapshot_version, 3);
+        switch (entry_1) {
+            case 0:
+                // Session is bound and initial state is reported
+                CHECK_EQUAL(progress_version, 0);
+                CHECK_EQUAL(uploaded_bytes, 0);
+                CHECK_EQUAL(snapshot_version, 3);
+                break;
+
+            case 1:
+                // We've received the empty DOWNLOAD message and now have reliable
+                // download progress
+                CHECK_EQUAL(progress_version, 1);
+                CHECK_EQUAL(uploaded_bytes, 0);
+                CHECK_EQUAL(snapshot_version, 5);
+                break;
+
+            case 2:
+                // First UPLOAD is complete, but we still have more to upload
+                // because the changesets are too large to batch into a single upload
+                CHECK_EQUAL(progress_version, 1);
+                CHECK_GREATER(uploaded_bytes, 0);
+                CHECK_LESS(uploaded_bytes, uploadable_bytes);
+                CHECK_EQUAL(snapshot_version, 6);
+                break;
+
+            case 3:
+                // Second UPLOAD is complete and we're done uploading
+                CHECK_EQUAL(progress_version, 1);
+                CHECK_EQUAL(uploaded_bytes, uploadable_bytes);
+                CHECK_EQUAL(snapshot_version, 7);
+                break;
         }
 
         ++entry_1;
@@ -3574,7 +3552,7 @@ TEST(Sync_UploadDownloadProgress_4)
     session_1.wait_for_upload_complete_or_client_stopped();
     session_1.wait_for_download_complete_or_client_stopped();
 
-    CHECK_NOT_EQUAL(entry_1, 0);
+    CHECK_EQUAL(entry_1, 4);
 
     Session session_2 = fixture.make_session(db_2, "/test");
 
@@ -3586,25 +3564,34 @@ TEST(Sync_UploadDownloadProgress_4)
         CHECK_EQUAL(uploaded_bytes, 0);
         CHECK_EQUAL(uploadable_bytes, 0);
 
-        if (entry_2 == 0) {
-            CHECK_EQUAL(progress_version, 0);
-            CHECK_EQUAL(downloaded_bytes, 0);
-            CHECK_EQUAL(downloadable_bytes, 0);
-            CHECK_EQUAL(snapshot_version, 1);
-        }
-        else if (entry_2 == 1) {
-            CHECK_GREATER(progress_version, 0);
-            CHECK_NOT_EQUAL(downloaded_bytes, 0);
-            CHECK_NOT_EQUAL(downloadable_bytes, 0);
-            CHECK_EQUAL(snapshot_version, 3);
-        }
-        else if (entry_2 == 2) {
-            CHECK_GREATER(progress_version, 0);
-            CHECK_NOT_EQUAL(downloaded_bytes, 0);
-            CHECK_NOT_EQUAL(downloadable_bytes, 0);
-            CHECK_EQUAL(snapshot_version, 4);
-        }
+        switch (entry_2) {
+            case 0:
+                // Session is bound and initial state is reported
+                CHECK_EQUAL(progress_version, 0);
+                CHECK_EQUAL(downloaded_bytes, 0);
+                CHECK_EQUAL(downloadable_bytes, 0);
+                CHECK_EQUAL(snapshot_version, 1);
+                break;
 
+            case 1:
+                // First DOWNLOAD message received. Some data is downloaded, but
+                // download isn't compelte
+                CHECK_EQUAL(progress_version, 1);
+                CHECK_GREATER(downloaded_bytes, 0);
+                CHECK_GREATER(downloadable_bytes, 0);
+                CHECK_LESS(downloaded_bytes, downloadable_bytes);
+                CHECK_EQUAL(snapshot_version, 3);
+                break;
+
+            case 2:
+                // Second DOWNLOAD message received. Download is now complete.
+                CHECK_EQUAL(progress_version, 1);
+                CHECK_GREATER(downloaded_bytes, 0);
+                CHECK_GREATER(downloadable_bytes, 0);
+                CHECK_EQUAL(downloaded_bytes, downloadable_bytes);
+                CHECK_EQUAL(snapshot_version, 4);
+                break;
+        }
         ++entry_2;
     };
 
@@ -3614,6 +3601,7 @@ TEST(Sync_UploadDownloadProgress_4)
 
     session_2.wait_for_upload_complete_or_client_stopped();
     session_2.wait_for_download_complete_or_client_stopped();
+    CHECK_EQUAL(entry_2, 3);
 }
 
 
@@ -3781,6 +3769,76 @@ TEST(Sync_UploadDownloadProgress_7)
 
     // The check is that we reach this point without deadlocking or throwing an assert while tearing
     // down the session that is in the process of being created.
+}
+
+TEST(Sync_UploadProgress_EmptyCommits)
+{
+    TEST_DIR(server_dir);
+    TEST_CLIENT_DB(db);
+
+    ClientServerFixture fixture(server_dir, test_context);
+    fixture.start();
+    Session session = fixture.make_session(db, "/test");
+
+    {
+        WriteTransaction wt{db};
+        wt.get_group().add_table_with_primary_key("class_table", type_Int, "_id");
+        wt.commit();
+    }
+
+    std::atomic<int> entry = 0;
+    session.set_progress_handler(
+        [&](uint_fast64_t, uint_fast64_t, uint_fast64_t, uint_fast64_t, uint_fast64_t, uint_fast64_t) {
+            ++entry;
+        });
+    session.bind();
+
+    // Each step calls wait_for_upload_complete twice because upload completion
+    // is fired before progress handlers, so we need another hop through the
+    // event loop after upload completion to know that the handler has been called
+    session.wait_for_upload_complete_or_client_stopped();
+    session.wait_for_upload_complete_or_client_stopped();
+
+    // Binding produces three notifications: the initial state, one after receiving
+    // the DOWNLOAD message, and one after uploading the schema
+    CHECK_EQUAL(entry, 3);
+
+    // No notification sent because an empty commit doesn't change uploadable_bytes
+    {
+        WriteTransaction wt{db};
+        wt.commit();
+    }
+    session.wait_for_upload_complete_or_client_stopped();
+    session.wait_for_upload_complete_or_client_stopped();
+    CHECK_EQUAL(entry, 3);
+
+    // Both the external and local commits are empty, so again no change in
+    // uploadable_bytes
+    {
+        auto db2 = DB::create(make_client_replication(), db_path);
+        WriteTransaction wt{db2};
+        wt.commit();
+        WriteTransaction wt2{db};
+        wt2.commit();
+    }
+    session.wait_for_upload_complete_or_client_stopped();
+    session.wait_for_upload_complete_or_client_stopped();
+    CHECK_EQUAL(entry, 3);
+
+    // Local commit is empty, but the changeset created by the external write
+    // is discovered after the local write, resulting in two notifications (one
+    // before uploading and one after).
+    {
+        auto db2 = DB::create(make_client_replication(), db_path);
+        WriteTransaction wt{db2};
+        wt.get_table("class_table")->create_object_with_primary_key(0);
+        wt.commit();
+        WriteTransaction wt2{db};
+        wt2.commit();
+    }
+    session.wait_for_upload_complete_or_client_stopped();
+    session.wait_for_upload_complete_or_client_stopped();
+    CHECK_EQUAL(entry, 5);
 }
 
 TEST(Sync_MultipleSyncAgentsNotAllowed)
@@ -4782,8 +4840,7 @@ TEST(Sync_ReadOnlyClientSideHistoryTrim)
             WriteTransaction wt{db_1};
             TableRef blobs = wt.get_table("class_Blob");
             blobs->begin()->set(col_ndx_blob_data, BinaryData{blob});
-            version_type new_version = wt.commit();
-            session_1.nonsync_transact_notify(new_version);
+            wt.commit();
         }
         session_1.wait_for_upload_complete_or_client_stopped();
         session_2.wait_for_download_complete_or_client_stopped();
@@ -5057,8 +5114,7 @@ TEST(Sync_ServerSideModify_Randomize)
             ;
             Obj obj = *(table->begin() + random.draw_int_mod(table->size()));
             obj.set<int64_t>("i", random.draw_int_max(0x0'7FFF'FFFF'FFFF'FFFF));
-            version_type new_version = wt.commit();
-            session.nonsync_transact_notify(new_version);
+            wt.commit();
             if (i % 16 == 0)
                 session.wait_for_upload_complete_or_client_stopped();
         }
@@ -5700,7 +5756,7 @@ TEST(Sync_CreateObjects_EraseObjects)
     Session session_1 = fixture.make_bound_session(db_1);
     Session session_2 = fixture.make_bound_session(db_2);
 
-    write_transaction_notifying_session(db_1, session_1, [](WriteTransaction& wt) {
+    write_transaction(db_1, [](WriteTransaction& wt) {
         TableRef table = wt.get_group().add_table_with_primary_key("class_persons", type_Int, "id");
         table->create_object_with_primary_key(1);
         table->create_object_with_primary_key(2);
@@ -5708,7 +5764,7 @@ TEST(Sync_CreateObjects_EraseObjects)
     session_1.wait_for_upload_complete_or_client_stopped();
     session_2.wait_for_download_complete_or_client_stopped();
 
-    write_transaction_notifying_session(db_1, session_1, [&](WriteTransaction& wt) {
+    write_transaction(db_1, [&](WriteTransaction& wt) {
         TableRef table = wt.get_table("class_persons");
         CHECK_EQUAL(table->size(), 2);
         table->get_object(0).remove();
@@ -5728,7 +5784,7 @@ TEST(Sync_CreateDeleteCreateTableWithPrimaryKey)
 
     Session session = fixture.make_bound_session(db);
 
-    write_transaction_notifying_session(db, session, [](WriteTransaction& wt) {
+    write_transaction(db, [](WriteTransaction& wt) {
         TableRef table = wt.get_group().add_table_with_primary_key("class_t", type_Int, "pk");
         wt.get_group().remove_table(table->get_key());
         table = wt.get_group().add_table_with_primary_key("class_t", type_String, "pk");
@@ -5829,7 +5885,8 @@ NONCONCURRENT_TEST_TYPES(Sync_PrimaryKeyTypes, Int, String, ObjectId, UUID, util
         list.insert(0, obj_2_id);
         list.insert(1, default_or_null);
         list.add(default_or_null);
-        session_1.nonsync_transact_notify(tr.commit());
+
+        tr.commit();
     }
 
     session_1.wait_for_upload_complete_or_client_stopped();
@@ -5894,7 +5951,7 @@ TEST(Sync_Mixed)
         values.insert(2, ObjLink{fops->get_key(), fop.get_key()});
         values.insert(3, 123.f);
 
-        session_1.nonsync_transact_notify(tr.commit());
+        tr.commit();
     }
 
     session_1.wait_for_upload_complete_or_client_stopped();
@@ -5953,7 +6010,7 @@ TEST(Sync_TypedLinks)
     session_1.bind();
     session_2.bind();
 
-    write_transaction_notifying_session(db_1, session_1, [](WriteTransaction& tr) {
+    write_transaction(db_1, [](WriteTransaction& tr) {
         auto& g = tr.get_group();
         auto foos = g.add_table_with_primary_key("class_Foo", type_Int, "id");
         auto bars = g.add_table_with_primary_key("class_Bar", type_String, "id");
@@ -6016,7 +6073,7 @@ TEST(Sync_Dictionary)
 
     Timestamp now{std::chrono::system_clock::now()};
 
-    write_transaction_notifying_session(db_1, session_1, [&](WriteTransaction& tr) {
+    write_transaction(db_1, [&](WriteTransaction& tr) {
         auto& g = tr.get_group();
         auto foos = g.add_table_with_primary_key("class_Foo", type_Int, "id");
         auto col_dict = foos->add_column_dictionary(type_Mixed, "dict");
@@ -6037,7 +6094,7 @@ TEST(Sync_Dictionary)
     session_1.wait_for_upload_complete_or_client_stopped();
     session_2.wait_for_download_complete_or_client_stopped();
 
-    write_transaction_notifying_session(db_2, session_2, [&](WriteTransaction& tr) {
+    write_transaction(db_2, [&](WriteTransaction& tr) {
         auto foos = tr.get_table("class_Foo");
         CHECK_EQUAL(foos->size(), 1);
 
@@ -6066,7 +6123,7 @@ TEST(Sync_Dictionary)
     session_2.wait_for_upload_complete_or_client_stopped();
     session_1.wait_for_download_complete_or_client_stopped();
 
-    write_transaction_notifying_session(db_1, session_1, [&](WriteTransaction& tr) {
+    write_transaction(db_1, [&](WriteTransaction& tr) {
         auto foos = tr.get_table("class_Foo");
         CHECK_EQUAL(foos->size(), 1);
 
@@ -6120,7 +6177,7 @@ TEST(Sync_Dictionary_Links)
 
     ColKey col_dict;
 
-    write_transaction_notifying_session(db_1, session_1, [&](WriteTransaction& tr) {
+    write_transaction(db_1, [&](WriteTransaction& tr) {
         auto& g = tr.get_group();
         auto foos = g.add_table_with_primary_key("class_Foo", type_Int, "id");
         auto bars = g.add_table_with_primary_key("class_Bar", type_String, "id");
@@ -6162,7 +6219,7 @@ TEST(Sync_Dictionary_Links)
 
     // Test that we can create tombstones for objects in dictionaries.
 
-    write_transaction_notifying_session(db_1, session_1, [&](WriteTransaction& tr) {
+    write_transaction(db_1, [&](WriteTransaction& tr) {
         auto& g = tr.get_group();
 
         auto bars = g.get_table("class_Bar");
@@ -6270,14 +6327,14 @@ TEST(Sync_Set)
         CHECK_EQUAL(mixeds.find(456.0), 1);
         CHECK_EQUAL(mixeds.find("a"), 2);
 
-        session_1.nonsync_transact_notify(wt.commit());
+        wt.commit();
     }
 
     session_1.wait_for_upload_complete_or_client_stopped();
     session_2.wait_for_download_complete_or_client_stopped();
 
     // Create a conflict. Session 1 should lose, because it has a lower peer ID.
-    write_transaction_notifying_session(db_1, session_1, [=](WriteTransaction& wt) {
+    write_transaction(db_1, [=](WriteTransaction& wt) {
         auto t = wt.get_table("class_Foo");
         auto obj = t->get_object_with_primary_key(0);
 
@@ -6285,7 +6342,7 @@ TEST(Sync_Set)
         ints.insert(999);
     });
 
-    write_transaction_notifying_session(db_2, session_2, [=](WriteTransaction& wt) {
+    write_transaction(db_2, [=](WriteTransaction& wt) {
         auto t = wt.get_table("class_Foo");
         auto obj = t->get_object_with_primary_key(0);
 
@@ -6305,7 +6362,7 @@ TEST(Sync_Set)
         CHECK(compare_groups(read_1, read_2));
     }
 
-    write_transaction_notifying_session(db_1, session_1, [=](WriteTransaction& wt) {
+    write_transaction(db_1, [=](WriteTransaction& wt) {
         auto t = wt.get_table("class_Foo");
         auto obj = t->get_object_with_primary_key(0);
         auto ints = obj.get_set<int64_t>(col_ints);
@@ -6416,7 +6473,7 @@ TEST(Sync_BundledRealmFile)
 
     Session session = fixture.make_bound_session(db);
 
-    write_transaction_notifying_session(db, session, [](WriteTransaction& tr) {
+    write_transaction(db, [](WriteTransaction& tr) {
         auto foos = tr.get_group().add_table_with_primary_key("class_Foo", type_Int, "id");
         foos->create_object_with_primary_key(123);
     });
@@ -6514,7 +6571,7 @@ TEST(Sync_UpgradeToClientHistory)
     session_1.bind();
     session_2.bind();
 
-    write_transaction_notifying_session(db_1, session_1, [](WriteTransaction& tr) {
+    write_transaction(db_1, [](WriteTransaction& tr) {
         auto foos = tr.get_group().get_table("class_Foo");
         foos->create_object_with_primary_key("456");
     });

--- a/test/test_sync.cpp
+++ b/test/test_sync.cpp
@@ -271,7 +271,7 @@ TEST(Sync_AsyncWaitForDownloadCompletion)
     {
         ReadTransaction rt_1(db_1);
         ReadTransaction rt_2(db_2);
-        CHECK(compare_groups(rt_1, rt_2));
+        CHECK(compare_groups(rt_1, rt_2, *test_context.logger));
     }
 
     // Again
@@ -291,7 +291,7 @@ TEST(Sync_AsyncWaitForDownloadCompletion)
     {
         ReadTransaction rt_1(db_1);
         ReadTransaction rt_2(db_2);
-        CHECK(compare_groups(rt_1, rt_2));
+        CHECK(compare_groups(rt_1, rt_2, *test_context.logger));
     }
 }
 
@@ -340,7 +340,7 @@ TEST(Sync_AsyncWaitForSyncCompletion)
     {
         ReadTransaction rt_1(db_1);
         ReadTransaction rt_2(db_2);
-        CHECK(compare_groups(rt_1, rt_2));
+        CHECK(compare_groups(rt_1, rt_2, *test_context.logger));
     }
 }
 
@@ -455,7 +455,7 @@ TEST(Sync_WaitForDownloadCompletion)
     {
         ReadTransaction rt_1(db_1);
         ReadTransaction rt_2(db_2);
-        CHECK(compare_groups(rt_1, rt_2));
+        CHECK(compare_groups(rt_1, rt_2, *test_context.logger));
     }
 
     // Again
@@ -475,7 +475,7 @@ TEST(Sync_WaitForDownloadCompletion)
     {
         ReadTransaction rt_1(db_1);
         ReadTransaction rt_2(db_2);
-        CHECK(compare_groups(rt_1, rt_2));
+        CHECK(compare_groups(rt_1, rt_2, *test_context.logger));
     }
 }
 
@@ -687,7 +687,7 @@ TEST(Sync_Replication)
     const Group& group_2 = rt_2;
     group_1.verify();
     group_2.verify();
-    CHECK(compare_groups(rt_1, rt_2));
+    CHECK(compare_groups(rt_1, rt_2, *test_context.logger));
     ConstTableRef table = group_1.get_table("class_foo");
     CHECK_EQUAL(100, table->size());
 }
@@ -745,7 +745,7 @@ TEST(Sync_Merge)
     const Group& group_2 = rt_2;
     group_1.verify();
     group_2.verify();
-    CHECK(compare_groups(rt_1, rt_2));
+    CHECK(compare_groups(rt_1, rt_2, *test_context.logger));
     ConstTableRef table = group_1.get_table("class_foo");
     CHECK_EQUAL(4, table->size());
 }
@@ -950,7 +950,7 @@ TEST(Sync_LateBind)
     const Group& group_2 = rt_2;
     group_1.verify();
     group_2.verify();
-    CHECK(compare_groups(rt_1, rt_2));
+    CHECK(compare_groups(rt_1, rt_2, *test_context.logger));
     CHECK_EQUAL(2, group_1.size());
 }
 
@@ -1535,7 +1535,7 @@ TEST(Sync_FailingReadsOnClientSide)
     const Group& group_2 = rt_2;
     group_1.verify();
     group_2.verify();
-    CHECK(compare_groups(rt_1, rt_2));
+    CHECK(compare_groups(rt_1, rt_2, *test_context.logger));
 }
 
 
@@ -1595,7 +1595,7 @@ TEST(Sync_FailingReadsOnServerSide)
     const Group& group_2 = rt_2;
     group_1.verify();
     group_2.verify();
-    CHECK(compare_groups(rt_1, rt_2));
+    CHECK(compare_groups(rt_1, rt_2, *test_context.logger));
 }
 
 
@@ -2297,7 +2297,7 @@ TEST(Sync_SingleClientUploadForever_CreateObjects)
 {
     int_fast32_t number_of_transactions = 100; // Set to low number in ordinary testing.
 
-    util::Logger& logger = *(test_context.logger);
+    util::Logger& logger = *test_context.logger;
 
     logger.info("Sync_SingleClientUploadForever_CreateObjects test. Number of transactions = %1",
                 number_of_transactions);
@@ -2359,7 +2359,7 @@ TEST(Sync_SingleClientUploadForever_MutateObject)
 {
     int_fast32_t number_of_transactions = 100; // Set to low number in ordinary testing.
 
-    util::Logger& logger = *(test_context.logger);
+    util::Logger& logger = *test_context.logger;
 
     logger.info("Sync_SingleClientUploadForever_MutateObject test. Number of transactions = %1",
                 number_of_transactions);
@@ -2517,7 +2517,7 @@ TEST(Sync_LargeUploadDownloadPerformance)
     for (int i = 0; i < number_of_download_clients; ++i) {
         ReadTransaction rt_1(db_upload);
         ReadTransaction rt_2(dbs[i]);
-        CHECK(compare_groups(rt_1, rt_2));
+        CHECK(compare_groups(rt_1, rt_2, *test_context.logger));
     }
 }
 
@@ -2581,7 +2581,7 @@ TEST_IF(Sync_4GB_Messages, false)
     {
         ReadTransaction rt_1(db_1);
         ReadTransaction rt_2(db_2);
-        CHECK(compare_groups(rt_1, rt_2));
+        CHECK(compare_groups(rt_1, rt_2, *test_context.logger));
     }
 }
 
@@ -3310,7 +3310,7 @@ TEST(Sync_UploadDownloadProgress_2)
     {
         ReadTransaction rt_1(db_1);
         ReadTransaction rt_2(db_2);
-        CHECK(compare_groups(rt_1, rt_2));
+        CHECK(compare_groups(rt_1, rt_2, *test_context.logger));
     }
 }
 
@@ -4746,7 +4746,7 @@ TEST(Sync_UploadLogCompactionEnabled)
     {
         ReadTransaction rt_1(db_1);
         ReadTransaction rt_2(db_2);
-        CHECK(compare_groups(rt_1, rt_2));
+        CHECK(compare_groups(rt_1, rt_2, *test_context.logger));
         ConstTableRef table = rt_1.get_table("class_foo");
         CHECK_EQUAL(2, table->size());
         CHECK_EQUAL(9999, table->begin()->get<Int>("integer column"));
@@ -4804,7 +4804,7 @@ TEST(Sync_UploadLogCompactionDisabled)
     {
         ReadTransaction rt_1(db_1);
         ReadTransaction rt_2(db_2);
-        CHECK(compare_groups(rt_1, rt_2));
+        CHECK(compare_groups(rt_1, rt_2, *test_context.logger));
         ConstTableRef table = rt_1.get_table("class_foo");
         CHECK_EQUAL(2, table->size());
         CHECK_EQUAL(9999, table->begin()->get<Int>("integer column"));
@@ -4895,7 +4895,7 @@ TEST(Sync_ContainerInsertAndSetLogCompaction)
     {
         ReadTransaction rt_1(db_1);
         ReadTransaction rt_2(db_2);
-        CHECK(compare_groups(rt_1, rt_2));
+        CHECK(compare_groups(rt_1, rt_2, *test_context.logger));
     }
 }
 
@@ -4939,7 +4939,7 @@ TEST(Sync_MultipleContainerColumns)
     {
         ReadTransaction rt_1(db_1);
         ReadTransaction rt_2(db_2);
-        CHECK(compare_groups(rt_1, rt_2));
+        CHECK(compare_groups(rt_1, rt_2, *test_context.logger));
 
         ConstTableRef table = rt_1.get_table("class_Table");
         const Obj row = *table->begin();
@@ -5130,7 +5130,7 @@ TEST(Sync_ServerSideModify_Randomize)
 
     ReadTransaction rt_1{db_1};
     ReadTransaction rt_2{db_2};
-    CHECK(compare_groups(rt_1, rt_2, *(test_context.logger)));
+    CHECK(compare_groups(rt_1, rt_2, *test_context.logger));
 }
 
 
@@ -5545,7 +5545,7 @@ TEST_IF(Sync_Issue2104, false)
     bool backup_whole_realm;
     _impl::ServerHistory::IntegrationResult result;
     history.integrate_client_changesets(integratable_changesets, version_info, backup_whole_realm, result,
-                                        *(test_context.logger));
+                                        *test_context.logger);
 }
 
 
@@ -6961,7 +6961,7 @@ TEST(Sync_TransformAgainstEmptyReciprocalChangeset)
     const Group& group_2 = rt_2;
     group_1.verify();
     group_2.verify();
-    CHECK(compare_groups(rt_1, rt_2));
+    CHECK(compare_groups(rt_1, rt_2, *test_context.logger));
 }
 
 TEST(Sync_ServerVersionsSkippedFromDownloadCursor)

--- a/test/test_sync_history_migration.cpp
+++ b/test/test_sync_history_migration.cpp
@@ -202,7 +202,7 @@ TEST(Sync_HistoryMigration)
         DBRef sg_2 = DB::create(sync::make_client_replication(), client_path_2);
         ReadTransaction rt_1{sg_1};
         ReadTransaction rt_2{sg_2};
-        return compare_groups(rt_1, rt_2, *(test_context.logger));
+        return compare_groups(rt_1, rt_2, *test_context.logger);
     };
 
     auto compare_client_and_server_files = [&](const std::string& client_path, const std::string& server_path) {
@@ -212,7 +212,7 @@ TEST(Sync_HistoryMigration)
         DBRef sg_2 = DB::create(history_2, server_path);
         ReadTransaction rt_1{sg_1};
         ReadTransaction rt_2{sg_2};
-        return compare_groups(rt_1, rt_2, *(test_context.logger));
+        return compare_groups(rt_1, rt_2, *test_context.logger);
     };
 
     std::string resources_dir = get_test_resource_path();

--- a/test/test_sync_subscriptions.cpp
+++ b/test/test_sync_subscriptions.cpp
@@ -40,7 +40,7 @@ TEST(Sync_SubscriptionStoreBasic)
     SHARED_GROUP_TEST_PATH(sub_store_path);
     {
         SubscriptionStoreFixture fixture(sub_store_path);
-        auto store = SubscriptionStore::create(fixture.db, [](int64_t) {});
+        auto store = SubscriptionStore::create(fixture.db);
         // Because there are no subscription sets yet, get_latest should point to an empty object
         auto latest = store->get_latest();
         CHECK(latest.begin() == latest.end());
@@ -83,7 +83,7 @@ TEST(Sync_SubscriptionStoreBasic)
     // Destroy the DB and reload it and make sure we can get the subscriptions we set in the previous block.
     {
         SubscriptionStoreFixture fixture(sub_store_path);
-        auto store = SubscriptionStore::create(fixture.db, [](int64_t) {});
+        auto store = SubscriptionStore::create(fixture.db);
 
         auto read_tr = fixture.db->start_read();
         Query query_a(read_tr->get_table(fixture.a_table_key));
@@ -113,7 +113,7 @@ TEST(Sync_SubscriptionStoreStateUpdates)
 {
     SHARED_GROUP_TEST_PATH(sub_store_path);
     SubscriptionStoreFixture fixture(sub_store_path);
-    auto store = SubscriptionStore::create(fixture.db, [](int64_t) {});
+    auto store = SubscriptionStore::create(fixture.db);
 
     auto read_tr = fixture.db->start_read();
     Query query_a(read_tr->get_table("class_a"));
@@ -208,7 +208,7 @@ TEST(Sync_SubscriptionStoreUpdateExisting)
 {
     SHARED_GROUP_TEST_PATH(sub_store_path);
     SubscriptionStoreFixture fixture(sub_store_path);
-    auto store = SubscriptionStore::create(fixture.db, [](int64_t) {});
+    auto store = SubscriptionStore::create(fixture.db);
 
     auto read_tr = fixture.db->start_read();
     Query query_a(read_tr->get_table("class_a"));
@@ -248,7 +248,7 @@ TEST(Sync_SubscriptionStoreAssignAnonAndNamed)
 {
     SHARED_GROUP_TEST_PATH(sub_store_path);
     SubscriptionStoreFixture fixture(sub_store_path);
-    auto store = SubscriptionStore::create(fixture.db, [](int64_t) {});
+    auto store = SubscriptionStore::create(fixture.db);
 
     auto read_tr = fixture.db->start_read();
     Query query_a(read_tr->get_table("class_a"));
@@ -284,7 +284,7 @@ TEST(Sync_SubscriptionStoreNotifications)
 {
     SHARED_GROUP_TEST_PATH(sub_store_path);
     SubscriptionStoreFixture fixture(sub_store_path);
-    auto store = SubscriptionStore::create(fixture.db, [](int64_t) {});
+    auto store = SubscriptionStore::create(fixture.db);
 
     std::vector<util::Future<SubscriptionSet::State>> notification_futures;
     auto sub_set = store->get_latest().make_mutable_copy();
@@ -404,7 +404,7 @@ TEST(Sync_SubscriptionStoreRefreshSubscriptionSetInvalid)
 {
     SHARED_GROUP_TEST_PATH(sub_store_path)
     SubscriptionStoreFixture fixture(sub_store_path);
-    auto store = SubscriptionStore::create(fixture.db, [](int64_t) {});
+    auto store = SubscriptionStore::create(fixture.db);
     // Because there are no subscription sets yet, get_latest should point to an empty object
     auto latest = std::make_unique<SubscriptionSet>(store->get_latest());
     CHECK(latest->begin() == latest->end());
@@ -431,7 +431,7 @@ TEST(Sync_SubscriptionStoreInternalSchemaMigration)
     CHECK(util::File::exists(path.string()));
     util::File::copy(path.string(), sub_store_path);
     SubscriptionStoreFixture fixture(sub_store_path);
-    auto store = SubscriptionStore::create(fixture.db, [](int64_t) {});
+    auto store = SubscriptionStore::create(fixture.db);
     auto [active_version, latest_version, pending_mark_version] = store->get_version_info();
     CHECK_EQUAL(active_version, latest_version);
     auto active = store->get_active();
@@ -455,7 +455,7 @@ TEST(Sync_SubscriptionStoreNextPendingVersion)
 {
     SHARED_GROUP_TEST_PATH(sub_store_path)
     SubscriptionStoreFixture fixture(sub_store_path);
-    auto store = SubscriptionStore::create(fixture.db, [](int64_t) {});
+    auto store = SubscriptionStore::create(fixture.db);
 
     auto mut_sub_set = store->get_latest().make_mutable_copy();
     auto sub_set = mut_sub_set.commit();
@@ -493,7 +493,7 @@ TEST(Sync_SubscriptionStoreSubSetHasTable)
 {
     SHARED_GROUP_TEST_PATH(sub_store_path)
     SubscriptionStoreFixture fixture(sub_store_path);
-    auto store = SubscriptionStore::create(fixture.db, [](int64_t) {});
+    auto store = SubscriptionStore::create(fixture.db);
 
     auto read_tr = fixture.db->start_read();
     // We should have no subscriptions yet so this should return false.
@@ -537,7 +537,7 @@ TEST(Sync_SubscriptionStoreNotifyAll)
 {
     SHARED_GROUP_TEST_PATH(sub_store_path)
     SubscriptionStoreFixture fixture(sub_store_path);
-    auto store = SubscriptionStore::create(fixture.db, [](int64_t) {});
+    auto store = SubscriptionStore::create(fixture.db);
 
     const Status status_abort(ErrorCodes::OperationAborted, "operation aborted");
 
@@ -612,7 +612,7 @@ TEST(Sync_SubscriptionStoreTerminate)
 {
     SHARED_GROUP_TEST_PATH(sub_store_path)
     SubscriptionStoreFixture fixture(sub_store_path);
-    auto store = SubscriptionStore::create(fixture.db, [](int64_t) {});
+    auto store = SubscriptionStore::create(fixture.db);
 
     size_t hit_count = 0;
 
@@ -848,7 +848,7 @@ TEST(Sync_MutableSubscriptionSetOperations)
 {
     SHARED_GROUP_TEST_PATH(sub_store_path);
     SubscriptionStoreFixture fixture(sub_store_path);
-    auto store = SubscriptionStore::create(fixture.db, [](int64_t) {});
+    auto store = SubscriptionStore::create(fixture.db);
 
     auto read_tr = fixture.db->start_read();
     Query query_a(read_tr->get_table("class_a"));

--- a/test/test_transform.cpp
+++ b/test/test_transform.cpp
@@ -108,7 +108,7 @@ TEST(Transform_TwoClients)
     }
     {
         ReadTransaction read_client_2(client_2->shared_group);
-        CHECK(compare_groups(read_server, read_client_2));
+        CHECK(compare_groups(read_server, read_client_2, *test_context.logger));
     }
 }
 
@@ -138,7 +138,7 @@ TEST(Transform_AddTableInOrder)
     }
     {
         ReadTransaction read_client_2(client_2->shared_group);
-        CHECK(compare_groups(read_server, read_client_2));
+        CHECK(compare_groups(read_server, read_client_2, *test_context.logger));
     }
 }
 
@@ -168,7 +168,7 @@ TEST(Transform_AddTableOutOfOrder)
     }
     {
         ReadTransaction read_client_2(client_2->shared_group);
-        CHECK(compare_groups(read_server, read_client_2));
+        CHECK(compare_groups(read_server, read_client_2, *test_context.logger));
     }
 }
 
@@ -204,7 +204,7 @@ TEST(Transform_AddColumnsInOrder)
     }
     {
         ReadTransaction read_client_2(client_2->shared_group);
-        CHECK(compare_groups(read_server, read_client_2));
+        CHECK(compare_groups(read_server, read_client_2, *test_context.logger));
     }
 }
 
@@ -237,7 +237,7 @@ TEST(Transform_AddColumnsOutOfOrder)
     ReadTransaction read_client_1(client_1->shared_group);
     ReadTransaction read_client_2(client_2->shared_group);
     CHECK(compare_groups(read_server, read_client_1));
-    CHECK(compare_groups(read_server, read_client_2));
+    CHECK(compare_groups(read_server, read_client_2, *test_context.logger));
 }
 
 TEST(Transform_LinkListSet_vs_MoveLastOver)
@@ -280,7 +280,7 @@ TEST(Transform_LinkListSet_vs_MoveLastOver)
     ReadTransaction read_client_1(client_1->shared_group);
     ReadTransaction read_client_2(client_2->shared_group);
     CHECK(compare_groups(read_server, read_client_1));
-    CHECK(compare_groups(read_server, read_client_2));
+    CHECK(compare_groups(read_server, read_client_2, *test_context.logger));
 }
 
 TEST(Transform_LinkListInsert_vs_MoveLastOver)
@@ -373,7 +373,7 @@ TEST(Transform_Experiment)
     ReadTransaction read_client_1(client_1->shared_group);
     ReadTransaction read_client_2(client_2->shared_group);
     CHECK(compare_groups(read_server, read_client_1));
-    CHECK(compare_groups(read_server, read_client_2));
+    CHECK(compare_groups(read_server, read_client_2, *test_context.logger));
 
     CHECK_EQUAL(read_server.get_table("class_t")->size(), 1);
     CHECK_EQUAL(read_server.get_table("class_t")->begin()->get_linklist("ll").size(), 2);
@@ -423,7 +423,7 @@ TEST(Transform_SelectLinkList)
     ReadTransaction read_client_1(client_1->shared_group);
     ReadTransaction read_client_2(client_2->shared_group);
     CHECK(compare_groups(read_server, read_client_1));
-    CHECK(compare_groups(read_server, read_client_2));
+    CHECK(compare_groups(read_server, read_client_2, *test_context.logger));
 
     CHECK_EQUAL(read_server.get_table("class_t")->size(), 1);
     CHECK_EQUAL(read_server.get_table("class_t")->begin()->get_linklist("ll").size(), 2);
@@ -462,7 +462,7 @@ TEST(Transform_InsertRows)
     ReadTransaction read_client_1(client_1->shared_group);
     ReadTransaction read_client_2(client_2->shared_group);
     CHECK(compare_groups(read_server, read_client_1));
-    CHECK(compare_groups(read_server, read_client_2));
+    CHECK(compare_groups(read_server, read_client_2, *test_context.logger));
 }
 
 TEST(Transform_AdjustSetLinkPayload)
@@ -507,7 +507,7 @@ TEST(Transform_AdjustSetLinkPayload)
     ReadTransaction read_client_1(client_1->shared_group);
     ReadTransaction read_client_2(client_2->shared_group);
     CHECK(compare_groups(read_server, read_client_1));
-    CHECK(compare_groups(read_server, read_client_2));
+    CHECK(compare_groups(read_server, read_client_2, *test_context.logger));
 
     {
         ConstTableRef t = read_client_1.get_table("class_t");
@@ -555,7 +555,7 @@ TEST(Transform_AdjustLinkListSetPayload)
     ReadTransaction read_client_1(client_1->shared_group);
     ReadTransaction read_client_2(client_2->shared_group);
     CHECK(compare_groups(read_server, read_client_1));
-    CHECK(compare_groups(read_server, read_client_2));
+    CHECK(compare_groups(read_server, read_client_2, *test_context.logger));
 
     ConstTableRef client_1_table_link = read_client_1.get_table("class_ll");
     LnkLst ll = client_1_table_link->get_object_with_primary_key(1).get_linklist("ll");
@@ -598,7 +598,7 @@ TEST(Transform_MergeInsertSetAndErase)
     ReadTransaction read_client_1(client_1->shared_group);
     ReadTransaction read_client_2(client_2->shared_group);
     CHECK(compare_groups(read_server, read_client_1));
-    CHECK(compare_groups(read_server, read_client_2));
+    CHECK(compare_groups(read_server, read_client_2, *test_context.logger));
 
     {
         ConstTableRef t = read_client_1.get_table("class_t");
@@ -642,7 +642,7 @@ TEST(Transform_MergeSetLinkAndMoveLastOver)
     ReadTransaction read_client_1(client_1->shared_group);
     ReadTransaction read_client_2(client_2->shared_group);
     CHECK(compare_groups(read_server, read_client_1));
-    CHECK(compare_groups(read_server, read_client_2));
+    CHECK(compare_groups(read_server, read_client_2, *test_context.logger));
 
     {
         ConstTableRef t = read_client_1.get_table("class_t");
@@ -695,7 +695,7 @@ TEST(Transform_MergeSetDefault)
     ReadTransaction read_client_1(client_1->shared_group);
     ReadTransaction read_client_2(client_2->shared_group);
     CHECK(compare_groups(read_server, read_client_1));
-    CHECK(compare_groups(read_server, read_client_2));
+    CHECK(compare_groups(read_server, read_client_2, *test_context.logger));
 
     ConstTableRef t = read_client_1.get_table("class_t");
     CHECK_EQUAL(t->size(), 1);
@@ -760,7 +760,7 @@ TEST(Transform_MergeLinkListsWithPrimaryKeys)
     ReadTransaction read_client_1(client_1->shared_group);
     ReadTransaction read_client_2(client_2->shared_group);
     CHECK(compare_groups(read_server, read_client_1));
-    CHECK(compare_groups(read_server, read_client_2));
+    CHECK(compare_groups(read_server, read_client_2, *test_context.logger));
 
     ConstTableRef t = read_client_1.get_table("class_t");
     CHECK_EQUAL(t->size(), 1);
@@ -808,7 +808,7 @@ TEST(Transform_AddInteger)
         ReadTransaction read_client_2(client_2->shared_group);
         CHECK_EQUAL(read_server.get_table("class_t")->begin()->get<Int>("i"), 9);
         CHECK(compare_groups(read_server, read_client_1));
-        CHECK(compare_groups(read_server, read_client_2));
+        CHECK(compare_groups(read_server, read_client_2, *test_context.logger));
     }
 
     client_2->history.advance_time(0);
@@ -833,7 +833,7 @@ TEST(Transform_AddInteger)
         ReadTransaction read_client_2(client_2->shared_group);
         CHECK_EQUAL(read_server.get_table("class_t")->begin()->get<Int>("i"), 103);
         CHECK(compare_groups(read_server, read_client_1));
-        CHECK(compare_groups(read_server, read_client_2));
+        CHECK(compare_groups(read_server, read_client_2, *test_context.logger));
     }
 }
 
@@ -887,7 +887,7 @@ TEST(Transform_AddIntegerSetNull)
         ReadTransaction read_client_2(client_2->shared_group);
         CHECK(read_server.get_table("class_t")->begin()->is_null("i"));
         CHECK(compare_groups(read_server, read_client_1));
-        CHECK(compare_groups(read_server, read_client_2));
+        CHECK(compare_groups(read_server, read_client_2, *test_context.logger));
     }
 }
 
@@ -952,7 +952,7 @@ TEST(Transform_EraseSelectedLinkView)
         ReadTransaction read_client_1(client_1->shared_group);
         ReadTransaction read_client_2(client_2->shared_group);
         CHECK(compare_groups(read_server, read_client_1));
-        CHECK(compare_groups(read_server, read_client_2));
+        CHECK(compare_groups(read_server, read_client_2, *test_context.logger));
 
         ConstTableRef origin = read_server.get_table("class_origin");
         ConstTableRef target = read_server.get_table("class_target");
@@ -1102,7 +1102,7 @@ std::tuple<double, double, double> timer_two_clients(TestContext& test_context, 
     ReadTransaction read_client_1(client_1->shared_group);
     ReadTransaction read_client_2(client_2->shared_group);
     CHECK(compare_groups(read_server, read_client_1));
-    CHECK(compare_groups(read_server, read_client_2));
+    CHECK(compare_groups(read_server, read_client_2, *test_context.logger));
 
     return std::make_tuple(double(duration_server), double(duration_client_1), double(duration_client_2));
 }

--- a/test/test_util_http.cpp
+++ b/test/test_util_http.cpp
@@ -264,7 +264,7 @@ TEST(HTTPParser_RequestLine)
 
 TEST(HTTPParser_ResponseLine)
 {
-    auto& logger = *(test_context.logger);
+    auto& logger = *test_context.logger;
     HTTPStatus s;
     struct expect_t {
         bool success;


### PR DESCRIPTION
The concrete bug which this fixes is that `await realm.subscriptions.update {}; await realm.refresh()` would hang forever. SubscriptionStore writes failed to notify RealmCoordinator of the write, so the async refresh would see that the Realm is not on the latest version, register a handler to be called when the autorefresh happened, and then nothing would ever schedule the autorefresh.

The sync client needs to be notified of non-sync writes and notify non-sync components when it performs writes. When it was first written, DB did not exist yet and so this was orchestrated via RealmCoordinator. However, that's a very awkward place to do it: not all writes go via RealmCoordinator, and the lifetime of sync sessions isn't actually tied to a coordinator. Nowadays we do have DB, and handling commit notifications there greatly simplifies everything.

There was also a *second* mechanism for notifying the sync client of writes which modified the subscription store. This appears to have been mostly redundant and unnecessary. The only additional information it conveyed was a number only used in some assertions.

Sync progress notifications somewhat relied on that some of the internal writes by the sync client didn't trigger them, and this change made it so that some very useless notifications were sent. To fix this, I made it so that commits will only trigger notifications if they changed the uploadable bytes, i.e. empty changesets don't produce notifications.

Ideally ExternalCommitHelper would live on DB rather than RealmCoordinator and nonsync_transact_notify() could go away entirely, but that looks like it'd be a pretty complicated change.