### PR TITLE
Enable the Parsley button in evergreen for uploaded file artifacts.

### DIFF
--- a/evergreen/config.yml
+++ b/evergreen/config.yml
@@ -336,7 +336,7 @@ functions:
       remote_file: 'realm-core-stable/${branch_name}/${task_id}/${execution}/baas_server.log'
       bucket: mciuploads
       permissions: public-read
-      content_type: text/text
+      content_type: text/plain
       display_name: baas server logs
       optional: true
   - command: s3.put
@@ -347,7 +347,7 @@ functions:
       remote_file: 'realm-core-stable/${branch_name}/${task_id}/${execution}/install_baas_output.log'
       bucket: mciuploads
       permissions: public-read
-      content_type: text/text
+      content_type: text/plain
       display_name: install baas output
       optional: true
   - command: s3.put
@@ -358,7 +358,7 @@ functions:
       remote_file: 'realm-core-stable/${branch_name}/${task_id}/${execution}/mongod.log'
       bucket: mciuploads
       permissions: public-read
-      content_type: text/text
+      content_type: text/plain
       display_name: mongod logs
       optional: true
   - command: s3.put
@@ -369,7 +369,7 @@ functions:
       remote_file: 'realm-core-stable/${branch_name}/${task_id}/${execution}/baas_proxy.log'
       bucket: mciuploads
       permissions: public-read
-      content_type: text/text
+      content_type: text/plain
       display_name: baas proxy logs
       optional: true
 
@@ -392,7 +392,7 @@ functions:
       remote_file: '${project}/${branch_name}/${task_id}/${execution}/realm-fuzzer-crash.txt'
       bucket: mciuploads
       permissions: public-read
-      content_type: text/text
+      content_type: text/plain
       display_name: Fuzzer crash report
       optional: true
 
@@ -880,7 +880,7 @@ tasks:
       remote_file: '${project}/${branch_name}/${task_id}/${execution}/bloaty-results-'
       bucket: mciuploads
       permissions: public-read
-      content_type: text/text
+      content_type: text/plain
       display_name: bloaty-results
   - command: s3.put
     params:


### PR DESCRIPTION
## What, How & Why?
The `content-type` for the uploaded text files was originally set to `text/text`, which is not a valid content type. Updated these uploads to use a content type of `text/plain` to enable the **Parsley** button on the **Files** tab in Evergreen.

## ☑️ ToDos
* ~[ ] 📝 Changelog update~
* ~[ ] 🚦 Tests (or not relevant)~
* ~[ ] C-API, if public C++ API changed~
* ~[ ] `bindgen/spec.yml`, if public C++ API changed~
