### PR TITLE
Implement the set algebra functions on Mixed

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@
 ### Internals
 * REALM_[ATMU]SAN cmake flags no longer override compilation options and can be combined with Debug|RelWithDebInfo|etc. build types. Rel[ATMU]SAN build type shortcuts are now all slightly optimized debug-based builds with sanitizers. REALM_ASAN now works with msvc (2019/2022) builds. ([PR #6911](https://github.com/realm/realm-core/pull/6911))
 * Remove ArrayWithFind's ability to use a templated callback parameter. The QueryStateBase consumers now use an index and the array leaf to get the actual value if needed. This allows certain queries such as count() to not do as many lookups to the actual values and results in a small performance gain. Also remove `find_action_pattern()` which was unused for a long time. This reduction in templating throughout the query system produces a small (~100k) binary size reduction. ([#7095](https://github.com/realm/realm-core/pull/7095))
+* Rework the implemenatation of the set algrebra functions on Set<T> to reduce the compiled size.
 
 ----------------------------------------------
 

--- a/evergreen/config.yml
+++ b/evergreen/config.yml
@@ -965,6 +965,7 @@ tasks:
             --ignore='src/external/**' \
             --ignore='src/realm/parser/generated/**' \
             --ignore='test/large_tests/**' \
+            --excl-line='LCOV_EXCL_LINE|REALM_TERMINATE|REALM_UNREACHABLE' \
             --parallel \
             --output-path=coveralls_${task_name}.json
 

--- a/src/realm/cluster.cpp
+++ b/src/realm/cluster.cpp
@@ -1392,6 +1392,7 @@ void Cluster::dump_objects(int64_t key_offset, std::string lead) const
                 }
                 case col_type_String: {
                     ArrayString arr(m_alloc);
+                    set_spec(arr, col.get_index());
                     ref_type ref = Array::get_as_ref(j);
                     arr.init_from_ref(ref);
                     std::cout << ", " << arr.get(i);

--- a/src/realm/collection.hpp
+++ b/src/realm/collection.hpp
@@ -124,6 +124,11 @@ public:
         return get_table()->get_column_name(get_col_key());
     }
 
+    // These are shadowed by typed versions in subclasses
+    using value_type = Mixed;
+    CollectionIterator<CollectionBase> begin() const;
+    CollectionIterator<CollectionBase> end() const;
+
 protected:
     friend class Transaction;
     CollectionBase() noexcept = default;
@@ -679,7 +684,12 @@ struct CollectionIterator {
 
     pointer operator->() const
     {
-        m_val = m_list->get(m_ndx);
+        if constexpr (std::is_same_v<L, CollectionBase>) {
+            m_val = m_list->get_any(m_ndx);
+        }
+        else {
+            m_val = m_list->get(m_ndx);
+        }
         return &m_val;
     }
 
@@ -764,6 +774,16 @@ private:
     const L* m_list;
     size_t m_ndx = size_t(-1);
 };
+
+
+inline CollectionIterator<CollectionBase> CollectionBase::begin() const
+{
+    return CollectionIterator<CollectionBase>(this, 0);
+}
+inline CollectionIterator<CollectionBase> CollectionBase::end() const
+{
+    return CollectionIterator<CollectionBase>(this, size());
+}
 
 namespace _impl {
 size_t get_collection_size_from_ref(ref_type, Allocator& alloc);

--- a/src/realm/list.hpp
+++ b/src/realm/list.hpp
@@ -285,9 +285,7 @@ private:
 
     static Mixed unresolved_to_null(Mixed value) noexcept
     {
-        if (value.is_type(type_TypedLink) && value.is_unresolved_link())
-            return Mixed{};
-        return value;
+        return value.is_unresolved_link() ? Mixed{} : value;
     }
     T do_get(size_t ndx, const char* msg) const;
 };

--- a/src/realm/object-store/set.cpp
+++ b/src/realm/object-store/set.cpp
@@ -246,72 +246,52 @@ std::pair<size_t, bool> Set::insert<Obj>(Obj obj)
 
 bool Set::is_subset_of(const Collection& rhs) const
 {
-    return dispatch([&](auto t) {
-        return this->as<std::decay_t<decltype(*t)>>().is_subset_of(rhs.get_impl());
-    });
+    return set_base().is_subset_of(rhs.get_impl());
 }
 
 bool Set::is_strict_subset_of(const Collection& rhs) const
 {
-    return dispatch([&](auto t) {
-        return this->as<std::decay_t<decltype(*t)>>().is_strict_subset_of(rhs.get_impl());
-    });
+    return set_base().is_strict_subset_of(rhs.get_impl());
 }
 
 bool Set::is_superset_of(const Collection& rhs) const
 {
-    return dispatch([&](auto t) {
-        return this->as<std::decay_t<decltype(*t)>>().is_superset_of(rhs.get_impl());
-    });
+    return set_base().is_superset_of(rhs.get_impl());
 }
 
 bool Set::is_strict_superset_of(const Collection& rhs) const
 {
-    return dispatch([&](auto t) {
-        return this->as<std::decay_t<decltype(*t)>>().is_strict_superset_of(rhs.get_impl());
-    });
+    return set_base().is_strict_superset_of(rhs.get_impl());
 }
 
 bool Set::intersects(const Collection& rhs) const
 {
-    return dispatch([&](auto t) {
-        return this->as<std::decay_t<decltype(*t)>>().intersects(rhs.get_impl());
-    });
+    return set_base().intersects(rhs.get_impl());
 }
 
 bool Set::set_equals(const Collection& rhs) const
 {
-    return dispatch([&](auto t) {
-        return this->as<std::decay_t<decltype(*t)>>().set_equals(rhs.get_impl());
-    });
+    return set_base().set_equals(rhs.get_impl());
 }
 
 void Set::assign_intersection(const Collection& rhs)
 {
-    return dispatch([&](auto t) {
-        return this->as<std::decay_t<decltype(*t)>>().assign_intersection(rhs.get_impl());
-    });
+    set_base().assign_intersection(rhs.get_impl());
 }
 
 void Set::assign_union(const Collection& rhs)
 {
-    return dispatch([&](auto t) {
-        return this->as<std::decay_t<decltype(*t)>>().assign_union(rhs.get_impl());
-    });
+    set_base().assign_union(rhs.get_impl());
 }
 
 void Set::assign_difference(const Collection& rhs)
 {
-    return dispatch([&](auto t) {
-        return this->as<std::decay_t<decltype(*t)>>().assign_difference(rhs.get_impl());
-    });
+    set_base().assign_difference(rhs.get_impl());
 }
 
 void Set::assign_symmetric_difference(const Collection& rhs)
 {
-    return dispatch([&](auto t) {
-        return this->as<std::decay_t<decltype(*t)>>().assign_symmetric_difference(rhs.get_impl());
-    });
+    set_base().assign_symmetric_difference(rhs.get_impl());
 }
 
 } // namespace realm::object_store

