### PR TITLE
Gracefully handle all exceptions during bootstrap processing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,12 +1,10 @@
 # NEXT RELEASE
 
 ### Enhancements
-* <New feature description> (PR [#????](https://github.com/realm/realm-core/pull/????))
-* None.
+* Exceptions thrown during bootstrap application will now be surfaced to the user via the sync error handler rather than terminating the program with an unhandled exception. ([PR #7197](https://github.com/realm/realm-core/pull/7197)).
 
 ### Fixed
-* <How do the end-user experience this issue? what was the impact?> ([#????](https://github.com/realm/realm-core/issues/????), since v?.?.?)
-* None.
+* Exceptions thrown during bootstrap application could crash the sync client with an `!m_sess` assertion if the bootstrap was being applied during sync::Session activation. ([#7196](https://github.com/realm/realm-core/issues/7196), since v12.0.0).
 
 ### Breaking changes
 * None.

--- a/src/realm/sync/config.hpp
+++ b/src/realm/sync/config.hpp
@@ -129,6 +129,7 @@ enum class SyncClientHookEvent {
     BootstrapMessageProcessed,
     BootstrapProcessed,
     ErrorMessageReceived,
+    BootstrapBatchAboutToProcess,
 };
 
 enum class SyncClientHookAction {

--- a/src/realm/sync/noinst/client_history_impl.hpp
+++ b/src/realm/sync/noinst/client_history_impl.hpp
@@ -71,12 +71,18 @@ constexpr int get_client_history_schema_version() noexcept
     return 12;
 }
 
-class IntegrationException : public RuntimeError {
+class IntegrationException : public Exception {
 public:
     IntegrationException(ErrorCodes::Error error, std::string message,
                          ProtocolError error_for_server = ProtocolError::other_session_error)
-        : RuntimeError(error, message)
+        : Exception(error, message)
         , error_for_server(error_for_server)
+    {
+    }
+
+    explicit IntegrationException(Status status)
+        : Exception(std::move(status))
+        , error_for_server(ProtocolError::other_session_error)
     {
     }
 

--- a/src/realm/sync/noinst/client_impl_base.cpp
+++ b/src/realm/sync/noinst/client_impl_base.cpp
@@ -1581,9 +1581,10 @@ void Session::on_integration_failure(const IntegrationException& error)
 
     m_client_error = util::make_optional<IntegrationException>(error);
     m_error_to_send = true;
-
+    SessionErrorInfo error_info{error.to_status(), IsFatal{false}};
+    error_info.server_requests_action = ProtocolErrorInfo::Action::Warning;
     // Surface the error to the user otherwise is lost.
-    on_connection_state_changed(m_conn.get_state(), SessionErrorInfo{error.to_status(), IsFatal{false}});
+    on_connection_state_changed(m_conn.get_state(), std::move(error_info));
 
     // Since the deactivation process has not been initiated, the UNBIND
     // message cannot have been sent unless an ERROR message was received.
@@ -1684,10 +1685,10 @@ void Session::activate()
         process_pending_flx_bootstrap();
     }
     catch (const IntegrationException& error) {
-        logger.error("Error integrating bootstrap changesets: %1", error.what());
-        m_suspended = true;
-        m_conn.one_less_active_unsuspended_session(); // Throws
-        on_suspended(SessionErrorInfo{Status{error.code(), error.what()}, IsFatal{true}});
+        on_integration_failure(error);
+    }
+    catch (...) {
+        on_integration_failure(IntegrationException(exception_to_status()));
     }
 
     if (has_pending_client_reset) {

--- a/test/object-store/sync/flx_sync.cpp
+++ b/test/object-store/sync/flx_sync.cpp
@@ -2573,6 +2573,13 @@ TEST_CASE("flx: commit subscription while refreshing the access token", "[sync][
 }
 
 TEST_CASE("flx: bootstrap batching prevents orphan documents", "[sync][flx][bootstrap][baas]") {
+    struct NovelException : public std::exception {
+        const char* what() const noexcept override
+        {
+            return "Oh no, a really weird exception happened!";
+        }
+    };
+
     FLXSyncTestHarness harness("flx_bootstrap_batching", {g_large_array_schema, {"queryable_int_field"}});
 
     std::vector<ObjectId> obj_ids_at_end = fill_large_array_schema(harness);
@@ -2605,7 +2612,7 @@ TEST_CASE("flx: bootstrap batching prevents orphan documents", "[sync][flx][boot
         });
     };
 
-    SECTION("exception occurs during bootstrap application") {
+    SECTION("unknown exception occurs during bootstrap application on session startup") {
         {
             auto [interrupted_promise, interrupted] = util::make_promise_future<void>();
             Realm::Config config = interrupted_realm_config;
@@ -2660,7 +2667,6 @@ TEST_CASE("flx: bootstrap batching prevents orphan documents", "[sync][flx][boot
             check_interrupted_state(realm);
         }
 
-        interrupted_realm_config.sync_config->simulate_integration_error = true;
         auto error_pf = util::make_promise_future<SyncError>();
         interrupted_realm_config.sync_config->error_handler =
             [promise = std::make_shared<util::Promise<SyncError>>(std::move(error_pf.promise))](
@@ -2668,10 +2674,104 @@ TEST_CASE("flx: bootstrap batching prevents orphan documents", "[sync][flx][boot
                 promise->emplace_value(std::move(error));
             };
 
+        interrupted_realm_config.sync_config->on_sync_client_event_hook =
+            [&, download_message_received = false](std::weak_ptr<SyncSession>,
+                                                   const SyncClientHookData& data) mutable {
+                if (data.event == SyncClientHookEvent::DownloadMessageReceived) {
+                    download_message_received = true;
+                }
+                if (data.event != SyncClientHookEvent::BootstrapBatchAboutToProcess) {
+                    return SyncClientHookAction::NoAction;
+                }
+
+                REQUIRE(!download_message_received);
+                throw NovelException{};
+                return SyncClientHookAction::NoAction;
+            };
+
         auto realm = Realm::get_shared_realm(interrupted_realm_config);
         const auto& error = error_pf.future.get();
-        REQUIRE(error.is_fatal);
-        REQUIRE(error.status == ErrorCodes::BadChangeset);
+        REQUIRE(!error.is_fatal);
+        REQUIRE(error.server_requests_action == sync::ProtocolErrorInfo::Action::Warning);
+        REQUIRE(error.status == ErrorCodes::UnknownError);
+        REQUIRE_THAT(error.status.reason(),
+                     Catch::Matchers::ContainsSubstring("Oh no, a really weird exception happened!"));
+    }
+
+    SECTION("exception occurs during bootstrap application") {
+        Status error_status(ErrorCodes::OutOfMemory, "no more memory!");
+        {
+            auto [interrupted_promise, interrupted] = util::make_promise_future<void>();
+            Realm::Config config = interrupted_realm_config;
+            config.sync_config = std::make_shared<SyncConfig>(*interrupted_realm_config.sync_config);
+            config.sync_config->on_sync_client_event_hook = [&](std::weak_ptr<SyncSession> weak_session,
+                                                                const SyncClientHookData& data) mutable {
+                if (data.event != SyncClientHookEvent::BootstrapBatchAboutToProcess) {
+                    return SyncClientHookAction::NoAction;
+                }
+                auto session = weak_session.lock();
+                if (!session) {
+                    return SyncClientHookAction::NoAction;
+                }
+
+                if (data.query_version == 1 && data.batch_state == sync::DownloadBatchState::MoreToCome) {
+                    throw sync::IntegrationException(error_status);
+                }
+                return SyncClientHookAction::NoAction;
+            };
+            auto error_pf = util::make_promise_future<SyncError>();
+            config.sync_config->error_handler =
+                [promise = std::make_shared<util::Promise<SyncError>>(std::move(error_pf.promise))](
+                    std::shared_ptr<SyncSession>, SyncError error) {
+                    promise->emplace_value(std::move(error));
+                };
+
+
+            auto realm = Realm::get_shared_realm(config);
+            {
+                auto mut_subs = realm->get_latest_subscription_set().make_mutable_copy();
+                auto table = realm->read_group().get_table("class_TopLevel");
+                mut_subs.insert_or_assign(Query(table));
+                mut_subs.commit();
+            }
+
+            auto error = error_pf.future.get();
+            REQUIRE(error.status.reason() == error_status.reason());
+            REQUIRE(error.status == error_status);
+            realm->sync_session()->shutdown_and_wait();
+            realm->close();
+        }
+
+        _impl::RealmCoordinator::assert_no_open_realms();
+
+        // Open up the realm without the sync client attached and verify that the realm got interrupted in the state
+        // we expected it to be in.
+        {
+            DBOptions options;
+            options.encryption_key = test_util::crypt_key();
+            auto realm = DB::create(sync::make_client_replication(), interrupted_realm_config.path, options);
+            util::StderrLogger logger;
+            sync::PendingBootstrapStore bootstrap_store(realm, logger);
+            REQUIRE(bootstrap_store.has_pending());
+            auto pending_batch = bootstrap_store.peek_pending(1024 * 1024 * 16);
+            REQUIRE(pending_batch.query_version == 1);
+            REQUIRE(pending_batch.progress);
+
+            check_interrupted_state(realm);
+        }
+
+        auto realm = Realm::get_shared_realm(interrupted_realm_config);
+        auto table = realm->read_group().get_table("class_TopLevel");
+        realm->get_latest_subscription_set()
+            .get_state_change_notification(sync::SubscriptionSet::State::Complete)
+            .get();
+
+        wait_for_advance(*realm);
+
+        REQUIRE(table->size() == obj_ids_at_end.size());
+        for (auto& id : obj_ids_at_end) {
+            REQUIRE(table->find_primary_key(Mixed{id}));
+        }
     }
 
     SECTION("interrupted before final bootstrap message") {


### PR DESCRIPTION
## What, How & Why?
This makes sure we catch exceptions getting thrown during bootstrap application and surface them to the user via the sync error handler. It also fixes one place during session activation where we were not exception-safe which may have caused an uncaught exception to manifest as a `REALM_ASSERT(!m_sess)` failure rather than a regular uncaught exception.

## ☑️ ToDos
* [x] 📝 Changelog update
* [x] 🚦 Tests (or not relevant)
* [ ] C-API, if public C++ API changed
* [ ] `bindgen/spec.yml`, if public C++ API changed
