### PR TITLE
Align run time for debug and simulator for slowests tests

### DIFF
--- a/test/test_shared.cpp
+++ b/test/test_shared.cpp
@@ -1087,7 +1087,7 @@ TEST(Shared_Writes)
 }
 
 #if !REALM_ANDROID // FIXME
-TEST_IF(Shared_ManyReaders, TEST_DURATION > 0)
+TEST(Shared_ManyReaders)
 {
     // This test was written primarily to expose a former bug in
     // SharedGroup::end_read(), where the lock-file was not remapped
@@ -1105,6 +1105,8 @@ TEST_IF(Shared_ManyReaders, TEST_DURATION > 0)
 #if TEST_DURATION < 1
     // Mac OS X 10.8 cannot handle more than 15 due to its default ulimit settings.
     int rounds[] = {3, 5, 7, 9, 11, 13};
+#elif REALM_DEBUG // this test is disproportionately slower in debug
+    int rounds[] = {3, 5, 7, 9, 11, 13, 15, 17, 23};
 #else
     int rounds[] = {3, 5, 11, 15, 17, 23, 27, 31, 47, 59};
 #endif

--- a/test/test_transform.cpp
+++ b/test/test_transform.cpp
@@ -20,6 +20,7 @@
 #include <realm/sync/transform.hpp>
 
 #include "test.hpp"
+#include "testsettings.hpp"
 #include "util/quote.hpp"
 
 #include "peer.hpp"
@@ -972,7 +973,12 @@ TEST_IF(Transform_Randomized, get_disable_sync_to_disk())
 
     // FIXME: Unfortunately these rounds are terribly slow, presumable due to
     // sync-to-disk. Can we use "in memory" mode too boost them?
-    int num_major_rounds = 100;
+    // also, they are disproportionately slower, espesially in debug and under simulator
+#ifndef REALM_DEBUG
+    int num_major_rounds = TEST_DURATION >= 1 ? 100 : 10;
+#else
+    int num_major_rounds = TEST_DURATION >= 1 ? 32 : 4;
+#endif
     int num_minor_rounds = 1;
 
     Random random(unit_test_random_seed); // Seed from slow global generator


### PR DESCRIPTION
## What, How & Why?
Shared_ManyReaders and Transform_Randomized dominate whole test suite running time under simulator and on debug builds.
This often leads to CI failures on Jenkins on checkiOSSimulator_Debug and checkLinuxDebug_* builders manifested as: 
"... wrapper script does not seem to be touching the log file... if on an extremely laggy filesystem..."
Adjust constants so that the time taken for these tests in same range as with others slowests tests.

## ☑️ ToDos
* [ ] 📝 Changelog update
* [ ] 🚦 Tests (or not relevant)
* [ ] C-API, if public C++ API changed
* [ ] `bindgen/spec.yml`, if public C++ API changed
