### PR TITLE
Use private tags in constructor of shared-only classes

### DIFF
--- a/src/realm/db.cpp
+++ b/src/realm/db.cpp
@@ -2733,7 +2733,7 @@ void DB::async_request_write_mutex(TransactionRef& tr, util::UniqueFunction<void
     });
 }
 
-inline DB::DB(const DBOptions& options)
+inline DB::DB(Private, const DBOptions& options)
     : m_upgrade_callback(std::move(options.upgrade_callback))
     , m_log_id(util::gen_log_id(this))
 {
@@ -2742,26 +2742,16 @@ inline DB::DB(const DBOptions& options)
     }
 }
 
-namespace {
-class DBInit : public DB {
-public:
-    explicit DBInit(const DBOptions& options)
-        : DB(options)
-    {
-    }
-};
-} // namespace
-
 DBRef DB::create(const std::string& file, bool no_create, const DBOptions& options) NO_THREAD_SAFETY_ANALYSIS
 {
-    DBRef retval = std::make_shared<DBInit>(options);
+    DBRef retval = std::make_shared<DB>(Private(), options);
     retval->open(file, no_create, options);
     return retval;
 }
 
 DBRef DB::create(Replication& repl, const std::string& file, const DBOptions& options) NO_THREAD_SAFETY_ANALYSIS
 {
-    DBRef retval = std::make_shared<DBInit>(options);
+    DBRef retval = std::make_shared<DB>(Private(), options);
     retval->open(repl, file, options);
     return retval;
 }
