### PR TITLE
Fix incorrect rebootstrap

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,8 +5,7 @@
 * None.
 
 ### Fixed
-* <How do the end-user experience this issue? what was the impact?> ([#????](https://github.com/realm/realm-core/issues/????), since v?.?.?)
-* None.
+* Application may crash with `incoming_changesets.size() != 0` when a download message is mistaken for a bootstrap message (PR [#7238](https://github.com/realm/realm-core/pull/7238), since v11.8.0)
 
 ### Breaking changes
 * None.

--- a/src/realm/sync/client.cpp
+++ b/src/realm/sync/client.cpp
@@ -1149,8 +1149,6 @@ SessionWrapper::SessionWrapper(ClientImpl& client, DBRef db, std::shared_ptr<Sub
     if (m_client_reset_config) {
         m_session_reason = SessionReason::ClientReset;
     }
-
-    update_subscription_version_info();
 }
 
 SessionWrapper::~SessionWrapper() noexcept
@@ -1542,6 +1540,10 @@ void SessionWrapper::actualize(ServerEndpoint endpoint)
         finalize_before_actualization();
         throw;
     }
+
+    // Initialize the variables relying on the bootstrap store from the event loop to guarantee that a previous
+    // session cannot change the state of the bootstrap store at the same time.
+    update_subscription_version_info();
 
     m_actualized = true;
     if (was_created)

--- a/test/object-store/sync/flx_sync.cpp
+++ b/test/object-store/sync/flx_sync.cpp
@@ -4720,6 +4720,9 @@ TEST_CASE("flx: pause and resume bootstrapping at query version 0", "[sync][flx]
     interrupted.get();
     std::lock_guard<std::mutex> lk(download_message_mutex);
     CHECK(download_message_integrated_count == 2);
+    auto active_sub_set = realm->sync_session()->get_flx_subscription_store()->get_active();
+    REQUIRE(active_sub_set.version() == 0);
+    REQUIRE(active_sub_set.state() == sync::SubscriptionSet::State::Complete);
 }
 
 } // namespace realm::app


### PR DESCRIPTION
## What, How & Why?
Pausing and resuming the sync session at a very specific time may cause the next download message to be mistaken for a bootstrap message and crash the application.

Fixes #6611.

## ☑️ ToDos
* [x] 📝 Changelog update
* [X] 🚦 Tests (or not relevant)
* ~~[ ] C-API, if public C++ API changed~~
* ~~[ ] `bindgen/spec.yml`, if public C++ API changed~~
