### PR TITLE
Bump valgrind max threads

### DIFF
--- a/evergreen/config.yml
+++ b/evergreen/config.yml
@@ -790,7 +790,7 @@ tasks:
       script: |-
         export UNITTEST_PROGRESS=1
         export UNITTEST_THREADS=1
-        valgrind --tool=memcheck --leak-check=full --undef-value-errors=yes --track-origins=yes --child-silent-after-fork=no --trace-children=yes --suppressions=$(pwd)/../../test/valgrind.suppress --error-exitcode=1 ./RelWithDebInfo/realm-tests
+        valgrind --tool=memcheck --leak-check=full --undef-value-errors=yes --track-origins=yes --child-silent-after-fork=no --trace-children=yes --suppressions=$(pwd)/../../test/valgrind.suppress --error-exitcode=1 --max-threads=5000 ./RelWithDebInfo/realm-tests
 
 - name: bloaty
   exec_timeout_secs: 1800

--- a/test/test_lang_bind_helper.cpp
+++ b/test/test_lang_bind_helper.cpp
@@ -132,7 +132,7 @@ TEST(Transactions_ConcurrentFrozenTableGetByName)
 #if REALM_VALGRIND
     // This test is slow under valgrind. Additionally, there is
     // a --max-threads config of 5000 for all (concurrent) tests
-    constexpr int num_threads = 100;
+    constexpr int num_threads = 3;
 #else
     constexpr int num_threads = 1000;
 #endif
@@ -226,7 +226,7 @@ TEST(Transactions_ConcurrentFrozenTableGetByKey)
 #if REALM_VALGRIND
     // This test is slow under valgrind. Additionally, there is
     // a --max-threads config of 5000 for all (concurrent) tests
-    constexpr int num_threads = 100;
+    constexpr int num_threads = 3;
 #else
     constexpr int num_threads = 1000;
 #endif


### PR DESCRIPTION
CI reports an [error](https://parsley.mongodb.com/evergreen/realm_core_stable_ubuntu_valgrind_valgrind_6595edf80ae606e16db012bb_24_01_03_23_30_00/0/task?bookmarks=0,886,5432):
```
[2024/01/03 15:45:24.366] ../test/test_lang_bind_helper.cpp:131: Begin Transactions_ConcurrentFrozenTableGetByName
[2024/01/03 15:47:04.549] Use --max-threads=INT to specify a larger number of threads
[2024/01/03 15:47:04.549] and rerun valgrind
[2024/01/03 15:47:04.549] valgrind: the 'impossible' happened:
[2024/01/03 15:47:04.549]    Max number of threads is too low
```
Valgrind's [default value](https://man7.org/linux/man-pages/man1/valgrind.1.html#:~:text=%2D%2Dmax%2Dthreads%3D%3Cnumber,%2D%2Dmax%2Dthreads%3D3000.) is 500 threads.
Since we have several of these tests that may run concurrently, we have several options:
1) Make each test that uses a large number of threads conditional with `TEST_IF(x, !REALM_VALGRIND)`
2) Increase Valgrind's limit.

I am opting to increase the limit here.