### PR TITLE
Add missing install headers

### DIFF
--- a/evergreen/config.yml
+++ b/evergreen/config.yml
@@ -721,6 +721,7 @@ tasks:
 
 - name: validate-installed-headers
   exec_timeout_secs: 1800
+  tags: [ "for_pull_requests" ]
   commands:
   - func: "fetch source"
   - func: "fetch binaries"

--- a/src/realm/CMakeLists.txt
+++ b/src/realm/CMakeLists.txt
@@ -210,6 +210,12 @@ set(REALM_INSTALL_HEADERS
     util/base64.hpp
     util/basic_system_errors.hpp
     util/bind_ptr.hpp
+    util/bson/bson.hpp
+    util/bson/indexed_map.hpp
+    util/bson/max_key.hpp
+    util/bson/min_key.hpp
+    util/bson/mongo_timestamp.hpp
+    util/bson/regular_expression.hpp
     util/buffer.hpp
     util/buffer_stream.hpp
     util/cf_ptr.hpp
@@ -273,12 +279,6 @@ set(REALM_NOINST_HEADERS
     util/timestamp_formatter.hpp
     util/timestamp_logger.hpp
     util/value_reset_guard.hpp
-    util/bson/bson.hpp
-    util/bson/min_key.hpp
-    util/bson/max_key.hpp
-    util/bson/regular_expression.hpp
-    util/bson/indexed_map.hpp
-    util/bson/mongo_timestamp.hpp
 ) # REALM_NOINST_HEADERS
 
 if(NOT MSVC)


### PR DESCRIPTION
The validate-install-headers job on realm-core-stable has been [failing](https://parsley.mongodb.com/evergreen/realm_core_stable_macos_validate_installed_headers_750db452530f44213039e67527c74336ade087dd_23_11_23_17_57_22/0/task?bookmarks=0,2743) since https://github.com/realm/realm-core/pull/7157

No changelog, since this hasn't been released yet.
