### PR TITLE
Fix building with non-beta Xcode 15

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@
 
 ### Fixed
 * <How do the end-user experience this issue? what was the impact?> ([#????](https://github.com/realm/realm-core/issues/????), since v?.?.?)
-* None.
+* Fix compilation with non-beta Xcode 15. Building for visionOS now requires explicitly specifying `-DCMAKE_XCODE_ATTRIBUTE_SDKROOT=xros` (PR [#7055](https://github.com/realm/realm-core/pull/7055)).
 
 ### Breaking changes
 * None.

--- a/tools/build-apple-device.sh
+++ b/tools/build-apple-device.sh
@@ -52,6 +52,11 @@ if [ "${platform}" == 'maccatalyst' ]; then
     buildDestination='generic/platform=macOS,variant=Mac Catalyst'
 fi
 
+sdkroot=iphoneos
+if [[ "${platform}" == xr* ]]; then
+    sdkroot=xros
+fi
+
 mkdir -p build-xcode-platforms
 cd build-xcode-platforms
 cmake \
@@ -59,6 +64,7 @@ cmake \
     -D REALM_VERSION="${VERSION}" \
     -D REALM_BUILD_LIB_ONLY=ON \
     -D CPACK_PACKAGE_DIRECTORY=.. \
+    -D CMAKE_XCODE_ATTRIBUTE_SDKROOT="$sdkroot" \
     ${CMAKE_FLAGS} \
     -G Xcode \
     ..

--- a/tools/cmake/xcode.toolchain.cmake
+++ b/tools/cmake/xcode.toolchain.cmake
@@ -17,14 +17,18 @@ set(CMAKE_XCODE_ATTRIBUTE_TARGETED_DEVICE_FAMILY "1,2,3,4,7")
 
 # With Xcode 14+ the base SDK *mostly* doesn't matter any more, as it
 # officially supports multi-platform builds from a single target.
-# However, as of Xcode 15 beta 2 xcodebuild (but not Xcode itself) requires the
-# visionOS SDK to build for visionOS. Hopefully this is just a beta bug.
+# However, as of Xcode 15 beta 8 xcodebuild (but not Xcode itself) requires the
+# visionOS SDK to build for visionOS. 15.0 final doesn't include the visionOS
+# SDK, so the SDKROOT is explicitly set by the invoker when building with the
+# beta Xcode rather than here.
 # Xcode 13 requires using the correct SDK. We no longer support Xcode 13, but
 # still use it on evergreen to build the macOS tests (and nothing else).
-set(CMAKE_XCODE_ATTRIBUTE_SDKROOT_1500 "xros")
-set(CMAKE_XCODE_ATTRIBUTE_SDKROOT_1400 "iphoneos")
-set(CMAKE_XCODE_ATTRIBUTE_SDKROOT_1300 "macosx")
-set(CMAKE_XCODE_ATTRIBUTE_SDKROOT "$(SDKROOT_$(XCODE_VERSION_MAJOR))")
+if(NOT DEFINED CMAKE_XCODE_ATTRIBUTE_SDKROOT)
+    set(CMAKE_XCODE_ATTRIBUTE_SDKROOT_1500 "iphoneos")
+    set(CMAKE_XCODE_ATTRIBUTE_SDKROOT_1400 "iphoneos")
+    set(CMAKE_XCODE_ATTRIBUTE_SDKROOT_1300 "macosx")
+    set(CMAKE_XCODE_ATTRIBUTE_SDKROOT "$(SDKROOT_$(XCODE_VERSION_MAJOR))")
+endif()
 
 set(CMAKE_XCODE_ATTRIBUTE_IPHONEOS_DEPLOYMENT_TARGET "11.0")
 set(CMAKE_XCODE_ATTRIBUTE_MACOSX_DEPLOYMENT_TARGET_CATALYST_NO "10.13")


### PR DESCRIPTION
The visionOS SDK is currently only available in beta versions of Xcode, so we can't use a major version check to enable it. Instead we need to explicitly enable visionOS when building for it.