### PR TITLE
Expand stacktrace buffer for tsan

### DIFF
--- a/evergreen/config.yml
+++ b/evergreen/config.yml
@@ -266,7 +266,8 @@ functions:
           if [[ -n "${run_with_encryption}" ]]; then
               export UNITTEST_ENCRYPT_ALL=1
           fi
-          export TSAN_OPTIONS="suppressions=$(pwd)/test/tsan.suppress"
+          export TSAN_OPTIONS="suppressions=$(pwd)/test/tsan.suppress history_size=4"
+          export UBSAN_OPTIONS="print_stacktrace=1"
 
           cd build
           if ! $CTEST -C ${cmake_build_type|Debug} $TEST_FLAGS; then


### PR DESCRIPTION
Change the default from 2 to 4 to help with 'failed to restore the stack' situation. Also, dump stacktrace for ubsan.

## What, How & Why?
<!-- Describe the changes and give some hints to guide your reviewers if possible. -->
<!-- Link to relevant issue this fixes -->

## ☑️ ToDos
* [ ] 📝 Changelog update
* [ ] 🚦 Tests (or not relevant)
* [ ] C-API, if public C++ API changed
* [ ] `bindgen/spec.yml`, if public C++ API changed
