### PR TITLE
Disable failing ci builders

### DIFF
--- a/evergreen/config.yml
+++ b/evergreen/config.yml
@@ -1736,7 +1736,7 @@ buildvariants:
     cmake_toolchain_file: "./tools/cmake/xcode.toolchain.cmake"
     cmake_generator: Xcode
     max_jobs: $(sysctl -n hw.logicalcpu)
-    xcode_developer_dir: /Applications/Xcode15.1.app/Contents/Developer
+    # xcode_developer_dir: /Applications/Xcode.app/Contents/Developer
     extra_flags: -DCMAKE_SYSTEM_NAME=Darwin -DCMAKE_OSX_ARCHITECTURES=arm64
     cmake_build_type: RelWithDebInfo
     enable_tsan: On

--- a/evergreen/config.yml
+++ b/evergreen/config.yml
@@ -1563,13 +1563,14 @@ buildvariants:
     python3: "/opt/mongodbtoolchain/v3/bin/python3"
     use_system_openssl: On
     fetch_missing_dependencies: On
+    cmake_build_type: RelWithDebInfo
   tasks:
   - name: compile_test_and_package
   - name: benchmarks
 
-- name: ubuntu2004-arm64-asan
-  display_name: "Ubuntu 20.04 ARM64 (ASAN)"
-  run_on: ubuntu2004-arm64-large
+- name: ubuntu2204-arm64-asan
+  display_name: "Ubuntu 22.04 ARM64 (ASAN)"
+  run_on: ubuntu2204-arm64-large
   expansions:
     cmake_url: "https://s3.amazonaws.com/static.realm.io/evergreen-assets/cmake-3.20.3-linux-aarch64.tar.gz"
     cmake_bindir: "./cmake_binaries/bin"
@@ -1581,9 +1582,9 @@ buildvariants:
   tasks:
   - name: compile_test
 
-- name: ubuntu2004-arm64-tsan
-  display_name: "Ubuntu 20.04 ARM64 (TSAN)"
-  run_on: ubuntu2004-arm64-large
+- name: ubuntu2204-arm64-tsan
+  display_name: "Ubuntu 22.04 ARM64 (TSAN)"
+  run_on: ubuntu2204-arm64-large
   expansions:
     cmake_url: "https://s3.amazonaws.com/static.realm.io/evergreen-assets/cmake-3.20.3-linux-aarch64.tar.gz"
     cmake_bindir: "./cmake_binaries/bin"
@@ -1726,23 +1727,23 @@ buildvariants:
   tasks:
   - name: compile_test
 
-- name: macos-1100-arm64-tsan
-  display_name: "MacOS 11 arm64 (TSAN)"
-  run_on: macos-1100-arm64
+- name: macos-1300-arm64-tsan
+  display_name: "MacOS 13 arm64 (TSAN)"
+  run_on: macos-1300-arm64
   expansions:
     cmake_url: "https://s3.amazonaws.com/static.realm.io/evergreen-assets/cmake-3.20.3-macos-universal.tar.gz"
     cmake_bindir: "./cmake_binaries/CMake.app/Contents/bin"
     cmake_toolchain_file: "./tools/cmake/xcode.toolchain.cmake"
     cmake_generator: Xcode
     max_jobs: $(sysctl -n hw.logicalcpu)
-    xcode_developer_dir: /Applications/Xcode13.1.app/Contents/Developer
+    xcode_developer_dir: /Applications/Xcode.app/Contents/Developer
     extra_flags: -DCMAKE_SYSTEM_NAME=Darwin -DCMAKE_OSX_ARCHITECTURES=arm64
     cmake_build_type: RelWithDebInfo
     enable_tsan: On
   tasks:
   # FIXME: tsan is not stable on arm64, fails often with internal errors
-  # - name: compile_test
-  - name: compile_test_object_store
+  - name: compile_test
+  #- name: compile_test_object_store
 
 - name: macos-coverage
   display_name: "MacOS 11 arm64 (Code Coverage)"

--- a/evergreen/config.yml
+++ b/evergreen/config.yml
@@ -1722,7 +1722,7 @@ buildvariants:
     cmake_toolchain_file: "./tools/cmake/xcode.toolchain.cmake"
     cmake_generator: Xcode
     max_jobs: $(sysctl -n hw.logicalcpu)
-    # xcode_developer_dir: /Applications/Xcode.app/Contents/Developer
+    xcode_developer_dir: /Applications/Xcode14.app/Contents/Developer
     extra_flags: -DCMAKE_SYSTEM_NAME=Darwin -DCMAKE_OSX_ARCHITECTURES=arm64
     cmake_build_type: RelWithDebInfo
     enable_tsan: On

--- a/evergreen/config.yml
+++ b/evergreen/config.yml
@@ -1567,6 +1567,34 @@ buildvariants:
   - name: compile_test_and_package
   - name: benchmarks
 
