### PR TITLE
Deliver appropriate subscription state change notifications in DiscardLocal client resets

### DIFF
--- a/src/realm/object-store/sync/sync_session.cpp
+++ b/src/realm/object-store/sync/sync_session.cpp
@@ -460,7 +460,7 @@ void SyncSession::download_fresh_realm(sync::ProtocolErrorInfo::Action server_re
         options.encryption_key = encryption_key.data();
 
     DBRef db;
-    auto fresh_path = ClientResetOperation::get_fresh_path_for(m_db->get_path());
+    auto fresh_path = client_reset::get_fresh_path_for(m_db->get_path());
     try {
         // We want to attempt to use a pre-existing file to reduce the chance of
         // downloading the first part of the file only to then delete it over
@@ -876,9 +876,8 @@ void SyncSession::create_sync_session()
     session_config.proxy_config = sync_config.proxy_config;
     session_config.simulate_integration_error = sync_config.simulate_integration_error;
     session_config.flx_bootstrap_batch_size_bytes = sync_config.flx_bootstrap_batch_size_bytes;
-    session_config.session_reason = ClientResetOperation::is_fresh_path(m_config.path)
-                                        ? sync::SessionReason::ClientReset
-                                        : sync::SessionReason::Sync;
+    session_config.session_reason =
+        client_reset::is_fresh_path(m_config.path) ? sync::SessionReason::ClientReset : sync::SessionReason::Sync;
 
     if (sync_config.on_sync_client_event_hook) {
         session_config.on_sync_client_event_hook = [hook = sync_config.on_sync_client_event_hook,

--- a/src/realm/sync/noinst/client_impl_base.hpp
+++ b/src/realm/sync/noinst/client_impl_base.hpp
@@ -2,37 +2,34 @@
 #ifndef REALM_NOINST_CLIENT_IMPL_BASE_HPP
 #define REALM_NOINST_CLIENT_IMPL_BASE_HPP
 
-#include <cstdint>
-#include <utility>
-#include <functional>
-#include <deque>
-#include <map>
-#include <string>
-#include <random>
-#include <list>
+#include <realm/sync/client_base.hpp>
 
 #include <realm/binary_data.hpp>
-#include <realm/util/optional.hpp>
-#include <realm/util/buffer_stream.hpp>
-#include <realm/util/logger.hpp>
-#include <realm/util/tagged_bool.hpp>
-#include <realm/sync/network/network_ssl.hpp>
+#include <realm/sync/history.hpp>
 #include <realm/sync/network/default_socket.hpp>
-#include <realm/util/span.hpp>
+#include <realm/sync/network/network_ssl.hpp>
 #include <realm/sync/noinst/client_history_impl.hpp>
-#include <realm/sync/noinst/client_reset_operation.hpp>
+#include <realm/sync/noinst/migration_store.hpp>
 #include <realm/sync/noinst/migration_store.hpp>
 #include <realm/sync/noinst/protocol_codec.hpp>
-#include <realm/sync/client_base.hpp>
-#include <realm/sync/history.hpp>
 #include <realm/sync/protocol.hpp>
 #include <realm/sync/subscriptions.hpp>
 #include <realm/sync/trigger.hpp>
-#include <realm/sync/noinst/migration_store.hpp>
+#include <realm/util/buffer_stream.hpp>
+#include <realm/util/logger.hpp>
+#include <realm/util/optional.hpp>
+#include <realm/util/span.hpp>
 
+#include <cstdint>
+#include <deque>
+#include <functional>
+#include <list>
+#include <map>
+#include <random>
+#include <string>
+#include <utility>
 
-namespace realm {
-namespace sync {
+namespace realm::sync {
 
 // (protocol, address, port, session_multiplex_ident)
 //
@@ -162,7 +159,6 @@ public:
     using port_type = network::Endpoint::port_type;
     using OutputBuffer = util::ResettableExpandableBufferOutputStream;
     using ClientProtocol = _impl::ClientProtocol;
-    using ClientResetOperation = _impl::ClientResetOperation;
     using RandomEngine = std::mt19937_64;
 
     /// Per-server endpoint information used to determine reconnect delays.
@@ -426,7 +422,7 @@ public:
     ///
     /// Prior to being activated, no messages will be sent or received on behalf
     /// of this session, and the associated Realm file will not be accessed,
-    /// i.e., Session::access_realm() will not be called.
+    /// i.e., `Session::get_db()` will not be called.
     ///
     /// If activation is successful, the connection keeps the session alive
     /// until the application calls initiated_session_deactivation() or until
@@ -449,7 +445,7 @@ public:
     /// initiate_session_deactivation().
     ///
     /// After the initiation of the deactivation process, the associated Realm
-    /// file will no longer be accessed, i.e., access_realm() will not be called
+    /// file will no longer be accessed, i.e., `get_db()` will not be called
     /// again, and a previously returned reference will also not be accessed
     /// again.
     ///
@@ -844,12 +840,8 @@ public:
 
     /// To be used in connection with implementations of
     /// initiate_integrate_changesets().
-    ///
-    /// This function is thread-safe, but if called from a thread other than the
-    /// event loop thread of the associated client object, the specified history
-    /// accessor must **not** be the one made available by access_realm().
-    void integrate_changesets(ClientReplication&, const SyncProgress&, std::uint_fast64_t downloadable_bytes,
-                              const ReceivedChangesets&, VersionInfo&, DownloadBatchState last_in_batch);
+    void integrate_changesets(const SyncProgress&, std::uint_fast64_t downloadable_bytes, const ReceivedChangesets&,
+                              VersionInfo&, DownloadBatchState last_in_batch);
 
     /// To be used in connection with implementations of
     /// initiate_integrate_changesets().
@@ -900,18 +892,11 @@ private:
     const std::string& get_virt_path() const noexcept;
 
     const std::string& get_realm_path() const noexcept;
-    DBRef get_db() const noexcept;
 
-    /// The implementation need only ensure that the returned reference stays valid
-    /// until the next invocation of access_realm() on one of the session
-    /// objects associated with the same client object.
-    ///
-    /// This function is always called by the event loop thread of the
-    /// associated client object.
-    ///
-    /// This function is guaranteed to not be called before activation, and also
-    /// not after initiation of deactivation.
-    ClientReplication& access_realm();
+    // Can only be called if the session is active or being activated
+    DBRef get_db() const noexcept;
+    ClientReplication& get_repl() const noexcept;
+    ClientHistory& get_history() const noexcept;
 
     // client_reset_config() returns the config for client
     // reset. If it returns none, ordinary sync is used. If it returns a
@@ -934,10 +919,6 @@ private:
     /// progress has been persisted, this function must provide for
     /// on_changesets_integrated() to be called without unnecessary delay,
     /// although never after initiation of session deactivation.
-    ///
-    /// The integration of the specified changesets must happen by means of an
-    /// invocation of integrate_changesets(), but not necessarily using the
-    /// history accessor made available by access_realm().
     ///
     /// The implementation is allowed, but not obliged to aggregate changesets
     /// from multiple invocations of initiate_integrate_changesets() and pass
@@ -1011,6 +992,7 @@ private:
     // Processes any pending FLX bootstraps, if one exists. Otherwise this is a noop.
     void process_pending_flx_bootstrap();
 
+    bool client_reset_if_needed();
     void handle_pending_client_reset_acknowledgement();
 
     void update_subscription_version_info();
@@ -1070,8 +1052,8 @@ private:
     // `ident == 0` means unassigned.
     SaltedFileIdent m_client_file_ident = {0, 0};
 
-    // m_client_reset_operation stores state for the lifetime of a client reset
-    std::unique_ptr<ClientResetOperation> m_client_reset_operation;
+    // True while this session is in the process of performing a client reset.
+    bool m_performing_client_reset = false;
 
     // The latest sync progress reported by the server via a DOWNLOAD
     // message. See struct SyncProgress for a description. The values stored in
@@ -1617,7 +1599,6 @@ inline void ClientImpl::Session::enlist_to_send()
     m_conn.enlist_to_send(this); // Throws
 }
 
-} // namespace sync
-} // namespace realm
+} // namespace realm::sync
 
 #endif // REALM_NOINST_CLIENT_IMPL_BASE_HPP

--- a/src/realm/sync/noinst/client_reset.cpp
+++ b/src/realm/sync/noinst/client_reset.cpp
@@ -554,7 +554,7 @@ static ClientResyncMode reset_precheck_guard(Transaction& wt, ClientResyncMode m
 LocalVersionIDs perform_client_reset_diff(DB& db_local, DB& db_remote, sync::SaltedFileIdent client_file_ident,
                                           util::Logger& logger, ClientResyncMode mode, bool recovery_is_allowed,
                                           bool* did_recover_out, sync::SubscriptionStore* sub_store,
-                                          util::UniqueFunction<void(int64_t)> on_flx_version_complete)
+                                          util::FunctionRef<void(int64_t)> on_flx_version_complete)
 {
     auto wt_local = db_local.start_write();
     auto actual_mode = reset_precheck_guard(*wt_local, mode, recovery_is_allowed, logger);
@@ -605,9 +605,7 @@ LocalVersionIDs perform_client_reset_diff(DB& db_local, DB& db_remote, sync::Sal
         if (did_recover_out) {
             *did_recover_out = false;
         }
-        if (on_flx_version_complete) {
-            on_flx_version_complete(subscription_version);
-        }
+        on_flx_version_complete(subscription_version);
 
         VersionID new_version_local = wt_local->get_version_of_current_transaction();
         logger.info("perform_client_reset_diff is done: old_version = (version: %1, index: %2), "
@@ -626,9 +624,7 @@ LocalVersionIDs perform_client_reset_diff(DB& db_local, DB& db_remote, sync::Sal
         auto mut_subs = subs.make_mutable_copy();
         mut_subs.update_state(sync::SubscriptionSet::State::Complete);
         auto sub = std::move(mut_subs).commit();
-        if (on_flx_version_complete) {
-            on_flx_version_complete(sub.version());
-        }
+        on_flx_version_complete(sub.version());
         logger.info("Recreated the active subscription set in the complete state (%1 -> %2)", before_version,
                     sub.version());
     };

--- a/src/realm/sync/noinst/client_reset.hpp
+++ b/src/realm/sync/noinst/client_reset.hpp
@@ -89,7 +89,7 @@ struct LocalVersionIDs {
 LocalVersionIDs perform_client_reset_diff(DB& db, DB& db_remote, sync::SaltedFileIdent client_file_ident,
                                           util::Logger& logger, ClientResyncMode mode, bool recovery_is_allowed,
                                           bool* did_recover_out, sync::SubscriptionStore* sub_store,
-                                          util::UniqueFunction<void(int64_t)> on_flx_version_complete);
+                                          util::FunctionRef<void(int64_t)> on_flx_version_complete);
 
 } // namespace _impl::client_reset
 } // namespace realm

--- a/src/realm/sync/noinst/client_reset_operation.cpp
+++ b/src/realm/sync/noinst/client_reset_operation.cpp
@@ -16,14 +16,15 @@
  *
  **************************************************************************/
 
-#include <realm/transaction.hpp>
+#include <realm/sync/noinst/client_reset_operation.hpp>
+
 #include <realm/sync/history.hpp>
 #include <realm/sync/noinst/client_history_impl.hpp>
 #include <realm/sync/noinst/client_reset.hpp>
-#include <realm/sync/noinst/client_reset_operation.hpp>
+#include <realm/transaction.hpp>
 #include <realm/util/scope_exit.hpp>
 
-namespace realm::_impl {
+namespace realm::_impl::client_reset {
 
 namespace {
 
@@ -31,24 +32,7 @@ constexpr static std::string_view c_fresh_suffix(".fresh");
 
 } // namespace
 
-ClientResetOperation::ClientResetOperation(util::Logger& logger, DBRef db, DBRef db_fresh, ClientResyncMode mode,
-                                           CallbackBeforeType notify_before, CallbackAfterType notify_after,
-                                           bool recovery_is_allowed)
-    : m_logger{logger}
-    , m_db{db}
-    , m_db_fresh(std::move(db_fresh))
-    , m_mode(mode)
-    , m_notify_before(std::move(notify_before))
-    , m_notify_after(std::move(notify_after))
-    , m_recovery_is_allowed(recovery_is_allowed)
-{
-    REALM_ASSERT(m_db);
-    REALM_ASSERT_RELEASE(m_mode != ClientResyncMode::Manual);
-    m_logger.debug("Create ClientResetOperation, realm_path = %1, mode = %2, recovery_allowed = %3", m_db->get_path(),
-                   m_mode, m_recovery_is_allowed);
-}
-
-std::string ClientResetOperation::get_fresh_path_for(const std::string& path)
+std::string get_fresh_path_for(const std::string& path)
 {
     const size_t suffix_len = c_fresh_suffix.size();
     REALM_ASSERT(path.length());
@@ -57,7 +41,7 @@ std::string ClientResetOperation::get_fresh_path_for(const std::string& path)
     return path + c_fresh_suffix.data();
 }
 
-bool ClientResetOperation::is_fresh_path(const std::string& path)
+bool is_fresh_path(const std::string& path)
 {
     const size_t suffix_len = c_fresh_suffix.size();
     REALM_ASSERT(path.length());
@@ -67,83 +51,57 @@ bool ClientResetOperation::is_fresh_path(const std::string& path)
     return path.substr(path.size() - suffix_len, suffix_len) == c_fresh_suffix;
 }
 
-bool ClientResetOperation::finalize(sync::SaltedFileIdent salted_file_ident, sync::SubscriptionStore* sub_store,
-                                    util::UniqueFunction<void(int64_t)> on_flx_version_complete)
+bool perform_client_reset(util::Logger& logger, DB& db, DB& fresh_db, ClientResyncMode mode,
+                          CallbackBeforeType notify_before, CallbackAfterType notify_after,
+                          sync::SaltedFileIdent new_file_ident, sync::SubscriptionStore* sub_store,
+                          util::FunctionRef<void(int64_t)> on_flx_version, bool recovery_is_allowed)
 {
-    m_salted_file_ident = salted_file_ident;
+    REALM_ASSERT(mode != ClientResyncMode::Manual);
+    logger.debug("Possibly beginning client reset operation: realm_path = %1, mode = %2, recovery_allowed = %3",
+                 db.get_path(), mode, recovery_is_allowed);
+
+    auto always_try_clean_up = util::make_scope_exit([&]() noexcept {
+        std::string path_to_clean = fresh_db.get_path();
+        try {
+            fresh_db.close();
+            constexpr bool delete_lockfile = true;
+            DB::delete_files(path_to_clean, nullptr, delete_lockfile);
+        }
+        catch (const std::exception& err) {
+            logger.warn("In ClientResetOperation::finalize, the fresh copy '%1' could not be cleaned up due to "
+                        "an exception: '%2'",
+                        path_to_clean, err.what());
+            // ignored, this is just a best effort
+        }
+    });
+
     // only do the reset if there is data to reset
     // if there is nothing in this Realm, then there is nothing to reset and
     // sync should be able to continue as normal
-    auto latest_version = m_db->get_version_id_of_latest_snapshot();
-
-    bool local_realm_exists = latest_version.version != 0;
-    m_logger.debug("ClientResetOperation::finalize, realm_path = %1, local_realm_exists = %2, mode = %3",
-                   m_db->get_path(), local_realm_exists, m_mode);
+    auto latest_version = db.get_version_id_of_latest_snapshot();
+    bool local_realm_exists = latest_version.version > 1;
     if (!local_realm_exists) {
+        logger.debug("Local Realm file has never been written to, so skipping client reset.");
         return false;
     }
 
-    REALM_ASSERT_EX(m_db_fresh, m_db->get_path(), m_mode);
-
-    client_reset::LocalVersionIDs local_version_ids;
-    auto always_try_clean_up = util::make_scope_exit([&]() noexcept {
-        clean_up_state();
-    });
-
-    VersionID frozen_before_state_version = m_notify_before ? m_notify_before() : latest_version;
+    VersionID frozen_before_state_version = notify_before ? notify_before() : latest_version;
 
     // If m_notify_after is set, pin the previous state to keep it around.
     TransactionRef previous_state;
-    if (m_notify_after) {
-        previous_state = m_db->start_frozen(frozen_before_state_version);
+    if (notify_after) {
+        previous_state = db.start_frozen(frozen_before_state_version);
     }
     bool did_recover_out = false;
-    local_version_ids = client_reset::perform_client_reset_diff(
-        *m_db, *m_db_fresh, m_salted_file_ident, m_logger, m_mode, m_recovery_is_allowed, &did_recover_out, sub_store,
-        std::move(on_flx_version_complete)); // throws
+    client_reset::perform_client_reset_diff(db, fresh_db, new_file_ident, logger, mode, recovery_is_allowed,
+                                            &did_recover_out, sub_store,
+                                            on_flx_version); // throws
 
-    if (m_notify_after) {
-        m_notify_after(previous_state->get_version_of_current_transaction(), did_recover_out);
+    if (notify_after) {
+        notify_after(previous_state->get_version_of_current_transaction(), did_recover_out);
     }
-
-    m_client_reset_old_version = local_version_ids.old_version;
-    m_client_reset_new_version = local_version_ids.new_version;
 
     return true;
 }
 
-void ClientResetOperation::clean_up_state() noexcept
-{
-    if (m_db_fresh) {
-        std::string path_to_clean = m_db_fresh->get_path();
-        try {
-            // In order to obtain the lock and delete the realm, we first have to close
-            // the Realm. This requires that we are the only remaining ref holder, and
-            // this is expected. Releasing the last ref should release the hold on the
-            // lock file and allow us to clean up.
-            long use_count = m_db_fresh.use_count();
-            REALM_ASSERT_DEBUG_EX(use_count == 1, use_count, path_to_clean);
-            m_db_fresh.reset();
-            // clean up the fresh Realm
-            // we don't mind leaving the fresh lock file around because trying to delete it
-            // here could cause a race if there are multiple resets ongoing
-            bool did_lock = DB::call_with_lock(path_to_clean, [&](const std::string& path) {
-                constexpr bool delete_lockfile = false;
-                DB::delete_files(path, nullptr, delete_lockfile);
-            });
-            if (!did_lock) {
-                m_logger.warn("In ClientResetOperation::finalize, the fresh copy '%1' could not be cleaned up. "
-                              "There were %2 refs remaining.",
-                              path_to_clean, use_count);
-            }
-        }
-        catch (const std::exception& err) {
-            m_logger.warn("In ClientResetOperation::finalize, the fresh copy '%1' could not be cleaned up due to "
-                          "an exception: '%2'",
-                          path_to_clean, err.what());
-            // ignored, this is just a best effort
-        }
-    }
-}
-
-} // namespace realm::_impl
+} // namespace realm::_impl::client_reset

--- a/src/realm/sync/noinst/client_reset_operation.hpp
+++ b/src/realm/sync/noinst/client_reset_operation.hpp
@@ -21,65 +21,27 @@
 
 #include <realm/db.hpp>
 #include <realm/util/functional.hpp>
+#include <realm/util/function_ref.hpp>
 #include <realm/util/logger.hpp>
+#include <realm/sync/config.hpp>
 #include <realm/sync/protocol.hpp>
 
 namespace realm::sync {
 class SubscriptionStore;
 }
 
-namespace realm::_impl {
+namespace realm::_impl::client_reset {
+using CallbackBeforeType = util::UniqueFunction<VersionID()>;
+using CallbackAfterType = util::UniqueFunction<void(VersionID, bool)>;
 
-// A ClientResetOperation object is used per client session to keep track of
-// state Realm download.
-class ClientResetOperation {
-public:
-    using CallbackBeforeType = util::UniqueFunction<VersionID()>;
-    using CallbackAfterType = util::UniqueFunction<void(VersionID, bool)>;
+std::string get_fresh_path_for(const std::string& realm_path);
+bool is_fresh_path(const std::string& realm_path);
 
-    ClientResetOperation(util::Logger& logger, DBRef db, DBRef db_fresh, ClientResyncMode mode,
-                         CallbackBeforeType notify_before, CallbackAfterType notify_after, bool recovery_is_allowed);
+bool perform_client_reset(util::Logger& logger, DB& target_db, DB& fresh_db, ClientResyncMode mode,
+                          CallbackBeforeType notify_before, CallbackAfterType notify_after,
+                          sync::SaltedFileIdent new_file_ident, sync::SubscriptionStore*,
+                          util::FunctionRef<void(int64_t)> on_flx_version, bool recovery_is_allowed);
 
-    // When the client has received the salted file ident from the server, it
-    // should deliver the ident to the ClientResetOperation object. The ident
-    // will be inserted in the Realm after download.
-    bool finalize(sync::SaltedFileIdent salted_file_ident, sync::SubscriptionStore*,
-                  util::UniqueFunction<void(int64_t)>); // throws
-
-    static std::string get_fresh_path_for(const std::string& realm_path);
-    static bool is_fresh_path(const std::string& realm_path);
-
-    realm::VersionID get_client_reset_old_version() const noexcept;
-    realm::VersionID get_client_reset_new_version() const noexcept;
-
-private:
-    void clean_up_state() noexcept;
-
-    // The lifetime of this class is within a Session, so no need for a shared_ptr
-    util::Logger& m_logger;
-    DBRef m_db;
-    DBRef m_db_fresh;
-    ClientResyncMode m_mode;
-    sync::SaltedFileIdent m_salted_file_ident = {0, 0};
-    realm::VersionID m_client_reset_old_version;
-    realm::VersionID m_client_reset_new_version;
-    CallbackBeforeType m_notify_before;
-    CallbackAfterType m_notify_after;
-    bool m_recovery_is_allowed;
-};
-
-// Implementation
-
-inline realm::VersionID ClientResetOperation::get_client_reset_old_version() const noexcept
-{
-    return m_client_reset_old_version;
-}
-
-inline realm::VersionID ClientResetOperation::get_client_reset_new_version() const noexcept
-{
-    return m_client_reset_new_version;
-}
-
-} // namespace realm::_impl
+} // namespace realm::_impl::client_reset
 
 #endif // REALM_NOINST_CLIENT_RESET_OPERATION_HPP

--- a/src/realm/sync/subscriptions.hpp
+++ b/src/realm/sync/subscriptions.hpp
@@ -362,14 +362,15 @@ public:
 
     // Recreate the active subscription set, marking any newer pending ones as
     // superseded. This is a no-op if there are no pending subscription sets.
-    int64_t set_active_as_latest(Transaction& wt);
-
-private:
-    using std::enable_shared_from_this<SubscriptionStore>::weak_from_this;
-    DBRef m_db;
+    int64_t set_active_as_latest(Transaction& wt) REQUIRES(!m_pending_notifications_mutex);
 
 protected:
     explicit SubscriptionStore(DBRef db);
+
+private:
+    using State = SubscriptionSet::State;
+    using std::enable_shared_from_this<SubscriptionStore>::weak_from_this;
+    DBRef m_db;
 
     struct NotificationRequest {
         NotificationRequest(int64_t version, util::Promise<SubscriptionSet::State> promise,

--- a/src/realm/sync/subscriptions.hpp
+++ b/src/realm/sync/subscriptions.hpp
@@ -16,16 +16,18 @@
  *
  **************************************************************************/
 
-#pragma once
+#ifndef REALM_SYNC_SUBSCRIPTIONS_HPP
+#define REALM_SYNC_SUBSCRIPTIONS_HPP
 
-#include "realm/db.hpp"
-#include "realm/obj.hpp"
-#include "realm/query.hpp"
-#include "realm/timestamp.hpp"
-#include "realm/util/future.hpp"
-#include "realm/util/functional.hpp"
-#include "realm/util/optional.hpp"
-#include "realm/util/tagged_bool.hpp"
+#include <realm/db.hpp>
+#include <realm/obj.hpp>
+#include <realm/query.hpp>
+#include <realm/timestamp.hpp>
+#include <realm/util/checked_mutex.hpp>
+#include <realm/util/future.hpp>
+#include <realm/util/functional.hpp>
+#include <realm/util/optional.hpp>
+#include <realm/util/tagged_bool.hpp>
 
 #include <list>
 #include <set>
@@ -332,7 +334,7 @@ public:
 
     // To be used internally by the sync client. This returns a read-only view of a subscription set by its
     // version ID. If there is no SubscriptionSet with that version ID, this throws KeyNotFound.
-    SubscriptionSet get_by_version(int64_t version_id) const;
+    SubscriptionSet get_by_version(int64_t version_id) const REQUIRES(!m_pending_notifications_mutex);
 
     // Returns true if there have been commits to the DB since the given version
     bool would_refresh(DB::version_type version) const noexcept;
@@ -346,17 +348,17 @@ public:
     };
 
     util::Optional<PendingSubscription> get_next_pending_version(int64_t last_query_version) const;
-    std::vector<SubscriptionSet> get_pending_subscriptions() const;
+    std::vector<SubscriptionSet> get_pending_subscriptions() const REQUIRES(!m_pending_notifications_mutex);
 
     // Notify all subscription state change notification handlers on this subscription store with the
     // provided Status - this does not change the state of any pending subscriptions.
     // Does not necessarily need to be called from the event loop thread.
-    void notify_all_state_change_notifications(Status status);
+    void notify_all_state_change_notifications(Status status) REQUIRES(!m_pending_notifications_mutex);
 
     // Reset SubscriptionStore and erase all current subscriptions and supersede any pending
     // subscriptions. Must be called from the event loop thread to prevent data race issues
     // with the subscription store.
-    void terminate();
+    void terminate() REQUIRES(!m_pending_notifications_mutex);
 
     // Recreate the active subscription set, marking any newer pending ones as
     // superseded. This is a no-op if there are no pending subscription sets.
@@ -413,11 +415,11 @@ protected:
     ColKey m_sub_set_error_str;
     ColKey m_sub_set_subscriptions;
 
-    mutable std::mutex m_pending_notifications_mutex;
-    mutable std::condition_variable m_pending_notifications_cv;
-    mutable int64_t m_outstanding_requests = 0;
-    mutable int64_t m_min_outstanding_version = 0;
-    mutable std::list<NotificationRequest> m_pending_notifications;
+    mutable util::CheckedMutex m_pending_notifications_mutex;
+    mutable int64_t m_min_outstanding_version GUARDED_BY(m_pending_notifications_mutex) = 0;
+    mutable std::list<NotificationRequest> m_pending_notifications GUARDED_BY(m_pending_notifications_mutex);
 };
 
 } // namespace realm::sync
+
+#endif // REALM_SYNC_SUBSCRIPTIONS_HPP

--- a/test/object-store/sync/client_reset.cpp
+++ b/test/object-store/sync/client_reset.cpp
@@ -185,7 +185,7 @@ TEST_CASE("sync: large reset with recovery is restartable", "[sync][pbs][client 
 
     realm->sync_session()->resume();
     timed_wait_for([&] {
-        return util::File::exists(_impl::ClientResetOperation::get_fresh_path_for(realm_config.path));
+        return util::File::exists(_impl::client_reset::get_fresh_path_for(realm_config.path));
     });
     realm->sync_session()->pause();
     realm->sync_session()->resume();
@@ -371,7 +371,7 @@ TEST_CASE("sync: client reset", "[sync][pbs][client reset][baas]") {
 
     local_config.cache = false;
     local_config.automatic_change_notifications = false;
-    const std::string fresh_path = realm::_impl::ClientResetOperation::get_fresh_path_for(local_config.path);
+    const std::string fresh_path = realm::_impl::client_reset::get_fresh_path_for(local_config.path);
     size_t before_callback_invocations = 0;
     size_t after_callback_invocations = 0;
     std::mutex mtx;
@@ -968,7 +968,7 @@ TEST_CASE("sync: client reset", "[sync][pbs][client reset][baas]") {
                 ->run();
 
             timed_wait_for([&] {
-                return util::File::exists(_impl::ClientResetOperation::get_fresh_path_for(local_config.path));
+                return util::File::exists(_impl::client_reset::get_fresh_path_for(local_config.path));
             });
 
             // Restart the session before the client reset finishes.
@@ -996,7 +996,7 @@ TEST_CASE("sync: client reset", "[sync][pbs][client reset][baas]") {
             local_config.sync_config->error_handler = [&](std::shared_ptr<SyncSession>, SyncError error) {
                 err = error;
             };
-            std::string fresh_path = realm::_impl::ClientResetOperation::get_fresh_path_for(local_config.path);
+            std::string fresh_path = realm::_impl::client_reset::get_fresh_path_for(local_config.path);
             util::File f(fresh_path, util::File::Mode::mode_Write);
             f.write("a non empty file");
             f.sync();
@@ -1013,7 +1013,7 @@ TEST_CASE("sync: client reset", "[sync][pbs][client reset][baas]") {
             local_config.sync_config->error_handler = [&](std::shared_ptr<SyncSession>, SyncError error) {
                 err = error;
             };
-            std::string fresh_path = realm::_impl::ClientResetOperation::get_fresh_path_for(local_config.path);
+            std::string fresh_path = realm::_impl::client_reset::get_fresh_path_for(local_config.path);
             // create a non-empty directory that we'll fail to delete
             util::make_dir(fresh_path);
             util::File(util::File::resolve("file", fresh_path), util::File::mode_Write);

--- a/test/object-store/sync/flx_migration.cpp
+++ b/test/object-store/sync/flx_migration.cpp
@@ -539,7 +539,7 @@ TEST_CASE("An interrupted migration or rollback can recover on the next session"
         auto realm = Realm::get_shared_realm(config);
 
         timed_wait_for([&] {
-            return util::File::exists(_impl::ClientResetOperation::get_fresh_path_for(config.path));
+            return util::File::exists(_impl::client_reset::get_fresh_path_for(config.path));
         });
 
         // Pause then resume the session. This triggers the server to send a new client reset request.
@@ -567,7 +567,7 @@ TEST_CASE("An interrupted migration or rollback can recover on the next session"
         auto realm = Realm::get_shared_realm(config);
 
         timed_wait_for([&] {
-            return util::File::exists(_impl::ClientResetOperation::get_fresh_path_for(config.path));
+            return util::File::exists(_impl::client_reset::get_fresh_path_for(config.path));
         });
 
         // Pause then resume the session. This triggers the server to send a new client reset request.

--- a/test/object-store/sync/flx_sync.cpp
+++ b/test/object-store/sync/flx_sync.cpp
@@ -579,7 +579,7 @@ TEST_CASE("flx: client reset", "[sync][flx][client reset][baas]") {
         auto&& [error_future, error_handler] = make_error_handler();
         config_local.sync_config->error_handler = error_handler;
 
-        std::string fresh_path = realm::_impl::ClientResetOperation::get_fresh_path_for(config_local.path);
+        std::string fresh_path = realm::_impl::client_reset::get_fresh_path_for(config_local.path);
         // create a non-empty directory that we'll fail to delete
         util::make_dir(fresh_path);
         util::File(util::File::resolve("file", fresh_path), util::File::mode_Write);
@@ -1005,7 +1005,7 @@ TEST_CASE("flx: client reset", "[sync][flx][client reset][baas]") {
         auto&& [error_future, error_handler] = make_error_handler();
         config_local.sync_config->error_handler = error_handler;
 
-        std::string fresh_path = realm::_impl::ClientResetOperation::get_fresh_path_for(config_local.path);
+        std::string fresh_path = realm::_impl::client_reset::get_fresh_path_for(config_local.path);
         // create a non-empty directory that we'll fail to delete
         util::make_dir(fresh_path);
         util::File(util::File::resolve("file", fresh_path), util::File::mode_Write);

--- a/test/object-store/util/sync/sync_test_utils.cpp
+++ b/test/object-store/util/sync/sync_test_utils.cpp
@@ -408,7 +408,7 @@ struct FakeLocalClientReset : public TestClientReset {
             using _impl::client_reset::perform_client_reset_diff;
             constexpr bool recovery_is_allowed = true;
             perform_client_reset_diff(*local_db, *remote_db, fake_ident, *logger, m_mode, recovery_is_allowed,
-                                      nullptr, nullptr, nullptr);
+                                      nullptr, nullptr, [](int64_t) {});
 
             remote_realm->close();
             if (m_on_post_reset) {

--- a/test/test_client_reset.cpp
+++ b/test/test_client_reset.cpp
@@ -1,18 +1,19 @@
-#include <string>
-#include <thread>
-
-#include <realm/util/random.hpp>
 #include <realm/db.hpp>
 #include <realm/list.hpp>
-#include <realm/table_view.hpp>
-
 #include <realm/object_converter.hpp>
 #include <realm/sync/noinst/client_reset.hpp>
+#include <realm/sync/noinst/client_reset_operation.hpp>
+#include <realm/sync/subscriptions.hpp>
+#include <realm/table_view.hpp>
+#include <realm/util/random.hpp>
 
 #include "test.hpp"
 #include "sync_fixtures.hpp"
 #include "util/semaphore.hpp"
 #include "util/compare_groups.hpp"
+
+#include <string>
+#include <thread>
 
 using namespace realm;
 using namespace realm::sync;
@@ -836,6 +837,386 @@ TEST(ClientReset_PinnedVersion)
         Session session = fixture.make_bound_session(sg, server_path_1, std::move(session_config));
         session.wait_for_download_complete_or_client_stopped();
     }
+}
+
+void mark_as_synchronized(DB& db)
+{
+    auto& history = static_cast<ClientReplication*>(db.get_replication())->get_history();
+    sync::version_type current_version;
+    sync::SaltedFileIdent file_ident;
+    sync::SyncProgress progress;
+    history.get_status(current_version, file_ident, progress);
+    progress.download.last_integrated_client_version = current_version;
+    progress.upload.client_version = current_version;
+    progress.upload.last_integrated_server_version = current_version;
+    sync::VersionInfo info_out;
+    history.set_sync_progress(progress, nullptr, info_out);
+}
+
+void expect_reset(unit_test::TestContext& test_context, DB& target, DB& fresh, ClientResyncMode mode,
+                  bool allow_recovery = true)
+{
+    auto db_version = target.get_version_of_latest_snapshot();
+    auto fresh_path = fresh.get_path();
+    bool did_reset = _impl::client_reset::perform_client_reset(
+        *test_context.logger, target, fresh, mode, nullptr, nullptr, {100, 200}, nullptr, [](int64_t) {},
+        allow_recovery);
+    CHECK(did_reset);
+
+    // Should have closed and deleted the fresh realm
+    CHECK_NOT(fresh.is_attached());
+    CHECK_NOT(util::File::exists(fresh_path));
+
+    // Should have performed exactly one write on the target DB
+    CHECK_EQUAL(target.get_version_of_latest_snapshot(), db_version + 1);
+
+    // Should have set the client file ident
+    CHECK_EQUAL(target.start_read()->get_sync_file_id(), 100);
+
+    // Client resets aren't marked as complete until the server has acknowledged
+    // sync completion to avoid reset cycles
+    {
+        auto wt = target.start_write();
+        _impl::client_reset::remove_pending_client_resets(*wt);
+        wt->commit();
+    }
+}
+
+void expect_reset(unit_test::TestContext& test_context, DB& target, DB& fresh, ClientResyncMode mode,
+                  SubscriptionStore* sub_store)
+{
+    auto db_version = target.get_version_of_latest_snapshot();
+    auto fresh_path = fresh.get_path();
+    bool did_reset = _impl::client_reset::perform_client_reset(
+        *test_context.logger, target, fresh, mode, nullptr, nullptr, {100, 200}, sub_store, [](int64_t) {}, true);
+    CHECK(did_reset);
+
+    // Should have closed and deleted the fresh realm
+    CHECK_NOT(fresh.is_attached());
+    CHECK_NOT(util::File::exists(fresh_path));
+
+    // Should have performed exactly one write on the target DB
+    CHECK_EQUAL(target.get_version_of_latest_snapshot(), db_version + 1);
+
+    // Should have set the client file ident
+    CHECK_EQUAL(target.start_read()->get_sync_file_id(), 100);
+
+    // Client resets aren't marked as complete until the server has acknowledged
+    // sync completion to avoid reset cycles
+    {
+        auto wt = target.start_write();
+        _impl::client_reset::remove_pending_client_resets(*wt);
+        wt->commit();
+    }
+}
+
+std::pair<DBRef, DBRef> prepare_db(const std::string& path, const std::string& copy_path,
+                                   util::FunctionRef<void(Transaction&)> fn)
+{
+    DBRef db = DB::create(make_client_replication(), path);
+    {
+        auto wt = db->start_write();
+        fn(*wt);
+        wt->commit();
+    }
+    mark_as_synchronized(*db);
+    db->write_copy(copy_path, nullptr);
+    auto db_2 = DB::create(make_client_replication(), copy_path);
+    return {db, db_2};
+}
+
+TEST(ClientReset_UninitializedFile)
+{
+    SHARED_GROUP_TEST_PATH(path_1);
+    SHARED_GROUP_TEST_PATH(path_2);
+    SHARED_GROUP_TEST_PATH(path_3);
+
+    auto [db, db_fresh] = prepare_db(path_1, path_2, [](Transaction& tr) {
+        tr.add_table_with_primary_key("class_table", type_Int, "pk");
+    });
+
+    auto db_empty = DB::create(make_client_replication(), path_3);
+    // Should not perform a client reset because the target file has never been
+    // written to
+    bool did_reset = _impl::client_reset::perform_client_reset(
+        *test_context.logger, *db_empty, *db_fresh, ClientResyncMode::Recover, nullptr, nullptr, {100, 200}, nullptr,
+        [](int64_t) {}, true);
+    CHECK_NOT(did_reset);
+
+    // Should still have closed and deleted the fresh realm
+    CHECK_NOT(db_fresh->is_attached());
+    CHECK_NOT(util::File::exists(path_2));
+}
+
+TEST(ClientReset_NoChanges)
+{
+    SHARED_GROUP_TEST_PATH(path);
+    SHARED_GROUP_TEST_PATH(path_fresh);
+    SHARED_GROUP_TEST_PATH(path_backup);
+
+    DBRef db = DB::create(make_client_replication(), path);
+    {
+        auto wt = db->start_write();
+        auto table = wt->add_table_with_primary_key("class_table", type_Int, "pk");
+        table->create_object_with_primary_key(1);
+        table->create_object_with_primary_key(2);
+        table->create_object_with_primary_key(3);
+        wt->commit();
+    }
+    mark_as_synchronized(*db);
+
+    // Write a copy of the pre-reset state to compare against
+    db->write_copy(path_backup, nullptr);
+    DBOptions options;
+    options.is_immutable = true;
+    auto backup_db = DB::create(path_backup, true, options);
+
+    const ClientResyncMode modes[] = {ClientResyncMode::Recover, ClientResyncMode::DiscardLocal,
+                                      ClientResyncMode::RecoverOrDiscard};
+    for (auto mode : modes) {
+        // Perform a reset with a fresh Realm that exactly matches the current
+        // one, which shouldn't result in any changes regardless of mode
+        db->write_copy(path_fresh, nullptr);
+        expect_reset(test_context, *db, *DB::create(make_client_replication(), path_fresh), mode);
+
+        // End state should exactly match the pre-reset state
+        CHECK_OR_RETURN(compare_groups(*db->start_read(), *backup_db->start_read()));
+    }
+}
+
+TEST(ClientReset_SimpleNonconflictingChanges)
+{
+    const std::pair<ClientResyncMode, bool> modes[] = {
+        {ClientResyncMode::Recover, true},
+        {ClientResyncMode::RecoverOrDiscard, true},
+        {ClientResyncMode::RecoverOrDiscard, false},
+        {ClientResyncMode::DiscardLocal, false},
+    };
+    for (auto [mode, allow_recovery] : modes) {
+        SHARED_GROUP_TEST_PATH(path_1);
+        SHARED_GROUP_TEST_PATH(path_2);
+
+        auto [db, db_fresh] = prepare_db(path_1, path_2, [](Transaction& tr) {
+            auto table = tr.add_table_with_primary_key("class_table", type_Int, "pk");
+            table->create_object_with_primary_key(1);
+            table->create_object_with_primary_key(2);
+            table->create_object_with_primary_key(3);
+        });
+
+        for (int i = 0; i < 5; ++i) {
+            auto wt = db->start_write();
+            auto table = wt->get_table("class_table");
+            table->create_object_with_primary_key(4 + i);
+            wt->commit();
+        }
+
+        {
+            auto wt = db_fresh->start_write();
+            auto table = wt->get_table("class_table");
+            for (int i = 0; i < 5; ++i) {
+                table->create_object_with_primary_key(10 + i);
+            }
+            wt->commit();
+        }
+
+        expect_reset(test_context, *db, *db_fresh, mode, allow_recovery);
+
+        if (allow_recovery) {
+            // Should have both the objects created locally and from the reset realm
+            auto tr = db->start_read();
+            auto table = tr->get_table("class_table");
+            CHECK_EQUAL(table->size(), 13);
+        }
+        else {
+            // Should only have the objects from the fresh realm
+            auto tr = db->start_read();
+            auto table = tr->get_table("class_table");
+            CHECK_EQUAL(table->size(), 8);
+            CHECK(table->get_object_with_primary_key(10));
+            CHECK_NOT(table->get_object_with_primary_key(4));
+        }
+    }
+}
+
+TEST(ClientReset_SimpleConflictingWrites)
+{
+    const std::pair<ClientResyncMode, bool> modes[] = {
+        {ClientResyncMode::Recover, true},
+        {ClientResyncMode::RecoverOrDiscard, true},
+        {ClientResyncMode::RecoverOrDiscard, false},
+        {ClientResyncMode::DiscardLocal, false},
+    };
+    for (auto [mode, allow_recovery] : modes) {
+        SHARED_GROUP_TEST_PATH(path_1);
+        SHARED_GROUP_TEST_PATH(path_2);
+
+        auto [db, db_fresh] = prepare_db(path_1, path_2, [](Transaction& tr) {
+            auto table = tr.add_table_with_primary_key("class_table", type_Int, "pk");
+            table->add_column(type_Int, "value");
+            table->create_object_with_primary_key(1).set_all(1);
+            table->create_object_with_primary_key(2).set_all(2);
+            table->create_object_with_primary_key(3).set_all(3);
+        });
+
+        {
+            auto wt = db->start_write();
+            auto table = wt->get_table("class_table");
+            for (auto&& obj : *table) {
+                obj.set_all(obj.get<int64_t>("value") + 10);
+            }
+            wt->commit();
+        }
+
+        {
+            auto wt = db_fresh->start_write();
+            auto table = wt->get_table("class_table");
+            for (auto&& obj : *table) {
+                obj.set_all(0);
+            }
+            wt->commit();
+        }
+
+        expect_reset(test_context, *db, *db_fresh, mode, allow_recovery);
+
+        auto tr = db->start_read();
+        auto table = tr->get_table("class_table");
+        CHECK_EQUAL(table->size(), 3);
+        if (allow_recovery) {
+            CHECK_EQUAL(table->get_object_with_primary_key(1).get<int64_t>("value"), 11);
+            CHECK_EQUAL(table->get_object_with_primary_key(2).get<int64_t>("value"), 12);
+            CHECK_EQUAL(table->get_object_with_primary_key(3).get<int64_t>("value"), 13);
+        }
+        else {
+            CHECK_EQUAL(table->get_object_with_primary_key(1).get<int64_t>("value"), 0);
+            CHECK_EQUAL(table->get_object_with_primary_key(2).get<int64_t>("value"), 0);
+            CHECK_EQUAL(table->get_object_with_primary_key(3).get<int64_t>("value"), 0);
+        }
+    }
+}
+
+TEST(ClientReset_Recover_RecoveryDisabled)
+{
+    SHARED_GROUP_TEST_PATH(path_1);
+    SHARED_GROUP_TEST_PATH(path_2);
+
+    auto dbs = prepare_db(path_1, path_2, [](Transaction& tr) {
+        tr.add_table_with_primary_key("class_table", type_Int, "pk");
+    });
+    CHECK_THROW((_impl::client_reset::perform_client_reset(
+                    *test_context.logger, *dbs.first, *dbs.second, ClientResyncMode::Recover, nullptr, nullptr,
+                    {100, 200}, nullptr, [](int64_t) {}, false)),
+                _impl::client_reset::ClientResetFailed);
+    CHECK_NOT(_impl::client_reset::has_pending_reset(*dbs.first->start_read()));
+}
+
+TEST(ClientReset_Recover_ModificationsOnDeletedObject)
+{
+    SHARED_GROUP_TEST_PATH(path_1);
+    SHARED_GROUP_TEST_PATH(path_2);
+
+    ColKey col;
+    auto [db, db_fresh] = prepare_db(path_1, path_2, [&](Transaction& tr) {
+        auto table = tr.add_table_with_primary_key("class_table", type_Int, "pk");
+        col = table->add_column(type_Int, "value");
+        table->create_object_with_primary_key(1).set_all(1);
+        table->create_object_with_primary_key(2).set_all(2);
+        table->create_object_with_primary_key(3).set_all(3);
+    });
+
+    {
+        auto wt = db->start_write();
+        auto table = wt->get_table("class_table");
+        table->get_object(0).set<int64_t>(col, 11);
+        table->get_object(1).add_int(col, 10);
+        table->get_object(2).set<int64_t>(col, 13);
+        wt->commit();
+    }
+    {
+        auto wt = db_fresh->start_write();
+        auto table = wt->get_table("class_table");
+        table->get_object(0).remove();
+        table->get_object(0).remove();
+        wt->commit();
+    }
+
+    expect_reset(test_context, *db, *db_fresh, ClientResyncMode::Recover);
+
+    auto tr = db->start_read();
+    auto table = tr->get_table("class_table");
+    CHECK_EQUAL(table->size(), 1);
+    CHECK_EQUAL(table->get_object_with_primary_key(3).get<int64_t>("value"), 13);
+}
+
+SubscriptionSet add_subscription(SubscriptionStore& sub_store, const std::string& name, const Query& q,
+                                 std::optional<SubscriptionSet::State> state = std::nullopt)
+{
+    auto mut = sub_store.get_latest().make_mutable_copy();
+    mut.insert_or_assign(name, q);
+    if (state) {
+        mut.update_state(*state);
+    }
+    return mut.commit();
+}
+
+TEST(ClientReset_DiscardLocal_DiscardsPendingSubscriptions)
+{
+    SHARED_GROUP_TEST_PATH(path_1);
+    SHARED_GROUP_TEST_PATH(path_2);
+    auto [db, db_fresh] = prepare_db(path_1, path_2, [&](Transaction& tr) {
+        tr.add_table_with_primary_key("class_table", type_Int, "pk");
+    });
+
+    auto tr = db->start_read();
+    Query query = tr->get_table("class_table")->where();
+    auto sub_store = SubscriptionStore::create(db);
+    add_subscription(*sub_store, "complete", query, SubscriptionSet::State::Complete);
+
+    std::vector<SubscriptionSet> pending_sets;
+    std::vector<util::Future<SubscriptionSet::State>> futures;
+    for (int i = 0; i < 3; ++i) {
+        auto set = add_subscription(*sub_store, util::format("pending %1", i), query);
+        futures.push_back(set.get_state_change_notification(SubscriptionSet::State::Complete));
+        pending_sets.push_back(std::move(set));
+    }
+
+    expect_reset(test_context, *db, *db_fresh, ClientResyncMode::DiscardLocal, sub_store.get());
+
+    CHECK(sub_store->get_pending_subscriptions().empty());
+    auto subs = sub_store->get_latest();
+    CHECK_EQUAL(subs.state(), SubscriptionSet::State::Complete);
+    CHECK_EQUAL(subs.size(), 1);
+    CHECK_EQUAL(subs.at(0).name, "complete");
+
+    for (auto& fut : futures) {
+        CHECK_EQUAL(fut.get(), SubscriptionSet::State::Superseded);
+    }
+    for (auto& set : pending_sets) {
+        CHECK_EQUAL(set.state(), SubscriptionSet::State::Pending);
+        set.refresh();
+        CHECK_EQUAL(set.state(), SubscriptionSet::State::Superseded);
+    }
+}
+
+TEST(ClientReset_DiscardLocal_MakesAwaitingMarkActiveSubscriptionsComplete)
+{
+    SHARED_GROUP_TEST_PATH(path_1);
+    SHARED_GROUP_TEST_PATH(path_2);
+    auto [db, db_fresh] = prepare_db(path_1, path_2, [&](Transaction& tr) {
+        tr.add_table_with_primary_key("class_table", type_Int, "pk");
+    });
+
+    auto tr = db->start_read();
+    Query query = tr->get_table("class_table")->where();
+    auto sub_store = SubscriptionStore::create(db);
+    auto set = add_subscription(*sub_store, "complete", query, SubscriptionSet::State::AwaitingMark);
+    auto future = set.get_state_change_notification(SubscriptionSet::State::Complete);
+
+    expect_reset(test_context, *db, *db_fresh, ClientResyncMode::DiscardLocal, sub_store.get());
+
+    CHECK_EQUAL(future.get(), SubscriptionSet::State::Complete);
+    CHECK_EQUAL(set.state(), SubscriptionSet::State::AwaitingMark);
+    set.refresh();
+    CHECK_EQUAL(set.state(), SubscriptionSet::State::Complete);
 }
 
 } // unnamed namespace

--- a/test/util/test_path.hpp
+++ b/test/util/test_path.hpp
@@ -22,6 +22,7 @@
 #include <string>
 #include <memory>
 
+#include <realm/string_data.hpp>
 #include <realm/util/features.h>
 
 #define TEST_PATH_HELPER(class_name, var_name, suffix)                                                               \
@@ -101,6 +102,10 @@ public:
     {
         return m_path;
     }
+    operator StringData() const
+    {
+        return m_path;
+    }
     const char* c_str() const noexcept
     {
         return m_path.c_str();
@@ -123,6 +128,10 @@ public:
     TestDirGuard(const std::string& path, bool init_clean = true);
     ~TestDirGuard() noexcept;
     operator std::string() const
+    {
+        return m_path;
+    }
+    operator StringData() const
     {
         return m_path;
     }


### PR DESCRIPTION
#7110 accidentally made it so that we no longer complete subscription state notifications in DiscardLocal client resets. I uncovered this while writing tests for a separate set of changes, so this includes some refactoring which those tests depend on.

No changelog entry since the bug hasn't been shipped.