### PR TITLE
Loosen checks for uids on exfat fs

### DIFF
--- a/test/test_file.cpp
+++ b/test/test_file.cpp
@@ -585,8 +585,13 @@ TEST(File_GetUniqueID)
         CHECK(uid2_1 == file2_1.get_unique_id());
     }
     else {
-        CHECK(uid1_1 == file2_1.get_unique_id());
-        CHECK(uid2_1 == file1_1.get_unique_id());
+        // fat32/exfat could reuse or reassign uid after truncate
+        // there is not much to guarantee about the values of uids
+        auto u1 = file1_1.get_unique_id();
+        auto u2 = file2_1.get_unique_id();
+        CHECK(u1 != u2);
+        auto u1_2 = file1_2.get_unique_id();
+        CHECK(u1 == u1_2);
     }
 }
 


### PR DESCRIPTION
## What, How & Why?
Apparently uids on fat32/exfat are assigned not so deterministically on truncate, so try to make simplier checks.

Example failure where most likely uids either stay the same or get completely new values:
```
[2023/10/30 23:39:13.137] Thread[08]: /System/Volumes/Data/data/mci/6327106b375800ccccaed93352fa5563/realm-core/test/test_file.cpp:588: ERROR in File_GetUniqueID: CHECK(uid1_1 == file2_1.get_unique_id()) failed
[2023/10/30 23:39:13.137] Thread[08]: /System/Volumes/Data/data/mci/6327106b375800ccccaed93352fa5563/realm-core/test/test_file.cpp:589: ERROR in File_GetUniqueID: CHECK(uid2_1 == file1_1.get_unique_id()) failed
```
or just one failure where it is probably just completely new uid for second file:
```
[2023/10/29 23:38:40.219] Thread[11]: /System/Volumes/Data/data/mci/60aa25829f9074ec643e693ea7f1f8cd/realm-core/test/test_file.cpp:589: ERROR in File_GetUniqueID: CHECK(uid2_1 == file1_1.get_unique_id()) failed
```

## ☑️ ToDos
~ * [ ] 📝 Changelog update ~
* [x] 🚦 Tests (or not relevant)
~ * [ ] C-API, if public C++ API changed. ~