+- name: ubuntu2004-arm64-asan
+  display_name: "Ubuntu 20.04 ARM64 (ASAN)"
+  run_on: ubuntu2004-arm64-large
+  expansions:
+    cmake_url: "https://s3.amazonaws.com/static.realm.io/evergreen-assets/cmake-3.20.3-linux-aarch64.tar.gz"
+    cmake_bindir: "./cmake_binaries/bin"
+    python3: "/opt/mongodbtoolchain/v3/bin/python3"
+    use_system_openssl: On
+    fetch_missing_dependencies: On
+    cmake_build_type: RelWithDebInfo
+    enable_asan: On
+  tasks:
+  - name: compile_test
+
+- name: ubuntu2004-arm64-tsan
+  display_name: "Ubuntu 20.04 ARM64 (TSAN)"
+  run_on: ubuntu2004-arm64-large
+  expansions:
+    cmake_url: "https://s3.amazonaws.com/static.realm.io/evergreen-assets/cmake-3.20.3-linux-aarch64.tar.gz"
+    cmake_bindir: "./cmake_binaries/bin"
+    python3: "/opt/mongodbtoolchain/v3/bin/python3"
+    use_system_openssl: On
+    fetch_missing_dependencies: On
+    cmake_build_type: RelWithDebInfo
+    enable_tsan: On
+  tasks:
+  - name: compile_test
+
 - name: macos
   display_name: "MacOS 11.0 x86_64"
   run_on: macos-1100

--- a/evergreen/config.yml
+++ b/evergreen/config.yml
@@ -1215,6 +1215,22 @@ task_groups:
   - .test_suite
   - .object_store_test_suite
 
+# compile and run only object store tests: local and remote
+- name: compile_test_object_store
+  max_hosts: 1
+  setup_group_can_fail_task: true
+  setup_group:
+  - func: "fetch source"
+  - func: "fetch binaries"
+  teardown_task:
+  - func: "upload test results"
+  - func: "upload baas artifacts"
+  timeout:
+  - func: "run hang analyzer"
+  tasks:
+  - compile
+  - .object_store_test_suite
+
 # Runs object-store-tests against baas running on remote host and runs
 # the network simulation tests as a separate task for nightly builds
 - name: network_tests
@@ -1696,7 +1712,9 @@ buildvariants:
     cmake_build_type: RelWithDebInfo
     enable_tsan: On
   tasks:
-  - name: compile_test
+  # FIXME: tsan is not stable on arm64, fails often with internal errors
+  # - name: compile_test
+  - name: compile_test_object_store
 
 - name: macos-coverage
   display_name: "MacOS 11 arm64 (Code Coverage)"

--- a/evergreen/config.yml
+++ b/evergreen/config.yml
@@ -1582,20 +1582,6 @@ buildvariants:
   tasks:
   - name: compile_test
 
-- name: ubuntu2204-arm64-tsan
-  display_name: "Ubuntu 22.04 ARM64 (TSAN)"
-  run_on: ubuntu2204-arm64-large
-  expansions:
-    cmake_url: "https://s3.amazonaws.com/static.realm.io/evergreen-assets/cmake-3.20.3-linux-aarch64.tar.gz"
-    cmake_bindir: "./cmake_binaries/bin"
-    python3: "/opt/mongodbtoolchain/v3/bin/python3"
-    use_system_openssl: On
-    fetch_missing_dependencies: On
-    cmake_build_type: RelWithDebInfo
-    enable_tsan: On
-  tasks:
-  - name: compile_test_object_store
-
 - name: macos
   display_name: "MacOS 11.0 x86_64"
   run_on: macos-1100

--- a/evergreen/config.yml
+++ b/evergreen/config.yml
@@ -1465,50 +1465,51 @@ buildvariants:
   tasks:
   - name: fuzzer-tests
 
