### PR TITLE
Use typed comparisons for set algebra on strings and binary

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 ### Fixed
 * <How do the end-user experience this issue? what was the impact?> ([#????](https://github.com/realm/realm-core/issues/????), since v?.?.?)
 * `Set::assign_intersection()` on `Set<StringData>`, `Set<BinaryData>`, and `Set<Mixed>` containing string or binary would cause a use-after-free if a set was intersected with itself ([PR #7144](https://github.com/realm/realm-core/pull/7144), since v10.0.0).
+* Set algebra on `Set<StringData>` and `Set<BinaryData>` gave incorrect results when used on platforms where `char` is signed ([#7135](https://github.com/realm/realm-core/issues/7135), since v13.23.3).
 
 ### Breaking changes
 * None.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@
 
 ### Fixed
 * <How do the end-user experience this issue? what was the impact?> ([#????](https://github.com/realm/realm-core/issues/????), since v?.?.?)
-* None.
+* `Set::assign_intersection()` on `Set<StringData>`, `Set<BinaryData>`, and `Set<Mixed>` containing string or binary would cause a use-after-free if a set was intersected with itself ([PR #7144](https://github.com/realm/realm-core/pull/7144), since v10.0.0).
 
 ### Breaking changes
 * None.

--- a/src/realm/collection.hpp
+++ b/src/realm/collection.hpp
@@ -124,6 +124,17 @@ public:
         return get_table()->get_column_name(get_col_key());
     }
 
+    bool operator==(const CollectionBase& other) const noexcept
+    {
+        return get_table() == other.get_table() && get_owner_key() == other.get_owner_key() &&
+               get_col_key() == other.get_col_key();
+    }
+
+    bool operator!=(const CollectionBase& other) const noexcept
+    {
+        return !(*this == other);
+    }
+
     // These are shadowed by typed versions in subclasses
     using value_type = Mixed;
     CollectionIterator<CollectionBase> begin() const;
@@ -372,17 +383,6 @@ public:
     using Interface::get_owner_key;
     using Interface::get_table;
     using Interface::get_target_table;
-
-    bool operator==(const CollectionBaseImpl& other) const noexcept
-    {
-        return get_table() == other.get_table() && get_owner_key() == other.get_owner_key() &&
-               get_col_key() == other.get_col_key();
-    }
-
-    bool operator!=(const CollectionBaseImpl& other) const noexcept
-    {
-        return !(*this == other);
-    }
 
 protected:
     Obj m_obj;

--- a/src/realm/set.cpp
+++ b/src/realm/set.cpp
@@ -271,6 +271,9 @@ bool SetBase::set_equals(const CollectionBase& rhs) const
 
 void SetBase::assign_union(const CollectionBase& rhs)
 {
+    if (*this == rhs) {
+        return;
+    }
     if (auto other_set = dynamic_cast<const SetBase*>(&rhs)) {
         return assign_union(other_set->begin(), other_set->end());
     }
@@ -292,6 +295,9 @@ void SetBase::assign_union(It1 first, It2 last)
 
 void SetBase::assign_intersection(const CollectionBase& rhs)
 {
+    if (*this == rhs) {
+        return;
+    }
     if (auto other_set = dynamic_cast<const SetBase*>(&rhs)) {
         return assign_intersection(other_set->begin(), other_set->end());
     }
@@ -313,6 +319,10 @@ void SetBase::assign_intersection(It1 first, It2 last)
 
 void SetBase::assign_difference(const CollectionBase& rhs)
 {
+    if (*this == rhs) {
+        clear();
+        return;
+    }
     if (auto other_set = dynamic_cast<const SetBase*>(&rhs)) {
         return assign_difference(other_set->begin(), other_set->end());
     }
@@ -334,6 +344,10 @@ void SetBase::assign_difference(It1 first, It2 last)
 
 void SetBase::assign_symmetric_difference(const CollectionBase& rhs)
 {
+    if (*this == rhs) {
+        clear();
+        return;
+    }
     if (auto other_set = dynamic_cast<const SetBase*>(&rhs)) {
         return assign_symmetric_difference(other_set->begin(), other_set->end());
     }

--- a/src/realm/set.hpp
+++ b/src/realm/set.hpp
@@ -61,28 +61,6 @@ protected:
         throw InvalidArgument(ErrorCodes::PropertyNotNullable,
                               util::format("Set: %1", CollectionBase::get_property_name()));
     }
-
-private:
-    template <class It1, class It2>
-    bool is_subset_of(It1, It2) const;
-
-    template <class It1, class It2>
-    bool is_superset_of(It1, It2) const;
-
-    template <class It1, class It2>
-    bool intersects(It1, It2) const;
-
-    template <class It1, class It2>
-    void assign_union(It1, It2);
-
-    template <class It1, class It2>
-    void assign_intersection(It1, It2);
-
-    template <class It1, class It2>
-    void assign_difference(It1, It2);
-
-    template <class It1, class It2>
-    void assign_symmetric_difference(It1, It2);
 };
 
 template <class T>

--- a/src/realm/table.cpp
+++ b/src/realm/table.cpp
@@ -2257,6 +2257,11 @@ void Table::set_collision_map(ref_type ref)
     m_top.set(top_position_for_collision_map, RefOrTagged::make_ref(ref));
 }
 
+void Table::set_col_key_sequence_number(uint64_t seq)
+{
+    m_top.set(top_position_for_column_key, RefOrTagged::make_tagged(seq));
+}
+
 TableRef Table::get_link_target(ColKey col_key) noexcept
 {
     return get_opposite_table(col_key);

--- a/src/realm/table.hpp
+++ b/src/realm/table.hpp
@@ -383,6 +383,8 @@ public:
     // Used by upgrade
     void set_sequence_number(uint64_t seq);
     void set_collision_map(ref_type ref);
+    // Used for testing purposes.
+    void set_col_key_sequence_number(uint64_t seq);
 
     // Get the key of this table directly, without needing a Table accessor.
     static TableKey get_key_direct(Allocator& alloc, ref_type top_ref);

--- a/test/test_set.cpp
+++ b/test/test_set.cpp
@@ -369,44 +369,68 @@ TEST_TYPES(Set_Types, Prop<Int>, Prop<String>, Prop<Float>, Prop<Double>, Prop<T
     CHECK(col.is_set());
 
     auto obj = t->create_object();
-    {
-        auto s = obj.get_set<type>(col);
-        auto l = obj.get_list<type>(col_list);
-        auto values = gen.values_from_int<type>({0, 1, 2, 3});
-        for (auto v : values) {
-            s.insert(v);
-            l.add(v);
-        }
-        auto sz = values.size();
-        CHECK_EQUAL(s.size(), sz);
-        auto s1 = s;
-        CHECK_EQUAL(s1.size(), sz);
-        CHECK(s.set_equals(l));
-        for (auto v : values) {
-            auto ndx = s.find(v);
-            CHECK_NOT_EQUAL(ndx, realm::npos);
-        }
-        auto [erased_ndx, erased] = s.erase(values[0]);
-        CHECK(erased);
-        CHECK_EQUAL(erased_ndx, 0);
-        CHECK_EQUAL(s.size(), values.size() - 1);
-        CHECK(s.is_subset_of(l));
+    auto values = gen.values_from_int<type>({0, 1, 2, 3});
 
+    auto l = obj.get_list<type>(col_list);
+    for (auto&& v : values) {
+        l.add(v);
+    }
+
+    auto s = obj.get_set<type>(col);
+    auto populate_set = [&] {
         s.clear();
-        CHECK_EQUAL(s.size(), 0);
-
-        if (TEST_TYPE::is_nullable) {
-            s.insert_null();
-            CHECK_EQUAL(s.size(), 1);
-            auto null_value = TEST_TYPE::default_value();
-            CHECK(value_is_null(null_value));
-            auto ndx = s.find(null_value);
-            CHECK_NOT_EQUAL(ndx, realm::npos);
-            s.erase_null();
-            CHECK_EQUAL(s.size(), 0);
-            ndx = s.find(null_value);
-            CHECK_EQUAL(ndx, realm::npos);
+        for (auto&& v : values) {
+            s.insert(v);
         }
+    };
+
+    populate_set();
+    auto sz = values.size();
+    CHECK_EQUAL(s.size(), sz);
+    auto s1 = s;
+    CHECK_EQUAL(s1.size(), sz);
+    CHECK(s.set_equals(l));
+    for (auto v : values) {
+        auto ndx = s.find(v);
+        CHECK_NOT_EQUAL(ndx, realm::npos);
+    }
+
+    auto [erased_ndx, erased] = s.erase(values[0]);
+    CHECK(erased);
+    CHECK_EQUAL(erased_ndx, 0);
+    CHECK_EQUAL(s.size(), values.size() - 1);
+    CHECK(s.is_subset_of(l));
+
+    s.clear();
+    CHECK_EQUAL(s.size(), 0);
+
+    // Union and intersection with self is a no-op
+    populate_set();
+    s.assign_union(s);
+    CHECK_EQUAL(s.size(), sz);
+    s.assign_intersection(s);
+    CHECK_EQUAL(s.size(), sz);
+
+    // Difference with self is clear()
+    populate_set();
+    s.assign_difference(s);
+    CHECK_EQUAL(s.size(), 0);
+
+    populate_set();
+    s.assign_symmetric_difference(s);
+    CHECK_EQUAL(s.size(), 0);
+
+    if (TEST_TYPE::is_nullable) {
+        s.insert_null();
+        CHECK_EQUAL(s.size(), 1);
+        auto null_value = TEST_TYPE::default_value();
+        CHECK(value_is_null(null_value));
+        auto ndx = s.find(null_value);
+        CHECK_NOT_EQUAL(ndx, realm::npos);
+        s.erase_null();
+        CHECK_EQUAL(s.size(), 0);
+        ndx = s.find(null_value);
+        CHECK_EQUAL(ndx, realm::npos);
     }
 }
 
@@ -848,4 +872,57 @@ TEST(Set_SymmetricDifferenceString)
     CHECK_EQUAL(set1.get(1), "Cosmic love");
     CHECK_EQUAL(set1.get(2), "The fox jumps over the lazy dog");
     CHECK_EQUAL(set1.get(3), "World");
+}
+
+namespace realm {
+template <typename T>
+static std::ostream& operator<<(std::ostream& os, const Set<T>& set)
+{
+    os << "Set(" << set.get_table()->get_key() << ", " << set.get_obj().get_key() << ", " << set.get_col_key() << ")";
+    return os;
+}
+} // namespace realm
+
+TEST(Set_Equality)
+{
+    // Table tries to avoid ColKey collisions, but we specifically want to trigger
+    // them to test that operator== handles them correctly
+    auto set_next_col_key = [](Table& table, int64_t value) {
+        table.set_col_key_sequence_number(value ^ table.get_key().value);
+    };
+
+    Group g_1;
+    auto table_1 = g_1.add_table("table 1");
+    set_next_col_key(*table_1, 5);
+    table_1->add_column_set(type_Int, "set 1");
+    set_next_col_key(*table_1, 10);
+    table_1->add_column_set(type_Int, "set 2");
+    auto table_2 = g_1.add_table("table 2");
+    set_next_col_key(*table_2, 5);
+    table_2->add_column_set(type_Int, "set 1");
+    Group g_2;
+    auto table_3 = g_2.add_table("table 1");
+    set_next_col_key(*table_3, 5);
+    table_3->add_column_set(type_Int, "set 1");
+
+    auto obj_1 = table_1->create_object();
+    auto obj_2 = table_1->create_object();
+    auto obj_3 = table_2->create_object();
+    auto obj_4 = table_3->create_object();
+
+    // Validate our assumptions that we actually do have key overlaps
+    CHECK_EQUAL(table_1->get_key(), table_3->get_key());
+    CHECK_EQUAL(table_1->get_column_key("set 1"), table_2->get_column_key("set 1"));
+    CHECK_EQUAL(obj_1.get_key(), obj_3.get_key());
+    CHECK_EQUAL(obj_1.get_key(), obj_4.get_key());
+
+    CHECK_EQUAL(obj_1.get_set<Int>("set 1"), obj_1.get_set<Int>("set 1"));
+    // Same obj, different col
+    CHECK_NOT_EQUAL(obj_1.get_set<Int>("set 1"), obj_1.get_set<Int>("set 2"));
+    // Same col, different obj
+    CHECK_NOT_EQUAL(obj_1.get_set<Int>("set 1"), obj_2.get_set<Int>("set 1"));
+    // Same col, same obj, different table
+    CHECK_NOT_EQUAL(obj_1.get_set<Int>("set 1"), obj_3.get_set<Int>("set 1"));
+    // Same col, same obj, same table, different group
+    CHECK_NOT_EQUAL(obj_1.get_set<Int>("set 1"), obj_4.get_set<Int>("set 1"));
 }

--- a/test/test_set.cpp
+++ b/test/test_set.cpp
@@ -775,6 +775,8 @@ TEST(Set_Difference)
     Group g;
     auto foos = g.add_table("class_Foo");
     ColKey col_set = foos->add_column_set(type_Int, "int set");
+    ColKey col_set_bin = foos->add_column_set(type_Binary, "bin set");
+    ColKey col_set_str = foos->add_column_set(type_String, "str set");
     ColKey col_list = foos->add_column_list(type_Int, "int list");
 
     auto obj1 = foos->create_object();
@@ -805,6 +807,37 @@ TEST(Set_Difference)
     CHECK_EQUAL(set1.size(), 2);
     CHECK_EQUAL(set1.get(0), 2);
     CHECK_EQUAL(set1.get(1), 3);
+
+    auto set3 = obj1.get_set<BinaryData>(col_set_bin);
+    auto set4 = obj2.get_set<BinaryData>(col_set_bin);
+
+    char buffer[5];
+    auto gen_bin = [&](char c) {
+        for (auto& b : buffer) {
+            b = c;
+        }
+        return BinaryData(buffer, 5);
+    };
+    for (char x : {1, 2}) {
+        set3.insert(gen_bin(x));
+    }
+    for (char x : {255, 1, 2, 3, 2}) {
+        set4.insert(gen_bin(x));
+    }
+    set3.assign_difference(set4);
+    CHECK_EQUAL(set3.size(), 0);
+
+    auto set5 = obj1.get_set<StringData>(col_set_str);
+    auto set6 = obj2.get_set<StringData>(col_set_str);
+
+    for (const char* x : {"Apple", "Banana"}) {
+        set5.insert(x);
+    }
+    for (const char* x : {"Æbler", "Apple", "Banana", "Citrus", "Dade"}) {
+        set6.insert(x);
+    }
+    set5.assign_difference(set6);
+    CHECK_EQUAL(set5.size(), 0);
 }
 
 TEST(Set_SymmetricDifference)


### PR DESCRIPTION
On platforms where `char` is signed, ordering StringData and Mixed containing the same strings gives different results, so we need to use the typed comparisons. This brings us up to 6 instantiations of each operation rather than 2, but it's still a lot less than the 38 we used to have.

While looking at the code I also noticed another problem: `assign_intersection()` cleared the set and then inserted the elements from the RHS set, which is a use-after-free if the RHS set is `this`.

Fixes #7135.