### PR TITLE
Consolidate app creation to a single method

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@
 * None.
 
 ### Breaking changes
-* None.
+* `App::get_uncached_app(...)` and `App::get_shared_app(...)` have been replaced by `App::get_app(App::CacheMode, ...)`. The App constructor is now enforced to be unusable, use `App::get_app()` instead. ([#7237](https://github.com/realm/realm-core/issues/7237))
 
 ### Compatibility
 * Fileformat: Generates files with format v23. Reads and automatically upgrade from fileformat v5.

--- a/bindgen/spec.yml
+++ b/bindgen/spec.yml
@@ -202,6 +202,12 @@ enums:
       TypedLink: 16
       UUID: 17
 
+  AppCacheMode:
+    cppName: app::App::CacheMode
+    values:
+      - Enabled
+      - Disabled
+
   AuthProvider:
     cppName: app::AuthProvider
     values:
@@ -1169,14 +1175,12 @@ classes:
     sharedPtrWrapped: SharedApp
     properties:
       config: const AppConfig&
-      base_url: const std::string&
       current_user: Nullable<SharedSyncUser>
       all_users: std::vector<SharedSyncUser>
       sync_manager: SharedSyncManager
       subscribers_count: count_t
     staticMethods:
-      get_shared_app: '(config: AppConfig, sync_client_config: SyncClientConfig) -> SharedApp'
-      get_uncached_app: '(config: AppConfig, sync_client_config: SyncClientConfig) -> SharedApp'
+      get_app: '(mode: AppCacheMode, config: AppConfig, sync_client_config: SyncClientConfig) -> SharedApp'
       get_cached_app: '(app_id: const std::string&) -> SharedApp'
       clear_cached_apps: ()
       close_all_sync_sessions: ()

--- a/src/realm/object-store/c_api/app.cpp
+++ b/src/realm/object-store/c_api/app.cpp
@@ -249,7 +249,7 @@ RLM_API realm_app_t* realm_app_create(const realm_app_config_t* app_config,
                                       const realm_sync_client_config_t* sync_client_config)
 {
     return wrap_err([&] {
-        return new realm_app_t(App::get_app(app::App::CacheMode::Enabled, *app_config, *sync_client_config));
+        return new realm_app_t(App::get_app(app::App::CacheMode::Disabled, *app_config, *sync_client_config));
     });
 }
 

--- a/src/realm/object-store/c_api/app.cpp
+++ b/src/realm/object-store/c_api/app.cpp
@@ -249,7 +249,7 @@ RLM_API realm_app_t* realm_app_create(const realm_app_config_t* app_config,
                                       const realm_sync_client_config_t* sync_client_config)
 {
     return wrap_err([&] {
-        return new realm_app_t(App::get_uncached_app(*app_config, *sync_client_config));
+        return new realm_app_t(App::get_app(app::App::CacheMode::Enabled, *app_config, *sync_client_config));
     });
 }
 
@@ -257,7 +257,7 @@ RLM_API realm_app_t* realm_app_create_cached(const realm_app_config_t* app_confi
                                              const realm_sync_client_config_t* sync_client_config)
 {
     return wrap_err([&] {
-        return new realm_app_t(App::get_shared_app(*app_config, *sync_client_config));
+        return new realm_app_t(App::get_app(app::App::CacheMode::Enabled, *app_config, *sync_client_config));
     });
 }
 

--- a/src/realm/object-store/sync/app.cpp
+++ b/src/realm/object-store/sync/app.cpp
@@ -211,6 +211,9 @@ App::Config::DeviceInfo::DeviceInfo(std::string a_platform_version, std::string 
     bundle_id = a_bundle_id;
 }
 
+// NO_THREAD_SAFETY_ANALYSIS because clang generates a false positive.
+// "Calling function configure requires negative capability '!app->m_route_mutex'"
+// But 'app' is an object just created in this static method so it is not possible to annotate this in the header.
 SharedApp App::get_app(CacheMode mode, const Config& config,
                        const SyncClientConfig& sync_client_config) NO_THREAD_SAFETY_ANALYSIS
 {

--- a/src/realm/object-store/sync/app.cpp
+++ b/src/realm/object-store/sync/app.cpp
@@ -171,15 +171,15 @@ UniqueFunction<void(const Response&)> handle_default_response(UniqueFunction<voi
     };
 }
 
-const static std::string default_base_url = "https://realm.mongodb.com";
-const static std::string base_path = "/api/client/v2.0";
-const static std::string app_path = "/app";
-const static std::string auth_path = "/auth";
-const static std::string sync_path = "/realm-sync";
-const static uint64_t default_timeout_ms = 60000;
-const static std::string username_password_provider_key = "local-userpass";
-const static std::string user_api_key_provider_key_path = "api_keys";
-const static int max_http_redirects = 20;
+constexpr static std::string_view s_default_base_url = "https://realm.mongodb.com";
+constexpr static std::string_view s_base_path = "/api/client/v2.0";
+constexpr static std::string_view s_app_path = "/app";
+constexpr static std::string_view s_auth_path = "/auth";
+constexpr static std::string_view s_sync_path = "/realm-sync";
+constexpr static uint64_t s_default_timeout_ms = 60000;
+constexpr static std::string_view s_username_password_provider_key = "local-userpass";
+constexpr static std::string_view s_user_api_key_provider_key_path = "api_keys";
+constexpr static int s_max_http_redirects = 20;
 static util::FlatMap<std::string, util::FlatMap<std::string, SharedApp>> s_apps_cache; // app_id -> base_url -> app
 std::mutex s_apps_mutex;
 
@@ -211,20 +211,20 @@ App::Config::DeviceInfo::DeviceInfo(std::string a_platform_version, std::string 
     bundle_id = a_bundle_id;
 }
 
-SharedApp App::get_shared_app(const Config& config, const SyncClientConfig& sync_client_config)
+SharedApp App::get_app(CacheMode mode, const Config& config,
+                       const SyncClientConfig& sync_client_config) NO_THREAD_SAFETY_ANALYSIS
 {
-    std::lock_guard<std::mutex> lock(s_apps_mutex);
-    auto& app = s_apps_cache[config.app_id][config.base_url.value_or(default_base_url)];
-    if (!app) {
-        app = std::make_shared<App>(config);
-        app->configure(sync_client_config);
+    if (mode == CacheMode::Enabled) {
+        std::lock_guard<std::mutex> lock(s_apps_mutex);
+        auto& app = s_apps_cache[config.app_id][config.base_url.value_or(std::string(s_default_base_url))];
+        if (!app) {
+            app = std::make_shared<App>(private_construction_only(0), config);
+            app->configure(sync_client_config);
+        }
+        return app;
     }
-    return app;
-}
-
-SharedApp App::get_uncached_app(const Config& config, const SyncClientConfig& sync_client_config)
-{
-    auto app = std::make_shared<App>(config);
+    REALM_ASSERT(mode == CacheMode::Disabled);
+    auto app = std::make_shared<App>(private_construction_only(0), config);
     app->configure(sync_client_config);
     return app;
 }
@@ -260,13 +260,9 @@ void App::close_all_sync_sessions()
     }
 }
 
-App::App(const Config& config)
+App::App(private_construction_only, const Config& config)
     : m_config(std::move(config))
-    , m_base_url(m_config.base_url.value_or(default_base_url))
-    , m_base_route(m_base_url + base_path)
-    , m_app_route(m_base_route + app_path + "/" + m_config.app_id)
-    , m_auth_route(m_app_route + auth_path)
-    , m_request_timeout_ms(m_config.default_request_timeout_ms.value_or(default_timeout_ms))
+    , m_request_timeout_ms(m_config.default_request_timeout_ms.value_or(s_default_timeout_ms))
 {
 #ifdef __EMSCRIPTEN__
     if (!m_config.transport) {
@@ -276,6 +272,7 @@ App::App(const Config& config)
     REALM_ASSERT(m_config.transport);
     REALM_ASSERT(!m_config.device_info.platform.empty());
 
+    update_hostname(m_config.base_url.value_or(""));
     if (m_config.device_info.platform_version.empty()) {
         throw InvalidArgument("You must specify the Platform Version in App::Config::device_info");
     }
@@ -287,26 +284,27 @@ App::App(const Config& config)
     if (m_config.device_info.sdk_version.empty()) {
         throw InvalidArgument("You must specify the SDK Version in App::Config::device_info");
     }
-
-    // change the scheme in the base url to ws from http to satisfy the sync client
-    auto sync_route = make_sync_route(m_app_route);
-
-    m_sync_manager = std::make_shared<SyncManager>();
 }
 
 App::~App() {}
 
 void App::configure(const SyncClientConfig& sync_client_config)
 {
-    auto sync_route = make_sync_route(m_app_route);
+    std::string sync_route;
+    {
+        util::CheckedLockGuard guard(m_route_mutex);
+        sync_route = make_sync_route(m_app_route);
+    }
+    m_sync_manager = std::make_shared<SyncManager>();
     m_sync_manager->configure(shared_from_this(), sync_route, sync_client_config);
+
     if (auto metadata = m_sync_manager->app_metadata()) {
         // If there is app metadata stored, then set up the initial hostname/syncroute
         // using that info - it will be updated upon first request to the server
         update_hostname(metadata);
     }
     {
-        std::lock_guard<std::mutex> lock(*m_route_mutex);
+        util::CheckedLockGuard guard(m_route_mutex);
         // Always update the location after the app is configured/re-configured
         m_location_updated = false;
     }
@@ -314,7 +312,7 @@ void App::configure(const SyncClientConfig& sync_client_config)
 
 bool App::init_logger()
 {
-    if (!m_logger_ptr) {
+    if (!m_logger_ptr && m_sync_manager) {
         m_logger_ptr = m_sync_manager->get_logger();
     }
     return bool(m_logger_ptr);
@@ -344,11 +342,29 @@ void App::log_error(const char* message, Params&&... params)
 std::string App::make_sync_route(const std::string& http_app_route)
 {
     // change the scheme in the base url from http to ws to satisfy the sync client URL
-    auto sync_route = http_app_route + sync_path;
+    auto sync_route = util::format("%1%2", http_app_route, s_sync_path);
     size_t uri_scheme_start = sync_route.find("http");
     if (uri_scheme_start == 0)
         sync_route.replace(uri_scheme_start, 4, "ws");
     return sync_route;
+}
+
+std::string App::auth_route()
+{
+    util::CheckedLockGuard guard(m_route_mutex);
+    return m_auth_route;
+}
+
+std::string App::base_url()
+{
+    util::CheckedLockGuard guard(m_route_mutex);
+    return m_base_url;
+}
+
+static std::string make_app_route(const std::string& hostname, const std::string& app_id)
+{
+    REALM_ASSERT(!hostname.empty());
+    return util::format("%1%2%3/%4", hostname, s_base_path, s_app_path, app_id);
 }
 
 void App::update_hostname(const util::Optional<SyncAppMetadata>& metadata)
@@ -363,14 +379,17 @@ void App::update_hostname(const std::string& hostname, const Optional<std::strin
 {
     // Update url components based on new hostname (and optional websocket hostname) values
     log_debug("App: update_hostname: %1 | %2", hostname, ws_hostname);
-    REALM_ASSERT(m_sync_manager);
-    std::lock_guard<std::mutex> lock(*m_route_mutex);
-    m_base_route = (hostname.length() > 0 ? hostname : default_base_url) + base_path;
-    std::string this_app_path = app_path + "/" + m_config.app_id;
-    m_app_route = m_base_route + this_app_path;
-    m_auth_route = m_app_route + auth_path;
-    if (ws_hostname && ws_hostname->length() > 0) {
-        m_sync_manager->set_sync_route(*ws_hostname + base_path + this_app_path + sync_path);
+    util::CheckedLockGuard guard(m_route_mutex);
+    m_base_url = hostname.empty() ? s_default_base_url : hostname;
+    m_base_route = util::format("%1%2", m_base_url, s_base_path);
+    m_app_route = make_app_route(m_base_url, m_config.app_id);
+    m_auth_route = util::format("%1%2", m_app_route, s_auth_path);
+    if (!m_sync_manager) {
+        return;
+    }
+    if (ws_hostname && !ws_hostname->empty()) {
+        m_sync_manager->set_sync_route(
+            util::format("%1%2", make_app_route(*ws_hostname, m_config.app_id), s_sync_path));
     }
     else {
         m_sync_manager->set_sync_route(make_sync_route(m_app_route));
@@ -397,7 +416,7 @@ void App::UsernamePasswordProviderClient::register_email(const std::string& emai
                                                          UniqueFunction<void(Optional<AppError>)>&& completion)
 {
     m_parent->log_debug("App: register_email: %1", email);
-    m_parent->post(util::format("%1/providers/%2/register", m_parent->m_auth_route, username_password_provider_key),
+    m_parent->post(util::format("%1/providers/%2/register", m_parent->auth_route(), s_username_password_provider_key),
                    std::move(completion), {{"email", email}, {"password", password}});
 }
 
@@ -405,7 +424,7 @@ void App::UsernamePasswordProviderClient::confirm_user(const std::string& token,
                                                        UniqueFunction<void(Optional<AppError>)>&& completion)
 {
     m_parent->log_debug("App: confirm_user");
-    m_parent->post(util::format("%1/providers/%2/confirm", m_parent->m_auth_route, username_password_provider_key),
+    m_parent->post(util::format("%1/providers/%2/confirm", m_parent->auth_route(), s_username_password_provider_key),
                    std::move(completion), {{"token", token}, {"tokenId", token_id}});
 }
 
@@ -414,7 +433,7 @@ void App::UsernamePasswordProviderClient::resend_confirmation_email(
 {
     m_parent->log_debug("App: resend_confirmation_email: %1", email);
     m_parent->post(
-        util::format("%1/providers/%2/confirm/send", m_parent->m_auth_route, username_password_provider_key),
+        util::format("%1/providers/%2/confirm/send", m_parent->auth_route(), s_username_password_provider_key),
         std::move(completion), {{"email", email}});
 }
 
@@ -423,7 +442,7 @@ void App::UsernamePasswordProviderClient::retry_custom_confirmation(
 {
     m_parent->log_debug("App: retry_custom_confirmation: %1", email);
     m_parent->post(
-        util::format("%1/providers/%2/confirm/call", m_parent->m_auth_route, username_password_provider_key),
+        util::format("%1/providers/%2/confirm/call", m_parent->auth_route(), s_username_password_provider_key),
         std::move(completion), {{"email", email}});
 }
 
@@ -431,8 +450,9 @@ void App::UsernamePasswordProviderClient::send_reset_password_email(
     const std::string& email, UniqueFunction<void(Optional<AppError>)>&& completion)
 {
     m_parent->log_debug("App: send_reset_password_email: %1", email);
-    m_parent->post(util::format("%1/providers/%2/reset/send", m_parent->m_auth_route, username_password_provider_key),
-                   std::move(completion), {{"email", email}});
+    m_parent->post(
+        util::format("%1/providers/%2/reset/send", m_parent->auth_route(), s_username_password_provider_key),
+        std::move(completion), {{"email", email}});
 }
 
 void App::UsernamePasswordProviderClient::reset_password(const std::string& password, const std::string& token,
@@ -440,7 +460,7 @@ void App::UsernamePasswordProviderClient::reset_password(const std::string& pass
                                                          UniqueFunction<void(Optional<AppError>)>&& completion)
 {
     m_parent->log_debug("App: reset_password");
-    m_parent->post(util::format("%1/providers/%2/reset", m_parent->m_auth_route, username_password_provider_key),
+    m_parent->post(util::format("%1/providers/%2/reset", m_parent->auth_route(), s_username_password_provider_key),
                    std::move(completion), {{"password", password}, {"token", token}, {"tokenId", token_id}});
 }
 
@@ -449,8 +469,9 @@ void App::UsernamePasswordProviderClient::call_reset_password_function(
     UniqueFunction<void(Optional<AppError>)>&& completion)
 {
     m_parent->log_debug("App: call_reset_password_function: %1", email);
-    m_parent->post(util::format("%1/providers/%2/reset/call", m_parent->m_auth_route, username_password_provider_key),
-                   std::move(completion), {{"email", email}, {"password", password}, {"arguments", args}});
+    m_parent->post(
+        util::format("%1/providers/%2/reset/call", m_parent->auth_route(), s_username_password_provider_key),
+        std::move(completion), {{"email", email}, {"password", password}, {"arguments", args}});
 }
 
 // MARK: - UserAPIKeyProviderClient
@@ -459,10 +480,10 @@ std::string App::UserAPIKeyProviderClient::url_for_path(const std::string& path 
 {
     if (!path.empty()) {
         return m_auth_request_client.url_for_path(
-            util::format("%1/%2/%3", auth_path, user_api_key_provider_key_path, path));
+            util::format("%1/%2/%3", s_auth_path, s_user_api_key_provider_key_path, path));
     }
 
-    return m_auth_request_client.url_for_path(util::format("%1/%2", auth_path, user_api_key_provider_key_path));
+    return m_auth_request_client.url_for_path(util::format("%1/%2", s_auth_path, s_user_api_key_provider_key_path));
 }
 
 void App::UserAPIKeyProviderClient::create_api_key(
@@ -572,7 +593,7 @@ void App::get_profile(const std::shared_ptr<SyncUser>& sync_user,
     req.timeout_ms = m_request_timeout_ms;
     req.uses_refresh_token = false;
     {
-        std::lock_guard<std::mutex> lock(*m_route_mutex);
+        util::CheckedLockGuard guard(m_route_mutex);
         req.url = util::format("%1/auth/profile", m_base_route);
     }
 
@@ -651,7 +672,7 @@ void App::log_in_with_credentials(
     }
 
     // construct the route
-    std::string route = util::format("%1/providers/%2/login%3", m_auth_route, credentials.provider_as_string(),
+    std::string route = util::format("%1/providers/%2/login%3", auth_route(), credentials.provider_as_string(),
                                      linking_user ? "?link=true" : "");
 
     BsonDocument body = credentials.serialize_as_bson();
@@ -713,17 +734,14 @@ void App::log_out(const std::shared_ptr<SyncUser>& user, UniqueFunction<void(Opt
     auto refresh_token = user->refresh_token();
     user->log_out();
 
-    std::string route = util::format("%1/auth/session", m_base_route);
-
     Request req;
     req.method = HttpMethod::del;
-    req.url = route;
     req.timeout_ms = m_request_timeout_ms;
     req.uses_refresh_token = true;
     req.headers = get_request_headers();
     req.headers.insert({"Authorization", util::format("Bearer %1", refresh_token)});
     {
-        std::lock_guard<std::mutex> lock(*m_route_mutex);
+        util::CheckedLockGuard guard(m_route_mutex);
         req.url = util::format("%1/auth/session", m_base_route);
     }
 
@@ -740,7 +758,7 @@ void App::log_out(const std::shared_ptr<SyncUser>& user, UniqueFunction<void(Opt
 void App::log_out(UniqueFunction<void(Optional<AppError>)>&& completion)
 {
     log_debug("App: log_out()");
-    log_out(current_user(), std::move(completion));
+    log_out(m_sync_manager->get_current_user(), std::move(completion));
 }
 
 bool App::verify_user_present(const std::shared_ptr<SyncUser>& user) const
@@ -848,16 +866,17 @@ void App::refresh_custom_data(const std::shared_ptr<SyncUser>& user, bool update
 
 std::string App::url_for_path(const std::string& path = "") const
 {
-    std::lock_guard<std::mutex> lock(*m_route_mutex);
+    util::CheckedLockGuard guard(m_route_mutex);
     return util::format("%1%2", m_base_route, path);
 }
 
 std::string App::get_app_route(const Optional<std::string>& hostname) const
 {
     if (hostname) {
-        return *hostname + base_path + app_path + "/" + m_config.app_id;
+        return make_app_route(*hostname, m_config.app_id);
     }
     else {
+        util::CheckedLockGuard guard(m_route_mutex);
         return m_app_route;
     }
 }
@@ -869,7 +888,7 @@ void App::init_app_metadata(UniqueFunction<void(const Optional<Response>&)>&& co
     std::string route;
 
     {
-        std::unique_lock<std::mutex> lock(*m_route_mutex);
+        util::CheckedUniqueLock lock(m_route_mutex);
         // Skip if the app_metadata/location data has already been initialized and a new hostname is not provided
         if (!new_hostname && m_location_updated) {
             // Release the lock before calling the completion function
@@ -877,6 +896,7 @@ void App::init_app_metadata(UniqueFunction<void(const Optional<Response>&)>&& co
             return completion(util::none); // early return
         }
         else {
+            lock.unlock();
             route = util::format("%1/location", new_hostname ? get_app_route(new_hostname) : get_app_route());
         }
     }
@@ -911,7 +931,7 @@ void App::init_app_metadata(UniqueFunction<void(const Optional<Response>&)>&& co
                 self->update_hostname(hostname, ws_hostname);
             }
             {
-                std::lock_guard<std::mutex> lock(*self->m_route_mutex);
+                util::CheckedLockGuard guard(self->m_route_mutex);
                 self->m_location_updated = true;
             }
         }
@@ -937,7 +957,7 @@ void App::update_metadata_and_resend(Request&& request, UniqueFunction<void(cons
     // request once that's complete; or if a new_hostname is provided, re-initialize
     // the metadata with the updated location info
     init_app_metadata(
-        [completion = std::move(completion), request = std::move(request), base_url = m_base_url,
+        [completion = std::move(completion), request = std::move(request), base_url = base_url(),
          self = shared_from_this()](const util::Optional<Response>& response) mutable {
             if (response) {
                 return self->handle_possible_redirect_response(std::move(request), *response, std::move(completion));
@@ -969,7 +989,7 @@ void App::do_request(Request&& request, UniqueFunction<void(const Response&)>&& 
     // Refresh the location metadata every time an app is created (or when requested) to ensure the http
     // and websocket URL information is up to date.
     {
-        std::unique_lock<std::mutex> lock(*m_route_mutex);
+        util::CheckedUniqueLock lock(m_route_mutex);
         if (update_location) {
             // Force the location to be updated before sending the request.
             m_location_updated = false;
@@ -1021,12 +1041,12 @@ void App::handle_redirect_response(Request&& request, const Response& response,
     }
 
     // Make sure we don't do too many redirects (max_http_redirects (20) is an arbitrary number)
-    if (++request.redirect_count > max_http_redirects) {
+    if (++request.redirect_count > s_max_http_redirects) {
         Response error;
         error.http_status_code = response.http_status_code;
         error.custom_status_code = 0;
         error.client_error_code = ErrorCodes::ClientTooManyRedirects;
-        error.body = util::format("number of redirections exceeded %1", max_http_redirects);
+        error.body = util::format("number of redirections exceeded %1", s_max_http_redirects);
         return completion(error); // early return
     }
 
@@ -1114,7 +1134,7 @@ void App::refresh_access_token(const std::shared_ptr<SyncUser>& sync_user, bool 
 
     std::string route;
     {
-        std::lock_guard<std::mutex> lock(*m_route_mutex);
+        util::CheckedLockGuard guard(m_route_mutex);
         route = util::format("%1/auth/session", m_base_route);
     }
 
@@ -1145,7 +1165,7 @@ void App::refresh_access_token(const std::shared_ptr<SyncUser>& sync_user, bool 
 
 std::string App::function_call_url_path() const
 {
-    std::lock_guard<std::mutex> lock(*m_route_mutex);
+    util::CheckedLockGuard guard(m_route_mutex);
     return util::format("%1/app/%2/functions/call", m_base_route, m_config.app_id);
 }
 

--- a/src/realm/object-store/sync/app.cpp
+++ b/src/realm/object-store/sync/app.cpp
@@ -218,13 +218,13 @@ SharedApp App::get_app(CacheMode mode, const Config& config,
         std::lock_guard<std::mutex> lock(s_apps_mutex);
         auto& app = s_apps_cache[config.app_id][config.base_url.value_or(std::string(s_default_base_url))];
         if (!app) {
-            app = std::make_shared<App>(private_construction_only(0), config);
+            app = std::make_shared<App>(PrivateConstructionOnly(), config);
             app->configure(sync_client_config);
         }
         return app;
     }
     REALM_ASSERT(mode == CacheMode::Disabled);
-    auto app = std::make_shared<App>(private_construction_only(0), config);
+    auto app = std::make_shared<App>(PrivateConstructionOnly(), config);
     app->configure(sync_client_config);
     return app;
 }
@@ -260,7 +260,7 @@ void App::close_all_sync_sessions()
     }
 }
 
-App::App(private_construction_only, const Config& config)
+App::App(PrivateConstructionOnly, const Config& config)
     : m_config(std::move(config))
     , m_request_timeout_ms(m_config.default_request_timeout_ms.value_or(s_default_timeout_ms))
 {

--- a/src/realm/object-store/sync/app.hpp
+++ b/src/realm/object-store/sync/app.hpp
@@ -57,8 +57,8 @@ class App : public std::enable_shared_from_this<App>,
             public AppServiceClient,
             public Subscribable<App> {
 
-    struct private_construction_only {
-        explicit private_construction_only(int) {}
+    struct PrivateConstructionOnly {
+        explicit PrivateConstructionOnly() {}
     };
 
 public:
@@ -95,7 +95,7 @@ public:
 
     // `enable_shared_from_this` is unsafe with public constructors;
     // use `App::get_app()` instead
-    explicit App(private_construction_only, const Config& config);
+    explicit App(PrivateConstructionOnly, const Config& config);
     App(App&&) noexcept = delete;
     App& operator=(App&&) noexcept = delete;
     ~App();

--- a/src/realm/object-store/sync/app.hpp
+++ b/src/realm/object-store/sync/app.hpp
@@ -27,6 +27,7 @@
 #include <realm/object-store/sync/subscribable.hpp>
 
 #include <realm/object_id.hpp>
+#include <realm/util/checked_mutex.hpp>
 #include <realm/util/logger.hpp>
 #include <realm/util/optional.hpp>
 #include <realm/util/functional.hpp>
@@ -55,6 +56,11 @@ class App : public std::enable_shared_from_this<App>,
             public AuthRequestClient,
             public AppServiceClient,
             public Subscribable<App> {
+
+    struct private_construction_only {
+        explicit private_construction_only(int) {}
+    };
+
 public:
     struct Config {
         // Information about the device where the app is running
@@ -87,20 +93,16 @@ public:
         DeviceInfo device_info;
     };
 
-    // `enable_shared_from_this` is unsafe with public constructors; use `get_shared_app` instead
-    App(const Config& config);
-    App(App&&) noexcept = default;
-    App& operator=(App&&) noexcept = default;
+    // `enable_shared_from_this` is unsafe with public constructors;
+    // use `App::get_app()` instead
+    explicit App(private_construction_only, const Config& config);
+    App(App&&) noexcept = delete;
+    App& operator=(App&&) noexcept = delete;
     ~App();
 
     const Config& config() const
     {
         return m_config;
-    }
-
-    const std::string& base_url() const
-    {
-        return m_base_url;
     }
 
     /// Get the last used user.
@@ -251,19 +253,19 @@ public:
         SharedApp m_parent;
     };
 
-    /// Retrieve a cached app instance if one was previously generated for `config`'s app_id+base_url combo,
-    /// otherwise generate and return a new instance and persist it in the cache.
-    static SharedApp get_shared_app(const Config& config, const SyncClientConfig& sync_client_config);
-
-    /// Generate and return a new app instance for the given config, bypassing the app cache.
-    static SharedApp get_uncached_app(const Config& config, const SyncClientConfig& sync_client_config);
+    enum class CacheMode {
+        Enabled, // Return a cached app instance if one was previously generated for `config`'s app_id+base_url combo,
+        Disabled // Bypass the app cache; return a new app instance.
+    };
+    /// Get a shared pointer to a configured App instance.
+    static SharedApp get_app(CacheMode mode, const Config& config, const SyncClientConfig& sync_client_config);
 
     /// Return a cached app instance if one was previously generated for the `app_id`+`base_url` combo using
-    /// `get_shared_app`.
+    /// `App::get_app()`.
     /// If base_url is not provided, and there are multiple cached apps with the same app_id but different base_urls,
     /// then a non-determinstic one will be returned.
     ///
-    /// Prefer using `get_shared_app` or populating `base_url` to avoid the non-deterministic behavior.
+    /// Prefer using `App::get_app()` or populating `base_url` to avoid the non-deterministic behavior.
     static SharedApp get_cached_app(const std::string& app_id,
                                     const std::optional<std::string>& base_url = std::nullopt);
 
@@ -277,22 +279,25 @@ public:
     /// @param completion A callback block to be invoked once the log in completes.
     void log_in_with_credentials(
         const AppCredentials& credentials,
-        util::UniqueFunction<void(const std::shared_ptr<SyncUser>&, util::Optional<AppError>)>&& completion);
+        util::UniqueFunction<void(const std::shared_ptr<SyncUser>&, util::Optional<AppError>)>&& completion)
+        REQUIRES(!m_route_mutex);
 
     /// Logout the current user.
-    void log_out(util::UniqueFunction<void(util::Optional<AppError>)>&&);
+    void log_out(util::UniqueFunction<void(util::Optional<AppError>)>&&) REQUIRES(!m_route_mutex);
 
     /// Refreshes the custom data for a specified user
     /// @param user The user you want to refresh
     /// @param update_location If true, the location metadata will be updated before refresh
     void refresh_custom_data(const std::shared_ptr<SyncUser>& user, bool update_location,
-                             util::UniqueFunction<void(util::Optional<AppError>)>&& completion);
+                             util::UniqueFunction<void(util::Optional<AppError>)>&& completion)
+        REQUIRES(!m_route_mutex);
     void refresh_custom_data(const std::shared_ptr<SyncUser>& user,
-                             util::UniqueFunction<void(util::Optional<AppError>)>&& completion);
+                             util::UniqueFunction<void(util::Optional<AppError>)>&& completion)
+        REQUIRES(!m_route_mutex);
 
     /// Log out the given user if they are not already logged out.
     void log_out(const std::shared_ptr<SyncUser>& user,
-                 util::UniqueFunction<void(util::Optional<AppError>)>&& completion);
+                 util::UniqueFunction<void(util::Optional<AppError>)>&& completion) REQUIRES(!m_route_mutex);
 
     /// Links the currently authenticated user with a new identity, where the identity is defined by the credential
     /// specified as a parameter. This will only be successful if this `SyncUser` is the currently authenticated
@@ -305,7 +310,8 @@ public:
     ///                         `SyncUser` object representing the user.
     void
     link_user(const std::shared_ptr<SyncUser>& user, const AppCredentials& credentials,
-              util::UniqueFunction<void(const std::shared_ptr<SyncUser>&, util::Optional<AppError>)>&& completion);
+              util::UniqueFunction<void(const std::shared_ptr<SyncUser>&, util::Optional<AppError>)>&& completion)
+        REQUIRES(!m_route_mutex);
 
     /// Switches the active user with the specified one. The user must
     /// exist in the list of all users who have logged into this application, and
@@ -321,13 +327,13 @@ public:
     /// @param user the user to remove
     /// @param completion Will return an error if the user is not found or the http request failed.
     void remove_user(const std::shared_ptr<SyncUser>& user,
-                     util::UniqueFunction<void(util::Optional<AppError>)>&& completion);
+                     util::UniqueFunction<void(util::Optional<AppError>)>&& completion) REQUIRES(!m_route_mutex);
 
     /// Deletes a user and all its data from the server.
     /// @param user The user to delete
     /// @param completion Will return an error if the user is not found or the http request failed.
     void delete_user(const std::shared_ptr<SyncUser>& user,
-                     util::UniqueFunction<void(util::Optional<AppError>)>&& completion);
+                     util::UniqueFunction<void(util::Optional<AppError>)>&& completion) REQUIRES(!m_route_mutex);
 
     // Get a provider client for the given class type.
     template <class T>
@@ -338,29 +344,35 @@ public:
 
     void call_function(const std::shared_ptr<SyncUser>& user, const std::string& name, std::string_view args_ejson,
                        const util::Optional<std::string>& service_name,
-                       util::UniqueFunction<void(const std::string*, util::Optional<AppError>)>&& completion) final;
+                       util::UniqueFunction<void(const std::string*, util::Optional<AppError>)>&& completion) final
+        REQUIRES(!m_route_mutex);
 
     void call_function(
         const std::shared_ptr<SyncUser>& user, const std::string& name, const bson::BsonArray& args_bson,
         const util::Optional<std::string>& service_name,
-        util::UniqueFunction<void(util::Optional<bson::Bson>&&, util::Optional<AppError>)>&& completion) final;
+        util::UniqueFunction<void(util::Optional<bson::Bson>&&, util::Optional<AppError>)>&& completion) final
+        REQUIRES(!m_route_mutex);
 
     void call_function(
         const std::shared_ptr<SyncUser>& user, const std::string&, const bson::BsonArray& args_bson,
-        util::UniqueFunction<void(util::Optional<bson::Bson>&&, util::Optional<AppError>)>&& completion) final;
+        util::UniqueFunction<void(util::Optional<bson::Bson>&&, util::Optional<AppError>)>&& completion) final
+        REQUIRES(!m_route_mutex);
 
     void call_function(
         const std::string& name, const bson::BsonArray& args_bson, const util::Optional<std::string>& service_name,
-        util::UniqueFunction<void(util::Optional<bson::Bson>&&, util::Optional<AppError>)>&& completion) final;
+        util::UniqueFunction<void(util::Optional<bson::Bson>&&, util::Optional<AppError>)>&& completion) final
+        REQUIRES(!m_route_mutex);
 
     void call_function(
         const std::string&, const bson::BsonArray& args_bson,
-        util::UniqueFunction<void(util::Optional<bson::Bson>&&, util::Optional<AppError>)>&& completion) final;
+        util::UniqueFunction<void(util::Optional<bson::Bson>&&, util::Optional<AppError>)>&& completion) final
+        REQUIRES(!m_route_mutex);
 
     template <typename T>
     void call_function(const std::shared_ptr<SyncUser>& user, const std::string& name,
                        const bson::BsonArray& args_bson,
                        util::UniqueFunction<void(util::Optional<T>&&, util::Optional<AppError>)>&& completion)
+        REQUIRES(!m_route_mutex)
     {
         call_function(
             user, name, args_bson, util::none,
@@ -376,7 +388,9 @@ public:
     template <typename T>
     void call_function(const std::string& name, const bson::BsonArray& args_bson,
                        util::UniqueFunction<void(util::Optional<T>&&, util::Optional<AppError>)>&& completion)
+        REQUIRES(!m_route_mutex)
     {
+
         call_function(current_user(), name, args_bson, std::move(completion));
     }
 
@@ -384,7 +398,7 @@ public:
     // setting other headers (eg. EventSource() in JS), you can ignore the headers field on the request.
     Request make_streaming_request(const std::shared_ptr<SyncUser>& user, const std::string& name,
                                    const bson::BsonArray& args_bson,
-                                   const util::Optional<std::string>& service_name) const;
+                                   const util::Optional<std::string>& service_name) const REQUIRES(!m_route_mutex);
 
     // MARK: Push notification client
     PushClient push_notification_client(const std::string& service_name);
@@ -404,12 +418,12 @@ private:
 
     // mutable to allow locking for reads in const functions
     // this is a shared pointer to support the App move constructor
-    mutable std::shared_ptr<std::mutex> m_route_mutex = std::make_shared<std::mutex>();
-    std::string m_base_url;
-    std::string m_base_route;
-    std::string m_app_route;
-    std::string m_auth_route;
-    bool m_location_updated = false;
+    mutable util::CheckedMutex m_route_mutex;
+    std::string m_base_url GUARDED_BY(m_route_mutex);
+    std::string m_base_route GUARDED_BY(m_route_mutex);
+    std::string m_app_route GUARDED_BY(m_route_mutex);
+    std::string m_auth_route GUARDED_BY(m_route_mutex);
+    bool m_location_updated GUARDED_BY(m_route_mutex) = false;
 
     uint64_t m_request_timeout_ms;
     std::shared_ptr<SyncManager> m_sync_manager;
@@ -431,7 +445,8 @@ private:
     /// @param completion Passes an error should one occur.
     /// @param update_location If true, the location metadata will be updated before refresh
     void refresh_access_token(const std::shared_ptr<SyncUser>& user, bool update_location,
-                              util::UniqueFunction<void(util::Optional<AppError>)>&& completion);
+                              util::UniqueFunction<void(util::Optional<AppError>)>&& completion)
+        REQUIRES(!m_route_mutex);
 
     /// Checks if an auth failure has taken place and if so it will attempt to refresh the
     /// access token and then perform the orginal request again with the new access token
@@ -442,65 +457,70 @@ private:
     /// occurs, if the refresh was a success the newly attempted response will be passed back
     void handle_auth_failure(const AppError& error, const Response& response, Request&& request,
                              const std::shared_ptr<SyncUser>& user,
-                             util::UniqueFunction<void(const Response&)>&& completion);
+                             util::UniqueFunction<void(const Response&)>&& completion) REQUIRES(!m_route_mutex);
 
-    std::string url_for_path(const std::string& path) const override;
+    std::string url_for_path(const std::string& path) const override REQUIRES(!m_route_mutex);
 
     /// Return the app route for this App instance, or creates a new app route string if
     /// a new hostname is provided
     /// @param hostname The hostname to generate a new app route
-    std::string get_app_route(const util::Optional<std::string>& hostname = util::none) const;
+    std::string get_app_route(const util::Optional<std::string>& hostname = util::none) const
+        REQUIRES(!m_route_mutex);
 
     /// Request the app metadata information from the server if it has not been processed yet. If
     /// a new hostname is provided, the app metadata will be refreshed using the new hostname.
     /// @param completion The server response if an error was encountered during the update
     /// @param new_hostname If provided, the metadata will be requested from this hostname
     void init_app_metadata(util::UniqueFunction<void(const util::Optional<Response>&)>&& completion,
-                           const util::Optional<std::string>& new_hostname = util::none);
+                           const util::Optional<std::string>& new_hostname = util::none) REQUIRES(!m_route_mutex);
 
     /// Update the app metadata and resend the request with the updated metadata
     /// @param request The original request object that needs to be sent after the update
     /// @param completion The original completion object that will be called with the response to the request
     /// @param new_hostname If provided, the metadata will be requested from this hostname
     void update_metadata_and_resend(Request&& request, util::UniqueFunction<void(const Response&)>&& completion,
-                                    const util::Optional<std::string>& new_hostname = util::none);
+                                    const util::Optional<std::string>& new_hostname = util::none)
+        REQUIRES(!m_route_mutex);
 
     void post(std::string&& route, util::UniqueFunction<void(util::Optional<AppError>)>&& completion,
-              const bson::BsonDocument& body);
+              const bson::BsonDocument& body) REQUIRES(!m_route_mutex);
 
     /// Performs a request to the Stitch server. This request does not contain authentication state.
     /// @param request The request to be performed
     /// @param completion Returns the response from the server
     /// @param update_location Force the location metadata to be updated prior to sending the request
     void do_request(Request&& request, util::UniqueFunction<void(const Response&)>&& completion,
-                    bool update_location = false);
+                    bool update_location = false) REQUIRES(!m_route_mutex);
 
     /// Check to see if hte response is a redirect and handle, otherwise pass the response to compleetion
     /// @param request The request to be performed (in case it needs to be sent again)
     /// @param response The response from the send_request_to_server operation
     /// @param completion Returns the response from the server if not a redirect
     void handle_possible_redirect_response(Request&& request, const Response& response,
-                                           util::UniqueFunction<void(const Response&)>&& completion);
+                                           util::UniqueFunction<void(const Response&)>&& completion)
+        REQUIRES(!m_route_mutex);
 
     /// Process the redirect response received from the last request that was sent to the server
     /// @param request The request to be performed (in case it needs to be sent again)
     /// @param response The response from the send_request_to_server operation
     /// @param completion Returns the response from the server if not a redirect
     void handle_redirect_response(Request&& request, const Response& response,
-                                  util::UniqueFunction<void(const Response&)>&& completion);
+                                  util::UniqueFunction<void(const Response&)>&& completion) REQUIRES(!m_route_mutex);
 
     /// Performs an authenticated request to the Stitch server, using the current authentication state
     /// @param request The request to be performed
     /// @param completion Returns the response from the server
     void do_authenticated_request(Request&& request, const std::shared_ptr<SyncUser>& user,
-                                  util::UniqueFunction<void(const Response&)>&& completion) override;
+                                  util::UniqueFunction<void(const Response&)>&& completion) override
+        REQUIRES(!m_route_mutex);
 
 
     /// Gets the social profile for a `SyncUser`
     /// @param completion Callback will pass the `SyncUser` with the social profile details
     void
     get_profile(const std::shared_ptr<SyncUser>& user,
-                util::UniqueFunction<void(const std::shared_ptr<SyncUser>&, util::Optional<AppError>)>&& completion);
+                util::UniqueFunction<void(const std::shared_ptr<SyncUser>&, util::Optional<AppError>)>&& completion)
+        REQUIRES(!m_route_mutex);
 
     /// Log in a user and asynchronously retrieve a user object.
     /// If the log in completes successfully, the completion block will be called, and a
@@ -513,20 +533,22 @@ private:
     /// @param completion A callback block to be invoked once the log in completes.
     void log_in_with_credentials(
         const AppCredentials& credentials, const std::shared_ptr<SyncUser>& linking_user,
-        util::UniqueFunction<void(const std::shared_ptr<SyncUser>&, util::Optional<AppError>)>&& completion);
+        util::UniqueFunction<void(const std::shared_ptr<SyncUser>&, util::Optional<AppError>)>&& completion)
+        REQUIRES(!m_route_mutex);
 
     /// Provides MongoDB Realm Cloud with metadata related to the users session
     void attach_auth_options(bson::BsonDocument& body);
 
-    std::string function_call_url_path() const;
+    std::string function_call_url_path() const REQUIRES(!m_route_mutex);
 
-    void configure(const SyncClientConfig& sync_client_config);
+    void configure(const SyncClientConfig& sync_client_config) REQUIRES(!m_route_mutex);
 
-    std::string make_sync_route(const std::string& http_app_route);
-
-    void update_hostname(const util::Optional<realm::SyncAppMetadata>& metadata);
-
-    void update_hostname(const std::string& hostname, const util::Optional<std::string>& ws_hostname = util::none);
+    static std::string make_sync_route(const std::string& http_app_route);
+    void update_hostname(const util::Optional<realm::SyncAppMetadata>& metadata) REQUIRES(!m_route_mutex);
+    void update_hostname(const std::string& hostname, const util::Optional<std::string>& ws_hostname = util::none)
+        REQUIRES(!m_route_mutex);
+    std::string auth_route() REQUIRES(!m_route_mutex);
+    std::string base_url() REQUIRES(!m_route_mutex);
 
     bool verify_user_present(const std::shared_ptr<SyncUser>& user) const;
 };

--- a/test/object-store/c_api/c_api.cpp
+++ b/test/object-store/c_api/c_api.cpp
@@ -586,7 +586,15 @@ TEST_CASE("C API (non-database)", "[c_api]") {
         realm_app_config_set_bundle_id(app_config.get(), "some_bundle_id");
         CHECK(app_config->device_info.bundle_id == "some_bundle_id");
 
-        auto test_app = std::make_shared<app::App>(*app_config);
+        std::string temp_dir = util::make_temp_dir();
+        auto guard = util::make_scope_exit([&temp_dir]() noexcept {
+            util::try_remove_dir_recursive(temp_dir);
+        });
+        SyncClientConfig sync_client_config;
+        sync_client_config.base_file_path = temp_dir;
+        sync_client_config.metadata_mode = SyncClientConfig::MetadataMode::NoMetadata;
+
+        auto test_app = app::App::get_app(app::App::CacheMode::Disabled, *app_config, sync_client_config);
         auto credentials = app::AppCredentials::anonymous();
         // Verify the values above are included in the login request
         test_app->log_in_with_credentials(credentials, [&](const std::shared_ptr<realm::SyncUser>&,

--- a/test/object-store/sync/app.cpp
+++ b/test/object-store/sync/app.cpp
@@ -2359,7 +2359,7 @@ TEST_CASE("app: sync integration", "[sync][pbs][app][baas]") {
         sc_config.metadata_mode = realm::SyncManager::MetadataMode::NoEncryption;
 
         // initialize app and sync client
-        auto redir_app = app::App::get_uncached_app(app_config, sc_config);
+        auto redir_app = app::App::get_app(app::App::CacheMode::Disabled, app_config, sc_config);
 
         SECTION("Test invalid redirect response") {
             int request_count = 0;
@@ -2547,7 +2547,7 @@ TEST_CASE("app: sync integration", "[sync][pbs][app][baas]") {
         sc_config.metadata_mode = realm::SyncManager::MetadataMode::NoMetadata;
 
         // initialize app and sync client
-        auto redir_app = app::App::get_uncached_app(app_config, sc_config);
+        auto redir_app = app::App::get_app(app::App::CacheMode::Disabled, app_config, sc_config);
 
         int request_count = 0;
         // redirect URL is localhost or 127.0.0.1 depending on what the initial value is
@@ -5309,10 +5309,10 @@ TEST_CASE("app: shared instances", "[sync][app]") {
     config4.base_url = "http://localhost:9090";
 
     // should all point to same underlying app
-    auto app1_1 = App::get_shared_app(config1, sync_config);
-    auto app1_2 = App::get_shared_app(config1, sync_config);
+    auto app1_1 = App::get_app(app::App::CacheMode::Enabled, config1, sync_config);
+    auto app1_2 = App::get_app(app::App::CacheMode::Enabled, config1, sync_config);
     auto app1_3 = App::get_cached_app(config1.app_id, config1.base_url);
-    auto app1_4 = App::get_shared_app(config2, sync_config);
+    auto app1_4 = App::get_app(app::App::CacheMode::Enabled, config2, sync_config);
     auto app1_5 = App::get_cached_app(config1.app_id);
 
     CHECK(app1_1 == app1_2);
@@ -5321,9 +5321,9 @@ TEST_CASE("app: shared instances", "[sync][app]") {
     CHECK(app1_1 == app1_5);
 
     // config3 and config4 should point to different apps
-    auto app2_1 = App::get_shared_app(config3, sync_config);
+    auto app2_1 = App::get_app(app::App::CacheMode::Enabled, config3, sync_config);
     auto app2_2 = App::get_cached_app(config3.app_id, config3.base_url);
-    auto app2_3 = App::get_shared_app(config4, sync_config);
+    auto app2_3 = App::get_app(app::App::CacheMode::Enabled, config4, sync_config);
     auto app2_4 = App::get_cached_app(config3.app_id);
     auto app2_5 = App::get_cached_app(config4.app_id, "https://some.different.url");
 

--- a/test/object-store/util/test_file.cpp
+++ b/test/object-store/util/test_file.cpp
@@ -354,7 +354,7 @@ TestAppSession::TestAppSession(AppSession session,
     // down sync clients immediately.
     sc_config.timeouts.connection_linger_time = 0;
 
-    m_app = app::App::get_uncached_app(app_config, sc_config);
+    m_app = app::App::get_app(app::App::CacheMode::Disabled, app_config, sc_config);
 
     // initialize sync client
     m_app->sync_manager()->get_sync_client();
@@ -438,7 +438,7 @@ TestSyncManager::TestSyncManager(const Config& config, const SyncServer::Config&
     sc_config.base_file_path = m_base_file_path;
     sc_config.metadata_mode = config.metadata_mode;
 
-    m_app = app::App::get_uncached_app(app_config, sc_config);
+    m_app = app::App::get_app(app::App::CacheMode::Disabled, app_config, sc_config);
     if (config.override_sync_route) {
         m_app->sync_manager()->set_sync_route(m_sync_server.base_url() + "/realm-sync");
     }


### PR DESCRIPTION
This is a collection of changes that I am extracting from another PR in order to reduce the complexity there as these changes can stand on their own.
- `App::get_uncached_app(...)` and `App::get_shared_app(...)` have been replaced by `App::get_app(App::CacheMode, ...)`
- The App constructor is now enforced to be unusable by the public.
- Renamed some static variables to have the `s_` prefix.
- Use a checked mutex to help validate locking throughout the API.

## ☑️ ToDos
* [x] 📝 Changelog update
* [x] 🚦 Tests (or not relevant)
* [x] C-API, if public C++ API changed
* [x] `bindgen/spec.yml`, if public C++ API changed