-- name: ubuntu2004-network-nonideal
-  display_name: "Ubuntu 20.04 x86_64 (Utunbu2004 - nonideal transfer)"
-  run_on: ubuntu2004-large
-  expansions:
-    clang_url: "https://s3.amazonaws.com/static.realm.io/evergreen-assets/clang%2Bllvm-11.0.0-x86_64-linux-gnu-ubuntu-20.04.tar.xz"
-    cmake_url: "https://s3.amazonaws.com/static.realm.io/evergreen-assets/cmake-3.20.3-linux-x86_64.tar.gz"
-    cmake_bindir: "./cmake_binaries/bin"
-    fetch_missing_dependencies: On
-    c_compiler: "./clang_binaries/bin/clang"
-    cxx_compiler: "./clang_binaries/bin/clang++"
-    cmake_build_type: RelWithDebInfo
-    run_with_encryption: On
-    baas_admin_port: 9098
-    test_logging_level: debug
-    test_timeout_extra: 60
-    proxy_toxics_file: evergreen/proxy-nonideal-transfer.toxics
-    # RANDOM1: bandwidth-upstream limited to between 10-50 KB/s from the client to the server
-    # RANDOM2: bandwidth-downstream limited to between 10-50 KB/s from the server to the client
-    proxy_toxics_randoms: "10:50|10:50"
-  tasks:
-  - name: network_tests
-
-- name: ubuntu2004-network-faulty
-  display_name: "Ubuntu 20.04 x86_64 (Utunbu2004 - network faults)"
-  run_on: ubuntu2004-large
-  expansions:
-    clang_url: "https://s3.amazonaws.com/static.realm.io/evergreen-assets/clang%2Bllvm-11.0.0-x86_64-linux-gnu-ubuntu-20.04.tar.xz"
-    cmake_url: "https://s3.amazonaws.com/static.realm.io/evergreen-assets/cmake-3.20.3-linux-x86_64.tar.gz"
-    cmake_bindir: "./cmake_binaries/bin"
-    fetch_missing_dependencies: On
-    c_compiler: "./clang_binaries/bin/clang"
-    cxx_compiler: "./clang_binaries/bin/clang++"
-    cmake_build_type: RelWithDebInfo
-    run_with_encryption: On
-    baas_admin_port: 9098
-    test_logging_level: debug
-    proxy_toxics_file: evergreen/proxy-network-faults.toxics
-    # RANDOM1: limit-data-upstream to close connection after between 1000-3000 bytes have been sent
-    # RANDOM2: limit-data-downstream to close connection after between 1000-3000 bytes have been received
-    # RANDOM3: slow-close-upstream to keep connection to server open after 1000-1500 milliseconds after being closed
-    # RANDOM4: reset-peer-upstream after 50-200 seconds to force close the connection to the server
-    proxy_toxics_randoms: "1000:3000|1000:3000|1000:1500|50:200"
-  tasks:
-  - name: network_tests
+# disable these builders since there are constantly failing and not yet ready for nightly builds
+# - name: ubuntu2004-network-nonideal
+#   display_name: "Ubuntu 20.04 x86_64 (Utunbu2004 - nonideal transfer)"
+#   run_on: ubuntu2004-large
+#   expansions:
+#     clang_url: "https://s3.amazonaws.com/static.realm.io/evergreen-assets/clang%2Bllvm-11.0.0-x86_64-linux-gnu-ubuntu-20.04.tar.xz"
+#     cmake_url: "https://s3.amazonaws.com/static.realm.io/evergreen-assets/cmake-3.20.3-linux-x86_64.tar.gz"
+#     cmake_bindir: "./cmake_binaries/bin"
+#     fetch_missing_dependencies: On
+#     c_compiler: "./clang_binaries/bin/clang"
+#     cxx_compiler: "./clang_binaries/bin/clang++"
+#     cmake_build_type: RelWithDebInfo
+#     run_with_encryption: On
+#     baas_admin_port: 9098
+#     test_logging_level: debug
+#     test_timeout_extra: 60
+#     proxy_toxics_file: evergreen/proxy-nonideal-transfer.toxics
+#     # RANDOM1: bandwidth-upstream limited to between 10-50 KB/s from the client to the server
+#     # RANDOM2: bandwidth-downstream limited to between 10-50 KB/s from the server to the client
+#     proxy_toxics_randoms: "10:50|10:50"
+#   tasks:
+#   - name: network_tests
+#
+# - name: ubuntu2004-network-faulty
+#   display_name: "Ubuntu 20.04 x86_64 (Utunbu2004 - network faults)"
+#   run_on: ubuntu2004-large
+#   expansions:
+#     clang_url: "https://s3.amazonaws.com/static.realm.io/evergreen-assets/clang%2Bllvm-11.0.0-x86_64-linux-gnu-ubuntu-20.04.tar.xz"
+#     cmake_url: "https://s3.amazonaws.com/static.realm.io/evergreen-assets/cmake-3.20.3-linux-x86_64.tar.gz"
+#     cmake_bindir: "./cmake_binaries/bin"
+#     fetch_missing_dependencies: On
+#     c_compiler: "./clang_binaries/bin/clang"
+#     cxx_compiler: "./clang_binaries/bin/clang++"
+#     cmake_build_type: RelWithDebInfo
+#     run_with_encryption: On
+#     baas_admin_port: 9098
+#     test_logging_level: debug
+#     proxy_toxics_file: evergreen/proxy-network-faults.toxics
+#     # RANDOM1: limit-data-upstream to close connection after between 1000-3000 bytes have been sent
+#     # RANDOM2: limit-data-downstream to close connection after between 1000-3000 bytes have been received
+#     # RANDOM3: slow-close-upstream to keep connection to server open after 1000-1500 milliseconds after being closed
+#     # RANDOM4: reset-peer-upstream after 50-200 seconds to force close the connection to the server
+#     proxy_toxics_randoms: "1000:3000|1000:3000|1000:1500|50:200"
+#   tasks:
+#   - name: network_tests
 
 - name: rhel70
   display_name: "RHEL 7 x86_64"

