### PR TITLE
Don't leak implementation of BsonDocument and BsonArray to the users.

### DIFF
--- a/src/realm/object-store/sync/app.cpp
+++ b/src/realm/object-store/sync/app.cpp
@@ -65,8 +65,8 @@ T as(const Bson& bson)
 template <typename T>
 T get(const BsonDocument& doc, const std::string& key)
 {
-    if (auto it = doc.find(key); it != doc.end()) {
-        return as<T>((*it).second);
+    if (auto val = doc.find(key)) {
+        return as<T>(*val);
     }
     throw_json_error(ErrorCodes::MissingJsonKey, key);
     return {};
@@ -75,8 +75,8 @@ T get(const BsonDocument& doc, const std::string& key)
 template <typename T>
 void read_field(const BsonDocument& data, const std::string& key, T& value)
 {
-    if (auto it = data.find(key); it != data.end()) {
-        value = as<T>((*it).second);
+    if (auto val = data.find(key)) {
+        value = as<T>(*val);
     }
     else {
         throw_json_error(ErrorCodes::MissingJsonKey, key);
@@ -92,8 +92,8 @@ void read_field(const BsonDocument& data, const std::string& key, ObjectId& valu
 template <typename T>
 void read_field(const BsonDocument& data, const std::string& key, Optional<T>& value)
 {
-    if (auto it = data.find(key); it != data.end()) {
-        value = as<T>((*it).second);
+    if (auto val = data.find(key)) {
+        value = as<T>(*val);
     }
 }
 

--- a/src/realm/object-store/sync/app_credentials.cpp
+++ b/src/realm/object-store/sync/app_credentials.cpp
@@ -98,9 +98,9 @@ AppCredentials::AppCredentials(AuthProvider provider,
     : m_provider(provider)
     , m_payload(std::make_unique<bson::BsonDocument>())
 {
-    (*m_payload)[kAppProviderKey] = provider_type_from_enum(provider);
+    m_payload->append(kAppProviderKey, provider_type_from_enum(provider));
     for (auto& [key, value] : values) {
-        (*m_payload)[key] = std::move(value);
+        m_payload->append(key, std::move(value));
     }
 }
 

--- a/src/realm/object-store/sync/app_credentials.hpp
+++ b/src/realm/object-store/sync/app_credentials.hpp
@@ -27,9 +27,7 @@
 namespace realm {
 namespace bson {
 class Bson;
-template <typename>
-class IndexedMap;
-using BsonDocument = IndexedMap<Bson>;
+class BsonDocument;
 } // namespace bson
 namespace app {
 

--- a/src/realm/object-store/sync/mongo_collection.cpp
+++ b/src/realm/object-store/sync/mongo_collection.cpp
@@ -32,10 +32,10 @@ using ResponseHandler = MongoCollection::ResponseHandler<T>;
 namespace {
 
 template <typename T>
-util::Optional<T> get(const std::unordered_map<std::string, Bson>& map, const char* key)
+util::Optional<T> get(const BsonDocument& map, const char* key)
 {
     if (auto it = map.find(key); it != map.end()) {
-        return static_cast<T>(it->second);
+        return static_cast<T>((*it).second);
     }
     return util::none;
 }
@@ -45,7 +45,7 @@ ResponseHandler<util::Optional<Bson>> get_delete_count_handler(ResponseHandler<u
     return [completion = std::move(completion)](util::Optional<Bson>&& value, util::Optional<AppError>&& error) {
         if (value && !error) {
             try {
-                auto& document = static_cast<const BsonDocument&>(*value).entries();
+                auto& document = static_cast<const BsonDocument&>(*value);
                 return completion(get<int32_t>(document, "deletedCount").value_or(0), std::move(error));
             }
             catch (const std::exception& e) {
@@ -65,7 +65,7 @@ ResponseHandler<util::Optional<Bson>> get_update_handler(ResponseHandler<MongoCo
         }
 
         try {
-            auto& document = static_cast<const BsonDocument&>(*value).entries();
+            auto& document = static_cast<const BsonDocument&>(*value);
             return completion(MongoCollection::UpdateResult{get<int32_t>(document, "matchedCount").value_or(0),
                                                             get<int32_t>(document, "modifiedCount").value_or(0),
                                                             get<Bson>(document, "upsertedId")},
@@ -184,7 +184,7 @@ void MongoCollection::count(const BsonDocument& filter_bson, ResponseHandler<uin
     count(filter_bson, 0, std::move(completion));
 }
 
-void MongoCollection::insert_many(const BsonArray& documents, ResponseHandler<std::vector<Bson>>&& completion)
+void MongoCollection::insert_many(const BsonArray& documents, ResponseHandler<BsonArray>&& completion)
 {
     insert_many_bson(documents, [completion = std::move(completion)](util::Optional<Bson>&& value,
                                                                      util::Optional<AppError>&& error) {
@@ -192,7 +192,7 @@ void MongoCollection::insert_many(const BsonArray& documents, ResponseHandler<st
             return completion({}, std::move(error));
         }
 
-        auto& bson = static_cast<const BsonDocument&>(*value).entries();
+        auto& bson = static_cast<const BsonDocument&>(*value);
         return completion(get<BsonArray>(bson, "insertedIds").value_or(BsonArray()), std::move(error));
     });
 }
@@ -279,15 +279,15 @@ void MongoCollection::call_function(const char* name, const bson::BsonDocument& 
 static void set_options(BsonDocument& base_args, const MongoCollection::FindOptions& options)
 {
     if (options.limit) {
-        base_args["limit"] = *options.limit;
+        base_args.append("limit", *options.limit);
     }
 
     if (options.projection_bson) {
-        base_args["project"] = *options.projection_bson;
+        base_args.append("project", *options.projection_bson);
     }
 
     if (options.sort_bson) {
-        base_args["sort"] = *options.sort_bson;
+        base_args.append("sort", *options.sort_bson);
     }
 }
 
@@ -295,7 +295,7 @@ void MongoCollection::find_bson(const BsonDocument& filter_bson, const FindOptio
                                 ResponseHandler<util::Optional<Bson>>&& completion)
 try {
     auto base_args = m_base_operation_args;
-    base_args["query"] = filter_bson;
+    base_args.append("query", filter_bson);
     set_options(base_args, options);
 
     call_function("find", base_args, std::move(completion));
@@ -308,7 +308,7 @@ void MongoCollection::find_one_bson(const BsonDocument& filter_bson, const FindO
                                     ResponseHandler<util::Optional<Bson>>&& completion)
 try {
     auto base_args = m_base_operation_args;
-    base_args["query"] = filter_bson;
+    base_args.append("query", filter_bson);
     set_options(base_args, options);
     call_function("findOne", base_args, std::move(completion));
 }
@@ -320,14 +320,14 @@ void MongoCollection::insert_one_bson(const BsonDocument& value_bson,
                                       ResponseHandler<util::Optional<Bson>>&& completion)
 {
     auto base_args = m_base_operation_args;
-    base_args["document"] = value_bson;
+    base_args.append("document", value_bson);
     call_function("insertOne", base_args, std::move(completion));
 }
 
 void MongoCollection::aggregate_bson(const BsonArray& pipline, ResponseHandler<util::Optional<Bson>>&& completion)
 {
     auto base_args = m_base_operation_args;
-    base_args["pipeline"] = pipline;
+    base_args.append("pipeline", pipline);
     call_function("aggregate", base_args, std::move(completion));
 }
 
@@ -335,9 +335,9 @@ void MongoCollection::count_bson(const BsonDocument& filter_bson, int64_t limit,
                                  ResponseHandler<util::Optional<Bson>>&& completion)
 {
     auto base_args = m_base_operation_args;
-    base_args["query"] = filter_bson;
+    base_args.append("query", filter_bson);
     if (limit != 0) {
-        base_args["limit"] = limit;
+        base_args.append("limit", limit);
     }
     call_function("count", base_args, std::move(completion));
 }
@@ -345,7 +345,7 @@ void MongoCollection::count_bson(const BsonDocument& filter_bson, int64_t limit,
 void MongoCollection::insert_many_bson(const BsonArray& documents, ResponseHandler<util::Optional<Bson>>&& completion)
 {
     auto base_args = m_base_operation_args;
-    base_args["documents"] = documents;
+    base_args.append("documents", documents);
     call_function("insertMany", base_args, std::move(completion));
 }
 
@@ -353,7 +353,7 @@ void MongoCollection::delete_one_bson(const BsonDocument& filter_bson,
                                       ResponseHandler<util::Optional<Bson>>&& completion)
 {
     auto base_args = m_base_operation_args;
-    base_args["query"] = filter_bson;
+    base_args.append("query", filter_bson);
     call_function("deleteOne", base_args, std::move(completion));
 }
 
@@ -361,7 +361,7 @@ void MongoCollection::delete_many_bson(const BsonDocument& filter_bson,
                                        ResponseHandler<util::Optional<Bson>>&& completion)
 {
     auto base_args = m_base_operation_args;
-    base_args["query"] = filter_bson;
+    base_args.append("query", filter_bson);
     call_function("deleteMany", base_args, std::move(completion));
 }
 
@@ -369,9 +369,9 @@ void MongoCollection::update_one_bson(const BsonDocument& filter_bson, const Bso
                                       ResponseHandler<util::Optional<Bson>>&& completion)
 {
     auto base_args = m_base_operation_args;
-    base_args["query"] = filter_bson;
-    base_args["update"] = update_bson;
-    base_args["upsert"] = upsert;
+    base_args.append("query", filter_bson);
+    base_args.append("update", update_bson);
+    base_args.append("upsert", upsert);
     call_function("updateOne", base_args, std::move(completion));
 }
 
@@ -379,9 +379,9 @@ void MongoCollection::update_many_bson(const BsonDocument& filter_bson, const Bs
                                        ResponseHandler<util::Optional<Bson>>&& completion)
 {
     auto base_args = m_base_operation_args;
-    base_args["query"] = filter_bson;
-    base_args["update"] = update_bson;
-    base_args["upsert"] = upsert;
+    base_args.append("query", filter_bson);
+    base_args.append("update", update_bson);
+    base_args.append("upsert", upsert);
     call_function("updateMany", base_args, std::move(completion));
 }
 
@@ -390,8 +390,8 @@ void MongoCollection::find_one_and_update_bson(const BsonDocument& filter_bson, 
                                                ResponseHandler<util::Optional<Bson>>&& completion)
 {
     auto base_args = m_base_operation_args;
-    base_args["filter"] = filter_bson;
-    base_args["update"] = update_bson;
+    base_args.append("filter", filter_bson);
+    base_args.append("update", update_bson);
     options.set_bson(base_args);
     call_function("findOneAndUpdate", base_args, std::move(completion));
 }
@@ -401,8 +401,8 @@ void MongoCollection::find_one_and_replace_bson(const BsonDocument& filter_bson,
                                                 ResponseHandler<util::Optional<Bson>>&& completion)
 {
     auto base_args = m_base_operation_args;
-    base_args["filter"] = filter_bson;
-    base_args["update"] = replacement_bson;
+    base_args.append("filter", filter_bson);
+    base_args.append("update", replacement_bson);
     options.set_bson(base_args);
     call_function("findOneAndReplace", base_args, std::move(completion));
 }
@@ -412,7 +412,7 @@ void MongoCollection::find_one_and_delete_bson(const BsonDocument& filter_bson,
                                                ResponseHandler<util::Optional<Bson>>&& completion)
 {
     auto base_args = m_base_operation_args;
-    base_args["filter"] = filter_bson;
+    base_args.append("filter", filter_bson);
     options.set_bson(base_args);
     call_function("findOneAndDelete", base_args, std::move(completion));
 }
@@ -568,8 +568,8 @@ void WatchStream::feed_sse(ServerSentEvent sse)
             if (parsed.type() != Bson::Type::Document)
                 return;
             auto& obj = static_cast<BsonDocument&>(parsed);
-            auto& code = obj.at("error_code");
-            auto& msg = obj.at("error");
+            auto code = obj.at("error_code");
+            auto msg = obj.at("error");
             if (code.type() != Bson::Type::String)
                 return;
             if (msg.type() != Bson::Type::String)
@@ -577,7 +577,7 @@ void WatchStream::feed_sse(ServerSentEvent sse)
             auto error_code = ErrorCodes::from_string(static_cast<const std::string&>(code));
             if (error_code == ErrorCodes::UnknownError)
                 error_code = ErrorCodes::AppUnknownError;
-            m_error = std::make_unique<AppError>(error_code, std::move(static_cast<std::string&>(msg)));
+            m_error = std::make_unique<AppError>(error_code, std::move(static_cast<const std::string&>(msg)));
         }
         catch (...) {
             return; // Use the default state.

--- a/src/realm/object-store/sync/mongo_collection.cpp
+++ b/src/realm/object-store/sync/mongo_collection.cpp
@@ -34,8 +34,8 @@ namespace {
 template <typename T>
 util::Optional<T> get(const BsonDocument& map, const char* key)
 {
-    if (auto it = map.find(key); it != map.end()) {
-        return static_cast<T>((*it).second);
+    if (auto val = map.find(key)) {
+        return static_cast<T>((*val));
     }
     return util::none;
 }

--- a/src/realm/object-store/sync/mongo_collection.hpp
+++ b/src/realm/object-store/sync/mongo_collection.hpp
@@ -74,19 +74,19 @@ public:
         void set_bson(bson::BsonDocument& bson) const
         {
             if (upsert) {
-                bson["upsert"] = true;
+                bson.append("upsert", true);
             }
 
             if (return_new_document) {
-                bson["returnNewDocument"] = true;
+                bson.append("returnNewDocument", true);
             }
 
             if (projection_bson) {
-                bson["projection"] = *projection_bson;
+                bson.append("projection", *projection_bson);
             }
 
             if (sort_bson) {
-                bson["sort"] = *sort_bson;
+                bson.append("sort", *sort_bson);
             }
         }
     };
@@ -169,7 +169,7 @@ public:
     /// they will be generated.
     /// @param documents  The `Document` values in a bson array to insert.
     /// @param completion The result of the insert, returns an array inserted document ids in order
-    void insert_many(const bson::BsonArray& documents, ResponseHandler<std::vector<bson::Bson>>&& completion);
+    void insert_many(const bson::BsonArray& documents, ResponseHandler<bson::BsonArray>&& completion);
 
     /// Deletes a single matching document from the collection.
     /// @param filter_bson A `Document` as bson that should match the query.

--- a/src/realm/object-store/sync/sync_user.cpp
+++ b/src/realm/object-store/sync/sync_user.cpp
@@ -70,8 +70,8 @@ RealmJWT::RealmJWT(const std::string& token)
     this->expires_at = static_cast<int64_t>(json["exp"]);
     this->issued_at = static_cast<int64_t>(json["iat"]);
 
-    if (json.find("user_data") != json.end()) {
-        this->user_data = static_cast<bson::BsonDocument>(json["user_data"]);
+    if (auto value = json.find("user_data")) {
+        this->user_data = static_cast<bson::BsonDocument>(*value);
     }
 }
 

--- a/src/realm/object-store/sync/sync_user.hpp
+++ b/src/realm/object-store/sync/sync_user.hpp
@@ -140,11 +140,10 @@ private:
 
     util::Optional<std::string> get_field(const char* name) const
     {
-        auto it = m_data.find(name);
-        if (it == m_data.end()) {
-            return util::none;
+        if (auto val = m_data.find(name)) {
+            return static_cast<std::string>((*val));
         }
-        return static_cast<std::string>((*it).second);
+        return util::none;
     }
 };
 

--- a/src/realm/util/bson/bson.cpp
+++ b/src/realm/util/bson/bson.cpp
@@ -333,13 +333,13 @@ bool holds_alternative<MaxKey>(const Bson& bson)
 }
 
 template <>
-bool holds_alternative<IndexedMap<Bson>>(const Bson& bson)
+bool holds_alternative<BsonDocument>(const Bson& bson)
 {
     return bson.m_type == Bson::Type::Document;
 }
 
 template <>
-bool holds_alternative<std::vector<Bson>>(const Bson& bson)
+bool holds_alternative<BsonArray>(const Bson& bson)
 {
     return bson.m_type == Bson::Type::Array;
 }
@@ -620,9 +620,9 @@ Bson dom_elem_to_bson(const Json& json)
         case Json::value_t::object:
             return dom_obj_to_bson(json);
         case Json::value_t::array: {
-            std::vector<Bson> out;
+            BsonArray out;
             for (auto&& elem : json) {
-                out.push_back(dom_elem_to_bson(elem));
+                out.append(dom_elem_to_bson(elem));
             }
             return Bson(std::move(out));
         }
@@ -787,7 +787,7 @@ Bson dom_obj_to_bson(const Json& json)
 
     BsonDocument out;
     for (auto&& [k, v] : json.items()) {
-        out[k] = dom_elem_to_bson(v);
+        out.append(k, dom_elem_to_bson(v));
     }
     return out;
 }

--- a/src/realm/util/bson/bson.hpp
+++ b/src/realm/util/bson/bson.hpp
@@ -322,9 +322,13 @@ public:
         return IndexedMap<Bson>::at(k);
     }
 
-    iterator find(const std::string& k) const
+    std::optional<Bson> find(const std::string& key) const
     {
-        return IndexedMap<Bson>::find(k);
+        auto& raw = entries();
+        if (auto it = raw.find(key); it != raw.end()) {
+            return it->second;
+        }
+        return {};
     }
 
     bool operator==(const BsonDocument& other) const

--- a/test/object-store/audit.cpp
+++ b/test/object-store/audit.cpp
@@ -182,18 +182,17 @@ static std::vector<AuditEvent> get_audit_events_from_baas(TestAppSession& sessio
     auto documents = session.get_documents(user, "AuditEvent", expected_count);
     std::vector<AuditEvent> events;
     events.reserve(documents.size());
-    for (auto document : documents) {
-        auto doc = document.entries();
+    for (auto doc : documents) {
         AuditEvent event;
         event.activity = static_cast<std::string>(doc["activity"]);
         event.timestamp = static_cast<Timestamp>(doc["timestamp"]);
-        if (auto it = doc.find("event"); it != doc.end() && it->second != bson::Bson()) {
-            event.event = static_cast<std::string>(it->second);
+        if (auto it = doc.find("event"); it != doc.end() && (*it).second != bson::Bson()) {
+            event.event = static_cast<std::string>((*it).second);
         }
-        if (auto it = doc.find("data"); it != doc.end() && it->second != bson::Bson()) {
-            event.data = json::parse(static_cast<std::string>(it->second));
+        if (auto it = doc.find("data"); it != doc.end() && (*it).second != bson::Bson()) {
+            event.data = json::parse(static_cast<std::string>((*it).second));
         }
-        for (auto& [key, value] : doc) {
+        for (auto [key, value] : doc) {
             if (value.type() == bson::Bson::Type::String && !nonmetadata_fields.count(key))
                 event.metadata.insert({key, static_cast<std::string>(value)});
         }

--- a/test/object-store/audit.cpp
+++ b/test/object-store/audit.cpp
@@ -186,11 +186,11 @@ static std::vector<AuditEvent> get_audit_events_from_baas(TestAppSession& sessio
         AuditEvent event;
         event.activity = static_cast<std::string>(doc["activity"]);
         event.timestamp = static_cast<Timestamp>(doc["timestamp"]);
-        if (auto it = doc.find("event"); it != doc.end() && (*it).second != bson::Bson()) {
-            event.event = static_cast<std::string>((*it).second);
+        if (auto val = doc.find("event"); bool(val) && *val != bson::Bson()) {
+            event.event = static_cast<std::string>(*val);
         }
-        if (auto it = doc.find("data"); it != doc.end() && (*it).second != bson::Bson()) {
-            event.data = json::parse(static_cast<std::string>((*it).second));
+        if (auto val = doc.find("data"); bool(val) && *val != bson::Bson()) {
+            event.data = json::parse(static_cast<std::string>(*val));
         }
         for (auto [key, value] : doc) {
             if (value.type() == bson::Bson::Type::String && !nonmetadata_fields.count(key))

--- a/test/object-store/bson.cpp
+++ b/test/object-store/bson.cpp
@@ -58,7 +58,7 @@ static inline void run_corpus(const char* test_key, const CorpusEntry<T>& entry)
 {
     std::string canonical_extjson = remove_whitespace(entry.canonical_extjson);
     auto val = static_cast<BsonDocument>(bson::parse(canonical_extjson));
-    auto& test_value = val[test_key];
+    const Bson& test_value = val[test_key];
     REQUIRE(bson::holds_alternative<T>(test_value));
     entry.check((T)test_value);
     if (!entry.lossy) {

--- a/test/object-store/sync/app.cpp
+++ b/test/object-store/sync/app.cpp
@@ -1471,7 +1471,7 @@ TEST_CASE("app: remote mongo client", "[sync][app][mongo][baas]") {
                                        [&](Optional<bson::Bson> bson, Optional<AppError> error) {
                                            REQUIRE_FALSE(error);
                                            auto document = static_cast<bson::BsonDocument>(*bson);
-                                           auto foundUpsertedId = document.find("upsertedId") != document.end();
+                                           auto foundUpsertedId = document.find("upsertedId");
                                            REQUIRE(!foundUpsertedId);
                                        });
 

--- a/test/object-store/sync/flx_sync.cpp
+++ b/test/object-store/sync/flx_sync.cpp
@@ -1901,10 +1901,10 @@ TEST_CASE("flx: geospatial", "[sync][flx][geospatial][baas]") {
                 bson::BsonArray inner{};
                 REALM_ASSERT_3(polygon.points.size(), ==, 1);
                 for (auto& point : polygon.points[0]) {
-                    inner.push_back(bson::BsonArray{point.longitude, point.latitude});
+                    inner.append(bson::BsonArray{point.longitude, point.latitude});
                 }
                 bson::BsonArray coords;
-                coords.push_back(inner);
+                coords.append(inner);
                 bson::BsonDocument geo_bson{{{"type", "Polygon"}, {"coordinates", coords}}};
                 bson::BsonDocument filter{
                     {"location", bson::BsonDocument{{"$geoWithin", bson::BsonDocument{{"$geometry", geo_bson}}}}}};
@@ -1913,8 +1913,8 @@ TEST_CASE("flx: geospatial", "[sync][flx][geospatial][baas]") {
             auto make_circle_filter = [&](const GeoCircle& circle) -> bson::BsonDocument {
                 bson::BsonArray coords{circle.center.longitude, circle.center.latitude};
                 bson::BsonArray inner;
-                inner.push_back(coords);
-                inner.push_back(circle.radius_radians);
+                inner.append(coords);
+                inner.append(circle.radius_radians);
                 bson::BsonDocument filter{
                     {"location", bson::BsonDocument{{"$geoWithin", bson::BsonDocument{{"$centerSphere", inner}}}}}};
                 return filter;
@@ -3057,12 +3057,12 @@ static void check_document(const std::vector<bson::BsonDocument>& documents, Obj
                            std::initializer_list<std::pair<const char*, bson::Bson>> fields)
 {
     auto it = std::find_if(documents.begin(), documents.end(), [&](auto&& doc) {
-        auto it = doc.entries().find("_id");
-        REQUIRE(it != doc.entries().end());
-        return it->second == id;
+        auto it = doc.find("_id");
+        REQUIRE(it != doc.end());
+        return (*it).second == id;
     });
     REQUIRE(it != documents.end());
-    auto& doc = it->entries();
+    auto& doc = *it;
     for (auto& [name, expected_value] : fields) {
         auto it = doc.find(name);
         REQUIRE(it != doc.end());
@@ -3071,11 +3071,11 @@ static void check_document(const std::vector<bson::BsonDocument>& documents, Obj
         // document might validly be in a different order than we expected and
         // we need to do a comparison that doesn't check order.
         if (expected_value.type() == bson::Bson::Type::Document) {
-            REQUIRE(static_cast<const bson::BsonDocument&>(it->second).entries() ==
-                    static_cast<const bson::BsonDocument&>(expected_value).entries());
+            REQUIRE(static_cast<const bson::BsonDocument&>((*it).second) ==
+                    static_cast<const bson::BsonDocument&>(expected_value));
         }
         else {
-            REQUIRE(it->second == expected_value);
+            REQUIRE((*it).second == expected_value);
         }
     }
 }

--- a/test/object-store/sync/flx_sync.cpp
+++ b/test/object-store/sync/flx_sync.cpp
@@ -3057,25 +3057,25 @@ static void check_document(const std::vector<bson::BsonDocument>& documents, Obj
                            std::initializer_list<std::pair<const char*, bson::Bson>> fields)
 {
     auto it = std::find_if(documents.begin(), documents.end(), [&](auto&& doc) {
-        auto it = doc.find("_id");
-        REQUIRE(it != doc.end());
-        return (*it).second == id;
+        auto val = doc.find("_id");
+        REQUIRE(val);
+        return *val == id;
     });
     REQUIRE(it != documents.end());
     auto& doc = *it;
     for (auto& [name, expected_value] : fields) {
-        auto it = doc.find(name);
-        REQUIRE(it != doc.end());
+        auto val = doc.find(name);
+        REQUIRE(val);
 
         // bson documents are ordered  but Realm dictionaries aren't, so the
         // document might validly be in a different order than we expected and
         // we need to do a comparison that doesn't check order.
         if (expected_value.type() == bson::Bson::Type::Document) {
-            REQUIRE(static_cast<const bson::BsonDocument&>((*it).second) ==
+            REQUIRE(static_cast<const bson::BsonDocument&>(*val) ==
                     static_cast<const bson::BsonDocument&>(expected_value));
         }
         else {
-            REQUIRE((*it).second == expected_value);
+            REQUIRE(*val == expected_value);
         }
     }
 }

--- a/test/object-store/util/test_file.cpp
+++ b/test/object-store/util/test_file.cpp
@@ -451,17 +451,16 @@ std::vector<bson::BsonDocument> TestAppSession::get_documents(SyncUser& user, co
         std::chrono::minutes(5));
 
     std::vector<bson::BsonDocument> documents;
-    collection.find({}, {},
-                    [&](util::Optional<std::vector<bson::Bson>>&& result, util::Optional<app::AppError> error) {
-                        REQUIRE(result);
-                        REQUIRE(!error);
-                        REQUIRE(result->size() == expected_count);
-                        documents.reserve(result->size());
-                        for (auto&& bson : *result) {
-                            REQUIRE(bson.type() == bson::Bson::Type::Document);
-                            documents.push_back(std::move(static_cast<bson::BsonDocument&>(bson)));
-                        }
-                    });
+    collection.find({}, {}, [&](util::Optional<bson::BsonArray>&& result, util::Optional<app::AppError> error) {
+        REQUIRE(result);
+        REQUIRE(!error);
+        REQUIRE(result->size() == expected_count);
+        documents.reserve(result->size());
+        for (auto&& bson : *result) {
+            REQUIRE(bson.type() == bson::Bson::Type::Document);
+            documents.push_back(std::move(static_cast<const bson::BsonDocument&>(bson)));
+        }
+    });
     return documents;
 }
 #endif // REALM_ENABLE_AUTH_TESTS


### PR DESCRIPTION
This is done by defining the interface explicitly and in a way that makes it possible to easily change the underlying implementation. The longer goal is to change this implementation to be able to easily produce BSON according to https://bsonspec.org/spec.html. Doing that makes lookup of elements in a document a bit slower, but building the document from a string faster. So the net result in typical applications as found in App, will be a speedup of ~20% on average.

## What, How & Why?
<!-- Describe the changes and give some hints to guide your reviewers if possible. -->
<!-- Link to relevant issue this fixes -->

## ☑️ ToDos
* [ ] 📝 Changelog update
* [ ] 🚦 Tests (or not relevant)
* [ ] C-API, if public C++ API changed
* [ ] `bindgen/spec.yml`, if public C++ API changed