--- a/src/realm/set.cpp
+++ b/src/realm/set.cpp
@@ -176,16 +176,185 @@ void SetBase::clear_repl(Replication* repl) const
     repl->set_clear(*this);
 }
 
-std::vector<Mixed> SetBase::convert_to_mixed_set(const CollectionBase& rhs)
+static std::vector<Mixed> convert_to_set(const CollectionBase& rhs)
 {
-    std::vector<Mixed> mixed;
-    mixed.reserve(rhs.size());
-    for (size_t i = 0; i < rhs.size(); i++) {
-        mixed.push_back(rhs.get_any(i));
-    }
+    std::vector<Mixed> mixed(rhs.begin(), rhs.end());
     std::sort(mixed.begin(), mixed.end(), SetElementLessThan<Mixed>());
     mixed.erase(std::unique(mixed.begin(), mixed.end()), mixed.end());
     return mixed;
+}
+
+bool SetBase::is_subset_of(const CollectionBase& rhs) const
+{
+    if (auto other_set = dynamic_cast<const SetBase*>(&rhs)) {
+        return is_subset_of(other_set->begin(), other_set->end());
+    }
+    auto other_set = convert_to_set(rhs);
+    return is_subset_of(other_set.begin(), other_set.end());
+}
+
+template <class It1, class It2>
+bool SetBase::is_subset_of(It1 first, It2 last) const
+{
+    return std::includes(first, last, begin(), end(), SetElementLessThan<Mixed>{});
+}
+
+bool SetBase::is_strict_subset_of(const CollectionBase& rhs) const
+{
+    if (auto other_set = dynamic_cast<const SetBase*>(&rhs)) {
+        return size() != rhs.size() && is_subset_of(other_set->begin(), other_set->end());
+    }
+    auto other_set = convert_to_set(rhs);
+    return size() != other_set.size() && is_subset_of(other_set.begin(), other_set.end());
+}
+
+bool SetBase::is_superset_of(const CollectionBase& rhs) const
+{
+    if (auto other_set = dynamic_cast<const SetBase*>(&rhs)) {
+        return is_superset_of(other_set->begin(), other_set->end());
+    }
+    auto other_set = convert_to_set(rhs);
+    return is_superset_of(other_set.begin(), other_set.end());
+}
+
+template <class It1, class It2>
+bool SetBase::is_superset_of(It1 first, It2 last) const
+{
+    return std::includes(begin(), end(), first, last, SetElementLessThan<Mixed>{});
+}
+
+bool SetBase::is_strict_superset_of(const CollectionBase& rhs) const
+{
+    if (auto other_set = dynamic_cast<const SetBase*>(&rhs)) {
+        return size() != rhs.size() && is_superset_of(other_set->begin(), other_set->end());
+    }
+    auto other_set = convert_to_set(rhs);
+    return size() != other_set.size() && is_superset_of(other_set.begin(), other_set.end());
+}
+
+bool SetBase::intersects(const CollectionBase& rhs) const
+{
+    if (auto other_set = dynamic_cast<const SetBase*>(&rhs)) {
+        return intersects(other_set->begin(), other_set->end());
+    }
+    auto other_set = convert_to_set(rhs);
+    return intersects(other_set.begin(), other_set.end());
+}
+
+template <class It1, class It2>
+bool SetBase::intersects(It1 first, It2 last) const
+{
+    SetElementLessThan<Mixed> less;
+    auto it = begin();
+    while (it != end() && first != last) {
+        if (less(*it, *first)) {
+            ++it;
+        }
+        else if (less(*first, *it)) {
+            ++first;
+        }
+        else {
+            return true;
+        }
+    }
+    return false;
+}
+
+bool SetBase::set_equals(const CollectionBase& rhs) const
+{
+    if (auto other_set = dynamic_cast<const SetBase*>(&rhs)) {
+        return size() == rhs.size() && is_subset_of(other_set->begin(), other_set->end());
+    }
+    auto other_set = convert_to_set(rhs);
+    return size() == other_set.size() && is_subset_of(other_set.begin(), other_set.end());
+}
+
+void SetBase::assign_union(const CollectionBase& rhs)
+{
+    if (auto other_set = dynamic_cast<const SetBase*>(&rhs)) {
+        return assign_union(other_set->begin(), other_set->end());
+    }
+    auto other_set = convert_to_set(rhs);
+    return assign_union(other_set.begin(), other_set.end());
+}
+
+template <class It1, class It2>
+void SetBase::assign_union(It1 first, It2 last)
+{
+    std::vector<Mixed> the_diff;
+    std::set_difference(first, last, begin(), end(), std::back_inserter(the_diff), SetElementLessThan<Mixed>{});
+    // 'the_diff' now contains all the elements that are in foreign set, but not in 'this'
+    // Now insert those elements
+    for (auto&& value : the_diff) {
+        insert_any(value);
+    }
+}
+
+void SetBase::assign_intersection(const CollectionBase& rhs)
+{
+    if (auto other_set = dynamic_cast<const SetBase*>(&rhs)) {
+        return assign_intersection(other_set->begin(), other_set->end());
+    }
+    auto other_set = convert_to_set(rhs);
+    return assign_intersection(other_set.begin(), other_set.end());
+}
+
+template <class It1, class It2>
+void SetBase::assign_intersection(It1 first, It2 last)
+{
+    std::vector<Mixed> intersection;
+    std::set_intersection(first, last, begin(), end(), std::back_inserter(intersection), SetElementLessThan<Mixed>{});
+    clear();
+    // Elements in intersection comes from foreign set, so ok to use here
+    for (auto&& value : intersection) {
+        insert_any(value);
+    }
+}
+
+void SetBase::assign_difference(const CollectionBase& rhs)
+{
+    if (auto other_set = dynamic_cast<const SetBase*>(&rhs)) {
+        return assign_difference(other_set->begin(), other_set->end());
+    }
+    auto other_set = convert_to_set(rhs);
+    return assign_difference(other_set.begin(), other_set.end());
+}
+
+template <class It1, class It2>
+void SetBase::assign_difference(It1 first, It2 last)
+{
+    std::vector<Mixed> intersection;
+    std::set_intersection(first, last, begin(), end(), std::back_inserter(intersection), SetElementLessThan<Mixed>{});
+    // 'intersection' now contains all the elements that are in both foreign set and 'this'.
+    // Remove those elements. The elements comes from the foreign set, so ok to refer to.
+    for (auto&& value : intersection) {
+        erase_any(value);
+    }
+}
+
+void SetBase::assign_symmetric_difference(const CollectionBase& rhs)
+{
+    if (auto other_set = dynamic_cast<const SetBase*>(&rhs)) {
+        return assign_symmetric_difference(other_set->begin(), other_set->end());
+    }
+    auto other_set = convert_to_set(rhs);
+    return assign_symmetric_difference(other_set.begin(), other_set.end());
+}
+
+template <class It1, class It2>
+void SetBase::assign_symmetric_difference(It1 first, It2 last)
+{
+    std::vector<Mixed> difference;
+    std::set_difference(first, last, begin(), end(), std::back_inserter(difference), SetElementLessThan<Mixed>{});
+    std::vector<Mixed> intersection;
+    std::set_intersection(first, last, begin(), end(), std::back_inserter(intersection), SetElementLessThan<Mixed>{});
+    // Now remove the common elements and add the differences
+    for (auto&& value : intersection) {
+        erase_any(value);
+    }
+    for (auto&& value : difference) {
+        insert_any(value);
+    }
 }
 
 template <>