--- a/evergreen/config.yml
+++ b/evergreen/config.yml
@@ -1577,7 +1577,7 @@ buildvariants:
     python3: "/opt/mongodbtoolchain/v3/bin/python3"
     use_system_openssl: On
     fetch_missing_dependencies: On
-    cmake_build_type: RelWithDebInfo
+    cmake_build_type: Debug
     enable_asan: On
   tasks:
   - name: compile_test
@@ -1594,7 +1594,7 @@ buildvariants:
     cmake_build_type: RelWithDebInfo
     enable_tsan: On
   tasks:
-  - name: compile_test
+  - name: compile_test_object_store
 
 - name: macos
   display_name: "MacOS 11.0 x86_64"
@@ -1736,7 +1736,7 @@ buildvariants:
     cmake_toolchain_file: "./tools/cmake/xcode.toolchain.cmake"
     cmake_generator: Xcode
     max_jobs: $(sysctl -n hw.logicalcpu)
-    xcode_developer_dir: /Applications/Xcode.app/Contents/Developer
+    xcode_developer_dir: /Applications/Xcode15.1.app/Contents/Developer
     extra_flags: -DCMAKE_SYSTEM_NAME=Darwin -DCMAKE_OSX_ARCHITECTURES=arm64
     cmake_build_type: RelWithDebInfo
     enable_tsan: On

--- a/evergreen/config.yml
+++ b/evergreen/config.yml
@@ -1713,23 +1713,23 @@ buildvariants:
   tasks:
   - name: compile_test
 
-- name: macos-1300-arm64-tsan
-  display_name: "MacOS 13 arm64 (TSAN)"
-  run_on: macos-1300-arm64
+- name: macos-1100-arm64-tsan
+  display_name: "MacOS 11 arm64 (TSAN)"
+  run_on: macos-1100-arm64
   expansions:
     cmake_url: "https://s3.amazonaws.com/static.realm.io/evergreen-assets/cmake-3.20.3-macos-universal.tar.gz"
     cmake_bindir: "./cmake_binaries/CMake.app/Contents/bin"
     cmake_toolchain_file: "./tools/cmake/xcode.toolchain.cmake"
     cmake_generator: Xcode
     max_jobs: $(sysctl -n hw.logicalcpu)
-    xcode_developer_dir: /Applications/Xcode14.app/Contents/Developer
+    xcode_developer_dir: /Applications/Xcode13.1.app/Contents/Developer
     extra_flags: -DCMAKE_SYSTEM_NAME=Darwin -DCMAKE_OSX_ARCHITECTURES=arm64
     cmake_build_type: RelWithDebInfo
     enable_tsan: On
   tasks:
   # FIXME: tsan is not stable on arm64, fails often with internal errors
-  - name: compile_test
-  #- name: compile_test_object_store
+  # - name: compile_test
+  - name: compile_test_object_store
 
 - name: macos-coverage
   display_name: "MacOS 11 arm64 (Code Coverage)"

--- a/test/tsan.suppress
+++ b/test/tsan.suppress
@@ -11,8 +11,11 @@ race:realm::util::EncryptedFileMapping::copy_up_to_date_page
 
 # Avoid a false positive instance of lock-order-inversion.
 # SyncManager::m_sessions_mutex and SyncSession::m_state_mutex are locked
-# in this order when a SyncSession is created, and in reverse order when 
+# in this order when a SyncSession is created, and in reverse order when
 # SyncSession::become_inactive is called. Creating a SyncSession and becoming
 # inactive cannot happen at the same time.
 deadlock:realm::sync::MigrationStore::create_sentinel_subscription_set
 deadlock:realm::sync::MigrationStore::create_subscriptions
+
+# mktime, timegm, gmtime modify global time zone env var, but the race is harmless
+race:adjtime


### PR DESCRIPTION
## What, How & Why?
* Disable builders testing faulty network - it was not supposed to run since it's not yet ready, and 'disable' tag doesn't work as expected
* Also, don't run core/sync internal test on new macos arm64 with tsan since it's not stable with apple clang 13 #7185
* Introduce new builders for asan/tsan on ubuntu arm64

## ☑️ ToDos
* [ ] ~📝 Changelog update~
* [ ] ~🚦 Tests (or not relevant)~
* [ ] ~C-API, if public C++ API changed~
* [ ] ~`bindgen/spec.yml`, if public C++ API changed~
