### PR TITLE
Fix backtrace macro

### DIFF
--- a/src/realm/util/backtrace.cpp
+++ b/src/realm/util/backtrace.cpp
@@ -39,7 +39,7 @@
 
 using namespace realm::util;
 
-#if REALM_PLATFORM_APPLE || (defined(__linux__) && !REALM_ANDROID)
+#if REALM_HAVE_BACKTRACE
 static const size_t g_backtrace_depth = 128;
 #endif
 static const char* g_backtrace_error = "<error calculating backtrace>";


### PR DESCRIPTION
When building Core inside of AOSP both `defined(__linux__)` and `defined(__GNUC__)` are true, this conflicts with the macro guard around `g_backtrace_depth` which states `!REALM_ANDROID`. This should use `REALM_HAVE_BACKTRACE` as the source of truth instead.