### PR TITLE
IQF compliant queries in migration tests

### DIFF
--- a/test/object-store/sync/flx_migration.cpp
+++ b/test/object-store/sync/flx_migration.cpp
@@ -210,7 +210,7 @@ TEST_CASE("Test server migration and rollback", "[sync][flx][flx migration][baas
             mut_subs.clear();
             mut_subs.insert_or_assign(
                 "flx_migrated_Objects_2",
-                Query(flx_table).equal(flx_table->get_column_key("realm_id"), StringData{partition2}));                
+                Query(flx_table).equal(flx_table->get_column_key("realm_id"), StringData{partition2}));
             auto subs = std::move(mut_subs).commit();
             subs.get_state_change_notification(sync::SubscriptionSet::State::Complete).get();
 

--- a/test/object-store/sync/flx_migration.cpp
+++ b/test/object-store/sync/flx_migration.cpp
@@ -207,14 +207,10 @@ TEST_CASE("Test server migration and rollback", "[sync][flx][flx migration][baas
         {
             auto flx_table = flx_realm->read_group().get_table("class_Object");
             auto mut_subs = flx_realm->get_latest_subscription_set().make_mutable_copy();
-
-            // Remove the existing subscription and subscribe to partition 1 and partition 2
             mut_subs.clear();
-            std::vector<std::string> partitions{ parition1, partition2 };
             mut_subs.insert_or_assign(
                 "flx_migrated_Objects_2",
-                Query(flx_table).equal(flx_table->get_column_key("realm_id"), partitions));
-                
+                Query(flx_table).equal(flx_table->get_column_key("realm_id"), StringData{partition2}));                
             auto subs = std::move(mut_subs).commit();
             subs.get_state_change_notification(sync::SubscriptionSet::State::Complete).get();
 
@@ -222,7 +218,7 @@ TEST_CASE("Test server migration and rollback", "[sync][flx][flx migration][baas
             REQUIRE(!wait_for_download(*flx_realm));
             wait_for_advance(*flx_realm);
 
-            check_data(flx_realm, true, true);
+            check_data(flx_realm, false, true);
         }
     }
 

--- a/test/object-store/sync/flx_migration.cpp
+++ b/test/object-store/sync/flx_migration.cpp
@@ -758,8 +758,7 @@ TEST_CASE("New table is synced after migration", "[sync][flx][flx migration][baa
         // Create a subscription for the new table.
         auto table = flx_realm->read_group().get_table("class_Object2");
         auto mut_subs = flx_realm->get_latest_subscription_set().make_mutable_copy();
-        mut_subs.insert_or_assign(
-            Query(table).equal(table->get_column_key("realm_id"), StringData{partition}));
+        mut_subs.insert_or_assign(Query(table).equal(table->get_column_key("realm_id"), StringData{partition}));
 
         auto subs = std::move(mut_subs).commit();
         subs.get_state_change_notification(sync::SubscriptionSet::State::Complete).get();


### PR DESCRIPTION
## What, How & Why?
Device sync is enabling indexed queryable fields in PBS->QBS migrations which means that there are limitations on the types of queries that a QBS client is able to make after the migration ([See Here](https://www.mongodb.com/docs/atlas/app-services/sync/configure/sync-settings/#indexed-queryable-fields))

This change fixes some non compliant queries in migration tests

```
realm_id = partition1 OR realm_id = partition2 -> realm_id = partition2
truepredicate -> realm_id = partition2
```

## ☑️ ToDos
* [x] 📝 Changelog update
* [x] 🚦 Tests (or not relevant)
* [x] C-API, if public C++ API changed.
