### PR TITLE
Improve performance when resurrecting an object with many backlinks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@
 
 ### Fixed
 * <How do the end-user experience this issue? what was the impact?> ([#????](https://github.com/realm/realm-core/issues/????), since v?.?.?)
-* Bad performance of initial Sync download involving many backlinks ([#7217](https://github.com/realm/realm-core/issues/7217)m since v10.0.0)
+* Bad performance of initial Sync download involving many backlinks ([#7217](https://github.com/realm/realm-core/issues/7217), since v10.0.0)
 
 ### Breaking changes
 * None.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@
 
 ### Fixed
 * <How do the end-user experience this issue? what was the impact?> ([#????](https://github.com/realm/realm-core/issues/????), since v?.?.?)
-* None.
+* Bad performance of initial Sync download involving many backlinks ([#7217](https://github.com/realm/realm-core/issues/7217)m since v10.0.0)
 
 ### Breaking changes
 * None.

--- a/src/realm/dictionary.hpp
+++ b/src/realm/dictionary.hpp
@@ -144,7 +144,7 @@ private:
     friend class CollectionColumnAggregate;
     friend class DictionaryLinkValues;
     friend class Cluster;
-    friend void Obj::assign_pk_and_backlinks(const Obj& other);
+    friend void Obj::assign_pk_and_backlinks(Obj& other);
 
     mutable std::unique_ptr<Array> m_dictionary_top;
     mutable std::unique_ptr<BPlusTreeBase> m_keys;

--- a/src/realm/list.cpp
+++ b/src/realm/list.cpp
@@ -440,6 +440,27 @@ void LnkLst::remove_all_target_rows()
     }
 }
 
+void LnkLst::replace_link(ObjKey old_val, ObjKey new_val)
+{
+    update_if_needed();
+    auto tree = m_list.m_tree.get();
+    auto n = tree->find_first(old_val);
+    REALM_ASSERT(n != realm::npos);
+    if (Replication* repl = get_obj().get_replication()) {
+        repl->list_set(m_list, n, new_val);
+    }
+    tree->set(n, new_val);
+    m_list.bump_content_version();
+    if (new_val.is_unresolved()) {
+        if (!old_val.is_unresolved()) {
+            tree->set_context_flag(true);
+        }
+    }
+    else {
+        _impl::check_for_last_unresolved(tree);
+    }
+}
+
 // Force instantiation:
 template class Lst<ObjKey>;
 template class Lst<Mixed>;

--- a/src/realm/list.hpp
+++ b/src/realm/list.hpp
@@ -487,6 +487,8 @@ public:
         return m_list.get_tree();
     }
 
+    void replace_link(ObjKey old_link, ObjKey new_link);
+
 private:
     friend class TableView;
     friend class Query;

--- a/src/realm/obj.hpp
+++ b/src/realm/obj.hpp
@@ -323,7 +323,7 @@ public:
     CollectionBasePtr get_collection_ptr(StringData col_name) const;
     LinkCollectionPtr get_linkcollection_ptr(ColKey col_key) const;
 
-    void assign_pk_and_backlinks(const Obj& other);
+    void assign_pk_and_backlinks(Obj& other);
 
     class Internal {
         friend class _impl::DeepChangeChecker;
@@ -396,9 +396,9 @@ private:
     Mixed get_unfiltered_mixed(ColKey::Idx col_ndx) const;
 
     template <class Val>
-    Obj& _set(size_t col_ndx, Val v);
+    Obj& _set_all(size_t col_ndx, Val v);
     template <class Head, class... Tail>
-    Obj& _set(size_t col_ndx, Head v, Tail... tail);
+    Obj& _set_all(size_t col_ndx, Head v, Tail... tail);
     ColKey spec_ndx2colkey(size_t col_ndx);
     size_t colkey2spec_ndx(ColKey);
     bool ensure_writeable();
@@ -586,16 +586,16 @@ std::vector<U> Obj::get_list_values(ColKey col_key) const
 }
 
 template <class Val>
-inline Obj& Obj::_set(size_t col_ndx, Val v)
+inline Obj& Obj::_set_all(size_t col_ndx, Val v)
 {
     return set(spec_ndx2colkey(col_ndx), v);
 }
 
 template <class Head, class... Tail>
-inline Obj& Obj::_set(size_t col_ndx, Head v, Tail... tail)
+inline Obj& Obj::_set_all(size_t col_ndx, Head v, Tail... tail)
 {
     set(spec_ndx2colkey(col_ndx), v);
-    return _set(col_ndx + 1, tail...);
+    return _set_all(col_ndx + 1, tail...);
 }
 
 template <class Head, class... Tail>
@@ -609,7 +609,7 @@ inline Obj& Obj::set_all(Head v, Tail... tail)
         start_index = 1;
     }
 
-    return _set(start_index, v, tail...);
+    return _set_all(start_index, v, tail...);
 }
 
 inline bool Obj::update_if_needed() const

--- a/src/realm/sync/instruction_replication.cpp
+++ b/src/realm/sync/instruction_replication.cpp
@@ -390,12 +390,10 @@ void SyncReplication::rename_column(const Table*, ColKey, StringData)
 
 void SyncReplication::list_set(const CollectionBase& list, size_t ndx, Mixed value)
 {
-    Mixed prior_value = list.get_any(ndx);
-    bool prior_is_unresolved =
-        prior_value.is_type(type_Link, type_TypedLink) && prior_value.get<ObjKey>().is_unresolved();
+    bool prior_is_unresolved = list.get_any(ndx).is_unresolved_link();
 
     // If link is unresolved, it should not be communicated.
-    if (value.is_type(type_Link, type_TypedLink) && value.get<ObjKey>().is_unresolved()) {
+    if (value.is_unresolved_link()) {
         // ... but reported internally as a deletion if prior value was not unresolved
         if (!prior_is_unresolved)
             Replication::list_erase(list, ndx);
@@ -450,7 +448,7 @@ void SyncReplication::list_set(const CollectionBase& list, size_t ndx, Mixed val
 void SyncReplication::list_insert(const CollectionBase& list, size_t ndx, Mixed value, size_t prior_size)
 {
     // If link is unresolved, it should not be communicated.
-    if (!(value.is_type(type_Link, type_TypedLink) && value.get<ObjKey>().is_unresolved())) {
+    if (!value.is_unresolved_link()) {
         Replication::list_insert(list, ndx, value, prior_size);
     }
 
@@ -490,7 +488,7 @@ void SyncReplication::set(const Table* table, ColKey col, ObjKey key, Mixed valu
     }
 
     // If link is unresolved, it should not be communicated.
-    if (value.is_type(type_Link, type_TypedLink) && value.get<ObjKey>().is_unresolved()) {
+    if (value.is_unresolved_link()) {
         return;
     }
 
@@ -553,7 +551,7 @@ void SyncReplication::list_erase(const CollectionBase& list, size_t ndx)
 {
     Mixed prior_value = list.get_any(ndx);
     // If link is unresolved, it should not be communicated.
-    if (!(prior_value.is_type(type_Link, type_TypedLink) && prior_value.get<ObjKey>().is_unresolved())) {
+    if (!prior_value.is_unresolved_link()) {
         Replication::list_erase(list, ndx);
     }
 
@@ -614,7 +612,7 @@ void SyncReplication::set_clear(const CollectionBase& set)
 void SyncReplication::dictionary_update(const CollectionBase& dict, const Mixed& key, const Mixed& value)
 {
     // If link is unresolved, it should not be communicated.
-    if (value.is_type(type_Link, type_TypedLink) && value.get<ObjKey>().is_unresolved()) {
+    if (value.is_unresolved_link()) {
         return;
     }
 


### PR DESCRIPTION
The process of first removing the backlink from the tombstone and then creating it again in the live object took a long time. As the backlinks will end up being identical, we can just move the whole structure from the tombstone to the new object and then just replace the link in the linking object without worring about backlinks.

This change is only done for link and linklist properties.

Fixes #7217 

## What, How & Why?
<!-- Describe the changes and give some hints to guide your reviewers if possible. -->
<!-- Link to relevant issue this fixes -->

## ☑️ ToDos
* [ ] 📝 Changelog update
* [ ] 🚦 Tests (or not relevant)
* [ ] C-API, if public C++ API changed
* [ ] `bindgen/spec.yml`, if public C++ API changed
