### PR TITLE
Simplify sync::Transformer and eliminate the abstract interface

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,7 @@
 * Add support for building against the musl library. ([PR #7067](https://github.com/realm/realm-core/pull/7067))
 * Remove ArrayWithFind's ability to use a templated callback parameter. The QueryStateBase consumers now use an index and the array leaf to get the actual value if needed. This allows certain queries such as count() to not do as many lookups to the actual values and results in a small performance gain. Also remove `find_action_pattern()` which was unused for a long time. This reduction in templating throughout the query system produces a small (~100k) binary size reduction. ([#7095](https://github.com/realm/realm-core/pull/7095))
 * Rework the implemenatation of the set algrebra functions on Set<T> to reduce the compiled size.
+* Rework the internal interface for sync Transformers to simplify it and reduce the compiled size ([PR #7098](https://github.com/realm/realm-core/pull/7098)).
 
 ----------------------------------------------
 

--- a/src/realm/sync/noinst/client_history_impl.hpp
+++ b/src/realm/sync/noinst/client_history_impl.hpp
@@ -272,10 +272,6 @@ private:
     ClientReplication& m_replication;
     DB* m_db = nullptr;
 
-    // FIXME: All history objects belonging to a particular client object
-    // (sync::Client) should use a single shared transformer object.
-    std::unique_ptr<Transformer> m_transformer;
-
     /// The version on which the first changeset in the continuous transactions
     /// history is based, or if that history is empty, the version associated
     /// with currently bound snapshot. In general, `m_ct_history_base_version +
@@ -412,7 +408,6 @@ private:
     void trim_sync_history();
     void do_trim_sync_history(std::size_t n);
     void clamp_sync_version_range(version_type& begin, version_type& end) const noexcept;
-    Transformer& get_transformer();
     void fix_up_client_file_ident_in_stored_changesets(Transaction&, file_ident_type);
     void record_current_schema_version();
     static void record_current_schema_version(Array& schema_versions, version_type snapshot_version);
@@ -533,13 +528,6 @@ inline void ClientHistory::clamp_sync_version_range(version_type& begin, version
         if (end < m_sync_history_base_version)
             end = m_sync_history_base_version;
     }
-}
-
-inline auto ClientHistory::get_transformer() -> Transformer&
-{
-    if (!m_transformer)
-        m_transformer = make_transformer(); // Throws
-    return *m_transformer;
 }
 
 

--- a/src/realm/sync/noinst/client_history_impl.hpp
+++ b/src/realm/sync/noinst/client_history_impl.hpp
@@ -82,7 +82,6 @@ public:
 class ClientHistory final : public _impl::History, public TransformHistory {
 public:
     using version_type = sync::version_type;
-    using RemoteChangeset = Transformer::RemoteChangeset;
 
     struct UploadChangeset {
         timestamp_type origin_timestamp;

--- a/src/realm/sync/noinst/client_impl_base.cpp
+++ b/src/realm/sync/noinst/client_impl_base.cpp
@@ -2379,7 +2379,7 @@ Status Session::receive_download_message(const SyncProgress& progress, std::uint
 
     version_type server_version = m_progress.download.server_version;
     version_type last_integrated_client_version = m_progress.download.last_integrated_client_version;
-    for (const Transformer::RemoteChangeset& changeset : received_changesets) {
+    for (const RemoteChangeset& changeset : received_changesets) {
         // Check that per-changeset server version is strictly increasing, except in FLX sync where the server
         // version must be increasing, but can stay the same during bootstraps.
         bool good_server_version = m_is_flx_sync_session ? (changeset.remote_version >= server_version)

--- a/src/realm/sync/noinst/pending_bootstrap_store.cpp
+++ b/src/realm/sync/noinst/pending_bootstrap_store.cpp
@@ -245,7 +245,7 @@ PendingBootstrapStore::PendingBatch PendingBootstrapStore::peek_pending(size_t l
         }
         REALM_ASSERT_3(ec, ==, std::error_code{});
 
-        Transformer::RemoteChangeset parsed_changeset;
+        RemoteChangeset parsed_changeset;
         parsed_changeset.original_changeset_size =
             static_cast<size_t>(cur_changeset.get<int64_t>(m_changeset_original_changeset_size));
         parsed_changeset.origin_timestamp = cur_changeset.get<int64_t>(m_changeset_origin_timestamp);

--- a/src/realm/sync/noinst/pending_bootstrap_store.hpp
+++ b/src/realm/sync/noinst/pending_bootstrap_store.hpp
@@ -56,7 +56,7 @@ public:
 
     struct PendingBatch {
         int64_t query_version = 0;
-        std::vector<Transformer::RemoteChangeset> changesets;
+        std::vector<RemoteChangeset> changesets;
         std::vector<util::AppendBuffer<char>> changeset_data;
         util::Optional<SyncProgress> progress;
         size_t remaining_changesets = 0;
@@ -79,7 +79,7 @@ public:
 
     // Adds a set of changesets to the store.
     void add_batch(int64_t query_version, util::Optional<SyncProgress> progress,
-                   const std::vector<Transformer::RemoteChangeset>& changesets, bool* created_new_batch);
+                   const std::vector<RemoteChangeset>& changesets, bool* created_new_batch);
 
     void clear();
 

--- a/src/realm/sync/noinst/protocol_codec.hpp
+++ b/src/realm/sync/noinst/protocol_codec.hpp
@@ -144,7 +144,7 @@ public:
     // clang-format on
 
     using OutputBuffer = util::ResettableExpandableBufferOutputStream;
-    using RemoteChangeset = sync::Transformer::RemoteChangeset;
+    using RemoteChangeset = sync::RemoteChangeset;
     using ReceivedChangesets = std::vector<RemoteChangeset>;
 
     /// Messages sent by the client.
@@ -422,7 +422,7 @@ private:
 
         // Loop through the body and find the changesets.
         while (!msg.at_end()) {
-            realm::sync::Transformer::RemoteChangeset cur_changeset;
+            RemoteChangeset cur_changeset;
             cur_changeset.remote_version = msg.read_next<version_type>();
             cur_changeset.last_integrated_local_version = msg.read_next<version_type>();
             cur_changeset.origin_timestamp = msg.read_next<timestamp_type>();

--- a/src/realm/sync/noinst/server/server_history.cpp
+++ b/src/realm/sync/noinst/server/server_history.cpp
@@ -1200,10 +1200,9 @@ bool ServerHistory::integrate_remote_changesets(file_ident_type remote_file_iden
         // Merge with causally unrelated changesets, and resolve the
         // conflicts if there are any.
         TransformHistoryImpl transform_hist{remote_file_ident, *this, recip_hist};
-        Transformer& transformer = m_context.get_transformer(); // Throws
+        Transformer transformer;
         transformer.transform_remote_changesets(transform_hist, m_local_file_ident, current_server_version,
-                                                parsed_transformed_changesets, std::move(apply),
-                                                logger); // Throws
+                                                parsed_transformed_changesets, apply, logger); // Throws
 
         for (std::size_t i = 0; i < num_changesets; ++i) {
             REALM_ASSERT(get_instruction_encoder().buffer().size() == 0);
@@ -2244,18 +2243,6 @@ void ServerHistory::record_current_schema_version(Array& schema_versions, versio
         std::time_t timestamp = std::time(nullptr);
         sv_timestamps.add(std::int_fast64_t(timestamp)); // Throws
     }
-}
-
-
-Transformer& ServerHistory::Context::get_transformer()
-{
-    throw util::runtime_error("Not supported");
-}
-
-
-util::Buffer<char>& ServerHistory::Context::get_transform_buffer()
-{
-    throw util::runtime_error("Not supported");
 }
 
 

--- a/src/realm/sync/noinst/server/server_history.hpp
+++ b/src/realm/sync/noinst/server/server_history.hpp
@@ -119,7 +119,7 @@ public:
     using UploadCursor           = sync::UploadCursor;
     using SyncProgress           = sync::SyncProgress;
     using HistoryEntry           = sync::HistoryEntry;
-    using RemoteChangeset        = sync::Transformer::RemoteChangeset;
+    using RemoteChangeset        = sync::RemoteChangeset;
     // clang-format on
 
     enum class BootstrapError {

--- a/src/realm/sync/noinst/server/server_history.hpp
+++ b/src/realm/sync/noinst/server/server_history.hpp
@@ -742,16 +742,6 @@ class ServerHistory::Context {
 public:
     virtual std::mt19937_64& server_history_get_random() noexcept = 0;
 
-    // @{
-    /// These are guaranteed to not be called until a remote changeset needs to
-    /// be integrated into the history.
-    ///
-    /// The default implementations throw std::runtime_error, with a message
-    /// saying "Not supported".
-    virtual sync::Transformer& get_transformer();
-    virtual util::Buffer<char>& get_transform_buffer();
-    // @}
-
 protected:
     Context() noexcept = default;
 };

--- a/src/realm/sync/tools/apply_to_state_command.cpp
+++ b/src/realm/sync/tools/apply_to_state_command.cpp
@@ -42,7 +42,7 @@ struct DownloadMessage {
     int64_t query_version;
 
     Buffer<char> uncompressed_body_buffer;
-    std::vector<realm::sync::Transformer::RemoteChangeset> changesets;
+    std::vector<realm::sync::RemoteChangeset> changesets;
 
     static DownloadMessage parse(HeaderLineParser& msg, Logger& logger, bool is_flx_sync);
 };
@@ -135,7 +135,7 @@ DownloadMessage DownloadMessage::parse(HeaderLineParser& msg, Logger& logger, bo
 
     HeaderLineParser body(body_str);
     while (!body.at_end()) {
-        realm::sync::Transformer::RemoteChangeset cur_changeset;
+        realm::sync::RemoteChangeset cur_changeset;
         cur_changeset.remote_version = body.read_next<sync::version_type>();
         cur_changeset.last_integrated_local_version = body.read_next<sync::version_type>();
         cur_changeset.origin_timestamp = body.read_next<sync::timestamp_type>();

--- a/src/realm/sync/transform.hpp
+++ b/src/realm/sync/transform.hpp
@@ -118,6 +118,12 @@ class TransformError; // Exception
 
 class Transformer {
 public:
+    using Changeset = sync::Changeset;
+    using file_ident_type = sync::file_ident_type;
+    using HistoryEntry = sync::HistoryEntry;
+    using Instruction = sync::Instruction;
+    using TransformHistory = sync::TransformHistory;
+    using version_type = sync::version_type;
     using iterator = util::Span<Changeset>::iterator;
 
     /// Produce operationally transformed versions of the specified changesets,
@@ -165,42 +171,11 @@ public:
     /// \throw TransformError Thrown if operational transformation fails due to
     /// a problem with the specified changeset.
     ///
-    /// FIXME: Consider using std::error_code instead of throwing
+    /// FIXME: Consider using Status instead of throwing
     /// TransformError.
-    virtual size_t transform_remote_changesets(TransformHistory&, file_ident_type local_file_ident,
-                                               version_type current_local_version, util::Span<Changeset> changesets,
-                                               util::FunctionRef<bool(const Changeset*)> changeset_applier,
-                                               util::Logger&) = 0;
-
-    virtual ~Transformer() noexcept {}
-};
-
-std::unique_ptr<Transformer> make_transformer();
-
-} // namespace sync
-
-namespace _impl {
-
-class TransformerImpl : public sync::Transformer {
-public:
-    using Changeset = sync::Changeset;
-    using file_ident_type = sync::file_ident_type;
-    using HistoryEntry = sync::HistoryEntry;
-    using Instruction = sync::Instruction;
-    using TransformHistory = sync::TransformHistory;
-    using version_type = sync::version_type;
-
-    TransformerImpl() = default;
-
-    size_t transform_remote_changesets(TransformHistory&, file_ident_type, version_type, util::Span<Changeset>,
-                                       util::FunctionRef<bool(const Changeset*)>, util::Logger&) override;
-
-protected:
-    virtual void merge_changesets(file_ident_type local_file_ident, Changeset* their_changesets,
-                                  std::size_t their_size,
-                                  // our_changesets is a pointer-pointer because these changesets
-                                  // are held by the reciprocal transform cache.
-                                  Changeset** our_changesets, std::size_t our_size, util::Logger& logger);
+    size_t transform_remote_changesets(TransformHistory&, file_ident_type local_file_ident, version_type,
+                                       util::Span<Changeset>,
+                                       util::FunctionRef<bool(const Changeset*)> changeset_applier, util::Logger&);
 
 private:
     std::map<version_type, Changeset> m_reciprocal_transform_cache;
@@ -208,12 +183,14 @@ private:
     Changeset& get_reciprocal_transform(TransformHistory&, file_ident_type local_file_ident, version_type version,
                                         const HistoryEntry&);
     void flush_reciprocal_transform_cache(TransformHistory&);
+
+protected:
+    // A hook which is overriden in tests to dump the changesets
+    virtual void merge_changesets(file_ident_type local_file_ident, util::Span<Changeset> their_changesets,
+                                  // our_changesets is a pointer because these changesets are held by the reciprocal
+                                  // transform cache which is non-contiguous storage.
+                                  util::Span<Changeset*> our_changesets, util::Logger& logger);
 };
-
-} // namespace _impl
-
-
-namespace sync {
 
 class RemoteChangeset {
 public:
@@ -258,7 +235,6 @@ public:
     RemoteChangeset() {}
     RemoteChangeset(version_type rv, version_type lv, ChunkedBinaryData d, timestamp_type ot, file_ident_type fi);
 };
-
 
 void parse_remote_changeset(const RemoteChangeset&, Changeset&);
 

--- a/test/peer.hpp
+++ b/test/peer.hpp
@@ -46,6 +46,7 @@ namespace realm {
 namespace test_util {
 
 using realm::sync::HistoryEntry;
+using realm::sync::RemoteChangeset;
 using realm::sync::SyncReplication;
 using realm::sync::Transformer;
 using realm::sync::TransformHistory;
@@ -71,16 +72,15 @@ public:
     }
 
     version_type integrate_remote_changeset(file_ident_type remote_file_ident, DB& sg,
-                                            const Transformer::RemoteChangeset& changeset,
-                                            util::Logger& replay_logger)
+                                            const RemoteChangeset& changeset, util::Logger& replay_logger)
     {
         std::size_t num_changesets = 1;
         return integrate_remote_changesets(remote_file_ident, sg, &changeset, num_changesets, replay_logger);
     }
 
     version_type integrate_remote_changesets(file_ident_type remote_file_ident, DB&,
-                                             const Transformer::RemoteChangeset* incoming_changesets,
-                                             std::size_t num_changesets, util::Logger& replay_logger);
+                                             const RemoteChangeset* incoming_changesets, std::size_t num_changesets,
+                                             util::Logger& replay_logger);
 
     version_type prepare_changeset(const char* data, std::size_t size, version_type orig_version) override
     {
@@ -462,7 +462,7 @@ private:
 
 
 inline auto ShortCircuitHistory::integrate_remote_changesets(file_ident_type remote_file_ident, DB& sg,
-                                                             const Transformer::RemoteChangeset* incoming_changesets,
+                                                             const RemoteChangeset* incoming_changesets,
                                                              size_t num_changesets, util::Logger& logger)
     -> version_type
 {
@@ -625,7 +625,7 @@ public:
         version_type& last_remote_version = last_remote_versions_integrated[remote.local_file_ident];
         if (last_remote_version == 0)
             last_remote_version = 1;
-        std::unique_ptr<Transformer::RemoteChangeset[]> changesets{new Transformer::RemoteChangeset[num_changesets]};
+        std::unique_ptr<RemoteChangeset[]> changesets{new RemoteChangeset[num_changesets]};
         remote.get_next_changesets_for_remote(local_file_ident, last_remote_version, changesets.get(),
                                               num_changesets);
         /*
@@ -670,7 +670,7 @@ private:
 
     void get_next_changesets_for_remote(file_ident_type remote_file_ident,
                                         version_type last_version_integrated_by_remote,
-                                        Transformer::RemoteChangeset* out_changesets, size_t num_changesets) const
+                                        RemoteChangeset* out_changesets, size_t num_changesets) const
     {
         // At least one transaction can be assumed to have been performed
         REALM_ASSERT(current_version != 0);

--- a/test/test_sync.cpp
+++ b/test/test_sync.cpp
@@ -6696,7 +6696,7 @@ TEST(Sync_NonIncreasingServerVersions)
     ++server_changesets.back().version;
 
     std::vector<ChangesetEncoder::Buffer> encoded;
-    std::vector<Transformer::RemoteChangeset> server_changesets_encoded;
+    std::vector<RemoteChangeset> server_changesets_encoded;
     for (const auto& changeset : server_changesets) {
         encoded.emplace_back();
         encode_changeset(changeset, encoded.back());
@@ -6734,7 +6734,7 @@ TEST(Sync_InvalidChangesetFromServer)
 
     ChangesetEncoder::Buffer encoded;
     encode_changeset(changeset, encoded);
-    Transformer::RemoteChangeset server_changeset;
+    RemoteChangeset server_changeset;
     server_changeset.origin_file_ident = 1;
     server_changeset.remote_version = 1;
     server_changeset.data = BinaryData(encoded.data(), encoded.size());
@@ -6845,7 +6845,7 @@ TEST(Sync_SetAndGetEmptyReciprocalChangeset)
     changeset.origin_file_ident = 2;
 
     ChangesetEncoder::Buffer encoded;
-    std::vector<Transformer::RemoteChangeset> server_changesets_encoded;
+    std::vector<RemoteChangeset> server_changesets_encoded;
     encode_changeset(changeset, encoded);
     server_changesets_encoded.emplace_back(changeset.version, changeset.last_integrated_remote_version,
                                            BinaryData(encoded.data(), encoded.size()), changeset.origin_timestamp,
@@ -6988,7 +6988,7 @@ TEST(Sync_ServerVersionsSkippedFromDownloadCursor)
     server_changeset.origin_file_ident = 1;
 
     std::vector<ChangesetEncoder::Buffer> encoded;
-    std::vector<Transformer::RemoteChangeset> server_changesets_encoded;
+    std::vector<RemoteChangeset> server_changesets_encoded;
     encoded.emplace_back();
     encode_changeset(server_changeset, encoded.back());
     server_changesets_encoded.emplace_back(server_changeset.version, server_changeset.last_integrated_remote_version,

--- a/test/test_sync.cpp
+++ b/test/test_sync.cpp
@@ -5320,30 +5320,15 @@ namespace issue2104 {
 
 class ServerHistoryContext : public _impl::ServerHistory::Context {
 public:
-    ServerHistoryContext()
-        : m_transformer{make_transformer()}
-    {
-    }
+    ServerHistoryContext() {}
 
     std::mt19937_64& server_history_get_random() noexcept override
     {
         return m_random;
     }
 
-    sync::Transformer& get_transformer() override
-    {
-        return *m_transformer;
-    }
-
-    util::Buffer<char>& get_transform_buffer() override
-    {
-        return m_transform_buffer;
-    }
-
 private:
     std::mt19937_64 m_random;
-    std::unique_ptr<sync::Transformer> m_transformer;
-    util::Buffer<char> m_transform_buffer;
 };
 
 } // namespace issue2104

--- a/test/test_sync_pending_bootstraps.cpp
+++ b/test/test_sync_pending_bootstraps.cpp
@@ -19,7 +19,7 @@ TEST(Sync_PendingBootstrapStoreBatching)
         sync::PendingBootstrapStore store(db, *test_context.logger);
 
         CHECK(!store.has_pending());
-        std::vector<Transformer::RemoteChangeset> changesets;
+        std::vector<RemoteChangeset> changesets;
         std::vector<std::string> changeset_data;
 
         changeset_data.emplace_back(1024, 'a');
@@ -117,7 +117,7 @@ TEST(Sync_PendingBootstrapStoreClear)
     sync::PendingBootstrapStore store(db, *test_context.logger);
 
     CHECK(!store.has_pending());
-    std::vector<Transformer::RemoteChangeset> changesets;
+    std::vector<RemoteChangeset> changesets;
     std::vector<std::string> changeset_data;
 
     changeset_data.emplace_back(1024, 'a');


### PR DESCRIPTION
https://github.com/realm/realm-sync/pull/3196 pulled TransformerImpl out of the anonymous namespace and made it extern. This innocent-looking change actually had a meaningful effect: a very, very large number of functions defined by composing templates were no longer inlined out of existence because static functions are inlined more aggressively than extern functions. Moving all of the helper functions back to the anonymous namespace results in transform.o halving in size due to better inlining.

While poking at this I noticed that Transformer's API didn't make any sense any more. It was designed to support Transformer objects holding state between transformations and to hide the implementation type entirely in the cpp file. Neither of these are done any more, so it was just very overcomplicated for no benefit.

This cuts ~150 KB off the obj-c dylib and makes the sync transform benchmark 5-10% faster, which doesn't seem big enough to be worth mentioning in the changelog.