@@ -335,36 +504,6 @@ void LnkSet::remove_all_target_rows()
     if (m_set.update()) {
         _impl::TableFriend::batch_erase_rows(*get_target_table(), m_set.tree());
     }
-}
-
-bool LnkSet::is_subset_of(const CollectionBase& rhs) const
-{
-    return this->m_set.is_subset_of(rhs);
-}
-
-bool LnkSet::is_strict_subset_of(const CollectionBase& rhs) const
-{
-    return this->m_set.is_strict_subset_of(rhs);
-}
-
-bool LnkSet::is_superset_of(const CollectionBase& rhs) const
-{
-    return this->m_set.is_superset_of(rhs);
-}
-
-bool LnkSet::is_strict_superset_of(const CollectionBase& rhs) const
-{
-    return this->m_set.is_strict_superset_of(rhs);
-}
-
-bool LnkSet::intersects(const CollectionBase& rhs) const
-{
-    return this->m_set.intersects(rhs);
-}
-
-bool LnkSet::set_equals(const CollectionBase& rhs) const
-{
-    return this->m_set.set_equals(rhs);
 }
 
 void set_sorted_indices(size_t sz, std::vector<size_t>& indices, bool ascending)

--- a/src/realm/set.hpp
+++ b/src/realm/set.hpp
@@ -24,7 +24,6 @@
 #include <realm/array_key.hpp>
 
 namespace realm {
-
 class SetBase : public CollectionBase {
 public:
     using CollectionBase::CollectionBase;
@@ -39,19 +38,51 @@ public:
     virtual std::pair<size_t, bool> insert_any(Mixed value) = 0;
     virtual std::pair<size_t, bool> erase_any(Mixed value) = 0;
 
+    bool is_subset_of(const CollectionBase&) const;
+    bool is_strict_subset_of(const CollectionBase& rhs) const;
+    bool is_superset_of(const CollectionBase& rhs) const;
+    bool is_strict_superset_of(const CollectionBase& rhs) const;
+    bool intersects(const CollectionBase& rhs) const;
+    bool set_equals(const CollectionBase& rhs) const;
+    void assign_union(const CollectionBase&);
+    void assign_intersection(const CollectionBase&);
+    void assign_difference(const CollectionBase&);
+    void assign_symmetric_difference(const CollectionBase&);
+
 protected:
     mutable std::unique_ptr<BPlusTreeBase> m_tree;
 
     void insert_repl(Replication* repl, size_t index, Mixed value) const;
     void erase_repl(Replication* repl, size_t index, Mixed value) const;
     void clear_repl(Replication* repl) const;
-    static std::vector<Mixed> convert_to_mixed_set(const CollectionBase& rhs);
 
     REALM_COLD REALM_NORETURN void throw_invalid_null()
     {
         throw InvalidArgument(ErrorCodes::PropertyNotNullable,
                               util::format("Set: %1", CollectionBase::get_property_name()));
     }
+
+private:
+    template <class It1, class It2>
+    bool is_subset_of(It1, It2) const;
+
+    template <class It1, class It2>
+    bool is_superset_of(It1, It2) const;
+
+    template <class It1, class It2>
+    bool intersects(It1, It2) const;
+
+    template <class It1, class It2>
+    void assign_union(It1, It2);
+
+    template <class It1, class It2>
+    void assign_intersection(It1, It2);
+
+    template <class It1, class It2>
+    void assign_difference(It1, It2);
+
+    template <class It1, class It2>
+    void assign_symmetric_difference(It1, It2);
 };
 
 template <class T>
@@ -103,17 +134,6 @@ public:
             func(found);
         }
     }
