### PR TITLE
Re-send subscription if bootstrap is interrupted and upload cursor is past the sub's snapshot version

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 ### Fixed
 * <How do the end-user experience this issue? what was the impact?> ([#????](https://github.com/realm/realm-core/issues/????), since v?.?.?)
 * Potential stack-use-after-scope issue on changesets integration with msvc-2019 and mpack code ([PR #6911](https://github.com/realm/realm-core/pull/6911))
+* Fixed FLX subscriptions not being sent to the server if the session was interrupted during bootstrapping. ([#7077](https://github.com/realm/realm-core/issues/7077), since v11.8.0)
 
 ### Breaking changes
 * None.

--- a/src/realm/sync/noinst/client_impl_base.cpp
+++ b/src/realm/sync/noinst/client_impl_base.cpp
@@ -1850,8 +1850,7 @@ void Session::send_message()
             return false;
         }
 
-        m_pending_flx_sub_set = get_flx_subscription_store()->get_next_pending_version(
-            m_last_sent_flx_query_version, m_upload_progress.client_version);
+        m_pending_flx_sub_set = get_flx_subscription_store()->get_next_pending_version(m_last_sent_flx_query_version);
 
         if (!m_pending_flx_sub_set) {
             return false;

--- a/src/realm/sync/subscriptions.hpp
+++ b/src/realm/sync/subscriptions.hpp
@@ -344,8 +344,7 @@ public:
         DB::version_type snapshot_version;
     };
 
-    util::Optional<PendingSubscription> get_next_pending_version(int64_t last_query_version,
-                                                                 DB::version_type after_client_version) const;
+    util::Optional<PendingSubscription> get_next_pending_version(int64_t last_query_version) const;
     std::vector<SubscriptionSet> get_pending_subscriptions() const;
 
     // Notify all subscription state change notification handlers on this subscription store with the

--- a/test/test_sync_subscriptions.cpp
+++ b/test/test_sync_subscriptions.cpp
@@ -477,15 +477,15 @@ TEST(Sync_SubscriptionStoreNextPendingVersion)
     mut_sub_set.update_state(SubscriptionSet::State::Bootstrapping);
     mut_sub_set.commit();
 
-    auto pending_version = store->get_next_pending_version(0, DB::version_type{});
+    auto pending_version = store->get_next_pending_version(0);
     CHECK(pending_version);
     CHECK_EQUAL(pending_version->query_version, bootstrapping_set);
 
-    pending_version = store->get_next_pending_version(bootstrapping_set, DB::version_type{});
+    pending_version = store->get_next_pending_version(bootstrapping_set);
     CHECK(pending_set);
     CHECK_EQUAL(pending_version->query_version, pending_set);
 
-    pending_version = store->get_next_pending_version(pending_set, DB::version_type{});
+    pending_version = store->get_next_pending_version(pending_set);
     CHECK(!pending_version);
 }
 


### PR DESCRIPTION
## What, How & Why?
`SubscriptionStore::get_next_pending_version()` returns the next subscription that needs to be sent to the server with a snapshot version **past** the upload cursor. Empty uploads may be acknowledged during bootstraps and so that will advance the upload cursor past the snapshot version of the subscription. If the subscription bootstrap is interrupted, it is not picked up by the sync client the next time get_next_pending_version() is called (and as a side effect a notification on that subscription will no be fulfilled).

get_next_pending_version() does not need to take into account the upload cursor, so the fix is to remove querying on it.

Fixes #7077.

## ☑️ ToDos
* [x] 📝 Changelog update
* ~~[ ] 🚦 Tests (or not relevant)~~
* ~~[ ] C-API, if public C++ API changed.~~
