### PR TITLE
Fix race in send_upload_message

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@
 ### Fixed
 * <How do the end-user experience this issue? what was the impact?> ([#????](https://github.com/realm/realm-core/issues/????), since v?.?.?)
 * Potential stack-use-after-scope issue on changesets integration with msvc-2019 and mpack code ([PR #6911](https://github.com/realm/realm-core/pull/6911))
+* Fixed FLX subscriptions not being sent to the server if an upload message was sent immediately after a subscription was committed but before the sync client checks for new subscriptions via `SubscriptionStore::get_next_pending_version()`. ([#7076](https://github.com/realm/realm-core/issues/7076), since v13.23.1)
+* Fixed application crash with 'KeyNotFound' exception when subscriptions are marked complete after a client reset. ([#7090](https://github.com/realm/realm-core/issues/7090), since v12.3.0)
 
 ### Breaking changes
 * None.

--- a/src/realm/sync/client.cpp
+++ b/src/realm/sync/client.cpp
@@ -123,6 +123,8 @@ public:
 
     void handle_pending_client_reset_acknowledgement();
 
+    void update_subscription_version_info();
+
     std::string get_appservices_connection_id();
 
 private:
@@ -784,6 +786,13 @@ void SessionImpl::handle_pending_client_reset_acknowledgement()
     }
 }
 
+void SessionImpl::update_subscription_version_info()
+{
+    // Ignore the call if the session is not active
+    if (m_state == State::Active) {
+        m_wrapper.update_subscription_version_info();
+    }
+}
 
 bool SessionImpl::process_flx_bootstrap_message(const SyncProgress& progress, DownloadBatchState batch_state,
                                                 int64_t query_version, const ReceivedChangesets& received_changesets)
@@ -1130,9 +1139,7 @@ SessionWrapper::SessionWrapper(ClientImpl& client, DBRef db, std::shared_ptr<Sub
     REALM_ASSERT(dynamic_cast<ClientReplication*>(m_db->get_replication()));
 
     if (m_flx_subscription_store) {
-        auto versions_info = m_flx_subscription_store->get_version_info();
-        m_flx_active_version = versions_info.active;
-        m_flx_pending_mark_version = versions_info.pending_mark;
+        update_subscription_version_info();
     }
 }
 
@@ -1819,6 +1826,13 @@ void SessionWrapper::handle_pending_client_reset_acknowledgement()
         _impl::client_reset::remove_pending_client_resets(wt);
         wt->commit();
     });
+}
+
+void SessionWrapper::update_subscription_version_info()
+{
+    auto versions_info = m_flx_subscription_store->get_version_info();
+    m_flx_active_version = versions_info.active;
+    m_flx_pending_mark_version = versions_info.pending_mark;
 }
 
 std::string SessionWrapper::get_appservices_connection_id()

--- a/src/realm/sync/client.cpp
+++ b/src/realm/sync/client.cpp
@@ -1138,9 +1138,7 @@ SessionWrapper::SessionWrapper(ClientImpl& client, DBRef db, std::shared_ptr<Sub
     REALM_ASSERT(m_db->get_replication());
     REALM_ASSERT(dynamic_cast<ClientReplication*>(m_db->get_replication()));
 
-    if (m_flx_subscription_store) {
-        update_subscription_version_info();
-    }
+    update_subscription_version_info();
 }
 
 SessionWrapper::~SessionWrapper() noexcept
@@ -1830,6 +1828,8 @@ void SessionWrapper::handle_pending_client_reset_acknowledgement()
 
 void SessionWrapper::update_subscription_version_info()
 {
+    if (!m_flx_subscription_store)
+        return;
     auto versions_info = m_flx_subscription_store->get_version_info();
     m_flx_active_version = versions_info.active;
     m_flx_pending_mark_version = versions_info.pending_mark;

--- a/src/realm/sync/noinst/client_impl_base.cpp
+++ b/src/realm/sync/noinst/client_impl_base.cpp
@@ -2303,6 +2303,8 @@ Status Session::receive_ident_message(SaltedFileIdent client_file_ident)
             handle_pending_client_reset_acknowledgement();
         }
 
+        update_subscription_version_info();
+
         // If a migration or rollback is in progress, mark it complete when client reset is completed.
         if (auto migration_store = get_migration_store()) {
             migration_store->complete_migration_or_rollback();

--- a/src/realm/sync/noinst/client_impl_base.cpp
+++ b/src/realm/sync/noinst/client_impl_base.cpp
@@ -2001,13 +2001,10 @@ void Session::send_upload_message()
     if (REALM_UNLIKELY(get_client().is_dry_run()))
         return;
 
-    version_type target_upload_version = get_db()->get_version_of_latest_snapshot();
+    version_type target_upload_version = m_last_version_available;
     if (m_pending_flx_sub_set) {
         REALM_ASSERT(m_is_flx_sync_session);
         target_upload_version = m_pending_flx_sub_set->snapshot_version;
-    }
-    if (target_upload_version > m_last_version_available) {
-        m_last_version_available = target_upload_version;
     }
 
     const ClientReplication& repl = access_realm(); // Throws

--- a/src/realm/sync/noinst/client_impl_base.hpp
+++ b/src/realm/sync/noinst/client_impl_base.hpp
@@ -1013,6 +1013,8 @@ private:
 
     void handle_pending_client_reset_acknowledgement();
 
+    void update_subscription_version_info();
+
     void gather_pending_compensating_writes(util::Span<Changeset> changesets, std::vector<ProtocolErrorInfo>* out);
 
     void begin_resumption_delay(const ProtocolErrorInfo& error_info);

--- a/src/realm/sync/noinst/client_reset.cpp
+++ b/src/realm/sync/noinst/client_reset.cpp
@@ -575,8 +575,9 @@ LocalVersionIDs perform_client_reset_diff(DBRef db_local, DBRef db_remote, sync:
         if (!sub_store) {
             return;
         }
-        auto mut_subs = sub_store->get_active().make_mutable_copy();
-        int64_t before_version = mut_subs.version();
+        auto subs = sub_store->get_active();
+        int64_t before_version = subs.version();
+        auto mut_subs = subs.make_mutable_copy();
         mut_subs.update_state(sync::SubscriptionSet::State::Complete);
         auto sub = std::move(mut_subs).commit();
         if (on_flx_version_complete) {


### PR DESCRIPTION
## What, How & Why?
A race in `send_upload_message()` causes subscriptions not being sent to the server (and as a side effect a notification on that subscription may never be fulfilled). This can happen when send_upload_message() is called as a result of a commit previous to the one for subscriptions. send_upload_message() then forwards the upload cursor past the version associated with the subscription and so the subscription is never uploaded to the server.

A second bug was uncovered while investigating this issue.

SessionWrapper reads the state of the SubscriptionStore when it is created, but this state can change after a client reset (when then state of existing subscription may change, in addition to new subscriptions being created and old subscriptions being removed). This can cause a crash with realm::KeyNotFound when trying to update a subscription which does not exist anymore.

Fixes #7076, #7090.

## ☑️ ToDos
* [x] 📝 Changelog update
* ~~[ ] 🚦 Tests (or not relevant)~~
* ~~[ ] C-API, if public C++ API changed.~~
