### PR TITLE
Allow calling handle_reconnect() multiple times after a non-fatal error

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 
 ### Fixed
 * Exceptions thrown during bootstrap application could crash the sync client with an `!m_sess` assertion if the bootstrap was being applied during sync::Session activation. ([#7196](https://github.com/realm/realm-core/issues/7196), since v12.0.0).
+* If a SyncSession was explicitly resumed via `handle_reconnect()` while it was waiting to auto-resume after a non-fatal error and then another non-fatal error was received, the sync client could crash with a `!m_try_again_activation_timer` assertion. ([#6961](https://github.com/realm/realm-core/issues/6961), since always)
 
 ### Breaking changes
 * None.

--- a/src/realm/sync/config.hpp
+++ b/src/realm/sync/config.hpp
@@ -129,6 +129,8 @@ enum class SyncClientHookEvent {
     BootstrapMessageProcessed,
     BootstrapProcessed,
     ErrorMessageReceived,
+    SessionSuspended,
+    BindMessageSent,
 };
 
 enum class SyncClientHookAction {

--- a/src/realm/sync/noinst/client_impl_base.cpp
+++ b/src/realm/sync/noinst/client_impl_base.cpp
@@ -1894,7 +1894,8 @@ void Session::send_bind_message()
     m_conn.initiate_write_message(out, this); // Throws
 
     m_bind_message_sent = true;
-    call_debug_hook(SyncClientHookEvent::BindMessageSent, m_progress, m_last_sent_flx_query_version, DownloadBatchState::SteadyState, 0);
+    call_debug_hook(SyncClientHookEvent::BindMessageSent, m_progress, m_last_sent_flx_query_version,
+                    DownloadBatchState::SteadyState, 0);
 
     // Ready to send the IDENT message if the file identifier pair is already
     // available.

--- a/src/realm/sync/noinst/client_impl_base.cpp
+++ b/src/realm/sync/noinst/client_impl_base.cpp
@@ -1491,6 +1491,9 @@ void Session::cancel_resumption_delay()
         initiate_rebind(); // Throws
 
     m_conn.one_more_active_unsuspended_session(); // Throws
+    if (m_try_again_activation_timer) {
+        m_try_again_activation_timer.reset();
+    }
 
     on_resumed(); // Throws
 }
@@ -1891,6 +1894,7 @@ void Session::send_bind_message()
     m_conn.initiate_write_message(out, this); // Throws
 
     m_bind_message_sent = true;
+    call_debug_hook(SyncClientHookEvent::BindMessageSent, m_progress, m_last_sent_flx_query_version, DownloadBatchState::SteadyState, 0);
 
     // Ready to send the IDENT message if the file identifier pair is already
     // available.
@@ -2565,6 +2569,7 @@ void Session::suspend(const SessionErrorInfo& info)
     // Notify the application of the suspension of the session if the session is
     // still in the Active state
     if (m_state == Active) {
+        call_debug_hook(SyncClientHookEvent::SessionSuspended, info);
         m_conn.one_less_active_unsuspended_session(); // Throws
         on_suspended(info);                           // Throws
     }

--- a/src/realm/sync/noinst/client_impl_base.hpp
+++ b/src/realm/sync/noinst/client_impl_base.hpp
@@ -1412,8 +1412,8 @@ inline void ClientImpl::Session::request_download_completion_notification()
 
     // Since the deactivation process has not been initiated, the UNBIND message
     // cannot have been sent unless an ERROR message was received.
-    REALM_ASSERT(m_suspended || !m_unbind_message_sent);
-    if (m_ident_message_sent && !m_suspended)
+    REALM_ASSERT(m_error_message_received || !m_unbind_message_sent);
+    if (m_ident_message_sent && !m_error_message_received)
         ensure_enlisted_to_send(); // Throws
 }
 

--- a/test/object-store/util/test_utils.hpp
+++ b/test/object-store/util/test_utils.hpp
@@ -26,6 +26,8 @@
 
 #include <functional>
 #include <filesystem>
+#include <mutex>
+#include <condition_variable>
 namespace fs = std::filesystem;
 
 namespace realm {

--- a/test/object-store/util/test_utils.hpp
+++ b/test/object-store/util/test_utils.hpp
@@ -39,15 +39,17 @@ public:
     {
     }
 
-    E transition(E from, E to)
+    template <typename Func>
+    void transition_with(Func&& func)
     {
         std::lock_guard lock{m_mutex};
-        if (m_cur_state != from) {
-            return m_cur_state;
+        std::optional<E> new_state = func(m_cur_state);
+        if (!new_state) {
+            return;
         }
-        m_cur_state = to;
+
+        m_cur_state = *new_state;
         m_cv.notify_one();
-        return from;
     }
 
     void wait_for(E target)


### PR DESCRIPTION
## What, How & Why?
If you get multiple non-fatal errors in a row and explicitly resume the session without waiting for (or canceling) the try_again timer to fire, the sync client can hit an assertion on the second error when it tries to create a new try again timer without canceling the old one. This fixes that and a few bad assertions we were making about when you could request download notifications after a retryable error has been received.

## ☑️ ToDos
* [x] 📝 Changelog update
* [x] 🚦 Tests (or not relevant)
* [ ] C-API, if public C++ API changed
* [ ] `bindgen/spec.yml`, if public C++ API changed
