### PR TITLE
Fix validate-installed-headers test

### DIFF
--- a/src/realm/query_state.hpp
+++ b/src/realm/query_state.hpp
@@ -22,6 +22,8 @@
 #include <cstdlib> // size_t
 #include <cstdint> // unint8_t etc
 
+#include <realm/node.hpp>
+
 namespace realm {
 
 enum Action { act_ReturnFirst, act_Sum, act_Max, act_Min, act_Count, act_FindAll, act_Average };


### PR DESCRIPTION
## What, How & Why?
The `validate-installed-headers` test was failing since the `query_state.hpp` file was using a class without including the file.

## ☑️ ToDos
* ~~[ ] 📝 Changelog update~~
* ~~[ ] 🚦 Tests (or not relevant)~~
* ~~[ ] C-API, if public C++ API changed.~~