-
-    bool is_subset_of(const CollectionBase&) const;
-    bool is_strict_subset_of(const CollectionBase& rhs) const;
-    bool is_superset_of(const CollectionBase& rhs) const;
-    bool is_strict_superset_of(const CollectionBase& rhs) const;
-    bool intersects(const CollectionBase& rhs) const;
-    bool set_equals(const CollectionBase& rhs) const;
-    void assign_union(const CollectionBase&);
-    void assign_intersection(const CollectionBase&);
-    void assign_difference(const CollectionBase&);
-    void assign_symmetric_difference(const CollectionBase&);
 
     /// Insert a value into the set if it does not already exist, returning the index of the inserted value,
     /// or the index of the already-existing value.
@@ -191,29 +211,6 @@ private:
     void do_clear();
 
     iterator find_impl(const T& value) const;
-
-    template <class It1, class It2>
-    bool is_subset_of(It1, It2) const;
-
-    template <class It1, class It2>
-    bool is_superset_of(It1, It2) const;
-
-    template <class It1, class It2>
-    bool intersects(It1, It2) const;
-
-    template <class It1, class It2>
-    void assign_union(It1, It2);
-
-    template <class It1, class It2>
-    void assign_intersection(It1, It2);
-
-    template <class It1, class It2>
-    void assign_difference(It1, It2);
-
-    template <class It1, class It2>
-    void assign_symmetric_difference(It1, It2);
-
-    static std::vector<T> convert_to_set(const CollectionBase& rhs, bool nullable);
 };
 
 class LnkSet final : public ObjCollectionBase<SetBase> {
@@ -240,17 +237,6 @@ public:
     size_t find_first(ObjKey) const;
     std::pair<size_t, bool> insert(ObjKey);
     std::pair<size_t, bool> erase(ObjKey);
-
-    bool is_subset_of(const CollectionBase&) const;
-    bool is_strict_subset_of(const CollectionBase& rhs) const;
-    bool is_superset_of(const CollectionBase& rhs) const;
-    bool is_strict_superset_of(const CollectionBase& rhs) const;
-    bool intersects(const CollectionBase& rhs) const;
-    bool set_equals(const CollectionBase& rhs) const;
-    void assign_union(const CollectionBase&);
-    void assign_intersection(const CollectionBase&);
-    void assign_difference(const CollectionBase&);
-    void assign_symmetric_difference(const CollectionBase&);
 
     // Overriding members of CollectionBase:
     using CollectionBase::get_owner_key;
@@ -790,225 +776,6 @@ inline void Set<T>::do_clear()
     m_tree->clear();
 }
 
