### PR TITLE
[C-API] Fix the return type of realm_set_collection

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@
 
 ### Fixed
 * <How do the end-user experience this issue? what was the impact?> ([#????](https://github.com/realm/realm-core/issues/????), since v?.?.?)
-* None.
+* \[C-API] Fixed the return type of `realm_set_list` and `realm_set_dictionary` to be the newly inserted collection, similarly to the behavior of `list/dictionary_insert_collection`.
 
 ### Breaking changes
 * None.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@
 
 ### Fixed
 * <How do the end-user experience this issue? what was the impact?> ([#????](https://github.com/realm/realm-core/issues/????), since v?.?.?)
-* \[C-API] Fixed the return type of `realm_set_list` and `realm_set_dictionary` to be the newly inserted collection, similarly to the behavior of `list/dictionary_insert_collection`.
+* \[C-API] Fixed the return type of `realm_set_list` and `realm_set_dictionary` to be the newly inserted collection, similarly to the behavior of `list/dictionary_insert_collection` (PR [#7247](https://github.com/realm/realm-core/pull/7247), since 14.0.0-beta.0)
 
 ### Breaking changes
 * None.

--- a/src/realm.h
+++ b/src/realm.h
@@ -1686,8 +1686,8 @@ RLM_API realm_object_t* realm_set_embedded(realm_object_t*, realm_property_key_t
  * Create a collection in a given Mixed property.
  *
  */
-RLM_API bool realm_set_list(realm_object_t*, realm_property_key_t);
-RLM_API bool realm_set_dictionary(realm_object_t*, realm_property_key_t);
+RLM_API realm_list_t* realm_set_list(realm_object_t*, realm_property_key_t);
+RLM_API realm_dictionary_t* realm_set_dictionary(realm_object_t*, realm_property_key_t);
 
 /** Return the object linked by the given property
  *

--- a/src/realm/object-store/c_api/object.cpp
+++ b/src/realm/object-store/c_api/object.cpp
@@ -354,21 +354,29 @@ RLM_API realm_object_t* realm_set_embedded(realm_object_t* obj, realm_property_k
     });
 }
 
-RLM_API bool realm_set_list(realm_object_t* obj, realm_property_key_t col)
+RLM_API realm_list_t* realm_set_list(realm_object_t* object, realm_property_key_t col)
 {
     return wrap_err([&]() {
-        obj->verify_attached();
-        obj->get_obj().set_collection(ColKey(col), CollectionType::List);
-        return true;
+        object->verify_attached();
+
+        auto& obj = object->get_obj();
+        auto col_key = ColKey(col);
+
+        obj.set_collection(col_key, CollectionType::List);
+        return new realm_list_t{List{object->get_realm(), std::move(obj), col_key}};
     });
 }
 
-RLM_API bool realm_set_dictionary(realm_object_t* obj, realm_property_key_t col)
+RLM_API realm_dictionary_t* realm_set_dictionary(realm_object_t* object, realm_property_key_t col)
 {
     return wrap_err([&]() {
-        obj->verify_attached();
-        obj->get_obj().set_collection(ColKey(col), CollectionType::Dictionary);
-        return true;
+        object->verify_attached();
+
+        auto& obj = object->get_obj();
+        auto col_key = ColKey(col);
+
+        obj.set_collection(col_key, CollectionType::Dictionary);
+        return new realm_dictionary_t{object_store::Dictionary{object->get_realm(), obj, col_key}};
     });
 }
 

--- a/test/object-store/c_api/c_api.cpp
+++ b/test/object-store/c_api/c_api.cpp
@@ -5128,7 +5128,8 @@ TEST_CASE("C API: nested collections", "[c_api]") {
 
     SECTION("results of mixed") {
         SECTION("dictionary") {
-            REQUIRE(realm_set_dictionary(obj1.get(), foo_any_col_key));
+            auto parent_dict = cptr_checked(realm_set_dictionary(obj1.get(), foo_any_col_key));
+            REQUIRE(parent_dict);
             realm_value_t value;
             realm_get_value(obj1.get(), foo_any_col_key, &value);
             REQUIRE(value.type == RLM_TYPE_DICTIONARY);
@@ -5154,7 +5155,8 @@ TEST_CASE("C API: nested collections", "[c_api]") {
             REQUIRE(result_dictionary->size() == ndict->size());
         }
         SECTION("list") {
-            REQUIRE(realm_set_list(obj1.get(), foo_any_col_key));
+            auto parent_list = cptr_checked(realm_set_list(obj1.get(), foo_any_col_key));
+            REQUIRE(parent_list);
             realm_value_t value;
             realm_get_value(obj1.get(), foo_any_col_key, &value);
             REQUIRE(value.type == RLM_TYPE_LIST);
@@ -5190,7 +5192,8 @@ TEST_CASE("C API: nested collections", "[c_api]") {
             realm_dictionary_t* dict;
         } user_data;
 
-        REQUIRE(realm_set_dictionary(obj1.get(), foo_any_col_key));
+        auto parent_dict = cptr_checked(realm_set_dictionary(obj1.get(), foo_any_col_key));
+        REQUIRE(parent_dict);
         realm_value_t value;
         realm_get_value(obj1.get(), foo_any_col_key, &value);
         REQUIRE(value.type == RLM_TYPE_DICTIONARY);
@@ -5247,7 +5250,8 @@ TEST_CASE("C API: nested collections", "[c_api]") {
             realm_list_t* list;
         } user_data;
 
-        REQUIRE(realm_set_list(obj1.get(), foo_any_col_key));
+        auto parent_list = cptr_checked(realm_set_list(obj1.get(), foo_any_col_key));
+        REQUIRE(parent_list);
         realm_value_t value;
         realm_get_value(obj1.get(), foo_any_col_key, &value);
         REQUIRE(value.type == RLM_TYPE_LIST);
@@ -5295,7 +5299,8 @@ TEST_CASE("C API: nested collections", "[c_api]") {
     }
 
     SECTION("set list for collection in mixed, verify that previous reference is invalid") {
-        REQUIRE(realm_set_list(obj1.get(), foo_any_col_key));
+        auto parent_list = cptr_checked(realm_set_list(obj1.get(), foo_any_col_key));
+        REQUIRE(parent_list);
         realm_value_t value;
         realm_get_value(obj1.get(), foo_any_col_key, &value);
         REQUIRE(value.type == RLM_TYPE_LIST);
@@ -5352,7 +5357,8 @@ TEST_CASE("C API: nested collections", "[c_api]") {
     }
 
     SECTION("freeze list") {
-        REQUIRE(realm_set_dictionary(obj1.get(), foo_any_col_key));
+        auto parent_dict = cptr_checked(realm_set_dictionary(obj1.get(), foo_any_col_key));
+        REQUIRE(parent_dict);
         auto dict = cptr_checked(realm_get_dictionary(obj1.get(), foo_any_col_key));
         auto list = cptr_checked(realm_dictionary_insert_list(dict.get(), rlm_str_val("List")));
         realm_list_insert(list.get(), 0, rlm_str_val("Hello"));


### PR DESCRIPTION
## What, How & Why?
This aligns the return type with the `realm_collection_set/insert_collection` API and makes it easier to consume.

## ☑️ ToDos
* [x] 📝 Changelog update
* [x] C-API, if public C++ API changed
