### PR TITLE
Switch back to disabling metadata storage for most object store tests

### DIFF
--- a/test/object-store/sync/app.cpp
+++ b/test/object-store/sync/app.cpp
@@ -3951,6 +3951,7 @@ TEST_CASE("app: login_with_credentials unit_tests", "[sync][app][user]") {
         UnitTestTransport::access_token = good_access_token;
         config.base_path = util::make_temp_dir();
         config.should_teardown_test_directory = false;
+        config.metadata_mode = SyncManager::MetadataMode::NoEncryption;
         {
             TestSyncManager tsm(config);
             auto app = tsm.app();
@@ -4962,6 +4963,7 @@ TEST_CASE("app: metadata is persisted between sessions", "[sync][app][metadata]"
     TestSyncManager::Config config = get_config(instance_of<transport>);
     config.base_path = util::make_temp_dir();
     config.should_teardown_test_directory = false;
+    config.metadata_mode = SyncManager::MetadataMode::NoEncryption;
 
     {
         TestSyncManager sync_manager(config, {});

--- a/test/object-store/util/test_file.hpp
+++ b/test/object-store/util/test_file.hpp
@@ -225,7 +225,7 @@ public:
         Config() {}
         realm::app::App::Config app_config;
         std::string base_path;
-        realm::SyncManager::MetadataMode metadata_mode = realm::SyncManager::MetadataMode::NoEncryption;
+        realm::SyncManager::MetadataMode metadata_mode = realm::SyncManager::MetadataMode::NoMetadata;
         bool should_teardown_test_directory = true;
         realm::util::Logger::Level log_level = realm::util::Logger::Level::TEST_LOGGING_LEVEL;
         bool override_sync_route = true;


### PR DESCRIPTION
This appears to have been accidentally reverted to NoEncryption in a bad merge while merging object store into the monorepo (in c51c278c9dd5537992ccba8094d27414a0abedd4). NoEncryption roughly doubles the runtime of the non-baas object store test suite compared to NoMetadata.

Disabling metadata for the baas tests has a much smaller benefit (~10 seconds off the 15+ minute runtime).