-template <class T>
-std::vector<T> Set<T>::convert_to_set(const CollectionBase& rhs, bool nullable)
-{
-    if constexpr (std::is_same_v<T, Mixed>) {
-        return SetBase::convert_to_mixed_set(rhs);
-    }
-
-    std::vector<Mixed> mixed = SetBase::convert_to_mixed_set(rhs);
-    std::vector<T> ret;
-    ret.reserve(mixed.size());
-    for (auto&& val : mixed) {
-        if constexpr (std::is_same_v<T, ObjKey>) {
-            static_cast<void>(nullable);
-            if (val.is_type(type_Link, type_TypedLink)) {
-                ret.push_back(val.get<ObjKey>());
-            }
-        }
-        else {
-            if (val.is_type(ColumnTypeTraits<T>::id)) {
-                ret.push_back(val.get<T>());
-            }
-            else if (val.is_null() && nullable) {
-                ret.push_back(BPlusTree<T>::default_value(true));
-            }
-        }
-    }
-    return ret;
-}
-
-template <class T>
-bool Set<T>::is_subset_of(const CollectionBase& rhs) const
-{
-    if (auto other_set = dynamic_cast<const Set<T>*>(&rhs)) {
-        return is_subset_of(other_set->begin(), other_set->end());
-    }
-    auto other_set = convert_to_set(rhs, m_nullable);
-    return is_subset_of(other_set.begin(), other_set.end());
-}
-
-template <class T>
-template <class It1, class It2>
-bool Set<T>::is_subset_of(It1 first, It2 last) const
-{
-    return std::includes(first, last, begin(), end(), SetElementLessThan<T>{});
-}
-
-template <class T>
-bool Set<T>::is_strict_subset_of(const CollectionBase& rhs) const
-{
-    if (auto other_set = dynamic_cast<const Set<T>*>(&rhs)) {
-        return size() != rhs.size() && is_subset_of(other_set->begin(), other_set->end());
-    }
-    auto other_set = convert_to_set(rhs, m_nullable);
-    return size() != other_set.size() && is_subset_of(other_set.begin(), other_set.end());
-}
-
-template <class T>
-bool Set<T>::is_superset_of(const CollectionBase& rhs) const
-{
-    if (auto other_set = dynamic_cast<const Set<T>*>(&rhs)) {
-        return is_superset_of(other_set->begin(), other_set->end());
-    }
-    auto other_set = convert_to_set(rhs, m_nullable);
-    return is_superset_of(other_set.begin(), other_set.end());
-}
-
-template <class T>
-template <class It1, class It2>
-bool Set<T>::is_superset_of(It1 first, It2 last) const
-{
-    return std::includes(begin(), end(), first, last, SetElementLessThan<T>{});
-}
-
-template <class T>
-bool Set<T>::is_strict_superset_of(const CollectionBase& rhs) const
-{
-    if (auto other_set = dynamic_cast<const Set<T>*>(&rhs)) {
-        return size() != rhs.size() && is_superset_of(other_set->begin(), other_set->end());
-    }
-    auto other_set = convert_to_set(rhs, m_nullable);
-    return size() != other_set.size() && is_superset_of(other_set.begin(), other_set.end());
-}
-
-template <class T>
-bool Set<T>::intersects(const CollectionBase& rhs) const
-{
-    if (auto other_set = dynamic_cast<const Set<T>*>(&rhs)) {
-        return intersects(other_set->begin(), other_set->end());
-    }
-    auto other_set = convert_to_set(rhs, m_nullable);
-    return intersects(other_set.begin(), other_set.end());
-}
-
-template <class T>
-template <class It1, class It2>
-bool Set<T>::intersects(It1 first, It2 last) const
-{
-    SetElementLessThan<T> less;
-    auto it = begin();
-    while (it != end() && first != last) {
-        if (less(*it, *first)) {
-            ++it;
-        }
-        else if (less(*first, *it)) {
-            ++first;
-        }
-        else {
-            return true;
-        }
-    }
-    return false;
-}
-
-template <class T>
-bool Set<T>::set_equals(const CollectionBase& rhs) const
-{
-    if (auto other_set = dynamic_cast<const Set<T>*>(&rhs)) {
-        return size() == rhs.size() && is_subset_of(other_set->begin(), other_set->end());
-    }
-    auto other_set = convert_to_set(rhs, m_nullable);
-    return size() == other_set.size() && is_subset_of(other_set.begin(), other_set.end());
-}
-
-template <class T>
-inline void Set<T>::assign_union(const CollectionBase& rhs)
-{
-    if (auto other_set = dynamic_cast<const Set<T>*>(&rhs)) {
-        return assign_union(other_set->begin(), other_set->end());
-    }
-    auto other_set = convert_to_set(rhs, m_nullable);
-    return assign_union(other_set.begin(), other_set.end());
-}
-
-template <class T>
-template <class It1, class It2>
-void Set<T>::assign_union(It1 first, It2 last)
-{
-    std::vector<T> the_diff;
-    std::set_difference(first, last, begin(), end(), std::back_inserter(the_diff), SetElementLessThan<T>{});
-    // 'the_diff' now contains all the elements that are in foreign set, but not in 'this'
-    // Now insert those elements
-    for (auto&& value : the_diff) {
-        insert(value);
-    }
-}
-
-template <class T>
-inline void Set<T>::assign_intersection(const CollectionBase& rhs)
-{
-    if (auto other_set = dynamic_cast<const Set<T>*>(&rhs)) {
-        return assign_intersection(other_set->begin(), other_set->end());
-    }
-    auto other_set = convert_to_set(rhs, m_nullable);
-    return assign_intersection(other_set.begin(), other_set.end());
-}
-
-template <class T>
-template <class It1, class It2>
-void Set<T>::assign_intersection(It1 first, It2 last)
-{
-    std::vector<T> intersection;
-    std::set_intersection(first, last, begin(), end(), std::back_inserter(intersection), SetElementLessThan<T>{});
-    clear();
-    // Elements in intersection comes from foreign set, so ok to use here
-    for (auto&& value : intersection) {
-        insert(value);
-    }
-}
-
-template <class T>
-inline void Set<T>::assign_difference(const CollectionBase& rhs)
-{
-    if (auto other_set = dynamic_cast<const Set<T>*>(&rhs)) {
-        return assign_difference(other_set->begin(), other_set->end());
-    }
-    auto other_set = convert_to_set(rhs, m_nullable);
-    return assign_difference(other_set.begin(), other_set.end());
-}
-
-template <class T>
-template <class It1, class It2>
-void Set<T>::assign_difference(It1 first, It2 last)
-{
-    std::vector<T> intersection;
-    std::set_intersection(first, last, begin(), end(), std::back_inserter(intersection), SetElementLessThan<T>{});
-    // 'intersection' now contains all the elements that are in both foreign set and 'this'.
-    // Remove those elements. The elements comes from the foreign set, so ok to refer to.
-    for (auto&& value : intersection) {
-        erase(value);
-    }
-}
-
-template <class T>
-inline void Set<T>::assign_symmetric_difference(const CollectionBase& rhs)
-{
-    if (auto other_set = dynamic_cast<const Set<T>*>(&rhs)) {
-        return assign_symmetric_difference(other_set->begin(), other_set->end());
-    }
-    auto other_set = convert_to_set(rhs, m_nullable);
-    return assign_symmetric_difference(other_set.begin(), other_set.end());
-}
-
-template <class T>
-template <class It1, class It2>
-void Set<T>::assign_symmetric_difference(It1 first, It2 last)
-{
-    std::vector<T> difference;
-    std::set_difference(first, last, begin(), end(), std::back_inserter(difference), SetElementLessThan<T>{});
-    std::vector<T> intersection;
-    std::set_intersection(first, last, begin(), end(), std::back_inserter(intersection), SetElementLessThan<T>{});
-    // Now remove the common elements and add the differences
-    for (auto&& value : intersection) {
-        erase(value);
-    }
-    for (auto&& value : difference) {
-        insert(value);
-    }
-}
-
 inline bool LnkSet::operator==(const LnkSet& other) const
 {
     return m_set == other.m_set;
@@ -1257,30 +1024,6 @@ inline Obj LnkSet::get_object(size_t ndx) const
 inline ObjKey LnkSet::get_key(size_t ndx) const
 {
     return get(ndx);
-}
-
-inline void LnkSet::assign_union(const CollectionBase& rhs)
-{
-    m_set.assign_union(rhs);
-    update_unresolved(UpdateStatus::Updated);
-}
-
-inline void LnkSet::assign_intersection(const CollectionBase& rhs)
-{
-    m_set.assign_intersection(rhs);
-    update_unresolved(UpdateStatus::Updated);
-}
-
-inline void LnkSet::assign_difference(const CollectionBase& rhs)
-{
-    m_set.assign_difference(rhs);
-    update_unresolved(UpdateStatus::Updated);
-}
-
-inline void LnkSet::assign_symmetric_difference(const CollectionBase& rhs)
-{
-    m_set.assign_symmetric_difference(rhs);
-    update_unresolved(UpdateStatus::Updated);
 }
 
 } // namespace realm

