### PR TITLE
Update spec.yml to expose `Dictionary::add_key_based_notification_callback` correctly

### DIFF
--- a/bindgen/spec.yml
+++ b/bindgen/spec.yml
@@ -1079,7 +1079,7 @@ classes:
       get_pair: '(ndx: count_t) const -> std::pair<StringData, Mixed>'
       contains: '(key: StringData) -> bool'
       freeze: '(frozen_realm: SharedRealm const&) const -> Dictionary'
-      add_key_based_notification_callback: '(cb: (changes: DictionaryChangeSet), keyPaths: KeyPathArray) -> NotificationToken'
+      add_key_based_notification_callback: '(cb: (changes: DictionaryChangeSet), keyPaths: util::Optional<KeyPathArray>) -> NotificationToken'
       insert_any: '(key: StringData, value: Mixed) -> std::pair<count_t, bool>'
       insert_embedded: '(key: StringData) -> Obj'
       try_get_any: '(key: StringData) const -> util::Optional<Mixed>'


### PR DESCRIPTION
## What, How & Why?
As per https://github.com/realm/realm-core/blob/master/src/realm/object-store/dictionary.hpp#L122 the second argument is optional.

## ☑️ ToDos
* [ ] 📝 Changelog update
* [ ] 🚦 Tests (or not relevant)
* [ ] C-API, if public C++ API changed
* [x] `bindgen/spec.yml`, if public C++ API changed
