### PR TITLE
Update test message check

### DIFF
--- a/test/object-store/sync/flx_sync.cpp
+++ b/test/object-store/sync/flx_sync.cpp
@@ -1769,9 +1769,10 @@ TEST_CASE("flx: query on non-queryable field results in query error message", "[
         CHECK(!status.is_ok());
         std::string reason = status.get_status().reason();
         // Depending on the version of baas used, it may return 'Invalid query:' or
-        // 'Client provided query with bad syntax:'
+        // 'Client provided query with bad syntax:' or 'Unsupported query for table'
         if ((reason.find("Invalid query:") == std::string::npos &&
-             reason.find("Client provided query with bad syntax:") == std::string::npos) ||
+             reason.find("Client provided query with bad syntax:") == std::string::npos
+             && reason.find("Unsupported query for table") == std::string::npos) ||
             reason.find("\"TopLevel\": key \"non_queryable_field\" is not a queryable field") == std::string::npos) {
             FAIL(reason);
         }


### PR DESCRIPTION
The test "bad query after bad query" occasionally [fails](https://ci.realm.io/blue/organizations/jenkins/realm%2Frealm-core/detail/PR-7229/3/pipeline/60) with the message `Unsupported query for table "TopLevel": key "non_queryable_field" is not a queryable field`. From what I can tell, this might be a race on the server but our tests shouldn't care too much about the exact wording on the client side so I'm just adding this to the client test to accommodate. 