--- a/src/realm/set.hpp
+++ b/src/realm/set.hpp
@@ -23,15 +23,16 @@
 #include <realm/bplustree.hpp>
 #include <realm/array_key.hpp>
 
-#include <numeric> // std::iota
-
 namespace realm {
 
 class SetBase : public CollectionBase {
 public:
     using CollectionBase::CollectionBase;
+    SetBase(const SetBase& other);
+    SetBase(SetBase&& other) noexcept;
+    SetBase& operator=(const SetBase& other);
+    SetBase& operator=(SetBase&& other) noexcept;
 
-    virtual ~SetBase() {}
     virtual SetBasePtr clone() const = 0;
     virtual std::pair<size_t, bool> insert_null() = 0;
     virtual std::pair<size_t, bool> erase_null() = 0;
@@ -39,10 +40,18 @@ public:
     virtual std::pair<size_t, bool> erase_any(Mixed value) = 0;
 
 protected:
+    mutable std::unique_ptr<BPlusTreeBase> m_tree;
+
     void insert_repl(Replication* repl, size_t index, Mixed value) const;
     void erase_repl(Replication* repl, size_t index, Mixed value) const;
     void clear_repl(Replication* repl) const;
     static std::vector<Mixed> convert_to_mixed_set(const CollectionBase& rhs);
+
+    REALM_COLD REALM_NORETURN void throw_invalid_null()
+    {
+        throw InvalidArgument(ErrorCodes::PropertyNotNullable,
+                              util::format("Set: %1", CollectionBase::get_property_name()));
+    }
 };
 
 template <class T>
@@ -68,7 +77,7 @@ public:
     {
         const auto current_size = size();
         CollectionBase::validate_index("get()", ndx, current_size);
-        return m_tree->get(ndx);
+        return tree().get(ndx);
     }
 
     iterator begin() const noexcept
@@ -144,55 +153,11 @@ public:
 
     const BPlusTree<T>& get_tree() const
     {
-        return *m_tree;
+        return tree();
     }
 
-    UpdateStatus update_if_needed() const final
-    {
-        auto status = Base::update_if_needed();
-        switch (status) {
-            case UpdateStatus::Detached: {
-                m_tree.reset();
-                return UpdateStatus::Detached;
-            }
-            case UpdateStatus::NoChange:
-                if (m_tree && m_tree->is_attached()) {
-                    return UpdateStatus::NoChange;
-                }
-                // The tree has not been initialized yet for this accessor, so
-                // perform lazy initialization by treating it as an update.
-                [[fallthrough]];
-            case UpdateStatus::Updated: {
-                bool attached = init_from_parent(false);
-                return attached ? UpdateStatus::Updated : UpdateStatus::Detached;
-            }
-        }
-        REALM_UNREACHABLE();
-    }
-
-    UpdateStatus ensure_created() final
-    {
-        auto status = Base::ensure_created();
-        switch (status) {
-            case UpdateStatus::Detached:
-                break; // Not possible (would have thrown earlier).
-            case UpdateStatus::NoChange: {
-                if (m_tree && m_tree->is_attached()) {
-                    return UpdateStatus::NoChange;
-                }
-                // The tree has not been initialized yet for this accessor, so
-                // perform lazy initialization by treating it as an update.
-                [[fallthrough]];
-            }
-            case UpdateStatus::Updated: {
-                bool attached = init_from_parent(true);
-                REALM_ASSERT(attached);
-                return attached ? UpdateStatus::Updated : UpdateStatus::Detached;
-            }
-        }
-
-        REALM_UNREACHABLE();
-    }
+    UpdateStatus update_if_needed() const final;
+    UpdateStatus ensure_created() final;
 
     void migrate();
 
@@ -201,37 +166,17 @@ private:
     // `ObjCollectionBase::get_mutable_tree()`.
     friend class LnkSet;
 
-    // BPlusTree must be wrapped in an `std::unique_ptr` because it is not
-    // default-constructible, due to its `Allocator&` member.
-    mutable std::unique_ptr<BPlusTree<T>> m_tree;
-
     using Base::bump_content_version;
     using Base::m_col_key;
     using Base::m_nullable;
     using Base::m_obj;
 
-    bool init_from_parent(bool allow_create) const
+    BPlusTree<T>& tree() const
     {
-        if (!m_tree) {
-            m_tree.reset(new BPlusTree<T>(m_obj.get_alloc()));
-            const ArrayParent* parent = this;
-            m_tree->set_parent(const_cast<ArrayParent*>(parent), 0);
-        }
-
-        if (m_tree->init_from_parent()) {
-            // All is well
-            return true;
-        }
-
-        if (!allow_create) {
-            return false;
-        }
-
-        // The ref in the column was NULL, create the tree in place.
-        m_tree->create();
-        REALM_ASSERT(m_tree->is_attached());
-        return true;
+        return static_cast<BPlusTree<T>&>(*m_tree);
     }
+
+    bool init_from_parent(bool allow_create) const;
 
     /// Update the accessor and return true if it is attached after the update.
     inline bool update() const
@@ -395,7 +340,7 @@ private:
 
     BPlusTree<ObjKey>* get_mutable_tree() const final
     {
-        return m_set.m_tree.get();
+        return &m_set.tree();
     }
 };
 
