### PR TITLE
Fix duplication of recoverable list changes after unrecoverable changes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 * `Set::assign_intersection()` on `Set<StringData>`, `Set<BinaryData>`, and `Set<Mixed>` containing string or binary would cause a use-after-free if a set was intersected with itself ([PR #7144](https://github.com/realm/realm-core/pull/7144), since v10.0.0).
 * Set algebra on `Set<StringData>` and `Set<BinaryData>` gave incorrect results when used on platforms where `char` is signed ([#7135](https://github.com/realm/realm-core/issues/7135), since v13.23.3).
 * Errors encountered while reapplying local changes for client reset recovery on partition-based sync Realms would result in the client reset attempt not being recorded, possibly resulting in an endless loop of attempting and failing to automatically recover the client reset. Flexible sync and errors from the server after completing the local recovery were handled correctly ([PR #7149](https://github.com/realm/realm-core/pull/7149), since v10.2.0).
+* Automatic client reset recovery would duplicate insertions in a list when recovering a write which made an unrecoverable change to a list (i.e. modifying or deleting a pre-existing entry), followed by a subscription change, followed by a write which added an entry to the list ([PR #7155](https://github.com/realm/realm-core/pull/7155), since v12.3.0).
 
 ### Breaking changes
 * None.

--- a/src/realm/sync/noinst/client_reset.cpp
+++ b/src/realm/sync/noinst/client_reset.cpp
@@ -662,7 +662,7 @@ LocalVersionIDs perform_client_reset_diff(DB& db_local, DB& db_remote, sync::Sal
         // the way to the final state, but since separate commits are necessary, this is
         // unavoidable.
         wt_local = db_local.start_write();
-        RecoverLocalChangesetsHandler handler{*wt_local, *frozen_pre_local_state, logger, db_local.get_replication()};
+        RecoverLocalChangesetsHandler handler{*wt_local, *frozen_pre_local_state, logger};
         handler.process_changesets(local_changes, std::move(pending_subscriptions)); // throws on error
         // The new file ident is set as part of the final commit. This is to ensure that if
         // there are any exceptions during recovery, or the process is killed for some
@@ -678,8 +678,7 @@ LocalVersionIDs perform_client_reset_diff(DB& db_local, DB& db_remote, sync::Sal
         // In PBS recovery, the strategy is to apply all local changes to the remote realm first,
         // and then transfer the modified state all at once to the local Realm. This creates a
         // nice side effect for notifications because only the minimal state change is made.
-        RecoverLocalChangesetsHandler handler{*wt_remote, *frozen_pre_local_state, logger,
-                                              db_remote.get_replication()};
+        RecoverLocalChangesetsHandler handler{*wt_remote, *frozen_pre_local_state, logger};
         handler.process_changesets(local_changes, {}); // throws on error
         ChangesetEncoder& encoder = repl_remote.get_instruction_encoder();
         const sync::ChangesetEncoder::Buffer& buffer = encoder.buffer();

--- a/src/realm/sync/noinst/client_reset_recovery.cpp
+++ b/src/realm/sync/noinst/client_reset_recovery.cpp
@@ -176,13 +176,19 @@ bool ListTracker::remove(uint32_t index, uint32_t& remote_index_out)
 
 bool ListTracker::requires_manual_copy() const
 {
-    return m_requires_manual_copy;
+    // We only ever need to copy a list once as we go straight to the final state
+    return m_requires_manual_copy && !m_has_been_copied;
 }
 
 void ListTracker::queue_for_manual_copy()
 {
     m_requires_manual_copy = true;
     m_indices_allowed.clear();
+}
+
+void ListTracker::mark_as_copied()
+{
+    m_has_been_copied = true;
 }
 
 std::string_view InterningBuffer::get_key(const InternDictKey& key) const
@@ -364,15 +370,13 @@ std::string ListPath::path_to_string(Transaction& remote, const InterningBuffer&
 
 RecoverLocalChangesetsHandler::RecoverLocalChangesetsHandler(Transaction& dest_wt,
                                                              Transaction& frozen_pre_local_state,
-                                                             util::Logger& logger, Replication* repl)
+                                                             util::Logger& logger)
     : InstructionApplier(dest_wt)
     , m_frozen_pre_local_state{frozen_pre_local_state}
     , m_logger{logger}
-    , m_replication{repl}
+    , m_replication{dest_wt.get_replication()}
 {
 }
-
-RecoverLocalChangesetsHandler::~RecoverLocalChangesetsHandler() {}
 
 REALM_NORETURN void RecoverLocalChangesetsHandler::handle_error(const std::string& message) const
 {
@@ -467,12 +471,12 @@ void RecoverLocalChangesetsHandler::copy_lists_with_unrecoverable_changes()
     // we would know where list elements ended up or if they were deleted by the server.
     using namespace realm::converters;
     EmbeddedObjectConverter embedded_object_tracker;
-    for (auto& it : m_lists) {
-        if (!it.second.requires_manual_copy())
+    for (auto& [path, tracker] : m_lists) {
+        if (!tracker.requires_manual_copy())
             continue;
 
-        std::string path_str = it.first.path_to_string(m_transaction, m_intern_keys);
-        bool did_translate = resolve(it.first, [&](LstBase& remote_list, LstBase& local_list) {
+        std::string path_str = path.path_to_string(m_transaction, m_intern_keys);
+        bool did_translate = resolve(path, [&](LstBase& remote_list, LstBase& local_list) {
             ConstTableRef local_table = local_list.get_table();
             ConstTableRef remote_table = remote_list.get_table();
             ColKey local_col_key = local_list.get_col_key();
@@ -486,7 +490,10 @@ void RecoverLocalChangesetsHandler::copy_lists_with_unrecoverable_changes()
             value_converter.copy_value(local_obj, remote_obj, nullptr);
             embedded_object_tracker.process_pending();
         });
-        if (!did_translate) {
+        if (did_translate) {
+            tracker.mark_as_copied();
+        }
+        else {
             // object no longer exists in the local state, ignore and continue
             m_logger.warn("Discarding a list recovery made to an object which could not be resolved. "
                           "remote_path='%1'",
@@ -494,7 +501,6 @@ void RecoverLocalChangesetsHandler::copy_lists_with_unrecoverable_changes()
         }
     }
     embedded_object_tracker.process_pending();
-    m_lists.clear();
 }
 
 bool RecoverLocalChangesetsHandler::resolve_path(ListPath& path, Obj remote_obj, Obj local_obj,
@@ -700,8 +706,6 @@ void RecoverLocalChangesetsHandler::RecoveryResolver::set_last_path_index(uint32
     m_mutable_instr.path[distance] = ndx;
 }
 
-RecoverLocalChangesetsHandler::RecoveryResolver::~RecoveryResolver() {}
-
 void RecoverLocalChangesetsHandler::operator()(const Instruction::AddTable& instr)
 {
     // Rely on InstructionApplier to validate existing tables
@@ -875,11 +879,10 @@ void RecoverLocalChangesetsHandler::operator()(const Instruction::AddColumn& ins
     }
 }
 
-void RecoverLocalChangesetsHandler::operator()(const Instruction::EraseColumn& instr)
+void RecoverLocalChangesetsHandler::operator()(const Instruction::EraseColumn&)
 {
     // Destructive schema changes are not allowed by the resetting client.
-    static_cast<void>(instr);
-    handle_error(util::format("Properties cannot be erased during client reset recovery"));
+    handle_error("Properties cannot be erased during client reset recovery");
 }
 
 void RecoverLocalChangesetsHandler::operator()(const Instruction::ArrayInsert& instr)

--- a/src/realm/sync/noinst/client_reset_recovery.hpp
+++ b/src/realm/sync/noinst/client_reset_recovery.hpp
@@ -47,10 +47,12 @@ struct ListTracker {
     bool remove(uint32_t index, uint32_t& remote_index_out);
     bool requires_manual_copy() const;
     void queue_for_manual_copy();
+    void mark_as_copied();
 
 private:
     std::vector<CrossListIndex> m_indices_allowed;
     bool m_requires_manual_copy = false;
+    bool m_has_been_copied = false;
 };
 
 struct InternDictKey {
@@ -154,9 +156,7 @@ private:
 };
 
 struct RecoverLocalChangesetsHandler : public sync::InstructionApplier {
-    RecoverLocalChangesetsHandler(Transaction& dest_wt, Transaction& frozen_pre_local_state, util::Logger& logger,
-                                  Replication* repl);
-    virtual ~RecoverLocalChangesetsHandler();
+    RecoverLocalChangesetsHandler(Transaction& dest_wt, Transaction& frozen_pre_local_state, util::Logger& logger);
     void process_changesets(const std::vector<sync::ClientHistory::LocalChange>& changesets,
                             std::vector<sync::SubscriptionSet>&& pending_subs);
 
@@ -167,7 +167,6 @@ protected:
     struct RecoveryResolver : public InstructionApplier::PathResolver {
         RecoveryResolver(RecoverLocalChangesetsHandler* applier, Instruction::PathInstruction& instr,
                          const std::string_view& instr_name);
-        virtual ~RecoveryResolver();
         void on_property(Obj&, ColKey) override;
         void on_list(LstBase&) override;
         Status on_list_index(LstBase&, uint32_t) override;

--- a/test/object-store/benchmarks/client_reset.cpp
+++ b/test/object-store/benchmarks/client_reset.cpp
@@ -144,7 +144,7 @@ struct BenchmarkLocalClientReset : public reset_utils::TestClientReset {
             auto history_local = dynamic_cast<sync::ClientHistory*>(wt_local.get_replication()->_get_history_write());
             std::vector<sync::ClientHistory::LocalChange> local_changes =
                 history_local->get_local_changes(current_local_version.version);
-            _impl::client_reset::RecoverLocalChangesetsHandler handler{wt_remote, frozen_local, logger, nullptr};
+            _impl::client_reset::RecoverLocalChangesetsHandler handler{wt_remote, frozen_local, logger};
             handler.process_changesets(local_changes, {}); // throws on error
         }
         _impl::client_reset::transfer_group(wt_remote, wt_local, logger, m_mode == ClientResyncMode::Recover);

--- a/test/test_client_reset.cpp
+++ b/test/test_client_reset.cpp
@@ -1222,4 +1222,67 @@ TEST(ClientReset_DiscardLocal_MakesAwaitingMarkActiveSubscriptionsComplete)
     CHECK_EQUAL(set.state(), SubscriptionSet::State::Complete);
 }
 
+TEST(ClientReset_Recover_RecoverableChangesOnListsAfterUnrecoverableAreNotDuplicated)
+{
+    SHARED_GROUP_TEST_PATH(path_1);
+    SHARED_GROUP_TEST_PATH(path_2);
+    auto [db, db_fresh] = prepare_db(path_1, path_2, [&](Transaction& tr) {
+        auto table = tr.add_table_with_primary_key("class_table", type_Int, "pk");
+        auto col = table->add_column_list(type_Int, "list");
+        auto list = table->create_object_with_primary_key(0).get_list<Int>(col);
+        list.add(0);
+        list.add(1);
+    });
+
+    auto sub_store = SubscriptionStore::create(db);
+    add_subscription(*sub_store, "complete", db->start_read()->get_table("class_table")->where(),
+                     SubscriptionSet::State::Complete);
+
+    { // offline modify local
+        auto wt = db->start_write();
+        auto list = wt->get_table("class_table")->begin()->get_list<Int>("list");
+        // triggers a copy since it's unrecoverable
+        list.remove(0);
+        list.add(4);
+        wt->commit_and_continue_as_read();
+
+        // Pending subscription in between the two writes makes this recovered
+        // in a second write, which shouldn't actually do anything as the new
+        // element was already added by the copy
+        add_subscription(*sub_store, "pending 1", wt->get_table("class_table")->where());
+        wt->promote_to_write();
+        list.add(5);
+        wt->commit();
+    }
+    { // remote modification that should be discarded
+        auto wt = db_fresh->start_write();
+        auto list = wt->get_table("class_table")->begin()->get_list<Int>("list");
+        list.clear();
+        list.add(8);
+        wt->commit();
+    }
+
+    bool did_reset = _impl::client_reset::perform_client_reset(
+        *test_context.logger, *db, *db_fresh, ClientResyncMode::Recover, nullptr, nullptr, {100, 200},
+        sub_store.get(), [](int64_t) {}, true);
+    CHECK(did_reset);
+
+    // List should match the pre-reset local state
+    auto rt = db->start_read();
+    auto list = rt->get_table("class_table")->begin()->get_list<Int>("list");
+    CHECK_EQUAL(list.size(), 3);
+    CHECK_EQUAL(list.get(0), 1);
+    CHECK_EQUAL(list.get(1), 4);
+    CHECK_EQUAL(list.get(2), 5);
+
+    // There should only be one non-empty changeset as the second one did not
+    // write anything
+    auto repl = static_cast<ClientReplication*>(db->get_replication());
+    auto changes = repl->get_history().get_local_changes(rt->get_version());
+    auto non_empty_count = std::count_if(changes.begin(), changes.end(), [](auto&& c) {
+        return c.changeset.size() > 0;
+    });
+    CHECK_EQUAL(non_empty_count, 1);
+}
+
 } // unnamed namespace


### PR DESCRIPTION
After we copy a list in client reset recovery we need to not apply any changes to that list in subsequent transactions as we copy directly to the final state of the list and applying changes would just duplicate those changes.

This is only applicable to flexible sync when there's a subscription change in between the write with unrecoverable changes and the write with recoverable changes.