### PR TITLE
Fallback to manually consume space if posix_fallocate isn't supported at runtime

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@
 
 ### Fixed
 * <How do the end-user experience this issue? what was the impact?> ([#????](https://github.com/realm/realm-core/issues/????), since v?.?.?)
-* None.
+* Handle `EOPNOTSUPP` when using `posix_fallocate()` and fallback to manually consume space. This should enable android users to open a Realm on restrictive filesystems. ([realm-js #6349](https://github.com/realm/realm-js/issues/6349), more prevalent since v13.23.3 with the change to `REALM_HAVE_POSIX_FALLOCATE` but it was also an issue in some platforms before this)
 
 ### Breaking changes
 * `App::get_uncached_app(...)` and `App::get_shared_app(...)` have been replaced by `App::get_app(App::CacheMode, ...)`. The App constructor is now enforced to be unusable, use `App::get_app()` instead. ([#7237](https://github.com/realm/realm-core/issues/7237))

--- a/src/realm/util/file.cpp
+++ b/src/realm/util/file.cpp
@@ -1010,7 +1010,7 @@ bool File::prealloc_if_supported(SizeType offset, size_t size)
         return true;
     }
 
-    if (status == EINVAL || status == EPERM) {
+    if (status == EINVAL || status == EPERM || status == EOPNOTSUPP) {
         return false; // Retry with non-atomic version
     }
 


### PR DESCRIPTION
Fixes https://github.com/realm/realm-js/issues/6349 and https://github.com/realm/realm-dotnet/issues/3482.

I think this has emerged as an issue since the change in https://github.com/realm/realm-core/pull/7067 where the compile  time detection of POSIX_FALLOCATE changed.

According to the man pages, `posix_fallocate` can return not supported:
```
EOPNOTSUPP
              The filesystem containing the file referred to by fd does
              not support this operation.  This error code can be
              returned by C libraries that don't perform the emulation
              shown in NOTES, such as musl libc.
```

Fortunately for us, we do not rely on this and already have a fallback path so it is simply a matter of handling this error code in the same way. Testing this requires combination of a system that passes our compile time check but fails at runtime which we do not have yet.

## ☑️ ToDos
* [x] 📝 Changelog update
* [ ] 🚦 Tests (or not relevant)
* [x] C-API, if public C++ API changed
* [x] `bindgen/spec.yml`, if public C++ API changed