@@ -516,6 +461,38 @@ inline Set<T>::Set(const Obj& obj, ColKey col_key)
     check_column_type<value_type>(m_col_key);
 }
 
+inline SetBase::SetBase(const SetBase& other)
+    : CollectionBase(other)
+{
+    // Note: does not copy m_tree and instead that's initialized on demand
+}
+
+inline SetBase::SetBase(SetBase&& other) noexcept
+    : CollectionBase(std::move(other))
+    , m_tree(std::exchange(other.m_tree, nullptr))
+{
+}
+
+inline SetBase& SetBase::operator=(const SetBase& other)
+{
+    if (this != &other) {
+        // Just reset the pointer and rely on init_from_parent() being called
+        // when the accessor is actually used.
+        m_tree.reset();
+    }
+
+    return *this;
+}
+
+inline SetBase& SetBase::operator=(SetBase&& other) noexcept
+{
+    if (this != &other) {
+        m_tree = std::exchange(other.m_tree, nullptr);
+    }
+
+    return *this;
+}
+
 template <class T>
 inline Set<T>::Set(const Set& other)
     : Base(static_cast<const Base&>(other))
@@ -528,7 +505,6 @@ inline Set<T>::Set(const Set& other)
 template <class T>
 inline Set<T>::Set(Set&& other) noexcept
     : Base(static_cast<Base&&>(other))
