### PR TITLE
Fix client reset cycle detection for PBS recovery errors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 * <How do the end-user experience this issue? what was the impact?> ([#????](https://github.com/realm/realm-core/issues/????), since v?.?.?)
 * `Set::assign_intersection()` on `Set<StringData>`, `Set<BinaryData>`, and `Set<Mixed>` containing string or binary would cause a use-after-free if a set was intersected with itself ([PR #7144](https://github.com/realm/realm-core/pull/7144), since v10.0.0).
 * Set algebra on `Set<StringData>` and `Set<BinaryData>` gave incorrect results when used on platforms where `char` is signed ([#7135](https://github.com/realm/realm-core/issues/7135), since v13.23.3).
+* Errors encountered while reapplying local changes for client reset recovery on partition-based sync Realms would result in the client reset attempt not being recorded, possibly resulting in an endless loop of attempting and failing to automatically recover the client reset. Flexible sync and errors from the server after completing the local recovery were handled correctly ([PR #7149](https://github.com/realm/realm-core/pull/7149), since v10.2.0).
 
 ### Breaking changes
 * None.

--- a/src/realm/sync/noinst/client_reset.cpp
+++ b/src/realm/sync/noinst/client_reset.cpp
@@ -496,6 +496,8 @@ void track_reset(Transaction& wt, ClientResyncMode mode)
                                           {{version_col, metadata_version},
                                            {timestamp_col, Timestamp(std::chrono::system_clock::now())},
                                            {type_col, mode_val}});
+
+    wt.commit_and_continue_writing();
 }
 
 static ClientResyncMode reset_precheck_guard(Transaction& wt, ClientResyncMode mode, bool recovery_is_allowed,

--- a/test/test_client_reset.cpp
+++ b/test/test_client_reset.cpp
@@ -771,8 +771,9 @@ TEST(ClientReset_DoNotRecoverSchema)
         CHECK(!compare_groups(rt_1, rt_2));
 
         const Group& group = rt_1.get_group();
-        CHECK_EQUAL(group.size(), 1);
+        CHECK_EQUAL(group.size(), 2);
         CHECK(group.get_table("class_table1"));
+        CHECK(group.get_table("client_reset_metadata"));
         CHECK_NOT(group.get_table("class_table2"));
         const Group& group2 = rt_2.get_group();
         CHECK_EQUAL(group2.size(), 1);
@@ -867,8 +868,9 @@ void expect_reset(unit_test::TestContext& test_context, DB& target, DB& fresh, C
     CHECK_NOT(fresh.is_attached());
     CHECK_NOT(util::File::exists(fresh_path));
 
-    // Should have performed exactly one write on the target DB
-    CHECK_EQUAL(target.get_version_of_latest_snapshot(), db_version + 1);
+    // Should have performed exactly two writes on the target DB: one to track
+    // that we're attempting recovery, and one with the actual reset
+    CHECK_EQUAL(target.get_version_of_latest_snapshot(), db_version + 2);
 
     // Should have set the client file ident
     CHECK_EQUAL(target.start_read()->get_sync_file_id(), 100);
@@ -895,8 +897,9 @@ void expect_reset(unit_test::TestContext& test_context, DB& target, DB& fresh, C
     CHECK_NOT(fresh.is_attached());
     CHECK_NOT(util::File::exists(fresh_path));
 
-    // Should have performed exactly one write on the target DB
-    CHECK_EQUAL(target.get_version_of_latest_snapshot(), db_version + 1);
+    // Should have performed exactly two writes on the target DB: one to track
+    // that we're attempting recovery, and one with the actual reset
+    CHECK_EQUAL(target.get_version_of_latest_snapshot(), db_version + 2);
 
     // Should have set the client file ident
     CHECK_EQUAL(target.start_read()->get_sync_file_id(), 100);


### PR DESCRIPTION
Tracking that a client reset was in progress was done in the same write transaction as the recovery operation, so if recovery failed the tracking was rolled back too. This worked for FLX due to that codepath committing before beginning recovery.

The good news is that we don't have any reports of users running into this problem, which is a strong sign that client reset recovery failing isn't a common scenario in the first place.