@@ -2770,7 +2760,7 @@ DBRef DB::create(std::unique_ptr<Replication> repl, const std::string& file,
                  const DBOptions& options) NO_THREAD_SAFETY_ANALYSIS
 {
     REALM_ASSERT(repl);
-    DBRef retval = std::make_shared<DBInit>(options);
+    DBRef retval = std::make_shared<DB>(Private(), options);
     retval->m_history = std::move(repl);
     retval->open(*retval->m_history, file, options);
     return retval;
@@ -2779,7 +2769,7 @@ DBRef DB::create(std::unique_ptr<Replication> repl, const std::string& file,
 DBRef DB::create(std::unique_ptr<Replication> repl, const DBOptions& options) NO_THREAD_SAFETY_ANALYSIS
 {
     REALM_ASSERT(repl);
-    DBRef retval = std::make_shared<DBInit>(options);
+    DBRef retval = std::make_shared<DB>(Private(), options);
     retval->m_history = std::move(repl);
     retval->open(*retval->m_history, options);
     return retval;
@@ -2797,7 +2787,7 @@ DBRef DB::create(BinaryData buffer, bool take_ownership) NO_THREAD_SAFETY_ANALYS
 {
     DBOptions options;
     options.is_immutable = true;
-    DBRef retval = std::make_shared<DBInit>(options);
+    DBRef retval = std::make_shared<DB>(Private(), options);
     retval->open(buffer, take_ownership);
     return retval;
 }

--- a/src/realm/db.hpp
+++ b/src/realm/db.hpp
@@ -120,8 +120,7 @@ using DBRef = std::shared_ptr<DB>;
 
 class DB : public std::enable_shared_from_this<DB> {
     struct ReadLockInfo;
-    struct Private {
-    };
+    struct Private {};
 
 public:
     // Create a DB and associate it with a file. DB Objects can only be associated with one file,

--- a/src/realm/db.hpp
+++ b/src/realm/db.hpp
@@ -120,6 +120,8 @@ using DBRef = std::shared_ptr<DB>;
 
 class DB : public std::enable_shared_from_this<DB> {
     struct ReadLockInfo;
+    struct Private {
+    };
 
 public:
     // Create a DB and associate it with a file. DB Objects can only be associated with one file,
@@ -140,6 +142,7 @@ public:
 
     ~DB() noexcept;
 
+    explicit DB(Private, const DBOptions& options);
     // Disable copying to prevent accessor errors. If you really want another
     // instance, open another DB object on the same file. But you don't.
     DB(const DB&) = delete;
@@ -446,9 +449,6 @@ public:
 
     void add_commit_listener(CommitListener*);
     void remove_commit_listener(CommitListener*);
-
-protected:
-    explicit DB(const DBOptions& options);
 
 private:
     class AsyncCommitHelper;

--- a/src/realm/object-store/audit.mm
+++ b/src/realm/object-store/audit.mm
@@ -615,8 +615,7 @@ private:
 // when the current one grows too large and ensuring that all of the Realms are
 // uploaded to the server.
 class AuditRealmPool : public std::enable_shared_from_this<AuditRealmPool> {
-    struct Private {
-    };
+    struct Private {};
 
 public:
     using ErrorHandler = std::function<void(SyncError)>;

--- a/src/realm/object-store/audit.mm
+++ b/src/realm/object-store/audit.mm
@@ -615,6 +615,9 @@ private:
 // when the current one grows too large and ensuring that all of the Realms are
 // uploaded to the server.
 class AuditRealmPool : public std::enable_shared_from_this<AuditRealmPool> {
+    struct Private {
+    };
+
 public:
     using ErrorHandler = std::function<void(SyncError)>;
 
@@ -629,9 +632,11 @@ public:
     // of the callback.
     void write(util::FunctionRef<void(Transaction&)> func) REQUIRES(!m_mutex);
 
-    // Do not call directly; use get_pool().
-    AuditRealmPool(std::shared_ptr<SyncUser> user, std::string const& partition_prefix, ErrorHandler error_handler,
-                   const std::shared_ptr<util::Logger>& logger, std::string_view app_id);
+    explicit AuditRealmPool(Private, std::shared_ptr<SyncUser> user, std::string const& partition_prefix,
+                            ErrorHandler error_handler, const std::shared_ptr<util::Logger>& logger,
+                            std::string_view app_id);
+    AuditRealmPool(const AuditRealmPool&) = delete;
+    AuditRealmPool& operator=(const AuditRealmPool&) = delete;
 
     // Block the calling thread until all pooled Realms have been fully uploaded,
     // including ones which do not currently have sync sessions. For testing
@@ -690,13 +695,13 @@ std::shared_ptr<AuditRealmPool> AuditRealmPool::get_pool(std::shared_ptr<SyncUse
         }
     }
 
-    auto pool = std::make_shared<AuditRealmPool>(user, partition_prefix, error_handler, logger, app_id);
+    auto pool = std::make_shared<AuditRealmPool>(Private(), user, partition_prefix, error_handler, logger, app_id);
     pool->scan_for_realms_to_upload();
     s_pools.push_back({user->identity(), partition_prefix, app_id, pool});
     return pool;
 }
 
-AuditRealmPool::AuditRealmPool(std::shared_ptr<SyncUser> user, std::string const& partition_prefix,
+AuditRealmPool::AuditRealmPool(Private, std::shared_ptr<SyncUser> user, std::string const& partition_prefix,
                                ErrorHandler error_handler, const std::shared_ptr<util::Logger>& logger,
                                std::string_view app_id)
     : m_user(user)

--- a/src/realm/object-store/impl/realm_coordinator.cpp
+++ b/src/realm/object-store/impl/realm_coordinator.cpp
@@ -65,7 +65,7 @@ std::shared_ptr<RealmCoordinator> RealmCoordinator::get_coordinator(StringData p
         return coordinator;
     }
 
-    auto coordinator = std::make_shared<RealmCoordinator>();
+    auto coordinator = std::make_shared<RealmCoordinator>(Private());
     weak_coordinator = coordinator;
     return coordinator;
 }
@@ -420,7 +420,8 @@ std::shared_ptr<AsyncOpenTask> RealmCoordinator::get_synchronized_realm(Realm::C
     util::CheckedLockGuard lock(m_realm_mutex);
     set_config(config);
     const auto db_open_first_time = open_db();
-    return std::make_shared<AsyncOpenTask>(shared_from_this(), m_sync_session, db_open_first_time);
+    return std::make_shared<AsyncOpenTask>(AsyncOpenTask::Private(), shared_from_this(), m_sync_session,
+                                           db_open_first_time);
 }
 
 #endif
@@ -626,7 +627,7 @@ void RealmCoordinator::advance_schema_cache(uint64_t previous, uint64_t next)
     m_schema_transaction_version_max = std::max(next, m_schema_transaction_version_max);
 }
 
-RealmCoordinator::RealmCoordinator() = default;
+RealmCoordinator::RealmCoordinator(Private) {}
 
 RealmCoordinator::~RealmCoordinator()
 {

--- a/src/realm/object-store/impl/realm_coordinator.hpp
+++ b/src/realm/object-store/impl/realm_coordinator.hpp
@@ -42,8 +42,7 @@ class WeakRealmNotifier;
 // RealmCoordinator manages the weak cache of Realm instances and communication
 // between per-thread Realm instances for a given file
 class RealmCoordinator : public std::enable_shared_from_this<RealmCoordinator>, DB::CommitListener {
-    struct Private {
-    };
+    struct Private {};
 
 public:
     // Get the coordinator for the given path, creating it if neccesary

--- a/src/realm/object-store/impl/realm_coordinator.hpp
+++ b/src/realm/object-store/impl/realm_coordinator.hpp
@@ -42,6 +42,9 @@ class WeakRealmNotifier;
 // RealmCoordinator manages the weak cache of Realm instances and communication
 // between per-thread Realm instances for a given file
 class RealmCoordinator : public std::enable_shared_from_this<RealmCoordinator>, DB::CommitListener {
+    struct Private {
+    };
+
 public:
     // Get the coordinator for the given path, creating it if neccesary
     static std::shared_ptr<RealmCoordinator> get_coordinator(StringData path);
@@ -153,8 +156,9 @@ public:
     // Verify that there are no Realms open for any paths
     static void assert_no_open_realms() noexcept;
 
-    // Explicit constructor/destructor needed for the unique_ptrs to forward-declared types
-    RealmCoordinator();
+    explicit RealmCoordinator(Private);
+    RealmCoordinator(const RealmCoordinator&) = delete;
+    RealmCoordinator& operator=(const RealmCoordinator&) = delete;
     ~RealmCoordinator();
 
     // Called by Realm's destructor to ensure the cache is cleaned up promptly

--- a/src/realm/object-store/shared_realm.cpp
+++ b/src/realm/object-store/shared_realm.cpp
@@ -78,7 +78,7 @@ private:
 } // namespace
 
 Realm::Realm(Config config, util::Optional<VersionID> version, std::shared_ptr<_impl::RealmCoordinator> coordinator,
-             MakeSharedTag)
+             Private)
     : m_config(std::move(config))
     , m_frozen_version(version)
     , m_scheduler(m_config.scheduler)
@@ -494,7 +494,7 @@ void Realm::update_schema(Schema schema, uint64_t version, MigrationFunction mig
             config.schema = util::none;
             // Don't go through the normal codepath for opening a Realm because
             // we're using a mismatched config
-            auto old_realm = std::make_shared<Realm>(std::move(config), none, m_coordinator, MakeSharedTag{});
+            auto old_realm = std::make_shared<Realm>(std::move(config), none, m_coordinator, Private());
             // block autorefresh for the old realm
             old_realm->m_auto_refresh = false;
             migration_function(old_realm, shared_from_this(), m_schema);

--- a/src/realm/object-store/shared_realm.hpp
+++ b/src/realm/object-store/shared_realm.hpp
@@ -185,6 +185,9 @@ struct RealmConfig {
 };
 
 class Realm : public std::enable_shared_from_this<Realm> {
+    struct Private {
+    };
+
 public:
     using Config = RealmConfig;
 
@@ -433,6 +436,8 @@ public:
 
     bool has_pending_async_work() const;
 
+    explicit Realm(Config config, util::Optional<VersionID> version,
+                   std::shared_ptr<_impl::RealmCoordinator> coordinator, Private);
     Realm(const Realm&) = delete;
     Realm& operator=(const Realm&) = delete;
     Realm(Realm&&) = delete;
@@ -450,8 +455,7 @@ public:
     static SharedRealm make_shared_realm(Config config, util::Optional<VersionID> version,
                                          std::shared_ptr<_impl::RealmCoordinator> coordinator)
     {
-        return std::make_shared<Realm>(std::move(config), std::move(version), std::move(coordinator),
-                                       MakeSharedTag{});
+        return std::make_shared<Realm>(std::move(config), std::move(version), std::move(coordinator), Private());
     }
 
     // Expose some internal functionality which isn't intended to be used directly
@@ -500,9 +504,6 @@ public:
 #endif
 
 private:
-    struct MakeSharedTag {
-    };
-
     std::shared_ptr<_impl::RealmCoordinator> m_coordinator;
 
     Config m_config;
@@ -581,10 +582,6 @@ private:
 
 public:
     std::unique_ptr<BindingContext> m_binding_context;
-
-    // `enable_shared_from_this` is unsafe with public constructors; use `make_shared_realm` instead
-    Realm(Config config, util::Optional<VersionID> version, std::shared_ptr<_impl::RealmCoordinator> coordinator,
-          MakeSharedTag);
 };
 
 } // namespace realm

--- a/src/realm/object-store/shared_realm.hpp
+++ b/src/realm/object-store/shared_realm.hpp
@@ -185,8 +185,7 @@ struct RealmConfig {
 };
 
 class Realm : public std::enable_shared_from_this<Realm> {
-    struct Private {
-    };
+    struct Private {};
 
 public:
     using Config = RealmConfig;

--- a/src/realm/object-store/sync/app.cpp
+++ b/src/realm/object-store/sync/app.cpp
@@ -221,13 +221,13 @@ SharedApp App::get_app(CacheMode mode, const Config& config,
         std::lock_guard<std::mutex> lock(s_apps_mutex);
         auto& app = s_apps_cache[config.app_id][config.base_url.value_or(std::string(s_default_base_url))];
         if (!app) {
-            app = std::make_shared<App>(PrivateConstructionOnly(), config);
+            app = std::make_shared<App>(Private(), config);
             app->configure(sync_client_config);
         }
         return app;
     }
     REALM_ASSERT(mode == CacheMode::Disabled);
-    auto app = std::make_shared<App>(PrivateConstructionOnly(), config);
+    auto app = std::make_shared<App>(Private(), config);
     app->configure(sync_client_config);
     return app;
 }
@@ -263,7 +263,7 @@ void App::close_all_sync_sessions()
     }
 }
 
-App::App(PrivateConstructionOnly, const Config& config)
+App::App(Private, const Config& config)
     : m_config(std::move(config))
     , m_request_timeout_ms(m_config.default_request_timeout_ms.value_or(s_default_timeout_ms))
 {

--- a/src/realm/object-store/sync/app.hpp
+++ b/src/realm/object-store/sync/app.hpp
@@ -57,8 +57,7 @@ class App : public std::enable_shared_from_this<App>,
             public AppServiceClient,
             public Subscribable<App> {
 
-    struct PrivateConstructionOnly {
-        explicit PrivateConstructionOnly() {}
+    struct Private {
     };
 
 public:
@@ -95,7 +94,7 @@ public:
 
     // `enable_shared_from_this` is unsafe with public constructors;
     // use `App::get_app()` instead
-    explicit App(PrivateConstructionOnly, const Config& config);
+    explicit App(Private, const Config& config);
     App(App&&) noexcept = delete;
     App& operator=(App&&) noexcept = delete;
     ~App();

--- a/src/realm/object-store/sync/app.hpp
+++ b/src/realm/object-store/sync/app.hpp
@@ -57,8 +57,7 @@ class App : public std::enable_shared_from_this<App>,
             public AppServiceClient,
             public Subscribable<App> {
 
-    struct Private {
-    };
+    struct Private {};
 
 public:
     struct Config {

--- a/src/realm/object-store/sync/async_open_task.cpp
+++ b/src/realm/object-store/sync/async_open_task.cpp
@@ -26,7 +26,7 @@
 
 namespace realm {
 
-AsyncOpenTask::AsyncOpenTask(std::shared_ptr<_impl::RealmCoordinator> coordinator,
+AsyncOpenTask::AsyncOpenTask(Private, std::shared_ptr<_impl::RealmCoordinator> coordinator,
                              std::shared_ptr<realm::SyncSession> session, bool db_first_open)
     : m_coordinator(coordinator)
     , m_session(session)

--- a/src/realm/object-store/sync/async_open_task.hpp
+++ b/src/realm/object-store/sync/async_open_task.hpp
@@ -37,12 +37,17 @@ class RealmCoordinator;
 // Class used to wrap the intent of opening a new Realm or fully synchronize it before returning it to the user
 // Timeouts are not handled by this class but must be handled by each binding.
 class AsyncOpenTask : public std::enable_shared_from_this<AsyncOpenTask> {
+    struct Private {
+    };
+
 public:
     using AsyncOpenCallback = util::UniqueFunction<void(ThreadSafeReference, std::exception_ptr)>;
     using SubscriptionCallback = util::UniqueFunction<void(std::shared_ptr<Realm>)>;
 
-    AsyncOpenTask(std::shared_ptr<_impl::RealmCoordinator> coordinator, std::shared_ptr<realm::SyncSession> session,
-                  bool db_open_for_the_first_time);
+    explicit AsyncOpenTask(Private, std::shared_ptr<_impl::RealmCoordinator> coordinator,
+                           std::shared_ptr<realm::SyncSession> session, bool db_open_for_the_first_time);
+    AsyncOpenTask(const AsyncOpenTask&) = delete;
+    AsyncOpenTask& operator=(const AsyncOpenTask&) = delete;
     // Starts downloading the Realm. The callback will be triggered either when the download completes
     // or an error is encountered.
     //
@@ -58,6 +63,8 @@ public:
     void unregister_download_progress_notifier(uint64_t token) REQUIRES(!m_mutex);
 
 private:
+    friend _impl::RealmCoordinator;
+
     void async_open_complete(AsyncOpenCallback&&, std::shared_ptr<_impl::RealmCoordinator>, Status)
         REQUIRES(!m_mutex);
     void attach_to_subscription_initializer(AsyncOpenCallback&&, std::shared_ptr<_impl::RealmCoordinator>, bool)

--- a/src/realm/object-store/sync/async_open_task.hpp
+++ b/src/realm/object-store/sync/async_open_task.hpp
@@ -37,8 +37,7 @@ class RealmCoordinator;
 // Class used to wrap the intent of opening a new Realm or fully synchronize it before returning it to the user
 // Timeouts are not handled by this class but must be handled by each binding.
 class AsyncOpenTask : public std::enable_shared_from_this<AsyncOpenTask> {
-    struct Private {
-    };
+    struct Private {};
 
 public:
     using AsyncOpenCallback = util::UniqueFunction<void(ThreadSafeReference, std::exception_ptr)>;

--- a/src/realm/object-store/sync/sync_manager.cpp
+++ b/src/realm/object-store/sync/sync_manager.cpp
@@ -107,7 +107,7 @@ void SyncManager::configure(std::shared_ptr<app::App> app, const std::string& sy
                 auto refresh_token = user_data.refresh_token();
                 auto access_token = user_data.access_token();
                 if (!refresh_token.empty() && !access_token.empty()) {
-                    users_to_add.push_back(std::make_shared<SyncUser>(user_data, this));
+                    users_to_add.push_back(std::make_shared<SyncUser>(SyncUser::Private(), user_data, this));
                 }
             }
 
@@ -347,7 +347,8 @@ std::shared_ptr<SyncUser> SyncManager::get_user(const std::string& user_id, cons
         });
         if (it == m_users.end()) {
             // No existing user.
-            auto new_user = std::make_shared<SyncUser>(refresh_token, user_id, access_token, device_id, this);
+            auto new_user = std::make_shared<SyncUser>(SyncUser::Private(), refresh_token, user_id, access_token,
+                                                       device_id, this);
             m_users.emplace(m_users.begin(), new_user);
             {
                 util::CheckedLockGuard lock(m_file_system_mutex);

--- a/src/realm/object-store/sync/sync_session.cpp
+++ b/src/realm/object-store/sync/sync_session.cpp
@@ -358,7 +358,7 @@ SyncSession::handle_refresh(const std::shared_ptr<SyncSession>& session, bool re
     };
 }
 
-SyncSession::SyncSession(SyncClient& client, std::shared_ptr<DB> db, const RealmConfig& config,
+SyncSession::SyncSession(Private, SyncClient& client, std::shared_ptr<DB> db, const RealmConfig& config,
                          SyncManager* sync_manager)
     : m_config{config}
     , m_db{std::move(db)}

--- a/src/realm/object-store/sync/sync_session.hpp
+++ b/src/realm/object-store/sync/sync_session.hpp
@@ -103,8 +103,7 @@ private:
 } // namespace _impl
 
 class SyncSession : public std::enable_shared_from_this<SyncSession> {
-    struct Private {
-    };
+    struct Private {};
 
 public:
     enum class State {

--- a/src/realm/object-store/sync/sync_user.cpp
+++ b/src/realm/object-store/sync/sync_user.cpp
@@ -84,7 +84,7 @@ SyncUserIdentity::SyncUserIdentity(const std::string& id, const std::string& pro
 SyncUserContextFactory SyncUser::s_binding_context_factory;
 std::mutex SyncUser::s_binding_context_factory_mutex;
 
-SyncUser::SyncUser(const std::string& refresh_token, const std::string& id, const std::string& access_token,
+SyncUser::SyncUser(Private, const std::string& refresh_token, const std::string& id, const std::string& access_token,
                    const std::string& device_id, SyncManager* sync_manager)
     : m_state(State::LoggedIn)
     , m_identity(id)
@@ -110,7 +110,7 @@ SyncUser::SyncUser(const std::string& refresh_token, const std::string& id, cons
     });
 }
 
-SyncUser::SyncUser(const SyncUserMetadata& data, SyncManager* sync_manager)
+SyncUser::SyncUser(Private, const SyncUserMetadata& data, SyncManager* sync_manager)
     : m_state(data.state())
     , m_legacy_identities(data.legacy_identities())
     , m_identity(data.identity())

--- a/src/realm/object-store/sync/sync_user.hpp
+++ b/src/realm/object-store/sync/sync_user.hpp
@@ -172,8 +172,7 @@ struct SyncUserIdentity {
 // are associated with it.
 class SyncUser : public std::enable_shared_from_this<SyncUser>, public Subscribable<SyncUser> {
     friend class SyncSession;
-    struct Private {
-    };
+    struct Private {};
 
 public:
     enum class State {

--- a/src/realm/object-store/sync/sync_user.hpp
+++ b/src/realm/object-store/sync/sync_user.hpp
@@ -172,6 +172,8 @@ struct SyncUserIdentity {
 // are associated with it.
 class SyncUser : public std::enable_shared_from_this<SyncUser>, public Subscribable<SyncUser> {
     friend class SyncSession;
+    struct Private {
+    };
 
 public:
     enum class State {
@@ -238,10 +240,11 @@ public:
     // testing purposes. SDKs should not call these directly in non-test code
     // or expose them in the public API.
 
-    // Don't use this directly; use the `SyncManager` APIs. Public for use with `make_shared`.
-    SyncUser(const std::string& refresh_token, const std::string& id, const std::string& access_token,
-             const std::string& device_id, SyncManager* sync_manager);
-    SyncUser(const SyncUserMetadata& data, SyncManager* sync_manager);
+    explicit SyncUser(Private, const std::string& refresh_token, const std::string& id,
+                      const std::string& access_token, const std::string& device_id, SyncManager* sync_manager);
+    explicit SyncUser(Private, const SyncUserMetadata& data, SyncManager* sync_manager);
+    SyncUser(const SyncUser&) = delete;
+    SyncUser& operator=(const SyncUser&) = delete;
 
     // Atomically set the user to be logged in and update both tokens.
     void log_in(const std::string& access_token, const std::string& refresh_token)

--- a/src/realm/sync/noinst/migration_store.cpp
+++ b/src/realm/sync/noinst/migration_store.cpp
@@ -16,22 +16,14 @@ constexpr static std::string_view
     c_flx_migration_sentinel_subscription_set_version("sentinel_subscription_set_version");
 constexpr static std::string_view c_flx_subscription_name_prefix("flx_migrated_");
 
-class MigrationStoreInit : public MigrationStore {
-public:
-    explicit MigrationStoreInit(DBRef db)
-        : MigrationStore(std::move(db))
-    {
-    }
-};
-
 } // namespace
 
 MigrationStoreRef MigrationStore::create(DBRef db)
 {
-    return std::make_shared<MigrationStoreInit>(std::move(db));
+    return std::make_shared<MigrationStore>(Private(), std::move(db));
 }
 
-MigrationStore::MigrationStore(DBRef db)
+MigrationStore::MigrationStore(Private, DBRef db)
     : m_db(std::move(db))
     , m_state(MigrationState::NotMigrated)
 {

--- a/src/realm/sync/noinst/migration_store.hpp
+++ b/src/realm/sync/noinst/migration_store.hpp
@@ -34,8 +34,7 @@ using MigrationStoreRef = std::shared_ptr<MigrationStore>;
 
 // A MigrationStore manages the PBS -> FLX migration metadata table.
 class MigrationStore : public std::enable_shared_from_this<MigrationStore> {
-    struct Private {
-    };
+    struct Private {};
 
 public:
     explicit MigrationStore(Private, DBRef db);

--- a/src/realm/sync/noinst/migration_store.hpp
+++ b/src/realm/sync/noinst/migration_store.hpp
@@ -34,7 +34,11 @@ using MigrationStoreRef = std::shared_ptr<MigrationStore>;
 
 // A MigrationStore manages the PBS -> FLX migration metadata table.
 class MigrationStore : public std::enable_shared_from_this<MigrationStore> {
+    struct Private {
+    };
+
 public:
+    explicit MigrationStore(Private, DBRef db);
     MigrationStore(const MigrationStore&) = delete;
     MigrationStore& operator=(const MigrationStore&) = delete;
 
@@ -88,8 +92,6 @@ public:
     std::optional<int64_t> get_sentinel_subscription_set_version();
 
 protected:
-    explicit MigrationStore(DBRef db);
-
     // Read the data from the database - returns true if successful
     // Will return false if read_only is set and the metadata schema
     // versions info is not already set.

--- a/src/realm/sync/subscriptions.cpp
+++ b/src/realm/sync/subscriptions.cpp
@@ -598,22 +598,12 @@ std::string SubscriptionSet::to_ext_json() const
     return output_json.dump();
 }
 
-namespace {
-class SubscriptionStoreInit : public SubscriptionStore {
-public:
-    explicit SubscriptionStoreInit(DBRef db)
-        : SubscriptionStore(std::move(db))
-    {
-    }
-};
-} // namespace
-
 SubscriptionStoreRef SubscriptionStore::create(DBRef db)
 {
-    return std::make_shared<SubscriptionStoreInit>(std::move(db));
+    return std::make_shared<SubscriptionStore>(Private(), std::move(db));
 }
 
-SubscriptionStore::SubscriptionStore(DBRef db)
+SubscriptionStore::SubscriptionStore(Private, DBRef db)
     : m_db(std::move(db))
 {
     std::vector<SyncMetadataTable> internal_tables{

--- a/src/realm/sync/subscriptions.hpp
+++ b/src/realm/sync/subscriptions.hpp
@@ -294,8 +294,7 @@ using SubscriptionStoreRef = std::shared_ptr<SubscriptionStore>;
 
 // A SubscriptionStore manages the FLX metadata tables, SubscriptionSets and Subscriptions.
 class SubscriptionStore : public std::enable_shared_from_this<SubscriptionStore> {
-    struct Private {
-    };
+    struct Private {};
 
 public:
     static SubscriptionStoreRef create(DBRef db);

--- a/src/realm/sync/subscriptions.hpp
+++ b/src/realm/sync/subscriptions.hpp
@@ -294,9 +294,13 @@ using SubscriptionStoreRef = std::shared_ptr<SubscriptionStore>;
 
 // A SubscriptionStore manages the FLX metadata tables, SubscriptionSets and Subscriptions.
 class SubscriptionStore : public std::enable_shared_from_this<SubscriptionStore> {
+    struct Private {
+    };
+
 public:
     static SubscriptionStoreRef create(DBRef db);
 
+    explicit SubscriptionStore(Private, DBRef db);
     SubscriptionStore(const SubscriptionStore&) = delete;
     SubscriptionStore& operator=(const SubscriptionStore&) = delete;
 
@@ -363,9 +367,6 @@ public:
     // Recreate the active subscription set, marking any newer pending ones as
     // superseded. This is a no-op if there are no pending subscription sets.
     int64_t set_active_as_latest(Transaction& wt) REQUIRES(!m_pending_notifications_mutex);
-
-protected:
-    explicit SubscriptionStore(DBRef db);
 
 private:
     using State = SubscriptionSet::State;


### PR DESCRIPTION
## What, How & Why?
This PR is replacing the inheritance pattern used to instantiate shared-only objects with private tags in the constructors of such classes.

## ☑️ ToDos
* ~~[ ] 📝 Changelog update~~
* ~~[ ] 🚦 Tests (or not relevant)~~
* ~~[ ] C-API, if public C++ API changed~~
* ~~[ ] `bindgen/spec.yml`, if public C++ API changed~~