-    , m_tree(std::exchange(other.m_tree, nullptr))
 {
     if (m_tree) {
         m_tree->set_parent(this, 0);
@@ -543,7 +519,6 @@ inline Set<T>& Set<T>::operator=(const Set& other)
     if (this != &other) {
         // Just reset the pointer and rely on init_from_parent() being called
         // when the accessor is actually used.
-        m_tree.reset();
         Base::reset_content_version();
     }
 
@@ -556,7 +531,6 @@ inline Set<T>& Set<T>::operator=(Set&& other) noexcept
     Base::operator=(static_cast<Base&&>(other));
 
     if (this != &other) {
-        m_tree = std::exchange(other.m_tree, nullptr);
         if (m_tree) {
             m_tree->set_parent(this, 0);
             // Note: We do not need to call reset_content_version(), because we
@@ -566,6 +540,7 @@ inline Set<T>& Set<T>::operator=(Set&& other) noexcept
 
     return *this;
 }
+
 
 template <typename U>
 Set<U> Obj::get_set(ColKey col_key) const
@@ -634,15 +609,13 @@ REALM_NOINLINE auto Set<T>::find_impl(const T& value) const -> iterator
 template <class T>
 std::pair<size_t, bool> Set<T>::insert(T value)
 {
+    if (!m_nullable && value_is_null(value))
+        throw_invalid_null();
+
     update_if_needed();
-
-    if (value_is_null(value) && !m_nullable)
-        throw InvalidArgument(ErrorCodes::PropertyNotNullable,
-                              util::format("Set: %1", CollectionBase::get_property_name()));
-
     ensure_created();
-    auto it = find_impl(value);
 
+    auto it = find_impl(value);
     if (it != this->end() && SetElementEquals<T>{}(*it, value)) {
         return {it.index(), false};
     }
@@ -748,7 +721,7 @@ template <class T>
 inline util::Optional<Mixed> Set<T>::min(size_t* return_ndx) const
 {
     if (update()) {
-        return MinHelper<T>::eval(*m_tree, return_ndx);
+        return MinHelper<T>::eval(tree(), return_ndx);
     }
     return MinHelper<T>::not_found(return_ndx);
 }
@@ -757,7 +730,7 @@ template <class T>
 inline util::Optional<Mixed> Set<T>::max(size_t* return_ndx) const
 {
     if (update()) {
-        return MaxHelper<T>::eval(*m_tree, return_ndx);
+        return MaxHelper<T>::eval(tree(), return_ndx);
     }
     return MaxHelper<T>::not_found(return_ndx);
 }
@@ -766,7 +739,7 @@ template <class T>
 inline util::Optional<Mixed> Set<T>::sum(size_t* return_cnt) const
 {
     if (update()) {
-        return SumHelper<T>::eval(*m_tree, return_cnt);
+        return SumHelper<T>::eval(tree(), return_cnt);
     }
     return SumHelper<T>::not_found(return_cnt);
 }
@@ -775,12 +748,12 @@ template <class T>
 inline util::Optional<Mixed> Set<T>::avg(size_t* return_cnt) const
 {
     if (update()) {
-        return AverageHelper<T>::eval(*m_tree, return_cnt);
+        return AverageHelper<T>::eval(tree(), return_cnt);
     }
     return AverageHelper<T>::not_found(return_cnt);
 }
 
-void set_sorted_indices(size_t sz, std::vector<size_t>& indices, bool ascending);
+REALM_NOINLINE void set_sorted_indices(size_t sz, std::vector<size_t>& indices, bool ascending);
 
 template <class T>
 inline void Set<T>::sort(std::vector<size_t>& indices, bool ascending) const
@@ -793,16 +766,16 @@ template <>
 void Set<Mixed>::sort(std::vector<size_t>& indices, bool ascending) const;
 
 template <class T>
-inline void Set<T>::distinct(std::vector<size_t>& indices, util::Optional<bool> sort_order) const
+void Set<T>::distinct(std::vector<size_t>& indices, util::Optional<bool> sort_order) const
 {
     auto ascending = !sort_order || *sort_order;
-    sort(indices, ascending);
+    set_sorted_indices(size(), indices, ascending);
 }
 
 template <class T>
 inline void Set<T>::do_insert(size_t ndx, T value)
 {
-    m_tree->insert(ndx, value);
+    tree().insert(ndx, value);
 }
 
 template <class T>
@@ -1053,7 +1026,7 @@ inline ObjKey LnkSet::get(size_t ndx) const
         throw OutOfBounds(util::format("Invalid index into set: %1", CollectionBase::get_property_name()), ndx,
                           current_size);
     }
-    return m_set.m_tree->get(virtual2real(ndx));
+    return m_set.tree().get(virtual2real(ndx));
 }
 
 inline size_t LnkSet::find(ObjKey value) const

--- a/test/object-store/audit.cpp
+++ b/test/object-store/audit.cpp
@@ -1372,7 +1372,7 @@ TEST_CASE("audit management", "[sync][pbs][audit]") {
     SECTION("custom audit event") {
         // Verify that each of the completion handlers is called in the expected order
         std::atomic<size_t> completions = 0;
-        std::array<std::pair<size_t, bool>, 5> completion_results;
+        std::array<std::pair<std::atomic<size_t>, std::atomic<bool>>, 5> completion_results;
         auto expect_completion = [&](size_t expected) {
             return [&, expected](std::exception_ptr e) {
                 completion_results[expected].second = bool(e);

--- a/test/object-store/set.cpp
+++ b/test/object-store/set.cpp
@@ -1138,6 +1138,10 @@ TEMPLATE_TEST_CASE("set", "[set]", CreateNewSet<void>, ReuseSet<void>)
         REQUIRE(set2().is_valid());
         CHECK(set2().size() == 3);
 
+        SECTION("set is a superset of set2") {
+            REQUIRE(set().is_superset_of(set2()));
+            REQUIRE_FALSE(set2().is_superset_of(set()));
+        }
         SECTION("set2 is a subset of set") {
             REQUIRE(set2().is_subset_of(set()));
             REQUIRE_FALSE(set().is_subset_of(set2()));

--- a/test/test_set.cpp
+++ b/test/test_set.cpp
@@ -377,7 +377,10 @@ TEST_TYPES(Set_Types, Prop<Int>, Prop<String>, Prop<Float>, Prop<Double>, Prop<T
             s.insert(v);
             l.add(v);
         }
-        CHECK_EQUAL(s.size(), values.size());
+        auto sz = values.size();
+        CHECK_EQUAL(s.size(), sz);
+        auto s1 = s;
+        CHECK_EQUAL(s1.size(), sz);
         CHECK(s.set_equals(l));
         for (auto v : values) {
             auto ndx = s.find(v);


### PR DESCRIPTION
It turned out that the set algebra functions on Set<T> were a full 5% of the compiled core library. Doing set algebra on Mixed instead will make them slightly slower, but they weren't particularly optimized to begin with. If it turns out that anyone cares about the performance of these, we could do something much faster for Set<Int>. This cuts ~700 kB off the obj-c dylib and is a net simplification of the code.